### PR TITLE
fix(desktop): support native billing sessions

### DIFF
--- a/desktop/electron.vite.config.ts
+++ b/desktop/electron.vite.config.ts
@@ -32,6 +32,11 @@ export default defineConfig({
   },
   renderer: {
     plugins: [react(), tailwindcss()],
+    server: {
+      host: "127.0.0.1",
+      port: 5173,
+      strictPort: true,
+    },
     resolve: {
       alias: {
         "@renderer": resolve(__dirname, "src/renderer/src"),

--- a/desktop/src/main/auth/header-injection.ts
+++ b/desktop/src/main/auth/header-injection.ts
@@ -84,7 +84,7 @@ function isLocalDevRendererOrigin(origin: string): boolean {
   const url = new URL(normalized);
   return (
     (url.hostname === "localhost" || url.hostname === "127.0.0.1" || url.hostname === "[::1]") &&
-    url.port.length > 0
+    url.port === "5173"
   );
 }
 

--- a/desktop/src/main/auth/header-injection.ts
+++ b/desktop/src/main/auth/header-injection.ts
@@ -78,9 +78,20 @@ function uniq(values: Array<string | null>): string[] {
   return Array.from(new Set(values.filter((value): value is string => Boolean(value))));
 }
 
+function isLocalDevRendererOrigin(origin: string): boolean {
+  const normalized = normalizedHttpOrigin(origin);
+  if (!normalized) return false;
+  const url = new URL(normalized);
+  return (
+    (url.hostname === "localhost" || url.hostname === "127.0.0.1" || url.hostname === "[::1]") &&
+    url.port.length > 0
+  );
+}
+
 export function buildRendererCsp(gatewayOrigin: string | null, rendererOrigin: string): string {
   const gatewayHttpOrigin = normalizedHttpOrigin(gatewayOrigin);
   const rendererHttpOrigin = rendererOrigin === "null" ? null : normalizedHttpOrigin(rendererOrigin);
+  const scriptSources = isLocalDevRendererOrigin(rendererOrigin) ? "'self' 'unsafe-inline'" : "'self'";
   const connectSources = uniq([
     "'self'",
     gatewayHttpOrigin,
@@ -91,7 +102,7 @@ export function buildRendererCsp(gatewayOrigin: string | null, rendererOrigin: s
 
   return [
     "default-src 'self'",
-    "script-src 'self'",
+    `script-src ${scriptSources}`,
     "style-src 'self' 'unsafe-inline'",
     `connect-src ${connectSources}`,
     "worker-src 'self' blob:",

--- a/desktop/src/renderer/src/features/settings/SettingsView.tsx
+++ b/desktop/src/renderer/src/features/settings/SettingsView.tsx
@@ -1,6 +1,7 @@
 import {
   Blocks,
   Clock,
+  CreditCard,
   Cpu,
   MonitorCog,
   Palette,
@@ -13,6 +14,7 @@ import AccountSection from "./sections/AccountSection";
 import AppearanceSection from "./sections/AppearanceSection";
 import RuntimeSection from "./sections/RuntimeSection";
 import AgentSection from "./sections/AgentSection";
+import BillingSection from "./sections/BillingSection";
 import ChannelsSection from "./sections/ChannelsSection";
 import IntegrationsSection from "./sections/IntegrationsSection";
 import CronSection from "./sections/CronSection";
@@ -22,6 +24,7 @@ import { invoke } from "../../lib/operator";
 type SectionId =
   | "account"
   | "appearance"
+  | "billing"
   | "runtime"
   | "agent"
   | "channels"
@@ -31,6 +34,7 @@ type SectionId =
 
 const SECTIONS: { id: SectionId; label: string; icon: React.ReactNode; group: string }[] = [
   { id: "account", label: "Account", icon: <UserRound size={15} />, group: "You" },
+  { id: "billing", label: "Billing", icon: <CreditCard size={15} />, group: "You" },
   { id: "appearance", label: "Appearance", icon: <Palette size={15} />, group: "You" },
   { id: "agent", label: "Agent (Hermes)", icon: <Sparkles size={15} />, group: "Machine" },
   { id: "runtime", label: "Runtime", icon: <Server size={15} />, group: "Machine" },
@@ -108,6 +112,7 @@ export default function SettingsView() {
       <div className="min-h-0 flex-1 overflow-y-auto">
         <div className="mx-auto w-full max-w-[720px] px-8 py-8">
           {section === "account" ? <AccountSection /> : null}
+          {section === "billing" ? <BillingSection /> : null}
           {section === "appearance" ? <AppearanceSection /> : null}
           {section === "runtime" ? <RuntimeSection /> : null}
           {section === "agent" ? <AgentSection /> : null}

--- a/desktop/src/renderer/src/features/settings/sections/AccountSection.tsx
+++ b/desktop/src/renderer/src/features/settings/sections/AccountSection.tsx
@@ -3,16 +3,53 @@ import { invoke } from "../../../lib/operator";
 import { useConnection } from "../../../stores/connection";
 import { Card, Row, SectionHeader } from "./section-kit";
 
+function initialsFor(name: string): string {
+  return name
+    .split(/\s+/)
+    .filter(Boolean)
+    .slice(0, 2)
+    .map((part) => part[0]?.toUpperCase() ?? "")
+    .join("") || "M";
+}
+
 export default function AccountSection() {
   const handle = useConnection((s) => s.handle);
+  const displayName = useConnection((s) => s.displayName);
+  const imageUrl = useConnection((s) => s.imageUrl);
   const platformHost = useConnection((s) => s.platformHost);
   const signOut = useConnection((s) => s.signOut);
   const manageUrl = platformHost.startsWith("https://") ? platformHost : "https://app.matrix-os.com";
+  const accountName = displayName ?? (handle ? `@${handle}` : "Account");
 
   return (
     <>
       <SectionHeader title="Account" description="Your Matrix OS identity and session." />
       <Card>
+        <div className="flex items-center gap-3">
+          <div
+            className="flex size-12 shrink-0 items-center justify-center overflow-hidden rounded-full text-sm font-semibold"
+            style={{ background: "var(--accent-muted)", color: "var(--accent)" }}
+          >
+            {imageUrl ? (
+              <img
+                src={imageUrl}
+                alt={`${accountName} avatar`}
+                className="h-full w-full object-cover"
+                referrerPolicy="no-referrer"
+              />
+            ) : (
+              initialsFor(accountName)
+            )}
+          </div>
+          <div className="min-w-0">
+            <p className="truncate text-sm font-semibold" style={{ color: "var(--text-primary)" }}>
+              {accountName}
+            </p>
+            <p className="truncate text-xs" style={{ color: "var(--text-tertiary)" }}>
+              {handle ? `@${handle}` : "Not signed in"}
+            </p>
+          </div>
+        </div>
         <Row label="Handle" value={handle ? `@${handle}` : "–"} />
         <Row label="Platform" value={platformHost} />
         <div className="flex items-center justify-between border-t pt-3" style={{ borderColor: "var(--border-subtle)" }}>

--- a/desktop/src/renderer/src/features/settings/sections/BillingSection.tsx
+++ b/desktop/src/renderer/src/features/settings/sections/BillingSection.tsx
@@ -1,5 +1,5 @@
 import { CreditCard, ExternalLink } from "lucide-react";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useReducer, useState } from "react";
 import { z } from "zod/v4";
 import { Button } from "../../../design/primitives";
 import { invoke } from "../../../lib/operator";
@@ -9,6 +9,7 @@ import { Card, Row, SectionHeader } from "./section-kit";
 const BillingEntitlementSchema = z
   .object({
     source: z.enum(["stripe", "override"]),
+    clerkUserId: z.string().min(1).max(128),
     planSlug: z.string().min(1).max(64),
     status: z.string().min(1).max(64),
     maxRuntimeSlots: z.number().int().nonnegative(),
@@ -52,6 +53,31 @@ type BillingStatus = z.infer<typeof BillingStatusSchema>;
 type BillingInterval = "monthly" | "annual";
 type BillingPlan = "matrix_starter" | "matrix_builder" | "matrix_max";
 type BillingRegion = "region_fsn1" | "region_nbg1" | "region_ash" | "region_hil";
+type BillingAction = "checkout" | "portal";
+
+interface BillingUiState {
+  plan: BillingPlan;
+  interval: BillingInterval;
+  region: BillingRegion;
+  actionError: string | null;
+  actionLoading: BillingAction | null;
+}
+
+type BillingUiAction =
+  | { type: "set-plan"; plan: BillingPlan }
+  | { type: "set-interval"; interval: BillingInterval }
+  | { type: "set-region"; region: BillingRegion }
+  | { type: "start-action"; action: BillingAction }
+  | { type: "finish-action" }
+  | { type: "fail-action"; message: string };
+
+const INITIAL_BILLING_UI_STATE: BillingUiState = {
+  plan: "matrix_builder",
+  interval: "monthly",
+  region: "region_fsn1",
+  actionError: null,
+  actionLoading: null,
+};
 
 const PLAN_LABELS: Record<string, string> = {
   matrix_starter: "Starter",
@@ -84,6 +110,27 @@ function formatStatus(status: string): string {
 function entitlementSummary(entitlement: BillingEntitlement | null): string {
   if (!entitlement) return "No billing entitlement found.";
   return `${planLabel(entitlement.planSlug)} · ${formatStatus(entitlement.status)}`;
+}
+
+function billingUiReducer(state: BillingUiState, action: BillingUiAction): BillingUiState {
+  switch (action.type) {
+    case "set-plan":
+      return { ...state, plan: action.plan };
+    case "set-interval":
+      return { ...state, interval: action.interval };
+    case "set-region":
+      return { ...state, region: action.region };
+    case "start-action":
+      return { ...state, actionError: null, actionLoading: action.action };
+    case "finish-action":
+      return { ...state, actionLoading: null };
+    case "fail-action":
+      return { ...state, actionError: action.message, actionLoading: null };
+  }
+}
+
+async function openBillingUrl(url: string): Promise<void> {
+  await invoke("shell:open-external", { url });
 }
 
 function useBillingStatus() {
@@ -125,11 +172,7 @@ export default function BillingSection() {
   const api = useConnection((s) => s.api);
   const platformHost = useConnection((s) => s.platformHost);
   const { status, loading, error, refresh } = useBillingStatus();
-  const [plan, setPlan] = useState<BillingPlan>("matrix_builder");
-  const [interval, setInterval] = useState<BillingInterval>("monthly");
-  const [region, setRegion] = useState<BillingRegion>("region_fsn1");
-  const [actionError, setActionError] = useState<string | null>(null);
-  const [actionLoading, setActionLoading] = useState<"checkout" | "portal" | null>(null);
+  const [ui, dispatchUi] = useReducer(billingUiReducer, INITIAL_BILLING_UI_STATE);
 
   const active = status?.access.runtimeProxyAllowed === true;
   const entitlement = status?.entitlement ?? null;
@@ -139,43 +182,35 @@ export default function BillingSection() {
     return `${base.replace(/\/$/, "")}/?billing=setup`;
   }, [platformHost]);
 
-  async function openBillingUrl(url: string): Promise<void> {
-    await invoke("shell:open-external", { url });
-  }
-
   async function startCheckout(): Promise<void> {
-    if (!api || actionLoading) return;
-    setActionError(null);
-    setActionLoading("checkout");
+    if (!api || ui.actionLoading) return;
+    dispatchUi({ type: "start-action", action: "checkout" });
     try {
       const raw = await api.post<unknown>("/billing/checkout", {
-        planSlug: plan,
-        interval,
-        regionSlug: region,
+        planSlug: ui.plan,
+        interval: ui.interval,
+        regionSlug: ui.region,
       });
       const parsed = BillingRedirectSchema.parse(raw);
       await openBillingUrl(parsed.url);
+      dispatchUi({ type: "finish-action" });
     } catch (err: unknown) {
       console.warn("[billing] checkout unavailable:", err instanceof Error ? err.message : String(err));
-      setActionError("Checkout is unavailable. Try again in a moment.");
-    } finally {
-      setActionLoading(null);
+      dispatchUi({ type: "fail-action", message: "Checkout is unavailable. Try again in a moment." });
     }
   }
 
   async function openPortal(): Promise<void> {
-    if (!api || !portalAvailable || actionLoading) return;
-    setActionError(null);
-    setActionLoading("portal");
+    if (!api || !portalAvailable || ui.actionLoading) return;
+    dispatchUi({ type: "start-action", action: "portal" });
     try {
       const raw = await api.post<unknown>("/billing/portal", {});
       const parsed = BillingRedirectSchema.parse(raw);
       await openBillingUrl(parsed.url);
+      dispatchUi({ type: "finish-action" });
     } catch (err: unknown) {
       console.warn("[billing] portal unavailable:", err instanceof Error ? err.message : String(err));
-      setActionError("Billing portal is unavailable. Try again in a moment.");
-    } finally {
-      setActionLoading(null);
+      dispatchUi({ type: "fail-action", message: "Billing portal is unavailable. Try again in a moment." });
     }
   }
 
@@ -225,24 +260,26 @@ export default function BillingSection() {
           </>
         ) : null}
 
-        {active ? (
+        {portalAvailable ? (
           <div className="flex items-center justify-between border-t pt-3" style={{ borderColor: "var(--border-subtle)" }}>
             <p className="text-sm" style={{ color: "var(--text-secondary)" }}>
               Invoices, payment methods, coupons, and cancellation live in Stripe.
             </p>
-            <Button onClick={() => void openPortal()} disabled={!portalAvailable || actionLoading !== null}>
-              {actionLoading === "portal" ? "Opening..." : "Open portal"}
+            <Button onClick={() => void openPortal()} disabled={!portalAvailable || ui.actionLoading !== null}>
+              {ui.actionLoading === "portal" ? "Opening..." : "Open portal"}
               <ExternalLink size={14} />
             </Button>
           </div>
-        ) : (
+        ) : null}
+
+        {!active ? (
           <div className="flex flex-col gap-3 border-t pt-3" style={{ borderColor: "var(--border-subtle)" }}>
             <div className="grid gap-3 md:grid-cols-3">
               <label className="flex flex-col gap-1 text-xs" style={{ color: "var(--text-secondary)" }}>
                 Plan
                 <select
-                  value={plan}
-                  onChange={(event) => setPlan(event.currentTarget.value as BillingPlan)}
+                  value={ui.plan}
+                  onChange={(event) => dispatchUi({ type: "set-plan", plan: event.currentTarget.value as BillingPlan })}
                   className="h-9 rounded-md border px-2 text-sm"
                   style={{ background: "var(--bg-sunken)", borderColor: "var(--border-default)", color: "var(--text-primary)" }}
                 >
@@ -254,8 +291,8 @@ export default function BillingSection() {
               <label className="flex flex-col gap-1 text-xs" style={{ color: "var(--text-secondary)" }}>
                 Interval
                 <select
-                  value={interval}
-                  onChange={(event) => setInterval(event.currentTarget.value as BillingInterval)}
+                  value={ui.interval}
+                  onChange={(event) => dispatchUi({ type: "set-interval", interval: event.currentTarget.value as BillingInterval })}
                   className="h-9 rounded-md border px-2 text-sm"
                   style={{ background: "var(--bg-sunken)", borderColor: "var(--border-default)", color: "var(--text-primary)" }}
                 >
@@ -266,8 +303,8 @@ export default function BillingSection() {
               <label className="flex flex-col gap-1 text-xs" style={{ color: "var(--text-secondary)" }}>
                 Region
                 <select
-                  value={region}
-                  onChange={(event) => setRegion(event.currentTarget.value as BillingRegion)}
+                  value={ui.region}
+                  onChange={(event) => dispatchUi({ type: "set-region", region: event.currentTarget.value as BillingRegion })}
                   className="h-9 rounded-md border px-2 text-sm"
                   style={{ background: "var(--bg-sunken)", borderColor: "var(--border-default)", color: "var(--text-primary)" }}
                 >
@@ -281,8 +318,8 @@ export default function BillingSection() {
               <p className="text-sm" style={{ color: "var(--text-secondary)" }}>
                 Checkout opens in your browser and returns to Matrix OS after Stripe confirms payment.
               </p>
-              <Button variant="primary" onClick={() => void startCheckout()} disabled={!api || actionLoading !== null}>
-                {actionLoading === "checkout" ? "Opening..." : "Continue to checkout"}
+              <Button variant="primary" onClick={() => void startCheckout()} disabled={!api || ui.actionLoading !== null}>
+                {ui.actionLoading === "checkout" ? "Opening..." : "Continue to checkout"}
                 <ExternalLink size={14} />
               </Button>
             </div>
@@ -290,11 +327,11 @@ export default function BillingSection() {
               Open billing setup in browser
             </Button>
           </div>
-        )}
+        ) : null}
 
-        {actionError ? (
+        {ui.actionError ? (
           <p className="text-sm" style={{ color: "var(--danger)" }}>
-            {actionError}
+            {ui.actionError}
           </p>
         ) : null}
       </Card>

--- a/desktop/src/renderer/src/features/settings/sections/BillingSection.tsx
+++ b/desktop/src/renderer/src/features/settings/sections/BillingSection.tsx
@@ -1,0 +1,303 @@
+import { CreditCard, ExternalLink } from "lucide-react";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { z } from "zod/v4";
+import { Button } from "../../../design/primitives";
+import { invoke } from "../../../lib/operator";
+import { useConnection } from "../../../stores/connection";
+import { Card, Row, SectionHeader } from "./section-kit";
+
+const BillingEntitlementSchema = z
+  .object({
+    source: z.enum(["stripe", "override"]),
+    planSlug: z.string().min(1).max(64),
+    status: z.string().min(1).max(64),
+    maxRuntimeSlots: z.number().int().nonnegative(),
+    includedRuntimeSlots: z.number().int().nonnegative(),
+    addonRuntimeSlots: z.number().int().nonnegative(),
+    defaultServerType: z.string().min(1).max(64),
+    allowedServerTypes: z.array(z.string().min(1).max(64)).max(16),
+    stripeSubscriptionId: z.string().max(256).nullable(),
+    stripePriceId: z.string().max(256).nullable(),
+    gracePeriodEndsAt: z.string().max(64).nullable(),
+    effectiveFrom: z.string().max(64),
+    effectiveUntil: z.string().max(64).nullable(),
+    updatedAt: z.string().max(64),
+  })
+  .strict();
+
+const BillingStatusSchema = z
+  .object({
+    entitlement: BillingEntitlementSchema.nullable(),
+    access: z
+      .object({
+        runtimeProxyAllowed: z.boolean(),
+        reason: z.string().max(128).optional(),
+      })
+      .passthrough(),
+  })
+  .passthrough();
+
+const BillingRedirectSchema = z
+  .object({
+    url: z
+      .string()
+      .url()
+      .max(2048)
+      .refine((url) => new URL(url).protocol === "https:", "Billing redirects must use HTTPS"),
+  })
+  .strict();
+
+type BillingEntitlement = z.infer<typeof BillingEntitlementSchema>;
+type BillingStatus = z.infer<typeof BillingStatusSchema>;
+type BillingInterval = "monthly" | "annual";
+type BillingPlan = "matrix_starter" | "matrix_builder" | "matrix_max";
+type BillingRegion = "region_fsn1" | "region_nbg1" | "region_ash" | "region_hil";
+
+const PLAN_LABELS: Record<string, string> = {
+  matrix_starter: "Starter",
+  matrix_builder: "Builder",
+  matrix_max: "Max",
+  internal: "Internal",
+};
+
+const PLANS: Array<{ slug: BillingPlan; label: string }> = [
+  { slug: "matrix_starter", label: "Starter" },
+  { slug: "matrix_builder", label: "Builder" },
+  { slug: "matrix_max", label: "Max" },
+];
+
+const REGIONS: Array<{ slug: BillingRegion; label: string }> = [
+  { slug: "region_fsn1", label: "EU Falkenstein" },
+  { slug: "region_nbg1", label: "EU Nuremberg" },
+  { slug: "region_ash", label: "US Ashburn" },
+  { slug: "region_hil", label: "US Hillsboro" },
+];
+
+function planLabel(slug: string): string {
+  return PLAN_LABELS[slug] ?? slug.replace(/^matrix_/, "").replaceAll("_", " ");
+}
+
+function formatStatus(status: string): string {
+  return status.replaceAll("_", " ");
+}
+
+function entitlementSummary(entitlement: BillingEntitlement | null): string {
+  if (!entitlement) return "No billing entitlement found.";
+  return `${planLabel(entitlement.planSlug)} · ${formatStatus(entitlement.status)}`;
+}
+
+function useBillingStatus() {
+  const api = useConnection((s) => s.api);
+  const [status, setStatus] = useState<BillingStatus | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(false);
+
+  const refresh = useCallback(async () => {
+    if (!api) {
+      setStatus(null);
+      setLoading(false);
+      setError(false);
+      return;
+    }
+    setLoading(true);
+    setError(false);
+    try {
+      const raw = await api.get<unknown>("/billing/status");
+      const parsed = BillingStatusSchema.parse(raw);
+      setStatus(parsed);
+    } catch (err: unknown) {
+      console.warn("[billing] status unavailable:", err instanceof Error ? err.message : String(err));
+      setStatus(null);
+      setError(true);
+    } finally {
+      setLoading(false);
+    }
+  }, [api]);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  return { status, loading, error, refresh };
+}
+
+export default function BillingSection() {
+  const api = useConnection((s) => s.api);
+  const platformHost = useConnection((s) => s.platformHost);
+  const { status, loading, error, refresh } = useBillingStatus();
+  const [plan, setPlan] = useState<BillingPlan>("matrix_builder");
+  const [interval, setInterval] = useState<BillingInterval>("monthly");
+  const [region, setRegion] = useState<BillingRegion>("region_fsn1");
+  const [actionError, setActionError] = useState<string | null>(null);
+  const [actionLoading, setActionLoading] = useState<"checkout" | "portal" | null>(null);
+
+  const active = status?.access.runtimeProxyAllowed === true;
+  const entitlement = status?.entitlement ?? null;
+  const portalAvailable = entitlement?.source === "stripe" && Boolean(entitlement.stripeSubscriptionId);
+  const settingsUrl = useMemo(() => {
+    const base = platformHost.startsWith("https://") ? platformHost : "https://app.matrix-os.com";
+    return `${base.replace(/\/$/, "")}/?billing=setup`;
+  }, [platformHost]);
+
+  async function openBillingUrl(url: string): Promise<void> {
+    await invoke("shell:open-external", { url });
+  }
+
+  async function startCheckout(): Promise<void> {
+    if (!api || actionLoading) return;
+    setActionError(null);
+    setActionLoading("checkout");
+    try {
+      const raw = await api.post<unknown>("/billing/checkout", {
+        planSlug: plan,
+        interval,
+        regionSlug: region,
+      });
+      const parsed = BillingRedirectSchema.parse(raw);
+      await openBillingUrl(parsed.url);
+    } catch (err: unknown) {
+      console.warn("[billing] checkout unavailable:", err instanceof Error ? err.message : String(err));
+      setActionError("Checkout is unavailable. Try again in a moment.");
+    } finally {
+      setActionLoading(null);
+    }
+  }
+
+  async function openPortal(): Promise<void> {
+    if (!api || !portalAvailable || actionLoading) return;
+    setActionError(null);
+    setActionLoading("portal");
+    try {
+      const raw = await api.post<unknown>("/billing/portal", {});
+      const parsed = BillingRedirectSchema.parse(raw);
+      await openBillingUrl(parsed.url);
+    } catch (err: unknown) {
+      console.warn("[billing] portal unavailable:", err instanceof Error ? err.message : String(err));
+      setActionError("Billing portal is unavailable. Try again in a moment.");
+    } finally {
+      setActionLoading(null);
+    }
+  }
+
+  return (
+    <>
+      <SectionHeader
+        title="Billing"
+        description="Manage hosted runtime billing through the native Matrix session."
+      />
+      <Card>
+        <div className="flex items-center gap-3">
+          <div
+            className="flex size-10 items-center justify-center rounded-lg"
+            style={{ background: "var(--accent-muted)", color: "var(--accent)" }}
+          >
+            <CreditCard size={18} />
+          </div>
+          <div className="min-w-0 flex-1">
+            <p className="text-sm font-semibold" style={{ color: "var(--text-primary)" }}>
+              {loading ? "Checking billing..." : active ? "Billing active" : "Billing required"}
+            </p>
+            <p className="text-xs" style={{ color: "var(--text-secondary)" }}>
+              {loading ? "Reading your platform billing status." : entitlementSummary(entitlement)}
+            </p>
+          </div>
+          <Button onClick={() => void refresh()} disabled={loading}>
+            Refresh
+          </Button>
+        </div>
+
+        {error ? (
+          <p className="text-sm" style={{ color: "var(--warning)" }}>
+            Billing status unavailable. The desktop app could not verify your plan.
+          </p>
+        ) : null}
+
+        <Row label="Access" value={loading ? "Checking" : active ? "Runtime allowed" : "Runtime locked"} />
+        {entitlement ? (
+          <>
+            <Row label="Plan" value={planLabel(entitlement.planSlug)} />
+            <Row label="Status" value={formatStatus(entitlement.status)} />
+            <Row
+              label="Runtime slots"
+              value={`${entitlement.includedRuntimeSlots + entitlement.addonRuntimeSlots} of ${entitlement.maxRuntimeSlots}`}
+            />
+            <Row label="Default machine" value={entitlement.defaultServerType} />
+          </>
+        ) : null}
+
+        {active ? (
+          <div className="flex items-center justify-between border-t pt-3" style={{ borderColor: "var(--border-subtle)" }}>
+            <p className="text-sm" style={{ color: "var(--text-secondary)" }}>
+              Invoices, payment methods, coupons, and cancellation live in Stripe.
+            </p>
+            <Button onClick={() => void openPortal()} disabled={!portalAvailable || actionLoading !== null}>
+              {actionLoading === "portal" ? "Opening..." : "Open portal"}
+              <ExternalLink size={14} />
+            </Button>
+          </div>
+        ) : (
+          <div className="flex flex-col gap-3 border-t pt-3" style={{ borderColor: "var(--border-subtle)" }}>
+            <div className="grid gap-3 md:grid-cols-3">
+              <label className="flex flex-col gap-1 text-xs" style={{ color: "var(--text-secondary)" }}>
+                Plan
+                <select
+                  value={plan}
+                  onChange={(event) => setPlan(event.currentTarget.value as BillingPlan)}
+                  className="h-9 rounded-md border px-2 text-sm"
+                  style={{ background: "var(--bg-sunken)", borderColor: "var(--border-default)", color: "var(--text-primary)" }}
+                >
+                  {PLANS.map((option) => (
+                    <option key={option.slug} value={option.slug}>{option.label}</option>
+                  ))}
+                </select>
+              </label>
+              <label className="flex flex-col gap-1 text-xs" style={{ color: "var(--text-secondary)" }}>
+                Interval
+                <select
+                  value={interval}
+                  onChange={(event) => setInterval(event.currentTarget.value as BillingInterval)}
+                  className="h-9 rounded-md border px-2 text-sm"
+                  style={{ background: "var(--bg-sunken)", borderColor: "var(--border-default)", color: "var(--text-primary)" }}
+                >
+                  <option value="monthly">Monthly</option>
+                  <option value="annual">Annual</option>
+                </select>
+              </label>
+              <label className="flex flex-col gap-1 text-xs" style={{ color: "var(--text-secondary)" }}>
+                Region
+                <select
+                  value={region}
+                  onChange={(event) => setRegion(event.currentTarget.value as BillingRegion)}
+                  className="h-9 rounded-md border px-2 text-sm"
+                  style={{ background: "var(--bg-sunken)", borderColor: "var(--border-default)", color: "var(--text-primary)" }}
+                >
+                  {REGIONS.map((option) => (
+                    <option key={option.slug} value={option.slug}>{option.label}</option>
+                  ))}
+                </select>
+              </label>
+            </div>
+            <div className="flex items-center justify-between gap-3">
+              <p className="text-sm" style={{ color: "var(--text-secondary)" }}>
+                Checkout opens in your browser and returns to Matrix OS after Stripe confirms payment.
+              </p>
+              <Button variant="primary" onClick={() => void startCheckout()} disabled={!api || actionLoading !== null}>
+                {actionLoading === "checkout" ? "Opening..." : "Continue to checkout"}
+                <ExternalLink size={14} />
+              </Button>
+            </div>
+            <Button variant="ghost" onClick={() => void openBillingUrl(settingsUrl)}>
+              Open billing setup in browser
+            </Button>
+          </div>
+        )}
+
+        {actionError ? (
+          <p className="text-sm" style={{ color: "var(--danger)" }}>
+            {actionError}
+          </p>
+        ) : null}
+      </Card>
+    </>
+  );
+}

--- a/packages/platform/src/main.ts
+++ b/packages/platform/src/main.ts
@@ -2077,22 +2077,24 @@ export function createApp(deps: {
   async function resolveBillingClerkUserId(c: Context): Promise<string | null> {
     const authorization = c.req.header('authorization');
     const cookie = c.req.header('cookie');
-    const token = clerkAuth?.extractToken(authorization, cookie) ?? (authorization?.startsWith('Bearer ') ? authorization.slice(7) : null);
-    if (!token) return null;
+    const clerkToken = clerkAuth?.extractToken(authorization, cookie);
+    const bearerToken = authorization?.startsWith('Bearer ') ? authorization.slice(7) : null;
+    if (!clerkToken && !bearerToken) return null;
 
     try {
-      if (clerkAuth) {
-        const result = await clerkAuth.verify(token);
+      if (clerkAuth && clerkToken) {
+        const result = await clerkAuth.verify(clerkToken);
         if (result.authenticated && result.userId) return result.userId;
+        console.warn('[billing] Clerk verification returned unauthenticated');
       }
     } catch (err: unknown) {
       const kind = err instanceof Error ? err.name : typeof err;
       console.warn(`[billing] Clerk verification failed: ${kind}`);
     }
 
-    if (!platformJwtSecret) return null;
+    if (!platformJwtSecret || !bearerToken) return null;
     try {
-      const claims = await verifySyncJwt(token, { secret: platformJwtSecret });
+      const claims = await verifySyncJwt(bearerToken, { secret: platformJwtSecret });
       return claims.sub;
     } catch (err: unknown) {
       const kind = err instanceof Error ? err.name : typeof err;

--- a/packages/platform/src/main.ts
+++ b/packages/platform/src/main.ts
@@ -2075,15 +2075,28 @@ export function createApp(deps: {
   }
 
   async function resolveBillingClerkUserId(c: Context): Promise<string | null> {
+    const authorization = c.req.header('authorization');
+    const cookie = c.req.header('cookie');
+    const token = clerkAuth?.extractToken(authorization, cookie) ?? (authorization?.startsWith('Bearer ') ? authorization.slice(7) : null);
+    if (!token) return null;
+
     try {
-      if (!clerkAuth) return null;
-      const token = clerkAuth.extractToken(c.req.header('authorization'), c.req.header('cookie'));
-      if (!token) return null;
-      const result = await clerkAuth.verify(token);
-      return result.authenticated && result.userId ? result.userId : null;
+      if (clerkAuth) {
+        const result = await clerkAuth.verify(token);
+        if (result.authenticated && result.userId) return result.userId;
+      }
     } catch (err: unknown) {
       const kind = err instanceof Error ? err.name : typeof err;
       console.warn(`[billing] Clerk verification failed: ${kind}`);
+    }
+
+    if (!platformJwtSecret) return null;
+    try {
+      const claims = await verifySyncJwt(token, { secret: platformJwtSecret });
+      return claims.sub;
+    } catch (err: unknown) {
+      const kind = err instanceof Error ? err.name : typeof err;
+      console.warn(`[billing] native token verification failed: ${kind}`);
       return null;
     }
   }

--- a/tests/desktop/account-section.test.tsx
+++ b/tests/desktop/account-section.test.tsx
@@ -1,0 +1,40 @@
+// @vitest-environment jsdom
+
+import React from "react";
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import AccountSection from "../../desktop/src/renderer/src/features/settings/sections/AccountSection";
+import { useConnection } from "../../desktop/src/renderer/src/stores/connection";
+
+describe("AccountSection", () => {
+  beforeEach(() => {
+    window.operator = {
+      invoke: vi.fn(async () => ({ ok: true })),
+      on: vi.fn(() => () => undefined),
+    };
+    useConnection.setState({
+      status: "signed-in",
+      handle: "operator",
+      displayName: "Ada Operator",
+      imageUrl: "https://example.com/avatar.png",
+      platformHost: "https://app.matrix-os.com",
+      runtimeSlot: "primary",
+      api: null,
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it("renders the native device-flow display profile", () => {
+    render(<AccountSection />);
+
+    expect(screen.getByText("Ada Operator")).not.toBeNull();
+    expect(screen.getAllByText("@operator").length).toBeGreaterThan(0);
+    expect(screen.getByAltText("Ada Operator avatar").getAttribute("src")).toBe(
+      "https://example.com/avatar.png",
+    );
+  });
+});

--- a/tests/desktop/billing-section.test.tsx
+++ b/tests/desktop/billing-section.test.tsx
@@ -11,6 +11,7 @@ const activeBilling = {
   access: { runtimeProxyAllowed: true, reason: "active" },
   entitlement: {
     source: "stripe",
+    clerkUserId: "user_test",
     planSlug: "matrix_builder",
     status: "active",
     maxRuntimeSlots: 2,
@@ -119,5 +120,19 @@ describe("desktop billing settings", () => {
     expect(window.operator.invoke).toHaveBeenCalledWith("shell:open-external", {
       url: "https://checkout.stripe.test/session",
     });
+  });
+
+  it("keeps the billing portal available for locked Stripe subscriptions", async () => {
+    const api = makeApi({
+      access: { runtimeProxyAllowed: false, reason: "billing_required" },
+      entitlement: { ...activeBilling.entitlement, status: "past_due" },
+    });
+    useConnection.setState({ api: api as never });
+
+    render(<BillingSection />);
+    await waitFor(() => expect(screen.getByText("Billing required")).not.toBeNull());
+
+    expect(screen.getByRole("button", { name: /Open portal/i })).not.toBeNull();
+    expect(screen.getByRole("button", { name: /Continue to checkout/i })).not.toBeNull();
   });
 });

--- a/tests/desktop/billing-section.test.tsx
+++ b/tests/desktop/billing-section.test.tsx
@@ -1,0 +1,123 @@
+// @vitest-environment jsdom
+
+import React from "react";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import BillingSection from "../../desktop/src/renderer/src/features/settings/sections/BillingSection";
+import SettingsView from "../../desktop/src/renderer/src/features/settings/SettingsView";
+import { useConnection } from "../../desktop/src/renderer/src/stores/connection";
+
+const activeBilling = {
+  access: { runtimeProxyAllowed: true, reason: "active" },
+  entitlement: {
+    source: "stripe",
+    planSlug: "matrix_builder",
+    status: "active",
+    maxRuntimeSlots: 2,
+    includedRuntimeSlots: 1,
+    addonRuntimeSlots: 1,
+    defaultServerType: "cpx32",
+    allowedServerTypes: ["cpx22", "cpx32"],
+    stripeSubscriptionId: "sub_123",
+    stripePriceId: "price_123",
+    gracePeriodEndsAt: null,
+    effectiveFrom: "2026-06-01T00:00:00.000Z",
+    effectiveUntil: null,
+    updatedAt: "2026-06-01T00:00:00.000Z",
+  },
+};
+
+function makeApi(statusResponse: unknown) {
+  return {
+    baseUrl: "https://app.matrix-os.com",
+    get: vi.fn(async () => statusResponse),
+    getText: vi.fn(),
+    post: vi.fn(async (path: string) => ({
+      url: path === "/billing/portal" ? "https://billing.stripe.test/session" : "https://checkout.stripe.test/session",
+    })),
+    patch: vi.fn(),
+    put: vi.fn(),
+    delete: vi.fn(),
+    putText: vi.fn(),
+  };
+}
+
+describe("desktop billing settings", () => {
+  beforeEach(() => {
+    Object.defineProperty(window, "matchMedia", {
+      configurable: true,
+      value: vi.fn().mockReturnValue({ matches: false }),
+    });
+    window.operator = {
+      invoke: vi.fn(async (channel: string) => {
+        if (channel === "state:get") return { value: { theme: "light" } };
+        return { ok: true };
+      }),
+      on: vi.fn(() => () => undefined),
+    };
+    useConnection.setState({
+      status: "signed-in",
+      handle: "operator",
+      displayName: "Ada Operator",
+      imageUrl: null,
+      platformHost: "https://app.matrix-os.com",
+      runtimeSlot: "primary",
+      api: makeApi(activeBilling) as never,
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it("shows billing in desktop settings navigation", () => {
+    render(<SettingsView />);
+    expect(screen.getByRole("button", { name: "Billing" })).not.toBeNull();
+  });
+
+  it("loads native billing status through the desktop API client", async () => {
+    const api = makeApi(activeBilling);
+    useConnection.setState({ api: api as never });
+
+    render(<BillingSection />);
+
+    await waitFor(() => expect(screen.getByText("Billing active")).not.toBeNull());
+    expect(api.get).toHaveBeenCalledWith("/billing/status");
+    expect(screen.getByText("Builder")).not.toBeNull();
+    expect(screen.getByText("2 of 2")).not.toBeNull();
+  });
+
+  it("opens the billing portal through the platform billing route", async () => {
+    const api = makeApi(activeBilling);
+    useConnection.setState({ api: api as never });
+
+    render(<BillingSection />);
+    await waitFor(() => expect(screen.getByText("Billing active")).not.toBeNull());
+    fireEvent.click(screen.getByRole("button", { name: /Open portal/i }));
+
+    await waitFor(() => expect(api.post).toHaveBeenCalledWith("/billing/portal", {}));
+    expect(window.operator.invoke).toHaveBeenCalledWith("shell:open-external", {
+      url: "https://billing.stripe.test/session",
+    });
+  });
+
+  it("starts checkout with the selected native billing options", async () => {
+    const api = makeApi({ access: { runtimeProxyAllowed: false }, entitlement: null });
+    useConnection.setState({ api: api as never });
+
+    render(<BillingSection />);
+    await waitFor(() => expect(screen.getByText("Billing required")).not.toBeNull());
+    fireEvent.click(screen.getByRole("button", { name: /Continue to checkout/i }));
+
+    await waitFor(() =>
+      expect(api.post).toHaveBeenCalledWith(
+        "/billing/checkout",
+        { planSlug: "matrix_builder", interval: "monthly", regionSlug: "region_fsn1" },
+      ),
+    );
+    expect(window.operator.invoke).toHaveBeenCalledWith("shell:open-external", {
+      url: "https://checkout.stripe.test/session",
+    });
+  });
+});

--- a/tests/desktop/header-injection.test.ts
+++ b/tests/desktop/header-injection.test.ts
@@ -148,9 +148,11 @@ describe("installGatewayCors", () => {
 
   it("allows Vite React Refresh inline preamble only for localhost development renderers", () => {
     const localhostCsp = buildRendererCsp(GATEWAY, "http://127.0.0.1:5173");
+    const otherLoopbackCsp = buildRendererCsp(GATEWAY, "http://127.0.0.1:9000");
     const remoteCsp = buildRendererCsp(GATEWAY, "https://preview.example.com");
 
     expect(scriptDirective(localhostCsp)).toBe("script-src 'self' 'unsafe-inline'");
+    expect(scriptDirective(otherLoopbackCsp)).toBe("script-src 'self'");
     expect(scriptDirective(remoteCsp)).toBe("script-src 'self'");
   });
 });

--- a/tests/desktop/header-injection.test.ts
+++ b/tests/desktop/header-injection.test.ts
@@ -15,6 +15,10 @@ function connectSources(csp: string): string[] {
   return connectDirective(csp).split(/\s+/).slice(1);
 }
 
+function scriptDirective(csp: string): string {
+  return csp.split(";").map((part) => part.trim()).find((part) => part.startsWith("script-src ")) ?? "";
+}
+
 type HeadersReceivedListener = (
   details: {
     url: string;
@@ -135,6 +139,19 @@ describe("installGatewayCors", () => {
     expect(sources).not.toContain("https:");
     expect(sources).not.toContain("wss:");
     expect(sources).not.toContain("*");
+  });
+
+  it("keeps packaged renderer scripts strict", () => {
+    const csp = buildRendererCsp(GATEWAY, "null");
+    expect(scriptDirective(csp)).toBe("script-src 'self'");
+  });
+
+  it("allows Vite React Refresh inline preamble only for localhost development renderers", () => {
+    const localhostCsp = buildRendererCsp(GATEWAY, "http://127.0.0.1:5173");
+    const remoteCsp = buildRendererCsp(GATEWAY, "https://preview.example.com");
+
+    expect(scriptDirective(localhostCsp)).toBe("script-src 'self' 'unsafe-inline'");
+    expect(scriptDirective(remoteCsp)).toBe("script-src 'self'");
   });
 });
 

--- a/tests/platform/proxy-routing.test.ts
+++ b/tests/platform/proxy-routing.test.ts
@@ -414,6 +414,64 @@ describe("platform proxy routing", () => {
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
+  it("uses the raw bearer sync JWT for native billing fallback when a stale Clerk cookie is present", async () => {
+    await upsertBillingEntitlement(db, {
+      clerkUserId: "user_alice",
+      source: "stripe",
+      planSlug: "matrix_builder",
+      status: "active",
+      maxRuntimeSlots: 1,
+      includedRuntimeSlots: 1,
+      addonRuntimeSlots: 0,
+      defaultServerType: "cpx32",
+      allowedServerTypes: ["cpx22", "cpx32"],
+      stripeSubscriptionId: "sub_123",
+      stripePriceId: "price_builder_monthly",
+      gracePeriodEndsAt: "2026-06-02T00:00:00.000Z",
+      effectiveFrom: "2026-05-30T00:00:00.000Z",
+      effectiveUntil: null,
+      updatedAt: "2026-05-30T00:00:00.000Z",
+    });
+    const issued = await issueSyncJwt({
+      secret: JWT_SECRET,
+      clerkUserId: "user_alice",
+      handle: "alice",
+      gatewayUrl: "https://app.matrix-os.com",
+      runtimeSlot: "primary",
+    });
+    process.env.PLATFORM_JWT_SECRET = JWT_SECRET;
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response("wrong target", { status: 200 }),
+    );
+    const app = createApp({
+      db,
+      orchestrator: stubOrchestrator(),
+      clerkAuth: {
+        extractToken: vi.fn((_authorization, cookie) => (cookie ? "stale-clerk-cookie" : null)),
+        verify: vi.fn().mockResolvedValue({ authenticated: false }),
+        verifyAndMatchOwner: vi.fn(),
+        revokeSession: vi.fn(),
+        isPublicPath: vi.fn(() => false),
+      },
+      platformSecret: "platform-secret-123",
+    });
+
+    const res = await app.request("/billing/status", {
+      headers: {
+        host: "app.matrix-os.com",
+        authorization: `Bearer ${issued.token}`,
+        cookie: "__session=stale-clerk-cookie",
+      },
+    });
+
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toMatchObject({
+      entitlement: { planSlug: "matrix_builder" },
+      access: { runtimeProxyAllowed: true },
+    });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
   it("returns unauthorized instead of leaking Clerk verification failures on billing routes", async () => {
     const app = createApp({
       db,

--- a/tests/platform/proxy-routing.test.ts
+++ b/tests/platform/proxy-routing.test.ts
@@ -361,6 +361,59 @@ describe("platform proxy routing", () => {
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
+  it("serves platform billing status for native desktop sync-JWT callers", async () => {
+    await upsertBillingEntitlement(db, {
+      clerkUserId: "user_alice",
+      source: "stripe",
+      planSlug: "matrix_builder",
+      status: "active",
+      maxRuntimeSlots: 1,
+      includedRuntimeSlots: 1,
+      addonRuntimeSlots: 0,
+      defaultServerType: "cpx32",
+      allowedServerTypes: ["cpx22", "cpx32"],
+      stripeSubscriptionId: "sub_123",
+      stripePriceId: "price_builder_monthly",
+      gracePeriodEndsAt: "2026-06-02T00:00:00.000Z",
+      effectiveFrom: "2026-05-30T00:00:00.000Z",
+      effectiveUntil: null,
+      updatedAt: "2026-05-30T00:00:00.000Z",
+    });
+    const issued = await issueSyncJwt({
+      secret: JWT_SECRET,
+      clerkUserId: "user_alice",
+      handle: "alice",
+      gatewayUrl: "https://app.matrix-os.com",
+      runtimeSlot: "primary",
+    });
+    process.env.PLATFORM_JWT_SECRET = JWT_SECRET;
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response("wrong target", { status: 200 }),
+    );
+    const app = createApp({
+      db,
+      orchestrator: stubOrchestrator(),
+      clerkAuth: createClerkAuth({
+        verifyToken: vi.fn().mockRejectedValue(new Error("not a Clerk token")),
+      }),
+      platformSecret: "platform-secret-123",
+    });
+
+    const res = await app.request("/billing/status", {
+      headers: {
+        host: "app.matrix-os.com",
+        authorization: `Bearer ${issued.token}`,
+      },
+    });
+
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toMatchObject({
+      entitlement: { planSlug: "matrix_builder" },
+      access: { runtimeProxyAllowed: true },
+    });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
   it("returns unauthorized instead of leaking Clerk verification failures on billing routes", async () => {
     const app = createApp({
       db,


### PR DESCRIPTION
## Summary
- authenticate platform billing routes with the native desktop sync JWT when Clerk cookies are unavailable
- add native Account profile rendering and a Billing settings section in the desktop app
- keep packaged renderer CSP strict while allowing only localhost dev React Refresh inline preamble

## Privacy
- Tests use synthetic handles, user ids, and avatar URLs only.
- No production account names, Clerk image URLs, emails, live secret values, or local machine paths are included in the diff or PR body.

## Invariants
- Source of truth: billing entitlement and runtime access remain owned by platform billing state; desktop only reads status and requests platform-created redirect URLs.
- Lock/transaction scope: this PR does not add new multi-write database flows; checkout, portal, and status keep using the existing platform billing handlers.
- Acceptable orphan states: if status, checkout, or portal fails, desktop keeps the user in settings and shows a generic unavailable message instead of clearing session state.
- Auth source of truth: Clerk tokens are verified first; native desktop bearer tokens must verify as Matrix sync JWTs using the platform JWT secret, issuer, audience, expiry, and required claims.
- Deferred scope: signed/notarized mac distribution and platform deployment are follow-up release work after this code path is reviewed.

## Tests
- pnpm test tests/desktop/account-section.test.tsx tests/desktop/billing-section.test.tsx tests/desktop/header-injection.test.ts tests/desktop/renderer-csp.test.ts tests/platform/proxy-routing.test.ts
- ./node_modules/.bin/tsc --noEmit -p desktop/tsconfig.json
- ./node_modules/.bin/tsc --noEmit -p desktop/tsconfig.node.json
- ./node_modules/.bin/tsc --noEmit -p packages/observability/tsconfig.json
- ./node_modules/.bin/tsc --noEmit -p packages/kernel/tsconfig.json
- ./node_modules/.bin/tsc --noEmit -p packages/gateway/tsconfig.json
- ./node_modules/.bin/tsc --noEmit -p packages/platform/tsconfig.typecheck.json
- ./node_modules/.bin/tsc --noEmit -p packages/proxy/tsconfig.json
- ./node_modules/.bin/tsc --noEmit -p packages/edge-router/tsconfig.json
- cd desktop && ../node_modules/.bin/electron-vite build
- bun run check:patterns
- npx react-doctor@latest --verbose --scope changed desktop

## Notes
- bun run typecheck and bun run test both failed before useful project diagnostics because the local pnpm wrapper returned `fetch failed` in this environment. Equivalent direct compiler checks and focused tests passed.
- A direct full Vitest run was stopped after unrelated environment failures in default-app, app-runtime, qmd, CLI, and E2E suites; the focused desktop/platform coverage above passed.