### PR TITLE
fix(runtime): skip inactive incremental object uploads

### DIFF
--- a/scripts/publish-release-r2.mjs
+++ b/scripts/publish-release-r2.mjs
@@ -184,6 +184,22 @@ function incrementalObjectEntries(incrementalManifest) {
   });
 }
 
+function incrementalRequiresFullBundle(incrementalManifest) {
+  return incrementalManifest.requiresFullBundle !== false;
+}
+
+async function validateIncrementalObjects(incrementalObjects) {
+  for (const object of incrementalObjects) {
+    const objectStat = await stat(object.path);
+    if (objectStat.size !== object.size) {
+      throw new Error(`incremental object size mismatch for ${object.path}`);
+    }
+    if ((await sha256(object.path)) !== object.sha256) {
+      throw new Error(`incremental object checksum mismatch for ${object.path}`);
+    }
+  }
+}
+
 const bundleStat = await stat(bundlePath);
 const checksum = await sha256(bundlePath);
 const checksumText = `${checksum}  ${bundleName}\n`;
@@ -194,7 +210,9 @@ const incrementalManifestSha256 = await sha256(incrementalManifestPath);
 const release = await readJson(releasePath);
 const manifest = await readJson(manifestPath);
 const incrementalManifest = await readJson(incrementalManifestPath);
-const incrementalObjects = incrementalObjectEntries(incrementalManifest);
+const incrementalObjects = incrementalRequiresFullBundle(incrementalManifest)
+  ? []
+  : incrementalObjectEntries(incrementalManifest);
 
 const registrationBody = {
   version,
@@ -220,12 +238,18 @@ if (dryRun) {
   console.log("=== DRY RUN ===");
   console.log(`Would upload ${bundlePath} to s3://${bucket}/${bundleKey}`);
   console.log(`Would upload checksum to s3://${bucket}/${checksumKey}`);
-  console.log(`Would upload ${incrementalObjects.length} incremental file objects`);
+  if (incrementalRequiresFullBundle(incrementalManifest)) {
+    console.log("Incremental manifest requires full bundle; skipping incremental file object uploads.");
+  } else {
+    console.log(`Would upload ${incrementalObjects.length} incremental file objects`);
+  }
   console.log(`Would upload incremental manifest to s3://${bucket}/${incrementalManifestKey}`);
   console.log("Would register release:");
   console.log(JSON.stringify(registrationBody, null, 2));
   process.exit(0);
 }
+
+await validateIncrementalObjects(incrementalObjects);
 
 const accountId = process.env.R2_ACCOUNT_ID;
 const accessKeyId = process.env.AWS_ACCESS_KEY_ID || required("R2_ACCESS_KEY_ID");
@@ -250,24 +274,21 @@ if (!(await verifyExistingChecksum(s3, checksumKey, checksum))) {
   await uploadImmutable(s3, checksumPath, checksumKey, "text/plain; charset=utf-8", checksum, checksumStat.size);
 }
 
-console.log(`  Uploading ${incrementalObjects.length} incremental file objects...`);
-for (const object of incrementalObjects) {
-  const objectStat = await stat(object.path);
-  if (objectStat.size !== object.size) {
-    throw new Error(`incremental object size mismatch for ${object.path}`);
-  }
-  if ((await sha256(object.path)) !== object.sha256) {
-    throw new Error(`incremental object checksum mismatch for ${object.path}`);
-  }
-  if (!(await verifyExistingBundle(s3, object.key, object.size, object.sha256))) {
-    await uploadImmutable(
-      s3,
-      object.path,
-      object.key,
-      "application/octet-stream",
-      object.sha256,
-      object.size,
-    );
+if (incrementalRequiresFullBundle(incrementalManifest)) {
+  console.log("  Incremental manifest requires full bundle; skipping incremental file object uploads.");
+} else {
+  console.log(`  Uploading ${incrementalObjects.length} incremental file objects...`);
+  for (const object of incrementalObjects) {
+    if (!(await verifyExistingBundle(s3, object.key, object.size, object.sha256))) {
+      await uploadImmutable(
+        s3,
+        object.path,
+        object.key,
+        "application/octet-stream",
+        object.sha256,
+        object.size,
+      );
+    }
   }
 }
 

--- a/scripts/publish-release.sh
+++ b/scripts/publish-release.sh
@@ -136,6 +136,10 @@ incremental_object_count() {
   python3 -c "import json,sys; print(len(json.load(open(sys.argv[1])).get('files', [])))" "$INCREMENTAL_MANIFEST"
 }
 
+incremental_requires_full_bundle() {
+  python3 -c "import json,sys; manifest=json.load(open(sys.argv[1])); sys.exit(0 if manifest.get('requiresFullBundle', True) is not False else 1)" "$INCREMENTAL_MANIFEST"
+}
+
 write_incremental_object_list() {
   python3 -c "
 import json, re, sys
@@ -335,7 +339,11 @@ if [ "$DRY_RUN" = "1" ]; then
   echo "Would upload immutable artifacts:"
   echo "  $BUNDLE → s3://$R2_BUCKET/$BUNDLE_KEY"
   echo "  sha256 → s3://$R2_BUCKET/$CHECKSUM_KEY"
-  echo "  $(incremental_object_count) incremental file objects"
+  if incremental_requires_full_bundle; then
+    echo "  Incremental manifest requires full bundle; would skip incremental file object uploads."
+  else
+    echo "  $(incremental_object_count) incremental file objects"
+  fi
   echo "  incremental manifest → s3://$R2_BUCKET/$INCREMENTAL_MANIFEST_KEY"
   echo ""
   echo "Would register release in platform DB:"
@@ -352,8 +360,10 @@ INCREMENTAL_OBJECTS_FILE="$(mktemp)"
 cleanup_temp_files() { rm -f "$AUTH_HEADER_FILE" "$CHECKSUM_FILE" "$INCREMENTAL_OBJECTS_FILE"; }
 trap cleanup_temp_files EXIT
 printf '%s  matrix-host-bundle.tar.gz\n' "$SHA256" > "$CHECKSUM_FILE"
-write_incremental_object_list > "$INCREMENTAL_OBJECTS_FILE"
-validate_incremental_object_list
+if ! incremental_requires_full_bundle; then
+  write_incremental_object_list > "$INCREMENTAL_OBJECTS_FILE"
+  validate_incremental_object_list
+fi
 
 echo "  Uploading versioned archive..."
 if object_exists "$BUNDLE_KEY"; then
@@ -368,22 +378,27 @@ if object_exists "$CHECKSUM_KEY"; then
 else
   upload_immutable_object "$CHECKSUM_FILE" "$CHECKSUM_KEY" "text/plain; charset=utf-8"
 fi
-echo "  Uploading incremental file objects with concurrency $INCREMENTAL_UPLOAD_CONCURRENCY..."
-incremental_upload_failed=0
-while IFS=$'\t' read -r object_sha256 object_size object_key; do
-  object_file="$DIST_DIR/objects/sha256/$object_sha256"
-  if ! wait_for_incremental_upload_slot; then
+
+if incremental_requires_full_bundle; then
+  echo "  Incremental manifest requires full bundle; skipping incremental file object uploads."
+else
+  echo "  Uploading incremental file objects with concurrency $INCREMENTAL_UPLOAD_CONCURRENCY..."
+  incremental_upload_failed=0
+  while IFS=$'\t' read -r object_sha256 object_size object_key; do
+    object_file="$DIST_DIR/objects/sha256/$object_sha256"
+    if ! wait_for_incremental_upload_slot; then
+      incremental_upload_failed=1
+    fi
+    upload_content_addressed_object "$object_file" "$object_key" "application/octet-stream" "$object_sha256" &
+    incremental_upload_pids+=("$!")
+  done < "$INCREMENTAL_OBJECTS_FILE"
+  if ! wait_for_incremental_uploads; then
     incremental_upload_failed=1
   fi
-  upload_content_addressed_object "$object_file" "$object_key" "application/octet-stream" "$object_sha256" &
-  incremental_upload_pids+=("$!")
-done < "$INCREMENTAL_OBJECTS_FILE"
-if ! wait_for_incremental_uploads; then
-  incremental_upload_failed=1
-fi
-if [ "$incremental_upload_failed" -ne 0 ]; then
-  echo "ERROR: one or more incremental file object uploads failed" >&2
-  exit 1
+  if [ "$incremental_upload_failed" -ne 0 ]; then
+    echo "ERROR: one or more incremental file object uploads failed" >&2
+    exit 1
+  fi
 fi
 if object_exists "$INCREMENTAL_MANIFEST_KEY"; then
   echo "  Verifying existing immutable incremental manifest..."

--- a/tests/platform/customer-vps-host-bundle.test.ts
+++ b/tests/platform/customer-vps-host-bundle.test.ts
@@ -153,6 +153,10 @@ describe('customer VPS host bundle', () => {
     expect(publishScript).toContain('write_incremental_object_list()');
     expect(publishScript).toContain('HOST_BUNDLE_INCREMENTAL_UPLOAD_CONCURRENCY');
     expect(publishScript).toContain('upload_content_addressed_object()');
+    expect(publishScript).toContain('incremental_requires_full_bundle()');
+    expect(publishScript).toContain('Incremental manifest requires full bundle; skipping incremental file object uploads.');
+    expect(publishScript).toContain('if incremental_requires_full_bundle; then');
+    expect(publishScript).toContain('if ! incremental_requires_full_bundle; then');
     expect(publishScript).toContain('PreconditionFailed');
     expect(publishScript).toContain('incremental_upload_pids=()');
     expect(publishScript).toContain('incremental_upload_pids+=("$!")');
@@ -196,6 +200,10 @@ describe('customer VPS host bundle', () => {
     expect(nodePublisher).toContain('incrementalManifestKey');
     expect(nodePublisher).toContain('incremental-manifest.json');
     expect(nodePublisher).toContain('incrementalObjectEntries');
+    expect(nodePublisher).toContain('incrementalRequiresFullBundle');
+    expect(nodePublisher).toContain('validateIncrementalObjects');
+    expect(nodePublisher).toContain('await validateIncrementalObjects(incrementalObjects);');
+    expect(nodePublisher).toContain('Incremental manifest requires full bundle; skipping incremental file object uploads.');
     expect(nodePublisher).toContain('system-bundles/objects/sha256/${file.sha256}');
     expect(nodePublisher).toContain('Uploading ${incrementalObjects.length} incremental file objects');
     expect(nodePublisher).toContain('"application/octet-stream"');


### PR DESCRIPTION
Summary:
- Skip per-file incremental object uploads while the generated incremental manifest still requires a full bundle.
- Keep full tarball, checksum, incremental manifest upload, and platform release registration intact.
- Validate active incremental object lists before immutable full-bundle uploads when requiresFullBundle=false, including the Node R2 fallback path.

Tests:
- bun run test tests/platform/customer-vps-host-bundle.test.ts
- bash -n scripts/publish-release.sh
- node --check scripts/publish-release-r2.mjs
- git diff --check
- bun run typecheck
- bun run check:patterns (0 violations; existing warnings only)
- bun run test (593 passed, 3 skipped; 6697 passed, 20 skipped)

Invariants:
- Source of truth: release artifacts remain the immutable full host-bundle tarball/checksum plus platform release metadata; the incremental manifest is published as metadata for future delta apply.
- Lock/transaction scope: no database transaction is changed; release registration still happens only after immutable artifact uploads complete.
- Acceptable orphan states: a full bundle and manifest may exist in R2 before platform registration, matching the existing retryable publish behavior; skipped object fan-out is deliberate while requiresFullBundle is true.
- Auth source of truth: R2 credentials and PLATFORM_SECRET remain environment-provided server-side secrets; no new client-visible auth path is introduced.
- Deferred scope: VPS-side delta apply and publishing content-addressed objects for requiresFullBundle=false manifests remain out of scope for this hotfix.
