### PR TITLE
ci(delivery): default CLI and bundle release lanes

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -16,7 +16,7 @@ protection is also updated when the shard list changes.
 - `Type Check`
 - `Pattern Scan`
 - `React Doctor`
-- `Sync Client Package (Node 20/24)`
+- `Sync Client Package (Node 20)`
 - `Unit Tests`
 - `E2E Tests`
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -219,14 +219,10 @@ jobs:
           done
 
   sync-client:
-    name: Sync Client Package (Node ${{ matrix.node }})
+    name: Sync Client Package
     needs: [changes, patterns]
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    strategy:
-      fail-fast: false
-      matrix:
-        node: [20, 24]
     steps:
       - name: Skip expensive CI for docs-only changes
         if: needs.changes.outputs.should_run != 'true'
@@ -241,7 +237,7 @@ jobs:
       - uses: actions/setup-node@v6
         if: needs.changes.outputs.should_run == 'true'
         with:
-          node-version: ${{ matrix.node }}
+          node-version: 20
           cache: pnpm
 
       - run: pnpm install --frozen-lockfile
@@ -380,7 +376,7 @@ jobs:
             echo "| Type Check | $TYPECHECK_RESULT |"
             echo "| Pattern Scan | $PATTERNS_RESULT |"
             echo "| React Doctor | $REACT_DOCTOR_RESULT |"
-            echo "| Sync Client Package (Node 20/24) | $SYNC_CLIENT_RESULT |"
+            echo "| Sync Client Package (Node 20) | $SYNC_CLIENT_RESULT |"
             echo "| Unit Tests | $UNIT_RESULT |"
             echo "| E2E Tests | $E2E_RESULT |"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/cli-release.yml
+++ b/.github/workflows/cli-release.yml
@@ -1,11 +1,13 @@
 name: CLI Release
 
-# Manually dispatched from the GitHub Actions UI. Publishes only the
-# installable Matrix CLI package (`@finnaai/matrix`), standalone CLI binaries,
-# and its matching `cli-v<version>` GitHub release/Homebrew formula. This
-# intentionally avoids the broader release workflow's full-repo test and
-# optional macOS installer path so a CLI patch can ship independently.
+# Publishes only the installable Matrix CLI package (`@finnaai/matrix`),
+# standalone CLI binaries, and its matching `cli-v<version>` GitHub release/
+# Homebrew formula. Push a `cli-v<version>` tag for the default release path,
+# or dispatch manually for recovery.
 on:
+  push:
+    tags:
+      - "cli-v*"
   workflow_dispatch:
     inputs:
       version:
@@ -28,7 +30,7 @@ permissions:
   id-token: write
 
 concurrency:
-  group: cli-release-${{ inputs.version }}
+  group: cli-release-${{ github.ref_type == 'tag' && github.ref_name || format('cli-v{0}', inputs.version) }}
   cancel-in-progress: false
 
 jobs:
@@ -46,7 +48,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: 24
+          node-version: 20
           cache: pnpm
           registry-url: "https://registry.npmjs.org"
 
@@ -58,6 +60,9 @@ jobs:
           VERSION: ${{ inputs.version }}
         run: |
           set -euo pipefail
+          if [ "$GITHUB_REF_TYPE" = "tag" ]; then
+            VERSION="${GITHUB_REF_NAME#cli-v}"
+          fi
           if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
             echo "version '$VERSION' is not valid semver (expected X.Y.Z or X.Y.Z-prerelease)" >&2
             exit 1
@@ -78,7 +83,7 @@ jobs:
             NPM_EXISTS=true
           fi
 
-          if git ls-remote --exit-code --tags origin "refs/tags/cli-v${VERSION}" >/dev/null 2>&1; then
+          if [ "$GITHUB_REF_TYPE" != "tag" ] && git ls-remote --exit-code --tags origin "refs/tags/cli-v${VERSION}" >/dev/null 2>&1; then
             echo "tag cli-v${VERSION} already exists" >&2
             exit 1
           fi
@@ -136,7 +141,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: 24
+          node-version: 20
           cache: pnpm
 
       - uses: oven-sh/setup-bun@v2
@@ -185,7 +190,7 @@ jobs:
   homebrew:
     name: Update Homebrew tap
     needs: [publish, github-release]
-    if: ${{ inputs.update_homebrew }}
+    if: ${{ github.event_name == 'push' || inputs.update_homebrew }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:

--- a/.github/workflows/host-bundle-release.yml
+++ b/.github/workflows/host-bundle-release.yml
@@ -9,7 +9,7 @@
 #   1. ci-gate — wait for same-SHA CI and verify all CI jobs succeeded
 #   2. build — compile gateway, shell, kernel into host bundle tarball
 #   3. publish — upload immutable R2 artifacts and register metadata in platform DB
-#   4. (optional) auto-deploy if severity is "security"
+#   4. deploy — main/dev publishes trigger exact-version VPS deployment by default
 
 name: Host Bundle Release
 
@@ -47,6 +47,11 @@ on:
         description: "Skip dev host-bundle build/publish for explicit manual maintenance runs"
         required: false
         default: false
+        type: boolean
+      deploy_after_publish:
+        description: "Deploy the published exact version to existing VPSes after registration"
+        required: false
+        default: true
         type: boolean
 
 permissions:
@@ -367,24 +372,35 @@ jobs:
 
           ./scripts/publish-release.sh "${ARGS[@]}"
 
-      - name: Auto-deploy on security severity
-        if: ${{ inputs.severity == 'security' }}
-        env:
-          PLATFORM_PUBLIC_URL: ${{ vars.PLATFORM_PUBLIC_URL || 'https://app.matrix-os.com' }}
-          PLATFORM_SECRET: ${{ secrets.PLATFORM_SECRET }}
+  deploy:
+    name: Deploy published host bundle
+    needs: [dev-bundle-gate, build, publish]
+    if: ${{ needs.dev-bundle-gate.outputs.should_build == 'true' && ((github.event_name == 'push' && github.ref_type == 'branch' && github.ref_name == 'main') || inputs.deploy_after_publish) }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    env:
+      PLATFORM_PUBLIC_URL: ${{ vars.PLATFORM_PUBLIC_URL || 'https://app.matrix-os.com' }}
+      PLATFORM_SECRET: ${{ secrets.PLATFORM_SECRET }}
+    steps:
+      - name: Trigger exact-version VPS deploy
         run: |
           set -euo pipefail
           VERSION="${{ needs.build.outputs.version }}"
           if [ -z "${PLATFORM_SECRET:-}" ]; then
-            echo "PLATFORM_SECRET not configured — skipping auto-deploy" >&2
-            exit 0
+            echo "PLATFORM_SECRET is required to deploy published host bundles." >&2
+            exit 1
           fi
-          echo "Security severity — waiting 60s for sync agents to discover manifest..."
-          sleep 60
-          echo "Triggering deploy for $VERSION..."
-          curl --fail --silent --show-error --max-time 30 \
+          echo "Triggering VPS deploy for $VERSION..."
+          DEPLOY_RESPONSE="$(curl --fail --silent --show-error --max-time 30 \
             -X POST "${PLATFORM_PUBLIC_URL%/}/vps/deploy" \
             -H "Authorization: Bearer ${PLATFORM_SECRET}" \
             -H "Content-Type: application/json" \
-            -d "{\"version\":\"$VERSION\"}"
-          echo "Deploy triggered successfully."
+            -d "{\"version\":\"$VERSION\"}")"
+          printf '%s\n' "$DEPLOY_RESPONSE" | jq .
+          failed="$(printf '%s' "$DEPLOY_RESPONSE" | jq -r '.failed // 0')"
+          triggered="$(printf '%s' "$DEPLOY_RESPONSE" | jq -r '.triggered // 0')"
+          if [ "$failed" -gt 0 ] || [ "$triggered" -eq 0 ]; then
+            echo "Exact-version VPS deploy did not update the fleet cleanly: triggered=$triggered failed=$failed" >&2
+            exit 1
+          fi
+          echo "Deploy triggered successfully: triggered=$triggered failed=$failed"

--- a/tests/platform/ci-workflows.test.ts
+++ b/tests/platform/ci-workflows.test.ts
@@ -60,6 +60,41 @@ describe('CI workflows', () => {
     expect(dockerBuildActionUses).toHaveLength(1);
   });
 
+  it('runs sync-client CI only on the supported Node 20 runtime', () => {
+    const root = process.cwd();
+    const workflow = readFileSync(join(root, '.github/workflows/ci.yml'), 'utf8');
+    const readme = readFileSync(join(root, '.github/workflows/README.md'), 'utf8');
+
+    expect(workflow).toContain('name: Sync Client Package');
+    expect(workflow).toContain('node-version: 20');
+    expect(workflow).not.toContain('matrix:\n        node: [20, 24]');
+    expect(workflow).not.toContain('Sync Client Package (Node 20/24)');
+    expect(readme).toContain('Sync Client Package (Node 20)');
+    expect(readme).not.toContain('Sync Client Package (Node 20/24)');
+  });
+
+  it('uses Node 20 for the dedicated installable CLI release jobs', () => {
+    const root = process.cwd();
+    const cliReleaseWorkflow = readFileSync(join(root, '.github/workflows/cli-release.yml'), 'utf8');
+
+    const setupNodeBlocks = cliReleaseWorkflow.match(/uses: actions\/setup-node@v6[\s\S]*?node-version: \d+/g) ?? [];
+    expect(setupNodeBlocks.length).toBeGreaterThan(0);
+    expect(setupNodeBlocks.every((block) => block.includes('node-version: 20'))).toBe(true);
+  });
+
+  it('publishes the installable CLI from cli-v tags without requiring manual inputs', () => {
+    const root = process.cwd();
+    const workflow = readFileSync(join(root, '.github/workflows/cli-release.yml'), 'utf8');
+
+    expect(workflow).toContain("group: cli-release-${{ github.ref_type == 'tag' && github.ref_name || format('cli-v{0}', inputs.version) }}");
+    expect(workflow).not.toContain("group: cli-release-${{ github.ref_type == 'tag' && github.ref_name || inputs.version }}");
+    expect(workflow).toContain('tags:\n      - "cli-v*"');
+    expect(workflow).toContain('if [ "$GITHUB_REF_TYPE" = "tag" ]; then');
+    expect(workflow).toContain('VERSION="${GITHUB_REF_NAME#cli-v}"');
+    expect(workflow).toContain("if: ${{ github.event_name == 'push' || inputs.update_homebrew }}");
+    expect(workflow).toContain('if [ "$GITHUB_REF_TYPE" != "tag" ] && git ls-remote --exit-code --tags origin "refs/tags/cli-v${VERSION}"');
+  });
+
   it('uses compatible artifact actions in CLI release workflows', () => {
     const root = process.cwd();
     const cliReleaseWorkflow = readFileSync(join(root, '.github/workflows/cli-release.yml'), 'utf8');
@@ -203,5 +238,23 @@ describe('CI workflows', () => {
     expect(workflow).toContain('${build_id}');
     expect(workflow).toContain('- cache_image:');
     expect(workflow).toContain('${cache_image}');
+  });
+
+  it('deploys published dev host bundles by exact version on main by default', () => {
+    const root = process.cwd();
+    const workflow = readFileSync(join(root, '.github/workflows/host-bundle-release.yml'), 'utf8');
+
+    expect(workflow).toContain('deploy_after_publish:');
+    expect(workflow).toContain('Deploy published host bundle');
+    expect(workflow).toContain("github.event_name == 'push' && github.ref_type == 'branch' && github.ref_name == 'main'");
+    expect(workflow).toContain('|| inputs.deploy_after_publish');
+    expect(workflow).not.toContain("|| inputs.severity == 'security'");
+    expect(workflow).toContain('VERSION="${{ needs.build.outputs.version }}"');
+    expect(workflow).toContain('DEPLOY_RESPONSE="$(curl --fail --silent --show-error --max-time 30 \\');
+    expect(workflow).toContain('failed="$(printf \'%s\' "$DEPLOY_RESPONSE" | jq -r \'.failed // 0\')"');
+    expect(workflow).toContain('triggered="$(printf \'%s\' "$DEPLOY_RESPONSE" | jq -r \'.triggered // 0\')"');
+    expect(workflow).toContain('if [ "$failed" -gt 0 ] || [ "$triggered" -eq 0 ]; then');
+    expect(workflow).toContain('-d "{\\"version\\":\\"$VERSION\\"}"');
+    expect(workflow).not.toContain('Auto-deploy on security severity');
   });
 });


### PR DESCRIPTION
Summary:
- Deploy main/dev host-bundle publishes to existing VPSes by exact version after R2/platform registration.
- Switch sync-client CI and the dedicated CLI release workflow to Node 20, while leaving the broader release workflow on Node 24.
- Allow `cli-v*` tag pushes to publish `@finnaai/matrix` and update Homebrew by default.
- Serialize tag/manual CLI releases for the same version and fail host-bundle deploys when platform fan-out reports zero triggered machines or any failed updates.

Tests:
- `bun run test tests/scripts/delivery-resolve-lanes.test.ts tests/platform/ci-workflows.test.ts`
- `bun run check:patterns -- --diff origin/main`
- `git diff --check`
- `pnpm exec node -e "import("yaml").then(({parse})=>{const fs=require("node:fs"); for (const f of process.argv.slice(1)) { parse(fs.readFileSync(f,"utf8")); console.log(f); }}).catch((e)=>{ console.error(e); process.exit(1); })" .github/workflows/ci.yml .github/workflows/cli-release.yml .github/workflows/host-bundle-release.yml .github/workflows/release.yml`
- Earlier before review fixes: `bun run typecheck`
- Earlier before review fixes: `bun run test` (592 files passed, 6689 tests passed, 20 skipped)

Invariants:
- Source of truth: host-bundle release metadata registered by `publish-release.sh`; CLI version from `packages/sync-client/package.json`.
- Lock/transaction scope: no DB transaction changes; deploy job runs only after publish completes and uses exact `needs.build.outputs.version`.
- Acceptable orphan states: if R2/platform release registration succeeds but `/vps/deploy` fails or reports `failed > 0`/`triggered == 0`, the immutable bundle remains published and the workflow fails so operators can retry exact-version deploy.
- Auth source of truth: host-bundle deploy uses `PLATFORM_SECRET`; CLI release uses GitHub tag/manual workflow auth, npm token, and tap token.
- Deferred scope: full delta-object updater is still not implemented here; this only makes publish-to-deploy and CLI release defaults safer.

Node 20 note:
- The broad `.github/workflows/release.yml` stays on Node 24. Node 20 is used only where it proves the installable CLI minimum runtime: sync-client CI and the dedicated CLI release jobs.