### PR TITLE
fix(shell): restore canvas launcher dock button

### DIFF
--- a/shell/src/components/Desktop.tsx
+++ b/shell/src/components/Desktop.tsx
@@ -1172,8 +1172,7 @@ export function Desktop({ launchAppPath, onOpenCommandPalette, chat }: DesktopPr
   const setDesktopMode = useDesktopMode((s) => s.setMode);
   const visibleModes = useDesktopMode((s) => s.visibleModes);
   const getModeConfig = useDesktopMode((s) => s.getModeConfig);
-  const hydrated = useDesktopMode((s) => s._hydrated);
-  const modeConfig = getModeConfig(hydrated ? desktopMode : "dev");
+  const modeConfig = getModeConfig(desktopMode);
   const visibleWindowCount = windows.reduce((count, w) => count + (w.minimized ? 0 : 1), 0);
   const developerDashboardVisible = shouldShowDeveloperDashboard(firstRunStatus, desktopMode, visibleWindowCount);
   const openPrCanvas = useWorkspaceCanvasStore((s) => s.openPrCanvas);

--- a/tests/shell/desktop-launcher-mode.test.tsx
+++ b/tests/shell/desktop-launcher-mode.test.tsx
@@ -107,12 +107,12 @@ function jsonResponse(body: unknown) {
   }));
 }
 
-type DesktopComponent = typeof Desktop;
+type DesktopComponentType = typeof Desktop;
 type DesktopModeStore = typeof useDesktopMode;
 type DesktopConfigStore = typeof useDesktopConfigStore;
 type WindowManagerStore = typeof useWindowManager;
 
-let DesktopComponent: DesktopComponent;
+let DesktopComponent: DesktopComponentType;
 let desktopModeStore: DesktopModeStore;
 let desktopConfigStore: DesktopConfigStore;
 let windowManagerStore: WindowManagerStore;

--- a/tests/shell/desktop-launcher-mode.test.tsx
+++ b/tests/shell/desktop-launcher-mode.test.tsx
@@ -1,0 +1,198 @@
+// @vitest-environment jsdom
+import React from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { Desktop } from "../../shell/src/components/Desktop.js";
+import type { useWindowManager } from "../../shell/src/hooks/useWindowManager.js";
+import type { useDesktopConfigStore } from "../../shell/src/stores/desktop-config.js";
+import type { useDesktopMode } from "../../shell/src/stores/desktop-mode.js";
+
+vi.mock("../../shell/src/hooks/useFileWatcher.js", () => ({
+  useFileWatcher: () => undefined,
+}));
+
+vi.mock("../../shell/src/components/terminal/TerminalApp.js", () => ({
+  TerminalApp: () => null,
+}));
+
+vi.mock("../../shell/src/components/AppViewer.js", () => ({
+  AppViewer: () => null,
+}));
+
+vi.mock("../../shell/src/components/workspace/WorkspaceApp.js", () => ({
+  WorkspaceApp: () => null,
+}));
+
+vi.mock("../../shell/src/components/file-browser/FileBrowser.js", () => ({
+  FileBrowser: () => null,
+}));
+
+vi.mock("../../shell/src/components/preview-window/PreviewWindow.js", () => ({
+  PreviewWindow: () => null,
+}));
+
+vi.mock("../../shell/src/components/system-activity/ActivityMonitorApp.js", () => ({
+  ActivityMonitorApp: () => null,
+}));
+
+vi.mock("../../shell/src/components/AIButton.js", () => ({
+  AIButton: () => null,
+}));
+
+vi.mock("../../shell/src/components/MissionControl.js", () => ({
+  MissionControl: () => null,
+}));
+
+vi.mock("../../shell/src/components/DotGrid.js", () => ({
+  DotGrid: () => null,
+}));
+
+vi.mock("../../shell/src/components/Settings.js", () => ({
+  Settings: () => null,
+}));
+
+vi.mock("../../shell/src/components/canvas/CanvasRenderer.js", () => ({
+  CanvasRenderer: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock("../../shell/src/components/canvas/CanvasToolbar.js", () => ({
+  CanvasToolbar: () => null,
+}));
+
+vi.mock("../../shell/src/components/VocalPanel.js", () => ({
+  VocalPanel: () => null,
+}));
+
+vi.mock("../../shell/src/components/UserButton.js", () => ({
+  UserButton: () => null,
+}));
+
+vi.mock("../../shell/src/components/ConnectionIndicator.js", () => ({
+  ConnectionIndicator: () => null,
+}));
+
+vi.mock("../../shell/src/components/AmbientClock.js", () => ({
+  AmbientClock: () => null,
+}));
+
+vi.mock("../../shell/src/components/MenuBar.js", () => ({
+  MenuBar: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock("../../shell/src/components/ChatApp.js", () => ({
+  ChatApp: () => null,
+}));
+
+vi.mock("../../shell/src/components/ChatPopover.js", () => ({
+  ChatPopover: () => null,
+}));
+
+vi.mock("../../shell/src/components/onboarding/ManualSetupStickers.js", () => ({
+  ManualSetupStickers: () => null,
+}));
+
+vi.mock("../../shell/src/components/RuntimeIdentityBanner.js", () => ({
+  RuntimeIdentityBanner: () => null,
+}));
+
+vi.mock("../../shell/src/components/developer/DeveloperModeDashboard.js", () => ({
+  DeveloperModeDashboard: () => null,
+}));
+
+function jsonResponse(body: unknown) {
+  return Promise.resolve(new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  }));
+}
+
+type DesktopComponent = typeof Desktop;
+type DesktopModeStore = typeof useDesktopMode;
+type DesktopConfigStore = typeof useDesktopConfigStore;
+type WindowManagerStore = typeof useWindowManager;
+
+let DesktopComponent: DesktopComponent;
+let desktopModeStore: DesktopModeStore;
+let desktopConfigStore: DesktopConfigStore;
+let windowManagerStore: WindowManagerStore;
+
+function createMemoryStorage(): Storage {
+  const values = new Map<string, string>();
+  return {
+    get length() {
+      return values.size;
+    },
+    clear: () => values.clear(),
+    getItem: (key) => values.get(key) ?? null,
+    key: (index) => Array.from(values.keys())[index] ?? null,
+    removeItem: (key) => values.delete(key),
+    setItem: (key, value) => values.set(key, value),
+  };
+}
+
+function resetShellMode(mode: "canvas" | "dev", hydrated: boolean) {
+  desktopModeStore.setState({
+    mode,
+    previousMode: null,
+    _hydrated: hydrated,
+  });
+  desktopConfigStore.setState({
+    dock: { position: "left", size: 56, iconSize: 40, autoHide: false },
+    pinnedApps: [],
+  });
+  windowManagerStore.setState({
+    windows: [],
+    apps: [],
+    nextZ: 1,
+    closedPaths: new Set(),
+    closedLayouts: new Map(),
+    focusedWindowId: null,
+    fullscreenWindowId: null,
+  });
+}
+
+describe("Desktop launcher dock button by mode", () => {
+  beforeEach(async () => {
+    vi.resetModules();
+    const storage = createMemoryStorage();
+    vi.stubGlobal("localStorage", storage);
+    Object.defineProperty(window, "localStorage", {
+      value: storage,
+      configurable: true,
+    });
+    vi.stubGlobal("fetch", vi.fn((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes("/api/settings/onboarding-status")) return jsonResponse({ complete: true });
+      if (url.includes("/api/shell/bootstrap")) return jsonResponse({ layout: { windows: [] }, apps: [], modules: [] });
+      return jsonResponse({});
+    }));
+    DesktopComponent = (await import("../../shell/src/components/Desktop.js")).Desktop;
+    desktopModeStore = (await import("../../shell/src/stores/desktop-mode.js")).useDesktopMode;
+    desktopConfigStore = (await import("../../shell/src/stores/desktop-config.js")).useDesktopConfigStore;
+    windowManagerStore = (await import("../../shell/src/hooks/useWindowManager.js")).useWindowManager;
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("keeps the launcher visible in canvas mode even before mode hydration completes", async () => {
+    resetShellMode("canvas", false);
+
+    render(<DesktopComponent />);
+
+    expect(await screen.findByTestId("dock-tasks")).toBeTruthy();
+  });
+
+  it("hides the launcher in developer mode", async () => {
+    resetShellMode("dev", true);
+
+    render(<DesktopComponent />);
+
+    await waitFor(() => {
+      expect(screen.queryByTestId("dock-tasks")).toBeNull();
+      expect(screen.getByTestId("dock-settings")).toBeTruthy();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Restore the Canvas-mode launcher dock button by resolving shell chrome from the active mode instead of temporarily falling back to Developer mode.
- Add a regression test that verifies Canvas shows the launcher while Developer mode keeps it hidden.
- Clean up the regression test type alias naming so the type and value identifiers are distinct.

## Tests
- `pnpm exec vitest run tests/shell/desktop-launcher-mode.test.tsx` (2 tests passed)
- `npx react-doctor@latest shell` (completed; baseline shell audit reports 71/100 with 186 pre-existing warnings)
- `npx react-doctor@latest --verbose --scope changed shell` (No issues found)

## Review/Monitoring
- Screenshot evidence: [Canvas launcher dock button visible](https://gist.github.com/Nima-Naderi/836757858d71af6ce7245821fdd1cfb8) after loading the shell in Canvas mode and waiting for `dock-tasks`.
- The screenshot was captured with Playwright against `http://localhost:3002/` after setting `matrix-os-desktop-mode` to Canvas in localStorage.
- `pnpm run test -- tests/shell/desktop-launcher-mode.test.tsx` was attempted first, but the root wrapper ignored the file filter and started a broad repository run. I stopped it after unrelated failures appeared in `tests/gateway/sync/home-mirror.test.ts` and `tests/gateway/app-runtime/process-manager.test.ts`; the direct focused Vitest command above passed.
- Latest Greptile review on commit `1c6953a9` was 4/5. This update addresses its three findings: screenshot evidence, React Doctor audit, and the test alias naming cleanup.

## Invariants
- **Source of truth**: `useDesktopMode` remains the source of truth for mode-specific shell chrome. Canvas mode owns Canvas launcher visibility; Developer mode owns its hidden-launcher behavior.
- **Lock/transaction scope**: No backend writes, locks, transactions, or network calls are introduced.
- **Acceptable orphan states**: None. This only changes which existing dock button renders for an already-selected shell mode.
- **Auth source of truth**: No auth behavior changes.
- **Deferred scope**: This does not change pinned apps, dock ordering, Developer mode dashboard behavior, or other sidebar controls.
