### PR TITLE
test(platform): align onboarding smoke workflow assertion

### DIFF
--- a/tests/platform/ci-workflows.test.ts
+++ b/tests/platform/ci-workflows.test.ts
@@ -107,7 +107,7 @@ describe('CI workflows', () => {
     expect(workflow).toContain('--min-instances "$min_instances"');
   });
 
-  it('smokes the pre-VPS auth and billing shell surface before promotion', () => {
+  it('smokes the pre-VPS auth and onboarding shell surface before promotion', () => {
     const root = process.cwd();
     const workflow = readFileSync(join(root, '.github/workflows/platform-cloud-run.yml'), 'utf8');
 
@@ -116,7 +116,8 @@ describe('CI workflows', () => {
     expect(workflow).toContain('$CANDIDATE_URL/?billing=setup');
     expect(workflow).toContain('pre-VPS auth shell');
     expect(workflow).toContain('data-matrix-auth-shell="true"');
-    expect(workflow).toContain('data-matrix-billing-gate="true"');
+    expect(workflow).toContain('data-matrix-(billing-gate|boot-sequence)="true"');
+    expect(workflow).toContain('did not serve the billing gate or boot sequence');
     expect(workflow).toContain('data-matrix-platform-fallback-auth="true"');
     expect(workflow).toContain('served the platform fallback auth page');
   });


### PR DESCRIPTION
## Summary
- update the platform Cloud Run workflow contract test to match the 092 journey-driven boot sequence smoke check
- keep the fallback auth-page rejection covered while allowing the legacy billing gate marker or the new boot-sequence marker

## Tests
- bun run test tests/platform/ci-workflows.test.ts
- bun run check:patterns (0 violations; pre-existing broad scanner warnings only)

## Review/Monitoring
- This PR unblocks current main CI so the Host Bundle Release same-SHA gate can build/publish after merge.
- Will monitor CI and Greptile on the current head before merge.

## Invariants
- Source of truth: .github/workflows/platform-cloud-run.yml remains the deployment smoke behavior; this test only verifies that contract.
- Lock/transaction scope: not applicable; test-only change.
- Acceptable orphan states: not applicable; no runtime state changes.
- Auth source of truth: unchanged; smoke still requires trusted edge-router headers and rejects platform fallback auth HTML.
- Deferred scope: does not alter deployment workflow behavior or production traffic.