### PR TITLE
fix(mobile): align terminal session APIs

### DIFF
--- a/apps/mobile/__tests__/terminal-client.test.ts
+++ b/apps/mobile/__tests__/terminal-client.test.ts
@@ -39,26 +39,54 @@ describe("mobile terminal client", () => {
 
   it("parses only safe terminal session summaries", () => {
     expect(parseTerminalSessions([
-      { sessionId: SESSION_ID, cwd: "/home/matrix/home", state: "running", attachedClients: 1 },
+      {
+        sessionId: SESSION_ID,
+        cwd: "/home/matrix/home",
+        state: "running",
+        createdAt: 1,
+        lastAttachedAt: 2,
+        attachedClients: 1,
+      },
       { sessionId: "../../../secret", cwd: "/tmp", state: "running" },
       { cwd: "/tmp" },
     ])).toEqual([
-      { sessionId: SESSION_ID, cwd: "/home/matrix/home", state: "running", attachedClients: 1 },
+      {
+        sessionId: SESSION_ID,
+        cwd: "/home/matrix/home",
+        state: "running",
+        createdAt: 1,
+        lastAttachedAt: 2,
+        attachedClients: 1,
+      },
     ]);
   });
 
-  it("fetches terminal sessions through the authenticated gateway", async () => {
+  it("fetches legacy PTY terminal sessions through the authenticated gateway", async () => {
     const fetchMock = jest.spyOn(global, "fetch").mockResolvedValueOnce(jsonResponse([
-      { sessionId: SESSION_ID, cwd: "/home/matrix/home/projects", state: "running" },
+      {
+        sessionId: SESSION_ID,
+        cwd: "projects",
+        state: "running",
+        createdAt: 1,
+        lastAttachedAt: 2,
+        attachedClients: 1,
+      },
     ]));
 
     const gateway = new GatewayClient("https://app.matrix-os.test", "clerk-token");
     await expect(gateway.getTerminalSessions()).resolves.toEqual([
-      { sessionId: SESSION_ID, cwd: "/home/matrix/home/projects", state: "running" },
+      {
+        sessionId: SESSION_ID,
+        cwd: "projects",
+        state: "running",
+        createdAt: 1,
+        lastAttachedAt: 2,
+        attachedClients: 1,
+      },
     ]);
 
     expect(fetchMock).toHaveBeenCalledWith(
-      "https://app.matrix-os.test/api/terminal/sessions",
+      "https://app.matrix-os.test/api/terminal/pty-sessions",
       expect.objectContaining({
         headers: expect.objectContaining({ Authorization: "Bearer clerk-token" }),
       }),
@@ -74,7 +102,7 @@ describe("mobile terminal client", () => {
 
     expect(fetchMock).toHaveBeenCalledTimes(1);
     expect(fetchMock).toHaveBeenCalledWith(
-      `https://app.matrix-os.test/api/terminal/sessions/${SESSION_ID}`,
+      `https://app.matrix-os.test/api/terminal/pty-sessions/${SESSION_ID}`,
       expect.objectContaining({ method: "DELETE" }),
     );
   });

--- a/apps/mobile/__tests__/terminal-client.test.ts
+++ b/apps/mobile/__tests__/terminal-client.test.ts
@@ -47,6 +47,13 @@ describe("mobile terminal client", () => {
         lastAttachedAt: 2,
         attachedClients: 1,
       },
+      {
+        sessionId: "850e8400-e29b-41d4-a716-446655440001",
+        cwd: "/home/matrix/home/projects",
+        state: "running",
+        createdAt: Number.NaN,
+        lastAttachedAt: Number.POSITIVE_INFINITY,
+      },
       { sessionId: "../../../secret", cwd: "/tmp", state: "running" },
       { cwd: "/tmp" },
     ])).toEqual([
@@ -57,6 +64,11 @@ describe("mobile terminal client", () => {
         createdAt: 1,
         lastAttachedAt: 2,
         attachedClients: 1,
+      },
+      {
+        sessionId: "850e8400-e29b-41d4-a716-446655440001",
+        cwd: "/home/matrix/home/projects",
+        state: "running",
       },
     ]);
   });

--- a/apps/mobile/lib/gateway-client.ts
+++ b/apps/mobile/lib/gateway-client.ts
@@ -77,6 +77,7 @@ type ReactNativeWebSocketConstructor = new (
 const RECONNECT_BASE_MS = 1000;
 const RECONNECT_MAX_MS = 30000;
 export const DEFAULT_GATEWAY_FETCH_TIMEOUT_MS = 10_000;
+const TERMINAL_PTY_SESSIONS_PATH = "/api/terminal/pty-sessions";
 const SECURE_TOKEN_TRANSPORT_ERROR =
   "Gateway tokens require HTTPS/WSS unless connecting to localhost.";
 
@@ -448,14 +449,14 @@ export class GatewayClient {
 
   async getTerminalSessions(): Promise<MobileTerminalSession[]> {
     try {
-      const res = await this.fetchGateway("/api/terminal/sessions");
+      const res = await this.fetchGateway(TERMINAL_PTY_SESSIONS_PATH);
       if (!res.ok) {
-        console.warn("[mobile] /api/terminal/sessions unavailable", res.status);
+        console.warn("[mobile] /api/terminal/pty-sessions unavailable", res.status);
         return [];
       }
       return parseTerminalSessions(await res.json());
-    } catch {
-      console.warn("[mobile] /api/terminal/sessions unavailable");
+    } catch (err: unknown) {
+      console.warn("[mobile] /api/terminal/pty-sessions unavailable", err instanceof Error ? err.message : String(err));
       return [];
     }
   }
@@ -464,14 +465,14 @@ export class GatewayClient {
     if (!isSafeSessionId(sessionId)) return false;
     try {
       const res = await this.fetchGateway(
-        `/api/terminal/sessions/${encodeURIComponent(sessionId)}`,
+        `${TERMINAL_PTY_SESSIONS_PATH}/${encodeURIComponent(sessionId)}`,
         { method: "DELETE" },
       );
       if (res.ok || res.status === 404) return true;
       console.warn("[mobile] terminal session delete unavailable", res.status);
       return false;
-    } catch {
-      console.warn("[mobile] terminal session delete unavailable");
+    } catch (err: unknown) {
+      console.warn("[mobile] terminal session delete unavailable", err instanceof Error ? err.message : String(err));
       return false;
     }
   }

--- a/apps/mobile/lib/terminal-state.ts
+++ b/apps/mobile/lib/terminal-state.ts
@@ -10,8 +10,8 @@ export interface MobileTerminalSession {
   sessionId: string;
   cwd: string;
   state: "running" | "exited" | "destroyed" | string;
-  createdAt?: string;
-  lastAttachedAt?: string;
+  createdAt?: string | number;
+  lastAttachedAt?: string | number;
   attachedClients?: number;
   exitCode?: number | null;
 }
@@ -147,8 +147,12 @@ export function parseTerminalSessions(value: unknown): MobileTerminalSession[] {
       cwd: typeof candidate.cwd === "string" ? candidate.cwd : "~",
       state: typeof candidate.state === "string" ? candidate.state : "running",
     };
-    if (typeof candidate.createdAt === "string") session.createdAt = candidate.createdAt;
-    if (typeof candidate.lastAttachedAt === "string") session.lastAttachedAt = candidate.lastAttachedAt;
+    if (typeof candidate.createdAt === "string" || typeof candidate.createdAt === "number") {
+      session.createdAt = candidate.createdAt;
+    }
+    if (typeof candidate.lastAttachedAt === "string" || typeof candidate.lastAttachedAt === "number") {
+      session.lastAttachedAt = candidate.lastAttachedAt;
+    }
     if (typeof candidate.attachedClients === "number") session.attachedClients = candidate.attachedClients;
     if (typeof candidate.exitCode === "number" || candidate.exitCode === null) session.exitCode = candidate.exitCode;
     return [session];

--- a/apps/mobile/lib/terminal-state.ts
+++ b/apps/mobile/lib/terminal-state.ts
@@ -147,10 +147,10 @@ export function parseTerminalSessions(value: unknown): MobileTerminalSession[] {
       cwd: typeof candidate.cwd === "string" ? candidate.cwd : "~",
       state: typeof candidate.state === "string" ? candidate.state : "running",
     };
-    if (typeof candidate.createdAt === "string" || typeof candidate.createdAt === "number") {
+    if (isTerminalTimestamp(candidate.createdAt)) {
       session.createdAt = candidate.createdAt;
     }
-    if (typeof candidate.lastAttachedAt === "string" || typeof candidate.lastAttachedAt === "number") {
+    if (isTerminalTimestamp(candidate.lastAttachedAt)) {
       session.lastAttachedAt = candidate.lastAttachedAt;
     }
     if (typeof candidate.attachedClients === "number") session.attachedClients = candidate.attachedClients;
@@ -204,6 +204,10 @@ function safeTerminalError(message: string): string {
   if (!trimmed || trimmed.length > 180) return "Terminal unavailable";
   if (/\/home\/|postgres|secret|token|provider/i.test(trimmed)) return "Terminal unavailable";
   return trimmed;
+}
+
+function isTerminalTimestamp(value: unknown): value is string | number {
+  return typeof value === "string" || (typeof value === "number" && Number.isFinite(value));
 }
 
 function clamp(value: number, min: number, max: number): number {


### PR DESCRIPTION
## Summary

- Align mobile terminal session list/delete calls with the legacy PTY REST API used by `/ws/terminal`.
- Preserve finite numeric `createdAt` and `lastAttachedAt` fields from the gateway PTY session list contract while rejecting non-finite numeric values.
- Update focused mobile regression tests so `/api/terminal/sessions` cannot mask the PTY route mismatch.

## Tests

- `pnpm --dir apps/mobile test -- terminal-client.test.ts` (before the Greptile follow-up guard)
- `pnpm --filter @matrix-os/observability build`
- `pnpm exec vitest run tests/gateway/terminal-ws.test.ts`
- `./scripts/review/check-patterns.sh`
- Not run locally after the final Greptile follow-up: mobile Jest/gateway Vitest because the earlier `pnpm install --frozen-lockfile` fallback filled `/tmp`/root to 0 bytes free; generated `node_modules` in this worktree were removed afterward to restore enough space for Git/lightweight checks.
- Not run locally: `bun run typecheck`, `bun run check:patterns`, `bun run test` because `bun` is unavailable in this environment. CI is monitoring the equivalent broad gates.

## Review/Monitoring

- PR is ready for review and labeled `ready-for-ci`.
- CI and Greptile are being monitored on the latest pushed commit.
- A prior Docker build failure was caused by a GitHub Actions cache export 503 after the image build completed; the failed workflow was rerun.

## Invariants

- **Source of truth**: Legacy mobile terminal sessions created through `/ws/terminal` are represented by the gateway legacy PTY session API at `/api/terminal/pty-sessions`; the zellij shell session API at `/api/terminal/sessions` remains a separate contract.
- **Lock/transaction scope**: This change does not add database or filesystem writes. Mobile continues to delegate PTY session lifecycle ownership to the gateway terminal registry.
- **Acceptable orphan states**: If a WebSocket PTY session exists but the PTY list/delete route is unavailable, mobile falls back to an empty list or failed delete result without clearing local state through this client path. Existing gateway idempotent delete behavior remains unchanged.
- **Auth source of truth**: Existing gateway terminal route authentication remains the source of truth; mobile sends the same authenticated gateway request headers to the matching PTY route.
- **Deferred scope**: This PR does not unify legacy PTY and zellij shell sessions, redesign terminal session storage, or change WebSocket creation semantics.
