### PR TITLE
fix(shell): keep billing setup out of onboarding loop

### DIFF
--- a/shell/src/components/BillingGate.tsx
+++ b/shell/src/components/BillingGate.tsx
@@ -3,7 +3,7 @@
 import { Suspense, useEffect, useRef, useState, type ReactNode } from "react";
 import { useAuth } from "@clerk/nextjs";
 import { useRouter, useSearchParams } from "next/navigation";
-import { AlertCircleIcon, Loader2Icon, LogInIcon } from "lucide-react";
+import { AlertCircleIcon, CircleDollarSignIcon, Loader2Icon, LogInIcon } from "lucide-react";
 import {
   getMatrixBillingSuccessRedirectUrl,
 } from "@/lib/billing";
@@ -205,10 +205,21 @@ function SubscriptionConfirmationPending({
 
 function BillingStatusLoading() {
   return (
-    <main data-matrix-billing-gate="true" className="flex min-h-screen items-center justify-center bg-page-bg text-forest/70">
-      <output className="flex items-center gap-2 text-sm">
-        <Loader2Icon className="size-4 animate-spin text-ember" aria-hidden="true" />
-        Loading billing status
+    <main data-matrix-billing-gate="true" className="flex min-h-screen items-center justify-center bg-page-bg px-6 py-10 text-forest/70">
+      <output
+        className="flex w-full max-w-md flex-col items-center gap-4 rounded-lg border border-forest/15 bg-white/85 p-6 text-center shadow-[0_24px_80px_rgba(50,53,46,0.16)]"
+        aria-live="polite"
+      >
+        <span className="flex size-12 items-center justify-center rounded-md border border-forest/15 bg-cream/60">
+          <CircleDollarSignIcon className="size-5 text-ember" aria-hidden="true" />
+        </span>
+        <span className="flex items-center gap-2 text-sm font-medium text-forest">
+          <Loader2Icon className="size-4 animate-spin text-ember" aria-hidden="true" />
+          Loading billing status
+        </span>
+        <span className="max-w-xs text-sm leading-6 text-forest/70">
+          Matrix is checking your subscription before opening billing setup.
+        </span>
       </output>
     </main>
   );

--- a/shell/src/components/BootSequence.tsx
+++ b/shell/src/components/BootSequence.tsx
@@ -2,7 +2,14 @@
 
 import { useEffect, useRef, useState, type ReactNode } from "react";
 import { useAuth, RedirectToSignIn } from "@clerk/nextjs";
-import { AlertCircleIcon, Loader2Icon, RefreshCwIcon } from "lucide-react";
+import {
+  AlertCircleIcon,
+  CheckCircle2Icon,
+  CircleDollarSignIcon,
+  Loader2Icon,
+  RefreshCwIcon,
+  ServerIcon,
+} from "lucide-react";
 import { useJourney, type JourneyState } from "@/hooks/useJourney";
 
 // Phases where the shell (Desktop) takes over — first-run UI is owned by Desktop,
@@ -16,6 +23,28 @@ const STAGE_LABEL: Record<string, string> = {
   finalizing: "Finishing setup",
 };
 
+type BootStep = "account" | "billing" | "computer";
+
+const STEP_ORDER: BootStep[] = ["account", "billing", "computer"];
+const STEP_LABEL: Record<BootStep, string> = {
+  account: "Account",
+  billing: "Billing",
+  computer: "Computer",
+};
+const STEP_ICON: Record<BootStep, typeof CheckCircle2Icon> = {
+  account: CheckCircle2Icon,
+  billing: CircleDollarSignIcon,
+  computer: ServerIcon,
+};
+
+function getStepState(step: BootStep, activeStep: BootStep): "done" | "active" | "pending" {
+  const stepIndex = STEP_ORDER.indexOf(step);
+  const activeIndex = STEP_ORDER.indexOf(activeStep);
+  if (stepIndex < activeIndex) return "done";
+  if (stepIndex === activeIndex) return "active";
+  return "pending";
+}
+
 async function authHeaders(getToken: () => Promise<string | null>): Promise<HeadersInit> {
   const token = await getToken();
   return {
@@ -25,13 +54,51 @@ async function authHeaders(getToken: () => Promise<string | null>): Promise<Head
   };
 }
 
-function BootShell({ children }: { children: ReactNode }) {
+function BootShell({
+  children,
+  activeStep = "account",
+}: {
+  children: ReactNode;
+  activeStep?: BootStep;
+}) {
   return (
     <main
       data-matrix-boot-sequence="true"
-      className="flex min-h-screen flex-col items-center justify-center gap-4 bg-page-bg px-6 text-center text-forest/80"
+      className="flex min-h-screen flex-col items-center justify-center bg-page-bg px-6 py-10 text-center text-forest/80"
     >
-      {children}
+      <section
+        className="flex w-full max-w-lg flex-col items-center gap-6 rounded-lg border border-forest/15 bg-white/85 p-6 shadow-[0_24px_80px_rgba(50,53,46,0.16)]"
+        aria-live="polite"
+      >
+        <div className="flex size-12 items-center justify-center rounded-md border border-forest/15 bg-cream/60">
+          <ServerIcon className="size-5 text-ember" aria-hidden="true" />
+        </div>
+        <div className="flex w-full flex-wrap items-center justify-center gap-2 text-xs font-medium text-forest/70">
+          {STEP_ORDER.map((step, index) => {
+            const state = getStepState(step, activeStep);
+            const Icon = STEP_ICON[step];
+            return (
+              <div key={step} className="flex min-w-0 items-center gap-2">
+                {index > 0 ? <span className="hidden h-px w-5 bg-forest/15 sm:inline-block" aria-hidden="true" /> : null}
+                <span
+                  className={[
+                    "inline-flex items-center gap-1.5 rounded-full border px-2.5 py-1",
+                    state === "active"
+                      ? "border-ember/35 bg-ember/10 text-deep"
+                      : state === "done"
+                        ? "border-forest/15 bg-cream/60 text-forest"
+                        : "border-forest/10 bg-white text-forest/50",
+                  ].join(" ")}
+                >
+                  <Icon className="size-3.5 shrink-0" aria-hidden="true" />
+                  <span>{STEP_LABEL[step]}</span>
+                </span>
+              </div>
+            );
+          })}
+        </div>
+        <div className="flex flex-col items-center gap-4">{children}</div>
+      </section>
     </main>
   );
 }
@@ -123,9 +190,10 @@ function BootSequenceInner({ children }: { children: ReactNode }) {
 
   if (!isLoaded) {
     return (
-      <BootShell>
+      <BootShell activeStep="account">
         <Spinner />
-        <p className="text-sm">Loading your Matrix computer…</p>
+        <h1 className="text-lg font-medium text-forest">Checking your session</h1>
+        <p className="max-w-sm text-sm">Matrix is loading your account before opening billing or your computer.</p>
       </BootShell>
     );
   }
@@ -138,9 +206,10 @@ function BootSequenceInner({ children }: { children: ReactNode }) {
 
   if (status === "loading") {
     return (
-      <BootShell>
+      <BootShell activeStep="account">
         <Spinner />
-        <p className="text-sm">Loading your Matrix computer…</p>
+        <h1 className="text-lg font-medium text-forest">Checking setup status</h1>
+        <p className="max-w-sm text-sm">Matrix is checking account, billing, and computer readiness.</p>
       </BootShell>
     );
   }
@@ -153,7 +222,7 @@ function BootSequenceInner({ children }: { children: ReactNode }) {
 
   if (status === "unreachable") {
     return (
-      <BootShell>
+      <BootShell activeStep="account">
         <AlertCircleIcon className="size-6 text-ember" aria-hidden="true" />
         <p className="text-sm">We can’t reach Matrix right now.</p>
         <button type="button" onClick={refreshJourney} className="inline-flex items-center gap-2 rounded-md border border-forest/20 px-3 py-1.5 text-sm hover:bg-forest/5">
@@ -172,7 +241,7 @@ function BootSequenceInner({ children }: { children: ReactNode }) {
   switch (state.phase) {
     case "plan_required":
       return (
-        <BootShell>
+        <BootShell activeStep="billing">
           <h1 className="text-lg font-medium text-forest">Choose your plan</h1>
           <p className="max-w-sm text-sm">{state.detail}</p>
           {state.nextAction.url ? (
@@ -184,7 +253,7 @@ function BootSequenceInner({ children }: { children: ReactNode }) {
       );
     case "payment_settling":
       return (
-        <BootShell>
+        <BootShell activeStep="billing">
           {state.settling?.delayed ? (
             <AlertCircleIcon className="size-6 text-ember" aria-hidden="true" />
           ) : (
@@ -201,7 +270,7 @@ function BootSequenceInner({ children }: { children: ReactNode }) {
       );
     case "provisioning":
       return (
-        <BootShell>
+        <BootShell activeStep="computer">
           <Spinner />
           <h1 className="text-lg font-medium text-forest">Building your Matrix computer</h1>
           <p className="max-w-sm text-sm">
@@ -211,7 +280,7 @@ function BootSequenceInner({ children }: { children: ReactNode }) {
       );
     case "provisioning_failed":
       return (
-        <BootShell>
+        <BootShell activeStep="computer">
           <AlertCircleIcon className="size-6 text-ember" aria-hidden="true" />
           <h1 className="text-lg font-medium text-forest">Setup needs attention</h1>
           <p className="max-w-sm text-sm">{state.detail}</p>
@@ -226,7 +295,7 @@ function BootSequenceInner({ children }: { children: ReactNode }) {
       );
     case "account_required":
       return (
-        <BootShell>
+        <BootShell activeStep="account">
           <AlertCircleIcon className="size-6 text-ember" aria-hidden="true" />
           <h1 className="text-lg font-medium text-forest">Finishing account setup</h1>
           <p className="max-w-sm text-sm">{state.detail || "We are finishing your Matrix account setup."}</p>
@@ -241,9 +310,9 @@ function BootSequenceInner({ children }: { children: ReactNode }) {
     default:
       // Unknown phase: do NOT fall through to the shell. Show a safe wait state.
       return (
-        <BootShell>
+        <BootShell activeStep="account">
           <Spinner />
-          <p className="text-sm">Loading your Matrix computer…</p>
+          <p className="text-sm">Checking setup status…</p>
         </BootShell>
       );
   }

--- a/shell/src/components/OnboardingGate.tsx
+++ b/shell/src/components/OnboardingGate.tsx
@@ -26,8 +26,12 @@ function OnboardingGateInner({
 }) {
   const searchParams = useSearchParams();
   const isDeviceFlow = searchParams.get("device_return") !== null;
+  const isBillingEntrypoint =
+    searchParams.has("billing") ||
+    searchParams.has("plans") ||
+    searchParams.has("checkout");
 
-  if (isDeviceFlow) {
+  if (isDeviceFlow || isBillingEntrypoint) {
     return <BillingGate platformSessionActive={platformSessionActive}>{children}</BillingGate>;
   }
   return (

--- a/tests/shell/onboarding-gate.test.tsx
+++ b/tests/shell/onboarding-gate.test.tsx
@@ -1,0 +1,100 @@
+// @vitest-environment jsdom
+
+import React from "react";
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const billingGateRender = vi.hoisted(() => vi.fn());
+const bootSequenceRender = vi.hoisted(() => vi.fn());
+
+vi.mock("next/navigation", () => ({
+  useSearchParams: () => new URLSearchParams(window.location.search),
+}));
+
+vi.mock("@/components/BillingGate", () => ({
+  BillingGate: ({
+    children,
+    platformSessionActive,
+  }: {
+    children: React.ReactNode;
+    platformSessionActive?: boolean;
+  }) => {
+    billingGateRender(platformSessionActive);
+    return <div data-testid="billing-gate">{children}</div>;
+  },
+}));
+
+vi.mock("@/components/BootSequence", () => ({
+  BootSequence: ({
+    children,
+    platformSessionActive,
+    e2eBypass,
+  }: {
+    children: React.ReactNode;
+    platformSessionActive?: boolean;
+    e2eBypass?: boolean;
+  }) => {
+    bootSequenceRender({ platformSessionActive, e2eBypass });
+    return <div data-testid="boot-sequence">{children}</div>;
+  },
+}));
+
+import { OnboardingGate } from "../../shell/src/components/OnboardingGate";
+
+describe("OnboardingGate", () => {
+  beforeEach(() => {
+    billingGateRender.mockClear();
+    bootSequenceRender.mockClear();
+    window.history.replaceState({}, "", "/");
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("uses the journey boot sequence for normal shell entry", async () => {
+    render(
+      <OnboardingGate>
+        <div>Matrix workspace</div>
+      </OnboardingGate>,
+    );
+
+    expect(await screen.findByTestId("boot-sequence")).toBeTruthy();
+    expect(screen.queryByTestId("billing-gate")).toBeNull();
+    expect(bootSequenceRender).toHaveBeenCalledWith({
+      platformSessionActive: false,
+      e2eBypass: false,
+    });
+  });
+
+  it.each(["/?billing=setup", "/?plans=1", "/?checkout=success", "/?checkout=success&billing=success"])(
+    "keeps explicit billing entrypoint %s on BillingGate",
+    async (path) => {
+      window.history.replaceState({}, "", path);
+
+      render(
+        <OnboardingGate>
+          <div>Matrix workspace</div>
+        </OnboardingGate>,
+      );
+
+      expect(await screen.findByTestId("billing-gate")).toBeTruthy();
+      expect(screen.queryByTestId("boot-sequence")).toBeNull();
+      expect(billingGateRender).toHaveBeenCalledWith(false);
+    },
+  );
+
+  it("keeps device approval billing on BillingGate", async () => {
+    window.history.replaceState({}, "", "/?device_return=%2Fauth%2Fdevice%3Fuser_code%3DBCDF-GHJK");
+
+    render(
+      <OnboardingGate platformSessionActive>
+        <div>Matrix workspace</div>
+      </OnboardingGate>,
+    );
+
+    expect(await screen.findByTestId("billing-gate")).toBeTruthy();
+    expect(screen.queryByTestId("boot-sequence")).toBeNull();
+    expect(billingGateRender).toHaveBeenCalledWith(true);
+  });
+});


### PR DESCRIPTION
## Summary
- route explicit billing entrypoints (`?billing=setup`, `?plans=1`, and checkout returns) through the existing BillingGate instead of the new journey BootSequence
- add a regression test for the setup/plans loop routing
- polish boot and billing loading states with explicit Account/Billing/Computer progress feedback

## Evidence
- Live Cloud Run logs showed repeated `/?billing=setup` -> `/api/journey` -> `/?plans=1` during the incident around 2026-06-16 16:07-16:08 UTC. `?plans=1` hops were ~5s each, while `/api/journey` was ~20-115ms.
- Production Cloud Run is currently `matrix-platform-00123-vaf`, image `matrix-platform:1083e4134f42`, with 100% traffic.

## Validation
- `bun run test tests/shell/onboarding-gate.test.tsx tests/shell/boot-sequence.test.tsx tests/shell/billing-gate.test.tsx`
- `bun run typecheck`
- `bun run check:patterns` (warnings only; no violations)
- `npx react-doctor@latest shell --scope changed --base origin/main` (no changed-scope issues)

## Screenshot Evidence
Not captured from a live browser in this run: the changed billing/setup surface is Clerk-session gated, and a clean local browser visit would show auth redirect states unless we use a signed test Clerk session. The changed UI states are covered by component tests.

## Invariants
- Source of truth: platform journey/billing APIs remain the source of truth; the shell only chooses the renderer for explicit billing URLs.
- Lock/transaction scope: no database writes or transactions changed.
- Acceptable orphan states: existing payment-settling and provisioning states are unchanged; explicit billing URLs now stay on BillingGate instead of being orphaned into plan-selection routing.
- Auth source of truth: Clerk/platform session behavior is unchanged; `platformSessionActive` is still passed through both gates.
- Deferred scope: no Stripe, provisioning, or backend journey derivation changes in this PR.
