### PR TITLE
fix(integrations): pass Pipedream project environment

### DIFF
--- a/packages/gateway/src/integrations/pipedream.ts
+++ b/packages/gateway/src/integrations/pipedream.ts
@@ -104,7 +104,7 @@ function normalizePipedreamProjectEnvironment(
     return normalized;
   }
 
-  throw new Error("Invalid Pipedream project environment");
+  throw new Error(`Invalid Pipedream project environment: "${value}"`);
 }
 
 export async function createPipedreamClient(

--- a/packages/gateway/src/integrations/pipedream.ts
+++ b/packages/gateway/src/integrations/pipedream.ts
@@ -90,6 +90,23 @@ export interface PipedreamConnectClient {
 const API_TIMEOUT_SECONDS = 10;
 const ACTION_TIMEOUT_SECONDS = 30;
 
+type PipedreamProjectEnvironment = "development" | "production";
+
+function normalizePipedreamProjectEnvironment(
+  value: string | undefined,
+): PipedreamProjectEnvironment {
+  if (value === undefined || value.trim() === "") {
+    return "production";
+  }
+
+  const normalized = value.trim().toLowerCase();
+  if (normalized === "development" || normalized === "production") {
+    return normalized;
+  }
+
+  throw new Error("Invalid Pipedream project environment");
+}
+
 export async function createPipedreamClient(
   config: PipedreamConfig,
 ): Promise<PipedreamConnectClient> {
@@ -98,6 +115,7 @@ export async function createPipedreamClient(
     clientId: config.clientId,
     clientSecret: config.clientSecret,
     projectId: config.projectId,
+    projectEnvironment: normalizePipedreamProjectEnvironment(config.environment),
   });
 
   return {

--- a/tests/integrations/pipedream.test.ts
+++ b/tests/integrations/pipedream.test.ts
@@ -9,15 +9,21 @@ const {
   mockTokensCreate,
   mockAccountsDelete,
   mockProxyPost,
+  mockPipedreamConstructors,
 } = vi.hoisted(() => ({
   mockTokensCreate: vi.fn(),
   mockAccountsDelete: vi.fn(),
   mockProxyPost: vi.fn(),
+  mockPipedreamConstructors: vi.fn(),
 }));
 
 vi.mock("@pipedream/sdk", () => {
   return {
     PipedreamClient: class MockPipedreamClient {
+      constructor(options: unknown) {
+        mockPipedreamConstructors(options);
+      }
+
       tokens = { create: mockTokensCreate };
       accounts = { delete: mockAccountsDelete };
       proxy = { post: mockProxyPost };
@@ -39,6 +45,64 @@ const TEST_CONFIG: PipedreamConfig = {
 describe("Pipedream Connect SDK Wrapper", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+  });
+
+  it("passes projectEnvironment to the Pipedream SDK", async () => {
+    await createPipedreamClient({
+      clientId: "test-client-id",
+      clientSecret: "test-client-secret",
+      projectId: "test-project-id",
+      environment: "production",
+    });
+
+    expect(mockPipedreamConstructors).toHaveBeenCalledWith(
+      expect.objectContaining({
+        clientId: "test-client-id",
+        clientSecret: "test-client-secret",
+        projectId: "test-project-id",
+        projectEnvironment: "production",
+      }),
+    );
+  });
+
+  it("normalizes development project environment", async () => {
+    await createPipedreamClient({
+      clientId: "test-client-id",
+      clientSecret: "test-client-secret",
+      projectId: "test-project-id",
+      environment: " DEVELOPMENT ",
+    });
+
+    expect(mockPipedreamConstructors).toHaveBeenCalledWith(
+      expect.objectContaining({
+        projectEnvironment: "development",
+      }),
+    );
+  });
+
+  it("defaults missing project environment to production", async () => {
+    await createPipedreamClient({
+      clientId: "test-client-id",
+      clientSecret: "test-client-secret",
+      projectId: "test-project-id",
+    });
+
+    expect(mockPipedreamConstructors).toHaveBeenCalledWith(
+      expect.objectContaining({
+        projectEnvironment: "production",
+      }),
+    );
+  });
+
+  it("rejects unsupported Pipedream project environments", async () => {
+    await expect(
+      createPipedreamClient({
+        clientId: "test-client-id",
+        clientSecret: "test-client-secret",
+        projectId: "test-project-id",
+        environment: "staging",
+      }),
+    ).rejects.toThrow("Invalid Pipedream project environment");
   });
 
   it("creates a connect token for a user", async () => {

--- a/tests/integrations/pipedream.test.ts
+++ b/tests/integrations/pipedream.test.ts
@@ -94,6 +94,21 @@ describe("Pipedream Connect SDK Wrapper", () => {
     );
   });
 
+  it("defaults blank project environment to production", async () => {
+    await createPipedreamClient({
+      clientId: "test-client-id",
+      clientSecret: "test-client-secret",
+      projectId: "test-project-id",
+      environment: "   ",
+    });
+
+    expect(mockPipedreamConstructors).toHaveBeenCalledWith(
+      expect.objectContaining({
+        projectEnvironment: "production",
+      }),
+    );
+  });
+
   it("rejects unsupported Pipedream project environments", async () => {
     await expect(
       createPipedreamClient({


### PR DESCRIPTION
## Summary

- Pass normalized `projectEnvironment` to `@pipedream/sdk` when constructing the Pipedream Connect client.
- Default missing or blank Pipedream environment config to `production` and reject unsupported values before SDK use.
- Add constructor-option regression coverage for production, normalized development, missing/blank production defaults, and invalid environments.

## Tests

- `pnpm vitest run tests/integrations/pipedream.test.ts`
- `pnpm --filter '@matrix-os/gateway' exec tsc --noEmit`
- `pnpm vitest run tests/integrations/routes.test.ts tests/platform/internal-integration-routes.test.ts` initially: gateway route suite passed; platform suite needed `@matrix-os/observability` build in the fresh worktree.
- `pnpm --filter '@matrix-os/observability' build`
- `pnpm vitest run tests/platform/internal-integration-routes.test.ts`
- `./scripts/review/check-patterns.sh` (0 violations, existing scanner warnings only)

Note: `bun run check:patterns` could not start in this coding environment because `bun` is not installed on PATH; the same shell scanner was run directly.

## Review/Monitoring

- CI/checks green on latest commit `72604a5992cc2fd93f0ddbd9a58caddf3a9d9830`.
- Latest trusted Greptile result: 5/5.
- Prior Greptile comments were fixed in the follow-up commit and their review threads are resolved.
- No React files changed; React Doctor not applicable.

## Invariants

Source of truth:
Pipedream Connect project credentials live in GCP Secret Manager and are loaded by matrix-platform Cloud Run.

Lock/transaction scope:
No DB writes are changed. OAuth connect token creation remains an external Pipedream SDK call with timeout.

Acceptable orphan states:
If Pipedream token creation fails, no Matrix DB state is mutated and the client receives a generic failure.

Auth source of truth:
Customer VPS gateways authenticate to platform internal integration routes with per-host UPGRADE_TOKEN. Platform authenticates to Pipedream with Secret Manager credentials.

Deferred scope:
This PR does not rotate Pipedream credentials, redesign integration onboarding UI, or change connected-service sync semantics.
