### PR TITLE
fix(mobile): prevent duplicate terminal connections

### DIFF
--- a/apps/mobile/__tests__/terminal-client.test.ts
+++ b/apps/mobile/__tests__/terminal-client.test.ts
@@ -265,6 +265,7 @@ describe("mobile terminal client", () => {
 
     await expect(connectPromise).rejects.toThrow("Terminal connection opened before attach could be sent");
     expect(socket.sent).toEqual([]);
+    expect(socket.closed).toBe(true);
     expect(statuses).toEqual(["connecting"]);
     expect(warnSpy).toHaveBeenCalledWith("[mobile] terminal websocket send failed", "Error");
   });

--- a/apps/mobile/__tests__/terminal-client.test.ts
+++ b/apps/mobile/__tests__/terminal-client.test.ts
@@ -17,12 +17,14 @@ class MockWebSocket {
   readyState = MockWebSocket.OPEN;
   sent: string[] = [];
   closed = false;
+  failSends = false;
   onopen: (() => void) | null = null;
   onmessage: ((event: { data: string }) => void) | null = null;
   onerror: (() => void) | null = null;
   onclose: (() => void) | null = null;
 
   send(data: string) {
+    if (this.failSends) throw new Error("send failed");
     this.sent.push(data);
   }
 
@@ -34,8 +36,7 @@ class MockWebSocket {
 }
 
 async function flushPromises() {
-  await Promise.resolve();
-  await Promise.resolve();
+  await new Promise((resolve) => setTimeout(resolve, 0));
 }
 
 describe("mobile terminal client", () => {
@@ -211,6 +212,61 @@ describe("mobile terminal client", () => {
     await expect(connectPromise).rejects.toThrow("Terminal connection closed before attach");
     expect(socket.sent).toEqual([]);
     expect(statuses).toEqual(["connecting", "closed"]);
+  });
+
+  it("does not emit duplicate status transitions for pre-attach socket errors", async () => {
+    const socket = new MockWebSocket();
+    socket.readyState = MockWebSocket.CONNECTING;
+    const gateway = {
+      getWsToken: jest.fn().mockResolvedValue("ws-token"),
+      setWebSocketToken: jest.fn(),
+      openTerminalWebSocket: jest.fn(() => socket as unknown as WebSocket),
+    };
+    const terminalClient = new MobileTerminalClient(gateway as unknown as GatewayClient);
+    const statuses: string[] = [];
+
+    const connectPromise = terminalClient.connect({
+      cwd: "projects",
+      onMessage: jest.fn(),
+      onStatus: (status) => statuses.push(status),
+    });
+
+    await flushPromises();
+    socket.onerror?.();
+    socket.onclose?.();
+
+    await expect(connectPromise).rejects.toThrow("Terminal connection failed before attach");
+    expect(socket.sent).toEqual([]);
+    expect(statuses).toEqual(["connecting"]);
+  });
+
+  it("rejects pending connects when attach cannot be sent after open", async () => {
+    const socket = new MockWebSocket();
+    socket.readyState = MockWebSocket.CONNECTING;
+    socket.failSends = true;
+    const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+    const gateway = {
+      getWsToken: jest.fn().mockResolvedValue("ws-token"),
+      setWebSocketToken: jest.fn(),
+      openTerminalWebSocket: jest.fn(() => socket as unknown as WebSocket),
+    };
+    const terminalClient = new MobileTerminalClient(gateway as unknown as GatewayClient);
+    const statuses: string[] = [];
+
+    const connectPromise = terminalClient.connect({
+      cwd: "projects",
+      onMessage: jest.fn(),
+      onStatus: (status) => statuses.push(status),
+    });
+
+    await flushPromises();
+    socket.readyState = MockWebSocket.OPEN;
+    socket.onopen?.();
+
+    await expect(connectPromise).rejects.toThrow("Terminal connection opened before attach could be sent");
+    expect(socket.sent).toEqual([]);
+    expect(statuses).toEqual(["connecting"]);
+    expect(warnSpy).toHaveBeenCalledWith("[mobile] terminal websocket send failed", "Error");
   });
 
   it("opens unauthenticated terminal sockets when the gateway returns no ws token", async () => {

--- a/apps/mobile/__tests__/terminal-client.test.ts
+++ b/apps/mobile/__tests__/terminal-client.test.ts
@@ -189,6 +189,35 @@ describe("mobile terminal client", () => {
     expect(statuses).toEqual(["connecting", "open"]);
   });
 
+  it("does not send attach after a pending connection is closed before open", async () => {
+    const socket = new MockWebSocket();
+    socket.readyState = MockWebSocket.CONNECTING;
+    const gateway = {
+      getWsToken: jest.fn().mockResolvedValue("ws-token"),
+      setWebSocketToken: jest.fn(),
+      openTerminalWebSocket: jest.fn(() => socket as unknown as WebSocket),
+    };
+    const terminalClient = new MobileTerminalClient(gateway as unknown as GatewayClient);
+    const pendingConnections: MobileTerminalConnection[] = [];
+
+    const connectPromise = terminalClient.connect({
+      cwd: "projects",
+      onMessage: jest.fn(),
+      onConnection: (connection) => {
+        pendingConnections.push(connection);
+      },
+    });
+
+    await flushPromises();
+    pendingConnections[0]?.close();
+    socket.readyState = MockWebSocket.OPEN;
+    socket.onopen?.();
+
+    await expect(connectPromise).rejects.toThrow("Terminal connection closed before attach");
+    expect(socket.closed).toBe(true);
+    expect(socket.sent).toEqual([]);
+  });
+
   it("rejects pending connects when a socket closes before attach is sent", async () => {
     const socket = new MockWebSocket();
     socket.readyState = MockWebSocket.CONNECTING;

--- a/apps/mobile/__tests__/terminal-client.test.ts
+++ b/apps/mobile/__tests__/terminal-client.test.ts
@@ -11,7 +11,9 @@ import { jsonResponse } from "./mobile-shell-test-utils";
 const SESSION_ID = "c4319d6a-a24c-4820-a0f8-f6f8a6ce76b9";
 
 class MockWebSocket {
+  static CONNECTING = 0;
   static OPEN = 1;
+  static CLOSED = 3;
   readyState = MockWebSocket.OPEN;
   sent: string[] = [];
   closed = false;
@@ -26,7 +28,14 @@ class MockWebSocket {
 
   close() {
     this.closed = true;
+    this.readyState = MockWebSocket.CLOSED;
+    this.onclose?.();
   }
+}
+
+async function flushPromises() {
+  await Promise.resolve();
+  await Promise.resolve();
 }
 
 describe("mobile terminal client", () => {
@@ -87,7 +96,7 @@ describe("mobile terminal client", () => {
     expect(isSafeSessionId("../bad")).toBe(false);
   });
 
-  it("sends attach, resize, input, and detach frames over the terminal websocket", () => {
+  it("sends attach, resize, input, and detach frames over the terminal websocket", async () => {
     const ws = new MockWebSocket() as unknown as WebSocket;
     const messages: unknown[] = [];
     const statuses: string[] = [];
@@ -100,14 +109,15 @@ describe("mobile terminal client", () => {
       onStatus: (status) => statuses.push(status),
     });
 
-    connection.attach();
+    const attachPromise = connection.attach();
     (ws as unknown as MockWebSocket).onopen?.();
+    await expect(attachPromise).resolves.toBeUndefined();
     connection.sendInput("pwd\r");
     connection.resize(999, 999);
     (ws as unknown as MockWebSocket).onmessage?.({ data: JSON.stringify({ type: "output", data: "ok" }) });
     connection.detach();
 
-    expect(statuses).toEqual(["connecting", "open"]);
+    expect(statuses).toEqual(["connecting", "open", "closed"]);
     expect((ws as unknown as MockWebSocket).sent.map((frame) => JSON.parse(frame))).toEqual([
       { type: "attach", sessionId: SESSION_ID, cwd: "projects" },
       { type: "resize", cols: 220, rows: 70 },
@@ -139,6 +149,70 @@ describe("mobile terminal client", () => {
     );
   });
 
+  it("keeps connect pending until socket open sends the attach frame", async () => {
+    const socket = new MockWebSocket();
+    socket.readyState = MockWebSocket.CONNECTING;
+    const gateway = {
+      getWsToken: jest.fn().mockResolvedValue("ws-token"),
+      setWebSocketToken: jest.fn(),
+      openTerminalWebSocket: jest.fn(() => socket as unknown as WebSocket),
+    };
+    const terminalClient = new MobileTerminalClient(gateway as unknown as GatewayClient);
+    const statuses: string[] = [];
+    let settled = false;
+
+    const connectPromise = terminalClient.connect({
+      cwd: "projects",
+      onMessage: jest.fn(),
+      onStatus: (status) => statuses.push(status),
+    }).then((connection) => {
+      settled = true;
+      return connection;
+    });
+
+    await flushPromises();
+
+    expect(gateway.openTerminalWebSocket).toHaveBeenCalledWith("ws-token");
+    expect(settled).toBe(false);
+    expect(socket.sent).toEqual([]);
+    expect(statuses).toEqual(["connecting"]);
+
+    socket.readyState = MockWebSocket.OPEN;
+    socket.onopen?.();
+
+    await expect(connectPromise).resolves.toBeTruthy();
+    expect(settled).toBe(true);
+    expect(socket.sent.map((frame) => JSON.parse(frame))).toEqual([
+      { type: "attach", cwd: "projects" },
+    ]);
+    expect(statuses).toEqual(["connecting", "open"]);
+  });
+
+  it("rejects pending connects when a socket closes before attach is sent", async () => {
+    const socket = new MockWebSocket();
+    socket.readyState = MockWebSocket.CONNECTING;
+    const gateway = {
+      getWsToken: jest.fn().mockResolvedValue("ws-token"),
+      setWebSocketToken: jest.fn(),
+      openTerminalWebSocket: jest.fn(() => socket as unknown as WebSocket),
+    };
+    const terminalClient = new MobileTerminalClient(gateway as unknown as GatewayClient);
+    const statuses: string[] = [];
+
+    const connectPromise = terminalClient.connect({
+      cwd: "projects",
+      onMessage: jest.fn(),
+      onStatus: (status) => statuses.push(status),
+    });
+
+    await flushPromises();
+    socket.close();
+
+    await expect(connectPromise).rejects.toThrow("Terminal connection closed before attach");
+    expect(socket.sent).toEqual([]);
+    expect(statuses).toEqual(["connecting", "closed"]);
+  });
+
   it("opens unauthenticated terminal sockets when the gateway returns no ws token", async () => {
     const webSocketMock = jest.fn().mockImplementation(() => new MockWebSocket());
     global.WebSocket = webSocketMock as unknown as typeof WebSocket;
@@ -159,7 +233,7 @@ describe("mobile terminal client", () => {
     );
   });
 
-  it("closes sockets before open and uses local ready-state constants", () => {
+  it("closes sockets before open and uses local ready-state constants", async () => {
     const ws = new MockWebSocket() as unknown as WebSocket;
     (ws as unknown as MockWebSocket).readyState = 0;
     const connection = new MobileTerminalConnection(ws, {
@@ -167,9 +241,10 @@ describe("mobile terminal client", () => {
       onMessage: jest.fn(),
     });
 
-    connection.attach();
+    const attachPromise = connection.attach();
     connection.detach();
 
+    await expect(attachPromise).rejects.toThrow("Terminal connection closed before attach");
     expect((ws as unknown as MockWebSocket).closed).toBe(true);
     expect((ws as unknown as MockWebSocket).sent).toEqual([]);
   });

--- a/apps/mobile/__tests__/terminal-screen.test.tsx
+++ b/apps/mobile/__tests__/terminal-screen.test.tsx
@@ -229,6 +229,61 @@ describe("TerminalScreen", () => {
     await waitFor(() => expect(gatewayClient.openTerminalWebSocket).toHaveBeenCalledTimes(1));
   });
 
+  it("keeps duplicate connect actions gated until the terminal socket opens", async () => {
+    global.WebSocket = {
+      CONNECTING: 0,
+      OPEN: 1,
+      CLOSED: 3,
+    } as typeof WebSocket;
+    const socket = new MockTerminalSocket();
+    socket.readyState = WebSocket.CONNECTING;
+    jest.mocked(AsyncStorage.getItem).mockResolvedValue(null);
+    jest.mocked(AsyncStorage.setItem).mockResolvedValue();
+    const gatewayClient = {
+      getTerminalSessions: jest.fn().mockResolvedValue([]),
+      getWsToken: jest.fn().mockResolvedValue("ws-token"),
+      setWebSocketToken: jest.fn(),
+      openTerminalWebSocket: jest.fn(() => socket as unknown as WebSocket),
+      deleteTerminalSession: jest.fn().mockResolvedValue(true),
+    };
+    jest.mocked(useGateway).mockReturnValue({
+      client: gatewayClient as unknown as GatewayClient,
+      connectionState: "connected",
+      gateway: null,
+      setGateway: jest.fn(),
+      unreadCount: 0,
+      incrementUnread: jest.fn(),
+      clearUnread: jest.fn(),
+    });
+
+    render(<TerminalScreen />);
+
+    const newSession = screen.getByLabelText("New session");
+    fireEvent.press(newSession);
+    await waitFor(() => expect(gatewayClient.openTerminalWebSocket).toHaveBeenCalledTimes(1));
+
+    fireEvent.press(newSession);
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(gatewayClient.getWsToken).toHaveBeenCalledTimes(1);
+    expect(gatewayClient.openTerminalWebSocket).toHaveBeenCalledTimes(1);
+    expect(socket.sent).toEqual([]);
+
+    await act(async () => {
+      socket.readyState = WebSocket.OPEN;
+      socket.onopen?.();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(socket.sent.map((frame) => JSON.parse(frame))).toEqual(
+      expect.arrayContaining([{ type: "attach", cwd: "projects" }]),
+    );
+  });
+
   it("keeps terminal recovery state when deleting a session fails", async () => {
     global.WebSocket = {
       OPEN: 1,

--- a/apps/mobile/__tests__/terminal-screen.test.tsx
+++ b/apps/mobile/__tests__/terminal-screen.test.tsx
@@ -284,6 +284,52 @@ describe("TerminalScreen", () => {
     );
   });
 
+  it("closes a pending terminal socket on unmount before late open can attach", async () => {
+    global.WebSocket = {
+      CONNECTING: 0,
+      OPEN: 1,
+      CLOSED: 3,
+    } as typeof WebSocket;
+    const socket = new MockTerminalSocket();
+    socket.readyState = WebSocket.CONNECTING;
+    jest.mocked(AsyncStorage.getItem).mockResolvedValue(null);
+    jest.mocked(AsyncStorage.setItem).mockResolvedValue();
+    const gatewayClient = {
+      getTerminalSessions: jest.fn().mockResolvedValue([]),
+      getWsToken: jest.fn().mockResolvedValue("ws-token"),
+      setWebSocketToken: jest.fn(),
+      openTerminalWebSocket: jest.fn(() => socket as unknown as WebSocket),
+      deleteTerminalSession: jest.fn().mockResolvedValue(true),
+    };
+    jest.mocked(useGateway).mockReturnValue({
+      client: gatewayClient as unknown as GatewayClient,
+      connectionState: "connected",
+      gateway: null,
+      setGateway: jest.fn(),
+      unreadCount: 0,
+      incrementUnread: jest.fn(),
+      clearUnread: jest.fn(),
+    });
+
+    const rendered = render(<TerminalScreen />);
+
+    fireEvent.press(screen.getByLabelText("New session"));
+    await waitFor(() => expect(gatewayClient.openTerminalWebSocket).toHaveBeenCalledTimes(1));
+
+    rendered.unmount();
+
+    expect(socket.closed).toBe(true);
+
+    await act(async () => {
+      socket.readyState = WebSocket.OPEN;
+      socket.onopen?.();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(socket.sent).toEqual([]);
+  });
+
   it("keeps terminal recovery state when deleting a session fails", async () => {
     global.WebSocket = {
       OPEN: 1,

--- a/apps/mobile/app/terminal/index.tsx
+++ b/apps/mobile/app/terminal/index.tsx
@@ -31,6 +31,10 @@ import {
 } from "@/lib/terminal-state";
 import { colors, fonts } from "@/lib/theme";
 
+function closePendingConnection(connection: MobileTerminalConnection | null): void {
+  connection?.close();
+}
+
 export default function TerminalScreen() {
   const router = useRouter();
   const insets = useSafeAreaInsets();
@@ -40,6 +44,7 @@ export default function TerminalScreen() {
   const [lastTerminalSessionId, setLastTerminalSessionId] = useState<string | null>(null);
   const terminalClient = useMemo(() => (client ? new MobileTerminalClient(client) : null), [client]);
   const connectionRef = useRef<MobileTerminalConnection | null>(null);
+  const pendingConnectionRef = useRef<MobileTerminalConnection | null>(null);
   const connectAttemptRef = useRef(0);
   const connectingRef = useRef(false);
   const outputRef = useRef<ScrollView | null>(null);
@@ -71,6 +76,8 @@ export default function TerminalScreen() {
     return () => {
       connectAttemptRef.current += 1;
       connectingRef.current = false;
+      closePendingConnection(pendingConnectionRef.current);
+      pendingConnectionRef.current = null;
       connectionRef.current?.detach();
       connectionRef.current = null;
     };
@@ -133,6 +140,8 @@ export default function TerminalScreen() {
     const attemptId = connectAttemptRef.current + 1;
     connectAttemptRef.current = attemptId;
     connectingRef.current = true;
+    closePendingConnection(pendingConnectionRef.current);
+    pendingConnectionRef.current = null;
     connectionRef.current?.detach();
     connectionRef.current = null;
     dispatch({ type: "connection.changed", status: "connecting" });
@@ -147,6 +156,13 @@ export default function TerminalScreen() {
         onMessage: (frame) => {
           if (connectAttemptRef.current === attemptId) handleFrame(frame);
         },
+        onConnection: (connection) => {
+          if (connectAttemptRef.current === attemptId) {
+            pendingConnectionRef.current = connection;
+            return;
+          }
+          connection.close();
+        },
         onStatus: (status) => {
           if (connectAttemptRef.current !== attemptId) return;
           if (status === "open") dispatch({ type: "connection.changed", status: "attached" });
@@ -159,13 +175,17 @@ export default function TerminalScreen() {
         return;
       }
       if (!nextConnection) {
+        pendingConnectionRef.current = null;
         dispatch({ type: "terminal.error", message: "Terminal unavailable" });
         return;
       }
+      pendingConnectionRef.current = null;
       connectionRef.current = nextConnection;
       inputRef.current?.focus();
     } catch (err: unknown) {
       if (connectAttemptRef.current === attemptId) {
+        closePendingConnection(pendingConnectionRef.current);
+        pendingConnectionRef.current = null;
         console.warn("[mobile] terminal connection failed", err instanceof Error ? err.message : String(err));
         dispatch({ type: "terminal.error", message: "Terminal unavailable" });
         dispatch({ type: "connection.changed", status: "detached" });
@@ -201,6 +221,8 @@ export default function TerminalScreen() {
     }
     connectAttemptRef.current += 1;
     connectingRef.current = false;
+    closePendingConnection(pendingConnectionRef.current);
+    pendingConnectionRef.current = null;
     connectionRef.current?.destroy();
     connectionRef.current = null;
     setLastTerminalSessionId(null);

--- a/apps/mobile/lib/terminal-client.ts
+++ b/apps/mobile/lib/terminal-client.ts
@@ -93,6 +93,7 @@ export class MobileTerminalConnection {
         if (settled) return;
         if (!this.sendFrame(this.attachFrame)) {
           rejectAttach(new Error("Terminal connection opened before attach could be sent"));
+          this.close();
           return;
         }
         this.attached = true;

--- a/apps/mobile/lib/terminal-client.ts
+++ b/apps/mobile/lib/terminal-client.ts
@@ -27,6 +27,7 @@ export interface MobileTerminalConnectOptions {
   rows?: number;
   fromSeq?: number;
   onMessage: (frame: TerminalServerFrame) => void;
+  onConnection?: (connection: MobileTerminalConnection) => void;
   onStatus?: (status: "connecting" | "open" | "closed" | "error") => void;
 }
 
@@ -46,6 +47,7 @@ export class MobileTerminalClient {
     this.gateway.setWebSocketToken(token);
     const ws = this.gateway.openTerminalWebSocket(token);
     const connection = new MobileTerminalConnection(ws, options);
+    options.onConnection?.(connection);
     await connection.attach();
     return connection;
   }
@@ -54,6 +56,7 @@ export class MobileTerminalClient {
 export class MobileTerminalConnection {
   private readonly attachFrame: TerminalClientFrame;
   private attached = false;
+  private cancelled = false;
 
   constructor(
     private readonly ws: WebSocket,
@@ -90,7 +93,7 @@ export class MobileTerminalConnection {
       };
 
       const handleOpen = () => {
-        if (settled) return;
+        if (settled || this.cancelled) return;
         if (!this.sendFrame(this.attachFrame)) {
           rejectAttach(new Error("Terminal connection opened before attach could be sent"));
           this.close();
@@ -148,6 +151,7 @@ export class MobileTerminalConnection {
 
   close(): void {
     if (this.ws.readyState !== WS_CONNECTING && this.ws.readyState !== WS_OPEN) return;
+    this.cancelled = true;
     this.attached = false;
     this.ws.close();
   }

--- a/apps/mobile/lib/terminal-client.ts
+++ b/apps/mobile/lib/terminal-client.ts
@@ -46,7 +46,7 @@ export class MobileTerminalClient {
     this.gateway.setWebSocketToken(token);
     const ws = this.gateway.openTerminalWebSocket(token);
     const connection = new MobileTerminalConnection(ws, options);
-    connection.attach();
+    await connection.attach();
     return connection;
   }
 }
@@ -67,30 +67,56 @@ export class MobileTerminalConnection {
     });
   }
 
-  attach(): void {
+  attach(): Promise<void> {
     this.options.onStatus?.("connecting");
-
-    this.ws.onopen = () => {
-      this.attached = true;
-      this.options.onStatus?.("open");
-      this.sendFrame(this.attachFrame);
-      if (this.options.cols && this.options.rows) {
-        this.resize(this.options.cols, this.options.rows);
-      }
-    };
 
     this.ws.onmessage = (event) => {
       const frame = parseTerminalServerFrame(event.data);
       if (frame) this.options.onMessage(frame);
     };
 
-    this.ws.onerror = () => {
-      this.options.onStatus?.("error");
-    };
+    return new Promise((resolve, reject) => {
+      let settled = false;
+      const resolveAttach = () => {
+        if (settled) return;
+        settled = true;
+        resolve();
+      };
+      const rejectAttach = (error: Error) => {
+        if (settled) return;
+        settled = true;
+        reject(error);
+      };
 
-    this.ws.onclose = () => {
-      this.options.onStatus?.("closed");
-    };
+      const handleOpen = () => {
+        if (settled) return;
+        if (!this.sendFrame(this.attachFrame)) {
+          rejectAttach(new Error("Terminal connection opened before attach could be sent"));
+          return;
+        }
+        this.attached = true;
+        if (this.options.cols && this.options.rows) {
+          this.resize(this.options.cols, this.options.rows);
+        }
+        this.options.onStatus?.("open");
+        resolveAttach();
+      };
+      this.ws.onopen = handleOpen;
+
+      this.ws.onerror = () => {
+        this.options.onStatus?.("error");
+        rejectAttach(new Error("Terminal connection failed before attach"));
+      };
+
+      this.ws.onclose = () => {
+        this.options.onStatus?.("closed");
+        rejectAttach(new Error("Terminal connection closed before attach"));
+      };
+
+      if (this.ws.readyState === WS_OPEN) {
+        handleOpen();
+      }
+    });
   }
 
   sendInput(data: string): boolean {
@@ -106,13 +132,13 @@ export class MobileTerminalConnection {
   }
 
   detach(): boolean {
-    const sent = this.sendFrame({ type: "detach" });
+    const sent = this.attached ? this.sendFrame({ type: "detach" }) : false;
     this.close();
     return sent;
   }
 
   destroy(): boolean {
-    const sent = this.sendFrame({ type: "destroy" });
+    const sent = this.attached ? this.sendFrame({ type: "destroy" }) : false;
     this.close();
     return sent;
   }

--- a/apps/mobile/lib/terminal-client.ts
+++ b/apps/mobile/lib/terminal-client.ts
@@ -77,6 +77,7 @@ export class MobileTerminalConnection {
 
     return new Promise((resolve, reject) => {
       let settled = false;
+      let attachSent = false;
       const resolveAttach = () => {
         if (settled) return;
         settled = true;
@@ -95,6 +96,7 @@ export class MobileTerminalConnection {
           return;
         }
         this.attached = true;
+        attachSent = true;
         if (this.options.cols && this.options.rows) {
           this.resize(this.options.cols, this.options.rows);
         }
@@ -104,12 +106,12 @@ export class MobileTerminalConnection {
       this.ws.onopen = handleOpen;
 
       this.ws.onerror = () => {
-        this.options.onStatus?.("error");
+        if (attachSent) this.options.onStatus?.("error");
         rejectAttach(new Error("Terminal connection failed before attach"));
       };
 
       this.ws.onclose = () => {
-        this.options.onStatus?.("closed");
+        if (!settled || attachSent) this.options.onStatus?.("closed");
         rejectAttach(new Error("Terminal connection closed before attach"));
       };
 
@@ -151,8 +153,13 @@ export class MobileTerminalConnection {
 
   private sendFrame(frame: TerminalClientFrame): boolean {
     if (this.ws.readyState !== WS_OPEN) return false;
-    this.ws.send(JSON.stringify(frame));
-    return true;
+    try {
+      this.ws.send(JSON.stringify(frame));
+      return true;
+    } catch (err: unknown) {
+      console.warn("[mobile] terminal websocket send failed", err instanceof Error ? err.name : typeof err);
+      return false;
+    }
   }
 }
 


### PR DESCRIPTION
## Summary

- Wait for the mobile terminal WebSocket `open` path to send the local attach frame before `MobileTerminalClient.connect()` resolves.
- Keep duplicate terminal connect/session attempts gated while the socket is still CONNECTING.
- Reject pending connects on pre-attach socket close/error and avoid detach/destroy frames for sockets that never attached.
- Address Greptile follow-up findings by avoiding pre-attach error double-dispatch, testing attach-send failure, and using a robust async test flush.
- Close sockets when the local attach-send path fails so rejected connects do not leak an unowned WebSocket.
- Expose pending mobile terminal connections before attach resolves so `TerminalScreen` can close a CONNECTING socket during cleanup/unmount; late `onopen` after cancellation cannot send attach.

## Tests

- `/home/nima/matrix-os/apps/mobile/node_modules/.bin/jest --config apps/mobile/jest.config.js terminal-client.test.ts terminal-screen.test.tsx --runInBand`
- `/home/nima/matrix-os/apps/mobile/node_modules/.bin/tsc --noEmit -p apps/mobile/tsconfig.json`
- `npx react-doctor@latest --verbose --scope changed apps/mobile`
- `./scripts/review/check-patterns.sh`
- `git diff --check`
- `bun run typecheck` not run locally: `bun` is not installed in this shell.
- `bun run test` not run locally: `bun` is not installed in this shell.

## Review/Monitoring

- Ready for CI after focused mobile lifecycle validation.
- CI and Greptile will be monitored again for the latest commit before merge.
- No gateway behavior changes; no backend invariants section required.
