### PR TITLE
feat(desktop): add board and thread foundations

### DIFF
--- a/desktop/src/renderer/src/design/primitives.tsx
+++ b/desktop/src/renderer/src/design/primitives.tsx
@@ -1,0 +1,217 @@
+// Lean UI primitives on the token system. Hand-rolled (no heavy deps):
+// consistent focus rings, light dismiss, Escape handling per the UX guide.
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  type CSSProperties,
+  type ReactNode,
+  type ButtonHTMLAttributes,
+} from "react";
+
+type ButtonVariant = "primary" | "ghost" | "danger" | "subtle";
+
+const BUTTON_STYLES: Record<ButtonVariant, CSSProperties> = {
+  primary: { background: "var(--accent)", color: "var(--text-on-accent)" },
+  ghost: { background: "transparent", color: "var(--text-secondary)" },
+  subtle: { background: "var(--bg-hover)", color: "var(--text-primary)" },
+  danger: { background: "var(--danger-muted)", color: "var(--danger)" },
+};
+
+export function Button({
+  variant = "subtle",
+  className = "",
+  style,
+  ...props
+}: ButtonHTMLAttributes<HTMLButtonElement> & { variant?: ButtonVariant }) {
+  return (
+    <button
+      type="button"
+      className={`no-drag inline-flex h-7 items-center gap-1.5 rounded-md px-2.5 text-sm font-medium transition-colors duration-100 hover:brightness-110 disabled:opacity-50 ${className}`}
+      style={{ ...BUTTON_STYLES[variant], ...style }}
+      {...props}
+    />
+  );
+}
+
+export function IconButton({
+  label,
+  className = "",
+  active = false,
+  ...props
+}: ButtonHTMLAttributes<HTMLButtonElement> & { label: string; active?: boolean }) {
+  return (
+    <button
+      type="button"
+      aria-label={label}
+      title={label}
+      className={`no-drag inline-flex h-7 w-7 items-center justify-center rounded-md transition-colors duration-100 ${className}`}
+      style={{
+        color: active ? "var(--accent)" : "var(--text-tertiary)",
+        background: active ? "var(--accent-muted)" : "transparent",
+      }}
+      onMouseEnter={(e) => {
+        if (!active) e.currentTarget.style.background = "var(--bg-hover)";
+      }}
+      onMouseLeave={(e) => {
+        if (!active) e.currentTarget.style.background = "transparent";
+      }}
+      {...props}
+    />
+  );
+}
+
+export function Dialog({
+  open,
+  onClose,
+  children,
+  width = 480,
+}: {
+  open: boolean;
+  onClose: () => void;
+  children: ReactNode;
+  width?: number;
+}) {
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        e.stopPropagation();
+        onClose();
+      }
+    };
+    window.addEventListener("keydown", onKey, true);
+    return () => window.removeEventListener("keydown", onKey, true);
+  }, [open, onClose]);
+
+  const onBackdrop = useCallback(
+    (e: React.MouseEvent) => {
+      if (e.target === e.currentTarget) onClose();
+    },
+    [onClose],
+  );
+
+  if (!open) return null;
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-start justify-center pt-[18vh]"
+      style={{ background: "rgba(0,0,0,0.45)" }}
+      onMouseDown={onBackdrop}
+    >
+      <div
+        ref={ref}
+        role="dialog"
+        aria-modal="true"
+        className="fade-in rounded-xl border"
+        style={{
+          width,
+          background: "var(--bg-overlay)",
+          borderColor: "var(--border-default)",
+          boxShadow: "var(--shadow-3)",
+        }}
+      >
+        {children}
+      </div>
+    </div>
+  );
+}
+
+export interface MenuItem {
+  label: string;
+  danger?: boolean;
+  disabled?: boolean;
+  onSelect: () => void;
+}
+
+export function ContextMenu({
+  position,
+  items,
+  onClose,
+}: {
+  position: { x: number; y: number } | null;
+  items: MenuItem[];
+  onClose: () => void;
+}) {
+  useEffect(() => {
+    if (!position) return;
+    const close = () => onClose();
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    window.addEventListener("mousedown", close);
+    window.addEventListener("keydown", onKey, true);
+    return () => {
+      window.removeEventListener("mousedown", close);
+      window.removeEventListener("keydown", onKey, true);
+    };
+  }, [position, onClose]);
+
+  if (!position) return null;
+  return (
+    <div
+      className="fade-in fixed z-50 min-w-[180px] rounded-lg border p-1"
+      style={{
+        left: Math.min(position.x, window.innerWidth - 200),
+        top: Math.min(position.y, window.innerHeight - items.length * 30 - 16),
+        background: "var(--bg-overlay)",
+        borderColor: "var(--border-default)",
+        boxShadow: "var(--shadow-2)",
+      }}
+      onMouseDown={(e) => e.stopPropagation()}
+    >
+      {items.map((item) => (
+        <button
+          key={item.label}
+          type="button"
+          disabled={item.disabled}
+          className="flex w-full items-center rounded-md px-2.5 py-1.5 text-left text-sm transition-colors duration-75 disabled:opacity-40"
+          style={{ color: item.danger ? "var(--danger)" : "var(--text-primary)" }}
+          onMouseEnter={(e) => (e.currentTarget.style.background = "var(--bg-hover)")}
+          onMouseLeave={(e) => (e.currentTarget.style.background = "transparent")}
+          onClick={() => {
+            onClose();
+            item.onSelect();
+          }}
+        >
+          {item.label}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+export function StatusDot({ color, pulse = false }: { color: string; pulse?: boolean }) {
+  return (
+    <span
+      className={`inline-block h-2 w-2 shrink-0 rounded-full ${pulse ? "status-pulse" : ""}`}
+      style={{ background: color }}
+    />
+  );
+}
+
+export function EmptyState({
+  icon,
+  headline,
+  description,
+  action,
+}: {
+  icon: ReactNode;
+  headline: string;
+  description: string;
+  action?: ReactNode;
+}) {
+  return (
+    <div className="flex flex-1 flex-col items-center justify-center gap-2 p-8">
+      <div style={{ color: "var(--text-tertiary)" }}>{icon}</div>
+      <h2 className="text-md font-semibold" style={{ color: "var(--text-primary)" }}>
+        {headline}
+      </h2>
+      <p className="max-w-[320px] text-center text-sm" style={{ color: "var(--text-secondary)" }}>
+        {description}
+      </p>
+      {action ? <div className="mt-2">{action}</div> : null}
+    </div>
+  );
+}

--- a/desktop/src/renderer/src/features/board/Board.tsx
+++ b/desktop/src/renderer/src/features/board/Board.tsx
@@ -1,0 +1,218 @@
+import {
+  DndContext,
+  DragOverlay,
+  PointerSensor,
+  useDraggable,
+  useDroppable,
+  useSensor,
+  useSensors,
+  type DragEndEvent,
+  type DragStartEvent,
+} from "@dnd-kit/core";
+import { Kanban } from "lucide-react";
+import { useMemo, useState } from "react";
+import { Button, EmptyState } from "../../design/primitives";
+import { toUserMessage } from "../../lib/errors";
+import { AppError } from "../../../../shared/app-error";
+import { useBoard, BOARD_COLUMNS, groupCardsByColumn, type Card, type CardStatus } from "../../stores/board";
+import { useConnection } from "../../stores/connection";
+import { useUi } from "../../stores/ui";
+import BoardCard from "./BoardCard";
+import CreateTaskDialog from "./CreateTaskDialog";
+
+const COLUMN_LABEL: Record<CardStatus, string> = {
+  todo: "Todo",
+  running: "Running",
+  waiting: "Waiting",
+  blocked: "Blocked",
+  complete: "Complete",
+  archived: "Archived",
+};
+
+const COLUMN_COLOR: Record<CardStatus, string> = {
+  todo: "var(--status-todo)",
+  running: "var(--status-running)",
+  waiting: "var(--status-waiting)",
+  blocked: "var(--status-blocked)",
+  complete: "var(--status-complete)",
+  archived: "var(--status-todo)",
+};
+
+function midpointOrder(cards: Card[], beforeId: string | null): number {
+  if (cards.length === 0) return 1;
+  if (beforeId === null) return (cards[cards.length - 1]?.order ?? 0) + 1;
+  const idx = cards.findIndex((c) => c.id === beforeId);
+  if (idx <= 0) return (cards[0]?.order ?? 1) - 1;
+  return ((cards[idx - 1]?.order ?? 0) + (cards[idx]?.order ?? 0)) / 2;
+}
+
+function Column({
+  status,
+  cards,
+  activeDragId,
+}: {
+  status: CardStatus;
+  cards: Card[];
+  activeDragId: string | null;
+}) {
+  const { setNodeRef, isOver } = useDroppable({ id: `column:${status}` });
+  return (
+    <div className="flex w-[252px] shrink-0 flex-col">
+      <div className="mb-2 flex items-center gap-2 px-1">
+        <span className="h-2 w-2 rounded-full" style={{ background: COLUMN_COLOR[status] }} />
+        <span className="text-sm font-semibold" style={{ color: "var(--text-primary)" }}>
+          {COLUMN_LABEL[status]}
+        </span>
+        <span className="text-xs" style={{ color: "var(--text-tertiary)" }}>
+          {cards.length}
+        </span>
+      </div>
+      <div
+        ref={setNodeRef}
+        className="flex min-h-[120px] flex-1 flex-col gap-1.5 rounded-lg p-1 transition-colors duration-100"
+        style={{ background: isOver ? "var(--bg-selected)" : "transparent" }}
+      >
+        {cards.map((card) => (
+          <DraggableCard key={card.id} card={card} dragging={activeDragId === card.id} />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function DraggableCard({ card, dragging }: { card: Card; dragging: boolean }) {
+  const { setNodeRef, attributes, listeners } = useDraggable({ id: card.id });
+  const { setNodeRef: setDropRef, isOver } = useDroppable({ id: `card:${card.id}` });
+  return (
+    <div ref={setDropRef} style={{ paddingTop: isOver ? 6 : 0, transition: "padding 80ms" }}>
+      <div ref={setNodeRef} {...attributes} {...listeners} style={{ opacity: dragging ? 0.35 : 1 }}>
+        <BoardCard card={card} />
+      </div>
+    </div>
+  );
+}
+
+export default function Board() {
+  const api = useConnection((s) => s.api);
+  const activeSlug = useBoard((s) => s.activeProjectSlug);
+  const cardsByProject = useBoard((s) => s.cardsByProject);
+  const firstLoadPending = useBoard((s) => s.firstLoadPending);
+  const error = useBoard((s) => s.error);
+  const moveTask = useBoard((s) => s.moveTask);
+  const createTaskOpen = useUi((s) => s.createTaskOpen);
+  const setCreateTaskOpen = useUi((s) => s.setCreateTaskOpen);
+  const [activeDragId, setActiveDragId] = useState<string | null>(null);
+
+  const cards = useMemo(
+    () => (activeSlug ? (cardsByProject[activeSlug] ?? []) : []),
+    [activeSlug, cardsByProject],
+  );
+  const columns = useMemo(() => groupCardsByColumn(cards), [cards]);
+
+  const sensors = useSensors(useSensor(PointerSensor, { activationConstraint: { distance: 5 } }));
+
+  const onDragStart = (event: DragStartEvent) => setActiveDragId(String(event.active.id));
+
+  const onDragEnd = (event: DragEndEvent) => {
+    setActiveDragId(null);
+    const { active, over } = event;
+    if (!over || !api || !activeSlug) return;
+    const cardId = String(active.id);
+    const overId = String(over.id);
+    let targetStatus: CardStatus | null = null;
+    let beforeId: string | null = null;
+    if (overId.startsWith("column:")) {
+      targetStatus = overId.slice("column:".length) as CardStatus;
+    } else if (overId.startsWith("card:")) {
+      const overCardId = overId.slice("card:".length);
+      if (overCardId === cardId) return;
+      const overCard = cards.find((c) => c.id === overCardId);
+      if (!overCard) return;
+      targetStatus = overCard.status;
+      beforeId = overCard.id;
+    }
+    if (!targetStatus) return;
+    const order = midpointOrder(columns[targetStatus] ?? [], beforeId);
+    void moveTask(api, activeSlug, cardId, targetStatus, order);
+  };
+
+  const dragCard = activeDragId ? cards.find((c) => c.id === activeDragId) : null;
+
+  if (firstLoadPending) {
+    return (
+      <div className="flex flex-1 gap-4 overflow-x-auto p-4">
+        {BOARD_COLUMNS.map((status) => (
+          <div key={status} className="flex w-[252px] shrink-0 flex-col gap-2">
+            <div className="h-5 w-24 rounded" style={{ background: "var(--bg-raised)" }} />
+            {[0, 1, 2].map((i) => (
+              <div
+                key={i}
+                className="status-pulse h-[72px] rounded-lg"
+                style={{ background: "var(--bg-raised)" }}
+              />
+            ))}
+          </div>
+        ))}
+      </div>
+    );
+  }
+
+  if (error && cards.length === 0) {
+    return (
+      <EmptyState
+        icon={<Kanban size={28} />}
+        headline="Can't load the board"
+        description={toUserMessage(new AppError(error))}
+        action={
+          <Button
+            variant="primary"
+            onClick={() => {
+              if (api && activeSlug) void useBoard.getState().refreshTasks(api, activeSlug);
+            }}
+          >
+            Retry
+          </Button>
+        }
+      />
+    );
+  }
+
+  if (cards.length === 0) {
+    return (
+      <>
+        <EmptyState
+          icon={<Kanban size={28} />}
+          headline="No tasks yet"
+          description="Create your first task to start working with your Matrix OS computer."
+          action={
+            <Button variant="primary" onClick={() => setCreateTaskOpen(true)}>
+              New task
+            </Button>
+          }
+        />
+        <CreateTaskDialog open={createTaskOpen} onClose={() => setCreateTaskOpen(false)} />
+      </>
+    );
+  }
+
+  return (
+    <>
+      <DndContext sensors={sensors} onDragStart={onDragStart} onDragEnd={onDragEnd}>
+        <div className="flex flex-1 gap-4 overflow-x-auto p-4">
+          {BOARD_COLUMNS.map((status) => (
+            <Column
+              key={status}
+              status={status}
+              cards={columns[status] ?? []}
+              activeDragId={activeDragId}
+            />
+          ))}
+        </div>
+        <DragOverlay dropAnimation={null}>
+          {dragCard ? <BoardCard card={dragCard} overlay /> : null}
+        </DragOverlay>
+      </DndContext>
+      <CreateTaskDialog open={createTaskOpen} onClose={() => setCreateTaskOpen(false)} />
+    </>
+  );
+}

--- a/desktop/src/renderer/src/features/board/Board.tsx
+++ b/desktop/src/renderer/src/features/board/Board.tsx
@@ -29,6 +29,8 @@ const COLUMN_LABEL: Record<CardStatus, string> = {
   archived: "Archived",
 };
 
+const EMPTY_CARDS: Card[] = [];
+
 const COLUMN_COLOR: Record<CardStatus, string> = {
   todo: "var(--status-todo)",
   running: "var(--status-running)",
@@ -95,7 +97,9 @@ function DraggableCard({ card, dragging }: { card: Card; dragging: boolean }) {
 export default function Board() {
   const api = useConnection((s) => s.api);
   const activeSlug = useBoard((s) => s.activeProjectSlug);
-  const cardsByProject = useBoard((s) => s.cardsByProject);
+  const cards = useBoard((s) =>
+    activeSlug ? (s.cardsByProject[activeSlug] ?? EMPTY_CARDS) : EMPTY_CARDS,
+  );
   const firstLoadPending = useBoard((s) => s.firstLoadPending);
   const error = useBoard((s) => s.error);
   const moveTask = useBoard((s) => s.moveTask);
@@ -103,10 +107,6 @@ export default function Board() {
   const setCreateTaskOpen = useUi((s) => s.setCreateTaskOpen);
   const [activeDragId, setActiveDragId] = useState<string | null>(null);
 
-  const cards = useMemo(
-    () => (activeSlug ? (cardsByProject[activeSlug] ?? []) : []),
-    [activeSlug, cardsByProject],
-  );
   const columns = useMemo(() => groupCardsByColumn(cards), [cards]);
 
   const sensors = useSensors(useSensor(PointerSensor, { activationConstraint: { distance: 5 } }));

--- a/desktop/src/renderer/src/features/board/BoardCard.tsx
+++ b/desktop/src/renderer/src/features/board/BoardCard.tsx
@@ -1,0 +1,99 @@
+import { SquareTerminal } from "lucide-react";
+import { useState } from "react";
+import { ContextMenu, type MenuItem } from "../../design/primitives";
+import { useBoard, BOARD_COLUMNS, type Card } from "../../stores/board";
+import { useConnection } from "../../stores/connection";
+import { useUi } from "../../stores/ui";
+
+const PRIORITY_STYLE: Record<Card["priority"], { label: string; color: string } | null> = {
+  low: { label: "Low", color: "var(--text-tertiary)" },
+  normal: null,
+  high: { label: "High", color: "var(--warning)" },
+  urgent: { label: "Urgent", color: "var(--danger)" },
+};
+
+export default function BoardCard({ card, overlay = false }: { card: Card; overlay?: boolean }) {
+  const navigate = useUi((s) => s.navigate);
+  const api = useConnection((s) => s.api);
+  const updateTask = useBoard((s) => s.updateTask);
+  const archiveTask = useBoard((s) => s.archiveTask);
+  const deleteTask = useBoard((s) => s.deleteTask);
+  const [menuPos, setMenuPos] = useState<{ x: number; y: number } | null>(null);
+
+  const priority = PRIORITY_STYLE[card.priority];
+
+  const menuItems: MenuItem[] = [
+    { label: "Open", onSelect: () => navigate({ kind: "task", taskId: card.id }) },
+    ...BOARD_COLUMNS.filter((s) => s !== card.status).map((status) => ({
+      label: `Move to ${status[0]?.toUpperCase()}${status.slice(1)}`,
+      onSelect: () => {
+        if (api) void updateTask(api, card.projectSlug, card.id, { status });
+      },
+    })),
+    {
+      label: "Archive",
+      onSelect: () => {
+        if (api) void archiveTask(api, card.projectSlug, card.id);
+      },
+    },
+    {
+      label: "Delete",
+      danger: true,
+      onSelect: () => {
+        if (api) void deleteTask(api, card.projectSlug, card.id);
+      },
+    },
+  ];
+
+  return (
+    <>
+      <div
+        role="button"
+        tabIndex={0}
+        className="flex cursor-default flex-col gap-1.5 rounded-lg border p-2.5 transition-colors duration-100"
+        style={{
+          background: "var(--bg-raised)",
+          borderColor: "var(--border-subtle)",
+          boxShadow: overlay ? "var(--shadow-2)" : "var(--shadow-1)",
+        }}
+        onMouseEnter={(e) => (e.currentTarget.style.borderColor = "var(--border-strong)")}
+        onMouseLeave={(e) => (e.currentTarget.style.borderColor = "var(--border-subtle)")}
+        onClick={() => navigate({ kind: "task", taskId: card.id })}
+        onKeyDown={(e) => {
+          if (e.key === "Enter") navigate({ kind: "task", taskId: card.id });
+        }}
+        onContextMenu={(e) => {
+          e.preventDefault();
+          setMenuPos({ x: e.clientX, y: e.clientY });
+        }}
+      >
+        <span className="text-sm leading-snug" style={{ color: "var(--text-primary)" }}>
+          {card.title}
+        </span>
+        {priority || card.tags.length > 0 || card.linkedSessionId ? (
+          <div className="flex items-center gap-1.5">
+            {priority ? (
+              <span className="text-xs font-medium" style={{ color: priority.color }}>
+                {priority.label}
+              </span>
+            ) : null}
+            {card.tags.slice(0, 3).map((tag) => (
+              <span
+                key={tag}
+                className="rounded px-1.5 py-px text-xs"
+                style={{ background: "var(--bg-hover)", color: "var(--text-secondary)" }}
+              >
+                {tag}
+              </span>
+            ))}
+            <div className="flex-1" />
+            {card.linkedSessionId ? (
+              <SquareTerminal size={13} style={{ color: "var(--text-tertiary)" }} />
+            ) : null}
+          </div>
+        ) : null}
+      </div>
+      {!overlay ? <ContextMenu position={menuPos} items={menuItems} onClose={() => setMenuPos(null)} /> : null}
+    </>
+  );
+}

--- a/desktop/src/renderer/src/features/board/CreateTaskDialog.tsx
+++ b/desktop/src/renderer/src/features/board/CreateTaskDialog.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { Button, Dialog } from "../../design/primitives";
 import { useBoard, BOARD_COLUMNS, type CardPriority, type CardStatus } from "../../stores/board";
 import { useConnection } from "../../stores/connection";
@@ -37,11 +37,23 @@ export default function CreateTaskDialog({ open, onClose }: { open: boolean; onC
     }
   }, [open]);
 
-  const closeFromUser = () => {
+  const closeFromUser = useCallback(() => {
     dialogGenerationRef.current += 1;
     dialogClosedRef.current = true;
     onClose();
-  };
+  }, [onClose]);
+
+  useEffect(() => {
+    if (!open) return undefined;
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== "Escape") return;
+      closeFromUser();
+    };
+    window.addEventListener("keydown", onKeyDown);
+    return () => {
+      window.removeEventListener("keydown", onKeyDown);
+    };
+  }, [closeFromUser, open]);
 
   const submit = async (openAfter: boolean) => {
     if (!api || !activeSlug || title.trim().length === 0 || submitting) return;
@@ -136,9 +148,9 @@ export default function CreateTaskDialog({ open, onClose }: { open: boolean; onC
           className="flex items-center justify-end gap-2 border-t pt-3"
           style={{ borderColor: "var(--border-subtle)" }}
         >
-        <Button variant="ghost" disabled={submitting} onClick={closeFromUser}>
-          Cancel
-        </Button>
+          <Button variant="ghost" onClick={closeFromUser}>
+            Cancel
+          </Button>
           <Button
             variant="subtle"
             disabled={submitting || title.trim().length === 0}

--- a/desktop/src/renderer/src/features/board/CreateTaskDialog.tsx
+++ b/desktop/src/renderer/src/features/board/CreateTaskDialog.tsx
@@ -18,20 +18,34 @@ export default function CreateTaskDialog({ open, onClose }: { open: boolean; onC
   const [submitting, setSubmitting] = useState(false);
   const [failed, setFailed] = useState(false);
   const titleRef = useRef<HTMLInputElement>(null);
+  const dialogClosedRef = useRef(false);
+  const dialogGenerationRef = useRef(0);
 
   useEffect(() => {
     if (open) {
+      dialogGenerationRef.current += 1;
+      dialogClosedRef.current = false;
       setTitle("");
       setDescription("");
       setStatus("todo");
       setPriority("normal");
+      setSubmitting(false);
       setFailed(false);
       setTimeout(() => titleRef.current?.focus(), 0);
+    } else {
+      dialogClosedRef.current = true;
     }
   }, [open]);
 
+  const closeFromUser = () => {
+    dialogGenerationRef.current += 1;
+    dialogClosedRef.current = true;
+    onClose();
+  };
+
   const submit = async (openAfter: boolean) => {
     if (!api || !activeSlug || title.trim().length === 0 || submitting) return;
+    const submitGeneration = dialogGenerationRef.current;
     setSubmitting(true);
     setFailed(false);
     const card = await createTask(api, activeSlug, {
@@ -40,6 +54,7 @@ export default function CreateTaskDialog({ open, onClose }: { open: boolean; onC
       status,
       priority,
     });
+    if (dialogClosedRef.current || dialogGenerationRef.current !== submitGeneration) return;
     setSubmitting(false);
     if (!card) {
       setFailed(true);
@@ -59,7 +74,7 @@ export default function CreateTaskDialog({ open, onClose }: { open: boolean; onC
   };
 
   return (
-    <Dialog open={open} onClose={onClose} width={520}>
+    <Dialog open={open} onClose={closeFromUser} width={520}>
       <form
         className="flex flex-col gap-3 p-4"
         onSubmit={(e) => {
@@ -121,7 +136,7 @@ export default function CreateTaskDialog({ open, onClose }: { open: boolean; onC
           className="flex items-center justify-end gap-2 border-t pt-3"
           style={{ borderColor: "var(--border-subtle)" }}
         >
-        <Button variant="ghost" disabled={submitting} onClick={onClose}>
+        <Button variant="ghost" disabled={submitting} onClick={closeFromUser}>
           Cancel
         </Button>
           <Button

--- a/desktop/src/renderer/src/features/board/CreateTaskDialog.tsx
+++ b/desktop/src/renderer/src/features/board/CreateTaskDialog.tsx
@@ -1,0 +1,147 @@
+import { useEffect, useRef, useState } from "react";
+import { Button, Dialog } from "../../design/primitives";
+import { useBoard, BOARD_COLUMNS, type CardPriority, type CardStatus } from "../../stores/board";
+import { useConnection } from "../../stores/connection";
+import { useUi } from "../../stores/ui";
+
+const PRIORITIES: CardPriority[] = ["low", "normal", "high", "urgent"];
+
+export default function CreateTaskDialog({ open, onClose }: { open: boolean; onClose: () => void }) {
+  const api = useConnection((s) => s.api);
+  const activeSlug = useBoard((s) => s.activeProjectSlug);
+  const createTask = useBoard((s) => s.createTask);
+  const navigate = useUi((s) => s.navigate);
+  const [title, setTitle] = useState("");
+  const [description, setDescription] = useState("");
+  const [status, setStatus] = useState<CardStatus>("todo");
+  const [priority, setPriority] = useState<CardPriority>("normal");
+  const [submitting, setSubmitting] = useState(false);
+  const [failed, setFailed] = useState(false);
+  const titleRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (open) {
+      setTitle("");
+      setDescription("");
+      setStatus("todo");
+      setPriority("normal");
+      setFailed(false);
+      setTimeout(() => titleRef.current?.focus(), 0);
+    }
+  }, [open]);
+
+  const submit = async (openAfter: boolean) => {
+    if (!api || !activeSlug || title.trim().length === 0 || submitting) return;
+    setSubmitting(true);
+    setFailed(false);
+    const card = await createTask(api, activeSlug, {
+      title: title.trim(),
+      description: description.trim() || undefined,
+      status,
+      priority,
+    });
+    setSubmitting(false);
+    if (!card) {
+      setFailed(true);
+      return;
+    }
+    onClose();
+    if (openAfter) navigate({ kind: "task", taskId: card.id });
+  };
+
+  const selectStyle: React.CSSProperties = {
+    background: "var(--bg-raised)",
+    color: "var(--text-primary)",
+    border: "1px solid var(--border-default)",
+    borderRadius: "var(--radius)",
+    padding: "4px 8px",
+    fontSize: "var(--text-sm)",
+  };
+
+  return (
+    <Dialog open={open} onClose={onClose} width={520}>
+      <form
+        className="flex flex-col gap-3 p-4"
+        onSubmit={(e) => {
+          e.preventDefault();
+          void submit(false);
+        }}
+        onKeyDown={(e) => {
+          if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
+            e.preventDefault();
+            void submit(e.shiftKey);
+          }
+        }}
+      >
+        <input
+          ref={titleRef}
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+          placeholder="Task title"
+          maxLength={200}
+          className="w-full bg-transparent text-lg font-medium outline-none"
+          style={{ color: "var(--text-primary)" }}
+        />
+        <textarea
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+          placeholder="Description (optional)"
+          rows={3}
+          className="w-full resize-none bg-transparent text-sm outline-none"
+          style={{ color: "var(--text-secondary)" }}
+        />
+        <div className="flex items-center gap-2">
+          <select value={status} onChange={(e) => setStatus(e.target.value as CardStatus)} style={selectStyle}>
+            {BOARD_COLUMNS.map((s) => (
+              <option key={s} value={s}>
+                {s[0]?.toUpperCase()}
+                {s.slice(1)}
+              </option>
+            ))}
+          </select>
+          <select
+            value={priority}
+            onChange={(e) => setPriority(e.target.value as CardPriority)}
+            style={selectStyle}
+          >
+            {PRIORITIES.map((p) => (
+              <option key={p} value={p}>
+                {p[0]?.toUpperCase()}
+                {p.slice(1)}
+              </option>
+            ))}
+          </select>
+        </div>
+        {failed ? (
+          <p className="text-sm" style={{ color: "var(--danger)" }}>
+            Couldn't create the task. Please try again.
+          </p>
+        ) : null}
+        <div
+          className="flex items-center justify-end gap-2 border-t pt-3"
+          style={{ borderColor: "var(--border-subtle)" }}
+        >
+          <Button variant="ghost" onClick={onClose}>
+            Cancel
+          </Button>
+          <Button
+            variant="subtle"
+            disabled={submitting || title.trim().length === 0}
+            onClick={() => void submit(true)}
+            title="Create and open (Cmd+Shift+Enter)"
+          >
+            Create + open
+          </Button>
+          <Button
+            variant="primary"
+            disabled={submitting || title.trim().length === 0}
+            onClick={() => void submit(false)}
+            title="Create (Cmd+Enter)"
+          >
+            {submitting ? "Creating…" : "Create"}
+          </Button>
+        </div>
+      </form>
+    </Dialog>
+  );
+}

--- a/desktop/src/renderer/src/features/board/CreateTaskDialog.tsx
+++ b/desktop/src/renderer/src/features/board/CreateTaskDialog.tsx
@@ -121,9 +121,9 @@ export default function CreateTaskDialog({ open, onClose }: { open: boolean; onC
           className="flex items-center justify-end gap-2 border-t pt-3"
           style={{ borderColor: "var(--border-subtle)" }}
         >
-          <Button variant="ghost" onClick={onClose}>
-            Cancel
-          </Button>
+        <Button variant="ghost" disabled={submitting} onClick={onClose}>
+          Cancel
+        </Button>
           <Button
             variant="subtle"
             disabled={submitting || title.trim().length === 0}

--- a/desktop/src/renderer/src/features/threads/Composer.tsx
+++ b/desktop/src/renderer/src/features/threads/Composer.tsx
@@ -3,7 +3,6 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import { Dialog } from "../../design/primitives";
 import { sendKernelMessage } from "../../lib/kernel-wiring";
 import { useBoard } from "../../stores/board";
-import { useSessions } from "../../stores/sessions";
 import { useThreads } from "../../stores/threads";
 import { useUi } from "../../stores/ui";
 
@@ -14,7 +13,6 @@ export default function Composer() {
   const navigate = useUi((s) => s.navigate);
   const startThread = useThreads((s) => s.startThread);
   const cardsByProject = useBoard((s) => s.cardsByProject);
-  const resolveAttachName = useSessions((s) => s.resolveAttachName);
   const [text, setText] = useState("");
   const inputRef = useRef<HTMLTextAreaElement>(null);
 

--- a/desktop/src/renderer/src/features/threads/Composer.tsx
+++ b/desktop/src/renderer/src/features/threads/Composer.tsx
@@ -1,0 +1,100 @@
+import { CornerDownLeft } from "lucide-react";
+import { useEffect, useMemo, useRef, useState } from "react";
+import { Dialog } from "../../design/primitives";
+import { sendKernelMessage } from "../../lib/kernel-wiring";
+import { useBoard } from "../../stores/board";
+import { useSessions } from "../../stores/sessions";
+import { useThreads } from "../../stores/threads";
+import { useUi } from "../../stores/ui";
+
+export default function Composer() {
+  const open = useUi((s) => s.composerOpen);
+  const setOpen = useUi((s) => s.setComposerOpen);
+  const view = useUi((s) => s.view);
+  const navigate = useUi((s) => s.navigate);
+  const startThread = useThreads((s) => s.startThread);
+  const cardsByProject = useBoard((s) => s.cardsByProject);
+  const resolveAttachName = useSessions((s) => s.resolveAttachName);
+  const [text, setText] = useState("");
+  const inputRef = useRef<HTMLTextAreaElement>(null);
+
+  const boundTask = useMemo(() => {
+    if (view.kind !== "task") return null;
+    for (const cards of Object.values(cardsByProject)) {
+      const card = cards.find((c) => c.id === view.taskId);
+      if (card) return card;
+    }
+    return null;
+  }, [view, cardsByProject]);
+
+  useEffect(() => {
+    if (open) {
+      setText("");
+      setTimeout(() => inputRef.current?.focus(), 0);
+    }
+  }, [open]);
+
+  const submit = () => {
+    const trimmed = text.trim();
+    if (trimmed.length === 0) return;
+    const requestId = crypto.randomUUID();
+    const thread = startThread({
+      text: trimmed,
+      title: trimmed.length > 60 ? `${trimmed.slice(0, 57)}…` : trimmed,
+      taskId: boundTask?.id ?? null,
+      sessionId: null,
+      requestId,
+    });
+    sendKernelMessage({ text: trimmed, requestId });
+    setOpen(false);
+    navigate({ kind: "thread", threadId: thread.id });
+  };
+
+  return (
+    <Dialog open={open} onClose={() => setOpen(false)} width={560}>
+      <div className="flex flex-col gap-2 p-4">
+        {boundTask ? (
+          <span
+            className="self-start rounded-full border px-2 py-0.5 text-xs"
+            style={{ borderColor: "var(--border-default)", color: "var(--text-secondary)" }}
+          >
+            Task: {boundTask.title}
+          </span>
+        ) : null}
+        <textarea
+          ref={inputRef}
+          value={text}
+          onChange={(e) => setText(e.target.value)}
+          placeholder="Ask Hermes to do something…"
+          rows={3}
+          maxLength={100_000}
+          className="w-full resize-none bg-transparent text-md outline-none"
+          style={{ color: "var(--text-primary)" }}
+          onKeyDown={(e) => {
+            if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
+              e.preventDefault();
+              submit();
+            }
+          }}
+        />
+        <div className="flex items-center justify-between">
+          <span className="text-xs" style={{ color: "var(--text-tertiary)" }}>
+            Runs on your computer as an agent thread
+          </span>
+          <button
+            type="button"
+            disabled={text.trim().length === 0}
+            onClick={submit}
+            className="inline-flex h-7 items-center gap-1.5 rounded-md px-3 text-sm font-medium transition-colors duration-100 disabled:opacity-50"
+            style={{ background: "var(--accent)", color: "var(--text-on-accent)" }}
+          >
+            Start
+            <span className="flex items-center gap-0.5 text-xs opacity-80">
+              ⌘<CornerDownLeft size={11} />
+            </span>
+          </button>
+        </div>
+      </div>
+    </Dialog>
+  );
+}

--- a/desktop/src/renderer/src/features/threads/ThreadView.tsx
+++ b/desktop/src/renderer/src/features/threads/ThreadView.tsx
@@ -1,0 +1,130 @@
+import { ArrowLeft, CircleStop, Wrench } from "lucide-react";
+import { useEffect, useMemo, useRef } from "react";
+import ReactMarkdown from "react-markdown";
+import { Button, IconButton, StatusDot } from "../../design/primitives";
+import { groupMessages, type ChatMessage } from "../../lib/chat";
+import { abortKernelRequest } from "../../lib/kernel-wiring";
+import { useThreads, type ThreadStatus } from "../../stores/threads";
+import { useUi } from "../../stores/ui";
+
+const STATUS_META: Record<ThreadStatus, { label: string; color: string }> = {
+  running: { label: "Running", color: "var(--status-running)" },
+  "needs-attention": { label: "Needs attention", color: "var(--status-attention)" },
+  done: { label: "Done", color: "var(--status-complete)" },
+  failed: { label: "Failed", color: "var(--status-failed)" },
+  aborted: { label: "Aborted", color: "var(--status-todo)" },
+};
+
+function ToolRow({ message }: { message: ChatMessage }) {
+  return (
+    <div
+      className="flex items-center gap-2 rounded-md border px-2.5 py-1.5 text-sm"
+      style={{
+        borderColor: "var(--border-subtle)",
+        background: "var(--bg-raised)",
+        color: "var(--text-secondary)",
+      }}
+    >
+      <Wrench size={12} style={{ color: "var(--text-tertiary)" }} />
+      <span className="truncate font-mono text-xs">{message.content}</span>
+    </div>
+  );
+}
+
+function MessageBubble({ message }: { message: ChatMessage }) {
+  if (message.role === "user") {
+    return (
+      <div className="flex justify-end">
+        <div
+          className="max-w-[78%] rounded-xl rounded-br-sm px-3.5 py-2 text-sm whitespace-pre-wrap"
+          style={{ background: "var(--accent-muted)", color: "var(--text-primary)" }}
+          data-selectable
+        >
+          {message.content}
+        </div>
+      </div>
+    );
+  }
+  return (
+    <div
+      className="prose-invert max-w-none text-sm leading-relaxed [&_code]:font-mono [&_code]:text-[12px] [&_pre]:overflow-x-auto [&_pre]:rounded-lg [&_pre]:border [&_pre]:p-3"
+      style={{ color: "var(--text-primary)" }}
+      data-selectable
+    >
+      <ReactMarkdown>{message.content}</ReactMarkdown>
+    </div>
+  );
+}
+
+export default function ThreadView({ threadId }: { threadId: string }) {
+  const thread = useThreads((s) => s.threads.find((t) => t.id === threadId));
+  const navigate = useUi((s) => s.navigate);
+  const scrollRef = useRef<HTMLDivElement>(null);
+
+  const groups = useMemo(
+    () => (thread ? groupMessages(thread.transcript) : []),
+    [thread],
+  );
+
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (el) el.scrollTop = el.scrollHeight;
+  }, [thread?.transcript.length, thread?.transcript[thread.transcript.length - 1]?.content]);
+
+  if (!thread) {
+    return (
+      <div className="flex flex-1 items-center justify-center">
+        <span className="text-sm" style={{ color: "var(--text-tertiary)" }}>
+          Thread not found.
+        </span>
+      </div>
+    );
+  }
+
+  const status = STATUS_META[thread.status];
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col">
+      <div
+        className="flex shrink-0 items-center gap-2 border-b px-3 py-2"
+        style={{ borderColor: "var(--border-subtle)", background: "var(--bg-surface)" }}
+      >
+        <IconButton label="Back" onClick={() => navigate({ kind: "board" })}>
+          <ArrowLeft size={15} />
+        </IconButton>
+        <span className="min-w-0 flex-1 truncate text-sm font-semibold" style={{ color: "var(--text-primary)" }}>
+          {thread.title}
+        </span>
+        <span className="flex items-center gap-1.5 text-xs" style={{ color: "var(--text-secondary)" }}>
+          <StatusDot color={status.color} pulse={thread.status === "running"} />
+          {status.label}
+        </span>
+        {thread.status === "running" ? (
+          <Button variant="danger" onClick={() => abortKernelRequest(thread.requestId)}>
+            <CircleStop size={13} />
+            Stop
+          </Button>
+        ) : null}
+      </div>
+
+      <div ref={scrollRef} className="flex min-h-0 flex-1 flex-col gap-3 overflow-y-auto px-5 py-4">
+        {groups.map((group, i) =>
+          group.type === "tool_group" ? (
+            <div key={i} className="flex flex-col gap-1">
+              {group.messages.map((m) => (
+                <ToolRow key={m.id} message={m} />
+              ))}
+            </div>
+          ) : (
+            <MessageBubble key={group.message.id} message={group.message} />
+          ),
+        )}
+        {thread.status === "running" ? (
+          <span className="status-pulse text-xs" style={{ color: "var(--text-tertiary)" }}>
+            Working…
+          </span>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/desktop/src/renderer/src/lib/chat.ts
+++ b/desktop/src/renderer/src/lib/chat.ts
@@ -1,0 +1,161 @@
+// Ported from shell/src/lib/chat.ts (spec 094 R4); keep semantics in sync.
+// Reducer rule (CLAUDE.md): never mutate -- always new objects; in-place
+// mutation causes streaming text duplication.
+
+export type ChatEvent =
+  | { type: "kernel:init"; sessionId: string; requestId?: string }
+  | { type: "kernel:text"; text: string; requestId?: string }
+  | { type: "kernel:tool_start"; tool: string; requestId?: string }
+  | { type: "kernel:tool_end"; input?: Record<string, unknown>; requestId?: string }
+  | { type: "kernel:result"; data?: unknown; requestId?: string }
+  | { type: "kernel:error"; message: string; requestId?: string }
+  | { type: "kernel:aborted"; requestId?: string };
+
+let msgSeq = 0;
+function newMsgId(): string {
+  msgSeq = (msgSeq + 1) & 0xffff;
+  return `msg-${Date.now()}-${msgSeq}`;
+}
+
+export interface ChatMessage {
+  id: string;
+  role: "user" | "assistant" | "system";
+  content: string;
+  tool?: string;
+  toolInput?: Record<string, unknown>;
+  requestId?: string;
+  metadata?: Record<string, unknown>;
+  timestamp: number;
+}
+
+export type MessageGroup =
+  | { type: "message"; message: ChatMessage }
+  | { type: "tool_group"; messages: ChatMessage[] };
+
+export function groupMessages(messages: ChatMessage[]): MessageGroup[] {
+  const groups: MessageGroup[] = [];
+  let toolBuf: ChatMessage[] = [];
+
+  function flushTools() {
+    if (toolBuf.length > 0) {
+      groups.push({ type: "tool_group", messages: [...toolBuf] });
+      toolBuf = [];
+    }
+  }
+
+  for (const msg of messages) {
+    if (msg.tool) {
+      toolBuf.push(msg);
+    } else {
+      flushTools();
+      groups.push({ type: "message", message: msg });
+    }
+  }
+  flushTools();
+
+  return groups;
+}
+
+export function reduceChat(messages: ChatMessage[], event: ChatEvent): ChatMessage[] {
+  const next = [...messages];
+  const reqId = event.requestId;
+
+  switch (event.type) {
+    case "kernel:text": {
+      let targetIdx = -1;
+
+      if (reqId) {
+        // With requestId: scan back to find matching assistant message,
+        // but stop if we hit a tool message from the same request --
+        // post-tool text should get its own bubble
+        for (let i = next.length - 1; i >= 0; i--) {
+          const m = next[i]!;
+          if (m.role === "assistant" && !m.tool && m.requestId === reqId) {
+            targetIdx = i;
+            break;
+          }
+          if (m.tool && m.requestId === reqId) {
+            break;
+          }
+        }
+      } else {
+        // Without requestId: original behavior - only check last message
+        const last = next[next.length - 1];
+        if (last?.role === "assistant" && !last.tool) {
+          targetIdx = next.length - 1;
+        }
+      }
+
+      if (targetIdx >= 0) {
+        const target = next[targetIdx]!;
+        next[targetIdx] = { ...target, content: target.content + event.text };
+      } else {
+        next.push({
+          id: newMsgId(),
+          role: "assistant",
+          content: event.text,
+          requestId: reqId,
+          timestamp: Date.now(),
+        });
+      }
+      break;
+    }
+    case "kernel:tool_start": {
+      next.push({
+        id: newMsgId(),
+        role: "system",
+        content: `Using ${event.tool}...`,
+        tool: event.tool,
+        requestId: reqId,
+        timestamp: Date.now(),
+      });
+      break;
+    }
+    case "kernel:tool_end": {
+      // Find last tool message matching requestId
+      for (let i = next.length - 1; i >= 0; i--) {
+        const m = next[i]!;
+        if (m.tool && m.content.startsWith("Using ")) {
+          if (!reqId || m.requestId === reqId) {
+            next[i] = { ...m, content: `Used ${m.tool}`, toolInput: event.input };
+            break;
+          }
+        }
+      }
+      break;
+    }
+    case "kernel:error": {
+      next.push({
+        id: newMsgId(),
+        role: "system",
+        content: event.message,
+        requestId: reqId,
+        timestamp: Date.now(),
+      });
+      break;
+    }
+    case "kernel:aborted": {
+      // Mark any in-flight tool message as stopped so its spinner switches
+      // to the check icon -- the server never emits kernel:tool_end after
+      // an abort.
+      for (let i = next.length - 1; i >= 0; i--) {
+        const m = next[i]!;
+        if (m.tool && m.content.startsWith("Using ")) {
+          if (!reqId || m.requestId === reqId) {
+            next[i] = { ...m, content: `Stopped ${m.tool}` };
+          }
+        }
+      }
+      next.push({
+        id: newMsgId(),
+        role: "system",
+        content: "Stopped.",
+        requestId: reqId,
+        timestamp: Date.now(),
+      });
+      break;
+    }
+  }
+
+  return next;
+}

--- a/desktop/src/renderer/src/lib/chat.ts
+++ b/desktop/src/renderer/src/lib/chat.ts
@@ -17,6 +17,23 @@ function newMsgId(): string {
   return `msg-${Date.now()}-${msgSeq}`;
 }
 
+const SAFE_KERNEL_ERROR_MESSAGE = "Something went wrong. Please try again.";
+const MAX_KERNEL_ERROR_CHARS = 180;
+const UNSAFE_KERNEL_ERROR_PATTERN =
+  /(?:\/home\/|\/tmp\/|node_modules|packages\/|desktop\/src|Error:|Exception|stack trace|postgres|database|anthropic|openai|claude|ENOENT|EACCES)/i;
+
+function safeKernelErrorMessage(message: string): string {
+  const trimmed = message.replace(/\s+/g, " ").trim();
+  if (
+    trimmed.length === 0 ||
+    trimmed.length > MAX_KERNEL_ERROR_CHARS ||
+    UNSAFE_KERNEL_ERROR_PATTERN.test(trimmed)
+  ) {
+    return SAFE_KERNEL_ERROR_MESSAGE;
+  }
+  return trimmed;
+}
+
 export interface ChatMessage {
   id: string;
   role: "user" | "assistant" | "system";
@@ -128,7 +145,7 @@ export function reduceChat(messages: ChatMessage[], event: ChatEvent): ChatMessa
       next.push({
         id: newMsgId(),
         role: "system",
-        content: event.message,
+        content: safeKernelErrorMessage(event.message),
         requestId: reqId,
         timestamp: Date.now(),
       });

--- a/desktop/src/renderer/src/stores/board.ts
+++ b/desktop/src/renderer/src/stores/board.ts
@@ -118,13 +118,21 @@ function categoryOf(err: unknown): AppErrorCategory {
 
 const TASKS_PAGE_LIMIT = 100;
 const MAX_TASK_PAGES = 10;
+const MAX_PENDING_TASK_MUTATIONS = 250;
 
 // Per-task in-flight chains so two rapid mutations cannot interleave. Each
 // queued fn handles its own errors (chain never rejects); entries evict
-// themselves once their chain settles, so the map stays bounded.
+// themselves once their chain settles, and the live map has a hard cap.
 const taskMutationTails = new Map<string, Promise<void>>();
 
+function canEnqueueTaskMutation(taskId: string): boolean {
+  return taskMutationTails.has(taskId) || taskMutationTails.size < MAX_PENDING_TASK_MUTATIONS;
+}
+
 function enqueueTaskMutation(taskId: string, fn: () => Promise<void>): Promise<void> {
+  if (!canEnqueueTaskMutation(taskId)) {
+    return Promise.reject(new AppError("server"));
+  }
   const tail = taskMutationTails.get(taskId) ?? Promise.resolve();
   const next = tail.then(fn);
   taskMutationTails.set(taskId, next);
@@ -233,6 +241,10 @@ export const useBoard = create<BoardState>()((set, get) => {
   ): Promise<void> {
     const before = get().cardsByProject[slug]?.find((card) => card.id === taskId);
     if (!before) return Promise.resolve();
+    if (!canEnqueueTaskMutation(taskId)) {
+      set({ error: "server" });
+      return Promise.resolve();
+    }
     patchCard(slug, taskId, (card) => ({ ...card, ...patch }));
     return enqueueTaskMutation(taskId, async () => {
       try {
@@ -323,25 +335,27 @@ export const useBoard = create<BoardState>()((set, get) => {
 
     deleteTask: (api, slug, taskId) => {
       const cards = get().cardsByProject[slug];
-      const target = cards?.find((card) => card.id === taskId);
-      if (!cards || !target) return Promise.resolve();
-      replaceProjectCards(slug, cards.filter((card) => card.id !== taskId));
+      if (!cards?.some((card) => card.id === taskId)) return Promise.resolve();
+      if (!canEnqueueTaskMutation(taskId)) {
+        set({ error: "server" });
+        return Promise.resolve();
+      }
       return enqueueTaskMutation(taskId, async () => {
         try {
           await api.delete<{ ok: boolean }>(taskPath(slug, taskId));
-          set({ error: null });
-        } catch (err: unknown) {
-          console.error("[board] Task delete failed:", err);
           set((state) => {
             const current = state.cardsByProject[slug] ?? [];
-            const restored = current.some((card) => card.id === taskId)
-              ? current
-              : [...current, target];
             return {
-              cardsByProject: { ...state.cardsByProject, [slug]: restored },
-              error: categoryOf(err),
+              cardsByProject: {
+                ...state.cardsByProject,
+                [slug]: current.filter((card) => card.id !== taskId),
+              },
+              error: null,
             };
           });
+        } catch (err: unknown) {
+          console.error("[board] Task delete failed:", err);
+          set({ error: categoryOf(err) });
         }
       });
     },

--- a/desktop/src/renderer/src/stores/board.ts
+++ b/desktop/src/renderer/src/stores/board.ts
@@ -1,0 +1,381 @@
+// Board (kanban) store. Wire shapes verified against
+// packages/gateway/src/workspace-routes.ts + task-manager.ts:
+//   GET  /api/workspace/projects            -> { projects: ProjectConfig[], nextCursor: null }
+//   GET  /api/projects/{slug}/tasks         -> { tasks: TaskRecord[], nextCursor: string|null }
+//   POST /api/projects/{slug}/tasks         -> { task: TaskRecord }
+//   PATCH/DELETE /api/projects/{slug}/tasks/{id} -> { task } / { ok: true }
+// Server is last-write-wins, so mutations are serialized per task and stale
+// writes trigger a refetch instead of a silent overwrite (FR-011).
+import { create } from "zustand";
+import { z } from "zod/v4";
+import { AppError, type AppErrorCategory } from "../../../shared/app-error";
+import type { ApiClient } from "../lib/api";
+
+export type CardStatus = "todo" | "running" | "waiting" | "blocked" | "complete" | "archived";
+export type CardPriority = "low" | "normal" | "high" | "urgent";
+
+export interface Card {
+  id: string;
+  projectSlug: string;
+  title: string;
+  description: string;
+  status: CardStatus;
+  priority: CardPriority;
+  order: number;
+  parentTaskId: string | null;
+  linkedSessionId: string | null;
+  linkedWorktreeId: string | null;
+  previewIds: string[];
+  tags: string[];
+  updatedAt: string | null;
+  revision: number | null;
+}
+
+export interface Project {
+  slug: string;
+  name: string;
+}
+
+export const BOARD_COLUMNS: readonly CardStatus[] = [
+  "todo",
+  "running",
+  "waiting",
+  "blocked",
+  "complete",
+];
+
+const CardStatusSchema = z.enum(["todo", "running", "waiting", "blocked", "complete", "archived"]);
+
+const WireTaskSchema = z.object({
+  id: z.string().min(1),
+  projectSlug: z.string().min(1),
+  title: z.string(),
+  description: z.string().nullish(),
+  status: CardStatusSchema,
+  priority: z.enum(["low", "normal", "high", "urgent"]),
+  order: z.number(),
+  parentTaskId: z.string().nullish(),
+  linkedSessionId: z.string().nullish(),
+  linkedWorktreeId: z.string().nullish(),
+  previewIds: z.array(z.string()).default([]),
+  tags: z.array(z.string()).default([]),
+  updatedAt: z.string().nullish(),
+  revision: z.number().nullish(),
+});
+
+const WireProjectSchema = z.object({
+  slug: z.string().min(1),
+  name: z.string().min(1),
+});
+
+function toCard(raw: unknown): Card | null {
+  const parsed = WireTaskSchema.safeParse(raw);
+  if (!parsed.success) {
+    console.warn("[board] Ignoring task with unexpected wire shape");
+    return null;
+  }
+  const task = parsed.data;
+  return {
+    id: task.id,
+    projectSlug: task.projectSlug,
+    title: task.title,
+    description: task.description ?? "",
+    status: task.status,
+    priority: task.priority,
+    order: task.order,
+    parentTaskId: task.parentTaskId ?? null,
+    linkedSessionId: task.linkedSessionId ?? null,
+    linkedWorktreeId: task.linkedWorktreeId ?? null,
+    previewIds: task.previewIds,
+    tags: task.tags,
+    updatedAt: task.updatedAt ?? null,
+    revision: task.revision ?? null,
+  };
+}
+
+export function groupCardsByColumn(cards: Card[]): Record<CardStatus, Card[]> {
+  const grouped: Record<CardStatus, Card[]> = {
+    todo: [],
+    running: [],
+    waiting: [],
+    blocked: [],
+    complete: [],
+    archived: [],
+  };
+  for (const card of cards) {
+    if (card.status === "archived") continue;
+    grouped[card.status].push(card);
+  }
+  for (const status of BOARD_COLUMNS) {
+    grouped[status].sort((a, b) => a.order - b.order || a.id.localeCompare(b.id));
+  }
+  return grouped;
+}
+
+function categoryOf(err: unknown): AppErrorCategory {
+  return err instanceof AppError ? err.category : "server";
+}
+
+const TASKS_PAGE_LIMIT = 100;
+const MAX_TASK_PAGES = 10;
+
+// Per-task in-flight chains so two rapid mutations cannot interleave. Each
+// queued fn handles its own errors (chain never rejects); entries evict
+// themselves once their chain settles, so the map stays bounded.
+const taskMutationTails = new Map<string, Promise<void>>();
+
+function enqueueTaskMutation(taskId: string, fn: () => Promise<void>): Promise<void> {
+  const tail = taskMutationTails.get(taskId) ?? Promise.resolve();
+  const next = tail.then(fn);
+  taskMutationTails.set(taskId, next);
+  void next.finally(() => {
+    if (taskMutationTails.get(taskId) === next) taskMutationTails.delete(taskId);
+  });
+  return next;
+}
+
+function taskPath(slug: string, taskId?: string): string {
+  const base = `/api/projects/${encodeURIComponent(slug)}/tasks`;
+  return taskId === undefined ? base : `${base}/${encodeURIComponent(taskId)}`;
+}
+
+async function fetchAllTasks(api: ApiClient, slug: string): Promise<Card[]> {
+  const cards: Card[] = [];
+  let cursor: string | null = null;
+  for (let page = 0; page < MAX_TASK_PAGES; page += 1) {
+    const query: string = cursor === null ? "" : `&cursor=${encodeURIComponent(cursor)}`;
+    const response: { tasks: unknown[]; nextCursor: string | null } = await api.get(
+      `${taskPath(slug)}?limit=${TASKS_PAGE_LIMIT}${query}`,
+    );
+    for (const raw of response.tasks ?? []) {
+      const card = toCard(raw);
+      if (card) cards.push(card);
+    }
+    if (!response.nextCursor) break;
+    cursor = response.nextCursor;
+  }
+  return cards;
+}
+
+export interface TaskEventCreated {
+  type: "task:created";
+  task: unknown;
+}
+
+export interface TaskEventUpdated {
+  type: "task:updated";
+  taskId: string;
+  status: string;
+}
+
+export interface CreateTaskInput {
+  title: string;
+  description?: string;
+  status?: CardStatus;
+  priority?: CardPriority;
+}
+
+export type CardPatch = Partial<Pick<Card, "title" | "description" | "status" | "priority" | "order">>;
+
+interface BoardState {
+  projects: Project[];
+  activeProjectSlug: string | null;
+  cardsByProject: Record<string, Card[]>;
+  firstLoadPending: boolean;
+  refreshing: boolean;
+  error: AppErrorCategory | null;
+  loadProjects(api: ApiClient): Promise<void>;
+  selectProject(api: ApiClient, slug: string): Promise<void>;
+  refreshTasks(api: ApiClient, slug: string): Promise<void>;
+  createTask(api: ApiClient, slug: string, input: CreateTaskInput): Promise<Card | null>;
+  updateTask(api: ApiClient, slug: string, taskId: string, patch: CardPatch): Promise<void>;
+  moveTask(api: ApiClient, slug: string, taskId: string, status: CardStatus, order: number): Promise<void>;
+  archiveTask(api: ApiClient, slug: string, taskId: string): Promise<void>;
+  deleteTask(api: ApiClient, slug: string, taskId: string): Promise<void>;
+  applyTaskEvent(event: TaskEventCreated | TaskEventUpdated): void;
+}
+
+export const useBoard = create<BoardState>()((set, get) => {
+  function replaceProjectCards(slug: string, cards: Card[]): void {
+    set((state) => ({ cardsByProject: { ...state.cardsByProject, [slug]: cards } }));
+  }
+
+  function patchCard(slug: string, taskId: string, apply: (card: Card) => Card): void {
+    set((state) => {
+      const cards = state.cardsByProject[slug];
+      if (!cards) return state;
+      return {
+        cardsByProject: {
+          ...state.cardsByProject,
+          [slug]: cards.map((card) => (card.id === taskId ? apply(card) : card)),
+        },
+      };
+    });
+  }
+
+  async function refreshInto(api: ApiClient, slug: string): Promise<void> {
+    set({ refreshing: true });
+    try {
+      const cards = await fetchAllTasks(api, slug);
+      replaceProjectCards(slug, cards);
+      set({ refreshing: false, error: null });
+    } catch (err: unknown) {
+      console.error("[board] Failed to load tasks:", err);
+      set({ refreshing: false, error: categoryOf(err) });
+    }
+  }
+
+  function mutateTask(
+    api: ApiClient,
+    slug: string,
+    taskId: string,
+    patch: CardPatch,
+  ): Promise<void> {
+    const before = get().cardsByProject[slug]?.find((card) => card.id === taskId);
+    if (!before) return Promise.resolve();
+    patchCard(slug, taskId, (card) => ({ ...card, ...patch }));
+    return enqueueTaskMutation(taskId, async () => {
+      try {
+        const response = await api.patch<{ task: unknown }>(taskPath(slug, taskId), patch);
+        const card = toCard(response.task);
+        if (card) patchCard(slug, taskId, () => card);
+        set({ error: null });
+      } catch (err: unknown) {
+        console.error("[board] Task update failed:", err);
+        patchCard(slug, taskId, () => before);
+        // FR-011: a rejected write may mean our base was stale — converge on
+        // server truth instead of silently overwriting, then surface the
+        // mutation failure (the refetch must not clear it).
+        await refreshInto(api, slug);
+        set({ error: categoryOf(err) });
+      }
+    });
+  }
+
+  return {
+    projects: [],
+    activeProjectSlug: null,
+    cardsByProject: {},
+    firstLoadPending: false,
+    refreshing: false,
+    error: null,
+
+    loadProjects: async (api) => {
+      try {
+        const response = await api.get<{ projects: unknown[] }>("/api/workspace/projects");
+        const projects: Project[] = [];
+        for (const raw of response.projects ?? []) {
+          const parsed = WireProjectSchema.safeParse(raw);
+          if (parsed.success) projects.push({ slug: parsed.data.slug, name: parsed.data.name });
+        }
+        set({ projects, error: null });
+      } catch (err: unknown) {
+        console.error("[board] Failed to load projects:", err);
+        set({ error: categoryOf(err) });
+      }
+    },
+
+    selectProject: async (api, slug) => {
+      const hasCache = get().cardsByProject[slug] !== undefined;
+      // L11: the skeleton shows only when this project has never loaded;
+      // otherwise cached cards stay visible while we revalidate.
+      set({ activeProjectSlug: slug, firstLoadPending: !hasCache });
+      try {
+        await refreshInto(api, slug);
+      } finally {
+        if (get().activeProjectSlug === slug) set({ firstLoadPending: false });
+      }
+    },
+
+    refreshTasks: async (api, slug) => {
+      await refreshInto(api, slug);
+    },
+
+    createTask: async (api, slug, input) => {
+      try {
+        const response = await api.post<{ task: unknown }>(taskPath(slug), input);
+        const card = toCard(response.task);
+        if (!card) {
+          set({ error: "server" });
+          return null;
+        }
+        set((state) => ({
+          cardsByProject: {
+            ...state.cardsByProject,
+            [slug]: [...(state.cardsByProject[slug] ?? []), card],
+          },
+          error: null,
+        }));
+        return card;
+      } catch (err: unknown) {
+        console.error("[board] Task create failed:", err);
+        set({ error: categoryOf(err) });
+        return null;
+      }
+    },
+
+    updateTask: (api, slug, taskId, patch) => mutateTask(api, slug, taskId, patch),
+
+    moveTask: (api, slug, taskId, status, order) =>
+      mutateTask(api, slug, taskId, { status, order }),
+
+    archiveTask: (api, slug, taskId) => mutateTask(api, slug, taskId, { status: "archived" }),
+
+    deleteTask: (api, slug, taskId) => {
+      const cards = get().cardsByProject[slug];
+      const target = cards?.find((card) => card.id === taskId);
+      if (!cards || !target) return Promise.resolve();
+      replaceProjectCards(slug, cards.filter((card) => card.id !== taskId));
+      return enqueueTaskMutation(taskId, async () => {
+        try {
+          await api.delete<{ ok: boolean }>(taskPath(slug, taskId));
+          set({ error: null });
+        } catch (err: unknown) {
+          console.error("[board] Task delete failed:", err);
+          set((state) => {
+            const current = state.cardsByProject[slug] ?? [];
+            const restored = current.some((card) => card.id === taskId)
+              ? current
+              : [...current, target];
+            return {
+              cardsByProject: { ...state.cardsByProject, [slug]: restored },
+              error: categoryOf(err),
+            };
+          });
+        }
+      });
+    },
+
+    applyTaskEvent: (event) => {
+      if (event.type === "task:created") {
+        const card = toCard(event.task);
+        if (!card) return;
+        set((state) => {
+          const cards = state.cardsByProject[card.projectSlug] ?? [];
+          if (cards.some((existing) => existing.id === card.id)) return state;
+          return {
+            cardsByProject: {
+              ...state.cardsByProject,
+              [card.projectSlug]: [...cards, card],
+            },
+          };
+        });
+        return;
+      }
+      const status = CardStatusSchema.safeParse(event.status);
+      if (!status.success) return;
+      set((state) => {
+        const cardsByProject = { ...state.cardsByProject };
+        let changed = false;
+        for (const [slug, cards] of Object.entries(cardsByProject)) {
+          if (!cards.some((card) => card.id === event.taskId)) continue;
+          cardsByProject[slug] = cards.map((card) =>
+            card.id === event.taskId ? { ...card, status: status.data } : card,
+          );
+          changed = true;
+        }
+        return changed ? { cardsByProject } : state;
+      });
+    },
+  };
+});

--- a/desktop/src/renderer/src/stores/board.ts
+++ b/desktop/src/renderer/src/stores/board.ts
@@ -331,7 +331,27 @@ export const useBoard = create<BoardState>()((set, get) => {
     moveTask: (api, slug, taskId, status, order) =>
       mutateTask(api, slug, taskId, { status, order }),
 
-    archiveTask: (api, slug, taskId) => mutateTask(api, slug, taskId, { status: "archived" }),
+    archiveTask: (api, slug, taskId) => {
+      const cards = get().cardsByProject[slug];
+      if (!cards?.some((card) => card.id === taskId)) return Promise.resolve();
+      if (!canEnqueueTaskMutation(taskId)) {
+        set({ error: "server" });
+        return Promise.resolve();
+      }
+      return enqueueTaskMutation(taskId, async () => {
+        try {
+          const response = await api.patch<{ task: unknown }>(taskPath(slug, taskId), {
+            status: "archived",
+          });
+          const card = toCard(response.task);
+          if (card) patchCard(slug, taskId, () => card);
+          set({ error: null });
+        } catch (err: unknown) {
+          console.error("[board] Task archive failed:", err);
+          set({ error: categoryOf(err) });
+        }
+      });
+    },
 
     deleteTask: (api, slug, taskId) => {
       const cards = get().cardsByProject[slug];

--- a/desktop/src/renderer/src/stores/board.ts
+++ b/desktop/src/renderer/src/stores/board.ts
@@ -314,7 +314,9 @@ export const useBoard = create<BoardState>()((set, get) => {
         set((state) => ({
           cardsByProject: {
             ...state.cardsByProject,
-            [slug]: [...(state.cardsByProject[slug] ?? []), card],
+            [slug]: (state.cardsByProject[slug] ?? []).some((existing) => existing.id === card.id)
+              ? (state.cardsByProject[slug] ?? [])
+              : [...(state.cardsByProject[slug] ?? []), card],
           },
           error: null,
         }));

--- a/desktop/src/renderer/src/stores/threads.ts
+++ b/desktop/src/renderer/src/stores/threads.ts
@@ -237,8 +237,14 @@ export const useThreads = create<ThreadsState>()((set, get) => ({
         // is running (unambiguous). With multiple running threads, guessing by
         // array order would flag the wrong one, so drop the event instead.
         const running = state.threads.filter((t) => t.status === "running");
-        const thread =
-          byRequestId(rawRequestId) ?? (running.length === 1 ? running[0] : undefined);
+        let thread: AgentThread | undefined;
+        if (rawRequestId) {
+          const matched = byRequestId(rawRequestId);
+          if (!matched || isTerminal(matched.status)) return {};
+          thread = matched;
+        } else {
+          thread = running.length === 1 ? running[0] : undefined;
+        }
         if (!thread) return {};
         return apply(thread, { status: "needs-attention" }, "attention");
       }

--- a/desktop/src/renderer/src/stores/threads.ts
+++ b/desktop/src/renderer/src/stores/threads.ts
@@ -139,10 +139,9 @@ export const useThreads = create<ThreadsState>()((set, get) => ({
   },
 
   handleKernelMessage: (msg, opts) => {
+    const rawMessage = msg as unknown as { requestId?: unknown };
     const rawRequestId =
-      typeof (msg as { requestId?: unknown }).requestId === "string"
-        ? (msg as { requestId: string }).requestId
-        : undefined;
+      typeof rawMessage.requestId === "string" ? rawMessage.requestId : undefined;
     const parsed = KnownKernelMessageSchema.safeParse(msg);
     if (!parsed.success) return {};
     const event = parsed.data;

--- a/desktop/src/renderer/src/stores/threads.ts
+++ b/desktop/src/renderer/src/stores/threads.ts
@@ -208,12 +208,12 @@ export const useThreads = create<ThreadsState>()((set, get) => ({
       }
       case "kernel:result": {
         const thread = byRequestId(event.requestId);
-        if (!thread) return {};
+        if (!thread || isTerminal(thread.status)) return {};
         return apply(thread, { status: "done" }, "done");
       }
       case "kernel:error": {
         const thread = byRequestId(event.requestId);
-        if (!thread) return {};
+        if (!thread || isTerminal(thread.status)) return {};
         return apply(
           thread,
           {

--- a/desktop/src/renderer/src/stores/threads.ts
+++ b/desktop/src/renderer/src/stores/threads.ts
@@ -227,8 +227,12 @@ export const useThreads = create<ThreadsState>()((set, get) => ({
         });
       }
       case "approval:request": {
+        // Match by requestId; otherwise fall back only when exactly one thread
+        // is running (unambiguous). With multiple running threads, guessing by
+        // array order would flag the wrong one, so drop the event instead.
+        const running = state.threads.filter((t) => t.status === "running");
         const thread =
-          byRequestId(rawRequestId) ?? state.threads.find((t) => t.status === "running");
+          byRequestId(rawRequestId) ?? (running.length === 1 ? running[0] : undefined);
         if (!thread) return {};
         return apply(thread, { status: "needs-attention" }, "attention");
       }

--- a/desktop/src/renderer/src/stores/threads.ts
+++ b/desktop/src/renderer/src/stores/threads.ts
@@ -226,6 +226,7 @@ export const useThreads = create<ThreadsState>()((set, get) => ({
       case "kernel:aborted": {
         const thread = byRequestId(event.requestId);
         if (!thread) return {};
+        if (isTerminal(thread.status)) return {};
         return apply(thread, {
           status: "aborted",
           transcript: capTranscript(reduceChat(thread.transcript, event)),

--- a/desktop/src/renderer/src/stores/threads.ts
+++ b/desktop/src/renderer/src/stores/threads.ts
@@ -181,9 +181,10 @@ export const useThreads = create<ThreadsState>()((set, get) => ({
 
     switch (event.type) {
       case "kernel:init": {
-        const thread =
-          byRequestId(event.requestId) ??
-          state.threads.find((t) => t.status === "running" && t.sessionId === null);
+        // Match by requestId; otherwise bind only when exactly one running thread
+        // is still awaiting its first session (unambiguous), else drop.
+        const unbound = state.threads.filter((t) => t.status === "running" && t.sessionId === null);
+        const thread = byRequestId(event.requestId) ?? (unbound.length === 1 ? unbound[0] : undefined);
         if (!thread) return {};
         return apply(thread, { sessionId: event.sessionId });
       }

--- a/desktop/src/renderer/src/stores/threads.ts
+++ b/desktop/src/renderer/src/stores/threads.ts
@@ -194,7 +194,7 @@ export const useThreads = create<ThreadsState>()((set, get) => ({
         // would attach the session to the wrong thread.
         const running = state.threads.filter((t) => t.status === "running");
         const thread =
-          state.threads.find((t) => t.id === state.activeThreadId) ??
+          state.threads.find((t) => t.id === state.activeThreadId && t.status === "running") ??
           (running.length === 1 ? running[0] : undefined);
         if (!thread) return {};
         return apply(thread, { sessionId: event.sessionId });

--- a/desktop/src/renderer/src/stores/threads.ts
+++ b/desktop/src/renderer/src/stores/threads.ts
@@ -139,6 +139,10 @@ export const useThreads = create<ThreadsState>()((set, get) => ({
   },
 
   handleKernelMessage: (msg, opts) => {
+    const rawRequestId =
+      typeof (msg as { requestId?: unknown }).requestId === "string"
+        ? (msg as { requestId: string }).requestId
+        : undefined;
     const parsed = KnownKernelMessageSchema.safeParse(msg);
     if (!parsed.success) return {};
     const event = parsed.data;
@@ -224,7 +228,8 @@ export const useThreads = create<ThreadsState>()((set, get) => ({
         });
       }
       case "approval:request": {
-        const thread = state.threads.find((t) => t.status === "running");
+        const thread =
+          byRequestId(rawRequestId) ?? state.threads.find((t) => t.status === "running");
         if (!thread) return {};
         return apply(thread, { status: "needs-attention" }, "attention");
       }

--- a/desktop/src/renderer/src/stores/threads.ts
+++ b/desktop/src/renderer/src/stores/threads.ts
@@ -188,9 +188,13 @@ export const useThreads = create<ThreadsState>()((set, get) => ({
         return apply(thread, { sessionId: event.sessionId });
       }
       case "session:switched": {
+        // Prefer the active thread; otherwise bind only when exactly one thread
+        // is running (unambiguous). Binding by array order under concurrent runs
+        // would attach the session to the wrong thread.
+        const running = state.threads.filter((t) => t.status === "running");
         const thread =
           state.threads.find((t) => t.id === state.activeThreadId) ??
-          state.threads.find((t) => t.status === "running");
+          (running.length === 1 ? running[0] : undefined);
         if (!thread) return {};
         return apply(thread, { sessionId: event.sessionId });
       }

--- a/desktop/src/renderer/src/stores/threads.ts
+++ b/desktop/src/renderer/src/stores/threads.ts
@@ -1,0 +1,252 @@
+// Agent threads store (data-model.md AgentThread): Codex-style parallel runs
+// multiplexed over one kernel socket, routed by requestId through the ported
+// chat reducer. State stays serializable (arrays only).
+import { create } from "zustand";
+import { reduceChat, type ChatMessage } from "../lib/chat";
+import {
+  KnownKernelMessageSchema,
+  type KernelServerMessage,
+} from "../lib/kernel-socket";
+
+export type ThreadStatus = "running" | "needs-attention" | "done" | "failed" | "aborted";
+
+export interface AgentThread {
+  id: string;
+  requestId: string;
+  sessionId: string | null;
+  taskId: string | null;
+  title: string;
+  status: ThreadStatus;
+  transcript: ChatMessage[];
+  unread: boolean;
+  createdAt: number;
+  updatedAt: number;
+}
+
+export interface ThreadNotification {
+  threadId: string;
+  kind: "done" | "failed" | "attention";
+  title: string;
+  body: string;
+}
+
+export interface StartThreadInput {
+  text: string;
+  title?: string;
+  taskId?: string | null;
+  sessionId?: string | null;
+  requestId: string;
+  now?: number;
+}
+
+export interface HandleKernelMessageOptions {
+  focusedThreadId?: string | null;
+  now?: number;
+}
+
+interface ThreadsState {
+  threads: AgentThread[];
+  activeThreadId: string | null;
+  startThread(input: StartThreadInput): AgentThread;
+  handleKernelMessage(
+    msg: KernelServerMessage,
+    opts?: HandleKernelMessageOptions,
+  ): { notification?: ThreadNotification };
+  abortThread(id: string): { requestId: string } | null;
+  setActiveThread(id: string | null): void;
+  unreadCount(): number;
+}
+
+const MAX_THREADS = 100;
+const MAX_TRANSCRIPT_MESSAGES = 500;
+const MAX_TITLE_LENGTH = 80;
+
+const NOTIFICATION_BODY: Record<ThreadNotification["kind"], string> = {
+  done: "Run completed",
+  failed: "Run failed",
+  attention: "Approval needed",
+};
+
+let threadSeq = 0;
+function newThreadId(now: number): string {
+  threadSeq = (threadSeq + 1) & 0xffff;
+  return `thread-${now}-${threadSeq}`;
+}
+
+function isTerminal(status: ThreadStatus): boolean {
+  return status === "done" || status === "failed" || status === "aborted";
+}
+
+function capThreads(threads: AgentThread[]): AgentThread[] {
+  if (threads.length <= MAX_THREADS) return threads;
+  let excess = threads.length - MAX_THREADS;
+  const drop: Record<string, true> = {};
+  // Newest first: walk from the oldest end, dropping finished threads first.
+  for (let i = threads.length - 1; i >= 0 && excess > 0; i--) {
+    const thread = threads[i]!;
+    if (isTerminal(thread.status)) {
+      drop[thread.id] = true;
+      excess--;
+    }
+  }
+  let result = threads.filter((t) => !drop[t.id]);
+  // Hard bound: if everything is still live, drop the oldest regardless.
+  if (result.length > MAX_THREADS) result = result.slice(0, MAX_THREADS);
+  return result;
+}
+
+function capTranscript(transcript: ChatMessage[]): ChatMessage[] {
+  if (transcript.length <= MAX_TRANSCRIPT_MESSAGES) return transcript;
+  return transcript.slice(transcript.length - MAX_TRANSCRIPT_MESSAGES);
+}
+
+function patchThread(
+  threads: AgentThread[],
+  id: string,
+  patch: Partial<AgentThread>,
+): AgentThread[] {
+  return threads.map((t) => (t.id === id ? { ...t, ...patch } : t));
+}
+
+export const useThreads = create<ThreadsState>()((set, get) => ({
+  threads: [],
+  activeThreadId: null,
+
+  startThread: (input) => {
+    const now = input.now ?? Date.now();
+    const thread: AgentThread = {
+      id: newThreadId(now),
+      requestId: input.requestId,
+      sessionId: input.sessionId ?? null,
+      taskId: input.taskId ?? null,
+      title: (input.title ?? input.text).slice(0, MAX_TITLE_LENGTH),
+      status: "running",
+      transcript: [
+        {
+          id: `user-${now}-${threadSeq}`,
+          role: "user",
+          content: input.text,
+          requestId: input.requestId,
+          timestamp: now,
+        },
+      ],
+      unread: false,
+      createdAt: now,
+      updatedAt: now,
+    };
+    set({ threads: capThreads([thread, ...get().threads]) });
+    return thread;
+  },
+
+  handleKernelMessage: (msg, opts) => {
+    const parsed = KnownKernelMessageSchema.safeParse(msg);
+    if (!parsed.success) return {};
+    const event = parsed.data;
+    const now = opts?.now ?? Date.now();
+    const state = get();
+    const focusedId =
+      opts?.focusedThreadId !== undefined ? opts.focusedThreadId : state.activeThreadId;
+
+    const byRequestId = (requestId: string | undefined): AgentThread | undefined =>
+      requestId ? state.threads.find((t) => t.requestId === requestId) : undefined;
+
+    const apply = (
+      thread: AgentThread,
+      patch: Partial<AgentThread>,
+      transition?: ThreadNotification["kind"],
+    ): { notification?: ThreadNotification } => {
+      const unfocused = thread.id !== focusedId;
+      set({
+        threads: patchThread(state.threads, thread.id, {
+          ...patch,
+          unread: unfocused ? true : thread.unread,
+          updatedAt: now,
+        }),
+      });
+      if (transition && unfocused) {
+        return {
+          notification: {
+            threadId: thread.id,
+            kind: transition,
+            title: thread.title,
+            body: NOTIFICATION_BODY[transition],
+          },
+        };
+      }
+      return {};
+    };
+
+    switch (event.type) {
+      case "kernel:init": {
+        const thread =
+          byRequestId(event.requestId) ??
+          state.threads.find((t) => t.status === "running" && t.sessionId === null);
+        if (!thread) return {};
+        return apply(thread, { sessionId: event.sessionId });
+      }
+      case "session:switched": {
+        const thread =
+          state.threads.find((t) => t.id === state.activeThreadId) ??
+          state.threads.find((t) => t.status === "running");
+        if (!thread) return {};
+        return apply(thread, { sessionId: event.sessionId });
+      }
+      case "kernel:text":
+      case "kernel:tool_start":
+      case "kernel:tool_end": {
+        const thread = byRequestId(event.requestId);
+        if (!thread) return {};
+        return apply(thread, { transcript: capTranscript(reduceChat(thread.transcript, event)) });
+      }
+      case "kernel:result": {
+        const thread = byRequestId(event.requestId);
+        if (!thread) return {};
+        return apply(thread, { status: "done" }, "done");
+      }
+      case "kernel:error": {
+        const thread = byRequestId(event.requestId);
+        if (!thread) return {};
+        return apply(
+          thread,
+          {
+            status: "failed",
+            transcript: capTranscript(reduceChat(thread.transcript, event)),
+          },
+          "failed",
+        );
+      }
+      case "kernel:aborted": {
+        const thread = byRequestId(event.requestId);
+        if (!thread) return {};
+        return apply(thread, {
+          status: "aborted",
+          transcript: capTranscript(reduceChat(thread.transcript, event)),
+        });
+      }
+      case "approval:request": {
+        const thread = state.threads.find((t) => t.status === "running");
+        if (!thread) return {};
+        return apply(thread, { status: "needs-attention" }, "attention");
+      }
+      default:
+        return {};
+    }
+  },
+
+  abortThread: (id) => {
+    const thread = get().threads.find((t) => t.id === id);
+    if (!thread || isTerminal(thread.status)) return null;
+    // Status stays as-is until the kernel confirms with kernel:aborted.
+    return { requestId: thread.requestId };
+  },
+
+  setActiveThread: (id) => {
+    const { threads } = get();
+    set({
+      activeThreadId: id,
+      threads: id ? patchThread(threads, id, { unread: false }) : threads,
+    });
+  },
+
+  unreadCount: () => get().threads.reduce((count, t) => count + (t.unread ? 1 : 0), 0),
+}));

--- a/desktop/src/renderer/src/stores/ui.ts
+++ b/desktop/src/renderer/src/stores/ui.ts
@@ -1,0 +1,32 @@
+// Navigation + transient UI state. Serializable only.
+import { create } from "zustand";
+
+export type MainView =
+  | { kind: "board" }
+  | { kind: "task"; taskId: string }
+  | { kind: "thread"; threadId: string }
+  | { kind: "sessions" }
+  | { kind: "session"; sessionName: string }
+  | { kind: "settings" };
+
+interface UiState {
+  view: MainView;
+  createTaskOpen: boolean;
+  composerOpen: boolean;
+  paletteOpen: boolean;
+  navigate: (view: MainView) => void;
+  setCreateTaskOpen: (open: boolean) => void;
+  setComposerOpen: (open: boolean) => void;
+  setPaletteOpen: (open: boolean) => void;
+}
+
+export const useUi = create<UiState>()((set) => ({
+  view: { kind: "board" },
+  createTaskOpen: false,
+  composerOpen: false,
+  paletteOpen: false,
+  navigate: (view) => set({ view }),
+  setCreateTaskOpen: (open) => set({ createTaskOpen: open }),
+  setComposerOpen: (open) => set({ composerOpen: open }),
+  setPaletteOpen: (open) => set({ paletteOpen: open }),
+}));

--- a/tests/desktop/board-store.test.ts
+++ b/tests/desktop/board-store.test.ts
@@ -333,15 +333,21 @@ describe("deleteTask", () => {
     await useBoard.getState().selectProject(api, "proj");
   }
 
-  it("removes optimistically and confirms with the server", async () => {
+  it("keeps the card visible until the server confirms deletion", async () => {
     await seed();
-    const api = makeApi({ delete: vi.fn().mockResolvedValue({ ok: true }) });
-    await useBoard.getState().deleteTask(api, "proj", "task_a");
+    const d = deferred<unknown>();
+    const api = makeApi({ delete: vi.fn().mockReturnValue(d.promise) });
+    const pending = useBoard.getState().deleteTask(api, "proj", "task_a");
+
+    expect(useBoard.getState().cardsByProject["proj"]).toEqual([card()]);
+    d.resolve({ ok: true });
+    await pending;
+
     expect(api.delete).toHaveBeenCalledWith("/api/projects/proj/tasks/task_a");
     expect(useBoard.getState().cardsByProject["proj"]).toEqual([]);
   });
 
-  it("rolls back the removal when the server rejects", async () => {
+  it("keeps the card visible and records the error when the server rejects", async () => {
     await seed();
     const api = makeApi({ delete: vi.fn().mockRejectedValue(new AppError("server")) });
     await useBoard.getState().deleteTask(api, "proj", "task_a");

--- a/tests/desktop/board-store.test.ts
+++ b/tests/desktop/board-store.test.ts
@@ -1,0 +1,373 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { AppError } from "@desktop/shared/app-error";
+import type { ApiClient } from "@desktop/renderer/src/lib/api";
+import {
+  BOARD_COLUMNS,
+  groupCardsByColumn,
+  useBoard,
+  type Card,
+} from "@desktop/renderer/src/stores/board";
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (err: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+function makeApi(overrides: Partial<ApiClient> = {}): ApiClient {
+  return {
+    baseUrl: "https://x.test",
+    get: vi.fn().mockResolvedValue({ tasks: [], nextCursor: null }),
+    post: vi.fn().mockResolvedValue({}),
+    patch: vi.fn().mockResolvedValue({}),
+    delete: vi.fn().mockResolvedValue({ ok: true }),
+    putText: vi.fn().mockResolvedValue({}),
+    ...overrides,
+  } as ApiClient;
+}
+
+// Mirrors the gateway TaskRecord wire shape (packages/gateway/src/task-manager.ts).
+function wireTask(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    id: "task_a",
+    projectSlug: "proj",
+    title: "Task A",
+    status: "todo",
+    priority: "normal",
+    order: 0,
+    previewIds: [],
+    createdAt: "2026-06-13T00:00:00.000Z",
+    updatedAt: "2026-06-13T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+function card(overrides: Partial<Card> = {}): Card {
+  return {
+    id: "task_a",
+    projectSlug: "proj",
+    title: "Task A",
+    description: "",
+    status: "todo",
+    priority: "normal",
+    order: 0,
+    parentTaskId: null,
+    linkedSessionId: null,
+    linkedWorktreeId: null,
+    previewIds: [],
+    tags: [],
+    updatedAt: "2026-06-13T00:00:00.000Z",
+    revision: null,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  useBoard.setState(useBoard.getInitialState(), true);
+});
+
+describe("groupCardsByColumn", () => {
+  it("groups by status, excludes archived, sorts by order then id", () => {
+    const cards: Card[] = [
+      card({ id: "task_b", status: "todo", order: 2 }),
+      card({ id: "task_c", status: "todo", order: 1 }),
+      card({ id: "task_a", status: "todo", order: 1 }),
+      card({ id: "task_d", status: "running", order: 0 }),
+      card({ id: "task_e", status: "archived", order: 0 }),
+    ];
+    const grouped = groupCardsByColumn(cards);
+    expect(grouped.todo.map((c) => c.id)).toEqual(["task_a", "task_c", "task_b"]);
+    expect(grouped.running.map((c) => c.id)).toEqual(["task_d"]);
+    expect(grouped.archived).toEqual([]);
+    expect(grouped.waiting).toEqual([]);
+    expect(grouped.blocked).toEqual([]);
+    expect(grouped.complete).toEqual([]);
+  });
+
+  it("defines the five visible board columns in order", () => {
+    expect(BOARD_COLUMNS).toEqual(["todo", "running", "waiting", "blocked", "complete"]);
+  });
+});
+
+describe("loadProjects", () => {
+  it("loads the project list from /api/workspace/projects", async () => {
+    const api = makeApi({
+      get: vi.fn().mockResolvedValue({
+        projects: [
+          { id: "p1", slug: "proj", name: "Proj", localPath: "/x", addedAt: "", updatedAt: "", ownerScope: { type: "user", id: "u" } },
+        ],
+        nextCursor: null,
+      }),
+    });
+    await useBoard.getState().loadProjects(api);
+    expect(api.get).toHaveBeenCalledWith("/api/workspace/projects");
+    expect(useBoard.getState().projects).toEqual([{ slug: "proj", name: "Proj" }]);
+    expect(useBoard.getState().error).toBeNull();
+  });
+
+  it("maps failures to an error category, never raw messages", async () => {
+    const api = makeApi({
+      get: vi.fn().mockRejectedValue(new AppError("offline")),
+    });
+    await useBoard.getState().loadProjects(api);
+    expect(useBoard.getState().error).toBe("offline");
+    expect(useBoard.getState().projects).toEqual([]);
+  });
+});
+
+describe("selectProject (stale-while-revalidate)", () => {
+  it("shows skeleton only on first load of a project", async () => {
+    const d = deferred<unknown>();
+    const api = makeApi({ get: vi.fn().mockReturnValue(d.promise) });
+    const pending = useBoard.getState().selectProject(api, "proj");
+
+    expect(useBoard.getState().activeProjectSlug).toBe("proj");
+    expect(useBoard.getState().firstLoadPending).toBe(true);
+    expect(useBoard.getState().refreshing).toBe(true);
+
+    d.resolve({ tasks: [wireTask()], nextCursor: null });
+    await pending;
+
+    expect(useBoard.getState().firstLoadPending).toBe(false);
+    expect(useBoard.getState().refreshing).toBe(false);
+    expect(useBoard.getState().cardsByProject["proj"]).toEqual([card()]);
+  });
+
+  it("keeps cached cards visible while refreshing an already-loaded project", async () => {
+    const first = makeApi({
+      get: vi.fn().mockResolvedValue({ tasks: [wireTask()], nextCursor: null }),
+    });
+    await useBoard.getState().selectProject(first, "proj");
+
+    const d = deferred<unknown>();
+    const second = makeApi({ get: vi.fn().mockReturnValue(d.promise) });
+    const pending = useBoard.getState().selectProject(second, "proj");
+
+    expect(useBoard.getState().firstLoadPending).toBe(false);
+    expect(useBoard.getState().refreshing).toBe(true);
+    expect(useBoard.getState().cardsByProject["proj"]).toEqual([card()]);
+
+    d.resolve({ tasks: [wireTask({ title: "Renamed" })], nextCursor: null });
+    await pending;
+    expect(useBoard.getState().cardsByProject["proj"]).toEqual([card({ title: "Renamed" })]);
+  });
+
+  it("clears the skeleton and sets an error category when the first load fails", async () => {
+    const api = makeApi({ get: vi.fn().mockRejectedValue(new AppError("timeout")) });
+    await useBoard.getState().selectProject(api, "proj");
+    expect(useBoard.getState().firstLoadPending).toBe(false);
+    expect(useBoard.getState().refreshing).toBe(false);
+    expect(useBoard.getState().error).toBe("timeout");
+  });
+});
+
+describe("refreshTasks", () => {
+  it("follows nextCursor pagination", async () => {
+    const get = vi
+      .fn()
+      .mockResolvedValueOnce({ tasks: [wireTask({ id: "task_a" })], nextCursor: "task_a" })
+      .mockResolvedValueOnce({ tasks: [wireTask({ id: "task_b" })], nextCursor: null });
+    const api = makeApi({ get });
+    await useBoard.getState().refreshTasks(api, "proj");
+    expect(get).toHaveBeenCalledTimes(2);
+    expect(String(get.mock.calls[1]![0])).toContain("cursor=task_a");
+    expect(useBoard.getState().cardsByProject["proj"]!.map((c) => c.id)).toEqual([
+      "task_a",
+      "task_b",
+    ]);
+  });
+
+  it("keeps cached cards and sets an error category on failure", async () => {
+    const ok = makeApi({
+      get: vi.fn().mockResolvedValue({ tasks: [wireTask()], nextCursor: null }),
+    });
+    await useBoard.getState().selectProject(ok, "proj");
+
+    const bad = makeApi({ get: vi.fn().mockRejectedValue(new AppError("server")) });
+    await useBoard.getState().refreshTasks(bad, "proj");
+    expect(useBoard.getState().cardsByProject["proj"]).toEqual([card()]);
+    expect(useBoard.getState().error).toBe("server");
+  });
+});
+
+describe("createTask", () => {
+  it("posts the input and appends the returned card", async () => {
+    const api = makeApi({
+      post: vi.fn().mockResolvedValue({ task: wireTask({ id: "task_new", title: "New" }) }),
+    });
+    const result = await useBoard.getState().createTask(api, "proj", { title: "New" });
+    expect(api.post).toHaveBeenCalledWith("/api/projects/proj/tasks", { title: "New" });
+    expect(result).toEqual(card({ id: "task_new", title: "New" }));
+    expect(useBoard.getState().cardsByProject["proj"]).toEqual([
+      card({ id: "task_new", title: "New" }),
+    ]);
+  });
+
+  it("returns null and records the error category on failure", async () => {
+    const api = makeApi({ post: vi.fn().mockRejectedValue(new AppError("unauthorized")) });
+    const result = await useBoard.getState().createTask(api, "proj", { title: "New" });
+    expect(result).toBeNull();
+    expect(useBoard.getState().error).toBe("unauthorized");
+  });
+});
+
+describe("updateTask", () => {
+  async function seed(): Promise<void> {
+    const api = makeApi({
+      get: vi.fn().mockResolvedValue({ tasks: [wireTask()], nextCursor: null }),
+    });
+    await useBoard.getState().selectProject(api, "proj");
+  }
+
+  it("applies optimistically then reconciles with the server response", async () => {
+    await seed();
+    const d = deferred<unknown>();
+    const api = makeApi({ patch: vi.fn().mockReturnValue(d.promise) });
+    const pending = useBoard.getState().updateTask(api, "proj", "task_a", { title: "Edited" });
+
+    expect(useBoard.getState().cardsByProject["proj"]![0]!.title).toBe("Edited");
+
+    d.resolve({ task: wireTask({ title: "Edited", updatedAt: "2026-06-13T01:00:00.000Z" }) });
+    await pending;
+    expect(api.patch).toHaveBeenCalledWith("/api/projects/proj/tasks/task_a", {
+      title: "Edited",
+    });
+    expect(useBoard.getState().cardsByProject["proj"]![0]).toEqual(
+      card({ title: "Edited", updatedAt: "2026-06-13T01:00:00.000Z" }),
+    );
+  });
+
+  it("rolls back and refetches on failure instead of silently overwriting", async () => {
+    await seed();
+    const get = vi.fn().mockResolvedValue({ tasks: [wireTask()], nextCursor: null });
+    const api = makeApi({
+      patch: vi.fn().mockRejectedValue(new AppError("server")),
+      get,
+    });
+    await useBoard.getState().updateTask(api, "proj", "task_a", { title: "Edited" });
+
+    expect(useBoard.getState().cardsByProject["proj"]![0]!.title).toBe("Task A");
+    expect(useBoard.getState().error).toBe("server");
+    expect(get).toHaveBeenCalled();
+  });
+
+  it("serializes two rapid mutations to the same task", async () => {
+    await seed();
+    const d1 = deferred<unknown>();
+    const order: string[] = [];
+    const patch = vi
+      .fn()
+      .mockImplementationOnce(() => {
+        order.push("first-sent");
+        return d1.promise;
+      })
+      .mockImplementationOnce(() => {
+        order.push("second-sent");
+        return Promise.resolve({ task: wireTask({ title: "Second" }) });
+      });
+    const api = makeApi({ patch });
+
+    const p1 = useBoard.getState().updateTask(api, "proj", "task_a", { title: "First" });
+    const p2 = useBoard.getState().updateTask(api, "proj", "task_a", { title: "Second" });
+
+    await vi.waitFor(() => expect(patch).toHaveBeenCalledTimes(1));
+    order.push("first-resolved");
+    d1.resolve({ task: wireTask({ title: "First" }) });
+    await Promise.all([p1, p2]);
+
+    expect(patch).toHaveBeenCalledTimes(2);
+    expect(order).toEqual(["first-sent", "first-resolved", "second-sent"]);
+    expect(useBoard.getState().cardsByProject["proj"]![0]!.title).toBe("Second");
+  });
+});
+
+describe("moveTask and archiveTask", () => {
+  async function seed(): Promise<void> {
+    const api = makeApi({
+      get: vi.fn().mockResolvedValue({ tasks: [wireTask()], nextCursor: null }),
+    });
+    await useBoard.getState().selectProject(api, "proj");
+  }
+
+  it("moveTask patches status and order optimistically", async () => {
+    await seed();
+    const api = makeApi({
+      patch: vi
+        .fn()
+        .mockResolvedValue({ task: wireTask({ status: "running", order: 3 }) }),
+    });
+    await useBoard.getState().moveTask(api, "proj", "task_a", "running", 3);
+    expect(api.patch).toHaveBeenCalledWith("/api/projects/proj/tasks/task_a", {
+      status: "running",
+      order: 3,
+    });
+    expect(useBoard.getState().cardsByProject["proj"]![0]).toMatchObject({
+      status: "running",
+      order: 3,
+    });
+  });
+
+  it("archiveTask patches status archived and hides the card from columns", async () => {
+    await seed();
+    const api = makeApi({
+      patch: vi.fn().mockResolvedValue({ task: wireTask({ status: "archived" }) }),
+    });
+    await useBoard.getState().archiveTask(api, "proj", "task_a");
+    expect(api.patch).toHaveBeenCalledWith("/api/projects/proj/tasks/task_a", {
+      status: "archived",
+    });
+    const grouped = groupCardsByColumn(useBoard.getState().cardsByProject["proj"]!);
+    expect(grouped.todo).toEqual([]);
+  });
+});
+
+describe("deleteTask", () => {
+  async function seed(): Promise<void> {
+    const api = makeApi({
+      get: vi.fn().mockResolvedValue({ tasks: [wireTask()], nextCursor: null }),
+    });
+    await useBoard.getState().selectProject(api, "proj");
+  }
+
+  it("removes optimistically and confirms with the server", async () => {
+    await seed();
+    const api = makeApi({ delete: vi.fn().mockResolvedValue({ ok: true }) });
+    await useBoard.getState().deleteTask(api, "proj", "task_a");
+    expect(api.delete).toHaveBeenCalledWith("/api/projects/proj/tasks/task_a");
+    expect(useBoard.getState().cardsByProject["proj"]).toEqual([]);
+  });
+
+  it("rolls back the removal when the server rejects", async () => {
+    await seed();
+    const api = makeApi({ delete: vi.fn().mockRejectedValue(new AppError("server")) });
+    await useBoard.getState().deleteTask(api, "proj", "task_a");
+    expect(useBoard.getState().cardsByProject["proj"]).toEqual([card()]);
+    expect(useBoard.getState().error).toBe("server");
+  });
+});
+
+describe("applyTaskEvent", () => {
+  it("adds a card on task:created and dedupes by id", () => {
+    useBoard.getState().applyTaskEvent({ type: "task:created", task: wireTask() });
+    useBoard.getState().applyTaskEvent({ type: "task:created", task: wireTask() });
+    expect(useBoard.getState().cardsByProject["proj"]).toEqual([card()]);
+  });
+
+  it("updates status on task:updated", () => {
+    useBoard.getState().applyTaskEvent({ type: "task:created", task: wireTask() });
+    useBoard.getState().applyTaskEvent({ type: "task:updated", taskId: "task_a", status: "running" });
+    expect(useBoard.getState().cardsByProject["proj"]![0]!.status).toBe("running");
+  });
+
+  it("ignores unknown task ids, invalid statuses, and malformed payloads", () => {
+    useBoard.getState().applyTaskEvent({ type: "task:created", task: wireTask() });
+    useBoard.getState().applyTaskEvent({ type: "task:updated", taskId: "task_zzz", status: "running" });
+    useBoard.getState().applyTaskEvent({ type: "task:updated", taskId: "task_a", status: "exploded" });
+    useBoard.getState().applyTaskEvent({ type: "task:created", task: { nonsense: true } });
+    expect(useBoard.getState().cardsByProject["proj"]).toEqual([card()]);
+  });
+});

--- a/tests/desktop/board-store.test.ts
+++ b/tests/desktop/board-store.test.ts
@@ -311,17 +311,35 @@ describe("moveTask and archiveTask", () => {
     });
   });
 
-  it("archiveTask patches status archived and hides the card from columns", async () => {
+  it("archiveTask keeps the card visible until the server confirms archive", async () => {
     await seed();
+    const d = deferred<unknown>();
     const api = makeApi({
-      patch: vi.fn().mockResolvedValue({ task: wireTask({ status: "archived" }) }),
+      patch: vi.fn().mockReturnValue(d.promise),
     });
-    await useBoard.getState().archiveTask(api, "proj", "task_a");
+    const pending = useBoard.getState().archiveTask(api, "proj", "task_a");
+
+    expect(groupCardsByColumn(useBoard.getState().cardsByProject["proj"]!).todo).toEqual([
+      card(),
+    ]);
+
+    d.resolve({ task: wireTask({ status: "archived" }) });
+    await pending;
     expect(api.patch).toHaveBeenCalledWith("/api/projects/proj/tasks/task_a", {
       status: "archived",
     });
     const grouped = groupCardsByColumn(useBoard.getState().cardsByProject["proj"]!);
     expect(grouped.todo).toEqual([]);
+  });
+
+  it("archiveTask keeps the card visible and records the error when the server rejects", async () => {
+    await seed();
+    const api = makeApi({ patch: vi.fn().mockRejectedValue(new AppError("server")) });
+    await useBoard.getState().archiveTask(api, "proj", "task_a");
+    expect(groupCardsByColumn(useBoard.getState().cardsByProject["proj"]!).todo).toEqual([
+      card(),
+    ]);
+    expect(useBoard.getState().error).toBe("server");
   });
 });
 

--- a/tests/desktop/board-store.test.ts
+++ b/tests/desktop/board-store.test.ts
@@ -207,6 +207,26 @@ describe("createTask", () => {
     ]);
   });
 
+  it("dedupes when a task:created event arrives before the POST response", async () => {
+    const response = deferred<unknown>();
+    const api = makeApi({
+      post: vi.fn().mockReturnValue(response.promise),
+    });
+
+    const pending = useBoard.getState().createTask(api, "proj", { title: "New" });
+    useBoard.getState().applyTaskEvent({
+      type: "task:created",
+      task: wireTask({ id: "task_new", title: "New" }),
+    });
+    response.resolve({ task: wireTask({ id: "task_new", title: "New" }) });
+    const result = await pending;
+
+    expect(result).toEqual(card({ id: "task_new", title: "New" }));
+    expect(useBoard.getState().cardsByProject["proj"]).toEqual([
+      card({ id: "task_new", title: "New" }),
+    ]);
+  });
+
   it("returns null and records the error category on failure", async () => {
     const api = makeApi({ post: vi.fn().mockRejectedValue(new AppError("unauthorized")) });
     const result = await useBoard.getState().createTask(api, "proj", { title: "New" });

--- a/tests/desktop/chat-reducer.test.ts
+++ b/tests/desktop/chat-reducer.test.ts
@@ -172,6 +172,28 @@ describe("reduceChat: abort and error", () => {
       requestId: "r1",
     });
   });
+
+  it("kernel:error replaces unsafe internal details with generic copy", () => {
+    const out = reduceChat([], {
+      type: "kernel:error",
+      message: "Error: anthropic request failed at /home/matrix/packages/kernel/index.ts",
+      requestId: "r1",
+    });
+    expect(out[0]).toMatchObject({
+      role: "system",
+      content: "Something went wrong. Please try again.",
+      requestId: "r1",
+    });
+  });
+
+  it("kernel:error replaces overlong messages with generic copy", () => {
+    const out = reduceChat([], {
+      type: "kernel:error",
+      message: "A".repeat(240),
+      requestId: "r1",
+    });
+    expect(out[0]!.content).toBe("Something went wrong. Please try again.");
+  });
 });
 
 describe("reduceChat: purity", () => {

--- a/tests/desktop/chat-reducer.test.ts
+++ b/tests/desktop/chat-reducer.test.ts
@@ -1,0 +1,227 @@
+import { describe, expect, it } from "vitest";
+import {
+  groupMessages,
+  reduceChat,
+  type ChatEvent,
+  type ChatMessage,
+} from "@desktop/renderer/src/lib/chat";
+
+function userMsg(content: string, requestId?: string): ChatMessage {
+  return { id: `u-${content}`, role: "user", content, requestId, timestamp: 1 };
+}
+
+function reduceAll(messages: ChatMessage[], events: ChatEvent[]): ChatMessage[] {
+  return events.reduce((acc, evt) => reduceChat(acc, evt), messages);
+}
+
+describe("reduceChat: text delta accumulation", () => {
+  it("accumulates deltas onto the last assistant message without requestId", () => {
+    const out = reduceAll(
+      [userMsg("hi")],
+      [
+        { type: "kernel:text", text: "Hel" },
+        { type: "kernel:text", text: "lo" },
+      ],
+    );
+    expect(out).toHaveLength(2);
+    expect(out[1]).toMatchObject({ role: "assistant", content: "Hello" });
+  });
+
+  it("accumulates deltas onto the matching requestId assistant message", () => {
+    const out = reduceAll(
+      [userMsg("hi", "r1")],
+      [
+        { type: "kernel:text", text: "A", requestId: "r1" },
+        { type: "kernel:text", text: "B", requestId: "r1" },
+      ],
+    );
+    expect(out).toHaveLength(2);
+    expect(out[1]).toMatchObject({ role: "assistant", content: "AB", requestId: "r1" });
+  });
+
+  it("creates a new assistant bubble when last message is a user message", () => {
+    const out = reduceChat([userMsg("hi")], { type: "kernel:text", text: "yo" });
+    expect(out).toHaveLength(2);
+    expect(out[1]!.role).toBe("assistant");
+  });
+
+  it("isolates interleaved requestIds into separate bubbles", () => {
+    const out = reduceAll(
+      [],
+      [
+        { type: "kernel:text", text: "one-", requestId: "r1" },
+        { type: "kernel:text", text: "two-", requestId: "r2" },
+        { type: "kernel:text", text: "1", requestId: "r1" },
+        { type: "kernel:text", text: "2", requestId: "r2" },
+      ],
+    );
+    expect(out).toHaveLength(2);
+    expect(out[0]).toMatchObject({ content: "one-1", requestId: "r1" });
+    expect(out[1]).toMatchObject({ content: "two-2", requestId: "r2" });
+  });
+});
+
+describe("reduceChat: tool lifecycle", () => {
+  it("kernel:tool_start appends a Using system message", () => {
+    const out = reduceChat([], { type: "kernel:tool_start", tool: "Read", requestId: "r1" });
+    expect(out).toHaveLength(1);
+    expect(out[0]).toMatchObject({
+      role: "system",
+      content: "Using Read...",
+      tool: "Read",
+      requestId: "r1",
+    });
+  });
+
+  it("kernel:tool_end marks the matching tool message Used and records toolInput", () => {
+    const out = reduceAll(
+      [],
+      [
+        { type: "kernel:tool_start", tool: "Read", requestId: "r1" },
+        { type: "kernel:tool_end", input: { path: "/tmp/x" }, requestId: "r1" },
+      ],
+    );
+    expect(out[0]).toMatchObject({
+      content: "Used Read",
+      tool: "Read",
+      toolInput: { path: "/tmp/x" },
+    });
+  });
+
+  it("kernel:tool_end only ends the tool from the same request", () => {
+    const out = reduceAll(
+      [],
+      [
+        { type: "kernel:tool_start", tool: "Read", requestId: "r1" },
+        { type: "kernel:tool_start", tool: "Bash", requestId: "r2" },
+        { type: "kernel:tool_end", input: {}, requestId: "r1" },
+      ],
+    );
+    expect(out[0]!.content).toBe("Used Read");
+    expect(out[1]!.content).toBe("Using Bash...");
+  });
+
+  it("splits text after a tool call in the same request into a new bubble", () => {
+    const out = reduceAll(
+      [],
+      [
+        { type: "kernel:text", text: "before", requestId: "r1" },
+        { type: "kernel:tool_start", tool: "Read", requestId: "r1" },
+        { type: "kernel:tool_end", input: {}, requestId: "r1" },
+        { type: "kernel:text", text: "after", requestId: "r1" },
+      ],
+    );
+    expect(out).toHaveLength(3);
+    expect(out[0]!.content).toBe("before");
+    expect(out[1]!.content).toBe("Used Read");
+    expect(out[2]).toMatchObject({ role: "assistant", content: "after", requestId: "r1" });
+  });
+
+  it("does not split bubbles across different requestIds", () => {
+    const out = reduceAll(
+      [],
+      [
+        { type: "kernel:text", text: "one", requestId: "r1" },
+        { type: "kernel:tool_start", tool: "Read", requestId: "r2" },
+        { type: "kernel:text", text: "+more", requestId: "r1" },
+      ],
+    );
+    expect(out).toHaveLength(2);
+    expect(out[0]!.content).toBe("one+more");
+  });
+});
+
+describe("reduceChat: abort and error", () => {
+  it("kernel:aborted marks in-flight tool messages Stopped and appends Stopped.", () => {
+    const out = reduceAll(
+      [],
+      [
+        { type: "kernel:tool_start", tool: "Bash", requestId: "r1" },
+        { type: "kernel:aborted", requestId: "r1" },
+      ],
+    );
+    expect(out).toHaveLength(2);
+    expect(out[0]!.content).toBe("Stopped Bash");
+    expect(out[1]).toMatchObject({ role: "system", content: "Stopped." });
+  });
+
+  it("kernel:aborted leaves completed tools and other requests alone", () => {
+    const out = reduceAll(
+      [],
+      [
+        { type: "kernel:tool_start", tool: "Read", requestId: "r1" },
+        { type: "kernel:tool_end", input: {}, requestId: "r1" },
+        { type: "kernel:tool_start", tool: "Bash", requestId: "r2" },
+        { type: "kernel:aborted", requestId: "r1" },
+      ],
+    );
+    expect(out[0]!.content).toBe("Used Read");
+    expect(out[1]!.content).toBe("Using Bash...");
+  });
+
+  it("kernel:error appends a system error bubble", () => {
+    const out = reduceChat([], {
+      type: "kernel:error",
+      message: "Something went wrong. Please try again.",
+      requestId: "r1",
+    });
+    expect(out).toHaveLength(1);
+    expect(out[0]).toMatchObject({
+      role: "system",
+      content: "Something went wrong. Please try again.",
+      requestId: "r1",
+    });
+  });
+});
+
+describe("reduceChat: purity", () => {
+  it("never mutates the input array or its messages", () => {
+    const original: ChatMessage[] = [
+      { id: "a1", role: "assistant", content: "Hel", requestId: "r1", timestamp: 1 },
+    ];
+    Object.freeze(original);
+    Object.freeze(original[0]);
+    const out = reduceChat(original, { type: "kernel:text", text: "lo", requestId: "r1" });
+    expect(original[0]!.content).toBe("Hel");
+    expect(out[0]!.content).toBe("Hello");
+    expect(out).not.toBe(original);
+    expect(out[0]).not.toBe(original[0]);
+  });
+
+  it("returns a fresh array for unhandled event types", () => {
+    const original: ChatMessage[] = [userMsg("hi")];
+    const out = reduceChat(original, { type: "kernel:result", requestId: "r1" });
+    expect(out).toEqual(original);
+    expect(out).not.toBe(original);
+  });
+});
+
+describe("groupMessages", () => {
+  it("groups consecutive tool messages and flushes around plain messages", () => {
+    const messages: ChatMessage[] = [
+      { id: "1", role: "user", content: "hi", timestamp: 1 },
+      { id: "2", role: "system", content: "Used Read", tool: "Read", timestamp: 2 },
+      { id: "3", role: "system", content: "Used Bash", tool: "Bash", timestamp: 3 },
+      { id: "4", role: "assistant", content: "done", timestamp: 4 },
+    ];
+    const groups = groupMessages(messages);
+    expect(groups).toHaveLength(3);
+    expect(groups[0]).toMatchObject({ type: "message" });
+    expect(groups[1]).toMatchObject({ type: "tool_group" });
+    expect((groups[1] as { messages: ChatMessage[] }).messages).toHaveLength(2);
+    expect(groups[2]).toMatchObject({ type: "message" });
+  });
+
+  it("flushes a trailing tool group", () => {
+    const groups = groupMessages([
+      { id: "1", role: "assistant", content: "x", timestamp: 1 },
+      { id: "2", role: "system", content: "Using Read...", tool: "Read", timestamp: 2 },
+    ]);
+    expect(groups).toHaveLength(2);
+    expect(groups[1]!.type).toBe("tool_group");
+  });
+
+  it("returns empty for no messages", () => {
+    expect(groupMessages([])).toEqual([]);
+  });
+});

--- a/tests/desktop/create-task-dialog.test.tsx
+++ b/tests/desktop/create-task-dialog.test.tsx
@@ -1,0 +1,98 @@
+// @vitest-environment jsdom
+
+import React, { useState } from "react";
+import { act, cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import CreateTaskDialog from "../../desktop/src/renderer/src/features/board/CreateTaskDialog";
+import { useBoard, type Card } from "../../desktop/src/renderer/src/stores/board";
+import { useConnection } from "../../desktop/src/renderer/src/stores/connection";
+import { useUi } from "../../desktop/src/renderer/src/stores/ui";
+
+function makeCard(id: string): Card {
+  return {
+    id,
+    projectSlug: "project",
+    title: "Task",
+    description: "",
+    status: "todo",
+    priority: "normal",
+    order: 0,
+    parentTaskId: null,
+    linkedSessionId: null,
+    linkedWorktreeId: null,
+    previewIds: [],
+    tags: [],
+    updatedAt: null,
+    revision: null,
+  };
+}
+
+describe("CreateTaskDialog", () => {
+  beforeEach(() => {
+    useConnection.setState({
+      status: "signed-in",
+      handle: "operator",
+      platformHost: "https://platform.test",
+      runtimeSlot: "primary",
+      api: { post: vi.fn() } as never,
+    });
+    useBoard.setState({
+      activeProjectSlug: "project",
+      projects: [{ slug: "project", name: "Project" }],
+      cardsByProject: {},
+      firstLoadPending: false,
+      refreshing: false,
+      error: null,
+    });
+    useUi.setState({
+      view: { kind: "board" },
+      createTaskOpen: false,
+      composerOpen: false,
+      paletteOpen: false,
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it("does not navigate after Escape closes an in-flight create-and-open submit", async () => {
+    let resolveCreate!: (card: Card) => void;
+    const createTask = vi.fn(
+      () => new Promise<Card>((resolve) => {
+        resolveCreate = resolve;
+      }),
+    );
+    const navigate = vi.fn();
+    useBoard.setState({ createTask });
+    useUi.setState({ navigate });
+
+    function Harness() {
+      const [open, setOpen] = useState(true);
+      return <CreateTaskDialog open={open} onClose={() => setOpen(false)} />;
+    }
+
+    render(<Harness />);
+
+    fireEvent.change(screen.getByPlaceholderText("Task title"), {
+      target: { value: "Ship desktop" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Create + open" }));
+    await waitFor(() => {
+      expect(createTask).toHaveBeenCalledOnce();
+    });
+
+    fireEvent.keyDown(window, { key: "Escape" });
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog")).toBeNull();
+    });
+
+    await act(async () => {
+      resolveCreate(makeCard("task-1"));
+    });
+
+    expect(navigate).not.toHaveBeenCalled();
+  });
+});

--- a/tests/desktop/threads-store.test.ts
+++ b/tests/desktop/threads-store.test.ts
@@ -180,6 +180,32 @@ describe("status transitions", () => {
     });
   });
 
+  it("ignores kernel:error after a thread is already done", () => {
+    const t = useThreads.getState().startThread({ text: "x", requestId: "r1", now: 1 });
+    useThreads.getState().handleKernelMessage({ type: "kernel:text", text: "done", requestId: "r1" });
+    useThreads.getState().handleKernelMessage({ type: "kernel:result", data: {}, requestId: "r1" });
+
+    useThreads.getState().handleKernelMessage({ type: "kernel:error", message: "late failure", requestId: "r1" });
+
+    const got = getThread(t.id);
+    expect(got.status).toBe("done");
+    expect(got.transcript.map((m) => m.content)).not.toContain("late failure");
+  });
+
+  it("ignores kernel:result after a thread has already failed", () => {
+    const t = useThreads.getState().startThread({ text: "x", requestId: "r1", now: 1 });
+    useThreads.getState().handleKernelMessage({ type: "kernel:error", message: "Run failed", requestId: "r1" });
+
+    useThreads.getState().handleKernelMessage({ type: "kernel:result", data: {}, requestId: "r1" });
+
+    const got = getThread(t.id);
+    expect(got.status).toBe("failed");
+    expect(got.transcript[got.transcript.length - 1]).toMatchObject({
+      role: "system",
+      content: "Run failed",
+    });
+  });
+
   it("kernel:aborted marks the thread aborted and stops in-flight tools", () => {
     const t = useThreads.getState().startThread({ text: "x", requestId: "r1", now: 1 });
     useThreads.getState().setActiveThread(t.id);

--- a/tests/desktop/threads-store.test.ts
+++ b/tests/desktop/threads-store.test.ts
@@ -174,6 +174,22 @@ describe("status transitions", () => {
     expect(getThread(t1.id).status).toBe("needs-attention");
     expect(getThread(t2.id).status).toBe("done");
   });
+
+  it("approval:request routes to the matching requestId when multiple threads are running", () => {
+    const store = useThreads.getState();
+    const t1 = store.startThread({ text: "one", requestId: "r1", now: 1 });
+    const t2 = store.startThread({ text: "two", requestId: "r2", now: 2 });
+    useThreads.getState().handleKernelMessage({
+      type: "approval:request",
+      id: "ap-1",
+      toolName: "Bash",
+      args: {},
+      timeout: 30,
+      requestId: "r1",
+    });
+    expect(getThread(t1.id).status).toBe("needs-attention");
+    expect(getThread(t2.id).status).toBe("running");
+  });
 });
 
 describe("unread and notifications", () => {

--- a/tests/desktop/threads-store.test.ts
+++ b/tests/desktop/threads-store.test.ts
@@ -191,6 +191,18 @@ describe("status transitions", () => {
     expect(got.transcript[got.transcript.length - 1]!.content).toBe("Stopped.");
   });
 
+  it("ignores kernel:aborted after a thread is already done", () => {
+    const t = useThreads.getState().startThread({ text: "x", requestId: "r1", now: 1 });
+    useThreads.getState().handleKernelMessage({ type: "kernel:text", text: "done", requestId: "r1" });
+    useThreads.getState().handleKernelMessage({ type: "kernel:result", data: {}, requestId: "r1" });
+
+    useThreads.getState().handleKernelMessage({ type: "kernel:aborted", requestId: "r1" });
+
+    const got = getThread(t.id);
+    expect(got.status).toBe("done");
+    expect(got.transcript.map((m) => m.content)).not.toContain("Stopped.");
+  });
+
   it("approval:request marks the most recent running thread needs-attention", () => {
     const store = useThreads.getState();
     const t1 = store.startThread({ text: "one", requestId: "r1", now: 1 });

--- a/tests/desktop/threads-store.test.ts
+++ b/tests/desktop/threads-store.test.ts
@@ -126,6 +126,16 @@ describe("handleKernelMessage routing", () => {
     useThreads.getState().handleKernelMessage({ type: "session:switched", sessionId: "s-2" });
     expect(getThread(t1.id).sessionId).toBe("s-2");
   });
+
+  it("session:switched does not bind to a guessed thread when ambiguous", () => {
+    const store = useThreads.getState();
+    const t1 = store.startThread({ text: "one", requestId: "r1", now: 1 });
+    const t2 = store.startThread({ text: "two", requestId: "r2", now: 2 });
+    // Two running threads and no active thread -> ambiguous, bind neither.
+    useThreads.getState().handleKernelMessage({ type: "session:switched", sessionId: "s-2" });
+    expect(getThread(t1.id).sessionId).toBeNull();
+    expect(getThread(t2.id).sessionId).toBeNull();
+  });
 });
 
 describe("status transitions", () => {

--- a/tests/desktop/threads-store.test.ts
+++ b/tests/desktop/threads-store.test.ts
@@ -190,6 +190,22 @@ describe("status transitions", () => {
     expect(getThread(t1.id).status).toBe("needs-attention");
     expect(getThread(t2.id).status).toBe("running");
   });
+
+  it("approval:request without a matching requestId does not guess when multiple threads are running", () => {
+    const store = useThreads.getState();
+    const t1 = store.startThread({ text: "one", requestId: "r1", now: 1 });
+    const t2 = store.startThread({ text: "two", requestId: "r2", now: 2 });
+    useThreads.getState().handleKernelMessage({
+      type: "approval:request",
+      id: "ap-1",
+      toolName: "Bash",
+      args: {},
+      timeout: 30,
+    });
+    // Ambiguous (two running, no requestId) -> flag neither rather than guess.
+    expect(getThread(t1.id).status).toBe("running");
+    expect(getThread(t2.id).status).toBe("running");
+  });
 });
 
 describe("unread and notifications", () => {

--- a/tests/desktop/threads-store.test.ts
+++ b/tests/desktop/threads-store.test.ts
@@ -145,6 +145,19 @@ describe("handleKernelMessage routing", () => {
     expect(getThread(t1.id).sessionId).toBeNull();
     expect(getThread(t2.id).sessionId).toBeNull();
   });
+
+  it("session:switched does not bind to a terminal active thread", () => {
+    const store = useThreads.getState();
+    const terminal = store.startThread({ text: "done", requestId: "r1", now: 1 });
+    const running = store.startThread({ text: "running", requestId: "r2", now: 2 });
+    useThreads.getState().handleKernelMessage({ type: "kernel:result", data: {}, requestId: "r1" });
+    useThreads.getState().setActiveThread(terminal.id);
+
+    useThreads.getState().handleKernelMessage({ type: "session:switched", sessionId: "s-2" });
+
+    expect(getThread(terminal.id).sessionId).toBeNull();
+    expect(getThread(running.id).sessionId).toBe("s-2");
+  });
 });
 
 describe("status transitions", () => {

--- a/tests/desktop/threads-store.test.ts
+++ b/tests/desktop/threads-store.test.ts
@@ -1,0 +1,302 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { useThreads, type AgentThread } from "@desktop/renderer/src/stores/threads";
+
+function reset(): void {
+  useThreads.setState({ threads: [], activeThreadId: null });
+}
+
+function getThread(id: string): AgentThread {
+  const thread = useThreads.getState().threads.find((t) => t.id === id);
+  if (!thread) throw new Error(`thread ${id} not found`);
+  return thread;
+}
+
+beforeEach(reset);
+
+describe("startThread", () => {
+  it("creates a running thread with an optimistic user message", () => {
+    const t = useThreads.getState().startThread({ text: "Fix the bug", requestId: "r1", now: 1000 });
+    expect(t.status).toBe("running");
+    expect(t.requestId).toBe("r1");
+    expect(t.sessionId).toBeNull();
+    expect(t.taskId).toBeNull();
+    expect(t.unread).toBe(false);
+    expect(t.createdAt).toBe(1000);
+    expect(t.updatedAt).toBe(1000);
+    expect(t.title).toBe("Fix the bug");
+    expect(t.transcript).toHaveLength(1);
+    expect(t.transcript[0]).toMatchObject({
+      role: "user",
+      content: "Fix the bug",
+      requestId: "r1",
+      timestamp: 1000,
+    });
+  });
+
+  it("orders threads newest first and honors explicit title/taskId/sessionId", () => {
+    const a = useThreads.getState().startThread({ text: "first", requestId: "r1", now: 1 });
+    const b = useThreads.getState().startThread({
+      text: "second",
+      title: "Custom title",
+      taskId: "task-9",
+      sessionId: "s-1",
+      requestId: "r2",
+      now: 2,
+    });
+    const { threads } = useThreads.getState();
+    expect(threads.map((t) => t.id)).toEqual([b.id, a.id]);
+    expect(b.title).toBe("Custom title");
+    expect(b.taskId).toBe("task-9");
+    expect(b.sessionId).toBe("s-1");
+  });
+
+  it("caps threads at 100 dropping the oldest finished threads first", () => {
+    const store = useThreads.getState();
+    const first = store.startThread({ text: "oldest finished", requestId: "r0", now: 0 });
+    for (let i = 1; i < 100; i++) {
+      store.startThread({ text: `t${i}`, requestId: `r${i}`, now: i });
+    }
+    useThreads.getState().handleKernelMessage({ type: "kernel:result", data: {}, requestId: "r0" });
+    useThreads.getState().startThread({ text: "newest", requestId: "r100", now: 100 });
+    const { threads } = useThreads.getState();
+    expect(threads).toHaveLength(100);
+    expect(threads.some((t) => t.id === first.id)).toBe(false);
+    expect(threads[0]!.requestId).toBe("r100");
+    expect(threads.some((t) => t.requestId === "r1")).toBe(true);
+  });
+
+  it("enforces the cap of 100 even when every thread is running", () => {
+    const store = useThreads.getState();
+    for (let i = 0; i <= 100; i++) {
+      store.startThread({ text: `t${i}`, requestId: `r${i}`, now: i });
+    }
+    const { threads } = useThreads.getState();
+    expect(threads).toHaveLength(100);
+    expect(threads.some((t) => t.requestId === "r0")).toBe(false);
+  });
+});
+
+describe("handleKernelMessage routing", () => {
+  it("routes events to the matching thread by requestId without cross-talk", () => {
+    const store = useThreads.getState();
+    const t1 = store.startThread({ text: "one", requestId: "r1", now: 1 });
+    const t2 = store.startThread({ text: "two", requestId: "r2", now: 2 });
+    const handle = useThreads.getState().handleKernelMessage;
+    handle({ type: "kernel:text", text: "A", requestId: "r1" });
+    handle({ type: "kernel:text", text: "B", requestId: "r2" });
+    handle({ type: "kernel:text", text: "A2", requestId: "r1" });
+    const got1 = getThread(t1.id);
+    const got2 = getThread(t2.id);
+    expect(got1.transcript).toHaveLength(2);
+    expect(got1.transcript[1]).toMatchObject({ role: "assistant", content: "AA2" });
+    expect(got2.transcript).toHaveLength(2);
+    expect(got2.transcript[1]).toMatchObject({ role: "assistant", content: "B" });
+  });
+
+  it("ignores kernel events with no matching requestId", () => {
+    const t = useThreads.getState().startThread({ text: "x", requestId: "r1", now: 1 });
+    const result = useThreads
+      .getState()
+      .handleKernelMessage({ type: "kernel:text", text: "stray", requestId: "r-none" });
+    expect(result).toEqual({});
+    expect(getThread(t.id).transcript).toHaveLength(1);
+  });
+
+  it("ignores chat events without a requestId and unknown message types", () => {
+    const t = useThreads.getState().startThread({ text: "x", requestId: "r1", now: 1 });
+    expect(useThreads.getState().handleKernelMessage({ type: "kernel:text", text: "no-id" })).toEqual({});
+    expect(
+      useThreads.getState().handleKernelMessage({ type: "file:change", path: "/x", event: "add" }),
+    ).toEqual({});
+    expect(useThreads.getState().handleKernelMessage({ type: "pong" })).toEqual({});
+    expect(getThread(t.id).transcript).toHaveLength(1);
+  });
+
+  it("binds sessionId from kernel:init by requestId", () => {
+    const t = useThreads.getState().startThread({ text: "x", requestId: "r1", now: 1 });
+    useThreads.getState().handleKernelMessage({ type: "kernel:init", sessionId: "s-9", requestId: "r1" });
+    expect(getThread(t.id).sessionId).toBe("s-9");
+  });
+
+  it("binds sessionId from session:switched to the active thread", () => {
+    const store = useThreads.getState();
+    const t1 = store.startThread({ text: "one", requestId: "r1", now: 1 });
+    store.startThread({ text: "two", requestId: "r2", now: 2 });
+    useThreads.getState().setActiveThread(t1.id);
+    useThreads.getState().handleKernelMessage({ type: "session:switched", sessionId: "s-2" });
+    expect(getThread(t1.id).sessionId).toBe("s-2");
+  });
+});
+
+describe("status transitions", () => {
+  it("kernel:result marks the thread done", () => {
+    const t = useThreads.getState().startThread({ text: "x", requestId: "r1", now: 1 });
+    useThreads.getState().setActiveThread(t.id);
+    useThreads.getState().handleKernelMessage({ type: "kernel:result", data: {}, requestId: "r1" });
+    expect(getThread(t.id).status).toBe("done");
+  });
+
+  it("kernel:error marks the thread failed and appends an error bubble", () => {
+    const t = useThreads.getState().startThread({ text: "x", requestId: "r1", now: 1 });
+    useThreads.getState().setActiveThread(t.id);
+    useThreads.getState().handleKernelMessage({ type: "kernel:error", message: "Run failed", requestId: "r1" });
+    const got = getThread(t.id);
+    expect(got.status).toBe("failed");
+    expect(got.transcript[got.transcript.length - 1]).toMatchObject({
+      role: "system",
+      content: "Run failed",
+    });
+  });
+
+  it("kernel:aborted marks the thread aborted and stops in-flight tools", () => {
+    const t = useThreads.getState().startThread({ text: "x", requestId: "r1", now: 1 });
+    useThreads.getState().setActiveThread(t.id);
+    useThreads.getState().handleKernelMessage({ type: "kernel:tool_start", tool: "Bash", requestId: "r1" });
+    useThreads.getState().handleKernelMessage({ type: "kernel:aborted", requestId: "r1" });
+    const got = getThread(t.id);
+    expect(got.status).toBe("aborted");
+    expect(got.transcript.some((m) => m.content === "Stopped Bash")).toBe(true);
+    expect(got.transcript[got.transcript.length - 1]!.content).toBe("Stopped.");
+  });
+
+  it("approval:request marks the most recent running thread needs-attention", () => {
+    const store = useThreads.getState();
+    const t1 = store.startThread({ text: "one", requestId: "r1", now: 1 });
+    const t2 = store.startThread({ text: "two", requestId: "r2", now: 2 });
+    useThreads.getState().handleKernelMessage({ type: "kernel:result", data: {}, requestId: "r2" });
+    useThreads.getState().handleKernelMessage({
+      type: "approval:request",
+      id: "ap-1",
+      toolName: "Bash",
+      args: {},
+      timeout: 30,
+    });
+    expect(getThread(t1.id).status).toBe("needs-attention");
+    expect(getThread(t2.id).status).toBe("done");
+  });
+});
+
+describe("unread and notifications", () => {
+  it("returns a done notification and marks unread for an unfocused thread", () => {
+    const store = useThreads.getState();
+    const t1 = store.startThread({ text: "background", requestId: "r1", now: 1 });
+    const t2 = store.startThread({ text: "focused", requestId: "r2", now: 2 });
+    useThreads.getState().setActiveThread(t2.id);
+    const result = useThreads
+      .getState()
+      .handleKernelMessage({ type: "kernel:result", data: {}, requestId: "r1" });
+    expect(result.notification).toMatchObject({ threadId: t1.id, kind: "done", title: t1.title });
+    expect(typeof result.notification!.body).toBe("string");
+    expect(getThread(t1.id).unread).toBe(true);
+  });
+
+  it("returns no notification for a focused thread", () => {
+    const t = useThreads.getState().startThread({ text: "x", requestId: "r1", now: 1 });
+    useThreads.getState().setActiveThread(t.id);
+    const result = useThreads
+      .getState()
+      .handleKernelMessage({ type: "kernel:result", data: {}, requestId: "r1" });
+    expect(result.notification).toBeUndefined();
+    expect(getThread(t.id).unread).toBe(false);
+  });
+
+  it("honors the focusedThreadId option over activeThreadId", () => {
+    const store = useThreads.getState();
+    const t1 = store.startThread({ text: "one", requestId: "r1", now: 1 });
+    useThreads.getState().setActiveThread(t1.id);
+    const result = useThreads
+      .getState()
+      .handleKernelMessage(
+        { type: "kernel:result", data: {}, requestId: "r1" },
+        { focusedThreadId: "someone-else" },
+      );
+    expect(result.notification).toMatchObject({ threadId: t1.id, kind: "done" });
+    expect(getThread(t1.id).unread).toBe(true);
+  });
+
+  it("marks unread on text deltas to unfocused threads without a notification", () => {
+    const store = useThreads.getState();
+    const t1 = store.startThread({ text: "one", requestId: "r1", now: 1 });
+    const t2 = store.startThread({ text: "two", requestId: "r2", now: 2 });
+    useThreads.getState().setActiveThread(t2.id);
+    const result = useThreads
+      .getState()
+      .handleKernelMessage({ type: "kernel:text", text: "hi", requestId: "r1" });
+    expect(result.notification).toBeUndefined();
+    expect(getThread(t1.id).unread).toBe(true);
+  });
+
+  it("returns failed and attention notifications for unfocused transitions", () => {
+    const store = useThreads.getState();
+    const t1 = store.startThread({ text: "one", requestId: "r1", now: 1 });
+    const t2 = store.startThread({ text: "two", requestId: "r2", now: 2 });
+    useThreads.getState().setActiveThread(null);
+    const failed = useThreads
+      .getState()
+      .handleKernelMessage({ type: "kernel:error", message: "boom", requestId: "r2" });
+    expect(failed.notification).toMatchObject({ threadId: t2.id, kind: "failed" });
+    const attention = useThreads.getState().handleKernelMessage({
+      type: "approval:request",
+      id: "ap-1",
+      toolName: "Bash",
+      args: {},
+      timeout: 30,
+    });
+    expect(attention.notification).toMatchObject({ threadId: t1.id, kind: "attention" });
+  });
+
+  it("returns no notification for aborts", () => {
+    useThreads.getState().startThread({ text: "x", requestId: "r1", now: 1 });
+    useThreads.getState().setActiveThread(null);
+    const result = useThreads.getState().handleKernelMessage({ type: "kernel:aborted", requestId: "r1" });
+    expect(result.notification).toBeUndefined();
+  });
+
+  it("setActiveThread clears unread and unreadCount tallies", () => {
+    const store = useThreads.getState();
+    const t1 = store.startThread({ text: "one", requestId: "r1", now: 1 });
+    const t2 = store.startThread({ text: "two", requestId: "r2", now: 2 });
+    useThreads.getState().setActiveThread(t2.id);
+    useThreads.getState().handleKernelMessage({ type: "kernel:text", text: "hi", requestId: "r1" });
+    expect(useThreads.getState().unreadCount()).toBe(1);
+    useThreads.getState().setActiveThread(t1.id);
+    expect(getThread(t1.id).unread).toBe(false);
+    expect(useThreads.getState().unreadCount()).toBe(0);
+  });
+});
+
+describe("abortThread", () => {
+  it("returns the requestId without changing status until kernel:aborted arrives", () => {
+    const t = useThreads.getState().startThread({ text: "x", requestId: "r1", now: 1 });
+    const result = useThreads.getState().abortThread(t.id);
+    expect(result).toEqual({ requestId: "r1" });
+    expect(getThread(t.id).status).toBe("running");
+    useThreads.getState().handleKernelMessage({ type: "kernel:aborted", requestId: "r1" });
+    expect(getThread(t.id).status).toBe("aborted");
+  });
+
+  it("returns null for unknown ids and finished threads", () => {
+    const t = useThreads.getState().startThread({ text: "x", requestId: "r1", now: 1 });
+    useThreads.getState().handleKernelMessage({ type: "kernel:result", data: {}, requestId: "r1" });
+    expect(useThreads.getState().abortThread(t.id)).toBeNull();
+    expect(useThreads.getState().abortThread("missing")).toBeNull();
+  });
+});
+
+describe("transcript cap", () => {
+  it("caps the transcript at 500 messages keeping the newest", () => {
+    const t = useThreads.getState().startThread({ text: "start", requestId: "r1", now: 1 });
+    for (let i = 0; i < 600; i++) {
+      useThreads.getState().handleKernelMessage({
+        type: "kernel:tool_start",
+        tool: `Tool${i}`,
+        requestId: "r1",
+      });
+    }
+    const got = getThread(t.id);
+    expect(got.transcript).toHaveLength(500);
+    expect(got.transcript[0]!.content).not.toBe("start");
+    expect(got.transcript[got.transcript.length - 1]!.content).toBe("Using Tool599...");
+    expect(got.transcript[0]!.content).toBe("Using Tool100...");
+  });
+});

--- a/tests/desktop/threads-store.test.ts
+++ b/tests/desktop/threads-store.test.ts
@@ -118,6 +118,15 @@ describe("handleKernelMessage routing", () => {
     expect(getThread(t.id).sessionId).toBe("s-9");
   });
 
+  it("kernel:init does not bind to an unbound running thread when ambiguous", () => {
+    const store = useThreads.getState();
+    const t1 = store.startThread({ text: "one", requestId: "r1", now: 1 });
+    const t2 = store.startThread({ text: "two", requestId: "r2", now: 2 });
+    useThreads.getState().handleKernelMessage({ type: "kernel:init", sessionId: "s-9" });
+    expect(getThread(t1.id).sessionId).toBeNull();
+    expect(getThread(t2.id).sessionId).toBeNull();
+  });
+
   it("binds sessionId from session:switched to the active thread", () => {
     const store = useThreads.getState();
     const t1 = store.startThread({ text: "one", requestId: "r1", now: 1 });

--- a/tests/desktop/threads-store.test.ts
+++ b/tests/desktop/threads-store.test.ts
@@ -261,6 +261,25 @@ describe("status transitions", () => {
     expect(getThread(t2.id).status).toBe("running");
   });
 
+  it("approval:request ignores a matching terminal thread by requestId", () => {
+    const store = useThreads.getState();
+    const terminal = store.startThread({ text: "done", requestId: "r1", now: 1 });
+    const running = store.startThread({ text: "running", requestId: "r2", now: 2 });
+    useThreads.getState().handleKernelMessage({ type: "kernel:result", data: {}, requestId: "r1" });
+
+    useThreads.getState().handleKernelMessage({
+      type: "approval:request",
+      id: "ap-1",
+      toolName: "Bash",
+      args: {},
+      timeout: 30,
+      requestId: "r1",
+    });
+
+    expect(getThread(terminal.id).status).toBe("done");
+    expect(getThread(running.id).status).toBe("running");
+  });
+
   it("approval:request without a matching requestId does not guess when multiple threads are running", () => {
     const store = useThreads.getState();
     const t1 = store.startThread({ text: "one", requestId: "r1", now: 1 });


### PR DESCRIPTION
## Summary
- Adds board state/UI and agent-thread foundations with focused reducer/store coverage.
- Part of the 094 Operator desktop stack split from original PR #507.
- Draft until the full stack validation and screenshots are refreshed.

## Validation
- Rebased onto current main after #506 merged.
- Rebuilt stack final tree matches the original #507 tree exactly.
- Per-layer CI/Greptile still needs to settle before review-ready.

## Invariants
- Source of truth: desktop app source under desktop/, specs/docs, and root workspace metadata in this stack; no owner runtime data is modified.
- Lock/transaction scope: no Postgres transaction scope is introduced in this layer; desktop local state remains scoped to the Electron app and existing gateway/platform APIs.
- Acceptable orphan states: stack PRs are draft and must land in order; partial stack landing is not a supported release state.
- Auth source of truth: Clerk/device auth and existing gateway token handling remain authoritative; this stack does not add a second auth authority.
- Deferred scope: packaged distribution, production desktop rollout, and customer VPS host-bundle deploy are outside this stack.