### PR TITLE
fix(vps): surface disk-blocked updates

### DIFF
--- a/distro/customer-vps/host-bin/matrix-sync-agent
+++ b/distro/customer-vps/host-bin/matrix-sync-agent
@@ -334,6 +334,7 @@ apply_update() {
   fi
   rm -rf "$extract_dir" "$bundle_file"
   clean_staging || true
+  restart_sync_agent_after_update
 }
 
 # ── Rollback ─────────────────────────────────────────────────────────
@@ -461,6 +462,13 @@ ensure_update_headroom() {
 }
 
 clean_repairable_tmp_artifacts() {
+  local staging_device tmp_device
+  staging_device="$(df -Pk "$STAGING_DIR" 2>/dev/null | awk 'NR==2 {print $1}')"
+  tmp_device="$(df -Pk /tmp 2>/dev/null | awk 'NR==2 {print $1}')"
+  if [ -n "$staging_device" ] && [ -n "$tmp_device" ] && [ "$staging_device" != "$tmp_device" ]; then
+    log "WARN: /tmp and update staging are on different filesystems; temp cleanup may not free update staging space"
+  fi
+
   local count=0 path
   while IFS= read -r -d '' path; do
     [ -e "$path" ] || continue
@@ -472,6 +480,11 @@ clean_repairable_tmp_artifacts() {
     log "Cleaned $count stale Matrix-owned temp files"
   fi
   return 0
+}
+
+restart_sync_agent_after_update() {
+  log "Restarting sync agent to load updated agent code"
+  sudo systemctl restart --no-block matrix-sync-agent.service || log "WARN: failed to restart matrix-sync-agent.service"
 }
 
 perform_update_repair() {

--- a/distro/customer-vps/host-bin/matrix-sync-agent
+++ b/distro/customer-vps/host-bin/matrix-sync-agent
@@ -6,6 +6,7 @@ set -euo pipefail
 # Env (from host.env):  MATRIX_MACHINE_ID, MATRIX_HOST_BUNDLE_URL, PLATFORM_INTERNAL_URL
 # Trigger files:        /opt/matrix/app/.update-now   — apply pending update
 #                       /opt/matrix/app/.rollback-now  — rollback to previous version
+#                       /opt/matrix/app/.update-repair-now — clean safe temp artifacts and retry
 # Signals:              SIGUSR1 — alternative apply-update trigger
 
 source /opt/matrix/env/host.env
@@ -19,11 +20,17 @@ readonly UPDATE_MARKER="$APP_DIR/.update-available.json"
 readonly UPDATE_TRIGGER="$APP_DIR/.update-now"
 readonly UPDATE_CHANNEL_FILE="$APP_DIR/.update-channel"
 readonly UPDATE_VERSION_FILE="$APP_DIR/.update-version"
+readonly UPDATE_ERROR_MARKER="$APP_DIR/.update-error.json"
+readonly UPDATE_REPAIR_TRIGGER="$APP_DIR/.update-repair-now"
 readonly ROLLBACK_TRIGGER="$APP_DIR/.rollback-now"
 readonly HEALTH_URL="http://127.0.0.1:4000/health"
 readonly AUTO_APPLY_FAILED_MARKER="$APP_DIR/.auto-apply-failed"
 readonly STAGING_ARTIFACT_TTL_SECONDS="${MATRIX_STAGING_ARTIFACT_TTL_SECONDS:-86400}"
 readonly STAGING_CLEANUP_INTERVAL_SECONDS="${MATRIX_STAGING_CLEANUP_INTERVAL_SECONDS:-3600}"
+readonly UPDATE_FREE_BUFFER_KB="${MATRIX_UPDATE_FREE_BUFFER_KB:-1048576}"
+readonly UPDATE_EXPANSION_FACTOR="${MATRIX_UPDATE_EXPANSION_FACTOR:-8}"
+readonly LEGACY_UPGRADE_DIR="/opt/matrix-upgrade"
+readonly LEGACY_UPGRADE_TTL_SECONDS="${MATRIX_LEGACY_UPGRADE_TTL_SECONDS:-86400}"
 readonly SYMPHONY_ENV_FILE="/opt/matrix/env/symphony.env"
 # Keys this agent owns and rewrites on every sync from platform-provided values.
 # Any other key in symphony.env (e.g. an operator-set SYMPHONY_LINEAR_PROJECT_SLUG)
@@ -98,6 +105,33 @@ release_url_for_version() { echo "$(platform_url)/system-bundles/releases/$1.jso
 release_url_for_channel() { echo "$(platform_url)/system-bundles/channels/$1.json"; }
 
 json_field() { python3 -c "import json,sys; print(json.load(sys.stdin).get(sys.argv[1],''))" "$2" <<< "$1"; }
+
+write_update_error() {
+  local code="$1" message="$2" version="${3:-}" available_kb="${4:-}" required_kb="${5:-}"
+  python3 - "$UPDATE_ERROR_MARKER" "$code" "$message" "$version" "$available_kb" "$required_kb" <<'PY'
+import json
+import sys
+from datetime import datetime, timezone
+
+path, code, message, version, available_kb, required_kb = sys.argv[1:7]
+payload = {
+    "code": code,
+    "message": message,
+    "failedAt": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+}
+if version:
+    payload["version"] = version
+for key, value in (("availableKb", available_kb), ("requiredKb", required_kb)):
+    if value:
+        try:
+            payload[key] = int(value)
+        except ValueError:
+            pass
+with open(path, "w", encoding="utf-8") as handle:
+    json.dump(payload, handle, separators=(",", ":"))
+    handle.write("\n")
+PY
+}
 
 fetch_manifest() {
   local url="$1" manifest
@@ -199,7 +233,8 @@ apply_update() {
 
   sudo mkdir -p "$STAGING_DIR"
   sudo chown matrix:matrix "$STAGING_DIR"
-  clean_staging || true
+  ensure_update_headroom "$(json_field "$manifest" size)" "$version" || return 1
+  rm -f "$UPDATE_ERROR_MARKER"
   bundle_file="$STAGING_DIR/bundle-${version}.tar.gz"
   extract_dir="$STAGING_DIR/bundle-${version}"
 
@@ -290,7 +325,7 @@ apply_update() {
   done
   if [ "$healthy" = true ]; then
     log "Health check passed — update to $version complete"
-    rm -f "$UPDATE_MARKER"
+    rm -f "$UPDATE_MARKER" "$UPDATE_ERROR_MARKER"
   else
     log "ERROR: health check failed — rolling back"
     do_rollback
@@ -358,6 +393,96 @@ clean_staging() {
   return 0
 }
 
+clean_staging_now() {
+  [ -d "$STAGING_DIR" ] || return 0
+  local count=0 path
+  while IFS= read -r -d '' path; do
+    [ -e "$path" ] || continue
+    [ ! -L "$path" ] || continue
+    sudo rm -rf -- "$path"
+    count=$((count + 1))
+  done < <(find "$STAGING_DIR" -mindepth 1 -maxdepth 1 \( -name 'failed-*' -o -name 'bundle-*' \) -print0)
+  if [ "$count" -gt 0 ]; then
+    log "Cleaned $count update staging artifacts"
+  fi
+  return 0
+}
+
+clean_legacy_upgrade_artifacts() {
+  [ -d "$LEGACY_UPGRADE_DIR" ] || return 0
+  local count=0 now cutoff path
+  now="$(date +%s)"
+  cutoff=$((now - LEGACY_UPGRADE_TTL_SECONDS))
+  while IFS= read -r -d '' path; do
+    [ -e "$path" ] || continue
+    [ ! -L "$path" ] || continue
+    if [ "$(stat -c %Y "$path" 2>/dev/null || echo "$now")" -gt "$cutoff" ]; then
+      continue
+    fi
+    sudo rm -f -- "$path"
+    count=$((count + 1))
+  done < <(find "$LEGACY_UPGRADE_DIR" -maxdepth 1 -type f \( -name 'matrix-host-bundle.tar.gz' -o -name 'matrix-host-bundle.tar.gz.sha256' \) -print0)
+  if [ "$count" -gt 0 ]; then
+    log "Cleaned $count stale legacy upgrade artifacts"
+  fi
+  return 0
+}
+
+required_update_free_kb() {
+  local bundle_size_bytes="${1:-}"
+  if [ -z "$bundle_size_bytes" ] || [[ "$bundle_size_bytes" == *[!0-9]* ]]; then
+    echo $((UPDATE_FREE_BUFFER_KB + 5242880))
+    return 0
+  fi
+  local bundle_kb
+  bundle_kb=$(((bundle_size_bytes + 1023) / 1024))
+  echo $((bundle_kb * UPDATE_EXPANSION_FACTOR + UPDATE_FREE_BUFFER_KB))
+}
+
+ensure_update_headroom() {
+  local bundle_size_bytes="${1:-}" version="${2:-}"
+  clean_staging || true
+  clean_legacy_upgrade_artifacts || true
+
+  local available required
+  required="$(required_update_free_kb "$bundle_size_bytes")"
+  available="$(df -Pk "$STAGING_DIR" | awk 'NR==2 {print $4}')"
+  if [ -z "$available" ]; then
+    log "WARN: could not determine free disk space before update"
+    return 0
+  fi
+  if [ "$available" -lt "$required" ]; then
+    log "ERROR: insufficient disk space for update (available: ${available}KB, required: ${required}KB)"
+    write_update_error "insufficient_disk_space" "Not enough free disk space to install this update." "$version" "$available" "$required"
+    return 1
+  fi
+  log "Update disk headroom OK (available: ${available}KB, required: ${required}KB)"
+  return 0
+}
+
+clean_repairable_tmp_artifacts() {
+  local count=0 path
+  while IFS= read -r -d '' path; do
+    [ -e "$path" ] || continue
+    [ ! -L "$path" ] || continue
+    sudo rm -f -- "$path"
+    count=$((count + 1))
+  done < <(find /tmp -xdev -user matrix -type f -mtime +1 \( -name '*.so' -o -path '/tmp/node-compile-cache/*' \) -print0)
+  if [ "$count" -gt 0 ]; then
+    log "Cleaned $count stale Matrix-owned temp files"
+  fi
+  return 0
+}
+
+perform_update_repair() {
+  log "Starting safe update repair cleanup"
+  clean_staging_now || true
+  clean_legacy_upgrade_artifacts || true
+  clean_repairable_tmp_artifacts || true
+  rm -f "$UPDATE_ERROR_MARKER"
+  log "Repair complete; retrying pending update"
+}
+
 last_staging_cleanup=0
 
 maybe_clean_staging() {
@@ -374,6 +499,7 @@ maybe_clean_staging() {
 log "Started for ${MATRIX_MACHINE_ID} (version: $(current_version))"
 mkdir -p "$STAGING_DIR"
 clean_staging
+clean_legacy_upgrade_artifacts || true
 last_staging_cleanup="$(date +%s)"
 
 while true; do
@@ -396,6 +522,20 @@ while true; do
     sudo rm -f "$ROLLBACK_TRIGGER"
     do_rollback || log "Rollback failed"
   fi
+  if [ -f "$UPDATE_REPAIR_TRIGGER" ]; then
+    sudo rm -f "$UPDATE_REPAIR_TRIGGER"
+    perform_update_repair
+    if prepare_triggered_update; then
+      if apply_update; then
+        rm -f "$UPDATE_CHANNEL_FILE" "$UPDATE_VERSION_FILE"
+      else
+        log "Update repair retry failed — will retry on next trigger"
+      fi
+    else
+      log "Requested release metadata fetch failed after repair — skipping apply"
+      rm -f "$UPDATE_MARKER"
+    fi
+  fi
   if [ "$update_requested" = true ]; then
     update_requested=false
     if prepare_triggered_update; then
@@ -417,7 +557,7 @@ while true; do
   # Sleep in 6s increments (50x = 5 min) so we react quickly to triggers
   for _ in $(seq 1 50); do
     sleep 6
-    if [ -f "$UPDATE_TRIGGER" ] || [ -f "$ROLLBACK_TRIGGER" ] || [ "$update_requested" = true ]; then
+    if [ -f "$UPDATE_TRIGGER" ] || [ -f "$ROLLBACK_TRIGGER" ] || [ -f "$UPDATE_REPAIR_TRIGGER" ] || [ "$update_requested" = true ]; then
       break
     fi
   done

--- a/distro/customer-vps/host-bin/matrix-update
+++ b/distro/customer-vps/host-bin/matrix-update
@@ -4,6 +4,7 @@ set -euo pipefail
 # matrix-update — trigger the sync agent to apply an update or rollback.
 # Usage: matrix-update                    Apply pending update
 #        matrix-update <channel|version>  Apply selected channel/version
+#        matrix-update repair             Clean safe temp artifacts and retry
 #        matrix-update rollback           Rollback to previous version
 
 write_update_target() {
@@ -18,7 +19,7 @@ write_update_target() {
       rm -f /opt/matrix/app/.update-channel
       ;;
     *)
-      echo "Usage: matrix-update [apply|rollback|stable|canary|beta|dev|v<version>|main-<build>]" >&2
+      echo "Usage: matrix-update [apply|rollback|repair|stable|canary|beta|dev|v<version>|main-<build>]" >&2
       exit 1
       ;;
   esac
@@ -36,13 +37,17 @@ case "${1:-apply}" in
     touch /opt/matrix/app/.rollback-now
     echo "Rollback triggered. Tailing sync-agent log (Ctrl-C to stop)..."
     ;;
+  repair)
+    touch /opt/matrix/app/.update-repair-now
+    echo "Update repair triggered. Tailing sync-agent log (Ctrl-C to stop)..."
+    ;;
   stable|canary|beta|dev|v[0-9]*|main-[A-Za-z0-9]*)
     write_update_target "$1"
     touch /opt/matrix/app/.update-now
     echo "Update to $1 triggered. Tailing sync-agent log (Ctrl-C to stop)..."
     ;;
   *)
-    echo "Usage: matrix-update [apply|rollback|stable|canary|beta|dev|v<version>|main-<build>]" >&2
+    echo "Usage: matrix-update [apply|rollback|repair|stable|canary|beta|dev|v<version>|main-<build>]" >&2
     exit 1
     ;;
 esac

--- a/distro/customer-vps/host-bin/matrix-update
+++ b/distro/customer-vps/host-bin/matrix-update
@@ -6,6 +6,13 @@ set -euo pipefail
 #        matrix-update <channel|version>  Apply selected channel/version
 #        matrix-update repair             Clean safe temp artifacts and retry
 #        matrix-update rollback           Rollback to previous version
+#        matrix-update --no-tail repair   Trigger repair without following logs
+
+tail_logs=1
+if [ "${1:-}" = "--no-tail" ]; then
+  tail_logs=0
+  shift
+fi
 
 write_update_target() {
   local target="$1"
@@ -19,7 +26,7 @@ write_update_target() {
       rm -f /opt/matrix/app/.update-channel
       ;;
     *)
-      echo "Usage: matrix-update [apply|rollback|repair|stable|canary|beta|dev|v<version>|main-<build>]" >&2
+      echo "Usage: matrix-update [--no-tail] [apply|rollback|repair|stable|canary|beta|dev|v<version>|main-<build>]" >&2
       exit 1
       ;;
   esac
@@ -47,9 +54,13 @@ case "${1:-apply}" in
     echo "Update to $1 triggered. Tailing sync-agent log (Ctrl-C to stop)..."
     ;;
   *)
-    echo "Usage: matrix-update [apply|rollback|repair|stable|canary|beta|dev|v<version>|main-<build>]" >&2
+    echo "Usage: matrix-update [--no-tail] [apply|rollback|repair|stable|canary|beta|dev|v<version>|main-<build>]" >&2
     exit 1
     ;;
 esac
+
+if [ "$tail_logs" -eq 0 ]; then
+  exit 0
+fi
 
 exec journalctl -u matrix-sync-agent -f --no-pager -n 20

--- a/packages/gateway/src/server.ts
+++ b/packages/gateway/src/server.ts
@@ -117,9 +117,11 @@ import {
   checkForSystemUpdate,
   listSystemReleases,
   parseInternalUpgradeTarget,
+  readSystemUpdateFailure,
   resolveInternalUpgradeStartTarget,
   resolveSystemUpdateChannel,
   startSystemUpdate,
+  startSystemUpdateRepair,
   writeInternalUpgradeTrigger,
 } from "./system-update.js";
 import { createInteractionLogger, type InteractionLogger } from "./logger.js";
@@ -4017,7 +4019,8 @@ export async function createGateway(config: GatewayConfig) {
       platformUrl: process.env.MATRIX_UPDATE_MANIFEST_BASE_URL ?? process.env.PLATFORM_INTERNAL_URL,
       channel,
     });
-    return c.json(result);
+    const installError = await readSystemUpdateFailure();
+    return c.json({ ...result, installError });
   });
 
   app.get("/api/system/releases", async (c) => {
@@ -4086,6 +4089,23 @@ export async function createGateway(config: GatewayConfig) {
   }
 
   app.post("/api/system/update", upgradeBodyLimit, startUpdateFromRequest);
+
+  app.post("/api/system/update/repair", upgradeBodyLimit, async (c) => {
+    const result = await startSystemUpdateRepair();
+    if (!result.ok) {
+      return c.json({ error: "Update repair not configured" }, 503);
+    }
+    void posthogErrorTracker.captureEvent("matrix_system_update_repair_requested", {
+      distinctId: ownerTelemetryDistinctId,
+      properties: {
+        handle: process.env.MATRIX_HANDLE,
+      },
+    }).catch((err: unknown) => {
+      const kind = err instanceof Error ? err.name : typeof err;
+      console.warn(`[posthog] Failed to queue system update repair event: ${kind}`);
+    });
+    return c.json({ ok: true, status: result.status }, 202);
+  });
 
   app.post("/api/system/upgrade", upgradeBodyLimit, async (c) => {
     return startUpdateFromRequest(c);

--- a/packages/gateway/src/system-update.ts
+++ b/packages/gateway/src/system-update.ts
@@ -437,7 +437,7 @@ export async function startSystemUpdateRepair(options: {
   }
 
   const spawnImpl = options.spawnImpl ?? spawn;
-  const child = spawnImpl("sudo", ["-n", updateCommand, "repair"], {
+  const child = spawnImpl("sudo", ["-n", updateCommand, "--no-tail", "repair"], {
     detached: true,
     stdio: "ignore",
     env: process.env,

--- a/packages/gateway/src/system-update.ts
+++ b/packages/gateway/src/system-update.ts
@@ -1,4 +1,4 @@
-import { access, mkdir, rm, writeFile } from "node:fs/promises";
+import { access, mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import { constants } from "node:fs";
 import { spawn, type ChildProcess } from "node:child_process";
 import { join } from "node:path";
@@ -51,6 +51,7 @@ export interface SystemUpdateCheck {
   updateAvailable: boolean;
   checkedAt: string;
   error?: string;
+  installError?: SystemUpdateFailure | null;
 }
 
 export interface SystemReleaseList {
@@ -61,6 +62,16 @@ export interface SystemReleaseList {
 }
 
 export type UpdateChannel = "stable" | "canary" | "beta" | "dev";
+
+export interface SystemUpdateFailure {
+  code: "insufficient_disk_space" | "update_failed";
+  message: string;
+  version?: string;
+  availableKb?: number;
+  requiredKb?: number;
+  failedAt?: string;
+  repairAvailable: boolean;
+}
 
 export function parseUpdateChannel(value: unknown): UpdateChannel | null {
   if (typeof value !== "string") return null;
@@ -215,6 +226,50 @@ function isExpectedAccessFailure(err: unknown): boolean {
   return code === "ENOENT" || code === "EACCES" || code === "EPERM" || code === "ENOTDIR";
 }
 
+function finiteNumber(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) && value >= 0 ? value : undefined;
+}
+
+function boundedString(value: unknown, maxLength: number): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  if (!trimmed || trimmed.length > maxLength) return undefined;
+  return trimmed;
+}
+
+export async function readSystemUpdateFailure(options: {
+  appDir?: string;
+  readFileImpl?: typeof readFile;
+} = {}): Promise<SystemUpdateFailure | null> {
+  const appDir = options.appDir ?? process.env.MATRIX_APP_DIR ?? "/opt/matrix/app";
+  const readFileImpl = options.readFileImpl ?? readFile;
+  let data: unknown;
+  try {
+    data = JSON.parse(await readFileImpl(join(appDir, ".update-error.json"), "utf8"));
+  } catch (err: unknown) {
+    if (isExpectedAccessFailure(err) || err instanceof SyntaxError) return null;
+    console.warn(
+      "[system-update] Failed to read update failure marker:",
+      err instanceof Error ? err.message : String(err),
+    );
+    return null;
+  }
+  if (!data || typeof data !== "object" || Array.isArray(data)) return null;
+  const record = data as Record<string, unknown>;
+  const rawCode = record.code === "insufficient_disk_space" ? "insufficient_disk_space" : "update_failed";
+  return {
+    code: rawCode,
+    message: rawCode === "insufficient_disk_space"
+      ? "Not enough free disk space to install this update."
+      : "Update failed.",
+    version: parseUpdateVersion(record.version) ?? undefined,
+    availableKb: finiteNumber(record.availableKb),
+    requiredKb: finiteNumber(record.requiredKb),
+    failedAt: boundedString(record.failedAt, 40),
+    repairAvailable: rawCode === "insufficient_disk_space",
+  };
+}
+
 export async function fetchHostBundleChannelManifest(options: {
   platformUrl: string;
   channel: UpdateChannel;
@@ -356,6 +411,33 @@ export async function startSystemUpdate(options: {
 
   const spawnImpl = options.spawnImpl ?? spawn;
   const child = spawnImpl("sudo", ["-n", updateCommand, target.value], {
+    detached: true,
+    stdio: "ignore",
+    env: process.env,
+  }) as ChildProcess;
+  child.unref();
+  return { ok: true, status: "started" };
+}
+
+export async function startSystemUpdateRepair(options: {
+  updateCommand?: string;
+  spawnImpl?: typeof spawn;
+} = {}): Promise<{ ok: true; status: "started" } | { ok: false; status: "not_configured" }> {
+  const updateCommand = options.updateCommand ?? process.env.MATRIX_UPDATE_COMMAND ?? "/opt/matrix/bin/matrix-update";
+  try {
+    await access(updateCommand, constants.X_OK);
+  } catch (err: unknown) {
+    if (!isExpectedAccessFailure(err)) {
+      console.warn(
+        "[system-update] Failed to check updater repair command:",
+        err instanceof Error ? err.message : String(err),
+      );
+    }
+    return { ok: false, status: "not_configured" };
+  }
+
+  const spawnImpl = options.spawnImpl ?? spawn;
+  const child = spawnImpl("sudo", ["-n", updateCommand, "repair"], {
     detached: true,
     stdio: "ignore",
     env: process.env,

--- a/shell/src/components/settings/sections/SystemSection.tsx
+++ b/shell/src/components/settings/sections/SystemSection.tsx
@@ -5,7 +5,7 @@ import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Separator } from "@/components/ui/separator";
 import { getGatewayUrl } from "@/lib/gateway";
-import { MonitorIcon, ActivityIcon, InfoIcon, ArrowUpCircleIcon, CloudIcon, Code2Icon } from "lucide-react";
+import { MonitorIcon, ActivityIcon, InfoIcon, ArrowUpCircleIcon, CloudIcon, Code2Icon, AlertTriangleIcon } from "lucide-react";
 
 const GATEWAY = getGatewayUrl();
 const SETTINGS_FETCH_TIMEOUT_MS = 10_000;
@@ -59,6 +59,15 @@ interface SystemUpdateStatus {
   updateAvailable?: boolean;
   checkedAt?: string;
   error?: string;
+  installError?: {
+    code?: string;
+    message?: string;
+    version?: string;
+    availableKb?: number;
+    requiredKb?: number;
+    failedAt?: string;
+    repairAvailable?: boolean;
+  } | null;
 }
 
 interface SystemRelease {
@@ -85,6 +94,7 @@ import {
   formatReleaseBuildId,
   formatReleaseBuildShortId,
   releaseActionLabel,
+  resolveUpdateFailureNotice,
   resolveUpgradeInstallCopy,
   severityBadgeStyle,
   resolveSystemUpdateState,
@@ -107,6 +117,7 @@ export function SystemSection({ billingActive = true }: { billingActive?: boolea
   const [releaseList, setReleaseList] = useState<SystemReleaseList | null>(null);
   const [releaseLoading, setReleaseLoading] = useState(false);
   const [upgrading, setUpgrading] = useState(false);
+  const [repairingUpdate, setRepairingUpdate] = useState(false);
   const [installingTarget, setInstallingTarget] = useState<string | null>(null);
   const [upgradeError, setUpgradeError] = useState<string | null>(null);
   const [upgradeMessage, setUpgradeMessage] = useState<string | null>(null);
@@ -211,6 +222,7 @@ export function SystemSection({ billingActive = true }: { billingActive?: boolea
     message: upgradeMessage,
     statusIndex: upgradeWaitingIndex,
   });
+  const updateFailureNotice = resolveUpdateFailureNotice(updateStatus?.installError);
 
   const waitForInstalledUpdate = async (
     target: { channel?: ReleaseChannel; version?: string },
@@ -317,6 +329,51 @@ export function SystemSection({ billingActive = true }: { billingActive?: boolea
 
   const handleUpgrade = async () => {
     await startUpdate({ channel: selectedChannel });
+  };
+
+  const handleRepairUpdate = async () => {
+    if (!billingActive) {
+      setUpgradeError("System upgrades are locked until billing is active.");
+      return;
+    }
+    const failedVersion = updateStatus?.installError?.version;
+    const targetKey = failedVersion ?? latestVersion ?? selectedChannel;
+    setRepairingUpdate(true);
+    setUpgrading(true);
+    setInstallingTarget(targetKey);
+    setUpgradeWaitingIndex(0);
+    setUpgradeError(null);
+    setUpgradeMessage("Cleaning safe temporary files and retrying the update...");
+    try {
+      const res = await fetch(`${GATEWAY}/api/system/update/repair`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({}),
+        signal: AbortSignal.timeout(SETTINGS_FETCH_TIMEOUT_MS),
+      });
+      if (!res.ok) {
+        setUpgradeError("Update cleanup could not start.");
+        setUpgradeMessage(null);
+        setUpgrading(false);
+        setInstallingTarget(null);
+        setRepairingUpdate(false);
+        return;
+      }
+    } catch (err: unknown) {
+      console.warn("[system-settings] update repair request interrupted:", err instanceof Error ? err.message : String(err));
+      setUpgradeMessage("Cleanup started. Waiting for the update to finish...");
+    }
+    setRepairingUpdate(false);
+
+    const installed = await waitForInstalledUpdate(failedVersion ? { version: failedVersion } : { channel: selectedChannel });
+    if (!mountedRef.current) return;
+    if (!installed) {
+      setUpgradeMessage(null);
+      setUpgradeError("Update cleanup started, but the install has not finished yet.");
+      setUpgrading(false);
+      setInstallingTarget(null);
+      void refreshReleaseData(selectedChannel);
+    }
   };
 
   return (
@@ -447,6 +504,33 @@ export function SystemSection({ billingActive = true }: { billingActive?: boolea
             <p className="text-xs text-red-600 font-medium pt-1">
               This is a security update scheduled for automatic installation. Use the button below if it hasn't taken effect.
             </p>
+          )}
+          {updateFailureNotice && (
+            <div className={`rounded-lg border p-3 ${
+              updateFailureNotice.tone === "warning"
+                ? "border-amber-500/25 bg-amber-500/10 text-amber-800 dark:text-amber-300"
+                : "border-red-500/25 bg-red-500/10 text-red-700 dark:text-red-300"
+            }`}>
+              <div className="flex items-start gap-2">
+                <AlertTriangleIcon className="mt-0.5 size-4 shrink-0" aria-hidden="true" />
+                <div className="min-w-0 flex-1 space-y-2">
+                  <div className="space-y-1">
+                    <p className="text-sm font-medium">{updateFailureNotice.title}</p>
+                    <p className="text-xs leading-5">{updateFailureNotice.detail}</p>
+                  </div>
+                  {updateFailureNotice.actionLabel && (
+                    <button
+                      type="button"
+                      onClick={() => void handleRepairUpdate()}
+                      disabled={upgrading || repairingUpdate || systemUpdatesLocked}
+                      className="inline-flex items-center justify-center rounded-md border border-current/30 px-3 py-1.5 text-xs font-medium hover:bg-background/60 transition-colors disabled:opacity-50"
+                    >
+                      {repairingUpdate ? "Starting cleanup..." : updateFailureNotice.actionLabel}
+                    </button>
+                  )}
+                </div>
+              </div>
+            </div>
           )}
           {upgradeError && (
             <p className="text-xs text-red-500">{upgradeError}</p>

--- a/shell/src/components/settings/sections/SystemSection.tsx
+++ b/shell/src/components/settings/sections/SystemSection.tsx
@@ -361,7 +361,12 @@ export function SystemSection({ billingActive = true }: { billingActive?: boolea
       }
     } catch (err: unknown) {
       console.warn("[system-settings] update repair request interrupted:", err instanceof Error ? err.message : String(err));
-      setUpgradeMessage("Cleanup started. Waiting for the update to finish...");
+      setUpgradeError("Update cleanup could not start. Please try again.");
+      setUpgradeMessage(null);
+      setUpgrading(false);
+      setInstallingTarget(null);
+      setRepairingUpdate(false);
+      return;
     }
     setRepairingUpdate(false);
 

--- a/shell/src/components/settings/sections/system-update-state.ts
+++ b/shell/src/components/settings/sections/system-update-state.ts
@@ -135,6 +135,12 @@ function formatGbFromKb(kb: number): string {
   return `${(kb / 1024 / 1024).toFixed(1)} GB`;
 }
 
+function safeUpdateFailureMessage(message: string | undefined): string {
+  return message === "Not enough free disk space to install this update." || message === "Update failed."
+    ? message
+    : "Update failed.";
+}
+
 export function resolveUpdateFailureNotice(input: UpdateFailureInput | null | undefined): {
   tone: "warning" | "error";
   title: string;
@@ -158,7 +164,7 @@ export function resolveUpdateFailureNotice(input: UpdateFailureInput | null | un
   return {
     tone: "error",
     title: "Update failed",
-    detail: input.message && input.message.length <= 120 ? input.message : "Update failed.",
+    detail: safeUpdateFailureMessage(input.message),
     actionLabel: null,
   };
 }

--- a/shell/src/components/settings/sections/system-update-state.ts
+++ b/shell/src/components/settings/sections/system-update-state.ts
@@ -123,6 +123,46 @@ export function resolveUpgradeInstallCopy(input: {
   };
 }
 
+export interface UpdateFailureInput {
+  code?: string;
+  message?: string;
+  availableKb?: number;
+  requiredKb?: number;
+  repairAvailable?: boolean;
+}
+
+function formatGbFromKb(kb: number): string {
+  return `${(kb / 1024 / 1024).toFixed(1)} GB`;
+}
+
+export function resolveUpdateFailureNotice(input: UpdateFailureInput | null | undefined): {
+  tone: "warning" | "error";
+  title: string;
+  detail: string;
+  actionLabel: string | null;
+} | null {
+  if (!input) return null;
+  if (input.code === "insufficient_disk_space") {
+    const missingKb = typeof input.requiredKb === "number" && typeof input.availableKb === "number"
+      ? Math.max(0, input.requiredKb - input.availableKb)
+      : null;
+    return {
+      tone: "warning",
+      title: "Not enough disk space",
+      detail: missingKb && missingKb > 0
+        ? `Free about ${formatGbFromKb(missingKb)} before retrying the update.`
+        : "Free disk space before retrying the update.",
+      actionLabel: input.repairAvailable ? "Clean Up and Retry" : null,
+    };
+  }
+  return {
+    tone: "error",
+    title: "Update failed",
+    detail: input.message && input.message.length <= 120 ? input.message : "Update failed.",
+    actionLabel: null,
+  };
+}
+
 export function resolveSystemUpdateState(input: {
   installedVersion?: string;
   latestVersion?: string | null;

--- a/tests/gateway/system-update.test.ts
+++ b/tests/gateway/system-update.test.ts
@@ -12,7 +12,9 @@ import {
   parseUpdateVersion,
   resolveInternalUpgradeStartTarget,
   resolveSystemUpdateChannel,
+  readSystemUpdateFailure,
   startSystemUpdate,
+  startSystemUpdateRepair,
   writeInternalUpgradeTrigger,
 } from "../../packages/gateway/src/system-update.js";
 
@@ -140,6 +142,42 @@ describe("system update checks", () => {
       expect(readFileSync(join(appDir, ".update-channel"), "utf8")).toBe("canary");
       expect(existsSync(join(appDir, ".update-version"))).toBe(false);
       expect(readFileSync(join(appDir, ".update-now"), "utf8")).toBe("");
+    } finally {
+      rmSync(appDir, { recursive: true, force: true });
+    }
+  });
+
+  it("reads sanitized update failure details for low disk failures", async () => {
+    const appDir = mkdtempSync(join(tmpdir(), "matrix-upgrade-"));
+    try {
+      writeFileSync(join(appDir, ".update-error.json"), JSON.stringify({
+        code: "insufficient_disk_space",
+        message: "tar: /secret/path: No space left on device",
+        version: "v2026.06.23-467",
+        availableKb: 3584640,
+        requiredKb: 8232960,
+        failedAt: "2026-06-24T08:14:31Z",
+      }));
+
+      await expect(readSystemUpdateFailure({ appDir })).resolves.toEqual({
+        code: "insufficient_disk_space",
+        message: "Not enough free disk space to install this update.",
+        version: "v2026.06.23-467",
+        availableKb: 3584640,
+        requiredKb: 8232960,
+        failedAt: "2026-06-24T08:14:31Z",
+        repairAvailable: true,
+      });
+    } finally {
+      rmSync(appDir, { recursive: true, force: true });
+    }
+  });
+
+  it("ignores malformed update failure marker contents", async () => {
+    const appDir = mkdtempSync(join(tmpdir(), "matrix-upgrade-"));
+    try {
+      writeFileSync(join(appDir, ".update-error.json"), "{ nope");
+      await expect(readSystemUpdateFailure({ appDir })).resolves.toBeNull();
     } finally {
       rmSync(appDir, { recursive: true, force: true });
     }
@@ -310,6 +348,29 @@ describe("system update start", () => {
       expect(spawnImpl).toHaveBeenCalledWith(
         "sudo",
         ["-n", updateCommand, "v2026.05.12-1"],
+        expect.objectContaining({ detached: true, stdio: "ignore" }),
+      );
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("starts safe update repair through sudo without launching a shell", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "matrix-update-"));
+    const updateCommand = join(dir, "matrix-update");
+    writeFileSync(updateCommand, "#!/bin/sh\n", { mode: 0o755 });
+    const spawnImpl = vi.fn().mockReturnValue({ unref: vi.fn() });
+
+    try {
+      const result = await startSystemUpdateRepair({
+        updateCommand,
+        spawnImpl,
+      });
+
+      expect(result).toEqual({ ok: true, status: "started" });
+      expect(spawnImpl).toHaveBeenCalledWith(
+        "sudo",
+        ["-n", updateCommand, "repair"],
         expect.objectContaining({ detached: true, stdio: "ignore" }),
       );
     } finally {

--- a/tests/gateway/system-update.test.ts
+++ b/tests/gateway/system-update.test.ts
@@ -370,7 +370,7 @@ describe("system update start", () => {
       expect(result).toEqual({ ok: true, status: "started" });
       expect(spawnImpl).toHaveBeenCalledWith(
         "sudo",
-        ["-n", updateCommand, "repair"],
+        ["-n", updateCommand, "--no-tail", "repair"],
         expect.objectContaining({ detached: true, stdio: "ignore" }),
       );
     } finally {

--- a/tests/platform/customer-vps-host-bundle.test.ts
+++ b/tests/platform/customer-vps-host-bundle.test.ts
@@ -476,9 +476,11 @@ test "$(readlink "$MATRIX_LEGACY_HOME/.hermes")" = "$MATRIX_HOME/.hermes"
     expect(updater).toContain('/opt/matrix/app/.update-version');
     expect(updater).toContain('touch /opt/matrix/app/.update-now');
     expect(updater).toContain('touch /opt/matrix/app/.rollback-now');
+    expect(updater).toContain('touch /opt/matrix/app/.update-repair-now');
+    expect(updater).toContain('repair)');
     expect(updater).toContain('stable|canary|beta|dev|v[0-9]*|main-[A-Za-z0-9]*');
     expect(updater).toContain('journalctl -u matrix-sync-agent -f --no-pager -n 20');
-    expect(updater).toContain('Usage: matrix-update [apply|rollback|stable|canary|beta|dev|v<version>|main-<build>]');
+    expect(updater).toContain('Usage: matrix-update [apply|rollback|repair|stable|canary|beta|dev|v<version>|main-<build>]');
   });
 
   it('sync agent installs bundled messaging systemd units during updates', () => {
@@ -505,6 +507,23 @@ test "$(readlink "$MATRIX_LEGACY_HOME/.hermes")" = "$MATRIX_HOME/.hermes"
     expect(syncAgent).toContain('maybe_clean_staging');
     expect(syncAgent).toContain('clean_staging || true');
     expect(syncAgent).toContain('last_staging_cleanup="$(date +%s)"');
+  });
+
+  it('sync agent reports low disk update failures and supports safe repair cleanup', () => {
+    const root = process.cwd();
+    const syncAgent = readFileSync(join(root, 'distro/customer-vps/host-bin/matrix-sync-agent'), 'utf8');
+
+    expect(syncAgent).toContain('readonly UPDATE_ERROR_MARKER="$APP_DIR/.update-error.json"');
+    expect(syncAgent).toContain('readonly UPDATE_REPAIR_TRIGGER="$APP_DIR/.update-repair-now"');
+    expect(syncAgent).toContain('readonly UPDATE_FREE_BUFFER_KB="${MATRIX_UPDATE_FREE_BUFFER_KB:-1048576}"');
+    expect(syncAgent).toContain('readonly UPDATE_EXPANSION_FACTOR="${MATRIX_UPDATE_EXPANSION_FACTOR:-8}"');
+    expect(syncAgent).toContain('write_update_error()');
+    expect(syncAgent).toContain('write_update_error "insufficient_disk_space"');
+    expect(syncAgent).toContain('ERROR: insufficient disk space for update');
+    expect(syncAgent).toContain('perform_update_repair()');
+    expect(syncAgent).toContain("find /tmp -xdev -user matrix -type f -mtime +1 \\( -name '*.so' -o -path '/tmp/node-compile-cache/*' \\)");
+    expect(syncAgent).toContain('sudo rm -f "$UPDATE_REPAIR_TRIGGER"');
+    expect(syncAgent).toContain('Repair complete; retrying pending update');
   });
 
   it('sync agent replaces the app tree with root permissions', () => {

--- a/tests/platform/customer-vps-host-bundle.test.ts
+++ b/tests/platform/customer-vps-host-bundle.test.ts
@@ -523,6 +523,8 @@ test "$(readlink "$MATRIX_LEGACY_HOME/.hermes")" = "$MATRIX_HOME/.hermes"
     expect(syncAgent).toContain('write_update_error "insufficient_disk_space"');
     expect(syncAgent).toContain('ERROR: insufficient disk space for update');
     expect(syncAgent).toContain('perform_update_repair()');
+    expect(syncAgent).toContain('df -Pk /tmp');
+    expect(syncAgent).toContain('WARN: /tmp and update staging are on different filesystems');
     expect(syncAgent).toContain("find /tmp -xdev -user matrix -type f -mtime +1 \\( -name '*.so' -o -path '/tmp/node-compile-cache/*' \\)");
     expect(syncAgent).toContain('sudo rm -f "$UPDATE_REPAIR_TRIGGER"');
     expect(syncAgent).toContain('Repair complete; retrying pending update');
@@ -539,6 +541,8 @@ test "$(readlink "$MATRIX_LEGACY_HOME/.hermes")" = "$MATRIX_HOME/.hermes"
     expect(syncAgent).toContain('echo "$version" | sudo tee "$VERSION_FILE" >/dev/null');
     expect(syncAgent).toContain('sudo rm -f "$UPDATE_TRIGGER"');
     expect(syncAgent).toContain('prepare_triggered_update');
+    expect(syncAgent).toContain('restart_sync_agent_after_update');
+    expect(syncAgent).toContain('sudo systemctl restart --no-block matrix-sync-agent.service');
     expect(syncAgent).toContain('release_url_for_version');
     expect(syncAgent).toContain('release_url_for_channel');
     expect(syncAgent).toContain('default_update_channel');

--- a/tests/platform/customer-vps-host-bundle.test.ts
+++ b/tests/platform/customer-vps-host-bundle.test.ts
@@ -478,9 +478,11 @@ test "$(readlink "$MATRIX_LEGACY_HOME/.hermes")" = "$MATRIX_HOME/.hermes"
     expect(updater).toContain('touch /opt/matrix/app/.rollback-now');
     expect(updater).toContain('touch /opt/matrix/app/.update-repair-now');
     expect(updater).toContain('repair)');
+    expect(updater).toContain('matrix-update --no-tail repair');
+    expect(updater).toContain('if [ "$tail_logs" -eq 0 ]; then');
     expect(updater).toContain('stable|canary|beta|dev|v[0-9]*|main-[A-Za-z0-9]*');
     expect(updater).toContain('journalctl -u matrix-sync-agent -f --no-pager -n 20');
-    expect(updater).toContain('Usage: matrix-update [apply|rollback|repair|stable|canary|beta|dev|v<version>|main-<build>]');
+    expect(updater).toContain('Usage: matrix-update [--no-tail] [apply|rollback|repair|stable|canary|beta|dev|v<version>|main-<build>]');
   });
 
   it('sync agent installs bundled messaging systemd units during updates', () => {

--- a/tests/shell/system-section-version.test.ts
+++ b/tests/shell/system-section-version.test.ts
@@ -5,6 +5,7 @@ import {
   normalizeMatrixReleaseTag,
   releaseActionLabel,
   resolveUpgradeInstallCopy,
+  resolveUpdateFailureNotice,
   resolveSystemUpdateState,
   severityBadgeStyle,
   formatReleaseBuildId,
@@ -169,6 +170,34 @@ describe("SystemSection version helpers", () => {
       title: "Installing update",
       detail: "Upgrade started. Waiting for services to come back...",
       statusLine: "Your workspace is getting the new version ready.",
+    });
+  });
+
+  it("builds actionable low-disk update failure copy", () => {
+    expect(resolveUpdateFailureNotice({
+      code: "insufficient_disk_space",
+      message: "Not enough free disk space to install this update.",
+      availableKb: 3584640,
+      requiredKb: 8232960,
+      repairAvailable: true,
+    })).toEqual({
+      tone: "warning",
+      title: "Not enough disk space",
+      detail: "Free about 4.4 GB before retrying the update.",
+      actionLabel: "Clean Up and Retry",
+    });
+  });
+
+  it("uses generic update failure copy for unknown failure markers", () => {
+    expect(resolveUpdateFailureNotice({
+      code: "unknown",
+      message: "Update failed.",
+      repairAvailable: false,
+    })).toEqual({
+      tone: "error",
+      title: "Update failed",
+      detail: "Update failed.",
+      actionLabel: null,
     });
   });
 });

--- a/tests/shell/system-section-version.test.ts
+++ b/tests/shell/system-section-version.test.ts
@@ -191,7 +191,7 @@ describe("SystemSection version helpers", () => {
   it("uses generic update failure copy for unknown failure markers", () => {
     expect(resolveUpdateFailureNotice({
       code: "unknown",
-      message: "Update failed.",
+      message: "postgres://internal.example/db failed while reading /opt/matrix/app",
       repairAvailable: false,
     })).toEqual({
       tone: "error",


### PR DESCRIPTION
## Summary
- add sync-agent disk headroom preflight before host-bundle download/extract
- write a sanitized `.update-error.json` marker for low-disk update failures
- expose low-disk failures in Settings with a Clean Up and Retry action that triggers safe update repair
- add safe repair cleanup for update staging, stale legacy bundle artifacts, and stale Matrix-owned temp files

## Invariants
- Source of truth: `/opt/matrix/release.json` and `/opt/matrix/app/BUNDLE_VERSION` remain canonical for installed runtime; `.update-error.json` is only a transient status marker.
- Lock/transaction scope: update install remains owned by `matrix-sync-agent`; gateway only starts the updater/repair command and reads sanitized marker state. No network calls are inside cleanup loops.
- Acceptable orphan states: if cleanup succeeds but install still fails, the marker remains or is rewritten on the next preflight and Settings continues to show a retryable failure.
- Auth source of truth: existing gateway system update auth/session boundary is unchanged; customer VPS internal deploy auth still uses platform-triggered update markers and local sudoers for `matrix-update`.
- Deferred scope: this does not resize disks, vacuum journals, or clean owner data under `/home/matrix/home`; broader fleet disk policy is deferred.

## Validation
- `./node_modules/.bin/vitest run tests/gateway/system-update.test.ts tests/shell/system-section-version.test.ts tests/platform/customer-vps-host-bundle.test.ts`
- `bun run check:patterns` (0 violations; existing warnings only)
- `npx react-doctor@latest shell` (exit 0; existing warnings remain)

## Live verification
- hamedmp was stuck on `v2026.06.21-452`; sync-agent logs showed `No space left on device` during tar extraction.
- removed only stale Matrix-owned `/tmp` files matching the new repair policy; disk improved from ~3.5 GiB free to ~27 GiB free before retry.
- triggered exact deploy for `v2026.06.23-467`; sync-agent completed health check at 2026-06-24T08:27:20Z.
- `/vps/fleet`, `/vps/releases`, `/opt/matrix/app/BUNDLE_VERSION`, and `/opt/matrix/release.json` all confirmed hamedmp on `v2026.06.23-467` / commit `55c79d3bbd080d1b0abf7798eddcf61cfe5eca7b`.

## Caveats
- `bun run typecheck` is currently blocked locally by pre-existing gateway errors in `src/sync/home-mirror.ts` (`Argument of type '() => void' is not assignable to parameter of type 'never'`). CI typecheck is running on the PR head.
- Screenshot evidence was not captured in this session; the full shell/gateway surface was not stood up locally.
- GCloud logging could not be queried because the active account requires interactive reauthentication.
- PostHog had no matching hamedmp update rows or update/disk error-tracking issues in the checked window.