### PR TITLE
fix(gateway): initialize scratch project git repos

### DIFF
--- a/packages/gateway/src/project-manager.ts
+++ b/packages/gateway/src/project-manager.ts
@@ -211,6 +211,8 @@ export function createProjectManager(options: {
               "user.name=Matrix OS",
               "-c",
               "user.email=matrix-os@example.invalid",
+              "-c",
+              "commit.gpgSign=false",
               "commit",
               "--allow-empty",
               "-m",

--- a/packages/gateway/src/project-manager.ts
+++ b/packages/gateway/src/project-manager.ts
@@ -201,12 +201,40 @@ export function createProjectManager(options: {
           }
           const repoPath = join(targetProjectPath, "repo");
           await mkdir(repoPath, { recursive: true });
+          try {
+            await runCommand("git", ["init", "-b", "main"], {
+              cwd: repoPath,
+              timeout: DEFAULT_TIMEOUT_MS,
+            });
+            await runCommand("git", [
+              "-c",
+              "user.name=Matrix OS",
+              "-c",
+              "user.email=matrix-os@example.invalid",
+              "commit",
+              "--allow-empty",
+              "-m",
+              "chore: initialize scratch project",
+            ], {
+              cwd: repoPath,
+              timeout: DEFAULT_TIMEOUT_MS,
+            });
+          } catch (err: unknown) {
+            if (err instanceof Error) {
+              console.warn("[project-manager] Scratch Git initialization failed:", err.message);
+            } else {
+              console.warn("[project-manager] Scratch Git initialization failed:", err);
+            }
+            await rm(targetProjectPath, { recursive: true, force: true });
+            return genericError(502, "scratch_init_failed", "Scratch project initialization failed");
+          }
           const timestamp = nowIso(options.now);
           const project: ProjectConfig = {
             id: `proj_${randomUUID()}`,
             name,
             slug,
             localPath: repoPath,
+            defaultBranch: "main",
             addedAt: timestamp,
             updatedAt: timestamp,
             ownerScope: input.ownerScope ?? { type: "user", id: "local" },

--- a/packages/gateway/src/workspace-routes.ts
+++ b/packages/gateway/src/workspace-routes.ts
@@ -310,6 +310,7 @@ export function createWorkspaceRoutes(options: {
       projectSlug: c.req.param("slug"),
       branch: body.value.branch,
       pr: body.value.pr,
+      createBranch: body.value.branch ? true : undefined,
     });
     if (!result.ok) return c.json({ error: result.error }, status(result.status));
     return c.json({ worktree: result.worktree }, result.status);

--- a/packages/gateway/src/worktree-manager.ts
+++ b/packages/gateway/src/worktree-manager.ts
@@ -210,13 +210,16 @@ export function createWorktreeManager(options: {
           }
           let addArgs = ["worktree", "add", "--", path, currentBranch];
           if (input.branch && input.createBranch) {
+            const canCreateFallbackBranch = !project.remote && !project.github;
             const branchExists = await gitRefExists(runCommand, project.localPath, `refs/heads/${currentBranch}`);
             if (!branchExists) {
               const remoteRef = `refs/remotes/origin/${currentBranch}`;
               const remoteBranchExists = await gitRefExists(runCommand, project.localPath, remoteRef);
-              addArgs = remoteBranchExists
-                ? ["worktree", "add", "-b", currentBranch, "--track", "--", path, `origin/${currentBranch}`]
-                : ["worktree", "add", "-b", currentBranch, "--", path, baseRef];
+              if (remoteBranchExists) {
+                addArgs = ["worktree", "add", "-b", currentBranch, "--track", "--", path, `origin/${currentBranch}`];
+              } else if (canCreateFallbackBranch) {
+                addArgs = ["worktree", "add", "-b", currentBranch, "--", path, baseRef];
+              }
             }
           }
           await runCommand("git", addArgs, {

--- a/tests/gateway/project-manager.test.ts
+++ b/tests/gateway/project-manager.test.ts
@@ -90,6 +90,8 @@ describe("project-manager", () => {
       "user.name=Matrix OS",
       "-c",
       "user.email=matrix-os@example.invalid",
+      "-c",
+      "commit.gpgSign=false",
       "commit",
       "--allow-empty",
       "-m",

--- a/tests/gateway/project-manager.test.ts
+++ b/tests/gateway/project-manager.test.ts
@@ -68,8 +68,8 @@ describe("project-manager", () => {
     expect(config.localPath).toBe(join(homePath, "projects", "repo", "repo"));
   });
 
-  it("creates a scratch project without GitHub auth or clone commands", async () => {
-    const runCommand = vi.fn();
+  it("creates a scratch project as a Git repo without GitHub auth or clone commands", async () => {
+    const runCommand = vi.fn(async () => ({ stdout: "", stderr: "" }));
     const manager = createProjectManager({ homePath, runCommand, now: () => "2026-04-26T00:00:00.000Z" });
 
     const result = await manager.createProject({
@@ -81,10 +81,29 @@ describe("project-manager", () => {
 
     expect(result.ok).toBe(true);
     if (!result.ok) return;
-    expect(runCommand).not.toHaveBeenCalled();
+    expect(runCommand).toHaveBeenCalledWith("git", ["init", "-b", "main"], {
+      cwd: join(homePath, "projects", "empty-workspace", "repo"),
+      timeout: 10_000,
+    });
+    expect(runCommand).toHaveBeenCalledWith("git", [
+      "-c",
+      "user.name=Matrix OS",
+      "-c",
+      "user.email=matrix-os@example.invalid",
+      "commit",
+      "--allow-empty",
+      "-m",
+      "chore: initialize scratch project",
+    ], {
+      cwd: join(homePath, "projects", "empty-workspace", "repo"),
+      timeout: 10_000,
+    });
+    expect(runCommand).not.toHaveBeenCalledWith("gh", expect.any(Array), expect.any(Object));
+    expect(runCommand).not.toHaveBeenCalledWith("git", expect.arrayContaining(["clone"]), expect.any(Object));
     expect(result.project).toMatchObject({
       name: "Empty Workspace",
       slug: "empty-workspace",
+      defaultBranch: "main",
       ownerScope: { type: "user", id: "user_123" },
     });
     expect(result.project.remote).toBeUndefined();
@@ -92,6 +111,27 @@ describe("project-manager", () => {
     await expect(stat(join(homePath, "projects", "empty-workspace", "repo"))).resolves.toBeTruthy();
     const config = JSON.parse(await readFile(join(homePath, "projects", "empty-workspace", "config.json"), "utf-8"));
     expect(config.localPath).toBe(join(homePath, "projects", "empty-workspace", "repo"));
+    expect(config.defaultBranch).toBe("main");
+  });
+
+  it("cleans up scratch project directories when Git initialization fails", async () => {
+    const runCommand = vi.fn(async () => {
+      throw new Error("fatal: leaked /home/matrixos/secret");
+    });
+    const manager = createProjectManager({ homePath, runCommand });
+
+    const result = await manager.createProject({
+      mode: "scratch",
+      name: "Broken Scratch",
+      slug: "broken-scratch",
+    });
+
+    expect(result).toMatchObject({ ok: false, status: 502, error: { code: "scratch_init_failed" } });
+    if (!result.ok) {
+      expect(result.error.message).toBe("Scratch project initialization failed");
+      expect(result.error.message).not.toContain("secret");
+    }
+    await expect(stat(join(homePath, "projects", "broken-scratch"))).rejects.toMatchObject({ code: "ENOENT" });
   });
 
   it("rejects slug conflicts before cloning", async () => {

--- a/tests/gateway/workspace-routes.test.ts
+++ b/tests/gateway/workspace-routes.test.ts
@@ -206,7 +206,21 @@ describe("workspace API routes", () => {
     expect(projectManager.listManagedProjects).toHaveBeenCalled();
     const res = await app.request(jsonRequest("/api/projects/repo/worktrees", { branch: "main" }));
     expect(res.status).toBe(201);
-    expect(worktreeManager.createWorktree).toHaveBeenCalledWith({ projectSlug: "repo", branch: "main" });
+    expect(worktreeManager.createWorktree).toHaveBeenCalledWith({
+      projectSlug: "repo",
+      branch: "main",
+      pr: undefined,
+      createBranch: true,
+    });
+
+    const prRes = await app.request(jsonRequest("/api/projects/repo/worktrees", { pr: 42 }));
+    expect(prRes.status).toBe(201);
+    expect(worktreeManager.createWorktree).toHaveBeenCalledWith({
+      projectSlug: "repo",
+      branch: undefined,
+      pr: 42,
+      createBranch: undefined,
+    });
   });
 
   it("derives project owner scope from the injected principal owner scope", async () => {

--- a/tests/gateway/worktree-manager.test.ts
+++ b/tests/gateway/worktree-manager.test.ts
@@ -90,6 +90,34 @@ describe("worktree-manager", () => {
     expect(runCommand).toHaveBeenNthCalledWith(3, "git", ["worktree", "add", "-b", "symphony/mat-1", "--track", "--", expect.any(String), "origin/symphony/mat-1"], expect.any(Object));
   });
 
+  it("does not create fallback branches for remote projects when the branch is missing", async () => {
+    await atomicWriteJson(join(homePath, "projects", "repo", "config.json"), {
+      id: "proj_repo",
+      slug: "repo",
+      name: "repo",
+      remote: "https://github.com/owner/repo.git",
+      localPath: join(homePath, "projects", "repo", "repo"),
+      defaultBranch: "main",
+      addedAt: "2026-04-26T00:00:00.000Z",
+      updatedAt: "2026-04-26T00:00:00.000Z",
+      ownerScope: { type: "user", id: "local" },
+      github: { owner: "owner", repo: "repo", htmlUrl: "https://github.com/owner/repo", authState: "ok" },
+    });
+    const runCommand = vi.fn(async (_command: string, args: string[]) => {
+      if (args[0] === "rev-parse") throw new Error("missing branch");
+      if (args.includes("-b")) throw new Error("unexpected fallback branch creation");
+      return { stdout: "", stderr: "" };
+    });
+    const manager = createWorktreeManager({ homePath, runCommand });
+
+    const result = await manager.createWorktree({ projectSlug: "repo", branch: "typo/new-branch", createBranch: true });
+
+    expect(result.ok).toBe(true);
+    expect(runCommand).toHaveBeenNthCalledWith(1, "git", ["rev-parse", "--verify", "--quiet", "refs/heads/typo/new-branch"], expect.any(Object));
+    expect(runCommand).toHaveBeenNthCalledWith(2, "git", ["rev-parse", "--verify", "--quiet", "refs/remotes/origin/typo/new-branch"], expect.any(Object));
+    expect(runCommand).toHaveBeenNthCalledWith(3, "git", ["worktree", "add", "--", expect.any(String), "typo/new-branch"], expect.any(Object));
+  });
+
   it("creates a new branch worktree immediately from a scratch project", async () => {
     const projectManager = createProjectManager({ homePath, now: () => "2026-04-26T00:00:00.000Z" });
     const createdProject = await projectManager.createProject({

--- a/tests/gateway/worktree-manager.test.ts
+++ b/tests/gateway/worktree-manager.test.ts
@@ -4,6 +4,7 @@ import { rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { atomicWriteJson } from "../../packages/gateway/src/state-ops.js";
+import { createProjectManager } from "../../packages/gateway/src/project-manager.js";
 import { createWorktreeManager } from "../../packages/gateway/src/worktree-manager.js";
 
 describe("worktree-manager", () => {
@@ -87,6 +88,29 @@ describe("worktree-manager", () => {
     expect(runCommand).toHaveBeenNthCalledWith(1, "git", ["rev-parse", "--verify", "--quiet", "refs/heads/symphony/mat-1"], expect.any(Object));
     expect(runCommand).toHaveBeenNthCalledWith(2, "git", ["rev-parse", "--verify", "--quiet", "refs/remotes/origin/symphony/mat-1"], expect.any(Object));
     expect(runCommand).toHaveBeenNthCalledWith(3, "git", ["worktree", "add", "-b", "symphony/mat-1", "--track", "--", expect.any(String), "origin/symphony/mat-1"], expect.any(Object));
+  });
+
+  it("creates a new branch worktree immediately from a scratch project", async () => {
+    const projectManager = createProjectManager({ homePath, now: () => "2026-04-26T00:00:00.000Z" });
+    const createdProject = await projectManager.createProject({
+      mode: "scratch",
+      name: "Scratch Flow",
+      slug: "scratch-flow",
+    });
+    expect(createdProject.ok).toBe(true);
+
+    const worktreeManager = createWorktreeManager({ homePath, now: () => "2026-04-26T00:00:00.000Z" });
+    const createdWorktree = await worktreeManager.createWorktree({
+      projectSlug: "scratch-flow",
+      branch: "feature/first",
+      createBranch: true,
+    });
+
+    expect(createdWorktree.ok).toBe(true);
+    if (!createdWorktree.ok) return;
+    expect(createdWorktree.worktree.currentBranch).toBe("feature/first");
+    await expect(stat(createdWorktree.worktree.path)).resolves.toMatchObject({ isDirectory: expect.any(Function) });
+    await expect(readFile(join(createdWorktree.worktree.path, ".matrix", "worktree.json"), "utf-8")).resolves.toContain("feature/first");
   });
 
   it("serializes concurrent creation for the same worktree", async () => {


### PR DESCRIPTION
## Summary

- Initialize scratch projects as Git repositories with a `main` default branch and an empty initial commit that ignores global GPG signing.
- Forward branch worktree creation requests with `createBranch: true`, while service-layer logic only creates fallback branches for local/scratch projects.
- Preserve GitHub/remote safety: existing local branches still work, existing remote branches are tracked, and missing remote branches do not silently create typo branches.
- Add gateway regression coverage for scratch Git initialization, initialization cleanup, route forwarding, immediate scratch-project branch worktree creation using real Git, and remote typo-branch behavior.

## Tests

- `pnpm test tests/gateway/project-manager.test.ts tests/gateway/worktree-manager.test.ts tests/gateway/workspace-routes.test.ts`
- `pnpm --filter @matrix-os/gateway exec tsc --noEmit`
- `pnpm run check:patterns` (0 violations; existing repo-wide warnings only)
- Earlier `pnpm test` full-suite run was attempted and stopped after unrelated failures in platform/sync/app-runtime areas unrelated to this gateway change.

## Review/Monitoring

- Greptile 3/5 findings addressed in `bad5ea7b`:
  - scratch empty commit now passes `-c commit.gpgSign=false`
  - fallback branch creation is scoped to local/scratch projects
- Latest checks and Greptile review are being monitored after the update.

## Invariants

- **Source of truth**: project metadata remains `~/projects/<slug>/config.json`; scratch repo bytes live in `~/projects/<slug>/repo`; worktree metadata remains under `~/projects/<slug>/worktrees/<wt>/.matrix/worktree.json`.
- **Lock/transaction scope**: scratch project creation stays inside the existing per-project lock. Directory creation, Git initialization, initial commit, and config write are serialized for the slug. Worktree creation remains serialized by the same project lock and decides fallback behavior from the persisted project config. There are no network calls in the scratch path.
- **Acceptable orphan states**: if scratch Git initialization or initial commit fails before config write, the partially created project directory is removed and the API returns a generic `scratch_init_failed` error. If remote branch lookup fails or a remote branch is absent, remote/GitHub projects use the existing non-fallback `git worktree add` path and return the existing generic checkout failure on Git failure.
- **Auth source of truth**: route auth and owner scope remain the existing workspace request principal and injected `getOwnerScope`; this change does not add or bypass auth.
- **Deferred scope**: no UI changes, no server route ordering changes, no shell React changes, no migration for already-created non-Git scratch project directories.
