### PR TITLE
fix(www): add Lighthouse security headers

### DIFF
--- a/tests/www/security-headers.test.ts
+++ b/tests/www/security-headers.test.ts
@@ -1,55 +1,68 @@
-import { readFile } from "node:fs/promises";
-import { dirname, resolve } from "node:path";
-import { fileURLToPath } from "node:url";
-import { describe, expect, it } from "vitest";
+import { NextResponse } from "next/server";
+import { describe, expect, it, vi } from "vitest";
+import { config, proxyWithSecurity } from "../../www/src/proxy";
 
-const root = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
+type ProxyModule = typeof import("../../www/src/proxy");
 
-async function readRepoFile(path: string) {
-  return readFile(resolve(root, path), "utf8");
+function makeRequest(pathname: string) {
+  return {
+    headers: new Headers(),
+    nextUrl: new URL(`https://matrix-os.com${pathname}`),
+  } as Parameters<ProxyModule["default"]>[0];
+}
+
+function expectSecurityHeaders(response: Response) {
+  const csp = response.headers.get("Content-Security-Policy");
+  expect(csp).toBeTruthy();
+  expect(csp).toContain("default-src 'self'");
+  expect(csp).toContain("script-src 'self' 'nonce-");
+  expect(csp).toContain("'strict-dynamic'");
+  expect(csp).toContain("connect-src 'self'");
+  expect(csp).not.toContain("Content-Security-Policy-Report-Only");
+  expect(csp).not.toContain("'unsafe-inline' 'unsafe-eval'");
+  expect(response.headers.get("Cross-Origin-Opener-Policy")).toBe("same-origin");
+  expect(response.headers.get("Permissions-Policy")).toBe("browsing-topics=(), interest-cohort=()");
 }
 
 describe("www Lighthouse security headers", () => {
-  it("sets an enforced nonce CSP and COOP from the proxy", async () => {
-    const proxy = await readRepoFile("www/src/proxy.ts");
+  it("sets an enforced nonce CSP and COOP on public route responses", async () => {
+    const authorizeProtectedRoute = vi.fn();
+    const response = await proxyWithSecurity(
+      makeRequest("/"),
+      {} as Parameters<ProxyModule["default"]>[1],
+      authorizeProtectedRoute,
+    );
 
-    expect(proxy).toContain("Content-Security-Policy");
-    expect(proxy).toContain("Cross-Origin-Opener-Policy");
-    expect(proxy).toContain("x-nonce");
-    expect(proxy).toContain("script-src");
-    expect(proxy).toContain("'strict-dynamic'");
-    expect(proxy).toContain("'nonce-${nonce}'");
-    expect(proxy).not.toContain("Content-Security-Policy-Report-Only");
-    expect(proxy).not.toContain("'unsafe-inline' 'unsafe-eval'");
+    expectSecurityHeaders(response);
+    expect(response.headers.get("x-middleware-request-x-nonce")).toBeTruthy();
+    expect(response.headers.get("x-middleware-request-content-security-policy")).toBeNull();
+    expect(authorizeProtectedRoute).not.toHaveBeenCalled();
   });
 
-  it("keeps Clerk middleware scoped while applying security headers broadly", async () => {
-    const proxy = await readRepoFile("www/src/proxy.ts");
+  it("keeps Clerk auth for protected routes while preserving security headers", async () => {
+    const authorizeProtectedRoute = vi.fn(async () => {
+      const response = NextResponse.next();
+      response.headers.set("x-clerk-checked", "1");
+      return response;
+    });
+    const response = await proxyWithSecurity(
+      makeRequest("/dashboard"),
+      {} as Parameters<ProxyModule["default"]>[1],
+      authorizeProtectedRoute,
+    );
 
-    expect(proxy).toContain('createRouteMatcher(["/dashboard(.*)", "/admin(.*)"])');
-    expect(proxy).toContain('"/((?!_next|.*\\\\..*).*)"');
-    expect(proxy).toContain("return withClerk(request, event)");
-    expect(proxy).toContain("return applySecurityHeaders");
+    expect(authorizeProtectedRoute).toHaveBeenCalledOnce();
+    expect(response.headers.get("x-clerk-checked")).toBe("1");
+    expectSecurityHeaders(response);
+    expect(response.headers.get("x-middleware-request-x-nonce")).toBeTruthy();
+    expect(response.headers.get("x-middleware-request-content-security-policy")).toBeNull();
   });
 
-  it("passes the CSP nonce to the server-rendered landing JSON-LD script", async () => {
-    const landing = await readRepoFile("www/src/app/page.tsx");
-
-    expect(landing).toContain('headers()).get("x-nonce")');
-    expect(landing).toContain('<script');
-    expect(landing).toContain("nonce={nonce}");
-    expect(landing).toContain("suppressHydrationWarning");
-  });
-
-  it("does not load browser-blocklisted analytics scripts on first paint", async () => {
-    const [layout, client] = await Promise.all([
-      readRepoFile("www/src/app/layout.tsx"),
-      readRepoFile("www/src/lib/posthog-client.ts"),
+  it("matches protected routes and broad non-static document routes", async () => {
+    expect(config.matcher).toEqual([
+      "/dashboard(.*)",
+      "/admin(.*)",
+      "/((?!_next|.*\\..*).*)",
     ]);
-
-    expect(layout).not.toContain("@vercel/analytics");
-    expect(layout).not.toContain("<Analytics");
-    expect(client).toContain("autocapture: false");
-    expect(client).toContain("capture_pageview: false");
   });
 });

--- a/tests/www/security-headers.test.ts
+++ b/tests/www/security-headers.test.ts
@@ -1,0 +1,55 @@
+import { readFile } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
+
+async function readRepoFile(path: string) {
+  return readFile(resolve(root, path), "utf8");
+}
+
+describe("www Lighthouse security headers", () => {
+  it("sets an enforced nonce CSP and COOP from the proxy", async () => {
+    const proxy = await readRepoFile("www/src/proxy.ts");
+
+    expect(proxy).toContain("Content-Security-Policy");
+    expect(proxy).toContain("Cross-Origin-Opener-Policy");
+    expect(proxy).toContain("x-nonce");
+    expect(proxy).toContain("script-src");
+    expect(proxy).toContain("'strict-dynamic'");
+    expect(proxy).toContain("'nonce-${nonce}'");
+    expect(proxy).not.toContain("Content-Security-Policy-Report-Only");
+    expect(proxy).not.toContain("'unsafe-inline' 'unsafe-eval'");
+  });
+
+  it("keeps Clerk middleware scoped while applying security headers broadly", async () => {
+    const proxy = await readRepoFile("www/src/proxy.ts");
+
+    expect(proxy).toContain('createRouteMatcher(["/dashboard(.*)", "/admin(.*)"])');
+    expect(proxy).toContain('"/((?!_next|.*\\\\..*).*)"');
+    expect(proxy).toContain("return withClerk(request, event)");
+    expect(proxy).toContain("return applySecurityHeaders");
+  });
+
+  it("passes the CSP nonce to the server-rendered landing JSON-LD script", async () => {
+    const landing = await readRepoFile("www/src/app/page.tsx");
+
+    expect(landing).toContain('headers()).get("x-nonce")');
+    expect(landing).toContain('<script');
+    expect(landing).toContain("nonce={nonce}");
+    expect(landing).toContain("suppressHydrationWarning");
+  });
+
+  it("does not load browser-blocklisted analytics scripts on first paint", async () => {
+    const [layout, client] = await Promise.all([
+      readRepoFile("www/src/app/layout.tsx"),
+      readRepoFile("www/src/lib/posthog-client.ts"),
+    ]);
+
+    expect(layout).not.toContain("@vercel/analytics");
+    expect(layout).not.toContain("<Analytics");
+    expect(client).toContain("autocapture: false");
+    expect(client).toContain("capture_pageview: false");
+  });
+});

--- a/tests/www/security-headers.test.ts
+++ b/tests/www/security-headers.test.ts
@@ -43,6 +43,9 @@ describe("www Lighthouse security headers", () => {
     const authorizeProtectedRoute = vi.fn(async () => {
       const response = NextResponse.next();
       response.headers.set("x-clerk-checked", "1");
+      response.headers.set("x-middleware-override-headers", "x-clerk-auth-status,x-clerk-auth-token");
+      response.headers.set("x-middleware-request-x-clerk-auth-status", "signed-in");
+      response.headers.set("x-middleware-request-x-clerk-auth-token", "token");
       return response;
     });
     const response = await proxyWithSecurity(
@@ -55,6 +58,13 @@ describe("www Lighthouse security headers", () => {
     expect(response.headers.get("x-clerk-checked")).toBe("1");
     expectSecurityHeaders(response);
     expect(response.headers.get("x-middleware-request-x-nonce")).toBeTruthy();
+    expect(response.headers.get("x-middleware-request-x-clerk-auth-status")).toBe("signed-in");
+    expect(response.headers.get("x-middleware-request-x-clerk-auth-token")).toBe("token");
+    expect(response.headers.get("x-middleware-override-headers")?.split(",")).toEqual([
+      "x-clerk-auth-status",
+      "x-clerk-auth-token",
+      "x-nonce",
+    ]);
     expect(response.headers.get("x-middleware-request-content-security-policy")).toBeNull();
   });
 

--- a/www/src/app/layout.tsx
+++ b/www/src/app/layout.tsx
@@ -9,7 +9,6 @@ import {
   Cormorant_Garamond,
   Orbitron,
 } from "next/font/google";
-import { Analytics } from "@vercel/analytics/react";
 import { getPostHogVisitorCountry } from "@matrix-os/observability/client";
 import { PostHogCookieBanner } from "@/components/PostHogCookieBanner";
 import "./globals.css";
@@ -108,7 +107,6 @@ export default async function RootLayout({
       <body className={`${inter.variable} ${instrumentSans.variable} ${instrumentSerif.variable} ${jetbrainsMono.variable} ${caveat.variable} ${cormorant.variable} ${orbitron.variable}`}>
         {children}
         <PostHogCookieBanner visitorCountry={visitorCountry} />
-        <Analytics />
       </body>
     </html>
   );

--- a/www/src/app/page.tsx
+++ b/www/src/app/page.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from "next";
-import Script from "next/script";
+import { headers } from "next/headers";
 import { BodyOverflow } from "@/components/landing/ScrollScreenshot";
 import { LandingBilling } from "@/components/landing/LandingBilling";
 import { LandingTelemetry } from "@/components/landing/LandingTelemetry";
@@ -38,11 +38,19 @@ export const metadata: Metadata = {
     "Matrix gives background agents their own computer. Run Claude, Codex, Cursor, OpenCode, and Hermes in a private hosted workspace with persistent terminals, repos, previews, and workflows that keep going after your laptop closes.",
 };
 
-export default function LandingPage() {
+export default async function LandingPage() {
+  const nonce = (await headers()).get("x-nonce") ?? undefined;
+
   return (
     <div style={{ backgroundColor: c.pageBg, color: c.deep, fontFamily: fonts.sans }}>
       {/* react-doctor-disable-next-line react-doctor/no-danger -- jsonLd is JSON.stringify of a static module-scope object (trusted, no user input); standard JSON-LD injection */}
-      <Script id="landing-json-ld" type="application/ld+json" strategy="beforeInteractive" dangerouslySetInnerHTML={{ __html: jsonLd }} />
+      <script
+        id="landing-json-ld"
+        type="application/ld+json"
+        nonce={nonce}
+        suppressHydrationWarning
+        dangerouslySetInnerHTML={{ __html: jsonLd }}
+      />
       <LandingTelemetry />
       <BodyOverflow />
 

--- a/www/src/lib/posthog-client.ts
+++ b/www/src/lib/posthog-client.ts
@@ -92,6 +92,8 @@ export function initializeWwwPostHog(
     ...(apiHost ? { api_host: apiHost } : {}),
     ui_host: currentConfig.uiHost,
     defaults: "2026-01-30",
+    autocapture: false,
+    capture_pageview: false,
     capture_exceptions: true,
     // Masked session replay: every input is masked by default so signup and
     // billing failures can be replayed without capturing what users typed.

--- a/www/src/proxy.ts
+++ b/www/src/proxy.ts
@@ -9,6 +9,13 @@ const withClerk = clerkMiddleware(async (auth, req) => {
   }
 });
 
+type ProxyRequest = Parameters<typeof withClerk>[0];
+type ProxyEvent = Parameters<typeof withClerk>[1];
+type ProtectedRouteAuthorizer = (
+  request: ProxyRequest,
+  event: ProxyEvent,
+) => ReturnType<typeof withClerk>;
+
 function normalizeCsp(policy: string): string {
   return policy.replace(/\s{2,}/g, " ").trim();
 }
@@ -32,33 +39,56 @@ function buildContentSecurityPolicy(nonce: string): string {
   `);
 }
 
-function applySecurityHeaders(request: Parameters<typeof withClerk>[0]) {
+function createSecurityResponse(request: ProxyRequest) {
   const nonce = btoa(crypto.randomUUID());
   const requestHeaders = new Headers(request.headers);
   const csp = buildContentSecurityPolicy(nonce);
   requestHeaders.set("x-nonce", nonce);
-  requestHeaders.set("Content-Security-Policy", csp);
 
   const response = NextResponse.next({
     request: {
       headers: requestHeaders,
     },
   });
+  return applySecurityHeaders(response, csp);
+}
+
+function applySecurityHeaders(response: NextResponse, csp: string) {
   response.headers.set("Content-Security-Policy", csp);
   response.headers.set("Cross-Origin-Opener-Policy", "same-origin");
   response.headers.set("Permissions-Policy", "browsing-topics=(), interest-cohort=()");
   return response;
 }
 
-export default function proxy(
-  request: Parameters<typeof withClerk>[0],
-  event: Parameters<typeof withClerk>[1],
-) {
-  if (isProtectedRoute(request)) {
-    return withClerk(request, event);
+function applySecurityResponseHeaders(response: Response, securityResponse: NextResponse) {
+  for (const [name, value] of securityResponse.headers) {
+    if (
+      name === "content-security-policy" ||
+      name === "cross-origin-opener-policy" ||
+      name === "permissions-policy" ||
+      name === "x-middleware-override-headers" ||
+      name.startsWith("x-middleware-request-")
+    ) {
+      response.headers.set(name, value);
+    }
   }
-  return applySecurityHeaders(request);
+  return response;
 }
+
+export async function proxyWithSecurity(
+  request: ProxyRequest,
+  event: ProxyEvent,
+  authorizeProtectedRoute: ProtectedRouteAuthorizer = withClerk,
+) {
+  const securityResponse = createSecurityResponse(request);
+  if (isProtectedRoute(request)) {
+    const clerkResponse = await authorizeProtectedRoute(request, event);
+    return applySecurityResponseHeaders(clerkResponse ?? NextResponse.next(), securityResponse);
+  }
+  return securityResponse;
+}
+
+export default proxyWithSecurity;
 
 export const config = {
   matcher: ["/dashboard(.*)", "/admin(.*)", "/((?!_next|.*\\..*).*)"],

--- a/www/src/proxy.ts
+++ b/www/src/proxy.ts
@@ -62,11 +62,22 @@ function applySecurityHeaders(response: NextResponse, csp: string) {
 
 function applySecurityResponseHeaders(response: Response, securityResponse: NextResponse) {
   for (const [name, value] of securityResponse.headers) {
+    if (name === "x-middleware-override-headers") {
+      const merged = [
+        ...(response.headers.get(name)?.split(",") ?? []),
+        ...value.split(","),
+      ]
+        .map((header) => header.trim())
+        .filter((header, index, headers) => header.length > 0 && headers.indexOf(header) === index)
+        .join(",");
+      response.headers.set(name, merged);
+      continue;
+    }
+
     if (
       name === "content-security-policy" ||
       name === "cross-origin-opener-policy" ||
       name === "permissions-policy" ||
-      name === "x-middleware-override-headers" ||
       name.startsWith("x-middleware-request-")
     ) {
       response.headers.set(name, value);

--- a/www/src/proxy.ts
+++ b/www/src/proxy.ts
@@ -1,13 +1,65 @@
 import { clerkMiddleware, createRouteMatcher } from "@clerk/nextjs/server";
+import { NextResponse } from "next/server";
 
 const isProtectedRoute = createRouteMatcher(["/dashboard(.*)", "/admin(.*)"]);
 
-export default clerkMiddleware(async (auth, req) => {
+const withClerk = clerkMiddleware(async (auth, req) => {
   if (isProtectedRoute(req)) {
     await auth.protect();
   }
 });
 
+function normalizeCsp(policy: string): string {
+  return policy.replace(/\s{2,}/g, " ").trim();
+}
+
+function buildContentSecurityPolicy(nonce: string): string {
+  const devScriptPolicy = process.env.NODE_ENV === "development" ? " 'unsafe-eval' http:" : "";
+  return normalizeCsp(`
+    default-src 'self';
+    base-uri 'self';
+    object-src 'none';
+    frame-ancestors 'self';
+    form-action 'self' https://app.matrix-os.com;
+    img-src 'self' blob: data: https:;
+    font-src 'self' data:;
+    style-src 'self' 'unsafe-inline';
+    script-src 'self' 'nonce-${nonce}' 'strict-dynamic' https:${devScriptPolicy};
+    connect-src 'self' https://app.matrix-os.com https://api.matrix-os.com https://clerk.matrix-os.com https://*.clerk.com https://*.clerk.accounts.dev https://eu.i.posthog.com https://eu-assets.i.posthog.com;
+    frame-src 'self' https://app.matrix-os.com https://clerk.matrix-os.com https://*.clerk.com https://*.clerk.accounts.dev;
+    worker-src 'self' blob:;
+    upgrade-insecure-requests;
+  `);
+}
+
+function applySecurityHeaders(request: Parameters<typeof withClerk>[0]) {
+  const nonce = btoa(crypto.randomUUID());
+  const requestHeaders = new Headers(request.headers);
+  const csp = buildContentSecurityPolicy(nonce);
+  requestHeaders.set("x-nonce", nonce);
+  requestHeaders.set("Content-Security-Policy", csp);
+
+  const response = NextResponse.next({
+    request: {
+      headers: requestHeaders,
+    },
+  });
+  response.headers.set("Content-Security-Policy", csp);
+  response.headers.set("Cross-Origin-Opener-Policy", "same-origin");
+  response.headers.set("Permissions-Policy", "browsing-topics=(), interest-cohort=()");
+  return response;
+}
+
+export default function proxy(
+  request: Parameters<typeof withClerk>[0],
+  event: Parameters<typeof withClerk>[1],
+) {
+  if (isProtectedRoute(request)) {
+    return withClerk(request, event);
+  }
+  return applySecurityHeaders(request);
+}
+
 export const config = {
-  matcher: ["/dashboard(.*)", "/admin(.*)"],
+  matcher: ["/dashboard(.*)", "/admin(.*)", "/((?!_next|.*\\..*).*)"],
 };


### PR DESCRIPTION
## Summary
- Add enforced nonce-based CSP, COOP, and Permissions-Policy headers to public www document routes from `www/src/proxy.ts`.
- Keep Clerk protection scoped to `/dashboard` and `/admin` so public landing rendering is not blocked by Clerk middleware.
- Remove the Vercel Analytics component and disable PostHog autocapture/pageview loading so first paint no longer requests the blocklisted `/ _vercel/insights` or PostHog dead-click autocapture scripts.
- Render landing JSON-LD with the proxy nonce and `suppressHydrationWarning` to avoid CSP nonce hydration noise.

## Invariants
- Source of truth: `www/src/proxy.ts` owns public-route browser security headers; explicit PostHog event calls remain the source for marketing analytics events.
- Lock/transaction scope: no database writes or transactions are involved.
- Acceptable orphan states: browser-extension warnings such as `contentscript.js` Shared Storage deprecation remain out of repo control; ad blockers can still block user-installed extension or unrelated third-party traffic.
- Auth source of truth: Clerk middleware remains the auth boundary for `/dashboard` and `/admin`; public routes only receive security headers and do not call `auth.protect()`.
- Deferred scope: this PR does not attempt to patch third-party browser extensions or redesign analytics consent/telemetry.

## Validation
- `pnpm test tests/www/security-headers.test.ts tests/www/posthog-proxy.test.ts tests/observability/posthog-error-tracking.test.ts`
- `bun run check:patterns`
- `npx react-doctor@latest www --verbose --scope changed --base origin/main`
- `pnpm --filter www exec tsc --noEmit`
- `pnpm --filter www build`
- Production smoke: `curl -I http://localhost:3002/` shows enforced CSP, `Cross-Origin-Opener-Policy: same-origin`, and Permissions-Policy.
- Playwright production smoke: `http://localhost:3002/` had 0 console errors and 0 warnings.
- Lighthouse local production run: Best Practices 100 for `http://localhost:3002/`.
