### PR TITLE
feat(shell): add developer mode dashboard

### DIFF
--- a/shell/src/components/Desktop.tsx
+++ b/shell/src/components/Desktop.tsx
@@ -11,6 +11,11 @@ import { useCanvasTransform } from "@/hooks/useCanvasTransform";
 import { useDesktopConfigStore } from "@/stores/desktop-config";
 import { saveDesktopConfigPatch } from "@/hooks/useDesktopConfig";
 import { useWorkspaceCanvasStore } from "@/stores/workspace-canvas-store";
+import {
+  parseDesktopFirstRunStatus,
+  shouldApplyInitialDesktopDefaults,
+  type DesktopFirstRunStatus,
+} from "@/lib/desktop-first-run";
 import { AppViewer } from "./AppViewer";
 import { TerminalApp } from "./terminal/TerminalApp";
 import { WorkspaceApp } from "./workspace/WorkspaceApp";
@@ -587,7 +592,8 @@ export function Desktop({ launchAppPath, onOpenCommandPalette, chat }: DesktopPr
   // busy because the popup auto-opens then resists close.
   const [chatOpen, setChatOpen] = useState(false);
   const [minimizingIds, setMinimizingIds] = useState<Set<string>>(new Set());
-  const [firstRunStatus, setFirstRunStatus] = useState<"checking" | "ready">("checking");
+  const [firstRunStatus, setFirstRunStatus] = useState<DesktopFirstRunStatus>("checking");
+  const firstRunStatusRef = useRef<DesktopFirstRunStatus>("checking");
   const launchPathConsumedRef = useRef<string | null>(null);
   const [manualSetupVisible, setManualSetupVisible] = useState(false);
 
@@ -627,19 +633,23 @@ export function Desktop({ launchAppPath, onOpenCommandPalette, chat }: DesktopPr
     })
       .then(async (res) => {
         if (!res.ok) throw new Error("onboarding status unavailable");
-        const status = await res.json() as { complete?: unknown };
-        if (typeof status.complete !== "boolean") throw new Error("invalid onboarding status");
+        const nextStatus = parseDesktopFirstRunStatus(await res.json());
+        if (!cancelled) {
+          firstRunStatusRef.current = nextStatus;
+          setFirstRunStatus(nextStatus);
+        }
       })
       .catch((err: unknown) => {
         if (!controller.signal.aborted) {
           console.warn("[desktop] first-run status check failed:", err);
         }
+        if (!cancelled) {
+          firstRunStatusRef.current = "ready";
+          setFirstRunStatus("ready");
+        }
       })
       .finally(() => {
         window.clearTimeout(timeout);
-        if (!cancelled) {
-          setFirstRunStatus("ready");
-        }
       });
     return () => {
       cancelled = true;
@@ -649,6 +659,9 @@ export function Desktop({ launchAppPath, onOpenCommandPalette, chat }: DesktopPr
   }, []);
 
   const completeOnboarding = () => {
+    if (!shouldApplyInitialDesktopDefaults(firstRunStatusRef.current)) return;
+    firstRunStatusRef.current = "ready";
+    setFirstRunStatus("ready");
     void markOnboardingComplete().catch((err: unknown) => {
       console.warn("[desktop] onboarding completion persist failed:", err instanceof Error ? err.message : String(err));
     });

--- a/shell/src/components/Desktop.tsx
+++ b/shell/src/components/Desktop.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useCallback, useEffect, useMemo, useRef, type CSSProperties, type ReactNode } from "react";
+import { useState, useCallback, useEffect, useRef, type CSSProperties, type ReactNode } from "react";
 import { useIconWithFallback } from "@/hooks/useIconWithFallback";
 import { useFileWatcher } from "@/hooks/useFileWatcher";
 import { useWindowManager, type LayoutWindow } from "@/hooks/useWindowManager";
@@ -1184,7 +1184,7 @@ export function Desktop({ launchAppPath, onOpenCommandPalette, chat }: DesktopPr
   const getModeConfig = useDesktopMode((s) => s.getModeConfig);
   const hydrated = useDesktopMode((s) => s._hydrated);
   const modeConfig = getModeConfig(hydrated ? desktopMode : "dev");
-  const visibleWindowCount = useMemo(() => windows.filter((w) => !w.minimized).length, [windows]);
+  const visibleWindowCount = windows.reduce((count, w) => count + (w.minimized ? 0 : 1), 0);
   const developerDashboardVisible = firstRunStatus === "ready"
     && desktopMode === "dev"
     && visibleWindowCount === 0;

--- a/shell/src/components/Desktop.tsx
+++ b/shell/src/components/Desktop.tsx
@@ -14,6 +14,7 @@ import { useWorkspaceCanvasStore } from "@/stores/workspace-canvas-store";
 import {
   parseDesktopFirstRunStatus,
   shouldApplyInitialDesktopDefaults,
+  shouldShowDeveloperDashboard,
   type DesktopFirstRunStatus,
 } from "@/lib/desktop-first-run";
 import { AppViewer } from "./AppViewer";
@@ -1198,9 +1199,7 @@ export function Desktop({ launchAppPath, onOpenCommandPalette, chat }: DesktopPr
   const hydrated = useDesktopMode((s) => s._hydrated);
   const modeConfig = getModeConfig(hydrated ? desktopMode : "dev");
   const visibleWindowCount = windows.reduce((count, w) => count + (w.minimized ? 0 : 1), 0);
-  const developerDashboardVisible = firstRunStatus === "ready"
-    && desktopMode === "dev"
-    && visibleWindowCount === 0;
+  const developerDashboardVisible = shouldShowDeveloperDashboard(firstRunStatus, desktopMode, visibleWindowCount);
   const openPrCanvas = useWorkspaceCanvasStore((s) => s.openPrCanvas);
 
   // Cascade windows back to the viewport when leaving canvas. Canvas

--- a/shell/src/components/Desktop.tsx
+++ b/shell/src/components/Desktop.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useCallback, useEffect, useRef, type CSSProperties, type ReactNode } from "react";
+import { useState, useCallback, useEffect, useMemo, useRef, type CSSProperties, type ReactNode } from "react";
 import { useIconWithFallback } from "@/hooks/useIconWithFallback";
 import { useFileWatcher } from "@/hooks/useFileWatcher";
 import { useWindowManager, type LayoutWindow } from "@/hooks/useWindowManager";
@@ -625,8 +625,10 @@ export function Desktop({ launchAppPath, onOpenCommandPalette, chat }: DesktopPr
       cache: "no-store",
       signal: controller.signal,
     })
-      .then((res) => {
+      .then(async (res) => {
         if (!res.ok) throw new Error("onboarding status unavailable");
+        const status = await res.json() as { complete?: unknown };
+        if (typeof status.complete !== "boolean") throw new Error("invalid onboarding status");
       })
       .catch((err: unknown) => {
         if (!controller.signal.aborted) {
@@ -1182,7 +1184,7 @@ export function Desktop({ launchAppPath, onOpenCommandPalette, chat }: DesktopPr
   const getModeConfig = useDesktopMode((s) => s.getModeConfig);
   const hydrated = useDesktopMode((s) => s._hydrated);
   const modeConfig = getModeConfig(hydrated ? desktopMode : "dev");
-  const visibleWindowCount = windows.filter((w) => !w.minimized).length;
+  const visibleWindowCount = useMemo(() => windows.filter((w) => !w.minimized).length, [windows]);
   const developerDashboardVisible = firstRunStatus === "ready"
     && desktopMode === "dev"
     && visibleWindowCount === 0;

--- a/shell/src/components/Desktop.tsx
+++ b/shell/src/components/Desktop.tsx
@@ -52,9 +52,9 @@ import { getGatewayUrl } from "@/lib/gateway";
 import { isPreVpsBillingSetupRoute } from "@/lib/pre-vps-shell";
 import { ChatApp } from "./ChatApp";
 import { ChatPopover } from "./ChatPopover";
-import { OnboardingScreen } from "./OnboardingScreen";
 import { ManualSetupStickers } from "./onboarding/ManualSetupStickers";
 import { RuntimeIdentityBanner } from "./RuntimeIdentityBanner";
+import { DeveloperModeDashboard } from "./developer/DeveloperModeDashboard";
 import { versionedIconUrl } from "@/lib/icon-url";
 import { nameToSlug } from "@/lib/utils";
 import { iconUrlForSlug } from "@/lib/app-launch";
@@ -558,7 +558,7 @@ interface DesktopProps {
   chat?: import("@/hooks/useChatState").ChatState;
 }
 
-// react-doctor-disable-next-line react-doctor/no-giant-component, react-doctor/prefer-useReducer -- no-giant-component: cohesive root shell component; extraction tracked separately. prefer-useReducer: the 9 useState values here (interacting, settingsOpen, chatOpen, minimizingIds, firstRunStatus, showOnboarding, manualSetupVisible, vocalMounted, plus mode flags) are independent shell concerns, not one related state machine; collapsing them into a reducer would couple unrelated transitions and obscure behavior in the core shell component
+// react-doctor-disable-next-line react-doctor/no-giant-component, react-doctor/prefer-useReducer -- no-giant-component: cohesive root shell component; extraction tracked separately. prefer-useReducer: the state values here (interacting, settingsOpen, chatOpen, minimizingIds, firstRunStatus, manualSetupVisible, vocalMounted, plus mode flags) are independent shell concerns, not one related state machine; collapsing them into a reducer would couple unrelated transitions and obscure behavior in the core shell component
 export function Desktop({ launchAppPath, onOpenCommandPalette, chat }: DesktopProps) {
   const windows = useWindowManager((s) => s.windows);
   const apps = useWindowManager((s) => s.apps);
@@ -588,7 +588,6 @@ export function Desktop({ launchAppPath, onOpenCommandPalette, chat }: DesktopPr
   const [chatOpen, setChatOpen] = useState(false);
   const [minimizingIds, setMinimizingIds] = useState<Set<string>>(new Set());
   const [firstRunStatus, setFirstRunStatus] = useState<"checking" | "ready">("checking");
-  const [showOnboarding, setShowOnboarding] = useState(true);
   const launchPathConsumedRef = useRef<string | null>(null);
   const [manualSetupVisible, setManualSetupVisible] = useState(false);
 
@@ -626,14 +625,8 @@ export function Desktop({ launchAppPath, onOpenCommandPalette, chat }: DesktopPr
       cache: "no-store",
       signal: controller.signal,
     })
-      .then(async (res) => {
+      .then((res) => {
         if (!res.ok) throw new Error("onboarding status unavailable");
-        return await res.json() as { complete?: unknown };
-      })
-      .then((status) => {
-        if (!cancelled) {
-          setShowOnboarding(status.complete !== true);
-        }
       })
       .catch((err: unknown) => {
         if (!controller.signal.aborted) {
@@ -653,9 +646,7 @@ export function Desktop({ launchAppPath, onOpenCommandPalette, chat }: DesktopPr
     };
   }, []);
 
-  const onboardingActive = firstRunStatus === "ready" && showOnboarding;
   const completeOnboarding = () => {
-    setShowOnboarding(false);
     void markOnboardingComplete().catch((err: unknown) => {
       console.warn("[desktop] onboarding completion persist failed:", err instanceof Error ? err.message : String(err));
     });
@@ -1190,28 +1181,12 @@ export function Desktop({ launchAppPath, onOpenCommandPalette, chat }: DesktopPr
   const visibleModes = useDesktopMode((s) => s.visibleModes);
   const getModeConfig = useDesktopMode((s) => s.getModeConfig);
   const hydrated = useDesktopMode((s) => s._hydrated);
-  const modeConfig = getModeConfig(hydrated ? desktopMode : "canvas");
+  const modeConfig = getModeConfig(hydrated ? desktopMode : "dev");
+  const visibleWindowCount = windows.filter((w) => !w.minimized).length;
+  const developerDashboardVisible = firstRunStatus === "ready"
+    && desktopMode === "dev"
+    && visibleWindowCount === 0;
   const openPrCanvas = useWorkspaceCanvasStore((s) => s.openPrCanvas);
-
-  const openManualSetup = () => {
-    setShowOnboarding(false);
-    setManualSetupVisible(true);
-    setDesktopMode("canvas");
-    setTaskBoardOpen(false);
-    setSettingsOpen(false);
-    setChatOpen(false);
-    void markOnboardingComplete().catch((err: unknown) => {
-      console.warn("[desktop] onboarding completion persist failed:", err instanceof Error ? err.message : String(err));
-    });
-    void saveDesktopConfigPatch({
-      background: { type: "wallpaper", name: "moraine-lake.jpg" },
-      dock,
-      pinnedApps: pinnedApps.length > 0 ? pinnedApps : [...DEFAULT_PINNED_APPS],
-      dockOrder,
-    }).catch((err: unknown) => {
-      console.warn("[desktop] initial desktop config persist failed:", err instanceof Error ? err.message : String(err));
-    });
-  };
 
   // Cascade windows back to the viewport when leaving canvas. Canvas
   // positions use a wide grid that extends off-screen in other modes.
@@ -1494,25 +1469,17 @@ export function Desktop({ launchAppPath, onOpenCommandPalette, chat }: DesktopPr
   return (
     <TooltipProvider delayDuration={300}>
       <RuntimeIdentityBanner />
-      {onboardingActive ? (
-        <OnboardingScreen
-          onComplete={completeOnboarding}
-          onOpenManualSetup={openManualSetup}
-        />
-      ) : null}
-      {onboardingActive ? null : (
-        <MenuBar onOpenCommandPalette={onOpenCommandPalette ?? (() => {})} onNewWindow={() => openWindow("Terminal", "__terminal__")} onMinimizeWindow={animateMinimize}>
-          {desktopMode === "canvas" ? (
-            <CanvasToolbar
-              guideVisible={manualSetupVisible}
-              onOpenGuide={() => setManualSetupVisible(true)}
-            />
-          ) : null}
-        </MenuBar>
-      )}
+      <MenuBar onOpenCommandPalette={onOpenCommandPalette ?? (() => {})} onNewWindow={() => openWindow("Terminal", "__terminal__")} onMinimizeWindow={animateMinimize}>
+        {desktopMode === "canvas" ? (
+          <CanvasToolbar
+            guideVisible={manualSetupVisible}
+            onOpenGuide={() => setManualSetupVisible(true)}
+          />
+        ) : null}
+      </MenuBar>
       <div className="relative flex-1 flex flex-col md:flex-row md:pt-7">
-        {/* Desktop dock -- hidden in ambient/conversational modes and during onboarding. */}
-        {modeConfig.showDock && !onboardingActive && <div
+        {/* Desktop dock -- hidden in ambient/conversational modes. */}
+        {modeConfig.showDock && <div
           className={[
             "hidden md:block fixed z-[55]",
             dock.position === "left" && "left-0 top-0 h-full",
@@ -1804,7 +1771,7 @@ export function Desktop({ launchAppPath, onOpenCommandPalette, chat }: DesktopPr
         </div>}
 
         {/* Mobile dock (bottom tab bar) */}
-        {modeConfig.showDock && !onboardingActive && (
+        {modeConfig.showDock && (
           <nav className="flex md:hidden items-center gap-1 px-2 py-1.5 border-t border-border/40 bg-card/80 backdrop-blur-sm order-last overflow-x-auto z-[55]">
             <button
               type="button"
@@ -1917,7 +1884,24 @@ export function Desktop({ launchAppPath, onOpenCommandPalette, chat }: DesktopPr
             </div>
           )}
 
-          {!onboardingActive && modeConfig.showWindows && desktopMode === "canvas" && (
+          {developerDashboardVisible && (
+            <DeveloperModeDashboard
+              onOpenTerminal={() => {
+                completeOnboarding();
+                focusOrOpen("Terminal", "__terminal__");
+              }}
+              onOpenSymphony={() => {
+                completeOnboarding();
+                focusOrOpen("Symphony", "apps/symphony/index.html");
+              }}
+              onSwitchCanvas={() => {
+                setDesktopMode("canvas");
+                setManualSetupVisible(true);
+              }}
+            />
+          )}
+
+          {modeConfig.showWindows && desktopMode === "canvas" && (
             <CanvasRenderer>
               {manualSetupVisible && (
                 <ManualSetupStickers
@@ -1933,7 +1917,7 @@ export function Desktop({ launchAppPath, onOpenCommandPalette, chat }: DesktopPr
             </CanvasRenderer>
           )}
 
-          {!onboardingActive && vocalMounted && (
+          {vocalMounted && (
             <VocalPanel
               active={vocalActive}
               chat={chat}

--- a/shell/src/components/developer/DeveloperModeDashboard.tsx
+++ b/shell/src/components/developer/DeveloperModeDashboard.tsx
@@ -34,9 +34,13 @@ export function DeveloperModeDashboard({
   const [copied, setCopied] = useState(false);
 
   const copyPrompt = async () => {
-    await navigator.clipboard.writeText(setupPrompt);
-    setCopied(true);
-    window.setTimeout(() => setCopied(false), 1600);
+    try {
+      await navigator.clipboard.writeText(setupPrompt);
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 1600);
+    } catch (err: unknown) {
+      console.warn("[DeveloperModeDashboard] clipboard write failed:", err instanceof Error ? err.message : String(err));
+    }
   };
 
   return (

--- a/shell/src/components/developer/DeveloperModeDashboard.tsx
+++ b/shell/src/components/developer/DeveloperModeDashboard.tsx
@@ -1,0 +1,140 @@
+"use client";
+
+import { useState } from "react";
+import { CheckCircle2Icon, ClipboardIcon, GitBranchIcon, SparklesIcon, TerminalIcon } from "lucide-react";
+
+export const DEVELOPER_SETUP_PROMPT = `Set up Matrix OS as my remote developer computer.
+
+Install or verify the Matrix CLI, run matrix login, and wait for the browser/device approval to finish. When my Matrix computer is ready, open a persistent setup terminal with matrix run -it --session setup -- gh auth login. Authenticate GitHub in the browser, create or use a Matrix-managed SSH key inside Matrix, clone my repository, and start my preferred coding agent inside Matrix.
+
+Do not upload local private keys, scan my laptop for secrets, or paste credentials into Matrix. Ask me before checkout, browser approvals, SSH key unlocks, or coding-agent authorization.`;
+
+interface DeveloperModeDashboardProps {
+  setupPrompt?: string;
+  onOpenTerminal: () => void;
+  onOpenSymphony: () => void;
+  onSwitchCanvas: () => void;
+}
+
+const SETUP_STEPS = [
+  "Account and plan approved",
+  "Matrix computer ready",
+  "GitHub browser login",
+  "Matrix-managed SSH key",
+  "Repository cloned",
+  "Coding agent running",
+] as const;
+
+export function DeveloperModeDashboard({
+  setupPrompt = DEVELOPER_SETUP_PROMPT,
+  onOpenTerminal,
+  onOpenSymphony,
+  onSwitchCanvas,
+}: DeveloperModeDashboardProps) {
+  const [copied, setCopied] = useState(false);
+
+  const copyPrompt = async () => {
+    await navigator.clipboard.writeText(setupPrompt);
+    setCopied(true);
+    window.setTimeout(() => setCopied(false), 1600);
+  };
+
+  return (
+    <section className="absolute inset-0 z-10 overflow-auto bg-[#080a0f] text-white">
+      <div className="mx-auto grid min-h-full max-w-7xl gap-6 px-5 py-6 lg:grid-cols-[320px_minmax(0,1fr)] lg:px-8">
+        <aside className="rounded-3xl border border-white/10 bg-white/[0.04] p-5 shadow-2xl shadow-black/30">
+          <p className="mb-2 text-xs font-medium uppercase tracking-[0.28em] text-amber-200/70">Developer Fast Path</p>
+          <h1 className="text-3xl font-semibold tracking-tight">Developer mode</h1>
+          <p className="mt-3 text-sm leading-6 text-white/64">
+            Terminal is the primary surface. Symphony is next after your runtime, repo, and coding agent are ready.
+          </p>
+          <ol className="mt-6 grid gap-3 text-sm">
+            {SETUP_STEPS.map((step, index) => (
+              <li key={step} className="flex items-center gap-3 rounded-2xl border border-white/8 bg-black/20 px-3 py-2.5 text-white/78">
+                <span className="grid size-7 place-items-center rounded-full bg-amber-300/12 text-xs font-semibold text-amber-100">
+                  {index + 1}
+                </span>
+                <span>{step}</span>
+              </li>
+            ))}
+          </ol>
+        </aside>
+
+        <main className="grid content-start gap-5">
+          <div className="rounded-[2rem] border border-amber-200/20 bg-[radial-gradient(circle_at_top_left,rgba(250,204,21,0.18),transparent_34%),linear-gradient(135deg,rgba(255,255,255,0.1),rgba(255,255,255,0.03))] p-5 shadow-2xl shadow-black/30 md:p-7">
+            <div className="flex flex-col gap-5 lg:flex-row lg:items-start lg:justify-between">
+              <div className="max-w-2xl">
+                <p className="text-sm font-medium text-amber-100/80">Start here</p>
+                <h2 className="mt-2 text-3xl font-semibold tracking-tight md:text-5xl">Get to a remote coding session.</h2>
+                <p className="mt-4 max-w-xl text-base leading-7 text-white/68">
+                  Copy the setup prompt into your local agent, or open Terminal and run the GitHub auth step directly inside Matrix.
+                </p>
+              </div>
+              <div className="grid gap-2 sm:grid-cols-2 lg:min-w-[320px] lg:grid-cols-1">
+                <button
+                  type="button"
+                  onClick={onOpenTerminal}
+                  className="inline-flex items-center justify-center gap-2 rounded-2xl bg-amber-200 px-4 py-3 text-sm font-semibold text-black transition hover:bg-amber-100"
+                >
+                  <TerminalIcon className="size-4" aria-hidden="true" />
+                  Open Terminal
+                </button>
+                <button
+                  type="button"
+                  onClick={onOpenSymphony}
+                  className="inline-flex items-center justify-center gap-2 rounded-2xl border border-white/12 bg-white/8 px-4 py-3 text-sm font-semibold text-white transition hover:bg-white/12"
+                >
+                  <SparklesIcon className="size-4" aria-hidden="true" />
+                  Open Symphony
+                </button>
+              </div>
+            </div>
+          </div>
+
+          <div className="grid gap-5 xl:grid-cols-[minmax(0,1fr)_320px]">
+            <article className="rounded-[2rem] border border-white/10 bg-white/[0.04] p-5">
+              <div className="mb-3 flex items-center justify-between gap-3">
+                <div>
+                  <p className="text-xs font-medium uppercase tracking-[0.2em] text-white/40">Agent setup prompt</p>
+                  <h3 className="mt-1 text-xl font-semibold">Bring your own coding agent</h3>
+                </div>
+                <button
+                  type="button"
+                  onClick={() => void copyPrompt()}
+                  className="inline-flex shrink-0 items-center gap-2 rounded-full border border-white/12 px-3 py-2 text-xs font-medium text-white/72 transition hover:bg-white/10 hover:text-white"
+                >
+                  <ClipboardIcon className="size-3.5" aria-hidden="true" />
+                  {copied ? "Copied" : "Copy"}
+                </button>
+              </div>
+              <textarea
+                readOnly
+                value={setupPrompt}
+                className="min-h-56 w-full resize-none rounded-2xl border border-white/10 bg-black/38 p-4 font-mono text-sm leading-6 text-emerald-50/88 outline-none"
+                aria-label="Developer setup prompt"
+              />
+            </article>
+
+            <aside className="grid content-start gap-3 rounded-[2rem] border border-white/10 bg-white/[0.04] p-5">
+              <div className="flex items-start gap-3 rounded-2xl bg-emerald-300/10 p-3 text-sm leading-6 text-emerald-50/82">
+                <CheckCircle2Icon className="mt-1 size-4 shrink-0 text-emerald-200" aria-hidden="true" />
+                <p>Use a Matrix-managed SSH key. Do not upload local private keys.</p>
+              </div>
+              <div className="flex items-start gap-3 rounded-2xl bg-sky-300/10 p-3 text-sm leading-6 text-sky-50/82">
+                <GitBranchIcon className="mt-1 size-4 shrink-0 text-sky-200" aria-hidden="true" />
+                <p>GitHub and coding-agent auth happen through browser approvals owned by you.</p>
+              </div>
+              <button
+                type="button"
+                onClick={onSwitchCanvas}
+                className="mt-2 rounded-2xl border border-white/12 px-4 py-3 text-sm font-semibold text-white/72 transition hover:bg-white/10 hover:text-white"
+              >
+                Switch to Canvas
+              </button>
+            </aside>
+          </div>
+        </main>
+      </div>
+    </section>
+  );
+}

--- a/shell/src/lib/desktop-first-run.ts
+++ b/shell/src/lib/desktop-first-run.ts
@@ -1,0 +1,12 @@
+export type DesktopFirstRunStatus = "checking" | "first-run" | "ready";
+
+export function parseDesktopFirstRunStatus(value: unknown): DesktopFirstRunStatus {
+  if (!value || typeof value !== "object") throw new Error("invalid onboarding status");
+  const complete = (value as { complete?: unknown }).complete;
+  if (typeof complete !== "boolean") throw new Error("invalid onboarding status");
+  return complete ? "ready" : "first-run";
+}
+
+export function shouldApplyInitialDesktopDefaults(status: DesktopFirstRunStatus): boolean {
+  return status === "first-run";
+}

--- a/shell/src/lib/desktop-first-run.ts
+++ b/shell/src/lib/desktop-first-run.ts
@@ -10,3 +10,11 @@ export function parseDesktopFirstRunStatus(value: unknown): DesktopFirstRunStatu
 export function shouldApplyInitialDesktopDefaults(status: DesktopFirstRunStatus): boolean {
   return status === "first-run";
 }
+
+export function shouldShowDeveloperDashboard(
+  status: DesktopFirstRunStatus,
+  desktopMode: string,
+  visibleWindowCount: number,
+): boolean {
+  return status !== "checking" && desktopMode === "dev" && visibleWindowCount === 0;
+}

--- a/shell/src/stores/desktop-mode.ts
+++ b/shell/src/stores/desktop-mode.ts
@@ -49,18 +49,17 @@ const MODE_CONFIGS: Record<DesktopMode, ModeConfig> = {
   },
   dev: {
     id: "dev",
-    label: "Dev",
-    description: "Developer mode with prominent terminal and sidebar chat",
+    label: "Developer",
+    description: "Terminal-first setup with Symphony and Canvas one click away",
     showDock: true,
     showWindows: true,
     showBottomPanel: true,
     chatPosition: "sidebar",
     terminalProminent: true,
-    hidden: true,
   },
 };
 
-const DEFAULT_MODE: DesktopMode = "canvas";
+const DEFAULT_MODE: DesktopMode = "dev";
 
 interface DesktopModeStore {
   mode: DesktopMode;
@@ -81,12 +80,12 @@ export const useDesktopMode = create<DesktopModeStore>()(
       setMode: (mode: DesktopMode) => set({ previousMode: get().mode, mode }),
       getModeConfig: (mode: DesktopMode) => MODE_CONFIGS[mode],
       allModes: () => Object.values(MODE_CONFIGS),
-      visibleModes: () => Object.values(MODE_CONFIGS).filter((m) => !m.hidden),
+      visibleModes: () => [MODE_CONFIGS.dev, MODE_CONFIGS.canvas],
     }),
     {
       name: "matrix-os-desktop-mode",
       onRehydrateStorage: () => (state) => {
-        // Coerce any persisted hidden mode (desktop/ambient/dev) or the
+        // Coerce any persisted hidden mode (desktop/ambient) or the
         // now-removed "vocal" mode into canvas. Aoede is an overlay now
         // (see `stores/vocal.ts`), not a mode.
         const config = state ? MODE_CONFIGS[state.mode] : undefined;

--- a/tests/shell/desktop-first-run.test.ts
+++ b/tests/shell/desktop-first-run.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  parseDesktopFirstRunStatus,
+  shouldApplyInitialDesktopDefaults,
+} from "../../shell/src/lib/desktop-first-run.js";
+
+describe("desktop first-run helpers", () => {
+  it("applies initial defaults only when onboarding is incomplete", () => {
+    expect(shouldApplyInitialDesktopDefaults(parseDesktopFirstRunStatus({ complete: false }))).toBe(true);
+    expect(shouldApplyInitialDesktopDefaults(parseDesktopFirstRunStatus({ complete: true }))).toBe(false);
+    expect(shouldApplyInitialDesktopDefaults("ready")).toBe(false);
+  });
+
+  it("rejects malformed onboarding status payloads", () => {
+    expect(() => parseDesktopFirstRunStatus({})).toThrow("invalid onboarding status");
+    expect(() => parseDesktopFirstRunStatus(null)).toThrow("invalid onboarding status");
+  });
+});

--- a/tests/shell/desktop-first-run.test.ts
+++ b/tests/shell/desktop-first-run.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   parseDesktopFirstRunStatus,
+  shouldShowDeveloperDashboard,
   shouldApplyInitialDesktopDefaults,
 } from "../../shell/src/lib/desktop-first-run.js";
 
@@ -15,5 +16,13 @@ describe("desktop first-run helpers", () => {
   it("rejects malformed onboarding status payloads", () => {
     expect(() => parseDesktopFirstRunStatus({})).toThrow("invalid onboarding status");
     expect(() => parseDesktopFirstRunStatus(null)).toThrow("invalid onboarding status");
+  });
+
+  it("shows the developer dashboard for first-run users after status resolves", () => {
+    expect(shouldShowDeveloperDashboard("first-run", "dev", 0)).toBe(true);
+    expect(shouldShowDeveloperDashboard("ready", "dev", 0)).toBe(true);
+    expect(shouldShowDeveloperDashboard("checking", "dev", 0)).toBe(false);
+    expect(shouldShowDeveloperDashboard("first-run", "canvas", 0)).toBe(false);
+    expect(shouldShowDeveloperDashboard("first-run", "dev", 1)).toBe(false);
   });
 });

--- a/tests/shell/desktop-modes.test.ts
+++ b/tests/shell/desktop-modes.test.ts
@@ -4,11 +4,11 @@ import { useDesktopMode, type DesktopMode } from "../../shell/src/stores/desktop
 
 describe("Desktop Mode Store", () => {
   beforeEach(() => {
-    useDesktopMode.setState({ mode: "canvas", previousMode: null });
+    useDesktopMode.setState({ mode: "dev", previousMode: null });
   });
 
-  it("defaults to 'canvas' mode", () => {
-    expect(useDesktopMode.getState().mode).toBe("canvas");
+  it("defaults to developer mode for the developer MVP", () => {
+    expect(useDesktopMode.getState().mode).toBe("dev");
   });
 
   it("setMode changes the active mode", () => {
@@ -44,12 +44,13 @@ describe("Desktop Mode Store", () => {
 
   it("getModeConfig returns correct config for dev mode", () => {
     const config = useDesktopMode.getState().getModeConfig("dev");
-    expect(config.label).toBe("Dev");
+    expect(config.label).toBe("Developer");
     expect(config.showDock).toBe(true);
     expect(config.showWindows).toBe(true);
     expect(config.showBottomPanel).toBe(true);
     expect(config.chatPosition).toBe("sidebar");
     expect(config.terminalProminent).toBe(true);
+    expect(config.hidden).toBeUndefined();
   });
 
   it("getModeConfig returns correct config for canvas mode", () => {
@@ -67,15 +68,15 @@ describe("Desktop Mode Store", () => {
     expect(modes.map((m) => m.id)).toEqual(["canvas", "desktop", "ambient", "dev"]);
   });
 
-  it("visibleModes only returns canvas", () => {
+  it("visibleModes exposes Developer beside Canvas", () => {
     const modes = useDesktopMode.getState().visibleModes();
-    expect(modes.map((m) => m.id)).toEqual(["canvas"]);
+    expect(modes.map((m) => m.id)).toEqual(["dev", "canvas"]);
   });
 
   it("setMode tracks previousMode", () => {
     expect(useDesktopMode.getState().previousMode).toBeNull();
     useDesktopMode.getState().setMode("desktop");
-    expect(useDesktopMode.getState().previousMode).toBe("canvas");
+    expect(useDesktopMode.getState().previousMode).toBe("dev");
     expect(useDesktopMode.getState().mode).toBe("desktop");
     useDesktopMode.getState().setMode("ambient");
     expect(useDesktopMode.getState().previousMode).toBe("desktop");

--- a/tests/shell/developer-mode-dashboard.test.tsx
+++ b/tests/shell/developer-mode-dashboard.test.tsx
@@ -1,12 +1,16 @@
 // @vitest-environment jsdom
 
 import React from "react";
-import { fireEvent, render, screen } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { DeveloperModeDashboard } from "../../shell/src/components/developer/DeveloperModeDashboard.js";
 
 describe("DeveloperModeDashboard", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   it("presents Terminal first, Symphony second, setup status, and Canvas as an explicit switch", () => {
     const onOpenTerminal = vi.fn();
     const onOpenSymphony = vi.fn();
@@ -35,5 +39,29 @@ describe("DeveloperModeDashboard", () => {
     expect(onOpenTerminal).toHaveBeenCalledTimes(1);
     expect(onOpenSymphony).toHaveBeenCalledTimes(1);
     expect(onSwitchCanvas).toHaveBeenCalledTimes(1);
+  });
+
+  it("logs clipboard failures instead of silently swallowing them", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    Object.assign(navigator, {
+      clipboard: {
+        writeText: vi.fn().mockRejectedValue(new Error("permission denied")),
+      },
+    });
+
+    render(
+      <DeveloperModeDashboard
+        setupPrompt="matrix login"
+        onOpenTerminal={vi.fn()}
+        onOpenSymphony={vi.fn()}
+        onSwitchCanvas={vi.fn()}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /copy/i }));
+
+    await waitFor(() => {
+      expect(warn).toHaveBeenCalledWith("[DeveloperModeDashboard] clipboard write failed:", "permission denied");
+    });
   });
 });

--- a/tests/shell/developer-mode-dashboard.test.tsx
+++ b/tests/shell/developer-mode-dashboard.test.tsx
@@ -1,0 +1,39 @@
+// @vitest-environment jsdom
+
+import React from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { DeveloperModeDashboard } from "../../shell/src/components/developer/DeveloperModeDashboard.js";
+
+describe("DeveloperModeDashboard", () => {
+  it("presents Terminal first, Symphony second, setup status, and Canvas as an explicit switch", () => {
+    const onOpenTerminal = vi.fn();
+    const onOpenSymphony = vi.fn();
+    const onSwitchCanvas = vi.fn();
+
+    render(
+      <DeveloperModeDashboard
+        setupPrompt="Install Matrix CLI, run matrix login, then matrix run -it --session setup -- gh auth login."
+        onOpenTerminal={onOpenTerminal}
+        onOpenSymphony={onOpenSymphony}
+        onSwitchCanvas={onSwitchCanvas}
+      />,
+    );
+
+    expect(screen.getByRole("heading", { name: /developer mode/i })).toBeTruthy();
+    expect(screen.getByText(/Terminal is the primary surface/i)).toBeTruthy();
+    expect(screen.getByText(/Symphony is next/i)).toBeTruthy();
+    expect(screen.getAllByText(/Matrix-managed SSH key/i).length).toBeGreaterThan(0);
+    expect(screen.getByText(/Do not upload local private keys/i)).toBeTruthy();
+    expect(screen.getByDisplayValue(/matrix run -it --session setup -- gh auth login/i)).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("button", { name: /open terminal/i }));
+    fireEvent.click(screen.getByRole("button", { name: /open symphony/i }));
+    fireEvent.click(screen.getByRole("button", { name: /switch to canvas/i }));
+
+    expect(onOpenTerminal).toHaveBeenCalledTimes(1);
+    expect(onOpenSymphony).toHaveBeenCalledTimes(1);
+    expect(onSwitchCanvas).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary
- Makes Developer mode the default and exposes it beside Canvas in the mode switcher.
- Replaces the legacy first-run cinematic overlay with a conventional Developer mode dashboard focused on Terminal first and Symphony second.
- Adds a copyable agent setup prompt, setup checklist, Matrix-managed SSH/private-key safety copy, and explicit Canvas switch action.

## Verification
- `bun run test tests/shell/desktop-modes.test.ts tests/shell/developer-mode-dashboard.test.tsx`
- `bun run typecheck`
- `bun run check:patterns:diff` passed with 0 violations; warning is a false-positive string `join` in the prior onboarding file.
- `bun run check:patterns` passed with 0 violations and existing repository warnings.
- `npx react-doctor@latest --scope changed --base main shell` passed at 100/100.
- `bun run test -- --reporter=dot` was attempted with a 15-minute timeout; the suite was still emitting passing tests when the tool killed it, so it did not produce a final summary.

## Screenshot Evidence
- Developer dashboard screenshot captured locally: `/tmp/matrix-097-developer-mode.png`

## Invariants
- Source of truth: the shell `desktop-mode` store controls the default mode and visible mode list; the dashboard is a renderer-only entry point for the existing Terminal and Symphony surfaces.
- Lock/transaction scope: no new backend writes, locks, or transactions are introduced. The dashboard only uses the existing onboarding-complete marker when users open Terminal or Symphony.
- Acceptable orphan states: if marking onboarding complete fails, the shell logs the existing generic warning and still opens the requested local surface; no user data or credentials are written by this PR.
- Auth source of truth: Terminal, Symphony, GitHub, and coding-agent auth remain owned by their existing surfaces and browser/device approval flows. The dashboard explicitly warns against uploading local private keys.
- Deferred scope: actual SSH vault/unlock implementation, Workspace removal/migration, consumer launcher pruning, and warm computer pool behavior are deferred to later 097 stack layers.