### PR TITLE
fix(terminal): polish agent menu state

### DIFF
--- a/shell/src/components/terminal/TerminalApp.tsx
+++ b/shell/src/components/terminal/TerminalApp.tsx
@@ -3528,6 +3528,9 @@ function LocalTerminalSidebar() {
 
   const openNewSessionMenu = (anchor: NewSessionMenuAnchor) => {
     if (creatingShell) return;
+    if (newSessionMenuAnchor !== anchor) {
+      void fetchAgentStatuses();
+    }
     setNewSessionMenuAnchor((current) => current === anchor ? null : anchor);
   };
 
@@ -3590,7 +3593,7 @@ function LocalTerminalSidebar() {
             display: "flex",
             minHeight: 0,
             opacity: 1,
-            overflow: "hidden",
+            overflow: "visible",
             transform: "translateX(0)",
             transition: TERMINAL_SIDEBAR_TRANSITION,
             width: 76,
@@ -3635,6 +3638,7 @@ function LocalTerminalSidebar() {
           maxHeight: ctx.mobile ? "52%" : undefined,
           minHeight: ctx.mobile ? 360 : undefined,
           opacity: 1,
+          overflow: "visible",
           position: "relative",
           transform: "translateX(0)",
           transition: ctx.mobile ? undefined : TERMINAL_SIDEBAR_TRANSITION,
@@ -4072,18 +4076,21 @@ function NewSessionMenuItem({
       >
         {install ? (
           <span
+            data-testid="terminal-agent-install-pill"
             style={{
               alignItems: "center",
-              background: "#D8792C",
-              borderRadius: 6,
-              color: "#FFFDF7",
+              background: "rgba(216, 121, 44, 0.12)",
+              border: "1px solid rgba(216, 121, 44, 0.18)",
+              borderRadius: 999,
+              boxSizing: "border-box",
+              color: "#84542B",
               display: "flex",
               fontFamily: "Inter, system-ui, sans-serif",
-              fontSize: 12,
-              fontWeight: 800,
-              height: 22,
+              fontSize: 11,
+              fontWeight: 700,
+              height: 21,
               lineHeight: "14px",
-              padding: "0 8px",
+              padding: "0 7px",
             }}
           >
             Install

--- a/shell/src/components/terminal/TerminalApp.tsx
+++ b/shell/src/components/terminal/TerminalApp.tsx
@@ -4079,11 +4079,11 @@ function NewSessionMenuItem({
             data-testid="terminal-agent-install-pill"
             style={{
               alignItems: "center",
-              background: "rgba(216, 121, 44, 0.12)",
-              border: "1px solid rgba(216, 121, 44, 0.18)",
+              background: "rgba(75, 78, 70, 0.1)",
+              border: "1px solid rgba(75, 78, 70, 0.14)",
               borderRadius: 999,
               boxSizing: "border-box",
-              color: "#84542B",
+              color: "#696D63",
               display: "flex",
               fontFamily: "Inter, system-ui, sans-serif",
               fontSize: 11,

--- a/tests/shell/terminal-app-component.test.tsx
+++ b/tests/shell/terminal-app-component.test.tsx
@@ -1331,6 +1331,23 @@ describe("TerminalApp", () => {
     ))).toBe(false);
   });
 
+  it("keeps the new-session menu visible outside a resized drawer", async () => {
+    render(<TerminalApp />);
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    await act(async () => {
+      await openNewSessionMenu();
+    });
+
+    expect(screen.getByRole("menu", { name: "New session menu" })).toBeTruthy();
+    expect(screen.getByTestId("terminal-sidebar-shell").style.overflow).toBe("visible");
+  });
+
   it("opens Matrix-named shell sessions from the new-session menu", async () => {
     render(<TerminalApp />);
 
@@ -2761,6 +2778,9 @@ describe("TerminalApp", () => {
     expect(within(menu).getByRole("menuitem", { name: /Pi.*Install/ })).toBeTruthy();
     expect(within(menu).queryByText("Ready")).toBeNull();
     expect(within(menu).getAllByText("Install")).toHaveLength(2);
+    const installPill = within(menu).getAllByTestId("terminal-agent-install-pill")[0];
+    expect(installPill.style.background).toBe("rgba(216, 121, 44, 0.12)");
+    expect(installPill.style.color).toBe("rgb(132, 84, 43)");
     expect(within(menu).getByTestId("terminal-agent-logo-claude")).toBeTruthy();
     expect(within(menu).getByTestId("terminal-agent-logo-codex")).toBeTruthy();
     expect(within(menu).getByTestId("terminal-agent-logo-opencode")).toBeTruthy();
@@ -2769,6 +2789,58 @@ describe("TerminalApp", () => {
     expectOptimizedImageSrc(within(menu).getByTestId("terminal-agent-logo-image-codex"), "/agent-logos/codex.png");
     expectOptimizedImageSrc(within(menu).getByTestId("terminal-agent-logo-image-opencode"), "/agent-logos/opencode-white.png");
     expectOptimizedImageSrc(within(menu).getByTestId("terminal-agent-logo-image-pi"), "/agent-logos/pi-coding-agent.png");
+  });
+
+  it("refreshes agent install state when opening the new-session menu", async () => {
+    let agentStatusCalls = 0;
+    vi.stubGlobal("fetch", vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.includes("/api/agents")) {
+        agentStatusCalls += 1;
+        const installed = agentStatusCalls > 1;
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            agents: [
+              { id: "claude", installed: true, authState: "ok" },
+              { id: "codex", installed: true, authState: "ok" },
+              { id: "opencode", installed, authState: installed ? "ok" : "unknown", errorCode: installed ? null : "agent_missing" },
+              { id: "pi", installed, authState: installed ? "ok" : "unknown", errorCode: installed ? null : "agent_missing" },
+            ],
+          }),
+        });
+      }
+      if (url.includes("/api/files/tree")) {
+        return Promise.resolve({ ok: true, json: async () => [] });
+      }
+      if (url.includes("/api/terminal/layout") && init?.method === "PUT") {
+        return Promise.resolve({ ok: true, json: async () => ({ ok: true }) });
+      }
+      if (url.includes("/api/terminal/layout")) {
+        return Promise.resolve({ ok: true, json: async () => ({}) });
+      }
+      return Promise.resolve({ ok: true, json: async () => ({}) });
+    }));
+
+    render(<TerminalApp />);
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    await act(async () => {
+      await openNewSessionMenu();
+    });
+
+    const menu = screen.getByRole("menu", { name: "New session menu" });
+    await vi.waitFor(() => {
+      expect(within(menu).queryByRole("menuitem", { name: /OpenCode.*Install/ })).toBeNull();
+      expect(within(menu).queryByRole("menuitem", { name: /Pi.*Install/ })).toBeNull();
+    });
+    expect(within(menu).getByRole("menuitem", { name: /^OpenCode$/ })).toBeTruthy();
+    expect(within(menu).getByRole("menuitem", { name: /^Pi$/ })).toBeTruthy();
   });
 
   it("starts installed agents directly from the new-session menu", async () => {

--- a/tests/shell/terminal-app-component.test.tsx
+++ b/tests/shell/terminal-app-component.test.tsx
@@ -2779,8 +2779,8 @@ describe("TerminalApp", () => {
     expect(within(menu).queryByText("Ready")).toBeNull();
     expect(within(menu).getAllByText("Install")).toHaveLength(2);
     const installPill = within(menu).getAllByTestId("terminal-agent-install-pill")[0];
-    expect(installPill.style.background).toBe("rgba(216, 121, 44, 0.12)");
-    expect(installPill.style.color).toBe("rgb(132, 84, 43)");
+    expect(installPill.style.background).toBe("rgba(75, 78, 70, 0.1)");
+    expect(installPill.style.color).toBe("rgb(105, 109, 99)");
     expect(within(menu).getByTestId("terminal-agent-logo-claude")).toBeTruthy();
     expect(within(menu).getByTestId("terminal-agent-logo-codex")).toBeTruthy();
     expect(within(menu).getByTestId("terminal-agent-logo-opencode")).toBeTruthy();


### PR DESCRIPTION
## Summary
- keep the terminal new-session menu visible after sidebar resizing by allowing the drawer overflow needed for the floating menu
- refresh /api/agents whenever the new-session menu is opened so installed agents stop showing Install after the next open
- make the Install pill quieter and add regression coverage for the refreshed state

## Validation
- bun run test -- tests/shell/terminal-app-component.test.tsx
- bun run typecheck
- bun run check:patterns
- npx react-doctor@latest shell
- bun run test

## Screenshot
- /private/tmp/terminal-menu-polish-pr.png

## Invariants
- Source of truth: /api/agents remains the canonical installed-agent status; the client only refreshes it on menu open.
- Lock/transaction scope: frontend-only state/rendering change, no persistence or critical section.
- Acceptable orphan states: if the refresh fails, the existing fallback/menu state remains visible and the next open can retry.
- Auth source of truth: unchanged existing terminal API/session auth.
- Deferred scope: no changes to installer commands, agent detection implementation, or provisioning defaults.