### PR TITLE
feat(desktop): wire app embeds into renderer

### DIFF
--- a/desktop/.gitignore
+++ b/desktop/.gitignore
@@ -1,0 +1,5 @@
+out/
+dist/
+node_modules/
+screenshots/
+*.log

--- a/desktop/src/main/embeds/embed-manager.ts
+++ b/desktop/src/main/embeds/embed-manager.ts
@@ -24,7 +24,8 @@ export type EmbedKind = "hosted-shell" | "app";
 
 export interface EmbedManagerOptions {
   createView: (opts: { partition: string; onState: (state: "loading" | "ready" | "failed") => void }) => EmbedViewLike;
-  allowedOrigins: string[];
+  allowedOrigins?: string[];
+  getAllowedOrigins?: () => string[];
   maxLive?: number;
 }
 
@@ -57,13 +58,13 @@ function isAbortedLoadError(err: unknown): boolean {
 export class EmbedManager {
   private readonly records = new Map<string, EmbedRecord>();
   private readonly createView: EmbedManagerOptions["createView"];
-  private readonly allowedOrigins: string[];
+  private readonly getAllowedOrigins: () => string[];
   private readonly maxLive: number;
   private tick = 0;
 
   constructor(options: EmbedManagerOptions) {
     this.createView = options.createView;
-    this.allowedOrigins = options.allowedOrigins;
+    this.getAllowedOrigins = options.getAllowedOrigins ?? (() => options.allowedOrigins ?? []);
     this.maxLive = options.maxLive ?? DEFAULT_MAX_LIVE;
     if (this.maxLive > MAX_TOTAL_EMBEDS) {
       throw new Error(
@@ -79,7 +80,7 @@ export class EmbedManager {
     url: string,
     options?: { id?: string; onState?: (state: "loading" | "ready" | "failed") => void },
   ): string {
-    if (!isNavigationAllowed(url, this.allowedOrigins)) {
+    if (!isNavigationAllowed(url, this.getAllowedOrigins())) {
       throw new Error("embed URL is not allowed");
     }
 

--- a/desktop/src/main/embeds/embed-manager.ts
+++ b/desktop/src/main/embeds/embed-manager.ts
@@ -142,6 +142,21 @@ export class EmbedManager {
     return true;
   }
 
+  reload(embedId: string): boolean {
+    const record = this.records.get(embedId);
+    if (!record) return false;
+    record.lastUsed = ++this.tick;
+    if (!record.live) {
+      record.view.attach();
+      record.live = true;
+    }
+    record.loadFailed = false;
+    record.onState("loading");
+    this.loadInto(record);
+    this.enforceMaxLive();
+    return true;
+  }
+
   close(embedId: string): boolean {
     const record = this.records.get(embedId);
     if (!record) return false;

--- a/desktop/src/main/embeds/embed-manager.ts
+++ b/desktop/src/main/embeds/embed-manager.ts
@@ -90,15 +90,24 @@ export class EmbedManager {
     const id = options?.id ?? randomUUID();
     if (this.records.has(id)) throw new Error("embed id already exists");
     const onState = options?.onState ?? (() => undefined);
-    const view = this.createView({ partition, onState });
-    const record: EmbedRecord = {
+    let record: EmbedRecord | null = null;
+    const emitState = (state: "loading" | "ready" | "failed") => {
+      if (state === "loading" && record) record.loadFailed = false;
+      if (state === "failed" && record) {
+        if (record.loadFailed) return;
+        record.loadFailed = true;
+      }
+      onState(state);
+    };
+    const view = this.createView({ partition, onState: emitState });
+    record = {
       id,
       url,
       view,
       live: true,
       loadFailed: false,
       lastUsed: ++this.tick,
-      onState,
+      onState: emitState,
     };
     view.attach();
     view.setBounds(bounds);
@@ -170,7 +179,6 @@ export class EmbedManager {
         "[embed-manager] embed load failed:",
         err instanceof Error ? err.message : String(err),
       );
-      record.loadFailed = true;
       record.onState("failed");
     });
   }

--- a/desktop/src/main/embeds/embed-manager.ts
+++ b/desktop/src/main/embeds/embed-manager.ts
@@ -39,6 +39,7 @@ interface EmbedRecord {
   view: EmbedViewLike;
   live: boolean;
   loadFailed: boolean;
+  loadGeneration: number;
   lastUsed: number;
   onState: (state: "loading" | "ready" | "failed") => void;
 }
@@ -106,6 +107,7 @@ export class EmbedManager {
       view,
       live: true,
       loadFailed: false,
+      loadGeneration: 0,
       lastUsed: ++this.tick,
       onState: emitState,
     };
@@ -188,7 +190,9 @@ export class EmbedManager {
   }
 
   private loadInto(record: EmbedRecord): void {
+    const generation = ++record.loadGeneration;
     void record.view.loadUrl(record.url).catch((err: unknown) => {
+      if (this.records.get(record.id) !== record || record.loadGeneration !== generation) return;
       if (isAbortedLoadError(err)) return;
       console.warn(
         "[embed-manager] embed load failed:",

--- a/desktop/src/main/embeds/embed-manager.ts
+++ b/desktop/src/main/embeds/embed-manager.ts
@@ -23,7 +23,7 @@ export interface EmbedViewLike {
 export type EmbedKind = "hosted-shell" | "app";
 
 export interface EmbedManagerOptions {
-  createView: (opts: { partition: string }) => EmbedViewLike;
+  createView: (opts: { partition: string; onState: (state: "loading" | "ready" | "failed") => void }) => EmbedViewLike;
   allowedOrigins: string[];
   maxLive?: number;
 }
@@ -39,6 +39,7 @@ interface EmbedRecord {
   live: boolean;
   loadFailed: boolean;
   lastUsed: number;
+  onState: (state: "loading" | "ready" | "failed") => void;
 }
 
 export class EmbedManager {
@@ -59,7 +60,13 @@ export class EmbedManager {
     }
   }
 
-  open(kind: EmbedKind, slug: string | null, bounds: Bounds, url: string): string {
+  open(
+    kind: EmbedKind,
+    slug: string | null,
+    bounds: Bounds,
+    url: string,
+    options?: { id?: string; onState?: (state: "loading" | "ready" | "failed") => void },
+  ): string {
     if (!isNavigationAllowed(url, this.allowedOrigins)) {
       throw new Error("embed URL is not allowed");
     }
@@ -69,8 +76,10 @@ export class EmbedManager {
         ? "persist:hosted-shell"
         : this.appPartition(slug);
 
-    const id = randomUUID();
-    const view = this.createView({ partition });
+    const id = options?.id ?? randomUUID();
+    if (this.records.has(id)) throw new Error("embed id already exists");
+    const onState = options?.onState ?? (() => undefined);
+    const view = this.createView({ partition, onState });
     const record: EmbedRecord = {
       id,
       url,
@@ -78,11 +87,12 @@ export class EmbedManager {
       live: true,
       loadFailed: false,
       lastUsed: ++this.tick,
+      onState,
     };
     view.attach();
     view.setBounds(bounds);
-    this.loadInto(record);
     this.records.set(id, record);
+    this.loadInto(record);
 
     this.enforceMaxLive();
     this.enforceTotalCap();
@@ -149,6 +159,7 @@ export class EmbedManager {
         err instanceof Error ? err.message : String(err),
       );
       record.loadFailed = true;
+      record.onState("failed");
     });
   }
 

--- a/desktop/src/main/embeds/embed-manager.ts
+++ b/desktop/src/main/embeds/embed-manager.ts
@@ -98,6 +98,10 @@ export class EmbedManager {
       if (state === "failed" && record) {
         if (record.loadFailed) return;
         record.loadFailed = true;
+        if (record.live) {
+          record.view.detach();
+          record.live = false;
+        }
       }
       onState(state);
     };

--- a/desktop/src/main/embeds/embed-manager.ts
+++ b/desktop/src/main/embeds/embed-manager.ts
@@ -31,6 +31,7 @@ export interface EmbedManagerOptions {
 export const MAX_TOTAL_EMBEDS = 12;
 const DEFAULT_MAX_LIVE = 3;
 const SAFE_SLUG = /^[a-zA-Z0-9][a-zA-Z0-9_-]*$/;
+const ERR_ABORTED = -3;
 
 interface EmbedRecord {
   id: string;
@@ -40,6 +41,16 @@ interface EmbedRecord {
   loadFailed: boolean;
   lastUsed: number;
   onState: (state: "loading" | "ready" | "failed") => void;
+}
+
+function isAbortedLoadError(err: unknown): boolean {
+  if (!err || typeof err !== "object") return false;
+  const maybe = err as { code?: unknown; errno?: unknown; message?: unknown };
+  return (
+    maybe.errno === ERR_ABORTED ||
+    maybe.code === "ERR_ABORTED" ||
+    (typeof maybe.message === "string" && maybe.message.includes("ERR_ABORTED"))
+  );
 }
 
 export class EmbedManager {
@@ -154,6 +165,7 @@ export class EmbedManager {
 
   private loadInto(record: EmbedRecord): void {
     void record.view.loadUrl(record.url).catch((err: unknown) => {
+      if (isAbortedLoadError(err)) return;
       console.warn(
         "[embed-manager] embed load failed:",
         err instanceof Error ? err.message : String(err),

--- a/desktop/src/main/embeds/embed-manager.ts
+++ b/desktop/src/main/embeds/embed-manager.ts
@@ -22,12 +22,14 @@ export interface EmbedViewLike {
 
 export type EmbedKind = "hosted-shell" | "app";
 
-export interface EmbedManagerOptions {
+type EmbedOriginOptions =
+  | { allowedOrigins: string[]; getAllowedOrigins?: never }
+  | { allowedOrigins?: never; getAllowedOrigins: () => string[] };
+
+export type EmbedManagerOptions = {
   createView: (opts: { partition: string; onState: (state: "loading" | "ready" | "failed") => void }) => EmbedViewLike;
-  allowedOrigins?: string[];
-  getAllowedOrigins?: () => string[];
   maxLive?: number;
-}
+} & EmbedOriginOptions;
 
 export const MAX_TOTAL_EMBEDS = 12;
 const DEFAULT_MAX_LIVE = 3;
@@ -64,7 +66,12 @@ export class EmbedManager {
 
   constructor(options: EmbedManagerOptions) {
     this.createView = options.createView;
-    this.getAllowedOrigins = options.getAllowedOrigins ?? (() => options.allowedOrigins ?? []);
+    const dynamicOrigins = options.getAllowedOrigins;
+    const staticOrigins = options.allowedOrigins;
+    if ((dynamicOrigins === undefined) === (staticOrigins === undefined)) {
+      throw new Error("EmbedManager requires exactly one allowed origin source");
+    }
+    this.getAllowedOrigins = dynamicOrigins ?? (() => staticOrigins!);
     this.maxLive = options.maxLive ?? DEFAULT_MAX_LIVE;
     if (this.maxLive > MAX_TOTAL_EMBEDS) {
       throw new Error(

--- a/desktop/src/main/embeds/embed-service.ts
+++ b/desktop/src/main/embeds/embed-service.ts
@@ -110,6 +110,7 @@ export class EmbedService {
         this.deps.emitState(embedId, "auth-required");
         return false;
       }
+      return this.manager.reload(embedId);
     }
     return this.manager.focus(embedId);
   }

--- a/desktop/src/main/embeds/embed-service.ts
+++ b/desktop/src/main/embeds/embed-service.ts
@@ -258,7 +258,10 @@ export class EmbedService {
     if (!cached) return false;
     if (!shouldAttach()) return false;
     const resolved = resolveLaunchUrl(cached.launchUrl, gatewayOrigin);
-    if (!resolved) throw new Error("app launch url failed origin check");
+    if (!resolved) {
+      console.warn("[embed-service] app launch url failed origin check:", cached.launchUrl);
+      return false;
+    }
     this.manager.open("app", slug, bounds, resolved, {
       id: embedId,
       onState: (state) => this.deps.emitState(embedId, state),

--- a/desktop/src/main/embeds/embed-service.ts
+++ b/desktop/src/main/embeds/embed-service.ts
@@ -88,8 +88,16 @@ export class EmbedService {
     // and resume the embed. The native principal is never altered here.
     if (this.pendingHostedShells.has(embedId)) {
       const bounds = this.pendingHostedShells.get(embedId)!;
-      const opened = await this.createHostedShellEmbed(this.deps.getGatewayOrigin(), bounds, embedId);
-      if (!opened) return false;
+      const gatewayOrigin = this.deps.getGatewayOrigin();
+      const handoff = await this.performHostedShellHandoff(gatewayOrigin);
+      if (!handoff) {
+        if (this.pendingHostedShells.has(embedId)) {
+          this.deps.emitState(embedId, "auth-required");
+        }
+        return false;
+      }
+      if (!this.pendingHostedShells.has(embedId)) return false;
+      this.attachHostedShellEmbed(gatewayOrigin, bounds, embedId);
       this.pendingHostedShells.delete(embedId);
       this.hostedShellIds.add(embedId);
       this.deps.emitState(embedId, "loading");
@@ -158,12 +166,20 @@ export class EmbedService {
   ): Promise<boolean> {
     const handoff = await this.performHostedShellHandoff(gatewayOrigin);
     if (!handoff) return false;
+    this.attachHostedShellEmbed(gatewayOrigin, bounds, embedId);
+    return true;
+  }
+
+  private attachHostedShellEmbed(
+    gatewayOrigin: string,
+    bounds: Bounds,
+    embedId: string,
+  ): void {
     const url = `${gatewayOrigin}/`;
     this.manager.open("hosted-shell", null, bounds, url, {
       id: embedId,
       onState: (state) => this.deps.emitState(embedId, state),
     });
-    return true;
   }
 
   private async performHostedShellHandoff(gatewayOrigin: string): Promise<boolean> {

--- a/desktop/src/main/embeds/embed-service.ts
+++ b/desktop/src/main/embeds/embed-service.ts
@@ -261,6 +261,7 @@ export class EmbedService {
     const resolved = resolveLaunchUrl(cached.launchUrl, gatewayOrigin);
     if (!resolved) {
       console.warn("[embed-service] app launch url failed origin check:", cached.launchUrl);
+      this.tokenCache.delete(slug);
       return false;
     }
     this.manager.open("app", slug, bounds, resolved, {

--- a/desktop/src/main/embeds/embed-service.ts
+++ b/desktop/src/main/embeds/embed-service.ts
@@ -114,7 +114,13 @@ export class EmbedService {
     }
     if (this.pendingApps.has(embedId)) {
       const pending = this.pendingApps.get(embedId)!;
-      const opened = await this.createAppEmbed(this.deps.getGatewayOrigin(), pending.slug, pending.bounds, embedId);
+      const opened = await this.createAppEmbed(
+        this.deps.getGatewayOrigin(),
+        pending.slug,
+        pending.bounds,
+        embedId,
+        () => this.pendingApps.has(embedId),
+      );
       if (!opened) {
         if (this.pendingApps.has(embedId)) this.deps.emitState(embedId, "auth-required");
         return false;
@@ -239,6 +245,7 @@ export class EmbedService {
     slug: string,
     bounds: Bounds,
     embedId: string,
+    shouldAttach: () => boolean = () => true,
   ): Promise<boolean> {
     let cached = this.tokenCache.get(slug);
     if (!cached) {
@@ -249,6 +256,7 @@ export class EmbedService {
       }
     }
     if (!cached) return false;
+    if (!shouldAttach()) return false;
     const resolved = resolveLaunchUrl(cached.launchUrl, gatewayOrigin);
     if (!resolved) throw new Error("app launch url failed origin check");
     this.manager.open("app", slug, bounds, resolved, {

--- a/desktop/src/main/embeds/embed-service.ts
+++ b/desktop/src/main/embeds/embed-service.ts
@@ -315,6 +315,10 @@ export class EmbedService {
       request.on("response", (response) => {
         const chunks: Buffer[] = [];
         response.on("data", (chunk) => chunks.push(chunk));
+        response.on("error", (err) => {
+          clearTimeout(timeout);
+          reject(err);
+        });
         response.on("end", () => {
           clearTimeout(timeout);
           const rawSetCookie = response.headers["set-cookie"];

--- a/desktop/src/main/embeds/embed-service.ts
+++ b/desktop/src/main/embeds/embed-service.ts
@@ -33,12 +33,19 @@ interface OpenResult {
 }
 
 const MAX_PENDING_HOSTED_SHELLS = 12;
+const MAX_PENDING_APPS = 12;
+
+interface PendingAppEmbed {
+  slug: string;
+  bounds: Bounds;
+}
 
 export class EmbedService {
   private readonly manager: EmbedManager;
   private readonly tokenCache = new LaunchTokenCache();
   private readonly deps: EmbedServiceDeps;
   private readonly pendingHostedShells = new Map<string, Bounds>();
+  private readonly pendingApps = new Map<string, PendingAppEmbed>();
   private readonly hostedShellIds = new Set<string>();
 
   constructor(deps: EmbedServiceDeps) {
@@ -72,12 +79,14 @@ export class EmbedService {
 
   close(embedId: string): boolean {
     const wasPending = this.pendingHostedShells.delete(embedId);
+    const wasPendingApp = this.pendingApps.delete(embedId);
     this.hostedShellIds.delete(embedId);
-    return this.manager.close(embedId) || wasPending;
+    return this.manager.close(embedId) || wasPending || wasPendingApp;
   }
 
   closeAll(): void {
     this.pendingHostedShells.clear();
+    this.pendingApps.clear();
     this.hostedShellIds.clear();
     this.tokenCache.clear();
     this.manager.closeAll();
@@ -100,6 +109,17 @@ export class EmbedService {
       this.attachHostedShellEmbed(gatewayOrigin, bounds, embedId);
       this.pendingHostedShells.delete(embedId);
       this.hostedShellIds.add(embedId);
+      this.deps.emitState(embedId, "loading");
+      return true;
+    }
+    if (this.pendingApps.has(embedId)) {
+      const pending = this.pendingApps.get(embedId)!;
+      const opened = await this.createAppEmbed(this.deps.getGatewayOrigin(), pending.slug, pending.bounds, embedId);
+      if (!opened) {
+        if (this.pendingApps.has(embedId)) this.deps.emitState(embedId, "auth-required");
+        return false;
+      }
+      this.pendingApps.delete(embedId);
       this.deps.emitState(embedId, "loading");
       return true;
     }
@@ -196,6 +216,30 @@ export class EmbedService {
   }
 
   private async openApp(gatewayOrigin: string, slug: string, bounds: Bounds): Promise<OpenResult> {
+    const embedId = randomUUID();
+    const opened = await this.createAppEmbed(gatewayOrigin, slug, bounds, embedId);
+    if (!opened) {
+      this.rememberPendingApp(embedId, { slug, bounds });
+      return { embedId, state: "auth-required" };
+    }
+    return { embedId, state: "loading" };
+  }
+
+  private rememberPendingApp(embedId: string, pending: PendingAppEmbed): void {
+    this.pendingApps.set(embedId, pending);
+    while (this.pendingApps.size > MAX_PENDING_APPS) {
+      const oldest = this.pendingApps.keys().next().value as string | undefined;
+      if (!oldest) break;
+      this.pendingApps.delete(oldest);
+    }
+  }
+
+  private async createAppEmbed(
+    gatewayOrigin: string,
+    slug: string,
+    bounds: Bounds,
+    embedId: string,
+  ): Promise<boolean> {
     let cached = this.tokenCache.get(slug);
     if (!cached) {
       const token = await this.fetchLaunchToken(gatewayOrigin, slug);
@@ -204,15 +248,14 @@ export class EmbedService {
         cached = token;
       }
     }
-    if (!cached) throw new Error("could not obtain app launch token");
+    if (!cached) return false;
     const resolved = resolveLaunchUrl(cached.launchUrl, gatewayOrigin);
     if (!resolved) throw new Error("app launch url failed origin check");
-    const embedId = randomUUID();
     this.manager.open("app", slug, bounds, resolved, {
       id: embedId,
       onState: (state) => this.deps.emitState(embedId, state),
     });
-    return { embedId, state: "loading" };
+    return true;
   }
 
   private async fetchLaunchToken(

--- a/desktop/src/main/embeds/embed-service.ts
+++ b/desktop/src/main/embeds/embed-service.ts
@@ -52,6 +52,7 @@ export class EmbedService {
     this.deps = deps;
     this.manager = new EmbedManager({
       maxLive: 3,
+      allowedOrigins: [this.deps.getGatewayOrigin()],
       createView: ({ partition, onState }) => {
         const window = this.deps.getWindow();
         if (!window) throw new Error("no window for embed");

--- a/desktop/src/main/embeds/embed-service.ts
+++ b/desktop/src/main/embeds/embed-service.ts
@@ -52,7 +52,7 @@ export class EmbedService {
     this.deps = deps;
     this.manager = new EmbedManager({
       maxLive: 3,
-      allowedOrigins: [this.deps.getGatewayOrigin()],
+      getAllowedOrigins: () => [this.deps.getGatewayOrigin()],
       createView: ({ partition, onState }) => {
         const window = this.deps.getWindow();
         if (!window) throw new Error("no window for embed");

--- a/desktop/src/main/embeds/embed-service.ts
+++ b/desktop/src/main/embeds/embed-service.ts
@@ -5,6 +5,7 @@
 // so the renderer can show an inline re-auth prompt without ever touching the
 // native principal (L1).
 import { net, session, type BaseWindow } from "electron";
+import { randomUUID } from "node:crypto";
 import { EmbedManager, type Bounds } from "./embed-manager";
 import { LaunchTokenCache } from "./launch-token-cache";
 import { handoffWithRetry, type CookieJarLike, type ParsedCookie } from "./app-session";
@@ -26,29 +27,38 @@ interface OpenRequest {
   bounds: Bounds;
 }
 
+interface OpenResult {
+  embedId: string;
+  state: EmbedState;
+}
+
+const MAX_PENDING_HOSTED_SHELLS = 12;
+
 export class EmbedService {
   private readonly manager: EmbedManager;
   private readonly tokenCache = new LaunchTokenCache();
   private readonly deps: EmbedServiceDeps;
+  private readonly pendingHostedShells = new Map<string, Bounds>();
+  private readonly hostedShellIds = new Set<string>();
 
   constructor(deps: EmbedServiceDeps) {
     this.deps = deps;
     this.manager = new EmbedManager({
       maxLive: 3,
-      createView: ({ partition }) => {
+      createView: ({ partition, onState }) => {
         const window = this.deps.getWindow();
         if (!window) throw new Error("no window for embed");
         return createWebContentsView({
           window,
           partition,
           allowedOrigins: [this.deps.getGatewayOrigin()],
-          onState: () => undefined,
+          onState,
         });
       },
     });
   }
 
-  async open(request: OpenRequest): Promise<string> {
+  async open(request: OpenRequest): Promise<OpenResult> {
     const gatewayOrigin = this.deps.getGatewayOrigin();
     if (request.kind === "hosted-shell") {
       return this.openHostedShell(gatewayOrigin, request.bounds);
@@ -61,17 +71,38 @@ export class EmbedService {
   }
 
   close(embedId: string): boolean {
-    return this.manager.close(embedId);
+    const wasPending = this.pendingHostedShells.delete(embedId);
+    this.hostedShellIds.delete(embedId);
+    return this.manager.close(embedId) || wasPending;
   }
 
   closeAll(): void {
+    this.pendingHostedShells.clear();
+    this.hostedShellIds.clear();
+    this.tokenCache.clear();
     this.manager.closeAll();
   }
 
   async retryAuth(embedId: string): Promise<boolean> {
     // The renderer asks to retry after an inline sign-in; re-run the handoff
     // and resume the embed. The native principal is never altered here.
+    if (this.pendingHostedShells.has(embedId)) {
+      const bounds = this.pendingHostedShells.get(embedId)!;
+      const opened = await this.createHostedShellEmbed(this.deps.getGatewayOrigin(), bounds, embedId);
+      if (!opened) return false;
+      this.pendingHostedShells.delete(embedId);
+      this.hostedShellIds.add(embedId);
+      this.deps.emitState(embedId, "loading");
+      return true;
+    }
     if (!this.manager.has(embedId)) return false;
+    if (this.hostedShellIds.has(embedId)) {
+      const handoff = await this.performHostedShellHandoff(this.deps.getGatewayOrigin());
+      if (!handoff) {
+        this.deps.emitState(embedId, "auth-required");
+        return false;
+      }
+    }
     return this.manager.focus(embedId);
   }
 
@@ -100,7 +131,42 @@ export class EmbedService {
     };
   }
 
-  private async openHostedShell(gatewayOrigin: string, bounds: Bounds): Promise<string> {
+  private async openHostedShell(gatewayOrigin: string, bounds: Bounds): Promise<OpenResult> {
+    const embedId = randomUUID();
+    const opened = await this.createHostedShellEmbed(gatewayOrigin, bounds, embedId);
+    if (!opened) {
+      this.rememberPendingHostedShell(embedId, bounds);
+      return { embedId, state: "auth-required" };
+    }
+    this.hostedShellIds.add(embedId);
+    return { embedId, state: "loading" };
+  }
+
+  private rememberPendingHostedShell(embedId: string, bounds: Bounds): void {
+    this.pendingHostedShells.set(embedId, bounds);
+    while (this.pendingHostedShells.size > MAX_PENDING_HOSTED_SHELLS) {
+      const oldest = this.pendingHostedShells.keys().next().value as string | undefined;
+      if (!oldest) break;
+      this.pendingHostedShells.delete(oldest);
+    }
+  }
+
+  private async createHostedShellEmbed(
+    gatewayOrigin: string,
+    bounds: Bounds,
+    embedId: string,
+  ): Promise<boolean> {
+    const handoff = await this.performHostedShellHandoff(gatewayOrigin);
+    if (!handoff) return false;
+    const url = `${gatewayOrigin}/`;
+    this.manager.open("hosted-shell", null, bounds, url, {
+      id: embedId,
+      onState: (state) => this.deps.emitState(embedId, state),
+    });
+    return true;
+  }
+
+  private async performHostedShellHandoff(gatewayOrigin: string): Promise<boolean> {
     const handoff = await handoffWithRetry(
       {
         gatewayOrigin,
@@ -109,15 +175,10 @@ export class EmbedService {
       },
       "/",
     );
-    const url = `${gatewayOrigin}/`;
-    const embedId = this.manager.open("hosted-shell", null, bounds, url);
-    if (!handoff.ok) {
-      this.deps.emitState(embedId, "auth-required");
-    }
-    return embedId;
+    return handoff.ok;
   }
 
-  private async openApp(gatewayOrigin: string, slug: string, bounds: Bounds): Promise<string> {
+  private async openApp(gatewayOrigin: string, slug: string, bounds: Bounds): Promise<OpenResult> {
     let cached = this.tokenCache.get(slug);
     if (!cached) {
       const token = await this.fetchLaunchToken(gatewayOrigin, slug);
@@ -129,7 +190,12 @@ export class EmbedService {
     if (!cached) throw new Error("could not obtain app launch token");
     const resolved = resolveLaunchUrl(cached.launchUrl, gatewayOrigin);
     if (!resolved) throw new Error("app launch url failed origin check");
-    return this.manager.open("app", slug, bounds, resolved);
+    const embedId = randomUUID();
+    this.manager.open("app", slug, bounds, resolved, {
+      id: embedId,
+      onState: (state) => this.deps.emitState(embedId, state),
+    });
+    return { embedId, state: "loading" };
   }
 
   private async fetchLaunchToken(

--- a/desktop/src/main/embeds/embed-service.ts
+++ b/desktop/src/main/embeds/embed-service.ts
@@ -1,0 +1,203 @@
+// Orchestrates embedded surfaces in the trusted core (US5). Hosted shell: runs
+// the app-session cookie-pair handoff into an isolated partition, then loads
+// Canvas. Bridged apps: fetches/caches a short-lived session token, resolves
+// the launch URL against the gateway origin, then loads it. Emits embed:state
+// so the renderer can show an inline re-auth prompt without ever touching the
+// native principal (L1).
+import { net, session, type BaseWindow } from "electron";
+import { EmbedManager, type Bounds } from "./embed-manager";
+import { LaunchTokenCache } from "./launch-token-cache";
+import { handoffWithRetry, type CookieJarLike, type ParsedCookie } from "./app-session";
+import { resolveLaunchUrl } from "./origin-policy";
+import { createWebContentsView } from "./web-contents-view";
+
+export type EmbedState = "loading" | "ready" | "auth-required" | "failed";
+
+interface EmbedServiceDeps {
+  getWindow: () => BaseWindow | null;
+  getGatewayOrigin: () => string;
+  getToken: () => string | null;
+  emitState: (embedId: string, state: EmbedState) => void;
+}
+
+interface OpenRequest {
+  kind: "hosted-shell" | "app";
+  slug?: string;
+  bounds: Bounds;
+}
+
+export class EmbedService {
+  private readonly manager: EmbedManager;
+  private readonly tokenCache = new LaunchTokenCache();
+  private readonly deps: EmbedServiceDeps;
+
+  constructor(deps: EmbedServiceDeps) {
+    this.deps = deps;
+    this.manager = new EmbedManager({
+      maxLive: 3,
+      createView: ({ partition }) => {
+        const window = this.deps.getWindow();
+        if (!window) throw new Error("no window for embed");
+        return createWebContentsView({
+          window,
+          partition,
+          allowedOrigins: [this.deps.getGatewayOrigin()],
+          onState: () => undefined,
+        });
+      },
+    });
+  }
+
+  async open(request: OpenRequest): Promise<string> {
+    const gatewayOrigin = this.deps.getGatewayOrigin();
+    if (request.kind === "hosted-shell") {
+      return this.openHostedShell(gatewayOrigin, request.bounds);
+    }
+    return this.openApp(gatewayOrigin, request.slug ?? "", request.bounds);
+  }
+
+  setBounds(embedId: string, bounds: Bounds): boolean {
+    return this.manager.setBounds(embedId, bounds);
+  }
+
+  close(embedId: string): boolean {
+    return this.manager.close(embedId);
+  }
+
+  closeAll(): void {
+    this.manager.closeAll();
+  }
+
+  async retryAuth(embedId: string): Promise<boolean> {
+    // The renderer asks to retry after an inline sign-in; re-run the handoff
+    // and resume the embed. The native principal is never altered here.
+    if (!this.manager.has(embedId)) return false;
+    return this.manager.focus(embedId);
+  }
+
+  private cookieJarFor(partition: string): CookieJarLike {
+    const jar = session.fromPartition(partition).cookies;
+    return {
+      get: async () => {
+        const cookies = await jar.get({});
+        return cookies.map((c) => ({ name: c.name, domain: c.domain, path: c.path }));
+      },
+      set: async (cookie: ParsedCookie & { url: string }) => {
+        await jar.set({
+          url: cookie.url,
+          name: cookie.name,
+          value: cookie.value,
+          ...(cookie.domain ? { domain: cookie.domain } : {}),
+          ...(cookie.path ? { path: cookie.path } : {}),
+          ...(cookie.secure !== undefined ? { secure: cookie.secure } : {}),
+          ...(cookie.httpOnly !== undefined ? { httpOnly: cookie.httpOnly } : {}),
+          ...(cookie.expires !== undefined ? { expirationDate: cookie.expires / 1000 } : {}),
+        });
+      },
+      remove: async (url: string, name: string) => {
+        await jar.remove(url, name);
+      },
+    };
+  }
+
+  private async openHostedShell(gatewayOrigin: string, bounds: Bounds): Promise<string> {
+    const handoff = await handoffWithRetry(
+      {
+        gatewayOrigin,
+        cookieJar: this.cookieJarFor("persist:hosted-shell"),
+        request: (url, init) => this.gatewayRequest(url, init),
+      },
+      "/",
+    );
+    const url = `${gatewayOrigin}/`;
+    const embedId = this.manager.open("hosted-shell", null, bounds, url);
+    if (!handoff.ok) {
+      this.deps.emitState(embedId, "auth-required");
+    }
+    return embedId;
+  }
+
+  private async openApp(gatewayOrigin: string, slug: string, bounds: Bounds): Promise<string> {
+    let cached = this.tokenCache.get(slug);
+    if (!cached) {
+      const token = await this.fetchLaunchToken(gatewayOrigin, slug);
+      if (token) {
+        this.tokenCache.set(slug, token);
+        cached = token;
+      }
+    }
+    if (!cached) throw new Error("could not obtain app launch token");
+    const resolved = resolveLaunchUrl(cached.launchUrl, gatewayOrigin);
+    if (!resolved) throw new Error("app launch url failed origin check");
+    return this.manager.open("app", slug, bounds, resolved);
+  }
+
+  private async fetchLaunchToken(
+    gatewayOrigin: string,
+    slug: string,
+  ): Promise<{ launchUrl: string; expiresAt: number } | null> {
+    try {
+      const response = await this.gatewayRequest(
+        `${gatewayOrigin}/api/apps/${encodeURIComponent(slug)}/session-token`,
+        { method: "POST", headers: { "content-type": "application/json" }, body: "{}" },
+      );
+      if (response.status < 200 || response.status >= 300) return null;
+      const parsed: unknown = JSON.parse(response.body);
+      if (
+        parsed &&
+        typeof parsed === "object" &&
+        typeof (parsed as { launchUrl?: unknown }).launchUrl === "string" &&
+        typeof (parsed as { expiresAt?: unknown }).expiresAt === "number"
+      ) {
+        const { launchUrl, expiresAt } = parsed as { launchUrl: string; expiresAt: number };
+        return { launchUrl, expiresAt };
+      }
+      return null;
+    } catch (err: unknown) {
+      console.warn(
+        "[embed-service] launch token fetch failed:",
+        err instanceof Error ? err.message : String(err),
+      );
+      return null;
+    }
+  }
+
+  private gatewayRequest(
+    url: string,
+    init: { method: string; headers: Record<string, string>; body: string },
+  ): Promise<{ status: number; setCookieHeaders: string[]; body: string }> {
+    return new Promise((resolve, reject) => {
+      const token = this.deps.getToken();
+      const request = net.request({ method: init.method, url });
+      for (const [key, value] of Object.entries(init.headers)) request.setHeader(key, value);
+      if (token) request.setHeader("Authorization", `Bearer ${token}`);
+      const timeout = setTimeout(() => {
+        request.abort();
+        reject(new Error("gateway request timed out"));
+      }, 10_000);
+      request.on("response", (response) => {
+        const chunks: Buffer[] = [];
+        response.on("data", (chunk) => chunks.push(chunk));
+        response.on("end", () => {
+          clearTimeout(timeout);
+          const rawSetCookie = response.headers["set-cookie"];
+          const setCookieHeaders = Array.isArray(rawSetCookie)
+            ? rawSetCookie
+            : typeof rawSetCookie === "string"
+              ? [rawSetCookie]
+              : [];
+          resolve({
+            status: response.statusCode,
+            setCookieHeaders,
+            body: Buffer.concat(chunks).toString("utf8"),
+          });
+        });
+      });
+      request.on("error", (err) => {
+        clearTimeout(timeout);
+        reject(err);
+      });
+      request.end(init.body);
+    });
+  }
+}

--- a/desktop/src/main/embeds/launch-token-cache.ts
+++ b/desktop/src/main/embeds/launch-token-cache.ts
@@ -42,6 +42,10 @@ export class LaunchTokenCache {
     }
   }
 
+  delete(slug: string): void {
+    this.entries.delete(slug);
+  }
+
   clear(): void {
     this.entries.clear();
   }

--- a/desktop/src/main/embeds/web-contents-view.ts
+++ b/desktop/src/main/embeds/web-contents-view.ts
@@ -25,12 +25,20 @@ export function createWebContentsView(options: {
 
   // Block any navigation outside the allowlist; route external links to the
   // system browser.
-  contents.on("will-navigate", (event, url) => {
+  const blockExternalNavigation = (event: unknown, maybeUrl: unknown) => {
+    const url = typeof maybeUrl === "string" ? maybeUrl : typeof event === "string" ? event : null;
+    const preventDefault =
+      event && typeof event === "object" && "preventDefault" in event
+        ? (event as { preventDefault?: unknown }).preventDefault
+        : null;
+    if (!url || typeof preventDefault !== "function") return;
     if (!isNavigationAllowed(url, options.allowedOrigins)) {
-      event.preventDefault();
+      preventDefault.call(event);
       if (url.startsWith("https://")) void shell.openExternal(url);
     }
-  });
+  };
+  contents.on("will-navigate", blockExternalNavigation);
+  contents.on("will-redirect", blockExternalNavigation);
   contents.setWindowOpenHandler(({ url }) => {
     if (url.startsWith("https://")) void shell.openExternal(url);
     return { action: "deny" };

--- a/desktop/src/main/embeds/web-contents-view.ts
+++ b/desktop/src/main/embeds/web-contents-view.ts
@@ -1,0 +1,74 @@
+// Electron WebContentsView adapter implementing EmbedViewLike. Each embed runs
+// in its own isolated partition with no preload/IPC exposure — remote content
+// can never reach the trusted core (FR-064). Navigation is gated by an origin
+// allowlist; external links open in the system browser.
+import { WebContentsView, shell, type BaseWindow } from "electron";
+import { isNavigationAllowed } from "./origin-policy";
+import type { Bounds, EmbedViewLike } from "./embed-manager";
+
+export function createWebContentsView(options: {
+  window: BaseWindow;
+  partition: string;
+  allowedOrigins: string[];
+  onState: (state: "loading" | "ready" | "failed") => void;
+}): EmbedViewLike {
+  const view = new WebContentsView({
+    webPreferences: {
+      partition: options.partition,
+      contextIsolation: true,
+      sandbox: true,
+      nodeIntegration: false,
+    },
+  });
+
+  const contents = view.webContents;
+
+  // Block any navigation outside the allowlist; route external links to the
+  // system browser.
+  contents.on("will-navigate", (event, url) => {
+    if (!isNavigationAllowed(url, options.allowedOrigins)) {
+      event.preventDefault();
+      if (url.startsWith("https://")) void shell.openExternal(url);
+    }
+  });
+  contents.setWindowOpenHandler(({ url }) => {
+    if (url.startsWith("https://")) void shell.openExternal(url);
+    return { action: "deny" };
+  });
+  contents.on("did-start-loading", () => options.onState("loading"));
+  contents.on("did-finish-load", () => options.onState("ready"));
+  contents.on("did-fail-load", (_e, errorCode) => {
+    // -3 is ERR_ABORTED (e.g. a redirect); not a real failure.
+    if (errorCode !== -3) options.onState("failed");
+  });
+
+  let attached = false;
+
+  return {
+    setBounds(bounds: Bounds) {
+      view.setBounds(bounds);
+    },
+    async loadUrl(url: string) {
+      await contents.loadURL(url);
+    },
+    attach() {
+      if (attached) return;
+      options.window.contentView.addChildView(view);
+      attached = true;
+    },
+    detach() {
+      if (!attached) return;
+      options.window.contentView.removeChildView(view);
+      attached = false;
+    },
+    destroy() {
+      if (attached) {
+        options.window.contentView.removeChildView(view);
+        attached = false;
+      }
+      // WebContentsView is GC'd once detached and dereferenced; closing the
+      // contents releases the renderer process promptly.
+      if (!contents.isDestroyed()) contents.close();
+    },
+  };
+}

--- a/desktop/src/main/embeds/web-contents-view.ts
+++ b/desktop/src/main/embeds/web-contents-view.ts
@@ -37,7 +37,8 @@ export function createWebContentsView(options: {
   });
   contents.on("did-start-loading", () => options.onState("loading"));
   contents.on("did-finish-load", () => options.onState("ready"));
-  contents.on("did-fail-load", (_e, errorCode) => {
+  contents.on("did-fail-load", (_e, errorCode, _description, _validatedUrl, isMainFrame) => {
+    if (isMainFrame === false) return;
     // -3 is ERR_ABORTED (e.g. a redirect); not a real failure.
     if (errorCode !== -3) options.onState("failed");
   });

--- a/desktop/src/main/index.ts
+++ b/desktop/src/main/index.ts
@@ -3,6 +3,7 @@ import { join } from "node:path";
 import { AuthService } from "./auth/auth-service";
 import { createCredentialStore } from "./auth/credential-store";
 import { installHeaderInjection } from "./auth/header-injection";
+import { EmbedService } from "./embeds/embed-service";
 import { registerIpcHandlers } from "./ipc/handlers";
 import { createLocalStore } from "./persistence/local-store";
 import { installAppMenu } from "./platform/menu";
@@ -130,9 +131,17 @@ if (!gotLock) {
         () => auth.getGatewayOrigin(),
       );
 
+      const embeds = new EmbedService({
+        getWindow: () => mainWindow,
+        getGatewayOrigin: () => auth.getGatewayOrigin(),
+        getToken: () => auth.getToken(),
+        emitState: (embedId, state) => sendEvent("embed:state", { embedId, state }),
+      });
+
       registerIpcHandlers(ipcMain, {
         auth,
         store,
+        embeds,
         openExternal: openExternalHttps,
         setBadgeCount: (count) => {
           app.setBadgeCount(count);
@@ -147,7 +156,12 @@ if (!gotLock) {
           });
           notification.show();
         },
-        onRuntimeChanged: (slot) => sendEvent("runtime:changed", { slot }),
+        onRuntimeChanged: (slot) => {
+          // Switching runtime invalidates embed cookies/tokens; tear them down so
+          // they re-handshake against the new slot (Integration Wiring rule).
+          embeds.closeAll();
+          sendEvent("runtime:changed", { slot });
+        },
       });
 
       let boundsSaveTimer: ReturnType<typeof setTimeout> | null = null;

--- a/desktop/src/main/ipc/handlers.ts
+++ b/desktop/src/main/ipc/handlers.ts
@@ -118,8 +118,7 @@ export function registerIpcHandlers(ipcMain: IpcMainLike, ctx: HandlerContext): 
 
   handle("embed:open", async ({ kind, slug, bounds }) => {
     try {
-      const embedId = await ctx.embeds.open({ kind, slug, bounds });
-      return { embedId };
+      return await ctx.embeds.open({ kind, slug, bounds });
     } catch (err: unknown) {
       console.warn(
         "[ipc] embed:open failed:",

--- a/desktop/src/main/ipc/handlers.ts
+++ b/desktop/src/main/ipc/handlers.ts
@@ -131,9 +131,17 @@ export function registerIpcHandlers(ipcMain: IpcMainLike, ctx: HandlerContext): 
     ok: ctx.embeds.setBounds(embedId, bounds),
   }));
   handle("embed:close", ({ embedId }) => ({ ok: ctx.embeds.close(embedId) }));
-  handle("embed:retry-auth", async ({ embedId }) => ({
-    ok: await ctx.embeds.retryAuth(embedId),
-  }));
+  handle("embed:retry-auth", async ({ embedId }) => {
+    try {
+      return { ok: await ctx.embeds.retryAuth(embedId) };
+    } catch (err: unknown) {
+      console.warn(
+        "[ipc] embed:retry-auth failed:",
+        err instanceof Error ? err.message : String(err),
+      );
+      return { ok: false };
+    }
+  });
 
   handle("update:check", () => ({ status: "disabled" as const }));
 }

--- a/desktop/src/main/ipc/handlers.ts
+++ b/desktop/src/main/ipc/handlers.ts
@@ -3,6 +3,7 @@
 // and logged with detail on the trusted side only.
 import { INVOKE_CHANNELS, type InvokeChannel, type InvokeRequest, type InvokeResponse } from "../../shared/ipc-contract";
 import type { AuthService } from "../auth/auth-service";
+import type { EmbedService } from "../embeds/embed-service";
 import type { LocalStore, LocalStoreKey } from "../persistence/local-store";
 
 interface IpcMainLike {
@@ -15,6 +16,7 @@ interface IpcMainLike {
 export interface HandlerContext {
   auth: AuthService;
   store: LocalStore;
+  embeds: EmbedService;
   openExternal: (url: string) => Promise<void>;
   setBadgeCount: (count: number) => void;
   notify: (input: { threadId: string; title: string; body: string; kind: string }) => void;
@@ -114,13 +116,25 @@ export function registerIpcHandlers(ipcMain: IpcMainLike, ctx: HandlerContext): 
     return { ok: true };
   });
 
-  // Embeds land in Phase 7 (US5); until then the channels exist but refuse.
-  handle("embed:open", () => {
-    throw new Error("embed unavailable");
+  handle("embed:open", async ({ kind, slug, bounds }) => {
+    try {
+      const embedId = await ctx.embeds.open({ kind, slug, bounds });
+      return { embedId };
+    } catch (err: unknown) {
+      console.warn(
+        "[ipc] embed:open failed:",
+        err instanceof Error ? err.message : String(err),
+      );
+      throw new Error("embed unavailable");
+    }
   });
-  handle("embed:set-bounds", () => ({ ok: false }));
-  handle("embed:close", () => ({ ok: false }));
-  handle("embed:retry-auth", () => ({ ok: false }));
+  handle("embed:set-bounds", ({ embedId, bounds }) => ({
+    ok: ctx.embeds.setBounds(embedId, bounds),
+  }));
+  handle("embed:close", ({ embedId }) => ({ ok: ctx.embeds.close(embedId) }));
+  handle("embed:retry-auth", async ({ embedId }) => ({
+    ok: await ctx.embeds.retryAuth(embedId),
+  }));
 
   handle("update:check", () => ({ status: "disabled" as const }));
 }

--- a/desktop/src/renderer/src/features/board/Board.tsx
+++ b/desktop/src/renderer/src/features/board/Board.tsx
@@ -144,9 +144,9 @@ export default function Board() {
         {BOARD_COLUMNS.map((status) => (
           <div key={status} className="flex w-[252px] shrink-0 flex-col gap-2">
             <div className="h-5 w-24 rounded" style={{ background: "var(--bg-raised)" }} />
-            {[0, 1, 2].map((i) => (
+            {["a", "b", "c"].map((slot) => (
               <div
-                key={i}
+                key={`${status}-${slot}`}
                 className="status-pulse h-[72px] rounded-lg"
                 style={{ background: "var(--bg-raised)" }}
               />

--- a/desktop/src/renderer/src/features/board/CreateTaskDialog.tsx
+++ b/desktop/src/renderer/src/features/board/CreateTaskDialog.tsx
@@ -1,11 +1,18 @@
-import { useCallback, useEffect, useRef, useState, type MutableRefObject } from "react";
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type CSSProperties,
+  type MutableRefObject,
+} from "react";
 import { Button, Dialog } from "../../design/primitives";
 import { useBoard, BOARD_COLUMNS, type CardPriority, type CardStatus } from "../../stores/board";
 import { useConnection } from "../../stores/connection";
 import { useUi } from "../../stores/ui";
 
 const PRIORITIES: CardPriority[] = ["low", "normal", "high", "urgent"];
-const SELECT_STYLE: React.CSSProperties = {
+const SELECT_STYLE: CSSProperties = {
   background: "var(--bg-raised)",
   color: "var(--text-primary)",
   border: "1px solid var(--border-default)",
@@ -14,38 +21,9 @@ const SELECT_STYLE: React.CSSProperties = {
   fontSize: "var(--text-sm)",
 };
 
-export default function CreateTaskDialog({ open, onClose }: { open: boolean; onClose: () => void }) {
-  const dialogClosedRef = useRef(!open);
-  const dialogGenerationRef = useRef(0);
-
-  useEffect(() => {
-    dialogGenerationRef.current += 1;
-    dialogClosedRef.current = !open;
-    return () => {
-      dialogGenerationRef.current += 1;
-      dialogClosedRef.current = true;
-    };
-  }, [open]);
-
-  const closeFromUser = useCallback(() => {
-    dialogGenerationRef.current += 1;
-    dialogClosedRef.current = true;
-    onClose();
-  }, [onClose]);
-
-  return (
-    <Dialog open={open} onClose={closeFromUser} width={520}>
-      {open ? (
-        <CreateTaskForm
-          onClose={closeFromUser}
-          dialogClosedRef={dialogClosedRef}
-          dialogGenerationRef={dialogGenerationRef}
-        />
-      ) : null}
-    </Dialog>
-  );
-}
-
+// Inner form is mounted only while the dialog is open, so its state starts
+// fresh on each open without a reset-on-prop effect (react-doctor: no
+// state-synced-to-prop). autoFocus replaces a focus setTimeout.
 function CreateTaskForm({
   onClose,
   dialogClosedRef,
@@ -65,20 +43,12 @@ function CreateTaskForm({
   const [priority, setPriority] = useState<CardPriority>("normal");
   const [submitting, setSubmitting] = useState(false);
   const [failed, setFailed] = useState(false);
-  const titleRef = useRef<HTMLInputElement>(null);
-
-  useEffect(() => {
-    const timer = window.setTimeout(() => titleRef.current?.focus(), 0);
-    return () => {
-      window.clearTimeout(timer);
-    };
-  }, []);
 
   const closeFromUser = useCallback(() => {
     dialogGenerationRef.current += 1;
     dialogClosedRef.current = true;
     onClose();
-  }, [onClose]);
+  }, [dialogClosedRef, dialogGenerationRef, onClose]);
 
   useEffect(() => {
     const onKeyDown = (event: KeyboardEvent) => {
@@ -140,7 +110,7 @@ function CreateTaskForm({
       }}
     >
       <input
-        ref={titleRef}
+        autoFocus
         value={title}
         onChange={(e) => setTitle(e.target.value)}
         placeholder="Task title"
@@ -214,5 +184,37 @@ function CreateTaskForm({
         </Button>
       </div>
     </form>
+  );
+}
+
+export default function CreateTaskDialog({ open, onClose }: { open: boolean; onClose: () => void }) {
+  const dialogClosedRef = useRef(!open);
+  const dialogGenerationRef = useRef(0);
+
+  useEffect(() => {
+    dialogGenerationRef.current += 1;
+    dialogClosedRef.current = !open;
+    return () => {
+      dialogGenerationRef.current += 1;
+      dialogClosedRef.current = true;
+    };
+  }, [open]);
+
+  const closeFromUser = useCallback(() => {
+    dialogGenerationRef.current += 1;
+    dialogClosedRef.current = true;
+    onClose();
+  }, [onClose]);
+
+  return (
+    <Dialog open={open} onClose={closeFromUser} width={520}>
+      {open ? (
+        <CreateTaskForm
+          onClose={closeFromUser}
+          dialogClosedRef={dialogClosedRef}
+          dialogGenerationRef={dialogGenerationRef}
+        />
+      ) : null}
+    </Dialog>
   );
 }

--- a/desktop/src/renderer/src/features/editor/EditorPanel.tsx
+++ b/desktop/src/renderer/src/features/editor/EditorPanel.tsx
@@ -6,9 +6,13 @@ import { useEditorTabs } from "./editor-tabs-store";
 
 const MonacoHost = lazy(() => import("./MonacoHost"));
 
+// Stable empty reference: a selector returning a fresh [] every render would
+// fail the Object.is check and loop forever (React #185, CLAUDE.md rule).
+const EMPTY_TABS: string[] = [];
+
 export default function EditorPanel({ taskId }: { taskId: string }) {
   const api = useConnection((s) => s.api);
-  const tabs = useEditorTabs((s) => s.tabsByTask[taskId] ?? []);
+  const tabs = useEditorTabs((s) => s.tabsByTask[taskId] ?? EMPTY_TABS);
   const activePath = useEditorTabs((s) => s.activePathByTask[taskId] ?? null);
   const setActive = useEditorTabs((s) => s.setActive);
   const closeTab = useEditorTabs((s) => s.closeTab);

--- a/desktop/src/renderer/src/features/embeds/AppLauncher.tsx
+++ b/desktop/src/renderer/src/features/embeds/AppLauncher.tsx
@@ -1,0 +1,113 @@
+import { LayoutGrid } from "lucide-react";
+import { useEffect, useState } from "react";
+import { EmbedHost } from "./index";
+import { EmptyState } from "../../design/primitives";
+import { useConnection } from "../../stores/connection";
+
+interface MatrixApp {
+  slug: string;
+  name: string;
+  icon?: string;
+  category?: string;
+}
+
+function parseApps(value: unknown): MatrixApp[] {
+  const list = Array.isArray(value)
+    ? value
+    : value && typeof value === "object" && Array.isArray((value as { apps?: unknown }).apps)
+      ? (value as { apps: unknown[] }).apps
+      : [];
+  const apps: MatrixApp[] = [];
+  for (const raw of list.slice(0, 200)) {
+    if (raw && typeof raw === "object" && typeof (raw as MatrixApp).slug === "string") {
+      const app = raw as MatrixApp;
+      apps.push({ slug: app.slug, name: app.name ?? app.slug, category: app.category });
+    }
+  }
+  return apps;
+}
+
+export default function AppLauncher() {
+  const api = useConnection((s) => s.api);
+  const [apps, setApps] = useState<MatrixApp[] | null>(null);
+  const [activeSlug, setActiveSlug] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!api) return;
+    let cancelled = false;
+    api
+      .get<unknown>("/api/apps")
+      .then((res) => {
+        if (!cancelled) setApps(parseApps(res));
+      })
+      .catch(() => {
+        if (!cancelled) setApps([]);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [api]);
+
+  if (activeSlug) {
+    return (
+      <div className="flex min-h-0 flex-1 flex-col">
+        <div
+          className="flex shrink-0 items-center gap-2 border-b px-3 py-1.5"
+          style={{ borderColor: "var(--border-subtle)", background: "var(--bg-surface)" }}
+        >
+          <button
+            type="button"
+            className="text-sm hover:underline"
+            style={{ color: "var(--accent)" }}
+            onClick={() => setActiveSlug(null)}
+          >
+            ← Apps
+          </button>
+          <span className="text-sm font-semibold" style={{ color: "var(--text-primary)" }}>
+            {apps?.find((a) => a.slug === activeSlug)?.name ?? activeSlug}
+          </span>
+        </div>
+        <EmbedHost kind="app" slug={activeSlug} />
+      </div>
+    );
+  }
+
+  if (apps && apps.length === 0) {
+    return (
+      <EmptyState
+        icon={<LayoutGrid size={26} />}
+        headline="No apps installed"
+        description="Matrix OS apps you install appear here, ready to launch in this window."
+      />
+    );
+  }
+
+  return (
+    <div className="flex flex-1 flex-col gap-3 overflow-y-auto p-5">
+      <h2 className="text-lg font-semibold" style={{ color: "var(--text-primary)" }}>
+        Apps
+      </h2>
+      <div className="grid grid-cols-[repeat(auto-fill,minmax(120px,1fr))] gap-3">
+        {(apps ?? []).map((app) => (
+          <button
+            key={app.slug}
+            type="button"
+            className="flex flex-col items-center gap-2 rounded-xl border p-4 transition-colors duration-100 hover:border-[var(--border-strong)]"
+            style={{ background: "var(--bg-raised)", borderColor: "var(--border-subtle)" }}
+            onClick={() => setActiveSlug(app.slug)}
+          >
+            <div
+              className="flex h-11 w-11 items-center justify-center rounded-xl text-lg font-semibold"
+              style={{ background: "var(--accent-muted)", color: "var(--accent)" }}
+            >
+              {app.name.charAt(0).toUpperCase()}
+            </div>
+            <span className="truncate text-sm" style={{ color: "var(--text-primary)" }}>
+              {app.name}
+            </span>
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/desktop/src/renderer/src/features/embeds/AppLauncher.tsx
+++ b/desktop/src/renderer/src/features/embeds/AppLauncher.tsx
@@ -19,10 +19,14 @@ function parseApps(value: unknown): MatrixApp[] {
       : [];
   const apps: MatrixApp[] = [];
   for (const raw of list.slice(0, 200)) {
-    if (raw && typeof raw === "object" && typeof (raw as MatrixApp).slug === "string") {
-      const app = raw as MatrixApp;
-      apps.push({ slug: app.slug, name: app.name ?? app.slug, category: app.category });
-    }
+    if (!raw || typeof raw !== "object") continue;
+    const app = raw as Partial<MatrixApp>;
+    if (typeof app.slug !== "string" || app.slug.trim().length === 0) continue;
+    const slug = app.slug.trim();
+    const name = typeof app.name === "string" && app.name.trim().length > 0 ? app.name.trim() : slug;
+    const category =
+      typeof app.category === "string" && app.category.trim().length > 0 ? app.category.trim() : undefined;
+    apps.push({ slug, name, category });
   }
   return apps;
 }

--- a/desktop/src/renderer/src/features/embeds/EmbedHost.tsx
+++ b/desktop/src/renderer/src/features/embeds/EmbedHost.tsx
@@ -40,20 +40,6 @@ export default function EmbedHost({
       height: Math.round(rect.height),
     };
 
-    void invoke("embed:open", { kind, ...(slug ? { slug } : {}), bounds })
-      .then(({ embedId, state: initialState }) => {
-        if (disposed) {
-          void invoke("embed:close", { embedId });
-          return;
-        }
-        embedIdRef.current = embedId;
-        setState(pendingStates.get(embedId) ?? initialState);
-        pendingStates.delete(embedId);
-      })
-      .catch(() => {
-        if (!disposed) setState("failed");
-      });
-
     const reportBounds = () => {
       const id = embedIdRef.current;
       if (!id) return;
@@ -68,6 +54,22 @@ export default function EmbedHost({
         },
       });
     };
+
+    void invoke("embed:open", { kind, ...(slug ? { slug } : {}), bounds })
+      .then(({ embedId, state: initialState }) => {
+        if (disposed) {
+          void invoke("embed:close", { embedId });
+          return;
+        }
+        embedIdRef.current = embedId;
+        setState(pendingStates.get(embedId) ?? initialState);
+        pendingStates.delete(embedId);
+        reportBounds();
+      })
+      .catch(() => {
+        if (!disposed) setState("failed");
+      });
+
     // ResizeObserver catches size changes; window resize catches position
     // shifts that don't change this element's own box.
     const observer = new ResizeObserver(reportBounds);

--- a/desktop/src/renderer/src/features/embeds/EmbedHost.tsx
+++ b/desktop/src/renderer/src/features/embeds/EmbedHost.tsx
@@ -21,6 +21,16 @@ export default function EmbedHost({
     if (!host) return;
     let disposed = false;
     let offState: (() => void) | null = null;
+    const pendingStates = new Map<string, typeof state>();
+
+    offState = onEvent("embed:state", (payload) => {
+      const currentId = embedIdRef.current;
+      if (payload.embedId === currentId) {
+        setState(payload.state);
+        return;
+      }
+      pendingStates.set(payload.embedId, payload.state);
+    });
 
     const rect = host.getBoundingClientRect();
     const bounds = {
@@ -31,15 +41,14 @@ export default function EmbedHost({
     };
 
     void invoke("embed:open", { kind, ...(slug ? { slug } : {}), bounds })
-      .then(({ embedId }) => {
+      .then(({ embedId, state: initialState }) => {
         if (disposed) {
           void invoke("embed:close", { embedId });
           return;
         }
         embedIdRef.current = embedId;
-        offState = onEvent("embed:state", (payload) => {
-          if (payload.embedId === embedId) setState(payload.state);
-        });
+        setState(pendingStates.get(embedId) ?? initialState);
+        pendingStates.delete(embedId);
       })
       .catch(() => {
         if (!disposed) setState("failed");

--- a/desktop/src/renderer/src/features/embeds/EmbedHost.tsx
+++ b/desktop/src/renderer/src/features/embeds/EmbedHost.tsx
@@ -106,7 +106,13 @@ export default function EmbedHost({
               const id = embedIdRef.current;
               if (id) {
                 setState("loading");
-                void invoke("embed:retry-auth", { embedId: id });
+                void invoke("embed:retry-auth", { embedId: id })
+                  .then((result) => {
+                    if (embedIdRef.current === id && !result.ok) setState("auth-required");
+                  })
+                  .catch(() => {
+                    if (embedIdRef.current === id) setState("auth-required");
+                  });
               }
             }}
           >

--- a/desktop/src/renderer/src/features/embeds/EmbedHost.tsx
+++ b/desktop/src/renderer/src/features/embeds/EmbedHost.tsx
@@ -16,6 +16,22 @@ export default function EmbedHost({
   const embedIdRef = useRef<string | null>(null);
   const [state, setState] = useState<"loading" | "ready" | "auth-required" | "failed">("loading");
 
+  function reportBounds(): void {
+    const id = embedIdRef.current;
+    const host = hostRef.current;
+    if (!id || !host) return;
+    const r = host.getBoundingClientRect();
+    void invoke("embed:set-bounds", {
+      embedId: id,
+      bounds: {
+        x: Math.round(r.left),
+        y: Math.round(r.top),
+        width: Math.round(r.width),
+        height: Math.round(r.height),
+      },
+    });
+  }
+
   useEffect(() => {
     const host = hostRef.current;
     if (!host) return;
@@ -40,21 +56,6 @@ export default function EmbedHost({
       height: Math.round(rect.height),
     };
 
-    const reportBounds = () => {
-      const id = embedIdRef.current;
-      if (!id) return;
-      const r = host.getBoundingClientRect();
-      void invoke("embed:set-bounds", {
-        embedId: id,
-        bounds: {
-          x: Math.round(r.left),
-          y: Math.round(r.top),
-          width: Math.round(r.width),
-          height: Math.round(r.height),
-        },
-      });
-    };
-
     void invoke("embed:open", { kind, ...(slug ? { slug } : {}), bounds })
       .then(({ embedId, state: initialState }) => {
         if (disposed) {
@@ -72,18 +73,20 @@ export default function EmbedHost({
 
     // ResizeObserver catches size changes; window resize catches position
     // shifts that don't change this element's own box.
-    const observer = new ResizeObserver(reportBounds);
+    const observer = new ResizeObserver(() => reportBounds());
     observer.observe(host);
-    window.addEventListener("resize", reportBounds);
+    const onWindowResize = () => reportBounds();
+    window.addEventListener("resize", onWindowResize);
 
     return () => {
       disposed = true;
       observer.disconnect();
-      window.removeEventListener("resize", reportBounds);
+      window.removeEventListener("resize", onWindowResize);
       offState?.();
       const id = embedIdRef.current;
       if (id) void invoke("embed:close", { embedId: id });
     };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [kind, slug]);
 
   return (
@@ -108,7 +111,9 @@ export default function EmbedHost({
                 setState("loading");
                 void invoke("embed:retry-auth", { embedId: id })
                   .then((result) => {
-                    if (embedIdRef.current === id && !result.ok) setState("auth-required");
+                    if (embedIdRef.current !== id) return;
+                    if (result.ok) reportBounds();
+                    else setState("auth-required");
                   })
                   .catch(() => {
                     if (embedIdRef.current === id) setState("auth-required");

--- a/desktop/src/renderer/src/features/embeds/EmbedHost.tsx
+++ b/desktop/src/renderer/src/features/embeds/EmbedHost.tsx
@@ -45,7 +45,7 @@ export default function EmbedHost({
         if (!disposed) setState("failed");
       });
 
-    const observer = new ResizeObserver(() => {
+    const reportBounds = () => {
       const id = embedIdRef.current;
       if (!id) return;
       const r = host.getBoundingClientRect();
@@ -58,13 +58,17 @@ export default function EmbedHost({
           height: Math.round(r.height),
         },
       });
-    });
+    };
+    // ResizeObserver catches size changes; window resize catches position
+    // shifts that don't change this element's own box.
+    const observer = new ResizeObserver(reportBounds);
     observer.observe(host);
-    window.addEventListener("resize", () => observer.disconnect());
+    window.addEventListener("resize", reportBounds);
 
     return () => {
       disposed = true;
       observer.disconnect();
+      window.removeEventListener("resize", reportBounds);
       offState?.();
       const id = embedIdRef.current;
       if (id) void invoke("embed:close", { embedId: id });

--- a/desktop/src/renderer/src/features/embeds/EmbedHost.tsx
+++ b/desktop/src/renderer/src/features/embeds/EmbedHost.tsx
@@ -1,0 +1,111 @@
+import { useEffect, useRef, useState } from "react";
+import { Button } from "../../design/primitives";
+import { invoke, onEvent } from "../../lib/operator";
+
+// Hosts a main-process WebContentsView positioned over this element's rect.
+// The remote content renders in an isolated partition with no IPC access; this
+// component only reports bounds and surfaces the inline re-auth prompt.
+export default function EmbedHost({
+  kind,
+  slug,
+}: {
+  kind: "hosted-shell" | "app";
+  slug?: string;
+}) {
+  const hostRef = useRef<HTMLDivElement>(null);
+  const embedIdRef = useRef<string | null>(null);
+  const [state, setState] = useState<"loading" | "ready" | "auth-required" | "failed">("loading");
+
+  useEffect(() => {
+    const host = hostRef.current;
+    if (!host) return;
+    let disposed = false;
+    let offState: (() => void) | null = null;
+
+    const rect = host.getBoundingClientRect();
+    const bounds = {
+      x: Math.round(rect.left),
+      y: Math.round(rect.top),
+      width: Math.round(rect.width),
+      height: Math.round(rect.height),
+    };
+
+    void invoke("embed:open", { kind, ...(slug ? { slug } : {}), bounds })
+      .then(({ embedId }) => {
+        if (disposed) {
+          void invoke("embed:close", { embedId });
+          return;
+        }
+        embedIdRef.current = embedId;
+        offState = onEvent("embed:state", (payload) => {
+          if (payload.embedId === embedId) setState(payload.state);
+        });
+      })
+      .catch(() => {
+        if (!disposed) setState("failed");
+      });
+
+    const observer = new ResizeObserver(() => {
+      const id = embedIdRef.current;
+      if (!id) return;
+      const r = host.getBoundingClientRect();
+      void invoke("embed:set-bounds", {
+        embedId: id,
+        bounds: {
+          x: Math.round(r.left),
+          y: Math.round(r.top),
+          width: Math.round(r.width),
+          height: Math.round(r.height),
+        },
+      });
+    });
+    observer.observe(host);
+    window.addEventListener("resize", () => observer.disconnect());
+
+    return () => {
+      disposed = true;
+      observer.disconnect();
+      offState?.();
+      const id = embedIdRef.current;
+      if (id) void invoke("embed:close", { embedId: id });
+    };
+  }, [kind, slug]);
+
+  return (
+    <div ref={hostRef} className="relative min-h-0 flex-1" style={{ background: "var(--bg-app)" }}>
+      {state === "loading" ? (
+        <div className="absolute inset-0 flex items-center justify-center">
+          <span className="status-pulse text-sm" style={{ color: "var(--text-tertiary)" }}>
+            Loading…
+          </span>
+        </div>
+      ) : null}
+      {state === "auth-required" ? (
+        <div className="absolute inset-0 flex flex-col items-center justify-center gap-3">
+          <p className="text-sm" style={{ color: "var(--text-secondary)" }}>
+            This surface needs you to sign in again.
+          </p>
+          <Button
+            variant="primary"
+            onClick={() => {
+              const id = embedIdRef.current;
+              if (id) {
+                setState("loading");
+                void invoke("embed:retry-auth", { embedId: id });
+              }
+            }}
+          >
+            Retry sign-in
+          </Button>
+        </div>
+      ) : null}
+      {state === "failed" ? (
+        <div className="absolute inset-0 flex items-center justify-center">
+          <span className="text-sm" style={{ color: "var(--text-secondary)" }}>
+            Couldn't load this surface.
+          </span>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/desktop/src/renderer/src/features/embeds/index.ts
+++ b/desktop/src/renderer/src/features/embeds/index.ts
@@ -1,0 +1,2 @@
+export { default as EmbedHost } from "./EmbedHost";
+export { default as AppLauncher } from "./AppLauncher";

--- a/desktop/src/renderer/src/features/files/QuickOpen.tsx
+++ b/desktop/src/renderer/src/features/files/QuickOpen.tsx
@@ -8,9 +8,9 @@ import { useWorkspace } from "../../stores/workspace";
 const SEARCH_DEBOUNCE_MS = 150;
 const MAX_RESULTS = 30;
 
-export default function QuickOpen() {
-  const open = useUi((s) => s.quickOpenOpen);
-  const setOpen = useUi((s) => s.setQuickOpenOpen);
+// Mounted only while open (fresh state per open, autoFocus instead of a focus
+// timeout). The search debounce timer is cleared on each change and unmount.
+function QuickOpenInner({ onClose }: { onClose: () => void }) {
   const view = useUi((s) => s.view);
   const api = useConnection((s) => s.api);
   const openTab = useEditorTabs((s) => s.openTab);
@@ -20,46 +20,18 @@ export default function QuickOpen() {
   const [results, setResults] = useState<string[]>([]);
   const [selected, setSelected] = useState(0);
   const [openError, setOpenError] = useState<string | null>(null);
-  const inputRef = useRef<HTMLInputElement>(null);
-  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const focusTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const searchSeqRef = useRef(0);
 
   useEffect(() => {
-    if (open) {
-      setQuery("");
-      setResults([]);
-      setSelected(0);
-      setOpenError(null);
-      if (focusTimerRef.current) clearTimeout(focusTimerRef.current);
-      focusTimerRef.current = setTimeout(() => {
-        focusTimerRef.current = null;
-        inputRef.current?.focus();
-      }, 0);
-    }
-    return () => {
-      if (focusTimerRef.current) {
-        clearTimeout(focusTimerRef.current);
-        focusTimerRef.current = null;
-      }
-    };
-  }, [open]);
-
-  useEffect(() => {
-    if (debounceRef.current) {
-      clearTimeout(debounceRef.current);
-      debounceRef.current = null;
-    }
     const searchSeq = searchSeqRef.current + 1;
     searchSeqRef.current = searchSeq;
     const trimmedQuery = query.trim();
-    if (!open || !api || trimmedQuery.length === 0) {
+    if (!api || trimmedQuery.length === 0) {
       setResults([]);
       return;
     }
     let cancelled = false;
-    debounceRef.current = setTimeout(() => {
-      debounceRef.current = null;
+    const timer = setTimeout(() => {
       api
         .get<{ results?: unknown; entries?: unknown }>(
           `/api/files/search?q=${encodeURIComponent(trimmedQuery)}&limit=${MAX_RESULTS}`,
@@ -89,14 +61,9 @@ export default function QuickOpen() {
     }, SEARCH_DEBOUNCE_MS);
     return () => {
       cancelled = true;
-      if (debounceRef.current) {
-        clearTimeout(debounceRef.current);
-        debounceRef.current = null;
-      }
+      clearTimeout(timer);
     };
-  }, [api, open, query]);
-
-  if (!open) return null;
+  }, [api, query]);
 
   const openPath = (path: string) => {
     if (view.kind !== "task") {
@@ -105,7 +72,7 @@ export default function QuickOpen() {
     }
     openTab(view.taskId, path);
     if (!layoutFor(view.taskId).visible.editor) togglePanel(view.taskId, "editor");
-    setOpen(false);
+    onClose();
   };
 
   return (
@@ -113,7 +80,7 @@ export default function QuickOpen() {
       className="fixed inset-0 z-50 flex items-start justify-center pt-[16vh]"
       style={{ background: "rgba(0,0,0,0.45)" }}
       onMouseDown={(e) => {
-        if (e.target === e.currentTarget) setOpen(false);
+        if (e.target === e.currentTarget) onClose();
       }}
     >
       <div
@@ -125,7 +92,7 @@ export default function QuickOpen() {
         }}
       >
         <input
-          ref={inputRef}
+          autoFocus
           value={query}
           onChange={(e) => {
             setQuery(e.target.value);
@@ -135,7 +102,7 @@ export default function QuickOpen() {
           className="w-full border-b bg-transparent px-4 py-3 text-md outline-none"
           style={{ borderColor: "var(--border-subtle)", color: "var(--text-primary)" }}
           onKeyDown={(e) => {
-            if (e.key === "Escape") setOpen(false);
+            if (e.key === "Escape") onClose();
             if (e.key === "ArrowDown") {
               e.preventDefault();
               setSelected((s) => Math.min(s + 1, results.length - 1));
@@ -180,4 +147,11 @@ export default function QuickOpen() {
       </div>
     </div>
   );
+}
+
+export default function QuickOpen() {
+  const open = useUi((s) => s.quickOpenOpen);
+  const setOpen = useUi((s) => s.setQuickOpenOpen);
+  if (!open) return null;
+  return <QuickOpenInner onClose={() => setOpen(false)} />;
 }

--- a/desktop/src/renderer/src/features/mission-control/MissionControl.tsx
+++ b/desktop/src/renderer/src/features/mission-control/MissionControl.tsx
@@ -11,6 +11,7 @@ import ThreadView from "../threads/ThreadView";
 import SessionsView from "../sessions/SessionsView";
 import SettingsView from "../settings/SettingsView";
 import StandaloneSession from "../sessions/StandaloneSession";
+import { AppLauncher, EmbedHost } from "../embeds";
 import QuickOpen from "../files/QuickOpen";
 import Composer from "../threads/Composer";
 import CommandPalette from "../palette/CommandPalette";
@@ -106,6 +107,8 @@ export default function MissionControl() {
           {view.kind === "session" ? (
             <StandaloneSession key={view.sessionName} sessionName={view.sessionName} />
           ) : null}
+          {view.kind === "canvas" ? <EmbedHost kind="hosted-shell" /> : null}
+          {view.kind === "apps" ? <AppLauncher /> : null}
           {view.kind === "settings" ? <SettingsView /> : null}
         </main>
       </div>

--- a/desktop/src/renderer/src/features/mission-control/Sidebar.tsx
+++ b/desktop/src/renderer/src/features/mission-control/Sidebar.tsx
@@ -1,4 +1,4 @@
-import { Kanban, LogOut, Plus, Settings, SquareTerminal } from "lucide-react";
+import { Kanban, LayoutGrid, LogOut, Plus, Settings, SquareTerminal, Sparkles } from "lucide-react";
 import { IconButton, StatusDot } from "../../design/primitives";
 import { useConnection } from "../../stores/connection";
 import { useThreads, type ThreadStatus } from "../../stores/threads";
@@ -72,6 +72,18 @@ export default function Sidebar() {
           label="Sessions"
           active={isView("sessions")}
           onClick={() => navigate({ kind: "sessions" })}
+        />
+        <NavRow
+          icon={<Sparkles size={15} />}
+          label="Canvas"
+          active={isView("canvas")}
+          onClick={() => navigate({ kind: "canvas" })}
+        />
+        <NavRow
+          icon={<LayoutGrid size={15} />}
+          label="Apps"
+          active={isView("apps")}
+          onClick={() => navigate({ kind: "apps" })}
         />
       </nav>
 

--- a/desktop/src/renderer/src/features/threads/Composer.tsx
+++ b/desktop/src/renderer/src/features/threads/Composer.tsx
@@ -1,20 +1,19 @@
 import { CornerDownLeft } from "lucide-react";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useMemo, useState } from "react";
 import { Dialog } from "../../design/primitives";
 import { sendKernelMessage } from "../../lib/kernel-wiring";
 import { useBoard } from "../../stores/board";
 import { useThreads } from "../../stores/threads";
 import { useUi } from "../../stores/ui";
 
-export default function Composer() {
-  const open = useUi((s) => s.composerOpen);
-  const setOpen = useUi((s) => s.setComposerOpen);
+// Mounted only while open, so input state is fresh per open and autoFocus
+// replaces a focus setTimeout (react-doctor: no leaked timer, no prop-sync).
+function ComposerForm({ onClose }: { onClose: () => void }) {
   const view = useUi((s) => s.view);
   const navigate = useUi((s) => s.navigate);
   const startThread = useThreads((s) => s.startThread);
   const cardsByProject = useBoard((s) => s.cardsByProject);
   const [text, setText] = useState("");
-  const inputRef = useRef<HTMLTextAreaElement>(null);
 
   const boundTask = useMemo(() => {
     if (view.kind !== "task") return null;
@@ -24,14 +23,6 @@ export default function Composer() {
     }
     return null;
   }, [view, cardsByProject]);
-
-  useEffect(() => {
-    if (open) {
-      setText("");
-      const timer = window.setTimeout(() => inputRef.current?.focus(), 0);
-      return () => window.clearTimeout(timer);
-    }
-  }, [open]);
 
   const submit = () => {
     const trimmed = text.trim();
@@ -45,55 +36,63 @@ export default function Composer() {
       requestId,
     });
     sendKernelMessage({ text: trimmed, requestId });
-    setOpen(false);
+    onClose();
     navigate({ kind: "thread", threadId: thread.id });
   };
 
   return (
-    <Dialog open={open} onClose={() => setOpen(false)} width={560}>
-      <div className="flex flex-col gap-2 p-4">
-        {boundTask ? (
-          <span
-            className="self-start rounded-full border px-2 py-0.5 text-xs"
-            style={{ borderColor: "var(--border-default)", color: "var(--text-secondary)" }}
-          >
-            Task: {boundTask.title}
+    <div className="flex flex-col gap-2 p-4">
+      {boundTask ? (
+        <span
+          className="self-start rounded-full border px-2 py-0.5 text-xs"
+          style={{ borderColor: "var(--border-default)", color: "var(--text-secondary)" }}
+        >
+          Task: {boundTask.title}
+        </span>
+      ) : null}
+      <textarea
+        autoFocus
+        value={text}
+        onChange={(e) => setText(e.target.value)}
+        placeholder="Ask Hermes to do something…"
+        rows={3}
+        maxLength={100_000}
+        className="w-full resize-none bg-transparent text-md outline-none"
+        style={{ color: "var(--text-primary)" }}
+        onKeyDown={(e) => {
+          if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
+            e.preventDefault();
+            submit();
+          }
+        }}
+      />
+      <div className="flex items-center justify-between">
+        <span className="text-xs" style={{ color: "var(--text-tertiary)" }}>
+          Runs on your computer as an agent thread
+        </span>
+        <button
+          type="button"
+          disabled={text.trim().length === 0}
+          onClick={submit}
+          className="inline-flex h-7 items-center gap-1.5 rounded-md px-3 text-sm font-medium transition-colors duration-100 disabled:opacity-50"
+          style={{ background: "var(--accent)", color: "var(--text-on-accent)" }}
+        >
+          Start
+          <span className="flex items-center gap-0.5 text-xs opacity-80">
+            ⌘<CornerDownLeft size={11} />
           </span>
-        ) : null}
-        <textarea
-          ref={inputRef}
-          value={text}
-          onChange={(e) => setText(e.target.value)}
-          placeholder="Ask Hermes to do something…"
-          rows={3}
-          maxLength={100_000}
-          className="w-full resize-none bg-transparent text-md outline-none"
-          style={{ color: "var(--text-primary)" }}
-          onKeyDown={(e) => {
-            if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
-              e.preventDefault();
-              submit();
-            }
-          }}
-        />
-        <div className="flex items-center justify-between">
-          <span className="text-xs" style={{ color: "var(--text-tertiary)" }}>
-            Runs on your computer as an agent thread
-          </span>
-          <button
-            type="button"
-            disabled={text.trim().length === 0}
-            onClick={submit}
-            className="inline-flex h-7 items-center gap-1.5 rounded-md px-3 text-sm font-medium transition-colors duration-100 disabled:opacity-50"
-            style={{ background: "var(--accent)", color: "var(--text-on-accent)" }}
-          >
-            Start
-            <span className="flex items-center gap-0.5 text-xs opacity-80">
-              ⌘<CornerDownLeft size={11} />
-            </span>
-          </button>
-        </div>
+        </button>
       </div>
+    </div>
+  );
+}
+
+export default function Composer() {
+  const open = useUi((s) => s.composerOpen);
+  const setOpen = useUi((s) => s.setComposerOpen);
+  return (
+    <Dialog open={open} onClose={() => setOpen(false)} width={560}>
+      <ComposerForm onClose={() => setOpen(false)} />
     </Dialog>
   );
 }

--- a/desktop/src/renderer/src/features/threads/Composer.tsx
+++ b/desktop/src/renderer/src/features/threads/Composer.tsx
@@ -92,7 +92,7 @@ export default function Composer() {
   const setOpen = useUi((s) => s.setComposerOpen);
   return (
     <Dialog open={open} onClose={() => setOpen(false)} width={560}>
-      <ComposerForm onClose={() => setOpen(false)} />
+      {open ? <ComposerForm onClose={() => setOpen(false)} /> : null}
     </Dialog>
   );
 }

--- a/desktop/src/renderer/src/features/threads/ThreadView.tsx
+++ b/desktop/src/renderer/src/features/threads/ThreadView.tsx
@@ -108,9 +108,9 @@ export default function ThreadView({ threadId }: { threadId: string }) {
       </div>
 
       <div ref={scrollRef} className="flex min-h-0 flex-1 flex-col gap-3 overflow-y-auto px-5 py-4">
-        {groups.map((group, i) =>
+        {groups.map((group) =>
           group.type === "tool_group" ? (
-            <div key={i} className="flex flex-col gap-1">
+            <div key={group.messages[0]?.id ?? "tools"} className="flex flex-col gap-1">
               {group.messages.map((m) => (
                 <ToolRow key={m.id} message={m} />
               ))}

--- a/desktop/src/renderer/src/stores/ui.ts
+++ b/desktop/src/renderer/src/stores/ui.ts
@@ -7,6 +7,8 @@ export type MainView =
   | { kind: "thread"; threadId: string }
   | { kind: "sessions" }
   | { kind: "session"; sessionName: string }
+  | { kind: "canvas" }
+  | { kind: "apps" }
   | { kind: "settings" };
 
 interface UiState {

--- a/desktop/src/shared/ipc-contract.ts
+++ b/desktop/src/shared/ipc-contract.ts
@@ -7,6 +7,7 @@ import { z } from "zod/v4";
 const Empty = z.object({}).strict();
 
 const Ok = z.object({ ok: z.boolean() }).strict();
+const EmbedStateSchema = z.enum(["loading", "ready", "auth-required", "failed"]);
 
 const ProfileSchema = z
   .object({
@@ -114,7 +115,7 @@ export const INVOKE_CHANNELS = {
         bounds: BoundsSchema,
       })
       .strict(),
-    response: z.object({ embedId: z.string().min(1).max(64) }).strict(),
+    response: z.object({ embedId: z.string().min(1).max(64), state: EmbedStateSchema }).strict(),
   },
   "embed:set-bounds": {
     request: z
@@ -178,7 +179,7 @@ export const EVENT_CHANNELS = {
   "embed:state": z
     .object({
       embedId: z.string().min(1).max(64),
-      state: z.enum(["loading", "ready", "auth-required", "failed"]),
+      state: EmbedStateSchema,
     })
     .strict(),
   "notification:clicked": z.object({ threadId: z.string().min(1).max(128) }).strict(),

--- a/tests/desktop/app-launcher.test.tsx
+++ b/tests/desktop/app-launcher.test.tsx
@@ -1,0 +1,46 @@
+// @vitest-environment jsdom
+
+import React from "react";
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import AppLauncher from "@desktop/renderer/src/features/embeds/AppLauncher";
+import { useConnection } from "@desktop/renderer/src/stores/connection";
+
+vi.mock("@desktop/renderer/src/features/embeds/EmbedHost", () => ({
+  default: ({ slug }: { slug: string }) => <div>Embed {slug}</div>,
+}));
+
+describe("AppLauncher", () => {
+  beforeEach(() => {
+    useConnection.setState({
+      status: "signed-in",
+      handle: "operator",
+      platformHost: "https://platform.test",
+      runtimeSlot: "primary",
+      api: {
+        get: vi.fn().mockResolvedValue({
+          apps: [
+            { slug: "notes", name: 42 },
+            { slug: "chat", name: "Chat" },
+            { slug: "", name: "Blank" },
+            { name: "Missing slug" },
+          ],
+        }),
+      } as never,
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it("falls back to slug names and skips invalid app rows", async () => {
+    render(<AppLauncher />);
+
+    expect(await screen.findByRole("button", { name: /notes/i })).toBeTruthy();
+    expect(screen.getByRole("button", { name: /chat/i })).toBeTruthy();
+    expect(screen.queryByRole("button", { name: /blank/i })).toBeNull();
+    expect(screen.queryByRole("button", { name: /missing slug/i })).toBeNull();
+  });
+});

--- a/tests/desktop/composer.test.tsx
+++ b/tests/desktop/composer.test.tsx
@@ -1,0 +1,49 @@
+// @vitest-environment jsdom
+
+import React from "react";
+import { act, cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import Composer from "../../desktop/src/renderer/src/features/threads/Composer";
+import { useBoard } from "../../desktop/src/renderer/src/stores/board";
+import { useThreads } from "../../desktop/src/renderer/src/stores/threads";
+import { useUi } from "../../desktop/src/renderer/src/stores/ui";
+
+describe("Composer", () => {
+  beforeEach(() => {
+    useBoard.setState({
+      projects: [],
+      activeProjectSlug: null,
+      cardsByProject: {},
+      firstLoadByProject: {},
+      refreshing: false,
+      error: null,
+    });
+    useThreads.setState({ threads: [], activeThreadId: null });
+    useUi.setState({
+      view: { kind: "board" },
+      createTaskOpen: false,
+      composerOpen: true,
+      paletteOpen: false,
+      quickOpenOpen: false,
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("resets draft text after closing and reopening", () => {
+    render(<Composer />);
+
+    fireEvent.change(screen.getByPlaceholderText(/ask hermes/i), {
+      target: { value: "stale draft" },
+    });
+    expect((screen.getByRole("textbox") as HTMLTextAreaElement).value).toBe("stale draft");
+
+    act(() => useUi.getState().setComposerOpen(false));
+    expect(screen.queryByRole("textbox")).toBeNull();
+
+    act(() => useUi.getState().setComposerOpen(true));
+    expect((screen.getByRole("textbox") as HTMLTextAreaElement).value).toBe("");
+  });
+});

--- a/tests/desktop/embed-host.test.tsx
+++ b/tests/desktop/embed-host.test.tsx
@@ -93,4 +93,31 @@ describe("EmbedHost", () => {
       expect(screen.getByRole("button", { name: "Retry sign-in" })).toBeTruthy();
     });
   });
+
+  it("refreshes bounds after a successful auth retry", async () => {
+    vi.mocked(invoke).mockImplementation((channel: string) => {
+      if (channel === "embed:open") {
+        return Promise.resolve({ embedId: "embed-1", state: "auth-required" }) as ReturnType<typeof invoke>;
+      }
+      if (channel === "embed:retry-auth") {
+        return Promise.resolve({ ok: true }) as ReturnType<typeof invoke>;
+      }
+      return Promise.resolve({ ok: true }) as ReturnType<typeof invoke>;
+    });
+
+    render(<EmbedHost kind="hosted-shell" />);
+
+    await screen.findByRole("button", { name: "Retry sign-in" });
+    vi.mocked(invoke).mockClear();
+    rect = { left: 90, top: 100, width: 700, height: 500 };
+    fireEvent.click(screen.getByRole("button", { name: "Retry sign-in" }));
+
+    await waitFor(() => {
+      expect(invoke).toHaveBeenCalledWith("embed:retry-auth", { embedId: "embed-1" });
+      expect(invoke).toHaveBeenCalledWith("embed:set-bounds", {
+        embedId: "embed-1",
+        bounds: { x: 90, y: 100, width: 700, height: 500 },
+      });
+    });
+  });
 });

--- a/tests/desktop/embed-host.test.tsx
+++ b/tests/desktop/embed-host.test.tsx
@@ -1,0 +1,75 @@
+// @vitest-environment jsdom
+
+import React from "react";
+import { act, cleanup, render, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import EmbedHost from "../../desktop/src/renderer/src/features/embeds/EmbedHost";
+import { invoke } from "../../desktop/src/renderer/src/lib/operator";
+
+vi.mock("../../desktop/src/renderer/src/lib/operator", () => ({
+  invoke: vi.fn(),
+  onEvent: vi.fn(() => () => undefined),
+}));
+
+describe("EmbedHost", () => {
+  let openResolve: ((value: { embedId: string; state: "loading" }) => void) | null = null;
+  let rect = { left: 10, top: 20, width: 300, height: 200 };
+
+  beforeEach(() => {
+    openResolve = null;
+    rect = { left: 10, top: 20, width: 300, height: 200 };
+    vi.mocked(invoke).mockImplementation((channel: string) => {
+      if (channel === "embed:open") {
+        return new Promise((resolve) => {
+          openResolve = resolve as typeof openResolve;
+        }) as ReturnType<typeof invoke>;
+      }
+      return Promise.resolve({ ok: true }) as ReturnType<typeof invoke>;
+    });
+    vi.spyOn(HTMLElement.prototype, "getBoundingClientRect").mockImplementation(
+      () =>
+        ({
+          x: rect.left,
+          y: rect.top,
+          left: rect.left,
+          top: rect.top,
+          right: rect.left + rect.width,
+          bottom: rect.top + rect.height,
+          width: rect.width,
+          height: rect.height,
+          toJSON: () => ({}),
+        }) as DOMRect,
+    );
+    vi.stubGlobal(
+      "ResizeObserver",
+      class ResizeObserver {
+        observe() {}
+        disconnect() {}
+      },
+    );
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it("reports fresh bounds when the embed opens after a pending layout change", async () => {
+    render(<EmbedHost kind="hosted-shell" />);
+
+    rect = { left: 40, top: 50, width: 640, height: 480 };
+    window.dispatchEvent(new Event("resize"));
+
+    await act(async () => {
+      openResolve?.({ embedId: "embed-1", state: "loading" });
+    });
+
+    await waitFor(() => {
+      expect(invoke).toHaveBeenCalledWith("embed:set-bounds", {
+        embedId: "embed-1",
+        bounds: { x: 40, y: 50, width: 640, height: 480 },
+      });
+    });
+  });
+});

--- a/tests/desktop/embed-host.test.tsx
+++ b/tests/desktop/embed-host.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 
 import React from "react";
-import { act, cleanup, render, waitFor } from "@testing-library/react";
+import { act, cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import EmbedHost from "../../desktop/src/renderer/src/features/embeds/EmbedHost";
 import { invoke } from "../../desktop/src/renderer/src/lib/operator";
@@ -12,7 +12,7 @@ vi.mock("../../desktop/src/renderer/src/lib/operator", () => ({
 }));
 
 describe("EmbedHost", () => {
-  let openResolve: ((value: { embedId: string; state: "loading" }) => void) | null = null;
+  let openResolve: ((value: { embedId: string; state: "loading" | "auth-required" }) => void) | null = null;
   let rect = { left: 10, top: 20, width: 300, height: 200 };
 
   beforeEach(() => {
@@ -70,6 +70,27 @@ describe("EmbedHost", () => {
         embedId: "embed-1",
         bounds: { x: 40, y: 50, width: 640, height: 480 },
       });
+    });
+  });
+
+  it("restores the auth retry prompt when retryAuth returns ok false", async () => {
+    vi.mocked(invoke).mockImplementation((channel: string) => {
+      if (channel === "embed:open") {
+        return Promise.resolve({ embedId: "embed-1", state: "auth-required" }) as ReturnType<typeof invoke>;
+      }
+      if (channel === "embed:retry-auth") {
+        return Promise.resolve({ ok: false }) as ReturnType<typeof invoke>;
+      }
+      return Promise.resolve({ ok: true }) as ReturnType<typeof invoke>;
+    });
+
+    render(<EmbedHost kind="hosted-shell" />);
+
+    fireEvent.click(await screen.findByRole("button", { name: "Retry sign-in" }));
+
+    await waitFor(() => {
+      expect(invoke).toHaveBeenCalledWith("embed:retry-auth", { embedId: "embed-1" });
+      expect(screen.getByRole("button", { name: "Retry sign-in" })).toBeTruthy();
     });
   });
 });

--- a/tests/desktop/embed-manager.test.ts
+++ b/tests/desktop/embed-manager.test.ts
@@ -194,6 +194,30 @@ describe("EmbedManager", () => {
     expect(views[0]?.view.loadedUrls).toEqual(["https://gw.test/apps/notes/"]);
   });
 
+  it("emits one failed state when the adapter reports failure and loadUrl rejects", async () => {
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    const states: string[] = [];
+    const manager = new EmbedManager({
+      createView: ({ onState }) => ({
+        setBounds: () => undefined,
+        loadUrl: async () => {
+          onState("failed");
+          throw new Error("main frame failed");
+        },
+        attach: () => undefined,
+        detach: () => undefined,
+        destroy: () => undefined,
+      }),
+    });
+
+    manager.open("app", "notes", BOUNDS, "https://gw.test/apps/notes/", {
+      onState: (state) => states.push(state),
+    });
+    await flush();
+
+    expect(states).toEqual(["failed"]);
+  });
+
   it("updates bounds for live embeds", () => {
     const { manager, views } = makeManager();
     const id = manager.open("hosted-shell", null, BOUNDS, "https://gw.test/");

--- a/tests/desktop/embed-manager.test.ts
+++ b/tests/desktop/embed-manager.test.ts
@@ -222,6 +222,7 @@ describe("EmbedManager", () => {
     let rejectFirst!: (err: unknown) => void;
     let loadCount = 0;
     const manager = new EmbedManager({
+      allowedOrigins: ["https://gw.test"],
       createView: () => ({
         setBounds: () => undefined,
         loadUrl: async () => {
@@ -267,6 +268,7 @@ describe("EmbedManager", () => {
     vi.spyOn(console, "warn").mockImplementation(() => {});
     const states: string[] = [];
     const manager = new EmbedManager({
+      allowedOrigins: ["https://gw.test"],
       createView: ({ onState }) => ({
         setBounds: () => undefined,
         loadUrl: async () => {

--- a/tests/desktop/embed-manager.test.ts
+++ b/tests/desktop/embed-manager.test.ts
@@ -3,6 +3,7 @@ import {
   EmbedManager,
   MAX_TOTAL_EMBEDS,
   type Bounds,
+  type EmbedManagerOptions,
   type EmbedViewLike,
 } from "@desktop/main/embeds/embed-manager";
 
@@ -89,6 +90,26 @@ afterEach(() => {
 });
 
 describe("EmbedManager", () => {
+  it("requires exactly one allowed origin source", () => {
+    const createView: EmbedManagerOptions["createView"] = ({ onState }) => new FakeView(null, onState);
+
+    expect(
+      () =>
+        new EmbedManager({
+          createView,
+        } as EmbedManagerOptions),
+    ).toThrow(/exactly one allowed origin source/);
+
+    expect(
+      () =>
+        new EmbedManager({
+          createView,
+          allowedOrigins: ["https://gw.test"],
+          getAllowedOrigins: () => ["https://gw.test"],
+        } as unknown as EmbedManagerOptions),
+    ).toThrow(/exactly one allowed origin source/);
+  });
+
   it("names partitions persist:hosted-shell and persist:app-<slug>", () => {
     const { manager, views } = makeManager();
     manager.open("hosted-shell", null, BOUNDS, "https://gw.test/canvas");

--- a/tests/desktop/embed-manager.test.ts
+++ b/tests/desktop/embed-manager.test.ts
@@ -13,9 +13,14 @@ class FakeView implements EmbedViewLike {
   loadedUrls: string[] = [];
   bounds: Bounds | null = null;
   failNextLoadError: unknown;
+  onState: (state: "loading" | "ready" | "failed") => void;
 
-  constructor(failNextLoadError: unknown = null) {
+  constructor(
+    failNextLoadError: unknown = null,
+    onState: (state: "loading" | "ready" | "failed") => void = () => undefined,
+  ) {
     this.failNextLoadError = failNextLoadError;
+    this.onState = onState;
   }
 
   setBounds(bounds: Bounds): void {
@@ -44,14 +49,18 @@ class FakeView implements EmbedViewLike {
   destroy(): void {
     this.events.push("destroy");
   }
+
+  emit(state: "loading" | "ready" | "failed"): void {
+    this.onState(state);
+  }
 }
 
 function makeManager(maxLive?: number) {
   const views: Array<{ partition: string; view: FakeView }> = [];
   let nextCreatedLoadError: unknown = null;
   const manager = new EmbedManager({
-    createView: ({ partition }) => {
-      const view = new FakeView(nextCreatedLoadError);
+    createView: ({ partition, onState }) => {
+      const view = new FakeView(nextCreatedLoadError, onState);
       nextCreatedLoadError = null;
       views.push({ partition, view });
       return view;
@@ -117,6 +126,19 @@ describe("EmbedManager", () => {
     expect(view?.events).toContain("attach");
     expect(view?.loadedUrls).toEqual(["https://gw.test/canvas"]);
     expect(view?.bounds).toEqual(BOUNDS);
+  });
+
+  it("propagates adapter lifecycle states to the caller", () => {
+    const { manager, views } = makeManager();
+    const states: string[] = [];
+    manager.open("hosted-shell", null, BOUNDS, "https://gw.test/canvas", {
+      onState: (state) => states.push(state),
+    });
+
+    views[0]?.view.emit("loading");
+    views[0]?.view.emit("ready");
+
+    expect(states).toEqual(["loading", "ready"]);
   });
 
   it("returns unique embed ids", () => {
@@ -192,6 +214,39 @@ describe("EmbedManager", () => {
 
     expect(states).toEqual(["loading"]);
     expect(views[0]?.view.loadedUrls).toEqual(["https://gw.test/", "https://gw.test/"]);
+  });
+
+  it("ignores stale loadUrl failures after a newer reload starts", async () => {
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    const states: string[] = [];
+    let rejectFirst!: (err: unknown) => void;
+    let loadCount = 0;
+    const manager = new EmbedManager({
+      createView: () => ({
+        setBounds: () => undefined,
+        loadUrl: async () => {
+          loadCount += 1;
+          if (loadCount === 1) {
+            return new Promise<void>((_resolve, reject) => {
+              rejectFirst = reject;
+            });
+          }
+        },
+        attach: () => undefined,
+        detach: () => undefined,
+        destroy: () => undefined,
+      }),
+    });
+    const id = manager.open("hosted-shell", null, BOUNDS, "https://gw.test/", {
+      onState: (state) => states.push(state),
+    });
+
+    expect(manager.reload(id)).toBe(true);
+    rejectFirst(new Error("stale navigation failed"));
+    await flush();
+
+    expect(states).toEqual(["loading"]);
+    expect(console.warn).not.toHaveBeenCalled();
   });
 
   it("does not mark aborted loadURL redirects as failed", async () => {

--- a/tests/desktop/embed-manager.test.ts
+++ b/tests/desktop/embed-manager.test.ts
@@ -222,11 +222,28 @@ describe("EmbedManager", () => {
     failNextCreatedLoad();
     const id = manager.open("app", "notes", BOUNDS, "https://gw.test/apps/notes/");
     await flush();
+    expect(views[0]?.view.events).toContain("detach");
     expect(manager.focus(id)).toBe(true);
     expect(views[0]?.view.loadedUrls).toEqual([
       "https://gw.test/apps/notes/",
       "https://gw.test/apps/notes/",
     ]);
+  });
+
+  it("detaches the native view when a live embed fails so the failed overlay is visible", async () => {
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    const states: string[] = [];
+    const { manager, views, failNextCreatedLoad } = makeManager();
+    failNextCreatedLoad();
+
+    manager.open("app", "notes", BOUNDS, "https://gw.test/apps/notes/", {
+      onState: (state) => states.push(state),
+    });
+    await flush();
+
+    expect(states).toEqual(["failed"]);
+    expect(views[0]?.view.events).toContain("detach");
+    expect(manager.liveCount).toBe(0);
   });
 
   it("reload emits loading and reloads the current url", async () => {

--- a/tests/desktop/embed-manager.test.ts
+++ b/tests/desktop/embed-manager.test.ts
@@ -115,6 +115,33 @@ describe("EmbedManager", () => {
     expect(views).toHaveLength(0);
   });
 
+  it("uses the latest allowed origins when opening after a runtime switch", () => {
+    const views: Array<{ partition: string; view: FakeView }> = [];
+    let gatewayOrigin = "https://first-gw.test";
+    const manager = new EmbedManager({
+      getAllowedOrigins: () => [gatewayOrigin],
+      createView: ({ partition, onState }) => {
+        const view = new FakeView(null, onState);
+        views.push({ partition, view });
+        return view;
+      },
+    });
+
+    const first = manager.open("hosted-shell", null, BOUNDS, "https://first-gw.test/canvas");
+    manager.closeAll();
+    gatewayOrigin = "https://second-gw.test";
+    const second = manager.open("hosted-shell", null, BOUNDS, "https://second-gw.test/canvas");
+
+    expect(first).not.toBe(second);
+    expect(views.map((entry) => entry.view.loadedUrls)).toEqual([
+      ["https://first-gw.test/canvas"],
+      ["https://second-gw.test/canvas"],
+    ]);
+    expect(() =>
+      manager.open("hosted-shell", null, BOUNDS, "https://first-gw.test/canvas"),
+    ).toThrow(/not allowed/);
+  });
+
   it("attaches, sizes, and loads new embeds", () => {
     const { manager, views } = makeManager();
     const id = manager.open("hosted-shell", null, BOUNDS, "https://gw.test/canvas");

--- a/tests/desktop/embed-manager.test.ts
+++ b/tests/desktop/embed-manager.test.ts
@@ -180,6 +180,20 @@ describe("EmbedManager", () => {
     ]);
   });
 
+  it("reload emits loading and reloads the current url", async () => {
+    const { manager, views } = makeManager();
+    const states: string[] = [];
+    const id = manager.open("hosted-shell", null, BOUNDS, "https://gw.test/", {
+      onState: (state) => states.push(state),
+    });
+
+    expect(manager.reload(id)).toBe(true);
+    await flush();
+
+    expect(states).toEqual(["loading"]);
+    expect(views[0]?.view.loadedUrls).toEqual(["https://gw.test/", "https://gw.test/"]);
+  });
+
   it("does not mark aborted loadURL redirects as failed", async () => {
     const { manager, views, failNextCreatedLoadWith } = makeManager();
     const states: string[] = [];

--- a/tests/desktop/embed-manager.test.ts
+++ b/tests/desktop/embed-manager.test.ts
@@ -12,10 +12,10 @@ class FakeView implements EmbedViewLike {
   events: string[] = [];
   loadedUrls: string[] = [];
   bounds: Bounds | null = null;
-  failNextLoad: boolean;
+  failNextLoadError: unknown;
 
-  constructor(failNextLoad = false) {
-    this.failNextLoad = failNextLoad;
+  constructor(failNextLoadError: unknown = null) {
+    this.failNextLoadError = failNextLoadError;
   }
 
   setBounds(bounds: Bounds): void {
@@ -26,9 +26,10 @@ class FakeView implements EmbedViewLike {
   async loadUrl(url: string): Promise<void> {
     this.events.push(`load:${url}`);
     this.loadedUrls.push(url);
-    if (this.failNextLoad) {
-      this.failNextLoad = false;
-      throw new Error("load failed");
+    if (this.failNextLoadError) {
+      const err = this.failNextLoadError;
+      this.failNextLoadError = null;
+      throw err;
     }
   }
 
@@ -47,11 +48,11 @@ class FakeView implements EmbedViewLike {
 
 function makeManager(maxLive?: number) {
   const views: Array<{ partition: string; view: FakeView }> = [];
-  let failNextCreatedLoad = false;
+  let nextCreatedLoadError: unknown = null;
   const manager = new EmbedManager({
     createView: ({ partition }) => {
-      const view = new FakeView(failNextCreatedLoad);
-      failNextCreatedLoad = false;
+      const view = new FakeView(nextCreatedLoadError);
+      nextCreatedLoadError = null;
       views.push({ partition, view });
       return view;
     },
@@ -62,7 +63,10 @@ function makeManager(maxLive?: number) {
     manager,
     views,
     failNextCreatedLoad: () => {
-      failNextCreatedLoad = true;
+      nextCreatedLoadError = new Error("load failed");
+    },
+    failNextCreatedLoadWith: (err: unknown) => {
+      nextCreatedLoadError = err;
     },
   };
 }
@@ -174,6 +178,20 @@ describe("EmbedManager", () => {
       "https://gw.test/apps/notes/",
       "https://gw.test/apps/notes/",
     ]);
+  });
+
+  it("does not mark aborted loadURL redirects as failed", async () => {
+    const { manager, views, failNextCreatedLoadWith } = makeManager();
+    const states: string[] = [];
+    failNextCreatedLoadWith(Object.assign(new Error("ERR_ABORTED"), { errno: -3 }));
+    const id = manager.open("app", "notes", BOUNDS, "https://gw.test/apps/notes/", {
+      onState: (state) => states.push(state),
+    });
+    await flush();
+    expect(states).toEqual([]);
+
+    expect(manager.focus(id)).toBe(true);
+    expect(views[0]?.view.loadedUrls).toEqual(["https://gw.test/apps/notes/"]);
   });
 
   it("updates bounds for live embeds", () => {

--- a/tests/desktop/embed-service.test.ts
+++ b/tests/desktop/embed-service.test.ts
@@ -10,6 +10,33 @@ vi.mock("electron", () => ({
 const BOUNDS: Bounds = { x: 0, y: 0, width: 800, height: 600 };
 
 describe("EmbedService", () => {
+  it("keeps retry auth recoverable when a pending app launch url fails origin checks", async () => {
+    const emitState = vi.fn();
+    const service = new EmbedService({
+      getWindow: () => null,
+      getGatewayOrigin: () => "https://gateway.test",
+      getToken: () => "token",
+      emitState,
+    });
+    const internals = service as unknown as {
+      pendingApps: Map<string, { slug: string; bounds: Bounds }>;
+      fetchLaunchToken: (gatewayOrigin: string, slug: string) => Promise<{ launchUrl: string; expiresAt: number } | null>;
+      manager: { open: (kind: string, slug: string | null, bounds: Bounds, url: string, options: unknown) => string };
+    };
+    const open = vi.spyOn(internals.manager, "open").mockReturnValue("embed-app");
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    vi.spyOn(internals, "fetchLaunchToken").mockResolvedValue({
+      launchUrl: "https://evil.test/apps/notes/",
+      expiresAt: Date.now() + 60_000,
+    });
+
+    internals.pendingApps.set("embed-app", { slug: "notes", bounds: BOUNDS });
+
+    await expect(service.retryAuth("embed-app")).resolves.toBe(false);
+    expect(open).not.toHaveBeenCalled();
+    expect(emitState).toHaveBeenCalledWith("embed-app", "auth-required");
+  });
+
   it("does not attach a pending app after it closes during retry auth", async () => {
     const emitState = vi.fn();
     const service = new EmbedService({

--- a/tests/desktop/embed-service.test.ts
+++ b/tests/desktop/embed-service.test.ts
@@ -63,16 +63,32 @@ describe("EmbedService", () => {
     };
     const open = vi.spyOn(internals.manager, "open").mockReturnValue("embed-app");
     vi.spyOn(console, "warn").mockImplementation(() => {});
-    vi.spyOn(internals, "fetchLaunchToken").mockResolvedValue({
-      launchUrl: "https://evil.test/apps/notes/",
-      expiresAt: Date.now() + 60_000,
-    });
+    const fetchLaunchToken = vi.spyOn(internals, "fetchLaunchToken");
+    fetchLaunchToken
+      .mockResolvedValueOnce({
+        launchUrl: "https://evil.test/apps/notes/",
+        expiresAt: Date.now() + 60_000,
+      })
+      .mockResolvedValueOnce({
+        launchUrl: "/apps/notes/",
+        expiresAt: Date.now() + 60_000,
+      });
 
     internals.pendingApps.set("embed-app", { slug: "notes", bounds: BOUNDS });
 
     await expect(service.retryAuth("embed-app")).resolves.toBe(false);
     expect(open).not.toHaveBeenCalled();
     expect(emitState).toHaveBeenCalledWith("embed-app", "auth-required");
+
+    await expect(service.retryAuth("embed-app")).resolves.toBe(true);
+    expect(fetchLaunchToken).toHaveBeenCalledTimes(2);
+    expect(open).toHaveBeenCalledWith(
+      "app",
+      "notes",
+      BOUNDS,
+      "https://gateway.test/apps/notes/",
+      expect.objectContaining({ id: "embed-app" }),
+    );
   });
 
   it("does not attach a pending app after it closes during retry auth", async () => {

--- a/tests/desktop/embed-service.test.ts
+++ b/tests/desktop/embed-service.test.ts
@@ -1,3 +1,5 @@
+import { EventEmitter } from "node:events";
+import { net } from "electron";
 import { describe, expect, it, vi } from "vitest";
 import { EmbedService } from "@desktop/main/embeds/embed-service";
 import type { Bounds } from "@desktop/main/embeds/embed-manager";
@@ -10,6 +12,42 @@ vi.mock("electron", () => ({
 const BOUNDS: Bounds = { x: 0, y: 0, width: 800, height: 600 };
 
 describe("EmbedService", () => {
+  it("rejects gateway requests when the response stream errors", async () => {
+    const service = new EmbedService({
+      getWindow: () => null,
+      getGatewayOrigin: () => "https://gateway.test",
+      getToken: () => "token",
+      emitState: vi.fn(),
+    });
+    const response = Object.assign(new EventEmitter(), {
+      headers: {},
+      statusCode: 200,
+    });
+    const request = Object.assign(new EventEmitter(), {
+      setHeader: vi.fn(),
+      abort: vi.fn(),
+      end: vi.fn(() => {
+        request.emit("response", response);
+        response.emit("error", new Error("stream reset"));
+      }),
+    });
+    vi.mocked(net.request).mockReturnValue(request as never);
+    const internals = service as unknown as {
+      gatewayRequest: (
+        url: string,
+        init: { method: string; headers: Record<string, string>; body: string },
+      ) => Promise<{ status: number; setCookieHeaders: string[]; body: string }>;
+    };
+
+    await expect(
+      internals.gatewayRequest("https://gateway.test/api/apps/notes/session-token", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: "{}",
+      }),
+    ).rejects.toThrow("stream reset");
+  });
+
   it("keeps retry auth recoverable when a pending app launch url fails origin checks", async () => {
     const emitState = vi.fn();
     const service = new EmbedService({

--- a/tests/desktop/embed-service.test.ts
+++ b/tests/desktop/embed-service.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it, vi } from "vitest";
+import { EmbedService } from "@desktop/main/embeds/embed-service";
+import type { Bounds } from "@desktop/main/embeds/embed-manager";
+
+vi.mock("electron", () => ({
+  net: { request: vi.fn() },
+  session: { fromPartition: vi.fn() },
+}));
+
+const BOUNDS: Bounds = { x: 0, y: 0, width: 800, height: 600 };
+
+describe("EmbedService", () => {
+  it("does not attach a pending app after it closes during retry auth", async () => {
+    const emitState = vi.fn();
+    const service = new EmbedService({
+      getWindow: () => null,
+      getGatewayOrigin: () => "https://gateway.test",
+      getToken: () => "token",
+      emitState,
+    });
+    const internals = service as unknown as {
+      pendingApps: Map<string, { slug: string; bounds: Bounds }>;
+      fetchLaunchToken: (gatewayOrigin: string, slug: string) => Promise<{ launchUrl: string; expiresAt: number } | null>;
+      manager: { open: (kind: string, slug: string | null, bounds: Bounds, url: string, options: unknown) => string };
+    };
+    const open = vi.spyOn(internals.manager, "open").mockReturnValue("embed-app");
+    let resolveToken!: (token: { launchUrl: string; expiresAt: number }) => void;
+    vi.spyOn(internals, "fetchLaunchToken").mockImplementation(
+      () => new Promise((resolve) => { resolveToken = resolve; }),
+    );
+
+    internals.pendingApps.set("embed-app", { slug: "notes", bounds: BOUNDS });
+    const retry = service.retryAuth("embed-app");
+    expect(service.close("embed-app")).toBe(true);
+    resolveToken({ launchUrl: "/apps/notes/", expiresAt: Date.now() + 60_000 });
+
+    await expect(retry).resolves.toBe(false);
+    expect(open).not.toHaveBeenCalled();
+    expect(emitState).not.toHaveBeenCalledWith("embed-app", "loading");
+  });
+});

--- a/tests/desktop/ipc-contract.test.ts
+++ b/tests/desktop/ipc-contract.test.ts
@@ -74,6 +74,13 @@ describe("IPC contract", () => {
     ).toBe(false);
   });
 
+  it("requires embed:open to return the initial embed state", () => {
+    const schema = INVOKE_CHANNELS["embed:open"].response;
+    expect(schema.safeParse({ embedId: "e1", state: "loading" }).success).toBe(true);
+    expect(schema.safeParse({ embedId: "e1" }).success).toBe(false);
+    expect(schema.safeParse({ embedId: "e1", state: "auth-required", token: "secret" }).success).toBe(false);
+  });
+
   it("caps state:set values at 64KB and only allows known keys", () => {
     const schema = INVOKE_CHANNELS["state:set"].request;
     expect(schema.safeParse({ key: "appearance", value: { theme: "dark" } }).success).toBe(true);

--- a/tests/desktop/ipc-handlers.test.ts
+++ b/tests/desktop/ipc-handlers.test.ts
@@ -77,8 +77,9 @@ describe("registerIpcHandlers", () => {
     );
   });
 
-  it("returns the public embed unavailable error for the phase stub", async () => {
+  it("returns the public embed unavailable error when embed open fails", async () => {
     const harness = makeHarness();
+    vi.mocked(harness.ctx.embeds.open).mockRejectedValue(new Error("native view unavailable"));
 
     await expect(
       harness.invoke("embed:open", {
@@ -87,5 +88,15 @@ describe("registerIpcHandlers", () => {
         bounds: { x: 0, y: 0, width: 640, height: 480 },
       }),
     ).rejects.toThrow("embed unavailable");
+  });
+
+  it("returns a failed retry-auth result when embed retry throws", async () => {
+    const harness = makeHarness();
+    vi.mocked(harness.ctx.embeds.retryAuth).mockRejectedValue(new Error("handoff unavailable"));
+
+    await expect(harness.invoke("embed:retry-auth", { embedId: "embed-1" })).resolves.toEqual({
+      ok: false,
+    });
+    expect(console.warn).toHaveBeenCalledWith("[ipc] embed:retry-auth failed:", "handoff unavailable");
   });
 });

--- a/tests/desktop/web-contents-view.test.ts
+++ b/tests/desktop/web-contents-view.test.ts
@@ -1,0 +1,60 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createWebContentsView } from "@desktop/main/embeds/web-contents-view";
+
+const electronMock = vi.hoisted(() => {
+  type Handler = (...args: unknown[]) => void;
+  const handlers = new Map<string, Handler>();
+  const webContents = {
+    on: vi.fn((eventName: string, handler: Handler) => {
+      handlers.set(eventName, handler);
+      return webContents;
+    }),
+    setWindowOpenHandler: vi.fn(),
+    loadURL: vi.fn(),
+    isDestroyed: vi.fn(() => false),
+    close: vi.fn(),
+  };
+  class WebContentsView {
+    webContents = webContents;
+    setBounds = vi.fn();
+  }
+  return {
+    handlers,
+    webContents,
+    shell: { openExternal: vi.fn() },
+    WebContentsView,
+  };
+});
+
+vi.mock("electron", () => electronMock);
+
+beforeEach(() => {
+  electronMock.handlers.clear();
+  electronMock.shell.openExternal.mockClear();
+});
+
+describe("createWebContentsView", () => {
+  it("blocks external server-side redirects", () => {
+    createWebContentsView({
+      window: {
+        contentView: {
+          addChildView: vi.fn(),
+          removeChildView: vi.fn(),
+        },
+      } as never,
+      partition: "persist:app-notes",
+      allowedOrigins: ["https://gateway.test"],
+      onState: vi.fn(),
+    });
+    const preventDefault = vi.fn();
+
+    const redirectCall = electronMock.webContents.on.mock.calls.find(
+      ([eventName]) => eventName === "will-redirect",
+    );
+    expect(redirectCall).toBeTruthy();
+    redirectCall?.[1]({ preventDefault }, "https://evil.test/phish");
+
+    expect(preventDefault).toHaveBeenCalledOnce();
+    expect(electronMock.shell.openExternal).toHaveBeenCalledWith("https://evil.test/phish");
+  });
+});


### PR DESCRIPTION
## Summary
- Wires native app embeds into the renderer and applies react-doctor cleanup.
- Part of the 094 Operator desktop stack split from original PR #507.
- Draft until the full stack validation and screenshots are refreshed.

## Validation
- Rebased onto current main after #506 merged.
- Rebuilt stack final tree matches the original #507 tree exactly.
- Per-layer CI/Greptile still needs to settle before review-ready.

## Invariants
- Source of truth: desktop app source under desktop/, specs/docs, and root workspace metadata in this stack; no owner runtime data is modified.
- Lock/transaction scope: no Postgres transaction scope is introduced in this layer; desktop local state remains scoped to the Electron app and existing gateway/platform APIs.
- Acceptable orphan states: stack PRs are draft and must land in order; partial stack landing is not a supported release state.
- Auth source of truth: Clerk/device auth and existing gateway token handling remain authoritative; this stack does not add a second auth authority.
- Deferred scope: packaged distribution, production desktop rollout, and customer VPS host-bundle deploy are outside this stack.