### PR TITLE
fix(shell): use owner handle in terminal prompt

### DIFF
--- a/packages/gateway/src/shell/zellij-config.ts
+++ b/packages/gateway/src/shell/zellij-config.ts
@@ -5,6 +5,7 @@ export type MatrixZellijConfigPaths = {
   file: string;
   shellFile: string;
   bashrcFile: string;
+  promptLabelFile: string;
   layoutDir: string;
   layoutFile: string;
 };
@@ -36,6 +37,34 @@ else
 fi
 `;
 
+export const MATRIX_TERMINAL_PROMPT_LABEL_SCRIPT = `#!/usr/bin/env node
+import { readFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const PROMPT_LABEL_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]{0,31}$/;
+
+function sanitizePromptLabel(value) {
+  if (typeof value !== "string") return null;
+  const label = value.trim().replace(/^@+/, "").replace(/\\s+/g, "-");
+  if (!PROMPT_LABEL_PATTERN.test(label)) return null;
+  return label;
+}
+
+try {
+  const matrixHome = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..");
+  const raw = readFileSync(join(matrixHome, "system", "handle.json"), "utf8");
+  const parsed = JSON.parse(raw);
+  const label = sanitizePromptLabel(parsed?.handle) ?? sanitizePromptLabel(parsed?.displayName);
+  if (label) process.stdout.write(label);
+} catch (err) {
+  const isFileMissing = err != null && typeof err === "object" && "code" in err && err.code === "ENOENT";
+  if (!isFileMissing || process.env.MATRIX_TERMINAL_PROMPT_DEBUG === "1") {
+    console.error("[matrix-terminal-prompt] unable to read owner identity", err);
+  }
+}
+`;
+
 export function matrixZellijConfigPaths(homePath: string): MatrixZellijConfigPaths {
   const zellijDir = join(resolve(homePath), "system", "zellij");
   return {
@@ -43,6 +72,7 @@ export function matrixZellijConfigPaths(homePath: string): MatrixZellijConfigPat
     file: join(zellijDir, "config.kdl"),
     shellFile: join(zellijDir, "matrix-terminal-shell"),
     bashrcFile: join(zellijDir, "bashrc"),
+    promptLabelFile: join(zellijDir, "prompt-label.mjs"),
     layoutDir: join(zellijDir, "layouts"),
     layoutFile: join(zellijDir, "layouts", "matrix.kdl"),
   };
@@ -58,13 +88,24 @@ theme "default"
 `;
 }
 
-export function matrixTerminalShellScript(bashrcPath: string): string {
+export function matrixTerminalShellScript(bashrcPath: string, promptLabelPath: string): string {
   return `#!/usr/bin/env bash
 set -euo pipefail
 
 export MATRIX_HOME="\${MATRIX_HOME:-\${HOME:-/home/matrix/home}}"
 export HOME="\${HOME:-$MATRIX_HOME}"
-export MATRIX_TERMINAL_PROMPT="\${MATRIX_TERMINAL_PROMPT:-\\\\[\\\\e[1;36m\\\\]\\\\u\\\\[\\\\e[0m\\\\]:\\\\[\\\\e[1;34m\\\\]\\\\w\\\\[\\\\e[0m\\\\]\\\\$ }"
+if [ -z "\${MATRIX_TERMINAL_PROMPT:-}" ]; then
+  matrix_prompt_label=""
+  if command -v node >/dev/null 2>&1; then
+    matrix_prompt_label="$(node ${shellSingleQuote(promptLabelPath)} 2>/dev/null || true)"
+  fi
+
+  if [ -n "$matrix_prompt_label" ]; then
+    export MATRIX_TERMINAL_PROMPT="\\\\[\\\\e[1;36m\\\\]$matrix_prompt_label\\\\[\\\\e[0m\\\\]:\\\\[\\\\e[1;34m\\\\]\\\\w\\\\[\\\\e[0m\\\\]\\\\$ "
+  else
+    export MATRIX_TERMINAL_PROMPT="\\\\[\\\\e[1;36m\\\\]\\\\u\\\\[\\\\e[0m\\\\]:\\\\[\\\\e[1;34m\\\\]\\\\w\\\\[\\\\e[0m\\\\]\\\\$ "
+  fi
+fi
 
 exec bash --noprofile --rcfile ${shellSingleQuote(bashrcPath)} -i
 `;

--- a/packages/gateway/src/shell/zellij.ts
+++ b/packages/gateway/src/shell/zellij.ts
@@ -9,6 +9,7 @@ import { join, resolve } from "node:path";
 import { shellError, type ShellSafeError } from "./errors.js";
 import {
   MATRIX_TERMINAL_BASHRC,
+  MATRIX_TERMINAL_PROMPT_LABEL_SCRIPT,
   MATRIX_ZELLIJ_LAYOUT,
   matrixTerminalShellScript,
   matrixZellijConfigPaths,
@@ -261,9 +262,13 @@ export function createZellijAdapter(deps: ZellijAdapterDeps = {}): ZellijAdapter
       ensureConfigPromise = (async () => {
         const { mkdir } = await import("node:fs/promises");
         await mkdir(zellijConfigPaths.layoutDir, { recursive: true });
-        await atomicWriteText(zellijConfigPaths.shellFile, matrixTerminalShellScript(zellijConfigPaths.bashrcFile));
+        await atomicWriteText(
+          zellijConfigPaths.shellFile,
+          matrixTerminalShellScript(zellijConfigPaths.bashrcFile, zellijConfigPaths.promptLabelFile),
+        );
         await chmod(zellijConfigPaths.shellFile, 0o700);
         await atomicWriteText(zellijConfigPaths.bashrcFile, MATRIX_TERMINAL_BASHRC);
+        await atomicWriteText(zellijConfigPaths.promptLabelFile, MATRIX_TERMINAL_PROMPT_LABEL_SCRIPT);
         await atomicWriteText(zellijConfigPaths.file, renderMatrixZellijConfig(zellijConfigPaths));
         await atomicWriteText(zellijConfigPaths.layoutFile, MATRIX_ZELLIJ_LAYOUT);
       })().catch((err: unknown) => {

--- a/packages/gateway/src/zellij-runtime.ts
+++ b/packages/gateway/src/zellij-runtime.ts
@@ -8,6 +8,7 @@ import type { AgentLaunchSpec } from "./agent-launcher.js";
 import { DANGEROUS_CONTROL_CHARS_GLOBAL } from "./prompt-validation.js";
 import {
   MATRIX_TERMINAL_BASHRC,
+  MATRIX_TERMINAL_PROMPT_LABEL_SCRIPT,
   MATRIX_ZELLIJ_LAYOUT,
   matrixTerminalShellScript,
   matrixZellijConfigPaths,
@@ -200,9 +201,13 @@ export function createZellijRuntime(options: {
     if (!ensureConfigPromise) {
       ensureConfigPromise = (async () => {
         await mkdir(layoutDir, { recursive: true });
-        await atomicWriteText(zellijConfigPaths.shellFile, matrixTerminalShellScript(zellijConfigPaths.bashrcFile));
+        await atomicWriteText(
+          zellijConfigPaths.shellFile,
+          matrixTerminalShellScript(zellijConfigPaths.bashrcFile, zellijConfigPaths.promptLabelFile),
+        );
         await chmod(zellijConfigPaths.shellFile, 0o700);
         await atomicWriteText(zellijConfigPaths.bashrcFile, MATRIX_TERMINAL_BASHRC);
+        await atomicWriteText(zellijConfigPaths.promptLabelFile, MATRIX_TERMINAL_PROMPT_LABEL_SCRIPT);
         await atomicWriteText(configPath, renderMatrixZellijConfig(zellijConfigPaths));
         await atomicWriteText(defaultLayoutPath, MATRIX_ZELLIJ_LAYOUT);
       })().catch((err: unknown) => {

--- a/tests/gateway/shell-zellij.test.ts
+++ b/tests/gateway/shell-zellij.test.ts
@@ -1,8 +1,10 @@
 import { EventEmitter } from "node:events";
+import { execFile as nodeExecFile } from "node:child_process";
 import { existsSync, readFileSync } from "node:fs";
-import { mkdtemp, readFile, rm, stat } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { promisify } from "node:util";
 import { describe, expect, it, vi } from "vitest";
 import {
   classifyZellijFailure,
@@ -10,6 +12,8 @@ import {
   sanitizeZellijError,
 } from "../../packages/gateway/src/shell/zellij.js";
 import { matrixTerminalShellScript } from "../../packages/gateway/src/shell/zellij-config.js";
+
+const execFileAsync = promisify(nodeExecFile);
 
 function childProcess() {
   return Object.assign(new EventEmitter(), {
@@ -300,10 +304,12 @@ describe("zellij adapter", () => {
       const layoutPath = join(configDir, "layouts", "matrix.kdl");
       const shellPath = join(configDir, "matrix-terminal-shell");
       const bashrcPath = join(configDir, "bashrc");
+      const promptLabelPath = join(configDir, "prompt-label.mjs");
       const config = await readFile(configPath, "utf8");
       const layout = await readFile(layoutPath, "utf8");
       const shell = await readFile(shellPath, "utf8");
       const bashrc = await readFile(bashrcPath, "utf8");
+      const promptLabel = await readFile(promptLabelPath, "utf8");
       const shellMode = (await stat(shellPath)).mode;
 
       expect(config).toContain("pane_frames false");
@@ -311,10 +317,12 @@ describe("zellij adapter", () => {
       expect(config).toContain('default_layout "matrix"');
       expect(config).toContain(`default_shell ${JSON.stringify(shellPath)}`);
       expect(shell).toContain(`exec bash --noprofile --rcfile '${bashrcPath}' -i`);
+      expect(shell).toContain(`node '${promptLabelPath}'`);
       expect(shell).not.toContain("/bin/bash");
       expect(shellMode & 0o700).toBe(0o700);
       expect(bashrc).toContain('PS1="${MATRIX_TERMINAL_PROMPT}"');
       expect(bashrc).toContain("\\u:\\w\\$ ");
+      expect(promptLabel).toContain("JSON.parse");
       expect(layout).toContain('plugin location="zellij:compact-bar"');
       expect(layout).not.toContain("tab-bar");
       expect(layout).not.toContain("status-bar");
@@ -328,6 +336,72 @@ describe("zellij adapter", () => {
           }),
         }),
       );
+    } finally {
+      await rm(homePath, { recursive: true, force: true });
+    }
+  });
+
+  it("derives prompt labels from owner handle.json without shell injection", async () => {
+    const homePath = await mkdtemp(join(tmpdir(), "matrix-shell-prompt-label-"));
+    try {
+      const systemDir = join(homePath, "system");
+      await mkdir(systemDir, { recursive: true });
+      const handlePath = join(systemDir, "handle.json");
+      await writeFile(handlePath, JSON.stringify({
+        handle: "hamedmp",
+        displayName: "Hamed MP",
+      }));
+
+      const pty = ptyProcess();
+      const spawnPty = vi.fn(() => pty);
+      const adapter = createZellijAdapter({
+        execFile: vi.fn(),
+        spawnPty,
+        timeoutMs: 25,
+        startupDelayMs: 1,
+        homePath,
+      });
+
+      await adapter.createSession({ name: "main" });
+
+      const promptLabelPath = join(homePath, "system", "zellij", "prompt-label.mjs");
+      await expect(execFileAsync(process.execPath, [promptLabelPath], {
+        env: { ...process.env, MATRIX_HOME: homePath },
+        timeout: 1_000,
+      })).resolves.toMatchObject({ stdout: "hamedmp" });
+
+      await writeFile(handlePath, JSON.stringify({
+        handle: "bad$(rm -rf /)",
+        displayName: "Hamed MP",
+      }));
+      await expect(execFileAsync(process.execPath, [promptLabelPath], {
+        env: { ...process.env, MATRIX_HOME: homePath },
+        timeout: 1_000,
+      })).resolves.toMatchObject({ stdout: "Hamed-MP" });
+
+      await writeFile(handlePath, JSON.stringify({
+        handle: "bad\\label",
+        displayName: "bad\u001b[31m",
+      }));
+      await expect(execFileAsync(process.execPath, [promptLabelPath], {
+        env: { ...process.env, MATRIX_HOME: homePath },
+        timeout: 1_000,
+      })).resolves.toMatchObject({ stdout: "" });
+
+      await writeFile(handlePath, "{not-json");
+      await expect(execFileAsync(process.execPath, [promptLabelPath], {
+        env: { ...process.env, MATRIX_HOME: homePath },
+        timeout: 1_000,
+      })).resolves.toMatchObject({
+        stdout: "",
+        stderr: expect.stringContaining("[matrix-terminal-prompt] unable to read owner identity"),
+      });
+
+      await rm(handlePath, { force: true });
+      await expect(execFileAsync(process.execPath, [promptLabelPath], {
+        env: { ...process.env, MATRIX_HOME: homePath },
+        timeout: 1_000,
+      })).resolves.toMatchObject({ stdout: "", stderr: "" });
     } finally {
       await rm(homePath, { recursive: true, force: true });
     }
@@ -515,9 +589,11 @@ describe("zellij adapter", () => {
 
   it("shell-quotes generated bash rcfile paths", () => {
     const path = `/tmp/matrix "owner"/it'works/bashrc`;
-    const script = matrixTerminalShellScript(path);
+    const promptLabelPath = `/tmp/matrix "owner"/it'works/prompt-label.mjs`;
+    const script = matrixTerminalShellScript(path, promptLabelPath);
 
     expect(script).toContain(`exec bash --noprofile --rcfile '/tmp/matrix "owner"/it'\\''works/bashrc' -i`);
+    expect(script).toContain(`node '/tmp/matrix "owner"/it'\\''works/prompt-label.mjs'`);
     expect(script).not.toContain("/bin/bash");
   });
 });

--- a/tests/gateway/zellij-runtime.test.ts
+++ b/tests/gateway/zellij-runtime.test.ts
@@ -103,9 +103,11 @@ describe("zellij-runtime", () => {
     const configPath = join(configDir, "config.kdl");
     const shellPath = join(configDir, "matrix-terminal-shell");
     const bashrcPath = join(configDir, "bashrc");
+    const promptLabelPath = join(configDir, "prompt-label.mjs");
     const config = await readFile(configPath, "utf-8");
     const shell = await readFile(shellPath, "utf-8");
     const bashrc = await readFile(bashrcPath, "utf-8");
+    const promptLabel = await readFile(promptLabelPath, "utf-8");
     const defaultLayout = await readFile(join(configDir, "layouts", "matrix.kdl"), "utf-8");
     const sessionLayout = await readFile(started.layoutPath, "utf-8");
 
@@ -114,7 +116,9 @@ describe("zellij-runtime", () => {
     expect(config).toContain('default_layout "matrix"');
     expect(config).toContain(`default_shell ${JSON.stringify(shellPath)}`);
     expect(shell).toContain(`exec bash --noprofile --rcfile '${bashrcPath}' -i`);
+    expect(shell).toContain(`node '${promptLabelPath}'`);
     expect(bashrc).toContain('PS1="${MATRIX_TERMINAL_PROMPT}"');
+    expect(promptLabel).toContain("handle.json");
     expect(defaultLayout).toContain('plugin location="zellij:compact-bar"');
     expect(sessionLayout).toContain('plugin location="zellij:compact-bar"');
     expect(spawnPty).toHaveBeenCalledWith(


### PR DESCRIPTION
Summary
- Generate a Matrix terminal prompt-label helper beside the Zellij config.
- Read the owner-controlled ~/system/handle.json at shell startup and prefer a safe handle over displayName.
- Keep MATRIX_TERMINAL_PROMPT as an explicit override and fall back to the OS user when no safe owner label exists.

Validation
- pnpm exec vitest run tests/gateway/shell-zellij.test.ts tests/gateway/zellij-runtime.test.ts
- pnpm exec tsc --noEmit -p packages/gateway/tsconfig.json
- bun run check:patterns
- git diff --check

Invariants
- Source of truth: owner-controlled ~/system/handle.json remains canonical for the user-facing prompt label; the Linux account and VPS hostname remain internal runtime identity.
- Lock/transaction scope: no database writes or multi-step persistent mutations beyond the existing atomic config-file writes.
- Acceptable orphan states: if handle.json is missing, malformed, or unsafe, the shell falls back to the OS user prompt; existing terminal sessions keep their current prompt until restarted.
- Auth source of truth: no auth change; this only reads local owner files inside the user home.
- Deferred scope: no settings UI for editing the handle/display name in this PR; this only makes the terminal consume the existing owner identity file safely.