### PR TITLE
fix(shell): reduce reload lag

### DIFF
--- a/packages/gateway/src/server.ts
+++ b/packages/gateway/src/server.ts
@@ -106,6 +106,7 @@ import { createVocalHandler } from "./vocal/ws-handler.js";
 import type { GeminiLiveConnection } from "./onboarding/gemini-live.js";
 import { resolveDefaultAppIconUrl, resolveSystemIconUrl } from "./default-icons.js";
 import { registerIconRoutes } from "./icon-routes.js";
+import { buildShellBootstrap } from "./shell-bootstrap.js";
 import { securityHeadersMiddleware } from "./security/headers.js";
 import { getSystemInfo } from "./system-info.js";
 import { collectSystemActivity } from "./system-activity/collector.js";
@@ -3795,6 +3796,10 @@ export async function createGateway(config: GatewayConfig) {
 
   app.get("/api/apps", async (c) => {
     return c.json(await listApps(homePath));
+  });
+
+  app.get("/api/shell/bootstrap", async (c) => {
+    return c.json(await buildShellBootstrap(homePath));
   });
 
   registerIconRoutes(app, homePath);

--- a/packages/gateway/src/shell-bootstrap.ts
+++ b/packages/gateway/src/shell-bootstrap.ts
@@ -1,0 +1,96 @@
+import { readFile, stat } from "node:fs/promises";
+import { basename, join } from "node:path";
+import { listApps, type AppEntry } from "./apps.js";
+import { resolveSystemIconPath } from "./default-icons.js";
+
+export interface ShellBootstrapIcon {
+  url: string;
+  etag: string | null;
+  versionedUrl: string;
+}
+
+export interface ShellBootstrap {
+  layout: { windows?: unknown[] };
+  modules: unknown[];
+  apps: AppEntry[];
+  icons: Record<string, ShellBootstrapIcon>;
+}
+
+const BOOTSTRAP_BUILT_IN_ICON_SLUGS = ["terminal", "workspace", "files", "chat", "chart"] as const;
+const SAFE_ICON_SLUG = /^[a-zA-Z0-9_-]{1,64}$/;
+
+function versionedIconUrl(url: string, etag: string | null): string {
+  if (!etag) return url;
+  const normalized = etag.replace(/^W\//, "").replace(/^"|"$/g, "");
+  if (!normalized) return url;
+  return `${url}${url.includes("?") ? "&" : "?"}v=${encodeURIComponent(normalized)}`;
+}
+
+async function readJsonFile(path: string): Promise<unknown | null> {
+  try {
+    return JSON.parse(await readFile(path, "utf8")) as unknown;
+  } catch (err: unknown) {
+    if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
+      console.warn("[shell-bootstrap] failed to read bootstrap JSON:", err instanceof Error ? err.message : String(err));
+    }
+    return null;
+  }
+}
+
+function normalizeLayout(value: unknown): { windows?: unknown[] } {
+  if (value && typeof value === "object" && Array.isArray((value as { windows?: unknown }).windows)) {
+    return { windows: (value as { windows: unknown[] }).windows };
+  }
+  return {};
+}
+
+function normalizeModules(value: unknown): unknown[] {
+  return Array.isArray(value) ? value : [];
+}
+
+async function resolveBootstrapIcon(homePath: string, slug: string): Promise<ShellBootstrapIcon | null> {
+  if (!SAFE_ICON_SLUG.test(slug)) return null;
+  const target = await resolveSystemIconPath(homePath, `${slug}.png`);
+  if (!target) return null;
+  try {
+    const iconStat = await stat(target);
+    const etag = `"${iconStat.mtimeMs.toString(36)}-${iconStat.size.toString(36)}"`;
+    const url = `/icons/${basename(target)}`;
+    return { url, etag, versionedUrl: versionedIconUrl(url, etag) };
+  } catch (err: unknown) {
+    if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
+      console.warn("[shell-bootstrap] failed to stat bootstrap icon:", err instanceof Error ? err.message : String(err));
+    }
+    return null;
+  }
+}
+
+export async function buildShellBootstrap(homePath: string): Promise<ShellBootstrap> {
+  const [layoutValue, modulesValue, apps] = await Promise.all([
+    readJsonFile(join(homePath, "system/layout.json")),
+    readJsonFile(join(homePath, "system/modules.json")),
+    listApps(homePath),
+  ]);
+
+  const iconSlugs = new Set<string>(BOOTSTRAP_BUILT_IN_ICON_SLUGS);
+  for (const app of apps) {
+    if (typeof app.icon === "string" && SAFE_ICON_SLUG.test(app.icon)) {
+      iconSlugs.add(app.icon);
+    } else if (typeof app.slug === "string" && SAFE_ICON_SLUG.test(app.slug)) {
+      iconSlugs.add(app.slug);
+    }
+  }
+
+  const icons: Record<string, ShellBootstrapIcon> = {};
+  await Promise.all(Array.from(iconSlugs).map(async (slug) => {
+    const icon = await resolveBootstrapIcon(homePath, slug);
+    if (icon) icons[slug] = icon;
+  }));
+
+  return {
+    layout: normalizeLayout(layoutValue),
+    modules: normalizeModules(modulesValue),
+    apps,
+    icons,
+  };
+}

--- a/packages/platform/src/main.ts
+++ b/packages/platform/src/main.ts
@@ -924,6 +924,30 @@ function applyCookieRoutedShellAssetCacheHeaders(headers: Headers): void {
   addVaryHeader(headers, ['Cookie', 'Accept-Encoding']);
 }
 
+function applyAppDomainRuntimeAssetCacheHeaders(headers: Headers, path: string, rawUrl: string): void {
+  const maxAge = getAppDomainRuntimeAssetBrowserMaxAge(path, rawUrl);
+  if (maxAge === null) return;
+  const immutable = maxAge === 31_536_000 ? ', immutable' : '';
+  headers.set('cache-control', `private, max-age=${maxAge}${immutable}`);
+  headers.set('cdn-cache-control', 'no-store');
+  headers.set('cloudflare-cdn-cache-control', 'no-store');
+  addVaryHeader(headers, ['Cookie', 'Accept-Encoding']);
+}
+
+function getAppDomainRuntimeAssetBrowserMaxAge(path: string, rawUrl: string): number | null {
+  if (path.startsWith('/_next/static/') || isViteAppAssetPath(path)) return 31_536_000;
+  if (path.startsWith('/icons/')) {
+    try {
+      return new URL(rawUrl, 'https://app.matrix-os.com').searchParams.has('v') ? 31_536_000 : 86_400;
+    } catch (err: unknown) {
+      console.warn('[platform] Failed to parse runtime asset cache URL:', err instanceof Error ? err.message : String(err));
+      return 86_400;
+    }
+  }
+  if (path.startsWith('/fonts/') || path.startsWith('/wallpapers/')) return 86_400;
+  return null;
+}
+
 function addVaryHeader(headers: Headers, values: string[]): void {
   const vary = headers.get('vary');
   const varyParts = new Set(
@@ -964,6 +988,8 @@ function isAppDomainStaticAssetPath(path: string): boolean {
     path === '/og.png' ||
     path.startsWith('/_next/static/') ||
     path.startsWith('/_next/image') ||
+    path.startsWith('/fonts/') ||
+    path.startsWith('/wallpapers/') ||
     isViteAppAssetPath(path)
   );
 }
@@ -3130,6 +3156,7 @@ export function createApp(deps: {
 
         const responseHeaders = sanitizeProxyResponseHeaders(upstream.headers);
         applySandboxedAppAssetCorsHeaders(responseHeaders, explicitVmRoute.upstreamPath, c.req.header('origin'));
+        applyAppDomainRuntimeAssetCacheHeaders(responseHeaders, explicitVmRoute.upstreamPath, c.req.url);
         responseHeaders.append('set-cookie', buildShellRouteCookie(machine.handle));
         return await buildAppDomainProxyResponse({
           upstream,
@@ -3290,6 +3317,7 @@ export function createApp(deps: {
         if ((identity.source === 'static-route' || isCookieRoutedShellAsset) && isAppDomainStaticAssetPath(path)) {
           applyCookieRoutedShellAssetCacheHeaders(responseHeaders);
         }
+        applyAppDomainRuntimeAssetCacheHeaders(responseHeaders, path, c.req.url);
         if (identity.source === 'mobile-session') {
           const routeCookie = buildAppRouteCookie(runningMachine.handle, path);
           if (routeCookie) responseHeaders.append('set-cookie', routeCookie);
@@ -3469,6 +3497,7 @@ export function createApp(deps: {
         if ((identity.source === 'static-route' || isCookieRoutedShellAsset) && isAppDomainStaticAssetPath(path)) {
           applyCookieRoutedShellAssetCacheHeaders(responseHeaders);
         }
+        applyAppDomainRuntimeAssetCacheHeaders(responseHeaders, path, c.req.url);
         if (identity.source === 'mobile-session') {
           const routeCookie = buildAppRouteCookie(record.handle, path);
           if (routeCookie) responseHeaders.append('set-cookie', routeCookie);

--- a/packages/platform/src/request-routing.ts
+++ b/packages/platform/src/request-routing.ts
@@ -96,6 +96,7 @@ export function isAppDomainGatewayPath(path: string): boolean {
     path.startsWith('/api/') ||
     path.startsWith('/ws') ||
     path.startsWith('/files/') ||
+    path.startsWith('/icons/') ||
     path.startsWith('/modules/') ||
     path === '/health'
   );

--- a/shell/src/components/ConnectionIndicator.tsx
+++ b/shell/src/components/ConnectionIndicator.tsx
@@ -8,7 +8,8 @@ import { getGatewayUrl } from "@/lib/gateway";
 import { resolveConnectionCopy, type RuntimeStatus } from "./connection-indicator-copy";
 
 const STATUS_REFRESH_MS = 5_000;
-const STATUS_TIMEOUT_MS = 4_000;
+const STATUS_TIMEOUT_MS = 1_500;
+const INITIAL_CONNECTION_GRACE_MS = 2_500;
 
 function classifyRuntimeStatusError(error: unknown): string {
   if (error instanceof DOMException) {
@@ -60,10 +61,20 @@ async function loadRuntimeStatus(): Promise<RuntimeStatus> {
 export function ConnectionIndicator() {
   const state = useConnectionHealth((s) => s.state);
   const [status, setStatus] = useState<RuntimeStatus>({ reachability: "checking" });
+  const [initialGraceElapsed, setInitialGraceElapsed] = useState(false);
+
+  useEffect(() => {
+    if (state !== "initializing") {
+      return;
+    }
+    const timer = setTimeout(() => setInitialGraceElapsed(true), INITIAL_CONNECTION_GRACE_MS);
+    return () => clearTimeout(timer);
+  }, [initialGraceElapsed, state]);
 
   // react-doctor-disable-next-line react-doctor/no-cascading-set-state -- polling loop: every setStatus call fires either synchronously to reset the gauge on disconnect or from async fetch/timer callbacks (never a synchronous cascade); a reducer would not change the self-rescheduling sequencing and the cancelled flag guards post-unmount writes.
   useEffect(() => {
     if (state === "connected") return;
+    if (state === "initializing" && !initialGraceElapsed) return;
     let cancelled = false;
     let timer: ReturnType<typeof setTimeout> | undefined;
 
@@ -89,7 +100,7 @@ export function ConnectionIndicator() {
       cancelled = true;
       if (timer) clearTimeout(timer);
     };
-  }, [state]);
+  }, [initialGraceElapsed, state]);
 
   const copy = resolveConnectionCopy(state, status);
   const toneClass = copy.tone === "danger" ? "text-red-500" : "text-amber-500";
@@ -98,7 +109,7 @@ export function ConnectionIndicator() {
     ? "border-red-500/25 bg-card/95 shadow-[0_18px_60px_-24px_rgba(239,68,68,0.58),0_24px_60px_-30px_rgba(0,0,0,0.38)]"
     : "border-amber-500/20 bg-card/95 shadow-[0_18px_60px_-24px_rgba(245,158,11,0.45),0_24px_60px_-30px_rgba(0,0,0,0.34)]";
 
-  if (state === "connected") return null;
+  if (state === "connected" || (state === "initializing" && !initialGraceElapsed)) return null;
 
   return (
     <aside

--- a/shell/src/components/ConnectionIndicator.tsx
+++ b/shell/src/components/ConnectionIndicator.tsx
@@ -69,7 +69,7 @@ export function ConnectionIndicator() {
     }
     const timer = setTimeout(() => setInitialGraceElapsed(true), INITIAL_CONNECTION_GRACE_MS);
     return () => clearTimeout(timer);
-  }, [initialGraceElapsed, state]);
+  }, [state]);
 
   // react-doctor-disable-next-line react-doctor/no-cascading-set-state -- polling loop: every setStatus call fires either synchronously to reset the gauge on disconnect or from async fetch/timer callbacks (never a synchronous cascade); a reducer would not change the self-rescheduling sequencing and the cancelled flag guards post-unmount writes.
   useEffect(() => {

--- a/shell/src/components/Desktop.tsx
+++ b/shell/src/components/Desktop.tsx
@@ -220,6 +220,19 @@ interface ModuleMeta {
   version?: string;
 }
 
+interface ShellBootstrapIcon {
+  url: string;
+  etag: string | null;
+  versionedUrl: string;
+}
+
+interface ShellBootstrap {
+  layout?: { windows?: LayoutWindow[] };
+  modules?: ModuleRegistryEntry[];
+  apps?: { name: string; path: string; icon?: string; slug?: string }[];
+  icons?: Record<string, ShellBootstrapIcon>;
+}
+
 function registryPathToRelativePath(path: string): string | null {
   if (path.startsWith("~/")) {
     return path.slice(2);
@@ -710,10 +723,8 @@ export function Desktop({ launchAppPath, onOpenCommandPalette, chat }: DesktopPr
 
   const generatingRef = useRef<Set<string> | null>(null);
   if (generatingRef.current === null) generatingRef.current = new Set<string>();
-  const checkedRef = useRef<Set<string> | null>(null);
-  if (checkedRef.current === null) checkedRef.current = new Set<string>();
 
-  // react-doctor-disable-next-line react-doctor/react-compiler-no-manual-memoization -- identity feeds checkAndGenerateIcon's deps, which feeds addApp's deps, which feeds loadModules' deps -- loadModules is a useEffect dependency, so a fresh identity here would re-fire the module-load effect every render
+  // react-doctor-disable-next-line react-doctor/react-compiler-no-manual-memoization -- stable identity feeds app-tile regenerate handlers and avoids re-registering commands that close over app actions
   const regenerateIcon = useCallback((slug: string) => {
     generatingRef.current!.add(slug);
     fetch(`${GATEWAY_URL}/api/apps/${slug}/icon`, {
@@ -740,38 +751,6 @@ export function Desktop({ launchAppPath, onOpenCommandPalette, chat }: DesktopPr
       .catch((err) => console.warn(`Icon regen request failed for "${slug}":`, err))
       .finally(() => generatingRef.current!.delete(slug));
   }, [wmSetApps]);
-
-  // react-doctor-disable-next-line react-doctor/react-compiler-no-manual-memoization -- identity feeds addApp's deps, which feeds loadModules' deps -- loadModules is a useEffect dependency, so a fresh identity here would re-fire the module-load effect every render
-  const checkAndGenerateIcon = useCallback((slug: string) => {
-    if (checkedRef.current!.has(slug) || generatingRef.current!.has(slug)) return;
-    checkedRef.current!.add(slug);
-    const iconPath = iconUrlForSlug(slug);
-    if (!iconPath) return;
-    fetch(`${GATEWAY_URL}${iconPath}`, {
-      method: "HEAD",
-      signal: AbortSignal.timeout(GATEWAY_FETCH_TIMEOUT_MS),
-    }).then((res) => {
-      if (res.ok) {
-        const etag = res.headers.get("etag");
-        if (etag) {
-          const versionedUrl = versionedIconUrl(iconPath, etag);
-          wmSetApps((prev) =>
-            prev.map((a) =>
-              nameToSlug(a.name) === slug && a.iconUrl !== versionedUrl
-                ? { ...a, iconUrl: versionedUrl }
-                : a,
-            ),
-          );
-        }
-      } else {
-        regenerateIcon(slug);
-      }
-    }).catch((err) => {
-      if (process.env.NODE_ENV !== "production") {
-        console.debug(`[desktop] Failed to check icon for "${slug}":`, err instanceof Error ? err.message : String(err));
-      }
-    });
-  }, [wmSetApps, regenerateIcon]);
 
   const renameAppOnServer = (slug: string, newName: string) => {
     fetch(`${GATEWAY_URL}/api/apps/${slug}/rename`, {
@@ -832,8 +811,8 @@ export function Desktop({ launchAppPath, onOpenCommandPalette, chat }: DesktopPr
   };
 
   // react-doctor-disable-next-line react-doctor/react-compiler-no-manual-memoization -- identity feeds loadModules' deps, and loadModules is a useEffect dependency (L~1070); a fresh function each render would re-fire the module-load effect every render
-  const addApp = useCallback((name: string, path: string, iconSlug?: string) => {
-    const iconUrl = iconUrlForSlug(iconSlug);
+  const addApp = useCallback((name: string, path: string, iconSlug?: string, iconUrlOverride?: string) => {
+    const iconUrl = iconUrlOverride ?? iconUrlForSlug(iconSlug);
     wmSetApps((prev) => {
       const existing = prev.find((a) => a.path === path);
       if (existing) {
@@ -845,8 +824,7 @@ export function Desktop({ launchAppPath, onOpenCommandPalette, chat }: DesktopPr
       }
       return [...prev, { name, path, iconUrl }];
     });
-    if (iconSlug) checkAndGenerateIcon(iconSlug);
-  }, [wmSetApps, checkAndGenerateIcon]);
+  }, [wmSetApps]);
 
 
   // react-doctor-disable-next-line react-doctor/react-compiler-no-manual-memoization -- identity consumed by the command-registration useEffect dependency array (L~1435) and feeds loadModules' deps (also a useEffect dependency); a fresh function each render would re-fire both effects every render
@@ -963,33 +941,20 @@ export function Desktop({ launchAppPath, onOpenCommandPalette, chat }: DesktopPr
   // react-doctor-disable-next-line react-doctor/react-compiler-no-manual-memoization -- identity consumed by the module-load useEffect dependency array (L~1070); a fresh function each render would re-run the layout/modules/apps fetch on every render
   const loadModules = useCallback(async () => {
     try {
-      const [layoutRes, modulesRes, appsRes] = await Promise.all([
-        isPreVpsBillingSetupRoute()
-          ? Promise.resolve(null)
-          : fetch(`${GATEWAY_URL}/api/layout`, {
-              signal: AbortSignal.timeout(GATEWAY_FETCH_TIMEOUT_MS),
-            }).catch((err) => {
-              if (process.env.NODE_ENV !== "production") {
-                console.debug("[desktop] Failed to fetch layout:", err instanceof Error ? err.message : String(err));
-              }
-              return null;
-            }),
-        fetch(`${GATEWAY_URL}/files/system/modules.json`, {
-          signal: AbortSignal.timeout(GATEWAY_FETCH_TIMEOUT_MS),
-        }).catch((err) => {
-          console.warn("[desktop] Failed to fetch module registry:", err);
-          return null;
-        }),
-        fetch(`${GATEWAY_URL}/api/apps`, {
-          signal: AbortSignal.timeout(GATEWAY_FETCH_TIMEOUT_MS),
-        }).catch((err) => {
-          console.warn("[desktop] Failed to fetch app list:", err);
-          return null;
-        }),
-      ]);
+      const bootstrapRes = await fetch(`${GATEWAY_URL}/api/shell/bootstrap`, {
+        signal: AbortSignal.timeout(GATEWAY_FETCH_TIMEOUT_MS),
+      }).catch((err) => {
+        console.warn("[desktop] Failed to fetch shell bootstrap:", err);
+        return null;
+      });
+      const bootstrap: ShellBootstrap = bootstrapRes?.ok ? await bootstrapRes.json() : {};
+      const iconForSlug = (slug: string | undefined): string | undefined => {
+        if (!slug) return undefined;
+        return bootstrap.icons?.[slug]?.versionedUrl ?? iconUrlForSlug(slug);
+      };
 
       const savedLayout: { windows?: LayoutWindow[] } =
-        layoutRes?.ok ? await layoutRes.json() : {};
+        !isPreVpsBillingSetupRoute() ? bootstrap.layout ?? {} : {};
       const savedWindows = (savedLayout.windows ?? []).map(normalizeBuiltInLayoutWindow);
       const layoutMap = new Map(savedWindows.map((w) => [w.path, w]));
 
@@ -1002,24 +967,25 @@ export function Desktop({ launchAppPath, onOpenCommandPalette, chat }: DesktopPr
       };
 
       // Register built-in apps
-      addApp("Terminal", "__terminal__", "terminal");
-      addApp("Workspace", "__workspace__", "workspace");
-      addApp("Files", "__file-browser__", "files");
-      addApp("Hermes", "__chat__", "chat");
-      addApp("Activity Monitor", "__activity-monitor__", "chart");
+      addApp("Terminal", "__terminal__", "terminal", iconForSlug("terminal"));
+      addApp("Workspace", "__workspace__", "workspace", iconForSlug("workspace"));
+      addApp("Files", "__file-browser__", "files", iconForSlug("files"));
+      addApp("Hermes", "__chat__", "chat", iconForSlug("chat"));
+      addApp("Activity Monitor", "__activity-monitor__", "chart", iconForSlug("chart"));
       const savedBuiltIns = savedWindows.filter((w) => isBuiltInAppPath(w.path));
       for (const saved of savedBuiltIns) {
         queueSavedLayout(saved);
       }
 
       // Load pre-installed apps from /api/apps (apps/ directory)
-      if (appsRes?.ok) {
-        const appsList: { name: string; path: string; icon?: string }[] = await appsRes.json();
+      if (Array.isArray(bootstrap.apps)) {
+        const appsList = bootstrap.apps;
         for (const app of appsList) {
           // path from API is like "/files/apps/calculator/index.html"
           // strip leading "/files/" to get relative path for AppViewer
           const relativePath = normalizeBuiltInAppPath(app.path.replace(/^\/files\//, ""));
-          addApp(app.name, relativePath, app.icon);
+          const iconSlug = app.icon ?? app.slug;
+          addApp(app.name, relativePath, iconSlug, iconForSlug(iconSlug));
 
           const saved = layoutMap.get(relativePath);
           queueSavedLayout(saved);
@@ -1028,8 +994,8 @@ export function Desktop({ launchAppPath, onOpenCommandPalette, chat }: DesktopPr
       }
 
       // Load modules from modules.json (Node/Python apps with ports)
-      if (modulesRes?.ok) {
-        const registry: ModuleRegistryEntry[] = await modulesRes.json();
+      if (Array.isArray(bootstrap.modules)) {
+        const registry = bootstrap.modules;
 
         for (const mod of registry) {
           if (mod.status !== "active") continue;

--- a/shell/src/components/connection-indicator-copy.ts
+++ b/shell/src/components/connection-indicator-copy.ts
@@ -16,6 +16,15 @@ export interface ConnectionCopy {
 }
 
 export function resolveConnectionCopy(state: ConnectionState, status: RuntimeStatus): ConnectionCopy {
+  if (state === "initializing") {
+    return {
+      tone: "warn",
+      title: "Checking connection",
+      detail: "Matrix is opening the live shell session.",
+      action: "Retry now",
+    };
+  }
+
   if (state === "disconnected") {
     return {
       tone: "danger",

--- a/shell/src/components/terminal/TerminalApp.tsx
+++ b/shell/src/components/terminal/TerminalApp.tsx
@@ -676,6 +676,11 @@ export function TerminalApp({ initialCommand, initialLabel, initialClaudeMode = 
   const closingPaneIdsRef = useRef<Set<string> | null>(null);
   if (closingPaneIdsRef.current === null) closingPaneIdsRef.current = new Set();
   const layoutSaveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const terminalLayoutHydratedRef = useRef(false);
+  const terminalLayoutDirtyRef = useRef(false);
+  const markTerminalLayoutDirty = () => {
+    terminalLayoutDirtyRef.current = true;
+  };
   // react-doctor-disable-next-line react-doctor/react-compiler-no-manual-memoization -- stable identity for effect dep: `log` is consumed in the dependency array of the tabs-changed useEffect below; removing the memo would re-create it every render and re-run that effect.
   const log = useCallback((event: string, details: Record<string, unknown> = {}) => {
     terminalAppDebug(event, {
@@ -930,6 +935,12 @@ export function TerminalApp({ initialCommand, initialLabel, initialClaudeMode = 
       return;
     }
 
+    if (!terminalLayoutHydratedRef.current) {
+      terminalLayoutHydratedRef.current = true;
+      if (!terminalLayoutDirtyRef.current) return;
+    }
+    terminalLayoutDirtyRef.current = true;
+
     if (layoutSaveTimerRef.current) {
       clearTimeout(layoutSaveTimerRef.current);
     }
@@ -937,6 +948,7 @@ export function TerminalApp({ initialCommand, initialLabel, initialClaudeMode = 
     layoutSaveTimerRef.current = setTimeout(() => {
       layoutSaveTimerRef.current = null;
       flushLayout();
+      terminalLayoutDirtyRef.current = false;
     }, 500);
 
     return () => {
@@ -952,6 +964,9 @@ export function TerminalApp({ initialCommand, initialLabel, initialClaudeMode = 
       if (!initialized) {
         return;
       }
+      if (!terminalLayoutDirtyRef.current) {
+        return;
+      }
 
       if (layoutSaveTimerRef.current) {
         clearTimeout(layoutSaveTimerRef.current);
@@ -959,6 +974,7 @@ export function TerminalApp({ initialCommand, initialLabel, initialClaudeMode = 
       }
 
       flushLayout();
+      terminalLayoutDirtyRef.current = false;
     };
 
     window.addEventListener("pagehide", flushOnPageHide);
@@ -1116,13 +1132,13 @@ export function TerminalApp({ initialCommand, initialLabel, initialClaudeMode = 
   const handleKeyDown = (e: React.KeyboardEvent) => {
     if (!e.ctrlKey || !e.shiftKey) return;
     switch (e.key.toUpperCase()) {
-      case "T": e.preventDefault(); void createShellSessionTab("Shell", getCwd()); break;
-      case "W": e.preventDefault(); if (focusedPaneId) closePane(focusedPaneId); break;
-      case "D": e.preventDefault(); if (focusedPaneId) splitPane(focusedPaneId, "horizontal"); break;
-      case "E": e.preventDefault(); if (focusedPaneId) splitPane(focusedPaneId, "vertical"); break;
-      case "B": e.preventDefault(); setSidebarOpen(o => !o); break;
-      case "C": e.preventDefault(); addTab(getCwd(), "Claude Code", true); break;
-      case "Z": e.preventDefault(); void createShellSessionTab("Shell", getCwd()); break;
+      case "T": e.preventDefault(); markTerminalLayoutDirty(); void createShellSessionTab("Shell", getCwd()); break;
+      case "W": e.preventDefault(); if (focusedPaneId) { markTerminalLayoutDirty(); closePane(focusedPaneId); } break;
+      case "D": e.preventDefault(); if (focusedPaneId) { markTerminalLayoutDirty(); splitPane(focusedPaneId, "horizontal"); } break;
+      case "E": e.preventDefault(); if (focusedPaneId) { markTerminalLayoutDirty(); splitPane(focusedPaneId, "vertical"); } break;
+      case "B": e.preventDefault(); markTerminalLayoutDirty(); setSidebarOpen(o => !o); break;
+      case "C": e.preventDefault(); markTerminalLayoutDirty(); addTab(getCwd(), "Claude Code", true); break;
+      case "Z": e.preventDefault(); markTerminalLayoutDirty(); void createShellSessionTab("Shell", getCwd()); break;
     }
   };
 
@@ -1131,9 +1147,59 @@ export function TerminalApp({ initialCommand, initialLabel, initialClaudeMode = 
   // Construct store-compatible interface for child components
   const storeApi = {
     tabs, activeTabId, sidebarOpen, sidebarSelectedPath, focusedPaneId, mobile, themeName: theme.name, windowControls,
-    addTab, addSessionTab, createShellSessionTab, backgroundShellSession, closeTab, setActiveTab: setActiveTabId, renameTab, renameShellSession, reorderTabs,
-    splitPane, closePane, setFocusedPane: setFocusedPaneId,
-    setSidebarOpen, setSidebarSelectedPath,
+    addTab: (...args: Parameters<typeof addTab>) => {
+      markTerminalLayoutDirty();
+      return addTab(...args);
+    },
+    addSessionTab: (...args: Parameters<typeof addSessionTab>) => {
+      markTerminalLayoutDirty();
+      return addSessionTab(...args);
+    },
+    createShellSessionTab: (...args: Parameters<typeof createShellSessionTab>) => {
+      markTerminalLayoutDirty();
+      return createShellSessionTab(...args);
+    },
+    backgroundShellSession: (...args: Parameters<typeof backgroundShellSession>) => {
+      markTerminalLayoutDirty();
+      return backgroundShellSession(...args);
+    },
+    closeTab: (...args: Parameters<typeof closeTab>) => {
+      markTerminalLayoutDirty();
+      return closeTab(...args);
+    },
+    setActiveTab: (tabId: string) => {
+      markTerminalLayoutDirty();
+      setActiveTabId(tabId);
+    },
+    renameTab: (...args: Parameters<typeof renameTab>) => {
+      markTerminalLayoutDirty();
+      return renameTab(...args);
+    },
+    renameShellSession: (...args: Parameters<typeof renameShellSession>) => {
+      markTerminalLayoutDirty();
+      return renameShellSession(...args);
+    },
+    reorderTabs: (...args: Parameters<typeof reorderTabs>) => {
+      markTerminalLayoutDirty();
+      return reorderTabs(...args);
+    },
+    splitPane: (...args: Parameters<typeof splitPane>) => {
+      markTerminalLayoutDirty();
+      return splitPane(...args);
+    },
+    closePane: (...args: Parameters<typeof closePane>) => {
+      markTerminalLayoutDirty();
+      return closePane(...args);
+    },
+    setFocusedPane: (paneId: string | null) => {
+      markTerminalLayoutDirty();
+      setFocusedPaneId(paneId);
+    },
+    setSidebarOpen: (value: React.SetStateAction<boolean>) => {
+      markTerminalLayoutDirty();
+      setSidebarOpen(value);
+    },
+    setSidebarSelectedPath,
   };
 
   return (

--- a/shell/src/hooks/useConnectionHealth.ts
+++ b/shell/src/hooks/useConnectionHealth.ts
@@ -1,11 +1,11 @@
 import { create } from "zustand";
 
-export type ConnectionState = "connected" | "reconnecting" | "disconnected";
+export type ConnectionState = "initializing" | "connected" | "reconnecting" | "disconnected";
 
 interface ConnectionHealthState {
   state: ConnectionState;
 }
 
 export const useConnectionHealth = create<ConnectionHealthState>()(() => ({
-  state: "disconnected" as ConnectionState,
+  state: "initializing" as ConnectionState,
 }));

--- a/shell/src/hooks/useSocket.ts
+++ b/shell/src/hooks/useSocket.ts
@@ -6,6 +6,7 @@ import { buildAuthenticatedWebSocketUrl } from "@/lib/websocket-auth";
 import { createSocketHealth, MessageQueue, reconnectDelay } from "@/lib/socket-health";
 import { capturePostHogEvent } from "@/lib/posthog-client";
 import { useConnectionHealth } from "./useConnectionHealth";
+import type { ConnectionState } from "./useConnectionHealth";
 import { MATRIX_TELEMETRY_EVENTS } from "@matrix-os/observability/events";
 
 export type ServerMessage =
@@ -36,7 +37,8 @@ let globalSocket: WebSocket | null = null;
 let handlers = new Set<MessageHandler>();
 let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
 let reconnectAttempt = 0;
-let connectionState: "connected" | "reconnecting" | "disconnected" = "disconnected";
+let connectionState: ConnectionState = "initializing";
+let hasOpenedSocket = false;
 let stateListeners = new Set<() => void>();
 
 const messageQueue = new MessageQueue({ maxSize: 50, ttlMs: 30_000 });
@@ -73,13 +75,13 @@ function connect() {
   if (globalSocket?.readyState === WebSocket.OPEN) return;
   if (globalSocket?.readyState === WebSocket.CONNECTING) return;
 
-  if (connectionState !== "reconnecting") {
+  if (connectionState !== "initializing" && connectionState !== "reconnecting") {
     capturePostHogEvent(MATRIX_TELEMETRY_EVENTS.SHELL_WS_RECONNECT_STARTED, {
       attempt: reconnectAttempt,
       visibility: typeof document !== "undefined" ? document.visibilityState : "unknown",
     });
+    setConnectionState("reconnecting");
   }
-  setConnectionState("reconnecting");
   void buildAuthenticatedWebSocketUrl("/ws")
     .catch((err: unknown) => {
       console.warn(
@@ -97,6 +99,7 @@ function connect() {
 
       globalSocket.onopen = () => {
         reconnectAttempt = 0;
+        hasOpenedSocket = true;
         setConnectionState("connected");
         capturePostHogEvent(MATRIX_TELEMETRY_EVENTS.SHELL_WS_CONNECTED);
         heartbeat.start();
@@ -113,8 +116,10 @@ function connect() {
           for (const handler of handlers) {
             handler(msg);
           }
-        } catch (_err: unknown) {
-          // ignore malformed messages
+        } catch (err: unknown) {
+          if (process.env.NODE_ENV !== "production") {
+            console.debug("[useSocket] ignored malformed websocket message:", err instanceof Error ? err.message : String(err));
+          }
         }
       };
 
@@ -128,7 +133,13 @@ function connect() {
           });
           return;
         }
-        setConnectionState("reconnecting");
+        if (hasOpenedSocket) {
+          capturePostHogEvent(MATRIX_TELEMETRY_EVENTS.SHELL_WS_RECONNECT_STARTED, {
+            attempt: reconnectAttempt,
+            visibility: typeof document !== "undefined" ? document.visibilityState : "unknown",
+          });
+          setConnectionState("reconnecting");
+        }
         const delay = reconnectDelay(reconnectAttempt);
         reconnectAttempt++;
         reconnectTimer = setTimeout(connect, delay);

--- a/shell/src/hooks/useSocket.ts
+++ b/shell/src/hooks/useSocket.ts
@@ -180,6 +180,17 @@ export function sendMessage(msg: ClientMessage) {
 
 export function manualReconnect() {
   reconnectAttempt = 0;
+  if (reconnectTimer) {
+    clearTimeout(reconnectTimer);
+    reconnectTimer = null;
+  }
+  if (connectionState === "initializing") {
+    capturePostHogEvent(MATRIX_TELEMETRY_EVENTS.SHELL_WS_RECONNECT_STARTED, {
+      attempt: reconnectAttempt,
+      visibility: typeof document !== "undefined" ? document.visibilityState : "unknown",
+    });
+    setConnectionState("reconnecting");
+  }
   connect();
 }
 

--- a/shell/src/hooks/useWindowManager.ts
+++ b/shell/src/hooks/useWindowManager.ts
@@ -90,8 +90,20 @@ interface WindowManagerActions {
 }
 
 let saveTimer: ReturnType<typeof setTimeout> | undefined;
+let layoutPersistenceArmed = false;
+
+function markUserLayoutMutation(): void {
+  layoutPersistenceArmed = true;
+}
+
+export function resetWindowManagerLayoutPersistenceForTests(): void {
+  layoutPersistenceArmed = false;
+  clearTimeout(saveTimer);
+  saveTimer = undefined;
+}
 
 function debouncedSave(state: WindowManagerState) {
+  if (!layoutPersistenceArmed) return;
   clearTimeout(saveTimer);
   saveTimer = setTimeout(() => {
     if (isPreVpsBillingSetupRoute()) return;
@@ -175,6 +187,7 @@ export const useWindowManager = create<WindowManagerState & WindowManagerActions
     fullscreenWindowId: null,
 
     openWindow: (name, path, dockXOffset) => {
+      markUserLayoutMutation();
       set((state) => {
         const launchTimes = { ...state.appLaunchTimes, [path]: Date.now() };
         const existing = state.windows.find((w) => w.path === path);
@@ -214,6 +227,7 @@ export const useWindowManager = create<WindowManagerState & WindowManagerActions
     },
 
     openWindowExclusive: (name, path, dockXOffset, basePath) => {
+      markUserLayoutMutation();
       set((state) => {
         const keepPath = basePath ?? path;
         const isSameApp = (w: AppWindow) =>
@@ -245,6 +259,7 @@ export const useWindowManager = create<WindowManagerState & WindowManagerActions
     },
 
     closeWindow: (id) => {
+      markUserLayoutMutation();
       set((state) => {
         const win = state.windows.find((w) => w.id === id);
         const newClosed = new Set(state.closedPaths);
@@ -270,6 +285,7 @@ export const useWindowManager = create<WindowManagerState & WindowManagerActions
     },
 
     minimizeWindow: (id) => {
+      markUserLayoutMutation();
       set((state) => ({
         windows: state.windows.map((w) =>
           w.id === id ? { ...w, minimized: true } : w,
@@ -279,6 +295,7 @@ export const useWindowManager = create<WindowManagerState & WindowManagerActions
     },
 
     restoreWindow: (id) => {
+      markUserLayoutMutation();
       set((state) => ({
         windows: state.windows.map((w) =>
           w.id === id ? { ...w, minimized: false } : w,
@@ -287,6 +304,7 @@ export const useWindowManager = create<WindowManagerState & WindowManagerActions
     },
 
     restoreAndFocusWindow: (id) => {
+      markUserLayoutMutation();
       set((state) => ({
         windows: state.windows.map((w) =>
           w.id === id ? { ...w, minimized: false, zIndex: state.nextZ } : w,
@@ -297,6 +315,7 @@ export const useWindowManager = create<WindowManagerState & WindowManagerActions
     },
 
     moveWindow: (id, x, y) => {
+      markUserLayoutMutation();
       set((state) => ({
         windows: state.windows.map((w) =>
           w.id === id ? { ...w, x, y } : w,
@@ -305,6 +324,7 @@ export const useWindowManager = create<WindowManagerState & WindowManagerActions
     },
 
     resizeWindow: (id, width, height) => {
+      markUserLayoutMutation();
       set((state) => ({
         windows: state.windows.map((w) => {
           if (w.id !== id) return w;
@@ -319,6 +339,7 @@ export const useWindowManager = create<WindowManagerState & WindowManagerActions
     },
 
     focusWindow: (id) => {
+      markUserLayoutMutation();
       set((state) => ({
         windows: state.windows.map((w) =>
           w.id === id ? { ...w, zIndex: state.nextZ } : w,
@@ -329,6 +350,7 @@ export const useWindowManager = create<WindowManagerState & WindowManagerActions
     },
 
     clearFocus: () => {
+      markUserLayoutMutation();
       set({ focusedWindowId: null });
     },
 
@@ -391,6 +413,7 @@ export const useWindowManager = create<WindowManagerState & WindowManagerActions
     },
 
     setWindows: (updater) => {
+      markUserLayoutMutation();
       set((state) => {
         const windows = typeof updater === "function" ? updater(state.windows) : updater;
         const focusedWindow = state.focusedWindowId
@@ -410,6 +433,7 @@ export const useWindowManager = create<WindowManagerState & WindowManagerActions
     },
 
     cascadeWindows: (startX, startY, gap) => {
+      markUserLayoutMutation();
       set((state) => ({
         windows: state.windows.map((w, i) => ({
           ...w,
@@ -420,6 +444,7 @@ export const useWindowManager = create<WindowManagerState & WindowManagerActions
     },
 
     toggleFullscreen: (id) => {
+      markUserLayoutMutation();
       set((state) => ({
         fullscreenWindowId: state.fullscreenWindowId === id ? null : id,
         focusedWindowId: id,
@@ -427,6 +452,7 @@ export const useWindowManager = create<WindowManagerState & WindowManagerActions
     },
 
     exitFullscreen: () => {
+      markUserLayoutMutation();
       set({ fullscreenWindowId: null });
     },
   })),

--- a/tests/gateway/shell-bootstrap.test.ts
+++ b/tests/gateway/shell-bootstrap.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { buildShellBootstrap } from "../../packages/gateway/src/shell-bootstrap.js";
+
+describe("shell bootstrap", () => {
+  let homePath: string;
+
+  beforeEach(async () => {
+    homePath = await mkdtemp(join(tmpdir(), "shell-bootstrap-"));
+    await mkdir(join(homePath, "system/icons"), { recursive: true });
+    await mkdir(join(homePath, "apps/notes"), { recursive: true });
+  });
+
+  afterEach(async () => {
+    await rm(homePath, { recursive: true, force: true });
+  });
+
+  it("returns layout, modules, apps, and versioned icon URLs", async () => {
+    await writeFile(join(homePath, "system/layout.json"), JSON.stringify({
+      windows: [{ path: "__terminal__", title: "Terminal", x: 0, y: 0, width: 640, height: 480, state: "open" }],
+    }));
+    await writeFile(join(homePath, "system/modules.json"), JSON.stringify([
+      { name: "Worker", path: "apps/worker", status: "active" },
+    ]));
+    await writeFile(join(homePath, "system/icons/terminal.png"), "terminal");
+    await writeFile(join(homePath, "system/icons/notes.png"), "notes");
+    await writeFile(join(homePath, "apps/notes/index.html"), "<html></html>");
+    await writeFile(join(homePath, "apps/notes/matrix.json"), JSON.stringify({
+      name: "Notes",
+      slug: "notes",
+      icon: "notes",
+      version: "1.0.0",
+      runtimeVersion: "^1.0.0",
+      runtime: "static",
+    }));
+
+    const bootstrap = await buildShellBootstrap(homePath);
+
+    expect(bootstrap.layout.windows).toHaveLength(1);
+    expect(bootstrap.modules).toEqual([{ name: "Worker", path: "apps/worker", status: "active" }]);
+    expect(bootstrap.apps.map((app) => app.name)).toEqual(["Notes"]);
+    expect(bootstrap.icons.terminal.versionedUrl).toMatch(/^\/icons\/terminal\.png\?v=/);
+    expect(bootstrap.icons.notes.versionedUrl).toMatch(/^\/icons\/notes\.png\?v=/);
+    expect(bootstrap.icons.notes.etag).toMatch(/^".+"$/);
+  });
+
+  it("uses safe empty defaults when layout and modules are missing", async () => {
+    await writeFile(join(homePath, "system/icons/game-center.png"), "fallback");
+
+    const bootstrap = await buildShellBootstrap(homePath);
+
+    expect(bootstrap.layout).toEqual({});
+    expect(bootstrap.modules).toEqual([]);
+    expect(bootstrap.apps).toEqual([]);
+  });
+
+  it("uses existing icon fallback resolution for missing app icons", async () => {
+    await writeFile(join(homePath, "system/icons/game-center.png"), "fallback");
+    await writeFile(join(homePath, "apps/notes/index.html"), "<html></html>");
+    await writeFile(join(homePath, "apps/notes/matrix.json"), JSON.stringify({
+      name: "Notes",
+      slug: "notes",
+      icon: "notes",
+      version: "1.0.0",
+      runtimeVersion: "^1.0.0",
+      runtime: "static",
+    }));
+
+    const bootstrap = await buildShellBootstrap(homePath);
+
+    expect(bootstrap.icons.notes.url).toBe("/icons/game-center.png");
+    expect(bootstrap.icons.notes.versionedUrl).toMatch(/^\/icons\/game-center\.png\?v=/);
+  });
+});

--- a/tests/platform/proxy-routing.test.ts
+++ b/tests/platform/proxy-routing.test.ts
@@ -866,7 +866,7 @@ describe("platform proxy routing", () => {
     expect(assetHeaders.get("cookie")).toBeNull();
     expect(res.headers.get("access-control-allow-origin")).toBe("null");
     expect(res.headers.get("access-control-allow-credentials")).toBe("true");
-    expect(res.headers.get("cache-control")).toBe("private, no-store");
+    expect(res.headers.get("cache-control")).toBe("private, max-age=31536000, immutable");
     expect(res.headers.get("vary")).toContain("Origin");
     expect(res.headers.get("vary")).toContain("Cookie");
     expect(res.headers.get("vary")).toContain("Accept-Encoding");
@@ -3294,7 +3294,7 @@ describe("platform proxy routing", () => {
     expect(url).toBe("https://203.0.113.33:443/_next/static/chunks/app.js");
     const headers = init?.headers as Headers;
     expect(headers.get("x-platform-user-id")).toBe("user_alice");
-    expect(res.headers.get("cache-control")).toBe("private, no-store");
+    expect(res.headers.get("cache-control")).toBe("private, max-age=31536000, immutable");
     expect(res.headers.get("set-cookie")).toContain("matrix_shell_route=alice-staging");
   });
 
@@ -4381,6 +4381,99 @@ describe("platform proxy routing", () => {
     }
   });
 
+  it("routes app-domain icons directly to the runtime gateway", async () => {
+    const verifyToken = vi.fn().mockResolvedValue({ sub: "user_alice" });
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response("icon", {
+        status: 200,
+        headers: { "content-type": "image/png", etag: '"icon-etag"', "cache-control": "no-store" },
+      }),
+    );
+    const app = createApp({
+      db,
+      docker: stubDocker(),
+      orchestrator: stubOrchestrator(),
+      clerkAuth: createClerkAuth({ verifyToken }),
+      platformSecret: "platform-secret-123",
+    });
+
+    const res = await app.request("/icons/workspace.png?v=icon-etag", {
+      headers: {
+        host: "app.matrix-os.com",
+        authorization: "Bearer clerk-session-jwt",
+      },
+    });
+
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe("icon");
+    const [url] = fetchMock.mock.calls[0]!;
+    expect(url).toBe("http://172.18.0.14:4000/icons/workspace.png?v=icon-etag");
+  });
+
+  it("uses private browser caching and disables shared CDN cache for app-domain static assets", async () => {
+    const verifyToken = vi.fn().mockResolvedValue({ sub: "user_alice" });
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response("chunk", {
+        status: 200,
+        headers: {
+          "content-type": "application/javascript",
+          "cache-control": "no-store",
+          "cdn-cache-control": "public, max-age=31536000",
+        },
+      }),
+    );
+    const app = createApp({
+      db,
+      docker: stubDocker(),
+      orchestrator: stubOrchestrator(),
+      clerkAuth: createClerkAuth({ verifyToken }),
+      platformSecret: "platform-secret-123",
+    });
+
+    const res = await app.request("/_next/static/chunks/app-shell-abc123.js", {
+      headers: {
+        host: "app.matrix-os.com",
+        authorization: "Bearer clerk-session-jwt",
+      },
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get("cache-control")).toBe("private, max-age=31536000, immutable");
+    expect(res.headers.get("cdn-cache-control")).toBe("no-store");
+    expect(res.headers.get("cloudflare-cdn-cache-control")).toBe("no-store");
+    expect(res.headers.get("vary")).toContain("Cookie");
+    expect(res.headers.get("vary")).toContain("Accept-Encoding");
+  });
+
+  it("uses short private browser caching for unversioned release-owned app-domain assets", async () => {
+    const verifyToken = vi.fn().mockResolvedValue({ sub: "user_alice" });
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response("font", {
+        status: 200,
+        headers: { "content-type": "font/woff2", "cache-control": "no-store" },
+      }),
+    );
+    const app = createApp({
+      db,
+      docker: stubDocker(),
+      orchestrator: stubOrchestrator(),
+      clerkAuth: createClerkAuth({ verifyToken }),
+      platformSecret: "platform-secret-123",
+    });
+
+    const res = await app.request("/fonts/inter.woff2", {
+      headers: {
+        host: "app.matrix-os.com",
+        authorization: "Bearer clerk-session-jwt",
+      },
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get("cache-control")).toBe("private, max-age=86400");
+    expect(res.headers.get("cdn-cache-control")).toBe("no-store");
+    expect(res.headers.get("cloudflare-cdn-cache-control")).toBe("no-store");
+  });
+
   it("routes app-domain shell static assets with the short-lived shell route cookie", async () => {
     await insertUserMachine(db, {
       machineId: "machine-alice",
@@ -4429,7 +4522,7 @@ describe("platform proxy routing", () => {
     expect(headers.get("x-platform-verified")).toBeNull();
     expect(res.headers.get("content-encoding")).toBeNull();
     expect(res.headers.get("content-length")).toBeNull();
-    expect(res.headers.get("cache-control")).toBe("private, no-store");
+    expect(res.headers.get("cache-control")).toBe("private, max-age=31536000, immutable");
     expect(res.headers.get("cdn-cache-control")).toBe("no-store");
     expect(res.headers.get("cloudflare-cdn-cache-control")).toBe("no-store");
     expect(res.headers.get("vary")).toContain("Cookie");

--- a/tests/shell/connection-health.test.ts
+++ b/tests/shell/connection-health.test.ts
@@ -5,11 +5,11 @@ describe("ConnectionHealth store", () => {
     vi.resetModules();
   });
 
-  it("defaults to disconnected state", async () => {
+  it("defaults to initializing state", async () => {
     const { useConnectionHealth } = await import(
       "../../shell/src/hooks/useConnectionHealth.js"
     );
-    expect(useConnectionHealth.getState().state).toBe("disconnected");
+    expect(useConnectionHealth.getState().state).toBe("initializing");
   });
 
   it("updates state via setState", async () => {
@@ -26,5 +26,13 @@ describe("ConnectionHealth store", () => {
     );
     useConnectionHealth.setState({ state: "reconnecting" });
     expect(useConnectionHealth.getState().state).toBe("reconnecting");
+  });
+
+  it("supports disconnected state", async () => {
+    const { useConnectionHealth } = await import(
+      "../../shell/src/hooks/useConnectionHealth.js"
+    );
+    useConnectionHealth.setState({ state: "disconnected" });
+    expect(useConnectionHealth.getState().state).toBe("disconnected");
   });
 });

--- a/tests/shell/connection-indicator.test.tsx
+++ b/tests/shell/connection-indicator.test.tsx
@@ -32,12 +32,49 @@ describe("ConnectionIndicator", () => {
   });
 
   afterEach(() => {
+    vi.useRealTimers();
     vi.restoreAllMocks();
     vi.unstubAllGlobals();
     mocks.manualReconnect.mockReset();
     act(() => {
-      useConnectionHealth.setState({ state: "disconnected" });
+      useConnectionHealth.setState({ state: "initializing" });
     });
+  });
+
+  it("stays hidden and does not probe health during normal initial connection", () => {
+    vi.useFakeTimers();
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    act(() => {
+      useConnectionHealth.setState({ state: "initializing" });
+    });
+
+    render(<ConnectionIndicator />);
+
+    expect(screen.queryByRole("status", { name: /matrix connection status/i })).toBeNull();
+    act(() => {
+      vi.advanceTimersByTime(2_499);
+    });
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(screen.queryByRole("status", { name: /matrix connection status/i })).toBeNull();
+  });
+
+  it("shows the warning if initial connection exceeds the grace period", async () => {
+    vi.useFakeTimers();
+    act(() => {
+      useConnectionHealth.setState({ state: "initializing" });
+    });
+    vi.stubGlobal("fetch", vi.fn(() => Promise.reject(new Error("gateway down"))));
+
+    render(<ConnectionIndicator />);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2_500);
+      await Promise.resolve();
+    });
+
+    expect(screen.getByRole("status", { name: /matrix connection status/i })).toBeTruthy();
+    expect(screen.getByText("Checking connection")).toBeTruthy();
   });
 
   it("describes gateway-online reconnects instead of a generic reconnecting label", async () => {
@@ -117,6 +154,14 @@ describe("ConnectionIndicator", () => {
 });
 
 describe("resolveConnectionCopy", () => {
+  it("uses quiet initial connection copy after grace", () => {
+    expect(resolveConnectionCopy("initializing", { reachability: "checking" })).toMatchObject({
+      title: "Checking connection",
+      detail: expect.stringContaining("opening"),
+      action: "Retry now",
+    });
+  });
+
   it("uses precise copy for disconnected but reachable runtimes", () => {
     expect(resolveConnectionCopy("disconnected", { reachability: "online" })).toMatchObject({
       title: "Connection lost",

--- a/tests/shell/dock-icon-resolution.test.ts
+++ b/tests/shell/dock-icon-resolution.test.ts
@@ -2,6 +2,15 @@ import { readFile } from "node:fs/promises";
 import { describe, expect, it } from "vitest";
 
 describe("dock icon resolution", () => {
+  it("boots Desktop from the shell bootstrap endpoint instead of separate app/layout fetches", async () => {
+    const source = await readFile("shell/src/components/Desktop.tsx", "utf8");
+
+    expect(source).toContain("/api/shell/bootstrap");
+    expect(source).not.toContain("/api/layout`,");
+    expect(source).not.toContain("/api/apps`,");
+    expect(source).not.toContain("/files/system/modules.json");
+  });
+
   it("uses the shared icon resolver in Desktop instead of a PNG-only local helper", async () => {
     const source = await readFile("shell/src/components/Desktop.tsx", "utf8");
 
@@ -9,16 +18,17 @@ describe("dock icon resolution", () => {
     expect(source).not.toContain("function iconUrlForSlug");
     expect(source).not.toContain("/icons/${encodeURIComponent(slug)}.png");
     expect(source).not.toContain("const iconPath = `/icons/${slug}.png`");
-    expect(source).toContain("const iconPath = iconUrlForSlug(slug)");
+    expect(source).toContain("bootstrap.icons?.[slug]?.versionedUrl ?? iconUrlForSlug(slug)");
+    expect(source).not.toContain("method: \"HEAD\"");
   });
 
   it("uses dedicated raster slugs for built-in launcher apps", async () => {
     const source = await readFile("shell/src/components/Desktop.tsx", "utf8");
 
-    expect(source).toContain("addApp(\"Terminal\", \"__terminal__\", \"terminal\")");
-    expect(source).toContain("addApp(\"Workspace\", \"__workspace__\", \"workspace\")");
-    expect(source).toContain("addApp(\"Files\", \"__file-browser__\", \"files\")");
-    expect(source).toContain("addApp(\"Hermes\", \"__chat__\", \"chat\")");
+    expect(source).toContain("addApp(\"Terminal\", \"__terminal__\", \"terminal\", iconForSlug(\"terminal\"))");
+    expect(source).toContain("addApp(\"Workspace\", \"__workspace__\", \"workspace\", iconForSlug(\"workspace\"))");
+    expect(source).toContain("addApp(\"Files\", \"__file-browser__\", \"files\", iconForSlug(\"files\"))");
+    expect(source).toContain("addApp(\"Hermes\", \"__chat__\", \"chat\", iconForSlug(\"chat\"))");
   });
 
   it("preserves versioned desktop icon URLs when app registration refreshes", async () => {

--- a/tests/shell/terminal-app-component.test.tsx
+++ b/tests/shell/terminal-app-component.test.tsx
@@ -150,6 +150,50 @@ describe("TerminalApp", () => {
     });
   });
 
+  it("does not immediately save after hydrating a saved terminal layout", async () => {
+    const fetchMock = vi.mocked(fetch);
+    fetchMock.mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.includes("/api/files/tree")) {
+        return Promise.resolve({ ok: true, json: async () => [] } as Response);
+      }
+      if (url.includes("/api/terminal/layout") && init?.method === "PUT") {
+        return Promise.resolve({ ok: true, json: async () => ({ ok: true }) } as Response);
+      }
+      if (url.includes("/api/terminal/layout")) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            activeTabId: "tab-saved",
+            sidebarOpen: true,
+            tabs: [{
+              id: "tab-saved",
+              label: "Saved",
+              paneTree: { type: "pane", id: "pane-saved", cwd: "projects/app" },
+            }],
+          }),
+        } as Response);
+      }
+      return Promise.resolve({ ok: true, json: async () => ({}) } as Response);
+    });
+
+    render(<TerminalApp />);
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    await act(async () => {
+      vi.advanceTimersByTime(600);
+    });
+
+    const layoutPutCalls = fetchMock.mock.calls.filter((call) => (
+      String(call[0]).includes("/api/terminal/layout") && call[1]?.method === "PUT"
+    ));
+    expect(layoutPutCalls).toHaveLength(0);
+  });
+
   it("does not render workspace transport ids as managed shell sessions", async () => {
     render(<TerminalApp initialSessionId="matrix-sess_run_db0dded67faaca6b" />);
 
@@ -1123,7 +1167,7 @@ describe("TerminalApp", () => {
     expect(screen.getByRole("button", { name: "Make matrix-main active" })).toBeTruthy();
   });
 
-  it("focuses active shell rows without creating duplicate attached tabs", async () => {
+  it("focuses active shell rows without creating duplicate attached tabs or layout save noise", async () => {
     render(<TerminalApp />);
 
     await act(async () => {
@@ -1147,10 +1191,7 @@ describe("TerminalApp", () => {
     const layoutSaveCalls = fetchMock.mock.calls.filter(([input, init]) => (
       String(input).includes("/api/terminal/layout") && init?.method === "PUT"
     ));
-    expect(layoutSaveCalls.length).toBeGreaterThan(0);
-    const latestBody = layoutSaveCalls.at(-1)?.[1]?.body;
-    expect(typeof latestBody).toBe("string");
-    expect(JSON.parse(latestBody as string).tabs).toHaveLength(1);
+    expect(layoutSaveCalls).toHaveLength(0);
   });
 
   it("renders a mobile sessions surface with compact foreground and background toggles", async () => {
@@ -1556,8 +1597,7 @@ describe("TerminalApp", () => {
     const layoutSave = vi.mocked(global.fetch).mock.calls.find(([input, init]) => (
       String(input).includes("/api/terminal/layout") && init?.method === "PUT"
     ));
-    expect(layoutSave).toBeTruthy();
-    expect(JSON.parse(String(layoutSave?.[1]?.body))).not.toHaveProperty("sidebarOpen");
+    expect(layoutSave).toBeUndefined();
   });
 
   it("starts normal terminal tabs on the canonical main shell session", async () => {

--- a/tests/shell/useSocket.test.ts
+++ b/tests/shell/useSocket.test.ts
@@ -247,7 +247,7 @@ describe("useSocket heartbeat and resilience", () => {
     expect(queued).toHaveLength(2);
   });
 
-  it("captures websocket reconnect and connected telemetry", async () => {
+  it("captures websocket connected and reconnect telemetry", async () => {
     vi.resetModules();
     const capturePostHogEvent = vi.fn();
     vi.doMock("@/lib/posthog-client", () => ({
@@ -261,10 +261,19 @@ describe("useSocket heartbeat and resilience", () => {
     ensureConnected();
     await vi.advanceTimersByTimeAsync(0);
 
+    expect(capturePostHogEvent).toHaveBeenCalledWith(MATRIX_TELEMETRY_EVENTS.SHELL_WS_CONNECTED);
+    expect(capturePostHogEvent).not.toHaveBeenCalledWith(
+      MATRIX_TELEMETRY_EVENTS.SHELL_WS_RECONNECT_STARTED,
+      expect.anything(),
+    );
+
+    const ws1 = MockWebSocket.instances[0];
+    ws1.readyState = 3;
+    ws1.onclose?.();
+
     expect(capturePostHogEvent).toHaveBeenCalledWith(
       MATRIX_TELEMETRY_EVENTS.SHELL_WS_RECONNECT_STARTED,
       expect.objectContaining({ attempt: 0, visibility: "visible" }),
     );
-    expect(capturePostHogEvent).toHaveBeenCalledWith(MATRIX_TELEMETRY_EVENTS.SHELL_WS_CONNECTED);
   });
 });

--- a/tests/shell/useSocket.test.ts
+++ b/tests/shell/useSocket.test.ts
@@ -276,4 +276,26 @@ describe("useSocket heartbeat and resilience", () => {
       expect.objectContaining({ attempt: 0, visibility: "visible" }),
     );
   });
+
+  it("shows reconnecting feedback when manual retry is clicked during initialization", async () => {
+    vi.resetModules();
+    const capturePostHogEvent = vi.fn();
+    vi.doMock("@/lib/posthog-client", () => ({
+      capturePostHogEvent,
+      capturePostHogException: vi.fn(),
+    }));
+    vi.stubGlobal("WebSocket", MockWebSocket);
+    vi.stubGlobal("document", { addEventListener: vi.fn(), visibilityState: "visible" });
+
+    const { getConnectionState, manualReconnect } = await import("../../shell/src/hooks/useSocket.js");
+
+    expect(getConnectionState()).toBe("initializing");
+    manualReconnect();
+
+    expect(getConnectionState()).toBe("reconnecting");
+    expect(capturePostHogEvent).toHaveBeenCalledWith(
+      MATRIX_TELEMETRY_EVENTS.SHELL_WS_RECONNECT_STARTED,
+      expect.objectContaining({ attempt: 0, visibility: "visible" }),
+    );
+  });
 });

--- a/tests/shell/window-manager.test.ts
+++ b/tests/shell/window-manager.test.ts
@@ -2,6 +2,7 @@
 import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
 import {
   useWindowManager,
+  resetWindowManagerLayoutPersistenceForTests,
   type AppWindow,
   type LayoutWindow,
 } from "../../shell/src/hooks/useWindowManager.js";
@@ -10,6 +11,7 @@ const fetchSpy = vi.fn().mockResolvedValue({ ok: true });
 vi.stubGlobal("fetch", fetchSpy);
 
 function resetStore() {
+  resetWindowManagerLayoutPersistenceForTests();
   useWindowManager.setState({
     windows: [],
     nextZ: 1,
@@ -246,6 +248,22 @@ describe("Window Manager Store", () => {
       expect(windows.find((w) => w.path === "apps/notes.html")?.minimized).toBe(false);
       expect(windows.find((w) => w.path === "apps/todo.html")?.minimized).toBe(true);
       expect(closedPaths.has("apps/closed.html")).toBe(true);
+    });
+
+    it("does not save immediately while hydrating server layout", () => {
+      const saved: LayoutWindow[] = [
+        {
+          path: "apps/notes.html",
+          title: "Notes",
+          x: 100, y: 100, width: 800, height: 600,
+          state: "open",
+        },
+      ];
+
+      useWindowManager.getState().loadLayout(saved);
+      vi.advanceTimersByTime(500);
+
+      expect(fetchSpy).not.toHaveBeenCalled();
     });
   });
 });


### PR DESCRIPTION
## Summary

- add `GET /api/shell/bootstrap` so shell boot loads layout, modules, apps, and versioned icon URLs in one gateway request
- make app-domain runtime static assets privately browser-cacheable while keeping shared/CDN caches disabled
- route `/icons/*` directly to the runtime gateway on `app.matrix-os.com`
- hide the connection warning during normal initial websocket startup and avoid initial `/health` probing
- prevent desktop and terminal layout hydration from immediately issuing layout PUTs

## Tests

- `pnpm exec vitest run tests/gateway/shell-bootstrap.test.ts tests/gateway/icon-routes.test.ts tests/platform/proxy-routing.test.ts tests/shell/dock-icon-resolution.test.ts tests/shell/window-manager.test.ts tests/shell/connection-health.test.ts tests/shell/connection-indicator.test.tsx tests/shell/useSocket.test.ts tests/shell/terminal-app-component.test.tsx`
- `pnpm exec vitest run tests/shell/useSocket.test.ts tests/shell/connection-indicator.test.tsx tests/shell/connection-health.test.ts`
- `pnpm --filter './shell' exec tsc --noEmit`
- `pnpm --filter '@matrix-os/gateway' exec tsc --noEmit`
- `pnpm --filter '@matrix-os/platform' exec tsc --noEmit -p tsconfig.typecheck.json`
- `pnpm --filter '@matrix-os/observability' exec tsc --noEmit`
- `pnpm --filter '@matrix-os/proxy' exec tsc --noEmit`
- `pnpm --filter '@matrix-os/edge-router' exec tsc --noEmit`
- `pnpm --filter desktop run typecheck`
- `pnpm run check:patterns`
- `npx react-doctor@latest shell`

Full-suite note:

- `pnpm test` was run because `bun` is not installed in this environment. It failed on baseline/environment issues that reproduce in isolation:
  - `tests/cli/doctor.test.ts` reads the real local Matrix profile and sees `http://127.0.0.1:4000` instead of the test's expected `http://localhost:4000`
  - `tests/mcp-browser/server.test.ts` cannot create `/tmp/test/data/browser-profiles/default` because `/tmp/test` is owned by `deploy`
  - `tests/gateway/sync/home-mirror.test.ts` cannot overwrite `/tmp/outside-target.txt` and `/tmp/escaped-delete.txt`, also owned by `deploy`
  - the branch-related `tests/shell/useSocket.test.ts` failure from the first full run was fixed and passes in the focused rerun

## Review/Monitoring

- First Greptile pass on `7b44ac25` reported 4/5 with two shell UX findings.
- Follow-up commit `59b5435b` fixes both findings:
  - removes the extra `ConnectionIndicator` grace-timer dependency
  - makes manual retry during `initializing` transition to `reconnecting` with telemetry
- Latest Greptile result for `59b5435b`: 5/5.

## Invariants

- **Source of truth**: gateway home files remain canonical for layout, modules, app manifests, and shipped icons; platform only adjusts routing/cache response headers for app-domain runtime assets.
- **Lock/transaction scope**: no new database writes or cross-resource transactions are introduced. Bootstrap performs read-only filesystem/app manifest aggregation; layout writes remain existing debounced user-initiated PUTs.
- **Acceptable orphan states**: missing layout/modules files return safe empty defaults. Missing app icons use the existing gateway icon fallback. If bootstrap fails, existing client fallback behavior still uses local icon URL construction for any missing icon entry.
- **Auth source of truth**: gateway bootstrap is mounted behind the existing gateway auth middleware. Platform routing continues to use existing Clerk/session/sync-JWT resolution and preserves cookie-aware `Vary` semantics for user-routed assets.
- **Deferred scope**: this does not re-enable the root service worker on `app.matrix-os.com`, does not add public/CDN caching for user-routed assets, does not broadly change API `no-store` behavior, and does not perform platform/app-shell deployment or host-bundle publish.

## Manual Verification

- Not captured in this environment. Runtime deployment verification still needs a fresh HAR and screenshot/recording after platform/app-shell deployment plus host-bundle publish/deploy.
