### PR TITLE
feat(observability): ship fleet logs to PostHog

### DIFF
--- a/distro/customer-vps/host-bin/matrix-install-logship
+++ b/distro/customer-vps/host-bin/matrix-install-logship
@@ -2,7 +2,7 @@
 # Install and enable the Grafana Alloy log shipper on a Matrix OS VPS.
 #
 # Usage:
-#   LOGS_INGEST_USER=... LOGS_INGEST_PASSWORD=... \
+#   LOGS_INGEST_USER=... LOGS_INGEST_PASSWORD=... POSTHOG_PROJECT_TOKEN=... \
 #     matrix-install-logship <ingest-url> <handle> <env>
 #
 #   ingest-url  https URL of the Loki push edge (e.g. https://logs.matrix-os.com)
@@ -38,6 +38,7 @@ HANDLE="$2"
 MATRIX_ENV="$3"
 INGEST_USER="${LOGS_INGEST_USER:?LOGS_INGEST_USER must be set in the environment}"
 INGEST_PASSWORD="${LOGS_INGEST_PASSWORD:?LOGS_INGEST_PASSWORD must be set in the environment}"
+POSTHOG_PROJECT_TOKEN="${POSTHOG_PROJECT_TOKEN:?POSTHOG_PROJECT_TOKEN must be set in the environment}"
 
 case "$INGEST_URL" in
   https://*) ;;
@@ -112,6 +113,20 @@ loki.write "central" {
   }
 }
 
+otelcol.receiver.loki "posthog" {
+  output {
+    logs = [otelcol.exporter.otlphttp.posthog_logs.input]
+  }
+}
+
+otelcol.exporter.otlphttp "posthog_logs" {
+  logs_endpoint = "https://eu.i.posthog.com/i/v1/logs"
+  client {
+    endpoint = "https://eu.i.posthog.com"
+    headers = { "Authorization" = "Bearer " + sys.env("POSTHOG_PROJECT_TOKEN") }
+  }
+}
+
 loki.relabel "journal" {
   forward_to = []
   rule {
@@ -120,39 +135,40 @@ loki.relabel "journal" {
   }
 }
 
+// handle/env are source labels so the OTLP path carries the same attribution as Loki.
 loki.source.journal "matrix_units" {
   matches       = "_SYSTEMD_UNIT=matrix-gateway.service"
   relabel_rules = loki.relabel.journal.rules
-  labels        = { source = "journal" }
-  forward_to    = [loki.write.central.receiver]
+  labels        = { source = "journal", handle = "${HANDLE}", env = "${MATRIX_ENV}" }
+  forward_to    = [loki.write.central.receiver, otelcol.receiver.loki.posthog.receiver]
 }
 
 loki.source.journal "matrix_shell" {
   matches       = "_SYSTEMD_UNIT=matrix-shell.service"
   relabel_rules = loki.relabel.journal.rules
-  labels        = { source = "journal" }
-  forward_to    = [loki.write.central.receiver]
+  labels        = { source = "journal", handle = "${HANDLE}", env = "${MATRIX_ENV}" }
+  forward_to    = [loki.write.central.receiver, otelcol.receiver.loki.posthog.receiver]
 }
 
 loki.source.journal "matrix_sync" {
   matches       = "_SYSTEMD_UNIT=matrix-sync-agent.service"
   relabel_rules = loki.relabel.journal.rules
-  labels        = { source = "journal" }
-  forward_to    = [loki.write.central.receiver]
+  labels        = { source = "journal", handle = "${HANDLE}", env = "${MATRIX_ENV}" }
+  forward_to    = [loki.write.central.receiver, otelcol.receiver.loki.posthog.receiver]
 }
 
 loki.source.journal "matrix_code" {
   matches       = "_SYSTEMD_UNIT=matrix-code.service"
   relabel_rules = loki.relabel.journal.rules
-  labels        = { source = "journal" }
-  forward_to    = [loki.write.central.receiver]
+  labels        = { source = "journal", handle = "${HANDLE}", env = "${MATRIX_ENV}" }
+  forward_to    = [loki.write.central.receiver, otelcol.receiver.loki.posthog.receiver]
 }
 
 loki.source.journal "matrix_symphony" {
   matches       = "_SYSTEMD_UNIT=matrix-symphony.service"
   relabel_rules = loki.relabel.journal.rules
-  labels        = { source = "journal" }
-  forward_to    = [loki.write.central.receiver]
+  labels        = { source = "journal", handle = "${HANDLE}", env = "${MATRIX_ENV}" }
+  forward_to    = [loki.write.central.receiver, otelcol.receiver.loki.posthog.receiver]
 }
 
 local.file_match "kernel_jsonl" {
@@ -161,7 +177,8 @@ local.file_match "kernel_jsonl" {
 
 loki.source.file "kernel_logs" {
   targets    = local.file_match.kernel_jsonl.targets
-  forward_to = [loki.write.central.receiver]
+  labels     = { source = "jsonl", handle = "${HANDLE}", env = "${MATRIX_ENV}" }
+  forward_to = [loki.write.central.receiver, otelcol.receiver.loki.posthog.receiver]
 }
 EOF
 chmod 0640 /etc/alloy/matrix-logship.alloy
@@ -169,8 +186,8 @@ chmod 0640 /etc/alloy/matrix-logship.alloy
 umask 077
 # printf %s writes values byte-for-byte; no heredoc/expansion semantics to
 # reason about for credentials containing shell-special characters.
-printf 'LOGS_INGEST_URL=%s\nLOGS_INGEST_USER=%s\nLOGS_INGEST_PASSWORD=%s\n' \
-  "$INGEST_URL" "$INGEST_USER" "$INGEST_PASSWORD" > /opt/matrix/env/logship.env
+printf 'LOGS_INGEST_URL=%s\nLOGS_INGEST_USER=%s\nLOGS_INGEST_PASSWORD=%s\nPOSTHOG_PROJECT_TOKEN=%s\n' \
+  "$INGEST_URL" "$INGEST_USER" "$INGEST_PASSWORD" "$POSTHOG_PROJECT_TOKEN" > /opt/matrix/env/logship.env
 chmod 0600 /opt/matrix/env/logship.env
 
 cat > /etc/systemd/system/matrix-logship.service << 'EOF'

--- a/docs/dev/preview-environments.md
+++ b/docs/dev/preview-environments.md
@@ -110,12 +110,14 @@ dashboards.
 - **VPSes (preview or fleet)**: Grafana Alloy, installed by
   `matrix-install-logship` (ships in the host bundle `bin/`). It tails the
   matrix systemd units and the kernel JSONL logs, labels streams with
-  `handle` and `env`, and pushes to `https://logs.matrix-os.com` — a Caddy
-  edge that accepts only authenticated `POST /loki/api/v1/push` (basic auth;
-  Loki's query API is not exposed). Enroll a VPS once from the ops box:
+  `handle` and `env`, and dual-writes to PostHog Logs via OTLP/HTTP plus the
+  existing `https://logs.matrix-os.com` Loki ingest edge. Loki is retained only
+  as the `preview-logs.sh` compatibility path until the self-hosted
+  observability stack retirement slice removes it. Enroll a VPS once from the
+  ops box:
 
   ```bash
-  PLATFORM_SECRET=... LOGS_INGEST_USER=fleet LOGS_INGEST_PASSWORD=... \
+  PLATFORM_SECRET=... LOGS_INGEST_USER=fleet LOGS_INGEST_PASSWORD=... POSTHOG_PROJECT_TOKEN=<project-token> \
     ./scripts/enable-vps-logship.sh <handle> <preview|prod|staging>
   ```
 

--- a/scripts/enable-vps-logship.sh
+++ b/scripts/enable-vps-logship.sh
@@ -2,7 +2,7 @@
 # Enroll a Matrix OS VPS in centralized log shipping from the ops box.
 #
 # Usage:
-#   PLATFORM_SECRET=... LOGS_INGEST_USER=... LOGS_INGEST_PASSWORD=... \
+#   PLATFORM_SECRET=... LOGS_INGEST_USER=... LOGS_INGEST_PASSWORD=... POSTHOG_PROJECT_TOKEN=... \
 #     ./scripts/enable-vps-logship.sh <handle> <env>
 #
 #   handle  matrix handle of the VPS (looked up in /vps/fleet)
@@ -27,6 +27,7 @@ VPS_SSH_KEY="${VPS_SSH_KEY:-$HOME/.ssh/customer_vps_smoke}"
 : "${PLATFORM_SECRET:?PLATFORM_SECRET must be set}"
 : "${LOGS_INGEST_USER:?LOGS_INGEST_USER must be set}"
 : "${LOGS_INGEST_PASSWORD:?LOGS_INGEST_PASSWORD must be set}"
+: "${POSTHOG_PROJECT_TOKEN:?POSTHOG_PROJECT_TOKEN must be set}"
 
 if ! printf '%s' "$HANDLE" | grep -Eq '^[a-z0-9][a-z0-9-]{1,62}$'; then
   echo "enable-vps-logship: invalid handle" >&2
@@ -69,10 +70,10 @@ echo "enable-vps-logship: enrolling ${HANDLE} (${ip}) as env=${MATRIX_ENV}"
 # the operator removes the stale entry.
 KNOWN_HOSTS="${LOGSHIP_KNOWN_HOSTS:-$HOME/.matrixos/logship-known-hosts}"
 mkdir -p "$(dirname "$KNOWN_HOSTS")"
-printf '%s\n%s\n' "$LOGS_INGEST_USER" "$LOGS_INGEST_PASSWORD" |
+printf '%s\n%s\n%s\n' "$LOGS_INGEST_USER" "$LOGS_INGEST_PASSWORD" "$POSTHOG_PROJECT_TOKEN" |
   ssh -i "$VPS_SSH_KEY" -o StrictHostKeyChecking=accept-new \
     -o UserKnownHostsFile="$KNOWN_HOSTS" "root@${ip}" \
-    "IFS= read -r u && IFS= read -r p && LOGS_INGEST_USER=\"\$u\" LOGS_INGEST_PASSWORD=\"\$p\" /opt/matrix/app/bin/matrix-install-logship '${LOGS_INGEST_URL}' '${HANDLE}' '${MATRIX_ENV}'"
+    "IFS= read -r u && IFS= read -r p && IFS= read -r t && LOGS_INGEST_USER=\"\$u\" LOGS_INGEST_PASSWORD=\"\$p\" POSTHOG_PROJECT_TOKEN=\"\$t\" /opt/matrix/app/bin/matrix-install-logship '${LOGS_INGEST_URL}' '${HANDLE}' '${MATRIX_ENV}'"
 
 # Record enrollment in the ops-side inventory so credential rotation has a
 # concrete target list (spec 093). Idempotent: one line per handle.

--- a/tests/observability/posthog-logship.test.ts
+++ b/tests/observability/posthog-logship.test.ts
@@ -1,0 +1,35 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const repoRoot = process.cwd();
+
+function readRepoFile(path: string): string {
+  return readFileSync(join(repoRoot, path), "utf8");
+}
+
+describe("PostHog fleet log shipping", () => {
+  it("dual-writes Alloy journal and JSONL logs to Loki and PostHog OTLP", () => {
+    const installer = readRepoFile("distro/customer-vps/host-bin/matrix-install-logship");
+
+    expect(installer).toContain('POSTHOG_PROJECT_TOKEN="${POSTHOG_PROJECT_TOKEN:?POSTHOG_PROJECT_TOKEN must be set in the environment}"');
+    expect(installer).toContain('otelcol.receiver.loki "posthog"');
+    expect(installer).toContain('otelcol.exporter.otlphttp "posthog_logs"');
+    expect(installer).toContain('logs_endpoint = "https://eu.i.posthog.com/i/v1/logs"');
+    expect(installer).toContain('headers = { "Authorization" = "Bearer " + sys.env("POSTHOG_PROJECT_TOKEN") }');
+
+    expect(installer).toContain('forward_to    = [loki.write.central.receiver, otelcol.receiver.loki.posthog.receiver]');
+    expect(installer).toContain('labels     = { source = "jsonl", handle = "${HANDLE}", env = "${MATRIX_ENV}" }');
+    expect(installer).toContain('forward_to = [loki.write.central.receiver, otelcol.receiver.loki.posthog.receiver]');
+  });
+
+  it("threads the PostHog project token through logship enrollment without argv exposure", () => {
+    const helper = readRepoFile("scripts/enable-vps-logship.sh");
+
+    expect(helper).toContain(": \"${POSTHOG_PROJECT_TOKEN:?POSTHOG_PROJECT_TOKEN must be set}\"");
+    expect(helper).toContain("printf '%s\\n%s\\n%s\\n' \"$LOGS_INGEST_USER\" \"$LOGS_INGEST_PASSWORD\" \"$POSTHOG_PROJECT_TOKEN\"");
+    expect(helper).toContain("IFS= read -r t");
+    expect(helper).toContain('POSTHOG_PROJECT_TOKEN=\\"\\$t\\"');
+    expect(helper).not.toContain("POSTHOG_PROJECT_TOKEN='${POSTHOG_PROJECT_TOKEN}'");
+  });
+});


### PR DESCRIPTION
## Summary
- dual-write VPS journald and JSONL log streams from Alloy to PostHog Logs over OTLP/HTTP
- thread the PostHog project token through root-owned logship env setup without argv exposure
- document the temporary Loki compatibility path for preview log queries

## Validation
- bun run typecheck
- bun run check:patterns
- bun run test
- bash -n distro/customer-vps/host-bin/matrix-install-logship
- bash -n scripts/enable-vps-logship.sh
- bun test tests/observability/posthog-logship.test.ts

## Invariants
- Source of truth: each VPS Alloy config and /opt/matrix/env/logship.env determine log export destinations; PostHog Logs is the observability destination while Loki remains a temporary compatibility path for existing preview log queries.
- Lock/transaction scope: no database transaction is involved; enrollment writes the host config/env and restarts the independent logship service, while runtime delivery is handled by Alloy queues/exporters outside Matrix service request paths.
- Acceptable orphan states: a host can remain on the previous Loki-only logshipper until re-enrolled or redeployed; if either destination is temporarily unavailable, the other destination remains configured and Matrix services keep running.
- Auth source of truth: the PostHog project token is supplied through root-owned environment files; Loki basic auth remains unchanged for the temporary compatibility path.
- Deferred scope: automatic cloud-init enrollment and self-hosted Grafana/Loki retirement are left to the follow-up retirement slice; preview-logs.sh remains Loki-backed in this PR.