### PR TITLE
fix(shell): shorten customer terminal prompt

### DIFF
--- a/packages/gateway/src/shell/zellij-config.ts
+++ b/packages/gateway/src/shell/zellij-config.ts
@@ -1,0 +1,75 @@
+import { join, resolve } from "node:path";
+
+export type MatrixZellijConfigPaths = {
+  dir: string;
+  file: string;
+  shellFile: string;
+  bashrcFile: string;
+  layoutDir: string;
+  layoutFile: string;
+};
+
+export const MATRIX_ZELLIJ_LAYOUT = `// Matrix OS keeps Zellij chrome compact; the browser shell renders sessions and actions.
+layout {
+  default_tab_template {
+    children
+    pane size=1 borderless=true {
+      plugin location="zellij:compact-bar"
+    }
+  }
+
+  tab name="main" {
+    pane
+  }
+}
+`;
+
+export const MATRIX_TERMINAL_BASHRC = `# Matrix OS generated terminal rcfile.
+if [ -r "$HOME/.bashrc" ]; then
+  . "$HOME/.bashrc"
+fi
+
+if [ -n "\${MATRIX_TERMINAL_PROMPT:-}" ]; then
+  PS1="\${MATRIX_TERMINAL_PROMPT}"
+else
+  PS1="\\u:\\w\\$ "
+fi
+`;
+
+export function matrixZellijConfigPaths(homePath: string): MatrixZellijConfigPaths {
+  const zellijDir = join(resolve(homePath), "system", "zellij");
+  return {
+    dir: zellijDir,
+    file: join(zellijDir, "config.kdl"),
+    shellFile: join(zellijDir, "matrix-terminal-shell"),
+    bashrcFile: join(zellijDir, "bashrc"),
+    layoutDir: join(zellijDir, "layouts"),
+    layoutFile: join(zellijDir, "layouts", "matrix.kdl"),
+  };
+}
+
+export function renderMatrixZellijConfig(configPaths: MatrixZellijConfigPaths): string {
+  return `// Matrix OS generated shell config.
+pane_frames false
+simplified_ui true
+default_layout "matrix"
+default_shell ${JSON.stringify(configPaths.shellFile)}
+theme "default"
+`;
+}
+
+export function matrixTerminalShellScript(bashrcPath: string): string {
+  return `#!/usr/bin/env bash
+set -euo pipefail
+
+export MATRIX_HOME="\${MATRIX_HOME:-\${HOME:-/home/matrix/home}}"
+export HOME="\${HOME:-$MATRIX_HOME}"
+export MATRIX_TERMINAL_PROMPT="\${MATRIX_TERMINAL_PROMPT:-\\\\[\\\\e[1;36m\\\\]\\\\u\\\\[\\\\e[0m\\\\]:\\\\[\\\\e[1;34m\\\\]\\\\w\\\\[\\\\e[0m\\\\]\\\\$ }"
+
+exec bash --noprofile --rcfile ${shellSingleQuote(bashrcPath)} -i
+`;
+}
+
+function shellSingleQuote(value: string): string {
+  return `'${value.replace(/'/g, `'\\''`)}'`;
+}

--- a/packages/gateway/src/shell/zellij.ts
+++ b/packages/gateway/src/shell/zellij.ts
@@ -2,7 +2,7 @@ import {
   execFile as nodeExecFile,
 } from "node:child_process";
 import { randomUUID } from "node:crypto";
-import { mkdtemp, rename, rm, writeFile } from "node:fs/promises";
+import { chmod, mkdtemp, rename, rm, writeFile } from "node:fs/promises";
 import { createRequire } from "node:module";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
@@ -110,12 +110,6 @@ const ZELLIJ_CONTEXT_ENV_KEYS = new Set([
 const DEFAULT_STARTUP_DELAY_MS = 500;
 const DEFAULT_RETAINED_PTY_TTL_MS = 4 * 60 * 60 * 1000;
 const DEFAULT_MAX_RETAINED_PTYS = 128;
-const MATRIX_ZELLIJ_CONFIG = `// Matrix OS generated shell config.
-pane_frames false
-simplified_ui true
-default_layout "matrix"
-theme "default"
-`;
 const MATRIX_ZELLIJ_LAYOUT = `// Matrix OS keeps Zellij chrome compact; the browser shell renders sessions and actions.
 layout {
   default_tab_template {
@@ -141,9 +135,47 @@ type RetainedCreatePty = {
 type ZellijConfigPaths = {
   dir: string;
   file: string;
+  shellFile: string;
+  bashrcFile: string;
   layoutDir: string;
   layoutFile: string;
 };
+
+function matrixZellijConfig(configPaths: ZellijConfigPaths | null): string {
+  const defaultShell = configPaths
+    ? `default_shell ${kdlString(configPaths.shellFile)}\n`
+    : "";
+  return `// Matrix OS generated shell config.
+pane_frames false
+simplified_ui true
+default_layout "matrix"
+${defaultShell}theme "default"
+`;
+}
+
+function matrixTerminalShellScript(bashrcPath: string): string {
+  return `#!/usr/bin/env bash
+set -euo pipefail
+
+export MATRIX_HOME="\${MATRIX_HOME:-\${HOME:-/home/matrix/home}}"
+export HOME="\${HOME:-$MATRIX_HOME}"
+export MATRIX_TERMINAL_PROMPT="\${MATRIX_TERMINAL_PROMPT:-\\\\[\\\\e[1;36m\\\\]\\\\u\\\\[\\\\e[0m\\\\]:\\\\[\\\\e[1;34m\\\\]\\\\w\\\\[\\\\e[0m\\\\]\\\\$ }"
+
+exec /bin/bash --noprofile --rcfile "${bashrcPath}" -i
+`;
+}
+
+const MATRIX_TERMINAL_BASHRC = `# Matrix OS generated terminal rcfile.
+if [ -r "$HOME/.bashrc" ]; then
+  . "$HOME/.bashrc"
+fi
+
+if [ -n "\${MATRIX_TERMINAL_PROMPT:-}" ]; then
+  PS1="\${MATRIX_TERMINAL_PROMPT}"
+else
+  PS1="\\u:\\w\\$ "
+fi
+`;
 
 function attachEnv(
   source: NodeJS.ProcessEnv = process.env,
@@ -274,6 +306,8 @@ export function createZellijAdapter(deps: ZellijAdapterDeps = {}): ZellijAdapter
     ? {
         dir: join(resolve(deps.homePath), "system", "zellij"),
         file: join(resolve(deps.homePath), "system", "zellij", "config.kdl"),
+        shellFile: join(resolve(deps.homePath), "system", "zellij", "matrix-terminal-shell"),
+        bashrcFile: join(resolve(deps.homePath), "system", "zellij", "bashrc"),
         layoutDir: join(resolve(deps.homePath), "system", "zellij", "layouts"),
         layoutFile: join(resolve(deps.homePath), "system", "zellij", "layouts", "matrix.kdl"),
       }
@@ -288,7 +322,10 @@ export function createZellijAdapter(deps: ZellijAdapterDeps = {}): ZellijAdapter
       ensureConfigPromise = (async () => {
         const { mkdir } = await import("node:fs/promises");
         await mkdir(zellijConfigPaths.layoutDir, { recursive: true });
-        await atomicWriteText(zellijConfigPaths.file, MATRIX_ZELLIJ_CONFIG);
+        await atomicWriteText(zellijConfigPaths.shellFile, matrixTerminalShellScript(zellijConfigPaths.bashrcFile));
+        await chmod(zellijConfigPaths.shellFile, 0o700);
+        await atomicWriteText(zellijConfigPaths.bashrcFile, MATRIX_TERMINAL_BASHRC);
+        await atomicWriteText(zellijConfigPaths.file, matrixZellijConfig(zellijConfigPaths));
         await atomicWriteText(zellijConfigPaths.layoutFile, MATRIX_ZELLIJ_LAYOUT);
       })().catch((err: unknown) => {
         ensureConfigPromise = null;

--- a/packages/gateway/src/shell/zellij.ts
+++ b/packages/gateway/src/shell/zellij.ts
@@ -7,6 +7,14 @@ import { createRequire } from "node:module";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { shellError, type ShellSafeError } from "./errors.js";
+import {
+  MATRIX_TERMINAL_BASHRC,
+  MATRIX_ZELLIJ_LAYOUT,
+  matrixTerminalShellScript,
+  matrixZellijConfigPaths,
+  renderMatrixZellijConfig,
+  type MatrixZellijConfigPaths,
+} from "./zellij-config.js";
 
 type ExecFile = typeof nodeExecFile;
 type Disposable = { dispose(): void };
@@ -110,21 +118,6 @@ const ZELLIJ_CONTEXT_ENV_KEYS = new Set([
 const DEFAULT_STARTUP_DELAY_MS = 500;
 const DEFAULT_RETAINED_PTY_TTL_MS = 4 * 60 * 60 * 1000;
 const DEFAULT_MAX_RETAINED_PTYS = 128;
-const MATRIX_ZELLIJ_LAYOUT = `// Matrix OS keeps Zellij chrome compact; the browser shell renders sessions and actions.
-layout {
-  default_tab_template {
-    children
-    pane size=1 borderless=true {
-      plugin location="zellij:compact-bar"
-    }
-  }
-
-  tab name="main" {
-    pane
-  }
-}
-`;
-
 type RetainedCreatePty = {
   process: ShellAttachProcess;
   startedAtMs: number;
@@ -132,54 +125,9 @@ type RetainedCreatePty = {
   tempLayoutDir?: string;
 };
 
-type ZellijConfigPaths = {
-  dir: string;
-  file: string;
-  shellFile: string;
-  bashrcFile: string;
-  layoutDir: string;
-  layoutFile: string;
-};
-
-function matrixZellijConfig(configPaths: ZellijConfigPaths | null): string {
-  const defaultShell = configPaths
-    ? `default_shell ${kdlString(configPaths.shellFile)}\n`
-    : "";
-  return `// Matrix OS generated shell config.
-pane_frames false
-simplified_ui true
-default_layout "matrix"
-${defaultShell}theme "default"
-`;
-}
-
-function matrixTerminalShellScript(bashrcPath: string): string {
-  return `#!/usr/bin/env bash
-set -euo pipefail
-
-export MATRIX_HOME="\${MATRIX_HOME:-\${HOME:-/home/matrix/home}}"
-export HOME="\${HOME:-$MATRIX_HOME}"
-export MATRIX_TERMINAL_PROMPT="\${MATRIX_TERMINAL_PROMPT:-\\\\[\\\\e[1;36m\\\\]\\\\u\\\\[\\\\e[0m\\\\]:\\\\[\\\\e[1;34m\\\\]\\\\w\\\\[\\\\e[0m\\\\]\\\\$ }"
-
-exec /bin/bash --noprofile --rcfile "${bashrcPath}" -i
-`;
-}
-
-const MATRIX_TERMINAL_BASHRC = `# Matrix OS generated terminal rcfile.
-if [ -r "$HOME/.bashrc" ]; then
-  . "$HOME/.bashrc"
-fi
-
-if [ -n "\${MATRIX_TERMINAL_PROMPT:-}" ]; then
-  PS1="\${MATRIX_TERMINAL_PROMPT}"
-else
-  PS1="\\u:\\w\\$ "
-fi
-`;
-
 function attachEnv(
   source: NodeJS.ProcessEnv = process.env,
-  configPaths: ZellijConfigPaths | null = null,
+  configPaths: MatrixZellijConfigPaths | null = null,
 ): Record<string, string> {
   const env: Record<string, string> = {};
   for (const [key, value] of Object.entries(source)) {
@@ -302,16 +250,7 @@ export function createZellijAdapter(deps: ZellijAdapterDeps = {}): ZellijAdapter
   const cwd = deps.cwd ?? process.cwd();
   const spawnPty = deps.spawnPty ?? defaultPtySpawn();
   const retainedCreatePtys = new Map<string, RetainedCreatePty>();
-  const zellijConfigPaths = deps.homePath
-    ? {
-        dir: join(resolve(deps.homePath), "system", "zellij"),
-        file: join(resolve(deps.homePath), "system", "zellij", "config.kdl"),
-        shellFile: join(resolve(deps.homePath), "system", "zellij", "matrix-terminal-shell"),
-        bashrcFile: join(resolve(deps.homePath), "system", "zellij", "bashrc"),
-        layoutDir: join(resolve(deps.homePath), "system", "zellij", "layouts"),
-        layoutFile: join(resolve(deps.homePath), "system", "zellij", "layouts", "matrix.kdl"),
-      }
-    : null;
+  const zellijConfigPaths = deps.homePath ? matrixZellijConfigPaths(deps.homePath) : null;
   let ensureConfigPromise: Promise<void> | null = null;
 
   async function ensureMatrixZellijConfig(): Promise<void> {
@@ -325,7 +264,7 @@ export function createZellijAdapter(deps: ZellijAdapterDeps = {}): ZellijAdapter
         await atomicWriteText(zellijConfigPaths.shellFile, matrixTerminalShellScript(zellijConfigPaths.bashrcFile));
         await chmod(zellijConfigPaths.shellFile, 0o700);
         await atomicWriteText(zellijConfigPaths.bashrcFile, MATRIX_TERMINAL_BASHRC);
-        await atomicWriteText(zellijConfigPaths.file, matrixZellijConfig(zellijConfigPaths));
+        await atomicWriteText(zellijConfigPaths.file, renderMatrixZellijConfig(zellijConfigPaths));
         await atomicWriteText(zellijConfigPaths.layoutFile, MATRIX_ZELLIJ_LAYOUT);
       })().catch((err: unknown) => {
         ensureConfigPromise = null;

--- a/packages/gateway/src/zellij-runtime.ts
+++ b/packages/gateway/src/zellij-runtime.ts
@@ -1,11 +1,18 @@
 import { execFile } from "node:child_process";
 import { randomUUID } from "node:crypto";
-import { mkdir } from "node:fs/promises";
+import { chmod, mkdir } from "node:fs/promises";
 import { join, resolve } from "node:path";
 import { promisify } from "node:util";
 import { z } from "zod/v4";
 import type { AgentLaunchSpec } from "./agent-launcher.js";
 import { DANGEROUS_CONTROL_CHARS_GLOBAL } from "./prompt-validation.js";
+import {
+  MATRIX_TERMINAL_BASHRC,
+  MATRIX_ZELLIJ_LAYOUT,
+  matrixTerminalShellScript,
+  matrixZellijConfigPaths,
+  renderMatrixZellijConfig,
+} from "./shell/zellij-config.js";
 
 type CommandRunner = (
   command: string,
@@ -51,26 +58,6 @@ const ZELLIJ_TIMEOUT_MS = 10_000;
 const ZELLIJ_STARTUP_DELAY_MS = 500;
 const MAX_RETAINED_ZELLIJ_PTYS = 128;
 const RETAINED_PTY_TTL_MS = 4 * 60 * 60 * 1000;
-const MATRIX_ZELLIJ_CONFIG = `// Matrix OS generated workspace config.
-pane_frames false
-simplified_ui true
-default_layout "matrix"
-theme "default"
-`;
-const MATRIX_ZELLIJ_LAYOUT = `// Matrix OS keeps Zellij chrome compact; Matrix shell renders sessions and actions.
-layout {
-  default_tab_template {
-    children
-    pane size=1 borderless=true {
-      plugin location="zellij:compact-bar"
-    }
-  }
-
-  tab name="main" {
-    pane
-  }
-}
-`;
 const SAFE_PROCESS_ENV_KEYS = new Set([
   "COLORTERM",
   "DISPLAY",
@@ -201,10 +188,11 @@ export function createZellijRuntime(options: {
   const startupDelayMs = options.startupDelayMs ?? ZELLIJ_STARTUP_DELAY_MS;
   const retainedPtyTtlMs = options.retainedPtyTtlMs ?? RETAINED_PTY_TTL_MS;
   const nowMs = options.nowMs ?? Date.now;
-  const layoutDir = join(homePath, "system", "zellij", "layouts");
-  const configDir = join(homePath, "system", "zellij");
-  const configPath = join(configDir, "config.kdl");
-  const defaultLayoutPath = join(layoutDir, "matrix.kdl");
+  const zellijConfigPaths = matrixZellijConfigPaths(homePath);
+  const layoutDir = zellijConfigPaths.layoutDir;
+  const configDir = zellijConfigPaths.dir;
+  const configPath = zellijConfigPaths.file;
+  const defaultLayoutPath = zellijConfigPaths.layoutFile;
   const retainedPtys = new Map<string, RetainedPty>();
   let ensureConfigPromise: Promise<void> | null = null;
 
@@ -212,7 +200,10 @@ export function createZellijRuntime(options: {
     if (!ensureConfigPromise) {
       ensureConfigPromise = (async () => {
         await mkdir(layoutDir, { recursive: true });
-        await atomicWriteText(configPath, MATRIX_ZELLIJ_CONFIG);
+        await atomicWriteText(zellijConfigPaths.shellFile, matrixTerminalShellScript(zellijConfigPaths.bashrcFile));
+        await chmod(zellijConfigPaths.shellFile, 0o700);
+        await atomicWriteText(zellijConfigPaths.bashrcFile, MATRIX_TERMINAL_BASHRC);
+        await atomicWriteText(configPath, renderMatrixZellijConfig(zellijConfigPaths));
         await atomicWriteText(defaultLayoutPath, MATRIX_ZELLIJ_LAYOUT);
       })().catch((err: unknown) => {
         ensureConfigPromise = null;

--- a/tests/gateway/shell-zellij.test.ts
+++ b/tests/gateway/shell-zellij.test.ts
@@ -9,6 +9,7 @@ import {
   createZellijAdapter,
   sanitizeZellijError,
 } from "../../packages/gateway/src/shell/zellij.js";
+import { matrixTerminalShellScript } from "../../packages/gateway/src/shell/zellij-config.js";
 
 function childProcess() {
   return Object.assign(new EventEmitter(), {
@@ -309,7 +310,8 @@ describe("zellij adapter", () => {
       expect(config).toContain("simplified_ui true");
       expect(config).toContain('default_layout "matrix"');
       expect(config).toContain(`default_shell ${JSON.stringify(shellPath)}`);
-      expect(shell).toContain(`--rcfile "${bashrcPath}" -i`);
+      expect(shell).toContain(`exec bash --noprofile --rcfile '${bashrcPath}' -i`);
+      expect(shell).not.toContain("/bin/bash");
       expect(shellMode & 0o700).toBe(0o700);
       expect(bashrc).toContain('PS1="${MATRIX_TERMINAL_PROMPT}"');
       expect(bashrc).toContain("\\u:\\w\\$ ");
@@ -509,5 +511,13 @@ describe("zellij adapter", () => {
     expect(sanitizeZellijError("bad /home/alice/projects/app and /tmp/file")).toBe(
       "bad [path] and [path]",
     );
+  });
+
+  it("shell-quotes generated bash rcfile paths", () => {
+    const path = `/tmp/matrix "owner"/it'works/bashrc`;
+    const script = matrixTerminalShellScript(path);
+
+    expect(script).toContain(`exec bash --noprofile --rcfile '/tmp/matrix "owner"/it'\\''works/bashrc' -i`);
+    expect(script).not.toContain("/bin/bash");
   });
 });

--- a/tests/gateway/shell-zellij.test.ts
+++ b/tests/gateway/shell-zellij.test.ts
@@ -1,6 +1,6 @@
 import { EventEmitter } from "node:events";
 import { existsSync, readFileSync } from "node:fs";
-import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { mkdtemp, readFile, rm, stat } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it, vi } from "vitest";
@@ -297,12 +297,22 @@ describe("zellij adapter", () => {
       const configDir = join(homePath, "system", "zellij");
       const configPath = join(configDir, "config.kdl");
       const layoutPath = join(configDir, "layouts", "matrix.kdl");
+      const shellPath = join(configDir, "matrix-terminal-shell");
+      const bashrcPath = join(configDir, "bashrc");
       const config = await readFile(configPath, "utf8");
       const layout = await readFile(layoutPath, "utf8");
+      const shell = await readFile(shellPath, "utf8");
+      const bashrc = await readFile(bashrcPath, "utf8");
+      const shellMode = (await stat(shellPath)).mode;
 
       expect(config).toContain("pane_frames false");
       expect(config).toContain("simplified_ui true");
       expect(config).toContain('default_layout "matrix"');
+      expect(config).toContain(`default_shell ${JSON.stringify(shellPath)}`);
+      expect(shell).toContain(`--rcfile "${bashrcPath}" -i`);
+      expect(shellMode & 0o700).toBe(0o700);
+      expect(bashrc).toContain('PS1="${MATRIX_TERMINAL_PROMPT}"');
+      expect(bashrc).toContain("\\u:\\w\\$ ");
       expect(layout).toContain('plugin location="zellij:compact-bar"');
       expect(layout).not.toContain("tab-bar");
       expect(layout).not.toContain("status-bar");

--- a/tests/gateway/zellij-runtime.test.ts
+++ b/tests/gateway/zellij-runtime.test.ts
@@ -101,13 +101,20 @@ describe("zellij-runtime", () => {
 
     const configDir = join(homePath, "system", "zellij");
     const configPath = join(configDir, "config.kdl");
+    const shellPath = join(configDir, "matrix-terminal-shell");
+    const bashrcPath = join(configDir, "bashrc");
     const config = await readFile(configPath, "utf-8");
+    const shell = await readFile(shellPath, "utf-8");
+    const bashrc = await readFile(bashrcPath, "utf-8");
     const defaultLayout = await readFile(join(configDir, "layouts", "matrix.kdl"), "utf-8");
     const sessionLayout = await readFile(started.layoutPath, "utf-8");
 
     expect(config).toContain("pane_frames false");
     expect(config).toContain("simplified_ui true");
     expect(config).toContain('default_layout "matrix"');
+    expect(config).toContain(`default_shell ${JSON.stringify(shellPath)}`);
+    expect(shell).toContain(`exec bash --noprofile --rcfile '${bashrcPath}' -i`);
+    expect(bashrc).toContain('PS1="${MATRIX_TERMINAL_PROMPT}"');
     expect(defaultLayout).toContain('plugin location="zellij:compact-bar"');
     expect(sessionLayout).toContain('plugin location="zellij:compact-bar"');
     expect(spawnPty).toHaveBeenCalledWith(


### PR DESCRIPTION
## Summary
- generate a Matrix-owned Zellij shell wrapper and rcfile under `~/system/zellij`
- set Zellij `default_shell` to the wrapper so new terminal panes show a compact `username:cwd$` prompt instead of `user@machine-id`
- keep the existing user `.bashrc` sourced before applying the Matrix prompt

## Validation
- `pnpm exec vitest run tests/gateway/shell-zellij.test.ts`
- `pnpm exec tsc --noEmit -p packages/gateway/tsconfig.json`
- `bun run check:patterns` (0 violations; existing repository warnings only)

## Invariants
- Source of truth: the generated Zellij config under the owner's `MATRIX_HOME/system/zellij` remains the canonical shell-session startup config. User dotfiles are sourced but not overwritten.
- Lock/transaction scope: no database writes or cross-process critical sections are introduced; config files are written via existing atomic file writes before session startup.
- Acceptable orphan states: if wrapper or rcfile generation fails, terminal session creation fails through the existing safe Zellij error path rather than falling back to the long host prompt silently.
- Auth source of truth: unchanged; terminal session auth and WebSocket access still use the existing gateway auth/session registry path.
- Deferred scope: this does not repair per-user GitHub credentials or publish a host bundle; it only changes terminal startup behavior for future deployed bundles.