### PR TITLE
fix(menu-bar): open session-routed web shell

### DIFF
--- a/apps/menu-bar/Package.swift
+++ b/apps/menu-bar/Package.swift
@@ -10,10 +10,19 @@ let package = Package(
         .executable(name: "MatrixSync", targets: ["MatrixSync"]),
     ],
     targets: [
+        .target(
+            name: "MatrixSyncSupport",
+            path: "Sources/MatrixSyncSupport"),
         .executableTarget(
             name: "MatrixSync",
+            dependencies: ["MatrixSyncSupport"],
             path: "Sources",
+            exclude: ["MatrixSyncSupport"],
             swiftSettings: [
                 .enableUpcomingFeature("StrictConcurrency"),
             ]),
+        .testTarget(
+            name: "MatrixSyncTests",
+            dependencies: ["MatrixSyncSupport"],
+            path: "Tests"),
     ])

--- a/apps/menu-bar/Sources/MatrixSyncSupport/WebShellURL.swift
+++ b/apps/menu-bar/Sources/MatrixSyncSupport/WebShellURL.swift
@@ -1,0 +1,3 @@
+import Foundation
+
+public let webShellURL = URL(string: "https://app.matrix-os.com")!

--- a/apps/menu-bar/Sources/MatrixSyncSupport/WebShellURL.swift
+++ b/apps/menu-bar/Sources/MatrixSyncSupport/WebShellURL.swift
@@ -1,3 +1,5 @@
 import Foundation
 
-public let webShellURL = URL(string: "https://app.matrix-os.com")!
+public enum MatrixSyncURLs {
+    public static let webShell = URL(string: "https://app.matrix-os.com")!
+}

--- a/apps/menu-bar/Sources/MenuBarView.swift
+++ b/apps/menu-bar/Sources/MenuBarView.swift
@@ -265,6 +265,6 @@ struct MenuBarView: View {
     }
 
     private func openWebShell() {
-        NSWorkspace.shared.open(webShellURL)
+        NSWorkspace.shared.open(MatrixSyncURLs.webShell)
     }
 }

--- a/apps/menu-bar/Sources/MenuBarView.swift
+++ b/apps/menu-bar/Sources/MenuBarView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import MatrixSyncSupport
 
 struct MenuBarView: View {
     @ObservedObject var status: SyncStatusModel
@@ -264,8 +265,6 @@ struct MenuBarView: View {
     }
 
     private func openWebShell() {
-        if let url = URL(string: "https://matrix-os.com") {
-            NSWorkspace.shared.open(url)
-        }
+        NSWorkspace.shared.open(webShellURL)
     }
 }

--- a/apps/menu-bar/Tests/WebShellURLTests.swift
+++ b/apps/menu-bar/Tests/WebShellURLTests.swift
@@ -1,0 +1,8 @@
+import XCTest
+import MatrixSyncSupport
+
+final class WebShellURLTests: XCTestCase {
+    func testWebShellURLUsesSessionRoutedAppShell() {
+        XCTAssertEqual(webShellURL.absoluteString, "https://app.matrix-os.com")
+    }
+}

--- a/apps/menu-bar/Tests/WebShellURLTests.swift
+++ b/apps/menu-bar/Tests/WebShellURLTests.swift
@@ -3,6 +3,6 @@ import MatrixSyncSupport
 
 final class WebShellURLTests: XCTestCase {
     func testWebShellURLUsesSessionRoutedAppShell() {
-        XCTAssertEqual(webShellURL.absoluteString, "https://app.matrix-os.com")
+        XCTAssertEqual(MatrixSyncURLs.webShell.absoluteString, "https://app.matrix-os.com")
     }
 }


### PR DESCRIPTION
## Summary

- Adds a tiny SwiftPM support target that exposes the Mac menu-bar Web Shell URL for tests and app code.
- Updates the Open Web Shell quick action to open `https://app.matrix-os.com`, the session-routed Matrix OS shell, instead of the marketing site.
- Adds a focused SwiftPM regression test for the shell URL.

## Tests

- `swift test --package-path apps/menu-bar` *(blocked locally: `swift` is not installed in this environment)*
- `swift build --package-path apps/menu-bar` *(blocked locally: `swift` is not installed in this environment)*
- `git diff --check`
- `rg -n "https://matrix-os\\.com|https://app\\.matrix-os\\.com|webShellURL|MatrixSyncSupport" apps/menu-bar`

## Review/Monitoring

- Scope is limited to `apps/menu-bar`.
- Opened as a non-draft PR for CI/review.
- Do not merge until CI and review monitoring are complete.
