### PR TITLE
ci(shell): require production shell build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,9 +116,50 @@ jobs:
         if: needs.changes.outputs.should_run == 'true'
         run: bun run typecheck
 
+  shell-production-build:
+    name: Shell Production Build
+    needs: [changes, typecheck]
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Skip expensive CI for docs-only changes
+        if: needs.changes.outputs.should_run != 'true'
+        run: echo "No CI-relevant source changes detected; skipping shell production build."
+
+      - uses: actions/checkout@v6
+        if: needs.changes.outputs.should_run == 'true'
+
+      - uses: oven-sh/setup-bun@v2
+        if: needs.changes.outputs.should_run == 'true'
+
+      - uses: pnpm/action-setup@v6
+        if: needs.changes.outputs.should_run == 'true'
+
+      - uses: actions/setup-node@v6
+        if: needs.changes.outputs.should_run == 'true'
+        with:
+          node-version: 24
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+        if: needs.changes.outputs.should_run == 'true'
+
+      - name: Build shell production bundle
+        if: needs.changes.outputs.should_run == 'true'
+        env:
+          NEXT_TELEMETRY_DISABLED: 1
+          NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: pk_test_Y2ktc2FmZS5leGFtcGxlLmNvbSQ=
+          NEXT_PUBLIC_CLERK_SIGN_IN_URL: /sign-in
+          NEXT_PUBLIC_CLERK_SIGN_UP_URL: /sign-up
+          NEXT_PUBLIC_POSTHOG_KEY: phc_ci_shell_build
+          NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN: phc_ci_shell_build
+          NEXT_PUBLIC_POSTHOG_HOST: https://eu.i.posthog.com
+          NEXT_PUBLIC_POSTHOG_API_HOST: /relay
+        run: bun run build:shell:production
+
   patterns:
     name: Pattern Scan
-    needs: changes
+    needs: [changes, shell-production-build]
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -345,7 +386,7 @@ jobs:
 
   ci-results:
     name: CI Results
-    needs: [changes, typecheck, patterns, react-doctor, sync-client, unit, e2e]
+    needs: [changes, typecheck, shell-production-build, patterns, react-doctor, sync-client, unit, e2e]
     if: always()
     runs-on: ubuntu-latest
     timeout-minutes: 2
@@ -355,6 +396,7 @@ jobs:
           SHOULD_RUN: ${{ needs.changes.outputs.should_run }}
           CHANGES_RESULT: ${{ needs.changes.result }}
           TYPECHECK_RESULT: ${{ needs.typecheck.result }}
+          SHELL_PRODUCTION_BUILD_RESULT: ${{ needs.shell-production-build.result }}
           PATTERNS_RESULT: ${{ needs.patterns.result }}
           REACT_DOCTOR_RESULT: ${{ needs.react-doctor.result }}
           SYNC_CLIENT_RESULT: ${{ needs.sync-client.result }}
@@ -374,6 +416,7 @@ jobs:
             echo "| --- | --- |"
             echo "| Detect CI-relevant changes | $CHANGES_RESULT |"
             echo "| Type Check | $TYPECHECK_RESULT |"
+            echo "| Shell Production Build | $SHELL_PRODUCTION_BUILD_RESULT |"
             echo "| Pattern Scan | $PATTERNS_RESULT |"
             echo "| React Doctor | $REACT_DOCTOR_RESULT |"
             echo "| Sync Client Package (Node 20) | $SYNC_CLIENT_RESULT |"
@@ -382,7 +425,7 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
           failed=false
-          for result in "$CHANGES_RESULT" "$TYPECHECK_RESULT" "$PATTERNS_RESULT" "$SYNC_CLIENT_RESULT" "$UNIT_RESULT" "$E2E_RESULT"; do
+          for result in "$CHANGES_RESULT" "$TYPECHECK_RESULT" "$SHELL_PRODUCTION_BUILD_RESULT" "$PATTERNS_RESULT" "$SYNC_CLIENT_RESULT" "$UNIT_RESULT" "$E2E_RESULT"; do
             case "$result" in
               success|skipped)
                 ;;

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,7 +159,7 @@ jobs:
 
   patterns:
     name: Pattern Scan
-    needs: [changes, shell-production-build]
+    needs: changes
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "dev:www": "pnpm --filter '@matrix-os/observability' build && bun run --filter www dev",
     "dev:desktop": "pnpm --filter desktop dev",
     "build:desktop": "pnpm --filter desktop build",
+    "build:shell:production": "pnpm --filter './shell' build",
     "dev:proxy": "pnpm --filter '@matrix-os/observability' build && bun run --filter '@matrix-os/proxy' dev",
     "dev:platform": "pnpm --filter '@matrix-os/observability' build && bun run --filter '@matrix-os/platform' dev",
     "docker": "docker compose -f docker-compose.dev.yml up",

--- a/shell/package.json
+++ b/shell/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "build": "pnpm --dir .. --filter '@matrix-os/observability' build && next build",
+    "build": "pnpm --dir .. --filter '@matrix-os/observability' build && next build --webpack",
     "start": "next start",
     "lint": "eslint",
     "test:screenshots": "playwright test"

--- a/tests/platform/ci-workflows.test.ts
+++ b/tests/platform/ci-workflows.test.ts
@@ -21,9 +21,10 @@ describe('CI workflows', () => {
     expect(workflow).toContain('ci-results:');
     expect(workflow).toContain('name: CI Results');
     expect(workflow).toContain('if: always()');
-    expect(workflow).toContain('needs: [changes, typecheck, patterns, react-doctor, sync-client, unit, e2e]');
+    expect(workflow).toContain('needs: [changes, typecheck, shell-production-build, patterns, react-doctor, sync-client, unit, e2e]');
     expect(workflow).toContain('### CI Results');
     expect(workflow).toContain('needs.typecheck.result');
+    expect(workflow).toContain('needs.shell-production-build.result');
     expect(workflow).toContain('needs.patterns.result');
     expect(workflow).toContain('needs.react-doctor.result');
     expect(workflow).toContain('needs.sync-client.result');


### PR DESCRIPTION
## Summary
- Adds a canonical `build:shell:production` root script.
- Aligns `shell/package.json` build with release by using `next build --webpack`.
- Adds a blocking `Shell Production Build` job to CI and wires it into `CI Results` without serializing the lighter pattern/unit jobs behind the shell build.

## Tests
- `pnpm install --frozen-lockfile`
- `bun run build:shell:production` with CI-safe public env
- `bun run check:patterns`
- workflow YAML parse via installed `yaml`
- `git diff --check`
- `bun run typecheck`
- `bun run test tests/platform/ci-workflows.test.ts`
- GitHub CI on head `8813b974bfeddcda6f095d32f224bddea20e4cfe`, including `Shell Production Build` and `CI Results`

## Review/Monitoring
- Replacement for PR #647, reopened under `Nima-Naderi`.
- Paired billing parser hotfix PR #649 has landed; this branch is rebased onto that fix.
- Greptile reviewed head `8813b974bfeddcda6f095d32f224bddea20e4cfe` at 5/5.

## Invariants
- Source of truth: no product source-of-truth changes; CI/build configuration only.
- Lock/transaction scope: no database or runtime mutation paths changed.
- Acceptable orphan states: a shell production build failure now blocks `CI Results` and prevents merging before deploy-time breakage reaches Platform Cloud Run.
- Auth source of truth: no auth behavior changed; CI uses public build-time placeholders only.
- Deferred scope: does not add a platform Docker image build job; this guards the auth-shell production build command that caused the deploy failure.