### PR TITLE
fix(desktop): allow Vite React preamble in dev CSP

### DIFF
--- a/desktop/src/main/auth/header-injection.ts
+++ b/desktop/src/main/auth/header-injection.ts
@@ -79,13 +79,18 @@ function uniq(values: Array<string | null>): string[] {
 }
 
 function isLocalDevRendererOrigin(origin: string): boolean {
-  const normalized = normalizedHttpOrigin(origin);
-  if (!normalized) return false;
-  const url = new URL(normalized);
-  return (
-    (url.hostname === "localhost" || url.hostname === "127.0.0.1" || url.hostname === "[::1]") &&
-    url.port === "5173"
-  );
+  try {
+    const url = new URL(origin);
+    if (url.protocol !== "http:") return false;
+    return (
+      url.hostname === "localhost" ||
+      url.hostname === "127.0.0.1" ||
+      url.hostname === "[::1]" ||
+      url.hostname === "::1"
+    );
+  } catch {
+    return false;
+  }
 }
 
 export function buildRendererCsp(gatewayOrigin: string | null, rendererOrigin: string): string {

--- a/desktop/src/main/auth/header-injection.ts
+++ b/desktop/src/main/auth/header-injection.ts
@@ -85,8 +85,7 @@ function isLocalDevRendererOrigin(origin: string): boolean {
     return (
       url.hostname === "localhost" ||
       url.hostname === "127.0.0.1" ||
-      url.hostname === "[::1]" ||
-      url.hostname === "::1"
+      url.hostname === "[::1]"
     );
   } catch {
     return false;

--- a/tests/desktop/header-injection.test.ts
+++ b/tests/desktop/header-injection.test.ts
@@ -146,13 +146,25 @@ describe("installGatewayCors", () => {
     expect(scriptDirective(csp)).toBe("script-src 'self'");
   });
 
-  it("allows Vite React Refresh inline preamble only for localhost development renderers", () => {
-    const localhostCsp = buildRendererCsp(GATEWAY, "http://127.0.0.1:5173");
-    const otherLoopbackCsp = buildRendererCsp(GATEWAY, "http://127.0.0.1:9000");
-    const remoteCsp = buildRendererCsp(GATEWAY, "https://preview.example.com");
+  it("allows Vite React Refresh inline preamble for localhost development renderers", () => {
+    const localhostCsp = buildRendererCsp(GATEWAY, "http://localhost:3000");
+    const loopbackCsp = buildRendererCsp(GATEWAY, "http://127.0.0.1:5173");
+    const ipv6LoopbackCsp = buildRendererCsp(GATEWAY, "http://[::1]:5173");
 
     expect(scriptDirective(localhostCsp)).toBe("script-src 'self' 'unsafe-inline'");
-    expect(scriptDirective(otherLoopbackCsp)).toBe("script-src 'self'");
+    expect(scriptDirective(loopbackCsp)).toBe("script-src 'self' 'unsafe-inline'");
+    expect(scriptDirective(ipv6LoopbackCsp)).toBe("script-src 'self' 'unsafe-inline'");
+  });
+
+  it("keeps non-dev renderer scripts strict", () => {
+    const productionCsp = buildRendererCsp(GATEWAY, "https://app.matrix-os.com");
+    const packagedCsp = buildRendererCsp(GATEWAY, "null");
+    const remoteHttpCsp = buildRendererCsp(GATEWAY, "http://192.0.2.10:5173");
+    const remoteCsp = buildRendererCsp(GATEWAY, "https://preview.example.com");
+
+    expect(scriptDirective(productionCsp)).toBe("script-src 'self'");
+    expect(scriptDirective(packagedCsp)).toBe("script-src 'self'");
+    expect(scriptDirective(remoteHttpCsp)).toBe("script-src 'self'");
     expect(scriptDirective(remoteCsp)).toBe("script-src 'self'");
   });
 });


### PR DESCRIPTION
## Summary
- Allow `script-src 'self' 'unsafe-inline'` only for Electron renderer origins served over HTTP loopback (`localhost`, `127.0.0.1`, and `::1`) so the Vite React refresh preamble can execute in local desktop dev.
- Keep packaged, production, `null`, HTTPS, and arbitrary remote HTTP renderer origins on strict `script-src 'self'`.
- Add CSP tests for localhost arbitrary ports, IPv4 loopback, IPv6 loopback, packaged/null, production, and remote origins.

## Tests
- `pnpm exec vitest run tests/desktop/header-injection.test.ts`
- `pnpm --filter desktop run typecheck`
- `bun run check:patterns` (0 violations; existing broad warnings only)

## Invariants
- **Source of truth**: Electron main process response-header injection remains the source of truth for renderer CSP in desktop dev and packaged desktop loads.
- **Lock/transaction scope**: No persistence or multi-write transaction is involved; the change is a pure CSP string decision at header-injection time.
- **Acceptable orphan states**: No durable side effects are created. A malformed renderer origin falls back to strict scripts.
- **Auth source of truth**: Unchanged; gateway auth injection still keys off exact gateway origin matching and this PR does not alter credential handling.
- **Deferred scope**: This does not broaden `connect-src`, app iframe CSP, production web CSP, or any remote renderer policy.
