### PR TITLE
feat(desktop): add workspace editor and quick-open tools

### DIFF
--- a/desktop/src/main/ipc/handlers.ts
+++ b/desktop/src/main/ipc/handlers.ts
@@ -86,6 +86,18 @@ export function registerIpcHandlers(ipcMain: IpcMainLike, ctx: HandlerContext): 
     }
     return { ok: true };
   });
+  handle("state:set-panel-layout", async ({ taskKey, layout }) => {
+    try {
+      await ctx.store.setPanelLayout(taskKey, layout);
+    } catch (err: unknown) {
+      console.warn(
+        "[ipc] state:set-panel-layout rejected:",
+        err instanceof Error ? err.message : String(err),
+      );
+      throw new Error("invalid request");
+    }
+    return { ok: true };
+  });
 
   handle("shell:open-external", async ({ url }) => {
     await ctx.openExternal(url);

--- a/desktop/src/renderer/src/features/editor/EditorPanel.tsx
+++ b/desktop/src/renderer/src/features/editor/EditorPanel.tsx
@@ -12,7 +12,7 @@ export default function EditorPanel({ taskId }: { taskId: string }) {
   const activePath = useEditorTabs((s) => s.activePathByTask[taskId] ?? null);
   const setActive = useEditorTabs((s) => s.setActive);
   const closeTab = useEditorTabs((s) => s.closeTab);
-  const dirtyPaths = useEditorTabs((s) => s.dirtyPaths);
+  const dirtyPaths = useEditorTabs((s) => s.dirtyPathsByTask[taskId] ?? []);
 
   if (tabs.length === 0) {
     return (

--- a/desktop/src/renderer/src/features/editor/EditorPanel.tsx
+++ b/desktop/src/renderer/src/features/editor/EditorPanel.tsx
@@ -92,9 +92,11 @@ export function useEditorOpenFile(taskId: string) {
 export function ConflictBar({
   onOverwrite,
   onReload,
+  busy = false,
 }: {
   onOverwrite: () => void;
   onReload: () => void;
+  busy?: boolean;
 }) {
   return (
     <div
@@ -105,10 +107,10 @@ export function ConflictBar({
         This file changed on your computer since you opened it.
       </span>
       <div className="flex gap-2">
-        <Button variant="subtle" onClick={onReload}>
+        <Button variant="subtle" disabled={busy} onClick={onReload}>
           Reload
         </Button>
-        <Button variant="danger" onClick={onOverwrite}>
+        <Button variant="danger" disabled={busy} onClick={onOverwrite}>
           Overwrite
         </Button>
       </div>

--- a/desktop/src/renderer/src/features/editor/EditorPanel.tsx
+++ b/desktop/src/renderer/src/features/editor/EditorPanel.tsx
@@ -1,0 +1,136 @@
+import { FileCode2, X } from "lucide-react";
+import { lazy, Suspense, useCallback, useEffect, useRef, useState } from "react";
+import { Button, EmptyState } from "../../design/primitives";
+import { useConnection } from "../../stores/connection";
+import { useEditorTabs } from "./editor-tabs-store";
+
+const MonacoHost = lazy(() => import("./MonacoHost"));
+
+export default function EditorPanel({ taskId }: { taskId: string }) {
+  const api = useConnection((s) => s.api);
+  const tabs = useEditorTabs((s) => s.tabsByTask[taskId] ?? []);
+  const activePath = useEditorTabs((s) => s.activePathByTask[taskId] ?? null);
+  const setActive = useEditorTabs((s) => s.setActive);
+  const closeTab = useEditorTabs((s) => s.closeTab);
+  const dirtyPaths = useEditorTabs((s) => s.dirtyPaths);
+
+  if (tabs.length === 0) {
+    return (
+      <EmptyState
+        icon={<FileCode2 size={24} />}
+        headline="No file open"
+        description="Open a file from the file browser or press ⌘P to quick-open."
+      />
+    );
+  }
+
+  return (
+    <div className="flex min-h-0 min-w-0 flex-1 flex-col">
+      <div
+        className="flex shrink-0 items-center gap-0.5 overflow-x-auto border-b px-1 pt-1"
+        style={{ borderColor: "var(--border-subtle)" }}
+      >
+        {tabs.map((path) => {
+          const name = path.split("/").pop() ?? path;
+          const active = path === activePath;
+          const dirty = dirtyPaths.includes(path);
+          return (
+            <div
+              key={path}
+              className="flex max-w-[180px] items-center gap-1.5 rounded-t-md border border-b-0 px-2.5 py-1.5 text-sm"
+              style={{
+                background: active ? "var(--bg-raised)" : "transparent",
+                borderColor: active ? "var(--border-subtle)" : "transparent",
+                color: active ? "var(--text-primary)" : "var(--text-tertiary)",
+              }}
+            >
+              <button
+                type="button"
+                className="min-w-0 truncate"
+                title={path}
+                onClick={() => setActive(taskId, path)}
+              >
+                {name}
+              </button>
+              {dirty ? (
+                <span className="h-1.5 w-1.5 shrink-0 rounded-full" style={{ background: "var(--accent)" }} />
+              ) : null}
+              <button
+                type="button"
+                aria-label={`Close ${name}`}
+                className="shrink-0 rounded p-0.5 hover:bg-[var(--bg-hover)]"
+                onClick={() => closeTab(taskId, path)}
+              >
+                <X size={11} />
+              </button>
+            </div>
+          );
+        })}
+      </div>
+      {activePath && api ? (
+        <Suspense
+          fallback={
+            <div className="flex flex-1 items-center justify-center">
+              <span className="status-pulse text-xs" style={{ color: "var(--text-tertiary)" }}>
+                Loading editor…
+              </span>
+            </div>
+          }
+        >
+          <MonacoHost key={activePath} taskId={taskId} path={activePath} />
+        </Suspense>
+      ) : null}
+    </div>
+  );
+}
+
+export function useEditorOpenFile(taskId: string) {
+  const openTab = useEditorTabs((s) => s.openTab);
+  return useCallback((path: string) => openTab(taskId, path), [openTab, taskId]);
+}
+
+export function ConflictBar({
+  onOverwrite,
+  onReload,
+}: {
+  onOverwrite: () => void;
+  onReload: () => void;
+}) {
+  return (
+    <div
+      className="flex items-center justify-between gap-3 border-t px-3 py-2"
+      style={{ background: "var(--warning-muted)", borderColor: "var(--border-default)" }}
+    >
+      <span className="text-sm" style={{ color: "var(--warning)" }}>
+        This file changed on your computer since you opened it.
+      </span>
+      <div className="flex gap-2">
+        <Button variant="subtle" onClick={onReload}>
+          Reload
+        </Button>
+        <Button variant="danger" onClick={onOverwrite}>
+          Overwrite
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+// Small per-task editor tab state, kept separate from the workspace store so
+// panel layout and file tabs evolve independently.
+export function useAutosaveShortcut(handler: () => void): void {
+  const ref = useRef(handler);
+  ref.current = handler;
+  const [, force] = useState(0);
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === "s") {
+        e.preventDefault();
+        ref.current();
+        force((n) => n + 1);
+      }
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, []);
+}

--- a/desktop/src/renderer/src/features/editor/MonacoHost.tsx
+++ b/desktop/src/renderer/src/features/editor/MonacoHost.tsx
@@ -14,6 +14,7 @@ export default function MonacoHost({ taskId, path }: { taskId: string; path: str
   const editorRef = useRef<monaco.editor.IStandaloneCodeEditor | null>(null);
   const [conflict, setConflict] = useState(false);
   const [loadError, setLoadError] = useState<string | null>(null);
+  const [saveError, setSaveError] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
   const doSaveRef = useRef<() => Promise<void>>(() => Promise.resolve());
 
@@ -40,9 +41,10 @@ export default function MonacoHost({ taskId, path }: { taskId: string; path: str
         fileRef.current = file;
         const model = getOrCreateModel(path, file.content);
         editor.setModel(model);
-        model.onDidChangeContent(() => {
+        const contentSubscription = model.onDidChangeContent(() => {
           setDirty(taskId, path, model.getValue() !== fileRef.current?.content);
         });
+        editor.onDidDispose(() => contentSubscription.dispose());
       })
       .catch((err: unknown) => {
         if (!disposed) setLoadError(toUserMessage(err));
@@ -78,12 +80,14 @@ export default function MonacoHost({ taskId, path }: { taskId: string; path: str
         fileRef.current = { ...file, content, loadedMtime: result.newMtime };
         setDirty(taskId, path, false);
         setConflict(false);
+        setSaveError(null);
       } else {
         setConflict(true);
+        setSaveError(null);
       }
     } catch (err: unknown) {
       console.warn("[editor] save failed:", err instanceof Error ? err.message : String(err));
-      setLoadError(toUserMessage(err));
+      setSaveError(toUserMessage(err));
     } finally {
       setSaving(false);
     }
@@ -100,9 +104,10 @@ export default function MonacoHost({ taskId, path }: { taskId: string; path: str
       fileRef.current = { path, content, loadedMtime: newMtime };
       setDirty(taskId, path, false);
       setConflict(false);
+      setSaveError(null);
     } catch (err: unknown) {
       console.warn("[editor] overwrite failed:", err instanceof Error ? err.message : String(err));
-      setLoadError(toUserMessage(err));
+      setSaveError(toUserMessage(err));
     }
   }
 
@@ -114,6 +119,7 @@ export default function MonacoHost({ taskId, path }: { taskId: string; path: str
       editorRef.current.getModel()?.setValue(file.content);
       setDirty(taskId, path, false);
       setConflict(false);
+      setSaveError(null);
     } catch (err: unknown) {
       setLoadError(toUserMessage(err));
     }
@@ -132,6 +138,14 @@ export default function MonacoHost({ taskId, path }: { taskId: string; path: str
   return (
     <div className="flex min-h-0 flex-1 flex-col">
       <div ref={hostRef} className="min-h-0 flex-1" data-selectable />
+      {saveError ? (
+        <div
+          className="border-t px-3 py-2 text-xs"
+          style={{ borderColor: "var(--border-subtle)", color: "var(--danger)" }}
+        >
+          {saveError}
+        </div>
+      ) : null}
       {conflict ? <ConflictBar onOverwrite={() => void overwrite()} onReload={() => void reload()} /> : null}
     </div>
   );

--- a/desktop/src/renderer/src/features/editor/MonacoHost.tsx
+++ b/desktop/src/renderer/src/features/editor/MonacoHost.tsx
@@ -4,7 +4,7 @@ import { useConnection } from "../../stores/connection";
 import { ConflictBar } from "./EditorPanel";
 import { useEditorTabs } from "./editor-tabs-store";
 import { createFilesApi, openFile, saveFile, saveFileOverwrite, type OpenedFile } from "./editor-save";
-import { getOrCreateModel, monaco } from "./monaco-setup";
+import { getOrCreateModel, markModelBaseline, monaco } from "./monaco-setup";
 
 export default function MonacoHost({ taskId, path }: { taskId: string; path: string }) {
   const api = useConnection((s) => s.api);
@@ -79,6 +79,7 @@ export default function MonacoHost({ taskId, path }: { taskId: string; path: str
       const result = await saveFile(createFilesApi(api), file, content);
       if (result.ok) {
         fileRef.current = { ...file, content, loadedMtime: result.newMtime };
+        markModelBaseline(path, content);
         setDirty(taskId, path, false);
         setConflict(false);
         setSaveError(null);
@@ -103,6 +104,7 @@ export default function MonacoHost({ taskId, path }: { taskId: string; path: str
     try {
       const newMtime = await saveFileOverwrite(createFilesApi(api), path, content);
       fileRef.current = { path, content, loadedMtime: newMtime };
+      markModelBaseline(path, content);
       setDirty(taskId, path, false);
       setConflict(false);
       setSaveError(null);
@@ -118,6 +120,7 @@ export default function MonacoHost({ taskId, path }: { taskId: string; path: str
       const file = await openFile(createFilesApi(api), path);
       fileRef.current = file;
       editorRef.current.getModel()?.setValue(file.content);
+      markModelBaseline(path, file.content);
       setDirty(taskId, path, false);
       setConflict(false);
       setSaveError(null);

--- a/desktop/src/renderer/src/features/editor/MonacoHost.tsx
+++ b/desktop/src/renderer/src/features/editor/MonacoHost.tsx
@@ -8,6 +8,10 @@ import { getOrCreateModel, markModelBaseline, monaco } from "./monaco-setup";
 
 const fileBaselines = new Map<string, OpenedFile>();
 
+function fileBaselineKey(taskId: string, path: string): string {
+  return `${taskId}\u0000${path}`;
+}
+
 export default function MonacoHost({ taskId, path }: { taskId: string; path: string }) {
   const api = useConnection((s) => s.api);
   const setDirty = useEditorTabs((s) => s.setDirty);
@@ -40,14 +44,15 @@ export default function MonacoHost({ taskId, path }: { taskId: string; path: str
     void openFile(files, path)
       .then((file) => {
         if (disposed) return;
-        const model = getOrCreateModel(path, file.content);
+        const baselineKey = fileBaselineKey(taskId, path);
+        const model = getOrCreateModel(taskId, path, file.content);
         const hasUnsavedModel = model.getValue() !== file.content;
         const baseline = hasUnsavedModel
-          ? (fileBaselines.get(path) ?? { ...file, loadedMtime: null })
+          ? (fileBaselines.get(baselineKey) ?? { ...file, loadedMtime: null })
           : file;
         fileRef.current = baseline;
         if (!hasUnsavedModel) {
-          fileBaselines.set(path, file);
+          fileBaselines.set(baselineKey, file);
         }
         editor.setModel(model);
         setDirty(taskId, path, model.getValue() !== baseline.content);
@@ -89,8 +94,8 @@ export default function MonacoHost({ taskId, path }: { taskId: string; path: str
       if (result.ok) {
         const saved = { ...file, content, loadedMtime: result.newMtime };
         fileRef.current = saved;
-        fileBaselines.set(path, saved);
-        markModelBaseline(path, content);
+        fileBaselines.set(fileBaselineKey(taskId, path), saved);
+        markModelBaseline(taskId, path, content);
         setDirty(taskId, path, false);
         setConflict(false);
         setSaveError(null);
@@ -116,8 +121,8 @@ export default function MonacoHost({ taskId, path }: { taskId: string; path: str
       const newMtime = await saveFileOverwrite(createFilesApi(api), path, content);
       const overwritten = { path, content, loadedMtime: newMtime };
       fileRef.current = overwritten;
-      fileBaselines.set(path, overwritten);
-      markModelBaseline(path, content);
+      fileBaselines.set(fileBaselineKey(taskId, path), overwritten);
+      markModelBaseline(taskId, path, content);
       setDirty(taskId, path, false);
       setConflict(false);
       setSaveError(null);
@@ -132,9 +137,9 @@ export default function MonacoHost({ taskId, path }: { taskId: string; path: str
     try {
       const file = await openFile(createFilesApi(api), path);
       fileRef.current = file;
-      fileBaselines.set(path, file);
+      fileBaselines.set(fileBaselineKey(taskId, path), file);
       editorRef.current.getModel()?.setValue(file.content);
-      markModelBaseline(path, file.content);
+      markModelBaseline(taskId, path, file.content);
       setDirty(taskId, path, false);
       setConflict(false);
       setSaveError(null);

--- a/desktop/src/renderer/src/features/editor/MonacoHost.tsx
+++ b/desktop/src/renderer/src/features/editor/MonacoHost.tsx
@@ -41,7 +41,7 @@ export default function MonacoHost({ taskId, path }: { taskId: string; path: str
         const model = getOrCreateModel(path, file.content);
         editor.setModel(model);
         model.onDidChangeContent(() => {
-          setDirty(path, model.getValue() !== fileRef.current?.content);
+          setDirty(taskId, path, model.getValue() !== fileRef.current?.content);
         });
       })
       .catch((err: unknown) => {
@@ -53,7 +53,7 @@ export default function MonacoHost({ taskId, path }: { taskId: string; path: str
       editorRef.current = null;
       editor.dispose();
     };
-  }, [api, path, setDirty]);
+  }, [api, path, setDirty, taskId]);
 
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
@@ -76,7 +76,7 @@ export default function MonacoHost({ taskId, path }: { taskId: string; path: str
       const result = await saveFile(createFilesApi(api), file, content);
       if (result.ok) {
         fileRef.current = { ...file, content, loadedMtime: result.newMtime };
-        setDirty(path, false);
+        setDirty(taskId, path, false);
         setConflict(false);
       } else {
         setConflict(true);
@@ -98,7 +98,7 @@ export default function MonacoHost({ taskId, path }: { taskId: string; path: str
     try {
       const newMtime = await saveFileOverwrite(createFilesApi(api), path, content);
       fileRef.current = { path, content, loadedMtime: newMtime };
-      setDirty(path, false);
+      setDirty(taskId, path, false);
       setConflict(false);
     } catch (err: unknown) {
       console.warn("[editor] overwrite failed:", err instanceof Error ? err.message : String(err));
@@ -112,7 +112,7 @@ export default function MonacoHost({ taskId, path }: { taskId: string; path: str
       const file = await openFile(createFilesApi(api), path);
       fileRef.current = file;
       editorRef.current.getModel()?.setValue(file.content);
-      setDirty(path, false);
+      setDirty(taskId, path, false);
       setConflict(false);
     } catch (err: unknown) {
       setLoadError(toUserMessage(err));

--- a/desktop/src/renderer/src/features/editor/MonacoHost.tsx
+++ b/desktop/src/renderer/src/features/editor/MonacoHost.tsx
@@ -41,6 +41,7 @@ export default function MonacoHost({ taskId, path }: { taskId: string; path: str
         fileRef.current = file;
         const model = getOrCreateModel(path, file.content);
         editor.setModel(model);
+        setDirty(taskId, path, model.getValue() !== file.content);
         const contentSubscription = model.onDidChangeContent(() => {
           setDirty(taskId, path, model.getValue() !== fileRef.current?.content);
         });

--- a/desktop/src/renderer/src/features/editor/MonacoHost.tsx
+++ b/desktop/src/renderer/src/features/editor/MonacoHost.tsx
@@ -1,0 +1,135 @@
+import { useEffect, useRef, useState } from "react";
+import { toUserMessage } from "../../lib/errors";
+import { useConnection } from "../../stores/connection";
+import { ConflictBar } from "./EditorPanel";
+import { useEditorTabs } from "./editor-tabs-store";
+import { createFilesApi, openFile, saveFile, saveFileOverwrite, type OpenedFile } from "./editor-save";
+import { getOrCreateModel, monaco } from "./monaco-setup";
+
+export default function MonacoHost({ taskId, path }: { taskId: string; path: string }) {
+  const api = useConnection((s) => s.api);
+  const setDirty = useEditorTabs((s) => s.setDirty);
+  const hostRef = useRef<HTMLDivElement>(null);
+  const fileRef = useRef<OpenedFile | null>(null);
+  const editorRef = useRef<monaco.editor.IStandaloneCodeEditor | null>(null);
+  const [conflict, setConflict] = useState(false);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    if (!api || !hostRef.current) return;
+    const files = createFilesApi(api);
+    let disposed = false;
+    const host = hostRef.current;
+
+    const editor = monaco.editor.create(host, {
+      theme: "operator-dark",
+      fontSize: 13,
+      fontFamily: 'JetBrains Mono, "SF Mono", Menlo, monospace',
+      minimap: { enabled: false },
+      automaticLayout: true,
+      scrollBeyondLastLine: false,
+      padding: { top: 8 },
+    });
+    editorRef.current = editor;
+
+    void openFile(files, path)
+      .then((file) => {
+        if (disposed) return;
+        fileRef.current = file;
+        const model = getOrCreateModel(path, file.content);
+        editor.setModel(model);
+        model.onDidChangeContent(() => {
+          setDirty(path, model.getValue() !== fileRef.current?.content);
+        });
+      })
+      .catch((err: unknown) => {
+        if (!disposed) setLoadError(toUserMessage(err));
+      });
+
+    return () => {
+      disposed = true;
+      editorRef.current = null;
+      editor.dispose();
+    };
+  }, [api, path, setDirty]);
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === "s") {
+        e.preventDefault();
+        void doSave();
+      }
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  });
+
+  async function doSave(): Promise<void> {
+    const editor = editorRef.current;
+    const file = fileRef.current;
+    if (!api || !editor || !file || saving) return;
+    const content = editor.getValue();
+    setSaving(true);
+    try {
+      const result = await saveFile(createFilesApi(api), file, content);
+      if (result.ok) {
+        fileRef.current = { ...file, content, loadedMtime: result.newMtime };
+        setDirty(path, false);
+        setConflict(false);
+      } else {
+        setConflict(true);
+      }
+    } catch (err: unknown) {
+      console.warn("[editor] save failed:", err instanceof Error ? err.message : String(err));
+      setLoadError(toUserMessage(err));
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function overwrite(): Promise<void> {
+    const editor = editorRef.current;
+    if (!api || !editor) return;
+    const content = editor.getValue();
+    try {
+      const newMtime = await saveFileOverwrite(createFilesApi(api), path, content);
+      fileRef.current = { path, content, loadedMtime: newMtime };
+      setDirty(path, false);
+      setConflict(false);
+    } catch (err: unknown) {
+      console.warn("[editor] overwrite failed:", err instanceof Error ? err.message : String(err));
+      setLoadError(toUserMessage(err));
+    }
+  }
+
+  async function reload(): Promise<void> {
+    if (!api || !editorRef.current) return;
+    try {
+      const file = await openFile(createFilesApi(api), path);
+      fileRef.current = file;
+      editorRef.current.getModel()?.setValue(file.content);
+      setDirty(path, false);
+      setConflict(false);
+    } catch (err: unknown) {
+      setLoadError(toUserMessage(err));
+    }
+  }
+
+  if (loadError) {
+    return (
+      <div className="flex flex-1 items-center justify-center">
+        <span className="text-sm" style={{ color: "var(--text-secondary)" }}>
+          {loadError}
+        </span>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col">
+      <div ref={hostRef} className="min-h-0 flex-1" data-selectable />
+      {conflict ? <ConflictBar onOverwrite={() => void overwrite()} onReload={() => void reload()} /> : null}
+    </div>
+  );
+}

--- a/desktop/src/renderer/src/features/editor/MonacoHost.tsx
+++ b/desktop/src/renderer/src/features/editor/MonacoHost.tsx
@@ -6,6 +6,8 @@ import { useEditorTabs } from "./editor-tabs-store";
 import { createFilesApi, openFile, saveFile, saveFileOverwrite, type OpenedFile } from "./editor-save";
 import { getOrCreateModel, markModelBaseline, monaco } from "./monaco-setup";
 
+const fileBaselines = new Map<string, OpenedFile>();
+
 export default function MonacoHost({ taskId, path }: { taskId: string; path: string }) {
   const api = useConnection((s) => s.api);
   const setDirty = useEditorTabs((s) => s.setDirty);
@@ -38,10 +40,17 @@ export default function MonacoHost({ taskId, path }: { taskId: string; path: str
     void openFile(files, path)
       .then((file) => {
         if (disposed) return;
-        fileRef.current = file;
         const model = getOrCreateModel(path, file.content);
+        const hasUnsavedModel = model.getValue() !== file.content;
+        const baseline = hasUnsavedModel
+          ? (fileBaselines.get(path) ?? { ...file, loadedMtime: null })
+          : file;
+        fileRef.current = baseline;
+        if (!hasUnsavedModel) {
+          fileBaselines.set(path, file);
+        }
         editor.setModel(model);
-        setDirty(taskId, path, model.getValue() !== file.content);
+        setDirty(taskId, path, model.getValue() !== baseline.content);
         const contentSubscription = model.onDidChangeContent(() => {
           setDirty(taskId, path, model.getValue() !== fileRef.current?.content);
         });
@@ -78,7 +87,9 @@ export default function MonacoHost({ taskId, path }: { taskId: string; path: str
     try {
       const result = await saveFile(createFilesApi(api), file, content);
       if (result.ok) {
-        fileRef.current = { ...file, content, loadedMtime: result.newMtime };
+        const saved = { ...file, content, loadedMtime: result.newMtime };
+        fileRef.current = saved;
+        fileBaselines.set(path, saved);
         markModelBaseline(path, content);
         setDirty(taskId, path, false);
         setConflict(false);
@@ -103,7 +114,9 @@ export default function MonacoHost({ taskId, path }: { taskId: string; path: str
     const content = editor.getValue();
     try {
       const newMtime = await saveFileOverwrite(createFilesApi(api), path, content);
-      fileRef.current = { path, content, loadedMtime: newMtime };
+      const overwritten = { path, content, loadedMtime: newMtime };
+      fileRef.current = overwritten;
+      fileBaselines.set(path, overwritten);
       markModelBaseline(path, content);
       setDirty(taskId, path, false);
       setConflict(false);
@@ -119,13 +132,15 @@ export default function MonacoHost({ taskId, path }: { taskId: string; path: str
     try {
       const file = await openFile(createFilesApi(api), path);
       fileRef.current = file;
+      fileBaselines.set(path, file);
       editorRef.current.getModel()?.setValue(file.content);
       markModelBaseline(path, file.content);
       setDirty(taskId, path, false);
       setConflict(false);
       setSaveError(null);
     } catch (err: unknown) {
-      setLoadError(toUserMessage(err));
+      console.warn("[editor] reload failed:", err instanceof Error ? err.message : String(err));
+      setSaveError(toUserMessage(err));
     }
   }
 

--- a/desktop/src/renderer/src/features/editor/MonacoHost.tsx
+++ b/desktop/src/renderer/src/features/editor/MonacoHost.tsx
@@ -29,6 +29,7 @@ export default function MonacoHost({ taskId, path }: { taskId: string; path: str
     const files = createFilesApi(api);
     let disposed = false;
     const host = hostRef.current;
+    let contentSubscription: { dispose(): void } | null = null;
 
     const editor = monaco.editor.create(host, {
       theme: "operator-dark",
@@ -47,19 +48,21 @@ export default function MonacoHost({ taskId, path }: { taskId: string; path: str
         const baselineKey = fileBaselineKey(taskId, path);
         const model = getOrCreateModel(taskId, path, file.content);
         const hasUnsavedModel = model.getValue() !== file.content;
-        const baseline = hasUnsavedModel
-          ? (fileBaselines.get(baselineKey) ?? { ...file, loadedMtime: null })
-          : file;
+        const previousBaseline = fileBaselines.get(baselineKey);
+        const baseline = hasUnsavedModel ? (previousBaseline ?? { ...file, loadedMtime: null }) : file;
         fileRef.current = baseline;
         if (!hasUnsavedModel) {
           fileBaselines.set(baselineKey, file);
+          setConflict(false);
+        } else if (previousBaseline && previousBaseline.loadedMtime !== file.loadedMtime) {
+          setConflict(true);
+          setSaveError(null);
         }
         editor.setModel(model);
         setDirty(taskId, path, model.getValue() !== baseline.content);
-        const contentSubscription = model.onDidChangeContent(() => {
+        contentSubscription = model.onDidChangeContent(() => {
           setDirty(taskId, path, model.getValue() !== fileRef.current?.content);
         });
-        editor.onDidDispose(() => contentSubscription.dispose());
       })
       .catch((err: unknown) => {
         if (!disposed) setLoadError(toUserMessage(err));
@@ -67,6 +70,8 @@ export default function MonacoHost({ taskId, path }: { taskId: string; path: str
 
     return () => {
       disposed = true;
+      contentSubscription?.dispose();
+      contentSubscription = null;
       editorRef.current = null;
       editor.dispose();
     };

--- a/desktop/src/renderer/src/features/editor/MonacoHost.tsx
+++ b/desktop/src/renderer/src/features/editor/MonacoHost.tsx
@@ -15,6 +15,7 @@ export default function MonacoHost({ taskId, path }: { taskId: string; path: str
   const [conflict, setConflict] = useState(false);
   const [loadError, setLoadError] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
+  const doSaveRef = useRef<() => Promise<void>>(() => Promise.resolve());
 
   useEffect(() => {
     if (!api || !hostRef.current) return;
@@ -58,12 +59,12 @@ export default function MonacoHost({ taskId, path }: { taskId: string; path: str
     const onKey = (e: KeyboardEvent) => {
       if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === "s") {
         e.preventDefault();
-        void doSave();
+        void doSaveRef.current();
       }
     };
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);
-  });
+  }, []);
 
   async function doSave(): Promise<void> {
     const editor = editorRef.current;
@@ -87,6 +88,8 @@ export default function MonacoHost({ taskId, path }: { taskId: string; path: str
       setSaving(false);
     }
   }
+
+  doSaveRef.current = doSave;
 
   async function overwrite(): Promise<void> {
     const editor = editorRef.current;

--- a/desktop/src/renderer/src/features/editor/MonacoHost.tsx
+++ b/desktop/src/renderer/src/features/editor/MonacoHost.tsx
@@ -22,6 +22,7 @@ export default function MonacoHost({ taskId, path }: { taskId: string; path: str
   const [loadError, setLoadError] = useState<string | null>(null);
   const [saveError, setSaveError] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
+  const saveInFlightRef = useRef(false);
   const doSaveRef = useRef<() => Promise<void>>(() => Promise.resolve());
 
   useEffect(() => {
@@ -91,8 +92,9 @@ export default function MonacoHost({ taskId, path }: { taskId: string; path: str
   async function doSave(): Promise<void> {
     const editor = editorRef.current;
     const file = fileRef.current;
-    if (!api || !editor || !file || saving) return;
+    if (!api || !editor || !file || saveInFlightRef.current) return;
     const content = editor.getValue();
+    saveInFlightRef.current = true;
     setSaving(true);
     try {
       const result = await saveFile(createFilesApi(api), file, content);
@@ -112,6 +114,7 @@ export default function MonacoHost({ taskId, path }: { taskId: string; path: str
       console.warn("[editor] save failed:", err instanceof Error ? err.message : String(err));
       setSaveError(toUserMessage(err));
     } finally {
+      saveInFlightRef.current = false;
       setSaving(false);
     }
   }
@@ -120,8 +123,10 @@ export default function MonacoHost({ taskId, path }: { taskId: string; path: str
 
   async function overwrite(): Promise<void> {
     const editor = editorRef.current;
-    if (!api || !editor) return;
+    if (!api || !editor || saveInFlightRef.current) return;
     const content = editor.getValue();
+    saveInFlightRef.current = true;
+    setSaving(true);
     try {
       const newMtime = await saveFileOverwrite(createFilesApi(api), path, content);
       const overwritten = { path, content, loadedMtime: newMtime };
@@ -134,11 +139,16 @@ export default function MonacoHost({ taskId, path }: { taskId: string; path: str
     } catch (err: unknown) {
       console.warn("[editor] overwrite failed:", err instanceof Error ? err.message : String(err));
       setSaveError(toUserMessage(err));
+    } finally {
+      saveInFlightRef.current = false;
+      setSaving(false);
     }
   }
 
   async function reload(): Promise<void> {
-    if (!api || !editorRef.current) return;
+    if (!api || !editorRef.current || saveInFlightRef.current) return;
+    saveInFlightRef.current = true;
+    setSaving(true);
     try {
       const file = await openFile(createFilesApi(api), path);
       fileRef.current = file;
@@ -151,6 +161,9 @@ export default function MonacoHost({ taskId, path }: { taskId: string; path: str
     } catch (err: unknown) {
       console.warn("[editor] reload failed:", err instanceof Error ? err.message : String(err));
       setSaveError(toUserMessage(err));
+    } finally {
+      saveInFlightRef.current = false;
+      setSaving(false);
     }
   }
 
@@ -175,7 +188,13 @@ export default function MonacoHost({ taskId, path }: { taskId: string; path: str
           {saveError}
         </div>
       ) : null}
-      {conflict ? <ConflictBar onOverwrite={() => void overwrite()} onReload={() => void reload()} /> : null}
+      {conflict ? (
+        <ConflictBar
+          busy={saving}
+          onOverwrite={() => void overwrite()}
+          onReload={() => void reload()}
+        />
+      ) : null}
     </div>
   );
 }

--- a/desktop/src/renderer/src/features/editor/MonacoHost.tsx
+++ b/desktop/src/renderer/src/features/editor/MonacoHost.tsx
@@ -4,9 +4,8 @@ import { useConnection } from "../../stores/connection";
 import { ConflictBar } from "./EditorPanel";
 import { useEditorTabs } from "./editor-tabs-store";
 import { createFilesApi, openFile, saveFile, saveFileOverwrite, type OpenedFile } from "./editor-save";
+import { getFileBaseline, rememberFileBaseline } from "./editor-baselines";
 import { getOrCreateModel, markModelBaseline, monaco } from "./monaco-setup";
-
-const fileBaselines = new Map<string, OpenedFile>();
 
 function fileBaselineKey(taskId: string, path: string): string {
   return `${taskId}\u0000${path}`;
@@ -49,11 +48,11 @@ export default function MonacoHost({ taskId, path }: { taskId: string; path: str
         const baselineKey = fileBaselineKey(taskId, path);
         const model = getOrCreateModel(taskId, path, file.content);
         const hasUnsavedModel = model.getValue() !== file.content;
-        const previousBaseline = fileBaselines.get(baselineKey);
+        const previousBaseline = getFileBaseline(baselineKey);
         const baseline = hasUnsavedModel ? (previousBaseline ?? { ...file, loadedMtime: null }) : file;
         fileRef.current = baseline;
         if (!hasUnsavedModel) {
-          fileBaselines.set(baselineKey, file);
+          rememberFileBaseline(baselineKey, file);
           setConflict(false);
         } else if (previousBaseline && previousBaseline.loadedMtime !== file.loadedMtime) {
           setConflict(true);
@@ -101,7 +100,7 @@ export default function MonacoHost({ taskId, path }: { taskId: string; path: str
       if (result.ok) {
         const saved = { ...file, content, loadedMtime: result.newMtime };
         fileRef.current = saved;
-        fileBaselines.set(fileBaselineKey(taskId, path), saved);
+        rememberFileBaseline(fileBaselineKey(taskId, path), saved);
         markModelBaseline(taskId, path, content);
         setDirty(taskId, path, false);
         setConflict(false);
@@ -131,7 +130,7 @@ export default function MonacoHost({ taskId, path }: { taskId: string; path: str
       const newMtime = await saveFileOverwrite(createFilesApi(api), path, content);
       const overwritten = { path, content, loadedMtime: newMtime };
       fileRef.current = overwritten;
-      fileBaselines.set(fileBaselineKey(taskId, path), overwritten);
+      rememberFileBaseline(fileBaselineKey(taskId, path), overwritten);
       markModelBaseline(taskId, path, content);
       setDirty(taskId, path, false);
       setConflict(false);
@@ -152,7 +151,7 @@ export default function MonacoHost({ taskId, path }: { taskId: string; path: str
     try {
       const file = await openFile(createFilesApi(api), path);
       fileRef.current = file;
-      fileBaselines.set(fileBaselineKey(taskId, path), file);
+      rememberFileBaseline(fileBaselineKey(taskId, path), file);
       editorRef.current.getModel()?.setValue(file.content);
       markModelBaseline(taskId, path, file.content);
       setDirty(taskId, path, false);

--- a/desktop/src/renderer/src/features/editor/editor-baselines.ts
+++ b/desktop/src/renderer/src/features/editor/editor-baselines.ts
@@ -1,0 +1,26 @@
+import type { OpenedFile } from "./editor-save";
+
+const FILE_BASELINE_CAP = 64;
+const fileBaselines = new Map<string, OpenedFile>();
+
+export function getFileBaseline(key: string): OpenedFile | undefined {
+  const baseline = fileBaselines.get(key);
+  if (!baseline) return undefined;
+  fileBaselines.delete(key);
+  fileBaselines.set(key, baseline);
+  return baseline;
+}
+
+export function rememberFileBaseline(key: string, file: OpenedFile): void {
+  fileBaselines.delete(key);
+  fileBaselines.set(key, file);
+  while (fileBaselines.size > FILE_BASELINE_CAP) {
+    const oldest = fileBaselines.keys().next();
+    if (oldest.done) break;
+    fileBaselines.delete(oldest.value);
+  }
+}
+
+export function clearFileBaselinesForTest(): void {
+  fileBaselines.clear();
+}

--- a/desktop/src/renderer/src/features/editor/editor-save.ts
+++ b/desktop/src/renderer/src/features/editor/editor-save.ts
@@ -104,5 +104,7 @@ export async function saveFileOverwrite(
   content: string,
 ): Promise<number | null> {
   const { mtime } = await files.write(path, content);
-  return mtime;
+  if (mtime !== null) return mtime;
+  const { mtime: refreshedMtime } = await files.stat(path);
+  return refreshedMtime;
 }

--- a/desktop/src/renderer/src/features/editor/editor-save.ts
+++ b/desktop/src/renderer/src/features/editor/editor-save.ts
@@ -93,7 +93,9 @@ export async function saveFile(
   // the only conflict-free null pairing. Network errors propagate as AppError.
   if (serverMtime !== file.loadedMtime) return { ok: false, reason: "conflict" };
   const { mtime: newMtime } = await files.write(file.path, content);
-  return { ok: true, newMtime: newMtime ?? serverMtime };
+  if (newMtime !== null) return { ok: true, newMtime };
+  const { mtime: refreshedMtime } = await files.stat(file.path);
+  return { ok: true, newMtime: refreshedMtime };
 }
 
 export async function saveFileOverwrite(

--- a/desktop/src/renderer/src/features/editor/editor-save.ts
+++ b/desktop/src/renderer/src/features/editor/editor-save.ts
@@ -8,7 +8,7 @@
 //     string, mime? }; 404 when missing. mtime field is `modified` (ISO),
 //     normalized here to epoch ms.
 //   GET /files/{path}            -> raw text body
-//   PUT /files/{path}            -> raw text body in, { ok: true } out
+//   PUT /files/{path}            -> raw text body in, { ok: true, modified? } out
 import { z } from "zod/v4";
 import { AppError } from "../../../../shared/app-error";
 import type { ApiClient } from "../../lib/api";
@@ -22,10 +22,13 @@ export interface OpenedFile {
 export interface FilesApi {
   stat(path: string): Promise<{ mtime: number | null }>;
   read(path: string): Promise<string>;
-  write(path: string, content: string): Promise<void>;
+  write(path: string, content: string): Promise<{ mtime: number | null }>;
 }
 
 const WireStatSchema = z.looseObject({
+  modified: z.union([z.string(), z.number()]).optional(),
+});
+const WireWriteSchema = z.looseObject({
   modified: z.union([z.string(), z.number()]).optional(),
 });
 
@@ -62,7 +65,10 @@ export function createFilesApi(api: ApiClient): FilesApi {
     },
     read: (path) => api.getText(`/files/${encodeFilesPath(path)}`),
     write: async (path, content) => {
-      await api.putText<{ ok: boolean }>(`/files/${encodeFilesPath(path)}`, content);
+      const raw = await api.putText<unknown>(`/files/${encodeFilesPath(path)}`, content);
+      const parsed = WireWriteSchema.safeParse(raw);
+      if (!parsed.success) return { mtime: null };
+      return { mtime: normalizeMtime(parsed.data.modified) };
     },
   };
 }
@@ -86,9 +92,8 @@ export async function saveFile(
   // Strict equality: null/null (file does not exist yet on either side) is
   // the only conflict-free null pairing. Network errors propagate as AppError.
   if (serverMtime !== file.loadedMtime) return { ok: false, reason: "conflict" };
-  await files.write(file.path, content);
-  const { mtime: newMtime } = await files.stat(file.path);
-  return { ok: true, newMtime };
+  const { mtime: newMtime } = await files.write(file.path, content);
+  return { ok: true, newMtime: newMtime ?? serverMtime };
 }
 
 export async function saveFileOverwrite(
@@ -96,7 +101,6 @@ export async function saveFileOverwrite(
   path: string,
   content: string,
 ): Promise<number | null> {
-  await files.write(path, content);
-  const { mtime } = await files.stat(path);
+  const { mtime } = await files.write(path, content);
   return mtime;
 }

--- a/desktop/src/renderer/src/features/editor/editor-save.ts
+++ b/desktop/src/renderer/src/features/editor/editor-save.ts
@@ -1,0 +1,102 @@
+// Editor open/save logic (FR-041). The gateway file PUT is an unconditional
+// overwrite, so every save stats first and refuses to clobber a newer server
+// mtime; overwrite is a separate, user-confirmed path.
+//
+// Verified wire shapes (packages/gateway/src/server.ts, file-ops.ts):
+//   GET /api/files/stat?path=<p> -> FileStatResult JSON: { name, path,
+//     type: "file"|"directory", size?, modified: ISO string, created: ISO
+//     string, mime? }; 404 when missing. mtime field is `modified` (ISO),
+//     normalized here to epoch ms.
+//   GET /files/{path}            -> raw text body
+//   PUT /files/{path}            -> raw text body in, { ok: true } out
+import { z } from "zod/v4";
+import { AppError } from "../../../../shared/app-error";
+import type { ApiClient } from "../../lib/api";
+
+export interface OpenedFile {
+  path: string;
+  content: string;
+  loadedMtime: number | null;
+}
+
+export interface FilesApi {
+  stat(path: string): Promise<{ mtime: number | null }>;
+  read(path: string): Promise<string>;
+  write(path: string, content: string): Promise<void>;
+}
+
+const WireStatSchema = z.looseObject({
+  modified: z.union([z.string(), z.number()]).optional(),
+});
+
+function encodeFilesPath(path: string): string {
+  return path
+    .split("/")
+    .map((segment) => encodeURIComponent(segment))
+    .join("/");
+}
+
+function normalizeMtime(value: string | number | undefined): number | null {
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  if (typeof value === "string") {
+    const parsed = Date.parse(value);
+    if (Number.isFinite(parsed)) return parsed;
+  }
+  return null;
+}
+
+export function createFilesApi(api: ApiClient): FilesApi {
+  return {
+    stat: async (path) => {
+      let raw: unknown;
+      try {
+        raw = await api.get<unknown>(`/api/files/stat?path=${encodeURIComponent(path)}`);
+      } catch (err: unknown) {
+        // A missing file is a valid pre-save state (new file), not a failure.
+        if (err instanceof AppError && err.category === "notFound") return { mtime: null };
+        throw err;
+      }
+      const parsed = WireStatSchema.safeParse(raw);
+      if (!parsed.success) return { mtime: null };
+      return { mtime: normalizeMtime(parsed.data.modified) };
+    },
+    read: (path) => api.getText(`/files/${encodeFilesPath(path)}`),
+    write: async (path, content) => {
+      await api.putText<{ ok: boolean }>(`/files/${encodeFilesPath(path)}`, content);
+    },
+  };
+}
+
+export async function openFile(files: FilesApi, path: string): Promise<OpenedFile> {
+  // Stat before read: if the file changes in between, the recorded mtime is
+  // older than the content and the next save fails safe with a conflict.
+  const { mtime } = await files.stat(path);
+  const content = await files.read(path);
+  return { path, content, loadedMtime: mtime };
+}
+
+export type SaveResult = { ok: true; newMtime: number | null } | { ok: false; reason: "conflict" };
+
+export async function saveFile(
+  files: FilesApi,
+  file: OpenedFile,
+  content: string,
+): Promise<SaveResult> {
+  const { mtime: serverMtime } = await files.stat(file.path);
+  // Strict equality: null/null (file does not exist yet on either side) is
+  // the only conflict-free null pairing. Network errors propagate as AppError.
+  if (serverMtime !== file.loadedMtime) return { ok: false, reason: "conflict" };
+  await files.write(file.path, content);
+  const { mtime: newMtime } = await files.stat(file.path);
+  return { ok: true, newMtime };
+}
+
+export async function saveFileOverwrite(
+  files: FilesApi,
+  path: string,
+  content: string,
+): Promise<number | null> {
+  await files.write(path, content);
+  const { mtime } = await files.stat(path);
+  return mtime;
+}

--- a/desktop/src/renderer/src/features/editor/editor-tabs-store.ts
+++ b/desktop/src/renderer/src/features/editor/editor-tabs-store.ts
@@ -1,0 +1,70 @@
+// Per-task open editor tabs + dirty tracking. Serializable state only.
+import { create } from "zustand";
+
+const MAX_TABS_PER_TASK = 16;
+
+interface EditorTabsState {
+  tabsByTask: Record<string, string[]>;
+  activePathByTask: Record<string, string | null>;
+  dirtyPaths: string[];
+  openTab: (taskId: string, path: string) => void;
+  setActive: (taskId: string, path: string) => void;
+  closeTab: (taskId: string, path: string) => void;
+  setDirty: (path: string, dirty: boolean) => void;
+  closeTask: (taskId: string) => void;
+}
+
+export const useEditorTabs = create<EditorTabsState>()((set) => ({
+  tabsByTask: {},
+  activePathByTask: {},
+  dirtyPaths: [],
+
+  openTab: (taskId, path) =>
+    set((state) => {
+      const existing = state.tabsByTask[taskId] ?? [];
+      const tabs = existing.includes(path)
+        ? existing
+        : [...existing, path].slice(-MAX_TABS_PER_TASK);
+      return {
+        tabsByTask: { ...state.tabsByTask, [taskId]: tabs },
+        activePathByTask: { ...state.activePathByTask, [taskId]: path },
+      };
+    }),
+
+  setActive: (taskId, path) =>
+    set((state) => ({
+      activePathByTask: { ...state.activePathByTask, [taskId]: path },
+    })),
+
+  closeTab: (taskId, path) =>
+    set((state) => {
+      const tabs = (state.tabsByTask[taskId] ?? []).filter((p) => p !== path);
+      const active =
+        state.activePathByTask[taskId] === path
+          ? (tabs[tabs.length - 1] ?? null)
+          : (state.activePathByTask[taskId] ?? null);
+      return {
+        tabsByTask: { ...state.tabsByTask, [taskId]: tabs },
+        activePathByTask: { ...state.activePathByTask, [taskId]: active },
+        dirtyPaths: state.dirtyPaths.filter((p) => p !== path),
+      };
+    }),
+
+  setDirty: (path, dirty) =>
+    set((state) => ({
+      dirtyPaths: dirty
+        ? state.dirtyPaths.includes(path)
+          ? state.dirtyPaths
+          : [...state.dirtyPaths, path].slice(-64)
+        : state.dirtyPaths.filter((p) => p !== path),
+    })),
+
+  closeTask: (taskId) =>
+    set((state) => {
+      const tabsByTask = { ...state.tabsByTask };
+      const activePathByTask = { ...state.activePathByTask };
+      delete tabsByTask[taskId];
+      delete activePathByTask[taskId];
+      return { tabsByTask, activePathByTask };
+    }),
+}));

--- a/desktop/src/renderer/src/features/editor/editor-tabs-store.ts
+++ b/desktop/src/renderer/src/features/editor/editor-tabs-store.ts
@@ -22,12 +22,17 @@ export const useEditorTabs = create<EditorTabsState>()((set) => ({
   openTab: (taskId, path) =>
     set((state) => {
       const existing = state.tabsByTask[taskId] ?? [];
-      const tabs = existing.includes(path)
-        ? existing
-        : [...existing, path].slice(-MAX_TABS_PER_TASK);
+      const nextTabs = existing.includes(path) ? existing : [...existing, path];
+      const tabs = nextTabs.slice(-MAX_TABS_PER_TASK);
+      const evicted = new Set(nextTabs.slice(0, Math.max(0, nextTabs.length - MAX_TABS_PER_TASK)));
+      const dirtyPaths = state.dirtyPathsByTask[taskId] ?? [];
       return {
         tabsByTask: { ...state.tabsByTask, [taskId]: tabs },
         activePathByTask: { ...state.activePathByTask, [taskId]: path },
+        dirtyPathsByTask: {
+          ...state.dirtyPathsByTask,
+          [taskId]: dirtyPaths.filter((dirtyPath) => !evicted.has(dirtyPath)),
+        },
       };
     }),
 

--- a/desktop/src/renderer/src/features/editor/editor-tabs-store.ts
+++ b/desktop/src/renderer/src/features/editor/editor-tabs-store.ts
@@ -6,18 +6,18 @@ const MAX_TABS_PER_TASK = 16;
 interface EditorTabsState {
   tabsByTask: Record<string, string[]>;
   activePathByTask: Record<string, string | null>;
-  dirtyPaths: string[];
+  dirtyPathsByTask: Record<string, string[]>;
   openTab: (taskId: string, path: string) => void;
   setActive: (taskId: string, path: string) => void;
   closeTab: (taskId: string, path: string) => void;
-  setDirty: (path: string, dirty: boolean) => void;
+  setDirty: (taskId: string, path: string, dirty: boolean) => void;
   closeTask: (taskId: string) => void;
 }
 
 export const useEditorTabs = create<EditorTabsState>()((set) => ({
   tabsByTask: {},
   activePathByTask: {},
-  dirtyPaths: [],
+  dirtyPathsByTask: {},
 
   openTab: (taskId, path) =>
     set((state) => {
@@ -46,31 +46,38 @@ export const useEditorTabs = create<EditorTabsState>()((set) => ({
       return {
         tabsByTask: { ...state.tabsByTask, [taskId]: tabs },
         activePathByTask: { ...state.activePathByTask, [taskId]: active },
-        dirtyPaths: state.dirtyPaths.filter((p) => p !== path),
+        dirtyPathsByTask: {
+          ...state.dirtyPathsByTask,
+          [taskId]: (state.dirtyPathsByTask[taskId] ?? []).filter((p) => p !== path),
+        },
       };
     }),
 
-  setDirty: (path, dirty) =>
-    set((state) => ({
-      dirtyPaths: dirty
-        ? state.dirtyPaths.includes(path)
-          ? state.dirtyPaths
-          : [...state.dirtyPaths, path].slice(-64)
-        : state.dirtyPaths.filter((p) => p !== path),
-    })),
+  setDirty: (taskId, path, dirty) =>
+    set((state) => {
+      const dirtyPaths = state.dirtyPathsByTask[taskId] ?? [];
+      const nextDirtyPaths = dirty
+        ? dirtyPaths.includes(path)
+          ? dirtyPaths
+          : [...dirtyPaths, path].slice(-64)
+        : dirtyPaths.filter((p) => p !== path);
+      return {
+        dirtyPathsByTask: { ...state.dirtyPathsByTask, [taskId]: nextDirtyPaths },
+      };
+    }),
 
   closeTask: (taskId) =>
     set((state) => {
-      const closingPaths = new Set(state.tabsByTask[taskId] ?? []);
       const tabsByTask = { ...state.tabsByTask };
       const activePathByTask = { ...state.activePathByTask };
+      const dirtyPathsByTask = { ...state.dirtyPathsByTask };
       delete tabsByTask[taskId];
       delete activePathByTask[taskId];
-      const remainingOpenPaths = new Set(Object.values(tabsByTask).flat());
+      delete dirtyPathsByTask[taskId];
       return {
         tabsByTask,
         activePathByTask,
-        dirtyPaths: state.dirtyPaths.filter((path) => !closingPaths.has(path) || remainingOpenPaths.has(path)),
+        dirtyPathsByTask,
       };
     }),
 }));

--- a/desktop/src/renderer/src/features/editor/editor-tabs-store.ts
+++ b/desktop/src/renderer/src/features/editor/editor-tabs-store.ts
@@ -61,10 +61,16 @@ export const useEditorTabs = create<EditorTabsState>()((set) => ({
 
   closeTask: (taskId) =>
     set((state) => {
+      const closingPaths = new Set(state.tabsByTask[taskId] ?? []);
       const tabsByTask = { ...state.tabsByTask };
       const activePathByTask = { ...state.activePathByTask };
       delete tabsByTask[taskId];
       delete activePathByTask[taskId];
-      return { tabsByTask, activePathByTask };
+      const remainingOpenPaths = new Set(Object.values(tabsByTask).flat());
+      return {
+        tabsByTask,
+        activePathByTask,
+        dirtyPaths: state.dirtyPaths.filter((path) => !closingPaths.has(path) || remainingOpenPaths.has(path)),
+      };
     }),
 }));

--- a/desktop/src/renderer/src/features/editor/monaco-setup.ts
+++ b/desktop/src/renderer/src/features/editor/monaco-setup.ts
@@ -39,6 +39,22 @@ const models = new Map<string, monaco.editor.ITextModel>();
 const modelBaselines = new Map<string, string>();
 const MODEL_CACHE_CAP = 32;
 
+function isModelClean(path: string, model: monaco.editor.ITextModel): boolean {
+  const baseline = modelBaselines.get(path);
+  return baseline === undefined || model.getValue() === baseline;
+}
+
+function evictOldestCleanModel(): void {
+  for (const [path, model] of models) {
+    if (model.isDisposed() || isModelClean(path, model)) {
+      model.dispose();
+      models.delete(path);
+      modelBaselines.delete(path);
+      return;
+    }
+  }
+}
+
 export function getOrCreateModel(path: string, content: string): monaco.editor.ITextModel {
   const existing = models.get(path);
   if (existing && !existing.isDisposed()) {
@@ -56,12 +72,7 @@ export function getOrCreateModel(path: string, content: string): monaco.editor.I
     modelBaselines.delete(path);
   }
   if (models.size >= MODEL_CACHE_CAP) {
-    const oldest = models.keys().next().value as string | undefined;
-    if (oldest) {
-      models.get(oldest)?.dispose();
-      models.delete(oldest);
-      modelBaselines.delete(oldest);
-    }
+    evictOldestCleanModel();
   }
   const model = monaco.editor.createModel(content, undefined, monaco.Uri.file(path));
   models.set(path, model);

--- a/desktop/src/renderer/src/features/editor/monaco-setup.ts
+++ b/desktop/src/renderer/src/features/editor/monaco-setup.ts
@@ -37,7 +37,9 @@ export { monaco };
 // Model cache so open files survive panel/workspace remounts (SC-006).
 const models = new Map<string, monaco.editor.ITextModel>();
 const modelBaselines = new Map<string, string>();
+const evictedDirtyModels = new Map<string, { value: string; baseline: string }>();
 const MODEL_CACHE_CAP = 32;
+const EVICTED_DIRTY_MODEL_CAP = 32;
 
 function modelKey(taskId: string, path: string): string {
   return `${taskId}\u0000${path}`;
@@ -52,7 +54,17 @@ function isModelClean(key: string, model: monaco.editor.ITextModel): boolean {
   return baseline === undefined || model.getValue() === baseline;
 }
 
-function evictOldestCleanModel(): void {
+function rememberEvictedDirtyModel(key: string, value: string, baseline: string): void {
+  evictedDirtyModels.delete(key);
+  evictedDirtyModels.set(key, { value, baseline });
+  while (evictedDirtyModels.size > EVICTED_DIRTY_MODEL_CAP) {
+    const oldest = evictedDirtyModels.keys().next();
+    if (oldest.done) break;
+    evictedDirtyModels.delete(oldest.value);
+  }
+}
+
+function evictOldestModel(): void {
   for (const [key, model] of models) {
     if (model.isDisposed() || isModelClean(key, model)) {
       model.dispose();
@@ -61,6 +73,14 @@ function evictOldestCleanModel(): void {
       return;
     }
   }
+  const oldest = models.entries().next();
+  if (oldest.done) return;
+  const [key, model] = oldest.value;
+  const value = model.getValue();
+  rememberEvictedDirtyModel(key, value, modelBaselines.get(key) ?? value);
+  model.dispose();
+  models.delete(key);
+  modelBaselines.delete(key);
 }
 
 export function getOrCreateModel(taskId: string, path: string, content: string): monaco.editor.ITextModel {
@@ -69,6 +89,7 @@ export function getOrCreateModel(taskId: string, path: string, content: string):
   if (existing && !existing.isDisposed()) {
     models.delete(key);
     models.set(key, existing);
+    evictedDirtyModels.delete(key);
     const baseline = modelBaselines.get(key);
     if (baseline === undefined) {
       modelBaselines.set(key, existing.getValue());
@@ -85,11 +106,17 @@ export function getOrCreateModel(taskId: string, path: string, content: string):
     modelBaselines.delete(key);
   }
   if (models.size >= MODEL_CACHE_CAP) {
-    evictOldestCleanModel();
+    evictOldestModel();
   }
-  const model = monaco.editor.createModel(content, undefined, monaco.Uri.file(modelUriPath(taskId, path)));
+  const evictedDirty = evictedDirtyModels.get(key);
+  evictedDirtyModels.delete(key);
+  const model = monaco.editor.createModel(
+    evictedDirty?.value ?? content,
+    undefined,
+    monaco.Uri.file(modelUriPath(taskId, path)),
+  );
   models.set(key, model);
-  modelBaselines.set(key, content);
+  modelBaselines.set(key, evictedDirty?.baseline ?? content);
   return model;
 }
 
@@ -97,6 +124,8 @@ export function markModelBaseline(taskId: string, path: string, content: string)
   const key = modelKey(taskId, path);
   if (models.has(key)) {
     modelBaselines.set(key, content);
+  } else if (evictedDirtyModels.has(key)) {
+    rememberEvictedDirtyModel(key, content, content);
   }
 }
 
@@ -108,4 +137,5 @@ export function dropModel(taskId: string, path: string): void {
     models.delete(key);
   }
   modelBaselines.delete(key);
+  evictedDirtyModels.delete(key);
 }

--- a/desktop/src/renderer/src/features/editor/monaco-setup.ts
+++ b/desktop/src/renderer/src/features/editor/monaco-setup.ts
@@ -39,62 +39,73 @@ const models = new Map<string, monaco.editor.ITextModel>();
 const modelBaselines = new Map<string, string>();
 const MODEL_CACHE_CAP = 32;
 
-function isModelClean(path: string, model: monaco.editor.ITextModel): boolean {
-  const baseline = modelBaselines.get(path);
+function modelKey(taskId: string, path: string): string {
+  return `${taskId}\u0000${path}`;
+}
+
+function modelUriPath(taskId: string, path: string): string {
+  return `/.matrix-os/tasks/${encodeURIComponent(taskId)}/${path.replace(/^\/+/, "")}`;
+}
+
+function isModelClean(key: string, model: monaco.editor.ITextModel): boolean {
+  const baseline = modelBaselines.get(key);
   return baseline === undefined || model.getValue() === baseline;
 }
 
 function evictOldestCleanModel(): void {
-  for (const [path, model] of models) {
-    if (model.isDisposed() || isModelClean(path, model)) {
+  for (const [key, model] of models) {
+    if (model.isDisposed() || isModelClean(key, model)) {
       model.dispose();
-      models.delete(path);
-      modelBaselines.delete(path);
+      models.delete(key);
+      modelBaselines.delete(key);
       return;
     }
   }
 }
 
-export function getOrCreateModel(path: string, content: string): monaco.editor.ITextModel {
-  const existing = models.get(path);
+export function getOrCreateModel(taskId: string, path: string, content: string): monaco.editor.ITextModel {
+  const key = modelKey(taskId, path);
+  const existing = models.get(key);
   if (existing && !existing.isDisposed()) {
-    models.delete(path);
-    models.set(path, existing);
-    const baseline = modelBaselines.get(path);
+    models.delete(key);
+    models.set(key, existing);
+    const baseline = modelBaselines.get(key);
     if (baseline === undefined) {
-      modelBaselines.set(path, existing.getValue());
+      modelBaselines.set(key, existing.getValue());
     } else if (existing.getValue() === baseline) {
       if (baseline !== content) {
         existing.setValue(content);
       }
-      modelBaselines.set(path, content);
+      modelBaselines.set(key, content);
     }
     return existing;
   }
   if (existing?.isDisposed()) {
-    models.delete(path);
-    modelBaselines.delete(path);
+    models.delete(key);
+    modelBaselines.delete(key);
   }
   if (models.size >= MODEL_CACHE_CAP) {
     evictOldestCleanModel();
   }
-  const model = monaco.editor.createModel(content, undefined, monaco.Uri.file(path));
-  models.set(path, model);
-  modelBaselines.set(path, content);
+  const model = monaco.editor.createModel(content, undefined, monaco.Uri.file(modelUriPath(taskId, path)));
+  models.set(key, model);
+  modelBaselines.set(key, content);
   return model;
 }
 
-export function markModelBaseline(path: string, content: string): void {
-  if (models.has(path)) {
-    modelBaselines.set(path, content);
+export function markModelBaseline(taskId: string, path: string, content: string): void {
+  const key = modelKey(taskId, path);
+  if (models.has(key)) {
+    modelBaselines.set(key, content);
   }
 }
 
-export function dropModel(path: string): void {
-  const model = models.get(path);
+export function dropModel(taskId: string, path: string): void {
+  const key = modelKey(taskId, path);
+  const model = models.get(key);
   if (model) {
     model.dispose();
-    models.delete(path);
+    models.delete(key);
   }
-  modelBaselines.delete(path);
+  modelBaselines.delete(key);
 }

--- a/desktop/src/renderer/src/features/editor/monaco-setup.ts
+++ b/desktop/src/renderer/src/features/editor/monaco-setup.ts
@@ -61,10 +61,14 @@ export function getOrCreateModel(path: string, content: string): monaco.editor.I
     models.delete(path);
     models.set(path, existing);
     const baseline = modelBaselines.get(path);
-    if (baseline !== undefined && existing.getValue() === baseline && baseline !== content) {
-      existing.setValue(content);
+    if (baseline === undefined) {
+      modelBaselines.set(path, existing.getValue());
+    } else if (existing.getValue() === baseline) {
+      if (baseline !== content) {
+        existing.setValue(content);
+      }
+      modelBaselines.set(path, content);
     }
-    modelBaselines.set(path, content);
     return existing;
   }
   if (existing?.isDisposed()) {

--- a/desktop/src/renderer/src/features/editor/monaco-setup.ts
+++ b/desktop/src/renderer/src/features/editor/monaco-setup.ts
@@ -1,0 +1,66 @@
+// Monaco bundled locally via vite workers (no CDN; CSP forbids remote code).
+import * as monaco from "monaco-editor";
+import editorWorker from "monaco-editor/esm/vs/editor/editor.worker?worker";
+import jsonWorker from "monaco-editor/esm/vs/language/json/json.worker?worker";
+import cssWorker from "monaco-editor/esm/vs/language/css/css.worker?worker";
+import htmlWorker from "monaco-editor/esm/vs/language/html/html.worker?worker";
+import tsWorker from "monaco-editor/esm/vs/language/typescript/ts.worker?worker";
+
+self.MonacoEnvironment = {
+  getWorker(_workerId: string, label: string) {
+    if (label === "json") return new jsonWorker();
+    if (label === "css" || label === "scss" || label === "less") return new cssWorker();
+    if (label === "html" || label === "handlebars" || label === "razor") return new htmlWorker();
+    if (label === "typescript" || label === "javascript") return new tsWorker();
+    return new editorWorker();
+  },
+};
+
+monaco.editor.defineTheme("operator-dark", {
+  base: "vs-dark",
+  inherit: true,
+  rules: [],
+  colors: {
+    "editor.background": "#14141b",
+    "editor.foreground": "#e9e9f1",
+    "editorLineNumber.foreground": "#4a4a5c",
+    "editorLineNumber.activeForeground": "#a3a3b8",
+    "editor.selectionBackground": "#7c6ff74d",
+    "editorCursor.foreground": "#7c6ff7",
+    "editorWidget.background": "#1f1f2a",
+    "editorWidget.border": "#2c2c3a",
+  },
+});
+
+export { monaco };
+
+// Model cache so open files survive panel/workspace remounts (SC-006).
+const models = new Map<string, monaco.editor.ITextModel>();
+const MODEL_CACHE_CAP = 32;
+
+export function getOrCreateModel(path: string, content: string): monaco.editor.ITextModel {
+  const existing = models.get(path);
+  if (existing && !existing.isDisposed()) {
+    models.delete(path);
+    models.set(path, existing);
+    return existing;
+  }
+  if (models.size >= MODEL_CACHE_CAP) {
+    const oldest = models.keys().next().value as string | undefined;
+    if (oldest) {
+      models.get(oldest)?.dispose();
+      models.delete(oldest);
+    }
+  }
+  const model = monaco.editor.createModel(content, undefined, monaco.Uri.file(path));
+  models.set(path, model);
+  return model;
+}
+
+export function dropModel(path: string): void {
+  const model = models.get(path);
+  if (model) {
+    model.dispose();
+    models.delete(path);
+  }
+}

--- a/desktop/src/renderer/src/features/editor/monaco-setup.ts
+++ b/desktop/src/renderer/src/features/editor/monaco-setup.ts
@@ -43,7 +43,6 @@ export function getOrCreateModel(path: string, content: string): monaco.editor.I
   if (existing && !existing.isDisposed()) {
     models.delete(path);
     models.set(path, existing);
-    if (existing.getValue() !== content) existing.setValue(content);
     return existing;
   }
   if (models.size >= MODEL_CACHE_CAP) {

--- a/desktop/src/renderer/src/features/editor/monaco-setup.ts
+++ b/desktop/src/renderer/src/features/editor/monaco-setup.ts
@@ -43,6 +43,7 @@ export function getOrCreateModel(path: string, content: string): monaco.editor.I
   if (existing && !existing.isDisposed()) {
     models.delete(path);
     models.set(path, existing);
+    if (existing.getValue() !== content) existing.setValue(content);
     return existing;
   }
   if (models.size >= MODEL_CACHE_CAP) {

--- a/desktop/src/renderer/src/features/editor/monaco-setup.ts
+++ b/desktop/src/renderer/src/features/editor/monaco-setup.ts
@@ -36,6 +36,7 @@ export { monaco };
 
 // Model cache so open files survive panel/workspace remounts (SC-006).
 const models = new Map<string, monaco.editor.ITextModel>();
+const modelBaselines = new Map<string, string>();
 const MODEL_CACHE_CAP = 32;
 
 export function getOrCreateModel(path: string, content: string): monaco.editor.ITextModel {
@@ -43,18 +44,35 @@ export function getOrCreateModel(path: string, content: string): monaco.editor.I
   if (existing && !existing.isDisposed()) {
     models.delete(path);
     models.set(path, existing);
+    const baseline = modelBaselines.get(path);
+    if (baseline !== undefined && existing.getValue() === baseline && baseline !== content) {
+      existing.setValue(content);
+    }
+    modelBaselines.set(path, content);
     return existing;
+  }
+  if (existing?.isDisposed()) {
+    models.delete(path);
+    modelBaselines.delete(path);
   }
   if (models.size >= MODEL_CACHE_CAP) {
     const oldest = models.keys().next().value as string | undefined;
     if (oldest) {
       models.get(oldest)?.dispose();
       models.delete(oldest);
+      modelBaselines.delete(oldest);
     }
   }
   const model = monaco.editor.createModel(content, undefined, monaco.Uri.file(path));
   models.set(path, model);
+  modelBaselines.set(path, content);
   return model;
+}
+
+export function markModelBaseline(path: string, content: string): void {
+  if (models.has(path)) {
+    modelBaselines.set(path, content);
+  }
 }
 
 export function dropModel(path: string): void {
@@ -63,4 +81,5 @@ export function dropModel(path: string): void {
     model.dispose();
     models.delete(path);
   }
+  modelBaselines.delete(path);
 }

--- a/desktop/src/renderer/src/features/files/FilesPanel.tsx
+++ b/desktop/src/renderer/src/features/files/FilesPanel.tsx
@@ -1,0 +1,156 @@
+import { ChevronDown, ChevronRight, File, Folder, RefreshCw } from "lucide-react";
+import { useCallback, useEffect, useState } from "react";
+import { IconButton } from "../../design/primitives";
+import { useConnection } from "../../stores/connection";
+import { useEditorTabs } from "../editor/editor-tabs-store";
+
+interface Entry {
+  name: string;
+  type: "file" | "directory";
+}
+
+function parseEntries(value: unknown): Entry[] {
+  if (!Array.isArray(value)) return [];
+  const entries: Entry[] = [];
+  for (const raw of value.slice(0, 500)) {
+    if (
+      raw &&
+      typeof raw === "object" &&
+      typeof (raw as Entry).name === "string" &&
+      ((raw as Entry).type === "file" || (raw as Entry).type === "directory")
+    ) {
+      entries.push({ name: (raw as Entry).name, type: (raw as Entry).type });
+    }
+  }
+  return entries.sort((a, b) =>
+    a.type === b.type ? a.name.localeCompare(b.name) : a.type === "directory" ? -1 : 1,
+  );
+}
+
+function TreeNode({
+  path,
+  name,
+  depth,
+  onOpenFile,
+}: {
+  path: string;
+  name: string;
+  depth: number;
+  onOpenFile: (path: string) => void;
+}) {
+  const api = useConnection((s) => s.api);
+  const [expanded, setExpanded] = useState(false);
+  const [children, setChildren] = useState<Entry[] | null>(null);
+
+  const toggle = useCallback(() => {
+    setExpanded((prev) => !prev);
+    if (!children && api) {
+      api
+        .get<{ entries: unknown }>(`/api/files/list?path=${encodeURIComponent(path)}`)
+        .then((res) => setChildren(parseEntries(res.entries)))
+        .catch((err: unknown) => {
+          console.warn("[files] list failed:", err instanceof Error ? err.message : String(err));
+          setChildren([]);
+        });
+    }
+  }, [api, children, path]);
+
+  return (
+    <>
+      <button
+        type="button"
+        className="flex w-full items-center gap-1.5 rounded px-1.5 py-1 text-left text-sm hover:bg-[var(--bg-hover)]"
+        style={{ paddingLeft: 6 + depth * 14, color: "var(--text-secondary)" }}
+        onClick={toggle}
+      >
+        {expanded ? <ChevronDown size={12} /> : <ChevronRight size={12} />}
+        <Folder size={13} style={{ color: "var(--text-tertiary)" }} />
+        <span className="truncate" style={{ color: "var(--text-primary)" }}>
+          {name}
+        </span>
+      </button>
+      {expanded && children
+        ? children.map((entry) => {
+            const childPath = path ? `${path}/${entry.name}` : entry.name;
+            return entry.type === "directory" ? (
+              <TreeNode
+                key={childPath}
+                path={childPath}
+                name={entry.name}
+                depth={depth + 1}
+                onOpenFile={onOpenFile}
+              />
+            ) : (
+              <button
+                key={childPath}
+                type="button"
+                className="flex w-full items-center gap-1.5 rounded px-1.5 py-1 text-left text-sm hover:bg-[var(--bg-hover)]"
+                style={{ paddingLeft: 6 + (depth + 1) * 14 + 14, color: "var(--text-secondary)" }}
+                onClick={() => onOpenFile(childPath)}
+              >
+                <File size={13} style={{ color: "var(--text-tertiary)" }} />
+                <span className="truncate">{entry.name}</span>
+              </button>
+            );
+          })
+        : null}
+    </>
+  );
+}
+
+export default function FilesPanel({ taskId }: { taskId: string }) {
+  const api = useConnection((s) => s.api);
+  const openTab = useEditorTabs((s) => s.openTab);
+  const [roots, setRoots] = useState<Entry[] | null>(null);
+
+  const loadRoots = useCallback(() => {
+    if (!api) return;
+    api
+      .get<{ entries: unknown }>(`/api/files/list?path=${encodeURIComponent("")}`)
+      .then((res) => setRoots(parseEntries(res.entries)))
+      .catch((err: unknown) => {
+        console.warn("[files] root list failed:", err instanceof Error ? err.message : String(err));
+        setRoots([]);
+      });
+  }, [api]);
+
+  useEffect(() => {
+    if (roots === null) loadRoots();
+  }, [loadRoots, roots]);
+
+  const onOpenFile = useCallback(
+    (path: string) => {
+      openTab(taskId, path);
+    },
+    [openTab, taskId],
+  );
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col overflow-y-auto p-1.5">
+      <div className="mb-1 flex items-center justify-between px-1">
+        <span className="text-xs font-semibold tracking-wide uppercase" style={{ color: "var(--text-tertiary)" }}>
+          Files
+        </span>
+        <IconButton label="Refresh files" onClick={loadRoots}>
+          <RefreshCw size={12} />
+        </IconButton>
+      </div>
+      {roots?.map((entry) =>
+        entry.type === "directory" ? (
+          <TreeNode key={entry.name} path={entry.name} name={entry.name} depth={0} onOpenFile={onOpenFile} />
+        ) : (
+          <button
+            key={entry.name}
+            type="button"
+            className="flex w-full items-center gap-1.5 rounded px-1.5 py-1 text-left text-sm hover:bg-[var(--bg-hover)]"
+            style={{ paddingLeft: 20, color: "var(--text-secondary)" }}
+            onClick={() => onOpenFile(entry.name)}
+          >
+            <File size={13} style={{ color: "var(--text-tertiary)" }} />
+            <span className="truncate">{entry.name}</span>
+          </button>
+        ),
+      )}
+    </div>
+  );
+}

--- a/desktop/src/renderer/src/features/files/FilesPanel.tsx
+++ b/desktop/src/renderer/src/features/files/FilesPanel.tsx
@@ -112,7 +112,7 @@ export default function FilesPanel({ taskId }: { taskId: string }) {
       .then((res) => setRoots(parseEntries(res.entries)))
       .catch((err: unknown) => {
         console.warn("[files] root list failed:", err instanceof Error ? err.message : String(err));
-        setRoots([]);
+        setRoots(null);
       });
   }, [api]);
 

--- a/desktop/src/renderer/src/features/files/FilesPanel.tsx
+++ b/desktop/src/renderer/src/features/files/FilesPanel.tsx
@@ -51,7 +51,8 @@ function TreeNode({
         .then((res) => setChildren(parseEntries(res.entries)))
         .catch((err: unknown) => {
           console.warn("[files] list failed:", err instanceof Error ? err.message : String(err));
-          setChildren([]);
+          setChildren(null);
+          setExpanded(false);
         });
     }
   }, [api, children, path]);

--- a/desktop/src/renderer/src/features/files/FilesPanel.tsx
+++ b/desktop/src/renderer/src/features/files/FilesPanel.tsx
@@ -2,6 +2,7 @@ import { ChevronDown, ChevronRight, File, Folder, RefreshCw } from "lucide-react
 import { useCallback, useEffect, useState } from "react";
 import { IconButton } from "../../design/primitives";
 import { useConnection } from "../../stores/connection";
+import { useWorkspace } from "../../stores/workspace";
 import { useEditorTabs } from "../editor/editor-tabs-store";
 
 interface Entry {
@@ -121,6 +122,10 @@ export default function FilesPanel({ taskId }: { taskId: string }) {
   const onOpenFile = useCallback(
     (path: string) => {
       openTab(taskId, path);
+      const workspace = useWorkspace.getState();
+      if (!workspace.layoutFor(taskId).visible.editor) {
+        workspace.togglePanel(taskId, "editor");
+      }
     },
     [openTab, taskId],
   );

--- a/desktop/src/renderer/src/features/files/QuickOpen.tsx
+++ b/desktop/src/renderer/src/features/files/QuickOpen.tsx
@@ -12,7 +12,6 @@ export default function QuickOpen() {
   const open = useUi((s) => s.quickOpenOpen);
   const setOpen = useUi((s) => s.setQuickOpenOpen);
   const view = useUi((s) => s.view);
-  const navigate = useUi((s) => s.navigate);
   const api = useConnection((s) => s.api);
   const openTab = useEditorTabs((s) => s.openTab);
   const togglePanel = useWorkspace((s) => s.togglePanel);
@@ -102,7 +101,6 @@ export default function QuickOpen() {
     if (view.kind !== "task") return;
     openTab(view.taskId, path);
     if (!layoutFor(view.taskId).visible.editor) togglePanel(view.taskId, "editor");
-    navigate(view);
   };
 
   return (

--- a/desktop/src/renderer/src/features/files/QuickOpen.tsx
+++ b/desktop/src/renderer/src/features/files/QuickOpen.tsx
@@ -1,0 +1,146 @@
+import { File } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
+import { useConnection } from "../../stores/connection";
+import { useUi } from "../../stores/ui";
+import { useEditorTabs } from "../editor/editor-tabs-store";
+import { useWorkspace } from "../../stores/workspace";
+
+const SEARCH_DEBOUNCE_MS = 150;
+const MAX_RESULTS = 30;
+
+export default function QuickOpen() {
+  const open = useUi((s) => s.quickOpenOpen);
+  const setOpen = useUi((s) => s.setQuickOpenOpen);
+  const view = useUi((s) => s.view);
+  const navigate = useUi((s) => s.navigate);
+  const api = useConnection((s) => s.api);
+  const openTab = useEditorTabs((s) => s.openTab);
+  const togglePanel = useWorkspace((s) => s.togglePanel);
+  const layoutFor = useWorkspace((s) => s.layoutFor);
+  const [query, setQuery] = useState("");
+  const [results, setResults] = useState<string[]>([]);
+  const [selected, setSelected] = useState(0);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    if (open) {
+      setQuery("");
+      setResults([]);
+      setSelected(0);
+      setTimeout(() => inputRef.current?.focus(), 0);
+    }
+  }, [open]);
+
+  useEffect(() => {
+    if (!open || !api || query.trim().length === 0) {
+      setResults([]);
+      return;
+    }
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    debounceRef.current = setTimeout(() => {
+      api
+        .get<{ results?: unknown; entries?: unknown }>(
+          `/api/files/search?q=${encodeURIComponent(query.trim())}&limit=${MAX_RESULTS}`,
+        )
+        .then((res) => {
+          const raw = Array.isArray(res.results)
+            ? res.results
+            : Array.isArray(res.entries)
+              ? res.entries
+              : [];
+          const paths: string[] = [];
+          for (const item of raw.slice(0, MAX_RESULTS)) {
+            if (typeof item === "string") paths.push(item);
+            else if (item && typeof item === "object" && typeof (item as { path?: unknown }).path === "string") {
+              paths.push((item as { path: string }).path);
+            }
+          }
+          setResults(paths);
+          setSelected(0);
+        })
+        .catch((err: unknown) => {
+          console.warn("[quick-open] search failed:", err instanceof Error ? err.message : String(err));
+          setResults([]);
+        });
+    }, SEARCH_DEBOUNCE_MS);
+    return () => {
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+    };
+  }, [api, open, query]);
+
+  if (!open) return null;
+
+  const openPath = (path: string) => {
+    setOpen(false);
+    if (view.kind !== "task") return;
+    openTab(view.taskId, path);
+    if (!layoutFor(view.taskId).visible.editor) togglePanel(view.taskId, "editor");
+    navigate(view);
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-start justify-center pt-[16vh]"
+      style={{ background: "rgba(0,0,0,0.45)" }}
+      onMouseDown={(e) => {
+        if (e.target === e.currentTarget) setOpen(false);
+      }}
+    >
+      <div
+        className="fade-in w-[560px] overflow-hidden rounded-xl border"
+        style={{
+          background: "var(--bg-overlay)",
+          borderColor: "var(--border-default)",
+          boxShadow: "var(--shadow-3)",
+        }}
+      >
+        <input
+          ref={inputRef}
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          placeholder="Go to file…"
+          className="w-full border-b bg-transparent px-4 py-3 text-md outline-none"
+          style={{ borderColor: "var(--border-subtle)", color: "var(--text-primary)" }}
+          onKeyDown={(e) => {
+            if (e.key === "Escape") setOpen(false);
+            if (e.key === "ArrowDown") {
+              e.preventDefault();
+              setSelected((s) => Math.min(s + 1, results.length - 1));
+            }
+            if (e.key === "ArrowUp") {
+              e.preventDefault();
+              setSelected((s) => Math.max(s - 1, 0));
+            }
+            if (e.key === "Enter" && results[selected]) {
+              openPath(results[selected]);
+            }
+          }}
+        />
+        <div className="max-h-[300px] overflow-y-auto p-1.5">
+          {results.map((path, i) => (
+            <button
+              key={path}
+              type="button"
+              className="flex w-full items-center gap-2 rounded-md px-2.5 py-1.5 text-left text-sm"
+              style={{
+                background: i === selected ? "var(--bg-selected)" : "transparent",
+                color: "var(--text-primary)",
+              }}
+              onMouseEnter={() => setSelected(i)}
+              onClick={() => openPath(path)}
+            >
+              <File size={13} style={{ color: "var(--text-tertiary)" }} />
+              <span className="truncate">{path}</span>
+            </button>
+          ))}
+          {query.trim().length > 0 && results.length === 0 ? (
+            <p className="px-3 py-4 text-center text-sm" style={{ color: "var(--text-tertiary)" }}>
+              No files found.
+            </p>
+          ) : null}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/desktop/src/renderer/src/features/files/QuickOpen.tsx
+++ b/desktop/src/renderer/src/features/files/QuickOpen.tsx
@@ -19,6 +19,7 @@ export default function QuickOpen() {
   const [query, setQuery] = useState("");
   const [results, setResults] = useState<string[]>([]);
   const [selected, setSelected] = useState(0);
+  const [openError, setOpenError] = useState<string | null>(null);
   const inputRef = useRef<HTMLInputElement>(null);
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const focusTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -29,6 +30,7 @@ export default function QuickOpen() {
       setQuery("");
       setResults([]);
       setSelected(0);
+      setOpenError(null);
       if (focusTimerRef.current) clearTimeout(focusTimerRef.current);
       focusTimerRef.current = setTimeout(() => {
         focusTimerRef.current = null;
@@ -97,10 +99,13 @@ export default function QuickOpen() {
   if (!open) return null;
 
   const openPath = (path: string) => {
-    setOpen(false);
-    if (view.kind !== "task") return;
+    if (view.kind !== "task") {
+      setOpenError("Open a task tab before opening files.");
+      return;
+    }
     openTab(view.taskId, path);
     if (!layoutFor(view.taskId).visible.editor) togglePanel(view.taskId, "editor");
+    setOpen(false);
   };
 
   return (
@@ -122,7 +127,10 @@ export default function QuickOpen() {
         <input
           ref={inputRef}
           value={query}
-          onChange={(e) => setQuery(e.target.value)}
+          onChange={(e) => {
+            setQuery(e.target.value);
+            setOpenError(null);
+          }}
           placeholder="Go to file…"
           className="w-full border-b bg-transparent px-4 py-3 text-md outline-none"
           style={{ borderColor: "var(--border-subtle)", color: "var(--text-primary)" }}
@@ -161,6 +169,11 @@ export default function QuickOpen() {
           {query.trim().length > 0 && results.length === 0 ? (
             <p className="px-3 py-4 text-center text-sm" style={{ color: "var(--text-tertiary)" }}>
               No files found.
+            </p>
+          ) : null}
+          {openError ? (
+            <p className="px-3 py-2 text-sm" style={{ color: "var(--danger)" }} role="status">
+              {openError}
             </p>
           ) : null}
         </div>

--- a/desktop/src/renderer/src/features/files/QuickOpen.tsx
+++ b/desktop/src/renderer/src/features/files/QuickOpen.tsx
@@ -22,28 +22,49 @@ export default function QuickOpen() {
   const [selected, setSelected] = useState(0);
   const inputRef = useRef<HTMLInputElement>(null);
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const focusTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const searchSeqRef = useRef(0);
 
   useEffect(() => {
     if (open) {
       setQuery("");
       setResults([]);
       setSelected(0);
-      setTimeout(() => inputRef.current?.focus(), 0);
+      if (focusTimerRef.current) clearTimeout(focusTimerRef.current);
+      focusTimerRef.current = setTimeout(() => {
+        focusTimerRef.current = null;
+        inputRef.current?.focus();
+      }, 0);
     }
+    return () => {
+      if (focusTimerRef.current) {
+        clearTimeout(focusTimerRef.current);
+        focusTimerRef.current = null;
+      }
+    };
   }, [open]);
 
   useEffect(() => {
-    if (!open || !api || query.trim().length === 0) {
+    if (debounceRef.current) {
+      clearTimeout(debounceRef.current);
+      debounceRef.current = null;
+    }
+    const searchSeq = searchSeqRef.current + 1;
+    searchSeqRef.current = searchSeq;
+    const trimmedQuery = query.trim();
+    if (!open || !api || trimmedQuery.length === 0) {
       setResults([]);
       return;
     }
-    if (debounceRef.current) clearTimeout(debounceRef.current);
+    let cancelled = false;
     debounceRef.current = setTimeout(() => {
+      debounceRef.current = null;
       api
         .get<{ results?: unknown; entries?: unknown }>(
-          `/api/files/search?q=${encodeURIComponent(query.trim())}&limit=${MAX_RESULTS}`,
+          `/api/files/search?q=${encodeURIComponent(trimmedQuery)}&limit=${MAX_RESULTS}`,
         )
         .then((res) => {
+          if (cancelled || searchSeqRef.current !== searchSeq) return;
           const raw = Array.isArray(res.results)
             ? res.results
             : Array.isArray(res.entries)
@@ -60,12 +81,17 @@ export default function QuickOpen() {
           setSelected(0);
         })
         .catch((err: unknown) => {
+          if (cancelled || searchSeqRef.current !== searchSeq) return;
           console.warn("[quick-open] search failed:", err instanceof Error ? err.message : String(err));
           setResults([]);
         });
     }, SEARCH_DEBOUNCE_MS);
     return () => {
-      if (debounceRef.current) clearTimeout(debounceRef.current);
+      cancelled = true;
+      if (debounceRef.current) {
+        clearTimeout(debounceRef.current);
+        debounceRef.current = null;
+      }
     };
   }, [api, open, query]);
 

--- a/desktop/src/renderer/src/features/git/GitPanel.tsx
+++ b/desktop/src/renderer/src/features/git/GitPanel.tsx
@@ -1,5 +1,6 @@
 import { GitBranch, GitPullRequest, FolderGit2, RefreshCw, Sparkles } from "lucide-react";
 import { useEffect } from "react";
+import { categoryMessage } from "../../../../shared/app-error";
 import { Button, IconButton } from "../../design/primitives";
 import { useConnection } from "../../stores/connection";
 import { useGit } from "../../stores/git";
@@ -21,6 +22,7 @@ export default function GitPanel({ projectSlug }: { projectSlug: string }) {
   const branches = useGit((s) => s.branches);
   const prs = useGit((s) => s.prs);
   const worktrees = useGit((s) => s.worktrees);
+  const error = useGit((s) => s.error);
   const loadAll = useGit((s) => s.loadAll);
   const setComposerOpen = useUi((s) => s.setComposerOpen);
 
@@ -43,6 +45,16 @@ export default function GitPanel({ projectSlug }: { projectSlug: string }) {
           <RefreshCw size={12} />
         </IconButton>
       </div>
+
+      {error ? (
+        <div
+          role="status"
+          className="mt-2 rounded-lg border px-2.5 py-2 text-xs"
+          style={{ borderColor: "var(--danger)", color: "var(--danger)", background: "var(--bg-raised)" }}
+        >
+          {categoryMessage(error)}
+        </div>
+      ) : null}
 
       <SectionHeading icon={<GitBranch size={12} />} label={`Branches (${branches.length})`} />
       {branches.slice(0, 20).map((branch) => (

--- a/desktop/src/renderer/src/features/git/GitPanel.tsx
+++ b/desktop/src/renderer/src/features/git/GitPanel.tsx
@@ -1,0 +1,95 @@
+import { GitBranch, GitPullRequest, FolderGit2, RefreshCw, Sparkles } from "lucide-react";
+import { useEffect } from "react";
+import { Button, IconButton } from "../../design/primitives";
+import { useConnection } from "../../stores/connection";
+import { useGit } from "../../stores/git";
+import { useUi } from "../../stores/ui";
+
+function SectionHeading({ icon, label }: { icon: React.ReactNode; label: string }) {
+  return (
+    <div className="mt-3 mb-1 flex items-center gap-1.5 px-1 first:mt-0">
+      <span style={{ color: "var(--text-tertiary)" }}>{icon}</span>
+      <span className="text-xs font-semibold tracking-wide uppercase" style={{ color: "var(--text-tertiary)" }}>
+        {label}
+      </span>
+    </div>
+  );
+}
+
+export default function GitPanel({ projectSlug }: { projectSlug: string }) {
+  const api = useConnection((s) => s.api);
+  const branches = useGit((s) => s.branches);
+  const prs = useGit((s) => s.prs);
+  const worktrees = useGit((s) => s.worktrees);
+  const loadAll = useGit((s) => s.loadAll);
+  const setComposerOpen = useUi((s) => s.setComposerOpen);
+
+  useEffect(() => {
+    if (api) void loadAll(api, projectSlug);
+  }, [api, loadAll, projectSlug]);
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col overflow-y-auto p-2">
+      <div className="flex items-center justify-between px-1">
+        <span className="text-sm font-medium" style={{ color: "var(--text-primary)" }}>
+          {projectSlug}
+        </span>
+        <IconButton
+          label="Refresh git"
+          onClick={() => {
+            if (api) void loadAll(api, projectSlug);
+          }}
+        >
+          <RefreshCw size={12} />
+        </IconButton>
+      </div>
+
+      <SectionHeading icon={<GitBranch size={12} />} label={`Branches (${branches.length})`} />
+      {branches.slice(0, 20).map((branch) => (
+        <div
+          key={branch.name}
+          className="truncate rounded px-1.5 py-1 font-mono text-xs"
+          style={{ color: "var(--text-secondary)" }}
+          title={branch.name}
+        >
+          {branch.name}
+        </div>
+      ))}
+
+      <SectionHeading icon={<GitPullRequest size={12} />} label={`Pull requests (${prs.length})`} />
+      {prs.slice(0, 20).map((pr) => (
+        <div key={pr.number} className="flex items-center gap-1.5 rounded px-1.5 py-1 text-xs">
+          <span style={{ color: "var(--text-tertiary)" }}>#{pr.number}</span>
+          <span className="truncate" style={{ color: "var(--text-secondary)" }}>
+            {pr.title}
+          </span>
+        </div>
+      ))}
+
+      <SectionHeading icon={<FolderGit2 size={12} />} label={`Worktrees (${worktrees.length})`} />
+      {worktrees.slice(0, 20).map((worktree, i) => (
+        <div
+          key={worktree.id ?? i}
+          className="truncate rounded px-1.5 py-1 font-mono text-xs"
+          style={{ color: "var(--text-secondary)" }}
+          title={worktree.path}
+        >
+          {worktree.currentBranch ?? worktree.sourceBranch ?? worktree.path ?? "worktree"}
+        </div>
+      ))}
+
+      <div
+        className="mt-4 flex flex-col gap-2 rounded-lg border p-3"
+        style={{ borderColor: "var(--border-subtle)", background: "var(--bg-raised)" }}
+      >
+        <span className="text-xs" style={{ color: "var(--text-secondary)" }}>
+          Diff review lands with gateway diff support. Meanwhile, ask the agent to review changes.
+        </span>
+        <Button variant="subtle" onClick={() => setComposerOpen(true)}>
+          <Sparkles size={13} />
+          Ask agent to review
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/desktop/src/renderer/src/features/mission-control/MissionControl.tsx
+++ b/desktop/src/renderer/src/features/mission-control/MissionControl.tsx
@@ -2,7 +2,7 @@ import { useEffect } from "react";
 import { useConnection } from "../../stores/connection";
 import { useBoard } from "../../stores/board";
 import { useUi } from "../../stores/ui";
-import { useWorkspace } from "../../stores/workspace";
+import { useWorkspace, type PanelLayout } from "../../stores/workspace";
 import Sidebar from "./Sidebar";
 import Titlebar from "./Titlebar";
 import Board from "../board/Board";
@@ -33,7 +33,7 @@ export default function MissionControl() {
     configure({
       loadLayouts: async () => {
         const result = await invoke("state:get", { key: "panelLayouts" });
-        return (result.value as Record<string, never> | null) ?? null;
+        return (result.value as Record<string, PanelLayout> | null) ?? null;
       },
       saveLayout: async (taskKey, layout) => {
         await invoke("state:set-panel-layout", { taskKey, layout });

--- a/desktop/src/renderer/src/features/mission-control/MissionControl.tsx
+++ b/desktop/src/renderer/src/features/mission-control/MissionControl.tsx
@@ -2,6 +2,7 @@ import { useEffect } from "react";
 import { useConnection } from "../../stores/connection";
 import { useBoard } from "../../stores/board";
 import { useUi } from "../../stores/ui";
+import { useWorkspace } from "../../stores/workspace";
 import Sidebar from "./Sidebar";
 import Titlebar from "./Titlebar";
 import Board from "../board/Board";
@@ -10,6 +11,7 @@ import ThreadView from "../threads/ThreadView";
 import SessionsView from "../sessions/SessionsView";
 import SettingsView from "../settings/SettingsView";
 import StandaloneSession from "../sessions/StandaloneSession";
+import QuickOpen from "../files/QuickOpen";
 import Composer from "../threads/Composer";
 import CommandPalette from "../palette/CommandPalette";
 import { useGlobalShortcuts } from "./shortcuts";
@@ -24,6 +26,26 @@ export default function MissionControl() {
   const view = useUi((s) => s.view);
 
   useGlobalShortcuts();
+
+  useEffect(() => {
+    // Wire workspace layout persistence through the trusted core once.
+    const { configure, hydrate } = useWorkspace.getState();
+    configure({
+      loadLayouts: async () => {
+        const result = await invoke("state:get", { key: "panelLayouts" });
+        return (result.value as Record<string, never> | null) ?? null;
+      },
+      saveLayout: async (taskKey, layout) => {
+        const current = await invoke("state:get", { key: "panelLayouts" });
+        const layouts = (current.value as Record<string, unknown> | null) ?? {};
+        await invoke("state:set", {
+          key: "panelLayouts",
+          value: { ...layouts, [taskKey]: layout },
+        });
+      },
+    });
+    void hydrate();
+  }, []);
 
   useEffect(() => {
     if (!api) return;
@@ -94,6 +116,7 @@ export default function MissionControl() {
       </div>
       <Composer />
       <CommandPalette />
+      <QuickOpen />
     </div>
   );
 }

--- a/desktop/src/renderer/src/features/mission-control/MissionControl.tsx
+++ b/desktop/src/renderer/src/features/mission-control/MissionControl.tsx
@@ -36,12 +36,7 @@ export default function MissionControl() {
         return (result.value as Record<string, never> | null) ?? null;
       },
       saveLayout: async (taskKey, layout) => {
-        const current = await invoke("state:get", { key: "panelLayouts" });
-        const layouts = (current.value as Record<string, unknown> | null) ?? {};
-        await invoke("state:set", {
-          key: "panelLayouts",
-          value: { ...layouts, [taskKey]: layout },
-        });
+        await invoke("state:set-panel-layout", { taskKey, layout });
       },
     });
     void hydrate();

--- a/desktop/src/renderer/src/features/mission-control/shortcuts.ts
+++ b/desktop/src/renderer/src/features/mission-control/shortcuts.ts
@@ -1,6 +1,12 @@
 import { useEffect } from "react";
 import { onEvent } from "../../lib/operator";
-import { useUi } from "../../stores/ui";
+import { useUi, type MainView } from "../../stores/ui";
+
+type MenuNavigateKind = Extract<MainView, { kind: "board" | "settings" }>["kind"];
+
+function isMenuNavigateKind(kind: string): kind is MenuNavigateKind {
+  return kind === "board" || kind === "settings";
+}
 
 function isTypingTarget(target: EventTarget | null): boolean {
   if (!(target instanceof HTMLElement)) return false;
@@ -44,7 +50,9 @@ export function useGlobalShortcuts(): void {
       if (action === "quick-open") ui.setQuickOpenOpen(!ui.quickOpenOpen);
     });
     const offNavigate = onEvent("menu:navigate", ({ kind }) => {
-      useUi.getState().navigate({ kind });
+      if (isMenuNavigateKind(kind)) {
+        useUi.getState().navigate({ kind });
+      }
     });
     return () => {
       window.removeEventListener("keydown", onKeyDown);

--- a/desktop/src/renderer/src/features/mission-control/shortcuts.ts
+++ b/desktop/src/renderer/src/features/mission-control/shortcuts.ts
@@ -1,4 +1,5 @@
 import { useEffect } from "react";
+import { onEvent } from "../../lib/operator";
 import { useUi } from "../../stores/ui";
 
 function isTypingTarget(target: EventTarget | null): boolean {
@@ -23,6 +24,11 @@ export function useGlobalShortcuts(): void {
         ui.setComposerOpen(!ui.composerOpen);
         return;
       }
+      if (meta && e.key.toLowerCase() === "p") {
+        e.preventDefault();
+        ui.setQuickOpenOpen(!ui.quickOpenOpen);
+        return;
+      }
       if (!meta && e.key.toLowerCase() === "c" && !isTypingTarget(e.target)) {
         if (ui.paletteOpen || ui.composerOpen || ui.createTaskOpen) return;
         e.preventDefault();
@@ -30,6 +36,20 @@ export function useGlobalShortcuts(): void {
       }
     };
     window.addEventListener("keydown", onKeyDown);
-    return () => window.removeEventListener("keydown", onKeyDown);
+    const offAction = onEvent("menu:action", ({ action }) => {
+      const ui = useUi.getState();
+      if (action === "new-task") ui.setCreateTaskOpen(true);
+      if (action === "new-thread") ui.setComposerOpen(true);
+      if (action === "palette") ui.setPaletteOpen(!ui.paletteOpen);
+      if (action === "quick-open") ui.setQuickOpenOpen(!ui.quickOpenOpen);
+    });
+    const offNavigate = onEvent("menu:navigate", ({ kind }) => {
+      useUi.getState().navigate({ kind });
+    });
+    return () => {
+      window.removeEventListener("keydown", onKeyDown);
+      offAction();
+      offNavigate();
+    };
   }, []);
 }

--- a/desktop/src/renderer/src/features/workspace/ArtifactsPanel.tsx
+++ b/desktop/src/renderer/src/features/workspace/ArtifactsPanel.tsx
@@ -6,7 +6,7 @@ import { useConnection } from "../../stores/connection";
 import { useGit } from "../../stores/git";
 
 export function canOpenPreviewUrl(url: string | null | undefined): url is string {
-  return typeof url === "string" && (url.startsWith("https://") || url.startsWith("http://"));
+  return typeof url === "string" && url.startsWith("https://");
 }
 
 export default function ArtifactsPanel({

--- a/desktop/src/renderer/src/features/workspace/ArtifactsPanel.tsx
+++ b/desktop/src/renderer/src/features/workspace/ArtifactsPanel.tsx
@@ -14,13 +14,17 @@ export default function ArtifactsPanel({
 }) {
   const api = useConnection((s) => s.api);
   const previews = useGit((s) => s.previews);
+  const previewScope = useGit((s) => s.previewScope);
   const loadPreviews = useGit((s) => s.loadPreviews);
 
   useEffect(() => {
     if (api) void loadPreviews(api, projectSlug, taskId);
   }, [api, loadPreviews, projectSlug, taskId]);
 
-  if (previews.length === 0) {
+  const scopedPreviews =
+    previewScope?.projectSlug === projectSlug && previewScope.taskId === taskId ? previews : [];
+
+  if (scopedPreviews.length === 0) {
     return (
       <EmptyState
         icon={<Package size={22} />}
@@ -42,7 +46,7 @@ export default function ArtifactsPanel({
           <RefreshCw size={12} />
         </IconButton>
       </div>
-      {previews.slice(0, 50).map((preview) => (
+      {scopedPreviews.slice(0, 50).map((preview) => (
         <button
           key={preview.id}
           type="button"

--- a/desktop/src/renderer/src/features/workspace/ArtifactsPanel.tsx
+++ b/desktop/src/renderer/src/features/workspace/ArtifactsPanel.tsx
@@ -1,0 +1,69 @@
+import { Package, RefreshCw } from "lucide-react";
+import { useEffect } from "react";
+import { EmptyState, IconButton } from "../../design/primitives";
+import { invoke } from "../../lib/operator";
+import { useConnection } from "../../stores/connection";
+import { useGit } from "../../stores/git";
+
+export default function ArtifactsPanel({
+  projectSlug,
+  taskId,
+}: {
+  projectSlug: string;
+  taskId: string;
+}) {
+  const api = useConnection((s) => s.api);
+  const previews = useGit((s) => s.previews);
+  const loadPreviews = useGit((s) => s.loadPreviews);
+
+  useEffect(() => {
+    if (api) void loadPreviews(api, projectSlug, taskId);
+  }, [api, loadPreviews, projectSlug, taskId]);
+
+  if (previews.length === 0) {
+    return (
+      <EmptyState
+        icon={<Package size={22} />}
+        headline="No artifacts"
+        description="Previews and artifacts created on this task appear here."
+      />
+    );
+  }
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col gap-1 overflow-y-auto p-2">
+      <div className="flex items-center justify-end">
+        <IconButton
+          label="Refresh artifacts"
+          onClick={() => {
+            if (api) void loadPreviews(api, projectSlug, taskId);
+          }}
+        >
+          <RefreshCw size={12} />
+        </IconButton>
+      </div>
+      {previews.slice(0, 50).map((preview) => (
+        <button
+          key={preview.id}
+          type="button"
+          className="flex flex-col gap-0.5 rounded-lg border p-2.5 text-left hover:border-[var(--border-strong)]"
+          style={{ borderColor: "var(--border-subtle)", background: "var(--bg-raised)" }}
+          onClick={() => {
+            if (preview.url && preview.url.startsWith("https://")) {
+              void invoke("shell:open-external", { url: preview.url });
+            }
+          }}
+        >
+          <span className="truncate text-sm" style={{ color: "var(--text-primary)" }}>
+            {preview.label ?? preview.id}
+          </span>
+          {preview.url ? (
+            <span className="truncate text-xs" style={{ color: "var(--text-tertiary)" }}>
+              {preview.url}
+            </span>
+          ) : null}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/desktop/src/renderer/src/features/workspace/ArtifactsPanel.tsx
+++ b/desktop/src/renderer/src/features/workspace/ArtifactsPanel.tsx
@@ -5,6 +5,10 @@ import { invoke } from "../../lib/operator";
 import { useConnection } from "../../stores/connection";
 import { useGit } from "../../stores/git";
 
+export function canOpenPreviewUrl(url: string | null | undefined): url is string {
+  return typeof url === "string" && (url.startsWith("https://") || url.startsWith("http://"));
+}
+
 export default function ArtifactsPanel({
   projectSlug,
   taskId,
@@ -53,7 +57,7 @@ export default function ArtifactsPanel({
           className="flex flex-col gap-0.5 rounded-lg border p-2.5 text-left hover:border-[var(--border-strong)]"
           style={{ borderColor: "var(--border-subtle)", background: "var(--bg-raised)" }}
           onClick={() => {
-            if (preview.url && preview.url.startsWith("https://")) {
+            if (canOpenPreviewUrl(preview.url)) {
               void invoke("shell:open-external", { url: preview.url });
             }
           }}

--- a/desktop/src/renderer/src/features/workspace/ArtifactsPanel.tsx
+++ b/desktop/src/renderer/src/features/workspace/ArtifactsPanel.tsx
@@ -20,22 +20,22 @@ export default function ArtifactsPanel({
   const api = useConnection((s) => s.api);
   const previews = useGit((s) => s.previews);
   const previewScope = useGit((s) => s.previewScope);
-  const error = useGit((s) => s.error);
+  const previewError = useGit((s) => s.previewError);
   const loadPreviews = useGit((s) => s.loadPreviews);
 
   useEffect(() => {
     if (api) void loadPreviews(api, projectSlug, taskId);
   }, [api, loadPreviews, projectSlug, taskId]);
 
-  const scopedPreviews =
-    previewScope?.projectSlug === projectSlug && previewScope.taskId === taskId ? previews : [];
+  const scopeMatches = previewScope?.projectSlug === projectSlug && previewScope.taskId === taskId;
+  const scopedPreviews = scopeMatches ? previews : [];
 
-  if (error && scopedPreviews.length === 0) {
+  if (scopeMatches && previewError && scopedPreviews.length === 0) {
     return (
       <EmptyState
         icon={<Package size={22} />}
         headline="Couldn't load artifacts"
-        description={categoryMessage(error)}
+        description={categoryMessage(previewError)}
       />
     );
   }

--- a/desktop/src/renderer/src/features/workspace/ArtifactsPanel.tsx
+++ b/desktop/src/renderer/src/features/workspace/ArtifactsPanel.tsx
@@ -1,5 +1,6 @@
 import { Package, RefreshCw } from "lucide-react";
 import { useEffect } from "react";
+import { categoryMessage } from "../../../../shared/app-error";
 import { EmptyState, IconButton } from "../../design/primitives";
 import { invoke } from "../../lib/operator";
 import { useConnection } from "../../stores/connection";
@@ -19,6 +20,7 @@ export default function ArtifactsPanel({
   const api = useConnection((s) => s.api);
   const previews = useGit((s) => s.previews);
   const previewScope = useGit((s) => s.previewScope);
+  const error = useGit((s) => s.error);
   const loadPreviews = useGit((s) => s.loadPreviews);
 
   useEffect(() => {
@@ -27,6 +29,16 @@ export default function ArtifactsPanel({
 
   const scopedPreviews =
     previewScope?.projectSlug === projectSlug && previewScope.taskId === taskId ? previews : [];
+
+  if (error && scopedPreviews.length === 0) {
+    return (
+      <EmptyState
+        icon={<Package size={22} />}
+        headline="Couldn't load artifacts"
+        description={categoryMessage(error)}
+      />
+    );
+  }
 
   if (scopedPreviews.length === 0) {
     return (

--- a/desktop/src/renderer/src/features/workspace/PanelStrip.tsx
+++ b/desktop/src/renderer/src/features/workspace/PanelStrip.tsx
@@ -1,0 +1,114 @@
+import { useCallback, useMemo, useRef } from "react";
+import {
+  useWorkspace,
+  defaultLayout,
+  PANEL_MIN_PCT,
+  type PanelKind,
+  type PanelLayout,
+} from "../../stores/workspace";
+
+export const PANEL_TITLES: Record<PanelKind, string> = {
+  terminal: "Terminal",
+  editor: "Editor",
+  git: "Git",
+  browser: "Browser",
+  artifacts: "Artifacts",
+  processes: "Processes",
+};
+
+interface PanelStripProps {
+  taskId: string;
+  renderPanel: (panel: PanelKind) => React.ReactNode;
+}
+
+export default function PanelStrip({ taskId, renderPanel }: PanelStripProps) {
+  const layouts = useWorkspace((s) => s.layouts);
+  const setPanelSizes = useWorkspace((s) => s.setPanelSizes);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const dragState = useRef<{ left: PanelKind; right: PanelKind; startX: number; startSizes: Record<PanelKind, number> } | null>(null);
+
+  const layout: PanelLayout = useMemo(() => layouts[taskId] ?? defaultLayout(), [layouts, taskId]);
+  const visiblePanels = useMemo(
+    () => layout.order.filter((panel) => layout.visible[panel]),
+    [layout],
+  );
+
+  const onDividerDown = useCallback(
+    (left: PanelKind, right: PanelKind, e: React.PointerEvent) => {
+      e.preventDefault();
+      (e.target as HTMLElement).setPointerCapture(e.pointerId);
+      dragState.current = {
+        left,
+        right,
+        startX: e.clientX,
+        startSizes: { ...layout.sizes },
+      };
+    },
+    [layout.sizes],
+  );
+
+  const onDividerMove = useCallback(
+    (e: React.PointerEvent) => {
+      const drag = dragState.current;
+      const container = containerRef.current;
+      if (!drag || !container) return;
+      const totalWidth = container.getBoundingClientRect().width;
+      if (totalWidth <= 0) return;
+      const deltaPct = ((e.clientX - drag.startX) / totalWidth) * 100;
+      const leftStart = drag.startSizes[drag.left] ?? 0;
+      const rightStart = drag.startSizes[drag.right] ?? 0;
+      const minLeft = PANEL_MIN_PCT[drag.left];
+      const minRight = PANEL_MIN_PCT[drag.right];
+      const clamped = Math.max(minLeft - leftStart, Math.min(deltaPct, rightStart - minRight));
+      setPanelSizes(taskId, {
+        ...drag.startSizes,
+        [drag.left]: leftStart + clamped,
+        [drag.right]: rightStart - clamped,
+      });
+    },
+    [setPanelSizes, taskId],
+  );
+
+  const onDividerUp = useCallback(() => {
+    dragState.current = null;
+  }, []);
+
+  if (visiblePanels.length === 0) {
+    return (
+      <div className="flex flex-1 items-center justify-center">
+        <span className="text-sm" style={{ color: "var(--text-tertiary)" }}>
+          All panels hidden. Toggle one from the toolbar (⌘1–⌘6).
+        </span>
+      </div>
+    );
+  }
+
+  return (
+    <div ref={containerRef} className="flex min-h-0 min-w-0 flex-1">
+      {visiblePanels.map((panel, index) => (
+        <div key={panel} className="flex min-h-0 min-w-0" style={{ flexBasis: `${layout.sizes[panel] ?? 100 / visiblePanels.length}%`, flexGrow: 0, flexShrink: 0, display: "flex" }}>
+          {index > 0 ? (
+            <div
+              role="separator"
+              aria-orientation="vertical"
+              className="w-[5px] shrink-0 cursor-col-resize transition-colors duration-100 hover:bg-[var(--accent-muted)]"
+              style={{ background: "var(--border-subtle)", backgroundClip: "padding-box", borderLeft: "2px solid transparent", borderRight: "2px solid transparent" }}
+              onPointerDown={(e) => onDividerDown(visiblePanels[index - 1]!, panel, e)}
+              onPointerMove={onDividerMove}
+              onPointerUp={onDividerUp}
+            />
+          ) : null}
+          <section className="flex min-h-0 min-w-0 flex-1 flex-col" aria-label={PANEL_TITLES[panel]}>
+            <header
+              className="flex h-7 shrink-0 items-center border-b px-2.5 text-xs font-semibold tracking-wide uppercase"
+              style={{ borderColor: "var(--border-subtle)", color: "var(--text-tertiary)", background: "var(--bg-surface)" }}
+            >
+              {PANEL_TITLES[panel]}
+            </header>
+            <div className="flex min-h-0 min-w-0 flex-1 flex-col">{renderPanel(panel)}</div>
+          </section>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/desktop/src/renderer/src/features/workspace/PanelStrip.tsx
+++ b/desktop/src/renderer/src/features/workspace/PanelStrip.tsx
@@ -107,6 +107,8 @@ export default function PanelStrip({ taskId, renderPanel }: PanelStripProps) {
               onPointerDown={(e) => onDividerDown(visiblePanels[index - 1]!, panel, e)}
               onPointerMove={onDividerMove}
               onPointerUp={onDividerUp}
+              onPointerCancel={onDividerUp}
+              onLostPointerCapture={onDividerUp}
             />
           ) : null}
           <section className="flex min-h-0 min-w-0 flex-1 flex-col" aria-label={PANEL_TITLES[panel]}>

--- a/desktop/src/renderer/src/features/workspace/PanelStrip.tsx
+++ b/desktop/src/renderer/src/features/workspace/PanelStrip.tsx
@@ -25,7 +25,13 @@ export default function PanelStrip({ taskId, renderPanel }: PanelStripProps) {
   const layouts = useWorkspace((s) => s.layouts);
   const setPanelSizes = useWorkspace((s) => s.setPanelSizes);
   const containerRef = useRef<HTMLDivElement>(null);
-  const dragState = useRef<{ left: PanelKind; right: PanelKind; startX: number; startSizes: Record<PanelKind, number> } | null>(null);
+  const dragState = useRef<{
+    left: PanelKind;
+    right: PanelKind;
+    startX: number;
+    startSizes: Record<PanelKind, number>;
+    latestSizes: Record<PanelKind, number> | null;
+  } | null>(null);
 
   const layout: PanelLayout = useMemo(() => layouts[taskId] ?? defaultLayout(), [layouts, taskId]);
   const visiblePanels = useMemo(
@@ -42,6 +48,7 @@ export default function PanelStrip({ taskId, renderPanel }: PanelStripProps) {
         right,
         startX: e.clientX,
         startSizes: { ...layout.sizes },
+        latestSizes: null,
       };
     },
     [layout.sizes],
@@ -60,18 +67,22 @@ export default function PanelStrip({ taskId, renderPanel }: PanelStripProps) {
       const minLeft = PANEL_MIN_PCT[drag.left];
       const minRight = PANEL_MIN_PCT[drag.right];
       const clamped = Math.max(minLeft - leftStart, Math.min(deltaPct, rightStart - minRight));
-      setPanelSizes(taskId, {
+      const nextSizes = {
         ...drag.startSizes,
         [drag.left]: leftStart + clamped,
         [drag.right]: rightStart - clamped,
-      });
+      };
+      drag.latestSizes = nextSizes;
+      setPanelSizes(taskId, nextSizes, Date.now(), { persist: false });
     },
     [setPanelSizes, taskId],
   );
 
   const onDividerUp = useCallback(() => {
+    const drag = dragState.current;
     dragState.current = null;
-  }, []);
+    if (drag?.latestSizes) setPanelSizes(taskId, drag.latestSizes);
+  }, [setPanelSizes, taskId]);
 
   if (visiblePanels.length === 0) {
     return (

--- a/desktop/src/renderer/src/features/workspace/ProcessesPanel.tsx
+++ b/desktop/src/renderer/src/features/workspace/ProcessesPanel.tsx
@@ -1,0 +1,12 @@
+import { Activity } from "lucide-react";
+import { EmptyState } from "../../design/primitives";
+
+export default function ProcessesPanel() {
+  return (
+    <EmptyState
+      icon={<Activity size={22} />}
+      headline="Processes"
+      description="Live process listing arrives with gateway support. Use the terminal (`htop`) meanwhile."
+    />
+  );
+}

--- a/desktop/src/renderer/src/features/workspace/TaskWorkspace.tsx
+++ b/desktop/src/renderer/src/features/workspace/TaskWorkspace.tsx
@@ -1,11 +1,45 @@
-import { ArrowLeft, SquareTerminal } from "lucide-react";
+import {
+  Activity,
+  ArrowLeft,
+  FileCode2,
+  FolderTree,
+  GitBranch,
+  Package,
+  SquareTerminal,
+} from "lucide-react";
 import { useEffect, useMemo } from "react";
 import { Button, EmptyState, IconButton } from "../../design/primitives";
 import { useBoard } from "../../stores/board";
 import { useConnection } from "../../stores/connection";
 import { useSessions } from "../../stores/sessions";
 import { useUi } from "../../stores/ui";
+import { useWorkspace, type PanelKind } from "../../stores/workspace";
+import EditorPanel from "../editor/EditorPanel";
+import FilesPanel from "../files/FilesPanel";
+import GitPanel from "../git/GitPanel";
 import TerminalView from "../terminal/TerminalView";
+import { getAttachManager } from "../terminal/terminal-runtime";
+import ArtifactsPanel from "./ArtifactsPanel";
+import PanelStrip, { PANEL_TITLES } from "./PanelStrip";
+import ProcessesPanel from "./ProcessesPanel";
+
+const PANEL_ICONS: Record<PanelKind, React.ReactNode> = {
+  terminal: <SquareTerminal size={14} />,
+  editor: <FileCode2 size={14} />,
+  git: <GitBranch size={14} />,
+  browser: <FolderTree size={14} />,
+  artifacts: <Package size={14} />,
+  processes: <Activity size={14} />,
+};
+
+const PANEL_SHORTCUT_ORDER: PanelKind[] = [
+  "terminal",
+  "editor",
+  "git",
+  "browser",
+  "artifacts",
+  "processes",
+];
 
 function warnSessionLoadFailure(err: unknown): void {
   console.warn("[task-workspace] load sessions failed:", err instanceof Error ? err.message : String(err));
@@ -16,9 +50,13 @@ export default function TaskWorkspace({ taskId }: { taskId: string }) {
   const activeSlug = useBoard((s) => s.activeProjectSlug);
   const cardsByProject = useBoard((s) => s.cardsByProject);
   const sessionsLoad = useSessions((s) => s.load);
-  // Select the map itself (not the resolver fn) so the load triggers a render.
   const aliasMap = useSessions((s) => s.aliasMap);
   const navigate = useUi((s) => s.navigate);
+  const openTask = useWorkspace((s) => s.openTask);
+  const focusTask = useWorkspace((s) => s.focusTask);
+  const togglePanel = useWorkspace((s) => s.togglePanel);
+  const layouts = useWorkspace((s) => s.layouts);
+  const layoutFor = useWorkspace((s) => s.layoutFor);
 
   const card = useMemo(() => {
     for (const cards of Object.values(cardsByProject)) {
@@ -32,18 +70,88 @@ export default function TaskWorkspace({ taskId }: { taskId: string }) {
     if (api) void sessionsLoad(api).catch(warnSessionLoadFailure);
   }, [api, sessionsLoad]);
 
+  useEffect(() => {
+    // LRU eviction releases attach buffers for tasks pushed out of the cap.
+    const { evicted } = openTask(taskId);
+    const manager = getAttachManager();
+    const aliases = useSessions.getState().aliasMap;
+    for (const evictedTaskId of evicted) {
+      const evictedCard = Object.values(useBoard.getState().cardsByProject)
+        .flat()
+        .find((c) => c.id === evictedTaskId);
+      const attachName = evictedCard?.linkedSessionId
+        ? aliases[evictedCard.linkedSessionId]
+        : null;
+      if (attachName) manager.releaseSession(attachName);
+    }
+    focusTask(taskId);
+  }, [taskId, openTask, focusTask]);
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (!(e.metaKey || e.ctrlKey) || e.shiftKey || e.altKey) return;
+      const index = Number.parseInt(e.key, 10);
+      if (Number.isInteger(index) && index >= 1 && index <= PANEL_SHORTCUT_ORDER.length) {
+        e.preventDefault();
+        togglePanel(taskId, PANEL_SHORTCUT_ORDER[index - 1]!);
+      }
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [taskId, togglePanel]);
+
   const attachName = card?.linkedSessionId ? (aliasMap[card.linkedSessionId] ?? null) : null;
+  const layout = layouts[taskId] ?? layoutFor(taskId);
+
+  const renderPanel = (panel: PanelKind): React.ReactNode => {
+    switch (panel) {
+      case "terminal":
+        return attachName ? (
+          <TerminalView sessionName={attachName} />
+        ) : (
+          <EmptyState
+            icon={<SquareTerminal size={22} />}
+            headline="No live session"
+            description={
+              card?.linkedSessionId
+                ? "This task's session has ended on your computer."
+                : "This task has no linked terminal session yet."
+            }
+            action={
+              <Button
+                variant="primary"
+                onClick={() => {
+                  if (api) void sessionsLoad(api).catch(warnSessionLoadFailure);
+                }}
+              >
+                Refresh sessions
+              </Button>
+            }
+          />
+        );
+      case "editor":
+        return <EditorPanel taskId={taskId} />;
+      case "git":
+        return activeSlug ? <GitPanel projectSlug={activeSlug} /> : null;
+      case "browser":
+        return <FilesPanel taskId={taskId} />;
+      case "artifacts":
+        return activeSlug ? <ArtifactsPanel projectSlug={activeSlug} taskId={taskId} /> : null;
+      case "processes":
+        return <ProcessesPanel />;
+    }
+  };
 
   return (
     <div className="flex min-h-0 flex-1 flex-col">
       <div
-        className="flex shrink-0 items-center gap-2 border-b px-3 py-2"
+        className="flex shrink-0 items-center gap-2 border-b px-3 py-1.5"
         style={{ borderColor: "var(--border-subtle)", background: "var(--bg-surface)" }}
       >
         <IconButton label="Back to board" onClick={() => navigate({ kind: "board" })}>
           <ArrowLeft size={15} />
         </IconButton>
-        <span className="truncate text-sm font-semibold" style={{ color: "var(--text-primary)" }}>
+        <span className="min-w-0 flex-1 truncate text-sm font-semibold" style={{ color: "var(--text-primary)" }}>
           {card?.title ?? "Task"}
         </span>
         {attachName ? (
@@ -54,33 +162,20 @@ export default function TaskWorkspace({ taskId }: { taskId: string }) {
             {attachName}
           </span>
         ) : null}
+        <div className="flex items-center gap-0.5">
+          {PANEL_SHORTCUT_ORDER.map((panel, i) => (
+            <IconButton
+              key={panel}
+              label={`${PANEL_TITLES[panel]} (⌘${i + 1})`}
+              active={Boolean(layout.visible[panel])}
+              onClick={() => togglePanel(taskId, panel)}
+            >
+              {PANEL_ICONS[panel]}
+            </IconButton>
+          ))}
+        </div>
       </div>
-
-      {attachName ? (
-        <TerminalView sessionName={attachName} />
-      ) : (
-        <EmptyState
-          icon={<SquareTerminal size={28} />}
-          headline="No live session"
-          description={
-            card?.linkedSessionId
-              ? "This task's session has ended on your computer."
-              : "This task has no linked terminal session yet."
-          }
-          action={
-            activeSlug ? (
-              <Button
-                variant="primary"
-                onClick={() => {
-                  if (api) void sessionsLoad(api).catch(warnSessionLoadFailure);
-                }}
-              >
-                Refresh sessions
-              </Button>
-            ) : null
-          }
-        />
-      )}
+      <PanelStrip taskId={taskId} renderPanel={renderPanel} />
     </div>
   );
 }

--- a/desktop/src/renderer/src/lib/api.ts
+++ b/desktop/src/renderer/src/lib/api.ts
@@ -22,6 +22,7 @@ export interface ApiClientOptions {
 
 export interface ApiClient {
   get<T>(path: string): Promise<T>;
+  getText(path: string): Promise<string>;
   post<T>(path: string, body: unknown): Promise<T>;
   patch<T>(path: string, body: unknown): Promise<T>;
   delete<T>(path: string): Promise<T>;
@@ -32,7 +33,7 @@ export interface ApiClient {
 export function createApiClient(options: ApiClientOptions): ApiClient {
   const fetchFn: FetchFn = options.fetchFn ?? ((input, init) => fetch(input, init));
 
-  async function request<T>(path: string, init: RequestInit): Promise<T> {
+  async function send(path: string, init: RequestInit): Promise<Response> {
     const url = buildGatewayUrl(options.baseUrl, path, options.getRuntimeSlot());
     let response: Response;
     try {
@@ -46,8 +47,22 @@ export function createApiClient(options: ApiClientOptions): ApiClient {
     if (!response.ok) {
       throw new AppError(classifyHttpStatus(response.status));
     }
+    return response;
+  }
+
+  async function request<T>(path: string, init: RequestInit): Promise<T> {
+    const response = await send(path, init);
     try {
       return (await response.json()) as T;
+    } catch (err: unknown) {
+      throw new AppError("server", { cause: err });
+    }
+  }
+
+  async function requestText(path: string, init: RequestInit): Promise<string> {
+    const response = await send(path, init);
+    try {
+      return await response.text();
     } catch (err: unknown) {
       throw new AppError("server", { cause: err });
     }
@@ -56,6 +71,7 @@ export function createApiClient(options: ApiClientOptions): ApiClient {
   return {
     baseUrl: options.baseUrl,
     get: (path) => request(path, { method: "GET" }),
+    getText: (path) => requestText(path, { method: "GET" }),
     post: (path, body) =>
       request(path, {
         method: "POST",

--- a/desktop/src/renderer/src/lib/quick-open.ts
+++ b/desktop/src/renderer/src/lib/quick-open.ts
@@ -1,0 +1,78 @@
+// Fuzzy file ranking for quick-open (FR-042, US6). Paths are only ever echoed
+// from server responses — this module ranks, it never composes filesystem
+// paths.
+
+const SEGMENT_BOUNDARIES = new Set(["/", "-", "_", ".", " "]);
+
+export interface FileHit {
+  path: string;
+  name: string;
+}
+
+function basenameOf(path: string): string {
+  const idx = path.lastIndexOf("/");
+  return idx === -1 ? path : path.slice(idx + 1);
+}
+
+const BASENAME_BONUS = 10;
+
+// Greedy subsequence walk over `text` with position-aware bonuses: consecutive
+// runs, segment starts, exact-case matches, and a word-completion bonus when
+// the match ends at a segment boundary. Returns 0 if `query` is not a
+// subsequence of `text`.
+function walk(query: string, text: string): number {
+  const q = query.toLowerCase();
+  const t = text.toLowerCase();
+  let qi = 0;
+  let score = 0;
+  let prevMatch = -2;
+  let lastMatch = -1;
+
+  for (let ti = 0; ti < text.length && qi < q.length; ti += 1) {
+    if (t[ti] !== q[qi]) continue;
+    let charScore = 1;
+    if (ti === prevMatch + 1) charScore += 3;
+    if (ti === 0 || SEGMENT_BOUNDARIES.has(text[ti - 1] ?? "")) charScore += 4;
+    if (text[ti] === query[qi]) charScore += 1;
+    score += charScore;
+    prevMatch = ti;
+    lastMatch = ti;
+    qi += 1;
+  }
+
+  if (qi < q.length) return 0;
+  const after = lastMatch + 1;
+  if (after >= text.length || SEGMENT_BOUNDARIES.has(text[after] ?? "")) score += 3;
+  return score;
+}
+
+// A match aligned inside the basename (e.g. "chat" -> "src/lib/chat.ts")
+// should outrank one a greedy full-path walk scatters across directories, so
+// the basename walk gets a strong bonus and we take the better of the two.
+export function fuzzyScore(query: string, candidate: string): number {
+  if (query.length === 0 || candidate.length === 0) return 0;
+  if (query.length > candidate.length) return 0;
+
+  const fullScore = walk(query, candidate);
+  if (fullScore === 0) return 0;
+
+  const basename = basenameOf(candidate);
+  const baseScore = walk(query, basename);
+  return baseScore > 0 ? Math.max(fullScore, baseScore + BASENAME_BONUS) : fullScore;
+}
+
+export function rankFiles(query: string, paths: string[], limit = 50): FileHit[] {
+  if (limit <= 0) return [];
+  const trimmed = query.trim();
+  if (trimmed.length === 0) {
+    return paths.slice(0, limit).map((path) => ({ path, name: basenameOf(path) }));
+  }
+
+  const scored: Array<{ path: string; name: string; score: number }> = [];
+  for (const path of paths) {
+    const score = fuzzyScore(trimmed, path);
+    if (score > 0) scored.push({ path, name: basenameOf(path), score });
+  }
+  scored.sort((a, b) => (b.score !== a.score ? b.score - a.score : a.path < b.path ? -1 : a.path > b.path ? 1 : 0));
+  return scored.slice(0, limit).map(({ path, name }) => ({ path, name }));
+}

--- a/desktop/src/renderer/src/stores/git.ts
+++ b/desktop/src/renderer/src/stores/git.ts
@@ -91,6 +91,8 @@ function parseRows<T>(schema: z.ZodType<T>, rows: unknown): T[] {
   return out;
 }
 
+let loadAllRequestSeq = 0;
+
 interface GitState {
   branches: Branch[];
   prs: PullRequest[];
@@ -116,6 +118,7 @@ export const useGit = create<GitState>()((set, get) => ({
   error: null,
 
   loadAll: async (api, slug) => {
+    const requestSeq = ++loadAllRequestSeq;
     set({ branches: [], prs: [], worktrees: [], refreshedAt: null, loading: true, error: null });
     const failures: AppErrorCategory[] = [];
     const patch: Partial<GitState> = {};
@@ -155,11 +158,16 @@ export const useGit = create<GitState>()((set, get) => ({
       })(),
     ]);
 
-    set({
-      ...patch,
-      refreshedAt: prRefreshed ?? branchRefreshed ?? get().refreshedAt,
-      loading: false,
-      error: failures.length > 0 ? worstCategory(failures) : null,
+    set((state) => {
+      if (requestSeq !== loadAllRequestSeq) {
+        return {};
+      }
+      return {
+        ...patch,
+        refreshedAt: prRefreshed ?? branchRefreshed ?? state.refreshedAt,
+        loading: false,
+        error: failures.length > 0 ? worstCategory(failures) : null,
+      };
     });
   },
 

--- a/desktop/src/renderer/src/stores/git.ts
+++ b/desktop/src/renderer/src/stores/git.ts
@@ -116,7 +116,7 @@ export const useGit = create<GitState>()((set, get) => ({
   error: null,
 
   loadAll: async (api, slug) => {
-    set({ loading: true });
+    set({ branches: [], prs: [], worktrees: [], refreshedAt: null, loading: true, error: null });
     const failures: AppErrorCategory[] = [];
     const patch: Partial<GitState> = {};
     let branchRefreshed: string | undefined;

--- a/desktop/src/renderer/src/stores/git.ts
+++ b/desktop/src/renderer/src/stores/git.ts
@@ -102,6 +102,7 @@ interface GitState {
   refreshedAt: string | null;
   loading: boolean;
   error: AppErrorCategory | null;
+  previewError: AppErrorCategory | null;
   loadAll(api: ApiClient, slug: string): Promise<void>;
   loadPreviews(api: ApiClient, slug: string, taskId?: string): Promise<void>;
   createWorktree(api: ApiClient, slug: string, input: { branch: string } | { pr: number }): Promise<Worktree | null>;
@@ -116,6 +117,7 @@ export const useGit = create<GitState>()((set, get) => ({
   refreshedAt: null,
   loading: false,
   error: null,
+  previewError: null,
 
   loadAll: async (api, slug) => {
     const requestSeq = ++loadAllRequestSeq;
@@ -174,7 +176,7 @@ export const useGit = create<GitState>()((set, get) => ({
   loadPreviews: async (api, slug, taskId) => {
     const scope: PreviewScope = { projectSlug: slug, taskId: taskId ?? null };
     const query = taskId ? `?limit=100&taskId=${encodeURIComponent(taskId)}` : "?limit=100";
-    set({ previews: [], previewScope: scope });
+    set({ previews: [], previewScope: scope, previewError: null });
     try {
       const res = await api.get<{ previews?: unknown }>(`/api/projects/${slug}/previews${query}`);
       set((state) => {
@@ -184,7 +186,7 @@ export const useGit = create<GitState>()((set, get) => ({
         ) {
           return {};
         }
-        return { previews: parseRows(PreviewSchema, res.previews), error: null };
+        return { previews: parseRows(PreviewSchema, res.previews), previewError: null };
       });
     } catch (err: unknown) {
       set((state) => {
@@ -194,7 +196,7 @@ export const useGit = create<GitState>()((set, get) => ({
         ) {
           return {};
         }
-        return { error: categoryOf(err) };
+        return { previewError: categoryOf(err) };
       });
     }
   },

--- a/desktop/src/renderer/src/stores/git.ts
+++ b/desktop/src/renderer/src/stores/git.ts
@@ -1,0 +1,190 @@
+// Git review surfaces (US4/FR-050..054). Read paths exist in the gateway today;
+// diff bodies are a gateway delta (see contracts/gateway-contract.md). Wire
+// item shapes mirror project-manager.ts (BranchSummary/PullRequestSummary),
+// worktree-manager.ts (WorktreeRecord), preview-manager.ts (PreviewRecord).
+import { create } from "zustand";
+import { z } from "zod/v4";
+import { AppError, type AppErrorCategory } from "../../../shared/app-error";
+import type { ApiClient } from "../lib/api";
+
+const BranchSchema = z.object({
+  name: z.string().min(1),
+  current: z.boolean().optional(),
+  default: z.boolean().optional(),
+});
+
+const PrSchema = z.object({
+  number: z.number(),
+  title: z.string().optional(),
+  author: z.string().optional(),
+  headRef: z.string().optional(),
+  baseRef: z.string().optional(),
+  state: z.string().optional(),
+});
+
+const WorktreePrSchema = z.object({
+  number: z.number(),
+  title: z.string().optional(),
+  headRef: z.string().optional(),
+  baseRef: z.string().optional(),
+});
+
+const WorktreeSchema = z.object({
+  id: z.string().min(1),
+  projectSlug: z.string().optional(),
+  path: z.string().optional(),
+  sourceBranch: z.string().optional(),
+  currentBranch: z.string().optional(),
+  dirtyState: z.string().optional(),
+  createdAt: z.string().optional(),
+  pr: WorktreePrSchema.optional(),
+});
+
+const PreviewSchema = z.object({
+  id: z.string().min(1),
+  projectSlug: z.string().optional(),
+  taskId: z.string().nullable().optional(),
+  label: z.string().optional(),
+  url: z.string().optional(),
+  lastStatus: z.string().optional(),
+  displayPreference: z.string().optional(),
+  createdAt: z.string().optional(),
+  updatedAt: z.string().optional(),
+});
+
+export type Branch = z.infer<typeof BranchSchema>;
+export type PullRequest = z.infer<typeof PrSchema>;
+export type Worktree = z.infer<typeof WorktreeSchema>;
+export type Preview = z.infer<typeof PreviewSchema>;
+
+// Higher = worse; loadAll surfaces the worst category across failing surfaces.
+const SEVERITY: Record<AppErrorCategory, number> = {
+  unauthorized: 6,
+  server: 5,
+  misconfigured: 4,
+  offline: 3,
+  timeout: 2,
+  fatalSession: 1,
+  notFound: 0,
+};
+
+function categoryOf(err: unknown): AppErrorCategory {
+  return err instanceof AppError ? err.category : "server";
+}
+
+function worstCategory(categories: AppErrorCategory[]): AppErrorCategory {
+  return categories.reduce((worst, next) => (SEVERITY[next] > SEVERITY[worst] ? next : worst));
+}
+
+function parseRows<T>(schema: z.ZodType<T>, rows: unknown): T[] {
+  if (!Array.isArray(rows)) return [];
+  const out: T[] = [];
+  for (const row of rows) {
+    const result = schema.safeParse(row);
+    if (result.success) out.push(result.data);
+    else console.warn("[git] skipping malformed row");
+  }
+  return out;
+}
+
+interface GitState {
+  branches: Branch[];
+  prs: PullRequest[];
+  worktrees: Worktree[];
+  previews: Preview[];
+  refreshedAt: string | null;
+  loading: boolean;
+  error: AppErrorCategory | null;
+  loadAll(api: ApiClient, slug: string): Promise<void>;
+  loadPreviews(api: ApiClient, slug: string, taskId?: string): Promise<void>;
+  createWorktree(api: ApiClient, slug: string, input: { branch: string } | { pr: number }): Promise<Worktree | null>;
+}
+
+export const useGit = create<GitState>()((set, get) => ({
+  branches: [],
+  prs: [],
+  worktrees: [],
+  previews: [],
+  refreshedAt: null,
+  loading: false,
+  error: null,
+
+  loadAll: async (api, slug) => {
+    set({ loading: true });
+    const failures: AppErrorCategory[] = [];
+    const patch: Partial<GitState> = {};
+    let branchRefreshed: string | undefined;
+    let prRefreshed: string | undefined;
+
+    await Promise.all([
+      (async () => {
+        try {
+          const res = await api.get<{ branches?: unknown; refreshedAt?: unknown }>(
+            `/api/projects/${slug}/branches`,
+          );
+          patch.branches = parseRows(BranchSchema, res.branches);
+          if (typeof res.refreshedAt === "string") branchRefreshed = res.refreshedAt;
+        } catch (err: unknown) {
+          failures.push(categoryOf(err));
+        }
+      })(),
+      (async () => {
+        try {
+          const res = await api.get<{ prs?: unknown; refreshedAt?: unknown }>(
+            `/api/projects/${slug}/prs`,
+          );
+          patch.prs = parseRows(PrSchema, res.prs);
+          if (typeof res.refreshedAt === "string") prRefreshed = res.refreshedAt;
+        } catch (err: unknown) {
+          failures.push(categoryOf(err));
+        }
+      })(),
+      (async () => {
+        try {
+          const res = await api.get<{ worktrees?: unknown }>(`/api/projects/${slug}/worktrees`);
+          patch.worktrees = parseRows(WorktreeSchema, res.worktrees);
+        } catch (err: unknown) {
+          failures.push(categoryOf(err));
+        }
+      })(),
+    ]);
+
+    set({
+      ...patch,
+      refreshedAt: prRefreshed ?? branchRefreshed ?? get().refreshedAt,
+      loading: false,
+      error: failures.length > 0 ? worstCategory(failures) : null,
+    });
+  },
+
+  loadPreviews: async (api, slug, taskId) => {
+    const query = taskId ? `?limit=100&taskId=${encodeURIComponent(taskId)}` : "?limit=100";
+    try {
+      const res = await api.get<{ previews?: unknown }>(`/api/projects/${slug}/previews${query}`);
+      set({ previews: parseRows(PreviewSchema, res.previews), error: null });
+    } catch (err: unknown) {
+      set({ error: categoryOf(err) });
+    }
+  },
+
+  createWorktree: async (api, slug, input) => {
+    try {
+      const res = await api.post<{ worktree?: unknown }>(`/api/projects/${slug}/worktrees`, input);
+      const parsed = WorktreeSchema.safeParse(res.worktree);
+      if (!parsed.success) {
+        console.warn("[git] createWorktree returned a malformed worktree");
+        set({ error: "server" });
+        return null;
+      }
+      const worktree = parsed.data;
+      set((state) => ({
+        worktrees: [...state.worktrees.filter((w) => w.id !== worktree.id), worktree],
+        error: null,
+      }));
+      return worktree;
+    } catch (err: unknown) {
+      set({ error: categoryOf(err) });
+      return null;
+    }
+  },
+}));

--- a/desktop/src/renderer/src/stores/git.ts
+++ b/desktop/src/renderer/src/stores/git.ts
@@ -56,6 +56,10 @@ export type Branch = z.infer<typeof BranchSchema>;
 export type PullRequest = z.infer<typeof PrSchema>;
 export type Worktree = z.infer<typeof WorktreeSchema>;
 export type Preview = z.infer<typeof PreviewSchema>;
+interface PreviewScope {
+  projectSlug: string;
+  taskId: string | null;
+}
 
 // Higher = worse; loadAll surfaces the worst category across failing surfaces.
 const SEVERITY: Record<AppErrorCategory, number> = {
@@ -92,6 +96,7 @@ interface GitState {
   prs: PullRequest[];
   worktrees: Worktree[];
   previews: Preview[];
+  previewScope: PreviewScope | null;
   refreshedAt: string | null;
   loading: boolean;
   error: AppErrorCategory | null;
@@ -105,6 +110,7 @@ export const useGit = create<GitState>()((set, get) => ({
   prs: [],
   worktrees: [],
   previews: [],
+  previewScope: null,
   refreshedAt: null,
   loading: false,
   error: null,
@@ -158,12 +164,30 @@ export const useGit = create<GitState>()((set, get) => ({
   },
 
   loadPreviews: async (api, slug, taskId) => {
+    const scope: PreviewScope = { projectSlug: slug, taskId: taskId ?? null };
     const query = taskId ? `?limit=100&taskId=${encodeURIComponent(taskId)}` : "?limit=100";
+    set({ previews: [], previewScope: scope });
     try {
       const res = await api.get<{ previews?: unknown }>(`/api/projects/${slug}/previews${query}`);
-      set({ previews: parseRows(PreviewSchema, res.previews), error: null });
+      set((state) => {
+        if (
+          state.previewScope?.projectSlug !== scope.projectSlug ||
+          state.previewScope.taskId !== scope.taskId
+        ) {
+          return {};
+        }
+        return { previews: parseRows(PreviewSchema, res.previews), error: null };
+      });
     } catch (err: unknown) {
-      set({ error: categoryOf(err) });
+      set((state) => {
+        if (
+          state.previewScope?.projectSlug !== scope.projectSlug ||
+          state.previewScope.taskId !== scope.taskId
+        ) {
+          return {};
+        }
+        return { error: categoryOf(err) };
+      });
     }
   },
 

--- a/desktop/src/renderer/src/stores/ui.ts
+++ b/desktop/src/renderer/src/stores/ui.ts
@@ -14,10 +14,12 @@ interface UiState {
   createTaskOpen: boolean;
   composerOpen: boolean;
   paletteOpen: boolean;
+  quickOpenOpen: boolean;
   navigate: (view: MainView) => void;
   setCreateTaskOpen: (open: boolean) => void;
   setComposerOpen: (open: boolean) => void;
   setPaletteOpen: (open: boolean) => void;
+  setQuickOpenOpen: (open: boolean) => void;
 }
 
 export const useUi = create<UiState>()((set) => ({
@@ -25,8 +27,10 @@ export const useUi = create<UiState>()((set) => ({
   createTaskOpen: false,
   composerOpen: false,
   paletteOpen: false,
+  quickOpenOpen: false,
   navigate: (view) => set({ view }),
   setCreateTaskOpen: (open) => set({ createTaskOpen: open }),
   setComposerOpen: (open) => set({ composerOpen: open }),
   setPaletteOpen: (open) => set({ paletteOpen: open }),
+  setQuickOpenOpen: (open) => set({ quickOpenOpen: open }),
 }));

--- a/desktop/src/renderer/src/stores/workspace.ts
+++ b/desktop/src/renderer/src/stores/workspace.ts
@@ -1,0 +1,200 @@
+// Open task workspaces + per-task panel layouts (US3, FR-040/FR-045).
+// Entries are ordered most-recently-focused first; beyond WORKSPACE_LRU_CAP
+// the least-recently-focused entries drop their live resources (sockets,
+// heavy views) but stay in the list so they restore on focus. Layout
+// persistence is injected via configure() so this store never touches IPC —
+// the UI wires it to window.operator state:get/state:set.
+import { create } from "zustand";
+
+export type PanelKind = "terminal" | "editor" | "git" | "browser" | "artifacts" | "processes";
+
+export const PANEL_KINDS: readonly PanelKind[] = [
+  "terminal",
+  "editor",
+  "git",
+  "browser",
+  "artifacts",
+  "processes",
+];
+
+export const PANEL_MIN_PCT: Record<PanelKind, number> = {
+  terminal: 20,
+  editor: 25,
+  git: 15,
+  browser: 15,
+  artifacts: 15,
+  processes: 15,
+};
+
+export interface PanelLayout {
+  order: PanelKind[];
+  visible: Record<PanelKind, boolean>;
+  sizes: Record<PanelKind, number>;
+  touchedAt: number;
+}
+
+function equalSplitSizes(visible: Record<PanelKind, boolean>): Record<PanelKind, number> {
+  const shown = PANEL_KINDS.filter((kind) => visible[kind]);
+  const share = shown.length > 0 ? 100 / shown.length : 0;
+  const sizes = {} as Record<PanelKind, number>;
+  for (const kind of PANEL_KINDS) {
+    sizes[kind] = visible[kind] ? share : 0;
+  }
+  return sizes;
+}
+
+export function defaultLayout(now: number = Date.now()): PanelLayout {
+  const visible = {} as Record<PanelKind, boolean>;
+  for (const kind of PANEL_KINDS) {
+    visible[kind] = kind === "terminal";
+  }
+  return {
+    order: [...PANEL_KINDS],
+    visible,
+    sizes: equalSplitSizes(visible),
+    touchedAt: now,
+  };
+}
+
+export interface WorkspaceEntry {
+  taskId: string;
+  lastFocusedAt: number;
+  live: boolean;
+}
+
+export const WORKSPACE_LRU_CAP = 8;
+
+interface WorkspacePersistence {
+  loadLayouts(): Promise<Record<string, PanelLayout> | null>;
+  saveLayout(taskKey: string, layout: PanelLayout): Promise<void>;
+}
+
+let persistence: WorkspacePersistence | null = null;
+
+function persistLayout(taskId: string, layout: PanelLayout): void {
+  if (!persistence) return;
+  persistence.saveLayout(taskId, layout).catch((err: unknown) => {
+    console.warn("[workspace] Failed to persist panel layout:", err);
+  });
+}
+
+interface WorkspaceState {
+  entries: WorkspaceEntry[];
+  layouts: Record<string, PanelLayout>;
+  hydrated: boolean;
+  configure(p: WorkspacePersistence): void;
+  hydrate(): Promise<void>;
+  openTask(taskId: string, now?: number): { evicted: string[] };
+  focusTask(taskId: string, now?: number): void;
+  closeTask(taskId: string): void;
+  togglePanel(taskId: string, panel: PanelKind, now?: number): void;
+  setPanelSizes(taskId: string, sizes: Record<PanelKind, number>, now?: number): void;
+  movePanel(taskId: string, panel: PanelKind, direction: "left" | "right", now?: number): void;
+  layoutFor(taskId: string): PanelLayout;
+}
+
+export const useWorkspace = create<WorkspaceState>()((set, get) => {
+  function writeLayout(taskId: string, layout: PanelLayout): void {
+    set((state) => ({ layouts: { ...state.layouts, [taskId]: layout } }));
+    persistLayout(taskId, layout);
+  }
+
+  return {
+    entries: [],
+    layouts: {},
+    hydrated: false,
+
+    configure: (p) => {
+      persistence = p;
+    },
+
+    hydrate: async () => {
+      if (get().hydrated) return;
+      if (!persistence) {
+        set({ hydrated: true });
+        return;
+      }
+      try {
+        const loaded = await persistence.loadLayouts();
+        // In-memory layouts win: they were touched during this session.
+        set((state) => ({
+          hydrated: true,
+          layouts: loaded ? { ...loaded, ...state.layouts } : state.layouts,
+        }));
+      } catch (err: unknown) {
+        console.warn("[workspace] Failed to load persisted layouts:", err);
+        set({ hydrated: true });
+      }
+    },
+
+    openTask: (taskId, now = Date.now()) => {
+      const rest = get().entries.filter((entry) => entry.taskId !== taskId);
+      const reordered: WorkspaceEntry[] = [{ taskId, lastFocusedAt: now, live: true }, ...rest];
+      const evicted: string[] = [];
+      const entries = reordered.map((entry, index) => {
+        if (index < WORKSPACE_LRU_CAP || !entry.live) return entry;
+        evicted.push(entry.taskId);
+        return { ...entry, live: false };
+      });
+      set({ entries });
+      return { evicted };
+    },
+
+    focusTask: (taskId, now = Date.now()) => {
+      const prior = get().entries;
+      const existing = prior.find((entry) => entry.taskId === taskId);
+      if (!existing) return;
+      set({
+        entries: [
+          { ...existing, lastFocusedAt: now, live: true },
+          ...prior.filter((entry) => entry.taskId !== taskId),
+        ],
+      });
+    },
+
+    closeTask: (taskId) => {
+      // Layout intentionally survives close: it persists per task (FR-040).
+      set((state) => ({ entries: state.entries.filter((entry) => entry.taskId !== taskId) }));
+    },
+
+    togglePanel: (taskId, panel, now = Date.now()) => {
+      const layout = get().layouts[taskId] ?? defaultLayout(now);
+      const visible = { ...layout.visible, [panel]: !layout.visible[panel] };
+      // A newly shown panel with no size triggers an equal re-split; a panel
+      // that kept a size from a previous show restores it untouched.
+      const sizes =
+        visible[panel] && (layout.sizes[panel] ?? 0) <= 0
+          ? equalSplitSizes(visible)
+          : { ...layout.sizes };
+      writeLayout(taskId, { ...layout, visible, sizes, touchedAt: now });
+    },
+
+    setPanelSizes: (taskId, sizes, now = Date.now()) => {
+      const layout = get().layouts[taskId] ?? defaultLayout(now);
+      const next = { ...layout.sizes };
+      for (const kind of PANEL_KINDS) {
+        const value = sizes[kind];
+        if (typeof value !== "number" || !Number.isFinite(value)) continue;
+        next[kind] = layout.visible[kind]
+          ? Math.max(value, PANEL_MIN_PCT[kind])
+          : Math.max(value, 0);
+      }
+      writeLayout(taskId, { ...layout, sizes: next, touchedAt: now });
+    },
+
+    movePanel: (taskId, panel, direction, now = Date.now()) => {
+      const layout = get().layouts[taskId] ?? defaultLayout(now);
+      const index = layout.order.indexOf(panel);
+      if (index === -1) return;
+      const target = direction === "left" ? index - 1 : index + 1;
+      if (target < 0 || target >= layout.order.length) return;
+      const order = [...layout.order];
+      const swapped = order[target]!;
+      order[target] = order[index]!;
+      order[index] = swapped;
+      writeLayout(taskId, { ...layout, order, touchedAt: now });
+    },
+
+    layoutFor: (taskId) => get().layouts[taskId] ?? defaultLayout(),
+  };
+});

--- a/desktop/src/renderer/src/stores/workspace.ts
+++ b/desktop/src/renderer/src/stores/workspace.ts
@@ -43,6 +43,49 @@ function equalSplitSizes(visible: Record<PanelKind, boolean>): Record<PanelKind,
   return sizes;
 }
 
+function normalizeVisibleSizes(
+  visible: Record<PanelKind, boolean>,
+  sizes: Record<PanelKind, number>,
+): Record<PanelKind, number> {
+  const shown = PANEL_KINDS.filter((kind) => visible[kind]);
+  const next = { ...sizes };
+  if (shown.length === 0) return next;
+  const total = shown.reduce((sum, kind) => sum + Math.max(next[kind] ?? 0, 0), 0);
+  if (total <= 0) return equalSplitSizes(visible);
+  for (const kind of shown) {
+    next[kind] = (Math.max(next[kind] ?? 0, 0) / total) * 100;
+  }
+  return next;
+}
+
+function restorePanelSize(
+  visible: Record<PanelKind, boolean>,
+  sizes: Record<PanelKind, number>,
+  panel: PanelKind,
+): Record<PanelKind, number> {
+  const restored = Math.max(sizes[panel] ?? 0, 0);
+  if (restored <= 0) return equalSplitSizes(visible);
+  const next = { ...sizes };
+  const others = PANEL_KINDS.filter((kind) => kind !== panel && visible[kind]);
+  if (others.length === 0) {
+    next[panel] = 100;
+    return next;
+  }
+  const panelSize = Math.min(restored, 95);
+  const otherBudget = 100 - panelSize;
+  const otherTotal = others.reduce((sum, kind) => sum + Math.max(next[kind] ?? 0, 0), 0);
+  next[panel] = panelSize;
+  if (otherTotal <= 0) {
+    const share = otherBudget / others.length;
+    for (const kind of others) next[kind] = share;
+  } else {
+    for (const kind of others) {
+      next[kind] = (Math.max(next[kind] ?? 0, 0) / otherTotal) * otherBudget;
+    }
+  }
+  return next;
+}
+
 export function defaultLayout(now: number = Date.now()): PanelLayout {
   const visible = {} as Record<PanelKind, boolean>;
   for (const kind of PANEL_KINDS) {
@@ -160,12 +203,9 @@ export const useWorkspace = create<WorkspaceState>()((set, get) => {
     togglePanel: (taskId, panel, now = Date.now()) => {
       const layout = get().layouts[taskId] ?? defaultLayout(now);
       const visible = { ...layout.visible, [panel]: !layout.visible[panel] };
-      // A newly shown panel with no size triggers an equal re-split; a panel
-      // that kept a size from a previous show restores it untouched.
-      const sizes =
-        visible[panel] && (layout.sizes[panel] ?? 0) <= 0
-          ? equalSplitSizes(visible)
-          : { ...layout.sizes };
+      const sizes = visible[panel]
+        ? restorePanelSize(visible, layout.sizes, panel)
+        : normalizeVisibleSizes(visible, layout.sizes);
       writeLayout(taskId, { ...layout, visible, sizes, touchedAt: now });
     },
 

--- a/desktop/src/renderer/src/stores/workspace.ts
+++ b/desktop/src/renderer/src/stores/workspace.ts
@@ -114,6 +114,10 @@ interface WorkspacePersistence {
 
 let persistence: WorkspacePersistence | null = null;
 
+interface WriteLayoutOptions {
+  persist?: boolean;
+}
+
 function persistLayout(taskId: string, layout: PanelLayout): void {
   if (!persistence) return;
   persistence.saveLayout(taskId, layout).catch((err: unknown) => {
@@ -131,15 +135,15 @@ interface WorkspaceState {
   focusTask(taskId: string, now?: number): void;
   closeTask(taskId: string): void;
   togglePanel(taskId: string, panel: PanelKind, now?: number): void;
-  setPanelSizes(taskId: string, sizes: Record<PanelKind, number>, now?: number): void;
+  setPanelSizes(taskId: string, sizes: Record<PanelKind, number>, now?: number, options?: WriteLayoutOptions): void;
   movePanel(taskId: string, panel: PanelKind, direction: "left" | "right", now?: number): void;
   layoutFor(taskId: string): PanelLayout;
 }
 
 export const useWorkspace = create<WorkspaceState>()((set, get) => {
-  function writeLayout(taskId: string, layout: PanelLayout): void {
+  function writeLayout(taskId: string, layout: PanelLayout, options: WriteLayoutOptions = {}): void {
     set((state) => ({ layouts: { ...state.layouts, [taskId]: layout } }));
-    persistLayout(taskId, layout);
+    if (options.persist !== false) persistLayout(taskId, layout);
   }
 
   return {
@@ -209,7 +213,7 @@ export const useWorkspace = create<WorkspaceState>()((set, get) => {
       writeLayout(taskId, { ...layout, visible, sizes, touchedAt: now });
     },
 
-    setPanelSizes: (taskId, sizes, now = Date.now()) => {
+    setPanelSizes: (taskId, sizes, now = Date.now(), options) => {
       const layout = get().layouts[taskId] ?? defaultLayout(now);
       const next = { ...layout.sizes };
       for (const kind of PANEL_KINDS) {
@@ -219,7 +223,7 @@ export const useWorkspace = create<WorkspaceState>()((set, get) => {
           ? Math.max(value, PANEL_MIN_PCT[kind])
           : Math.max(value, 0);
       }
-      writeLayout(taskId, { ...layout, sizes: next, touchedAt: now });
+      writeLayout(taskId, { ...layout, sizes: next, touchedAt: now }, options);
     },
 
     movePanel: (taskId, panel, direction, now = Date.now()) => {

--- a/desktop/src/renderer/src/vite-env.d.ts
+++ b/desktop/src/renderer/src/vite-env.d.ts
@@ -1,0 +1,12 @@
+/// <reference types="vite/client" />
+
+declare module "*?worker" {
+  const workerConstructor: new () => Worker;
+  export default workerConstructor;
+}
+
+interface Window {
+  MonacoEnvironment?: {
+    getWorker(workerId: string, label: string): Worker;
+  };
+}

--- a/desktop/src/shared/ipc-contract.ts
+++ b/desktop/src/shared/ipc-contract.ts
@@ -24,6 +24,15 @@ const BoundsSchema = z
   })
   .strict();
 
+const PanelLayoutSchema = z
+  .object({
+    order: z.array(z.string().max(32)).max(12),
+    visible: z.record(z.string().max(32), z.boolean()),
+    sizes: z.record(z.string().max(32), z.number().min(0).max(100)),
+    touchedAt: z.number().int().nonnegative(),
+  })
+  .strict();
+
 const STATE_KEYS = [
   "windowBounds",
   "lastProjectSlug",
@@ -88,6 +97,12 @@ export const INVOKE_CHANNELS = {
   "state:set": {
     request: z
       .object({ key: z.enum(STATE_KEYS), value: BoundedJsonValue })
+      .strict(),
+    response: Ok,
+  },
+  "state:set-panel-layout": {
+    request: z
+      .object({ taskKey: z.string().min(1).max(256), layout: PanelLayoutSchema })
       .strict(),
     response: Ok,
   },

--- a/tests/desktop/artifacts-panel.test.tsx
+++ b/tests/desktop/artifacts-panel.test.tsx
@@ -1,5 +1,15 @@
-import { describe, expect, it } from "vitest";
-import { canOpenPreviewUrl } from "../../desktop/src/renderer/src/features/workspace/ArtifactsPanel";
+// @vitest-environment jsdom
+
+import React from "react";
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import ArtifactsPanel, { canOpenPreviewUrl } from "../../desktop/src/renderer/src/features/workspace/ArtifactsPanel";
+import { useConnection } from "../../desktop/src/renderer/src/stores/connection";
+import { useGit } from "../../desktop/src/renderer/src/stores/git";
+
+afterEach(() => {
+  cleanup();
+});
 
 describe("artifacts preview URLs", () => {
   it("allows only secure HTTP preview links", () => {
@@ -12,5 +22,19 @@ describe("artifacts preview URLs", () => {
     expect(canOpenPreviewUrl("file:///tmp/preview.html")).toBe(false);
     expect(canOpenPreviewUrl("/relative-preview")).toBe(false);
     expect(canOpenPreviewUrl(null)).toBe(false);
+  });
+
+  it("surfaces preview load failures instead of showing an empty artifact list", () => {
+    useConnection.setState({ api: null });
+    useGit.setState({
+      previews: [],
+      previewScope: { projectSlug: "matrix-os", taskId: "task-1" },
+      error: "timeout",
+    });
+
+    render(<ArtifactsPanel projectSlug="matrix-os" taskId="task-1" />);
+
+    expect(screen.getByText("Couldn't load artifacts")).toBeTruthy();
+    expect(screen.queryByText("No artifacts")).toBeNull();
   });
 });

--- a/tests/desktop/artifacts-panel.test.tsx
+++ b/tests/desktop/artifacts-panel.test.tsx
@@ -2,8 +2,8 @@ import { describe, expect, it } from "vitest";
 import { canOpenPreviewUrl } from "../../desktop/src/renderer/src/features/workspace/ArtifactsPanel";
 
 describe("artifacts preview URLs", () => {
-  it("allows local and secure HTTP preview links", () => {
-    expect(canOpenPreviewUrl("http://127.0.0.1:5173")).toBe(true);
+  it("allows only secure HTTP preview links", () => {
+    expect(canOpenPreviewUrl("http://127.0.0.1:5173")).toBe(false);
     expect(canOpenPreviewUrl("https://preview.example.com")).toBe(true);
   });
 

--- a/tests/desktop/artifacts-panel.test.tsx
+++ b/tests/desktop/artifacts-panel.test.tsx
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { canOpenPreviewUrl } from "../../desktop/src/renderer/src/features/workspace/ArtifactsPanel";
+
+describe("artifacts preview URLs", () => {
+  it("allows local and secure HTTP preview links", () => {
+    expect(canOpenPreviewUrl("http://127.0.0.1:5173")).toBe(true);
+    expect(canOpenPreviewUrl("https://preview.example.com")).toBe(true);
+  });
+
+  it("rejects non-web preview links", () => {
+    expect(canOpenPreviewUrl("javascript:alert(1)")).toBe(false);
+    expect(canOpenPreviewUrl("file:///tmp/preview.html")).toBe(false);
+    expect(canOpenPreviewUrl("/relative-preview")).toBe(false);
+    expect(canOpenPreviewUrl(null)).toBe(false);
+  });
+});

--- a/tests/desktop/artifacts-panel.test.tsx
+++ b/tests/desktop/artifacts-panel.test.tsx
@@ -29,12 +29,28 @@ describe("artifacts preview URLs", () => {
     useGit.setState({
       previews: [],
       previewScope: { projectSlug: "matrix-os", taskId: "task-1" },
-      error: "timeout",
+      error: null,
+      previewError: "timeout",
     });
 
     render(<ArtifactsPanel projectSlug="matrix-os" taskId="task-1" />);
 
     expect(screen.getByText("Couldn't load artifacts")).toBeTruthy();
     expect(screen.queryByText("No artifacts")).toBeNull();
+  });
+
+  it("does not show list load failures as artifact failures", () => {
+    useConnection.setState({ api: null });
+    useGit.setState({
+      previews: [],
+      previewScope: { projectSlug: "matrix-os", taskId: "task-1" },
+      error: "timeout",
+      previewError: null,
+    });
+
+    render(<ArtifactsPanel projectSlug="matrix-os" taskId="task-1" />);
+
+    expect(screen.queryByText("Couldn't load artifacts")).toBeNull();
+    expect(screen.getByText("No artifacts")).toBeTruthy();
   });
 });

--- a/tests/desktop/editor-baselines.test.ts
+++ b/tests/desktop/editor-baselines.test.ts
@@ -1,0 +1,39 @@
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  clearFileBaselinesForTest,
+  getFileBaseline,
+  rememberFileBaseline,
+} from "@desktop/renderer/src/features/editor/editor-baselines";
+
+function file(path: string, content: string = path) {
+  return { path, content, loadedMtime: "2026-06-17T00:00:00.000Z" };
+}
+
+afterEach(() => {
+  clearFileBaselinesForTest();
+});
+
+describe("editor file baselines", () => {
+  it("evicts the oldest entries beyond the baseline cap", () => {
+    for (let i = 0; i < 65; i += 1) {
+      rememberFileBaseline(`task\0file-${i}`, file(`file-${i}`));
+    }
+
+    expect(getFileBaseline("task\0file-0")).toBeUndefined();
+    expect(getFileBaseline("task\0file-1")?.path).toBe("file-1");
+    expect(getFileBaseline("task\0file-64")?.path).toBe("file-64");
+  });
+
+  it("refreshes recency when a baseline is read", () => {
+    rememberFileBaseline("task\0keep", file("keep"));
+    for (let i = 0; i < 63; i += 1) {
+      rememberFileBaseline(`task\0file-${i}`, file(`file-${i}`));
+    }
+    expect(getFileBaseline("task\0keep")?.path).toBe("keep");
+
+    rememberFileBaseline("task\0new", file("new"));
+
+    expect(getFileBaseline("task\0file-0")).toBeUndefined();
+    expect(getFileBaseline("task\0keep")?.path).toBe("keep");
+  });
+});

--- a/tests/desktop/editor-save.test.ts
+++ b/tests/desktop/editor-save.test.ts
@@ -196,4 +196,16 @@ describe("saveFileOverwrite", () => {
     expect(stat).not.toHaveBeenCalled();
     expect(newMtime).toBe(MODIFIED_MS + 9_000);
   });
+
+  it("refreshes the baseline when overwrite response omits mtime", async () => {
+    const stat = vi.fn().mockResolvedValue({ mtime: MODIFIED_MS + 9_000 });
+    const files = makeFiles({
+      stat,
+      write: vi.fn().mockResolvedValue({ mtime: null }),
+    });
+    const newMtime = await saveFileOverwrite(files, "projects/notes.md", "forced");
+    expect(files.write).toHaveBeenCalledWith("projects/notes.md", "forced");
+    expect(stat).toHaveBeenCalledWith("projects/notes.md");
+    expect(newMtime).toBe(MODIFIED_MS + 9_000);
+  });
 });

--- a/tests/desktop/editor-save.test.ts
+++ b/tests/desktop/editor-save.test.ts
@@ -1,0 +1,185 @@
+import { describe, expect, it, vi } from "vitest";
+import { AppError } from "@desktop/shared/app-error";
+import type { ApiClient } from "@desktop/renderer/src/lib/api";
+import {
+  createFilesApi,
+  openFile,
+  saveFile,
+  saveFileOverwrite,
+  type FilesApi,
+} from "@desktop/renderer/src/features/editor/editor-save";
+
+const MODIFIED_ISO = "2026-06-13T10:00:00.000Z";
+const MODIFIED_MS = Date.parse(MODIFIED_ISO);
+
+// Mirrors the gateway FileStatResult wire shape (packages/gateway/src/file-ops.ts).
+function wireStat(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    name: "notes.md",
+    path: "projects/notes.md",
+    type: "file",
+    size: 42,
+    modified: MODIFIED_ISO,
+    created: "2026-06-01T00:00:00.000Z",
+    mime: "text/markdown",
+    ...overrides,
+  };
+}
+
+function makeApi(overrides: Partial<ApiClient> = {}): ApiClient {
+  return {
+    baseUrl: "https://x.test",
+    get: vi.fn().mockResolvedValue(wireStat()),
+    getText: vi.fn().mockResolvedValue("file body"),
+    post: vi.fn().mockResolvedValue({}),
+    patch: vi.fn().mockResolvedValue({}),
+    delete: vi.fn().mockResolvedValue({ ok: true }),
+    putText: vi.fn().mockResolvedValue({ ok: true }),
+    ...overrides,
+  } as ApiClient;
+}
+
+function makeFiles(overrides: Partial<FilesApi> = {}): FilesApi {
+  return {
+    stat: vi.fn().mockResolvedValue({ mtime: MODIFIED_MS }),
+    read: vi.fn().mockResolvedValue("file body"),
+    write: vi.fn().mockResolvedValue(undefined),
+    ...overrides,
+  };
+}
+
+describe("createFilesApi", () => {
+  it("stats via /api/files/stat with an encoded query param and normalizes modified to epoch ms", async () => {
+    const api = makeApi();
+    const files = createFilesApi(api);
+    const result = await files.stat("projects/my notes.md");
+    expect(api.get).toHaveBeenCalledWith("/api/files/stat?path=projects%2Fmy%20notes.md");
+    expect(result).toEqual({ mtime: MODIFIED_MS });
+  });
+
+  it("returns a null mtime when the stat response has no parsable modified field", async () => {
+    const api = makeApi({ get: vi.fn().mockResolvedValue(wireStat({ modified: undefined })) });
+    expect((await createFilesApi(api).stat("a.md")).mtime).toBeNull();
+
+    const garbled = makeApi({ get: vi.fn().mockResolvedValue(wireStat({ modified: "not a date" })) });
+    expect((await createFilesApi(garbled).stat("a.md")).mtime).toBeNull();
+  });
+
+  it("accepts a numeric modified field as epoch ms", async () => {
+    const api = makeApi({ get: vi.fn().mockResolvedValue(wireStat({ modified: 12_345 })) });
+    expect((await createFilesApi(api).stat("a.md")).mtime).toBe(12_345);
+  });
+
+  it("treats notFound stats as mtime null (new file) but propagates other errors", async () => {
+    const missing = makeApi({ get: vi.fn().mockRejectedValue(new AppError("notFound")) });
+    expect((await createFilesApi(missing).stat("new.md")).mtime).toBeNull();
+
+    const offline = makeApi({ get: vi.fn().mockRejectedValue(new AppError("offline")) });
+    await expect(createFilesApi(offline).stat("a.md")).rejects.toMatchObject({
+      category: "offline",
+    });
+  });
+
+  it("reads raw text from /files with per-segment path encoding", async () => {
+    const api = makeApi();
+    const files = createFilesApi(api);
+    await expect(files.read("projects/my notes.md")).resolves.toBe("file body");
+    expect(api.getText).toHaveBeenCalledWith("/files/projects/my%20notes.md");
+  });
+
+  it("writes raw text via PUT /files with per-segment path encoding", async () => {
+    const api = makeApi();
+    const files = createFilesApi(api);
+    await files.write("projects/my notes.md", "hello");
+    expect(api.putText).toHaveBeenCalledWith("/files/projects/my%20notes.md", "hello");
+  });
+});
+
+describe("openFile", () => {
+  it("returns content and the server mtime as the loaded baseline", async () => {
+    const files = makeFiles();
+    const opened = await openFile(files, "projects/notes.md");
+    expect(opened).toEqual({
+      path: "projects/notes.md",
+      content: "file body",
+      loadedMtime: MODIFIED_MS,
+    });
+  });
+
+  it("propagates read failures", async () => {
+    const files = makeFiles({ read: vi.fn().mockRejectedValue(new AppError("notFound")) });
+    await expect(openFile(files, "missing.md")).rejects.toMatchObject({ category: "notFound" });
+  });
+});
+
+describe("saveFile", () => {
+  const opened = { path: "projects/notes.md", content: "old", loadedMtime: MODIFIED_MS };
+
+  it("refuses to write when the server mtime differs from the loaded baseline", async () => {
+    const files = makeFiles({ stat: vi.fn().mockResolvedValue({ mtime: MODIFIED_MS + 1_000 }) });
+    const result = await saveFile(files, opened, "new content");
+    expect(result).toEqual({ ok: false, reason: "conflict" });
+    expect(files.write).not.toHaveBeenCalled();
+  });
+
+  it("writes and returns the fresh mtime when the baseline matches", async () => {
+    const stat = vi
+      .fn()
+      .mockResolvedValueOnce({ mtime: MODIFIED_MS })
+      .mockResolvedValueOnce({ mtime: MODIFIED_MS + 5_000 });
+    const files = makeFiles({ stat });
+    const result = await saveFile(files, opened, "new content");
+    expect(files.write).toHaveBeenCalledWith("projects/notes.md", "new content");
+    expect(result).toEqual({ ok: true, newMtime: MODIFIED_MS + 5_000 });
+    expect(stat).toHaveBeenCalledTimes(2);
+  });
+
+  it("treats null mtimes as conflict-free only when both sides are null", async () => {
+    const newFile = { path: "new.md", content: "", loadedMtime: null };
+    const bothNull = makeFiles({
+      stat: vi
+        .fn()
+        .mockResolvedValueOnce({ mtime: null })
+        .mockResolvedValueOnce({ mtime: MODIFIED_MS }),
+    });
+    await expect(saveFile(bothNull, newFile, "hello")).resolves.toEqual({
+      ok: true,
+      newMtime: MODIFIED_MS,
+    });
+
+    const serverHasFile = makeFiles({ stat: vi.fn().mockResolvedValue({ mtime: MODIFIED_MS }) });
+    await expect(saveFile(serverHasFile, newFile, "hello")).resolves.toEqual({
+      ok: false,
+      reason: "conflict",
+    });
+    expect(serverHasFile.write).not.toHaveBeenCalled();
+
+    const serverLostFile = makeFiles({ stat: vi.fn().mockResolvedValue({ mtime: null }) });
+    await expect(saveFile(serverLostFile, opened, "hello")).resolves.toEqual({
+      ok: false,
+      reason: "conflict",
+    });
+    expect(serverLostFile.write).not.toHaveBeenCalled();
+  });
+
+  it("propagates network errors instead of swallowing them", async () => {
+    const files = makeFiles({ stat: vi.fn().mockRejectedValue(new AppError("offline")) });
+    await expect(saveFile(files, opened, "x")).rejects.toMatchObject({ category: "offline" });
+    expect(files.write).not.toHaveBeenCalled();
+
+    const writeFails = makeFiles({ write: vi.fn().mockRejectedValue(new AppError("timeout")) });
+    await expect(saveFile(writeFails, opened, "x")).rejects.toMatchObject({ category: "timeout" });
+  });
+});
+
+describe("saveFileOverwrite", () => {
+  it("writes without a conflict precheck and returns the fresh mtime", async () => {
+    const stat = vi.fn().mockResolvedValue({ mtime: MODIFIED_MS + 9_000 });
+    const files = makeFiles({ stat });
+    const newMtime = await saveFileOverwrite(files, "projects/notes.md", "forced");
+    expect(files.write).toHaveBeenCalledWith("projects/notes.md", "forced");
+    expect(stat).toHaveBeenCalledTimes(1);
+    expect(stat).toHaveBeenCalledAfter(files.write as ReturnType<typeof vi.fn>);
+    expect(newMtime).toBe(MODIFIED_MS + 9_000);
+  });
+});

--- a/tests/desktop/editor-save.test.ts
+++ b/tests/desktop/editor-save.test.ts
@@ -136,14 +136,16 @@ describe("saveFile", () => {
     expect(stat).toHaveBeenCalledTimes(1);
   });
 
-  it("does not stat after writing when the gateway omits write mtime", async () => {
-    const stat = vi.fn().mockResolvedValue({ mtime: MODIFIED_MS });
+  it("refreshes the baseline after writing when the gateway omits write mtime", async () => {
+    const stat = vi.fn()
+      .mockResolvedValueOnce({ mtime: MODIFIED_MS })
+      .mockResolvedValueOnce({ mtime: MODIFIED_MS + 5_000 });
     const files = makeFiles({ stat, write: vi.fn().mockResolvedValue({ mtime: null }) });
     await expect(saveFile(files, opened, "new content")).resolves.toEqual({
       ok: true,
-      newMtime: MODIFIED_MS,
+      newMtime: MODIFIED_MS + 5_000,
     });
-    expect(stat).toHaveBeenCalledTimes(1);
+    expect(stat).toHaveBeenCalledTimes(2);
   });
 
   it("treats null mtimes as conflict-free only when both sides are null", async () => {

--- a/tests/desktop/editor-save.test.ts
+++ b/tests/desktop/editor-save.test.ts
@@ -43,7 +43,7 @@ function makeFiles(overrides: Partial<FilesApi> = {}): FilesApi {
   return {
     stat: vi.fn().mockResolvedValue({ mtime: MODIFIED_MS }),
     read: vi.fn().mockResolvedValue("file body"),
-    write: vi.fn().mockResolvedValue(undefined),
+    write: vi.fn().mockResolvedValue({ mtime: MODIFIED_MS + 5_000 }),
     ...overrides,
   };
 }
@@ -90,8 +90,13 @@ describe("createFilesApi", () => {
   it("writes raw text via PUT /files with per-segment path encoding", async () => {
     const api = makeApi();
     const files = createFilesApi(api);
-    await files.write("projects/my notes.md", "hello");
+    await expect(files.write("projects/my notes.md", "hello")).resolves.toEqual({ mtime: null });
     expect(api.putText).toHaveBeenCalledWith("/files/projects/my%20notes.md", "hello");
+  });
+
+  it("returns the normalized write mtime when PUT includes modified metadata", async () => {
+    const api = makeApi({ putText: vi.fn().mockResolvedValue({ ok: true, modified: MODIFIED_ISO }) });
+    await expect(createFilesApi(api).write("notes.md", "hello")).resolves.toEqual({ mtime: MODIFIED_MS });
   });
 });
 
@@ -122,25 +127,30 @@ describe("saveFile", () => {
     expect(files.write).not.toHaveBeenCalled();
   });
 
-  it("writes and returns the fresh mtime when the baseline matches", async () => {
-    const stat = vi
-      .fn()
-      .mockResolvedValueOnce({ mtime: MODIFIED_MS })
-      .mockResolvedValueOnce({ mtime: MODIFIED_MS + 5_000 });
+  it("writes and returns the write response mtime when the baseline matches", async () => {
+    const stat = vi.fn().mockResolvedValue({ mtime: MODIFIED_MS });
     const files = makeFiles({ stat });
     const result = await saveFile(files, opened, "new content");
     expect(files.write).toHaveBeenCalledWith("projects/notes.md", "new content");
     expect(result).toEqual({ ok: true, newMtime: MODIFIED_MS + 5_000 });
-    expect(stat).toHaveBeenCalledTimes(2);
+    expect(stat).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not stat after writing when the gateway omits write mtime", async () => {
+    const stat = vi.fn().mockResolvedValue({ mtime: MODIFIED_MS });
+    const files = makeFiles({ stat, write: vi.fn().mockResolvedValue({ mtime: null }) });
+    await expect(saveFile(files, opened, "new content")).resolves.toEqual({
+      ok: true,
+      newMtime: MODIFIED_MS,
+    });
+    expect(stat).toHaveBeenCalledTimes(1);
   });
 
   it("treats null mtimes as conflict-free only when both sides are null", async () => {
     const newFile = { path: "new.md", content: "", loadedMtime: null };
     const bothNull = makeFiles({
-      stat: vi
-        .fn()
-        .mockResolvedValueOnce({ mtime: null })
-        .mockResolvedValueOnce({ mtime: MODIFIED_MS }),
+      stat: vi.fn().mockResolvedValue({ mtime: null }),
+      write: vi.fn().mockResolvedValue({ mtime: MODIFIED_MS }),
     });
     await expect(saveFile(bothNull, newFile, "hello")).resolves.toEqual({
       ok: true,
@@ -173,13 +183,15 @@ describe("saveFile", () => {
 });
 
 describe("saveFileOverwrite", () => {
-  it("writes without a conflict precheck and returns the fresh mtime", async () => {
-    const stat = vi.fn().mockResolvedValue({ mtime: MODIFIED_MS + 9_000 });
-    const files = makeFiles({ stat });
+  it("writes without a conflict precheck and returns the write response mtime", async () => {
+    const stat = vi.fn();
+    const files = makeFiles({
+      stat,
+      write: vi.fn().mockResolvedValue({ mtime: MODIFIED_MS + 9_000 }),
+    });
     const newMtime = await saveFileOverwrite(files, "projects/notes.md", "forced");
     expect(files.write).toHaveBeenCalledWith("projects/notes.md", "forced");
-    expect(stat).toHaveBeenCalledTimes(1);
-    expect(stat).toHaveBeenCalledAfter(files.write as ReturnType<typeof vi.fn>);
+    expect(stat).not.toHaveBeenCalled();
     expect(newMtime).toBe(MODIFIED_MS + 9_000);
   });
 });

--- a/tests/desktop/editor-tabs-store.test.ts
+++ b/tests/desktop/editor-tabs-store.test.ts
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, it } from "vitest";
 import { useEditorTabs } from "@desktop/renderer/src/features/editor/editor-tabs-store";
 
 beforeEach(() => {
-  useEditorTabs.setState({ tabsByTask: {}, activePathByTask: {}, dirtyPaths: [] });
+  useEditorTabs.setState({ tabsByTask: {}, activePathByTask: {}, dirtyPathsByTask: {} });
 });
 
 describe("useEditorTabs", () => {
@@ -12,15 +12,16 @@ describe("useEditorTabs", () => {
     store.openTab("task_a", "src/shared.ts");
     store.openTab("task_b", "src/b.ts");
     store.openTab("task_b", "src/shared.ts");
-    store.setDirty("src/a.ts", true);
-    store.setDirty("src/shared.ts", true);
-    store.setDirty("src/b.ts", true);
+    store.setDirty("task_a", "src/a.ts", true);
+    store.setDirty("task_a", "src/shared.ts", true);
+    store.setDirty("task_b", "src/b.ts", true);
+    store.setDirty("task_b", "src/shared.ts", true);
 
     store.closeTask("task_a");
 
     const state = useEditorTabs.getState();
     expect(state.tabsByTask).toEqual({ task_b: ["src/b.ts", "src/shared.ts"] });
     expect(state.activePathByTask).toEqual({ task_b: "src/shared.ts" });
-    expect(state.dirtyPaths).toEqual(["src/shared.ts", "src/b.ts"]);
+    expect(state.dirtyPathsByTask).toEqual({ task_b: ["src/b.ts", "src/shared.ts"] });
   });
 });

--- a/tests/desktop/editor-tabs-store.test.ts
+++ b/tests/desktop/editor-tabs-store.test.ts
@@ -6,6 +6,21 @@ beforeEach(() => {
 });
 
 describe("useEditorTabs", () => {
+  it("drops dirty flags for paths evicted by the tab cap", () => {
+    const store = useEditorTabs.getState();
+    for (let i = 0; i < 16; i += 1) {
+      store.openTab("task_a", `src/${i}.ts`);
+    }
+    store.setDirty("task_a", "src/0.ts", true);
+    store.setDirty("task_a", "src/15.ts", true);
+
+    store.openTab("task_a", "src/16.ts");
+
+    const state = useEditorTabs.getState();
+    expect(state.tabsByTask.task_a).not.toContain("src/0.ts");
+    expect(state.dirtyPathsByTask.task_a).toEqual(["src/15.ts"]);
+  });
+
   it("clears dirty paths owned by a closed task", () => {
     const store = useEditorTabs.getState();
     store.openTab("task_a", "src/a.ts");

--- a/tests/desktop/editor-tabs-store.test.ts
+++ b/tests/desktop/editor-tabs-store.test.ts
@@ -1,0 +1,26 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { useEditorTabs } from "@desktop/renderer/src/features/editor/editor-tabs-store";
+
+beforeEach(() => {
+  useEditorTabs.setState({ tabsByTask: {}, activePathByTask: {}, dirtyPaths: [] });
+});
+
+describe("useEditorTabs", () => {
+  it("clears dirty paths owned by a closed task", () => {
+    const store = useEditorTabs.getState();
+    store.openTab("task_a", "src/a.ts");
+    store.openTab("task_a", "src/shared.ts");
+    store.openTab("task_b", "src/b.ts");
+    store.openTab("task_b", "src/shared.ts");
+    store.setDirty("src/a.ts", true);
+    store.setDirty("src/shared.ts", true);
+    store.setDirty("src/b.ts", true);
+
+    store.closeTask("task_a");
+
+    const state = useEditorTabs.getState();
+    expect(state.tabsByTask).toEqual({ task_b: ["src/b.ts", "src/shared.ts"] });
+    expect(state.activePathByTask).toEqual({ task_b: "src/shared.ts" });
+    expect(state.dirtyPaths).toEqual(["src/shared.ts", "src/b.ts"]);
+  });
+});

--- a/tests/desktop/files-panel.test.tsx
+++ b/tests/desktop/files-panel.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 
 import React from "react";
-import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { act, cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import FilesPanel from "../../desktop/src/renderer/src/features/files/FilesPanel";
 import { useConnection } from "../../desktop/src/renderer/src/stores/connection";
@@ -55,5 +55,30 @@ describe("FilesPanel", () => {
     fireEvent.click(src);
     await screen.findByText("index.ts");
     expect(get).toHaveBeenCalledTimes(3);
+  });
+
+  it("auto-retries root loading when the api reconnects after an initial failure", async () => {
+    const offlineGet = vi.fn().mockRejectedValue(new Error("offline"));
+    useConnection.setState({
+      status: "signed-in",
+      handle: "operator",
+      platformHost: "https://platform.test",
+      runtimeSlot: "primary",
+      api: { get: offlineGet } as never,
+    });
+
+    render(<FilesPanel taskId="task-1" />);
+
+    await waitFor(() => {
+      expect(offlineGet).toHaveBeenCalledWith("/api/files/list?path=");
+    });
+
+    const onlineGet = vi.fn().mockResolvedValue({ entries: [{ name: "README.md", type: "file" }] });
+    await act(async () => {
+      useConnection.setState({ api: { get: onlineGet } as never });
+    });
+
+    await screen.findByText("README.md");
+    expect(onlineGet).toHaveBeenCalledWith("/api/files/list?path=");
   });
 });

--- a/tests/desktop/files-panel.test.tsx
+++ b/tests/desktop/files-panel.test.tsx
@@ -1,0 +1,59 @@
+// @vitest-environment jsdom
+
+import React from "react";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import FilesPanel from "../../desktop/src/renderer/src/features/files/FilesPanel";
+import { useConnection } from "../../desktop/src/renderer/src/stores/connection";
+import { useEditorTabs } from "../../desktop/src/renderer/src/features/editor/editor-tabs-store";
+import { useWorkspace } from "../../desktop/src/renderer/src/stores/workspace";
+
+describe("FilesPanel", () => {
+  beforeEach(() => {
+    useEditorTabs.setState({
+      tabsByTask: {},
+      activePathByTask: {},
+      dirtyPathsByTask: {},
+    });
+    useWorkspace.setState({
+      layouts: {},
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it("keeps a failed directory expandable so a later click can retry loading children", async () => {
+    const get = vi.fn((path: string) => {
+      if (path === "/api/files/list?path=") {
+        return Promise.resolve({ entries: [{ name: "src", type: "directory" }] });
+      }
+      if (path === "/api/files/list?path=src" && get.mock.calls.length === 2) {
+        return Promise.reject(new Error("temporary offline"));
+      }
+      return Promise.resolve({ entries: [{ name: "index.ts", type: "file" }] });
+    });
+    useConnection.setState({
+      status: "signed-in",
+      handle: "operator",
+      platformHost: "https://platform.test",
+      runtimeSlot: "primary",
+      api: { get } as never,
+    });
+
+    render(<FilesPanel taskId="task-1" />);
+
+    const src = await screen.findByRole("button", { name: /src/i });
+    fireEvent.click(src);
+    await waitFor(() => {
+      expect(get).toHaveBeenCalledWith("/api/files/list?path=src");
+    });
+    expect(screen.queryByText("index.ts")).toBeNull();
+
+    fireEvent.click(src);
+    await screen.findByText("index.ts");
+    expect(get).toHaveBeenCalledTimes(3);
+  });
+});

--- a/tests/desktop/git-panel.test.tsx
+++ b/tests/desktop/git-panel.test.tsx
@@ -1,0 +1,35 @@
+// @vitest-environment jsdom
+
+import React from "react";
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import GitPanel from "../../desktop/src/renderer/src/features/git/GitPanel";
+import { useConnection } from "../../desktop/src/renderer/src/stores/connection";
+import { useGit } from "../../desktop/src/renderer/src/stores/git";
+
+describe("GitPanel", () => {
+  beforeEach(() => {
+    useConnection.setState({ api: null });
+    useGit.setState({
+      branches: [],
+      prs: [],
+      worktrees: [],
+      previews: [],
+      previewScope: null,
+      refreshedAt: null,
+      loading: false,
+      error: "offline",
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it("surfaces git load failures instead of rendering only empty counts", () => {
+    render(<GitPanel projectSlug="matrix-os" />);
+
+    expect(screen.getByRole("status").textContent).toMatch(/connection/i);
+  });
+});

--- a/tests/desktop/git-store.test.ts
+++ b/tests/desktop/git-store.test.ts
@@ -213,6 +213,7 @@ describe("loadPreviews", () => {
     await useGit.getState().loadPreviews(api, "proj");
 
     expect(get).toHaveBeenCalledWith("/api/projects/proj/previews?limit=100");
+    expect(useGit.getState().previewScope).toEqual({ projectSlug: "proj", taskId: null });
     expect(useGit.getState().previews).toEqual([
       {
         id: "prev_1",
@@ -238,7 +239,7 @@ describe("loadPreviews", () => {
     expect(get).toHaveBeenCalledWith("/api/projects/proj/previews?limit=100&taskId=task_a");
   });
 
-  it("keeps existing previews and sets the error category on failure", async () => {
+  it("clears stale previews and sets the error category on failure", async () => {
     const existing = {
       id: "prev_keep",
       projectSlug: "proj",
@@ -253,8 +254,28 @@ describe("loadPreviews", () => {
 
     await useGit.getState().loadPreviews(api, "proj");
 
-    expect(useGit.getState().previews).toEqual([existing]);
+    expect(useGit.getState().previews).toEqual([]);
     expect(useGit.getState().error).toBe("timeout");
+  });
+
+  it("ignores stale preview responses from a previous task scope", async () => {
+    const first = deferred<{ previews: unknown[] }>();
+    const second = deferred<{ previews: unknown[] }>();
+    const get = vi
+      .fn()
+      .mockReturnValueOnce(first.promise)
+      .mockReturnValueOnce(second.promise);
+    const api = makeApi({ get: get as never });
+
+    const firstLoad = useGit.getState().loadPreviews(api, "proj", "task_a");
+    const secondLoad = useGit.getState().loadPreviews(api, "proj", "task_b");
+    second.resolve({ previews: [wirePreview({ id: "prev_b", taskId: "task_b" })] });
+    await secondLoad;
+    first.resolve({ previews: [wirePreview({ id: "prev_a", taskId: "task_a" })] });
+    await firstLoad;
+
+    expect(useGit.getState().previewScope).toEqual({ projectSlug: "proj", taskId: "task_b" });
+    expect(useGit.getState().previews.map((preview) => preview.id)).toEqual(["prev_b"]);
   });
 });
 

--- a/tests/desktop/git-store.test.ts
+++ b/tests/desktop/git-store.test.ts
@@ -296,7 +296,7 @@ describe("loadPreviews", () => {
         updatedAt: T1,
       },
     ]);
-    expect(useGit.getState().error).toBeNull();
+    expect(useGit.getState().previewError).toBeNull();
   });
 
   it("scopes previews by taskId via query param", async () => {
@@ -324,7 +324,28 @@ describe("loadPreviews", () => {
     await useGit.getState().loadPreviews(api, "proj");
 
     expect(useGit.getState().previews).toEqual([]);
-    expect(useGit.getState().error).toBe("timeout");
+    expect(useGit.getState().previewError).toBe("timeout");
+  });
+
+  it("keeps preview loads from clearing git list errors", async () => {
+    useGit.setState({ error: "unauthorized" });
+    const get = vi.fn().mockResolvedValue({ previews: [wirePreview()], nextCursor: null });
+    const api = makeApi({ get: get as never });
+
+    await useGit.getState().loadPreviews(api, "proj");
+
+    expect(useGit.getState().error).toBe("unauthorized");
+    expect(useGit.getState().previewError).toBeNull();
+  });
+
+  it("keeps preview failures out of git list errors", async () => {
+    const get = vi.fn().mockRejectedValue(new AppError("timeout"));
+    const api = makeApi({ get: get as never });
+
+    await useGit.getState().loadPreviews(api, "proj");
+
+    expect(useGit.getState().error).toBeNull();
+    expect(useGit.getState().previewError).toBe("timeout");
   });
 
   it("ignores stale preview responses from a previous task scope", async () => {

--- a/tests/desktop/git-store.test.ts
+++ b/tests/desktop/git-store.test.ts
@@ -143,15 +143,25 @@ describe("loadAll", () => {
       return Promise.resolve({ worktrees: [] });
     });
     const api = makeApi({ get: get as never });
+    useGit.setState({
+      branches: [{ name: "stale" }],
+      prs: [wirePr({ number: 99 }) as never],
+      worktrees: [wireWorktree({ id: "stale_wt" }) as never],
+      refreshedAt: T2,
+    });
 
     const pending = useGit.getState().loadAll(api, "proj");
     expect(useGit.getState().loading).toBe(true);
+    expect(useGit.getState().branches).toEqual([]);
+    expect(useGit.getState().prs).toEqual([]);
+    expect(useGit.getState().worktrees).toEqual([]);
+    expect(useGit.getState().refreshedAt).toBeNull();
     d.resolve({ branches: [], refreshedAt: T1 });
     await pending;
     expect(useGit.getState().loading).toBe(false);
   });
 
-  it("keeps the previous data for a failing surface and updates the others", async () => {
+  it("keeps failed surfaces empty after the project-scoped pre-clear and updates the others", async () => {
     useGit.setState({ branches: [{ name: "previous" }] });
     const get = routedGet({
       "/branches": new AppError("offline"),
@@ -163,7 +173,7 @@ describe("loadAll", () => {
     await useGit.getState().loadAll(api, "proj");
 
     const state = useGit.getState();
-    expect(state.branches).toEqual([{ name: "previous" }]);
+    expect(state.branches).toEqual([]);
     expect(state.prs).toHaveLength(1);
     expect(state.worktrees).toHaveLength(1);
     expect(state.error).toBe("offline");

--- a/tests/desktop/git-store.test.ts
+++ b/tests/desktop/git-store.test.ts
@@ -161,6 +161,65 @@ describe("loadAll", () => {
     expect(useGit.getState().loading).toBe(false);
   });
 
+  it("ignores stale loadAll results when project switches resolve out of order", async () => {
+    const projectABranches = deferred<unknown>();
+    const projectAPrs = deferred<unknown>();
+    const projectAWorktrees = deferred<unknown>();
+    const get = vi.fn((path: string) => {
+      if (path.includes("/api/projects/project-a/branches")) return projectABranches.promise;
+      if (path.includes("/api/projects/project-a/prs")) return projectAPrs.promise;
+      if (path.includes("/api/projects/project-a/worktrees")) return projectAWorktrees.promise;
+      if (path.includes("/api/projects/project-b/branches")) {
+        return Promise.resolve({ branches: [wireBranch({ name: "project-b-main" })], refreshedAt: T2 });
+      }
+      if (path.includes("/api/projects/project-b/prs")) {
+        return Promise.resolve({ prs: [wirePr({ number: 22, title: "Project B" })], refreshedAt: T2 });
+      }
+      if (path.includes("/api/projects/project-b/worktrees")) {
+        return Promise.resolve({ worktrees: [wireWorktree({ id: "wt_project_b", projectSlug: "project-b" })] });
+      }
+      throw new Error(`unmocked path: ${path}`);
+    });
+    const api = makeApi({ get: get as never });
+
+    const stale = useGit.getState().loadAll(api, "project-a");
+    const fresh = useGit.getState().loadAll(api, "project-b");
+    await fresh;
+
+    expect(useGit.getState().branches).toEqual([{ name: "project-b-main", current: true, default: true }]);
+    expect(useGit.getState().prs).toEqual([
+      {
+        number: 22,
+        title: "Project B",
+        author: "hamed",
+        headRef: "fix/things",
+        baseRef: "main",
+        state: "OPEN",
+      },
+    ]);
+    expect(useGit.getState().worktrees).toEqual([
+      {
+        id: "wt_project_b",
+        projectSlug: "project-b",
+        path: "/home/matrix/worktrees/wt_abc123def456",
+        sourceBranch: "main",
+        currentBranch: "fix/things",
+        dirtyState: "clean",
+        createdAt: T1,
+      },
+    ]);
+
+    projectABranches.resolve({ branches: [wireBranch({ name: "project-a-main" })], refreshedAt: T1 });
+    projectAPrs.resolve({ prs: [wirePr({ number: 11, title: "Project A" })], refreshedAt: T1 });
+    projectAWorktrees.resolve({ worktrees: [wireWorktree({ id: "wt_project_a", projectSlug: "project-a" })] });
+    await stale;
+
+    expect(useGit.getState().branches).toEqual([{ name: "project-b-main", current: true, default: true }]);
+    expect(useGit.getState().prs[0]?.number).toBe(22);
+    expect(useGit.getState().worktrees[0]?.projectSlug).toBe("project-b");
+    expect(useGit.getState().loading).toBe(false);
+  });
+
   it("keeps failed surfaces empty after the project-scoped pre-clear and updates the others", async () => {
     useGit.setState({ branches: [{ name: "previous" }] });
     const get = routedGet({

--- a/tests/desktop/git-store.test.ts
+++ b/tests/desktop/git-store.test.ts
@@ -1,0 +1,325 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { AppError } from "@desktop/shared/app-error";
+import type { ApiClient } from "@desktop/renderer/src/lib/api";
+import { useGit, type Worktree } from "@desktop/renderer/src/stores/git";
+
+const T1 = "2026-06-13T00:00:00.000Z";
+const T2 = "2026-06-13T01:00:00.000Z";
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (err: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+function makeApi(overrides: Partial<ApiClient> = {}): ApiClient {
+  return {
+    baseUrl: "https://x.test",
+    get: vi.fn().mockResolvedValue({}),
+    post: vi.fn().mockResolvedValue({}),
+    patch: vi.fn().mockResolvedValue({}),
+    delete: vi.fn().mockResolvedValue({ ok: true }),
+    putText: vi.fn().mockResolvedValue({}),
+    ...overrides,
+  } as ApiClient;
+}
+
+type Routes = Record<string, unknown>;
+
+// Dispatches GETs by path substring; values that are Errors reject.
+function routedGet(routes: Routes) {
+  return vi.fn(async (path: string) => {
+    for (const [needle, value] of Object.entries(routes)) {
+      if (path.includes(needle)) {
+        if (value instanceof Error) throw value;
+        return value;
+      }
+    }
+    throw new Error(`unmocked path: ${path}`);
+  });
+}
+
+// Fixtures mirror the gateway wire item shapes:
+// BranchSummary / PullRequestSummary (project-manager.ts),
+// WorktreeRecord (worktree-manager.ts), PreviewRecord (preview-manager.ts).
+function wireBranch(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return { name: "main", current: true, default: true, ...overrides };
+}
+
+function wirePr(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    number: 7,
+    title: "Fix things",
+    author: "hamed",
+    headRef: "fix/things",
+    baseRef: "main",
+    state: "OPEN",
+    ...overrides,
+  };
+}
+
+function wireWorktree(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    id: "wt_abc123def456",
+    projectSlug: "proj",
+    path: "/home/matrix/worktrees/wt_abc123def456",
+    sourceBranch: "main",
+    currentBranch: "fix/things",
+    dirtyState: "clean",
+    createdAt: T1,
+    ...overrides,
+  };
+}
+
+function wirePreview(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    id: "prev_1",
+    projectSlug: "proj",
+    taskId: "task_a",
+    label: "Dev server",
+    url: "https://preview.test",
+    lastStatus: "ok",
+    displayPreference: "panel",
+    createdAt: T1,
+    updatedAt: T1,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  useGit.setState(useGit.getInitialState(), true);
+  vi.spyOn(console, "warn").mockImplementation(() => {});
+  vi.spyOn(console, "error").mockImplementation(() => {});
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("loadAll", () => {
+  it("fetches branches, prs, and worktrees and populates state", async () => {
+    const get = routedGet({
+      "/branches": { branches: [wireBranch()], refreshedAt: T1 },
+      "/prs": { prs: [wirePr()], refreshedAt: T2 },
+      "/worktrees": { worktrees: [wireWorktree()] },
+    });
+    const api = makeApi({ get: get as never });
+
+    await useGit.getState().loadAll(api, "proj");
+
+    expect(get).toHaveBeenCalledWith("/api/projects/proj/branches");
+    expect(get).toHaveBeenCalledWith("/api/projects/proj/prs");
+    expect(get).toHaveBeenCalledWith("/api/projects/proj/worktrees");
+    const state = useGit.getState();
+    expect(state.branches).toEqual([{ name: "main", current: true, default: true }]);
+    expect(state.prs).toEqual([
+      { number: 7, title: "Fix things", author: "hamed", headRef: "fix/things", baseRef: "main", state: "OPEN" },
+    ]);
+    expect(state.worktrees).toEqual([
+      {
+        id: "wt_abc123def456",
+        projectSlug: "proj",
+        path: "/home/matrix/worktrees/wt_abc123def456",
+        sourceBranch: "main",
+        currentBranch: "fix/things",
+        dirtyState: "clean",
+        createdAt: T1,
+      },
+    ]);
+    expect(state.refreshedAt).toBe(T2);
+    expect(state.loading).toBe(false);
+    expect(state.error).toBeNull();
+  });
+
+  it("sets loading while requests are in flight", async () => {
+    const d = deferred<unknown>();
+    const get = vi.fn((path: string) => {
+      if (path.includes("/branches")) return d.promise;
+      if (path.includes("/prs")) return Promise.resolve({ prs: [], refreshedAt: T1 });
+      return Promise.resolve({ worktrees: [] });
+    });
+    const api = makeApi({ get: get as never });
+
+    const pending = useGit.getState().loadAll(api, "proj");
+    expect(useGit.getState().loading).toBe(true);
+    d.resolve({ branches: [], refreshedAt: T1 });
+    await pending;
+    expect(useGit.getState().loading).toBe(false);
+  });
+
+  it("keeps the previous data for a failing surface and updates the others", async () => {
+    useGit.setState({ branches: [{ name: "previous" }] });
+    const get = routedGet({
+      "/branches": new AppError("offline"),
+      "/prs": { prs: [wirePr()], refreshedAt: T1 },
+      "/worktrees": { worktrees: [wireWorktree()] },
+    });
+    const api = makeApi({ get: get as never });
+
+    await useGit.getState().loadAll(api, "proj");
+
+    const state = useGit.getState();
+    expect(state.branches).toEqual([{ name: "previous" }]);
+    expect(state.prs).toHaveLength(1);
+    expect(state.worktrees).toHaveLength(1);
+    expect(state.error).toBe("offline");
+    expect(state.loading).toBe(false);
+  });
+
+  it("surfaces the worst error category across failing surfaces", async () => {
+    const get = routedGet({
+      "/branches": new AppError("notFound"),
+      "/prs": new AppError("unauthorized"),
+      "/worktrees": { worktrees: [] },
+    });
+    const api = makeApi({ get: get as never });
+
+    await useGit.getState().loadAll(api, "proj");
+
+    expect(useGit.getState().error).toBe("unauthorized");
+  });
+
+  it("skips malformed rows with a warning and tolerates unknown extra fields", async () => {
+    const get = routedGet({
+      "/branches": {
+        branches: [wireBranch({ upstream: "origin/main" }), { name: 42 }],
+        refreshedAt: T1,
+      },
+      "/prs": { prs: [{ title: "missing number" }], refreshedAt: T1 },
+      "/worktrees": { worktrees: [wireWorktree({ extra: { nested: true } })] },
+    });
+    const api = makeApi({ get: get as never });
+
+    await useGit.getState().loadAll(api, "proj");
+
+    const state = useGit.getState();
+    expect(state.branches).toEqual([{ name: "main", current: true, default: true }]);
+    expect(state.prs).toEqual([]);
+    expect(state.worktrees).toHaveLength(1);
+    expect(state.error).toBeNull();
+    expect(console.warn).toHaveBeenCalled();
+  });
+});
+
+describe("loadPreviews", () => {
+  it("loads previews for a project", async () => {
+    const get = vi.fn().mockResolvedValue({ previews: [wirePreview()], nextCursor: null });
+    const api = makeApi({ get: get as never });
+
+    await useGit.getState().loadPreviews(api, "proj");
+
+    expect(get).toHaveBeenCalledWith("/api/projects/proj/previews?limit=100");
+    expect(useGit.getState().previews).toEqual([
+      {
+        id: "prev_1",
+        projectSlug: "proj",
+        taskId: "task_a",
+        label: "Dev server",
+        url: "https://preview.test",
+        lastStatus: "ok",
+        displayPreference: "panel",
+        createdAt: T1,
+        updatedAt: T1,
+      },
+    ]);
+    expect(useGit.getState().error).toBeNull();
+  });
+
+  it("scopes previews by taskId via query param", async () => {
+    const get = vi.fn().mockResolvedValue({ previews: [], nextCursor: null });
+    const api = makeApi({ get: get as never });
+
+    await useGit.getState().loadPreviews(api, "proj", "task_a");
+
+    expect(get).toHaveBeenCalledWith("/api/projects/proj/previews?limit=100&taskId=task_a");
+  });
+
+  it("keeps existing previews and sets the error category on failure", async () => {
+    const existing = {
+      id: "prev_keep",
+      projectSlug: "proj",
+      label: "Keep",
+      url: "https://keep.test",
+      lastStatus: "unknown",
+      displayPreference: "panel",
+    };
+    useGit.setState({ previews: [existing as never] });
+    const get = vi.fn().mockRejectedValue(new AppError("timeout"));
+    const api = makeApi({ get: get as never });
+
+    await useGit.getState().loadPreviews(api, "proj");
+
+    expect(useGit.getState().previews).toEqual([existing]);
+    expect(useGit.getState().error).toBe("timeout");
+  });
+});
+
+describe("createWorktree", () => {
+  it("posts a branch payload and appends the created worktree", async () => {
+    const post = vi.fn().mockResolvedValue({ worktree: wireWorktree() });
+    const api = makeApi({ post: post as never });
+
+    const created = await useGit.getState().createWorktree(api, "proj", { branch: "fix/things" });
+
+    expect(post).toHaveBeenCalledWith("/api/projects/proj/worktrees", { branch: "fix/things" });
+    expect(created?.id).toBe("wt_abc123def456");
+    expect(useGit.getState().worktrees.map((w: Worktree) => w.id)).toEqual(["wt_abc123def456"]);
+    expect(useGit.getState().error).toBeNull();
+  });
+
+  it("posts a pr payload", async () => {
+    const post = vi.fn().mockResolvedValue({
+      worktree: wireWorktree({ pr: { number: 12, title: "PR 12", headRef: "h", baseRef: "main" } }),
+    });
+    const api = makeApi({ post: post as never });
+
+    const created = await useGit.getState().createWorktree(api, "proj", { pr: 12 });
+
+    expect(post).toHaveBeenCalledWith("/api/projects/proj/worktrees", { pr: 12 });
+    expect(created?.pr?.number).toBe(12);
+  });
+
+  it("returns null and maps the error category on failure", async () => {
+    const post = vi.fn().mockRejectedValue(new AppError("unauthorized"));
+    const api = makeApi({ post: post as never });
+
+    const created = await useGit.getState().createWorktree(api, "proj", { branch: "x" });
+
+    expect(created).toBeNull();
+    expect(useGit.getState().error).toBe("unauthorized");
+    expect(useGit.getState().worktrees).toEqual([]);
+  });
+
+  it("returns null with a server error when the response shape is malformed", async () => {
+    const post = vi.fn().mockResolvedValue({ worktree: { path: "no id" } });
+    const api = makeApi({ post: post as never });
+
+    const created = await useGit.getState().createWorktree(api, "proj", { branch: "x" });
+
+    expect(created).toBeNull();
+    expect(useGit.getState().error).toBe("server");
+    expect(console.warn).toHaveBeenCalled();
+  });
+
+  it("replaces an existing worktree with the same id instead of duplicating", async () => {
+    useGit.setState({
+      worktrees: [
+        {
+          id: "wt_abc123def456",
+          dirtyState: "unknown",
+        } as Worktree,
+      ],
+    });
+    const post = vi.fn().mockResolvedValue({ worktree: wireWorktree() });
+    const api = makeApi({ post: post as never });
+
+    await useGit.getState().createWorktree(api, "proj", { branch: "fix/things" });
+
+    expect(useGit.getState().worktrees).toHaveLength(1);
+    expect(useGit.getState().worktrees[0]?.dirtyState).toBe("clean");
+  });
+});

--- a/tests/desktop/monaco-host.test.tsx
+++ b/tests/desktop/monaco-host.test.tsx
@@ -1,0 +1,160 @@
+// @vitest-environment jsdom
+
+import React from "react";
+import { act, cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import MonacoHost from "@desktop/renderer/src/features/editor/MonacoHost";
+import type { ApiClient } from "@desktop/renderer/src/lib/api";
+import { useConnection } from "@desktop/renderer/src/stores/connection";
+
+const monacoHarness = vi.hoisted(() => {
+  const listeners = new Set<() => void>();
+  let value = "";
+  let currentModel: {
+    getValue: () => string;
+    setValue: (next: string) => void;
+    onDidChangeContent: (listener: () => void) => { dispose: () => void };
+    isDisposed: () => boolean;
+    dispose: () => void;
+  };
+
+  const reset = () => {
+    listeners.clear();
+    value = "";
+    currentModel = {
+      getValue: () => value,
+      setValue: (next: string) => {
+        value = next;
+        for (const listener of listeners) listener();
+      },
+      onDidChangeContent: (listener: () => void) => {
+        listeners.add(listener);
+        return { dispose: () => listeners.delete(listener) };
+      },
+      isDisposed: () => false,
+      dispose: vi.fn(),
+    };
+  };
+
+  reset();
+
+  const editor = {
+    getValue: () => currentModel.getValue(),
+    getModel: () => currentModel,
+    setModel: vi.fn((model: typeof currentModel) => {
+      currentModel = model;
+    }),
+    dispose: vi.fn(),
+  };
+
+  return { editor, model: () => currentModel, reset };
+});
+
+vi.mock("monaco-editor", () => ({
+  editor: {
+    create: vi.fn(() => monacoHarness.editor),
+    createModel: vi.fn((content: string) => {
+      monacoHarness.model().setValue(content);
+      return monacoHarness.model();
+    }),
+    defineTheme: vi.fn(),
+  },
+  Uri: {
+    file: vi.fn((path: string) => ({ path })),
+  },
+}), { virtual: true });
+
+vi.mock("monaco-editor/esm/vs/editor/editor.worker?worker", () => ({ default: class Worker {} }), { virtual: true });
+vi.mock("monaco-editor/esm/vs/language/json/json.worker?worker", () => ({ default: class Worker {} }), { virtual: true });
+vi.mock("monaco-editor/esm/vs/language/css/css.worker?worker", () => ({ default: class Worker {} }), { virtual: true });
+vi.mock("monaco-editor/esm/vs/language/html/html.worker?worker", () => ({ default: class Worker {} }), { virtual: true });
+vi.mock("monaco-editor/esm/vs/language/typescript/ts.worker?worker", () => ({
+  default: class Worker {},
+}), { virtual: true });
+
+const OLD_MODIFIED = "2026-06-13T10:00:00.000Z";
+const NEW_MODIFIED = "2026-06-13T10:01:00.000Z";
+
+function wireStat(modified: string): Record<string, unknown> {
+  return {
+    name: "notes.md",
+    path: "projects/notes.md",
+    type: "file",
+    size: 42,
+    modified,
+    created: "2026-06-01T00:00:00.000Z",
+    mime: "text/markdown",
+  };
+}
+
+function makeApi(overrides: Partial<ApiClient>): ApiClient {
+  return {
+    baseUrl: "https://x.test",
+    get: vi.fn(),
+    getText: vi.fn().mockResolvedValue("server body"),
+    post: vi.fn().mockResolvedValue({}),
+    patch: vi.fn().mockResolvedValue({}),
+    delete: vi.fn().mockResolvedValue({ ok: true }),
+    putText: vi.fn().mockResolvedValue({ ok: true, modified: NEW_MODIFIED }),
+    ...overrides,
+  } as ApiClient;
+}
+
+async function renderConflict(api: ApiClient) {
+  useConnection.setState({
+    status: "signed-in",
+    handle: "operator",
+    platformHost: "https://x.test",
+    runtimeSlot: "primary",
+    api,
+  });
+  render(<MonacoHost taskId="task-1" path="projects/notes.md" />);
+  await waitFor(() => expect(monacoHarness.editor.setModel).toHaveBeenCalled());
+
+  act(() => {
+    monacoHarness.model().setValue("local edit");
+  });
+  fireEvent.keyDown(window, { key: "s", ctrlKey: true });
+  await screen.findByText("This file changed on your computer since you opened it.");
+}
+
+describe("MonacoHost conflict actions", () => {
+  beforeEach(() => {
+    monacoHarness.reset();
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it("ignores a second overwrite click while the first overwrite is pending", async () => {
+    const api = makeApi({
+      get: vi.fn()
+        .mockResolvedValueOnce(wireStat(OLD_MODIFIED))
+        .mockResolvedValueOnce(wireStat(NEW_MODIFIED)),
+      putText: vi.fn(() => new Promise(() => undefined)),
+    });
+    await renderConflict(api);
+
+    fireEvent.click(screen.getByRole("button", { name: "Overwrite" }));
+    fireEvent.click(screen.getByRole("button", { name: "Overwrite" }));
+
+    expect(api.putText).toHaveBeenCalledTimes(1);
+  });
+
+  it("ignores a second reload click while the first reload is pending", async () => {
+    const api = makeApi({
+      get: vi.fn()
+        .mockResolvedValueOnce(wireStat(OLD_MODIFIED))
+        .mockResolvedValueOnce(wireStat(NEW_MODIFIED))
+        .mockImplementationOnce(() => new Promise(() => undefined)),
+    });
+    await renderConflict(api);
+
+    fireEvent.click(screen.getByRole("button", { name: "Reload" }));
+    fireEvent.click(screen.getByRole("button", { name: "Reload" }));
+
+    expect(api.get).toHaveBeenCalledTimes(3);
+  });
+});

--- a/tests/desktop/monaco-setup.test.ts
+++ b/tests/desktop/monaco-setup.test.ts
@@ -1,0 +1,67 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+class TestModel {
+  private value: string;
+  private disposed = false;
+
+  constructor(value: string) {
+    this.value = value;
+  }
+
+  getValue() {
+    return this.value;
+  }
+
+  setValue(value: string) {
+    this.value = value;
+  }
+
+  dispose() {
+    this.disposed = true;
+  }
+
+  isDisposed() {
+    return this.disposed;
+  }
+}
+
+vi.mock("monaco-editor", () => ({
+  editor: {
+    defineTheme: vi.fn(),
+    createModel: vi.fn((content: string) => new TestModel(content)),
+  },
+  Uri: {
+    file: vi.fn((path: string) => ({ path })),
+  },
+}));
+
+vi.mock("monaco-editor/esm/vs/editor/editor.worker?worker", () => ({ default: class Worker {} }));
+vi.mock("monaco-editor/esm/vs/language/json/json.worker?worker", () => ({ default: class Worker {} }));
+vi.mock("monaco-editor/esm/vs/language/css/css.worker?worker", () => ({ default: class Worker {} }));
+vi.mock("monaco-editor/esm/vs/language/html/html.worker?worker", () => ({ default: class Worker {} }));
+vi.mock("monaco-editor/esm/vs/language/typescript/ts.worker?worker", () => ({ default: class Worker {} }));
+
+async function loadMonacoSetup() {
+  vi.resetModules();
+  (globalThis as { self?: unknown }).self = {};
+  return import("../../desktop/src/renderer/src/features/editor/monaco-setup");
+}
+
+describe("monaco model cache", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("does not evict models with unsaved edits when the cache is full", async () => {
+    const { getOrCreateModel } = await loadMonacoSetup();
+    const dirty = getOrCreateModel("dirty.ts", "server-value");
+    dirty.setValue("unsaved-value");
+
+    for (let i = 0; i < 32; i += 1) {
+      getOrCreateModel(`clean-${i}.ts`, `clean-${i}`);
+    }
+
+    expect(dirty.isDisposed()).toBe(false);
+    expect(getOrCreateModel("dirty.ts", "server-value").getValue()).toBe("unsaved-value");
+  });
+});

--- a/tests/desktop/monaco-setup.test.ts
+++ b/tests/desktop/monaco-setup.test.ts
@@ -79,6 +79,23 @@ describe("monaco model cache", () => {
     expect(dirty.isDisposed()).toBe(false);
   });
 
+  it("caps the live cache while preserving evicted dirty content", async () => {
+    const { getOrCreateModel } = await loadMonacoSetup();
+    const dirtyModels: TestModel[] = [];
+
+    for (let i = 0; i < 32; i += 1) {
+      const model = getOrCreateModel("task-a", `dirty-${i}.ts`, `server-${i}`) as TestModel;
+      model.setValue(`unsaved-${i}`);
+      dirtyModels.push(model);
+    }
+
+    const extra = getOrCreateModel("task-a", "extra.ts", "server-extra");
+
+    expect(extra.getValue()).toBe("server-extra");
+    expect(dirtyModels[0]?.isDisposed()).toBe(true);
+    expect(getOrCreateModel("task-a", "dirty-0.ts", "server-0").getValue()).toBe("unsaved-0");
+  });
+
   it("isolates same-path dirty models by task", async () => {
     const { getOrCreateModel } = await loadMonacoSetup();
     const taskA = getOrCreateModel("task-a", "src/app.ts", "server-a");

--- a/tests/desktop/monaco-setup.test.ts
+++ b/tests/desktop/monaco-setup.test.ts
@@ -54,28 +54,40 @@ describe("monaco model cache", () => {
 
   it("does not evict models with unsaved edits when the cache is full", async () => {
     const { getOrCreateModel } = await loadMonacoSetup();
-    const dirty = getOrCreateModel("dirty.ts", "server-value");
+    const dirty = getOrCreateModel("task-a", "dirty.ts", "server-value");
     dirty.setValue("unsaved-value");
 
     for (let i = 0; i < 32; i += 1) {
-      getOrCreateModel(`clean-${i}.ts`, `clean-${i}`);
+      getOrCreateModel("task-a", `clean-${i}.ts`, `clean-${i}`);
     }
 
     expect(dirty.isDisposed()).toBe(false);
-    expect(getOrCreateModel("dirty.ts", "server-value").getValue()).toBe("unsaved-value");
+    expect(getOrCreateModel("task-a", "dirty.ts", "server-value").getValue()).toBe("unsaved-value");
   });
 
   it("does not advance a dirty model baseline on cache hit", async () => {
     const { getOrCreateModel } = await loadMonacoSetup();
-    const dirty = getOrCreateModel("dirty.ts", "server-value");
+    const dirty = getOrCreateModel("task-a", "dirty.ts", "server-value");
     dirty.setValue("unsaved-value");
 
-    expect(getOrCreateModel("dirty.ts", "unsaved-value").getValue()).toBe("unsaved-value");
+    expect(getOrCreateModel("task-a", "dirty.ts", "unsaved-value").getValue()).toBe("unsaved-value");
 
     for (let i = 0; i < 32; i += 1) {
-      getOrCreateModel(`clean-${i}.ts`, `clean-${i}`);
+      getOrCreateModel("task-a", `clean-${i}.ts`, `clean-${i}`);
     }
 
     expect(dirty.isDisposed()).toBe(false);
+  });
+
+  it("isolates same-path dirty models by task", async () => {
+    const { getOrCreateModel } = await loadMonacoSetup();
+    const taskA = getOrCreateModel("task-a", "src/app.ts", "server-a");
+    taskA.setValue("task-a unsaved");
+
+    const taskB = getOrCreateModel("task-b", "src/app.ts", "server-b");
+
+    expect(taskB).not.toBe(taskA);
+    expect(taskB.getValue()).toBe("server-b");
+    expect(getOrCreateModel("task-a", "src/app.ts", "server-a").getValue()).toBe("task-a unsaved");
   });
 });

--- a/tests/desktop/monaco-setup.test.ts
+++ b/tests/desktop/monaco-setup.test.ts
@@ -64,4 +64,18 @@ describe("monaco model cache", () => {
     expect(dirty.isDisposed()).toBe(false);
     expect(getOrCreateModel("dirty.ts", "server-value").getValue()).toBe("unsaved-value");
   });
+
+  it("does not advance a dirty model baseline on cache hit", async () => {
+    const { getOrCreateModel } = await loadMonacoSetup();
+    const dirty = getOrCreateModel("dirty.ts", "server-value");
+    dirty.setValue("unsaved-value");
+
+    expect(getOrCreateModel("dirty.ts", "unsaved-value").getValue()).toBe("unsaved-value");
+
+    for (let i = 0; i < 32; i += 1) {
+      getOrCreateModel(`clean-${i}.ts`, `clean-${i}`);
+    }
+
+    expect(dirty.isDisposed()).toBe(false);
+  });
 });

--- a/tests/desktop/quick-open.test.ts
+++ b/tests/desktop/quick-open.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "vitest";
+import { fuzzyScore, rankFiles } from "@desktop/renderer/src/lib/quick-open";
+
+describe("fuzzyScore", () => {
+  it("requires the query to be a subsequence of the candidate", () => {
+    expect(fuzzyScore("xyz", "src/chat.ts")).toBe(0);
+    expect(fuzzyScore("tac", "chat.ts")).toBe(0);
+    expect(fuzzyScore("cht", "chat.ts")).toBeGreaterThan(0);
+  });
+
+  it("returns 0 for empty query, empty candidate, or query longer than candidate", () => {
+    expect(fuzzyScore("", "chat.ts")).toBe(0);
+    expect(fuzzyScore("chat", "")).toBe(0);
+    expect(fuzzyScore("chat.ts.long", "chat.ts")).toBe(0);
+  });
+
+  it("matches case-insensitively", () => {
+    expect(fuzzyScore("readme", "README.md")).toBeGreaterThan(0);
+  });
+
+  it("gives a bonus for exact-case matches", () => {
+    expect(fuzzyScore("README", "README.md")).toBeGreaterThan(fuzzyScore("readme", "README.md"));
+  });
+
+  it("scores consecutive runs above scattered matches", () => {
+    expect(fuzzyScore("cha", "chat.ts")).toBeGreaterThan(fuzzyScore("cha", "cxhxa.ts"));
+  });
+
+  it("scores segment starts above embedded matches", () => {
+    expect(fuzzyScore("kb", "kernel-bridge.ts")).toBeGreaterThan(fuzzyScore("kb", "skb.ts"));
+  });
+
+  it("prefers a basename alignment over an earlier directory alignment", () => {
+    // "ab" aligns fully inside the basename of abx/ab.ts; the greedy full-path
+    // walk alone would have consumed the directory "abx" first.
+    expect(fuzzyScore("ab", "abx/ab.ts")).toBeGreaterThan(fuzzyScore("ab", "abq/x.ts"));
+  });
+});
+
+describe("rankFiles", () => {
+  it("ranks basename matches above directory matches", () => {
+    const hits = rankFiles("chat", ["src/chat/util.ts", "src/lib/chat.ts"]);
+    expect(hits.map((h) => h.path)).toEqual(["src/lib/chat.ts", "src/chat/util.ts"]);
+  });
+
+  it("extracts the basename as the hit name", () => {
+    const hits = rankFiles("chat", ["src/lib/chat.ts", "chatter"]);
+    expect(hits[0]).toEqual({ path: "src/lib/chat.ts", name: "chat.ts" });
+    expect(hits.find((h) => h.path === "chatter")).toEqual({ path: "chatter", name: "chatter" });
+  });
+
+  it("excludes paths that do not match", () => {
+    const hits = rankFiles("chat", ["src/board.ts", "src/chat.ts"]);
+    expect(hits.map((h) => h.path)).toEqual(["src/chat.ts"]);
+  });
+
+  it("bounds results to the default limit of 50", () => {
+    const paths = Array.from({ length: 80 }, (_, i) => `src/chat-${i}.ts`);
+    expect(rankFiles("chat", paths)).toHaveLength(50);
+  });
+
+  it("honors an explicit limit", () => {
+    const paths = Array.from({ length: 80 }, (_, i) => `src/chat-${i}.ts`);
+    expect(rankFiles("chat", paths, 10)).toHaveLength(10);
+    expect(rankFiles("chat", paths, 0)).toHaveLength(0);
+  });
+
+  it("returns the first limit paths as-is for an empty query", () => {
+    const paths = ["b/second.ts", "a/first.ts", "c/third.ts"];
+    expect(rankFiles("", paths, 2)).toEqual([
+      { path: "b/second.ts", name: "second.ts" },
+      { path: "a/first.ts", name: "first.ts" },
+    ]);
+  });
+
+  it("breaks score ties by path ascending", () => {
+    const hits = rankFiles("chat", ["b/chat.ts", "a/chat.ts"]);
+    expect(hits.map((h) => h.path)).toEqual(["a/chat.ts", "b/chat.ts"]);
+  });
+
+  it("ranks 10k paths well under 500ms", () => {
+    const paths = Array.from(
+      { length: 10_000 },
+      (_, i) => `packages/pkg-${i % 40}/src/module-${i % 200}/feature-file-${i}.ts`,
+    );
+    const start = performance.now();
+    const hits = rankFiles("featfile", paths);
+    const elapsed = performance.now() - start;
+    expect(hits).toHaveLength(50);
+    expect(elapsed).toBeLessThan(500);
+  });
+});

--- a/tests/desktop/quick-open.test.tsx
+++ b/tests/desktop/quick-open.test.tsx
@@ -1,0 +1,67 @@
+// @vitest-environment jsdom
+
+import React from "react";
+import { act, cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import QuickOpen from "../../desktop/src/renderer/src/features/files/QuickOpen";
+import { useConnection } from "../../desktop/src/renderer/src/stores/connection";
+import { useUi } from "../../desktop/src/renderer/src/stores/ui";
+import { useEditorTabs } from "../../desktop/src/renderer/src/features/editor/editor-tabs-store";
+import { useWorkspace } from "../../desktop/src/renderer/src/stores/workspace";
+
+async function searchForFile(path: string): Promise<void> {
+  fireEvent.change(screen.getByPlaceholderText(/go to file/i), { target: { value: path } });
+  await act(async () => {
+    vi.advanceTimersByTime(150);
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+describe("QuickOpen", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    useConnection.setState({
+      api: {
+        get: vi.fn().mockResolvedValue({ results: ["src/app.ts"] }),
+      } as never,
+    });
+    useUi.setState({
+      view: { kind: "board" },
+      createTaskOpen: false,
+      composerOpen: false,
+      paletteOpen: false,
+      quickOpenOpen: true,
+    });
+    useEditorTabs.setState(useEditorTabs.getInitialState(), true);
+    useWorkspace.setState(useWorkspace.getInitialState(), true);
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("keeps the dialog open with feedback when opening outside a task", async () => {
+    render(<QuickOpen />);
+
+    await searchForFile("app");
+    fireEvent.click(screen.getByRole("button", { name: /src\/app\.ts/i }));
+
+    expect(screen.getByRole("status").textContent).toContain("Open a task tab");
+    expect(useUi.getState().quickOpenOpen).toBe(true);
+    expect(useEditorTabs.getState().activePathByTask).toEqual({});
+  });
+
+  it("opens the file and dismisses from a task view", async () => {
+    useUi.setState({ view: { kind: "task", taskId: "task_a" } });
+    render(<QuickOpen />);
+
+    await searchForFile("app");
+    fireEvent.click(screen.getByRole("button", { name: /src\/app\.ts/i }));
+
+    expect(useEditorTabs.getState().activePathByTask.task_a).toBe("src/app.ts");
+    expect(useUi.getState().quickOpenOpen).toBe(false);
+  });
+});

--- a/tests/desktop/workspace-store.test.ts
+++ b/tests/desktop/workspace-store.test.ts
@@ -215,6 +215,43 @@ describe("persistence", () => {
     expect(persistence.saveLayout).toHaveBeenCalledTimes(3);
   });
 
+  it("can defer panel size persistence during resize previews until the final commit", async () => {
+    const persistence = makePersistence();
+    useWorkspace.getState().configure(persistence);
+    useWorkspace.getState().togglePanel("task_a", "editor", 1_000);
+    await flushMicrotasks();
+    persistence.saveLayout.mockClear();
+
+    useWorkspace
+      .getState()
+      .setPanelSizes(
+        "task_a",
+        { terminal: 65, editor: 35, git: 0, browser: 0, artifacts: 0, processes: 0 },
+        2_000,
+        { persist: false },
+      );
+    await flushMicrotasks();
+    expect(useWorkspace.getState().layouts["task_a"]!.sizes).toMatchObject({
+      terminal: 65,
+      editor: 35,
+    });
+    expect(persistence.saveLayout).not.toHaveBeenCalled();
+
+    useWorkspace
+      .getState()
+      .setPanelSizes(
+        "task_a",
+        { terminal: 65, editor: 35, git: 0, browser: 0, artifacts: 0, processes: 0 },
+        3_000,
+      );
+    await flushMicrotasks();
+    expect(persistence.saveLayout).toHaveBeenCalledTimes(1);
+    const [taskKey, layout] = persistence.saveLayout.mock.calls[0] as [string, PanelLayout];
+    expect(taskKey).toBe("task_a");
+    expect(layout.sizes).toMatchObject({ terminal: 65, editor: 35 });
+    expect(layout.touchedAt).toBe(3_000);
+  });
+
   it("logs and does not throw when persistence fails", async () => {
     const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
     try {

--- a/tests/desktop/workspace-store.test.ts
+++ b/tests/desktop/workspace-store.test.ts
@@ -1,0 +1,285 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  PANEL_KINDS,
+  PANEL_MIN_PCT,
+  WORKSPACE_LRU_CAP,
+  defaultLayout,
+  useWorkspace,
+  type PanelKind,
+  type PanelLayout,
+} from "@desktop/renderer/src/stores/workspace";
+
+function makePersistence(layouts: Record<string, PanelLayout> | null = null) {
+  return {
+    loadLayouts: vi.fn().mockResolvedValue(layouts),
+    saveLayout: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+async function flushMicrotasks(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+beforeEach(() => {
+  useWorkspace.setState({ entries: [], layouts: {}, hydrated: false });
+  useWorkspace.getState().configure(makePersistence());
+});
+
+describe("defaultLayout", () => {
+  it("orders all panel kinds with only the terminal visible at full width", () => {
+    const layout = defaultLayout(1_000);
+    expect(layout.order).toEqual([...PANEL_KINDS]);
+    expect(layout.visible.terminal).toBe(true);
+    for (const kind of PANEL_KINDS.filter((k) => k !== "terminal")) {
+      expect(layout.visible[kind]).toBe(false);
+      expect(layout.sizes[kind]).toBe(0);
+    }
+    expect(layout.sizes.terminal).toBe(100);
+    expect(layout.touchedAt).toBe(1_000);
+  });
+});
+
+describe("openTask / focusTask / closeTask", () => {
+  it("adds opened tasks most-recently-focused first, deterministically on equal timestamps", () => {
+    const store = useWorkspace.getState();
+    store.openTask("task_a", 1_000);
+    store.openTask("task_b", 1_000);
+    expect(useWorkspace.getState().entries.map((e) => e.taskId)).toEqual(["task_b", "task_a"]);
+    expect(useWorkspace.getState().entries.every((e) => e.live)).toBe(true);
+  });
+
+  it("re-opening an existing task bumps it to the front without duplicating", () => {
+    const store = useWorkspace.getState();
+    store.openTask("task_a", 1_000);
+    store.openTask("task_b", 2_000);
+    store.openTask("task_a", 3_000);
+    const entries = useWorkspace.getState().entries;
+    expect(entries.map((e) => e.taskId)).toEqual(["task_a", "task_b"]);
+    expect(entries[0]!.lastFocusedAt).toBe(3_000);
+  });
+
+  it("evicts least-recently-focused entries beyond the LRU cap but keeps them restorable", () => {
+    const store = useWorkspace.getState();
+    for (let i = 0; i < WORKSPACE_LRU_CAP; i += 1) {
+      expect(store.openTask(`task_${i}`, 1_000 + i).evicted).toEqual([]);
+    }
+    const overflow = store.openTask("task_extra", 9_000);
+    expect(overflow.evicted).toEqual(["task_0"]);
+
+    const entries = useWorkspace.getState().entries;
+    expect(entries).toHaveLength(WORKSPACE_LRU_CAP + 1);
+    const evictedEntry = entries.find((e) => e.taskId === "task_0");
+    expect(evictedEntry).toMatchObject({ live: false });
+  });
+
+  it("does not report already-evicted entries again on subsequent opens", () => {
+    const store = useWorkspace.getState();
+    for (let i = 0; i < WORKSPACE_LRU_CAP + 1; i += 1) {
+      store.openTask(`task_${i}`, 1_000 + i);
+    }
+    const second = store.openTask("task_more", 9_000);
+    expect(second.evicted).toEqual(["task_1"]);
+  });
+
+  it("focusTask bumps recency and revives an evicted entry", () => {
+    const store = useWorkspace.getState();
+    for (let i = 0; i < WORKSPACE_LRU_CAP + 1; i += 1) {
+      store.openTask(`task_${i}`, 1_000 + i);
+    }
+    store.focusTask("task_0", 9_999);
+    const entries = useWorkspace.getState().entries;
+    expect(entries[0]).toMatchObject({ taskId: "task_0", lastFocusedAt: 9_999, live: true });
+  });
+
+  it("focusTask on an unknown task is a no-op", () => {
+    const store = useWorkspace.getState();
+    store.openTask("task_a", 1_000);
+    store.focusTask("task_unknown", 2_000);
+    expect(useWorkspace.getState().entries.map((e) => e.taskId)).toEqual(["task_a"]);
+  });
+
+  it("closeTask removes the entry but keeps the persisted layout", () => {
+    const store = useWorkspace.getState();
+    store.openTask("task_a", 1_000);
+    store.togglePanel("task_a", "editor", 2_000);
+    store.closeTask("task_a");
+    const state = useWorkspace.getState();
+    expect(state.entries).toEqual([]);
+    expect(state.layouts["task_a"]).toBeDefined();
+  });
+});
+
+describe("panel layout mutations", () => {
+  it("showing a panel with no size redistributes sizes equally among visible panels", () => {
+    const store = useWorkspace.getState();
+    store.togglePanel("task_a", "editor", 1_000);
+    const layout = useWorkspace.getState().layouts["task_a"]!;
+    expect(layout.visible.editor).toBe(true);
+    expect(layout.sizes.terminal).toBe(50);
+    expect(layout.sizes.editor).toBe(50);
+    expect(layout.touchedAt).toBe(1_000);
+  });
+
+  it("hiding a panel retains its size so re-showing restores it without redistribution", () => {
+    const store = useWorkspace.getState();
+    store.togglePanel("task_a", "editor", 1_000);
+    store.setPanelSizes(
+      "task_a",
+      { terminal: 70, editor: 30, git: 0, browser: 0, artifacts: 0, processes: 0 },
+      2_000,
+    );
+    store.togglePanel("task_a", "editor", 3_000);
+    let layout = useWorkspace.getState().layouts["task_a"]!;
+    expect(layout.visible.editor).toBe(false);
+    expect(layout.sizes.editor).toBe(30);
+
+    store.togglePanel("task_a", "editor", 4_000);
+    layout = useWorkspace.getState().layouts["task_a"]!;
+    expect(layout.visible.editor).toBe(true);
+    expect(layout.sizes).toMatchObject({ terminal: 70, editor: 30 });
+  });
+
+  it("clamps panel sizes to per-panel minimums at write time", () => {
+    const store = useWorkspace.getState();
+    store.togglePanel("task_a", "editor", 1_000);
+    store.setPanelSizes(
+      "task_a",
+      { terminal: 5, editor: 10, git: 0, browser: 0, artifacts: 0, processes: 0 },
+      2_000,
+    );
+    const layout = useWorkspace.getState().layouts["task_a"]!;
+    expect(layout.sizes.terminal).toBe(PANEL_MIN_PCT.terminal);
+    expect(layout.sizes.editor).toBe(PANEL_MIN_PCT.editor);
+  });
+
+  it("does not clamp hidden panels to visible minimums", () => {
+    const store = useWorkspace.getState();
+    store.setPanelSizes(
+      "task_a",
+      { terminal: 100, editor: 0, git: 0, browser: 0, artifacts: 0, processes: 0 },
+      1_000,
+    );
+    const layout = useWorkspace.getState().layouts["task_a"]!;
+    expect(layout.sizes.editor).toBe(0);
+  });
+
+  it("movePanel swaps with its neighbor and is a no-op at the edge", () => {
+    const store = useWorkspace.getState();
+    store.movePanel("task_a", "editor", "left", 1_000);
+    let layout = useWorkspace.getState().layouts["task_a"]!;
+    expect(layout.order[0]).toBe("editor");
+    expect(layout.order[1]).toBe("terminal");
+
+    store.movePanel("task_a", "editor", "left", 2_000);
+    layout = useWorkspace.getState().layouts["task_a"]!;
+    expect(layout.order[0]).toBe("editor");
+    expect(layout.touchedAt).toBe(1_000);
+  });
+
+  it("layoutFor returns the default layout without mutating state", () => {
+    const layout = useWorkspace.getState().layoutFor("task_missing");
+    expect(layout.visible.terminal).toBe(true);
+    expect(useWorkspace.getState().layouts).toEqual({});
+  });
+
+  it("layoutFor returns the stored layout when one exists", () => {
+    const store = useWorkspace.getState();
+    store.togglePanel("task_a", "git", 1_000);
+    expect(store.layoutFor("task_a").visible.git).toBe(true);
+  });
+});
+
+describe("persistence", () => {
+  it("persists the updated layout on every mutation", async () => {
+    const persistence = makePersistence();
+    useWorkspace.getState().configure(persistence);
+    useWorkspace.getState().togglePanel("task_a", "editor", 1_000);
+    await flushMicrotasks();
+    expect(persistence.saveLayout).toHaveBeenCalledTimes(1);
+    const [taskKey, layout] = persistence.saveLayout.mock.calls[0] as [string, PanelLayout];
+    expect(taskKey).toBe("task_a");
+    expect(layout.visible.editor).toBe(true);
+    expect(layout.touchedAt).toBe(1_000);
+
+    useWorkspace
+      .getState()
+      .setPanelSizes(
+        "task_a",
+        { terminal: 60, editor: 40, git: 0, browser: 0, artifacts: 0, processes: 0 },
+        2_000,
+      );
+    useWorkspace.getState().movePanel("task_a", "editor", "left", 3_000);
+    await flushMicrotasks();
+    expect(persistence.saveLayout).toHaveBeenCalledTimes(3);
+  });
+
+  it("logs and does not throw when persistence fails", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    try {
+      const persistence = makePersistence();
+      persistence.saveLayout.mockRejectedValue(new Error("disk full"));
+      useWorkspace.getState().configure(persistence);
+      expect(() => useWorkspace.getState().togglePanel("task_a", "editor", 1_000)).not.toThrow();
+      await flushMicrotasks();
+      expect(warn).toHaveBeenCalled();
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it("hydrate merges persisted layouts under in-memory ones and only runs once", async () => {
+    const persistedA = { ...defaultLayout(10), touchedAt: 10 };
+    const persistedB = { ...defaultLayout(20), touchedAt: 20 };
+    const persistence = makePersistence({ task_a: persistedA, task_b: persistedB });
+    useWorkspace.getState().configure(persistence);
+
+    useWorkspace.getState().togglePanel("task_a", "editor", 5_000);
+    const inMemoryA = useWorkspace.getState().layouts["task_a"]!;
+
+    await useWorkspace.getState().hydrate();
+    const state = useWorkspace.getState();
+    expect(state.hydrated).toBe(true);
+    expect(state.layouts["task_a"]).toEqual(inMemoryA);
+    expect(state.layouts["task_b"]).toEqual(persistedB);
+
+    await useWorkspace.getState().hydrate();
+    expect(persistence.loadLayouts).toHaveBeenCalledTimes(1);
+  });
+
+  it("hydrate tolerates a load failure and still marks the store hydrated", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    try {
+      const persistence = makePersistence();
+      persistence.loadLayouts.mockRejectedValue(new Error("ipc broken"));
+      useWorkspace.getState().configure(persistence);
+      await useWorkspace.getState().hydrate();
+      expect(useWorkspace.getState().hydrated).toBe(true);
+      expect(warn).toHaveBeenCalled();
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it("state stays serializable (no Set/Map values)", () => {
+    const store = useWorkspace.getState();
+    store.openTask("task_a", 1_000);
+    store.togglePanel("task_a", "editor", 2_000);
+    const { entries, layouts, hydrated } = useWorkspace.getState();
+    const roundTripped = JSON.parse(JSON.stringify({ entries, layouts, hydrated })) as {
+      entries: unknown;
+      layouts: unknown;
+      hydrated: boolean;
+    };
+    expect(roundTripped.entries).toEqual(entries);
+    expect(roundTripped.layouts).toEqual(layouts);
+  });
+});
+
+describe("PANEL_MIN_PCT", () => {
+  it("covers every panel kind", () => {
+    for (const kind of PANEL_KINDS) {
+      expect(PANEL_MIN_PCT[kind as PanelKind]).toBeGreaterThan(0);
+    }
+  });
+});

--- a/tests/desktop/workspace-store.test.ts
+++ b/tests/desktop/workspace-store.test.ts
@@ -132,6 +132,7 @@ describe("panel layout mutations", () => {
     store.togglePanel("task_a", "editor", 3_000);
     let layout = useWorkspace.getState().layouts["task_a"]!;
     expect(layout.visible.editor).toBe(false);
+    expect(layout.sizes.terminal).toBe(100);
     expect(layout.sizes.editor).toBe(30);
 
     store.togglePanel("task_a", "editor", 4_000);


### PR DESCRIPTION
## Summary
- Adds editor, file browser, git panel, workspace panels, quick-open store, and related tests.
- Part of the 094 Operator desktop stack split from original PR #507.
- Draft until the full stack validation and screenshots are refreshed.

## Validation
- Rebased onto current main after #506 merged.
- Rebuilt stack final tree matches the original #507 tree exactly.
- Per-layer CI/Greptile still needs to settle before review-ready.

## Invariants
- Source of truth: desktop app source under desktop/, specs/docs, and root workspace metadata in this stack; no owner runtime data is modified.
- Lock/transaction scope: no Postgres transaction scope is introduced in this layer; desktop local state remains scoped to the Electron app and existing gateway/platform APIs.
- Acceptable orphan states: stack PRs are draft and must land in order; partial stack landing is not a supported release state.
- Auth source of truth: Clerk/device auth and existing gateway token handling remain authoritative; this stack does not add a second auth authority.
- Deferred scope: packaged distribution, production desktop rollout, and customer VPS host-bundle deploy are outside this stack.


## Greptile Deferrals

- Greptile current-head review on `f5a92f0fb2ae` is 4/5 with no concrete blocking defect; it requests a focused second pass over the workspace editor state machinery after merge. Deferred to #571.
