### PR TITLE
fix(cli): create pnpm home during runner validation

### DIFF
--- a/packages/sync-client/scripts/validate-package-runners.mjs
+++ b/packages/sync-client/scripts/validate-package-runners.mjs
@@ -8,13 +8,18 @@ import { fileURLToPath } from "node:url";
 const pkgRoot = resolve(fileURLToPath(new URL("..", import.meta.url)));
 const tempRoot = await mkdtemp(join(tmpdir(), "matrix-cli-runners-"));
 
-function run(command, args, options = {}) {
+async function run(command, args, options = {}) {
+  const runHome = options.home ?? join(tempRoot, "home");
+  const pnpmHome = options.pnpmHome ?? join(tempRoot, "pnpm-home");
+  await mkdir(runHome, { recursive: true });
+  await mkdir(pnpmHome, { recursive: true });
   return new Promise((resolveRun, reject) => {
     const child = spawn(command, args, {
       cwd: options.cwd ?? pkgRoot,
       env: {
         ...process.env,
-        HOME: options.home ?? join(tempRoot, "home"),
+        HOME: runHome,
+        PNPM_HOME: pnpmHome,
         npm_config_yes: "true",
         npm_config_update_notifier: "false",
         ...options.env,
@@ -57,6 +62,7 @@ try {
   await mkdir(packDestination, { recursive: true });
   const packed = await run("npm", ["pack", "--pack-destination", packDestination, "--json"], {
     home: join(tempRoot, "npm-pack-home"),
+    pnpmHome: join(tempRoot, "npm-pack-pnpm-home"),
   });
   const [packInfo] = JSON.parse(packed.stdout);
   const tarball = join(packDestination, packInfo.filename);
@@ -75,6 +81,7 @@ try {
 
   const npmRun = await run("npm", ["exec", "--yes", "--package", tarball, "--", "matrix", "--version"], {
     home: join(tempRoot, "npm-exec-home"),
+    pnpmHome: join(tempRoot, "npm-exec-pnpm-home"),
   });
   const npmOutput = npmRun.stdout + npmRun.stderr;
   if (!npmOutput.includes(packInfo.version)) {
@@ -83,6 +90,7 @@ try {
 
   const pnpmRun = await run("pnpm", ["dlx", `file:${tarball}`, "--version"], {
     home: join(tempRoot, "pnpm-dlx-home"),
+    pnpmHome: join(tempRoot, "pnpm-dlx-pnpm-home"),
   });
   const pnpmOutput = pnpmRun.stdout + pnpmRun.stderr;
   if (!pnpmOutput.includes(packInfo.version)) {

--- a/tests/cli/package-runner.test.ts
+++ b/tests/cli/package-runner.test.ts
@@ -48,6 +48,21 @@ describe("published CLI package runners", () => {
     expect(script).toContain('MATRIX_CLI_STANDALONE: "1"');
   });
 
+  it("creates isolated package-manager homes before validating package runners", async () => {
+    const script = await readFile(
+      resolve(repoRoot, "packages/sync-client/scripts/validate-package-runners.mjs"),
+      "utf8",
+    );
+
+    expect(script).toContain("async function run(");
+    expect(script).toContain('await mkdir(runHome, { recursive: true });');
+    expect(script).toContain('await mkdir(pnpmHome, { recursive: true });');
+    expect(script).toContain('PNPM_HOME: pnpmHome');
+    expect(script).toContain('pnpmHome: join(tempRoot, "npm-pack-pnpm-home")');
+    expect(script).toContain('pnpmHome: join(tempRoot, "npm-exec-pnpm-home")');
+    expect(script).toContain('pnpmHome: join(tempRoot, "pnpm-dlx-pnpm-home")');
+  });
+
   it("installs standalone binary upgrades atomically", async () => {
     const script = await readFile(resolve(repoRoot, "scripts/install.sh"), "utf8");
 


### PR DESCRIPTION
## Summary
- create isolated HOME and PNPM_HOME directories before CLI package-runner validation spawns npm/pnpm
- add a regression assertion for the release validator so GitHub Actions does not fail pnpm dlx with a missing temp home

## Invariants
- Source of truth: the packaged @finnaai/matrix tarball remains the release artifact validated by npm exec and pnpm dlx.
- Lock/transaction scope: no persistent state or database writes; the script creates only per-run temp directories under mkdtemp output.
- Acceptable orphan states: temp validation directories are removed by the existing finally cleanup; a failed validation still aborts before npm publish.
- Auth source of truth: unchanged GitHub Actions/npm provenance path; no secrets or tokens are read by this change.
- Deferred scope: does not publish 0.3.7 by itself; the cli-v0.3.7 release tag will be retried after this fix lands.

## Validation
- bun run test tests/cli/package-runner.test.ts
- pnpm --filter @finnaai/matrix exec node ./scripts/validate-package-runners.mjs
- bun run check:patterns -- --diff origin/main
- git diff --check