### PR TITLE
feat(delivery): add lane router

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -36,6 +36,27 @@ logs and artifacts.
 | `pr-title.yml` | Conventional Commit PR title policy | PR title changes | Yes |
 | `docker.yml` | Legacy Docker image publishing/deploy path | `v*` tags, manual | Legacy only, not the customer runtime path |
 
+## Delivery Lane Router
+
+Use `scripts/delivery/resolve-lanes.mjs` before lane-specific build or deploy
+jobs. The router accepts either a git diff range:
+
+```bash
+node scripts/delivery/resolve-lanes.mjs --base "$BASE_SHA" --head "$HEAD_SHA"
+```
+
+or explicit operator inputs:
+
+```bash
+node scripts/delivery/resolve-lanes.mjs --selector deploy/shell --tag shell/v2026.06.16.1
+```
+
+It emits a JSON object with `lanes`, `reason`, `requires`, and `blocked`.
+Workflows must fail closed if the script exits non-zero, emits invalid JSON, or
+returns an unknown lane. `runtime/*` tags are intentionally invalid until the
+host-bundle release workflow migrates away from the existing `v*` runtime tag
+contract.
+
 ## Release Rules
 
 The `Host Bundle Release` workflow publishes code that customer VPSes install

--- a/scripts/delivery/resolve-lanes.mjs
+++ b/scripts/delivery/resolve-lanes.mjs
@@ -73,6 +73,11 @@ const PATH_RULES = Object.freeze([
     reason: "platform shared proxy package changed",
   },
   {
+    test: (path) => path.startsWith("packages/ui/"),
+    lanes: ["shell", "runtime"],
+    reason: "shared UI package changed",
+  },
+  {
     test: (path) => path.startsWith("packages/gateway/src/integrations/"),
     lanes: ["platform", "runtime"],
     reason: "platform-mounted gateway integration code changed",
@@ -126,6 +131,14 @@ export function buildGitDiffArgs({ base, head }) {
     throw new Error("Both --base and --head are required when --path is not provided");
   }
   return ["diff", "--name-only", `${base}..${head}`];
+}
+
+export function formatGitDiffFailure(args, result) {
+  if (result.error instanceof Error) {
+    return result.error.message || String(result.error);
+  }
+  const stderr = typeof result.stderr === "string" ? result.stderr.trim() : "";
+  return stderr || `git ${args.join(" ")} failed`;
 }
 
 export function resolveLaneDecision({ changedPaths = [], selectors = [], labels = [], tags = [] } = {}) {
@@ -321,7 +334,7 @@ function readChangedPaths({ base, head, paths }) {
     timeout: GIT_DIFF_TIMEOUT_MS,
   });
   if (result.status !== 0) {
-    throw new Error(result.stderr.trim() || `git ${args.join(" ")} failed`);
+    throw new Error(formatGitDiffFailure(args, result));
   }
   return result.stdout
     .split("\n")

--- a/scripts/delivery/resolve-lanes.mjs
+++ b/scripts/delivery/resolve-lanes.mjs
@@ -1,0 +1,358 @@
+#!/usr/bin/env node
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+export const LANES = Object.freeze(["platform", "shell", "edge", "runtime", "www", "cli", "ops"]);
+
+const LANE_ORDER = new Map(LANES.map((lane, index) => [lane, index]));
+
+const DISPATCH_SELECTORS = Object.freeze({
+  "deploy/platform": "platform",
+  "deploy/shell": "shell",
+  "deploy/edge": "edge",
+  "deploy/runtime": "runtime",
+  "deploy/www": "www",
+  "deploy/cli": "cli",
+  "deploy/ops": "ops",
+});
+
+const LABEL_SELECTORS = Object.freeze({
+  "deploy-platform-preview": "platform",
+  "deploy-shell-preview": "shell",
+  "deploy-edge-preview": "edge",
+  "preview-vps": "runtime",
+});
+
+const REQUIRED_CHECKS_BY_LANE = Object.freeze({
+  platform: ["platform-smoke"],
+  shell: ["react-doctor", "shell-smoke"],
+  edge: ["edge-smoke"],
+  runtime: ["host-bundle-smoke"],
+  www: ["www-smoke"],
+  cli: ["cli-smoke"],
+  ops: ["ops-smoke"],
+});
+
+const ROOT_WORKSPACE_METADATA = new Set(["package.json", "pnpm-lock.yaml", "pnpm-workspace.yaml", ".npmrc"]);
+
+const PATH_RULES = Object.freeze([
+  {
+    test: (path) => ROOT_WORKSPACE_METADATA.has(path),
+    lanes: LANES,
+    reason: "root workspace metadata changed",
+  },
+  {
+    test: (path) => path === "Dockerfile.platform" || path === "cloudbuild.platform.yaml",
+    lanes: ["platform"],
+    reason: "platform image build inputs changed",
+  },
+  {
+    test: (path) => path === "scripts/start-platform-cloud-run.sh",
+    lanes: ["platform"],
+    reason: "platform Cloud Run startup changed",
+  },
+  {
+    test: (path) => path === "scripts/build-host-bundle.sh" || path === "scripts/host-bundle-release.mjs",
+    lanes: ["runtime"],
+    reason: "host-bundle release tooling changed",
+  },
+  {
+    test: (path) => path.startsWith("shell/"),
+    lanes: ["shell", "runtime"],
+    reason: "shell files changed",
+  },
+  {
+    test: (path) => path.startsWith("packages/platform/") || path.startsWith("packages/clerk-sync/"),
+    lanes: ["platform"],
+    reason: "platform control-plane code changed",
+  },
+  {
+    test: (path) => path.startsWith("packages/gateway/src/integrations/"),
+    lanes: ["platform", "runtime"],
+    reason: "platform-mounted gateway integration code changed",
+  },
+  {
+    test: (path) =>
+      path.startsWith("packages/gateway/") ||
+      path.startsWith("packages/kernel/") ||
+      path.startsWith("packages/sync-client/"),
+    lanes: ["runtime"],
+    reason: "customer runtime package changed",
+  },
+  {
+    test: (path) => path.startsWith("packages/edge-router/"),
+    lanes: ["edge"],
+    reason: "edge router package changed",
+  },
+  {
+    test: (path) => path.startsWith("packages/observability/"),
+    lanes: ["ops", "platform", "shell", "www"],
+    reason: "observability package changed",
+  },
+  {
+    test: (path) => path.startsWith("www/"),
+    lanes: ["www"],
+    reason: "website/docs changed",
+  },
+  {
+    test: (path) =>
+      path.startsWith("home/") ||
+      path.startsWith("skills/") ||
+      path.startsWith("distro/customer-vps/host-bin/") ||
+      path.startsWith("distro/customer-vps/systemd/"),
+    lanes: ["runtime"],
+    reason: "host-bundle shipped files changed",
+  },
+  {
+    test: (path) => path === "distro/customer-vps/cloud-init.yaml",
+    lanes: ["platform"],
+    reason: "customer VPS provisioning inputs changed",
+  },
+  {
+    test: (path) => path.startsWith("distro/observability/"),
+    lanes: ["ops"],
+    reason: "observability ops files changed",
+  },
+]);
+
+export function buildGitDiffArgs({ base, head }) {
+  if (!base || !head) {
+    throw new Error("Both --base and --head are required when --path is not provided");
+  }
+  return ["diff", "--name-only", `${base}..${head}`];
+}
+
+export function resolveLaneDecision({ changedPaths = [], selectors = [], labels = [], tags = [] } = {}) {
+  const lanes = new Set();
+  const requires = new Set();
+  const reasonParts = [];
+  const blocked = [];
+
+  for (const selector of selectors) {
+    const lane = DISPATCH_SELECTORS[selector];
+    if (!lane) {
+      throw new Error(`Unknown deploy selector: ${selector}`);
+    }
+    lanes.add(lane);
+    reasonParts.push(`manual dispatch ${selector}`);
+  }
+
+  for (const label of labels) {
+    const lane = LABEL_SELECTORS[label];
+    if (lane) {
+      lanes.add(lane);
+      reasonParts.push(`label ${label}`);
+    }
+  }
+
+  for (const tag of tags) {
+    const lane = laneForTag(tag);
+    lanes.add(lane);
+    reasonParts.push(`tag ${tag}`);
+  }
+
+  for (const path of changedPaths) {
+    const normalized = normalizePath(path);
+    const rule = PATH_RULES.find((candidate) => candidate.test(normalized));
+    if (!rule) {
+      continue;
+    }
+    for (const lane of rule.lanes) {
+      lanes.add(lane);
+    }
+    reasonParts.push(rule.reason);
+  }
+
+  for (const lane of lanes) {
+    for (const required of REQUIRED_CHECKS_BY_LANE[lane] ?? []) {
+      requires.add(required);
+    }
+  }
+
+  const decision = {
+    lanes: sortByLaneOrder([...lanes]),
+    reason: unique(reasonParts).join("; ") || "no deployable surfaces changed",
+    requires: sortRequires([...requires]),
+    blocked,
+  };
+
+  validateLaneDecision(decision);
+  return decision;
+}
+
+export function validateLaneDecision(decision) {
+  if (!decision || typeof decision !== "object" || Array.isArray(decision)) {
+    throw new Error("Lane decision must be an object");
+  }
+  if (!Array.isArray(decision.lanes)) {
+    throw new Error("Lane decision must include a lanes array");
+  }
+  for (const lane of decision.lanes) {
+    if (!LANES.includes(lane)) {
+      throw new Error(`Invalid lane emitted by delivery router: ${lane}`);
+    }
+  }
+  if (typeof decision.reason !== "string" || decision.reason.length === 0) {
+    throw new Error("Lane decision must include a non-empty reason");
+  }
+  if (!Array.isArray(decision.requires)) {
+    throw new Error("Lane decision must include a requires array");
+  }
+  if (!Array.isArray(decision.blocked)) {
+    throw new Error("Lane decision must include a blocked array");
+  }
+  for (const entry of decision.blocked) {
+    if (
+      !entry ||
+      typeof entry !== "object" ||
+      Array.isArray(entry) ||
+      !Array.isArray(entry.lanes) ||
+      typeof entry.reason !== "string" ||
+      typeof entry.action !== "string"
+    ) {
+      throw new Error("Invalid blocked entry emitted by delivery router");
+    }
+    for (const lane of entry.lanes) {
+      if (!LANES.includes(lane)) {
+        throw new Error(`Invalid blocked lane emitted by delivery router: ${lane}`);
+      }
+    }
+  }
+  return decision;
+}
+
+function laneForTag(tag) {
+  if (/^runtime\//.test(tag)) {
+    throw new Error("runtime/* tags are not valid until the runtime tag migration lands");
+  }
+  if (/^platform\/v\d{4}\.\d{2}\.\d{2}\.\d+$/.test(tag)) return "platform";
+  if (/^shell\/v\d{4}\.\d{2}\.\d{2}\.\d+$/.test(tag)) return "shell";
+  if (/^edge\/v\d{4}\.\d{2}\.\d{2}\.\d+$/.test(tag)) return "edge";
+  if (/^www\/v\d{4}\.\d{2}\.\d{2}\.\d+$/.test(tag)) return "www";
+  if (/^cli-v\d+\.\d+\.\d+/.test(tag)) return "cli";
+  if (/^v[\w.-]+$/.test(tag)) return "runtime";
+  throw new Error(`Unknown deploy tag: ${tag}`);
+}
+
+function normalizePath(path) {
+  return path.replaceAll("\\", "/").replace(/^\.\//, "");
+}
+
+function sortByLaneOrder(values) {
+  return unique(values).sort((left, right) => LANE_ORDER.get(left) - LANE_ORDER.get(right));
+}
+
+function sortRequires(values) {
+  return unique(values).sort((left, right) => {
+    const leftLane = laneForRequiredCheck(left);
+    const rightLane = laneForRequiredCheck(right);
+    if (leftLane !== rightLane) {
+      return leftLane - rightLane;
+    }
+    return left.localeCompare(right);
+  });
+}
+
+function laneForRequiredCheck(check) {
+  for (const [lane, checks] of Object.entries(REQUIRED_CHECKS_BY_LANE)) {
+    if (checks.includes(check)) return LANE_ORDER.get(lane);
+  }
+  return Number.MAX_SAFE_INTEGER;
+}
+
+function unique(values) {
+  return [...new Set(values)];
+}
+
+function parseArgs(argv) {
+  const parsed = {
+    base: "",
+    head: "",
+    paths: [],
+    selectors: [],
+    labels: [],
+    tags: [],
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === "--base") parsed.base = requireValue(argv, ++index, arg);
+    else if (arg === "--head") parsed.head = requireValue(argv, ++index, arg);
+    else if (arg === "--path") parsed.paths.push(requireValue(argv, ++index, arg));
+    else if (arg === "--selector") parsed.selectors.push(requireValue(argv, ++index, arg));
+    else if (arg === "--label") parsed.labels.push(requireValue(argv, ++index, arg));
+    else if (arg === "--tag") parsed.tags.push(requireValue(argv, ++index, arg));
+    else if (arg === "--help" || arg === "-h") {
+      printHelp();
+      process.exit(0);
+    } else {
+      throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+
+  return parsed;
+}
+
+function requireValue(argv, index, flag) {
+  const value = argv[index];
+  if (!value || value.startsWith("--")) {
+    throw new Error(`${flag} requires a value`);
+  }
+  return value;
+}
+
+function readChangedPaths({ base, head, paths }) {
+  if (paths.length > 0) {
+    return paths;
+  }
+  if (!base && !head) {
+    return [];
+  }
+  const args = buildGitDiffArgs({ base, head });
+  const result = spawnSync("git", args, {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  if (result.status !== 0) {
+    throw new Error(result.stderr.trim() || `git ${args.join(" ")} failed`);
+  }
+  return result.stdout
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean);
+}
+
+function printHelp() {
+  console.log(`Usage: node scripts/delivery/resolve-lanes.mjs [options]
+
+Options:
+  --base <sha>       Base SHA for git diff
+  --head <sha>       Head SHA for git diff
+  --path <path>      Changed path. Repeatable; skips git diff when present
+  --selector <name>  Manual dispatch selector such as deploy/platform
+  --label <name>     PR label. Repeatable
+  --tag <name>       Git tag. Repeatable
+`);
+}
+
+function main() {
+  try {
+    const args = parseArgs(process.argv.slice(2));
+    const changedPaths = readChangedPaths(args);
+    const decision = resolveLaneDecision({
+      changedPaths,
+      selectors: args.selectors,
+      labels: args.labels,
+      tags: args.tags,
+    });
+    process.stdout.write(`${JSON.stringify(decision, null, 2)}\n`);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Unknown delivery router failure";
+    process.stderr.write(`resolve-lanes: ${message}\n`);
+    process.exitCode = 1;
+  }
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  main();
+}

--- a/scripts/delivery/resolve-lanes.mjs
+++ b/scripts/delivery/resolve-lanes.mjs
@@ -3,6 +3,7 @@ import { spawnSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
 
 export const LANES = Object.freeze(["platform", "shell", "edge", "runtime", "www", "cli", "ops"]);
+export const GIT_DIFF_TIMEOUT_MS = 30_000;
 
 const LANE_ORDER = new Map(LANES.map((lane, index) => [lane, index]));
 
@@ -65,6 +66,11 @@ const PATH_RULES = Object.freeze([
     test: (path) => path.startsWith("packages/platform/") || path.startsWith("packages/clerk-sync/"),
     lanes: ["platform"],
     reason: "platform control-plane code changed",
+  },
+  {
+    test: (path) => path.startsWith("packages/proxy/"),
+    lanes: ["platform"],
+    reason: "platform shared proxy package changed",
   },
   {
     test: (path) => path.startsWith("packages/gateway/src/integrations/"),
@@ -229,7 +235,7 @@ function laneForTag(tag) {
   if (/^shell\/v\d{4}\.\d{2}\.\d{2}\.\d+$/.test(tag)) return "shell";
   if (/^edge\/v\d{4}\.\d{2}\.\d{2}\.\d+$/.test(tag)) return "edge";
   if (/^www\/v\d{4}\.\d{2}\.\d{2}\.\d+$/.test(tag)) return "www";
-  if (/^cli-v\d+\.\d+\.\d+/.test(tag)) return "cli";
+  if (/^cli-v\d+\.\d+\.\d+$/.test(tag)) return "cli";
   if (/^v[\w.-]+$/.test(tag)) return "runtime";
   throw new Error(`Unknown deploy tag: ${tag}`);
 }
@@ -312,6 +318,7 @@ function readChangedPaths({ base, head, paths }) {
   const result = spawnSync("git", args, {
     encoding: "utf8",
     stdio: ["ignore", "pipe", "pipe"],
+    timeout: GIT_DIFF_TIMEOUT_MS,
   });
   if (result.status !== 0) {
     throw new Error(result.stderr.trim() || `git ${args.join(" ")} failed`);

--- a/tests/scripts/delivery-resolve-lanes.test.ts
+++ b/tests/scripts/delivery-resolve-lanes.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildGitDiffArgs,
+  resolveLaneDecision,
+  validateLaneDecision,
+} from "../../scripts/delivery/resolve-lanes.mjs";
+
+describe("delivery lane router", () => {
+  it("routes shell changes to both pre-VPS shell and customer runtime lanes", () => {
+    const decision = resolveLaneDecision({
+      changedPaths: ["shell/src/components/BillingGate.tsx"],
+    });
+
+    expect(decision.lanes).toEqual(["shell", "runtime"]);
+    expect(decision.requires).toEqual(["react-doctor", "shell-smoke", "host-bundle-smoke"]);
+    expect(decision.blocked).toEqual([]);
+  });
+
+  it("fans root workspace metadata out to every lane that installs from the workspace", () => {
+    const decision = resolveLaneDecision({
+      changedPaths: ["pnpm-lock.yaml"],
+    });
+
+    expect(decision.lanes).toEqual(["platform", "shell", "edge", "runtime", "www", "cli", "ops"]);
+    expect(decision.reason).toContain("root workspace metadata");
+  });
+
+  it("adds lanes from explicit deploy selectors", () => {
+    const decision = resolveLaneDecision({
+      changedPaths: [],
+      selectors: ["deploy/platform", "deploy/www"],
+    });
+
+    expect(decision.lanes).toEqual(["platform", "www"]);
+    expect(decision.reason).toContain("manual dispatch");
+  });
+
+  it("rejects unknown deploy selectors instead of falling through to a default lane", () => {
+    expect(() =>
+      resolveLaneDecision({
+        changedPaths: [],
+        selectors: ["deploy/database"],
+      }),
+    ).toThrow(/Unknown deploy selector/);
+  });
+
+  it("keeps existing v* host-bundle tags on the runtime lane and rejects runtime/* tags", () => {
+    expect(
+      resolveLaneDecision({
+        changedPaths: [],
+        tags: ["v2026.06.16-1"],
+      }).lanes,
+    ).toEqual(["runtime"]);
+
+    expect(() =>
+      resolveLaneDecision({
+        changedPaths: [],
+        tags: ["runtime/v2026.06.16-1"],
+      }),
+    ).toThrow(/runtime\/\* tags are not valid/);
+  });
+
+  it("validates emitted decisions before workflows can consume them", () => {
+    expect(() =>
+      validateLaneDecision({
+        lanes: ["shell", "database"],
+        reason: "bad lane",
+        requires: [],
+        blocked: [],
+      }),
+    ).toThrow(/Invalid lane/);
+
+    expect(() =>
+      validateLaneDecision({
+        lanes: ["shell"],
+        reason: "bad block",
+        requires: [],
+        blocked: ["unsupported-path"],
+      }),
+    ).toThrow(/Invalid blocked entry/);
+  });
+
+  it("builds the git diff command without shell interpolation", () => {
+    expect(buildGitDiffArgs({ base: "base-sha", head: "head-sha" })).toEqual([
+      "diff",
+      "--name-only",
+      "base-sha..head-sha",
+    ]);
+  });
+});

--- a/tests/scripts/delivery-resolve-lanes.test.ts
+++ b/tests/scripts/delivery-resolve-lanes.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   buildGitDiffArgs,
+  GIT_DIFF_TIMEOUT_MS,
   resolveLaneDecision,
   validateLaneDecision,
 } from "../../scripts/delivery/resolve-lanes.mjs";
@@ -60,6 +61,24 @@ describe("delivery lane router", () => {
     ).toThrow(/runtime\/\* tags are not valid/);
   });
 
+  it("rejects prerelease-looking CLI tags instead of routing them to the CLI lane", () => {
+    expect(() =>
+      resolveLaneDecision({
+        changedPaths: [],
+        tags: ["cli-v1.2.3-rc1"],
+      }),
+    ).toThrow(/Unknown deploy tag/);
+  });
+
+  it("routes shared proxy package changes through the platform lane", () => {
+    const decision = resolveLaneDecision({
+      changedPaths: ["packages/proxy/src/main.ts"],
+    });
+
+    expect(decision.lanes).toEqual(["platform"]);
+    expect(decision.reason).toContain("proxy package changed");
+  });
+
   it("validates emitted decisions before workflows can consume them", () => {
     expect(() =>
       validateLaneDecision({
@@ -86,5 +105,6 @@ describe("delivery lane router", () => {
       "--name-only",
       "base-sha..head-sha",
     ]);
+    expect(GIT_DIFF_TIMEOUT_MS).toBe(30_000);
   });
 });

--- a/tests/scripts/delivery-resolve-lanes.test.ts
+++ b/tests/scripts/delivery-resolve-lanes.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   buildGitDiffArgs,
+  formatGitDiffFailure,
   GIT_DIFF_TIMEOUT_MS,
   resolveLaneDecision,
   validateLaneDecision,
@@ -79,6 +80,16 @@ describe("delivery lane router", () => {
     expect(decision.reason).toContain("proxy package changed");
   });
 
+  it("routes shared UI package changes through shell and runtime lanes", () => {
+    const decision = resolveLaneDecision({
+      changedPaths: ["packages/ui/src/Button.tsx"],
+    });
+
+    expect(decision.lanes).toEqual(["shell", "runtime"]);
+    expect(decision.requires).toEqual(["react-doctor", "shell-smoke", "host-bundle-smoke"]);
+    expect(decision.reason).toContain("shared UI package changed");
+  });
+
   it("validates emitted decisions before workflows can consume them", () => {
     expect(() =>
       validateLaneDecision({
@@ -106,5 +117,16 @@ describe("delivery lane router", () => {
       "base-sha..head-sha",
     ]);
     expect(GIT_DIFF_TIMEOUT_MS).toBe(30_000);
+  });
+
+  it("surfaces spawn errors from git diff failures", () => {
+    const args = buildGitDiffArgs({ base: "base-sha", head: "head-sha" });
+
+    expect(
+      formatGitDiffFailure(args, {
+        stderr: "",
+        error: Object.assign(new Error("spawn git ETIMEDOUT"), { code: "ETIMEDOUT" }),
+      }),
+    ).toContain("spawn git ETIMEDOUT");
   });
 });


### PR DESCRIPTION
Summary
- Stack: 2/3 after #560.
- Adds scripts/delivery/resolve-lanes.mjs with an importable router core and CLI JSON output.
- Covers path, tag, PR label, and manual dispatch lane decisions with fail-closed validation.

Tests
- bun run test tests/scripts/delivery-resolve-lanes.test.ts tests/platform/ci-workflows.test.ts

Review/Monitoring
- Greptile and GitHub checks are running on head 2ad04352123b62c0163d2a5e29c0ea2cd682e840.

Invariants
- Source of truth: the router emits JSON only from checked-in path/tag/selector maps.
- Lock/transaction scope: no runtime state or external mutation; script only reads git diff paths when base/head are provided.
- Acceptable orphan states: unknown selectors/tags or invalid emitted lanes fail before deploy; no permissive fallback lane.
- Auth source of truth: no secrets or auth decisions are handled in this layer.
- Deferred scope: workflow consumption and production deploy-lane enforcement remain in the upstack Phase 1 layers.