### PR TITLE
fix(shell): move shell errors to notification stack

### DIFF
--- a/shell/src/components/ConnectionIndicator.tsx
+++ b/shell/src/components/ConnectionIndicator.tsx
@@ -6,6 +6,7 @@ import { useConnectionHealth } from "@/hooks/useConnectionHealth";
 import { manualReconnect } from "@/hooks/useSocket";
 import { getGatewayUrl } from "@/lib/gateway";
 import { resolveConnectionCopy, type RuntimeStatus } from "./connection-indicator-copy";
+import { ShellNotificationCard } from "./ShellNotificationCard";
 
 const STATUS_REFRESH_MS = 5_000;
 const STATUS_TIMEOUT_MS = 1_500;
@@ -112,42 +113,40 @@ export function ConnectionIndicator() {
   if (state === "connected" || (state === "initializing" && !initialGraceElapsed)) return null;
 
   return (
-    <aside
-      className="pointer-events-none fixed inset-x-0 bottom-[calc(env(safe-area-inset-bottom)+0.75rem)] z-[90] flex justify-center px-3 sm:px-4"
+    <ShellNotificationCard
+      className={`flex flex-col gap-3 rounded-2xl border px-3.5 py-3 text-card-foreground backdrop-blur-md backdrop-saturate-150 sm:flex-row sm:items-center sm:gap-4 ${panelClass}`}
       aria-label="Matrix connection status"
-      data-variant="dock"
+      data-variant="toast"
       role="status"
     >
-      <div className={`pointer-events-auto flex w-full max-w-[min(92vw,560px)] flex-col gap-3 rounded-2xl border px-3.5 py-3 text-card-foreground backdrop-blur-md backdrop-saturate-150 sm:flex-row sm:items-center sm:gap-4 ${panelClass}`}>
-        <div className="flex min-w-0 flex-1 items-start gap-3">
-          <span
-            className={`mt-2 size-2.5 shrink-0 rounded-full ${dotClass} ${state === "reconnecting" ? "animate-pulse" : ""}`}
-            aria-hidden="true"
-          />
-          <div className="min-w-0 flex-1">
-            <div className={`text-sm font-semibold leading-5 ${toneClass}`}>{copy.title}</div>
-            <p className="mt-0.5 text-sm leading-5 text-muted-foreground">{copy.detail}</p>
-            {(status.releaseChannel || status.releaseVersion) && (
-              <div className="mt-1.5 flex flex-wrap items-center gap-2 text-[11px] text-muted-foreground/80">
-                {status.releaseChannel && (
-                  <span className="rounded-full border border-border/50 bg-background/50 px-2 py-0.5 font-mono">
-                    {status.releaseChannel}
-                  </span>
-                )}
-                {status.releaseVersion && <span className="truncate font-mono">{status.releaseVersion}</span>}
-              </div>
-            )}
-          </div>
+      <div className="flex min-w-0 flex-1 items-start gap-3">
+        <span
+          className={`mt-2 size-2.5 shrink-0 rounded-full ${dotClass} ${state === "reconnecting" ? "animate-pulse" : ""}`}
+          aria-hidden="true"
+        />
+        <div className="min-w-0 flex-1">
+          <div className={`text-sm font-semibold leading-5 ${toneClass}`}>{copy.title}</div>
+          <p className="mt-0.5 text-sm leading-5 text-muted-foreground">{copy.detail}</p>
+          {(status.releaseChannel || status.releaseVersion) && (
+            <div className="mt-1.5 flex flex-wrap items-center gap-2 text-[11px] text-muted-foreground/80">
+              {status.releaseChannel && (
+                <span className="rounded-full border border-border/50 bg-background/50 px-2 py-0.5 font-mono">
+                  {status.releaseChannel}
+                </span>
+              )}
+              {status.releaseVersion && <span className="truncate font-mono">{status.releaseVersion}</span>}
+            </div>
+          )}
         </div>
-        <button
-          className="inline-flex min-h-8 shrink-0 items-center justify-center gap-1.5 rounded-full border border-border/70 bg-background/80 px-3 text-sm font-medium text-foreground transition hover:border-border hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-          onClick={manualReconnect}
-          type="button"
-        >
-          <RefreshCwIcon className="size-3.5" aria-hidden="true" />
-          {copy.action}
-        </button>
       </div>
-    </aside>
+      <button
+        className="inline-flex min-h-8 shrink-0 items-center justify-center gap-1.5 rounded-full border border-border/70 bg-background/80 px-3 text-sm font-medium text-foreground transition hover:border-border hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        onClick={manualReconnect}
+        type="button"
+      >
+        <RefreshCwIcon className="size-3.5" aria-hidden="true" />
+        {copy.action}
+      </button>
+    </ShellNotificationCard>
   );
 }

--- a/shell/src/components/Desktop.tsx
+++ b/shell/src/components/Desktop.tsx
@@ -60,6 +60,7 @@ import { ChatApp } from "./ChatApp";
 import { ChatPopover } from "./ChatPopover";
 import { ManualSetupStickers } from "./onboarding/ManualSetupStickers";
 import { RuntimeIdentityBanner } from "./RuntimeIdentityBanner";
+import { ShellNotificationStack } from "./ShellNotificationStack";
 import { DeveloperModeDashboard } from "./developer/DeveloperModeDashboard";
 import { versionedIconUrl } from "@/lib/icon-url";
 import { nameToSlug } from "@/lib/utils";
@@ -1452,7 +1453,9 @@ export function Desktop({ launchAppPath, onOpenCommandPalette, chat }: DesktopPr
   if (firstRunStatus === "checking") {
     return (
       <TooltipProvider delayDuration={300}>
-        <RuntimeIdentityBanner />
+        <ShellNotificationStack>
+          <RuntimeIdentityBanner />
+        </ShellNotificationStack>
         <MatrixFirstRunLoading />
       </TooltipProvider>
     );
@@ -1460,7 +1463,10 @@ export function Desktop({ launchAppPath, onOpenCommandPalette, chat }: DesktopPr
 
   return (
     <TooltipProvider delayDuration={300}>
-      <RuntimeIdentityBanner />
+      <ShellNotificationStack>
+        <RuntimeIdentityBanner />
+        <ConnectionIndicator />
+      </ShellNotificationStack>
       <MenuBar onOpenCommandPalette={onOpenCommandPalette ?? (() => {})} onNewWindow={() => openWindow("Terminal", "__terminal__")} onMinimizeWindow={animateMinimize}>
         {desktopMode === "canvas" ? (
           <CanvasToolbar
@@ -1752,15 +1758,6 @@ export function Desktop({ launchAppPath, onOpenCommandPalette, chat }: DesktopPr
           />
           <AoedeDockButton size={dock.iconSize} variant="desktop" tooltipSide={tooltipSide} />
 
-          <div
-            className={
-              isHorizontal
-                ? "absolute left-full top-1/2 -translate-y-1/2 ml-2 pointer-events-auto"
-                : "absolute top-full left-1/2 -translate-x-1/2 mt-2 pointer-events-auto"
-            }
-          >
-            <ConnectionIndicator />
-          </div>
         </aside>
         </div>}
 

--- a/shell/src/components/OnboardingScreen.tsx
+++ b/shell/src/components/OnboardingScreen.tsx
@@ -8,6 +8,8 @@ import { ApiKeyInput } from "./onboarding/ApiKeyInput";
 import { MicPermissionDialog } from "./MicPermissionDialog";
 import { KeyboardIcon, MicIcon, SparklesIcon } from "lucide-react";
 import { MATRIX_ONBOARDING_BRAND_VERSION } from "@/lib/onboarding-brand";
+import { ShellNotificationCard } from "./ShellNotificationCard";
+import { ShellNotificationStack } from "./ShellNotificationStack";
 
 const SHIMMER_GRADIENT =
   "linear-gradient(90deg, #2F392C 0%, #2F392C 24%, #C4A265 50%, #2F392C 76%, #2F392C 100%)";
@@ -461,9 +463,14 @@ export function OnboardingScreen({ onComplete, onOpenManualSetup }: OnboardingSc
 
       {/* Error */}
       {ob.error && (
-        <div className="absolute bottom-4 left-1/2 -translate-x-1/2 px-4 py-2 rounded-lg bg-destructive/10 border border-destructive/20 text-destructive text-xs">
-          {ob.error}
-        </div>
+        <ShellNotificationStack>
+          <ShellNotificationCard
+            className="rounded-lg border border-destructive/20 bg-destructive/10 px-4 py-2 text-xs text-destructive shadow-[0_18px_60px_-24px_rgba(239,68,68,0.58),0_24px_60px_-30px_rgba(0,0,0,0.38)] backdrop-blur-md"
+            role="alert"
+          >
+            {ob.error}
+          </ShellNotificationCard>
+        </ShellNotificationStack>
       )}
     </div>
     </>

--- a/shell/src/components/RuntimeIdentityBanner.tsx
+++ b/shell/src/components/RuntimeIdentityBanner.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from "react";
 import { AlertTriangleIcon, CpuIcon, HardDriveIcon, RefreshCcwIcon, ServerIcon, XIcon } from "lucide-react";
 import { getGatewayUrl } from "@/lib/gateway";
+import { ShellNotificationCard } from "./ShellNotificationCard";
 
 const ATTENTION_RELEASE_CHANNELS = new Set(["dev", "canary", "beta"]);
 
@@ -131,9 +132,9 @@ export function RuntimeIdentityBanner() {
   };
 
   return (
-    <aside
+    <ShellNotificationCard
       className={[
-        "fixed right-3 top-9 z-[95] max-w-[calc(100vw-1.5rem)] rounded-md border px-3 py-2 shadow-[0_18px_60px_rgba(0,0,0,0.18)] backdrop-blur-md",
+        "rounded-md border px-3 py-2 shadow-[0_18px_60px_rgba(0,0,0,0.18)] backdrop-blur-md",
         summary.isStaging
           ? "border-[#8a3a11]/35 bg-[#fff1df]/92 text-[#3f210d]"
           : "border-[#8a3a11]/30 bg-[#fff8e8]/92 text-[#3f210d]",
@@ -187,6 +188,6 @@ export function RuntimeIdentityBanner() {
           <XIcon className="h-3.5 w-3.5" aria-hidden="true" />
         </button>
       </div>
-    </aside>
+    </ShellNotificationCard>
   );
 }

--- a/shell/src/components/ShellNotificationCard.tsx
+++ b/shell/src/components/ShellNotificationCard.tsx
@@ -1,0 +1,21 @@
+"use client";
+
+import type { ComponentPropsWithoutRef } from "react";
+
+export function ShellNotificationCard({
+  children,
+  className,
+  ...props
+}: ComponentPropsWithoutRef<"div">) {
+  return (
+    <div
+      className={[
+        "pointer-events-auto w-full max-w-[min(92vw,560px)]",
+        className,
+      ].filter(Boolean).join(" ")}
+      {...props}
+    >
+      {children}
+    </div>
+  );
+}

--- a/shell/src/components/ShellNotificationPortal.tsx
+++ b/shell/src/components/ShellNotificationPortal.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import { useSyncExternalStore, type ReactNode } from "react";
+import { createPortal } from "react-dom";
+import {
+  getShellNotificationHostServerSnapshot,
+  getShellNotificationHostSnapshot,
+  subscribeShellNotificationHost,
+} from "./shell-notification-host";
+import {
+  ShellNotificationStack,
+} from "./ShellNotificationStack";
+
+export function ShellNotificationPortal({ children }: { children: ReactNode }) {
+  const host = useSyncExternalStore(
+    subscribeShellNotificationHost,
+    getShellNotificationHostSnapshot,
+    getShellNotificationHostServerSnapshot,
+  );
+
+  if (host) return createPortal(children, host);
+
+  return (
+    <ShellNotificationStack registerHost={false}>
+      {children}
+    </ShellNotificationStack>
+  );
+}

--- a/shell/src/components/ShellNotificationStack.tsx
+++ b/shell/src/components/ShellNotificationStack.tsx
@@ -12,9 +12,7 @@ export function ShellNotificationStack({
 }) {
   return (
     <div
-      ref={(node) => {
-        if (registerHost) setShellNotificationHost(node);
-      }}
+      ref={registerHost ? setShellNotificationHost : undefined}
       id={SHELL_NOTIFICATION_STACK_ID}
       data-testid="shell-notification-stack"
       className="pointer-events-none fixed right-3 top-[calc(env(safe-area-inset-top)+0.75rem)] z-[10000] flex w-[calc(100vw-1.5rem)] max-w-[min(92vw,560px)] flex-col items-end gap-2 md:top-9"

--- a/shell/src/components/ShellNotificationStack.tsx
+++ b/shell/src/components/ShellNotificationStack.tsx
@@ -17,7 +17,7 @@ export function ShellNotificationStack({
       }}
       id={SHELL_NOTIFICATION_STACK_ID}
       data-testid="shell-notification-stack"
-      className="pointer-events-none fixed right-3 top-[calc(env(safe-area-inset-top)+0.75rem)] z-[95] flex w-[calc(100vw-1.5rem)] max-w-[min(92vw,560px)] flex-col items-end gap-2 md:top-9"
+      className="pointer-events-none fixed right-3 top-[calc(env(safe-area-inset-top)+0.75rem)] z-[10000] flex w-[calc(100vw-1.5rem)] max-w-[min(92vw,560px)] flex-col items-end gap-2 md:top-9"
     >
       {children}
     </div>

--- a/shell/src/components/ShellNotificationStack.tsx
+++ b/shell/src/components/ShellNotificationStack.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+import type { ReactNode } from "react";
+import { SHELL_NOTIFICATION_STACK_ID, setShellNotificationHost } from "./shell-notification-host";
+
+export function ShellNotificationStack({
+  children,
+  registerHost = true,
+}: {
+  children: ReactNode;
+  registerHost?: boolean;
+}) {
+  return (
+    <div
+      ref={(node) => {
+        if (registerHost) setShellNotificationHost(node);
+      }}
+      id={SHELL_NOTIFICATION_STACK_ID}
+      data-testid="shell-notification-stack"
+      className="pointer-events-none fixed right-3 top-[calc(env(safe-area-inset-top)+0.75rem)] z-[95] flex w-[calc(100vw-1.5rem)] max-w-[min(92vw,560px)] flex-col items-end gap-2 md:top-9"
+    >
+      {children}
+    </div>
+  );
+}

--- a/shell/src/components/ShellNotificationStack.tsx
+++ b/shell/src/components/ShellNotificationStack.tsx
@@ -13,7 +13,7 @@ export function ShellNotificationStack({
   return (
     <div
       ref={registerHost ? setShellNotificationHost : undefined}
-      id={SHELL_NOTIFICATION_STACK_ID}
+      id={registerHost ? SHELL_NOTIFICATION_STACK_ID : undefined}
       data-testid="shell-notification-stack"
       className="pointer-events-none fixed right-3 top-[calc(env(safe-area-inset-top)+0.75rem)] z-[10000] flex w-[calc(100vw-1.5rem)] max-w-[min(92vw,560px)] flex-col items-end gap-2 md:top-9"
     >

--- a/shell/src/components/VocalPanel.tsx
+++ b/shell/src/components/VocalPanel.tsx
@@ -5,6 +5,8 @@ import { useVocalSession, type VocalIntent, type BuildProgressSnapshot } from "@
 import type { ChatState } from "@/hooks/useChatState";
 import { useWindowManager } from "@/hooks/useWindowManager";
 import { AgentStatusCard } from "./AgentStatusCard";
+import { ShellNotificationCard } from "./ShellNotificationCard";
+import { ShellNotificationPortal } from "./ShellNotificationPortal";
 
 const GLOW_OPACITY: Record<string, number> = {
   idle: 0.68,
@@ -562,9 +564,14 @@ export function VocalPanel({ active, chat, onOpenApp, onDismissChat }: VocalPane
       />
 
       {error && (
-        <div className="pointer-events-auto absolute bottom-4 left-1/2 -translate-x-1/2 px-4 py-2 rounded-lg bg-destructive/10 border border-destructive/20 text-destructive text-xs">
-          {error}
-        </div>
+        <ShellNotificationPortal>
+          <ShellNotificationCard
+            className="rounded-lg border border-destructive/20 bg-destructive/10 px-4 py-2 text-xs text-destructive shadow-[0_18px_60px_-24px_rgba(239,68,68,0.58),0_24px_60px_-30px_rgba(0,0,0,0.38)] backdrop-blur-md"
+            role="alert"
+          >
+            {error}
+          </ShellNotificationCard>
+        </ShellNotificationPortal>
       )}
 
       {/* react-doctor-disable-next-line react-doctor/no-unknown-property -- valid styled-jsx attribute */}

--- a/shell/src/components/shell-notification-host.ts
+++ b/shell/src/components/shell-notification-host.ts
@@ -1,0 +1,25 @@
+export const SHELL_NOTIFICATION_STACK_ID = "shell-notification-stack-root";
+
+let shellNotificationHost: HTMLElement | null = null;
+let shellNotificationListeners: Array<() => void> = [];
+
+export function setShellNotificationHost(host: HTMLElement | null): void {
+  if (shellNotificationHost === host) return;
+  shellNotificationHost = host;
+  for (const listener of shellNotificationListeners) listener();
+}
+
+export function subscribeShellNotificationHost(listener: () => void): () => void {
+  shellNotificationListeners = [...shellNotificationListeners, listener];
+  return () => {
+    shellNotificationListeners = shellNotificationListeners.filter((candidate) => candidate !== listener);
+  };
+}
+
+export function getShellNotificationHostSnapshot(): HTMLElement | null {
+  return shellNotificationHost;
+}
+
+export function getShellNotificationHostServerSnapshot(): null {
+  return null;
+}

--- a/tests/shell/connection-indicator.test.tsx
+++ b/tests/shell/connection-indicator.test.tsx
@@ -135,7 +135,9 @@ describe("ConnectionIndicator", () => {
       expect(screen.getByText(/keeping your workspace open/i)).toBeTruthy();
       expect(screen.queryByText("Matrix computer is restarting")).toBeNull();
       expect(screen.queryByText(/bundle upgrades or gateway restarts/i)).toBeNull();
-      expect(screen.getByRole("status", { name: /matrix connection status/i }).getAttribute("data-variant")).toBe("dock");
+      const indicator = screen.getByRole("status", { name: /matrix connection status/i });
+      expect(indicator.getAttribute("data-variant")).toBe("toast");
+      expect(indicator.className).not.toContain("bottom-");
     });
   });
 

--- a/tests/shell/desktop-notification-placement.test.tsx
+++ b/tests/shell/desktop-notification-placement.test.tsx
@@ -1,0 +1,193 @@
+// @vitest-environment jsdom
+
+import React from "react";
+import { act, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { Desktop } from "../../shell/src/components/Desktop.js";
+import { useDesktopMode } from "../../shell/src/stores/desktop-mode.js";
+import { useWindowManager } from "../../shell/src/hooks/useWindowManager.js";
+import { useDesktopConfigStore } from "../../shell/src/stores/desktop-config.js";
+import { useVocalStore } from "../../shell/src/stores/vocal.js";
+
+const originalConsoleError = console.error;
+
+function isStyledJsxAttributeWarning(message: unknown, args: unknown[]): boolean {
+  if (typeof message !== "string") return false;
+  return (
+    (message.includes("non-boolean attribute `jsx`") || message.includes("non-boolean attribute `global`")) ||
+    (message.includes("non-boolean attribute `%s`") && (args.includes("jsx") || args.includes("global")))
+  );
+}
+
+vi.mock("../../shell/src/hooks/useFileWatcher.js", () => ({
+  useFileWatcher: () => undefined,
+}));
+
+vi.mock("../../shell/src/components/AppViewer.js", () => ({
+  AppViewer: () => null,
+}));
+
+vi.mock("../../shell/src/components/terminal/TerminalApp.js", () => ({
+  TerminalApp: () => null,
+}));
+
+vi.mock("../../shell/src/components/workspace/WorkspaceApp.js", () => ({
+  WorkspaceApp: () => null,
+}));
+
+vi.mock("../../shell/src/components/file-browser/FileBrowser.js", () => ({
+  FileBrowser: () => null,
+}));
+
+vi.mock("../../shell/src/components/preview-window/PreviewWindow.js", () => ({
+  PreviewWindow: () => null,
+}));
+
+vi.mock("../../shell/src/components/system-activity/ActivityMonitorApp.js", () => ({
+  ActivityMonitorApp: () => null,
+}));
+
+vi.mock("../../shell/src/components/AIButton.js", () => ({
+  AIButton: () => null,
+}));
+
+vi.mock("../../shell/src/components/MissionControl.js", () => ({
+  MissionControl: () => null,
+}));
+
+vi.mock("../../shell/src/components/DotGrid.js", () => ({
+  DotGrid: () => null,
+}));
+
+vi.mock("../../shell/src/components/Settings.js", () => ({
+  Settings: () => null,
+}));
+
+vi.mock("../../shell/src/components/canvas/CanvasRenderer.js", () => ({
+  CanvasRenderer: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock("../../shell/src/components/canvas/CanvasToolbar.js", () => ({
+  CanvasToolbar: () => null,
+}));
+
+vi.mock("@/hooks/useVocalSession", () => ({
+  useVocalSession: () => ({
+    voiceState: "idle",
+    subtitle: "",
+    error: "Aoede could not connect",
+    connected: false,
+    notifyDelegationComplete: vi.fn(),
+    notifyExecuteResult: vi.fn(),
+    pushDelegationStatus: vi.fn(),
+  }),
+}));
+
+vi.mock("../../shell/src/components/UserButton.js", () => ({
+  UserButton: () => null,
+}));
+
+vi.mock("../../shell/src/components/ConnectionIndicator.js", () => ({
+  ConnectionIndicator: () => <div data-testid="connection-indicator" data-variant="toast" />,
+}));
+
+vi.mock("../../shell/src/components/AmbientClock.js", () => ({
+  AmbientClock: () => null,
+}));
+
+vi.mock("../../shell/src/components/MenuBar.js", () => ({
+  MenuBar: ({ children }: { children?: React.ReactNode }) => <div data-menu-bar>{children}</div>,
+}));
+
+vi.mock("../../shell/src/components/ChatApp.js", () => ({
+  ChatApp: () => null,
+}));
+
+vi.mock("../../shell/src/components/ChatPopover.js", () => ({
+  ChatPopover: () => null,
+}));
+
+vi.mock("../../shell/src/components/onboarding/ManualSetupStickers.js", () => ({
+  ManualSetupStickers: () => null,
+}));
+
+vi.mock("../../shell/src/components/RuntimeIdentityBanner.js", () => ({
+  RuntimeIdentityBanner: () => <div data-testid="runtime-identity-banner" />,
+}));
+
+vi.mock("../../shell/src/components/developer/DeveloperModeDashboard.js", () => ({
+  DeveloperModeDashboard: () => null,
+}));
+
+function jsonResponse(body: unknown) {
+  return Promise.resolve(new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  }));
+}
+
+describe("Desktop shell notifications", () => {
+  beforeEach(() => {
+    vi.spyOn(console, "error").mockImplementation((message: unknown, ...args: unknown[]) => {
+      if (isStyledJsxAttributeWarning(message, args)) return;
+      Reflect.apply(originalConsoleError, console, [message, ...args]);
+    });
+    act(() => {
+      useDesktopMode.setState({
+        mode: "dev",
+        previousMode: null,
+        _hydrated: true,
+      });
+      useDesktopConfigStore.setState({
+        dock: { position: "bottom", size: 64, iconSize: 48, autoHide: false },
+        pinnedApps: [],
+      });
+      useWindowManager.setState({
+        windows: [],
+        apps: [],
+        nextZ: 1,
+        closedPaths: new Set(),
+        closedLayouts: new Map(),
+        focusedWindowId: null,
+        fullscreenWindowId: null,
+      });
+      useVocalStore.setState({ active: true });
+    });
+    vi.stubGlobal("fetch", vi.fn((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes("/api/settings/onboarding-status")) return jsonResponse({ complete: true });
+      if (url.includes("/api/layout")) return jsonResponse({ windows: [] });
+      if (url.includes("/files/system/modules.json")) return jsonResponse([]);
+      if (url.includes("/api/apps")) return jsonResponse([]);
+      return jsonResponse({});
+    }));
+  });
+
+  afterEach(() => {
+    act(() => {
+      useVocalStore.setState({ active: false });
+    });
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it("renders connection, runtime, and vocal notices in the shared top-right stack outside the dock", async () => {
+    render(<Desktop />);
+
+    const indicator = await screen.findByTestId("connection-indicator");
+    const banner = screen.getByTestId("runtime-identity-banner");
+    const stack = screen.getByTestId("shell-notification-stack");
+    const vocalError = await screen.findByRole("alert");
+
+    await waitFor(() => {
+      expect(stack.contains(indicator)).toBe(true);
+      expect(stack.contains(banner)).toBe(true);
+      expect(stack.contains(vocalError)).toBe(true);
+    });
+
+    const dock = document.querySelector("[data-dock]");
+    expect(dock).toBeTruthy();
+    expect(dock?.contains(indicator)).toBe(false);
+    expect(vocalError.textContent).toContain("Aoede could not connect");
+  });
+});

--- a/tests/shell/shell-notification-stack.test.tsx
+++ b/tests/shell/shell-notification-stack.test.tsx
@@ -47,6 +47,17 @@ describe("ShellNotificationStack", () => {
     expect(screen.queryByTestId("shell-notification-card")).toBeNull();
   });
 
+  it("only assigns the host id to registering stacks", () => {
+    render(
+      <ShellNotificationStack registerHost={false}>
+        <ShellNotificationCard>Fallback</ShellNotificationCard>
+      </ShellNotificationStack>,
+    );
+
+    const stack = screen.getByTestId("shell-notification-stack");
+    expect(stack.id).toBe("");
+  });
+
   it("keeps the registered host stable across rerenders", () => {
     const hostChanges: Array<HTMLElement | null> = [];
     const unsubscribe = subscribeShellNotificationHost(() => {

--- a/tests/shell/shell-notification-stack.test.tsx
+++ b/tests/shell/shell-notification-stack.test.tsx
@@ -1,0 +1,44 @@
+// @vitest-environment jsdom
+
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import {
+  ShellNotificationStack,
+} from "../../shell/src/components/ShellNotificationStack.js";
+import { ShellNotificationCard } from "../../shell/src/components/ShellNotificationCard.js";
+
+describe("ShellNotificationStack", () => {
+  it("anchors shell overlays in a shared top-right viewport stack", () => {
+    render(
+      <ShellNotificationStack>
+        <ShellNotificationCard data-testid="shell-notification-card">
+          <button type="button">Retry</button>
+        </ShellNotificationCard>
+      </ShellNotificationStack>,
+    );
+
+    const stack = screen.getByTestId("shell-notification-stack");
+    expect(stack.className).toContain("fixed");
+    expect(stack.className).toContain("right-3");
+    expect(stack.className).toContain("top-[calc(env(safe-area-inset-top)+0.75rem)]");
+    expect(stack.className).toContain("md:top-9");
+    expect(stack.className).toContain("pointer-events-none");
+    expect(stack.className).toContain("flex-col");
+
+    const card = screen.getByTestId("shell-notification-card");
+    expect(card.className).toContain("pointer-events-auto");
+    expect(card.className).toContain("max-w-[min(92vw,560px)]");
+  });
+
+  it("does not assign duplicate card test ids by default", () => {
+    render(
+      <ShellNotificationStack>
+        <ShellNotificationCard>First</ShellNotificationCard>
+        <ShellNotificationCard>Second</ShellNotificationCard>
+      </ShellNotificationStack>,
+    );
+
+    expect(screen.queryByTestId("shell-notification-card")).toBeNull();
+  });
+});

--- a/tests/shell/shell-notification-stack.test.tsx
+++ b/tests/shell/shell-notification-stack.test.tsx
@@ -25,6 +25,7 @@ describe("ShellNotificationStack", () => {
     expect(stack.className).toContain("md:top-9");
     expect(stack.className).toContain("pointer-events-none");
     expect(stack.className).toContain("flex-col");
+    expect(stack.className).toContain("z-[10000]");
 
     const card = screen.getByTestId("shell-notification-card");
     expect(card.className).toContain("pointer-events-auto");

--- a/tests/shell/shell-notification-stack.test.tsx
+++ b/tests/shell/shell-notification-stack.test.tsx
@@ -7,6 +7,10 @@ import {
   ShellNotificationStack,
 } from "../../shell/src/components/ShellNotificationStack.js";
 import { ShellNotificationCard } from "../../shell/src/components/ShellNotificationCard.js";
+import {
+  getShellNotificationHostSnapshot,
+  subscribeShellNotificationHost,
+} from "../../shell/src/components/shell-notification-host.js";
 
 describe("ShellNotificationStack", () => {
   it("anchors shell overlays in a shared top-right viewport stack", () => {
@@ -41,5 +45,33 @@ describe("ShellNotificationStack", () => {
     );
 
     expect(screen.queryByTestId("shell-notification-card")).toBeNull();
+  });
+
+  it("keeps the registered host stable across rerenders", () => {
+    const hostChanges: Array<HTMLElement | null> = [];
+    const unsubscribe = subscribeShellNotificationHost(() => {
+      hostChanges.push(getShellNotificationHostSnapshot());
+    });
+
+    const { rerender, unmount } = render(
+      <ShellNotificationStack>
+        <ShellNotificationCard>First</ShellNotificationCard>
+      </ShellNotificationStack>,
+    );
+
+    expect(hostChanges).toHaveLength(1);
+    const host = hostChanges[0];
+    expect(host).toBeInstanceOf(HTMLElement);
+
+    rerender(
+      <ShellNotificationStack>
+        <ShellNotificationCard>Second</ShellNotificationCard>
+      </ShellNotificationStack>,
+    );
+
+    expect(hostChanges).toEqual([host]);
+
+    unmount();
+    unsubscribe();
   });
 });

--- a/tests/shell/shell-transient-error-placement.test.tsx
+++ b/tests/shell/shell-transient-error-placement.test.tsx
@@ -1,0 +1,131 @@
+// @vitest-environment jsdom
+
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { OnboardingScreen } from "../../shell/src/components/OnboardingScreen.js";
+import { VocalPanel } from "../../shell/src/components/VocalPanel.js";
+
+const mocks = vi.hoisted(() => ({
+  useOnboarding: vi.fn(),
+  useMicPermission: vi.fn(),
+  useVocalSession: vi.fn(),
+}));
+const originalConsoleError = console.error;
+
+function isStyledJsxAttributeWarning(message: unknown, args: unknown[]): boolean {
+  if (typeof message !== "string") return false;
+  return (
+    (message.includes("non-boolean attribute `jsx`") || message.includes("non-boolean attribute `global`")) ||
+    (message.includes("non-boolean attribute `%s`") && (args.includes("jsx") || args.includes("global")))
+  );
+}
+
+vi.mock("../../shell/src/hooks/useOnboarding.js", () => ({
+  useOnboarding: () => mocks.useOnboarding(),
+}));
+
+vi.mock("../../shell/src/hooks/useMicPermission.js", () => ({
+  useMicPermission: () => mocks.useMicPermission(),
+}));
+
+vi.mock("../../shell/src/hooks/useVocalSession.js", () => ({
+  useVocalSession: (enabled: boolean, options: unknown) => mocks.useVocalSession(enabled, options),
+}));
+
+vi.mock("../../shell/src/components/onboarding/VoiceWave.js", () => ({
+  VoiceWave: () => <div data-testid="voice-wave" />,
+}));
+
+vi.mock("../../shell/src/components/onboarding/ApiKeyInput.js", () => ({
+  ApiKeyInput: () => <div data-testid="api-key-input" />,
+}));
+
+vi.mock("../../shell/src/components/MicPermissionDialog.js", () => ({
+  MicPermissionDialog: () => null,
+}));
+
+function baseOnboardingState(error: string | null) {
+  return {
+    stage: "connecting",
+    voiceState: "idle",
+    transcripts: [],
+    suggestedApps: [],
+    error,
+    isVoiceMode: false,
+    alreadyComplete: false,
+    apiKeyResult: null,
+    currentSubtitle: "",
+    contextualContent: null,
+    readiness: null,
+    selectedGoalIds: [],
+    onboardingSteps: [],
+    start: vi.fn(),
+    sendText: vi.fn(),
+    sendApiKey: vi.fn(),
+    confirmApps: vi.fn(),
+    selectGoal: vi.fn(),
+    refreshReadiness: vi.fn(),
+    chooseClaudeCode: vi.fn(),
+    finishInterview: vi.fn(),
+  };
+}
+
+function baseVocalSession(error: string | null) {
+  return {
+    voiceState: "idle",
+    subtitle: "",
+    error,
+    connected: false,
+    notifyDelegationComplete: vi.fn(),
+    notifyExecuteResult: vi.fn(),
+    pushDelegationStatus: vi.fn(),
+  };
+}
+
+describe("transient shell error placement", () => {
+  beforeEach(() => {
+    vi.spyOn(console, "error").mockImplementation((message: unknown, ...args: unknown[]) => {
+      if (isStyledJsxAttributeWarning(message, args)) {
+        return;
+      }
+      Reflect.apply(originalConsoleError, console, [message, ...args]);
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.clearAllMocks();
+  });
+
+  it("renders onboarding shell errors in the top-right notification stack", () => {
+    mocks.useOnboarding.mockReturnValue(baseOnboardingState("Onboarding connection failed"));
+    mocks.useMicPermission.mockReturnValue({ state: "prompt", requestAccess: vi.fn() });
+
+    render(<OnboardingScreen onComplete={vi.fn()} onOpenManualSetup={vi.fn()} />);
+
+    const stack = screen.getByTestId("shell-notification-stack");
+    const alert = screen.getByRole("alert");
+
+    expect(stack.contains(alert)).toBe(true);
+    expect(stack.className).toContain("right-3");
+    expect(stack.className).toContain("top-[calc(env(safe-area-inset-top)+0.75rem)]");
+    expect(alert.className).not.toContain("bottom-");
+    expect(alert.textContent).toContain("Onboarding connection failed");
+  });
+
+  it("renders vocal shell errors in the top-right notification stack", async () => {
+    mocks.useVocalSession.mockReturnValue(baseVocalSession("Aoede could not connect"));
+
+    render(<VocalPanel active={true} />);
+
+    const stack = await screen.findByTestId("shell-notification-stack");
+    const alert = await screen.findByRole("alert");
+
+    expect(stack.contains(alert)).toBe(true);
+    expect(stack.className).toContain("right-3");
+    expect(stack.className).toContain("top-[calc(env(safe-area-inset-top)+0.75rem)]");
+    expect(alert.className).not.toContain("bottom-");
+    expect(alert.textContent).toContain("Aoede could not connect");
+  });
+});


### PR DESCRIPTION
## Summary
- Added a shared top-right `ShellNotificationStack`/`ShellNotificationCard`/`ShellNotificationPortal` treatment for transient shell overlays.
- Moved `ConnectionIndicator` out of the dock subtree, changed it from `data-variant="dock"` to `data-variant="toast"`, and stacked it with `RuntimeIdentityBanner`.
- Moved onboarding and VocalPanel transient shell errors to the same top-right notification treatment while keeping inline form/settings/app errors local.
- Raised the shell notification stack above fullscreen shell windows with `z-[10000]`, so connection/error cards remain visible over fullscreen surfaces.
- Stabilized the notification host ref and made the fallback stack avoid claiming the shared host id.

## Tests
- PASS: `pnpm exec vitest run tests/shell/connection-indicator.test.tsx tests/shell/runtime-identity-banner.test.tsx tests/shell/shell-notification-stack.test.tsx tests/shell/desktop-notification-placement.test.tsx tests/shell/shell-transient-error-placement.test.tsx` (5 files, 26 tests)
- PASS: Typecheck equivalent to root `bun run typecheck`, run with `pnpm` because `bun` is not installed in this environment:
  - `pnpm --filter @matrix-os/observability build`
  - `pnpm --filter @matrix-os/kernel build`
  - `pnpm --filter @matrix-os/observability exec tsc --noEmit`
  - `pnpm --filter @matrix-os/gateway exec tsc --noEmit`
  - `pnpm --filter @matrix-os/platform exec tsc --noEmit -p tsconfig.typecheck.json`
  - `pnpm --filter @matrix-os/proxy exec tsc --noEmit`
  - `pnpm --filter @matrix-os/edge-router exec tsc --noEmit`
  - `pnpm --filter desktop run typecheck`
- PASS: `pnpm run check:patterns` (0 violations; existing warnings only)
- PASS: `npx react-doctor@latest shell` (exit 0; project-wide pre-existing warnings)
- PASS: `npx react-doctor@latest --verbose --scope changed shell` (No issues found)
- PASS: `git diff --check`

## Review/Monitoring
- Latest head: `f93bfb5504b95a57058c9a3b8e8b567b1d9e681e` (`fix(shell): avoid duplicate notification stack host id`).
- GitHub checks on latest head: PR Title, Preview VPS Gate, Greptile Review, Vercel, and Vercel Preview Comments are green; preview deploy jobs are skipped as expected.
- Greptile: latest trusted result is `5/5` on `f93bfb5504b95a57058c9a3b8e8b567b1d9e681e`; Greptile says no files require special attention.
- Local shell screenshot attempt: `pnpm --filter shell dev` started Next on `http://localhost:3002` and a Playwright screenshot was captured, but the standalone local shell reached the Clerk/pre-VPS session check surface instead of Canvas/Desktop. A later Next dev run also hit host disk exhaustion during cache compaction (`No space left on device`), so Canvas/Desktop/mobile screenshot evidence is not complete from this environment.
- No backend code changed; PR invariants section is omitted.
