### PR TITLE
fix(platform): prevent auth shell cache poisoning

### DIFF
--- a/packages/edge-router/src/index.ts
+++ b/packages/edge-router/src/index.ts
@@ -122,6 +122,7 @@ function withEdgeHeaders(response: Response): Response {
   const headers = new Headers(response.headers);
   headers.set("cache-control", "no-store");
   headers.set("cdn-cache-control", "no-store");
+  headers.set("cloudflare-cdn-cache-control", "no-store");
   const isWebSocketUpgrade = response.status === 101;
 
   return new Response(isWebSocketUpgrade ? null : response.body, buildEdgeResponseInit(response, headers));
@@ -185,6 +186,7 @@ function noStoreTextHeaders(): Headers {
     "content-type": "text/plain; charset=utf-8",
     "cache-control": "no-store",
     "cdn-cache-control": "no-store",
+    "cloudflare-cdn-cache-control": "no-store",
   });
 }
 

--- a/packages/platform/src/main.ts
+++ b/packages/platform/src/main.ts
@@ -684,6 +684,14 @@ function applyNoStoreHeaders(c: import('hono').Context): void {
   c.header('Expires', '0');
 }
 
+function applyNoStoreResponseHeaders(headers: Headers): void {
+  headers.set('cache-control', 'no-store, private');
+  headers.set('cdn-cache-control', 'no-store');
+  headers.set('cloudflare-cdn-cache-control', 'no-store');
+  headers.set('pragma', 'no-cache');
+  headers.set('expires', '0');
+}
+
 const APP_DOMAIN_UNREGISTER_SERVICE_WORKER = `
 self.addEventListener("install", () => {
   self.skipWaiting();
@@ -2057,9 +2065,11 @@ export function createApp(deps: {
         redirect: 'manual',
         signal: AbortSignal.timeout(AUTH_SHELL_PROXY_TIMEOUT_MS),
       });
+      const responseHeaders = sanitizeProxyResponseHeaders(response.headers);
+      applyNoStoreResponseHeaders(responseHeaders);
       return new Response(response.body, {
         status: response.status,
-        headers: sanitizeProxyResponseHeaders(response.headers),
+        headers: responseHeaders,
       });
     } catch (err: unknown) {
       logPlatformRouteError('app-domain auth-shell proxy', err);

--- a/packages/platform/src/session-cookies.ts
+++ b/packages/platform/src/session-cookies.ts
@@ -104,6 +104,17 @@ export function buildClearNativeAppSessionCookie(): string {
   ].join('; ');
 }
 
+export function buildClearShellRouteCookie(): string {
+  return [
+    `${SHELL_ROUTE_COOKIE}=`,
+    'Path=/',
+    'HttpOnly',
+    'Secure',
+    'SameSite=Lax',
+    'Max-Age=0',
+  ].join('; ');
+}
+
 export function buildClearBrowserCookie(name: string, domain?: string): string {
   return [
     `${name}=`,
@@ -142,6 +153,7 @@ export function appendSignOutClearCookies(c: Context): void {
   const domain = matrixCookieDomainForHost(c.req.header('host'));
   c.header('Set-Cookie', buildClearAppSessionCookie(), { append: true });
   c.header('Set-Cookie', buildClearNativeAppSessionCookie(), { append: true });
+  c.header('Set-Cookie', buildClearShellRouteCookie(), { append: true });
   for (const name of clerkCookieClearNames(cookieHeader)) {
     c.header('Set-Cookie', buildClearBrowserCookie(name), { append: true });
     if (domain) {

--- a/tests/edge-router/edge-router.test.ts
+++ b/tests/edge-router/edge-router.test.ts
@@ -59,6 +59,7 @@ describe("edge router worker", () => {
     expect(response.status).toBe(200);
     expect(response.headers.get("cache-control")).toBe("no-store");
     expect(response.headers.get("cdn-cache-control")).toBe("no-store");
+    expect(response.headers.get("cloudflare-cdn-cache-control")).toBe("no-store");
     const [request] = fetchMock.mock.calls[0]!;
     expect(request).toBeInstanceOf(Request);
     const upstream = request as Request;
@@ -100,6 +101,7 @@ describe("edge router worker", () => {
     expect(response.status).toBe(200);
     expect(response.headers.get("cache-control")).toBe("no-store");
     expect(response.headers.get("cdn-cache-control")).toBe("no-store");
+    expect(response.headers.get("cloudflare-cdn-cache-control")).toBe("no-store");
   });
 
   it("rejects oversized bodies before forwarding", async () => {

--- a/tests/platform/proxy-routing.test.ts
+++ b/tests/platform/proxy-routing.test.ts
@@ -2033,6 +2033,7 @@ describe("platform proxy routing", () => {
           "matrix_app_session=matrix-token",
           "__session=clerk-token",
           "__client_uat=123",
+          "matrix_shell_route=alice",
           "__session_safeSuffix-123=clerk-token",
           "__client_uat_safeSuffix_456=456",
           "__session_unsafe.suffix=ignored",
@@ -2050,6 +2051,7 @@ describe("platform proxy routing", () => {
     const setCookie = combinedSetCookie(res.headers);
     expect(setCookie).toContain("matrix_app_session=;");
     expect(setCookie).toContain("matrix_native_app_session=;");
+    expect(setCookie).toContain("matrix_shell_route=;");
     expect(setCookie).toContain("__session=;");
     expect(setCookie).toContain("__client_uat=;");
     expect(setCookie).toContain("__session_safeSuffix-123=;");
@@ -3025,6 +3027,9 @@ describe("platform proxy routing", () => {
 
     expect(res.status).toBe(200);
     expect(await res.text()).toBe("auth shell");
+    expect(res.headers.get("cache-control")).toBe("no-store, private");
+    expect(res.headers.get("cdn-cache-control")).toBe("no-store");
+    expect(res.headers.get("cloudflare-cdn-cache-control")).toBe("no-store");
     expect(fetchMock.mock.calls[0]?.[0]).toBe(
       "http://auth-shell.test:3200/?device_return=%2Fauth%2Fdevice%3Fuser_code%3DBCDF-GHJK",
     );


### PR DESCRIPTION
## Summary
- clear the short-lived `matrix_shell_route` cookie during sign-out so signed-out auth-shell asset requests cannot keep stale runtime routing context
- force no-store, CDN no-store, and Cloudflare no-store headers on proxied auth-shell responses
- stamp the edge router's managed responses with `Cloudflare-CDN-Cache-Control: no-store` as well as the existing cache headers

## Tests
- `bun run test -- tests/platform/proxy-routing.test.ts`
- `bun run test -- tests/edge-router/edge-router.test.ts`
- `pnpm --filter '@matrix-os/platform' exec tsc --noEmit -p tsconfig.typecheck.json && pnpm --filter '@matrix-os/edge-router' exec tsc --noEmit`
- `git diff --check`

## Review/Monitoring
- Ready for CI and Greptile review.
- Root checkout remains on `main`; implementation lives in `/home/deploy/matrix-os.worktrees/fix-auth-shell-cache`.

## Invariants
- Source of truth: platform auth/session cookies remain the canonical browser routing state; customer VPS state is not changed by sign-out.
- Lock/transaction scope: no database writes or multi-step persistence are added; this change only adjusts response headers and cookie clearing.
- Acceptable orphan states: already-issued `matrix_shell_route` cookies expire naturally within 10 minutes, and new sign-outs actively clear them.
- Auth source of truth: Clerk/app-session verification remains unchanged; stale shell-route cookies do not grant auth and are removed on sign-out.
- Deferred scope: this PR does not purge existing Cloudflare cache entries or redeploy production; that remains an operator action after merge/deploy.
