### PR TITLE
fix(desktop): allow packaged gateway connections

### DIFF
--- a/desktop/src/main/auth/header-injection.ts
+++ b/desktop/src/main/auth/header-injection.ts
@@ -13,7 +13,12 @@ interface WebRequestLike {
   ): void;
   onHeadersReceived(
     listener: (
-      details: { url: string; method: string; responseHeaders?: Record<string, string[]> },
+      details: {
+        url: string;
+        method: string;
+        responseHeaders?: Record<string, string[]>;
+        resourceType?: string;
+      },
       callback: (response: { responseHeaders?: Record<string, string[]>; statusLine?: string }) => void,
     ) => void,
   ): void;
@@ -46,6 +51,55 @@ export function shouldInjectAuth(requestUrl: string, gatewayOrigin: string | nul
   );
 }
 
+function websocketOrigin(origin: string): string | null {
+  try {
+    const url = new URL(origin);
+    if (url.protocol === "https:") url.protocol = "wss:";
+    else if (url.protocol === "http:") url.protocol = "ws:";
+    else return null;
+    return url.origin;
+  } catch {
+    return null;
+  }
+}
+
+function normalizedHttpOrigin(origin: string | null): string | null {
+  if (!origin) return null;
+  try {
+    const url = new URL(origin);
+    if (url.protocol !== "http:" && url.protocol !== "https:") return null;
+    return url.origin;
+  } catch {
+    return null;
+  }
+}
+
+function uniq(values: Array<string | null>): string[] {
+  return Array.from(new Set(values.filter((value): value is string => Boolean(value))));
+}
+
+export function buildRendererCsp(gatewayOrigin: string | null, rendererOrigin: string): string {
+  const gatewayHttpOrigin = normalizedHttpOrigin(gatewayOrigin);
+  const rendererHttpOrigin = rendererOrigin === "null" ? null : normalizedHttpOrigin(rendererOrigin);
+  const connectSources = uniq([
+    "'self'",
+    gatewayHttpOrigin,
+    gatewayHttpOrigin ? websocketOrigin(gatewayHttpOrigin) : null,
+    rendererHttpOrigin,
+    rendererHttpOrigin ? websocketOrigin(rendererHttpOrigin) : null,
+  ]).join(" ");
+
+  return [
+    "default-src 'self'",
+    "script-src 'self'",
+    "style-src 'self' 'unsafe-inline'",
+    `connect-src ${connectSources}`,
+    "worker-src 'self' blob:",
+    "font-src 'self' data:",
+    "img-src 'self' data: https:",
+  ].join("; ");
+}
+
 export function installHeaderInjection(
   rendererSession: SessionLike,
   getToken: () => string | null,
@@ -72,7 +126,17 @@ export function installGatewayCors(
   rendererOrigin: string,
 ): void {
   rendererSession.webRequest.onHeadersReceived((details, callback) => {
-    if (!shouldInjectAuth(details.url, getGatewayOrigin())) {
+    const gatewayOrigin = getGatewayOrigin();
+    const isGatewayResponse = shouldInjectAuth(details.url, gatewayOrigin);
+    const isRendererMainFrame = details.resourceType === "mainFrame" && (() => {
+      try {
+        return new URL(details.url).origin === rendererOrigin;
+      } catch {
+        return false;
+      }
+    })();
+
+    if (!isGatewayResponse && !isRendererMainFrame) {
       callback({});
       return;
     }
@@ -83,16 +147,22 @@ export function installGatewayCors(
         lower !== "access-control-allow-origin" &&
         lower !== "access-control-allow-methods" &&
         lower !== "access-control-allow-headers" &&
-        lower !== "access-control-allow-credentials"
+        lower !== "access-control-allow-credentials" &&
+        lower !== "content-security-policy"
       ) {
         responseHeaders[key] = value;
       }
     }
-    responseHeaders["Access-Control-Allow-Origin"] = [rendererOrigin];
-    responseHeaders["Access-Control-Allow-Methods"] = ["GET, POST, PATCH, PUT, DELETE, OPTIONS"];
-    responseHeaders["Access-Control-Allow-Headers"] = ["Authorization, Content-Type, x-runtime-slot"];
-    responseHeaders["Access-Control-Allow-Credentials"] = ["true"];
-    if (details.method === "OPTIONS") {
+    if (isRendererMainFrame) {
+      responseHeaders["Content-Security-Policy"] = [buildRendererCsp(gatewayOrigin, rendererOrigin)];
+    }
+    if (isGatewayResponse) {
+      responseHeaders["Access-Control-Allow-Origin"] = [rendererOrigin];
+      responseHeaders["Access-Control-Allow-Methods"] = ["GET, POST, PATCH, PUT, DELETE, OPTIONS"];
+      responseHeaders["Access-Control-Allow-Headers"] = ["Authorization, Content-Type, x-runtime-slot"];
+      responseHeaders["Access-Control-Allow-Credentials"] = ["true"];
+    }
+    if (isGatewayResponse && details.method === "OPTIONS") {
       callback({ responseHeaders, statusLine: "HTTP/1.1 200 OK" });
       return;
     }

--- a/desktop/src/renderer/index.html
+++ b/desktop/src/renderer/index.html
@@ -2,15 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <!--
-      CSP: no remote scripts ever; network restricted to https/wss (gateway origin is
-      enforced more tightly at the session layer in main). Monaco needs blob: workers
-      and inline styles. http/ws localhost allowed for dev gateways.
-    -->
-    <meta
-      http-equiv="Content-Security-Policy"
-      content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; connect-src 'self' http://localhost:* ws://localhost:* http://127.0.0.1:* ws://127.0.0.1:*; worker-src 'self' blob:; font-src 'self' data:; img-src 'self' data: https:"
-    />
+    <!-- CSP is injected by the Electron main process with the active gateway origin. -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Matrix OS</title>
   </head>

--- a/scripts/docker-test/channels.sh
+++ b/scripts/docker-test/channels.sh
@@ -14,6 +14,7 @@ begin_test "Channel Adapter Lifecycle"
 # Clean slate and start
 echo -e "${YELLOW}[SETUP]${NC} Starting fresh container..."
 $COMPOSE down -v --timeout 5 2>/dev/null || true
+pull_compose_images
 $COMPOSE up $COMPOSE_UP_FLAGS -d dev
 
 wait_for_healthy "dev" "${DOCKER_HEALTH_TIMEOUT:-180}"

--- a/scripts/docker-test/customized-files.sh
+++ b/scripts/docker-test/customized-files.sh
@@ -14,6 +14,7 @@ begin_test "Customized Files Survive Sync"
 # Clean slate and start
 echo -e "${YELLOW}[SETUP]${NC} Starting fresh container..."
 $COMPOSE down -v --timeout 5 2>/dev/null || true
+pull_compose_images
 $COMPOSE up $COMPOSE_UP_FLAGS -d dev
 
 wait_for_healthy "dev" "${DOCKER_HEALTH_TIMEOUT:-180}"

--- a/scripts/docker-test/fresh-install.sh
+++ b/scripts/docker-test/fresh-install.sh
@@ -17,6 +17,7 @@ $COMPOSE down -v --timeout 5 2>/dev/null || true
 
 # Start fresh
 echo -e "${YELLOW}[SETUP]${NC} Starting dev container..."
+pull_compose_images
 $COMPOSE up $COMPOSE_UP_FLAGS -d dev
 
 wait_for_healthy "dev" "${DOCKER_HEALTH_TIMEOUT:-180}"

--- a/scripts/docker-test/lib.sh
+++ b/scripts/docker-test/lib.sh
@@ -191,6 +191,28 @@ wait_for_url() {
   return 1
 }
 
+pull_compose_images() {
+  local attempts="${DOCKER_PULL_ATTEMPTS:-3}"
+  local delay="${DOCKER_PULL_RETRY_DELAY:-10}"
+  local attempt=1
+
+  echo -e "${YELLOW}[SETUP]${NC} Pulling Docker service images (attempts: $attempts)..."
+  while [ "$attempt" -le "$attempts" ]; do
+    if $COMPOSE pull --quiet --ignore-buildable; then
+      return 0
+    fi
+
+    if [ "$attempt" -eq "$attempts" ]; then
+      echo -e "  ${RED}FAIL${NC} Docker image pull failed after $attempts attempts"
+      return 1
+    fi
+
+    echo -e "  ${YELLOW}RETRY${NC} Docker image pull failed (attempt $attempt/$attempts); retrying in ${delay}s..."
+    sleep "$delay"
+    attempt=$((attempt + 1))
+  done
+}
+
 cleanup() {
   echo -e "${YELLOW}[CLEANUP]${NC} Stopping containers..."
   $COMPOSE down -v --timeout 5 2>/dev/null || true

--- a/scripts/docker-test/recovery.sh
+++ b/scripts/docker-test/recovery.sh
@@ -14,6 +14,7 @@ begin_test "Crash Recovery"
 # Clean slate and start
 echo -e "${YELLOW}[SETUP]${NC} Starting fresh container..."
 $COMPOSE down -v --timeout 5 2>/dev/null || true
+pull_compose_images
 $COMPOSE up $COMPOSE_UP_FLAGS -d dev
 
 wait_for_healthy "dev" "${DOCKER_HEALTH_TIMEOUT:-180}"

--- a/scripts/docker-test/upgrade.sh
+++ b/scripts/docker-test/upgrade.sh
@@ -14,6 +14,7 @@ begin_test "Upgrade (Template Sync)"
 # Clean slate and start
 echo -e "${YELLOW}[SETUP]${NC} Starting fresh container..."
 $COMPOSE down -v --timeout 5 2>/dev/null || true
+pull_compose_images
 $COMPOSE up $COMPOSE_UP_FLAGS -d dev
 
 wait_for_healthy "dev" "${DOCKER_HEALTH_TIMEOUT:-180}"

--- a/tests/desktop/header-injection.test.ts
+++ b/tests/desktop/header-injection.test.ts
@@ -1,10 +1,27 @@
 import { describe, expect, it, vi } from "vitest";
-import { installGatewayCors, shouldInjectAuth } from "@desktop/main/auth/header-injection";
+import {
+  buildRendererCsp,
+  installGatewayCors,
+  shouldInjectAuth,
+} from "@desktop/main/auth/header-injection";
 
 const GATEWAY = "https://app.matrix-os.com";
 
+function connectDirective(csp: string): string {
+  return csp.split(";").map((part) => part.trim()).find((part) => part.startsWith("connect-src ")) ?? "";
+}
+
+function connectSources(csp: string): string[] {
+  return connectDirective(csp).split(/\s+/).slice(1);
+}
+
 type HeadersReceivedListener = (
-  details: { url: string; method: string; responseHeaders?: Record<string, string[]> },
+  details: {
+    url: string;
+    method: string;
+    responseHeaders?: Record<string, string[]>;
+    resourceType?: string;
+  },
   callback: (response: { responseHeaders?: Record<string, string[]>; statusLine?: string }) => void,
 ) => void;
 
@@ -20,7 +37,12 @@ function corsSession() {
   };
   return {
     session,
-    fire(details: { url: string; method: string; responseHeaders?: Record<string, string[]> }) {
+    fire(details: {
+      url: string;
+      method: string;
+      responseHeaders?: Record<string, string[]>;
+      resourceType?: string;
+    }) {
       const cb = vi.fn();
       listener?.(details, cb);
       return cb.mock.calls[0]?.[0] ?? {};
@@ -80,6 +102,39 @@ describe("installGatewayCors", () => {
     installGatewayCors(session, () => GATEWAY, "http://localhost:5173");
     const res = fire({ url: "https://evil.example.com/api", method: "GET", responseHeaders: { x: ["1"] } });
     expect(res.responseHeaders).toBeUndefined();
+  });
+
+  it("injects a gateway-scoped CSP for the packaged renderer document", () => {
+    const { session, fire } = corsSession();
+    installGatewayCors(session, () => GATEWAY, "null");
+    const res = fire({
+      url: "file:///Applications/Matrix%20OS.app/Contents/Resources/app.asar/out/renderer/index.html",
+      method: "GET",
+      resourceType: "mainFrame",
+      responseHeaders: { "Content-Security-Policy": ["connect-src https:"] },
+    });
+    const csp = res.responseHeaders?.["Content-Security-Policy"]?.[0] ?? "";
+    const connect = connectDirective(csp);
+    const sources = connectSources(csp);
+
+    expect(connect).toBe("connect-src 'self' https://app.matrix-os.com wss://app.matrix-os.com");
+    expect(sources).not.toContain("https:");
+    expect(sources).not.toContain("wss:");
+    expect(sources).not.toContain("*");
+    expect(sources).not.toContain("https://evil.example.com");
+  });
+
+  it("includes the Vite renderer origin for development HMR without broad external connect", () => {
+    const csp = buildRendererCsp("http://localhost:18789", "http://localhost:5173");
+    const connect = connectDirective(csp);
+    const sources = connectSources(csp);
+
+    expect(connect).toBe(
+      "connect-src 'self' http://localhost:18789 ws://localhost:18789 http://localhost:5173 ws://localhost:5173",
+    );
+    expect(sources).not.toContain("https:");
+    expect(sources).not.toContain("wss:");
+    expect(sources).not.toContain("*");
   });
 });
 

--- a/tests/desktop/renderer-csp.test.ts
+++ b/tests/desktop/renderer-csp.test.ts
@@ -1,0 +1,25 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+function rendererHtml(): string {
+  return readFileSync(resolve("desktop/src/renderer/index.html"), "utf8");
+}
+
+function staticRendererCsp(): string | null {
+  const html = readFileSync(resolve("desktop/src/renderer/index.html"), "utf8");
+  const match = html.match(/http-equiv="Content-Security-Policy"\s+content="([^"]+)"/);
+  return match?.[1] ?? null;
+}
+
+describe("desktop renderer CSP", () => {
+  it("keeps runtime gateway connect policy out of static packaged HTML", () => {
+    const html = rendererHtml();
+    const csp = staticRendererCsp();
+
+    expect(html).toContain("CSP is injected by the Electron main process");
+    expect(csp).toBeNull();
+    expect(html).not.toContain("connect-src https:");
+    expect(html).not.toContain("connect-src *");
+  });
+});

--- a/tests/platform/ci-workflows.test.ts
+++ b/tests/platform/ci-workflows.test.ts
@@ -82,6 +82,31 @@ describe('CI workflows', () => {
     expect(scenariosHeader).not.toContain('timeout-minutes: 20');
   });
 
+  it('retries Docker compose image pulls before scenario startup', () => {
+    const root = process.cwd();
+    const harness = readFileSync(join(root, 'scripts/docker-test/lib.sh'), 'utf8');
+    const scenarioScripts = [
+      'fresh-install.sh',
+      'upgrade.sh',
+      'customized-files.sh',
+      'channels.sh',
+      'recovery.sh',
+    ];
+
+    expect(harness).toContain('pull_compose_images()');
+    expect(harness).toContain('DOCKER_PULL_ATTEMPTS');
+    expect(harness).toContain('docker compose');
+    expect(harness).toContain('pull --quiet --ignore-buildable');
+
+    for (const scriptName of scenarioScripts) {
+      const scenario = readFileSync(join(root, 'scripts/docker-test', scriptName), 'utf8');
+      const firstStartup = scenario.indexOf('$COMPOSE up $COMPOSE_UP_FLAGS -d dev');
+
+      expect(firstStartup).toBeGreaterThan(0);
+      expect(scenario.slice(0, firstStartup)).toContain('pull_compose_images');
+    }
+  });
+
   it('runs sync-client CI only on the supported Node 20 runtime', () => {
     const root = process.cwd();
     const workflow = readFileSync(join(root, '.github/workflows/ci.yml'), 'utf8');


### PR DESCRIPTION
## Summary

- Move the packaged Electron renderer CSP out of static HTML and inject it from the main process with the active gateway origin.
- Scope `connect-src` to the resolved Matrix gateway plus its matching WebSocket origin, while preserving the Vite renderer origin for local HMR.
- Add regression coverage for both packaged HTML and the Electron session-layer CSP/CORS hook.

## Tests

- `bun run test tests/desktop/header-injection.test.ts tests/desktop/renderer-csp.test.ts`
- `bun run test tests/desktop/renderer-csp.test.ts`
- `pnpm --filter desktop run typecheck`
- `bun run typecheck`
- `bun run check:patterns` (0 violations; existing warnings only)
- `git diff --check`

## Review/Monitoring

- This PR fixes the downloaded Mac app failure by allowing `https://app.matrix-os.com/api/*` and `wss://app.matrix-os.com/*` from the packaged renderer without opening `connect-src` to arbitrary HTTPS/WSS hosts.
- No React `.tsx`/`.jsx` files changed, so React Doctor is not applicable.
- No screenshot required: this changes packaged connectivity/security policy, not UI layout or visual styling.
- After merge, publish a new desktop bundle/release; the existing downloaded bundle still contains the old CSP.
