### PR TITLE
feat(observability): capture process errors in PostHog

### DIFF
--- a/distro/cloudflared.yml
+++ b/distro/cloudflared.yml
@@ -2,8 +2,6 @@ tunnel: matrix-os
 credentials-file: /etc/cloudflared/credentials.json
 
 ingress:
-  - hostname: grafana.matrix-os.com
-    service: http://grafana:3000
   # Authenticated push-only Loki ingest edge (basic auth in logs-edge).
   - hostname: logs.matrix-os.com
     service: http://logs-edge:8080

--- a/packages/gateway/src/main.ts
+++ b/packages/gateway/src/main.ts
@@ -6,6 +6,11 @@ import { fileURLToPath } from "node:url";
 import { writeHeapSnapshot } from "node:v8";
 import { ensureHome, loadHandle, saveIdentity, deriveAiHandle } from "@matrix-os/kernel";
 import type { SyncReport } from "@matrix-os/kernel";
+import {
+  createPostHogErrorTracker,
+  installPostHogProcessErrorTracking,
+  resolveOwnerTelemetryDistinctId,
+} from "@matrix-os/observability";
 import { createGateway } from "./server.js";
 
 try {
@@ -13,6 +18,15 @@ try {
 } catch (err: unknown) {
   console.warn("[gateway] Could not load .env:", err instanceof Error ? err.message : String(err));
 }
+
+const processPosthogErrorTracker = createPostHogErrorTracker({
+  service: "matrix-gateway",
+});
+const posthogProcessErrors = installPostHogProcessErrorTracking({
+  tracker: processPosthogErrorTracker,
+  service: "matrix-gateway",
+  distinctId: resolveOwnerTelemetryDistinctId(),
+});
 
 const syncResult = ensureHome(process.env.MATRIX_HOME || undefined);
 const homePath = syncResult.homePath;
@@ -75,7 +89,9 @@ if (proxyUrl) {
 }
 
 process.on("SIGINT", async () => {
+  posthogProcessErrors.dispose();
   await gateway.close();
+  await processPosthogErrorTracker.shutdown();
   process.exit(0);
 });
 

--- a/packages/observability/src/index.ts
+++ b/packages/observability/src/index.ts
@@ -327,7 +327,6 @@ export function installPostHogProcessErrorTracking(
           distinctId: options.distinctId,
           properties: processProperties(origin),
         });
-        await options.tracker.flush();
         await options.tracker.shutdown();
       } catch (captureErr: unknown) {
         logger.warn(`[posthog] Failed to capture process exception for ${options.service}: ${errorKind(captureErr)}`);
@@ -530,5 +529,30 @@ function errorForLog(err: unknown): string {
 }
 
 function normalizeProcessError(err: unknown): Error {
-  return err instanceof Error ? err : new Error(`Non-Error rejection: ${typeof err}`);
+  return err instanceof Error ? err : new Error(`Non-Error rejection: ${formatProcessRejectionValue(err)}`);
+}
+
+function formatProcessRejectionValue(value: unknown): string {
+  if (typeof value === "string") return sanitizeProcessErrorValue(value);
+  if (value === null) return "null";
+  if (value === undefined) return "undefined";
+  if (typeof value === "number" || typeof value === "boolean" || typeof value === "bigint") {
+    return String(value);
+  }
+  if (typeof value === "symbol" || typeof value === "function") {
+    return sanitizeProcessErrorValue(String(value));
+  }
+  try {
+    return sanitizeProcessErrorValue(JSON.stringify(value));
+  } catch (err: unknown) {
+    if (!(err instanceof TypeError)) {
+      return errorKind(err);
+    }
+    return Object.prototype.toString.call(value);
+  }
+}
+
+function sanitizeProcessErrorValue(value: string | undefined): string {
+  const sanitized = value?.replace(/[\r\n\t]/g, " ").slice(0, MAX_PROPERTY_LENGTH).trim();
+  return sanitized || "unserializable";
 }

--- a/packages/observability/src/index.ts
+++ b/packages/observability/src/index.ts
@@ -76,6 +76,37 @@ export interface PostHogServerExceptionReporter {
   shutdown(): Promise<void>;
 }
 
+export interface PostHogProcessErrorTracker {
+  enabled: boolean;
+  captureException(error: unknown, options?: CaptureExceptionOptions): Promise<boolean>;
+  flush(): Promise<void>;
+  shutdown(): Promise<void>;
+}
+
+export interface PostHogProcessErrorTarget {
+  on(event: "uncaughtException", listener: (err: Error, origin: NodeJS.UncaughtExceptionOrigin) => void): unknown;
+  on(event: "unhandledRejection", listener: (reason: unknown, promise: Promise<unknown>) => void): unknown;
+  off(event: "uncaughtException", listener: (err: Error, origin: NodeJS.UncaughtExceptionOrigin) => void): unknown;
+  off(event: "unhandledRejection", listener: (reason: unknown, promise: Promise<unknown>) => void): unknown;
+}
+
+export interface PostHogProcessErrorLogger extends PostHogLogger {
+  error(message: string): void;
+}
+
+export interface InstallPostHogProcessErrorTrackingOptions {
+  tracker: PostHogProcessErrorTracker;
+  service: string;
+  distinctId?: string;
+  process?: PostHogProcessErrorTarget;
+  logger?: PostHogProcessErrorLogger;
+  exit?: (code: number) => void;
+}
+
+export interface InstalledPostHogProcessErrorTracking {
+  dispose(): void;
+}
+
 const TOKEN_ENV_KEYS = [
   "POSTHOG_TOKEN",
   "POSTHOG_PROJECT_TOKEN",
@@ -274,6 +305,60 @@ export function createPostHogServerExceptionReporter(
   };
 }
 
+export function installPostHogProcessErrorTracking(
+  options: InstallPostHogProcessErrorTrackingOptions,
+): InstalledPostHogProcessErrorTracking {
+  const target: PostHogProcessErrorTarget = options.process ?? process;
+  const logger = options.logger ?? console;
+  const exit = options.exit ?? ((code: number) => process.exit(code));
+
+  const processProperties = (errorType: string): PostHogProperties => ({
+    service: options.service,
+    runtime: "node",
+    error_source: "process",
+    error_type: errorType,
+  });
+
+  const onUncaughtException = (err: Error, origin: NodeJS.UncaughtExceptionOrigin): void => {
+    void (async () => {
+      logger.error(`[posthog] Uncaught exception for ${options.service}: ${errorForLog(err)}`);
+      try {
+        await options.tracker.captureException(err, {
+          distinctId: options.distinctId,
+          properties: processProperties(origin),
+        });
+        await options.tracker.flush();
+        await options.tracker.shutdown();
+      } catch (captureErr: unknown) {
+        logger.warn(`[posthog] Failed to capture process exception for ${options.service}: ${errorKind(captureErr)}`);
+      } finally {
+        exit(1);
+      }
+    })();
+  };
+
+  const onUnhandledRejection = (reason: unknown): void => {
+    const error = normalizeProcessError(reason);
+    logger.warn(`[posthog] Unhandled rejection for ${options.service}: ${errorKind(reason)}`);
+    void options.tracker.captureException(error, {
+      distinctId: options.distinctId,
+      properties: processProperties("unhandledRejection"),
+    }).catch((captureErr: unknown) => {
+      logger.warn(`[posthog] Failed to capture process rejection for ${options.service}: ${errorKind(captureErr)}`);
+    });
+  };
+
+  target.on("uncaughtException", onUncaughtException);
+  target.on("unhandledRejection", onUnhandledRejection);
+
+  return {
+    dispose() {
+      target.off("uncaughtException", onUncaughtException);
+      target.off("unhandledRejection", onUnhandledRejection);
+    },
+  };
+}
+
 export function extractPostHogDistinctId(cookieHeader: string | string[] | null | undefined): string | undefined {
   const cookie = Array.isArray(cookieHeader) ? cookieHeader.join("; ") : cookieHeader;
   if (!cookie) return undefined;
@@ -442,4 +527,8 @@ function errorKind(err: unknown): string {
 function errorForLog(err: unknown): string {
   if (err instanceof Error) return err.stack ?? `${err.name}: ${err.message}`;
   return typeof err === "string" ? err : errorKind(err);
+}
+
+function normalizeProcessError(err: unknown): Error {
+  return err instanceof Error ? err : new Error(`Non-Error rejection: ${typeof err}`);
 }

--- a/packages/observability/src/index.ts
+++ b/packages/observability/src/index.ts
@@ -321,8 +321,8 @@ export function installPostHogProcessErrorTracking(
 
   const onUncaughtException = (err: Error, origin: NodeJS.UncaughtExceptionOrigin): void => {
     void (async () => {
-      logger.error(`[posthog] Uncaught exception for ${options.service}: ${errorForLog(err)}`);
       try {
+        logger.error(`[posthog] Uncaught exception for ${options.service}: ${errorForLog(err)}`);
         await options.tracker.captureException(err, {
           distinctId: options.distinctId,
           properties: processProperties(origin),

--- a/packages/platform/src/main.ts
+++ b/packages/platform/src/main.ts
@@ -7,7 +7,14 @@ import {
 import { Hono, type Context } from 'hono';
 import { bodyLimit } from 'hono/body-limit';
 import { serve } from '@hono/node-server';
-import { installPostHogHonoErrorTracking, isMatrixTelemetryEvent, MATRIX_TELEMETRY_EVENTS, type MatrixTelemetryEvent } from '@matrix-os/observability';
+import {
+  createPostHogErrorTracker,
+  installPostHogHonoErrorTracking,
+  installPostHogProcessErrorTracking,
+  isMatrixTelemetryEvent,
+  MATRIX_TELEMETRY_EVENTS,
+  type MatrixTelemetryEvent,
+} from '@matrix-os/observability';
 import { createConnection, type Socket } from 'node:net';
 import { connect as createTlsConnection } from 'node:tls';
 import type { IncomingMessage, Server } from 'node:http';
@@ -4270,6 +4277,13 @@ if (process.argv[1]?.endsWith('main.ts') || process.argv[1]?.endsWith('main.js')
     customerVpsObjectStore,
     hostBundleObjectStore,
   });
+  const processPosthogErrorTracker = createPostHogErrorTracker({
+    service: 'matrix-platform',
+  });
+  const posthogProcessErrors = installPostHogProcessErrorTracking({
+    tracker: processPosthogErrorTracker,
+    service: 'matrix-platform',
+  });
 
   const server = serve({ fetch: app.fetch, port: PORT }, () => {
     console.log(`Platform listening on :${PORT}`);
@@ -4303,7 +4317,9 @@ if (process.argv[1]?.endsWith('main.ts') || process.argv[1]?.endsWith('main.js')
           containerProxyDispatcher.close(),
           customerVpsProxyDispatcher.close(),
         ]);
+        posthogProcessErrors.dispose();
         await app.shutdownPostHog();
+        await processPosthogErrorTracker.shutdown();
         await db.destroy();
       })()
         .catch((destroyErr: unknown) => {

--- a/tests/observability/cloudflared-ingress.test.ts
+++ b/tests/observability/cloudflared-ingress.test.ts
@@ -1,0 +1,11 @@
+import { readFile } from "node:fs/promises";
+import { describe, expect, it } from "vitest";
+
+describe("cloudflared observability ingress", () => {
+  it("does not expose Grafana through the public tunnel", async () => {
+    const source = await readFile("distro/cloudflared.yml", "utf8");
+
+    expect(source).not.toContain("grafana.matrix-os.com");
+    expect(source).not.toMatch(/service:\s*http:\/\/grafana:3000/);
+  });
+});

--- a/tests/observability/posthog-error-tracking.test.ts
+++ b/tests/observability/posthog-error-tracking.test.ts
@@ -234,7 +234,7 @@ describe("PostHog error tracking", () => {
         error_type: "uncaughtException",
       },
     });
-    expect(flush).toHaveBeenCalledOnce();
+    expect(flush).not.toHaveBeenCalled();
     expect(shutdown).toHaveBeenCalledOnce();
     expect(exit).toHaveBeenCalledWith(1);
   });
@@ -269,7 +269,34 @@ describe("PostHog error tracking", () => {
         error_type: "unhandledRejection",
       },
     });
-    expect(captureException.mock.calls[0]?.[0].message).toBe("Non-Error rejection: string");
+    expect(captureException.mock.calls[0]?.[0].message).toBe("Non-Error rejection: async failure");
+    expect(exit).not.toHaveBeenCalled();
+  });
+
+  it("captures object rejection values with diagnostic detail", async () => {
+    const processEvents = new EventEmitter();
+    const captureException = vi.fn().mockResolvedValue(true);
+    const exit = vi.fn();
+
+    installPostHogProcessErrorTracking({
+      tracker: {
+        enabled: true,
+        captureException,
+        flush: vi.fn().mockResolvedValue(undefined),
+        shutdown: vi.fn().mockResolvedValue(undefined),
+      },
+      process: processEvents,
+      service: "matrix-platform",
+      logger: { warn: vi.fn(), error: vi.fn() },
+      exit,
+    });
+
+    processEvents.emit("unhandledRejection", { code: "worker_failed", retryable: true }, Promise.resolve());
+    await new Promise((resolve) => setImmediate(resolve));
+
+    expect(captureException.mock.calls[0]?.[0].message).toBe(
+      'Non-Error rejection: {"code":"worker_failed","retryable":true}',
+    );
     expect(exit).not.toHaveBeenCalled();
   });
 

--- a/tests/observability/posthog-error-tracking.test.ts
+++ b/tests/observability/posthog-error-tracking.test.ts
@@ -1,4 +1,5 @@
 import { readFile } from "node:fs/promises";
+import { EventEmitter } from "node:events";
 import { describe, expect, it, vi } from "vitest";
 import { Hono } from "hono";
 import { HTTPException } from "hono/http-exception";
@@ -13,6 +14,7 @@ import {
   createPostHogErrorTracker,
   createPostHogServerExceptionReporter,
   extractPostHogDistinctId,
+  installPostHogProcessErrorTracking,
   installPostHogHonoErrorTracking,
 } from "../../packages/observability/src/index.ts";
 
@@ -202,6 +204,73 @@ describe("PostHog error tracking", () => {
     });
     expect(JSON.stringify(captureException.mock.calls[0]?.[2])).not.toContain("secret");
     expect(flush).toHaveBeenCalledOnce();
+  });
+
+  it("captures uncaught exceptions before exiting the process", async () => {
+    const processEvents = new EventEmitter();
+    const captureException = vi.fn().mockResolvedValue(true);
+    const flush = vi.fn().mockResolvedValue(undefined);
+    const shutdown = vi.fn().mockResolvedValue(undefined);
+    const exit = vi.fn();
+
+    installPostHogProcessErrorTracking({
+      tracker: { enabled: true, captureException, flush, shutdown },
+      process: processEvents,
+      service: "matrix-gateway",
+      logger: { warn: vi.fn(), error: vi.fn() },
+      exit,
+    });
+
+    const err = new Error("background failure");
+    processEvents.emit("uncaughtException", err, "uncaughtException");
+    await new Promise((resolve) => setImmediate(resolve));
+
+    expect(captureException).toHaveBeenCalledWith(err, {
+      distinctId: undefined,
+      properties: {
+        service: "matrix-gateway",
+        runtime: "node",
+        error_source: "process",
+        error_type: "uncaughtException",
+      },
+    });
+    expect(flush).toHaveBeenCalledOnce();
+    expect(shutdown).toHaveBeenCalledOnce();
+    expect(exit).toHaveBeenCalledWith(1);
+  });
+
+  it("captures unhandled promise rejections without exiting the process", async () => {
+    const processEvents = new EventEmitter();
+    const captureException = vi.fn().mockResolvedValue(true);
+    const exit = vi.fn();
+
+    installPostHogProcessErrorTracking({
+      tracker: {
+        enabled: true,
+        captureException,
+        flush: vi.fn().mockResolvedValue(undefined),
+        shutdown: vi.fn().mockResolvedValue(undefined),
+      },
+      process: processEvents,
+      service: "matrix-platform",
+      logger: { warn: vi.fn(), error: vi.fn() },
+      exit,
+    });
+
+    processEvents.emit("unhandledRejection", "async failure", Promise.resolve());
+    await new Promise((resolve) => setImmediate(resolve));
+
+    expect(captureException).toHaveBeenCalledWith(expect.any(Error), {
+      distinctId: undefined,
+      properties: {
+        service: "matrix-platform",
+        runtime: "node",
+        error_source: "process",
+        error_type: "unhandledRejection",
+      },
+    });
+    expect(captureException.mock.calls[0]?.[0].message).toBe("Non-Error rejection: string");
+    expect(exit).not.toHaveBeenCalled();
   });
 
   it("does not capture expected 4xx Hono HTTPExceptions", async () => {

--- a/tests/observability/posthog-error-tracking.test.ts
+++ b/tests/observability/posthog-error-tracking.test.ts
@@ -239,6 +239,38 @@ describe("PostHog error tracking", () => {
     expect(exit).toHaveBeenCalledWith(1);
   });
 
+  it("exits after uncaught exceptions even when the process logger fails", async () => {
+    const processEvents = new EventEmitter();
+    const captureException = vi.fn().mockResolvedValue(true);
+    const shutdown = vi.fn().mockResolvedValue(undefined);
+    const exit = vi.fn();
+
+    installPostHogProcessErrorTracking({
+      tracker: {
+        enabled: true,
+        captureException,
+        flush: vi.fn().mockResolvedValue(undefined),
+        shutdown,
+      },
+      process: processEvents,
+      service: "matrix-gateway",
+      logger: {
+        warn: vi.fn(),
+        error: vi.fn(() => {
+          throw new Error("logger failed");
+        }),
+      },
+      exit,
+    });
+
+    processEvents.emit("uncaughtException", new Error("background failure"), "uncaughtException");
+    await new Promise((resolve) => setImmediate(resolve));
+
+    expect(captureException).not.toHaveBeenCalled();
+    expect(shutdown).not.toHaveBeenCalled();
+    expect(exit).toHaveBeenCalledWith(1);
+  });
+
   it("captures unhandled promise rejections without exiting the process", async () => {
     const processEvents = new EventEmitter();
     const captureException = vi.fn().mockResolvedValue(true);

--- a/tests/observability/process-error-entrypoints.test.ts
+++ b/tests/observability/process-error-entrypoints.test.ts
@@ -1,0 +1,19 @@
+import { readFile } from "node:fs/promises";
+import { describe, expect, it } from "vitest";
+
+describe("process-level PostHog error entrypoints", () => {
+  it("wires gateway and platform process errors to their shared PostHog trackers", async () => {
+    const [gatewayMain, platformMain] = await Promise.all([
+      readFile("packages/gateway/src/main.ts", "utf8"),
+      readFile("packages/platform/src/main.ts", "utf8"),
+    ]);
+
+    expect(gatewayMain).toContain("installPostHogProcessErrorTracking");
+    expect(gatewayMain).toContain('service: "matrix-gateway"');
+    expect(gatewayMain).toContain("resolveOwnerTelemetryDistinctId");
+
+    expect(platformMain).toContain("installPostHogProcessErrorTracking");
+    expect(platformMain).toContain("service: 'matrix-platform'");
+    expect(platformMain).toContain("posthogProcessErrors.dispose()");
+  });
+});

--- a/tests/platform/middleware-shortcircuit.test.ts
+++ b/tests/platform/middleware-shortcircuit.test.ts
@@ -39,6 +39,8 @@ describe("container-proxy middleware short-circuit for device-flow paths", () =>
   beforeEach(async () => {
     process.env.PLATFORM_JWT_SECRET = JWT_SECRET;
     process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY = 'pk_test_"bad"&<tag>';
+    process.env.AUTH_SHELL_HOST = '127.0.0.1';
+    process.env.AUTH_SHELL_PORT = '1';
     ({ db } = await createTestPlatformDb());
 
     // Clerk stub that always fails verification -- proves the short-circuit
@@ -54,6 +56,8 @@ describe("container-proxy middleware short-circuit for device-flow paths", () =>
     await destroyTestPlatformDb(db);
     delete process.env.PLATFORM_JWT_SECRET;
     delete process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY;
+    delete process.env.AUTH_SHELL_HOST;
+    delete process.env.AUTH_SHELL_PORT;
   });
 
   it("GET /auth/device?user_code=XYZ on Host app.matrix-os.com short-circuits to the device-flow handler (not 500/502)", async () => {


### PR DESCRIPTION
## Summary
- add shared process-level PostHog error tracking for Node entrypoints
- wire gateway and platform process errors to PostHog without swallowing uncaught exceptions
- remove public tunnel ingress for the legacy dashboard UI

## Tests
- bun run typecheck
- bun run check:patterns
- bun run test
- bun run test tests/observability/posthog-error-tracking.test.ts tests/observability/process-error-entrypoints.test.ts tests/observability/cloudflared-ingress.test.ts tests/platform/middleware-shortcircuit.test.ts

## Review/Monitoring
- Greptile reviewed the first commit at 3/5; both findings were fixed in the follow-up commit.
- Greptile reviewed the second commit at 4/5; the remaining exit-path finding was fixed in the final follow-up commit.
- Latest trusted Greptile result on the current head is 5/5.

## Invariants
- Source of truth: server telemetry uses the configured PostHog project token environment; tunnel ingress is defined by the checked-in cloudflared config.
- Lock/transaction scope: no database writes or transactions are introduced; process handlers only capture and shut down telemetry before preserving crash behavior.
- Acceptable orphan states: if telemetry capture or shutdown fails during an uncaught exception, the process still exits with code 1; the crash is not swallowed.
- Auth source of truth: no route authentication behavior changes; legacy dashboard access is narrowed by removing its public tunnel ingress.
- Deferred scope: PostHog Logs shipping, alert provisioning, and broader self-hosted stack removal remain for later slices.