### PR TITLE
feat(desktop): add launcher search and markdown preview

### DIFF
--- a/desktop/src/renderer/src/features/board/Board.tsx
+++ b/desktop/src/renderer/src/features/board/Board.tsx
@@ -9,7 +9,7 @@ import {
   type DragEndEvent,
   type DragStartEvent,
 } from "@dnd-kit/core";
-import { Kanban } from "lucide-react";
+import { Kanban, Plus } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
 import { Button, EmptyState } from "../../design/primitives";
 import { toUserMessage } from "../../lib/errors";
@@ -60,8 +60,9 @@ function Column({
   activeDragId: string | null;
 }) {
   const { setNodeRef, isOver } = useDroppable({ id: `column:${status}` });
+  const openCreateTask = useUi((s) => s.openCreateTask);
   return (
-    <div className="flex w-[252px] shrink-0 flex-col">
+    <div className="group/col flex w-[252px] shrink-0 flex-col">
       <div className="mb-2 flex items-center gap-2 px-1">
         <span className="h-2 w-2 rounded-full" style={{ background: COLUMN_COLOR[status] }} />
         <span className="text-sm font-semibold" style={{ color: "var(--text-primary)" }}>
@@ -70,6 +71,17 @@ function Column({
         <span className="text-xs" style={{ color: "var(--text-tertiary)" }}>
           {cards.length}
         </span>
+        <div className="flex-1" />
+        <button
+          type="button"
+          aria-label={`New task in ${COLUMN_LABEL[status]}`}
+          title={`New task in ${COLUMN_LABEL[status]}`}
+          className="flex h-5 w-5 items-center justify-center rounded opacity-0 transition-opacity duration-100 hover:bg-[var(--bg-hover)] group-hover/col:opacity-100"
+          style={{ color: "var(--text-tertiary)" }}
+          onClick={() => openCreateTask(status)}
+        >
+          <Plus size={14} />
+        </button>
       </div>
       <div
         ref={setNodeRef}
@@ -79,6 +91,15 @@ function Column({
         {cards.map((card) => (
           <DraggableCard key={card.id} card={card} dragging={activeDragId === card.id} />
         ))}
+        <button
+          type="button"
+          className="flex items-center gap-1.5 rounded-md px-2 py-1.5 text-left text-sm transition-colors duration-100 hover:bg-[var(--bg-hover)]"
+          style={{ color: "var(--text-tertiary)" }}
+          onClick={() => openCreateTask(status)}
+        >
+          <Plus size={13} />
+          New task
+        </button>
       </div>
     </div>
   );

--- a/desktop/src/renderer/src/features/board/CreateTaskDialog.tsx
+++ b/desktop/src/renderer/src/features/board/CreateTaskDialog.tsx
@@ -10,6 +10,7 @@ import { Button, Dialog } from "../../design/primitives";
 import { useBoard, BOARD_COLUMNS, type CardPriority, type CardStatus } from "../../stores/board";
 import { useConnection } from "../../stores/connection";
 import { useTabs } from "../../stores/tabs";
+import { useUi } from "../../stores/ui";
 
 const PRIORITIES: CardPriority[] = ["low", "normal", "high", "urgent"];
 const SELECT_STYLE: CSSProperties = {
@@ -20,6 +21,15 @@ const SELECT_STYLE: CSSProperties = {
   padding: "4px 8px",
   fontSize: "var(--text-sm)",
 };
+
+// Default the new task to the column its "+" was clicked from (set in the UI
+// store when opening), falling back to "todo".
+function initialStatus(): CardStatus {
+  const fromColumn = useUi.getState().createTaskStatus;
+  return fromColumn && (BOARD_COLUMNS as readonly string[]).includes(fromColumn)
+    ? (fromColumn as CardStatus)
+    : "todo";
+}
 
 // Inner form is mounted only while the dialog is open, so its state starts
 // fresh on each open without a reset-on-prop effect (react-doctor: no
@@ -39,7 +49,7 @@ function CreateTaskForm({
   const openTab = useTabs((s) => s.openTab);
   const [title, setTitle] = useState("");
   const [description, setDescription] = useState("");
-  const [status, setStatus] = useState<CardStatus>("todo");
+  const [status, setStatus] = useState<CardStatus>(initialStatus);
   const [priority, setPriority] = useState<CardPriority>("normal");
   const [submitting, setSubmitting] = useState(false);
   const [failureMessage, setFailureMessage] = useState<string | null>(null);

--- a/desktop/src/renderer/src/features/editor/EditorPanel.tsx
+++ b/desktop/src/renderer/src/features/editor/EditorPanel.tsx
@@ -1,14 +1,17 @@
-import { FileCode2, X } from "lucide-react";
+import { Code2, Eye, FileCode2, X } from "lucide-react";
 import { lazy, Suspense, useCallback, useEffect, useRef, useState } from "react";
 import { Button, EmptyState } from "../../design/primitives";
 import { useConnection } from "../../stores/connection";
 import { useEditorTabs } from "./editor-tabs-store";
 
 const CodeMirrorHost = lazy(() => import("./CodeMirrorHost"));
+const MarkdownPreview = lazy(() => import("./MarkdownPreview"));
 
 // Stable empty reference: a selector returning a fresh [] every render would
 // fail the Object.is check and loop forever (React #185, CLAUDE.md rule).
 const EMPTY_TABS: string[] = [];
+
+const isMarkdown = (path: string): boolean => /\.mdx?$/i.test(path);
 
 export default function EditorPanel({ taskId }: { taskId: string }) {
   const api = useConnection((s) => s.api);
@@ -17,6 +20,8 @@ export default function EditorPanel({ taskId }: { taskId: string }) {
   const setActive = useEditorTabs((s) => s.setActive);
   const closeTab = useEditorTabs((s) => s.closeTab);
   const dirtyPaths = useEditorTabs((s) => s.dirtyPathsByTask[taskId] ?? []);
+  // Per-path "edit this markdown as code" overrides; markdown previews by default.
+  const [editPaths, setEditPaths] = useState<Record<string, boolean>>({});
 
   if (tabs.length === 0) {
     return (
@@ -70,18 +75,34 @@ export default function EditorPanel({ taskId }: { taskId: string }) {
             </div>
           );
         })}
+        {activePath && isMarkdown(activePath) ? (
+          <button
+            type="button"
+            className="no-drag ml-auto mr-1 mb-1 flex items-center gap-1.5 self-center rounded-md border px-2 py-1 text-xs"
+            style={{ borderColor: "var(--border-subtle)", color: "var(--text-secondary)" }}
+            onClick={() => setEditPaths((m) => ({ ...m, [activePath]: !m[activePath] }))}
+            title={editPaths[activePath] ? "Preview rendered markdown" : "Edit as code"}
+          >
+            {editPaths[activePath] ? <Eye size={12} /> : <Code2 size={12} />}
+            {editPaths[activePath] ? "Preview" : "Edit"}
+          </button>
+        ) : null}
       </div>
       {activePath && api ? (
         <Suspense
           fallback={
             <div className="flex flex-1 items-center justify-center">
               <span className="status-pulse text-xs" style={{ color: "var(--text-tertiary)" }}>
-                Loading editor…
+                Loading…
               </span>
             </div>
           }
         >
-          <CodeMirrorHost key={activePath} taskId={taskId} path={activePath} />
+          {isMarkdown(activePath) && !editPaths[activePath] ? (
+            <MarkdownPreview key={`md:${activePath}`} path={activePath} />
+          ) : (
+            <CodeMirrorHost key={activePath} taskId={taskId} path={activePath} />
+          )}
         </Suspense>
       ) : null}
     </div>

--- a/desktop/src/renderer/src/features/editor/MarkdownPreview.tsx
+++ b/desktop/src/renderer/src/features/editor/MarkdownPreview.tsx
@@ -1,0 +1,50 @@
+import ReactMarkdown from "react-markdown";
+import { useEffect, useState } from "react";
+import { toUserMessage } from "../../lib/errors";
+import { useConnection } from "../../stores/connection";
+import { createFilesApi, openFile } from "./editor-save";
+
+// Read-only rendered markdown for .md/.mdx files. Reuses the chat response prose
+// styling so docs read like docs instead of raw CodeMirror text. Toggle to Code
+// in the editor header to edit.
+export default function MarkdownPreview({ path }: { path: string }) {
+  const api = useConnection((s) => s.api);
+  const [content, setContent] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!api) return;
+    let cancelled = false;
+    setContent(null);
+    setError(null);
+    void openFile(createFilesApi(api), path)
+      .then((file) => {
+        if (!cancelled) setContent(file.content);
+      })
+      .catch((err: unknown) => {
+        if (!cancelled) setError(toUserMessage(err));
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [api, path]);
+
+  if (error) {
+    return <div className="flex flex-1 items-center justify-center text-sm" style={{ color: "var(--danger)" }}>{error}</div>;
+  }
+  if (content === null) {
+    return <div className="flex flex-1 items-center justify-center text-sm" style={{ color: "var(--text-tertiary)" }}>Loading…</div>;
+  }
+
+  return (
+    <div className="min-h-0 flex-1 overflow-y-auto px-6 py-5">
+      <div
+        className="prose-sm mx-auto max-w-[760px] text-sm leading-relaxed [&_a]:text-[var(--highlight)] [&_blockquote]:border-l-2 [&_blockquote]:border-[var(--border-default)] [&_blockquote]:pl-3 [&_blockquote]:text-[var(--text-secondary)] [&_code]:rounded [&_code]:bg-[var(--bg-sunken)] [&_code]:px-1 [&_code]:py-0.5 [&_code]:font-mono [&_code]:text-[12px] [&_h1]:mt-4 [&_h1]:mb-2 [&_h1]:text-xl [&_h1]:font-semibold [&_h2]:mt-4 [&_h2]:mb-2 [&_h2]:text-lg [&_h2]:font-semibold [&_h3]:mt-3 [&_h3]:mb-1.5 [&_h3]:font-semibold [&_hr]:my-4 [&_hr]:border-[var(--border-subtle)] [&_li]:my-0.5 [&_ol]:list-decimal [&_ol]:pl-5 [&_p]:my-2 [&_pre]:overflow-x-auto [&_pre]:rounded-lg [&_pre]:border [&_pre]:border-[var(--border-subtle)] [&_pre]:bg-[var(--bg-sunken)] [&_pre]:p-3 [&_pre_code]:bg-transparent [&_ul]:list-disc [&_ul]:pl-5"
+        style={{ color: "var(--text-primary)" }}
+        data-selectable
+      >
+        <ReactMarkdown>{content}</ReactMarkdown>
+      </div>
+    </div>
+  );
+}

--- a/desktop/src/renderer/src/features/editor/MarkdownPreview.tsx
+++ b/desktop/src/renderer/src/features/editor/MarkdownPreview.tsx
@@ -4,35 +4,44 @@ import { toUserMessage } from "../../lib/errors";
 import { useConnection } from "../../stores/connection";
 import { createFilesApi, openFile } from "./editor-save";
 
+type PreviewState =
+  | { path: string; status: "loading" }
+  | { path: string; status: "ready"; content: string }
+  | { path: string; status: "error"; error: string };
+
 // Read-only rendered markdown for .md/.mdx files. Reuses the chat response prose
 // styling so docs read like docs instead of raw CodeMirror text. Toggle to Code
 // in the editor header to edit.
 export default function MarkdownPreview({ path }: { path: string }) {
   const api = useConnection((s) => s.api);
-  const [content, setContent] = useState<string | null>(null);
-  const [error, setError] = useState<string | null>(null);
+  const [state, setState] = useState<PreviewState>(() => ({ path, status: "loading" }));
+
+  let preview = state;
+  if (state.path !== path) {
+    preview = { path, status: "loading" };
+    setState(preview);
+  }
 
   useEffect(() => {
     if (!api) return;
     let cancelled = false;
-    setContent(null);
-    setError(null);
+    const requestedPath = path;
     void openFile(createFilesApi(api), path)
       .then((file) => {
-        if (!cancelled) setContent(file.content);
+        if (!cancelled) setState({ path: requestedPath, status: "ready", content: file.content });
       })
       .catch((err: unknown) => {
-        if (!cancelled) setError(toUserMessage(err));
+        if (!cancelled) setState({ path: requestedPath, status: "error", error: toUserMessage(err) });
       });
     return () => {
       cancelled = true;
     };
   }, [api, path]);
 
-  if (error) {
-    return <div className="flex flex-1 items-center justify-center text-sm" style={{ color: "var(--danger)" }}>{error}</div>;
+  if (preview.status === "error") {
+    return <div className="flex flex-1 items-center justify-center text-sm" style={{ color: "var(--danger)" }}>{preview.error}</div>;
   }
-  if (content === null) {
+  if (preview.status === "loading") {
     return <div className="flex flex-1 items-center justify-center text-sm" style={{ color: "var(--text-tertiary)" }}>Loading…</div>;
   }
 
@@ -43,7 +52,7 @@ export default function MarkdownPreview({ path }: { path: string }) {
         style={{ color: "var(--text-primary)" }}
         data-selectable
       >
-        <ReactMarkdown>{content}</ReactMarkdown>
+        <ReactMarkdown>{preview.content}</ReactMarkdown>
       </div>
     </div>
   );

--- a/desktop/src/renderer/src/features/editor/MarkdownPreview.tsx
+++ b/desktop/src/renderer/src/features/editor/MarkdownPreview.tsx
@@ -9,21 +9,29 @@ type PreviewState =
   | { path: string; status: "ready"; content: string }
   | { path: string; status: "error"; error: string };
 
+export function safeUrlTransform(url: string): string {
+  try {
+    const parsed = new URL(url, "https://matrix.local");
+    if (parsed.protocol === "http:" || parsed.protocol === "https:" || parsed.protocol === "mailto:") {
+      return url;
+    }
+  } catch {
+    return "";
+  }
+  return "";
+}
+
 // Read-only rendered markdown for .md/.mdx files. Reuses the chat response prose
 // styling so docs read like docs instead of raw CodeMirror text. Toggle to Code
 // in the editor header to edit.
 export default function MarkdownPreview({ path }: { path: string }) {
   const api = useConnection((s) => s.api);
   const [state, setState] = useState<PreviewState>(() => ({ path, status: "loading" }));
-
-  let preview = state;
-  if (state.path !== path) {
-    preview = { path, status: "loading" };
-    setState(preview);
-  }
+  const preview: PreviewState = state.path === path ? state : { path, status: "loading" };
 
   useEffect(() => {
-    if (!api) return;
+    setState({ path, status: "loading" });
+    if (!api) return undefined;
     let cancelled = false;
     const requestedPath = path;
     void openFile(createFilesApi(api), path)
@@ -52,7 +60,7 @@ export default function MarkdownPreview({ path }: { path: string }) {
         style={{ color: "var(--text-primary)" }}
         data-selectable
       >
-        <ReactMarkdown>{preview.content}</ReactMarkdown>
+        <ReactMarkdown urlTransform={safeUrlTransform}>{preview.content}</ReactMarkdown>
       </div>
     </div>
   );

--- a/desktop/src/renderer/src/features/embeds/AppLauncher.tsx
+++ b/desktop/src/renderer/src/features/embeds/AppLauncher.tsx
@@ -1,12 +1,41 @@
 import { LayoutGrid, Search } from "lucide-react";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { EmptyState } from "../../design/primitives";
-import { useApps } from "../../stores/apps";
+import { appIconUrl, useApps } from "../../stores/apps";
 import { useConnection } from "../../stores/connection";
 import { useTabs } from "../../stores/tabs";
 
+function AppIcon({ url, name }: { url: string | null; name: string }) {
+  const [failed, setFailed] = useState(false);
+  const prev = useRef<string | null>(null);
+  if (prev.current !== url) {
+    prev.current = url;
+    if (failed) setFailed(false);
+  }
+  if (url && !failed) {
+    return (
+      <img
+        src={url}
+        alt=""
+        className="h-11 w-11 rounded-xl object-cover"
+        referrerPolicy="no-referrer"
+        onError={() => setFailed(true)}
+      />
+    );
+  }
+  return (
+    <div
+      className="flex h-11 w-11 items-center justify-center rounded-xl text-lg font-semibold"
+      style={{ background: "var(--accent-muted)", color: "var(--accent)" }}
+    >
+      {name.charAt(0).toUpperCase()}
+    </div>
+  );
+}
+
 export default function AppLauncher() {
   const api = useConnection((s) => s.api);
+  const platformHost = useConnection((s) => s.platformHost);
   const openTab = useTabs((s) => s.openTab);
   const apps = useApps((s) => s.apps);
   const loaded = useApps((s) => s.loaded);
@@ -35,7 +64,8 @@ export default function AppLauncher() {
     setActive((i) => (i >= filtered.length ? 0 : i));
   }, [filtered.length]);
 
-  const open = (slug: string, name: string) => openTab({ kind: "app", slug, title: name });
+  const open = (slug: string, name: string) =>
+    openTab({ kind: "app", slug, title: name, ...(appIconUrl(platformHost, slug) ? { icon: appIconUrl(platformHost, slug)! } : {}) });
 
   const onKeyDown = (e: React.KeyboardEvent) => {
     if (filtered.length === 0) return;
@@ -101,12 +131,7 @@ export default function AppLauncher() {
                   onMouseEnter={() => setActive(i)}
                   onClick={() => open(app.slug, app.name)}
                 >
-                  <div
-                    className="flex h-11 w-11 items-center justify-center rounded-xl text-lg font-semibold"
-                    style={{ background: "var(--accent-muted)", color: "var(--accent)" }}
-                  >
-                    {app.name.charAt(0).toUpperCase()}
-                  </div>
+                  <AppIcon url={appIconUrl(platformHost, app.slug)} name={app.name} />
                   <span className="w-full truncate text-center text-sm" style={{ color: "var(--text-primary)" }}>
                     {app.name}
                   </span>

--- a/desktop/src/renderer/src/features/embeds/AppLauncher.tsx
+++ b/desktop/src/renderer/src/features/embeds/AppLauncher.tsx
@@ -1,6 +1,6 @@
 import { LayoutGrid, Search } from "lucide-react";
 import { useEffect, useMemo, useRef, useState } from "react";
-import { EmptyState } from "../../design/primitives";
+import { Button, EmptyState } from "../../design/primitives";
 import { appIconUrl, useApps } from "../../stores/apps";
 import { useConnection } from "../../stores/connection";
 import { useTabs } from "../../stores/tabs";
@@ -39,6 +39,8 @@ export default function AppLauncher() {
   const openTab = useTabs((s) => s.openTab);
   const apps = useApps((s) => s.apps);
   const loaded = useApps((s) => s.loaded);
+  const loading = useApps((s) => s.loading);
+  const error = useApps((s) => s.error);
   const load = useApps((s) => s.load);
   const [query, setQuery] = useState("");
   const [active, setActive] = useState(0);
@@ -82,7 +84,24 @@ export default function AppLauncher() {
     }
   };
 
-  if (loaded && apps.length === 0) {
+  if (error) {
+    return (
+      <EmptyState
+        icon={<LayoutGrid size={26} />}
+        headline="Apps unavailable"
+        description="The app catalog could not be loaded. Try again once your computer is reachable."
+        action={
+          api ? (
+            <Button variant="primary" disabled={loading} onClick={() => void load(api, true)}>
+              {loading ? "Loading..." : "Retry"}
+            </Button>
+          ) : null
+        }
+      />
+    );
+  }
+
+  if (loaded && !loading && apps.length === 0) {
     return (
       <EmptyState
         icon={<LayoutGrid size={26} />}

--- a/desktop/src/renderer/src/features/embeds/AppLauncher.tsx
+++ b/desktop/src/renderer/src/features/embeds/AppLauncher.tsx
@@ -45,6 +45,7 @@ export default function AppLauncher() {
   const [query, setQuery] = useState("");
   const [active, setActive] = useState(0);
   const inputRef = useRef<HTMLInputElement>(null);
+  const previousQueryRef = useRef(query);
 
   useEffect(() => {
     if (api) void load(api);
@@ -63,8 +64,13 @@ export default function AppLauncher() {
 
   // Keep the highlighted index in range as the filter changes.
   useEffect(() => {
+    if (previousQueryRef.current !== query) {
+      previousQueryRef.current = query;
+      setActive(0);
+      return;
+    }
     setActive((i) => (i >= filtered.length ? 0 : i));
-  }, [filtered.length]);
+  }, [filtered.length, query]);
 
   const open = (slug: string, name: string) =>
     openTab({ kind: "app", slug, title: name, ...(appIconUrl(platformHost, slug) ? { icon: appIconUrl(platformHost, slug)! } : {}) });

--- a/desktop/src/renderer/src/features/embeds/AppLauncher.tsx
+++ b/desktop/src/renderer/src/features/embeds/AppLauncher.tsx
@@ -45,7 +45,6 @@ export default function AppLauncher() {
   const [query, setQuery] = useState("");
   const [active, setActive] = useState(0);
   const inputRef = useRef<HTMLInputElement>(null);
-  const previousQueryRef = useRef(query);
 
   useEffect(() => {
     if (api) void load(api);
@@ -62,15 +61,7 @@ export default function AppLauncher() {
     return apps.filter((a) => a.name.toLowerCase().includes(q) || a.slug.toLowerCase().includes(q));
   }, [apps, query]);
 
-  // Keep the highlighted index in range as the filter changes.
-  useEffect(() => {
-    if (previousQueryRef.current !== query) {
-      previousQueryRef.current = query;
-      setActive(0);
-      return;
-    }
-    setActive((i) => (i >= filtered.length ? 0 : i));
-  }, [filtered.length, query]);
+  const activeIndex = filtered.length === 0 ? 0 : Math.min(active, filtered.length - 1);
 
   const open = (slug: string, name: string) =>
     openTab({ kind: "app", slug, title: name, ...(appIconUrl(platformHost, slug) ? { icon: appIconUrl(platformHost, slug)! } : {}) });
@@ -85,7 +76,7 @@ export default function AppLauncher() {
       setActive((i) => (i - 1 + filtered.length) % filtered.length);
     } else if (e.key === "Enter") {
       e.preventDefault();
-      const app = filtered[active];
+      const app = filtered[activeIndex];
       if (app) open(app.slug, app.name);
     }
   };
@@ -128,7 +119,10 @@ export default function AppLauncher() {
           <input
             ref={inputRef}
             value={query}
-            onChange={(e) => setQuery(e.target.value)}
+            onChange={(e) => {
+              setQuery(e.target.value);
+              setActive(0);
+            }}
             onKeyDown={onKeyDown}
             placeholder="Search apps…"
             aria-label="Search apps"
@@ -143,7 +137,7 @@ export default function AppLauncher() {
         ) : (
           <div className="grid grid-cols-[repeat(auto-fill,minmax(124px,1fr))] gap-3">
             {filtered.map((app, i) => {
-              const highlighted = i === active;
+              const highlighted = i === activeIndex;
               return (
                 <button
                   key={app.slug}

--- a/desktop/src/renderer/src/features/embeds/AppLauncher.tsx
+++ b/desktop/src/renderer/src/features/embeds/AppLauncher.tsx
@@ -108,6 +108,16 @@ export default function AppLauncher() {
     );
   }
 
+  if (!loaded && apps.length === 0) {
+    return (
+      <EmptyState
+        icon={<LayoutGrid size={26} />}
+        headline="Loading apps"
+        description="The app catalog will appear here once your computer responds."
+      />
+    );
+  }
+
   return (
     <div className="flex flex-1 flex-col overflow-hidden">
       <div className="shrink-0 px-6 pt-6 pb-3">

--- a/desktop/src/renderer/src/features/embeds/AppLauncher.tsx
+++ b/desktop/src/renderer/src/features/embeds/AppLauncher.tsx
@@ -1,58 +1,58 @@
-import { LayoutGrid } from "lucide-react";
-import { useEffect, useState } from "react";
+import { LayoutGrid, Search } from "lucide-react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { EmptyState } from "../../design/primitives";
+import { useApps } from "../../stores/apps";
 import { useConnection } from "../../stores/connection";
 import { useTabs } from "../../stores/tabs";
-
-interface MatrixApp {
-  slug: string;
-  name: string;
-  icon?: string;
-  category?: string;
-}
-
-function parseApps(value: unknown): MatrixApp[] {
-  const list = Array.isArray(value)
-    ? value
-    : value && typeof value === "object" && Array.isArray((value as { apps?: unknown }).apps)
-      ? (value as { apps: unknown[] }).apps
-      : [];
-  const apps: MatrixApp[] = [];
-  for (const raw of list.slice(0, 200)) {
-    if (!raw || typeof raw !== "object") continue;
-    const app = raw as Partial<MatrixApp>;
-    if (typeof app.slug !== "string" || app.slug.trim().length === 0) continue;
-    const slug = app.slug.trim();
-    const name = typeof app.name === "string" && app.name.trim().length > 0 ? app.name.trim() : slug;
-    const category =
-      typeof app.category === "string" && app.category.trim().length > 0 ? app.category.trim() : undefined;
-    apps.push({ slug, name, category });
-  }
-  return apps;
-}
 
 export default function AppLauncher() {
   const api = useConnection((s) => s.api);
   const openTab = useTabs((s) => s.openTab);
-  const [apps, setApps] = useState<MatrixApp[] | null>(null);
+  const apps = useApps((s) => s.apps);
+  const loaded = useApps((s) => s.loaded);
+  const load = useApps((s) => s.load);
+  const [query, setQuery] = useState("");
+  const [active, setActive] = useState(0);
+  const inputRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
-    if (!api) return;
-    let cancelled = false;
-    api
-      .get<unknown>("/api/apps")
-      .then((res) => {
-        if (!cancelled) setApps(parseApps(res));
-      })
-      .catch(() => {
-        if (!cancelled) setApps([]);
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, [api]);
+    if (api) void load(api);
+  }, [api, load]);
 
-  if (apps && apps.length === 0) {
+  // Launcher behavior: focus the search immediately like a desktop launcher.
+  useEffect(() => {
+    inputRef.current?.focus();
+  }, []);
+
+  const filtered = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    if (!q) return apps;
+    return apps.filter((a) => a.name.toLowerCase().includes(q) || a.slug.toLowerCase().includes(q));
+  }, [apps, query]);
+
+  // Keep the highlighted index in range as the filter changes.
+  useEffect(() => {
+    setActive((i) => (i >= filtered.length ? 0 : i));
+  }, [filtered.length]);
+
+  const open = (slug: string, name: string) => openTab({ kind: "app", slug, title: name });
+
+  const onKeyDown = (e: React.KeyboardEvent) => {
+    if (filtered.length === 0) return;
+    if (e.key === "ArrowDown" || (e.key === "Tab" && !e.shiftKey)) {
+      e.preventDefault();
+      setActive((i) => (i + 1) % filtered.length);
+    } else if (e.key === "ArrowUp" || (e.key === "Tab" && e.shiftKey)) {
+      e.preventDefault();
+      setActive((i) => (i - 1 + filtered.length) % filtered.length);
+    } else if (e.key === "Enter") {
+      e.preventDefault();
+      const app = filtered[active];
+      if (app) open(app.slug, app.name);
+    }
+  };
+
+  if (loaded && apps.length === 0) {
     return (
       <EmptyState
         icon={<LayoutGrid size={26} />}
@@ -63,28 +63,58 @@ export default function AppLauncher() {
   }
 
   return (
-    <div className="flex flex-1 flex-col gap-4 overflow-y-auto p-6">
-      <h2 className="text-lg font-semibold" style={{ color: "var(--text-primary)" }}>Apps</h2>
-      <div className="grid grid-cols-[repeat(auto-fill,minmax(124px,1fr))] gap-3">
-        {(apps ?? []).map((app) => (
-          <button
-            key={app.slug}
-            type="button"
-            className="flex flex-col items-center gap-2 rounded-xl border p-4 transition-colors duration-100 hover:border-[var(--border-strong)]"
-            style={{ background: "var(--bg-surface)", borderColor: "var(--border-subtle)" }}
-            onClick={() => openTab({ kind: "app", slug: app.slug, title: app.name })}
-          >
-            <div
-              className="flex h-11 w-11 items-center justify-center rounded-xl text-lg font-semibold"
-              style={{ background: "var(--accent-muted)", color: "var(--accent)" }}
-            >
-              {app.name.charAt(0).toUpperCase()}
-            </div>
-            <span className="w-full truncate text-center text-sm" style={{ color: "var(--text-primary)" }}>
-              {app.name}
-            </span>
-          </button>
-        ))}
+    <div className="flex flex-1 flex-col overflow-hidden">
+      <div className="shrink-0 px-6 pt-6 pb-3">
+        <div
+          className="prompt-card flex items-center gap-2 rounded-xl border px-3"
+          style={{ background: "var(--bg-surface)" }}
+        >
+          <Search size={15} style={{ color: "var(--text-tertiary)" }} />
+          <input
+            ref={inputRef}
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            onKeyDown={onKeyDown}
+            placeholder="Search apps…"
+            aria-label="Search apps"
+            className="h-11 w-full bg-transparent text-md outline-none"
+            style={{ color: "var(--text-primary)" }}
+          />
+        </div>
+      </div>
+      <div className="flex flex-1 flex-col gap-4 overflow-y-auto px-6 pb-6">
+        {filtered.length === 0 ? (
+          <p className="px-1 text-sm" style={{ color: "var(--text-tertiary)" }}>No apps match “{query}”.</p>
+        ) : (
+          <div className="grid grid-cols-[repeat(auto-fill,minmax(124px,1fr))] gap-3">
+            {filtered.map((app, i) => {
+              const highlighted = i === active;
+              return (
+                <button
+                  key={app.slug}
+                  type="button"
+                  className="flex flex-col items-center gap-2 rounded-xl border p-4 transition-colors duration-100"
+                  style={{
+                    background: highlighted ? "var(--bg-selected)" : "var(--bg-surface)",
+                    borderColor: highlighted ? "var(--accent)" : "var(--border-subtle)",
+                  }}
+                  onMouseEnter={() => setActive(i)}
+                  onClick={() => open(app.slug, app.name)}
+                >
+                  <div
+                    className="flex h-11 w-11 items-center justify-center rounded-xl text-lg font-semibold"
+                    style={{ background: "var(--accent-muted)", color: "var(--accent)" }}
+                  >
+                    {app.name.charAt(0).toUpperCase()}
+                  </div>
+                  <span className="w-full truncate text-center text-sm" style={{ color: "var(--text-primary)" }}>
+                    {app.name}
+                  </span>
+                </button>
+              );
+            })}
+          </div>
+        )}
       </div>
     </div>
   );

--- a/desktop/src/renderer/src/features/files/FilesPanel.tsx
+++ b/desktop/src/renderer/src/features/files/FilesPanel.tsx
@@ -1,61 +1,28 @@
 import { ChevronDown, ChevronRight, File, Folder, RefreshCw } from "lucide-react";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect } from "react";
 import { IconButton } from "../../design/primitives";
 import { useConnection } from "../../stores/connection";
+import { useFileTree, type FileEntry } from "../../stores/file-tree";
 import { useWorkspace } from "../../stores/workspace";
 import { useEditorTabs } from "../editor/editor-tabs-store";
-
-interface Entry {
-  name: string;
-  type: "file" | "directory";
-}
-
-function parseEntries(value: unknown): Entry[] {
-  if (!Array.isArray(value)) return [];
-  const entries: Entry[] = [];
-  for (const raw of value.slice(0, 500)) {
-    if (
-      raw &&
-      typeof raw === "object" &&
-      typeof (raw as Entry).name === "string" &&
-      ((raw as Entry).type === "file" || (raw as Entry).type === "directory")
-    ) {
-      entries.push({ name: (raw as Entry).name, type: (raw as Entry).type });
-    }
-  }
-  return entries.sort((a, b) =>
-    a.type === b.type ? a.name.localeCompare(b.name) : a.type === "directory" ? -1 : 1,
-  );
-}
 
 function TreeNode({
   path,
   name,
   depth,
+  activePath,
   onOpenFile,
 }: {
   path: string;
   name: string;
   depth: number;
+  activePath: string | null;
   onOpenFile: (path: string) => void;
 }) {
   const api = useConnection((s) => s.api);
-  const [expanded, setExpanded] = useState(false);
-  const [children, setChildren] = useState<Entry[] | null>(null);
-
-  const toggle = useCallback(() => {
-    setExpanded((prev) => !prev);
-    if (!children && api) {
-      api
-        .get<{ entries: unknown }>(`/api/files/list?path=${encodeURIComponent(path)}`)
-        .then((res) => setChildren(parseEntries(res.entries)))
-        .catch((err: unknown) => {
-          console.warn("[files] list failed:", err instanceof Error ? err.message : String(err));
-          setChildren(null);
-          setExpanded(false);
-        });
-    }
-  }, [api, children, path]);
+  const expanded = useFileTree((s) => s.expanded[path] ?? false);
+  const children = useFileTree((s) => s.childrenByPath[path]);
+  const toggle = useFileTree((s) => s.toggle);
 
   return (
     <>
@@ -63,7 +30,9 @@ function TreeNode({
         type="button"
         className="flex w-full items-center gap-1.5 rounded px-1.5 py-1 text-left text-sm hover:bg-[var(--bg-hover)]"
         style={{ paddingLeft: 6 + depth * 14, color: "var(--text-secondary)" }}
-        onClick={toggle}
+        onClick={() => {
+          if (api) void toggle(api, path);
+        }}
       >
         {expanded ? <ChevronDown size={12} /> : <ChevronRight size={12} />}
         <Folder size={13} style={{ color: "var(--text-tertiary)" }} />
@@ -80,19 +49,18 @@ function TreeNode({
                 path={childPath}
                 name={entry.name}
                 depth={depth + 1}
+                activePath={activePath}
                 onOpenFile={onOpenFile}
               />
             ) : (
-              <button
+              <FileRow
                 key={childPath}
-                type="button"
-                className="flex w-full items-center gap-1.5 rounded px-1.5 py-1 text-left text-sm hover:bg-[var(--bg-hover)]"
-                style={{ paddingLeft: 6 + (depth + 1) * 14 + 14, color: "var(--text-secondary)" }}
-                onClick={() => onOpenFile(childPath)}
-              >
-                <File size={13} style={{ color: "var(--text-tertiary)" }} />
-                <span className="truncate">{entry.name}</span>
-              </button>
+                path={childPath}
+                name={entry.name}
+                depth={depth + 1}
+                active={childPath === activePath}
+                onOpenFile={onOpenFile}
+              />
             );
           })
         : null}
@@ -100,25 +68,52 @@ function TreeNode({
   );
 }
 
+function FileRow({
+  path,
+  name,
+  depth,
+  active,
+  onOpenFile,
+}: {
+  path: string;
+  name: string;
+  depth: number;
+  active: boolean;
+  onOpenFile: (path: string) => void;
+}) {
+  return (
+    <button
+      type="button"
+      className="flex w-full items-center gap-1.5 rounded px-1.5 py-1 text-left text-sm"
+      style={{
+        paddingLeft: 6 + depth * 14 + 14,
+        background: active ? "var(--bg-selected)" : "transparent",
+        color: active ? "var(--text-primary)" : "var(--text-secondary)",
+      }}
+      onMouseEnter={(e) => { if (!active) e.currentTarget.style.background = "var(--bg-hover)"; }}
+      onMouseLeave={(e) => { if (!active) e.currentTarget.style.background = "transparent"; }}
+      onClick={() => onOpenFile(path)}
+    >
+      <File size={13} style={{ color: "var(--text-tertiary)" }} />
+      <span className="truncate">{name}</span>
+    </button>
+  );
+}
+
 export default function FilesPanel({ taskId }: { taskId: string }) {
   const api = useConnection((s) => s.api);
   const openTab = useEditorTabs((s) => s.openTab);
-  const [roots, setRoots] = useState<Entry[] | null>(null);
-
-  const loadRoots = useCallback(() => {
-    if (!api) return;
-    api
-      .get<{ entries: unknown }>(`/api/files/list?path=${encodeURIComponent("")}`)
-      .then((res) => setRoots(parseEntries(res.entries)))
-      .catch((err: unknown) => {
-        console.warn("[files] root list failed:", err instanceof Error ? err.message : String(err));
-        setRoots(null);
-      });
-  }, [api]);
+  const activePath = useEditorTabs((s) => s.activePathByTask[taskId] ?? null);
+  const roots = useFileTree((s) => s.roots);
+  const loadRoots = useFileTree((s) => s.loadRoots);
 
   useEffect(() => {
-    if (roots === null) loadRoots();
-  }, [loadRoots, roots]);
+    if (api) void loadRoots(api);
+  }, [api, loadRoots]);
+
+  const refresh = useCallback(() => {
+    if (api) void loadRoots(api, true);
+  }, [api, loadRoots]);
 
   const onOpenFile = useCallback(
     (path: string) => {
@@ -137,24 +132,15 @@ export default function FilesPanel({ taskId }: { taskId: string }) {
         <span className="text-xs font-semibold tracking-wide uppercase" style={{ color: "var(--text-tertiary)" }}>
           Files
         </span>
-        <IconButton label="Refresh files" onClick={loadRoots}>
+        <IconButton label="Refresh files" onClick={refresh}>
           <RefreshCw size={12} />
         </IconButton>
       </div>
-      {roots?.map((entry) =>
+      {roots?.map((entry: FileEntry) =>
         entry.type === "directory" ? (
-          <TreeNode key={entry.name} path={entry.name} name={entry.name} depth={0} onOpenFile={onOpenFile} />
+          <TreeNode key={entry.name} path={entry.name} name={entry.name} depth={0} activePath={activePath} onOpenFile={onOpenFile} />
         ) : (
-          <button
-            key={entry.name}
-            type="button"
-            className="flex w-full items-center gap-1.5 rounded px-1.5 py-1 text-left text-sm hover:bg-[var(--bg-hover)]"
-            style={{ paddingLeft: 20, color: "var(--text-secondary)" }}
-            onClick={() => onOpenFile(entry.name)}
-          >
-            <File size={13} style={{ color: "var(--text-tertiary)" }} />
-            <span className="truncate">{entry.name}</span>
-          </button>
+          <FileRow key={entry.name} path={entry.name} name={entry.name} depth={0} active={entry.name === activePath} onOpenFile={onOpenFile} />
         ),
       )}
     </div>

--- a/desktop/src/renderer/src/features/mission-control/TabBar.tsx
+++ b/desktop/src/renderer/src/features/mission-control/TabBar.tsx
@@ -10,6 +10,7 @@ import {
   X,
   type LucideIcon,
 } from "lucide-react";
+import { useRef, useState } from "react";
 import { useTabs, type Tab, type TabKind } from "../../stores/tabs";
 
 const TAB_ICON: Record<TabKind, LucideIcon> = {
@@ -26,10 +27,32 @@ const TAB_ICON: Record<TabKind, LucideIcon> = {
   settings: Settings,
 };
 
+function TabIcon({ tab, active }: { tab: Tab; active: boolean }) {
+  const Icon = TAB_ICON[tab.kind];
+  const iconUrl = tab.icon && /^https?:\/\//.test(tab.icon) ? tab.icon : null;
+  const [failed, setFailed] = useState(false);
+  const prev = useRef<string | null>(null);
+  if (prev.current !== iconUrl) {
+    prev.current = iconUrl;
+    if (failed) setFailed(false);
+  }
+  if (iconUrl && !failed) {
+    return (
+      <img
+        src={iconUrl}
+        alt=""
+        className="h-3.5 w-3.5 shrink-0 rounded-sm object-cover"
+        referrerPolicy="no-referrer"
+        onError={() => setFailed(true)}
+      />
+    );
+  }
+  return <Icon size={13} style={{ color: active ? "var(--accent)" : "var(--text-tertiary)", flexShrink: 0 }} />;
+}
+
 function TabChip({ tab, active }: { tab: Tab; active: boolean }) {
   const focusTab = useTabs((s) => s.focusTab);
   const closeTab = useTabs((s) => s.closeTab);
-  const Icon = TAB_ICON[tab.kind];
 
   return (
     <div
@@ -57,7 +80,7 @@ function TabChip({ tab, active }: { tab: Tab; active: boolean }) {
         if (!active) e.currentTarget.style.background = "transparent";
       }}
     >
-      <Icon size={13} style={{ color: active ? "var(--accent)" : "var(--text-tertiary)", flexShrink: 0 }} />
+      <TabIcon tab={tab} active={active} />
       <span className="min-w-0 flex-1 truncate">{tab.title}</span>
       {tab.closable ? (
         <button

--- a/desktop/src/renderer/src/features/mission-control/TabContent.tsx
+++ b/desktop/src/renderer/src/features/mission-control/TabContent.tsx
@@ -78,6 +78,7 @@ export default function TabContent() {
             className="absolute inset-0 flex min-h-0 flex-col"
             style={{ visibility: active ? "visible" : "hidden", zIndex: active ? 1 : 0 }}
             aria-hidden={!active}
+            // `inert` keeps keyboard focus out of cached-but-hidden panes.
             inert={!active}
           >
             <TabPane tab={tab} active={paneActive} />

--- a/desktop/src/renderer/src/features/palette/CommandPalette.tsx
+++ b/desktop/src/renderer/src/features/palette/CommandPalette.tsx
@@ -1,7 +1,7 @@
 import { Command } from "cmdk";
 import { useEffect } from "react";
 import { Home, Kanban, LayoutGrid, MessageSquarePlus, PanelsTopLeft, Plus, Settings, SquareTerminal } from "lucide-react";
-import { useApps } from "../../stores/apps";
+import { appIconUrl, useApps } from "../../stores/apps";
 import { useBoard } from "../../stores/board";
 import { useConnection } from "../../stores/connection";
 import { useSessions } from "../../stores/sessions";
@@ -24,6 +24,7 @@ export default function CommandPalette() {
   const apps = useApps((s) => s.apps);
   const loadApps = useApps((s) => s.load);
   const api = useConnection((s) => s.api);
+  const platformHost = useConnection((s) => s.platformHost);
 
   // Make sure apps are available the first time the palette opens.
   useEffect(() => {
@@ -134,7 +135,7 @@ export default function CommandPalette() {
                   key={app.slug}
                   icon={<LayoutGrid size={14} />}
                   label={app.name}
-                  onSelect={() => run(() => openTab({ kind: "app", slug: app.slug, title: app.name }))}
+                  onSelect={() => run(() => openTab({ kind: "app", slug: app.slug, title: app.name, ...(appIconUrl(platformHost, app.slug) ? { icon: appIconUrl(platformHost, app.slug)! } : {}) }))}
                 />
               ))}
             </Command.Group>

--- a/desktop/src/renderer/src/features/palette/CommandPalette.tsx
+++ b/desktop/src/renderer/src/features/palette/CommandPalette.tsx
@@ -1,6 +1,9 @@
 import { Command } from "cmdk";
-import { Home, Kanban, MessageSquarePlus, Plus, Settings, SquareTerminal } from "lucide-react";
+import { useEffect } from "react";
+import { Home, Kanban, LayoutGrid, MessageSquarePlus, PanelsTopLeft, Plus, Settings, SquareTerminal } from "lucide-react";
+import { useApps } from "../../stores/apps";
 import { useBoard } from "../../stores/board";
+import { useConnection } from "../../stores/connection";
 import { useSessions } from "../../stores/sessions";
 import { useTabs } from "../../stores/tabs";
 import { useUi } from "../../stores/ui";
@@ -9,16 +12,28 @@ export default function CommandPalette() {
   const open = useUi((s) => s.paletteOpen);
   const setOpen = useUi((s) => s.setPaletteOpen);
   const openTab = useTabs((s) => s.openTab);
+  const focusTab = useTabs((s) => s.focusTab);
+  const tabs = useTabs((s) => s.tabs);
+  const activeTabId = useTabs((s) => s.activeTabId);
   const setCreateTaskOpen = useUi((s) => s.setCreateTaskOpen);
   const setComposerOpen = useUi((s) => s.setComposerOpen);
   const activeSlug = useBoard((s) => s.activeProjectSlug);
   const projects = useBoard((s) => s.projects);
   const cardsByProject = useBoard((s) => s.cardsByProject);
   const sessions = useSessions((s) => s.sessions);
+  const apps = useApps((s) => s.apps);
+  const loadApps = useApps((s) => s.load);
+  const api = useConnection((s) => s.api);
+
+  // Make sure apps are available the first time the palette opens.
+  useEffect(() => {
+    if (open && api) void loadApps(api);
+  }, [open, api, loadApps]);
 
   if (!open) return null;
 
   const cards = activeSlug ? (cardsByProject[activeSlug] ?? []) : [];
+  const otherTabs = tabs.filter((t) => t.id !== activeTabId);
 
   const run = (fn: () => void) => {
     setOpen(false);
@@ -107,6 +122,32 @@ export default function CommandPalette() {
                   onSelect={() =>
                     run(() => openTab({ kind: "terminal", sessionName: session.attachName, title: session.name }))
                   }
+                />
+              ))}
+            </Command.Group>
+          ) : null}
+
+          {apps.length > 0 ? (
+            <Command.Group heading="Apps" style={{ color: "var(--text-tertiary)" }}>
+              {apps.slice(0, 30).map((app) => (
+                <PaletteItem
+                  key={app.slug}
+                  icon={<LayoutGrid size={14} />}
+                  label={app.name}
+                  onSelect={() => run(() => openTab({ kind: "app", slug: app.slug, title: app.name }))}
+                />
+              ))}
+            </Command.Group>
+          ) : null}
+
+          {otherTabs.length > 0 ? (
+            <Command.Group heading="Open tabs" style={{ color: "var(--text-tertiary)" }}>
+              {otherTabs.map((tab) => (
+                <PaletteItem
+                  key={tab.id}
+                  icon={<PanelsTopLeft size={14} />}
+                  label={tab.title}
+                  onSelect={() => run(() => focusTab(tab.id))}
                 />
               ))}
             </Command.Group>

--- a/desktop/src/renderer/src/features/palette/CommandPalette.tsx
+++ b/desktop/src/renderer/src/features/palette/CommandPalette.tsx
@@ -22,14 +22,15 @@ export default function CommandPalette() {
   const cardsByProject = useBoard((s) => s.cardsByProject);
   const sessions = useSessions((s) => s.sessions);
   const apps = useApps((s) => s.apps);
+  const appsError = useApps((s) => s.error);
   const loadApps = useApps((s) => s.load);
   const api = useConnection((s) => s.api);
   const platformHost = useConnection((s) => s.platformHost);
 
   // Make sure apps are available the first time the palette opens.
   useEffect(() => {
-    if (open && api) void loadApps(api);
-  }, [open, api, loadApps]);
+    if (open && api) void loadApps(api, Boolean(appsError));
+  }, [open, api, appsError, loadApps]);
 
   if (!open) return null;
 

--- a/desktop/src/renderer/src/features/workspace/StartSessionControls.tsx
+++ b/desktop/src/renderer/src/features/workspace/StartSessionControls.tsx
@@ -48,7 +48,6 @@ export default function StartSessionControls({
 }) {
   const api = useConnection((s) => s.api);
   const creating = useSessions((s) => s.creating);
-  const createError = useSessions((s) => s.createError);
   const [error, setError] = useState<string | null>(null);
   const [pending, setPending] = useState<string | null>(null);
 
@@ -76,7 +75,7 @@ export default function StartSessionControls({
     }
   };
 
-  const shownError = error ?? createError;
+  const shownError = error;
   const errorLabel = startSessionErrorLabel(shownError, compact);
 
   return (

--- a/desktop/src/renderer/src/features/workspace/StartSessionControls.tsx
+++ b/desktop/src/renderer/src/features/workspace/StartSessionControls.tsx
@@ -48,15 +48,17 @@ export default function StartSessionControls({
 }) {
   const api = useConnection((s) => s.api);
   const creating = useSessions((s) => s.creating);
+  const createError = useSessions((s) => s.createError);
   const [error, setError] = useState<string | null>(null);
   const [pending, setPending] = useState<string | null>(null);
-  const errorLabel = startSessionErrorLabel(error, compact);
 
   const launch = async (l: Launch) => {
     if (!api || pending) return;
     setPending(l.label);
     setError(null);
     try {
+      // The sessions store sets a specific `createError` on failure (mapped
+      // from the gateway's reason code); fall back to a generic line.
       const ok = await startTaskSession(api, {
         projectSlug,
         taskId,
@@ -66,13 +68,16 @@ export default function StartSessionControls({
         kind: l.kind,
         ...(l.kind === "agent" ? { agent: l.agent } : {}),
       });
-      if (!ok) setError("Couldn't start the session. Check that the agent is connected.");
+      if (!ok) setError(useSessions.getState().createError ?? "Couldn't start the session.");
     } catch (err: unknown) {
       setError(toUserMessage(err));
     } finally {
       setPending(null);
     }
   };
+
+  const shownError = error ?? createError;
+  const errorLabel = startSessionErrorLabel(shownError, compact);
 
   return (
     <div className={compact ? "flex items-center gap-1.5" : "flex flex-col items-center gap-2"}>
@@ -101,7 +106,7 @@ export default function StartSessionControls({
               : "flex items-center gap-1 text-xs"
           }
           style={{ color: "var(--danger)" }}
-          title={compact ? error ?? undefined : undefined}
+          title={compact ? shownError ?? undefined : undefined}
           aria-live="polite"
         >
           <AlertCircle size={12} className="shrink-0" />

--- a/desktop/src/renderer/src/lib/api.ts
+++ b/desktop/src/renderer/src/lib/api.ts
@@ -1,7 +1,7 @@
 // Typed gateway client (contracts/gateway-contract.md). Auth rides the
 // Authorization header injected by the trusted core at the network layer —
 // this module never sees the credential. Every call has a timeout.
-import { AppError, classifyHttpStatus, classifyTransportError } from "../../../shared/app-error";
+import { AppError, classifyHttpStatus, classifyTransportError, safeErrorDetail } from "../../../shared/app-error";
 
 const API_TIMEOUT_MS = 10_000;
 
@@ -50,7 +50,17 @@ export function createApiClient(options: ApiClientOptions): ApiClient {
     }
     if (!response.ok) {
       if (response.status === 401) options.onUnauthorized?.();
-      throw new AppError(classifyHttpStatus(response.status));
+      // Extract the gateway's safe error CODE (e.g. invalid_session_request) so
+      // callers can surface a specific reason instead of only the generic copy.
+      let detail: string | undefined;
+      try {
+        const body = (await response.clone().json()) as { error?: unknown };
+        const err = body.error;
+        detail = safeErrorDetail(typeof err === "object" && err ? (err as { code?: unknown }).code : err);
+      } catch {
+        // Non-JSON / empty body — no detail to surface.
+      }
+      throw new AppError(classifyHttpStatus(response.status), detail ? { detail } : undefined);
     }
     return response;
   }

--- a/desktop/src/renderer/src/stores/apps.ts
+++ b/desktop/src/renderer/src/stores/apps.ts
@@ -1,0 +1,58 @@
+// Installed Matrix OS apps (GET /api/apps). Loaded lazily and shared by the
+// Apps launcher and the command palette so both list the same set.
+import { create } from "zustand";
+import { AppError, type AppErrorCategory } from "../../../shared/app-error";
+import type { ApiClient } from "../lib/api";
+
+export interface MatrixApp {
+  slug: string;
+  name: string;
+  category?: string;
+}
+
+export function parseApps(value: unknown): MatrixApp[] {
+  const list = Array.isArray(value)
+    ? value
+    : value && typeof value === "object" && Array.isArray((value as { apps?: unknown }).apps)
+      ? (value as { apps: unknown[] }).apps
+      : [];
+  const apps: MatrixApp[] = [];
+  for (const raw of list.slice(0, 200)) {
+    if (!raw || typeof raw !== "object") continue;
+    const app = raw as Partial<MatrixApp>;
+    if (typeof app.slug !== "string" || app.slug.trim().length === 0) continue;
+    const slug = app.slug.trim();
+    const name = typeof app.name === "string" && app.name.trim().length > 0 ? app.name.trim() : slug;
+    const category =
+      typeof app.category === "string" && app.category.trim().length > 0 ? app.category.trim() : undefined;
+    apps.push({ slug, name, category });
+  }
+  return apps;
+}
+
+interface AppsState {
+  apps: MatrixApp[];
+  loaded: boolean;
+  loading: boolean;
+  error: AppErrorCategory | null;
+  load(api: ApiClient, force?: boolean): Promise<void>;
+}
+
+export const useApps = create<AppsState>()((set, get) => ({
+  apps: [],
+  loaded: false,
+  loading: false,
+  error: null,
+
+  load: async (api, force = false) => {
+    if (get().loading) return;
+    if (get().loaded && !force) return;
+    set({ loading: true });
+    try {
+      const res = await api.get<unknown>("/api/apps");
+      set({ apps: parseApps(res), loaded: true, loading: false, error: null });
+    } catch (err: unknown) {
+      set({ loading: false, loaded: true, error: err instanceof AppError ? err.category : "server" });
+    }
+  },
+}));

--- a/desktop/src/renderer/src/stores/apps.ts
+++ b/desktop/src/renderer/src/stores/apps.ts
@@ -10,6 +10,14 @@ export interface MatrixApp {
   category?: string;
 }
 
+// Apps resolve their icon through the gateway's /icons/{slug}.png, which falls
+// back to shipped assets. Bearer auth is injected by the trusted core for the
+// gateway origin, so the renderer can load it directly.
+export function appIconUrl(platformHost: string, slug: string): string | null {
+  if (!platformHost) return null;
+  return `${platformHost.replace(/\/$/, "")}/icons/${encodeURIComponent(slug)}.png`;
+}
+
 export function parseApps(value: unknown): MatrixApp[] {
   const list = Array.isArray(value)
     ? value

--- a/desktop/src/renderer/src/stores/file-tree.ts
+++ b/desktop/src/renderer/src/stores/file-tree.ts
@@ -1,0 +1,81 @@
+// Persistent file-tree state (roots, lazily-loaded children, expansion) for the
+// VPS home. Lives in a store rather than component state so opening a file —
+// which can remount the Files panel when the editor panel appears — never
+// collapses the tree or drops loaded directories.
+import { create } from "zustand";
+import type { ApiClient } from "../lib/api";
+
+export interface FileEntry {
+  name: string;
+  type: "file" | "directory";
+}
+
+export function parseEntries(value: unknown): FileEntry[] {
+  if (!Array.isArray(value)) return [];
+  const entries: FileEntry[] = [];
+  for (const raw of value.slice(0, 1000)) {
+    if (
+      raw &&
+      typeof raw === "object" &&
+      typeof (raw as FileEntry).name === "string" &&
+      ((raw as FileEntry).type === "file" || (raw as FileEntry).type === "directory")
+    ) {
+      entries.push({ name: (raw as FileEntry).name, type: (raw as FileEntry).type });
+    }
+  }
+  return entries.sort((a, b) =>
+    a.type === b.type ? a.name.localeCompare(b.name) : a.type === "directory" ? -1 : 1,
+  );
+}
+
+interface FileTreeState {
+  roots: FileEntry[] | null;
+  childrenByPath: Record<string, FileEntry[]>;
+  expanded: Record<string, boolean>;
+  loadRoots(api: ApiClient, force?: boolean): Promise<void>;
+  toggle(api: ApiClient, path: string): Promise<void>;
+}
+
+async function listDir(api: ApiClient, path: string): Promise<FileEntry[]> {
+  const res = await api.get<{ entries: unknown }>(`/api/files/list?path=${encodeURIComponent(path)}`);
+  return parseEntries(res.entries);
+}
+
+export const useFileTree = create<FileTreeState>()((set, get) => ({
+  roots: null,
+  childrenByPath: {},
+  expanded: {},
+
+  loadRoots: async (api, force = false) => {
+    if (get().roots !== null && !force) return;
+    try {
+      const roots = await listDir(api, "");
+      set({ roots });
+    } catch (err: unknown) {
+      console.warn("[files] root list failed:", err instanceof Error ? err.message : String(err));
+      set({ roots: null });
+    }
+  },
+
+  toggle: async (api, path) => {
+    const open = !get().expanded[path];
+    set((s) => ({ expanded: { ...s.expanded, [path]: open } }));
+    // Lazy-load children once, then keep them cached across collapse/expand.
+    if (open && get().childrenByPath[path] === undefined) {
+      try {
+        const children = await listDir(api, path);
+        set((s) => ({ childrenByPath: { ...s.childrenByPath, [path]: children } }));
+      } catch (err: unknown) {
+        console.warn("[files] list failed:", err instanceof Error ? err.message : String(err));
+        set((s) => {
+          const childrenByPath = { ...s.childrenByPath };
+          delete childrenByPath[path];
+          return {
+            childrenByPath,
+            expanded: { ...s.expanded, [path]: false },
+          };
+        });
+      }
+    }
+  },
+}));

--- a/desktop/src/renderer/src/stores/file-tree.ts
+++ b/desktop/src/renderer/src/stores/file-tree.ts
@@ -53,7 +53,11 @@ export const useFileTree = create<FileTreeState>()((set, get) => ({
   loadRoots: async (api, force = false) => {
     if (get().roots !== null && !force) return;
     if (get().loadingRoots) return;
-    set({ loadingRoots: true });
+    set(
+      force
+        ? { roots: null, childrenByPath: {}, expanded: {}, loadingPaths: {}, loadingRoots: true }
+        : { loadingRoots: true },
+    );
     try {
       const roots = await listDir(api, "");
       set({ roots, loadingRoots: false });

--- a/desktop/src/renderer/src/stores/file-tree.ts
+++ b/desktop/src/renderer/src/stores/file-tree.ts
@@ -76,10 +76,13 @@ export const useFileTree = create<FileTreeState>()((set, get) => ({
       set((s) => ({ loadingPaths: { ...s.loadingPaths, [path]: true } }));
       try {
         const children = await listDir(api, path);
-        set((s) => ({
-          childrenByPath: { ...s.childrenByPath, [path]: children },
-          loadingPaths: { ...s.loadingPaths, [path]: false },
-        }));
+        set((s) => {
+          if (!s.loadingPaths[path]) return s;
+          return {
+            childrenByPath: { ...s.childrenByPath, [path]: children },
+            loadingPaths: { ...s.loadingPaths, [path]: false },
+          };
+        });
       } catch (err: unknown) {
         console.warn("[files] list failed:", err instanceof Error ? err.message : String(err));
         set((s) => {

--- a/desktop/src/renderer/src/stores/file-tree.ts
+++ b/desktop/src/renderer/src/stores/file-tree.ts
@@ -32,6 +32,8 @@ interface FileTreeState {
   roots: FileEntry[] | null;
   childrenByPath: Record<string, FileEntry[]>;
   expanded: Record<string, boolean>;
+  loadingRoots: boolean;
+  loadingPaths: Record<string, boolean>;
   loadRoots(api: ApiClient, force?: boolean): Promise<void>;
   toggle(api: ApiClient, path: string): Promise<void>;
 }
@@ -45,15 +47,19 @@ export const useFileTree = create<FileTreeState>()((set, get) => ({
   roots: null,
   childrenByPath: {},
   expanded: {},
+  loadingRoots: false,
+  loadingPaths: {},
 
   loadRoots: async (api, force = false) => {
     if (get().roots !== null && !force) return;
+    if (get().loadingRoots) return;
+    set({ loadingRoots: true });
     try {
       const roots = await listDir(api, "");
-      set({ roots });
+      set({ roots, loadingRoots: false });
     } catch (err: unknown) {
       console.warn("[files] root list failed:", err instanceof Error ? err.message : String(err));
-      set({ roots: null });
+      set({ roots: null, loadingRoots: false });
     }
   },
 
@@ -62,9 +68,14 @@ export const useFileTree = create<FileTreeState>()((set, get) => ({
     set((s) => ({ expanded: { ...s.expanded, [path]: open } }));
     // Lazy-load children once, then keep them cached across collapse/expand.
     if (open && get().childrenByPath[path] === undefined) {
+      if (get().loadingPaths[path]) return;
+      set((s) => ({ loadingPaths: { ...s.loadingPaths, [path]: true } }));
       try {
         const children = await listDir(api, path);
-        set((s) => ({ childrenByPath: { ...s.childrenByPath, [path]: children } }));
+        set((s) => ({
+          childrenByPath: { ...s.childrenByPath, [path]: children },
+          loadingPaths: { ...s.loadingPaths, [path]: false },
+        }));
       } catch (err: unknown) {
         console.warn("[files] list failed:", err instanceof Error ? err.message : String(err));
         set((s) => {
@@ -73,6 +84,7 @@ export const useFileTree = create<FileTreeState>()((set, get) => ({
           return {
             childrenByPath,
             expanded: { ...s.expanded, [path]: false },
+            loadingPaths: { ...s.loadingPaths, [path]: false },
           };
         });
       }

--- a/desktop/src/renderer/src/stores/sessions.ts
+++ b/desktop/src/renderer/src/stores/sessions.ts
@@ -39,11 +39,37 @@ interface SessionsState {
   loading: boolean;
   creating: boolean;
   error: AppErrorCategory | null;
+  // A specific, user-facing reason the last create() failed (null when fine).
+  createError: string | null;
   load(api: ApiClient): Promise<void>;
   create(api: ApiClient, input?: SessionCreateInput): Promise<CreatedSession | null>;
   kill(api: ApiClient, attachName: string): Promise<boolean>;
   restart(api: ApiClient, attachName: string): Promise<CreatedSession | null>;
   resolveAttachName(linkedSessionId: string | null): string | null;
+}
+
+// Map the gateway's safe error code (AppError.detail) to a specific reason so
+// the user sees WHY a session couldn't start, not just a generic failure.
+function describeSessionError(err: unknown): string {
+  const detail = err instanceof AppError ? err.detail : undefined;
+  switch (detail) {
+    case "invalid_session_request":
+      return "Your computer rejected the session request.";
+    case "not_found":
+      return "The project or worktree wasn't found on your computer.";
+    case "worktree_locked":
+      return "That worktree is already in use by another session.";
+    case "sandbox_unavailable":
+      return "The coding agent's sandbox isn't available. Check that the agent is connected.";
+    case "runtime_unavailable":
+      return "The session runtime (zellij) isn't available right now.";
+    case "server_misconfigured":
+      return "Your computer isn't fully set up for cloud sessions yet.";
+    default:
+      if (err instanceof AppError && err.category === "unauthorized") return "Your session expired. Sign in again.";
+      if (err instanceof AppError && err.category === "offline") return "Can't reach your computer. Check your connection.";
+      return "Couldn't start the session. Check that your computer and agent are connected.";
+  }
 }
 
 function asArray<T>(value: unknown): T[] {
@@ -108,6 +134,7 @@ export const useSessions = create<SessionsState>()((set, get) => ({
   loading: false,
   creating: false,
   error: null,
+  createError: null,
 
   load: async (api) => {
     const sequence = ++loadSequence;
@@ -132,7 +159,7 @@ export const useSessions = create<SessionsState>()((set, get) => ({
   },
 
   create: async (api, input) => {
-    set({ creating: true, error: null });
+    set({ creating: true, error: null, createError: null });
     try {
       if (!input) {
         const name = nextSessionName();
@@ -191,6 +218,7 @@ export const useSessions = create<SessionsState>()((set, get) => ({
           loading: false,
           creating: false,
           error: null,
+          createError: null,
         });
       } else {
         set((state) => {
@@ -203,6 +231,7 @@ export const useSessions = create<SessionsState>()((set, get) => ({
             aliasMap: next.aliasMap,
             creating: false,
             error: null,
+            createError: null,
           };
         });
       }
@@ -213,7 +242,11 @@ export const useSessions = create<SessionsState>()((set, get) => ({
       };
     } catch (err: unknown) {
       console.error("[sessions] Failed to create session:", err);
-      set({ creating: false, error: err instanceof AppError ? err.category : "server" });
+      set({
+        creating: false,
+        error: err instanceof AppError ? err.category : "server",
+        createError: describeSessionError(err),
+      });
       return null;
     }
   },

--- a/desktop/src/renderer/src/stores/ui.ts
+++ b/desktop/src/renderer/src/stores/ui.ts
@@ -27,7 +27,7 @@ export const useUi = create<UiState>()((set) => ({
   paletteOpen: false,
   quickOpenOpen: false,
   sidebarCollapsed: false,
-  setCreateTaskOpen: (open) => set({ createTaskOpen: open }),
+  setCreateTaskOpen: (open) => set({ createTaskOpen: open, createTaskStatus: null }),
   openCreateTask: (status) => set({ createTaskOpen: true, createTaskStatus: status ?? null }),
   setComposerOpen: (open) => set({ composerOpen: open }),
   setPaletteOpen: (open) => set({ paletteOpen: open }),

--- a/desktop/src/renderer/src/stores/ui.ts
+++ b/desktop/src/renderer/src/stores/ui.ts
@@ -4,11 +4,15 @@ import { create } from "zustand";
 
 interface UiState {
   createTaskOpen: boolean;
+  // The board column a new task should default to (set when opening the create
+  // dialog from a specific column's "+"). null → default ("todo").
+  createTaskStatus: string | null;
   composerOpen: boolean;
   paletteOpen: boolean;
   quickOpenOpen: boolean;
   sidebarCollapsed: boolean;
   setCreateTaskOpen: (open: boolean) => void;
+  openCreateTask: (status?: string) => void;
   setComposerOpen: (open: boolean) => void;
   setPaletteOpen: (open: boolean) => void;
   setQuickOpenOpen: (open: boolean) => void;
@@ -18,11 +22,13 @@ interface UiState {
 
 export const useUi = create<UiState>()((set) => ({
   createTaskOpen: false,
+  createTaskStatus: null,
   composerOpen: false,
   paletteOpen: false,
   quickOpenOpen: false,
   sidebarCollapsed: false,
   setCreateTaskOpen: (open) => set({ createTaskOpen: open }),
+  openCreateTask: (status) => set({ createTaskOpen: true, createTaskStatus: status ?? null }),
   setComposerOpen: (open) => set({ composerOpen: open }),
   setPaletteOpen: (open) => set({ paletteOpen: open }),
   setQuickOpenOpen: (open) => set({ quickOpenOpen: open }),

--- a/desktop/src/shared/app-error.ts
+++ b/desktop/src/shared/app-error.ts
@@ -22,13 +22,25 @@ const CATEGORY_MESSAGES: Record<AppErrorCategory, string> = {
 
 export class AppError extends Error {
   readonly category: AppErrorCategory;
+  // An optional safe, app-level reason CODE from the gateway (e.g.
+  // "invalid_session_request", "not_found"). Never a raw provider/DB/path
+  // string — only short slugs the gateway emits as { error: { code } }.
+  readonly detail?: string;
 
-  constructor(category: AppErrorCategory, options?: { cause?: unknown }) {
+  constructor(category: AppErrorCategory, options?: { cause?: unknown; detail?: string }) {
     // The message is always the generic copy — the cause stays internal.
     super(CATEGORY_MESSAGES[category], options);
     this.name = "AppError";
     this.category = category;
+    if (options?.detail) this.detail = options.detail;
   }
+}
+
+// Gateway error codes are short lower_snake slugs; anything else (provider
+// names, paths, long strings) is rejected so it never reaches the UI.
+export function safeErrorDetail(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  return /^[a-z][a-z0-9_]{2,48}$/.test(value) ? value : undefined;
 }
 
 export function categoryMessage(category: AppErrorCategory): string {

--- a/tests/desktop/app-launcher.test.tsx
+++ b/tests/desktop/app-launcher.test.tsx
@@ -78,4 +78,18 @@ describe("AppLauncher", () => {
       });
     });
   });
+
+  it("does not show a no-match state before the app catalog loads", () => {
+    useApps.setState({
+      apps: [],
+      loaded: false,
+      loading: true,
+      error: null,
+    });
+
+    render(<AppLauncher />);
+
+    expect(screen.getByText("Loading apps")).toBeTruthy();
+    expect(screen.queryByText(/No apps match/i)).toBeNull();
+  });
 });

--- a/tests/desktop/app-launcher.test.tsx
+++ b/tests/desktop/app-launcher.test.tsx
@@ -1,17 +1,41 @@
 // @vitest-environment jsdom
 
 import React from "react";
-import { cleanup, render, screen } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import AppLauncher from "@desktop/renderer/src/features/embeds/AppLauncher";
-import { useConnection } from "@desktop/renderer/src/stores/connection";
-
-vi.mock("@desktop/renderer/src/features/embeds/EmbedHost", () => ({
-  default: ({ slug }: { slug: string }) => <div>Embed {slug}</div>,
-}));
+import AppLauncher from "../../desktop/src/renderer/src/features/embeds/AppLauncher";
+import { useApps } from "../../desktop/src/renderer/src/stores/apps";
+import { useConnection } from "../../desktop/src/renderer/src/stores/connection";
+import { useTabs } from "../../desktop/src/renderer/src/stores/tabs";
 
 describe("AppLauncher", () => {
   beforeEach(() => {
+    useConnection.setState({
+      status: "signed-in",
+      handle: "operator",
+      platformHost: "https://platform.test",
+      runtimeSlot: "primary",
+      api: null,
+    });
+    useApps.setState({
+      apps: [
+        { slug: "alpha", name: "Alpha" },
+        { slug: "beta", name: "Beta" },
+        { slug: "bravo", name: "Bravo" },
+      ],
+      loaded: true,
+      loading: false,
+      error: null,
+    });
+    useTabs.setState({ tabs: [], activeTabId: null });
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it("falls back to slug names and skips invalid app rows", async () => {
     useConnection.setState({
       status: "signed-in",
       handle: "operator",
@@ -28,19 +52,30 @@ describe("AppLauncher", () => {
         }),
       } as never,
     });
-  });
+    useApps.setState({ apps: [], loaded: false, loading: false, error: null });
 
-  afterEach(() => {
-    cleanup();
-    vi.restoreAllMocks();
-  });
-
-  it("falls back to slug names and skips invalid app rows", async () => {
     render(<AppLauncher />);
 
     expect(await screen.findByRole("button", { name: /notes/i })).toBeTruthy();
     expect(screen.getByRole("button", { name: /chat/i })).toBeTruthy();
     expect(screen.queryByRole("button", { name: /blank/i })).toBeNull();
     expect(screen.queryByRole("button", { name: /missing slug/i })).toBeNull();
+  });
+
+  it("resets the active app when the search query changes", async () => {
+    render(<AppLauncher />);
+    const search = screen.getByLabelText("Search apps");
+
+    fireEvent.keyDown(search, { key: "ArrowDown" });
+    fireEvent.change(search, { target: { value: "b" } });
+    fireEvent.keyDown(search, { key: "Enter" });
+
+    await waitFor(() => {
+      expect(useTabs.getState().tabs[0]).toMatchObject({
+        kind: "app",
+        slug: "beta",
+        title: "Beta",
+      });
+    });
   });
 });

--- a/tests/desktop/command-palette.test.tsx
+++ b/tests/desktop/command-palette.test.tsx
@@ -1,0 +1,61 @@
+// @vitest-environment jsdom
+
+import React from "react";
+import { cleanup, render, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import CommandPalette from "../../desktop/src/renderer/src/features/palette/CommandPalette";
+import { useApps } from "../../desktop/src/renderer/src/stores/apps";
+import { useBoard } from "../../desktop/src/renderer/src/stores/board";
+import { useConnection } from "../../desktop/src/renderer/src/stores/connection";
+import { useSessions } from "../../desktop/src/renderer/src/stores/sessions";
+import { useTabs } from "../../desktop/src/renderer/src/stores/tabs";
+import { useUi } from "../../desktop/src/renderer/src/stores/ui";
+
+describe("CommandPalette", () => {
+  beforeEach(() => {
+    class ResizeObserverStub {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    }
+    Object.defineProperty(window, "ResizeObserver", {
+      configurable: true,
+      writable: true,
+      value: ResizeObserverStub,
+    });
+    window.HTMLElement.prototype.scrollIntoView = vi.fn();
+    useUi.setState({ paletteOpen: true, createTaskOpen: false, createProjectOpen: false, composerOpen: false });
+    useBoard.setState({ activeProjectSlug: null, projects: [], cardsByProject: {} });
+    useSessions.setState({ sessions: [] });
+    useTabs.setState({ tabs: [], activeTabId: null });
+    useConnection.setState({
+      status: "signed-in",
+      handle: "operator",
+      platformHost: "https://platform.test",
+      runtimeSlot: "primary",
+      api: { get: vi.fn() } as never,
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it("forces an app catalog retry after a previous palette load failed", async () => {
+    const load = vi.fn().mockResolvedValue(undefined);
+    useApps.setState({
+      apps: [],
+      loaded: true,
+      loading: false,
+      error: "server",
+      load,
+    });
+
+    render(<CommandPalette />);
+
+    await waitFor(() => {
+      expect(load).toHaveBeenCalledWith(useConnection.getState().api, true);
+    });
+  });
+});

--- a/tests/desktop/file-tree.test.ts
+++ b/tests/desktop/file-tree.test.ts
@@ -64,6 +64,24 @@ describe("useFileTree", () => {
     expect(useFileTree.getState().roots).toEqual([{ name: "README.md", type: "file" }]);
   });
 
+  it("clears cached children and expansion state on forced root refresh", async () => {
+    const get = vi.fn().mockResolvedValue({ entries: [{ name: "README.md", type: "file" }] });
+    const api = makeApi(get as never);
+    useFileTree.setState({
+      roots: [{ name: "src", type: "directory" }],
+      childrenByPath: { src: [{ name: "stale.ts", type: "file" }] },
+      expanded: { src: true },
+      loadingPaths: { src: true },
+    });
+
+    await useFileTree.getState().loadRoots(api, true);
+
+    expect(useFileTree.getState().roots).toEqual([{ name: "README.md", type: "file" }]);
+    expect(useFileTree.getState().childrenByPath).toEqual({});
+    expect(useFileTree.getState().expanded).toEqual({});
+    expect(useFileTree.getState().loadingPaths).toEqual({});
+  });
+
   it("coalesces concurrent child loads for the same directory", async () => {
     const childLoad = deferred<{ entries: unknown[] }>();
     const get = vi.fn(() => childLoad.promise);

--- a/tests/desktop/file-tree.test.ts
+++ b/tests/desktop/file-tree.test.ts
@@ -1,0 +1,66 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ApiClient } from "@desktop/renderer/src/lib/api";
+import { useFileTree } from "@desktop/renderer/src/stores/file-tree";
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+}
+
+function makeApi(get: ApiClient["get"]): ApiClient {
+  return {
+    baseUrl: "https://x.test",
+    get,
+    post: vi.fn(),
+    patch: vi.fn(),
+    delete: vi.fn(),
+    putText: vi.fn(),
+  } as ApiClient;
+}
+
+beforeEach(() => {
+  useFileTree.setState({
+    roots: null,
+    childrenByPath: {},
+    expanded: {},
+    loadingRoots: false,
+    loadingPaths: {},
+  });
+});
+
+describe("useFileTree", () => {
+  it("coalesces concurrent root loads", async () => {
+    const rootLoad = deferred<{ entries: unknown[] }>();
+    const get = vi.fn(() => rootLoad.promise);
+    const api = makeApi(get as never);
+
+    const first = useFileTree.getState().loadRoots(api);
+    const second = useFileTree.getState().loadRoots(api);
+    rootLoad.resolve({ entries: [{ name: "README.md", type: "file" }] });
+    await Promise.all([first, second]);
+
+    expect(get).toHaveBeenCalledTimes(1);
+    expect(useFileTree.getState().roots).toEqual([{ name: "README.md", type: "file" }]);
+    expect(useFileTree.getState().loadingRoots).toBe(false);
+  });
+
+  it("coalesces concurrent child loads for the same directory", async () => {
+    const childLoad = deferred<{ entries: unknown[] }>();
+    const get = vi.fn(() => childLoad.promise);
+    const api = makeApi(get as never);
+
+    const first = useFileTree.getState().toggle(api, "src");
+    const second = useFileTree.getState().toggle(api, "src");
+    childLoad.resolve({ entries: [{ name: "index.ts", type: "file" }] });
+    await Promise.all([first, second]);
+
+    expect(get).toHaveBeenCalledTimes(1);
+    expect(useFileTree.getState().childrenByPath.src).toEqual([
+      { name: "index.ts", type: "file" },
+    ]);
+    expect(useFileTree.getState().loadingPaths.src).toBe(false);
+  });
+});

--- a/tests/desktop/file-tree.test.ts
+++ b/tests/desktop/file-tree.test.ts
@@ -63,4 +63,25 @@ describe("useFileTree", () => {
     ]);
     expect(useFileTree.getState().loadingPaths.src).toBe(false);
   });
+
+  it("keeps failed child loads retryable", async () => {
+    vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    const get = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("temporary"))
+      .mockResolvedValueOnce({ entries: [{ name: "index.ts", type: "file" }] });
+    const api = makeApi(get as never);
+
+    await useFileTree.getState().toggle(api, "src");
+    expect(useFileTree.getState().childrenByPath.src).toBeUndefined();
+    expect(useFileTree.getState().loadingPaths.src).toBe(false);
+
+    await useFileTree.getState().toggle(api, "src");
+    await useFileTree.getState().toggle(api, "src");
+
+    expect(get).toHaveBeenCalledTimes(2);
+    expect(useFileTree.getState().childrenByPath.src).toEqual([
+      { name: "index.ts", type: "file" },
+    ]);
+  });
 });

--- a/tests/desktop/file-tree.test.ts
+++ b/tests/desktop/file-tree.test.ts
@@ -47,6 +47,23 @@ describe("useFileTree", () => {
     expect(useFileTree.getState().loadingRoots).toBe(false);
   });
 
+  it("keeps failed root loads retryable", async () => {
+    vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    const get = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("temporary"))
+      .mockResolvedValueOnce({ entries: [{ name: "README.md", type: "file" }] });
+    const api = makeApi(get as never);
+
+    await useFileTree.getState().loadRoots(api);
+    expect(useFileTree.getState().roots).toBeNull();
+    expect(useFileTree.getState().loadingRoots).toBe(false);
+
+    await useFileTree.getState().loadRoots(api);
+    expect(get).toHaveBeenCalledTimes(2);
+    expect(useFileTree.getState().roots).toEqual([{ name: "README.md", type: "file" }]);
+  });
+
   it("coalesces concurrent child loads for the same directory", async () => {
     const childLoad = deferred<{ entries: unknown[] }>();
     const get = vi.fn(() => childLoad.promise);

--- a/tests/desktop/file-tree.test.ts
+++ b/tests/desktop/file-tree.test.ts
@@ -82,6 +82,24 @@ describe("useFileTree", () => {
     expect(useFileTree.getState().loadingPaths).toEqual({});
   });
 
+  it("does not let a stale child load repopulate children after forced root refresh", async () => {
+    const childLoad = deferred<{ entries: unknown[] }>();
+    const get = vi
+      .fn()
+      .mockReturnValueOnce(childLoad.promise)
+      .mockResolvedValueOnce({ entries: [{ name: "README.md", type: "file" }] });
+    const api = makeApi(get as never);
+
+    const toggle = useFileTree.getState().toggle(api, "src");
+    await useFileTree.getState().loadRoots(api, true);
+    childLoad.resolve({ entries: [{ name: "stale.ts", type: "file" }] });
+    await toggle;
+
+    expect(useFileTree.getState().roots).toEqual([{ name: "README.md", type: "file" }]);
+    expect(useFileTree.getState().childrenByPath.src).toBeUndefined();
+    expect(useFileTree.getState().loadingPaths.src).toBeUndefined();
+  });
+
   it("coalesces concurrent child loads for the same directory", async () => {
     const childLoad = deferred<{ entries: unknown[] }>();
     const get = vi.fn(() => childLoad.promise);

--- a/tests/desktop/files-panel.test.tsx
+++ b/tests/desktop/files-panel.test.tsx
@@ -1,11 +1,13 @@
 // @vitest-environment jsdom
 
 import React from "react";
+import * as Tooltip from "@radix-ui/react-tooltip";
 import { act, cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import FilesPanel from "../../desktop/src/renderer/src/features/files/FilesPanel";
 import { useConnection } from "../../desktop/src/renderer/src/stores/connection";
 import { useEditorTabs } from "../../desktop/src/renderer/src/features/editor/editor-tabs-store";
+import { useFileTree } from "../../desktop/src/renderer/src/stores/file-tree";
 import { useWorkspace } from "../../desktop/src/renderer/src/stores/workspace";
 
 describe("FilesPanel", () => {
@@ -17,6 +19,13 @@ describe("FilesPanel", () => {
     });
     useWorkspace.setState({
       layouts: {},
+    });
+    useFileTree.setState({
+      roots: null,
+      childrenByPath: {},
+      expanded: {},
+      loadingRoots: false,
+      loadingPaths: {},
     });
   });
 
@@ -43,7 +52,11 @@ describe("FilesPanel", () => {
       api: { get } as never,
     });
 
-    render(<FilesPanel taskId="task-1" />);
+    render(
+      <Tooltip.Provider>
+        <FilesPanel taskId="task-1" />
+      </Tooltip.Provider>,
+    );
 
     const src = await screen.findByRole("button", { name: /src/i });
     fireEvent.click(src);
@@ -67,7 +80,11 @@ describe("FilesPanel", () => {
       api: { get: offlineGet } as never,
     });
 
-    render(<FilesPanel taskId="task-1" />);
+    render(
+      <Tooltip.Provider>
+        <FilesPanel taskId="task-1" />
+      </Tooltip.Provider>,
+    );
 
     await waitFor(() => {
       expect(offlineGet).toHaveBeenCalledWith("/api/files/list?path=");

--- a/tests/desktop/markdown-preview.test.ts
+++ b/tests/desktop/markdown-preview.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vitest";
+import { safeUrlTransform } from "@desktop/renderer/src/features/editor/MarkdownPreview";
+
+describe("safeUrlTransform", () => {
+  it("allows http, https, mailto, and relative markdown links", () => {
+    expect(safeUrlTransform("https://matrix-os.com/docs")).toBe("https://matrix-os.com/docs");
+    expect(safeUrlTransform("http://localhost:5173")).toBe("http://localhost:5173");
+    expect(safeUrlTransform("mailto:hello@matrix-os.com")).toBe("mailto:hello@matrix-os.com");
+    expect(safeUrlTransform("./guide.md")).toBe("./guide.md");
+  });
+
+  it("strips javascript links", () => {
+    expect(safeUrlTransform("javascript:alert(1)")).toBe("");
+  });
+});

--- a/tests/desktop/ui-store.test.ts
+++ b/tests/desktop/ui-store.test.ts
@@ -1,0 +1,23 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { useUi } from "@desktop/renderer/src/stores/ui";
+
+beforeEach(() => {
+  useUi.setState(useUi.getInitialState(), true);
+});
+
+describe("ui store create task dialog state", () => {
+  it("keeps explicit column preselection only for openCreateTask", () => {
+    useUi.getState().openCreateTask("done");
+    expect(useUi.getState().createTaskOpen).toBe(true);
+    expect(useUi.getState().createTaskStatus).toBe("done");
+  });
+
+  it("clears stale column preselection on generic create-task open", () => {
+    useUi.getState().openCreateTask("done");
+    useUi.getState().setCreateTaskOpen(false);
+    useUi.getState().setCreateTaskOpen(true);
+
+    expect(useUi.getState().createTaskOpen).toBe(true);
+    expect(useUi.getState().createTaskStatus).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- Adds launcher search, persistent file tree, rendered markdown preview, and live-test fixes.
- Part of the 094 Operator desktop stack split from original PR #507.
- Draft until the full stack validation and screenshots are refreshed.

## Validation
- Rebased onto current main after #506 merged.
- Rebuilt stack final tree matches the original #507 tree exactly.
- Per-layer CI/Greptile still needs to settle before review-ready.

## Invariants
- Source of truth: desktop app source under desktop/, specs/docs, and root workspace metadata in this stack; no owner runtime data is modified.
- Lock/transaction scope: no Postgres transaction scope is introduced in this layer; desktop local state remains scoped to the Electron app and existing gateway/platform APIs.
- Acceptable orphan states: stack PRs are draft and must land in order; partial stack landing is not a supported release state.
- Auth source of truth: Clerk/device auth and existing gateway token handling remain authoritative; this stack does not add a second auth authority.
- Deferred scope: packaged distribution, production desktop rollout, and customer VPS host-bundle deploy are outside this stack.