### PR TITLE
fix(terminal): correct shell session rename

### DIFF
--- a/packages/gateway/src/server.ts
+++ b/packages/gateway/src/server.ts
@@ -514,6 +514,7 @@ export async function createGateway(config: GatewayConfig) {
     adapter: zellijAdapter,
     maxSessions: 10,
     scrollbackStore: shellScrollbackStore,
+    preferencesStore: shellPreferencesStore,
   });
   const symphonyRunner = createSymphonyRunner({ homePath });
   const initialSymphonyPort = await resolveInitialSymphonyPort(symphonyRunner);

--- a/packages/gateway/src/shell/preferences.ts
+++ b/packages/gateway/src/shell/preferences.ts
@@ -1,7 +1,8 @@
-import { readFile } from "node:fs/promises";
-import { join } from "node:path";
+import { link, mkdir, readFile, rm } from "node:fs/promises";
+import { dirname, join } from "node:path";
 import { z } from "zod/v4";
 import { writeUtf8FileAtomic } from "./atomic-write.js";
+import { shellError } from "./errors.js";
 import { validateSessionName } from "./names.js";
 
 const LegacyThemeIdSchema = z.enum([
@@ -91,6 +92,45 @@ export class ShellPreferencesStore {
     const next = ShellPreferencesSchema.parse(input);
     await writeUtf8FileAtomic(this.pathFor(safeName), JSON.stringify(next, null, 2));
     return next;
+  }
+
+  async rename(fromName: string, toName: string): Promise<void> {
+    const safeFromName = validateSessionName(fromName);
+    const safeToName = validateSessionName(toName);
+    const fromPath = this.pathFor(safeFromName);
+    const toPath = this.pathFor(safeToName);
+    await mkdir(dirname(toPath), { recursive: true, mode: 0o700 });
+    try {
+      await link(fromPath, toPath);
+    } catch (err: unknown) {
+      if (
+        err instanceof Error &&
+        "code" in err &&
+        (err as NodeJS.ErrnoException).code === "ENOENT"
+      ) {
+        return;
+      }
+      if (
+        err instanceof Error &&
+        "code" in err &&
+        (err as NodeJS.ErrnoException).code === "EEXIST"
+      ) {
+        throw shellError("session_exists", "Session already exists", 409);
+      }
+      throw err;
+    }
+
+    try {
+      await rm(fromPath);
+    } catch (err: unknown) {
+      await rm(toPath, { force: true }).catch((cleanupErr: unknown) => {
+        console.warn(
+          "[shell] failed to clean copied preferences during rename rollback:",
+          cleanupErr instanceof Error ? cleanupErr.message : String(cleanupErr),
+        );
+      });
+      throw err;
+    }
   }
 
   private pathFor(name: string): string {

--- a/packages/gateway/src/shell/preferences.ts
+++ b/packages/gateway/src/shell/preferences.ts
@@ -61,13 +61,20 @@ export type ShellThemeId = z.infer<typeof ShellThemeIdSchema>;
 export interface ShellPreferencesStoreOptions {
   homePath: string;
   preferencesDir?: string;
+  renameFileOps?: {
+    mkdir: typeof mkdir;
+    link: typeof link;
+    rm: typeof rm;
+  };
 }
 
 export class ShellPreferencesStore {
   private readonly preferencesDir: string;
+  private readonly renameFileOps: NonNullable<ShellPreferencesStoreOptions["renameFileOps"]>;
 
   constructor(options: ShellPreferencesStoreOptions) {
     this.preferencesDir = options.preferencesDir ?? join(options.homePath, "system", "shell-preferences");
+    this.renameFileOps = options.renameFileOps ?? { mkdir, link, rm };
   }
 
   async load(name: string): Promise<ShellPreferences> {
@@ -99,9 +106,9 @@ export class ShellPreferencesStore {
     const safeToName = validateSessionName(toName);
     const fromPath = this.pathFor(safeFromName);
     const toPath = this.pathFor(safeToName);
-    await mkdir(dirname(toPath), { recursive: true, mode: 0o700 });
+    await this.renameFileOps.mkdir(dirname(toPath), { recursive: true, mode: 0o700 });
     try {
-      await link(fromPath, toPath);
+      await this.renameFileOps.link(fromPath, toPath);
     } catch (err: unknown) {
       if (
         err instanceof Error &&
@@ -121,9 +128,16 @@ export class ShellPreferencesStore {
     }
 
     try {
-      await rm(fromPath);
+      await this.renameFileOps.rm(fromPath);
     } catch (err: unknown) {
-      await rm(toPath, { force: true }).catch((cleanupErr: unknown) => {
+      if (
+        err instanceof Error &&
+        "code" in err &&
+        (err as NodeJS.ErrnoException).code === "ENOENT"
+      ) {
+        return;
+      }
+      await this.renameFileOps.rm(toPath, { force: true }).catch((cleanupErr: unknown) => {
         console.warn(
           "[shell] failed to clean copied preferences during rename rollback:",
           cleanupErr instanceof Error ? cleanupErr.message : String(cleanupErr),

--- a/packages/gateway/src/shell/registry.ts
+++ b/packages/gateway/src/shell/registry.ts
@@ -58,12 +58,17 @@ export interface ShellSessionUiStatePatch {
   visualStatus?: ShellVisualStatus;
 }
 
+export interface ShellNameScopedStore {
+  rename(fromName: string, toName: string): Promise<void>;
+}
+
 export interface ShellRegistryOptions {
   homePath: string;
   adapter: ShellRegistryAdapter;
   maxSessions?: number;
   persistPath?: string;
   scrollbackStore?: ScrollbackStore;
+  preferencesStore?: ShellNameScopedStore;
 }
 
 export class ShellRegistry {
@@ -275,9 +280,12 @@ export class ShellRegistry {
 
       await this.options.adapter.renameSession(safeName, safeNextName);
       let scrollbackRenamed = false;
+      let preferencesRenamed = false;
       try {
         await this.options.scrollbackStore?.rename(safeName, safeNextName);
         scrollbackRenamed = true;
+        await this.options.preferencesStore?.rename(safeName, safeNextName);
+        preferencesRenamed = true;
         if (file.order) {
           const nextLive = new Set(live);
           nextLive.delete(safeName);
@@ -296,6 +304,14 @@ export class ShellRegistry {
           await this.options.scrollbackStore?.rename(safeNextName, safeName).catch((rollbackErr: unknown) => {
             console.warn(
               "[shell] failed to rollback renamed scrollback:",
+              rollbackErr instanceof Error ? rollbackErr.message : String(rollbackErr),
+            );
+          });
+        }
+        if (preferencesRenamed) {
+          await this.options.preferencesStore?.rename(safeNextName, safeName).catch((rollbackErr: unknown) => {
+            console.warn(
+              "[shell] failed to rollback renamed preferences:",
               rollbackErr instanceof Error ? rollbackErr.message : String(rollbackErr),
             );
           });

--- a/packages/gateway/src/shell/routes.ts
+++ b/packages/gateway/src/shell/routes.ts
@@ -178,7 +178,7 @@ export function createShellRoutes(deps: ShellRouteDeps): Hono {
     }
   });
 
-  app.patch("/sessions/:name", sessionRenameBodyLimit, async (c) => {
+  const renameSessionHandler = async (c: Context) => {
     try {
       if (!deps.registry.rename) return unavailable(c, "session_rename_unavailable");
       const body = SessionRenameBodySchema.parse(await c.req.json());
@@ -190,7 +190,10 @@ export function createShellRoutes(deps: ShellRouteDeps): Hono {
     } catch (err) {
       return safeError(c, err);
     }
-  });
+  };
+
+  app.put("/sessions/:name/rename", sessionRenameBodyLimit, renameSessionHandler);
+  app.patch("/sessions/:name", sessionRenameBodyLimit, renameSessionHandler);
 
   app.patch("/sessions/:name/ui-state", uiStateBodyLimit, async (c) => {
     try {

--- a/shell/src/components/terminal/TerminalApp.tsx
+++ b/shell/src/components/terminal/TerminalApp.tsx
@@ -776,7 +776,7 @@ export function TerminalApp({ initialCommand, initialLabel, initialClaudeMode = 
 
   const createShellSessionTab = async (label: string, cwd = DEFAULT_CWD) => {
     for (let attempt = 0; attempt < 3; attempt += 1) {
-      const name = `zellij-${genId()}`;
+      const name = `matrix-${genId()}`;
       try {
         // react-doctor-disable-next-line react-doctor/async-await-in-loop -- sequential-by-design retry loop: each attempt only runs if the prior one failed with a 409 name collision or abort; parallelizing would create multiple sessions
         const res = await fetch(`${getGatewayUrl()}/api/terminal/sessions`, {
@@ -1039,16 +1039,20 @@ export function TerminalApp({ initialCommand, initialLabel, initialClaudeMode = 
   };
 
   const renameShellSession = (fromSessionId: string, toSessionId: string) => {
-    setTabs(prev => prev.map((tab) => {
-      const nextTree = renameSessionInTree(tab.paneTree, fromSessionId, toSessionId);
-      const nextLabel =
-        tab.label === fromSessionId || tab.label === formatShellDisplayName(fromSessionId)
-          ? formatShellDisplayName(toSessionId)
-          : tab.label;
-      return nextTree === tab.paneTree && nextLabel === tab.label
-        ? tab
-        : { ...tab, label: nextLabel, paneTree: nextTree };
-    }));
+    setTabs(prev => {
+      const nextTabs = prev.map((tab) => {
+        const nextTree = renameSessionInTree(tab.paneTree, fromSessionId, toSessionId);
+        const nextLabel =
+          tab.label === fromSessionId || tab.label === formatShellDisplayName(fromSessionId)
+            ? formatShellDisplayName(toSessionId)
+            : tab.label;
+        return nextTree === tab.paneTree && nextLabel === tab.label
+          ? tab
+          : { ...tab, label: nextLabel, paneTree: nextTree };
+      });
+      tabsRef.current = nextTabs;
+      return nextTabs;
+    });
   };
 
   const reorderTabs = (from: number, to: number) => {
@@ -2215,7 +2219,7 @@ function LocalTerminalTabBar({ defaultCwd }: { defaultCwd: string }) {
   const getCwd = () => ctx.sidebarSelectedPath ?? defaultCwd;
   const newTabButton = (
     <ToolbarBtn
-      onClick={() => { void ctx.createShellSessionTab("Zellij", getCwd()); }}
+      onClick={() => { void ctx.createShellSessionTab("Shell", getCwd()); }}
       title="New tab (Ctrl+Shift+T)"
       ariaLabel="New tab"
     >
@@ -2362,11 +2366,11 @@ function LocalTerminalTabBar({ defaultCwd }: { defaultCwd: string }) {
               Claude
             </ToolbarBtn>
             <ToolbarBtn
-              onClick={() => { void ctx.createShellSessionTab("Zellij", getCwd()); }}
-              title="Launch Zellij (Ctrl+Shift+Z)"
+              onClick={() => { void ctx.createShellSessionTab("Shell", getCwd()); }}
+              title="Launch Shell (Ctrl+Shift+Z)"
               variant="primary"
             >
-              Zellij
+              Shell
             </ToolbarBtn>
             <div style={{ width: 1, height: 18, background: "var(--border)", margin: "0 4px" }} />
             <ToolbarBtn
@@ -3111,8 +3115,8 @@ function LocalTerminalSidebar() {
     }
     setShellsError(null);
     try {
-      const res = await fetch(`${getGatewayUrl()}/api/terminal/sessions/${encodeURIComponent(shell.name)}`, {
-        method: "PATCH",
+      const res = await fetch(`${getGatewayUrl()}/api/terminal/sessions/${encodeURIComponent(shell.name)}/rename`, {
+        method: "PUT",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ name: nextName }),
         signal: AbortSignal.timeout(10_000),
@@ -5096,7 +5100,7 @@ interface ProjectCardProps {
 function ProjectCard({ project, onOpenShell, onOpenClaude, onOpenZellij, onSelect, isSelected }: ProjectCardProps) {
   const [hover, setHover] = useState(false);
   return (
-    // react-doctor-disable-next-line react-doctor/prefer-tag-over-role -- cannot be a native <button>: this selectable card contains nested interactive <button> children (Shell/Claude/Zellij actions), and nesting a button inside a button is invalid HTML; role="button" + tabIndex + keyboard handler is the correct accessible pattern here.
+    // react-doctor-disable-next-line react-doctor/prefer-tag-over-role -- cannot be a native <button>: this selectable card contains nested interactive <button> children (shell and agent actions), and nesting a button inside a button is invalid HTML; role="button" + tabIndex + keyboard handler is the correct accessible pattern here.
     <div
       role="button"
       tabIndex={0}
@@ -5169,7 +5173,7 @@ function ProjectCard({ project, onOpenShell, onOpenClaude, onOpenZellij, onSelec
       >
         <ProjectActionBtn label="Shell" onClick={(e) => { e.stopPropagation(); onOpenShell(); }} />
         <ProjectActionBtn label="Claude" onClick={(e) => { e.stopPropagation(); onOpenClaude(); }} accent="var(--success)" />
-        <ProjectActionBtn label="Zellij" onClick={(e) => { e.stopPropagation(); onOpenZellij(); }} accent="var(--primary)" />
+        <ProjectActionBtn label="Session" onClick={(e) => { e.stopPropagation(); onOpenZellij(); }} accent="var(--primary)" />
       </div>
     </div>
   );

--- a/tests/gateway/shell-preferences.test.ts
+++ b/tests/gateway/shell-preferences.test.ts
@@ -76,6 +76,29 @@ describe("shell preferences", () => {
     });
   });
 
+  it("keeps the destination preferences when source cleanup already happened", async () => {
+    const root = await tempRoot();
+    const rmMock = vi.fn(async (path: string) => {
+      if (path.endsWith("main.json")) {
+        throw Object.assign(new Error("missing source"), { code: "ENOENT" });
+      }
+    });
+    const store = new ShellPreferencesStore({
+      homePath: root,
+      renameFileOps: {
+        mkdir: vi.fn(async () => undefined) as never,
+        link: vi.fn(async () => undefined),
+        rm: rmMock as never,
+      },
+    });
+
+    await expect(store.rename("main", "review-main")).resolves.toBeUndefined();
+
+    expect(rmMock).toHaveBeenCalledTimes(1);
+    expect(rmMock.mock.calls[0]?.[0]).toContain("main.json");
+    expect(rmMock.mock.calls.some(([path]) => String(path).endsWith("review-main.json"))).toBe(false);
+  });
+
   it("serves GET and PUT preferences routes with validation", async () => {
     const root = await tempRoot();
     const preferences = new ShellPreferencesStore({ homePath: root });

--- a/tests/gateway/shell-preferences.test.ts
+++ b/tests/gateway/shell-preferences.test.ts
@@ -55,6 +55,27 @@ describe("shell preferences", () => {
     });
   });
 
+  it("renames per-session preferences without overwriting another preference file", async () => {
+    const root = await tempRoot();
+    const store = new ShellPreferencesStore({ homePath: root });
+
+    await store.save("main", { shellThemeId: "matrix", fontFamily: "MesloLGS NF" });
+    await store.rename("main", "review-main");
+
+    await expect(store.load("main")).resolves.toMatchObject({ shellThemeId: "dark" });
+    await expect(store.load("review-main")).resolves.toMatchObject({
+      shellThemeId: "matrix",
+      fontFamily: "MesloLGS NF",
+    });
+
+    await store.rename("missing", "new-name");
+    await store.save("occupied", { shellThemeId: "light" });
+    await expect(store.rename("review-main", "occupied")).rejects.toMatchObject({
+      code: "session_exists",
+      status: 409,
+    });
+  });
+
   it("serves GET and PUT preferences routes with validation", async () => {
     const root = await tempRoot();
     const preferences = new ShellPreferencesStore({ homePath: root });

--- a/tests/gateway/shell-registry.test.ts
+++ b/tests/gateway/shell-registry.test.ts
@@ -202,6 +202,8 @@ describe("shell registry", () => {
   });
 
   it("persists active/background placement and derives unread visual status from scrollback", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-06-18T12:00:00.000Z"));
     const root = await tempRoot();
     const adapter = {
       listSessions: vi.fn(async () => ["main", "deploy-logs", "review-done"]),
@@ -222,7 +224,9 @@ describe("shell registry", () => {
     });
 
     await registry.updateUiState("main", { placement: "background", lastSeenSeq: 4 });
+    vi.setSystemTime(new Date("2026-06-18T12:00:01.000Z"));
     await registry.updateUiState("review-done", { lastSeenSeq: 3, visualStatus: "finished" });
+    vi.setSystemTime(new Date("2026-06-18T12:00:02.000Z"));
 
     await expect(registry.list()).resolves.toMatchObject([
       {
@@ -382,11 +386,15 @@ describe("shell registry", () => {
       cleanup: vi.fn(async () => undefined),
       rename: vi.fn(async () => undefined),
     };
+    const preferencesStore = {
+      rename: vi.fn(async () => undefined),
+    };
     const registry = new ShellRegistry({
       homePath: root,
       adapter,
       maxSessions: 4,
       scrollbackStore: scrollbackStore as never,
+      preferencesStore: preferencesStore as never,
     });
 
     await registry.updateUiState("main", {
@@ -407,10 +415,58 @@ describe("shell registry", () => {
 
     expect(adapter.renameSession).toHaveBeenCalledWith("main", "review-main");
     expect(scrollbackStore.rename).toHaveBeenCalledWith("main", "review-main");
+    expect(preferencesStore.rename).toHaveBeenCalledWith("main", "review-main");
     const raw = await readFile(join(root, "system", "shell-sessions.json"), "utf-8");
     const sessions = JSON.parse(raw).sessions;
     expect(sessions.main).toBeUndefined();
     expect(sessions["review-main"].placement).toBe("background");
+  });
+
+  it("rolls back zellij, scrollback, and preferences when renamed metadata cannot persist", async () => {
+    const root = await tempRoot();
+    const systemDir = join(root, "system");
+    const live = new Set(["main"]);
+    const adapter = {
+      listSessions: vi.fn(async () => Array.from(live)),
+      createSession: vi.fn(async () => undefined),
+      deleteSession: vi.fn(async () => undefined),
+      renameSession: vi.fn(async (name: string, nextName: string) => {
+        live.delete(name);
+        live.add(nextName);
+      }),
+    };
+    const scrollbackStore = {
+      latestSeq: vi.fn(async () => null),
+      cleanup: vi.fn(async () => undefined),
+      rename: vi.fn(async () => undefined),
+    };
+    const preferencesStore = {
+      rename: vi.fn(async () => {
+        if (preferencesStore.rename.mock.calls.length === 1) {
+          await rm(systemDir, { recursive: true, force: true });
+          await writeFile(systemDir, "not a directory", { flag: "wx" });
+        }
+      }),
+    };
+    const registry = new ShellRegistry({
+      homePath: root,
+      adapter,
+      maxSessions: 4,
+      scrollbackStore: scrollbackStore as never,
+      preferencesStore: preferencesStore as never,
+    });
+
+    await registry.updateUiState("main", { placement: "background" });
+
+    await expect(registry.rename("main", "review-main")).rejects.toBeInstanceOf(Error);
+
+    expect(adapter.renameSession).toHaveBeenNthCalledWith(1, "main", "review-main");
+    expect(adapter.renameSession).toHaveBeenNthCalledWith(2, "review-main", "main");
+    expect(scrollbackStore.rename).toHaveBeenNthCalledWith(1, "main", "review-main");
+    expect(scrollbackStore.rename).toHaveBeenNthCalledWith(2, "review-main", "main");
+    expect(preferencesStore.rename).toHaveBeenNthCalledWith(1, "main", "review-main");
+    expect(preferencesStore.rename).toHaveBeenNthCalledWith(2, "review-main", "main");
+    expect(Array.from(live)).toEqual(["main"]);
   });
 
   it("connects by adopting an orphan active zellij session", async () => {

--- a/tests/gateway/shell-routes.test.ts
+++ b/tests/gateway/shell-routes.test.ts
@@ -239,8 +239,8 @@ describe("gateway shell routes", () => {
     };
     const app = appWithRegistry(registry);
 
-    const res = await app.request("/api/terminal/sessions/main", {
-      method: "PATCH",
+    const res = await app.request("/api/terminal/sessions/main/rename", {
+      method: "PUT",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ name: "review-main" }),
     });
@@ -265,18 +265,18 @@ describe("gateway shell routes", () => {
     };
     const app = appWithRegistry(registry);
 
-    const invalidParam = await app.request("/api/terminal/sessions/Main", {
-      method: "PATCH",
+    const invalidParam = await app.request("/api/terminal/sessions/Main/rename", {
+      method: "PUT",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ name: "review-main" }),
     });
-    const invalidBody = await app.request("/api/terminal/sessions/main", {
-      method: "PATCH",
+    const invalidBody = await app.request("/api/terminal/sessions/main/rename", {
+      method: "PUT",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ name: "Review Main" }),
     });
-    const tooLarge = await app.request("/api/terminal/sessions/main", {
-      method: "PATCH",
+    const tooLarge = await app.request("/api/terminal/sessions/main/rename", {
+      method: "PUT",
       headers: {
         "Content-Type": "application/json",
         "Content-Length": "2048",

--- a/tests/shell/builtin-apps.test.ts
+++ b/tests/shell/builtin-apps.test.ts
@@ -29,7 +29,7 @@ describe("built-in app helpers", () => {
     expect(normalizeBuiltInAppPath("__terminal__:1712345678-a3bc")).toBe("__terminal__");
     expect(normalizeBuiltInLayoutWindow({
       path: "__terminal__:1712345678-a3bc",
-      title: "zellij-x6mb8y2",
+      title: "matrix-x6mb8y2",
       x: 10,
       y: 20,
       width: 800,

--- a/tests/shell/terminal-app-component.test.tsx
+++ b/tests/shell/terminal-app-component.test.tsx
@@ -673,7 +673,7 @@ describe("TerminalApp", () => {
           }),
         } as Response);
       }
-      if (url.endsWith("/api/terminal/sessions/main") && init?.method === "PATCH") {
+      if (url.endsWith("/api/terminal/sessions/main/rename") && init?.method === "PUT") {
         return Promise.resolve({
           ok: true,
           json: async () => ({
@@ -731,9 +731,9 @@ describe("TerminalApp", () => {
     expect(screen.getByRole("button", { name: "Open review-main" })).toBeTruthy();
     expect(calls).toEqual(expect.arrayContaining([
       expect.objectContaining({
-        url: expect.stringContaining("/api/terminal/sessions/main"),
+        url: expect.stringContaining("/api/terminal/sessions/main/rename"),
         init: expect.objectContaining({
-          method: "PATCH",
+          method: "PUT",
           body: JSON.stringify({ name: "review-main" }),
         }),
       }),
@@ -1222,7 +1222,7 @@ describe("TerminalApp", () => {
     ))).toBe(false);
   });
 
-  it("opens zellij-backed shell sessions from the new-session menu", async () => {
+  it("opens Matrix-named shell sessions from the new-session menu", async () => {
     render(<TerminalApp />);
 
     await act(async () => {
@@ -1243,10 +1243,10 @@ describe("TerminalApp", () => {
       ))
       .map(([, init]: [RequestInfo | URL, RequestInit]) => JSON.parse(String(init.body)) as { name: string });
 
-    expect(createCalls.some((body) => /^zellij-/.test(body.name))).toBe(true);
+    expect(createCalls.some((body) => /^matrix-/.test(body.name))).toBe(true);
     expect(paneGridSpy.mock.lastCall?.[0]).toMatchObject({
       paneTree: {
-        sessionId: expect.stringMatching(/^zellij-/),
+        sessionId: expect.stringMatching(/^matrix-/),
       },
     });
   });
@@ -1469,7 +1469,7 @@ describe("TerminalApp", () => {
     expect(screen.getByRole("button", { name: "Open matrix-main" })).toBeTruthy();
   });
 
-  it("opens zellij-backed shell sessions from Ctrl+Shift+T", async () => {
+  it("opens Matrix-named shell sessions from Ctrl+Shift+T", async () => {
     render(<TerminalApp />);
 
     await act(async () => {
@@ -1490,7 +1490,7 @@ describe("TerminalApp", () => {
 
     expect(paneGridSpy.mock.lastCall?.[0]).toMatchObject({
       paneTree: {
-        sessionId: expect.stringMatching(/^zellij-/),
+        sessionId: expect.stringMatching(/^matrix-/),
       },
     });
   });
@@ -1871,7 +1871,7 @@ describe("TerminalApp", () => {
     });
   });
 
-  it("creates toolbar zellij launches as canonical shell sessions", async () => {
+  it("creates toolbar shell launches as Matrix-named canonical shell sessions", async () => {
     render(<TerminalApp />);
 
     await act(async () => {
@@ -1891,12 +1891,12 @@ describe("TerminalApp", () => {
       String(input).includes("/api/terminal/sessions") &&
       init?.method === "POST" &&
       typeof init.body === "string" &&
-      JSON.parse(init.body).name.startsWith("zellij-")
+      JSON.parse(init.body).name.startsWith("matrix-")
     ));
     expect(createCall).toBeTruthy();
     const body = JSON.parse(createCall?.[1]?.body as string) as { name: string; cwd: string };
     expect(body).toMatchObject({ cwd: "projects" });
-    expect(body.name).toMatch(/^zellij-[a-z0-9]+$/);
+    expect(body.name).toMatch(/^matrix-[a-z0-9]+$/);
 
     const props = paneGridSpy.mock.lastCall?.[0] as {
       paneTree: { type: "pane"; sessionId?: string; startupCommand?: string };
@@ -1905,7 +1905,7 @@ describe("TerminalApp", () => {
     expect(props.paneTree.startupCommand).toBeUndefined();
   });
 
-  it("cleans up a just-created zellij shell when unmounted before the tab is attached", async () => {
+  it("cleans up a just-created Matrix shell when unmounted before the tab is attached", async () => {
     let resolveCreate: ((value: { ok: boolean; status: number; json: () => Promise<{ name: string }> }) => void) | null = null;
     vi.stubGlobal("fetch", vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
       const url = String(input);
@@ -1967,7 +1967,7 @@ describe("TerminalApp", () => {
     );
   });
 
-  it("manages canonical zellij shells from a dedicated sidebar surface", async () => {
+  it("manages canonical Matrix shells from a dedicated sidebar surface", async () => {
     let mainDeleted = false;
     vi.stubGlobal("fetch", vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
       const url = String(input);
@@ -1985,7 +1985,7 @@ describe("TerminalApp", () => {
         return Promise.resolve({ ok: true, json: async () => ({ ok: true }) });
       }
       if (url.includes("/api/terminal/sessions") && init?.method === "POST") {
-        return Promise.resolve({ ok: true, json: async () => ({ name: "zellij-new", created: true }) });
+        return Promise.resolve({ ok: true, json: async () => ({ name: "matrix-new", created: true }) });
       }
       if (url.includes("/api/terminal/sessions")) {
         return Promise.resolve({


### PR DESCRIPTION
## Summary

- Add canonical `PUT /api/terminal/sessions/:name/rename` while keeping the legacy PATCH route as a compatibility alias.
- Migrate terminal session preferences during backend rename alongside registry metadata and scrollback, with rollback if persistence fails.
- Generate new managed shell sessions as `matrix-*` and update the terminal rename UI to call the backend rename endpoint and rewrite pane session ids.

## Tests

- `pnpm exec vitest run tests/gateway/shell-registry.test.ts tests/gateway/shell-routes.test.ts tests/gateway/shell-preferences.test.ts tests/shell/terminal-app-component.test.tsx tests/shell/builtin-apps.test.ts`
- `pnpm exec vitest run tests/gateway/shell-preferences.test.ts`
- `pnpm exec vitest run tests/gateway/shell-registry.test.ts tests/gateway/shell-routes.test.ts tests/gateway/shell-preferences.test.ts`
- `pnpm run check:patterns`
- `pnpm --filter '@matrix-os/gateway' exec tsc --noEmit`
- `pnpm --dir shell exec tsc --noEmit -p tsconfig.json`
- `pnpm --filter desktop run typecheck`
- `npx react-doctor@latest shell --scope changed --base origin/main --verbose`

`pnpm run typecheck` could not run directly because this environment does not have `bun`; the command exits before TypeScript starts at `bun run typecheck:build-kernel`.

## Review/Monitoring

- Addressed Greptile's 4/5 preference rename cleanup-race finding in commit `328119ed`.
- Latest Greptile status: 5/5 on commit `328119ed`.
- Resolved the old Greptile review thread after the 5/5 re-review confirmed the finding was fixed.

## Invariants

- **Source of truth**: live Zellij sessions remain the runtime source of truth; `system/shell-sessions.json`, `system/shell-preferences/*.json`, and scrollback files are durable metadata keyed by validated session names.
- **Lock/transaction scope**: `ShellRegistry.rename()` runs under the existing registry mutation queue. The Zellij rename, scrollback rename, preferences rename, and registry metadata write are serialized in that critical section; no network calls are inside it.
- **Acceptable orphan states**: if Zellij rename succeeds but scrollback, preferences, or registry persistence fails, the registry attempts to rename Zellij and any migrated side stores back to the original name before surfacing the error. Rollback failures are logged server-side.
- **Auth source of truth**: terminal routes continue to use the gateway-level auth middleware. Route params and JSON bodies are validated at the route boundary before calling the registry.
- **Deferred scope**: broader terminal sidebar polish, Canvas minimize/focus behavior, fullscreen pill behavior, and existing live session restyling are intentionally left for follow-up PRs.
