### PR TITLE
fix(mobile): handle terminal replay exit frames

### DIFF
--- a/apps/mobile/__tests__/terminal-client.test.ts
+++ b/apps/mobile/__tests__/terminal-client.test.ts
@@ -119,6 +119,52 @@ describe("mobile terminal client", () => {
     expect((ws as unknown as MockWebSocket).closed).toBe(true);
   });
 
+  it("includes replay cursors in attach frames when resuming an existing session", () => {
+    const ws = new MockWebSocket() as unknown as WebSocket;
+    const connection = new MobileTerminalConnection(ws, {
+      sessionId: SESSION_ID,
+      fromSeq: 42,
+      onMessage: jest.fn(),
+    });
+
+    connection.attach();
+    (ws as unknown as MockWebSocket).onopen?.();
+
+    expect((ws as unknown as MockWebSocket).sent.map((frame) => JSON.parse(frame))).toEqual([
+      { type: "attach", sessionId: SESSION_ID, fromSeq: 42 },
+    ]);
+  });
+
+  it("normalizes gateway replay and exit frames for mobile state handling", () => {
+    const ws = new MockWebSocket() as unknown as WebSocket;
+    const messages: unknown[] = [];
+    const connection = new MobileTerminalConnection(ws, {
+      onMessage: (frame) => messages.push(frame),
+    });
+
+    connection.attach();
+    (ws as unknown as MockWebSocket).onopen?.();
+    (ws as unknown as MockWebSocket).onmessage?.({
+      data: JSON.stringify({ type: "replay-start", fromSeq: 4 }),
+    });
+    (ws as unknown as MockWebSocket).onmessage?.({
+      data: JSON.stringify({ type: "output", data: "resumed\n", seq: 4 }),
+    });
+    (ws as unknown as MockWebSocket).onmessage?.({
+      data: JSON.stringify({ type: "replay-end", toSeq: 5 }),
+    });
+    (ws as unknown as MockWebSocket).onmessage?.({
+      data: JSON.stringify({ type: "exit", code: 7 }),
+    });
+
+    expect(messages).toEqual([
+      { type: "replay-start", fromSeq: 4 },
+      { type: "output", data: "resumed\n", seq: 4 },
+      { type: "replay-end", toSeq: 5 },
+      { type: "exit", exitCode: 7 },
+    ]);
+  });
+
   it("opens terminal sockets with browser-compatible query auth and native bearer headers", async () => {
     const webSocketMock = jest.fn().mockImplementation(() => new MockWebSocket());
     global.WebSocket = webSocketMock as unknown as typeof WebSocket;

--- a/apps/mobile/__tests__/terminal-screen.test.tsx
+++ b/apps/mobile/__tests__/terminal-screen.test.tsx
@@ -186,6 +186,79 @@ describe("TerminalScreen", () => {
     );
   });
 
+  it("reattaches to the active terminal session from the last replay cursor", async () => {
+    global.WebSocket = {
+      OPEN: 1,
+      CLOSED: 3,
+    } as typeof WebSocket;
+    const firstSocket = new MockTerminalSocket();
+    const secondSocket = new MockTerminalSocket();
+    jest.mocked(AsyncStorage.getItem).mockResolvedValue(null);
+    jest.mocked(AsyncStorage.setItem).mockResolvedValue();
+    const gatewayClient = {
+      getTerminalSessions: jest.fn().mockResolvedValue([
+        {
+          sessionId: SESSION_ID,
+          cwd: "/home/matrix/home/projects",
+          state: "running",
+        },
+      ]),
+      getWsToken: jest.fn().mockResolvedValue("ws-token"),
+      setWebSocketToken: jest.fn(),
+      openTerminalWebSocket: jest
+        .fn()
+        .mockReturnValueOnce(firstSocket as unknown as WebSocket)
+        .mockReturnValueOnce(secondSocket as unknown as WebSocket),
+      deleteTerminalSession: jest.fn().mockResolvedValue(true),
+    };
+    jest.mocked(useGateway).mockReturnValue({
+      client: gatewayClient as unknown as GatewayClient,
+      connectionState: "connected",
+      gateway: null,
+      setGateway: jest.fn(),
+      unreadCount: 0,
+      incrementUnread: jest.fn(),
+      clearUnread: jest.fn(),
+    });
+
+    render(<TerminalScreen />);
+
+    await waitFor(() => expect(screen.getByLabelText("Resume ~/projects")).toBeTruthy());
+    fireEvent.press(screen.getByLabelText("Resume ~/projects"));
+    await waitFor(() => expect(gatewayClient.openTerminalWebSocket).toHaveBeenCalledTimes(1));
+
+    await act(async () => {
+      firstSocket.onopen?.();
+      firstSocket.onmessage?.({
+        data: JSON.stringify({
+          type: "attached",
+          sessionId: SESSION_ID,
+          cwd: "/home/matrix/home/projects",
+        }),
+      });
+      firstSocket.onmessage?.({
+        data: JSON.stringify({ type: "output", data: "first\n", seq: 7 }),
+      });
+      firstSocket.onmessage?.({
+        data: JSON.stringify({ type: "replay-end", toSeq: 8 }),
+      });
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    fireEvent.press(screen.getByLabelText("Resume ~/projects"));
+    await waitFor(() => expect(gatewayClient.openTerminalWebSocket).toHaveBeenCalledTimes(2));
+
+    await act(async () => {
+      secondSocket.onopen?.();
+      await Promise.resolve();
+    });
+
+    expect(secondSocket.sent.map((frame) => JSON.parse(frame))).toEqual(
+      expect.arrayContaining([{ type: "attach", sessionId: SESSION_ID, fromSeq: 8 }]),
+    );
+  });
+
   it("ignores duplicate connect actions while a terminal connection is pending", async () => {
     global.WebSocket = {
       OPEN: 1,

--- a/apps/mobile/__tests__/terminal-state.test.ts
+++ b/apps/mobile/__tests__/terminal-state.test.ts
@@ -20,6 +20,43 @@ describe("mobile terminal state", () => {
     expect(state.activeSessionId).toBe("c4319d6a-a24c-4820-a0f8-f6f8a6ce76b9");
     expect(state.cwd).toBe("~/projects/matrix-os");
     expect(state.output).toContain("$ pwd");
+    expect(state.lastSeq).toBeNull();
+  });
+
+  it("accumulates replay output and tracks the next replay cursor", () => {
+    const attached = terminalReducer(initialTerminalState, {
+      type: "terminal.attached",
+      sessionId: "c4319d6a-a24c-4820-a0f8-f6f8a6ce76b9",
+      cwd: "/home/matrix/home/projects",
+    });
+    const withFirstReplayFrame = terminalReducer(attached, {
+      type: "terminal.output",
+      data: "first\n",
+      seq: 4,
+    });
+    const withSecondReplayFrame = terminalReducer(withFirstReplayFrame, {
+      type: "terminal.output",
+      data: "second\n",
+      seq: 5,
+    });
+    const replayComplete = terminalReducer(withSecondReplayFrame, {
+      type: "terminal.replayFinished",
+      toSeq: 6,
+    });
+
+    expect(replayComplete.output).toBe("first\nsecond\n");
+    expect(replayComplete.lastSeq).toBe(5);
+    expect(replayComplete.nextSeq).toBe(6);
+  });
+
+  it("records terminal exit codes from normalized gateway exit frames", () => {
+    const state = terminalReducer(initialTerminalState, {
+      type: "terminal.ended",
+      exitCode: 7,
+    });
+
+    expect(state.status).toBe("ended");
+    expect(state.exitCode).toBe(7);
   });
 
   it("caps terminal output and command input for mobile memory safety", () => {

--- a/apps/mobile/app/terminal/index.tsx
+++ b/apps/mobile/app/terminal/index.tsx
@@ -44,6 +44,15 @@ export default function TerminalScreen() {
   const connectingRef = useRef(false);
   const outputRef = useRef<ScrollView | null>(null);
   const inputRef = useRef<TextInput | null>(null);
+  const cursorRef = useRef<{
+    activeSessionId: string | null;
+    lastSeq: number | null;
+    nextSeq: number | null;
+  }>({
+    activeSessionId: null,
+    lastSeq: null,
+    nextSeq: null,
+  });
 
   const cols = Math.max(40, Math.floor(width / (8 * state.fontScale)));
   const rows = Math.max(18, Math.floor(height / (18 * state.fontScale)));
@@ -81,6 +90,14 @@ export default function TerminalScreen() {
       connectionRef.current?.resize(cols, rows);
     }
   }, [cols, rows, state.status]);
+
+  useEffect(() => {
+    cursorRef.current = {
+      activeSessionId: state.activeSessionId,
+      lastSeq: state.lastSeq,
+      nextSeq: state.nextSeq,
+    };
+  }, [state.activeSessionId, state.lastSeq, state.nextSeq]);
 
   useEffect(() => {
     outputRef.current?.scrollToEnd({ animated: true });
@@ -143,10 +160,14 @@ export default function TerminalScreen() {
 
     let nextConnection: MobileTerminalConnection | null = null;
     try {
+      const cursor = cursorRef.current;
+      const replayFromSeq = sessionId && sessionId === cursor.activeSessionId
+        ? cursor.nextSeq ?? nextSeqFromLastSeq(cursor.lastSeq)
+        : undefined;
       nextConnection = await terminalClient.connect({
         sessionId,
         cwd: sessionId ? undefined : "projects",
-        fromSeq: sessionId && sessionId === state.activeSessionId ? (state.nextSeq ?? undefined) : undefined,
+        fromSeq: replayFromSeq,
         cols,
         rows,
         onMessage: (frame) => {
@@ -180,7 +201,7 @@ export default function TerminalScreen() {
         connectingRef.current = false;
       }
     }
-  }, [cols, handleFrame, rows, state.activeSessionId, state.nextSeq, terminalClient]);
+  }, [cols, handleFrame, rows, terminalClient]);
 
   const sendData = useCallback((data: string) => {
     if (!data) return;
@@ -320,6 +341,12 @@ export default function TerminalScreen() {
       />
     </KeyboardAvoidingView>
   );
+}
+
+function nextSeqFromLastSeq(lastSeq: number | null): number | undefined {
+  if (lastSeq === null || !Number.isSafeInteger(lastSeq) || lastSeq < 0) return undefined;
+  if (lastSeq >= Number.MAX_SAFE_INTEGER) return Number.MAX_SAFE_INTEGER;
+  return lastSeq + 1;
 }
 
 interface TerminalHeaderProps {

--- a/apps/mobile/app/terminal/index.tsx
+++ b/apps/mobile/app/terminal/index.tsx
@@ -109,7 +109,11 @@ export default function TerminalScreen() {
       return;
     }
     if (frame.type === "output") {
-      dispatch({ type: "terminal.output", data: frame.data });
+      dispatch({ type: "terminal.output", data: frame.data, seq: frame.seq });
+      return;
+    }
+    if (frame.type === "replay-end") {
+      dispatch({ type: "terminal.replayFinished", toSeq: frame.toSeq });
       return;
     }
     if (frame.type === "exit") {
@@ -142,6 +146,7 @@ export default function TerminalScreen() {
       nextConnection = await terminalClient.connect({
         sessionId,
         cwd: sessionId ? undefined : "projects",
+        fromSeq: sessionId && sessionId === state.activeSessionId ? (state.nextSeq ?? undefined) : undefined,
         cols,
         rows,
         onMessage: (frame) => {
@@ -175,7 +180,7 @@ export default function TerminalScreen() {
         connectingRef.current = false;
       }
     }
-  }, [cols, handleFrame, rows, terminalClient]);
+  }, [cols, handleFrame, rows, state.activeSessionId, state.nextSeq, terminalClient]);
 
   const sendData = useCallback((data: string) => {
     if (!data) return;

--- a/apps/mobile/lib/terminal-client.ts
+++ b/apps/mobile/lib/terminal-client.ts
@@ -138,49 +138,50 @@ export function buildTerminalWebSocketUrl(baseUrl: string, token?: string | null
 
 function parseTerminalServerFrame(data: unknown): TerminalServerFrame | null {
   if (typeof data !== "string") return null;
+  let frame: Record<string, unknown>;
   try {
-    const frame = JSON.parse(data) as Record<string, unknown>;
-    if (!frame || typeof frame !== "object" || typeof frame.type !== "string") return null;
-    if (frame.type === "attached" && typeof frame.sessionId === "string") {
-      return {
-        type: "attached",
-        sessionId: frame.sessionId,
-        cwd: typeof frame.cwd === "string" ? frame.cwd : undefined,
-        replay: typeof frame.replay === "string" ? frame.replay : undefined,
-      };
-    }
-    if (frame.type === "output" && typeof frame.data === "string") {
-      return {
-        type: "output",
-        data: frame.data,
-        seq: parseTerminalSeq(frame.seq),
-      };
-    }
-    if (frame.type === "replay-start") {
-      return {
-        type: "replay-start",
-        fromSeq: parseTerminalSeq(frame.fromSeq),
-        toSeq: parseTerminalSeq(frame.toSeq),
-      };
-    }
-    if (frame.type === "replay-end") {
-      return {
-        type: "replay-end",
-        toSeq: parseTerminalSeq(frame.toSeq),
-      };
-    }
-    if (frame.type === "exit") {
-      return {
-        type: "exit",
-        exitCode: parseTerminalExitCode(frame.exitCode ?? frame.code),
-      };
-    }
-    if (frame.type === "error") return { type: "error", message: typeof frame.message === "string" ? frame.message : undefined };
-    return null;
+    frame = JSON.parse(data) as Record<string, unknown>;
   } catch (err: unknown) {
     if (err instanceof SyntaxError) return null;
-    return null;
+    throw err;
   }
+  if (!frame || typeof frame !== "object" || typeof frame.type !== "string") return null;
+  if (frame.type === "attached" && typeof frame.sessionId === "string") {
+    return {
+      type: "attached",
+      sessionId: frame.sessionId,
+      cwd: typeof frame.cwd === "string" ? frame.cwd : undefined,
+      replay: typeof frame.replay === "string" ? frame.replay : undefined,
+    };
+  }
+  if (frame.type === "output" && typeof frame.data === "string") {
+    return {
+      type: "output",
+      data: frame.data,
+      seq: parseTerminalSeq(frame.seq),
+    };
+  }
+  if (frame.type === "replay-start") {
+    return {
+      type: "replay-start",
+      fromSeq: parseTerminalSeq(frame.fromSeq),
+      toSeq: parseTerminalSeq(frame.toSeq),
+    };
+  }
+  if (frame.type === "replay-end") {
+    return {
+      type: "replay-end",
+      toSeq: parseTerminalSeq(frame.toSeq),
+    };
+  }
+  if (frame.type === "exit") {
+    return {
+      type: "exit",
+      exitCode: parseTerminalExitCode(frame.exitCode ?? frame.code),
+    };
+  }
+  if (frame.type === "error") return { type: "error", message: typeof frame.message === "string" ? frame.message : undefined };
+  return null;
 }
 
 function parseTerminalSeq(value: unknown): number | undefined {

--- a/apps/mobile/lib/terminal-client.ts
+++ b/apps/mobile/lib/terminal-client.ts
@@ -14,9 +14,9 @@ export type TerminalClientFrame =
 
 export type TerminalServerFrame =
   | { type: "attached"; sessionId: string; cwd?: string; replay?: string }
-  | { type: "output"; data: string }
+  | { type: "output"; data: string; seq?: number }
   | { type: "replay-start"; fromSeq?: number; toSeq?: number }
-  | { type: "replay-end"; nextSeq?: number }
+  | { type: "replay-end"; toSeq?: number }
   | { type: "exit"; exitCode?: number | null }
   | { type: "error"; message?: string };
 
@@ -139,16 +139,59 @@ export function buildTerminalWebSocketUrl(baseUrl: string, token?: string | null
 function parseTerminalServerFrame(data: unknown): TerminalServerFrame | null {
   if (typeof data !== "string") return null;
   try {
-    const frame = JSON.parse(data) as TerminalServerFrame;
+    const frame = JSON.parse(data) as Record<string, unknown>;
     if (!frame || typeof frame !== "object" || typeof frame.type !== "string") return null;
-    if (frame.type === "attached" && typeof frame.sessionId === "string") return frame;
-    if (frame.type === "output" && typeof frame.data === "string") return frame;
-    if (frame.type === "replay-start" || frame.type === "replay-end" || frame.type === "exit") return frame;
+    if (frame.type === "attached" && typeof frame.sessionId === "string") {
+      return {
+        type: "attached",
+        sessionId: frame.sessionId,
+        cwd: typeof frame.cwd === "string" ? frame.cwd : undefined,
+        replay: typeof frame.replay === "string" ? frame.replay : undefined,
+      };
+    }
+    if (frame.type === "output" && typeof frame.data === "string") {
+      return {
+        type: "output",
+        data: frame.data,
+        seq: parseTerminalSeq(frame.seq),
+      };
+    }
+    if (frame.type === "replay-start") {
+      return {
+        type: "replay-start",
+        fromSeq: parseTerminalSeq(frame.fromSeq),
+        toSeq: parseTerminalSeq(frame.toSeq),
+      };
+    }
+    if (frame.type === "replay-end") {
+      return {
+        type: "replay-end",
+        toSeq: parseTerminalSeq(frame.toSeq),
+      };
+    }
+    if (frame.type === "exit") {
+      return {
+        type: "exit",
+        exitCode: parseTerminalExitCode(frame.exitCode ?? frame.code),
+      };
+    }
     if (frame.type === "error") return { type: "error", message: typeof frame.message === "string" ? frame.message : undefined };
     return null;
-  } catch {
+  } catch (err: unknown) {
+    if (err instanceof SyntaxError) return null;
     return null;
   }
+}
+
+function parseTerminalSeq(value: unknown): number | undefined {
+  if (typeof value !== "number" || !Number.isSafeInteger(value) || value < 0) return undefined;
+  return value;
+}
+
+function parseTerminalExitCode(value: unknown): number | null | undefined {
+  if (value === null) return null;
+  if (typeof value !== "number" || !Number.isSafeInteger(value)) return undefined;
+  return value;
 }
 
 function compactFrame<T extends Record<string, unknown>>(frame: T): T {

--- a/apps/mobile/lib/terminal-state.ts
+++ b/apps/mobile/lib/terminal-state.ts
@@ -25,6 +25,9 @@ export interface TerminalState {
   input: string;
   error: string | null;
   fontScale: number;
+  exitCode: number | null;
+  lastSeq: number | null;
+  nextSeq: number | null;
 }
 
 export type TerminalControlKey =
@@ -43,7 +46,8 @@ export type TerminalAction =
   | { type: "connection.changed"; status: TerminalConnectionStatus }
   | { type: "sessions.loaded"; sessions: MobileTerminalSession[] }
   | { type: "terminal.attached"; sessionId: string; cwd?: string; replay?: string }
-  | { type: "terminal.output"; data: string }
+  | { type: "terminal.output"; data: string; seq?: number }
+  | { type: "terminal.replayFinished"; toSeq?: number }
   | { type: "terminal.input"; input: string }
   | { type: "terminal.clearInput" }
   | { type: "terminal.error"; message: string }
@@ -67,6 +71,9 @@ export const initialTerminalState: TerminalState = {
   input: "",
   error: null,
   fontScale: 1,
+  exitCode: null,
+  lastSeq: null,
+  nextSeq: null,
 };
 
 export function terminalReducer(
@@ -92,19 +99,33 @@ export function terminalReducer(
         activeSessionId: activeSessionStillExists ? state.activeSessionId : null,
       };
     }
-    case "terminal.attached":
+    case "terminal.attached": {
+      const sameSession = state.activeSessionId === action.sessionId;
       return {
         ...state,
         status: "attached",
         activeSessionId: action.sessionId,
         cwd: formatTerminalCwd(action.cwd ?? state.cwd),
         output: action.replay ? trimTerminalOutput(action.replay) : state.output,
+        exitCode: null,
+        lastSeq: sameSession ? state.lastSeq : null,
+        nextSeq: sameSession ? state.nextSeq : null,
         error: null,
       };
-    case "terminal.output":
+    }
+    case "terminal.output": {
+      const nextSeq = nextTerminalSeq(action.seq);
       return {
         ...state,
         output: trimTerminalOutput(`${state.output}${action.data}`),
+        lastSeq: maxNullableSeq(state.lastSeq, action.seq),
+        nextSeq: maxNullableSeq(state.nextSeq, nextSeq),
+      };
+    }
+    case "terminal.replayFinished":
+      return {
+        ...state,
+        nextSeq: maxNullableSeq(state.nextSeq, action.toSeq),
       };
     case "terminal.input":
       return { ...state, input: action.input.slice(0, MAX_TERMINAL_INPUT_CHARS) };
@@ -113,7 +134,7 @@ export function terminalReducer(
     case "terminal.error":
       return { ...state, status: "error", error: safeTerminalError(action.message) };
     case "terminal.ended":
-      return { ...state, status: "ended", error: null };
+      return { ...state, status: "ended", exitCode: action.exitCode ?? null, error: null };
     case "font.scale":
       return {
         ...state,
@@ -204,4 +225,15 @@ function safeTerminalError(message: string): string {
 
 function clamp(value: number, min: number, max: number): number {
   return Math.max(min, Math.min(max, value));
+}
+
+function maxNullableSeq(current: number | null, next: number | undefined): number | null {
+  if (typeof next !== "number" || !Number.isSafeInteger(next) || next < 0) return current;
+  return current === null ? next : Math.max(current, next);
+}
+
+function nextTerminalSeq(seq: number | undefined): number | undefined {
+  if (typeof seq !== "number" || !Number.isSafeInteger(seq) || seq < 0) return undefined;
+  if (seq >= Number.MAX_SAFE_INTEGER) return Number.MAX_SAFE_INTEGER;
+  return seq + 1;
 }


### PR DESCRIPTION
## Summary

- Normalize mobile terminal WebSocket frames to the gateway PTY contract: output frames can carry `seq`, replay completion uses `toSeq`, and exit frames normalize gateway `{ type: "exit", code }` into mobile `exitCode`.
- Track `lastSeq`, `nextSeq`, and `exitCode` in mobile terminal reducer state while preserving existing output trimming and session behavior.
- Pass `fromSeq` when reattaching the currently active mobile terminal session so replay resumes from the last observed cursor.
- Add focused regression coverage for replay cursor attach frames, replay output accumulation, exit code normalization, and screen-level active-session reattach.

## Tests

- `pnpm test --runInBand __tests__/terminal-client.test.ts __tests__/terminal-state.test.ts __tests__/terminal-screen.test.tsx` in `apps/mobile` - passed, 25 tests.
- `pnpm exec tsc --noEmit` in `apps/mobile` - passed.
- `npx react-doctor@latest --verbose --scope changed apps/mobile` - passed, 100/100, no issues found. Note: non-verbose project scan reported one pre-existing performance warning, but changed-scope scan is clean.
- `pnpm run check:patterns` - passed with 0 violations and existing scanner warnings outside this PR.
- `bun run typecheck` / `pnpm run typecheck` - blocked because `bun` is not installed in this shell; the root typecheck script invokes `bun run typecheck:build-kernel`.
- `pnpm run test` - failed after a long broad run with unrelated environment/suite failures: 46 failed files / 223 failed tests / 26 errors. Most failures are outside mobile and include sandbox `EPERM` for spawning/listening, e2e gateway listen failures, and app-runtime build timeouts.

## Review/Monitoring

- Draft PR is now ready for review and CI.
- Local focused mobile validation is green.
- CI and Greptile will be monitored after the branch update; any PR-scoped findings will be fixed in follow-up commits.
