### PR TITLE
fix(desktop): harden release artifact verification

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -118,10 +118,22 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          test -f desktop/dist/latest-mac.yml
-          test -f desktop/dist/*.dmg
-          test -f desktop/dist/*.zip
-          test -f desktop/dist/mac*/Matrix\ OS.app/Contents/Resources/app-update.yml
+          if [ ! -f desktop/dist/latest-mac.yml ]; then
+            echo "Missing macOS update manifest: desktop/dist/latest-mac.yml" >&2
+            exit 1
+          fi
+          if ! find desktop/dist -maxdepth 1 -type f -name "*.dmg" -print -quit | grep -q .; then
+            echo "Missing macOS DMG artifact in desktop/dist" >&2
+            exit 1
+          fi
+          if ! find desktop/dist -maxdepth 1 -type f -name "*.zip" -print -quit | grep -q .; then
+            echo "Missing macOS ZIP artifact in desktop/dist" >&2
+            exit 1
+          fi
+          if ! find desktop/dist -path "*/Matrix OS.app/Contents/Resources/app-update.yml" -type f -print -quit | grep -q .; then
+            echo "Missing packaged macOS app-update.yml" >&2
+            exit 1
+          fi
 
       - name: Rename mac update manifest for arch
         shell: bash
@@ -190,8 +202,14 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          test -f desktop/dist/*.AppImage
-          test -f desktop/dist/latest-linux.yml
+          if ! find desktop/dist -maxdepth 1 -type f -name "*.AppImage" -print -quit | grep -q .; then
+            echo "Missing Linux AppImage artifact in desktop/dist" >&2
+            exit 1
+          fi
+          if [ ! -f desktop/dist/latest-linux.yml ]; then
+            echo "Missing Linux update manifest: desktop/dist/latest-linux.yml" >&2
+            exit 1
+          fi
 
       - name: Upload Linux artifacts
         uses: actions/upload-artifact@v6

--- a/tests/desktop/desktop-release-workflows.test.ts
+++ b/tests/desktop/desktop-release-workflows.test.ts
@@ -15,6 +15,8 @@ describe("desktop release workflows", () => {
     expect(workflow).toContain('find desktop/dist -maxdepth 1 -type f -name "*.dmg" -print -quit');
     expect(workflow).toContain('find desktop/dist -maxdepth 1 -type f -name "*.zip" -print -quit');
     expect(workflow).toContain('find desktop/dist -path "*/Matrix OS.app/Contents/Resources/app-update.yml"');
+    expect(workflow).toContain('find desktop/dist -maxdepth 1 -type f -name "*.AppImage" -print -quit');
+    expect(workflow).toContain("[ ! -f desktop/dist/latest-linux.yml ]");
     expect(workflow).not.toContain("test -f desktop/dist/*.dmg");
     expect(workflow).not.toContain("test -f desktop/dist/*.zip");
     expect(workflow).not.toContain("test -f desktop/dist/*.AppImage");

--- a/tests/desktop/desktop-release-workflows.test.ts
+++ b/tests/desktop/desktop-release-workflows.test.ts
@@ -11,7 +11,12 @@ describe("desktop release workflows", () => {
     const workflow = readFileSync(join(root, ".github/workflows/desktop-build.yml"), "utf8");
 
     expect(workflow).toContain("Rename mac update manifest for arch");
-    expect(workflow).toContain("test -f desktop/dist/latest-mac.yml");
+    expect(workflow).toContain("[ ! -f desktop/dist/latest-mac.yml ]");
+    expect(workflow).toContain('find desktop/dist -maxdepth 1 -type f -name "*.dmg" -print -quit');
+    expect(workflow).toContain('find desktop/dist -maxdepth 1 -type f -name "*.zip" -print -quit');
+    expect(workflow).toContain('find desktop/dist -path "*/Matrix OS.app/Contents/Resources/app-update.yml"');
+    expect(workflow).not.toContain("test -f desktop/dist/*.dmg");
+    expect(workflow).not.toContain("test -f desktop/dist/*.zip");
     expect(workflow).not.toContain("test -f desktop/dist/*-mac.yml");
     expect(workflow).toContain('mv desktop/dist/latest-mac.yml "desktop/dist/${{ matrix.arch }}-mac.yml"');
     expect(workflow).toContain('mv "desktop/dist/${CHANNEL}-mac.yml" "desktop/dist/${{ matrix.arch }}-${CHANNEL}-mac.yml"');

--- a/tests/desktop/desktop-release-workflows.test.ts
+++ b/tests/desktop/desktop-release-workflows.test.ts
@@ -7,7 +7,7 @@ import { describe, expect, it } from "vitest";
 const root = process.cwd();
 
 describe("desktop release workflows", () => {
-  it("renames mac update manifests before artifact upload", () => {
+  it("verifies packaged artifacts before renaming mac update manifests", () => {
     const workflow = readFileSync(join(root, ".github/workflows/desktop-build.yml"), "utf8");
 
     expect(workflow).toContain("Rename mac update manifest for arch");
@@ -17,6 +17,7 @@ describe("desktop release workflows", () => {
     expect(workflow).toContain('find desktop/dist -path "*/Matrix OS.app/Contents/Resources/app-update.yml"');
     expect(workflow).not.toContain("test -f desktop/dist/*.dmg");
     expect(workflow).not.toContain("test -f desktop/dist/*.zip");
+    expect(workflow).not.toContain("test -f desktop/dist/*.AppImage");
     expect(workflow).not.toContain("test -f desktop/dist/*-mac.yml");
     expect(workflow).toContain('mv desktop/dist/latest-mac.yml "desktop/dist/${{ matrix.arch }}-mac.yml"');
     expect(workflow).toContain('mv "desktop/dist/${CHANNEL}-mac.yml" "desktop/dist/${{ matrix.arch }}-${CHANNEL}-mac.yml"');


### PR DESCRIPTION
## Summary
- Replace fragile `test -f desktop/dist/*.dmg` and similar artifact glob checks with `find`-based existence checks.
- Keep exact manifest checks and add clearer release-log errors when required desktop artifacts are missing.
- Add workflow regression assertions so the macOS verifier cannot reintroduce multi-match `test -f` globs.

## Validation
- `bun run test tests/desktop/desktop-release-workflows.test.ts tests/desktop/update-config.test.ts`
- `pnpm --filter desktop typecheck`
- `bun run check:patterns` (0 violations; existing warnings only)
- `git diff --check`

## Invariants
- Source of truth: GitHub Actions desktop build output under `desktop/dist`; the workflow only verifies expected artifacts before upload.
- Lock/transaction scope: not applicable; no database writes or concurrent runtime state changes.
- Acceptable orphan states: a missing artifact fails the build before upload/publish; no partial release is promoted by this verifier step.
- Auth source of truth: unchanged; GitHub Actions permissions and release tokens are untouched.
- Deferred scope: no changes to signing/notarization credentials, updater server behavior, or Electron packaging targets.