### PR TITLE
fix(desktop): restore native login redirect

### DIFF
--- a/desktop/electron-builder.yml
+++ b/desktop/electron-builder.yml
@@ -12,6 +12,7 @@ asarUnpack: []
 protocols:
   - name: Matrix OS
     schemes:
+      - matrixos
       - matrix-os
 mac:
   category: public.app-category.productivity

--- a/desktop/src/main/auth/device-auth.ts
+++ b/desktop/src/main/auth/device-auth.ts
@@ -4,7 +4,7 @@
 import { AppError, classifyHttpStatus, classifyTransportError } from "../../shared/app-error";
 
 export const DEVICE_CLIENT_ID = "matrix-os-desktop";
-export const DEVICE_REDIRECT_URI = "matrix-os://device-auth";
+export const DEVICE_REDIRECT_URI = "matrixos://auth?status=approved";
 
 const REQUEST_TIMEOUT_MS = 10_000;
 

--- a/desktop/src/main/index.ts
+++ b/desktop/src/main/index.ts
@@ -21,6 +21,28 @@ if (process.env.OPERATOR_USER_DATA_DIR) {
 let mainWindow: BrowserWindow | null = null;
 let updateCheckTimer: ReturnType<typeof setInterval> | null = null;
 
+function isMatrixOsDeepLink(value: string): boolean {
+  try {
+    const url = new URL(value);
+    return url.protocol === "matrixos:" || url.protocol === "matrix-os:";
+  } catch {
+    return false;
+  }
+}
+
+function focusMainWindow(): void {
+  const win = mainWindow ?? BrowserWindow.getAllWindows()[0];
+  if (!win) return;
+  if (win.isMinimized()) win.restore();
+  win.show();
+  win.focus();
+}
+
+function handleDeepLink(url: string): void {
+  if (!isMatrixOsDeepLink(url)) return;
+  focusMainWindow();
+}
+
 function sendEvent<C extends EventChannel>(channel: C, payload: EventPayload<C>): void {
   const parsed = EVENT_CHANNELS[channel].safeParse(payload);
   if (!parsed.success) {
@@ -92,12 +114,18 @@ const gotLock = app.requestSingleInstanceLock();
 if (!gotLock) {
   app.quit();
 } else {
-  app.on("second-instance", () => {
-    const win = BrowserWindow.getAllWindows()[0];
-    if (win) {
-      if (win.isMinimized()) win.restore();
-      win.focus();
+  app.on("second-instance", (_event, argv) => {
+    const deepLink = argv.find(isMatrixOsDeepLink);
+    if (deepLink) {
+      handleDeepLink(deepLink);
+      return;
     }
+    focusMainWindow();
+  });
+
+  app.on("open-url", (event, url) => {
+    event.preventDefault();
+    handleDeepLink(url);
   });
 
   void app

--- a/macos/Sources/App/AppModel.swift
+++ b/macos/Sources/App/AppModel.swift
@@ -718,7 +718,7 @@ public final class AppModel: ObservableObject {
     }
 
     public func handleOpenURL(_ url: URL) {
-        guard url.scheme == "matrixos", url.host == "auth" else { return }
+        guard (url.scheme == "matrixos" || url.scheme == "matrix-os"), url.host == "auth" else { return }
         let status = URLComponents(url: url, resolvingAgainstBaseURL: false)?
             .queryItems?
             .first(where: { $0.name == "status" })?

--- a/macos/Tests/AppTests/AppModelAuthTests.swift
+++ b/macos/Tests/AppTests/AppModelAuthTests.swift
@@ -56,6 +56,24 @@ final class AppModelAuthTests: XCTestCase {
         XCTAssertEqual(state.token, "native-token")
     }
 
+    func testHandleOpenURLAcceptsCanonicalAndLegacyAuthCallbacks() {
+        let model = AppModel(
+            principal: PrincipalProvider(store: MemoryTokenStore()),
+            projectSlug: "default",
+            profile: nil,
+            makeClient: { url, provider in GatewayHTTPClient(baseURL: url, tokenProvider: provider) },
+            makeLoader: { _ in EmptyBoardLoader() },
+            deviceAuth: MockDeviceAuthorizer(),
+            openExternalURL: { _ in }
+        )
+
+        model.handleOpenURL(URL(string: "matrixos://auth?status=approved")!)
+        XCTAssertEqual(model.signIn, .idle)
+
+        model.handleOpenURL(URL(string: "matrix-os://auth?status=approved")!)
+        XCTAssertEqual(model.signIn, .idle)
+    }
+
     func testRefreshRequiresTokenEvenWhenProfileIsPersisted() async {
         let principal = PrincipalProvider(store: MemoryTokenStore())
         let profile = ConnectionProfile(handle: "alice", gatewayHost: "app.matrix-os.com")

--- a/packages/platform/src/auth-routes.ts
+++ b/packages/platform/src/auth-routes.ts
@@ -132,6 +132,10 @@ function verifiedNativeRedirectUri(
   return timingSafeTokenEquals(expected, signatureValue) ? redirectUri : null;
 }
 
+function isTrustedNativeDesktopClient(clientId: unknown): boolean {
+  return clientId === 'matrix-os-macos' || clientId === 'matrix-os-desktop';
+}
+
 function escapeHtmlAttr(value: string): string {
   return value
     .replaceAll("&", "&amp;")
@@ -645,8 +649,9 @@ function normalizeNativeRedirectUri(value: unknown): string | null {
   if (typeof value !== 'string' || value.length > 512) return null;
   try {
     const url = new URL(value);
-    if (url.protocol !== 'matrixos:' || url.hostname !== 'auth') return null;
-    return url.toString();
+    if (url.protocol === 'matrixos:' && url.hostname === 'auth') return url.toString();
+    if (url.protocol === 'matrix-os:') return url.toString();
+    return null;
   } catch (err: unknown) {
     if (!(err instanceof TypeError)) {
       console.error(
@@ -778,7 +783,7 @@ export function createAuthRoutes(config: AuthRoutesConfig): Hono {
         const issued = await flow.createDeviceCode();
         const nativeRedirectUri = normalizeNativeRedirectUri(body.redirectUri);
         const verificationUrl = new URL(issued.verificationUri);
-        if (nativeRedirectUri && body.clientId === 'matrix-os-macos') {
+        if (nativeRedirectUri && isTrustedNativeDesktopClient(body.clientId)) {
           verificationUrl.searchParams.set('redirect_uri', nativeRedirectUri);
           verificationUrl.searchParams.set(
             'redirect_sig',

--- a/packages/platform/src/auth-routes.ts
+++ b/packages/platform/src/auth-routes.ts
@@ -650,7 +650,9 @@ function normalizeNativeRedirectUri(value: unknown): string | null {
   try {
     const url = new URL(value);
     if (url.protocol === 'matrixos:' && url.hostname === 'auth') return url.toString();
-    if (url.protocol === 'matrix-os:') return url.toString();
+    if (url.protocol === 'matrix-os:' && url.hostname === 'device-auth' && url.search === '') {
+      return url.toString();
+    }
     return null;
   } catch (err: unknown) {
     if (!(err instanceof TypeError)) {

--- a/tests/desktop/device-auth.test.ts
+++ b/tests/desktop/device-auth.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it, vi } from "vitest";
-import { requestDeviceCode, pollForToken, DEVICE_CLIENT_ID } from "@desktop/main/auth/device-auth";
+import {
+  requestDeviceCode,
+  pollForToken,
+  DEVICE_CLIENT_ID,
+  DEVICE_REDIRECT_URI,
+} from "@desktop/main/auth/device-auth";
 
 function jsonResponse(status: number, body: unknown): Response {
   return new Response(JSON.stringify(body), {
@@ -28,6 +33,11 @@ describe("requestDeviceCode", () => {
     expect(url).toBe("https://app.matrix-os.com/api/auth/device/code");
     const body = JSON.parse((init as RequestInit).body as string);
     expect(body.clientId).toBe(DEVICE_CLIENT_ID);
+    expect(body.redirectUri).toBe(DEVICE_REDIRECT_URI);
+    expect(body).toMatchObject({
+      clientId: "matrix-os-desktop",
+      redirectUri: "matrixos://auth?status=approved",
+    });
     expect((init as RequestInit).signal).toBeInstanceOf(AbortSignal);
   });
 

--- a/tests/desktop/packaging.test.ts
+++ b/tests/desktop/packaging.test.ts
@@ -1,0 +1,17 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { parseDocument } from "yaml";
+
+describe("desktop packaging", () => {
+  it("registers canonical and legacy macOS URL schemes", () => {
+    const raw = readFileSync(join(process.cwd(), "desktop/electron-builder.yml"), "utf8");
+    const config = parseDocument(raw).toJS() as {
+      protocols?: Array<{ schemes?: string[] }>;
+    };
+
+    const schemes = config.protocols?.flatMap((protocol) => protocol.schemes ?? []) ?? [];
+    expect(schemes).toContain("matrixos");
+    expect(schemes).toContain("matrix-os");
+  });
+});

--- a/tests/platform/device-routes.test.ts
+++ b/tests/platform/device-routes.test.ts
@@ -108,6 +108,44 @@ describe("device routes", () => {
       expect(verificationUri.searchParams.get("redirect_sig")).toEqual(expect.any(String));
     });
 
+    it("includes a signed canonical native callback for the Electron desktop client", async () => {
+      const res = await app.request("/api/auth/device/code", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          clientId: "matrix-os-desktop",
+          redirectUri: "matrixos://auth?status=approved",
+        }),
+      });
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      const verificationUri = new URL(body.verificationUri);
+      expect(verificationUri.searchParams.get("redirect_uri")).toBe(
+        "matrixos://auth?status=approved",
+      );
+      expect(verificationUri.searchParams.get("redirect_sig")).toEqual(expect.any(String));
+    });
+
+    it("keeps the legacy app-owned scheme signable for trusted desktop clients", async () => {
+      const res = await app.request("/api/auth/device/code", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          clientId: "matrix-os-desktop",
+          redirectUri: "matrix-os://device-auth",
+        }),
+      });
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      const verificationUri = new URL(body.verificationUri);
+      expect(verificationUri.searchParams.get("redirect_uri")).toBe(
+        "matrix-os://device-auth",
+      );
+      expect(verificationUri.searchParams.get("redirect_sig")).toEqual(expect.any(String));
+    });
+
     it("uses the app shell origin for macOS approval even when platform API origin differs", async () => {
       process.env.PLATFORM_PUBLIC_URL = "https://api.matrix-os.com";
       process.env.NEXT_PUBLIC_MATRIX_APP_URL = "https://app.matrix-os.com";
@@ -161,7 +199,9 @@ describe("device routes", () => {
       const cliBody = await cliRes.json();
       const invalidBody = await invalidRes.json();
       expect(new URL(cliBody.verificationUri).searchParams.has("redirect_uri")).toBe(false);
+      expect(new URL(cliBody.verificationUri).searchParams.has("redirect_sig")).toBe(false);
       expect(new URL(invalidBody.verificationUri).searchParams.has("redirect_uri")).toBe(false);
+      expect(new URL(invalidBody.verificationUri).searchParams.has("redirect_sig")).toBe(false);
     });
 
     it("rejects oversized body with 413", async () => {
@@ -449,7 +489,7 @@ describe("device routes", () => {
           method: "POST",
           headers: { "content-type": "application/json" },
           body: JSON.stringify({
-            clientId: "matrix-os-macos",
+            clientId: "matrix-os-desktop",
             redirectUri: "matrixos://auth?status=approved",
           }),
         })

--- a/tests/platform/device-routes.test.ts
+++ b/tests/platform/device-routes.test.ts
@@ -146,6 +146,23 @@ describe("device routes", () => {
       expect(verificationUri.searchParams.get("redirect_sig")).toEqual(expect.any(String));
     });
 
+    it("rejects arbitrary legacy scheme callbacks even for trusted desktop clients", async () => {
+      const res = await app.request("/api/auth/device/code", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          clientId: "matrix-os-desktop",
+          redirectUri: "matrix-os://settings?status=approved",
+        }),
+      });
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      const verificationUri = new URL(body.verificationUri);
+      expect(verificationUri.searchParams.has("redirect_uri")).toBe(false);
+      expect(verificationUri.searchParams.has("redirect_sig")).toBe(false);
+    });
+
     it("uses the app shell origin for macOS approval even when platform API origin differs", async () => {
       process.env.PLATFORM_PUBLIC_URL = "https://api.matrix-os.com";
       process.env.NEXT_PUBLIC_MATRIX_APP_URL = "https://app.matrix-os.com";


### PR DESCRIPTION
## Summary
- make matrixos://auth?status=approved the desktop auth callback while keeping matrix-os as a legacy alias
- register both macOS URL schemes in Electron packaging and focus the app on deep-link handoff without exposing callback data to the renderer
- allow trusted native desktop clients to receive signed native redirects and update Swift URL handling/tests

## Tests
- pnpm test tests/desktop/device-auth.test.ts tests/desktop/packaging.test.ts tests/platform/device-routes.test.ts
- pnpm --filter desktop run typecheck
- pnpm --filter @matrix-os/platform exec tsc --noEmit -p tsconfig.typecheck.json
- git diff --check

Not run: Swift tests, because this environment does not have the swift binary.