### PR TITLE
fix(billing): type billing access parser state

### DIFF
--- a/shell/src/hooks/useMatrixBillingAccess.ts
+++ b/shell/src/hooks/useMatrixBillingAccess.ts
@@ -180,7 +180,7 @@ function readRemoteBillingStatus(
     cache: "no-store",
     signal: controller.signal,
   })
-    .then(async (response) => {
+    .then(async (response): Promise<BillingAccessRemoteState> => {
       if (response.status >= 500 || response.status === 429) {
         throw new Error("billing_status_retryable");
       }


### PR DESCRIPTION
## Summary
- Annotates the billing status fetch parser callback as `Promise<BillingAccessRemoteState>`.
- Keeps `accessIssue: "auth"` contextually typed as `BillingAccessIssue` during the shell production Next build.
- Preserves existing stale app-session retry/cache behavior with no runtime logic changes.

## Tests
- `pnpm --filter @matrix-os/observability build`
- `NEXT_PUBLIC_* placeholders pnpm --filter ./shell exec next build --webpack`
- `bun run test tests/shell/billing-gate.test.tsx tests/shell/billing-section.test.tsx`
- `bun run check:patterns`
- `bun run typecheck`

## Review/Monitoring
- Replacement for PR #648, reopened under `Nima-Naderi`.
- Greptile and CI should be rechecked on this PR head before merge.

## Invariants
- Source of truth: no backend source-of-truth changes; frontend billing status parser typing only.
- Lock/transaction scope: no database or filesystem writes changed.
- Acceptable orphan states: unchanged; stale app-session retry behavior remains as before.
- Auth source of truth: unchanged; `/billing/status` response status and `x-auth-failure` header handling stay intact.
- Deferred scope: no CI workflow changes in this PR.