### PR TITLE
fix(gateway): clean up stale PTY subscribers

### DIFF
--- a/apps/mobile/__tests__/terminal-client.test.ts
+++ b/apps/mobile/__tests__/terminal-client.test.ts
@@ -1,5 +1,6 @@
 import { GatewayClient } from "../lib/gateway-client";
 import {
+  MOBILE_TERMINAL_KEEPALIVE_MS,
   MobileTerminalClient,
   MobileTerminalConnection,
   buildTerminalWebSocketUrl,
@@ -34,6 +35,7 @@ describe("mobile terminal client", () => {
 
   afterEach(() => {
     global.WebSocket = OriginalWebSocket;
+    jest.useRealTimers();
     jest.restoreAllMocks();
   });
 
@@ -173,4 +175,129 @@ describe("mobile terminal client", () => {
     expect((ws as unknown as MockWebSocket).closed).toBe(true);
     expect((ws as unknown as MockWebSocket).sent).toEqual([]);
   });
+
+  it("sends periodic terminal pings while attached", () => {
+    jest.useFakeTimers();
+    expect(MOBILE_TERMINAL_KEEPALIVE_MS).toBeLessThan(120_000);
+
+    const ws = new MockWebSocket() as unknown as WebSocket;
+    const connection = new MobileTerminalConnection(ws, {
+      cwd: "projects",
+      onMessage: jest.fn(),
+    });
+
+    connection.attach();
+    (ws as unknown as MockWebSocket).onopen?.();
+    jest.advanceTimersByTime(MOBILE_TERMINAL_KEEPALIVE_MS - 1);
+    expect(parseSentFrames(ws)).toEqual([{ type: "attach", cwd: "projects" }]);
+
+    jest.advanceTimersByTime(1);
+    jest.advanceTimersByTime(MOBILE_TERMINAL_KEEPALIVE_MS);
+
+    expect(parseSentFrames(ws)).toEqual([
+      { type: "attach", cwd: "projects" },
+      { type: "ping" },
+      { type: "ping" },
+    ]);
+  });
+
+  it("stops terminal keepalive pings after detach", () => {
+    jest.useFakeTimers();
+    const ws = new MockWebSocket() as unknown as WebSocket;
+    const connection = new MobileTerminalConnection(ws, {
+      cwd: "projects",
+      onMessage: jest.fn(),
+    });
+
+    connection.attach();
+    (ws as unknown as MockWebSocket).onopen?.();
+    jest.advanceTimersByTime(MOBILE_TERMINAL_KEEPALIVE_MS);
+    connection.detach();
+    const sentAfterDetach = parseSentFrames(ws);
+
+    jest.advanceTimersByTime(MOBILE_TERMINAL_KEEPALIVE_MS * 2);
+
+    expect(sentAfterDetach).toEqual([
+      { type: "attach", cwd: "projects" },
+      { type: "ping" },
+      { type: "detach" },
+    ]);
+    expect(parseSentFrames(ws)).toEqual(sentAfterDetach);
+  });
+
+  it("stops terminal keepalive pings after destroy", () => {
+    jest.useFakeTimers();
+    const ws = new MockWebSocket() as unknown as WebSocket;
+    const connection = new MobileTerminalConnection(ws, {
+      cwd: "projects",
+      onMessage: jest.fn(),
+    });
+
+    connection.attach();
+    (ws as unknown as MockWebSocket).onopen?.();
+    jest.advanceTimersByTime(MOBILE_TERMINAL_KEEPALIVE_MS);
+    connection.destroy();
+    const sentAfterDestroy = parseSentFrames(ws);
+
+    jest.advanceTimersByTime(MOBILE_TERMINAL_KEEPALIVE_MS * 2);
+
+    expect(sentAfterDestroy).toEqual([
+      { type: "attach", cwd: "projects" },
+      { type: "ping" },
+      { type: "destroy" },
+    ]);
+    expect(parseSentFrames(ws)).toEqual(sentAfterDestroy);
+  });
+
+  it("stops terminal keepalive pings after socket close", () => {
+    jest.useFakeTimers();
+    const statuses: string[] = [];
+    const ws = new MockWebSocket() as unknown as WebSocket;
+    const connection = new MobileTerminalConnection(ws, {
+      cwd: "projects",
+      onMessage: jest.fn(),
+      onStatus: (status) => statuses.push(status),
+    });
+
+    connection.attach();
+    (ws as unknown as MockWebSocket).onopen?.();
+    jest.advanceTimersByTime(MOBILE_TERMINAL_KEEPALIVE_MS);
+    (ws as unknown as MockWebSocket).onclose?.();
+    const sentAfterClose = parseSentFrames(ws);
+
+    jest.advanceTimersByTime(MOBILE_TERMINAL_KEEPALIVE_MS * 2);
+
+    expect(statuses).toEqual(["connecting", "open", "closed"]);
+    expect(sentAfterClose).toEqual([
+      { type: "attach", cwd: "projects" },
+      { type: "ping" },
+    ]);
+    expect(parseSentFrames(ws)).toEqual(sentAfterClose);
+  });
+
+  it("does not attach or start terminal keepalive pings after pre-open close", () => {
+    jest.useFakeTimers();
+    const statuses: string[] = [];
+    const ws = new MockWebSocket() as unknown as WebSocket;
+    (ws as unknown as MockWebSocket).readyState = 0;
+    const connection = new MobileTerminalConnection(ws, {
+      cwd: "projects",
+      onMessage: jest.fn(),
+      onStatus: (status) => statuses.push(status),
+    });
+
+    connection.attach();
+    connection.close();
+    (ws as unknown as MockWebSocket).readyState = MockWebSocket.OPEN;
+    (ws as unknown as MockWebSocket).onopen?.();
+    jest.advanceTimersByTime(MOBILE_TERMINAL_KEEPALIVE_MS * 2);
+
+    expect(statuses).toEqual(["connecting"]);
+    expect((ws as unknown as MockWebSocket).closed).toBe(true);
+    expect(parseSentFrames(ws)).toEqual([]);
+  });
 });
+
+function parseSentFrames(ws: WebSocket): unknown[] {
+  return (ws as unknown as MockWebSocket).sent.map((frame) => JSON.parse(frame));
+}

--- a/apps/mobile/lib/terminal-client.ts
+++ b/apps/mobile/lib/terminal-client.ts
@@ -4,11 +4,13 @@ export { isSafeSessionId, parseTerminalSessions } from "@/lib/terminal-state";
 
 const WS_CONNECTING = 0;
 const WS_OPEN = 1;
+export const MOBILE_TERMINAL_KEEPALIVE_MS = 30_000;
 
 export type TerminalClientFrame =
   | { type: "attach"; sessionId?: string; cwd?: string; fromSeq?: number }
   | { type: "input"; data: string }
   | { type: "resize"; cols: number; rows: number }
+  | { type: "ping" }
   | { type: "detach" }
   | { type: "destroy" };
 
@@ -53,7 +55,9 @@ export class MobileTerminalClient {
 
 export class MobileTerminalConnection {
   private readonly attachFrame: TerminalClientFrame;
+  private keepaliveTimer: ReturnType<typeof setInterval> | null = null;
   private attached = false;
+  private closed = false;
 
   constructor(
     private readonly ws: WebSocket,
@@ -71,12 +75,14 @@ export class MobileTerminalConnection {
     this.options.onStatus?.("connecting");
 
     this.ws.onopen = () => {
+      if (this.closed) return;
       this.attached = true;
       this.options.onStatus?.("open");
       this.sendFrame(this.attachFrame);
       if (this.options.cols && this.options.rows) {
         this.resize(this.options.cols, this.options.rows);
       }
+      this.startKeepalive();
     };
 
     this.ws.onmessage = (event) => {
@@ -89,6 +95,9 @@ export class MobileTerminalConnection {
     };
 
     this.ws.onclose = () => {
+      this.attached = false;
+      this.closed = true;
+      this.stopKeepalive();
       this.options.onStatus?.("closed");
     };
   }
@@ -118,15 +127,32 @@ export class MobileTerminalConnection {
   }
 
   close(): void {
-    if (this.ws.readyState !== WS_CONNECTING && this.ws.readyState !== WS_OPEN) return;
+    if (this.closed) return;
+    this.closed = true;
     this.attached = false;
+    this.stopKeepalive();
+    if (this.ws.readyState !== WS_CONNECTING && this.ws.readyState !== WS_OPEN) return;
     this.ws.close();
   }
 
   private sendFrame(frame: TerminalClientFrame): boolean {
+    if (this.closed) return false;
     if (this.ws.readyState !== WS_OPEN) return false;
     this.ws.send(JSON.stringify(frame));
     return true;
+  }
+
+  private startKeepalive(): void {
+    this.stopKeepalive();
+    this.keepaliveTimer = setInterval(() => {
+      this.sendFrame({ type: "ping" });
+    }, MOBILE_TERMINAL_KEEPALIVE_MS);
+  }
+
+  private stopKeepalive(): void {
+    if (!this.keepaliveTimer) return;
+    clearInterval(this.keepaliveTimer);
+    this.keepaliveTimer = null;
   }
 }
 

--- a/packages/gateway/src/server.ts
+++ b/packages/gateway/src/server.ts
@@ -2589,6 +2589,9 @@ export async function createGateway(config: GatewayConfig) {
 
           switch (msg.type) {
             case "ping":
+              if (handle) {
+                handle.send(msg);
+              }
               ws.send(JSON.stringify({ type: "pong" }));
               break;
             case "attach": {

--- a/packages/gateway/src/server.ts
+++ b/packages/gateway/src/server.ts
@@ -19,7 +19,7 @@ import { createDispatcher, type Dispatcher, type BatchEntry, type DispatchContex
 import { createAiGenerationRecorder } from "./ai-analytics.js";
 import { createWatcher, type Watcher } from "./watcher.js";
 import { createPtyHandler, type PtyMessage } from "./pty.js";
-import { SessionRegistry, ClientMessageSchema, UUID_REGEX, type SessionHandle, type PtyServerMessage, type SessionInfo } from "./session-registry.js";
+import { SessionRegistry, ClientMessageSchema, UUID_REGEX, type ClientMessage, type SessionHandle, type PtyServerMessage, type SessionInfo } from "./session-registry.js";
 import { createConversationStore, type ConversationStore } from "./conversations.js";
 import { ConversationRunRegistry, type ConversationRunMessage } from "./conversation-run-registry.js";
 import { summarizeConversation, saveSummary } from "./conversation-summary.js";
@@ -265,6 +265,35 @@ function logTerminalDebug(event: string, details: Record<string, unknown> = {}):
 export const TERMINAL_SESSION_DELETE_BODY_LIMIT_BYTES = 1024;
 
 export type TerminalSessionRouteRegistry = Pick<SessionRegistry, "list" | "getSession" | "destroy">;
+
+export interface LegacyTerminalHandleDispatchOptions {
+  handle: SessionHandle;
+  msg: ClientMessage;
+  sendJson: (message: PtyServerMessage) => void;
+  close: () => void;
+  onDeadHandle?: () => void;
+}
+
+export function dispatchLegacyTerminalHandleMessage(options: LegacyTerminalHandleDispatchOptions): boolean {
+  if (options.handle.send(options.msg)) return true;
+  closeDeadLegacyTerminalHandle(options);
+  return false;
+}
+
+export function replayLegacyTerminalHandleOrClose(
+  options: Omit<LegacyTerminalHandleDispatchOptions, "msg"> & { fromSeq: number },
+): boolean {
+  if (options.handle.replay(options.fromSeq)) return true;
+  closeDeadLegacyTerminalHandle(options);
+  return false;
+}
+
+function closeDeadLegacyTerminalHandle(options: Omit<LegacyTerminalHandleDispatchOptions, "msg">): void {
+  options.sendJson({ type: "error", message: "Terminal session unavailable" });
+  options.handle.detach();
+  options.onDeadHandle?.();
+  options.close();
+}
 
 export function registerTerminalSessionRoutes(
   app: Hono,
@@ -2528,7 +2557,13 @@ export async function createGateway(config: GatewayConfig) {
                 if (handle) {
                   handle.subscribe(sendJson);
                   sendJson({ type: "attached", sessionId, state: "running" });
-                  handle.replay(0);
+                  replayLegacyTerminalHandleOrClose({
+                    handle,
+                    fromSeq: 0,
+                    sendJson,
+                    close: () => ws.close(),
+                    onDeadHandle: () => { handle = null; },
+                  });
                 } else {
                   sessionRegistry.destroy(sessionId);
                   autoCreatedSessionId = null;
@@ -2590,7 +2625,14 @@ export async function createGateway(config: GatewayConfig) {
           switch (msg.type) {
             case "ping":
               if (handle) {
-                handle.send(msg);
+                const alive = dispatchLegacyTerminalHandleMessage({
+                  handle,
+                  msg,
+                  sendJson,
+                  close: () => ws.close(),
+                  onDeadHandle: () => { handle = null; },
+                });
+                if (!alive) break;
               }
               ws.send(JSON.stringify({ type: "pong" }));
               break;
@@ -2627,7 +2669,13 @@ export async function createGateway(config: GatewayConfig) {
                   if (handle) {
                     handle.subscribe(sendJson);
                     sendJson({ type: "attached", sessionId, state: "running" });
-                    handle.replay(0);
+                    replayLegacyTerminalHandleOrClose({
+                      handle,
+                      fromSeq: 0,
+                      sendJson,
+                      close: () => ws.close(),
+                      onDeadHandle: () => { handle = null; },
+                    });
                   } else {
                     sessionRegistry.destroy(sessionId);
                   }
@@ -2659,7 +2707,13 @@ export async function createGateway(config: GatewayConfig) {
                       state: info?.state ?? "running",
                       exitCode: info?.exitCode,
                     });
-                    handle.replay(msg.fromSeq ?? 0);
+                    replayLegacyTerminalHandleOrClose({
+                      handle,
+                      fromSeq: msg.fromSeq ?? 0,
+                      sendJson,
+                      close: () => ws.close(),
+                      onDeadHandle: () => { handle = null; },
+                    });
                   } else {
                     logTerminalDebug("attach-existing-miss", { sessionId: msg.sessionId });
                     captureTerminalEvent("attach-miss");
@@ -2680,7 +2734,13 @@ export async function createGateway(config: GatewayConfig) {
             case "input":
             case "resize":
               if (handle) {
-                handle.send(msg);
+                dispatchLegacyTerminalHandleMessage({
+                  handle,
+                  msg,
+                  sendJson,
+                  close: () => ws.close(),
+                  onDeadHandle: () => { handle = null; },
+                });
               }
               break;
             case "detach":

--- a/packages/gateway/src/session-registry.ts
+++ b/packages/gateway/src/session-registry.ts
@@ -108,8 +108,8 @@ export type PtyServerMessage =
 export interface SessionHandle {
   readonly sessionId: string;
   subscribe(cb: (msg: PtyServerMessage) => void): void;
-  send(msg: ClientMessage): void;
-  replay(fromSeq: number): void;
+  send(msg: ClientMessage): boolean;
+  replay(fromSeq: number): boolean;
   detach(): void;
 }
 
@@ -502,11 +502,11 @@ export class SessionRegistry {
       },
 
       send(msg: ClientMessage) {
-        if (subscriberPruned) return;
+        if (detached || subscriberPruned) return false;
         if (subscriberFn && !session.touchSubscriber(subscriberFn, nowFn())) {
           subscriberFn = null;
           subscriberPruned = true;
-          return;
+          return false;
         }
         switch (msg.type) {
           case "input":
@@ -516,15 +516,16 @@ export class SessionRegistry {
             session.resize(msg.cols, msg.rows);
             break;
         }
+        return true;
       },
 
       replay(fromSeq: number) {
-        if (subscriberPruned) return;
-        if (!subscriberFn) return;
+        if (detached || subscriberPruned) return false;
+        if (!subscriberFn) return false;
         if (!session.touchSubscriber(subscriberFn, nowFn())) {
           subscriberFn = null;
           subscriberPruned = true;
-          return;
+          return false;
         }
         const chunks = session.buffer.getSince(fromSeq);
         subscriberFn({ type: "replay-start", fromSeq });
@@ -532,6 +533,7 @@ export class SessionRegistry {
           subscriberFn({ type: "output", data: chunk.data, seq: chunk.seq });
         }
         subscriberFn({ type: "replay-end", toSeq: session.buffer.nextSeq });
+        return true;
       },
 
       detach() {

--- a/packages/gateway/src/session-registry.ts
+++ b/packages/gateway/src/session-registry.ts
@@ -10,6 +10,7 @@ import { resolveWithinHome } from "./path-security.js";
 const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 const TERMINAL_DEBUG_ENABLED = process.env.TERMINAL_DEBUG === "1";
 export const MIN_TERMINAL_SESSION_TTL_MS = 24 * 60 * 60 * 1000;
+export const DEFAULT_TERMINAL_SUBSCRIBER_TTL_MS = 2 * 60 * 1000;
 
 function logTerminalDebug(event: string, details: Record<string, unknown> = {}): void {
   if (!TERMINAL_DEBUG_ENABLED) {
@@ -118,6 +119,8 @@ export interface SessionRegistryOptions {
   persistPath?: string;
   allowedShells?: string[];
   sessionTtlMs?: number;
+  subscriberTtlMs?: number;
+  now?: () => number;
   /**
    * When false, the registry skips reading and restoring persisted sessions
    * from `persistPath` on construction. Defense-in-depth for callers that
@@ -129,6 +132,10 @@ export interface SessionRegistryOptions {
 }
 
 type SubscriberFn = (msg: PtyServerMessage) => void;
+
+interface SubscriberRecord {
+  lastTouchedAt: number;
+}
 
 interface PtyLike {
   onData: (cb: (data: string) => void) => void;
@@ -180,8 +187,9 @@ class PtySession {
   exitCode?: number;
   private ptyProcess: PtyLike;
   private static readonly MAX_SUBSCRIBERS = 10;
-  private subscribers = new Set<SubscriberFn>();
+  private subscribers = new Map<SubscriberFn, SubscriberRecord>();
   private _attachedClients = 0;
+  private readonly now: () => number;
 
   constructor(
     sessionId: string,
@@ -190,13 +198,15 @@ class PtySession {
     cwd: string,
     shell: string,
     metadata?: Pick<SessionInfo, "createdAt" | "lastAttachedAt">,
+    now: () => number = Date.now,
   ) {
     this.sessionId = sessionId;
     this.ptyProcess = ptyProcess;
     this.buffer = buffer;
     this.cwd = cwd;
     this.shell = shell;
-    this.createdAt = metadata?.createdAt ?? Date.now();
+    this.now = now;
+    this.createdAt = metadata?.createdAt ?? this.now();
     this.lastAttachedAt = metadata?.lastAttachedAt ?? this.createdAt;
 
     this.ptyProcess.onData((data: string) => {
@@ -207,7 +217,7 @@ class PtySession {
           continue;
         }
         const msg: PtyServerMessage = { type: "output", data: chunk, seq };
-        for (const sub of this.subscribers) {
+        for (const sub of this.subscribers.keys()) {
           sub(msg);
         }
       }
@@ -217,7 +227,7 @@ class PtySession {
       this.state = "exited";
       this.exitCode = exitCode;
       const msg: PtyServerMessage = { type: "exit", code: exitCode };
-      for (const sub of this.subscribers) {
+      for (const sub of this.subscribers.keys()) {
         sub(msg);
       }
     });
@@ -229,7 +239,7 @@ class PtySession {
 
   incrementClients(): void {
     this._attachedClients++;
-    this.lastAttachedAt = Date.now();
+    this.lastAttachedAt = this.now();
   }
 
   decrementClients(): void {
@@ -238,19 +248,44 @@ class PtySession {
     }
   }
 
-  addSubscriber(fn: SubscriberFn): void {
-    if (this.subscribers.size >= PtySession.MAX_SUBSCRIBERS) {
+  addSubscriber(fn: SubscriberFn, now = this.now()): void {
+    if (!this.subscribers.has(fn) && this.subscribers.size >= PtySession.MAX_SUBSCRIBERS) {
       throw new Error("Too many subscribers");
     }
-    this.subscribers.add(fn);
+    this.subscribers.set(fn, { lastTouchedAt: now });
+    this.lastAttachedAt = now;
   }
 
-  removeSubscriber(fn: SubscriberFn): void {
-    this.subscribers.delete(fn);
+  removeSubscriber(fn: SubscriberFn): boolean {
+    return this.subscribers.delete(fn);
+  }
+
+  touchSubscriber(fn: SubscriberFn, now = this.now()): boolean {
+    const subscriber = this.subscribers.get(fn);
+    if (!subscriber) {
+      return false;
+    }
+    subscriber.lastTouchedAt = now;
+    this.lastAttachedAt = now;
+    return true;
+  }
+
+  pruneStaleSubscribers(now: number, subscriberTtlMs: number): number {
+    let removed = 0;
+    for (const [fn, subscriber] of this.subscribers) {
+      if (now - subscriber.lastTouchedAt < subscriberTtlMs) {
+        continue;
+      }
+      this.subscribers.delete(fn);
+      this.decrementClients();
+      removed += 1;
+    }
+    return removed;
   }
 
   clearSubscribers(): void {
     this.subscribers.clear();
+    this._attachedClients = 0;
   }
 
   write(data: string): void {
@@ -300,6 +335,8 @@ export class SessionRegistry {
   private readonly spawnFn: SpawnFn;
   private readonly allowedShells: Set<string>;
   private readonly sessionTtlMs: number;
+  private readonly subscriberTtlMs: number;
+  private readonly now: () => number;
   private persistTimer?: ReturnType<typeof setTimeout>;
   private persistQueue: Promise<void> = Promise.resolve();
 
@@ -313,6 +350,8 @@ export class SessionRegistry {
     this.bufferSize = options?.bufferSize ?? 1024 * 1024;
     this.persistPath = options?.persistPath ?? join(homePath, "system", "terminal-sessions.json");
     this.sessionTtlMs = normalizeSessionTtl(options?.sessionTtlMs);
+    this.subscriberTtlMs = normalizeSubscriberTtl(options?.subscriberTtlMs);
+    this.now = options?.now ?? Date.now;
     this.allowedShells = options?.allowedShells
       ? new Set(options.allowedShells)
       : DEFAULT_ALLOWED_SHELLS;
@@ -336,8 +375,10 @@ export class SessionRegistry {
   }
 
   create(cwd: string, shell?: string): string {
-    this.evictExpiredSessions();
-    this.evictIfNeeded();
+    const now = this.now();
+    this.cleanupStaleSubscribers(now);
+    this.evictExpiredSessions(now);
+    this.evictIfNeeded(now);
 
     if (this.sessions.size >= this.maxSessions) {
       throw new Error("Session limit reached");
@@ -363,7 +404,7 @@ export class SessionRegistry {
       }
     }
 
-    const session = new PtySession(sessionId, ptyProcess, buffer, targetCwd, resolvedShell);
+    const session = new PtySession(sessionId, ptyProcess, buffer, targetCwd, resolvedShell, undefined, this.now);
     this.sessions.set(sessionId, session);
     this.schedulePersist();
     logTerminalDebug("create", {
@@ -377,8 +418,10 @@ export class SessionRegistry {
   }
 
   registerExternal(input: ExternalSessionRegistration): string {
-    this.evictExpiredSessions();
-    this.evictIfNeeded();
+    const now = this.now();
+    this.cleanupStaleSubscribers(now);
+    this.evictExpiredSessions(now);
+    this.evictIfNeeded(now);
 
     if (this.sessions.size >= this.maxSessions) {
       throw new Error("Session limit reached");
@@ -395,7 +438,7 @@ export class SessionRegistry {
       this.spawnOptions(targetCwd, "/bin/bash"),
     );
 
-    const session = new PtySession(sessionId, ptyProcess, buffer, targetCwd, parsed.command);
+    const session = new PtySession(sessionId, ptyProcess, buffer, targetCwd, parsed.command, undefined, this.now);
     this.sessions.set(sessionId, session);
     this.schedulePersist();
     logTerminalDebug("register-external", {
@@ -409,6 +452,9 @@ export class SessionRegistry {
   }
 
   attach(sessionId: string): SessionHandle | null {
+    const now = this.now();
+    this.cleanupStaleSubscribers(now);
+    this.evictExpiredSessions(now);
     const session = this.sessions.get(sessionId);
     if (!session) {
       logTerminalDebug("attach-miss", { sessionId, totalSessions: this.sessions.size });
@@ -423,6 +469,7 @@ export class SessionRegistry {
 
     let subscriberFn: SubscriberFn | null = null;
     let detached = false;
+    const nowFn = this.now;
 
     const handle: SessionHandle = {
       sessionId,
@@ -430,27 +477,33 @@ export class SessionRegistry {
       subscribe(cb: (msg: PtyServerMessage) => void) {
         if (detached) return;
 
+        const now = nowFn();
         const previousSubscriber = subscriberFn;
+        let previousSubscriberWasActive = false;
         if (previousSubscriber) {
-          session.removeSubscriber(previousSubscriber);
+          previousSubscriberWasActive = session.removeSubscriber(previousSubscriber);
         }
 
         try {
-          session.addSubscriber(cb);
+          session.addSubscriber(cb, now);
         } catch (error) {
-          if (previousSubscriber) {
-            session.addSubscriber(previousSubscriber);
+          if (previousSubscriber && previousSubscriberWasActive) {
+            session.addSubscriber(previousSubscriber, now);
           }
           throw error;
         }
 
         subscriberFn = cb;
-        if (!previousSubscriber) {
+        if (!previousSubscriberWasActive) {
           session.incrementClients();
         }
       },
 
       send(msg: ClientMessage) {
+        if (subscriberFn && !session.touchSubscriber(subscriberFn, nowFn())) {
+          subscriberFn = null;
+          return;
+        }
         switch (msg.type) {
           case "input":
             session.write(msg.data);
@@ -463,6 +516,10 @@ export class SessionRegistry {
 
       replay(fromSeq: number) {
         if (!subscriberFn) return;
+        if (!session.touchSubscriber(subscriberFn, nowFn())) {
+          subscriberFn = null;
+          return;
+        }
         const chunks = session.buffer.getSince(fromSeq);
         subscriberFn({ type: "replay-start", fromSeq });
         for (const chunk of chunks) {
@@ -480,8 +537,9 @@ export class SessionRegistry {
           attachedClientsBefore: session.attachedClients,
         });
         if (subscriberFn) {
-          session.removeSubscriber(subscriberFn);
-          session.decrementClients();
+          if (session.removeSubscriber(subscriberFn)) {
+            session.decrementClients();
+          }
           subscriberFn = null;
         }
       },
@@ -515,12 +573,16 @@ export class SessionRegistry {
   }
 
   list(): SessionInfo[] {
-    this.evictExpiredSessions();
+    const now = this.now();
+    this.cleanupStaleSubscribers(now);
+    this.evictExpiredSessions(now);
     return Array.from(this.sessions.values()).map((s) => s.toInfo());
   }
 
   getSession(sessionId: string): SessionInfo | null {
-    this.evictExpiredSessions();
+    const now = this.now();
+    this.cleanupStaleSubscribers(now);
+    this.evictExpiredSessions(now);
     const session = this.sessions.get(sessionId);
     return session ? session.toInfo() : null;
   }
@@ -534,11 +596,21 @@ export class SessionRegistry {
     await this.persistNow();
   }
 
-  private evictIfNeeded(): void {
+  private cleanupStaleSubscribers(now = this.now()): void {
+    let removed = 0;
+    for (const session of this.sessions.values()) {
+      removed += session.pruneStaleSubscribers(now, this.subscriberTtlMs);
+    }
+    if (removed > 0) {
+      logTerminalDebug("prune-stale-subscribers", { removed });
+      this.schedulePersist();
+    }
+  }
+
+  private evictIfNeeded(now = this.now()): void {
     if (this.sessions.size < this.maxSessions) return;
 
     let candidate: PtySession | null = null;
-    const now = Date.now();
     for (const session of this.sessions.values()) {
       if (session.attachedClients > 0) continue;
       if (!this.isExpired(session, now)) continue;
@@ -644,7 +716,7 @@ export class SessionRegistry {
         }
       }
 
-      const now = Date.now();
+      const now = this.now();
       let restored = 0;
       let expired = 0;
       for (const session of sessions) {
@@ -687,6 +759,7 @@ export class SessionRegistry {
           createdAt: info.createdAt,
           lastAttachedAt: info.lastAttachedAt,
         },
+        this.now,
       );
       this.sessions.set(info.sessionId, session);
       return true;
@@ -705,4 +778,11 @@ function normalizeSessionTtl(value: number | undefined): number {
     return MIN_TERMINAL_SESSION_TTL_MS;
   }
   return Math.max(value, MIN_TERMINAL_SESSION_TTL_MS);
+}
+
+function normalizeSubscriberTtl(value: number | undefined): number {
+  if (value === undefined || !Number.isFinite(value) || value <= 0) {
+    return DEFAULT_TERMINAL_SUBSCRIBER_TTL_MS;
+  }
+  return value;
 }

--- a/packages/gateway/src/session-registry.ts
+++ b/packages/gateway/src/session-registry.ts
@@ -468,6 +468,7 @@ export class SessionRegistry {
     });
 
     let subscriberFn: SubscriberFn | null = null;
+    let subscriberPruned = false;
     let detached = false;
     const nowFn = this.now;
 
@@ -494,14 +495,17 @@ export class SessionRegistry {
         }
 
         subscriberFn = cb;
+        subscriberPruned = false;
         if (!previousSubscriberWasActive) {
           session.incrementClients();
         }
       },
 
       send(msg: ClientMessage) {
+        if (subscriberPruned) return;
         if (subscriberFn && !session.touchSubscriber(subscriberFn, nowFn())) {
           subscriberFn = null;
+          subscriberPruned = true;
           return;
         }
         switch (msg.type) {
@@ -515,9 +519,11 @@ export class SessionRegistry {
       },
 
       replay(fromSeq: number) {
+        if (subscriberPruned) return;
         if (!subscriberFn) return;
         if (!session.touchSubscriber(subscriberFn, nowFn())) {
           subscriberFn = null;
+          subscriberPruned = true;
           return;
         }
         const chunks = session.buffer.getSince(fromSeq);
@@ -633,7 +639,7 @@ export class SessionRegistry {
     }
   }
 
-  private evictExpiredSessions(now = Date.now()): void {
+  private evictExpiredSessions(now = this.now()): void {
     for (const session of this.sessions.values()) {
       if (session.attachedClients > 0) continue;
       if (!this.isExpired(session, now)) continue;

--- a/tests/gateway/session-registry.test.ts
+++ b/tests/gateway/session-registry.test.ts
@@ -460,7 +460,7 @@ describe("SessionRegistry", () => {
       const handle = registry.attach(id)!;
       const received: PtyServerMessage[] = [];
       handle.subscribe((msg) => received.push(msg));
-      handle.replay(0);
+      expect(handle.replay(0)).toBe(true);
 
       expect(received[0]).toEqual({ type: "replay-start", fromSeq: 0 });
       expect(received[1]).toEqual({ type: "output", data: "line1\r\n", seq: 0 });
@@ -483,7 +483,7 @@ describe("SessionRegistry", () => {
       const handle = registry.attach(id)!;
       const received: PtyServerMessage[] = [];
       handle.subscribe((msg) => received.push(msg));
-      handle.replay(2);
+      expect(handle.replay(2)).toBe(true);
 
       expect(received[0]).toEqual({ type: "replay-start", fromSeq: 2 });
       expect(received[1]).toEqual({ type: "output", data: "c", seq: 2 });
@@ -497,7 +497,7 @@ describe("SessionRegistry", () => {
       const handle = registry.attach(id)!;
       const received: PtyServerMessage[] = [];
       handle.subscribe((msg) => received.push(msg));
-      handle.replay(0);
+      expect(handle.replay(0)).toBe(true);
 
       expect(received).toHaveLength(2);
       expect(received[0]).toEqual({ type: "replay-start", fromSeq: 0 });
@@ -512,7 +512,7 @@ describe("SessionRegistry", () => {
       handle.subscribe(() => {});
 
       clock.advance(90);
-      handle.replay(0);
+      expect(handle.replay(0)).toBe(true);
       clock.advance(90);
 
       expect(registry.getSession(id)!.attachedClients).toBe(1);
@@ -530,7 +530,7 @@ describe("SessionRegistry", () => {
       const id = registry.create("/home");
       const handle = registry.attach(id)!;
 
-      handle.send({ type: "input", data: "hello" });
+      expect(handle.send({ type: "input", data: "hello" })).toBe(true);
       expect(mockPty.write).toHaveBeenCalledWith("hello");
     });
 
@@ -541,7 +541,7 @@ describe("SessionRegistry", () => {
       const id = registry.create("/home");
       const handle = registry.attach(id)!;
 
-      handle.send({ type: "resize", cols: 120, rows: 40 });
+      expect(handle.send({ type: "resize", cols: 120, rows: 40 })).toBe(true);
       expect(mockPty.resize).toHaveBeenCalledWith(120, 40);
     });
 
@@ -553,11 +553,11 @@ describe("SessionRegistry", () => {
       handle.subscribe(() => {});
 
       clock.advance(90);
-      handle.send({ type: "input", data: "hello" });
+      expect(handle.send({ type: "input", data: "hello" })).toBe(true);
       clock.advance(90);
-      handle.send({ type: "resize", cols: 80, rows: 24 });
+      expect(handle.send({ type: "resize", cols: 80, rows: 24 })).toBe(true);
       clock.advance(90);
-      handle.send({ type: "ping" });
+      expect(handle.send({ type: "ping" })).toBe(true);
       clock.advance(90);
 
       expect(registry.getSession(id)!.attachedClients).toBe(1);
@@ -577,10 +577,24 @@ describe("SessionRegistry", () => {
 
       clock.advance(101);
       expect(registry.getSession(id)!.attachedClients).toBe(0);
-      handle.send({ type: "input", data: "stale" });
-      handle.send({ type: "input", data: "still-stale" });
+      expect(handle.send({ type: "input", data: "stale" })).toBe(false);
+      expect(handle.send({ type: "input", data: "still-stale" })).toBe(false);
 
       expect(mockPty.write).not.toHaveBeenCalled();
+    });
+
+    it("reports failure for stale pruned ping and replay handles", () => {
+      const clock = createClock();
+      const registry = createRegistry({ subscriberTtlMs: 100, now: clock.now });
+      const id = registry.create("/home");
+      const handle = registry.attach(id)!;
+      handle.subscribe(() => {});
+
+      clock.advance(101);
+      expect(registry.getSession(id)!.attachedClients).toBe(0);
+
+      expect(handle.send({ type: "ping" })).toBe(false);
+      expect(handle.replay(0)).toBe(false);
     });
   });
 

--- a/tests/gateway/session-registry.test.ts
+++ b/tests/gateway/session-registry.test.ts
@@ -43,6 +43,16 @@ function createRegistry(
 
 const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
+function createClock(initialNow = 1_000) {
+  let now = initialNow;
+  return {
+    now: () => now,
+    advance(ms: number) {
+      now += ms;
+    },
+  };
+}
+
 describe("SessionRegistry", () => {
   describe("create", () => {
     it("returns a UUID string", () => {
@@ -191,6 +201,37 @@ describe("SessionRegistry", () => {
       handle.detach(); // second detach is a no-op
       expect(registry.getSession(id)!.attachedClients).toBe(0);
     });
+
+    it("keeps detach idempotent after stale subscriber cleanup", () => {
+      const clock = createClock();
+      const registry = createRegistry({ subscriberTtlMs: 100, now: clock.now });
+      const id = registry.create("/home");
+      const handle = registry.attach(id)!;
+      handle.subscribe(() => {});
+
+      expect(registry.getSession(id)!.attachedClients).toBe(1);
+
+      clock.advance(101);
+      expect(registry.getSession(id)!.attachedClients).toBe(0);
+
+      handle.detach();
+      expect(registry.getSession(id)!.attachedClients).toBe(0);
+    });
+
+    it("counts a resubscribe after stale cleanup as a fresh attachment", () => {
+      const clock = createClock();
+      const registry = createRegistry({ subscriberTtlMs: 100, now: clock.now });
+      const id = registry.create("/home");
+      const handle = registry.attach(id)!;
+      handle.subscribe(() => {});
+
+      clock.advance(101);
+      expect(registry.getSession(id)!.attachedClients).toBe(0);
+
+      handle.subscribe(() => {});
+
+      expect(registry.getSession(id)!.attachedClients).toBe(1);
+    });
   });
 
   describe("destroy", () => {
@@ -309,6 +350,43 @@ describe("SessionRegistry", () => {
       expect(() => registry.create("/home")).toThrow("Session limit reached");
       expect(registry.list()).toHaveLength(2);
     });
+
+    it("prunes stale subscribers before deciding session cap eviction", () => {
+      const clock = createClock();
+      const registry = createRegistry({ maxSessions: 2, subscriberTtlMs: 100, now: clock.now });
+
+      const id1 = registry.create("/home");
+      const id2 = registry.create("/home");
+      registry.attach(id1)!.subscribe(() => {});
+
+      const sessionMap = (registry as unknown as { sessions: Map<string, { lastAttachedAt: number }> }).sessions;
+      sessionMap.get(id1)!.lastAttachedAt = clock.now() - MIN_TERMINAL_SESSION_TTL_MS - 1;
+
+      clock.advance(101);
+      const id3 = registry.create("/home");
+
+      expect(registry.getSession(id1)).toBeNull();
+      expect(registry.getSession(id2)).not.toBeNull();
+      expect(registry.getSession(id3)).not.toBeNull();
+    });
+
+    it("keeps recently touched subscribers protected from cap eviction", () => {
+      const clock = createClock();
+      const registry = createRegistry({ maxSessions: 2, subscriberTtlMs: 100, now: clock.now });
+
+      const id1 = registry.create("/home");
+      registry.create("/home");
+      registry.attach(id1)!.subscribe(() => {});
+
+      const sessionMap = (registry as unknown as { sessions: Map<string, { lastAttachedAt: number }> }).sessions;
+      sessionMap.get(id1)!.lastAttachedAt = clock.now() - MIN_TERMINAL_SESSION_TTL_MS - 1;
+
+      clock.advance(99);
+
+      expect(() => registry.create("/home")).toThrow("Session limit reached");
+      expect(registry.getSession(id1)).not.toBeNull();
+      expect(registry.getSession(id1)!.attachedClients).toBe(1);
+    });
   });
 
   describe("list", () => {
@@ -425,6 +503,23 @@ describe("SessionRegistry", () => {
       expect(received[0]).toEqual({ type: "replay-start", fromSeq: 0 });
       expect(received[1]).toEqual({ type: "replay-end", toSeq: 0 });
     });
+
+    it("refreshes subscriber liveness when replay is requested", () => {
+      const clock = createClock();
+      const registry = createRegistry({ subscriberTtlMs: 100, now: clock.now });
+      const id = registry.create("/home");
+      const handle = registry.attach(id)!;
+      handle.subscribe(() => {});
+
+      clock.advance(90);
+      handle.replay(0);
+      clock.advance(90);
+
+      expect(registry.getSession(id)!.attachedClients).toBe(1);
+
+      clock.advance(11);
+      expect(registry.getSession(id)!.attachedClients).toBe(0);
+    });
   });
 
   describe("handle.send", () => {
@@ -448,6 +543,43 @@ describe("SessionRegistry", () => {
 
       handle.send({ type: "resize", cols: 120, rows: 40 });
       expect(mockPty.resize).toHaveBeenCalledWith(120, 40);
+    });
+
+    it("refreshes subscriber liveness on input, resize, and ping", () => {
+      const clock = createClock();
+      const registry = createRegistry({ subscriberTtlMs: 100, now: clock.now });
+      const id = registry.create("/home");
+      const handle = registry.attach(id)!;
+      handle.subscribe(() => {});
+
+      clock.advance(90);
+      handle.send({ type: "input", data: "hello" });
+      clock.advance(90);
+      handle.send({ type: "resize", cols: 80, rows: 24 });
+      clock.advance(90);
+      handle.send({ type: "ping" });
+      clock.advance(90);
+
+      expect(registry.getSession(id)!.attachedClients).toBe(1);
+
+      clock.advance(11);
+      expect(registry.getSession(id)!.attachedClients).toBe(0);
+    });
+
+    it("does not let a stale pruned handle continue writing to the PTY", () => {
+      const clock = createClock();
+      const mockPty = createMockPty();
+      const mockSpawn = createMockSpawn(mockPty);
+      const registry = createRegistry({ subscriberTtlMs: 100, now: clock.now }, mockSpawn);
+      const id = registry.create("/home");
+      const handle = registry.attach(id)!;
+      handle.subscribe(() => {});
+
+      clock.advance(101);
+      expect(registry.getSession(id)!.attachedClients).toBe(0);
+      handle.send({ type: "input", data: "stale" });
+
+      expect(mockPty.write).not.toHaveBeenCalled();
     });
   });
 
@@ -539,6 +671,25 @@ describe("SessionRegistry", () => {
         { type: "output", data: "6", seq: 1 },
         { type: "replay-end", toSeq: 2 },
       ]);
+    });
+
+    it("does not treat PTY output broadcast as subscriber liveness", () => {
+      const clock = createClock();
+      const mockPty = createMockPty();
+      const mockSpawn = createMockSpawn(mockPty);
+      const registry = createRegistry({ subscriberTtlMs: 100, now: clock.now }, mockSpawn);
+      const id = registry.create("/home");
+      const handle = registry.attach(id)!;
+      const received: PtyServerMessage[] = [];
+      handle.subscribe((msg) => received.push(msg));
+
+      clock.advance(90);
+      const dataCb = mockPty.onData.mock.calls[0][0];
+      dataCb("still not proof of life");
+      clock.advance(11);
+
+      expect(received).toContainEqual({ type: "output", data: "still not proof of life", seq: 0 });
+      expect(registry.getSession(id)!.attachedClients).toBe(0);
     });
   });
 

--- a/tests/gateway/session-registry.test.ts
+++ b/tests/gateway/session-registry.test.ts
@@ -578,6 +578,7 @@ describe("SessionRegistry", () => {
       clock.advance(101);
       expect(registry.getSession(id)!.attachedClients).toBe(0);
       handle.send({ type: "input", data: "stale" });
+      handle.send({ type: "input", data: "still-stale" });
 
       expect(mockPty.write).not.toHaveBeenCalled();
     });

--- a/tests/gateway/terminal-ws.test.ts
+++ b/tests/gateway/terminal-ws.test.ts
@@ -13,6 +13,7 @@ import {
   DestroySchema,
 } from "../../packages/gateway/src/session-registry.js";
 import {
+  dispatchLegacyTerminalHandleMessage,
   resetVolatilePtySessionList,
   registerTerminalSessionRoutes,
   TERMINAL_SESSION_DELETE_BODY_LIMIT_BYTES,
@@ -279,5 +280,96 @@ describe("Terminal session REST routes", () => {
     expect(res.status).toBe(413);
     expect(registry.getSession).not.toHaveBeenCalled();
     expect(registry.destroy).not.toHaveBeenCalled();
+  });
+});
+
+describe("legacy terminal websocket handle dispatch", () => {
+  it("keeps live terminal pings eligible for pong responses", () => {
+    const sent: unknown[] = [];
+    const handle = {
+      sessionId: SESSION_ID,
+      send: vi.fn(() => true),
+      replay: vi.fn(),
+      subscribe: vi.fn(),
+      detach: vi.fn(),
+    };
+    const closed = vi.fn();
+
+    const alive = dispatchLegacyTerminalHandleMessage({
+      handle,
+      msg: { type: "ping" },
+      sendJson: (message) => sent.push(message),
+      close: closed,
+    });
+
+    if (alive) {
+      sent.push({ type: "pong" });
+    }
+
+    expect(alive).toBe(true);
+    expect(handle.send).toHaveBeenCalledWith({ type: "ping" });
+    expect(handle.detach).not.toHaveBeenCalled();
+    expect(closed).not.toHaveBeenCalled();
+    expect(sent).toEqual([{ type: "pong" }]);
+  });
+
+  it("sends a generic error and closes instead of ponging stale-pruned terminal pings", () => {
+    const sent: unknown[] = [];
+    const onDeadHandle = vi.fn();
+    const handle = {
+      sessionId: SESSION_ID,
+      send: vi.fn(() => false),
+      replay: vi.fn(),
+      subscribe: vi.fn(),
+      detach: vi.fn(),
+    };
+    const closed = vi.fn();
+
+    const alive = dispatchLegacyTerminalHandleMessage({
+      handle,
+      msg: { type: "ping" },
+      sendJson: (message) => sent.push(message),
+      close: closed,
+      onDeadHandle,
+    });
+
+    if (alive) {
+      sent.push({ type: "pong" });
+    }
+
+    expect(alive).toBe(false);
+    expect(handle.send).toHaveBeenCalledWith({ type: "ping" });
+    expect(handle.detach).toHaveBeenCalledTimes(1);
+    expect(onDeadHandle).toHaveBeenCalledTimes(1);
+    expect(closed).toHaveBeenCalledTimes(1);
+    expect(sent).toEqual([{ type: "error", message: "Terminal session unavailable" }]);
+  });
+
+  it("sends a generic error and closes instead of silently dropping stale-pruned terminal input", () => {
+    const sent: unknown[] = [];
+    const onDeadHandle = vi.fn();
+    const handle = {
+      sessionId: SESSION_ID,
+      send: vi.fn(() => false),
+      replay: vi.fn(),
+      subscribe: vi.fn(),
+      detach: vi.fn(),
+    };
+    const closed = vi.fn();
+
+    const alive = dispatchLegacyTerminalHandleMessage({
+      handle,
+      msg: { type: "input", data: "pwd\r" },
+      sendJson: (message) => sent.push(message),
+      close: closed,
+      onDeadHandle,
+    });
+
+    expect(alive).toBe(false);
+    expect(handle.send).toHaveBeenCalledWith({ type: "input", data: "pwd\r" });
+    expect(handle.detach).toHaveBeenCalledTimes(1);
+    expect(onDeadHandle).toHaveBeenCalledTimes(1);
+    expect(closed).toHaveBeenCalledTimes(1);
+    expect(sent).toEqual([{ type: "error", message: "Terminal session unavailable" }]);
   });
 });


### PR DESCRIPTION
## Summary

- Track legacy PTY subscribers with bounded records that include `lastTouchedAt`, preserving the existing 10-subscriber cap.
- Prune stale subscribers before registry reads, attaches, creates, external registrations, and eviction checks so missed WebSocket close cleanup cannot pin `attachedClients > 0` forever.
- Refresh subscriber liveness only from explicit client activity: subscribe, replay, input/resize sends, and terminal `ping` frames. PTY output broadcasts do not prove subscriber liveness.
- Treat stale-pruned handles as inactive for future writes/replays, while allowing an explicit resubscribe to count as a fresh attachment.

## Tests

- PASS: `/home/nima/matrix-os/node_modules/.bin/vitest run tests/gateway/session-registry.test.ts tests/gateway/terminal-ws.test.ts` (`87` tests)
- PASS: `/home/nima/matrix-os/node_modules/.bin/tsc --noEmit -p packages/gateway/tsconfig.json`
- PASS: `./scripts/review/check-patterns.sh` (0 violations; pre-existing warnings only)
- ATTEMPTED: `bun run test` / `bun run typecheck` were not runnable because `bun` is not installed in this shell.
- ATTEMPTED: `pnpm run test` completed but failed in unrelated baseline/environment suites, including missing linked desktop/platform deps (`sonner`, `@dnd-kit/core`, `react-resizable-panels`, `stripe`, `@posthog/nextjs-config`), platform telemetry constant failures, E2E `resolveOwnerTelemetryDistinctId` import failures, CLI doctor URL expectation drift, browser profile `/tmp` permission failures, sync tests writing outside the sandbox, and an orchestrator hook timeout. The focused gateway tests for this PR passed.

## Review/Monitoring

- PR marked ready for CI after implementation commit `45b1bc50`.
- Added `ready-for-ci` label for CI/review orchestration.
- Greptile/CI monitoring remains active; findings will be fixed in this PR unless explicitly deferred with a follow-up.

## Invariants

- Source of truth: legacy PTY `SessionRegistry` remains the in-memory owner of active PTY sessions and subscriber attachment state for this code path.
- Lock/transaction scope: no database transactions are involved; cleanup is coordinated within `SessionRegistry` state transitions before reads, attach/create paths, and eviction decisions.
- Acceptable orphan states: stale subscribers may be pruned after the configured subscriber TTL; once all subscribers are stale, the existing session TTL/cap eviction policy may remove now-orphaned sessions. Live clients must continue touching liveness through explicit client activity.
- Auth source of truth: terminal WebSocket route authorization remains unchanged. This PR only adjusts post-auth subscriber/session resource management for legacy PTY sessions.
- Deferred scope: named zellij sessions, terminal UI behavior, persistence format changes, and platform/desktop dependency baseline failures are outside this PR.