### PR TITLE
chore(preview): track cloudflared preview ingress

### DIFF
--- a/distro/cloudflared.yml
+++ b/distro/cloudflared.yml
@@ -27,4 +27,8 @@ ingress:
     service: http://matrixos-staging-4:3000
   - hostname: api-staging-4.matrix-os.com
     service: http://matrixos-staging-4:4000
+  # Browser-reachable preview platform (Cloud Run; spec 093, PR #532).
+  # Routes to the matrix-platform-preview run.app origin.
+  - hostname: preview.matrix-os.com
+    service: https://matrix-platform-preview-jqxkjdhtkq-ey.a.run.app
   - service: http_status:404


### PR DESCRIPTION
## Summary
- add the live preview.matrix-os.com Cloudflare Tunnel route to the checked-in cloudflared config
- set the Cloud Run run.app host as the origin service and Host header so Cloud Run routes the request to the preview service
- keep the route near the other staging/preview ingress entries

## Invariants
- Source of truth: this file documents the Cloudflare Tunnel ingress routing for Matrix OS preview/staging hostnames; live tunnel config should match it.
- Lock/transaction scope: not applicable; this is static tunnel configuration only.
- Acceptable orphan states: if the preview Cloud Run service is deleted or renamed, preview.matrix-os.com will fail closed through the tunnel route rather than exposing app data. The direct run.app origin is not a secret and should be treated as public preview infrastructure.
- Auth source of truth: unchanged; this route does not add auth. Preview platform access remains controlled by the preview platform's own runtime configuration.
- Deferred scope: this does not add a preview edge router, edge-secret injection, or Cloud Run ingress lockdown. If preview traffic must be forced through Cloudflare, that should ship as a separate Worker/origin-auth hardening PR.

## Validation
- cloudflared --config distro/cloudflared.yml tunnel ingress validate
- git diff --check
- bun run check:patterns