### PR TITLE
fix(billing): type billing access parser state

### DIFF
--- a/shell/src/hooks/useMatrixBillingAccess.ts
+++ b/shell/src/hooks/useMatrixBillingAccess.ts
@@ -180,7 +180,7 @@ function readRemoteBillingStatus(
     cache: "no-store",
     signal: controller.signal,
   })
-    .then(async (response) => {
+    .then(async (response): Promise<BillingAccessRemoteState> => {
       if (response.status >= 500 || response.status === 429) {
         throw new Error("billing_status_retryable");
       }


### PR DESCRIPTION
## Summary

- Annotates the remote billing status response parser callback as `Promise<BillingAccessRemoteState>`.
- Preserves the existing stale app-session retry and billing cache behavior; this is a type-only fix for the production Next build.

## Tests

- `pnpm --filter '@matrix-os/observability' build`
- Pre-fix reproduction: `NEXT_PUBLIC_* placeholders pnpm --filter './shell' exec next build --webpack` failed at `shell/src/hooks/useMatrixBillingAccess.ts:223` with `accessIssue: string` not assignable to `BillingAccessIssue`.
- Post-fix: `NEXT_PUBLIC_* placeholders pnpm --filter './shell' exec next build --webpack`
- `bun run test tests/shell/billing-gate.test.tsx tests/shell/billing-section.test.tsx`
- `bun run check:patterns` (0 violations; existing warnings only outside this hook)
- `bun run typecheck`

## Review/Monitoring

- This should unblock the Platform Cloud Run / Host Bundle Release shell production build failure observed on `origin/main` `e55cfe902684d4a61be815d9acf603f5fd27fca5`.
- Greptile should verify the one-line type-only diff; no runtime billing behavior intentionally changed.
- React Doctor was not required because this PR changes a `.ts` hook only, not `.tsx` or `.jsx`.

## Invariants

- Source of truth: unchanged. Backend billing and entitlement state remain canonical; this PR only types the frontend parser branch.
- Lock/transaction scope: unchanged. No backend writes, database transactions, or critical sections are added or modified.
- Acceptable orphan states: unchanged. Existing stale app-session retry and cache behavior remains as-is.
- Auth source of truth: unchanged. Clerk/app-session auth handling and the `x-auth-failure` stale-session signal are interpreted exactly as before.
- Deferred scope: no billing UX, checkout flow, cache policy, backend route, or entitlement behavior changes are included.