### PR TITLE
fix(cli): keep homebrew formula on node 20

### DIFF
--- a/homebrew-tap/Formula/matrix.rb
+++ b/homebrew-tap/Formula/matrix.rb
@@ -19,7 +19,7 @@ class Matrix < Formula
 
   license "AGPL-3.0-or-later"
 
-  depends_on "node@24"
+  depends_on "node@20"
 
   def install
     # Install the package into libexec, then symlink the bins into HOMEBREW_PREFIX/bin.

--- a/tests/cli/package-runner.test.ts
+++ b/tests/cli/package-runner.test.ts
@@ -108,4 +108,11 @@ describe("published CLI package runners", () => {
       /macOS package not available for \$TAG; installing CLI-only standalone binary"\n\s+rm -rf "\$INSTALL_TMPDIR"\n\s+install_cli_binary "darwin" "\$TAG"/,
     );
   });
+
+  it("keeps the checked-in Homebrew formula on the CLI Node 20 runtime", async () => {
+    const formula = await readFile(resolve(repoRoot, "homebrew-tap/Formula/matrix.rb"), "utf8");
+
+    expect(formula).toContain('depends_on "node@20"');
+    expect(formula).not.toContain('depends_on "node@24"');
+  });
 });


### PR DESCRIPTION
## Summary

- Keeps the checked-in Homebrew formula on `node@20` for the Node 20-only CLI release line.
- Adds a regression test so future CLI/package-runner changes do not drift the formula back to Node 24.

## Validation

- `bun run test tests/cli/package-runner.test.ts`
- `bun run typecheck`
- `bun run check:patterns`
- `bun run test`

## Invariants

- Source of truth: CLI runtime support is declared by the package metadata and the checked-in Homebrew formula.
- Lock/transaction scope: no database or multi-write runtime state is touched.
- Acceptable orphan states: none; this only changes formula metadata and tests.
- Auth source of truth: unchanged; CLI auth/runtime behavior is not modified.
- Deferred scope: this does not publish npm or Homebrew by itself; release automation consumes the formula after merge.
