### PR TITLE
fix(shell): harden terminal sessions

### DIFF
--- a/packages/gateway/src/shell/scrollback-store.ts
+++ b/packages/gateway/src/shell/scrollback-store.ts
@@ -1,10 +1,35 @@
-import { appendFile, mkdir, open, readFile, rename, rm, stat, writeFile } from "node:fs/promises";
+import { appendFile, mkdir, readFile, rename, rm, stat, writeFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import { randomBytes } from "node:crypto";
+import { z } from "zod/v4";
 import { validateSessionName } from "./names.js";
 import type { ReplayEvent } from "./replay-buffer.js";
 
 export type ScrollbackRecord = Extract<ReplayEvent, { type: "output" | "block-mark" }>;
+
+const Osc133MarkSchema = z.discriminatedUnion("code", [
+  z.object({ code: z.literal("A"), kind: z.literal("prompt-start") }),
+  z.object({ code: z.literal("B"), kind: z.literal("command-start") }),
+  z.object({ code: z.literal("C"), kind: z.literal("command-executed") }),
+  z.object({
+    code: z.literal("D"),
+    kind: z.literal("command-finished"),
+    exitCode: z.number().int().nullable(),
+  }),
+]);
+
+const ScrollbackRecordSchema = z.discriminatedUnion("type", [
+  z.object({
+    type: z.literal("output"),
+    seq: z.number().int().nonnegative(),
+    data: z.string(),
+  }),
+  z.object({
+    type: z.literal("block-mark"),
+    seq: z.number().int().nonnegative(),
+    mark: Osc133MarkSchema,
+  }),
+]);
 
 export interface ScrollbackStoreOptions {
   homePath: string;
@@ -23,7 +48,7 @@ export class ScrollbackStore {
   }
 
   pathForSession(name: string): string {
-    return join(this.scrollbackDir, `${validateSessionName(name)}.ndjson`);
+    return this.pathForValidatedSession(validateSessionName(name));
   }
 
   async append(name: string, records: ScrollbackRecord[]): Promise<void> {
@@ -43,12 +68,11 @@ export class ScrollbackStore {
   }
 
   async readSince(name: string, fromSeq: number): Promise<ScrollbackRecord[]> {
+    const safeName = validateSessionName(name);
     try {
-      const raw = await readFile(this.pathForSession(name), "utf-8");
-      return raw
-        .split("\n")
-        .filter(Boolean)
-        .map((line) => JSON.parse(line) as ScrollbackRecord)
+      const raw = await readFile(this.pathForValidatedSession(safeName), "utf-8");
+      const parsed = parseScrollbackLines(raw.split("\n"), safeName);
+      return parsed.records
         .filter((record) => record.seq >= fromSeq)
         .sort((a, b) => a.seq - b.seq);
     } catch (err: unknown) {
@@ -64,28 +88,11 @@ export class ScrollbackStore {
   }
 
   async latestSeq(name: string): Promise<number | null> {
+    const safeName = validateSessionName(name);
     try {
-      const handle = await open(this.pathForSession(name), "r");
-      try {
-        const info = await handle.stat();
-        let position = info.size;
-        let text = "";
-        while (position > 0) {
-          const length = Math.min(64 * 1024, position);
-          position -= length;
-          const buffer = Buffer.alloc(length);
-          await handle.read(buffer, 0, length, position);
-          text = `${buffer.toString("utf-8")}${text}`;
-          const lines = text.split("\n").filter(Boolean);
-          if (lines.length > 0 && (position === 0 || text.includes("\n"))) {
-            const record = JSON.parse(lines.at(-1)!) as ScrollbackRecord;
-            return record.seq;
-          }
-        }
-        return null;
-      } finally {
-        await handle.close();
-      }
+      const raw = await readFile(this.pathForValidatedSession(safeName), "utf-8");
+      const parsed = parseScrollbackLines(raw.split("\n"), safeName);
+      return parsed.records.at(-1)?.seq ?? null;
     } catch (err: unknown) {
       if (
         err instanceof Error &&
@@ -142,4 +149,40 @@ export class ScrollbackStore {
     );
     await run;
   }
+
+  private pathForValidatedSession(name: string): string {
+    return join(this.scrollbackDir, `${name}.ndjson`);
+  }
+}
+
+function parseScrollbackLines(lines: string[], session: string): { records: ScrollbackRecord[]; malformed: number } {
+  const records: ScrollbackRecord[] = [];
+  let malformed = 0;
+  for (const rawLine of lines) {
+    const line = rawLine.trim();
+    if (!line) continue;
+    try {
+      const parsed = ScrollbackRecordSchema.safeParse(JSON.parse(line));
+      if (parsed.success) {
+        records.push(parsed.data);
+      } else {
+        malformed += 1;
+      }
+    } catch (err: unknown) {
+      if (!(err instanceof SyntaxError)) {
+        console.warn("[shell] unexpected scrollback parse failure:", {
+          session,
+          error: err instanceof Error ? err.name : typeof err,
+        });
+      }
+      malformed += 1;
+    }
+  }
+  if (malformed > 0) {
+    console.warn("[shell] skipped malformed scrollback records:", {
+      session,
+      count: malformed,
+    });
+  }
+  return { records, malformed };
 }

--- a/shell/src/components/terminal/PaneGrid.tsx
+++ b/shell/src/components/terminal/PaneGrid.tsx
@@ -49,14 +49,24 @@ interface PaneNodeRendererProps {
 
 function PaneNodeRenderer({ node, theme, focusedPaneId, onFocusPane, onSessionAttached, shouldCachePane, shouldDestroyPane, allowRemoteResize = true, suppressNativeKeyboard = false }: PaneNodeRendererProps) {
   if (node.type === "pane") {
+    const focused = focusedPaneId === node.id;
     return (
-      <div key={node.id} className="h-full w-full min-h-0 min-w-0">
+      <div
+        key={node.id}
+        className="h-full w-full min-h-0 min-w-0"
+        style={{
+          boxShadow: focused
+            ? "inset 0 0 0 2px var(--primary), inset 0 0 0 3px color-mix(in srgb, var(--background) 68%, transparent)"
+            : "inset 0 0 0 1px color-mix(in srgb, var(--border) 62%, transparent)",
+          position: "relative",
+        }}
+      >
         <TerminalPane
           key={node.id}
           paneId={node.id}
           cwd={node.cwd}
           theme={theme}
-          isFocused={focusedPaneId === node.id}
+          isFocused={focused}
           sessionId={node.sessionId}
           claudeMode={node.claudeMode === true}
           startupCommand={node.startupCommand}

--- a/shell/src/components/terminal/TerminalApp.tsx
+++ b/shell/src/components/terminal/TerminalApp.tsx
@@ -69,6 +69,21 @@ const TAB_CLOSE_BUTTON_STYLE: CSSProperties = {
   marginLeft: "auto",
 };
 
+const ACTIVE_TAB_PILL_STYLE: CSSProperties = {
+  alignItems: "center",
+  background: "color-mix(in srgb, var(--primary) 16%, transparent)",
+  border: "1px solid color-mix(in srgb, var(--primary) 44%, transparent)",
+  borderRadius: 999,
+  color: "var(--primary)",
+  display: "inline-flex",
+  flex: "0 0 auto",
+  fontSize: 12,
+  fontWeight: 800,
+  height: 18,
+  lineHeight: "16px",
+  padding: "0 6px",
+};
+
 const SHELL_NEW_BUTTON_BASE_STYLE: CSSProperties = {
   height: 28,
   padding: "0 10px",
@@ -87,6 +102,17 @@ const SIDEBAR_RAIL_BUTTON_BASE_STYLE: CSSProperties = {
   borderRadius: 8,
   fontSize: 12,
   fontWeight: 700,
+};
+
+const SHELL_CARD_DELETE_BUTTON_STYLE: CSSProperties = {
+  background: "#F0EFE5",
+  border: "1px solid #DCDAC9",
+  borderRadius: 7,
+  color: "#77786E",
+  flexShrink: 0,
+  fontSize: 16,
+  height: 28,
+  width: 28,
 };
 
 const SHELL_CARD_NAME_BUTTON_STYLE: CSSProperties = {
@@ -1317,13 +1343,13 @@ function LocalTerminalTabBar({ defaultCwd }: { defaultCwd: string }) {
                 ...TAB_ITEM_BASE_STYLE,
                 background: active ? "var(--background)" : "color-mix(in srgb, var(--background) 42%, transparent)",
                 color: active ? "var(--foreground)" : "var(--muted-foreground)",
-                border: `1px solid ${active ? "var(--border)" : "color-mix(in srgb, var(--border) 55%, transparent)"}`,
+                border: `1px solid ${active ? "var(--primary)" : "color-mix(in srgb, var(--border) 55%, transparent)"}`,
                 padding: ctx.mobile ? "0 7px" : "0 8px",
-                fontWeight: active ? 600 : 450,
+                fontWeight: active ? 750 : 450,
                 flex: ctx.mobile ? "0 1 148px" : "0 1 168px",
                 minWidth: ctx.mobile ? 96 : 108,
                 maxWidth: ctx.mobile ? 160 : 190,
-                boxShadow: active ? "0 1px 0 rgba(0,0,0,0.08)" : "none",
+                boxShadow: active ? "inset 0 -3px 0 var(--primary), 0 0 0 1px color-mix(in srgb, var(--primary) 28%, transparent)" : "none",
               }}
               draggable
               onClick={() => ctx.setActiveTab(tab.id)}
@@ -1348,6 +1374,14 @@ function LocalTerminalTabBar({ defaultCwd }: { defaultCwd: string }) {
               >
                 <span style={{ overflow: "hidden", textOverflow: "ellipsis" }}>{tab.label}</span>
               </span>
+              {active && (
+                <span
+                  aria-hidden="true"
+                  style={ACTIVE_TAB_PILL_STYLE}
+                >
+                  Active
+                </span>
+              )}
               <button
                 type="button"
                 className="cursor-pointer flex items-center justify-center transition-colors"
@@ -2014,6 +2048,7 @@ function LocalTerminalSidebar() {
     for (const sessionId of getSessionIds(terminalTab.paneTree)) {
       if (!sessionId || openSessionIds.has(sessionId)) continue;
       openSessionIds.add(sessionId);
+      if (!isCanonicalShellSessionId(sessionId)) continue;
       syntheticShells.push({
         name: sessionId,
         status: "active",
@@ -2461,16 +2496,9 @@ function ShellCard({
             disabled={deleting}
             className="flex items-center justify-center"
             style={{
-              background: "#F0EFE5",
-              border: "1px solid #DCDAC9",
-              borderRadius: 7,
-              color: "#77786E",
+              ...SHELL_CARD_DELETE_BUTTON_STYLE,
               cursor: deleting ? "not-allowed" : "pointer",
-              flexShrink: 0,
-              fontSize: 16,
-              height: 28,
               opacity: deleting ? 0.65 : 1,
-              width: 28,
             }}
           >
             ×

--- a/shell/src/components/terminal/preferences-panel.tsx
+++ b/shell/src/components/terminal/preferences-panel.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { useEffect } from "react";
 import { TERMINAL_FONT_FAMILIES, useTerminalSettings, type TerminalCursorStyle, type TerminalFontFamily, type TerminalThemeId } from "@/stores/terminal-settings";
 import { getGatewayUrl } from "@/lib/gateway";
 import { TERMINAL_THEME_OPTIONS } from "./terminal-themes";
@@ -22,41 +21,6 @@ export function TerminalPreferencesPanel({ sessionName }: TerminalPreferencesPan
   const setLigatures = useTerminalSettings((s) => s.setLigatures);
   const setCursorStyle = useTerminalSettings((s) => s.setCursorStyle);
   const setSmoothScroll = useTerminalSettings((s) => s.setSmoothScroll);
-
-  // react-doctor-disable-next-line react-doctor/no-cascading-set-state, react-doctor/no-effect-event-handler, react-doctor/no-fetch-in-effect -- guarded preferences load: runs only when `sessionName` is set, aborts via AbortSignal.timeout, and is cancellation-guarded by the `cancelled` flag in cleanup. The setters hydrate the terminal-settings store from one server response (not a synchronous render cascade), and the load is render-driven, not a user event. A data-fetching library is unnecessary for this one-shot session read.
-  useEffect(() => {
-    if (!sessionName || typeof fetch !== "function") {
-      return;
-    }
-    let cancelled = false;
-    void fetch(`${getGatewayUrl()}/api/sessions/${encodeURIComponent(sessionName)}/preferences`, {
-      signal: AbortSignal.timeout(10_000),
-    })
-      .then((res) => res.ok ? res.json() : null)
-      .then((data: unknown) => {
-        if (cancelled || !data || typeof data !== "object" || !("preferences" in data)) {
-          return;
-        }
-        const preferences = (data as { preferences: Partial<{
-          themeId: TerminalThemeId;
-          fontFamily: TerminalFontFamily;
-          ligatures: boolean;
-          cursorStyle: TerminalCursorStyle;
-          smoothScroll: boolean;
-        }> }).preferences;
-        if (preferences.themeId) setThemeId(preferences.themeId);
-        if (preferences.fontFamily) setFontFamily(preferences.fontFamily);
-        if (typeof preferences.ligatures === "boolean") setLigatures(preferences.ligatures);
-        if (preferences.cursorStyle) setCursorStyle(preferences.cursorStyle);
-        if (typeof preferences.smoothScroll === "boolean") setSmoothScroll(preferences.smoothScroll);
-      })
-      .catch((err: unknown) => {
-        console.warn("Failed to load terminal preferences:", err instanceof Error ? err.message : err);
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, [sessionName, setCursorStyle, setFontFamily, setLigatures, setSmoothScroll, setThemeId]);
 
   const persist = (patch: Partial<{
     themeId: TerminalThemeId;

--- a/tests/gateway/shell-scrollback-store.test.ts
+++ b/tests/gateway/shell-scrollback-store.test.ts
@@ -1,7 +1,7 @@
-import { mkdtemp, readFile, rm, stat } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { ScrollbackStore } from "../../packages/gateway/src/shell/scrollback-store.js";
 import { ShellReplayBuffer } from "../../packages/gateway/src/shell/replay-buffer.js";
 
@@ -15,6 +15,7 @@ async function tempRoot() {
 
 afterEach(async () => {
   await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+  vi.restoreAllMocks();
 });
 
 describe("scrollback store", () => {
@@ -74,5 +75,47 @@ describe("scrollback store", () => {
     await expect(readFile(store.pathForSession("main"), "utf-8")).rejects.toMatchObject({
       code: "ENOENT",
     });
+  });
+
+  it("skips malformed scrollback records when replaying a session", async () => {
+    const root = await tempRoot();
+    const store = new ScrollbackStore({ homePath: root });
+    const path = store.pathForSession("main");
+    await mkdir(join(root, "system", "scrollback"), { recursive: true });
+    await writeFile(path, [
+      JSON.stringify({ type: "output", seq: 1, data: "one" }),
+      "{\"type\":\"output\",\"seq\":",
+      JSON.stringify({ type: "output", seq: 3, data: "three" }),
+      "",
+    ].join("\n"));
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+
+    await expect(store.readSince("main", 0)).resolves.toEqual([
+      { type: "output", seq: 1, data: "one" },
+      { type: "output", seq: 3, data: "three" },
+    ]);
+    expect(warn).toHaveBeenCalledWith(
+      "[shell] skipped malformed scrollback records:",
+      expect.objectContaining({ session: "main", count: 1 }),
+    );
+  });
+
+  it("uses the newest valid sequence when the scrollback tail is malformed", async () => {
+    const root = await tempRoot();
+    const store = new ScrollbackStore({ homePath: root });
+    const path = store.pathForSession("main");
+    await mkdir(join(root, "system", "scrollback"), { recursive: true });
+    await writeFile(path, [
+      JSON.stringify({ type: "output", seq: 8, data: "ready" }),
+      "{\"type\":\"output\",\"seq\":",
+      "",
+    ].join("\n"));
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+
+    await expect(store.latestSeq("main")).resolves.toBe(8);
+    expect(warn).toHaveBeenCalledWith(
+      "[shell] skipped malformed scrollback records:",
+      expect.objectContaining({ session: "main", count: 1 }),
+    );
   });
 });

--- a/tests/shell/preferences-panel.test.tsx
+++ b/tests/shell/preferences-panel.test.tsx
@@ -2,7 +2,7 @@
 
 import React from "react";
 import { fireEvent, render, screen } from "@testing-library/react";
-import { beforeEach, describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { TerminalPreferencesPanel } from "../../shell/src/components/terminal/preferences-panel.js";
 import { useTerminalSettings } from "../../shell/src/stores/terminal-settings.js";
 
@@ -37,5 +37,27 @@ describe("TerminalPreferencesPanel", () => {
       cursorStyle: "bar",
       smoothScroll: false,
     });
+  });
+
+  it("does not replace the active terminal theme when preferences are opened", async () => {
+    useTerminalSettings.setState({ themeId: "dracula" });
+    vi.stubGlobal("fetch", vi.fn(async () => ({
+      ok: true,
+      json: async () => ({
+        preferences: {
+          themeId: "system",
+          fontFamily: "MesloLGS NF",
+          ligatures: true,
+          cursorStyle: "block",
+          smoothScroll: true,
+        },
+      }),
+    })));
+
+    render(<TerminalPreferencesPanel sessionName="main" />);
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(useTerminalSettings.getState().themeId).toBe("dracula");
   });
 });

--- a/tests/shell/terminal-app-component.test.tsx
+++ b/tests/shell/terminal-app-component.test.tsx
@@ -95,6 +95,19 @@ describe("TerminalApp", () => {
     });
   });
 
+  it("does not render workspace transport ids as managed shell sessions", async () => {
+    render(<TerminalApp initialSessionId="matrix-sess_run_db0dded67faaca6b" />);
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(screen.queryByText("matrix-sess_run_db0dded67faaca6b")).toBeNull();
+    expect(screen.queryByRole("button", { name: /close matrix-sess_run_db0dded67faaca6b/i })).toBeNull();
+  });
+
   it("keeps the mobile terminal chrome clear of cwd badges that overlap zellij tabs", async () => {
     render(<TerminalApp mobile />);
 


### PR DESCRIPTION
## Summary
- Skip malformed terminal scrollback records instead of failing WebSocket replay/attach.
- Keep workspace transport ids out of managed shell-session delete flows.
- Make the active terminal tab/pane visually explicit and stop opening preferences from applying server defaults to the live theme.

## Invariants
- Source of truth: terminal scrollback remains per-session NDJSON under the owner home; malformed records are ignored for replay and valid records remain canonical.
- Lock/transaction scope: scrollback writes continue through the existing per-store write queue; this PR changes read parsing only and performs no network calls inside that path.
- Acceptable orphan states: malformed scrollback lines can remain on disk but no longer block attach/replay; they are counted in logs without exposing terminal content.
- Auth source of truth: unchanged; terminal HTTP/WS auth remains enforced by existing gateway auth middleware and query-token allowlist.
- Deferred scope: this PR does not add a scrollback compaction/quarantine job, does not alter zellij lifecycle semantics, and does not change workspace-session transport APIs.

## Validation
- bun run test tests/gateway/shell-scrollback-store.test.ts tests/shell/preferences-panel.test.tsx tests/shell/terminal-app-component.test.tsx
- bun run typecheck
- bun run check:patterns
- npx react-doctor@latest shell --scope changed --base origin/main --verbose

## Live check
- hamedmp gateway services are active; recent gateway logs showed no new terminal attach failures after the earlier post-upgrade window.
- Current live scrollback files were scanned by parse count only; no malformed files were present, so no live data rewrite was performed.

## Screenshot evidence
- Not captured in-agent: terminal UI requires the live authenticated shell surface. The behavior is covered by focused component tests plus React Doctor changed-file scan.