### PR TITLE
fix(gateway): route workspace sessions before shell legacy

### DIFF
--- a/packages/gateway/src/server.ts
+++ b/packages/gateway/src/server.ts
@@ -358,9 +358,10 @@ export function registerShellAndWorkspaceRoutes(
     workspaceRoutes: Parameters<typeof createWorkspaceRoutes>[0];
   },
 ): void {
-  app.route("/api/terminal", createShellRoutes(options.shellRoutes));
+  const shellRouter = createShellRoutes(options.shellRoutes);
+  app.route("/api/terminal", shellRouter);
   app.route("/", createWorkspaceRoutes(options.workspaceRoutes));
-  app.route("/api", createShellRoutes(options.shellRoutes));
+  app.route("/api", shellRouter);
 }
 
 function kernelEventToServerMessage(event: KernelEvent, requestId?: string): ServerMessage {

--- a/packages/gateway/src/server.ts
+++ b/packages/gateway/src/server.ts
@@ -351,6 +351,18 @@ export type ServerMessage =
   | { type: "sync:share-invite"; shareId: string; ownerHandle: string; path: string; role: string }
   | { type: "sync:access-revoked"; shareId: string; ownerHandle: string; path: string };
 
+export function registerShellAndWorkspaceRoutes(
+  app: Hono,
+  options: {
+    shellRoutes: Parameters<typeof createShellRoutes>[0];
+    workspaceRoutes: Parameters<typeof createWorkspaceRoutes>[0];
+  },
+): void {
+  app.route("/api/terminal", createShellRoutes(options.shellRoutes));
+  app.route("/", createWorkspaceRoutes(options.workspaceRoutes));
+  app.route("/api", createShellRoutes(options.shellRoutes));
+}
+
 function kernelEventToServerMessage(event: KernelEvent, requestId?: string): ServerMessage {
   switch (event.type) {
     case "init":
@@ -1703,8 +1715,15 @@ export async function createGateway(config: GatewayConfig) {
     savePolicy: (policy) => systemActivityPolicy.save(policy),
     readHistory: (query) => systemActivityHistory.list(query),
   }));
-  app.route("/api/terminal", createShellRoutes(shellRouteDeps));
-  app.route("/api", createShellRoutes(shellRouteDeps));
+  registerShellAndWorkspaceRoutes(app, {
+    shellRoutes: shellRouteDeps,
+    workspaceRoutes: {
+      homePath,
+      zellijRuntime: workspaceZellijRuntime,
+      sessionRuntimeBridge: workspaceSessionRuntimeBridge,
+      getOwnerScope: (c) => ({ type: "user", id: requireRequestPrincipal(c).userId }),
+    },
+  });
 
   // HKDF master secret for per-app session cookies. In production MATRIX_AUTH_TOKEN
   // is the source. When it is absent (local dev, .env.example default) we mint an
@@ -2917,12 +2936,6 @@ export async function createGateway(config: GatewayConfig) {
   const upgradeBodyLimit = bodyLimit({ maxSize: 4096 });
   const pushRegistrationBodyLimit = bodyLimit({ maxSize: 4096 });
   const clientErrorBodyLimit = bodyLimit({ maxSize: CLIENT_ERROR_LOG_BODY_LIMIT });
-  app.route("/", createWorkspaceRoutes({
-    homePath,
-    zellijRuntime: workspaceZellijRuntime,
-    sessionRuntimeBridge: workspaceSessionRuntimeBridge,
-    getOwnerScope: (c) => ({ type: "user", id: requireRequestPrincipal(c).userId }),
-  }));
   app.route("/api/symphony", createElixirSymphonyProxyRoutes({
     upstreamOrigin: symphonyUpstreamOriginForPort(initialSymphonyPort),
   }));

--- a/tests/gateway/workspace-shell-route-order.test.ts
+++ b/tests/gateway/workspace-shell-route-order.test.ts
@@ -1,0 +1,106 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Hono } from "hono";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  registerShellAndWorkspaceRoutes,
+} from "../../packages/gateway/src/server.js";
+import type { ShellRouteDeps } from "../../packages/gateway/src/shell/routes.js";
+import type { createWorkspaceRoutes } from "../../packages/gateway/src/workspace-routes.js";
+
+const roots: string[] = [];
+
+async function tempRoot() {
+  const root = await mkdtemp(join(tmpdir(), "matrix-workspace-shell-route-order-"));
+  roots.push(root);
+  return root;
+}
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+  vi.restoreAllMocks();
+});
+
+describe("gateway workspace and shell route order", () => {
+  it("routes workspace sessions before legacy shell sessions without breaking shell namespaces", async () => {
+    const homePath = await tempRoot();
+    const app = new Hono();
+    const shellSession = { name: "main" };
+    const workspaceSession = { id: "sess_workspace", projectSlug: "repo" };
+    const shellRoutes: ShellRouteDeps = {
+      registry: {
+        list: vi.fn(async () => [shellSession]),
+        create: vi.fn(async () => shellSession),
+        delete: vi.fn(async () => undefined),
+      },
+      workspace: {
+        listTabs: vi.fn(async () => [{ idx: 0, name: "main", focused: true }]),
+        createTab: vi.fn(async () => ({ idx: 1, name: "api" })),
+        switchTab: vi.fn(async () => ({ ok: true })),
+        closeTab: vi.fn(async () => ({ ok: true })),
+        splitPane: vi.fn(async () => ({ pane: "pane-1" })),
+        closePane: vi.fn(async () => ({ ok: true })),
+        applyLayout: vi.fn(async () => ({ ok: true })),
+        dumpLayout: vi.fn(async () => ({ kdl: "layout {}" })),
+      },
+    };
+    const sessionOrchestrator = {
+      startSession: vi.fn(async () => ({ ok: true, status: 201, session: workspaceSession })),
+      listSessions: vi.fn(async () => ({ ok: true, sessions: [workspaceSession], nextCursor: null })),
+      getSession: vi.fn(async () => ({ ok: true, session: workspaceSession })),
+      sendInput: vi.fn(async () => ({ ok: true, session: workspaceSession })),
+      attachSession: vi.fn(async () => ({ ok: true, terminalSessionId: "term_workspace" })),
+      stopSession: vi.fn(async () => ({ ok: true, session: workspaceSession })),
+    };
+    const workspaceRoutes: Parameters<typeof createWorkspaceRoutes>[0] = {
+      homePath,
+      sessionOrchestrator: sessionOrchestrator as never,
+      getOwnerScope: () => ({ type: "user", id: "user_workspace" }),
+    };
+
+    registerShellAndWorkspaceRoutes(app, { shellRoutes, workspaceRoutes });
+
+    await expect((await app.request("/api/sessions?projectSlug=repo&limit=10")).json()).resolves.toEqual({
+      sessions: [workspaceSession],
+      nextCursor: null,
+    });
+    await expect((await app.request("/api/sessions", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        kind: "shell",
+        projectSlug: "repo",
+        worktreeId: "wt_abc123",
+      }),
+    })).json()).resolves.toEqual({
+      session: workspaceSession,
+    });
+    await expect((await app.request("/api/terminal/sessions")).json()).resolves.toEqual({
+      sessions: [shellSession],
+    });
+    await expect((await app.request("/api/sessions/main/tabs")).json()).resolves.toEqual({
+      tabs: [{ idx: 0, name: "main", focused: true }],
+    });
+
+    expect(sessionOrchestrator.listSessions).toHaveBeenCalledWith({
+      projectSlug: "repo",
+      taskId: undefined,
+      status: undefined,
+      pr: undefined,
+      limit: 10,
+      cursor: undefined,
+    });
+    expect(sessionOrchestrator.startSession).toHaveBeenCalledWith({
+      ownerScope: { type: "user", id: "user_workspace" },
+      request: {
+        kind: "shell",
+        projectSlug: "repo",
+        worktreeId: "wt_abc123",
+      },
+    });
+    expect(shellRoutes.registry.list).toHaveBeenCalledTimes(1);
+    expect(shellRoutes.registry.create).not.toHaveBeenCalled();
+    expect(shellRoutes.workspace?.listTabs).toHaveBeenCalledWith("main");
+  });
+});

--- a/tests/gateway/workspace-shell-route-order.test.ts
+++ b/tests/gateway/workspace-shell-route-order.test.ts
@@ -9,6 +9,9 @@ import {
 import type { ShellRouteDeps } from "../../packages/gateway/src/shell/routes.js";
 import type { createWorkspaceRoutes } from "../../packages/gateway/src/workspace-routes.js";
 
+type WorkspaceRouteOptions = Parameters<typeof createWorkspaceRoutes>[0];
+type WorkspaceSessionOrchestrator = NonNullable<WorkspaceRouteOptions["sessionOrchestrator"]>;
+
 const roots: string[] = [];
 
 async function tempRoot() {
@@ -45,17 +48,18 @@ describe("gateway workspace and shell route order", () => {
         dumpLayout: vi.fn(async () => ({ kdl: "layout {}" })),
       },
     };
-    const sessionOrchestrator = {
+    const sessionOrchestrator: WorkspaceSessionOrchestrator = {
       startSession: vi.fn(async () => ({ ok: true, status: 201, session: workspaceSession })),
       listSessions: vi.fn(async () => ({ ok: true, sessions: [workspaceSession], nextCursor: null })),
       getSession: vi.fn(async () => ({ ok: true, session: workspaceSession })),
       sendInput: vi.fn(async () => ({ ok: true, session: workspaceSession })),
       attachSession: vi.fn(async () => ({ ok: true, terminalSessionId: "term_workspace" })),
       stopSession: vi.fn(async () => ({ ok: true, session: workspaceSession })),
+      recoverSessions: vi.fn(async () => ({ ok: true, sessions: [workspaceSession], nextCursor: null })),
     };
-    const workspaceRoutes: Parameters<typeof createWorkspaceRoutes>[0] = {
+    const workspaceRoutes: WorkspaceRouteOptions = {
       homePath,
-      sessionOrchestrator: sessionOrchestrator as never,
+      sessionOrchestrator,
       getOwnerScope: () => ({ type: "user", id: "user_workspace" }),
     };
 


### PR DESCRIPTION
## Summary

- Route Workspace `/api/sessions` GET/POST before the legacy shell `/api/sessions` compatibility mount.
- Keep canonical shell sessions available at `/api/terminal/sessions`.
- Reuse one shell router instance for both `/api/terminal` and legacy `/api` mounts so shell route internals stay shared.
- Add a focused Hono route-composition regression covering Workspace sessions, canonical shell sessions, and non-colliding legacy shell paths.
- Keep the route-order test session orchestrator stub typed without `as never`.

## Tests

- PASS: `/home/nima/matrix-os/.worktrees/fix-workspace-session-route-order/node_modules/.bin/vitest run tests/gateway/workspace-shell-route-order.test.ts tests/gateway/workspace-routes.test.ts tests/gateway/shell-tabs.test.ts tests/gateway/shell-layout-routes.test.ts tests/gateway/shell-panes.test.ts --reporter=dot`
- PASS: `./scripts/review/check-patterns.sh` (0 violations; existing repository warnings only)
- PASS: pnpm equivalent of typecheck:
  `pnpm --filter '@matrix-os/observability' build && pnpm --filter '@matrix-os/kernel' build && pnpm --filter '@matrix-os/observability' exec tsc --noEmit && pnpm --filter '@matrix-os/gateway' exec tsc --noEmit && pnpm --filter '@matrix-os/platform' exec tsc --noEmit -p tsconfig.typecheck.json && pnpm --filter '@matrix-os/proxy' exec tsc --noEmit && pnpm --filter '@matrix-os/edge-router' exec tsc --noEmit && pnpm --filter desktop run typecheck`
- NOTE: direct `pnpm run typecheck` cannot run in this environment because `bun` is not installed; the pnpm equivalent above passed.
- PREVIOUSLY ATTEMPTED: `pnpm run test -- --reporter=dot`; interrupted after several minutes once unrelated failures were observed outside this PR scope, including platform proxy/device tests, sync home-mirror tests, and app-runtime dispatcher/process-manager tests.

## Review/Monitoring

- Branch created from `origin/main` in a manual worktree.
- Follow-up commit addresses Greptile 4/5 findings: shared shell router instance and typed orchestrator test stub.
- Do not merge until CI and Greptile complete successfully.
- Greptile findings, if any, should be fixed in this diff or explicitly deferred with a linked follow-up.

## Invariants

- Source of truth: Workspace session ownership stays in the Workspace session orchestrator and its existing stores. Shell session ownership stays in the shell registry/zellij adapter. This change only fixes gateway route dispatch order.
- Lock/transaction scope: No database writes, locks, or transactions are added. No network calls are introduced by this route-order change.
- Acceptable orphan states: None introduced. Existing session create/attach/stop failure behavior is unchanged; requests now reach the intended existing Workspace or shell handler.
- Auth source of truth: Existing gateway `authMiddleware` and `requireRequestPrincipal` behavior remain unchanged. Workspace routes still derive owner scope from the authenticated request principal.
- Deferred scope: No Workspace UI changes, no workspace-routes changes, and no project/worktree manager changes. Legacy shell compatibility routes remain mounted after Workspace for non-colliding paths.
