### PR TITLE
feat(desktop): add terminal session runtime

### DIFF
--- a/desktop/src/renderer/src/features/sessions/SessionsView.tsx
+++ b/desktop/src/renderer/src/features/sessions/SessionsView.tsx
@@ -1,13 +1,16 @@
-import { RefreshCw, SquareTerminal } from "lucide-react";
+import { AlertTriangle, RefreshCw, SquareTerminal } from "lucide-react";
 import { useEffect } from "react";
 import { Button, EmptyState, IconButton, StatusDot } from "../../design/primitives";
 import { useConnection } from "../../stores/connection";
 import { useSessions } from "../../stores/sessions";
 import { useUi } from "../../stores/ui";
+import { categoryMessage } from "../../../../shared/app-error";
 
 export default function SessionsView() {
   const api = useConnection((s) => s.api);
   const sessions = useSessions((s) => s.sessions);
+  const loading = useSessions((s) => s.loading);
+  const error = useSessions((s) => s.error);
   const load = useSessions((s) => s.load);
   const navigate = useUi((s) => s.navigate);
 
@@ -15,12 +18,36 @@ export default function SessionsView() {
     if (api) void load(api);
   }, [api, load]);
 
+  if (sessions.length === 0 && error) {
+    return (
+      <EmptyState
+        icon={<AlertTriangle size={28} />}
+        headline="Could not load sessions"
+        description={categoryMessage(error)}
+        action={
+          <Button
+            variant="primary"
+            onClick={() => {
+              if (api) void load(api);
+            }}
+          >
+            Refresh
+          </Button>
+        }
+      />
+    );
+  }
+
   if (sessions.length === 0) {
     return (
       <EmptyState
         icon={<SquareTerminal size={28} />}
-        headline="No sessions"
-        description="Terminal sessions running on your computer appear here."
+        headline={loading ? "Loading sessions" : "No sessions"}
+        description={
+          loading
+            ? "Checking terminal sessions on your computer."
+            : "Terminal sessions running on your computer appear here."
+        }
         action={
           <Button
             variant="primary"

--- a/desktop/src/renderer/src/features/sessions/SessionsView.tsx
+++ b/desktop/src/renderer/src/features/sessions/SessionsView.tsx
@@ -1,0 +1,76 @@
+import { RefreshCw, SquareTerminal } from "lucide-react";
+import { useEffect } from "react";
+import { Button, EmptyState, IconButton, StatusDot } from "../../design/primitives";
+import { useConnection } from "../../stores/connection";
+import { useSessions } from "../../stores/sessions";
+import { useUi } from "../../stores/ui";
+
+export default function SessionsView() {
+  const api = useConnection((s) => s.api);
+  const sessions = useSessions((s) => s.sessions);
+  const load = useSessions((s) => s.load);
+  const navigate = useUi((s) => s.navigate);
+
+  useEffect(() => {
+    if (api) void load(api);
+  }, [api, load]);
+
+  if (sessions.length === 0) {
+    return (
+      <EmptyState
+        icon={<SquareTerminal size={28} />}
+        headline="No sessions"
+        description="Terminal sessions running on your computer appear here."
+        action={
+          <Button
+            variant="primary"
+            onClick={() => {
+              if (api) void load(api);
+            }}
+          >
+            Refresh
+          </Button>
+        }
+      />
+    );
+  }
+
+  return (
+    <div className="flex flex-1 flex-col gap-1 overflow-y-auto p-4">
+      <div className="mb-1 flex items-center justify-between">
+        <h2 className="text-md font-semibold" style={{ color: "var(--text-primary)" }}>
+          Sessions
+        </h2>
+        <IconButton
+          label="Refresh"
+          onClick={() => {
+            if (api) void load(api);
+          }}
+        >
+          <RefreshCw size={14} />
+        </IconButton>
+      </div>
+      {sessions.map((session) => (
+        <button
+          key={session.attachName}
+          type="button"
+          className="flex items-center gap-3 rounded-lg border px-3 py-2.5 text-left transition-colors duration-100"
+          style={{ background: "var(--bg-raised)", borderColor: "var(--border-subtle)" }}
+          onMouseEnter={(e) => (e.currentTarget.style.borderColor = "var(--border-strong)")}
+          onMouseLeave={(e) => (e.currentTarget.style.borderColor = "var(--border-subtle)")}
+          onClick={() => navigate({ kind: "session", sessionName: session.attachName })}
+        >
+          <StatusDot
+            color={session.status === "active" ? "var(--status-complete)" : "var(--status-todo)"}
+          />
+          <span className="flex-1 truncate font-mono text-sm" style={{ color: "var(--text-primary)" }}>
+            {session.name}
+          </span>
+          <span className="text-xs" style={{ color: "var(--text-tertiary)" }}>
+            {session.status}
+          </span>
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/desktop/src/renderer/src/features/sessions/SessionsView.tsx
+++ b/desktop/src/renderer/src/features/sessions/SessionsView.tsx
@@ -77,6 +77,20 @@ export default function SessionsView() {
           <RefreshCw size={14} />
         </IconButton>
       </div>
+      {error ? (
+        <div
+          role="alert"
+          className="mb-2 flex items-center gap-2 rounded-lg border px-3 py-2 text-sm"
+          style={{
+            borderColor: "var(--danger-muted)",
+            color: "var(--danger)",
+            background: "var(--danger-muted)",
+          }}
+        >
+          <AlertTriangle size={14} />
+          <span>{categoryMessage(error)}</span>
+        </div>
+      ) : null}
       {sessions.map((session) => (
         <button
           key={session.attachName}

--- a/desktop/src/renderer/src/features/sessions/StandaloneSession.tsx
+++ b/desktop/src/renderer/src/features/sessions/StandaloneSession.tsx
@@ -1,0 +1,24 @@
+import { ArrowLeft } from "lucide-react";
+import { IconButton } from "../../design/primitives";
+import { useUi } from "../../stores/ui";
+import TerminalView from "../terminal/TerminalView";
+
+export default function StandaloneSession({ sessionName }: { sessionName: string }) {
+  const navigate = useUi((s) => s.navigate);
+  return (
+    <div className="flex min-h-0 flex-1 flex-col">
+      <div
+        className="flex shrink-0 items-center gap-2 border-b px-3 py-2"
+        style={{ borderColor: "var(--border-subtle)", background: "var(--bg-surface)" }}
+      >
+        <IconButton label="Back to sessions" onClick={() => navigate({ kind: "sessions" })}>
+          <ArrowLeft size={15} />
+        </IconButton>
+        <span className="truncate font-mono text-sm" style={{ color: "var(--text-primary)" }}>
+          {sessionName}
+        </span>
+      </div>
+      <TerminalView sessionName={sessionName} />
+    </div>
+  );
+}

--- a/desktop/src/renderer/src/features/terminal/TerminalView.tsx
+++ b/desktop/src/renderer/src/features/terminal/TerminalView.tsx
@@ -19,13 +19,17 @@ interface TerminalViewProps {
 
 export default function TerminalView({ sessionName, onRecreate }: TerminalViewProps) {
   const hostRef = useRef<HTMLDivElement>(null);
+  const [stateSessionName, setStateSessionName] = useState(sessionName);
   const [socketState, setSocketState] = useState<ShellSocketState>("connecting");
   const [exitCode, setExitCode] = useState<number | null>(null);
 
-  useEffect(() => {
+  if (stateSessionName !== sessionName) {
+    setStateSessionName(sessionName);
     setSocketState("connecting");
     setExitCode(null);
+  }
 
+  useEffect(() => {
     const host = hostRef.current;
     if (!host) return;
 

--- a/desktop/src/renderer/src/features/terminal/TerminalView.tsx
+++ b/desktop/src/renderer/src/features/terminal/TerminalView.tsx
@@ -10,7 +10,7 @@ import { buildTerminalFontStack } from "../../lib/terminal/terminal-fonts";
 import type { ShellSocketState } from "../../lib/shell-socket";
 import { getAttachManager } from "./terminal-runtime";
 
-const GAP_MARKER = "\r\n[2m── output gap ──[0m\r\n";
+const GAP_MARKER = "\r\n\x1b[2m── output gap ──\x1b[0m\r\n";
 
 interface TerminalViewProps {
   sessionName: string;

--- a/desktop/src/renderer/src/features/terminal/TerminalView.tsx
+++ b/desktop/src/renderer/src/features/terminal/TerminalView.tsx
@@ -75,8 +75,13 @@ export default function TerminalView({ sessionName, onRecreate }: TerminalViewPr
       attachment.resize(terminal.cols, terminal.rows);
     };
     sendDims();
+    let rafId: number | null = null;
     const observer = new ResizeObserver(() => {
-      window.requestAnimationFrame(sendDims);
+      if (rafId !== null) cancelAnimationFrame(rafId);
+      rafId = window.requestAnimationFrame(() => {
+        rafId = null;
+        sendDims();
+      });
     });
     observer.observe(host);
 
@@ -84,6 +89,10 @@ export default function TerminalView({ sessionName, onRecreate }: TerminalViewPr
 
     return () => {
       observer.disconnect();
+      if (rafId !== null) {
+        cancelAnimationFrame(rafId);
+        rafId = null;
+      }
       dataDisposable.dispose();
       try {
         manager.cacheBuffer(sessionName, serialize.serialize());

--- a/desktop/src/renderer/src/features/terminal/TerminalView.tsx
+++ b/desktop/src/renderer/src/features/terminal/TerminalView.tsx
@@ -23,6 +23,9 @@ export default function TerminalView({ sessionName, onRecreate }: TerminalViewPr
   const [exitCode, setExitCode] = useState<number | null>(null);
 
   useEffect(() => {
+    setSocketState("connecting");
+    setExitCode(null);
+
     const host = hostRef.current;
     if (!host) return;
 

--- a/desktop/src/renderer/src/features/terminal/TerminalView.tsx
+++ b/desktop/src/renderer/src/features/terminal/TerminalView.tsx
@@ -1,0 +1,152 @@
+import { Terminal } from "@xterm/xterm";
+import { FitAddon } from "@xterm/addon-fit";
+import { SerializeAddon } from "@xterm/addon-serialize";
+import { WebglAddon } from "@xterm/addon-webgl";
+import { useEffect, useRef, useState } from "react";
+import "@xterm/xterm/css/xterm.css";
+import { Button } from "../../design/primitives";
+import { getTerminalThemePreset } from "../../lib/terminal/terminal-themes";
+import { buildTerminalFontStack } from "../../lib/terminal/terminal-fonts";
+import type { ShellSocketState } from "../../lib/shell-socket";
+import { getAttachManager } from "./terminal-runtime";
+
+const GAP_MARKER = "\r\n[2m── output gap ──[0m\r\n";
+
+interface TerminalViewProps {
+  sessionName: string;
+  onRecreate?: () => void;
+}
+
+export default function TerminalView({ sessionName, onRecreate }: TerminalViewProps) {
+  const hostRef = useRef<HTMLDivElement>(null);
+  const [socketState, setSocketState] = useState<ShellSocketState>("connecting");
+  const [exitCode, setExitCode] = useState<number | null>(null);
+
+  useEffect(() => {
+    const host = hostRef.current;
+    if (!host) return;
+
+    const manager = getAttachManager();
+    const theme = getTerminalThemePreset("one-dark");
+    const terminal = new Terminal({
+      allowProposedApi: true,
+      cursorBlink: true,
+      fontSize: 13,
+      fontFamily: buildTerminalFontStack("JetBrains Mono", undefined),
+      lineHeight: 1.25,
+      scrollback: 5000,
+      theme,
+    });
+    const fit = new FitAddon();
+    const serialize = new SerializeAddon();
+    terminal.loadAddon(fit);
+    terminal.loadAddon(serialize);
+    terminal.open(host);
+    try {
+      terminal.loadAddon(new WebglAddon());
+    } catch (err: unknown) {
+      console.warn(
+        "[terminal] webgl renderer unavailable, falling back to canvas:",
+        err instanceof Error ? err.message : String(err),
+      );
+    }
+    fit.fit();
+
+    const cached = manager.getCachedBuffer(sessionName);
+    if (cached) terminal.write(cached);
+
+    const attachment = manager.attach(sessionName, {
+      onState: (state) => setSocketState(state),
+      onOutput: (data) => terminal.write(data),
+      onGap: () => {
+        terminal.clear();
+        terminal.write(GAP_MARKER);
+      },
+      onExit: (code) => {
+        setExitCode(code);
+        setSocketState("ended");
+      },
+    });
+
+    const dataDisposable = terminal.onData((data) => attachment.write(data));
+
+    const sendDims = () => {
+      fit.fit();
+      attachment.resize(terminal.cols, terminal.rows);
+    };
+    sendDims();
+    const observer = new ResizeObserver(() => {
+      window.requestAnimationFrame(sendDims);
+    });
+    observer.observe(host);
+
+    terminal.focus();
+
+    return () => {
+      observer.disconnect();
+      dataDisposable.dispose();
+      try {
+        manager.cacheBuffer(sessionName, serialize.serialize());
+      } catch (err: unknown) {
+        console.warn(
+          "[terminal] buffer snapshot failed:",
+          err instanceof Error ? err.message : String(err),
+        );
+      }
+      if (manager.activeSessionName === sessionName) manager.detachActive();
+      terminal.dispose();
+    };
+  }, [sessionName]);
+
+  const banner = (() => {
+    if (socketState === "fatal") {
+      return {
+        text: "This session has ended on your computer.",
+        action: onRecreate ? <Button variant="primary" onClick={onRecreate}>Start new session</Button> : null,
+      };
+    }
+    if (socketState === "ended") {
+      return {
+        text: exitCode !== null ? `Session exited (code ${exitCode}).` : "Session ended.",
+        action: onRecreate ? <Button variant="primary" onClick={onRecreate}>Start new session</Button> : null,
+      };
+    }
+    if (socketState === "connection-lost") {
+      return { text: "Connection lost. Reconnecting…", action: null };
+    }
+    return null;
+  })();
+
+  return (
+    <div className="relative flex min-h-0 flex-1 flex-col" style={{ background: "#0d1017" }}>
+      <div ref={hostRef} className="min-h-0 flex-1 px-2 pt-1.5" data-selectable />
+      {socketState === "connecting" || socketState === "reconnecting" ? (
+        <div
+          className="pointer-events-none absolute inset-x-0 top-0 flex justify-center pt-2"
+          aria-live="polite"
+        >
+          <span
+            className="status-pulse rounded-full px-3 py-1 text-xs"
+            style={{ background: "var(--bg-overlay)", color: "var(--text-secondary)" }}
+          >
+            {socketState === "connecting" ? "Connecting…" : "Reconnecting…"}
+          </span>
+        </div>
+      ) : null}
+      {banner ? (
+        <div
+          className="absolute inset-x-0 bottom-0 flex items-center justify-between gap-3 border-t px-4 py-2.5"
+          style={{
+            background: "var(--bg-overlay)",
+            borderColor: "var(--border-default)",
+          }}
+        >
+          <span className="text-sm" style={{ color: "var(--text-secondary)" }}>
+            {banner.text}
+          </span>
+          {banner.action}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/desktop/src/renderer/src/features/terminal/attach-manager.ts
+++ b/desktop/src/renderer/src/features/terminal/attach-manager.ts
@@ -1,0 +1,145 @@
+// Lesson L4: at most one live terminal socket app-wide; switching focus
+// detaches the previous socket. Lesson L9: a generation counter drops events
+// from sockets that are no longer the active attachment. Detached terminals
+// restore instantly from a bounded LRU of serialized buffers.
+
+import type { ShellSocketEvents, ShellSocketState } from "../../lib/shell-socket";
+
+const DEFAULT_BUFFER_CACHE_CAP = 8;
+
+export interface SocketControl {
+  connect(): void;
+  sendInput(data: string): void;
+  resize(cols: number, rows: number): void;
+  detach(): void;
+  dispose(): void;
+}
+
+export interface AttachManagerOptions {
+  createSocket: (sessionName: string, events: ShellSocketEvents) => SocketControl;
+  bufferCacheCap?: number;
+}
+
+export interface ActiveAttachment {
+  sessionName: string;
+  write(data: string): void;
+  resize(cols: number, rows: number): void;
+}
+
+interface ActiveSocket {
+  sessionName: string;
+  socket: SocketControl;
+  generation: number;
+}
+
+function errorText(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+export class AttachManager {
+  private readonly createSocket: AttachManagerOptions["createSocket"];
+  private readonly bufferCacheCap: number;
+  private readonly buffers = new Map<string, string>();
+  private active: ActiveSocket | null = null;
+  private generation = 0;
+  private disposed = false;
+
+  constructor(options: AttachManagerOptions) {
+    this.createSocket = options.createSocket;
+    this.bufferCacheCap = Math.max(1, Math.floor(options.bufferCacheCap ?? DEFAULT_BUFFER_CACHE_CAP));
+  }
+
+  get activeSessionName(): string | null {
+    return this.active?.sessionName ?? null;
+  }
+
+  attach(sessionName: string, events: ShellSocketEvents): ActiveAttachment {
+    if (this.disposed) {
+      throw new Error("AttachManager is disposed");
+    }
+    this.detachActive();
+    this.generation += 1;
+    const generation = this.generation;
+    const guarded: ShellSocketEvents = {
+      onState: (state: ShellSocketState, detail?: { code?: string }) => {
+        if (this.isLive(generation)) events.onState(state, detail);
+      },
+      onOutput: (data: string, seq: number) => {
+        if (this.isLive(generation)) events.onOutput(data, seq);
+      },
+      onGap: () => {
+        if (this.isLive(generation)) events.onGap();
+      },
+      onExit: (code: number) => {
+        if (this.isLive(generation)) events.onExit(code);
+      },
+    };
+    const socket = this.createSocket(sessionName, guarded);
+    this.active = { sessionName, socket, generation };
+    socket.connect();
+    return {
+      sessionName,
+      write: (data: string) => {
+        if (this.isLive(generation)) socket.sendInput(data);
+      },
+      resize: (cols: number, rows: number) => {
+        if (this.isLive(generation)) socket.resize(cols, rows);
+      },
+    };
+  }
+
+  cacheBuffer(sessionName: string, serialized: string): void {
+    if (this.buffers.has(sessionName)) {
+      this.buffers.delete(sessionName);
+    } else if (this.buffers.size >= this.bufferCacheCap) {
+      const oldest = this.buffers.keys().next().value;
+      if (oldest !== undefined) {
+        this.buffers.delete(oldest);
+      }
+    }
+    this.buffers.set(sessionName, serialized);
+  }
+
+  getCachedBuffer(sessionName: string): string | null {
+    const value = this.buffers.get(sessionName);
+    if (value === undefined) return null;
+    this.buffers.delete(sessionName);
+    this.buffers.set(sessionName, value);
+    return value;
+  }
+
+  detachActive(): void {
+    const active = this.active;
+    if (active === null) return;
+    // Clear first so events emitted during detach/dispose fail the guard.
+    this.active = null;
+    try {
+      active.socket.detach();
+    } catch (err: unknown) {
+      console.warn("[attach-manager] socket detach failed:", errorText(err));
+    }
+    try {
+      active.socket.dispose();
+    } catch (err: unknown) {
+      console.warn("[attach-manager] socket dispose failed:", errorText(err));
+    }
+  }
+
+  releaseSession(sessionName: string): void {
+    this.buffers.delete(sessionName);
+    if (this.active?.sessionName === sessionName) {
+      this.detachActive();
+    }
+  }
+
+  dispose(): void {
+    if (this.disposed) return;
+    this.detachActive();
+    this.buffers.clear();
+    this.disposed = true;
+  }
+
+  private isLive(generation: number): boolean {
+    return !this.disposed && this.active !== null && this.active.generation === generation;
+  }
+}

--- a/desktop/src/renderer/src/features/terminal/terminal-runtime.ts
+++ b/desktop/src/renderer/src/features/terminal/terminal-runtime.ts
@@ -1,0 +1,30 @@
+// Singleton attach manager wiring sockets to the connection profile.
+// Single live attachment app-wide (lesson L4); buffers cached LRU for instant
+// task switching (FR-022, SC-006).
+import { AttachManager } from "./attach-manager";
+import { ShellSocket, type ShellSocketEvents } from "../../lib/shell-socket";
+import { useConnection } from "../../stores/connection";
+
+let manager: AttachManager | null = null;
+
+export function getAttachManager(): AttachManager {
+  if (!manager) {
+    manager = new AttachManager({
+      createSocket: (sessionName: string, events: ShellSocketEvents) => {
+        const { platformHost, runtimeSlot } = useConnection.getState();
+        return new ShellSocket({
+          baseUrl: platformHost,
+          sessionName,
+          runtimeSlot,
+          events,
+        });
+      },
+    });
+  }
+  return manager;
+}
+
+export function resetAttachManager(): void {
+  manager?.dispose();
+  manager = null;
+}

--- a/desktop/src/renderer/src/lib/kernel-socket.ts
+++ b/desktop/src/renderer/src/lib/kernel-socket.ts
@@ -1,0 +1,342 @@
+// One multiplexed kernel /ws connection (contracts/gateway-contract.md,
+// "Kernel /ws"). Framework-free: WebSocket factory, timers, and randomness
+// are injectable for tests. Known message types are validated with zod;
+// unknown types pass through to subscribers for forward compatibility.
+import { z } from "zod/v4";
+
+export type KernelConnectionState = "connecting" | "connected" | "reconnecting" | "offline";
+
+export interface KernelServerMessage {
+  type: string;
+  [key: string]: unknown;
+}
+
+export type KernelClientMessage =
+  | { type: "message"; text: string; sessionId?: string; requestId: string }
+  | { type: "abort"; requestId: string }
+  | { type: "approval_response"; id: string; approved: boolean }
+  | { type: "ping" };
+
+// Structurally identical to the browser WebSocket subset the socket needs.
+export interface WebSocketLike {
+  readyState: number;
+  send(data: string): void;
+  close(code?: number, reason?: string): void;
+  onopen: (() => void) | null;
+  onmessage: ((event: { data: unknown }) => void) | null;
+  onclose: (() => void) | null;
+  onerror: (() => void) | null;
+}
+
+export interface KernelSocketOptions {
+  baseUrl: string;
+  runtimeSlot: string;
+  createWebSocket?: (url: string) => WebSocketLike;
+  setTimeoutFn?: typeof setTimeout;
+  clearTimeoutFn?: typeof clearTimeout;
+  random?: () => number;
+}
+
+const WS_CONNECTING = 0;
+const WS_OPEN = 1;
+
+const SUBSCRIBER_CAP = 64;
+const SEND_QUEUE_CAP = 32;
+const BACKOFF_BASE_MS = 500;
+const BACKOFF_MAX_MS = 30_000;
+const OFFLINE_AFTER_FAILURES = 3;
+const MAX_FRAME_CHARS = 1_000_000;
+
+const requestIdField = z.string().min(1).max(256).optional();
+
+export const KnownKernelMessageSchema = z.discriminatedUnion("type", [
+  z.looseObject({ type: z.literal("kernel:init"), sessionId: z.string(), requestId: requestIdField }),
+  z.looseObject({ type: z.literal("kernel:text"), text: z.string(), requestId: requestIdField }),
+  z.looseObject({ type: z.literal("kernel:tool_start"), tool: z.string(), requestId: requestIdField }),
+  z.looseObject({
+    type: z.literal("kernel:tool_end"),
+    input: z.record(z.string(), z.unknown()).optional(),
+    requestId: requestIdField,
+  }),
+  z.looseObject({ type: z.literal("kernel:result"), data: z.unknown(), requestId: requestIdField }),
+  z.looseObject({ type: z.literal("kernel:error"), message: z.string(), requestId: requestIdField }),
+  z.looseObject({ type: z.literal("kernel:aborted"), requestId: requestIdField }),
+  z.looseObject({ type: z.literal("session:switched"), sessionId: z.string() }),
+  z.looseObject({
+    type: z.literal("task:created"),
+    task: z.looseObject({ id: z.string(), type: z.string(), status: z.string(), input: z.string() }),
+  }),
+  z.looseObject({ type: z.literal("task:updated"), taskId: z.string(), status: z.string() }),
+  z.looseObject({
+    type: z.literal("approval:request"),
+    id: z.string(),
+    toolName: z.string(),
+    args: z.unknown(),
+    timeout: z.number(),
+  }),
+  z.looseObject({ type: z.literal("pong") }),
+]);
+
+export type KnownKernelMessage = z.infer<typeof KnownKernelMessageSchema>;
+
+const KNOWN_TYPES: ReadonlySet<string> = new Set(
+  KnownKernelMessageSchema.options.map((option) => option.shape.type.value),
+);
+
+const BaseMessageSchema = z.looseObject({ type: z.string().min(1).max(128) });
+
+export function parseKernelServerMessage(value: unknown): KernelServerMessage | null {
+  const base = BaseMessageSchema.safeParse(value);
+  if (!base.success) return null;
+  if (KNOWN_TYPES.has(base.data.type)) {
+    const known = KnownKernelMessageSchema.safeParse(base.data);
+    return known.success ? known.data : null;
+  }
+  return base.data;
+}
+
+export function buildKernelWsUrl(baseUrl: string, runtimeSlot: string): string {
+  const base = baseUrl.replace(/\/+$/, "").replace(/^http/, "ws");
+  const url = `${base}/ws`;
+  if (runtimeSlot === "primary") return url;
+  return `${url}?runtime=${encodeURIComponent(runtimeSlot)}`;
+}
+
+type MessageHandler = (msg: KernelServerMessage) => void;
+type StateHandler = (state: KernelConnectionState) => void;
+
+export class KernelSocket {
+  private readonly baseUrl: string;
+  private readonly runtimeSlot: string;
+  private readonly createWebSocket: (url: string) => WebSocketLike;
+  private readonly setTimeoutFn: typeof setTimeout;
+  private readonly clearTimeoutFn: typeof clearTimeout;
+  private readonly random: () => number;
+
+  private socket: WebSocketLike | null = null;
+  private readonly handlers = new Set<MessageHandler>();
+  private readonly stateHandlers = new Set<StateHandler>();
+  private readonly sendQueue: string[] = [];
+  private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+  private attempt = 0;
+  private consecutiveFailures = 0;
+  private currentState: KernelConnectionState = "connecting";
+  private disposed = false;
+
+  constructor(options: KernelSocketOptions) {
+    this.baseUrl = options.baseUrl;
+    this.runtimeSlot = options.runtimeSlot;
+    this.createWebSocket =
+      options.createWebSocket ??
+      ((url) => new WebSocket(url) as unknown as WebSocketLike);
+    this.setTimeoutFn = options.setTimeoutFn ?? setTimeout;
+    this.clearTimeoutFn = options.clearTimeoutFn ?? clearTimeout;
+    this.random = options.random ?? Math.random;
+  }
+
+  get state(): KernelConnectionState {
+    return this.currentState;
+  }
+
+  connect(): void {
+    if (this.disposed) return;
+    if (
+      this.socket &&
+      (this.socket.readyState === WS_OPEN || this.socket.readyState === WS_CONNECTING)
+    ) {
+      return;
+    }
+    this.clearReconnectTimer();
+
+    const url = buildKernelWsUrl(this.baseUrl, this.runtimeSlot);
+    let socket: WebSocketLike;
+    try {
+      socket = this.createWebSocket(url);
+    } catch (err: unknown) {
+      console.warn(
+        "[kernel-socket] failed to create websocket:",
+        err instanceof Error ? err.message : err,
+      );
+      this.handleConnectionLoss();
+      return;
+    }
+    this.socket = socket;
+
+    socket.onopen = () => {
+      this.attempt = 0;
+      this.consecutiveFailures = 0;
+      this.setState("connected");
+      this.drainQueue();
+    };
+
+    socket.onmessage = (event) => {
+      this.handleFrame(event.data);
+    };
+
+    socket.onclose = () => {
+      if (this.disposed) return;
+      this.socket = null;
+      this.handleConnectionLoss();
+    };
+
+    socket.onerror = () => {
+      try {
+        socket.close();
+      } catch (err: unknown) {
+        console.warn(
+          "[kernel-socket] close after error failed:",
+          err instanceof Error ? err.message : err,
+        );
+      }
+    };
+  }
+
+  subscribe(handler: MessageHandler): () => void {
+    if (this.handlers.size >= SUBSCRIBER_CAP) {
+      throw new Error(`KernelSocket subscriber cap (${SUBSCRIBER_CAP}) exceeded`);
+    }
+    this.handlers.add(handler);
+    return () => {
+      this.handlers.delete(handler);
+    };
+  }
+
+  onStateChange(handler: StateHandler): () => void {
+    if (this.stateHandlers.size >= SUBSCRIBER_CAP) {
+      throw new Error(`KernelSocket state-subscriber cap (${SUBSCRIBER_CAP}) exceeded`);
+    }
+    this.stateHandlers.add(handler);
+    return () => {
+      this.stateHandlers.delete(handler);
+    };
+  }
+
+  send(msg: KernelClientMessage): void {
+    const data = JSON.stringify(msg);
+    if (this.socket?.readyState === WS_OPEN) {
+      try {
+        this.socket.send(data);
+        return;
+      } catch (err: unknown) {
+        console.warn(
+          "[kernel-socket] send failed, queueing:",
+          err instanceof Error ? err.message : err,
+        );
+      }
+    }
+    if (this.sendQueue.length >= SEND_QUEUE_CAP) {
+      this.sendQueue.shift();
+      console.warn(`[kernel-socket] send queue full (${SEND_QUEUE_CAP}); dropping oldest message`);
+    }
+    this.sendQueue.push(data);
+  }
+
+  dispose(): void {
+    if (this.disposed) return;
+    this.disposed = true;
+    this.clearReconnectTimer();
+    const socket = this.socket;
+    this.socket = null;
+    if (socket) {
+      socket.onopen = null;
+      socket.onmessage = null;
+      socket.onclose = null;
+      socket.onerror = null;
+      try {
+        socket.close();
+      } catch (err: unknown) {
+        console.warn(
+          "[kernel-socket] close on dispose failed:",
+          err instanceof Error ? err.message : err,
+        );
+      }
+    }
+    this.setState("offline");
+    this.handlers.clear();
+    this.stateHandlers.clear();
+  }
+
+  private handleFrame(data: unknown): void {
+    if (typeof data !== "string" || data.length === 0 || data.length > MAX_FRAME_CHARS) {
+      return;
+    }
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(data);
+    } catch (err: unknown) {
+      console.warn(
+        "[kernel-socket] dropping unparseable frame:",
+        err instanceof Error ? err.message : err,
+      );
+      return;
+    }
+    const msg = parseKernelServerMessage(parsed);
+    if (!msg) return;
+    for (const handler of [...this.handlers]) {
+      try {
+        handler(msg);
+      } catch (err: unknown) {
+        console.warn(
+          "[kernel-socket] subscriber failed:",
+          err instanceof Error ? err.message : err,
+        );
+      }
+    }
+  }
+
+  private handleConnectionLoss(): void {
+    if (this.disposed) return;
+    this.consecutiveFailures++;
+    this.setState(this.consecutiveFailures >= OFFLINE_AFTER_FAILURES ? "offline" : "reconnecting");
+    const delay = this.backoffDelay(this.attempt);
+    this.attempt++;
+    this.reconnectTimer = this.setTimeoutFn(() => {
+      this.reconnectTimer = null;
+      this.connect();
+    }, delay);
+  }
+
+  private backoffDelay(attempt: number): number {
+    const base = Math.min(BACKOFF_BASE_MS * 2 ** attempt, BACKOFF_MAX_MS);
+    // Jitter factor in [0.5, 1.0]
+    return Math.round(base * (0.5 + this.random() * 0.5));
+  }
+
+  private drainQueue(): void {
+    while (this.sendQueue.length > 0 && this.socket?.readyState === WS_OPEN) {
+      const data = this.sendQueue.shift()!;
+      try {
+        this.socket.send(data);
+      } catch (err: unknown) {
+        console.warn(
+          "[kernel-socket] drain send failed, requeueing:",
+          err instanceof Error ? err.message : err,
+        );
+        this.sendQueue.unshift(data);
+        return;
+      }
+    }
+  }
+
+  private setState(state: KernelConnectionState): void {
+    if (this.currentState === state) return;
+    this.currentState = state;
+    for (const handler of [...this.stateHandlers]) {
+      try {
+        handler(state);
+      } catch (err: unknown) {
+        console.warn(
+          "[kernel-socket] state subscriber failed:",
+          err instanceof Error ? err.message : err,
+        );
+      }
+    }
+  }
+
+  private clearReconnectTimer(): void {
+    if (this.reconnectTimer !== null) {
+      this.clearTimeoutFn(this.reconnectTimer);
+      this.reconnectTimer = null;
+    }
+  }
+}

--- a/desktop/src/renderer/src/lib/kernel-wiring.ts
+++ b/desktop/src/renderer/src/lib/kernel-wiring.ts
@@ -1,0 +1,85 @@
+// Wires the singleton kernel socket into the stores: thread routing, board
+// task events, native notifications, dock badge.
+import { invoke } from "./operator";
+import { KernelSocket } from "./kernel-socket";
+import { useBoard } from "../stores/board";
+import { useConnection } from "../stores/connection";
+import { useThreads } from "../stores/threads";
+import { useUi } from "../stores/ui";
+
+let socket: KernelSocket | null = null;
+
+export function getKernelSocket(): KernelSocket | null {
+  return socket;
+}
+
+export function sendKernelMessage(msg: {
+  text: string;
+  sessionId?: string;
+  requestId: string;
+}): void {
+  socket?.send({ type: "message", text: msg.text, requestId: msg.requestId, ...(msg.sessionId ? { sessionId: msg.sessionId } : {}) });
+}
+
+export function abortKernelRequest(requestId: string): void {
+  socket?.send({ type: "abort", requestId });
+}
+
+export function wireKernel(): () => void {
+  const { platformHost, runtimeSlot } = useConnection.getState();
+  if (socket) {
+    socket.dispose();
+    socket = null;
+  }
+  socket = new KernelSocket({ baseUrl: platformHost, runtimeSlot });
+
+  const unsubscribeMessages = socket.subscribe((msg) => {
+    const ui = useUi.getState();
+    const focusedThreadId = ui.view.kind === "thread" ? ui.view.threadId : null;
+    const { notification } = useThreads
+      .getState()
+      .handleKernelMessage(msg, { focusedThreadId });
+    if (notification) {
+      void invoke("notify", {
+        threadId: notification.threadId,
+        title: notification.title.slice(0, 80),
+        body: notification.body.slice(0, 200),
+        kind: notification.kind,
+      }).catch((err: unknown) => {
+        console.warn(
+          "[kernel-wiring] notify failed:",
+          err instanceof Error ? err.message : String(err),
+        );
+      });
+    }
+    if (msg.type === "task:created" || msg.type === "task:updated") {
+      useBoard.getState().applyTaskEvent(msg as never);
+    }
+  });
+
+  let lastBadge = -1;
+  const unsubscribeBadge = useThreads.subscribe((state) => {
+    const count = state.threads.reduce(
+      (sum, t) => sum + (t.unread || t.status === "needs-attention" ? 1 : 0),
+      0,
+    );
+    if (count !== lastBadge) {
+      lastBadge = count;
+      void invoke("badge:set", { count: Math.min(count, 999) }).catch((err: unknown) => {
+        console.warn(
+          "[kernel-wiring] badge update failed:",
+          err instanceof Error ? err.message : String(err),
+        );
+      });
+    }
+  });
+
+  socket.connect();
+
+  return () => {
+    unsubscribeMessages();
+    unsubscribeBadge();
+    socket?.dispose();
+    socket = null;
+  };
+}

--- a/desktop/src/renderer/src/lib/kernel-wiring.ts
+++ b/desktop/src/renderer/src/lib/kernel-wiring.ts
@@ -1,13 +1,28 @@
 // Wires the singleton kernel socket into the stores: thread routing, board
 // task events, native notifications, dock badge.
 import { invoke } from "./operator";
-import { KernelSocket } from "./kernel-socket";
-import { useBoard } from "../stores/board";
+import { KernelSocket, type KernelServerMessage } from "./kernel-socket";
+import {
+  useBoard,
+  type TaskEventCreated,
+  type TaskEventUpdated,
+} from "../stores/board";
 import { useConnection } from "../stores/connection";
 import { useThreads } from "../stores/threads";
 import { useUi } from "../stores/ui";
 
 let socket: KernelSocket | null = null;
+
+type BoardTaskEvent = KernelServerMessage & (TaskEventCreated | TaskEventUpdated);
+
+function isTaskEvent(msg: KernelServerMessage): msg is BoardTaskEvent {
+  if (msg.type === "task:created") return "task" in msg;
+  return (
+    msg.type === "task:updated" &&
+    typeof msg.taskId === "string" &&
+    typeof msg.status === "string"
+  );
+}
 
 export function getKernelSocket(): KernelSocket | null {
   return socket;
@@ -52,8 +67,8 @@ export function wireKernel(): () => void {
         );
       });
     }
-    if (msg.type === "task:created" || msg.type === "task:updated") {
-      useBoard.getState().applyTaskEvent(msg as never);
+    if (isTaskEvent(msg)) {
+      useBoard.getState().applyTaskEvent(msg);
     }
   });
 

--- a/desktop/src/renderer/src/lib/kernel-wiring.ts
+++ b/desktop/src/renderer/src/lib/kernel-wiring.ts
@@ -12,6 +12,7 @@ import { useThreads } from "../stores/threads";
 import { useUi } from "../stores/ui";
 
 let socket: KernelSocket | null = null;
+let cleanupKernel: (() => void) | null = null;
 
 type BoardTaskEvent = KernelServerMessage & (TaskEventCreated | TaskEventUpdated);
 
@@ -42,13 +43,17 @@ export function abortKernelRequest(requestId: string): void {
 
 export function wireKernel(): () => void {
   const { platformHost, runtimeSlot } = useConnection.getState();
-  if (socket) {
+  if (cleanupKernel) {
+    cleanupKernel();
+    cleanupKernel = null;
+  } else if (socket) {
     socket.dispose();
     socket = null;
   }
   socket = new KernelSocket({ baseUrl: platformHost, runtimeSlot });
+  const activeSocket = socket;
 
-  const unsubscribeMessages = socket.subscribe((msg) => {
+  const unsubscribeMessages = activeSocket.subscribe((msg) => {
     const ui = useUi.getState();
     const focusedThreadId = ui.view.kind === "thread" ? ui.view.threadId : null;
     const { notification } = useThreads
@@ -89,12 +94,18 @@ export function wireKernel(): () => void {
     }
   });
 
-  socket.connect();
+  activeSocket.connect();
 
-  return () => {
+  let cleaned = false;
+  const cleanup = () => {
+    if (cleaned) return;
+    cleaned = true;
     unsubscribeMessages();
     unsubscribeBadge();
-    socket?.dispose();
-    socket = null;
+    activeSocket.dispose();
+    if (socket === activeSocket) socket = null;
+    if (cleanupKernel === cleanup) cleanupKernel = null;
   };
+  cleanupKernel = cleanup;
+  return cleanup;
 }

--- a/desktop/src/renderer/src/lib/session-merge.ts
+++ b/desktop/src/renderer/src/lib/session-merge.ts
@@ -1,0 +1,81 @@
+// Merges zellij sessions (GET /api/terminal/sessions) with workspace session
+// records (GET /api/sessions) into the single attachable list (L6). Workspace
+// records without runtime.zellijSession are orchestrator-only and must NEVER
+// become attach targets — their UUIDs caused infinite session_not_found
+// retries in the 092 prototype.
+
+export interface ZellijSessionDTO {
+  name: string;
+  status?: "active" | "exited";
+}
+
+export interface WorkspaceSessionDTO {
+  id?: string;
+  sessionId?: string;
+  name?: string;
+  runtime?: { zellijSession?: string | null; status?: string } | null;
+  status?: string;
+}
+
+export interface AttachableSession {
+  name: string;
+  attachName: string;
+  status: "active" | "exited";
+  source: "zellij" | "workspace";
+}
+
+export interface SessionMergeResult {
+  sessions: AttachableSession[];
+  aliasMap: Record<string, string>;
+}
+
+const EXITED_STATUSES = new Set(["exited", "failed"]);
+
+function workspaceStatus(record: WorkspaceSessionDTO): "active" | "exited" {
+  const status = record.runtime?.status ?? record.status;
+  return status !== undefined && EXITED_STATUSES.has(status) ? "exited" : "active";
+}
+
+export function mergeAttachableSessions(
+  zellij: ZellijSessionDTO[],
+  workspace: WorkspaceSessionDTO[],
+): SessionMergeResult {
+  const sessions: AttachableSession[] = [];
+  const aliasMap: Record<string, string> = {};
+  const seenAttachNames = new Set<string>();
+
+  for (const entry of zellij) {
+    const name = entry.name;
+    if (!name || name.trim().length === 0 || seenAttachNames.has(name)) continue;
+    seenAttachNames.add(name);
+    sessions.push({
+      name,
+      attachName: name,
+      status: entry.status === "exited" ? "exited" : "active",
+      source: "zellij",
+    });
+    aliasMap[name] = name;
+  }
+
+  for (const record of workspace) {
+    const attachName = record.runtime?.zellijSession;
+    if (!attachName || attachName.trim().length === 0) continue;
+
+    for (const alias of [record.id, record.sessionId, record.name, attachName]) {
+      if (alias && alias.trim().length > 0) aliasMap[alias] = attachName;
+    }
+
+    // Zellij (or an earlier record) already owns this attach name — its
+    // status wins, only the aliases above are added.
+    if (seenAttachNames.has(attachName)) continue;
+    seenAttachNames.add(attachName);
+    sessions.push({
+      name: record.name && record.name.trim().length > 0 ? record.name : attachName,
+      attachName,
+      status: workspaceStatus(record),
+      source: "workspace",
+    });
+  }
+
+  return { sessions, aliasMap };
+}

--- a/desktop/src/renderer/src/stores/sessions.ts
+++ b/desktop/src/renderer/src/stores/sessions.ts
@@ -1,0 +1,64 @@
+// Attachable session list: zellij sessions (GET /api/terminal/sessions ->
+// { sessions: [{ name, status, ... }] }) merged with workspace records
+// (GET /api/sessions -> { sessions: [{ id, runtime: { zellijSession? } }], nextCursor }).
+// Only entries with a real zellij attach name exist here (L6).
+import { create } from "zustand";
+import { AppError, type AppErrorCategory } from "../../../shared/app-error";
+import type { ApiClient } from "../lib/api";
+import {
+  mergeAttachableSessions,
+  type AttachableSession,
+  type WorkspaceSessionDTO,
+  type ZellijSessionDTO,
+} from "../lib/session-merge";
+
+interface SessionsState {
+  sessions: AttachableSession[];
+  aliasMap: Record<string, string>;
+  loading: boolean;
+  error: AppErrorCategory | null;
+  load(api: ApiClient): Promise<void>;
+  resolveAttachName(linkedSessionId: string | null): string | null;
+}
+
+function asArray<T>(value: unknown): T[] {
+  return Array.isArray(value) ? (value as T[]) : [];
+}
+
+export const useSessions = create<SessionsState>()((set, get) => ({
+  sessions: [],
+  aliasMap: {},
+  loading: false,
+  error: null,
+
+  load: async (api) => {
+    set({ loading: true });
+    try {
+      const [zellijResponse, workspaceResponse] = await Promise.all([
+        api.get<{ sessions: unknown }>("/api/terminal/sessions"),
+        api.get<{ sessions: unknown; nextCursor: string | null }>("/api/sessions"),
+      ]);
+      const merged = mergeAttachableSessions(
+        asArray<ZellijSessionDTO>(zellijResponse.sessions),
+        asArray<WorkspaceSessionDTO>(workspaceResponse.sessions),
+      );
+      set({
+        sessions: merged.sessions,
+        aliasMap: merged.aliasMap,
+        loading: false,
+        error: null,
+      });
+    } catch (err: unknown) {
+      console.error("[sessions] Failed to load sessions:", err);
+      set({
+        loading: false,
+        error: err instanceof AppError ? err.category : "server",
+      });
+    }
+  },
+
+  resolveAttachName: (linkedSessionId) => {
+    if (!linkedSessionId) return null;
+    return get().aliasMap[linkedSessionId] ?? null;
+  },
+}));

--- a/desktop/src/renderer/src/stores/sessions.ts
+++ b/desktop/src/renderer/src/stores/sessions.ts
@@ -25,6 +25,8 @@ function asArray<T>(value: unknown): T[] {
   return Array.isArray(value) ? (value as T[]) : [];
 }
 
+let loadSequence = 0;
+
 export const useSessions = create<SessionsState>()((set, get) => ({
   sessions: [],
   aliasMap: {},
@@ -32,6 +34,7 @@ export const useSessions = create<SessionsState>()((set, get) => ({
   error: null,
 
   load: async (api) => {
+    const sequence = ++loadSequence;
     set({ loading: true, error: null });
     try {
       const [zellijResponse, workspaceResponse] = await Promise.all([
@@ -42,6 +45,7 @@ export const useSessions = create<SessionsState>()((set, get) => ({
         asArray<ZellijSessionDTO>(zellijResponse.sessions),
         asArray<WorkspaceSessionDTO>(workspaceResponse.sessions),
       );
+      if (sequence !== loadSequence) return;
       set({
         sessions: merged.sessions,
         aliasMap: merged.aliasMap,
@@ -49,6 +53,7 @@ export const useSessions = create<SessionsState>()((set, get) => ({
         error: null,
       });
     } catch (err: unknown) {
+      if (sequence !== loadSequence) return;
       console.error("[sessions] Failed to load sessions:", err);
       set({
         loading: false,

--- a/desktop/src/renderer/src/stores/sessions.ts
+++ b/desktop/src/renderer/src/stores/sessions.ts
@@ -32,7 +32,7 @@ export const useSessions = create<SessionsState>()((set, get) => ({
   error: null,
 
   load: async (api) => {
-    set({ loading: true });
+    set({ loading: true, error: null });
     try {
       const [zellijResponse, workspaceResponse] = await Promise.all([
         api.get<{ sessions: unknown }>("/api/terminal/sessions"),

--- a/tests/desktop/attach-manager.test.ts
+++ b/tests/desktop/attach-manager.test.ts
@@ -1,0 +1,279 @@
+import { describe, expect, it } from "vitest";
+import type {
+  ShellSocketEvents,
+  ShellSocketState,
+} from "@desktop/renderer/src/lib/shell-socket";
+import {
+  AttachManager,
+  type SocketControl,
+} from "@desktop/renderer/src/features/terminal/attach-manager";
+
+class FakeSocketControl implements SocketControl {
+  connected = 0;
+  detached = 0;
+  disposedCount = 0;
+  readonly inputs: string[] = [];
+  readonly resizes: Array<{ cols: number; rows: number }> = [];
+
+  constructor(
+    readonly sessionName: string,
+    readonly events: ShellSocketEvents,
+  ) {}
+
+  connect(): void {
+    this.connected += 1;
+  }
+
+  sendInput(data: string): void {
+    this.inputs.push(data);
+  }
+
+  resize(cols: number, rows: number): void {
+    this.resizes.push({ cols, rows });
+  }
+
+  detach(): void {
+    this.detached += 1;
+  }
+
+  dispose(): void {
+    this.disposedCount += 1;
+  }
+}
+
+interface RecordedEvents {
+  states: ShellSocketState[];
+  outputs: Array<{ data: string; seq: number }>;
+  gaps: number;
+  exits: number[];
+}
+
+function recordingEvents(): { calls: RecordedEvents; events: ShellSocketEvents } {
+  const calls: RecordedEvents = { states: [], outputs: [], gaps: 0, exits: [] };
+  const events: ShellSocketEvents = {
+    onState: (state) => {
+      calls.states.push(state);
+    },
+    onOutput: (data, seq) => {
+      calls.outputs.push({ data, seq });
+    },
+    onGap: () => {
+      calls.gaps += 1;
+    },
+    onExit: (code) => {
+      calls.exits.push(code);
+    },
+  };
+  return { calls, events };
+}
+
+function createManager(bufferCacheCap?: number): {
+  manager: AttachManager;
+  created: FakeSocketControl[];
+} {
+  const created: FakeSocketControl[] = [];
+  const manager = new AttachManager({
+    bufferCacheCap,
+    createSocket: (sessionName, events) => {
+      const socket = new FakeSocketControl(sessionName, events);
+      created.push(socket);
+      return socket;
+    },
+  });
+  return { manager, created };
+}
+
+describe("AttachManager single-active invariant", () => {
+  it("creates and connects one socket per attach", () => {
+    const { manager, created } = createManager();
+    const { events } = recordingEvents();
+    manager.attach("alpha", events);
+    expect(created).toHaveLength(1);
+    expect(created[0]?.connected).toBe(1);
+    expect(manager.activeSessionName).toBe("alpha");
+  });
+
+  it("attaching B detaches and disposes A's socket", () => {
+    const { manager, created } = createManager();
+    manager.attach("alpha", recordingEvents().events);
+    manager.attach("beta", recordingEvents().events);
+    expect(created).toHaveLength(2);
+    expect(created[0]?.detached).toBe(1);
+    expect(created[0]?.disposedCount).toBe(1);
+    expect(created[1]?.detached).toBe(0);
+    expect(created[1]?.disposedCount).toBe(0);
+    expect(created[1]?.connected).toBe(1);
+    expect(manager.activeSessionName).toBe("beta");
+  });
+
+  it("re-attaching the same session replaces the socket", () => {
+    const { manager, created } = createManager();
+    manager.attach("alpha", recordingEvents().events);
+    manager.attach("alpha", recordingEvents().events);
+    expect(created).toHaveLength(2);
+    expect(created[0]?.disposedCount).toBe(1);
+    expect(manager.activeSessionName).toBe("alpha");
+  });
+});
+
+describe("AttachManager generation guard", () => {
+  it("forwards events from the active socket", () => {
+    const { manager, created } = createManager();
+    const recorder = recordingEvents();
+    manager.attach("alpha", recorder.events);
+    created[0]?.events.onState("attached");
+    created[0]?.events.onOutput("hi", 1);
+    created[0]?.events.onGap();
+    created[0]?.events.onExit(0);
+    expect(recorder.calls.states).toEqual(["attached"]);
+    expect(recorder.calls.outputs).toEqual([{ data: "hi", seq: 1 }]);
+    expect(recorder.calls.gaps).toBe(1);
+    expect(recorder.calls.exits).toEqual([0]);
+  });
+
+  it("drops stale events from a previous generation after switching", () => {
+    const { manager, created } = createManager();
+    const recorderA = recordingEvents();
+    const recorderB = recordingEvents();
+    manager.attach("alpha", recorderA.events);
+    manager.attach("beta", recorderB.events);
+
+    created[0]?.events.onState("ended");
+    created[0]?.events.onOutput("stale", 9);
+    created[0]?.events.onGap();
+    created[0]?.events.onExit(1);
+    expect(recorderA.calls.states).toHaveLength(0);
+    expect(recorderA.calls.outputs).toHaveLength(0);
+    expect(recorderA.calls.gaps).toBe(0);
+    expect(recorderA.calls.exits).toHaveLength(0);
+
+    created[1]?.events.onOutput("live", 1);
+    expect(recorderB.calls.outputs).toEqual([{ data: "live", seq: 1 }]);
+  });
+
+  it("routes write and resize through the active socket and ignores stale attachments", () => {
+    const { manager, created } = createManager();
+    const a = manager.attach("alpha", recordingEvents().events);
+    a.write("first");
+    a.resize(80, 24);
+    expect(created[0]?.inputs).toEqual(["first"]);
+    expect(created[0]?.resizes).toEqual([{ cols: 80, rows: 24 }]);
+
+    const b = manager.attach("beta", recordingEvents().events);
+    a.write("stale");
+    a.resize(100, 30);
+    expect(created[0]?.inputs).toEqual(["first"]);
+    expect(created[0]?.resizes).toEqual([{ cols: 80, rows: 24 }]);
+
+    b.write("live");
+    expect(created[1]?.inputs).toEqual(["live"]);
+    expect(b.sessionName).toBe("beta");
+  });
+});
+
+describe("AttachManager buffer cache (LRU)", () => {
+  it("returns null for unknown sessions", () => {
+    const { manager } = createManager();
+    expect(manager.getCachedBuffer("nope")).toBeNull();
+  });
+
+  it("evicts the oldest entry past the cap", () => {
+    const { manager } = createManager(2);
+    manager.cacheBuffer("a", "buf-a");
+    manager.cacheBuffer("b", "buf-b");
+    manager.cacheBuffer("c", "buf-c");
+    expect(manager.getCachedBuffer("a")).toBeNull();
+    expect(manager.getCachedBuffer("b")).toBe("buf-b");
+    expect(manager.getCachedBuffer("c")).toBe("buf-c");
+  });
+
+  it("getCachedBuffer refreshes recency", () => {
+    const { manager } = createManager(2);
+    manager.cacheBuffer("a", "buf-a");
+    manager.cacheBuffer("b", "buf-b");
+    expect(manager.getCachedBuffer("a")).toBe("buf-a");
+    manager.cacheBuffer("c", "buf-c");
+    expect(manager.getCachedBuffer("b")).toBeNull();
+    expect(manager.getCachedBuffer("a")).toBe("buf-a");
+    expect(manager.getCachedBuffer("c")).toBe("buf-c");
+  });
+
+  it("cacheBuffer on an existing key updates the value and refreshes recency", () => {
+    const { manager } = createManager(2);
+    manager.cacheBuffer("a", "old-a");
+    manager.cacheBuffer("b", "buf-b");
+    manager.cacheBuffer("a", "new-a");
+    manager.cacheBuffer("c", "buf-c");
+    expect(manager.getCachedBuffer("b")).toBeNull();
+    expect(manager.getCachedBuffer("a")).toBe("new-a");
+  });
+
+  it("defaults the cap to 8", () => {
+    const { manager } = createManager();
+    for (let i = 1; i <= 9; i += 1) {
+      manager.cacheBuffer(`s${i}`, `buf-${i}`);
+    }
+    expect(manager.getCachedBuffer("s1")).toBeNull();
+    for (let i = 2; i <= 9; i += 1) {
+      expect(manager.getCachedBuffer(`s${i}`)).toBe(`buf-${i}`);
+    }
+  });
+});
+
+describe("AttachManager detachActive and releaseSession", () => {
+  it("detachActive detaches, disposes, and clears the active session", () => {
+    const { manager, created } = createManager();
+    manager.attach("alpha", recordingEvents().events);
+    manager.detachActive();
+    expect(created[0]?.detached).toBe(1);
+    expect(created[0]?.disposedCount).toBe(1);
+    expect(manager.activeSessionName).toBeNull();
+    manager.detachActive();
+    expect(created[0]?.detached).toBe(1);
+  });
+
+  it("releaseSession drops the cache and detaches when active", () => {
+    const { manager, created } = createManager();
+    manager.attach("alpha", recordingEvents().events);
+    manager.cacheBuffer("alpha", "buf");
+    manager.releaseSession("alpha");
+    expect(manager.getCachedBuffer("alpha")).toBeNull();
+    expect(created[0]?.detached).toBe(1);
+    expect(created[0]?.disposedCount).toBe(1);
+    expect(manager.activeSessionName).toBeNull();
+  });
+
+  it("releaseSession of an inactive session leaves the active attachment alone", () => {
+    const { manager, created } = createManager();
+    manager.attach("alpha", recordingEvents().events);
+    manager.cacheBuffer("beta", "buf-b");
+    manager.releaseSession("beta");
+    expect(manager.getCachedBuffer("beta")).toBeNull();
+    expect(created[0]?.detached).toBe(0);
+    expect(manager.activeSessionName).toBe("alpha");
+  });
+});
+
+describe("AttachManager dispose", () => {
+  it("disposes the active socket, clears the cache, and drops stale events", () => {
+    const { manager, created } = createManager();
+    const recorder = recordingEvents();
+    manager.attach("alpha", recorder.events);
+    manager.cacheBuffer("beta", "buf-b");
+    manager.dispose();
+
+    expect(created[0]?.detached).toBe(1);
+    expect(created[0]?.disposedCount).toBe(1);
+    expect(manager.activeSessionName).toBeNull();
+    expect(manager.getCachedBuffer("beta")).toBeNull();
+
+    created[0]?.events.onOutput("stale", 1);
+    expect(recorder.calls.outputs).toHaveLength(0);
+  });
+
+  it("rejects attach after dispose", () => {
+    const { manager } = createManager();
+    manager.dispose();
+    expect(() => manager.attach("alpha", recordingEvents().events)).toThrow(/disposed/);
+  });
+});

--- a/tests/desktop/kernel-socket.test.ts
+++ b/tests/desktop/kernel-socket.test.ts
@@ -1,0 +1,358 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  buildKernelWsUrl,
+  KernelSocket,
+  type KernelConnectionState,
+  type KernelServerMessage,
+  type WebSocketLike,
+} from "@desktop/renderer/src/lib/kernel-socket";
+
+class FakeWebSocket implements WebSocketLike {
+  readyState = 0;
+  sent: string[] = [];
+  onopen: (() => void) | null = null;
+  onmessage: ((event: { data: unknown }) => void) | null = null;
+  onclose: (() => void) | null = null;
+  onerror: (() => void) | null = null;
+
+  send(data: string): void {
+    this.sent.push(data);
+  }
+
+  close(): void {
+    if (this.readyState === 3) return;
+    this.readyState = 3;
+    this.onclose?.();
+  }
+
+  open(): void {
+    this.readyState = 1;
+    this.onopen?.();
+  }
+
+  message(data: unknown): void {
+    this.onmessage?.({ data });
+  }
+
+  fail(): void {
+    this.close();
+  }
+}
+
+interface ScheduledTimer {
+  id: number;
+  fn: () => void;
+  delay: number;
+  cleared: boolean;
+  fired: boolean;
+}
+
+function createFakeTimers() {
+  const scheduled: ScheduledTimer[] = [];
+  let nextId = 1;
+  const setTimeoutFn = ((fn: () => void, delay?: number) => {
+    const timer: ScheduledTimer = {
+      id: nextId++,
+      fn,
+      delay: delay ?? 0,
+      cleared: false,
+      fired: false,
+    };
+    scheduled.push(timer);
+    return timer.id as unknown as ReturnType<typeof setTimeout>;
+  }) as typeof setTimeout;
+  const clearTimeoutFn = ((id?: unknown) => {
+    const timer = scheduled.find((t) => t.id === id);
+    if (timer) timer.cleared = true;
+  }) as typeof clearTimeout;
+  function runNext(): void {
+    const timer = scheduled.find((t) => !t.cleared && !t.fired);
+    if (!timer) throw new Error("no pending timer");
+    timer.fired = true;
+    timer.fn();
+  }
+  function pending(): ScheduledTimer[] {
+    return scheduled.filter((t) => !t.cleared && !t.fired);
+  }
+  return { scheduled, setTimeoutFn, clearTimeoutFn, runNext, pending };
+}
+
+function createHarness(overrides?: { runtimeSlot?: string; random?: () => number }) {
+  const sockets: FakeWebSocket[] = [];
+  const urls: string[] = [];
+  const timers = createFakeTimers();
+  const socket = new KernelSocket({
+    baseUrl: "https://app.matrix-os.com",
+    runtimeSlot: overrides?.runtimeSlot ?? "primary",
+    createWebSocket: (url) => {
+      urls.push(url);
+      const ws = new FakeWebSocket();
+      sockets.push(ws);
+      return ws;
+    },
+    setTimeoutFn: timers.setTimeoutFn,
+    clearTimeoutFn: timers.clearTimeoutFn,
+    random: overrides?.random ?? (() => 1),
+  });
+  return { socket, sockets, urls, timers, last: () => sockets[sockets.length - 1]! };
+}
+
+beforeEach(() => {
+  vi.spyOn(console, "warn").mockImplementation(() => {});
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("buildKernelWsUrl", () => {
+  it("converts http(s) to ws(s) and appends /ws", () => {
+    expect(buildKernelWsUrl("https://app.matrix-os.com", "primary")).toBe(
+      "wss://app.matrix-os.com/ws",
+    );
+    expect(buildKernelWsUrl("http://localhost:4000", "primary")).toBe("ws://localhost:4000/ws");
+  });
+
+  it("appends runtime only when slot is not primary", () => {
+    expect(buildKernelWsUrl("https://app.matrix-os.com", "vm-2")).toBe(
+      "wss://app.matrix-os.com/ws?runtime=vm-2",
+    );
+  });
+
+  it("strips a trailing slash from the base", () => {
+    expect(buildKernelWsUrl("https://app.matrix-os.com/", "primary")).toBe(
+      "wss://app.matrix-os.com/ws",
+    );
+  });
+});
+
+describe("KernelSocket: connection and routing", () => {
+  it("connects to the built URL", () => {
+    const h = createHarness({ runtimeSlot: "vm-2" });
+    h.socket.connect();
+    expect(h.urls).toEqual(["wss://app.matrix-os.com/ws?runtime=vm-2"]);
+  });
+
+  it("routes parsed messages to all subscribers", () => {
+    const h = createHarness();
+    const seen1: KernelServerMessage[] = [];
+    const seen2: KernelServerMessage[] = [];
+    h.socket.subscribe((m) => seen1.push(m));
+    h.socket.subscribe((m) => seen2.push(m));
+    h.socket.connect();
+    h.last().open();
+    h.last().message(JSON.stringify({ type: "kernel:text", text: "hi", requestId: "r1" }));
+    expect(seen1).toEqual([{ type: "kernel:text", text: "hi", requestId: "r1" }]);
+    expect(seen2).toEqual(seen1);
+  });
+
+  it("stops routing after unsubscribe", () => {
+    const h = createHarness();
+    const seen: KernelServerMessage[] = [];
+    const unsubscribe = h.socket.subscribe((m) => seen.push(m));
+    h.socket.connect();
+    h.last().open();
+    unsubscribe();
+    h.last().message(JSON.stringify({ type: "pong" }));
+    expect(seen).toEqual([]);
+  });
+
+  it("passes unknown message types through as-is for forward compat", () => {
+    const h = createHarness();
+    const seen: KernelServerMessage[] = [];
+    h.socket.subscribe((m) => seen.push(m));
+    h.socket.connect();
+    h.last().open();
+    h.last().message(JSON.stringify({ type: "future:event", payload: { x: 1 } }));
+    expect(seen).toEqual([{ type: "future:event", payload: { x: 1 } }]);
+  });
+
+  it("ignores malformed frames", () => {
+    const h = createHarness();
+    const seen: KernelServerMessage[] = [];
+    h.socket.subscribe((m) => seen.push(m));
+    h.socket.connect();
+    h.last().open();
+    h.last().message("{not json");
+    h.last().message(JSON.stringify({ noType: true }));
+    h.last().message(JSON.stringify({ type: "kernel:text" })); // known type missing required field
+    h.last().message(JSON.stringify(["array"]));
+    h.last().message(12345);
+    expect(seen).toEqual([]);
+  });
+
+  it("isolates subscriber failures so later subscribers still receive", () => {
+    const h = createHarness();
+    const seen: KernelServerMessage[] = [];
+    h.socket.subscribe(() => {
+      throw new Error("subscriber boom");
+    });
+    h.socket.subscribe((m) => seen.push(m));
+    h.socket.connect();
+    h.last().open();
+    h.last().message(JSON.stringify({ type: "pong" }));
+    expect(seen).toEqual([{ type: "pong" }]);
+  });
+
+  it("caps the subscriber registry at 64", () => {
+    const h = createHarness();
+    for (let i = 0; i < 64; i++) h.socket.subscribe(() => {});
+    expect(() => h.socket.subscribe(() => {})).toThrow();
+  });
+});
+
+describe("KernelSocket: send queue", () => {
+  it("queues sends while not connected and drains on open in order", () => {
+    const h = createHarness();
+    h.socket.connect();
+    h.socket.send({ type: "message", text: "a", requestId: "r1" });
+    h.socket.send({ type: "ping" });
+    expect(h.last().sent).toEqual([]);
+    h.last().open();
+    expect(h.last().sent.map((s) => JSON.parse(s))).toEqual([
+      { type: "message", text: "a", requestId: "r1" },
+      { type: "ping" },
+    ]);
+  });
+
+  it("sends immediately while connected", () => {
+    const h = createHarness();
+    h.socket.connect();
+    h.last().open();
+    h.socket.send({ type: "abort", requestId: "r1" });
+    expect(JSON.parse(h.last().sent[0]!)).toEqual({ type: "abort", requestId: "r1" });
+  });
+
+  it("caps the queue at 32, dropping the oldest with a warning", () => {
+    const h = createHarness();
+    h.socket.connect();
+    for (let i = 0; i < 40; i++) {
+      h.socket.send({ type: "message", text: `m${i}`, requestId: `r${i}` });
+    }
+    expect(console.warn).toHaveBeenCalled();
+    h.last().open();
+    const texts = h.last().sent.map((s) => (JSON.parse(s) as { text: string }).text);
+    expect(texts).toHaveLength(32);
+    expect(texts[0]).toBe("m8");
+    expect(texts[31]).toBe("m39");
+  });
+
+  it("drains queued messages after a reconnect", () => {
+    const h = createHarness();
+    h.socket.connect();
+    h.last().open();
+    h.last().fail();
+    h.socket.send({ type: "message", text: "while-down", requestId: "r9" });
+    h.timers.runNext();
+    h.last().open();
+    expect(JSON.parse(h.last().sent[0]!)).toEqual({
+      type: "message",
+      text: "while-down",
+      requestId: "r9",
+    });
+  });
+});
+
+describe("KernelSocket: reconnect backoff and state", () => {
+  it("starts connecting, then connected on open", () => {
+    const h = createHarness();
+    const states: KernelConnectionState[] = [];
+    h.socket.onStateChange((s) => states.push(s));
+    expect(h.socket.state).toBe("connecting");
+    h.socket.connect();
+    h.last().open();
+    expect(h.socket.state).toBe("connected");
+    expect(states).toContain("connected");
+  });
+
+  it("follows the 500ms * 2^n schedule capped at 30s (random=1)", () => {
+    const h = createHarness({ random: () => 1 });
+    h.socket.connect();
+    const delays: number[] = [];
+    for (let i = 0; i < 8; i++) {
+      h.last().fail();
+      const pending = h.timers.pending();
+      expect(pending).toHaveLength(1);
+      delays.push(pending[0]!.delay);
+      h.timers.runNext();
+    }
+    expect(delays).toEqual([500, 1000, 2000, 4000, 8000, 16000, 30000, 30000]);
+  });
+
+  it("applies 0.5 jitter as the lower bound (random=0 halves the delay)", () => {
+    const h = createHarness({ random: () => 0 });
+    h.socket.connect();
+    h.last().fail();
+    expect(h.timers.pending()[0]!.delay).toBe(250);
+  });
+
+  it("goes reconnecting on first failures, offline after 3, but keeps retrying", () => {
+    const h = createHarness();
+    h.socket.connect();
+    h.last().fail();
+    expect(h.socket.state).toBe("reconnecting");
+    h.timers.runNext();
+    h.last().fail();
+    expect(h.socket.state).toBe("reconnecting");
+    h.timers.runNext();
+    h.last().fail();
+    expect(h.socket.state).toBe("offline");
+    expect(h.timers.pending()).toHaveLength(1);
+    h.timers.runNext();
+    h.last().fail();
+    expect(h.socket.state).toBe("offline");
+    expect(h.timers.pending()).toHaveLength(1);
+  });
+
+  it("resets backoff and failure count after a successful connection", () => {
+    const h = createHarness();
+    h.socket.connect();
+    h.last().fail();
+    h.timers.runNext();
+    h.last().fail();
+    h.timers.runNext();
+    h.last().open();
+    expect(h.socket.state).toBe("connected");
+    h.last().fail();
+    expect(h.socket.state).toBe("reconnecting");
+    expect(h.timers.pending()[0]!.delay).toBe(500);
+  });
+
+  it("unsubscribing a state handler stops notifications", () => {
+    const h = createHarness();
+    const states: KernelConnectionState[] = [];
+    const off = h.socket.onStateChange((s) => states.push(s));
+    off();
+    h.socket.connect();
+    h.last().open();
+    expect(states).toEqual([]);
+  });
+});
+
+describe("KernelSocket: dispose", () => {
+  it("clears pending reconnect timers and closes the socket", () => {
+    const h = createHarness();
+    h.socket.connect();
+    h.last().fail();
+    expect(h.timers.pending()).toHaveLength(1);
+    h.socket.dispose();
+    expect(h.timers.pending()).toHaveLength(0);
+    expect(h.sockets).toHaveLength(1);
+  });
+
+  it("does not reconnect or deliver messages after dispose", () => {
+    const h = createHarness();
+    const seen: KernelServerMessage[] = [];
+    h.socket.subscribe((m) => seen.push(m));
+    h.socket.connect();
+    const ws = h.last();
+    ws.open();
+    h.socket.dispose();
+    ws.message(JSON.stringify({ type: "pong" }));
+    expect(seen).toEqual([]);
+    expect(h.timers.pending()).toHaveLength(0);
+    expect(h.sockets).toHaveLength(1);
+    h.socket.connect();
+    expect(h.sockets).toHaveLength(1);
+  });
+});

--- a/tests/desktop/session-merge.test.ts
+++ b/tests/desktop/session-merge.test.ts
@@ -1,0 +1,197 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { AppError } from "@desktop/shared/app-error";
+import type { ApiClient } from "@desktop/renderer/src/lib/api";
+import {
+  mergeAttachableSessions,
+  type WorkspaceSessionDTO,
+  type ZellijSessionDTO,
+} from "@desktop/renderer/src/lib/session-merge";
+import { useSessions } from "@desktop/renderer/src/stores/sessions";
+
+describe("mergeAttachableSessions", () => {
+  it("returns empty result for empty inputs", () => {
+    expect(mergeAttachableSessions([], [])).toEqual({ sessions: [], aliasMap: {} });
+  });
+
+  it("makes every zellij entry with a non-empty name attachable by name", () => {
+    const zellij: ZellijSessionDTO[] = [
+      { name: "main", status: "active" },
+      { name: "old", status: "exited" },
+    ];
+    const { sessions, aliasMap } = mergeAttachableSessions(zellij, []);
+    expect(sessions).toEqual([
+      { name: "main", attachName: "main", status: "active", source: "zellij" },
+      { name: "old", attachName: "old", status: "exited", source: "zellij" },
+    ]);
+    expect(aliasMap["main"]).toBe("main");
+    expect(aliasMap["old"]).toBe("old");
+  });
+
+  it("skips zellij entries with empty names", () => {
+    const { sessions, aliasMap } = mergeAttachableSessions([{ name: "" }, { name: "   " }], []);
+    expect(sessions).toEqual([]);
+    expect(aliasMap).toEqual({});
+  });
+
+  it("defaults zellij status to active when missing", () => {
+    const { sessions } = mergeAttachableSessions([{ name: "main" }], []);
+    expect(sessions[0]!.status).toBe("active");
+  });
+
+  it("makes workspace records attachable only when runtime.zellijSession is non-empty", () => {
+    const workspace: WorkspaceSessionDTO[] = [
+      { id: "sess_aaa", runtime: { zellijSession: "matrix-sess-aaa" } },
+      { id: "sess_bbb", runtime: { zellijSession: "" } },
+      { id: "sess_ccc", runtime: {} },
+      { id: "sess_ddd", runtime: null },
+      { id: "sess_eee" },
+    ];
+    const { sessions } = mergeAttachableSessions([], workspace);
+    expect(sessions).toEqual([
+      {
+        name: "matrix-sess-aaa",
+        attachName: "matrix-sess-aaa",
+        status: "active",
+        source: "workspace",
+      },
+    ]);
+  });
+
+  it("never exposes orchestrator UUIDs as attach targets", () => {
+    const workspace: WorkspaceSessionDTO[] = [
+      { id: "9b2f8c3e-1d4a-4f6b-8e2a-7c5d9e0f1a2b", runtime: null },
+      { sessionId: "sess_orchestrator", runtime: { zellijSession: null } },
+    ];
+    const { sessions, aliasMap } = mergeAttachableSessions([], workspace);
+    expect(sessions).toEqual([]);
+    expect(aliasMap).toEqual({});
+  });
+
+  it("maps every identifier of an attachable workspace record to the attach name", () => {
+    const workspace: WorkspaceSessionDTO[] = [
+      {
+        id: "sess_abc123",
+        sessionId: "sess_alias456",
+        name: "fix-login-bug",
+        runtime: { zellijSession: "matrix-sess-abc" },
+      },
+    ];
+    const { aliasMap } = mergeAttachableSessions([], workspace);
+    expect(aliasMap["sess_abc123"]).toBe("matrix-sess-abc");
+    expect(aliasMap["sess_alias456"]).toBe("matrix-sess-abc");
+    expect(aliasMap["fix-login-bug"]).toBe("matrix-sess-abc");
+    expect(aliasMap["matrix-sess-abc"]).toBe("matrix-sess-abc");
+  });
+
+  it("uses the workspace record name for display when present", () => {
+    const { sessions } = mergeAttachableSessions(
+      [],
+      [{ id: "sess_x", name: "review-pr", runtime: { zellijSession: "matrix-sess-x" } }],
+    );
+    expect(sessions[0]).toEqual({
+      name: "review-pr",
+      attachName: "matrix-sess-x",
+      status: "active",
+      source: "workspace",
+    });
+  });
+
+  it("maps exited and failed workspace statuses to exited", () => {
+    const { sessions } = mergeAttachableSessions(
+      [],
+      [
+        { id: "sess_1", status: "exited", runtime: { zellijSession: "z1" } },
+        { id: "sess_2", status: "failed", runtime: { zellijSession: "z2" } },
+        { id: "sess_3", status: "running", runtime: { zellijSession: "z3" } },
+      ],
+    );
+    expect(sessions.map((s) => s.status)).toEqual(["exited", "exited", "active"]);
+  });
+
+  it("dedupes workspace records against zellij entries with zellij status winning", () => {
+    const zellij: ZellijSessionDTO[] = [{ name: "matrix-sess-abc", status: "active" }];
+    const workspace: WorkspaceSessionDTO[] = [
+      { id: "sess_abc123", status: "exited", runtime: { zellijSession: "matrix-sess-abc" } },
+    ];
+    const { sessions, aliasMap } = mergeAttachableSessions(zellij, workspace);
+    expect(sessions).toHaveLength(1);
+    expect(sessions[0]).toEqual({
+      name: "matrix-sess-abc",
+      attachName: "matrix-sess-abc",
+      status: "active",
+      source: "zellij",
+    });
+    expect(aliasMap["sess_abc123"]).toBe("matrix-sess-abc");
+  });
+
+  it("dedupes two workspace records sharing one zellij session, keeping all aliases", () => {
+    const workspace: WorkspaceSessionDTO[] = [
+      { id: "sess_first", runtime: { zellijSession: "shared" } },
+      { id: "sess_second", runtime: { zellijSession: "shared" } },
+    ];
+    const { sessions, aliasMap } = mergeAttachableSessions([], workspace);
+    expect(sessions).toHaveLength(1);
+    expect(aliasMap["sess_first"]).toBe("shared");
+    expect(aliasMap["sess_second"]).toBe("shared");
+  });
+});
+
+describe("useSessions store", () => {
+  beforeEach(() => {
+    useSessions.setState(useSessions.getInitialState(), true);
+  });
+
+  function makeApi(get: ReturnType<typeof vi.fn>): ApiClient {
+    return {
+      baseUrl: "https://x.test",
+      get,
+      post: vi.fn(),
+      patch: vi.fn(),
+      delete: vi.fn(),
+      putText: vi.fn(),
+    } as ApiClient;
+  }
+
+  it("loads both routes and merges into attachable sessions", async () => {
+    const get = vi.fn().mockImplementation((path: string) => {
+      if (path === "/api/terminal/sessions") {
+        return Promise.resolve({ sessions: [{ name: "main", status: "active" }] });
+      }
+      if (path === "/api/sessions") {
+        return Promise.resolve({
+          sessions: [
+            { id: "sess_abc", runtime: { type: "zellij", status: "running", zellijSession: "matrix-sess-abc" } },
+            { id: "sess_orphan", runtime: { type: "pty", status: "running" } },
+          ],
+          nextCursor: null,
+        });
+      }
+      return Promise.reject(new AppError("notFound"));
+    });
+    await useSessions.getState().load(makeApi(get));
+
+    const state = useSessions.getState();
+    expect(get).toHaveBeenCalledWith("/api/terminal/sessions");
+    expect(get).toHaveBeenCalledWith("/api/sessions");
+    expect(state.sessions.map((s) => s.attachName)).toEqual(["main", "matrix-sess-abc"]);
+    expect(state.resolveAttachName("sess_abc")).toBe("matrix-sess-abc");
+    expect(state.resolveAttachName("sess_orphan")).toBeNull();
+    expect(state.resolveAttachName(null)).toBeNull();
+    expect(state.error).toBeNull();
+  });
+
+  it("keeps previous sessions and sets an error category when a fetch fails", async () => {
+    const ok = vi.fn().mockImplementation((path: string) =>
+      path === "/api/terminal/sessions"
+        ? Promise.resolve({ sessions: [{ name: "main", status: "active" }] })
+        : Promise.resolve({ sessions: [], nextCursor: null }),
+    );
+    await useSessions.getState().load(makeApi(ok));
+
+    const bad = vi.fn().mockRejectedValue(new AppError("offline"));
+    await useSessions.getState().load(makeApi(bad));
+
+    expect(useSessions.getState().sessions.map((s) => s.attachName)).toEqual(["main"]);
+    expect(useSessions.getState().error).toBe("offline");
+  });
+});

--- a/tests/desktop/session-merge.test.ts
+++ b/tests/desktop/session-merge.test.ts
@@ -152,6 +152,14 @@ describe("useSessions store", () => {
     } as ApiClient;
   }
 
+  function deferred<T>() {
+    let resolve!: (value: T) => void;
+    const promise = new Promise<T>((res) => {
+      resolve = res;
+    });
+    return { promise, resolve };
+  }
+
   it("loads both routes and merges into attachable sessions", async () => {
     const get = vi.fn().mockImplementation((path: string) => {
       if (path === "/api/terminal/sessions") {
@@ -193,6 +201,35 @@ describe("useSessions store", () => {
 
     expect(useSessions.getState().sessions.map((s) => s.attachName)).toEqual(["main"]);
     expect(useSessions.getState().error).toBe("offline");
+  });
+
+  it("ignores stale slower load results after a newer load finishes", async () => {
+    const firstTerminal = deferred<{ sessions: unknown[] }>();
+    const firstWorkspace = deferred<{ sessions: unknown[]; nextCursor: null }>();
+    let call = 0;
+    const get = vi.fn((path: string) => {
+      call += 1;
+      if (call === 1 && path === "/api/terminal/sessions") return firstTerminal.promise;
+      if (call === 2 && path === "/api/sessions") return firstWorkspace.promise;
+      if (path === "/api/terminal/sessions") {
+        return Promise.resolve({ sessions: [{ name: "new-session", status: "active" }] });
+      }
+      return Promise.resolve({ sessions: [], nextCursor: null });
+    });
+
+    const staleLoad = useSessions.getState().load(makeApi(get));
+    const freshLoad = useSessions.getState().load(makeApi(get));
+    await freshLoad;
+
+    firstTerminal.resolve({ sessions: [{ name: "old-session", status: "active" }] });
+    firstWorkspace.resolve({ sessions: [], nextCursor: null });
+    await staleLoad;
+
+    expect(useSessions.getState().sessions.map((session) => session.attachName)).toEqual([
+      "new-session",
+    ]);
+    expect(useSessions.getState().loading).toBe(false);
+    expect(useSessions.getState().error).toBeNull();
   });
 
   it("clears a stale load error while a refresh is pending", async () => {

--- a/tests/desktop/session-merge.test.ts
+++ b/tests/desktop/session-merge.test.ts
@@ -194,4 +194,26 @@ describe("useSessions store", () => {
     expect(useSessions.getState().sessions.map((s) => s.attachName)).toEqual(["main"]);
     expect(useSessions.getState().error).toBe("offline");
   });
+
+  it("clears a stale load error while a refresh is pending", async () => {
+    let resolveTerminal: ((value: { sessions: unknown[] }) => void) | null = null;
+    const terminal = new Promise<{ sessions: unknown[] }>((resolve) => {
+      resolveTerminal = resolve;
+    });
+    const get = vi.fn().mockImplementation((path: string) => {
+      if (path === "/api/terminal/sessions") {
+        return terminal;
+      }
+      return Promise.resolve({ sessions: [], nextCursor: null });
+    });
+
+    useSessions.setState({ error: "offline" });
+    const load = useSessions.getState().load(makeApi(get));
+
+    expect(useSessions.getState().loading).toBe(true);
+    expect(useSessions.getState().error).toBeNull();
+
+    resolveTerminal?.({ sessions: [] });
+    await load;
+  });
 });

--- a/tests/desktop/sessions-view.test.tsx
+++ b/tests/desktop/sessions-view.test.tsx
@@ -1,0 +1,46 @@
+// @vitest-environment jsdom
+
+import React from "react";
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import SessionsView from "../../desktop/src/renderer/src/features/sessions/SessionsView";
+import { useConnection } from "../../desktop/src/renderer/src/stores/connection";
+import { useSessions } from "../../desktop/src/renderer/src/stores/sessions";
+import { useUi } from "../../desktop/src/renderer/src/stores/ui";
+
+describe("SessionsView", () => {
+  beforeEach(() => {
+    useConnection.setState({
+      status: "signed-in",
+      handle: "operator",
+      platformHost: "https://x.test",
+      runtimeSlot: "primary",
+      api: null,
+    });
+    useSessions.setState({
+      sessions: [
+        {
+          name: "main",
+          attachName: "main",
+          status: "active",
+          source: "zellij",
+        },
+      ],
+      aliasMap: { main: "main" },
+      loading: false,
+      error: "offline",
+    });
+    useUi.setState({ view: { kind: "sessions" } });
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("keeps cached sessions visible while surfacing refresh errors", () => {
+    render(<SessionsView />);
+
+    expect(screen.getByRole("alert").textContent).toContain("Can't reach Matrix OS");
+    expect(screen.getByText("main")).toBeTruthy();
+  });
+});

--- a/tests/desktop/terminal-view.test.tsx
+++ b/tests/desktop/terminal-view.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import React from "react";
-import { cleanup, render, screen } from "@testing-library/react";
+import { act, cleanup, render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ShellSocketEvents } from "@desktop/renderer/src/lib/shell-socket";
 import TerminalView from "@desktop/renderer/src/features/terminal/TerminalView";
@@ -76,7 +76,9 @@ describe("TerminalView session switching", () => {
   it("clears the ended banner before the next session emits state", () => {
     const { rerender } = render(<TerminalView sessionName="alpha" />);
     const alphaEvents = attachMock.mock.calls[0]?.[1] as ShellSocketEvents;
-    alphaEvents.onExit(7);
+    act(() => {
+      alphaEvents.onExit(7);
+    });
 
     expect(screen.getByText("Session exited (code 7).")).toBeTruthy();
 

--- a/tests/desktop/terminal-view.test.tsx
+++ b/tests/desktop/terminal-view.test.tsx
@@ -1,0 +1,87 @@
+// @vitest-environment jsdom
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ShellSocketEvents } from "@desktop/renderer/src/lib/shell-socket";
+import TerminalView from "@desktop/renderer/src/features/terminal/TerminalView";
+
+const attachMock = vi.fn();
+
+vi.mock("@xterm/xterm", () => ({
+  Terminal: class FakeTerminal {
+    cols = 80;
+    rows = 24;
+
+    loadAddon(): void {}
+    open(): void {}
+    write(): void {}
+    clear(): void {}
+    focus(): void {}
+    dispose(): void {}
+    onData(): { dispose: () => void } {
+      return { dispose: () => {} };
+    }
+  },
+}));
+
+vi.mock("@xterm/addon-fit", () => ({
+  FitAddon: class FakeFitAddon {
+    fit(): void {}
+  },
+}));
+
+vi.mock("@xterm/addon-serialize", () => ({
+  SerializeAddon: class FakeSerializeAddon {
+    serialize(): string {
+      return "";
+    }
+  },
+}));
+
+vi.mock("@xterm/addon-webgl", () => ({
+  WebglAddon: class FakeWebglAddon {},
+}));
+
+vi.mock("@desktop/renderer/src/features/terminal/terminal-runtime", () => ({
+  getAttachManager: () => ({
+    activeSessionName: null,
+    attach: attachMock,
+    cacheBuffer: vi.fn(),
+    detachActive: vi.fn(),
+    getCachedBuffer: vi.fn(() => null),
+  }),
+}));
+
+describe("TerminalView session switching", () => {
+  beforeEach(() => {
+    attachMock.mockReset();
+    attachMock.mockImplementation((_sessionName: string, _events: ShellSocketEvents) => ({
+      resize: vi.fn(),
+      write: vi.fn(),
+    }));
+    vi.stubGlobal(
+      "ResizeObserver",
+      class FakeResizeObserver {
+        observe(): void {}
+        disconnect(): void {}
+      },
+    );
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.unstubAllGlobals();
+  });
+
+  it("clears the ended banner before the next session emits state", () => {
+    const { rerender } = render(<TerminalView sessionName="alpha" />);
+    const alphaEvents = attachMock.mock.calls[0]?.[1] as ShellSocketEvents;
+    alphaEvents.onExit(7);
+
+    expect(screen.getByText("Session exited (code 7).")).toBeTruthy();
+
+    rerender(<TerminalView sessionName="beta" />);
+
+    expect(screen.queryByText("Session exited (code 7).")).toBeNull();
+    expect(screen.getByText(/Connecting/)).toBeTruthy();
+  });
+});

--- a/tests/desktop/terminal-view.test.tsx
+++ b/tests/desktop/terminal-view.test.tsx
@@ -1,4 +1,5 @@
 // @vitest-environment jsdom
+import React from "react";
 import { cleanup, render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ShellSocketEvents } from "@desktop/renderer/src/lib/shell-socket";

--- a/tests/e2e/desktop/fixtures/stub-gateway.ts
+++ b/tests/e2e/desktop/fixtures/stub-gateway.ts
@@ -262,6 +262,8 @@ export async function startStubGateway(): Promise<StubGateway> {
     state,
     close: () =>
       new Promise<void>((resolve, reject) => {
+        for (const client of terminalWss.clients) client.terminate();
+        for (const client of kernelWss.clients) client.terminate();
         terminalWss.close();
         kernelWss.close();
         server.close((err) => (err ? reject(err) : resolve()));

--- a/tests/e2e/desktop/fixtures/stub-gateway.ts
+++ b/tests/e2e/desktop/fixtures/stub-gateway.ts
@@ -199,8 +199,8 @@ export async function startStubGateway(): Promise<StubGateway> {
     socket.destroy();
   });
 
-  let seq = 0;
   function runTerminalSession(ws: WebSocket, session: string): void {
+    let seq = 0;
     if (session !== "matrix-task-1") {
       ws.send(JSON.stringify({ type: "error", code: "session_not_found", message: "Session not found" }));
       ws.close();

--- a/tests/e2e/desktop/fixtures/stub-gateway.ts
+++ b/tests/e2e/desktop/fixtures/stub-gateway.ts
@@ -245,7 +245,7 @@ export async function startStubGateway(): Promise<StubGateway> {
         ws.send(JSON.stringify({ type: "kernel:init", sessionId: "kernel-sess-1", requestId }));
         ws.send(JSON.stringify({ type: "kernel:text", text: "On it. ", requestId }));
         ws.send(JSON.stringify({ type: "kernel:tool_start", tool: "Bash", requestId }));
-        ws.send(JSON.stringify({ type: "kernel:tool_end", input: "ls", requestId }));
+        ws.send(JSON.stringify({ type: "kernel:tool_end", input: { command: "ls" }, requestId }));
         ws.send(JSON.stringify({ type: "kernel:text", text: "Done — all tests pass.", requestId }));
         ws.send(JSON.stringify({ type: "kernel:result", data: "ok", requestId }));
       }

--- a/tests/e2e/desktop/fixtures/stub-gateway.ts
+++ b/tests/e2e/desktop/fixtures/stub-gateway.ts
@@ -1,0 +1,270 @@
+// Minimal gateway stub implementing the contract subset the Operator desktop
+// app consumes (specs/094-electron-macos-shell/contracts/gateway-contract.md).
+// Device auth approves instantly; one project with tasks; one fake zellij echo
+// session with sequence-numbered output; scripted kernel stream.
+import { createServer, type IncomingMessage, type Server, type ServerResponse } from "node:http";
+import { WebSocketServer, type WebSocket } from "ws";
+
+export interface StubGateway {
+  url: string;
+  port: number;
+  close(): Promise<void>;
+  state: {
+    deviceCodeRequests: number;
+    tokenRequests: number;
+    terminalInputs: string[];
+    kernelMessages: Array<Record<string, unknown>>;
+  };
+}
+
+const TOKEN = "stub-token-1";
+
+function json(res: ServerResponse, status: number, body: unknown): void {
+  res.writeHead(status, { "content-type": "application/json" });
+  res.end(JSON.stringify(body));
+}
+
+async function readBody(req: IncomingMessage): Promise<Record<string, unknown>> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of req) chunks.push(chunk as Buffer);
+  const raw = Buffer.concat(chunks).toString("utf8");
+  if (!raw) return {};
+  try {
+    return JSON.parse(raw) as Record<string, unknown>;
+  } catch {
+    return {};
+  }
+}
+
+const TASKS = [
+  {
+    id: "task-1",
+    projectSlug: "matrix-os",
+    title: "Fix the failing auth tests",
+    description: "",
+    status: "todo",
+    priority: "high",
+    order: 1,
+    parentTaskId: null,
+    linkedSessionId: "sess-orch-1",
+    linkedWorktreeId: null,
+    previewIds: [],
+    tags: ["auth"],
+    updatedAt: new Date(0).toISOString(),
+    revision: 1,
+  },
+  {
+    id: "task-2",
+    projectSlug: "matrix-os",
+    title: "Polish the board design",
+    description: "",
+    status: "running",
+    priority: "normal",
+    order: 1,
+    parentTaskId: null,
+    linkedSessionId: null,
+    linkedWorktreeId: null,
+    previewIds: [],
+    tags: [],
+    updatedAt: new Date(0).toISOString(),
+    revision: 1,
+  },
+];
+
+export async function startStubGateway(): Promise<StubGateway> {
+  const state: StubGateway["state"] = {
+    deviceCodeRequests: 0,
+    tokenRequests: 0,
+    terminalInputs: [],
+    kernelMessages: [],
+  };
+
+  const server: Server = createServer((req, res) => {
+    void handle(req, res);
+  });
+
+  async function handle(req: IncomingMessage, res: ServerResponse): Promise<void> {
+    const url = new URL(req.url ?? "/", "http://localhost");
+    const path = url.pathname;
+
+    if (req.method === "POST" && path === "/api/auth/device/code") {
+      state.deviceCodeRequests += 1;
+      await readBody(req);
+      json(res, 200, {
+        deviceCode: "stub-device-code",
+        userCode: "STUB-1234",
+        verificationUri: "https://example.test/activate",
+        expiresIn: 600,
+        interval: 1,
+      });
+      return;
+    }
+
+    if (req.method === "POST" && path === "/api/auth/device/token") {
+      state.tokenRequests += 1;
+      await readBody(req);
+      json(res, 200, {
+        accessToken: TOKEN,
+        expiresAt: Date.now() + 3_600_000,
+        userId: "user-1",
+        handle: "neo",
+      });
+      return;
+    }
+
+    // Everything below requires the bearer header (verifies header injection).
+    if (req.headers.authorization !== `Bearer ${TOKEN}`) {
+      json(res, 401, { error: "unauthorized" });
+      return;
+    }
+
+    if (path === "/api/workspace/projects") {
+      json(res, 200, { projects: [{ slug: "matrix-os", name: "Matrix OS" }] });
+      return;
+    }
+    if (path === "/api/projects/matrix-os/tasks" && req.method === "GET") {
+      json(res, 200, { tasks: TASKS, nextCursor: null });
+      return;
+    }
+    if (path.startsWith("/api/projects/matrix-os/tasks/") && req.method === "PATCH") {
+      const id = path.split("/").pop();
+      const body = await readBody(req);
+      const task = TASKS.find((t) => t.id === id);
+      json(res, 200, { task: { ...(task ?? TASKS[0]), ...body } });
+      return;
+    }
+    if (path === "/api/projects/matrix-os/tasks" && req.method === "POST") {
+      const body = await readBody(req);
+      json(res, 201, {
+        task: {
+          ...TASKS[0],
+          id: `task-${Date.now()}`,
+          title: typeof body.title === "string" ? body.title : "New task",
+          status: typeof body.status === "string" ? body.status : "todo",
+          linkedSessionId: null,
+          tags: [],
+        },
+      });
+      return;
+    }
+    if (path === "/api/terminal/sessions") {
+      json(res, 200, { sessions: [{ name: "matrix-task-1", status: "active" }] });
+      return;
+    }
+    if (path === "/api/sessions") {
+      json(res, 200, {
+        sessions: [
+          { id: "sess-orch-1", name: "Task 1 session", runtime: { zellijSession: "matrix-task-1" } },
+          { id: "sess-orch-2", name: "Orchestrator-only", runtime: {} },
+        ],
+        nextCursor: null,
+      });
+      return;
+    }
+    if (path === "/api/system/info") {
+      json(res, 200, {
+        version: "stub",
+        uptime: 1,
+        runtime: { handle: "neo", runtimeSlot: "primary" },
+        resources: { cpuCount: 8, memoryTotal: 8e9, memoryFree: 4e9, diskTotal: 1e11, diskFree: 5e10 },
+      });
+      return;
+    }
+    json(res, 404, { error: "not found" });
+  }
+
+  const terminalWss = new WebSocketServer({ noServer: true });
+  const kernelWss = new WebSocketServer({ noServer: true });
+
+  server.on("upgrade", (req, socket, head) => {
+    const url = new URL(req.url ?? "/", "http://localhost");
+    // WS upgrades carry the bearer header via the app's header injection.
+    if (req.headers.authorization !== `Bearer ${TOKEN}`) {
+      socket.write("HTTP/1.1 401 Unauthorized\r\n\r\n");
+      socket.destroy();
+      return;
+    }
+    if (url.pathname === "/ws/terminal/session") {
+      terminalWss.handleUpgrade(req, socket, head, (ws) => {
+        runTerminalSession(ws, url.searchParams.get("session") ?? "");
+      });
+      return;
+    }
+    if (url.pathname === "/ws") {
+      kernelWss.handleUpgrade(req, socket, head, (ws) => {
+        runKernel(ws);
+      });
+      return;
+    }
+    socket.destroy();
+  });
+
+  let seq = 0;
+  function runTerminalSession(ws: WebSocket, session: string): void {
+    if (session !== "matrix-task-1") {
+      ws.send(JSON.stringify({ type: "error", code: "session_not_found", message: "Session not found" }));
+      ws.close();
+      return;
+    }
+    ws.send(JSON.stringify({ type: "attached", session, state: "running", fromSeq: seq }));
+    seq += 1;
+    ws.send(JSON.stringify({ type: "output", seq, data: "stub-shell$ " }));
+    ws.on("message", (raw) => {
+      let msg: Record<string, unknown>;
+      try {
+        msg = JSON.parse(String(raw)) as Record<string, unknown>;
+      } catch {
+        return;
+      }
+      if (msg.type === "input" && typeof msg.data === "string") {
+        state.terminalInputs.push(msg.data);
+        seq += 1;
+        // Echo back like a shell, with deterministic seq numbering.
+        ws.send(JSON.stringify({ type: "output", seq, data: msg.data.replace(/\r/g, "\r\nran!\r\nstub-shell$ ") }));
+      } else if (msg.type === "ping") {
+        ws.send(JSON.stringify({ type: "pong" }));
+      }
+    });
+  }
+
+  function runKernel(ws: WebSocket): void {
+    ws.on("message", (raw) => {
+      let msg: Record<string, unknown>;
+      try {
+        msg = JSON.parse(String(raw)) as Record<string, unknown>;
+      } catch {
+        return;
+      }
+      state.kernelMessages.push(msg);
+      if (msg.type === "ping") {
+        ws.send(JSON.stringify({ type: "pong" }));
+        return;
+      }
+      if (msg.type === "message") {
+        const requestId = typeof msg.requestId === "string" ? msg.requestId : "r1";
+        ws.send(JSON.stringify({ type: "kernel:init", sessionId: "kernel-sess-1", requestId }));
+        ws.send(JSON.stringify({ type: "kernel:text", text: "On it. ", requestId }));
+        ws.send(JSON.stringify({ type: "kernel:tool_start", tool: "Bash", requestId }));
+        ws.send(JSON.stringify({ type: "kernel:tool_end", input: "ls", requestId }));
+        ws.send(JSON.stringify({ type: "kernel:text", text: "Done — all tests pass.", requestId }));
+        ws.send(JSON.stringify({ type: "kernel:result", data: "ok", requestId }));
+      }
+    });
+  }
+
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const address = server.address();
+  const port = typeof address === "object" && address ? address.port : 0;
+
+  return {
+    url: `http://127.0.0.1:${port}`,
+    port,
+    state,
+    close: () =>
+      new Promise<void>((resolve, reject) => {
+        terminalWss.close();
+        kernelWss.close();
+        server.close((err) => (err ? reject(err) : resolve()));
+      }),
+  };
+}


### PR DESCRIPTION
## Summary
- Adds terminal session runtime, kernel socket wiring, attach manager, and terminal/session tests.
- Part of the 094 Operator desktop stack split from original PR #507.
- Draft until the full stack validation and screenshots are refreshed.

## Validation
- Rebased onto current main after #506 merged.
- Rebuilt stack final tree matches the original #507 tree exactly.
- Per-layer CI/Greptile still needs to settle before review-ready.

## Invariants
- Source of truth: desktop app source under desktop/, specs/docs, and root workspace metadata in this stack; no owner runtime data is modified.
- Lock/transaction scope: no Postgres transaction scope is introduced in this layer; desktop local state remains scoped to the Electron app and existing gateway/platform APIs.
- Acceptable orphan states: stack PRs are draft and must land in order; partial stack landing is not a supported release state.
- Auth source of truth: Clerk/device auth and existing gateway token handling remain authoritative; this stack does not add a second auth authority.
- Deferred scope: packaged distribution, production desktop rollout, and customer VPS host-bundle deploy are outside this stack.