### PR TITLE
fix(terminal): soft detach zellij tabs

### DIFF
--- a/packages/gateway/src/shell/ws.ts
+++ b/packages/gateway/src/shell/ws.ts
@@ -214,9 +214,13 @@ export function createShellWsHandler(options: ShellWsHandlerOptions) {
         return;
       }
       closed = true;
-      abortController.abort();
       cleanupProcessListeners();
-      child.kill();
+      if (typeof child.detach === "function") {
+        child.detach();
+      } else {
+        abortController.abort();
+        child.kill();
+      }
     };
 
     return {

--- a/packages/gateway/src/shell/zellij.ts
+++ b/packages/gateway/src/shell/zellij.ts
@@ -481,16 +481,11 @@ export function createZellijAdapter(deps: ZellijAdapterDeps = {}): ZellijAdapter
         if (exited) {
           return;
         }
-        try {
-          // Zellij's default detach binding is Session mode (Ctrl-O), then `d`.
-          // This exits only the attached client, leaving the named session and
-          // its running panes alive for later reattach.
-          pty.write("\x0fd");
-        } catch (err: unknown) {
-          console.warn("[shell] zellij attach detach failed:", err instanceof Error ? err.message : String(err));
-          killAttachClient();
-          return;
-        }
+        void run(["--session", name, "action", "detach"], 1500)
+          .catch((err: unknown) => {
+            console.warn("[shell] zellij attach detach failed:", err instanceof Error ? err.message : String(err));
+            killAttachClient();
+          });
         clearDetachFallbackTimer();
         detachFallbackTimer = setTimeout(() => {
           detachFallbackTimer = null;

--- a/packages/gateway/src/shell/zellij.ts
+++ b/packages/gateway/src/shell/zellij.ts
@@ -24,6 +24,7 @@ type PtyExitEvent = { exitCode: number; signal?: number };
 export interface ShellAttachProcess {
   write(data: string): void;
   resize(cols: number, rows: number): void;
+  detach?(): void;
   kill(): void;
   onData(listener: (data: string) => void): Disposable;
   onExit(listener: (event: PtyExitEvent) => void): Disposable;
@@ -462,10 +463,47 @@ export function createZellijAdapter(deps: ZellijAdapterDeps = {}): ZellijAdapter
         cwd,
         env: attachEnv(deps.env, zellijConfigPaths),
       });
-      const abort = () => {
+      let exited = false;
+      let detachFallbackTimer: ReturnType<typeof setTimeout> | null = null;
+      const clearDetachFallbackTimer = () => {
+        if (detachFallbackTimer) {
+          clearTimeout(detachFallbackTimer);
+          detachFallbackTimer = null;
+        }
+      };
+      const killAttachClient = () => {
+        if (exited) {
+          return;
+        }
         pty.kill();
       };
+      const detachAttachClient = () => {
+        if (exited) {
+          return;
+        }
+        try {
+          // Zellij's default detach binding is Session mode (Ctrl-O), then `d`.
+          // This exits only the attached client, leaving the named session and
+          // its running panes alive for later reattach.
+          pty.write("\x0fd");
+        } catch (err: unknown) {
+          console.warn("[shell] zellij attach detach failed:", err instanceof Error ? err.message : String(err));
+          killAttachClient();
+          return;
+        }
+        clearDetachFallbackTimer();
+        detachFallbackTimer = setTimeout(() => {
+          detachFallbackTimer = null;
+          killAttachClient();
+        }, 1500);
+        detachFallbackTimer.unref?.();
+      };
+      const abort = () => {
+        killAttachClient();
+      };
       const exitDisposable = pty.onExit(() => {
+        exited = true;
+        clearDetachFallbackTimer();
         options.signal?.removeEventListener("abort", abort);
         exitDisposable.dispose();
       });
@@ -474,7 +512,14 @@ export function createZellijAdapter(deps: ZellijAdapterDeps = {}): ZellijAdapter
       } else {
         options.signal?.addEventListener("abort", abort, { once: true });
       }
-      return pty;
+      return {
+        write: pty.write.bind(pty),
+        resize: pty.resize.bind(pty),
+        kill: killAttachClient,
+        detach: detachAttachClient,
+        onData: pty.onData.bind(pty),
+        onExit: pty.onExit.bind(pty),
+      };
     },
     async listTabs(name) {
       const stdout = await run(["--session", name, "action", "query-tab-names"]);

--- a/tests/gateway/shell-zellij.test.ts
+++ b/tests/gateway/shell-zellij.test.ts
@@ -232,6 +232,47 @@ describe("zellij adapter", () => {
     expect(pty.kill).toHaveBeenCalled();
   });
 
+  it("soft-detaches attach PTYs and clears the fallback when zellij exits", () => {
+    vi.useFakeTimers();
+    try {
+      const pty = ptyProcess();
+      const spawnPty = vi.fn(() => pty);
+      const adapter = createZellijAdapter({ execFile: vi.fn(), spawnPty, timeoutMs: 25 });
+
+      const attached = adapter.attachSession("main");
+      attached.detach?.();
+
+      expect(pty.writes).toEqual(["\x0fd"]);
+      expect(pty.kill).not.toHaveBeenCalled();
+
+      pty.emitExit(0);
+      vi.advanceTimersByTime(1500);
+      expect(pty.kill).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("kills soft-detached attach PTYs when zellij does not exit", () => {
+    vi.useFakeTimers();
+    try {
+      const pty = ptyProcess();
+      const spawnPty = vi.fn(() => pty);
+      const adapter = createZellijAdapter({ execFile: vi.fn(), spawnPty, timeoutMs: 25 });
+
+      const attached = adapter.attachSession("main");
+      attached.detach?.();
+
+      expect(pty.writes).toEqual(["\x0fd"]);
+      expect(pty.kill).not.toHaveBeenCalled();
+
+      vi.advanceTimersByTime(1500);
+      expect(pty.kill).toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("attaches through a PTY so input, output, exit, and resize behave like a real terminal", () => {
     const pty = ptyProcess();
     const spawnPty = vi.fn(() => pty);

--- a/tests/gateway/shell-zellij.test.ts
+++ b/tests/gateway/shell-zellij.test.ts
@@ -232,17 +232,29 @@ describe("zellij adapter", () => {
     expect(pty.kill).toHaveBeenCalled();
   });
 
-  it("soft-detaches attach PTYs and clears the fallback when zellij exits", () => {
+  it("soft-detaches attach PTYs through zellij actions and clears the fallback when zellij exits", async () => {
     vi.useFakeTimers();
     try {
       const pty = ptyProcess();
       const spawnPty = vi.fn(() => pty);
-      const adapter = createZellijAdapter({ execFile: vi.fn(), spawnPty, timeoutMs: 25 });
+      const execFile = vi.fn((_file, _args, _opts, cb) => {
+        cb(null, "", "");
+        return childProcess();
+      });
+      const adapter = createZellijAdapter({ execFile, spawnPty, timeoutMs: 25 });
 
       const attached = adapter.attachSession("main");
       attached.detach?.();
+      await Promise.resolve();
+      await Promise.resolve();
 
-      expect(pty.writes).toEqual(["\x0fd"]);
+      expect(execFile).toHaveBeenCalledWith(
+        "zellij",
+        ["--session", "main", "action", "detach"],
+        expect.objectContaining({ timeout: 1500, signal: expect.any(AbortSignal) }),
+        expect.any(Function),
+      );
+      expect(pty.writes).toEqual([]);
       expect(pty.kill).not.toHaveBeenCalled();
 
       pty.emitExit(0);
@@ -253,17 +265,29 @@ describe("zellij adapter", () => {
     }
   });
 
-  it("kills soft-detached attach PTYs when zellij does not exit", () => {
+  it("kills soft-detached attach PTYs when zellij does not exit", async () => {
     vi.useFakeTimers();
     try {
       const pty = ptyProcess();
       const spawnPty = vi.fn(() => pty);
-      const adapter = createZellijAdapter({ execFile: vi.fn(), spawnPty, timeoutMs: 25 });
+      const execFile = vi.fn((_file, _args, _opts, cb) => {
+        cb(null, "", "");
+        return childProcess();
+      });
+      const adapter = createZellijAdapter({ execFile, spawnPty, timeoutMs: 25 });
 
       const attached = adapter.attachSession("main");
       attached.detach?.();
+      await Promise.resolve();
+      await Promise.resolve();
 
-      expect(pty.writes).toEqual(["\x0fd"]);
+      expect(execFile).toHaveBeenCalledWith(
+        "zellij",
+        ["--session", "main", "action", "detach"],
+        expect.objectContaining({ timeout: 1500, signal: expect.any(AbortSignal) }),
+        expect.any(Function),
+      );
+      expect(pty.writes).toEqual([]);
       expect(pty.kill).not.toHaveBeenCalled();
 
       vi.advanceTimersByTime(1500);

--- a/tests/gateway/terminal-zellij-ws.test.ts
+++ b/tests/gateway/terminal-zellij-ws.test.ts
@@ -12,6 +12,7 @@ class FakePty {
   writes: string[] = [];
   resizes: Array<{ cols: number; rows: number }> = [];
   killed = false;
+  detached = false;
   private dataListeners = new Set<(data: string) => void>();
   private exitListeners = new Set<(event: { exitCode: number; signal?: number }) => void>();
 
@@ -25,6 +26,11 @@ class FakePty {
 
   kill(): void {
     this.killed = true;
+    this.emitExit({ exitCode: 0 });
+  }
+
+  detach(): void {
+    this.detached = true;
     this.emitExit({ exitCode: 0 });
   }
 
@@ -65,7 +71,7 @@ function socket(): ShellWsSocket & { sent: unknown[]; closed: boolean } {
 }
 
 describe("zellij terminal WebSocket", () => {
-  it("attaches to a named session, replays from seq, forwards input, and cleans up", async () => {
+  it("attaches to a named session, replays from seq, forwards input, and soft-detaches on close", async () => {
     const pty = new FakePty();
     const ws = socket();
     const handler = createShellWsHandler({
@@ -94,6 +100,31 @@ describe("zellij terminal WebSocket", () => {
     expect(ws.sent).toContainEqual({ type: "output", seq: 0, data: "hello" });
     expect(pty.writes).toEqual(["pwd\r"]);
     expect(pty.resizes).toEqual([{ cols: 100, rows: 30 }]);
+    expect(pty.detached).toBe(true);
+    expect(pty.killed).toBe(false);
+  });
+
+  it("falls back to killing attach processes that do not support soft detach", async () => {
+    const pty = new FakePty();
+    const ws = socket();
+    const handler = createShellWsHandler({
+      registry: {
+        list: vi.fn(async () => [{ name: "main", status: "active" }]),
+      },
+      adapter: {
+        attachSession: vi.fn(() => ({
+          write: pty.write.bind(pty),
+          resize: pty.resize.bind(pty),
+          kill: pty.kill.bind(pty),
+          onData: pty.onData.bind(pty),
+          onExit: pty.onExit.bind(pty),
+        })),
+      },
+    });
+
+    const session = await handler.open({ ws, session: "main", fromSeq: 0 });
+    session.onClose();
+
     expect(pty.killed).toBe(true);
   });
 


### PR DESCRIPTION
## Summary

- Soft-detach Zellij attach clients on terminal WebSocket close/detach instead of killing them immediately.
- Keep hard-kill behavior as the fallback for attach processes that do not support soft detach.
- Add regression tests for named Zellij WebSocket close and Zellij adapter detach fallback behavior.

## Validation

- `pnpm exec vitest run tests/gateway/terminal-zellij-ws.test.ts`
- `pnpm exec vitest run tests/gateway/shell-zellij.test.ts`
- `bun run check:patterns`
- `pnpm --filter '@matrix-os/gateway' exec tsc --noEmit`
- `git diff --check`

## Invariants

**Source of truth**: Zellij remains the source of truth for named shell sessions and their panes; the WebSocket attach process is only a client view into that session.

**Lock/transaction scope**: No database or file writes are introduced. The critical lifecycle boundary is the WebSocket cleanup path, which now chooses `detach()` for soft client cleanup and only falls back to `kill()` when no detach primitive exists.

**Acceptable orphan states**: A named Zellij session may have zero attached WebSocket clients after tab switch, browser close, or network close. That is intentional; running panes remain available for later reattach. If the soft-detached attach client does not exit promptly, the adapter kills only that attach client after a bounded fallback timer.

**Auth source of truth**: WebSocket auth is unchanged and continues to use the existing `/ws/terminal` middleware/token path.

**Deferred scope**: This PR does not change session creation, session deletion, placement state, shell UI rendering, or legacy UUID PTY session TTL/eviction behavior.
