### PR TITLE
docs(architecture): add domain boundary foundation

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -34,6 +34,11 @@ Production customer runtime is VPS-native. Do not model new user-facing runtime 
 | `packages/platform/` | Clerk auth, customer VPS lifecycle, billing/provisioning gates, host-bundle release metadata, platform-owned integrations | Owner app data, per-owner runtime internals |
 | `packages/proxy/` | Shared API proxy, usage and quota accounting | Product-domain state or shell behavior |
 | `packages/sync-client/` | CLI, sync daemon, local profile/session commands | Gateway route ownership or platform provisioning |
+| `packages/observability/` | Shared telemetry, PostHog wiring, and error tracking helpers | Product-domain behavior or user-owned data |
+| `packages/edge-router/` | Edge routing helpers and Cloudflare-facing routing code | Owner runtime state or shell UI policy |
+| `packages/neo-worker/` | Cloudflare Worker surface for PostHog/edge support paths | Owner runtime APIs or platform database ownership |
+| `packages/mcp-browser/` | Browser automation MCP helpers and browser security utilities | Shell renderer state or app data persistence |
+| `packages/clerk-sync/` | Clerk user/profile synchronization helpers | General platform provisioning or owner app data |
 | `packages/ui/` | Shared UI primitives used by shells/apps | Domain business rules |
 | `shell/` | Browser shell renderer, Canvas/Desktop windows, frontend stores | Canonical backend source of truth |
 | `desktop/` | Desktop package/runtime integration | Web-only shell product logic |

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,95 @@
+# Matrix OS Architecture
+
+Matrix OS is a Web 4 operating system: the AI kernel, gateway, platform, owner-controlled data, and app runtime are headless; shells render and operate those capabilities.
+
+This document is the root map for contributors. Package-specific architecture notes should link back here instead of redefining system boundaries.
+
+## Runtime Shape
+
+```text
+matrix-os.com / app.matrix-os.com
+  |-- www/                 public docs, marketing, signup entry points
+  |-- shell/               web shell renderer for owner runtime
+  |-- desktop/             desktop shell packaging/runtime
+  |
+  +-- packages/platform/   control plane: auth, billing, VPS provisioning, routing
+      |
+      +-- customer VPS per owner
+          |-- packages/gateway/       HTTP, WebSocket, app bridge, channel adapters
+          |-- packages/kernel/        AI kernel, agents, tools, skills
+          |-- packages/sync-client/   CLI and sync daemon
+          |-- home/                   owner-visible OS template and default apps
+          +-- owner Postgres          canonical app/workspace/social data
+```
+
+Production customer runtime is VPS-native. Do not model new user-facing runtime behavior around shared platform containers, Docker Compose rollouts, or platform-owned app data.
+
+## Top-Level Areas
+
+| Path | Responsibility | Should Not Own |
+|------|----------------|----------------|
+| `packages/kernel/` | AI kernel, Agent SDK integration, agent/tool orchestration, skills | HTTP routing, shell rendering, platform billing |
+| `packages/gateway/` | Owner runtime API, WebSockets, app bridge, filesystem bridge, channel adapters | Platform auth/control-plane state, shell UI policy |
+| `packages/platform/` | Clerk auth, customer VPS lifecycle, billing/provisioning gates, host-bundle release metadata, platform-owned integrations | Owner app data, per-owner runtime internals |
+| `packages/proxy/` | Shared API proxy, usage and quota accounting | Product-domain state or shell behavior |
+| `packages/sync-client/` | CLI, sync daemon, local profile/session commands | Gateway route ownership or platform provisioning |
+| `packages/ui/` | Shared UI primitives used by shells/apps | Domain business rules |
+| `shell/` | Browser shell renderer, Canvas/Desktop windows, frontend stores | Canonical backend source of truth |
+| `desktop/` | Desktop package/runtime integration | Web-only shell product logic |
+| `www/` | Public website and docs | Runtime-only shell behavior |
+| `home/` | Owner-visible OS files, default apps, icons, templates | Hidden platform state |
+| `specs/` | Product/architecture specs and quality gates | Implementation-only scratch plans |
+| `tests/` | Cross-package Vitest suites | Runtime code |
+
+## Source-Of-Truth Rules
+
+- Identity/config/export state lives in inspectable owner files under `home/` or the deployed owner home.
+- App, workspace, social, and durable runtime data live in owner-controlled Postgres through Kysely.
+- Platform-owned data is limited to control-plane state: auth linkage, billing/provisioning status, release metadata, routing, and platform-owned integration credentials.
+- Shell stores are renderer state. They may cache or optimistically stage data, but backend files/Postgres remain canonical.
+- Default apps under `home/apps/**` use the Matrix bridge, not direct fetches to `/api/bridge/*`.
+
+## Domain Boundary Direction
+
+The current repo has infrastructure-oriented packages. As product domains become large enough to extract, prefer domain packages with explicit boundary docs instead of growing gateway or shell catch-all modules.
+
+Recommended dependency direction:
+
+```text
+shell/ or apps/*
+  -> packages/ui
+  -> domain package API/types
+  -> packages/gateway route adapters
+  -> packages/kernel/platform/proxy infrastructure as needed
+```
+
+Rules:
+
+- A domain package may expose pure types, validators, repository/service interfaces, and route registration helpers.
+- Gateway/platform packages may adapt HTTP/auth/runtime dependencies into domain APIs.
+- Domain packages must not import renderer components from `shell/` or `www/`.
+- Domain packages must not bypass owner data rules with a new database or ORM.
+- Cross-domain calls should go through explicit service interfaces or stable public functions, not deep imports from another domain's internals.
+- If `packages/domains/*` is introduced, update `pnpm-workspace.yaml` before adding packages there.
+
+## When To Extract A Domain
+
+Extract a package or add a package-level `DOMAIN.md` when at least two of these are true:
+
+- The feature spans gateway routes, shell UI, persistence, tests, and docs.
+- Multiple files import the same domain schemas/helpers across packages.
+- Reviewers need domain invariants to judge changes safely.
+- The feature has its own source-of-truth, auth, concurrency, or recovery policy.
+- The gateway or shell module has become a catch-all for unrelated behavior.
+
+Do not extract only to move files around. The first useful extraction is usually documentation plus a narrow public API.
+
+## Change Workflow
+
+For architecture-affecting changes:
+
+1. Add or update the relevant spec under `specs/` when behavior changes.
+2. Update this root map if ownership or dependency direction changes.
+3. Add or update a `DOMAIN.md` near the domain code when domain invariants matter.
+4. Keep PRs split by boundary: docs, gateway, platform, shell, sync-client, or one domain package.
+5. Run the normal review gates from `docs/dev/review-pipeline.md`.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -11,6 +11,7 @@ matrix-os.com / app.matrix-os.com
   |-- www/                 public docs, marketing, signup entry points
   |-- shell/               web shell renderer for owner runtime
   |-- desktop/             desktop shell packaging/runtime
+  |-- apps/                companion app surfaces, including mobile and menu bar
   |
   +-- packages/platform/   control plane: auth, billing, VPS provisioning, routing
       |
@@ -36,6 +37,7 @@ Production customer runtime is VPS-native. Do not model new user-facing runtime 
 | `packages/ui/` | Shared UI primitives used by shells/apps | Domain business rules |
 | `shell/` | Browser shell renderer, Canvas/Desktop windows, frontend stores | Canonical backend source of truth |
 | `desktop/` | Desktop package/runtime integration | Web-only shell product logic |
+| `apps/` | Companion shell surfaces such as mobile and menu bar apps | Canonical backend source of truth or platform control-plane ownership |
 | `www/` | Public website and docs | Runtime-only shell behavior |
 | `home/` | Owner-visible OS files, default apps, icons, templates | Hidden platform state |
 | `specs/` | Product/architecture specs and quality gates | Implementation-only scratch plans |

--- a/DOMAIN.md
+++ b/DOMAIN.md
@@ -1,0 +1,81 @@
+# Domain Documentation Convention
+
+Use `DOMAIN.md` to make product-domain boundaries explicit for humans and coding agents. A domain document should explain what the domain owns, what it depends on, and which invariants reviewers must preserve.
+
+Root `DOMAIN.md` defines the convention. Package or domain directories may add their own `DOMAIN.md` when they own non-trivial business behavior.
+
+## Where Domain Docs Live
+
+Preferred locations:
+
+- `packages/<package>/DOMAIN.md` for package-wide domain rules.
+- `packages/domains/<domain>/DOMAIN.md` if/when nested domain packages are introduced.
+- `shell/src/<domain>/DOMAIN.md` only for renderer-specific domain behavior that has not yet moved to a package.
+- `home/apps/<app>/DOMAIN.md` for first-party default apps with durable app-specific data.
+
+Do not create duplicate domain docs for the same source of truth. Link to the canonical document instead.
+
+## Required Sections
+
+Each non-root `DOMAIN.md` should include:
+
+```markdown
+# <Domain Name>
+
+## Scope
+- What this domain owns.
+- What is explicitly out of scope.
+
+## Source Of Truth
+- Canonical files, Postgres tables, external services, or platform rows.
+- Which caches or UI stores are derived.
+
+## Public API
+- Exported modules, route registration helpers, schemas, commands, or bridge methods other code may use.
+- Internal paths that other packages must not import.
+
+## Auth And Trust Boundaries
+- Auth source of truth.
+- Inputs requiring validation.
+- Error redaction policy.
+
+## Concurrency And Recovery
+- Transaction/lock scope.
+- Optimistic concurrency rules.
+- Acceptable orphan states and cleanup policy.
+
+## Tests
+- Focused tests that must run for domain changes.
+```
+
+## Boundary Rules
+
+- Public exports should be intentional. Avoid deep imports from another domain's `src/internal`, route files, stores, or test helpers.
+- Route handlers validate HTTP shape and auth, then call domain services. They should not become the domain model.
+- Shell components render domain state and call public APIs. They should not duplicate source-of-truth rules from services.
+- Domain services may depend on repositories and injected infrastructure, but they should not create hidden global state.
+- Any in-memory registry must document its cap, eviction, and shutdown behavior in the owning domain doc or adjacent code.
+- Any external fetch must document timeout and SSRF posture when URLs can be user-controlled.
+
+## Extraction Sequence
+
+Use this order for safe domain extraction:
+
+1. Write `DOMAIN.md` for the current code in place.
+2. Add a narrow public API or barrel for existing imports.
+3. Move pure schemas/types/helpers first.
+4. Move repository/service code after tests cover source-of-truth and failure modes.
+5. Move route adapters last, preserving endpoint behavior.
+6. Update `ARCHITECTURE.md`, specs, and public docs when ownership changes.
+
+Avoid compatibility shims unless external consumers, persisted data, or shipped behavior require them.
+
+## PR Checklist
+
+For a PR that adds or changes a domain boundary:
+
+- State whether this is documentation-only, API extraction, route move, persistence move, or renderer move.
+- Keep moved files in a separate commit when practical so reviewers can separate rename noise from behavior changes.
+- Include the backend Invariants section when backend behavior changes.
+- Run `bun run check:patterns:diff`, targeted tests, and `bun run typecheck` before opening the PR.
+- For React changes, run `npx react-doctor@latest <project-dir>`.

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -6,6 +6,8 @@ How the engineering skills should consume this repo's domain documentation when 
 
 - **`CONTEXT.md`** at the repo root, or
 - **`CONTEXT-MAP.md`** at the repo root if it exists — it points at one `CONTEXT.md` per context. Read each one relevant to the topic.
+- **`ARCHITECTURE.md`** at the repo root when touching package ownership, runtime boundaries, or cross-package dependency direction.
+- **`DOMAIN.md`** at the repo root when creating or changing a package/domain boundary, then any nearest package-level `DOMAIN.md` if it exists.
 - **`docs/adr/`** — read ADRs that touch the area you're about to work in. In multi-context repos, also check `src/<context>/docs/adr/` for context-scoped decisions.
 - **`docs/dev/vps-deployment.md`** and **`specs/070-vps-per-user/changelog.md`** when touching production routing, user containers, customer VPS hosts, host bundles, Cloudflare tunnel behavior, R2 backup/restore, or first-customer migrations.
 
@@ -18,6 +20,8 @@ Single-context repo (most repos):
 ```
 /
 ├── CONTEXT.md
+├── ARCHITECTURE.md
+├── DOMAIN.md
 ├── docs/adr/
 │   ├── 0001-event-sourced-orders.md
 │   └── 0002-postgres-for-write-model.md


### PR DESCRIPTION
## Summary
- Add root `ARCHITECTURE.md` with the Matrix OS runtime map, package ownership table, source-of-truth rules, and domain extraction guidance.
- Add root `DOMAIN.md` defining the convention for package/domain boundary docs.
- Update agent domain guidance so coding agents read the new architecture/domain docs for boundary work.

## Verification
- `./scripts/review/check-patterns.sh --diff origin/main`

## Invariants

### Source of truth
- Documentation-only change. Runtime source-of-truth rules are documented but no data ownership changes are implemented.

### Lock/transaction scope
- No runtime writes, locks, transactions, or network calls are introduced.

### Acceptable orphan states
- None. No data or runtime resources are created.

### Auth source of truth
- No auth behavior changes.

### Deferred scope
- No package moves, boundary enforcement scripts, or import rewrites are included in this foundation PR.