### PR TITLE
chore(cli): prepare 0.3.6 release

### DIFF
--- a/docs/dev/cli-release.md
+++ b/docs/dev/cli-release.md
@@ -4,7 +4,7 @@ The installable Matrix CLI is the `@finnaai/matrix` package in `packages/sync-cl
 
 ## Current Prepared Release
 
-`0.3.5` is the prepared CLI patch release for the merged CLI fixes after `0.3.4`, including package-runner launch docs, publish validation for `npx`/`pnpm dlx`, and the latest cloud shell CLI hardening.
+`0.3.6` is the prepared CLI patch release for the merged CLI fixes after `0.3.5`, including journey-aware `mos login` / `mos setup`, shell attach reconnect hardening, and CLI telemetry.
 
 ## Versioning
 
@@ -34,7 +34,7 @@ git tag -l 'cli-v*'
 
 ## Release
 
-Use the manual GitHub Actions workflow named `CLI Release` with `version=0.3.5` and `update_homebrew=true`. The workflow:
+Use the manual GitHub Actions workflow named `CLI Release` with `version=0.3.6` and `update_homebrew=true`. The workflow:
 
 1. Validates the requested semver, local package version, npm availability, and `cli-v<version>` tag availability.
 2. Installs the workspace and runs the sync-client build, tests, and publish-shape check.
@@ -50,7 +50,7 @@ npm view @finnaai/matrix dist.tarball
 npx --yes @finnaai/matrix --version
 pnpm dlx @finnaai/matrix --version
 brew update && brew info finnaai/tap/matrix
-MATRIX_VERSION=0.3.5 sh scripts/install.sh
+MATRIX_VERSION=0.3.6 sh scripts/install.sh
 matrix --version
 matrix login --help
 matrix run --help
@@ -66,12 +66,12 @@ matrix run -- ls
 matrix forward 5173
 ```
 
-For macOS, also verify the GitHub release contains `MatrixSync-0.3.5.pkg` when the macOS job was enabled.
+For macOS, also verify the GitHub release contains `MatrixSync-0.3.6.pkg` when the macOS job was enabled.
 
 ## Rollback
 
-npm package versions are immutable. If a bad CLI release is published, ship a patch release such as `0.3.5` and update Homebrew through the release workflow. Only deprecate the bad npm version when the replacement is available:
+npm package versions are immutable. If a bad CLI release is published, ship a patch release such as `0.3.7` and update Homebrew through the release workflow. Only deprecate the bad npm version when the replacement is available:
 
 ```bash
-npm deprecate @finnaai/matrix@0.3.4 "Use @finnaai/matrix@0.3.5"
+npm deprecate @finnaai/matrix@0.3.6 "Use @finnaai/matrix@0.3.7"
 ```

--- a/packages/sync-client/package.json
+++ b/packages/sync-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@finnaai/matrix",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "description": "Matrix OS command-line client — login, sync, and peer management for matrix-os.com",
   "type": "module",
   "license": "AGPL-3.0-or-later",


### PR DESCRIPTION
## Summary
- bump @finnaai/matrix from 0.3.5 to 0.3.6
- update the CLI release runbook for the 0.3.6 publish and verification commands
- document the post-0.3.5 changes included in this release: journey-aware mos login/setup, shell attach reconnect hardening, and CLI telemetry

## Release
After this PR merges, dispatch the checked-in `CLI Release` workflow from `main` with:

`version=0.3.6`
`update_homebrew=true`
`allow_existing_npm=false`

## Validation
- pnpm install --frozen-lockfile
- pnpm --filter @finnaai/matrix build
- pnpm --filter @finnaai/matrix test (303 tests)
- pnpm --filter @finnaai/matrix exec node ./scripts/check-publish.mjs
- pnpm --filter @finnaai/matrix exec node ./scripts/validate-package-runners.mjs
- bun run check:patterns
- git diff --check
- npm view @finnaai/matrix@0.3.6 version (expected 404; version is available)
- git ls-remote --tags origin refs/tags/cli-v0.3.6 (no tag found)

## Invariants
- Source of truth: packages/sync-client/package.json is the release version consumed by CLI Release.
- Lock/transaction scope: not applicable; release metadata/docs only.
- Acceptable orphan states: until the workflow is dispatched after merge, npm remains at 0.3.5 and no cli-v0.3.6 tag exists.
- Auth source of truth: unchanged; no auth code or secrets handling changes.
- Deferred scope: this PR does not publish npm/Homebrew itself; publishing happens only after merge via CLI Release.
