### PR TITLE
fix(runtime): parallelize incremental bundle object uploads

### DIFF
--- a/.github/workflows/host-bundle-release.yml
+++ b/.github/workflows/host-bundle-release.yml
@@ -277,7 +277,7 @@ jobs:
     needs: [dev-bundle-gate, build]
     if: needs.dev-bundle-gate.outputs.should_build == 'true'
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 20
     env:
       R2_ACCOUNT_ID: ${{ secrets.R2_BUNDLES_ACCOUNT_ID || secrets.R2_ACCOUNT_ID }}
       AWS_ACCESS_KEY_ID: ${{ secrets.R2_BUNDLES_ACCESS_KEY_ID || secrets.R2_ACCESS_KEY_ID }}

--- a/scripts/publish-release.sh
+++ b/scripts/publish-release.sh
@@ -157,6 +157,27 @@ for entry in manifest.get('files', []):
 " "$INCREMENTAL_MANIFEST"
 }
 
+validate_incremental_object_list() {
+  local object_sha256 object_size object_key object_file actual_size actual_sha256
+  while IFS=$'\t' read -r object_sha256 object_size object_key; do
+    object_file="$DIST_DIR/objects/sha256/$object_sha256"
+    if [ ! -f "$object_file" ]; then
+      echo "ERROR: missing incremental object file $object_file" >&2
+      exit 1
+    fi
+    actual_size="$(stat --printf='%s' "$object_file")"
+    if [ "$actual_size" != "$object_size" ]; then
+      echo "ERROR: incremental object size mismatch for $object_file" >&2
+      exit 1
+    fi
+    actual_sha256="$(sha256sum "$object_file" | awk '{print $1}')"
+    if [ "$actual_sha256" != "$object_sha256" ]; then
+      echo "ERROR: incremental object checksum mismatch for $object_file" >&2
+      exit 1
+    fi
+  done < "$INCREMENTAL_OBJECTS_FILE"
+}
+
 AWS_ARGS=(--endpoint-url "$R2_ENDPOINT" --region auto)
 
 object_exists() {
@@ -270,7 +291,7 @@ upload_content_addressed_object() {
   fi
 
   local status=$?
-  if grep -Eq 'PreconditionFailed|Precondition Failed|pre-condition|status code: 412|\(412\)' "$error_file"; then
+  if grep -Eq 'PreconditionFailed|Precondition Failed|pre-condition|status code: 412|\(412\)|(^|[^0-9])412([^0-9]|$)' "$error_file"; then
     rm -f "$error_file"
     return 0
   fi
@@ -282,7 +303,7 @@ upload_content_addressed_object() {
 
 wait_for_incremental_upload_slot() {
   while [ "$(jobs -pr | wc -l)" -ge "$INCREMENTAL_UPLOAD_CONCURRENCY" ]; do
-    wait -n
+    wait -n || return
   done
 }
 
@@ -326,6 +347,7 @@ cleanup_temp_files() { rm -f "$AUTH_HEADER_FILE" "$CHECKSUM_FILE" "$INCREMENTAL_
 trap cleanup_temp_files EXIT
 printf '%s  matrix-host-bundle.tar.gz\n' "$SHA256" > "$CHECKSUM_FILE"
 write_incremental_object_list > "$INCREMENTAL_OBJECTS_FILE"
+validate_incremental_object_list
 
 echo "  Uploading versioned archive..."
 if object_exists "$BUNDLE_KEY"; then
@@ -344,20 +366,6 @@ echo "  Uploading incremental file objects with concurrency $INCREMENTAL_UPLOAD_
 incremental_upload_failed=0
 while IFS=$'\t' read -r object_sha256 object_size object_key; do
   object_file="$DIST_DIR/objects/sha256/$object_sha256"
-  if [ ! -f "$object_file" ]; then
-    echo "ERROR: missing incremental object file $object_file" >&2
-    exit 1
-  fi
-  actual_size="$(stat --printf='%s' "$object_file")"
-  if [ "$actual_size" != "$object_size" ]; then
-    echo "ERROR: incremental object size mismatch for $object_file" >&2
-    exit 1
-  fi
-  actual_sha256="$(sha256sum "$object_file" | awk '{print $1}')"
-  if [ "$actual_sha256" != "$object_sha256" ]; then
-    echo "ERROR: incremental object checksum mismatch for $object_file" >&2
-    exit 1
-  fi
   if ! wait_for_incremental_upload_slot; then
     incremental_upload_failed=1
   fi

--- a/scripts/publish-release.sh
+++ b/scripts/publish-release.sh
@@ -91,6 +91,11 @@ if [ -z "${R2_ENDPOINT:-}" ]; then
   R2_ENDPOINT="https://${R2_ACCOUNT_ID}.r2.cloudflarestorage.com"
 fi
 PLATFORM_PUBLIC_URL="${PLATFORM_PUBLIC_URL:-https://app.matrix-os.com}"
+INCREMENTAL_UPLOAD_CONCURRENCY="${HOST_BUNDLE_INCREMENTAL_UPLOAD_CONCURRENCY:-16}"
+if ! [[ "$INCREMENTAL_UPLOAD_CONCURRENCY" =~ ^[0-9]+$ ]] || [ "$INCREMENTAL_UPLOAD_CONCURRENCY" -lt 1 ] || [ "$INCREMENTAL_UPLOAD_CONCURRENCY" -gt 64 ]; then
+  echo "HOST_BUNDLE_INCREMENTAL_UPLOAD_CONCURRENCY must be an integer from 1 to 64" >&2
+  exit 1
+fi
 
 SHA256="$(sha256sum "$BUNDLE" | awk '{print $1}')"
 SIZE="$(stat --printf='%s' "$BUNDLE")"
@@ -223,23 +228,6 @@ verify_existing_checksum() {
   fi
 }
 
-verify_existing_content_object() {
-  local key="$1"
-  local expected_size="$2"
-  local expected_sha256="$3"
-  local existing_size existing_sha256
-  existing_size="$(object_size "$key")"
-  if [ "$existing_size" != "$expected_size" ]; then
-    echo "ERROR: existing immutable object size mismatch for s3://$R2_BUCKET/$key" >&2
-    exit 1
-  fi
-  existing_sha256="$(bundle_object_sha256 "$key")"
-  if [ "$existing_sha256" != "$expected_sha256" ]; then
-    echo "ERROR: existing immutable object content mismatch for s3://$R2_BUCKET/$key" >&2
-    exit 1
-  fi
-}
-
 upload_immutable_object() {
   local source_file="$1"
   local key="$2"
@@ -259,6 +247,53 @@ upload_immutable_object() {
     --metadata "sha256=$metadata_sha256" \
     --if-none-match '*' \
     "${AWS_ARGS[@]}" >/dev/null
+}
+
+upload_content_addressed_object() {
+  local source_file="$1"
+  local key="$2"
+  local content_type="$3"
+  local metadata_sha256="$4"
+  local error_file
+  error_file="$(mktemp)"
+
+  if aws s3api put-object \
+    --bucket "$R2_BUCKET" \
+    --key "$key" \
+    --body "$source_file" \
+    --content-type "$content_type" \
+    --metadata "sha256=$metadata_sha256" \
+    --if-none-match '*' \
+    "${AWS_ARGS[@]}" > /dev/null 2>"$error_file"; then
+    rm -f "$error_file"
+    return 0
+  fi
+
+  local status=$?
+  if grep -Eq 'PreconditionFailed|Precondition Failed|pre-condition|status code: 412|\(412\)' "$error_file"; then
+    rm -f "$error_file"
+    return 0
+  fi
+
+  cat "$error_file" >&2
+  rm -f "$error_file"
+  return "$status"
+}
+
+wait_for_incremental_upload_slot() {
+  while [ "$(jobs -pr | wc -l)" -ge "$INCREMENTAL_UPLOAD_CONCURRENCY" ]; do
+    wait -n
+  done
+}
+
+wait_for_incremental_uploads() {
+  local failed=0
+  while [ "$(jobs -pr | wc -l)" -gt 0 ]; do
+    if ! wait -n; then
+      failed=1
+    fi
+  done
+  return "$failed"
 }
 
 if [ "$DRY_RUN" = "1" ]; then
@@ -305,7 +340,8 @@ if object_exists "$CHECKSUM_KEY"; then
 else
   upload_immutable_object "$CHECKSUM_FILE" "$CHECKSUM_KEY" "text/plain; charset=utf-8"
 fi
-echo "  Uploading incremental file objects..."
+echo "  Uploading incremental file objects with concurrency $INCREMENTAL_UPLOAD_CONCURRENCY..."
+incremental_upload_failed=0
 while IFS=$'\t' read -r object_sha256 object_size object_key; do
   object_file="$DIST_DIR/objects/sha256/$object_sha256"
   if [ ! -f "$object_file" ]; then
@@ -322,12 +358,18 @@ while IFS=$'\t' read -r object_sha256 object_size object_key; do
     echo "ERROR: incremental object checksum mismatch for $object_file" >&2
     exit 1
   fi
-  if object_exists "$object_key"; then
-    verify_existing_content_object "$object_key" "$object_size" "$object_sha256"
-  else
-    upload_immutable_object "$object_file" "$object_key" "application/octet-stream" "$object_sha256"
+  if ! wait_for_incremental_upload_slot; then
+    incremental_upload_failed=1
   fi
+  upload_content_addressed_object "$object_file" "$object_key" "application/octet-stream" "$object_sha256" &
 done < "$INCREMENTAL_OBJECTS_FILE"
+if ! wait_for_incremental_uploads; then
+  incremental_upload_failed=1
+fi
+if [ "$incremental_upload_failed" -ne 0 ]; then
+  echo "ERROR: one or more incremental file object uploads failed" >&2
+  exit 1
+fi
 if object_exists "$INCREMENTAL_MANIFEST_KEY"; then
   echo "  Verifying existing immutable incremental manifest..."
   verify_existing_incremental_manifest

--- a/scripts/publish-release.sh
+++ b/scripts/publish-release.sh
@@ -301,19 +301,25 @@ upload_content_addressed_object() {
   return "$status"
 }
 
+incremental_upload_pids=()
+
 wait_for_incremental_upload_slot() {
-  while [ "$(jobs -pr | wc -l)" -ge "$INCREMENTAL_UPLOAD_CONCURRENCY" ]; do
-    wait -n || return
+  local first_pid
+  while [ "${#incremental_upload_pids[@]}" -ge "$INCREMENTAL_UPLOAD_CONCURRENCY" ]; do
+    first_pid="${incremental_upload_pids[0]}"
+    incremental_upload_pids=("${incremental_upload_pids[@]:1}")
+    wait "$first_pid" || return
   done
 }
 
 wait_for_incremental_uploads() {
-  local failed=0
-  while [ "$(jobs -pr | wc -l)" -gt 0 ]; do
-    if ! wait -n; then
+  local failed=0 upload_pid
+  for upload_pid in "${incremental_upload_pids[@]}"; do
+    if ! wait "$upload_pid"; then
       failed=1
     fi
   done
+  incremental_upload_pids=()
   return "$failed"
 }
 
@@ -370,6 +376,7 @@ while IFS=$'\t' read -r object_sha256 object_size object_key; do
     incremental_upload_failed=1
   fi
   upload_content_addressed_object "$object_file" "$object_key" "application/octet-stream" "$object_sha256" &
+  incremental_upload_pids+=("$!")
 done < "$INCREMENTAL_OBJECTS_FILE"
 if ! wait_for_incremental_uploads; then
   incremental_upload_failed=1

--- a/tests/platform/customer-vps-host-bundle.test.ts
+++ b/tests/platform/customer-vps-host-bundle.test.ts
@@ -154,7 +154,13 @@ describe('customer VPS host bundle', () => {
     expect(publishScript).toContain('HOST_BUNDLE_INCREMENTAL_UPLOAD_CONCURRENCY');
     expect(publishScript).toContain('upload_content_addressed_object()');
     expect(publishScript).toContain('PreconditionFailed');
-    expect(publishScript).toContain('wait -n');
+    expect(publishScript).toContain('incremental_upload_pids=()');
+    expect(publishScript).toContain('incremental_upload_pids+=("$!")');
+    expect(publishScript).toContain('while [ "${#incremental_upload_pids[@]}" -ge "$INCREMENTAL_UPLOAD_CONCURRENCY" ]; do');
+    expect(publishScript).toContain('wait "$first_pid" || return');
+    expect(publishScript).toContain('for upload_pid in "${incremental_upload_pids[@]}"; do');
+    expect(publishScript).not.toContain('jobs -pr');
+    expect(publishScript).not.toContain('wait -n');
     expect(publishScript).toContain('object_size "$BUNDLE_KEY"');
     expect(publishScript).toContain('bundle_object_sha256 "$BUNDLE_KEY"');
     expect(publishScript).toContain('checksum_object_sha256 "$CHECKSUM_KEY"');
@@ -170,7 +176,6 @@ describe('customer VPS host bundle', () => {
     expect(publishScript).not.toContain('verify_existing_content_object "$object_key" "$object_size" "$object_sha256"');
     expect(publishScript).toContain('validate_incremental_object_list()');
     expect(publishScript).toContain('validate_incremental_object_list');
-    expect(publishScript).toContain('wait -n || return');
     expect(publishScript).toContain('(^|[^0-9])412([^0-9]|$)');
     expect(publishScript).toContain('upload_immutable_object "$INCREMENTAL_MANIFEST" "$INCREMENTAL_MANIFEST_KEY" "application/json; charset=utf-8" "$INCREMENTAL_MANIFEST_SHA256"');
     expect(publishScript).toContain(': "${R2_ACCOUNT_ID:?set R2_ACCOUNT_ID or R2_ENDPOINT}"');

--- a/tests/platform/customer-vps-host-bundle.test.ts
+++ b/tests/platform/customer-vps-host-bundle.test.ts
@@ -168,6 +168,10 @@ describe('customer VPS host bundle', () => {
     expect(publishScript).toContain('upload_content_addressed_object "$object_file" "$object_key" "application/octet-stream" "$object_sha256"');
     expect(publishScript).not.toContain('verify_existing_content_object()');
     expect(publishScript).not.toContain('verify_existing_content_object "$object_key" "$object_size" "$object_sha256"');
+    expect(publishScript).toContain('validate_incremental_object_list()');
+    expect(publishScript).toContain('validate_incremental_object_list');
+    expect(publishScript).toContain('wait -n || return');
+    expect(publishScript).toContain('(^|[^0-9])412([^0-9]|$)');
     expect(publishScript).toContain('upload_immutable_object "$INCREMENTAL_MANIFEST" "$INCREMENTAL_MANIFEST_KEY" "application/json; charset=utf-8" "$INCREMENTAL_MANIFEST_SHA256"');
     expect(publishScript).toContain(': "${R2_ACCOUNT_ID:?set R2_ACCOUNT_ID or R2_ENDPOINT}"');
     expect(publishScript).toContain('if [ -z "${R2_ENDPOINT:-}" ]; then');

--- a/tests/platform/customer-vps-host-bundle.test.ts
+++ b/tests/platform/customer-vps-host-bundle.test.ts
@@ -150,8 +150,11 @@ describe('customer VPS host bundle', () => {
     expect(publishScript).toContain('verify_existing_bundle()');
     expect(publishScript).toContain('verify_existing_checksum()');
     expect(publishScript).toContain('verify_existing_incremental_manifest()');
-    expect(publishScript).toContain('verify_existing_content_object()');
     expect(publishScript).toContain('write_incremental_object_list()');
+    expect(publishScript).toContain('HOST_BUNDLE_INCREMENTAL_UPLOAD_CONCURRENCY');
+    expect(publishScript).toContain('upload_content_addressed_object()');
+    expect(publishScript).toContain('PreconditionFailed');
+    expect(publishScript).toContain('wait -n');
     expect(publishScript).toContain('object_size "$BUNDLE_KEY"');
     expect(publishScript).toContain('bundle_object_sha256 "$BUNDLE_KEY"');
     expect(publishScript).toContain('checksum_object_sha256 "$CHECKSUM_KEY"');
@@ -162,7 +165,9 @@ describe('customer VPS host bundle', () => {
     expect(publishScript).toContain('--metadata "sha256=$metadata_sha256"');
     expect(publishScript).toContain('upload_immutable_object "$BUNDLE" "$BUNDLE_KEY" "application/gzip"');
     expect(publishScript).toContain('upload_immutable_object "$CHECKSUM_FILE" "$CHECKSUM_KEY" "text/plain; charset=utf-8"');
-    expect(publishScript).toContain('upload_immutable_object "$object_file" "$object_key" "application/octet-stream" "$object_sha256"');
+    expect(publishScript).toContain('upload_content_addressed_object "$object_file" "$object_key" "application/octet-stream" "$object_sha256"');
+    expect(publishScript).not.toContain('verify_existing_content_object()');
+    expect(publishScript).not.toContain('verify_existing_content_object "$object_key" "$object_size" "$object_sha256"');
     expect(publishScript).toContain('upload_immutable_object "$INCREMENTAL_MANIFEST" "$INCREMENTAL_MANIFEST_KEY" "application/json; charset=utf-8" "$INCREMENTAL_MANIFEST_SHA256"');
     expect(publishScript).toContain(': "${R2_ACCOUNT_ID:?set R2_ACCOUNT_ID or R2_ENDPOINT}"');
     expect(publishScript).toContain('if [ -z "${R2_ENDPOINT:-}" ]; then');
@@ -204,6 +209,7 @@ describe('customer VPS host bundle', () => {
     expect(workflow).toContain('HOST_BUNDLE_CHANNEL: ${{ needs.build.outputs.channel }}');
     expect(workflow).toContain("PLATFORM_PUBLIC_URL: ${{ vars.PLATFORM_PUBLIC_URL || 'https://app.matrix-os.com' }}");
     expect(workflow).toContain('R2_ACCOUNT_ID: ${{ secrets.R2_BUNDLES_ACCOUNT_ID || secrets.R2_ACCOUNT_ID }}');
+    expect(workflow).toContain('timeout-minutes: 20');
     expect(workflow).toContain('AWS_ACCESS_KEY_ID: ${{ secrets.R2_BUNDLES_ACCESS_KEY_ID || secrets.R2_ACCESS_KEY_ID }}');
     expect(workflow).toContain('AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_BUNDLES_SECRET_ACCESS_KEY || secrets.R2_SECRET_ACCESS_KEY }}');
     expect(workflow).toContain("R2_BUCKET: ${{ vars.R2_BUNDLES_BUCKET || vars.R2_BUCKET || 'matrixos-sync' }}");


### PR DESCRIPTION
## Summary
- Parallelize content-addressed incremental object uploads in the host-bundle publisher.
- Treat R2 precondition/existing-object responses as success for SHA-addressed objects.
- Increase the publish job timeout from 10 to 20 minutes after the first incremental publish hit the timeout.

## Invariants
- Source of truth: R2 immutable bundle/object keys plus platform release metadata remain canonical.
- Lock/transaction scope: publish still writes immutable objects first, then registers the release; no DB transaction wraps object-store uploads.
- Acceptable orphan states: uploaded bundle/object bytes may exist without release registration and are safe because keys are immutable/content-addressed.
- Auth source of truth: platform registration still uses PLATFORM_SECRET via header file; R2 auth stays in GitHub secrets.
- Deferred scope: VPS-side delta apply remains disabled by requiresFullBundle until the installer/apply layer lands.

## Verification
- bun run test tests/platform/customer-vps-host-bundle.test.ts
- bash -n scripts/publish-release.sh
- git diff --check
- bun run check:patterns