### PR TITLE
fix(desktop): validate mac dmg artifacts

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -114,24 +114,79 @@ jobs:
         working-directory: desktop
         run: pnpm exec electron-builder --config electron-builder.yml --mac --${{ matrix.arch }} --publish never
 
+      - name: Resolve mac artifact metadata
+        id: mac_artifact
+        shell: bash
+        run: |
+          set -euo pipefail
+          package_version="$(node -p "require('./desktop/package.json').version")"
+          {
+            echo "package_version=$package_version"
+            echo "artifact_base=Matrix-OS-${package_version}-mac-${{ matrix.arch }}"
+          } >> "$GITHUB_OUTPUT"
+
       - name: Verify packaged update resources
         shell: bash
+        env:
+          ARTIFACT_BASE: ${{ steps.mac_artifact.outputs.artifact_base }}
         run: |
           set -euo pipefail
           if [ ! -f desktop/dist/latest-mac.yml ]; then
             echo "Missing macOS update manifest: desktop/dist/latest-mac.yml" >&2
             exit 1
           fi
-          if ! find desktop/dist -maxdepth 1 -type f -name "*.dmg" -print -quit | grep -q .; then
-            echo "Missing macOS DMG artifact in desktop/dist" >&2
+          if [ ! -f "desktop/dist/${ARTIFACT_BASE}.dmg" ]; then
+            echo "Missing macOS DMG artifact: desktop/dist/${ARTIFACT_BASE}.dmg" >&2
             exit 1
           fi
-          if ! find desktop/dist -maxdepth 1 -type f -name "*.zip" -print -quit | grep -q .; then
-            echo "Missing macOS ZIP artifact in desktop/dist" >&2
+          if [ ! -f "desktop/dist/${ARTIFACT_BASE}.zip" ]; then
+            echo "Missing macOS ZIP artifact: desktop/dist/${ARTIFACT_BASE}.zip" >&2
+            exit 1
+          fi
+          if [ ! -f "desktop/dist/${ARTIFACT_BASE}.dmg.blockmap" ]; then
+            echo "Missing macOS DMG blockmap: desktop/dist/${ARTIFACT_BASE}.dmg.blockmap" >&2
+            exit 1
+          fi
+          if [ ! -f "desktop/dist/${ARTIFACT_BASE}.zip.blockmap" ]; then
+            echo "Missing macOS ZIP blockmap: desktop/dist/${ARTIFACT_BASE}.zip.blockmap" >&2
+            exit 1
+          fi
+          unexpected_artifact="$(
+            find desktop/dist -maxdepth 1 -type f \
+              \( -name "Matrix-OS-*-mac-*.dmg" -o -name "Matrix-OS-*-mac-*.zip" -o -name "Matrix-OS-*-mac-*.blockmap" \) \
+              ! -name "${ARTIFACT_BASE}.dmg" \
+              ! -name "${ARTIFACT_BASE}.zip" \
+              ! -name "${ARTIFACT_BASE}.dmg.blockmap" \
+              ! -name "${ARTIFACT_BASE}.zip.blockmap" \
+              -print -quit
+          )"
+          if [ -n "$unexpected_artifact" ]; then
+            echo "macOS ${{ matrix.arch }} build produced unexpected artifact: $unexpected_artifact" >&2
             exit 1
           fi
           if ! find desktop/dist -path "*/Matrix OS.app/Contents/Resources/app-update.yml" -type f -print -quit | grep -q .; then
             echo "Missing packaged macOS app-update.yml" >&2
+            exit 1
+          fi
+
+      - name: Smoke test macOS DMG mount
+        shell: bash
+        env:
+          ARTIFACT_BASE: ${{ steps.mac_artifact.outputs.artifact_base }}
+        run: |
+          set -euo pipefail
+          dmg_path="desktop/dist/${ARTIFACT_BASE}.dmg"
+          mount_dir="$(mktemp -d)"
+          copy_dir="$(mktemp -d)"
+          cleanup() {
+            hdiutil detach "$mount_dir" -quiet || true
+            rm -rf "$mount_dir" "$copy_dir"
+          }
+          trap cleanup EXIT
+          hdiutil attach "$dmg_path" -mountpoint "$mount_dir" -nobrowse -readonly
+          ditto "$mount_dir/Matrix OS.app" "$copy_dir/Matrix OS.app"
+          if [ ! -x "$copy_dir/Matrix OS.app/Contents/MacOS/Matrix OS" ]; then
+            echo "Copied macOS app is missing executable entrypoint" >&2
             exit 1
           fi
 

--- a/desktop/electron-builder.yml
+++ b/desktop/electron-builder.yml
@@ -16,10 +16,8 @@ protocols:
 mac:
   category: public.app-category.productivity
   target:
-    - target: dmg
-      arch: [arm64, x64]
-    - target: zip
-      arch: [arm64, x64]
+    - dmg
+    - zip
   hardenedRuntime: true
   gatekeeperAssess: false
   entitlements: build/entitlements.mac.plist

--- a/tests/desktop/desktop-release-workflows.test.ts
+++ b/tests/desktop/desktop-release-workflows.test.ts
@@ -11,10 +11,23 @@ describe("desktop release workflows", () => {
     const workflow = readFileSync(join(root, ".github/workflows/desktop-build.yml"), "utf8");
 
     expect(workflow).toContain("Rename mac update manifest for arch");
+    expect(workflow).toContain("Resolve mac artifact metadata");
+    expect(workflow).toContain('package_version="$(node -p "require(\'./desktop/package.json\').version")"');
+    expect(workflow).toContain('echo "artifact_base=Matrix-OS-${package_version}-mac-${{ matrix.arch }}"');
+    expect(workflow).toContain("ARTIFACT_BASE: ${{ steps.mac_artifact.outputs.artifact_base }}");
     expect(workflow).toContain("[ ! -f desktop/dist/latest-mac.yml ]");
-    expect(workflow).toContain('find desktop/dist -maxdepth 1 -type f -name "*.dmg" -print -quit');
-    expect(workflow).toContain('find desktop/dist -maxdepth 1 -type f -name "*.zip" -print -quit');
+    expect(workflow).toContain('[ ! -f "desktop/dist/${ARTIFACT_BASE}.dmg" ]');
+    expect(workflow).toContain('[ ! -f "desktop/dist/${ARTIFACT_BASE}.zip" ]');
+    expect(workflow).toContain('[ ! -f "desktop/dist/${ARTIFACT_BASE}.dmg.blockmap" ]');
+    expect(workflow).toContain('[ ! -f "desktop/dist/${ARTIFACT_BASE}.zip.blockmap" ]');
+    expect(workflow).toContain('unexpected_artifact="$(');
+    expect(workflow).toContain('-name "Matrix-OS-*-mac-*.dmg"');
+    expect(workflow).toContain('! -name "${ARTIFACT_BASE}.zip.blockmap"');
+    expect(workflow).not.toContain('other_arch="x64"');
     expect(workflow).toContain('find desktop/dist -path "*/Matrix OS.app/Contents/Resources/app-update.yml"');
+    expect(workflow).toContain("Smoke test macOS DMG mount");
+    expect(workflow).toContain('hdiutil attach "$dmg_path" -mountpoint "$mount_dir" -nobrowse -readonly');
+    expect(workflow).toContain('ditto "$mount_dir/Matrix OS.app" "$copy_dir/Matrix OS.app"');
     expect(workflow).toContain('find desktop/dist -maxdepth 1 -type f -name "*.AppImage" -print -quit');
     expect(workflow).toContain("[ ! -f desktop/dist/latest-linux.yml ]");
     expect(workflow).not.toContain("test -f desktop/dist/*.dmg");
@@ -27,6 +40,14 @@ describe("desktop release workflows", () => {
     expect(workflow).toContain('! -name "${{ matrix.arch }}-${CHANNEL}-mac.yml"');
     expect(workflow).toContain("desktop/dist/*-mac.yml");
     expect(workflow).toContain("desktop/dist/*.blockmap");
+  });
+
+  it("lets the mac matrix arch control electron-builder outputs", () => {
+    const config = readFileSync(join(root, "desktop/electron-builder.yml"), "utf8");
+
+    expect(config).toContain("- dmg");
+    expect(config).toContain("- zip");
+    expect(config).not.toContain("arch: [arm64, x64]");
   });
 
   it("falls back from an empty desktop update channel at build time", () => {


### PR DESCRIPTION
## Summary
- let the desktop mac matrix arch control electron-builder output archs
- require exact matrix-arch DMG/ZIP/blockmap artifacts before upload
- mount each generated DMG and copy Matrix OS.app in CI before publishing artifacts

## Tests
- bun run test tests/desktop/desktop-release-workflows.test.ts
- pnpm --filter desktop typecheck
- bun run check:patterns
- git diff --check

## Invariants
- Source of truth: GitHub release artifacts generated by the Desktop Build workflow remain the canonical desktop release payloads.
- Lock/transaction scope: no database or shared state writes; each mac matrix job validates its own local dist output before upload.
- Acceptable orphan states: a failed DMG smoke test stops the mac build before release publication; no partial release is created by this workflow_call job.
- Auth source of truth: unchanged GitHub Actions secrets and release permissions; this PR does not alter runtime auth.
- Deferred scope: notarized Developer ID signing is still dependent on Apple signing secrets being configured separately.