### PR TITLE
fix(ci): stabilize main workflow checks

### DIFF
--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -101,14 +101,29 @@ jobs:
         if: needs.changes.outputs.should_run == 'true'
         uses: docker/setup-buildx-action@v4
 
-      - name: Populate dev image cache
+      - name: Build dev image
         if: needs.changes.outputs.should_run == 'true'
         uses: docker/build-push-action@v7
         with:
           context: .
           file: Dockerfile.dev
+          load: true
+          tags: matrix-os-dev:ci
           cache-from: type=gha,scope=dev-image
           cache-to: type=gha,mode=max,scope=dev-image
+
+      - name: Save Docker image artifact
+        if: needs.changes.outputs.should_run == 'true'
+        run: docker save matrix-os-dev:ci | gzip -1 > /tmp/matrix-os-dev-ci.tar.gz
+
+      - name: Upload Docker image artifact
+        if: needs.changes.outputs.should_run == 'true'
+        uses: actions/upload-artifact@v7
+        with:
+          name: matrix-os-dev-image
+          path: /tmp/matrix-os-dev-ci.tar.gz
+          retention-days: 1
+          if-no-files-found: error
 
   docker-smoke:
     name: Docker Smoke Test
@@ -125,19 +140,16 @@ jobs:
       - uses: actions/checkout@v6
         if: needs.changes.outputs.should_run == 'true'
 
-      - name: Set up Docker Buildx
+      - name: Download Docker image artifact
         if: needs.changes.outputs.should_run == 'true'
-        uses: docker/setup-buildx-action@v4
-
-      - name: Build dev image
-        if: needs.changes.outputs.should_run == 'true'
-        uses: docker/build-push-action@v7
+        uses: actions/download-artifact@v7
         with:
-          context: .
-          file: Dockerfile.dev
-          load: true
-          tags: matrix-os-dev:ci
-          cache-from: type=gha,scope=dev-image
+          name: matrix-os-dev-image
+          path: /tmp/docker-image
+
+      - name: Load Docker image artifact
+        if: needs.changes.outputs.should_run == 'true'
+        run: gzip -dc /tmp/docker-image/matrix-os-dev-ci.tar.gz | docker load
 
       - name: Create CI env file
         if: needs.changes.outputs.should_run == 'true'
@@ -207,17 +219,14 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
-
-      - name: Build dev image
-        uses: docker/build-push-action@v7
+      - name: Download Docker image artifact
+        uses: actions/download-artifact@v7
         with:
-          context: .
-          file: Dockerfile.dev
-          load: true
-          tags: matrix-os-dev:ci
-          cache-from: type=gha,scope=dev-image
+          name: matrix-os-dev-image
+          path: /tmp/docker-image
+
+      - name: Load Docker image artifact
+        run: gzip -dc /tmp/docker-image/matrix-os-dev-ci.tar.gz | docker load
 
       - name: Create CI env file
         run: |

--- a/tests/platform/ci-workflows.test.ts
+++ b/tests/platform/ci-workflows.test.ts
@@ -45,6 +45,21 @@ describe('CI workflows', () => {
     expect(readme).toContain('Screenshot workflow removed');
   });
 
+  it('reuses one Docker test image artifact across scenario jobs', () => {
+    const root = process.cwd();
+    const workflow = readFileSync(join(root, '.github/workflows/docker-test.yml'), 'utf8');
+
+    expect(workflow).toContain('name: Upload Docker image artifact');
+    expect(workflow).toContain('name: Download Docker image artifact');
+    expect(workflow).toContain('uses: actions/download-artifact@v7');
+    expect(workflow).not.toContain('uses: actions/download-artifact@v8');
+    expect(workflow).toContain('docker save matrix-os-dev:ci | gzip -1 > /tmp/matrix-os-dev-ci.tar.gz');
+    expect(workflow).toContain('gzip -dc /tmp/docker-image/matrix-os-dev-ci.tar.gz | docker load');
+
+    const dockerBuildActionUses = workflow.match(/uses: docker\/build-push-action@v7/g) ?? [];
+    expect(dockerBuildActionUses).toHaveLength(1);
+  });
+
   it('wires every required Stripe price secret into platform Cloud Run', () => {
     const root = process.cwd();
     const workflow = readFileSync(join(root, '.github/workflows/platform-cloud-run.yml'), 'utf8');

--- a/tests/www/landing-agent-setup.test.ts
+++ b/tests/www/landing-agent-setup.test.ts
@@ -44,8 +44,7 @@ describe("www landing agent setup", () => {
 
     expect(proxy).toContain('"/dashboard(.*)"');
     expect(proxy).toContain('"/admin(.*)"');
-    expect(proxy).toContain('matcher: ["/dashboard(.*)", "/admin(.*)"]');
-    expect(proxy).not.toContain('"/((?!_next');
+    expect(proxy).toContain('matcher: ["/dashboard(.*)", "/admin(.*)", "/((?!_next|.*\\\\..*).*)"]');
     expect(proxy).not.toContain('"/(api|trpc)(.*)"');
   });
 


### PR DESCRIPTION
## Summary
- Update the www proxy matcher test to account for the site-wide security header matcher.
- Build the Docker dev image once in the Docker workflow, upload it as a short-lived artifact, and load that artifact in smoke/scenario jobs.
- Add a CI workflow regression test so scenario jobs do not re-run the Docker build action.

## Tests
- bun test tests/www/landing-agent-setup.test.ts tests/platform/ci-workflows.test.ts
- bun run typecheck
- bun run check:patterns
- bun run test

## Invariants
- Source of truth: the workflow file defines the Docker scenario image handoff; the www proxy file defines the security-header matcher behavior.
- Lock/transaction scope: no database or runtime locks are involved; the Docker image is built once in the build job and consumed as an immutable artifact by dependent jobs.
- Acceptable orphan states: if the artifact cannot be saved, uploaded, downloaded, or loaded, the workflow fails before running smoke or scenario checks.
- Auth source of truth: unchanged; the public landing path stays outside Clerk route matching, and protected route matching remains scoped to the existing protected paths.
- Deferred scope: this does not shrink the Docker image or change scenario coverage; it only removes repeated downstream image builds.