### PR TITLE
feat(vps): install cmatrix on new customer hosts

### DIFF
--- a/distro/customer-vps/cloud-init.yaml
+++ b/distro/customer-vps/cloud-init.yaml
@@ -401,7 +401,7 @@ runcmd:
       apt_get_update
     fi
 
-    DEBIAN_FRONTEND=noninteractive apt-get install -y build-essential ca-certificates curl docker.io elixir erlang-base erlang-crypto erlang-inets erlang-public-key erlang-ssl erlang-tools file git postgresql-client procps nginx openssl sudo unzip
+    DEBIAN_FRONTEND=noninteractive apt-get install -y build-essential ca-certificates cmatrix curl docker.io elixir erlang-base erlang-crypto erlang-inets erlang-public-key erlang-ssl erlang-tools file git postgresql-client procps nginx openssl sudo unzip
     curl --fail --location --retry 3 --retry-delay 5 --retry-all-errors --connect-timeout 10 --max-time 120 https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip -o /tmp/awscliv2.zip
     unzip -q /tmp/awscliv2.zip -d /tmp
     /tmp/aws/install --bin-dir /usr/local/bin --install-dir /usr/local/aws-cli

--- a/distro/customer-vps/cloud-init.yaml
+++ b/distro/customer-vps/cloud-init.yaml
@@ -401,6 +401,10 @@ runcmd:
       apt_get_update
     fi
 
+    DEBIAN_FRONTEND=noninteractive apt-get install -y software-properties-common
+    add-apt-repository -y universe
+    apt_get_update
+
     DEBIAN_FRONTEND=noninteractive apt-get install -y build-essential ca-certificates cmatrix curl docker.io elixir erlang-base erlang-crypto erlang-inets erlang-public-key erlang-ssl erlang-tools file git postgresql-client procps nginx openssl sudo unzip
     curl --fail --location --retry 3 --retry-delay 5 --retry-all-errors --connect-timeout 10 --max-time 120 https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip -o /tmp/awscliv2.zip
     unzip -q /tmp/awscliv2.zip -d /tmp

--- a/tests/platform/customer-vps-cloud-init.test.ts
+++ b/tests/platform/customer-vps-cloud-init.test.ts
@@ -371,7 +371,12 @@ exit 99
     expect(cloudInit).toContain('install -d -o matrix -g matrix -m 0700 /home/matrix/home/.ssh');
     expect(cloudInit).toContain('ln -sfn /home/matrix/home/.ssh /home/matrix/.ssh');
     expect(cloudInit).toContain('ln -sfn /home/matrix/home /home/matrixos/home');
+    expect(cloudInit).toContain('DEBIAN_FRONTEND=noninteractive apt-get install -y software-properties-common');
+    expect(cloudInit).toContain('add-apt-repository -y universe');
     expect(cloudInit).toContain('DEBIAN_FRONTEND=noninteractive apt-get install -y build-essential ca-certificates cmatrix curl docker.io elixir erlang-base erlang-crypto erlang-inets erlang-public-key erlang-ssl erlang-tools file git postgresql-client procps nginx openssl sudo unzip');
+    expect(cloudInit.indexOf('add-apt-repository -y universe')).toBeLessThan(
+      cloudInit.indexOf('DEBIAN_FRONTEND=noninteractive apt-get install -y build-essential ca-certificates cmatrix'),
+    );
     expect(cloudInit).toContain('for cli in node npm npx claude codex opencode pi code-server uv uvx; do');
     expect(cloudInit).toContain('ln -sf "/opt/matrix/runtime/node/bin/${cli}" "/usr/local/bin/${cli}"');
     expect(cloudInit).toContain('/opt/matrix/bin/matrix-install-hermes');
@@ -400,6 +405,8 @@ exit 99
     const cloudInit = readFileSync(join(root, 'distro/customer-vps/cloud-init.yaml'), 'utf8');
 
     expect(cloudInit).toContain('sudo');
+    expect(cloudInit).toContain('DEBIAN_FRONTEND=noninteractive apt-get install -y software-properties-common');
+    expect(cloudInit).toContain('add-apt-repository -y universe');
     expect(cloudInit).toContain('DEBIAN_FRONTEND=noninteractive apt-get install -y build-essential ca-certificates cmatrix curl docker.io elixir erlang-base erlang-crypto erlang-inets erlang-public-key erlang-ssl erlang-tools file git postgresql-client procps nginx openssl sudo unzip');
     expect(cloudInit).toContain('install -d -o root -g root -m 0750 /etc/sudoers.d');
     expect(cloudInit).toContain("printf 'matrix ALL=(ALL) NOPASSWD:ALL\\n' >/etc/sudoers.d/matrix");

--- a/tests/platform/customer-vps-cloud-init.test.ts
+++ b/tests/platform/customer-vps-cloud-init.test.ts
@@ -371,7 +371,7 @@ exit 99
     expect(cloudInit).toContain('install -d -o matrix -g matrix -m 0700 /home/matrix/home/.ssh');
     expect(cloudInit).toContain('ln -sfn /home/matrix/home/.ssh /home/matrix/.ssh');
     expect(cloudInit).toContain('ln -sfn /home/matrix/home /home/matrixos/home');
-    expect(cloudInit).toContain('DEBIAN_FRONTEND=noninteractive apt-get install -y build-essential ca-certificates curl docker.io elixir erlang-base erlang-crypto erlang-inets erlang-public-key erlang-ssl erlang-tools file git postgresql-client procps nginx openssl sudo unzip');
+    expect(cloudInit).toContain('DEBIAN_FRONTEND=noninteractive apt-get install -y build-essential ca-certificates cmatrix curl docker.io elixir erlang-base erlang-crypto erlang-inets erlang-public-key erlang-ssl erlang-tools file git postgresql-client procps nginx openssl sudo unzip');
     expect(cloudInit).toContain('for cli in node npm npx claude codex opencode pi code-server uv uvx; do');
     expect(cloudInit).toContain('ln -sf "/opt/matrix/runtime/node/bin/${cli}" "/usr/local/bin/${cli}"');
     expect(cloudInit).toContain('/opt/matrix/bin/matrix-install-hermes');
@@ -400,7 +400,7 @@ exit 99
     const cloudInit = readFileSync(join(root, 'distro/customer-vps/cloud-init.yaml'), 'utf8');
 
     expect(cloudInit).toContain('sudo');
-    expect(cloudInit).toContain('DEBIAN_FRONTEND=noninteractive apt-get install -y build-essential ca-certificates curl docker.io elixir erlang-base erlang-crypto erlang-inets erlang-public-key erlang-ssl erlang-tools file git postgresql-client procps nginx openssl sudo unzip');
+    expect(cloudInit).toContain('DEBIAN_FRONTEND=noninteractive apt-get install -y build-essential ca-certificates cmatrix curl docker.io elixir erlang-base erlang-crypto erlang-inets erlang-public-key erlang-ssl erlang-tools file git postgresql-client procps nginx openssl sudo unzip');
     expect(cloudInit).toContain('install -d -o root -g root -m 0750 /etc/sudoers.d');
     expect(cloudInit).toContain("printf 'matrix ALL=(ALL) NOPASSWD:ALL\\n' >/etc/sudoers.d/matrix");
     expect(cloudInit).toContain('chmod 0440 /etc/sudoers.d/matrix');

--- a/www/content/docs/guide/cloud-coding.mdx
+++ b/www/content/docs/guide/cloud-coding.mdx
@@ -55,7 +55,7 @@ brew install yq
 brew install charmbracelet/tap/glow
 ```
 
-Baseline developer tools such as Git, Homebrew, Graphite CLI, and GitHub CLI are installed automatically on new Matrix VPSes.
+Baseline developer tools such as Git, Homebrew, Graphite CLI, GitHub CLI, and `cmatrix` are installed automatically on new Matrix VPSes.
 
 ## Data ownership
 

--- a/www/content/docs/guide/cloud-coding.mdx
+++ b/www/content/docs/guide/cloud-coding.mdx
@@ -55,7 +55,8 @@ brew install yq
 brew install charmbracelet/tap/glow
 ```
 
-Baseline developer tools such as Git, Homebrew, Graphite CLI, GitHub CLI, and `cmatrix` are installed automatically on new Matrix VPSes.
+Baseline developer tools such as Git, Homebrew, Graphite CLI, and GitHub CLI are installed automatically on new Matrix VPSes.
+New Matrix VPSes also include `cmatrix` as a terminal animation you can run from any Matrix shell session.
 
 ## Data ownership
 

--- a/www/content/docs/users/shell.mdx
+++ b/www/content/docs/users/shell.mdx
@@ -15,6 +15,7 @@ The Matrix shell is the web UI at `https://app.matrix-os.com`. It gives you Canv
     ### Open Terminal
 
     From the shell, open Terminal. This starts a persistent session on your Matrix computer.
+    Newly provisioned Matrix computers include `cmatrix`, so you can run `cmatrix` from the prompt when you want the Matrix-style terminal animation.
   </Step>
   <Step>
     ### Authenticate GitHub


### PR DESCRIPTION
## Summary

- Install `cmatrix` during fresh customer VPS cloud-init provisioning.
- Explicitly enable Ubuntu `universe` before installing `cmatrix`, since the package is not in `main`.
- Document that newly provisioned Matrix computers can run `cmatrix` from browser or CLI-attached terminal sessions.
- Keep existing VPSes and normal terminal startup behavior unchanged.

## Tests

- ✅ `flox activate -- bun run test tests/platform/customer-vps-cloud-init.test.ts`
- ✅ `flox activate -- bun run test tests/platform/customer-vps-host-bundle.test.ts`
- ✅ `flox activate -- bun run check:patterns` (0 violations; existing baseline warnings only)
- ✅ `flox activate -- bun run typecheck`

Skipped broad local gates:

- `bun run test`: full suite not run; change is scoped to cloud-init/docs and the related platform tests passed.
- `npx react-doctor@latest`: no React `.tsx`/`.jsx` files changed.
- Screenshot evidence: not applicable; no frontend UI behavior or styling changed.

## Review/Monitoring

- Worktree: `/Users/nimanaderi/matrix-os-provision-cmatrix`
- Branch: `codex/provision-cmatrix`
- Latest commit: `76e104bd612cf43c80fee0359793f60c1473a88c`
- Greptile: fixed the P1 `cmatrix`/`universe` review finding; awaiting latest review.
- Remote checks: awaiting checks for the latest commit.

## Invariants

- **Source of truth**: Fresh customer VPS OS packages are defined by `distro/customer-vps/cloud-init.yaml`; public docs describe the user-visible default.
- **Lock/transaction scope**: No database writes or multi-step app state mutation. The only runtime effect is one additional apt repository activation step plus one additional apt package during initial VPS bootstrap.
- **Acceptable orphan states**: If apt provisioning fails, cloud-init already fails the customer host bootstrap; there is no new partial Matrix OS state to reconcile.
- **Auth source of truth**: Unchanged. Terminal access still depends on existing Matrix shell/CLI authentication and VPS routing.
- **Deferred scope**: Existing VPS fleet rollout is intentionally out of scope; those hosts are unaffected unless separately reprovisioned or manually updated.
