### PR TITLE
fix(desktop): add mac electron entitlements

### DIFF
--- a/desktop/build/entitlements.mac.plist
+++ b/desktop/build/entitlements.mac.plist
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>com.apple.security.cs.allow-jit</key>
+  <true/>
+  <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+  <true/>
+  <key>com.apple.security.cs.disable-library-validation</key>
+  <true/>
+</dict>
+</plist>

--- a/desktop/build/entitlements.mac.plist
+++ b/desktop/build/entitlements.mac.plist
@@ -7,6 +7,7 @@
   <true/>
   <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
   <true/>
+  <!-- Electron Framework.framework fails hardened-runtime library validation in packaged desktop builds. -->
   <key>com.apple.security.cs.disable-library-validation</key>
   <true/>
 </dict>

--- a/tests/desktop/packaging.test.ts
+++ b/tests/desktop/packaging.test.ts
@@ -29,11 +29,14 @@ describe("desktop packaging", () => {
     const entitlements = readFileSync(join(root, "desktop/build/entitlements.mac.plist"), "utf8");
     const entitlementKeys = Array.from(entitlements.matchAll(/<key>([^<]+)<\/key>/g), (match) => match[1]);
 
-    expect(entitlementKeys).toEqual([
-      "com.apple.security.cs.allow-jit",
-      "com.apple.security.cs.allow-unsigned-executable-memory",
-      "com.apple.security.cs.disable-library-validation",
-    ]);
+    expect(entitlementKeys).toHaveLength(3);
+    expect(entitlementKeys).toEqual(
+      expect.arrayContaining([
+        "com.apple.security.cs.allow-jit",
+        "com.apple.security.cs.allow-unsigned-executable-memory",
+        "com.apple.security.cs.disable-library-validation",
+      ]),
+    );
     expect(entitlementKeys).not.toContain("com.apple.security.app-sandbox");
     expect(entitlementKeys).not.toContain("com.apple.security.network.client");
     expect(entitlementKeys).not.toContain("com.apple.security.files.user-selected.read-write");

--- a/tests/desktop/packaging.test.ts
+++ b/tests/desktop/packaging.test.ts
@@ -14,4 +14,28 @@ describe("desktop packaging", () => {
     expect(schemes).toContain("matrixos");
     expect(schemes).toContain("matrix-os");
   });
+
+  it("uses the minimal Electron hardened-runtime entitlements for macOS", () => {
+    const root = process.cwd();
+    const raw = readFileSync(join(root, "desktop/electron-builder.yml"), "utf8");
+    const config = parseDocument(raw).toJS() as {
+      mac?: { entitlements?: string; entitlementsInherit?: string; hardenedRuntime?: boolean };
+    };
+
+    expect(config.mac?.hardenedRuntime).toBe(true);
+    expect(config.mac?.entitlements).toBe("build/entitlements.mac.plist");
+    expect(config.mac?.entitlementsInherit).toBe("build/entitlements.mac.plist");
+
+    const entitlements = readFileSync(join(root, "desktop/build/entitlements.mac.plist"), "utf8");
+    const entitlementKeys = Array.from(entitlements.matchAll(/<key>([^<]+)<\/key>/g), (match) => match[1]);
+
+    expect(entitlementKeys).toEqual([
+      "com.apple.security.cs.allow-jit",
+      "com.apple.security.cs.allow-unsigned-executable-memory",
+      "com.apple.security.cs.disable-library-validation",
+    ]);
+    expect(entitlementKeys).not.toContain("com.apple.security.app-sandbox");
+    expect(entitlementKeys).not.toContain("com.apple.security.network.client");
+    expect(entitlementKeys).not.toContain("com.apple.security.files.user-selected.read-write");
+  });
 });


### PR DESCRIPTION
## Summary
- add the missing macOS entitlements file referenced by the desktop electron-builder config
- include the minimal Electron hardened-runtime exceptions needed for signed macOS builds
- add a packaging regression test that keeps sandbox, file, and network entitlements out of this release config

## Validation
- pnpm test tests/desktop/desktop-release-workflows.test.ts tests/desktop/packaging.test.ts
- bun run check:patterns
- git diff --check
- desktop electron-vite build
- electron-builder mac arm64 package produced DMG/ZIP/update artifacts
- codesign verification passed for the packaged app
- DMG mount/copy smoke test passed
- spctl rejects the local artifact as unnotarized because Apple notary credentials are not present in this environment

## Invariants
- Source of truth: desktop/electron-builder.yml continues to reference desktop/build/entitlements.mac.plist for mac signing.
- Lock/transaction scope: no runtime state or database writes are changed.
- Acceptable orphan states: none; the regression test fails if the config references a missing entitlements file.
- Auth source of truth: unchanged.
- Deferred scope: notarization still requires APPLE_ID, APPLE_APP_SPECIFIC_PASSWORD or APPLE_APP_PASSWORD, and APPLE_TEAM_ID in the packaging environment.

## Privacy
- No production data, personal account fixtures, certificates, or secret values are included in the diff.
