### PR TITLE
feat(desktop): add coding control-plane actions

### DIFF
--- a/desktop/src/renderer/src/features/board/Board.tsx
+++ b/desktop/src/renderer/src/features/board/Board.tsx
@@ -16,6 +16,8 @@ import { toUserMessage } from "../../lib/errors";
 import { AppError } from "../../../../shared/app-error";
 import { useBoard, BOARD_COLUMNS, groupCardsByColumn, type Card, type CardStatus } from "../../stores/board";
 import { useConnection } from "../../stores/connection";
+import { useGit } from "../../stores/git";
+import { useSessions } from "../../stores/sessions";
 import { useUi } from "../../stores/ui";
 import BoardCard from "./BoardCard";
 import CreateTaskDialog from "./CreateTaskDialog";
@@ -107,6 +109,9 @@ export default function Board({ projectSlug, active = true }: { projectSlug?: st
   const error = useBoard((s) => s.error);
   const moveTask = useBoard((s) => s.moveTask);
   const selectProject = useBoard((s) => s.selectProject);
+  const sessionsLoad = useSessions((s) => s.load);
+  const gitLoadAll = useGit((s) => s.loadAll);
+  const gitLoadPreviews = useGit((s) => s.loadPreviews);
   const createTaskOpen = useUi((s) => s.createTaskOpen);
   const setCreateTaskOpen = useUi((s) => s.setCreateTaskOpen);
   const [activeDragId, setActiveDragId] = useState<string | null>(null);
@@ -116,6 +121,14 @@ export default function Board({ projectSlug, active = true }: { projectSlug?: st
   useEffect(() => {
     if (api && activeSlug && active) void selectProject(api, activeSlug);
   }, [api, active, activeSlug, selectProject]);
+
+  // Live development state for the card badges (session/branch/dirty/preview).
+  useEffect(() => {
+    if (!api || !activeSlug) return;
+    void sessionsLoad(api);
+    void gitLoadAll(api, activeSlug);
+    void gitLoadPreviews(api, activeSlug);
+  }, [api, activeSlug, sessionsLoad, gitLoadAll, gitLoadPreviews]);
 
   const columns = useMemo(() => groupCardsByColumn(cards), [cards]);
 

--- a/desktop/src/renderer/src/features/board/Board.tsx
+++ b/desktop/src/renderer/src/features/board/Board.tsx
@@ -124,11 +124,11 @@ export default function Board({ projectSlug, active = true }: { projectSlug?: st
 
   // Live development state for the card badges (session/branch/dirty/preview).
   useEffect(() => {
-    if (!api || !activeSlug) return;
+    if (!api || !activeSlug || !active) return;
     void sessionsLoad(api);
     void gitLoadAll(api, activeSlug);
     void gitLoadPreviews(api, activeSlug);
-  }, [api, activeSlug, sessionsLoad, gitLoadAll, gitLoadPreviews]);
+  }, [api, active, activeSlug, sessionsLoad, gitLoadAll, gitLoadPreviews]);
 
   const columns = useMemo(() => groupCardsByColumn(cards), [cards]);
 

--- a/desktop/src/renderer/src/features/board/BoardCard.tsx
+++ b/desktop/src/renderer/src/features/board/BoardCard.tsx
@@ -1,7 +1,12 @@
-import { SquareTerminal } from "lucide-react";
-import { ContextMenu, type MenuItem } from "../../design/primitives";
+import { GitBranch, Globe, SquareTerminal } from "lucide-react";
+import { useMemo } from "react";
+import { ContextMenu, StatusDot, type MenuItem } from "../../design/primitives";
+import { invoke } from "../../lib/operator";
+import { startTaskSession } from "../../lib/task-sessions";
 import { useBoard, BOARD_COLUMNS, type Card } from "../../stores/board";
 import { useConnection } from "../../stores/connection";
+import { useGit } from "../../stores/git";
+import { useSessions } from "../../stores/sessions";
 import { useTabs } from "../../stores/tabs";
 
 const PRIORITY_STYLE: Record<Card["priority"], { label: string; color: string } | null> = {
@@ -19,11 +24,64 @@ export default function BoardCard({ card, overlay = false }: { card: Card; overl
   const updateTask = useBoard((s) => s.updateTask);
   const archiveTask = useBoard((s) => s.archiveTask);
   const deleteTask = useBoard((s) => s.deleteTask);
+  // Raw store slices (stable refs); derive per-card view with useMemo so the
+  // selector never allocates a fresh array each render (Zustand rule).
+  const sessions = useSessions((s) => s.sessions);
+  const aliasMap = useSessions((s) => s.aliasMap);
+  const worktrees = useGit((s) => s.worktrees);
+  const previews = useGit((s) => s.previews);
+
+  const sessionLive = useMemo(() => {
+    if (!card.linkedSessionId) return false;
+    const attach = aliasMap[card.linkedSessionId];
+    return attach ? sessions.some((s) => s.attachName === attach && s.status === "active") : false;
+  }, [card.linkedSessionId, aliasMap, sessions]);
+
+  const worktree = useMemo(
+    () => (card.linkedWorktreeId ? worktrees.find((w) => w.id === card.linkedWorktreeId) ?? null : null),
+    [card.linkedWorktreeId, worktrees],
+  );
+
+  const cardPreviews = useMemo(() => previews.filter((p) => p.taskId === card.id), [previews, card.id]);
+  const previewUrl = cardPreviews.find((p) => typeof p.url === "string" && p.url.length > 0)?.url ?? null;
+  const previewColor =
+    cardPreviews.length === 0
+      ? null
+      : cardPreviews.some((p) => p.lastStatus === "failed")
+        ? "var(--danger)"
+        : cardPreviews.every((p) => p.lastStatus === "ok")
+          ? "var(--success)"
+          : "var(--text-tertiary)";
 
   const priority = PRIORITY_STYLE[card.priority];
+  const hasBadges =
+    priority !== null ||
+    card.tags.length > 0 ||
+    card.linkedSessionId !== null ||
+    worktree !== null ||
+    cardPreviews.length > 0;
+
+  const startAgent = (agent: "claude" | "codex") => {
+    if (!api) return;
+    void startTaskSession(api, {
+      projectSlug: card.projectSlug,
+      taskId: card.id,
+      worktreeId: card.linkedWorktreeId,
+      title: card.title,
+      description: card.description,
+      kind: "agent",
+      agent,
+    });
+  };
 
   const menuItems: MenuItem[] = [
     { label: "Open", onSelect: openCard },
+    { label: "Open terminal", onSelect: openCard },
+    { label: "Start Claude", onSelect: () => startAgent("claude") },
+    { label: "Start Codex", onSelect: () => startAgent("codex") },
+    ...(previewUrl
+      ? [{ label: "Open preview", onSelect: () => void invoke("shell:open-external", { url: previewUrl }) }]
+      : []),
     ...BOARD_COLUMNS.filter((s) => s !== card.status).map((status) => ({
       label: `Move to ${status[0]?.toUpperCase()}${status.slice(1)}`,
       onSelect: () => {
@@ -65,14 +123,14 @@ export default function BoardCard({ card, overlay = false }: { card: Card; overl
       <span className="text-sm leading-snug" style={{ color: "var(--text-primary)" }}>
         {card.title}
       </span>
-      {priority || card.tags.length > 0 || card.linkedSessionId ? (
+      {hasBadges ? (
         <div className="flex items-center gap-1.5">
           {priority ? (
             <span className="text-xs font-medium" style={{ color: priority.color }}>
               {priority.label}
             </span>
           ) : null}
-          {card.tags.slice(0, 3).map((tag) => (
+          {card.tags.slice(0, 2).map((tag) => (
             <span
               key={tag}
               className="rounded px-1.5 py-px text-xs"
@@ -82,8 +140,22 @@ export default function BoardCard({ card, overlay = false }: { card: Card; overl
             </span>
           ))}
           <div className="flex-1" />
+          {worktree ? (
+            <span
+              className="flex items-center gap-0.5 text-xs"
+              style={{ color: "var(--text-tertiary)" }}
+              title={worktree.dirtyState === "dirty" ? "Uncommitted changes" : "Clean"}
+            >
+              <GitBranch size={11} />
+              {worktree.dirtyCount ? <span style={{ color: "var(--highlight)" }}>±{worktree.dirtyCount}</span> : null}
+            </span>
+          ) : null}
+          {previewColor ? <Globe size={12} style={{ color: previewColor }} /> : null}
           {card.linkedSessionId ? (
-            <SquareTerminal size={13} style={{ color: "var(--text-tertiary)" }} />
+            <span className="flex items-center gap-1" title={sessionLive ? "Live session" : "Session"}>
+              {sessionLive ? <StatusDot color="var(--success)" pulse /> : null}
+              <SquareTerminal size={13} style={{ color: sessionLive ? "var(--success)" : "var(--text-tertiary)" }} />
+            </span>
           ) : null}
         </div>
       ) : null}

--- a/desktop/src/renderer/src/features/board/BoardCard.tsx
+++ b/desktop/src/renderer/src/features/board/BoardCard.tsx
@@ -76,7 +76,6 @@ export default function BoardCard({ card, overlay = false }: { card: Card; overl
 
   const menuItems: MenuItem[] = [
     { label: "Open", onSelect: openCard },
-    { label: "Open terminal", onSelect: openCard },
     { label: "Start Claude", onSelect: () => startAgent("claude") },
     { label: "Start Codex", onSelect: () => startAgent("codex") },
     ...(previewUrl

--- a/desktop/src/renderer/src/features/board/BoardCard.tsx
+++ b/desktop/src/renderer/src/features/board/BoardCard.tsx
@@ -43,7 +43,18 @@ export default function BoardCard({ card, overlay = false }: { card: Card; overl
   );
 
   const cardPreviews = useMemo(() => previews.filter((p) => p.taskId === card.id), [previews, card.id]);
-  const previewUrl = cardPreviews.find((p) => typeof p.url === "string" && p.url.length > 0)?.url ?? null;
+  const previewUrl = useMemo(() => {
+    for (const preview of cardPreviews) {
+      if (typeof preview.url !== "string" || preview.url.length === 0) continue;
+      try {
+        const url = new URL(preview.url);
+        if (url.protocol === "https:") return url.toString();
+      } catch (err: unknown) {
+        console.warn("[board] Ignoring invalid preview URL:", err instanceof Error ? err.message : String(err));
+      }
+    }
+    return null;
+  }, [cardPreviews]);
   const previewColor =
     cardPreviews.length === 0
       ? null
@@ -63,7 +74,7 @@ export default function BoardCard({ card, overlay = false }: { card: Card; overl
 
   const startAgent = (agent: "claude" | "codex") => {
     if (!api) return;
-    void startTaskSession(api, {
+    startTaskSession(api, {
       projectSlug: card.projectSlug,
       taskId: card.id,
       worktreeId: card.linkedWorktreeId,
@@ -71,7 +82,14 @@ export default function BoardCard({ card, overlay = false }: { card: Card; overl
       description: card.description,
       kind: "agent",
       agent,
-    });
+    }).then(
+      (ok) => {
+        if (!ok) console.warn(`[board] Failed to start ${agent} session for task ${card.id}`);
+      },
+      (err: unknown) => {
+        console.warn("[board] Start agent failed:", err instanceof Error ? err.message : String(err));
+      },
+    );
   };
 
   const menuItems: MenuItem[] = [

--- a/desktop/src/renderer/src/features/board/BoardCard.tsx
+++ b/desktop/src/renderer/src/features/board/BoardCard.tsx
@@ -74,7 +74,7 @@ export default function BoardCard({ card, overlay = false }: { card: Card; overl
     cardPreviews.length > 0;
 
   const startAgent = async (agent: "claude" | "codex") => {
-    if (!api) return;
+    if (!api || sessionLive) return;
     setStartError(null);
     try {
       const ok = await startTaskSession(api, {
@@ -98,8 +98,12 @@ export default function BoardCard({ card, overlay = false }: { card: Card; overl
 
   const menuItems: MenuItem[] = [
     { label: "Open", onSelect: openCard },
-    { label: "Start Claude", onSelect: () => void startAgent("claude") },
-    { label: "Start Codex", onSelect: () => void startAgent("codex") },
+    ...(sessionLive
+      ? []
+      : [
+          { label: "Start Claude", onSelect: () => void startAgent("claude") },
+          { label: "Start Codex", onSelect: () => void startAgent("codex") },
+        ]),
     ...(previewUrl
       ? [{ label: "Open preview", onSelect: () => void invoke("shell:open-external", { url: previewUrl }) }]
       : []),

--- a/desktop/src/renderer/src/features/board/BoardCard.tsx
+++ b/desktop/src/renderer/src/features/board/BoardCard.tsx
@@ -1,5 +1,5 @@
 import { GitBranch, Globe, SquareTerminal } from "lucide-react";
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
 import { ContextMenu, StatusDot, type MenuItem } from "../../design/primitives";
 import { invoke } from "../../lib/operator";
 import { startTaskSession } from "../../lib/task-sessions";
@@ -30,6 +30,7 @@ export default function BoardCard({ card, overlay = false }: { card: Card; overl
   const aliasMap = useSessions((s) => s.aliasMap);
   const worktrees = useGit((s) => s.worktrees);
   const previews = useGit((s) => s.previews);
+  const [startError, setStartError] = useState<string | null>(null);
 
   const sessionLive = useMemo(() => {
     if (!card.linkedSessionId) return false;
@@ -72,30 +73,33 @@ export default function BoardCard({ card, overlay = false }: { card: Card; overl
     worktree !== null ||
     cardPreviews.length > 0;
 
-  const startAgent = (agent: "claude" | "codex") => {
+  const startAgent = async (agent: "claude" | "codex") => {
     if (!api) return;
-    startTaskSession(api, {
-      projectSlug: card.projectSlug,
-      taskId: card.id,
-      worktreeId: card.linkedWorktreeId,
-      title: card.title,
-      description: card.description,
-      kind: "agent",
-      agent,
-    }).then(
-      (ok) => {
-        if (!ok) console.warn(`[board] Failed to start ${agent} session for task ${card.id}`);
-      },
-      (err: unknown) => {
-        console.warn("[board] Start agent failed:", err instanceof Error ? err.message : String(err));
-      },
-    );
+    setStartError(null);
+    try {
+      const ok = await startTaskSession(api, {
+        projectSlug: card.projectSlug,
+        taskId: card.id,
+        worktreeId: card.linkedWorktreeId,
+        title: card.title,
+        description: card.description,
+        kind: "agent",
+        agent,
+      });
+      if (!ok) {
+        setStartError(`Couldn't start ${agent}.`);
+        console.warn(`[board] Failed to start ${agent} session for task ${card.id}`);
+      }
+    } catch (err: unknown) {
+      setStartError(`Couldn't start ${agent}.`);
+      console.warn("[board] Start agent failed:", err instanceof Error ? err.message : String(err));
+    }
   };
 
   const menuItems: MenuItem[] = [
     { label: "Open", onSelect: openCard },
-    { label: "Start Claude", onSelect: () => startAgent("claude") },
-    { label: "Start Codex", onSelect: () => startAgent("codex") },
+    { label: "Start Claude", onSelect: () => void startAgent("claude") },
+    { label: "Start Codex", onSelect: () => void startAgent("codex") },
     ...(previewUrl
       ? [{ label: "Open preview", onSelect: () => void invoke("shell:open-external", { url: previewUrl }) }]
       : []),
@@ -175,6 +179,11 @@ export default function BoardCard({ card, overlay = false }: { card: Card; overl
             </span>
           ) : null}
         </div>
+      ) : null}
+      {startError ? (
+        <span className="text-xs" style={{ color: "var(--danger)" }}>
+          {startError}
+        </span>
       ) : null}
     </div>
   );

--- a/desktop/src/renderer/src/features/terminal/TerminalsTab.tsx
+++ b/desktop/src/renderer/src/features/terminal/TerminalsTab.tsx
@@ -170,7 +170,7 @@ export default function TerminalsTab() {
                         type="button"
                         aria-label="Kill session"
                         title="Kill session"
-                        disabled={busy !== null}
+                        disabled={creating || busy !== null}
                         onClick={() => void killSession(s.attachName)}
                         className="flex h-6 w-6 items-center justify-center rounded opacity-0 transition-opacity group-hover/session:opacity-100 disabled:opacity-40"
                         style={{ color: "var(--text-tertiary)" }}

--- a/desktop/src/renderer/src/features/terminal/TerminalsTab.tsx
+++ b/desktop/src/renderer/src/features/terminal/TerminalsTab.tsx
@@ -1,22 +1,36 @@
-import { Plus, RefreshCw, SquareTerminal } from "lucide-react";
-import { useEffect, useState } from "react";
+import { Plus, RefreshCw, RotateCcw, SquareTerminal, X } from "lucide-react";
+import { useEffect, useMemo, useState } from "react";
 import { Button, EmptyState, IconButton, StatusDot } from "../../design/primitives";
 import { categoryMessage } from "../../../../shared/app-error";
+import type { AttachableSession } from "../../lib/session-merge";
+import { useBoard } from "../../stores/board";
 import { useConnection } from "../../stores/connection";
 import { useSessions } from "../../stores/sessions";
 import TerminalView from "./TerminalView";
 
-// The Terminal workspace: an inner sidebar listing every VPS session, with the
-// selected one attached on the right. Mirrors the shell's terminal app.
+interface SessionGroup {
+  key: string;
+  label: string;
+  sessions: AttachableSession[];
+}
+
+// The Terminal workspace: an inner sidebar listing every VPS session grouped by
+// the task it belongs to, with the selected one attached on the right. Mirrors
+// the shell's terminal app, plus new/kill/restart controls.
 export default function TerminalsTab() {
   const api = useConnection((s) => s.api);
   const sessions = useSessions((s) => s.sessions);
   const loading = useSessions((s) => s.loading);
   const error = useSessions((s) => s.error);
+  const aliasMap = useSessions((s) => s.aliasMap);
   const load = useSessions((s) => s.load);
   const create = useSessions((s) => s.create);
+  const kill = useSessions((s) => s.kill);
+  const creating = useSessions((s) => s.creating);
+  const cardsByProject = useBoard((s) => s.cardsByProject);
+  const projects = useBoard((s) => s.projects);
   const [selected, setSelected] = useState<string | null>(null);
-  const [creating, setCreating] = useState(false);
+  const [busy, setBusy] = useState<string | null>(null);
 
   useEffect(() => {
     if (api) void load(api);
@@ -32,10 +46,70 @@ export default function TerminalsTab() {
     }
   }, [sessions, selected]);
 
+  // attachName -> task label, derived from board cards (no merge change needed).
+  const taskByAttach = useMemo(() => {
+    const map: Record<string, { title: string; projectSlug: string }> = {};
+    for (const cards of Object.values(cardsByProject)) {
+      for (const c of cards) {
+        if (!c.linkedSessionId) continue;
+        const attach = aliasMap[c.linkedSessionId];
+        if (attach) map[attach] = { title: c.title, projectSlug: c.projectSlug };
+      }
+    }
+    return map;
+  }, [cardsByProject, aliasMap]);
+
+  const projectName = useMemo(() => {
+    const m: Record<string, string> = {};
+    for (const p of projects) m[p.slug] = p.name;
+    return m;
+  }, [projects]);
+
+  const groups = useMemo<SessionGroup[]>(() => {
+    const byProject = new Map<string, AttachableSession[]>();
+    const other: AttachableSession[] = [];
+    for (const s of sessions) {
+      const task = taskByAttach[s.attachName];
+      if (task) {
+        const arr = byProject.get(task.projectSlug) ?? [];
+        arr.push(s);
+        byProject.set(task.projectSlug, arr);
+      } else {
+        other.push(s);
+      }
+    }
+    const out: SessionGroup[] = [];
+    for (const [slug, list] of byProject) {
+      out.push({ key: slug, label: projectName[slug] ?? slug, sessions: list });
+    }
+    if (other.length > 0) out.push({ key: "__other__", label: "Other sessions", sessions: other });
+    return out;
+  }, [sessions, taskByAttach, projectName]);
+
+  const labelFor = (s: AttachableSession) => taskByAttach[s.attachName]?.title ?? s.name;
+
+  const newSession = async () => {
+    if (!api || creating) return;
+    const created = await create(api, { kind: "shell" });
+    if (created?.attachName) setSelected(created.attachName);
+  };
+
+  const killSession = async (attachName: string) => {
+    if (!api || busy) return;
+    setBusy(attachName);
+    try {
+      await kill(api, attachName);
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  const selectedSession = sessions.find((s) => s.attachName === selected) ?? null;
+
   return (
     <div className="flex min-h-0 flex-1">
       <div
-        className="flex w-[220px] shrink-0 flex-col border-r"
+        className="flex w-[230px] shrink-0 flex-col border-r"
         style={{ borderColor: "var(--border-subtle)", background: "var(--bg-surface)" }}
       >
         <div className="flex items-center justify-between border-b px-3 py-2.5" style={{ borderColor: "var(--border-subtle)" }}>
@@ -55,54 +129,92 @@ export default function TerminalsTab() {
           ) : sessions.length === 0 && !error ? (
             <p className="px-2.5 py-2 text-xs" style={{ color: "var(--text-tertiary)" }}>No sessions on your computer yet.</p>
           ) : (
-            sessions.map((s) => {
-              const active = s.attachName === selected;
-              return (
-                <button
-                  key={s.attachName}
-                  type="button"
-                  className="flex items-center gap-2 rounded-md px-2.5 py-1.5 text-left transition-colors duration-100"
-                  style={{ background: active ? "var(--bg-selected)" : "transparent" }}
-                  onMouseEnter={(e) => { if (!active) e.currentTarget.style.background = "var(--bg-hover)"; }}
-                  onMouseLeave={(e) => { if (!active) e.currentTarget.style.background = "transparent"; }}
-                  onClick={() => setSelected(s.attachName)}
-                >
-                  <StatusDot color={s.status === "active" ? "var(--status-complete)" : "var(--status-todo)"} />
-                  <span className="min-w-0 flex-1 truncate font-mono text-xs" style={{ color: "var(--text-primary)" }}>{s.name}</span>
-                </button>
-              );
-            })
+            groups.map((group) => (
+              <div key={group.key} className="mb-1 flex flex-col gap-0.5">
+                <span className="px-2.5 pt-1.5 pb-0.5 text-xs font-semibold tracking-wide uppercase" style={{ color: "var(--text-tertiary)" }}>
+                  {group.label}
+                </span>
+                {group.sessions.map((s) => {
+                  const active = s.attachName === selected;
+                  const exited = s.status === "exited";
+                  return (
+                    <div
+                      key={s.attachName}
+                      className="group/session flex items-center gap-2 rounded-md px-2.5 py-1.5 transition-colors duration-100"
+                      style={{ background: active ? "var(--bg-selected)" : "transparent" }}
+                      onMouseEnter={(e) => { if (!active) e.currentTarget.style.background = "var(--bg-hover)"; }}
+                      onMouseLeave={(e) => { if (!active) e.currentTarget.style.background = "transparent"; }}
+                    >
+                      <StatusDot color={exited ? "var(--status-todo)" : "var(--status-complete)"} pulse={!exited && active} />
+                      <button
+                        type="button"
+                        className="flex min-w-0 flex-1 flex-col text-left"
+                        onClick={() => setSelected(s.attachName)}
+                      >
+                        <span className="truncate text-xs" style={{ color: "var(--text-primary)" }}>{labelFor(s)}</span>
+                        <span className="truncate font-mono text-[10px]" style={{ color: "var(--text-tertiary)" }}>{s.name}</span>
+                      </button>
+                      {exited ? (
+                        <IconButton label="Restart session" onClick={() => void newSession()}>
+                          <RotateCcw size={12} />
+                        </IconButton>
+                      ) : null}
+                      <button
+                        type="button"
+                        aria-label="Kill session"
+                        title="Kill session"
+                        disabled={busy === s.attachName}
+                        onClick={() => void killSession(s.attachName)}
+                        className="flex h-6 w-6 items-center justify-center rounded opacity-0 transition-opacity group-hover/session:opacity-100 disabled:opacity-40"
+                        style={{ color: "var(--text-tertiary)" }}
+                        onMouseEnter={(e) => (e.currentTarget.style.color = "var(--danger)")}
+                        onMouseLeave={(e) => (e.currentTarget.style.color = "var(--text-tertiary)")}
+                      >
+                        <X size={13} />
+                      </button>
+                    </div>
+                  );
+                })}
+              </div>
+            ))
           )}
         </div>
         <div className="border-t p-2" style={{ borderColor: "var(--border-subtle)" }}>
-          <Button
-            variant="subtle"
-            className="w-full justify-center"
-            disabled={!api || creating}
-            onClick={() => {
-              if (!api || creating) return;
-              setCreating(true);
-              void create(api)
-                .then((session) => {
-                  if (session) setSelected(session.attachName);
-                })
-                .finally(() => setCreating(false));
-            }}
-          >
+          <Button variant="subtle" className="w-full justify-center" disabled={!api || creating} onClick={() => void newSession()}>
             <Plus size={13} />
-            {creating ? "Creating…" : "New session"}
+            {creating ? "Starting…" : "New session"}
           </Button>
         </div>
       </div>
 
       <div className="flex min-h-0 min-w-0 flex-1 flex-col">
-        {selected ? (
-          <TerminalView key={selected} sessionName={selected} active />
+        {selectedSession ? (
+          <>
+            <div
+              className="flex shrink-0 items-center gap-2 border-b px-3 py-1.5"
+              style={{ borderColor: "var(--border-subtle)", background: "var(--bg-surface)" }}
+            >
+              <StatusDot color={selectedSession.status === "exited" ? "var(--status-todo)" : "var(--status-complete)"} pulse={selectedSession.status !== "exited"} />
+              <span className="truncate text-sm font-medium" style={{ color: "var(--text-primary)" }}>{labelFor(selectedSession)}</span>
+              <span className="truncate font-mono text-xs" style={{ color: "var(--text-tertiary)" }}>{selectedSession.name}</span>
+              <div className="flex-1" />
+              <span className="text-xs" style={{ color: "var(--text-tertiary)" }}>
+                {selectedSession.status === "exited" ? "Ended" : "Live"}
+              </span>
+            </div>
+            <TerminalView key={selected ?? undefined} sessionName={selectedSession.attachName} active />
+          </>
         ) : (
           <EmptyState
             icon={<SquareTerminal size={26} />}
             headline="No session selected"
-            description="Pick a session on the left, or open one from a project."
+            description="Pick a session on the left, start a new one, or open one from a task."
+            action={
+              <Button variant="primary" disabled={!api || creating} onClick={() => void newSession()}>
+                <Plus size={13} />
+                New session
+              </Button>
+            }
           />
         )}
       </div>

--- a/desktop/src/renderer/src/features/terminal/TerminalsTab.tsx
+++ b/desktop/src/renderer/src/features/terminal/TerminalsTab.tsx
@@ -26,6 +26,7 @@ export default function TerminalsTab() {
   const load = useSessions((s) => s.load);
   const create = useSessions((s) => s.create);
   const kill = useSessions((s) => s.kill);
+  const restart = useSessions((s) => s.restart);
   const creating = useSessions((s) => s.creating);
   const cardsByProject = useBoard((s) => s.cardsByProject);
   const projects = useBoard((s) => s.projects);
@@ -104,6 +105,12 @@ export default function TerminalsTab() {
     }
   };
 
+  const restartSession = async (attachName: string) => {
+    if (!api || creating) return;
+    const restarted = await restart(api, attachName);
+    if (restarted?.attachName) setSelected(restarted.attachName);
+  };
+
   const selectedSession = sessions.find((s) => s.attachName === selected) ?? null;
 
   return (
@@ -155,7 +162,7 @@ export default function TerminalsTab() {
                         <span className="truncate font-mono text-[10px]" style={{ color: "var(--text-tertiary)" }}>{s.name}</span>
                       </button>
                       {exited ? (
-                        <IconButton label="Restart session" onClick={() => void newSession()}>
+                        <IconButton label="Restart session" onClick={() => void restartSession(s.attachName)}>
                           <RotateCcw size={12} />
                         </IconButton>
                       ) : null}

--- a/desktop/src/renderer/src/features/terminal/TerminalsTab.tsx
+++ b/desktop/src/renderer/src/features/terminal/TerminalsTab.tsx
@@ -106,7 +106,7 @@ export default function TerminalsTab() {
   };
 
   const restartSession = async (attachName: string) => {
-    if (!api || creating) return;
+    if (!api || creating || busy !== null) return;
     const restarted = await restart(api, attachName);
     if (restarted?.attachName) setSelected(restarted.attachName);
   };
@@ -162,7 +162,7 @@ export default function TerminalsTab() {
                         <span className="truncate font-mono text-[10px]" style={{ color: "var(--text-tertiary)" }}>{s.name}</span>
                       </button>
                       {exited ? (
-                        <IconButton label="Restart session" disabled={creating} onClick={() => void restartSession(s.attachName)}>
+                        <IconButton label="Restart session" disabled={creating || busy !== null} onClick={() => void restartSession(s.attachName)}>
                           <RotateCcw size={12} />
                         </IconButton>
                       ) : null}

--- a/desktop/src/renderer/src/features/terminal/TerminalsTab.tsx
+++ b/desktop/src/renderer/src/features/terminal/TerminalsTab.tsx
@@ -162,7 +162,7 @@ export default function TerminalsTab() {
                         <span className="truncate font-mono text-[10px]" style={{ color: "var(--text-tertiary)" }}>{s.name}</span>
                       </button>
                       {exited ? (
-                        <IconButton label="Restart session" onClick={() => void restartSession(s.attachName)}>
+                        <IconButton label="Restart session" disabled={creating} onClick={() => void restartSession(s.attachName)}>
                           <RotateCcw size={12} />
                         </IconButton>
                       ) : null}

--- a/desktop/src/renderer/src/features/terminal/TerminalsTab.tsx
+++ b/desktop/src/renderer/src/features/terminal/TerminalsTab.tsx
@@ -170,7 +170,7 @@ export default function TerminalsTab() {
                         type="button"
                         aria-label="Kill session"
                         title="Kill session"
-                        disabled={busy === s.attachName}
+                        disabled={busy !== null}
                         onClick={() => void killSession(s.attachName)}
                         className="flex h-6 w-6 items-center justify-center rounded opacity-0 transition-opacity group-hover/session:opacity-100 disabled:opacity-40"
                         style={{ color: "var(--text-tertiary)" }}

--- a/desktop/src/renderer/src/features/terminal/TerminalsTab.tsx
+++ b/desktop/src/renderer/src/features/terminal/TerminalsTab.tsx
@@ -32,6 +32,7 @@ export default function TerminalsTab() {
   const projects = useBoard((s) => s.projects);
   const [selected, setSelected] = useState<string | null>(null);
   const [busy, setBusy] = useState<string | null>(null);
+  const [actionError, setActionError] = useState<string | null>(null);
 
   useEffect(() => {
     if (api) void load(api);
@@ -91,15 +92,19 @@ export default function TerminalsTab() {
 
   const newSession = async () => {
     if (!api || creating) return;
+    setActionError(null);
     const created = await create(api, { kind: "shell" });
     if (created?.attachName) setSelected(created.attachName);
+    else setActionError("Start failed");
   };
 
   const killSession = async (attachName: string) => {
     if (!api || busy) return;
+    setActionError(null);
     setBusy(attachName);
     try {
-      await kill(api, attachName);
+      const ok = await kill(api, attachName);
+      if (!ok) setActionError("Kill failed");
     } finally {
       setBusy(null);
     }
@@ -107,8 +112,10 @@ export default function TerminalsTab() {
 
   const restartSession = async (attachName: string) => {
     if (!api || creating || busy !== null) return;
+    setActionError(null);
     const restarted = await restart(api, attachName);
     if (restarted?.attachName) setSelected(restarted.attachName);
+    else setActionError("Restart failed");
   };
 
   const selectedSession = sessions.find((s) => s.attachName === selected) ?? null;
@@ -187,6 +194,11 @@ export default function TerminalsTab() {
           )}
         </div>
         <div className="border-t p-2" style={{ borderColor: "var(--border-subtle)" }}>
+          {actionError ? (
+            <p className="mb-2 text-xs" role="status" aria-live="polite" style={{ color: "var(--danger)" }}>
+              {actionError}
+            </p>
+          ) : null}
           <Button variant="subtle" className="w-full justify-center" disabled={!api || creating} onClick={() => void newSession()}>
             <Plus size={13} />
             {creating ? "Starting…" : "New session"}

--- a/desktop/src/renderer/src/features/terminal/TerminalsTab.tsx
+++ b/desktop/src/renderer/src/features/terminal/TerminalsTab.tsx
@@ -94,8 +94,18 @@ export default function TerminalsTab() {
     if (!api || creating) return;
     setActionError(null);
     const created = await create(api, { kind: "shell" });
-    if (created?.attachName) setSelected(created.attachName);
-    else setActionError("Start failed");
+    if (created?.attachName) {
+      setSelected(created.attachName);
+      return;
+    }
+    if (created?.sessionId) {
+      try {
+        await api.delete(`/api/sessions/${encodeURIComponent(created.sessionId)}`);
+      } catch (err: unknown) {
+        console.error("[terminal] Failed to clean up unattached shell session:", err);
+      }
+    }
+    setActionError("Start failed");
   };
 
   const killSession = async (attachName: string) => {

--- a/desktop/src/renderer/src/features/workspace/ArtifactsPanel.tsx
+++ b/desktop/src/renderer/src/features/workspace/ArtifactsPanel.tsx
@@ -34,7 +34,9 @@ export default function ArtifactsPanel({
   }, [api, loadPreviews, projectSlug, taskId]);
 
   const scopeMatches = previewScope?.projectSlug === projectSlug && previewScope.taskId === taskId;
-  const scopedPreviews = scopeMatches ? allPreviews.filter((p) => p.taskId === taskId) : [];
+  const scopedPreviews = allPreviews.filter(
+    (preview) => preview.projectSlug === projectSlug && preview.taskId === taskId,
+  );
   const openPreview = (url: string | undefined) => {
     if (canOpenPreviewUrl(url)) void invoke("shell:open-external", { url });
   };
@@ -43,7 +45,7 @@ export default function ArtifactsPanel({
     return (
       <EmptyState
         icon={<Globe size={22} />}
-        headline="Couldn't load artifacts"
+        headline="Couldn't load previews"
         description={categoryMessage(previewError)}
       />
     );

--- a/desktop/src/renderer/src/features/workspace/ArtifactsPanel.tsx
+++ b/desktop/src/renderer/src/features/workspace/ArtifactsPanel.tsx
@@ -1,7 +1,7 @@
-import { Package, RefreshCw } from "lucide-react";
+import { ExternalLink, Globe, RefreshCw } from "lucide-react";
 import { useEffect } from "react";
 import { categoryMessage } from "../../../../shared/app-error";
-import { EmptyState, IconButton } from "../../design/primitives";
+import { EmptyState, IconButton, StatusDot } from "../../design/primitives";
 import { invoke } from "../../lib/operator";
 import { useConnection } from "../../stores/connection";
 import { useGit } from "../../stores/git";
@@ -9,6 +9,12 @@ import { useGit } from "../../stores/git";
 export function canOpenPreviewUrl(url: string | null | undefined): url is string {
   return typeof url === "string" && url.startsWith("https://");
 }
+
+const HEALTH_COLOR: Record<string, string> = {
+  ok: "var(--success)",
+  failed: "var(--danger)",
+  unknown: "var(--text-tertiary)",
+};
 
 export default function ArtifactsPanel({
   projectSlug,
@@ -18,7 +24,7 @@ export default function ArtifactsPanel({
   taskId: string;
 }) {
   const api = useConnection((s) => s.api);
-  const previews = useGit((s) => s.previews);
+  const allPreviews = useGit((s) => s.previews);
   const previewScope = useGit((s) => s.previewScope);
   const previewError = useGit((s) => s.previewError);
   const loadPreviews = useGit((s) => s.loadPreviews);
@@ -28,12 +34,15 @@ export default function ArtifactsPanel({
   }, [api, loadPreviews, projectSlug, taskId]);
 
   const scopeMatches = previewScope?.projectSlug === projectSlug && previewScope.taskId === taskId;
-  const scopedPreviews = scopeMatches ? previews : [];
+  const scopedPreviews = scopeMatches ? allPreviews.filter((p) => p.taskId === taskId) : [];
+  const openPreview = (url: string | undefined) => {
+    if (canOpenPreviewUrl(url)) void invoke("shell:open-external", { url });
+  };
 
   if (scopeMatches && previewError && scopedPreviews.length === 0) {
     return (
       <EmptyState
-        icon={<Package size={22} />}
+        icon={<Globe size={22} />}
         headline="Couldn't load artifacts"
         description={categoryMessage(previewError)}
       />
@@ -43,9 +52,9 @@ export default function ArtifactsPanel({
   if (scopedPreviews.length === 0) {
     return (
       <EmptyState
-        icon={<Package size={22} />}
-        headline="No artifacts"
-        description="Previews and artifacts created on this task appear here."
+        icon={<Globe size={22} />}
+        headline="No previews"
+        description="Preview URLs exposed by this task's session appear here with a health check."
       />
     );
   }
@@ -54,7 +63,7 @@ export default function ArtifactsPanel({
     <div className="flex min-h-0 flex-1 flex-col gap-1 overflow-y-auto p-2">
       <div className="flex items-center justify-end">
         <IconButton
-          label="Refresh artifacts"
+          label="Refresh previews"
           onClick={() => {
             if (api) void loadPreviews(api, projectSlug, taskId);
           }}
@@ -62,28 +71,38 @@ export default function ArtifactsPanel({
           <RefreshCw size={12} />
         </IconButton>
       </div>
-      {scopedPreviews.slice(0, 50).map((preview) => (
-        <button
-          key={preview.id}
-          type="button"
-          className="flex flex-col gap-0.5 rounded-lg border p-2.5 text-left hover:border-[var(--border-strong)]"
-          style={{ borderColor: "var(--border-subtle)", background: "var(--bg-raised)" }}
-          onClick={() => {
-            if (canOpenPreviewUrl(preview.url)) {
-              void invoke("shell:open-external", { url: preview.url });
-            }
-          }}
-        >
-          <span className="truncate text-sm" style={{ color: "var(--text-primary)" }}>
-            {preview.label ?? preview.id}
-          </span>
-          {preview.url ? (
-            <span className="truncate text-xs" style={{ color: "var(--text-tertiary)" }}>
-              {preview.url}
-            </span>
-          ) : null}
-        </button>
-      ))}
+      {scopedPreviews.slice(0, 50).map((preview) => {
+        const openable = canOpenPreviewUrl(preview.url);
+        return (
+          <button
+            key={preview.id}
+            type="button"
+            disabled={!openable}
+            className="group/preview flex items-center gap-2.5 rounded-lg border p-2.5 text-left transition-colors hover:border-[var(--border-strong)] disabled:cursor-default"
+            style={{ borderColor: "var(--border-subtle)", background: "var(--bg-raised)" }}
+            onClick={() => openPreview(preview.url)}
+          >
+            <StatusDot color={HEALTH_COLOR[preview.lastStatus ?? "unknown"] ?? "var(--text-tertiary)"} />
+            <div className="flex min-w-0 flex-1 flex-col">
+              <span className="truncate text-sm" style={{ color: "var(--text-primary)" }}>
+                {preview.label ?? preview.id}
+              </span>
+              {preview.url ? (
+                <span className="truncate text-xs" style={{ color: "var(--text-tertiary)" }}>
+                  {preview.url}
+                </span>
+              ) : null}
+            </div>
+            {openable ? (
+              <ExternalLink
+                size={13}
+                className="opacity-0 transition-opacity group-hover/preview:opacity-100"
+                style={{ color: "var(--text-tertiary)" }}
+              />
+            ) : null}
+          </button>
+        );
+      })}
     </div>
   );
 }

--- a/desktop/src/renderer/src/features/workspace/PanelStrip.tsx
+++ b/desktop/src/renderer/src/features/workspace/PanelStrip.tsx
@@ -14,7 +14,7 @@ export const PANEL_TITLES: Record<PanelKind, string> = {
   editor: "Editor",
   git: "Git",
   browser: "Files",
-  artifacts: "Artifacts",
+  artifacts: "Preview",
   processes: "Processes",
   timeline: "Timeline",
 };

--- a/desktop/src/renderer/src/features/workspace/PanelStrip.tsx
+++ b/desktop/src/renderer/src/features/workspace/PanelStrip.tsx
@@ -3,6 +3,7 @@ import { Group, Panel, Separator, type Layout as GroupLayout } from "react-resiz
 import {
   useWorkspace,
   defaultLayout,
+  normalizeLayout,
   PANEL_MIN_PCT,
   type PanelKind,
   type PanelLayout,
@@ -15,6 +16,7 @@ export const PANEL_TITLES: Record<PanelKind, string> = {
   browser: "Files",
   artifacts: "Artifacts",
   processes: "Processes",
+  timeline: "Timeline",
 };
 
 interface PanelStripProps {
@@ -53,7 +55,7 @@ export default function PanelStrip({ taskId, renderPanel }: PanelStripProps) {
   const layouts = useWorkspace((s) => s.layouts);
   const setPanelSizes = useWorkspace((s) => s.setPanelSizes);
 
-  const layout: PanelLayout = useMemo(() => layouts[taskId] ?? defaultLayout(), [layouts, taskId]);
+  const layout: PanelLayout = useMemo(() => normalizeLayout(layouts[taskId] ?? defaultLayout()), [layouts, taskId]);
   const visiblePanels = useMemo(() => layout.order.filter((panel) => layout.visible[panel]), [layout]);
 
   // Remount the group when the visible set changes so default sizes re-apply.
@@ -69,7 +71,7 @@ export default function PanelStrip({ taskId, renderPanel }: PanelStripProps) {
     return (
       <div className="flex flex-1 items-center justify-center">
         <span className="text-sm" style={{ color: "var(--text-tertiary)" }}>
-          All panels hidden. Toggle one from the toolbar (⌘1–⌘6).
+          All panels hidden. Toggle one from the toolbar (⌘1–⌘7).
         </span>
       </div>
     );

--- a/desktop/src/renderer/src/features/workspace/ProcessesPanel.tsx
+++ b/desktop/src/renderer/src/features/workspace/ProcessesPanel.tsx
@@ -1,12 +1,152 @@
-import { Activity } from "lucide-react";
-import { EmptyState } from "../../design/primitives";
+import { Activity, RefreshCw } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
+import { z } from "zod/v4";
+import { EmptyState, IconButton, StatusDot } from "../../design/primitives";
+import { toUserMessage } from "../../lib/errors";
+import { useConnection } from "../../stores/connection";
+
+const POLL_MS = 5000;
+
+const ProcessSchema = z.object({
+  processRef: z.string(),
+  pid: z.number().optional(),
+  classification: z.string().optional(),
+  displayName: z.string().optional(),
+  cpuPercent: z.number().optional(),
+  rssBytes: z.number().optional(),
+  ports: z.array(z.union([z.number(), z.string(), z.record(z.string(), z.unknown())])).optional(),
+});
+const ServiceSchema = z.object({ name: z.string(), status: z.string().optional() });
+const SnapshotSchema = z.object({
+  resources: z
+    .object({
+      cpu: z.object({ cores: z.number().optional(), load1: z.number().optional() }).optional(),
+      memory: z.object({ totalBytes: z.number().optional(), usedBytes: z.number().optional() }).optional(),
+    })
+    .optional(),
+  services: z.array(ServiceSchema).optional(),
+  processes: z.array(ProcessSchema).optional(),
+});
+type Snapshot = z.infer<typeof SnapshotSchema>;
+
+/** Human byte size (e.g. 1.5 GB) from a byte count. */
+export function formatBytes(bytes: number | undefined): string {
+  if (typeof bytes !== "number" || !Number.isFinite(bytes) || bytes < 0) return "—";
+  const units = ["B", "KB", "MB", "GB", "TB"];
+  let value = bytes;
+  let i = 0;
+  while (value >= 1024 && i < units.length - 1) {
+    value /= 1024;
+    i += 1;
+  }
+  const rounded = value >= 10 || i === 0 ? Math.round(value) : Math.round(value * 10) / 10;
+  return `${rounded} ${units[i]}`;
+}
+
+function portList(ports: unknown[] | undefined): string {
+  if (!ports || ports.length === 0) return "";
+  const nums = ports
+    .map((p) => (typeof p === "number" ? p : typeof p === "object" && p && "port" in p ? (p as { port: unknown }).port : null))
+    .filter((p): p is number => typeof p === "number");
+  return nums.length ? nums.join(", ") : "";
+}
+
+const SERVICE_OK = new Set(["running", "active", "ok", "healthy"]);
 
 export default function ProcessesPanel() {
+  const api = useConnection((s) => s.api);
+  const [snapshot, setSnapshot] = useState<Snapshot | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const inFlight = useRef(false);
+
+  const load = async () => {
+    if (!api || inFlight.current) return;
+    inFlight.current = true;
+    try {
+      const raw = await api.get<unknown>("/api/system/activity?processLimit=25");
+      const parsed = SnapshotSchema.safeParse(raw);
+      setSnapshot(parsed.success ? parsed.data : {});
+      setError(parsed.success ? null : "Unexpected response.");
+    } catch (err: unknown) {
+      setError(toUserMessage(err));
+      setSnapshot((prev) => prev ?? {});
+    } finally {
+      inFlight.current = false;
+    }
+  };
+
+  useEffect(() => {
+    if (!api) return;
+    let cancelled = false;
+    const tick = () => {
+      if (!cancelled) void load();
+    };
+    tick();
+    const timer = setInterval(tick, POLL_MS);
+    return () => {
+      cancelled = true;
+      clearInterval(timer);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [api]);
+
+  if (snapshot === null) {
+    return <div className="flex flex-1 items-center justify-center text-sm" style={{ color: "var(--text-tertiary)" }}>Loading processes…</div>;
+  }
+
+  const processes = (snapshot.processes ?? []).slice().sort((a, b) => (b.rssBytes ?? 0) - (a.rssBytes ?? 0));
+  const mem = snapshot.resources?.memory;
+  const cpu = snapshot.resources?.cpu;
+  const services = snapshot.services ?? [];
+
+  if (processes.length === 0 && services.length === 0) {
+    return (
+      <EmptyState
+        icon={<Activity size={22} />}
+        headline="No process data"
+        description={error ?? "Nothing running to report on this machine right now."}
+      />
+    );
+  }
+
   return (
-    <EmptyState
-      icon={<Activity size={22} />}
-      headline="Processes"
-      description="Live process listing arrives with gateway support. Use the terminal (`htop`) meanwhile."
-    />
+    <div className="flex min-h-0 flex-1 flex-col overflow-y-auto">
+      <div className="flex shrink-0 items-center justify-between gap-3 border-b px-3 py-2 text-xs" style={{ borderColor: "var(--border-subtle)", color: "var(--text-secondary)" }}>
+        <div className="flex items-center gap-3">
+          {cpu ? <span>CPU load {cpu.load1?.toFixed(2) ?? "—"}{cpu.cores ? ` / ${cpu.cores}` : ""}</span> : null}
+          {mem ? <span>Mem {formatBytes(mem.usedBytes)} / {formatBytes(mem.totalBytes)}</span> : null}
+        </div>
+        <IconButton label="Refresh processes" onClick={() => void load()}>
+          <RefreshCw size={12} />
+        </IconButton>
+      </div>
+
+      {services.length > 0 ? (
+        <div className="flex flex-wrap gap-1.5 border-b px-3 py-2" style={{ borderColor: "var(--border-subtle)" }}>
+          {services.map((s) => (
+            <span key={s.name} className="flex items-center gap-1.5 rounded-full border px-2 py-0.5 text-xs" style={{ borderColor: "var(--border-subtle)", color: "var(--text-secondary)" }}>
+              <StatusDot color={SERVICE_OK.has((s.status ?? "").toLowerCase()) ? "var(--success)" : "var(--warning)"} />
+              {s.name.replace(/^matrix-/, "")}
+            </span>
+          ))}
+        </div>
+      ) : null}
+
+      <div className="flex min-h-0 flex-1 flex-col">
+        {processes.map((p) => {
+          const ports = portList(p.ports);
+          return (
+            <div key={p.processRef} className="flex items-center gap-3 border-b px-3 py-1.5 text-xs" style={{ borderColor: "var(--border-subtle)" }}>
+              <span className="min-w-0 flex-1 truncate" style={{ color: "var(--text-primary)" }}>
+                {p.displayName ?? p.classification ?? `pid ${p.pid ?? "?"}`}
+              </span>
+              {ports ? <span className="font-mono" style={{ color: "var(--highlight)" }}>:{ports}</span> : null}
+              <span className="tabular-nums" style={{ color: "var(--text-tertiary)" }}>{(p.cpuPercent ?? 0).toFixed(0)}%</span>
+              <span className="w-14 text-right tabular-nums" style={{ color: "var(--text-tertiary)" }}>{formatBytes(p.rssBytes)}</span>
+            </div>
+          );
+        })}
+      </div>
+    </div>
   );
 }

--- a/desktop/src/renderer/src/features/workspace/ProcessesPanel.tsx
+++ b/desktop/src/renderer/src/features/workspace/ProcessesPanel.tsx
@@ -91,6 +91,7 @@ export default function ProcessesPanel() {
     return () => {
       cancelled = true;
       mounted.current = false;
+      inFlight.current = false;
       clearInterval(timer);
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/desktop/src/renderer/src/features/workspace/ProcessesPanel.tsx
+++ b/desktop/src/renderer/src/features/workspace/ProcessesPanel.tsx
@@ -4,6 +4,7 @@ import { z } from "zod/v4";
 import { EmptyState, IconButton, StatusDot } from "../../design/primitives";
 import { toUserMessage } from "../../lib/errors";
 import { useConnection } from "../../stores/connection";
+import { formatBytes, portList } from "./process-format";
 
 const POLL_MS = 5000;
 
@@ -28,28 +29,6 @@ const SnapshotSchema = z.object({
   processes: z.array(ProcessSchema).optional(),
 });
 type Snapshot = z.infer<typeof SnapshotSchema>;
-
-/** Human byte size (e.g. 1.5 GB) from a byte count. */
-export function formatBytes(bytes: number | undefined): string {
-  if (typeof bytes !== "number" || !Number.isFinite(bytes) || bytes < 0) return "—";
-  const units = ["B", "KB", "MB", "GB", "TB"];
-  let value = bytes;
-  let i = 0;
-  while (value >= 1024 && i < units.length - 1) {
-    value /= 1024;
-    i += 1;
-  }
-  const rounded = value >= 10 || i === 0 ? Math.round(value) : Math.round(value * 10) / 10;
-  return `${rounded} ${units[i]}`;
-}
-
-function portList(ports: unknown[] | undefined): string {
-  if (!ports || ports.length === 0) return "";
-  const nums = ports
-    .map((p) => (typeof p === "number" ? p : typeof p === "object" && p && "port" in p ? (p as { port: unknown }).port : null))
-    .filter((p): p is number => typeof p === "number");
-  return nums.length ? nums.join(", ") : "";
-}
 
 const SERVICE_OK = new Set(["running", "active", "ok", "healthy"]);
 

--- a/desktop/src/renderer/src/features/workspace/ProcessesPanel.tsx
+++ b/desktop/src/renderer/src/features/workspace/ProcessesPanel.tsx
@@ -58,16 +58,20 @@ export default function ProcessesPanel() {
   const [snapshot, setSnapshot] = useState<Snapshot | null>(null);
   const [error, setError] = useState<string | null>(null);
   const inFlight = useRef(false);
+  const mounted = useRef(false);
 
-  const load = async () => {
+  const load = async (isCancelled: () => boolean = () => false) => {
     if (!api || inFlight.current) return;
     inFlight.current = true;
+    const cancelled = () => !mounted.current || isCancelled();
     try {
       const raw = await api.get<unknown>("/api/system/activity?processLimit=25");
+      if (cancelled()) return;
       const parsed = SnapshotSchema.safeParse(raw);
       setSnapshot(parsed.success ? parsed.data : {});
       setError(parsed.success ? null : "Unexpected response.");
     } catch (err: unknown) {
+      if (cancelled()) return;
       setError(toUserMessage(err));
       setSnapshot((prev) => prev ?? {});
     } finally {
@@ -77,14 +81,16 @@ export default function ProcessesPanel() {
 
   useEffect(() => {
     if (!api) return;
+    mounted.current = true;
     let cancelled = false;
     const tick = () => {
-      if (!cancelled) void load();
+      if (!cancelled) void load(() => cancelled);
     };
     tick();
     const timer = setInterval(tick, POLL_MS);
     return () => {
       cancelled = true;
+      mounted.current = false;
       clearInterval(timer);
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/desktop/src/renderer/src/features/workspace/ProcessesPanel.tsx
+++ b/desktop/src/renderer/src/features/workspace/ProcessesPanel.tsx
@@ -59,10 +59,12 @@ export default function ProcessesPanel() {
   const [error, setError] = useState<string | null>(null);
   const inFlight = useRef(false);
   const mounted = useRef(false);
+  const requestSeq = useRef(0);
 
   const load = async (isCancelled: () => boolean = () => false) => {
     if (!api || inFlight.current) return;
     inFlight.current = true;
+    const requestId = ++requestSeq.current;
     const cancelled = () => !mounted.current || isCancelled();
     try {
       const raw = await api.get<unknown>("/api/system/activity?processLimit=25");
@@ -75,7 +77,7 @@ export default function ProcessesPanel() {
       setError(toUserMessage(err));
       setSnapshot((prev) => prev ?? {});
     } finally {
-      inFlight.current = false;
+      if (requestSeq.current === requestId) inFlight.current = false;
     }
   };
 
@@ -91,6 +93,7 @@ export default function ProcessesPanel() {
     return () => {
       cancelled = true;
       mounted.current = false;
+      requestSeq.current += 1;
       inFlight.current = false;
       clearInterval(timer);
     };

--- a/desktop/src/renderer/src/features/workspace/StartSessionControls.tsx
+++ b/desktop/src/renderer/src/features/workspace/StartSessionControls.tsx
@@ -1,0 +1,108 @@
+import { Bot, SquareTerminal, Sparkles } from "lucide-react";
+import { useState } from "react";
+import { toUserMessage } from "../../lib/errors";
+import { useBoard } from "../../stores/board";
+import { useConnection } from "../../stores/connection";
+import { useSessions } from "../../stores/sessions";
+
+type Launch =
+  | { kind: "shell"; label: string }
+  | { kind: "agent"; agent: "claude" | "codex"; label: string };
+
+const LAUNCHERS: Launch[] = [
+  { kind: "shell", label: "Shell" },
+  { kind: "agent", agent: "claude", label: "Claude" },
+  { kind: "agent", agent: "codex", label: "Codex" },
+];
+
+function glyph(l: Launch) {
+  if (l.kind === "shell") return <SquareTerminal size={13} />;
+  return l.agent === "claude" ? <Sparkles size={13} /> : <Bot size={13} />;
+}
+
+/**
+ * Launches a cloud terminal/agent session bound to a task: POST /api/sessions
+ * (with the task + worktree + an agent prompt prefilled from the task) then
+ * links the new session back onto the task and flips it to "running". The task
+ * workspace re-derives its attach target and the terminal panel attaches.
+ */
+export default function StartSessionControls({
+  projectSlug,
+  taskId,
+  worktreeId,
+  title,
+  description,
+  compact = false,
+}: {
+  projectSlug: string;
+  taskId: string;
+  worktreeId: string | null;
+  title: string;
+  description: string;
+  compact?: boolean;
+}) {
+  const api = useConnection((s) => s.api);
+  const createSession = useSessions((s) => s.create);
+  const creating = useSessions((s) => s.creating);
+  const linkSession = useBoard((s) => s.linkSession);
+  const [error, setError] = useState<string | null>(null);
+  const [pending, setPending] = useState<string | null>(null);
+
+  const launch = async (l: Launch) => {
+    if (!api || pending) return;
+    setPending(l.label);
+    setError(null);
+    try {
+      const prompt =
+        l.kind === "agent"
+          ? [title, description].filter((s) => s.trim().length > 0).join("\n\n")
+          : undefined;
+      const created = await createSession(api, {
+        kind: l.kind,
+        ...(l.kind === "agent" ? { agent: l.agent } : {}),
+        projectSlug,
+        taskId,
+        ...(worktreeId ? { worktreeId } : {}),
+        ...(prompt ? { prompt } : {}),
+      });
+      if (!created) {
+        setError("Couldn't start the session. Check that the agent is connected.");
+        return;
+      }
+      await linkSession(api, projectSlug, taskId, {
+        linkedSessionId: created.sessionId,
+        ...(worktreeId ? { linkedWorktreeId: worktreeId } : {}),
+        status: "running",
+      });
+    } catch (err: unknown) {
+      setError(toUserMessage(err));
+    } finally {
+      setPending(null);
+    }
+  };
+
+  return (
+    <div className={compact ? "flex items-center gap-1.5" : "flex flex-col items-center gap-2"}>
+      <div className="flex items-center gap-1.5">
+        {LAUNCHERS.map((l) => (
+          <button
+            key={l.label}
+            type="button"
+            disabled={creating || pending !== null}
+            onClick={() => void launch(l)}
+            className="no-drag flex h-8 items-center gap-1.5 rounded-lg border px-2.5 text-sm font-medium transition-colors duration-100 disabled:opacity-50"
+            style={{ borderColor: "var(--border-default)", background: "var(--bg-surface)", color: "var(--text-primary)" }}
+            onMouseEnter={(e) => (e.currentTarget.style.background = "var(--bg-hover)")}
+            onMouseLeave={(e) => (e.currentTarget.style.background = "var(--bg-surface)")}
+          >
+            {glyph(l)}
+            {pending === l.label ? "Starting…" : l.label}
+          </button>
+        ))}
+      </div>
+      {error && !compact ? (
+        <span className="text-xs" style={{ color: "var(--danger)" }}>{error}</span>
+      ) : null}
+    </div>
+  );
+}

--- a/desktop/src/renderer/src/features/workspace/StartSessionControls.tsx
+++ b/desktop/src/renderer/src/features/workspace/StartSessionControls.tsx
@@ -1,4 +1,4 @@
-import { Bot, SquareTerminal, Sparkles } from "lucide-react";
+import { AlertCircle, Bot, SquareTerminal, Sparkles } from "lucide-react";
 import { useState } from "react";
 import { toUserMessage } from "../../lib/errors";
 import { startTaskSession } from "../../lib/task-sessions";
@@ -18,6 +18,11 @@ const LAUNCHERS: Launch[] = [
 function glyph(l: Launch) {
   if (l.kind === "shell") return <SquareTerminal size={13} />;
   return l.agent === "claude" ? <Sparkles size={13} /> : <Bot size={13} />;
+}
+
+export function startSessionErrorLabel(error: string | null, compact: boolean): string | null {
+  if (!error) return null;
+  return compact ? "Start failed" : error;
 }
 
 /**
@@ -45,6 +50,7 @@ export default function StartSessionControls({
   const creating = useSessions((s) => s.creating);
   const [error, setError] = useState<string | null>(null);
   const [pending, setPending] = useState<string | null>(null);
+  const errorLabel = startSessionErrorLabel(error, compact);
 
   const launch = async (l: Launch) => {
     if (!api || pending) return;
@@ -87,8 +93,20 @@ export default function StartSessionControls({
           </button>
         ))}
       </div>
-      {error && !compact ? (
-        <span className="text-xs" style={{ color: "var(--danger)" }}>{error}</span>
+      {errorLabel ? (
+        <span
+          className={
+            compact
+              ? "flex max-w-36 items-center gap-1 truncate text-xs"
+              : "flex items-center gap-1 text-xs"
+          }
+          style={{ color: "var(--danger)" }}
+          title={compact ? error ?? undefined : undefined}
+          aria-live="polite"
+        >
+          <AlertCircle size={12} className="shrink-0" />
+          <span className="truncate">{errorLabel}</span>
+        </span>
       ) : null}
     </div>
   );

--- a/desktop/src/renderer/src/features/workspace/StartSessionControls.tsx
+++ b/desktop/src/renderer/src/features/workspace/StartSessionControls.tsx
@@ -1,7 +1,7 @@
 import { Bot, SquareTerminal, Sparkles } from "lucide-react";
 import { useState } from "react";
 import { toUserMessage } from "../../lib/errors";
-import { useBoard } from "../../stores/board";
+import { startTaskSession } from "../../lib/task-sessions";
 import { useConnection } from "../../stores/connection";
 import { useSessions } from "../../stores/sessions";
 
@@ -42,9 +42,7 @@ export default function StartSessionControls({
   compact?: boolean;
 }) {
   const api = useConnection((s) => s.api);
-  const createSession = useSessions((s) => s.create);
   const creating = useSessions((s) => s.creating);
-  const linkSession = useBoard((s) => s.linkSession);
   const [error, setError] = useState<string | null>(null);
   const [pending, setPending] = useState<string | null>(null);
 
@@ -53,27 +51,16 @@ export default function StartSessionControls({
     setPending(l.label);
     setError(null);
     try {
-      const prompt =
-        l.kind === "agent"
-          ? [title, description].filter((s) => s.trim().length > 0).join("\n\n")
-          : undefined;
-      const created = await createSession(api, {
-        kind: l.kind,
-        ...(l.kind === "agent" ? { agent: l.agent } : {}),
+      const ok = await startTaskSession(api, {
         projectSlug,
         taskId,
-        ...(worktreeId ? { worktreeId } : {}),
-        ...(prompt ? { prompt } : {}),
+        worktreeId,
+        title,
+        description,
+        kind: l.kind,
+        ...(l.kind === "agent" ? { agent: l.agent } : {}),
       });
-      if (!created) {
-        setError("Couldn't start the session. Check that the agent is connected.");
-        return;
-      }
-      await linkSession(api, projectSlug, taskId, {
-        linkedSessionId: created.sessionId,
-        ...(worktreeId ? { linkedWorktreeId: worktreeId } : {}),
-        status: "running",
-      });
+      if (!ok) setError("Couldn't start the session. Check that the agent is connected.");
     } catch (err: unknown) {
       setError(toUserMessage(err));
     } finally {

--- a/desktop/src/renderer/src/features/workspace/TaskWorkspace.tsx
+++ b/desktop/src/renderer/src/features/workspace/TaskWorkspace.tsx
@@ -1,10 +1,12 @@
 import {
   Activity,
+  CircleStop,
   FileCode2,
   FolderTree,
   GitBranch,
   Globe,
   ListTree,
+  Sparkles,
   SquareTerminal,
 } from "lucide-react";
 import { useEffect, useMemo } from "react";
@@ -49,6 +51,27 @@ function warnSessionLoadFailure(err: unknown): void {
   console.warn("[task-workspace] load sessions failed:", err instanceof Error ? err.message : String(err));
 }
 
+// Map an agent session's runtime status to a label/color and whether it can
+// still be stopped (running/waiting are abortable; exited/failed are terminal).
+function describeAgentRun(
+  agent: string | undefined,
+  runtimeStatus: string | undefined,
+): { label: string; color: string; stoppable: boolean } {
+  const name = agent ? agent[0]!.toUpperCase() + agent.slice(1) : "Agent";
+  switch (runtimeStatus) {
+    case "waiting":
+      return { label: `${name} · needs input`, color: "var(--warning)", stoppable: true };
+    case "failed":
+      return { label: `${name} · failed`, color: "var(--danger)", stoppable: false };
+    case "exited":
+      return { label: `${name} · done`, color: "var(--text-tertiary)", stoppable: false };
+    case "idle":
+      return { label: `${name} · idle`, color: "var(--text-secondary)", stoppable: true };
+    default:
+      return { label: `${name} · running`, color: "var(--success)", stoppable: true };
+  }
+}
+
 export default function TaskWorkspace({
   taskId,
   projectSlug: initialProjectSlug,
@@ -61,6 +84,7 @@ export default function TaskWorkspace({
   const api = useConnection((s) => s.api);
   const cardsByProject = useBoard((s) => s.cardsByProject);
   const sessionsLoad = useSessions((s) => s.load);
+  const killSession = useSessions((s) => s.kill);
   const aliasMap = useSessions((s) => s.aliasMap);
   const sessionList = useSessions((s) => s.sessions);
   const worktrees = useGit((s) => s.worktrees);
@@ -128,10 +152,13 @@ export default function TaskWorkspace({
   const attachName = card?.linkedSessionId ? (aliasMap[card.linkedSessionId] ?? null) : null;
   const layout = layouts[taskId] ?? layoutFor(taskId);
 
-  // Header chips: live session, worktree branch/dirty, preview health.
-  const sessionLive = attachName
-    ? sessionList.some((s) => s.attachName === attachName && s.status === "active")
-    : false;
+  // Header chips: live session, agent run, worktree branch/dirty, preview health.
+  const liveSession = useMemo(
+    () => (attachName ? sessionList.find((s) => s.attachName === attachName) ?? null : null),
+    [attachName, sessionList],
+  );
+  const sessionLive = liveSession?.status === "active";
+  const agentRun = liveSession?.kind === "agent" ? describeAgentRun(liveSession.agent, liveSession.runtimeStatus) : null;
   const worktree = useMemo(
     () => (card?.linkedWorktreeId ? worktrees.find((w) => w.id === card.linkedWorktreeId) ?? null : null),
     [worktrees, card?.linkedWorktreeId],
@@ -213,6 +240,29 @@ export default function TaskWorkspace({
             >
               <StatusDot color={sessionLive ? "var(--success)" : "var(--text-tertiary)"} pulse={sessionLive} />
               <span className="font-mono">{attachName}</span>
+            </span>
+          ) : null}
+          {agentRun ? (
+            <span
+              className="flex items-center gap-1.5 rounded-full border px-2 py-0.5 text-xs"
+              style={{ borderColor: "var(--border-default)", color: agentRun.color }}
+            >
+              <Sparkles size={11} />
+              {agentRun.label}
+              {agentRun.stoppable && attachName ? (
+                <button
+                  type="button"
+                  aria-label="Stop agent"
+                  title="Stop agent"
+                  className="ml-0.5 flex h-4 w-4 items-center justify-center rounded"
+                  style={{ color: "var(--danger)" }}
+                  onClick={() => {
+                    if (api && attachName) void killSession(api, attachName);
+                  }}
+                >
+                  <CircleStop size={12} />
+                </button>
+              ) : null}
             </span>
           ) : null}
           {worktree ? (

--- a/desktop/src/renderer/src/features/workspace/TaskWorkspace.tsx
+++ b/desktop/src/renderer/src/features/workspace/TaskWorkspace.tsx
@@ -3,13 +3,15 @@ import {
   FileCode2,
   FolderTree,
   GitBranch,
+  Globe,
   Package,
   SquareTerminal,
 } from "lucide-react";
 import { useEffect, useMemo } from "react";
-import { Button, EmptyState, IconButton } from "../../design/primitives";
+import { EmptyState, IconButton, StatusDot } from "../../design/primitives";
 import { useBoard } from "../../stores/board";
 import { useConnection } from "../../stores/connection";
+import { useGit } from "../../stores/git";
 import { useSessions } from "../../stores/sessions";
 import { useWorkspace, type PanelKind } from "../../stores/workspace";
 import EditorPanel from "../editor/EditorPanel";
@@ -20,6 +22,7 @@ import { getAttachManager } from "../terminal/terminal-runtime";
 import ArtifactsPanel from "./ArtifactsPanel";
 import PanelStrip, { PANEL_TITLES } from "./PanelStrip";
 import ProcessesPanel from "./ProcessesPanel";
+import StartSessionControls from "./StartSessionControls";
 
 const PANEL_ICONS: Record<PanelKind, React.ReactNode> = {
   terminal: <SquareTerminal size={14} />,
@@ -56,6 +59,11 @@ export default function TaskWorkspace({
   const cardsByProject = useBoard((s) => s.cardsByProject);
   const sessionsLoad = useSessions((s) => s.load);
   const aliasMap = useSessions((s) => s.aliasMap);
+  const sessionList = useSessions((s) => s.sessions);
+  const worktrees = useGit((s) => s.worktrees);
+  const previews = useGit((s) => s.previews);
+  const gitLoadAll = useGit((s) => s.loadAll);
+  const gitLoadPreviews = useGit((s) => s.loadPreviews);
   const openTask = useWorkspace((s) => s.openTask);
   const focusTask = useWorkspace((s) => s.focusTask);
   const togglePanel = useWorkspace((s) => s.togglePanel);
@@ -75,6 +83,14 @@ export default function TaskWorkspace({
   useEffect(() => {
     if (api) void sessionsLoad(api).catch(warnSessionLoadFailure);
   }, [api, sessionsLoad]);
+
+  // Worktree + preview state powers the task header chips (branch/dirty/preview
+  // health). Scoped to this task's project so the header reflects live work.
+  useEffect(() => {
+    if (!api || !projectSlug) return;
+    void gitLoadAll(api, projectSlug);
+    void gitLoadPreviews(api, projectSlug, taskId);
+  }, [api, projectSlug, taskId, gitLoadAll, gitLoadPreviews]);
 
   useEffect(() => {
     // LRU eviction releases attach buffers for tasks pushed out of the cap.
@@ -109,6 +125,29 @@ export default function TaskWorkspace({
   const attachName = card?.linkedSessionId ? (aliasMap[card.linkedSessionId] ?? null) : null;
   const layout = layouts[taskId] ?? layoutFor(taskId);
 
+  // Header chips: live session, worktree branch/dirty, preview health.
+  const sessionLive = attachName
+    ? sessionList.some((s) => s.attachName === attachName && s.status === "active")
+    : false;
+  const worktree = useMemo(
+    () => (card?.linkedWorktreeId ? worktrees.find((w) => w.id === card.linkedWorktreeId) ?? null : null),
+    [worktrees, card?.linkedWorktreeId],
+  );
+  const taskPreviews = useMemo(
+    () => previews.filter((p) => p.taskId === taskId),
+    [previews, taskId],
+  );
+  const previewHealth: "ok" | "failed" | "unknown" | null =
+    taskPreviews.length === 0
+      ? null
+      : taskPreviews.some((p) => p.lastStatus === "failed")
+        ? "failed"
+        : taskPreviews.every((p) => p.lastStatus === "ok")
+          ? "ok"
+          : "unknown";
+  const previewColor =
+    previewHealth === "ok" ? "var(--success)" : previewHealth === "failed" ? "var(--danger)" : "var(--text-tertiary)";
+
   const renderPanel = (panel: PanelKind): React.ReactNode => {
     switch (panel) {
       case "terminal":
@@ -120,18 +159,19 @@ export default function TaskWorkspace({
             headline="No live session"
             description={
               card?.linkedSessionId
-                ? "This task's session has ended on your computer."
-                : "This task has no linked terminal session yet."
+                ? "This task's session has ended. Start a new one on your cloud computer."
+                : "Start a cloud terminal or coding agent for this task."
             }
             action={
-              <Button
-                variant="primary"
-                onClick={() => {
-                  if (api) void sessionsLoad(api).catch(warnSessionLoadFailure);
-                }}
-              >
-                Refresh sessions
-              </Button>
+              projectSlug && card ? (
+                <StartSessionControls
+                  projectSlug={projectSlug}
+                  taskId={taskId}
+                  worktreeId={card.linkedWorktreeId}
+                  title={card.title}
+                  description={card.description}
+                />
+              ) : null
             }
           />
         );
@@ -154,17 +194,58 @@ export default function TaskWorkspace({
         className="flex shrink-0 items-center gap-2 border-b px-3 py-1.5"
         style={{ borderColor: "var(--border-subtle)", background: "var(--bg-surface)" }}
       >
-        <span className="min-w-0 flex-1 truncate text-sm font-semibold" style={{ color: "var(--text-primary)" }}>
+        <span className="min-w-0 max-w-[40%] truncate text-sm font-semibold" style={{ color: "var(--text-primary)" }}>
           {card?.title ?? "Task"}
         </span>
-        {attachName ? (
-          <span
-            className="rounded-full border px-2 py-0.5 font-mono text-xs"
-            style={{ borderColor: "var(--border-default)", color: "var(--text-tertiary)" }}
-          >
-            {attachName}
-          </span>
+
+        {/* Work-state chips: session, worktree/branch + dirty, preview health. */}
+        <div className="flex min-w-0 flex-1 items-center gap-1.5 overflow-hidden">
+          {attachName ? (
+            <span
+              className="flex items-center gap-1.5 rounded-full border px-2 py-0.5 text-xs"
+              style={{ borderColor: "var(--border-default)", color: "var(--text-secondary)" }}
+              title={sessionLive ? "Live session" : "Session ended"}
+            >
+              <StatusDot color={sessionLive ? "var(--success)" : "var(--text-tertiary)"} pulse={sessionLive} />
+              <span className="font-mono">{attachName}</span>
+            </span>
+          ) : null}
+          {worktree ? (
+            <span
+              className="flex items-center gap-1 rounded-full border px-2 py-0.5 text-xs"
+              style={{ borderColor: "var(--border-default)", color: "var(--text-secondary)" }}
+              title={worktree.dirtyState === "dirty" ? "Uncommitted changes" : "Clean working tree"}
+            >
+              <GitBranch size={11} />
+              <span className="max-w-[140px] truncate font-mono">{worktree.currentBranch ?? worktree.sourceBranch ?? "worktree"}</span>
+              {worktree.dirtyCount ? (
+                <span style={{ color: "var(--highlight)" }}>±{worktree.dirtyCount}</span>
+              ) : null}
+            </span>
+          ) : null}
+          {previewHealth ? (
+            <span
+              className="flex items-center gap-1 rounded-full border px-2 py-0.5 text-xs"
+              style={{ borderColor: "var(--border-default)", color: previewColor }}
+              title={`Preview ${previewHealth}`}
+            >
+              <Globe size={11} />
+              {taskPreviews.length}
+            </span>
+          ) : null}
+        </div>
+
+        {projectSlug && card ? (
+          <StartSessionControls
+            projectSlug={projectSlug}
+            taskId={taskId}
+            worktreeId={card.linkedWorktreeId}
+            title={card.title}
+            description={card.description}
+            compact
+          />
         ) : null}
+
         <div className="flex items-center gap-0.5">
           {PANEL_SHORTCUT_ORDER.map((panel, i) => (
             <IconButton

--- a/desktop/src/renderer/src/features/workspace/TaskWorkspace.tsx
+++ b/desktop/src/renderer/src/features/workspace/TaskWorkspace.tsx
@@ -9,7 +9,7 @@ import {
   Sparkles,
   SquareTerminal,
 } from "lucide-react";
-import { useEffect, useMemo } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { EmptyState, IconButton, StatusDot } from "../../design/primitives";
 import { useBoard } from "../../stores/board";
 import { useConnection } from "../../stores/connection";
@@ -96,6 +96,11 @@ export default function TaskWorkspace({
   const togglePanel = useWorkspace((s) => s.togglePanel);
   const layouts = useWorkspace((s) => s.layouts);
   const layoutFor = useWorkspace((s) => s.layoutFor);
+  const [stopAgentState, setStopAgentState] = useState<{
+    attachName: string | null;
+    pending: boolean;
+    error: string | null;
+  }>({ attachName: null, pending: false, error: null });
 
   const card = useMemo(() => {
     for (const cards of Object.values(cardsByProject)) {
@@ -151,6 +156,11 @@ export default function TaskWorkspace({
 
   const attachName = card?.linkedSessionId ? (aliasMap[card.linkedSessionId] ?? null) : null;
   const layout = layouts[taskId] ?? layoutFor(taskId);
+  if (stopAgentState.attachName !== attachName) {
+    setStopAgentState({ attachName, pending: false, error: null });
+  }
+  const stopAgentPending = stopAgentState.attachName === attachName && stopAgentState.pending;
+  const stopAgentError = stopAgentState.attachName === attachName ? stopAgentState.error : null;
 
   // Header chips: live session, agent run, worktree branch/dirty, preview health.
   const liveSession = useMemo(
@@ -177,6 +187,13 @@ export default function TaskWorkspace({
           : "unknown";
   const previewColor =
     previewHealth === "ok" ? "var(--success)" : previewHealth === "failed" ? "var(--danger)" : "var(--text-tertiary)";
+
+  const stopAgent = async () => {
+    if (!api || !attachName || stopAgentPending) return;
+    setStopAgentState({ attachName, pending: true, error: null });
+    const ok = await killSession(api, attachName);
+    setStopAgentState({ attachName, pending: false, error: ok ? null : "Stop failed" });
+  };
 
   const renderPanel = (panel: PanelKind): React.ReactNode => {
     switch (panel) {
@@ -253,16 +270,17 @@ export default function TaskWorkspace({
                 <button
                   type="button"
                   aria-label="Stop agent"
-                  title="Stop agent"
+                  aria-busy={stopAgentPending}
+                  disabled={!api || stopAgentPending}
+                  title={stopAgentPending ? "Stopping agent" : stopAgentError ?? "Stop agent"}
                   className="ml-0.5 flex h-4 w-4 items-center justify-center rounded"
-                  style={{ color: "var(--danger)" }}
-                  onClick={() => {
-                    if (api && attachName) void killSession(api, attachName);
-                  }}
+                  style={{ color: stopAgentPending ? "var(--text-tertiary)" : "var(--danger)" }}
+                  onClick={() => void stopAgent()}
                 >
                   <CircleStop size={12} />
                 </button>
               ) : null}
+              {stopAgentError ? <span style={{ color: "var(--danger)" }}>{stopAgentError}</span> : null}
             </span>
           ) : null}
           {worktree ? (

--- a/desktop/src/renderer/src/features/workspace/TaskWorkspace.tsx
+++ b/desktop/src/renderer/src/features/workspace/TaskWorkspace.tsx
@@ -5,7 +5,6 @@ import {
   GitBranch,
   Globe,
   ListTree,
-  Package,
   SquareTerminal,
 } from "lucide-react";
 import { useEffect, useMemo } from "react";
@@ -31,7 +30,7 @@ const PANEL_ICONS: Record<PanelKind, React.ReactNode> = {
   editor: <FileCode2 size={14} />,
   git: <GitBranch size={14} />,
   browser: <FolderTree size={14} />,
-  artifacts: <Package size={14} />,
+  artifacts: <Globe size={14} />,
   processes: <Activity size={14} />,
   timeline: <ListTree size={14} />,
 };

--- a/desktop/src/renderer/src/features/workspace/TaskWorkspace.tsx
+++ b/desktop/src/renderer/src/features/workspace/TaskWorkspace.tsx
@@ -156,9 +156,11 @@ export default function TaskWorkspace({
 
   const attachName = card?.linkedSessionId ? (aliasMap[card.linkedSessionId] ?? null) : null;
   const layout = layouts[taskId] ?? layoutFor(taskId);
-  if (stopAgentState.attachName !== attachName) {
-    setStopAgentState({ attachName, pending: false, error: null });
-  }
+  useEffect(() => {
+    setStopAgentState((current) =>
+      current.attachName === attachName ? current : { attachName, pending: false, error: null },
+    );
+  }, [attachName]);
   const stopAgentPending = stopAgentState.attachName === attachName && stopAgentState.pending;
   const stopAgentError = stopAgentState.attachName === attachName ? stopAgentState.error : null;
 
@@ -308,7 +310,7 @@ export default function TaskWorkspace({
           ) : null}
         </div>
 
-        {projectSlug && card ? (
+        {projectSlug && card && !sessionLive ? (
           <StartSessionControls
             projectSlug={projectSlug}
             taskId={taskId}

--- a/desktop/src/renderer/src/features/workspace/TaskWorkspace.tsx
+++ b/desktop/src/renderer/src/features/workspace/TaskWorkspace.tsx
@@ -4,6 +4,7 @@ import {
   FolderTree,
   GitBranch,
   Globe,
+  ListTree,
   Package,
   SquareTerminal,
 } from "lucide-react";
@@ -23,6 +24,7 @@ import ArtifactsPanel from "./ArtifactsPanel";
 import PanelStrip, { PANEL_TITLES } from "./PanelStrip";
 import ProcessesPanel from "./ProcessesPanel";
 import StartSessionControls from "./StartSessionControls";
+import TimelinePanel from "./TimelinePanel";
 
 const PANEL_ICONS: Record<PanelKind, React.ReactNode> = {
   terminal: <SquareTerminal size={14} />,
@@ -31,6 +33,7 @@ const PANEL_ICONS: Record<PanelKind, React.ReactNode> = {
   browser: <FolderTree size={14} />,
   artifacts: <Package size={14} />,
   processes: <Activity size={14} />,
+  timeline: <ListTree size={14} />,
 };
 
 const PANEL_SHORTCUT_ORDER: PanelKind[] = [
@@ -40,6 +43,7 @@ const PANEL_SHORTCUT_ORDER: PanelKind[] = [
   "browser",
   "artifacts",
   "processes",
+  "timeline",
 ];
 
 function warnSessionLoadFailure(err: unknown): void {
@@ -185,6 +189,8 @@ export default function TaskWorkspace({
         return projectSlug ? <ArtifactsPanel projectSlug={projectSlug} taskId={taskId} /> : null;
       case "processes":
         return <ProcessesPanel />;
+      case "timeline":
+        return <TimelinePanel taskId={taskId} />;
     }
   };
 

--- a/desktop/src/renderer/src/features/workspace/TimelinePanel.tsx
+++ b/desktop/src/renderer/src/features/workspace/TimelinePanel.tsx
@@ -55,11 +55,18 @@ export function relativeTime(iso: string, now: number): string {
 
 export default function TimelinePanel({ taskId }: { taskId: string }) {
   const api = useConnection((s) => s.api);
+  const [loadedTaskId, setLoadedTaskId] = useState(taskId);
   const [events, setEvents] = useState<TimelineEvent[] | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [now, setNow] = useState(() => Date.now());
   const inFlight = useRef(false);
   const requestSeq = useRef(0);
+
+  if (loadedTaskId !== taskId) {
+    setLoadedTaskId(taskId);
+    setEvents(null);
+    setError(null);
+  }
 
   useEffect(() => {
     if (!api) return;

--- a/desktop/src/renderer/src/features/workspace/TimelinePanel.tsx
+++ b/desktop/src/renderer/src/features/workspace/TimelinePanel.tsx
@@ -59,6 +59,7 @@ export default function TimelinePanel({ taskId }: { taskId: string }) {
   const [error, setError] = useState<string | null>(null);
   const [now, setNow] = useState(() => Date.now());
   const inFlight = useRef(false);
+  const requestSeq = useRef(0);
 
   useEffect(() => {
     if (!api) return;
@@ -66,6 +67,7 @@ export default function TimelinePanel({ taskId }: { taskId: string }) {
     const tick = async () => {
       if (inFlight.current) return;
       inFlight.current = true;
+      const requestId = ++requestSeq.current;
       try {
         const res = await api.get<{ events?: unknown[] }>(
           `/api/workspace/events?taskId=${encodeURIComponent(taskId)}&limit=50`,
@@ -87,13 +89,14 @@ export default function TimelinePanel({ taskId }: { taskId: string }) {
           setEvents((prev) => prev ?? []);
         }
       } finally {
-        inFlight.current = false;
+        if (requestSeq.current === requestId) inFlight.current = false;
       }
     };
     void tick();
     const timer = setInterval(() => void tick(), POLL_MS);
     return () => {
       cancelled = true;
+      requestSeq.current += 1;
       inFlight.current = false;
       clearInterval(timer);
     };

--- a/desktop/src/renderer/src/features/workspace/TimelinePanel.tsx
+++ b/desktop/src/renderer/src/features/workspace/TimelinePanel.tsx
@@ -94,6 +94,7 @@ export default function TimelinePanel({ taskId }: { taskId: string }) {
     const timer = setInterval(() => void tick(), POLL_MS);
     return () => {
       cancelled = true;
+      inFlight.current = false;
       clearInterval(timer);
     };
   }, [api, taskId]);

--- a/desktop/src/renderer/src/features/workspace/TimelinePanel.tsx
+++ b/desktop/src/renderer/src/features/workspace/TimelinePanel.tsx
@@ -1,0 +1,128 @@
+import { useEffect, useRef, useState } from "react";
+import { z } from "zod/v4";
+import { Activity } from "lucide-react";
+import { EmptyState } from "../../design/primitives";
+import { toUserMessage } from "../../lib/errors";
+import { useConnection } from "../../stores/connection";
+
+const POLL_MS = 5000;
+
+const EventSchema = z.object({
+  id: z.string(),
+  type: z.string(),
+  payload: z.record(z.string(), z.unknown()).optional(),
+  createdAt: z.string(),
+});
+export type TimelineEvent = z.infer<typeof EventSchema>;
+
+/** Human-readable label + accent color for a workspace activity event. */
+export function describeEvent(event: TimelineEvent): { label: string; color: string } {
+  const p = event.payload ?? {};
+  const str = (k: string): string | null => (typeof p[k] === "string" ? (p[k] as string) : null);
+  switch (event.type) {
+    case "task.created":
+      return { label: "Task created", color: "var(--text-secondary)" };
+    case "task.updated":
+      return { label: str("status") ? `Status → ${str("status")}` : "Task updated", color: "var(--text-secondary)" };
+    case "session.started":
+      return { label: str("agent") ? `Agent launched (${str("agent")})` : "Session started", color: "var(--success)" };
+    case "session.stopped":
+      return { label: "Session stopped", color: "var(--text-tertiary)" };
+    case "preview.created":
+      return { label: "Preview created", color: "var(--highlight)" };
+    case "preview.updated":
+      return { label: str("lastStatus") === "failed" ? "Preview unhealthy" : "Preview updated", color: "var(--highlight)" };
+    case "preview.deleted":
+      return { label: "Preview removed", color: "var(--text-tertiary)" };
+    default:
+      if (event.type.startsWith("review.")) return { label: `Review ${event.type.slice(7).replace(/\./g, " ")}`, color: "var(--accent)" };
+      return { label: event.type.replace(/[._]/g, " "), color: "var(--text-secondary)" };
+  }
+}
+
+/** Compact relative time ("now", "3m", "2h", "5d") from an ISO string. */
+export function relativeTime(iso: string, now: number): string {
+  const then = Date.parse(iso);
+  if (Number.isNaN(then)) return "";
+  const sec = Math.max(0, Math.floor((now - then) / 1000));
+  if (sec < 45) return "now";
+  const min = Math.floor(sec / 60);
+  if (min < 60) return `${min}m`;
+  const hr = Math.floor(min / 60);
+  if (hr < 24) return `${hr}h`;
+  return `${Math.floor(hr / 24)}d`;
+}
+
+export default function TimelinePanel({ taskId }: { taskId: string }) {
+  const api = useConnection((s) => s.api);
+  const [events, setEvents] = useState<TimelineEvent[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [now, setNow] = useState(() => Date.now());
+  const inFlight = useRef(false);
+
+  useEffect(() => {
+    if (!api) return;
+    let cancelled = false;
+    const tick = async () => {
+      if (inFlight.current) return;
+      inFlight.current = true;
+      try {
+        const res = await api.get<{ events?: unknown[] }>(
+          `/api/workspace/events?taskId=${encodeURIComponent(taskId)}&limit=50`,
+        );
+        if (cancelled) return;
+        const parsed: TimelineEvent[] = [];
+        for (const raw of res.events ?? []) {
+          const r = EventSchema.safeParse(raw);
+          if (r.success) parsed.push(r.data);
+        }
+        // Newest first.
+        parsed.sort((a, b) => Date.parse(b.createdAt) - Date.parse(a.createdAt));
+        setEvents(parsed);
+        setNow(Date.now());
+        setError(null);
+      } catch (err: unknown) {
+        if (!cancelled) {
+          setError(toUserMessage(err));
+          setEvents((prev) => prev ?? []);
+        }
+      } finally {
+        inFlight.current = false;
+      }
+    };
+    void tick();
+    const timer = setInterval(() => void tick(), POLL_MS);
+    return () => {
+      cancelled = true;
+      clearInterval(timer);
+    };
+  }, [api, taskId]);
+
+  if (events === null) {
+    return <div className="flex flex-1 items-center justify-center text-sm" style={{ color: "var(--text-tertiary)" }}>Loading activity…</div>;
+  }
+  if (events.length === 0) {
+    return (
+      <EmptyState
+        icon={<Activity size={22} />}
+        headline="No activity yet"
+        description={error ?? "Start a session or agent and this task's activity will appear here."}
+      />
+    );
+  }
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col gap-px overflow-y-auto p-2">
+      {events.map((event) => {
+        const { label, color } = describeEvent(event);
+        return (
+          <div key={event.id} className="flex items-start gap-2.5 rounded-md px-2 py-1.5">
+            <span className="mt-1.5 h-1.5 w-1.5 shrink-0 rounded-full" style={{ background: color }} />
+            <span className="min-w-0 flex-1 text-sm" style={{ color: "var(--text-primary)" }}>{label}</span>
+            <span className="shrink-0 text-xs tabular-nums" style={{ color: "var(--text-tertiary)" }}>{relativeTime(event.createdAt, now)}</span>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/desktop/src/renderer/src/features/workspace/process-format.ts
+++ b/desktop/src/renderer/src/features/workspace/process-format.ts
@@ -1,0 +1,29 @@
+/** Human byte size (e.g. 1.5 GB) from a byte count. */
+export function formatBytes(bytes: number | undefined): string {
+  if (typeof bytes !== "number" || !Number.isFinite(bytes) || bytes < 0) return "—";
+  const units = ["B", "KB", "MB", "GB", "TB"];
+  let value = bytes;
+  let i = 0;
+  while (value >= 1024 && i < units.length - 1) {
+    value /= 1024;
+    i += 1;
+  }
+  const rounded = value >= 10 || i === 0 ? Math.round(value) : Math.round(value * 10) / 10;
+  return `${rounded} ${units[i]}`;
+}
+
+export function portList(ports: unknown[] | undefined): string {
+  if (!ports || ports.length === 0) return "";
+  const values = ports
+    .map((p) => {
+      const value =
+        typeof p === "object" && p && "port" in p
+          ? (p as { port: unknown }).port
+          : p;
+      if (typeof value === "number" && Number.isFinite(value)) return String(value);
+      if (typeof value === "string" && value.trim().length > 0) return value.trim();
+      return null;
+    })
+    .filter((p): p is string => p !== null);
+  return values.length ? values.join(", ") : "";
+}

--- a/desktop/src/renderer/src/lib/session-merge.ts
+++ b/desktop/src/renderer/src/lib/session-merge.ts
@@ -15,6 +15,9 @@ export interface WorkspaceSessionDTO {
   name?: string;
   kind?: string;
   agent?: string;
+  projectSlug?: string;
+  taskId?: string | null;
+  worktreeId?: string | null;
   runtime?: { zellijSession?: string | null; status?: string } | null;
   status?: string;
 }
@@ -29,6 +32,9 @@ export interface AttachableSession {
   // (running | waiting | idle | failed | …) that drives the agent-run badge.
   kind?: "shell" | "agent";
   agent?: string;
+  projectSlug?: string;
+  taskId?: string;
+  worktreeId?: string;
   runtimeStatus?: string;
 }
 
@@ -46,10 +52,15 @@ function workspaceStatus(record: WorkspaceSessionDTO): "active" | "exited" {
 
 // Optional workspace metadata, added only when present so plain zellij shells
 // keep their minimal shape.
-function workspaceMeta(record: WorkspaceSessionDTO): Partial<Pick<AttachableSession, "kind" | "agent" | "runtimeStatus">> {
-  const meta: Partial<Pick<AttachableSession, "kind" | "agent" | "runtimeStatus">> = {};
+function workspaceMeta(
+  record: WorkspaceSessionDTO,
+): Partial<Pick<AttachableSession, "kind" | "agent" | "projectSlug" | "taskId" | "worktreeId" | "runtimeStatus">> {
+  const meta: Partial<Pick<AttachableSession, "kind" | "agent" | "projectSlug" | "taskId" | "worktreeId" | "runtimeStatus">> = {};
   if (record.kind === "shell" || record.kind === "agent") meta.kind = record.kind;
   if (typeof record.agent === "string" && record.agent.length > 0) meta.agent = record.agent;
+  if (typeof record.projectSlug === "string" && record.projectSlug.length > 0) meta.projectSlug = record.projectSlug;
+  if (typeof record.taskId === "string" && record.taskId.length > 0) meta.taskId = record.taskId;
+  if (typeof record.worktreeId === "string" && record.worktreeId.length > 0) meta.worktreeId = record.worktreeId;
   const runtimeStatus = record.runtime?.status;
   if (typeof runtimeStatus === "string" && runtimeStatus.length > 0) meta.runtimeStatus = runtimeStatus;
   return meta;

--- a/desktop/src/renderer/src/lib/session-merge.ts
+++ b/desktop/src/renderer/src/lib/session-merge.ts
@@ -13,6 +13,8 @@ export interface WorkspaceSessionDTO {
   id?: string;
   sessionId?: string;
   name?: string;
+  kind?: string;
+  agent?: string;
   runtime?: { zellijSession?: string | null; status?: string } | null;
   status?: string;
 }
@@ -22,6 +24,12 @@ export interface AttachableSession {
   attachName: string;
   status: "active" | "exited";
   source: "zellij" | "workspace";
+  // Workspace-only metadata (absent for plain zellij shells): the session kind,
+  // the agent CLI when kind==="agent", and the fine-grained runtime status
+  // (running | waiting | idle | failed | …) that drives the agent-run badge.
+  kind?: "shell" | "agent";
+  agent?: string;
+  runtimeStatus?: string;
 }
 
 export interface SessionMergeResult {
@@ -36,11 +44,23 @@ function workspaceStatus(record: WorkspaceSessionDTO): "active" | "exited" {
   return status !== undefined && EXITED_STATUSES.has(status) ? "exited" : "active";
 }
 
+// Optional workspace metadata, added only when present so plain zellij shells
+// keep their minimal shape.
+function workspaceMeta(record: WorkspaceSessionDTO): Partial<Pick<AttachableSession, "kind" | "agent" | "runtimeStatus">> {
+  const meta: Partial<Pick<AttachableSession, "kind" | "agent" | "runtimeStatus">> = {};
+  if (record.kind === "shell" || record.kind === "agent") meta.kind = record.kind;
+  if (typeof record.agent === "string" && record.agent.length > 0) meta.agent = record.agent;
+  const runtimeStatus = record.runtime?.status;
+  if (typeof runtimeStatus === "string" && runtimeStatus.length > 0) meta.runtimeStatus = runtimeStatus;
+  return meta;
+}
+
 export function mergeAttachableSessions(
   zellij: ZellijSessionDTO[],
   workspace: WorkspaceSessionDTO[],
 ): SessionMergeResult {
   const sessions: AttachableSession[] = [];
+  const byAttach = new Map<string, AttachableSession>();
   const aliasMap: Record<string, string> = {};
   const seenAttachNames = new Set<string>();
 
@@ -48,12 +68,14 @@ export function mergeAttachableSessions(
     const name = entry.name;
     if (!name || name.trim().length === 0 || seenAttachNames.has(name)) continue;
     seenAttachNames.add(name);
-    sessions.push({
+    const session: AttachableSession = {
       name,
       attachName: name,
       status: entry.status === "exited" ? "exited" : "active",
       source: "zellij",
-    });
+    };
+    sessions.push(session);
+    byAttach.set(name, session);
     aliasMap[name] = name;
   }
 
@@ -65,16 +87,23 @@ export function mergeAttachableSessions(
       if (alias && alias.trim().length > 0) aliasMap[alias] = attachName;
     }
 
-    // Zellij (or an earlier record) already owns this attach name — its
-    // status wins, only the aliases above are added.
-    if (seenAttachNames.has(attachName)) continue;
+    // Zellij (or an earlier record) already owns this attach name — its status
+    // wins, but enrich it with the workspace metadata (kind/agent/run status).
+    if (seenAttachNames.has(attachName)) {
+      const existing = byAttach.get(attachName);
+      if (existing) Object.assign(existing, workspaceMeta(record));
+      continue;
+    }
     seenAttachNames.add(attachName);
-    sessions.push({
+    const session: AttachableSession = {
       name: record.name && record.name.trim().length > 0 ? record.name : attachName,
       attachName,
       status: workspaceStatus(record),
       source: "workspace",
-    });
+      ...workspaceMeta(record),
+    };
+    sessions.push(session);
+    byAttach.set(attachName, session);
   }
 
   return { sessions, aliasMap };

--- a/desktop/src/renderer/src/lib/task-sessions.ts
+++ b/desktop/src/renderer/src/lib/task-sessions.ts
@@ -43,6 +43,9 @@ export async function startTaskSession(api: ApiClient, input: StartTaskSessionIn
     return true;
   } catch (err: unknown) {
     console.warn("[task-sessions] task link failed after session create:", err instanceof Error ? err.message : String(err));
+    if (created.attachName) {
+      await useSessions.getState().kill(api, created.attachName);
+    }
     return false;
   }
 }

--- a/desktop/src/renderer/src/lib/task-sessions.ts
+++ b/desktop/src/renderer/src/lib/task-sessions.ts
@@ -46,7 +46,14 @@ export async function startTaskSession(api: ApiClient, input: StartTaskSessionIn
     if (created.attachName) {
       await useSessions.getState().kill(api, created.attachName);
     } else {
-      await api.delete(`/api/sessions/${encodeURIComponent(created.sessionId)}`);
+      try {
+        await api.delete(`/api/sessions/${encodeURIComponent(created.sessionId)}`);
+      } catch (cleanupErr: unknown) {
+        console.warn(
+          "[task-sessions] failed to clean up unlinked session:",
+          cleanupErr instanceof Error ? cleanupErr.message : String(cleanupErr),
+        );
+      }
     }
     return false;
   }

--- a/desktop/src/renderer/src/lib/task-sessions.ts
+++ b/desktop/src/renderer/src/lib/task-sessions.ts
@@ -1,0 +1,43 @@
+// Shared "start a cloud session bound to a task" flow, used by both the task
+// workspace launch controls and the board card quick actions. Talks to the
+// stores directly so it works from event handlers outside React render.
+import type { ApiClient } from "./api";
+import { useBoard } from "../stores/board";
+import { useSessions } from "../stores/sessions";
+
+export interface StartTaskSessionInput {
+  projectSlug: string;
+  taskId: string;
+  worktreeId: string | null;
+  title: string;
+  description: string;
+  kind: "shell" | "agent";
+  agent?: "claude" | "codex";
+}
+
+/**
+ * Creates a terminal/agent session on the cloud computer scoped to the task
+ * (agent prompt prefilled from the task), links it back onto the task, and
+ * flips the task to "running". Returns true on success.
+ */
+export async function startTaskSession(api: ApiClient, input: StartTaskSessionInput): Promise<boolean> {
+  const prompt =
+    input.kind === "agent"
+      ? [input.title, input.description].filter((s) => s.trim().length > 0).join("\n\n")
+      : undefined;
+  const created = await useSessions.getState().create(api, {
+    kind: input.kind,
+    ...(input.agent ? { agent: input.agent } : {}),
+    projectSlug: input.projectSlug,
+    taskId: input.taskId,
+    ...(input.worktreeId ? { worktreeId: input.worktreeId } : {}),
+    ...(prompt ? { prompt } : {}),
+  });
+  if (!created) return false;
+  await useBoard.getState().linkSession(api, input.projectSlug, input.taskId, {
+    linkedSessionId: created.sessionId,
+    ...(input.worktreeId ? { linkedWorktreeId: input.worktreeId } : {}),
+    status: "running",
+  });
+  return true;
+}

--- a/desktop/src/renderer/src/lib/task-sessions.ts
+++ b/desktop/src/renderer/src/lib/task-sessions.ts
@@ -45,6 +45,8 @@ export async function startTaskSession(api: ApiClient, input: StartTaskSessionIn
     console.warn("[task-sessions] task link failed after session create:", err instanceof Error ? err.message : String(err));
     if (created.attachName) {
       await useSessions.getState().kill(api, created.attachName);
+    } else {
+      await api.delete(`/api/sessions/${encodeURIComponent(created.sessionId)}`);
     }
     return false;
   }

--- a/desktop/src/renderer/src/lib/task-sessions.ts
+++ b/desktop/src/renderer/src/lib/task-sessions.ts
@@ -34,10 +34,15 @@ export async function startTaskSession(api: ApiClient, input: StartTaskSessionIn
     ...(prompt ? { prompt } : {}),
   });
   if (!created) return false;
-  await useBoard.getState().linkSession(api, input.projectSlug, input.taskId, {
-    linkedSessionId: created.sessionId,
-    ...(input.worktreeId ? { linkedWorktreeId: input.worktreeId } : {}),
-    status: "running",
-  });
-  return true;
+  try {
+    await useBoard.getState().linkSession(api, input.projectSlug, input.taskId, {
+      linkedSessionId: created.sessionId,
+      ...(input.worktreeId ? { linkedWorktreeId: input.worktreeId } : {}),
+      status: "running",
+    });
+    return true;
+  } catch (err: unknown) {
+    console.warn("[task-sessions] task link failed after session create:", err instanceof Error ? err.message : String(err));
+    return false;
+  }
 }

--- a/desktop/src/renderer/src/stores/board.ts
+++ b/desktop/src/renderer/src/stores/board.ts
@@ -343,7 +343,11 @@ export const useBoard = create<BoardState>()((set, get) => {
 
     linkSession: (api, slug, taskId, fields) => {
       const before = get().cardsByProject[slug]?.find((card) => card.id === taskId);
-      if (!before) return Promise.resolve();
+      if (!before) {
+        const err = new AppError("server");
+        set({ error: err.category });
+        return Promise.reject(err);
+      }
       patchCard(slug, taskId, (card) => ({
         ...card,
         ...(fields.linkedSessionId !== undefined ? { linkedSessionId: fields.linkedSessionId } : {}),

--- a/desktop/src/renderer/src/stores/board.ts
+++ b/desktop/src/renderer/src/stores/board.ts
@@ -120,9 +120,10 @@ const TASKS_PAGE_LIMIT = 100;
 const MAX_TASK_PAGES = 10;
 const MAX_PENDING_TASK_MUTATIONS = 250;
 
-// Per-task in-flight chains so two rapid mutations cannot interleave. Each
-// queued fn handles its own errors (chain never rejects); entries evict
-// themselves once their chain settles, and the live map has a hard cap.
+// Per-task in-flight chains so two rapid mutations cannot interleave. The
+// stored tail never rejects, while the returned promise preserves the caller's
+// success/failure result. Entries evict themselves once their chain settles,
+// and the live map has a hard cap.
 const taskMutationTails = new Map<string, Promise<void>>();
 
 function canEnqueueTaskMutation(taskId: string): boolean {
@@ -134,12 +135,13 @@ function enqueueTaskMutation(taskId: string, fn: () => Promise<void>): Promise<v
     return Promise.reject(new AppError("server"));
   }
   const tail = taskMutationTails.get(taskId) ?? Promise.resolve();
-  const next = tail.then(fn);
-  taskMutationTails.set(taskId, next);
-  void next.finally(() => {
-    if (taskMutationTails.get(taskId) === next) taskMutationTails.delete(taskId);
+  const run = tail.then(fn);
+  const storedTail = run.catch(() => undefined);
+  taskMutationTails.set(taskId, storedTail);
+  void storedTail.finally(() => {
+    if (taskMutationTails.get(taskId) === storedTail) taskMutationTails.delete(taskId);
   });
-  return next;
+  return run;
 }
 
 function taskPath(slug: string, taskId?: string): string {
@@ -359,6 +361,7 @@ export const useBoard = create<BoardState>()((set, get) => {
           patchCard(slug, taskId, () => before);
           await refreshInto(api, slug);
           set({ error: categoryOf(err) });
+          throw err;
         }
       });
     },

--- a/desktop/src/renderer/src/stores/board.ts
+++ b/desktop/src/renderer/src/stores/board.ts
@@ -197,6 +197,12 @@ interface BoardState {
   refreshTasks(api: ApiClient, slug: string): Promise<void>;
   createTask(api: ApiClient, slug: string, input: CreateTaskInput): Promise<Card | null>;
   updateTask(api: ApiClient, slug: string, taskId: string, patch: CardPatch): Promise<void>;
+  linkSession(
+    api: ApiClient,
+    slug: string,
+    taskId: string,
+    fields: { linkedSessionId?: string; linkedWorktreeId?: string; status?: CardStatus },
+  ): Promise<void>;
   moveTask(api: ApiClient, slug: string, taskId: string, status: CardStatus, order: number): Promise<void>;
   archiveTask(api: ApiClient, slug: string, taskId: string): Promise<void>;
   deleteTask(api: ApiClient, slug: string, taskId: string): Promise<void>;
@@ -332,6 +338,30 @@ export const useBoard = create<BoardState>()((set, get) => {
     },
 
     updateTask: (api, slug, taskId, patch) => mutateTask(api, slug, taskId, patch),
+
+    linkSession: (api, slug, taskId, fields) => {
+      const before = get().cardsByProject[slug]?.find((card) => card.id === taskId);
+      if (!before) return Promise.resolve();
+      patchCard(slug, taskId, (card) => ({
+        ...card,
+        ...(fields.linkedSessionId !== undefined ? { linkedSessionId: fields.linkedSessionId } : {}),
+        ...(fields.linkedWorktreeId !== undefined ? { linkedWorktreeId: fields.linkedWorktreeId } : {}),
+        ...(fields.status !== undefined ? { status: fields.status } : {}),
+      }));
+      return enqueueTaskMutation(taskId, async () => {
+        try {
+          const response = await api.patch<{ task: unknown }>(taskPath(slug, taskId), fields);
+          const card = toCard(response.task);
+          if (card) patchCard(slug, taskId, () => card);
+          set({ error: null });
+        } catch (err: unknown) {
+          console.error("[board] Link session failed:", err);
+          patchCard(slug, taskId, () => before);
+          await refreshInto(api, slug);
+          set({ error: categoryOf(err) });
+        }
+      });
+    },
 
     moveTask: (api, slug, taskId, status, order) =>
       mutateTask(api, slug, taskId, { status, order }),

--- a/desktop/src/renderer/src/stores/git.ts
+++ b/desktop/src/renderer/src/stores/git.ts
@@ -96,20 +96,12 @@ let loadAllRequestSeq = 0;
 
 function mergePreviewsForScope(existing: Preview[], incoming: Preview[], slug: string, taskId?: string): Preview[] {
   const incomingIds = new Set(incoming.map((preview) => preview.id));
-<<<<<<< HEAD
-  const scopedOut = existing.filter((preview) => {
-    if (preview.projectSlug !== slug) return true;
-    return taskId ? preview.taskId !== taskId : false;
-  });
-  return [...scopedOut.filter((preview) => !incomingIds.has(preview.id)), ...incoming];
-=======
   const retained = existing.filter((preview) => {
     if (incomingIds.has(preview.id)) return false;
     if (preview.projectSlug !== slug) return true;
     return taskId ? preview.taskId !== taskId : false;
   });
   return [...retained, ...incoming];
->>>>>>> a5e95acf6 (fix(desktop): propagate task session link failures)
 }
 
 interface GitState {

--- a/desktop/src/renderer/src/stores/git.ts
+++ b/desktop/src/renderer/src/stores/git.ts
@@ -104,6 +104,33 @@ function mergePreviewsForScope(existing: Preview[], incoming: Preview[], slug: s
   return [...retained, ...incoming];
 }
 
+const MAX_PREVIEW_REQUEST_SCOPES = 100;
+let previewRequestSeq = 0;
+let previewRequestScopes: string[] = [];
+const previewRequestSeqByScope: Record<string, number> = {};
+
+function previewScopeKey(scope: PreviewScope): string {
+  return `${scope.projectSlug}\0${scope.taskId ?? ""}`;
+}
+
+function markPreviewRequest(scope: PreviewScope): { key: string; seq: number } {
+  const key = previewScopeKey(scope);
+  const seq = ++previewRequestSeq;
+  if (previewRequestSeqByScope[key] === undefined) {
+    previewRequestScopes.push(key);
+    if (previewRequestScopes.length > MAX_PREVIEW_REQUEST_SCOPES) {
+      const expired = previewRequestScopes.shift();
+      if (expired !== undefined) delete previewRequestSeqByScope[expired];
+    }
+  }
+  previewRequestSeqByScope[key] = seq;
+  return { key, seq };
+}
+
+function isLatestPreviewRequest(key: string, seq: number): boolean {
+  return previewRequestSeqByScope[key] === seq;
+}
+
 interface GitState {
   branches: Branch[];
   prs: PullRequest[];
@@ -186,26 +213,21 @@ export const useGit = create<GitState>()((set, get) => ({
 
   loadPreviews: async (api, slug, taskId) => {
     const scope: PreviewScope = { projectSlug: slug, taskId: taskId ?? null };
+    const request = markPreviewRequest(scope);
     const query = taskId ? `?limit=100&taskId=${encodeURIComponent(taskId)}` : "?limit=100";
     set({ previewScope: scope, previewError: null });
     try {
       const res = await api.get<{ previews?: unknown }>(`/api/projects/${slug}/previews${query}`);
       const incoming = parseRows(PreviewSchema, res.previews);
       set((state) => {
-        if (
-          state.previewScope?.projectSlug !== scope.projectSlug ||
-          state.previewScope.taskId !== scope.taskId
-        ) {
+        if (!isLatestPreviewRequest(request.key, request.seq)) {
           return {};
         }
         return { previews: mergePreviewsForScope(state.previews, incoming, slug, taskId), previewError: null };
       });
     } catch (err: unknown) {
       set((state) => {
-        if (
-          state.previewScope?.projectSlug !== scope.projectSlug ||
-          state.previewScope.taskId !== scope.taskId
-        ) {
+        if (!isLatestPreviewRequest(request.key, request.seq)) {
           return {};
         }
         return { previewError: categoryOf(err) };

--- a/desktop/src/renderer/src/stores/git.ts
+++ b/desktop/src/renderer/src/stores/git.ts
@@ -36,6 +36,7 @@ const WorktreeSchema = z.object({
   sourceBranch: z.string().optional(),
   currentBranch: z.string().optional(),
   dirtyState: z.string().optional(),
+  dirtyCount: z.number().optional(),
   createdAt: z.string().optional(),
   pr: WorktreePrSchema.optional(),
 });

--- a/desktop/src/renderer/src/stores/git.ts
+++ b/desktop/src/renderer/src/stores/git.ts
@@ -94,6 +94,15 @@ function parseRows<T>(schema: z.ZodType<T>, rows: unknown): T[] {
 
 let loadAllRequestSeq = 0;
 
+function mergePreviewsForScope(existing: Preview[], incoming: Preview[], slug: string, taskId?: string): Preview[] {
+  const incomingIds = new Set(incoming.map((preview) => preview.id));
+  const scopedOut = existing.filter((preview) => {
+    if (preview.projectSlug !== slug) return true;
+    return taskId ? preview.taskId !== taskId : false;
+  });
+  return [...scopedOut.filter((preview) => !incomingIds.has(preview.id)), ...incoming];
+}
+
 interface GitState {
   branches: Branch[];
   prs: PullRequest[];
@@ -177,9 +186,10 @@ export const useGit = create<GitState>()((set, get) => ({
   loadPreviews: async (api, slug, taskId) => {
     const scope: PreviewScope = { projectSlug: slug, taskId: taskId ?? null };
     const query = taskId ? `?limit=100&taskId=${encodeURIComponent(taskId)}` : "?limit=100";
-    set({ previews: [], previewScope: scope, previewError: null });
+    set({ previewScope: scope, previewError: null });
     try {
       const res = await api.get<{ previews?: unknown }>(`/api/projects/${slug}/previews${query}`);
+      const incoming = parseRows(PreviewSchema, res.previews);
       set((state) => {
         if (
           state.previewScope?.projectSlug !== scope.projectSlug ||
@@ -187,7 +197,7 @@ export const useGit = create<GitState>()((set, get) => ({
         ) {
           return {};
         }
-        return { previews: parseRows(PreviewSchema, res.previews), previewError: null };
+        return { previews: mergePreviewsForScope(state.previews, incoming, slug, taskId), previewError: null };
       });
     } catch (err: unknown) {
       set((state) => {

--- a/desktop/src/renderer/src/stores/git.ts
+++ b/desktop/src/renderer/src/stores/git.ts
@@ -96,11 +96,20 @@ let loadAllRequestSeq = 0;
 
 function mergePreviewsForScope(existing: Preview[], incoming: Preview[], slug: string, taskId?: string): Preview[] {
   const incomingIds = new Set(incoming.map((preview) => preview.id));
+<<<<<<< HEAD
   const scopedOut = existing.filter((preview) => {
     if (preview.projectSlug !== slug) return true;
     return taskId ? preview.taskId !== taskId : false;
   });
   return [...scopedOut.filter((preview) => !incomingIds.has(preview.id)), ...incoming];
+=======
+  const retained = existing.filter((preview) => {
+    if (incomingIds.has(preview.id)) return false;
+    if (preview.projectSlug !== slug) return true;
+    return taskId ? preview.taskId !== taskId : false;
+  });
+  return [...retained, ...incoming];
+>>>>>>> a5e95acf6 (fix(desktop): propagate task session link failures)
 }
 
 interface GitState {

--- a/desktop/src/renderer/src/stores/git.ts
+++ b/desktop/src/renderer/src/stores/git.ts
@@ -159,7 +159,7 @@ export const useGit = create<GitState>()((set, get) => ({
 
   loadAll: async (api, slug) => {
     const requestSeq = ++loadAllRequestSeq;
-    set({ branches: [], prs: [], worktrees: [], refreshedAt: null, loading: true, error: null });
+    set({ loading: true, error: null });
     const failures: AppErrorCategory[] = [];
     const patch: Partial<GitState> = {};
     let branchRefreshed: string | undefined;

--- a/desktop/src/renderer/src/stores/sessions.ts
+++ b/desktop/src/renderer/src/stores/sessions.ts
@@ -201,6 +201,7 @@ export const useSessions = create<SessionsState>()((set, get) => ({
           return {
             sessions: next.sessions,
             aliasMap: next.aliasMap,
+            loading: false,
             creating: false,
             error: null,
           };

--- a/desktop/src/renderer/src/stores/sessions.ts
+++ b/desktop/src/renderer/src/stores/sessions.ts
@@ -177,6 +177,9 @@ export const useSessions = create<SessionsState>()((set, get) => ({
         const input: SessionCreateInput = { kind: existing.kind };
         const agent = existing.kind === "agent" ? sessionAgent(existing.agent) : undefined;
         if (agent) input.agent = agent;
+        if (existing.projectSlug) input.projectSlug = existing.projectSlug;
+        if (existing.taskId) input.taskId = existing.taskId;
+        if (existing.worktreeId) input.worktreeId = existing.worktreeId;
         const res = await api.post<{
           session?: { id?: unknown; runtime?: { zellijSession?: unknown } | null };
         }>("/api/sessions", input);

--- a/desktop/src/renderer/src/stores/sessions.ts
+++ b/desktop/src/renderer/src/stores/sessions.ts
@@ -201,7 +201,6 @@ export const useSessions = create<SessionsState>()((set, get) => ({
           return {
             sessions: next.sessions,
             aliasMap: next.aliasMap,
-            loading: false,
             creating: false,
             error: null,
           };

--- a/desktop/src/renderer/src/stores/sessions.ts
+++ b/desktop/src/renderer/src/stores/sessions.ts
@@ -205,12 +205,18 @@ export const useSessions = create<SessionsState>()((set, get) => ({
           set({ creating: false, error: refreshError });
           return null;
         }
-        set({ creating: false, error: null });
+        let linkError: unknown = null;
         if (existing.projectSlug && existing.taskId) {
-          await useBoard.getState().linkSession(api, existing.projectSlug, existing.taskId, {
-            linkedSessionId: sessionId,
-          });
+          try {
+            await useBoard.getState().linkSession(api, existing.projectSlug, existing.taskId, {
+              linkedSessionId: sessionId,
+            });
+          } catch (err: unknown) {
+            console.error("[sessions] Failed to relink restarted session:", err);
+            linkError = err;
+          }
         }
+        set({ creating: false, error: linkError instanceof AppError ? linkError.category : linkError ? "server" : null });
         return { sessionId, attachName: get().aliasMap[sessionId] ?? directAttachName };
       }
       const response = await api.post<{ name?: unknown }>("/api/terminal/sessions", { name: attachName });

--- a/desktop/src/renderer/src/stores/sessions.ts
+++ b/desktop/src/renderer/src/stores/sessions.ts
@@ -61,6 +61,10 @@ async function deleteAttachableSession(api: ApiClient, attachName: string): Prom
   await api.delete(`/api/terminal/sessions/${encodeURIComponent(attachName)}?force=1`);
 }
 
+async function deleteWorkspaceSession(api: ApiClient, sessionId: string): Promise<void> {
+  await api.delete(`/api/sessions/${encodeURIComponent(sessionId)}`);
+}
+
 let loadSequence = 0;
 
 export const useSessions = create<SessionsState>()((set, get) => ({
@@ -230,6 +234,13 @@ export const useSessions = create<SessionsState>()((set, get) => ({
               await get().load(api);
             } catch (cleanupErr: unknown) {
               console.error("[sessions] Failed to clean up unlinked restarted session:", cleanupErr);
+            }
+          } else {
+            try {
+              await deleteWorkspaceSession(api, sessionId);
+              await get().load(api);
+            } catch (cleanupErr: unknown) {
+              console.error("[sessions] Failed to delete unlinked restarted session:", cleanupErr);
             }
           }
           set({ creating: false, error: linkError instanceof AppError ? linkError.category : "server" });

--- a/desktop/src/renderer/src/stores/sessions.ts
+++ b/desktop/src/renderer/src/stores/sessions.ts
@@ -79,6 +79,29 @@ async function fetchMergedSessions(api: ApiClient): Promise<{
   );
 }
 
+function mergeCreatedSessionState(
+  state: Pick<SessionsState, "sessions" | "aliasMap">,
+  merged: { sessions: AttachableSession[]; aliasMap: Record<string, string> },
+  sessionId: string,
+  directAttachName: string | null,
+): { sessions: AttachableSession[]; aliasMap: Record<string, string>; attachName: string | null } {
+  const attachName = merged.aliasMap[sessionId] ?? directAttachName;
+  if (!attachName) return { sessions: state.sessions, aliasMap: state.aliasMap, attachName: null };
+  const created = merged.sessions.find((session) => session.attachName === attachName) ?? null;
+  const existingIndex = state.sessions.findIndex((session) => session.attachName === attachName);
+  const sessions =
+    created === null
+      ? state.sessions
+      : existingIndex >= 0
+        ? state.sessions.map((session, index) => (index === existingIndex ? created : session))
+        : [created, ...state.sessions];
+  return {
+    sessions,
+    aliasMap: { ...state.aliasMap, [sessionId]: attachName },
+    attachName,
+  };
+}
+
 export const useSessions = create<SessionsState>()((set, get) => ({
   sessions: [],
   aliasMap: {},
@@ -170,10 +193,24 @@ export const useSessions = create<SessionsState>()((set, get) => ({
           error: null,
         });
       } else {
-        set({ creating: false, error: null });
+        set((state) => {
+          const next =
+            sessionId === null
+              ? { sessions: state.sessions, aliasMap: state.aliasMap }
+              : mergeCreatedSessionState(state, merged, sessionId, directAttachName);
+          return {
+            sessions: next.sessions,
+            aliasMap: next.aliasMap,
+            creating: false,
+            error: null,
+          };
+        });
       }
       if (!sessionId) return null;
-      return { sessionId, attachName: merged.aliasMap[sessionId] ?? directAttachName };
+      return {
+        sessionId,
+        attachName: merged.aliasMap[sessionId] ?? directAttachName,
+      };
     } catch (err: unknown) {
       console.error("[sessions] Failed to create session:", err);
       set({ creating: false, error: err instanceof AppError ? err.category : "server" });
@@ -236,6 +273,7 @@ export const useSessions = create<SessionsState>()((set, get) => ({
           set({ creating: false, error: err instanceof AppError ? err.category : "server" });
           return null;
         }
+        let nextAttachName = merged.aliasMap[sessionId] ?? directAttachName;
         if (sequence === loadSequence) {
           set({
             sessions: merged.sessions,
@@ -244,8 +282,17 @@ export const useSessions = create<SessionsState>()((set, get) => ({
             creating: true,
             error: null,
           });
+        } else {
+          set((state) => {
+            const next = mergeCreatedSessionState(state, merged, sessionId, directAttachName);
+            nextAttachName = next.attachName;
+            return {
+              sessions: next.sessions,
+              aliasMap: next.aliasMap,
+              error: null,
+            };
+          });
         }
-        const nextAttachName = merged.aliasMap[sessionId] ?? directAttachName;
         let linkError: unknown = null;
         if (existing.projectSlug && existing.taskId) {
           try {

--- a/desktop/src/renderer/src/stores/sessions.ts
+++ b/desktop/src/renderer/src/stores/sessions.ts
@@ -65,7 +65,19 @@ async function deleteWorkspaceSession(api: ApiClient, sessionId: string): Promis
   await api.delete(`/api/sessions/${encodeURIComponent(sessionId)}`);
 }
 
-let loadSequence = 0;
+async function fetchMergedSessions(api: ApiClient): Promise<{
+  sessions: AttachableSession[];
+  aliasMap: Record<string, string>;
+}> {
+  const [zellijResponse, workspaceResponse] = await Promise.all([
+    api.get<{ sessions: unknown }>("/api/terminal/sessions"),
+    api.get<{ sessions: unknown; nextCursor: string | null }>("/api/sessions"),
+  ]);
+  return mergeAttachableSessions(
+    asArray<ZellijSessionDTO>(zellijResponse.sessions),
+    asArray<WorkspaceSessionDTO>(workspaceResponse.sessions),
+  );
+}
 
 export const useSessions = create<SessionsState>()((set, get) => ({
   sessions: [],
@@ -78,14 +90,7 @@ export const useSessions = create<SessionsState>()((set, get) => ({
     const sequence = ++loadSequence;
     set({ loading: true, error: null });
     try {
-      const [zellijResponse, workspaceResponse] = await Promise.all([
-        api.get<{ sessions: unknown }>("/api/terminal/sessions"),
-        api.get<{ sessions: unknown; nextCursor: string | null }>("/api/sessions"),
-      ]);
-      const merged = mergeAttachableSessions(
-        asArray<ZellijSessionDTO>(zellijResponse.sessions),
-        asArray<WorkspaceSessionDTO>(workspaceResponse.sessions),
-      );
+      const merged = await fetchMergedSessions(api);
       if (sequence !== loadSequence) return;
       set({
         sessions: merged.sessions,
@@ -137,25 +142,38 @@ export const useSessions = create<SessionsState>()((set, get) => ({
           ? res.session.runtime.zellijSession
           : null;
       // Reload so the merged aliasMap resolves the new session's zellij name
-      // (the attach target). load() clears `loading`; restore `creating`.
-      await get().load(api);
-      const refreshError = get().error;
-      if (!sessionId) {
-        set({ creating: false, error: refreshError });
+      // (the attach target). Keep this snapshot local so a concurrent external
+      // load cannot preempt the return value for the just-created session.
+      const sequence = ++loadSequence;
+      let merged: Awaited<ReturnType<typeof fetchMergedSessions>>;
+      try {
+        merged = await fetchMergedSessions(api);
+      } catch (err: unknown) {
+        if (sessionId) {
+          await api.delete(`/api/sessions/${encodeURIComponent(sessionId)}`).catch((cleanupErr: unknown) => {
+            console.warn(
+              "[sessions] Failed to clean up created session after refresh failure:",
+              cleanupErr instanceof Error ? cleanupErr.message : String(cleanupErr),
+            );
+          });
+        }
+        console.error("[sessions] Failed to refresh sessions after create:", err);
+        set({ creating: false, error: err instanceof AppError ? err.category : "server" });
         return null;
       }
-      if (refreshError) {
-        await api.delete(`/api/sessions/${encodeURIComponent(sessionId)}`).catch((err: unknown) => {
-          console.warn(
-            "[sessions] Failed to clean up created session after refresh failure:",
-            err instanceof Error ? err.message : String(err),
-          );
+      if (sequence === loadSequence) {
+        set({
+          sessions: merged.sessions,
+          aliasMap: merged.aliasMap,
+          loading: false,
+          creating: false,
+          error: null,
         });
-        set({ creating: false, error: refreshError });
-        return null;
+      } else {
+        set({ creating: false, error: null });
       }
-      set({ creating: false, error: null });
-      return { sessionId, attachName: get().aliasMap[sessionId] ?? directAttachName };
+      if (!sessionId) return null;
+      return { sessionId, attachName: merged.aliasMap[sessionId] ?? directAttachName };
     } catch (err: unknown) {
       console.error("[sessions] Failed to create session:", err);
       set({ creating: false, error: err instanceof AppError ? err.category : "server" });
@@ -199,23 +217,35 @@ export const useSessions = create<SessionsState>()((set, get) => ({
           typeof res.session?.runtime?.zellijSession === "string"
             ? res.session.runtime.zellijSession
             : null;
-        await get().load(api);
-        const refreshError = get().error;
         if (!sessionId) {
-          set({ creating: false, error: refreshError });
+          set({ creating: false, error: null });
           return null;
         }
-        if (refreshError) {
-          await api.delete(`/api/sessions/${encodeURIComponent(sessionId)}`).catch((err: unknown) => {
+        const sequence = ++loadSequence;
+        let merged: Awaited<ReturnType<typeof fetchMergedSessions>>;
+        try {
+          merged = await fetchMergedSessions(api);
+        } catch (err: unknown) {
+          await api.delete(`/api/sessions/${encodeURIComponent(sessionId)}`).catch((cleanupErr: unknown) => {
             console.warn(
               "[sessions] Failed to clean up restarted session after refresh failure:",
-              err instanceof Error ? err.message : String(err),
+              cleanupErr instanceof Error ? cleanupErr.message : String(cleanupErr),
             );
           });
-          set({ creating: false, error: refreshError });
+          console.error("[sessions] Failed to refresh sessions after restart:", err);
+          set({ creating: false, error: err instanceof AppError ? err.category : "server" });
           return null;
         }
-        const nextAttachName = get().aliasMap[sessionId] ?? directAttachName;
+        if (sequence === loadSequence) {
+          set({
+            sessions: merged.sessions,
+            aliasMap: merged.aliasMap,
+            loading: false,
+            creating: true,
+            error: null,
+          });
+        }
+        const nextAttachName = merged.aliasMap[sessionId] ?? directAttachName;
         let linkError: unknown = null;
         if (existing.projectSlug && existing.taskId) {
           try {

--- a/desktop/src/renderer/src/stores/sessions.ts
+++ b/desktop/src/renderer/src/stores/sessions.ts
@@ -57,6 +57,10 @@ function nextSessionName(): string {
   return `operator-${Date.now().toString(36)}-${suffix}`;
 }
 
+async function deleteAttachableSession(api: ApiClient, attachName: string): Promise<void> {
+  await api.delete(`/api/terminal/sessions/${encodeURIComponent(attachName)}?force=1`);
+}
+
 export const useSessions = create<SessionsState>()((set, get) => ({
   sessions: [],
   aliasMap: {},
@@ -155,7 +159,7 @@ export const useSessions = create<SessionsState>()((set, get) => ({
 
   kill: async (api, attachName) => {
     try {
-      await api.delete(`/api/terminal/sessions/${encodeURIComponent(attachName)}?force=1`);
+      await deleteAttachableSession(api, attachName);
       await get().load(api);
       return true;
     } catch (err: unknown) {
@@ -170,7 +174,7 @@ export const useSessions = create<SessionsState>()((set, get) => ({
     try {
       const existing = get().sessions.find((session) => session.attachName === attachName) ?? null;
       try {
-        await api.delete(`/api/terminal/sessions/${encodeURIComponent(attachName)}?force=1`);
+        await deleteAttachableSession(api, attachName);
       } catch (err: unknown) {
         if (!(err instanceof AppError && err.category === "notFound")) throw err;
       }
@@ -205,6 +209,7 @@ export const useSessions = create<SessionsState>()((set, get) => ({
           set({ creating: false, error: refreshError });
           return null;
         }
+        const nextAttachName = get().aliasMap[sessionId] ?? directAttachName;
         let linkError: unknown = null;
         if (existing.projectSlug && existing.taskId) {
           try {
@@ -216,8 +221,20 @@ export const useSessions = create<SessionsState>()((set, get) => ({
             linkError = err;
           }
         }
-        set({ creating: false, error: linkError instanceof AppError ? linkError.category : linkError ? "server" : null });
-        return { sessionId, attachName: get().aliasMap[sessionId] ?? directAttachName };
+        if (linkError) {
+          if (nextAttachName) {
+            try {
+              await deleteAttachableSession(api, nextAttachName);
+              await get().load(api);
+            } catch (cleanupErr: unknown) {
+              console.error("[sessions] Failed to clean up unlinked restarted session:", cleanupErr);
+            }
+          }
+          set({ creating: false, error: linkError instanceof AppError ? linkError.category : "server" });
+          return null;
+        }
+        set({ creating: false, error: null });
+        return { sessionId, attachName: nextAttachName };
       }
       const response = await api.post<{ name?: unknown }>("/api/terminal/sessions", { name: attachName });
       const restarted = typeof response.name === "string" && response.name.trim() ? response.name.trim() : attachName;

--- a/desktop/src/renderer/src/stores/sessions.ts
+++ b/desktop/src/renderer/src/stores/sessions.ts
@@ -21,6 +21,12 @@ export interface SessionCreateInput {
   prompt?: string;
 }
 
+const SUPPORTED_AGENTS = new Set(["claude", "codex", "opencode", "pi"]);
+
+function sessionAgent(agent: string | undefined): SessionCreateInput["agent"] | undefined {
+  return SUPPORTED_AGENTS.has(agent ?? "") ? (agent as SessionCreateInput["agent"]) : undefined;
+}
+
 export interface CreatedSession {
   sessionId: string;
   attachName: string | null;
@@ -111,8 +117,14 @@ export const useSessions = create<SessionsState>()((set, get) => ({
         return { sessionId: attachName, attachName };
       }
 
-      const res = await api.post<{ session?: { id?: unknown } }>("/api/sessions", input);
+      const res = await api.post<{
+        session?: { id?: unknown; runtime?: { zellijSession?: unknown } | null };
+      }>("/api/sessions", input);
       const sessionId = typeof res.session?.id === "string" ? res.session.id : null;
+      const directAttachName =
+        typeof res.session?.runtime?.zellijSession === "string"
+          ? res.session.runtime.zellijSession
+          : null;
       // Reload so the merged aliasMap resolves the new session's zellij name
       // (the attach target). load() clears `loading`; restore `creating`.
       await get().load(api);
@@ -132,7 +144,7 @@ export const useSessions = create<SessionsState>()((set, get) => ({
         return null;
       }
       set({ creating: false, error: null });
-      return { sessionId, attachName: get().aliasMap[sessionId] ?? null };
+      return { sessionId, attachName: get().aliasMap[sessionId] ?? directAttachName };
     } catch (err: unknown) {
       console.error("[sessions] Failed to create session:", err);
       set({ creating: false, error: err instanceof AppError ? err.category : "server" });
@@ -155,10 +167,42 @@ export const useSessions = create<SessionsState>()((set, get) => ({
   restart: async (api, attachName) => {
     set({ creating: true });
     try {
+      const existing = get().sessions.find((session) => session.attachName === attachName) ?? null;
       try {
         await api.delete(`/api/terminal/sessions/${encodeURIComponent(attachName)}?force=1`);
       } catch (err: unknown) {
         if (!(err instanceof AppError && err.category === "notFound")) throw err;
+      }
+      if (existing?.source === "workspace" && existing.kind) {
+        const input: SessionCreateInput = { kind: existing.kind };
+        const agent = existing.kind === "agent" ? sessionAgent(existing.agent) : undefined;
+        if (agent) input.agent = agent;
+        const res = await api.post<{
+          session?: { id?: unknown; runtime?: { zellijSession?: unknown } | null };
+        }>("/api/sessions", input);
+        const sessionId = typeof res.session?.id === "string" ? res.session.id : null;
+        const directAttachName =
+          typeof res.session?.runtime?.zellijSession === "string"
+            ? res.session.runtime.zellijSession
+            : null;
+        await get().load(api);
+        const refreshError = get().error;
+        if (!sessionId) {
+          set({ creating: false, error: refreshError });
+          return null;
+        }
+        if (refreshError) {
+          await api.delete(`/api/sessions/${encodeURIComponent(sessionId)}`).catch((err: unknown) => {
+            console.warn(
+              "[sessions] Failed to clean up restarted session after refresh failure:",
+              err instanceof Error ? err.message : String(err),
+            );
+          });
+          set({ creating: false, error: refreshError });
+          return null;
+        }
+        set({ creating: false, error: null });
+        return { sessionId, attachName: get().aliasMap[sessionId] ?? directAttachName };
       }
       const response = await api.post<{ name?: unknown }>("/api/terminal/sessions", { name: attachName });
       const restarted = typeof response.name === "string" && response.name.trim() ? response.name.trim() : attachName;

--- a/desktop/src/renderer/src/stores/sessions.ts
+++ b/desktop/src/renderer/src/stores/sessions.ts
@@ -221,13 +221,20 @@ export const useSessions = create<SessionsState>()((set, get) => ({
   kill: async (api, attachName) => {
     try {
       await deleteAttachableSession(api, attachName);
-      await get().load(api);
-      return true;
     } catch (err: unknown) {
-      console.error("[sessions] Failed to kill session:", err);
-      set({ error: err instanceof AppError ? err.category : "server" });
-      return false;
+      if (!(err instanceof AppError && err.category === "notFound")) {
+        console.error("[sessions] Failed to kill session:", err);
+        set({ error: err instanceof AppError ? err.category : "server" });
+        return false;
+      }
     }
+    try {
+      await get().load(api);
+    } catch (err: unknown) {
+      console.error("[sessions] Failed to reload after kill:", err);
+      set({ error: err instanceof AppError ? err.category : "server" });
+    }
+    return true;
   },
 
   restart: async (api, attachName) => {

--- a/desktop/src/renderer/src/stores/sessions.ts
+++ b/desktop/src/renderer/src/stores/sessions.ts
@@ -34,6 +34,7 @@ interface SessionsState {
   error: AppErrorCategory | null;
   load(api: ApiClient): Promise<void>;
   create(api: ApiClient, input?: SessionCreateInput): Promise<CreatedSession | null>;
+  kill(api: ApiClient, attachName: string): Promise<boolean>;
   resolveAttachName(linkedSessionId: string | null): string | null;
 }
 
@@ -135,6 +136,18 @@ export const useSessions = create<SessionsState>()((set, get) => ({
       console.error("[sessions] Failed to create session:", err);
       set({ creating: false, error: err instanceof AppError ? err.category : "server" });
       return null;
+    }
+  },
+
+  kill: async (api, attachName) => {
+    try {
+      await api.delete(`/api/terminal/sessions/${encodeURIComponent(attachName)}?force=1`);
+      await get().load(api);
+      return true;
+    } catch (err: unknown) {
+      console.error("[sessions] Failed to kill session:", err);
+      set({ error: err instanceof AppError ? err.category : "server" });
+      return false;
     }
   },
 

--- a/desktop/src/renderer/src/stores/sessions.ts
+++ b/desktop/src/renderer/src/stores/sessions.ts
@@ -61,6 +61,8 @@ async function deleteAttachableSession(api: ApiClient, attachName: string): Prom
   await api.delete(`/api/terminal/sessions/${encodeURIComponent(attachName)}?force=1`);
 }
 
+let loadSequence = 0;
+
 export const useSessions = create<SessionsState>()((set, get) => ({
   sessions: [],
   aliasMap: {},

--- a/desktop/src/renderer/src/stores/sessions.ts
+++ b/desktop/src/renderer/src/stores/sessions.ts
@@ -11,6 +11,7 @@ import {
   type WorkspaceSessionDTO,
   type ZellijSessionDTO,
 } from "../lib/session-merge";
+import { useBoard } from "./board";
 
 export interface SessionCreateInput {
   kind: "shell" | "agent";
@@ -205,6 +206,11 @@ export const useSessions = create<SessionsState>()((set, get) => ({
           return null;
         }
         set({ creating: false, error: null });
+        if (existing.projectSlug && existing.taskId) {
+          await useBoard.getState().linkSession(api, existing.projectSlug, existing.taskId, {
+            linkedSessionId: sessionId,
+          });
+        }
         return { sessionId, attachName: get().aliasMap[sessionId] ?? directAttachName };
       }
       const response = await api.post<{ name?: unknown }>("/api/terminal/sessions", { name: attachName });

--- a/desktop/src/renderer/src/stores/sessions.ts
+++ b/desktop/src/renderer/src/stores/sessions.ts
@@ -35,6 +35,7 @@ interface SessionsState {
   load(api: ApiClient): Promise<void>;
   create(api: ApiClient, input?: SessionCreateInput): Promise<CreatedSession | null>;
   kill(api: ApiClient, attachName: string): Promise<boolean>;
+  restart(api: ApiClient, attachName: string): Promise<CreatedSession | null>;
   resolveAttachName(linkedSessionId: string | null): string | null;
 }
 
@@ -148,6 +149,26 @@ export const useSessions = create<SessionsState>()((set, get) => ({
       console.error("[sessions] Failed to kill session:", err);
       set({ error: err instanceof AppError ? err.category : "server" });
       return false;
+    }
+  },
+
+  restart: async (api, attachName) => {
+    set({ creating: true });
+    try {
+      try {
+        await api.delete(`/api/terminal/sessions/${encodeURIComponent(attachName)}?force=1`);
+      } catch (err: unknown) {
+        if (!(err instanceof AppError && err.category === "notFound")) throw err;
+      }
+      const response = await api.post<{ name?: unknown }>("/api/terminal/sessions", { name: attachName });
+      const restarted = typeof response.name === "string" && response.name.trim() ? response.name.trim() : attachName;
+      await get().load(api);
+      set({ creating: false, error: null });
+      return { sessionId: restarted, attachName: restarted };
+    } catch (err: unknown) {
+      console.error("[sessions] Failed to restart session:", err);
+      set({ creating: false, error: err instanceof AppError ? err.category : "server" });
+      return null;
     }
   },
 

--- a/desktop/src/renderer/src/stores/sessions.ts
+++ b/desktop/src/renderer/src/stores/sessions.ts
@@ -12,13 +12,28 @@ import {
   type ZellijSessionDTO,
 } from "../lib/session-merge";
 
+export interface SessionCreateInput {
+  kind: "shell" | "agent";
+  agent?: "claude" | "codex" | "opencode" | "pi";
+  projectSlug?: string;
+  taskId?: string;
+  worktreeId?: string;
+  prompt?: string;
+}
+
+export interface CreatedSession {
+  sessionId: string;
+  attachName: string | null;
+}
+
 interface SessionsState {
   sessions: AttachableSession[];
   aliasMap: Record<string, string>;
   loading: boolean;
+  creating: boolean;
   error: AppErrorCategory | null;
   load(api: ApiClient): Promise<void>;
-  create(api: ApiClient): Promise<AttachableSession | null>;
+  create(api: ApiClient, input?: SessionCreateInput): Promise<CreatedSession | null>;
   resolveAttachName(linkedSessionId: string | null): string | null;
 }
 
@@ -37,6 +52,7 @@ export const useSessions = create<SessionsState>()((set, get) => ({
   sessions: [],
   aliasMap: {},
   loading: false,
+  creating: false,
   error: null,
 
   load: async (api) => {
@@ -68,34 +84,56 @@ export const useSessions = create<SessionsState>()((set, get) => ({
     }
   },
 
-  create: async (api) => {
-    const name = nextSessionName();
-    set({ loading: true, error: null });
+  create: async (api, input) => {
+    set({ creating: true, error: null });
     try {
-      const response = await api.post<{ name?: unknown }>("/api/terminal/sessions", { name });
-      const attachName = typeof response.name === "string" && response.name.trim() ? response.name.trim() : name;
-      const refreshSequence = loadSequence + 1;
+      if (!input) {
+        const name = nextSessionName();
+        const response = await api.post<{ name?: unknown }>("/api/terminal/sessions", { name });
+        const attachName = typeof response.name === "string" && response.name.trim() ? response.name.trim() : name;
+        const refreshSequence = loadSequence + 1;
+        await get().load(api);
+        const refreshError = get().error;
+        const created = get().sessions.find((session) => session.attachName === attachName) ?? {
+          name: attachName,
+          attachName,
+          status: "active" as const,
+          source: "zellij" as const,
+        };
+        set((state) => {
+          const loadingPatch = refreshSequence === loadSequence && state.loading ? { loading: false } : {};
+          return state.sessions.some((session) => session.attachName === created.attachName)
+            ? { ...loadingPatch, creating: false, error: refreshError }
+            : { sessions: [created, ...state.sessions], ...loadingPatch, creating: false, error: refreshError };
+        });
+        return { sessionId: attachName, attachName };
+      }
+
+      const res = await api.post<{ session?: { id?: unknown } }>("/api/sessions", input);
+      const sessionId = typeof res.session?.id === "string" ? res.session.id : null;
+      // Reload so the merged aliasMap resolves the new session's zellij name
+      // (the attach target). load() clears `loading`; restore `creating`.
       await get().load(api);
       const refreshError = get().error;
-      const created = get().sessions.find((session) => session.attachName === attachName) ?? {
-        name: attachName,
-        attachName,
-        status: "active" as const,
-        source: "zellij" as const,
-      };
-      set((state) => {
-        const loadingPatch = refreshSequence === loadSequence && state.loading ? { loading: false } : {};
-        return state.sessions.some((session) => session.attachName === created.attachName)
-          ? { ...loadingPatch, error: refreshError }
-          : { sessions: [created, ...state.sessions], ...loadingPatch, error: refreshError };
-      });
-      return created;
+      if (!sessionId) {
+        set({ creating: false, error: refreshError });
+        return null;
+      }
+      if (refreshError) {
+        await api.delete(`/api/sessions/${encodeURIComponent(sessionId)}`).catch((err: unknown) => {
+          console.warn(
+            "[sessions] Failed to clean up created session after refresh failure:",
+            err instanceof Error ? err.message : String(err),
+          );
+        });
+        set({ creating: false, error: refreshError });
+        return null;
+      }
+      set({ creating: false, error: null });
+      return { sessionId, attachName: get().aliasMap[sessionId] ?? null };
     } catch (err: unknown) {
       console.error("[sessions] Failed to create session:", err);
-      set({
-        loading: false,
-        error: err instanceof AppError ? err.category : "server",
-      });
+      set({ creating: false, error: err instanceof AppError ? err.category : "server" });
       return null;
     }
   },

--- a/desktop/src/renderer/src/stores/workspace.ts
+++ b/desktop/src/renderer/src/stores/workspace.ts
@@ -6,7 +6,7 @@
 // the UI wires it to window.operator state:get/state:set.
 import { create } from "zustand";
 
-export type PanelKind = "terminal" | "editor" | "git" | "browser" | "artifacts" | "processes";
+export type PanelKind = "terminal" | "editor" | "git" | "browser" | "artifacts" | "processes" | "timeline";
 
 export const PANEL_KINDS: readonly PanelKind[] = [
   "terminal",
@@ -15,6 +15,7 @@ export const PANEL_KINDS: readonly PanelKind[] = [
   "browser",
   "artifacts",
   "processes",
+  "timeline",
 ];
 
 export const PANEL_MIN_PCT: Record<PanelKind, number> = {
@@ -24,6 +25,7 @@ export const PANEL_MIN_PCT: Record<PanelKind, number> = {
   browser: 15,
   artifacts: 15,
   processes: 15,
+  timeline: 18,
 };
 
 export interface PanelLayout {
@@ -97,6 +99,22 @@ export function defaultLayout(now: number = Date.now()): PanelLayout {
     sizes: equalSplitSizes(visible),
     touchedAt: now,
   };
+}
+
+// Migrate a (possibly older) persisted layout so it contains every current
+// PanelKind — new kinds are appended to order, hidden, with zero size. Without
+// this, a panel added after a layout was saved would never render (PanelStrip
+// only walks layout.order).
+export function normalizeLayout(layout: PanelLayout): PanelLayout {
+  const order = [...layout.order.filter((k) => PANEL_KINDS.includes(k))];
+  for (const kind of PANEL_KINDS) if (!order.includes(kind)) order.push(kind);
+  const visible = { ...layout.visible } as Record<PanelKind, boolean>;
+  const sizes = { ...layout.sizes } as Record<PanelKind, number>;
+  for (const kind of PANEL_KINDS) {
+    if (typeof visible[kind] !== "boolean") visible[kind] = false;
+    if (typeof sizes[kind] !== "number") sizes[kind] = 0;
+  }
+  return { ...layout, order, visible, sizes };
 }
 
 export interface WorkspaceEntry {
@@ -205,7 +223,7 @@ export const useWorkspace = create<WorkspaceState>()((set, get) => {
     },
 
     togglePanel: (taskId, panel, now = Date.now()) => {
-      const layout = get().layouts[taskId] ?? defaultLayout(now);
+      const layout = normalizeLayout(get().layouts[taskId] ?? defaultLayout(now));
       const visible = { ...layout.visible, [panel]: !layout.visible[panel] };
       const sizes = visible[panel]
         ? restorePanelSize(visible, layout.sizes, panel)
@@ -214,7 +232,7 @@ export const useWorkspace = create<WorkspaceState>()((set, get) => {
     },
 
     setPanelSizes: (taskId, sizes, now = Date.now(), options) => {
-      const layout = get().layouts[taskId] ?? defaultLayout(now);
+      const layout = normalizeLayout(get().layouts[taskId] ?? defaultLayout(now));
       const next = { ...layout.sizes };
       for (const kind of PANEL_KINDS) {
         const value = sizes[kind];
@@ -227,7 +245,7 @@ export const useWorkspace = create<WorkspaceState>()((set, get) => {
     },
 
     movePanel: (taskId, panel, direction, now = Date.now()) => {
-      const layout = get().layouts[taskId] ?? defaultLayout(now);
+      const layout = normalizeLayout(get().layouts[taskId] ?? defaultLayout(now));
       const index = layout.order.indexOf(panel);
       if (index === -1) return;
       const target = direction === "left" ? index - 1 : index + 1;
@@ -239,6 +257,6 @@ export const useWorkspace = create<WorkspaceState>()((set, get) => {
       writeLayout(taskId, { ...layout, order, touchedAt: now });
     },
 
-    layoutFor: (taskId) => get().layouts[taskId] ?? defaultLayout(),
+    layoutFor: (taskId) => normalizeLayout(get().layouts[taskId] ?? defaultLayout()),
   };
 });

--- a/tests/desktop/artifacts-panel.test.tsx
+++ b/tests/desktop/artifacts-panel.test.tsx
@@ -36,7 +36,7 @@ describe("artifacts preview URLs", () => {
     render(<ArtifactsPanel projectSlug="matrix-os" taskId="task-1" />);
 
     expect(screen.getByText("Couldn't load artifacts")).toBeTruthy();
-    expect(screen.queryByText("No artifacts")).toBeNull();
+    expect(screen.queryByText("No previews")).toBeNull();
   });
 
   it("does not show list load failures as artifact failures", () => {
@@ -51,6 +51,6 @@ describe("artifacts preview URLs", () => {
     render(<ArtifactsPanel projectSlug="matrix-os" taskId="task-1" />);
 
     expect(screen.queryByText("Couldn't load artifacts")).toBeNull();
-    expect(screen.getByText("No artifacts")).toBeTruthy();
+    expect(screen.getByText("No previews")).toBeTruthy();
   });
 });

--- a/tests/desktop/artifacts-panel.test.tsx
+++ b/tests/desktop/artifacts-panel.test.tsx
@@ -1,17 +1,57 @@
 // @vitest-environment jsdom
 
 import React from "react";
+import * as Tooltip from "@radix-ui/react-tooltip";
 import { cleanup, render, screen } from "@testing-library/react";
-import { afterEach, describe, expect, it } from "vitest";
-import ArtifactsPanel, { canOpenPreviewUrl } from "../../desktop/src/renderer/src/features/workspace/ArtifactsPanel";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import ArtifactsPanel, {
+  canOpenPreviewUrl,
+} from "../../desktop/src/renderer/src/features/workspace/ArtifactsPanel";
 import { useConnection } from "../../desktop/src/renderer/src/stores/connection";
 import { useGit } from "../../desktop/src/renderer/src/stores/git";
 
-afterEach(() => {
-  cleanup();
-});
+describe("ArtifactsPanel", () => {
+  beforeEach(() => {
+    useConnection.setState({
+      status: "signed-in",
+      handle: "operator",
+      platformHost: "https://platform.test",
+      runtimeSlot: "primary",
+      api: null,
+    });
+    useGit.setState({
+      previews: [
+        {
+          id: "preview_task_a",
+          projectSlug: "proj",
+          taskId: "task_a",
+          label: "Task preview",
+          url: "https://preview.example.com",
+          lastStatus: "ok",
+        },
+      ],
+      previewScope: { projectSlug: "proj", taskId: null },
+      error: null,
+      previewError: null,
+    });
+  });
 
-describe("artifacts preview URLs", () => {
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it("renders task previews even after a project-wide preview load changes scope", () => {
+    render(
+      <Tooltip.Provider>
+        <ArtifactsPanel projectSlug="proj" taskId="task_a" />
+      </Tooltip.Provider>,
+    );
+
+    expect(screen.getByText("Task preview")).toBeTruthy();
+    expect(screen.queryByText("No previews")).toBeNull();
+  });
+
   it("allows only secure HTTP preview links", () => {
     expect(canOpenPreviewUrl("http://127.0.0.1:5173")).toBe(false);
     expect(canOpenPreviewUrl("https://preview.example.com")).toBe(true);
@@ -33,9 +73,13 @@ describe("artifacts preview URLs", () => {
       previewError: "timeout",
     });
 
-    render(<ArtifactsPanel projectSlug="matrix-os" taskId="task-1" />);
+    render(
+      <Tooltip.Provider>
+        <ArtifactsPanel projectSlug="matrix-os" taskId="task-1" />
+      </Tooltip.Provider>,
+    );
 
-    expect(screen.getByText("Couldn't load artifacts")).toBeTruthy();
+    expect(screen.getByText("Couldn't load previews")).toBeTruthy();
     expect(screen.queryByText("No previews")).toBeNull();
   });
 
@@ -48,9 +92,13 @@ describe("artifacts preview URLs", () => {
       previewError: null,
     });
 
-    render(<ArtifactsPanel projectSlug="matrix-os" taskId="task-1" />);
+    render(
+      <Tooltip.Provider>
+        <ArtifactsPanel projectSlug="matrix-os" taskId="task-1" />
+      </Tooltip.Provider>,
+    );
 
-    expect(screen.queryByText("Couldn't load artifacts")).toBeNull();
+    expect(screen.queryByText("Couldn't load previews")).toBeNull();
     expect(screen.getByText("No previews")).toBeTruthy();
   });
 });

--- a/tests/desktop/board-card.test.tsx
+++ b/tests/desktop/board-card.test.tsx
@@ -1,0 +1,103 @@
+// @vitest-environment jsdom
+
+import React from "react";
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import BoardCard from "../../desktop/src/renderer/src/features/board/BoardCard";
+import type { Card } from "../../desktop/src/renderer/src/stores/board";
+import { useConnection } from "../../desktop/src/renderer/src/stores/connection";
+import { useGit } from "../../desktop/src/renderer/src/stores/git";
+import { useSessions } from "../../desktop/src/renderer/src/stores/sessions";
+
+vi.mock("../../desktop/src/renderer/src/design/primitives", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../desktop/src/renderer/src/design/primitives")>();
+  return {
+    ...actual,
+    ContextMenu: ({
+      items,
+      children,
+    }: {
+      items: Array<{ label: string; onSelect: () => void }>;
+      children: React.ReactNode;
+    }) => (
+      <div>
+        {children}
+        <div data-testid="board-card-menu">
+          {items.map((item) => (
+            <button key={item.label} type="button" onClick={item.onSelect}>
+              {item.label}
+            </button>
+          ))}
+        </div>
+      </div>
+    ),
+  };
+});
+
+const baseCard: Card = {
+  id: "task-1",
+  projectSlug: "project",
+  title: "Ship desktop",
+  description: "",
+  status: "todo",
+  priority: "normal",
+  order: 1,
+  parentTaskId: null,
+  linkedSessionId: "session-1",
+  linkedWorktreeId: null,
+  previewIds: [],
+  tags: [],
+  updatedAt: null,
+  revision: null,
+};
+
+describe("BoardCard", () => {
+  beforeEach(() => {
+    useConnection.setState({ api: null });
+    useGit.setState({ worktrees: [], previews: [] });
+    useSessions.setState({ sessions: [], aliasMap: {} });
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it("hides start-agent menu actions while a linked session is live", () => {
+    useSessions.setState({
+      aliasMap: { "session-1": "operator-session" },
+      sessions: [
+        {
+          name: "operator-session",
+          attachName: "operator-session",
+          status: "active",
+          source: "workspace",
+        },
+      ],
+    });
+
+    render(<BoardCard card={baseCard} />);
+
+    expect(screen.queryByText("Start Claude")).toBeNull();
+    expect(screen.queryByText("Start Codex")).toBeNull();
+  });
+
+  it("shows start-agent menu actions when no linked session is live", () => {
+    useSessions.setState({
+      aliasMap: { "session-1": "operator-session" },
+      sessions: [
+        {
+          name: "operator-session",
+          attachName: "operator-session",
+          status: "exited",
+          source: "workspace",
+        },
+      ],
+    });
+
+    render(<BoardCard card={baseCard} />);
+
+    expect(screen.getByText("Start Claude")).toBeTruthy();
+    expect(screen.getByText("Start Codex")).toBeTruthy();
+  });
+});

--- a/tests/desktop/board-store.test.ts
+++ b/tests/desktop/board-store.test.ts
@@ -122,7 +122,9 @@ describe("linkSession", () => {
     });
     useBoard.setState({ cardsByProject: { proj: [card({ id: "task_a", linkedSessionId: null })] } });
 
-    await useBoard.getState().linkSession(api, "proj", "task_a", { linkedSessionId: "sess_1" });
+    await expect(
+      useBoard.getState().linkSession(api, "proj", "task_a", { linkedSessionId: "sess_1" }),
+    ).rejects.toBeInstanceOf(AppError);
     expect(useBoard.getState().error).toBe("server");
   });
 });

--- a/tests/desktop/board-store.test.ts
+++ b/tests/desktop/board-store.test.ts
@@ -127,6 +127,17 @@ describe("linkSession", () => {
     ).rejects.toBeInstanceOf(AppError);
     expect(useBoard.getState().error).toBe("server");
   });
+
+  it("rejects instead of reporting success when the task is missing locally", async () => {
+    const patch = vi.fn().mockResolvedValue({ task: wireTask({ linkedSessionId: "sess_1" }) });
+    const api = makeApi({ patch });
+
+    await expect(
+      useBoard.getState().linkSession(api, "proj", "task_a", { linkedSessionId: "sess_1" }),
+    ).rejects.toBeInstanceOf(AppError);
+    expect(patch).not.toHaveBeenCalled();
+    expect(useBoard.getState().error).toBe("server");
+  });
 });
 
 describe("loadProjects", () => {

--- a/tests/desktop/board-store.test.ts
+++ b/tests/desktop/board-store.test.ts
@@ -93,6 +93,40 @@ describe("groupCardsByColumn", () => {
   });
 });
 
+describe("linkSession", () => {
+  it("optimistically links a session and persists the patch", async () => {
+    const patched = wireTask({ linkedSessionId: "sess_1", status: "running" });
+    const patch = vi.fn().mockResolvedValue({ task: patched });
+    const api = makeApi({ patch });
+    useBoard.setState({ cardsByProject: { proj: [card({ id: "task_a" })] } });
+
+    await useBoard.getState().linkSession(api, "proj", "task_a", {
+      linkedSessionId: "sess_1",
+      status: "running",
+    });
+
+    expect(patch).toHaveBeenCalledWith(
+      "/api/projects/proj/tasks/task_a",
+      { linkedSessionId: "sess_1", status: "running" },
+    );
+    const updated = useBoard.getState().cardsByProject["proj"]![0]!;
+    expect(updated.linkedSessionId).toBe("sess_1");
+    expect(updated.status).toBe("running");
+    expect(useBoard.getState().error).toBeNull();
+  });
+
+  it("rolls back and surfaces an error category on failure", async () => {
+    const api = makeApi({
+      patch: vi.fn().mockRejectedValue(new AppError("server")),
+      get: vi.fn().mockResolvedValue({ tasks: [], nextCursor: null }),
+    });
+    useBoard.setState({ cardsByProject: { proj: [card({ id: "task_a", linkedSessionId: null })] } });
+
+    await useBoard.getState().linkSession(api, "proj", "task_a", { linkedSessionId: "sess_1" });
+    expect(useBoard.getState().error).toBe("server");
+  });
+});
+
 describe("loadProjects", () => {
   it("loads the project list from /api/workspace/projects", async () => {
     const api = makeApi({

--- a/tests/desktop/git-store.test.ts
+++ b/tests/desktop/git-store.test.ts
@@ -135,7 +135,7 @@ describe("loadAll", () => {
     expect(state.error).toBeNull();
   });
 
-  it("sets loading while requests are in flight", async () => {
+  it("sets loading without clearing existing surfaces while requests are in flight", async () => {
     const d = deferred<unknown>();
     const get = vi.fn((path: string) => {
       if (path.includes("/branches")) return d.promise;
@@ -152,10 +152,10 @@ describe("loadAll", () => {
 
     const pending = useGit.getState().loadAll(api, "proj");
     expect(useGit.getState().loading).toBe(true);
-    expect(useGit.getState().branches).toEqual([]);
-    expect(useGit.getState().prs).toEqual([]);
-    expect(useGit.getState().worktrees).toEqual([]);
-    expect(useGit.getState().refreshedAt).toBeNull();
+    expect(useGit.getState().branches).toEqual([{ name: "stale" }]);
+    expect(useGit.getState().prs).toEqual([wirePr({ number: 99 })]);
+    expect(useGit.getState().worktrees).toEqual([wireWorktree({ id: "stale_wt" })]);
+    expect(useGit.getState().refreshedAt).toBe(T2);
     d.resolve({ branches: [], refreshedAt: T1 });
     await pending;
     expect(useGit.getState().loading).toBe(false);
@@ -220,7 +220,7 @@ describe("loadAll", () => {
     expect(useGit.getState().loading).toBe(false);
   });
 
-  it("keeps failed surfaces empty after the project-scoped pre-clear and updates the others", async () => {
+  it("keeps stale surfaces visible when refresh fails and updates the others", async () => {
     useGit.setState({ branches: [{ name: "previous" }] });
     const get = routedGet({
       "/branches": new AppError("offline"),
@@ -232,7 +232,7 @@ describe("loadAll", () => {
     await useGit.getState().loadAll(api, "proj");
 
     const state = useGit.getState();
-    expect(state.branches).toEqual([]);
+    expect(state.branches).toEqual([{ name: "previous" }]);
     expect(state.prs).toHaveLength(1);
     expect(state.worktrees).toHaveLength(1);
     expect(state.error).toBe("offline");
@@ -282,7 +282,6 @@ describe("loadPreviews", () => {
     await useGit.getState().loadPreviews(api, "proj");
 
     expect(get).toHaveBeenCalledWith("/api/projects/proj/previews?limit=100");
-    expect(useGit.getState().previewScope).toEqual({ projectSlug: "proj", taskId: null });
     expect(useGit.getState().previews).toEqual([
       {
         id: "prev_1",
@@ -413,7 +412,6 @@ describe("loadPreviews", () => {
     first.resolve({ previews: [wirePreview({ id: "prev_a", taskId: "task_a" })] });
     await firstLoad;
 
-    expect(useGit.getState().previewScope).toEqual({ projectSlug: "proj", taskId: "task_b" });
     expect(useGit.getState().previews.map((preview) => preview.id)).toEqual(["prev_b", "prev_a"]);
   });
 
@@ -433,7 +431,6 @@ describe("loadPreviews", () => {
     first.resolve({ previews: [wirePreview({ id: "prev_old", taskId: "task_a" })] });
     await firstLoad;
 
-    expect(useGit.getState().previewScope).toEqual({ projectSlug: "proj", taskId: "task_a" });
     expect(useGit.getState().previews.map((preview) => preview.id)).toEqual(["prev_new"]);
   });
 
@@ -458,7 +455,6 @@ describe("loadPreviews", () => {
     });
     await projectLoad;
 
-    expect(useGit.getState().previewScope).toEqual({ projectSlug: "proj", taskId: "task_a" });
     expect(useGit.getState().previews.map((preview) => preview.id)).toEqual([
       "prev_project_a",
       "prev_project_b",

--- a/tests/desktop/git-store.test.ts
+++ b/tests/desktop/git-store.test.ts
@@ -397,7 +397,7 @@ describe("loadPreviews", () => {
     expect(useGit.getState().previewError).toBe("timeout");
   });
 
-  it("ignores stale preview responses from a previous task scope", async () => {
+  it("allows concurrent preview responses from different scopes", async () => {
     const first = deferred<{ previews: unknown[] }>();
     const second = deferred<{ previews: unknown[] }>();
     const get = vi
@@ -414,7 +414,55 @@ describe("loadPreviews", () => {
     await firstLoad;
 
     expect(useGit.getState().previewScope).toEqual({ projectSlug: "proj", taskId: "task_b" });
-    expect(useGit.getState().previews.map((preview) => preview.id)).toEqual(["prev_b"]);
+    expect(useGit.getState().previews.map((preview) => preview.id)).toEqual(["prev_b", "prev_a"]);
+  });
+
+  it("ignores stale preview responses from an older request for the same scope", async () => {
+    const first = deferred<{ previews: unknown[] }>();
+    const second = deferred<{ previews: unknown[] }>();
+    const get = vi
+      .fn()
+      .mockReturnValueOnce(first.promise)
+      .mockReturnValueOnce(second.promise);
+    const api = makeApi({ get: get as never });
+
+    const firstLoad = useGit.getState().loadPreviews(api, "proj", "task_a");
+    const secondLoad = useGit.getState().loadPreviews(api, "proj", "task_a");
+    second.resolve({ previews: [wirePreview({ id: "prev_new", taskId: "task_a" })] });
+    await secondLoad;
+    first.resolve({ previews: [wirePreview({ id: "prev_old", taskId: "task_a" })] });
+    await firstLoad;
+
+    expect(useGit.getState().previewScope).toEqual({ projectSlug: "proj", taskId: "task_a" });
+    expect(useGit.getState().previews.map((preview) => preview.id)).toEqual(["prev_new"]);
+  });
+
+  it("does not discard a concurrent project-wide preview response after a task-scoped load starts", async () => {
+    const projectWide = deferred<{ previews: unknown[] }>();
+    const taskScoped = deferred<{ previews: unknown[] }>();
+    const get = vi
+      .fn()
+      .mockReturnValueOnce(projectWide.promise)
+      .mockReturnValueOnce(taskScoped.promise);
+    const api = makeApi({ get: get as never });
+
+    const projectLoad = useGit.getState().loadPreviews(api, "proj");
+    const taskLoad = useGit.getState().loadPreviews(api, "proj", "task_a");
+    taskScoped.resolve({ previews: [wirePreview({ id: "prev_task", taskId: "task_a" })] });
+    await taskLoad;
+    projectWide.resolve({
+      previews: [
+        wirePreview({ id: "prev_project_a", taskId: "task_a" }),
+        wirePreview({ id: "prev_project_b", taskId: "task_b" }),
+      ],
+    });
+    await projectLoad;
+
+    expect(useGit.getState().previewScope).toEqual({ projectSlug: "proj", taskId: "task_a" });
+    expect(useGit.getState().previews.map((preview) => preview.id)).toEqual([
+      "prev_project_a",
+      "prev_project_b",
+    ]);
   });
 });
 

--- a/tests/desktop/git-store.test.ts
+++ b/tests/desktop/git-store.test.ts
@@ -335,6 +335,28 @@ describe("loadPreviews", () => {
     });
   });
 
+  it("replaces stale preview records when a preview is reassigned into the loaded scope", async () => {
+    useGit.setState({
+      previews: [
+        {
+          ...wirePreview({ id: "prev_move", taskId: "task_b", label: "Old task" }),
+          updatedAt: T1,
+        },
+      ],
+    });
+    const get = vi.fn().mockResolvedValue({
+      previews: [wirePreview({ id: "prev_move", taskId: "task_a", label: "New task" })],
+      nextCursor: null,
+    });
+    const api = makeApi({ get: get as never });
+
+    await useGit.getState().loadPreviews(api, "proj", "task_a");
+
+    expect(useGit.getState().previews).toMatchObject([
+      { id: "prev_move", taskId: "task_a", label: "New task" },
+    ]);
+  });
+
   it("keeps existing previews and sets the error category on failure", async () => {
     const existing = {
       id: "prev_keep",

--- a/tests/desktop/git-store.test.ts
+++ b/tests/desktop/git-store.test.ts
@@ -308,7 +308,34 @@ describe("loadPreviews", () => {
     expect(get).toHaveBeenCalledWith("/api/projects/proj/previews?limit=100&taskId=task_a");
   });
 
-  it("clears stale previews and sets the error category on failure", async () => {
+  it("merges task-scoped previews without removing other task badges", async () => {
+    useGit.setState({
+      previews: [
+        {
+          ...wirePreview({ id: "prev_task_a", taskId: "task_a", label: "Task A" }),
+          updatedAt: T1,
+        },
+        {
+          ...wirePreview({ id: "prev_task_b", taskId: "task_b", label: "Task B" }),
+          updatedAt: T1,
+        },
+      ],
+    });
+    const get = vi.fn().mockResolvedValue({
+      previews: [wirePreview({ id: "prev_task_a", taskId: "task_a", label: "Task A refreshed" })],
+      nextCursor: null,
+    });
+    const api = makeApi({ get: get as never });
+
+    await useGit.getState().loadPreviews(api, "proj", "task_a");
+
+    expect(Object.fromEntries(useGit.getState().previews.map((preview) => [preview.id, preview.label]))).toEqual({
+      prev_task_a: "Task A refreshed",
+      prev_task_b: "Task B",
+    });
+  });
+
+  it("keeps existing previews and sets the error category on failure", async () => {
     const existing = {
       id: "prev_keep",
       projectSlug: "proj",
@@ -323,7 +350,7 @@ describe("loadPreviews", () => {
 
     await useGit.getState().loadPreviews(api, "proj");
 
-    expect(useGit.getState().previews).toEqual([]);
+    expect(useGit.getState().previews).toEqual([existing]);
     expect(useGit.getState().previewError).toBe("timeout");
   });
 

--- a/tests/desktop/processes-panel.test.ts
+++ b/tests/desktop/processes-panel.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { formatBytes } from "@desktop/renderer/src/features/workspace/ProcessesPanel";
+import { formatBytes, portList } from "@desktop/renderer/src/features/workspace/process-format";
 
 describe("formatBytes", () => {
   it("scales through byte units", () => {
@@ -15,5 +15,17 @@ describe("formatBytes", () => {
     expect(formatBytes(undefined)).toBe("—");
     expect(formatBytes(-1)).toBe("—");
     expect(formatBytes(Number.NaN)).toBe("—");
+  });
+});
+
+describe("portList", () => {
+  it("renders numeric, string, and object port values", () => {
+    expect(portList([3000, "5173", { port: "8080/tcp" }, { port: 9229 }])).toBe(
+      "3000, 5173, 8080/tcp, 9229",
+    );
+  });
+
+  it("skips invalid and empty port values", () => {
+    expect(portList([Number.NaN, "", "  ", { port: null }, { name: "api" }])).toBe("");
   });
 });

--- a/tests/desktop/processes-panel.test.ts
+++ b/tests/desktop/processes-panel.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import { formatBytes } from "@desktop/renderer/src/features/workspace/ProcessesPanel";
+
+describe("formatBytes", () => {
+  it("scales through byte units", () => {
+    expect(formatBytes(0)).toBe("0 B");
+    expect(formatBytes(512)).toBe("512 B");
+    expect(formatBytes(1536)).toBe("1.5 KB");
+    expect(formatBytes(5 * 1024 * 1024)).toBe("5 MB");
+    expect(formatBytes(2.5 * 1024 ** 3)).toBe("2.5 GB");
+  });
+
+  it("rounds large mantissas and renders a dash for invalid input", () => {
+    expect(formatBytes(15.7 * 1024 * 1024)).toBe("16 MB");
+    expect(formatBytes(undefined)).toBe("—");
+    expect(formatBytes(-1)).toBe("—");
+    expect(formatBytes(Number.NaN)).toBe("—");
+  });
+});

--- a/tests/desktop/session-merge.test.ts
+++ b/tests/desktop/session-merge.test.ts
@@ -124,6 +124,28 @@ describe("mergeAttachableSessions", () => {
     expect(aliasMap["sess_abc123"]).toBe("matrix-sess-abc");
   });
 
+  it("carries agent/kind/runtime status from a workspace record", () => {
+    const { sessions } = mergeAttachableSessions(
+      [],
+      [{ id: "sess_a", kind: "agent", agent: "claude", runtime: { zellijSession: "z1", status: "waiting" } }],
+    );
+    expect(sessions[0]).toMatchObject({ attachName: "z1", kind: "agent", agent: "claude", runtimeStatus: "waiting" });
+  });
+
+  it("enriches a zellij-sourced session with workspace agent metadata (zellij status still wins)", () => {
+    const { sessions } = mergeAttachableSessions(
+      [{ name: "z1", status: "active" }],
+      [{ id: "sess_a", kind: "agent", agent: "codex", runtime: { zellijSession: "z1", status: "running" } }],
+    );
+    expect(sessions).toHaveLength(1);
+    expect(sessions[0]).toMatchObject({ attachName: "z1", source: "zellij", status: "active", kind: "agent", agent: "codex", runtimeStatus: "running" });
+  });
+
+  it("omits metadata for a plain workspace shell (minimal shape preserved)", () => {
+    const { sessions } = mergeAttachableSessions([], [{ id: "sess_s", runtime: { zellijSession: "z2" } }]);
+    expect(sessions[0]).toEqual({ name: "z2", attachName: "z2", status: "active", source: "workspace" });
+  });
+
   it("dedupes two workspace records sharing one zellij session, keeping all aliases", () => {
     const workspace: WorkspaceSessionDTO[] = [
       { id: "sess_first", runtime: { zellijSession: "shared" } },

--- a/tests/desktop/session-merge.test.ts
+++ b/tests/desktop/session-merge.test.ts
@@ -127,9 +127,27 @@ describe("mergeAttachableSessions", () => {
   it("carries agent/kind/runtime status from a workspace record", () => {
     const { sessions } = mergeAttachableSessions(
       [],
-      [{ id: "sess_a", kind: "agent", agent: "claude", runtime: { zellijSession: "z1", status: "waiting" } }],
+      [
+        {
+          id: "sess_a",
+          kind: "agent",
+          agent: "claude",
+          projectSlug: "proj",
+          taskId: "task_a",
+          worktreeId: "wt_1",
+          runtime: { zellijSession: "z1", status: "waiting" },
+        },
+      ],
     );
-    expect(sessions[0]).toMatchObject({ attachName: "z1", kind: "agent", agent: "claude", runtimeStatus: "waiting" });
+    expect(sessions[0]).toMatchObject({
+      attachName: "z1",
+      kind: "agent",
+      agent: "claude",
+      projectSlug: "proj",
+      taskId: "task_a",
+      worktreeId: "wt_1",
+      runtimeStatus: "waiting",
+    });
   });
 
   it("enriches a zellij-sourced session with workspace agent metadata (zellij status still wins)", () => {

--- a/tests/desktop/sessions-store.test.ts
+++ b/tests/desktop/sessions-store.test.ts
@@ -85,3 +85,29 @@ describe("useSessions.create", () => {
     expect(useSessions.getState().error).toBe("offline");
   });
 });
+
+describe("useSessions.kill", () => {
+  it("DELETEs the zellij session by name (forced) and reloads", async () => {
+    const del = vi.fn().mockResolvedValue({ ok: true });
+    const get = vi.fn().mockResolvedValue({ sessions: [], nextCursor: null });
+    const api = makeApi({ delete: del, get });
+    const ok = await useSessions.getState().kill(api, "matrix-task-1");
+    expect(ok).toBe(true);
+    expect(del).toHaveBeenCalledWith("/api/terminal/sessions/matrix-task-1?force=1");
+    expect(get).toHaveBeenCalled(); // reload
+  });
+
+  it("encodes unsafe session names in the delete path", async () => {
+    const del = vi.fn().mockResolvedValue({ ok: true });
+    const api = makeApi({ delete: del });
+    await useSessions.getState().kill(api, "weird/name");
+    expect(del).toHaveBeenCalledWith("/api/terminal/sessions/weird%2Fname?force=1");
+  });
+
+  it("returns false and records an error category on failure", async () => {
+    const api = makeApi({ delete: vi.fn().mockRejectedValue(new AppError("server")) });
+    const ok = await useSessions.getState().kill(api, "matrix-task-1");
+    expect(ok).toBe(false);
+    expect(useSessions.getState().error).toBe("server");
+  });
+});

--- a/tests/desktop/sessions-store.test.ts
+++ b/tests/desktop/sessions-store.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { AppError } from "@desktop/shared/app-error";
 import type { ApiClient } from "@desktop/renderer/src/lib/api";
+import { useBoard, type Card } from "@desktop/renderer/src/stores/board";
 import { useSessions } from "@desktop/renderer/src/stores/sessions";
 
 function makeApi(overrides: Partial<ApiClient> = {}): ApiClient {
@@ -19,6 +20,14 @@ function makeApi(overrides: Partial<ApiClient> = {}): ApiClient {
 
 beforeEach(() => {
   useSessions.setState({ sessions: [], aliasMap: {}, loading: false, creating: false, error: null });
+  useBoard.setState({
+    projects: [],
+    activeProjectSlug: null,
+    cardsByProject: {},
+    firstLoadByProject: {},
+    refreshing: false,
+    error: null,
+  });
 });
 
 describe("useSessions.create", () => {
@@ -184,6 +193,23 @@ describe("useSessions.restart", () => {
   });
 
   it("restarts workspace agent sessions through the session orchestrator", async () => {
+    const card: Card = {
+      id: "task_a",
+      projectSlug: "proj",
+      title: "Review",
+      description: "",
+      status: "running",
+      priority: "normal",
+      order: 1,
+      parentTaskId: null,
+      linkedSessionId: "sess_old",
+      linkedWorktreeId: "wt_1",
+      previewIds: [],
+      tags: [],
+      updatedAt: null,
+      revision: 1,
+    };
+    useBoard.setState({ cardsByProject: { proj: [card] } });
     useSessions.setState({
       sessions: [
         {
@@ -205,7 +231,10 @@ describe("useSessions.restart", () => {
       session: { id: "sess_next", runtime: { zellijSession: "matrix-agent-2" } },
     });
     const get = vi.fn().mockResolvedValue({ sessions: [], nextCursor: null });
-    const api = makeApi({ delete: del, post, get });
+    const patch = vi.fn().mockResolvedValue({
+      task: { ...card, linkedSessionId: "sess_next" },
+    });
+    const api = makeApi({ delete: del, post, get, patch });
 
     const restarted = await useSessions.getState().restart(api, "matrix-agent-1");
 
@@ -216,6 +245,9 @@ describe("useSessions.restart", () => {
       projectSlug: "proj",
       taskId: "task_a",
       worktreeId: "wt_1",
+    });
+    expect(patch).toHaveBeenCalledWith("/api/projects/proj/tasks/task_a", {
+      linkedSessionId: "sess_next",
     });
     expect(restarted).toEqual({ sessionId: "sess_next", attachName: "matrix-agent-2" });
   });

--- a/tests/desktop/sessions-store.test.ts
+++ b/tests/desktop/sessions-store.test.ts
@@ -252,7 +252,7 @@ describe("useSessions.restart", () => {
     expect(restarted).toEqual({ sessionId: "sess_next", attachName: "matrix-agent-2" });
   });
 
-  it("returns the restarted workspace session when relinking the task fails", async () => {
+  it("cleans up the restarted workspace session when relinking the task fails", async () => {
     const card: Card = {
       id: "task_a",
       projectSlug: "proj",
@@ -286,8 +286,9 @@ describe("useSessions.restart", () => {
       ],
       aliasMap: { sess_old: "matrix-agent-1" },
     });
+    const del = vi.fn().mockResolvedValue({ ok: true });
     const api = makeApi({
-      delete: vi.fn().mockResolvedValue({ ok: true }),
+      delete: del,
       post: vi.fn().mockResolvedValue({
         session: { id: "sess_next", runtime: { zellijSession: "matrix-agent-2" } },
       }),
@@ -297,7 +298,9 @@ describe("useSessions.restart", () => {
 
     const restarted = await useSessions.getState().restart(api, "matrix-agent-1");
 
-    expect(restarted).toEqual({ sessionId: "sess_next", attachName: "matrix-agent-2" });
+    expect(restarted).toBeNull();
+    expect(del).toHaveBeenCalledWith("/api/terminal/sessions/matrix-agent-1?force=1");
+    expect(del).toHaveBeenCalledWith("/api/terminal/sessions/matrix-agent-2?force=1");
     expect(useSessions.getState().creating).toBe(false);
     expect(useSessions.getState().error).toBe("offline");
   });

--- a/tests/desktop/sessions-store.test.ts
+++ b/tests/desktop/sessions-store.test.ts
@@ -30,6 +30,44 @@ beforeEach(() => {
   });
 });
 
+describe("useSessions.load", () => {
+  it("ignores stale slower load results after a newer load finishes", async () => {
+    let resolveFirstTerminal!: (value: { sessions: unknown[] }) => void;
+    let resolveFirstWorkspace!: (value: { sessions: unknown[]; nextCursor: null }) => void;
+    const firstTerminal = new Promise<{ sessions: unknown[] }>((resolve) => {
+      resolveFirstTerminal = resolve;
+    });
+    const firstWorkspace = new Promise<{ sessions: unknown[]; nextCursor: null }>((resolve) => {
+      resolveFirstWorkspace = resolve;
+    });
+    let call = 0;
+    const get = vi.fn((path: string) => {
+      call += 1;
+      if (call === 1) return firstTerminal;
+      if (call === 2) return firstWorkspace;
+      if (path === "/api/terminal/sessions") {
+        return Promise.resolve({ sessions: [{ name: "new-session", status: "active" }] });
+      }
+      return Promise.resolve({ sessions: [], nextCursor: null });
+    });
+    const api = makeApi({ get });
+
+    const staleLoad = useSessions.getState().load(api);
+    const freshLoad = useSessions.getState().load(api);
+    await freshLoad;
+
+    resolveFirstTerminal({ sessions: [{ name: "old-session", status: "active" }] });
+    resolveFirstWorkspace({ sessions: [], nextCursor: null });
+    await staleLoad;
+
+    expect(useSessions.getState().sessions.map((session) => session.attachName)).toEqual([
+      "new-session",
+    ]);
+    expect(useSessions.getState().loading).toBe(false);
+    expect(useSessions.getState().error).toBeNull();
+  });
+});
+
 describe("useSessions.create", () => {
   it("POSTs the session, reloads, and resolves the new attach name", async () => {
     const post = vi.fn().mockResolvedValue({ session: { id: "sess_new" } });

--- a/tests/desktop/sessions-store.test.ts
+++ b/tests/desktop/sessions-store.test.ts
@@ -18,6 +18,14 @@ function makeApi(overrides: Partial<ApiClient> = {}): ApiClient {
   } as ApiClient;
 }
 
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+}
+
 beforeEach(() => {
   useSessions.setState({ sessions: [], aliasMap: {}, loading: false, creating: false, error: null });
   useBoard.setState({
@@ -137,6 +145,34 @@ describe("useSessions.create", () => {
     const created = await useSessions.getState().create(api, { kind: "shell", taskId: "task_a" });
 
     expect(created).toEqual({ sessionId: "sess_new", attachName: "matrix-task-new" });
+  });
+
+  it("resolves the new attach name from its own reload when another load preempts state", async () => {
+    const internalTerminal = deferred<{ sessions: unknown[] }>();
+    const internalWorkspace = deferred<{ sessions: unknown[]; nextCursor: null }>();
+    const post = vi.fn().mockResolvedValue({ session: { id: "sess_new", runtime: {} } });
+    let call = 0;
+    const get = vi.fn((path: string) => {
+      call += 1;
+      if (call === 1 && path === "/api/terminal/sessions") return internalTerminal.promise;
+      if (call === 2 && path === "/api/sessions") return internalWorkspace.promise;
+      if (path === "/api/terminal/sessions") return Promise.resolve({ sessions: [] });
+      return Promise.resolve({ sessions: [], nextCursor: null });
+    });
+    const api = makeApi({ post, get });
+
+    const createPromise = useSessions.getState().create(api, { kind: "shell", taskId: "task_a" });
+    await Promise.resolve();
+    await Promise.resolve();
+    await useSessions.getState().load(api);
+
+    internalTerminal.resolve({ sessions: [{ name: "matrix-task-9", status: "active" }] });
+    internalWorkspace.resolve({
+      sessions: [{ id: "sess_new", runtime: { zellijSession: "matrix-task-9" } }],
+      nextCursor: null,
+    });
+
+    await expect(createPromise).resolves.toEqual({ sessionId: "sess_new", attachName: "matrix-task-9" });
   });
 
   it("surfaces an error category and clears the creating flag on failure", async () => {

--- a/tests/desktop/sessions-store.test.ts
+++ b/tests/desktop/sessions-store.test.ts
@@ -205,6 +205,37 @@ describe("useSessions.create", () => {
     expect(useSessions.getState().sessions.some((session) => session.attachName === "matrix-task-9")).toBe(true);
   });
 
+  it("clears loading when another load preempts the create reload", async () => {
+    const internalTerminal = deferred<{ sessions: unknown[] }>();
+    const internalWorkspace = deferred<{ sessions: unknown[]; nextCursor: null }>();
+    const competingTerminal = new Promise<{ sessions: unknown[] }>(() => undefined);
+    const competingWorkspace = new Promise<{ sessions: unknown[]; nextCursor: null }>(() => undefined);
+    const post = vi.fn().mockResolvedValue({ session: { id: "sess_new", runtime: {} } });
+    let call = 0;
+    const get = vi.fn((path: string) => {
+      call += 1;
+      if (call === 1 && path === "/api/terminal/sessions") return internalTerminal.promise;
+      if (call === 2 && path === "/api/sessions") return internalWorkspace.promise;
+      if (path === "/api/terminal/sessions") return competingTerminal;
+      return competingWorkspace;
+    });
+    const api = makeApi({ post, get });
+
+    const createPromise = useSessions.getState().create(api, { kind: "shell", taskId: "task_a" });
+    while (call < 2) {
+      await Promise.resolve();
+    }
+    void useSessions.getState().load(api);
+    expect(useSessions.getState().loading).toBe(true);
+
+    internalTerminal.resolve({ sessions: [] });
+    internalWorkspace.resolve({ sessions: [], nextCursor: null });
+    await createPromise;
+
+    expect(useSessions.getState().loading).toBe(false);
+    expect(useSessions.getState().creating).toBe(false);
+  });
+
   it("surfaces an error category and clears the creating flag on failure", async () => {
     const api = makeApi({ post: vi.fn().mockRejectedValue(new AppError("offline")) });
     const created = await useSessions.getState().create(api, { kind: "shell", taskId: "task_a" });

--- a/tests/desktop/sessions-store.test.ts
+++ b/tests/desktop/sessions-store.test.ts
@@ -77,10 +77,53 @@ describe("useSessions.create", () => {
     expect(useSessions.getState().error).toBe("offline");
   });
 
+  it("uses the create response attach name when the reload has not indexed the alias yet", async () => {
+    const post = vi.fn().mockResolvedValue({
+      session: { id: "sess_new", runtime: { zellijSession: "matrix-task-new" } },
+    });
+    const get = vi.fn(async (path: string) => {
+      if (path === "/api/terminal/sessions") return { sessions: [] };
+      return { sessions: [], nextCursor: null };
+    });
+    const api = makeApi({ post, get });
+
+    const created = await useSessions.getState().create(api, { kind: "shell", taskId: "task_a" });
+
+    expect(created).toEqual({ sessionId: "sess_new", attachName: "matrix-task-new" });
+  });
+
   it("surfaces an error category and clears the creating flag on failure", async () => {
     const api = makeApi({ post: vi.fn().mockRejectedValue(new AppError("offline")) });
     const created = await useSessions.getState().create(api, { kind: "shell", taskId: "task_a" });
     expect(created).toBeNull();
+    expect(useSessions.getState().creating).toBe(false);
+    expect(useSessions.getState().error).toBe("offline");
+  });
+});
+
+describe("useSessions.restart", () => {
+  it("deletes a restarted workspace session when the refresh fails", async () => {
+    useSessions.setState({
+      sessions: [
+        {
+          name: "task shell",
+          attachName: "matrix-task-old",
+          status: "active",
+          source: "workspace",
+          kind: "shell",
+        },
+      ],
+    });
+    const post = vi.fn().mockResolvedValue({ session: { id: "sess_restart" } });
+    const get = vi.fn().mockRejectedValue(new AppError("offline"));
+    const del = vi.fn().mockResolvedValue({ ok: true });
+    const api = makeApi({ post, get, delete: del });
+
+    const restarted = await useSessions.getState().restart(api, "matrix-task-old");
+
+    expect(restarted).toBeNull();
+    expect(del).toHaveBeenCalledWith("/api/terminal/sessions/matrix-task-old?force=1");
+    expect(del).toHaveBeenCalledWith("/api/sessions/sess_restart");
     expect(useSessions.getState().creating).toBe(false);
     expect(useSessions.getState().error).toBe("offline");
   });
@@ -138,5 +181,33 @@ describe("useSessions.restart", () => {
 
     expect(restarted?.attachName).toBe("matrix-task-1");
     expect(post).toHaveBeenCalledWith("/api/terminal/sessions", { name: "matrix-task-1" });
+  });
+
+  it("restarts workspace agent sessions through the session orchestrator", async () => {
+    useSessions.setState({
+      sessions: [
+        {
+          name: "Review",
+          attachName: "matrix-agent-1",
+          status: "exited",
+          source: "workspace",
+          kind: "agent",
+          agent: "codex",
+        },
+      ],
+      aliasMap: { sess_old: "matrix-agent-1" },
+    });
+    const del = vi.fn().mockResolvedValue({ ok: true });
+    const post = vi.fn().mockResolvedValue({
+      session: { id: "sess_next", runtime: { zellijSession: "matrix-agent-2" } },
+    });
+    const get = vi.fn().mockResolvedValue({ sessions: [], nextCursor: null });
+    const api = makeApi({ delete: del, post, get });
+
+    const restarted = await useSessions.getState().restart(api, "matrix-agent-1");
+
+    expect(del).toHaveBeenCalledWith("/api/terminal/sessions/matrix-agent-1?force=1");
+    expect(post).toHaveBeenCalledWith("/api/sessions", { kind: "agent", agent: "codex" });
+    expect(restarted).toEqual({ sessionId: "sess_next", attachName: "matrix-agent-2" });
   });
 });

--- a/tests/desktop/sessions-store.test.ts
+++ b/tests/desktop/sessions-store.test.ts
@@ -111,3 +111,32 @@ describe("useSessions.kill", () => {
     expect(useSessions.getState().error).toBe("server");
   });
 });
+
+describe("useSessions.restart", () => {
+  it("recreates the same zellij session name and reloads", async () => {
+    const del = vi.fn().mockResolvedValue({ ok: true });
+    const post = vi.fn().mockResolvedValue({ name: "matrix-task-1", created: true });
+    const get = vi.fn().mockResolvedValue({ sessions: [], nextCursor: null });
+    const api = makeApi({ delete: del, post, get });
+
+    const restarted = await useSessions.getState().restart(api, "matrix-task-1");
+
+    expect(del).toHaveBeenCalledWith("/api/terminal/sessions/matrix-task-1?force=1");
+    expect(post).toHaveBeenCalledWith("/api/terminal/sessions", { name: "matrix-task-1" });
+    expect(get).toHaveBeenCalled();
+    expect(restarted).toEqual({ sessionId: "matrix-task-1", attachName: "matrix-task-1" });
+    expect(useSessions.getState().creating).toBe(false);
+    expect(useSessions.getState().error).toBeNull();
+  });
+
+  it("continues when the old session is already gone", async () => {
+    const del = vi.fn().mockRejectedValue(new AppError("notFound"));
+    const post = vi.fn().mockResolvedValue({ name: "matrix-task-1", created: true });
+    const api = makeApi({ delete: del, post });
+
+    const restarted = await useSessions.getState().restart(api, "matrix-task-1");
+
+    expect(restarted?.attachName).toBe("matrix-task-1");
+    expect(post).toHaveBeenCalledWith("/api/terminal/sessions", { name: "matrix-task-1" });
+  });
+});

--- a/tests/desktop/sessions-store.test.ts
+++ b/tests/desktop/sessions-store.test.ts
@@ -251,4 +251,54 @@ describe("useSessions.restart", () => {
     });
     expect(restarted).toEqual({ sessionId: "sess_next", attachName: "matrix-agent-2" });
   });
+
+  it("returns the restarted workspace session when relinking the task fails", async () => {
+    const card: Card = {
+      id: "task_a",
+      projectSlug: "proj",
+      title: "Review",
+      description: "",
+      status: "running",
+      priority: "normal",
+      order: 1,
+      parentTaskId: null,
+      linkedSessionId: "sess_old",
+      linkedWorktreeId: "wt_1",
+      previewIds: [],
+      tags: [],
+      updatedAt: null,
+      revision: 1,
+    };
+    useBoard.setState({ cardsByProject: { proj: [card] } });
+    useSessions.setState({
+      sessions: [
+        {
+          name: "Review",
+          attachName: "matrix-agent-1",
+          status: "exited",
+          source: "workspace",
+          kind: "agent",
+          agent: "codex",
+          projectSlug: "proj",
+          taskId: "task_a",
+          worktreeId: "wt_1",
+        },
+      ],
+      aliasMap: { sess_old: "matrix-agent-1" },
+    });
+    const api = makeApi({
+      delete: vi.fn().mockResolvedValue({ ok: true }),
+      post: vi.fn().mockResolvedValue({
+        session: { id: "sess_next", runtime: { zellijSession: "matrix-agent-2" } },
+      }),
+      get: vi.fn().mockResolvedValue({ sessions: [], nextCursor: null }),
+      patch: vi.fn().mockRejectedValue(new AppError("offline")),
+    });
+
+    const restarted = await useSessions.getState().restart(api, "matrix-agent-1");
+
+    expect(restarted).toEqual({ sessionId: "sess_next", attachName: "matrix-agent-2" });
+    expect(useSessions.getState().creating).toBe(false);
+    expect(useSessions.getState().error).toBe("offline");
+  });
 });

--- a/tests/desktop/sessions-store.test.ts
+++ b/tests/desktop/sessions-store.test.ts
@@ -175,6 +175,36 @@ describe("useSessions.create", () => {
     await expect(createPromise).resolves.toEqual({ sessionId: "sess_new", attachName: "matrix-task-9" });
   });
 
+  it("keeps the created alias in state when another load preempts the create reload", async () => {
+    const internalTerminal = deferred<{ sessions: unknown[] }>();
+    const internalWorkspace = deferred<{ sessions: unknown[]; nextCursor: null }>();
+    const post = vi.fn().mockResolvedValue({ session: { id: "sess_new", runtime: {} } });
+    let call = 0;
+    const get = vi.fn((path: string) => {
+      call += 1;
+      if (call === 1 && path === "/api/terminal/sessions") return internalTerminal.promise;
+      if (call === 2 && path === "/api/sessions") return internalWorkspace.promise;
+      if (path === "/api/terminal/sessions") return Promise.resolve({ sessions: [] });
+      return Promise.resolve({ sessions: [], nextCursor: null });
+    });
+    const api = makeApi({ post, get });
+
+    const createPromise = useSessions.getState().create(api, { kind: "shell", taskId: "task_a" });
+    await Promise.resolve();
+    await Promise.resolve();
+    await useSessions.getState().load(api);
+
+    internalTerminal.resolve({ sessions: [{ name: "matrix-task-9", status: "active" }] });
+    internalWorkspace.resolve({
+      sessions: [{ id: "sess_new", runtime: { zellijSession: "matrix-task-9" } }],
+      nextCursor: null,
+    });
+    await createPromise;
+
+    expect(useSessions.getState().resolveAttachName("sess_new")).toBe("matrix-task-9");
+    expect(useSessions.getState().sessions.some((session) => session.attachName === "matrix-task-9")).toBe(true);
+  });
+
   it("surfaces an error category and clears the creating flag on failure", async () => {
     const api = makeApi({ post: vi.fn().mockRejectedValue(new AppError("offline")) });
     const created = await useSessions.getState().create(api, { kind: "shell", taskId: "task_a" });
@@ -428,5 +458,75 @@ describe("useSessions.restart", () => {
     expect(del).toHaveBeenCalledWith("/api/sessions/sess_next");
     expect(useSessions.getState().creating).toBe(false);
     expect(useSessions.getState().error).toBe("offline");
+  });
+
+  it("cleans up the restarted attachable session when a concurrent load preempts the restart reload", async () => {
+    const card: Card = {
+      id: "task_a",
+      projectSlug: "proj",
+      title: "Review",
+      description: "",
+      status: "running",
+      priority: "normal",
+      order: 1,
+      parentTaskId: null,
+      linkedSessionId: "sess_old",
+      linkedWorktreeId: "wt_1",
+      previewIds: [],
+      tags: [],
+      updatedAt: null,
+      revision: 1,
+    };
+    useBoard.setState({ cardsByProject: { proj: [card] } });
+    useSessions.setState({
+      sessions: [
+        {
+          name: "Review",
+          attachName: "matrix-agent-1",
+          status: "exited",
+          source: "workspace",
+          kind: "agent",
+          agent: "codex",
+          projectSlug: "proj",
+          taskId: "task_a",
+          worktreeId: "wt_1",
+        },
+      ],
+      aliasMap: { sess_old: "matrix-agent-1" },
+    });
+    const internalTerminal = deferred<{ sessions: unknown[] }>();
+    const internalWorkspace = deferred<{ sessions: unknown[]; nextCursor: null }>();
+    let getCall = 0;
+    const get = vi.fn((path: string) => {
+      getCall += 1;
+      if (getCall === 1 && path === "/api/terminal/sessions") return internalTerminal.promise;
+      if (getCall === 2 && path === "/api/sessions") return internalWorkspace.promise;
+      if (path === "/api/terminal/sessions") return Promise.resolve({ sessions: [] });
+      return Promise.resolve({ sessions: [], nextCursor: null });
+    });
+    const del = vi.fn().mockResolvedValue({ ok: true });
+    const api = makeApi({
+      delete: del,
+      post: vi.fn().mockResolvedValue({ session: { id: "sess_next", runtime: {} } }),
+      get,
+      patch: vi.fn().mockRejectedValue(new AppError("offline")),
+    });
+
+    const restartPromise = useSessions.getState().restart(api, "matrix-agent-1");
+    while (getCall < 2) {
+      await Promise.resolve();
+    }
+    const competingLoad = useSessions.getState().load(api);
+    internalTerminal.resolve({ sessions: [{ name: "matrix-agent-2", status: "active" }] });
+    internalWorkspace.resolve({
+      sessions: [{ id: "sess_next", runtime: { zellijSession: "matrix-agent-2" } }],
+      nextCursor: null,
+    });
+
+    await expect(restartPromise).resolves.toBeNull();
+    await competingLoad;
+    expect(del).toHaveBeenCalledWith("/api/terminal/sessions/matrix-agent-1?force=1");
+    expect(del).toHaveBeenCalledWith("/api/terminal/sessions/matrix-agent-2?force=1");
+    expect(del).not.toHaveBeenCalledWith("/api/sessions/sess_next");
   });
 });

--- a/tests/desktop/sessions-store.test.ts
+++ b/tests/desktop/sessions-store.test.ts
@@ -205,7 +205,7 @@ describe("useSessions.create", () => {
     expect(useSessions.getState().sessions.some((session) => session.attachName === "matrix-task-9")).toBe(true);
   });
 
-  it("clears loading when another load preempts the create reload", async () => {
+  it("keeps loading when another load preempts the create reload", async () => {
     const internalTerminal = deferred<{ sessions: unknown[] }>();
     const internalWorkspace = deferred<{ sessions: unknown[]; nextCursor: null }>();
     const competingTerminal = new Promise<{ sessions: unknown[] }>(() => undefined);
@@ -232,7 +232,7 @@ describe("useSessions.create", () => {
     internalWorkspace.resolve({ sessions: [], nextCursor: null });
     await createPromise;
 
-    expect(useSessions.getState().loading).toBe(false);
+    expect(useSessions.getState().loading).toBe(true);
     expect(useSessions.getState().creating).toBe(false);
   });
 

--- a/tests/desktop/sessions-store.test.ts
+++ b/tests/desktop/sessions-store.test.ts
@@ -1,0 +1,87 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { AppError } from "@desktop/shared/app-error";
+import type { ApiClient } from "@desktop/renderer/src/lib/api";
+import { useSessions } from "@desktop/renderer/src/stores/sessions";
+
+function makeApi(overrides: Partial<ApiClient> = {}): ApiClient {
+  return {
+    baseUrl: "https://x.test",
+    get: vi.fn().mockResolvedValue({ sessions: [], nextCursor: null }),
+    getText: vi.fn().mockResolvedValue(""),
+    post: vi.fn().mockResolvedValue({}),
+    patch: vi.fn().mockResolvedValue({}),
+    put: vi.fn().mockResolvedValue({}),
+    delete: vi.fn().mockResolvedValue({ ok: true }),
+    putText: vi.fn().mockResolvedValue({}),
+    ...overrides,
+  } as ApiClient;
+}
+
+beforeEach(() => {
+  useSessions.setState({ sessions: [], aliasMap: {}, loading: false, creating: false, error: null });
+});
+
+describe("useSessions.create", () => {
+  it("POSTs the session, reloads, and resolves the new attach name", async () => {
+    const post = vi.fn().mockResolvedValue({ session: { id: "sess_new" } });
+    // After creation, the reload returns the workspace session carrying its
+    // zellij attach name so the merged aliasMap can resolve it.
+    const get = vi.fn(async (path: string) => {
+      if (path === "/api/terminal/sessions") return { sessions: [{ name: "matrix-task-9", status: "active" }] };
+      return { sessions: [{ id: "sess_new", runtime: { zellijSession: "matrix-task-9" } }], nextCursor: null };
+    });
+    const api = makeApi({ post, get });
+
+    const created = await useSessions.getState().create(api, {
+      kind: "agent",
+      agent: "claude",
+      projectSlug: "proj",
+      taskId: "task_a",
+      prompt: "Fix the failing auth tests",
+    });
+
+    expect(post).toHaveBeenCalledWith("/api/sessions", {
+      kind: "agent",
+      agent: "claude",
+      projectSlug: "proj",
+      taskId: "task_a",
+      prompt: "Fix the failing auth tests",
+    });
+    expect(created).toEqual({ sessionId: "sess_new", attachName: "matrix-task-9" });
+    expect(useSessions.getState().creating).toBe(false);
+    expect(useSessions.getState().error).toBeNull();
+  });
+
+  it("returns a null attach name when the new session has no zellij runtime yet", async () => {
+    const post = vi.fn().mockResolvedValue({ session: { id: "sess_orch" } });
+    const get = vi.fn(async (path: string) => {
+      if (path === "/api/terminal/sessions") return { sessions: [] };
+      return { sessions: [{ id: "sess_orch", runtime: {} }], nextCursor: null };
+    });
+    const api = makeApi({ post, get });
+    const created = await useSessions.getState().create(api, { kind: "shell", taskId: "task_a" });
+    expect(created).toEqual({ sessionId: "sess_orch", attachName: null });
+  });
+
+  it("deletes a workspace session when the post-create refresh fails", async () => {
+    const post = vi.fn().mockResolvedValue({ session: { id: "sess_orphan" } });
+    const get = vi.fn().mockRejectedValue(new AppError("offline"));
+    const del = vi.fn().mockResolvedValue({ ok: true });
+    const api = makeApi({ post, get, delete: del });
+
+    const created = await useSessions.getState().create(api, { kind: "shell", taskId: "task_a" });
+
+    expect(created).toBeNull();
+    expect(del).toHaveBeenCalledWith("/api/sessions/sess_orphan");
+    expect(useSessions.getState().creating).toBe(false);
+    expect(useSessions.getState().error).toBe("offline");
+  });
+
+  it("surfaces an error category and clears the creating flag on failure", async () => {
+    const api = makeApi({ post: vi.fn().mockRejectedValue(new AppError("offline")) });
+    const created = await useSessions.getState().create(api, { kind: "shell", taskId: "task_a" });
+    expect(created).toBeNull();
+    expect(useSessions.getState().creating).toBe(false);
+    expect(useSessions.getState().error).toBe("offline");
+  });
+});

--- a/tests/desktop/sessions-store.test.ts
+++ b/tests/desktop/sessions-store.test.ts
@@ -297,6 +297,18 @@ describe("useSessions.kill", () => {
     expect(ok).toBe(false);
     expect(useSessions.getState().error).toBe("server");
   });
+
+  it("treats an already-deleted session as a successful kill", async () => {
+    const del = vi.fn().mockRejectedValue(new AppError("notFound"));
+    const get = vi.fn().mockResolvedValue({ sessions: [], nextCursor: null });
+    const api = makeApi({ delete: del, get });
+
+    const ok = await useSessions.getState().kill(api, "matrix-task-1");
+
+    expect(ok).toBe(true);
+    expect(get).toHaveBeenCalled();
+    expect(useSessions.getState().error).toBeNull();
+  });
 });
 
 describe("useSessions.restart", () => {

--- a/tests/desktop/sessions-store.test.ts
+++ b/tests/desktop/sessions-store.test.ts
@@ -193,6 +193,9 @@ describe("useSessions.restart", () => {
           source: "workspace",
           kind: "agent",
           agent: "codex",
+          projectSlug: "proj",
+          taskId: "task_a",
+          worktreeId: "wt_1",
         },
       ],
       aliasMap: { sess_old: "matrix-agent-1" },
@@ -207,7 +210,13 @@ describe("useSessions.restart", () => {
     const restarted = await useSessions.getState().restart(api, "matrix-agent-1");
 
     expect(del).toHaveBeenCalledWith("/api/terminal/sessions/matrix-agent-1?force=1");
-    expect(post).toHaveBeenCalledWith("/api/sessions", { kind: "agent", agent: "codex" });
+    expect(post).toHaveBeenCalledWith("/api/sessions", {
+      kind: "agent",
+      agent: "codex",
+      projectSlug: "proj",
+      taskId: "task_a",
+      worktreeId: "wt_1",
+    });
     expect(restarted).toEqual({ sessionId: "sess_next", attachName: "matrix-agent-2" });
   });
 });

--- a/tests/desktop/sessions-store.test.ts
+++ b/tests/desktop/sessions-store.test.ts
@@ -342,4 +342,55 @@ describe("useSessions.restart", () => {
     expect(useSessions.getState().creating).toBe(false);
     expect(useSessions.getState().error).toBe("offline");
   });
+
+  it("deletes the restarted workspace session when relinking fails before an attach name exists", async () => {
+    const card: Card = {
+      id: "task_a",
+      projectSlug: "proj",
+      title: "Review",
+      description: "",
+      status: "running",
+      priority: "normal",
+      order: 1,
+      parentTaskId: null,
+      linkedSessionId: "sess_old",
+      linkedWorktreeId: "wt_1",
+      previewIds: [],
+      tags: [],
+      updatedAt: null,
+      revision: 1,
+    };
+    useBoard.setState({ cardsByProject: { proj: [card] } });
+    useSessions.setState({
+      sessions: [
+        {
+          name: "Review",
+          attachName: "matrix-agent-1",
+          status: "exited",
+          source: "workspace",
+          kind: "agent",
+          agent: "codex",
+          projectSlug: "proj",
+          taskId: "task_a",
+          worktreeId: "wt_1",
+        },
+      ],
+      aliasMap: { sess_old: "matrix-agent-1" },
+    });
+    const del = vi.fn().mockResolvedValue({ ok: true });
+    const api = makeApi({
+      delete: del,
+      post: vi.fn().mockResolvedValue({ session: { id: "sess_next", runtime: {} } }),
+      get: vi.fn().mockResolvedValue({ sessions: [], nextCursor: null }),
+      patch: vi.fn().mockRejectedValue(new AppError("offline")),
+    });
+
+    const restarted = await useSessions.getState().restart(api, "matrix-agent-1");
+
+    expect(restarted).toBeNull();
+    expect(del).toHaveBeenCalledWith("/api/terminal/sessions/matrix-agent-1?force=1");
+    expect(del).toHaveBeenCalledWith("/api/sessions/sess_next");
+    expect(useSessions.getState().creating).toBe(false);
+    expect(useSessions.getState().error).toBe("offline");
+  });
 });

--- a/tests/desktop/start-session-controls.test.ts
+++ b/tests/desktop/start-session-controls.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+import { startSessionErrorLabel } from "@desktop/renderer/src/features/workspace/StartSessionControls";
+
+describe("startSessionErrorLabel", () => {
+  it("keeps the full error visible in the expanded workspace controls", () => {
+    expect(startSessionErrorLabel("Couldn't start the session.", false)).toBe(
+      "Couldn't start the session.",
+    );
+  });
+
+  it("keeps a compact visible error signal in the task header", () => {
+    expect(startSessionErrorLabel("Couldn't start the session.", true)).toBe("Start failed");
+  });
+
+  it("renders nothing when there is no launch error", () => {
+    expect(startSessionErrorLabel(null, true)).toBeNull();
+  });
+});

--- a/tests/desktop/task-sessions.test.ts
+++ b/tests/desktop/task-sessions.test.ts
@@ -1,0 +1,85 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { AppError } from "@desktop/shared/app-error";
+import type { ApiClient } from "@desktop/renderer/src/lib/api";
+import { startTaskSession } from "@desktop/renderer/src/lib/task-sessions";
+import { useBoard, type Card } from "@desktop/renderer/src/stores/board";
+import { useSessions } from "@desktop/renderer/src/stores/sessions";
+
+function makeApi(overrides: Partial<ApiClient> = {}): ApiClient {
+  return {
+    baseUrl: "https://x.test",
+    get: vi.fn(async (path: string) => {
+      if (path === "/api/terminal/sessions") return { sessions: [{ name: "matrix-task-1", status: "active" }] };
+      if (path === "/api/sessions") {
+        return { sessions: [{ id: "sess_new", runtime: { zellijSession: "matrix-task-1" } }], nextCursor: null };
+      }
+      return { tasks: [], nextCursor: null };
+    }),
+    post: vi.fn().mockResolvedValue({ session: { id: "sess_new" } }),
+    patch: vi.fn().mockResolvedValue({}),
+    delete: vi.fn().mockResolvedValue({ ok: true }),
+    putText: vi.fn().mockResolvedValue({}),
+    ...overrides,
+  } as ApiClient;
+}
+
+function card(overrides: Partial<Card> = {}): Card {
+  return {
+    id: "task_a",
+    projectSlug: "proj",
+    title: "Task A",
+    description: "Fix it",
+    status: "todo",
+    priority: "normal",
+    order: 0,
+    parentTaskId: null,
+    linkedSessionId: null,
+    linkedWorktreeId: null,
+    previewIds: [],
+    tags: [],
+    updatedAt: "2026-06-13T00:00:00.000Z",
+    revision: null,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  useBoard.setState(useBoard.getInitialState(), true);
+  useSessions.setState(useSessions.getInitialState(), true);
+  vi.spyOn(console, "error").mockImplementation(() => {});
+  vi.spyOn(console, "warn").mockImplementation(() => {});
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("startTaskSession", () => {
+  it("returns false when task linking fails after creating the session", async () => {
+    const api = makeApi({
+      patch: vi.fn().mockRejectedValue(new AppError("server")),
+    });
+    useBoard.setState({ cardsByProject: { proj: [card()] } });
+
+    const ok = await startTaskSession(api, {
+      projectSlug: "proj",
+      taskId: "task_a",
+      worktreeId: null,
+      title: "Task A",
+      description: "Fix it",
+      kind: "agent",
+      agent: "claude",
+    });
+
+    expect(ok).toBe(false);
+    expect(api.post).toHaveBeenCalledWith("/api/sessions", {
+      kind: "agent",
+      agent: "claude",
+      projectSlug: "proj",
+      taskId: "task_a",
+      prompt: "Task A\n\nFix it",
+    });
+    expect(useBoard.getState().error).toBe("server");
+    expect(useBoard.getState().cardsByProject.proj?.some((task) => task.linkedSessionId === "sess_new")).toBe(false);
+  });
+});

--- a/tests/desktop/task-sessions.test.ts
+++ b/tests/desktop/task-sessions.test.ts
@@ -85,4 +85,33 @@ describe("startTaskSession", () => {
     expect(useBoard.getState().cardsByProject.proj?.some((task) => task.linkedSessionId === "sess_new")).toBe(false);
     expect(del).toHaveBeenCalledWith("/api/terminal/sessions/matrix-task-1?force=1");
   });
+
+  it("stops the workspace session when task linking fails before an attachable session exists", async () => {
+    const del = vi.fn().mockResolvedValue({ ok: true });
+    const api = makeApi({
+      get: vi.fn(async (path: string) => {
+        if (path === "/api/terminal/sessions") return { sessions: [] };
+        if (path === "/api/sessions") {
+          return { sessions: [{ id: "sess_new", runtime: {} }], nextCursor: null };
+        }
+        return { tasks: [], nextCursor: null };
+      }),
+      patch: vi.fn().mockRejectedValue(new AppError("server")),
+      delete: del,
+    });
+    useBoard.setState({ cardsByProject: { proj: [card()] } });
+
+    const ok = await startTaskSession(api, {
+      projectSlug: "proj",
+      taskId: "task_a",
+      worktreeId: null,
+      title: "Task A",
+      description: "Fix it",
+      kind: "agent",
+      agent: "claude",
+    });
+
+    expect(ok).toBe(false);
+    expect(del).toHaveBeenCalledWith("/api/sessions/sess_new");
+  });
 });

--- a/tests/desktop/task-sessions.test.ts
+++ b/tests/desktop/task-sessions.test.ts
@@ -114,4 +114,37 @@ describe("startTaskSession", () => {
     expect(ok).toBe(false);
     expect(del).toHaveBeenCalledWith("/api/sessions/sess_new");
   });
+
+  it("returns false when unlinked workspace-session cleanup also fails", async () => {
+    const del = vi.fn().mockRejectedValue(new AppError("offline"));
+    const api = makeApi({
+      get: vi.fn(async (path: string) => {
+        if (path === "/api/terminal/sessions") return { sessions: [] };
+        if (path === "/api/sessions") {
+          return { sessions: [{ id: "sess_new", runtime: {} }], nextCursor: null };
+        }
+        return { tasks: [], nextCursor: null };
+      }),
+      patch: vi.fn().mockRejectedValue(new AppError("server")),
+      delete: del,
+    });
+    useBoard.setState({ cardsByProject: { proj: [card()] } });
+
+    const ok = await startTaskSession(api, {
+      projectSlug: "proj",
+      taskId: "task_a",
+      worktreeId: null,
+      title: "Task A",
+      description: "Fix it",
+      kind: "agent",
+      agent: "claude",
+    });
+
+    expect(ok).toBe(false);
+    expect(del).toHaveBeenCalledWith("/api/sessions/sess_new");
+    expect(console.warn).toHaveBeenCalledWith(
+      "[task-sessions] failed to clean up unlinked session:",
+      "Can't reach Matrix OS. Check your connection.",
+    );
+  });
 });

--- a/tests/desktop/task-sessions.test.ts
+++ b/tests/desktop/task-sessions.test.ts
@@ -56,8 +56,10 @@ afterEach(() => {
 
 describe("startTaskSession", () => {
   it("returns false when task linking fails after creating the session", async () => {
+    const del = vi.fn().mockResolvedValue({ ok: true });
     const api = makeApi({
       patch: vi.fn().mockRejectedValue(new AppError("server")),
+      delete: del,
     });
     useBoard.setState({ cardsByProject: { proj: [card()] } });
 
@@ -81,5 +83,6 @@ describe("startTaskSession", () => {
     });
     expect(useBoard.getState().error).toBe("server");
     expect(useBoard.getState().cardsByProject.proj?.some((task) => task.linkedSessionId === "sess_new")).toBe(false);
+    expect(del).toHaveBeenCalledWith("/api/terminal/sessions/matrix-task-1?force=1");
   });
 });

--- a/tests/desktop/task-workspace.test.tsx
+++ b/tests/desktop/task-workspace.test.tsx
@@ -1,0 +1,133 @@
+// @vitest-environment jsdom
+
+import React from "react";
+import * as Tooltip from "@radix-ui/react-tooltip";
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import TaskWorkspace from "../../desktop/src/renderer/src/features/workspace/TaskWorkspace";
+import { useBoard, type Card } from "../../desktop/src/renderer/src/stores/board";
+import { useConnection } from "../../desktop/src/renderer/src/stores/connection";
+import { useGit } from "../../desktop/src/renderer/src/stores/git";
+import { useSessions } from "../../desktop/src/renderer/src/stores/sessions";
+import { useWorkspace } from "../../desktop/src/renderer/src/stores/workspace";
+
+vi.mock("../../desktop/src/renderer/src/features/terminal/TerminalView", () => ({
+  default: ({ sessionName }: { sessionName: string }) => <div>Terminal {sessionName}</div>,
+}));
+
+vi.mock("../../desktop/src/renderer/src/features/workspace/PanelStrip", () => ({
+  default: ({ renderPanel }: { renderPanel: (panel: "terminal") => React.ReactNode }) => (
+    <div>{renderPanel("terminal")}</div>
+  ),
+  PANEL_TITLES: {
+    terminal: "Terminal",
+    editor: "Editor",
+    git: "Git",
+    browser: "Files",
+    artifacts: "Artifacts",
+    processes: "Processes",
+    timeline: "Timeline",
+  },
+}));
+
+vi.mock("../../desktop/src/renderer/src/features/workspace/StartSessionControls", () => ({
+  default: () => <button type="button">Start controls</button>,
+}));
+
+vi.mock("../../desktop/src/renderer/src/features/editor/EditorPanel", () => ({
+  default: () => <div>Editor</div>,
+}));
+
+vi.mock("../../desktop/src/renderer/src/features/files/FilesPanel", () => ({
+  default: () => <div>Files</div>,
+}));
+
+vi.mock("../../desktop/src/renderer/src/features/git/GitPanel", () => ({
+  default: () => <div>Git</div>,
+}));
+
+vi.mock("../../desktop/src/renderer/src/features/workspace/ArtifactsPanel", () => ({
+  default: () => <div>Artifacts</div>,
+}));
+
+vi.mock("../../desktop/src/renderer/src/features/workspace/ProcessesPanel", () => ({
+  default: () => <div>Processes</div>,
+}));
+
+vi.mock("../../desktop/src/renderer/src/features/workspace/TimelinePanel", () => ({
+  default: () => <div>Timeline</div>,
+}));
+
+function card(overrides: Partial<Card> = {}): Card {
+  return {
+    id: "task_a",
+    projectSlug: "proj",
+    title: "Task A",
+    description: "Fix it",
+    status: "running",
+    priority: "normal",
+    order: 0,
+    parentTaskId: null,
+    linkedSessionId: "sess_live",
+    linkedWorktreeId: null,
+    previewIds: [],
+    tags: [],
+    updatedAt: null,
+    revision: null,
+    ...overrides,
+  };
+}
+
+describe("TaskWorkspace", () => {
+  beforeEach(() => {
+    useConnection.setState({ api: {} as never });
+    useBoard.setState({
+      projects: [],
+      activeProjectSlug: null,
+      cardsByProject: { proj: [card()] },
+      firstLoadByProject: {},
+      refreshing: false,
+      error: null,
+    });
+    useSessions.setState({
+      sessions: [
+        {
+          name: "Task A",
+          attachName: "matrix-agent-1",
+          status: "active",
+          source: "workspace",
+          kind: "agent",
+          agent: "codex",
+          projectSlug: "proj",
+          taskId: "task_a",
+        },
+      ],
+      aliasMap: { sess_live: "matrix-agent-1" },
+      load: vi.fn().mockResolvedValue(undefined),
+      kill: vi.fn().mockResolvedValue(true),
+    });
+    useGit.setState({
+      worktrees: [],
+      previews: [],
+      loadAll: vi.fn().mockResolvedValue(undefined),
+      loadPreviews: vi.fn().mockResolvedValue(undefined),
+    });
+    useWorkspace.setState(useWorkspace.getInitialState(), true);
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it("hides header start controls while a live session is attached", () => {
+    render(
+      <Tooltip.Provider>
+        <TaskWorkspace taskId="task_a" />
+      </Tooltip.Provider>,
+    );
+
+    expect(screen.queryByRole("button", { name: /start controls/i })).toBeNull();
+    expect(screen.getByText("Terminal matrix-agent-1")).toBeTruthy();
+  });
+});

--- a/tests/desktop/terminals-tab.test.tsx
+++ b/tests/desktop/terminals-tab.test.tsx
@@ -178,4 +178,24 @@ describe("TerminalsTab", () => {
       await Promise.resolve();
     });
   });
+
+  it("disables kill while a session is being created or restarted", () => {
+    const kill = vi.fn().mockResolvedValue(true);
+    useSessions.setState({
+      sessions: [{ attachName: "main", name: "main", status: "active" }],
+      creating: true,
+      kill,
+    });
+
+    render(
+      <Tooltip.Provider>
+        <TerminalsTab />
+      </Tooltip.Provider>,
+    );
+
+    const killButton = screen.getByRole("button", { name: /kill session/i }) as HTMLButtonElement;
+    expect(killButton.disabled).toBe(true);
+    fireEvent.click(killButton);
+    expect(kill).not.toHaveBeenCalled();
+  });
 });

--- a/tests/desktop/terminals-tab.test.tsx
+++ b/tests/desktop/terminals-tab.test.tsx
@@ -38,7 +38,11 @@ describe("TerminalsTab", () => {
     const create = vi.fn(
       () =>
         new Promise<{ attachName: string; name: string; status: "active" }>((resolve) => {
-          resolveCreate = resolve;
+          useSessions.setState({ creating: true });
+          resolveCreate = (value) => {
+            useSessions.setState({ creating: false });
+            resolve(value);
+          };
         }),
     );
     useSessions.setState({ create });
@@ -51,7 +55,9 @@ describe("TerminalsTab", () => {
 
     const button = screen.getAllByRole("button", { name: /new session/i })[0]!;
     fireEvent.click(button);
-    fireEvent.click(screen.getByRole("button", { name: /creating/i }));
+    const starting = screen.getByRole("button", { name: /starting/i }) as HTMLButtonElement;
+    expect(starting.disabled).toBe(true);
+    fireEvent.click(starting);
 
     expect(create).toHaveBeenCalledOnce();
 

--- a/tests/desktop/terminals-tab.test.tsx
+++ b/tests/desktop/terminals-tab.test.tsx
@@ -120,7 +120,7 @@ describe("TerminalsTab", () => {
       </Tooltip.Provider>,
     );
 
-    fireEvent.click(screen.getByRole("button", { name: /new session/i }));
+    fireEvent.click(screen.getAllByRole("button", { name: /new session/i })[0]!);
 
     expect(await screen.findByText("Something went wrong. Please try again.")).toBeTruthy();
   });

--- a/tests/desktop/terminals-tab.test.tsx
+++ b/tests/desktop/terminals-tab.test.tsx
@@ -32,6 +32,7 @@ describe("TerminalsTab", () => {
     useSessions.setState({
       sessions: [],
       error: null,
+      creating: false,
       load: vi.fn().mockResolvedValue(undefined),
       kill: vi.fn().mockResolvedValue(true),
       restart: vi.fn().mockResolvedValue(null),
@@ -197,5 +198,24 @@ describe("TerminalsTab", () => {
     expect(killButton.disabled).toBe(true);
     fireEvent.click(killButton);
     expect(kill).not.toHaveBeenCalled();
+  });
+
+  it("surfaces restart failures", async () => {
+    const restart = vi.fn().mockResolvedValue(null);
+    useSessions.setState({
+      sessions: [{ attachName: "main", name: "main", status: "exited" }],
+      restart,
+    });
+
+    render(
+      <Tooltip.Provider>
+        <TerminalsTab />
+      </Tooltip.Provider>,
+    );
+
+    fireEvent.click(await screen.findByRole("button", { name: /restart session/i }));
+
+    await screen.findByText(/restart failed/i);
+    expect(restart).toHaveBeenCalledWith(expect.any(Object), "main");
   });
 });

--- a/tests/desktop/terminals-tab.test.tsx
+++ b/tests/desktop/terminals-tab.test.tsx
@@ -12,6 +12,14 @@ vi.mock("../../desktop/src/renderer/src/features/terminal/TerminalView", () => (
   default: ({ sessionName }: { sessionName: string }) => <div>Terminal {sessionName}</div>,
 }));
 
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+}
+
 describe("TerminalsTab", () => {
   beforeEach(() => {
     useConnection.setState({
@@ -25,6 +33,8 @@ describe("TerminalsTab", () => {
       sessions: [],
       error: null,
       load: vi.fn().mockResolvedValue(undefined),
+      kill: vi.fn().mockResolvedValue(true),
+      restart: vi.fn().mockResolvedValue(null),
     });
   });
 
@@ -138,5 +148,34 @@ describe("TerminalsTab", () => {
 
     await screen.findByText("Terminal next");
     expect(screen.queryByText("Terminal main")).toBeNull();
+  });
+
+  it("disables restart while a kill operation is in flight", async () => {
+    const killed = deferred<boolean>();
+    const kill = vi.fn(() => killed.promise);
+    const restart = vi.fn().mockResolvedValue({ attachName: "main", name: "main", status: "active" });
+    useSessions.setState({
+      sessions: [{ attachName: "main", name: "main", status: "exited", source: "workspace" }],
+      kill,
+      restart,
+    });
+
+    render(
+      <Tooltip.Provider>
+        <TerminalsTab />
+      </Tooltip.Provider>,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /kill session/i }));
+
+    const restartButton = await screen.findByRole("button", { name: /restart session/i });
+    expect((restartButton as HTMLButtonElement).disabled).toBe(true);
+    fireEvent.click(restartButton);
+    expect(restart).not.toHaveBeenCalled();
+
+    await act(async () => {
+      killed.resolve(true);
+      await Promise.resolve();
+    });
   });
 });

--- a/tests/desktop/terminals-tab.test.tsx
+++ b/tests/desktop/terminals-tab.test.tsx
@@ -125,6 +125,30 @@ describe("TerminalsTab", () => {
     expect(await screen.findByText("Something went wrong. Please try again.")).toBeTruthy();
   });
 
+  it("deletes a shell workspace session when start returns no attach name", async () => {
+    const del = vi.fn().mockResolvedValue({ ok: true });
+    const create = vi.fn().mockResolvedValue({ sessionId: "sess_orphan", attachName: null });
+    useConnection.setState({
+      status: "signed-in",
+      handle: "operator",
+      platformHost: "https://platform.test",
+      runtimeSlot: "primary",
+      api: { delete: del } as never,
+    });
+    useSessions.setState({ create });
+
+    render(
+      <Tooltip.Provider>
+        <TerminalsTab />
+      </Tooltip.Provider>,
+    );
+
+    fireEvent.click(screen.getAllByRole("button", { name: /new session/i })[0]!);
+
+    await screen.findByText(/start failed/i);
+    expect(del).toHaveBeenCalledWith("/api/sessions/sess_orphan");
+  });
+
   it("selects a remaining session when the selected session disappears", async () => {
     useSessions.setState({
       sessions: [

--- a/tests/desktop/timeline-panel.test.tsx
+++ b/tests/desktop/timeline-panel.test.tsx
@@ -1,0 +1,52 @@
+// @vitest-environment jsdom
+
+import React from "react";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import TimelinePanel from "../../desktop/src/renderer/src/features/workspace/TimelinePanel";
+import { useConnection } from "../../desktop/src/renderer/src/stores/connection";
+
+describe("TimelinePanel", () => {
+  beforeEach(() => undefined);
+
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+    useConnection.setState({
+      status: "loading",
+      handle: null,
+      platformHost: "",
+      runtimeSlot: "primary",
+      api: null,
+    });
+  });
+
+  it("clears previous task events while the next task is loading", async () => {
+    const get = vi.fn((path: string) => {
+      if (path.includes("task-a")) {
+        return Promise.resolve({
+          events: [{ id: "event-a", type: "session.started", createdAt: new Date().toISOString() }],
+        });
+      }
+      return new Promise(() => undefined);
+    });
+    useConnection.setState({
+      status: "signed-in",
+      handle: "operator",
+      platformHost: "https://platform.test",
+      runtimeSlot: "primary",
+      api: { get, post: vi.fn(), patch: vi.fn(), delete: vi.fn(), putText: vi.fn() } as never,
+    });
+
+    const { rerender } = render(<TimelinePanel taskId="task-a" />);
+
+    await waitFor(() => {
+      expect(screen.queryByText("Session started")).not.toBeNull();
+    });
+
+    rerender(<TimelinePanel taskId="task-b" />);
+
+    expect(screen.queryByText("Session started")).toBeNull();
+    expect(screen.queryByText(/Loading activity/)).not.toBeNull();
+  });
+});

--- a/tests/desktop/timeline.test.ts
+++ b/tests/desktop/timeline.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import { describeEvent, relativeTime } from "@desktop/renderer/src/features/workspace/TimelinePanel";
+
+const at = "2026-06-13T00:00:00.000Z";
+
+describe("describeEvent", () => {
+  it("labels session start, including the agent when present", () => {
+    expect(describeEvent({ id: "1", type: "session.started", payload: { agent: "claude" }, createdAt: at })).toEqual({
+      label: "Agent launched (claude)",
+      color: "var(--success)",
+    });
+    expect(describeEvent({ id: "2", type: "session.started", createdAt: at }).label).toBe("Session started");
+  });
+
+  it("shows the new status on task.updated", () => {
+    expect(describeEvent({ id: "3", type: "task.updated", payload: { status: "running" }, createdAt: at }).label).toBe(
+      "Status → running",
+    );
+  });
+
+  it("flags an unhealthy preview", () => {
+    expect(describeEvent({ id: "4", type: "preview.updated", payload: { lastStatus: "failed" }, createdAt: at }).label).toBe(
+      "Preview unhealthy",
+    );
+  });
+
+  it("humanizes review events and unknown types", () => {
+    expect(describeEvent({ id: "5", type: "review.completed", createdAt: at }).label).toBe("Review completed");
+    expect(describeEvent({ id: "6", type: "diff.changed", createdAt: at }).label).toBe("diff changed");
+  });
+});
+
+describe("relativeTime", () => {
+  const now = Date.parse("2026-06-13T01:00:00.000Z");
+  it("renders compact buckets", () => {
+    expect(relativeTime("2026-06-13T00:59:30.000Z", now)).toBe("now");
+    expect(relativeTime("2026-06-13T00:55:00.000Z", now)).toBe("5m");
+    expect(relativeTime("2026-06-13T00:00:00.000Z", now)).toBe("1h");
+    expect(relativeTime("2026-06-10T01:00:00.000Z", now)).toBe("3d");
+  });
+  it("returns empty for an unparseable timestamp", () => {
+    expect(relativeTime("not-a-date", now)).toBe("");
+  });
+});

--- a/tests/desktop/workspace-store.test.ts
+++ b/tests/desktop/workspace-store.test.ts
@@ -4,6 +4,7 @@ import {
   PANEL_MIN_PCT,
   WORKSPACE_LRU_CAP,
   defaultLayout,
+  normalizeLayout,
   useWorkspace,
   type PanelKind,
   type PanelLayout,
@@ -319,5 +320,40 @@ describe("PANEL_MIN_PCT", () => {
     for (const kind of PANEL_KINDS) {
       expect(PANEL_MIN_PCT[kind as PanelKind]).toBeGreaterThan(0);
     }
+  });
+});
+
+describe("normalizeLayout (migration of older persisted layouts)", () => {
+  it("appends panel kinds missing from a stale layout (hidden, zero size)", () => {
+    // A layout saved before "timeline" existed.
+    const stale: PanelLayout = {
+      order: ["terminal", "editor"] as PanelKind[],
+      visible: { terminal: true, editor: false } as Record<PanelKind, boolean>,
+      sizes: { terminal: 100, editor: 0 } as Record<PanelKind, number>,
+      touchedAt: 1,
+    };
+    const norm = normalizeLayout(stale);
+    for (const kind of PANEL_KINDS) {
+      expect(norm.order).toContain(kind);
+      expect(typeof norm.visible[kind]).toBe("boolean");
+      expect(typeof norm.sizes[kind]).toBe("number");
+    }
+    // Newly added kinds default to hidden so they don't disrupt the saved view.
+    expect(norm.visible.timeline).toBe(false);
+    // Existing values are preserved.
+    expect(norm.visible.terminal).toBe(true);
+    expect(norm.sizes.terminal).toBe(100);
+  });
+
+  it("drops unknown panel kinds from order", () => {
+    const layout = { ...defaultLayout(1), order: ["terminal", "ghost", "editor"] as PanelKind[] };
+    const norm = normalizeLayout(layout);
+    expect(norm.order).not.toContain("ghost" as PanelKind);
+    expect(norm.order).toContain("terminal");
+  });
+
+  it("is idempotent for a current default layout", () => {
+    const def = defaultLayout(1);
+    expect(normalizeLayout(def).order).toEqual(def.order);
   });
 });


### PR DESCRIPTION
## Summary
- Adds cloud coding session ownership, live board badges, terminal workspace polish, timeline/process panels, and abort/status controls.
- Part of the 094 Operator desktop stack split from original PR #507.
- Draft until the full stack validation and screenshots are refreshed.

## Validation
- Rebased onto current main after #506 merged.
- Rebuilt stack final tree matches the original #507 tree exactly.
- Per-layer CI/Greptile still needs to settle before review-ready.

## Invariants
- Source of truth: desktop app source under desktop/, specs/docs, and root workspace metadata in this stack; no owner runtime data is modified.
- Lock/transaction scope: no Postgres transaction scope is introduced in this layer; desktop local state remains scoped to the Electron app and existing gateway/platform APIs.
- Acceptable orphan states: stack PRs are draft and must land in order; partial stack landing is not a supported release state.
- Auth source of truth: Clerk/device auth and existing gateway token handling remain authoritative; this stack does not add a second auth authority.
- Deferred scope: packaged distribution, production desktop rollout, and customer VPS host-bundle deploy are outside this stack.

## Greptile Deferrals

- Greptile current-head review on a36ce8701ca9 is 4/5 with non-blocking display-quality follow-ups: ProcessesPanel stale snapshot on API disconnect, TimelinePanel timestamp refresh during polling errors, and ArtifactsPanel project-level preview error visibility. Deferred to #576.