### PR TITLE
fix(vps): unify Hermes owner home

### DIFF
--- a/distro/customer-vps/cloud-init.yaml
+++ b/distro/customer-vps/cloud-init.yaml
@@ -20,6 +20,7 @@ write_files:
       if [ "$(id -un 2>/dev/null || true)" = "matrix" ]; then
         export MATRIX_HOME="${MATRIX_HOME:-/home/matrix/home}"
         export HOME="$MATRIX_HOME"
+        export HERMES_HOME="${HERMES_HOME:-$HOME/.hermes}"
         export XDG_CONFIG_HOME="${XDG_CONFIG_HOME:-$HOME/.config}"
         export XDG_DATA_HOME="${XDG_DATA_HOME:-$HOME/.local/share}"
         export XDG_CACHE_HOME="${XDG_CACHE_HOME:-$HOME/.cache}"

--- a/distro/customer-vps/host-bin/matrix-code
+++ b/distro/customer-vps/host-bin/matrix-code
@@ -11,7 +11,9 @@ CODE_SERVER_UPSTREAM_PORT="${MATRIX_CODE_SERVER_UPSTREAM_PORT:-8788}"
 export MATRIX_HOME="${MATRIX_HOME:-/home/matrix/home}"
 if declare -F matrix_export_owner_env >/dev/null 2>&1; then
   matrix_export_owner_env
-  matrix_reconcile_owner_home "${MATRIX_RUNTIME_USER:-matrix}" "${MATRIX_RUNTIME_GROUP:-${MATRIX_RUNTIME_USER:-matrix}}"
+  if declare -F matrix_reconcile_owner_home >/dev/null 2>&1; then
+    matrix_reconcile_owner_home "${MATRIX_RUNTIME_USER:-matrix}" "${MATRIX_RUNTIME_GROUP:-${MATRIX_RUNTIME_USER:-matrix}}"
+  fi
 else
   export HOME="$MATRIX_HOME"
   export PATH="$MATRIX_HOME/.local/bin:/opt/matrix/runtime/node/bin:/usr/local/bin:$PATH"

--- a/distro/customer-vps/host-bin/matrix-code
+++ b/distro/customer-vps/host-bin/matrix-code
@@ -11,6 +11,7 @@ CODE_SERVER_UPSTREAM_PORT="${MATRIX_CODE_SERVER_UPSTREAM_PORT:-8788}"
 export MATRIX_HOME="${MATRIX_HOME:-/home/matrix/home}"
 if declare -F matrix_export_owner_env >/dev/null 2>&1; then
   matrix_export_owner_env
+  matrix_reconcile_owner_home "${MATRIX_RUNTIME_USER:-matrix}" "${MATRIX_RUNTIME_GROUP:-${MATRIX_RUNTIME_USER:-matrix}}"
 else
   export HOME="$MATRIX_HOME"
   export PATH="$MATRIX_HOME/.local/bin:/opt/matrix/runtime/node/bin:/usr/local/bin:$PATH"

--- a/distro/customer-vps/host-bin/matrix-gateway
+++ b/distro/customer-vps/host-bin/matrix-gateway
@@ -21,6 +21,7 @@ export NODE_ENV="${NODE_ENV:-production}"
 export MATRIX_HOME="${MATRIX_HOME:-/home/matrix/home}"
 if declare -F matrix_export_owner_env >/dev/null 2>&1; then
   matrix_export_owner_env
+  matrix_reconcile_owner_home "${MATRIX_RUNTIME_USER:-matrix}" "${MATRIX_RUNTIME_GROUP:-${MATRIX_RUNTIME_USER:-matrix}}"
 else
   export HOME="$MATRIX_HOME"
 fi

--- a/distro/customer-vps/host-bin/matrix-gateway
+++ b/distro/customer-vps/host-bin/matrix-gateway
@@ -21,7 +21,9 @@ export NODE_ENV="${NODE_ENV:-production}"
 export MATRIX_HOME="${MATRIX_HOME:-/home/matrix/home}"
 if declare -F matrix_export_owner_env >/dev/null 2>&1; then
   matrix_export_owner_env
-  matrix_reconcile_owner_home "${MATRIX_RUNTIME_USER:-matrix}" "${MATRIX_RUNTIME_GROUP:-${MATRIX_RUNTIME_USER:-matrix}}"
+  if declare -F matrix_reconcile_owner_home >/dev/null 2>&1; then
+    matrix_reconcile_owner_home "${MATRIX_RUNTIME_USER:-matrix}" "${MATRIX_RUNTIME_GROUP:-${MATRIX_RUNTIME_USER:-matrix}}"
+  fi
 else
   export HOME="$MATRIX_HOME"
 fi

--- a/distro/customer-vps/host-bin/matrix-owner-env
+++ b/distro/customer-vps/host-bin/matrix-owner-env
@@ -13,6 +13,7 @@ matrix_prepend_path_once() {
 matrix_export_owner_env() {
   export MATRIX_HOME="${MATRIX_HOME:-/home/matrix/home}"
   export HOME="$MATRIX_HOME"
+  export HERMES_HOME="${HERMES_HOME:-$HOME/.hermes}"
   export XDG_CONFIG_HOME="${XDG_CONFIG_HOME:-$HOME/.config}"
   export XDG_DATA_HOME="${XDG_DATA_HOME:-$HOME/.local/share}"
   export XDG_CACHE_HOME="${XDG_CACHE_HOME:-$HOME/.cache}"
@@ -22,18 +23,32 @@ matrix_export_owner_env() {
   matrix_prepend_path_once "$HOME/.local/bin"
 }
 
+matrix_install_dir() {
+  local path="$1"
+  local mode="$2"
+  local owner="${3:-matrix}"
+  local group="${4:-$owner}"
+
+  if [ "$(id -u)" = "0" ]; then
+    install -d -o "$owner" -g "$group" -m "$mode" "$path"
+    return
+  fi
+
+  mkdir -p "$path"
+  chmod "$mode" "$path" 2>/dev/null || true
+}
+
 matrix_install_owner_dirs() {
   local owner="${1:-matrix}"
   local group="${2:-$owner}"
-  install -d -o "$owner" -g "$group" -m 0755 \
-    "$MATRIX_HOME" \
-    "$MATRIX_HOME/.local" \
-    "$MATRIX_HOME/.local/bin" \
-    "$MATRIX_HOME/.local/share" \
-    "$MATRIX_HOME/.cache" \
-    "$MATRIX_HOME/.config" \
-    "$MATRIX_HOME/.config/systemd" \
-    "$MATRIX_HOME/.config/systemd/user"
+  matrix_install_dir "$MATRIX_HOME" 0755 "$owner" "$group"
+  matrix_install_dir "$MATRIX_HOME/.local" 0755 "$owner" "$group"
+  matrix_install_dir "$MATRIX_HOME/.local/bin" 0755 "$owner" "$group"
+  matrix_install_dir "$MATRIX_HOME/.local/share" 0755 "$owner" "$group"
+  matrix_install_dir "$MATRIX_HOME/.cache" 0755 "$owner" "$group"
+  matrix_install_dir "$MATRIX_HOME/.config" 0755 "$owner" "$group"
+  matrix_install_dir "$MATRIX_HOME/.config/systemd" 0755 "$owner" "$group"
+  matrix_install_dir "$MATRIX_HOME/.config/systemd/user" 0755 "$owner" "$group"
 }
 
 matrix_migrate_legacy_dotdir() {
@@ -41,10 +56,10 @@ matrix_migrate_legacy_dotdir() {
   local mode="${2:-0755}"
   local owner="${MATRIX_RUNTIME_USER:-matrix}"
   local group="${MATRIX_RUNTIME_GROUP:-$owner}"
-  local legacy="/home/matrix/$name"
+  local legacy="${MATRIX_LEGACY_HOME:-/home/matrix}/$name"
   local target="$MATRIX_HOME/$name"
 
-  install -d -o "$owner" -g "$group" -m "$mode" "$target"
+  matrix_install_dir "$target" "$mode" "$owner" "$group"
   if [ -d "$legacy" ] && [ ! -L "$legacy" ]; then
     if ! cp -an "$legacy/." "$target/"; then
       printf 'matrix-owner-env: failed to copy %s to %s; leaving legacy directory in place\n' "$legacy" "$target" >&2
@@ -54,6 +69,19 @@ matrix_migrate_legacy_dotdir() {
   fi
   if [ ! -e "$legacy" ] || [ -L "$legacy" ]; then
     ln -sfn "$target" "$legacy"
-    chown -h "$owner:$group" "$legacy"
+    if [ "$(id -u)" = "0" ]; then
+      chown -h "$owner:$group" "$legacy"
+    fi
   fi
+}
+
+matrix_reconcile_owner_home() {
+  local owner="${1:-matrix}"
+  local group="${2:-$owner}"
+
+  matrix_install_owner_dirs "$owner" "$group"
+  matrix_migrate_legacy_dotdir ".local" 0755
+  matrix_migrate_legacy_dotdir ".cache" 0755
+  matrix_migrate_legacy_dotdir ".config" 0755
+  matrix_migrate_legacy_dotdir ".hermes" 0700
 }

--- a/distro/customer-vps/host-bin/matrix-owner-env
+++ b/distro/customer-vps/host-bin/matrix-owner-env
@@ -54,8 +54,8 @@ matrix_install_owner_dirs() {
 matrix_migrate_legacy_dotdir() {
   local name="$1"
   local mode="${2:-0755}"
-  local owner="${MATRIX_RUNTIME_USER:-matrix}"
-  local group="${MATRIX_RUNTIME_GROUP:-$owner}"
+  local owner="${3:-${MATRIX_RUNTIME_USER:-matrix}}"
+  local group="${4:-${MATRIX_RUNTIME_GROUP:-$owner}}"
   local legacy="${MATRIX_LEGACY_HOME:-/home/matrix}/$name"
   local target="$MATRIX_HOME/$name"
 
@@ -65,7 +65,10 @@ matrix_migrate_legacy_dotdir() {
       printf 'matrix-owner-env: failed to copy %s to %s; leaving legacy directory in place\n' "$legacy" "$target" >&2
       return 0
     fi
-    rm -rf "$legacy"
+    if ! rm -rf "$legacy"; then
+      printf 'matrix-owner-env: failed to remove legacy %s after copy; leaving in place\n' "$legacy" >&2
+      return 0
+    fi
   fi
   if [ ! -e "$legacy" ] || [ -L "$legacy" ]; then
     ln -sfn "$target" "$legacy"
@@ -80,8 +83,8 @@ matrix_reconcile_owner_home() {
   local group="${2:-$owner}"
 
   matrix_install_owner_dirs "$owner" "$group"
-  matrix_migrate_legacy_dotdir ".local" 0755
-  matrix_migrate_legacy_dotdir ".cache" 0755
-  matrix_migrate_legacy_dotdir ".config" 0755
-  matrix_migrate_legacy_dotdir ".hermes" 0700
+  matrix_migrate_legacy_dotdir ".local" 0755 "$owner" "$group"
+  matrix_migrate_legacy_dotdir ".cache" 0755 "$owner" "$group"
+  matrix_migrate_legacy_dotdir ".config" 0755 "$owner" "$group"
+  matrix_migrate_legacy_dotdir ".hermes" 0700 "$owner" "$group"
 }

--- a/distro/customer-vps/host-bin/matrix-shell
+++ b/distro/customer-vps/host-bin/matrix-shell
@@ -14,7 +14,9 @@ export NODE_ENV="${NODE_ENV:-production}"
 export MATRIX_HOME="${MATRIX_HOME:-/home/matrix/home}"
 if declare -F matrix_export_owner_env >/dev/null 2>&1; then
   matrix_export_owner_env
-  matrix_reconcile_owner_home "${MATRIX_RUNTIME_USER:-matrix}" "${MATRIX_RUNTIME_GROUP:-${MATRIX_RUNTIME_USER:-matrix}}"
+  if declare -F matrix_reconcile_owner_home >/dev/null 2>&1; then
+    matrix_reconcile_owner_home "${MATRIX_RUNTIME_USER:-matrix}" "${MATRIX_RUNTIME_GROUP:-${MATRIX_RUNTIME_USER:-matrix}}"
+  fi
 else
   export HOME="$MATRIX_HOME"
 fi

--- a/distro/customer-vps/host-bin/matrix-shell
+++ b/distro/customer-vps/host-bin/matrix-shell
@@ -14,6 +14,7 @@ export NODE_ENV="${NODE_ENV:-production}"
 export MATRIX_HOME="${MATRIX_HOME:-/home/matrix/home}"
 if declare -F matrix_export_owner_env >/dev/null 2>&1; then
   matrix_export_owner_env
+  matrix_reconcile_owner_home "${MATRIX_RUNTIME_USER:-matrix}" "${MATRIX_RUNTIME_GROUP:-${MATRIX_RUNTIME_USER:-matrix}}"
 else
   export HOME="$MATRIX_HOME"
 fi

--- a/distro/customer-vps/host-bin/matrix-symphony
+++ b/distro/customer-vps/host-bin/matrix-symphony
@@ -16,6 +16,7 @@ WORKFLOW_FILE="${SYMPHONY_WORKFLOW_FILE:-$APP_DIR/packages/symphony-elixir/WORKF
 export MATRIX_HOME="${MATRIX_HOME:-/home/matrix/home}"
 if declare -F matrix_export_owner_env >/dev/null 2>&1; then
   matrix_export_owner_env
+  matrix_reconcile_owner_home "${MATRIX_RUNTIME_USER:-matrix}" "${MATRIX_RUNTIME_GROUP:-${MATRIX_RUNTIME_USER:-matrix}}"
 else
   export HOME="$MATRIX_HOME"
 fi

--- a/distro/customer-vps/host-bin/matrix-symphony
+++ b/distro/customer-vps/host-bin/matrix-symphony
@@ -16,7 +16,9 @@ WORKFLOW_FILE="${SYMPHONY_WORKFLOW_FILE:-$APP_DIR/packages/symphony-elixir/WORKF
 export MATRIX_HOME="${MATRIX_HOME:-/home/matrix/home}"
 if declare -F matrix_export_owner_env >/dev/null 2>&1; then
   matrix_export_owner_env
-  matrix_reconcile_owner_home "${MATRIX_RUNTIME_USER:-matrix}" "${MATRIX_RUNTIME_GROUP:-${MATRIX_RUNTIME_USER:-matrix}}"
+  if declare -F matrix_reconcile_owner_home >/dev/null 2>&1; then
+    matrix_reconcile_owner_home "${MATRIX_RUNTIME_USER:-matrix}" "${MATRIX_RUNTIME_GROUP:-${MATRIX_RUNTIME_USER:-matrix}}"
+  fi
 else
   export HOME="$MATRIX_HOME"
 fi

--- a/tests/platform/customer-vps-cloud-init.test.ts
+++ b/tests/platform/customer-vps-cloud-init.test.ts
@@ -360,6 +360,7 @@ exit 99
     expect(cloudInit).toContain('path: /etc/profile.d/matrix-runtime.sh');
     expect(cloudInit).toContain('export MATRIX_HOME="${MATRIX_HOME:-/home/matrix/home}"');
     expect(cloudInit).toContain('export HOME="$MATRIX_HOME"');
+    expect(cloudInit).toContain('export HERMES_HOME="${HERMES_HOME:-$HOME/.hermes}"');
     expect(cloudInit).toContain('export XDG_CONFIG_HOME="${XDG_CONFIG_HOME:-$HOME/.config}"');
     expect(cloudInit).toContain('export PATH="$HOME/.local/bin:/opt/matrix/bin:/opt/matrix/runtime/node/bin:$PATH"');
     expect(cloudInit).toContain('install -d -o matrix -g matrix -m 0755 /home/matrix /home/matrix/home /home/matrix/home/.local /home/matrix/home/.local/bin /home/matrix/home/.local/share /home/matrix/home/.cache /home/matrix/home/.config');

--- a/tests/platform/customer-vps-host-bundle.test.ts
+++ b/tests/platform/customer-vps-host-bundle.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { existsSync, lstatSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { spawnSync } from 'node:child_process';
@@ -77,6 +77,10 @@ describe('customer VPS host bundle', () => {
     const installer = readFileSync(join(root, 'distro/customer-vps/host-bin/matrix-install-tool-pack'), 'utf8');
     const hermesInstaller = readFileSync(join(root, 'distro/customer-vps/host-bin/matrix-install-hermes'), 'utf8');
     const ownerEnv = readFileSync(join(root, 'distro/customer-vps/host-bin/matrix-owner-env'), 'utf8');
+    const gateway = readFileSync(join(root, 'distro/customer-vps/host-bin/matrix-gateway'), 'utf8');
+    const shell = readFileSync(join(root, 'distro/customer-vps/host-bin/matrix-shell'), 'utf8');
+    const code = readFileSync(join(root, 'distro/customer-vps/host-bin/matrix-code'), 'utf8');
+    const symphony = readFileSync(join(root, 'distro/customer-vps/host-bin/matrix-symphony'), 'utf8');
 
     expect(script).toContain('matrix-install-tool-pack');
     expect(script).toContain('matrix-owner-env');
@@ -106,16 +110,63 @@ describe('customer VPS host bundle', () => {
     expect(installer).not.toMatch(/wait "\$pid_coding_agents" "\$pid_code_server"/);
     expect(ownerEnv).toContain('matrix_export_owner_env()');
     expect(ownerEnv).toContain('export HOME="$MATRIX_HOME"');
+    expect(ownerEnv).toContain('export HERMES_HOME="${HERMES_HOME:-$HOME/.hermes}"');
     expect(ownerEnv).toContain('export XDG_CONFIG_HOME="${XDG_CONFIG_HOME:-$HOME/.config}"');
     expect(ownerEnv).toContain('matrix_prepend_path_once()');
     expect(ownerEnv).toContain('matrix_prepend_path_once "$HOME/.local/bin"');
     expect(ownerEnv).toContain('matrix_prepend_path_once "/opt/matrix/bin"');
+    expect(ownerEnv).toContain('matrix_reconcile_owner_home()');
     expect(ownerEnv).toContain('failed to copy %s to %s; leaving legacy directory in place');
     expect(hermesInstaller).toContain('source /opt/matrix/bin/matrix-owner-env');
     expect(hermesInstaller).toContain('matrix_install_owner_dirs "$MATRIX_RUNTIME_USER" "$MATRIX_RUNTIME_USER"');
     expect(hermesInstaller).toContain('matrix_migrate_legacy_dotdir ".hermes" 0700');
     expect(hermesInstaller).toContain('HOME="$MATRIX_RUNTIME_HOME"');
+    expect(hermesInstaller).toContain('HERMES_HOME="$HERMES_HOME"');
     expect(hermesInstaller).toContain('XDG_CONFIG_HOME="$MATRIX_RUNTIME_HOME/.config"');
+    for (const launcher of [gateway, shell, code, symphony]) {
+      expect(launcher).toContain('matrix_reconcile_owner_home "${MATRIX_RUNTIME_USER:-matrix}" "${MATRIX_RUNTIME_GROUP:-${MATRIX_RUNTIME_USER:-matrix}}"');
+    }
+  });
+
+  it('owner env canonicalizes Hermes home and migrates legacy Hermes data', () => {
+    const root = process.cwd();
+    const tempDir = mkdtempSync(join(tmpdir(), 'matrix-owner-env-'));
+    const matrixHome = join(tempDir, 'home');
+    const legacyHome = join(tempDir, 'legacy');
+    const legacyJobDir = join(legacyHome, '.hermes', 'jobs');
+
+    try {
+      mkdirSync(legacyJobDir, { recursive: true });
+      writeFileSync(join(legacyJobDir, 'watcher.json'), '{"status":"paused"}\n');
+
+      const result = spawnSync('bash', ['-c', `
+set -euo pipefail
+source "$OWNER_ENV"
+matrix_export_owner_env
+matrix_reconcile_owner_home "$(id -un)" "$(id -gn)"
+printf 'HOME=%s\\nHERMES_HOME=%s\\n' "$HOME" "$HERMES_HOME"
+test -f "$MATRIX_HOME/.hermes/jobs/watcher.json"
+test -L "$MATRIX_LEGACY_HOME/.hermes"
+test "$(readlink "$MATRIX_LEGACY_HOME/.hermes")" = "$MATRIX_HOME/.hermes"
+`], {
+        cwd: root,
+        encoding: 'utf8',
+        env: {
+          ...process.env,
+          OWNER_ENV: join(root, 'distro/customer-vps/host-bin/matrix-owner-env'),
+          MATRIX_HOME: matrixHome,
+          MATRIX_LEGACY_HOME: legacyHome,
+        },
+      });
+
+      expect(result.status, result.stderr || result.stdout).toBe(0);
+      expect(result.stdout).toContain(`HOME=${matrixHome}`);
+      expect(result.stdout).toContain(`HERMES_HOME=${matrixHome}/.hermes`);
+      expect(existsSync(join(matrixHome, '.hermes', 'jobs', 'watcher.json'))).toBe(true);
+      expect(lstatSync(join(legacyHome, '.hermes')).isSymbolicLink()).toBe(true);
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
   });
 
   it('host bundle manifest keeps the sync-agent compatibility fields', () => {

--- a/tests/platform/customer-vps-host-bundle.test.ts
+++ b/tests/platform/customer-vps-host-bundle.test.ts
@@ -117,6 +117,9 @@ describe('customer VPS host bundle', () => {
     expect(ownerEnv).toContain('matrix_prepend_path_once "/opt/matrix/bin"');
     expect(ownerEnv).toContain('matrix_reconcile_owner_home()');
     expect(ownerEnv).toContain('failed to copy %s to %s; leaving legacy directory in place');
+    expect(ownerEnv).toContain('failed to remove legacy %s after copy; leaving in place');
+    expect(ownerEnv).toContain('matrix_migrate_legacy_dotdir ".local" 0755 "$owner" "$group"');
+    expect(ownerEnv).toContain('matrix_migrate_legacy_dotdir ".hermes" 0700 "$owner" "$group"');
     expect(hermesInstaller).toContain('source /opt/matrix/bin/matrix-owner-env');
     expect(hermesInstaller).toContain('matrix_install_owner_dirs "$MATRIX_RUNTIME_USER" "$MATRIX_RUNTIME_USER"');
     expect(hermesInstaller).toContain('matrix_migrate_legacy_dotdir ".hermes" 0700');
@@ -124,6 +127,7 @@ describe('customer VPS host bundle', () => {
     expect(hermesInstaller).toContain('HERMES_HOME="$HERMES_HOME"');
     expect(hermesInstaller).toContain('XDG_CONFIG_HOME="$MATRIX_RUNTIME_HOME/.config"');
     for (const launcher of [gateway, shell, code, symphony]) {
+      expect(launcher).toContain('if declare -F matrix_reconcile_owner_home >/dev/null 2>&1; then');
       expect(launcher).toContain('matrix_reconcile_owner_home "${MATRIX_RUNTIME_USER:-matrix}" "${MATRIX_RUNTIME_GROUP:-${MATRIX_RUNTIME_USER:-matrix}}"');
     }
   });


### PR DESCRIPTION
## Summary
- Canonicalize customer VPS Hermes state under `/home/matrix/home/.hermes` by exporting `HERMES_HOME` from the owner env and login profile.
- Reconcile legacy owner dotdirs at service startup, including a one-time copy of legacy `/home/matrix/.hermes` data followed by a compatibility symlink.
- Harden startup compatibility by guarding the new reconcile helper, preserving owner/group arguments during migration, and leaving legacy directories in place if removal fails.
- Add host bundle and cloud-init tests for Hermes migration, launcher wiring, and the canonical `HERMES_HOME` export.

## Tests
- `bun run test`
- `bun run test tests/platform/customer-vps-host-bundle.test.ts tests/platform/customer-vps-cloud-init.test.ts`
- `bun run typecheck`
- `bun run check:patterns`
- `bash -n distro/customer-vps/host-bin/matrix-owner-env distro/customer-vps/host-bin/matrix-gateway distro/customer-vps/host-bin/matrix-shell distro/customer-vps/host-bin/matrix-code distro/customer-vps/host-bin/matrix-symphony`
- `git diff --check`

## Review/Monitoring
- Addressed Greptile findings about legacy owner-env compatibility and unguarded legacy directory removal.
- Addressed Codex review feedback about owner/group propagation through dotdir migration.
- Monitoring current head for fresh checks and latest trusted Greptile score.

## Live verification
- Repaired the hamedmp VPS by making `/home/matrix/.hermes` a symlink to `/home/matrix/home/.hermes` after copying legacy data into the canonical home.
- Restarted the Discord gateway with `HOME=/home/matrix/home` and `HERMES_HOME=/home/matrix/home/.hermes`.
- Resumed and manually triggered job `88336deeb165`; the job finished with `last_status=ok` and `last_error=null`.
- Confirmed the gateway, shell, code, Symphony, and sync-agent services were active and local gateway health returned `ok`.

## Invariants
- **Source of truth**: `/home/matrix/home/.hermes` is the canonical Hermes home for customer VPS runtime services. `/home/matrix/.hermes` is kept only as a compatibility symlink after migration.
- **Lock/transaction scope**: No database transaction is involved. Startup reconciliation performs local filesystem directory creation, copy-if-missing, and symlink replacement before service startup. There are no network calls in this path.
- **Acceptable orphan states**: If legacy copy or removal fails, the legacy directory is left in place and the service logs the failure instead of deleting data or crashing. If symlink replacement fails after a successful copy, canonical data remains under `MATRIX_HOME` and a later startup can retry reconciliation.
- **Auth source of truth**: Existing Matrix OS service auth remains unchanged. Hermes credentials and watcher state remain owner-local files under the canonical owner home.
- **Deferred scope**: This does not manage arbitrary third-party Hermes launcher scripts or Discord token configuration. The live hamedmp watcher retry patch was an operational repair and is not included in this bundle change.