### PR TITLE
feat(cli): support Node 20 and standalone binaries

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -16,7 +16,7 @@ protection is also updated when the shard list changes.
 - `Type Check`
 - `Pattern Scan`
 - `React Doctor`
-- `Sync Client Package`
+- `Sync Client Package (Node 20/24)`
 - `Unit Tests`
 - `E2E Tests`
 
@@ -32,7 +32,7 @@ logs and artifacts.
 | `docker-test.yml` | Legacy/local Docker scenario validation | `ready-for-ci`, ready PRs, merge queue, `main`, nightly, manual | Required when Docker/runtime paths are touched |
 | `host-bundle-release.yml` | VPS-native customer runtime release | `main`, `v*` tags, manual | Required for host bundle publishing |
 | `platform-cloud-run.yml` | Platform/app-shell Cloud Run deployment | `main` when platform/auth-shell inputs change, manual | Required for app.matrix-os.com platform changes |
-| `release.yml` / `cli-release.yml` | Installable `@finnaai/matrix` CLI release | Manual CLI release | Required for CLI publishing |
+| `release.yml` / `cli-release.yml` | Installable `@finnaai/matrix` CLI release plus standalone binaries | Manual CLI release | Required for CLI publishing |
 | `pr-title.yml` | Conventional Commit PR title policy | PR title changes | Yes |
 | `docker.yml` | Legacy Docker image publishing/deploy path | `v*` tags, manual | Legacy only, not the customer runtime path |
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -219,10 +219,14 @@ jobs:
           done
 
   sync-client:
-    name: Sync Client Package
+    name: Sync Client Package (Node ${{ matrix.node }})
     needs: [changes, patterns]
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        node: [20, 24]
     steps:
       - name: Skip expensive CI for docs-only changes
         if: needs.changes.outputs.should_run != 'true'
@@ -237,7 +241,7 @@ jobs:
       - uses: actions/setup-node@v6
         if: needs.changes.outputs.should_run == 'true'
         with:
-          node-version: 24
+          node-version: ${{ matrix.node }}
           cache: pnpm
 
       - run: pnpm install --frozen-lockfile
@@ -376,7 +380,7 @@ jobs:
             echo "| Type Check | $TYPECHECK_RESULT |"
             echo "| Pattern Scan | $PATTERNS_RESULT |"
             echo "| React Doctor | $REACT_DOCTOR_RESULT |"
-            echo "| Sync Client Package | $SYNC_CLIENT_RESULT |"
+            echo "| Sync Client Package (Node 20/24) | $SYNC_CLIENT_RESULT |"
             echo "| Unit Tests | $UNIT_RESULT |"
             echo "| E2E Tests | $E2E_RESULT |"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/cli-release.yml
+++ b/.github/workflows/cli-release.yml
@@ -1,10 +1,10 @@
 name: CLI Release
 
 # Manually dispatched from the GitHub Actions UI. Publishes only the
-# installable Matrix CLI package (`@finnaai/matrix`) and its matching
-# `cli-v<version>` GitHub release/Homebrew formula. This intentionally avoids
-# the broader release workflow's full-repo test and optional macOS installer
-# path so a CLI patch can ship independently.
+# installable Matrix CLI package (`@finnaai/matrix`), standalone CLI binaries,
+# and its matching `cli-v<version>` GitHub release/Homebrew formula. This
+# intentionally avoids the broader release workflow's full-repo test and
+# optional macOS installer path so a CLI patch can ship independently.
 on:
   workflow_dispatch:
     inputs:
@@ -98,6 +98,9 @@ jobs:
       - name: Verify publish shape
         run: pnpm --filter @finnaai/matrix exec node ./scripts/check-publish.mjs
 
+      - name: Verify package runners
+        run: pnpm --filter @finnaai/matrix exec node ./scripts/validate-package-runners.mjs
+
       - name: Pack CLI package
         working-directory: packages/sync-client
         run: npm pack --dry-run
@@ -121,13 +124,51 @@ jobs:
           npm view "@finnaai/matrix@$VERSION" version
           npm view "@finnaai/matrix@$VERSION" dist.tarball
 
+  build-binaries:
+    name: Build standalone binaries
+    needs: publish
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: pnpm/action-setup@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: pnpm
+
+      - uses: oven-sh/setup-bun@v2
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build standalone CLI binaries
+        env:
+          MATRIX_CLI_VERSION: ${{ needs.publish.outputs.version }}
+        run: pnpm --filter @finnaai/matrix build:binaries
+
+      - name: Upload standalone CLI binaries
+        uses: actions/upload-artifact@v7
+        with:
+          name: cli-binaries
+          path: dist/cli-binaries/*
+          if-no-files-found: error
+
   github-release:
     name: Create GitHub release
-    needs: publish
+    needs: [publish, build-binaries]
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v6
+
+      - name: Download standalone CLI binaries
+        uses: actions/download-artifact@v7
+        with:
+          name: cli-binaries
+          path: dist/cli-binaries
 
       - name: Create release
         uses: softprops/action-gh-release@v3
@@ -136,7 +177,9 @@ jobs:
           name: cli-v${{ needs.publish.outputs.version }}
           target_commitish: ${{ github.sha }}
           generate_release_notes: true
-          files: scripts/install.sh
+          files: |
+            scripts/install.sh
+            dist/cli-binaries/*
           fail_on_unmatched_files: false
 
   homebrew:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -199,11 +199,11 @@ jobs:
 
   publish-npm:
     name: Publish npm
-    needs: [test, build-macos]
+    needs: [test, build-macos, build-binaries]
     # Skipped jobs report as "skipped" in needs.build-macos.result; we want
     # npm publish to continue even when the macOS pkg is disabled, but fail
     # fast if it actually failed.
-    if: ${{ !cancelled() && needs.test.result == 'success' && (needs.build-macos.result == 'success' || needs.build-macos.result == 'skipped') }}
+    if: ${{ !cancelled() && needs.test.result == 'success' && needs.build-binaries.result == 'success' && (needs.build-macos.result == 'success' || needs.build-macos.result == 'skipped') }}
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -235,8 +235,8 @@ jobs:
 
   build-binaries:
     name: Build standalone binaries
-    needs: publish-npm
-    if: ${{ !cancelled() && needs.publish-npm.result == 'success' }}
+    needs: test
+    if: ${{ !cancelled() && needs.test.result == 'success' }}
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,9 @@
 name: Release
 
-# Manually dispatched. Runs tests, publishes @finnaai/matrix to npm, builds +
-# signs + notarises the macOS installer (when enabled via ENABLE_MACOS_PKG),
-# creates a GitHub release tagged cli-v<version>, and refreshes the Homebrew
-# formula in FinnaAI/homebrew-tap.
+# Manually dispatched. Runs tests, publishes @finnaai/matrix to npm, builds
+# standalone CLI binaries, builds + signs + notarises the macOS installer (when
+# enabled via ENABLE_MACOS_PKG), creates a GitHub release tagged cli-v<version>,
+# and refreshes the Homebrew formula in FinnaAI/homebrew-tap.
 #
 # Security note: the only user-controlled input is `version`, validated against
 # a strict semver regex below before it's interpolated into run: steps.
@@ -94,6 +94,9 @@ jobs:
 
       - name: Verify sync-client publish shape
         run: pnpm --filter @finnaai/matrix exec node ./scripts/check-publish.mjs
+
+      - name: Verify package runners
+        run: pnpm --filter @finnaai/matrix exec node ./scripts/validate-package-runners.mjs
 
       - name: Type check
         run: bun run typecheck
@@ -230,10 +233,42 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npm publish --provenance --access public
 
+  build-binaries:
+    name: Build standalone binaries
+    needs: publish-npm
+    if: ${{ !cancelled() && needs.publish-npm.result == 'success' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: pnpm/action-setup@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: pnpm
+
+      - uses: oven-sh/setup-bun@v2
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Build standalone CLI binaries
+        env:
+          MATRIX_CLI_VERSION: ${{ inputs.version }}
+        run: pnpm --filter @finnaai/matrix build:binaries
+
+      - name: Upload standalone CLI binaries
+        uses: actions/upload-artifact@v7
+        with:
+          name: cli-binaries
+          path: dist/cli-binaries/*
+          if-no-files-found: error
+
   github-release:
     name: GitHub release
-    needs: [build-macos, publish-npm]
-    if: ${{ !cancelled() && needs.publish-npm.result == 'success' }}
+    needs: [build-macos, publish-npm, build-binaries]
+    if: ${{ !cancelled() && needs.publish-npm.result == 'success' && needs.build-binaries.result == 'success' }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -241,10 +276,16 @@ jobs:
 
       - name: Download macOS pkg (if built)
         if: ${{ needs.build-macos.result == 'success' }}
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@v7
         with:
           name: macos-pkg
           path: dist/macos
+
+      - name: Download standalone CLI binaries
+        uses: actions/download-artifact@v7
+        with:
+          name: cli-binaries
+          path: dist/cli-binaries
 
       - name: Create release
         uses: softprops/action-gh-release@v3
@@ -255,6 +296,7 @@ jobs:
           generate_release_notes: true
           files: |
             dist/macos/*.pkg
+            dist/cli-binaries/*
             scripts/install.sh
           fail_on_unmatched_files: false
 

--- a/docs/dev/cli-release.md
+++ b/docs/dev/cli-release.md
@@ -4,7 +4,7 @@ The installable Matrix CLI is the `@finnaai/matrix` package in `packages/sync-cl
 
 ## Current Prepared Release
 
-`0.3.6` is the prepared CLI patch release for the merged CLI fixes after `0.3.5`, including journey-aware `mos login` / `mos setup`, shell attach reconnect hardening, and CLI telemetry.
+`0.3.7` is the prepared CLI patch release after `0.3.6`, including Node 20+ package-runner support and standalone CLI binaries for no-Node installs.
 
 ## Versioning
 
@@ -34,13 +34,14 @@ git tag -l 'cli-v*'
 
 ## Release
 
-Use the manual GitHub Actions workflow named `CLI Release` with `version=0.3.6` and `update_homebrew=true`. The workflow:
+Use the manual GitHub Actions workflow named `CLI Release` with `version=0.3.7` and `update_homebrew=true`. The workflow:
 
 1. Validates the requested semver, local package version, npm availability, and `cli-v<version>` tag availability.
 2. Installs the workspace and runs the sync-client build, tests, and publish-shape check.
 3. Publishes `@finnaai/matrix` to npm with provenance.
 4. Creates GitHub release `cli-v<version>`.
-5. Updates `FinnaAI/homebrew-tap` with the npm tarball URL and SHA-256 when `update_homebrew` is enabled.
+5. Builds standalone Linux/macOS CLI binaries and attaches them to the GitHub release.
+6. Updates `FinnaAI/homebrew-tap` with the npm tarball URL and SHA-256 when `update_homebrew` is enabled.
 
 ## Post-Release Verification
 
@@ -50,7 +51,7 @@ npm view @finnaai/matrix dist.tarball
 npx --yes @finnaai/matrix --version
 pnpm dlx @finnaai/matrix --version
 brew update && brew info finnaai/tap/matrix
-MATRIX_VERSION=0.3.6 sh scripts/install.sh
+MATRIX_VERSION=0.3.7 sh scripts/install.sh
 matrix --version
 matrix login --help
 matrix run --help
@@ -66,12 +67,19 @@ matrix run -- ls
 matrix forward 5173
 ```
 
-For macOS, also verify the GitHub release contains `MatrixSync-0.3.6.pkg` when the macOS job was enabled.
+For standalone binaries, also verify the GitHub release contains:
+
+- `matrix-0.3.7-linux-x64`
+- `matrix-0.3.7-linux-arm64`
+- `matrix-0.3.7-darwin-x64`
+- `matrix-0.3.7-darwin-arm64`
+
+For macOS app packaging, also verify the GitHub release contains `MatrixSync-0.3.7.pkg` when the macOS job was enabled.
 
 ## Rollback
 
 npm package versions are immutable. If a bad CLI release is published, ship a patch release such as `0.3.7` and update Homebrew through the release workflow. Only deprecate the bad npm version when the replacement is available:
 
 ```bash
-npm deprecate @finnaai/matrix@0.3.6 "Use @finnaai/matrix@0.3.7"
+npm deprecate @finnaai/matrix@0.3.7 "Use @finnaai/matrix@0.3.8"
 ```

--- a/packages/sync-client/README.md
+++ b/packages/sync-client/README.md
@@ -49,7 +49,8 @@ All three bin entries are installed: `matrix`, `matrixos`, `mos`.
 
 ## Requirements
 
-- Node.js 24 or newer
+- Node.js 20 or newer for npm package runners and global npm installs
+- No Node.js install is required when using the standalone binary from `get.matrix-os.com`
 - A Matrix OS account — sign up at [app.matrix-os.com](https://app.matrix-os.com)
 
 ## License

--- a/packages/sync-client/package.json
+++ b/packages/sync-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@finnaai/matrix",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "description": "Matrix OS command-line client — login, sync, and peer management for matrix-os.com",
   "type": "module",
   "license": "AGPL-3.0-or-later",
@@ -21,7 +21,7 @@
     "matrixos"
   ],
   "engines": {
-    "node": ">=24"
+    "node": ">=20"
   },
   "bin": {
     "matrix": "bin/matrix.mjs",
@@ -52,7 +52,8 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "prepublishOnly": "node ./scripts/check-publish.mjs",
-    "validate:package-runners": "node ./scripts/validate-package-runners.mjs"
+    "validate:package-runners": "node ./scripts/validate-package-runners.mjs",
+    "build:binaries": "node ./scripts/build-binaries.mjs"
   },
   "dependencies": {
     "chokidar": "^4.0.0",
@@ -61,7 +62,6 @@
     "picomatch": "^4.0.4",
     "pino": "^9.6.0",
     "pino-roll": "^2.1.0",
-    "posthog-node": "^5.24.15",
     "tsx": "^4.21.0",
     "ws": "^8.19.0",
     "zod": "^4.4.3"

--- a/packages/sync-client/scripts/build-binaries.mjs
+++ b/packages/sync-client/scripts/build-binaries.mjs
@@ -1,0 +1,70 @@
+#!/usr/bin/env node
+import { createHash } from "node:crypto";
+import { chmod, mkdir, readFile, writeFile } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+import { spawn } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const pkgRoot = resolve(here, "..");
+const repoRoot = resolve(pkgRoot, "../..");
+const pkg = JSON.parse(await readFile(resolve(pkgRoot, "package.json"), "utf8"));
+const version = process.env.MATRIX_CLI_VERSION || pkg.version;
+const outDir = resolve(repoRoot, "dist", "cli-binaries");
+const entry = resolve(pkgRoot, "src", "cli", "index.ts");
+
+const targets = [
+  { os: "linux", arch: "x64", bunTarget: "bun-linux-x64" },
+  { os: "linux", arch: "arm64", bunTarget: "bun-linux-arm64" },
+  { os: "darwin", arch: "x64", bunTarget: "bun-darwin-x64" },
+  { os: "darwin", arch: "arm64", bunTarget: "bun-darwin-arm64" },
+];
+
+function run(command, args) {
+  return new Promise((resolveRun, reject) => {
+    const child = spawn(command, args, {
+      cwd: repoRoot,
+      stdio: "inherit",
+      env: {
+        ...process.env,
+        MATRIX_CLI_VERSION: version,
+        MATRIX_CLI_STANDALONE: "1",
+      },
+    });
+    child.on("error", reject);
+    child.on("exit", (code, signal) => {
+      if (code === 0) {
+        resolveRun();
+        return;
+      }
+      reject(new Error(`${command} ${args.join(" ")} failed (${signal ?? code})`));
+    });
+  });
+}
+
+await mkdir(outDir, { recursive: true });
+
+await Promise.all(
+  targets.map(async (target) => {
+    const name = `matrix-${version}-${target.os}-${target.arch}`;
+    const outfile = resolve(outDir, name);
+    await run("bun", [
+      "build",
+      entry,
+      "--compile",
+      "--no-compile-autoload-dotenv",
+      "--no-compile-autoload-bunfig",
+      "--target",
+      target.bunTarget,
+      "--outfile",
+      outfile,
+      "--env",
+      "MATRIX_CLI_*",
+    ]);
+    await chmod(outfile, 0o755);
+    const sha256 = createHash("sha256").update(await readFile(outfile)).digest("hex");
+    await writeFile(resolve(outDir, `${name}.sha256`), `${sha256}  ${name}\n`);
+  }),
+);
+
+console.log(`Built Matrix CLI standalone binaries in ${outDir}`);

--- a/packages/sync-client/scripts/check-publish.mjs
+++ b/packages/sync-client/scripts/check-publish.mjs
@@ -15,6 +15,7 @@ const mustExist = [
   'src/index.ts',
   'src/lib/find-tsx-loader.mjs',
   'src/lib/node-runtime-guard.mjs',
+  'scripts/build-binaries.mjs',
 ];
 
 const missing = mustExist.filter((p) => !existsSync(resolve(pkgRoot, p)));

--- a/packages/sync-client/src/cli/commands/sync.ts
+++ b/packages/sync-client/src/cli/commands/sync.ts
@@ -132,6 +132,7 @@ async function runStart(
       currentRuntime,
     })
   ) {
+    await saveConfig({ ...config, syncDaemonRuntime: currentRuntime });
     console.log(`Sync already running for: ${syncPath}`);
     console.log(`Peer ID: ${config.peerId}`);
     if (gatewayFolder) console.log(`Gateway folder: ${gatewayFolder}`);

--- a/packages/sync-client/src/cli/commands/sync.ts
+++ b/packages/sync-client/src/cli/commands/sync.ts
@@ -114,8 +114,6 @@ async function runStart(
         peerId: generatePeerId(),
         pauseSync: false,
       };
-  await saveConfig(config);
-
   const serviceCommand = currentRuntime === "standalone"
     ? createStandaloneDaemonServiceCommand()
     : createSourceDaemonServiceCommand(new URL("../../daemon/launcher.mjs", import.meta.url).pathname);

--- a/packages/sync-client/src/cli/commands/sync.ts
+++ b/packages/sync-client/src/cli/commands/sync.ts
@@ -7,11 +7,20 @@ import {
   sendCommand,
   isDaemonRunning,
 } from "../daemon-client.js";
-import { installService, startService } from "../../daemon/service.js";
+import {
+  createSourceDaemonServiceCommand,
+  createStandaloneDaemonServiceCommand,
+  installService,
+  startService,
+} from "../../daemon/service.js";
 import { resolveCliProfile } from "../profiles.js";
 import { formatCliError, formatCliSuccess } from "../output.js";
 
 const SUBCOMMANDS = new Set(["status", "pause", "resume"]);
+
+function isStandaloneCliRuntime(): boolean {
+  return process.env.MATRIX_CLI_STANDALONE === "1" && typeof process.versions.bun === "string";
+}
 
 function writeSyncError(err: unknown, json: boolean): void {
   const code = isDaemonClientError(err) ? err.code : "sync_failed";
@@ -89,11 +98,10 @@ async function runStart(
     return;
   }
 
-  // Point launchd/systemd at the .mjs launcher -- it re-execs node with
-  // --import tsx so the .ts daemon entry can be loaded directly. Plain node
-  // can't import .ts files.
-  const daemonPath = new URL("../../daemon/launcher.mjs", import.meta.url).pathname;
-  await installService(daemonPath);
+  const serviceCommand = isStandaloneCliRuntime()
+    ? createStandaloneDaemonServiceCommand()
+    : createSourceDaemonServiceCommand(new URL("../../daemon/launcher.mjs", import.meta.url).pathname);
+  await installService(serviceCommand);
   await startService();
 
   console.log(`Sync started for: ${syncPath}`);

--- a/packages/sync-client/src/cli/commands/sync.ts
+++ b/packages/sync-client/src/cli/commands/sync.ts
@@ -1,7 +1,13 @@
 import { defineCommand } from "citty";
 import { resolve } from "node:path";
 import { mkdir } from "node:fs/promises";
-import { loadConfig, saveConfig, defaultSyncPath, generatePeerId } from "../../lib/config.js";
+import {
+  loadConfig,
+  saveConfig,
+  defaultSyncPath,
+  generatePeerId,
+  type SyncConfig,
+} from "../../lib/config.js";
 import {
   isDaemonClientError,
   sendCommand,
@@ -17,9 +23,35 @@ import { resolveCliProfile } from "../profiles.js";
 import { formatCliError, formatCliSuccess } from "../output.js";
 
 const SUBCOMMANDS = new Set(["status", "pause", "resume"]);
+type SyncDaemonRuntime = NonNullable<SyncConfig["syncDaemonRuntime"]>;
 
-function isStandaloneCliRuntime(): boolean {
-  return process.env.MATRIX_CLI_STANDALONE === "1" && typeof process.versions.bun === "string";
+function currentSyncDaemonRuntime(): SyncDaemonRuntime {
+  return process.env.MATRIX_CLI_STANDALONE === "1" && typeof process.versions.bun === "string"
+    ? "standalone"
+    : "source";
+}
+
+export function shouldReuseRunningSyncService({
+  previous,
+  syncPath,
+  gatewayFolder,
+  currentRuntime,
+}: {
+  previous: SyncConfig | null;
+  syncPath: string;
+  gatewayFolder: string;
+  currentRuntime: SyncDaemonRuntime;
+}): boolean {
+  const sameTarget =
+    previous?.syncPath === syncPath &&
+    (previous?.gatewayFolder ?? "") === gatewayFolder;
+  if (!sameTarget) return false;
+
+  // Configs written before standalone binaries existed did not record a daemon
+  // runtime. Those are source/npm services, so a standalone install must force
+  // one service rewrite instead of reusing the old launcher.
+  const previousRuntime = previous?.syncDaemonRuntime ?? "source";
+  return previousRuntime === currentRuntime;
 }
 
 function writeSyncError(err: unknown, json: boolean): void {
@@ -62,6 +94,7 @@ async function runStart(
   await mkdir(syncPath, { recursive: true });
 
   const previous = await loadConfig();
+  const currentRuntime = currentSyncDaemonRuntime();
   const profile = await resolveCliProfile(args);
   const gatewayFolder = folder ?? previous?.gatewayFolder ?? "";
   const config = previous
@@ -84,24 +117,33 @@ async function runStart(
       };
   await saveConfig(config);
 
+  const serviceCommand = currentRuntime === "standalone"
+    ? createStandaloneDaemonServiceCommand()
+    : createSourceDaemonServiceCommand(new URL("../../daemon/launcher.mjs", import.meta.url).pathname);
+
   // Skip the launchctl unload/load bounce if the daemon is already running
-  // and neither the sync path nor the gateway folder changed. Bouncing for
-  // no reason creates a race where `matrix sync status` immediately after
-  // returns "not running" while the socket is being recreated.
-  const sameTarget =
-    previous?.syncPath === syncPath &&
-    (previous?.gatewayFolder ?? "") === gatewayFolder;
-  if (sameTarget && (await isDaemonRunning())) {
+  // and neither the sync target nor the daemon launcher runtime changed.
+  // Bouncing for no reason creates a race where `matrix sync status`
+  // immediately after returns "not running" while the socket is being
+  // recreated.
+  if (
+    (await isDaemonRunning()) &&
+    shouldReuseRunningSyncService({
+      previous,
+      syncPath,
+      gatewayFolder,
+      currentRuntime,
+    })
+  ) {
     console.log(`Sync already running for: ${syncPath}`);
     console.log(`Peer ID: ${config.peerId}`);
     if (gatewayFolder) console.log(`Gateway folder: ${gatewayFolder}`);
     return;
   }
 
-  const serviceCommand = isStandaloneCliRuntime()
-    ? createStandaloneDaemonServiceCommand()
-    : createSourceDaemonServiceCommand(new URL("../../daemon/launcher.mjs", import.meta.url).pathname);
   await installService(serviceCommand);
+  const installedConfig = { ...config, syncDaemonRuntime: currentRuntime };
+  await saveConfig(installedConfig);
   await startService();
 
   console.log(`Sync started for: ${syncPath}`);

--- a/packages/sync-client/src/cli/commands/sync.ts
+++ b/packages/sync-client/src/cli/commands/sync.ts
@@ -20,15 +20,14 @@ import {
   startService,
 } from "../../daemon/service.js";
 import { resolveCliProfile } from "../profiles.js";
+import { isStandaloneRuntime } from "../standalone-runtime.js";
 import { formatCliError, formatCliSuccess } from "../output.js";
 
 const SUBCOMMANDS = new Set(["status", "pause", "resume"]);
 type SyncDaemonRuntime = NonNullable<SyncConfig["syncDaemonRuntime"]>;
 
 function currentSyncDaemonRuntime(): SyncDaemonRuntime {
-  return process.env.MATRIX_CLI_STANDALONE === "1" && typeof process.versions.bun === "string"
-    ? "standalone"
-    : "source";
+  return isStandaloneRuntime() ? "standalone" : "source";
 }
 
 export function shouldReuseRunningSyncService({

--- a/packages/sync-client/src/cli/index.ts
+++ b/packages/sync-client/src/cli/index.ts
@@ -17,6 +17,7 @@ import { downloadCommand } from "./commands/download.js";
 import { agentCommand } from "./commands/agent.js";
 import { forwardAliasCommand, portCommand } from "./commands/port.js";
 import { normalizeLeadingGlobalFlags } from "./global-flags.js";
+import { shouldRunStandaloneDaemon } from "./standalone-runtime.js";
 import { getCliTelemetry } from "./telemetry.js";
 import { resolveCliVersion } from "./version.js";
 
@@ -53,7 +54,7 @@ const main = defineCommand({
 
 const rawArgs = normalizeLeadingGlobalFlags(process.argv.slice(2));
 
-if (rawArgs[0] === "__daemon") {
+if (shouldRunStandaloneDaemon(rawArgs)) {
   const { startDaemon } = await import("../daemon/index.js");
   await startDaemon();
 } else {

--- a/packages/sync-client/src/cli/index.ts
+++ b/packages/sync-client/src/cli/index.ts
@@ -1,4 +1,3 @@
-import { createRequire } from "node:module";
 import { defineCommand, runMain } from "citty";
 import { loginCommand } from "./commands/login.js";
 import { setupCommand } from "./commands/setup.js";
@@ -19,9 +18,7 @@ import { agentCommand } from "./commands/agent.js";
 import { forwardAliasCommand, portCommand } from "./commands/port.js";
 import { normalizeLeadingGlobalFlags } from "./global-flags.js";
 import { getCliTelemetry } from "./telemetry.js";
-
-const require = createRequire(import.meta.url);
-const pkg = require("../../package.json") as { version: string };
+import { resolveCliVersion } from "./version.js";
 
 const subCommands = {
   login: loginCommand,
@@ -48,7 +45,7 @@ const subCommands = {
 const main = defineCommand({
   meta: {
     name: "matrixos",
-    version: pkg.version,
+    version: resolveCliVersion(),
     description: "Matrix OS CLI — file sync, shell sessions, and instance access",
   },
   subCommands,
@@ -56,21 +53,26 @@ const main = defineCommand({
 
 const rawArgs = normalizeLeadingGlobalFlags(process.argv.slice(2));
 
-// Anonymous usage telemetry (no-op without a PostHog token; opt out with
-// MATRIX_NO_TELEMETRY). Only the resolved command name and an argument count
-// are captured -- never argument values or paths. Unknown first tokens are
-// reported as "unknown" so typos cannot leak file names.
-const telemetry = getCliTelemetry();
-const firstPositional = rawArgs.find((arg) => !arg.startsWith("-"));
-const commandName = firstPositional
-  ? Object.hasOwn(subCommands, firstPositional)
-    ? firstPositional
-    : "unknown"
-  : "root";
-telemetry.captureCommandRun(commandName, Math.max(rawArgs.length - (firstPositional ? 1 : 0), 0));
+if (rawArgs[0] === "__daemon") {
+  const { startDaemon } = await import("../daemon/index.js");
+  await startDaemon();
+} else {
+  // Anonymous usage telemetry (no-op without a PostHog token; opt out with
+  // MATRIX_NO_TELEMETRY). Only the resolved command name and an argument count
+  // are captured -- never argument values or paths. Unknown first tokens are
+  // reported as "unknown" so typos cannot leak file names.
+  const telemetry = getCliTelemetry();
+  const firstPositional = rawArgs.find((arg) => !arg.startsWith("-"));
+  const commandName = firstPositional
+    ? Object.hasOwn(subCommands, firstPositional)
+      ? firstPositional
+      : "unknown"
+    : "root";
+  telemetry.captureCommandRun(commandName, Math.max(rawArgs.length - (firstPositional ? 1 : 0), 0));
 
-try {
-  await runMain(main, { rawArgs });
-} finally {
-  await telemetry.shutdown();
+  try {
+    await runMain(main, { rawArgs });
+  } finally {
+    await telemetry.shutdown();
+  }
 }

--- a/packages/sync-client/src/cli/output.ts
+++ b/packages/sync-client/src/cli/output.ts
@@ -5,7 +5,7 @@ const GENERIC_MESSAGES: Record<string, string> = {
   gateway_unreachable: "Gateway unreachable. Matrix CLI could not contact your Matrix OS instance.",
   request_timeout: "Request timed out. Try again or run `mos doctor`.",
   zellij_failed: "Shell backend unavailable. Your Matrix OS instance could not start a shell session.",
-  unsupported_node: "Matrix CLI requires Node.js 24 or newer.",
+  unsupported_node: "Matrix CLI requires Node.js 20 or newer.",
   attach_failed: "Shell attach failed.",
   attach_timeout: "Shell attach timed out. Try again or run `mos doctor`.",
   login_failed: "Login failed. Run `mos login` to retry.",

--- a/packages/sync-client/src/cli/standalone-runtime.ts
+++ b/packages/sync-client/src/cli/standalone-runtime.ts
@@ -1,0 +1,18 @@
+type RuntimeVersions = NodeJS.ProcessVersions & {
+  bun?: string;
+};
+
+export function isStandaloneRuntime(
+  env: NodeJS.ProcessEnv = process.env,
+  versions: RuntimeVersions = process.versions as RuntimeVersions,
+): boolean {
+  return env.MATRIX_CLI_STANDALONE === "1" && typeof versions.bun === "string";
+}
+
+export function shouldRunStandaloneDaemon(
+  rawArgs: string[],
+  env: NodeJS.ProcessEnv = process.env,
+  versions: RuntimeVersions = process.versions as RuntimeVersions,
+): boolean {
+  return rawArgs[0] === "__daemon" && isStandaloneRuntime(env, versions);
+}

--- a/packages/sync-client/src/cli/standalone-runtime.ts
+++ b/packages/sync-client/src/cli/standalone-runtime.ts
@@ -2,11 +2,16 @@ type RuntimeVersions = NodeJS.ProcessVersions & {
   bun?: string;
 };
 
+const bakedStandaloneMarker = process.env.MATRIX_CLI_STANDALONE;
+
 export function isStandaloneRuntime(
-  env: NodeJS.ProcessEnv = process.env,
+  env?: NodeJS.ProcessEnv,
   versions: RuntimeVersions = process.versions as RuntimeVersions,
 ): boolean {
-  return env.MATRIX_CLI_STANDALONE === "1" && typeof versions.bun === "string";
+  const standaloneMarker = env === undefined
+    ? bakedStandaloneMarker
+    : env.MATRIX_CLI_STANDALONE;
+  return standaloneMarker === "1" && typeof versions.bun === "string";
 }
 
 export function shouldRunStandaloneDaemon(

--- a/packages/sync-client/src/cli/telemetry.ts
+++ b/packages/sync-client/src/cli/telemetry.ts
@@ -1,5 +1,3 @@
-import { PostHog } from "posthog-node";
-
 /**
  * Anonymous CLI telemetry. Mirrors the env precedence of
  * `getPostHogConfig` in @matrix-os/observability, replicated here because
@@ -21,6 +19,7 @@ const TOKEN_ENV_KEYS = [
 ];
 const HOST_ENV_KEYS = ["POSTHOG_HOST", "NEXT_PUBLIC_POSTHOG_HOST"];
 
+const DEFAULT_POSTHOG_HOST = "https://us.i.posthog.com";
 const DEFAULT_SHUTDOWN_TIMEOUT_MS = 2_000;
 
 export const CLI_TELEMETRY_EVENTS = {
@@ -51,6 +50,7 @@ export interface CliTelemetryLogger {
 export interface CreateCliTelemetryOptions {
   env?: EnvSource;
   clientFactory?: (config: CliTelemetryConfig) => CliTelemetryClient;
+  fetch?: typeof fetch;
   logger?: CliTelemetryLogger;
   shutdownTimeoutMs?: number;
 }
@@ -98,6 +98,50 @@ function resolveDistinctId(env: EnvSource): string {
   return env.MATRIX_USER_ID?.trim() || env.MATRIX_HANDLE?.trim() || "matrix-cli-anonymous";
 }
 
+function posthogCaptureUrl(host: string): string {
+  return `${host.replace(/\/+$/, "")}/capture/`;
+}
+
+function createFetchTelemetryClient(
+  config: CliTelemetryConfig,
+  fetchImpl: typeof fetch,
+  logger: CliTelemetryLogger,
+  timeoutMs: number,
+): CliTelemetryClient {
+  const pending = new Set<Promise<void>>();
+  const host = config.host ?? DEFAULT_POSTHOG_HOST;
+
+  async function send(input: CliTelemetryCaptureInput): Promise<void> {
+    const response = await fetchImpl(posthogCaptureUrl(host), {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        api_key: config.token,
+        distinct_id: input.distinctId,
+        event: input.event,
+        properties: input.properties,
+      }),
+      signal: AbortSignal.timeout(timeoutMs),
+    });
+    if (!response.ok) {
+      logger.warn(`[telemetry] capture failed: Http${response.status}`);
+    }
+  }
+
+  return {
+    capture(input) {
+      const operation = send(input).catch((err: unknown) => {
+        logger.warn(`[telemetry] capture failed: ${errorKind(err)}`);
+      });
+      pending.add(operation);
+      operation.finally(() => pending.delete(operation));
+    },
+    shutdown() {
+      return Promise.allSettled([...pending]);
+    },
+  };
+}
+
 export function createCliTelemetry(options: CreateCliTelemetryOptions = {}): CliTelemetry {
   const env = options.env ?? process.env;
   const logger = options.logger ?? console;
@@ -122,14 +166,7 @@ export function createCliTelemetry(options: CreateCliTelemetryOptions = {}): Cli
       const config: CliTelemetryConfig = host ? { token, host } : { token };
       client = options.clientFactory
         ? options.clientFactory(config)
-        : new PostHog(config.token, {
-            ...(config.host ? { host: config.host } : {}),
-            // Short-lived process: send each event immediately, no batching,
-            // no geo lookups.
-            flushAt: 1,
-            flushInterval: 0,
-            disableGeoip: true,
-          });
+        : createFetchTelemetryClient(config, options.fetch ?? fetch, logger, shutdownTimeoutMs);
     }
     return client;
   }

--- a/packages/sync-client/src/cli/version.ts
+++ b/packages/sync-client/src/cli/version.ts
@@ -2,16 +2,33 @@ import { createRequire } from "node:module";
 
 const require = createRequire(import.meta.url);
 
+interface VersionLogger {
+  warn(message: string, detail: string): void;
+}
+
 export function resolveCliVersion(): string {
   if (process.env.MATRIX_CLI_VERSION) {
     return process.env.MATRIX_CLI_VERSION;
   }
 
+  return resolveCliVersionFromPackage(
+    () => require("../../package.json") as { version?: string },
+    console,
+  );
+}
+
+export function resolveCliVersionFromPackage(
+  readPackageJson: () => { version?: string },
+  logger: VersionLogger,
+): string {
   try {
-    const pkg = require("../../package.json") as { version?: string };
+    const pkg = readPackageJson();
     return typeof pkg.version === "string" && pkg.version.length > 0 ? pkg.version : "0.0.0";
   } catch (err) {
-    void err;
+    logger.warn(
+      "[cli/version] failed to read package version:",
+      err instanceof Error ? err.message : String(err),
+    );
     return "0.0.0";
   }
 }

--- a/packages/sync-client/src/cli/version.ts
+++ b/packages/sync-client/src/cli/version.ts
@@ -1,0 +1,17 @@
+import { createRequire } from "node:module";
+
+const require = createRequire(import.meta.url);
+
+export function resolveCliVersion(): string {
+  if (process.env.MATRIX_CLI_VERSION) {
+    return process.env.MATRIX_CLI_VERSION;
+  }
+
+  try {
+    const pkg = require("../../package.json") as { version?: string };
+    return typeof pkg.version === "string" && pkg.version.length > 0 ? pkg.version : "0.0.0";
+  } catch (err) {
+    void err;
+    return "0.0.0";
+  }
+}

--- a/packages/sync-client/src/daemon/service.ts
+++ b/packages/sync-client/src/daemon/service.ts
@@ -45,8 +45,14 @@ export function escapeSystemdUnitValue(value: string): string {
   return Array.from(value, (char) => {
     if (char === "%") return "%%";
     if (/^[A-Za-z0-9/:_.-]$/.test(char)) return char;
-    const hex = char.codePointAt(0)?.toString(16).padStart(2, "0");
-    return hex === undefined ? "" : `\\x${hex}`;
+    const codePoint = char.codePointAt(0);
+    if (codePoint === undefined) return "";
+    if (codePoint > 0x7f) {
+      return codePoint <= 0xffff
+        ? `\\u${codePoint.toString(16).padStart(4, "0")}`
+        : `\\U${codePoint.toString(16).padStart(8, "0")}`;
+    }
+    return `\\x${codePoint.toString(16).padStart(2, "0")}`;
   }).join("");
 }
 

--- a/packages/sync-client/src/daemon/service.ts
+++ b/packages/sync-client/src/daemon/service.ts
@@ -31,6 +31,16 @@ export function escapeXml(value: string): string {
     .replaceAll("'", "&apos;");
 }
 
+export function escapeSystemdExecArg(value: string): string {
+  if (/^[^\s"'\\%$]+$/.test(value)) return value;
+  return `"${value
+    .replaceAll("\\", "\\\\")
+    .replaceAll('"', '\\"')
+    .replaceAll("%", "%%")
+    .replaceAll("$", () => "$$")
+  }"`;
+}
+
 // Walk up from `daemonPath` to find the directory containing node_modules/tsx.
 // launchd/systemd give the spawned process an empty cwd, so node module
 // resolution can't find tsx unless we set WorkingDirectory there.
@@ -99,7 +109,7 @@ After=network.target
 [Service]
 Type=simple
 WorkingDirectory=${command.workingDirectory}
-ExecStart=${[command.executable, ...command.args].join(" ")}
+ExecStart=${[command.executable, ...command.args].map(escapeSystemdExecArg).join(" ")}
 Restart=on-failure
 RestartSec=5
 

--- a/packages/sync-client/src/daemon/service.ts
+++ b/packages/sync-client/src/daemon/service.ts
@@ -16,6 +16,12 @@ function execFileAsync(cmd: string, args: string[]): Promise<void> {
 
 const LABEL = "com.matrixos.sync";
 
+export interface DaemonServiceCommand {
+  executable: string;
+  args: string[];
+  workingDirectory: string;
+}
+
 export function escapeXml(value: string): string {
   return value
     .replaceAll("&", "&amp;")
@@ -39,7 +45,27 @@ function findRepoRoot(start: string): string {
   return dirname(start);
 }
 
-function launchdPlist(daemonPath: string, logDir: string, workDir: string): string {
+export function createSourceDaemonServiceCommand(daemonPath: string): DaemonServiceCommand {
+  const resolvedDaemonPath = resolve(daemonPath);
+  return {
+    executable: process.execPath,
+    args: [resolvedDaemonPath],
+    workingDirectory: findRepoRoot(resolvedDaemonPath),
+  };
+}
+
+export function createStandaloneDaemonServiceCommand(
+  executable = process.execPath,
+  workingDirectory = homedir(),
+): DaemonServiceCommand {
+  return {
+    executable,
+    args: ["__daemon"],
+    workingDirectory,
+  };
+}
+
+export function launchdPlist(command: DaemonServiceCommand, logDir: string): string {
   return `<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
@@ -48,11 +74,11 @@ function launchdPlist(daemonPath: string, logDir: string, workDir: string): stri
   <string>${LABEL}</string>
   <key>ProgramArguments</key>
   <array>
-    <string>${escapeXml(process.execPath)}</string>
-    <string>${escapeXml(daemonPath)}</string>
+    <string>${escapeXml(command.executable)}</string>
+${command.args.map((arg) => `    <string>${escapeXml(arg)}</string>`).join("\n")}
   </array>
   <key>WorkingDirectory</key>
-  <string>${escapeXml(workDir)}</string>
+  <string>${escapeXml(command.workingDirectory)}</string>
   <key>KeepAlive</key>
   <true/>
   <key>RunAtLoad</key>
@@ -65,15 +91,15 @@ function launchdPlist(daemonPath: string, logDir: string, workDir: string): stri
 </plist>`;
 }
 
-function systemdUnit(daemonPath: string, workDir: string): string {
+export function systemdUnit(command: DaemonServiceCommand): string {
   return `[Unit]
 Description=Matrix OS Sync Daemon
 After=network.target
 
 [Service]
 Type=simple
-WorkingDirectory=${workDir}
-ExecStart=${process.execPath} ${daemonPath}
+WorkingDirectory=${command.workingDirectory}
+ExecStart=${[command.executable, ...command.args].join(" ")}
 Restart=on-failure
 RestartSec=5
 
@@ -82,17 +108,16 @@ WantedBy=default.target
 `;
 }
 
-export async function installService(daemonPath: string): Promise<string> {
+export async function installService(command: DaemonServiceCommand): Promise<string> {
   const os = platform();
   const logDir = join(homedir(), ".matrixos", "logs");
   await mkdir(logDir, { recursive: true });
-  const workDir = findRepoRoot(resolve(daemonPath));
 
   if (os === "darwin") {
     const plistDir = join(homedir(), "Library", "LaunchAgents");
     await mkdir(plistDir, { recursive: true });
     const plistPath = join(plistDir, `${LABEL}.plist`);
-    await writeUtf8FileAtomic(plistPath, launchdPlist(daemonPath, logDir, workDir));
+    await writeUtf8FileAtomic(plistPath, launchdPlist(command, logDir));
     return plistPath;
   }
 
@@ -105,7 +130,7 @@ export async function installService(daemonPath: string): Promise<string> {
     );
     await mkdir(unitDir, { recursive: true });
     const unitPath = join(unitDir, "matrixos-sync.service");
-    await writeUtf8FileAtomic(unitPath, systemdUnit(daemonPath, workDir));
+    await writeUtf8FileAtomic(unitPath, systemdUnit(command));
     return unitPath;
   }
 

--- a/packages/sync-client/src/daemon/service.ts
+++ b/packages/sync-client/src/daemon/service.ts
@@ -41,6 +41,15 @@ export function escapeSystemdExecArg(value: string): string {
   }"`;
 }
 
+export function escapeSystemdUnitValue(value: string): string {
+  const escaped = value
+    .replaceAll("\\", "\\\\")
+    .replaceAll('"', '\\"')
+    .replaceAll("%", "%%");
+  if (/^[^\s"\\%]+$/.test(value)) return escaped;
+  return `"${escaped}"`;
+}
+
 // Walk up from `daemonPath` to find the directory containing node_modules/tsx.
 // launchd/systemd give the spawned process an empty cwd, so node module
 // resolution can't find tsx unless we set WorkingDirectory there.
@@ -108,7 +117,7 @@ After=network.target
 
 [Service]
 Type=simple
-WorkingDirectory=${command.workingDirectory}
+WorkingDirectory=${escapeSystemdUnitValue(command.workingDirectory)}
 ExecStart=${[command.executable, ...command.args].map(escapeSystemdExecArg).join(" ")}
 Restart=on-failure
 RestartSec=5

--- a/packages/sync-client/src/daemon/service.ts
+++ b/packages/sync-client/src/daemon/service.ts
@@ -118,6 +118,14 @@ WantedBy=default.target
 `;
 }
 
+export function linuxStartServiceCommands(): string[][] {
+  return [
+    ["--user", "daemon-reload"],
+    ["--user", "enable", "matrixos-sync.service"],
+    ["--user", "restart", "matrixos-sync.service"],
+  ];
+}
+
 export async function installService(command: DaemonServiceCommand): Promise<string> {
   const os = platform();
   const logDir = join(homedir(), ".matrixos", "logs");
@@ -165,18 +173,15 @@ export async function startService(): Promise<void> {
   }
 
   if (os === "linux") {
-    await execFileAsync("systemctl", ["--user", "daemon-reload"]).catch((err: unknown) => {
+    const [daemonReload, enable, restart] = linuxStartServiceCommands();
+    await execFileAsync("systemctl", daemonReload).catch((err: unknown) => {
       console.warn(
         "[sync/service] systemctl daemon-reload failed:",
         err instanceof Error ? err.message : String(err),
       );
     });
-    await execFileAsync("systemctl", [
-      "--user",
-      "enable",
-      "--now",
-      "matrixos-sync.service",
-    ]);
+    await execFileAsync("systemctl", enable);
+    await execFileAsync("systemctl", restart);
     return;
   }
 

--- a/packages/sync-client/src/daemon/service.ts
+++ b/packages/sync-client/src/daemon/service.ts
@@ -42,12 +42,12 @@ export function escapeSystemdExecArg(value: string): string {
 }
 
 export function escapeSystemdUnitValue(value: string): string {
-  const escaped = value
-    .replaceAll("\\", "\\\\")
-    .replaceAll('"', '\\"')
-    .replaceAll("%", "%%");
-  if (/^[^\s"\\%]+$/.test(value)) return escaped;
-  return `"${escaped}"`;
+  return Array.from(value, (char) => {
+    if (char === "%") return "%%";
+    if (/^[A-Za-z0-9/:_.-]$/.test(char)) return char;
+    const hex = char.codePointAt(0)?.toString(16).padStart(2, "0");
+    return hex === undefined ? "" : `\\x${hex}`;
+  }).join("");
 }
 
 // Walk up from `daemonPath` to find the directory containing node_modules/tsx.

--- a/packages/sync-client/src/lib/config.ts
+++ b/packages/sync-client/src/lib/config.ts
@@ -28,6 +28,7 @@ export const SyncConfigSchema = z.object({
   folders: z.array(z.string()).optional(),
   exclude: z.array(z.string()).optional(),
   pauseSync: z.boolean().default(false),
+  syncDaemonRuntime: z.enum(["source", "standalone"]).optional(),
 });
 
 export type SyncConfig = z.infer<typeof SyncConfigSchema>;

--- a/packages/sync-client/src/lib/node-runtime-guard.mjs
+++ b/packages/sync-client/src/lib/node-runtime-guard.mjs
@@ -1,4 +1,4 @@
-export const MIN_NODE_MAJOR = 24;
+export const MIN_NODE_MAJOR = 20;
 
 export function nodeMajor(version) {
   const match = /^v?(\d+)\./.exec(String(version));
@@ -11,7 +11,7 @@ export function isSupportedNodeVersion(version) {
 }
 
 export function unsupportedNodeMessage(version) {
-  return `Matrix CLI requires Node.js 24 or newer (current: ${version}).`;
+  return `Matrix CLI requires Node.js 20 or newer (current: ${version}).`;
 }
 
 export function hasJsonFlag(argv) {

--- a/packages/sync-client/tests/unit/node-runtime-guard.test.ts
+++ b/packages/sync-client/tests/unit/node-runtime-guard.test.ts
@@ -5,25 +5,27 @@ import {
 } from "../../src/lib/node-runtime-guard.mjs";
 
 describe("node runtime guard", () => {
-  it("rejects Node versions older than 24", () => {
-    expect(isSupportedNodeVersion("v20.17.0")).toBe(false);
-    expect(isSupportedNodeVersion("v22.12.0")).toBe(false);
+  it("rejects Node versions older than 20", () => {
+    expect(isSupportedNodeVersion("v18.20.0")).toBe(false);
+    expect(isSupportedNodeVersion("v19.9.0")).toBe(false);
   });
 
-  it("allows Node 24 and newer", () => {
+  it("allows Node 20 and newer", () => {
+    expect(isSupportedNodeVersion("v20.0.0")).toBe(true);
+    expect(isSupportedNodeVersion("v22.12.0")).toBe(true);
     expect(isSupportedNodeVersion("v24.0.0")).toBe(true);
     expect(isSupportedNodeVersion("v25.1.0")).toBe(true);
   });
 
   it("formats safe human and JSON unsupported-node errors", () => {
-    expect(formatUnsupportedNodeError("v20.17.0", false)).toBe(
-      "Error: Matrix CLI requires Node.js 24 or newer (current: v20.17.0).",
+    expect(formatUnsupportedNodeError("v18.20.0", false)).toBe(
+      "Error: Matrix CLI requires Node.js 20 or newer (current: v18.20.0).",
     );
-    expect(JSON.parse(formatUnsupportedNodeError("v20.17.0", true))).toEqual({
+    expect(JSON.parse(formatUnsupportedNodeError("v18.20.0", true))).toEqual({
       v: 1,
       error: {
         code: "unsupported_node",
-        message: "Matrix CLI requires Node.js 24 or newer (current: v20.17.0).",
+        message: "Matrix CLI requires Node.js 20 or newer (current: v18.20.0).",
       },
     });
   });

--- a/packages/sync-client/tests/unit/service.test.ts
+++ b/packages/sync-client/tests/unit/service.test.ts
@@ -33,9 +33,9 @@ describe("escapeSystemdExecArg", () => {
 });
 
 describe("escapeSystemdUnitValue", () => {
-  it("escapes systemd specifiers in WorkingDirectory values", () => {
+  it("escapes systemd specifiers and whitespace in WorkingDirectory values", () => {
     expect(escapeSystemdUnitValue("/home/User Name/%h/project")).toBe(
-      '"/home/User Name/%%h/project"',
+      "/home/User\\x20Name/%%h/project",
     );
   });
 });
@@ -82,7 +82,7 @@ describe("daemon service command rendering", () => {
       "/home/User Name/%h",
     );
 
-    expect(systemdUnit(command)).toContain('WorkingDirectory="/home/User Name/%%h"');
+    expect(systemdUnit(command)).toContain("WorkingDirectory=/home/User\\x20Name/%%h");
   });
 });
 

--- a/packages/sync-client/tests/unit/service.test.ts
+++ b/packages/sync-client/tests/unit/service.test.ts
@@ -38,6 +38,12 @@ describe("escapeSystemdUnitValue", () => {
       "/home/User\\x20Name/%%h/project",
     );
   });
+
+  it("uses systemd Unicode escapes for non-ASCII WorkingDirectory values", () => {
+    expect(escapeSystemdUnitValue("/home/Zoë/🚀/%h")).toBe(
+      "/home/Zo\\u00eb/\\U0001f680/%%h",
+    );
+  });
 });
 
 describe("daemon service command rendering", () => {

--- a/packages/sync-client/tests/unit/service.test.ts
+++ b/packages/sync-client/tests/unit/service.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   createSourceDaemonServiceCommand,
   createStandaloneDaemonServiceCommand,
+  escapeSystemdUnitValue,
   escapeSystemdExecArg,
   escapeXml,
   launchdPlist,
@@ -27,6 +28,14 @@ describe("escapeSystemdExecArg", () => {
   it("quotes systemd ExecStart arguments that need escaping", () => {
     expect(escapeSystemdExecArg('/home/User Name/bin/matrix"$\\%')).toBe(
       '"/home/User Name/bin/matrix\\"$$\\\\%%"',
+    );
+  });
+});
+
+describe("escapeSystemdUnitValue", () => {
+  it("escapes systemd specifiers in WorkingDirectory values", () => {
+    expect(escapeSystemdUnitValue("/home/User Name/%h/project")).toBe(
+      '"/home/User Name/%%h/project"',
     );
   });
 });
@@ -65,6 +74,15 @@ describe("daemon service command rendering", () => {
       "<string>/home/User Name/.local/bin/matrix</string>",
     );
     expect(plist).toContain("<string>__daemon</string>");
+  });
+
+  it("escapes standalone working directories before writing systemd units", () => {
+    const command = createStandaloneDaemonServiceCommand(
+      "/home/user/.local/bin/matrix",
+      "/home/User Name/%h",
+    );
+
+    expect(systemdUnit(command)).toContain('WorkingDirectory="/home/User Name/%%h"');
   });
 });
 

--- a/packages/sync-client/tests/unit/service.test.ts
+++ b/packages/sync-client/tests/unit/service.test.ts
@@ -5,6 +5,7 @@ import {
   escapeSystemdExecArg,
   escapeXml,
   launchdPlist,
+  linuxStartServiceCommands,
   systemdUnit,
 } from "../../src/daemon/service.js";
 
@@ -64,5 +65,15 @@ describe("daemon service command rendering", () => {
       "<string>/home/User Name/.local/bin/matrix</string>",
     );
     expect(plist).toContain("<string>__daemon</string>");
+  });
+});
+
+describe("linuxStartServiceCommands", () => {
+  it("restarts an already-active service so rewritten units take effect", () => {
+    expect(linuxStartServiceCommands()).toEqual([
+      ["--user", "daemon-reload"],
+      ["--user", "enable", "matrixos-sync.service"],
+      ["--user", "restart", "matrixos-sync.service"],
+    ]);
   });
 });

--- a/packages/sync-client/tests/unit/service.test.ts
+++ b/packages/sync-client/tests/unit/service.test.ts
@@ -1,10 +1,49 @@
 import { describe, expect, it } from "vitest";
-import { escapeXml } from "../../src/daemon/service.js";
+import {
+  createSourceDaemonServiceCommand,
+  createStandaloneDaemonServiceCommand,
+  escapeXml,
+  launchdPlist,
+  systemdUnit,
+} from "../../src/daemon/service.js";
 
 describe("escapeXml", () => {
   it("escapes launchd XML metacharacters in interpolated paths", () => {
     expect(escapeXml(`bad<&>"'path`)).toBe(
       "bad&lt;&amp;&gt;&quot;&apos;path",
     );
+  });
+});
+
+describe("daemon service command rendering", () => {
+  it("keeps source installs pointed at the daemon launcher file", () => {
+    const command = createSourceDaemonServiceCommand(
+      "/repo/packages/sync-client/src/daemon/launcher.mjs",
+    );
+    const unit = systemdUnit(command);
+
+    expect(command.executable).toBe(process.execPath);
+    expect(command.args).toEqual([
+      "/repo/packages/sync-client/src/daemon/launcher.mjs",
+    ]);
+    expect(unit).toContain(
+      `ExecStart=${process.execPath} /repo/packages/sync-client/src/daemon/launcher.mjs`,
+    );
+  });
+
+  it("points standalone binary installs at the bundled daemon entrypoint", () => {
+    const command = createStandaloneDaemonServiceCommand(
+      "/home/user/.local/bin/matrix",
+      "/home/user",
+    );
+    const unit = systemdUnit(command);
+    const plist = launchdPlist(command, "/home/user/.matrixos/logs");
+
+    expect(command.args).toEqual(["__daemon"]);
+    expect(unit).toContain("WorkingDirectory=/home/user");
+    expect(unit).toContain("ExecStart=/home/user/.local/bin/matrix __daemon");
+    expect(unit).not.toContain("/daemon/launcher.mjs");
+    expect(plist).toContain("<string>/home/user/.local/bin/matrix</string>");
+    expect(plist).toContain("<string>__daemon</string>");
   });
 });

--- a/packages/sync-client/tests/unit/service.test.ts
+++ b/packages/sync-client/tests/unit/service.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   createSourceDaemonServiceCommand,
   createStandaloneDaemonServiceCommand,
+  escapeSystemdExecArg,
   escapeXml,
   launchdPlist,
   systemdUnit,
@@ -11,6 +12,20 @@ describe("escapeXml", () => {
   it("escapes launchd XML metacharacters in interpolated paths", () => {
     expect(escapeXml(`bad<&>"'path`)).toBe(
       "bad&lt;&amp;&gt;&quot;&apos;path",
+    );
+  });
+});
+
+describe("escapeSystemdExecArg", () => {
+  it("leaves simple systemd ExecStart arguments unquoted", () => {
+    expect(escapeSystemdExecArg("/home/user/.local/bin/matrix")).toBe(
+      "/home/user/.local/bin/matrix",
+    );
+  });
+
+  it("quotes systemd ExecStart arguments that need escaping", () => {
+    expect(escapeSystemdExecArg('/home/User Name/bin/matrix"$\\%')).toBe(
+      '"/home/User Name/bin/matrix\\"$$\\\\%%"',
     );
   });
 });
@@ -33,7 +48,7 @@ describe("daemon service command rendering", () => {
 
   it("points standalone binary installs at the bundled daemon entrypoint", () => {
     const command = createStandaloneDaemonServiceCommand(
-      "/home/user/.local/bin/matrix",
+      "/home/User Name/.local/bin/matrix",
       "/home/user",
     );
     const unit = systemdUnit(command);
@@ -41,9 +56,13 @@ describe("daemon service command rendering", () => {
 
     expect(command.args).toEqual(["__daemon"]);
     expect(unit).toContain("WorkingDirectory=/home/user");
-    expect(unit).toContain("ExecStart=/home/user/.local/bin/matrix __daemon");
+    expect(unit).toContain(
+      'ExecStart="/home/User Name/.local/bin/matrix" __daemon',
+    );
     expect(unit).not.toContain("/daemon/launcher.mjs");
-    expect(plist).toContain("<string>/home/user/.local/bin/matrix</string>");
+    expect(plist).toContain(
+      "<string>/home/User Name/.local/bin/matrix</string>",
+    );
     expect(plist).toContain("<string>__daemon</string>");
   });
 });

--- a/packages/sync-client/tests/unit/standalone-runtime.test.ts
+++ b/packages/sync-client/tests/unit/standalone-runtime.test.ts
@@ -1,7 +1,26 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { isStandaloneRuntime, shouldRunStandaloneDaemon } from "../../src/cli/standalone-runtime.js";
 
 describe("isStandaloneRuntime", () => {
+  it("uses the baked standalone marker when no test env is injected", async () => {
+    const previousMarker = process.env.MATRIX_CLI_STANDALONE;
+    process.env.MATRIX_CLI_STANDALONE = "1";
+    vi.resetModules();
+    const module = await import("../../src/cli/standalone-runtime.js");
+
+    try {
+      expect(module.isStandaloneRuntime(undefined, { bun: "1.3.13" })).toBe(true);
+      expect(module.isStandaloneRuntime({}, { bun: "1.3.13" })).toBe(false);
+    } finally {
+      if (previousMarker === undefined) {
+        delete process.env.MATRIX_CLI_STANDALONE;
+      } else {
+        process.env.MATRIX_CLI_STANDALONE = previousMarker;
+      }
+      vi.resetModules();
+    }
+  });
+
   it("requires both the baked standalone env marker and Bun runtime", () => {
     expect(
       isStandaloneRuntime(

--- a/packages/sync-client/tests/unit/standalone-runtime.test.ts
+++ b/packages/sync-client/tests/unit/standalone-runtime.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import { isStandaloneRuntime, shouldRunStandaloneDaemon } from "../../src/cli/standalone-runtime.js";
+
+describe("isStandaloneRuntime", () => {
+  it("requires both the baked standalone env marker and Bun runtime", () => {
+    expect(
+      isStandaloneRuntime(
+        { MATRIX_CLI_STANDALONE: "1" },
+        { bun: "1.3.13" },
+      ),
+    ).toBe(true);
+    expect(
+      isStandaloneRuntime(
+        { MATRIX_CLI_STANDALONE: "1" },
+        {},
+      ),
+    ).toBe(false);
+    expect(
+      isStandaloneRuntime(
+        {},
+        { bun: "1.3.13" },
+      ),
+    ).toBe(false);
+  });
+});
+
+describe("shouldRunStandaloneDaemon", () => {
+  it("only dispatches __daemon inside standalone binaries", () => {
+    expect(
+      shouldRunStandaloneDaemon(
+        ["__daemon"],
+        { MATRIX_CLI_STANDALONE: "1" },
+        { bun: "1.3.13" },
+      ),
+    ).toBe(true);
+    expect(
+      shouldRunStandaloneDaemon(
+        ["__daemon"],
+        {},
+        { bun: "1.3.13" },
+      ),
+    ).toBe(false);
+    expect(
+      shouldRunStandaloneDaemon(
+        ["sync"],
+        { MATRIX_CLI_STANDALONE: "1" },
+        { bun: "1.3.13" },
+      ),
+    ).toBe(false);
+  });
+});

--- a/packages/sync-client/tests/unit/sync-command-run.test.ts
+++ b/packages/sync-client/tests/unit/sync-command-run.test.ts
@@ -1,0 +1,126 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { SyncConfig } from "../../src/lib/config.js";
+
+const {
+  createSourceDaemonServiceCommandMock,
+  createStandaloneDaemonServiceCommandMock,
+  installServiceMock,
+  isDaemonRunningMock,
+  isStandaloneRuntimeMock,
+  loadConfigMock,
+  resolveCliProfileMock,
+  saveConfigMock,
+  sendCommandMock,
+  startServiceMock,
+} = vi.hoisted(() => ({
+  createSourceDaemonServiceCommandMock: vi.fn(() => ({
+    executable: "/usr/bin/node",
+    args: ["/repo/launcher.mjs"],
+    workingDirectory: "/repo",
+  })),
+  createStandaloneDaemonServiceCommandMock: vi.fn(() => ({
+    executable: "/home/user/.local/bin/matrix",
+    args: ["__daemon"],
+    workingDirectory: "/home/user",
+  })),
+  installServiceMock: vi.fn().mockResolvedValue("/service/path"),
+  isDaemonRunningMock: vi.fn().mockResolvedValue(true),
+  isStandaloneRuntimeMock: vi.fn(() => false),
+  loadConfigMock: vi.fn(),
+  resolveCliProfileMock: vi.fn().mockResolvedValue({
+    name: "cloud",
+    platformUrl: "https://platform.example",
+    gatewayUrl: "https://gateway.example",
+  }),
+  saveConfigMock: vi.fn().mockResolvedValue(undefined),
+  sendCommandMock: vi.fn(),
+  startServiceMock: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("../../src/lib/config.js", () => ({
+  defaultSyncPath: () => "/tmp/matrixos-sync-command-test",
+  generatePeerId: () => "peer-generated",
+  loadConfig: loadConfigMock,
+  saveConfig: saveConfigMock,
+}));
+
+vi.mock("../../src/cli/daemon-client.js", () => ({
+  isDaemonClientError: () => false,
+  isDaemonRunning: isDaemonRunningMock,
+  sendCommand: sendCommandMock,
+}));
+
+vi.mock("../../src/daemon/service.js", () => ({
+  createSourceDaemonServiceCommand: createSourceDaemonServiceCommandMock,
+  createStandaloneDaemonServiceCommand: createStandaloneDaemonServiceCommandMock,
+  installService: installServiceMock,
+  startService: startServiceMock,
+}));
+
+vi.mock("../../src/cli/profiles.js", () => ({
+  resolveCliProfile: resolveCliProfileMock,
+}));
+
+vi.mock("../../src/cli/standalone-runtime.js", () => ({
+  isStandaloneRuntime: isStandaloneRuntimeMock,
+}));
+
+function previousConfig(overrides: Partial<SyncConfig> = {}): SyncConfig {
+  return {
+    gatewayUrl: "https://old-gateway.example",
+    syncPath: "/tmp/matrixos-sync-command-test",
+    gatewayFolder: "",
+    peerId: "peer-1",
+    pauseSync: false,
+    platformUrl: "https://old-platform.example",
+    profile: "old",
+    syncDaemonRuntime: "source",
+    ...overrides,
+  };
+}
+
+async function runSync(args: Record<string, unknown> = {}, rawArgs: string[] = []): Promise<void> {
+  const mod = await import("../../src/cli/commands/sync.js");
+  await mod.syncCommand.run!({ args: { json: false, ...args }, rawArgs } as never);
+}
+
+beforeEach(() => {
+  vi.resetModules();
+  createSourceDaemonServiceCommandMock.mockClear();
+  createStandaloneDaemonServiceCommandMock.mockClear();
+  installServiceMock.mockClear();
+  isDaemonRunningMock.mockClear();
+  isDaemonRunningMock.mockResolvedValue(true);
+  isStandaloneRuntimeMock.mockClear();
+  isStandaloneRuntimeMock.mockReturnValue(false);
+  loadConfigMock.mockClear();
+  loadConfigMock.mockResolvedValue(previousConfig());
+  resolveCliProfileMock.mockClear();
+  saveConfigMock.mockClear();
+  sendCommandMock.mockClear();
+  startServiceMock.mockClear();
+  vi.spyOn(console, "log").mockImplementation(() => {});
+  vi.spyOn(console, "error").mockImplementation(() => {});
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("syncCommand start", () => {
+  it("persists refreshed config before returning when the correct daemon is already running", async () => {
+    await runSync();
+
+    expect(installServiceMock).not.toHaveBeenCalled();
+    expect(startServiceMock).not.toHaveBeenCalled();
+    expect(saveConfigMock).toHaveBeenCalledTimes(1);
+    expect(saveConfigMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        gatewayUrl: "https://gateway.example",
+        platformUrl: "https://platform.example",
+        profile: "cloud",
+        syncDaemonRuntime: "source",
+      }),
+    );
+  });
+});

--- a/packages/sync-client/tests/unit/sync-command.test.ts
+++ b/packages/sync-client/tests/unit/sync-command.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import { shouldReuseRunningSyncService } from "../../src/cli/commands/sync.js";
+import type { SyncConfig } from "../../src/lib/config.js";
+
+function config(overrides: Partial<SyncConfig> = {}): SyncConfig {
+  return {
+    gatewayUrl: "https://app.matrix-os.com",
+    syncPath: "/home/user/matrixos",
+    gatewayFolder: "",
+    peerId: "peer-1",
+    pauseSync: false,
+    ...overrides,
+  };
+}
+
+describe("shouldReuseRunningSyncService", () => {
+  it("does not reuse a running source service when the standalone CLI should own the daemon", () => {
+    expect(
+      shouldReuseRunningSyncService({
+        previous: config({ syncDaemonRuntime: "source" }),
+        syncPath: "/home/user/matrixos",
+        gatewayFolder: "",
+        currentRuntime: "standalone",
+      }),
+    ).toBe(false);
+  });
+
+  it("reuses an already-running standalone service for the same sync target", () => {
+    expect(
+      shouldReuseRunningSyncService({
+        previous: config({ syncDaemonRuntime: "standalone" }),
+        syncPath: "/home/user/matrixos",
+        gatewayFolder: "",
+        currentRuntime: "standalone",
+      }),
+    ).toBe(true);
+  });
+
+  it("keeps legacy source configs compatible when runtime metadata is absent", () => {
+    expect(
+      shouldReuseRunningSyncService({
+        previous: config(),
+        syncPath: "/home/user/matrixos",
+        gatewayFolder: "",
+        currentRuntime: "source",
+      }),
+    ).toBe(true);
+  });
+});

--- a/packages/sync-client/tests/unit/version.test.ts
+++ b/packages/sync-client/tests/unit/version.test.ts
@@ -1,0 +1,25 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { resolveCliVersionFromPackage } from "../../src/cli/version.js";
+
+describe("resolveCliVersionFromPackage", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("logs unexpected package version read failures before using the fallback", () => {
+    const warn = vi.fn();
+
+    expect(
+      resolveCliVersionFromPackage(
+        () => {
+          throw new Error("package read failed");
+        },
+        { warn },
+      ),
+    ).toBe("0.0.0");
+    expect(warn).toHaveBeenCalledWith(
+      "[cli/version] failed to read package version:",
+      "package read failed",
+    );
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -580,9 +580,6 @@ importers:
       pino-roll:
         specifier: ^2.1.0
         version: 2.2.0
-      posthog-node:
-        specifier: ^5.24.15
-        version: 5.28.4
       tsx:
         specifier: ^4.21.0
         version: 4.21.0

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -2,10 +2,9 @@
 # Matrix OS installer. Served at https://get.matrix-os.com.
 #
 # Platform detection:
-#   macOS   -> downloads the signed .pkg from the GitHub release and runs
-#              `installer -pkg`. Needs sudo for /Applications + /usr/local.
-#   Linux   -> `npm i -g @finnaai/matrix` (stop-gap until a standalone binary).
-#   Windows -> print a PowerShell install hint.
+#   macOS/Linux -> downloads the standalone `matrix` CLI binary from the
+#                  matching GitHub release and installs it on PATH.
+#   Windows     -> print a PowerShell install hint.
 #
 # Usage:
 #   curl -sL https://get.matrix-os.com | sh
@@ -13,6 +12,7 @@
 # Env overrides:
 #   MATRIX_VERSION   pin to a specific release tag (default: latest)
 #   MATRIX_CHANNEL   "stable" (default). Reserved for future pre-release lanes.
+#   MATRIX_INSTALL_DIR  override install directory (default: $HOME/.local/bin or /usr/local/bin)
 
 set -eu
 
@@ -52,7 +52,11 @@ fetch() {
 resolve_version() {
   # Turn "latest" into an actual tag so all downstream URLs are deterministic.
   if [ "$MATRIX_VERSION" != "latest" ]; then
-    printf '%s' "$MATRIX_VERSION"
+    case "$MATRIX_VERSION" in
+      cli-v*) printf '%s' "$MATRIX_VERSION" ;;
+      v*)     printf '%s' "$MATRIX_VERSION" ;;
+      *)      printf 'cli-v%s' "$MATRIX_VERSION" ;;
+    esac
     return
   fi
   # GitHub's /releases/latest endpoint 302s to /releases/tag/<tag>.
@@ -67,78 +71,160 @@ resolve_version() {
   fi
 }
 
-install_macos() {
-  echo "==> Matrix OS installer (macOS)"
+cli_version_from_tag() {
+  case "$1" in
+    cli-v*) printf '%s' "${1#cli-v}" ;;
+    v*)     printf '%s' "${1#v}" ;;
+    *)      printf '%s' "$1" ;;
+  esac
+}
+
+detect_asset_arch() {
+  ARCH="$(uname -m 2>/dev/null || echo unknown)"
+  case "$ARCH" in
+    x86_64|amd64) printf 'x64' ;;
+    arm64|aarch64) printf 'arm64' ;;
+    *) die "unsupported CPU architecture: $ARCH" ;;
+  esac
+}
+
+verify_checksum() {
+  FILE="$1"
+  SHA_FILE="$2"
+  EXPECTED="$(awk '{print $1}' "$SHA_FILE" | head -1)"
+  [ -n "$EXPECTED" ] || die "checksum file is empty"
+
+  if command -v sha256sum >/dev/null 2>&1; then
+    ACTUAL="$(sha256sum "$FILE" | awk '{print $1}')"
+  elif command -v shasum >/dev/null 2>&1; then
+    ACTUAL="$(shasum -a 256 "$FILE" | awk '{print $1}')"
+  else
+    die "need sha256sum or shasum to verify download"
+  fi
+
+  [ "$ACTUAL" = "$EXPECTED" ] || die "download checksum mismatch"
+}
+
+install_binary_unprivileged() {
+  INSTALL_DIR="$1"
+  if { [ -d "$INSTALL_DIR" ] || mkdir -p "$INSTALL_DIR" 2>/dev/null; } && [ -w "$INSTALL_DIR" ]; then
+    echo "==> Installing to $INSTALL_DIR/matrix"
+    TMP_BIN="$INSTALL_DIR/.matrix.tmp.$$"
+    rm -f "$TMP_BIN"
+    if cp "$BIN_PATH" "$TMP_BIN" && chmod 0755 "$TMP_BIN" && mv -f "$TMP_BIN" "$INSTALL_DIR/matrix"; then
+      ln -sf matrix "$INSTALL_DIR/matrixos"
+      ln -sf matrix "$INSTALL_DIR/mos"
+      return 0
+    fi
+    rm -f "$TMP_BIN"
+  fi
+  return 1
+}
+
+install_binary_with_sudo() {
+  INSTALL_DIR="$1"
   need sudo
-  TAG="$(resolve_version)"
-  # Release tags are v-prefixed (v0.2.0) but the .pkg asset strips the v
-  # (MatrixSync-0.2.0.pkg). Normalize both for URL construction.
-  VERSION="${TAG#v}"
+  echo "==> Installing to $INSTALL_DIR/matrix"
+  sudo mkdir -p "$INSTALL_DIR"
+  TMP_BIN="$INSTALL_DIR/.matrix.tmp.$$"
+  sudo rm -f "$TMP_BIN"
+  sudo install -m 0755 "$BIN_PATH" "$TMP_BIN"
+  sudo mv -f "$TMP_BIN" "$INSTALL_DIR/matrix"
+  sudo ln -sf matrix "$INSTALL_DIR/matrixos"
+  sudo ln -sf matrix "$INSTALL_DIR/mos"
+}
+
+install_cli_binary() {
+  ASSET_OS="$1"
+  TAG="${2:-$(resolve_version)}"
+  VERSION="$(cli_version_from_tag "$TAG")"
+  ASSET_ARCH="$(detect_asset_arch)"
+  ASSET="matrix-$VERSION-$ASSET_OS-$ASSET_ARCH"
+  BASE_URL="https://github.com/$MATRIX_REPO/releases/download/$TAG"
+
+  echo "==> Matrix OS CLI installer ($ASSET_OS/$ASSET_ARCH)"
   echo "    version: $VERSION"
 
   INSTALL_TMPDIR="$(mktemp -d)"
   trap 'rm -rf "$INSTALL_TMPDIR"' EXIT
 
-  PKG_URL="https://github.com/$MATRIX_REPO/releases/download/$TAG/MatrixSync-$VERSION.pkg"
-  PKG_PATH="$INSTALL_TMPDIR/MatrixSync.pkg"
+  BIN_PATH="$INSTALL_TMPDIR/matrix"
+  SHA_PATH="$INSTALL_TMPDIR/$ASSET.sha256"
 
-  echo "==> Downloading $PKG_URL"
-  fetch "$PKG_URL" "$PKG_PATH" || die "download failed. Check that $VERSION has a .pkg artefact."
+  echo "==> Downloading $BASE_URL/$ASSET"
+  fetch "$BASE_URL/$ASSET" "$BIN_PATH" || die "download failed. Check that $TAG has a $ASSET release asset."
+  fetch "$BASE_URL/$ASSET.sha256" "$SHA_PATH" || die "checksum download failed for $ASSET"
+  verify_checksum "$BIN_PATH" "$SHA_PATH"
+  chmod 0755 "$BIN_PATH"
 
-  # Gatekeeper sanity: verify the downloaded pkg is signed + notarised before
-  # asking the user for their sudo password.
-  echo "==> Verifying signature"
-  pkgutil --check-signature "$PKG_PATH" >/dev/null \
-    || die "downloaded pkg failed signature check"
-  spctl --assess --type install "$PKG_PATH" >/dev/null 2>&1 \
-    || echo "    (warning: spctl assess returned non-zero; continuing)"
-
-  echo "==> Installing (you'll be prompted for your password)"
-  sudo installer -pkg "$PKG_PATH" -target /
-
-  if command -v matrix >/dev/null 2>&1; then
-    echo "==> Installed: $(matrix --version 2>/dev/null || echo 'matrix')"
-    echo "Next: run 'matrix login' to sign in."
+  if [ -n "${MATRIX_INSTALL_DIR:-}" ]; then
+    INSTALL_DIR="$MATRIX_INSTALL_DIR"
+    install_binary_unprivileged "$INSTALL_DIR" || install_binary_with_sudo "$INSTALL_DIR"
+  elif [ -n "${HOME:-}" ] && install_binary_unprivileged "$HOME/.local/bin"; then
+    INSTALL_DIR="$HOME/.local/bin"
   else
-    echo "    matrix CLI not on PATH. You may need to open a new shell."
+    INSTALL_DIR="/usr/local/bin"
+    install_binary_unprivileged "$INSTALL_DIR" || install_binary_with_sudo "$INSTALL_DIR"
   fi
+
+  if "$INSTALL_DIR/matrix" --version >/dev/null 2>&1; then
+    echo "==> Installed: $("$INSTALL_DIR/matrix" --version 2>/dev/null)"
+  else
+    echo "==> Installed: $INSTALL_DIR/matrix"
+  fi
+  case ":$PATH:" in
+    *":$INSTALL_DIR:"*) ;;
+    *) echo "    Add $INSTALL_DIR to PATH or run '$INSTALL_DIR/matrix' directly." ;;
+  esac
+  echo "Next: run 'matrix login' to sign in."
+}
+
+install_macos() {
+  TAG="$(resolve_version)"
+  VERSION="$(cli_version_from_tag "$TAG")"
+  PKG_NAME="MatrixSync-$VERSION.pkg"
+  BASE_URL="https://github.com/$MATRIX_REPO/releases/download/$TAG"
+
+  echo "==> Matrix OS installer (macOS)"
+  echo "    version: $VERSION"
+
+  if [ -n "${MATRIX_INSTALL_DIR:-}" ]; then
+    echo "==> MATRIX_INSTALL_DIR set; installing CLI-only standalone binary"
+    install_cli_binary "darwin" "$TAG"
+    return
+  fi
+
+  INSTALL_TMPDIR="$(mktemp -d)"
+  trap 'rm -rf "$INSTALL_TMPDIR"' EXIT
+
+  PKG_PATH="$INSTALL_TMPDIR/$PKG_NAME"
+  echo "==> Checking for $BASE_URL/$PKG_NAME"
+  if fetch "$BASE_URL/$PKG_NAME" "$PKG_PATH"; then
+    need sudo
+    echo "==> Verifying package signature"
+    pkgutil --check-signature "$PKG_PATH" >/dev/null || die "downloaded pkg failed signature check"
+    spctl --assess --type install "$PKG_PATH" >/dev/null 2>&1 \
+      || echo "    (warning: spctl assess returned non-zero; continuing)"
+
+    echo "==> Installing MatrixSync.app and matrix CLI (you may be prompted for your password)"
+    sudo installer -pkg "$PKG_PATH" -target /
+
+    if command -v matrix >/dev/null 2>&1; then
+      echo "==> Installed: $(matrix --version 2>/dev/null || echo 'matrix')"
+    else
+      echo "==> Installed MatrixSync.app. Open a new shell if 'matrix' is not on PATH yet."
+    fi
+    echo "Next: run 'matrix login' to sign in."
+    return
+  fi
+
+  echo "==> macOS package not available for $TAG; installing CLI-only standalone binary"
+  rm -rf "$INSTALL_TMPDIR"
+  install_cli_binary "darwin" "$TAG"
 }
 
 install_linux() {
-  echo "==> Matrix OS installer (Linux)"
-  if ! command -v npm >/dev/null 2>&1; then
-    die "npm not found. Install Node.js 24+ from https://nodejs.org then re-run this script."
-  fi
-  # Check Node version. The CLI requires Node 24+.
-  NODE_MAJOR="$(node -p 'process.versions.node.split(".")[0]' 2>/dev/null || echo 0)"
-  case "$NODE_MAJOR" in
-    ''|*[!0-9]*) die "could not determine Node.js version. Ensure 'node' is on PATH." ;;
-  esac
-  if [ "$NODE_MAJOR" -lt 24 ]; then
-    die "Node.js 24 or newer required (detected $NODE_MAJOR). Upgrade at https://nodejs.org"
-  fi
-
-  VERSION="${MATRIX_VERSION#v}"
-  case "$MATRIX_VERSION" in
-    latest) NPM_SPEC="@finnaai/matrix" ;;
-    *)      NPM_SPEC="@finnaai/matrix@$VERSION" ;;
-  esac
-
-  # Prefer an unprivileged install when the user has npm prefix configured for
-  # it; otherwise fall back to sudo.
-  if [ -w "$(npm config get prefix 2>/dev/null)/lib/node_modules" ] 2>/dev/null; then
-    npm install -g "$NPM_SPEC"
-  else
-    echo "==> Installing globally (may prompt for sudo)"
-    sudo npm install -g "$NPM_SPEC"
-  fi
-
-  if command -v matrix >/dev/null 2>&1; then
-    echo "==> Installed: $(matrix --version 2>/dev/null || echo 'matrix')"
-    echo "Next: run 'matrix login' to sign in."
-  else
-    echo "    matrix not on PATH yet. Check your npm global prefix."
-  fi
+  install_cli_binary "linux"
 }
 
 install_windows() {
@@ -148,7 +234,7 @@ Windows installer is not available yet.
 Temporary workaround (PowerShell):
   npm install -g @finnaai/matrix
 
-Requires Node.js 24+ from https://nodejs.org.
+Requires Node.js 20+ from https://nodejs.org.
 WIN
   exit 1
 }

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -134,6 +134,14 @@ install_binary_with_sudo() {
   sudo ln -sf matrix "$INSTALL_DIR/mos"
 }
 
+existing_matrix_install_dir() {
+  EXISTING_MATRIX="$(command -v matrix 2>/dev/null || true)"
+  case "$EXISTING_MATRIX" in
+    */matrix) dirname "$EXISTING_MATRIX" ;;
+    *)        printf '' ;;
+  esac
+}
+
 install_cli_binary() {
   ASSET_OS="$1"
   TAG="${2:-$(resolve_version)}"
@@ -160,6 +168,9 @@ install_cli_binary() {
   if [ -n "${MATRIX_INSTALL_DIR:-}" ]; then
     INSTALL_DIR="$MATRIX_INSTALL_DIR"
     install_binary_unprivileged "$INSTALL_DIR" || install_binary_with_sudo "$INSTALL_DIR"
+  elif EXISTING_DIR="$(existing_matrix_install_dir)" && [ -n "$EXISTING_DIR" ]; then
+    INSTALL_DIR="$EXISTING_DIR"
+    install_binary_unprivileged "$INSTALL_DIR" || install_binary_with_sudo "$INSTALL_DIR"
   elif [ -n "${HOME:-}" ] && install_binary_unprivileged "$HOME/.local/bin"; then
     INSTALL_DIR="$HOME/.local/bin"
   else
@@ -176,6 +187,10 @@ install_cli_binary() {
     *":$INSTALL_DIR:"*) ;;
     *) echo "    Add $INSTALL_DIR to PATH or run '$INSTALL_DIR/matrix' directly." ;;
   esac
+  PATH_MATRIX="$(command -v matrix 2>/dev/null || true)"
+  if [ -n "$PATH_MATRIX" ] && [ "$PATH_MATRIX" != "$INSTALL_DIR/matrix" ]; then
+    echo "    Warning: current shell resolves 'matrix' to $PATH_MATRIX before $INSTALL_DIR/matrix."
+  fi
   echo "Next: run 'matrix login' to sign in."
 }
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -54,7 +54,7 @@ resolve_version() {
   if [ "$MATRIX_VERSION" != "latest" ]; then
     case "$MATRIX_VERSION" in
       cli-v*) printf '%s' "$MATRIX_VERSION" ;;
-      v*)     printf '%s' "$MATRIX_VERSION" ;;
+      v*)     printf 'cli-v%s' "${MATRIX_VERSION#v}" ;;
       *)      printf 'cli-v%s' "$MATRIX_VERSION" ;;
     esac
     return

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -128,8 +128,14 @@ install_binary_with_sudo() {
   sudo mkdir -p "$INSTALL_DIR"
   TMP_BIN="$INSTALL_DIR/.matrix.tmp.$$"
   sudo rm -f "$TMP_BIN"
-  sudo install -m 0755 "$BIN_PATH" "$TMP_BIN"
-  sudo mv -f "$TMP_BIN" "$INSTALL_DIR/matrix"
+  if ! sudo install -m 0755 "$BIN_PATH" "$TMP_BIN"; then
+    sudo rm -f "$TMP_BIN"
+    return 1
+  fi
+  if ! sudo mv -f "$TMP_BIN" "$INSTALL_DIR/matrix"; then
+    sudo rm -f "$TMP_BIN"
+    return 1
+  fi
   sudo ln -sf matrix "$INSTALL_DIR/matrixos"
   sudo ln -sf matrix "$INSTALL_DIR/mos"
 }

--- a/tests/cli/package-runner.test.ts
+++ b/tests/cli/package-runner.test.ts
@@ -55,6 +55,10 @@ describe("published CLI package runners", () => {
     expect(script).toContain('TMP_BIN="$INSTALL_DIR/.matrix.tmp.$$"');
     expect(script).toContain('mv -f "$TMP_BIN" "$INSTALL_DIR/matrix"');
     expect(script).toContain('sudo mv -f "$TMP_BIN" "$INSTALL_DIR/matrix"');
+    expect(script).toContain('sudo rm -f "$TMP_BIN"');
+    expect(script).toMatch(
+      /if ! sudo mv -f "\$TMP_BIN" "\$INSTALL_DIR\/matrix"; then\n\s+sudo rm -f "\$TMP_BIN"\n\s+return 1\n\s+fi/,
+    );
   });
 
   it("prefers upgrading the existing matrix command path before installing elsewhere", async () => {

--- a/tests/cli/package-runner.test.ts
+++ b/tests/cli/package-runner.test.ts
@@ -18,7 +18,8 @@ describe("published CLI package runners", () => {
     );
 
     expect(packageJson.name).toBe("@finnaai/matrix");
-    expect(packageJson.engines.node).toBe(">=24");
+    expect(packageJson.engines.node).toBe(">=20");
+    expect(packageJson.dependencies).not.toHaveProperty("posthog-node");
     expect(packageJson.bin).toEqual({
       matrix: "bin/matrix.mjs",
       matrixos: "bin/matrix.mjs",
@@ -32,8 +33,42 @@ describe("published CLI package runners", () => {
   });
 
   it("reports Node runtime prerequisites before loading the TypeScript CLI", () => {
-    expect(nodeMajor("24.14.1")).toBe(24);
-    expect(isSupportedNodeVersion("24.0.0")).toBe(true);
-    expect(formatUnsupportedNodeError("23.11.0", false)).toContain("Matrix CLI requires Node.js 24 or newer");
+    expect(nodeMajor("20.14.1")).toBe(20);
+    expect(isSupportedNodeVersion("20.0.0")).toBe(true);
+    expect(formatUnsupportedNodeError("19.11.0", false)).toContain("Matrix CLI requires Node.js 20 or newer");
+  });
+
+  it("ships the standalone binary build helper used by the release workflow", async () => {
+    const script = await readFile(
+      resolve(repoRoot, "packages/sync-client/scripts/build-binaries.mjs"),
+      "utf8",
+    );
+
+    expect(script).toContain('run("bun", [');
+    expect(script).toContain('MATRIX_CLI_STANDALONE: "1"');
+  });
+
+  it("installs standalone binary upgrades atomically", async () => {
+    const script = await readFile(resolve(repoRoot, "scripts/install.sh"), "utf8");
+
+    expect(script).not.toContain('cp "$BIN_PATH" "$INSTALL_DIR/matrix"');
+    expect(script).toContain('TMP_BIN="$INSTALL_DIR/.matrix.tmp.$$"');
+    expect(script).toContain('mv -f "$TMP_BIN" "$INSTALL_DIR/matrix"');
+    expect(script).toContain('sudo mv -f "$TMP_BIN" "$INSTALL_DIR/matrix"');
+  });
+
+  it("preserves the macOS package installer when available", async () => {
+    const script = await readFile(resolve(repoRoot, "scripts/install.sh"), "utf8");
+    const macosInstaller = script.slice(script.indexOf("install_macos() {"));
+    const installDirBranch = macosInstaller.indexOf('if [ -n "${MATRIX_INSTALL_DIR:-}" ]; then');
+
+    expect(script).toContain('PKG_NAME="MatrixSync-$VERSION.pkg"');
+    expect(installDirBranch).toBeGreaterThan(-1);
+    expect(installDirBranch).toBeLessThan(macosInstaller.indexOf('PKG_PATH="$INSTALL_TMPDIR/$PKG_NAME"'));
+    expect(script).toContain('pkgutil --check-signature "$PKG_PATH"');
+    expect(script).toContain('sudo installer -pkg "$PKG_PATH" -target /');
+    expect(script).toMatch(
+      /macOS package not available for \$TAG; installing CLI-only standalone binary"\n\s+rm -rf "\$INSTALL_TMPDIR"\n\s+install_cli_binary "darwin" "\$TAG"/,
+    );
   });
 });

--- a/tests/cli/package-runner.test.ts
+++ b/tests/cli/package-runner.test.ts
@@ -61,6 +61,13 @@ describe("published CLI package runners", () => {
     );
   });
 
+  it("normalizes v-prefixed MATRIX_VERSION pins to CLI release tags", async () => {
+    const script = await readFile(resolve(repoRoot, "scripts/install.sh"), "utf8");
+
+    expect(script).toMatch(/v\*\)\s+printf 'cli-v%s' "\$\{MATRIX_VERSION#v\}" ;;/);
+    expect(script).toContain('*)      printf \'cli-v%s\' "$MATRIX_VERSION" ;;');
+  });
+
   it("prefers upgrading the existing matrix command path before installing elsewhere", async () => {
     const script = await readFile(resolve(repoRoot, "scripts/install.sh"), "utf8");
 

--- a/tests/cli/package-runner.test.ts
+++ b/tests/cli/package-runner.test.ts
@@ -57,6 +57,17 @@ describe("published CLI package runners", () => {
     expect(script).toContain('sudo mv -f "$TMP_BIN" "$INSTALL_DIR/matrix"');
   });
 
+  it("prefers upgrading the existing matrix command path before installing elsewhere", async () => {
+    const script = await readFile(resolve(repoRoot, "scripts/install.sh"), "utf8");
+
+    expect(script).toContain("existing_matrix_install_dir()");
+    expect(script).toContain('EXISTING_MATRIX="$(command -v matrix 2>/dev/null || true)"');
+    expect(script).toMatch(
+      /elif EXISTING_DIR="\$\(existing_matrix_install_dir\)" && \[ -n "\$EXISTING_DIR" \]; then\n\s+INSTALL_DIR="\$EXISTING_DIR"\n\s+install_binary_unprivileged "\$INSTALL_DIR" \|\| install_binary_with_sudo "\$INSTALL_DIR"/,
+    );
+    expect(script).toContain('PATH_MATRIX="$(command -v matrix 2>/dev/null || true)"');
+  });
+
   it("preserves the macOS package installer when available", async () => {
     const script = await readFile(resolve(repoRoot, "scripts/install.sh"), "utf8");
     const macosInstaller = script.slice(script.indexOf("install_macos() {"));

--- a/tests/platform/ci-workflows.test.ts
+++ b/tests/platform/ci-workflows.test.ts
@@ -73,6 +73,15 @@ describe('CI workflows', () => {
     }
   });
 
+  it('builds standalone CLI assets before publishing npm in the manual release workflow', () => {
+    const root = process.cwd();
+    const workflow = readFileSync(join(root, '.github/workflows/release.yml'), 'utf8');
+
+    expect(workflow).toContain('publish-npm:\n    name: Publish npm\n    needs: [test, build-macos, build-binaries]');
+    expect(workflow).toContain('build-binaries:\n    name: Build standalone binaries\n    needs: test');
+    expect(workflow).not.toContain('build-binaries:\n    name: Build standalone binaries\n    needs: publish-npm');
+  });
+
   it('wires every required Stripe price secret into platform Cloud Run', () => {
     const root = process.cwd();
     const workflow = readFileSync(join(root, '.github/workflows/platform-cloud-run.yml'), 'utf8');

--- a/tests/platform/ci-workflows.test.ts
+++ b/tests/platform/ci-workflows.test.ts
@@ -60,6 +60,19 @@ describe('CI workflows', () => {
     expect(dockerBuildActionUses).toHaveLength(1);
   });
 
+  it('uses compatible artifact actions in CLI release workflows', () => {
+    const root = process.cwd();
+    const cliReleaseWorkflow = readFileSync(join(root, '.github/workflows/cli-release.yml'), 'utf8');
+    const releaseWorkflow = readFileSync(join(root, '.github/workflows/release.yml'), 'utf8');
+
+    for (const workflow of [cliReleaseWorkflow, releaseWorkflow]) {
+      expect(workflow).toContain('uses: actions/upload-artifact@v7');
+      expect(workflow).toContain('uses: actions/download-artifact@v7');
+      expect(workflow).not.toContain('uses: actions/upload-artifact@v4');
+      expect(workflow).not.toContain('uses: actions/download-artifact@v8');
+    }
+  });
+
   it('wires every required Stripe price secret into platform Cloud Run', () => {
     const root = process.cwd();
     const workflow = readFileSync(join(root, '.github/workflows/platform-cloud-run.yml'), 'utf8');

--- a/www/content/docs/guide/cli.mdx
+++ b/www/content/docs/guide/cli.mdx
@@ -25,7 +25,7 @@ pnpm dlx @finnaai/matrix whoami
 
 If you do not have a Matrix account yet, `login --profile cloud` keeps waiting while the browser walks you through signup, hosted trial checkout, and provisioning your Matrix computer. When setup finishes, approve the CLI in that same browser tab and return to your terminal.
 
-The package runner requires Node.js 24 or newer. If your shell uses an older Node runtime, install Node 24+ first and rerun the same command.
+The package runner requires Node.js 20 or newer. If your shell uses an older Node runtime, use the install script below to install the standalone binary instead.
 
 ## Install Permanently
 
@@ -35,6 +35,9 @@ brew install finnaai/tap/matrix
 
 # npm
 npm install -g @finnaai/matrix
+
+# Standalone binary, no Node.js required
+curl -fsSL https://get.matrix-os.com | sh
 
 # Inside the matrix-os repo (development)
 pnpm install

--- a/www/content/docs/users/cli.mdx
+++ b/www/content/docs/users/cli.mdx
@@ -15,6 +15,9 @@ brew install finnaai/tap/matrix
 
 # npm
 npm install -g @finnaai/matrix
+
+# Standalone binary, no Node.js required
+curl -fsSL https://get.matrix-os.com | sh
 ```
 
 Verify:


### PR DESCRIPTION
## Summary

- lower the published `@finnaai/matrix` CLI runtime floor from Node 24 to Node 20 for `npx`, `pnpm dlx`, `bunx`, and global npm installs
- add Bun-compiled standalone CLI binaries for Linux/macOS x64 and arm64, attach them to both CLI release workflows, and make `scripts/install.sh` install those binaries without requiring Node
- preserve the macOS `MatrixSync-<version>.pkg` installer when it is available, falling back to the standalone Darwin CLI binary only for CLI-only releases
- install standalone binary upgrades through a same-directory temp file plus atomic rename, so upgrades can replace a running CLI binary without `Text file busy`
- add a bundled daemon entrypoint so standalone installs can start `matrix sync` services without depending on source-tree launcher files
- keep CLI release artifact upload/download actions on one compatible generation and cover that release-path invariant with a workflow regression test
- bump the prepared CLI release to `0.3.7` and update public/dev docs for package-runner versus standalone install paths

## Invariants

- **Source of truth**: `packages/sync-client/package.json` remains the package version source; `cli-v<version>` GitHub release assets are the standalone installer source; npm remains the package-runner/Homebrew source. When a GitHub release also has `MatrixSync-<version>.pkg`, macOS `get.matrix-os.com` installs that package first.
- **Lock/transaction scope**: no database or runtime state is modified. Release workflows publish npm first, then build binary assets from the same checked-out commit/version and attach them to the matching GitHub release.
- **Acceptable orphan states**: npm publish can succeed while GitHub release asset creation fails; rerunning the dedicated CLI release with `allow_existing_npm=true` is the recovery path. macOS package absence is explicitly handled as a CLI-only binary fallback. Binary build artifacts are not committed.
- **Auth source of truth**: CLI login/setup auth is unchanged; this only changes runtime packaging and release/install wiring.
- **Deferred scope**: Windows standalone binaries are not expanded here. Homebrew continues to install from the npm tarball.

## Tests

- `pnpm install --frozen-lockfile`
- `bun run typecheck`
- `bun run check:patterns`
- `pnpm --filter @finnaai/matrix build`
- `pnpm --filter @finnaai/matrix test`
- `pnpm --filter @finnaai/matrix test -- tests/unit/service.test.ts`
- `bun run test tests/cli/package-runner.test.ts`
- `bun run test tests/platform/ci-workflows.test.ts`
- `pnpm --filter @finnaai/matrix exec node ./scripts/check-publish.mjs`
- `pnpm --filter @finnaai/matrix exec node ./scripts/validate-package-runners.mjs`
- `pnpm --filter @finnaai/matrix build:binaries`
- `./dist/cli-binaries/matrix-0.3.7-linux-x64 --version`
- `./dist/cli-binaries/matrix-0.3.7-linux-x64 doctor --help`
- `sh -n scripts/install.sh`
- `git diff --check`
