### PR TITLE
fix(terminal): clear deleted shell panes

### DIFF
--- a/shell/src/components/terminal/TerminalApp.tsx
+++ b/shell/src/components/terminal/TerminalApp.tsx
@@ -485,6 +485,30 @@ function getSessionIds(node: PaneNode): string[] {
   return [...getSessionIds(node.children[0]), ...getSessionIds(node.children[1])];
 }
 
+function getPaneIdsForSession(node: PaneNode, sessionId: string): string[] {
+  if (node.type === "pane") {
+    return node.sessionId === sessionId ? [node.id] : [];
+  }
+  return [
+    ...getPaneIdsForSession(node.children[0], sessionId),
+    ...getPaneIdsForSession(node.children[1], sessionId),
+  ];
+}
+
+function removeSessionFromPaneTree(node: PaneNode, sessionId: string): PaneNode | null {
+  if (node.type === "pane") {
+    return node.sessionId === sessionId ? null : node;
+  }
+  const left = removeSessionFromPaneTree(node.children[0], sessionId);
+  const right = removeSessionFromPaneTree(node.children[1], sessionId);
+  if (!left) return right;
+  if (!right) return left;
+  if (left === node.children[0] && right === node.children[1]) {
+    return node;
+  }
+  return { ...node, children: [left, right] };
+}
+
 function layoutUsesOnlyCanonicalShellSessions(layout: TerminalLayout): boolean {
   if (!Array.isArray(layout.tabs) || layout.tabs.length === 0) {
     return false;
@@ -898,6 +922,31 @@ export function TerminalApp({ initialCommand, initialLabel, initialClaudeMode = 
     setFocusedPaneId(nextFocusedPaneId);
   };
 
+  const removeDeletedShellSessionFromLayout = (sessionId: string) => {
+    const paneIds = tabsRef.current.flatMap((tab) => getPaneIdsForSession(tab.paneTree, sessionId));
+    if (paneIds.length === 0) {
+      return;
+    }
+    markPanesClosing(paneIds);
+    setTabs((prev) => {
+      const next = prev
+        .map((tab) => {
+          const paneTree = removeSessionFromPaneTree(tab.paneTree, sessionId);
+          return paneTree ? { ...tab, paneTree } : null;
+        })
+        .filter((tab): tab is Tab => tab !== null);
+      tabsRef.current = next;
+      setActiveTabId((current) => next.some((tab) => tab.id === current) ? current : next[0]?.id ?? "");
+      setFocusedPaneId((current) => {
+        if (current && next.some((tab) => hasPaneId(tab.paneTree, current))) {
+          return current;
+        }
+        return next[0] ? getFirstPaneId(next[0].paneTree) : null;
+      });
+      return next;
+    });
+  };
+
   // react-doctor-disable-next-line react-doctor/no-fetch-in-effect -- one-time mount bootstrap that loads the saved terminal layout from the gateway; the fetch is AbortSignal-guarded and every state write is gated behind a `cancelled` flag cleared in cleanup, so this is an intentional mount-driven load, not render data
   useEffect(() => {
     let cancelled = false;
@@ -1241,6 +1290,10 @@ export function TerminalApp({ initialCommand, initialLabel, initialClaudeMode = 
       markTerminalLayoutDirty();
       return backgroundShellSession(...args);
     },
+    removeDeletedShellSessionFromLayout: (...args: Parameters<typeof removeDeletedShellSessionFromLayout>) => {
+      markTerminalLayoutDirty();
+      return removeDeletedShellSessionFromLayout(...args);
+    },
     closeTab: (...args: Parameters<typeof closeTab>) => {
       markTerminalLayoutDirty();
       return closeTab(...args);
@@ -1380,6 +1433,7 @@ interface TerminalAppContextType {
   addSessionTab: (label: string, sessionId: string, cwd?: string) => string;
   createShellSessionTab: (label: string, cwd?: string) => Promise<string | null>;
   backgroundShellSession: (sessionId: string) => void;
+  removeDeletedShellSessionFromLayout: (sessionId: string) => void;
   closeTab: (tabId: string) => void;
   setActiveTab: (tabId: string) => void;
   renameTab: (tabId: string, label: string) => void;
@@ -2929,6 +2983,7 @@ function LocalTerminalSidebar() {
         setShells((prev) => prev.some((shell) => shell.name === name) || !deletedShell ? prev : [...prev, deletedShell]);
         return;
       }
+      ctx.removeDeletedShellSessionFromLayout(name);
       await fetchShells({ silent: true });
     } catch (err: unknown) {
       console.warn("Failed to remove shell session:", err instanceof Error ? err.message : err);

--- a/tests/shell/terminal-app-component.test.tsx
+++ b/tests/shell/terminal-app-component.test.tsx
@@ -2347,6 +2347,83 @@ describe("TerminalApp", () => {
     expect(screen.queryByText("matrix-main")).toBeNull();
   });
 
+  it("removes open panes for a managed shell after deleting that shell", async () => {
+    let benchDeleted = false;
+    vi.stubGlobal("fetch", vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.includes("/api/files/tree")) {
+        return Promise.resolve({ ok: true, json: async () => [] });
+      }
+      if (url.includes("/api/terminal/layout") && init?.method === "PUT") {
+        return Promise.resolve({ ok: true, json: async () => ({ ok: true }) });
+      }
+      if (url.includes("/api/terminal/layout")) {
+        return Promise.resolve({ ok: true, json: async () => ({}) });
+      }
+      if (url.includes("/api/terminal/sessions/bench") && init?.method === "DELETE") {
+        benchDeleted = true;
+        return Promise.resolve({ ok: true, json: async () => ({ ok: true }) });
+      }
+      if (url.includes("/api/terminal/sessions")) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            sessions: [
+              {
+                name: "main",
+                status: "active",
+                attachedClients: 0,
+                tabs: [{ idx: 0, name: "main", focused: true }],
+              },
+              ...(benchDeleted ? [] : [{
+                name: "bench",
+                status: "active",
+                attachedClients: 0,
+                tabs: [{ idx: 0, name: "work", focused: true }],
+              }]),
+            ],
+          }),
+        });
+      }
+      return Promise.resolve({ ok: true, json: async () => ({}) });
+    }));
+
+    render(<TerminalApp />);
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /open bench/i }));
+      await Promise.resolve();
+    });
+    expect(paneGridSpy.mock.lastCall?.[0]).toMatchObject({
+      paneTree: { sessionId: "bench" },
+    });
+
+    revealSessionActions("bench");
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /close bench/i }));
+      await Promise.resolve();
+    });
+    await act(async () => {
+      fireEvent.click(within(screen.getByRole("dialog", { name: "Close this session?" })).getByRole("button", { name: "Delete" }));
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(vi.mocked(global.fetch).mock.calls.filter(([input, init]) => (
+      String(input).includes("/api/terminal/sessions/bench?force=1") && init?.method === "DELETE"
+    ))).toHaveLength(1);
+    expect(paneGridSpy.mock.lastCall?.[0]).toMatchObject({
+      paneTree: expect.not.objectContaining({ sessionId: "bench" }),
+    });
+  });
+
   it("keeps the Shells sidebar synchronized after manual refresh", async () => {
     let revealBench = false;
     vi.stubGlobal("fetch", vi.fn((input: RequestInfo | URL, init?: RequestInit) => {


### PR DESCRIPTION
## Summary
- remove open terminal panes/tabs that reference a managed shell session after that session is successfully deleted
- collapse split pane trees around the removed deleted-session pane instead of keeping stale session ids
- add a regression test for deleting an active managed shell and preventing switch-back to a dead session

## Invariants
- Source of truth: the gateway shell session registry remains canonical for which managed shell sessions exist; the browser terminal layout mirrors only still-valid session references.
- Lock/transaction scope: no database or server transaction is touched; UI layout cleanup happens only after the DELETE request succeeds.
- Acceptable orphan states: if DELETE fails, the open pane/layout is preserved and the sidebar rolls back the shell row. If DELETE succeeds but later shell refresh fails, the dead session pane has still been removed locally and will be persisted by the layout save flow.
- Auth source of truth: unchanged; existing gateway-authenticated terminal session APIs are used.
- Deferred scope: this does not change zellij attach/detach semantics or session resurrection behavior.

## Validation
- `pnpm exec vitest run tests/shell/terminal-app-component.test.tsx --testNamePattern "removes open panes"`
- `pnpm exec vitest run tests/shell/terminal-app-component.test.tsx tests/shell/terminal-pane.test.tsx`
- `pnpm exec tsc --noEmit -p shell/tsconfig.json`
- `bun run check:patterns` (0 violations; existing warnings only)
- `npx react-doctor@latest shell --verbose --scope changed` (No issues found)
- `git diff --check`

## Notes
- `bun run typecheck` currently fails on existing `packages/gateway/src/sync/home-mirror.ts` errors unrelated to this shell change.
- Screenshot: no visual styling change; this is a state/lifecycle fix covered by the regression test.
