### PR TITLE
fix(gateway): recover volatile Canvas terminal sessions

### DIFF
--- a/packages/gateway/src/canvas/recovery.ts
+++ b/packages/gateway/src/canvas/recovery.ts
@@ -13,6 +13,22 @@ export interface CleanupPolicy {
   maxFiles: number;
 }
 
+function missingReferenceMetadata(
+  node: object,
+  sourceRef: { kind?: string; id?: string },
+): Record<string, unknown> {
+  const metadata = { ...(node as { metadata?: Record<string, unknown> }).metadata };
+  if (sourceRef.kind === "terminal_session" && sourceRef.id) {
+    return {
+      ...metadata,
+      recoveryReason: "terminal_session_missing",
+      terminalSessionState: "missing",
+      terminalSessionId: sourceRef.id,
+    };
+  }
+  return { ...metadata, recoveryReason: "missing_reference" };
+}
+
 export async function materializeCanvasExport(record: CanvasRecord, deps: RecoveryDeps): Promise<string> {
   const now = deps.now?.() ?? Date.now();
   const canvasId = CanvasIdSchema.parse(record.id);
@@ -43,7 +59,7 @@ export function reconcileCanvasRecord(record: CanvasRecord, liveRefs: { terminal
       sourceRef.kind === "review_loop" &&
       !liveRefs.reviewLoopIds.has(sourceRef.id);
     if (missingTerminal || missingProject || missingReview) {
-      return { ...node, displayState: "recoverable", metadata: { ...(node as { metadata?: object }).metadata, recoveryReason: "missing_reference" } };
+      return { ...node, displayState: "recoverable", metadata: missingReferenceMetadata(node, sourceRef) };
     }
     return node;
   });

--- a/packages/gateway/src/canvas/service.ts
+++ b/packages/gateway/src/canvas/service.ts
@@ -61,6 +61,8 @@ export interface CanvasTerminalRegistry {
   destroy(sessionId: string): void;
 }
 
+type TerminalSessionSnapshot = NonNullable<ReturnType<CanvasTerminalRegistry["getSession"]>>;
+
 export interface CanvasServiceOptions {
   terminalRegistry?: CanvasTerminalRegistry;
   homePath?: string;
@@ -101,7 +103,7 @@ function nodeCounts(record: CanvasRecord) {
     const displayState = (node as { displayState?: unknown }).displayState;
     const type = (node as { type?: unknown }).type;
     if (displayState === "stale") stale += 1;
-    const liveDisplayState = displayState === "normal" || displayState === "minimized" || displayState === "summary";
+    const liveDisplayState = displayState !== "stale" && displayState !== "recoverable" && displayState !== "missing";
     if (
       liveDisplayState &&
       (type === "terminal" || type === "review_loop" || type === "preview" || type === "app_window")
@@ -230,7 +232,7 @@ export class CanvasService {
     let records = await this.repository.list(ownerFromUser(userId), query.limit ?? 50);
     if (query.scopeType) records = records.filter((record) => record.scopeType === query.scopeType);
     if (query.scopeId) records = records.filter((record) => JSON.stringify(record.scopeRef ?? {}).includes(query.scopeId ?? ""));
-    records = safeSearch(records, query.q).map((record) => this.reconcileRecord(record));
+    records = safeSearch(records, query.q).map((record) => this.reconcileRecord(record).record);
     return {
       canvases: records.map((record) => ({
         id: record.id,
@@ -259,10 +261,10 @@ export class CanvasService {
   async getCanvas(userId: string, canvasId: string): Promise<CanvasDocumentResult> {
     const stored = await this.repository.get(ownerFromUser(userId), canvasId);
     if (!stored) throw new CanvasNotFoundError(canvasId);
-    const record = this.reconcileRecord(stored);
+    const { record, terminalSessionsById } = this.reconcileRecord(stored);
     return {
       document: record,
-      linkedState: this.resolveLinkedState(record),
+      linkedState: this.resolveLinkedState(record, terminalSessionsById),
     };
   }
 
@@ -340,20 +342,23 @@ export class CanvasService {
     return record.nodes.filter((node) => JSON.stringify(node).toLowerCase().includes(needle));
   }
 
-  private reconcileRecord(record: CanvasRecord): CanvasRecord {
+  private reconcileRecord(record: CanvasRecord): { record: CanvasRecord; terminalSessionsById: Record<string, TerminalSessionSnapshot> } {
     const terminalSessionIds = new Set<string>();
+    const terminalSessionsById: Record<string, TerminalSessionSnapshot> = {};
     for (const node of record.nodes) {
       if (typeof node !== "object" || node === null) continue;
       const sourceRef = (node as { sourceRef?: { kind?: string; id?: string } | null }).sourceRef;
       if (sourceRef?.kind !== "terminal_session" || typeof sourceRef.id !== "string" || sourceRef.id === "unattached") continue;
-      if (this.terminalRegistry?.getSession(sourceRef.id)) {
+      const session = this.terminalRegistry?.getSession(sourceRef.id);
+      if (session) {
         terminalSessionIds.add(sourceRef.id);
+        terminalSessionsById[sourceRef.id] = session;
       }
     }
-    return reconcileCanvasRecord(record, { terminalSessionIds });
+    return { record: reconcileCanvasRecord(record, { terminalSessionIds }), terminalSessionsById };
   }
 
-  private resolveLinkedState(record: CanvasRecord): CanvasDocumentResult["linkedState"] {
+  private resolveLinkedState(record: CanvasRecord, terminalSessionsById?: Record<string, TerminalSessionSnapshot>): CanvasDocumentResult["linkedState"] {
     const terminalSessions: unknown[] = [];
     const pullRequests: unknown[] = [];
     const reviewLoops: unknown[] = [];
@@ -363,7 +368,11 @@ export class CanvasService {
       const sourceRef = (node as { sourceRef?: { kind?: string; id?: string } | null }).sourceRef;
       if (!sourceRef?.id) continue;
       if (sourceRef.kind === "terminal_session") {
-        const session = sourceRef.id === "unattached" ? null : this.terminalRegistry?.getSession(sourceRef.id);
+        const session = sourceRef.id === "unattached"
+          ? null
+          : terminalSessionsById
+            ? terminalSessionsById[sourceRef.id] ?? null
+            : this.terminalRegistry?.getSession(sourceRef.id);
         if (session) terminalSessions.push(session);
         else missingRefs.push({
           kind: sourceRef.kind,

--- a/packages/gateway/src/canvas/service.ts
+++ b/packages/gateway/src/canvas/service.ts
@@ -62,6 +62,7 @@ export interface CanvasTerminalRegistry {
 }
 
 type TerminalSessionSnapshot = NonNullable<ReturnType<CanvasTerminalRegistry["getSession"]>>;
+type TerminalSessionSnapshotById = Record<string, TerminalSessionSnapshot>;
 
 export interface CanvasServiceOptions {
   terminalRegistry?: CanvasTerminalRegistry;
@@ -342,9 +343,9 @@ export class CanvasService {
     return record.nodes.filter((node) => JSON.stringify(node).toLowerCase().includes(needle));
   }
 
-  private reconcileRecord(record: CanvasRecord): { record: CanvasRecord; terminalSessionsById: Record<string, TerminalSessionSnapshot> } {
+  private reconcileRecord(record: CanvasRecord): { record: CanvasRecord; terminalSessionsById: TerminalSessionSnapshotById } {
     const terminalSessionIds = new Set<string>();
-    const terminalSessionsById: Record<string, TerminalSessionSnapshot> = {};
+    const terminalSessionsById: TerminalSessionSnapshotById = Object.create(null) as TerminalSessionSnapshotById;
     for (const node of record.nodes) {
       if (typeof node !== "object" || node === null) continue;
       const sourceRef = (node as { sourceRef?: { kind?: string; id?: string } | null }).sourceRef;
@@ -358,7 +359,7 @@ export class CanvasService {
     return { record: reconcileCanvasRecord(record, { terminalSessionIds }), terminalSessionsById };
   }
 
-  private resolveLinkedState(record: CanvasRecord, terminalSessionsById?: Record<string, TerminalSessionSnapshot>): CanvasDocumentResult["linkedState"] {
+  private resolveLinkedState(record: CanvasRecord, terminalSessionsById?: TerminalSessionSnapshotById): CanvasDocumentResult["linkedState"] {
     const terminalSessions: unknown[] = [];
     const pullRequests: unknown[] = [];
     const reviewLoops: unknown[] = [];
@@ -371,7 +372,7 @@ export class CanvasService {
         const session = sourceRef.id === "unattached"
           ? null
           : terminalSessionsById
-            ? terminalSessionsById[sourceRef.id] ?? null
+            ? Object.hasOwn(terminalSessionsById, sourceRef.id) ? terminalSessionsById[sourceRef.id] : null
             : this.terminalRegistry?.getSession(sourceRef.id);
         if (session) terminalSessions.push(session);
         else missingRefs.push({

--- a/packages/gateway/src/canvas/service.ts
+++ b/packages/gateway/src/canvas/service.ts
@@ -101,7 +101,13 @@ function nodeCounts(record: CanvasRecord) {
     const displayState = (node as { displayState?: unknown }).displayState;
     const type = (node as { type?: unknown }).type;
     if (displayState === "stale") stale += 1;
-    if (type === "terminal" || type === "review_loop" || type === "preview" || type === "app_window") live += 1;
+    const liveDisplayState = displayState === "normal" || displayState === "minimized" || displayState === "summary";
+    if (
+      liveDisplayState &&
+      (type === "terminal" || type === "review_loop" || type === "preview" || type === "app_window")
+    ) {
+      live += 1;
+    }
   }
   return { total: record.nodes.length, stale, live };
 }
@@ -359,7 +365,12 @@ export class CanvasService {
       if (sourceRef.kind === "terminal_session") {
         const session = sourceRef.id === "unattached" ? null : this.terminalRegistry?.getSession(sourceRef.id);
         if (session) terminalSessions.push(session);
-        else missingRefs.push({ kind: sourceRef.kind, id: sourceRef.id });
+        else missingRefs.push({
+          kind: sourceRef.kind,
+          id: sourceRef.id,
+          state: sourceRef.id === "unattached" ? "unattached" : "missing",
+          recoverable: sourceRef.id !== "unattached",
+        });
       }
       if (sourceRef.kind === "pull_request") pullRequests.push(sourceRef);
       if (sourceRef.kind === "review_loop") reviewLoops.push(sourceRef);

--- a/tests/gateway/canvas-recovery.test.ts
+++ b/tests/gateway/canvas-recovery.test.ts
@@ -45,6 +45,21 @@ describe("canvas recovery", () => {
     expect((reconciled.nodes[0] as any).displayState).toBe("recoverable");
   });
 
+  it("classifies stale terminal session refs as missing volatile PTY handles", () => {
+    const staleSessionId = "550e8400-e29b-41d4-a716-446655440000";
+    const reconciled = reconcileCanvasRecord(record(), { terminalSessionIds: new Set() });
+
+    expect(reconciled.nodes[0]).toMatchObject({
+      sourceRef: { kind: "terminal_session", id: staleSessionId },
+      displayState: "recoverable",
+      metadata: {
+        recoveryReason: "terminal_session_missing",
+        terminalSessionState: "missing",
+        terminalSessionId: staleSessionId,
+      },
+    });
+  });
+
   it("does not mark omitted live reference categories as missing", () => {
     const base = record();
     const reconciled = reconcileCanvasRecord({

--- a/tests/gateway/canvas-service.test.ts
+++ b/tests/gateway/canvas-service.test.ts
@@ -171,6 +171,38 @@ describe("CanvasService", () => {
     expect(terminalRegistry.create).not.toHaveBeenCalled();
   });
 
+  it("treats prototype-named terminal refs as missing instead of live sessions", async () => {
+    const terminalRegistry = {
+      create: vi.fn(),
+      getSession: vi.fn().mockReturnValue(null),
+      destroy: vi.fn(),
+    };
+    const service = new CanvasService(repository([record({
+      nodes: [{
+        id: "node_terminal",
+        type: "terminal",
+        sourceRef: { kind: "terminal_session", id: "toString" },
+        displayState: "normal",
+        metadata: {},
+      }],
+    })]), {
+      terminalRegistry,
+    });
+
+    const result = await service.getCanvas("user_a", "cnv_0123456789abcdef");
+
+    expect(result.linkedState.terminalSessions).toEqual([]);
+    expect(result.linkedState.missingRefs).toContainEqual({
+      kind: "terminal_session",
+      id: "toString",
+      state: "missing",
+      recoverable: true,
+    });
+    expect(terminalRegistry.getSession).toHaveBeenCalledTimes(1);
+    expect(terminalRegistry.getSession).toHaveBeenCalledWith("toString");
+    expect(terminalRegistry.create).not.toHaveBeenCalled();
+  });
+
   it("classifies stale terminal refs in canvas summaries without spawning sessions", async () => {
     const terminalRegistry = {
       create: vi.fn(),

--- a/tests/gateway/canvas-service.test.ts
+++ b/tests/gateway/canvas-service.test.ts
@@ -131,7 +131,12 @@ describe("CanvasService", () => {
     expect(repo.patchNode).not.toHaveBeenCalled();
   });
 
-  it("marks stale terminal refs recoverable on the main canvas read path", async () => {
+  it("marks stale terminal refs missing without spawning on the main canvas read path", async () => {
+    const terminalRegistry = {
+      create: vi.fn(),
+      getSession: vi.fn().mockReturnValue(null),
+      destroy: vi.fn(),
+    };
     const service = new CanvasService(repository([record({
       nodes: [{
         id: "node_terminal",
@@ -141,19 +146,49 @@ describe("CanvasService", () => {
         metadata: {},
       }],
     })]), {
-      terminalRegistry: {
-        create: vi.fn(),
-        getSession: vi.fn().mockReturnValue(null),
-        destroy: vi.fn(),
-      },
+      terminalRegistry,
     });
 
     const result = await service.getCanvas("user_a", "cnv_0123456789abcdef");
 
     expect(result.document.nodes[0]).toMatchObject({
       displayState: "recoverable",
-      metadata: { recoveryReason: "missing_reference" },
+      metadata: {
+        recoveryReason: "terminal_session_missing",
+        terminalSessionState: "missing",
+        terminalSessionId: "550e8400-e29b-41d4-a716-446655440000",
+      },
     });
+    expect(result.linkedState.terminalSessions).toEqual([]);
+    expect(result.linkedState.missingRefs).toContainEqual({
+      kind: "terminal_session",
+      id: "550e8400-e29b-41d4-a716-446655440000",
+      state: "missing",
+      recoverable: true,
+    });
+    expect(terminalRegistry.create).not.toHaveBeenCalled();
+  });
+
+  it("classifies stale terminal refs in canvas summaries without spawning sessions", async () => {
+    const terminalRegistry = {
+      create: vi.fn(),
+      getSession: vi.fn().mockReturnValue(null),
+      destroy: vi.fn(),
+    };
+    const service = new CanvasService(repository([record({
+      nodes: [{
+        id: "node_terminal",
+        type: "terminal",
+        sourceRef: { kind: "terminal_session", id: "550e8400-e29b-41d4-a716-446655440000" },
+        displayState: "normal",
+        metadata: {},
+      }],
+    })]), { terminalRegistry });
+
+    const result = await service.listCanvases("user_a");
+
+    expect(result.canvases[0].nodeCounts).toEqual({ total: 1, stale: 0, live: 0 });
+    expect(terminalRegistry.create).not.toHaveBeenCalled();
   });
 
   it("maps canvas configuration failures to service unavailable", () => {

--- a/tests/gateway/canvas-service.test.ts
+++ b/tests/gateway/canvas-service.test.ts
@@ -166,6 +166,8 @@ describe("CanvasService", () => {
       state: "missing",
       recoverable: true,
     });
+    expect(terminalRegistry.getSession).toHaveBeenCalledTimes(1);
+    expect(terminalRegistry.getSession).toHaveBeenCalledWith("550e8400-e29b-41d4-a716-446655440000");
     expect(terminalRegistry.create).not.toHaveBeenCalled();
   });
 
@@ -188,6 +190,8 @@ describe("CanvasService", () => {
     const result = await service.listCanvases("user_a");
 
     expect(result.canvases[0].nodeCounts).toEqual({ total: 1, stale: 0, live: 0 });
+    expect(terminalRegistry.getSession).toHaveBeenCalledTimes(1);
+    expect(terminalRegistry.getSession).toHaveBeenCalledWith("550e8400-e29b-41d4-a716-446655440000");
     expect(terminalRegistry.create).not.toHaveBeenCalled();
   });
 


### PR DESCRIPTION
## Summary

- Classifies missing legacy Canvas `terminal_session` refs as recoverable missing PTY handles instead of generic missing references.
- Keeps Canvas read/list reconciliation side-effect free: stale PTY refs do not spawn replacement terminal processes.
- Exposes missing terminal refs in `linkedState.missingRefs` with `state: "missing"` and `recoverable: true`, and excludes recoverable terminal nodes from live summary counts.

## Tests

- `pnpm exec vitest run tests/gateway/canvas-recovery.test.ts tests/gateway/canvas-service.test.ts`
- `pnpm --filter '@matrix-os/gateway' exec tsc --noEmit`
- `pnpm run check:patterns`
- Manual `typecheck` equivalent passed after `pnpm install --frozen-lockfile --offline`: observability build/typecheck, kernel build, gateway/platform/proxy/edge-router/desktop typechecks.
- `pnpm run test` was attempted. The local broad suite produced many unrelated environment-sensitive failures across platform/e2e/CLI/app-runtime/UI tests and stopped yielding a usable final summary after an extended run; focused Canvas/gateway coverage for this PR passed.
- Exact `bun run ...` commands were not run because `bun` is not installed in this environment.

## Review/Monitoring

- Ready for CI after focused tests, gateway typecheck, pattern scan, and manual broader typecheck equivalents.
- Needs CI/Greptile monitoring before merge; merge is intentionally out of scope.

## Invariants

- Source of truth: live PTY process state is volatile and owned by the gateway runtime. Persisted Canvas/mobile terminal refs are recoverable metadata, not durable process handles.
- Lock/transaction scope: Canvas read/list reconciliation only classifies stored node state and does not write or spawn processes. Explicit terminal actions remain the process-spawning boundary.
- Acceptable orphan states: after gateway restart, a Canvas node may retain a stale legacy PTY ID, but it is surfaced as recoverable missing terminal state and omitted from live session summaries.
- Auth source of truth: existing Canvas and terminal action authorization paths remain unchanged; no new terminal auth path is introduced.
- Deferred scope: zellij migration is deferred. UI copy/state changes are deferred because the existing recoverable node UI can already act on the gateway classification.
