### PR TITLE
ci(docker): keep scenario push checks green

### DIFF
--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -137,10 +137,6 @@ jobs:
         if: github.event_name != 'pull_request'
         run: echo "Full Docker scenario matrix covers push runs; PR smoke runs only on pull_request events."
 
-      - name: Skip Docker smoke for docs-only changes
-        if: needs.changes.outputs.should_run != 'true' && github.event_name == 'pull_request'
-        run: echo "No Docker-relevant source changes detected; skipping smoke scenario."
-
       - uses: actions/checkout@v6
         if: needs.changes.outputs.should_run == 'true' && github.event_name == 'pull_request'
 

--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -128,20 +128,24 @@ jobs:
   docker-smoke:
     name: Docker Smoke Test
     needs: [changes, docker-build]
-    if: needs.changes.outputs.should_run == 'true' && github.event_name == 'pull_request'
+    if: needs.changes.outputs.should_run == 'true'
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 45
 
     steps:
+      - name: Record push coverage
+        if: github.event_name != 'pull_request'
+        run: echo "Full Docker scenario matrix covers push runs; PR smoke runs only on pull_request events."
+
       - name: Skip Docker smoke for docs-only changes
-        if: needs.changes.outputs.should_run != 'true'
+        if: needs.changes.outputs.should_run != 'true' && github.event_name == 'pull_request'
         run: echo "No Docker-relevant source changes detected; skipping smoke scenario."
 
       - uses: actions/checkout@v6
-        if: needs.changes.outputs.should_run == 'true'
+        if: needs.changes.outputs.should_run == 'true' && github.event_name == 'pull_request'
 
       - name: Free runner disk before Docker load
-        if: needs.changes.outputs.should_run == 'true'
+        if: needs.changes.outputs.should_run == 'true' && github.event_name == 'pull_request'
         run: |
           df -h
           sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL || true
@@ -149,23 +153,23 @@ jobs:
           df -h
 
       - name: Download Docker image artifact
-        if: needs.changes.outputs.should_run == 'true'
+        if: needs.changes.outputs.should_run == 'true' && github.event_name == 'pull_request'
         uses: actions/download-artifact@v7
         with:
           name: matrix-os-dev-image
           path: /tmp/docker-image
 
       - name: Load Docker image artifact
-        if: needs.changes.outputs.should_run == 'true'
+        if: needs.changes.outputs.should_run == 'true' && github.event_name == 'pull_request'
         run: gzip -dc /tmp/docker-image/matrix-os-dev-ci.tar.gz | docker load
 
       - name: Create CI env file
-        if: needs.changes.outputs.should_run == 'true'
+        if: needs.changes.outputs.should_run == 'true' && github.event_name == 'pull_request'
         run: |
           echo "ANTHROPIC_API_KEY=test-not-used-in-docker-scenarios" > .env.docker
 
       - name: Create CI compose override
-        if: needs.changes.outputs.should_run == 'true'
+        if: needs.changes.outputs.should_run == 'true' && github.event_name == 'pull_request'
         run: |
           cat > docker-compose.ci.yml <<'EOF'
           services:
@@ -179,11 +183,11 @@ jobs:
           EOF
 
       - name: Create external volumes
-        if: needs.changes.outputs.should_run == 'true'
+        if: needs.changes.outputs.should_run == 'true' && github.event_name == 'pull_request'
         run: docker volume create matrixos-ai-auth
 
       - name: Run scenario tests
-        if: needs.changes.outputs.should_run == 'true'
+        if: needs.changes.outputs.should_run == 'true' && github.event_name == 'pull_request'
         run: |
           chmod +x scripts/docker-test/*.sh
           ./scripts/docker-test/fresh-install.sh
@@ -192,14 +196,14 @@ jobs:
           DOCKER_HEALTH_TIMEOUT: "600"
 
       - name: Collect container logs on failure
-        if: failure()
+        if: failure() && github.event_name == 'pull_request'
         run: |
           mkdir -p /tmp/docker-test-logs
           docker compose -f docker-compose.dev.yml -f docker-compose.ci.yml logs --tail 100 > /tmp/docker-test-logs/compose.log 2>&1 || true
           docker compose -f docker-compose.dev.yml -f docker-compose.ci.yml ps -a > /tmp/docker-test-logs/containers.log 2>&1 || true
 
       - name: Upload test logs on failure
-        if: failure()
+        if: failure() && github.event_name == 'pull_request'
         uses: actions/upload-artifact@v7
         with:
           name: docker-test-logs-fresh-install
@@ -207,7 +211,7 @@ jobs:
           retention-days: 7
 
       - name: Cleanup Docker disk
-        if: always()
+        if: always() && github.event_name == 'pull_request'
         run: |
           docker compose -f docker-compose.dev.yml -f docker-compose.ci.yml down -v --remove-orphans || true
           docker system prune -af --volumes || true
@@ -218,7 +222,7 @@ jobs:
     needs: [changes, docker-build]
     if: needs.changes.outputs.should_run == 'true' && github.event_name != 'pull_request'
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 45
     strategy:
       fail-fast: false
       max-parallel: 2

--- a/tests/platform/ci-workflows.test.ts
+++ b/tests/platform/ci-workflows.test.ts
@@ -75,10 +75,11 @@ describe('CI workflows', () => {
   it('gives Docker scenario jobs enough timeout for slow artifact transfer before tests start', () => {
     const root = process.cwd();
     const workflow = readFileSync(join(root, '.github/workflows/docker-test.yml'), 'utf8');
+    const scenariosHeader = workflow.match(/docker-scenarios:[\s\S]*?strategy:/)?.[0] ?? '';
 
     expect(workflow).toContain('docker-scenarios:');
-    expect(workflow).toContain('timeout-minutes: 45');
-    expect(workflow).not.toContain('docker-scenarios:\n    name: Docker Scenario Tests (${{ matrix.scenario }})\n    needs: [changes, docker-build]\n    if: needs.changes.outputs.should_run == \'true\' && github.event_name != \'pull_request\'\n    runs-on: ubuntu-latest\n    timeout-minutes: 20');
+    expect(scenariosHeader).toContain('timeout-minutes: 45');
+    expect(scenariosHeader).not.toContain('timeout-minutes: 20');
   });
 
   it('runs sync-client CI only on the supported Node 20 runtime', () => {

--- a/tests/platform/ci-workflows.test.ts
+++ b/tests/platform/ci-workflows.test.ts
@@ -60,6 +60,27 @@ describe('CI workflows', () => {
     expect(dockerBuildActionUses).toHaveLength(1);
   });
 
+  it('keeps Docker push checks green while reserving smoke execution for pull requests', () => {
+    const root = process.cwd();
+    const workflow = readFileSync(join(root, '.github/workflows/docker-test.yml'), 'utf8');
+    const smokeHeader = workflow.match(/docker-smoke:[\s\S]*?steps:/)?.[0] ?? '';
+
+    expect(workflow).toContain('name: Docker Smoke Test');
+    expect(smokeHeader).toContain("if: needs.changes.outputs.should_run == 'true'");
+    expect(smokeHeader).not.toContain("if: needs.changes.outputs.should_run == 'true' && github.event_name == 'pull_request'");
+    expect(workflow).toContain('name: Record push coverage');
+    expect(workflow).toContain('Full Docker scenario matrix covers push runs; PR smoke runs only on pull_request events.');
+  });
+
+  it('gives Docker scenario jobs enough timeout for slow artifact transfer before tests start', () => {
+    const root = process.cwd();
+    const workflow = readFileSync(join(root, '.github/workflows/docker-test.yml'), 'utf8');
+
+    expect(workflow).toContain('docker-scenarios:');
+    expect(workflow).toContain('timeout-minutes: 45');
+    expect(workflow).not.toContain('docker-scenarios:\n    name: Docker Scenario Tests (${{ matrix.scenario }})\n    needs: [changes, docker-build]\n    if: needs.changes.outputs.should_run == \'true\' && github.event_name != \'pull_request\'\n    runs-on: ubuntu-latest\n    timeout-minutes: 20');
+  });
+
   it('runs sync-client CI only on the supported Node 20 runtime', () => {
     const root = process.cwd();
     const workflow = readFileSync(join(root, '.github/workflows/ci.yml'), 'utf8');


### PR DESCRIPTION
## Summary
- keep Docker Smoke Test green on push runs by recording that the full scenario matrix covers push validation while PRs still execute smoke
- raise Docker smoke/scenario timeouts to 45m so slow artifact download/load cannot consume the whole scenario budget
- add workflow regression tests for push smoke coverage and scenario timeout margin

## Tests
- PASS: flox activate -- bun run test tests/platform/ci-workflows.test.ts
- PASS: flox activate -- bun run check:patterns
- PASS: flox activate -- bun run typecheck
- FAIL: flox activate -- bun run test (7 unrelated local timeout failures: app-db-migration, app-db-query, template-builds, app-registry, device-flow, host-bundle-route, symphony-env-merge; plus one Vitest worker startup timeout)

## Review/Monitoring
- Monitoring GitHub checks and Greptile until the latest trusted result is 5/5.

## Invariants
- N/A: CI workflow/test-only change; no runtime source of truth, auth, transactions, or data model changes.