### PR TITLE
ci(shell): require production shell build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,9 +116,50 @@ jobs:
         if: needs.changes.outputs.should_run == 'true'
         run: bun run typecheck
 
+  shell-production-build:
+    name: Shell Production Build
+    needs: [changes, typecheck]
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Skip expensive CI for docs-only changes
+        if: needs.changes.outputs.should_run != 'true'
+        run: echo "No CI-relevant source changes detected; skipping shell production build."
+
+      - uses: actions/checkout@v6
+        if: needs.changes.outputs.should_run == 'true'
+
+      - uses: oven-sh/setup-bun@v2
+        if: needs.changes.outputs.should_run == 'true'
+
+      - uses: pnpm/action-setup@v6
+        if: needs.changes.outputs.should_run == 'true'
+
+      - uses: actions/setup-node@v6
+        if: needs.changes.outputs.should_run == 'true'
+        with:
+          node-version: 24
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+        if: needs.changes.outputs.should_run == 'true'
+
+      - name: Build shell production bundle
+        if: needs.changes.outputs.should_run == 'true'
+        env:
+          NEXT_TELEMETRY_DISABLED: 1
+          NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: pk_test_Y2ktc2FmZS5leGFtcGxlLmNvbSQ=
+          NEXT_PUBLIC_CLERK_SIGN_IN_URL: /sign-in
+          NEXT_PUBLIC_CLERK_SIGN_UP_URL: /sign-up
+          NEXT_PUBLIC_POSTHOG_KEY: phc_ci_shell_build
+          NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN: phc_ci_shell_build
+          NEXT_PUBLIC_POSTHOG_HOST: https://eu.i.posthog.com
+          NEXT_PUBLIC_POSTHOG_API_HOST: /relay
+        run: bun run build:shell:production
+
   patterns:
     name: Pattern Scan
-    needs: changes
+    needs: [changes, shell-production-build]
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -345,7 +386,7 @@ jobs:
 
   ci-results:
     name: CI Results
-    needs: [changes, typecheck, patterns, react-doctor, sync-client, unit, e2e]
+    needs: [changes, typecheck, shell-production-build, patterns, react-doctor, sync-client, unit, e2e]
     if: always()
     runs-on: ubuntu-latest
     timeout-minutes: 2
@@ -355,6 +396,7 @@ jobs:
           SHOULD_RUN: ${{ needs.changes.outputs.should_run }}
           CHANGES_RESULT: ${{ needs.changes.result }}
           TYPECHECK_RESULT: ${{ needs.typecheck.result }}
+          SHELL_PRODUCTION_BUILD_RESULT: ${{ needs.shell-production-build.result }}
           PATTERNS_RESULT: ${{ needs.patterns.result }}
           REACT_DOCTOR_RESULT: ${{ needs.react-doctor.result }}
           SYNC_CLIENT_RESULT: ${{ needs.sync-client.result }}
@@ -374,6 +416,7 @@ jobs:
             echo "| --- | --- |"
             echo "| Detect CI-relevant changes | $CHANGES_RESULT |"
             echo "| Type Check | $TYPECHECK_RESULT |"
+            echo "| Shell Production Build | $SHELL_PRODUCTION_BUILD_RESULT |"
             echo "| Pattern Scan | $PATTERNS_RESULT |"
             echo "| React Doctor | $REACT_DOCTOR_RESULT |"
             echo "| Sync Client Package (Node 20) | $SYNC_CLIENT_RESULT |"
@@ -382,7 +425,7 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
           failed=false
-          for result in "$CHANGES_RESULT" "$TYPECHECK_RESULT" "$PATTERNS_RESULT" "$SYNC_CLIENT_RESULT" "$UNIT_RESULT" "$E2E_RESULT"; do
+          for result in "$CHANGES_RESULT" "$TYPECHECK_RESULT" "$SHELL_PRODUCTION_BUILD_RESULT" "$PATTERNS_RESULT" "$SYNC_CLIENT_RESULT" "$UNIT_RESULT" "$E2E_RESULT"; do
             case "$result" in
               success|skipped)
                 ;;

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "dev:www": "pnpm --filter '@matrix-os/observability' build && bun run --filter www dev",
     "dev:desktop": "pnpm --filter desktop dev",
     "build:desktop": "pnpm --filter desktop build",
+    "build:shell:production": "pnpm --filter './shell' build",
     "dev:proxy": "pnpm --filter '@matrix-os/observability' build && bun run --filter '@matrix-os/proxy' dev",
     "dev:platform": "pnpm --filter '@matrix-os/observability' build && bun run --filter '@matrix-os/platform' dev",
     "docker": "docker compose -f docker-compose.dev.yml up",

--- a/shell/package.json
+++ b/shell/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "build": "pnpm --dir .. --filter '@matrix-os/observability' build && next build",
+    "build": "pnpm --dir .. --filter '@matrix-os/observability' build && next build --webpack",
     "start": "next start",
     "lint": "eslint",
     "test:screenshots": "playwright test"


### PR DESCRIPTION
## Summary

- Adds a canonical root `build:shell:production` script for the shell production build.
- Changes `shell/package.json` to run `next build --webpack`, matching `Dockerfile.platform` and `scripts/build-host-bundle.sh`.
- Adds a blocking `Shell Production Build` CI job after Type Check and before Pattern Scan, and wires it into `CI Results`.
- Uses only CI-safe public env vars for the shell build and does not set `POSTHOG_API_KEY` or `POSTHOG_PROJECT_ID`, so CI does not upload sourcemaps.

## Tests

- `pnpm install --frozen-lockfile`
- `CI=1 NEXT_TELEMETRY_DISABLED=1 NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=pk_test_Y2ktc2FmZS5leGFtcGxlLmNvbSQ= NEXT_PUBLIC_CLERK_SIGN_IN_URL=/sign-in NEXT_PUBLIC_CLERK_SIGN_UP_URL=/sign-up NEXT_PUBLIC_POSTHOG_KEY=phc_ci_shell_build NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN=phc_ci_shell_build NEXT_PUBLIC_POSTHOG_HOST=https://eu.i.posthog.com NEXT_PUBLIC_POSTHOG_API_HOST=/relay bun run build:shell:production`
  - Expected guard behavior observed: fails on current `origin/main` shell production typecheck at `shell/src/hooks/useMatrixBillingAccess.ts:223`.
- `bun run check:patterns`
- `node -e 'const fs = require("node:fs"); const { parseDocument } = require("yaml"); const doc = parseDocument(fs.readFileSync(".github/workflows/ci.yml", "utf8")); if (doc.errors.length) { for (const err of doc.errors) console.error(err.message); process.exit(1); } console.log("workflow yaml ok");'`
- `git diff --check`
- `bun run typecheck`

## Review/Monitoring

- This PR intentionally makes shell production build failures blocking through `CI Results`.
- Current local production shell build fails on a pre-existing shell type error, which is the class of failure this guard is meant to catch before merge.
- Greptile and CI should be checked on the current PR head before merge; do not merge until the shell production build is green.

## Invariants

- Source of truth: CI configuration and package scripts only; no backend or data source-of-truth changes.
- Lock/transaction scope: not applicable; no runtime writes, database transactions, or locks are introduced.
- Acceptable orphan states: not applicable; the CI job either passes or blocks merge, and no persistent runtime state is created.
- Auth source of truth: unchanged; the build uses public compile-time env placeholders only and no private provider credentials.
- Deferred scope: fixing the currently surfaced shell type error is intentionally outside this PR's scoped files.
