### PR TITLE
fix(shell): keep sockets alive in background tabs

### DIFF
--- a/shell/src/lib/socket-health.ts
+++ b/shell/src/lib/socket-health.ts
@@ -5,14 +5,27 @@ export interface SocketHealthConfig {
   onDead: () => void;
 }
 
+function shouldEnforcePongTimeout(): boolean {
+  return typeof document === "undefined" || document.visibilityState !== "hidden";
+}
+
 export function createSocketHealth(config: SocketHealthConfig) {
   let pingTimer: ReturnType<typeof setInterval> | null = null;
   let pongTimer: ReturnType<typeof setTimeout> | null = null;
+  let hiddenPingAwaitingPong = false;
 
   function sendPing() {
     config.send(JSON.stringify({ type: "ping" }));
+    if (!shouldEnforcePongTimeout()) {
+      hiddenPingAwaitingPong = true;
+      return;
+    }
+    hiddenPingAwaitingPong = false;
     pongTimer = setTimeout(() => {
       pongTimer = null;
+      if (!shouldEnforcePongTimeout()) {
+        return;
+      }
       config.onDead();
     }, config.pongTimeoutMs);
   }
@@ -26,15 +39,18 @@ export function createSocketHealth(config: SocketHealthConfig) {
     stop() {
       if (pingTimer) { clearInterval(pingTimer); pingTimer = null; }
       if (pongTimer) { clearTimeout(pongTimer); pongTimer = null; }
+      hiddenPingAwaitingPong = false;
     },
 
     receivedPong() {
       if (pongTimer) { clearTimeout(pongTimer); pongTimer = null; }
+      hiddenPingAwaitingPong = false;
     },
 
     /** Send an immediate ping (used on visibility change). */
     pingNow() {
       if (pongTimer) return; // already waiting for pong
+      if (hiddenPingAwaitingPong && !shouldEnforcePongTimeout()) return;
       sendPing();
     },
   };

--- a/tests/shell/socket-health.test.ts
+++ b/tests/shell/socket-health.test.ts
@@ -5,6 +5,7 @@ describe("SocketHealth", () => {
     vi.useFakeTimers();
   });
   afterEach(() => {
+    vi.unstubAllGlobals();
     vi.useRealTimers();
   });
 
@@ -152,6 +153,75 @@ describe("SocketHealth", () => {
       vi.advanceTimersByTime(5_000);  // timeout
 
       expect(deadCount).toBe(1);
+      health.stop();
+    });
+
+    it("does not declare the socket dead from a background-tab pong timeout", async () => {
+      const { createSocketHealth } = await import("../../shell/src/lib/socket-health.js");
+      let deadCount = 0;
+      const sent: string[] = [];
+      vi.stubGlobal("document", { visibilityState: "hidden" });
+      const health = createSocketHealth({
+        pingIntervalMs: 30_000,
+        pongTimeoutMs: 5_000,
+        send: (data) => sent.push(data),
+        onDead: () => { deadCount++; },
+      });
+
+      health.pingNow();
+      vi.advanceTimersByTime(5_000);
+
+      expect(sent).toEqual(['{"type":"ping"}']);
+      expect(deadCount).toBe(0);
+
+      vi.stubGlobal("document", { visibilityState: "visible" });
+      health.pingNow();
+      vi.advanceTimersByTime(5_000);
+
+      expect(sent).toEqual(['{"type":"ping"}', '{"type":"ping"}']);
+      expect(deadCount).toBe(1);
+      health.stop();
+    });
+
+    it("does not declare the socket dead when the tab is hidden after a visible ping", async () => {
+      const { createSocketHealth } = await import("../../shell/src/lib/socket-health.js");
+      let deadCount = 0;
+      vi.stubGlobal("document", { visibilityState: "visible" });
+      const health = createSocketHealth({
+        pingIntervalMs: 30_000,
+        pongTimeoutMs: 5_000,
+        send: () => {},
+        onDead: () => { deadCount++; },
+      });
+
+      health.pingNow();
+      vi.stubGlobal("document", { visibilityState: "hidden" });
+      vi.advanceTimersByTime(5_000);
+
+      expect(deadCount).toBe(0);
+      health.stop();
+    });
+
+    it("deduplicates immediate pings while hidden but probes again when visible", async () => {
+      const { createSocketHealth } = await import("../../shell/src/lib/socket-health.js");
+      const sent: string[] = [];
+      vi.stubGlobal("document", { visibilityState: "hidden" });
+      const health = createSocketHealth({
+        pingIntervalMs: 30_000,
+        pongTimeoutMs: 5_000,
+        send: (data) => sent.push(data),
+        onDead: () => {},
+      });
+
+      health.pingNow();
+      health.pingNow();
+
+      expect(sent).toEqual(['{"type":"ping"}']);
+
+      vi.stubGlobal("document", { visibilityState: "visible" });
+      health.pingNow();
+
+      expect(sent).toEqual(['{"type":"ping"}', '{"type":"ping"}']);
       health.stop();
     });
   });


### PR DESCRIPTION
## Summary

- Prevent socket heartbeat pong timeouts from declaring browser sockets dead while the tab is hidden.
- Add a regression test for background-tab heartbeat behavior.

## Invariants

- Source of truth: the browser websocket `readyState` remains the local connection source of truth; heartbeat only decides when to force a reconnect.
- Lock/transaction scope: no database writes or cross-process locks are involved.
- Acceptable orphan states: if a real disconnect happens while hidden, the existing visibility handler reconnects when the tab becomes visible.
- Auth source of truth: websocket authentication and token generation are unchanged.
- Deferred scope: this does not change gateway websocket routing or terminal session persistence; it only removes false-positive client heartbeat closes caused by background-tab timer throttling.

## Validation

- `bun run test tests/shell/socket-health.test.ts` (red before fix, green after)
- `bun run test tests/shell/socket-health.test.ts tests/shell/useSocket.test.ts`
- `bun run check:patterns`
- `bun run typecheck`
- `git diff --check`
