### PR TITLE
ci(docker): free runner disk before scenario loads

### DIFF
--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -140,6 +140,14 @@ jobs:
       - uses: actions/checkout@v6
         if: needs.changes.outputs.should_run == 'true'
 
+      - name: Free runner disk before Docker load
+        if: needs.changes.outputs.should_run == 'true'
+        run: |
+          df -h
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL || true
+          docker system prune -af || true
+          df -h
+
       - name: Download Docker image artifact
         if: needs.changes.outputs.should_run == 'true'
         uses: actions/download-artifact@v7
@@ -198,6 +206,13 @@ jobs:
           path: /tmp/docker-test-logs/
           retention-days: 7
 
+      - name: Cleanup Docker disk
+        if: always()
+        run: |
+          docker compose -f docker-compose.dev.yml -f docker-compose.ci.yml down -v --remove-orphans || true
+          docker system prune -af --volumes || true
+          df -h
+
   docker-scenarios:
     name: Docker Scenario Tests (${{ matrix.scenario }})
     needs: [changes, docker-build]
@@ -206,6 +221,7 @@ jobs:
     timeout-minutes: 20
     strategy:
       fail-fast: false
+      max-parallel: 2
       matrix:
         # multi-user and resource-limits remain excluded because they need
         # dedicated profile/resource setup outside this parallel smoke matrix.
@@ -218,6 +234,13 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+
+      - name: Free runner disk before Docker load
+        run: |
+          df -h
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL || true
+          docker system prune -af || true
+          df -h
 
       - name: Download Docker image artifact
         uses: actions/download-artifact@v7
@@ -270,3 +293,10 @@ jobs:
           name: docker-test-logs-${{ matrix.scenario }}
           path: /tmp/docker-test-logs/
           retention-days: 7
+
+      - name: Cleanup Docker disk
+        if: always()
+        run: |
+          docker compose -f docker-compose.dev.yml -f docker-compose.ci.yml down -v --remove-orphans || true
+          docker system prune -af --volumes || true
+          df -h


### PR DESCRIPTION
## Summary
- free hosted-runner disk before each Docker image artifact load
- clean Docker containers, images, volumes, and builder cache after each scenario
- cap full non-PR Docker scenario fan-out at two concurrent jobs to reduce runner disk pressure

## Invariants
- Source of truth: unchanged; Docker scenario tests still use the CI-built `matrix-os-dev:ci` image artifact.
- Lock/transaction scope: not applicable; this is CI workflow orchestration only.
- Acceptable orphan states: failed scenario containers and volumes are removed after logs are collected/uploaded; logs remain as GitHub artifacts on failure.
- Auth source of truth: unchanged; no runtime auth or secrets handling changes.
- Deferred scope: this PR does not replace the image artifact fan-out with GHCR pulls; it only makes the current runner path more reliable.

## Validation
- bun run check:patterns
- git diff --check

## Notes
- Ruby, a local YAML parser package, and Prettier are not installed in this checkout, so YAML parsing/format checks were not available locally. GitHub Actions will parse this workflow on PR.