### PR TITLE
fix(shell): layer settings above fullscreen windows

### DIFF
--- a/shell/src/components/BillingGate.tsx
+++ b/shell/src/components/BillingGate.tsx
@@ -9,6 +9,7 @@ import {
 } from "@/lib/billing";
 import { useMatrixBillingAccess } from "@/hooks/useMatrixBillingAccess";
 import { capturePostHogEvent, capturePostHogLog } from "@/lib/posthog-client";
+import { SHELL_Z_CLASSES } from "@/lib/shell-layering";
 import { Settings } from "./Settings";
 
 const e2eBillingBypass = process.env.NEXT_PUBLIC_E2E_TEST_BYPASS === "1";
@@ -158,7 +159,7 @@ function SubscriptionConfirmationPending({
   const failed = status === "failed";
 
   return (
-    <div className="fixed inset-0 z-[80] flex items-center justify-center bg-deep/30 px-4 py-8 text-deep backdrop-blur-md">
+    <div className={`fixed inset-0 ${SHELL_Z_CLASSES.hardGate} flex items-center justify-center bg-deep/30 px-4 py-8 text-deep backdrop-blur-md`}>
       <section className="relative flex w-full max-w-md flex-col overflow-hidden rounded-3xl border border-forest/15 bg-page-bg/95 shadow-[0_40px_120px_rgba(50,53,46,0.35)]">
         <div
           className="pointer-events-none absolute -right-20 -top-20 size-60 rounded-full opacity-60 blur-3xl"

--- a/shell/src/components/BillingGate.tsx
+++ b/shell/src/components/BillingGate.tsx
@@ -9,7 +9,7 @@ import {
 } from "@/lib/billing";
 import { useMatrixBillingAccess } from "@/hooks/useMatrixBillingAccess";
 import { capturePostHogEvent, capturePostHogLog } from "@/lib/posthog-client";
-import { SHELL_Z_CLASSES } from "@/lib/shell-layering";
+import { SHELL_Z_INDEX } from "@/lib/shell-layering";
 import { Settings } from "./Settings";
 
 const e2eBillingBypass = process.env.NEXT_PUBLIC_E2E_TEST_BYPASS === "1";
@@ -159,7 +159,10 @@ function SubscriptionConfirmationPending({
   const failed = status === "failed";
 
   return (
-    <div className={`fixed inset-0 ${SHELL_Z_CLASSES.hardGate} flex items-center justify-center bg-deep/30 px-4 py-8 text-deep backdrop-blur-md`}>
+    <div
+      className="fixed inset-0 flex items-center justify-center bg-deep/30 px-4 py-8 text-deep backdrop-blur-md"
+      style={{ zIndex: SHELL_Z_INDEX.hardGate }}
+    >
       <section className="relative flex w-full max-w-md flex-col overflow-hidden rounded-3xl border border-forest/15 bg-page-bg/95 shadow-[0_40px_120px_rgba(50,53,46,0.35)]">
         <div
           className="pointer-events-none absolute -right-20 -top-20 size-60 rounded-full opacity-60 blur-3xl"

--- a/shell/src/components/Desktop.tsx
+++ b/shell/src/components/Desktop.tsx
@@ -67,7 +67,7 @@ import { nameToSlug } from "@/lib/utils";
 import { iconUrlForSlug } from "@/lib/app-launch";
 import { isSystemApp, applyOrder } from "@/lib/dock-sections";
 import { MATRIX_ONBOARDING_BRAND_VERSION } from "@/lib/onboarding-brand";
-import { SHELL_Z_CLASSES, SHELL_Z_INDEX } from "@/lib/shell-layering";
+import { SHELL_Z_INDEX } from "@/lib/shell-layering";
 import { enqueueTerminalLaunch, TERMINAL_SETUP_WINDOW_PATH } from "@/lib/terminal-launch";
 import {
   DEFAULT_PINNED_APPS,
@@ -557,7 +557,10 @@ function AoedeDockButton({
 
 function FullscreenExitPill({ onExit }: { onExit: () => void }) {
   return (
-    <div className={`group/fsexit fixed top-0 left-0 ${SHELL_Z_CLASSES.fullscreenExit} w-14 h-3 hover:h-10 transition-all duration-300`}>
+    <div
+      className="group/fsexit fixed top-0 left-0 w-14 h-3 hover:h-10 transition-all duration-300"
+      style={{ zIndex: SHELL_Z_INDEX.fullscreenExit }}
+    >
       <button
         type="button"
         onClick={onExit}

--- a/shell/src/components/Desktop.tsx
+++ b/shell/src/components/Desktop.tsx
@@ -67,6 +67,7 @@ import { nameToSlug } from "@/lib/utils";
 import { iconUrlForSlug } from "@/lib/app-launch";
 import { isSystemApp, applyOrder } from "@/lib/dock-sections";
 import { MATRIX_ONBOARDING_BRAND_VERSION } from "@/lib/onboarding-brand";
+import { SHELL_Z_CLASSES, SHELL_Z_INDEX } from "@/lib/shell-layering";
 import { enqueueTerminalLaunch, TERMINAL_SETUP_WINDOW_PATH } from "@/lib/terminal-launch";
 import {
   DEFAULT_PINNED_APPS,
@@ -556,7 +557,7 @@ function AoedeDockButton({
 
 function FullscreenExitPill({ onExit }: { onExit: () => void }) {
   return (
-    <div className="group/fsexit fixed top-0 left-0 z-[101] w-14 h-3 hover:h-10 transition-all duration-300">
+    <div className={`group/fsexit fixed top-0 left-0 ${SHELL_Z_CLASSES.fullscreenExit} w-14 h-3 hover:h-10 transition-all duration-300`}>
       <button
         type="button"
         onClick={onExit}
@@ -1965,7 +1966,7 @@ export function Desktop({ launchAppPath, onOpenCommandPalette, chat }: DesktopPr
                   : "app-window absolute gap-0 rounded-none md:rounded-lg p-0 overflow-hidden shadow-2xl"
                 }
                 style={isFullscreen ? {
-                  zIndex: 100,
+                  zIndex: SHELL_Z_INDEX.fullscreenWindow,
                   transition: "all 300ms cubic-bezier(0.22, 1, 0.36, 1)",
                 } : {
                   "--win-x": `${win.x}px`,

--- a/shell/src/components/OnboardingScreen.tsx
+++ b/shell/src/components/OnboardingScreen.tsx
@@ -10,7 +10,7 @@ import { KeyboardIcon, MicIcon, SparklesIcon } from "lucide-react";
 import { MATRIX_ONBOARDING_BRAND_VERSION } from "@/lib/onboarding-brand";
 import { ShellNotificationCard } from "./ShellNotificationCard";
 import { ShellNotificationStack } from "./ShellNotificationStack";
-import { SHELL_Z_CLASSES } from "@/lib/shell-layering";
+import { SHELL_Z_INDEX } from "@/lib/shell-layering";
 
 const SHIMMER_GRADIENT =
   "linear-gradient(90deg, #2F392C 0%, #2F392C 24%, #C4A265 50%, #2F392C 76%, #2F392C 100%)";
@@ -184,7 +184,10 @@ export function OnboardingScreen({ onComplete, onOpenManualSetup }: OnboardingSc
     <>
     {/* Landing screen — stays mounted as overlay during transition */}
     {phase !== "revealing" && (
-      <div className={`fixed inset-0 ${SHELL_Z_CLASSES.hardGate} flex flex-col bg-background`}>
+      <div
+        className="fixed inset-0 flex flex-col bg-background"
+        style={{ zIndex: SHELL_Z_INDEX.hardGate }}
+      >
         <MicPermissionDialog
           open={showMicDialog}
           permissionState={mic.state}

--- a/shell/src/components/OnboardingScreen.tsx
+++ b/shell/src/components/OnboardingScreen.tsx
@@ -10,6 +10,7 @@ import { KeyboardIcon, MicIcon, SparklesIcon } from "lucide-react";
 import { MATRIX_ONBOARDING_BRAND_VERSION } from "@/lib/onboarding-brand";
 import { ShellNotificationCard } from "./ShellNotificationCard";
 import { ShellNotificationStack } from "./ShellNotificationStack";
+import { SHELL_Z_CLASSES } from "@/lib/shell-layering";
 
 const SHIMMER_GRADIENT =
   "linear-gradient(90deg, #2F392C 0%, #2F392C 24%, #C4A265 50%, #2F392C 76%, #2F392C 100%)";
@@ -183,7 +184,7 @@ export function OnboardingScreen({ onComplete, onOpenManualSetup }: OnboardingSc
     <>
     {/* Landing screen — stays mounted as overlay during transition */}
     {phase !== "revealing" && (
-      <div className="fixed inset-0 z-[60] flex flex-col bg-background">
+      <div className={`fixed inset-0 ${SHELL_Z_CLASSES.hardGate} flex flex-col bg-background`}>
         <MicPermissionDialog
           open={showMicDialog}
           permissionState={mic.state}

--- a/shell/src/components/Settings.tsx
+++ b/shell/src/components/Settings.tsx
@@ -25,6 +25,7 @@ import { SystemSection } from "./settings/sections/SystemSection";
 import { BillingSection } from "./settings/sections/BillingSection";
 import { useMatrixBillingAccess } from "@/hooks/useMatrixBillingAccess";
 import { UserButton as AccountButton } from "./UserButton";
+import { SHELL_Z_CLASSES } from "@/lib/shell-layering";
 
 
 const sections = [
@@ -184,7 +185,7 @@ export function Settings({
 
   const transitionEase = "cubic-bezier(0.22, 1, 0.36, 1)";
   return (
-    <div className="fixed inset-0 z-[45]">
+    <div className={`fixed inset-0 ${SHELL_Z_CLASSES.settings}`}>
       <button
         type="button"
         aria-label="Close settings"

--- a/shell/src/components/Settings.tsx
+++ b/shell/src/components/Settings.tsx
@@ -25,7 +25,7 @@ import { SystemSection } from "./settings/sections/SystemSection";
 import { BillingSection } from "./settings/sections/BillingSection";
 import { useMatrixBillingAccess } from "@/hooks/useMatrixBillingAccess";
 import { UserButton as AccountButton } from "./UserButton";
-import { SHELL_Z_CLASSES } from "@/lib/shell-layering";
+import { SHELL_Z_INDEX } from "@/lib/shell-layering";
 
 
 const sections = [
@@ -185,7 +185,7 @@ export function Settings({
 
   const transitionEase = "cubic-bezier(0.22, 1, 0.36, 1)";
   return (
-    <div className={`fixed inset-0 ${SHELL_Z_CLASSES.settings}`}>
+    <div className="fixed inset-0" style={{ zIndex: SHELL_Z_INDEX.settings }}>
       <button
         type="button"
         aria-label="Close settings"

--- a/shell/src/components/ShellNotificationStack.tsx
+++ b/shell/src/components/ShellNotificationStack.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import type { ReactNode } from "react";
-import { SHELL_Z_CLASSES } from "@/lib/shell-layering";
+import { SHELL_Z_INDEX } from "@/lib/shell-layering";
 import { SHELL_NOTIFICATION_STACK_ID, setShellNotificationHost } from "./shell-notification-host";
 
 export function ShellNotificationStack({
@@ -16,7 +16,8 @@ export function ShellNotificationStack({
       ref={registerHost ? setShellNotificationHost : undefined}
       id={registerHost ? SHELL_NOTIFICATION_STACK_ID : undefined}
       data-testid="shell-notification-stack"
-      className={`pointer-events-none fixed right-3 top-[calc(env(safe-area-inset-top)+0.75rem)] ${SHELL_Z_CLASSES.notifications} flex w-[calc(100vw-1.5rem)] max-w-[min(92vw,560px)] flex-col items-end gap-2 md:top-9`}
+      className="pointer-events-none fixed right-3 top-[calc(env(safe-area-inset-top)+0.75rem)] flex w-[calc(100vw-1.5rem)] max-w-[min(92vw,560px)] flex-col items-end gap-2 md:top-9"
+      style={{ zIndex: SHELL_Z_INDEX.notifications }}
     >
       {children}
     </div>

--- a/shell/src/components/ShellNotificationStack.tsx
+++ b/shell/src/components/ShellNotificationStack.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import type { ReactNode } from "react";
+import { SHELL_Z_CLASSES } from "@/lib/shell-layering";
 import { SHELL_NOTIFICATION_STACK_ID, setShellNotificationHost } from "./shell-notification-host";
 
 export function ShellNotificationStack({
@@ -15,7 +16,7 @@ export function ShellNotificationStack({
       ref={registerHost ? setShellNotificationHost : undefined}
       id={registerHost ? SHELL_NOTIFICATION_STACK_ID : undefined}
       data-testid="shell-notification-stack"
-      className="pointer-events-none fixed right-3 top-[calc(env(safe-area-inset-top)+0.75rem)] z-[10000] flex w-[calc(100vw-1.5rem)] max-w-[min(92vw,560px)] flex-col items-end gap-2 md:top-9"
+      className={`pointer-events-none fixed right-3 top-[calc(env(safe-area-inset-top)+0.75rem)] ${SHELL_Z_CLASSES.notifications} flex w-[calc(100vw-1.5rem)] max-w-[min(92vw,560px)] flex-col items-end gap-2 md:top-9`}
     >
       {children}
     </div>

--- a/shell/src/components/canvas/CanvasWindow.tsx
+++ b/shell/src/components/canvas/CanvasWindow.tsx
@@ -5,6 +5,7 @@ import { useCanvasTransform, INTERACTION_THRESHOLD } from "@/hooks/useCanvasTran
 import { useWindowManager, type AppWindow } from "@/hooks/useWindowManager";
 import { useMobileViewport } from "@/hooks/useMobileViewport";
 import { useCanvasSettings } from "@/stores/canvas-settings";
+import { SHELL_Z_INDEX } from "@/lib/shell-layering";
 import { AppViewer } from "../AppViewer";
 import { TerminalApp } from "../terminal/TerminalApp";
 import { FileBrowser } from "../file-browser/FileBrowser";
@@ -527,7 +528,7 @@ export function CanvasWindow({ win, hidden = false, deferAppContent = false }: C
     ? {
         left: -contLeft / zoom - panX,
         top: -contTop / zoom - panY,
-        zIndex: 9999,
+        zIndex: SHELL_Z_INDEX.fullscreenWindow,
         transform: `scale(${1 / zoom})`,
         transformOrigin: "0 0",
       }

--- a/shell/src/hooks/useWindowManager.ts
+++ b/shell/src/hooks/useWindowManager.ts
@@ -3,6 +3,7 @@ import { subscribeWithSelector } from "zustand/middleware";
 import { TERMINAL_MIN_WINDOW_HEIGHT, TERMINAL_MIN_WINDOW_WIDTH } from "@/lib/builtin-apps";
 import { getGatewayUrl } from "@/lib/gateway";
 import { isPreVpsBillingSetupRoute } from "@/lib/pre-vps-shell";
+import { SHELL_WINDOW_Z_INDEX_MAX, SHELL_WINDOW_Z_INDEX_START } from "@/lib/shell-layering";
 
 export interface AppWindow {
   id: string;
@@ -175,6 +176,32 @@ function createWindowRecord(
   };
 }
 
+function normalizeWindowZOrder(
+  windows: AppWindow[],
+  nextZ: number,
+): { windows: AppWindow[]; nextZ: number } {
+  if (nextZ <= SHELL_WINDOW_Z_INDEX_MAX) {
+    return { windows, nextZ };
+  }
+
+  const ordered = [...windows].sort((left, right) => left.zIndex - right.zIndex);
+  const zById = new Map<string, number>();
+  ordered.forEach((windowRecord, index) => {
+    zById.set(
+      windowRecord.id,
+      Math.min(SHELL_WINDOW_Z_INDEX_START + index, SHELL_WINDOW_Z_INDEX_MAX),
+    );
+  });
+
+  return {
+    windows: windows.map((windowRecord) => ({
+      ...windowRecord,
+      zIndex: zById.get(windowRecord.id) ?? SHELL_WINDOW_Z_INDEX_START,
+    })),
+    nextZ: Math.min(SHELL_WINDOW_Z_INDEX_START + ordered.length, SHELL_WINDOW_Z_INDEX_MAX),
+  };
+}
+
 export const useWindowManager = create<WindowManagerState & WindowManagerActions>()(
   subscribeWithSelector((set, get) => ({
     windows: [],
@@ -189,16 +216,17 @@ export const useWindowManager = create<WindowManagerState & WindowManagerActions
     openWindow: (name, path, dockXOffset) => {
       markUserLayoutMutation();
       set((state) => {
+        const zState = normalizeWindowZOrder(state.windows, state.nextZ);
         const launchTimes = { ...state.appLaunchTimes, [path]: Date.now() };
-        const existing = state.windows.find((w) => w.path === path);
+        const existing = zState.windows.find((w) => w.path === path);
         if (existing) {
           return {
-            windows: state.windows.map((w) =>
+            windows: zState.windows.map((w) =>
               w.path === path
-                ? { ...w, minimized: false, zIndex: state.nextZ }
+                ? { ...w, minimized: false, zIndex: zState.nextZ }
                 : w,
             ),
-            nextZ: state.nextZ + 1,
+            nextZ: zState.nextZ + 1,
             focusedWindowId: existing.id,
             appLaunchTimes: launchTimes,
           };
@@ -207,7 +235,7 @@ export const useWindowManager = create<WindowManagerState & WindowManagerActions
         // Compute fallback position to the right of the rightmost visible window
         let fallbackX = dockXOffset + 20;
         let fallbackY = 20;
-        const visible = state.windows.filter((w) => !w.minimized);
+        const visible = zState.windows.filter((w) => !w.minimized);
         if (visible.length > 0) {
           const rightmost = visible.reduce((best, w) =>
             (w.x + w.width) > (best.x + best.width) ? w : best,
@@ -216,10 +244,16 @@ export const useWindowManager = create<WindowManagerState & WindowManagerActions
           fallbackY = rightmost.y;
         }
 
-        const nextWindow = createWindowRecord(state, name, path, fallbackX, fallbackY);
+        const nextWindow = createWindowRecord(
+          { ...state, windows: zState.windows, nextZ: zState.nextZ },
+          name,
+          path,
+          fallbackX,
+          fallbackY,
+        );
         return {
-          windows: [...state.windows, nextWindow],
-          nextZ: state.nextZ + 1,
+          windows: [...zState.windows, nextWindow],
+          nextZ: zState.nextZ + 1,
           focusedWindowId: nextWindow.id,
           appLaunchTimes: launchTimes,
         };
@@ -229,10 +263,11 @@ export const useWindowManager = create<WindowManagerState & WindowManagerActions
     openWindowExclusive: (name, path, dockXOffset, basePath) => {
       markUserLayoutMutation();
       set((state) => {
+        const zState = normalizeWindowZOrder(state.windows, state.nextZ);
         const keepPath = basePath ?? path;
         const isSameApp = (w: AppWindow) =>
           w.path === keepPath || w.path.startsWith(keepPath + ":");
-        const withMinimized = state.windows.map((w) =>
+        const withMinimized = zState.windows.map((w) =>
           !isSameApp(w) && !w.minimized ? { ...w, minimized: true } : w,
         );
 
@@ -241,18 +276,24 @@ export const useWindowManager = create<WindowManagerState & WindowManagerActions
           return {
             windows: withMinimized.map((w) =>
               w.path === path
-                ? { ...w, minimized: false, zIndex: state.nextZ }
+                ? { ...w, minimized: false, zIndex: zState.nextZ }
                 : w,
             ),
-            nextZ: state.nextZ + 1,
+            nextZ: zState.nextZ + 1,
             focusedWindowId: existing.id,
           };
         }
 
-        const nextWindow = createWindowRecord(state, name, path, dockXOffset + 20, 48);
+        const nextWindow = createWindowRecord(
+          { ...state, windows: zState.windows, nextZ: zState.nextZ },
+          name,
+          path,
+          dockXOffset + 20,
+          48,
+        );
         return {
           windows: [...withMinimized, nextWindow],
-          nextZ: state.nextZ + 1,
+          nextZ: zState.nextZ + 1,
           focusedWindowId: nextWindow.id,
         };
       });
@@ -305,13 +346,16 @@ export const useWindowManager = create<WindowManagerState & WindowManagerActions
 
     restoreAndFocusWindow: (id) => {
       markUserLayoutMutation();
-      set((state) => ({
-        windows: state.windows.map((w) =>
-          w.id === id ? { ...w, minimized: false, zIndex: state.nextZ } : w,
-        ),
-        nextZ: state.nextZ + 1,
-        focusedWindowId: id,
-      }));
+      set((state) => {
+        const zState = normalizeWindowZOrder(state.windows, state.nextZ);
+        return {
+          windows: zState.windows.map((w) =>
+            w.id === id ? { ...w, minimized: false, zIndex: zState.nextZ } : w,
+          ),
+          nextZ: zState.nextZ + 1,
+          focusedWindowId: id,
+        };
+      });
     },
 
     moveWindow: (id, x, y) => {
@@ -340,13 +384,16 @@ export const useWindowManager = create<WindowManagerState & WindowManagerActions
 
     focusWindow: (id) => {
       markUserLayoutMutation();
-      set((state) => ({
-        windows: state.windows.map((w) =>
-          w.id === id ? { ...w, zIndex: state.nextZ } : w,
-        ),
-        nextZ: state.nextZ + 1,
-        focusedWindowId: id,
-      }));
+      set((state) => {
+        const zState = normalizeWindowZOrder(state.windows, state.nextZ);
+        return {
+          windows: zState.windows.map((w) =>
+            w.id === id ? { ...w, zIndex: zState.nextZ } : w,
+          ),
+          nextZ: zState.nextZ + 1,
+          focusedWindowId: id,
+        };
+      });
     },
 
     clearFocus: () => {

--- a/shell/src/lib/shell-layering.ts
+++ b/shell/src/lib/shell-layering.ts
@@ -1,17 +1,10 @@
 export const SHELL_Z_INDEX = {
-  appWindowMax: 89,
-  fullscreenWindow: 100,
-  fullscreenExit: 101,
-  settings: 110,
-  hardGate: 120,
+  appWindowMax: 500,
+  fullscreenWindow: 600,
+  fullscreenExit: 601,
+  settings: 700,
+  hardGate: 800,
   notifications: 10000,
-} as const;
-
-export const SHELL_Z_CLASSES = {
-  fullscreenExit: "z-[101]",
-  settings: "z-[110]",
-  hardGate: "z-[120]",
-  notifications: "z-[10000]",
 } as const;
 
 export const SHELL_WINDOW_Z_INDEX_START = 1;

--- a/shell/src/lib/shell-layering.ts
+++ b/shell/src/lib/shell-layering.ts
@@ -1,0 +1,18 @@
+export const SHELL_Z_INDEX = {
+  appWindowMax: 89,
+  fullscreenWindow: 100,
+  fullscreenExit: 101,
+  settings: 110,
+  hardGate: 120,
+  notifications: 10000,
+} as const;
+
+export const SHELL_Z_CLASSES = {
+  fullscreenExit: "z-[101]",
+  settings: "z-[110]",
+  hardGate: "z-[120]",
+  notifications: "z-[10000]",
+} as const;
+
+export const SHELL_WINDOW_Z_INDEX_START = 1;
+export const SHELL_WINDOW_Z_INDEX_MAX = SHELL_Z_INDEX.appWindowMax;

--- a/tests/shell/canvas-window-terminal-overlay.test.tsx
+++ b/tests/shell/canvas-window-terminal-overlay.test.tsx
@@ -5,6 +5,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { CanvasWindow } from "../../shell/src/components/canvas/CanvasWindow.js";
 import { useCanvasTransform } from "../../shell/src/hooks/useCanvasTransform.js";
 import { useWindowManager, type AppWindow } from "../../shell/src/hooks/useWindowManager.js";
+import { SHELL_Z_INDEX } from "../../shell/src/lib/shell-layering.js";
 
 const appViewerRender = vi.hoisted(() => vi.fn());
 const terminalRender = vi.hoisted(() => vi.fn());
@@ -102,6 +103,19 @@ describe("CanvasWindow terminal interactivity", () => {
 
     expect(screen.getByRole("button", { name: "Terminal tab one" })).toBeTruthy();
     expect(container.querySelector("[data-canvas-interaction-overlay]")).toBeNull();
+  });
+
+  it("keeps fullscreen Canvas windows below the settings layer", () => {
+    useWindowManager.setState({
+      windows: [terminalWindow],
+      fullscreenWindowId: terminalWindow.id,
+    });
+
+    const { container } = render(<CanvasWindow win={terminalWindow} />);
+    const wrapper = container.firstElementChild as HTMLElement;
+
+    expect(wrapper.style.zIndex).toBe(String(SHELL_Z_INDEX.fullscreenWindow));
+    expect(SHELL_Z_INDEX.fullscreenWindow).toBeLessThan(SHELL_Z_INDEX.settings);
   });
 
   it("focuses terminal Canvas windows during capture before terminal child handling", async () => {

--- a/tests/shell/settings-panel.test.tsx
+++ b/tests/shell/settings-panel.test.tsx
@@ -4,20 +4,11 @@ import React from "react";
 import "@testing-library/jest-dom/vitest";
 import { render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import {
-  SHELL_Z_CLASSES,
-  SHELL_Z_INDEX,
-} from "../../shell/src/lib/shell-layering.js";
+import { SHELL_Z_INDEX } from "../../shell/src/lib/shell-layering.js";
 
 const billingState = vi.hoisted(() => ({
   active: true as boolean | null,
 }));
-
-function zIndexFromClassName(className: string): number {
-  const match = className.match(/\bz-\[(\d+)\]/);
-  expect(match).toBeTruthy();
-  return Number(match?.[1]);
-}
 
 vi.mock("@/hooks/useMatrixBillingAccess", () => ({
   useMatrixBillingAccess: () => ({
@@ -127,9 +118,9 @@ describe("Settings panel", () => {
 
     const settingsLayer = screen.getByLabelText("Close settings").parentElement;
     expect(settingsLayer).toBeTruthy();
-    expect(settingsLayer?.className).toContain(SHELL_Z_CLASSES.settings);
 
-    const settingsZ = zIndexFromClassName(settingsLayer?.className ?? "");
+    const settingsZ = Number(settingsLayer?.style.zIndex);
+    expect(settingsZ).toBe(SHELL_Z_INDEX.settings);
     expect(settingsZ).toBeGreaterThan(SHELL_Z_INDEX.fullscreenExit);
     expect(settingsZ).toBeLessThan(SHELL_Z_INDEX.hardGate);
     expect(settingsZ).toBeLessThan(SHELL_Z_INDEX.notifications);

--- a/tests/shell/settings-panel.test.tsx
+++ b/tests/shell/settings-panel.test.tsx
@@ -4,10 +4,20 @@ import React from "react";
 import "@testing-library/jest-dom/vitest";
 import { render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  SHELL_Z_CLASSES,
+  SHELL_Z_INDEX,
+} from "../../shell/src/lib/shell-layering.js";
 
 const billingState = vi.hoisted(() => ({
   active: true as boolean | null,
 }));
+
+function zIndexFromClassName(className: string): number {
+  const match = className.match(/\bz-\[(\d+)\]/);
+  expect(match).toBeTruthy();
+  return Number(match?.[1]);
+}
 
 vi.mock("@/hooks/useMatrixBillingAccess", () => ({
   useMatrixBillingAccess: () => ({
@@ -108,5 +118,20 @@ describe("Settings panel", () => {
     expect(nav.className).toContain("sm:overflow-y-auto");
     expect(accountRegion.className).toContain("sticky");
     expect(accountRegion.className).toContain("sm:static");
+  });
+
+  it("renders above fullscreen app windows while staying below hard gates and shell notifications", async () => {
+    const { Settings } = await import("../../shell/src/components/Settings.js");
+
+    render(<Settings open onOpenChange={() => {}} />);
+
+    const settingsLayer = screen.getByLabelText("Close settings").parentElement;
+    expect(settingsLayer).toBeTruthy();
+    expect(settingsLayer?.className).toContain(SHELL_Z_CLASSES.settings);
+
+    const settingsZ = zIndexFromClassName(settingsLayer?.className ?? "");
+    expect(settingsZ).toBeGreaterThan(SHELL_Z_INDEX.fullscreenExit);
+    expect(settingsZ).toBeLessThan(SHELL_Z_INDEX.hardGate);
+    expect(settingsZ).toBeLessThan(SHELL_Z_INDEX.notifications);
   });
 });

--- a/tests/shell/shell-layering.test.ts
+++ b/tests/shell/shell-layering.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vitest";
+import {
+  SHELL_WINDOW_Z_INDEX_MAX,
+  SHELL_Z_INDEX,
+} from "../../shell/src/lib/shell-layering.js";
+
+describe("shell layer ordering", () => {
+  it("keeps app windows below settings and hard gates above settings", () => {
+    expect(SHELL_WINDOW_Z_INDEX_MAX).toBeLessThan(SHELL_Z_INDEX.fullscreenWindow);
+    expect(SHELL_Z_INDEX.fullscreenWindow).toBeLessThan(SHELL_Z_INDEX.fullscreenExit);
+    expect(SHELL_Z_INDEX.fullscreenExit).toBeLessThan(SHELL_Z_INDEX.settings);
+    expect(SHELL_Z_INDEX.settings).toBeLessThan(SHELL_Z_INDEX.hardGate);
+    expect(SHELL_Z_INDEX.hardGate).toBeLessThan(SHELL_Z_INDEX.notifications);
+  });
+});

--- a/tests/shell/shell-notification-stack.test.tsx
+++ b/tests/shell/shell-notification-stack.test.tsx
@@ -7,6 +7,7 @@ import {
   ShellNotificationStack,
 } from "../../shell/src/components/ShellNotificationStack.js";
 import { ShellNotificationCard } from "../../shell/src/components/ShellNotificationCard.js";
+import { SHELL_Z_CLASSES } from "../../shell/src/lib/shell-layering.js";
 import {
   getShellNotificationHostSnapshot,
   subscribeShellNotificationHost,
@@ -29,7 +30,7 @@ describe("ShellNotificationStack", () => {
     expect(stack.className).toContain("md:top-9");
     expect(stack.className).toContain("pointer-events-none");
     expect(stack.className).toContain("flex-col");
-    expect(stack.className).toContain("z-[10000]");
+    expect(stack.className).toContain(SHELL_Z_CLASSES.notifications);
 
     const card = screen.getByTestId("shell-notification-card");
     expect(card.className).toContain("pointer-events-auto");

--- a/tests/shell/shell-notification-stack.test.tsx
+++ b/tests/shell/shell-notification-stack.test.tsx
@@ -7,7 +7,7 @@ import {
   ShellNotificationStack,
 } from "../../shell/src/components/ShellNotificationStack.js";
 import { ShellNotificationCard } from "../../shell/src/components/ShellNotificationCard.js";
-import { SHELL_Z_CLASSES } from "../../shell/src/lib/shell-layering.js";
+import { SHELL_Z_INDEX } from "../../shell/src/lib/shell-layering.js";
 import {
   getShellNotificationHostSnapshot,
   subscribeShellNotificationHost,
@@ -30,7 +30,7 @@ describe("ShellNotificationStack", () => {
     expect(stack.className).toContain("md:top-9");
     expect(stack.className).toContain("pointer-events-none");
     expect(stack.className).toContain("flex-col");
-    expect(stack.className).toContain(SHELL_Z_CLASSES.notifications);
+    expect(stack.style.zIndex).toBe(String(SHELL_Z_INDEX.notifications));
 
     const card = screen.getByTestId("shell-notification-card");
     expect(card.className).toContain("pointer-events-auto");

--- a/tests/shell/window-manager.test.ts
+++ b/tests/shell/window-manager.test.ts
@@ -6,6 +6,10 @@ import {
   type AppWindow,
   type LayoutWindow,
 } from "../../shell/src/hooks/useWindowManager.js";
+import {
+  SHELL_WINDOW_Z_INDEX_MAX,
+  SHELL_Z_INDEX,
+} from "../../shell/src/lib/shell-layering.js";
 
 const fetchSpy = vi.fn().mockResolvedValue({ ok: true });
 vi.stubGlobal("fetch", fetchSpy);
@@ -19,6 +23,7 @@ function resetStore() {
     closedLayouts: new Map(),
     apps: [],
     focusedWindowId: null,
+    fullscreenWindowId: null,
   });
 }
 
@@ -147,6 +152,43 @@ describe("Window Manager Store", () => {
       const [w1, w2] = useWindowManager.getState().windows;
       expect(w1.zIndex).toBeGreaterThan(w2.zIndex);
       expect(useWindowManager.getState().getFocusedWindow()?.id).toBe(w1Id);
+    });
+
+    it("compacts focused window z-indexes below the settings layer", () => {
+      const terminal: AppWindow = {
+        id: "win-terminal",
+        title: "Terminal",
+        path: "__terminal__",
+        x: 0,
+        y: 0,
+        width: 800,
+        height: 600,
+        minimized: false,
+        zIndex: SHELL_WINDOW_Z_INDEX_MAX,
+      };
+      const notes: AppWindow = {
+        id: "win-notes",
+        title: "Notes",
+        path: "apps/notes.html",
+        x: 40,
+        y: 40,
+        width: 640,
+        height: 480,
+        minimized: false,
+        zIndex: SHELL_WINDOW_Z_INDEX_MAX - 1,
+      };
+      useWindowManager.setState({
+        windows: [terminal, notes],
+        nextZ: SHELL_WINDOW_Z_INDEX_MAX + 1,
+      });
+
+      useWindowManager.getState().focusWindow("win-terminal");
+
+      const { windows } = useWindowManager.getState();
+      const focused = windows.find((w) => w.id === "win-terminal");
+      const highestWindowZ = Math.max(...windows.map((w) => w.zIndex));
+      expect(focused?.zIndex).toBe(highestWindowZ);
+      expect(highestWindowZ).toBeLessThan(SHELL_Z_INDEX.settings);
     });
 
     it("clears focused window when clicking the canvas background", () => {


### PR DESCRIPTION
## Summary
- Recreate the #602 Settings layering fix directly against main.
- Add shared shell z-index constants so fullscreen windows, Settings, hard gates, and notifications have an explicit order.
- Keep normal app windows capped below Settings so a focused Terminal cannot drift above Settings outside fullscreen.
- Fold in #602 Greptile feedback by keeping BillingGate/Onboarding hard gates above Settings and replacing brittle notification assertions with numeric layer-order tests.
- Use numeric inline z-index styles for shared shell layers so the browser gets the intended computed z-index without relying on dynamic Tailwind arbitrary classes.

## Tests
- PASS: `NODE_OPTIONS=--localstorage-file=/private/tmp/matrix-os-settings-layering-main-localstorage bun run test -- tests/shell/shell-layering.test.ts tests/shell/settings-panel.test.tsx tests/shell/shell-notification-stack.test.tsx tests/shell/window-manager.test.ts tests/shell/desktop-terminal-fullscreen-pill.test.tsx tests/shell/canvas-window-terminal-overlay.test.tsx` (6 files, 46 tests; existing CanvasWindow act warning only)
- PASS: `npx react-doctor@latest --verbose --scope changed shell`
- PASS: `bun run typecheck`
- PASS: `bun run check:patterns` (existing warnings only; no violations)

## Review/Monitoring
- Replaces PR #602's stacked-branch change with a main-targeted PR.
- Addresses the Greptile findings from #602 and the first #605 review: Settings no longer sits above hard gates, shell z-index classes are no longer duplicated, and app-window compaction has generous headroom below Settings.

## Screenshot Evidence
- Posted in https://github.com/HamedMP/matrix-os/pull/605#issuecomment-4772069993
- Captured from local bypassed shell at `http://localhost:3002/?launch=__terminal__` with Terminal fullscreened and Settings opened.
- Computed browser z-index evidence: fullscreen Terminal `600`, Settings `700`, Settings content visible `true`.
