### PR TITLE
feat(terminal): persist shell sidebar ordering

### DIFF
--- a/packages/gateway/src/shell/registry.ts
+++ b/packages/gateway/src/shell/registry.ts
@@ -38,9 +38,11 @@ const ShellSessionSchema = z.object({
 
 const RegistryFileSchema = z.object({
   sessions: z.record(z.string(), ShellSessionSchema).default({}),
+  order: z.array(z.string()).optional(),
 });
 
 type PersistedShellSession = z.infer<typeof ShellSessionSchema>;
+type RegistryFile = z.infer<typeof RegistryFileSchema>;
 export type ShellPlacement = z.infer<typeof ShellPlacementSchema>;
 export type ShellVisualStatus = z.infer<typeof ShellVisualStatusSchema>;
 export interface ShellSession extends PersistedShellSession {
@@ -80,8 +82,8 @@ export class ShellRegistry {
       const file = await this.read();
       const live = await this.options.adapter.listSessions();
       let changed = false;
-      const sessions: ShellSession[] = [];
       const now = new Date().toISOString();
+      const activeSessions: PersistedShellSession[] = [];
 
       for (const name of live) {
         const existing = file.sessions[name];
@@ -90,7 +92,7 @@ export class ShellRegistry {
           status: "active" as const,
           updatedAt: existing?.status === "active" ? existing.updatedAt : now,
         };
-        sessions.push(await this.decorateSession(session));
+        activeSessions.push(session);
         if (!existing || existing.status !== "active") {
           file.sessions[name] = session;
           changed = true;
@@ -98,12 +100,13 @@ export class ShellRegistry {
       }
 
       changed = await this.markMissingMetadataExited(file, new Set(live)) || changed;
+      changed = this.normalizeCustomOrder(file, activeSessions) || changed;
 
       if (changed) {
         await this.write(file);
       }
 
-      return sessions;
+      return this.decorateSessions(this.orderActiveSessions(file, activeSessions));
     });
   }
 
@@ -178,6 +181,14 @@ export class ShellRegistry {
         lastSeenSeq: null,
       };
       file.sessions[name] = session;
+      if (file.order) {
+        file.order = this.orderedNamesFromSessions(this.orderActiveSessions(file, [
+          ...Array.from(live)
+            .filter((liveName) => liveName !== name)
+            .map((liveName) => file.sessions[liveName] ?? this.adoptSession(liveName, now)),
+          session,
+        ]));
+      }
 
       try {
         await this.write(file);
@@ -258,12 +269,21 @@ export class ShellRegistry {
       };
       delete file.sessions[safeName];
       file.sessions[safeNextName] = next;
+      if (file.order) {
+        file.order = file.order.map((entry) => entry === safeName ? safeNextName : entry);
+      }
 
       await this.options.adapter.renameSession(safeName, safeNextName);
       let scrollbackRenamed = false;
       try {
         await this.options.scrollbackStore?.rename(safeName, safeNextName);
         scrollbackRenamed = true;
+        if (file.order) {
+          const nextLive = new Set(live);
+          nextLive.delete(safeName);
+          nextLive.add(safeNextName);
+          this.normalizeCustomOrder(file, Array.from(nextLive).map((liveName) => file.sessions[liveName] ?? this.adoptSession(liveName, now)));
+        }
         await this.write(file);
       } catch (err: unknown) {
         await this.options.adapter.renameSession(safeNextName, safeName).catch((rollbackErr: unknown) => {
@@ -302,8 +322,51 @@ export class ShellRegistry {
       }
       await this.options.adapter.deleteSession(safeName, options);
       delete file.sessions[safeName];
+      if (file.order) {
+        file.order = file.order.filter((entry) => entry !== safeName);
+      }
       await this.cleanupScrollback(safeName);
       await this.write(file);
+    });
+  }
+
+  async reorder(order: string[]): Promise<ShellSession[]> {
+    return this.withMutationLock(async () => {
+      const requestedOrder = Array.from(new Set(order.map((name) => validateSessionName(name))));
+      const file = await this.read();
+      const live = await this.options.adapter.listSessions();
+      const liveSet = new Set(live);
+      const now = new Date().toISOString();
+      const activeSessions: PersistedShellSession[] = [];
+
+      for (const name of live) {
+        const existing = file.sessions[name];
+        const session: PersistedShellSession = {
+          ...(existing ?? this.adoptSession(name, now)),
+          status: "active",
+          updatedAt: existing?.status === "active" ? existing.updatedAt : now,
+        };
+        activeSessions.push(session);
+        if (!existing || existing.status !== "active") {
+          file.sessions[name] = session;
+        }
+      }
+
+      await this.markMissingMetadataExited(file, liveSet);
+      const requestedLiveSessions = requestedOrder
+        .filter((name) => liveSet.has(name))
+        .map((name) => file.sessions[name])
+        .filter((session): session is PersistedShellSession => session !== undefined);
+      const requestedLiveNames = new Set(requestedLiveSessions.map((session) => session.name));
+      const appendedSessions = this.defaultOrderSessions(
+        activeSessions.filter((session) => !requestedLiveNames.has(session.name)),
+        false,
+      );
+      const orderedSessions = [...requestedLiveSessions, ...appendedSessions];
+      file.order = this.orderedNamesFromSessions(orderedSessions);
+
+      await this.write(file);
+      return this.decorateSessions(orderedSessions);
     });
   }
 
@@ -361,7 +424,7 @@ export class ShellRegistry {
   }
 
   private async markMissingMetadataExited(
-    file: z.infer<typeof RegistryFileSchema>,
+    file: RegistryFile,
     live: Set<string>,
   ): Promise<boolean> {
     let changed = false;
@@ -376,7 +439,61 @@ export class ShellRegistry {
     return changed;
   }
 
-  private async read(): Promise<z.infer<typeof RegistryFileSchema>> {
+  private defaultOrderSessions(sessions: PersistedShellSession[], mainFirst = true): PersistedShellSession[] {
+    return [...sessions].sort((left, right) => {
+      if (mainFirst) {
+        if (left.name === "main" && right.name !== "main") return -1;
+        if (right.name === "main" && left.name !== "main") return 1;
+      }
+      const created = left.createdAt.localeCompare(right.createdAt);
+      return created === 0 ? left.name.localeCompare(right.name) : created;
+    });
+  }
+
+  private orderedNamesFromSessions(sessions: PersistedShellSession[]): string[] {
+    return sessions.map((session) => session.name);
+  }
+
+  private orderActiveSessions(file: RegistryFile, sessions: PersistedShellSession[]): PersistedShellSession[] {
+    if (!file.order) {
+      return this.defaultOrderSessions(sessions);
+    }
+    const byName = new Map(sessions.map((session) => [session.name, session]));
+    const ordered: PersistedShellSession[] = [];
+    const seen = new Set<string>();
+    for (const name of file.order) {
+      const session = byName.get(name);
+      if (!session || seen.has(name)) {
+        continue;
+      }
+      ordered.push(session);
+      seen.add(name);
+    }
+    const appended = this.defaultOrderSessions(sessions.filter((session) => !seen.has(session.name)), false);
+    return [...ordered, ...appended];
+  }
+
+  private normalizeCustomOrder(file: RegistryFile, activeSessions: PersistedShellSession[]): boolean {
+    if (!file.order) {
+      return false;
+    }
+    const nextOrder = this.orderedNamesFromSessions(this.orderActiveSessions(file, activeSessions));
+    const changed = file.order.length !== nextOrder.length || file.order.some((name, index) => name !== nextOrder[index]);
+    if (changed) {
+      file.order = nextOrder;
+    }
+    return changed;
+  }
+
+  private async decorateSessions(sessions: PersistedShellSession[]): Promise<ShellSession[]> {
+    const decorated: ShellSession[] = [];
+    for (const session of sessions) {
+      decorated.push(await this.decorateSession(session));
+    }
+    return decorated;
+  }
+
+  private async read(): Promise<RegistryFile> {
     try {
       const raw = await readFile(this.persistPath, "utf-8");
       return RegistryFileSchema.parse(JSON.parse(raw));
@@ -392,7 +509,7 @@ export class ShellRegistry {
     }
   }
 
-  private async write(file: z.infer<typeof RegistryFileSchema>): Promise<void> {
+  private async write(file: RegistryFile): Promise<void> {
     await writeUtf8FileAtomic(this.persistPath, JSON.stringify(file, null, 2));
   }
 

--- a/packages/gateway/src/shell/registry.ts
+++ b/packages/gateway/src/shell/registry.ts
@@ -282,7 +282,7 @@ export class ShellRegistry {
           const nextLive = new Set(live);
           nextLive.delete(safeName);
           nextLive.add(safeNextName);
-          this.normalizeCustomOrder(file, Array.from(nextLive).map((liveName) => file.sessions[liveName] ?? this.adoptSession(liveName, now)));
+          void this.normalizeCustomOrder(file, Array.from(nextLive).map((liveName) => file.sessions[liveName] ?? this.adoptSession(liveName, now)));
         }
         await this.write(file);
       } catch (err: unknown) {

--- a/packages/gateway/src/shell/routes.ts
+++ b/packages/gateway/src/shell/routes.ts
@@ -113,7 +113,7 @@ export function createShellRoutes(deps: ShellRouteDeps): Hono {
   const app = new Hono();
   const sessionBodyLimit = bodyLimit({ maxSize: 4096 });
   const sessionRenameBodyLimit = bodyLimit({ maxSize: 1024 });
-  const sessionOrderBodyLimit = bodyLimit({ maxSize: 1024 });
+  const sessionOrderBodyLimit = bodyLimit({ maxSize: 8192 });
   const uiStateBodyLimit = bodyLimit({ maxSize: 1024 });
   const preferencesBodyLimit = bodyLimit({ maxSize: 4096 });
   const workspaceBodyLimit = bodyLimit({ maxSize: 8192 });

--- a/packages/gateway/src/shell/routes.ts
+++ b/packages/gateway/src/shell/routes.ts
@@ -19,6 +19,7 @@ interface SessionRegistryRoutes {
   }): Promise<unknown>;
   delete(name: string, options?: { force?: boolean }): Promise<void>;
   rename?(name: string, nextName: string): Promise<unknown>;
+  reorder?(order: string[]): Promise<unknown[]>;
   updateUiState?(name: string, input: {
     placement?: "active" | "background";
     lastSeenSeq?: number | null;
@@ -98,6 +99,9 @@ const SessionUiStateBodySchema = z.object({
 const SessionRenameBodySchema = z.object({
   name: SafeSessionNameSchema,
 }).strict();
+const SessionOrderBodySchema = z.object({
+  order: z.array(SafeSessionNameSchema).max(100),
+}).strict();
 
 function safeCwdSchema() {
   return z.string().min(1).max(1024)
@@ -109,6 +113,7 @@ export function createShellRoutes(deps: ShellRouteDeps): Hono {
   const app = new Hono();
   const sessionBodyLimit = bodyLimit({ maxSize: 4096 });
   const sessionRenameBodyLimit = bodyLimit({ maxSize: 1024 });
+  const sessionOrderBodyLimit = bodyLimit({ maxSize: 1024 });
   const uiStateBodyLimit = bodyLimit({ maxSize: 1024 });
   const preferencesBodyLimit = bodyLimit({ maxSize: 4096 });
   const workspaceBodyLimit = bodyLimit({ maxSize: 8192 });
@@ -147,6 +152,16 @@ export function createShellRoutes(deps: ShellRouteDeps): Hono {
           ? String((session as { name: unknown }).name)
           : body.name;
       return c.json({ name, created: true }, 201);
+    } catch (err) {
+      return safeError(c, err);
+    }
+  });
+
+  app.put("/sessions/order", sessionOrderBodyLimit, async (c) => {
+    try {
+      if (!deps.registry.reorder) return unavailable(c, "session_reorder_unavailable");
+      const body = SessionOrderBodySchema.parse(await c.req.json());
+      return c.json({ sessions: await deps.registry.reorder(body.order) });
     } catch (err) {
       return safeError(c, err);
     }

--- a/shell/src/components/terminal/TerminalApp.tsx
+++ b/shell/src/components/terminal/TerminalApp.tsx
@@ -4890,7 +4890,7 @@ function ShellCard({
                 opacity: showActions ? 1 : 0,
                 pointerEvents: showActions ? "auto" : "none",
                 transition: "opacity 120ms ease",
-                width: 86,
+                width: 90,
               }}
             >
               <button

--- a/shell/src/components/terminal/TerminalApp.tsx
+++ b/shell/src/components/terminal/TerminalApp.tsx
@@ -8,11 +8,11 @@ import {
   ChevronsLeftIcon,
   ChevronsRightIcon,
   ClipboardPasteIcon,
-  CopyIcon,
   FilesIcon,
   FolderIcon,
   GripVerticalIcon,
   KeyboardIcon,
+  LinkIcon,
   MonitorIcon,
   PanelLeftOpenIcon,
   PencilIcon,
@@ -80,6 +80,38 @@ const PAPER_THEME_MENU_STYLE: CSSProperties = {
   top: 34,
   width: 280,
   zIndex: 50,
+};
+
+const ACTIVE_SHELL_TOGGLE_STYLE: CSSProperties = {
+  alignItems: "center",
+  background: "#DDEDD6",
+  border: "1px solid #C9E1C2",
+  borderRadius: 999,
+  color: "#24452A",
+  cursor: "pointer",
+  display: "flex",
+  flexShrink: 0,
+  height: 18,
+  justifyContent: "flex-start",
+  padding: 2,
+  pointerEvents: "auto",
+  width: 40,
+};
+
+const BACKGROUND_SHELL_TOGGLE_STYLE: CSSProperties = {
+  alignItems: "center",
+  background: "#D8D7C7",
+  border: "1px solid #C8C7B7",
+  borderRadius: 999,
+  color: "#77786E",
+  cursor: "pointer",
+  display: "flex",
+  flexShrink: 0,
+  height: 18,
+  justifyContent: "flex-end",
+  padding: 2,
+  pointerEvents: "auto",
+  width: 38,
 };
 
 const SHELL_THEME_OPTIONS: Array<{
@@ -191,36 +223,6 @@ const SIDEBAR_RAIL_BUTTON_BASE_STYLE: CSSProperties = {
   borderRadius: 8,
   fontSize: 12,
   fontWeight: 700,
-};
-
-const SHELL_CARD_NAME_BUTTON_STYLE: CSSProperties = {
-  color: "var(--foreground)",
-  fontSize: 13,
-  fontWeight: 650,
-  fontFamily: "var(--font-mono, ui-monospace, monospace)",
-  background: "transparent",
-  border: "none",
-  padding: 0,
-  textAlign: "left",
-  cursor: "copy",
-};
-
-const SHELL_CARD_COPY_BUTTON_STYLE: CSSProperties = {
-  alignItems: "center",
-  background: "#EFEEE2",
-  border: "1px solid #DCDAC9",
-  borderRadius: 7,
-  color: "#8A8B7C",
-  cursor: "copy",
-  display: "flex",
-  flex: "1 1 auto",
-  fontFamily: "var(--font-mono, ui-monospace, monospace)",
-  fontSize: 12,
-  gap: 7,
-  height: 28,
-  minWidth: 0,
-  padding: "0 8px 0 10px",
-  pointerEvents: "auto",
 };
 
 const SHELLS_REFRESH_INTERVAL_MS = 5_000;
@@ -522,6 +524,39 @@ async function ensureShellSessions(sessionNames: string[]): Promise<boolean> {
 
 async function ensureDefaultShellSession(): Promise<boolean> {
   return ensureShellSessions([DEFAULT_SHELL_SESSION_NAME]);
+}
+
+async function getFirstOrderedShellSessionName(): Promise<string | null> {
+  try {
+    const res = await fetch(`${getGatewayUrl()}/api/terminal/sessions`, {
+      signal: AbortSignal.timeout(10_000),
+    });
+    if (!res.ok) {
+      return null;
+    }
+    const data = await res.json() as { sessions?: Array<{ name?: unknown; status?: unknown }> };
+    if (!Array.isArray(data.sessions)) {
+      return null;
+    }
+    for (const session of data.sessions) {
+      if (typeof session.name === "string" && isCanonicalShellSessionId(session.name) && session.status !== "exited") {
+        return session.name;
+      }
+    }
+    return null;
+  } catch (err: unknown) {
+    console.warn("Failed to load ordered shell sessions:", err instanceof Error ? err.message : err);
+    return null;
+  }
+}
+
+async function ensureInitialShellSession(): Promise<string | null> {
+  const firstOrdered = await getFirstOrderedShellSessionName();
+  if (firstOrdered) {
+    return firstOrdered;
+  }
+  const sessionReady = await ensureDefaultShellSession();
+  return sessionReady ? DEFAULT_SHELL_SESSION_NAME : null;
 }
 
 function getSafePreferencesSessionName(value: string | null): string | null {
@@ -831,9 +866,9 @@ export function TerminalApp({ initialCommand, initialLabel, initialClaudeMode = 
               }
             }
 
-            const sessionReady = await ensureDefaultShellSession();
-            if (!cancelled && sessionReady) {
-              addSessionTab(DEFAULT_SHELL_SESSION_NAME, DEFAULT_SHELL_SESSION_NAME);
+            const sessionName = await ensureInitialShellSession();
+            if (!cancelled && sessionName) {
+              addSessionTab(formatShellDisplayName(sessionName), sessionName);
               setInitialized(true);
               return;
             }
@@ -844,10 +879,10 @@ export function TerminalApp({ initialCommand, initialLabel, initialClaudeMode = 
       }
 
       if (!cancelled) {
-        const sessionReady = await ensureDefaultShellSession();
+        const sessionName = await ensureInitialShellSession();
         if (!cancelled) {
-          if (sessionReady) {
-            addSessionTab(DEFAULT_SHELL_SESSION_NAME, DEFAULT_SHELL_SESSION_NAME);
+          if (sessionName) {
+            addSessionTab(formatShellDisplayName(sessionName), sessionName);
           } else {
             addTab(DEFAULT_CWD);
           }
@@ -2627,11 +2662,8 @@ interface WorkspaceSessionSummary {
 }
 
 function shellSessionsEqual(left: ShellSessionSummary[], right: ShellSessionSummary[]): boolean {
-  if (left.length !== right.length) return false;
-  const sortedLeft = [...left].sort((a, b) => a.name.localeCompare(b.name));
-  const sortedRight = [...right].sort((a, b) => a.name.localeCompare(b.name));
-  return sortedLeft.every((session, index) => {
-    const next = sortedRight[index];
+  return left.length === right.length && left.every((session, index) => {
+    const next = right[index];
     if (!next) return false;
     if (
       session.name !== next.name ||
@@ -2709,7 +2741,7 @@ function shellConnectCommand(name: string): string {
 }
 
 function shellAttachCommand(shell: ShellSessionSummary): string {
-  return shell.attachCommand ?? shellConnectCommand(shell.name);
+  return shellConnectCommand(shell.name);
 }
 
 function getShellUiStatePatchKeys(patch: ShellUiStatePatch): ShellUiStatePatchKey[] {
@@ -3252,8 +3284,11 @@ function LocalTerminalSidebar() {
       ? ctx.focusedPaneId
       : getFirstPaneId(activeTerminalTab.paneTree)
     : null;
-  const selectedShellName = activeTerminalTab && selectedPaneId
+  const activePaneSessionId = activeTerminalTab && selectedPaneId
     ? getPaneSessionId(activeTerminalTab.paneTree, selectedPaneId)
+    : null;
+  const activeShellName = activePaneSessionId && isCanonicalShellSessionId(activePaneSessionId)
+    ? activePaneSessionId
     : null;
   const drawerWidth = ctx.mobile ? "100%" : 392;
   const openActiveShell = (shell: ShellSessionSummary, options: { markSeen?: boolean } = {}) => {
@@ -3289,18 +3324,40 @@ function LocalTerminalSidebar() {
     shell.placement ?? (openSessionIds.has(shell.name) ? "active" : "background")
   );
 
-  const reorderShells = (fromName: string, toName: string) => {
+  const reorderShells = async (fromName: string, toName: string) => {
     if (fromName === toName) return;
-    setShells((prev) => {
-      const fromIndex = prev.findIndex((shell) => shell.name === fromName);
-      const toIndex = prev.findIndex((shell) => shell.name === toName);
-      if (fromIndex < 0 || toIndex < 0) return prev;
-      const next = [...prev];
-      const [moved] = next.splice(fromIndex, 1);
-      if (!moved) return prev;
-      next.splice(toIndex, 0, moved);
-      return next;
-    });
+    const fromIndex = shells.findIndex((shell) => shell.name === fromName);
+    const toIndex = shells.findIndex((shell) => shell.name === toName);
+    if (fromIndex < 0 || toIndex < 0) return;
+    const nextShells = [...shells];
+    const [moved] = nextShells.splice(fromIndex, 1);
+    if (!moved) return;
+    nextShells.splice(toIndex, 0, moved);
+    setShells(nextShells);
+    setShellsError(null);
+    try {
+      const res = await fetch(`${getGatewayUrl()}/api/terminal/sessions/order`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ order: nextShells.map((shell) => shell.name) }),
+        signal: AbortSignal.timeout(10_000),
+      });
+      if (!res.ok) {
+        setShellsError("Shell order could not be saved");
+        await fetchShells({ silent: true });
+        return;
+      }
+      const data = (await res.json()) as { sessions?: ShellSessionSummary[] };
+      if (Array.isArray(data.sessions)) {
+        setShells((prev) => shellSessionsEqual(prev, data.sessions!) ? prev : data.sessions!);
+      } else {
+        await fetchShells({ silent: true });
+      }
+    } catch (err: unknown) {
+      console.warn("Failed to save shell order:", err instanceof Error ? err.message : err);
+      setShellsError("Shell order could not be saved");
+      await fetchShells({ silent: true });
+    }
   };
 
   const finishShellDrag = () => {
@@ -3327,7 +3384,7 @@ function LocalTerminalSidebar() {
       return;
     }
     if (draggingShellName && draggingShellName !== shell.name) {
-      reorderShells(draggingShellName, shell.name);
+      void reorderShells(draggingShellName, shell.name);
     }
     finishShellDrag();
   };
@@ -3375,7 +3432,7 @@ function LocalTerminalSidebar() {
       <>
         <CollapsedSessionsRail
           shells={unfilteredRenderedShells}
-          selectedShellName={selectedShellName}
+          selectedShellName={activeShellName}
           onExpand={() => ctx.setSidebarOpen(true)}
           creatingShell={creatingShell}
           newSessionMenuOpen={newSessionMenuAnchor === "rail"}
@@ -3572,7 +3629,7 @@ function LocalTerminalSidebar() {
             shells={activeShells}
             deletingShellNames={deletingShellNames}
             foreground
-            selectedShellName={selectedShellName}
+            selectedShellName={activeShellName}
             onOpen={openActiveShell}
             onToggle={moveShellToBackground}
             onRename={(shell, nextName) => renameManagedShell(shell, nextName)}
@@ -3592,7 +3649,7 @@ function LocalTerminalSidebar() {
             shells={backgroundShells}
             deletingShellNames={deletingShellNames}
             foreground={false}
-            selectedShellName={selectedShellName}
+            selectedShellName={activeShellName}
             onOpen={makeShellActive}
             onToggle={makeShellActive}
             onRename={(shell, nextName) => renameManagedShell(shell, nextName)}
@@ -4454,8 +4511,6 @@ function ShellCard({
   onDrop: () => void;
   onDragEnd: () => void;
 }) {
-  const tabs = shell.tabs ?? [];
-  const focusedTab = tabs.find((tab) => tab.focused) ?? tabs[0];
   const statusDotStyle = getShellStatusDotStyle(shell);
   const [copyFeedback, setCopyFeedback] = useState<"copied" | "failed" | null>(null);
   const displayName = formatShellDisplayName(shell.name);
@@ -4467,7 +4522,7 @@ function ShellCard({
   const renameInputRef = useRef<HTMLInputElement>(null);
   const renameCommittingRef = useRef(false);
   const copiedTimerRef = useRef<number | null>(null);
-  const showActions = foreground && actionsVisible;
+  const showActions = actionsVisible || copyFeedback !== null;
   const showRenameControl = foreground && actionsVisible && !renaming;
   const showDragHandle = (actionsVisible || dragging) && !renaming && !deleting;
   const renameControlLabel = `Rename ${displayName}`;
@@ -4494,7 +4549,7 @@ function ShellCard({
       copiedTimerRef.current = window.setTimeout(() => {
         copiedTimerRef.current = null;
         setCopyFeedback(null);
-      }, 1600);
+      }, 1200);
     } catch (err: unknown) {
       console.warn("Failed to copy shell connect command:", err instanceof Error ? err.message : err);
       setCopyFeedback("failed");
@@ -4504,7 +4559,7 @@ function ShellCard({
       copiedTimerRef.current = window.setTimeout(() => {
         copiedTimerRef.current = null;
         setCopyFeedback(null);
-      }, 2200);
+      }, 1600);
     }
   };
   const cancelRename = useCallback(() => {
@@ -4607,10 +4662,11 @@ function ShellCard({
             : foreground ? "0 9px 22px rgba(39,40,34,0.13)" : "none",
         cursor: renaming || deleting ? "default" : "pointer",
         display: "flex",
-        flexDirection: "column",
-        gap: showActions ? 8 : 0,
+        alignItems: "center",
+        gap: 10,
+        height: 52,
         opacity: dragging ? 0.94 : foreground ? 1 : 0.86,
-        padding: foreground ? "10px 12px" : "14px 12px",
+        padding: "0 12px",
         position: "relative",
         transform: dragging ? "translateY(-2px)" : "translateY(0)",
         transition: "border-color 150ms ease, box-shadow 150ms ease, opacity 120ms ease, transform 150ms ease",
@@ -4667,7 +4723,7 @@ function ShellCard({
           }}
         />
       )}
-      <div className="flex items-center" style={{ gap: 10, minHeight: 24, pointerEvents: "none", position: "relative", zIndex: 1 }}>
+      <div className="flex min-w-0 flex-1 items-center" style={{ gap: 10, pointerEvents: "none", position: "relative", zIndex: 1 }}>
         <button
           type="button"
           aria-label={`Drag ${displayName} session`}
@@ -4813,32 +4869,89 @@ function ShellCard({
               <PencilIcon size={12} strokeWidth={2} />
             </button>
           )}
-          {foreground && !renaming && showActions && (
-            <button
-              type="button"
-              aria-label={`Copy connect command for ${displayName}`}
-              title={copyFeedback === "copied" ? "Command copied" : shellAttachCommand(shell)}
-              onClick={(event) => {
-                event.stopPropagation();
-                void copyAttachCommand();
-              }}
-              onPointerDown={(event) => event.stopPropagation()}
-              onMouseDown={(event) => event.stopPropagation()}
-              className="flex items-center justify-center"
+          {!renaming && (
+            <div
+              data-testid={`terminal-session-actions-${shell.name}`}
+              aria-hidden={showActions ? undefined : "true"}
+              className="flex shrink-0 items-center justify-end"
               style={{
-                background: "#F0EFE5",
-                border: "1px solid #E4E2D2",
-                borderRadius: 6,
-                color: "#8A8B7C",
-                cursor: "pointer",
-                flexShrink: 0,
-                height: 22,
-                pointerEvents: "auto",
-                width: 22,
+                gap: 6,
+                opacity: showActions ? 1 : 0,
+                pointerEvents: showActions ? "auto" : "none",
+                transition: "opacity 120ms ease",
+                width: 86,
               }}
             >
-              <CopyIcon size={12} strokeWidth={2} />
-            </button>
+              <button
+                type="button"
+                aria-label={`Copy connect command for ${displayName}`}
+                title={copyFeedback === "copied" ? "Copied" : shellConnectCommand(shell.name)}
+                tabIndex={showActions ? 0 : -1}
+                onClick={(event) => {
+                  event.stopPropagation();
+                  void copyAttachCommand();
+                }}
+                onPointerDown={(event) => event.stopPropagation()}
+                onMouseDown={(event) => event.stopPropagation()}
+                className="flex items-center justify-center"
+                style={{
+                  background: "#F0EFE5",
+                  border: "1px solid #E4E2D2",
+                  borderRadius: 6,
+                  color: copyFeedback === "copied" ? "#465243" : "#8A8B7C",
+                  cursor: "pointer",
+                  flexShrink: 0,
+                  fontSize: 12,
+                  fontWeight: 800,
+                  gap: 5,
+                  height: 24,
+                  pointerEvents: "auto",
+                  width: copyFeedback === "copied" ? 58 : 24,
+                }}
+              >
+                {copyFeedback === "copied" ? (
+                  <>
+                    <CheckIcon size={12} strokeWidth={2.2} />
+                    <output
+                      data-testid={`terminal-session-copy-toast-${shell.name}`}
+                      aria-live="polite"
+                    >
+                      Copied
+                    </output>
+                  </>
+                ) : (
+                  <LinkIcon size={12} strokeWidth={2.1} />
+                )}
+              </button>
+              <button
+                type="button"
+                aria-label={`${deleting ? "Deleting" : "Close"} ${displayName}`}
+                tabIndex={showActions ? 0 : -1}
+                onClick={(event) => {
+                  event.stopPropagation();
+                  onDelete();
+                }}
+                onPointerDown={(event) => event.stopPropagation()}
+                onMouseDown={(event) => event.stopPropagation()}
+                disabled={deleting}
+                className="flex shrink-0 items-center justify-center"
+                style={{
+                  background: "#F0EFE5",
+                  border: "1px solid #E4E2D2",
+                  borderRadius: 6,
+                  color: "#77786E",
+                  cursor: deleting ? "not-allowed" : "pointer",
+                  fontSize: 15,
+                  height: 24,
+                  lineHeight: "20px",
+                  opacity: deleting ? 0.65 : 1,
+                  pointerEvents: "auto",
+                  width: 24,
+                }}
+              >
+                ×
+              </button>
+            </div>
           )}
         </div>
         <button
@@ -4850,21 +4963,7 @@ function ShellCard({
           }}
           onPointerDown={(event) => event.stopPropagation()}
           onMouseDown={(event) => event.stopPropagation()}
-          style={{
-            alignItems: "center",
-            background: foreground ? "#DDEDD6" : "#D8D7C7",
-            border: `1px solid ${foreground ? "#C9E1C2" : "#C8C7B7"}`,
-            borderRadius: 999,
-            color: foreground ? "#24452A" : "#77786E",
-            cursor: "pointer",
-            display: "flex",
-            flexShrink: 0,
-            height: 18,
-            justifyContent: foreground ? "flex-start" : "flex-end",
-            padding: 2,
-            pointerEvents: "auto",
-            width: foreground ? 40 : 38,
-          }}
+          style={foreground ? ACTIVE_SHELL_TOGGLE_STYLE : BACKGROUND_SHELL_TOGGLE_STYLE}
         >
           {foreground && <span style={{ background: "#4F8A55", borderRadius: 999, height: 12, width: 12 }} />}
           <span style={{ flex: "1 1 auto", fontSize: 10, fontWeight: 800, lineHeight: "10px", textAlign: "center" }}>
@@ -4873,92 +4972,6 @@ function ShellCard({
           {!foreground && <span style={{ background: "#F7F6EC", border: "1px solid #D6D5C4", borderRadius: 999, height: 12, width: 12 }} />}
         </button>
       </div>
-      {foreground && (
-        <div
-          data-testid={`terminal-session-actions-${shell.name}`}
-          className="pointer-events-none relative z-[1] flex items-center"
-          style={{
-            gap: 25,
-            maxHeight: showActions ? 28 : 0,
-            opacity: showActions ? 1 : 0,
-            overflow: "hidden",
-            paddingLeft: 17,
-            transition: "max-height 150ms ease, opacity 120ms ease",
-          }}
-        >
-          {showActions ? (
-            <>
-              <button
-                type="button"
-                aria-label={`Copy Matrix shell connect command for ${displayName}`}
-                className="min-w-0"
-                onClick={(event) => {
-                  event.stopPropagation();
-                  void copyAttachCommand();
-                }}
-                onPointerDown={(event) => event.stopPropagation()}
-                onMouseDown={(event) => event.stopPropagation()}
-                style={SHELL_CARD_COPY_BUTTON_STYLE}
-              >
-                <span
-                  className="truncate"
-                  data-testid={copyFeedback ? `terminal-session-copy-toast-${shell.name}` : undefined}
-                  role={copyFeedback ? "status" : undefined}
-                  aria-live={copyFeedback ? "polite" : undefined}
-                  style={{
-                    color: copyFeedback === "failed"
-                      ? "#A24F2F"
-                      : copyFeedback === "copied"
-                        ? "#465243"
-                        : "#8A8B7C",
-                    minWidth: 0,
-                  }}
-                >
-                  {copyFeedback ? (
-                    <span style={{ alignItems: "center", display: "inline-flex", gap: 6 }}>
-                      <span
-                        aria-hidden="true"
-                        style={{
-                          background: copyFeedback === "copied" ? "#9CB77A" : "#D8792C",
-                          borderRadius: 999,
-                          height: 6,
-                          width: 6,
-                        }}
-                      />
-                      {copyFeedback === "copied" ? "Command copied" : "Copy failed"}
-                    </span>
-                  ) : (
-                    <>
-                      <span>matrix shell connect</span>
-                      <span style={{ color: "#B0AF9F" }}> {shell.name}</span>
-                    </>
-                  )}
-                </span>
-                <CopyIcon size={12} strokeWidth={2} style={{ flexShrink: 0 }} />
-              </button>
-              <button
-                type="button"
-                aria-label={`${deleting ? "Deleting" : "Close"} ${displayName}`}
-                onClick={(event) => {
-                  event.stopPropagation();
-                  onDelete();
-                }}
-                onPointerDown={(event) => event.stopPropagation()}
-                onMouseDown={(event) => event.stopPropagation()}
-                disabled={deleting}
-                className={`pointer-events-auto flex h-7 w-7 shrink-0 items-center justify-center rounded-[7px] border border-[#DCDAC9] bg-[#F0EFE5] text-base text-[#77786E] ${deleting ? "cursor-not-allowed opacity-[0.65]" : "cursor-pointer opacity-100"}`}
-              >
-                ×
-              </button>
-            </>
-          ) : null}
-        </div>
-      )}
-      {!foreground && focusedTab ? (
-        <div className="pointer-events-none relative z-[1] truncate" style={{ color: "#858578", fontSize: 13, lineHeight: "16px", marginTop: 2, paddingLeft: 18 }}>
-          {focusedTab.name ? `last tab ${focusedTab.name}` : "keeps process alive"}
-        </div>
-      ) : null}
     </div>
   );
 }

--- a/shell/src/components/terminal/TerminalApp.tsx
+++ b/shell/src/components/terminal/TerminalApp.tsx
@@ -2862,6 +2862,7 @@ function LocalTerminalSidebar() {
   const [shellsLoading, setShellsLoading] = useState(false);
   const [shellsError, setShellsError] = useState<string | null>(null);
   const creatingShellRef = useRef(false);
+  const reorderSaveCountRef = useRef(0);
   const [creatingShell, setCreatingShell] = useState(false);
   const deletingShellsRef = useRef<Set<string> | null>(null);
   if (deletingShellsRef.current === null) deletingShellsRef.current = new Set();
@@ -2915,7 +2916,7 @@ function LocalTerminalSidebar() {
   }, [tab, fetchProjects]);
 
   // react-doctor-disable-next-line react-doctor/react-compiler-no-manual-memoization -- stable identity for effect dep: `fetchShells` is in the dependency array of the shells-tab load useEffect below and command handlers.
-  const fetchShells = useCallback(async (options: { silent?: boolean; signal?: AbortSignal } = {}) => {
+  const fetchShells = useCallback(async (options: { silent?: boolean; signal?: AbortSignal; preserveOrderDuringReorder?: boolean } = {}) => {
     const silent = options.silent === true;
     if (!silent) setShellsLoading(true);
     if (!silent) setShellsError(null);
@@ -2928,6 +2929,9 @@ function LocalTerminalSidebar() {
         if (!silent) {
           setShellsError("Failed to load shells");
         }
+        return;
+      }
+      if (options.preserveOrderDuringReorder === true && reorderSaveCountRef.current > 0) {
         return;
       }
       const data = (await res.json()) as { sessions?: ShellSessionSummary[] };
@@ -2952,7 +2956,7 @@ function LocalTerminalSidebar() {
     // react-doctor-disable-next-line react-hooks-js/set-state-in-effect, react-doctor/no-event-handler -- async network load of the shell-session list when the Shells tab becomes active; `tab` is live derived state that can change from many sources (restore, programmatic nav, deep link), not a single DOM click handler, so the fetch belongs in the effect and cannot be hoisted to one parent handler
     void fetchShells({ signal: controller.signal });
     const refreshTimer = window.setInterval(() => {
-      void fetchShells({ silent: true, signal: controller.signal });
+      void fetchShells({ silent: true, signal: controller.signal, preserveOrderDuringReorder: true });
     }, SHELLS_REFRESH_INTERVAL_MS);
     return () => {
       controller.abort();
@@ -3333,8 +3337,12 @@ function LocalTerminalSidebar() {
     const [moved] = nextShells.splice(fromIndex, 1);
     if (!moved) return;
     nextShells.splice(toIndex, 0, moved);
+    reorderSaveCountRef.current += 1;
     setShells(nextShells);
     setShellsError(null);
+    const finishReorderSave = () => {
+      reorderSaveCountRef.current = Math.max(0, reorderSaveCountRef.current - 1);
+    };
     try {
       const res = await fetch(`${getGatewayUrl()}/api/terminal/sessions/order`, {
         method: "PUT",
@@ -3345,6 +3353,7 @@ function LocalTerminalSidebar() {
       if (!res.ok) {
         setShellsError("Shell order could not be saved");
         await fetchShells({ silent: true });
+        finishReorderSave();
         return;
       }
       const data = (await res.json()) as { sessions?: ShellSessionSummary[] };
@@ -3353,10 +3362,12 @@ function LocalTerminalSidebar() {
       } else {
         await fetchShells({ silent: true });
       }
+      finishReorderSave();
     } catch (err: unknown) {
       console.warn("Failed to save shell order:", err instanceof Error ? err.message : err);
       setShellsError("Shell order could not be saved");
       await fetchShells({ silent: true });
+      finishReorderSave();
     }
   };
 

--- a/tests/gateway/shell-registry.test.ts
+++ b/tests/gateway/shell-registry.test.ts
@@ -18,6 +18,114 @@ afterEach(async () => {
 });
 
 describe("shell registry", () => {
+  it("lists main first, then active sessions by creation time when no custom order exists", async () => {
+    const root = await tempRoot();
+    const persistPath = join(root, "system", "shell-sessions.json");
+    await mkdir(join(root, "system"), { recursive: true });
+    await writeFile(
+      persistPath,
+      JSON.stringify({
+        sessions: {
+          bench: { name: "bench", status: "active", createdAt: "2026-06-15T12:00:02.000Z", updatedAt: "x", attachedClients: 0, tabs: [] },
+          main: { name: "main", status: "active", createdAt: "2026-06-15T12:00:03.000Z", updatedAt: "x", attachedClients: 0, tabs: [] },
+          docs: { name: "docs", status: "active", createdAt: "2026-06-15T12:00:01.000Z", updatedAt: "x", attachedClients: 0, tabs: [] },
+        },
+      }),
+      { flag: "wx" },
+    );
+    const adapter = {
+      listSessions: vi.fn(async () => ["bench", "main", "docs"]),
+      createSession: vi.fn(async () => undefined),
+      deleteSession: vi.fn(async () => undefined),
+    };
+    const registry = new ShellRegistry({ homePath: root, adapter, maxSessions: 4 });
+
+    await expect(registry.list()).resolves.toMatchObject([
+      { name: "main" },
+      { name: "docs" },
+      { name: "bench" },
+    ]);
+  });
+
+  it("persists custom order and respects it after reload", async () => {
+    const root = await tempRoot();
+    const live = new Set(["main", "bench", "docs"]);
+    const adapter = {
+      listSessions: vi.fn(async () => Array.from(live)),
+      createSession: vi.fn(async () => undefined),
+      deleteSession: vi.fn(async () => undefined),
+    };
+    const registry = new ShellRegistry({ homePath: root, adapter, maxSessions: 4 });
+
+    await registry.list();
+    await expect(registry.reorder(["docs", "main"])).resolves.toMatchObject([
+      { name: "docs" },
+      { name: "main" },
+      { name: "bench" },
+    ]);
+
+    const reloaded = new ShellRegistry({ homePath: root, adapter, maxSessions: 4 });
+    await expect(reloaded.list()).resolves.toMatchObject([
+      { name: "docs" },
+      { name: "main" },
+      { name: "bench" },
+    ]);
+    const raw = await readFile(join(root, "system", "shell-sessions.json"), "utf-8");
+    expect(JSON.parse(raw).order).toEqual(["docs", "main", "bench"]);
+  });
+
+  it("prunes deleted sessions from persisted custom order", async () => {
+    const root = await tempRoot();
+    const live = new Set(["main", "bench", "docs"]);
+    const adapter = {
+      listSessions: vi.fn(async () => Array.from(live)),
+      createSession: vi.fn(async () => undefined),
+      deleteSession: vi.fn(async (name: string) => {
+        live.delete(name);
+      }),
+    };
+    const registry = new ShellRegistry({ homePath: root, adapter, maxSessions: 4 });
+
+    await registry.list();
+    await registry.reorder(["docs", "bench", "main"]);
+    await registry.delete("bench");
+
+    const raw = await readFile(join(root, "system", "shell-sessions.json"), "utf-8");
+    expect(JSON.parse(raw).order).toEqual(["docs", "main"]);
+  });
+
+  it("ignores stale custom order entries and appends new live sessions deterministically", async () => {
+    const root = await tempRoot();
+    const persistPath = join(root, "system", "shell-sessions.json");
+    await mkdir(join(root, "system"), { recursive: true });
+    await writeFile(
+      persistPath,
+      JSON.stringify({
+        order: ["ghost", "docs"],
+        sessions: {
+          docs: { name: "docs", status: "active", createdAt: "2026-06-15T12:00:04.000Z", updatedAt: "x", attachedClients: 0, tabs: [] },
+          bench: { name: "bench", status: "active", createdAt: "2026-06-15T12:00:02.000Z", updatedAt: "x", attachedClients: 0, tabs: [] },
+          main: { name: "main", status: "active", createdAt: "2026-06-15T12:00:03.000Z", updatedAt: "x", attachedClients: 0, tabs: [] },
+        },
+      }),
+      { flag: "wx" },
+    );
+    const adapter = {
+      listSessions: vi.fn(async () => ["main", "bench", "docs"]),
+      createSession: vi.fn(async () => undefined),
+      deleteSession: vi.fn(async () => undefined),
+    };
+    const registry = new ShellRegistry({ homePath: root, adapter, maxSessions: 4 });
+
+    await expect(registry.list()).resolves.toMatchObject([
+      { name: "docs" },
+      { name: "bench" },
+      { name: "main" },
+    ]);
+    const raw = await readFile(persistPath, "utf-8");
+    expect(JSON.parse(raw).order).toEqual(["docs", "bench", "main"]);
+  });
+
   it("atomically persists created sessions", async () => {
     const root = await tempRoot();
     const adapter = {
@@ -127,17 +235,17 @@ describe("shell registry", () => {
         attachCommand: "mos shell attach main",
       },
       {
-        name: "deploy-logs",
-        placement: "active",
-        unread: false,
-        visualStatus: "idle",
-      },
-      {
         name: "review-done",
         latestSeq: 7,
         lastSeenSeq: 3,
         unread: true,
         visualStatus: "finished",
+      },
+      {
+        name: "deploy-logs",
+        placement: "active",
+        unread: false,
+        visualStatus: "idle",
       },
     ]);
 
@@ -210,12 +318,12 @@ describe("shell registry", () => {
     await registry.updateUiState("legacy-running", { lastSeenSeq: 1, visualStatus: "running" });
 
     await expect(registry.list()).resolves.toMatchObject([
+      { name: "legacy-running", latestSeq: 5, lastSeenSeq: 1, unread: true, visualStatus: "finished" },
+      { name: "osc-done", latestSeq: 21, lastSeenSeq: 20, unread: true, visualStatus: "finished" },
+      { name: "osc-running", unread: false, visualStatus: "running" },
       { name: "quiet", unread: false, visualStatus: "idle" },
       { name: "unread-done", latestSeq: 8, lastSeenSeq: 2, unread: true, visualStatus: "finished" },
-      { name: "osc-running", unread: false, visualStatus: "running" },
-      { name: "osc-done", latestSeq: 21, lastSeenSeq: 20, unread: true, visualStatus: "finished" },
       { name: "waiting", visualStatus: "waiting" },
-      { name: "legacy-running", latestSeq: 5, lastSeenSeq: 1, unread: true, visualStatus: "finished" },
     ]);
   });
 

--- a/tests/gateway/shell-routes.test.ts
+++ b/tests/gateway/shell-routes.test.ts
@@ -8,6 +8,7 @@ describe("gateway shell routes", () => {
     create: (input: unknown) => Promise<unknown>;
     delete: (name: string, options?: { force?: boolean }) => Promise<void>;
     rename?: (name: string, nextName: string) => Promise<unknown>;
+    reorder?: (order: string[]) => Promise<unknown[]>;
   }, shellBackend?: { health: () => Promise<{ ok: boolean; code: string }> }) {
     const app = new Hono();
     app.route("/api/terminal", createShellRoutes({ registry, shellBackend }));
@@ -142,6 +143,66 @@ describe("gateway shell routes", () => {
 
     expect(res.status).toBe(200);
     expect(registry.delete).toHaveBeenCalledWith("main", { force: true });
+  });
+
+  it("persists session order through a bounded JSON route under both mounts", async () => {
+    const registry = {
+      list: vi.fn(async () => []),
+      create: vi.fn(),
+      delete: vi.fn(),
+      reorder: vi.fn(async (order: string[]) => order.map((name) => ({ name, status: "active" }))),
+    };
+    const app = appWithRegistry(registry);
+
+    const terminalRes = await app.request("/api/terminal/sessions/order", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ order: ["bench", "main"] }),
+    });
+    const apiRes = await app.request("/api/sessions/order", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ order: ["main", "bench"] }),
+    });
+
+    expect(terminalRes.status).toBe(200);
+    await expect(terminalRes.json()).resolves.toEqual({
+      sessions: [
+        { name: "bench", status: "active" },
+        { name: "main", status: "active" },
+      ],
+    });
+    expect(apiRes.status).toBe(200);
+    expect(registry.reorder).toHaveBeenNthCalledWith(1, ["bench", "main"]);
+    expect(registry.reorder).toHaveBeenNthCalledWith(2, ["main", "bench"]);
+  });
+
+  it("validates session order bodies before dispatch", async () => {
+    const registry = {
+      list: vi.fn(async () => []),
+      create: vi.fn(),
+      delete: vi.fn(),
+      reorder: vi.fn(),
+    };
+    const app = appWithRegistry(registry);
+
+    const invalidName = await app.request("/api/terminal/sessions/order", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ order: ["Main"] }),
+    });
+    const tooLarge = await app.request("/api/terminal/sessions/order", {
+      method: "PUT",
+      headers: {
+        "Content-Type": "application/json",
+        "Content-Length": "2048",
+      },
+      body: JSON.stringify({ order: ["main"] }),
+    });
+
+    expect(invalidName.status).toBe(400);
+    expect(tooLarge.status).toBe(413);
+    expect(registry.reorder).not.toHaveBeenCalled();
   });
 
   it("renames sessions through a bounded JSON route", async () => {

--- a/tests/gateway/shell-routes.test.ts
+++ b/tests/gateway/shell-routes.test.ts
@@ -177,6 +177,27 @@ describe("gateway shell routes", () => {
     expect(registry.reorder).toHaveBeenNthCalledWith(2, ["main", "bench"]);
   });
 
+  it("accepts large valid session order bodies within the schema cap", async () => {
+    const order = Array.from({ length: 30 }, (_, index) => `s${String(index).padStart(2, "0")}-${"a".repeat(27)}`);
+    expect(JSON.stringify({ order }).length).toBeGreaterThan(1024);
+    const registry = {
+      list: vi.fn(async () => []),
+      create: vi.fn(),
+      delete: vi.fn(),
+      reorder: vi.fn(async (nextOrder: string[]) => nextOrder.map((name) => ({ name, status: "active" }))),
+    };
+    const app = appWithRegistry(registry);
+
+    const res = await app.request("/api/terminal/sessions/order", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ order }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(registry.reorder).toHaveBeenCalledWith(order);
+  });
+
   it("validates session order bodies before dispatch", async () => {
     const registry = {
       list: vi.fn(async () => []),
@@ -195,7 +216,7 @@ describe("gateway shell routes", () => {
       method: "PUT",
       headers: {
         "Content-Type": "application/json",
-        "Content-Length": "2048",
+        "Content-Length": "9000",
       },
       body: JSON.stringify({ order: ["main"] }),
     });

--- a/tests/shell/terminal-app-component.test.tsx
+++ b/tests/shell/terminal-app-component.test.tsx
@@ -377,17 +377,18 @@ describe("TerminalApp", () => {
     expect(row).toBeTruthy();
     fireEvent.mouseEnter(row!);
     const actions = screen.getByTestId("terminal-session-actions-main");
-    expect(within(actions).getByText("matrix shell connect")).toBeTruthy();
-    expect(within(actions).getByText("main")).toBeTruthy();
-    expect(actions.style.gap).toBe("25px");
+    expect(screen.queryByText("matrix shell connect")).toBeNull();
+    expect(actions.style.maxHeight).toBe("");
+    expect(within(actions).getByRole("button", { name: "Copy connect command for matrix-main" })).toBeTruthy();
+    expect(within(actions).getByRole("button", { name: "Close matrix-main" })).toBeTruthy();
 
     await act(async () => {
       fireEvent.click(screen.getByRole("button", { name: "Copy connect command for matrix-main" }));
       await Promise.resolve();
     });
 
-    expect(writeText).toHaveBeenCalledWith("mos shell attach main");
-    expect(screen.getByTestId("terminal-session-copy-toast-main").textContent).toContain("Command copied");
+    expect(writeText).toHaveBeenCalledWith("matrix shell connect main");
+    expect(screen.getByTestId("terminal-session-copy-toast-main").textContent).toContain("Copied");
     expect(within(actions).queryByText("matrix shell connect")).toBeNull();
   });
 
@@ -442,7 +443,7 @@ describe("TerminalApp", () => {
 
     expect(writeText).not.toHaveBeenCalled();
     expect(execCommand).toHaveBeenCalledWith("copy");
-    expect(screen.getByTestId("terminal-session-copy-toast-main").textContent).toContain("Command copied");
+    expect(screen.getByTestId("terminal-session-copy-toast-main").textContent).toContain("Copied");
   });
 
   it("falls back to the Clipboard API when legacy copy returns false", async () => {
@@ -493,18 +494,32 @@ describe("TerminalApp", () => {
     });
 
     expect(execCommand).toHaveBeenCalledWith("copy");
-    expect(writeText).toHaveBeenCalledWith("mos shell attach main");
-    expect(screen.getByTestId("terminal-session-copy-toast-main").textContent).toContain("Command copied");
+    expect(writeText).toHaveBeenCalledWith("matrix shell connect main");
+    expect(screen.getByTestId("terminal-session-copy-toast-main").textContent).toContain("Copied");
   });
 
   it("reorders active shell sessions with the Paper drag affordance", async () => {
+    const calls: Array<{ url: string; init?: RequestInit }> = [];
     vi.mocked(fetch).mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
       const url = String(input);
+      calls.push({ url, init });
       if (url.includes("/api/terminal/layout") && init?.method === "PUT") {
         return Promise.resolve({ ok: true, json: async () => ({ ok: true }) } as Response);
       }
       if (url.includes("/api/terminal/layout")) {
         return Promise.resolve({ ok: true, json: async () => ({}) } as Response);
+      }
+      if (url.endsWith("/api/terminal/sessions/order") && init?.method === "PUT") {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            sessions: [
+              { name: "docs", status: "active", placement: "active", attachCommand: "mos shell attach docs", tabs: [] },
+              { name: "review", status: "active", placement: "active", attachCommand: "mos shell attach review", tabs: [] },
+              { name: "main", status: "active", placement: "active", attachCommand: "mos shell attach main", tabs: [] },
+            ],
+          }),
+        } as Response);
       }
       if (url.endsWith("/api/terminal/sessions") && init?.method !== "POST") {
         return Promise.resolve({
@@ -542,9 +557,22 @@ describe("TerminalApp", () => {
 
     expect(screen.getByTestId("terminal-session-drop-line-docs")).toBeTruthy();
 
-    fireEvent.drop(screen.getByTestId("terminal-session-card-docs"), { dataTransfer });
+    await act(async () => {
+      fireEvent.drop(screen.getByTestId("terminal-session-card-docs"), { dataTransfer });
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
 
-    expect(getOrder()).toEqual(["review", "docs", "main"]);
+    const orderCall = calls.find((call) => call.url.endsWith("/api/terminal/sessions/order") && call.init?.method === "PUT");
+    expect(orderCall).toBeTruthy();
+    expect(JSON.parse(String(orderCall?.init?.body))).toEqual({ order: ["review", "docs", "main"] });
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(getOrder()).toEqual(["docs", "review", "main"]);
   });
 
   it("renames sessions from the Paper pencil affordance", async () => {
@@ -1158,6 +1186,93 @@ describe("TerminalApp", () => {
     expect(screen.queryByRole("button", { name: "Projects" })).toBeNull();
     expect(screen.getByText("Active")).toBeTruthy();
     expect(screen.getByLabelText("Search sessions")).toBeTruthy();
+  });
+
+  it("highlights the shell attached to the active restored pane on first render", async () => {
+    vi.mocked(fetch).mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.includes("/api/terminal/layout") && init?.method === "PUT") {
+        return Promise.resolve({ ok: true, json: async () => ({ ok: true }) } as Response);
+      }
+      if (url.includes("/api/terminal/layout")) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            tabs: [
+              {
+                id: "tab-docs",
+                label: "Docs",
+                paneTree: { type: "pane", id: "pane-docs", cwd: "projects", sessionId: "docs" },
+              },
+            ],
+            activeTabId: "tab-docs",
+            sidebarOpen: true,
+          }),
+        } as Response);
+      }
+      if (url.endsWith("/api/terminal/sessions") && init?.method !== "POST") {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            sessions: [
+              { name: "main", status: "active", placement: "active", tabs: [] },
+              { name: "docs", status: "active", placement: "active", tabs: [] },
+            ],
+          }),
+        } as Response);
+      }
+      return Promise.resolve({ ok: true, json: async () => ({}) } as Response);
+    });
+
+    render(<TerminalApp />);
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(screen.getByTestId("terminal-session-row-docs").getAttribute("data-selected")).toBe("true");
+    expect(screen.getByTestId("terminal-session-row-main").getAttribute("data-selected")).toBe("false");
+  });
+
+  it("attaches and highlights the first ordered shell when no saved layout exists", async () => {
+    vi.mocked(fetch).mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.includes("/api/terminal/layout") && init?.method === "PUT") {
+        return Promise.resolve({ ok: true, json: async () => ({ ok: true }) } as Response);
+      }
+      if (url.includes("/api/terminal/layout")) {
+        return Promise.resolve({ ok: true, json: async () => ({}) } as Response);
+      }
+      if (url.endsWith("/api/terminal/sessions") && init?.method !== "POST") {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            sessions: [
+              { name: "bench", status: "active", placement: "active", tabs: [] },
+              { name: "main", status: "active", placement: "active", tabs: [] },
+            ],
+          }),
+        } as Response);
+      }
+      return Promise.resolve({ ok: true, json: async () => ({}) } as Response);
+    });
+
+    render(<TerminalApp />);
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(paneGridSpy.mock.lastCall?.[0]).toMatchObject({
+      paneTree: {
+        sessionId: "bench",
+      },
+    });
+    expect(screen.getByTestId("terminal-session-row-bench").getAttribute("data-selected")).toBe("true");
   });
 
   it("renders the Paper collapsed sessions rail in layout flow when hidden", async () => {

--- a/tests/shell/terminal-app-component.test.tsx
+++ b/tests/shell/terminal-app-component.test.tsx
@@ -575,6 +575,83 @@ describe("TerminalApp", () => {
     expect(getOrder()).toEqual(["docs", "review", "main"]);
   });
 
+  it("keeps an optimistic shell reorder visible while polling returns the old order", async () => {
+    let shellList = [
+      { name: "main", status: "active", placement: "active", attachCommand: "mos shell attach main", tabs: [] },
+      { name: "review", status: "active", placement: "active", attachCommand: "mos shell attach review", tabs: [] },
+      { name: "docs", status: "active", placement: "active", attachCommand: "mos shell attach docs", tabs: [] },
+    ];
+    let resolveOrder: ((value: Response) => void) | undefined;
+    const orderPromise = new Promise<Response>((resolve) => {
+      resolveOrder = resolve;
+    });
+    vi.mocked(fetch).mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.includes("/api/terminal/layout") && init?.method === "PUT") {
+        return Promise.resolve({ ok: true, json: async () => ({ ok: true }) } as Response);
+      }
+      if (url.includes("/api/terminal/layout")) {
+        return Promise.resolve({ ok: true, json: async () => ({}) } as Response);
+      }
+      if (url.endsWith("/api/terminal/sessions/order") && init?.method === "PUT") {
+        return orderPromise;
+      }
+      if (url.endsWith("/api/terminal/sessions") && init?.method !== "POST") {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ sessions: shellList }),
+        } as Response);
+      }
+      return Promise.resolve({ ok: true, json: async () => ({}) } as Response);
+    });
+
+    render(<TerminalApp />);
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    const activeGroup = screen.getByTestId("terminal-session-group-active");
+    const getOrder = () => Array.from(activeGroup.querySelectorAll("[data-session-name]"))
+      .map((node) => node.getAttribute("data-session-name"));
+    expect(getOrder()).toEqual(["main", "review", "docs"]);
+
+    const dataTransfer = createDragDataTransfer();
+    fireEvent.mouseEnter(screen.getByTestId("terminal-session-card-main"));
+    fireEvent.dragStart(screen.getByRole("button", { name: "Drag matrix-main session" }), { dataTransfer });
+    fireEvent.dragOver(screen.getByTestId("terminal-session-card-docs"), { dataTransfer });
+
+    await act(async () => {
+      fireEvent.drop(screen.getByTestId("terminal-session-card-docs"), { dataTransfer });
+      await Promise.resolve();
+    });
+    expect(getOrder()).toEqual(["review", "docs", "main"]);
+
+    await act(async () => {
+      vi.advanceTimersByTime(5_000);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(getOrder()).toEqual(["review", "docs", "main"]);
+
+    shellList = [
+      { name: "docs", status: "active", placement: "active", attachCommand: "mos shell attach docs", tabs: [] },
+      { name: "review", status: "active", placement: "active", attachCommand: "mos shell attach review", tabs: [] },
+      { name: "main", status: "active", placement: "active", attachCommand: "mos shell attach main", tabs: [] },
+    ];
+    await act(async () => {
+      resolveOrder?.({
+        ok: true,
+        json: async () => ({ sessions: shellList }),
+      } as Response);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(getOrder()).toEqual(["docs", "review", "main"]);
+  });
+
   it("renames sessions from the Paper pencil affordance", async () => {
     const calls: Array<{ url: string; init?: RequestInit }> = [];
     vi.mocked(fetch).mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {


### PR DESCRIPTION
## Summary

- Keeps shell sidebar rows fixed-height with inline hover/focus actions for connect-copy and delete.
- Derives the active shell highlight from the active terminal pane session immediately on open.
- Persists global shell order in the gateway shell registry and adds `PUT /api/terminal/sessions/order` plus the `/api/sessions/order` mount.
- Adds optimistic drag/drop reorder that saves to the gateway and refreshes safely on failure.

## Tests

- `pnpm exec vitest run tests/gateway/shell-registry.test.ts tests/gateway/shell-routes.test.ts tests/shell/terminal-app-component.test.tsx`
- `pnpm --dir packages/gateway exec tsc --noEmit`
- `pnpm --dir shell exec tsc --noEmit -p tsconfig.json`
- `./scripts/review/check-patterns.sh` (0 violations; reviewed bounded local Set warnings in registry ordering code)
- `npx react-doctor@latest shell --verbose --scope changed --base origin/main` (no issues found)

Notes:
- `bun run typecheck` could not be run in this environment because `bun` is not installed and `flox` is unavailable; scoped package TypeScript checks passed instead.
- Full-project `npx react-doctor@latest shell` reports pre-existing project-wide warnings outside this diff; changed-file audit is clean.

## Screenshot Evidence

- `/tmp/terminal-sidebar-hover.png`
- `/tmp/terminal-sidebar-copied.png`
- `/tmp/terminal-sidebar-hover-crop.png`
- `/tmp/terminal-sidebar-copied-crop.png`

## Invariants

**Source of truth:** Shell session metadata and custom order are gateway-owned in `~/system/shell-sessions.json`; live zellij sessions are reconciled into that registry before list/reorder responses.

**Lock/transaction scope:** `ShellRegistry` mutation locking covers registry read, live-session reconciliation, order normalization, and atomic file writes for reorder/create/delete/rename paths. The persisted registry is written with the existing atomic UTF-8 file helper.

**Acceptable orphan states:** Stale order entries are ignored and pruned on reconciliation. Delete prunes names from persisted order. If client order save fails, the sidebar shows a generic error and refreshes from the server. Existing create rollback behavior is preserved if zellij creation succeeds but registry persistence fails.

**Auth source of truth:** The new order route is mounted only through the existing shell route stack under `/api/terminal` and `/api`; it uses the same gateway auth surface as neighboring shell session routes. Request JSON is bounded with `bodyLimit` and validated with Zod safe shell-session names.

**Deferred scope:** This does not add realtime cross-browser order push; other browsers/devices see the canonical order on refresh or polling. The gateway still returns the legacy `attachCommand` field for compatibility, while the UI copies the requested `matrix shell connect <session-name>` command.
