### PR TITLE
feat(desktop): add native app embed management

### DIFF
--- a/desktop/src/main/embeds/app-session.ts
+++ b/desktop/src/main/embeds/app-session.ts
@@ -12,6 +12,7 @@ export interface ParsedCookie {
   value: string;
   domain?: string;
   path?: string;
+  /** Milliseconds since Unix epoch; Electron cookie adapters must convert to seconds. */
   expires?: number;
   secure?: boolean;
   httpOnly?: boolean;

--- a/desktop/src/main/embeds/app-session.ts
+++ b/desktop/src/main/embeds/app-session.ts
@@ -5,6 +5,7 @@
 // cleared before installing the fresh pair).
 
 export const REQUIRED_COOKIES = ["matrix_app_session", "matrix_native_app_session"] as const;
+const APP_SESSION_TIMEOUT_MS = 10_000;
 
 export interface ParsedCookie {
   name: string;
@@ -107,6 +108,12 @@ export function isStaleClerkCookie(cookie: { name: string; domain?: string }): b
   return false;
 }
 
+function removalUrlForCookie(cookie: { domain?: string }, gatewayOrigin: string): string {
+  const fallbackHost = new URL(gatewayOrigin).hostname;
+  const domain = cookie.domain?.replace(/^\./, "").trim() || fallbackHost;
+  return `https://${domain}`;
+}
+
 export interface CookieJarLike {
   get(filter: Record<string, never>): Promise<Array<{ name: string; domain?: string; path?: string }>>;
   set(cookie: ParsedCookie & { url: string }): Promise<void>;
@@ -116,7 +123,7 @@ export interface CookieJarLike {
 export interface HandoffDeps {
   request: (
     url: string,
-    init: { method: string; headers: Record<string, string>; body: string },
+    init: { method: string; headers: Record<string, string>; body: string; signal?: AbortSignal },
   ) => Promise<{ status: number; setCookieHeaders: string[] }>;
   cookieJar: CookieJarLike;
   gatewayOrigin: string;
@@ -134,6 +141,7 @@ export async function performAppSessionHandoff(
       method: "POST",
       headers: { "content-type": "application/json" },
       body: JSON.stringify({ redirectTo }),
+      signal: AbortSignal.timeout(APP_SESSION_TIMEOUT_MS),
     });
   } catch (err: unknown) {
     console.warn(
@@ -154,7 +162,9 @@ export async function performAppSessionHandoff(
     // L3: clear stale Clerk cookies before installing the fresh pair.
     const existing = await deps.cookieJar.get({});
     for (const cookie of existing) {
-      if (isStaleClerkCookie(cookie)) await deps.cookieJar.remove(deps.gatewayOrigin, cookie.name);
+      if (isStaleClerkCookie(cookie)) {
+        await deps.cookieJar.remove(removalUrlForCookie(cookie, deps.gatewayOrigin), cookie.name);
+      }
     }
     for (const name of REQUIRED_COOKIES) {
       const cookie = cookies.find((c) => c.name === name);

--- a/desktop/src/main/embeds/app-session.ts
+++ b/desktop/src/main/embeds/app-session.ts
@@ -1,0 +1,182 @@
+// Hosted-shell app-session handoff (FR-060/061). Encodes three paid-for
+// lessons: L1 (embedded-surface auth never touches the native principal — this
+// module has no access to the credential store and never escalates), L2 (BOTH
+// session cookies must land or the handoff failed), L3 (stale Clerk cookies are
+// cleared before installing the fresh pair).
+
+export const REQUIRED_COOKIES = ["matrix_app_session", "matrix_native_app_session"] as const;
+
+export interface ParsedCookie {
+  name: string;
+  value: string;
+  domain?: string;
+  path?: string;
+  expires?: number;
+  secure?: boolean;
+  httpOnly?: boolean;
+  sameSite?: "unspecified" | "no_restriction" | "lax" | "strict";
+}
+
+function mapSameSite(value: string): ParsedCookie["sameSite"] {
+  switch (value.toLowerCase()) {
+    case "lax":
+      return "lax";
+    case "strict":
+      return "strict";
+    case "none":
+      return "no_restriction";
+    default:
+      return "unspecified";
+  }
+}
+
+function parseOne(header: string): ParsedCookie | null {
+  // Electron's net response exposes set-cookie as a string[], so each header is
+  // already a single cookie — no comma splitting (which would corrupt Expires).
+  const parts = header.split(";");
+  const first = (parts[0] ?? "").trim();
+  const eq = first.indexOf("=");
+  if (eq <= 0) return null;
+  const name = first.slice(0, eq).trim();
+  if (name.length === 0) return null;
+  const value = first.slice(eq + 1);
+
+  const cookie: ParsedCookie = { name, value };
+  let maxAgeSeconds: number | null = null;
+
+  for (let i = 1; i < parts.length; i += 1) {
+    const attr = parts[i]!.trim();
+    if (attr.length === 0) continue;
+    const aeq = attr.indexOf("=");
+    const key = (aeq === -1 ? attr : attr.slice(0, aeq)).trim().toLowerCase();
+    const val = aeq === -1 ? "" : attr.slice(aeq + 1).trim();
+    switch (key) {
+      case "path":
+        cookie.path = val;
+        break;
+      case "domain":
+        cookie.domain = val;
+        break;
+      case "secure":
+        cookie.secure = true;
+        break;
+      case "httponly":
+        cookie.httpOnly = true;
+        break;
+      case "samesite":
+        cookie.sameSite = mapSameSite(val);
+        break;
+      case "expires": {
+        const ts = Date.parse(val);
+        if (!Number.isNaN(ts)) cookie.expires = ts;
+        break;
+      }
+      case "max-age": {
+        const n = Number(val);
+        if (Number.isFinite(n)) maxAgeSeconds = n;
+        break;
+      }
+      default:
+        break;
+    }
+  }
+
+  if (maxAgeSeconds !== null) cookie.expires = Date.now() + maxAgeSeconds * 1000;
+  return cookie;
+}
+
+export function parseSetCookieHeaders(headers: string[]): ParsedCookie[] {
+  const cookies: ParsedCookie[] = [];
+  for (const header of headers) {
+    const cookie = parseOne(header);
+    if (cookie) cookies.push(cookie);
+    else console.warn("[app-session] skipping malformed Set-Cookie header");
+  }
+  return cookies;
+}
+
+export function verifyCookiePair(cookies: ParsedCookie[]): boolean {
+  return REQUIRED_COOKIES.every((name) =>
+    cookies.some((cookie) => cookie.name === name && cookie.value.length > 0),
+  );
+}
+
+export function isStaleClerkCookie(cookie: { name: string; domain?: string }): boolean {
+  if (cookie.name.startsWith("__client") || cookie.name.startsWith("__session")) return true;
+  if (cookie.domain && cookie.domain.toLowerCase().includes("clerk")) return true;
+  return false;
+}
+
+export interface CookieJarLike {
+  get(filter: Record<string, never>): Promise<Array<{ name: string; domain?: string; path?: string }>>;
+  set(cookie: ParsedCookie & { url: string }): Promise<void>;
+  remove(url: string, name: string): Promise<void>;
+}
+
+export interface HandoffDeps {
+  request: (
+    url: string,
+    init: { method: string; headers: Record<string, string>; body: string },
+  ) => Promise<{ status: number; setCookieHeaders: string[] }>;
+  cookieJar: CookieJarLike;
+  gatewayOrigin: string;
+}
+
+export type HandoffResult = { ok: true } | { ok: false; reason: "auth" | "unavailable" };
+
+export async function performAppSessionHandoff(
+  deps: HandoffDeps,
+  redirectTo: string,
+): Promise<HandoffResult> {
+  let response: { status: number; setCookieHeaders: string[] };
+  try {
+    response = await deps.request(`${deps.gatewayOrigin}/api/auth/app-session`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ redirectTo }),
+    });
+  } catch (err: unknown) {
+    console.warn(
+      "[app-session] handoff request failed:",
+      err instanceof Error ? err.message : String(err),
+    );
+    return { ok: false, reason: "unavailable" };
+  }
+
+  if (response.status === 401 || response.status === 403) return { ok: false, reason: "auth" };
+  if (response.status < 200 || response.status >= 300) return { ok: false, reason: "unavailable" };
+
+  const cookies = parseSetCookieHeaders(response.setCookieHeaders);
+  // L2: a single-cookie response is an auth failure, not a partial success.
+  if (!verifyCookiePair(cookies)) return { ok: false, reason: "auth" };
+
+  try {
+    // L3: clear stale Clerk cookies before installing the fresh pair.
+    const existing = await deps.cookieJar.get({});
+    for (const cookie of existing) {
+      if (isStaleClerkCookie(cookie)) await deps.cookieJar.remove(deps.gatewayOrigin, cookie.name);
+    }
+    for (const name of REQUIRED_COOKIES) {
+      const cookie = cookies.find((c) => c.name === name);
+      if (cookie) await deps.cookieJar.set({ ...cookie, url: deps.gatewayOrigin });
+    }
+  } catch (err: unknown) {
+    console.warn(
+      "[app-session] cookie installation failed:",
+      err instanceof Error ? err.message : String(err),
+    );
+    return { ok: false, reason: "unavailable" };
+  }
+
+  return { ok: true };
+}
+
+export async function handoffWithRetry(
+  deps: HandoffDeps,
+  redirectTo: string,
+): Promise<HandoffResult> {
+  const first = await performAppSessionHandoff(deps, redirectTo);
+  if (first.ok || first.reason === "auth") return first;
+  // Exactly one retry on transient unavailability; never retry auth (L1).
+  return performAppSessionHandoff(deps, redirectTo);
+}

--- a/desktop/src/main/embeds/embed-manager.ts
+++ b/desktop/src/main/embeds/embed-manager.ts
@@ -1,0 +1,169 @@
+// Embedded surface lifecycle (FR-064, lesson L14: suspend — don't overlay).
+// At most `maxLive` embeds keep a live WebContentsView; the rest are detached
+// but restorable. Total records are capped so a runaway open loop can't grow
+// unbounded.
+import { randomUUID } from "node:crypto";
+
+export interface Bounds {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+export interface EmbedViewLike {
+  setBounds(bounds: Bounds): void;
+  loadUrl(url: string): Promise<void>;
+  attach(): void;
+  detach(): void;
+  destroy(): void;
+}
+
+export type EmbedKind = "hosted-shell" | "app";
+
+export interface EmbedManagerOptions {
+  createView: (opts: { partition: string }) => EmbedViewLike;
+  maxLive?: number;
+}
+
+export const MAX_TOTAL_EMBEDS = 12;
+const DEFAULT_MAX_LIVE = 3;
+const SAFE_SLUG = /^[a-zA-Z0-9][a-zA-Z0-9_-]*$/;
+
+interface EmbedRecord {
+  id: string;
+  url: string;
+  view: EmbedViewLike;
+  live: boolean;
+  loadFailed: boolean;
+  lastUsed: number;
+}
+
+export class EmbedManager {
+  private readonly records = new Map<string, EmbedRecord>();
+  private readonly createView: EmbedManagerOptions["createView"];
+  private readonly maxLive: number;
+  private tick = 0;
+
+  constructor(options: EmbedManagerOptions) {
+    this.createView = options.createView;
+    this.maxLive = options.maxLive ?? DEFAULT_MAX_LIVE;
+  }
+
+  open(kind: EmbedKind, slug: string | null, bounds: Bounds, url: string): string {
+    const partition =
+      kind === "hosted-shell"
+        ? "persist:hosted-shell"
+        : this.appPartition(slug);
+
+    const id = randomUUID();
+    const view = this.createView({ partition });
+    const record: EmbedRecord = {
+      id,
+      url,
+      view,
+      live: true,
+      loadFailed: false,
+      lastUsed: ++this.tick,
+    };
+    view.attach();
+    view.setBounds(bounds);
+    this.loadInto(record);
+    this.records.set(id, record);
+
+    this.enforceMaxLive();
+    this.enforceTotalCap();
+    return id;
+  }
+
+  setBounds(embedId: string, bounds: Bounds): boolean {
+    const record = this.records.get(embedId);
+    if (!record) return false;
+    record.view.setBounds(bounds);
+    return true;
+  }
+
+  focus(embedId: string): boolean {
+    const record = this.records.get(embedId);
+    if (!record) return false;
+    record.lastUsed = ++this.tick;
+    if (!record.live) {
+      record.view.attach();
+      record.live = true;
+    }
+    if (record.loadFailed) {
+      record.loadFailed = false;
+      this.loadInto(record);
+    }
+    this.enforceMaxLive();
+    return true;
+  }
+
+  close(embedId: string): boolean {
+    const record = this.records.get(embedId);
+    if (!record) return false;
+    record.view.destroy();
+    this.records.delete(embedId);
+    return true;
+  }
+
+  closeAll(): void {
+    for (const record of this.records.values()) record.view.destroy();
+    this.records.clear();
+  }
+
+  has(embedId: string): boolean {
+    return this.records.has(embedId);
+  }
+
+  get liveCount(): number {
+    let count = 0;
+    for (const record of this.records.values()) if (record.live) count += 1;
+    return count;
+  }
+
+  private appPartition(slug: string | null): string {
+    if (!slug || !SAFE_SLUG.test(slug)) {
+      throw new Error("invalid app slug for embed partition");
+    }
+    return `persist:app-${slug}`;
+  }
+
+  private loadInto(record: EmbedRecord): void {
+    void record.view.loadUrl(record.url).catch((err: unknown) => {
+      console.warn(
+        "[embed-manager] embed load failed:",
+        err instanceof Error ? err.message : String(err),
+      );
+      record.loadFailed = true;
+    });
+  }
+
+  private enforceMaxLive(): void {
+    while (this.liveCount > this.maxLive) {
+      const victim = this.leastRecentlyUsed((r) => r.live);
+      if (!victim) break;
+      victim.view.detach();
+      victim.live = false;
+    }
+  }
+
+  private enforceTotalCap(): void {
+    while (this.records.size > MAX_TOTAL_EMBEDS) {
+      const victim =
+        this.leastRecentlyUsed((r) => !r.live) ?? this.leastRecentlyUsed(() => true);
+      if (!victim) break;
+      victim.view.destroy();
+      this.records.delete(victim.id);
+    }
+  }
+
+  private leastRecentlyUsed(predicate: (record: EmbedRecord) => boolean): EmbedRecord | null {
+    let chosen: EmbedRecord | null = null;
+    for (const record of this.records.values()) {
+      if (!predicate(record)) continue;
+      if (!chosen || record.lastUsed < chosen.lastUsed) chosen = record;
+    }
+    return chosen;
+  }
+}

--- a/desktop/src/main/embeds/embed-manager.ts
+++ b/desktop/src/main/embeds/embed-manager.ts
@@ -107,13 +107,13 @@ export class EmbedManager {
   close(embedId: string): boolean {
     const record = this.records.get(embedId);
     if (!record) return false;
-    record.view.destroy();
+    this.destroyRecord(record);
     this.records.delete(embedId);
     return true;
   }
 
   closeAll(): void {
-    for (const record of this.records.values()) record.view.destroy();
+    for (const record of this.records.values()) this.destroyRecord(record);
     this.records.clear();
   }
 
@@ -158,13 +158,17 @@ export class EmbedManager {
       const victim =
         this.leastRecentlyUsed((r) => !r.live) ?? this.leastRecentlyUsed(() => true);
       if (!victim) break;
-      if (victim.live) {
-        victim.view.detach();
-        victim.live = false;
-      }
-      victim.view.destroy();
+      this.destroyRecord(victim);
       this.records.delete(victim.id);
     }
+  }
+
+  private destroyRecord(record: EmbedRecord): void {
+    if (record.live) {
+      record.view.detach();
+      record.live = false;
+    }
+    record.view.destroy();
   }
 
   private leastRecentlyUsed(predicate: (record: EmbedRecord) => boolean): EmbedRecord | null {

--- a/desktop/src/main/embeds/embed-manager.ts
+++ b/desktop/src/main/embeds/embed-manager.ts
@@ -3,6 +3,7 @@
 // but restorable. Total records are capped so a runaway open loop can't grow
 // unbounded.
 import { randomUUID } from "node:crypto";
+import { isNavigationAllowed } from "./origin-policy";
 
 export interface Bounds {
   x: number;
@@ -23,6 +24,7 @@ export type EmbedKind = "hosted-shell" | "app";
 
 export interface EmbedManagerOptions {
   createView: (opts: { partition: string }) => EmbedViewLike;
+  allowedOrigins: string[];
   maxLive?: number;
 }
 
@@ -42,11 +44,13 @@ interface EmbedRecord {
 export class EmbedManager {
   private readonly records = new Map<string, EmbedRecord>();
   private readonly createView: EmbedManagerOptions["createView"];
+  private readonly allowedOrigins: string[];
   private readonly maxLive: number;
   private tick = 0;
 
   constructor(options: EmbedManagerOptions) {
     this.createView = options.createView;
+    this.allowedOrigins = options.allowedOrigins;
     this.maxLive = options.maxLive ?? DEFAULT_MAX_LIVE;
     if (this.maxLive > MAX_TOTAL_EMBEDS) {
       throw new Error(
@@ -56,6 +60,10 @@ export class EmbedManager {
   }
 
   open(kind: EmbedKind, slug: string | null, bounds: Bounds, url: string): string {
+    if (!isNavigationAllowed(url, this.allowedOrigins)) {
+      throw new Error("embed URL is not allowed");
+    }
+
     const partition =
       kind === "hosted-shell"
         ? "persist:hosted-shell"

--- a/desktop/src/main/embeds/embed-manager.ts
+++ b/desktop/src/main/embeds/embed-manager.ts
@@ -48,6 +48,11 @@ export class EmbedManager {
   constructor(options: EmbedManagerOptions) {
     this.createView = options.createView;
     this.maxLive = options.maxLive ?? DEFAULT_MAX_LIVE;
+    if (this.maxLive > MAX_TOTAL_EMBEDS) {
+      throw new Error(
+        `maxLive (${this.maxLive}) must not exceed MAX_TOTAL_EMBEDS (${MAX_TOTAL_EMBEDS})`,
+      );
+    }
   }
 
   open(kind: EmbedKind, slug: string | null, bounds: Bounds, url: string): string {
@@ -153,6 +158,10 @@ export class EmbedManager {
       const victim =
         this.leastRecentlyUsed((r) => !r.live) ?? this.leastRecentlyUsed(() => true);
       if (!victim) break;
+      if (victim.live) {
+        victim.view.detach();
+        victim.live = false;
+      }
       victim.view.destroy();
       this.records.delete(victim.id);
     }

--- a/desktop/src/main/embeds/launch-token-cache.ts
+++ b/desktop/src/main/embeds/launch-token-cache.ts
@@ -1,0 +1,45 @@
+// Bridged-app launch token cache (FR-063): bounded LRU with a TTL safety
+// margin so a token isn't reused right before it expires.
+
+export interface LaunchToken {
+  launchUrl: string;
+  expiresAt: number;
+}
+
+const TTL_MARGIN_MS = 30_000;
+const DEFAULT_CAP = 32;
+
+export class LaunchTokenCache {
+  private readonly entries = new Map<string, LaunchToken>();
+  private readonly cap: number;
+  private readonly clock: () => number;
+
+  constructor(options?: { cap?: number; clock?: () => number }) {
+    this.cap = options?.cap ?? DEFAULT_CAP;
+    this.clock = options?.clock ?? Date.now;
+  }
+
+  get(slug: string): LaunchToken | null {
+    const token = this.entries.get(slug);
+    if (!token) return null;
+    if (this.clock() > token.expiresAt - TTL_MARGIN_MS) return null;
+    // Refresh recency.
+    this.entries.delete(slug);
+    this.entries.set(slug, token);
+    return token;
+  }
+
+  set(slug: string, token: LaunchToken): void {
+    if (this.entries.has(slug)) this.entries.delete(slug);
+    this.entries.set(slug, token);
+    while (this.entries.size > this.cap) {
+      const oldest = this.entries.keys().next().value as string | undefined;
+      if (oldest === undefined) break;
+      this.entries.delete(oldest);
+    }
+  }
+
+  clear(): void {
+    this.entries.clear();
+  }
+}

--- a/desktop/src/main/embeds/launch-token-cache.ts
+++ b/desktop/src/main/embeds/launch-token-cache.ts
@@ -22,7 +22,10 @@ export class LaunchTokenCache {
   get(slug: string): LaunchToken | null {
     const token = this.entries.get(slug);
     if (!token) return null;
-    if (this.clock() > token.expiresAt - TTL_MARGIN_MS) return null;
+    if (this.clock() > token.expiresAt - TTL_MARGIN_MS) {
+      this.entries.delete(slug);
+      return null;
+    }
     // Refresh recency.
     this.entries.delete(slug);
     this.entries.set(slug, token);

--- a/desktop/src/main/embeds/origin-policy.ts
+++ b/desktop/src/main/embeds/origin-policy.ts
@@ -1,0 +1,48 @@
+// Origin policy for embedded surfaces (FR-062/FR-064). Bridged app launch URLs
+// must be relative and resolve to the gateway origin; embedded navigation is
+// restricted to an explicit origin allowlist.
+
+export function resolveLaunchUrl(launchUrl: string, gatewayOrigin: string): string | null {
+  // Must be a rooted path, never protocol-relative or scheme'd.
+  if (!launchUrl.startsWith("/") || launchUrl.startsWith("//")) return null;
+
+  let gateway: URL;
+  try {
+    gateway = new URL(gatewayOrigin);
+  } catch {
+    return null;
+  }
+
+  let resolved: URL;
+  try {
+    resolved = new URL(launchUrl, gateway);
+  } catch {
+    return null;
+  }
+
+  // URL resolution collapses traversal and (for special schemes) backslash
+  // authority tricks; the origin check is the final arbiter.
+  if (resolved.origin !== gateway.origin) return null;
+  return resolved.toString();
+}
+
+export function isNavigationAllowed(targetUrl: string, allowedOrigins: string[]): boolean {
+  let target: URL;
+  try {
+    target = new URL(targetUrl);
+  } catch {
+    return false;
+  }
+  if (target.protocol !== "https:" && target.protocol !== "http:") return false;
+
+  for (const origin of allowedOrigins) {
+    let allowed: URL;
+    try {
+      allowed = new URL(origin);
+    } catch {
+      continue;
+    }
+    if (target.origin === allowed.origin) return true;
+  }
+  return false;
+}

--- a/desktop/src/main/index.ts
+++ b/desktop/src/main/index.ts
@@ -5,6 +5,7 @@ import { createCredentialStore } from "./auth/credential-store";
 import { installHeaderInjection } from "./auth/header-injection";
 import { registerIpcHandlers } from "./ipc/handlers";
 import { createLocalStore } from "./persistence/local-store";
+import { installAppMenu } from "./platform/menu";
 import { EVENT_CHANNELS, type EventChannel, type EventPayload } from "../shared/ipc-contract";
 
 const DEFAULT_PLATFORM_HOST = "https://app.matrix-os.com";
@@ -177,6 +178,7 @@ if (!gotLock) {
       };
 
       await openMainWindow();
+      installAppMenu(() => mainWindow);
 
       app.on("activate", () => {
         if (BrowserWindow.getAllWindows().length === 0) {

--- a/desktop/src/main/platform/menu.ts
+++ b/desktop/src/main/platform/menu.ts
@@ -1,0 +1,84 @@
+// macOS application menu (US6): standard roles so copy/paste, window
+// management, and full-screen behave like a first-class Mac app.
+import { app, Menu, shell, type BrowserWindow, type MenuItemConstructorOptions } from "electron";
+
+export function installAppMenu(getWindow: () => BrowserWindow | null): void {
+  const send = (channel: string, payload: unknown) => {
+    getWindow()?.webContents.send(channel, payload);
+  };
+
+  const template: MenuItemConstructorOptions[] = [
+    {
+      label: app.name,
+      submenu: [
+        { role: "about" },
+        { type: "separator" },
+        {
+          label: "Settings…",
+          accelerator: "Cmd+,",
+          click: () => send("menu:navigate", { kind: "settings" }),
+        },
+        { type: "separator" },
+        { role: "services" },
+        { type: "separator" },
+        { role: "hide" },
+        { role: "hideOthers" },
+        { role: "unhide" },
+        { type: "separator" },
+        { role: "quit" },
+      ],
+    },
+    {
+      label: "File",
+      submenu: [
+        {
+          label: "New Task",
+          accelerator: "Cmd+N",
+          click: () => send("menu:action", { action: "new-task" }),
+        },
+        {
+          label: "New Agent Thread",
+          accelerator: "Cmd+J",
+          click: () => send("menu:action", { action: "new-thread" }),
+        },
+        { type: "separator" },
+        { role: "close" },
+      ],
+    },
+    { role: "editMenu" },
+    {
+      label: "View",
+      submenu: [
+        {
+          label: "Command Palette",
+          accelerator: "Cmd+K",
+          click: () => send("menu:action", { action: "palette" }),
+        },
+        {
+          label: "Go to File",
+          accelerator: "Cmd+P",
+          click: () => send("menu:action", { action: "quick-open" }),
+        },
+        { type: "separator" },
+        { role: "togglefullscreen" },
+        ...(app.isPackaged
+          ? []
+          : ([{ type: "separator" }, { role: "reload" }, { role: "toggleDevTools" }] as MenuItemConstructorOptions[])),
+      ],
+    },
+    { role: "windowMenu" },
+    {
+      role: "help",
+      submenu: [
+        {
+          label: "Matrix OS Documentation",
+          click: () => {
+            void shell.openExternal("https://matrix-os.com/docs");
+          },
+        },
+      ],
+    },
+  ];
+
+  Menu.setApplicationMenu(Menu.buildFromTemplate(template));
+}

--- a/desktop/src/shared/ipc-contract.ts
+++ b/desktop/src/shared/ipc-contract.ts
@@ -170,6 +170,10 @@ export const EVENT_CHANNELS = {
   "update:available": z.object({ version: z.string().max(64) }).strict(),
   "update:ready": z.object({ version: z.string().max(64) }).strict(),
   "window:focus-changed": z.object({ focused: z.boolean() }).strict(),
+  "menu:action": z
+    .object({ action: z.enum(["new-task", "new-thread", "palette", "quick-open"]) })
+    .strict(),
+  "menu:navigate": z.object({ kind: z.enum(["settings", "board"]) }).strict(),
 } as const;
 
 export type InvokeChannel = keyof typeof INVOKE_CHANNELS;

--- a/tests/desktop/app-session.test.ts
+++ b/tests/desktop/app-session.test.ts
@@ -1,0 +1,316 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  REQUIRED_COOKIES,
+  handoffWithRetry,
+  isStaleClerkCookie,
+  parseSetCookieHeaders,
+  performAppSessionHandoff,
+  verifyCookiePair,
+  type HandoffDeps,
+  type ParsedCookie,
+} from "@desktop/main/embeds/app-session";
+
+const GATEWAY = "https://app.matrix-os.com";
+
+type ScriptedResponse = { status: number; setCookieHeaders: string[] } | Error;
+
+function scriptedDeps(
+  script: ScriptedResponse[],
+  jarCookies: Array<{ name: string; domain?: string; path?: string }> = [],
+) {
+  const requests: Array<{
+    url: string;
+    init: { method: string; headers: Record<string, string>; body: string };
+  }> = [];
+  const ops: string[] = [];
+  const deps: HandoffDeps = {
+    gatewayOrigin: GATEWAY,
+    request: async (url, init) => {
+      requests.push({ url, init });
+      const next = script.shift();
+      if (!next) throw new Error("unscripted request");
+      if (next instanceof Error) throw next;
+      return next;
+    },
+    cookieJar: {
+      get: async () => {
+        ops.push("jar:get");
+        return jarCookies;
+      },
+      set: async (cookie) => {
+        ops.push(`jar:set:${cookie.name}@${cookie.url}`);
+      },
+      remove: async (_url, name) => {
+        ops.push(`jar:remove:${name}`);
+      },
+    },
+  };
+  return { deps, requests, ops };
+}
+
+const BOTH_COOKIES: ScriptedResponse = {
+  status: 200,
+  setCookieHeaders: [
+    "matrix_app_session=app-value; Path=/; HttpOnly; Secure; SameSite=Lax",
+    "matrix_native_app_session=native-value; Path=/; Secure",
+  ],
+};
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("parseSetCookieHeaders", () => {
+  it("parses multiple headers with attributes", () => {
+    const cookies = parseSetCookieHeaders([
+      "matrix_app_session=abc123; Path=/; HttpOnly; Secure; SameSite=Lax; Domain=.matrix-os.com",
+      "matrix_native_app_session=def456; Path=/app; Secure",
+    ]);
+    expect(cookies).toHaveLength(2);
+    expect(cookies[0]).toEqual({
+      name: "matrix_app_session",
+      value: "abc123",
+      path: "/",
+      httpOnly: true,
+      secure: true,
+      sameSite: "lax",
+      domain: ".matrix-os.com",
+    });
+    expect(cookies[1]).toEqual({
+      name: "matrix_native_app_session",
+      value: "def456",
+      path: "/app",
+      secure: true,
+    });
+  });
+
+  it("keeps comma-containing Expires values intact", () => {
+    // Headers arrive pre-split as an array (Electron's net response gives
+    // set-cookie as string[]), so the comma inside the Expires date never
+    // requires splitting a combined header string.
+    const expires = "Wed, 21 Oct 2026 07:28:00 GMT";
+    const cookies = parseSetCookieHeaders([`matrix_app_session=abc; Expires=${expires}; Path=/`]);
+    expect(cookies).toHaveLength(1);
+    expect(cookies[0]?.name).toBe("matrix_app_session");
+    expect(cookies[0]?.expires).toBe(Date.parse(expires));
+    expect(cookies[0]?.path).toBe("/");
+  });
+
+  it("treats attribute names case-insensitively", () => {
+    const cookies = parseSetCookieHeaders([
+      "x=y; PATH=/foo; HTTPONLY; secure; SAMESITE=STRICT; DOMAIN=.example.com",
+    ]);
+    expect(cookies[0]).toEqual({
+      name: "x",
+      value: "y",
+      path: "/foo",
+      httpOnly: true,
+      secure: true,
+      sameSite: "strict",
+      domain: ".example.com",
+    });
+  });
+
+  it("keeps '=' characters inside cookie values", () => {
+    const cookies = parseSetCookieHeaders(["tok=a=b=c; Path=/"]);
+    expect(cookies[0]?.name).toBe("tok");
+    expect(cookies[0]?.value).toBe("a=b=c");
+  });
+
+  it("maps SameSite=None to no_restriction and unknown values to unspecified", () => {
+    const cookies = parseSetCookieHeaders(["a=1; SameSite=None", "b=2; SameSite=Bogus"]);
+    expect(cookies[0]?.sameSite).toBe("no_restriction");
+    expect(cookies[1]?.sameSite).toBe("unspecified");
+  });
+
+  it("derives expires from Max-Age relative to now", () => {
+    const before = Date.now();
+    const cookies = parseSetCookieHeaders(["a=1; Max-Age=3600"]);
+    const after = Date.now();
+    expect(cookies[0]?.expires).toBeGreaterThanOrEqual(before + 3_600_000);
+    expect(cookies[0]?.expires).toBeLessThanOrEqual(after + 3_600_000);
+  });
+
+  it("skips malformed headers with a warning", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    expect(parseSetCookieHeaders(["", "; Path=/", "=value"])).toEqual([]);
+    expect(warn).toHaveBeenCalled();
+  });
+});
+
+describe("verifyCookiePair", () => {
+  const pair: ParsedCookie[] = [
+    { name: "matrix_app_session", value: "a" },
+    { name: "matrix_native_app_session", value: "b" },
+  ];
+
+  it("requires both cookies (L2: single-cookie success bug)", () => {
+    expect(verifyCookiePair(pair)).toBe(true);
+    expect(verifyCookiePair([pair[0] as ParsedCookie])).toBe(false);
+    expect(verifyCookiePair([pair[1] as ParsedCookie])).toBe(false);
+    expect(verifyCookiePair([])).toBe(false);
+  });
+
+  it("rejects empty values", () => {
+    expect(
+      verifyCookiePair([
+        { name: "matrix_app_session", value: "" },
+        { name: "matrix_native_app_session", value: "b" },
+      ]),
+    ).toBe(false);
+  });
+
+  it("ignores unrelated cookies", () => {
+    expect(verifyCookiePair([...pair, { name: "other", value: "x" }])).toBe(true);
+  });
+
+  it("exports the required cookie names", () => {
+    expect(REQUIRED_COOKIES).toEqual(["matrix_app_session", "matrix_native_app_session"]);
+  });
+});
+
+describe("isStaleClerkCookie", () => {
+  it("flags __client and __session prefixed names (L3)", () => {
+    expect(isStaleClerkCookie({ name: "__client" })).toBe(true);
+    expect(isStaleClerkCookie({ name: "__client_uat" })).toBe(true);
+    expect(isStaleClerkCookie({ name: "__session" })).toBe(true);
+    expect(isStaleClerkCookie({ name: "__session_abc" })).toBe(true);
+  });
+
+  it("flags cookies on clerk domains regardless of name", () => {
+    expect(isStaleClerkCookie({ name: "anything", domain: "clerk.matrix-os.com" })).toBe(true);
+    expect(isStaleClerkCookie({ name: "anything", domain: ".Clerk.example.com" })).toBe(true);
+  });
+
+  it("leaves the matrix session cookies alone", () => {
+    expect(isStaleClerkCookie({ name: "matrix_app_session", domain: "app.matrix-os.com" })).toBe(
+      false,
+    );
+    expect(isStaleClerkCookie({ name: "matrix_native_app_session" })).toBe(false);
+  });
+});
+
+describe("performAppSessionHandoff", () => {
+  it("posts redirectTo to the app-session endpoint", async () => {
+    const { deps, requests } = scriptedDeps([BOTH_COOKIES]);
+    await performAppSessionHandoff(deps, "/canvas");
+    expect(requests).toHaveLength(1);
+    expect(requests[0]?.url).toBe(`${GATEWAY}/api/auth/app-session`);
+    expect(requests[0]?.init.method).toBe("POST");
+    expect(JSON.parse(requests[0]?.init.body ?? "{}")).toEqual({ redirectTo: "/canvas" });
+  });
+
+  it("returns auth on 401 and 403 without touching the jar", async () => {
+    for (const status of [401, 403]) {
+      const { deps, ops } = scriptedDeps([{ status, setCookieHeaders: [] }]);
+      const result = await performAppSessionHandoff(deps, "/");
+      expect(result).toEqual({ ok: false, reason: "auth" });
+      expect(ops).toEqual([]);
+    }
+  });
+
+  it("returns unavailable on other non-2xx statuses", async () => {
+    const { deps } = scriptedDeps([{ status: 503, setCookieHeaders: [] }]);
+    expect(await performAppSessionHandoff(deps, "/")).toEqual({
+      ok: false,
+      reason: "unavailable",
+    });
+  });
+
+  it("returns unavailable on network failure without throwing", async () => {
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    const { deps } = scriptedDeps([new Error("ECONNREFUSED")]);
+    expect(await performAppSessionHandoff(deps, "/")).toEqual({
+      ok: false,
+      reason: "unavailable",
+    });
+  });
+
+  it("treats a single-cookie response as auth failure and installs nothing (L2)", async () => {
+    const { deps, ops } = scriptedDeps([
+      { status: 200, setCookieHeaders: ["matrix_app_session=only-one; Path=/"] },
+    ]);
+    const result = await performAppSessionHandoff(deps, "/");
+    expect(result).toEqual({ ok: false, reason: "auth" });
+    expect(ops.filter((op) => op.startsWith("jar:set"))).toEqual([]);
+  });
+
+  it("installs both cookies into the embed jar with the gateway url", async () => {
+    const { deps, ops } = scriptedDeps([BOTH_COOKIES]);
+    const result = await performAppSessionHandoff(deps, "/canvas");
+    expect(result).toEqual({ ok: true });
+    expect(ops.filter((op) => op.startsWith("jar:set"))).toEqual([
+      `jar:set:matrix_app_session@${GATEWAY}`,
+      `jar:set:matrix_native_app_session@${GATEWAY}`,
+    ]);
+  });
+
+  it("removes stale Clerk cookies before installing (L3)", async () => {
+    const { deps, ops } = scriptedDeps(
+      [BOTH_COOKIES],
+      [
+        { name: "__client_uat", domain: "app.matrix-os.com" },
+        { name: "harmless", domain: "app.matrix-os.com" },
+        { name: "session_helper", domain: "clerk.matrix-os.com" },
+      ],
+    );
+    const result = await performAppSessionHandoff(deps, "/");
+    expect(result).toEqual({ ok: true });
+    expect(ops.filter((op) => op.startsWith("jar:remove"))).toEqual([
+      "jar:remove:__client_uat",
+      "jar:remove:session_helper",
+    ]);
+    const lastRemove = ops.lastIndexOf("jar:remove:session_helper");
+    const firstSet = ops.findIndex((op) => op.startsWith("jar:set"));
+    expect(firstSet).toBeGreaterThan(lastRemove);
+  });
+
+  it("returns unavailable when cookie installation fails", async () => {
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    const { deps } = scriptedDeps([BOTH_COOKIES]);
+    deps.cookieJar.set = async () => {
+      throw new Error("jar write failed");
+    };
+    expect(await performAppSessionHandoff(deps, "/")).toEqual({
+      ok: false,
+      reason: "unavailable",
+    });
+  });
+});
+
+describe("handoffWithRetry", () => {
+  it("retries exactly once on unavailable", async () => {
+    const { deps, requests } = scriptedDeps([{ status: 502, setCookieHeaders: [] }, BOTH_COOKIES]);
+    const result = await handoffWithRetry(deps, "/canvas");
+    expect(result).toEqual({ ok: true });
+    expect(requests).toHaveLength(2);
+  });
+
+  it("does not retry on auth failure (L1: never cascades)", async () => {
+    const { deps, requests } = scriptedDeps([{ status: 401, setCookieHeaders: [] }]);
+    const result = await handoffWithRetry(deps, "/canvas");
+    expect(result).toEqual({ ok: false, reason: "auth" });
+    expect(requests).toHaveLength(1);
+  });
+
+  it("gives up after the single retry", async () => {
+    const { deps, requests } = scriptedDeps([
+      { status: 500, setCookieHeaders: [] },
+      { status: 500, setCookieHeaders: [] },
+      BOTH_COOKIES,
+    ]);
+    const result = await handoffWithRetry(deps, "/canvas");
+    expect(result).toEqual({ ok: false, reason: "unavailable" });
+    expect(requests).toHaveLength(2);
+  });
+
+  it("never throws even when every request rejects", async () => {
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    const { deps, requests } = scriptedDeps([new Error("boom"), new Error("boom")]);
+    await expect(handoffWithRetry(deps, "/")).resolves.toEqual({
+      ok: false,
+      reason: "unavailable",
+    });
+    expect(requests).toHaveLength(2);
+  });
+});

--- a/tests/desktop/app-session.test.ts
+++ b/tests/desktop/app-session.test.ts
@@ -20,7 +20,7 @@ function scriptedDeps(
 ) {
   const requests: Array<{
     url: string;
-    init: { method: string; headers: Record<string, string>; body: string };
+    init: Parameters<HandoffDeps["request"]>[1];
   }> = [];
   const ops: string[] = [];
   const deps: HandoffDeps = {
@@ -40,8 +40,8 @@ function scriptedDeps(
       set: async (cookie) => {
         ops.push(`jar:set:${cookie.name}@${cookie.url}`);
       },
-      remove: async (_url, name) => {
-        ops.push(`jar:remove:${name}`);
+      remove: async (url, name) => {
+        ops.push(`jar:remove:${name}@${url}`);
       },
     },
   };
@@ -197,6 +197,7 @@ describe("performAppSessionHandoff", () => {
     expect(requests).toHaveLength(1);
     expect(requests[0]?.url).toBe(`${GATEWAY}/api/auth/app-session`);
     expect(requests[0]?.init.method).toBe("POST");
+    expect(requests[0]?.init.signal).toBeInstanceOf(AbortSignal);
     expect(JSON.parse(requests[0]?.init.body ?? "{}")).toEqual({ redirectTo: "/canvas" });
   });
 
@@ -257,10 +258,10 @@ describe("performAppSessionHandoff", () => {
     const result = await performAppSessionHandoff(deps, "/");
     expect(result).toEqual({ ok: true });
     expect(ops.filter((op) => op.startsWith("jar:remove"))).toEqual([
-      "jar:remove:__client_uat",
-      "jar:remove:session_helper",
+      "jar:remove:__client_uat@https://app.matrix-os.com",
+      "jar:remove:session_helper@https://clerk.matrix-os.com",
     ]);
-    const lastRemove = ops.lastIndexOf("jar:remove:session_helper");
+    const lastRemove = ops.lastIndexOf("jar:remove:session_helper@https://clerk.matrix-os.com");
     const firstSet = ops.findIndex((op) => op.startsWith("jar:set"));
     expect(firstSet).toBeGreaterThan(lastRemove);
   });

--- a/tests/desktop/embed-manager.test.ts
+++ b/tests/desktop/embed-manager.test.ts
@@ -120,6 +120,10 @@ describe("EmbedManager", () => {
     expect(views[2]?.view.events).not.toContain("detach");
   });
 
+  it("rejects maxLive values above the total embed cap", () => {
+    expect(() => makeManager(MAX_TOTAL_EMBEDS + 1)).toThrow(/maxLive/);
+  });
+
   it("focus bumps recency so the LRU choice changes", () => {
     const { manager, views } = makeManager(2);
     const a = manager.open("app", "a", BOUNDS, "https://gw.test/a");

--- a/tests/desktop/embed-manager.test.ts
+++ b/tests/desktop/embed-manager.test.ts
@@ -1,0 +1,210 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  EmbedManager,
+  MAX_TOTAL_EMBEDS,
+  type Bounds,
+  type EmbedViewLike,
+} from "@desktop/main/embeds/embed-manager";
+
+const BOUNDS: Bounds = { x: 0, y: 0, width: 800, height: 600 };
+
+class FakeView implements EmbedViewLike {
+  events: string[] = [];
+  loadedUrls: string[] = [];
+  bounds: Bounds | null = null;
+  failNextLoad: boolean;
+
+  constructor(failNextLoad = false) {
+    this.failNextLoad = failNextLoad;
+  }
+
+  setBounds(bounds: Bounds): void {
+    this.bounds = bounds;
+    this.events.push("setBounds");
+  }
+
+  async loadUrl(url: string): Promise<void> {
+    this.events.push(`load:${url}`);
+    this.loadedUrls.push(url);
+    if (this.failNextLoad) {
+      this.failNextLoad = false;
+      throw new Error("load failed");
+    }
+  }
+
+  attach(): void {
+    this.events.push("attach");
+  }
+
+  detach(): void {
+    this.events.push("detach");
+  }
+
+  destroy(): void {
+    this.events.push("destroy");
+  }
+}
+
+function makeManager(maxLive?: number) {
+  const views: Array<{ partition: string; view: FakeView }> = [];
+  let failNextCreatedLoad = false;
+  const manager = new EmbedManager({
+    createView: ({ partition }) => {
+      const view = new FakeView(failNextCreatedLoad);
+      failNextCreatedLoad = false;
+      views.push({ partition, view });
+      return view;
+    },
+    ...(maxLive === undefined ? {} : { maxLive }),
+  });
+  return {
+    manager,
+    views,
+    failNextCreatedLoad: () => {
+      failNextCreatedLoad = true;
+    },
+  };
+}
+
+function flush(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("EmbedManager", () => {
+  it("names partitions persist:hosted-shell and persist:app-<slug>", () => {
+    const { manager, views } = makeManager();
+    manager.open("hosted-shell", null, BOUNDS, "https://gw.test/canvas");
+    manager.open("app", "notes", BOUNDS, "https://gw.test/apps/notes/");
+    expect(views.map((v) => v.partition)).toEqual(["persist:hosted-shell", "persist:app-notes"]);
+  });
+
+  it("rejects app embeds without a safe slug", () => {
+    const { manager } = makeManager();
+    expect(() => manager.open("app", null, BOUNDS, "https://gw.test/")).toThrow();
+    expect(() => manager.open("app", "../evil", BOUNDS, "https://gw.test/")).toThrow();
+    expect(() => manager.open("app", "a b", BOUNDS, "https://gw.test/")).toThrow();
+  });
+
+  it("attaches, sizes, and loads new embeds", () => {
+    const { manager, views } = makeManager();
+    const id = manager.open("hosted-shell", null, BOUNDS, "https://gw.test/canvas");
+    expect(typeof id).toBe("string");
+    expect(id.length).toBeGreaterThan(0);
+    expect(manager.has(id)).toBe(true);
+    expect(manager.liveCount).toBe(1);
+    const view = views[0]?.view;
+    expect(view?.events).toContain("attach");
+    expect(view?.loadedUrls).toEqual(["https://gw.test/canvas"]);
+    expect(view?.bounds).toEqual(BOUNDS);
+  });
+
+  it("returns unique embed ids", () => {
+    const { manager } = makeManager();
+    const a = manager.open("hosted-shell", null, BOUNDS, "https://gw.test/");
+    const b = manager.open("app", "notes", BOUNDS, "https://gw.test/");
+    expect(a).not.toBe(b);
+  });
+
+  it("suspends the least-recently-used live embed beyond maxLive", () => {
+    const { manager, views } = makeManager(2);
+    manager.open("app", "a", BOUNDS, "https://gw.test/a");
+    manager.open("app", "b", BOUNDS, "https://gw.test/b");
+    manager.open("app", "c", BOUNDS, "https://gw.test/c");
+    expect(manager.liveCount).toBe(2);
+    expect(views[0]?.view.events).toContain("detach");
+    expect(views[1]?.view.events).not.toContain("detach");
+    expect(views[2]?.view.events).not.toContain("detach");
+  });
+
+  it("focus bumps recency so the LRU choice changes", () => {
+    const { manager, views } = makeManager(2);
+    const a = manager.open("app", "a", BOUNDS, "https://gw.test/a");
+    manager.open("app", "b", BOUNDS, "https://gw.test/b");
+    expect(manager.focus(a)).toBe(true);
+    manager.open("app", "c", BOUNDS, "https://gw.test/c");
+    expect(views[1]?.view.events).toContain("detach");
+    expect(views[0]?.view.events).not.toContain("detach");
+  });
+
+  it("focus resumes a suspended embed without an unnecessary reload", () => {
+    const { manager, views } = makeManager(2);
+    const a = manager.open("app", "a", BOUNDS, "https://gw.test/a");
+    manager.open("app", "b", BOUNDS, "https://gw.test/b");
+    manager.open("app", "c", BOUNDS, "https://gw.test/c");
+    const viewA = views[0]?.view;
+    expect(viewA?.events).toContain("detach");
+
+    expect(manager.focus(a)).toBe(true);
+    expect(manager.liveCount).toBe(2);
+    expect(viewA?.events.filter((e) => e === "attach")).toHaveLength(2);
+    expect(viewA?.loadedUrls).toHaveLength(1);
+    // Resuming pushed the new LRU live embed (b) out.
+    expect(views[1]?.view.events).toContain("detach");
+  });
+
+  it("reloads on focus when the initial load failed", async () => {
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    const { manager, views, failNextCreatedLoad } = makeManager();
+    failNextCreatedLoad();
+    const id = manager.open("app", "notes", BOUNDS, "https://gw.test/apps/notes/");
+    await flush();
+    expect(manager.focus(id)).toBe(true);
+    expect(views[0]?.view.loadedUrls).toEqual([
+      "https://gw.test/apps/notes/",
+      "https://gw.test/apps/notes/",
+    ]);
+  });
+
+  it("updates bounds for live embeds", () => {
+    const { manager, views } = makeManager();
+    const id = manager.open("hosted-shell", null, BOUNDS, "https://gw.test/");
+    const next = { x: 10, y: 20, width: 400, height: 300 };
+    expect(manager.setBounds(id, next)).toBe(true);
+    expect(views[0]?.view.bounds).toEqual(next);
+  });
+
+  it("close destroys the view and forgets the embed", () => {
+    const { manager, views } = makeManager();
+    const id = manager.open("hosted-shell", null, BOUNDS, "https://gw.test/");
+    expect(manager.close(id)).toBe(true);
+    expect(views[0]?.view.events).toContain("destroy");
+    expect(manager.has(id)).toBe(false);
+    expect(manager.liveCount).toBe(0);
+    expect(manager.close(id)).toBe(false);
+  });
+
+  it("returns false for unknown embed ids", () => {
+    const { manager } = makeManager();
+    expect(manager.focus("nope")).toBe(false);
+    expect(manager.setBounds("nope", BOUNDS)).toBe(false);
+    expect(manager.close("nope")).toBe(false);
+    expect(manager.has("nope")).toBe(false);
+  });
+
+  it("closeAll destroys every embed including suspended ones", () => {
+    const { manager, views } = makeManager(1);
+    manager.open("app", "a", BOUNDS, "https://gw.test/a");
+    manager.open("app", "b", BOUNDS, "https://gw.test/b");
+    manager.closeAll();
+    expect(manager.liveCount).toBe(0);
+    for (const { view } of views) {
+      expect(view.events).toContain("destroy");
+    }
+  });
+
+  it("caps total records and evicts the LRU suspended embed entirely", () => {
+    const { manager, views } = makeManager(2);
+    const ids: string[] = [];
+    for (let i = 0; i <= MAX_TOTAL_EMBEDS; i++) {
+      ids.push(manager.open("app", `app-${i}`, BOUNDS, `https://gw.test/app-${i}`));
+    }
+    expect(manager.has(ids[0] ?? "")).toBe(false);
+    expect(views[0]?.view.events).toContain("destroy");
+    expect(manager.has(ids[1] ?? "")).toBe(true);
+    expect(manager.liveCount).toBe(2);
+  });
+});

--- a/tests/desktop/embed-manager.test.ts
+++ b/tests/desktop/embed-manager.test.ts
@@ -175,7 +175,13 @@ describe("EmbedManager", () => {
     const { manager, views } = makeManager();
     const id = manager.open("hosted-shell", null, BOUNDS, "https://gw.test/");
     expect(manager.close(id)).toBe(true);
-    expect(views[0]?.view.events).toContain("destroy");
+    expect(views[0]?.view.events).toEqual([
+      "attach",
+      "setBounds",
+      "load:https://gw.test/",
+      "detach",
+      "destroy",
+    ]);
     expect(manager.has(id)).toBe(false);
     expect(manager.liveCount).toBe(0);
     expect(manager.close(id)).toBe(false);
@@ -195,9 +201,20 @@ describe("EmbedManager", () => {
     manager.open("app", "b", BOUNDS, "https://gw.test/b");
     manager.closeAll();
     expect(manager.liveCount).toBe(0);
-    for (const { view } of views) {
-      expect(view.events).toContain("destroy");
-    }
+    expect(views[0]?.view.events).toEqual([
+      "attach",
+      "setBounds",
+      "load:https://gw.test/a",
+      "detach",
+      "destroy",
+    ]);
+    expect(views[1]?.view.events).toEqual([
+      "attach",
+      "setBounds",
+      "load:https://gw.test/b",
+      "detach",
+      "destroy",
+    ]);
   });
 
   it("caps total records and evicts the LRU suspended embed entirely", () => {

--- a/tests/desktop/embed-manager.test.ts
+++ b/tests/desktop/embed-manager.test.ts
@@ -55,6 +55,7 @@ function makeManager(maxLive?: number) {
       views.push({ partition, view });
       return view;
     },
+    allowedOrigins: ["https://gw.test"],
     ...(maxLive === undefined ? {} : { maxLive }),
   });
   return {
@@ -87,6 +88,18 @@ describe("EmbedManager", () => {
     expect(() => manager.open("app", null, BOUNDS, "https://gw.test/")).toThrow();
     expect(() => manager.open("app", "../evil", BOUNDS, "https://gw.test/")).toThrow();
     expect(() => manager.open("app", "a b", BOUNDS, "https://gw.test/")).toThrow();
+  });
+
+  it("rejects embeds outside the allowed origin before creating a view", () => {
+    const { manager, views } = makeManager();
+
+    expect(() => manager.open("app", "notes", BOUNDS, "https://evil.test/apps/notes/")).toThrow(
+      /not allowed/,
+    );
+    expect(() => manager.open("hosted-shell", null, BOUNDS, "file:///tmp/index.html")).toThrow(
+      /not allowed/,
+    );
+    expect(views).toHaveLength(0);
   });
 
   it("attaches, sizes, and loads new embeds", () => {

--- a/tests/desktop/launch-token.test.ts
+++ b/tests/desktop/launch-token.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest";
+import { LaunchTokenCache, type LaunchToken } from "@desktop/main/embeds/launch-token-cache";
+
+function token(expiresAt: number, launchUrl = "/apps/notes/"): LaunchToken {
+  return { launchUrl, expiresAt };
+}
+
+describe("LaunchTokenCache", () => {
+  it("returns cached tokens while fresh", () => {
+    let now = 1_000_000;
+    const cache = new LaunchTokenCache({ clock: () => now });
+    cache.set("notes", token(now + 120_000));
+    expect(cache.get("notes")).toEqual(token(1_120_000));
+  });
+
+  it("returns null for unknown slugs", () => {
+    const cache = new LaunchTokenCache({ clock: () => 0 });
+    expect(cache.get("missing")).toBeNull();
+  });
+
+  it("treats tokens within 30s of expiry as stale (TTL safety margin)", () => {
+    let now = 1_000_000;
+    const cache = new LaunchTokenCache({ clock: () => now });
+    const expiresAt = now + 60_000;
+    cache.set("notes", token(expiresAt));
+
+    now = expiresAt - 30_000;
+    expect(cache.get("notes")).toEqual(token(expiresAt));
+
+    now = expiresAt - 29_999;
+    expect(cache.get("notes")).toBeNull();
+  });
+
+  it("evicts the least-recently-used entry beyond the cap", () => {
+    let now = 0;
+    const cache = new LaunchTokenCache({ cap: 2, clock: () => now });
+    cache.set("a", token(100_000, "/a"));
+    cache.set("b", token(100_000, "/b"));
+    cache.set("c", token(100_000, "/c"));
+    expect(cache.get("a")).toBeNull();
+    expect(cache.get("b")).toEqual(token(100_000, "/b"));
+    expect(cache.get("c")).toEqual(token(100_000, "/c"));
+  });
+
+  it("refreshes recency on get", () => {
+    let now = 0;
+    const cache = new LaunchTokenCache({ cap: 2, clock: () => now });
+    cache.set("a", token(100_000, "/a"));
+    cache.set("b", token(100_000, "/b"));
+    cache.get("a");
+    cache.set("c", token(100_000, "/c"));
+    expect(cache.get("a")).toEqual(token(100_000, "/a"));
+    expect(cache.get("b")).toBeNull();
+  });
+
+  it("refreshes recency and replaces the token on re-set", () => {
+    let now = 0;
+    const cache = new LaunchTokenCache({ cap: 2, clock: () => now });
+    cache.set("a", token(100_000, "/a"));
+    cache.set("b", token(100_000, "/b"));
+    cache.set("a", token(200_000, "/a2"));
+    cache.set("c", token(100_000, "/c"));
+    expect(cache.get("a")).toEqual(token(200_000, "/a2"));
+    expect(cache.get("b")).toBeNull();
+  });
+
+  it("defaults the cap to 32", () => {
+    let now = 0;
+    const cache = new LaunchTokenCache({ clock: () => now });
+    for (let i = 0; i < 33; i++) {
+      cache.set(`app-${i}`, token(100_000, `/app-${i}`));
+    }
+    expect(cache.get("app-0")).toBeNull();
+    expect(cache.get("app-1")).toEqual(token(100_000, "/app-1"));
+    expect(cache.get("app-32")).toEqual(token(100_000, "/app-32"));
+  });
+
+  it("clears all entries", () => {
+    let now = 0;
+    const cache = new LaunchTokenCache({ clock: () => now });
+    cache.set("a", token(100_000));
+    cache.clear();
+    expect(cache.get("a")).toBeNull();
+  });
+});

--- a/tests/desktop/launch-token.test.ts
+++ b/tests/desktop/launch-token.test.ts
@@ -53,6 +53,20 @@ describe("LaunchTokenCache", () => {
     expect(cache.get("b")).toBeNull();
   });
 
+  it("evicts stale entries on get before later cap enforcement", () => {
+    let now = 0;
+    const cache = new LaunchTokenCache({ cap: 2, clock: () => now });
+    cache.set("fresh", token(200_000, "/fresh"));
+    cache.set("stale", token(60_000, "/stale"));
+
+    now = 40_000;
+    expect(cache.get("stale")).toBeNull();
+    cache.set("new", token(200_000, "/new"));
+
+    expect(cache.get("fresh")).toEqual(token(200_000, "/fresh"));
+    expect(cache.get("new")).toEqual(token(200_000, "/new"));
+  });
+
   it("refreshes recency and replaces the token on re-set", () => {
     let now = 0;
     const cache = new LaunchTokenCache({ cap: 2, clock: () => now });

--- a/tests/desktop/origin-policy.test.ts
+++ b/tests/desktop/origin-policy.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from "vitest";
+import { isNavigationAllowed, resolveLaunchUrl } from "@desktop/main/embeds/origin-policy";
+
+const GATEWAY = "https://app.matrix-os.com";
+
+describe("resolveLaunchUrl", () => {
+  it("resolves a relative launch url against the gateway origin", () => {
+    expect(resolveLaunchUrl("/apps/notes/", GATEWAY)).toBe("https://app.matrix-os.com/apps/notes/");
+  });
+
+  it("preserves query and hash", () => {
+    expect(resolveLaunchUrl("/apps/notes/?token=abc#view", GATEWAY)).toBe(
+      "https://app.matrix-os.com/apps/notes/?token=abc#view",
+    );
+  });
+
+  it("rejects protocol-relative urls", () => {
+    expect(resolveLaunchUrl("//evil.com/apps", GATEWAY)).toBeNull();
+    expect(resolveLaunchUrl("//app.matrix-os.com/apps", GATEWAY)).toBeNull();
+  });
+
+  it("rejects absolute urls even when same-origin", () => {
+    expect(resolveLaunchUrl("https://evil.com/apps", GATEWAY)).toBeNull();
+    expect(resolveLaunchUrl("https://app.matrix-os.com/apps", GATEWAY)).toBeNull();
+    expect(resolveLaunchUrl("https://app.matrix-os.com.evil.tld/apps", GATEWAY)).toBeNull();
+  });
+
+  it("rejects scheme'd urls", () => {
+    expect(resolveLaunchUrl("javascript:alert(1)", GATEWAY)).toBeNull();
+    expect(resolveLaunchUrl("data:text/html,hi", GATEWAY)).toBeNull();
+  });
+
+  it("rejects empty and non-rooted paths", () => {
+    expect(resolveLaunchUrl("", GATEWAY)).toBeNull();
+    expect(resolveLaunchUrl("apps/notes", GATEWAY)).toBeNull();
+  });
+
+  it("allows path traversal that stays same-origin", () => {
+    expect(resolveLaunchUrl("/apps/../api/files", GATEWAY)).toBe(
+      "https://app.matrix-os.com/api/files",
+    );
+    // "/..//evil.com" resolves to a same-origin path ("//evil.com" is a path
+    // here, not an authority) — URL resolution + origin equality decides.
+    expect(resolveLaunchUrl("/..//evil.com", GATEWAY)).toBe(
+      "https://app.matrix-os.com//evil.com",
+    );
+  });
+
+  it("rejects backslash authority tricks", () => {
+    // For special schemes the URL parser treats "/\" like "//" — the resolved
+    // origin becomes evil.com, which the origin check rejects.
+    expect(resolveLaunchUrl("/\\evil.com", GATEWAY)).toBeNull();
+    expect(resolveLaunchUrl("\\\\evil.com", GATEWAY)).toBeNull();
+  });
+
+  it("rejects when the gateway origin itself is invalid", () => {
+    expect(resolveLaunchUrl("/apps/notes/", "not a url")).toBeNull();
+  });
+});
+
+describe("isNavigationAllowed", () => {
+  const ALLOWED = ["https://app.matrix-os.com"];
+
+  it("allows exact-origin matches only", () => {
+    expect(isNavigationAllowed("https://app.matrix-os.com/canvas", ALLOWED)).toBe(true);
+    expect(isNavigationAllowed("https://app.matrix-os.com/", ALLOWED)).toBe(true);
+  });
+
+  it("rejects scheme, host, and port mismatches", () => {
+    expect(isNavigationAllowed("http://app.matrix-os.com/canvas", ALLOWED)).toBe(false);
+    expect(isNavigationAllowed("https://app.matrix-os.com:8443/canvas", ALLOWED)).toBe(false);
+    expect(isNavigationAllowed("https://evil.com/", ALLOWED)).toBe(false);
+    expect(isNavigationAllowed("https://sub.app.matrix-os.com/", ALLOWED)).toBe(false);
+    expect(isNavigationAllowed("https://app.matrix-os.com.evil.tld/", ALLOWED)).toBe(false);
+  });
+
+  it("rejects invalid urls", () => {
+    expect(isNavigationAllowed("not a url", ALLOWED)).toBe(false);
+    expect(isNavigationAllowed("", ALLOWED)).toBe(false);
+  });
+
+  it("rejects non-http(s) schemes regardless of allowlist", () => {
+    expect(isNavigationAllowed("javascript:alert(1)", ALLOWED)).toBe(false);
+    expect(isNavigationAllowed("file:///etc/passwd", ALLOWED)).toBe(false);
+    expect(isNavigationAllowed("ftp://app.matrix-os.com/", ALLOWED)).toBe(false);
+  });
+
+  it("matches against multiple allowed origins", () => {
+    const origins = ["https://app.matrix-os.com", "http://localhost:18789"];
+    expect(isNavigationAllowed("http://localhost:18789/apps", origins)).toBe(true);
+    expect(isNavigationAllowed("http://localhost:9999/apps", origins)).toBe(false);
+  });
+
+  it("returns false for an empty allowlist", () => {
+    expect(isNavigationAllowed("https://app.matrix-os.com/", [])).toBe(false);
+  });
+
+  it("skips malformed allowlist entries without matching", () => {
+    expect(isNavigationAllowed("https://app.matrix-os.com/", ["garbage", GATEWAY])).toBe(true);
+    expect(isNavigationAllowed("https://evil.com/", ["garbage"])).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds native app embed session management, launch-token cache, origin policy, menu integration, and tests.
- Part of the 094 Operator desktop stack split from original PR #507.
- Draft until the full stack validation and screenshots are refreshed.

## Validation
- Rebased onto current main after #506 merged.
- Rebuilt stack final tree matches the original #507 tree exactly.
- Per-layer CI/Greptile still needs to settle before review-ready.

## Invariants
- Source of truth: desktop app source under desktop/, specs/docs, and root workspace metadata in this stack; no owner runtime data is modified.
- Lock/transaction scope: no Postgres transaction scope is introduced in this layer; desktop local state remains scoped to the Electron app and existing gateway/platform APIs.
- Acceptable orphan states: stack PRs are draft and must land in order; partial stack landing is not a supported release state.
- Auth source of truth: Clerk/device auth and existing gateway token handling remain authoritative; this stack does not add a second auth authority.
- Deferred scope: packaged distribution, production desktop rollout, and customer VPS host-bundle deploy are outside this stack.