### PR TITLE
fix(terminal): allow legacy session delete routes

### DIFF
--- a/packages/gateway/src/shell/names.ts
+++ b/packages/gateway/src/shell/names.ts
@@ -2,7 +2,7 @@ import { realpath } from "node:fs/promises";
 import { isAbsolute, resolve, sep } from "node:path";
 import { shellError } from "./errors.js";
 
-const SESSION_SLUG = /^[a-z0-9][a-z0-9_-]{0,63}$/;
+export const SESSION_NAME_PATTERN = /^[a-z0-9][a-z0-9_-]{0,63}$/;
 const PROFILE_SLUG = /^[a-z][a-z0-9-]{0,30}$/;
 const LONG_SLUG = /^[a-z][a-z0-9-]{0,63}$/;
 
@@ -14,7 +14,7 @@ function validateSlug(value: string, regex: RegExp, code: string): string {
 }
 
 export function validateSessionName(value: string): string {
-  return validateSlug(value, SESSION_SLUG, "invalid_session_name");
+  return validateSlug(value, SESSION_NAME_PATTERN, "invalid_session_name");
 }
 
 export function validateProfileName(value: string): string {

--- a/packages/gateway/src/shell/routes.ts
+++ b/packages/gateway/src/shell/routes.ts
@@ -3,6 +3,7 @@ import { bodyLimit } from "hono/body-limit";
 import { z } from "zod/v4";
 import { createRateLimiter, type RateLimiter } from "../security/rate-limiter.js";
 import { toShellError } from "./errors.js";
+import { SESSION_NAME_PATTERN } from "./names.js";
 import {
   ShellPreferencesSchema,
   type ShellThemeId,
@@ -72,14 +73,15 @@ export const SHELL_SESSION_CREATE_RATE_LIMIT = {
   maxKeys: 1,
 };
 
+const NewSessionNameSchema = z.string().regex(/^[a-z0-9][a-z0-9-]{0,30}$/);
 const CreateSessionBodySchema = z.object({
-  name: z.string().regex(/^[a-z0-9][a-z0-9-]{0,30}$/),
+  name: NewSessionNameSchema,
   cwd: safeCwdSchema().optional(),
   layout: z.string().regex(/^[a-z][a-z0-9-]{0,63}$/).optional(),
   cmd: z.string().min(1).max(4096).optional(),
 });
 const SafeNameSchema = z.string().regex(/^[a-zA-Z0-9][a-zA-Z0-9_.-]{0,63}$/);
-const SafeSessionNameSchema = z.string().regex(/^[a-z0-9][a-z0-9-]{0,30}$/);
+const SafeSessionNameSchema = z.string().regex(SESSION_NAME_PATTERN);
 const SafeLayoutNameSchema = z.string().regex(/^[a-z][a-z0-9-]{0,63}$/);
 const SafeCwdSchema = safeCwdSchema();
 const TabBodySchema = z.object({
@@ -106,7 +108,7 @@ const SessionUiStateBodySchema = z.object({
   visualStatus: z.enum(["running", "finished", "idle", "waiting"]).optional(),
 }).strict().refine((value) => Object.keys(value).length > 0);
 const SessionRenameBodySchema = z.object({
-  name: SafeSessionNameSchema,
+  name: NewSessionNameSchema,
 }).strict();
 const SessionOrderBodySchema = z.object({
   order: z.array(SafeSessionNameSchema).max(100),

--- a/tests/gateway/shell-routes.test.ts
+++ b/tests/gateway/shell-routes.test.ts
@@ -182,6 +182,28 @@ describe("gateway shell routes", () => {
     expect(registry.delete).toHaveBeenCalledWith("main", { force: true });
   });
 
+  it("deletes legacy matrix session names with force query support under both mounts", async () => {
+    const registry = {
+      list: vi.fn(async () => []),
+      create: vi.fn(),
+      delete: vi.fn(async () => undefined),
+    };
+    const app = appWithRegistry(registry);
+    const name = "matrix-sess_run_8162a7cca11891c0";
+
+    const terminalRes = await app.request(`/api/terminal/sessions/${name}?force=1`, {
+      method: "DELETE",
+    });
+    const legacyMountRes = await app.request(`/api/sessions/${name}?force=1`, {
+      method: "DELETE",
+    });
+
+    expect(terminalRes.status).toBe(200);
+    expect(legacyMountRes.status).toBe(200);
+    expect(registry.delete).toHaveBeenNthCalledWith(1, name, { force: true });
+    expect(registry.delete).toHaveBeenNthCalledWith(2, name, { force: true });
+  });
+
   it("persists session order through a bounded JSON route under both mounts", async () => {
     const registry = {
       list: vi.fn(async () => []),
@@ -291,6 +313,25 @@ describe("gateway shell routes", () => {
       },
     });
     expect(registry.rename).toHaveBeenCalledWith("main", "review-main");
+  });
+
+  it("keeps rename target names aligned with session creation names", async () => {
+    const registry = {
+      list: vi.fn(async () => []),
+      create: vi.fn(),
+      delete: vi.fn(),
+      rename: vi.fn(),
+    };
+    const app = appWithRegistry(registry);
+
+    const res = await app.request("/api/terminal/sessions/matrix-sess_run_8162a7cca11891c0/rename", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ name: "review_main" }),
+    });
+
+    expect(res.status).toBe(400);
+    expect(registry.rename).not.toHaveBeenCalled();
   });
 
   it("validates session rename params and body before dispatch", async () => {


### PR DESCRIPTION
## Summary
- Reuse the canonical shell session-name pattern at the HTTP route boundary.
- Allow legacy `matrix-sess_run_*` session ids to reach the registry delete path instead of failing route validation with 400.
- Add a regression test for forced deletion of the reported legacy session shape.

## Invariants
- Source of truth: zellij remains the live session source and `system/shell-sessions.json` remains the shell metadata source; this only aligns route validation with the existing registry validator.
- Lock/transaction scope: deletes still run through `ShellRegistry.delete()` and its mutation lock; no new multi-write or network boundary is introduced.
- Acceptable orphan states: unchanged; if zellij deletion fails, metadata cleanup does not proceed. If metadata cleanup fails after zellij deletion, the existing registry error path remains authoritative.
- Auth source of truth: unchanged gateway auth/session routing; this PR only changes validated session-name characters at the route boundary.
- Deferred scope: does not change session creation naming rules, zellij deletion semantics, or UI state cleanup beyond allowing legacy names through the existing path.

## Validation
- `pnpm exec vitest run tests/gateway/shell-routes.test.ts --testNamePattern "legacy matrix session"`
- `pnpm exec vitest run tests/gateway/shell-routes.test.ts tests/gateway/shell-names.test.ts`
- `bun run check:patterns`
- `pnpm exec tsc --noEmit -p packages/gateway/tsconfig.json` *(fails on pre-existing `packages/gateway/src/sync/home-mirror.ts` TS2345 errors unrelated to this PR)*