### PR TITLE
feat(runtime): publish incremental host bundle manifests

### DIFF
--- a/.github/workflows/host-bundle-release.yml
+++ b/.github/workflows/host-bundle-release.yml
@@ -265,6 +265,8 @@ jobs:
           path: |
             dist/host-bundle/matrix-host-bundle.tar.gz
             dist/host-bundle/matrix-host-bundle.tar.gz.sha256
+            dist/host-bundle/incremental-manifest.json
+            dist/host-bundle/objects/**
             dist/host-bundle/manifest.json
             dist/host-bundle/release.json
           if-no-files-found: error
@@ -308,7 +310,7 @@ jobs:
           fi
           SOURCE_DIR="$(dirname "$BUNDLE_FILE")"
           mkdir -p "$TARGET_DIR"
-          for file in matrix-host-bundle.tar.gz matrix-host-bundle.tar.gz.sha256 manifest.json release.json; do
+          for file in matrix-host-bundle.tar.gz matrix-host-bundle.tar.gz.sha256 incremental-manifest.json manifest.json release.json; do
             if [ ! -f "$SOURCE_DIR/$file" ]; then
               echo "Downloaded host bundle artifact is missing $file" >&2
               find "$ARTIFACT_DIR" -maxdepth 4 -type f -print >&2
@@ -316,6 +318,12 @@ jobs:
             fi
             cp "$SOURCE_DIR/$file" "$TARGET_DIR/$file"
           done
+          if [ ! -d "$SOURCE_DIR/objects" ]; then
+            echo "Downloaded host bundle artifact is missing objects/" >&2
+            find "$ARTIFACT_DIR" -maxdepth 4 -type f -print >&2
+            exit 1
+          fi
+          cp -a "$SOURCE_DIR/objects" "$TARGET_DIR/objects"
 
       - name: Install AWS CLI
         run: |

--- a/packages/platform/src/db.ts
+++ b/packages/platform/src/db.ts
@@ -68,6 +68,8 @@ interface HostBundleReleasesTable {
   build_time: string;
   bundle_key: string;
   checksum_key: string | null;
+  incremental_manifest_key: string | null;
+  incremental_manifest_sha256: string | null;
   sha256: string;
   size: number;
   severity: string;
@@ -423,6 +425,8 @@ export interface HostBundleReleaseRecord {
   buildTime: string;
   bundleKey: string;
   checksumKey: string | null;
+  incrementalManifestKey: string | null;
+  incrementalManifestSha256: string | null;
   sha256: string;
   size: number;
   severity: string;
@@ -439,6 +443,8 @@ export interface NewHostBundleRelease {
   buildTime: string;
   bundleKey: string;
   checksumKey?: string | null;
+  incrementalManifestKey?: string | null;
+  incrementalManifestSha256?: string | null;
   sha256: string;
   size: number;
   severity?: string;
@@ -783,6 +789,8 @@ async function migrate(db: Kysely<PlatformDatabase>): Promise<void> {
       build_time TEXT NOT NULL,
       bundle_key TEXT NOT NULL,
       checksum_key TEXT,
+      incremental_manifest_key TEXT,
+      incremental_manifest_sha256 TEXT,
       sha256 TEXT NOT NULL,
       size INTEGER NOT NULL,
       severity TEXT NOT NULL DEFAULT 'normal',
@@ -792,6 +800,8 @@ async function migrate(db: Kysely<PlatformDatabase>): Promise<void> {
     )
   `.execute(db);
   await sql`ALTER TABLE host_bundle_releases ADD COLUMN IF NOT EXISTS channel TEXT`.execute(db);
+  await sql`ALTER TABLE host_bundle_releases ADD COLUMN IF NOT EXISTS incremental_manifest_key TEXT`.execute(db);
+  await sql`ALTER TABLE host_bundle_releases ADD COLUMN IF NOT EXISTS incremental_manifest_sha256 TEXT`.execute(db);
   await sql`CREATE INDEX IF NOT EXISTS idx_host_bundle_releases_channel ON host_bundle_releases(channel)`.execute(db);
   await sql`CREATE INDEX IF NOT EXISTS idx_host_bundle_releases_created_at ON host_bundle_releases(created_at)`.execute(db);
 
@@ -1188,6 +1198,8 @@ function mapHostBundleRelease(row: HostBundleReleasesTable): HostBundleReleaseRe
     buildTime: row.build_time,
     bundleKey: row.bundle_key,
     checksumKey: row.checksum_key,
+    incrementalManifestKey: row.incremental_manifest_key,
+    incrementalManifestSha256: row.incremental_manifest_sha256,
     sha256: row.sha256,
     size: row.size,
     severity: row.severity,
@@ -1207,6 +1219,8 @@ function toHostBundleReleaseRow(record: NewHostBundleRelease): HostBundleRelease
     build_time: record.buildTime,
     bundle_key: record.bundleKey,
     checksum_key: record.checksumKey ?? null,
+    incremental_manifest_key: record.incrementalManifestKey ?? null,
+    incremental_manifest_sha256: record.incrementalManifestSha256 ?? null,
     sha256: record.sha256,
     size: record.size,
     severity: record.severity ?? 'normal',
@@ -2070,9 +2084,13 @@ export async function upsertHostBundleRelease(
           severity: row.severity,
           update_type: row.update_type,
           changelog: row.changelog,
+          incremental_manifest_key: row.incremental_manifest_key,
+          incremental_manifest_sha256: row.incremental_manifest_sha256,
         })
           .where(sql<boolean>`host_bundle_releases.bundle_key = ${row.bundle_key}`)
           .where(sql<boolean>`host_bundle_releases.checksum_key IS NOT DISTINCT FROM ${row.checksum_key}`)
+          .where(sql<boolean>`host_bundle_releases.incremental_manifest_key IS NOT DISTINCT FROM ${row.incremental_manifest_key}`)
+          .where(sql<boolean>`host_bundle_releases.incremental_manifest_sha256 IS NOT DISTINCT FROM ${row.incremental_manifest_sha256}`)
           .where(sql<boolean>`host_bundle_releases.sha256 = ${row.sha256}`)
           .where(sql<boolean>`host_bundle_releases.size = ${row.size}`),
       )

--- a/packages/platform/src/main.ts
+++ b/packages/platform/src/main.ts
@@ -181,6 +181,7 @@ const HOST_BUNDLE_IMAGE_VERSION_PATTERN = /^[A-Za-z0-9._-]{1,128}$/;
 const HOST_BUNDLE_FILES = new Set([
   'matrix-host-bundle.tar.gz',
   'matrix-host-bundle.tar.gz.sha256',
+  'incremental-manifest.json',
   'manifest.json',
   'release.json',
 ]);
@@ -247,6 +248,8 @@ const HostBundleReleaseBodySchema = z.object({
   buildTime: z.string().min(1).max(128),
   bundleKey: z.string().regex(/^system-bundles\/[A-Za-z0-9._-]{1,128}\/matrix-host-bundle\.tar\.gz$/),
   checksumKey: z.string().regex(/^system-bundles\/[A-Za-z0-9._-]{1,128}\/matrix-host-bundle\.tar\.gz\.sha256$/).nullable().optional(),
+  incrementalManifestKey: z.string().regex(/^system-bundles\/[A-Za-z0-9._-]{1,128}\/incremental-manifest\.json$/).nullable().optional(),
+  incrementalManifestSha256: z.string().regex(/^[a-f0-9]{64}$/i).nullable().optional(),
   sha256: z.string().regex(/^[a-f0-9]{64}$/i),
   size: z.number().int().positive(),
   severity: z.enum(['normal', 'security']).optional(),
@@ -468,6 +471,8 @@ function hostBundleReleaseResponse(
     buildTime: release.buildTime,
     bundleKey: release.bundleKey,
     checksumKey: release.checksumKey,
+    incrementalManifestKey: release.incrementalManifestKey,
+    incrementalManifestSha256: release.incrementalManifestSha256,
     sha256: release.sha256,
     bundleSha256: release.sha256,
     size: release.size,
@@ -2129,6 +2134,10 @@ export function createApp(deps: {
   }
 
   async function getSignedBundleUrl(release: HostBundleReleaseRecord): Promise<string> {
+    return getSignedHostBundleObjectUrl(release.bundleKey);
+  }
+
+  async function getSignedHostBundleObjectUrl(key: string): Promise<string> {
     const hostBundleObjectStore = getHostBundleObjectStore();
     if (!hostBundleObjectStore) {
       throw new Error('Host bundle storage unavailable');
@@ -2136,7 +2145,7 @@ export function createApp(deps: {
     if (!hostBundleObjectStore.getPresignedGetUrl) {
       throw new Error('Host bundle storage cannot create signed URLs');
     }
-    return hostBundleObjectStore.getPresignedGetUrl(release.bundleKey, 3600);
+    return hostBundleObjectStore.getPresignedGetUrl(key, 3600);
   }
 
   function requireHostBundleAdmin(c: Context): Response | null {
@@ -2265,6 +2274,57 @@ export function createApp(deps: {
     }
   });
 
+  app.get('/system-bundles/objects/sha256/:sha256', async (c) => {
+    const hostBundleObjectStore = getHostBundleObjectStore();
+    if (!hostBundleObjectStore) {
+      return c.json({ error: 'Host bundle storage unavailable' }, 503);
+    }
+
+    const sha256 = c.req.param('sha256');
+    if (!/^[a-f0-9]{64}$/i.test(sha256)) {
+      return c.json({ error: 'Invalid request' }, 400);
+    }
+
+    const objectKey = `system-bundles/objects/sha256/${sha256.toLowerCase()}`;
+    if (hostBundleObjectStore.getPresignedGetUrl) {
+      try {
+        const url = await getSignedHostBundleObjectUrl(objectKey);
+        return c.redirect(url, 302);
+      } catch (err: unknown) {
+        if (isObjectNotFoundError(err)) {
+          return c.json({ error: 'Not found' }, 404);
+        }
+        logPlatformRouteError('/system-bundles/objects/sha256/:sha256', err);
+        return c.json({ error: 'Host bundle unavailable' }, 502);
+      }
+    }
+
+    try {
+      const object = await hostBundleObjectStore.getObject(
+        objectKey,
+        { signal: AbortSignal.timeout(HOST_BUNDLE_READ_TIMEOUT_MS) },
+      );
+      if (!object.body) {
+        return c.json({ error: 'Not found' }, 404);
+      }
+      return new Response(object.body, {
+        status: 200,
+        headers: {
+          'content-type': 'application/octet-stream',
+          'cache-control': 'public, max-age=31536000, immutable',
+          'cdn-cache-control': 'public, max-age=31536000, immutable',
+          'cloudflare-cdn-cache-control': 'public, max-age=31536000, immutable',
+        },
+      });
+    } catch (err: unknown) {
+      if (isObjectNotFoundError(err)) {
+        return c.json({ error: 'Not found' }, 404);
+      }
+      logPlatformRouteError('/system-bundles/objects/sha256/:sha256 getObject', err);
+      return c.json({ error: 'Host bundle unavailable' }, 502);
+    }
+  });
+
   // Public, immutable host-service bundles used by customer VPS cloud-init.
   // Metadata comes from Postgres; R2 only stores the bytes.
   app.get('/system-bundles/:imageVersion/:file', async (c) => {
@@ -2342,6 +2402,48 @@ export function createApp(deps: {
         'content-type': 'text/plain; charset=utf-8',
         ...cacheHeaders,
       });
+    }
+
+    if (file === 'incremental-manifest.json') {
+      if (!release.incrementalManifestKey) {
+        return c.json({ error: 'Not found' }, 404);
+      }
+      if (hostBundleObjectStore.getPresignedGetUrl) {
+        try {
+          const url = await getSignedHostBundleObjectUrl(release.incrementalManifestKey);
+          return c.redirect(url, 302);
+        } catch (err: unknown) {
+          if (isObjectNotFoundError(err)) {
+            return c.json({ error: 'Not found' }, 404);
+          }
+          logPlatformRouteError('/system-bundles/:imageVersion/incremental-manifest.json', err);
+          return c.json({ error: 'Host bundle unavailable' }, 502);
+        }
+      }
+      try {
+        const object = await hostBundleObjectStore.getObject(
+          release.incrementalManifestKey,
+          { signal: AbortSignal.timeout(HOST_BUNDLE_READ_TIMEOUT_MS) },
+        );
+        if (!object.body) {
+          return c.json({ error: 'Not found' }, 404);
+        }
+        return new Response(object.body, {
+          status: 200,
+          headers: {
+            'content-type': 'application/json; charset=utf-8',
+            'cache-control': 'public, max-age=31536000, immutable',
+            'cdn-cache-control': 'public, max-age=31536000, immutable',
+            'cloudflare-cdn-cache-control': 'public, max-age=31536000, immutable',
+          },
+        });
+      } catch (err: unknown) {
+        if (isObjectNotFoundError(err)) {
+          return c.json({ error: 'Not found' }, 404);
+        }
+        logPlatformRouteError('/system-bundles/:imageVersion/incremental-manifest.json getObject', err);
+        return c.json({ error: 'Host bundle unavailable' }, 502);
+      }
     }
 
     if (file.endsWith('.json')) {

--- a/scripts/build-host-bundle.sh
+++ b/scripts/build-host-bundle.sh
@@ -106,9 +106,13 @@ fi
 rm -rf "$STAGE_DIR/app/shell/.next/cache" "$STAGE_DIR/app/shell/e2e" "$STAGE_DIR/app/shell/node_modules"
 find "$STAGE_DIR/app/home/apps" -type d -name node_modules -prune -exec rm -rf {} +
 
-# Writes release.json into the bundle and manifest.json beside the tarball.
+# Writes release.json plus the incremental app manifest before packaging, then
+# writes the bundle manifest beside the tarball.
 node "$ROOT_DIR/scripts/host-bundle-release.mjs" write-release
-tar -C "$STAGE_DIR" -czf "$DIST_DIR/$BUNDLE_NAME" bin app runtime systemd release.json
+HOST_BUNDLE_INCREMENTAL_EXCLUDE_PREFIXES="${HOST_BUNDLE_INCREMENTAL_EXCLUDE_PREFIXES:-node_modules/}" \
+  node "$ROOT_DIR/scripts/host-bundle-incremental-manifest.mjs" "$STAGE_DIR/app" "$STAGE_DIR/incremental-manifest.json" "$DIST_DIR/objects"
+cp -a "$STAGE_DIR/incremental-manifest.json" "$DIST_DIR/incremental-manifest.json"
+tar -C "$STAGE_DIR" -czf "$DIST_DIR/$BUNDLE_NAME" bin app runtime systemd release.json incremental-manifest.json
 node "$ROOT_DIR/scripts/host-bundle-release.mjs" write-manifest
 
 printf '%s\n' "$DIST_DIR/$BUNDLE_NAME"

--- a/scripts/host-bundle-incremental-manifest.mjs
+++ b/scripts/host-bundle-incremental-manifest.mjs
@@ -1,0 +1,170 @@
+#!/usr/bin/env node
+import { createHash } from "node:crypto";
+import { createReadStream } from "node:fs";
+import { copyFile, lstat, mkdir, readdir, readlink, writeFile } from "node:fs/promises";
+import { dirname, join, relative, resolve, sep } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const DEFAULT_OBJECT_ROOT = "system-bundles/objects/sha256";
+const DEFAULT_EXCLUDED_PREFIXES = ["node_modules/"];
+const DEFAULT_PROTECTED_PATHS = [
+  "/home/matrix/home/system/desktop.json",
+  "/home/matrix/home/system/theme.json",
+  "/home/matrix/home/system/wallpapers/",
+  "/home/matrix/home/system/icons/",
+  "/home/matrix/home/conversations/",
+  "/home/matrix/home/memory/",
+];
+
+function toManifestPath(root, path) {
+  const rel = relative(root, path).split(sep).join("/");
+  if (!rel || rel === "." || rel.startsWith("../") || rel.includes("/../")) {
+    throw new Error(`invalid app manifest path: ${rel}`);
+  }
+  return rel;
+}
+
+function modeString(mode) {
+  return (mode & 0o777).toString(8).padStart(4, "0");
+}
+
+function compareStablePath(a, b) {
+  return a < b ? -1 : a > b ? 1 : 0;
+}
+
+function isExcludedPath(manifestPath, excludedPrefixes) {
+  return excludedPrefixes.some((prefix) => (
+    manifestPath === prefix.slice(0, -1) ||
+    manifestPath.startsWith(prefix)
+  ));
+}
+
+function parseExcludedPrefixes(value) {
+  if (!value) return DEFAULT_EXCLUDED_PREFIXES;
+  return value
+    .split(",")
+    .map((prefix) => prefix.trim())
+    .filter(Boolean)
+    .map((prefix) => (prefix.endsWith("/") ? prefix : `${prefix}/`));
+}
+
+async function sha256File(path) {
+  const hash = createHash("sha256");
+  await new Promise((resolvePromise, reject) => {
+    createReadStream(path)
+      .on("data", (chunk) => hash.update(chunk))
+      .on("error", reject)
+      .on("end", resolvePromise);
+  });
+  return hash.digest("hex");
+}
+
+function assertRelativeSymlinkTargetInsideRoot(appRoot, linkPath, target) {
+  if (target.startsWith("/")) {
+    throw new Error(`symlink ${toManifestPath(appRoot, linkPath)} target is absolute`);
+  }
+  const resolved = resolve(dirname(linkPath), target);
+  if (resolved !== appRoot && !resolved.startsWith(`${appRoot}${sep}`)) {
+    throw new Error(`symlink ${toManifestPath(appRoot, linkPath)} target escapes app root`);
+  }
+}
+
+async function writeObjectFile(objectDir, sha256, sourcePath) {
+  if (!objectDir) return;
+  const target = join(objectDir, "sha256", sha256);
+  await mkdir(dirname(target), { recursive: true });
+  await copyFile(sourcePath, target);
+}
+
+async function walkAppTree(appRoot, current, entries) {
+  const names = await readdir(current);
+  names.sort(compareStablePath);
+  for (const name of names) {
+    const path = join(current, name);
+    const manifestPath = toManifestPath(appRoot, path);
+    if (isExcludedPath(manifestPath, entries.excludedPrefixes)) {
+      continue;
+    }
+    const stat = await lstat(path);
+    if (stat.isDirectory()) {
+      await walkAppTree(appRoot, path, entries);
+      continue;
+    }
+    if (stat.isSymbolicLink()) {
+      const target = await readlink(path);
+      assertRelativeSymlinkTargetInsideRoot(appRoot, path, target);
+      entries.symlinks.push({ path: manifestPath, target });
+      continue;
+    }
+    if (!stat.isFile()) {
+      throw new Error(`unsupported host bundle app entry: ${manifestPath}`);
+    }
+    const sha256 = await sha256File(path);
+    await writeObjectFile(entries.objectDir, sha256, path);
+    entries.files.push({
+      type: "file",
+      path: manifestPath,
+      sha256,
+      size: stat.size,
+      mode: modeString(stat.mode),
+      url: `${entries.objectRoot}/${sha256}`,
+    });
+  }
+}
+
+export async function buildIncrementalManifest(options) {
+  const appRoot = resolve(options.appDir);
+  const objectRoot = options.objectRoot ?? DEFAULT_OBJECT_ROOT;
+  const entries = {
+    files: [],
+    symlinks: [],
+    objectRoot,
+    objectDir: options.objectDir ? resolve(options.objectDir) : null,
+    excludedPrefixes: options.excludedPrefixes ?? DEFAULT_EXCLUDED_PREFIXES,
+  };
+  await walkAppTree(appRoot, appRoot, entries);
+  entries.files.sort((a, b) => compareStablePath(a.path, b.path));
+  entries.symlinks.sort((a, b) => compareStablePath(a.path, b.path));
+
+  return {
+    manifestVersion: 1,
+    version: options.version,
+    baseVersion: options.baseVersion ?? null,
+    objectRoot,
+    files: entries.files,
+    symlinks: entries.symlinks,
+    delete: [],
+    requiresFullBundle: options.requiresFullBundle ?? true,
+    excludedPrefixes: entries.excludedPrefixes,
+    protected: options.protectedPaths ?? DEFAULT_PROTECTED_PATHS,
+  };
+}
+
+export function canonicalManifestJson(manifest) {
+  return `${JSON.stringify(manifest, null, 2)}\n`;
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  const appDir = args[0];
+  const outPath = args[1];
+  const objectDir = args[2] || null;
+  if (!appDir || !outPath) {
+    console.error("usage: host-bundle-incremental-manifest.mjs <app-dir> <out-json> [objects-dir]");
+    process.exit(2);
+  }
+  const manifest = await buildIncrementalManifest({
+    appDir,
+    objectDir,
+    version: process.env.HOST_BUNDLE_VERSION || process.env.MATRIX_VERSION || "unknown",
+    baseVersion: process.env.HOST_BUNDLE_BASE_VERSION || null,
+    requiresFullBundle: process.env.HOST_BUNDLE_INCREMENTAL_REQUIRES_FULL_BUNDLE !== "false",
+    excludedPrefixes: parseExcludedPrefixes(process.env.HOST_BUNDLE_INCREMENTAL_EXCLUDE_PREFIXES),
+  });
+  await mkdir(dirname(outPath), { recursive: true });
+  await writeFile(outPath, canonicalManifestJson(manifest));
+}
+
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  await main();
+}

--- a/scripts/host-bundle-release.mjs
+++ b/scripts/host-bundle-release.mjs
@@ -68,8 +68,11 @@ async function writeManifest() {
   const release = JSON.parse(await readFile(join(distDir, "release.json"), "utf8"));
   const policy = releasePolicy();
   const bundlePath = join(distDir, bundleName);
+  const incrementalManifestPath = join(distDir, "incremental-manifest.json");
   const checksum = await sha256(bundlePath);
   const bundleStat = await stat(bundlePath);
+  const incrementalManifestChecksum = await sha256(incrementalManifestPath);
+  const incrementalManifestStat = await stat(incrementalManifestPath);
   const checksumText = `${checksum}  ${bundleName}\n`;
   await writeFile(join(distDir, `${bundleName}.sha256`), checksumText);
   const manifest = {
@@ -89,6 +92,11 @@ async function writeManifest() {
         path: `system-bundles/${release.version}/${bundleName}.sha256`,
         sha256: await sha256(join(distDir, `${bundleName}.sha256`)),
         size: Buffer.byteLength(checksumText),
+      },
+      incrementalManifest: {
+        path: `system-bundles/${release.version}/incremental-manifest.json`,
+        sha256: incrementalManifestChecksum,
+        size: incrementalManifestStat.size,
       },
     },
   };

--- a/scripts/publish-release-r2.mjs
+++ b/scripts/publish-release-r2.mjs
@@ -69,8 +69,10 @@ const bundlePath = join(distDir, bundleName);
 const checksumPath = join(await mkdtemp(join(tmpdir(), "matrix-bundle-")), `${bundleName}.sha256`);
 const manifestPath = join(distDir, "manifest.json");
 const releasePath = join(distDir, "release.json");
+const incrementalManifestPath = join(distDir, "incremental-manifest.json");
 const bundleKey = `system-bundles/${version}/${bundleName}`;
 const checksumKey = `${bundleKey}.sha256`;
+const incrementalManifestKey = `system-bundles/${version}/incremental-manifest.json`;
 const bucket = process.env.R2_BUCKET || "matrixos-sync";
 const platformPublicUrl = process.env.PLATFORM_PUBLIC_URL || "https://app.matrix-os.com";
 const updateType = severity === "security" ? "auto" : "manual";
@@ -157,13 +159,42 @@ async function uploadImmutable(s3, path, key, contentType, metadataSha256, size)
   }));
 }
 
+function incrementalObjectEntries(incrementalManifest) {
+  if (!Array.isArray(incrementalManifest.files)) return [];
+  return incrementalManifest.files.map((file) => {
+    if (
+      !file ||
+      file.type !== "file" ||
+      typeof file.sha256 !== "string" ||
+      !/^[a-f0-9]{64}$/.test(file.sha256) ||
+      typeof file.url !== "string" ||
+      file.url !== `system-bundles/objects/sha256/${file.sha256}` ||
+      typeof file.size !== "number" ||
+      !Number.isSafeInteger(file.size) ||
+      file.size < 0
+    ) {
+      throw new Error("incremental manifest contains an invalid file object entry");
+    }
+    return {
+      key: file.url,
+      path: join(distDir, "objects", "sha256", file.sha256),
+      sha256: file.sha256,
+      size: file.size,
+    };
+  });
+}
+
 const bundleStat = await stat(bundlePath);
 const checksum = await sha256(bundlePath);
 const checksumText = `${checksum}  ${bundleName}\n`;
 await writeFile(checksumPath, checksumText);
 const checksumStat = await stat(checksumPath);
+const incrementalManifestStat = await stat(incrementalManifestPath);
+const incrementalManifestSha256 = await sha256(incrementalManifestPath);
 const release = await readJson(releasePath);
 const manifest = await readJson(manifestPath);
+const incrementalManifest = await readJson(incrementalManifestPath);
+const incrementalObjects = incrementalObjectEntries(incrementalManifest);
 
 const registrationBody = {
   version,
@@ -172,6 +203,8 @@ const registrationBody = {
   buildTime: manifest.buildTime || release.buildTime || new Date().toISOString(),
   bundleKey,
   checksumKey,
+  incrementalManifestKey,
+  incrementalManifestSha256,
   sha256: checksum,
   size: bundleStat.size,
   severity,
@@ -187,6 +220,8 @@ if (dryRun) {
   console.log("=== DRY RUN ===");
   console.log(`Would upload ${bundlePath} to s3://${bucket}/${bundleKey}`);
   console.log(`Would upload checksum to s3://${bucket}/${checksumKey}`);
+  console.log(`Would upload ${incrementalObjects.length} incremental file objects`);
+  console.log(`Would upload incremental manifest to s3://${bucket}/${incrementalManifestKey}`);
   console.log("Would register release:");
   console.log(JSON.stringify(registrationBody, null, 2));
   process.exit(0);
@@ -213,6 +248,39 @@ if (!(await verifyExistingBundle(s3, bundleKey, bundleStat.size, checksum))) {
 console.log("  Uploading checksum...");
 if (!(await verifyExistingChecksum(s3, checksumKey, checksum))) {
   await uploadImmutable(s3, checksumPath, checksumKey, "text/plain; charset=utf-8", checksum, checksumStat.size);
+}
+
+console.log(`  Uploading ${incrementalObjects.length} incremental file objects...`);
+for (const object of incrementalObjects) {
+  const objectStat = await stat(object.path);
+  if (objectStat.size !== object.size) {
+    throw new Error(`incremental object size mismatch for ${object.path}`);
+  }
+  if ((await sha256(object.path)) !== object.sha256) {
+    throw new Error(`incremental object checksum mismatch for ${object.path}`);
+  }
+  if (!(await verifyExistingBundle(s3, object.key, object.size, object.sha256))) {
+    await uploadImmutable(
+      s3,
+      object.path,
+      object.key,
+      "application/octet-stream",
+      object.sha256,
+      object.size,
+    );
+  }
+}
+
+console.log("  Uploading incremental manifest...");
+if (!(await verifyExistingBundle(s3, incrementalManifestKey, incrementalManifestStat.size, incrementalManifestSha256))) {
+  await uploadImmutable(
+    s3,
+    incrementalManifestPath,
+    incrementalManifestKey,
+    "application/json; charset=utf-8",
+    incrementalManifestSha256,
+    incrementalManifestStat.size,
+  );
 }
 
 console.log("  Registering release in platform DB...");

--- a/scripts/publish-release.sh
+++ b/scripts/publish-release.sh
@@ -21,6 +21,7 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 DIST_DIR="${HOST_BUNDLE_DIST_DIR:-$ROOT_DIR/dist/host-bundle}"
 BUNDLE="$DIST_DIR/matrix-host-bundle.tar.gz"
+INCREMENTAL_MANIFEST="$DIST_DIR/incremental-manifest.json"
 CHANNEL="${HOST_BUNDLE_CHANNEL:-${MATRIX_IMAGE_VERSION:-dev}}"
 VERSION=""
 DRY_RUN=""
@@ -65,6 +66,10 @@ if [ ! -f "$BUNDLE" ]; then
   echo "Bundle not found at $BUNDLE — run build-host-bundle.sh first" >&2
   exit 1
 fi
+if [ ! -f "$INCREMENTAL_MANIFEST" ]; then
+  echo "Incremental manifest not found at $INCREMENTAL_MANIFEST — run build-host-bundle.sh first" >&2
+  exit 1
+fi
 
 if ! command -v aws >/dev/null 2>&1; then
   echo "aws CLI not found; publishing through scripts/publish-release-r2.mjs"
@@ -89,6 +94,8 @@ PLATFORM_PUBLIC_URL="${PLATFORM_PUBLIC_URL:-https://app.matrix-os.com}"
 
 SHA256="$(sha256sum "$BUNDLE" | awk '{print $1}')"
 SIZE="$(stat --printf='%s' "$BUNDLE")"
+INCREMENTAL_MANIFEST_SHA256="$(sha256sum "$INCREMENTAL_MANIFEST" | awk '{print $1}')"
+INCREMENTAL_MANIFEST_SIZE="$(stat --printf='%s' "$INCREMENTAL_MANIFEST")"
 PUBLISHED="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 GIT_COMMIT="$(python3 -c "import json,sys; print(json.load(open(sys.argv[1])).get('gitCommit',''))" "$DIST_DIR/manifest.json" 2>/dev/null || true)"
 GIT_REF="$(python3 -c "import json,sys; print(json.load(open(sys.argv[1])).get('gitRef',''))" "$DIST_DIR/manifest.json" 2>/dev/null || true)"
@@ -98,6 +105,7 @@ GIT_REF="${GIT_REF:-$(git -C "$ROOT_DIR" rev-parse --abbrev-ref HEAD)}"
 BUILD_TIME="${BUILD_TIME:-$PUBLISHED}"
 BUNDLE_KEY="system-bundles/$VERSION/matrix-host-bundle.tar.gz"
 CHECKSUM_KEY="system-bundles/$VERSION/matrix-host-bundle.tar.gz.sha256"
+INCREMENTAL_MANIFEST_KEY="system-bundles/$VERSION/incremental-manifest.json"
 
 REGISTRATION_BODY=$(python3 -c "
 import json, sys
@@ -108,14 +116,41 @@ print(json.dumps({
     'buildTime': sys.argv[4],
     'bundleKey': sys.argv[5],
     'checksumKey': sys.argv[6],
-    'sha256': sys.argv[7],
-    'size': int(sys.argv[8]),
-    'severity': sys.argv[9],
-    'updateType': sys.argv[10],
-    'changelog': sys.argv[11] or None,
-    **({} if sys.argv[12] == 'none' else {'channel': sys.argv[12]}),
+    'incrementalManifestKey': sys.argv[7],
+    'incrementalManifestSha256': sys.argv[8],
+    'sha256': sys.argv[9],
+    'size': int(sys.argv[10]),
+    'severity': sys.argv[11],
+    'updateType': sys.argv[12],
+    'changelog': sys.argv[13] or None,
+    **({} if sys.argv[14] == 'none' else {'channel': sys.argv[14]}),
 }, indent=2))
-" "$VERSION" "$GIT_COMMIT" "$GIT_REF" "$BUILD_TIME" "$BUNDLE_KEY" "$CHECKSUM_KEY" "$SHA256" "$SIZE" "$SEVERITY" "$UPDATE_TYPE" "$CHANGELOG" "$CHANNEL")
+" "$VERSION" "$GIT_COMMIT" "$GIT_REF" "$BUILD_TIME" "$BUNDLE_KEY" "$CHECKSUM_KEY" "$INCREMENTAL_MANIFEST_KEY" "$INCREMENTAL_MANIFEST_SHA256" "$SHA256" "$SIZE" "$SEVERITY" "$UPDATE_TYPE" "$CHANGELOG" "$CHANNEL")
+
+incremental_object_count() {
+  python3 -c "import json,sys; print(len(json.load(open(sys.argv[1])).get('files', [])))" "$INCREMENTAL_MANIFEST"
+}
+
+write_incremental_object_list() {
+  python3 -c "
+import json, re, sys
+manifest = json.load(open(sys.argv[1]))
+for entry in manifest.get('files', []):
+    sha = entry.get('sha256')
+    key = entry.get('url')
+    size = entry.get('size')
+    if (
+        entry.get('type') != 'file'
+        or not isinstance(sha, str)
+        or not re.fullmatch(r'[a-f0-9]{64}', sha)
+        or key != f'system-bundles/objects/sha256/{sha}'
+        or not isinstance(size, int)
+        or size < 0
+    ):
+        raise SystemExit('incremental manifest contains an invalid file object entry')
+    print(f'{sha}\t{size}\t{key}')
+" "$INCREMENTAL_MANIFEST"
+}
 
 AWS_ARGS=(--endpoint-url "$R2_ENDPOINT" --region auto)
 
@@ -142,6 +177,20 @@ checksum_object_sha256() {
 bundle_object_sha256() {
   local key="$1"
   aws s3 cp "s3://$R2_BUCKET/$key" - "${AWS_ARGS[@]}" 2>/dev/null | sha256sum | awk '{print $1}'
+}
+
+verify_existing_incremental_manifest() {
+  local existing_size existing_sha256
+  existing_size="$(object_size "$INCREMENTAL_MANIFEST_KEY")"
+  if [ "$existing_size" != "$INCREMENTAL_MANIFEST_SIZE" ]; then
+    echo "ERROR: existing immutable incremental manifest size mismatch for s3://$R2_BUCKET/$INCREMENTAL_MANIFEST_KEY" >&2
+    exit 1
+  fi
+  existing_sha256="$(bundle_object_sha256 "$INCREMENTAL_MANIFEST_KEY")"
+  if [ "$existing_sha256" != "$INCREMENTAL_MANIFEST_SHA256" ]; then
+    echo "ERROR: existing immutable incremental manifest content mismatch for s3://$R2_BUCKET/$INCREMENTAL_MANIFEST_KEY" >&2
+    exit 1
+  fi
 }
 
 verify_existing_bundle() {
@@ -174,10 +223,28 @@ verify_existing_checksum() {
   fi
 }
 
+verify_existing_content_object() {
+  local key="$1"
+  local expected_size="$2"
+  local expected_sha256="$3"
+  local existing_size existing_sha256
+  existing_size="$(object_size "$key")"
+  if [ "$existing_size" != "$expected_size" ]; then
+    echo "ERROR: existing immutable object size mismatch for s3://$R2_BUCKET/$key" >&2
+    exit 1
+  fi
+  existing_sha256="$(bundle_object_sha256 "$key")"
+  if [ "$existing_sha256" != "$expected_sha256" ]; then
+    echo "ERROR: existing immutable object content mismatch for s3://$R2_BUCKET/$key" >&2
+    exit 1
+  fi
+}
+
 upload_immutable_object() {
   local source_file="$1"
   local key="$2"
   local content_type="$3"
+  local metadata_sha256="${4:-$SHA256}"
 
   if object_exists "$key"; then
     echo "  Immutable object already exists: s3://$R2_BUCKET/$key"
@@ -189,7 +256,7 @@ upload_immutable_object() {
     --key "$key" \
     --body "$source_file" \
     --content-type "$content_type" \
-    --metadata "sha256=$SHA256" \
+    --metadata "sha256=$metadata_sha256" \
     --if-none-match '*' \
     "${AWS_ARGS[@]}" >/dev/null
 }
@@ -206,6 +273,8 @@ if [ "$DRY_RUN" = "1" ]; then
   echo "Would upload immutable artifacts:"
   echo "  $BUNDLE → s3://$R2_BUCKET/$BUNDLE_KEY"
   echo "  sha256 → s3://$R2_BUCKET/$CHECKSUM_KEY"
+  echo "  $(incremental_object_count) incremental file objects"
+  echo "  incremental manifest → s3://$R2_BUCKET/$INCREMENTAL_MANIFEST_KEY"
   echo ""
   echo "Would register release in platform DB:"
   echo "$REGISTRATION_BODY"
@@ -217,9 +286,11 @@ echo "  Bundle: $SIZE bytes, sha256: $SHA256"
 
 AUTH_HEADER_FILE=""
 CHECKSUM_FILE="$(mktemp)"
-cleanup_temp_files() { rm -f "$AUTH_HEADER_FILE" "$CHECKSUM_FILE"; }
+INCREMENTAL_OBJECTS_FILE="$(mktemp)"
+cleanup_temp_files() { rm -f "$AUTH_HEADER_FILE" "$CHECKSUM_FILE" "$INCREMENTAL_OBJECTS_FILE"; }
 trap cleanup_temp_files EXIT
 printf '%s  matrix-host-bundle.tar.gz\n' "$SHA256" > "$CHECKSUM_FILE"
+write_incremental_object_list > "$INCREMENTAL_OBJECTS_FILE"
 
 echo "  Uploading versioned archive..."
 if object_exists "$BUNDLE_KEY"; then
@@ -233,6 +304,35 @@ if object_exists "$CHECKSUM_KEY"; then
   verify_existing_checksum
 else
   upload_immutable_object "$CHECKSUM_FILE" "$CHECKSUM_KEY" "text/plain; charset=utf-8"
+fi
+echo "  Uploading incremental file objects..."
+while IFS=$'\t' read -r object_sha256 object_size object_key; do
+  object_file="$DIST_DIR/objects/sha256/$object_sha256"
+  if [ ! -f "$object_file" ]; then
+    echo "ERROR: missing incremental object file $object_file" >&2
+    exit 1
+  fi
+  actual_size="$(stat --printf='%s' "$object_file")"
+  if [ "$actual_size" != "$object_size" ]; then
+    echo "ERROR: incremental object size mismatch for $object_file" >&2
+    exit 1
+  fi
+  actual_sha256="$(sha256sum "$object_file" | awk '{print $1}')"
+  if [ "$actual_sha256" != "$object_sha256" ]; then
+    echo "ERROR: incremental object checksum mismatch for $object_file" >&2
+    exit 1
+  fi
+  if object_exists "$object_key"; then
+    verify_existing_content_object "$object_key" "$object_size" "$object_sha256"
+  else
+    upload_immutable_object "$object_file" "$object_key" "application/octet-stream" "$object_sha256"
+  fi
+done < "$INCREMENTAL_OBJECTS_FILE"
+if object_exists "$INCREMENTAL_MANIFEST_KEY"; then
+  echo "  Verifying existing immutable incremental manifest..."
+  verify_existing_incremental_manifest
+else
+  upload_immutable_object "$INCREMENTAL_MANIFEST" "$INCREMENTAL_MANIFEST_KEY" "application/json; charset=utf-8" "$INCREMENTAL_MANIFEST_SHA256"
 fi
 
 echo "  Registering release in platform DB..."

--- a/tests/platform/customer-vps-host-bundle.test.ts
+++ b/tests/platform/customer-vps-host-bundle.test.ts
@@ -47,10 +47,13 @@ describe('customer VPS host bundle', () => {
     expect(script).toContain('scripts/reset-shipped-icons.mjs');
     expect(script).toContain('scripts/sync-matrix-agent-skills.sh');
     expect(script).toContain('scripts/host-bundle-release.mjs" write-release');
+    expect(script).toContain('HOST_BUNDLE_INCREMENTAL_EXCLUDE_PREFIXES="${HOST_BUNDLE_INCREMENTAL_EXCLUDE_PREFIXES:-node_modules/}"');
+    expect(script).toContain('scripts/host-bundle-incremental-manifest.mjs" "$STAGE_DIR/app" "$STAGE_DIR/incremental-manifest.json" "$DIST_DIR/objects"');
     expect(script).toContain('scripts/host-bundle-release.mjs" write-manifest');
-    expect(script).toContain('bin app runtime systemd release.json');
+    expect(script).toContain('bin app runtime systemd release.json incremental-manifest.json');
     expect(script).toContain('manifest.json');
     expect(script).toContain('release.json');
+    expect(script).toContain('incremental-manifest.json');
     expect(script).toContain('NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY:?set NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY before building the customer host bundle');
     expect(script).toContain('GH_VERSION="${HOST_BUNDLE_GH_VERSION:-2.86.0}"');
     expect(script).toContain('GH_URL="https://github.com/cli/cli/releases/download/v${GH_VERSION}/${GH_ARCHIVE}"');
@@ -124,6 +127,8 @@ describe('customer VPS host bundle', () => {
     expect(releaseScript).toContain('severity');
     expect(releaseScript).toContain('updateType');
     expect(releaseScript).toContain('bundleSha256: checksum');
+    expect(releaseScript).toContain('incrementalManifest');
+    expect(releaseScript).toContain('system-bundles/${release.version}/incremental-manifest.json');
   });
 
   it('publish script keeps platform secrets out of curl arguments', () => {
@@ -144,15 +149,21 @@ describe('customer VPS host bundle', () => {
     expect(publishScript).toContain('object_exists()');
     expect(publishScript).toContain('verify_existing_bundle()');
     expect(publishScript).toContain('verify_existing_checksum()');
+    expect(publishScript).toContain('verify_existing_incremental_manifest()');
+    expect(publishScript).toContain('verify_existing_content_object()');
+    expect(publishScript).toContain('write_incremental_object_list()');
     expect(publishScript).toContain('object_size "$BUNDLE_KEY"');
     expect(publishScript).toContain('bundle_object_sha256 "$BUNDLE_KEY"');
     expect(publishScript).toContain('checksum_object_sha256 "$CHECKSUM_KEY"');
     expect(publishScript).not.toContain('existing immutable bundle is missing checksum object');
     expect(publishScript).toContain('aws s3api put-object');
     expect(publishScript).toContain('--if-none-match');
-    expect(publishScript).toContain('--metadata "sha256=$SHA256"');
+    expect(publishScript).toContain('local metadata_sha256="${4:-$SHA256}"');
+    expect(publishScript).toContain('--metadata "sha256=$metadata_sha256"');
     expect(publishScript).toContain('upload_immutable_object "$BUNDLE" "$BUNDLE_KEY" "application/gzip"');
     expect(publishScript).toContain('upload_immutable_object "$CHECKSUM_FILE" "$CHECKSUM_KEY" "text/plain; charset=utf-8"');
+    expect(publishScript).toContain('upload_immutable_object "$object_file" "$object_key" "application/octet-stream" "$object_sha256"');
+    expect(publishScript).toContain('upload_immutable_object "$INCREMENTAL_MANIFEST" "$INCREMENTAL_MANIFEST_KEY" "application/json; charset=utf-8" "$INCREMENTAL_MANIFEST_SHA256"');
     expect(publishScript).toContain(': "${R2_ACCOUNT_ID:?set R2_ACCOUNT_ID or R2_ENDPOINT}"');
     expect(publishScript).toContain('if [ -z "${R2_ENDPOINT:-}" ]; then');
     expect(publishScript).not.toContain('aws s3 cp "$BUNDLE" "s3://$R2_BUCKET/$BUNDLE_KEY"');
@@ -168,6 +179,12 @@ describe('customer VPS host bundle', () => {
     expect(publishScript).toContain('exec node "$ROOT_DIR/scripts/publish-release-r2.mjs"');
     expect(nodePublisher).toContain('IfNoneMatch: "*"');
     expect(nodePublisher).toContain('existing immutable bundle has no checksum metadata');
+    expect(nodePublisher).toContain('incrementalManifestKey');
+    expect(nodePublisher).toContain('incremental-manifest.json');
+    expect(nodePublisher).toContain('incrementalObjectEntries');
+    expect(nodePublisher).toContain('system-bundles/objects/sha256/${file.sha256}');
+    expect(nodePublisher).toContain('Uploading ${incrementalObjects.length} incremental file objects');
+    expect(nodePublisher).toContain('"application/octet-stream"');
     expect(nodePublisher).not.toContain('head.Metadata?.sha256 && head.Metadata.sha256 !== expectedSha256');
     expect(nodePublisher).toContain('R2_ACCESS_KEY_ID');
     expect(nodePublisher).toContain('R2_SECRET_ACCESS_KEY');
@@ -255,6 +272,8 @@ describe('customer VPS host bundle', () => {
     expect(workflow).toContain('name: Upload bundle artifact');
     expect(workflow).toContain('dist/host-bundle/matrix-host-bundle.tar.gz');
     expect(workflow).toContain('dist/host-bundle/matrix-host-bundle.tar.gz.sha256');
+    expect(workflow).toContain('dist/host-bundle/incremental-manifest.json');
+    expect(workflow).toContain('dist/host-bundle/objects/**');
     expect(workflow).toContain('dist/host-bundle/manifest.json');
     expect(workflow).toContain('dist/host-bundle/release.json');
     expect(workflow).not.toContain('path: dist/host-bundle/');
@@ -269,8 +288,9 @@ describe('customer VPS host bundle', () => {
     expect(workflow).toContain('name: Normalize downloaded bundle artifact');
     expect(workflow).toContain('BUNDLE_FILE="$(find "$ARTIFACT_DIR" -type f -name matrix-host-bundle.tar.gz -print -quit)"');
     expect(workflow).toContain('TARGET_DIR="dist/host-bundle"');
-    expect(workflow).toContain('for file in matrix-host-bundle.tar.gz matrix-host-bundle.tar.gz.sha256 manifest.json release.json; do');
+    expect(workflow).toContain('for file in matrix-host-bundle.tar.gz matrix-host-bundle.tar.gz.sha256 incremental-manifest.json manifest.json release.json; do');
     expect(workflow).toContain('cp "$SOURCE_DIR/$file" "$TARGET_DIR/$file"');
+    expect(workflow).toContain('cp -a "$SOURCE_DIR/objects" "$TARGET_DIR/objects"');
   });
 
   it('host bundle release workflow cancels only superseded dev-channel builds', () => {

--- a/tests/platform/host-bundle-route.test.ts
+++ b/tests/platform/host-bundle-route.test.ts
@@ -384,6 +384,63 @@ describe('platform host bundle route', () => {
     expect(res.headers.get('cloudflare-cdn-cache-control')).toBe('private, max-age=30');
   });
 
+  it('redirects incremental manifests to signed object-store URLs', async () => {
+    await upsertHostBundleRelease(db, {
+      version: 'v2026.05.12-8',
+      gitCommit: 'c1598218',
+      gitRef: 'refs/tags/v2026.05.12-8',
+      buildTime: '2026-05-12T00:00:00.000Z',
+      bundleKey: 'system-bundles/v2026.05.12-8/matrix-host-bundle.tar.gz',
+      checksumKey: 'system-bundles/v2026.05.12-8/matrix-host-bundle.tar.gz.sha256',
+      incrementalManifestKey: 'system-bundles/v2026.05.12-8/incremental-manifest.json',
+      incrementalManifestSha256: 'c'.repeat(64),
+      sha256: 'a'.repeat(64),
+      size: 1234,
+    });
+    const getPresignedGetUrl = vi.fn().mockResolvedValue('https://r2.example/signed-incremental-manifest');
+    const app = createApp({
+      db,
+      orchestrator,
+      customerVpsObjectStore: {
+        getObject: vi.fn(),
+        getPresignedGetUrl,
+        putObject: vi.fn(),
+      } as unknown as CustomerVpsObjectStore,
+    });
+
+    const res = await app.request('/system-bundles/v2026.05.12-8/incremental-manifest.json');
+
+    expect(res.status).toBe(302);
+    expect(res.headers.get('location')).toBe('https://r2.example/signed-incremental-manifest');
+    expect(getPresignedGetUrl).toHaveBeenCalledWith(
+      'system-bundles/v2026.05.12-8/incremental-manifest.json',
+      3600,
+    );
+  });
+
+  it('redirects incremental file objects to signed object-store URLs', async () => {
+    const sha256 = 'd'.repeat(64);
+    const getPresignedGetUrl = vi.fn().mockResolvedValue('https://r2.example/signed-incremental-object');
+    const app = createApp({
+      db,
+      orchestrator,
+      customerVpsObjectStore: {
+        getObject: vi.fn(),
+        getPresignedGetUrl,
+        putObject: vi.fn(),
+      } as unknown as CustomerVpsObjectStore,
+    });
+
+    const res = await app.request(`/system-bundles/objects/sha256/${sha256}`);
+
+    expect(res.status).toBe(302);
+    expect(res.headers.get('location')).toBe('https://r2.example/signed-incremental-object');
+    expect(getPresignedGetUrl).toHaveBeenCalledWith(
+      `system-bundles/objects/sha256/${sha256}`,
+      3600,
+    );
+  });
+
   it('registers release metadata in platform DB and promotes channels', async () => {
     const app = createApp({
       db,
@@ -408,6 +465,8 @@ describe('platform host bundle route', () => {
         buildTime: '2026-05-12T01:00:00.000Z',
         bundleKey: 'system-bundles/v2026.05.12-2/matrix-host-bundle.tar.gz',
         checksumKey: 'system-bundles/v2026.05.12-2/matrix-host-bundle.tar.gz.sha256',
+        incrementalManifestKey: 'system-bundles/v2026.05.12-2/incremental-manifest.json',
+        incrementalManifestSha256: 'c'.repeat(64),
         sha256: 'b'.repeat(64),
         size: 5678,
         channel: 'canary',
@@ -420,6 +479,8 @@ describe('platform host bundle route', () => {
         version: 'v2026.05.12-2',
         channel: 'canary',
         gitCommit: 'c15982181234567890',
+        incrementalManifestKey: 'system-bundles/v2026.05.12-2/incremental-manifest.json',
+        incrementalManifestSha256: 'c'.repeat(64),
       },
       channel: {
         channel: 'canary',
@@ -482,6 +543,8 @@ describe('platform host bundle route', () => {
         buildTime: '2026-05-12T01:00:00.000Z',
         bundleKey: 'system-bundles/v2026.05.12-2/matrix-host-bundle.tar.gz',
         checksumKey: 'system-bundles/v2026.05.12-2/matrix-host-bundle.tar.gz.sha256',
+        incrementalManifestKey: 'system-bundles/v2026.05.12-2/incremental-manifest.json',
+        incrementalManifestSha256: 'c'.repeat(64),
         sha256: 'b'.repeat(64),
         size: 5678,
         channel: 'stable',

--- a/tests/scripts/host-bundle-incremental-manifest.test.ts
+++ b/tests/scripts/host-bundle-incremental-manifest.test.ts
@@ -1,0 +1,120 @@
+import { createHash } from "node:crypto";
+import { chmod, mkdir, mkdtemp, readFile, rm, symlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  buildIncrementalManifest,
+  canonicalManifestJson,
+} from "../../scripts/host-bundle-incremental-manifest.mjs";
+
+const tempDirs: string[] = [];
+
+async function tempAppDir() {
+  const dir = await mkdtemp(join(tmpdir(), "matrix-host-bundle-manifest-"));
+  tempDirs.push(dir);
+  const appDir = join(dir, "app");
+  await mkdir(appDir, { recursive: true });
+  return { dir, appDir };
+}
+
+function sha256(text: string) {
+  return createHash("sha256").update(text).digest("hex");
+}
+
+describe("host bundle incremental manifest", () => {
+  afterEach(async () => {
+    await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+  });
+
+  it("builds a deterministic content-addressed manifest for app files", async () => {
+    const { dir, appDir } = await tempAppDir();
+    const objectDir = join(dir, "objects");
+    await mkdir(join(appDir, "bin"), { recursive: true });
+    await mkdir(join(appDir, "nested"), { recursive: true });
+    await writeFile(join(appDir, "nested", "b.txt"), "bravo");
+    await writeFile(join(appDir, "a.sh"), "#!/usr/bin/env bash\n");
+    await chmod(join(appDir, "a.sh"), 0o755);
+    await symlink("../a.sh", join(appDir, "bin", "a-link"));
+
+    const manifest = await buildIncrementalManifest({
+      appDir,
+      objectDir,
+      version: "v2026.06.17-1",
+      baseVersion: "v2026.06.16-1",
+    });
+
+    expect(manifest).toMatchObject({
+      manifestVersion: 1,
+      version: "v2026.06.17-1",
+      baseVersion: "v2026.06.16-1",
+      objectRoot: "system-bundles/objects/sha256",
+      requiresFullBundle: true,
+      excludedPrefixes: ["node_modules/"],
+      delete: [],
+    });
+    await expect(readFile(join(objectDir, "sha256", sha256("#!/usr/bin/env bash\n")), "utf8")).resolves.toBe(
+      "#!/usr/bin/env bash\n",
+    );
+    await expect(readFile(join(objectDir, "sha256", sha256("bravo")), "utf8")).resolves.toBe("bravo");
+    expect(manifest.files.map((file) => file.path)).toEqual(["a.sh", "nested/b.txt"]);
+    expect(manifest.files[0]).toMatchObject({
+      type: "file",
+      path: "a.sh",
+      sha256: sha256("#!/usr/bin/env bash\n"),
+      size: 20,
+      mode: "0755",
+      url: `system-bundles/objects/sha256/${sha256("#!/usr/bin/env bash\n")}`,
+    });
+    expect(manifest.symlinks).toEqual([{ path: "bin/a-link", target: "../a.sh" }]);
+    expect(manifest.protected).toEqual([
+      "/home/matrix/home/system/desktop.json",
+      "/home/matrix/home/system/theme.json",
+      "/home/matrix/home/system/wallpapers/",
+      "/home/matrix/home/system/icons/",
+      "/home/matrix/home/conversations/",
+      "/home/matrix/home/memory/",
+    ]);
+  });
+
+  it("excludes staged dependency stores from the incremental object set", async () => {
+    const { dir, appDir } = await tempAppDir();
+    const objectDir = join(dir, "objects");
+    await mkdir(join(appDir, "node_modules", "huge-package"), { recursive: true });
+    await writeFile(join(appDir, "node_modules", "huge-package", "index.js"), "dependency");
+    await writeFile(join(appDir, "runtime.js"), "runtime");
+
+    const manifest = await buildIncrementalManifest({
+      appDir,
+      objectDir,
+      version: "v1",
+    });
+
+    expect(manifest.files.map((file) => file.path)).toEqual(["runtime.js"]);
+    await expect(readFile(join(objectDir, "sha256", sha256("runtime")), "utf8")).resolves.toBe("runtime");
+    await expect(readFile(join(objectDir, "sha256", sha256("dependency")), "utf8")).rejects.toMatchObject({
+      code: "ENOENT",
+    });
+  });
+
+  it("serializes canonical JSON bytes with stable key order", async () => {
+    const { appDir } = await tempAppDir();
+    await writeFile(join(appDir, "file.txt"), "hello");
+
+    const manifest = await buildIncrementalManifest({ appDir, version: "v1" });
+    const json = canonicalManifestJson(manifest);
+
+    expect(json).toContain('"manifestVersion": 1,\n  "version": "v1"');
+    expect(json).toContain(`"url": "system-bundles/objects/sha256/${sha256("hello")}"`);
+    expect(json.endsWith("\n")).toBe(true);
+  });
+
+  it("rejects symlink targets that escape the staged app tree", async () => {
+    const { appDir } = await tempAppDir();
+    await symlink("../../etc/passwd", join(appDir, "bad-link"));
+
+    await expect(buildIncrementalManifest({ appDir, version: "v1" })).rejects.toThrow(
+      "escapes app root",
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- Generates a canonical incremental host-bundle manifest from the staged app tree.
- Emits content-addressed app file objects under `dist/host-bundle/objects/sha256/<hash>`.
- Publishes incremental file objects and the immutable manifest to R2 before registering release metadata.
- Stores and serves incremental manifest metadata through platform release records.

## Validation

- `bun run test tests/scripts/host-bundle-incremental-manifest.test.ts tests/platform/host-bundle-route.test.ts tests/platform/customer-vps-host-bundle.test.ts` (49 tests)
- `bash -n scripts/publish-release.sh scripts/build-host-bundle.sh`
- `bun run typecheck`
- `bun run check:patterns`
- `git diff --check`
- `bun run test` passed before the final object-route review fix; the current head was revalidated with the focused host-bundle suites plus typecheck/pattern/whitespace checks.

## Invariants

- Source of truth: platform DB release metadata remains canonical for release registration; R2 immutable objects hold bundle bytes, checksum bytes, incremental file objects, and the incremental manifest.
- Lock/transaction scope: release object uploads happen before the platform registration write; the platform release upsert remains the DB commit point for discoverability.
- Acceptable orphan states: uploaded R2 objects may exist before registration if publishing fails. They are immutable and content-addressed, so retries verify existing size/checksum before reuse.
- Auth source of truth: release registration still uses `PLATFORM_SECRET`; object uploads still use the configured R2/S3 credentials.
- Deferred scope: VPS-side delta application is intentionally not enabled here. The manifest defaults `requiresFullBundle: true`, so current VPS updates keep using the full bundle until the installer layer is reviewed separately.
