### PR TITLE
feat(shell): simplify developer mode dock

### DIFF
--- a/shell/src/components/Desktop.tsx
+++ b/shell/src/components/Desktop.tsx
@@ -5,7 +5,7 @@ import { useIconWithFallback } from "@/hooks/useIconWithFallback";
 import { useFileWatcher } from "@/hooks/useFileWatcher";
 import { useWindowManager, type LayoutWindow } from "@/hooks/useWindowManager";
 import { useCommandStore } from "@/stores/commands";
-import { useDesktopMode } from "@/stores/desktop-mode";
+import { useDesktopMode, type DesktopMode } from "@/stores/desktop-mode";
 import { useVocalStore } from "@/stores/vocal";
 import { useCanvasTransform } from "@/hooks/useCanvasTransform";
 import { useDesktopConfigStore } from "@/stores/desktop-config";
@@ -404,13 +404,14 @@ function DockIcon({
 function ModeSwitcher({
   iconSize,
   tooltipSide,
+  onSelectMode,
 }: {
   iconSize: number;
   tooltipSide: "left" | "right" | "top";
+  onSelectMode: (mode: DesktopMode) => void;
 }) {
   const [open, setOpen] = useState(false);
   const mode = useDesktopMode((s) => s.mode);
-  const setMode = useDesktopMode((s) => s.setMode);
   const visibleModes = useDesktopMode((s) => s.visibleModes);
   const getModeConfig = useDesktopMode((s) => s.getModeConfig);
   const modeConfig = getModeConfig(mode);
@@ -473,7 +474,7 @@ function ModeSwitcher({
               type="button"
               key={m.id}
               onClick={() => {
-                setMode(m.id);
+                onSelectMode(m.id);
                 setOpen(false);
               }}
               className={`flex items-center gap-2 px-3 py-1.5 text-xs transition-colors hover:bg-muted ${
@@ -1201,6 +1202,10 @@ export function Desktop({ launchAppPath, onOpenCommandPalette, chat }: DesktopPr
   const visibleWindowCount = windows.reduce((count, w) => count + (w.minimized ? 0 : 1), 0);
   const developerDashboardVisible = shouldShowDeveloperDashboard(firstRunStatus, desktopMode, visibleWindowCount);
   const openPrCanvas = useWorkspaceCanvasStore((s) => s.openPrCanvas);
+  const selectDesktopMode = (mode: DesktopMode) => {
+    setDesktopMode(mode);
+    if (!getModeConfig(mode).showLauncher) setTaskBoardOpen(false);
+  };
 
   // Cascade windows back to the viewport when leaving canvas. Canvas
   // positions use a wide grid that extends off-screen in other modes.
@@ -1265,7 +1270,10 @@ export function Desktop({ launchAppPath, onOpenCommandPalette, chat }: DesktopPr
       label: `Mode: ${m.label}`,
       group: "Actions" as const,
       keywords: ["mode", "layout", m.id, m.description],
-      execute: () => setDesktopMode(m.id),
+      execute: () => {
+        setDesktopMode(m.id);
+        if (!m.showLauncher) setTaskBoardOpen(false);
+      },
     }));
 
     register([
@@ -1735,7 +1743,7 @@ export function Desktop({ launchAppPath, onOpenCommandPalette, chat }: DesktopPr
                   </TooltipTrigger>
                   <TooltipContent side={tooltipSide} sideOffset={8}>Hermes</TooltipContent>
                 </Tooltip>
-                <ModeSwitcher iconSize={dock.iconSize} tooltipSide={tooltipSide} />
+                <ModeSwitcher iconSize={dock.iconSize} tooltipSide={tooltipSide} onSelectMode={selectDesktopMode} />
                 <Tooltip>
                   <TooltipTrigger asChild>
                     <button
@@ -1821,7 +1829,7 @@ export function Desktop({ launchAppPath, onOpenCommandPalette, chat }: DesktopPr
                 <KanbanSquareIcon className="size-4" />
               </button>
             )}
-            <ModeSwitcher iconSize={36} tooltipSide="top" />
+            <ModeSwitcher iconSize={36} tooltipSide="top" onSelectMode={selectDesktopMode} />
             <button
               type="button"
               onClick={() => { setSettingsOpen((prev) => !prev); setTaskBoardOpen(false); setChatOpen(false); }}

--- a/shell/src/components/Desktop.tsx
+++ b/shell/src/components/Desktop.tsx
@@ -1688,26 +1688,28 @@ export function Desktop({ launchAppPath, onOpenCommandPalette, chat }: DesktopPr
                     />
                   );
                 })}
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <button
-                      type="button"
-                      data-testid="dock-tasks"
-                      onClick={() => { setTaskBoardOpen((prev) => !prev); setSettingsOpen(false); setChatOpen(false); }}
-                      className={`flex items-center justify-center rounded-xl border shadow-sm hover:shadow-md hover:scale-105 active:scale-95 transition-all ${
-                        taskBoardOpen
-                          ? "bg-primary text-primary-foreground border-primary"
-                          : "bg-card border-border/60"
-                      }`}
-                      style={{ width: dock.iconSize, height: dock.iconSize }}
-                    >
-                      <KanbanSquareIcon className="size-4" />
-                    </button>
-                  </TooltipTrigger>
-                  <TooltipContent side={tooltipSide} sideOffset={8}>
-                    Launcher
-                  </TooltipContent>
-                </Tooltip>
+                {modeConfig.showLauncher && (
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <button
+                        type="button"
+                        data-testid="dock-tasks"
+                        onClick={() => { setTaskBoardOpen((prev) => !prev); setSettingsOpen(false); setChatOpen(false); }}
+                        className={`flex items-center justify-center rounded-xl border shadow-sm hover:shadow-md hover:scale-105 active:scale-95 transition-all ${
+                          taskBoardOpen
+                            ? "bg-primary text-primary-foreground border-primary"
+                            : "bg-card border-border/60"
+                        }`}
+                        style={{ width: dock.iconSize, height: dock.iconSize }}
+                      >
+                        <KanbanSquareIcon className="size-4" />
+                      </button>
+                    </TooltipTrigger>
+                    <TooltipContent side={tooltipSide} sideOffset={8}>
+                      Launcher
+                    </TooltipContent>
+                  </Tooltip>
+                )}
                 <Tooltip>
                   <TooltipTrigger asChild>
                     <button
@@ -1806,17 +1808,19 @@ export function Desktop({ launchAppPath, onOpenCommandPalette, chat }: DesktopPr
                 />
               )}
             </button>
-            <button
-              type="button"
-              onClick={() => { setTaskBoardOpen((prev) => !prev); setSettingsOpen(false); setChatOpen(false); }}
-              className={`flex shrink-0 size-9 items-center justify-center rounded-lg border transition-all active:scale-95 ${
-                taskBoardOpen
-                  ? "bg-primary text-primary-foreground border-primary"
-                  : "bg-card border-border/60"
-              }`}
-            >
-              <KanbanSquareIcon className="size-4" />
-            </button>
+            {modeConfig.showLauncher && (
+              <button
+                type="button"
+                onClick={() => { setTaskBoardOpen((prev) => !prev); setSettingsOpen(false); setChatOpen(false); }}
+                className={`flex shrink-0 size-9 items-center justify-center rounded-lg border transition-all active:scale-95 ${
+                  taskBoardOpen
+                    ? "bg-primary text-primary-foreground border-primary"
+                    : "bg-card border-border/60"
+                }`}
+              >
+                <KanbanSquareIcon className="size-4" />
+              </button>
+            )}
             <ModeSwitcher iconSize={36} tooltipSide="top" />
             <button
               type="button"

--- a/shell/src/stores/desktop-mode.ts
+++ b/shell/src/stores/desktop-mode.ts
@@ -10,6 +10,7 @@ export interface ModeConfig {
   showDock: boolean;
   showWindows: boolean;
   showBottomPanel: boolean;
+  showLauncher: boolean;
   chatPosition: "sidebar" | "center";
   terminalProminent?: boolean;
   // Hidden modes still work if set programmatically, but are filtered out of
@@ -25,6 +26,7 @@ const MODE_CONFIGS: Record<DesktopMode, ModeConfig> = {
     showDock: true,
     showWindows: true,
     showBottomPanel: false,
+    showLauncher: true,
     chatPosition: "sidebar",
   },
   desktop: {
@@ -34,6 +36,7 @@ const MODE_CONFIGS: Record<DesktopMode, ModeConfig> = {
     showDock: true,
     showWindows: true,
     showBottomPanel: false,
+    showLauncher: true,
     chatPosition: "sidebar",
     hidden: true,
   },
@@ -44,6 +47,7 @@ const MODE_CONFIGS: Record<DesktopMode, ModeConfig> = {
     showDock: false,
     showWindows: false,
     showBottomPanel: false,
+    showLauncher: false,
     chatPosition: "center",
     hidden: true,
   },
@@ -54,6 +58,7 @@ const MODE_CONFIGS: Record<DesktopMode, ModeConfig> = {
     showDock: true,
     showWindows: true,
     showBottomPanel: true,
+    showLauncher: false,
     chatPosition: "sidebar",
     terminalProminent: true,
   },

--- a/tests/shell/desktop-modes.test.ts
+++ b/tests/shell/desktop-modes.test.ts
@@ -30,6 +30,7 @@ describe("Desktop Mode Store", () => {
     expect(config.showDock).toBe(true);
     expect(config.showWindows).toBe(true);
     expect(config.showBottomPanel).toBe(false);
+    expect(config.showLauncher).toBe(true);
     expect(config.chatPosition).toBe("sidebar");
   });
 
@@ -39,6 +40,7 @@ describe("Desktop Mode Store", () => {
     expect(config.showDock).toBe(false);
     expect(config.showWindows).toBe(false);
     expect(config.showBottomPanel).toBe(false);
+    expect(config.showLauncher).toBe(false);
     expect(config.chatPosition).toBe("center");
   });
 

--- a/tests/shell/desktop-modes.test.ts
+++ b/tests/shell/desktop-modes.test.ts
@@ -50,6 +50,7 @@ describe("Desktop Mode Store", () => {
     expect(config.showBottomPanel).toBe(true);
     expect(config.chatPosition).toBe("sidebar");
     expect(config.terminalProminent).toBe(true);
+    expect(config.showLauncher).toBe(false);
     expect(config.hidden).toBeUndefined();
   });
 
@@ -60,6 +61,7 @@ describe("Desktop Mode Store", () => {
     expect(config.showWindows).toBe(true);
     expect(config.showBottomPanel).toBe(false);
     expect(config.chatPosition).toBe("sidebar");
+    expect(config.showLauncher).toBe(true);
   });
 
   it("allModes returns all 4 modes with canvas first", () => {


### PR DESCRIPTION
## Summary
- Hide the Launcher dock button while the shell is in Developer mode so the default developer fast path stays Terminal-first.
- Keep Canvas mode unchanged; Canvas still shows Launcher.
- Keep Workspace, Aoede/voice, Hermes, Settings, Integrations, and opened/pinned app indicators available.

## Verification
- `bun run test tests/shell/desktop-modes.test.ts tests/shell/developer-mode-dashboard.test.tsx tests/shell/desktop-first-run.test.ts`
- `bun run typecheck`
- `./scripts/review/check-patterns.sh --diff origin/main` (0 violations; existing Desktop.tsx scanner warnings only)
- `npx react-doctor@latest shell --scope changed --base origin/main` (100/100, no issues found)

## Screenshot
- `/tmp/matrix-097-dev-mode-prune-launcher.png`

## Invariants

### Source of truth
- Shell mode config remains the source of truth for mode-specific chrome behavior.
- This does not change app/window source of truth, persisted layout state, or owner data.

### Lock/transaction scope
- No backend writes, locks, transactions, or network calls are introduced.

### Acceptable orphan states
- None. This only gates whether an existing dock button renders.

### Auth source of truth
- No auth behavior changes.

### Deferred scope
- Does not remove Workspace, Aoede/voice, integrations, Activity Monitor, command-palette entries, or Canvas Launcher behavior.