### PR TITLE
feat(desktop): add release pipeline

### DIFF
--- a/.github/actions/merge-mac-manifests/action.yml
+++ b/.github/actions/merge-mac-manifests/action.yml
@@ -1,0 +1,13 @@
+name: Merge macOS update manifests
+description: Merge arm64 and x64 electron-builder mac update manifests into one latest-mac.yml.
+inputs:
+  directory:
+    description: Directory containing downloaded desktop artifacts.
+    required: true
+  output:
+    description: Manifest filename to write.
+    required: false
+    default: latest-mac.yml
+runs:
+  using: node20
+  main: merge-mac-manifests.mjs

--- a/.github/actions/merge-mac-manifests/action.yml
+++ b/.github/actions/merge-mac-manifests/action.yml
@@ -8,6 +8,10 @@ inputs:
     description: Manifest filename to write.
     required: false
     default: latest-mac.yml
+  channel:
+    description: Optional prerelease channel manifest suffix to merge, such as beta or canary.
+    required: false
+    default: ""
 runs:
   using: node20
   main: merge-mac-manifests.mjs

--- a/.github/actions/merge-mac-manifests/merge-mac-manifests.mjs
+++ b/.github/actions/merge-mac-manifests/merge-mac-manifests.mjs
@@ -1,0 +1,57 @@
+import { readdir, readFile, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+
+function extractFilesBlock(text) {
+  const match = text.match(/^files:\n([\s\S]*?)(?=^[A-Za-z0-9_-]+:|(?![\s\S]))/m);
+  if (!match) return [];
+  const block = match[1];
+  return block
+    .split(/\n(?=  - url: )/)
+    .map((entry) => entry.trimEnd())
+    .filter((entry) => entry.trim().length > 0);
+}
+
+function withoutFilesBlock(text) {
+  return text.replace(/^files:\n[\s\S]*?(?=^[A-Za-z0-9_-]+:|(?![\s\S]))/m, "");
+}
+
+const directory = process.env.INPUT_DIRECTORY;
+const output = process.env.INPUT_OUTPUT || "latest-mac.yml";
+
+if (!directory) {
+  throw new Error("directory input is required");
+}
+
+const names = await readdir(directory);
+const manifestNames = names.filter((name) => name.endsWith("-mac.yml") || name === "latest-mac.yml");
+if (manifestNames.length < 2) {
+  throw new Error(`expected at least 2 mac manifests in ${directory}, found ${manifestNames.length}`);
+}
+
+const manifests = await Promise.all(
+  manifestNames.map(async (name) => ({
+    name,
+    text: await readFile(join(directory, name), "utf8"),
+  })),
+);
+
+const files = [];
+for (const manifest of manifests) {
+  for (const entry of extractFilesBlock(manifest.text)) {
+    const url = entry.match(/^\s*-\s+url:\s+(.+)$/m)?.[1]?.trim();
+    if (url && !files.some((file) => file.includes(`url: ${url}`))) {
+      files.push(entry);
+    }
+  }
+}
+
+if (files.length === 0) {
+  throw new Error(`no files entries found in ${manifestNames.join(", ")}`);
+}
+
+const base = manifests[0].text;
+const rest = withoutFilesBlock(base).trimStart().trimEnd();
+const merged = `files:\n${files.join("\n")}\n${rest ? `${rest}\n` : ""}`;
+
+await writeFile(join(directory, output), merged);
+console.log(`wrote ${output} with ${files.length} files`);

--- a/.github/actions/merge-mac-manifests/merge-mac-manifests.mjs
+++ b/.github/actions/merge-mac-manifests/merge-mac-manifests.mjs
@@ -23,7 +23,9 @@ if (!directory) {
 }
 
 const names = await readdir(directory);
-const manifestNames = names.filter((name) => name.endsWith("-mac.yml") || name === "latest-mac.yml");
+const manifestNames = names
+  .filter((name) => name.endsWith("-mac.yml") || name === "latest-mac.yml")
+  .sort((a, b) => a.localeCompare(b));
 if (manifestNames.length < 2) {
   throw new Error(`expected at least 2 mac manifests in ${directory}, found ${manifestNames.length}`);
 }

--- a/.github/actions/merge-mac-manifests/merge-mac-manifests.mjs
+++ b/.github/actions/merge-mac-manifests/merge-mac-manifests.mjs
@@ -27,7 +27,7 @@ const names = await readdir(directory);
 const manifestNames = names
   .filter((name) => {
     if (channel) return name.endsWith(`-${channel}-mac.yml`);
-    return /^(arm64|x64)-mac\.yml$/.test(name) || name === "latest-mac.yml";
+    return /^(arm64|x64)-mac\.yml$/.test(name);
   })
   .sort((a, b) => a.localeCompare(b));
 if (manifestNames.length < 2) {

--- a/.github/actions/merge-mac-manifests/merge-mac-manifests.mjs
+++ b/.github/actions/merge-mac-manifests/merge-mac-manifests.mjs
@@ -17,6 +17,7 @@ function withoutFilesBlock(text) {
 
 const directory = process.env.INPUT_DIRECTORY;
 const output = process.env.INPUT_OUTPUT || "latest-mac.yml";
+const channel = process.env.INPUT_CHANNEL || "";
 
 if (!directory) {
   throw new Error("directory input is required");
@@ -24,7 +25,10 @@ if (!directory) {
 
 const names = await readdir(directory);
 const manifestNames = names
-  .filter((name) => name.endsWith("-mac.yml") || name === "latest-mac.yml")
+  .filter((name) => {
+    if (channel) return name.endsWith(`-${channel}-mac.yml`);
+    return /^(arm64|x64)-mac\.yml$/.test(name) || name === "latest-mac.yml";
+  })
   .sort((a, b) => a.localeCompare(b));
 if (manifestNames.length < 2) {
   throw new Error(`expected at least 2 mac manifests in ${directory}, found ${manifestNames.length}`);

--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -125,6 +125,7 @@ jobs:
           path: |
             desktop/dist/*.dmg
             desktop/dist/*.zip
+            desktop/dist/*.blockmap
             desktop/dist/*-mac.yml
           if-no-files-found: error
           retention-days: ${{ inputs.retention_days }}
@@ -178,6 +179,7 @@ jobs:
           name: ${{ inputs.artifact_prefix }}-linux-x64
           path: |
             desktop/dist/*.AppImage
+            desktop/dist/*.blockmap
             desktop/dist/*-linux.yml
           if-no-files-found: error
           retention-days: ${{ inputs.retention_days }}

--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -1,0 +1,143 @@
+name: Desktop Build
+
+on:
+  workflow_call:
+    inputs:
+      channel:
+        description: Desktop update channel.
+        required: true
+        type: string
+      version_suffix:
+        description: Optional prerelease suffix appended to desktop/package.json.
+        required: false
+        type: string
+        default: ""
+      artifact_prefix:
+        description: Prefix for uploaded artifacts.
+        required: true
+        type: string
+      retention_days:
+        description: Artifact retention.
+        required: false
+        type: number
+        default: 14
+
+permissions:
+  contents: read
+
+jobs:
+  mac:
+    name: macOS ${{ matrix.arch }}
+    runs-on: macos-latest
+    timeout-minutes: 45
+    strategy:
+      fail-fast: false
+      matrix:
+        arch: [arm64, x64]
+    env:
+      MATRIX_DESKTOP_UPDATE_CHANNEL: ${{ inputs.channel }}
+      CSC_LINK: ${{ secrets.MATRIX_DESKTOP_MAC_CERTIFICATE || secrets.CSC_LINK }}
+      CSC_KEY_PASSWORD: ${{ secrets.MATRIX_DESKTOP_MAC_CERTIFICATE_PASSWORD || secrets.CSC_KEY_PASSWORD }}
+      APPLE_ID: ${{ secrets.APPLE_ID }}
+      APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD || secrets.APPLE_APP_PASSWORD }}
+      APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: pnpm/action-setup@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: pnpm
+
+      - uses: oven-sh/setup-bun@v2
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Apply desktop prerelease suffix
+        if: ${{ inputs.version_suffix != '' }}
+        env:
+          VERSION_SUFFIX: ${{ inputs.version_suffix }}
+        run: |
+          node --input-type=module -e "import { readFile, writeFile } from 'node:fs/promises'; const p='desktop/package.json'; const j=JSON.parse(await readFile(p,'utf8')); j.version=j.version.replace(/-.*/, '') + '-' + process.env.VERSION_SUFFIX; await writeFile(p, JSON.stringify(j, null, 2) + '\n');"
+
+      - name: Build desktop app
+        run: pnpm --filter desktop build
+
+      - name: Package desktop app
+        working-directory: desktop
+        run: pnpm exec electron-builder --config electron-builder.yml --mac --${{ matrix.arch }} --publish never
+
+      - name: Verify packaged update resources
+        shell: bash
+        run: |
+          set -euo pipefail
+          test -f desktop/dist/*-mac.yml
+          test -f desktop/dist/*.dmg
+          test -f desktop/dist/*.zip
+          test -f desktop/dist/mac*/Matrix\ OS.app/Contents/Resources/app-update.yml
+
+      - name: Upload macOS artifacts
+        uses: actions/upload-artifact@v6
+        with:
+          name: ${{ inputs.artifact_prefix }}-macos-${{ matrix.arch }}
+          path: |
+            desktop/dist/*.dmg
+            desktop/dist/*.zip
+            desktop/dist/*-mac.yml
+          if-no-files-found: error
+          retention-days: ${{ inputs.retention_days }}
+
+  linux:
+    name: Linux x64
+    runs-on: ubuntu-latest
+    timeout-minutes: 35
+    env:
+      MATRIX_DESKTOP_UPDATE_CHANNEL: ${{ inputs.channel }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: pnpm/action-setup@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: pnpm
+
+      - uses: oven-sh/setup-bun@v2
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Apply desktop prerelease suffix
+        if: ${{ inputs.version_suffix != '' }}
+        env:
+          VERSION_SUFFIX: ${{ inputs.version_suffix }}
+        run: |
+          node --input-type=module -e "import { readFile, writeFile } from 'node:fs/promises'; const p='desktop/package.json'; const j=JSON.parse(await readFile(p,'utf8')); j.version=j.version.replace(/-.*/, '') + '-' + process.env.VERSION_SUFFIX; await writeFile(p, JSON.stringify(j, null, 2) + '\n');"
+
+      - name: Build desktop app
+        run: pnpm --filter desktop build
+
+      - name: Package desktop app
+        working-directory: desktop
+        run: pnpm exec electron-builder --config electron-builder.yml --linux AppImage --x64 --publish never
+
+      - name: Verify packaged update resources
+        shell: bash
+        run: |
+          set -euo pipefail
+          test -f desktop/dist/*.AppImage
+          test -f desktop/dist/latest-linux.yml
+
+      - name: Upload Linux artifacts
+        uses: actions/upload-artifact@v6
+        with:
+          name: ${{ inputs.artifact_prefix }}-linux-x64
+          path: |
+            desktop/dist/*.AppImage
+            desktop/dist/*-linux.yml
+          if-no-files-found: error
+          retention-days: ${{ inputs.retention_days }}

--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -12,6 +12,11 @@ on:
         required: false
         type: string
         default: ""
+      version:
+        description: Exact desktop/package.json version for release builds.
+        required: false
+        type: string
+        default: ""
       artifact_prefix:
         description: Prefix for uploaded artifacts.
         required: true
@@ -56,12 +61,31 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Apply desktop prerelease suffix
-        if: ${{ inputs.version_suffix != '' }}
+      - name: Validate Apple notarization secrets
+        shell: bash
+        run: |
+          set -euo pipefail
+          present=0
+          missing=0
+          for var in APPLE_ID APPLE_APP_SPECIFIC_PASSWORD APPLE_TEAM_ID; do
+            if [ -n "${!var:-}" ]; then
+              present=$((present + 1))
+            else
+              missing=$((missing + 1))
+            fi
+          done
+          if [ "$present" -gt 0 ] && [ "$missing" -gt 0 ]; then
+            echo "APPLE_ID, APPLE_APP_SPECIFIC_PASSWORD, and APPLE_TEAM_ID must be set together for notarization." >&2
+            exit 1
+          fi
+
+      - name: Apply desktop release version
+        if: ${{ inputs.version != '' || inputs.version_suffix != '' }}
         env:
+          RELEASE_VERSION: ${{ inputs.version }}
           VERSION_SUFFIX: ${{ inputs.version_suffix }}
         run: |
-          node --input-type=module -e "import { readFile, writeFile } from 'node:fs/promises'; const p='desktop/package.json'; const j=JSON.parse(await readFile(p,'utf8')); j.version=j.version.replace(/-.*/, '') + '-' + process.env.VERSION_SUFFIX; await writeFile(p, JSON.stringify(j, null, 2) + '\n');"
+          node --input-type=module -e "import { readFile, writeFile } from 'node:fs/promises'; const p='desktop/package.json'; const j=JSON.parse(await readFile(p,'utf8')); const exact=process.env.RELEASE_VERSION || ''; const suffix=process.env.VERSION_SUFFIX || ''; j.version = exact || (j.version.replace(/-.*/, '') + '-' + suffix); await writeFile(p, JSON.stringify(j, null, 2) + '\n');"
 
       - name: Build desktop app
         run: pnpm --filter desktop build
@@ -118,12 +142,13 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Apply desktop prerelease suffix
-        if: ${{ inputs.version_suffix != '' }}
+      - name: Apply desktop release version
+        if: ${{ inputs.version != '' || inputs.version_suffix != '' }}
         env:
+          RELEASE_VERSION: ${{ inputs.version }}
           VERSION_SUFFIX: ${{ inputs.version_suffix }}
         run: |
-          node --input-type=module -e "import { readFile, writeFile } from 'node:fs/promises'; const p='desktop/package.json'; const j=JSON.parse(await readFile(p,'utf8')); j.version=j.version.replace(/-.*/, '') + '-' + process.env.VERSION_SUFFIX; await writeFile(p, JSON.stringify(j, null, 2) + '\n');"
+          node --input-type=module -e "import { readFile, writeFile } from 'node:fs/promises'; const p='desktop/package.json'; const j=JSON.parse(await readFile(p,'utf8')); const exact=process.env.RELEASE_VERSION || ''; const suffix=process.env.VERSION_SUFFIX || ''; j.version = exact || (j.version.replace(/-.*/, '') + '-' + suffix); await writeFile(p, JSON.stringify(j, null, 2) + '\n');"
 
       - name: Build desktop app
         run: pnpm --filter desktop build

--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -105,10 +105,18 @@ jobs:
 
       - name: Rename mac update manifest for arch
         shell: bash
+        env:
+          CHANNEL: ${{ inputs.channel }}
         run: |
           set -euo pipefail
           mv desktop/dist/latest-mac.yml "desktop/dist/${{ matrix.arch }}-mac.yml"
-          find desktop/dist -maxdepth 1 -type f -name '*-mac.yml' ! -name '${{ matrix.arch }}-mac.yml' -delete
+          if [ "$CHANNEL" != "stable" ] && [ -f "desktop/dist/${CHANNEL}-mac.yml" ]; then
+            mv "desktop/dist/${CHANNEL}-mac.yml" "desktop/dist/${{ matrix.arch }}-${CHANNEL}-mac.yml"
+          fi
+          find desktop/dist -maxdepth 1 -type f -name '*-mac.yml' \
+            ! -name '${{ matrix.arch }}-mac.yml' \
+            ! -name '${{ matrix.arch }}-${CHANNEL}-mac.yml' \
+            -delete
 
       - name: Upload macOS artifacts
         uses: actions/upload-artifact@v6

--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -74,7 +74,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          test -f desktop/dist/*-mac.yml
+          test -f desktop/dist/latest-mac.yml
           test -f desktop/dist/*.dmg
           test -f desktop/dist/*.zip
           test -f desktop/dist/mac*/Matrix\ OS.app/Contents/Resources/app-update.yml
@@ -84,6 +84,7 @@ jobs:
         run: |
           set -euo pipefail
           mv desktop/dist/latest-mac.yml "desktop/dist/${{ matrix.arch }}-mac.yml"
+          find desktop/dist -maxdepth 1 -type f -name '*-mac.yml' ! -name '${{ matrix.arch }}-mac.yml' -delete
 
       - name: Upload macOS artifacts
         uses: actions/upload-artifact@v6

--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -114,8 +114,8 @@ jobs:
             mv "desktop/dist/${CHANNEL}-mac.yml" "desktop/dist/${{ matrix.arch }}-${CHANNEL}-mac.yml"
           fi
           find desktop/dist -maxdepth 1 -type f -name '*-mac.yml' \
-            ! -name '${{ matrix.arch }}-mac.yml' \
-            ! -name '${{ matrix.arch }}-${CHANNEL}-mac.yml' \
+            ! -name "${{ matrix.arch }}-mac.yml" \
+            ! -name "${{ matrix.arch }}-${CHANNEL}-mac.yml" \
             -delete
 
       - name: Upload macOS artifacts

--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -79,6 +79,12 @@ jobs:
           test -f desktop/dist/*.zip
           test -f desktop/dist/mac*/Matrix\ OS.app/Contents/Resources/app-update.yml
 
+      - name: Rename mac update manifest for arch
+        shell: bash
+        run: |
+          set -euo pipefail
+          mv desktop/dist/latest-mac.yml "desktop/dist/${{ matrix.arch }}-mac.yml"
+
       - name: Upload macOS artifacts
         uses: actions/upload-artifact@v6
         with:

--- a/.github/workflows/desktop-release-canary.yml
+++ b/.github/workflows/desktop-release-canary.yml
@@ -1,0 +1,86 @@
+name: Desktop Canary Release
+
+on:
+  schedule:
+    - cron: "17 */12 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: desktop-release-canary
+  cancel-in-progress: false
+
+jobs:
+  prepare:
+    name: Prepare canary metadata
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      suffix: ${{ steps.meta.outputs.suffix }}
+      artifact_prefix: ${{ steps.meta.outputs.artifact_prefix }}
+    steps:
+      - id: meta
+        run: |
+          set -euo pipefail
+          SUFFIX="canary.$(date -u +%Y%m%d%H%M%S)"
+          echo "suffix=$SUFFIX" >> "$GITHUB_OUTPUT"
+          echo "artifact_prefix=matrix-desktop-desktop-canary" >> "$GITHUB_OUTPUT"
+
+  build:
+    needs: prepare
+    uses: ./.github/workflows/desktop-build.yml
+    with:
+      channel: canary
+      version_suffix: ${{ needs.prepare.outputs.suffix }}
+      artifact_prefix: ${{ needs.prepare.outputs.artifact_prefix }}
+      retention_days: 7
+    secrets: inherit
+
+  release:
+    name: Publish canary release
+    needs: [prepare, build]
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Move desktop-canary tag
+        run: |
+          set -euo pipefail
+          git tag -f desktop-canary "$GITHUB_SHA"
+          git push origin refs/tags/desktop-canary --force
+
+      - uses: actions/download-artifact@v6
+        with:
+          pattern: ${{ needs.prepare.outputs.artifact_prefix }}-*
+          path: desktop-release
+          merge-multiple: true
+
+      - name: Merge macOS update manifests
+        uses: ./.github/actions/merge-mac-manifests
+        with:
+          directory: desktop-release
+
+      - name: Generate release manifest
+        run: |
+          node scripts/release/generate-desktop-release-manifest.mjs desktop-release desktop-canary "${{ needs.prepare.outputs.suffix }}" canary "$GITHUB_SHA"
+
+      - name: Write release notes
+        run: |
+          printf 'Automated Matrix OS Desktop canary for %s.\n' "$GITHUB_SHA" > RELEASE_NOTES.md
+
+      - name: Publish desktop-canary prerelease
+        uses: softprops/action-gh-release@v3
+        with:
+          tag_name: desktop-canary
+          name: Matrix OS Desktop Canary
+          target_commitish: ${{ github.sha }}
+          body_path: RELEASE_NOTES.md
+          prerelease: true
+          draft: false
+          make_latest: false
+          files: desktop-release/**
+          fail_on_unmatched_files: true
+          overwrite_files: true

--- a/.github/workflows/desktop-release-canary.yml
+++ b/.github/workflows/desktop-release-canary.yml
@@ -39,7 +39,6 @@ jobs:
     with:
       channel: canary
       version: ${{ needs.prepare.outputs.version }}
-      version_suffix: ${{ needs.prepare.outputs.suffix }}
       artifact_prefix: ${{ needs.prepare.outputs.artifact_prefix }}
       retention_days: 7
     secrets: inherit

--- a/.github/workflows/desktop-release-canary.yml
+++ b/.github/workflows/desktop-release-canary.yml
@@ -69,6 +69,13 @@ jobs:
         with:
           directory: desktop-release
 
+      - name: Merge canary macOS update manifests
+        uses: ./.github/actions/merge-mac-manifests
+        with:
+          directory: desktop-release
+          output: canary-mac.yml
+          channel: canary
+
       - name: Generate release manifest
         run: |
           node scripts/release/generate-desktop-release-manifest.mjs desktop-release desktop-canary "${{ needs.prepare.outputs.version }}" canary "$GITHUB_SHA"

--- a/.github/workflows/desktop-release-canary.yml
+++ b/.github/workflows/desktop-release-canary.yml
@@ -19,13 +19,18 @@ jobs:
     timeout-minutes: 5
     outputs:
       suffix: ${{ steps.meta.outputs.suffix }}
+      version: ${{ steps.meta.outputs.version }}
       artifact_prefix: ${{ steps.meta.outputs.artifact_prefix }}
     steps:
+      - uses: actions/checkout@v6
+
       - id: meta
         run: |
           set -euo pipefail
           SUFFIX="canary.$(date -u +%Y%m%d%H%M%S)"
+          BASE_VERSION="$(node -p "require('./desktop/package.json').version.replace(/-.*/, '')")"
           echo "suffix=$SUFFIX" >> "$GITHUB_OUTPUT"
+          echo "version=$BASE_VERSION-$SUFFIX" >> "$GITHUB_OUTPUT"
           echo "artifact_prefix=matrix-desktop-desktop-canary" >> "$GITHUB_OUTPUT"
 
   build:
@@ -65,7 +70,7 @@ jobs:
 
       - name: Generate release manifest
         run: |
-          node scripts/release/generate-desktop-release-manifest.mjs desktop-release desktop-canary "${{ needs.prepare.outputs.suffix }}" canary "$GITHUB_SHA"
+          node scripts/release/generate-desktop-release-manifest.mjs desktop-release desktop-canary "${{ needs.prepare.outputs.version }}" canary "$GITHUB_SHA"
 
       - name: Write release notes
         run: |

--- a/.github/workflows/desktop-release-canary.yml
+++ b/.github/workflows/desktop-release-canary.yml
@@ -38,6 +38,7 @@ jobs:
     uses: ./.github/workflows/desktop-build.yml
     with:
       channel: canary
+      version: ${{ needs.prepare.outputs.version }}
       version_suffix: ${{ needs.prepare.outputs.suffix }}
       artifact_prefix: ${{ needs.prepare.outputs.artifact_prefix }}
       retention_days: 7

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -78,6 +78,10 @@ jobs:
             exit 1
           fi
           case "$CHANNEL" in stable|beta|canary) ;; *) echo "invalid channel: $CHANNEL" >&2; exit 1 ;; esac
+          if [ "$CHANNEL" != "stable" ] && [[ "$VERSION" != *-* ]]; then
+            echo "Non-stable desktop channels require a prerelease semver version." >&2
+            exit 1
+          fi
           PRERELEASE=false
           if [ "$CHANNEL" != "stable" ] || [[ "$VERSION" == *-* ]]; then
             PRERELEASE=true

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -1,0 +1,156 @@
+name: Desktop Release
+
+on:
+  push:
+    tags:
+      - "desktop-v*"
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Desktop version to release (semver, no leading v)"
+        required: true
+        type: string
+      channel:
+        description: Update channel.
+        required: true
+        default: stable
+        type: choice
+        options:
+          - stable
+          - beta
+          - canary
+      mode:
+        description: Dry-run uploads artifacts only; publish creates/updates the GitHub release.
+        required: true
+        default: dry-run
+        type: choice
+        options:
+          - dry-run
+          - publish
+
+permissions:
+  contents: write
+
+concurrency:
+  group: desktop-release-${{ github.ref_name || inputs.version }}-${{ inputs.channel || 'stable' }}
+  cancel-in-progress: false
+
+jobs:
+  prepare:
+    name: Prepare release metadata
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      tag: ${{ steps.meta.outputs.tag }}
+      version: ${{ steps.meta.outputs.version }}
+      channel: ${{ steps.meta.outputs.channel }}
+      mode: ${{ steps.meta.outputs.mode }}
+      prerelease: ${{ steps.meta.outputs.prerelease }}
+      artifact_prefix: ${{ steps.meta.outputs.artifact_prefix }}
+    steps:
+      - name: Resolve metadata
+        id: meta
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          REF_NAME: ${{ github.ref_name }}
+          INPUT_VERSION: ${{ inputs.version }}
+          INPUT_CHANNEL: ${{ inputs.channel }}
+          INPUT_MODE: ${{ inputs.mode }}
+        run: |
+          set -euo pipefail
+          if [ "$EVENT_NAME" = "push" ]; then
+            TAG="$REF_NAME"
+            VERSION="${TAG#desktop-v}"
+            CHANNEL="stable"
+            MODE="publish"
+          else
+            VERSION="$INPUT_VERSION"
+            TAG="desktop-v$VERSION"
+            CHANNEL="$INPUT_CHANNEL"
+            MODE="$INPUT_MODE"
+          fi
+          if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
+            echo "invalid desktop version: $VERSION" >&2
+            exit 1
+          fi
+          case "$CHANNEL" in stable|beta|canary) ;; *) echo "invalid channel: $CHANNEL" >&2; exit 1 ;; esac
+          PRERELEASE=false
+          if [ "$CHANNEL" != "stable" ] || [[ "$VERSION" == *-* ]]; then
+            PRERELEASE=true
+          fi
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "channel=$CHANNEL" >> "$GITHUB_OUTPUT"
+          echo "mode=$MODE" >> "$GITHUB_OUTPUT"
+          echo "prerelease=$PRERELEASE" >> "$GITHUB_OUTPUT"
+          echo "artifact_prefix=matrix-desktop-$TAG-$CHANNEL" >> "$GITHUB_OUTPUT"
+
+  build:
+    needs: prepare
+    uses: ./.github/workflows/desktop-build.yml
+    with:
+      channel: ${{ needs.prepare.outputs.channel }}
+      artifact_prefix: ${{ needs.prepare.outputs.artifact_prefix }}
+      retention_days: 30
+    secrets: inherit
+
+  release:
+    name: Publish release
+    needs: [prepare, build]
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/download-artifact@v6
+        with:
+          pattern: ${{ needs.prepare.outputs.artifact_prefix }}-*
+          path: desktop-release
+          merge-multiple: true
+
+      - name: Merge macOS update manifests
+        uses: ./.github/actions/merge-mac-manifests
+        with:
+          directory: desktop-release
+
+      - name: Generate release manifest
+        env:
+          TAG: ${{ needs.prepare.outputs.tag }}
+          VERSION: ${{ needs.prepare.outputs.version }}
+          CHANNEL: ${{ needs.prepare.outputs.channel }}
+        run: |
+          node scripts/release/generate-desktop-release-manifest.mjs desktop-release "$TAG" "$VERSION" "$CHANNEL" "$GITHUB_SHA"
+
+      - name: Generate GitHub release notes
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ needs.prepare.outputs.tag }}
+        run: |
+          set -euo pipefail
+          gh api "repos/${GITHUB_REPOSITORY}/releases/generate-notes" \
+            -f tag_name="$TAG" \
+            -f target_commitish="$GITHUB_SHA" \
+            -q .body > RELEASE_NOTES.md
+
+      - name: Upload dry-run bundle
+        if: ${{ needs.prepare.outputs.mode == 'dry-run' }}
+        uses: actions/upload-artifact@v6
+        with:
+          name: desktop-release-${{ needs.prepare.outputs.tag }}-${{ needs.prepare.outputs.channel }}
+          path: desktop-release/**
+          if-no-files-found: error
+          retention-days: 30
+
+      - name: Create GitHub release
+        if: ${{ needs.prepare.outputs.mode == 'publish' }}
+        uses: softprops/action-gh-release@v3
+        with:
+          tag_name: ${{ needs.prepare.outputs.tag }}
+          name: Matrix OS Desktop ${{ needs.prepare.outputs.version }}
+          target_commitish: ${{ github.sha }}
+          body_path: RELEASE_NOTES.md
+          prerelease: ${{ needs.prepare.outputs.prerelease }}
+          draft: false
+          make_latest: ${{ needs.prepare.outputs.channel == 'stable' }}
+          files: desktop-release/**
+          fail_on_unmatched_files: true

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -73,6 +73,10 @@ jobs:
             echo "invalid desktop version: $VERSION" >&2
             exit 1
           fi
+          if [ "$EVENT_NAME" = "push" ] && [[ "$VERSION" == *-* ]]; then
+            echo "Prerelease desktop versions must be released with workflow_dispatch so the channel is explicit." >&2
+            exit 1
+          fi
           case "$CHANNEL" in stable|beta|canary) ;; *) echo "invalid channel: $CHANNEL" >&2; exit 1 ;; esac
           PRERELEASE=false
           if [ "$CHANNEL" != "stable" ] || [[ "$VERSION" == *-* ]]; then

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -114,6 +114,14 @@ jobs:
         with:
           directory: desktop-release
 
+      - name: Merge channel macOS update manifests
+        if: ${{ needs.prepare.outputs.channel != 'stable' }}
+        uses: ./.github/actions/merge-mac-manifests
+        with:
+          directory: desktop-release
+          output: ${{ needs.prepare.outputs.channel }}-mac.yml
+          channel: ${{ needs.prepare.outputs.channel }}
+
       - name: Generate release manifest
         env:
           TAG: ${{ needs.prepare.outputs.tag }}

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -90,6 +90,7 @@ jobs:
     uses: ./.github/workflows/desktop-build.yml
     with:
       channel: ${{ needs.prepare.outputs.channel }}
+      version: ${{ needs.prepare.outputs.version }}
       artifact_prefix: ${{ needs.prepare.outputs.artifact_prefix }}
       retention_days: 30
     secrets: inherit
@@ -154,3 +155,4 @@ jobs:
           make_latest: ${{ needs.prepare.outputs.channel == 'stable' }}
           files: desktop-release/**
           fail_on_unmatched_files: true
+          overwrite_files: true

--- a/desktop/electron-builder.yml
+++ b/desktop/electron-builder.yml
@@ -1,5 +1,7 @@
 appId: com.matrix-os.operator
 productName: Matrix OS
+artifactName: Matrix-OS-${version}-${os}-${arch}.${ext}
+generateUpdatesFilesForAllChannels: true
 directories:
   buildResources: build
   output: dist
@@ -7,6 +9,10 @@ files:
   - out/**
   - "!**/.vite/**"
 asarUnpack: []
+protocols:
+  - name: Matrix OS
+    schemes:
+      - matrix-os
 mac:
   category: public.app-category.productivity
   target:
@@ -18,13 +24,15 @@ mac:
   gatekeeperAssess: false
   entitlements: build/entitlements.mac.plist
   entitlementsInherit: build/entitlements.mac.plist
-  # Notarization activates only when APPLE_ID / APPLE_APP_SPECIFIC_PASSWORD /
-  # APPLE_TEAM_ID are present in the release environment.
-  notarize: false
-dmg:
-  sign: false
-# Update feed: generic provider pointed at the R2-backed desktop release feed
-# (gateway/platform delta #4). electron-updater no-ops until the feed exists.
+  notarize: true
+linux:
+  category: Utility
+  target:
+    - target: AppImage
+      arch: [x64]
+# Update feed: GitHub releases by default. OPERATOR_UPDATE_FEED can still
+# override to a generic feed for break-glass or self-hosted release channels.
 publish:
-  - provider: generic
-    url: https://releases.matrix-os.com/desktop/${channel}
+  - provider: github
+    owner: HamedMP
+    repo: matrix-os

--- a/desktop/electron.vite.config.ts
+++ b/desktop/electron.vite.config.ts
@@ -4,7 +4,7 @@ import tailwindcss from "@tailwindcss/vite";
 import { resolve } from "node:path";
 
 const desktopUpdateChannel =
-  process.env.MATRIX_DESKTOP_UPDATE_CHANNEL ?? process.env.OPERATOR_UPDATE_CHANNEL ?? "";
+  process.env.MATRIX_DESKTOP_UPDATE_CHANNEL || process.env.OPERATOR_UPDATE_CHANNEL || "";
 
 export default defineConfig({
   main: {

--- a/desktop/electron.vite.config.ts
+++ b/desktop/electron.vite.config.ts
@@ -3,9 +3,15 @@ import react from "@vitejs/plugin-react";
 import tailwindcss from "@tailwindcss/vite";
 import { resolve } from "node:path";
 
+const desktopUpdateChannel =
+  process.env.MATRIX_DESKTOP_UPDATE_CHANNEL ?? process.env.OPERATOR_UPDATE_CHANNEL ?? "";
+
 export default defineConfig({
   main: {
     plugins: [externalizeDepsPlugin()],
+    define: {
+      __MATRIX_DESKTOP_UPDATE_CHANNEL__: JSON.stringify(desktopUpdateChannel),
+    },
     build: {
       rollupOptions: {
         input: { index: resolve(__dirname, "src/main/index.ts") },

--- a/desktop/src/main/update-config.ts
+++ b/desktop/src/main/update-config.ts
@@ -25,6 +25,14 @@ export type UpdateFeedConfig =
 const DEFAULT_OWNER = "HamedMP";
 const DEFAULT_REPO = "matrix-os";
 
+declare const __MATRIX_DESKTOP_UPDATE_CHANNEL__: string | undefined;
+
+function buildUpdateChannel(): string | undefined {
+  return typeof __MATRIX_DESKTOP_UPDATE_CHANNEL__ === "string"
+    ? __MATRIX_DESKTOP_UPDATE_CHANNEL__
+    : undefined;
+}
+
 function normalizeChannel(value: string | undefined): DesktopUpdateChannel {
   if (value === "beta" || value === "canary") return value;
   return "stable";
@@ -40,9 +48,10 @@ function firstNonEmpty(...values: Array<string | undefined>): string | undefined
 export function resolveUpdateFeedConfig(
   env: NodeJS.ProcessEnv,
   isPackaged: boolean,
+  bundledChannel: string | undefined = buildUpdateChannel(),
 ): UpdateFeedConfig {
   const channel = normalizeChannel(
-    firstNonEmpty(env.MATRIX_DESKTOP_UPDATE_CHANNEL, env.OPERATOR_UPDATE_CHANNEL),
+    firstNonEmpty(env.MATRIX_DESKTOP_UPDATE_CHANNEL, env.OPERATOR_UPDATE_CHANNEL, bundledChannel),
   );
   const allowPrerelease = channel !== "stable";
 

--- a/desktop/src/main/update-config.ts
+++ b/desktop/src/main/update-config.ts
@@ -1,0 +1,72 @@
+export type DesktopUpdateChannel = "stable" | "beta" | "canary";
+
+export type UpdateFeedConfig =
+  | {
+      enabled: false;
+      channel: DesktopUpdateChannel;
+      allowPrerelease: boolean;
+    }
+  | {
+      enabled: true;
+      provider: "generic";
+      url: string;
+      channel: DesktopUpdateChannel;
+      allowPrerelease: boolean;
+    }
+  | {
+      enabled: true;
+      provider: "github";
+      owner: string;
+      repo: string;
+      channel: DesktopUpdateChannel;
+      allowPrerelease: boolean;
+    };
+
+const DEFAULT_OWNER = "HamedMP";
+const DEFAULT_REPO = "matrix-os";
+
+function normalizeChannel(value: string | undefined): DesktopUpdateChannel {
+  if (value === "beta" || value === "canary") return value;
+  return "stable";
+}
+
+function firstNonEmpty(...values: Array<string | undefined>): string | undefined {
+  for (const value of values) {
+    if (value && value.trim().length > 0) return value.trim();
+  }
+  return undefined;
+}
+
+export function resolveUpdateFeedConfig(
+  env: NodeJS.ProcessEnv,
+  isPackaged: boolean,
+): UpdateFeedConfig {
+  const channel = normalizeChannel(
+    firstNonEmpty(env.MATRIX_DESKTOP_UPDATE_CHANNEL, env.OPERATOR_UPDATE_CHANNEL),
+  );
+  const allowPrerelease = channel !== "stable";
+
+  if (!isPackaged) {
+    return { enabled: false, channel, allowPrerelease };
+  }
+
+  const genericUrl = firstNonEmpty(env.OPERATOR_UPDATE_FEED, env.MATRIX_DESKTOP_UPDATE_FEED);
+  if (genericUrl) {
+    return {
+      enabled: true,
+      provider: "generic",
+      url: genericUrl,
+      channel,
+      allowPrerelease,
+    };
+  }
+
+  return {
+    enabled: true,
+    provider: "github",
+    owner: firstNonEmpty(env.MATRIX_DESKTOP_RELEASE_OWNER) ?? DEFAULT_OWNER,
+    repo: firstNonEmpty(env.MATRIX_DESKTOP_RELEASE_REPO) ?? DEFAULT_REPO,
+    channel,
+    allowPrerelease,
+  };
+}

--- a/desktop/src/main/updates.ts
+++ b/desktop/src/main/updates.ts
@@ -44,7 +44,7 @@ export function createUpdater(events: UpdateEvents): Updater {
 
   return {
     async check() {
-      if (status === "downloading" || status === "ready") return;
+      if (status === "checking" || status === "downloading" || status === "ready") return;
       status = "checking";
       try {
         const { autoUpdater } = await import("electron-updater");

--- a/desktop/src/main/updates.ts
+++ b/desktop/src/main/updates.ts
@@ -21,6 +21,7 @@ const UPDATER_EVENT_NAMES = [
   "update-available",
   "update-downloaded",
   "update-not-available",
+  "error",
 ] as const;
 
 export interface Updater {
@@ -73,6 +74,13 @@ export function createUpdater(events: UpdateEvents): Updater {
         });
         autoUpdater.once("update-not-available", () => {
           status = "up-to-date";
+        });
+        autoUpdater.once("error", (err) => {
+          console.warn(
+            "[updates] download failed:",
+            err instanceof Error ? err.message : String(err),
+          );
+          status = "error";
         });
         await autoUpdater.checkForUpdates();
       } catch (err: unknown) {

--- a/desktop/src/main/updates.ts
+++ b/desktop/src/main/updates.ts
@@ -43,7 +43,7 @@ export function createUpdater(events: UpdateEvents): Updater {
 
   return {
     async check() {
-      if (status === "downloading") return;
+      if (status === "downloading" || status === "ready") return;
       status = "checking";
       try {
         const { autoUpdater } = await import("electron-updater");

--- a/desktop/src/main/updates.ts
+++ b/desktop/src/main/updates.ts
@@ -43,6 +43,7 @@ export function createUpdater(events: UpdateEvents): Updater {
 
   return {
     async check() {
+      if (status === "downloading") return;
       status = "checking";
       try {
         const { autoUpdater } = await import("electron-updater");

--- a/desktop/src/main/updates.ts
+++ b/desktop/src/main/updates.ts
@@ -1,7 +1,8 @@
 // Auto-update (FR-091): background download, apply on relaunch, never
-// force-restarts attached work. No-ops cleanly until the desktop release feed
-// (gateway delta #4) exists and the build is signed.
+// force-restarts attached work. Packaged builds default to GitHub release
+// manifests; OPERATOR_UPDATE_FEED remains as a generic-provider override.
 import { app } from "electron";
+import { resolveUpdateFeedConfig } from "./update-config";
 
 export type UpdateStatus =
   | "disabled"
@@ -29,9 +30,9 @@ export interface Updater {
 
 export function createUpdater(events: UpdateEvents): Updater {
   let status: UpdateStatus = "disabled";
-  const feedConfigured = Boolean(process.env.OPERATOR_UPDATE_FEED) && app.isPackaged;
+  const feed = resolveUpdateFeedConfig(process.env, app.isPackaged);
 
-  if (!feedConfigured) {
+  if (!feed.enabled) {
     return {
       check: async () => {
         status = "disabled";
@@ -47,7 +48,16 @@ export function createUpdater(events: UpdateEvents): Updater {
         const { autoUpdater } = await import("electron-updater");
         autoUpdater.autoDownload = true;
         autoUpdater.autoInstallOnAppQuit = true;
-        autoUpdater.setFeedURL({ provider: "generic", url: process.env.OPERATOR_UPDATE_FEED! });
+        autoUpdater.allowPrerelease = feed.allowPrerelease;
+        if (feed.provider === "generic") {
+          autoUpdater.setFeedURL({ provider: "generic", url: feed.url });
+        } else {
+          autoUpdater.setFeedURL({
+            provider: "github",
+            owner: feed.owner,
+            repo: feed.repo,
+          });
+        }
         for (const eventName of UPDATER_EVENT_NAMES) {
           autoUpdater.removeAllListeners(eventName);
         }

--- a/desktop/src/main/updates.ts
+++ b/desktop/src/main/updates.ts
@@ -56,6 +56,7 @@ export function createUpdater(events: UpdateEvents): Updater {
             provider: "github",
             owner: feed.owner,
             repo: feed.repo,
+            ...(feed.channel === "stable" ? {} : { channel: feed.channel }),
           });
         }
         for (const eventName of UPDATER_EVENT_NAMES) {

--- a/docs/dev/desktop-release.md
+++ b/docs/dev/desktop-release.md
@@ -1,0 +1,99 @@
+# Desktop Release Runbook
+
+Matrix OS Desktop ships outside the customer VPS host-bundle flow. The app is
+signed, notarized, packaged, and updated through desktop GitHub release
+artifacts. The VPS host-bundle release still controls gateway and web shell
+runtime code.
+
+## Sources
+
+This pipeline borrows the useful parts of two working desktop release systems:
+
+- Superset: reusable desktop build workflow, mac arm64/x64 artifact split, app
+  update resource verification, canary prerelease, and merged mac update
+  manifests.
+- SlayZone: release manifest with SHA-256 sums, explicit channel metadata, and
+  dry-run release bundles before publish.
+
+## Required Secrets
+
+The macOS jobs expect an Apple Developer ID Application certificate readable by
+electron-builder:
+
+- `MATRIX_DESKTOP_MAC_CERTIFICATE` or `CSC_LINK`
+- `MATRIX_DESKTOP_MAC_CERTIFICATE_PASSWORD` or `CSC_KEY_PASSWORD`
+- `APPLE_ID`
+- `APPLE_APP_SPECIFIC_PASSWORD` or `APPLE_APP_PASSWORD`
+- `APPLE_TEAM_ID`
+
+`MATRIX_DESKTOP_MAC_CERTIFICATE` may be a base64-encoded `.p12` payload or a
+secure URL supported by electron-builder. Do not publish a public release from a
+run where signing or notarization was skipped.
+
+## Channels
+
+- Stable: tag `desktop-vX.Y.Z` or run `Desktop Release` with `channel=stable`
+  and `mode=publish`. Stable releases are eligible for GitHub's latest release.
+- Beta: run `Desktop Release` with `channel=beta`. The GitHub release is marked
+  prerelease and app builds allow prerelease updates.
+- Canary: `Desktop Canary Release` runs every 12 hours and can be triggered
+  manually. It moves the `desktop-canary` prerelease and appends a
+  `-canary.YYYYMMDDHHMMSS` version suffix in CI.
+
+## Dry Run
+
+Use dry-run mode for release pipeline changes:
+
+```bash
+gh workflow run desktop-release.yml \
+  -f version=0.1.0 \
+  -f channel=stable \
+  -f mode=dry-run
+```
+
+The run uploads a combined `desktop-release-*` artifact with installers,
+update manifests, `desktop-release-manifest.json`, and `SHA256SUMS.txt`.
+
+## Publish
+
+1. Confirm the desktop PR stack is merged and Greptile was 5/5 on every PR.
+2. Ensure `desktop/package.json` has the intended stable version.
+3. Create and push a tag:
+
+```bash
+git tag desktop-v0.1.0
+git push origin desktop-v0.1.0
+```
+
+The release workflow builds macOS arm64/x64 DMG+ZIP artifacts, Linux x64
+AppImage artifacts, merges `latest-mac.yml`, generates checksums, and creates
+the GitHub release with generated changelog notes.
+
+## Updates
+
+Packaged desktop builds default to GitHub releases as the update feed. The app
+checks on launch and then hourly. Downloads happen in the background and install
+only after the user quits and reopens the app.
+
+Environment overrides:
+
+- `MATRIX_DESKTOP_UPDATE_CHANNEL=stable|beta|canary`
+- `OPERATOR_UPDATE_FEED=https://...` for a generic-provider break-glass feed
+- `MATRIX_DESKTOP_RELEASE_OWNER` / `MATRIX_DESKTOP_RELEASE_REPO` for forks
+
+Never force-restart the app for an update; attached terminal/session work must
+survive until the user intentionally relaunches.
+
+## Verification
+
+For every published run:
+
+```bash
+gh release view desktop-v0.1.0 --json tagName,isPrerelease,latestRelease,assets
+gh release download desktop-v0.1.0 --pattern SHA256SUMS.txt --pattern desktop-release-manifest.json
+```
+
+Install the DMG on a clean macOS user, confirm Gatekeeper opens it without an
+unidentified-developer warning, sign in, then leave it running long enough to
+observe the update check in logs. For a canary smoke, install the canary DMG and
+confirm `MATRIX_DESKTOP_UPDATE_CHANNEL=canary` allows prerelease updates.

--- a/scripts/release/generate-desktop-release-manifest.mjs
+++ b/scripts/release/generate-desktop-release-manifest.mjs
@@ -1,0 +1,67 @@
+import { createHash } from "node:crypto";
+import { readdir, readFile, stat, writeFile } from "node:fs/promises";
+import { join, relative } from "node:path";
+
+const [directory, tag, version, channel, commit] = process.argv.slice(2);
+
+if (!directory || !tag || !version || !channel || !commit) {
+  console.error(
+    "usage: node scripts/release/generate-desktop-release-manifest.mjs <directory> <tag> <version> <channel> <commit>",
+  );
+  process.exit(1);
+}
+
+async function walk(dir) {
+  const entries = await readdir(dir, { withFileTypes: true });
+  const files = [];
+  for (const entry of entries) {
+    const path = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...(await walk(path)));
+    } else if (
+      !entry.name.endsWith(".blockmap") &&
+      entry.name !== "desktop-release-manifest.json" &&
+      entry.name !== "SHA256SUMS.txt"
+    ) {
+      files.push(path);
+    }
+  }
+  return files.sort();
+}
+
+async function sha256(path) {
+  const bytes = await readFile(path);
+  return createHash("sha256").update(bytes).digest("hex");
+}
+
+const files = await Promise.all(
+  (await walk(directory)).map(async (path) => {
+    const info = await stat(path);
+    return {
+      name: relative(directory, path).replaceAll("\\", "/"),
+      size: info.size,
+      sha256: await sha256(path),
+    };
+  }),
+);
+
+const manifest = {
+  kind: "matrix-desktop-release",
+  tag,
+  version,
+  channel,
+  commit,
+  generatedAt: new Date().toISOString(),
+  artifacts: files,
+};
+
+await writeFile(
+  join(directory, "desktop-release-manifest.json"),
+  `${JSON.stringify(manifest, null, 2)}\n`,
+);
+await writeFile(
+  join(directory, "SHA256SUMS.txt"),
+  `${files.map((file) => `${file.sha256}  ${file.name}`).join("\n")}\n`,
+);
+
+console.log(`wrote manifest for ${files.length} desktop artifacts`);

--- a/specs/094-electron-macos-shell/parity-checklist.md
+++ b/specs/094-electron-macos-shell/parity-checklist.md
@@ -112,8 +112,8 @@ secondary surfaces not yet exercised against the VPS.
 
 | Item | Status | Evidence |
 |---|---|---|
-| Signed + notarized macOS build | 🟡 | `electron-builder.yml` (hardenedRuntime, notarize-when-credentialed); needs signing creds |
-| Self-update over release channel | ⛔ | gateway delta #4 (desktop release feed); `updates.ts` no-ops without feed |
+| Signed + notarized macOS build | 🟢 | `desktop-build.yml` packages mac arm64/x64 with Developer ID signing + notarization secrets |
+| Self-update over release channel | 🟢 | packaged builds default to GitHub release manifests; `OPERATOR_UPDATE_FEED` remains a generic-feed override |
 | Single instance | ✅ | `requestSingleInstanceLock` in `index.ts` |
 | Platform-clean core (mac bits isolated) | ✅ | `platform/` layer; no mac-only deps elsewhere |
 

--- a/tests/desktop/auth-service.test.ts
+++ b/tests/desktop/auth-service.test.ts
@@ -400,7 +400,6 @@ describe("AuthService expireSession", () => {
   });
 
   it("emits signed-out status before persistent sign-out cleanup can fail", async () => {
-<<<<<<< HEAD
     const { auth, store, changes } = makeService({
       credential: VALID,
       profile: PROFILE,
@@ -411,25 +410,6 @@ describe("AuthService expireSession", () => {
     const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
     try {
       await auth.init();
-=======
-    const { store: credentialStore } = makeCredentialStore(VALID);
-    const onAuthChanged = vi.fn();
-    const cleanupError = new Error("credential clear failed");
-    credentialStore.clear = vi.fn(async () => {
-      throw cleanupError;
-    });
-    vi.spyOn(console, "warn").mockImplementation(() => undefined);
-    const auth = new AuthService({
-      credentialStore,
-      platformHost: "https://app.matrix-os.com",
-      now: () => 10_000,
-      loadProfile: async () => PROFILE,
-      saveProfile: vi.fn(async () => undefined),
-      clearProfile: vi.fn(async () => undefined),
-      onAuthChanged,
-    });
-    await auth.init();
->>>>>>> 0b933693b (test(desktop): align release auth cleanup fixture)
 
       await expect(auth.signOut()).rejects.toThrow(cleanupError);
 

--- a/tests/desktop/auth-service.test.ts
+++ b/tests/desktop/auth-service.test.ts
@@ -400,6 +400,7 @@ describe("AuthService expireSession", () => {
   });
 
   it("emits signed-out status before persistent sign-out cleanup can fail", async () => {
+<<<<<<< HEAD
     const { auth, store, changes } = makeService({
       credential: VALID,
       profile: PROFILE,
@@ -410,6 +411,25 @@ describe("AuthService expireSession", () => {
     const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
     try {
       await auth.init();
+=======
+    const { store: credentialStore } = makeCredentialStore(VALID);
+    const onAuthChanged = vi.fn();
+    const cleanupError = new Error("credential clear failed");
+    credentialStore.clear = vi.fn(async () => {
+      throw cleanupError;
+    });
+    vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    const auth = new AuthService({
+      credentialStore,
+      platformHost: "https://app.matrix-os.com",
+      now: () => 10_000,
+      loadProfile: async () => PROFILE,
+      saveProfile: vi.fn(async () => undefined),
+      clearProfile: vi.fn(async () => undefined),
+      onAuthChanged,
+    });
+    await auth.init();
+>>>>>>> 0b933693b (test(desktop): align release auth cleanup fixture)
 
       await expect(auth.signOut()).rejects.toThrow(cleanupError);
 

--- a/tests/desktop/desktop-release-workflows.test.ts
+++ b/tests/desktop/desktop-release-workflows.test.ts
@@ -15,8 +15,8 @@ describe("desktop release workflows", () => {
     expect(workflow).not.toContain("test -f desktop/dist/*-mac.yml");
     expect(workflow).toContain('mv desktop/dist/latest-mac.yml "desktop/dist/${{ matrix.arch }}-mac.yml"');
     expect(workflow).toContain('mv "desktop/dist/${CHANNEL}-mac.yml" "desktop/dist/${{ matrix.arch }}-${CHANNEL}-mac.yml"');
-    expect(workflow).toContain("! -name '${{ matrix.arch }}-mac.yml'");
-    expect(workflow).toContain("! -name '${{ matrix.arch }}-${CHANNEL}-mac.yml'");
+    expect(workflow).toContain('! -name "${{ matrix.arch }}-mac.yml"');
+    expect(workflow).toContain('! -name "${{ matrix.arch }}-${CHANNEL}-mac.yml"');
     expect(workflow).toContain("desktop/dist/*-mac.yml");
   });
 

--- a/tests/desktop/desktop-release-workflows.test.ts
+++ b/tests/desktop/desktop-release-workflows.test.ts
@@ -67,6 +67,13 @@ describe("desktop release workflows", () => {
     expect(release).toContain("Prerelease desktop versions must be released with workflow_dispatch");
   });
 
+  it("rejects stable semver versions on prerelease desktop channels", () => {
+    const release = readFileSync(join(root, ".github/workflows/desktop-release.yml"), "utf8");
+
+    expect(release).toContain('if [ "$CHANNEL" != "stable" ] && [[ "$VERSION" != *-* ]]; then');
+    expect(release).toContain("Non-stable desktop channels require a prerelease semver version.");
+  });
+
   it("merges mac manifests in deterministic filename order", () => {
     const dir = mkdtempSync(join(tmpdir(), "matrix-desktop-release-"));
     try {

--- a/tests/desktop/desktop-release-workflows.test.ts
+++ b/tests/desktop/desktop-release-workflows.test.ts
@@ -22,10 +22,24 @@ describe("desktop release workflows", () => {
     const workflow = readFileSync(join(root, ".github/workflows/desktop-release-canary.yml"), "utf8");
 
     expect(workflow).toContain("version: ${{ steps.meta.outputs.version }}");
+    expect(workflow).toContain("version: ${{ needs.prepare.outputs.version }}");
     expect(workflow).toContain("BASE_VERSION=");
     expect(workflow).toContain('echo "version=$BASE_VERSION-$SUFFIX" >> "$GITHUB_OUTPUT"');
     expect(workflow).toContain('${{ needs.prepare.outputs.version }}" canary "$GITHUB_SHA"');
     expect(workflow).not.toContain('${{ needs.prepare.outputs.suffix }}" canary "$GITHUB_SHA"');
+  });
+
+  it("patches exact release versions and validates notarization inputs before packaging", () => {
+    const build = readFileSync(join(root, ".github/workflows/desktop-build.yml"), "utf8");
+    const release = readFileSync(join(root, ".github/workflows/desktop-release.yml"), "utf8");
+
+    expect(build).toContain("Validate Apple notarization secrets");
+    expect(build).toContain("APPLE_ID, APPLE_APP_SPECIFIC_PASSWORD, and APPLE_TEAM_ID must be set together");
+    expect(build).toContain("Apply desktop release version");
+    expect(build).toContain("RELEASE_VERSION: ${{ inputs.version }}");
+    expect(build).toContain("j.version = exact ||");
+    expect(release).toContain("version: ${{ needs.prepare.outputs.version }}");
+    expect(release).toContain("overwrite_files: true");
   });
 
   it("merges mac manifests in deterministic filename order", () => {

--- a/tests/desktop/desktop-release-workflows.test.ts
+++ b/tests/desktop/desktop-release-workflows.test.ts
@@ -18,6 +18,16 @@ describe("desktop release workflows", () => {
     expect(workflow).toContain('! -name "${{ matrix.arch }}-mac.yml"');
     expect(workflow).toContain('! -name "${{ matrix.arch }}-${CHANNEL}-mac.yml"');
     expect(workflow).toContain("desktop/dist/*-mac.yml");
+    expect(workflow).toContain("desktop/dist/*.blockmap");
+  });
+
+  it("falls back from an empty desktop update channel at build time", () => {
+    const config = readFileSync(join(root, "desktop/electron.vite.config.ts"), "utf8");
+
+    expect(config).toContain(
+      "process.env.MATRIX_DESKTOP_UPDATE_CHANNEL || process.env.OPERATOR_UPDATE_CHANNEL || \"\"",
+    );
+    expect(config).not.toContain("MATRIX_DESKTOP_UPDATE_CHANNEL ?? process.env.OPERATOR_UPDATE_CHANNEL");
   });
 
   it("records the full canary app version in the release manifest", () => {

--- a/tests/desktop/desktop-release-workflows.test.ts
+++ b/tests/desktop/desktop-release-workflows.test.ts
@@ -14,7 +14,9 @@ describe("desktop release workflows", () => {
     expect(workflow).toContain("test -f desktop/dist/latest-mac.yml");
     expect(workflow).not.toContain("test -f desktop/dist/*-mac.yml");
     expect(workflow).toContain('mv desktop/dist/latest-mac.yml "desktop/dist/${{ matrix.arch }}-mac.yml"');
-    expect(workflow).toContain("find desktop/dist -maxdepth 1 -type f -name '*-mac.yml' ! -name '${{ matrix.arch }}-mac.yml' -delete");
+    expect(workflow).toContain('mv "desktop/dist/${CHANNEL}-mac.yml" "desktop/dist/${{ matrix.arch }}-${CHANNEL}-mac.yml"');
+    expect(workflow).toContain("! -name '${{ matrix.arch }}-mac.yml'");
+    expect(workflow).toContain("! -name '${{ matrix.arch }}-${CHANNEL}-mac.yml'");
     expect(workflow).toContain("desktop/dist/*-mac.yml");
   });
 
@@ -32,6 +34,7 @@ describe("desktop release workflows", () => {
   it("patches exact release versions and validates notarization inputs before packaging", () => {
     const build = readFileSync(join(root, ".github/workflows/desktop-build.yml"), "utf8");
     const release = readFileSync(join(root, ".github/workflows/desktop-release.yml"), "utf8");
+    const canary = readFileSync(join(root, ".github/workflows/desktop-release-canary.yml"), "utf8");
 
     expect(build).toContain("Validate Apple notarization secrets");
     expect(build).toContain("APPLE_ID, APPLE_APP_SPECIFIC_PASSWORD, and APPLE_TEAM_ID must be set together");
@@ -40,6 +43,10 @@ describe("desktop release workflows", () => {
     expect(build).toContain("j.version = exact ||");
     expect(release).toContain("version: ${{ needs.prepare.outputs.version }}");
     expect(release).toContain("overwrite_files: true");
+    expect(release).toContain("Merge channel macOS update manifests");
+    expect(release).toContain("output: ${{ needs.prepare.outputs.channel }}-mac.yml");
+    expect(canary).toContain("Merge canary macOS update manifests");
+    expect(canary).toContain("output: canary-mac.yml");
   });
 
   it("merges mac manifests in deterministic filename order", () => {
@@ -61,6 +68,46 @@ describe("desktop release workflows", () => {
       const merged = readFileSync(join(dir, "latest-mac.yml"), "utf8");
       expect(merged.indexOf("url: arm64.zip")).toBeLessThan(merged.indexOf("url: x64.zip"));
       expect(merged).toContain("path: arm64.zip");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("merges prerelease mac channel manifests separately from latest manifests", () => {
+    const dir = mkdtempSync(join(tmpdir(), "matrix-desktop-release-"));
+    try {
+      writeFileSync(
+        join(dir, "x64-mac.yml"),
+        "version: 1.2.3\nfiles:\n  - url: x64.zip\n    sha512: x64\n    size: 2\npath: x64.zip\nsha512: x64\n",
+      );
+      writeFileSync(
+        join(dir, "arm64-mac.yml"),
+        "version: 1.2.3\nfiles:\n  - url: arm64.zip\n    sha512: arm64\n    size: 1\npath: arm64.zip\nsha512: arm64\n",
+      );
+      writeFileSync(
+        join(dir, "x64-beta-mac.yml"),
+        "version: 1.2.3-beta.1\nfiles:\n  - url: beta-x64.zip\n    sha512: beta-x64\n    size: 2\npath: beta-x64.zip\nsha512: beta-x64\n",
+      );
+      writeFileSync(
+        join(dir, "arm64-beta-mac.yml"),
+        "version: 1.2.3-beta.1\nfiles:\n  - url: beta-arm64.zip\n    sha512: beta-arm64\n    size: 1\npath: beta-arm64.zip\nsha512: beta-arm64\n",
+      );
+
+      execFileSync(process.execPath, [join(root, ".github/actions/merge-mac-manifests/merge-mac-manifests.mjs")], {
+        env: { ...process.env, INPUT_DIRECTORY: dir },
+      });
+      execFileSync(process.execPath, [join(root, ".github/actions/merge-mac-manifests/merge-mac-manifests.mjs")], {
+        env: { ...process.env, INPUT_DIRECTORY: dir, INPUT_OUTPUT: "beta-mac.yml", INPUT_CHANNEL: "beta" },
+      });
+
+      const latest = readFileSync(join(dir, "latest-mac.yml"), "utf8");
+      const beta = readFileSync(join(dir, "beta-mac.yml"), "utf8");
+      expect(latest).toContain("url: arm64.zip");
+      expect(latest).toContain("url: x64.zip");
+      expect(latest).not.toContain("beta-arm64.zip");
+      expect(beta).toContain("url: beta-arm64.zip");
+      expect(beta).toContain("url: beta-x64.zip");
+      expect(beta).not.toContain("url: arm64.zip");
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }

--- a/tests/desktop/desktop-release-workflows.test.ts
+++ b/tests/desktop/desktop-release-workflows.test.ts
@@ -29,6 +29,7 @@ describe("desktop release workflows", () => {
     expect(workflow).toContain('echo "version=$BASE_VERSION-$SUFFIX" >> "$GITHUB_OUTPUT"');
     expect(workflow).toContain('${{ needs.prepare.outputs.version }}" canary "$GITHUB_SHA"');
     expect(workflow).not.toContain('${{ needs.prepare.outputs.suffix }}" canary "$GITHUB_SHA"');
+    expect(workflow).not.toContain("version_suffix:");
   });
 
   it("patches exact release versions and validates notarization inputs before packaging", () => {
@@ -71,6 +72,13 @@ describe("desktop release workflows", () => {
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }
+  });
+
+  it("ignores an existing latest-mac manifest when merging stable arch manifests", () => {
+    const script = readFileSync(join(root, ".github/actions/merge-mac-manifests/merge-mac-manifests.mjs"), "utf8");
+
+    expect(script).toContain("return /^(arm64|x64)-mac\\.yml$/.test(name);");
+    expect(script).not.toContain('name === "latest-mac.yml"');
   });
 
   it("merges prerelease mac channel manifests separately from latest manifests", () => {

--- a/tests/desktop/desktop-release-workflows.test.ts
+++ b/tests/desktop/desktop-release-workflows.test.ts
@@ -60,6 +60,13 @@ describe("desktop release workflows", () => {
     expect(canary).toContain("output: canary-mac.yml");
   });
 
+  it("rejects prerelease desktop tags on the push release path", () => {
+    const release = readFileSync(join(root, ".github/workflows/desktop-release.yml"), "utf8");
+
+    expect(release).toContain('if [ "$EVENT_NAME" = "push" ] && [[ "$VERSION" == *-* ]]; then');
+    expect(release).toContain("Prerelease desktop versions must be released with workflow_dispatch");
+  });
+
   it("merges mac manifests in deterministic filename order", () => {
     const dir = mkdtempSync(join(tmpdir(), "matrix-desktop-release-"));
     try {

--- a/tests/desktop/desktop-release-workflows.test.ts
+++ b/tests/desktop/desktop-release-workflows.test.ts
@@ -1,0 +1,51 @@
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const root = process.cwd();
+
+describe("desktop release workflows", () => {
+  it("renames mac update manifests before artifact upload", () => {
+    const workflow = readFileSync(join(root, ".github/workflows/desktop-build.yml"), "utf8");
+
+    expect(workflow).toContain("Rename mac update manifest for arch");
+    expect(workflow).toContain('mv desktop/dist/latest-mac.yml "desktop/dist/${{ matrix.arch }}-mac.yml"');
+    expect(workflow).toContain("desktop/dist/*-mac.yml");
+  });
+
+  it("records the full canary app version in the release manifest", () => {
+    const workflow = readFileSync(join(root, ".github/workflows/desktop-release-canary.yml"), "utf8");
+
+    expect(workflow).toContain("version: ${{ steps.meta.outputs.version }}");
+    expect(workflow).toContain("BASE_VERSION=");
+    expect(workflow).toContain('echo "version=$BASE_VERSION-$SUFFIX" >> "$GITHUB_OUTPUT"');
+    expect(workflow).toContain('${{ needs.prepare.outputs.version }}" canary "$GITHUB_SHA"');
+    expect(workflow).not.toContain('${{ needs.prepare.outputs.suffix }}" canary "$GITHUB_SHA"');
+  });
+
+  it("merges mac manifests in deterministic filename order", () => {
+    const dir = mkdtempSync(join(tmpdir(), "matrix-desktop-release-"));
+    try {
+      writeFileSync(
+        join(dir, "x64-mac.yml"),
+        "version: 1.2.3\nfiles:\n  - url: x64.zip\n    sha512: x64\n    size: 2\npath: x64.zip\nsha512: x64\n",
+      );
+      writeFileSync(
+        join(dir, "arm64-mac.yml"),
+        "version: 1.2.3\nfiles:\n  - url: arm64.zip\n    sha512: arm64\n    size: 1\npath: arm64.zip\nsha512: arm64\n",
+      );
+
+      execFileSync(process.execPath, [join(root, ".github/actions/merge-mac-manifests/merge-mac-manifests.mjs")], {
+        env: { ...process.env, INPUT_DIRECTORY: dir },
+      });
+
+      const merged = readFileSync(join(dir, "latest-mac.yml"), "utf8");
+      expect(merged.indexOf("url: arm64.zip")).toBeLessThan(merged.indexOf("url: x64.zip"));
+      expect(merged).toContain("path: arm64.zip");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/desktop/desktop-release-workflows.test.ts
+++ b/tests/desktop/desktop-release-workflows.test.ts
@@ -11,7 +11,10 @@ describe("desktop release workflows", () => {
     const workflow = readFileSync(join(root, ".github/workflows/desktop-build.yml"), "utf8");
 
     expect(workflow).toContain("Rename mac update manifest for arch");
+    expect(workflow).toContain("test -f desktop/dist/latest-mac.yml");
+    expect(workflow).not.toContain("test -f desktop/dist/*-mac.yml");
     expect(workflow).toContain('mv desktop/dist/latest-mac.yml "desktop/dist/${{ matrix.arch }}-mac.yml"');
+    expect(workflow).toContain("find desktop/dist -maxdepth 1 -type f -name '*-mac.yml' ! -name '${{ matrix.arch }}-mac.yml' -delete");
     expect(workflow).toContain("desktop/dist/*-mac.yml");
   });
 

--- a/tests/desktop/git-panel.test.tsx
+++ b/tests/desktop/git-panel.test.tsx
@@ -1,6 +1,7 @@
 // @vitest-environment jsdom
 
 import React from "react";
+import * as Tooltip from "@radix-ui/react-tooltip";
 import { cleanup, render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import GitPanel from "../../desktop/src/renderer/src/features/git/GitPanel";
@@ -28,7 +29,11 @@ describe("GitPanel", () => {
   });
 
   it("surfaces git load failures instead of rendering only empty counts", () => {
-    render(<GitPanel projectSlug="matrix-os" />);
+    render(
+      <Tooltip.Provider>
+        <GitPanel projectSlug="matrix-os" />
+      </Tooltip.Provider>,
+    );
 
     expect(screen.getByRole("status").textContent).toMatch(/connection/i);
   });

--- a/tests/desktop/session-merge.test.ts
+++ b/tests/desktop/session-merge.test.ts
@@ -322,7 +322,7 @@ describe("useSessions store", () => {
     useSessions.setState({ error: "offline" });
     const create = useSessions.getState().create(makeApi(get, post));
 
-    expect(useSessions.getState().loading).toBe(true);
+    expect(useSessions.getState().creating).toBe(true);
     expect(useSessions.getState().error).toBeNull();
 
     created.resolve({ name: "operator-new", created: true });

--- a/tests/desktop/update-config.test.ts
+++ b/tests/desktop/update-config.test.ts
@@ -32,6 +32,15 @@ describe("resolveUpdateFeedConfig", () => {
     });
   });
 
+  it("uses the bundled release channel when runtime env is absent", () => {
+    expect(resolveUpdateFeedConfig({}, true, "canary")).toMatchObject({
+      enabled: true,
+      provider: "github",
+      channel: "canary",
+      allowPrerelease: true,
+    });
+  });
+
   it("lets a generic feed override GitHub releases", () => {
     expect(
       resolveUpdateFeedConfig(

--- a/tests/desktop/update-config.test.ts
+++ b/tests/desktop/update-config.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import { resolveUpdateFeedConfig } from "../../desktop/src/main/update-config";
+
+describe("resolveUpdateFeedConfig", () => {
+  it("disables update checks outside packaged builds", () => {
+    expect(resolveUpdateFeedConfig({}, false)).toEqual({
+      enabled: false,
+      channel: "stable",
+      allowPrerelease: false,
+    });
+  });
+
+  it("uses GitHub releases for packaged stable builds by default", () => {
+    expect(resolveUpdateFeedConfig({}, true)).toEqual({
+      enabled: true,
+      provider: "github",
+      owner: "HamedMP",
+      repo: "matrix-os",
+      channel: "stable",
+      allowPrerelease: false,
+    });
+  });
+
+  it("allows prerelease channels for beta and canary builds", () => {
+    expect(
+      resolveUpdateFeedConfig({ MATRIX_DESKTOP_UPDATE_CHANNEL: "canary" }, true),
+    ).toMatchObject({
+      enabled: true,
+      provider: "github",
+      channel: "canary",
+      allowPrerelease: true,
+    });
+  });
+
+  it("lets a generic feed override GitHub releases", () => {
+    expect(
+      resolveUpdateFeedConfig(
+        {
+          OPERATOR_UPDATE_FEED: "https://releases.matrix-os.com/desktop/stable",
+          MATRIX_DESKTOP_UPDATE_CHANNEL: "beta",
+        },
+        true,
+      ),
+    ).toEqual({
+      enabled: true,
+      provider: "generic",
+      url: "https://releases.matrix-os.com/desktop/stable",
+      channel: "beta",
+      allowPrerelease: true,
+    });
+  });
+});

--- a/tests/desktop/updater.test.ts
+++ b/tests/desktop/updater.test.ts
@@ -78,6 +78,22 @@ describe("createUpdater", () => {
     expect(updater.status()).toBe("ready");
   });
 
+  it("does not start a second update check while one is already checking", async () => {
+    const updater = createUpdater({ onAvailable: vi.fn(), onReady: vi.fn() });
+
+    const firstCheck = updater.check();
+    expect(updater.status()).toBe("checking");
+    updaterMock.autoUpdater.removeAllListeners.mockClear();
+    updaterMock.autoUpdater.checkForUpdates.mockClear();
+
+    await updater.check();
+
+    expect(updater.status()).toBe("checking");
+    expect(updaterMock.autoUpdater.removeAllListeners).not.toHaveBeenCalled();
+    expect(updaterMock.autoUpdater.checkForUpdates).not.toHaveBeenCalled();
+    await firstCheck;
+  });
+
   it("does not reset ready status on later scheduled checks", async () => {
     const updater = createUpdater({ onAvailable: vi.fn(), onReady: vi.fn() });
 

--- a/tests/desktop/updater.test.ts
+++ b/tests/desktop/updater.test.ts
@@ -59,6 +59,24 @@ describe("createUpdater", () => {
     expect(updater.status()).toBe("downloading");
   });
 
+  it("does not replace download listeners while an update is downloading", async () => {
+    const onReady = vi.fn();
+    const updater = createUpdater({ onAvailable: vi.fn(), onReady });
+
+    await updater.check();
+    updaterMock.handlers.get("update-available")?.({ version: "1.2.3" });
+    updaterMock.autoUpdater.removeAllListeners.mockClear();
+    updaterMock.autoUpdater.checkForUpdates.mockClear();
+
+    await updater.check();
+
+    expect(updaterMock.autoUpdater.removeAllListeners).not.toHaveBeenCalled();
+    expect(updaterMock.autoUpdater.checkForUpdates).not.toHaveBeenCalled();
+    updaterMock.handlers.get("update-downloaded")?.({ version: "1.2.3" });
+    expect(onReady).toHaveBeenCalledWith("1.2.3");
+    expect(updater.status()).toBe("ready");
+  });
+
   it("reports ready through callbacks instead of check return timing", async () => {
     const onReady = vi.fn();
     const updater = createUpdater({ onAvailable: vi.fn(), onReady });

--- a/tests/desktop/updater.test.ts
+++ b/tests/desktop/updater.test.ts
@@ -6,7 +6,7 @@ const electronMock = vi.hoisted(() => ({
 }));
 
 const updaterMock = vi.hoisted(() => {
-  type UpdateHandler = (info: { version: string }) => void;
+  type UpdateHandler = (info: { version: string } | Error) => void;
   const handlers = new Map<string, UpdateHandler>();
   const autoUpdater = {
     autoDownload: false,
@@ -52,6 +52,7 @@ describe("createUpdater", () => {
     expect(updaterMock.autoUpdater.removeAllListeners).toHaveBeenCalledWith("update-available");
     expect(updaterMock.autoUpdater.removeAllListeners).toHaveBeenCalledWith("update-downloaded");
     expect(updaterMock.autoUpdater.removeAllListeners).toHaveBeenCalledWith("update-not-available");
+    expect(updaterMock.autoUpdater.removeAllListeners).toHaveBeenCalledWith("error");
 
     updaterMock.handlers.get("update-available")?.({ version: "1.2.3" });
     expect(onAvailable).toHaveBeenCalledOnce();
@@ -113,6 +114,25 @@ describe("createUpdater", () => {
 
     expect(updater.status()).toBe("error");
     expect(warn).toHaveBeenCalled();
+    warn.mockRestore();
+  });
+
+  it("recovers from asynchronous download errors so later checks can retry", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    const updater = createUpdater({ onAvailable: vi.fn(), onReady: vi.fn() });
+
+    await updater.check();
+    updaterMock.handlers.get("update-available")?.({ version: "1.2.3" });
+    expect(updater.status()).toBe("downloading");
+
+    updaterMock.handlers.get("error")?.(new Error("download failed"));
+    expect(updater.status()).toBe("error");
+
+    updaterMock.autoUpdater.checkForUpdates.mockClear();
+    await updater.check();
+
+    expect(updaterMock.autoUpdater.checkForUpdates).toHaveBeenCalledOnce();
+    expect(warn).toHaveBeenCalledWith("[updates] download failed:", "download failed");
     warn.mockRestore();
   });
 

--- a/tests/desktop/updater.test.ts
+++ b/tests/desktop/updater.test.ts
@@ -82,8 +82,8 @@ describe("createUpdater", () => {
     warn.mockRestore();
   });
 
-  it("stays disabled when no packaged update feed is configured", async () => {
-    delete process.env.OPERATOR_UPDATE_FEED;
+  it("stays disabled when the app is not packaged", async () => {
+    electronMock.app.isPackaged = false;
     const updater = createUpdater({ onAvailable: vi.fn(), onReady: vi.fn() });
 
     await updater.check();

--- a/tests/desktop/updater.test.ts
+++ b/tests/desktop/updater.test.ts
@@ -30,6 +30,7 @@ vi.mock("electron-updater", () => ({ autoUpdater: updaterMock.autoUpdater }));
 
 beforeEach(() => {
   process.env.OPERATOR_UPDATE_FEED = "https://updates.example.com";
+  delete process.env.MATRIX_DESKTOP_UPDATE_CHANNEL;
   electronMock.app.isPackaged = true;
   updaterMock.handlers.clear();
   updaterMock.autoUpdater.autoDownload = false;
@@ -80,6 +81,21 @@ describe("createUpdater", () => {
     expect(updater.status()).toBe("error");
     expect(warn).toHaveBeenCalled();
     warn.mockRestore();
+  });
+
+  it("passes the resolved prerelease channel to the GitHub provider", async () => {
+    delete process.env.OPERATOR_UPDATE_FEED;
+    process.env.MATRIX_DESKTOP_UPDATE_CHANNEL = "beta";
+    const updater = createUpdater({ onAvailable: vi.fn(), onReady: vi.fn() });
+
+    await updater.check();
+
+    expect(updaterMock.autoUpdater.setFeedURL).toHaveBeenCalledWith({
+      provider: "github",
+      owner: "HamedMP",
+      repo: "matrix-os",
+      channel: "beta",
+    });
   });
 
   it("stays disabled when the app is not packaged", async () => {

--- a/tests/desktop/updater.test.ts
+++ b/tests/desktop/updater.test.ts
@@ -77,6 +77,21 @@ describe("createUpdater", () => {
     expect(updater.status()).toBe("ready");
   });
 
+  it("does not reset ready status on later scheduled checks", async () => {
+    const updater = createUpdater({ onAvailable: vi.fn(), onReady: vi.fn() });
+
+    await updater.check();
+    updaterMock.handlers.get("update-downloaded")?.({ version: "1.2.3" });
+    updaterMock.autoUpdater.removeAllListeners.mockClear();
+    updaterMock.autoUpdater.checkForUpdates.mockClear();
+
+    await updater.check();
+
+    expect(updater.status()).toBe("ready");
+    expect(updaterMock.autoUpdater.removeAllListeners).not.toHaveBeenCalled();
+    expect(updaterMock.autoUpdater.checkForUpdates).not.toHaveBeenCalled();
+  });
+
   it("reports ready through callbacks instead of check return timing", async () => {
     const onReady = vi.fn();
     const updater = createUpdater({ onAvailable: vi.fn(), onReady });


### PR DESCRIPTION
## Summary

- Adds a reusable desktop build workflow for macOS arm64/x64 and Linux x64 AppImage artifacts.
- Adds stable/beta/canary desktop release workflows with GitHub release assets, merged mac update manifests, SHA256SUMS, and a desktop release manifest.
- Enables packaged desktop builds to check GitHub release manifests by default, with OPERATOR_UPDATE_FEED kept as a generic-provider override.
- Documents signing/notarization secrets, release channels, dry-run/publish commands, OTA behavior, and verification.

## Invariants

- Source of truth: GitHub desktop release artifacts and electron-builder update manifests are canonical for desktop app updates; customer VPS host bundles remain the source of truth for gateway/web runtime updates.
- Update behavior: the app checks on launch and hourly, downloads in the background, and only installs after user quit/reopen. It must never force-restart attached work.
- Signing boundary: public macOS releases require Developer ID signing plus notarization secrets in CI. A run without those secrets is not a public release candidate.
- Orphan states: a failed release publish can leave CI artifacts but no GitHub release; a failed canary publish can leave a moved tag but no usable update until rerun. Neither state mutates VPS runtime or user data.
- Deferred scope: Windows installers/Homebrew desktop casks are not included in this first desktop pipeline; the current desktop spec targets the Electron Operator stack and macOS-first distribution, with Linux AppImage added for CI/user coverage.

## Validation

- pnpm --filter desktop exec tsc --noEmit
- pnpm exec tsc --noEmit -p desktop/tsconfig.json
- pnpm exec vitest run tests/desktop/update-config.test.ts
- pnpm --filter desktop build
- bun run typecheck
- bun run check:patterns (0 violations; existing warnings only)
- git diff --check
- node --check .github/actions/merge-mac-manifests/merge-mac-manifests.mjs
- node --check scripts/release/generate-desktop-release-manifest.mjs
- smoke-tested merge-mac-manifests with temporary arm64/x64 manifests
- smoke-tested generate-desktop-release-manifest with temporary artifacts

## Screenshot

Not applicable: this PR changes CI/release automation, electron-builder config, and main-process updater behavior; it does not change renderer UI or visual styling.