### PR TITLE
fix(observability): move Alloy file labels to targets

### DIFF
--- a/distro/customer-vps/host-bin/matrix-install-logship
+++ b/distro/customer-vps/host-bin/matrix-install-logship
@@ -172,12 +172,11 @@ loki.source.journal "matrix_symphony" {
 }
 
 local.file_match "kernel_jsonl" {
-  path_targets = [{ __path__ = "${MATRIX_HOME_LOGS}/*.jsonl" }]
+  path_targets = [{ __path__ = "${MATRIX_HOME_LOGS}/*.jsonl", source = "jsonl", handle = "${HANDLE}", env = "${MATRIX_ENV}" }]
 }
 
 loki.source.file "kernel_logs" {
   targets    = local.file_match.kernel_jsonl.targets
-  labels     = { source = "jsonl", handle = "${HANDLE}", env = "${MATRIX_ENV}" }
   forward_to = [loki.write.central.receiver, otelcol.receiver.loki.posthog.receiver]
 }
 EOF

--- a/tests/observability/posthog-logship.test.ts
+++ b/tests/observability/posthog-logship.test.ts
@@ -19,7 +19,8 @@ describe("PostHog fleet log shipping", () => {
     expect(installer).toContain('headers = { "Authorization" = "Bearer " + sys.env("POSTHOG_PROJECT_TOKEN") }');
 
     expect(installer).toContain('forward_to    = [loki.write.central.receiver, otelcol.receiver.loki.posthog.receiver]');
-    expect(installer).toContain('labels     = { source = "jsonl", handle = "${HANDLE}", env = "${MATRIX_ENV}" }');
+    expect(installer).toContain('path_targets = [{ __path__ = "${MATRIX_HOME_LOGS}/*.jsonl", source = "jsonl", handle = "${HANDLE}", env = "${MATRIX_ENV}" }]');
+    expect(installer).not.toMatch(/loki\.source\.file "kernel_logs" \{[\s\S]*?\n\s+labels\s+=/);
     expect(installer).toContain('forward_to = [loki.write.central.receiver, otelcol.receiver.loki.posthog.receiver]');
   });
 

--- a/tests/observability/posthog-logship.test.ts
+++ b/tests/observability/posthog-logship.test.ts
@@ -20,7 +20,7 @@ describe("PostHog fleet log shipping", () => {
 
     expect(installer).toContain('forward_to    = [loki.write.central.receiver, otelcol.receiver.loki.posthog.receiver]');
     expect(installer).toContain('path_targets = [{ __path__ = "${MATRIX_HOME_LOGS}/*.jsonl", source = "jsonl", handle = "${HANDLE}", env = "${MATRIX_ENV}" }]');
-    expect(installer).not.toMatch(/loki\.source\.file "kernel_logs" \{[\s\S]*?\n\s+labels\s+=/);
+    expect(installer).not.toMatch(/loki\.source\.file "kernel_logs" \{[^}]*\n\s+labels\s+=/);
     expect(installer).toContain('forward_to = [loki.write.central.receiver, otelcol.receiver.loki.posthog.receiver]');
   });
 


### PR DESCRIPTION
## Summary
- move JSONL log labels from the unsupported loki.source.file labels attribute into the file target map
- add regression coverage that rejects labels inside the loki.source.file block

## Tests
- bash -n distro/customer-vps/host-bin/matrix-install-logship
- bun test tests/observability/posthog-logship.test.ts
- bun run typecheck
- bun run check:patterns
- bun run test

## Review/Monitoring
- Greptile must report 5/5 or no findings before merge.

## Invariants
- Source of truth: Alloy target maps carry JSONL stream labels; the service unit remains generated by matrix-install-logship.
- Lock/transaction scope: no DB writes or locks; the installer rewrites local config files atomically enough for idempotent reruns and then asks systemd to reload.
- Acceptable orphan states: if service start fails after config/env write, Matrix runtime services continue independently and rerunning enrollment replaces the generated logship config.
- Auth source of truth: log ingestion credentials remain in /opt/matrix/env/logship.env and are supplied from ops-side enrollment, not argv.
- Deferred scope: does not retire Loki, change alerting, or add platform auto-enrollment.