### PR TITLE
fix(terminal): polish session drawer controls

### DIFF
--- a/.github/workflows/preview-vps.yml
+++ b/.github/workflows/preview-vps.yml
@@ -4,7 +4,7 @@
 # running that PR's host bundle, reachable at app.matrix-os.com/vm/pr-<N>.
 #
 # Flow:
-#   deploy   — on label / push while labeled: build bundle 0.0.0-pr<N>.<sha7>,
+#   deploy   — on label / push while labeled: build bundle v<date>-pr<N>-<sha7>,
 #              publish register-only (--channel none, never promoted),
 #              provision pr-<N> if absent, deploy the exact version, comment.
 #   teardown — on PR close: delete the pr-<N> VPS.
@@ -136,7 +136,7 @@ jobs:
           HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
         run: |
           set -euo pipefail
-          VERSION="0.0.0-pr${PR_NUMBER}.${HEAD_SHA:0:7}"
+          VERSION="v$(date -u +%Y.%m.%d)-pr${PR_NUMBER}-${HEAD_SHA:0:7}"
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "Preview version: $VERSION"
 
@@ -157,6 +157,8 @@ jobs:
           path: |
             dist/host-bundle/matrix-host-bundle.tar.gz
             dist/host-bundle/matrix-host-bundle.tar.gz.sha256
+            dist/host-bundle/incremental-manifest.json
+            dist/host-bundle/objects/**
             dist/host-bundle/manifest.json
             dist/host-bundle/release.json
           if-no-files-found: error

--- a/shell/src/components/Desktop.tsx
+++ b/shell/src/components/Desktop.tsx
@@ -2065,6 +2065,7 @@ export function Desktop({ launchAppPath, onOpenCommandPalette, chat }: DesktopPr
                           onPointerMove: onDragMove,
                           onPointerUp: onDragEnd,
                           onPointerCancel: onDragEnd,
+                          onDoubleClick: () => wmToggleFullscreen(win.id),
                         },
                       }}
                     />

--- a/shell/src/components/terminal/TerminalApp.tsx
+++ b/shell/src/components/terminal/TerminalApp.tsx
@@ -1784,6 +1784,10 @@ function TerminalWorkspaceChrome() {
     if (ctx.mobile || isTerminalChromeControl(event.target)) return;
     dragHandleProps?.onMouseDown?.(event);
   };
+  const handleDragDoubleClick: MouseEventHandler<HTMLElement> = (event) => {
+    if (ctx.mobile || isTerminalChromeControl(event.target)) return;
+    dragHandleProps?.onDoubleClick?.(event);
+  };
 
   return (
     <div
@@ -1793,7 +1797,7 @@ function TerminalWorkspaceChrome() {
       onPointerUp={dragHandleProps?.onPointerUp}
       onPointerCancel={dragHandleProps?.onPointerCancel}
       onMouseDownCapture={handleDragMouseDownCapture}
-      onDoubleClick={dragHandleProps?.onDoubleClick}
+      onDoubleClick={handleDragDoubleClick}
       style={{
         alignItems: "center",
         background: "#15180F",
@@ -3065,12 +3069,14 @@ function LocalTerminalSidebar() {
     const handlePointerMove = (moveEvent: globalThis.PointerEvent) => {
       ctx.setSidebarWidth(clampTerminalSidebarWidth(startWidth + moveEvent.clientX - startX));
     };
-    const handlePointerUp = () => {
+    const finishResize = () => {
       window.removeEventListener("pointermove", handlePointerMove);
-      window.removeEventListener("pointerup", handlePointerUp);
+      window.removeEventListener("pointerup", finishResize);
+      window.removeEventListener("pointercancel", finishResize);
     };
     window.addEventListener("pointermove", handlePointerMove);
-    window.addEventListener("pointerup", handlePointerUp, { once: true });
+    window.addEventListener("pointerup", finishResize, { once: true });
+    window.addEventListener("pointercancel", finishResize, { once: true });
   };
   const resizeSidebarWithKeyboard = (event: KeyboardEvent<HTMLElement>) => {
     if (ctx.mobile) return;

--- a/shell/src/components/terminal/TerminalApp.tsx
+++ b/shell/src/components/terminal/TerminalApp.tsx
@@ -3056,7 +3056,7 @@ function LocalTerminalSidebar() {
     ? activePaneSessionId
     : null;
   const drawerWidth = ctx.mobile ? "100%" : clampTerminalSidebarWidth(ctx.sidebarWidth);
-  const startSidebarResize = (event: PointerEvent<HTMLDivElement>) => {
+  const startSidebarResize = (event: PointerEvent<HTMLElement>) => {
     if (ctx.mobile) return;
     event.preventDefault();
     event.stopPropagation();
@@ -3072,7 +3072,7 @@ function LocalTerminalSidebar() {
     window.addEventListener("pointermove", handlePointerMove);
     window.addEventListener("pointerup", handlePointerUp, { once: true });
   };
-  const resizeSidebarWithKeyboard = (event: KeyboardEvent<HTMLDivElement>) => {
+  const resizeSidebarWithKeyboard = (event: KeyboardEvent<HTMLElement>) => {
     if (ctx.mobile) return;
     if (event.key !== "ArrowLeft" && event.key !== "ArrowRight") return;
     event.preventDefault();

--- a/shell/src/components/terminal/TerminalApp.tsx
+++ b/shell/src/components/terminal/TerminalApp.tsx
@@ -3064,12 +3064,18 @@ function LocalTerminalSidebar() {
     if (ctx.mobile) return;
     event.preventDefault();
     event.stopPropagation();
+    const resizeHandle = event.currentTarget;
+    const pointerId = event.pointerId;
+    resizeHandle.setPointerCapture?.(pointerId);
     const startX = event.clientX;
     const startWidth = clampTerminalSidebarWidth(ctx.sidebarWidth);
     const handlePointerMove = (moveEvent: globalThis.PointerEvent) => {
       ctx.setSidebarWidth(clampTerminalSidebarWidth(startWidth + moveEvent.clientX - startX));
     };
     const finishResize = () => {
+      if (resizeHandle.hasPointerCapture?.(pointerId)) {
+        resizeHandle.releasePointerCapture?.(pointerId);
+      }
       window.removeEventListener("pointermove", handlePointerMove);
       window.removeEventListener("pointerup", finishResize);
       window.removeEventListener("pointercancel", finishResize);

--- a/shell/src/components/terminal/TerminalApp.tsx
+++ b/shell/src/components/terminal/TerminalApp.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { createContext, use, useEffect, useEffectEvent, useRef, useCallback, useState, type CSSProperties, type KeyboardEvent, type MouseEventHandler, type PointerEventHandler } from "react";
+import { createContext, use, useEffect, useEffectEvent, useRef, useCallback, useState, type CSSProperties, type KeyboardEvent, type MouseEventHandler, type PointerEvent, type PointerEventHandler } from "react";
 import {
   BotIcon,
   CheckIcon,
@@ -63,34 +63,40 @@ const PAPER_THEME_BUTTON_STYLE: CSSProperties = {
 
 const ACTIVE_SHELL_TOGGLE_STYLE: CSSProperties = {
   alignItems: "center",
+  alignSelf: "center",
   background: "#DDEDD6",
   border: "1px solid #C9E1C2",
   borderRadius: 999,
+  boxSizing: "border-box",
   color: "#24452A",
   cursor: "pointer",
   display: "flex",
   flexShrink: 0,
-  height: 18,
+  height: 20,
   justifyContent: "flex-start",
+  overflow: "hidden",
   padding: 2,
   pointerEvents: "auto",
-  width: 40,
+  width: 46,
 };
 
 const BACKGROUND_SHELL_TOGGLE_STYLE: CSSProperties = {
   alignItems: "center",
+  alignSelf: "center",
   background: "#D8D7C7",
   border: "1px solid #C8C7B7",
   borderRadius: 999,
+  boxSizing: "border-box",
   color: "#77786E",
   cursor: "pointer",
   display: "flex",
   flexShrink: 0,
-  height: 18,
+  height: 20,
   justifyContent: "flex-end",
+  overflow: "hidden",
   padding: 2,
   pointerEvents: "auto",
-  width: 38,
+  width: 44,
 };
 
 const SHELL_THEME_OPTIONS: Array<{
@@ -171,17 +177,19 @@ const TAB_CLOSE_BUTTON_STYLE: CSSProperties = {
 
 const ACTIVE_TAB_PILL_STYLE: CSSProperties = {
   alignItems: "center",
+  alignSelf: "center",
   background: "color-mix(in srgb, var(--primary) 16%, transparent)",
   border: "1px solid color-mix(in srgb, var(--primary) 44%, transparent)",
   borderRadius: 999,
   color: "var(--primary)",
   display: "inline-flex",
   flex: "0 0 auto",
-  fontSize: 12,
+  fontSize: 10,
   fontWeight: 800,
-  height: 18,
-  lineHeight: "16px",
-  padding: "0 6px",
+  height: 16,
+  lineHeight: "14px",
+  overflow: "hidden",
+  padding: "0 5px",
 };
 
 const SHELL_NEW_BUTTON_BASE_STYLE: CSSProperties = {
@@ -206,9 +214,16 @@ const SIDEBAR_RAIL_BUTTON_BASE_STYLE: CSSProperties = {
 
 const SHELLS_REFRESH_INTERVAL_MS = 5_000;
 const SHELL_SESSION_NAME_PATTERN = /^[a-z0-9][a-z0-9-]{0,30}$/;
+const DEFAULT_TERMINAL_SIDEBAR_WIDTH = 392;
+const MIN_TERMINAL_SIDEBAR_WIDTH = 280;
+const MAX_TERMINAL_SIDEBAR_WIDTH = 560;
 const TERMINAL_SIDEBAR_TRANSITION = "opacity 140ms ease, transform 180ms ease";
 const SESSION_ACTIONS_STYLE: CSSProperties = {
   gap: 6,
+  position: "absolute",
+  right: 0,
+  top: "50%",
+  transform: "translateY(-50%)",
   transition: "opacity 120ms ease",
   width: 58,
 };
@@ -248,6 +263,19 @@ const SESSION_CLOSE_BUTTON_STYLE: CSSProperties = {
   lineHeight: "20px",
   pointerEvents: "auto",
   width: 24,
+};
+const SESSION_NAME_BUTTON_BASE_STYLE: CSSProperties = {
+  background: "transparent",
+  border: 0,
+  cursor: "pointer",
+  fontFamily: "var(--font-mono, ui-monospace, monospace)",
+  fontSize: 14,
+  fontWeight: 700,
+  lineHeight: "18px",
+  minWidth: 0,
+  padding: 0,
+  pointerEvents: "auto",
+  textAlign: "left",
 };
 const SHELL_STATUS_DOT_CSS = `
 @keyframes terminal-session-status-pulse {
@@ -633,6 +661,10 @@ function terminalAppDebug(event: string, details: Record<string, unknown>): void
 
 const countPanes = countPanesFromStore;
 
+function clampTerminalSidebarWidth(width: number): number {
+  return Math.min(MAX_TERMINAL_SIDEBAR_WIDTH, Math.max(MIN_TERMINAL_SIDEBAR_WIDTH, Math.round(width)));
+}
+
 export interface TerminalWindowControls {
   close?: () => void;
   minimize?: () => void;
@@ -685,6 +717,7 @@ export function TerminalApp({ initialCommand, initialLabel, initialClaudeMode = 
   const [activeTabId, setActiveTabId] = useState("");
   const [focusedPaneId, setFocusedPaneId] = useState<string | null>(null);
   const [sidebarOpen, setSidebarOpen] = useState(true);
+  const [sidebarWidth, setSidebarWidth] = useState(DEFAULT_TERMINAL_SIDEBAR_WIDTH);
   const [sidebarSelectedPath, setSidebarSelectedPath] = useState<string | null>(null);
   const [initialized, setInitialized] = useState(false);
 
@@ -1171,10 +1204,10 @@ export function TerminalApp({ initialCommand, initialLabel, initialClaudeMode = 
 
   // Construct store-compatible interface for child components
   const storeApi = {
-    tabs, activeTabId, sidebarOpen, sidebarSelectedPath, focusedPaneId, mobile, windowControls,
+    tabs, activeTabId, sidebarOpen, sidebarWidth, sidebarSelectedPath, focusedPaneId, mobile, windowControls,
     addTab, addSessionTab, createShellSessionTab, backgroundShellSession, closeTab, setActiveTab: setActiveTabId, renameTab, renameShellSession, reorderTabs,
     splitPane, closePane, setFocusedPane: setFocusedPaneId,
-    setSidebarOpen, setSidebarSelectedPath,
+    setSidebarOpen, setSidebarWidth, setSidebarSelectedPath,
   };
 
   return (
@@ -1265,6 +1298,7 @@ interface TerminalAppContextType {
   tabs: Tab[];
   activeTabId: string;
   sidebarOpen: boolean;
+  sidebarWidth: number;
   sidebarSelectedPath: string | null;
   focusedPaneId: string | null;
   mobile: boolean;
@@ -1282,6 +1316,7 @@ interface TerminalAppContextType {
   closePane: (paneId: string) => void;
   setFocusedPane: (paneId: string) => void;
   setSidebarOpen: (open: boolean | ((prev: boolean) => boolean)) => void;
+  setSidebarWidth: (width: number | ((prev: number) => number)) => void;
   setSidebarSelectedPath: (path: string | null) => void;
 }
 
@@ -1829,11 +1864,14 @@ function TerminalWorkspaceChrome() {
                 background: "#20241C",
                 border: "1px solid #24271F",
                 borderRadius: 8,
+                boxSizing: "border-box",
                 color: "#858578",
-                fontSize: 12,
+                fontSize: 11,
                 gap: 5,
-                height: 26,
-                padding: "0 9px",
+                height: 22,
+                lineHeight: "14px",
+                overflow: "hidden",
+                padding: "0 8px",
               }}
             >
               main
@@ -3017,7 +3055,30 @@ function LocalTerminalSidebar() {
   const activeShellName = activePaneSessionId && isCanonicalShellSessionId(activePaneSessionId)
     ? activePaneSessionId
     : null;
-  const drawerWidth = ctx.mobile ? "100%" : 392;
+  const drawerWidth = ctx.mobile ? "100%" : clampTerminalSidebarWidth(ctx.sidebarWidth);
+  const startSidebarResize = (event: PointerEvent<HTMLDivElement>) => {
+    if (ctx.mobile) return;
+    event.preventDefault();
+    event.stopPropagation();
+    const startX = event.clientX;
+    const startWidth = clampTerminalSidebarWidth(ctx.sidebarWidth);
+    const handlePointerMove = (moveEvent: globalThis.PointerEvent) => {
+      ctx.setSidebarWidth(clampTerminalSidebarWidth(startWidth + moveEvent.clientX - startX));
+    };
+    const handlePointerUp = () => {
+      window.removeEventListener("pointermove", handlePointerMove);
+      window.removeEventListener("pointerup", handlePointerUp);
+    };
+    window.addEventListener("pointermove", handlePointerMove);
+    window.addEventListener("pointerup", handlePointerUp, { once: true });
+  };
+  const resizeSidebarWithKeyboard = (event: KeyboardEvent<HTMLDivElement>) => {
+    if (ctx.mobile) return;
+    if (event.key !== "ArrowLeft" && event.key !== "ArrowRight") return;
+    event.preventDefault();
+    const delta = event.key === "ArrowLeft" ? -16 : 16;
+    ctx.setSidebarWidth((width) => clampTerminalSidebarWidth(width + delta));
+  };
   const openActiveShell = (shell: ShellSessionSummary, options: { markSeen?: boolean } = {}) => {
     const markSeen = options.markSeen !== false;
     const existingTab = ctx.tabs.find((tab) => getSessionIds(tab.paneTree).includes(shell.name));
@@ -3215,6 +3276,7 @@ function LocalTerminalSidebar() {
           maxHeight: ctx.mobile ? "52%" : undefined,
           minHeight: ctx.mobile ? 360 : undefined,
           opacity: 1,
+          position: "relative",
           transform: "translateX(0)",
           transition: ctx.mobile ? undefined : TERMINAL_SIDEBAR_TRANSITION,
           width: drawerWidth,
@@ -3423,6 +3485,26 @@ function LocalTerminalSidebar() {
           />
         )}
       </div>
+      {!ctx.mobile ? (
+        <button
+          type="button"
+          aria-label="Resize sessions drawer"
+          onPointerDown={startSidebarResize}
+          onKeyDown={resizeSidebarWithKeyboard}
+          style={{
+            background: "linear-gradient(to right, transparent 0 2px, #C5C4B4 2px 4px, transparent 4px 8px)",
+            border: 0,
+            bottom: 0,
+            cursor: "col-resize",
+            margin: 0,
+            position: "absolute",
+            right: 0,
+            top: 0,
+            width: 8,
+            zIndex: 5,
+          }}
+        />
+      ) : null}
     </div>
       {closeConfirmationOverlay}
     </>
@@ -3859,7 +3941,7 @@ function ShellCloseConfirmation({
                 color: "#3E4339",
                 cursor: "pointer",
                 fontFamily: "Inter, system-ui, sans-serif",
-                fontSize: 11,
+                fontSize: 12,
                 fontWeight: 600,
                 height: 30,
                 padding: "0 14px",
@@ -4608,13 +4690,15 @@ function ShellCard({
           />
         <div
           className="min-w-0"
-          style={{
-            alignItems: "center",
-            display: "grid",
-            gap: 6,
-            gridTemplateColumns: renaming ? "minmax(0, 1fr)" : foreground ? "minmax(0, 1fr) 22px 58px" : "minmax(0, 1fr) 58px",
-          }}
-        >
+        style={{
+          alignItems: "center",
+          display: "grid",
+          gap: 6,
+          gridTemplateColumns: renaming ? "minmax(0, 1fr)" : foreground ? "minmax(0, 1fr) 22px" : "minmax(0, 1fr)",
+          paddingRight: renaming ? 0 : 64,
+          position: "relative",
+        }}
+      >
           {renaming ? (
             <input
               ref={renameInputRef}
@@ -4665,18 +4749,8 @@ function ShellCard({
                 onOpen();
               }}
               style={{
-                background: "transparent",
-                border: 0,
+                ...SESSION_NAME_BUTTON_BASE_STYLE,
                 color: foreground ? "#31362D" : "#5F6258",
-                cursor: "pointer",
-                fontFamily: "var(--font-mono, ui-monospace, monospace)",
-                fontSize: 14,
-                fontWeight: 700,
-                lineHeight: "18px",
-                minWidth: 0,
-                padding: 0,
-                pointerEvents: "auto",
-                textAlign: "left",
               }}
             >
               {displayName}

--- a/shell/src/components/terminal/TerminalApp.tsx
+++ b/shell/src/components/terminal/TerminalApp.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { createContext, use, useEffect, useEffectEvent, useRef, useCallback, useState, type CSSProperties, type KeyboardEvent, type MouseEventHandler, type PointerEvent, type PointerEventHandler } from "react";
+import { createContext, use, useEffect, useEffectEvent, useRef, useCallback, useState, type CSSProperties, type KeyboardEvent, type MouseEventHandler, type PointerEvent as ReactPointerEvent, type PointerEventHandler } from "react";
 import {
   BotIcon,
   CheckIcon,
@@ -3056,7 +3056,7 @@ function LocalTerminalSidebar() {
     ? activePaneSessionId
     : null;
   const drawerWidth = ctx.mobile ? "100%" : clampTerminalSidebarWidth(ctx.sidebarWidth);
-  const startSidebarResize = (event: PointerEvent<HTMLElement>) => {
+  const startSidebarResize = (event: ReactPointerEvent<HTMLElement>) => {
     if (ctx.mobile) return;
     event.preventDefault();
     event.stopPropagation();

--- a/tests/platform/customer-vps-host-bundle.test.ts
+++ b/tests/platform/customer-vps-host-bundle.test.ts
@@ -236,6 +236,17 @@ describe('customer VPS host bundle', () => {
     expect(workflow).not.toContain('-X POST "https://app.matrix-os.com/vps/deploy"');
   });
 
+  it('preview VPS workflow publishes deployable host bundle artifacts', () => {
+    const root = process.cwd();
+    const workflow = readFileSync(join(root, '.github/workflows/preview-vps.yml'), 'utf8');
+
+    expect(workflow).toContain('VERSION="v$(date -u +%Y.%m.%d)-pr${PR_NUMBER}-${HEAD_SHA:0:7}"');
+    expect(workflow).toContain('dist/host-bundle/incremental-manifest.json');
+    expect(workflow).toContain('dist/host-bundle/objects/**');
+    expect(workflow).toContain('./scripts/publish-release.sh "$VERSION" --channel none');
+    expect(workflow).toContain('-X POST "${PLATFORM_PUBLIC_URL}/vps/deploy"');
+  });
+
   it('host bundle release workflow can skip dev bundles only through explicit manual input', () => {
     const root = process.cwd();
     const workflow = readFileSync(join(root, '.github/workflows/host-bundle-release.yml'), 'utf8');

--- a/tests/shell/desktop-terminal-fullscreen-pill.test.tsx
+++ b/tests/shell/desktop-terminal-fullscreen-pill.test.tsx
@@ -1,17 +1,21 @@
 // @vitest-environment jsdom
 import React from "react";
-import { render, screen, waitFor } from "@testing-library/react";
+import { act, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { Desktop } from "../../shell/src/components/Desktop.js";
 import { useDesktopMode } from "../../shell/src/stores/desktop-mode.js";
 import { useWindowManager, type AppWindow } from "../../shell/src/hooks/useWindowManager.js";
+
+const { terminalRender } = vi.hoisted(() => ({
+  terminalRender: vi.fn(() => <div>Terminal content</div>),
+}));
 
 vi.mock("../../shell/src/hooks/useFileWatcher.js", () => ({
   useFileWatcher: () => undefined,
 }));
 
 vi.mock("../../shell/src/components/terminal/TerminalApp.js", () => ({
-  TerminalApp: () => <div>Terminal content</div>,
+  TerminalApp: terminalRender,
 }));
 
 vi.mock("../../shell/src/components/AppViewer.js", () => ({
@@ -124,7 +128,7 @@ function jsonResponse(body: unknown) {
   }));
 }
 
-function resetStores(win: AppWindow) {
+function resetStores(win: AppWindow, fullscreenWindowId: string | null = win.id) {
   useDesktopMode.setState({
     mode: "dev",
     previousMode: null,
@@ -137,12 +141,13 @@ function resetStores(win: AppWindow) {
     closedLayouts: new Map(),
     apps: [],
     focusedWindowId: win.id,
-    fullscreenWindowId: win.id,
+    fullscreenWindowId,
   });
 }
 
 describe("Desktop terminal fullscreen chrome", () => {
   beforeEach(() => {
+    terminalRender.mockClear();
     vi.stubGlobal("fetch", vi.fn((input: RequestInfo | URL) => {
       const url = String(input);
       if (url.includes("/api/settings/onboarding-status")) return jsonResponse({ complete: true });
@@ -175,5 +180,28 @@ describe("Desktop terminal fullscreen chrome", () => {
 
     await screen.findByText("App content");
     expect(screen.getByRole("button", { name: "Exit fullscreen" })).toBeTruthy();
+  });
+
+  it("lets the terminal-owned title bar double-click toggle window zoom", async () => {
+    resetStores(terminalWindow, null);
+
+    render(<Desktop />);
+
+    await screen.findByText("Terminal content");
+    const props = terminalRender.mock.lastCall?.[0] as {
+      windowControls?: {
+        dragHandleProps?: {
+          onDoubleClick?: () => void;
+        };
+      };
+    };
+
+    expect(props.windowControls?.dragHandleProps?.onDoubleClick).toEqual(expect.any(Function));
+
+    act(() => {
+      props.windowControls!.dragHandleProps!.onDoubleClick!();
+    });
+
+    expect(useWindowManager.getState().fullscreenWindowId).toBe("win-terminal");
   });
 });

--- a/tests/shell/terminal-app-component.test.tsx
+++ b/tests/shell/terminal-app-component.test.tsx
@@ -1383,6 +1383,8 @@ describe("TerminalApp", () => {
     expect(sidebarShell.style.width).toBe("392px");
 
     const resizeHandle = screen.getByRole("button", { name: "Resize sessions drawer" });
+    const setPointerCapture = vi.fn();
+    Object.defineProperty(resizeHandle, "setPointerCapture", { configurable: true, value: setPointerCapture });
     await act(async () => {
       fireEvent.pointerDown(resizeHandle, { clientX: 392, pointerId: 1 });
       fireEvent.pointerMove(window, { clientX: 456 });
@@ -1390,6 +1392,7 @@ describe("TerminalApp", () => {
       await Promise.resolve();
     });
 
+    expect(setPointerCapture).toHaveBeenCalledWith(1);
     expect(sidebarShell.style.width).toBe("456px");
 
     await act(async () => {

--- a/tests/shell/terminal-app-component.test.tsx
+++ b/tests/shell/terminal-app-component.test.tsx
@@ -384,6 +384,10 @@ describe("TerminalApp", () => {
     expect(row!.style.display).toBe("grid");
     expect(row!.style.gridTemplateColumns).toBe("minmax(0, 1fr) 46px");
     expect(actions.style.width).toBe("58px");
+    expect(actions.style.position).toBe("absolute");
+    expect(actions.style.right).toBe("0px");
+    expect(actions.style.top).toBe("50%");
+    expect(actions.style.transform).toBe("translateY(-50%)");
     expect(copyButton.style.width).toBe("24px");
     expect(screen.queryByText("matrix shell connect")).toBeNull();
     expect(actions.style.maxHeight).toBe("");
@@ -1348,6 +1352,52 @@ describe("TerminalApp", () => {
     expect(screen.queryByRole("button", { name: "Projects" })).toBeNull();
     expect(screen.getByText("Active")).toBeTruthy();
     expect(screen.getByLabelText("Search sessions")).toBeTruthy();
+  });
+
+  it("keeps shell placement badges inside their row height", async () => {
+    render(<TerminalApp />);
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    const activeToggle = screen.getByRole("button", { name: "Move matrix-main to background" });
+    expect(activeToggle.style.height).toBe("20px");
+    expect(activeToggle.style.boxSizing).toBe("border-box");
+    expect(activeToggle.style.overflow).toBe("hidden");
+    expect(activeToggle.style.alignSelf).toBe("center");
+  });
+
+  it("lets desktop users resize the terminal sessions drawer", async () => {
+    render(<TerminalApp />);
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    const sidebarShell = screen.getByTestId("terminal-sidebar-shell");
+    expect(sidebarShell.style.width).toBe("392px");
+
+    const resizeHandle = screen.getByRole("button", { name: "Resize sessions drawer" });
+    await act(async () => {
+      fireEvent.pointerDown(resizeHandle, { clientX: 392, pointerId: 1 });
+      fireEvent.pointerMove(window, { clientX: 456 });
+      fireEvent.pointerUp(window);
+      await Promise.resolve();
+    });
+
+    expect(sidebarShell.style.width).toBe("456px");
+
+    await act(async () => {
+      fireEvent.keyDown(resizeHandle, { key: "ArrowLeft" });
+      await Promise.resolve();
+    });
+
+    expect(sidebarShell.style.width).toBe("440px");
   });
 
   it("highlights the shell attached to the active restored pane on first render", async () => {

--- a/tests/shell/terminal-app-component.test.tsx
+++ b/tests/shell/terminal-app-component.test.tsx
@@ -1400,6 +1400,43 @@ describe("TerminalApp", () => {
     expect(sidebarShell.style.width).toBe("440px");
   });
 
+  it("stops terminal drawer resizing when the drag is canceled", async () => {
+    render(<TerminalApp />);
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    const sidebarShell = screen.getByTestId("terminal-sidebar-shell");
+    const resizeHandle = screen.getByRole("button", { name: "Resize sessions drawer" });
+    await act(async () => {
+      fireEvent.pointerDown(resizeHandle, { clientX: 392, pointerId: 1 });
+      fireEvent.pointerMove(window, { clientX: 456 });
+      fireEvent.pointerCancel(window);
+      fireEvent.pointerMove(window, { clientX: 520 });
+      await Promise.resolve();
+    });
+
+    expect(sidebarShell.style.width).toBe("456px");
+  });
+
+  it("does not treat terminal chrome control double-clicks as title-bar zooms", async () => {
+    const handleTitleDoubleClick = vi.fn();
+    render(<TerminalApp windowControls={{ dragHandleProps: { onDoubleClick: handleTitleDoubleClick } }} />);
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    fireEvent.doubleClick(screen.getByRole("button", { name: "Toggle Terminal fullscreen" }));
+
+    expect(handleTitleDoubleClick).not.toHaveBeenCalled();
+  });
+
   it("highlights the shell attached to the active restored pane on first render", async () => {
     vi.mocked(fetch).mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
       const url = String(input);


### PR DESCRIPTION
## Summary
- Add a desktop resize handle for the Terminal sessions drawer with pointer and keyboard controls.
- Keep Terminal session placement badges and hover actions bounded inside their rows.
- Wire Terminal-owned title-bar double-click to window fullscreen/zoom.

## Screenshot
- Captured current Terminal UI evidence locally at `/tmp/matrix-terminal-ui-polish.png` from the branch shell.

## Tests
- `bun run test tests/shell/terminal-app-component.test.tsx tests/shell/desktop-terminal-fullscreen-pill.test.tsx tests/shell/canvas-window-terminal-overlay.test.tsx tests/shell/terminal-settings-panel.test.tsx`
- `bun run typecheck`
- `./scripts/review/check-patterns.sh --diff origin/main`
- `npx react-doctor@latest shell --scope changed --base origin/main`
- `bun run test` (674 passed, 4 skipped; 7355 passed, 26 skipped)
- `bun run check:patterns` (0 violations; existing warnings only)

## Invariants
- Source of truth: Terminal sessions and layout remain owned by the existing gateway APIs; drawer width is client-local UI state only.
- Lock/transaction scope: no backend writes or transactions changed.
- Acceptable orphan states: resizing is not persisted, so refresh returns to the default drawer width.
- Auth source of truth: unchanged; existing shell/gateway auth boundaries still apply.
- Deferred scope: persisting per-user drawer width is intentionally deferred.