### PR TITLE
feat(desktop): add shell socket client

### DIFF
--- a/desktop/src/renderer/src/lib/shell-socket.ts
+++ b/desktop/src/renderer/src/lib/shell-socket.ts
@@ -80,6 +80,18 @@ function clampInt(value: number, min: number, max: number): number {
   return Math.min(max, Math.max(min, Math.floor(value)));
 }
 
+function nextChunkEnd(value: string, start: number): number {
+  let end = Math.min(start + INPUT_CHUNK_CHARS, value.length);
+  if (end < value.length) {
+    const prev = value.charCodeAt(end - 1);
+    const next = value.charCodeAt(end);
+    if (prev >= 0xd800 && prev <= 0xdbff && next >= 0xdc00 && next <= 0xdfff) {
+      end -= 1;
+    }
+  }
+  return end <= start ? Math.min(start + INPUT_CHUNK_CHARS, value.length) : end;
+}
+
 function defaultCreateWebSocket(url: string): WebSocketLike {
   return new WebSocket(url) as unknown as WebSocketLike;
 }
@@ -143,8 +155,10 @@ export class ShellSocket {
   sendInput(data: string): void {
     if (this.disposed || this.currentState === "ended" || this.currentState === "fatal") return;
     if (data.length === 0) return;
-    for (let offset = 0; offset < data.length; offset += INPUT_CHUNK_CHARS) {
-      const chunk = data.slice(offset, offset + INPUT_CHUNK_CHARS);
+    for (let offset = 0; offset < data.length;) {
+      const end = nextChunkEnd(data, offset);
+      const chunk = data.slice(offset, end);
+      offset = end;
       if (this.currentState === "attached" && this.socket !== null) {
         this.sendFrame({ type: "input", data: chunk });
       } else {
@@ -177,8 +191,9 @@ export class ShellSocket {
   detach(): void {
     if (this.disposed || this.currentState === "ended" || this.currentState === "fatal") return;
     this.detachPending = true;
-    if (this.socket === null) {
+    if (this.currentState !== "attached") {
       const sessionName = this.attachedSessionName ?? this.opts.sessionName ?? null;
+      this.teardownSocket();
       this.clearAllTimers();
       this.setState("ended");
       if (sessionName !== null && sessionName.length > 0) {
@@ -308,6 +323,9 @@ export class ShellSocket {
       return;
     }
     const frame = parsed as Record<string, unknown>;
+    if (this.currentState === "ended" && !(this.detachPending && frame.type === "attached")) {
+      return;
+    }
     switch (frame.type) {
       case "attached":
         this.handleAttached(frame);
@@ -342,8 +360,8 @@ export class ShellSocket {
       return;
     }
     this.failedAttempts = 0;
-    this.setState("attached");
     this.flushPendingInput();
+    this.setState("attached");
     this.scheduleAttachTimers();
   }
 
@@ -365,8 +383,8 @@ export class ShellSocket {
       console.warn("[shell-socket] ignoring invalid exit frame");
       return;
     }
-    this.opts.events.onExit(code);
     this.endSession();
+    this.opts.events.onExit(code);
   }
 
   private handleErrorFrame(frame: Record<string, unknown>): void {

--- a/desktop/src/renderer/src/lib/shell-socket.ts
+++ b/desktop/src/renderer/src/lib/shell-socket.ts
@@ -47,6 +47,7 @@ const BACKOFF_BASE_MS = 500;
 const BACKOFF_CAP_MS = 30_000;
 const BACKOFF_JITTER = 0.5;
 const BACKOFF_MAX_EXPONENT = 10;
+const ATTACH_HANDSHAKE_TIMEOUT_MS = BACKOFF_BASE_MS;
 const CONNECTION_LOST_AFTER_FAILURES = 2;
 const RESIZE_DEBOUNCE_STARTUP_MS = 220;
 const RESIZE_DEBOUNCE_STEADY_MS = 90;
@@ -95,6 +96,7 @@ export class ShellSocket {
   private started = false;
   private disposed = false;
   private lastSeqValue = 0;
+  private receivedOutput = false;
   private attachedSessionName: string | null = null;
   private failedAttempts = 0;
   private pendingInput: string[] = [];
@@ -106,6 +108,7 @@ export class ShellSocket {
   private resizeTimer: TimerHandle | null = null;
   private settleTimer: TimerHandle | null = null;
   private fallbackTimer: TimerHandle | null = null;
+  private handshakeTimer: TimerHandle | null = null;
 
   constructor(options: ShellSocketOptions) {
     const hasSession = typeof options.sessionName === "string" && options.sessionName.length > 0;
@@ -214,7 +217,16 @@ export class ShellSocket {
       this.scheduleReconnect();
     };
 
-    socket.onopen = () => undefined;
+    socket.onopen = () => {
+      if (this.socket !== socket) return;
+      this.clearAttachHandshakeTimer();
+      this.handshakeTimer = this.setT(() => {
+        if (this.socket !== socket || this.disposed) return;
+        this.handshakeTimer = null;
+        console.warn("[shell-socket] attach handshake timed out");
+        onClosed();
+      }, ATTACH_HANDSHAKE_TIMEOUT_MS);
+    };
     socket.onmessage = (event) => {
       if (this.socket === socket) this.handleMessage(event.data);
     };
@@ -235,7 +247,7 @@ export class ShellSocket {
       ? (this.attachedSessionName ?? this.opts.sessionName ?? null)
       : (this.opts.sessionName ?? null);
     if (sessionName !== null && sessionName.length > 0) {
-      const fromSeq = isReconnect ? this.lastSeqValue + 1 : LIVE_TAIL_FROM_SEQ;
+      const fromSeq = isReconnect && this.receivedOutput ? this.lastSeqValue + 1 : LIVE_TAIL_FROM_SEQ;
       return `${base}/ws/terminal/session?session=${encodeURIComponent(sessionName)}&fromSeq=${fromSeq}${runtimeSuffix}`;
     }
     return `${base}/ws/terminal?cwd=${encodeURIComponent(this.opts.cwd ?? "")}${runtimeSuffix}`;
@@ -252,6 +264,7 @@ export class ShellSocket {
       this.clearT(this.fallbackTimer);
       this.fallbackTimer = null;
     }
+    this.clearAttachHandshakeTimer();
     const exponent = Math.min(this.failedAttempts, BACKOFF_MAX_EXPONENT);
     const baseDelay = Math.min(BACKOFF_BASE_MS * 2 ** exponent, BACKOFF_CAP_MS);
     const delay = baseDelay * (1 - BACKOFF_JITTER * this.random());
@@ -308,6 +321,7 @@ export class ShellSocket {
   }
 
   private handleAttached(frame: Record<string, unknown>): void {
+    this.clearAttachHandshakeTimer();
     if (typeof frame.session === "string" && frame.session.length > 0) {
       this.attachedSessionName = frame.session;
     }
@@ -325,6 +339,7 @@ export class ShellSocket {
       return;
     }
     this.lastSeqValue = seq;
+    this.receivedOutput = true;
     this.opts.events.onOutput(data, seq);
   }
 
@@ -339,6 +354,7 @@ export class ShellSocket {
   }
 
   private handleErrorFrame(frame: Record<string, unknown>): void {
+    this.clearAttachHandshakeTimer();
     const code = typeof frame.code === "string" ? frame.code : "unknown";
     if (FATAL_ERROR_CODES.has(code)) {
       this.teardownSocket();
@@ -419,8 +435,21 @@ export class ShellSocket {
     socket.onerror = null;
   }
 
+  private clearAttachHandshakeTimer(): void {
+    if (this.handshakeTimer !== null) {
+      this.clearT(this.handshakeTimer);
+      this.handshakeTimer = null;
+    }
+  }
+
   private clearAllTimers(): void {
-    for (const key of ["reconnectTimer", "resizeTimer", "settleTimer", "fallbackTimer"] as const) {
+    for (const key of [
+      "reconnectTimer",
+      "resizeTimer",
+      "settleTimer",
+      "fallbackTimer",
+      "handshakeTimer",
+    ] as const) {
       const handle = this[key];
       if (handle !== null) {
         this.clearT(handle);

--- a/desktop/src/renderer/src/lib/shell-socket.ts
+++ b/desktop/src/renderer/src/lib/shell-socket.ts
@@ -331,14 +331,17 @@ export class ShellSocket {
         this.handleAttached(frame);
         return;
       case "output":
+        if (this.currentState !== "attached") return;
         this.handleOutput(frame);
         return;
       case "exit":
+        if (this.currentState !== "attached") return;
         this.handleExit(frame);
         return;
       case "pong":
         return;
       case "replay-evicted":
+        if (this.currentState !== "attached") return;
         this.opts.events.onGap();
         return;
       case "error":
@@ -366,6 +369,7 @@ export class ShellSocket {
   }
 
   private handleOutput(frame: Record<string, unknown>): void {
+    if (this.currentState !== "attached") return;
     const seq = frame.seq;
     const data = frame.data;
     if (typeof seq !== "number" || !Number.isFinite(seq) || typeof data !== "string") {
@@ -378,6 +382,7 @@ export class ShellSocket {
   }
 
   private handleExit(frame: Record<string, unknown>): void {
+    if (this.currentState !== "attached") return;
     const code = frame.code;
     if (typeof code !== "number" || !Number.isFinite(code)) {
       console.warn("[shell-socket] ignoring invalid exit frame");

--- a/desktop/src/renderer/src/lib/shell-socket.ts
+++ b/desktop/src/renderer/src/lib/shell-socket.ts
@@ -280,7 +280,7 @@ export class ShellSocket {
   }
 
   private scheduleReconnect(): void {
-    if (this.disposed || this.currentState === "ended" || this.currentState === "fatal") return;
+    if (this.reconnectCancelled()) return;
     // Attach-lifecycle timers belong to the connection that just dropped.
     if (this.settleTimer !== null) {
       this.clearT(this.settleTimer);
@@ -297,14 +297,18 @@ export class ShellSocket {
     this.setState(
       this.failedAttempts >= CONNECTION_LOST_AFTER_FAILURES ? "connection-lost" : "reconnecting",
     );
-    if (this.disposed || this.currentState === "ended" || this.currentState === "fatal") return;
+    if (this.reconnectCancelled()) return;
     this.failedAttempts += 1;
     if (this.reconnectTimer !== null) this.clearT(this.reconnectTimer);
     this.reconnectTimer = this.setT(() => {
       this.reconnectTimer = null;
-      if (this.disposed || this.currentState === "ended" || this.currentState === "fatal") return;
+      if (this.reconnectCancelled()) return;
       this.openSocket(true);
     }, delay);
+  }
+
+  private reconnectCancelled(): boolean {
+    return this.disposed || this.currentState === "ended" || this.currentState === "fatal";
   }
 
   private handleMessage(data: unknown): void {

--- a/desktop/src/renderer/src/lib/shell-socket.ts
+++ b/desktop/src/renderer/src/lib/shell-socket.ts
@@ -297,10 +297,12 @@ export class ShellSocket {
     this.setState(
       this.failedAttempts >= CONNECTION_LOST_AFTER_FAILURES ? "connection-lost" : "reconnecting",
     );
+    if (this.disposed || this.currentState === "ended" || this.currentState === "fatal") return;
     this.failedAttempts += 1;
     if (this.reconnectTimer !== null) this.clearT(this.reconnectTimer);
     this.reconnectTimer = this.setT(() => {
       this.reconnectTimer = null;
+      if (this.disposed || this.currentState === "ended" || this.currentState === "fatal") return;
       this.openSocket(true);
     }, delay);
   }

--- a/desktop/src/renderer/src/lib/shell-socket.ts
+++ b/desktop/src/renderer/src/lib/shell-socket.ts
@@ -98,6 +98,7 @@ export class ShellSocket {
   private lastSeqValue = 0;
   private receivedOutput = false;
   private attachedSessionName: string | null = null;
+  private detachPending = false;
   private failedAttempts = 0;
   private pendingInput: string[] = [];
   private lastKnownDims: Dims | null = null;
@@ -175,7 +176,17 @@ export class ShellSocket {
 
   detach(): void {
     if (this.disposed || this.currentState === "ended" || this.currentState === "fatal") return;
-    this.sendFrame({ type: "detach" });
+    this.detachPending = true;
+    if (this.socket === null) {
+      const sessionName = this.attachedSessionName ?? this.opts.sessionName ?? null;
+      this.clearAllTimers();
+      this.setState("ended");
+      if (sessionName !== null && sessionName.length > 0) {
+        this.openSocket(true);
+      }
+      return;
+    }
+    this.sendDetachFrame();
     this.endSession();
   }
 
@@ -325,6 +336,11 @@ export class ShellSocket {
     if (typeof frame.session === "string" && frame.session.length > 0) {
       this.attachedSessionName = frame.session;
     }
+    if (this.detachPending) {
+      this.sendDetachFrame();
+      this.endSession();
+      return;
+    }
     this.failedAttempts = 0;
     this.setState("attached");
     this.flushPendingInput();
@@ -408,6 +424,11 @@ export class ShellSocket {
     } catch (err: unknown) {
       console.warn("[shell-socket] websocket send failed:", errorText(err));
     }
+  }
+
+  private sendDetachFrame(): void {
+    this.sendFrame({ type: "detach" });
+    this.detachPending = false;
   }
 
   private endSession(): void {

--- a/desktop/src/renderer/src/lib/shell-socket.ts
+++ b/desktop/src/renderer/src/lib/shell-socket.ts
@@ -364,8 +364,8 @@ export class ShellSocket {
     }
     this.failedAttempts = 0;
     this.flushPendingInput();
-    this.setState("attached");
     this.scheduleAttachTimers();
+    this.setState("attached");
   }
 
   private handleOutput(frame: Record<string, unknown>): void {
@@ -388,8 +388,10 @@ export class ShellSocket {
       console.warn("[shell-socket] ignoring invalid exit frame");
       return;
     }
-    this.endSession();
+    this.teardownSocket();
+    this.clearAllTimers();
     this.opts.events.onExit(code);
+    this.setState("ended");
   }
 
   private handleErrorFrame(frame: Record<string, unknown>): void {

--- a/desktop/src/renderer/src/lib/shell-socket.ts
+++ b/desktop/src/renderer/src/lib/shell-socket.ts
@@ -1,0 +1,437 @@
+// Terminal WebSocket client for the gateway shell protocol
+// (packages/gateway/src/shell/ws.ts, specs/094 research R3). Framework-free:
+// the WebSocket factory and timers are injectable so tests never need a
+// network or real clocks.
+
+export const LIVE_TAIL_FROM_SEQ = 9_007_199_254_740_991;
+
+export type ShellSocketState =
+  | "connecting"
+  | "attached"
+  | "reconnecting"
+  | "connection-lost"
+  | "ended"
+  | "fatal";
+
+export interface WebSocketLike {
+  send(data: string): void;
+  close(): void;
+  onopen: (() => void) | null;
+  onmessage: ((event: { data: unknown }) => void) | null;
+  onclose: (() => void) | null;
+  onerror: (() => void) | null;
+}
+
+export interface ShellSocketEvents {
+  onState(state: ShellSocketState, detail?: { code?: string }): void;
+  onOutput(data: string, seq: number): void;
+  onGap(): void;
+  onExit(code: number): void;
+}
+
+export interface ShellSocketOptions {
+  baseUrl: string;
+  sessionName?: string;
+  cwd?: string;
+  runtimeSlot: string;
+  events: ShellSocketEvents;
+  createWebSocket?: (url: string) => WebSocketLike;
+  setTimeoutFn?: typeof setTimeout;
+  clearTimeoutFn?: typeof clearTimeout;
+  random?: () => number;
+}
+
+const INPUT_CHUNK_CHARS = 32_768;
+const PENDING_INPUT_MAX_CHUNKS = 64;
+const BACKOFF_BASE_MS = 500;
+const BACKOFF_CAP_MS = 30_000;
+const BACKOFF_JITTER = 0.5;
+const BACKOFF_MAX_EXPONENT = 10;
+const CONNECTION_LOST_AFTER_FAILURES = 2;
+const RESIZE_DEBOUNCE_STARTUP_MS = 220;
+const RESIZE_DEBOUNCE_STEADY_MS = 90;
+const STARTUP_SETTLE_AFTER_ATTACH_MS = 300;
+const RESIZE_FALLBACK_AFTER_ATTACH_MS = 900;
+const MIN_COLS = 1;
+const MAX_COLS = 500;
+const MIN_ROWS = 1;
+const MAX_ROWS = 200;
+
+// Lesson L5: these codes must never trigger a reconnect loop.
+const FATAL_ERROR_CODES: ReadonlySet<string> = new Set([
+  "session_not_found",
+  "invalid_request",
+  "attach_failed",
+]);
+
+type TimerHandle = ReturnType<typeof setTimeout>;
+
+interface Dims {
+  cols: number;
+  rows: number;
+}
+
+function errorText(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+function clampInt(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, Math.floor(value)));
+}
+
+function defaultCreateWebSocket(url: string): WebSocketLike {
+  return new WebSocket(url) as unknown as WebSocketLike;
+}
+
+export class ShellSocket {
+  private readonly opts: ShellSocketOptions;
+  private readonly createWs: (url: string) => WebSocketLike;
+  private readonly setT: typeof setTimeout;
+  private readonly clearT: typeof clearTimeout;
+  private readonly random: () => number;
+
+  private socket: WebSocketLike | null = null;
+  private currentState: ShellSocketState | null = null;
+  private started = false;
+  private disposed = false;
+  private lastSeqValue = 0;
+  private attachedSessionName: string | null = null;
+  private failedAttempts = 0;
+  private pendingInput: string[] = [];
+  private lastKnownDims: Dims | null = null;
+  private lastSentDims: Dims | null = null;
+  private resizeSentSinceAttach = false;
+  private inStartupWindow = true;
+  private reconnectTimer: TimerHandle | null = null;
+  private resizeTimer: TimerHandle | null = null;
+  private settleTimer: TimerHandle | null = null;
+  private fallbackTimer: TimerHandle | null = null;
+
+  constructor(options: ShellSocketOptions) {
+    const hasSession = typeof options.sessionName === "string" && options.sessionName.length > 0;
+    const hasCwd = typeof options.cwd === "string" && options.cwd.length > 0;
+    if (hasSession === hasCwd) {
+      throw new Error("ShellSocket requires exactly one of sessionName or cwd");
+    }
+    this.opts = options;
+    this.createWs = options.createWebSocket ?? defaultCreateWebSocket;
+    this.setT = options.setTimeoutFn ?? (globalThis.setTimeout.bind(globalThis) as typeof setTimeout);
+    this.clearT =
+      options.clearTimeoutFn ?? (globalThis.clearTimeout.bind(globalThis) as typeof clearTimeout);
+    this.random = options.random ?? Math.random;
+  }
+
+  get lastSeq(): number {
+    return this.lastSeqValue;
+  }
+
+  get state(): ShellSocketState {
+    return this.currentState ?? "connecting";
+  }
+
+  connect(): void {
+    if (this.disposed || this.started) return;
+    this.started = true;
+    this.setState("connecting");
+    this.openSocket(false);
+  }
+
+  sendInput(data: string): void {
+    if (this.disposed || this.currentState === "ended" || this.currentState === "fatal") return;
+    if (data.length === 0) return;
+    for (let offset = 0; offset < data.length; offset += INPUT_CHUNK_CHARS) {
+      const chunk = data.slice(offset, offset + INPUT_CHUNK_CHARS);
+      if (this.currentState === "attached" && this.socket !== null) {
+        this.sendFrame({ type: "input", data: chunk });
+      } else {
+        this.pendingInput.push(chunk);
+        if (this.pendingInput.length > PENDING_INPUT_MAX_CHUNKS) {
+          this.pendingInput.shift();
+        }
+      }
+    }
+  }
+
+  resize(cols: number, rows: number): void {
+    if (this.disposed || this.currentState === "ended" || this.currentState === "fatal") return;
+    if (!Number.isFinite(cols) || !Number.isFinite(rows)) {
+      console.warn("[shell-socket] ignoring non-finite resize dims");
+      return;
+    }
+    this.lastKnownDims = {
+      cols: clampInt(cols, MIN_COLS, MAX_COLS),
+      rows: clampInt(rows, MIN_ROWS, MAX_ROWS),
+    };
+    if (this.resizeTimer !== null) this.clearT(this.resizeTimer);
+    const debounceMs = this.inStartupWindow ? RESIZE_DEBOUNCE_STARTUP_MS : RESIZE_DEBOUNCE_STEADY_MS;
+    this.resizeTimer = this.setT(() => {
+      this.resizeTimer = null;
+      this.flushResize();
+    }, debounceMs);
+  }
+
+  detach(): void {
+    if (this.disposed || this.currentState === "ended" || this.currentState === "fatal") return;
+    this.sendFrame({ type: "detach" });
+    this.endSession();
+  }
+
+  dispose(): void {
+    if (this.disposed) return;
+    this.disposed = true;
+    this.teardownSocket();
+    this.clearAllTimers();
+  }
+
+  private openSocket(isReconnect: boolean): void {
+    if (this.disposed) return;
+    // Per-connection resize bookkeeping: a fresh attach starts a new startup
+    // window and may need the last known dims resent.
+    this.lastSentDims = null;
+    this.resizeSentSinceAttach = false;
+    this.inStartupWindow = true;
+
+    const url = this.buildUrl(isReconnect);
+    let socket: WebSocketLike;
+    try {
+      socket = this.createWs(url);
+    } catch (err: unknown) {
+      console.warn("[shell-socket] websocket create failed:", errorText(err));
+      this.scheduleReconnect();
+      return;
+    }
+    this.socket = socket;
+
+    const onClosed = () => {
+      if (this.socket !== socket) return;
+      this.socket = null;
+      this.detachSocketHandlers(socket);
+      try {
+        socket.close();
+      } catch (err: unknown) {
+        console.warn("[shell-socket] websocket close failed:", errorText(err));
+      }
+      this.scheduleReconnect();
+    };
+
+    socket.onopen = () => undefined;
+    socket.onmessage = (event) => {
+      if (this.socket === socket) this.handleMessage(event.data);
+    };
+    socket.onclose = onClosed;
+    socket.onerror = () => {
+      console.warn("[shell-socket] websocket transport error");
+      onClosed();
+    };
+  }
+
+  private buildUrl(isReconnect: boolean): string {
+    const base = this.opts.baseUrl.replace(/\/+$/, "").replace(/^http(s?):\/\//, "ws$1://");
+    const runtimeSuffix =
+      this.opts.runtimeSlot !== "primary"
+        ? `&runtime=${encodeURIComponent(this.opts.runtimeSlot)}`
+        : "";
+    const sessionName = isReconnect
+      ? (this.attachedSessionName ?? this.opts.sessionName ?? null)
+      : (this.opts.sessionName ?? null);
+    if (sessionName !== null && sessionName.length > 0) {
+      const fromSeq = isReconnect ? this.lastSeqValue + 1 : LIVE_TAIL_FROM_SEQ;
+      return `${base}/ws/terminal/session?session=${encodeURIComponent(sessionName)}&fromSeq=${fromSeq}${runtimeSuffix}`;
+    }
+    return `${base}/ws/terminal?cwd=${encodeURIComponent(this.opts.cwd ?? "")}${runtimeSuffix}`;
+  }
+
+  private scheduleReconnect(): void {
+    if (this.disposed || this.currentState === "ended" || this.currentState === "fatal") return;
+    // Attach-lifecycle timers belong to the connection that just dropped.
+    if (this.settleTimer !== null) {
+      this.clearT(this.settleTimer);
+      this.settleTimer = null;
+    }
+    if (this.fallbackTimer !== null) {
+      this.clearT(this.fallbackTimer);
+      this.fallbackTimer = null;
+    }
+    const exponent = Math.min(this.failedAttempts, BACKOFF_MAX_EXPONENT);
+    const baseDelay = Math.min(BACKOFF_BASE_MS * 2 ** exponent, BACKOFF_CAP_MS);
+    const delay = baseDelay * (1 - BACKOFF_JITTER * this.random());
+    this.setState(
+      this.failedAttempts >= CONNECTION_LOST_AFTER_FAILURES ? "connection-lost" : "reconnecting",
+    );
+    this.failedAttempts += 1;
+    if (this.reconnectTimer !== null) this.clearT(this.reconnectTimer);
+    this.reconnectTimer = this.setT(() => {
+      this.reconnectTimer = null;
+      this.openSocket(true);
+    }, delay);
+  }
+
+  private handleMessage(data: unknown): void {
+    if (this.disposed) return;
+    if (typeof data !== "string") {
+      console.warn("[shell-socket] ignoring non-string websocket frame");
+      return;
+    }
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(data);
+    } catch (err: unknown) {
+      console.warn("[shell-socket] ignoring malformed websocket frame:", errorText(err));
+      return;
+    }
+    if (parsed === null || typeof parsed !== "object") {
+      console.warn("[shell-socket] ignoring non-object websocket frame");
+      return;
+    }
+    const frame = parsed as Record<string, unknown>;
+    switch (frame.type) {
+      case "attached":
+        this.handleAttached(frame);
+        return;
+      case "output":
+        this.handleOutput(frame);
+        return;
+      case "exit":
+        this.handleExit(frame);
+        return;
+      case "pong":
+        return;
+      case "replay-evicted":
+        this.opts.events.onGap();
+        return;
+      case "error":
+        this.handleErrorFrame(frame);
+        return;
+      default:
+        console.warn("[shell-socket] ignoring unknown frame type:", String(frame.type));
+    }
+  }
+
+  private handleAttached(frame: Record<string, unknown>): void {
+    if (typeof frame.session === "string" && frame.session.length > 0) {
+      this.attachedSessionName = frame.session;
+    }
+    this.failedAttempts = 0;
+    this.setState("attached");
+    this.flushPendingInput();
+    this.scheduleAttachTimers();
+  }
+
+  private handleOutput(frame: Record<string, unknown>): void {
+    const seq = frame.seq;
+    const data = frame.data;
+    if (typeof seq !== "number" || !Number.isFinite(seq) || typeof data !== "string") {
+      console.warn("[shell-socket] ignoring invalid output frame");
+      return;
+    }
+    this.lastSeqValue = seq;
+    this.opts.events.onOutput(data, seq);
+  }
+
+  private handleExit(frame: Record<string, unknown>): void {
+    const code = frame.code;
+    if (typeof code !== "number" || !Number.isFinite(code)) {
+      console.warn("[shell-socket] ignoring invalid exit frame");
+      return;
+    }
+    this.opts.events.onExit(code);
+    this.endSession();
+  }
+
+  private handleErrorFrame(frame: Record<string, unknown>): void {
+    const code = typeof frame.code === "string" ? frame.code : "unknown";
+    if (FATAL_ERROR_CODES.has(code)) {
+      this.teardownSocket();
+      this.clearAllTimers();
+      this.setState("fatal", { code });
+      return;
+    }
+    console.warn("[shell-socket] non-fatal terminal error:", code);
+  }
+
+  private scheduleAttachTimers(): void {
+    if (this.settleTimer !== null) this.clearT(this.settleTimer);
+    if (this.fallbackTimer !== null) this.clearT(this.fallbackTimer);
+    this.settleTimer = this.setT(() => {
+      this.settleTimer = null;
+      this.inStartupWindow = false;
+    }, STARTUP_SETTLE_AFTER_ATTACH_MS);
+    this.fallbackTimer = this.setT(() => {
+      this.fallbackTimer = null;
+      if (!this.resizeSentSinceAttach && this.lastKnownDims !== null) {
+        this.flushResize();
+      }
+    }, RESIZE_FALLBACK_AFTER_ATTACH_MS);
+  }
+
+  private flushResize(): void {
+    if (this.disposed || this.currentState !== "attached" || this.socket === null) return;
+    const dims = this.lastKnownDims;
+    if (dims === null) return;
+    if (this.lastSentDims !== null && this.lastSentDims.cols === dims.cols && this.lastSentDims.rows === dims.rows) {
+      return;
+    }
+    this.sendFrame({ type: "resize", cols: dims.cols, rows: dims.rows });
+    this.lastSentDims = dims;
+    this.resizeSentSinceAttach = true;
+  }
+
+  private flushPendingInput(): void {
+    if (this.pendingInput.length === 0) return;
+    const chunks = this.pendingInput;
+    this.pendingInput = [];
+    for (const chunk of chunks) {
+      this.sendFrame({ type: "input", data: chunk });
+    }
+  }
+
+  private sendFrame(frame: Record<string, unknown>): void {
+    if (this.socket === null) return;
+    try {
+      this.socket.send(JSON.stringify(frame));
+    } catch (err: unknown) {
+      console.warn("[shell-socket] websocket send failed:", errorText(err));
+    }
+  }
+
+  private endSession(): void {
+    this.teardownSocket();
+    this.clearAllTimers();
+    this.setState("ended");
+  }
+
+  private teardownSocket(): void {
+    const socket = this.socket;
+    if (socket === null) return;
+    this.socket = null;
+    this.detachSocketHandlers(socket);
+    try {
+      socket.close();
+    } catch (err: unknown) {
+      console.warn("[shell-socket] websocket close failed:", errorText(err));
+    }
+  }
+
+  private detachSocketHandlers(socket: WebSocketLike): void {
+    socket.onopen = null;
+    socket.onmessage = null;
+    socket.onclose = null;
+    socket.onerror = null;
+  }
+
+  private clearAllTimers(): void {
+    for (const key of ["reconnectTimer", "resizeTimer", "settleTimer", "fallbackTimer"] as const) {
+      const handle = this[key];
+      if (handle !== null) {
+        this.clearT(handle);
+        this[key] = null;
+      }
+    }
+  }
+
+  private setState(state: ShellSocketState, detail?: { code?: string }): void {
+    if (this.disposed || this.currentState === state) return;
+    this.currentState = state;
+    this.opts.events.onState(state, detail);
+  }
+}

--- a/desktop/src/renderer/src/lib/shell-socket.ts
+++ b/desktop/src/renderer/src/lib/shell-socket.ts
@@ -370,9 +370,9 @@ export class ShellSocket {
   }
 
   private handleErrorFrame(frame: Record<string, unknown>): void {
-    this.clearAttachHandshakeTimer();
     const code = typeof frame.code === "string" ? frame.code : "unknown";
     if (FATAL_ERROR_CODES.has(code)) {
+      this.clearAttachHandshakeTimer();
       this.teardownSocket();
       this.clearAllTimers();
       this.setState("fatal", { code });

--- a/tests/desktop/shell-socket.test.ts
+++ b/tests/desktop/shell-socket.test.ts
@@ -351,6 +351,24 @@ describe("ShellSocket server frames", () => {
     expect(h.events.gaps).toBe(1);
   });
 
+  it("ignores pre-attach replay frames so reconnect remains a live tail", () => {
+    const h = createHarness();
+    h.socket.connect();
+    h.latest().open();
+    h.latest().frame({ type: "output", seq: 41, data: "early" });
+    h.latest().frame({ type: "replay-evicted", fromSeq: 1, nextSeq: 42 });
+    expect(h.events.outputs).toEqual([]);
+    expect(h.events.gaps).toBe(0);
+    expect(h.socket.lastSeq).toBe(0);
+
+    h.latest().serverClose();
+    h.timers.advance(500);
+    expect(h.sockets).toHaveLength(2);
+    expect(h.latest().url).toBe(
+      `wss://app.matrix-os.com/ws/terminal/session?session=main&fromSeq=${LIVE_TAIL_FROM_SEQ}`,
+    );
+  });
+
   it("treats session_not_found, invalid_request, and attach_failed as fatal and never reconnects", () => {
     for (const code of ["session_not_found", "invalid_request", "attach_failed"]) {
       const h = createHarness();

--- a/tests/desktop/shell-socket.test.ts
+++ b/tests/desktop/shell-socket.test.ts
@@ -256,6 +256,17 @@ describe("ShellSocket URL building", () => {
     );
   });
 
+  it("reconnects with the live-tail sentinel when no output has arrived yet", () => {
+    const h = createHarness();
+    connectAndAttach(h);
+    h.latest().serverClose();
+    h.timers.advance(500);
+    expect(h.sockets).toHaveLength(2);
+    expect(h.latest().url).toBe(
+      `wss://app.matrix-os.com/ws/terminal/session?session=main&fromSeq=${LIVE_TAIL_FROM_SEQ}`,
+    );
+  });
+
   it("reconnects an auto-created terminal by its attached session name", () => {
     const h = createHarness({ sessionName: undefined, cwd: "/work" });
     h.socket.connect();
@@ -383,6 +394,21 @@ describe("ShellSocket reconnect", () => {
     h.timers.advance(499);
     expect(h.sockets).toHaveLength(1);
     h.timers.advance(1);
+    expect(h.sockets).toHaveLength(2);
+  });
+
+  it("reconnects when the websocket opens but never sends an attach frame", () => {
+    const h = createHarness();
+    h.socket.connect();
+    h.latest().open();
+
+    h.timers.advance(499);
+    expect(h.sockets).toHaveLength(1);
+    expect(h.socket.state).toBe("connecting");
+
+    h.timers.advance(1);
+    expect(h.socket.state).toBe("reconnecting");
+    h.timers.advance(500);
     expect(h.sockets).toHaveLength(2);
   });
 

--- a/tests/desktop/shell-socket.test.ts
+++ b/tests/desktop/shell-socket.test.ts
@@ -313,6 +313,29 @@ describe("ShellSocket server frames", () => {
     expect(h.sockets).toHaveLength(1);
   });
 
+  it("closes the socket before notifying onExit", () => {
+    let h!: Harness;
+    let closedDuringExit = false;
+    h = createHarness({
+      events: {
+        onState: (state, detail) => {
+          h.events.states.push(detail === undefined ? { state } : { state, detail });
+        },
+        onOutput: (data, seq) => h.events.outputs.push({ data, seq }),
+        onGap: () => {
+          h.events.gaps += 1;
+        },
+        onExit: (code) => {
+          closedDuringExit = h.latest().closed;
+          h.events.exits.push(code);
+        },
+      },
+    });
+    connectAndAttach(h);
+    h.latest().frame({ type: "exit", code: 0 });
+    expect(closedDuringExit).toBe(true);
+  });
+
   it("ignores pong frames", () => {
     const h = createHarness();
     connectAndAttach(h);
@@ -642,6 +665,40 @@ describe("ShellSocket input", () => {
     expect(h.latest().inputFrames()).toEqual(["hel", "lo"]);
   });
 
+  it("flushes pending input before the attached state callback runs", () => {
+    let h!: Harness;
+    let framesSeenOnAttach: string[] = [];
+    h = createHarness({
+      events: {
+        onState: (state, detail) => {
+          h.events.states.push(detail === undefined ? { state } : { state, detail });
+          if (state === "attached") framesSeenOnAttach = h.latest().inputFrames();
+        },
+        onOutput: (data, seq) => h.events.outputs.push({ data, seq }),
+        onGap: () => {
+          h.events.gaps += 1;
+        },
+        onExit: (code) => h.events.exits.push(code),
+      },
+    });
+    h.socket.connect();
+    h.socket.sendInput("queued");
+    h.latest().open();
+    h.latest().frame({ type: "attached", session: "main", state: "running", fromSeq: 0 });
+    expect(framesSeenOnAttach).toEqual(["queued"]);
+  });
+
+  it("does not split surrogate pairs across input chunks", () => {
+    const h = createHarness();
+    connectAndAttach(h);
+    const input = `${"a".repeat(32_767)}😀b`;
+    h.socket.sendInput(input);
+    const chunks = h.latest().inputFrames();
+    expect(chunks.join("")).toBe(input);
+    expect(chunks[0]).toBe("a".repeat(32_767));
+    expect(chunks[1]).toBe("😀b");
+  });
+
   it("caps the pre-attach buffer at 64 chunks, dropping the oldest", () => {
     const h = createHarness();
     h.socket.connect();
@@ -693,6 +750,38 @@ describe("ShellSocket detach and dispose", () => {
     expect(h.latest().closed).toBe(true);
     h.timers.advance(120_000);
     expect(h.sockets).toHaveLength(2);
+  });
+
+  it("ignores non-attach frames while cleanup-attaching after end", () => {
+    const h = createHarness();
+    connectAndAttach(h);
+    h.latest().serverClose();
+    h.socket.detach();
+
+    h.latest().open();
+    h.latest().frame({ type: "output", seq: 2, data: "late" });
+
+    expect(h.socket.state).toBe("ended");
+    expect(h.events.outputs).toEqual([]);
+    h.latest().frame({ type: "attached", session: "main", state: "running", fromSeq: 0 });
+    expect(h.latest().sentFrames()).toContainEqual({ type: "detach" });
+  });
+
+  it("detach while connecting closes the partial socket and cleanup-attaches", () => {
+    const h = createHarness();
+    h.socket.connect();
+    const connecting = h.latest();
+
+    h.socket.detach();
+
+    expect(connecting.sentFrames()).toEqual([]);
+    expect(connecting.closed).toBe(true);
+    expect(h.socket.state).toBe("ended");
+    expect(h.sockets).toHaveLength(2);
+    h.latest().open();
+    h.latest().frame({ type: "attached", session: "main", state: "running", fromSeq: 0 });
+    expect(h.latest().sentFrames()).toContainEqual({ type: "detach" });
+    expect(h.latest().closed).toBe(true);
   });
 
   it("dispose clears every timer and emits no further events", () => {

--- a/tests/desktop/shell-socket.test.ts
+++ b/tests/desktop/shell-socket.test.ts
@@ -352,6 +352,21 @@ describe("ShellSocket server frames", () => {
     expect(h.events.outputs).toEqual([{ data: "still alive", seq: 1 }]);
   });
 
+  it("keeps the handshake timeout active after a pre-attach non-fatal error", () => {
+    const h = createHarness();
+    h.socket.connect();
+    h.latest().open();
+    h.latest().frame({ type: "error", code: "buffer_overflow", message: "slow down" });
+
+    h.timers.advance(499);
+    expect(h.sockets).toHaveLength(1);
+    h.timers.advance(1);
+
+    expect(h.socket.state).toBe("reconnecting");
+    h.timers.advance(500);
+    expect(h.sockets).toHaveLength(2);
+  });
+
   it("ignores malformed JSON frames without crashing", () => {
     const h = createHarness();
     connectAndAttach(h);

--- a/tests/desktop/shell-socket.test.ts
+++ b/tests/desktop/shell-socket.test.ts
@@ -813,6 +813,31 @@ describe("ShellSocket detach and dispose", () => {
     expect(h.sockets).toHaveLength(2);
   });
 
+  it("detach inside reconnecting callback cancels the pending reconnect timer", () => {
+    let h!: Harness;
+    h = createHarness({
+      events: {
+        onState: (state, detail) => {
+          h.events.states.push(detail === undefined ? { state } : { state, detail });
+          if (state === "reconnecting") h.socket.detach();
+        },
+        onOutput: (data, seq) => h.events.outputs.push({ data, seq }),
+        onGap: () => {
+          h.events.gaps += 1;
+        },
+        onExit: (code) => h.events.exits.push(code),
+      },
+    });
+
+    connectAndAttach(h);
+    h.latest().serverClose();
+
+    expect(h.socket.state).toBe("ended");
+    expect(h.sockets).toHaveLength(2);
+    h.timers.advance(120_000);
+    expect(h.sockets).toHaveLength(2);
+  });
+
   it("ignores non-attach frames while cleanup-attaching after end", () => {
     const h = createHarness();
     connectAndAttach(h);

--- a/tests/desktop/shell-socket.test.ts
+++ b/tests/desktop/shell-socket.test.ts
@@ -664,15 +664,20 @@ describe("ShellSocket detach and dispose", () => {
     expect(h.sockets).toHaveLength(1);
   });
 
-  it("detach during a pending reconnect cancels the retry", () => {
+  it("detach during a pending reconnect sends a detach frame through a cleanup attach", () => {
     const h = createHarness();
     connectAndAttach(h);
     h.latest().serverClose();
     expect(h.socket.state).toBe("reconnecting");
     h.socket.detach();
     expect(h.socket.state).toBe("ended");
+    expect(h.sockets).toHaveLength(2);
+    h.latest().open();
+    h.latest().frame({ type: "attached", session: "main", state: "running", fromSeq: 0 });
+    expect(h.latest().sentFrames()).toContainEqual({ type: "detach" });
+    expect(h.latest().closed).toBe(true);
     h.timers.advance(120_000);
-    expect(h.sockets).toHaveLength(1);
+    expect(h.sockets).toHaveLength(2);
   });
 
   it("dispose clears every timer and emits no further events", () => {

--- a/tests/desktop/shell-socket.test.ts
+++ b/tests/desktop/shell-socket.test.ts
@@ -1,0 +1,689 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  LIVE_TAIL_FROM_SEQ,
+  ShellSocket,
+  type ShellSocketOptions,
+  type ShellSocketState,
+  type WebSocketLike,
+} from "@desktop/renderer/src/lib/shell-socket";
+
+class FakeWebSocket implements WebSocketLike {
+  readonly sent: string[] = [];
+  closed = false;
+  onopen: (() => void) | null = null;
+  onmessage: ((event: { data: unknown }) => void) | null = null;
+  onclose: (() => void) | null = null;
+  onerror: (() => void) | null = null;
+
+  constructor(readonly url: string) {}
+
+  send(data: string): void {
+    if (this.closed) throw new Error("send after close");
+    this.sent.push(data);
+  }
+
+  close(): void {
+    this.closed = true;
+  }
+
+  open(): void {
+    this.onopen?.();
+  }
+
+  frame(value: unknown): void {
+    this.onmessage?.({ data: JSON.stringify(value) });
+  }
+
+  raw(data: unknown): void {
+    this.onmessage?.({ data });
+  }
+
+  serverClose(): void {
+    this.onclose?.();
+  }
+
+  sentFrames(): Array<Record<string, unknown>> {
+    return this.sent.map((entry) => JSON.parse(entry) as Record<string, unknown>);
+  }
+
+  inputFrames(): string[] {
+    return this.sentFrames()
+      .filter((frame) => frame.type === "input")
+      .map((frame) => String(frame.data));
+  }
+
+  resizeFrames(): Array<{ cols: number; rows: number }> {
+    return this.sentFrames()
+      .filter((frame) => frame.type === "resize")
+      .map((frame) => ({ cols: Number(frame.cols), rows: Number(frame.rows) }));
+  }
+}
+
+class FakeTimers {
+  private now = 0;
+  private nextId = 1;
+  private readonly timers = new Map<number, { at: number; fn: () => void }>();
+
+  readonly set = ((fn: () => void, ms?: number) => {
+    const id = this.nextId;
+    this.nextId += 1;
+    this.timers.set(id, { at: this.now + (ms ?? 0), fn });
+    return id;
+  }) as unknown as typeof setTimeout;
+
+  readonly clear = ((handle?: unknown) => {
+    if (typeof handle === "number") this.timers.delete(handle);
+  }) as unknown as typeof clearTimeout;
+
+  advance(ms: number): void {
+    const target = this.now + ms;
+    for (;;) {
+      let dueId: number | null = null;
+      let dueAt = Number.POSITIVE_INFINITY;
+      for (const [id, timer] of this.timers) {
+        if (timer.at <= target && timer.at < dueAt) {
+          dueAt = timer.at;
+          dueId = id;
+        }
+      }
+      if (dueId === null) break;
+      const due = this.timers.get(dueId);
+      this.timers.delete(dueId);
+      this.now = Math.max(this.now, dueAt);
+      due?.fn();
+    }
+    this.now = target;
+  }
+
+  get pendingCount(): number {
+    return this.timers.size;
+  }
+}
+
+interface RecordedEvents {
+  states: Array<{ state: ShellSocketState; detail?: { code?: string } }>;
+  outputs: Array<{ data: string; seq: number }>;
+  gaps: number;
+  exits: number[];
+}
+
+interface Harness {
+  socket: ShellSocket;
+  sockets: FakeWebSocket[];
+  timers: FakeTimers;
+  events: RecordedEvents;
+  latest(): FakeWebSocket;
+  stateNames(): ShellSocketState[];
+}
+
+function createHarness(overrides: Partial<ShellSocketOptions> = {}): Harness {
+  const sockets: FakeWebSocket[] = [];
+  const timers = new FakeTimers();
+  const events: RecordedEvents = { states: [], outputs: [], gaps: 0, exits: [] };
+  const socket = new ShellSocket({
+    baseUrl: "https://app.matrix-os.com",
+    sessionName: "main",
+    runtimeSlot: "primary",
+    events: {
+      onState: (state, detail) => {
+        events.states.push(detail === undefined ? { state } : { state, detail });
+      },
+      onOutput: (data, seq) => {
+        events.outputs.push({ data, seq });
+      },
+      onGap: () => {
+        events.gaps += 1;
+      },
+      onExit: (code) => {
+        events.exits.push(code);
+      },
+    },
+    createWebSocket: (url) => {
+      const ws = new FakeWebSocket(url);
+      sockets.push(ws);
+      return ws;
+    },
+    setTimeoutFn: timers.set,
+    clearTimeoutFn: timers.clear,
+    random: () => 0,
+    ...overrides,
+  });
+  return {
+    socket,
+    sockets,
+    timers,
+    events,
+    latest: () => {
+      const ws = sockets[sockets.length - 1];
+      if (!ws) throw new Error("no socket created yet");
+      return ws;
+    },
+    stateNames: () => events.states.map((entry) => entry.state),
+  };
+}
+
+function connectAndAttach(h: Harness, session = "main"): void {
+  h.socket.connect();
+  h.latest().open();
+  h.latest().frame({ type: "attached", session, state: "running", fromSeq: 0 });
+}
+
+let warnSpy: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+});
+
+afterEach(() => {
+  warnSpy.mockRestore();
+});
+
+describe("ShellSocket URL building", () => {
+  it("first connect attaches with the live-tail sentinel over wss", () => {
+    const h = createHarness();
+    h.socket.connect();
+    expect(h.latest().url).toBe(
+      `wss://app.matrix-os.com/ws/terminal/session?session=main&fromSeq=${LIVE_TAIL_FROM_SEQ}`,
+    );
+    expect(LIVE_TAIL_FROM_SEQ).toBe(9_007_199_254_740_991);
+  });
+
+  it("converts http base urls to ws and strips trailing slashes", () => {
+    const h = createHarness({ baseUrl: "http://localhost:3001/" });
+    h.socket.connect();
+    expect(h.latest().url).toBe(
+      `ws://localhost:3001/ws/terminal/session?session=main&fromSeq=${LIVE_TAIL_FROM_SEQ}`,
+    );
+  });
+
+  it("appends runtime only for non-primary slots", () => {
+    const nonPrimary = createHarness({ runtimeSlot: "vm-2" });
+    nonPrimary.socket.connect();
+    expect(nonPrimary.latest().url).toContain("&runtime=vm-2");
+
+    const primary = createHarness();
+    primary.socket.connect();
+    expect(primary.latest().url).not.toContain("runtime=");
+  });
+
+  it("auto-creates with an encoded cwd and no fromSeq", () => {
+    const h = createHarness({ sessionName: undefined, cwd: "/Users/h/my project" });
+    h.socket.connect();
+    expect(h.latest().url).toBe(
+      "wss://app.matrix-os.com/ws/terminal?cwd=%2FUsers%2Fh%2Fmy%20project",
+    );
+  });
+
+  it("appends runtime to the auto-create url for non-primary slots", () => {
+    const h = createHarness({ sessionName: undefined, cwd: "/work", runtimeSlot: "vm-3" });
+    h.socket.connect();
+    expect(h.latest().url).toBe(
+      "wss://app.matrix-os.com/ws/terminal?cwd=%2Fwork&runtime=vm-3",
+    );
+  });
+
+  it("requires exactly one of sessionName or cwd", () => {
+    const events = {
+      onState: () => undefined,
+      onOutput: () => undefined,
+      onGap: () => undefined,
+      onExit: () => undefined,
+    };
+    expect(
+      () => new ShellSocket({ baseUrl: "https://x", runtimeSlot: "primary", events }),
+    ).toThrow(/sessionName or cwd/);
+    expect(
+      () =>
+        new ShellSocket({
+          baseUrl: "https://x",
+          sessionName: "a",
+          cwd: "/b",
+          runtimeSlot: "primary",
+          events,
+        }),
+    ).toThrow(/sessionName or cwd/);
+  });
+
+  it("reconnects from lastSeq+1", () => {
+    const h = createHarness();
+    connectAndAttach(h);
+    h.latest().frame({ type: "output", seq: 41, data: "x" });
+    h.latest().serverClose();
+    h.timers.advance(500);
+    expect(h.sockets).toHaveLength(2);
+    expect(h.latest().url).toBe(
+      "wss://app.matrix-os.com/ws/terminal/session?session=main&fromSeq=42",
+    );
+  });
+
+  it("reconnects an auto-created terminal by its attached session name", () => {
+    const h = createHarness({ sessionName: undefined, cwd: "/work" });
+    h.socket.connect();
+    h.latest().open();
+    h.latest().frame({ type: "attached", session: "w-1", state: "running", fromSeq: 0 });
+    h.latest().frame({ type: "output", seq: 5, data: "x" });
+    h.latest().serverClose();
+    h.timers.advance(500);
+    expect(h.latest().url).toBe(
+      "wss://app.matrix-os.com/ws/terminal/session?session=w-1&fromSeq=6",
+    );
+  });
+});
+
+describe("ShellSocket server frames", () => {
+  it("starts in connecting state and reaches attached", () => {
+    const h = createHarness();
+    expect(h.socket.state).toBe("connecting");
+    connectAndAttach(h);
+    expect(h.socket.state).toBe("attached");
+    expect(h.stateNames()).toEqual(["connecting", "attached"]);
+  });
+
+  it("tracks lastSeq and emits output", () => {
+    const h = createHarness();
+    connectAndAttach(h);
+    expect(h.socket.lastSeq).toBe(0);
+    h.latest().frame({ type: "output", seq: 7, data: "hello" });
+    h.latest().frame({ type: "output", seq: 8, data: "world" });
+    expect(h.events.outputs).toEqual([
+      { data: "hello", seq: 7 },
+      { data: "world", seq: 8 },
+    ]);
+    expect(h.socket.lastSeq).toBe(8);
+  });
+
+  it("ends on exit with the exit code and never reconnects", () => {
+    const h = createHarness();
+    connectAndAttach(h);
+    h.latest().frame({ type: "exit", code: 3 });
+    expect(h.events.exits).toEqual([3]);
+    expect(h.socket.state).toBe("ended");
+    h.timers.advance(120_000);
+    expect(h.sockets).toHaveLength(1);
+  });
+
+  it("ignores pong frames", () => {
+    const h = createHarness();
+    connectAndAttach(h);
+    h.latest().frame({ type: "pong" });
+    expect(h.stateNames()).toEqual(["connecting", "attached"]);
+    expect(h.events.outputs).toHaveLength(0);
+  });
+
+  it("emits onGap for replay-evicted", () => {
+    const h = createHarness();
+    connectAndAttach(h);
+    h.latest().frame({ type: "replay-evicted", fromSeq: 1, nextSeq: 60 });
+    expect(h.events.gaps).toBe(1);
+  });
+
+  it("treats session_not_found, invalid_request, and attach_failed as fatal and never reconnects", () => {
+    for (const code of ["session_not_found", "invalid_request", "attach_failed"]) {
+      const h = createHarness();
+      h.socket.connect();
+      h.latest().open();
+      h.latest().frame({ type: "error", code, message: "nope" });
+      expect(h.socket.state).toBe("fatal");
+      expect(h.events.states.at(-1)).toEqual({ state: "fatal", detail: { code } });
+      h.latest().serverClose();
+      h.timers.advance(120_000);
+      expect(h.sockets).toHaveLength(1);
+    }
+  });
+
+  it("logs and continues on non-fatal error codes", () => {
+    const h = createHarness();
+    connectAndAttach(h);
+    h.latest().frame({ type: "error", code: "buffer_overflow", message: "slow down" });
+    expect(h.socket.state).toBe("attached");
+    expect(warnSpy).toHaveBeenCalled();
+    h.latest().frame({ type: "output", seq: 1, data: "still alive" });
+    expect(h.events.outputs).toEqual([{ data: "still alive", seq: 1 }]);
+  });
+
+  it("ignores malformed JSON frames without crashing", () => {
+    const h = createHarness();
+    connectAndAttach(h);
+    h.latest().raw("{not json");
+    expect(warnSpy).toHaveBeenCalled();
+    h.latest().frame({ type: "output", seq: 2, data: "ok" });
+    expect(h.events.outputs).toEqual([{ data: "ok", seq: 2 }]);
+  });
+
+  it("ignores non-string and non-object frames", () => {
+    const h = createHarness();
+    connectAndAttach(h);
+    h.latest().raw(42);
+    h.latest().raw(new ArrayBuffer(4));
+    h.latest().frame("just-a-string");
+    h.latest().frame(null);
+    expect(h.events.outputs).toHaveLength(0);
+    expect(h.socket.state).toBe("attached");
+  });
+
+  it("ignores unknown frame types and invalid field shapes", () => {
+    const h = createHarness();
+    connectAndAttach(h);
+    h.latest().frame({ type: "mystery" });
+    h.latest().frame({ type: "output", seq: "nan", data: "x" });
+    h.latest().frame({ type: "output", seq: 1 });
+    h.latest().frame({ type: "exit", code: "one" });
+    expect(h.events.outputs).toHaveLength(0);
+    expect(h.events.exits).toHaveLength(0);
+    expect(h.socket.state).toBe("attached");
+  });
+});
+
+describe("ShellSocket reconnect", () => {
+  it("reconnects after an unexpected close with the base 500ms delay", () => {
+    const h = createHarness();
+    connectAndAttach(h);
+    h.latest().serverClose();
+    expect(h.socket.state).toBe("reconnecting");
+    h.timers.advance(499);
+    expect(h.sockets).toHaveLength(1);
+    h.timers.advance(1);
+    expect(h.sockets).toHaveLength(2);
+  });
+
+  it("doubles the backoff and reports connection-lost after 2 failed attempts while still retrying", () => {
+    const h = createHarness();
+    connectAndAttach(h);
+
+    h.latest().serverClose();
+    h.timers.advance(500);
+    expect(h.sockets).toHaveLength(2);
+
+    h.latest().serverClose();
+    expect(h.stateNames()).not.toContain("connection-lost");
+    h.timers.advance(999);
+    expect(h.sockets).toHaveLength(2);
+    h.timers.advance(1);
+    expect(h.sockets).toHaveLength(3);
+
+    h.latest().serverClose();
+    expect(h.socket.state).toBe("connection-lost");
+    h.timers.advance(2000);
+    expect(h.sockets).toHaveLength(4);
+  });
+
+  it("caps the retry interval at 30s and keeps retrying", () => {
+    const h = createHarness();
+    connectAndAttach(h);
+    const delays = [500, 1000, 2000, 4000, 8000, 16_000, 30_000, 30_000];
+    for (const delay of delays) {
+      h.latest().serverClose();
+      h.timers.advance(delay - 1);
+      const before = h.sockets.length;
+      h.timers.advance(1);
+      expect(h.sockets.length).toBe(before + 1);
+    }
+  });
+
+  it("applies jitter as delay * (1 - 0.5 * random())", () => {
+    const h = createHarness({ random: () => 1 });
+    connectAndAttach(h);
+    h.latest().serverClose();
+    h.timers.advance(249);
+    expect(h.sockets).toHaveLength(1);
+    h.timers.advance(1);
+    expect(h.sockets).toHaveLength(2);
+  });
+
+  it("resets the attempt counter on a successful attach", () => {
+    const h = createHarness();
+    connectAndAttach(h);
+
+    h.latest().serverClose();
+    h.timers.advance(500);
+    h.latest().serverClose();
+    h.timers.advance(1000);
+    h.latest().serverClose();
+    expect(h.socket.state).toBe("connection-lost");
+    h.timers.advance(2000);
+
+    h.latest().open();
+    h.latest().frame({ type: "attached", session: "main", state: "running", fromSeq: 0 });
+    expect(h.socket.state).toBe("attached");
+
+    h.latest().serverClose();
+    expect(h.socket.state).toBe("reconnecting");
+    h.timers.advance(499);
+    expect(h.sockets).toHaveLength(4);
+    h.timers.advance(1);
+    expect(h.sockets).toHaveLength(5);
+  });
+
+  it("schedules a retry when the websocket factory throws", () => {
+    let fail = true;
+    const sockets: FakeWebSocket[] = [];
+    const h = createHarness({
+      createWebSocket: (url) => {
+        if (fail) {
+          fail = false;
+          throw new Error("boom");
+        }
+        const ws = new FakeWebSocket(url);
+        sockets.push(ws);
+        return ws;
+      },
+    });
+    h.socket.connect();
+    expect(h.socket.state).toBe("reconnecting");
+    h.timers.advance(500);
+    expect(sockets).toHaveLength(1);
+  });
+});
+
+describe("ShellSocket resize coalescing", () => {
+  it("debounces at 220ms during the startup window", () => {
+    const h = createHarness();
+    connectAndAttach(h);
+    h.socket.resize(120, 40);
+    h.timers.advance(90);
+    expect(h.latest().resizeFrames()).toHaveLength(0);
+    h.timers.advance(130);
+    expect(h.latest().resizeFrames()).toEqual([{ cols: 120, rows: 40 }]);
+  });
+
+  it("debounces at 90ms once the startup window settles (300ms after attach)", () => {
+    const h = createHarness();
+    connectAndAttach(h);
+    h.timers.advance(300);
+    h.socket.resize(100, 30);
+    h.timers.advance(89);
+    expect(h.latest().resizeFrames()).toHaveLength(0);
+    h.timers.advance(1);
+    expect(h.latest().resizeFrames()).toEqual([{ cols: 100, rows: 30 }]);
+  });
+
+  it("coalesces rapid resizes into one send of the latest dims", () => {
+    const h = createHarness();
+    connectAndAttach(h);
+    h.timers.advance(300);
+    h.socket.resize(100, 30);
+    h.timers.advance(50);
+    h.socket.resize(101, 31);
+    h.timers.advance(90);
+    expect(h.latest().resizeFrames()).toEqual([{ cols: 101, rows: 31 }]);
+  });
+
+  it("does not resend unchanged dims", () => {
+    const h = createHarness();
+    connectAndAttach(h);
+    h.timers.advance(300);
+    h.socket.resize(80, 24);
+    h.timers.advance(90);
+    h.socket.resize(80, 24);
+    h.timers.advance(90);
+    expect(h.latest().resizeFrames()).toEqual([{ cols: 80, rows: 24 }]);
+  });
+
+  it("clamps cols to 1..500 and rows to 1..200", () => {
+    const h = createHarness();
+    connectAndAttach(h);
+    h.timers.advance(300);
+    h.socket.resize(9999, 9999);
+    h.timers.advance(90);
+    h.socket.resize(0, -5);
+    h.timers.advance(90);
+    expect(h.latest().resizeFrames()).toEqual([
+      { cols: 500, rows: 200 },
+      { cols: 1, rows: 1 },
+    ]);
+  });
+
+  it("sends last known dims 900ms after attach when none were sent", () => {
+    const h = createHarness();
+    h.socket.connect();
+    h.socket.resize(90, 30);
+    h.timers.advance(220);
+    h.latest().open();
+    h.latest().frame({ type: "attached", session: "main", state: "running", fromSeq: 0 });
+    h.timers.advance(899);
+    expect(h.latest().resizeFrames()).toHaveLength(0);
+    h.timers.advance(1);
+    expect(h.latest().resizeFrames()).toEqual([{ cols: 90, rows: 30 }]);
+  });
+
+  it("skips the 900ms fallback when a resize was already sent after attach", () => {
+    const h = createHarness();
+    connectAndAttach(h);
+    h.socket.resize(120, 40);
+    h.timers.advance(220);
+    expect(h.latest().resizeFrames()).toHaveLength(1);
+    h.timers.advance(680);
+    expect(h.latest().resizeFrames()).toHaveLength(1);
+  });
+
+  it("skips the 900ms fallback when the caller never provided dims", () => {
+    const h = createHarness();
+    connectAndAttach(h);
+    h.timers.advance(900);
+    expect(h.latest().resizeFrames()).toHaveLength(0);
+  });
+
+  it("resends dims to a fresh connection after reconnect via the fallback", () => {
+    const h = createHarness();
+    connectAndAttach(h);
+    h.timers.advance(300);
+    h.socket.resize(100, 30);
+    h.timers.advance(90);
+    expect(h.latest().resizeFrames()).toEqual([{ cols: 100, rows: 30 }]);
+
+    h.latest().serverClose();
+    h.timers.advance(500);
+    h.latest().open();
+    h.latest().frame({ type: "attached", session: "main", state: "running", fromSeq: 0 });
+    h.timers.advance(900);
+    expect(h.latest().resizeFrames()).toEqual([{ cols: 100, rows: 30 }]);
+  });
+});
+
+describe("ShellSocket input", () => {
+  it("chunks large input into <=32768-char pieces", () => {
+    const h = createHarness();
+    connectAndAttach(h);
+    h.socket.sendInput("a".repeat(70_000));
+    const chunks = h.latest().inputFrames();
+    expect(chunks.map((chunk) => chunk.length)).toEqual([32_768, 32_768, 4464]);
+    expect(chunks.join("")).toBe("a".repeat(70_000));
+  });
+
+  it("buffers input typed before attach and flushes it in order on attach", () => {
+    const h = createHarness();
+    h.socket.connect();
+    h.socket.sendInput("hel");
+    h.socket.sendInput("lo");
+    expect(h.latest().sent).toHaveLength(0);
+    h.latest().open();
+    h.latest().frame({ type: "attached", session: "main", state: "running", fromSeq: 0 });
+    expect(h.latest().inputFrames()).toEqual(["hel", "lo"]);
+  });
+
+  it("caps the pre-attach buffer at 64 chunks, dropping the oldest", () => {
+    const h = createHarness();
+    h.socket.connect();
+    for (let i = 0; i < 70; i += 1) {
+      h.socket.sendInput(`c${i}`);
+    }
+    h.latest().open();
+    h.latest().frame({ type: "attached", session: "main", state: "running", fromSeq: 0 });
+    const flushed = h.latest().inputFrames();
+    expect(flushed).toHaveLength(64);
+    expect(flushed[0]).toBe("c6");
+    expect(flushed.at(-1)).toBe("c69");
+  });
+
+  it("ignores input after the session ends", () => {
+    const h = createHarness();
+    connectAndAttach(h);
+    h.latest().frame({ type: "exit", code: 0 });
+    const before = h.latest().sent.length;
+    h.socket.sendInput("ghost");
+    expect(h.latest().sent).toHaveLength(before);
+  });
+});
+
+describe("ShellSocket detach and dispose", () => {
+  it("detach sends a detach frame, closes, ends, and never reconnects", () => {
+    const h = createHarness();
+    connectAndAttach(h);
+    h.socket.detach();
+    expect(h.latest().sentFrames()).toContainEqual({ type: "detach" });
+    expect(h.latest().closed).toBe(true);
+    expect(h.socket.state).toBe("ended");
+    expect(h.timers.pendingCount).toBe(0);
+    h.timers.advance(120_000);
+    expect(h.sockets).toHaveLength(1);
+  });
+
+  it("detach during a pending reconnect cancels the retry", () => {
+    const h = createHarness();
+    connectAndAttach(h);
+    h.latest().serverClose();
+    expect(h.socket.state).toBe("reconnecting");
+    h.socket.detach();
+    expect(h.socket.state).toBe("ended");
+    h.timers.advance(120_000);
+    expect(h.sockets).toHaveLength(1);
+  });
+
+  it("dispose clears every timer and emits no further events", () => {
+    const h = createHarness();
+    connectAndAttach(h);
+    h.socket.resize(100, 30);
+    expect(h.timers.pendingCount).toBeGreaterThan(0);
+    const statesBefore = h.events.states.length;
+    h.socket.dispose();
+    expect(h.timers.pendingCount).toBe(0);
+    h.timers.advance(120_000);
+    expect(h.sockets).toHaveLength(1);
+    expect(h.events.states).toHaveLength(statesBefore);
+    expect(h.latest().closed).toBe(true);
+  });
+
+  it("dispose during a pending reconnect clears the retry timer", () => {
+    const h = createHarness();
+    connectAndAttach(h);
+    h.latest().serverClose();
+    expect(h.timers.pendingCount).toBeGreaterThan(0);
+    h.socket.dispose();
+    expect(h.timers.pendingCount).toBe(0);
+    h.timers.advance(120_000);
+    expect(h.sockets).toHaveLength(1);
+  });
+
+  it("connect is a no-op when called twice or after dispose", () => {
+    const h = createHarness();
+    h.socket.connect();
+    h.socket.connect();
+    expect(h.sockets).toHaveLength(1);
+
+    const disposed = createHarness();
+    disposed.socket.connect();
+    disposed.socket.dispose();
+    disposed.socket.connect();
+    expect(disposed.sockets).toHaveLength(1);
+  });
+});

--- a/tests/desktop/shell-socket.test.ts
+++ b/tests/desktop/shell-socket.test.ts
@@ -336,6 +336,27 @@ describe("ShellSocket server frames", () => {
     expect(closedDuringExit).toBe(true);
   });
 
+  it("notifies onExit before the ended state callback", () => {
+    const order: string[] = [];
+    const h = createHarness({
+      events: {
+        onState: (state) => {
+          order.push(`state:${state}`);
+        },
+        onOutput: () => undefined,
+        onGap: () => undefined,
+        onExit: (code) => {
+          order.push(`exit:${code}`);
+        },
+      },
+    });
+    connectAndAttach(h);
+
+    h.latest().frame({ type: "exit", code: 7 });
+
+    expect(order).toEqual(["state:connecting", "state:attached", "exit:7", "state:ended"]);
+  });
+
   it("ignores pong frames", () => {
     const h = createHarness();
     connectAndAttach(h);
@@ -752,6 +773,28 @@ describe("ShellSocket detach and dispose", () => {
     expect(h.timers.pendingCount).toBe(0);
     h.timers.advance(120_000);
     expect(h.sockets).toHaveLength(1);
+  });
+
+  it("clears attach timers when attached callback detaches immediately", () => {
+    let h!: Harness;
+    h = createHarness({
+      events: {
+        onState: (state, detail) => {
+          h.events.states.push(detail === undefined ? { state } : { state, detail });
+          if (state === "attached") h.socket.detach();
+        },
+        onOutput: (data, seq) => h.events.outputs.push({ data, seq }),
+        onGap: () => {
+          h.events.gaps += 1;
+        },
+        onExit: (code) => h.events.exits.push(code),
+      },
+    });
+
+    connectAndAttach(h);
+
+    expect(h.socket.state).toBe("ended");
+    expect(h.timers.pendingCount).toBe(0);
   });
 
   it("detach during a pending reconnect sends a detach frame through a cleanup attach", () => {


### PR DESCRIPTION
## Summary
- Adds the gateway shell-socket client and its parser/transport coverage.
- Part of the 094 Operator desktop stack split from original PR #507.
- Draft until the full stack validation and screenshots are refreshed.

## Validation
- Rebased onto current main after #506 merged.
- Rebuilt stack final tree matches the original #507 tree exactly.
- Per-layer CI/Greptile still needs to settle before review-ready.

## Invariants
- Source of truth: desktop app source under desktop/, specs/docs, and root workspace metadata in this stack; no owner runtime data is modified.
- Lock/transaction scope: no Postgres transaction scope is introduced in this layer; desktop local state remains scoped to the Electron app and existing gateway/platform APIs.
- Acceptable orphan states: stack PRs are draft and must land in order; partial stack landing is not a supported release state.
- Auth source of truth: Clerk/device auth and existing gateway token handling remain authoritative; this stack does not add a second auth authority.
- Deferred scope: packaged distribution, production desktop rollout, and customer VPS host-bundle deploy are outside this stack.