### PR TITLE
fix(platform): resolve internal integrations for VPS machines

### DIFF
--- a/packages/platform/src/main.ts
+++ b/packages/platform/src/main.ts
@@ -3584,12 +3584,16 @@ export function createApp(deps: {
       }
 
       const record = await getContainer(db, handle);
-      if (!record?.clerkUserId) {
+      const runningMachine = record?.clerkUserId
+        ? undefined
+        : await getRunningUserMachineByHandle(db, handle);
+      const clerkUserId = record?.clerkUserId ?? runningMachine?.clerkUserId;
+      if (!clerkUserId) {
         return c.json({ error: 'Unknown handle' }, 404);
       }
 
       c.set('internalContainerHandle', handle);
-      c.set('internalContainerClerkUserId', record.clerkUserId);
+      c.set('internalContainerClerkUserId', clerkUserId);
       return next();
     });
     internalIntegrationApp.route('/', deps.internalIntegrationRoutes);

--- a/tests/platform/internal-integration-routes.test.ts
+++ b/tests/platform/internal-integration-routes.test.ts
@@ -4,6 +4,7 @@ import { Hono } from "hono";
 import { createHmac } from "node:crypto";
 import {
   insertContainer,
+  insertUserMachine,
   type PlatformDB,
 } from "../../packages/platform/src/db.js";
 import { createApp } from "../../packages/platform/src/main.js";
@@ -81,5 +82,28 @@ describe("platform/internal-integration-routes", () => {
 
     expect(res.status).toBe(200);
     await expect(res.json()).resolves.toEqual({ clerkUserId: "user_alice" });
+  });
+
+  it("resolves current VPS user machines without legacy container rows", async () => {
+    await insertUserMachine(db, {
+      machineId: "machine-bob",
+      clerkUserId: "user_bob",
+      handle: "bob",
+      hetznerServerId: 123,
+      publicIPv4: "203.0.113.12",
+      status: "running",
+      imageVersion: "matrix-os-host-dev",
+      provisionedAt: "2026-06-24T00:00:00.000Z",
+    });
+    const app = createTestApp();
+
+    const res = await app.request("/internal/containers/bob/integrations/probe", {
+      headers: {
+        authorization: `Bearer ${bearerFor("bob", "platform-secret-123")}`,
+      },
+    });
+
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual({ clerkUserId: "user_bob" });
   });
 });

--- a/tests/platform/internal-integration-routes.test.ts
+++ b/tests/platform/internal-integration-routes.test.ts
@@ -106,4 +106,40 @@ describe("platform/internal-integration-routes", () => {
     expect(res.status).toBe(200);
     await expect(res.json()).resolves.toEqual({ clerkUserId: "user_bob" });
   });
+
+  it("keeps unknown internal integration handles as 404", async () => {
+    const app = createTestApp();
+
+    const res = await app.request("/internal/containers/charlie/integrations/probe", {
+      headers: {
+        authorization: `Bearer ${bearerFor("charlie", "platform-secret-123")}`,
+      },
+    });
+
+    expect(res.status).toBe(404);
+    await expect(res.json()).resolves.toEqual({ error: "Unknown handle" });
+  });
+
+  it("does not resolve non-running VPS machines for internal integrations", async () => {
+    await insertUserMachine(db, {
+      machineId: "machine-dana",
+      clerkUserId: "user_dana",
+      handle: "dana",
+      hetznerServerId: 124,
+      publicIPv4: "203.0.113.13",
+      status: "stopped",
+      imageVersion: "matrix-os-host-dev",
+      provisionedAt: "2026-06-24T00:00:00.000Z",
+    });
+    const app = createTestApp();
+
+    const res = await app.request("/internal/containers/dana/integrations/probe", {
+      headers: {
+        authorization: `Bearer ${bearerFor("dana", "platform-secret-123")}`,
+      },
+    });
+
+    expect(res.status).toBe(404);
+    await expect(res.json()).resolves.toEqual({ error: "Unknown handle" });
+  });
 });


### PR DESCRIPTION
## Summary
- resolve internal integration requests against current `user_machines` records when no legacy `containers` row exists
- keep the existing legacy container lookup behavior
- add regression coverage for internal integration routing from a running VPS machine record
- add negative coverage for unknown handles and non-running VPS machines

## Context
Symphony was reaching the platform-owned Linear bridge at `/internal/containers/:handle/integrations/call`, but the platform returned `404 {"error":"Unknown handle"}` before Linear/Pipedream was reached. The internal integration middleware only checked the legacy `containers` table, while current customer VPS instances are represented in `user_machines`.

## Validation
- `/opt/matrix/runtime/node/bin/corepack pnpm --filter @matrix-os/observability build && /opt/matrix/runtime/node/bin/corepack pnpm --filter @matrix-os/kernel build && /opt/matrix/runtime/node/bin/corepack pnpm exec vitest run tests/platform/internal-integration-routes.test.ts`
- `tests/platform/internal-integration-routes.test.ts`: 5 tests passed
