### PR TITLE
fix(billing): honor app shell sessions

### DIFF
--- a/packages/platform/src/main.ts
+++ b/packages/platform/src/main.ts
@@ -2083,7 +2083,8 @@ export function createApp(deps: {
     const cookie = c.req.header('cookie');
     const clerkToken = clerkAuth?.extractToken(authorization, cookie);
     const bearerToken = authorization?.startsWith('Bearer ') ? authorization.slice(7) : null;
-    if (!clerkToken && !bearerToken) return null;
+    const appSessionToken = readCookie(cookie, APP_SESSION_COOKIE);
+    if (!clerkToken && !bearerToken && !appSessionToken) return null;
 
     try {
       if (clerkAuth && clerkToken) {
@@ -2096,13 +2097,15 @@ export function createApp(deps: {
       console.warn(`[billing] Clerk verification failed: ${kind}`);
     }
 
-    if (!platformJwtSecret || !bearerToken) return null;
+    const syncJwtToken = bearerToken ?? appSessionToken;
+    if (!platformJwtSecret || !syncJwtToken) return null;
     try {
-      const claims = await verifySyncJwt(bearerToken, { secret: platformJwtSecret });
+      const claims = await verifySyncJwt(syncJwtToken, { secret: platformJwtSecret });
       return claims.sub;
     } catch (err: unknown) {
       const kind = err instanceof Error ? err.name : typeof err;
-      console.warn(`[billing] native token verification failed: ${kind}`);
+      const source = bearerToken ? 'native token' : 'app session token';
+      console.warn(`[billing] ${source} verification failed: ${kind}`);
       return null;
     }
   }

--- a/shell/src/components/BillingGate.tsx
+++ b/shell/src/components/BillingGate.tsx
@@ -424,7 +424,7 @@ function BillingGateInner({ children }: { children: ReactNode }) {
   }
 
   useEffect(() => {
-    if (!isLoaded) return;
+    if (!isLoaded || billingChecking) return;
     const state = hasBillingAccess
       ? "billing_active"
       : !isSignedIn
@@ -446,7 +446,7 @@ function BillingGateInner({ children }: { children: ReactNode }) {
       access_state: state,
       checkout_return_requested: checkoutReturnRequested,
     });
-  }, [checkoutReturnRequested, hasBillingAccess, isLoaded, isSignedIn]);
+  }, [billingChecking, checkoutReturnRequested, hasBillingAccess, isLoaded, isSignedIn]);
 
   if (e2eBillingBypass) {
     return <>{children}</>;

--- a/shell/src/components/BillingGate.tsx
+++ b/shell/src/components/BillingGate.tsx
@@ -283,14 +283,14 @@ export function BillingGate({
 
 function BillingGateInner({ children }: { children: ReactNode }) {
   const { isLoaded, isSignedIn, getToken } = useAuth();
-  const { active: billingActive } = useMatrixBillingAccess();
+  const { active: billingActive, checking: billingAccessChecking } = useMatrixBillingAccess();
   const router = useRouter();
   const searchParams = useSearchParams();
   const checkoutReturnRequested = searchParams.get("checkout") === "success";
   const deviceReturnPath = normalizeDeviceReturnPath(searchParams.get("device_return"));
   const billingCheckoutReturnPath = getBillingCheckoutReturnPath(deviceReturnPath);
-  const hasBillingAccess = isSignedIn ? billingActive === true : false;
-  const billingChecking = isSignedIn && billingActive === null;
+  const hasBillingAccess = billingActive === true;
+  const billingChecking = billingAccessChecking;
   const [checkoutJustCompleted, setCheckoutJustCompleted] = useState(false);
   const [checkoutAttemptChecked, setCheckoutAttemptChecked] = useState(false);
   const [deviceSetupStatus, setDeviceSetupStatus] = useState<"idle" | "preparing" | "failed">("idle");
@@ -425,10 +425,10 @@ function BillingGateInner({ children }: { children: ReactNode }) {
 
   useEffect(() => {
     if (!isLoaded) return;
-    const state = !isSignedIn
-      ? "signed_out"
-      : hasBillingAccess
-        ? "billing_active"
+    const state = hasBillingAccess
+      ? "billing_active"
+      : !isSignedIn
+        ? "signed_out"
         : checkoutReturnRequested
           ? "checkout_return_pending"
           : "billing_required";
@@ -456,7 +456,7 @@ function BillingGateInner({ children }: { children: ReactNode }) {
     return <BillingStatusLoading />;
   }
 
-  if (!isSignedIn) {
+  if (!isSignedIn && !hasBillingAccess) {
     return <SignInRedirecting />;
   }
 

--- a/shell/src/hooks/useMatrixBillingAccess.ts
+++ b/shell/src/hooks/useMatrixBillingAccess.ts
@@ -73,8 +73,11 @@ export function useMatrixBillingAccess(): BillingAccessState {
       return;
     }
     const billingCacheKey = isSignedIn ? userId : PLATFORM_SESSION_BILLING_CACHE_KEY;
+    const shouldUseSnapshotCache = isSignedIn;
     const checkoutReturnRequested = isCheckoutSuccessReturn();
-    const cached = checkoutReturnRequested ? null : readCachedBillingStatus(billingCacheKey);
+    const cached = checkoutReturnRequested || !shouldUseSnapshotCache
+      ? null
+      : readCachedBillingStatus(billingCacheKey);
     if (cached !== null) {
       setRemoteState(cached);
       setRemoteChecked(true);
@@ -83,7 +86,10 @@ export function useMatrixBillingAccess(): BillingAccessState {
     let disposed = false;
     let retryTimeoutId: number | undefined;
     setRemoteChecked(false);
-    readRemoteBillingStatus(billingCacheKey, { skipInactiveCache: checkoutReturnRequested })
+    readRemoteBillingStatus(billingCacheKey, {
+      skipCache: !shouldUseSnapshotCache,
+      skipInactiveCache: checkoutReturnRequested,
+    })
       .then((state) => {
         if (disposed) return;
         setRemoteState(state);
@@ -138,7 +144,7 @@ function isCheckoutSuccessReturn(): boolean {
 
 function readRemoteBillingStatus(
   cacheKey: string,
-  options: { skipInactiveCache?: boolean } = {},
+  options: { skipCache?: boolean; skipInactiveCache?: boolean } = {},
 ): Promise<BillingAccessRemoteState> {
   if (billingStatusRequest?.cacheKey === cacheKey) return billingStatusRequest.promise;
 
@@ -167,7 +173,7 @@ function readRemoteBillingStatus(
       };
     })
     .then((state) => {
-      if (state.active || !options.skipInactiveCache) {
+      if (!options.skipCache && (state.active || !options.skipInactiveCache)) {
         billingStatusSnapshot = { cacheKey, state, checkedAt: Date.now() };
       }
       return state;

--- a/shell/src/hooks/useMatrixBillingAccess.ts
+++ b/shell/src/hooks/useMatrixBillingAccess.ts
@@ -7,15 +7,16 @@ import { hasMatrixBillingAccess } from "@/lib/billing";
 const BILLING_STATUS_TIMEOUT_MS = 10_000;
 const BILLING_STATUS_CACHE_TTL_MS = 30_000;
 const BILLING_STATUS_RETRY_MS = 3_000;
+const PLATFORM_SESSION_BILLING_CACHE_KEY = "platform-session";
 
 type BillingStatusSnapshot = {
-  userId: string;
+  cacheKey: string;
   state: BillingAccessRemoteState;
   checkedAt: number;
 };
 
 let billingStatusSnapshot: BillingStatusSnapshot | null = null;
-let billingStatusRequest: { userId: string; promise: Promise<BillingAccessRemoteState> } | null = null;
+let billingStatusRequest: { cacheKey: string; promise: Promise<BillingAccessRemoteState> } | null = null;
 
 type BillingAccessState = {
   active: boolean | null;
@@ -60,19 +61,20 @@ export function useMatrixBillingAccess(): BillingAccessState {
 
   // react-doctor-disable-next-line react-doctor/no-cascading-set-state -- the setRemoteState/setRemoteChecked pairs live in mutually-exclusive branches (auth-gate, missing-userId, cache-hit, async fetch then/catch) representing a single load's loading -> result transition; they are not a synchronous render cascade and combining them across branches would obscure the distinct cases
   useEffect(() => {
-    if (!isLoaded || !isSignedIn || legacyActive) {
+    if (!isLoaded || legacyActive) {
       // react-doctor-disable-next-line react-hooks-js/set-state-in-effect -- async billing-status load hook: it reads Clerk auth + a module-level cache and otherwise fetches /billing/status, setting remoteState/remoteChecked from the (async) result; the value cannot be derived in render
       setRemoteState(null);
-      setRemoteChecked(!isLoaded || !isSignedIn || legacyActive);
+      setRemoteChecked(!isLoaded || legacyActive);
       return;
     }
-    if (!userId) {
+    if (isSignedIn && !userId) {
       setRemoteState({ active: false, entitlement: null, accessReason: null });
       setRemoteChecked(true);
       return;
     }
+    const billingCacheKey = isSignedIn ? userId : PLATFORM_SESSION_BILLING_CACHE_KEY;
     const checkoutReturnRequested = isCheckoutSuccessReturn();
-    const cached = checkoutReturnRequested ? null : readCachedBillingStatus(userId);
+    const cached = checkoutReturnRequested ? null : readCachedBillingStatus(billingCacheKey);
     if (cached !== null) {
       setRemoteState(cached);
       setRemoteChecked(true);
@@ -81,7 +83,7 @@ export function useMatrixBillingAccess(): BillingAccessState {
     let disposed = false;
     let retryTimeoutId: number | undefined;
     setRemoteChecked(false);
-    readRemoteBillingStatus(userId, { skipInactiveCache: checkoutReturnRequested })
+    readRemoteBillingStatus(billingCacheKey, { skipInactiveCache: checkoutReturnRequested })
       .then((state) => {
         if (disposed) return;
         setRemoteState(state);
@@ -108,7 +110,6 @@ export function useMatrixBillingAccess(): BillingAccessState {
   }, [isLoaded, isSignedIn, legacyActive, retryTick, userId]);
 
   if (!isLoaded) return { active: null, checking: true, entitlement: null, accessReason: null };
-  if (!isSignedIn) return { active: false, checking: false, entitlement: null, accessReason: null };
   if (legacyActive) return { active: true, checking: false, entitlement: null, accessReason: "legacy_clerk_plan" };
   if (!remoteChecked) return { active: null, checking: true, entitlement: null, accessReason: null };
   return {
@@ -124,8 +125,8 @@ export function resetMatrixBillingAccessCacheForTests(): void {
   billingStatusRequest = null;
 }
 
-function readCachedBillingStatus(userId: string): BillingAccessRemoteState | null {
-  if (!billingStatusSnapshot || billingStatusSnapshot.userId !== userId) return null;
+function readCachedBillingStatus(cacheKey: string): BillingAccessRemoteState | null {
+  if (!billingStatusSnapshot || billingStatusSnapshot.cacheKey !== cacheKey) return null;
   if (Date.now() - billingStatusSnapshot.checkedAt > BILLING_STATUS_CACHE_TTL_MS) return null;
   return billingStatusSnapshot.state;
 }
@@ -136,10 +137,10 @@ function isCheckoutSuccessReturn(): boolean {
 }
 
 function readRemoteBillingStatus(
-  userId: string,
+  cacheKey: string,
   options: { skipInactiveCache?: boolean } = {},
 ): Promise<BillingAccessRemoteState> {
-  if (billingStatusRequest?.userId === userId) return billingStatusRequest.promise;
+  if (billingStatusRequest?.cacheKey === cacheKey) return billingStatusRequest.promise;
 
   const controller = new AbortController();
   const timeoutId = window.setTimeout(() => controller.abort(), BILLING_STATUS_TIMEOUT_MS);
@@ -167,7 +168,7 @@ function readRemoteBillingStatus(
     })
     .then((state) => {
       if (state.active || !options.skipInactiveCache) {
-        billingStatusSnapshot = { userId, state, checkedAt: Date.now() };
+        billingStatusSnapshot = { cacheKey, state, checkedAt: Date.now() };
       }
       return state;
     })
@@ -176,6 +177,6 @@ function readRemoteBillingStatus(
       if (billingStatusRequest?.promise === promise) billingStatusRequest = null;
     });
 
-  billingStatusRequest = { userId, promise };
+  billingStatusRequest = { cacheKey, promise };
   return promise;
 }

--- a/tests/platform/proxy-routing.test.ts
+++ b/tests/platform/proxy-routing.test.ts
@@ -415,6 +415,110 @@ describe("platform proxy routing", () => {
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
+  it("serves platform billing status for app-shell session cookie callers", async () => {
+    await upsertBillingEntitlement(db, {
+      clerkUserId: "user_alice",
+      source: "stripe",
+      planSlug: "matrix_builder",
+      status: "active",
+      maxRuntimeSlots: 1,
+      includedRuntimeSlots: 1,
+      addonRuntimeSlots: 0,
+      defaultServerType: "cpx32",
+      allowedServerTypes: ["cpx22", "cpx32"],
+      stripeSubscriptionId: "sub_123",
+      stripePriceId: "price_builder_monthly",
+      gracePeriodEndsAt: "2026-06-02T00:00:00.000Z",
+      effectiveFrom: "2026-05-30T00:00:00.000Z",
+      effectiveUntil: null,
+      updatedAt: "2026-05-30T00:00:00.000Z",
+    });
+    const issued = await issueSyncJwt({
+      secret: JWT_SECRET,
+      clerkUserId: "user_alice",
+      handle: "alice",
+      gatewayUrl: "https://app.matrix-os.com",
+      runtimeSlot: "primary",
+    });
+    process.env.PLATFORM_JWT_SECRET = JWT_SECRET;
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response("wrong target", { status: 200 }),
+    );
+    const app = createApp({
+      db,
+      orchestrator: stubOrchestrator(),
+      clerkAuth: createClerkAuth({
+        verifyToken: vi.fn().mockRejectedValue(new Error("missing Clerk token")),
+      }),
+      platformSecret: "platform-secret-123",
+    });
+
+    const res = await app.request("/billing/status", {
+      headers: {
+        host: "app.matrix-os.com",
+        cookie: `matrix_app_session=${encodeURIComponent(issued.token)}`,
+      },
+    });
+
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toMatchObject({
+      entitlement: { planSlug: "matrix_builder" },
+      access: { runtimeProxyAllowed: true },
+    });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("does not authorize billing routes with per-app session cookies", async () => {
+    const issued = await issueSyncJwt({
+      secret: JWT_SECRET,
+      clerkUserId: "user_alice",
+      handle: "alice",
+      gatewayUrl: "https://app.matrix-os.com",
+      runtimeSlot: "primary",
+    });
+    process.env.PLATFORM_JWT_SECRET = JWT_SECRET;
+    const app = createApp({
+      db,
+      orchestrator: stubOrchestrator(),
+      clerkAuth: createClerkAuth({
+        verifyToken: vi.fn().mockRejectedValue(new Error("missing Clerk token")),
+      }),
+      platformSecret: "platform-secret-123",
+    });
+
+    const res = await app.request("/billing/status", {
+      headers: {
+        host: "app.matrix-os.com",
+        cookie: `matrix_app_session__calculator=${encodeURIComponent(issued.token)}`,
+      },
+    });
+
+    expect(res.status).toBe(401);
+    expect(await res.json()).toEqual({ error: "Unauthorized" });
+  });
+
+  it("returns unauthorized for invalid app-shell session cookies on billing routes", async () => {
+    process.env.PLATFORM_JWT_SECRET = JWT_SECRET;
+    const app = createApp({
+      db,
+      orchestrator: stubOrchestrator(),
+      clerkAuth: createClerkAuth({
+        verifyToken: vi.fn().mockRejectedValue(new Error("missing Clerk token")),
+      }),
+      platformSecret: "platform-secret-123",
+    });
+
+    const res = await app.request("/billing/status", {
+      headers: {
+        host: "app.matrix-os.com",
+        cookie: "matrix_app_session=not-a-sync-jwt",
+      },
+    });
+
+    expect(res.status).toBe(401);
+    expect(await res.json()).toEqual({ error: "Unauthorized" });
+  });
+
   it("uses the raw bearer sync JWT for native billing fallback when a stale Clerk cookie is present", async () => {
     await upsertBillingEntitlement(db, {
       clerkUserId: "user_alice",

--- a/tests/shell/billing-gate.test.tsx
+++ b/tests/shell/billing-gate.test.tsx
@@ -122,6 +122,38 @@ describe("BillingGate", () => {
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
+  it("renders the shell for app-session billing access without Clerk client auth", async () => {
+    vi.unstubAllEnvs();
+    clerkState.isLoaded = true;
+    clerkState.isSignedIn = false;
+    clerkState.activePlan = null;
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ access: { runtimeProxyAllowed: true, reason: "active" } }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+    vi.resetModules();
+
+    const { BillingGate } = await loadBillingGate();
+
+    render(
+      <BillingGate>
+        <div>Matrix workspace</div>
+      </BillingGate>,
+    );
+
+    expect(await screen.findByText("Matrix workspace")).toBeTruthy();
+    expect(screen.queryByText("Opening Matrix OS sign in")).toBeNull();
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/billing/status",
+      expect.objectContaining({
+        credentials: "include",
+        method: "GET",
+      }),
+    );
+  });
+
   it("bypasses billing only for explicit test screenshot runs", async () => {
     vi.stubEnv("NEXT_PUBLIC_E2E_TEST_BYPASS", "1");
     clerkState.isLoaded = true;
@@ -533,7 +565,7 @@ describe("BillingGate", () => {
     );
 
     expect(screen.queryByText("Matrix workspace")).toBeNull();
-    expect(screen.getByText("Opening Matrix OS sign in")).toBeTruthy();
+    expect(await screen.findByText("Opening Matrix OS sign in")).toBeTruthy();
     expect(screen.queryByTestId("sign-in-component")).toBeNull();
     expect(screen.queryByTestId("pricing-table")).toBeNull();
   });

--- a/tests/shell/billing-gate.test.tsx
+++ b/tests/shell/billing-gate.test.tsx
@@ -154,6 +154,47 @@ describe("BillingGate", () => {
     );
   });
 
+  it("revalidates app-session billing instead of reusing a signed-out active cache", async () => {
+    vi.unstubAllEnvs();
+    clerkState.isLoaded = true;
+    clerkState.isSignedIn = false;
+    clerkState.activePlan = null;
+    const fetchMock = vi.spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ access: { runtimeProxyAllowed: true, reason: "active" } }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ error: "Unauthorized" }), {
+          status: 401,
+          headers: { "content-type": "application/json" },
+        }),
+      );
+    vi.resetModules();
+
+    const { BillingGate } = await loadBillingGate();
+
+    render(
+      <BillingGate>
+        <div>Matrix workspace</div>
+      </BillingGate>,
+    );
+
+    expect(await screen.findByText("Matrix workspace")).toBeTruthy();
+    cleanup();
+
+    render(
+      <BillingGate>
+        <div>Matrix workspace</div>
+      </BillingGate>,
+    );
+
+    expect(await screen.findByText("Opening Matrix OS sign in")).toBeTruthy();
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
   it("bypasses billing only for explicit test screenshot runs", async () => {
     vi.stubEnv("NEXT_PUBLIC_E2E_TEST_BYPASS", "1");
     clerkState.isLoaded = true;

--- a/tests/shell/billing-section.test.tsx
+++ b/tests/shell/billing-section.test.tsx
@@ -6,7 +6,8 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const clerkState = vi.hoisted(() => ({
   isLoaded: true,
-  userId: "user_123",
+  isSignedIn: true,
+  userId: "user_123" as string | null,
   activePlan: null as string | null,
 }));
 
@@ -14,7 +15,7 @@ function installClerkMock() {
   vi.doMock("@clerk/nextjs", () => ({
     useAuth: () => ({
       isLoaded: clerkState.isLoaded,
-      isSignedIn: true,
+      isSignedIn: clerkState.isSignedIn,
       userId: clerkState.userId,
       has: ({ plan }: { plan: string }) => plan === clerkState.activePlan,
     }),
@@ -36,6 +37,10 @@ describe("BillingSection", () => {
       "../../shell/src/hooks/useMatrixBillingAccess.js"
     );
     resetMatrixBillingAccessCacheForTests();
+    clerkState.isLoaded = true;
+    clerkState.isSignedIn = true;
+    clerkState.userId = "user_123";
+    clerkState.activePlan = null;
     vi.spyOn(globalThis, "fetch").mockImplementation(async () =>
       new Response(JSON.stringify({ access: { runtimeProxyAllowed: false } }), {
         status: 200,
@@ -76,6 +81,32 @@ describe("BillingSection", () => {
     expect(screen.getByRole("button", { name: "Annual" }).getAttribute("aria-pressed")).toBe("false");
     expect(screen.queryByText("Developer tools")).toBeNull();
     expect(screen.queryByTestId("pricing-table")).toBeNull();
+  });
+
+  it("checks cookie-backed billing status when Clerk is signed out", async () => {
+    clerkState.isLoaded = true;
+    clerkState.isSignedIn = false;
+    clerkState.userId = null;
+    clerkState.activePlan = null;
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ access: { runtimeProxyAllowed: false } }), {
+        status: 401,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+
+    const { BillingSection } = await loadBillingSection();
+
+    render(<BillingSection />);
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledWith(
+      "/billing/status",
+      expect.objectContaining({
+        credentials: "include",
+        method: "GET",
+      }),
+    ));
+    await waitFor(() => expect(screen.getByText("Not active")).toBeTruthy());
   });
 
   it("keeps billing status unknown and retries after transient status failures", async () => {


### PR DESCRIPTION
## Summary
- Allow platform billing routes to authenticate the first-party `matrix_app_session` cookie in addition to Clerk and native bearer sync JWTs.
- Let the shell billing hook query `/billing/status` with cookies even when Clerk client auth is signed out.
- Let `BillingGate` open the workspace when cookie-backed billing status is active.

## Tests
- `bunx vitest run tests/platform/proxy-routing.test.ts --testNamePattern billing`
- `bunx vitest run tests/shell/billing-gate.test.tsx tests/shell/billing-section.test.tsx --environment jsdom`
- `pnpm --filter @matrix-os/platform exec tsc --noEmit -p tsconfig.typecheck.json`
- `pnpm --filter shell exec tsc --noEmit -p tsconfig.json`
- `bun run check:patterns` (passes with pre-existing scanner warnings)
- `npx react-doctor@latest --verbose --scope changed shell`

Full `bun run typecheck` was attempted but the nested worktree dependency layout hit an unrelated desktop Vite 6/7 type mismatch before the changed packages. Full `bun run test` was attempted and stopped after broad unrelated environment failures: default-app localStorage unavailable, GPG signing blocked in sandboxed git tests, CLI TTY timeouts, and app-runtime build timeouts. Billing-focused tests and changed-package typechecks pass.

## Review/Monitoring
- Please let CI and Greptile run on this branch.
- This PR should be deployed through the platform/app-shell service after merge; a customer host-bundle-only publish will not update the affected pre/VPS app-shell path.

## Invariants
- Source of truth: billing entitlement remains platform Postgres; this only expands accepted auth for reading existing billing status.
- Auth source of truth: Clerk remains preferred, native bearer sync JWT remains supported, and only the first-party `matrix_app_session` cookie is accepted as app-shell fallback. Per-app cookies such as `matrix_app_session__<slug>` do not authorize billing.
- Lock/transaction scope: no new DB writes, transactions, or migrations are introduced.
- Acceptable orphan states: invalid or stale app-session cookies return the existing generic unauthorized response and do not alter entitlement state.
- Deferred scope: Clerk-only account UI polish is not included; this PR fixes billing access/gating correctness.