### PR TITLE
fix(desktop): support dev OTA releases

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -41,8 +41,6 @@ jobs:
         arch: [arm64, x64]
     env:
       MATRIX_DESKTOP_UPDATE_CHANNEL: ${{ inputs.channel }}
-      CSC_LINK: ${{ secrets.MATRIX_DESKTOP_MAC_CERTIFICATE || secrets.CSC_LINK }}
-      CSC_KEY_PASSWORD: ${{ secrets.MATRIX_DESKTOP_MAC_CERTIFICATE_PASSWORD || secrets.CSC_KEY_PASSWORD }}
       APPLE_ID: ${{ secrets.APPLE_ID }}
       APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD || secrets.APPLE_APP_PASSWORD }}
       APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
@@ -60,6 +58,26 @@ jobs:
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
+
+      - name: Prepare mac signing environment
+        shell: bash
+        env:
+          MAC_CERTIFICATE: ${{ secrets.MATRIX_DESKTOP_MAC_CERTIFICATE || secrets.CSC_LINK }}
+          MAC_CERTIFICATE_PASSWORD: ${{ secrets.MATRIX_DESKTOP_MAC_CERTIFICATE_PASSWORD || secrets.CSC_KEY_PASSWORD }}
+        run: |
+          set -euo pipefail
+          if [ -n "${MAC_CERTIFICATE:-}" ]; then
+            {
+              echo "CSC_LINK<<__MATRIX_DESKTOP_CERT__"
+              printf '%s\n' "$MAC_CERTIFICATE"
+              echo "__MATRIX_DESKTOP_CERT__"
+              echo "CSC_KEY_PASSWORD<<__MATRIX_DESKTOP_CERT_PASSWORD__"
+              printf '%s\n' "${MAC_CERTIFICATE_PASSWORD:-}"
+              echo "__MATRIX_DESKTOP_CERT_PASSWORD__"
+            } >> "$GITHUB_ENV"
+          else
+            echo "CSC_IDENTITY_AUTO_DISCOVERY=false" >> "$GITHUB_ENV"
+          fi
 
       - name: Validate Apple notarization secrets
         shell: bash

--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -67,13 +67,15 @@ jobs:
         run: |
           set -euo pipefail
           if [ -n "${MAC_CERTIFICATE:-}" ]; then
+            cert_delimiter="MATRIX_DESKTOP_CERT_$(uuidgen | tr '[:lower:]' '[:upper:]' | tr -d '-')"
+            password_delimiter="MATRIX_DESKTOP_CERT_PASSWORD_$(uuidgen | tr '[:lower:]' '[:upper:]' | tr -d '-')"
             {
-              echo "CSC_LINK<<__MATRIX_DESKTOP_CERT__"
+              echo "CSC_LINK<<$cert_delimiter"
               printf '%s\n' "$MAC_CERTIFICATE"
-              echo "__MATRIX_DESKTOP_CERT__"
-              echo "CSC_KEY_PASSWORD<<__MATRIX_DESKTOP_CERT_PASSWORD__"
+              echo "$cert_delimiter"
+              echo "CSC_KEY_PASSWORD<<$password_delimiter"
               printf '%s\n' "${MAC_CERTIFICATE_PASSWORD:-}"
-              echo "__MATRIX_DESKTOP_CERT_PASSWORD__"
+              echo "$password_delimiter"
             } >> "$GITHUB_ENV"
           else
             echo "CSC_IDENTITY_AUTO_DISCOVERY=false" >> "$GITHUB_ENV"

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -19,6 +19,7 @@ on:
           - stable
           - beta
           - canary
+          - dev
       mode:
         description: Dry-run uploads artifacts only; publish creates/updates the GitHub release.
         required: true
@@ -77,7 +78,7 @@ jobs:
             echo "Prerelease desktop versions must be released with workflow_dispatch so the channel is explicit." >&2
             exit 1
           fi
-          case "$CHANNEL" in stable|beta|canary) ;; *) echo "invalid channel: $CHANNEL" >&2; exit 1 ;; esac
+          case "$CHANNEL" in stable|beta|canary|dev) ;; *) echo "invalid channel: $CHANNEL" >&2; exit 1 ;; esac
           if [ "$CHANNEL" != "stable" ] && [[ "$VERSION" != *-* ]]; then
             echo "Non-stable desktop channels require a prerelease semver version." >&2
             exit 1

--- a/desktop/src/main/update-config.ts
+++ b/desktop/src/main/update-config.ts
@@ -1,4 +1,4 @@
-export type DesktopUpdateChannel = "stable" | "beta" | "canary";
+export type DesktopUpdateChannel = "stable" | "beta" | "canary" | "dev";
 
 export type UpdateFeedConfig =
   | {
@@ -34,7 +34,7 @@ function buildUpdateChannel(): string | undefined {
 }
 
 function normalizeChannel(value: string | undefined): DesktopUpdateChannel {
-  if (value === "beta" || value === "canary") return value;
+  if (value === "beta" || value === "canary" || value === "dev") return value;
   return "stable";
 }
 

--- a/tests/desktop/desktop-release-workflows.test.ts
+++ b/tests/desktop/desktop-release-workflows.test.ts
@@ -48,6 +48,10 @@ describe("desktop release workflows", () => {
     const canary = readFileSync(join(root, ".github/workflows/desktop-release-canary.yml"), "utf8");
 
     expect(build).toContain("Validate Apple notarization secrets");
+    expect(build).toContain("Prepare mac signing environment");
+    expect(build).toContain("CSC_IDENTITY_AUTO_DISCOVERY=false");
+    expect(build).toContain("MAC_CERTIFICATE: ${{ secrets.MATRIX_DESKTOP_MAC_CERTIFICATE || secrets.CSC_LINK }}");
+    expect(build).not.toContain("CSC_LINK: ${{ secrets.MATRIX_DESKTOP_MAC_CERTIFICATE || secrets.CSC_LINK }}");
     expect(build).toContain("APPLE_ID, APPLE_APP_SPECIFIC_PASSWORD, and APPLE_TEAM_ID must be set together");
     expect(build).toContain("Apply desktop release version");
     expect(build).toContain("RELEASE_VERSION: ${{ inputs.version }}");
@@ -58,6 +62,14 @@ describe("desktop release workflows", () => {
     expect(release).toContain("output: ${{ needs.prepare.outputs.channel }}-mac.yml");
     expect(canary).toContain("Merge canary macOS update manifests");
     expect(canary).toContain("output: canary-mac.yml");
+  });
+
+  it("supports a dev desktop update channel for test releases", () => {
+    const release = readFileSync(join(root, ".github/workflows/desktop-release.yml"), "utf8");
+
+    expect(release).toContain("- dev");
+    expect(release).toContain("stable|beta|canary|dev");
+    expect(release).toContain("Non-stable desktop channels require a prerelease semver version.");
   });
 
   it("rejects prerelease desktop tags on the push release path", () => {

--- a/tests/desktop/desktop-release-workflows.test.ts
+++ b/tests/desktop/desktop-release-workflows.test.ts
@@ -50,6 +50,8 @@ describe("desktop release workflows", () => {
     expect(build).toContain("Validate Apple notarization secrets");
     expect(build).toContain("Prepare mac signing environment");
     expect(build).toContain("CSC_IDENTITY_AUTO_DISCOVERY=false");
+    expect(build).toContain("cert_delimiter=\"MATRIX_DESKTOP_CERT_$(uuidgen");
+    expect(build).toContain("password_delimiter=\"MATRIX_DESKTOP_CERT_PASSWORD_$(uuidgen");
     expect(build).toContain("MAC_CERTIFICATE: ${{ secrets.MATRIX_DESKTOP_MAC_CERTIFICATE || secrets.CSC_LINK }}");
     expect(build).not.toContain("CSC_LINK: ${{ secrets.MATRIX_DESKTOP_MAC_CERTIFICATE || secrets.CSC_LINK }}");
     expect(build).toContain("APPLE_ID, APPLE_APP_SPECIFIC_PASSWORD, and APPLE_TEAM_ID must be set together");

--- a/tests/desktop/update-config.test.ts
+++ b/tests/desktop/update-config.test.ts
@@ -32,6 +32,15 @@ describe("resolveUpdateFeedConfig", () => {
     });
   });
 
+  it("allows dev builds to use the dev update channel", () => {
+    expect(resolveUpdateFeedConfig({ MATRIX_DESKTOP_UPDATE_CHANNEL: "dev" }, true)).toMatchObject({
+      enabled: true,
+      provider: "github",
+      channel: "dev",
+      allowPrerelease: true,
+    });
+  });
+
   it("uses the bundled release channel when runtime env is absent", () => {
     expect(resolveUpdateFeedConfig({}, true, "canary")).toMatchObject({
       enabled: true,


### PR DESCRIPTION
Summary
- Add dev as a first-class Matrix OS Desktop update channel.
- Avoid exporting empty mac signing env vars so unsigned dev/canary packaging can proceed when signing secrets are absent.
- Cover dev updater config and desktop release workflow behavior with focused tests.

Tests
- bun run test tests/desktop/update-config.test.ts tests/desktop/desktop-release-workflows.test.ts
- pnpm --filter desktop typecheck
- bun run check:patterns (0 violations; existing warnings only)
- git diff --check

Review/Monitoring
- Need current-head CI and Greptile before merge.

Invariants
- Source of truth: GitHub Releases remain the desktop OTA feed; the bundled update channel selects stable/beta/canary/dev.
- Lock/transaction scope: not applicable; workflow/update-channel config only.
- Acceptable orphan states: a failed desktop release workflow may leave no GitHub release or a failed draftless attempt; rerunning with the same version/tag overwrites artifacts through the release action.
- Auth source of truth: GitHub Actions secrets remain the signing/notarization source; empty secrets no longer masquerade as CSC_LINK.
- Deferred scope: this does not add Apple signing credentials or publish stable desktop releases.