### PR TITLE
fix(shell): restore terminal UI state build

### DIFF
--- a/shell/src/components/terminal/TerminalApp.tsx
+++ b/shell/src/components/terminal/TerminalApp.tsx
@@ -2727,6 +2727,62 @@ function applyShellUiStatePatch(shell: ShellSessionSummary, patch: ShellUiStateP
   return deriveShellUnread({ ...shell, ...patch });
 }
 
+function snapshotShellUiStatePatchValue(
+  previousValues: ShellUiStatePatch,
+  shell: ShellSessionSummary,
+  key: ShellUiStatePatchKey,
+): void {
+  switch (key) {
+    case "placement":
+      previousValues.placement = shell.placement;
+      return;
+    case "lastSeenSeq":
+      previousValues.lastSeenSeq = shell.lastSeenSeq;
+      return;
+    case "visualStatus":
+      previousValues.visualStatus = shell.visualStatus;
+      return;
+    default: {
+      const unhandledKey: never = key;
+      throw new Error(`Unhandled shell UI state patch key: ${String(unhandledKey)}`);
+    }
+  }
+}
+
+function snapshotShellUiStatePatch(shell: ShellSessionSummary, patch: ShellUiStatePatch): ShellUiStatePatch {
+  const previousValues: ShellUiStatePatch = {};
+  for (const key of getShellUiStatePatchKeys(patch)) {
+    snapshotShellUiStatePatchValue(previousValues, shell, key);
+  }
+  return previousValues;
+}
+
+function rollbackShellUiStatePatchValue(
+  shell: ShellSessionSummary,
+  patch: ShellUiStatePatch,
+  previousValues: ShellUiStatePatch,
+  key: ShellUiStatePatchKey,
+): ShellSessionSummary {
+  switch (key) {
+    case "placement":
+      return Object.is(shell.placement, patch.placement)
+        ? { ...shell, placement: previousValues.placement }
+        : shell;
+    case "lastSeenSeq":
+      return Object.is(shell.lastSeenSeq, patch.lastSeenSeq)
+        ? { ...shell, lastSeenSeq: previousValues.lastSeenSeq }
+        : shell;
+    case "visualStatus":
+      return Object.is(shell.visualStatus, patch.visualStatus)
+        ? { ...shell, visualStatus: previousValues.visualStatus }
+        : shell;
+    default: {
+      const unhandledKey: never = key;
+      throw new Error(`Unhandled shell UI state patch key: ${String(unhandledKey)}`);
+    }
+  }
+}
+
 function rollbackShellUiStatePatch(
   shell: ShellSessionSummary,
   patch: ShellUiStatePatch,
@@ -2734,9 +2790,7 @@ function rollbackShellUiStatePatch(
 ): ShellSessionSummary {
   let next = shell;
   for (const key of getShellUiStatePatchKeys(patch)) {
-    if (Object.is(next[key], patch[key])) {
-      next = { ...next, [key]: previousValues[key] };
-    }
+    next = rollbackShellUiStatePatchValue(next, patch, previousValues, key);
   }
   return deriveShellUnread(next);
 }
@@ -3054,9 +3108,7 @@ function LocalTerminalSidebar() {
     const previousValues: ShellUiStatePatch = {};
     setShells((prev) => prev.map((shell) => {
       if (shell.name !== name) return shell;
-      for (const key of getShellUiStatePatchKeys(patch)) {
-        previousValues[key] = shell[key];
-      }
+      Object.assign(previousValues, snapshotShellUiStatePatch(shell, patch));
       return applyShellUiStatePatch(shell, patch);
     }));
     const rollback = () => {


### PR DESCRIPTION
## Summary

- Fixes the `main` deploy failure introduced by `be6de50d47c0a44893c7794331d7ca19c99e45f2`.
- Replaces the terminal shell UI-state optimistic rollback indexed assignment with explicit typed snapshot/rollback helpers.
- Keeps the existing active/background placement, last-seen sequence, and visual-status rollback behavior intact.

## Root Cause

`Platform Cloud Run` and `Host Bundle Release` both failed in the production shell `next build --webpack` TypeScript phase:

`TerminalApp.tsx:3058: previousValues[key] = shell[key]`

The indexed assignment collapsed the `ShellUiStatePatch` target type to `undefined`, so `number | "active" | "background" | "running" | "waiting" | "finished" | "idle" | null | undefined` could not be assigned during production build typechecking.

## Tests

- `pnpm --dir shell exec tsc --noEmit --pretty false` (red before fix, green after)
- `pnpm exec vitest run tests/shell/terminal-app-component.test.tsx` (48 passed)
- `pnpm --filter @matrix-os/observability build`
- `pnpm --dir shell exec next build --webpack`
- `npx react-doctor@latest shell`
- `npx react-doctor@latest shell --scope changed --base origin/main --verbose` (no issues found)
- `bun run check:patterns` (0 violations, existing warnings only)
- `bun run typecheck`
- `git diff --check`
- `bun run test` (591 files passed, 6665 tests passed, 20 skipped)

## Review/Monitoring

- Monitor current-head GitHub Actions until green.
- Wait for latest trusted Greptile review on this PR head to reach `5/5`.
- If merged, verify the follow-up `main` workflows that were failing: `Platform Cloud Run` and `Host Bundle Release`.

## Invariants

- Source of truth: terminal shell session state remains the gateway session list; this change only snapshots local optimistic UI-state fields for rollback.
- Lock/transaction scope: not applicable; no backend persistence or database writes changed.
- Acceptable orphan states: unchanged; failed `/ui-state` PATCH requests roll back only fields still matching the optimistic patch.
- Auth source of truth: unchanged; existing gateway session endpoints and browser auth behavior are untouched.
- Deferred scope: this PR does not change the release workflows or broaden shell typecheck coverage; it fixes the concrete production build break.
