### PR TITLE
fix(billing): refresh hosted shell sessions for desktop

### DIFF
--- a/desktop/src/main/embeds/app-session.ts
+++ b/desktop/src/main/embeds/app-session.ts
@@ -4,7 +4,15 @@
 // session cookies must land or the handoff failed), L3 (stale Clerk cookies are
 // cleared before installing the fresh pair).
 
-export const REQUIRED_COOKIES = ["matrix_app_session", "matrix_native_app_session"] as const;
+export const HOSTED_SHELL_APP_SESSION_COOKIE = "matrix_app_session";
+export const HOSTED_SHELL_NATIVE_SESSION_COOKIE = "matrix_native_app_session";
+export const REQUIRED_COOKIES = [
+  HOSTED_SHELL_APP_SESSION_COOKIE,
+  HOSTED_SHELL_NATIVE_SESSION_COOKIE,
+] as const;
+export const HOSTED_SHELL_SESSION_REFRESH_SKEW_MS = 10 * 60 * 1000;
+export const HOSTED_SHELL_SESSION_REFRESH_FALLBACK_MS = 30 * 60 * 1000;
+export const HOSTED_SHELL_SESSION_REFRESH_RETRY_MS = 30 * 1000;
 const APP_SESSION_TIMEOUT_MS = 10_000;
 
 export interface ParsedCookie {
@@ -109,6 +117,20 @@ export function isStaleClerkCookie(cookie: { name: string; domain?: string }): b
   return false;
 }
 
+export function computeHostedShellSessionRefreshDelay(
+  cookies: Array<{ name: string; expires?: number }>,
+  now = Date.now(),
+): number {
+  const appSessionCookie = cookies.find(
+    (cookie) =>
+      cookie.name === HOSTED_SHELL_APP_SESSION_COOKIE &&
+      typeof cookie.expires === "number" &&
+      Number.isFinite(cookie.expires),
+  );
+  if (!appSessionCookie?.expires) return HOSTED_SHELL_SESSION_REFRESH_FALLBACK_MS;
+  return Math.max(0, appSessionCookie.expires - HOSTED_SHELL_SESSION_REFRESH_SKEW_MS - now);
+}
+
 function removalUrlForCookie(cookie: { domain?: string }, gatewayOrigin: string): string {
   const fallbackHost = new URL(gatewayOrigin).hostname;
   const domain = cookie.domain?.replace(/^\./, "").trim() || fallbackHost;
@@ -116,7 +138,7 @@ function removalUrlForCookie(cookie: { domain?: string }, gatewayOrigin: string)
 }
 
 export interface CookieJarLike {
-  get(filter: Record<string, never>): Promise<Array<{ name: string; domain?: string; path?: string }>>;
+  get(filter: Record<string, never>): Promise<Array<{ name: string; domain?: string; path?: string; expires?: number }>>;
   set(cookie: ParsedCookie & { url: string }): Promise<void>;
   remove(url: string, name: string): Promise<void>;
 }

--- a/desktop/src/main/embeds/embed-service.ts
+++ b/desktop/src/main/embeds/embed-service.ts
@@ -297,7 +297,7 @@ export class EmbedService {
           err instanceof Error ? err.message : String(err),
         );
         if (this.hostedShellRefreshGatewayOrigin === gatewayOrigin) {
-          this.armHostedShellRefreshTimer(gatewayOrigin, delayMs ?? HOSTED_SHELL_SESSION_REFRESH_RETRY_MS);
+          this.armHostedShellRefreshTimer(gatewayOrigin, HOSTED_SHELL_SESSION_REFRESH_RETRY_MS);
         }
       });
   }

--- a/desktop/src/main/embeds/embed-service.ts
+++ b/desktop/src/main/embeds/embed-service.ts
@@ -8,7 +8,14 @@ import { net, session, type BaseWindow } from "electron";
 import { randomUUID } from "node:crypto";
 import { EmbedManager, type Bounds } from "./embed-manager";
 import { LaunchTokenCache } from "./launch-token-cache";
-import { handoffWithRetry, type CookieJarLike, type ParsedCookie } from "./app-session";
+import {
+  HOSTED_SHELL_SESSION_REFRESH_RETRY_MS,
+  computeHostedShellSessionRefreshDelay,
+  handoffWithRetry,
+  type CookieJarLike,
+  type HandoffResult,
+  type ParsedCookie,
+} from "./app-session";
 import { resolveLaunchUrl } from "./origin-policy";
 import { createWebContentsView } from "./web-contents-view";
 
@@ -35,6 +42,7 @@ interface OpenResult {
 
 const MAX_PENDING_HOSTED_SHELLS = 12;
 const MAX_PENDING_APPS = 12;
+const HOSTED_SHELL_PARTITION = "persist:hosted-shell";
 
 interface PendingAppEmbed {
   slug: string;
@@ -49,6 +57,9 @@ export class EmbedService {
   private readonly pendingApps = new Map<string, PendingAppEmbed>();
   private readonly pendingActive = new Map<string, boolean>();
   private readonly hostedShellIds = new Set<string>();
+  private hostedShellRefreshTimer: ReturnType<typeof setTimeout> | null = null;
+  private hostedShellRefreshInFlight = false;
+  private hostedShellRefreshGatewayOrigin: string | null = null;
 
   constructor(deps: EmbedServiceDeps) {
     this.deps = deps;
@@ -85,6 +96,9 @@ export class EmbedService {
     if (pending) {
       this.pendingActive.set(embedId, active);
     }
+    if (active && this.hostedShellIds.has(embedId)) {
+      this.scheduleHostedShellSessionRefresh(this.deps.getGatewayOrigin());
+    }
     return this.manager.setActive(embedId, active) || pending;
   }
 
@@ -93,6 +107,9 @@ export class EmbedService {
     const wasPendingApp = this.pendingApps.delete(embedId);
     this.pendingActive.delete(embedId);
     this.hostedShellIds.delete(embedId);
+    if (this.hostedShellIds.size === 0) {
+      this.clearHostedShellRefreshTimer();
+    }
     return this.manager.close(embedId) || wasPending || wasPendingApp;
   }
 
@@ -101,6 +118,7 @@ export class EmbedService {
     this.pendingApps.clear();
     this.pendingActive.clear();
     this.hostedShellIds.clear();
+    this.clearHostedShellRefreshTimer();
     this.tokenCache.clear();
     this.manager.closeAll();
   }
@@ -112,7 +130,7 @@ export class EmbedService {
       const bounds = this.pendingHostedShells.get(embedId)!;
       const gatewayOrigin = this.deps.getGatewayOrigin();
       const handoff = await this.performHostedShellHandoff(gatewayOrigin);
-      if (!handoff) {
+      if (!handoff.ok) {
         if (this.pendingHostedShells.has(embedId)) {
           this.deps.emitState(embedId, "auth-required");
         }
@@ -124,6 +142,7 @@ export class EmbedService {
       this.pendingHostedShells.delete(embedId);
       this.pendingActive.delete(embedId);
       this.hostedShellIds.add(embedId);
+      this.scheduleHostedShellSessionRefresh(gatewayOrigin);
       this.deps.emitState(embedId, "loading");
       return true;
     }
@@ -149,10 +168,11 @@ export class EmbedService {
     if (!this.manager.has(embedId)) return false;
     if (this.hostedShellIds.has(embedId)) {
       const handoff = await this.performHostedShellHandoff(this.deps.getGatewayOrigin());
-      if (!handoff) {
+      if (!handoff.ok) {
         this.deps.emitState(embedId, "auth-required");
         return false;
       }
+      this.scheduleHostedShellSessionRefresh(this.deps.getGatewayOrigin());
       return this.manager.reload(embedId);
     }
     return this.manager.focus(embedId);
@@ -163,7 +183,12 @@ export class EmbedService {
     return {
       get: async () => {
         const cookies = await jar.get({});
-        return cookies.map((c) => ({ name: c.name, domain: c.domain, path: c.path }));
+        return cookies.map((c) => ({
+          name: c.name,
+          domain: c.domain,
+          path: c.path,
+          ...(typeof c.expirationDate === "number" ? { expires: c.expirationDate * 1000 } : {}),
+        }));
       },
       set: async (cookie: ParsedCookie & { url: string }) => {
         await jar.set({
@@ -191,6 +216,7 @@ export class EmbedService {
       return { embedId, state: "auth-required" };
     }
     this.hostedShellIds.add(embedId);
+    this.scheduleHostedShellSessionRefresh(gatewayOrigin);
     return { embedId, state: "loading" };
   }
 
@@ -212,7 +238,7 @@ export class EmbedService {
     active: boolean,
   ): Promise<boolean> {
     const handoff = await this.performHostedShellHandoff(gatewayOrigin);
-    if (!handoff) return false;
+    if (!handoff.ok) return false;
     this.attachHostedShellEmbed(gatewayOrigin, bounds, embedId, active);
     return true;
   }
@@ -231,16 +257,90 @@ export class EmbedService {
     });
   }
 
-  private async performHostedShellHandoff(gatewayOrigin: string): Promise<boolean> {
-    const handoff = await handoffWithRetry(
+  private async performHostedShellHandoff(gatewayOrigin: string): Promise<HandoffResult> {
+    return handoffWithRetry(
       {
         gatewayOrigin,
-        cookieJar: this.cookieJarFor("persist:hosted-shell"),
+        cookieJar: this.cookieJarFor(HOSTED_SHELL_PARTITION),
         request: (url, init) => this.gatewayRequest(url, init),
       },
       "/",
     );
-    return handoff.ok;
+  }
+
+  private clearHostedShellRefreshTimer(): void {
+    if (this.hostedShellRefreshTimer) clearTimeout(this.hostedShellRefreshTimer);
+    this.hostedShellRefreshTimer = null;
+    this.hostedShellRefreshGatewayOrigin = null;
+  }
+
+  private scheduleHostedShellSessionRefresh(gatewayOrigin: string, delayMs?: number): void {
+    this.hostedShellRefreshGatewayOrigin = gatewayOrigin;
+    if (this.hostedShellRefreshTimer) clearTimeout(this.hostedShellRefreshTimer);
+    this.hostedShellRefreshTimer = null;
+    if (this.hostedShellIds.size === 0) return;
+
+    if (delayMs !== undefined) {
+      this.armHostedShellRefreshTimer(gatewayOrigin, delayMs);
+      return;
+    }
+
+    void this.readHostedShellRefreshDelay()
+      .then((delay) => {
+        if (this.hostedShellRefreshGatewayOrigin === gatewayOrigin) {
+          this.armHostedShellRefreshTimer(gatewayOrigin, delay);
+        }
+      })
+      .catch((err: unknown) => {
+        console.warn(
+          "[embed-service] unable to read hosted-shell session expiry:",
+          err instanceof Error ? err.message : String(err),
+        );
+        if (this.hostedShellRefreshGatewayOrigin === gatewayOrigin) {
+          this.armHostedShellRefreshTimer(gatewayOrigin, delayMs ?? HOSTED_SHELL_SESSION_REFRESH_RETRY_MS);
+        }
+      });
+  }
+
+  private armHostedShellRefreshTimer(gatewayOrigin: string, delayMs: number): void {
+    if (this.hostedShellRefreshTimer) clearTimeout(this.hostedShellRefreshTimer);
+    this.hostedShellRefreshTimer = setTimeout(() => {
+      void this.refreshHostedShellSession(gatewayOrigin);
+    }, Math.max(0, delayMs));
+  }
+
+  private async readHostedShellRefreshDelay(): Promise<number> {
+    const cookies = await this.cookieJarFor(HOSTED_SHELL_PARTITION).get({});
+    return computeHostedShellSessionRefreshDelay(cookies);
+  }
+
+  private emitHostedShellAuthRequired(): void {
+    for (const embedId of this.hostedShellIds) {
+      this.deps.emitState(embedId, "auth-required");
+    }
+  }
+
+  private async refreshHostedShellSession(gatewayOrigin: string): Promise<HandoffResult> {
+    if (this.hostedShellRefreshInFlight) return { ok: false, reason: "unavailable" };
+    if (this.hostedShellIds.size === 0) {
+      this.clearHostedShellRefreshTimer();
+      return { ok: false, reason: "unavailable" };
+    }
+    this.hostedShellRefreshInFlight = true;
+    try {
+      const result = await this.performHostedShellHandoff(gatewayOrigin);
+      if (result.ok) {
+        this.scheduleHostedShellSessionRefresh(gatewayOrigin);
+      } else if (result.reason === "unavailable") {
+        this.scheduleHostedShellSessionRefresh(gatewayOrigin, HOSTED_SHELL_SESSION_REFRESH_RETRY_MS);
+      } else {
+        this.clearHostedShellRefreshTimer();
+        this.emitHostedShellAuthRequired();
+      }
+      return result;
+    } finally {
+      this.hostedShellRefreshInFlight = false;
+    }
   }
 
   private async openApp(gatewayOrigin: string, slug: string, bounds: Bounds, active: boolean): Promise<OpenResult> {

--- a/packages/platform/src/main.ts
+++ b/packages/platform/src/main.ts
@@ -2078,6 +2078,9 @@ export function createApp(deps: {
     }
   }
 
+  const BILLING_AUTH_FAILURE_HEADER = 'X-Auth-Failure';
+  const BILLING_APP_SESSION_STALE_FAILURE = 'app-session-stale';
+
   async function resolveBillingClerkUserId(c: Context): Promise<string | null> {
     const authorization = c.req.header('authorization');
     const cookie = c.req.header('cookie');
@@ -2106,6 +2109,9 @@ export function createApp(deps: {
       const kind = err instanceof Error ? err.name : typeof err;
       const source = bearerToken ? 'native token' : 'app session token';
       console.warn(`[billing] ${source} verification failed: ${kind}`);
+      if (!bearerToken && appSessionToken) {
+        c.header(BILLING_AUTH_FAILURE_HEADER, BILLING_APP_SESSION_STALE_FAILURE);
+      }
       return null;
     }
   }

--- a/shell/src/components/settings/sections/BillingPanel.tsx
+++ b/shell/src/components/settings/sections/BillingPanel.tsx
@@ -26,7 +26,10 @@ import {
   MATRIX_BILLING_REGIONS,
   MATRIX_BILLING_SERVER_PROFILES,
 } from "@/lib/billing";
-import type { BillingEntitlementSummary } from "@/hooks/useMatrixBillingAccess";
+import type {
+  BillingAccessIssue,
+  BillingEntitlementSummary,
+} from "@/hooks/useMatrixBillingAccess";
 import { capturePostHogEvent, capturePostHogLog } from "@/lib/posthog-client";
 
 export type BillingPanelMode = "settings" | "provisioning" | "device-setup";
@@ -387,6 +390,22 @@ function ActiveBillingPanel({
   );
 }
 
+function BillingSessionRefreshingPanel() {
+  return (
+    <div className="flex min-h-48 items-center justify-center rounded-xl border border-sky-500/20 bg-sky-500/5 p-4">
+      <output className="flex max-w-md flex-col items-center gap-3 text-center text-sm text-sky-900">
+        <span className="flex size-10 items-center justify-center rounded-lg border border-sky-500/20 bg-white">
+          <Loader2Icon className="size-4 animate-spin text-sky-700" aria-hidden="true" />
+        </span>
+        <span className="font-semibold">Reconnecting billing session</span>
+        <span className="leading-6 text-sky-900/70">
+          Matrix is refreshing your desktop session before checking billing.
+        </span>
+      </output>
+    </div>
+  );
+}
+
 function BillingMetric({
   label,
   value,
@@ -725,6 +744,7 @@ export function BillingPanel({
   active,
   entitlement,
   accessReason,
+  accessIssue,
   mode = "settings",
   onCheckoutIntent,
   checkoutReturnPath,
@@ -732,6 +752,7 @@ export function BillingPanel({
   active: boolean | null;
   entitlement?: BillingEntitlementSummary | null;
   accessReason?: string | null;
+  accessIssue?: BillingAccessIssue;
   mode?: BillingPanelMode;
   onCheckoutIntent?: () => void;
   checkoutReturnPath?: string;
@@ -822,6 +843,10 @@ export function BillingPanel({
 
   if (active === true) {
     return <ActiveBillingPanel entitlement={entitlement ?? null} accessReason={accessReason ?? null} />;
+  }
+
+  if (accessIssue === "auth") {
+    return <BillingSessionRefreshingPanel />;
   }
 
   if (active === null) {

--- a/shell/src/components/settings/sections/BillingPanel.tsx
+++ b/shell/src/components/settings/sections/BillingPanel.tsx
@@ -393,7 +393,11 @@ function ActiveBillingPanel({
 function BillingSessionRefreshingPanel() {
   return (
     <div className="flex min-h-48 items-center justify-center rounded-xl border border-sky-500/20 bg-sky-500/5 p-4">
-      <output className="flex max-w-md flex-col items-center gap-3 text-center text-sm text-sky-900">
+      <div
+        aria-busy="true"
+        aria-live="polite"
+        className="flex max-w-md flex-col items-center gap-3 text-center text-sm text-sky-900"
+      >
         <span className="flex size-10 items-center justify-center rounded-lg border border-sky-500/20 bg-white">
           <Loader2Icon className="size-4 animate-spin text-sky-700" aria-hidden="true" />
         </span>
@@ -401,7 +405,7 @@ function BillingSessionRefreshingPanel() {
         <span className="leading-6 text-sky-900/70">
           Matrix is refreshing your desktop session before checking billing.
         </span>
-      </output>
+      </div>
     </div>
   );
 }

--- a/shell/src/components/settings/sections/BillingSection.tsx
+++ b/shell/src/components/settings/sections/BillingSection.tsx
@@ -13,7 +13,7 @@ export function BillingSection({
   onCheckoutIntent?: () => void;
   checkoutReturnPath?: string;
 }) {
-  const { active, entitlement, accessReason } = useMatrixBillingAccess();
+  const { active, entitlement, accessReason, accessIssue } = useMatrixBillingAccess();
 
   return (
     <div className="mx-auto max-w-5xl space-y-3 p-2 sm:p-4">
@@ -33,12 +33,14 @@ export function BillingSection({
           className={
             active === true
               ? "border-forest/25 bg-forest/8 text-forest"
+              : accessIssue === "auth"
+                ? "border-sky-500/30 bg-sky-500/10 text-sky-700"
               : active === false
                 ? "border-amber-500/30 bg-amber-500/10 text-amber-700"
                 : "border-border/30 bg-muted/30 text-muted-foreground"
           }
         >
-          {active === true ? "Active" : active === false ? "Not active" : "Checking"}
+          {active === true ? "Active" : accessIssue === "auth" ? "Reconnecting" : active === false ? "Not active" : "Checking"}
         </Badge>
       </div>
 
@@ -46,6 +48,7 @@ export function BillingSection({
         active={active}
         entitlement={entitlement}
         accessReason={accessReason}
+        accessIssue={accessIssue}
         mode={mode}
         onCheckoutIntent={onCheckoutIntent}
         checkoutReturnPath={checkoutReturnPath}

--- a/shell/src/hooks/useMatrixBillingAccess.ts
+++ b/shell/src/hooks/useMatrixBillingAccess.ts
@@ -23,7 +23,10 @@ type BillingAccessState = {
   checking: boolean;
   entitlement: BillingEntitlementSummary | null;
   accessReason: string | null;
+  accessIssue: BillingAccessIssue;
 };
+
+export type BillingAccessIssue = "auth" | null;
 
 export type BillingEntitlementSummary = {
   source: "stripe" | "override";
@@ -43,9 +46,10 @@ export type BillingEntitlementSummary = {
 };
 
 type BillingAccessRemoteState = {
-  active: boolean;
+  active: boolean | null;
   entitlement: BillingEntitlementSummary | null;
   accessReason: string | null;
+  accessIssue: BillingAccessIssue;
 };
 
 export function useMatrixBillingAccess(): BillingAccessState {
@@ -68,7 +72,7 @@ export function useMatrixBillingAccess(): BillingAccessState {
       return;
     }
     if (isSignedIn && !userId) {
-      setRemoteState({ active: false, entitlement: null, accessReason: null });
+      setRemoteState({ active: false, entitlement: null, accessReason: null, accessIssue: null });
       setRemoteChecked(true);
       return;
     }
@@ -94,7 +98,7 @@ export function useMatrixBillingAccess(): BillingAccessState {
         if (disposed) return;
         setRemoteState(state);
         setRemoteChecked(true);
-        if (checkoutReturnRequested && !state.active) {
+        if (state.accessIssue === "auth" || (checkoutReturnRequested && state.active === false)) {
           retryTimeoutId = window.setTimeout(() => {
             setRetryTick((current) => current + 1);
           }, BILLING_STATUS_RETRY_MS);
@@ -115,14 +119,32 @@ export function useMatrixBillingAccess(): BillingAccessState {
     };
   }, [isLoaded, isSignedIn, legacyActive, retryTick, userId]);
 
-  if (!isLoaded) return { active: null, checking: true, entitlement: null, accessReason: null };
-  if (legacyActive) return { active: true, checking: false, entitlement: null, accessReason: "legacy_clerk_plan" };
-  if (!remoteChecked) return { active: null, checking: true, entitlement: null, accessReason: null };
+  if (!isLoaded) return { active: null, checking: true, entitlement: null, accessReason: null, accessIssue: null };
+  if (legacyActive) {
+    return {
+      active: true,
+      checking: false,
+      entitlement: null,
+      accessReason: "legacy_clerk_plan",
+      accessIssue: null,
+    };
+  }
+  if (remoteState?.accessIssue === "auth") {
+    return {
+      active: null,
+      checking: true,
+      entitlement: null,
+      accessReason: remoteState.accessReason,
+      accessIssue: "auth",
+    };
+  }
+  if (!remoteChecked) return { active: null, checking: true, entitlement: null, accessReason: null, accessIssue: null };
   return {
     active: remoteState?.active === true,
     checking: false,
     entitlement: remoteState?.entitlement ?? null,
     accessReason: remoteState?.accessReason ?? null,
+    accessIssue: null,
   };
 }
 
@@ -161,7 +183,17 @@ function readRemoteBillingStatus(
       if (response.status >= 500 || response.status === 429) {
         throw new Error("billing_status_retryable");
       }
-      if (!response.ok) return { active: false, entitlement: null, accessReason: null };
+      if (response.status === 401 || response.status === 403) {
+        return {
+          active: null,
+          entitlement: null,
+          accessReason: "auth_session_refreshing",
+          accessIssue: "auth",
+        };
+      }
+      if (!response.ok) {
+        return { active: false, entitlement: null, accessReason: null, accessIssue: null };
+      }
       const body = (await response.json()) as {
         access?: { runtimeProxyAllowed?: boolean; reason?: string };
         entitlement?: BillingEntitlementSummary | null;
@@ -170,10 +202,11 @@ function readRemoteBillingStatus(
         active: body.access?.runtimeProxyAllowed === true,
         entitlement: body.entitlement ?? null,
         accessReason: typeof body.access?.reason === "string" ? body.access.reason : null,
+        accessIssue: null,
       };
     })
     .then((state) => {
-      if (!options.skipCache && (state.active || !options.skipInactiveCache)) {
+      if (!options.skipCache && state.accessIssue === null && (state.active || !options.skipInactiveCache)) {
         billingStatusSnapshot = { cacheKey, state, checkedAt: Date.now() };
       }
       return state;

--- a/shell/src/hooks/useMatrixBillingAccess.ts
+++ b/shell/src/hooks/useMatrixBillingAccess.ts
@@ -8,6 +8,7 @@ const BILLING_STATUS_TIMEOUT_MS = 10_000;
 const BILLING_STATUS_CACHE_TTL_MS = 30_000;
 const BILLING_STATUS_RETRY_MS = 3_000;
 const PLATFORM_SESSION_BILLING_CACHE_KEY = "platform-session";
+const APP_SESSION_STALE_AUTH_FAILURE = "app-session-stale";
 
 type BillingStatusSnapshot = {
   cacheKey: string;
@@ -184,6 +185,9 @@ function readRemoteBillingStatus(
         throw new Error("billing_status_retryable");
       }
       if (response.status === 401 || response.status === 403) {
+        if (response.headers.get("x-auth-failure") !== APP_SESSION_STALE_AUTH_FAILURE) {
+          return { active: false, entitlement: null, accessReason: null, accessIssue: null };
+        }
         return {
           active: null,
           entitlement: null,

--- a/tests/desktop/app-session.test.ts
+++ b/tests/desktop/app-session.test.ts
@@ -1,6 +1,9 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
+  HOSTED_SHELL_SESSION_REFRESH_FALLBACK_MS,
+  HOSTED_SHELL_SESSION_REFRESH_SKEW_MS,
   REQUIRED_COOKIES,
+  computeHostedShellSessionRefreshDelay,
   handoffWithRetry,
   isStaleClerkCookie,
   parseSetCookieHeaders,
@@ -187,6 +190,37 @@ describe("isStaleClerkCookie", () => {
       false,
     );
     expect(isStaleClerkCookie({ name: "matrix_native_app_session" })).toBe(false);
+  });
+});
+
+describe("computeHostedShellSessionRefreshDelay", () => {
+  it("schedules refresh ten minutes before the matrix app session expires", () => {
+    const now = Date.parse("2026-06-25T10:00:00.000Z");
+    const expires = now + 60 * 60 * 1000;
+    expect(
+      computeHostedShellSessionRefreshDelay([
+        { name: "matrix_native_app_session", expires },
+        { name: "matrix_app_session", expires },
+      ], now),
+    ).toBe(60 * 60 * 1000 - HOSTED_SHELL_SESSION_REFRESH_SKEW_MS);
+  });
+
+  it("refreshes immediately when the app session is already inside the skew window", () => {
+    const now = Date.parse("2026-06-25T10:00:00.000Z");
+    expect(
+      computeHostedShellSessionRefreshDelay([
+        { name: "matrix_app_session", expires: now + 2 * 60 * 1000 },
+      ], now),
+    ).toBe(0);
+  });
+
+  it("falls back to a periodic refresh when cookie expiry metadata is unavailable", () => {
+    expect(
+      computeHostedShellSessionRefreshDelay([
+        { name: "matrix_app_session" },
+        { name: "matrix_native_app_session", expires: Date.now() + 60_000 },
+      ]),
+    ).toBe(HOSTED_SHELL_SESSION_REFRESH_FALLBACK_MS);
   });
 });
 

--- a/tests/desktop/embed-service.test.ts
+++ b/tests/desktop/embed-service.test.ts
@@ -1,8 +1,9 @@
 import { EventEmitter } from "node:events";
 import { net } from "electron";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { EmbedService } from "@desktop/main/embeds/embed-service";
 import type { Bounds } from "@desktop/main/embeds/embed-manager";
+import type { HandoffResult } from "@desktop/main/embeds/app-session";
 
 vi.mock("electron", () => ({
   net: { request: vi.fn() },
@@ -12,6 +13,11 @@ vi.mock("electron", () => ({
 const BOUNDS: Bounds = { x: 0, y: 0, width: 800, height: 600 };
 
 describe("EmbedService", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
   it("honors pending hosted-shell inactive state when retry auth finishes", async () => {
     const emitState = vi.fn();
     const service = new EmbedService({
@@ -22,11 +28,13 @@ describe("EmbedService", () => {
     });
     const internals = service as unknown as {
       pendingHostedShells: Map<string, Bounds>;
-      performHostedShellHandoff: (gatewayOrigin: string) => Promise<boolean>;
+      performHostedShellHandoff: (gatewayOrigin: string) => Promise<HandoffResult>;
+      scheduleHostedShellSessionRefresh: (gatewayOrigin: string) => void;
       manager: { open: (kind: string, slug: string | null, bounds: Bounds, url: string, options: { active?: boolean }) => string };
     };
     const open = vi.spyOn(internals.manager, "open").mockReturnValue("embed-shell");
-    let resolveHandoff!: (ok: boolean) => void;
+    vi.spyOn(internals, "scheduleHostedShellSessionRefresh").mockImplementation(() => {});
+    let resolveHandoff!: (result: HandoffResult) => void;
     vi.spyOn(internals, "performHostedShellHandoff").mockImplementation(
       () => new Promise((resolve) => { resolveHandoff = resolve; }),
     );
@@ -35,7 +43,7 @@ describe("EmbedService", () => {
     const retry = service.retryAuth("embed-shell");
     expect(service.setActive("embed-shell", false)).toBe(true);
 
-    resolveHandoff(true);
+    resolveHandoff({ ok: true });
     await expect(retry).resolves.toBe(true);
 
     expect(open).toHaveBeenCalledWith(
@@ -46,6 +54,95 @@ describe("EmbedService", () => {
       expect.objectContaining({ id: "embed-shell", active: false }),
     );
     expect(emitState).toHaveBeenCalledWith("embed-shell", "loading");
+  });
+
+  it("schedules hosted-shell session refresh from the app-session cookie expiry", async () => {
+    vi.useFakeTimers();
+    const service = new EmbedService({
+      getWindow: () => null,
+      getGatewayOrigin: () => "https://gateway.test",
+      getToken: () => "token",
+      emitState: vi.fn(),
+    });
+    const internals = service as unknown as {
+      hostedShellIds: Set<string>;
+      scheduleHostedShellSessionRefresh: (gatewayOrigin: string) => void;
+      readHostedShellRefreshDelay: () => Promise<number>;
+      refreshHostedShellSession: (gatewayOrigin: string) => Promise<HandoffResult>;
+    };
+    const refresh = vi
+      .spyOn(internals, "refreshHostedShellSession")
+      .mockResolvedValue({ ok: true });
+    vi.spyOn(internals, "readHostedShellRefreshDelay").mockResolvedValue(120_000);
+
+    internals.hostedShellIds.add("embed-shell");
+    internals.scheduleHostedShellSessionRefresh("https://gateway.test");
+    await vi.runAllTicks();
+
+    await vi.advanceTimersByTimeAsync(119_999);
+    expect(refresh).not.toHaveBeenCalled();
+    await vi.advanceTimersByTimeAsync(1);
+    expect(refresh).toHaveBeenCalledWith("https://gateway.test");
+  });
+
+  it("retries transient hosted-shell refresh failures without marking auth required", async () => {
+    vi.useFakeTimers();
+    const emitState = vi.fn();
+    const service = new EmbedService({
+      getWindow: () => null,
+      getGatewayOrigin: () => "https://gateway.test",
+      getToken: () => "token",
+      emitState,
+    });
+    const internals = service as unknown as {
+      hostedShellIds: Set<string>;
+      refreshHostedShellSession: (gatewayOrigin: string) => Promise<HandoffResult>;
+      performHostedShellHandoff: (gatewayOrigin: string) => Promise<HandoffResult>;
+    };
+    vi.spyOn(internals, "performHostedShellHandoff").mockResolvedValue({
+      ok: false,
+      reason: "unavailable",
+    });
+    internals.hostedShellIds.add("embed-shell");
+
+    await expect(internals.refreshHostedShellSession("https://gateway.test")).resolves.toEqual({
+      ok: false,
+      reason: "unavailable",
+    });
+    expect(emitState).not.toHaveBeenCalledWith("embed-shell", "auth-required");
+
+    await vi.advanceTimersByTimeAsync(30_000);
+    expect(internals.performHostedShellHandoff).toHaveBeenCalledTimes(2);
+  });
+
+  it("emits auth-required and stops refreshing on hosted-shell auth failure", async () => {
+    vi.useFakeTimers();
+    const emitState = vi.fn();
+    const service = new EmbedService({
+      getWindow: () => null,
+      getGatewayOrigin: () => "https://gateway.test",
+      getToken: () => "token",
+      emitState,
+    });
+    const internals = service as unknown as {
+      hostedShellIds: Set<string>;
+      refreshHostedShellSession: (gatewayOrigin: string) => Promise<HandoffResult>;
+      performHostedShellHandoff: (gatewayOrigin: string) => Promise<HandoffResult>;
+    };
+    vi.spyOn(internals, "performHostedShellHandoff").mockResolvedValue({
+      ok: false,
+      reason: "auth",
+    });
+    internals.hostedShellIds.add("embed-shell");
+
+    await expect(internals.refreshHostedShellSession("https://gateway.test")).resolves.toEqual({
+      ok: false,
+      reason: "auth",
+    });
+    expect(emitState).toHaveBeenCalledWith("embed-shell", "auth-required");
+
+    await vi.advanceTimersByTimeAsync(120_000);
+    expect(internals.performHostedShellHandoff).toHaveBeenCalledTimes(1);
   });
 
   it("rejects gateway requests when the response stream errors", async () => {

--- a/tests/platform/proxy-routing.test.ts
+++ b/tests/platform/proxy-routing.test.ts
@@ -519,6 +519,36 @@ describe("platform proxy routing", () => {
     expect(await res.json()).toEqual({ error: "Unauthorized" });
   });
 
+  it("returns generic unauthorized for expired app-shell session cookies on billing routes", async () => {
+    const issued = await issueSyncJwt({
+      secret: JWT_SECRET,
+      clerkUserId: "user_alice",
+      handle: "alice",
+      gatewayUrl: "https://app.matrix-os.com",
+      runtimeSlot: "primary",
+      expiresInSec: -120,
+    });
+    process.env.PLATFORM_JWT_SECRET = JWT_SECRET;
+    const app = createApp({
+      db,
+      orchestrator: stubOrchestrator(),
+      clerkAuth: createClerkAuth({
+        verifyToken: vi.fn().mockRejectedValue(new Error("missing Clerk token")),
+      }),
+      platformSecret: "platform-secret-123",
+    });
+
+    const res = await app.request("/billing/status", {
+      headers: {
+        host: "app.matrix-os.com",
+        cookie: `matrix_app_session=${encodeURIComponent(issued.token)}`,
+      },
+    });
+
+    expect(res.status).toBe(401);
+    expect(await res.json()).toEqual({ error: "Unauthorized" });
+  });
+
   it("uses the raw bearer sync JWT for native billing fallback when a stale Clerk cookie is present", async () => {
     await upsertBillingEntitlement(db, {
       clerkUserId: "user_alice",

--- a/tests/platform/proxy-routing.test.ts
+++ b/tests/platform/proxy-routing.test.ts
@@ -494,6 +494,7 @@ describe("platform proxy routing", () => {
     });
 
     expect(res.status).toBe(401);
+    expect(res.headers.get("x-auth-failure")).toBeNull();
     expect(await res.json()).toEqual({ error: "Unauthorized" });
   });
 
@@ -516,6 +517,7 @@ describe("platform proxy routing", () => {
     });
 
     expect(res.status).toBe(401);
+    expect(res.headers.get("x-auth-failure")).toBe("app-session-stale");
     expect(await res.json()).toEqual({ error: "Unauthorized" });
   });
 
@@ -546,6 +548,7 @@ describe("platform proxy routing", () => {
     });
 
     expect(res.status).toBe(401);
+    expect(res.headers.get("x-auth-failure")).toBe("app-session-stale");
     expect(await res.json()).toEqual({ error: "Unauthorized" });
   });
 

--- a/tests/shell/billing-gate.test.tsx
+++ b/tests/shell/billing-gate.test.tsx
@@ -95,6 +95,7 @@ describe("BillingGate", () => {
   });
 
   afterEach(() => {
+    vi.useRealTimers();
     window.history.replaceState({}, "", "/");
     window.sessionStorage.clear();
     navigationState.replace.mockReset();
@@ -191,8 +192,47 @@ describe("BillingGate", () => {
       </BillingGate>,
     );
 
-    expect(await screen.findByText("Opening Matrix OS sign in")).toBeTruthy();
+    expect(await screen.findByText("Loading billing status")).toBeTruthy();
+    expect(screen.queryByText("Opening Matrix OS sign in")).toBeNull();
+    expect(screen.queryByRole("button", { name: "Continue to pay" })).toBeNull();
     expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("keeps signed-out app-session billing in checking state on 401 and unlocks after refresh", async () => {
+    vi.unstubAllEnvs();
+    clerkState.isLoaded = true;
+    clerkState.isSignedIn = false;
+    clerkState.activePlan = null;
+    const fetchMock = vi.spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ error: "Unauthorized" }), {
+          status: 401,
+          headers: { "content-type": "application/json" },
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ access: { runtimeProxyAllowed: true, reason: "active" } }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+      );
+    vi.resetModules();
+
+    const { BillingGate } = await loadBillingGate();
+
+    render(
+      <BillingGate>
+        <div>Matrix workspace</div>
+      </BillingGate>,
+    );
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+    expect(screen.getByText("Loading billing status")).toBeTruthy();
+    expect(screen.queryByText("Opening Matrix OS sign in")).toBeNull();
+    expect(screen.queryByRole("button", { name: "Continue to pay" })).toBeNull();
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2), { timeout: 5_000 });
+    expect(await screen.findByText("Matrix workspace")).toBeTruthy();
   });
 
   it("bypasses billing only for explicit test screenshot runs", async () => {

--- a/tests/shell/billing-gate.test.tsx
+++ b/tests/shell/billing-gate.test.tsx
@@ -170,7 +170,7 @@ describe("BillingGate", () => {
       .mockResolvedValueOnce(
         new Response(JSON.stringify({ error: "Unauthorized" }), {
           status: 401,
-          headers: { "content-type": "application/json" },
+          headers: { "content-type": "application/json", "x-auth-failure": "app-session-stale" },
         }),
       );
     vi.resetModules();
@@ -207,7 +207,7 @@ describe("BillingGate", () => {
       .mockResolvedValueOnce(
         new Response(JSON.stringify({ error: "Unauthorized" }), {
           status: 401,
-          headers: { "content-type": "application/json" },
+          headers: { "content-type": "application/json", "x-auth-failure": "app-session-stale" },
         }),
       )
       .mockResolvedValueOnce(
@@ -233,6 +233,32 @@ describe("BillingGate", () => {
 
     await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2), { timeout: 5_000 });
     expect(await screen.findByText("Matrix workspace")).toBeTruthy();
+  });
+
+  it("redirects signed-out users instead of reconnecting on a plain billing 401", async () => {
+    vi.unstubAllEnvs();
+    clerkState.isLoaded = true;
+    clerkState.isSignedIn = false;
+    clerkState.activePlan = null;
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ error: "Unauthorized" }), {
+        status: 401,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+    vi.resetModules();
+
+    const { BillingGate } = await loadBillingGate();
+
+    render(
+      <BillingGate>
+        <div>Matrix workspace</div>
+      </BillingGate>,
+    );
+
+    expect(await screen.findByText("Opening Matrix OS sign in")).toBeTruthy();
+    expect(screen.queryByText("Loading billing status")).toBeNull();
+    expect(screen.queryByRole("button", { name: "Continue to pay" })).toBeNull();
   });
 
   it("bypasses billing only for explicit test screenshot runs", async () => {

--- a/tests/shell/billing-section.test.tsx
+++ b/tests/shell/billing-section.test.tsx
@@ -95,7 +95,7 @@ describe("BillingSection", () => {
     const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
       new Response(JSON.stringify({ access: { runtimeProxyAllowed: false } }), {
         status: 401,
-        headers: { "content-type": "application/json" },
+        headers: { "content-type": "application/json", "x-auth-failure": "app-session-stale" },
       }),
     );
 
@@ -124,7 +124,7 @@ describe("BillingSection", () => {
       .mockResolvedValueOnce(
         new Response(JSON.stringify({ error: "Unauthorized" }), {
           status: 401,
-          headers: { "content-type": "application/json" },
+          headers: { "content-type": "application/json", "x-auth-failure": "app-session-stale" },
         }),
       )
       .mockResolvedValueOnce(
@@ -143,6 +143,27 @@ describe("BillingSection", () => {
 
     await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2), { timeout: 5_000 });
     await waitFor(() => expect(screen.getAllByText("Active").length).toBeGreaterThanOrEqual(1));
+  });
+
+  it("shows payment setup instead of reconnecting for a plain signed-out billing 401", async () => {
+    clerkState.isLoaded = true;
+    clerkState.isSignedIn = false;
+    clerkState.userId = null;
+    clerkState.activePlan = null;
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ error: "Unauthorized" }), {
+        status: 401,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+
+    const { BillingSection } = await loadBillingSection();
+
+    render(<BillingSection />);
+
+    await waitFor(() => expect(screen.getByText("Not active")).toBeTruthy());
+    expect(screen.queryByText("Reconnecting billing session")).toBeNull();
+    expect(screen.getByRole("button", { name: "Continue to pay" })).toBeTruthy();
   });
 
   it("keeps billing status unknown and retries after transient status failures", async () => {

--- a/tests/shell/billing-section.test.tsx
+++ b/tests/shell/billing-section.test.tsx
@@ -2,7 +2,7 @@
 
 import React from "react";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const clerkState = vi.hoisted(() => ({
   isLoaded: true,
@@ -49,6 +49,10 @@ describe("BillingSection", () => {
     );
   });
 
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it("waits for Clerk before rendering a subscription state", async () => {
     clerkState.isLoaded = false;
     clerkState.activePlan = "matrix_starter";
@@ -83,7 +87,7 @@ describe("BillingSection", () => {
     expect(screen.queryByTestId("pricing-table")).toBeNull();
   });
 
-  it("checks cookie-backed billing status when Clerk is signed out", async () => {
+  it("shows a reconnecting billing session state when signed-out app-session billing returns 401", async () => {
     clerkState.isLoaded = true;
     clerkState.isSignedIn = false;
     clerkState.userId = null;
@@ -106,7 +110,39 @@ describe("BillingSection", () => {
         method: "GET",
       }),
     ));
-    await waitFor(() => expect(screen.getByText("Not active")).toBeTruthy());
+    await waitFor(() => expect(screen.getByText("Reconnecting")).toBeTruthy());
+    expect(screen.getByText("Reconnecting billing session")).toBeTruthy();
+    expect(screen.queryByRole("button", { name: "Continue to pay" })).toBeNull();
+  });
+
+  it("does not cache signed-out billing 401 and unlocks after session refresh succeeds", async () => {
+    clerkState.isLoaded = true;
+    clerkState.isSignedIn = false;
+    clerkState.userId = null;
+    clerkState.activePlan = null;
+    const fetchMock = vi.spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ error: "Unauthorized" }), {
+          status: 401,
+          headers: { "content-type": "application/json" },
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ access: { runtimeProxyAllowed: true, reason: "active" } }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+      );
+
+    const { BillingSection } = await loadBillingSection();
+
+    render(<BillingSection />);
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(screen.getByText("Reconnecting billing session")).toBeTruthy());
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2), { timeout: 5_000 });
+    await waitFor(() => expect(screen.getAllByText("Active").length).toBeGreaterThanOrEqual(1));
   });
 
   it("keeps billing status unknown and retries after transient status failures", async () => {


### PR DESCRIPTION
## Summary
- Refresh the hosted-shell `matrix_app_session` cookie from the trusted native desktop bearer-token handoff while a hosted shell is open.
- Treat `/billing/status` `401/403` in the shell as an auth/session-refresh state instead of inactive billing, so paid desktop users do not see checkout while the native app repairs the hosted-shell session.
- Keep platform billing auth strict: expired app-session JWTs return generic `401 Unauthorized`, per-app cookies still do not authorize billing, and native bearer-token billing remains covered.

## Tests
- `bunx vitest run tests/desktop/app-session.test.ts tests/desktop/embed-service.test.ts --environment jsdom` ✅
- `bunx vitest run tests/shell/billing-gate.test.tsx tests/shell/billing-section.test.tsx --environment jsdom` ✅
- `bunx vitest run tests/platform/proxy-routing.test.ts --testNamePattern billing` ✅
- `bun run typecheck` ✅
- `bun run check:patterns` ✅ (warnings only; no violations)
- `npx react-doctor@latest shell` ✅ completed; existing project warnings remain
- `npx react-doctor@latest --verbose --scope changed shell` ✅ one unrelated warning in `src/components/terminal/TerminalApp.tsx:4401`, no billing-file findings
- `bun run test` ⚠️ default environment failed broadly because Node localStorage was unavailable and Node emitted DEP0205 warnings into CLI stderr. Re-ran with `NODE_OPTIONS=--localstorage-file=/private/tmp/matrix-os-vitest-localstorage NODE_NO_WARNINGS=1`; suite reduced to 2 unrelated failures in `tests/default-apps/2048-app.test.tsx` localStorage failure-warning expectations. Billing/platform/desktop/shell tests passed in both relevant runs.

## Review/Monitoring
- Opened from a manual worktree: `/Users/nimanaderi/matrix-os.worktrees/fix-desktop-billing-session-refresh`.
- Branch: `codex/fix-desktop-billing-session-refresh`.
- After merge, ship affected surfaces:
  - Desktop Canary release for the Mac hosted-shell session refresh.
  - Host bundle release/deploy for hosted shell billing hook/UI changes on existing VPSes.
  - Platform/app-shell deployment only if the serving path includes this shell bundle in the platform-owned app shell.
- Acceptance smoke: expire or age `matrix_app_session`, keep native desktop signed in, open Settings -> Billing, verify the app reconnects billing session and then shows active entitlement instead of checkout.

## Invariants
- **Source of truth**: billing entitlement remains server-side platform billing state; desktop only refreshes verified hosted-shell cookies via the existing `/api/auth/app-session` handoff.
- **Lock/transaction scope**: no database writes or migrations were added. Desktop refresh state is a single hosted-shell timer scoped to live hosted-shell embeds.
- **Acceptable orphan states**: transient handoff failures retry every 30 seconds while a hosted shell is open; auth failures emit `auth-required` and stop the loop rather than silently leaving expired cookies.
- **Auth source of truth**: refresh uses only the trusted native bearer token through the existing handoff. Shell billing accepts server-verified `/billing/status` results only; client display username, VPS handle, and per-app sandbox cookies are not trusted.
- **Deferred scope**: this PR does not redesign the Clerk-only account button, add a public API, or change billing database projection. If refreshed `/billing/status` returns `200 inactive`, that is a billing-data issue outside this auth/session lifecycle fix.
