### PR TITLE
test(sync-client): cover durable shell reconnect semantics

### DIFF
--- a/packages/sync-client/tests/unit/shell-client.test.ts
+++ b/packages/sync-client/tests/unit/shell-client.test.ts
@@ -1,6 +1,6 @@
 import { EventEmitter } from "node:events";
 import { PassThrough } from "node:stream";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   createShellClient,
   SHELL_ATTACH_LIVE_TAIL_FROM_SEQ,
@@ -8,6 +8,7 @@ import {
 
 class FakeWebSocket extends EventEmitter {
   static last: FakeWebSocket | null = null;
+  static instances: FakeWebSocket[] = [];
 
   url: string;
   sent: string[] = [];
@@ -17,6 +18,7 @@ class FakeWebSocket extends EventEmitter {
     super();
     this.url = url;
     FakeWebSocket.last = this;
+    FakeWebSocket.instances.push(this);
   }
 
   send(data: string): void {
@@ -28,7 +30,24 @@ class FakeWebSocket extends EventEmitter {
   }
 }
 
+async function waitForFakeSocketCount(expectedCount: number): Promise<void> {
+  const deadline = Date.now() + 250;
+  while (FakeWebSocket.instances.length < expectedCount) {
+    if (Date.now() > deadline) {
+      throw new Error(`Timed out waiting for ${expectedCount} fake WebSocket instances; saw ${FakeWebSocket.instances.length}`);
+    }
+    await new Promise((resolve) => {
+      setTimeout(resolve, 1);
+    });
+  }
+}
+
 describe("createShellClient attachSession", () => {
+  beforeEach(() => {
+    FakeWebSocket.last = null;
+    FakeWebSocket.instances = [];
+  });
+
   it("detaches on raw Ctrl-C before the websocket has attached", async () => {
     const input = new PassThrough() as PassThrough & {
       isTTY: true;
@@ -104,8 +123,8 @@ describe("createShellClient attachSession", () => {
     expect(FakeWebSocket.last?.closed).toBe(false);
     expect(FakeWebSocket.last?.sent).toContain(JSON.stringify({ type: "input", data: "\u0003" }));
 
-    FakeWebSocket.last?.emit("close");
-    await attach;
+    FakeWebSocket.last?.emit("message", JSON.stringify({ type: "exit" }));
+    await expect(attach).resolves.toEqual({ detached: false });
   });
 
   it("uses live tail by default so attach does not replay stale full-screen frames", async () => {
@@ -124,8 +143,48 @@ describe("createShellClient attachSession", () => {
     expect(FakeWebSocket.last?.url).toContain(`fromSeq=${SHELL_ATTACH_LIVE_TAIL_FROM_SEQ}`);
 
     FakeWebSocket.last?.emit("message", JSON.stringify({ type: "attached" }));
-    FakeWebSocket.last?.emit("close");
-    await attach;
+    FakeWebSocket.last?.emit("message", JSON.stringify({ type: "exit" }));
+    await expect(attach).resolves.toEqual({ detached: false });
+  });
+
+  it("reconnects on unexpected close after attach instead of resolving detached", async () => {
+    const client = createShellClient({
+      gatewayUrl: "https://matrix.example",
+      token: "token-123",
+      timeoutMs: 100,
+    });
+
+    const attach = client.attachSession("main", {
+      input: new PassThrough() as NodeJS.ReadStream,
+      output: new PassThrough() as NodeJS.WriteStream,
+      errorOutput: new PassThrough() as NodeJS.WriteStream,
+      WebSocketImpl: FakeWebSocket as never,
+      heartbeatIntervalMs: 0,
+      reconnectBaseDelayMs: 1,
+      reconnectMaxDelayMs: 1,
+    });
+
+    const firstSocket = FakeWebSocket.last;
+    firstSocket?.emit("message", JSON.stringify({ type: "attached" }));
+    firstSocket?.emit("close");
+
+    await waitForFakeSocketCount(2);
+
+    expect(FakeWebSocket.instances).toHaveLength(2);
+    expect(FakeWebSocket.instances[0]).toBe(firstSocket);
+    expect(FakeWebSocket.instances[1]?.url).toContain(`fromSeq=${SHELL_ATTACH_LIVE_TAIL_FROM_SEQ}`);
+
+    const result = await Promise.race([
+      attach.then((value) => ({ status: "settled" as const, value })),
+      new Promise<{ status: "pending" }>((resolve) => {
+        setTimeout(() => resolve({ status: "pending" }), 10);
+      }),
+    ]);
+    expect(result).toEqual({ status: "pending" });
+
+    FakeWebSocket.last?.emit("message", JSON.stringify({ type: "attached" }));
+    FakeWebSocket.last?.emit("message", JSON.stringify({ type: "exit" }));
+    await expect(attach).resolves.toEqual({ detached: false });
   });
 
   it("forwards SIGINT after attach so terminals that still emit signals can interrupt remote programs", async () => {
@@ -162,8 +221,8 @@ describe("createShellClient attachSession", () => {
     expect(FakeWebSocket.last?.closed).toBe(false);
     expect(FakeWebSocket.last?.sent.filter((frame) => frame === JSON.stringify({ type: "input", data: "\u0003" }))).toHaveLength(2);
 
-    FakeWebSocket.last?.emit("close");
-    await attach;
+    FakeWebSocket.last?.emit("message", JSON.stringify({ type: "exit" }));
+    await expect(attach).resolves.toEqual({ detached: false });
   });
 
   it("detaches cleanly on SIGTERM after attach", async () => {

--- a/tests/cli/run.test.ts
+++ b/tests/cli/run.test.ts
@@ -51,7 +51,10 @@ async function createFakeRunGateway(runResult: Record<string, unknown> = {
   wss.on("connection", (ws) => {
     wsConnections += 1;
     ws.send(JSON.stringify({ type: "attached" }));
-    setTimeout(() => ws.close(), 10).unref?.();
+    setTimeout(() => {
+      ws.send(JSON.stringify({ type: "exit" }));
+      ws.close();
+    }, 10).unref?.();
   });
 
   await new Promise<void>((resolve) => {
@@ -204,7 +207,7 @@ describe("run CLI command", () => {
       expect(JSON.parse(result.stdout)).toEqual({
         v: 1,
         ok: true,
-        data: { detached: true, session: "run-session" },
+        data: { detached: false, session: "run-session" },
       });
       expect(result.stderr).toContain("\u001b[?1000l");
       expect(gateway.createRequests).toBe(1);

--- a/tests/shell/proxy-auth.test.ts
+++ b/tests/shell/proxy-auth.test.ts
@@ -375,6 +375,7 @@ describe("proxy auth: sign-in redirects", () => {
 
   it("uses the configured public HTTPS app origin for anonymous redirects", async () => {
     vi.resetModules();
+    vi.stubEnv("NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY", "pk_test_proxy_auth");
     vi.stubEnv("NEXT_PUBLIC_MATRIX_APP_URL", "https://app.matrix-os.com");
 
     const clerkMiddleware = vi.fn((handler) => async (request: unknown, event: unknown) =>


### PR DESCRIPTION
## Summary

- update the sync-client package-local shell attach tests to finish with the remote `exit` message instead of an unexpected socket close
- add a package-local regression proving a close after `attached` reconnects instead of resolving the attach promise

## Root Cause

PR #459 changed durable shell attach semantics so a WebSocket close after attach is treated as a transient drop and retried. `packages/sync-client/tests/unit/shell-client.test.ts` still expected close-after-attach to settle, so the `Sync Client Package` job on `main` timed out.

## Tests

- `pnpm --filter @finnaai/matrix exec vitest run tests/unit/shell-client.test.ts`
- `pnpm --filter @finnaai/matrix test`
- `pnpm --filter @finnaai/matrix build`
- `pnpm run check:patterns`

## Review/Monitoring

- main CI failure targeted: `CI / Sync Client Package`
- Docker Buildx timeout on main is separate runner/Docker Hub infrastructure flake and is not addressed here

