### PR TITLE
feat(desktop): add terminal tabs and auth readiness

### DIFF
--- a/desktop/src/main/auth/auth-service.ts
+++ b/desktop/src/main/auth/auth-service.ts
@@ -33,7 +33,6 @@ interface AuthServiceDeps {
   credentialStore: CredentialStore;
   platformHost: string;
   fetchFn?: FetchFn;
-  openExternal: (url: string) => Promise<void>;
   loadProfile: () => Promise<ConnectionProfile | null>;
   saveProfile: (profile: ConnectionProfile) => Promise<void>;
   clearProfile: () => Promise<void>;
@@ -193,13 +192,10 @@ export class AuthService {
         this.pendingDeviceCode = null;
       });
 
-    void this.deps.openExternal(code.verificationUri).catch((err: unknown) => {
-      console.warn(
-        "[auth] failed to open verification url:",
-        err instanceof Error ? err.message : String(err),
-      );
-    });
-
+    // Do NOT auto-open the browser. The renderer shows the user code and an
+    // explicit "Open approval page" button (shell:open-external) — auto-opening
+    // popped a surprise tab on every launch (and on every e2e run, which points
+    // at a stub whose verification URL is unroutable).
     return pendingDeviceCode;
   }
 

--- a/desktop/src/main/auth/auth-service.ts
+++ b/desktop/src/main/auth/auth-service.ts
@@ -13,6 +13,9 @@ export interface ConnectionProfile {
   userId: string;
   platformHost: string;
   runtimeSlot: string;
+  displayName?: string;
+  imageUrl?: string;
+  email?: string;
 }
 
 export interface AuthStatus {
@@ -20,6 +23,8 @@ export interface AuthStatus {
   handle?: string;
   runtimeSlot: string;
   platformHost: string;
+  displayName?: string;
+  imageUrl?: string;
 }
 
 export type PollResult = {
@@ -96,6 +101,8 @@ export class AuthService {
     return {
       signedIn,
       ...(signedIn && this.profile ? { handle: this.profile.handle } : {}),
+      ...(signedIn && this.profile?.displayName ? { displayName: this.profile.displayName } : {}),
+      ...(signedIn && this.profile?.imageUrl ? { imageUrl: this.profile.imageUrl } : {}),
       runtimeSlot: this.profile?.runtimeSlot ?? "primary",
       platformHost: this.getGatewayOrigin(),
     };
@@ -135,17 +142,28 @@ export class AuthService {
     })
       .then(async (token) => {
         if (nonce !== this.flowNonce) return;
-        const profile = {
+        // The encrypted credential holds only the secret token + identity; the
+        // non-secret display profile lives in the plain profile store.
+        const credential: StoredCredential = {
+          accessToken: token.accessToken,
+          expiresAt: token.expiresAt,
+          userId: token.userId,
+          handle: token.handle,
+        };
+        this.credential = credential;
+        const profile: ConnectionProfile = {
           handle: token.handle,
           userId: token.userId,
           platformHost: baseUrl,
           runtimeSlot: this.profile?.runtimeSlot ?? "primary",
+          ...(token.displayName ? { displayName: token.displayName } : {}),
+          ...(token.imageUrl ? { imageUrl: token.imageUrl } : {}),
+          ...(token.email ? { email: token.email } : {}),
         };
-        this.credential = token;
         this.profile = profile;
         try {
           if (nonce !== this.flowNonce) return;
-          await this.deps.credentialStore.save(token);
+          await this.deps.credentialStore.save(credential);
           if (nonce !== this.flowNonce) {
             await this.clearStaleFlowPersistence();
             return;

--- a/desktop/src/main/auth/auth-service.ts
+++ b/desktop/src/main/auth/auth-service.ts
@@ -34,10 +34,15 @@ export type PollResult = {
 
 type FetchFn = (input: string, init?: RequestInit) => Promise<Response>;
 
+// Re-authenticate slightly before the token's real expiry so an in-flight
+// request doesn't race the cutoff.
+const EXPIRY_SKEW_MS = 30_000;
+
 interface AuthServiceDeps {
   credentialStore: CredentialStore;
   platformHost: string;
   fetchFn?: FetchFn;
+  now?: () => number;
   loadProfile: () => Promise<ConnectionProfile | null>;
   saveProfile: (profile: ConnectionProfile) => Promise<void>;
   clearProfile: () => Promise<void>;
@@ -59,9 +64,8 @@ export class AuthService {
   async init(): Promise<void> {
     this.credential = await this.deps.credentialStore.load();
     this.profile = await this.deps.loadProfile();
-    if (this.credential && !this.isCredentialValid(this.credential)) {
+    if (this.isExpired()) {
       this.credential = null;
-      this.profile = null;
       try {
         await this.deps.credentialStore.clear();
       } catch (err: unknown) {
@@ -70,15 +74,17 @@ export class AuthService {
           err instanceof Error ? err.message : String(err),
         );
       }
-      try {
-        await this.deps.clearProfile();
-      } catch (err: unknown) {
-        console.warn(
-          "[auth] failed to clear expired profile:",
-          err instanceof Error ? err.message : String(err),
-        );
-      }
     }
+  }
+
+  private now(): number {
+    return this.deps.now ? this.deps.now() : Date.now();
+  }
+
+  // A credential past (or within the skew window of) its expiry is unusable;
+  // sending it would just earn a 401, so treat it as signed-out.
+  private isExpired(): boolean {
+    return this.credential !== null && this.credential.expiresAt <= this.now() + EXPIRY_SKEW_MS;
   }
 
   getToken(): string | null {
@@ -97,7 +103,7 @@ export class AuthService {
   }
 
   private currentStatus(): AuthStatus {
-    const signedIn = this.credential !== null && this.isCredentialValid(this.credential);
+    const signedIn = this.credential !== null && !this.isExpired();
     return {
       signedIn,
       ...(signedIn && this.profile ? { handle: this.profile.handle } : {}),
@@ -234,6 +240,17 @@ export class AuthService {
     await this.deps.saveProfile(this.profile);
   }
 
+  // The session token expired or the gateway rejected it (401). Drop the
+  // credential but KEEP the profile so platformHost/runtime survive for a
+  // one-click re-auth, then notify the renderer to show sign-in. Idempotent.
+  async expireSession(): Promise<void> {
+    if (!this.credential) return;
+    this.credential = null;
+    this.flowState = "idle";
+    await this.deps.credentialStore.clear();
+    this.deps.onAuthChanged(this.getStatus());
+  }
+
   async signOut(): Promise<void> {
     this.flowNonce += 1;
     this.pendingDeviceCode = null;
@@ -283,27 +300,16 @@ export class AuthService {
     }
   }
 
-  private isCredentialValid(credential: StoredCredential): boolean {
-    return credential.expiresAt > Date.now();
-  }
-
   private expireCredentialIfNeeded(): void {
-    if (!this.credential || this.isCredentialValid(this.credential)) return;
+    if (!this.isExpired()) return;
     this.flowNonce += 1;
     this.pendingDeviceCode = null;
     this.credential = null;
-    this.profile = null;
     this.flowState = "idle";
     this.deps.onAuthChanged(this.currentStatus());
     void this.deps.credentialStore.clear().catch((err: unknown) => {
       console.warn(
         "[auth] failed to clear expired credential:",
-        err instanceof Error ? err.message : String(err),
-      );
-    });
-    void this.deps.clearProfile().catch((err: unknown) => {
-      console.warn(
-        "[auth] failed to clear expired profile:",
         err instanceof Error ? err.message : String(err),
       );
     });

--- a/desktop/src/main/auth/auth-service.ts
+++ b/desktop/src/main/auth/auth-service.ts
@@ -247,8 +247,19 @@ export class AuthService {
     if (!this.credential) return;
     this.credential = null;
     this.flowState = "idle";
-    await this.deps.credentialStore.clear();
-    this.deps.onAuthChanged(this.getStatus());
+    let cleanupError: unknown = null;
+    try {
+      await this.deps.credentialStore.clear();
+    } catch (err: unknown) {
+      cleanupError = err;
+      console.warn(
+        "[auth] failed to clear expired credential:",
+        err instanceof Error ? err.message : String(err),
+      );
+    } finally {
+      this.deps.onAuthChanged(this.getStatus());
+    }
+    if (cleanupError) throw cleanupError;
   }
 
   async signOut(): Promise<void> {

--- a/desktop/src/main/auth/auth-service.ts
+++ b/desktop/src/main/auth/auth-service.ts
@@ -247,11 +247,9 @@ export class AuthService {
     if (!this.credential) return;
     this.credential = null;
     this.flowState = "idle";
-    let cleanupError: unknown = null;
     try {
       await this.deps.credentialStore.clear();
     } catch (err: unknown) {
-      cleanupError = err;
       console.warn(
         "[auth] failed to clear expired credential:",
         err instanceof Error ? err.message : String(err),
@@ -259,7 +257,6 @@ export class AuthService {
     } finally {
       this.deps.onAuthChanged(this.getStatus());
     }
-    if (cleanupError) throw cleanupError;
   }
 
   async signOut(): Promise<void> {

--- a/desktop/src/main/auth/device-auth.ts
+++ b/desktop/src/main/auth/device-auth.ts
@@ -21,6 +21,12 @@ export interface DeviceTokenResponse {
   expiresAt: number;
   userId: string;
   handle: string;
+  // Optional, non-secret display profile (sidebar avatar/name). The platform
+  // fills these from Clerk; absent for older gateways or when the profile
+  // lookup degraded, so every consumer must treat them as optional.
+  displayName?: string;
+  imageUrl?: string;
+  email?: string;
 }
 
 export class DeviceFlowError extends Error {
@@ -112,7 +118,17 @@ export async function pollForToken(options: {
       ) {
         throw new AppError("server");
       }
-      return { accessToken, expiresAt, userId, handle };
+      const optionalString = (value: unknown): string | undefined =>
+        typeof value === "string" && value.length > 0 ? value : undefined;
+      return {
+        accessToken,
+        expiresAt,
+        userId,
+        handle,
+        ...(optionalString(data.displayName) ? { displayName: optionalString(data.displayName) } : {}),
+        ...(optionalString(data.imageUrl) ? { imageUrl: optionalString(data.imageUrl) } : {}),
+        ...(optionalString(data.email) ? { email: optionalString(data.email) } : {}),
+      };
     }
 
     if (response.status === 410) throw new DeviceFlowError("expired");

--- a/desktop/src/main/auth/header-injection.ts
+++ b/desktop/src/main/auth/header-injection.ts
@@ -90,7 +90,7 @@ export function installGatewayCors(
     }
     responseHeaders["Access-Control-Allow-Origin"] = [rendererOrigin];
     responseHeaders["Access-Control-Allow-Methods"] = ["GET, POST, PATCH, PUT, DELETE, OPTIONS"];
-    responseHeaders["Access-Control-Allow-Headers"] = ["Authorization, Content-Type"];
+    responseHeaders["Access-Control-Allow-Headers"] = ["Authorization, Content-Type, x-runtime-slot"];
     responseHeaders["Access-Control-Allow-Credentials"] = ["true"];
     if (details.method === "OPTIONS") {
       callback({ responseHeaders, statusLine: "HTTP/1.1 200 OK" });

--- a/desktop/src/main/auth/header-injection.ts
+++ b/desktop/src/main/auth/header-injection.ts
@@ -78,11 +78,20 @@ export function installGatewayCors(
     }
     const responseHeaders: Record<string, string[]> = {};
     for (const [key, value] of Object.entries(details.responseHeaders ?? {})) {
-      if (!key.toLowerCase().startsWith("access-control-")) responseHeaders[key] = value;
+      const lower = key.toLowerCase();
+      if (
+        lower !== "access-control-allow-origin" &&
+        lower !== "access-control-allow-methods" &&
+        lower !== "access-control-allow-headers" &&
+        lower !== "access-control-allow-credentials"
+      ) {
+        responseHeaders[key] = value;
+      }
     }
     responseHeaders["Access-Control-Allow-Origin"] = [rendererOrigin];
     responseHeaders["Access-Control-Allow-Methods"] = ["GET, POST, PATCH, PUT, DELETE, OPTIONS"];
     responseHeaders["Access-Control-Allow-Headers"] = ["Authorization, Content-Type"];
+    responseHeaders["Access-Control-Allow-Credentials"] = ["true"];
     if (details.method === "OPTIONS") {
       callback({ responseHeaders, statusLine: "HTTP/1.1 200 OK" });
       return;

--- a/desktop/src/main/auth/header-injection.ts
+++ b/desktop/src/main/auth/header-injection.ts
@@ -11,6 +11,12 @@ interface WebRequestLike {
       callback: (response: { requestHeaders: Record<string, string> }) => void,
     ) => void,
   ): void;
+  onHeadersReceived(
+    listener: (
+      details: { url: string; method: string; responseHeaders?: Record<string, string[]> },
+      callback: (response: { responseHeaders?: Record<string, string[]>; statusLine?: string }) => void,
+    ) => void,
+  ): void;
 }
 
 interface SessionLike {
@@ -51,5 +57,36 @@ export function installHeaderInjection(
       details.requestHeaders["Authorization"] = `Bearer ${token}`;
     }
     callback({ requestHeaders: details.requestHeaders });
+  });
+}
+
+// The renderer (file:// in production, http://localhost in dev) is a different
+// origin than the gateway, so its fetch() calls are cross-origin and the
+// gateway does not send Access-Control-Allow-Origin for them. Since the trusted
+// core owns the network layer, we inject CORS response headers for the gateway
+// origin on the renderer session only — scoped to our own backend, never a
+// server-side wildcard. Preflight OPTIONS are answered 200 so mutations pass.
+export function installGatewayCors(
+  rendererSession: SessionLike,
+  getGatewayOrigin: () => string | null,
+  rendererOrigin: string,
+): void {
+  rendererSession.webRequest.onHeadersReceived((details, callback) => {
+    if (!shouldInjectAuth(details.url, getGatewayOrigin())) {
+      callback({});
+      return;
+    }
+    const responseHeaders: Record<string, string[]> = {};
+    for (const [key, value] of Object.entries(details.responseHeaders ?? {})) {
+      if (!key.toLowerCase().startsWith("access-control-")) responseHeaders[key] = value;
+    }
+    responseHeaders["Access-Control-Allow-Origin"] = [rendererOrigin];
+    responseHeaders["Access-Control-Allow-Methods"] = ["GET, POST, PATCH, PUT, DELETE, OPTIONS"];
+    responseHeaders["Access-Control-Allow-Headers"] = ["Authorization, Content-Type"];
+    if (details.method === "OPTIONS") {
+      callback({ responseHeaders, statusLine: "HTTP/1.1 200 OK" });
+      return;
+    }
+    callback({ responseHeaders });
   });
 }

--- a/desktop/src/main/embeds/embed-manager.ts
+++ b/desktop/src/main/embeds/embed-manager.ts
@@ -140,6 +140,30 @@ export class EmbedManager {
     return true;
   }
 
+  // Show or hide an embed by attaching/detaching its native view from the
+  // window. Detaching is what actually removes the overlay — a WebContentsView
+  // always paints above the renderer, so bounds tricks can't hide it.
+  setActive(embedId: string, active: boolean): boolean {
+    const record = this.records.get(embedId);
+    if (!record) return false;
+    if (active) {
+      if (!record.live) {
+        record.view.attach();
+        record.live = true;
+      }
+      record.lastUsed = ++this.tick;
+      if (record.loadFailed) {
+        record.loadFailed = false;
+        this.loadInto(record);
+      }
+      this.enforceMaxLive();
+    } else if (record.live) {
+      record.view.detach();
+      record.live = false;
+    }
+    return true;
+  }
+
   focus(embedId: string): boolean {
     const record = this.records.get(embedId);
     if (!record) return false;

--- a/desktop/src/main/embeds/embed-manager.ts
+++ b/desktop/src/main/embeds/embed-manager.ts
@@ -85,7 +85,7 @@ export class EmbedManager {
     slug: string | null,
     bounds: Bounds,
     url: string,
-    options?: { id?: string; onState?: (state: "loading" | "ready" | "failed") => void },
+    options?: { id?: string; active?: boolean; onState?: (state: "loading" | "ready" | "failed") => void },
   ): string {
     if (!isNavigationAllowed(url, this.getAllowedOrigins())) {
       throw new Error("embed URL is not allowed");
@@ -97,6 +97,7 @@ export class EmbedManager {
         : this.appPartition(slug);
 
     const id = options?.id ?? randomUUID();
+    const active = options?.active ?? true;
     if (this.records.has(id)) throw new Error("embed id already exists");
     const onState = options?.onState ?? (() => undefined);
     let record: EmbedRecord | null = null;
@@ -117,13 +118,13 @@ export class EmbedManager {
       id,
       url,
       view,
-      live: true,
+      live: active,
       loadFailed: false,
       loadGeneration: 0,
       lastUsed: ++this.tick,
       onState: emitState,
     };
-    view.attach();
+    if (active) view.attach();
     view.setBounds(bounds);
     this.records.set(id, record);
     this.loadInto(record);

--- a/desktop/src/main/embeds/embed-service.ts
+++ b/desktop/src/main/embeds/embed-service.ts
@@ -78,6 +78,10 @@ export class EmbedService {
     return this.manager.setBounds(embedId, bounds);
   }
 
+  setActive(embedId: string, active: boolean): boolean {
+    return this.manager.setActive(embedId, active);
+  }
+
   close(embedId: string): boolean {
     const wasPending = this.pendingHostedShells.delete(embedId);
     const wasPendingApp = this.pendingApps.delete(embedId);

--- a/desktop/src/main/embeds/embed-service.ts
+++ b/desktop/src/main/embeds/embed-service.ts
@@ -47,6 +47,7 @@ export class EmbedService {
   private readonly deps: EmbedServiceDeps;
   private readonly pendingHostedShells = new Map<string, Bounds>();
   private readonly pendingApps = new Map<string, PendingAppEmbed>();
+  private readonly pendingActive = new Map<string, boolean>();
   private readonly hostedShellIds = new Set<string>();
 
   constructor(deps: EmbedServiceDeps) {
@@ -80,12 +81,17 @@ export class EmbedService {
   }
 
   setActive(embedId: string, active: boolean): boolean {
-    return this.manager.setActive(embedId, active);
+    const pending = this.pendingHostedShells.has(embedId) || this.pendingApps.has(embedId);
+    if (pending) {
+      this.pendingActive.set(embedId, active);
+    }
+    return this.manager.setActive(embedId, active) || pending;
   }
 
   close(embedId: string): boolean {
     const wasPending = this.pendingHostedShells.delete(embedId);
     const wasPendingApp = this.pendingApps.delete(embedId);
+    this.pendingActive.delete(embedId);
     this.hostedShellIds.delete(embedId);
     return this.manager.close(embedId) || wasPending || wasPendingApp;
   }
@@ -93,6 +99,7 @@ export class EmbedService {
   closeAll(): void {
     this.pendingHostedShells.clear();
     this.pendingApps.clear();
+    this.pendingActive.clear();
     this.hostedShellIds.clear();
     this.tokenCache.clear();
     this.manager.closeAll();
@@ -112,8 +119,10 @@ export class EmbedService {
         return false;
       }
       if (!this.pendingHostedShells.has(embedId)) return false;
-      this.attachHostedShellEmbed(gatewayOrigin, bounds, embedId);
+      const active = this.pendingActive.get(embedId) ?? true;
+      this.attachHostedShellEmbed(gatewayOrigin, bounds, embedId, active);
       this.pendingHostedShells.delete(embedId);
+      this.pendingActive.delete(embedId);
       this.hostedShellIds.add(embedId);
       this.deps.emitState(embedId, "loading");
       return true;
@@ -125,7 +134,7 @@ export class EmbedService {
         pending.slug,
         pending.bounds,
         embedId,
-        true,
+        this.pendingActive.get(embedId) ?? true,
         () => this.pendingApps.has(embedId),
       );
       if (!opened) {
@@ -133,6 +142,7 @@ export class EmbedService {
         return false;
       }
       this.pendingApps.delete(embedId);
+      this.pendingActive.delete(embedId);
       this.deps.emitState(embedId, "loading");
       return true;
     }
@@ -177,19 +187,21 @@ export class EmbedService {
     const embedId = randomUUID();
     const opened = await this.createHostedShellEmbed(gatewayOrigin, bounds, embedId, active);
     if (!opened) {
-      this.rememberPendingHostedShell(embedId, bounds);
+      this.rememberPendingHostedShell(embedId, bounds, active);
       return { embedId, state: "auth-required" };
     }
     this.hostedShellIds.add(embedId);
     return { embedId, state: "loading" };
   }
 
-  private rememberPendingHostedShell(embedId: string, bounds: Bounds): void {
+  private rememberPendingHostedShell(embedId: string, bounds: Bounds, active: boolean): void {
     this.pendingHostedShells.set(embedId, bounds);
+    this.pendingActive.set(embedId, active);
     while (this.pendingHostedShells.size > MAX_PENDING_HOSTED_SHELLS) {
       const oldest = this.pendingHostedShells.keys().next().value as string | undefined;
       if (!oldest) break;
       this.pendingHostedShells.delete(oldest);
+      this.pendingActive.delete(oldest);
     }
   }
 
@@ -235,18 +247,20 @@ export class EmbedService {
     const embedId = randomUUID();
     const opened = await this.createAppEmbed(gatewayOrigin, slug, bounds, embedId, active);
     if (!opened) {
-      this.rememberPendingApp(embedId, { slug, bounds });
+      this.rememberPendingApp(embedId, { slug, bounds }, active);
       return { embedId, state: "auth-required" };
     }
     return { embedId, state: "loading" };
   }
 
-  private rememberPendingApp(embedId: string, pending: PendingAppEmbed): void {
+  private rememberPendingApp(embedId: string, pending: PendingAppEmbed, active: boolean): void {
     this.pendingApps.set(embedId, pending);
+    this.pendingActive.set(embedId, active);
     while (this.pendingApps.size > MAX_PENDING_APPS) {
       const oldest = this.pendingApps.keys().next().value as string | undefined;
       if (!oldest) break;
       this.pendingApps.delete(oldest);
+      this.pendingActive.delete(oldest);
     }
   }
 

--- a/desktop/src/main/embeds/embed-service.ts
+++ b/desktop/src/main/embeds/embed-service.ts
@@ -25,6 +25,7 @@ interface OpenRequest {
   kind: "hosted-shell" | "app";
   slug?: string;
   bounds: Bounds;
+  active?: boolean;
 }
 
 interface OpenResult {
@@ -69,9 +70,9 @@ export class EmbedService {
   async open(request: OpenRequest): Promise<OpenResult> {
     const gatewayOrigin = this.deps.getGatewayOrigin();
     if (request.kind === "hosted-shell") {
-      return this.openHostedShell(gatewayOrigin, request.bounds);
+      return this.openHostedShell(gatewayOrigin, request.bounds, request.active ?? true);
     }
-    return this.openApp(gatewayOrigin, request.slug ?? "", request.bounds);
+    return this.openApp(gatewayOrigin, request.slug ?? "", request.bounds, request.active ?? true);
   }
 
   setBounds(embedId: string, bounds: Bounds): boolean {
@@ -124,6 +125,7 @@ export class EmbedService {
         pending.slug,
         pending.bounds,
         embedId,
+        true,
         () => this.pendingApps.has(embedId),
       );
       if (!opened) {
@@ -171,9 +173,9 @@ export class EmbedService {
     };
   }
 
-  private async openHostedShell(gatewayOrigin: string, bounds: Bounds): Promise<OpenResult> {
+  private async openHostedShell(gatewayOrigin: string, bounds: Bounds, active: boolean): Promise<OpenResult> {
     const embedId = randomUUID();
-    const opened = await this.createHostedShellEmbed(gatewayOrigin, bounds, embedId);
+    const opened = await this.createHostedShellEmbed(gatewayOrigin, bounds, embedId, active);
     if (!opened) {
       this.rememberPendingHostedShell(embedId, bounds);
       return { embedId, state: "auth-required" };
@@ -195,10 +197,11 @@ export class EmbedService {
     gatewayOrigin: string,
     bounds: Bounds,
     embedId: string,
+    active: boolean,
   ): Promise<boolean> {
     const handoff = await this.performHostedShellHandoff(gatewayOrigin);
     if (!handoff) return false;
-    this.attachHostedShellEmbed(gatewayOrigin, bounds, embedId);
+    this.attachHostedShellEmbed(gatewayOrigin, bounds, embedId, active);
     return true;
   }
 
@@ -206,10 +209,12 @@ export class EmbedService {
     gatewayOrigin: string,
     bounds: Bounds,
     embedId: string,
+    active = true,
   ): void {
     const url = `${gatewayOrigin}/`;
     this.manager.open("hosted-shell", null, bounds, url, {
       id: embedId,
+      active,
       onState: (state) => this.deps.emitState(embedId, state),
     });
   }
@@ -226,9 +231,9 @@ export class EmbedService {
     return handoff.ok;
   }
 
-  private async openApp(gatewayOrigin: string, slug: string, bounds: Bounds): Promise<OpenResult> {
+  private async openApp(gatewayOrigin: string, slug: string, bounds: Bounds, active: boolean): Promise<OpenResult> {
     const embedId = randomUUID();
-    const opened = await this.createAppEmbed(gatewayOrigin, slug, bounds, embedId);
+    const opened = await this.createAppEmbed(gatewayOrigin, slug, bounds, embedId, active);
     if (!opened) {
       this.rememberPendingApp(embedId, { slug, bounds });
       return { embedId, state: "auth-required" };
@@ -250,6 +255,7 @@ export class EmbedService {
     slug: string,
     bounds: Bounds,
     embedId: string,
+    active = true,
     shouldAttach: () => boolean = () => true,
   ): Promise<boolean> {
     let cached = this.tokenCache.get(slug);
@@ -270,6 +276,7 @@ export class EmbedService {
     }
     this.manager.open("app", slug, bounds, resolved, {
       id: embedId,
+      active,
       onState: (state) => this.deps.emitState(embedId, state),
     });
     return true;

--- a/desktop/src/main/index.ts
+++ b/desktop/src/main/index.ts
@@ -159,6 +159,19 @@ if (!gotLock) {
         getToken: () => auth.getToken(),
         emitState: (embedId, state) => sendEvent("embed:state", { embedId, state }),
       });
+      const updater = createUpdater({
+        onAvailable: (version) => {
+          console.info(`[updates] downloading Matrix OS ${version}`);
+        },
+        onReady: (version) => {
+          if (!Notification.isSupported()) return;
+          new Notification({
+            title: "Matrix OS update ready",
+            body: `Version ${version} will install after you quit and reopen the app.`,
+            silent: false,
+          }).show();
+        },
+      });
 
       registerIpcHandlers(ipcMain, {
         auth,
@@ -184,6 +197,7 @@ if (!gotLock) {
           embeds.closeAll();
           sendEvent("runtime:changed", { slot });
         },
+        getUpdateStatus: () => updater.status(),
       });
 
       let boundsSaveTimer: ReturnType<typeof setTimeout> | null = null;
@@ -216,19 +230,6 @@ if (!gotLock) {
       await openMainWindow();
       installAppMenu(() => mainWindow);
 
-      const updater = createUpdater({
-        onAvailable: (version) => {
-          console.info(`[updates] downloading Matrix OS ${version}`);
-        },
-        onReady: (version) => {
-          if (!Notification.isSupported()) return;
-          new Notification({
-            title: "Matrix OS update ready",
-            body: `Version ${version} will install after you quit and reopen the app.`,
-            silent: false,
-          }).show();
-        },
-      });
       void updater.check();
       updateCheckTimer = setInterval(() => {
         void updater.check();

--- a/desktop/src/main/index.ts
+++ b/desktop/src/main/index.ts
@@ -95,6 +95,112 @@ if (!gotLock) {
     if (win) {
       if (win.isMinimized()) win.restore();
       win.focus();
+<<<<<<< HEAD
+=======
+=======
+app.whenReady().then(async () => {
+  const userData = app.getPath("userData");
+  const store = createLocalStore({ dir: userData });
+  const credentialStore = createCredentialStore({ dir: userData, safeStorage });
+
+  const platformHost = process.env.OPERATOR_GATEWAY_URL ?? DEFAULT_PLATFORM_HOST;
+
+  const auth = new AuthService({
+    credentialStore,
+    platformHost,
+    loadProfile: () => store.get("profile"),
+    saveProfile: (profile) => store.set("profile", profile),
+    clearProfile: () => store.delete("profile"),
+    onAuthChanged: (status) => {
+      sendEvent("auth:changed", {
+        signedIn: status.signedIn,
+        ...(status.handle ? { handle: status.handle } : {}),
+        ...(status.displayName ? { displayName: status.displayName } : {}),
+        ...(status.imageUrl ? { imageUrl: status.imageUrl } : {}),
+      });
+    },
+  });
+  await auth.init();
+
+  // Renderer session gets origin-scoped bearer injection; embed partitions
+  // (separate sessions) never do (lesson L1).
+  installHeaderInjection(
+    session.defaultSession,
+    () => auth.getToken(),
+    () => auth.getGatewayOrigin(),
+  );
+  // The renderer is a different origin than the gateway (file:// in prod,
+  // localhost in dev), so allow its cross-origin fetches to the gateway.
+  const rendererOrigin = process.env.ELECTRON_RENDERER_URL
+    ? new URL(process.env.ELECTRON_RENDERER_URL).origin
+    : "null";
+  installGatewayCors(session.defaultSession, () => auth.getGatewayOrigin(), rendererOrigin);
+
+  const embeds = new EmbedService({
+    getWindow: () => mainWindow,
+    getGatewayOrigin: () => auth.getGatewayOrigin(),
+    getToken: () => auth.getToken(),
+    emitState: (embedId, state) => sendEvent("embed:state", { embedId, state }),
+  });
+
+  registerIpcHandlers(ipcMain, {
+    auth,
+    store,
+    embeds,
+    openExternal: openExternalHttps,
+    setBadgeCount: (count) => {
+      app.setBadgeCount(count);
+    },
+    notify: ({ threadId, title, body }) => {
+      if (!Notification.isSupported()) return;
+      const notification = new Notification({ title, body, silent: false });
+      notification.on("click", () => {
+        mainWindow?.show();
+        mainWindow?.focus();
+        sendEvent("notification:clicked", { threadId });
+      });
+      notification.show();
+    },
+    onRuntimeChanged: (slot) => {
+      // Switching runtime invalidates embed cookies/tokens; tear them down so
+      // they re-handshake against the new slot (Integration Wiring rule).
+      embeds.closeAll();
+      sendEvent("runtime:changed", { slot });
+    },
+  });
+
+  const savedBounds = await store.get("windowBounds");
+  mainWindow = createWindow(savedBounds ?? { width: 1280, height: 820 });
+  installAppMenu(() => mainWindow);
+
+  let boundsSaveTimer: ReturnType<typeof setTimeout> | null = null;
+  const persistBounds = () => {
+    if (boundsSaveTimer) clearTimeout(boundsSaveTimer);
+    boundsSaveTimer = setTimeout(() => {
+      if (!mainWindow || mainWindow.isDestroyed()) return;
+      const b = mainWindow.getBounds();
+      void store
+        .set("windowBounds", { x: b.x, y: b.y, width: b.width, height: b.height })
+        .catch((err: unknown) => {
+          console.warn(
+            "[main] failed to persist window bounds:",
+            err instanceof Error ? err.message : String(err),
+          );
+        });
+    }, 500);
+  };
+  mainWindow.on("resize", persistBounds);
+  mainWindow.on("move", persistBounds);
+  mainWindow.on("closed", () => {
+    if (boundsSaveTimer) clearTimeout(boundsSaveTimer);
+    mainWindow = null;
+  });
+
+  app.on("activate", () => {
+    if (BrowserWindow.getAllWindows().length === 0) {
+      mainWindow = createWindow({ width: 1280, height: 820 });
+>>>>>>> a180ce0fa (fix(desktop): stop auto-opening the device-auth browser; brand focus ring; Matrix OS name)
+>>>>>>> 70ce804b5 (feat(desktop): surface Clerk display name + avatar in the sidebar profile)
     }
   });
 

--- a/desktop/src/main/index.ts
+++ b/desktop/src/main/index.ts
@@ -2,7 +2,7 @@ import { app, BrowserWindow, ipcMain, Notification, safeStorage, session, shell 
 import { join } from "node:path";
 import { AuthService } from "./auth/auth-service";
 import { createCredentialStore } from "./auth/credential-store";
-import { installHeaderInjection } from "./auth/header-injection";
+import { installGatewayCors, installHeaderInjection } from "./auth/header-injection";
 import { EmbedService } from "./embeds/embed-service";
 import { registerIpcHandlers } from "./ipc/handlers";
 import { createLocalStore } from "./persistence/local-store";
@@ -130,6 +130,12 @@ if (!gotLock) {
         () => auth.getToken(),
         () => auth.getGatewayOrigin(),
       );
+      // The renderer is a different origin than the gateway (file:// in prod,
+      // localhost in dev), so allow its cross-origin fetches to the gateway.
+      const rendererOrigin = process.env.ELECTRON_RENDERER_URL
+        ? new URL(process.env.ELECTRON_RENDERER_URL).origin
+        : "null";
+      installGatewayCors(session.defaultSession, () => auth.getGatewayOrigin(), rendererOrigin);
 
       const embeds = new EmbedService({
         getWindow: () => mainWindow,

--- a/desktop/src/main/index.ts
+++ b/desktop/src/main/index.ts
@@ -7,6 +7,7 @@ import { EmbedService } from "./embeds/embed-service";
 import { registerIpcHandlers } from "./ipc/handlers";
 import { createLocalStore } from "./persistence/local-store";
 import { installAppMenu } from "./platform/menu";
+import { createUpdater } from "./updates";
 import { EVENT_CHANNELS, type EventChannel, type EventPayload } from "../shared/ipc-contract";
 
 const DEFAULT_PLATFORM_HOST = "https://app.matrix-os.com";
@@ -18,6 +19,7 @@ if (process.env.OPERATOR_USER_DATA_DIR) {
 }
 
 let mainWindow: BrowserWindow | null = null;
+let updateCheckTimer: ReturnType<typeof setInterval> | null = null;
 
 function sendEvent<C extends EventChannel>(channel: C, payload: EventPayload<C>): void {
   const parsed = EVENT_CHANNELS[channel].safeParse(payload);
@@ -95,118 +97,25 @@ if (!gotLock) {
     if (win) {
       if (win.isMinimized()) win.restore();
       win.focus();
-<<<<<<< HEAD
-=======
-=======
-app.whenReady().then(async () => {
-  const userData = app.getPath("userData");
-  const store = createLocalStore({ dir: userData });
-  const credentialStore = createCredentialStore({ dir: userData, safeStorage });
-
-  const platformHost = process.env.OPERATOR_GATEWAY_URL ?? DEFAULT_PLATFORM_HOST;
-
-  const auth = new AuthService({
-    credentialStore,
-    platformHost,
-    loadProfile: () => store.get("profile"),
-    saveProfile: (profile) => store.set("profile", profile),
-    clearProfile: () => store.delete("profile"),
-    onAuthChanged: (status) => {
-      sendEvent("auth:changed", {
-        signedIn: status.signedIn,
-        ...(status.handle ? { handle: status.handle } : {}),
-        ...(status.displayName ? { displayName: status.displayName } : {}),
-        ...(status.imageUrl ? { imageUrl: status.imageUrl } : {}),
-      });
-    },
-  });
-  await auth.init();
-
-  // Renderer session gets origin-scoped bearer injection; embed partitions
-  // (separate sessions) never do (lesson L1).
-  installHeaderInjection(
-    session.defaultSession,
-    () => auth.getToken(),
-    () => auth.getGatewayOrigin(),
-  );
-  // The renderer is a different origin than the gateway (file:// in prod,
-  // localhost in dev), so allow its cross-origin fetches to the gateway.
-  const rendererOrigin = process.env.ELECTRON_RENDERER_URL
-    ? new URL(process.env.ELECTRON_RENDERER_URL).origin
-    : "null";
-  installGatewayCors(session.defaultSession, () => auth.getGatewayOrigin(), rendererOrigin);
-
-  const embeds = new EmbedService({
-    getWindow: () => mainWindow,
-    getGatewayOrigin: () => auth.getGatewayOrigin(),
-    getToken: () => auth.getToken(),
-    emitState: (embedId, state) => sendEvent("embed:state", { embedId, state }),
-  });
-
-  registerIpcHandlers(ipcMain, {
-    auth,
-    store,
-    embeds,
-    openExternal: openExternalHttps,
-    setBadgeCount: (count) => {
-      app.setBadgeCount(count);
-    },
-    notify: ({ threadId, title, body }) => {
-      if (!Notification.isSupported()) return;
-      const notification = new Notification({ title, body, silent: false });
-      notification.on("click", () => {
-        mainWindow?.show();
-        mainWindow?.focus();
-        sendEvent("notification:clicked", { threadId });
-      });
-      notification.show();
-    },
-    onRuntimeChanged: (slot) => {
-      // Switching runtime invalidates embed cookies/tokens; tear them down so
-      // they re-handshake against the new slot (Integration Wiring rule).
-      embeds.closeAll();
-      sendEvent("runtime:changed", { slot });
-    },
-  });
-
-  const savedBounds = await store.get("windowBounds");
-  mainWindow = createWindow(savedBounds ?? { width: 1280, height: 820 });
-  installAppMenu(() => mainWindow);
-
-  let boundsSaveTimer: ReturnType<typeof setTimeout> | null = null;
-  const persistBounds = () => {
-    if (boundsSaveTimer) clearTimeout(boundsSaveTimer);
-    boundsSaveTimer = setTimeout(() => {
-      if (!mainWindow || mainWindow.isDestroyed()) return;
-      const b = mainWindow.getBounds();
-      void store
-        .set("windowBounds", { x: b.x, y: b.y, width: b.width, height: b.height })
-        .catch((err: unknown) => {
-          console.warn(
-            "[main] failed to persist window bounds:",
-            err instanceof Error ? err.message : String(err),
-          );
-        });
-    }, 500);
-  };
-  mainWindow.on("resize", persistBounds);
-  mainWindow.on("move", persistBounds);
-  mainWindow.on("closed", () => {
-    if (boundsSaveTimer) clearTimeout(boundsSaveTimer);
-    mainWindow = null;
-  });
-
-  app.on("activate", () => {
-    if (BrowserWindow.getAllWindows().length === 0) {
-      mainWindow = createWindow({ width: 1280, height: 820 });
->>>>>>> a180ce0fa (fix(desktop): stop auto-opening the device-auth browser; brand focus ring; Matrix OS name)
->>>>>>> 70ce804b5 (feat(desktop): surface Clerk display name + avatar in the sidebar profile)
     }
   });
 
   void app
     .whenReady()
     .then(async () => {
+      // Packaged builds get the icon from build/icon.icns automatically; in dev
+      // the dock shows Electron's default icon unless we set the brand icon.
+      if (process.platform === "darwin" && !app.isPackaged && app.dock) {
+        try {
+          app.dock.setIcon(join(app.getAppPath(), "build", "icon.png"));
+        } catch (err: unknown) {
+          console.warn(
+            "[main] could not set dev dock icon:",
+            err instanceof Error ? err.message : String(err),
+          );
+        }
+      }
+
       const userData = app.getPath("userData");
       const store = createLocalStore({ dir: userData });
       const credentialStore = createCredentialStore({ dir: userData, safeStorage });
@@ -216,7 +125,6 @@ app.whenReady().then(async () => {
       const auth = new AuthService({
         credentialStore,
         platformHost,
-        openExternal: openExternalHttps,
         loadProfile: () => store.get("profile"),
         saveProfile: (profile) => store.set("profile", profile),
         clearProfile: () => store.delete("profile"),
@@ -224,6 +132,8 @@ app.whenReady().then(async () => {
           sendEvent("auth:changed", {
             signedIn: status.signedIn,
             ...(status.handle ? { handle: status.handle } : {}),
+            ...(status.displayName ? { displayName: status.displayName } : {}),
+            ...(status.imageUrl ? { imageUrl: status.imageUrl } : {}),
           });
         },
       });
@@ -306,6 +216,24 @@ app.whenReady().then(async () => {
       await openMainWindow();
       installAppMenu(() => mainWindow);
 
+      const updater = createUpdater({
+        onAvailable: (version) => {
+          console.info(`[updates] downloading Matrix OS ${version}`);
+        },
+        onReady: (version) => {
+          if (!Notification.isSupported()) return;
+          new Notification({
+            title: "Matrix OS update ready",
+            body: `Version ${version} will install after you quit and reopen the app.`,
+            silent: false,
+          }).show();
+        },
+      });
+      void updater.check();
+      updateCheckTimer = setInterval(() => {
+        void updater.check();
+      }, 60 * 60 * 1000);
+
       app.on("activate", () => {
         if (BrowserWindow.getAllWindows().length === 0) {
           void openMainWindow();
@@ -315,6 +243,13 @@ app.whenReady().then(async () => {
     .catch((err: unknown) => {
       logMainError("failed to start app", err);
     });
+
+  app.on("before-quit", () => {
+    if (updateCheckTimer) {
+      clearInterval(updateCheckTimer);
+      updateCheckTimer = null;
+    }
+  });
 
   app.on("window-all-closed", () => {
     if (process.platform !== "darwin") app.quit();

--- a/desktop/src/main/ipc/handlers.ts
+++ b/desktop/src/main/ipc/handlers.ts
@@ -5,6 +5,7 @@ import { INVOKE_CHANNELS, type InvokeChannel, type InvokeRequest, type InvokeRes
 import type { AuthService } from "../auth/auth-service";
 import type { EmbedService } from "../embeds/embed-service";
 import type { LocalStore, LocalStoreKey } from "../persistence/local-store";
+import type { UpdateStatus } from "../updates";
 
 interface IpcMainLike {
   handle(
@@ -21,6 +22,7 @@ export interface HandlerContext {
   setBadgeCount: (count: number) => void;
   notify: (input: { threadId: string; title: string; body: string; kind: string }) => void;
   onRuntimeChanged: (slot: string) => void;
+  getUpdateStatus: () => UpdateStatus;
 }
 
 type Handler<C extends InvokeChannel> = (
@@ -150,5 +152,5 @@ export function registerIpcHandlers(ipcMain: IpcMainLike, ctx: HandlerContext): 
     }
   });
 
-  handle("update:check", () => ({ status: "disabled" as const }));
+  handle("update:check", () => ({ status: ctx.getUpdateStatus() }));
 }

--- a/desktop/src/main/ipc/handlers.ts
+++ b/desktop/src/main/ipc/handlers.ts
@@ -66,6 +66,10 @@ export function registerIpcHandlers(ipcMain: IpcMainLike, ctx: HandlerContext): 
     await ctx.auth.signOut();
     return { ok: true };
   });
+  handle("auth:session-expired", async () => {
+    await ctx.auth.expireSession();
+    return { ok: true };
+  });
 
   handle("runtime:select", async ({ slot }) => {
     await ctx.auth.selectRuntime(slot);

--- a/desktop/src/main/ipc/handlers.ts
+++ b/desktop/src/main/ipc/handlers.ts
@@ -130,6 +130,9 @@ export function registerIpcHandlers(ipcMain: IpcMainLike, ctx: HandlerContext): 
   handle("embed:set-bounds", ({ embedId, bounds }) => ({
     ok: ctx.embeds.setBounds(embedId, bounds),
   }));
+  handle("embed:set-active", ({ embedId, active }) => ({
+    ok: ctx.embeds.setActive(embedId, active),
+  }));
   handle("embed:close", ({ embedId }) => ({ ok: ctx.embeds.close(embedId) }));
   handle("embed:retry-auth", async ({ embedId }) => {
     try {

--- a/desktop/src/main/ipc/handlers.ts
+++ b/desktop/src/main/ipc/handlers.ts
@@ -120,9 +120,9 @@ export function registerIpcHandlers(ipcMain: IpcMainLike, ctx: HandlerContext): 
     return { ok: true };
   });
 
-  handle("embed:open", async ({ kind, slug, bounds }) => {
+  handle("embed:open", async ({ kind, slug, bounds, active }) => {
     try {
-      return await ctx.embeds.open({ kind, slug, bounds });
+      return await ctx.embeds.open({ kind, slug, bounds, active });
     } catch (err: unknown) {
       console.warn(
         "[ipc] embed:open failed:",

--- a/desktop/src/main/persistence/local-store.ts
+++ b/desktop/src/main/persistence/local-store.ts
@@ -40,6 +40,9 @@ const ProfileSchema = z
     userId: z.string().min(1).max(128),
     platformHost: z.string().min(1).max(256),
     runtimeSlot: z.string().min(1).max(64),
+    displayName: z.string().max(256).optional(),
+    imageUrl: z.string().url().max(2048).optional(),
+    email: z.string().max(320).optional(),
   })
   .strict();
 

--- a/desktop/src/renderer/src/design/index.css
+++ b/desktop/src/renderer/src/design/index.css
@@ -74,6 +74,24 @@ textarea,
   border-radius: var(--radius-sm);
 }
 
+/* ── Composer card: brand focus-within, no inner ring ─────────── */
+.prompt-card {
+  border-color: var(--border-default);
+  box-shadow: var(--shadow-2);
+  transition:
+    border-color var(--duration-fast) var(--ease-out),
+    box-shadow var(--duration-fast) var(--ease-out);
+}
+.prompt-card:focus-within {
+  border-color: var(--accent);
+  box-shadow:
+    0 0 0 3px var(--accent-muted),
+    var(--shadow-2);
+}
+.prompt-card textarea:focus-visible {
+  box-shadow: none;
+}
+
 /* ── Scrollbars ───────────────────────────────────────────────── */
 ::-webkit-scrollbar {
   width: 10px;

--- a/desktop/src/renderer/src/design/tokens.css
+++ b/desktop/src/renderer/src/design/tokens.css
@@ -81,7 +81,7 @@
   --shadow-3: 0 18px 48px rgba(40, 44, 37, 0.16);
 
   /* ── Focus & motion ─────────────────────────────────────────── */
-  --focus-ring: 0 0 0 2px rgba(208, 111, 37, 0.4);
+  --focus-ring: 0 0 0 3px rgba(67, 78, 63, 0.22);
   --ease-out: cubic-bezier(0.2, 0, 0, 1);
   --duration-fast: 120ms;
   --duration-base: 160ms;
@@ -124,7 +124,7 @@
   --shadow-2: 0 6px 20px rgba(0, 0, 0, 0.5);
   --shadow-3: 0 18px 48px rgba(0, 0, 0, 0.6);
 
-  --focus-ring: 0 0 0 2px rgba(140, 199, 190, 0.5);
+  --focus-ring: 0 0 0 3px rgba(140, 199, 190, 0.32);
 
   color-scheme: dark;
 }

--- a/desktop/src/renderer/src/features/chat/ChatTab.tsx
+++ b/desktop/src/renderer/src/features/chat/ChatTab.tsx
@@ -50,7 +50,7 @@ export default function ChatTab() {
   const projects = useBoard((s) => s.projects);
   const [draft, setDraft] = useState("");
 
-  const projectName = projects[0]?.name ?? projects[0]?.slug ?? "matrix-os";
+  const projectName = projects[0]?.name ?? projects[0]?.slug ?? "Matrix OS";
   const groups = groupMessages(messages);
   const empty = messages.length === 0;
   const lastMessage = messages.at(-1);

--- a/desktop/src/renderer/src/features/chat/elements/prompt-input.tsx
+++ b/desktop/src/renderer/src/features/chat/elements/prompt-input.tsx
@@ -42,6 +42,7 @@ export function PromptInput({
         value={value}
         onChange={(e) => onChange(e.target.value)}
         placeholder={placeholder}
+        aria-label={placeholder}
         rows={1}
         className="w-full resize-none bg-transparent px-4 pt-3.5 text-md outline-none"
         style={{ color: "var(--text-primary)", maxHeight: 220 }}

--- a/desktop/src/renderer/src/features/chat/elements/prompt-input.tsx
+++ b/desktop/src/renderer/src/features/chat/elements/prompt-input.tsx
@@ -33,8 +33,8 @@ export function PromptInput({
 
   return (
     <div
-      className="flex flex-col overflow-hidden rounded-2xl border"
-      style={{ background: "var(--bg-surface)", borderColor: "var(--border-default)", boxShadow: "var(--shadow-2)" }}
+      className="prompt-card flex flex-col overflow-hidden rounded-2xl border"
+      style={{ background: "var(--bg-surface)" }}
     >
       <textarea
         ref={ref}

--- a/desktop/src/renderer/src/features/embeds/AppLauncher.tsx
+++ b/desktop/src/renderer/src/features/embeds/AppLauncher.tsx
@@ -1,8 +1,8 @@
 import { LayoutGrid } from "lucide-react";
 import { useEffect, useState } from "react";
-import EmbedHost from "./EmbedHost";
 import { EmptyState } from "../../design/primitives";
 import { useConnection } from "../../stores/connection";
+import { useTabs } from "../../stores/tabs";
 
 interface MatrixApp {
   slug: string;
@@ -33,8 +33,8 @@ function parseApps(value: unknown): MatrixApp[] {
 
 export default function AppLauncher() {
   const api = useConnection((s) => s.api);
+  const openTab = useTabs((s) => s.openTab);
   const [apps, setApps] = useState<MatrixApp[] | null>(null);
-  const [activeSlug, setActiveSlug] = useState<string | null>(null);
 
   useEffect(() => {
     if (!api) return;
@@ -52,30 +52,6 @@ export default function AppLauncher() {
     };
   }, [api]);
 
-  if (activeSlug) {
-    return (
-      <div className="flex min-h-0 flex-1 flex-col">
-        <div
-          className="flex shrink-0 items-center gap-2 border-b px-3 py-1.5"
-          style={{ borderColor: "var(--border-subtle)", background: "var(--bg-surface)" }}
-        >
-          <button
-            type="button"
-            className="text-sm hover:underline"
-            style={{ color: "var(--accent)" }}
-            onClick={() => setActiveSlug(null)}
-          >
-            ← Apps
-          </button>
-          <span className="text-sm font-semibold" style={{ color: "var(--text-primary)" }}>
-            {apps?.find((a) => a.slug === activeSlug)?.name ?? activeSlug}
-          </span>
-        </div>
-        <EmbedHost kind="app" slug={activeSlug} />
-      </div>
-    );
-  }
-
   if (apps && apps.length === 0) {
     return (
       <EmptyState
@@ -87,18 +63,16 @@ export default function AppLauncher() {
   }
 
   return (
-    <div className="flex flex-1 flex-col gap-3 overflow-y-auto p-5">
-      <h2 className="text-lg font-semibold" style={{ color: "var(--text-primary)" }}>
-        Apps
-      </h2>
-      <div className="grid grid-cols-[repeat(auto-fill,minmax(120px,1fr))] gap-3">
+    <div className="flex flex-1 flex-col gap-4 overflow-y-auto p-6">
+      <h2 className="text-lg font-semibold" style={{ color: "var(--text-primary)" }}>Apps</h2>
+      <div className="grid grid-cols-[repeat(auto-fill,minmax(124px,1fr))] gap-3">
         {(apps ?? []).map((app) => (
           <button
             key={app.slug}
             type="button"
             className="flex flex-col items-center gap-2 rounded-xl border p-4 transition-colors duration-100 hover:border-[var(--border-strong)]"
-            style={{ background: "var(--bg-raised)", borderColor: "var(--border-subtle)" }}
-            onClick={() => setActiveSlug(app.slug)}
+            style={{ background: "var(--bg-surface)", borderColor: "var(--border-subtle)" }}
+            onClick={() => openTab({ kind: "app", slug: app.slug, title: app.name })}
           >
             <div
               className="flex h-11 w-11 items-center justify-center rounded-xl text-lg font-semibold"
@@ -106,7 +80,7 @@ export default function AppLauncher() {
             >
               {app.name.charAt(0).toUpperCase()}
             </div>
-            <span className="truncate text-sm" style={{ color: "var(--text-primary)" }}>
+            <span className="w-full truncate text-center text-sm" style={{ color: "var(--text-primary)" }}>
               {app.name}
             </span>
           </button>

--- a/desktop/src/renderer/src/features/embeds/EmbedHost.tsx
+++ b/desktop/src/renderer/src/features/embeds/EmbedHost.tsx
@@ -3,13 +3,10 @@ import { Button } from "../../design/primitives";
 import { invoke, onEvent } from "../../lib/operator";
 
 // Hosts a main-process WebContentsView positioned over this element's rect.
-// The remote content renders in an isolated partition with no IPC access; this
-// component only reports bounds and surfaces the inline re-auth prompt.
-// Off-screen rect used to hide the native view while its tab is inactive
-// (a WebContentsView is an OS overlay and would otherwise paint over the active
-// tab — lesson L14).
-const HIDDEN_BOUNDS = { x: -20000, y: 0, width: 800, height: 600 };
-
+// The remote content renders in an isolated partition with no IPC access.
+// A WebContentsView is a native overlay that always paints above the renderer,
+// so when this host's tab is inactive the view is DETACHED from the window
+// (embed:set-active false) rather than moved off-screen (lesson L14).
 export default function EmbedHost({
   kind,
   slug,
@@ -28,11 +25,7 @@ export default function EmbedHost({
   function reportBounds(): void {
     const id = embedIdRef.current;
     const host = hostRef.current;
-    if (!id || !host) return;
-    if (!activeRef.current) {
-      void invoke("embed:set-bounds", { embedId: id, bounds: HIDDEN_BOUNDS });
-      return;
-    }
+    if (!id || !host || !activeRef.current) return;
     const r = host.getBoundingClientRect();
     void invoke("embed:set-bounds", {
       embedId: id,
@@ -61,15 +54,15 @@ export default function EmbedHost({
       pendingStates.set(payload.embedId, payload.state);
     });
 
-    const rect = host.getBoundingClientRect();
+    const r = host.getBoundingClientRect();
     const bounds = {
-      x: Math.round(rect.left),
-      y: Math.round(rect.top),
-      width: Math.round(rect.width),
-      height: Math.round(rect.height),
+      x: Math.round(r.left),
+      y: Math.round(r.top),
+      width: Math.round(r.width),
+      height: Math.round(r.height),
     };
 
-    void invoke("embed:open", { kind, ...(slug ? { slug } : {}), bounds })
+    void invoke("embed:open", { kind, ...(slug ? { slug } : {}), bounds, active: activeRef.current })
       .then(({ embedId, state: initialState }) => {
         if (disposed) {
           void invoke("embed:close", { embedId });
@@ -78,7 +71,9 @@ export default function EmbedHost({
         embedIdRef.current = embedId;
         setState(pendingStates.get(embedId) ?? initialState);
         pendingStates.delete(embedId);
-        reportBounds();
+        // Apply the current active state (handles a tab switch mid-open).
+        void invoke("embed:set-active", { embedId, active: activeRef.current });
+        if (activeRef.current) reportBounds();
       })
       .catch(() => {
         if (!disposed) setState("failed");
@@ -102,9 +97,14 @@ export default function EmbedHost({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [kind, slug]);
 
-  // Show/hide the native view as the hosting tab activates/deactivates.
+  // Attach/detach the native view as the hosting tab activates/deactivates.
   useEffect(() => {
-    reportBounds();
+    const id = embedIdRef.current;
+    // While embed:open is pending there is no native view to attach yet. The
+    // open resolution path applies activeRef.current before reporting bounds.
+    if (!id) return;
+    void invoke("embed:set-active", { embedId: id, active });
+    if (active) reportBounds();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [active]);
 

--- a/desktop/src/renderer/src/features/embeds/EmbedHost.tsx
+++ b/desktop/src/renderer/src/features/embeds/EmbedHost.tsx
@@ -5,21 +5,34 @@ import { invoke, onEvent } from "../../lib/operator";
 // Hosts a main-process WebContentsView positioned over this element's rect.
 // The remote content renders in an isolated partition with no IPC access; this
 // component only reports bounds and surfaces the inline re-auth prompt.
+// Off-screen rect used to hide the native view while its tab is inactive
+// (a WebContentsView is an OS overlay and would otherwise paint over the active
+// tab — lesson L14).
+const HIDDEN_BOUNDS = { x: -20000, y: 0, width: 800, height: 600 };
+
 export default function EmbedHost({
   kind,
   slug,
+  active = true,
 }: {
   kind: "hosted-shell" | "app";
   slug?: string;
+  active?: boolean;
 }) {
   const hostRef = useRef<HTMLDivElement>(null);
   const embedIdRef = useRef<string | null>(null);
+  const activeRef = useRef(active);
+  activeRef.current = active;
   const [state, setState] = useState<"loading" | "ready" | "auth-required" | "failed">("loading");
 
   function reportBounds(): void {
     const id = embedIdRef.current;
     const host = hostRef.current;
     if (!id || !host) return;
+    if (!activeRef.current) {
+      void invoke("embed:set-bounds", { embedId: id, bounds: HIDDEN_BOUNDS });
+      return;
+    }
     const r = host.getBoundingClientRect();
     void invoke("embed:set-bounds", {
       embedId: id,
@@ -88,6 +101,12 @@ export default function EmbedHost({
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [kind, slug]);
+
+  // Show/hide the native view as the hosting tab activates/deactivates.
+  useEffect(() => {
+    reportBounds();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [active]);
 
   return (
     <div ref={hostRef} className="relative min-h-0 flex-1" style={{ background: "var(--bg-app)" }}>

--- a/desktop/src/renderer/src/features/mission-control/HomeTab.tsx
+++ b/desktop/src/renderer/src/features/mission-control/HomeTab.tsx
@@ -9,10 +9,12 @@ import { EmbedHost } from "../embeds";
 // Home previews the user's live hosted Matrix OS shell (Canvas) with a thin
 // action bar on top. The shell embed authenticates via session handoff.
 export default function HomeTab({ active = true }: { active?: boolean }) {
+  const status = useConnection((s) => s.status);
   const handle = useConnection((s) => s.handle);
   const platformHost = useConnection((s) => s.platformHost);
   const projects = useBoard((s) => s.projects);
   const openTab = useTabs((s) => s.openTab);
+  const signedIn = status === "signed-in";
 
   return (
     <div className="flex min-h-0 flex-1 flex-col">
@@ -46,7 +48,7 @@ export default function HomeTab({ active = true }: { active?: boolean }) {
           Open in browser
         </Button>
       </div>
-      <EmbedHost kind="hosted-shell" active={active} />
+      {signedIn ? <EmbedHost kind="hosted-shell" active={active} /> : null}
     </div>
   );
 }

--- a/desktop/src/renderer/src/features/mission-control/HomeTab.tsx
+++ b/desktop/src/renderer/src/features/mission-control/HomeTab.tsx
@@ -1,136 +1,52 @@
-import { Kanban, Plus, RefreshCw, Sparkles, SquareTerminal } from "lucide-react";
-import { useEffect } from "react";
-import { Button, IconButton } from "../../design/primitives";
+import { Kanban, Maximize2, Sparkles } from "lucide-react";
+import { Button } from "../../design/primitives";
+import { invoke } from "../../lib/operator";
 import { useBoard } from "../../stores/board";
 import { useConnection } from "../../stores/connection";
-import { useSessions } from "../../stores/sessions";
 import { useTabs } from "../../stores/tabs";
-import { useUi } from "../../stores/ui";
+import { EmbedHost } from "../embeds";
 
-function Card({ children }: { children: React.ReactNode }) {
-  return (
-    <div
-      className="flex flex-col gap-3 rounded-xl border p-4"
-      style={{ background: "var(--bg-surface)", borderColor: "var(--border-subtle)", boxShadow: "var(--shadow-1)" }}
-    >
-      {children}
-    </div>
-  );
-}
-
-export default function HomeTab() {
-  const api = useConnection((s) => s.api);
+// Home previews the user's live hosted Matrix OS shell (Canvas) with a thin
+// action bar on top. The shell embed authenticates via session handoff.
+export default function HomeTab({ active = true }: { active?: boolean }) {
   const handle = useConnection((s) => s.handle);
+  const platformHost = useConnection((s) => s.platformHost);
   const projects = useBoard((s) => s.projects);
-  const sessions = useSessions((s) => s.sessions);
-  const sessionsLoading = useSessions((s) => s.loading);
-  const sessionsError = useSessions((s) => s.error);
-  const loadSessions = useSessions((s) => s.load);
   const openTab = useTabs((s) => s.openTab);
-  const setComposerOpen = useUi((s) => s.setComposerOpen);
-
-  useEffect(() => {
-    if (api) void loadSessions(api);
-  }, [api, loadSessions]);
 
   return (
-    <div className="flex min-h-0 flex-1 flex-col overflow-y-auto">
-      <div className="mx-auto w-full max-w-[920px] px-8 py-10">
-        <div className="mb-8 flex flex-col gap-1">
-          <h1 className="text-2xl font-semibold tracking-tight" style={{ color: "var(--text-primary)", fontSize: "var(--text-2xl)" }}>
+    <div className="flex min-h-0 flex-1 flex-col">
+      <div
+        className="flex shrink-0 items-center gap-3 border-b px-5 py-3"
+        style={{ borderColor: "var(--border-subtle)", background: "var(--bg-surface)" }}
+      >
+        <div className="flex min-w-0 flex-1 flex-col">
+          <span className="truncate text-sm font-semibold" style={{ color: "var(--text-primary)" }}>
             {handle ? `Welcome back, @${handle}` : "Welcome to Matrix OS"}
-          </h1>
-          <p className="text-md" style={{ color: "var(--text-secondary)" }}>
-            Your cloud computer is ready. Pick up a project, attach a terminal, or start an agent.
-          </p>
+          </span>
+          <span className="truncate text-xs" style={{ color: "var(--text-tertiary)" }}>
+            Your cloud computer · live preview of your shell
+          </span>
         </div>
-
-        <div className="mb-6 flex gap-3">
-          <Button variant="primary" onClick={() => setComposerOpen(true)}>
-            <Sparkles size={14} />
-            Start an agent
+        <Button variant="subtle" onClick={() => openTab({ kind: "chat", title: "Hermes", closable: false })}>
+          <Sparkles size={14} />
+          Ask Hermes
+        </Button>
+        {projects[0] ? (
+          <Button
+            variant="subtle"
+            onClick={() => openTab({ kind: "board", projectSlug: projects[0]!.slug, title: projects[0]!.name || projects[0]!.slug })}
+          >
+            <Kanban size={14} />
+            Board
           </Button>
-          {projects[0] ? (
-            <Button
-              variant="subtle"
-              onClick={() => openTab({ kind: "board", projectSlug: projects[0]!.slug, title: projects[0]!.name || projects[0]!.slug })}
-            >
-              <Kanban size={14} />
-              Open board
-            </Button>
-          ) : null}
-        </div>
-
-        <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
-          <Card>
-            <div className="flex items-center justify-between">
-              <h2 className="flex items-center gap-2 text-sm font-semibold" style={{ color: "var(--text-primary)" }}>
-                <Kanban size={15} style={{ color: "var(--accent)" }} /> Projects
-              </h2>
-            </div>
-            <div className="flex flex-col gap-0.5">
-              {projects.length === 0 ? (
-                <p className="text-sm" style={{ color: "var(--text-tertiary)" }}>No projects yet.</p>
-              ) : (
-                projects.slice(0, 6).map((p) => (
-                  <button
-                    key={p.slug}
-                    type="button"
-                    className="flex items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm hover:bg-[var(--bg-hover)]"
-                    style={{ color: "var(--text-secondary)" }}
-                    onClick={() => openTab({ kind: "board", projectSlug: p.slug, title: p.name || p.slug })}
-                  >
-                    <span style={{ color: "var(--text-tertiary)" }}>▣</span>
-                    <span className="truncate" style={{ color: "var(--text-primary)" }}>{p.name || p.slug}</span>
-                  </button>
-                ))
-              )}
-            </div>
-          </Card>
-
-          <Card>
-            <div className="flex items-center justify-between">
-              <h2 className="flex items-center gap-2 text-sm font-semibold" style={{ color: "var(--text-primary)" }}>
-                <SquareTerminal size={15} style={{ color: "var(--accent)" }} /> Sessions
-              </h2>
-              <IconButton label="Refresh sessions" onClick={() => api && void loadSessions(api)}>
-                <RefreshCw size={13} />
-              </IconButton>
-            </div>
-            <div className="flex flex-col gap-0.5">
-              {sessionsLoading && sessions.length === 0 ? (
-                <p className="text-sm" style={{ color: "var(--text-tertiary)" }}>Loading sessions…</p>
-              ) : sessionsError ? (
-                <div className="flex flex-col items-start gap-2">
-                  <p className="text-sm" style={{ color: "var(--danger)" }}>Sessions unavailable.</p>
-                  <Button variant="subtle" onClick={() => api && void loadSessions(api)}>
-                    <RefreshCw size={13} />
-                    Retry sessions
-                  </Button>
-                </div>
-              ) : sessions.length === 0 ? (
-                <p className="text-sm" style={{ color: "var(--text-tertiary)" }}>No live sessions.</p>
-              ) : (
-                sessions.slice(0, 8).map((s) => (
-                  <button
-                    key={s.attachName}
-                    type="button"
-                    className="flex items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm hover:bg-[var(--bg-hover)]"
-                    onClick={() => openTab({ kind: "terminal", sessionName: s.attachName, title: s.name })}
-                  >
-                    <span
-                      className="h-2 w-2 shrink-0 rounded-full"
-                      style={{ background: s.status === "active" ? "var(--status-complete)" : "var(--status-todo)" }}
-                    />
-                    <span className="min-w-0 flex-1 truncate font-mono text-xs" style={{ color: "var(--text-primary)" }}>{s.name}</span>
-                    <Plus size={12} style={{ color: "var(--text-tertiary)" }} />
-                  </button>
-                ))
-              )}
-            </div>
-          </Card>
-        </div>
+        ) : null}
+        <Button variant="primary" onClick={() => void invoke("shell:open-external", { url: platformHost.startsWith("https://") ? platformHost : "https://app.matrix-os.com" })}>
+          <Maximize2 size={13} />
+          Open in browser
+        </Button>
       </div>
+      <EmbedHost kind="hosted-shell" active={active} />
     </div>
   );
 }

--- a/desktop/src/renderer/src/features/mission-control/Sidebar.tsx
+++ b/desktop/src/renderer/src/features/mission-control/Sidebar.tsx
@@ -8,7 +8,7 @@ import {
   Sparkles,
   SquareTerminal,
 } from "lucide-react";
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { MatrixMark } from "../../design/BrandPanel";
 import { IconButton } from "../../design/primitives";
 import { invoke } from "../../lib/operator";
@@ -68,14 +68,31 @@ export default function Sidebar() {
   const projects = useBoard((s) => s.projects);
   const signOut = useConnection((s) => s.signOut);
   const handle = useConnection((s) => s.handle);
+  const profileName = useConnection((s) => s.displayName);
+  const imageUrl = useConnection((s) => s.imageUrl);
   const platformHost = useConnection((s) => s.platformHost);
   const unread = useThreads((s) => s.threads.filter((t) => t.unread || t.status === "needs-attention").length);
   const collapsed = useUi((s) => s.sidebarCollapsed);
   const toggleSidebar = useUi((s) => s.toggleSidebar);
   const [projectsOpen, setProjectsOpen] = useState(true);
 
+  // Reset the avatar fallback whenever the URL changes so a new image gets a
+  // fresh load attempt (lesson: track prev URL, reset imgFailed on differ).
+  const [imgFailed, setImgFailed] = useState(false);
+  const prevImg = useRef<string | null>(null);
+  useEffect(() => {
+    if (prevImg.current !== imageUrl) {
+      prevImg.current = imageUrl;
+      setImgFailed(false);
+    }
+  }, [imageUrl]);
+
+  const primaryLabel = profileName ?? (handle ? `@${handle}` : "Signed in");
+  const secondaryLabel = profileName && handle ? `@${handle}` : null;
+  const avatarInitial = (profileName ?? handle ?? "?").charAt(0).toUpperCase();
+  const showAvatar = Boolean(imageUrl) && !imgFailed;
+
   const activeTab = tabs.find((t) => t.id === activeTabId);
-  const displayName = handle ? `@${handle}` : "Signed in";
   const width = collapsed ? 56 : 240;
 
   return (
@@ -143,15 +160,30 @@ export default function Sidebar() {
           <button
             type="button"
             title="Manage account"
-            className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full text-xs font-semibold"
+            className="flex h-7 w-7 shrink-0 items-center justify-center overflow-hidden rounded-full text-xs font-semibold"
             style={{ background: "var(--accent-muted)", color: "var(--accent)" }}
             onClick={() => void invoke("shell:open-external", { url: platformHost.startsWith("https://") ? platformHost : "https://app.matrix-os.com" })}
           >
-            {(handle ?? "?").charAt(0).toUpperCase()}
+            {showAvatar && imageUrl ? (
+              <img
+                src={imageUrl}
+                alt=""
+                className="h-full w-full object-cover"
+                referrerPolicy="no-referrer"
+                onError={() => setImgFailed(true)}
+              />
+            ) : (
+              avatarInitial
+            )}
           </button>
           {!collapsed ? (
             <>
-              <span className="min-w-0 flex-1 truncate text-sm" style={{ color: "var(--text-primary)" }}>{displayName}</span>
+              <div className="flex min-w-0 flex-1 flex-col leading-tight">
+                <span className="truncate text-sm" style={{ color: "var(--text-primary)" }}>{primaryLabel}</span>
+                {secondaryLabel ? (
+                  <span className="truncate text-xs" style={{ color: "var(--text-tertiary)" }}>{secondaryLabel}</span>
+                ) : null}
+              </div>
               <IconButton label="Collapse sidebar" onClick={toggleSidebar}>
                 <PanelLeftClose size={15} />
               </IconButton>

--- a/desktop/src/renderer/src/features/mission-control/Sidebar.tsx
+++ b/desktop/src/renderer/src/features/mission-control/Sidebar.tsx
@@ -65,7 +65,6 @@ export default function Sidebar() {
   const tabs = useTabs((s) => s.tabs);
   const activeTabId = useTabs((s) => s.activeTabId);
   const openTab = useTabs((s) => s.openTab);
-  const focusTab = useTabs((s) => s.focusTab);
   const projects = useBoard((s) => s.projects);
   const signOut = useConnection((s) => s.signOut);
   const handle = useConnection((s) => s.handle);
@@ -76,7 +75,6 @@ export default function Sidebar() {
   const [projectsOpen, setProjectsOpen] = useState(true);
 
   const activeTab = tabs.find((t) => t.id === activeTabId);
-  const terminalTabs = tabs.filter((t) => t.kind === "terminal");
   const displayName = handle ? `@${handle}` : "Signed in";
   const width = collapsed ? 56 : 240;
 
@@ -105,33 +103,12 @@ export default function Sidebar() {
         <nav className="flex flex-col gap-0.5">
           <NavRow icon={<Home size={15} />} label="Home" collapsed={collapsed} active={activeTab?.kind === "home"} onClick={() => openTab({ kind: "home", title: "Home", closable: false })} />
           <NavRow icon={<Sparkles size={15} />} label="Chat" collapsed={collapsed} active={activeTab?.kind === "chat"} onClick={() => openTab({ kind: "chat", title: "Hermes", closable: false })} />
-          <NavRow icon={<LayoutGrid size={15} />} label="Apps" collapsed={collapsed} active={activeTab?.kind === "apps"} onClick={() => openTab({ kind: "apps", title: "Apps" })} />
+          <NavRow icon={<SquareTerminal size={15} />} label="Terminal" collapsed={collapsed} active={activeTab?.kind === "terminals"} onClick={() => openTab({ kind: "terminals", title: "Terminal" })} />
+          <NavRow icon={<LayoutGrid size={15} />} label="Apps" collapsed={collapsed} active={activeTab?.kind === "apps" || activeTab?.kind === "app"} onClick={() => openTab({ kind: "apps", title: "Apps" })} />
         </nav>
 
         {!collapsed ? (
           <>
-            <div className="mt-4 mb-1 flex items-center justify-between px-2.5">
-              <span className="text-xs font-semibold tracking-wide uppercase" style={{ color: "var(--text-tertiary)" }}>Terminals</span>
-            </div>
-            {terminalTabs.length === 0 ? (
-              <p className="px-2.5 py-1 text-xs" style={{ color: "var(--text-tertiary)" }}>Open a session from a project or Home.</p>
-            ) : (
-              terminalTabs.map((tab) => (
-                <button
-                  key={tab.id}
-                  type="button"
-                  className="flex w-full items-center gap-2 rounded-md px-2.5 py-1.5 text-left text-sm transition-colors duration-100"
-                  style={{ background: tab.id === activeTabId ? "var(--bg-selected)" : "transparent", color: "var(--text-secondary)" }}
-                  onMouseEnter={(e) => { if (tab.id !== activeTabId) e.currentTarget.style.background = "var(--bg-hover)"; }}
-                  onMouseLeave={(e) => { if (tab.id !== activeTabId) e.currentTarget.style.background = "transparent"; }}
-                  onClick={() => focusTab(tab.id)}
-                >
-                  <SquareTerminal size={14} style={{ color: "var(--text-tertiary)" }} />
-                  <span className="min-w-0 flex-1 truncate font-mono text-xs">{tab.title}</span>
-                </button>
-              ))
-            )}
-
             <button type="button" className="mt-4 mb-1 flex w-full items-center gap-1 px-2.5" onClick={() => setProjectsOpen((v) => !v)}>
               <ChevronRight size={12} style={{ color: "var(--text-tertiary)", transform: projectsOpen ? "rotate(90deg)" : "none", transition: "transform 120ms" }} />
               <span className="text-xs font-semibold tracking-wide uppercase" style={{ color: "var(--text-tertiary)" }}>Projects</span>
@@ -155,15 +132,7 @@ export default function Sidebar() {
               <p className="px-2.5 py-1 text-xs" style={{ color: "var(--text-tertiary)" }}>No projects yet.</p>
             ) : null}
           </>
-        ) : (
-          <div className="mt-2 flex flex-col items-center gap-1">
-            {terminalTabs.map((tab) => (
-              <IconButton key={tab.id} label={tab.title} active={tab.id === activeTabId} onClick={() => focusTab(tab.id)}>
-                <SquareTerminal size={15} />
-              </IconButton>
-            ))}
-          </div>
-        )}
+        ) : null}
       </div>
 
       <div className="flex flex-col border-t" style={{ borderColor: "var(--border-subtle)" }}>

--- a/desktop/src/renderer/src/features/mission-control/TabBar.tsx
+++ b/desktop/src/renderer/src/features/mission-control/TabBar.tsx
@@ -18,9 +18,11 @@ const TAB_ICON: Record<TabKind, LucideIcon> = {
   board: Kanban,
   task: FileCode2,
   terminal: SquareTerminal,
+  terminals: SquareTerminal,
   agents: MessageSquare,
   thread: MessageSquare,
   apps: LayoutGrid,
+  app: LayoutGrid,
   settings: Settings,
 };
 

--- a/desktop/src/renderer/src/features/mission-control/TabContent.tsx
+++ b/desktop/src/renderer/src/features/mission-control/TabContent.tsx
@@ -10,6 +10,8 @@ import HomeTab from "./HomeTab";
 import AgentsTab from "../threads/AgentsTab";
 import ChatTab from "../chat/ChatTab";
 import { AppLauncher } from "../embeds";
+import TerminalsTab from "../terminal/TerminalsTab";
+import EmbedHost from "../embeds/EmbedHost";
 
 function TabPane({ tab, active }: { tab: Tab; active: boolean }) {
   switch (tab.kind) {
@@ -17,8 +19,12 @@ function TabPane({ tab, active }: { tab: Tab; active: boolean }) {
       return <HomeTab />;
     case "chat":
       return <ChatTab />;
+    case "terminals":
+      return <TerminalsTab />;
     case "apps":
       return <AppLauncher />;
+    case "app":
+      return tab.slug ? <EmbedHost kind="app" slug={tab.slug} /> : null;
     case "board":
       return <Board projectSlug={tab.projectSlug} active={active} />;
     case "task":

--- a/desktop/src/renderer/src/features/mission-control/TabContent.tsx
+++ b/desktop/src/renderer/src/features/mission-control/TabContent.tsx
@@ -16,7 +16,7 @@ import EmbedHost from "../embeds/EmbedHost";
 function TabPane({ tab, active }: { tab: Tab; active: boolean }) {
   switch (tab.kind) {
     case "home":
-      return <HomeTab />;
+      return <HomeTab active={active} />;
     case "chat":
       return <ChatTab />;
     case "terminals":
@@ -24,7 +24,7 @@ function TabPane({ tab, active }: { tab: Tab; active: boolean }) {
     case "apps":
       return <AppLauncher />;
     case "app":
-      return tab.slug ? <EmbedHost kind="app" slug={tab.slug} /> : null;
+      return tab.slug ? <EmbedHost kind="app" slug={tab.slug} active={active} /> : null;
     case "board":
       return <Board projectSlug={tab.projectSlug} active={active} />;
     case "task":

--- a/desktop/src/renderer/src/features/mission-control/TabContent.tsx
+++ b/desktop/src/renderer/src/features/mission-control/TabContent.tsx
@@ -1,6 +1,7 @@
 import { Sparkles } from "lucide-react";
 import { EmptyState } from "../../design/primitives";
 import { useTabs, type Tab } from "../../stores/tabs";
+import { useUi } from "../../stores/ui";
 import Board from "../board/Board";
 import TaskWorkspace from "../workspace/TaskWorkspace";
 import TerminalView from "../terminal/TerminalView";
@@ -45,6 +46,12 @@ function TabPane({ tab, active }: { tab: Tab; active: boolean }) {
 export default function TabContent() {
   const tabs = useTabs((s) => s.tabs);
   const activeTabId = useTabs((s) => s.activeTabId);
+  // A native embed paints above the renderer, so while a modal overlay is open
+  // we treat embeds as inactive (detached) — otherwise the palette/composer/
+  // dialogs would render behind the embed.
+  const overlayOpen = useUi(
+    (s) => s.paletteOpen || s.composerOpen || s.quickOpenOpen || s.createTaskOpen,
+  );
 
   if (tabs.length === 0) {
     return (
@@ -62,6 +69,9 @@ export default function TabContent() {
     <div className="relative min-h-0 flex-1">
       {tabs.map((tab) => {
         const active = tab.id === activeTabId;
+        // Embeds also detach while a modal overlay is open so it isn't obscured.
+        const isEmbed = tab.kind === "home" || tab.kind === "app";
+        const paneActive = active && !(isEmbed && overlayOpen);
         return (
           <div
             key={tab.id}
@@ -70,7 +80,7 @@ export default function TabContent() {
             aria-hidden={!active}
             inert={!active}
           >
-            <TabPane tab={tab} active={active} />
+            <TabPane tab={tab} active={paneActive} />
           </div>
         );
       })}

--- a/desktop/src/renderer/src/features/settings/sections/AgentSection.tsx
+++ b/desktop/src/renderer/src/features/settings/sections/AgentSection.tsx
@@ -1,13 +1,81 @@
 import { Save } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
-import { Button } from "../../../design/primitives";
+import { Button, StatusDot } from "../../../design/primitives";
 import { toUserMessage } from "../../../lib/errors";
 import { useConnection } from "../../../stores/connection";
 import { Card, Empty, SectionHeader } from "./section-kit";
 
 const SOUL_PATH = "/files/system/soul.md";
+const AGENT_PATH = "/api/settings/agent";
+const CREDENTIALS_PATH = "/api/agents/credentials/status";
 
-export default function AgentSection() {
+interface ModelOption {
+  id: string;
+  label: string;
+  tier: string;
+}
+interface AgentConfig {
+  kernel: { model: string | null; effort: string | null };
+  availableModels: ModelOption[];
+  availableEfforts: string[];
+  defaults: { model: string; effort: string };
+}
+interface AgentCredential {
+  agent: string;
+  status: "available" | "missing" | "expired" | "revoked" | "failed";
+  coordinationRole?: string;
+  nextAction?: string | null;
+}
+interface CredentialStatus {
+  systemAgent?: string;
+  routingExplanation?: string;
+  agents: AgentCredential[];
+}
+
+const STATUS_COLOR: Record<AgentCredential["status"], string> = {
+  available: "var(--success)",
+  missing: "var(--text-tertiary)",
+  expired: "var(--warning)",
+  revoked: "var(--warning)",
+  failed: "var(--danger)",
+};
+
+function Segmented<T extends string>({
+  options,
+  value,
+  onChange,
+  labelFor,
+}: {
+  options: readonly T[];
+  value: T | null;
+  onChange: (v: T) => void;
+  labelFor?: (v: T) => string;
+}) {
+  return (
+    <div className="flex rounded-lg border p-0.5" style={{ borderColor: "var(--border-subtle)", background: "var(--bg-sunken)" }}>
+      {options.map((opt) => {
+        const active = opt === value;
+        return (
+          <button
+            key={opt}
+            type="button"
+            onClick={() => onChange(opt)}
+            className="flex-1 whitespace-nowrap rounded-md px-3 py-1.5 text-sm font-medium transition-colors duration-100"
+            style={{
+              background: active ? "var(--bg-surface)" : "transparent",
+              color: active ? "var(--text-primary)" : "var(--text-secondary)",
+              boxShadow: active ? "var(--shadow-1)" : "none",
+            }}
+          >
+            {labelFor ? labelFor(opt) : opt}
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+function SoulEditor() {
   const api = useConnection((s) => s.api);
   const [soul, setSoul] = useState("");
   const [baseline, setBaseline] = useState("");
@@ -43,11 +111,12 @@ export default function AgentSection() {
           setError(toUserMessage(err));
         }
       });
-    return () => { cancelled = true; };
+    return () => {
+      cancelled = true;
+    };
   }, [api]);
 
   const dirty = soul !== baseline;
-
   const save = async () => {
     if (!api || !dirty) return;
     const saveSeq = saveSeqRef.current + 1;
@@ -58,6 +127,7 @@ export default function AgentSection() {
       savedTimerRef.current = null;
     }
     setStatus("saving");
+    setError(null);
     try {
       await api.putText(SOUL_PATH, nextSoul);
       if (!mountedRef.current || saveSeqRef.current !== saveSeq) return;
@@ -76,45 +146,192 @@ export default function AgentSection() {
   };
 
   return (
+    <Card>
+      <div className="flex items-center justify-between">
+        <span className="text-sm font-medium" style={{ color: "var(--text-primary)" }}>SOUL · system/soul.md</span>
+        <div className="flex items-center gap-2">
+          {status === "saved" ? <span className="text-xs" style={{ color: "var(--success)" }}>Saved</span> : null}
+          <Button variant="primary" disabled={!dirty || status === "saving"} onClick={() => void save()}>
+            <Save size={13} />
+            {status === "saving" ? "Saving…" : "Save"}
+          </Button>
+        </div>
+      </div>
+      {!loaded ? (
+        <Empty text="Loading…" />
+      ) : (
+        <textarea
+          value={soul}
+          onChange={(e) => setSoul(e.target.value)}
+          spellCheck={false}
+          aria-label="SOUL system instructions"
+          className="min-h-[260px] w-full resize-y rounded-lg border bg-transparent p-3 font-mono text-xs leading-relaxed outline-none"
+          style={{ borderColor: "var(--border-default)", color: "var(--text-primary)", background: "var(--bg-sunken)" }}
+          placeholder="# SOUL&#10;&#10;You are Hermes, the Matrix OS agent…"
+          data-selectable
+        />
+      )}
+      {error ? <span className="text-xs" style={{ color: "var(--danger)" }}>{error}</span> : null}
+    </Card>
+  );
+}
+
+function ModelEffortCard() {
+  const api = useConnection((s) => s.api);
+  const [config, setConfig] = useState<AgentConfig | null>(null);
+  const [model, setModel] = useState<string | null>(null);
+  const [effort, setEffort] = useState<string | null>(null);
+  const [base, setBase] = useState<{ model: string | null; effort: string | null }>({ model: null, effort: null });
+  const [status, setStatus] = useState<"idle" | "saving" | "saved" | "error">("idle");
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!api) return;
+    let cancelled = false;
+    api
+      .get<AgentConfig>(AGENT_PATH)
+      .then((cfg) => {
+        if (cancelled) return;
+        const m = cfg.kernel.model ?? cfg.defaults.model;
+        const e = cfg.kernel.effort ?? cfg.defaults.effort;
+        setConfig(cfg);
+        setModel(m);
+        setEffort(e);
+        setBase({ model: m, effort: e });
+      })
+      .catch((err: unknown) => {
+        if (!cancelled) setError(toUserMessage(err));
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [api]);
+
+  const dirty = model !== base.model || effort !== base.effort;
+  const save = async () => {
+    if (!api || !dirty || !model || !effort) return;
+    setStatus("saving");
+    setError(null);
+    try {
+      await api.put(AGENT_PATH, { model, effort });
+      setBase({ model, effort });
+      setStatus("saved");
+      setTimeout(() => setStatus("idle"), 1500);
+    } catch (err: unknown) {
+      setError(toUserMessage(err));
+      setStatus("error");
+    }
+  };
+
+  return (
+    <Card>
+      <div className="flex items-center justify-between">
+        <span className="text-sm font-medium" style={{ color: "var(--text-primary)" }}>Model &amp; reasoning</span>
+        <div className="flex items-center gap-2">
+          {status === "saved" ? <span className="text-xs" style={{ color: "var(--success)" }}>Saved</span> : null}
+          <Button variant="primary" disabled={!dirty || status === "saving"} onClick={() => void save()}>
+            <Save size={13} />
+            {status === "saving" ? "Saving…" : "Save"}
+          </Button>
+        </div>
+      </div>
+      {!config ? (
+        <Empty text={error ?? "Loading…"} />
+      ) : (
+        <>
+          <div className="flex flex-col gap-1.5">
+            <span className="text-xs font-medium" style={{ color: "var(--text-secondary)" }}>Model</span>
+            <Segmented
+              options={config.availableModels.map((m) => m.id)}
+              value={model}
+              onChange={setModel}
+              labelFor={(id) => config.availableModels.find((m) => m.id === id)?.label ?? id}
+            />
+            <span className="text-xs" style={{ color: "var(--text-tertiary)" }}>
+              {config.availableModels.find((m) => m.id === model)?.tier ?? "Used by Hermes for every conversation."}
+            </span>
+          </div>
+          <div className="flex flex-col gap-1.5">
+            <span className="text-xs font-medium" style={{ color: "var(--text-secondary)" }}>Reasoning effort</span>
+            <Segmented options={config.availableEfforts} value={effort} onChange={setEffort} />
+            <span className="text-xs" style={{ color: "var(--text-tertiary)" }}>
+              Higher effort means deeper thinking and slower, more thorough responses.
+            </span>
+          </div>
+          {error ? <span className="text-xs" style={{ color: "var(--danger)" }}>{error}</span> : null}
+        </>
+      )}
+    </Card>
+  );
+}
+
+function ProvidersCard() {
+  const api = useConnection((s) => s.api);
+  const [status, setStatus] = useState<CredentialStatus | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!api) return;
+    let cancelled = false;
+    api
+      .get<CredentialStatus>(CREDENTIALS_PATH)
+      .then((s) => {
+        if (!cancelled) setStatus(s);
+      })
+      .catch((err: unknown) => {
+        if (!cancelled) setError(toUserMessage(err));
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [api]);
+
+  return (
+    <Card>
+      <span className="text-sm font-medium" style={{ color: "var(--text-primary)" }}>Coding agents &amp; credentials</span>
+      {status?.routingExplanation ? (
+        <p className="text-xs" style={{ color: "var(--text-secondary)" }}>{status.routingExplanation}</p>
+      ) : null}
+      {!status ? (
+        <Empty text={error ?? "Checking provider status…"} />
+      ) : (
+        <div className="flex flex-col gap-2">
+          {status.agents.map((a) => (
+            <div
+              key={a.agent}
+              className="flex items-center justify-between rounded-lg border px-3 py-2"
+              style={{ borderColor: "var(--border-subtle)", background: "var(--bg-sunken)" }}
+            >
+              <div className="flex items-center gap-2.5">
+                <StatusDot color={STATUS_COLOR[a.status]} />
+                <div className="flex flex-col">
+                  <span className="text-sm font-medium capitalize" style={{ color: "var(--text-primary)" }}>{a.agent}</span>
+                  {a.coordinationRole ? (
+                    <span className="text-xs" style={{ color: "var(--text-tertiary)" }}>{a.coordinationRole.replace(/_/g, " ")}</span>
+                  ) : null}
+                </div>
+              </div>
+              <span className="text-right text-xs" style={{ color: a.status === "available" ? "var(--success)" : "var(--text-secondary)" }}>
+                {a.status === "available" ? "Ready" : (a.nextAction ?? a.status)}
+              </span>
+            </div>
+          ))}
+        </div>
+      )}
+    </Card>
+  );
+}
+
+export default function AgentSection() {
+  return (
     <>
       <SectionHeader
         title="Agent (Hermes)"
-        description="Hermes is your OS agent. Its identity and standing instructions live in SOUL — edit it here and every conversation picks it up."
+        description="Hermes is your OS agent. Tune its model and reasoning, edit its standing instructions (SOUL), and check which coding agents are connected."
       />
-      <Card>
-        <div className="flex items-center justify-between">
-          <span className="text-sm font-medium" style={{ color: "var(--text-primary)" }}>SOUL · system/soul.md</span>
-          <div className="flex items-center gap-2">
-            {status === "saved" ? <span className="text-xs" style={{ color: "var(--success)" }}>Saved</span> : null}
-            <Button variant="primary" disabled={!dirty || status === "saving"} onClick={() => void save()}>
-              <Save size={13} />
-              {status === "saving" ? "Saving…" : "Save"}
-            </Button>
-          </div>
-        </div>
-        {!loaded ? (
-          <Empty text="Loading…" />
-        ) : (
-          <textarea
-            value={soul}
-            onChange={(e) => setSoul(e.target.value)}
-            spellCheck={false}
-            className="min-h-[320px] w-full resize-y rounded-lg border bg-transparent p-3 font-mono text-xs leading-relaxed outline-none"
-            style={{ borderColor: "var(--border-default)", color: "var(--text-primary)", background: "var(--bg-sunken)" }}
-            placeholder="# SOUL&#10;&#10;You are Hermes, the Matrix OS agent…"
-            data-selectable
-          />
-        )}
-        {error ? <span className="text-xs" style={{ color: "var(--danger)" }}>{error}</span> : null}
-      </Card>
-      <Card>
-        <span className="text-sm font-medium" style={{ color: "var(--text-primary)" }}>Model & persona</span>
-        <p className="text-sm" style={{ color: "var(--text-secondary)" }}>
-          Model routing, persona, and tool access are governed by your kernel configuration on the VPS.
-          Deeper in-app controls (model picker, reasoning effort, per-tool permissions) arrive with the
-          agent-config gateway endpoints.
-        </p>
-      </Card>
+      <ModelEffortCard />
+      <ProvidersCard />
+      <SoulEditor />
     </>
   );
 }

--- a/desktop/src/renderer/src/features/settings/sections/AgentSection.tsx
+++ b/desktop/src/renderer/src/features/settings/sections/AgentSection.tsx
@@ -184,6 +184,20 @@ function ModelEffortCard() {
   const [base, setBase] = useState<{ model: string | null; effort: string | null }>({ model: null, effort: null });
   const [status, setStatus] = useState<"idle" | "saving" | "saved" | "error">("idle");
   const [error, setError] = useState<string | null>(null);
+  const mountedRef = useRef(true);
+  const saveSeqRef = useRef(0);
+  const savedTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    return () => {
+      mountedRef.current = false;
+      saveSeqRef.current += 1;
+      if (savedTimerRef.current) {
+        clearTimeout(savedTimerRef.current);
+        savedTimerRef.current = null;
+      }
+    };
+  }, []);
 
   useEffect(() => {
     if (!api) return;
@@ -210,14 +224,25 @@ function ModelEffortCard() {
   const dirty = model !== base.model || effort !== base.effort;
   const save = async () => {
     if (!api || !dirty || !model || !effort) return;
+    const saveSeq = saveSeqRef.current + 1;
+    saveSeqRef.current = saveSeq;
+    if (savedTimerRef.current) {
+      clearTimeout(savedTimerRef.current);
+      savedTimerRef.current = null;
+    }
     setStatus("saving");
     setError(null);
     try {
       await api.put(AGENT_PATH, { model, effort });
+      if (!mountedRef.current || saveSeqRef.current !== saveSeq) return;
       setBase({ model, effort });
       setStatus("saved");
-      setTimeout(() => setStatus("idle"), 1500);
+      savedTimerRef.current = setTimeout(() => {
+        savedTimerRef.current = null;
+        if (mountedRef.current && saveSeqRef.current === saveSeq) setStatus("idle");
+      }, 1500);
     } catch (err: unknown) {
+      if (!mountedRef.current || saveSeqRef.current !== saveSeq) return;
       setError(toUserMessage(err));
       setStatus("error");
     }

--- a/desktop/src/renderer/src/features/settings/sections/AgentSection.tsx
+++ b/desktop/src/renderer/src/features/settings/sections/AgentSection.tsx
@@ -236,6 +236,7 @@ function ModelEffortCard() {
       await api.put(AGENT_PATH, { model, effort });
       if (!mountedRef.current || saveSeqRef.current !== saveSeq) return;
       setBase({ model, effort });
+      setError(null);
       setStatus("saved");
       savedTimerRef.current = setTimeout(() => {
         savedTimerRef.current = null;

--- a/desktop/src/renderer/src/features/settings/sections/AgentSection.tsx
+++ b/desktop/src/renderer/src/features/settings/sections/AgentSection.tsx
@@ -29,7 +29,7 @@ interface AgentCredential {
 interface CredentialStatus {
   systemAgent?: string;
   routingExplanation?: string;
-  agents: AgentCredential[];
+  agents?: AgentCredential[];
 }
 
 const STATUS_COLOR: Record<AgentCredential["status"], string> = {
@@ -296,7 +296,7 @@ function ProvidersCard() {
         <Empty text={error ?? "Checking provider status…"} />
       ) : (
         <div className="flex flex-col gap-2">
-          {status.agents.map((a) => (
+          {(status.agents ?? []).map((a) => (
             <div
               key={a.agent}
               className="flex items-center justify-between rounded-lg border px-3 py-2"

--- a/desktop/src/renderer/src/features/signin/SignIn.tsx
+++ b/desktop/src/renderer/src/features/signin/SignIn.tsx
@@ -129,8 +129,15 @@ export default function SignIn() {
                   {userCode}
                 </div>
                 {verificationUri ? (
-                  <button type="button" className="text-sm underline-offset-2 hover:underline" style={{ color: "var(--highlight)" }} onClick={() => void invoke("shell:open-external", { url: verificationUri })}>
-                    Reopen approval page
+                  <button
+                    type="button"
+                    className="no-drag flex h-10 w-full items-center justify-center rounded-lg text-sm font-semibold transition-colors duration-100"
+                    style={{ background: "var(--accent)", color: "var(--text-on-accent)" }}
+                    onMouseEnter={(e) => (e.currentTarget.style.background = "var(--accent-hover)")}
+                    onMouseLeave={(e) => (e.currentTarget.style.background = "var(--accent)")}
+                    onClick={() => void invoke("shell:open-external", { url: verificationUri })}
+                  >
+                    Open approval page
                   </button>
                 ) : null}
                 <span className="status-pulse text-xs" style={{ color: "var(--text-tertiary)" }}>
@@ -177,7 +184,7 @@ export default function SignIn() {
                   onMouseEnter={(e) => (e.currentTarget.style.background = "var(--accent-hover)")}
                   onMouseLeave={(e) => (e.currentTarget.style.background = "var(--accent)")}
                 >
-                  {phase === "starting" ? "Opening browser…" : tab === "signin" ? "Sign in" : "Create account"}
+                  {phase === "starting" ? "Starting…" : tab === "signin" ? "Sign in" : "Create account"}
                 </button>
 
                 {phase === "expired" ? (

--- a/desktop/src/renderer/src/features/terminal/TerminalsTab.tsx
+++ b/desktop/src/renderer/src/features/terminal/TerminalsTab.tsx
@@ -13,6 +13,7 @@ export default function TerminalsTab() {
   const load = useSessions((s) => s.load);
   const create = useSessions((s) => s.create);
   const [selected, setSelected] = useState<string | null>(null);
+  const [creating, setCreating] = useState(false);
 
   useEffect(() => {
     if (api) void load(api);
@@ -61,15 +62,19 @@ export default function TerminalsTab() {
           <Button
             variant="subtle"
             className="w-full justify-center"
+            disabled={!api || creating}
             onClick={() => {
-              if (!api) return;
-              void create(api).then((session) => {
-                if (session) setSelected(session.attachName);
-              });
+              if (!api || creating) return;
+              setCreating(true);
+              void create(api)
+                .then((session) => {
+                  if (session) setSelected(session.attachName);
+                })
+                .finally(() => setCreating(false));
             }}
           >
             <Plus size={13} />
-            New session
+            {creating ? "Creating…" : "New session"}
           </Button>
         </div>
       </div>

--- a/desktop/src/renderer/src/features/terminal/TerminalsTab.tsx
+++ b/desktop/src/renderer/src/features/terminal/TerminalsTab.tsx
@@ -20,7 +20,13 @@ export default function TerminalsTab() {
   }, [api, load]);
 
   useEffect(() => {
-    if (!selected && sessions[0]) setSelected(sessions[0].attachName);
+    if (sessions.length === 0) {
+      if (selected) setSelected(null);
+      return;
+    }
+    if (!selected || !sessions.some((s) => s.attachName === selected)) {
+      setSelected(sessions[0]?.attachName ?? null);
+    }
   }, [sessions, selected]);
 
   return (

--- a/desktop/src/renderer/src/features/terminal/TerminalsTab.tsx
+++ b/desktop/src/renderer/src/features/terminal/TerminalsTab.tsx
@@ -11,6 +11,7 @@ export default function TerminalsTab() {
   const api = useConnection((s) => s.api);
   const sessions = useSessions((s) => s.sessions);
   const load = useSessions((s) => s.load);
+  const create = useSessions((s) => s.create);
   const [selected, setSelected] = useState<string | null>(null);
 
   useEffect(() => {
@@ -57,7 +58,16 @@ export default function TerminalsTab() {
           )}
         </div>
         <div className="border-t p-2" style={{ borderColor: "var(--border-subtle)" }}>
-          <Button variant="subtle" className="w-full justify-center" onClick={() => api && void load(api)}>
+          <Button
+            variant="subtle"
+            className="w-full justify-center"
+            onClick={() => {
+              if (!api) return;
+              void create(api).then((session) => {
+                if (session) setSelected(session.attachName);
+              });
+            }}
+          >
             <Plus size={13} />
             New session
           </Button>

--- a/desktop/src/renderer/src/features/terminal/TerminalsTab.tsx
+++ b/desktop/src/renderer/src/features/terminal/TerminalsTab.tsx
@@ -1,0 +1,80 @@
+import { Plus, RefreshCw, SquareTerminal } from "lucide-react";
+import { useEffect, useState } from "react";
+import { Button, EmptyState, IconButton, StatusDot } from "../../design/primitives";
+import { useConnection } from "../../stores/connection";
+import { useSessions } from "../../stores/sessions";
+import TerminalView from "./TerminalView";
+
+// The Terminal workspace: an inner sidebar listing every VPS session, with the
+// selected one attached on the right. Mirrors the shell's terminal app.
+export default function TerminalsTab() {
+  const api = useConnection((s) => s.api);
+  const sessions = useSessions((s) => s.sessions);
+  const load = useSessions((s) => s.load);
+  const [selected, setSelected] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (api) void load(api);
+  }, [api, load]);
+
+  useEffect(() => {
+    if (!selected && sessions[0]) setSelected(sessions[0].attachName);
+  }, [sessions, selected]);
+
+  return (
+    <div className="flex min-h-0 flex-1">
+      <div
+        className="flex w-[220px] shrink-0 flex-col border-r"
+        style={{ borderColor: "var(--border-subtle)", background: "var(--bg-surface)" }}
+      >
+        <div className="flex items-center justify-between border-b px-3 py-2.5" style={{ borderColor: "var(--border-subtle)" }}>
+          <span className="text-sm font-semibold" style={{ color: "var(--text-primary)" }}>Sessions</span>
+          <IconButton label="Refresh sessions" onClick={() => api && void load(api)}>
+            <RefreshCw size={13} />
+          </IconButton>
+        </div>
+        <div className="flex min-h-0 flex-1 flex-col gap-0.5 overflow-y-auto p-1.5">
+          {sessions.length === 0 ? (
+            <p className="px-2.5 py-2 text-xs" style={{ color: "var(--text-tertiary)" }}>No sessions on your computer yet.</p>
+          ) : (
+            sessions.map((s) => {
+              const active = s.attachName === selected;
+              return (
+                <button
+                  key={s.attachName}
+                  type="button"
+                  className="flex items-center gap-2 rounded-md px-2.5 py-1.5 text-left transition-colors duration-100"
+                  style={{ background: active ? "var(--bg-selected)" : "transparent" }}
+                  onMouseEnter={(e) => { if (!active) e.currentTarget.style.background = "var(--bg-hover)"; }}
+                  onMouseLeave={(e) => { if (!active) e.currentTarget.style.background = "transparent"; }}
+                  onClick={() => setSelected(s.attachName)}
+                >
+                  <StatusDot color={s.status === "active" ? "var(--status-complete)" : "var(--status-todo)"} />
+                  <span className="min-w-0 flex-1 truncate font-mono text-xs" style={{ color: "var(--text-primary)" }}>{s.name}</span>
+                </button>
+              );
+            })
+          )}
+        </div>
+        <div className="border-t p-2" style={{ borderColor: "var(--border-subtle)" }}>
+          <Button variant="subtle" className="w-full justify-center" onClick={() => api && void load(api)}>
+            <Plus size={13} />
+            New session
+          </Button>
+        </div>
+      </div>
+
+      <div className="flex min-h-0 min-w-0 flex-1 flex-col">
+        {selected ? (
+          <TerminalView key={selected} sessionName={selected} active />
+        ) : (
+          <EmptyState
+            icon={<SquareTerminal size={26} />}
+            headline="No session selected"
+            description="Pick a session on the left, or open one from a project."
+          />
+        )}
+      </div>
+    </div>
+  );
+}

--- a/desktop/src/renderer/src/features/terminal/TerminalsTab.tsx
+++ b/desktop/src/renderer/src/features/terminal/TerminalsTab.tsx
@@ -1,6 +1,7 @@
 import { Plus, RefreshCw, SquareTerminal } from "lucide-react";
 import { useEffect, useState } from "react";
 import { Button, EmptyState, IconButton, StatusDot } from "../../design/primitives";
+import { categoryMessage } from "../../../../shared/app-error";
 import { useConnection } from "../../stores/connection";
 import { useSessions } from "../../stores/sessions";
 import TerminalView from "./TerminalView";
@@ -10,6 +11,8 @@ import TerminalView from "./TerminalView";
 export default function TerminalsTab() {
   const api = useConnection((s) => s.api);
   const sessions = useSessions((s) => s.sessions);
+  const loading = useSessions((s) => s.loading);
+  const error = useSessions((s) => s.error);
   const load = useSessions((s) => s.load);
   const create = useSessions((s) => s.create);
   const [selected, setSelected] = useState<string | null>(null);
@@ -42,7 +45,14 @@ export default function TerminalsTab() {
           </IconButton>
         </div>
         <div className="flex min-h-0 flex-1 flex-col gap-0.5 overflow-y-auto p-1.5">
-          {sessions.length === 0 ? (
+          {error ? (
+            <p className="rounded-md px-2.5 py-2 text-xs" style={{ color: "var(--danger)", background: "var(--danger-muted)" }}>
+              {categoryMessage(error)}
+            </p>
+          ) : null}
+          {loading && sessions.length === 0 ? (
+            <p className="px-2.5 py-2 text-xs" style={{ color: "var(--text-tertiary)" }}>Loading sessions...</p>
+          ) : sessions.length === 0 && !error ? (
             <p className="px-2.5 py-2 text-xs" style={{ color: "var(--text-tertiary)" }}>No sessions on your computer yet.</p>
           ) : (
             sessions.map((s) => {

--- a/desktop/src/renderer/src/lib/api.ts
+++ b/desktop/src/renderer/src/lib/api.ts
@@ -18,6 +18,9 @@ export interface ApiClientOptions {
   baseUrl: string;
   getRuntimeSlot: () => string;
   fetchFn?: FetchFn;
+  // Invoked once when the gateway rejects the request with 401 (token expired
+  // or revoked), so the app can drop the stale session and prompt re-auth.
+  onUnauthorized?: () => void;
 }
 
 export interface ApiClient {
@@ -45,6 +48,7 @@ export function createApiClient(options: ApiClientOptions): ApiClient {
       throw new AppError(classifyTransportError(err), { cause: err });
     }
     if (!response.ok) {
+      if (response.status === 401) options.onUnauthorized?.();
       throw new AppError(classifyHttpStatus(response.status));
     }
     return response;

--- a/desktop/src/renderer/src/lib/api.ts
+++ b/desktop/src/renderer/src/lib/api.ts
@@ -28,6 +28,7 @@ export interface ApiClient {
   getText(path: string): Promise<string>;
   post<T>(path: string, body: unknown): Promise<T>;
   patch<T>(path: string, body: unknown): Promise<T>;
+  put<T>(path: string, body: unknown): Promise<T>;
   delete<T>(path: string): Promise<T>;
   putText<T>(path: string, body: string): Promise<T>;
   baseUrl: string;
@@ -85,6 +86,12 @@ export function createApiClient(options: ApiClientOptions): ApiClient {
     patch: (path, body) =>
       request(path, {
         method: "PATCH",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(body),
+      }),
+    put: (path, body) =>
+      request(path, {
+        method: "PUT",
         headers: { "content-type": "application/json" },
         body: JSON.stringify(body),
       }),

--- a/desktop/src/renderer/src/stores/connection.ts
+++ b/desktop/src/renderer/src/stores/connection.ts
@@ -9,6 +9,8 @@ export type ConnectionStatus = "loading" | "signed-out" | "signed-in";
 interface ConnectionState {
   status: ConnectionStatus;
   handle: string | null;
+  displayName: string | null;
+  imageUrl: string | null;
   platformHost: string;
   runtimeSlot: string;
   api: ApiClient | null;
@@ -20,6 +22,8 @@ interface ConnectionState {
 export const useConnection = create<ConnectionState>()((set, get) => ({
   status: "loading",
   handle: null,
+  displayName: null,
+  imageUrl: null,
   platformHost: "",
   runtimeSlot: "primary",
   api: null,
@@ -31,18 +35,25 @@ export const useConnection = create<ConnectionState>()((set, get) => ({
         ? createApiClient({
             baseUrl: status.platformHost,
             getRuntimeSlot: () => get().runtimeSlot,
+            // A 401 means the session token expired/was revoked. Drop it in the
+            // trusted core (which emits auth:changed → refresh → sign-in screen).
+            onUnauthorized: () => {
+              void invoke("auth:session-expired", {});
+            },
           })
         : null;
       set({
         status: status.signedIn ? "signed-in" : "signed-out",
         handle: status.handle ?? null,
+        displayName: status.displayName ?? null,
+        imageUrl: status.imageUrl ?? null,
         platformHost: status.platformHost,
         runtimeSlot: status.runtimeSlot,
         api,
       });
     } catch (err: unknown) {
       console.warn("[connection] failed to refresh auth status:", err instanceof Error ? err.message : String(err));
-      set({ status: "signed-out", handle: null, api: null });
+      set({ status: "signed-out", handle: null, displayName: null, imageUrl: null, api: null });
     }
   },
 
@@ -53,7 +64,7 @@ export const useConnection = create<ConnectionState>()((set, get) => ({
 
   signOut: async () => {
     await invoke("auth:sign-out", {});
-    set({ status: "signed-out", handle: null, api: null });
+    set({ status: "signed-out", handle: null, displayName: null, imageUrl: null, api: null });
   },
 }));
 

--- a/desktop/src/renderer/src/stores/sessions.ts
+++ b/desktop/src/renderer/src/stores/sessions.ts
@@ -74,6 +74,7 @@ export const useSessions = create<SessionsState>()((set, get) => ({
     try {
       const response = await api.post<{ name?: unknown }>("/api/terminal/sessions", { name });
       const attachName = typeof response.name === "string" && response.name.trim() ? response.name.trim() : name;
+      const refreshSequence = loadSequence + 1;
       await get().load(api);
       const refreshError = get().error;
       const created = get().sessions.find((session) => session.attachName === attachName) ?? {
@@ -83,7 +84,7 @@ export const useSessions = create<SessionsState>()((set, get) => ({
         source: "zellij" as const,
       };
       set((state) => {
-        const loadingPatch = state.loading ? { loading: false } : {};
+        const loadingPatch = refreshSequence === loadSequence && state.loading ? { loading: false } : {};
         return state.sessions.some((session) => session.attachName === created.attachName)
           ? { ...loadingPatch, error: refreshError }
           : { sessions: [created, ...state.sessions], ...loadingPatch, error: refreshError };

--- a/desktop/src/renderer/src/stores/sessions.ts
+++ b/desktop/src/renderer/src/stores/sessions.ts
@@ -70,7 +70,7 @@ export const useSessions = create<SessionsState>()((set, get) => ({
 
   create: async (api) => {
     const name = nextSessionName();
-    set({ loading: true });
+    set({ loading: true, error: null });
     try {
       const response = await api.post<{ name?: unknown }>("/api/terminal/sessions", { name });
       const attachName = typeof response.name === "string" && response.name.trim() ? response.name.trim() : name;

--- a/desktop/src/renderer/src/stores/sessions.ts
+++ b/desktop/src/renderer/src/stores/sessions.ts
@@ -75,6 +75,7 @@ export const useSessions = create<SessionsState>()((set, get) => ({
       const response = await api.post<{ name?: unknown }>("/api/terminal/sessions", { name });
       const attachName = typeof response.name === "string" && response.name.trim() ? response.name.trim() : name;
       await get().load(api);
+      const refreshError = get().error;
       const created = get().sessions.find((session) => session.attachName === attachName) ?? {
         name: attachName,
         attachName,
@@ -83,8 +84,8 @@ export const useSessions = create<SessionsState>()((set, get) => ({
       };
       set((state) =>
         state.sessions.some((session) => session.attachName === created.attachName)
-          ? { loading: false, error: null }
-          : { sessions: [created, ...state.sessions], loading: false, error: null },
+          ? { loading: false, error: refreshError }
+          : { sessions: [created, ...state.sessions], loading: false, error: refreshError },
       );
       return created;
     } catch (err: unknown) {

--- a/desktop/src/renderer/src/stores/sessions.ts
+++ b/desktop/src/renderer/src/stores/sessions.ts
@@ -82,11 +82,12 @@ export const useSessions = create<SessionsState>()((set, get) => ({
         status: "active" as const,
         source: "zellij" as const,
       };
-      set((state) =>
-        state.sessions.some((session) => session.attachName === created.attachName)
-          ? { loading: false, error: refreshError }
-          : { sessions: [created, ...state.sessions], loading: false, error: refreshError },
-      );
+      set((state) => {
+        const loadingPatch = state.loading ? { loading: false } : {};
+        return state.sessions.some((session) => session.attachName === created.attachName)
+          ? { ...loadingPatch, error: refreshError }
+          : { sessions: [created, ...state.sessions], ...loadingPatch, error: refreshError };
+      });
       return created;
     } catch (err: unknown) {
       console.error("[sessions] Failed to create session:", err);

--- a/desktop/src/renderer/src/stores/sessions.ts
+++ b/desktop/src/renderer/src/stores/sessions.ts
@@ -18,6 +18,7 @@ interface SessionsState {
   loading: boolean;
   error: AppErrorCategory | null;
   load(api: ApiClient): Promise<void>;
+  create(api: ApiClient): Promise<AttachableSession | null>;
   resolveAttachName(linkedSessionId: string | null): string | null;
 }
 
@@ -26,6 +27,11 @@ function asArray<T>(value: unknown): T[] {
 }
 
 let loadSequence = 0;
+
+function nextSessionName(): string {
+  const suffix = crypto.randomUUID().replace(/-/g, "").slice(0, 8);
+  return `operator-${Date.now().toString(36)}-${suffix}`;
+}
 
 export const useSessions = create<SessionsState>()((set, get) => ({
   sessions: [],
@@ -59,6 +65,35 @@ export const useSessions = create<SessionsState>()((set, get) => ({
         loading: false,
         error: err instanceof AppError ? err.category : "server",
       });
+    }
+  },
+
+  create: async (api) => {
+    const name = nextSessionName();
+    set({ loading: true });
+    try {
+      const response = await api.post<{ name?: unknown }>("/api/terminal/sessions", { name });
+      const attachName = typeof response.name === "string" && response.name.trim() ? response.name.trim() : name;
+      await get().load(api);
+      const created = get().sessions.find((session) => session.attachName === attachName) ?? {
+        name: attachName,
+        attachName,
+        status: "active" as const,
+        source: "zellij" as const,
+      };
+      set((state) =>
+        state.sessions.some((session) => session.attachName === created.attachName)
+          ? { loading: false, error: null }
+          : { sessions: [created, ...state.sessions], loading: false, error: null },
+      );
+      return created;
+    } catch (err: unknown) {
+      console.error("[sessions] Failed to create session:", err);
+      set({
+        loading: false,
+        error: err instanceof AppError ? err.category : "server",
+      });
+      return null;
     }
   },
 

--- a/desktop/src/renderer/src/stores/tabs.ts
+++ b/desktop/src/renderer/src/stores/tabs.ts
@@ -4,7 +4,18 @@
 // instead of duplicating it.
 import { create } from "zustand";
 
-export type TabKind = "home" | "chat" | "board" | "task" | "terminal" | "agents" | "thread" | "apps" | "settings";
+export type TabKind =
+  | "home"
+  | "chat"
+  | "board"
+  | "task"
+  | "terminal"
+  | "terminals"
+  | "agents"
+  | "thread"
+  | "apps"
+  | "app"
+  | "settings";
 
 export interface Tab {
   id: string;
@@ -16,13 +27,23 @@ export interface Tab {
   taskId?: string;
   sessionName?: string;
   threadId?: string;
+  slug?: string;
   closable: boolean;
 }
 
 const MAX_TABS = 24;
 
-function identityKey(spec: Pick<Tab, "kind" | "projectSlug" | "taskId" | "sessionName" | "threadId">): string {
-  return [spec.kind, spec.projectSlug ?? "", spec.taskId ?? "", spec.sessionName ?? "", spec.threadId ?? ""].join("|");
+function identityKey(
+  spec: Pick<Tab, "kind" | "projectSlug" | "taskId" | "sessionName" | "threadId" | "slug">,
+): string {
+  return [
+    spec.kind,
+    spec.projectSlug ?? "",
+    spec.taskId ?? "",
+    spec.sessionName ?? "",
+    spec.threadId ?? "",
+    spec.slug ?? "",
+  ].join("|");
 }
 
 interface TabsState {

--- a/desktop/src/shared/ipc-contract.ts
+++ b/desktop/src/shared/ipc-contract.ts
@@ -123,6 +123,10 @@ export const INVOKE_CHANNELS = {
       .strict(),
     response: Ok,
   },
+  "embed:set-active": {
+    request: z.object({ embedId: z.string().min(1).max(64), active: z.boolean() }).strict(),
+    response: Ok,
+  },
   "embed:close": {
     request: z.object({ embedId: z.string().min(1).max(64) }).strict(),
     response: Ok,

--- a/desktop/src/shared/ipc-contract.ts
+++ b/desktop/src/shared/ipc-contract.ts
@@ -174,7 +174,7 @@ export const INVOKE_CHANNELS = {
   "update:check": {
     request: Empty,
     response: z
-      .object({ status: z.enum(["disabled", "checking", "up-to-date", "downloading", "ready"]) })
+      .object({ status: z.enum(["disabled", "checking", "up-to-date", "downloading", "ready", "error"]) })
       .strict(),
   },
 } as const;

--- a/desktop/src/shared/ipc-contract.ts
+++ b/desktop/src/shared/ipc-contract.ts
@@ -81,6 +81,8 @@ export const INVOKE_CHANNELS = {
       .object({
         signedIn: z.boolean(),
         handle: z.string().max(64).optional(),
+        displayName: z.string().max(256).optional(),
+        imageUrl: z.string().url().max(2048).optional(),
         runtimeSlot: z.string().max(64),
         platformHost: z.string().max(256),
       })
@@ -177,7 +179,12 @@ export const INVOKE_CHANNELS = {
 
 export const EVENT_CHANNELS = {
   "auth:changed": z
-    .object({ signedIn: z.boolean(), handle: z.string().max(64).optional() })
+    .object({
+      signedIn: z.boolean(),
+      handle: z.string().max(64).optional(),
+      displayName: z.string().max(256).optional(),
+      imageUrl: z.string().url().max(2048).optional(),
+    })
     .strict(),
   "runtime:changed": z.object({ slot: z.string().min(1).max(64) }).strict(),
   "embed:state": z

--- a/desktop/src/shared/ipc-contract.ts
+++ b/desktop/src/shared/ipc-contract.ts
@@ -89,6 +89,7 @@ export const INVOKE_CHANNELS = {
       .strict(),
   },
   "auth:sign-out": { request: Empty, response: Ok },
+  "auth:session-expired": { request: Empty, response: Ok },
   "runtime:select": {
     request: z.object({ slot: z.string().min(1).max(64) }).strict(),
     response: Ok,

--- a/desktop/src/shared/ipc-contract.ts
+++ b/desktop/src/shared/ipc-contract.ts
@@ -116,6 +116,7 @@ export const INVOKE_CHANNELS = {
         kind: z.enum(["hosted-shell", "app"]),
         slug: z.string().min(1).max(128).optional(),
         bounds: BoundsSchema,
+        active: z.boolean().optional(),
       })
       .strict(),
     response: z.object({ embedId: z.string().min(1).max(64), state: EmbedStateSchema }).strict(),

--- a/tests/desktop/agent-section.test.tsx
+++ b/tests/desktop/agent-section.test.tsx
@@ -1,42 +1,54 @@
 // @vitest-environment jsdom
 
 import React from "react";
-import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import AgentSection from "../../desktop/src/renderer/src/features/settings/sections/AgentSection";
 import { useConnection } from "../../desktop/src/renderer/src/stores/connection";
 
 describe("AgentSection", () => {
+  let api: {
+    get: ReturnType<typeof vi.fn>;
+    getText: ReturnType<typeof vi.fn>;
+    put: ReturnType<typeof vi.fn>;
+    putText: ReturnType<typeof vi.fn>;
+  };
+
   beforeEach(() => {
+    api = {
+      get: vi.fn((path: string) => {
+        if (path === "/api/settings/agent") {
+          return Promise.resolve({
+            kernel: { model: null, effort: null },
+            availableModels: [
+              { id: "sonnet", label: "Sonnet", tier: "Balanced" },
+              { id: "opus", label: "Opus", tier: "Deep" },
+            ],
+            availableEfforts: ["medium"],
+            defaults: { model: "sonnet", effort: "medium" },
+          });
+        }
+        if (path === "/api/agents/credentials/status") {
+          return Promise.resolve({});
+        }
+        return Promise.reject(new Error(`unexpected path ${path}`));
+      }),
+      getText: vi.fn().mockResolvedValue("# SOUL"),
+      put: vi.fn().mockResolvedValue({ ok: true }),
+      putText: vi.fn(),
+    };
     useConnection.setState({
       status: "signed-in",
       handle: "operator",
       platformHost: "https://platform.test",
       runtimeSlot: "primary",
-      api: {
-        get: vi.fn((path: string) => {
-          if (path === "/api/settings/agent") {
-            return Promise.resolve({
-              kernel: { model: null, effort: null },
-              availableModels: [{ id: "sonnet", label: "Sonnet", tier: "Balanced" }],
-              availableEfforts: ["medium"],
-              defaults: { model: "sonnet", effort: "medium" },
-            });
-          }
-          if (path === "/api/agents/credentials/status") {
-            return Promise.resolve({});
-          }
-          return Promise.reject(new Error(`unexpected path ${path}`));
-        }),
-        getText: vi.fn().mockResolvedValue("# SOUL"),
-        put: vi.fn(),
-        putText: vi.fn(),
-      } as never,
+      api: api as never,
     });
   });
 
   afterEach(() => {
     cleanup();
+    vi.useRealTimers();
     vi.restoreAllMocks();
   });
 
@@ -47,5 +59,23 @@ describe("AgentSection", () => {
     await waitFor(() => {
       expect(screen.queryByText("Checking provider status...")).toBeNull();
     });
+  });
+
+  it("clears the model save timer on unmount", async () => {
+    const clearTimeoutSpy = vi.spyOn(globalThis, "clearTimeout");
+    const { unmount } = render(<AgentSection />);
+
+    fireEvent.click(await screen.findByRole("button", { name: "Opus" }));
+    const saveButtons = screen.getAllByRole("button", { name: /save/i }) as HTMLButtonElement[];
+    const enabledSave = saveButtons.find((button) => !button.disabled);
+    expect(enabledSave).toBeTruthy();
+    fireEvent.click(enabledSave!);
+
+    await waitFor(() => expect(api.put).toHaveBeenCalledWith("/api/settings/agent", { model: "opus", effort: "medium" }));
+    await screen.findByText("Saved");
+
+    unmount();
+
+    expect(clearTimeoutSpy).toHaveBeenCalled();
   });
 });

--- a/tests/desktop/agent-section.test.tsx
+++ b/tests/desktop/agent-section.test.tsx
@@ -78,4 +78,26 @@ describe("AgentSection", () => {
 
     expect(clearTimeoutSpy).toHaveBeenCalled();
   });
+
+  it("clears a stale model save error after a successful retry", async () => {
+    api.put
+      .mockRejectedValueOnce(new Error("first save failed"))
+      .mockResolvedValueOnce({ ok: true });
+    render(<AgentSection />);
+
+    fireEvent.click(await screen.findByRole("button", { name: "Opus" }));
+    const findEnabledSave = () =>
+      (screen.getAllByRole("button", { name: /save/i }) as HTMLButtonElement[]).find(
+        (button) => !button.disabled,
+      );
+
+    fireEvent.click(findEnabledSave()!);
+    await screen.findByText("Something went wrong. Please try again.");
+
+    fireEvent.click(findEnabledSave()!);
+
+    await waitFor(() => expect(api.put).toHaveBeenCalledTimes(2));
+    await screen.findByText("Saved");
+    expect(screen.queryByText("Something went wrong. Please try again.")).toBeNull();
+  });
 });

--- a/tests/desktop/agent-section.test.tsx
+++ b/tests/desktop/agent-section.test.tsx
@@ -1,0 +1,51 @@
+// @vitest-environment jsdom
+
+import React from "react";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import AgentSection from "../../desktop/src/renderer/src/features/settings/sections/AgentSection";
+import { useConnection } from "../../desktop/src/renderer/src/stores/connection";
+
+describe("AgentSection", () => {
+  beforeEach(() => {
+    useConnection.setState({
+      status: "signed-in",
+      handle: "operator",
+      platformHost: "https://platform.test",
+      runtimeSlot: "primary",
+      api: {
+        get: vi.fn((path: string) => {
+          if (path === "/api/settings/agent") {
+            return Promise.resolve({
+              kernel: { model: null, effort: null },
+              availableModels: [{ id: "sonnet", label: "Sonnet", tier: "Balanced" }],
+              availableEfforts: ["medium"],
+              defaults: { model: "sonnet", effort: "medium" },
+            });
+          }
+          if (path === "/api/agents/credentials/status") {
+            return Promise.resolve({});
+          }
+          return Promise.reject(new Error(`unexpected path ${path}`));
+        }),
+        getText: vi.fn().mockResolvedValue("# SOUL"),
+        put: vi.fn(),
+        putText: vi.fn(),
+      } as never,
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it("does not crash when provider status omits agents", async () => {
+    render(<AgentSection />);
+
+    await screen.findByText("Coding agents & credentials");
+    await waitFor(() => {
+      expect(screen.queryByText("Checking provider status...")).toBeNull();
+    });
+  });
+});

--- a/tests/desktop/api-client.test.ts
+++ b/tests/desktop/api-client.test.ts
@@ -55,6 +55,32 @@ describe("createApiClient", () => {
     await expect(client.get("/api/apps")).rejects.toMatchObject({ category: "unauthorized" });
   });
 
+  it("invokes onUnauthorized exactly once on a 401, before throwing", async () => {
+    const fetchFn = vi.fn().mockResolvedValue(jsonResponse(401, {}));
+    const onUnauthorized = vi.fn();
+    const client = createApiClient({
+      baseUrl: "https://x.test",
+      getRuntimeSlot: () => "primary",
+      fetchFn,
+      onUnauthorized,
+    });
+    await expect(client.get("/api/apps")).rejects.toMatchObject({ category: "unauthorized" });
+    expect(onUnauthorized).toHaveBeenCalledOnce();
+  });
+
+  it("does not invoke onUnauthorized for non-401 errors", async () => {
+    const fetchFn = vi.fn().mockResolvedValue(jsonResponse(500, {}));
+    const onUnauthorized = vi.fn();
+    const client = createApiClient({
+      baseUrl: "https://x.test",
+      getRuntimeSlot: () => "primary",
+      fetchFn,
+      onUnauthorized,
+    });
+    await expect(client.get("/api/apps")).rejects.toMatchObject({ category: "server" });
+    expect(onUnauthorized).not.toHaveBeenCalled();
+  });
+
   it("maps network failure to offline", async () => {
     const fetchFn = vi.fn().mockRejectedValue(new TypeError("fetch failed"));
     const client = createApiClient({

--- a/tests/desktop/auth-service.test.ts
+++ b/tests/desktop/auth-service.test.ts
@@ -1,25 +1,49 @@
 import { describe, expect, it, vi } from "vitest";
-import { AuthService, type ConnectionProfile } from "@desktop/main/auth/auth-service";
+import { AuthService, type AuthStatus, type ConnectionProfile } from "@desktop/main/auth/auth-service";
 import type { CredentialStore, StoredCredential } from "@desktop/main/auth/credential-store";
 
-function makeCredential(overrides: Partial<StoredCredential> = {}): StoredCredential {
-  return {
-    accessToken: "token-1",
-    expiresAt: Date.now() + 60_000,
-    userId: "user-1",
-    handle: "neo",
-    ...overrides,
+const HOUR_MS = 3_600_000;
+
+function makeCredentialStore(initial: StoredCredential | null = null) {
+  let stored = initial;
+  const store: CredentialStore = {
+    save: vi.fn(async (credential: StoredCredential) => {
+      stored = credential;
+    }),
+    load: vi.fn(async () => stored),
+    clear: vi.fn(async () => {
+      stored = null;
+    }),
   };
+  return { store, peek: () => stored };
 }
 
-function makeProfile(overrides: Partial<ConnectionProfile> = {}): ConnectionProfile {
-  return {
-    handle: "neo",
-    userId: "user-1",
+function makeService(opts: {
+  credential?: StoredCredential | null;
+  profile?: ConnectionProfile | null;
+  now: number | (() => number);
+  fetchFn?: (input: string, init?: RequestInit) => Promise<Response>;
+  saveProfile?: (profile: ConnectionProfile) => Promise<void>;
+}) {
+  const { store, peek } = makeCredentialStore(opts.credential ?? null);
+  let profile = opts.profile ?? null;
+  const changes: AuthStatus[] = [];
+  const auth = new AuthService({
+    credentialStore: store,
     platformHost: "https://app.matrix-os.com",
-    runtimeSlot: "primary",
-    ...overrides,
-  };
+    ...(opts.fetchFn ? { fetchFn: opts.fetchFn } : {}),
+    now: () => (typeof opts.now === "function" ? opts.now() : opts.now),
+    loadProfile: async () => profile,
+    saveProfile: async (nextProfile) => {
+      if (opts.saveProfile) await opts.saveProfile(nextProfile);
+      profile = nextProfile;
+    },
+    clearProfile: async () => {
+      profile = null;
+    },
+    onAuthChanged: (status) => changes.push(status),
+  });
+  return { auth, store, changes, getProfile: () => profile, peekCredential: peek };
 }
 
 function deferred<T = void>() {
@@ -30,25 +54,6 @@ function deferred<T = void>() {
     reject = rej;
   });
   return { promise, resolve, reject };
-}
-
-function makeCredentialStore(initial: StoredCredential | null): CredentialStore & {
-  saved: StoredCredential | null;
-  cleared: boolean;
-} {
-  return {
-    saved: null,
-    cleared: false,
-    async load() {
-      return initial;
-    },
-    async save(credential) {
-      this.saved = credential;
-    },
-    async clear() {
-      this.cleared = true;
-    },
-  };
 }
 
 function jsonResponse(body: unknown, status = 200): Response {
@@ -65,99 +70,108 @@ async function flushAuthFlow(): Promise<void> {
   await new Promise((resolve) => setTimeout(resolve, 0));
 }
 
-describe("AuthService", () => {
-  it("treats expired persisted credentials as signed out", async () => {
-    const credentialStore = makeCredentialStore(makeCredential({ expiresAt: Date.now() - 1000 }));
-    const clearProfile = vi.fn(async () => undefined);
-    const auth = new AuthService({
-      credentialStore,
-      platformHost: "https://app.matrix-os.com",
-      openExternal: vi.fn(async () => undefined),
-      loadProfile: async () => makeProfile(),
-      saveProfile: vi.fn(async () => undefined),
-      clearProfile,
-      onAuthChanged: vi.fn(),
-    });
+const VALID: StoredCredential = {
+  accessToken: "tok",
+  expiresAt: 10_000 + HOUR_MS,
+  userId: "user-1",
+  handle: "neo",
+};
 
+const PROFILE: ConnectionProfile = {
+  handle: "neo",
+  userId: "user-1",
+  platformHost: "https://app.matrix-os.com",
+  runtimeSlot: "primary",
+  displayName: "Thomas Anderson",
+};
+
+describe("AuthService token expiry", () => {
+  it("reports signed-in and returns the token while the credential is valid", async () => {
+    const { auth } = makeService({ credential: VALID, profile: PROFILE, now: 10_000 });
     await auth.init();
-
-    expect(auth.getStatus().signedIn).toBe(false);
-    expect(auth.getToken()).toBeNull();
-    expect(credentialStore.cleared).toBe(true);
-    expect(clearProfile).toHaveBeenCalledOnce();
+    expect(auth.getStatus().signedIn).toBe(true);
+    expect(auth.getStatus().displayName).toBe("Thomas Anderson");
+    expect(auth.getToken()).toBe("tok");
   });
 
   it("does not throw when expired credential cleanup fails during init", async () => {
-    const credentialStore = makeCredentialStore(makeCredential({ expiresAt: Date.now() - 1000 }));
-    credentialStore.clear = vi.fn(async () => {
-      throw new Error("credential clear failed");
+    const { auth, store, getProfile } = makeService({
+      credential: { ...VALID, expiresAt: 9_000 },
+      profile: PROFILE,
+      now: 10_000,
     });
-    const clearProfile = vi.fn(async () => {
-      throw new Error("profile clear failed");
-    });
-    vi.spyOn(console, "warn").mockImplementation(() => undefined);
-    const auth = new AuthService({
-      credentialStore,
-      platformHost: "https://app.matrix-os.com",
-      openExternal: vi.fn(async () => undefined),
-      loadProfile: async () => makeProfile(),
-      saveProfile: vi.fn(async () => undefined),
-      clearProfile,
-      onAuthChanged: vi.fn(),
-    });
+    vi.mocked(store.clear).mockRejectedValueOnce(new Error("credential clear failed"));
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    try {
+      await expect(auth.init()).resolves.toBeUndefined();
 
-    await expect(auth.init()).resolves.toBeUndefined();
-
-    expect(auth.getStatus().signedIn).toBe(false);
-    expect(auth.getToken()).toBeNull();
-    expect(credentialStore.clear).toHaveBeenCalledOnce();
-    expect(clearProfile).toHaveBeenCalledOnce();
-    expect(console.warn).toHaveBeenCalledWith("[auth] failed to clear expired credential:", "credential clear failed");
-    expect(console.warn).toHaveBeenCalledWith("[auth] failed to clear expired profile:", "profile clear failed");
+      expect(auth.getStatus().signedIn).toBe(false);
+      expect(auth.getToken()).toBeNull();
+      expect(store.clear).toHaveBeenCalledOnce();
+      expect(getProfile()).toEqual(PROFILE);
+      expect(console.warn).toHaveBeenCalledWith("[auth] failed to clear expired credential:", "credential clear failed");
+    } finally {
+      warn.mockRestore();
+    }
   });
 
   it("emits signed-out status when an in-memory credential expires mid-session", async () => {
-    const now = Date.now();
-    const dateNow = vi.spyOn(Date, "now").mockReturnValue(now);
-    const credentialStore = makeCredentialStore(makeCredential({ expiresAt: now + 1000 }));
-    const clearProfile = vi.fn(async () => undefined);
-    const onAuthChanged = vi.fn();
-    const auth = new AuthService({
-      credentialStore,
-      platformHost: "https://app.matrix-os.com",
-      openExternal: vi.fn(async () => undefined),
-      loadProfile: async () => makeProfile(),
-      saveProfile: vi.fn(async () => undefined),
-      clearProfile,
-      onAuthChanged,
+    let now = 10_000;
+    const { auth, store, changes, getProfile } = makeService({
+      credential: VALID,
+      profile: PROFILE,
+      now: () => now,
     });
     await auth.init();
     expect(auth.getStatus().signedIn).toBe(true);
 
-    dateNow.mockReturnValue(now + 2000);
+    now = 10_000 + HOUR_MS;
 
-    expect(auth.getStatus()).toEqual({
+    expect(auth.getStatus()).toMatchObject({
       signedIn: false,
       runtimeSlot: "primary",
       platformHost: "https://app.matrix-os.com",
     });
     expect(auth.getToken()).toBeNull();
-    expect(onAuthChanged).toHaveBeenCalledTimes(1);
-    expect(onAuthChanged).toHaveBeenCalledWith({
+    expect(changes).toHaveLength(1);
+    expect(changes.at(-1)).toMatchObject({
       signedIn: false,
       runtimeSlot: "primary",
       platformHost: "https://app.matrix-os.com",
     });
     await Promise.resolve();
     await Promise.resolve();
-    expect(credentialStore.cleared).toBe(true);
-    expect(clearProfile).toHaveBeenCalledOnce();
-
-    dateNow.mockRestore();
+    expect(store.clear).toHaveBeenCalledOnce();
+    expect(getProfile()).toEqual(PROFILE);
   });
 
+  it("treats an expired credential as signed-out and withholds the token", async () => {
+    const { auth, store, getProfile } = makeService({
+      credential: { ...VALID, expiresAt: 9_000 },
+      profile: PROFILE,
+      now: 10_000,
+    });
+    await auth.init();
+    expect(auth.getStatus().signedIn).toBe(false);
+    expect(auth.getToken()).toBeNull();
+    expect(store.clear).toHaveBeenCalledOnce();
+    expect(getProfile()).toEqual(PROFILE);
+  });
+
+  it("withholds the token within the refresh skew window before exact expiry", async () => {
+    const { auth } = makeService({
+      credential: { ...VALID, expiresAt: 15_000 },
+      profile: PROFILE,
+      now: 10_000,
+    });
+    await auth.init();
+    expect(auth.getToken()).toBeNull();
+    expect(auth.getStatus().signedIn).toBe(false);
+  });
+});
+
+describe("AuthService device flow", () => {
   it("reuses a pending device flow instead of launching parallel poll loops", async () => {
-    const credentialStore = makeCredentialStore(null);
     let codeRequests = 0;
     const tokenPromise = new Promise<Response>(() => undefined);
     const fetchFn = vi.fn(async (url: string) => {
@@ -173,16 +187,7 @@ describe("AuthService", () => {
       }
       return tokenPromise;
     });
-    const auth = new AuthService({
-      credentialStore,
-      platformHost: "https://app.matrix-os.com",
-      fetchFn,
-      openExternal: vi.fn(async () => undefined),
-      loadProfile: async () => null,
-      saveProfile: vi.fn(async () => undefined),
-      clearProfile: vi.fn(async () => undefined),
-      onAuthChanged: vi.fn(),
-    });
+    const { auth } = makeService({ now: 10_000, fetchFn });
 
     const first = await auth.startDeviceFlow();
     const second = await auth.startDeviceFlow();
@@ -192,9 +197,6 @@ describe("AuthService", () => {
   });
 
   it("does not restore credentials when an in-flight poll resolves after sign-out", async () => {
-    const credentialStore = makeCredentialStore(null);
-    const saveProfile = vi.fn(async () => undefined);
-    const onAuthChanged = vi.fn();
     let resolveToken!: (response: Response) => void;
     const tokenPromise = new Promise<Response>((resolve) => {
       resolveToken = resolve;
@@ -211,23 +213,14 @@ describe("AuthService", () => {
       }
       return tokenPromise;
     });
-    const auth = new AuthService({
-      credentialStore,
-      platformHost: "https://app.matrix-os.com",
-      fetchFn,
-      openExternal: vi.fn(async () => undefined),
-      loadProfile: async () => null,
-      saveProfile,
-      clearProfile: vi.fn(async () => undefined),
-      onAuthChanged,
-    });
+    const { auth, changes, getProfile, peekCredential } = makeService({ now: 10_000, fetchFn });
 
     await auth.startDeviceFlow();
     await auth.signOut();
     resolveToken(
       jsonResponse({
         accessToken: "late-token",
-        expiresAt: Date.now() + 60_000,
+        expiresAt: 10_000 + HOUR_MS,
         userId: "user-1",
         handle: "neo",
       }),
@@ -236,26 +229,34 @@ describe("AuthService", () => {
     await Promise.resolve();
 
     expect(auth.getStatus().signedIn).toBe(false);
-    expect(credentialStore.saved).toBeNull();
-    expect(saveProfile).not.toHaveBeenCalled();
-    expect(onAuthChanged).toHaveBeenCalledTimes(1);
+    expect(peekCredential()).toBeNull();
+    expect(getProfile()).toBeNull();
+    expect(changes).toHaveLength(1);
   });
 
   it("clears a credential save that completes after sign-out invalidates the device flow", async () => {
-    const credentialStore = makeCredentialStore(null);
+    let stored: StoredCredential | null = null;
+    let profile: ConnectionProfile | null = null;
     const saveStarted = deferred<void>();
     const finishSave = deferred<void>();
-    credentialStore.save = vi.fn(async (credential) => {
-      saveStarted.resolve();
-      await finishSave.promise;
-      credentialStore.saved = credential;
+    const credentialStore: CredentialStore = {
+      load: vi.fn(async () => stored),
+      save: vi.fn(async (credential) => {
+        saveStarted.resolve();
+        await finishSave.promise;
+        stored = credential;
+      }),
+      clear: vi.fn(async () => {
+        stored = null;
+      }),
+    };
+    const saveProfile = vi.fn(async (nextProfile: ConnectionProfile) => {
+      profile = nextProfile;
     });
-    credentialStore.clear = vi.fn(async () => {
-      credentialStore.cleared = true;
-      credentialStore.saved = null;
+    const clearProfile = vi.fn(async () => {
+      profile = null;
     });
-    const saveProfile = vi.fn(async () => undefined);
-    const onAuthChanged = vi.fn();
+    const changes: AuthStatus[] = [];
     const fetchFn = vi.fn(async (url: string) => {
       if (url.endsWith("/api/auth/device/code")) {
         return jsonResponse({
@@ -268,7 +269,7 @@ describe("AuthService", () => {
       }
       return jsonResponse({
         accessToken: "late-token",
-        expiresAt: Date.now() + 60_000,
+        expiresAt: 10_000 + HOUR_MS,
         userId: "user-1",
         handle: "neo",
       });
@@ -277,11 +278,11 @@ describe("AuthService", () => {
       credentialStore,
       platformHost: "https://app.matrix-os.com",
       fetchFn,
-      openExternal: vi.fn(async () => undefined),
-      loadProfile: async () => null,
+      now: () => 10_000,
+      loadProfile: async () => profile,
       saveProfile,
-      clearProfile: vi.fn(async () => undefined),
-      onAuthChanged,
+      clearProfile,
+      onAuthChanged: (status) => changes.push(status),
     });
 
     await auth.startDeviceFlow();
@@ -291,50 +292,16 @@ describe("AuthService", () => {
     await flushAuthFlow();
 
     expect(auth.getStatus().signedIn).toBe(false);
-    expect(credentialStore.saved).toBeNull();
+    expect(stored).toBeNull();
+    expect(profile).toBeNull();
     expect(saveProfile).not.toHaveBeenCalled();
-    expect(onAuthChanged).toHaveBeenCalledTimes(1);
-  });
-
-  it("emits signed-out status before persistent sign-out cleanup can fail", async () => {
-    const credentialStore = makeCredentialStore(makeCredential());
-    const onAuthChanged = vi.fn();
-    const cleanupError = new Error("credential clear failed");
-    credentialStore.clear = vi.fn(async () => {
-      throw cleanupError;
-    });
-    vi.spyOn(console, "warn").mockImplementation(() => undefined);
-    const auth = new AuthService({
-      credentialStore,
-      platformHost: "https://app.matrix-os.com",
-      openExternal: vi.fn(async () => undefined),
-      loadProfile: async () => makeProfile(),
-      saveProfile: vi.fn(async () => undefined),
-      clearProfile: vi.fn(async () => undefined),
-      onAuthChanged,
-    });
-    await auth.init();
-
-    await expect(auth.signOut()).rejects.toThrow(cleanupError);
-
-    expect(auth.getStatus().signedIn).toBe(false);
-    expect(onAuthChanged).toHaveBeenCalledWith({
-      signedIn: false,
-      runtimeSlot: "primary",
-      platformHost: "https://app.matrix-os.com",
-    });
+    expect(changes).toHaveLength(1);
   });
 
   it("emits signed-in status even when persistence fails after device authorization", async () => {
-    const credentialStore = makeCredentialStore(null);
-    credentialStore.save = vi.fn(async () => {
-      throw new Error("credential save failed");
-    });
     const saveProfile = vi.fn(async () => {
       throw new Error("profile save failed");
     });
-    const onAuthChanged = vi.fn();
-    vi.spyOn(console, "warn").mockImplementation(() => undefined);
     const fetchFn = vi.fn(async (url: string) => {
       if (url.endsWith("/api/auth/device/code")) {
         return jsonResponse({
@@ -347,46 +314,92 @@ describe("AuthService", () => {
       }
       return jsonResponse({
         accessToken: "token-1",
-        expiresAt: Date.now() + 60_000,
+        expiresAt: 10_000 + HOUR_MS,
         userId: "user-1",
         handle: "neo",
+        displayName: "Thomas Anderson",
       });
     });
-    const auth = new AuthService({
-      credentialStore,
-      platformHost: "https://app.matrix-os.com",
-      fetchFn,
-      openExternal: vi.fn(async () => undefined),
-      loadProfile: async () => null,
-      saveProfile,
-      clearProfile: vi.fn(async () => undefined),
-      onAuthChanged,
-    });
+    const { auth, store, changes } = makeService({ now: 10_000, fetchFn, saveProfile });
+    vi.mocked(store.save).mockRejectedValueOnce(new Error("credential save failed"));
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    try {
+      await auth.startDeviceFlow();
+      await flushAuthFlow();
 
-    await auth.startDeviceFlow();
-    await flushAuthFlow();
+      expect(auth.getStatus()).toEqual({
+        signedIn: true,
+        handle: "neo",
+        displayName: "Thomas Anderson",
+        runtimeSlot: "primary",
+        platformHost: "https://app.matrix-os.com",
+      });
+      expect(auth.poll()).toEqual({ status: "authorized", profile: { handle: "neo", userId: "user-1" } });
+      expect(changes.at(-1)).toMatchObject({
+        signedIn: true,
+        handle: "neo",
+        displayName: "Thomas Anderson",
+      });
+      expect(console.warn).toHaveBeenCalledWith("[auth] failed to persist credential:", "credential save failed");
+      expect(console.warn).toHaveBeenCalledWith("[auth] failed to persist profile:", "profile save failed");
+    } finally {
+      warn.mockRestore();
+    }
+  });
+});
 
-    expect(auth.getStatus()).toEqual({
-      signedIn: true,
-      handle: "neo",
-      runtimeSlot: "primary",
-      platformHost: "https://app.matrix-os.com",
+describe("AuthService expireSession", () => {
+  it("clears the credential, keeps the profile, and emits a signed-out change", async () => {
+    const { auth, store, changes, getProfile } = makeService({
+      credential: VALID,
+      profile: PROFILE,
+      now: 10_000,
     });
-    expect(auth.poll()).toEqual({ status: "authorized", profile: { handle: "neo", userId: "user-1" } });
-    expect(onAuthChanged).toHaveBeenCalledWith({
-      signedIn: true,
-      handle: "neo",
-      runtimeSlot: "primary",
-      platformHost: "https://app.matrix-os.com",
+    await auth.init();
+    await auth.expireSession();
+
+    expect(auth.getToken()).toBeNull();
+    expect(auth.getStatus().signedIn).toBe(false);
+    expect(store.clear).toHaveBeenCalledOnce();
+    expect(getProfile()).not.toBeNull();
+    expect(auth.getStatus().platformHost).toBe("https://app.matrix-os.com");
+    expect(changes.at(-1)).toMatchObject({ signedIn: false });
+  });
+
+  it("is a no-op when there is no active credential", async () => {
+    const { auth, store, changes } = makeService({ credential: null, profile: PROFILE, now: 10_000 });
+    await auth.init();
+    await auth.expireSession();
+    expect(store.clear).not.toHaveBeenCalled();
+    expect(changes).toHaveLength(0);
+  });
+
+  it("emits signed-out status before persistent sign-out cleanup can fail", async () => {
+    const { auth, store, changes } = makeService({
+      credential: VALID,
+      profile: PROFILE,
+      now: 10_000,
     });
-    expect(console.warn).toHaveBeenCalledWith("[auth] failed to persist credential:", "credential save failed");
-    expect(console.warn).toHaveBeenCalledWith("[auth] failed to persist profile:", "profile save failed");
+    const cleanupError = new Error("credential clear failed");
+    vi.mocked(store.clear).mockRejectedValueOnce(cleanupError);
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    try {
+      await auth.init();
+
+      await expect(auth.signOut()).rejects.toThrow(cleanupError);
+
+      expect(auth.getStatus().signedIn).toBe(false);
+      expect(changes.at(-1)).toMatchObject({
+        signedIn: false,
+        runtimeSlot: "primary",
+        platformHost: "https://app.matrix-os.com",
+      });
+    } finally {
+      warn.mockRestore();
+    }
   });
 
   it("does not start polling when sign-out races an in-flight device-code request", async () => {
-    const credentialStore = makeCredentialStore(null);
-    const saveProfile = vi.fn(async () => undefined);
-    const openExternal = vi.fn(async () => undefined);
     let resolveCode!: (response: Response) => void;
     const codePromise = new Promise<Response>((resolve) => {
       resolveCode = resolve;
@@ -402,16 +415,7 @@ describe("AuthService", () => {
         handle: "neo",
       });
     });
-    const auth = new AuthService({
-      credentialStore,
-      platformHost: "https://app.matrix-os.com",
-      fetchFn,
-      openExternal,
-      loadProfile: async () => null,
-      saveProfile,
-      clearProfile: vi.fn(async () => undefined),
-      onAuthChanged: vi.fn(),
-    });
+    const { auth, getProfile, peekCredential, store } = makeService({ now: 10_000, fetchFn });
 
     const flow = auth.startDeviceFlow();
     await Promise.resolve();
@@ -429,8 +433,8 @@ describe("AuthService", () => {
     await expect(flow).rejects.toThrow("Sign-in request was canceled.");
     expect(auth.getStatus().signedIn).toBe(false);
     expect(tokenRequests).toBe(0);
-    expect(openExternal).not.toHaveBeenCalled();
-    expect(credentialStore.saved).toBeNull();
-    expect(saveProfile).not.toHaveBeenCalled();
+    expect(peekCredential()).toBeNull();
+    expect(getProfile()).toBeNull();
+    expect(store.save).not.toHaveBeenCalled();
   });
 });

--- a/tests/desktop/auth-service.test.ts
+++ b/tests/desktop/auth-service.test.ts
@@ -366,7 +366,7 @@ describe("AuthService expireSession", () => {
     expect(changes.at(-1)).toMatchObject({ signedIn: false });
   });
 
-  it("still emits signed-out status when credential cleanup fails", async () => {
+  it("logs credential cleanup failures without re-throwing after expiry", async () => {
     const { auth, store, changes } = makeService({
       credential: VALID,
       profile: PROFILE,
@@ -378,13 +378,14 @@ describe("AuthService expireSession", () => {
     try {
       await auth.init();
 
-      await expect(auth.expireSession()).rejects.toThrow(cleanupError);
+      await expect(auth.expireSession()).resolves.toBeUndefined();
 
       expect(auth.getStatus().signedIn).toBe(false);
       expect(changes.at(-1)).toMatchObject({
         signedIn: false,
         platformHost: "https://app.matrix-os.com",
       });
+      expect(warn).toHaveBeenCalledWith("[auth] failed to clear expired credential:", "credential clear failed");
     } finally {
       warn.mockRestore();
     }

--- a/tests/desktop/auth-service.test.ts
+++ b/tests/desktop/auth-service.test.ts
@@ -366,6 +366,30 @@ describe("AuthService expireSession", () => {
     expect(changes.at(-1)).toMatchObject({ signedIn: false });
   });
 
+  it("still emits signed-out status when credential cleanup fails", async () => {
+    const { auth, store, changes } = makeService({
+      credential: VALID,
+      profile: PROFILE,
+      now: 10_000,
+    });
+    const cleanupError = new Error("credential clear failed");
+    vi.mocked(store.clear).mockRejectedValueOnce(cleanupError);
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    try {
+      await auth.init();
+
+      await expect(auth.expireSession()).rejects.toThrow(cleanupError);
+
+      expect(auth.getStatus().signedIn).toBe(false);
+      expect(changes.at(-1)).toMatchObject({
+        signedIn: false,
+        platformHost: "https://app.matrix-os.com",
+      });
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
   it("is a no-op when there is no active credential", async () => {
     const { auth, store, changes } = makeService({ credential: null, profile: PROFILE, now: 10_000 });
     await auth.init();

--- a/tests/desktop/device-auth.test.ts
+++ b/tests/desktop/device-auth.test.ts
@@ -65,6 +65,41 @@ describe("pollForToken", () => {
     expect(sleeps).toEqual([5000, 5000]);
   });
 
+  it("parses the optional display profile when present", async () => {
+    const fetchFn = vi.fn().mockResolvedValueOnce(
+      jsonResponse(200, {
+        accessToken: "tok",
+        expiresAt: 1,
+        userId: "u1",
+        handle: "neo",
+        displayName: "Thomas Anderson",
+        imageUrl: "https://img.clerk.com/neo.png",
+        email: "neo@matrix-os.com",
+      }),
+    );
+    const result = await pollForToken({ ...base, fetchFn, intervalSeconds: 5, expiresInSeconds: 600, sleep: async () => {} });
+    expect(result.displayName).toBe("Thomas Anderson");
+    expect(result.imageUrl).toBe("https://img.clerk.com/neo.png");
+    expect(result.email).toBe("neo@matrix-os.com");
+  });
+
+  it("ignores a non-string display profile and still returns the token", async () => {
+    const fetchFn = vi.fn().mockResolvedValueOnce(
+      jsonResponse(200, {
+        accessToken: "tok",
+        expiresAt: 1,
+        userId: "u1",
+        handle: "neo",
+        displayName: 42,
+        imageUrl: { not: "a string" },
+      }),
+    );
+    const result = await pollForToken({ ...base, fetchFn, intervalSeconds: 5, expiresInSeconds: 600, sleep: async () => {} });
+    expect(result.accessToken).toBe("tok");
+    expect(result.displayName).toBeUndefined();
+    expect(result.imageUrl).toBeUndefined();
+  });
+
   it("adds 5 seconds to the interval on 429 slow_down", async () => {
     const fetchFn = vi
       .fn()

--- a/tests/desktop/embed-manager.test.ts
+++ b/tests/desktop/embed-manager.test.ts
@@ -176,6 +176,23 @@ describe("EmbedManager", () => {
     expect(view?.bounds).toEqual(BOUNDS);
   });
 
+  it("can open embeds detached so inactive tabs do not flash a native overlay", () => {
+    const { manager, views } = makeManager();
+    const id = manager.open("hosted-shell", null, BOUNDS, "https://gw.test/canvas", {
+      active: false,
+    });
+    const view = views[0]?.view;
+
+    expect(manager.liveCount).toBe(0);
+    expect(view?.events).not.toContain("attach");
+    expect(view?.bounds).toEqual(BOUNDS);
+    expect(view?.loadedUrls).toEqual(["https://gw.test/canvas"]);
+
+    manager.setActive(id, true);
+    expect(manager.liveCount).toBe(1);
+    expect(view?.events).toContain("attach");
+  });
+
   it("propagates adapter lifecycle states to the caller", () => {
     const { manager, views } = makeManager();
     const states: string[] = [];

--- a/tests/desktop/embed-manager.test.ts
+++ b/tests/desktop/embed-manager.test.ts
@@ -386,6 +386,30 @@ describe("EmbedManager", () => {
     expect(manager.has("nope")).toBe(false);
   });
 
+  it("setActive(false) detaches the native view so it can't overlay other tabs", () => {
+    const { manager, views } = makeManager();
+    const id = manager.open("hosted-shell", null, BOUNDS, "https://gw.test/canvas");
+    expect(views[0]?.view.events).toContain("attach");
+    expect(manager.setActive(id, false)).toBe(true);
+    expect(views[0]?.view.events).toContain("detach");
+    expect(manager.liveCount).toBe(0);
+  });
+
+  it("setActive(true) re-attaches a detached embed without reloading", () => {
+    const { manager, views } = makeManager();
+    const id = manager.open("hosted-shell", null, BOUNDS, "https://gw.test/canvas");
+    manager.setActive(id, false);
+    manager.setActive(id, true);
+    expect(views[0]?.view.events.filter((e) => e === "attach")).toHaveLength(2);
+    expect(views[0]?.view.loadedUrls).toHaveLength(1);
+    expect(manager.liveCount).toBe(1);
+  });
+
+  it("setActive returns false for unknown ids", () => {
+    const { manager } = makeManager();
+    expect(manager.setActive("nope", false)).toBe(false);
+  });
+
   it("closeAll destroys every embed including suspended ones", () => {
     const { manager, views } = makeManager(1);
     manager.open("app", "a", BOUNDS, "https://gw.test/a");

--- a/tests/desktop/embed-service.test.ts
+++ b/tests/desktop/embed-service.test.ts
@@ -12,6 +12,42 @@ vi.mock("electron", () => ({
 const BOUNDS: Bounds = { x: 0, y: 0, width: 800, height: 600 };
 
 describe("EmbedService", () => {
+  it("honors pending hosted-shell inactive state when retry auth finishes", async () => {
+    const emitState = vi.fn();
+    const service = new EmbedService({
+      getWindow: () => null,
+      getGatewayOrigin: () => "https://gateway.test",
+      getToken: () => "token",
+      emitState,
+    });
+    const internals = service as unknown as {
+      pendingHostedShells: Map<string, Bounds>;
+      performHostedShellHandoff: (gatewayOrigin: string) => Promise<boolean>;
+      manager: { open: (kind: string, slug: string | null, bounds: Bounds, url: string, options: { active?: boolean }) => string };
+    };
+    const open = vi.spyOn(internals.manager, "open").mockReturnValue("embed-shell");
+    let resolveHandoff!: (ok: boolean) => void;
+    vi.spyOn(internals, "performHostedShellHandoff").mockImplementation(
+      () => new Promise((resolve) => { resolveHandoff = resolve; }),
+    );
+
+    internals.pendingHostedShells.set("embed-shell", BOUNDS);
+    const retry = service.retryAuth("embed-shell");
+    expect(service.setActive("embed-shell", false)).toBe(true);
+
+    resolveHandoff(true);
+    await expect(retry).resolves.toBe(true);
+
+    expect(open).toHaveBeenCalledWith(
+      "hosted-shell",
+      null,
+      BOUNDS,
+      "https://gateway.test/",
+      expect.objectContaining({ id: "embed-shell", active: false }),
+    );
+    expect(emitState).toHaveBeenCalledWith("embed-shell", "loading");
+  });
+
   it("rejects gateway requests when the response stream errors", async () => {
     const service = new EmbedService({
       getWindow: () => null,

--- a/tests/desktop/header-injection.test.ts
+++ b/tests/desktop/header-injection.test.ts
@@ -35,6 +35,7 @@ describe("installGatewayCors", () => {
     const res = fire({ url: `${GATEWAY}/api/channels/status`, method: "GET", responseHeaders: { "content-type": ["application/json"] } });
     expect(res.responseHeaders?.["Access-Control-Allow-Origin"]).toEqual(["http://localhost:5173"]);
     expect(res.responseHeaders?.["Access-Control-Allow-Headers"]?.[0]).toContain("Authorization");
+    expect(res.responseHeaders?.["Access-Control-Allow-Headers"]?.[0]).toContain("x-runtime-slot");
     expect(res.responseHeaders?.["Access-Control-Allow-Credentials"]).toEqual(["true"]);
     expect(res.responseHeaders?.["content-type"]).toEqual(["application/json"]);
   });

--- a/tests/desktop/header-injection.test.ts
+++ b/tests/desktop/header-injection.test.ts
@@ -1,7 +1,69 @@
-import { describe, expect, it } from "vitest";
-import { shouldInjectAuth } from "@desktop/main/auth/header-injection";
+import { describe, expect, it, vi } from "vitest";
+import { installGatewayCors, shouldInjectAuth } from "@desktop/main/auth/header-injection";
 
 const GATEWAY = "https://app.matrix-os.com";
+
+type HeadersReceivedListener = (
+  details: { url: string; method: string; responseHeaders?: Record<string, string[]> },
+  callback: (response: { responseHeaders?: Record<string, string[]>; statusLine?: string }) => void,
+) => void;
+
+function corsSession() {
+  let listener: HeadersReceivedListener | null = null;
+  const session = {
+    webRequest: {
+      onBeforeSendHeaders: () => undefined,
+      onHeadersReceived: (l: HeadersReceivedListener) => {
+        listener = l;
+      },
+    },
+  };
+  return {
+    session,
+    fire(details: { url: string; method: string; responseHeaders?: Record<string, string[]> }) {
+      const cb = vi.fn();
+      listener?.(details, cb);
+      return cb.mock.calls[0]?.[0] ?? {};
+    },
+  };
+}
+
+describe("installGatewayCors", () => {
+  it("adds Access-Control-Allow-Origin for gateway responses", () => {
+    const { session, fire } = corsSession();
+    installGatewayCors(session, () => GATEWAY, "http://localhost:5173");
+    const res = fire({ url: `${GATEWAY}/api/channels/status`, method: "GET", responseHeaders: { "content-type": ["application/json"] } });
+    expect(res.responseHeaders?.["Access-Control-Allow-Origin"]).toEqual(["http://localhost:5173"]);
+    expect(res.responseHeaders?.["Access-Control-Allow-Headers"]?.[0]).toContain("Authorization");
+    expect(res.responseHeaders?.["content-type"]).toEqual(["application/json"]);
+  });
+
+  it("answers preflight OPTIONS with 200", () => {
+    const { session, fire } = corsSession();
+    installGatewayCors(session, () => GATEWAY, "null");
+    const res = fire({ url: `${GATEWAY}/api/projects/x/tasks`, method: "OPTIONS" });
+    expect(res.statusLine).toBe("HTTP/1.1 200 OK");
+    expect(res.responseHeaders?.["Access-Control-Allow-Origin"]).toEqual(["null"]);
+  });
+
+  it("strips any upstream ACAO to avoid duplicates", () => {
+    const { session, fire } = corsSession();
+    installGatewayCors(session, () => GATEWAY, "http://localhost:5173");
+    const res = fire({
+      url: `${GATEWAY}/api/apps`,
+      method: "GET",
+      responseHeaders: { "Access-Control-Allow-Origin": ["https://app.matrix-os.com"] },
+    });
+    expect(res.responseHeaders?.["Access-Control-Allow-Origin"]).toEqual(["http://localhost:5173"]);
+  });
+
+  it("leaves non-gateway responses untouched", () => {
+    const { session, fire } = corsSession();
+    installGatewayCors(session, () => GATEWAY, "http://localhost:5173");
+    const res = fire({ url: "https://evil.example.com/api", method: "GET", responseHeaders: { x: ["1"] } });
+    expect(res.responseHeaders).toBeUndefined();
+  });
+});
 
 describe("shouldInjectAuth", () => {
   it("injects for exact-origin https requests", () => {

--- a/tests/desktop/header-injection.test.ts
+++ b/tests/desktop/header-injection.test.ts
@@ -35,6 +35,7 @@ describe("installGatewayCors", () => {
     const res = fire({ url: `${GATEWAY}/api/channels/status`, method: "GET", responseHeaders: { "content-type": ["application/json"] } });
     expect(res.responseHeaders?.["Access-Control-Allow-Origin"]).toEqual(["http://localhost:5173"]);
     expect(res.responseHeaders?.["Access-Control-Allow-Headers"]?.[0]).toContain("Authorization");
+    expect(res.responseHeaders?.["Access-Control-Allow-Credentials"]).toEqual(["true"]);
     expect(res.responseHeaders?.["content-type"]).toEqual(["application/json"]);
   });
 
@@ -55,6 +56,22 @@ describe("installGatewayCors", () => {
       responseHeaders: { "Access-Control-Allow-Origin": ["https://app.matrix-os.com"] },
     });
     expect(res.responseHeaders?.["Access-Control-Allow-Origin"]).toEqual(["http://localhost:5173"]);
+  });
+
+  it("preserves upstream exposed headers while replacing allow headers", () => {
+    const { session, fire } = corsSession();
+    installGatewayCors(session, () => GATEWAY, "http://localhost:5173");
+    const res = fire({
+      url: `${GATEWAY}/api/apps`,
+      method: "GET",
+      responseHeaders: {
+        "Access-Control-Allow-Origin": ["https://app.matrix-os.com"],
+        "Access-Control-Expose-Headers": ["ETag, X-Matrix-Version"],
+      },
+    });
+    expect(res.responseHeaders?.["Access-Control-Allow-Origin"]).toEqual(["http://localhost:5173"]);
+    expect(res.responseHeaders?.["Access-Control-Expose-Headers"]).toEqual(["ETag, X-Matrix-Version"]);
+    expect(res.responseHeaders?.["Access-Control-Allow-Credentials"]).toEqual(["true"]);
   });
 
   it("leaves non-gateway responses untouched", () => {

--- a/tests/desktop/home-tab.test.tsx
+++ b/tests/desktop/home-tab.test.tsx
@@ -60,4 +60,21 @@ describe("HomeTab", () => {
       );
     });
   });
+
+  it("does not open the hosted shell embed before sign-in is confirmed", () => {
+    useConnection.setState({
+      status: "loading",
+      handle: null,
+      platformHost: "https://platform.test",
+      runtimeSlot: "primary",
+      api: null,
+    });
+
+    render(<HomeTab />);
+
+    expect(invoke).not.toHaveBeenCalledWith(
+      "embed:open",
+      expect.objectContaining({ kind: "hosted-shell" }),
+    );
+  });
 });

--- a/tests/desktop/home-tab.test.tsx
+++ b/tests/desktop/home-tab.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 
 import React from "react";
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { cleanup, render, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import HomeTab from "../../desktop/src/renderer/src/features/mission-control/HomeTab";
 import { useBoard } from "../../desktop/src/renderer/src/stores/board";
@@ -11,9 +11,12 @@ import { useTabs } from "../../desktop/src/renderer/src/stores/tabs";
 import { useUi } from "../../desktop/src/renderer/src/stores/ui";
 
 describe("HomeTab", () => {
+  let invoke: ReturnType<typeof vi.fn>;
+
   beforeEach(() => {
+    invoke = vi.fn(async () => ({ embedId: "embed-test", state: "ready" }));
     vi.stubGlobal("operator", {
-      invoke: vi.fn(async () => ({ embedId: "embed-test", state: "ready" })),
+      invoke,
       on: vi.fn(() => () => undefined),
     });
     vi.stubGlobal(
@@ -47,19 +50,14 @@ describe("HomeTab", () => {
     vi.restoreAllMocks();
   });
 
-  it("surfaces session load errors with a retry action", () => {
-    const load = vi.fn(async () => undefined);
-    useSessions.setState({
-      sessions: [],
-      loading: false,
-      error: "offline",
-      load,
-    });
-
+  it("opens the hosted shell embed", async () => {
     render(<HomeTab />);
 
-    expect(screen.queryByText("Sessions unavailable.")).not.toBeNull();
-    fireEvent.click(screen.getByRole("button", { name: /retry sessions/i }));
-    expect(load).toHaveBeenCalledWith(useConnection.getState().api);
+    await waitFor(() => {
+      expect(invoke).toHaveBeenCalledWith(
+        "embed:open",
+        expect.objectContaining({ kind: "hosted-shell" }),
+      );
+    });
   });
 });

--- a/tests/desktop/ipc-handlers.test.ts
+++ b/tests/desktop/ipc-handlers.test.ts
@@ -35,6 +35,7 @@ function makeHarness(overrides: Partial<HandlerContext> = {}) {
     setBadgeCount: vi.fn(),
     notify: vi.fn(),
     onRuntimeChanged: vi.fn(),
+    getUpdateStatus: vi.fn(() => "disabled"),
     ...overrides,
   } as unknown as HandlerContext;
 
@@ -98,5 +99,11 @@ describe("registerIpcHandlers", () => {
       ok: false,
     });
     expect(console.warn).toHaveBeenCalledWith("[ipc] embed:retry-auth failed:", "handoff unavailable");
+  });
+
+  it("reports the live updater status from the handler context", async () => {
+    const harness = makeHarness({ getUpdateStatus: vi.fn(() => "ready") });
+
+    await expect(harness.invoke("update:check")).resolves.toEqual({ status: "ready" });
   });
 });

--- a/tests/desktop/session-merge.test.ts
+++ b/tests/desktop/session-merge.test.ts
@@ -273,4 +273,15 @@ describe("useSessions store", () => {
     expect(useSessions.getState().sessions.map((s) => s.attachName)).toEqual(["operator-new"]);
     expect(useSessions.getState().error).toBeNull();
   });
+
+  it("keeps the created session visible and preserves refresh errors after create", async () => {
+    const get = vi.fn().mockRejectedValue(new AppError("offline"));
+    const post = vi.fn().mockResolvedValue({ name: "operator-new", created: true });
+
+    const created = await useSessions.getState().create(makeApi(get, post));
+
+    expect(created?.attachName).toBe("operator-new");
+    expect(useSessions.getState().sessions.map((s) => s.attachName)).toEqual(["operator-new"]);
+    expect(useSessions.getState().error).toBe("offline");
+  });
 });

--- a/tests/desktop/session-merge.test.ts
+++ b/tests/desktop/session-merge.test.ts
@@ -146,6 +146,7 @@ describe("useSessions store", () => {
       baseUrl: "https://x.test",
       get,
       post,
+      put: vi.fn(),
       patch: vi.fn(),
       delete: vi.fn(),
       putText: vi.fn(),

--- a/tests/desktop/session-merge.test.ts
+++ b/tests/desktop/session-merge.test.ts
@@ -274,6 +274,21 @@ describe("useSessions store", () => {
     expect(useSessions.getState().error).toBeNull();
   });
 
+  it("clears a stale session error while create is pending", async () => {
+    const created = deferred<{ name: string; created: true }>();
+    const get = vi.fn().mockResolvedValue({ sessions: [], nextCursor: null });
+    const post = vi.fn().mockReturnValue(created.promise);
+
+    useSessions.setState({ error: "offline" });
+    const create = useSessions.getState().create(makeApi(get, post));
+
+    expect(useSessions.getState().loading).toBe(true);
+    expect(useSessions.getState().error).toBeNull();
+
+    created.resolve({ name: "operator-new", created: true });
+    await create;
+  });
+
   it("keeps the created session visible and preserves refresh errors after create", async () => {
     const get = vi.fn().mockRejectedValue(new AppError("offline"));
     const post = vi.fn().mockResolvedValue({ name: "operator-new", created: true });

--- a/tests/desktop/session-merge.test.ts
+++ b/tests/desktop/session-merge.test.ts
@@ -141,11 +141,11 @@ describe("useSessions store", () => {
     useSessions.setState(useSessions.getInitialState(), true);
   });
 
-  function makeApi(get: ReturnType<typeof vi.fn>): ApiClient {
+  function makeApi(get: ReturnType<typeof vi.fn>, post: ReturnType<typeof vi.fn> = vi.fn()): ApiClient {
     return {
       baseUrl: "https://x.test",
       get,
-      post: vi.fn(),
+      post,
       patch: vi.fn(),
       delete: vi.fn(),
       putText: vi.fn(),
@@ -252,5 +252,24 @@ describe("useSessions store", () => {
 
     resolveTerminal?.({ sessions: [] });
     await load;
+  });
+
+  it("creates a terminal session and selects the attachable result", async () => {
+    const get = vi.fn().mockImplementation((path: string) => {
+      if (path === "/api/terminal/sessions") {
+        return Promise.resolve({ sessions: [{ name: "operator-new", status: "active" }] });
+      }
+      return Promise.resolve({ sessions: [], nextCursor: null });
+    });
+    const post = vi.fn().mockResolvedValue({ name: "operator-new", created: true });
+
+    const created = await useSessions.getState().create(makeApi(get, post));
+
+    expect(post).toHaveBeenCalledWith("/api/terminal/sessions", {
+      name: expect.stringMatching(/^operator-[a-z0-9]+-[a-f0-9]{8}$/),
+    });
+    expect(created?.attachName).toBe("operator-new");
+    expect(useSessions.getState().sessions.map((s) => s.attachName)).toEqual(["operator-new"]);
+    expect(useSessions.getState().error).toBeNull();
   });
 });

--- a/tests/desktop/session-merge.test.ts
+++ b/tests/desktop/session-merge.test.ts
@@ -284,4 +284,33 @@ describe("useSessions store", () => {
     expect(useSessions.getState().sessions.map((s) => s.attachName)).toEqual(["operator-new"]);
     expect(useSessions.getState().error).toBe("offline");
   });
+
+  it("keeps a superseding load in progress after create refresh is preempted", async () => {
+    const internalTerminal = deferred<{ sessions: unknown[] }>();
+    const internalWorkspace = deferred<{ sessions: unknown[]; nextCursor: null }>();
+    const competingTerminal = new Promise<{ sessions: unknown[] }>(() => undefined);
+    const competingWorkspace = new Promise<{ sessions: unknown[]; nextCursor: null }>(() => undefined);
+    const post = vi.fn().mockResolvedValue({ name: "operator-new", created: true });
+    let call = 0;
+    const get = vi.fn((path: string) => {
+      call += 1;
+      if (call === 1 && path === "/api/terminal/sessions") return internalTerminal.promise;
+      if (call === 2 && path === "/api/sessions") return internalWorkspace.promise;
+      if (path === "/api/terminal/sessions") return competingTerminal;
+      return competingWorkspace;
+    });
+
+    const createPromise = useSessions.getState().create(makeApi(get, post));
+    while (call < 2) {
+      await Promise.resolve();
+    }
+    void useSessions.getState().load(makeApi(get));
+    expect(useSessions.getState().loading).toBe(true);
+
+    internalTerminal.resolve({ sessions: [{ name: "operator-new", status: "active" }] });
+    internalWorkspace.resolve({ sessions: [], nextCursor: null });
+
+    await expect(createPromise).resolves.toMatchObject({ attachName: "operator-new" });
+    expect(useSessions.getState().loading).toBe(true);
+  });
 });

--- a/tests/desktop/terminals-tab.test.tsx
+++ b/tests/desktop/terminals-tab.test.tsx
@@ -65,6 +65,49 @@ describe("TerminalsTab", () => {
     });
   });
 
+  it("shows loading and load errors instead of the empty session state", async () => {
+    useSessions.setState({ loading: true, error: null, sessions: [] });
+
+    const { rerender } = render(
+      <Tooltip.Provider>
+        <TerminalsTab />
+      </Tooltip.Provider>,
+    );
+
+    expect(screen.getByText("Loading sessions...")).toBeTruthy();
+    expect(screen.queryByText("No sessions on your computer yet.")).toBeNull();
+
+    act(() => {
+      useSessions.setState({ loading: false, error: "offline", sessions: [] });
+    });
+    rerender(
+      <Tooltip.Provider>
+        <TerminalsTab />
+      </Tooltip.Provider>,
+    );
+
+    expect(screen.getByText("Can't reach Matrix OS. Check your connection.")).toBeTruthy();
+    expect(screen.queryByText("No sessions on your computer yet.")).toBeNull();
+  });
+
+  it("surfaces session creation failures", async () => {
+    const create = vi.fn(async () => {
+      useSessions.setState({ error: "server" });
+      return null;
+    });
+    useSessions.setState({ create });
+
+    render(
+      <Tooltip.Provider>
+        <TerminalsTab />
+      </Tooltip.Provider>,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /new session/i }));
+
+    expect(await screen.findByText("Something went wrong. Please try again.")).toBeTruthy();
+  });
+
   it("selects a remaining session when the selected session disappears", async () => {
     useSessions.setState({
       sessions: [

--- a/tests/desktop/terminals-tab.test.tsx
+++ b/tests/desktop/terminals-tab.test.tsx
@@ -64,4 +64,30 @@ describe("TerminalsTab", () => {
       expect(buttons.some((nextButton) => !nextButton.disabled)).toBe(true);
     });
   });
+
+  it("selects a remaining session when the selected session disappears", async () => {
+    useSessions.setState({
+      sessions: [
+        { attachName: "main", name: "main", status: "active", source: "workspace" },
+        { attachName: "next", name: "next", status: "active", source: "workspace" },
+      ],
+    });
+
+    render(
+      <Tooltip.Provider>
+        <TerminalsTab />
+      </Tooltip.Provider>,
+    );
+
+    await screen.findByText("Terminal main");
+
+    act(() => {
+      useSessions.setState({
+        sessions: [{ attachName: "next", name: "next", status: "active", source: "workspace" }],
+      });
+    });
+
+    await screen.findByText("Terminal next");
+    expect(screen.queryByText("Terminal main")).toBeNull();
+  });
 });

--- a/tests/desktop/terminals-tab.test.tsx
+++ b/tests/desktop/terminals-tab.test.tsx
@@ -1,0 +1,68 @@
+// @vitest-environment jsdom
+
+import React from "react";
+import * as Tooltip from "@radix-ui/react-tooltip";
+import { act, cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import TerminalsTab from "../../desktop/src/renderer/src/features/terminal/TerminalsTab";
+import { useConnection } from "../../desktop/src/renderer/src/stores/connection";
+import { useSessions } from "../../desktop/src/renderer/src/stores/sessions";
+
+vi.mock("../../desktop/src/renderer/src/features/terminal/TerminalView", () => ({
+  default: ({ sessionName }: { sessionName: string }) => <div>Terminal {sessionName}</div>,
+}));
+
+describe("TerminalsTab", () => {
+  beforeEach(() => {
+    useConnection.setState({
+      status: "signed-in",
+      handle: "operator",
+      platformHost: "https://platform.test",
+      runtimeSlot: "primary",
+      api: {} as never,
+    });
+    useSessions.setState({
+      sessions: [],
+      creating: false,
+      error: null,
+      load: vi.fn().mockResolvedValue(undefined),
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it("prevents duplicate session creates while one is in flight", async () => {
+    let resolveCreate: ((value: { attachName: string; name: string; status: "active" }) => void) | null = null;
+    const create = vi.fn(
+      () =>
+        new Promise<{ attachName: string; name: string; status: "active" }>((resolve) => {
+          resolveCreate = resolve;
+        }),
+    );
+    useSessions.setState({ create });
+
+    render(
+      <Tooltip.Provider>
+        <TerminalsTab />
+      </Tooltip.Provider>,
+    );
+
+    const button = screen.getAllByRole("button", { name: /new session/i })[0]!;
+    fireEvent.click(button);
+    fireEvent.click(screen.getByRole("button", { name: /creating/i }));
+
+    expect(create).toHaveBeenCalledOnce();
+
+    await act(async () => {
+      resolveCreate?.({ attachName: "main", name: "main", status: "active" });
+      await Promise.resolve();
+    });
+    await waitFor(() => {
+      const buttons = screen.getAllByRole("button", { name: /new session/i }) as HTMLButtonElement[];
+      expect(buttons.some((nextButton) => !nextButton.disabled)).toBe(true);
+    });
+  });
+});

--- a/tests/desktop/terminals-tab.test.tsx
+++ b/tests/desktop/terminals-tab.test.tsx
@@ -23,7 +23,6 @@ describe("TerminalsTab", () => {
     });
     useSessions.setState({
       sessions: [],
-      creating: false,
       error: null,
       load: vi.fn().mockResolvedValue(undefined),
     });

--- a/tests/e2e/desktop/fixtures/stub-gateway.ts
+++ b/tests/e2e/desktop/fixtures/stub-gateway.ts
@@ -24,6 +24,11 @@ function json(res: ServerResponse, status: number, body: unknown): void {
   res.end(JSON.stringify(body));
 }
 
+function html(res: ServerResponse, status: number, body: string): void {
+  res.writeHead(status, { "content-type": "text/html; charset=utf-8" });
+  res.end(body);
+}
+
 async function readBody(req: IncomingMessage): Promise<Record<string, unknown>> {
   const chunks: Buffer[] = [];
   for await (const chunk of req) chunks.push(chunk as Buffer);
@@ -113,9 +118,39 @@ export async function startStubGateway(): Promise<StubGateway> {
       return;
     }
 
+    if (req.method === "GET" && path === "/") {
+      html(
+        res,
+        200,
+        `<!doctype html>
+          <html>
+            <body style="margin:0;background:#083344;color:#ecfeff;font:600 20px system-ui;display:grid;place-items:center;min-height:100vh">
+              <main style="text-align:center">
+                <div>Stub Hosted Shell</div>
+                <small style="display:block;margin-top:8px;font-size:13px;color:#a5f3fc">Canvas preview</small>
+              </main>
+            </body>
+          </html>`,
+      );
+      return;
+    }
+
     // Everything below requires the bearer header (verifies header injection).
     if (req.headers.authorization !== `Bearer ${TOKEN}`) {
       json(res, 401, { error: "unauthorized" });
+      return;
+    }
+
+    if (req.method === "POST" && path === "/api/auth/app-session") {
+      await readBody(req);
+      res.writeHead(200, {
+        "content-type": "application/json",
+        "set-cookie": [
+          "matrix_app_session=stub-app-session; Path=/; HttpOnly; SameSite=Lax",
+          "matrix_native_app_session=stub-native-session; Path=/; HttpOnly; SameSite=Lax",
+        ],
+      });
+      res.end(JSON.stringify({ ok: true }));
       return;
     }
 

--- a/tests/e2e/desktop/fixtures/stub-gateway.ts
+++ b/tests/e2e/desktop/fixtures/stub-gateway.ts
@@ -114,6 +114,7 @@ export async function startStubGateway(): Promise<StubGateway> {
         expiresAt: Date.now() + 3_600_000,
         userId: "user-1",
         handle: "neo",
+        displayName: "Thomas Anderson",
       });
       return;
     }

--- a/tests/e2e/desktop/operator.e2e.test.ts
+++ b/tests/e2e/desktop/operator.e2e.test.ts
@@ -87,10 +87,22 @@ suite("operator desktop e2e", () => {
     await page.screenshot({ path: join(SCREENSHOT_DIR, "04-agents.png") });
   }, 30_000);
 
-  it("renders the app launcher from the gateway catalog", async () => {
-    await page.getByRole("button", { name: "Apps" }).click();
-    await page.getByText("Notes").waitFor({ timeout: 10_000 });
-    await page.getByText("Pomodoro").waitFor({ timeout: 10_000 });
-    await page.screenshot({ path: join(SCREENSHOT_DIR, "04-apps.png") });
+  it("opens the Terminal workspace with a session sidebar", async () => {
+    await page.locator("aside button", { hasText: "Terminal" }).first().click();
+    // Inner sessions sidebar lists the VPS session as a clickable button
+    // (the hidden task-tab chip with the same name is a span, not matched here).
+    await page.getByText("Sessions").first().waitFor({ timeout: 10_000 });
+    await page.locator("button", { hasText: "matrix-task-1" }).first().waitFor({ state: "visible", timeout: 10_000 });
+    await page.screenshot({ path: join(SCREENSHOT_DIR, "05-terminal-workspace.png") });
+  }, 30_000);
+
+  it("lists apps and opens one as a tab", async () => {
+    await page.locator("aside button", { hasText: "Apps" }).first().click();
+    await page.getByText("Notes").first().waitFor({ timeout: 10_000 });
+    await page.getByText("Pomodoro").first().waitFor({ timeout: 10_000 });
+    await page.getByText("Notes").first().click();
+    // The app opens in its own tab (tab chip with the app name).
+    await page.locator('[role="tab"]', { hasText: "Notes" }).first().waitFor({ timeout: 10_000 });
+    await page.screenshot({ path: join(SCREENSHOT_DIR, "06-apps.png") });
   }, 30_000);
 });

--- a/tests/e2e/desktop/operator.e2e.test.ts
+++ b/tests/e2e/desktop/operator.e2e.test.ts
@@ -21,6 +21,13 @@ suite("operator desktop e2e", () => {
   let page: Page;
   let userDataDir: string;
 
+  async function attachedNativeViewCount(): Promise<number> {
+    return app.evaluate(({ BrowserWindow }) => {
+      const window = BrowserWindow.getAllWindows()[0];
+      return window?.contentView.children.length ?? 0;
+    });
+  }
+
   beforeAll(async () => {
     mkdirSync(SCREENSHOT_DIR, { recursive: true });
     gateway = await startStubGateway();
@@ -105,4 +112,31 @@ suite("operator desktop e2e", () => {
     await page.locator('[role="tab"]', { hasText: "Notes" }).first().waitFor({ timeout: 10_000 });
     await page.screenshot({ path: join(SCREENSHOT_DIR, "06-apps.png") });
   }, 30_000);
+
+  it("detaches the hosted shell while non-Home tabs are active", async () => {
+    await page.locator("aside button", { hasText: "Home" }).first().click();
+    await page.getByText(/Welcome back/i).first().waitFor({ timeout: 10_000 });
+    await expect.poll(attachedNativeViewCount).toBe(1);
+    await page.screenshot({ path: join(SCREENSHOT_DIR, "07-home-shell-active.png") });
+
+    await page.locator("aside button", { hasText: "Settings" }).first().click();
+    await page.getByRole("heading", { name: "Settings" }).waitFor({ timeout: 10_000 });
+    await expect.poll(attachedNativeViewCount).toBe(0);
+    await page.screenshot({ path: join(SCREENSHOT_DIR, "08-settings-no-shell-overlay.png") });
+
+    await page.locator("aside button", { hasText: "Chat" }).first().click();
+    await page.getByRole("heading", { name: /What should we build/i }).waitFor({ timeout: 10_000 });
+    await expect.poll(attachedNativeViewCount).toBe(0);
+    await page.screenshot({ path: join(SCREENSHOT_DIR, "09-chat-no-shell-overlay.png") });
+
+    await page.locator("aside button", { hasText: "Apps" }).first().click();
+    await page.getByText("Notes").first().waitFor({ timeout: 10_000 });
+    await expect.poll(attachedNativeViewCount).toBe(0);
+    await page.screenshot({ path: join(SCREENSHOT_DIR, "10-apps-no-shell-overlay.png") });
+
+    await page.locator("aside button", { hasText: "Home" }).first().click();
+    await page.getByText(/Welcome back/i).first().waitFor({ timeout: 10_000 });
+    await expect.poll(attachedNativeViewCount).toBe(1);
+    await page.screenshot({ path: join(SCREENSHOT_DIR, "11-home-shell-restored.png") });
+  }, 40_000);
 });


### PR DESCRIPTION
## Summary
- Adds terminal tabs, home shell preview, embed detachment fixes, desktop CORS/auth/profile readiness, and model config readiness.
- Part of the 094 Operator desktop stack split from original PR #507.
- Draft until the full stack validation and screenshots are refreshed.

## Validation
- Rebased onto current main after #506 merged.
- Rebuilt stack final tree matches the original #507 tree exactly.
- Per-layer CI/Greptile still needs to settle before review-ready.

## Invariants
- Source of truth: desktop app source under desktop/, specs/docs, and root workspace metadata in this stack; no owner runtime data is modified.
- Lock/transaction scope: no Postgres transaction scope is introduced in this layer; desktop local state remains scoped to the Electron app and existing gateway/platform APIs.
- Acceptable orphan states: stack PRs are draft and must land in order; partial stack landing is not a supported release state.
- Auth source of truth: Clerk/device auth and existing gateway token handling remain authoritative; this stack does not add a second auth authority.
- Deferred scope: packaged distribution, production desktop rollout, and customer VPS host-bundle deploy are outside this stack.

## Greptile Deferrals

- Current-head Greptile is 4/5 on 1c9fbe038a9bcf24c366aedd4a9f4fd6f059c584. The remaining items are non-blocking follow-ups: ModelEffortCard stale error clearing and auth/profile event hardening. Deferred to #572.
