### PR TITLE
fix: fix Symphony scrolling and VPS integration auth

### DIFF
--- a/home/apps/symphony/src/App.tsx
+++ b/home/apps/symphony/src/App.tsx
@@ -349,7 +349,7 @@ export default function App() {
   const logLines = flattenLogs(detail?.logs);
 
   return (
-    <main className="min-h-screen bg-background text-foreground">
+    <main className="flex h-screen min-h-0 flex-col overflow-hidden bg-background text-foreground">
       <SymphonyHeader
         activeIssue={activeIssue}
         busy={busy}
@@ -367,7 +367,7 @@ export default function App() {
         <Notice tone="warning" text="Connect Linear in Matrix Integrations to let Symphony poll assigned work." />
       )}
 
-      <section className="grid gap-5 px-5 pb-5 lg:grid-cols-[minmax(0,1fr)_minmax(320px,420px)]">
+      <section className="grid min-h-0 flex-1 gap-5 overflow-y-auto px-5 pb-5 lg:grid-cols-[minmax(0,1fr)_minmax(320px,420px)] lg:overflow-hidden">
         <RunGroups busy={busy} state={state} onSelectIssue={selectIssue} />
         <DetailPanel activeIssue={activeIssue} detail={detail} logLines={logLines} state={state} />
       </section>
@@ -436,7 +436,7 @@ function Metrics({ state }: { state: SymphonyState }) {
 
 function RunGroups({ busy, state, onSelectIssue }: { busy: string | null; state: SymphonyState; onSelectIssue: (issueIdentifier: string | null | undefined) => void }) {
   return (
-    <div className="space-y-4">
+    <div className="min-h-0 space-y-4 lg:overflow-y-auto lg:pr-1">
       {RUN_GROUPS.map((group) => (
         <section key={group} className="border bg-white">
           <div className="flex items-center justify-between border-b px-4 py-3">
@@ -476,7 +476,7 @@ function DetailPanel({ activeIssue, detail, logLines, state }: {
   state: SymphonyState;
 }) {
   return (
-    <aside className="border bg-white p-4">
+    <aside className="min-h-0 overflow-y-auto border bg-white p-4">
       <div className="flex items-start justify-between gap-3">
         <div className="min-w-0">
           <h2 className="truncate text-base font-semibold">{detail?.issueIdentifier ?? activeIssue ?? "No active issue"}</h2>

--- a/home/apps/symphony/src/index.css
+++ b/home/apps/symphony/src/index.css
@@ -56,10 +56,16 @@
   border-color: var(--border);
 }
 
+html,
+body,
+#root {
+  width: 100%;
+  height: 100%;
+}
+
 body {
   margin: 0;
   min-width: 320px;
-  min-height: 100vh;
   overflow: hidden;
   background: linear-gradient(170deg, var(--sand-light) 0%, var(--sand-mid) 30%, #F7F3ED 60%, var(--sand-light) 100%);
   color: var(--foreground);

--- a/packages/platform/src/main.ts
+++ b/packages/platform/src/main.ts
@@ -3583,7 +3583,9 @@ export function createApp(deps: {
         return c.json({ error: 'Unauthorized' }, 401);
       }
 
-      const record = await getContainer(db, handle);
+      const record =
+        (await getRunningUserMachineByHandle(db, handle)) ??
+        (await getContainer(db, handle));
       if (!record?.clerkUserId) {
         return c.json({ error: 'Unknown handle' }, 404);
       }

--- a/packages/platform/src/main.ts
+++ b/packages/platform/src/main.ts
@@ -3583,9 +3583,17 @@ export function createApp(deps: {
         return c.json({ error: 'Unauthorized' }, 401);
       }
 
-      const record =
-        (await getRunningUserMachineByHandle(db, handle)) ??
-        (await getContainer(db, handle));
+      const machine = await getRunningUserMachineByHandle(db, handle);
+      const legacyContainer = await getContainer(db, handle);
+      if (
+        machine?.clerkUserId &&
+        legacyContainer?.clerkUserId &&
+        machine.clerkUserId !== legacyContainer.clerkUserId
+      ) {
+        return c.json({ error: 'Handle owner mismatch' }, 409);
+      }
+
+      const record = machine ?? legacyContainer;
       if (!record?.clerkUserId) {
         return c.json({ error: 'Unknown handle' }, 404);
       }

--- a/tests/platform/internal-integration-routes.test.ts
+++ b/tests/platform/internal-integration-routes.test.ts
@@ -106,4 +106,27 @@ describe("platform/internal-integration-routes", () => {
     expect(res.status).toBe(200);
     await expect(res.json()).resolves.toEqual({ clerkUserId: "user_bob" });
   });
+
+  it("rejects handles whose VPS machine and legacy container owners differ", async () => {
+    await insertUserMachine(db, {
+      machineId: "machine-alice-mismatch",
+      clerkUserId: "user_other",
+      handle: "alice",
+      hetznerServerId: 789,
+      publicIPv4: "203.0.113.13",
+      status: "running",
+      imageVersion: "matrix-os-host-dev",
+      provisionedAt: "2026-05-06T00:00:00.000Z",
+    });
+    const app = createTestApp();
+
+    const res = await app.request("/internal/containers/alice/integrations/probe", {
+      headers: {
+        authorization: `Bearer ${bearerFor("alice", "platform-secret-123")}`,
+      },
+    });
+
+    expect(res.status).toBe(409);
+    await expect(res.json()).resolves.toEqual({ error: "Handle owner mismatch" });
+  });
 });

--- a/tests/platform/internal-integration-routes.test.ts
+++ b/tests/platform/internal-integration-routes.test.ts
@@ -4,6 +4,7 @@ import { Hono } from "hono";
 import { createHmac } from "node:crypto";
 import {
   insertContainer,
+  insertUserMachine,
   type PlatformDB,
 } from "../../packages/platform/src/db.js";
 import { createApp } from "../../packages/platform/src/main.js";
@@ -81,5 +82,28 @@ describe("platform/internal-integration-routes", () => {
 
     expect(res.status).toBe(200);
     await expect(res.json()).resolves.toEqual({ clerkUserId: "user_alice" });
+  });
+
+  it("authorizes VPS-native user machines when no legacy container row exists", async () => {
+    await insertUserMachine(db, {
+      machineId: "machine-bob",
+      clerkUserId: "user_bob",
+      handle: "bob",
+      hetznerServerId: 456,
+      publicIPv4: "203.0.113.12",
+      status: "running",
+      imageVersion: "matrix-os-host-dev",
+      provisionedAt: "2026-05-06T00:00:00.000Z",
+    });
+    const app = createTestApp();
+
+    const res = await app.request("/internal/containers/bob/integrations/probe", {
+      headers: {
+        authorization: `Bearer ${bearerFor("bob", "platform-secret-123")}`,
+      },
+    });
+
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual({ clerkUserId: "user_bob" });
   });
 });


### PR DESCRIPTION
## Summary
- authorize internal integration routes against running user machine records before falling back to legacy containers
- add coverage for VPS-native user machines without legacy container rows
- make Symphony fill the Matrix app window and keep scrolling inside the run list/detail panes

## Verification
- `pnpm exec vitest run tests/platform/internal-integration-routes.test.ts`
- `pnpm exec tsc --noEmit` from `home/apps/symphony`
- `pnpm exec vite build --configLoader runner --outDir /tmp/symphony-pr-dist --emptyOutDir` from `home/apps/symphony`

Note: the default root build wrappers and Symphony default `dist` output are blocked in this VPS worktree by root-owned generated directories, so verification used direct commands and a temporary build output directory.