### PR TITLE
fix(observability): use host logship installer path

### DIFF
--- a/scripts/enable-vps-logship.sh
+++ b/scripts/enable-vps-logship.sh
@@ -73,7 +73,7 @@ mkdir -p "$(dirname "$KNOWN_HOSTS")"
 printf '%s\n%s\n%s\n' "$LOGS_INGEST_USER" "$LOGS_INGEST_PASSWORD" "$POSTHOG_PROJECT_TOKEN" |
   ssh -i "$VPS_SSH_KEY" -o StrictHostKeyChecking=accept-new \
     -o UserKnownHostsFile="$KNOWN_HOSTS" "root@${ip}" \
-    "IFS= read -r u && IFS= read -r p && IFS= read -r t && LOGS_INGEST_USER=\"\$u\" LOGS_INGEST_PASSWORD=\"\$p\" POSTHOG_PROJECT_TOKEN=\"\$t\" /opt/matrix/app/bin/matrix-install-logship '${LOGS_INGEST_URL}' '${HANDLE}' '${MATRIX_ENV}'"
+    "IFS= read -r u && IFS= read -r p && IFS= read -r t && LOGS_INGEST_USER=\"\$u\" LOGS_INGEST_PASSWORD=\"\$p\" POSTHOG_PROJECT_TOKEN=\"\$t\" /opt/matrix/bin/matrix-install-logship '${LOGS_INGEST_URL}' '${HANDLE}' '${MATRIX_ENV}'"
 
 # Record enrollment in the ops-side inventory so credential rotation has a
 # concrete target list (spec 093). Idempotent: one line per handle.

--- a/tests/observability/posthog-logship.test.ts
+++ b/tests/observability/posthog-logship.test.ts
@@ -30,6 +30,8 @@ describe("PostHog fleet log shipping", () => {
     expect(helper).toContain("printf '%s\\n%s\\n%s\\n' \"$LOGS_INGEST_USER\" \"$LOGS_INGEST_PASSWORD\" \"$POSTHOG_PROJECT_TOKEN\"");
     expect(helper).toContain("IFS= read -r t");
     expect(helper).toContain('POSTHOG_PROJECT_TOKEN=\\"\\$t\\"');
+    expect(helper).toContain("/opt/matrix/bin/matrix-install-logship");
+    expect(helper).not.toContain("/opt/matrix/app/bin/matrix-install-logship");
     expect(helper).not.toContain("POSTHOG_PROJECT_TOKEN='${POSTHOG_PROJECT_TOKEN}'");
   });
 });


### PR DESCRIPTION
## Summary
- point VPS logship enrollment at the host-bundle installer under /opt/matrix/bin
- add regression coverage for the installer path used by the helper

## Tests
- bash -n scripts/enable-vps-logship.sh
- bun test tests/observability/posthog-logship.test.ts
- bun run typecheck
- bun run check:patterns
- bun run test

## Review/Monitoring
- Greptile must report 5/5 or no findings before merge.

## Invariants
- Source of truth: host-bundle host-bin scripts are installed under /opt/matrix/bin.
- Lock/transaction scope: no DB writes or locks; enrollment still runs one SSH command per host.
- Acceptable orphan states: failed enrollment leaves existing log shipping config/service untouched for that host.
- Auth source of truth: platform bearer token authorizes fleet lookup; log credentials remain stdin/environment only, not argv.
- Deferred scope: does not change auto-enrollment or retire Loki.