### PR TITLE
fix(shell): route terminal launches through canonical surface

### DIFF
--- a/shell/src/lib/app-launch.ts
+++ b/shell/src/lib/app-launch.ts
@@ -92,6 +92,6 @@ export function canonicalAppLaunchPath(app: GatewayAppEntryLike): string | null 
 }
 
 export function terminalContextLaunchPath(projectSlug: string | null | undefined): string {
-  if (!projectSlug || !SAFE_APP_SLUG.test(projectSlug)) return "__terminal__";
-  return `__terminal__?project=${encodeURIComponent(projectSlug)}`;
+  void projectSlug;
+  return "__terminal__";
 }

--- a/shell/src/lib/app-launch.ts
+++ b/shell/src/lib/app-launch.ts
@@ -91,7 +91,6 @@ export function canonicalAppLaunchPath(app: GatewayAppEntryLike): string | null 
   return app.path.replace(/^\/files\//, "");
 }
 
-export function terminalContextLaunchPath(projectSlug: string | null | undefined): string {
-  void projectSlug;
+export function terminalContextLaunchPath(_projectSlug: string | null | undefined): string {
   return "__terminal__";
 }

--- a/shell/src/lib/terminal-launch.ts
+++ b/shell/src/lib/terminal-launch.ts
@@ -27,7 +27,7 @@ const TERMINAL_ACTIONS: Record<TerminalLaunchAction, TerminalLaunchConfig> = {
 };
 
 const TERMINAL_LAUNCH_QUEUE_KEY = "matrix:terminal-launch-queue";
-export const TERMINAL_SETUP_WINDOW_PATH = "__terminal__:setup";
+export const TERMINAL_SETUP_WINDOW_PATH = "__terminal__";
 export const TERMINAL_LAUNCH_EVENT = "matrix:terminal-launch";
 
 interface QueuedTerminalLaunch {

--- a/tests/shell/app-launch.test.ts
+++ b/tests/shell/app-launch.test.ts
@@ -55,9 +55,9 @@ describe("app launch helpers", () => {
     expect(isGameApp("apps/mydir/apps/games/tool/index.html")).toBe(false);
   });
 
-  it("keeps project context for valid project slugs that are not icon slugs", () => {
-    expect(terminalContextLaunchPath("matrix_os")).toBe("__terminal__?project=matrix_os");
-    expect(terminalContextLaunchPath("org/matrix_os")).toBe("__terminal__?project=org%2Fmatrix_os");
+  it("routes project-context launches through the canonical terminal surface", () => {
+    expect(terminalContextLaunchPath("matrix_os")).toBe("__terminal__");
+    expect(terminalContextLaunchPath("org/matrix_os")).toBe("__terminal__");
     expect(terminalContextLaunchPath("../matrix")).toBe("__terminal__");
   });
 });

--- a/tests/shell/terminal-launch.test.ts
+++ b/tests/shell/terminal-launch.test.ts
@@ -6,6 +6,7 @@ import {
   drainTerminalLaunchQueue,
   enqueueTerminalLaunch,
   parseTerminalLaunchPath,
+  TERMINAL_SETUP_WINDOW_PATH,
 } from "../../shell/src/lib/terminal-launch.js";
 
 describe("terminal launch paths", () => {
@@ -36,6 +37,10 @@ describe("terminal launch paths", () => {
   it("ignores ordinary terminal paths", () => {
     expect(parseTerminalLaunchPath("__terminal__")).toBeNull();
     expect(parseTerminalLaunchPath("__terminal__:random")).toBeNull();
+  });
+
+  it("targets setup actions at the canonical terminal surface", () => {
+    expect(TERMINAL_SETUP_WINDOW_PATH).toBe("__terminal__");
   });
 
   it("queues setup actions so an existing terminal can open them as tabs", () => {


### PR DESCRIPTION
## Summary
- Route setup/login Terminal launch windows through the canonical `__terminal__` built-in surface instead of a `__terminal__:setup` window path.
- Route project-context Terminal launch helpers to `__terminal__` so Desktop/Mobile launch matching uses the registered Terminal app path.
- Add regression coverage for canonical Terminal launch path routing.

## Tests
- `bun run test tests/shell/app-launch.test.ts tests/shell/terminal-launch.test.ts tests/shell/manual-setup-stickers.test.tsx`
- `bun run test tests/shell/mobile-shell.test.tsx tests/shell/app-viewer-slug.test.ts tests/shell/builtin-apps.test.ts`
- `bun run typecheck`
- `bun run check:patterns` (0 violations; existing warnings only)
- `bun run test tests/gateway/shell-registry.test.ts` (reran after full-suite flake; passed)
- `bun run test` attempted twice: first run had one unrelated `tests/gateway/shell-registry.test.ts` ordering/flaky assertion that passed in isolation; second run exceeded the 20-minute tool timeout after progressing through the suite without showing a product failure.