### PR TITLE
fix(shell): remove terminal inset and pale divider

### DIFF
--- a/shell/src/components/terminal/TerminalApp.tsx
+++ b/shell/src/components/terminal/TerminalApp.tsx
@@ -1224,6 +1224,7 @@ export function TerminalApp({ initialCommand, initialLabel, initialClaudeMode = 
   // Construct store-compatible interface for child components
   const storeApi = {
     tabs, activeTabId, sidebarOpen, sidebarWidth, sidebarSelectedPath, focusedPaneId, mobile, windowControls,
+    terminalBackground,
     addTab: (...args: Parameters<typeof addTab>) => {
       markTerminalLayoutDirty();
       return addTab(...args);
@@ -1374,6 +1375,7 @@ interface TerminalAppContextType {
   focusedPaneId: string | null;
   mobile: boolean;
   windowControls?: TerminalWindowControls;
+  terminalBackground: string;
   addTab: (cwd: string, label?: string, claude?: boolean, startupCommand?: string) => string;
   addSessionTab: (label: string, sessionId: string, cwd?: string) => string;
   createShellSessionTab: (label: string, cwd?: string) => Promise<string | null>;
@@ -3130,6 +3132,7 @@ function LocalTerminalSidebar() {
   const activeShellName = activePaneSessionId && isCanonicalShellSessionId(activePaneSessionId)
     ? activePaneSessionId
     : null;
+  const terminalDividerColor = ctx.terminalBackground || "#080A08";
   const drawerWidth = ctx.mobile ? "100%" : clampTerminalSidebarWidth(ctx.sidebarWidth);
   const startSidebarResize = (event: ReactPointerEvent<HTMLElement>) => {
     if (ctx.mobile) return;
@@ -3324,6 +3327,7 @@ function LocalTerminalSidebar() {
           <CollapsedSessionsRail
             shells={unfilteredRenderedShells}
             selectedShellName={activeShellName}
+            terminalDividerColor={terminalDividerColor}
             onExpand={() => ctx.setSidebarOpen(true)}
             creatingShell={creatingShell}
             newSessionMenuOpen={newSessionMenuAnchor === "rail"}
@@ -3351,7 +3355,7 @@ function LocalTerminalSidebar() {
         className="shrink-0 overflow-hidden"
         style={{
           background: "#E9E9D8",
-          borderRight: ctx.mobile ? "none" : "1px solid #D6D5C4",
+          borderRight: ctx.mobile ? "none" : `1px solid ${terminalDividerColor}`,
           borderBottom: ctx.mobile ? "1px solid #D6D5C4" : "none",
           color: "#31362D",
           display: "flex",
@@ -3575,7 +3579,7 @@ function LocalTerminalSidebar() {
           onPointerDown={startSidebarResize}
           onKeyDown={resizeSidebarWithKeyboard}
           style={{
-            background: "linear-gradient(to right, transparent 0 2px, #C5C4B4 2px 4px, transparent 4px 8px)",
+            background: `linear-gradient(to right, transparent 0 2px, ${terminalDividerColor} 2px 4px, transparent 4px 8px)`,
             border: 0,
             bottom: 0,
             cursor: "col-resize",
@@ -4124,6 +4128,7 @@ function getShellStatusDotClassName(shell: ShellSessionSummary): string {
 function CollapsedSessionsRail({
   shells,
   selectedShellName,
+  terminalDividerColor,
   onExpand,
   creatingShell,
   newSessionMenuOpen,
@@ -4136,6 +4141,7 @@ function CollapsedSessionsRail({
 }: {
   shells: ShellSessionSummary[];
   selectedShellName: string | null;
+  terminalDividerColor: string;
   onExpand: () => void;
   creatingShell: boolean;
   newSessionMenuOpen: boolean;
@@ -4155,7 +4161,7 @@ function CollapsedSessionsRail({
       style={{
         alignItems: "center",
         background: "#E9E9D8",
-        borderRight: "1px solid #D6D5C4",
+        borderRight: `1px solid ${terminalDividerColor}`,
         color: "#31362D",
         display: "flex",
         flexDirection: "column",

--- a/shell/src/components/terminal/TerminalApp.tsx
+++ b/shell/src/components/terminal/TerminalApp.tsx
@@ -700,9 +700,8 @@ export function TerminalApp({ initialCommand, initialLabel, initialClaudeMode = 
   const theme = useTheme();
   const themeId = useTerminalSettings((s) => s.themeId);
 
-  // Match the padding around the xterm to the active terminal theme so the
-  // user never sees a colored seam between the OS theme bg and the xterm
-  // bg. Falls back to the desktop theme bg when "Match OS" is selected.
+  // Keep shell-controlled terminal surfaces aligned with the active terminal
+  // theme. Falls back to the desktop theme when "Match OS" is selected.
   const terminalPreset = themeId === "system" ? null : getTerminalThemePreset(themeId);
   const terminalBackground =
     themeId === "system"
@@ -1299,8 +1298,8 @@ export function TerminalApp({ initialCommand, initialLabel, initialClaudeMode = 
             <div
               className="flex-1 min-w-0 min-h-0 flex"
               style={{
-                padding: mobile ? "0" : "20px",
-                background: "#1C2019",
+                padding: 0,
+                background: terminalBackground,
                 minHeight: mobile ? 0 : undefined,
               }}
             >

--- a/shell/src/components/terminal/TerminalApp.tsx
+++ b/shell/src/components/terminal/TerminalApp.tsx
@@ -1296,6 +1296,7 @@ export function TerminalApp({ initialCommand, initialLabel, initialClaudeMode = 
           <LocalTerminalSidebar />
           {activeTab ? (
             <div
+              data-testid="terminal-content-surface"
               className="flex-1 min-w-0 min-h-0 flex"
               style={{
                 padding: 0,

--- a/shell/src/components/terminal/TerminalApp.tsx
+++ b/shell/src/components/terminal/TerminalApp.tsx
@@ -3579,7 +3579,7 @@ function LocalTerminalSidebar() {
           onPointerDown={startSidebarResize}
           onKeyDown={resizeSidebarWithKeyboard}
           style={{
-            background: `linear-gradient(to right, transparent 0 2px, ${terminalDividerColor} 2px 4px, transparent 4px 8px)`,
+            background: terminalDividerColor,
             border: 0,
             bottom: 0,
             cursor: "col-resize",

--- a/tests/shell/terminal-app-component.test.tsx
+++ b/tests/shell/terminal-app-component.test.tsx
@@ -1492,7 +1492,8 @@ describe("TerminalApp", () => {
     const resizeHandle = screen.getByRole("button", { name: "Resize sessions drawer" });
 
     expect(sidebarShell.style.borderRight).toBe("1px solid rgb(12, 12, 12)");
-    expect(resizeHandle.style.background).toContain("rgb(12, 12, 12)");
+    expect(resizeHandle.style.background).toBe("rgb(12, 12, 12)");
+    expect(resizeHandle.style.background).not.toContain("transparent");
     expect(resizeHandle.style.background).not.toContain("197, 196, 180");
 
     fireEvent.click(screen.getByRole("button", { name: "Hide sessions drawer" }));

--- a/tests/shell/terminal-app-component.test.tsx
+++ b/tests/shell/terminal-app-component.test.tsx
@@ -1477,6 +1477,29 @@ describe("TerminalApp", () => {
     expect(sidebarShell.style.width).toBe("440px");
   });
 
+  it("uses the terminal background for the sessions drawer terminal-facing divider", async () => {
+    terminalSettingsState.themeId = "dark";
+
+    render(<TerminalApp />);
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    const sidebarShell = screen.getByTestId("terminal-sidebar-shell");
+    const resizeHandle = screen.getByRole("button", { name: "Resize sessions drawer" });
+
+    expect(sidebarShell.style.borderRight).toBe("1px solid rgb(12, 12, 12)");
+    expect(resizeHandle.style.background).toContain("rgb(12, 12, 12)");
+    expect(resizeHandle.style.background).not.toContain("197, 196, 180");
+
+    fireEvent.click(screen.getByRole("button", { name: "Hide sessions drawer" }));
+
+    expect(screen.getByTestId("terminal-collapsed-rail").style.borderRight).toBe("1px solid rgb(12, 12, 12)");
+  });
+
   it("stops terminal drawer resizing when the drag is canceled", async () => {
     render(<TerminalApp />);
 

--- a/tests/shell/terminal-app-component.test.tsx
+++ b/tests/shell/terminal-app-component.test.tsx
@@ -5,8 +5,24 @@ import { act, fireEvent, render, screen, within } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi, afterEach } from "vitest";
 
 const paneGridSpy = vi.fn();
-const { saveThemeSpy } = vi.hoisted(() => ({
+const { saveThemeSpy, terminalSettingsState } = vi.hoisted(() => ({
   saveThemeSpy: vi.fn(async () => {}),
+  terminalSettingsState: {
+    themeId: "system",
+    fontSize: 13,
+    fontFamily: "JetBrains Mono",
+    ligatures: true,
+    cursorStyle: "block",
+    smoothScroll: true,
+    cursorBlink: true,
+    setThemeId: vi.fn(),
+    setFontSize: vi.fn(),
+    setFontFamily: vi.fn(),
+    setLigatures: vi.fn(),
+    setCursorStyle: vi.fn(),
+    setSmoothScroll: vi.fn(),
+    setCursorBlink: vi.fn(),
+  },
 }));
 
 vi.mock("../../shell/src/components/terminal/PaneGrid.js", () => ({
@@ -28,24 +44,8 @@ vi.mock("@/hooks/useTheme", () => ({
 }));
 
 vi.mock("@/stores/terminal-settings", () => {
-  const state = {
-    themeId: "system",
-    fontSize: 13,
-    fontFamily: "JetBrains Mono",
-    ligatures: true,
-    cursorStyle: "block",
-    smoothScroll: true,
-    cursorBlink: true,
-    setThemeId: vi.fn(),
-    setFontSize: vi.fn(),
-    setFontFamily: vi.fn(),
-    setLigatures: vi.fn(),
-    setCursorStyle: vi.fn(),
-    setSmoothScroll: vi.fn(),
-    setCursorBlink: vi.fn(),
-  };
-  const useTerminalSettings = (selector: (value: typeof state) => unknown) => selector(state);
-  useTerminalSettings.getState = () => state;
+  const useTerminalSettings = (selector: (value: typeof terminalSettingsState) => unknown) => selector(terminalSettingsState);
+  useTerminalSettings.getState = () => terminalSettingsState;
 
   return {
     TERMINAL_FONT_FAMILIES: ["MesloLGS NF", "Berkeley Mono", "JetBrains Mono", "Fira Code"],
@@ -110,6 +110,7 @@ describe("TerminalApp", () => {
   beforeEach(() => {
     paneGridSpy.mockReset();
     saveThemeSpy.mockClear();
+    terminalSettingsState.themeId = "system";
     vi.useFakeTimers();
     vi.stubGlobal("ResizeObserver", ResizeObserverMock as unknown as typeof ResizeObserver);
     vi.stubGlobal("fetch", vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
@@ -158,11 +159,28 @@ describe("TerminalApp", () => {
       await Promise.resolve();
     });
 
-    const paneGrid = screen.getByTestId("terminal-pane-grid");
-    const contentSurface = paneGrid.parentElement?.parentElement;
+    expect(screen.getByTestId("terminal-pane-grid")).toBeTruthy();
+    const contentSurface = screen.getByTestId("terminal-content-surface");
 
     expect(contentSurface).toBeInstanceOf(HTMLElement);
-    expect((contentSurface as HTMLElement).style.padding).toBe("0px");
+    expect(contentSurface.style.padding).toBe("0px");
+    expect(contentSurface.style.background).toBe("rgb(28, 32, 25)");
+  });
+
+  it("uses the selected non-system terminal theme background for the flush content surface", async () => {
+    terminalSettingsState.themeId = "dark";
+
+    render(<TerminalApp initialSessionId="canvas-session-123" />);
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    const contentSurface = screen.getByTestId("terminal-content-surface");
+
+    expect(contentSurface.style.padding).toBe("0px");
+    expect(contentSurface.style.background).toBe("rgb(12, 12, 12)");
   });
 
   it("does not immediately save after hydrating a saved terminal layout", async () => {

--- a/tests/shell/terminal-app-component.test.tsx
+++ b/tests/shell/terminal-app-component.test.tsx
@@ -12,7 +12,7 @@ const { saveThemeSpy } = vi.hoisted(() => ({
 vi.mock("../../shell/src/components/terminal/PaneGrid.js", () => ({
   PaneGrid: (props: unknown) => {
     paneGridSpy(props);
-    return null;
+    return <div data-testid="terminal-pane-grid" />;
   },
 }));
 
@@ -148,6 +148,21 @@ describe("TerminalApp", () => {
       type: "pane",
       sessionId: "canvas-session-123",
     });
+  });
+
+  it("renders the desktop terminal pane grid flush without an inset content frame", async () => {
+    render(<TerminalApp initialSessionId="canvas-session-123" />);
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    const paneGrid = screen.getByTestId("terminal-pane-grid");
+    const contentSurface = paneGrid.parentElement?.parentElement;
+
+    expect(contentSurface).toBeInstanceOf(HTMLElement);
+    expect((contentSurface as HTMLElement).style.padding).toBe("0px");
   });
 
   it("does not immediately save after hydrating a saved terminal layout", async () => {


### PR DESCRIPTION
## Summary

- Remove the shell-added desktop terminal content inset so the terminal pane grid renders flush.
- Keep the terminal wrapper background aligned with the active terminal theme instead of a hardcoded greenish frame.
- Use the active terminal background for the sessions drawer terminal-facing border, resize handle stripe, and collapsed rail edge so no pale divider cuts into the terminal surface.
- Add regression coverage for the no-inset content surface, terminal-themed backgrounds, and the dark sidebar divider/resize handle.

## Tests

- `pnpm exec vitest run tests/shell/terminal-app-component.test.tsx --testNamePattern "terminal-facing divider"`
- `pnpm exec vitest run tests/shell/terminal-app-component.test.tsx`
- `pnpm exec vitest run tests/shell/canvas-window-terminal-overlay.test.tsx` (passed; existing React `act(...)` warning emitted by the test)
- `./scripts/review/check-patterns.sh` (0 violations; existing broad warnings only)
- `npx react-doctor@latest shell` (completed with existing broad shell warnings)
- `npx react-doctor@latest --verbose --scope changed shell` (No issues found)
- Replacement connected-terminal screenshot attached in [PR comment](https://github.com/HamedMP/matrix-os/pull/618#issuecomment-4787299394), showing live terminal output plus DOM metrics confirming `padding: "0px"` and matching terminal surface / `.xterm` bounds.
- Updated divider screenshot attached in [PR comment](https://github.com/HamedMP/matrix-os/pull/618#issuecomment-4788544258), showing live terminal output plus DOM metrics confirming `sidebarBorderRight`, terminal surface background, and resize handle stripe all use `rgb(12, 12, 12)`.

## Review/Monitoring

- Initial Greptile review on `910d684b78bde0bb9b3c8946877e5e3d106e0570` was 4/5.
- Follow-up commit `1e02edc921f7c4a574c71ee1b88a54097f2456f9` addresses the fragile DOM traversal and missing background assertion findings.
- Latest pushed commit `051f1ea6` adds the terminal sidebar divider color fix and focused regression coverage; waiting for fresh PR checks/review on that head.

## Invariants

- Source of truth: Terminal visual state remains the existing terminal settings/theme store plus live Zellij/terminal content.
- Lock/transaction scope: Not applicable; this is a shell-rendering-only change with no persistence writes.
- Acceptable orphan states: Not applicable; no new multi-step writes or external state changes.
- Auth source of truth: Unchanged; terminal access/auth paths are not modified.
- Deferred scope: Does not remove Zellij-rendered terminal UI such as its own bottom status bar and does not change sidebar resizing behavior.

## Notes

- `bun` is not installed in this environment (`command -v bun` returned no path), so the full `bun run typecheck` and `bun run test` gates could not be executed locally. The equivalent pattern scanner script was run directly.
