### PR TITLE
fix(platform): polish default install fallback

### DIFF
--- a/packages/platform/src/auth-pages.ts
+++ b/packages/platform/src/auth-pages.ts
@@ -336,6 +336,16 @@ export function getAuthPage(
       font-weight: 800;
       letter-spacing: 0;
     }
+    .developer-tool-logo svg {
+      width: 20px;
+      height: 20px;
+      display: block;
+      fill: currentColor;
+    }
+    .developer-tool-logo svg[viewBox="0 0 800 800"] {
+      width: 22px;
+      height: 22px;
+    }
     .developer-tool-name {
       overflow: hidden;
       color: #32352E;
@@ -446,6 +456,12 @@ export function getAuthPage(
     var checkoutAttemptStorageKey = 'matrix.billing.checkoutAttemptAt';
     var checkoutAttemptMaxAgeMs = 30 * 60 * 1000;
     var defaultDeveloperTools = ['codex', 'claude-code', 'opencode', 'pi'];
+    var developerToolLogos = {
+      codex: '<svg role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><title>OpenAI</title><path d="M22.2819 9.8211a5.9847 5.9847 0 0 0-.5157-4.9108 6.0462 6.0462 0 0 0-6.5098-2.9A6.0651 6.0651 0 0 0 4.9807 4.1818a5.9847 5.9847 0 0 0-3.9977 2.9 6.0462 6.0462 0 0 0 .7427 7.0966 5.98 5.98 0 0 0 .511 4.9107 6.051 6.051 0 0 0 6.5146 2.9001A5.9847 5.9847 0 0 0 13.2599 24a6.0557 6.0557 0 0 0 5.7718-4.2058 5.9894 5.9894 0 0 0 3.9977-2.9001 6.0557 6.0557 0 0 0-.7475-7.0729zm-9.022 12.6081a4.4755 4.4755 0 0 1-2.8764-1.0408l.1419-.0804 4.7783-2.7582a.7948.7948 0 0 0 .3927-.6813v-6.7369l2.02 1.1686a.071.071 0 0 1 .038.052v5.5826a4.504 4.504 0 0 1-4.4945 4.4944zm-9.6607-4.1254a4.4708 4.4708 0 0 1-.5346-3.0137l.142.0852 4.783 2.7582a.7712.7712 0 0 0 .7806 0l5.8428-3.3685v2.3324a.0804.0804 0 0 1-.0332.0615L9.74 19.9502a4.4992 4.4992 0 0 1-6.1408-1.6464zM2.3408 7.8956a4.485 4.485 0 0 1 2.3655-1.9728V11.6a.7664.7664 0 0 0 .3879.6765l5.8144 3.3543-2.0201 1.1685a.0757.0757 0 0 1-.071 0l-4.8303-2.7865A4.504 4.504 0 0 1 2.3408 7.872zm16.5963 3.8558L13.1038 8.364 15.1192 7.2a.0757.0757 0 0 1 .071 0l4.8303 2.7913a4.4944 4.4944 0 0 1-.6765 8.1042v-5.6772a.79.79 0 0 0-.407-.667zm2.0107-3.0231l-.142-.0852-4.7735-2.7818a.7759.7759 0 0 0-.7854 0L9.409 9.2297V6.8974a.0662.0662 0 0 1 .0284-.0615l4.8303-2.7866a4.4992 4.4992 0 0 1 6.6802 4.66zM8.3065 12.863l-2.02-1.1638a.0804.0804 0 0 1-.038-.0567V6.0742a4.4992 4.4992 0 0 1 7.3757-3.4537l-.142.0805L8.704 5.459a.7948.7948 0 0 0-.3927.6813zm1.0976-2.3654l2.602-1.4998 2.6069 1.4998v2.9994l-2.5974 1.4997-2.6067-1.4997Z"/></svg>',
+      'claude-code': '<svg role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><title>Anthropic</title><path d="M17.3041 3.541h-3.6718l6.696 16.918H24Zm-10.6082 0L0 20.459h3.7442l1.3693-3.5527h7.0052l1.3693 3.5528h3.7442L10.5363 3.5409Zm-.3712 10.2232 2.2914-5.9456 2.2914 5.9456Z"/></svg>',
+      opencode: '<svg role="img" aria-labelledby="opencode-title" viewBox="0 0 300 300" fill="none" xmlns="http://www.w3.org/2000/svg"><title id="opencode-title">OpenCode</title><g transform="translate(30 0)"><path d="M180 240H60V120H180V240Z" fill="#F7F3EF"/><path d="M180 60H60V240H180V60ZM240 300H0V0H240V300Z" fill="#181616"/></g></svg>',
+      pi: '<svg role="img" viewBox="0 0 800 800" xmlns="http://www.w3.org/2000/svg"><title>Pi</title><rect width="800" height="800" rx="120" fill="#09090b"/><path fill="#fff" fill-rule="evenodd" d="M165.29 165.29H517.36V400H400V517.36H282.65V634.72H165.29ZM282.65 282.65V400H400V282.65Z"/><path fill="#fff" d="M517.36 400 H634.72 V634.72 H517.36 Z"/></svg>'
+    };
     function hasTrustedCheckoutReturn() {
       try {
         var rawAttemptAt = window.sessionStorage.getItem(checkoutAttemptStorageKey);
@@ -637,7 +653,7 @@ export function getAuthPage(
         var logo = document.createElement('span');
         logo.className = 'developer-tool-logo';
         logo.setAttribute('aria-hidden', 'true');
-        logo.textContent = tool === 'claude-code' ? 'AI' : tool === 'opencode' ? 'O' : tool === 'codex' ? 'C' : 'Pi';
+        logo.innerHTML = developerToolLogos[tool] || '';
         var text = document.createElement('span');
         text.className = 'developer-tool-name';
         text.textContent = tool === 'claude-code' ? 'Claude Code' : tool === 'opencode' ? 'OpenCode' : tool === 'codex' ? 'Codex' : 'Pi';

--- a/packages/platform/src/auth-pages.ts
+++ b/packages/platform/src/auth-pages.ts
@@ -182,6 +182,10 @@ export function getAuthPage(
       padding: 32px;
       backdrop-filter: blur(14px);
     }
+    .auth-card.default-installs-card {
+      max-width: 860px;
+      align-items: stretch;
+    }
     #auth { width: 100%; min-height: 400px; display: flex; align-items: center; justify-content: center; }
     .loading { color: #7A7768; font-size: 14px; }
     .session-state {
@@ -225,11 +229,181 @@ export function getAuthPage(
       background: #D06F25;
       color: #fffdf6;
     }
+    .default-installs-state {
+      gap: 16px;
+      max-width: 100%;
+    }
+    .install-hero {
+      border: 1px solid rgba(67,78,63,0.15);
+      border-radius: 22px;
+      background: #fbf7ed;
+      box-shadow: 0 24px 80px rgba(50,53,46,0.12);
+      padding: 20px 22px;
+    }
+    .install-kicker {
+      margin: 0 0 8px;
+      color: rgba(67,78,63,0.6);
+      font-size: 11px;
+      font-weight: 750;
+      letter-spacing: 0.2em;
+      text-transform: uppercase;
+    }
+    .install-title {
+      margin: 0;
+      color: #32352E;
+      font-size: 30px;
+      line-height: 1.08;
+      font-weight: 750;
+      letter-spacing: 0;
+    }
+    .install-detail {
+      margin: 10px 0 0;
+      max-width: 560px;
+      color: rgba(67,78,63,0.7);
+      font-size: 14px;
+      line-height: 1.6;
+    }
+    .developer-tools-panel {
+      border: 1px solid rgba(67,78,63,0.12);
+      border-radius: 22px;
+      background: rgba(255,255,255,0.86);
+      padding: 14px;
+    }
+    .developer-tools-header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 16px;
+      margin-bottom: 12px;
+      padding: 0 4px;
+    }
+    .developer-tools-header h3 {
+      margin: 0;
+      color: #32352E;
+      font-size: 14px;
+      line-height: 1.25;
+      font-weight: 700;
+    }
+    .developer-tools-header p {
+      margin: 0;
+      color: rgba(67,78,63,0.45);
+      font-size: 12px;
+      line-height: 1.5;
+      text-align: right;
+    }
+    .developer-tool-grid {
+      display: grid;
+      grid-template-columns: repeat(4, minmax(0, 1fr));
+      gap: 8px;
+    }
+    .developer-tool-option {
+      min-height: 68px;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 10px;
+      border: 1px solid rgba(67,78,63,0.1);
+      border-radius: 14px;
+      background: #fff;
+      color: #32352E;
+      cursor: pointer;
+      padding: 10px 12px;
+      transition: border-color 160ms ease, background 160ms ease, box-shadow 160ms ease;
+    }
+    .developer-tool-option.selected {
+      border-color: #D06F25;
+      background: #fff7ec;
+      box-shadow: 0 10px 24px rgba(83,68,48,0.10);
+    }
+    .developer-tool-copy {
+      min-width: 0;
+      display: flex;
+      align-items: center;
+      gap: 10px;
+    }
+    .developer-tool-logo {
+      width: 36px;
+      height: 36px;
+      display: grid;
+      place-items: center;
+      flex: none;
+      border: 1px solid rgba(67,78,63,0.1);
+      border-radius: 10px;
+      background: #fff;
+      box-shadow: 0 2px 8px rgba(50,53,46,0.12);
+      color: #32352E;
+      font-size: 12px;
+      font-weight: 800;
+      letter-spacing: 0;
+    }
+    .developer-tool-name {
+      overflow: hidden;
+      color: #32352E;
+      font-size: 14px;
+      font-weight: 650;
+      line-height: 1.25;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+    .developer-tool-option input {
+      width: 16px;
+      height: 16px;
+      flex: none;
+      accent-color: #D06F25;
+    }
+    .default-installs-footer {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 16px;
+    }
+    .default-installs-footer p {
+      margin: 0;
+      color: rgba(67,78,63,0.55);
+      font-size: 12px;
+      line-height: 1.55;
+    }
+    .default-installs-actions {
+      display: flex;
+      flex: none;
+      align-items: center;
+      gap: 10px;
+    }
+    .default-installs-actions button {
+      min-height: 44px;
+      border: 1px solid #C9C4B8;
+      border-radius: 14px;
+      background: rgba(250,250,245,0.76);
+      color: #32352E;
+      cursor: pointer;
+      font: inherit;
+      font-size: 14px;
+      font-weight: 650;
+      padding: 0 18px;
+    }
+    .default-installs-actions button.primary {
+      border-color: #434E3F;
+      background: #434E3F;
+      color: #fffdf6;
+      box-shadow: 0 14px 30px rgba(63,74,58,0.18);
+    }
     @media (max-width: 860px) {
       .page { grid-template-columns: 1fr; }
       .story { min-height: 42vh; border-right: 0; border-bottom: 1px solid #D6D3C8; padding: 40px 24px; }
       .auth-panel { padding: 28px 20px 44px; }
       .auth-card { max-width: 440px; padding: 24px; }
+      .auth-card.default-installs-card { max-width: 860px; }
+      .developer-tools-header { align-items: flex-start; flex-direction: column; gap: 4px; }
+      .developer-tools-header p { text-align: left; }
+      .developer-tool-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+      .default-installs-footer { align-items: stretch; flex-direction: column; }
+      .default-installs-actions { justify-content: flex-end; }
+    }
+    @media (max-width: 520px) {
+      .install-title { font-size: 26px; }
+      .developer-tool-grid { grid-template-columns: 1fr; }
+      .default-installs-actions { flex-direction: column; }
+      .default-installs-actions button { width: 100%; }
     }
   </style>
 </head>
@@ -345,6 +519,7 @@ export function getAuthPage(
     }
     function renderSessionState(title, detail, primaryLabel, primaryHandler) {
       var el = document.getElementById('auth');
+      setDefaultInstallsCard(false);
       el.innerHTML = '';
 
       var state = document.createElement('div');
@@ -396,6 +571,7 @@ export function getAuthPage(
     }
     function showLoadingState(message) {
       var el = document.getElementById('auth');
+      setDefaultInstallsCard(false);
       el.innerHTML = '';
       var loading = document.createElement('span');
       loading.className = 'loading';
@@ -415,35 +591,58 @@ export function getAuthPage(
     }
     function showDefaultInstallsState() {
       var el = document.getElementById('auth');
+      setDefaultInstallsCard(true);
       el.innerHTML = '';
       var selectedTools = defaultDeveloperTools.slice();
 
       var state = document.createElement('div');
-      state.className = 'session-state';
+      state.className = 'session-state default-installs-state';
 
+      var hero = document.createElement('section');
+      hero.className = 'install-hero';
+      var kicker = document.createElement('p');
+      kicker.className = 'install-kicker';
+      kicker.textContent = 'Default installs';
+      hero.appendChild(kicker);
       var heading = document.createElement('h2');
-      heading.textContent = 'Default installs';
-      state.appendChild(heading);
+      heading.className = 'install-title';
+      heading.textContent = 'Choose what Matrix installs first';
+      hero.appendChild(heading);
 
       var detailText = document.createElement('p');
+      detailText.className = 'install-detail';
       detailText.textContent = 'Choose command-line agents to preinstall on this VPS.';
-      state.appendChild(detailText);
+      hero.appendChild(detailText);
+      state.appendChild(hero);
+
+      var toolsPanel = document.createElement('section');
+      toolsPanel.className = 'developer-tools-panel';
+      var toolsHeader = document.createElement('div');
+      toolsHeader.className = 'developer-tools-header';
+      var toolsHeading = document.createElement('h3');
+      toolsHeading.textContent = 'Developer tools';
+      toolsHeader.appendChild(toolsHeading);
+      var toolsDetail = document.createElement('p');
+      toolsDetail.textContent = 'Choose command-line agents to preinstall on this VPS.';
+      toolsHeader.appendChild(toolsDetail);
+      toolsPanel.appendChild(toolsHeader);
 
       var toolList = document.createElement('div');
-      toolList.className = 'session-actions';
+      toolList.className = 'developer-tool-grid';
       defaultDeveloperTools.forEach(function(tool) {
         var label = document.createElement('label');
-        label.style.display = 'flex';
-        label.style.alignItems = 'center';
-        label.style.justifyContent = 'space-between';
-        label.style.gap = '0.75rem';
-        label.style.width = '100%';
-        label.style.border = '1px solid rgba(92, 90, 79, 0.22)';
-        label.style.borderRadius = '0.875rem';
-        label.style.padding = '0.75rem';
-        label.style.cursor = 'pointer';
+        label.className = 'developer-tool-option selected';
+        var copy = document.createElement('span');
+        copy.className = 'developer-tool-copy';
+        var logo = document.createElement('span');
+        logo.className = 'developer-tool-logo';
+        logo.setAttribute('aria-hidden', 'true');
+        logo.textContent = tool === 'claude-code' ? 'AI' : tool === 'opencode' ? 'O' : tool === 'codex' ? 'C' : 'Pi';
         var text = document.createElement('span');
+        text.className = 'developer-tool-name';
         text.textContent = tool === 'claude-code' ? 'Claude Code' : tool === 'opencode' ? 'OpenCode' : tool === 'codex' ? 'Codex' : 'Pi';
+        copy.appendChild(logo);
+        copy.appendChild(text);
         var input = document.createElement('input');
         input.type = 'checkbox';
         input.checked = true;
@@ -451,18 +650,26 @@ export function getAuthPage(
         input.addEventListener('change', function() {
           if (input.checked) {
             if (selectedTools.indexOf(tool) === -1) selectedTools.push(tool);
+            label.classList.add('selected');
           } else {
             selectedTools = selectedTools.filter(function(selected) { return selected !== tool; });
+            label.classList.remove('selected');
           }
         });
-        label.appendChild(text);
+        label.appendChild(copy);
         label.appendChild(input);
         toolList.appendChild(label);
       });
-      state.appendChild(toolList);
+      toolsPanel.appendChild(toolList);
+      state.appendChild(toolsPanel);
 
+      var footer = document.createElement('div');
+      footer.className = 'default-installs-footer';
+      var footerText = document.createElement('p');
+      footerText.textContent = 'CLI login happens after the VPS is ready. Tool authentication is completed inside each CLI.';
+      footer.appendChild(footerText);
       var actions = document.createElement('div');
-      actions.className = 'session-actions';
+      actions.className = 'default-installs-actions';
       var buildButton = document.createElement('button');
       buildButton.type = 'button';
       buildButton.className = 'primary';
@@ -494,8 +701,19 @@ export function getAuthPage(
           .catch(redirectAfterSignOutIssue);
       });
       actions.appendChild(signOutButton);
-      state.appendChild(actions);
+      footer.appendChild(actions);
+      state.appendChild(footer);
       el.appendChild(state);
+    }
+    function setDefaultInstallsCard(active) {
+      var el = document.getElementById('auth');
+      var card = el ? el.closest('.auth-card') : null;
+      if (!card) return;
+      if (active) {
+        card.classList.add('default-installs-card');
+      } else {
+        card.classList.remove('default-installs-card');
+      }
     }
     function showBillingRequiredState() {
       showLoadingState('Opening Billing settings...');

--- a/tests/platform/proxy-routing.test.ts
+++ b/tests/platform/proxy-routing.test.ts
@@ -2855,6 +2855,15 @@ describe("platform proxy routing", () => {
     expect(html).toContain("fetch('/api/auth/provision-runtime'");
     expect(html).toContain("signal: controller.signal");
     expect(html).toContain("window.clearTimeout(timeoutId);");
+    expect(html).toContain(".auth-card.default-installs-card");
+    expect(html).toContain("setDefaultInstallsCard(true);");
+    expect(html).toContain("state.className = 'session-state default-installs-state';");
+    expect(html).toContain("kicker.textContent = 'Default installs';");
+    expect(html).toContain("heading.textContent = 'Choose what Matrix installs first';");
+    expect(html).toContain("toolsHeading.textContent = 'Developer tools';");
+    expect(html).toContain("label.className = 'developer-tool-option selected';");
+    expect(html).toContain("logo.textContent = tool === 'claude-code' ? 'AI'");
+    expect(html).toContain("footerText.textContent = 'CLI login happens after the VPS is ready. Tool authentication is completed inside each CLI.';");
     expect(html).toContain("matrix.billing.checkoutAttemptAt");
     expect(html).toContain("hasTrustedCheckoutReturn()");
     expect(html).toContain("stripCheckoutReturnParams()");

--- a/tests/platform/proxy-routing.test.ts
+++ b/tests/platform/proxy-routing.test.ts
@@ -2862,7 +2862,12 @@ describe("platform proxy routing", () => {
     expect(html).toContain("heading.textContent = 'Choose what Matrix installs first';");
     expect(html).toContain("toolsHeading.textContent = 'Developer tools';");
     expect(html).toContain("label.className = 'developer-tool-option selected';");
-    expect(html).toContain("logo.textContent = tool === 'claude-code' ? 'AI'");
+    expect(html).toContain("var developerToolLogos = {");
+    expect(html).toContain("<title>OpenAI</title>");
+    expect(html).toContain("<title>Anthropic</title>");
+    expect(html).toContain("<title id=\"opencode-title\">OpenCode</title>");
+    expect(html).toContain("<title>Pi</title>");
+    expect(html).toContain("logo.innerHTML = developerToolLogos[tool] || '';");
     expect(html).toContain("footerText.textContent = 'CLI login happens after the VPS is ready. Tool authentication is completed inside each CLI.';");
     expect(html).toContain("matrix.billing.checkoutAttemptAt");
     expect(html).toContain("hasTrustedCheckoutReturn()");


### PR DESCRIPTION
## Summary

- Restyles the platform inline auth fallback default-installs state so the no-VPS flow matches the polished onboarding selector while keeping it inside the existing "Welcome back to Matrix" split screen.
- Adds a wide-card default-installs mode with responsive developer tool cards, selected states, Build VPS, and Sign out controls.
- Embeds the Codex, Claude Code, OpenCode, and Pi SVG marks directly in the fallback so the logos render before any customer VPS or shell asset route exists.
- Keeps the pre-VPS behavior unchanged: the VPS is still created only when the existing Build VPS handler calls `/api/auth/provision-runtime`.
- Adds regression coverage to the platform proxy routing auth-page test so the fallback cannot silently drift back to the old checkbox stack or initials-only logos.

## Screenshot Evidence

Captured locally with Playwright:

`/tmp/pr-platform-default-installs-auth-page-logos.png`

## Tests

- `bun run typecheck` passed before the logo follow-up; the follow-up only changes inline HTML/CSS/script strings
- `bun run check:patterns` passed with 0 violations before the logo follow-up
- `git diff --check` passed after the logo follow-up
- `bun run test tests/platform/proxy-routing.test.ts` passed after the logo follow-up, 119 tests
- Playwright render check passed after the logo follow-up and wrote `/tmp/pr-platform-default-installs-auth-page-logos.png`
- `bun run test` was attempted earlier, but the full repo suite fails in this fresh worktree for unrelated environment/test-harness issues: `better-sqlite3` ABI mismatch, missing browser globals/localStorage in Node 26 test runs, CLI stderr deprecation-warning pollution, and fixture git-add/commit failures. The targeted platform suite above is green.

## Invariants

- **Source of truth**: Platform journey/provisioning state remains canonical. The inline auth page only collects the selected `developerTools` before provisioning.
- **Lock/transaction scope**: Unchanged. This PR does not add database writes, transactions, or network calls beyond the existing provisioning button path.
- **Acceptable orphan states**: Unchanged. Rendering the selector before the user clicks Build VPS creates no VPS row or server. Existing provisioning error handling still owns failed create attempts.
- **Auth source of truth**: Unchanged Clerk token exchange and app-session flow. This PR does not add a new auth path.
- **Deferred scope**: This does not remove the duplicate shell/auth-shell render path or add platform asset routing for shell agent SVGs; it makes the current platform fallback visually consistent when that fallback is used.
