### PR TITLE
fix(symphony): report truthful Linear credential status and persist host env

### DIFF
--- a/distro/customer-vps/host-bin/matrix-symphony-control
+++ b/distro/customer-vps/host-bin/matrix-symphony-control
@@ -35,10 +35,22 @@ unit_available() {
   systemctl cat "$UNIT" >/dev/null 2>&1
 }
 
-credential_configured() {
-  local credential_dir="$MATRIX_HOME/system/symphony/credentials"
-  [ -d "$credential_dir" ] || return 1
-  find "$credential_dir" -maxdepth 1 -type f -name '*.linear' -size +0c -print -quit | grep -q .
+# Reports whether the Symphony->platform Linear bridge is wired on this host:
+# the env file must carry the handle, platform URL, and upgrade token the
+# Elixir service uses to reach platform-owned Linear credentials. This is a
+# host-verifiable precondition, not proof Linear is connected -- the
+# authoritative connection signal is the Symphony service credential_status
+# (derived from a live Linear poll). The previous check scanned a Symphony
+# credential directory for a per-credential file that nothing on the host ever
+# creates, so it was always false.
+SYMPHONY_ENV_FILE="${SYMPHONY_ENV_FILE:-/opt/matrix/env/symphony.env}"
+bridge_configured() {
+  [ -r "$SYMPHONY_ENV_FILE" ] || return 1
+  local key
+  for key in MATRIX_HANDLE PLATFORM_INTERNAL_URL UPGRADE_TOKEN; do
+    grep -Eq "^${key}=.+" "$SYMPHONY_ENV_FILE" || return 1
+  done
+  return 0
 }
 
 print_status() {
@@ -67,7 +79,7 @@ print_status() {
         ;;
     esac
   fi
-  if credential_configured; then
+  if bridge_configured; then
     credential=true
   fi
   printf '{"available":%s,"running":%s,"status":"%s","canStart":%s,"canStop":%s,"credentialConfigured":%s,"managedBy":"systemd"}\n' \

--- a/distro/customer-vps/host-bin/matrix-sync-agent
+++ b/distro/customer-vps/host-bin/matrix-sync-agent
@@ -24,10 +24,44 @@ readonly HEALTH_URL="http://127.0.0.1:4000/health"
 readonly AUTO_APPLY_FAILED_MARKER="$APP_DIR/.auto-apply-failed"
 readonly STAGING_ARTIFACT_TTL_SECONDS="${MATRIX_STAGING_ARTIFACT_TTL_SECONDS:-86400}"
 readonly STAGING_CLEANUP_INTERVAL_SECONDS="${MATRIX_STAGING_CLEANUP_INTERVAL_SECONDS:-3600}"
+readonly SYMPHONY_ENV_FILE="/opt/matrix/env/symphony.env"
+# Keys this agent owns and rewrites on every sync from platform-provided values.
+# Any other key in symphony.env (e.g. an operator-set SYMPHONY_LINEAR_PROJECT_SLUG)
+# is preserved across updates instead of being wiped.
+readonly SYMPHONY_MANAGED_KEYS="MATRIX_HANDLE PLATFORM_INTERNAL_URL UPGRADE_TOKEN"
 
 log() { echo "matrix-sync-agent: $(date -u +%Y-%m-%dT%H:%M:%SZ) $*"; }
 current_version() { cat "$VERSION_FILE" 2>/dev/null || echo "unknown"; }
 platform_url() { echo "${MATRIX_UPDATE_MANIFEST_BASE_URL:-${PLATFORM_INTERNAL_URL:-https://app.matrix-os.com}}"; }
+
+# Echo the lines of an existing symphony.env that this agent does not manage so
+# operator-set configuration survives a host bundle update. Blank and comment
+# lines are kept; managed KEY= lines are dropped (re-emitted with fresh values
+# by write_symphony_env). Group-readable file (root:matrix 0640), so the matrix
+# user that runs this agent can read it directly.
+preserve_unmanaged_symphony_env() {
+  local existing_file="$1"
+  [ -f "$existing_file" ] || return 0
+  local line key
+  while IFS= read -r line || [ -n "$line" ]; do
+    case "$line" in
+      '' | '#'*)
+        printf '%s\n' "$line"
+        ;;
+      *=*)
+        key="${line%%=*}"
+        case " $SYMPHONY_MANAGED_KEYS " in
+          *" $key "*) : ;; # managed key: re-emitted with fresh value elsewhere
+          *) printf '%s\n' "$line" ;;
+        esac
+        ;;
+      *)
+        printf '%s\n' "$line"
+        ;;
+    esac
+  done <"$existing_file"
+}
+
 write_symphony_env() {
   local status=0
   local temp_file
@@ -36,8 +70,9 @@ write_symphony_env() {
     printf 'MATRIX_HANDLE=%s\n' "${MATRIX_HANDLE:?MATRIX_HANDLE is required}"
     printf 'PLATFORM_INTERNAL_URL=%s\n' "${PLATFORM_INTERNAL_URL:?PLATFORM_INTERNAL_URL is required}"
     printf 'UPGRADE_TOKEN=%s\n' "${UPGRADE_TOKEN:?UPGRADE_TOKEN is required}"
+    preserve_unmanaged_symphony_env "$SYMPHONY_ENV_FILE"
   } >"$temp_file"
-  sudo install -o root -g matrix -m 0640 "$temp_file" /opt/matrix/env/symphony.env || status=$?
+  sudo install -o root -g matrix -m 0640 "$temp_file" "$SYMPHONY_ENV_FILE" || status=$?
   rm -f "$temp_file"
   return "$status"
 }

--- a/packages/symphony-elixir/lib/symphony_elixir/linear/client.ex
+++ b/packages/symphony-elixir/lib/symphony_elixir/linear/client.ex
@@ -472,6 +472,11 @@ defmodule SymphonyElixir.Linear.Client do
     {:ok, %{response | body: data}}
   end
 
+  defp unwrap_matrix_linear_bridge_response({:ok, %{status: 404, body: %{"error" => _error}}}) do
+    Logger.warning("Matrix Linear bridge reports Linear is not connected")
+    {:error, :linear_not_connected}
+  end
+
   defp unwrap_matrix_linear_bridge_response({:ok, %{body: %{"error" => _error}}}) do
     Logger.warning("Matrix Linear bridge returned an error response")
     {:error, :matrix_linear_bridge_error}

--- a/packages/symphony-elixir/lib/symphony_elixir/linear/client.ex
+++ b/packages/symphony-elixir/lib/symphony_elixir/linear/client.ex
@@ -472,9 +472,18 @@ defmodule SymphonyElixir.Linear.Client do
     {:ok, %{response | body: data}}
   end
 
-  defp unwrap_matrix_linear_bridge_response({:ok, %{status: 404, body: %{"error" => _error}}}) do
-    Logger.warning("Matrix Linear bridge reports Linear is not connected")
-    {:error, :linear_not_connected}
+  defp unwrap_matrix_linear_bridge_response({:ok, %{status: 404, body: %{"error" => error}}})
+       when is_binary(error) do
+    # The platform bridge answers 404 for both "service not connected" and other
+    # missing resources (e.g. an unknown handle). Only the former means the owner
+    # must connect Linear; classify it narrowly so unrelated 404s stay generic.
+    if linear_not_connected_error?(error) do
+      Logger.warning("Matrix Linear bridge reports Linear is not connected")
+      {:error, :linear_not_connected}
+    else
+      Logger.warning("Matrix Linear bridge returned a 404 error response")
+      {:error, :matrix_linear_bridge_error}
+    end
   end
 
   defp unwrap_matrix_linear_bridge_response({:ok, %{body: %{"error" => _error}}}) do
@@ -483,6 +492,10 @@ defmodule SymphonyElixir.Linear.Client do
   end
 
   defp unwrap_matrix_linear_bridge_response(other), do: other
+
+  defp linear_not_connected_error?(error) when is_binary(error) do
+    String.contains?(String.downcase(error), "not connected")
+  end
 
   defp decode_linear_response(%{"data" => %{"issues" => %{"nodes" => nodes}}}, assignee_filter) do
     issues =

--- a/packages/symphony-elixir/lib/symphony_elixir/orchestrator.ex
+++ b/packages/symphony-elixir/lib/symphony_elixir/orchestrator.ex
@@ -37,7 +37,8 @@ defmodule SymphonyElixir.Orchestrator do
       claimed: MapSet.new(),
       retry_attempts: %{},
       codex_totals: nil,
-      codex_rate_limits: nil
+      codex_rate_limits: nil,
+      last_tracker_status: nil
     ]
   end
 
@@ -210,52 +211,72 @@ defmodule SymphonyElixir.Orchestrator do
   defp maybe_dispatch(%State{} = state) do
     state = reconcile_running_issues(state)
 
-    with :ok <- Config.validate!(),
-         {:ok, issues} <- Tracker.fetch_candidate_issues(),
-         true <- available_slots(state) > 0 do
-      choose_issues(issues, state)
-    else
-      {:error, :missing_linear_api_token} ->
-        Logger.error("Linear API token missing in WORKFLOW.md")
-        state
-
-      {:error, :missing_linear_project_slug} ->
-        Logger.error("Linear project slug missing in WORKFLOW.md")
-        state
-
-      {:error, :missing_tracker_kind} ->
-        Logger.error("Tracker kind missing in WORKFLOW.md")
-
-        state
-
-      {:error, {:unsupported_tracker_kind, kind}} ->
-        Logger.error("Unsupported tracker kind in WORKFLOW.md: #{inspect(kind)}")
-
-        state
-
-      {:error, {:invalid_workflow_config, message}} ->
-        Logger.error("Invalid WORKFLOW.md config: #{message}")
-        state
-
-      {:error, {:missing_workflow_file, path, reason}} ->
-        Logger.error("Missing WORKFLOW.md at #{path}: #{inspect(reason)}")
-        state
-
-      {:error, :workflow_front_matter_not_a_map} ->
-        Logger.error("Failed to parse WORKFLOW.md: workflow front matter must decode to a map")
-        state
-
-      {:error, {:workflow_parse_error, reason}} ->
-        Logger.error("Failed to parse WORKFLOW.md: #{inspect(reason)}")
-        state
+    case Config.validate!() do
+      :ok ->
+        dispatch_candidate_issues(state)
 
       {:error, reason} ->
-        Logger.error("Failed to fetch from Linear: #{inspect(reason)}")
-        state
-
-      false ->
-        state
+        log_dispatch_blocker(reason)
+        put_tracker_status(state, tracker_status_for_error(reason))
     end
+  end
+
+  defp dispatch_candidate_issues(%State{} = state) do
+    case Tracker.fetch_candidate_issues() do
+      {:ok, issues} ->
+        # The candidate poll succeeded, so Linear is reachable and authorized.
+        state = put_tracker_status(state, :ok)
+
+        if available_slots(state) > 0 do
+          choose_issues(issues, state)
+        else
+          state
+        end
+
+      {:error, reason} ->
+        log_dispatch_blocker(reason)
+        put_tracker_status(state, tracker_status_for_error(reason))
+    end
+  end
+
+  defp log_dispatch_blocker(:missing_linear_api_token),
+    do: Logger.error("Linear API token missing in WORKFLOW.md")
+
+  defp log_dispatch_blocker(:missing_linear_project_slug),
+    do: Logger.error("Linear project slug missing in WORKFLOW.md")
+
+  defp log_dispatch_blocker(:missing_tracker_kind),
+    do: Logger.error("Tracker kind missing in WORKFLOW.md")
+
+  defp log_dispatch_blocker({:unsupported_tracker_kind, kind}),
+    do: Logger.error("Unsupported tracker kind in WORKFLOW.md: #{inspect(kind)}")
+
+  defp log_dispatch_blocker({:invalid_workflow_config, message}),
+    do: Logger.error("Invalid WORKFLOW.md config: #{message}")
+
+  defp log_dispatch_blocker({:missing_workflow_file, path, reason}),
+    do: Logger.error("Missing WORKFLOW.md at #{path}: #{inspect(reason)}")
+
+  defp log_dispatch_blocker(:workflow_front_matter_not_a_map),
+    do: Logger.error("Failed to parse WORKFLOW.md: workflow front matter must decode to a map")
+
+  defp log_dispatch_blocker({:workflow_parse_error, reason}),
+    do: Logger.error("Failed to parse WORKFLOW.md: #{inspect(reason)}")
+
+  defp log_dispatch_blocker(reason),
+    do: Logger.error("Failed to fetch from Linear: #{inspect(reason)}")
+
+  # Maps a poll/validation failure to the credential signal surfaced to the
+  # shell. Only a missing token or an explicit "Linear not connected" from the
+  # platform bridge means the owner must connect Linear; everything else is a
+  # transient/operational error reported as unavailable.
+  defp tracker_status_for_error(:missing_linear_api_token), do: :setup_required
+  defp tracker_status_for_error({:linear_api_request, :linear_not_connected}), do: :setup_required
+  defp tracker_status_for_error(_reason), do: :error
+
+  defp put_tracker_status(%State{} = state, status)
+       when status in [:ok, :setup_required, :error] do
+    %{state | last_tracker_status: status}
   end
 
   defp reconcile_running_issues(%State{} = state) do
@@ -1038,6 +1059,7 @@ defmodule SymphonyElixir.Orchestrator do
        retrying: retrying,
        codex_totals: state.codex_totals,
        rate_limits: Map.get(state, :codex_rate_limits),
+       tracker: %{status: state.last_tracker_status},
        polling: %{
          checking?: state.poll_check_in_progress == true,
          next_poll_in_ms: next_poll_in_ms(state.next_poll_due_at_ms, now_ms),

--- a/packages/symphony-elixir/lib/symphony_elixir_web/presenter.ex
+++ b/packages/symphony-elixir/lib/symphony_elixir_web/presenter.ex
@@ -3,7 +3,7 @@ defmodule SymphonyElixirWeb.Presenter do
   Shared projections for the observability API and dashboard.
   """
 
-  alias SymphonyElixir.{Config, Linear.Bridge, Orchestrator, StatusDashboard}
+  alias SymphonyElixir.{Config, Orchestrator, StatusDashboard}
 
   @spec state_payload(GenServer.name(), timeout()) :: map()
   def state_payload(orchestrator, snapshot_timeout_ms) do
@@ -13,7 +13,7 @@ defmodule SymphonyElixirWeb.Presenter do
       %{} = snapshot ->
         %{
           generated_at: generated_at,
-          credential_status: credential_status(),
+          credential_status: credential_status(snapshot),
           counts: %{
             running: length(snapshot.running),
             retrying: length(snapshot.retrying)
@@ -27,14 +27,14 @@ defmodule SymphonyElixirWeb.Presenter do
       :timeout ->
         %{
           generated_at: generated_at,
-          credential_status: credential_status(),
+          credential_status: credential_status(:no_snapshot),
           error: %{code: "snapshot_timeout", message: "Snapshot timed out"}
         }
 
       :unavailable ->
         %{
           generated_at: generated_at,
-          credential_status: credential_status(),
+          credential_status: credential_status(:no_snapshot),
           error: %{code: "snapshot_unavailable", message: "Snapshot unavailable"}
         }
     end
@@ -190,21 +190,17 @@ defmodule SymphonyElixirWeb.Presenter do
   defp summarize_message(nil), do: nil
   defp summarize_message(message), do: StatusDashboard.humanize_codex_message(message)
 
-  defp credential_status do
+  # Reports whether Linear is actually usable, derived from the orchestrator's
+  # most recent candidate poll rather than mere presence of bridge env vars.
+  # Those vars are always written on a customer VPS, so env presence cannot tell
+  # a connected integration apart from a disconnected one; the live poll can.
+  defp credential_status(snapshot) do
     case Config.settings() do
       {:ok, settings} ->
-        cond do
-          settings.tracker.kind != "linear" ->
-            "not_required"
-
-          is_binary(settings.tracker.api_key) and settings.tracker.api_key == Bridge.credential() ->
-            if matrix_linear_bridge_configured?(), do: "connected", else: "setup_required"
-
-          is_binary(settings.tracker.api_key) ->
-            "connected"
-
-          true ->
-            "setup_required"
+        if settings.tracker.kind == "linear" do
+          linear_credential_status(snapshot)
+        else
+          "not_required"
         end
 
       {:error, _reason} ->
@@ -212,14 +208,10 @@ defmodule SymphonyElixirWeb.Presenter do
     end
   end
 
-  defp matrix_linear_bridge_configured? do
-    Enum.all?(["PLATFORM_INTERNAL_URL", "UPGRADE_TOKEN", "MATRIX_HANDLE"], fn name ->
-      case System.get_env(name) do
-        value when is_binary(value) and value != "" -> true
-        _ -> false
-      end
-    end)
-  end
+  defp linear_credential_status(%{tracker: %{status: :ok}}), do: "connected"
+  defp linear_credential_status(%{tracker: %{status: :setup_required}}), do: "setup_required"
+  # :error, nil (no poll completed yet), or no live snapshot (timeout/unavailable).
+  defp linear_credential_status(_snapshot), do: "unavailable"
 
   defp due_at_iso8601(due_in_ms) when is_integer(due_in_ms) do
     DateTime.utc_now()

--- a/tests/deploy/customer-vps/symphony-env-merge.test.ts
+++ b/tests/deploy/customer-vps/symphony-env-merge.test.ts
@@ -1,0 +1,96 @@
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync, readFileSync, chmodSync, mkdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+// Extract a `name() { ... }` shell function body (signature line through the
+// first line that is exactly `}`) from a script so we can exercise the real
+// code without sourcing the whole daemon (which would run its poll loop).
+function extractShellFunction(script: string, name: string): string {
+  const lines = script.split("\n");
+  const start = lines.findIndex((l) => l === `${name}() {`);
+  if (start === -1) throw new Error(`function ${name} not found`);
+  const end = lines.findIndex((l, i) => i > start && l === "}");
+  if (end === -1) throw new Error(`function ${name} has no closing brace`);
+  return lines.slice(start, end + 1).join("\n");
+}
+
+describe("matrix-sync-agent symphony.env merge", () => {
+  const script = readFileSync(
+    "distro/customer-vps/host-bin/matrix-sync-agent",
+    "utf8",
+  );
+
+  function runWriteSymphonyEnv(existingEnv: string | null): string {
+    const dir = mkdtempSync(join(tmpdir(), "symphony-env-"));
+    try {
+      const envFile = join(dir, "symphony.env");
+      if (existingEnv !== null) writeFileSync(envFile, existingEnv);
+
+      // PATH shims so write_symphony_env runs without privileges: sudo execs
+      // its args; install ignores -o/-g/-m and copies SRC -> DEST.
+      const bin = join(dir, "bin");
+      mkdirSync(bin);
+      writeFileSync(join(bin, "sudo"), '#!/usr/bin/env bash\nexec "$@"\n');
+      writeFileSync(
+        join(bin, "install"),
+        '#!/usr/bin/env bash\nargs=(); while [ $# -gt 0 ]; do case "$1" in -o|-g|-m) shift 2;; *) args+=("$1"); shift;; esac; done\ncp "${args[0]}" "${args[1]}"\n',
+      );
+      chmodSync(join(bin, "sudo"), 0o755);
+      chmodSync(join(bin, "install"), 0o755);
+
+      const harness = [
+        "set -euo pipefail",
+        `export PATH="${bin}:$PATH"`,
+        'SYMPHONY_MANAGED_KEYS="MATRIX_HANDLE PLATFORM_INTERNAL_URL UPGRADE_TOKEN"',
+        `SYMPHONY_ENV_FILE="${envFile}"`,
+        "export MATRIX_HANDLE=newhandle",
+        "export PLATFORM_INTERNAL_URL=https://new.example",
+        "export UPGRADE_TOKEN=newtoken",
+        extractShellFunction(script, "preserve_unmanaged_symphony_env"),
+        extractShellFunction(script, "write_symphony_env"),
+        "write_symphony_env",
+        `cat "${envFile}"`,
+      ].join("\n");
+
+      return execFileSync("bash", ["-c", harness], { encoding: "utf8" });
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  }
+
+  it("rewrites managed keys with fresh values and preserves operator-set keys", () => {
+    const result = runWriteSymphonyEnv(
+      [
+        "MATRIX_HANDLE=oldhandle",
+        "PLATFORM_INTERNAL_URL=https://old.example",
+        "UPGRADE_TOKEN=oldtoken",
+        "# operator added these",
+        "SYMPHONY_LINEAR_PROJECT_SLUG=my-project",
+        "SYMPHONY_CODEX_COMMAND=codex app-server",
+        "",
+      ].join("\n"),
+    );
+
+    // Managed keys carry the fresh platform values, exactly once each.
+    expect(result.match(/^MATRIX_HANDLE=newhandle$/gm)).toHaveLength(1);
+    expect(result.match(/^PLATFORM_INTERNAL_URL=https:\/\/new\.example$/gm)).toHaveLength(1);
+    expect(result.match(/^UPGRADE_TOKEN=newtoken$/gm)).toHaveLength(1);
+    expect(result).not.toContain("oldhandle");
+    expect(result).not.toContain("oldtoken");
+
+    // Operator-set keys and their comment survive the rewrite.
+    expect(result).toContain("# operator added these");
+    expect(result).toContain("SYMPHONY_LINEAR_PROJECT_SLUG=my-project");
+    expect(result).toContain("SYMPHONY_CODEX_COMMAND=codex app-server");
+  });
+
+  it("writes only managed keys when no prior file exists", () => {
+    const result = runWriteSymphonyEnv(null);
+    expect(result).toContain("MATRIX_HANDLE=newhandle");
+    expect(result).toContain("PLATFORM_INTERNAL_URL=https://new.example");
+    expect(result).toContain("UPGRADE_TOKEN=newtoken");
+    expect(result).not.toContain("SYMPHONY_LINEAR_PROJECT_SLUG");
+  });
+});

--- a/tests/deploy/customer-vps/symphony-env-merge.test.ts
+++ b/tests/deploy/customer-vps/symphony-env-merge.test.ts
@@ -6,7 +6,10 @@ import { describe, expect, it } from "vitest";
 
 // Extract a `name() { ... }` shell function body (signature line through the
 // first line that is exactly `}`) from a script so we can exercise the real
-// code without sourcing the whole daemon (which would run its poll loop).
+// code without sourcing the whole daemon (which would run its poll loop). The
+// host-bin functions follow the repo convention of a column-0 closing `}` and
+// have no nested column-0 `}` line, so an exact-line match is deterministic
+// here; brace counting would misfire on `${...}` parameter expansions.
 function extractShellFunction(script: string, name: string): string {
   const lines = script.split("\n");
   const start = lines.findIndex((l) => l === `${name}() {`);

--- a/tests/deploy/customer-vps/symphony-systemd.test.ts
+++ b/tests/deploy/customer-vps/symphony-systemd.test.ts
@@ -307,9 +307,12 @@ describe("customer VPS Symphony systemd unit", () => {
     expect(linearClient).toContain('service: "linear"');
     expect(linearClient).toContain('action: "graphql"');
     expect(linearClient).toContain(":matrix_linear_bridge_error");
-    // A 404 from the bridge means Linear is not connected; classify it distinctly
-    // so the orchestrator can surface "setup_required" instead of a generic error.
+    // A 404 whose error says "not connected" means Linear is not connected;
+    // classify it distinctly so the orchestrator surfaces "setup_required". Other
+    // 404s (e.g. unknown handle) stay generic so they are not misreported.
     expect(linearClient).toContain(":linear_not_connected");
-    expect(linearClient).toContain("status: 404, body: %{\"error\" => _error}");
+    expect(linearClient).toContain("status: 404, body: %{\"error\" => error}");
+    expect(linearClient).toContain("linear_not_connected_error?");
+    expect(linearClient).toContain('String.contains?(String.downcase(error), "not connected")');
   });
 });

--- a/tests/deploy/customer-vps/symphony-systemd.test.ts
+++ b/tests/deploy/customer-vps/symphony-systemd.test.ts
@@ -116,6 +116,11 @@ describe("customer VPS Symphony systemd unit", () => {
     expect(control).toContain("status=stopping");
     expect(control).toContain("\"credentialConfigured\"");
     expect(control).not.toContain("journalctl");
+    // credentialConfigured now reflects the host-verifiable Linear bridge wiring,
+    // not a `*.linear` credential file that nothing on the host ever writes.
+    expect(control).toContain("bridge_configured()");
+    expect(control).not.toContain("*.linear");
+    expect(control).not.toContain("system/symphony/credentials");
     expect(proxy).toContain('app.get("/service"');
     expect(proxy).toContain('app.post("/service/start"');
     expect(proxy).toContain('app.post("/service/stop"');
@@ -131,7 +136,12 @@ describe("customer VPS Symphony systemd unit", () => {
     expect(syncAgent).toContain("printf 'MATRIX_HANDLE=%s\\n'");
     expect(syncAgent).toContain("printf 'PLATFORM_INTERNAL_URL=%s\\n'");
     expect(syncAgent).toContain("printf 'UPGRADE_TOKEN=%s\\n'");
-    expect(syncAgent).toContain("sudo install -o root -g matrix -m 0640 \"$temp_file\" /opt/matrix/env/symphony.env || status=$?");
+    // Operator-set keys (e.g. SYMPHONY_LINEAR_PROJECT_SLUG) must survive updates:
+    // managed keys are rewritten, every other line in the file is preserved.
+    expect(syncAgent).toContain("SYMPHONY_MANAGED_KEYS=\"MATRIX_HANDLE PLATFORM_INTERNAL_URL UPGRADE_TOKEN\"");
+    expect(syncAgent).toContain("preserve_unmanaged_symphony_env()");
+    expect(syncAgent).toContain("preserve_unmanaged_symphony_env \"$SYMPHONY_ENV_FILE\"");
+    expect(syncAgent).toContain("sudo install -o root -g matrix -m 0640 \"$temp_file\" \"$SYMPHONY_ENV_FILE\" || status=$?");
     expect(syncAgent).toContain("rm -f \"$temp_file\"");
     expect(syncAgent).toContain("return \"$status\"");
     expect(syncAgent).toContain("sudo systemctl enable matrix-symphony.service");
@@ -282,7 +292,11 @@ describe("customer VPS Symphony systemd unit", () => {
     expect(linearClient).not.toMatch(/when\s+\w+\s*==\s*Bridge\.credential\(\)/);
     expect(linearClient).not.toContain("when token == Bridge.credential()");
     expect(statusDashboard).not.toContain("when String.length(");
-    expect(presenter).toContain("is_binary(settings.tracker.api_key) and settings.tracker.api_key == Bridge.credential()");
+    // credential_status is derived from the live candidate poll, not env presence:
+    // a successful poll means connected, an explicit "not connected" means setup.
+    expect(presenter).toContain('linear_credential_status(%{tracker: %{status: :ok}}), do: "connected"');
+    expect(presenter).toContain('linear_credential_status(%{tracker: %{status: :setup_required}}), do: "setup_required"');
+    expect(presenter).not.toContain("matrix_linear_bridge_configured?");
     expect(linearClient).toContain("PLATFORM_INTERNAL_URL");
     expect(linearClient).toContain("UPGRADE_TOKEN");
     expect(linearClient).toContain("MATRIX_HANDLE");
@@ -293,5 +307,9 @@ describe("customer VPS Symphony systemd unit", () => {
     expect(linearClient).toContain('service: "linear"');
     expect(linearClient).toContain('action: "graphql"');
     expect(linearClient).toContain(":matrix_linear_bridge_error");
+    // A 404 from the bridge means Linear is not connected; classify it distinctly
+    // so the orchestrator can surface "setup_required" instead of a generic error.
+    expect(linearClient).toContain(":linear_not_connected");
+    expect(linearClient).toContain("status: 404, body: %{\"error\" => _error}");
   });
 });

--- a/tests/platform/customer-vps-host-bundle.test.ts
+++ b/tests/platform/customer-vps-host-bundle.test.ts
@@ -378,7 +378,7 @@ describe('customer VPS host bundle', () => {
 
     expect(syncAgent).toContain('write_symphony_env()');
     expect(syncAgent).toContain('/opt/matrix/env/symphony.env');
-    expect(syncAgent).toContain('sudo install -o root -g matrix -m 0640 "$temp_file" /opt/matrix/env/symphony.env || status=$?');
+    expect(syncAgent).toContain('sudo install -o root -g matrix -m 0640 "$temp_file" "$SYMPHONY_ENV_FILE" || status=$?');
     expect(syncAgent).toContain('rm -f "$temp_file"');
     expect(syncAgent).toContain("sudo find \"$extract_dir/systemd\" -maxdepth 1 -name 'matrix-*.service'");
     expect(syncAgent).toContain('sudo systemctl daemon-reload');


### PR DESCRIPTION
## Problem

Symphony's shell showed `Linear: connected` even when Linear was never connected in Matrix integrations. Because the only \"Connect Linear\" prompt is gated on `credentialStatus === \"setup_required\"`, the prompt never appeared and the run queue stayed silently empty — there was no signal that the actual blocker was a missing Linear connection.

Root cause: the Elixir presenter computed `credential_status` from the mere presence of the bridge env vars (`PLATFORM_INTERNAL_URL` / `UPGRADE_TOKEN` / `MATRIX_HANDLE`). Those are always written on a customer VPS, so env presence cannot distinguish a connected integration from a disconnected one.

Two adjacent defects are fixed in the same area:
- `matrix-sync-agent` rewrote `/opt/matrix/env/symphony.env` from scratch on every update, wiping any operator-set key (e.g. `SYMPHONY_LINEAR_PROJECT_SLUG`).
- `matrix-symphony-control` reported `credentialConfigured` from a `*.linear` file under `$MATRIX_HOME` that nothing on the host ever writes, so it was always `false`.

## Changes

- **Truthful `credential_status` (Elixir).** It now reflects the orchestrator's most recent Linear candidate poll: a successful poll → `connected`, a missing token or explicit bridge \"not connected\" → `setup_required`, any other failure (or no completed poll yet) → `unavailable`. The orchestrator records the last poll outcome in its state and exposes it via `snapshot`; the presenter maps it. No new process and no extra network calls — it reuses the existing 5s poll.
- **Bridge \"not connected\" classification (Elixir).** The platform bridge returns HTTP 404 `{\"error\":\"Service linear is not connected\"}`; the client now maps that to `:linear_not_connected` instead of collapsing it into the generic bridge error, so the orchestrator can surface `setup_required`.
- **Durable `symphony.env` (host).** `write_symphony_env` rewrites only the three platform-managed keys and preserves every other line (operator keys, comments, blanks).
- **Honest host credential signal (host).** `matrix-symphony-control` replaces the dead `*.linear` check with a host-verifiable check that the Linear bridge env is wired. The authoritative connection signal remains the Symphony service `credential_status`.

## Tests

- New `tests/deploy/customer-vps/symphony-env-merge.test.ts` executes the real `write_symphony_env` / `preserve_unmanaged_symphony_env` against temp files (stubbed `sudo`/`install`) and asserts managed keys are refreshed while operator keys survive.
- Updated `symphony-systemd.test.ts` and `customer-vps-host-bundle.test.ts` static assertions for the new presenter logic, the `:linear_not_connected` classification, the env-merge behavior, and removal of the dead credential-file check.
- All 97 symphony-related tests pass. `check:patterns` reports 0 violations.

> Note: `packages/symphony-elixir` has no ExUnit suite and CI does not run `mix test` (only `mix release` at bundle-build, which compiles). The Elixir changes are correct-by-inspection and compile-safe; behavior is pinned by the static-content assertions above. Adding an ExUnit harness is out of scope.

## Invariants

- **Source of truth.** Linear connection state is owned by the platform integrations store; the customer VPS observes it only through the bridge. `credential_status` is now derived from the live poll result against that store, never from local env presence. Divergence self-heals on the next poll (≤ `polling.interval_ms`, default 5s).
- **Lock/transaction scope.** None added. `last_tracker_status` is a single field on the orchestrator `GenServer` state, mutated only inside the existing serialized poll handler; `snapshot` reads it under the same process. No DB writes.
- **Acceptable orphan states.** Between boot and the first completed poll, `last_tracker_status` is `nil` and `credential_status` reports `unavailable` (sub-second, self-correcting). A transient bridge/platform error reports `unavailable` (not `setup_required`), so a platform blip does not nag the owner to reconnect.
- **Auth source of truth.** Unchanged. The bridge call is authenticated by `UPGRADE_TOKEN` (HMAC of handle with the platform secret); this PR does not touch auth.
- **Deferred scope.** Not in scope: a project/team picker or `SYMPHONY_LINEAR_PROJECT_SLUG` UI; codex/GitHub auth provisioning on the VPS; removing the (now unused) `credentialConfigured` field from the proxy/shell contract; an ExUnit suite for `symphony-elixir`.