### PR TITLE
fix(terminal): align zellij close fallback

### DIFF
--- a/packages/gateway/src/server.ts
+++ b/packages/gateway/src/server.ts
@@ -431,6 +431,105 @@ function dispatchNamedTerminalMessage(
   });
 }
 
+type NamedTerminalRouteSession = {
+  onMessage(raw: string): void | Promise<void>;
+  onClose(): void;
+};
+
+type NamedTerminalPendingInputQueue = {
+  enqueue(raw: string): boolean;
+  drain(callback: (raw: string) => void): void;
+  clear(): void;
+};
+
+function isNamedTerminalDestroyFrame(raw: string): boolean {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err: unknown) {
+    if (!(err instanceof SyntaxError)) {
+      console.warn("[shell] terminal message parse failed:", err instanceof Error ? err.message : String(err));
+    }
+    return false;
+  }
+  return typeof parsed === "object" && parsed !== null && "type" in parsed && parsed.type === "destroy";
+}
+
+export function createNamedTerminalRouteController(options: {
+  pendingInput?: NamedTerminalPendingInputQueue;
+  onBufferOverflow?: () => void;
+} = {}) {
+  let namedHandle: NamedTerminalRouteSession | null = null;
+  let socketClosed = false;
+  let pendingDestroyFrame: string | null = null;
+
+  const dispatchDestroyOrClose = (session: NamedTerminalRouteSession) => {
+    const destroyFrame = pendingDestroyFrame;
+    pendingDestroyFrame = null;
+    if (destroyFrame) {
+      dispatchNamedTerminalMessage(session, destroyFrame);
+      return;
+    }
+    session.onClose();
+  };
+
+  return {
+    isSocketClosed(): boolean {
+      return socketClosed;
+    },
+    clearPendingState(): void {
+      pendingDestroyFrame = null;
+      options.pendingInput?.clear();
+    },
+    onOpenResolved(session: NamedTerminalRouteSession, openOptions: { drainPendingInput: boolean }): void {
+      if (socketClosed) {
+        options.pendingInput?.clear();
+        dispatchDestroyOrClose(session);
+        return;
+      }
+
+      namedHandle = session;
+      if (pendingDestroyFrame) {
+        options.pendingInput?.clear();
+        dispatchDestroyOrClose(session);
+        return;
+      }
+
+      if (openOptions.drainPendingInput) {
+        options.pendingInput?.drain((raw) => {
+          dispatchNamedTerminalMessage(session, raw);
+        });
+      }
+    },
+    onMessage(raw: string, messageOptions: { onBufferOverflow?: () => void } = {}): boolean {
+      if (namedHandle) {
+        dispatchNamedTerminalMessage(namedHandle, raw);
+        return true;
+      }
+
+      if (isNamedTerminalDestroyFrame(raw)) {
+        pendingDestroyFrame = raw;
+        return true;
+      }
+
+      if (!options.pendingInput) {
+        return false;
+      }
+
+      if (!options.pendingInput.enqueue(raw)) {
+        (messageOptions.onBufferOverflow ?? options.onBufferOverflow)?.();
+      }
+      return true;
+    },
+    onClose(): void {
+      socketClosed = true;
+      options.pendingInput?.clear();
+      namedHandle?.onClose();
+      namedHandle = null;
+    },
+  };
+}
+
 type SymphonyRunner = ReturnType<typeof createSymphonyRunner>;
 
 export async function readInitialSymphonyPort(runner: Pick<SymphonyRunner, "getConfig">): Promise<number | undefined> {
@@ -2354,9 +2453,8 @@ export async function createGateway(config: GatewayConfig) {
     upgradeWebSocket((c) => {
       const namedSession = c.req.query("session");
       const fromSeqParam = c.req.query("fromSeq");
-      let namedHandle: { onMessage(raw: string): void | Promise<void>; onClose(): void } | null = null;
-      let namedSocketClosed = false;
       const pendingInput = createPendingTerminalInputQueue();
+      const namedRouteController = createNamedTerminalRouteController({ pendingInput });
 
       return {
         onOpen(_evt, ws) {
@@ -2378,18 +2476,11 @@ export async function createGateway(config: GatewayConfig) {
             session: namedSession,
             fromSeq,
           }).then((session) => {
-            if (namedSocketClosed) {
-              session.onClose();
-              return;
-            }
-            namedHandle = session;
-            pendingInput.drain((raw) => {
-              dispatchNamedTerminalMessage(session, raw);
-            });
+            namedRouteController.onOpenResolved(session, { drainPendingInput: true });
           }).catch((err: unknown) => {
             console.warn("[shell] terminal session attach failed:", err instanceof Error ? err.message : String(err));
-            pendingInput.clear();
-            if (namedSocketClosed) {
+            namedRouteController.clearPendingState();
+            if (namedRouteController.isSocketClosed()) {
               return;
             }
             try {
@@ -2409,28 +2500,23 @@ export async function createGateway(config: GatewayConfig) {
           if (raw === null) {
             return;
           }
-          if (namedHandle) {
-            dispatchNamedTerminalMessage(namedHandle, raw);
-            return;
-          }
-          if (!pendingInput.enqueue(raw)) {
-            try {
-              ws.send(JSON.stringify({
-                type: "error",
-                code: "buffer_overflow",
-                message: "Input buffer overflow before session was ready",
-              }));
-            } catch (sendErr: unknown) {
-              logUnexpectedWsSendFailure("Terminal WebSocket send failed", sendErr);
-            }
-            ws.close();
-          }
+          namedRouteController.onMessage(raw, {
+            onBufferOverflow: () => {
+              try {
+                ws.send(JSON.stringify({
+                  type: "error",
+                  code: "buffer_overflow",
+                  message: "Input buffer overflow before session was ready",
+                }));
+              } catch (sendErr: unknown) {
+                logUnexpectedWsSendFailure("Terminal WebSocket send failed", sendErr);
+              }
+              ws.close();
+            },
+          });
         },
         onClose() {
-          namedSocketClosed = true;
-          pendingInput.clear();
-          namedHandle?.onClose();
-          namedHandle = null;
+          namedRouteController.onClose();
         },
       };
     }),
@@ -2443,8 +2529,7 @@ export async function createGateway(config: GatewayConfig) {
       const namedSession = c.req.query("session");
       const fromSeqParam = c.req.query("fromSeq");
       let handle: SessionHandle | null = null;
-      let namedHandle: { onMessage(raw: string): void | Promise<void>; onClose(): void } | null = null;
-      let namedSocketClosed = false;
+      const namedRouteController = createNamedTerminalRouteController();
       let autoCreateTimer: ReturnType<typeof setTimeout> | null = null;
       let autoCreatedSessionId: string | null = null;
 
@@ -2495,18 +2580,15 @@ export async function createGateway(config: GatewayConfig) {
               session: namedSession,
               fromSeq,
             }).then((session) => {
-              if (namedSocketClosed) {
-                session.onClose();
-                return;
-              }
-              namedHandle = session;
+              namedRouteController.onOpenResolved(session, { drainPendingInput: false });
             }).catch((err: unknown) => {
               console.warn("[shell] zellij terminal attach failed:", err instanceof Error ? err.message : String(err));
               captureTerminalEvent("named-attach-failed", {
                 namedSession: true,
-                socketClosed: namedSocketClosed,
+                socketClosed: namedRouteController.isSocketClosed(),
               });
-              if (namedSocketClosed) {
+              namedRouteController.clearPendingState();
+              if (namedRouteController.isSocketClosed()) {
                 return;
               }
               try {
@@ -2567,9 +2649,7 @@ export async function createGateway(config: GatewayConfig) {
             return;
           }
           if (namedSession) {
-            if (namedHandle) {
-              dispatchNamedTerminalMessage(namedHandle, raw);
-            }
+            namedRouteController.onMessage(raw);
             return;
           }
           let parsed: unknown;
@@ -2716,11 +2796,7 @@ export async function createGateway(config: GatewayConfig) {
         },
 
         onClose() {
-          namedSocketClosed = true;
-          if (namedHandle) {
-            namedHandle.onClose();
-            namedHandle = null;
-          }
+          namedRouteController.onClose();
           logTerminalDebug("ws-close", {
             handleSessionId: handle?.sessionId ?? null,
             autoCreatedSessionId,

--- a/packages/gateway/src/server.ts
+++ b/packages/gateway/src/server.ts
@@ -2345,9 +2345,17 @@ export async function createGateway(config: GatewayConfig) {
     upgradeWebSocket((c) => {
       const namedSession = c.req.query("session");
       const fromSeqParam = c.req.query("fromSeq");
-      let namedHandle: { onMessage(raw: string): void; onClose(): void } | null = null;
+      let namedHandle: { onMessage(raw: string): void | Promise<void>; onClose(): void } | null = null;
       let namedSocketClosed = false;
       const pendingInput = createPendingTerminalInputQueue();
+      const dispatchNamedMessage = (
+        session: { onMessage(raw: string): void | Promise<void> },
+        raw: string,
+      ) => {
+        void Promise.resolve(session.onMessage(raw)).catch((err: unknown) => {
+          console.warn("[shell] terminal session message failed:", err instanceof Error ? err.message : String(err));
+        });
+      };
 
       return {
         onOpen(_evt, ws) {
@@ -2375,7 +2383,7 @@ export async function createGateway(config: GatewayConfig) {
             }
             namedHandle = session;
             pendingInput.drain((raw) => {
-              session.onMessage(raw);
+              dispatchNamedMessage(session, raw);
             });
           }).catch((err: unknown) => {
             console.warn("[shell] terminal session attach failed:", err instanceof Error ? err.message : String(err));
@@ -2401,7 +2409,7 @@ export async function createGateway(config: GatewayConfig) {
             return;
           }
           if (namedHandle) {
-            namedHandle.onMessage(raw);
+            dispatchNamedMessage(namedHandle, raw);
             return;
           }
           if (!pendingInput.enqueue(raw)) {
@@ -2434,10 +2442,18 @@ export async function createGateway(config: GatewayConfig) {
       const namedSession = c.req.query("session");
       const fromSeqParam = c.req.query("fromSeq");
       let handle: SessionHandle | null = null;
-      let namedHandle: { onMessage(raw: string): void; onClose(): void } | null = null;
+      let namedHandle: { onMessage(raw: string): void | Promise<void>; onClose(): void } | null = null;
       let namedSocketClosed = false;
       let autoCreateTimer: ReturnType<typeof setTimeout> | null = null;
       let autoCreatedSessionId: string | null = null;
+      const dispatchNamedMessage = (
+        session: { onMessage(raw: string): void | Promise<void> },
+        raw: string,
+      ) => {
+        void Promise.resolve(session.onMessage(raw)).catch((err: unknown) => {
+          console.warn("[shell] terminal session message failed:", err instanceof Error ? err.message : String(err));
+        });
+      };
 
       const cleanupAutoCreatedSession = (destroyAutoCreated = true) => {
         logTerminalDebug("ws-cleanup", {
@@ -2558,7 +2574,9 @@ export async function createGateway(config: GatewayConfig) {
             return;
           }
           if (namedSession) {
-            namedHandle?.onMessage(raw);
+            if (namedHandle) {
+              dispatchNamedMessage(namedHandle, raw);
+            }
             return;
           }
           let parsed: unknown;

--- a/packages/gateway/src/server.ts
+++ b/packages/gateway/src/server.ts
@@ -422,6 +422,15 @@ export function createAllowedOriginController(options: {
   };
 }
 
+function dispatchNamedTerminalMessage(
+  session: { onMessage(raw: string): void | Promise<void> },
+  raw: string,
+): void {
+  void Promise.resolve(session.onMessage(raw)).catch((err: unknown) => {
+    console.warn("[shell] terminal session message failed:", err instanceof Error ? err.message : String(err));
+  });
+}
+
 type SymphonyRunner = ReturnType<typeof createSymphonyRunner>;
 
 export async function readInitialSymphonyPort(runner: Pick<SymphonyRunner, "getConfig">): Promise<number | undefined> {
@@ -2348,14 +2357,6 @@ export async function createGateway(config: GatewayConfig) {
       let namedHandle: { onMessage(raw: string): void | Promise<void>; onClose(): void } | null = null;
       let namedSocketClosed = false;
       const pendingInput = createPendingTerminalInputQueue();
-      const dispatchNamedMessage = (
-        session: { onMessage(raw: string): void | Promise<void> },
-        raw: string,
-      ) => {
-        void Promise.resolve(session.onMessage(raw)).catch((err: unknown) => {
-          console.warn("[shell] terminal session message failed:", err instanceof Error ? err.message : String(err));
-        });
-      };
 
       return {
         onOpen(_evt, ws) {
@@ -2383,7 +2384,7 @@ export async function createGateway(config: GatewayConfig) {
             }
             namedHandle = session;
             pendingInput.drain((raw) => {
-              dispatchNamedMessage(session, raw);
+              dispatchNamedTerminalMessage(session, raw);
             });
           }).catch((err: unknown) => {
             console.warn("[shell] terminal session attach failed:", err instanceof Error ? err.message : String(err));
@@ -2409,7 +2410,7 @@ export async function createGateway(config: GatewayConfig) {
             return;
           }
           if (namedHandle) {
-            dispatchNamedMessage(namedHandle, raw);
+            dispatchNamedTerminalMessage(namedHandle, raw);
             return;
           }
           if (!pendingInput.enqueue(raw)) {
@@ -2446,14 +2447,6 @@ export async function createGateway(config: GatewayConfig) {
       let namedSocketClosed = false;
       let autoCreateTimer: ReturnType<typeof setTimeout> | null = null;
       let autoCreatedSessionId: string | null = null;
-      const dispatchNamedMessage = (
-        session: { onMessage(raw: string): void | Promise<void> },
-        raw: string,
-      ) => {
-        void Promise.resolve(session.onMessage(raw)).catch((err: unknown) => {
-          console.warn("[shell] terminal session message failed:", err instanceof Error ? err.message : String(err));
-        });
-      };
 
       const cleanupAutoCreatedSession = (destroyAutoCreated = true) => {
         logTerminalDebug("ws-cleanup", {
@@ -2575,7 +2568,7 @@ export async function createGateway(config: GatewayConfig) {
           }
           if (namedSession) {
             if (namedHandle) {
-              dispatchNamedMessage(namedHandle, raw);
+              dispatchNamedTerminalMessage(namedHandle, raw);
             }
             return;
           }

--- a/packages/gateway/src/shell/ws.ts
+++ b/packages/gateway/src/shell/ws.ts
@@ -20,6 +20,10 @@ const ShellWsDetachSchema = z.object({
   type: z.literal("detach"),
 });
 
+const ShellWsDestroySchema = z.object({
+  type: z.literal("destroy"),
+});
+
 const ShellWsPingSchema = z.object({
   type: z.literal("ping"),
 });
@@ -28,6 +32,7 @@ const ShellWsClientMessageSchema = z.union([
   ShellWsInputSchema,
   ShellWsResizeSchema,
   ShellWsDetachSchema,
+  ShellWsDestroySchema,
   ShellWsPingSchema,
 ]);
 
@@ -41,6 +46,7 @@ export interface ShellWsSocket {
 
 interface ShellWsRegistry {
   list(): Promise<Array<{ name: string; status?: "active" | "exited" }>>;
+  delete?(name: string, options?: { force?: boolean }): Promise<void>;
 }
 
 interface ShellWsAdapter {
@@ -62,8 +68,16 @@ export interface ShellWsOpenOptions {
 }
 
 export interface ShellWsSession {
-  onMessage(raw: string): void;
+  onMessage(raw: string): void | Promise<void>;
   onClose(): void;
+}
+
+function isMissingSessionError(err: unknown): boolean {
+  if (!(err instanceof Error)) {
+    return false;
+  }
+  const candidate = err as { code?: unknown; status?: unknown };
+  return candidate.code === "session_not_found" || candidate.status === 404;
 }
 
 export function shellWsMessageDataToString(data: unknown): string | null {
@@ -219,8 +233,29 @@ export function createShellWsHandler(options: ShellWsHandlerOptions) {
       child.kill();
     };
 
+    const destroySession = async () => {
+      try {
+        if (!options.registry.delete) {
+          throw new Error("shell registry delete unavailable");
+        }
+        await options.registry.delete(safeName, { force: true });
+      } catch (err: unknown) {
+        if (!isMissingSessionError(err)) {
+          console.warn("[shell] zellij session destroy failed:", err instanceof Error ? err.message : String(err));
+          sendJson(ws, {
+            type: "error",
+            code: "destroy_failed",
+            message: "Terminal session cleanup failed",
+          });
+        }
+      } finally {
+        closeSession();
+        ws.close?.();
+      }
+    };
+
     return {
-      onMessage(raw: string) {
+      async onMessage(raw: string) {
         let parsed: unknown;
         try {
           parsed = JSON.parse(raw);
@@ -244,6 +279,10 @@ export function createShellWsHandler(options: ShellWsHandlerOptions) {
         if (msg.type === "detach") {
           closeSession();
           ws.close?.();
+          return;
+        }
+        if (msg.type === "destroy") {
+          await destroySession();
           return;
         }
         if (msg.type === "input") {

--- a/tests/gateway/terminal-zellij-route-race.test.ts
+++ b/tests/gateway/terminal-zellij-route-race.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it, vi } from "vitest";
+import { createNamedTerminalRouteController } from "../../packages/gateway/src/server.js";
+
+function createQueue() {
+  const pending: string[] = [];
+  return {
+    enqueue(raw: string): boolean {
+      pending.push(raw);
+      return true;
+    },
+    drain(callback: (raw: string) => void): void {
+      while (pending.length > 0) {
+        const raw = pending.shift();
+        if (raw !== undefined) callback(raw);
+      }
+    },
+    clear(): void {
+      pending.length = 0;
+    },
+  };
+}
+
+function createSession() {
+  return {
+    onMessage: vi.fn(async (_raw: string) => undefined),
+    onClose: vi.fn(),
+  };
+}
+
+const destroyFrame = JSON.stringify({ type: "destroy" });
+const inputFrame = JSON.stringify({ type: "input", data: "pwd\r" });
+
+describe("named zellij terminal route close race", () => {
+  it("preserves /ws/terminal/session destroy intent when the socket closes before attach resolves", async () => {
+    const controller = createNamedTerminalRouteController({
+      pendingInput: createQueue(),
+      onBufferOverflow: vi.fn(),
+    });
+    const session = createSession();
+
+    expect(controller.onMessage(destroyFrame)).toBe(true);
+    controller.onClose();
+    controller.onOpenResolved(session, { drainPendingInput: true });
+    await Promise.resolve();
+
+    expect(session.onMessage).toHaveBeenCalledWith(destroyFrame);
+    expect(session.onClose).not.toHaveBeenCalled();
+  });
+
+  it("keeps /ws/terminal/session pre-open close without destroy as a detach-only cleanup", async () => {
+    const controller = createNamedTerminalRouteController({
+      pendingInput: createQueue(),
+      onBufferOverflow: vi.fn(),
+    });
+    const session = createSession();
+
+    expect(controller.onMessage(inputFrame)).toBe(true);
+    controller.onClose();
+    controller.onOpenResolved(session, { drainPendingInput: true });
+    await Promise.resolve();
+
+    expect(session.onMessage).not.toHaveBeenCalled();
+    expect(session.onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("preserves /ws/terminal?session destroy intent when the socket closes before attach resolves", async () => {
+    const controller = createNamedTerminalRouteController();
+    const session = createSession();
+
+    expect(controller.onMessage(destroyFrame)).toBe(true);
+    controller.onClose();
+    controller.onOpenResolved(session, { drainPendingInput: false });
+    await Promise.resolve();
+
+    expect(session.onMessage).toHaveBeenCalledWith(destroyFrame);
+    expect(session.onClose).not.toHaveBeenCalled();
+  });
+
+  it("keeps /ws/terminal?session pre-open close without destroy as a detach-only cleanup", async () => {
+    const controller = createNamedTerminalRouteController();
+    const session = createSession();
+
+    expect(controller.onMessage(inputFrame)).toBe(false);
+    controller.onClose();
+    controller.onOpenResolved(session, { drainPendingInput: false });
+    await Promise.resolve();
+
+    expect(session.onMessage).not.toHaveBeenCalled();
+    expect(session.onClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/gateway/terminal-zellij-ws.test.ts
+++ b/tests/gateway/terminal-zellij-ws.test.ts
@@ -134,6 +134,89 @@ describe("zellij terminal WebSocket", () => {
     expect(pty.writes).toEqual([]);
   });
 
+  it("destroys an attached zellij session through the canonical registry delete path", async () => {
+    const pty = new FakePty();
+    const ws = socket();
+    const deleteSession = vi.fn(async () => undefined);
+    const handler = createShellWsHandler({
+      registry: {
+        list: vi.fn(async () => [{ name: "main", status: "active" }]),
+        delete: deleteSession,
+      },
+      adapter: {
+        attachSession: vi.fn(() => pty),
+      },
+    });
+
+    const session = await handler.open({ ws, session: "main", fromSeq: 0 });
+    await session.onMessage(JSON.stringify({ type: "destroy" }));
+
+    expect(deleteSession).toHaveBeenCalledWith("main", { force: true });
+    expect(pty.killed).toBe(true);
+    expect(ws.closed).toBe(true);
+    expect(ws.sent).not.toContainEqual({ type: "error", code: "invalid_message", message: "Invalid message" });
+  });
+
+  it("treats an already-deleted session as a successful destroy fallback", async () => {
+    const pty = new FakePty();
+    const ws = socket();
+    const deleteSession = vi.fn(async () => {
+      throw Object.assign(new Error("Session not found"), {
+        code: "session_not_found",
+        status: 404,
+      });
+    });
+    const handler = createShellWsHandler({
+      registry: {
+        list: vi.fn(async () => [{ name: "main", status: "active" }]),
+        delete: deleteSession,
+      },
+      adapter: {
+        attachSession: vi.fn(() => pty),
+      },
+    });
+
+    const session = await handler.open({ ws, session: "main", fromSeq: 0 });
+    await session.onMessage(JSON.stringify({ type: "destroy" }));
+
+    expect(deleteSession).toHaveBeenCalledWith("main", { force: true });
+    expect(pty.killed).toBe(true);
+    expect(ws.closed).toBe(true);
+    expect(ws.sent).not.toContainEqual(expect.objectContaining({ type: "error" }));
+  });
+
+  it("hides unexpected zellij destroy failures behind a generic websocket error", async () => {
+    const pty = new FakePty();
+    const ws = socket();
+    const deleteSession = vi.fn(async () => {
+      throw new Error("zellij delete-session exploded with /internal/path");
+    });
+    const handler = createShellWsHandler({
+      registry: {
+        list: vi.fn(async () => [{ name: "main", status: "active" }]),
+        delete: deleteSession,
+      },
+      adapter: {
+        attachSession: vi.fn(() => pty),
+      },
+    });
+
+    const session = await handler.open({ ws, session: "main", fromSeq: 0 });
+    await session.onMessage(JSON.stringify({ type: "destroy" }));
+
+    expect(deleteSession).toHaveBeenCalledWith("main", { force: true });
+    expect(ws.sent).toContainEqual({
+      type: "error",
+      code: "destroy_failed",
+      message: "Terminal session cleanup failed",
+    });
+    expect(ws.sent).not.toContainEqual(expect.objectContaining({
+      message: expect.stringContaining("zellij"),
+    }));
+    expect(pty.killed).toBe(true);
+    expect(ws.closed).toBe(true);
+  });
+
   it("normalizes binary websocket frames before protocol parsing", async () => {
     const pty = new FakePty();
     const ws = socket();

--- a/tests/gateway/terminal-zellij-ws.test.ts
+++ b/tests/gateway/terminal-zellij-ws.test.ts
@@ -217,6 +217,33 @@ describe("zellij terminal WebSocket", () => {
     expect(ws.closed).toBe(true);
   });
 
+  it("hides missing zellij destroy wiring behind a generic websocket error", async () => {
+    const pty = new FakePty();
+    const ws = socket();
+    const handler = createShellWsHandler({
+      registry: {
+        list: vi.fn(async () => [{ name: "main", status: "active" }]),
+      },
+      adapter: {
+        attachSession: vi.fn(() => pty),
+      },
+    });
+
+    const session = await handler.open({ ws, session: "main", fromSeq: 0 });
+    await session.onMessage(JSON.stringify({ type: "destroy" }));
+
+    expect(ws.sent).toContainEqual({
+      type: "error",
+      code: "destroy_failed",
+      message: "Terminal session cleanup failed",
+    });
+    expect(ws.sent).not.toContainEqual(expect.objectContaining({
+      message: expect.stringContaining("registry"),
+    }));
+    expect(pty.killed).toBe(true);
+    expect(ws.closed).toBe(true);
+  });
+
   it("normalizes binary websocket frames before protocol parsing", async () => {
     const pty = new FakePty();
     const ws = socket();


### PR DESCRIPTION
## Summary

- Add protocol support for `{ "type": "destroy" }` on canonical zellij `/ws/terminal/session` sockets.
- Route zellij WebSocket destroy through the canonical shell registry delete path with `{ force: true }`, while keeping `detach` as attach-process-only cleanup.
- Treat already-deleted/missing sessions as successful explicit-close cleanup and send only generic WebSocket errors for unexpected destroy failures.

## Tests

- `pnpm test tests/gateway/terminal-zellij-ws.test.ts` (passes)
- `pnpm test tests/gateway/terminal-zellij-ws.test.ts tests/gateway/shell-routes.test.ts tests/gateway/shell-registry.test.ts tests/shell/terminal-app-component.test.tsx tests/desktop/shell-socket.test.ts` (passes)
- `pnpm run typecheck:build-kernel` (passes)
- Equivalent package typecheck through gateway passed before platform typecheck failed on missing `stripe` module in this worktree dependency setup.
- `pnpm run check:patterns` (passes with existing scanner warnings only)
- `pnpm test` (attempted; fails on unrelated repo/environment issues, including missing desktop deps, platform telemetry constants, socket listen `EPERM`, app-runtime build/process tests, and other existing broad-suite failures)

## Review/Monitoring

Ready for CI/Greptile. CI is expected to provide authoritative clean-environment signal; local broad suite is noisy in this sandbox/worktree, but focused terminal suites pass.

## Invariants

- Source of truth: zellij terminal session lifecycle remains owned by the gateway shell session registry and its canonical delete path.
- Lock/transaction scope: no database transaction is introduced; in-memory attach cleanup remains local to the WebSocket handler, while session deletion stays inside the registry mutation path.
- Acceptable orphan states: REST DELETE failure or racing WebSocket cleanup should not leave explicit close without a protocol-correct destroy fallback; already-missing sessions during fallback are treated as successful cleanup.
- Auth source of truth: existing terminal WebSocket and REST authentication remain authoritative; no auth bypass or client-trusted ownership change is introduced.
- Deferred scope: terminal UI polish, non-zellij legacy behavior changes, and broad session lifecycle refactors are out of scope.