### PR TITLE
fix(desktop): derive prerelease mac manifests

### DIFF
--- a/.github/actions/merge-mac-manifests/merge-mac-manifests.mjs
+++ b/.github/actions/merge-mac-manifests/merge-mac-manifests.mjs
@@ -24,12 +24,18 @@ if (!directory) {
 }
 
 const names = await readdir(directory);
-const manifestNames = names
+let manifestNames = names
   .filter((name) => {
     if (channel) return name.endsWith(`-${channel}-mac.yml`);
     return /^(arm64|x64)-mac\.yml$/.test(name);
   })
   .sort((a, b) => a.localeCompare(b));
+
+if (channel && manifestNames.length === 0) {
+  manifestNames = names.filter((name) => /^(arm64|x64)-mac\.yml$/.test(name)).sort((a, b) => a.localeCompare(b));
+  console.log(`no ${channel} mac manifests found; falling back to architecture mac manifests`);
+}
+
 if (manifestNames.length < 2) {
   throw new Error(`expected at least 2 mac manifests in ${directory}, found ${manifestNames.length}`);
 }

--- a/tests/desktop/desktop-release-workflows.test.ts
+++ b/tests/desktop/desktop-release-workflows.test.ts
@@ -166,4 +166,28 @@ describe("desktop release workflows", () => {
       rmSync(dir, { recursive: true, force: true });
     }
   });
+
+  it("falls back to architecture mac manifests when a prerelease channel manifest is missing", () => {
+    const dir = mkdtempSync(join(tmpdir(), "matrix-desktop-release-"));
+    try {
+      writeFileSync(
+        join(dir, "x64-mac.yml"),
+        "version: 1.2.3-dev.1\nfiles:\n  - url: dev-x64.zip\n    sha512: dev-x64\n    size: 2\npath: dev-x64.zip\nsha512: dev-x64\n",
+      );
+      writeFileSync(
+        join(dir, "arm64-mac.yml"),
+        "version: 1.2.3-dev.1\nfiles:\n  - url: dev-arm64.zip\n    sha512: dev-arm64\n    size: 1\npath: dev-arm64.zip\nsha512: dev-arm64\n",
+      );
+
+      execFileSync(process.execPath, [join(root, ".github/actions/merge-mac-manifests/merge-mac-manifests.mjs")], {
+        env: { ...process.env, INPUT_DIRECTORY: dir, INPUT_OUTPUT: "dev-mac.yml", INPUT_CHANNEL: "dev" },
+      });
+
+      const dev = readFileSync(join(dir, "dev-mac.yml"), "utf8");
+      expect(dev).toContain("url: dev-arm64.zip");
+      expect(dev).toContain("url: dev-x64.zip");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
 });


### PR DESCRIPTION
## Summary
- Make the macOS manifest merge helper fall back to architecture manifests when a prerelease channel has no channel-specific manifests.
- Preserve channel-specific manifest behavior when electron-builder emits those files.
- Add a regression test for the dev release shape from the failed publish job.

## Validation
- `bun run test tests/desktop/desktop-release-workflows.test.ts tests/desktop/update-config.test.ts`
- `pnpm --filter desktop typecheck`
- `bun run check:patterns` (0 violations; existing warnings only)
- `git diff --check`

## Invariants
- Source of truth: downloaded desktop build artifacts under `desktop-release`; channel manifests are derived only from those packaged artifacts.
- Lock/transaction scope: not applicable; this is release artifact assembly with no DB writes or runtime state mutation.
- Acceptable orphan states: if fewer than two mac architecture manifests exist, publish still fails before creating a GitHub release.
- Auth source of truth: unchanged; GitHub Actions token and release permissions are untouched.
- Deferred scope: no changes to signing/notarization, artifact upload patterns, or Electron updater runtime behavior.