### PR TITLE
feat(preview): browser-reachable preview platform with Stripe test mode

### DIFF
--- a/.github/workflows/preview-platform.yml
+++ b/.github/workflows/preview-platform.yml
@@ -8,15 +8,27 @@
 # Cloud Run service running as a dedicated runtime SA
 # (matrix-platform-preview-runner) that can only read preview/staging
 # secrets: the staging database, preview-generated platform/jwt/edge-router
-# secrets, the Clerk keys, and the R2 bundles credentials (required for
-# CUSTOMER_VPS_ENABLED=true boot validation -- no Hetzner token is mounted,
-# so previews cannot provision real VPSes). Production CLOUD_RUN_SERVICE,
-# its runtime SA, and its secrets are never referenced. The service is
-# IAM-authenticated only (no public ingress); reach a preview with
-#   gcloud run services proxy matrix-platform-preview --region europe-west3
-# or an identity token. Config lives in the GitHub "Preview" environment;
-# the jobs no-op with a notice when it is absent. Neon branch databases per
-# PR remain deferred (spec 093).
+# secrets, the Clerk keys, the R2 bundles credentials, and Stripe TEST-mode
+# secrets (test secret key, test webhook secret, test price IDs). Production
+# CLOUD_RUN_SERVICE, its runtime SA, and its secrets are never referenced, and
+# only test-mode Stripe keys are mounted -- a preview can never touch live money
+# or the production database.
+#
+# Exposure: the service runs with public ingress (--allow-unauthenticated),
+# exactly like the production platform -- the app enforces its own Clerk/JWT
+# auth on every route, and the operator API stays gated by the preview
+# PLATFORM_SECRET. It is fronted by the browser-reachable host
+# https://preview.matrix-os.com so onboarding/billing PRs can be walked end to
+# end before merge. Previews are still per-PR tagged, zero-traffic revisions;
+# to walk a specific PR, route its tag to the host:
+#   gcloud run services update-traffic matrix-platform-preview \
+#     --region europe-west3 --to-tags pr-<N>=100
+# then reset when done. No Hetzner token is mounted, so previews still cannot
+# provision real VPSes (enabling the provisioned hand-off slice is a separate,
+# deliberate change -- a preview-scoped Hetzner token plus VPS reaping).
+# Config lives in the GitHub "Preview" environment; the jobs no-op with a
+# notice when it is absent. Neon branch databases per PR remain deferred
+# (spec 093).
 
 name: Preview Platform
 
@@ -106,6 +118,9 @@ jobs:
           # Derive the deterministic service URL (no hardcoded project number).
           project_number="$(gcloud projects describe "$GCP_PROJECT_ID" --format='value(projectNumber)')"
           public_url="https://${CLOUD_RUN_PREVIEW_SERVICE}-${project_number}.${GCP_REGION}.run.app"
+          # Browser-reachable preview host (custom domain mapped to this service).
+          # Origins/redirects and Stripe return URLs resolve to this host.
+          PREVIEW_PUBLIC_URL="${PREVIEW_PUBLIC_URL:-https://preview.matrix-os.com}"
           gcloud run deploy "$CLOUD_RUN_PREVIEW_SERVICE" \
             --project "$GCP_PROJECT_ID" \
             --region "$GCP_REGION" \
@@ -113,9 +128,9 @@ jobs:
             --service-account "$CLOUD_RUN_SERVICE_ACCOUNT" \
             --tag "pr-${PR_NUMBER}" \
             --no-traffic \
-            --no-allow-unauthenticated \
-            --set-env-vars "PLATFORM_RUNTIME_MODE=cloud_run,PLATFORM_PORT=8080,PLATFORM_PREVIEW=true,CUSTOMER_VPS_ENABLED=true,CUSTOMER_VPS_IMAGE_VERSION=dev,CUSTOMER_VPS_CLOUD_INIT_PATH=distro/customer-vps/cloud-init.yaml,AUTH_SHELL_HOST=127.0.0.1,AUTH_SHELL_PORT=3200,MATRIX_LEGACY_CONTAINER_ROUTING_ENABLED=false,PLATFORM_PUBLIC_URL=${public_url}" \
-            --set-secrets "PLATFORM_DATABASE_URL=platform-database-url-staging:latest,PLATFORM_SECRET=platform-preview-secret:latest,PLATFORM_JWT_SECRET=platform-preview-jwt-secret:latest,EDGE_ROUTER_SECRET=edge-router-preview-secret:latest,CLERK_SECRET_KEY=clerk-secret-key:latest,NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=next-public-clerk-publishable-key:latest,R2_BUNDLES_ACCOUNT_ID=r2-bundles-account-id:latest,R2_BUNDLES_BUCKET=r2-bundles-bucket:latest,R2_BUNDLES_ENDPOINT=r2-bundles-endpoint:latest,R2_BUNDLES_ACCESS_KEY_ID=r2-bundles-access-key-id:latest,R2_BUNDLES_SECRET_ACCESS_KEY=r2-bundles-secret-access-key:latest" \
+            --allow-unauthenticated \
+            --set-env-vars "PLATFORM_RUNTIME_MODE=cloud_run,PLATFORM_PORT=8080,PLATFORM_PREVIEW=true,CUSTOMER_VPS_ENABLED=true,CUSTOMER_VPS_IMAGE_VERSION=dev,CUSTOMER_VPS_CLOUD_INIT_PATH=distro/customer-vps/cloud-init.yaml,AUTH_SHELL_HOST=127.0.0.1,AUTH_SHELL_PORT=3200,MATRIX_LEGACY_CONTAINER_ROUTING_ENABLED=false,MATRIX_STRIPE_BILLING_ENABLED=true,PLATFORM_PUBLIC_URL=${PREVIEW_PUBLIC_URL},MATRIX_APP_URL=${PREVIEW_PUBLIC_URL},MATRIX_APP_DOMAIN_HOSTS=preview.matrix-os.com" \
+            --set-secrets "PLATFORM_DATABASE_URL=platform-database-url-staging:latest,PLATFORM_SECRET=platform-preview-secret:latest,PLATFORM_JWT_SECRET=platform-preview-jwt-secret:latest,EDGE_ROUTER_SECRET=edge-router-preview-secret:latest,CLERK_SECRET_KEY=clerk-secret-key:latest,NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=next-public-clerk-publishable-key:latest,R2_BUNDLES_ACCOUNT_ID=r2-bundles-account-id:latest,R2_BUNDLES_BUCKET=r2-bundles-bucket:latest,R2_BUNDLES_ENDPOINT=r2-bundles-endpoint:latest,R2_BUNDLES_ACCESS_KEY_ID=r2-bundles-access-key-id:latest,R2_BUNDLES_SECRET_ACCESS_KEY=r2-bundles-secret-access-key:latest,STRIPE_SECRET_KEY=stripe-secret-key-test:latest,STRIPE_WEBHOOK_SECRET=stripe-webhook-secret-test:latest,STRIPE_PRICE_MATRIX_STARTER_MONTHLY=stripe-price-matrix-starter-monthly-test:latest,STRIPE_PRICE_MATRIX_STARTER_ANNUAL=stripe-price-matrix-starter-annual-test:latest,STRIPE_PRICE_MATRIX_BUILDER_MONTHLY=stripe-price-matrix-builder-monthly-test:latest,STRIPE_PRICE_MATRIX_BUILDER_ANNUAL=stripe-price-matrix-builder-annual-test:latest,STRIPE_PRICE_MATRIX_MAX_MONTHLY=stripe-price-matrix-max-monthly-test:latest,STRIPE_PRICE_MATRIX_MAX_ANNUAL=stripe-price-matrix-max-annual-test:latest" \
             --cpu 1 --memory 1Gi --concurrency 10 --timeout 300 --min-instances 0 --max-instances 2 \
             --quiet
           desc="$(gcloud run services describe "$CLOUD_RUN_PREVIEW_SERVICE" \
@@ -128,6 +143,7 @@ jobs:
             url="https://pr-${PR_NUMBER}---${base#https://}"
           fi
           echo "PREVIEW_URL=$url" >> "$GITHUB_ENV"
+          echo "PREVIEW_PUBLIC_URL=$PREVIEW_PUBLIC_URL" >> "$GITHUB_ENV"
 
       - name: Comment preview URL on PR
         if: steps.config.outputs.configured == 'true' && github.event_name == 'pull_request'
@@ -137,10 +153,11 @@ jobs:
           set -euo pipefail
           body="**Platform preview revision deployed**
 
-          - URL: ${PREVIEW_URL} (IAM-authenticated; use \`gcloud run services proxy ${CLOUD_RUN_PREVIEW_SERVICE} --region ${GCP_REGION}\` or an identity token)
-          - Service: \`${CLOUD_RUN_PREVIEW_SERVICE}\` (zero traffic, tag \`pr-${PR_NUMBER}\`)
+          - Browser-reachable host: ${PREVIEW_PUBLIC_URL} (route this PR's tag to it: \`gcloud run services update-traffic ${CLOUD_RUN_PREVIEW_SERVICE} --region ${GCP_REGION} --to-tags pr-${PR_NUMBER}=100\`, then reset when done)
+          - Revision URL: ${PREVIEW_URL}
+          - Service: \`${CLOUD_RUN_PREVIEW_SERVICE}\` (deployed zero-traffic, tag \`pr-${PR_NUMBER}\`)
 
-          Preview revisions run as the preview runtime SA against the staging database; production service, SA, and secrets are untouched."
+          Runs as the preview runtime SA against the staging database with Stripe TEST-mode keys; production service, SA, database, and live Stripe keys are untouched."
           existing="$(gh api "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" \
             --jq '[.[] | select(.body | startswith("**Platform preview revision deployed**"))] | .[0].id // ""')"
           if [ -n "$existing" ]; then

--- a/.github/workflows/preview-platform.yml
+++ b/.github/workflows/preview-platform.yml
@@ -118,9 +118,14 @@ jobs:
           # Derive the deterministic service URL (no hardcoded project number).
           project_number="$(gcloud projects describe "$GCP_PROJECT_ID" --format='value(projectNumber)')"
           public_url="https://${CLOUD_RUN_PREVIEW_SERVICE}-${project_number}.${GCP_REGION}.run.app"
-          # Browser-reachable preview host (custom domain mapped to this service).
+          # Browser-reachable preview host (custom domain routed to this service).
           # Origins/redirects and Stripe return URLs resolve to this host.
           PREVIEW_PUBLIC_URL="${PREVIEW_PUBLIC_URL:-https://preview.matrix-os.com}"
+          # Derive the bare host so MATRIX_APP_DOMAIN_HOSTS always tracks
+          # PREVIEW_PUBLIC_URL (origin/CORS checks must match the real host).
+          PREVIEW_DOMAIN="${PREVIEW_PUBLIC_URL#http://}"
+          PREVIEW_DOMAIN="${PREVIEW_DOMAIN#https://}"
+          PREVIEW_DOMAIN="${PREVIEW_DOMAIN%%/*}"
           gcloud run deploy "$CLOUD_RUN_PREVIEW_SERVICE" \
             --project "$GCP_PROJECT_ID" \
             --region "$GCP_REGION" \
@@ -129,7 +134,7 @@ jobs:
             --tag "pr-${PR_NUMBER}" \
             --no-traffic \
             --allow-unauthenticated \
-            --set-env-vars "PLATFORM_RUNTIME_MODE=cloud_run,PLATFORM_PORT=8080,PLATFORM_PREVIEW=true,CUSTOMER_VPS_ENABLED=true,CUSTOMER_VPS_IMAGE_VERSION=dev,CUSTOMER_VPS_CLOUD_INIT_PATH=distro/customer-vps/cloud-init.yaml,AUTH_SHELL_HOST=127.0.0.1,AUTH_SHELL_PORT=3200,MATRIX_LEGACY_CONTAINER_ROUTING_ENABLED=false,MATRIX_STRIPE_BILLING_ENABLED=true,PLATFORM_PUBLIC_URL=${PREVIEW_PUBLIC_URL},MATRIX_APP_URL=${PREVIEW_PUBLIC_URL},MATRIX_APP_DOMAIN_HOSTS=preview.matrix-os.com" \
+            --set-env-vars "PLATFORM_RUNTIME_MODE=cloud_run,PLATFORM_PORT=8080,PLATFORM_PREVIEW=true,CUSTOMER_VPS_ENABLED=true,CUSTOMER_VPS_IMAGE_VERSION=dev,CUSTOMER_VPS_CLOUD_INIT_PATH=distro/customer-vps/cloud-init.yaml,AUTH_SHELL_HOST=127.0.0.1,AUTH_SHELL_PORT=3200,MATRIX_LEGACY_CONTAINER_ROUTING_ENABLED=false,MATRIX_STRIPE_BILLING_ENABLED=true,PLATFORM_PUBLIC_URL=${PREVIEW_PUBLIC_URL},MATRIX_APP_URL=${PREVIEW_PUBLIC_URL},MATRIX_APP_DOMAIN_HOSTS=${PREVIEW_DOMAIN}" \
             --set-secrets "PLATFORM_DATABASE_URL=platform-database-url-staging:latest,PLATFORM_SECRET=platform-preview-secret:latest,PLATFORM_JWT_SECRET=platform-preview-jwt-secret:latest,EDGE_ROUTER_SECRET=edge-router-preview-secret:latest,CLERK_SECRET_KEY=clerk-secret-key:latest,NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=next-public-clerk-publishable-key:latest,R2_BUNDLES_ACCOUNT_ID=r2-bundles-account-id:latest,R2_BUNDLES_BUCKET=r2-bundles-bucket:latest,R2_BUNDLES_ENDPOINT=r2-bundles-endpoint:latest,R2_BUNDLES_ACCESS_KEY_ID=r2-bundles-access-key-id:latest,R2_BUNDLES_SECRET_ACCESS_KEY=r2-bundles-secret-access-key:latest,STRIPE_SECRET_KEY=stripe-secret-key-test:latest,STRIPE_WEBHOOK_SECRET=stripe-webhook-secret-test:latest,STRIPE_PRICE_MATRIX_STARTER_MONTHLY=stripe-price-matrix-starter-monthly-test:latest,STRIPE_PRICE_MATRIX_STARTER_ANNUAL=stripe-price-matrix-starter-annual-test:latest,STRIPE_PRICE_MATRIX_BUILDER_MONTHLY=stripe-price-matrix-builder-monthly-test:latest,STRIPE_PRICE_MATRIX_BUILDER_ANNUAL=stripe-price-matrix-builder-annual-test:latest,STRIPE_PRICE_MATRIX_MAX_MONTHLY=stripe-price-matrix-max-monthly-test:latest,STRIPE_PRICE_MATRIX_MAX_ANNUAL=stripe-price-matrix-max-annual-test:latest" \
             --cpu 1 --memory 1Gi --concurrency 10 --timeout 300 --min-instances 0 --max-instances 2 \
             --quiet

--- a/docs/dev/preview-environments.md
+++ b/docs/dev/preview-environments.md
@@ -117,9 +117,13 @@ The label workflow assumes this is already provisioned in GCP/Cloudflare/Stripe
 1. **Stripe test secrets** in Secret Manager (test mode only):
    `stripe-secret-key-test`, `stripe-webhook-secret-test`,
    `stripe-price-matrix-{starter,builder,max}-{monthly,annual}-test`.
-2. **Custom domain** `preview.matrix-os.com` mapped to the
-   `matrix-platform-preview` service (Cloud Run domain mapping) with a
-   Cloudflare DNS record, same as production app/api hosts.
+2. **Routing** `preview.matrix-os.com` → the `matrix-platform-preview` run.app
+   origin (`matrix-platform-preview-<hash>-ey.a.run.app`) via Cloudflare, the
+   **same mechanism app/api.matrix-os.com use** (Cloud Run domain mappings are
+   not available in `europe-west3`, so this is Cloudflare-proxied with the
+   run.app Host header, not a GCP domain mapping). Because previews are tagged
+   zero-traffic revisions, also route the PR under test to traffic
+   (`update-traffic --to-tags pr-<N>=100`) so the base origin serves it.
 3. **Stripe test webhook** → `https://preview.matrix-os.com/billing/webhooks/stripe`
    (`checkout.session.completed`, `.expired`, `customer.subscription.*`); store
    its signing secret as `stripe-webhook-secret-test`.

--- a/docs/dev/preview-environments.md
+++ b/docs/dev/preview-environments.md
@@ -100,9 +100,14 @@ the PR you want to walk, then reset:
 ```bash
 gcloud run services update-traffic matrix-platform-preview \
   --region europe-west3 --to-tags pr-<N>=100      # walk this PR
-gcloud run services update-traffic matrix-platform-preview \
-  --region europe-west3 --to-latest               # reset when done
 ```
+
+The host serves whichever PR tag currently holds traffic, so switching to
+another PR is just another `--to-tags pr-<M>=100` (no separate reset needed).
+Avoid `--to-latest` here — on this service "latest" is the most recently
+*deployed* PR revision, not a stable base, so it would leave the host pinned to
+whatever deployed last. To park the host on a known-good target, point traffic
+at an explicit revision/tag you designate as the resting state.
 
 Provisioning the boot→ready hand-off in the browser is still out of scope (no
 Hetzner token on preview); enabling it is a deliberate follow-up (a

--- a/docs/dev/preview-environments.md
+++ b/docs/dev/preview-environments.md
@@ -75,18 +75,55 @@ pipeline and remains the manual/deep-debug path.
 Add the **`preview-platform`** label. The workflow (bound to the GitHub
 `Preview` environment) deploys the platform image to the dedicated
 `matrix-platform-preview` Cloud Run service as a zero-traffic tagged revision
-(`https://pr-<N>---<service-url>`). The service is **IAM-authenticated only**
-— reach it with `gcloud run services proxy matrix-platform-preview --region
-europe-west3` or an identity token. It runs as the dedicated
+(`https://pr-<N>---<service-url>`). It runs as the dedicated
 `matrix-platform-preview-runner` SA, which can read only: the **staging**
 database (`platform-database-url-staging` — previews share it; Neon branch
 per PR is deferred, spec 093), preview-generated platform/JWT/edge-router
-secrets, the Clerk keys, and the R2 bundles credentials (required by
-`CUSTOMER_VPS_ENABLED=true` boot validation). No Hetzner token is mounted, so
-a preview platform cannot provision real VPSes. On PR close the workflow
-removes the `pr-<N>` tag and deletes its revisions, mirroring the VPS
-teardown model. Production `CLOUD_RUN_SERVICE`, its runtime SA, and its
-secrets are never referenced.
+secrets, the Clerk keys, the R2 bundles credentials (required by
+`CUSTOMER_VPS_ENABLED=true` boot validation), and **Stripe TEST-mode** secrets.
+Production `CLOUD_RUN_SERVICE`, its runtime SA, its database, and live Stripe
+keys are never referenced. No Hetzner token is mounted, so a preview platform
+cannot provision real VPSes. On PR close the workflow removes the `pr-<N>` tag
+and deletes its revisions, mirroring the VPS teardown model.
+
+**Browser-reachable onboarding/billing.** The service runs with public ingress
+(`--allow-unauthenticated`, exactly like production — the app enforces its own
+Clerk/JWT auth, the operator API stays gated by the preview `PLATFORM_SECRET`)
+and is fronted by **`https://preview.matrix-os.com`**. So a labelled PR can be
+walked end to end in a browser before merge: sign in → plan → Stripe **test**
+checkout (`4242 4242 4242 4242`) → settling → journey. Origins/redirects
+resolve to the preview host (`MATRIX_APP_URL`/`PLATFORM_PUBLIC_URL`).
+
+Previews are still per-PR tagged, zero-traffic revisions, so point the host at
+the PR you want to walk, then reset:
+
+```bash
+gcloud run services update-traffic matrix-platform-preview \
+  --region europe-west3 --to-tags pr-<N>=100      # walk this PR
+gcloud run services update-traffic matrix-platform-preview \
+  --region europe-west3 --to-latest               # reset when done
+```
+
+Provisioning the boot→ready hand-off in the browser is still out of scope (no
+Hetzner token on preview); enabling it is a deliberate follow-up (a
+preview-scoped Hetzner token + VPS reaping). For that slice today, use the
+feature-VPS path in [Staging Platform and Feature VPS Runbook](staging-platform-vps.md).
+
+### One-time infrastructure setup
+
+The label workflow assumes this is already provisioned in GCP/Cloudflare/Stripe
+(run by an owner with the relevant access — the workflow only deploys):
+
+1. **Stripe test secrets** in Secret Manager (test mode only):
+   `stripe-secret-key-test`, `stripe-webhook-secret-test`,
+   `stripe-price-matrix-{starter,builder,max}-{monthly,annual}-test`.
+2. **Custom domain** `preview.matrix-os.com` mapped to the
+   `matrix-platform-preview` service (Cloud Run domain mapping) with a
+   Cloudflare DNS record, same as production app/api hosts.
+3. **Stripe test webhook** → `https://preview.matrix-os.com/billing/webhooks/stripe`
+   (`checkout.session.completed`, `.expired`, `customer.subscription.*`); store
+   its signing secret as `stripe-webhook-secret-test`.
+4. Grant `matrix-platform-preview-runner` `secretAccessor` on the new secrets.
 
 ## Centralized logs
 


### PR DESCRIPTION
## Summary

Closes the preview gap: today no environment runs **branch** platform code with
**Stripe test mode** against a **non-prod DB**, browser-reachable — so the 092
onboarding/billing flow (journey -> plan -> checkout -> settling) can't be
walked before merge. This makes `matrix-platform-preview` that environment.

**Draft** — the workflow change is ready, but it depends on one-time infra you
need to provision (my `gcloud` token is expired; some steps need the
Cloudflare/Stripe dashboards). See "Owner setup" below; once done, label any PR
`preview-platform` and walk it at `https://preview.matrix-os.com`.

## What the workflow now does

- Deploys the preview service with **public ingress** (`--allow-unauthenticated`),
  exactly like production `matrix-platform`. App-level Clerk/JWT auth gates every
  route; the operator API stays gated by the preview `PLATFORM_SECRET`.
- Mounts **Stripe TEST** secrets + `MATRIX_STRIPE_BILLING_ENABLED=true`.
- Sets `PLATFORM_PUBLIC_URL`/`MATRIX_APP_URL` to `https://preview.matrix-os.com`
  so 092d origins resolve redirects/return URLs correctly.
- Keeps per-PR tagged, zero-traffic revisions; PR comment shows how to route a
  tag to 100% traffic to walk it, then reset.

## Invariants / security

- **Source of truth / data**: staging DB only (`platform-database-url-staging`).
  Production DB, SA, service, and **live Stripe keys** are never referenced.
- **Auth matrix**: public ingress + app Clerk/JWT auth (same as prod) +
  `PLATFORM_SECRET`-gated operator API. No new bypass.
- **Money**: test-mode Stripe only — a preview can never touch live money.
- **Provisioning**: no Hetzner token mounted, so previews still cannot create
  real VPSes. The browser boot->ready hand-off is explicitly **out of scope**
  here (deliberate follow-up: preview-scoped Hetzner token + reaping).
- **Blast radius**: one shared preview service; walk one PR at a time via traffic
  routing.

## Owner setup (one-time, needs GCP/Cloudflare/Stripe access)

```bash
gcloud auth login   # my token is expired

# 1) Stripe TEST secrets in Secret Manager
for s in stripe-secret-key-test stripe-webhook-secret-test \
  stripe-price-matrix-{starter,builder,max}-{monthly,annual}-test; do
  printf '%s' "<value>" | gcloud secrets create "$s" --data-file=- --project matrix-os-1144 || \
  printf '%s' "<value>" | gcloud secrets versions add "$s" --data-file=- --project matrix-os-1144
  gcloud secrets add-iam-policy-binding "$s" --project matrix-os-1144 \
    --member="serviceAccount:matrix-platform-preview-runner@matrix-os-1144.iam.gserviceaccount.com" \
    --role=roles/secretmanager.secretAccessor
done

# 2) Map preview.matrix-os.com to the service (Cloud Run domain mapping) + add the
#    Cloudflare DNS record, same mechanism as app/api.matrix-os.com.
gcloud beta run domain-mappings create --service matrix-platform-preview \
  --domain preview.matrix-os.com --region europe-west3 --project matrix-os-1144

# 3) Stripe TEST webhook -> https://preview.matrix-os.com/billing/webhooks/stripe
#    (checkout.session.completed/.expired, customer.subscription.*); store its
#    signing secret as stripe-webhook-secret-test.
```

I can run the Stripe webhook creation via the `stripe` CLI (it's authed in test
mode here) once the host resolves — say the word.

## Tests

Workflow + docs only; no app code. `check:patterns` clean, YAML validated. Cannot
dry-run the Cloud Run deploy (gcloud auth expired) — verify on first labelled deploy.

## Review/Monitoring

Greptile to 5/5. Keep as draft until the owner setup lands and a labelled deploy
is verified at `https://preview.matrix-os.com`.