### PR TITLE
fix(ci): prevent corrupt Docker image artifacts

### DIFF
--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -107,14 +107,18 @@ jobs:
         with:
           context: .
           file: Dockerfile.dev
-          load: true
           tags: matrix-os-dev:ci
+          outputs: type=docker,dest=/tmp/matrix-os-dev-ci.tar
           cache-from: type=gha,scope=dev-image
           cache-to: type=gha,mode=max,scope=dev-image
 
       - name: Save Docker image artifact
         if: needs.changes.outputs.should_run == 'true'
-        run: docker save matrix-os-dev:ci | gzip -1 > /tmp/matrix-os-dev-ci.tar.gz
+        run: |
+          set -euo pipefail
+          gzip -1 < /tmp/matrix-os-dev-ci.tar > /tmp/matrix-os-dev-ci.tar.gz
+          gzip -t /tmp/matrix-os-dev-ci.tar.gz
+          test "$(stat -c%s /tmp/matrix-os-dev-ci.tar.gz)" -gt 1000000
 
       - name: Upload Docker image artifact
         if: needs.changes.outputs.should_run == 'true'
@@ -157,7 +161,10 @@ jobs:
 
       - name: Load Docker image artifact
         if: needs.changes.outputs.should_run == 'true' && github.event_name == 'pull_request'
-        run: gzip -dc /tmp/docker-image/matrix-os-dev-ci.tar.gz | docker load
+        run: |
+          set -euo pipefail
+          gzip -t /tmp/docker-image/matrix-os-dev-ci.tar.gz
+          gzip -dc /tmp/docker-image/matrix-os-dev-ci.tar.gz | docker load
 
       - name: Create CI env file
         if: needs.changes.outputs.should_run == 'true' && github.event_name == 'pull_request'
@@ -249,7 +256,10 @@ jobs:
           path: /tmp/docker-image
 
       - name: Load Docker image artifact
-        run: gzip -dc /tmp/docker-image/matrix-os-dev-ci.tar.gz | docker load
+        run: |
+          set -euo pipefail
+          gzip -t /tmp/docker-image/matrix-os-dev-ci.tar.gz
+          gzip -dc /tmp/docker-image/matrix-os-dev-ci.tar.gz | docker load
 
       - name: Create CI env file
         run: |

--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -117,6 +117,7 @@ jobs:
         run: |
           set -euo pipefail
           gzip -1 < /tmp/matrix-os-dev-ci.tar > /tmp/matrix-os-dev-ci.tar.gz
+          rm /tmp/matrix-os-dev-ci.tar
           gzip -t /tmp/matrix-os-dev-ci.tar.gz
           test "$(stat -c%s /tmp/matrix-os-dev-ci.tar.gz)" -gt 1000000
 

--- a/tests/platform/ci-workflows.test.ts
+++ b/tests/platform/ci-workflows.test.ts
@@ -53,8 +53,14 @@ describe('CI workflows', () => {
     expect(workflow).toContain('name: Download Docker image artifact');
     expect(workflow).toContain('uses: actions/download-artifact@v7');
     expect(workflow).not.toContain('uses: actions/download-artifact@v8');
-    expect(workflow).toContain('docker save matrix-os-dev:ci | gzip -1 > /tmp/matrix-os-dev-ci.tar.gz');
+    expect(workflow).toContain('outputs: type=docker,dest=/tmp/matrix-os-dev-ci.tar');
+    expect(workflow).toContain('gzip -1 < /tmp/matrix-os-dev-ci.tar > /tmp/matrix-os-dev-ci.tar.gz');
+    expect(workflow).toContain('rm /tmp/matrix-os-dev-ci.tar');
+    expect(workflow).toContain('test "$(stat -c%s /tmp/matrix-os-dev-ci.tar.gz)" -gt 1000000');
+    expect(workflow).toContain('gzip -t /tmp/matrix-os-dev-ci.tar.gz');
+    expect(workflow).toContain('gzip -t /tmp/docker-image/matrix-os-dev-ci.tar.gz');
     expect(workflow).toContain('gzip -dc /tmp/docker-image/matrix-os-dev-ci.tar.gz | docker load');
+    expect(workflow).not.toContain('docker save matrix-os-dev:ci | gzip -1');
 
     const dockerBuildActionUses = workflow.match(/uses: docker\/build-push-action@v7/g) ?? [];
     expect(dockerBuildActionUses).toHaveLength(1);


### PR DESCRIPTION
## Summary

- Export the Docker test image directly from Buildx to `/tmp/matrix-os-dev-ci.tar` instead of loading it into the Docker daemon and then running `docker save`.
- Validate the compressed image artifact before upload with `gzip -t` and a minimum size sanity check.
- Remove the raw uncompressed tar immediately after compression to reduce runner disk pressure before artifact upload.
- Add `set -euo pipefail` and gzip validation before every `docker load` consumer path, so a corrupt image artifact fails at the real producer/consumer step instead of fanning out across the scenario matrix.
- Update the workflow regression test so it requires the new direct-export and artifact-validation path.

## Tests

- `git diff --check`
- `python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('.github/workflows/docker-test.yml').read_text())"`
- `pnpm run check:patterns` (0 violations; existing scanner warnings only)
- GitHub Actions CI on `6e048cf9`: `Type Check`, `Pattern Scan`, `React Doctor`, `Sync Client Package`, `Unit Tests (1/4..4/4)`, `E2E Tests`, and `CI Results` all passed.
- GitHub Actions Docker Tests on `6e048cf9`: `Build Docker Test Image`, artifact save/validate/upload, artifact download/load, and `Docker Smoke Test` fresh-install scenario all passed.
- Greptile Review passed on `6e048cf9`.

Not run locally:

- Focused Vitest run for `tests/platform/ci-workflows.test.ts`; this worktree does not have a local `vitest` binary installed. The same assertion is covered by CI `Unit Tests (1/4)`, which passed.

## Invariants

- Source of truth: the Docker test image artifact is the Buildx-exported tar at `/tmp/matrix-os-dev-ci.tar`, compressed once to `/tmp/matrix-os-dev-ci.tar.gz` for upload.
- Lock/transaction scope: not applicable; this PR changes GitHub Actions workflow orchestration only.
- Acceptable orphan states: if compression, validation, upload, download, or load fails, the workflow fails at that boundary and does not fan out a corrupt artifact into downstream scenario jobs.
- Auth source of truth: unchanged GitHub Actions workflow permissions and repository checkout behavior.
- Deferred scope: this does not change Docker image contents, scenario scripts, or production runtime deployment.

## Review/Monitoring

- This PR fixes the root cause seen on main after #624: `docker save` failed with `no space left on device`, the pipeline still uploaded a 173-byte gzip artifact, and all Docker scenario jobs failed while loading that corrupt artifact.
- `ready-for-ci` was refreshed after the test update so gated CI and Docker workflows ran on the latest commit.
