### PR TITLE
feat(shell): add terminal mode switcher polish

### DIFF
--- a/shell/src/components/Desktop.tsx
+++ b/shell/src/components/Desktop.tsx
@@ -65,6 +65,7 @@ import { DeveloperModeDashboard } from "./developer/DeveloperModeDashboard";
 import { versionedIconUrl } from "@/lib/icon-url";
 import { cn, nameToSlug } from "@/lib/utils";
 import { iconUrlForSlug } from "@/lib/app-launch";
+import { HERMES_CHAT_HIDDEN } from "@/lib/feature-flags";
 import { isSystemApp, applyOrder } from "@/lib/dock-sections";
 import { MATRIX_ONBOARDING_BRAND_VERSION } from "@/lib/onboarding-brand";
 import { SHELL_Z_INDEX } from "@/lib/shell-layering";
@@ -954,7 +955,9 @@ export function Desktop({ launchAppPath, onOpenCommandPalette, chat }: DesktopPr
       addApp("Terminal", "__terminal__", "terminal", iconForSlug("terminal"));
       addApp("Workspace", "__workspace__", "workspace", iconForSlug("workspace"));
       addApp("Files", "__file-browser__", "files", iconForSlug("files"));
-      addApp("Hermes", "__chat__", "chat", iconForSlug("chat"));
+      if (!HERMES_CHAT_HIDDEN) {
+        addApp("Hermes", "__chat__", "chat", iconForSlug("chat"));
+      }
       addApp("Activity Monitor", "__activity-monitor__", "chart", iconForSlug("chart"));
       const savedBuiltIns = savedWindows.filter((w) => isBuiltInAppPath(w.path));
       for (const saved of savedBuiltIns) {
@@ -1671,6 +1674,7 @@ export function Desktop({ launchAppPath, onOpenCommandPalette, chat }: DesktopPr
                     </TooltipContent>
                   </Tooltip>
                 )}
+                {!HERMES_CHAT_HIDDEN && (
                 <Tooltip>
                   <TooltipTrigger asChild>
                     <button
@@ -1696,6 +1700,7 @@ export function Desktop({ launchAppPath, onOpenCommandPalette, chat }: DesktopPr
                   </TooltipTrigger>
                   <TooltipContent side={tooltipSide} sideOffset={8}>Hermes</TooltipContent>
                 </Tooltip>
+                )}
                 <ModeSwitcher iconSize={dock.iconSize} tooltipSide={tooltipSide} onSelectMode={selectDesktopMode} />
                 <Tooltip>
                   <TooltipTrigger asChild>
@@ -1741,6 +1746,7 @@ export function Desktop({ launchAppPath, onOpenCommandPalette, chat }: DesktopPr
         {/* Mobile dock (bottom tab bar) */}
         {modeConfig.showDock && (
           <nav className="flex md:hidden items-center gap-1 px-2 py-1.5 border-t border-border/40 bg-card/80 backdrop-blur-sm order-last overflow-x-auto z-[55]">
+            {!HERMES_CHAT_HIDDEN && (
             <button
               type="button"
               data-testid="dock-chat-mobile"
@@ -1760,6 +1766,7 @@ export function Desktop({ launchAppPath, onOpenCommandPalette, chat }: DesktopPr
                 />
               )}
             </button>
+            )}
             {modeConfig.showLauncher && (
               <button
                 type="button"

--- a/shell/src/components/Desktop.tsx
+++ b/shell/src/components/Desktop.tsx
@@ -47,7 +47,7 @@ import {
   ContextMenuSeparator,
   ContextMenuTrigger,
 } from "@/components/ui/context-menu";
-import { KanbanSquareIcon, MonitorIcon, SettingsIcon, PinOffIcon, RefreshCwIcon, CheckIcon, PencilIcon, XCircleIcon, MessageSquareIcon, MicIcon } from "lucide-react";
+import { KanbanSquareIcon, SettingsIcon, PinOffIcon, RefreshCwIcon, PencilIcon, XCircleIcon, MessageSquareIcon, MicIcon } from "lucide-react";
 import { UserButton } from "./UserButton";
 import { ConnectionIndicator } from "./ConnectionIndicator";
 import { AmbientClock } from "./AmbientClock";

--- a/shell/src/components/Desktop.tsx
+++ b/shell/src/components/Desktop.tsx
@@ -417,100 +417,6 @@ function DockIcon({
   );
 }
 
-function ModeSwitcher({
-  iconSize,
-  tooltipSide,
-  onSelectMode,
-}: {
-  iconSize: number;
-  tooltipSide: "left" | "right" | "top";
-  onSelectMode: (mode: DesktopMode) => void;
-}) {
-  const [open, setOpen] = useState(false);
-  const mode = useDesktopMode((s) => s.mode);
-  const visibleModes = useDesktopMode((s) => s.visibleModes);
-  const getModeConfig = useDesktopMode((s) => s.getModeConfig);
-  const modeConfig = getModeConfig(mode);
-  const modes = visibleModes();
-  const ref = useRef<HTMLDivElement>(null);
-
-  // Close on click outside
-  useEffect(() => {
-    if (!open) return;
-    const onClickOutside = (e: MouseEvent) => {
-      if (ref.current && !ref.current.contains(e.target as Node)) {
-        setOpen(false);
-      }
-    };
-    document.addEventListener("pointerdown", onClickOutside);
-    return () => document.removeEventListener("pointerdown", onClickOutside);
-  }, [open]);
-
-  // Close on Escape
-  useEffect(() => {
-    if (!open) return;
-    const onKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") setOpen(false);
-    };
-    document.addEventListener("keydown", onKey);
-    return () => document.removeEventListener("keydown", onKey);
-  }, [open]);
-
-  return (
-    <div className="relative" ref={ref}>
-      {/* Suppress hover tooltip while the mode menu is open so it
-          doesn't overlap the dropdown panel. */}
-      <Tooltip open={open ? false : undefined}>
-        <TooltipTrigger asChild>
-          <button
-            type="button"
-            onClick={() => setOpen((prev) => !prev)}
-            className={`flex items-center justify-center rounded-xl border shadow-sm hover:shadow-md hover:scale-105 active:scale-95 transition-all ${
-              open ? "bg-primary text-primary-foreground border-primary" : "bg-card border-border/60"
-            }`}
-            style={{ width: iconSize, height: iconSize }}
-            aria-label={`${modeConfig.label} mode`}
-          >
-            <MonitorIcon className="size-4" />
-          </button>
-        </TooltipTrigger>
-        <TooltipContent side={tooltipSide} sideOffset={8}>{modeConfig.label}</TooltipContent>
-      </Tooltip>
-      {open && (
-        <div
-          className={[
-            "absolute flex flex-col min-w-[160px] py-1 rounded-lg bg-card border border-border shadow-xl z-[60]",
-            tooltipSide === "right" && "left-full top-0 ml-2",
-            tooltipSide === "left" && "right-full top-0 mr-2",
-            tooltipSide === "top" && "bottom-full left-1/2 -translate-x-1/2 mb-2",
-          ].filter(Boolean).join(" ")}
-        >
-          {modes.map((m) => (
-            <button
-              type="button"
-              key={m.id}
-              onClick={() => {
-                onSelectMode(m.id);
-                setOpen(false);
-              }}
-              className={`flex items-center gap-2 px-3 py-1.5 text-xs transition-colors hover:bg-muted ${
-                mode === m.id ? "text-foreground font-medium" : "text-muted-foreground"
-              }`}
-            >
-              {mode === m.id ? (
-                <CheckIcon className="size-3 shrink-0" />
-              ) : (
-                <span className="size-3 shrink-0" />
-              )}
-              <span>{m.label}</span>
-            </button>
-          ))}
-        </div>
-      )}
-    </div>
-  );
-}
-
 /**
  * Aoede's dock entrypoint. Uses the `.aoede-dock-button` class (defined
  * in globals.css) for the shimmer ring + fill sweep shared with the
@@ -1700,9 +1606,7 @@ export function Desktop({ launchAppPath, onOpenCommandPalette, chat }: DesktopPr
                   </TooltipTrigger>
                   <TooltipContent side={tooltipSide} sideOffset={8}>Hermes</TooltipContent>
                 </Tooltip>
-                )}
-                <ModeSwitcher iconSize={dock.iconSize} tooltipSide={tooltipSide} onSelectMode={selectDesktopMode} />
-                <Tooltip>
+                )}                <Tooltip>
                   <TooltipTrigger asChild>
                     <button
                       type="button"
@@ -1779,9 +1683,7 @@ export function Desktop({ launchAppPath, onOpenCommandPalette, chat }: DesktopPr
               >
                 <KanbanSquareIcon className="size-4" />
               </button>
-            )}
-            <ModeSwitcher iconSize={36} tooltipSide="top" onSelectMode={selectDesktopMode} />
-            <button
+            )}            <button
               type="button"
               onClick={() => { setSettingsOpen((prev) => !prev); setTaskBoardOpen(false); setChatOpen(false); }}
               className={`flex shrink-0 size-9 items-center justify-center rounded-lg border transition-all active:scale-95 ${

--- a/shell/src/components/Desktop.tsx
+++ b/shell/src/components/Desktop.tsx
@@ -58,7 +58,7 @@ import { getGatewayUrl } from "@/lib/gateway";
 import { isPreVpsBillingSetupRoute } from "@/lib/pre-vps-shell";
 import { ChatApp } from "./ChatApp";
 import { ChatPopover } from "./ChatPopover";
-import { ManualSetupStickers } from "./onboarding/ManualSetupStickers";
+import { SetupChecklist } from "./onboarding/SetupChecklist";
 import { RuntimeIdentityBanner } from "./RuntimeIdentityBanner";
 import { ShellNotificationStack } from "./ShellNotificationStack";
 import { DeveloperModeDashboard } from "./developer/DeveloperModeDashboard";
@@ -1881,15 +1881,7 @@ export function Desktop({ launchAppPath, onOpenCommandPalette, chat }: DesktopPr
           {modeConfig.showWindows && desktopMode === "canvas" && (
             <CanvasRenderer>
               {manualSetupVisible && (
-                <ManualSetupStickers
-                  onOpenTerminal={openSetupTerminal}
-                  onAskHermes={() => {
-                    focusOrOpen("Hermes", "__chat__");
-                    setTaskBoardOpen(false);
-                    setSettingsOpen(false);
-                  }}
-                  onClose={() => setManualSetupVisible(false)}
-                />
+                <SetupChecklist onOpenTerminal={openSetupTerminal} />
               )}
             </CanvasRenderer>
           )}

--- a/shell/src/components/MenuBar.tsx
+++ b/shell/src/components/MenuBar.tsx
@@ -8,6 +8,7 @@ import { SearchIcon, UserIcon } from "lucide-react";
 import { AppSettingsDialog } from "./AppSettingsDialog";
 import { useMatrixBillingAccess } from "@/hooks/useMatrixBillingAccess";
 import { UserButton } from "./UserButton";
+import { ModeSwitcherBar } from "./ModeSwitcherBar";
 
 const FALLBACK_APP_ICON = "/icon-192.png";
 
@@ -282,8 +283,9 @@ export function MenuBar({ onOpenCommandPalette, onNewWindow, onMinimizeWindow, o
           <MenuDropdown label="View" items={viewItems} open={openMenu === "view"} onToggle={() => toggleMenu("view")} onClose={closeMenu} />
         </div>
 
-        {/* Center: contextual toolbar controls — always centered via grid */}
+        {/* Center: mode switcher + contextual toolbar controls — always centered via grid */}
         <div className="flex items-center gap-0.5 text-foreground/70 [&_button]:text-foreground/60 [&_button:hover]:text-foreground/90 [&_button]:transition-colors [&_.w-px]:bg-foreground/10 [&_.w-px]:h-3">
+          <ModeSwitcherBar />
           {children}
         </div>
 

--- a/shell/src/components/ModeSwitcherBar.tsx
+++ b/shell/src/components/ModeSwitcherBar.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import { useDesktopMode } from "@/stores/desktop-mode";
+
+export function ModeSwitcherBar() {
+  const mode = useDesktopMode((s) => s.mode);
+  const setMode = useDesktopMode((s) => s.setMode);
+  const modes = useDesktopMode((s) => s.visibleModes)();
+
+  return (
+    <div className="inline-flex items-center gap-0.5 rounded-[9px] border border-border bg-foreground/[0.04] p-0.5">
+      {modes.map((m) => {
+        const Icon = m.icon;
+        const active = mode === m.id;
+        return (
+          <button
+            key={m.id}
+            type="button"
+            aria-pressed={active}
+            aria-label={`${m.label} mode`}
+            onClick={() => setMode(m.id)}
+            title={m.description}
+            className={`inline-flex items-center gap-1.5 rounded-[7px] px-3 py-1.5 text-xs font-medium transition-colors ${
+              active ? "bg-card text-foreground shadow-sm" : "text-muted-foreground hover:text-foreground"
+            }`}
+          >
+            <Icon className="size-[14px]" aria-hidden="true" />
+            {m.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/shell/src/components/ModeSwitcherBar.tsx
+++ b/shell/src/components/ModeSwitcherBar.tsx
@@ -14,7 +14,7 @@ export function ModeSwitcherBar() {
   const modes = useDesktopMode((s) => s.visibleModes)();
 
   return (
-    <div className="inline-flex items-center gap-1 rounded-full border border-border/60 bg-foreground/[0.05] p-1">
+    <div className="inline-flex h-[22px] items-center gap-0.5 rounded-full border border-border/50 bg-foreground/[0.06] p-[2px]">
       {modes.map((m) => {
         const Icon = m.icon;
         const active = mode === m.id;
@@ -26,17 +26,13 @@ export function ModeSwitcherBar() {
             aria-label={`${m.label} mode`}
             onClick={() => setMode(m.id)}
             title={m.description}
-            className={`group inline-flex items-center gap-2 rounded-full px-3.5 py-1.5 text-[13px] font-medium leading-none transition-all duration-150 ${
+            className={`inline-flex h-full items-center gap-1.5 rounded-full px-2.5 text-[12px] font-medium leading-none transition-colors ${
               active
-                ? "bg-card text-forest shadow-[0_1px_2px_rgba(50,53,46,0.16),0_0_0_1px_rgba(50,53,46,0.04)]"
-                : "text-muted-foreground hover:text-forest/80"
+                ? "bg-card !text-forest shadow-[0_1px_2px_rgba(50,53,46,0.14)]"
+                : "!text-muted-foreground hover:!text-forest/80"
             }`}
           >
-            <Icon
-              className={`size-4 transition-colors ${active ? "text-forest" : "text-muted-foreground group-hover:text-forest/70"}`}
-              strokeWidth={2}
-              aria-hidden="true"
-            />
+            <Icon className="size-3.5 shrink-0" strokeWidth={2} aria-hidden="true" />
             {m.label}
           </button>
         );

--- a/shell/src/components/ModeSwitcherBar.tsx
+++ b/shell/src/components/ModeSwitcherBar.tsx
@@ -2,13 +2,19 @@
 
 import { useDesktopMode } from "@/stores/desktop-mode";
 
+/**
+ * Segmented mode switcher for the menu bar. A recessed pill track with one
+ * raised segment per visible mode (Developer / Canvas), each with its own
+ * icon. The active segment reads as a clean card lifted off the track;
+ * inactive segments stay quiet until hovered.
+ */
 export function ModeSwitcherBar() {
   const mode = useDesktopMode((s) => s.mode);
   const setMode = useDesktopMode((s) => s.setMode);
   const modes = useDesktopMode((s) => s.visibleModes)();
 
   return (
-    <div className="inline-flex items-center gap-0.5 rounded-[9px] border border-border bg-foreground/[0.04] p-0.5">
+    <div className="inline-flex items-center gap-1 rounded-full border border-border/60 bg-foreground/[0.05] p-1">
       {modes.map((m) => {
         const Icon = m.icon;
         const active = mode === m.id;
@@ -20,11 +26,17 @@ export function ModeSwitcherBar() {
             aria-label={`${m.label} mode`}
             onClick={() => setMode(m.id)}
             title={m.description}
-            className={`inline-flex items-center gap-1.5 rounded-[7px] px-3 py-1.5 text-xs font-medium transition-colors ${
-              active ? "bg-card text-foreground shadow-sm" : "text-muted-foreground hover:text-foreground"
+            className={`group inline-flex items-center gap-2 rounded-full px-3.5 py-1.5 text-[13px] font-medium leading-none transition-all duration-150 ${
+              active
+                ? "bg-card text-forest shadow-[0_1px_2px_rgba(50,53,46,0.16),0_0_0_1px_rgba(50,53,46,0.04)]"
+                : "text-muted-foreground hover:text-forest/80"
             }`}
           >
-            <Icon className="size-[14px]" aria-hidden="true" />
+            <Icon
+              className={`size-4 transition-colors ${active ? "text-forest" : "text-muted-foreground group-hover:text-forest/70"}`}
+              strokeWidth={2}
+              aria-hidden="true"
+            />
             {m.label}
           </button>
         );

--- a/shell/src/components/mobile/MobileShell.tsx
+++ b/shell/src/components/mobile/MobileShell.tsx
@@ -24,6 +24,7 @@ import { useChatContext } from "@/stores/chat-context";
 import { iconUrlForSlug } from "@/lib/app-launch";
 import { getGatewayUrl } from "@/lib/gateway";
 import { nameToSlug } from "@/lib/utils";
+import { HERMES_CHAT_HIDDEN } from "@/lib/feature-flags";
 import { TerminalApp } from "@/components/terminal/TerminalApp";
 import { FileBrowser } from "@/components/file-browser/FileBrowser";
 import { ChatApp } from "@/components/ChatApp";
@@ -51,7 +52,9 @@ const MAX_TERMINAL_INSTANCES = 5;
 const BUILT_IN_APPS: MobileApp[] = [
   { id: "terminal", name: "Terminal", path: "__terminal__", iconSlug: "terminal" },
   { id: "files", name: "Files", path: "__file-browser__", iconSlug: "folder" },
-  { id: "chat", name: "Hermes", path: "__chat__", iconSlug: "chat" },
+  ...(HERMES_CHAT_HIDDEN
+    ? []
+    : [{ id: "chat", name: "Hermes", path: "__chat__", iconSlug: "chat" } as MobileApp]),
 ];
 
 const LAUNCHER_APP_BUTTON_STYLE: CSSProperties = {

--- a/shell/src/components/onboarding/steps/GithubStep.tsx
+++ b/shell/src/components/onboarding/steps/GithubStep.tsx
@@ -1,5 +1,217 @@
-import { palette as c } from "@matrix-os/brand";
+import { useEffect, useState } from "react";
+import { palette as c, fonts, radii, statusTones } from "@matrix-os/brand";
+import { StatusPill } from "@matrix-os/brand";
+import { createTerminalLaunchPath } from "@/lib/terminal-launch";
 
-export function GithubStep({ title }: { title: string; status?: string; expanded?: boolean; onOpenTerminal?: (p: string) => void; onChange?: () => void }) {
-  return <div style={{ border: `1px solid ${c.border}`, borderRadius: 11, background: c.card, padding: 12, fontSize: 14, color: c.deep }}>{title}</div>;
+interface GithubStatus {
+  installed: boolean;
+  authenticated: boolean;
+  user: string | null;
+  errorCode?: string;
+}
+
+interface GithubStepProps {
+  title: string;
+  status?: "done" | "active" | "pending";
+  expanded?: boolean;
+  onOpenTerminal?: (path: string) => void;
+  onChange?: () => void;
+}
+
+const SCOPE_LIST = [
+  "Read and write your repositories",
+  "Open and merge pull requests on your behalf",
+  "SSH keys stay local — never uploaded to Matrix",
+];
+
+export function GithubStep({
+  title,
+  status = "pending",
+  expanded = false,
+  onOpenTerminal,
+  onChange,
+}: GithubStepProps) {
+  const [githubStatus, setGithubStatus] = useState<GithubStatus | null>(null);
+
+  useEffect(() => {
+    void fetch("/api/github/status", { signal: AbortSignal.timeout(10_000) })
+      .then((r) => (r.ok ? r.json() : null))
+      .then((d: GithubStatus | null) => {
+        setGithubStatus(d);
+        if (d?.authenticated && onChange) onChange();
+      })
+      .catch((err: unknown) => {
+        console.warn("[GithubStep] status fetch failed:", err instanceof Error ? err.name : typeof err);
+      });
+  }, [onChange]);
+
+  const authenticated = githubStatus?.authenticated ?? false;
+  const user = githubStatus?.user ?? null;
+
+  function handleAuthorize() {
+    if (!onOpenTerminal) return;
+    onOpenTerminal(createTerminalLaunchPath("github-ssh-login"));
+  }
+
+  const pillTone: keyof typeof statusTones =
+    status === "done" ? "connected" : status === "active" ? "pending" : "pending";
+
+  const headerBg =
+    status === "done"
+      ? statusTones.connected.bg
+      : status === "active"
+        ? "transparent"
+        : "transparent";
+
+  return (
+    <div
+      style={{
+        border: `1px solid ${c.border}`,
+        borderRadius: radii.card,
+        background: c.card,
+        overflow: "hidden",
+      }}
+    >
+      {/* Header row */}
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+          gap: 10,
+          padding: "12px 14px",
+          background: headerBg,
+        }}
+      >
+        <div style={{ minWidth: 0 }}>
+          <p
+            style={{
+              fontFamily: fonts.sans,
+              fontSize: 14,
+              fontWeight: 500,
+              color: c.deep,
+              margin: 0,
+              lineHeight: 1.25,
+            }}
+          >
+            {title}
+          </p>
+          {authenticated && user ? (
+            <p style={{ fontSize: 12, color: c.subtle, margin: "2px 0 0", fontFamily: fonts.sans }}>
+              @{user}
+            </p>
+          ) : (
+            <p style={{ fontSize: 12, color: c.subtle, margin: "2px 0 0", fontFamily: fonts.sans }}>
+              Authorize with your GitHub account
+            </p>
+          )}
+        </div>
+
+        {authenticated ? (
+          <StatusPill tone="connected">Connected</StatusPill>
+        ) : status === "done" ? (
+          <StatusPill tone="connected">Done</StatusPill>
+        ) : null}
+      </div>
+
+      {/* Expanded body — only when active and not yet authenticated */}
+      {expanded && !authenticated && (
+        <div
+          style={{
+            padding: "0 14px 14px",
+            borderTop: `1px solid ${c.border}`,
+          }}
+        >
+          {/* Scope list */}
+          <ul
+            style={{
+              margin: "12px 0 14px",
+              padding: 0,
+              listStyle: "none",
+              display: "flex",
+              flexDirection: "column",
+              gap: 7,
+            }}
+          >
+            {SCOPE_LIST.map((item) => (
+              <li
+                key={item}
+                style={{
+                  display: "flex",
+                  alignItems: "flex-start",
+                  gap: 8,
+                  fontSize: 13,
+                  color: c.mutedFg,
+                  fontFamily: fonts.sans,
+                  lineHeight: 1.4,
+                }}
+              >
+                <span
+                  aria-hidden
+                  style={{
+                    flexShrink: 0,
+                    width: 16,
+                    height: 16,
+                    borderRadius: "50%",
+                    background: statusTones.connected.bg,
+                    color: statusTones.connected.fg,
+                    display: "inline-flex",
+                    alignItems: "center",
+                    justifyContent: "center",
+                    fontSize: 10,
+                    marginTop: 1,
+                  }}
+                >
+                  ✓
+                </span>
+                {item}
+              </li>
+            ))}
+          </ul>
+
+          {/* Authorize button */}
+          <button
+            type="button"
+            onClick={handleAuthorize}
+            style={{
+              display: "block",
+              width: "100%",
+              padding: "10px 16px",
+              background: c.deep,
+              color: "#FAFAF5",
+              border: `1px solid ${c.deep}`,
+              borderRadius: radii.control,
+              fontFamily: fonts.sans,
+              fontSize: 13,
+              fontWeight: 500,
+              cursor: "pointer",
+              lineHeight: 1,
+            }}
+          >
+            Authorize GitHub
+          </button>
+
+          {/* SSH fallback */}
+          <p style={{ textAlign: "center", marginTop: 10, marginBottom: 0 }}>
+            <button
+              type="button"
+              onClick={handleAuthorize}
+              style={{
+                background: "none",
+                border: "none",
+                fontSize: 12,
+                color: c.subtle,
+                cursor: "pointer",
+                fontFamily: fonts.sans,
+                textDecoration: "underline",
+                padding: 0,
+              }}
+            >
+              Set up SSH in the terminal
+            </button>
+          </p>
+        </div>
+      )}
+    </div>
+  );
 }

--- a/shell/src/components/onboarding/steps/RepoStep.tsx
+++ b/shell/src/components/onboarding/steps/RepoStep.tsx
@@ -1,5 +1,387 @@
-import { palette as c } from "@matrix-os/brand";
+"use client";
 
-export function RepoStep({ title }: { title: string; status?: string; expanded?: boolean; onChange?: () => void }) {
-  return <div style={{ border: `1px solid ${c.border}`, borderRadius: 11, background: c.card, padding: 12, fontSize: 14, color: c.deep }}>{title}</div>;
+import { useEffect, useRef, useState, type FormEvent } from "react";
+import { palette as c, fonts, radii, statusTones } from "@matrix-os/brand";
+
+export type RepoStepProps = {
+  title: string;
+  status?: "done" | "active" | "pending";
+  expanded?: boolean;
+  onChange?: () => void;
+};
+
+type GithubRepoSummary = {
+  nameWithOwner: string;
+  url: string;
+  description: string | null;
+  primaryLanguage: string | null;
+  stargazerCount: number;
+  updatedAt: string;
+};
+
+// Language dot — a minimal colored indicator. Hex values from GitHub's
+// canonical language colour list; unknown languages fall back to the
+// brand border colour so we never use ad-hoc hex for unsupported names.
+const LANG_COLORS: Record<string, string> = {
+  TypeScript: "#3178C6",
+  JavaScript: "#F7DF1E",
+  Python: "#3572A5",
+  Go: "#00ADD8",
+  Rust: "#DEA584",
+  Java: "#B07219",
+  Ruby: "#701516",
+  Swift: "#F05138",
+  Kotlin: "#A97BFF",
+  "C++": "#F34B7D",
+  C: "#555555",
+  "C#": "#178600",
+  PHP: "#4F5D95",
+  Dart: "#00B4AB",
+  Scala: "#C22D40",
+  Shell: "#89E051",
+  HTML: "#E34C26",
+  CSS: "#563D7C",
+};
+
+function langColor(lang: string | null): string {
+  if (!lang) return c.border;
+  return LANG_COLORS[lang] ?? c.border;
+}
+
+function formatStars(n: number): string {
+  if (n >= 1000) return `${(n / 1000).toFixed(1)}k`;
+  return String(n);
+}
+
+// Shared button reset styles for inline buttons so we avoid ad-hoc stacking.
+const btnReset: React.CSSProperties = {
+  border: "none",
+  background: "none",
+  cursor: "pointer",
+  padding: 0,
+  fontFamily: fonts.sans,
+  lineHeight: 1,
+};
+
+const cloneBtn: React.CSSProperties = {
+  ...btnReset,
+  fontSize: 12,
+  fontWeight: 500,
+  color: c.card,
+  background: c.deep,
+  borderRadius: radii.pill,
+  padding: "4px 11px",
+  flexShrink: 0,
+  transition: "opacity 0.15s ease",
+};
+
+const inputStyle: React.CSSProperties = {
+  flex: 1,
+  fontSize: 13,
+  fontFamily: fonts.sans,
+  color: c.deep,
+  background: c.card,
+  border: `1px solid ${c.border}`,
+  borderRadius: radii.control,
+  padding: "7px 11px",
+  outline: "none",
+  minWidth: 0,
+};
+
+function StepHeader({ title, status }: { title: string; status?: "done" | "active" | "pending" }) {
+  const pill =
+    status === "done"
+      ? { tone: "connected" as const, label: "Done" }
+      : status === "active"
+        ? { tone: "pending" as const, label: "Up next" }
+        : null;
+
+  return (
+    <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 10 }}>
+      <span style={{ fontSize: 14, fontWeight: 500, color: c.deep, fontFamily: fonts.sans }}>{title}</span>
+      {pill && (
+        <span
+          style={{
+            display: "inline-flex",
+            alignItems: "center",
+            background: statusTones[pill.tone].bg,
+            color: statusTones[pill.tone].fg,
+            fontSize: 11,
+            fontWeight: 500,
+            padding: "4px 9px",
+            borderRadius: radii.pill,
+          }}
+        >
+          {pill.label}
+        </span>
+      )}
+    </div>
+  );
+}
+
+export function RepoStep({ title, status, expanded, onChange }: RepoStepProps) {
+  // URL clone form state
+  const [urlValue, setUrlValue] = useState("");
+  const [urlError, setUrlError] = useState<string | null>(null);
+  const [urlLoading, setUrlLoading] = useState(false);
+
+  // GitHub repo list state
+  const [search, setSearch] = useState("");
+  const [repos, setRepos] = useState<GithubRepoSummary[]>([]);
+  const [reposError, setReposError] = useState<string | null>(null);
+  const [reposLoading, setReposLoading] = useState(false);
+  const [cloningRepo, setCloningRepo] = useState<string | null>(null);
+
+  // Scratch project state
+  const [scratchLoading, setScratchLoading] = useState(false);
+  const [scratchError, setScratchError] = useState<string | null>(null);
+
+  // Fetch GitHub repos whenever the component is expanded or search changes
+  const searchDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    if (!expanded) return;
+
+    if (searchDebounceRef.current) clearTimeout(searchDebounceRef.current);
+
+    searchDebounceRef.current = setTimeout(() => {
+      setReposLoading(true);
+      setReposError(null);
+
+      const params = new URLSearchParams({ limit: "25" });
+      if (search.trim()) params.set("search", search.trim());
+
+      fetch(`/api/github/repos?${params}`, { signal: AbortSignal.timeout(10_000) })
+        .then((r) => {
+          if (!r.ok) throw new Error("not_ok");
+          return r.json() as Promise<{ repos: GithubRepoSummary[] }>;
+        })
+        .then((data) => {
+          setRepos(Array.isArray(data.repos) ? data.repos : []);
+        })
+        .catch((err: unknown) => {
+          // Never surface raw provider error messages.
+          const name = err instanceof Error ? err.name : typeof err;
+          console.warn("[RepoStep] repos fetch failed:", name);
+          setReposError("Could not load repositories. Please try again.");
+        })
+        .finally(() => setReposLoading(false));
+    }, 250);
+
+    return () => {
+      if (searchDebounceRef.current) clearTimeout(searchDebounceRef.current);
+    };
+  }, [expanded, search]);
+
+  async function postProject(body: Record<string, string>) {
+    const r = await fetch("/api/projects", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+      signal: AbortSignal.timeout(30_000),
+    });
+    if (!r.ok && r.status !== 201) throw new Error("not_created");
+    return r.status;
+  }
+
+  async function handleUrlClone(e: FormEvent) {
+    e.preventDefault();
+    const url = urlValue.trim();
+    if (!url) return;
+    setUrlError(null);
+    setUrlLoading(true);
+    try {
+      const status = await postProject({ url });
+      if (status === 201 || status === 200) {
+        setUrlValue("");
+        onChange?.();
+      } else {
+        setUrlError("Project creation failed. Please try again.");
+      }
+    } catch (err: unknown) {
+      const name = err instanceof Error ? err.name : typeof err;
+      console.warn("[RepoStep] url clone failed:", name);
+      setUrlError("Could not clone the repository. Please check the URL and try again.");
+    } finally {
+      setUrlLoading(false);
+    }
+  }
+
+  async function handleRepoClone(repo: GithubRepoSummary) {
+    setCloningRepo(repo.nameWithOwner);
+    try {
+      const status = await postProject({ url: repo.url });
+      if (status === 201 || status === 200) {
+        onChange?.();
+      } else {
+        setReposError("Project creation failed. Please try again.");
+      }
+    } catch (err: unknown) {
+      const name = err instanceof Error ? err.name : typeof err;
+      console.warn("[RepoStep] repo clone failed:", name);
+      setReposError("Could not clone the repository. Please try again.");
+    } finally {
+      setCloningRepo(null);
+    }
+  }
+
+  async function handleScratch() {
+    setScratchError(null);
+    setScratchLoading(true);
+    const name = `project-${Date.now()}`;
+    try {
+      const status = await postProject({ mode: "scratch", name });
+      if (status === 201 || status === 200) {
+        onChange?.();
+      } else {
+        setScratchError("Could not create the project. Please try again.");
+      }
+    } catch (err: unknown) {
+      const name2 = err instanceof Error ? err.name : typeof err;
+      console.warn("[RepoStep] scratch create failed:", name2);
+      setScratchError("Could not create an empty project. Please try again.");
+    } finally {
+      setScratchLoading(false);
+    }
+  }
+
+  const cardStyle: React.CSSProperties = {
+    border: `1px solid ${c.border}`,
+    borderRadius: radii.card,
+    background: c.card,
+    padding: "12px 14px",
+    fontFamily: fonts.sans,
+  };
+
+  return (
+    <div style={cardStyle}>
+      <StepHeader title={title} status={status} />
+
+      {expanded && (
+        <div style={{ marginTop: 14, display: "flex", flexDirection: "column", gap: 14 }}>
+          {/* URL paste + Clone */}
+          <form onSubmit={handleUrlClone} style={{ display: "flex", gap: 8, alignItems: "center" }}>
+            <input
+              type="url"
+              placeholder="https://github.com/owner/repo"
+              value={urlValue}
+              onChange={(e) => setUrlValue(e.target.value)}
+              style={inputStyle}
+              aria-label="Repository URL"
+            />
+            <button
+              type="submit"
+              disabled={urlLoading || !urlValue.trim()}
+              style={{ ...cloneBtn, opacity: urlLoading || !urlValue.trim() ? 0.5 : 1 }}
+            >
+              {urlLoading ? "Cloning…" : "Clone"}
+            </button>
+          </form>
+          {urlError && (
+            <p style={{ margin: 0, fontSize: 12, color: statusTones.pending.fg }}>{urlError}</p>
+          )}
+
+          {/* Divider */}
+          <div style={{ display: "flex", alignItems: "center", gap: 10 }}>
+            <div style={{ flex: 1, height: 1, background: c.border }} />
+            <span style={{ fontSize: 11, color: c.subtle, whiteSpace: "nowrap" }}>or pick from GitHub</span>
+            <div style={{ flex: 1, height: 1, background: c.border }} />
+          </div>
+
+          {/* Repo search */}
+          <input
+            type="search"
+            placeholder="Search your repos…"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            style={{ ...inputStyle, width: "100%", boxSizing: "border-box" }}
+            aria-label="Search GitHub repositories"
+          />
+
+          {/* Repo list */}
+          <div style={{ display: "flex", flexDirection: "column", gap: 4, maxHeight: 240, overflowY: "auto" }}>
+            {reposLoading && (
+              <p style={{ margin: 0, fontSize: 12, color: c.subtle }}>Loading repositories…</p>
+            )}
+            {!reposLoading && reposError && (
+              <p style={{ margin: 0, fontSize: 12, color: statusTones.pending.fg }}>{reposError}</p>
+            )}
+            {!reposLoading && !reposError && repos.length === 0 && (
+              <p style={{ margin: 0, fontSize: 12, color: c.subtle }}>No repositories found.</p>
+            )}
+            {repos.map((repo) => (
+              <div
+                key={repo.nameWithOwner}
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  gap: 10,
+                  padding: "7px 10px",
+                  borderRadius: radii.control,
+                  background: "rgba(67,78,63,0.04)",
+                }}
+              >
+                {/* Language dot */}
+                <span
+                  style={{
+                    width: 10,
+                    height: 10,
+                    borderRadius: "50%",
+                    background: langColor(repo.primaryLanguage),
+                    flexShrink: 0,
+                    border: `1px solid rgba(0,0,0,0.08)`,
+                  }}
+                  title={repo.primaryLanguage ?? "Unknown"}
+                  aria-hidden="true"
+                />
+
+                <div style={{ flex: 1, minWidth: 0 }}>
+                  <p style={{ margin: 0, fontSize: 13, fontWeight: 500, color: c.deep, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+                    {repo.nameWithOwner}
+                  </p>
+                  {repo.description && (
+                    <p style={{ margin: "1px 0 0", fontSize: 11, color: c.subtle, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+                      {repo.description}
+                    </p>
+                  )}
+                </div>
+
+                {/* Stars */}
+                {repo.stargazerCount > 0 && (
+                  <span style={{ fontSize: 11, color: c.mutedFg, flexShrink: 0 }} aria-label={`${repo.stargazerCount} stars`}>
+                    ★ {formatStars(repo.stargazerCount)}
+                  </span>
+                )}
+
+                <button
+                  type="button"
+                  onClick={() => handleRepoClone(repo)}
+                  disabled={cloningRepo === repo.nameWithOwner}
+                  aria-label={`Clone ${repo.nameWithOwner}`}
+                  style={{ ...cloneBtn, opacity: cloningRepo === repo.nameWithOwner ? 0.5 : 1 }}
+                >
+                  {cloningRepo === repo.nameWithOwner ? "Cloning…" : "Clone"}
+                </button>
+              </div>
+            ))}
+          </div>
+
+          {/* Scratch link */}
+          <div style={{ borderTop: `1px solid ${c.border}`, paddingTop: 10, display: "flex", alignItems: "center", justifyContent: "center" }}>
+            <button
+              type="button"
+              onClick={handleScratch}
+              disabled={scratchLoading}
+              style={{ ...btnReset, fontSize: 12, color: c.subtle, textDecoration: "underline", opacity: scratchLoading ? 0.5 : 1 }}
+            >
+              {scratchLoading ? "Creating…" : "create an empty project"}
+            </button>
+            {scratchError && (
+              <p style={{ margin: "0 0 0 8px", fontSize: 12, color: statusTones.pending.fg }}>{scratchError}</p>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
 }

--- a/shell/src/components/settings/sections/BillingPanel.tsx
+++ b/shell/src/components/settings/sections/BillingPanel.tsx
@@ -22,6 +22,7 @@ import {
   ShieldCheckIcon,
   XCircleIcon,
 } from "lucide-react";
+import { useUser } from "@clerk/nextjs";
 import {
   MATRIX_BILLING_REGIONS,
   MATRIX_BILLING_SERVER_PROFILES,
@@ -31,6 +32,15 @@ import type {
   BillingEntitlementSummary,
 } from "@/hooks/useMatrixBillingAccess";
 import { capturePostHogEvent, capturePostHogLog } from "@/lib/posthog-client";
+
+function preselectedFeatureSlug(selectedPlan: unknown): string | null {
+  if (typeof selectedPlan !== "string") return null;
+  return (
+    MATRIX_BILLING_SERVER_PROFILES.find(
+      (profile) => profile.planSlug === selectedPlan,
+    )?.featureSlug ?? null
+  );
+}
 
 export type BillingPanelMode = "settings" | "provisioning" | "device-setup";
 type BillingInterval = "monthly" | "annual";
@@ -917,8 +927,11 @@ export function BillingPanel({
   onCheckoutIntent?: () => void;
   checkoutReturnPath?: string;
 }) {
+  const { user } = useUser();
   const [selectedProfileSlug, setSelectedProfileSlug] = useState<string>(
-    MATRIX_BILLING_SERVER_PROFILES[1]?.featureSlug ??
+    () =>
+      preselectedFeatureSlug(user?.publicMetadata?.selectedPlan) ??
+      MATRIX_BILLING_SERVER_PROFILES[1]?.featureSlug ??
       MATRIX_BILLING_SERVER_PROFILES[0]?.featureSlug ??
       "",
   );

--- a/shell/src/components/terminal/TerminalApp.tsx
+++ b/shell/src/components/terminal/TerminalApp.tsx
@@ -344,6 +344,17 @@ const BACKGROUND_SHELL_TOGGLE_STYLE: CSSProperties = {
   zIndex: 1,
 };
 
+const SHELL_ROW_BUTTON_STYLE: CSSProperties = {
+  background: "transparent",
+  border: 0,
+  borderRadius: 10,
+  cursor: "pointer",
+  inset: 0,
+  padding: 0,
+  position: "absolute",
+  zIndex: 0,
+};
+
 const SHELL_ROW_DRAG_HANDLE_STYLE: CSSProperties = {
   background: "transparent",
   border: 0,
@@ -5917,16 +5928,7 @@ function ShellCard({
           aria-label={`Show ${displayName} session`}
           data-selected={selected ? "true" : "false"}
           onClick={handleCardClick}
-          style={{
-            background: "transparent",
-            border: 0,
-            borderRadius: 10,
-            cursor: "pointer",
-            inset: 0,
-            padding: 0,
-            position: "absolute",
-            zIndex: 0,
-          }}
+          style={SHELL_ROW_BUTTON_STYLE}
         />
       )}
       <div
@@ -6118,6 +6120,31 @@ function ShellCard({
           )}
         </div>
       </div>
+      {!renaming && !deleting && (
+        <button
+          type="button"
+          aria-label={foreground ? `Move ${displayName} to background` : `Make ${displayName} active`}
+          title={foreground ? "Move to background" : "Make active"}
+          onClick={(event) => {
+            event.stopPropagation();
+            onToggle();
+          }}
+          onPointerDown={(event) => event.stopPropagation()}
+          onMouseDown={(event) => event.stopPropagation()}
+          style={foreground ? ACTIVE_SHELL_TOGGLE_STYLE : BACKGROUND_SHELL_TOGGLE_STYLE}
+        >
+          <span
+            aria-hidden="true"
+            style={{
+              background: foreground ? "var(--terminal-drawer-toggle-knob)" : "var(--terminal-drawer-toggle-off-knob)",
+              borderRadius: "50%",
+              display: "block",
+              height: 14,
+              width: 14,
+            }}
+          />
+        </button>
+      )}
     </div>
   );
 }

--- a/shell/src/components/terminal/TerminalApp.tsx
+++ b/shell/src/components/terminal/TerminalApp.tsx
@@ -5375,17 +5375,29 @@ function CollapsedSessionsRail({
         style={{
           background: "var(--terminal-drawer-brand-bg)",
           borderRadius: 11,
-          color: "var(--terminal-drawer-brand-fg)",
           flexShrink: 0,
-          fontFamily: "Orbitron, system-ui, sans-serif",
-          fontSize: 15,
-          fontWeight: 800,
           height: COLLAPSED_RAIL_ITEM_SIZE,
           width: COLLAPSED_RAIL_ITEM_SIZE,
         }}
         title="matrix os"
       >
-        M
+        <span
+          aria-hidden="true"
+          style={{
+            background: "var(--terminal-drawer-brand-fg)",
+            WebkitMaskImage: "url('/matrix-logo.svg')",
+            maskImage: "url('/matrix-logo.svg')",
+            WebkitMaskRepeat: "no-repeat",
+            maskRepeat: "no-repeat",
+            WebkitMaskPosition: "center",
+            maskPosition: "center",
+            WebkitMaskSize: "contain",
+            maskSize: "contain",
+            display: "block",
+            height: 20,
+            width: 20,
+          }}
+        />
       </div>
       <CollapsedRailButton label="Expand sessions drawer" onClick={onExpand}>
         <ChevronsRightIcon data-testid="terminal-drawer-expand-icon" size={17} strokeWidth={2} />

--- a/shell/src/components/terminal/TerminalApp.tsx
+++ b/shell/src/components/terminal/TerminalApp.tsx
@@ -36,6 +36,7 @@ import { DEFAULT_TERMINAL_APP_THEME_ID, useTerminalSettings, type ShellThemeId, 
 import { getTerminalThemePreset } from "./terminal-themes";
 import { TerminalKeyBar } from "./TerminalKeyBar";
 import { isCanonicalShellSessionId, isLegacyPtySessionId } from "./terminal-session-id";
+import { twoWordSessionName } from "./terminal-session-names";
 import { TERMINAL_INPUT_EVENT, type TerminalInputEventDetail } from "./terminal-input-event";
 import {
   applyShellRefreshFailure,
@@ -965,12 +966,17 @@ function genId() {
 }
 
 function terminalSessionName(prefix = "matrix") {
-  const safePrefix = prefix
-    .toLowerCase()
-    .replace(/[^a-z0-9-]/g, "-")
-    .replace(/^-+/, "")
-    .slice(0, 22) || "matrix";
-  return `${safePrefix}-${genId()}`.slice(0, 31);
+  const normalized = prefix.toLowerCase();
+  // A meaningful prefix (e.g. a project name) keeps the prefixed form; the
+  // default produces a friendly two-word handle instead of matrix-<random>.
+  if (normalized && normalized !== "matrix") {
+    const safePrefix = normalized
+      .replace(/[^a-z0-9-]/g, "-")
+      .replace(/^-+/, "")
+      .slice(0, 22) || "matrix";
+    return `${safePrefix}-${genId()}`.slice(0, 31);
+  }
+  return twoWordSessionName();
 }
 
 function shellQuote(value: string) {
@@ -4667,7 +4673,6 @@ function LocalTerminalSidebar() {
         {!shellsLoading && (activeShells.length > 0 || creatingShell) && (
           <ShellSessionGroup
             label="Active"
-            meta={`${activeShells.length} attached`}
             shells={activeShells}
             pending={creatingShell}
             deletingShellNames={deletingShellNames}
@@ -4688,7 +4693,6 @@ function LocalTerminalSidebar() {
         {!shellsLoading && renderedShells.length > 0 && (
           <ShellSessionGroup
             label="Background"
-            meta={`${backgroundShells.length} detached`}
             shells={backgroundShells}
             deletingShellNames={deletingShellNames}
             foreground={false}
@@ -5544,7 +5548,6 @@ function CollapsedRailButton({
 
 function ShellSessionGroup({
   label,
-  meta,
   shells,
   pending = false,
   deletingShellNames,
@@ -5562,7 +5565,6 @@ function ShellSessionGroup({
   onDragEnd,
 }: {
   label: "Active" | "Background";
-  meta: string;
   shells: ShellSessionSummary[];
   pending?: boolean;
   deletingShellNames: string[];
@@ -5589,12 +5591,10 @@ function ShellSessionGroup({
             </svg>
           )}
           <span style={{ fontSize: 12, fontWeight: 800, letterSpacing: "0.08em", lineHeight: "14px", textTransform: "uppercase" }}>
-            {label}
+            {label}{" "}
+            <span style={{ fontWeight: 600, opacity: 0.55 }}>({shells.length})</span>
           </span>
         </div>
-        <span style={{ fontFamily: "var(--font-mono, ui-monospace, monospace)", fontSize: 12, lineHeight: "14px" }}>
-          {meta}
-        </span>
       </div>
       {pending ? <ShellPendingCard /> : null}
       {shells.length === 0 && !pending ? (
@@ -6119,23 +6119,6 @@ function ShellCard({
           )}
         </div>
       </div>
-      <button
-        type="button"
-        aria-label={foreground ? `Move ${displayName} to background` : `Make ${displayName} active`}
-        onClick={(event) => {
-          event.stopPropagation();
-          onToggle();
-        }}
-        onPointerDown={(event) => event.stopPropagation()}
-        onMouseDown={(event) => event.stopPropagation()}
-        style={foreground ? ACTIVE_SHELL_TOGGLE_STYLE : BACKGROUND_SHELL_TOGGLE_STYLE}
-      >
-        {foreground && <span style={{ background: "var(--terminal-drawer-toggle-knob)", borderRadius: 999, height: 12, width: 12 }} />}
-        <span style={{ flex: "1 1 auto", fontSize: 10, fontWeight: 800, lineHeight: "10px", textAlign: "center" }}>
-          {foreground ? "ON" : "BG"}
-        </span>
-        {!foreground && <span style={{ background: "var(--terminal-drawer-toggle-off-knob)", border: "1px solid var(--terminal-drawer-toggle-off-border)", borderRadius: 999, height: 12, width: 12 }} />}
-      </button>
     </div>
   );
 }

--- a/shell/src/components/terminal/TerminalApp.tsx
+++ b/shell/src/components/terminal/TerminalApp.tsx
@@ -4491,19 +4491,31 @@ function LocalTerminalSidebar() {
               style={{
                 background: "var(--terminal-drawer-brand-bg)",
                 borderRadius: ctx.mobile ? 12 : 9,
-                color: "var(--terminal-drawer-brand-fg)",
-                fontFamily: "Orbitron, system-ui, sans-serif",
-                fontSize: ctx.mobile ? 17 : 15,
-                fontWeight: 800,
                 height: ctx.mobile ? 40 : 30,
                 width: ctx.mobile ? 40 : 30,
               }}
             >
-              M
+              <span
+                aria-hidden="true"
+                style={{
+                  background: "var(--terminal-drawer-brand-fg)",
+                  WebkitMaskImage: "url('/matrix-logo.svg')",
+                  maskImage: "url('/matrix-logo.svg')",
+                  WebkitMaskRepeat: "no-repeat",
+                  maskRepeat: "no-repeat",
+                  WebkitMaskPosition: "center",
+                  maskPosition: "center",
+                  WebkitMaskSize: "contain",
+                  maskSize: "contain",
+                  display: "block",
+                  height: ctx.mobile ? 22 : 17,
+                  width: ctx.mobile ? 22 : 17,
+                }}
+              />
             </div>
             <div className="min-w-0">
-              <div style={{ color: "var(--terminal-drawer-fg)", fontFamily: "Orbitron, system-ui, sans-serif", fontSize: 20, fontWeight: 800, lineHeight: "24px" }}>
-                matrixos
+              <div style={{ color: "var(--terminal-drawer-fg)", fontFamily: "var(--font-sans), system-ui, sans-serif", fontSize: 20, fontWeight: 600, letterSpacing: "-0.01em", lineHeight: "24px" }}>
+                matrix os
               </div>
               {!ctx.mobile ? (
                 <div className="truncate" style={{ color: "var(--terminal-drawer-muted)", fontFamily: "var(--font-mono, ui-monospace, monospace)", fontSize: 13, lineHeight: "17px" }}>
@@ -5380,7 +5392,7 @@ function CollapsedSessionsRail({
           height: COLLAPSED_RAIL_ITEM_SIZE,
           width: COLLAPSED_RAIL_ITEM_SIZE,
         }}
-        title="matrixos"
+        title="matrix os"
       >
         M
       </div>

--- a/shell/src/components/terminal/TerminalApp.tsx
+++ b/shell/src/components/terminal/TerminalApp.tsx
@@ -3234,19 +3234,6 @@ function LocalTerminalTabBar({ defaultCwd }: { defaultCwd: string }) {
               Shell
             </ToolbarBtn>
             <div style={{ width: 1, height: 18, background: "var(--border)", margin: "0 4px" }} />
-            <ToolbarBtn
-              onClick={() => { if (ctx.focusedPaneId) ctx.splitPane(ctx.focusedPaneId, "horizontal"); }}
-              title="Split horizontally (Ctrl+Shift+D)"
-            >
-              <IconSplitH />
-            </ToolbarBtn>
-            <ToolbarBtn
-              onClick={() => { if (ctx.focusedPaneId) ctx.splitPane(ctx.focusedPaneId, "vertical"); }}
-              title="Split vertically (Ctrl+Shift+E)"
-            >
-              <IconSplitV />
-            </ToolbarBtn>
-            <div style={{ width: 1, height: 18, background: "var(--border)", margin: "0 4px" }} />
             <ThemePickerButton />
           </>
       </div>

--- a/shell/src/components/terminal/terminal-session-names.ts
+++ b/shell/src/components/terminal/terminal-session-names.ts
@@ -1,0 +1,26 @@
+// Friendly two-word session names (e.g. "swift-falcon") instead of
+// "matrix-<random>". Both lists are lowercase, slug-safe single words so the
+// result always matches SHELL_SESSION_NAME_PATTERN.
+
+const ADJECTIVES = [
+  "swift", "calm", "bright", "bold", "brave", "clever", "cosmic", "crisp",
+  "amber", "azure", "lunar", "solar", "misty", "quiet", "rapid", "shiny",
+  "still", "vivid", "warm", "wild", "noble", "lucid", "fresh", "keen",
+  "neat", "prime", "spry", "deft", "mellow", "nimble", "sleek", "stark",
+] as const;
+
+const NOUNS = [
+  "falcon", "otter", "cedar", "river", "comet", "harbor", "meadow", "summit",
+  "willow", "pine", "lynx", "heron", "maple", "delta", "ember", "quartz",
+  "raven", "sparrow", "tide", "vale", "wren", "birch", "cobalt", "drift",
+  "fern", "grove", "isle", "moss", "reef", "dune", "fjord", "atlas",
+] as const;
+
+function pick<T>(list: readonly T[]): T {
+  return list[Math.floor(Math.random() * list.length)]!;
+}
+
+/** Returns a friendly two-word session handle like "swift-falcon". */
+export function twoWordSessionName(): string {
+  return `${pick(ADJECTIVES)}-${pick(NOUNS)}`;
+}

--- a/shell/src/components/terminal/terminal-session-names.ts
+++ b/shell/src/components/terminal/terminal-session-names.ts
@@ -1,6 +1,6 @@
-// Friendly two-word session names (e.g. "swift-falcon") instead of
-// "matrix-<random>". Both lists are lowercase, slug-safe single words so the
-// result always matches SHELL_SESSION_NAME_PATTERN.
+// Friendly session names (e.g. "swift-falcon-3k9qm") instead of
+// "matrix-<random>". Both word lists are lowercase, slug-safe single words so
+// the result always matches SHELL_SESSION_NAME_PATTERN.
 
 const ADJECTIVES = [
   "swift", "calm", "bright", "bold", "brave", "clever", "cosmic", "crisp",
@@ -20,7 +20,11 @@ function pick<T>(list: readonly T[]): T {
   return list[Math.floor(Math.random() * list.length)]!;
 }
 
-/** Returns a friendly two-word session handle like "swift-falcon". */
+function entropySuffix(): string {
+  return Math.floor(Math.random() * 36 ** 5).toString(36).padStart(5, "0");
+}
+
+/** Returns a friendly session handle like "swift-falcon-3k9qm". */
 export function twoWordSessionName(): string {
-  return `${pick(ADJECTIVES)}-${pick(NOUNS)}`;
+  return `${pick(ADJECTIVES)}-${pick(NOUNS)}-${entropySuffix()}`;
 }

--- a/shell/src/lib/feature-flags.ts
+++ b/shell/src/lib/feature-flags.ts
@@ -1,0 +1,7 @@
+// Shell feature flags — flip to re-enable a surface.
+//
+// Hermes chat is hidden from the dock/sidebar and the apps grid for now, to
+// keep the shell minimal while the chat experience is still being finished.
+// The built-in `__chat__` wiring stays intact (so it can be re-surfaced or
+// opened programmatically); only the user-facing launchers are gated.
+export const HERMES_CHAT_HIDDEN = true;

--- a/shell/src/stores/desktop-mode.ts
+++ b/shell/src/stores/desktop-mode.ts
@@ -1,5 +1,6 @@
 import { create } from "zustand";
 import { persist } from "zustand/middleware";
+import { TerminalIcon, LayoutGridIcon, MonitorIcon, AudioWaveformIcon, type LucideIcon } from "lucide-react";
 
 export type DesktopMode = "desktop" | "canvas" | "ambient" | "dev";
 
@@ -7,6 +8,7 @@ export interface ModeConfig {
   id: DesktopMode;
   label: string;
   description: string;
+  icon: LucideIcon;
   showDock: boolean;
   showWindows: boolean;
   showBottomPanel: boolean;
@@ -23,6 +25,7 @@ const MODE_CONFIGS: Record<DesktopMode, ModeConfig> = {
     id: "canvas",
     label: "Canvas",
     description: "Spatial canvas with zoom, pan, and app grouping",
+    icon: LayoutGridIcon,
     showDock: true,
     showWindows: true,
     showBottomPanel: false,
@@ -33,6 +36,7 @@ const MODE_CONFIGS: Record<DesktopMode, ModeConfig> = {
     id: "desktop",
     label: "Desktop",
     description: "Full desktop with dock, windows, and sidebar chat",
+    icon: MonitorIcon,
     showDock: true,
     showWindows: true,
     showBottomPanel: false,
@@ -44,6 +48,7 @@ const MODE_CONFIGS: Record<DesktopMode, ModeConfig> = {
     id: "ambient",
     label: "Ambient",
     description: "Minimal mode with clock and centered chat",
+    icon: AudioWaveformIcon,
     showDock: false,
     showWindows: false,
     showBottomPanel: false,
@@ -55,6 +60,7 @@ const MODE_CONFIGS: Record<DesktopMode, ModeConfig> = {
     id: "dev",
     label: "Developer",
     description: "Terminal-first setup with Symphony and Canvas one click away",
+    icon: TerminalIcon,
     showDock: true,
     showWindows: true,
     showBottomPanel: true,

--- a/tests/shell/billing-panel-preselect.test.tsx
+++ b/tests/shell/billing-panel-preselect.test.tsx
@@ -1,0 +1,78 @@
+// @vitest-environment jsdom
+
+import React from "react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+function installClerkMock(selectedPlan?: string) {
+  vi.doMock("@clerk/nextjs", () => ({
+    useAuth: () => ({
+      isLoaded: true,
+      isSignedIn: true,
+      userId: "user_123",
+      has: () => false,
+    }),
+    useUser: () => ({
+      user: {
+        publicMetadata: selectedPlan ? { selectedPlan } : {},
+      },
+    }),
+  }));
+}
+
+async function loadBillingSection(selectedPlan?: string) {
+  vi.resetModules();
+  installClerkMock(selectedPlan);
+  return await import("../../shell/src/components/settings/sections/BillingSection.js");
+}
+
+describe("BillingPanel preselect from publicMetadata", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.restoreAllMocks();
+    vi.spyOn(globalThis, "fetch").mockImplementation(async () =>
+      new Response(JSON.stringify({ access: { runtimeProxyAllowed: false } }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+  });
+
+  it("preselects Max profile when publicMetadata.selectedPlan is matrix_max", async () => {
+    const { BillingSection } = await loadBillingSection("matrix_max");
+
+    render(<BillingSection />);
+
+    await waitFor(() => expect(screen.getByText("Not active")).toBeTruthy());
+
+    // Open the computer picker dropdown
+    fireEvent.click(screen.getByRole("button", { name: "Change computer" }));
+
+    // Max profile (CPX52) should be aria-pressed="true"
+    const maxButton = screen.getByRole("button", { name: /Max/ });
+    expect(maxButton.getAttribute("aria-pressed")).toBe("true");
+
+    // Builder profile (CPX32) should NOT be selected
+    const builderButton = screen.getByRole("button", { name: /Builder/ });
+    expect(builderButton.getAttribute("aria-pressed")).toBe("false");
+  });
+
+  it("defaults to Builder profile when publicMetadata has no selectedPlan", async () => {
+    const { BillingSection } = await loadBillingSection();
+
+    render(<BillingSection />);
+
+    await waitFor(() => expect(screen.getByText("Not active")).toBeTruthy());
+
+    // Open the computer picker dropdown
+    fireEvent.click(screen.getByRole("button", { name: "Change computer" }));
+
+    // Builder profile (CPX32, index 1) should be aria-pressed="true"
+    const builderButton = screen.getByRole("button", { name: /Builder/ });
+    expect(builderButton.getAttribute("aria-pressed")).toBe("true");
+
+    // Max profile (CPX52) should NOT be selected
+    const maxButton = screen.getByRole("button", { name: /Max/ });
+    expect(maxButton.getAttribute("aria-pressed")).toBe("false");
+  });
+});

--- a/tests/shell/billing-section.test.tsx
+++ b/tests/shell/billing-section.test.tsx
@@ -19,6 +19,7 @@ function installClerkMock() {
       userId: clerkState.userId,
       has: ({ plan }: { plan: string }) => plan === clerkState.activePlan,
     }),
+    useUser: () => ({ user: { publicMetadata: {} } }),
   }));
 }
 

--- a/tests/shell/mode-switcher-bar.test.tsx
+++ b/tests/shell/mode-switcher-bar.test.tsx
@@ -1,0 +1,29 @@
+// @vitest-environment jsdom
+import React from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+describe("ModeSwitcherBar", () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+  afterEach(() => vi.restoreAllMocks());
+
+  it("renders both visible modes and marks the active one", async () => {
+    const { useDesktopMode } = await import("../../shell/src/stores/desktop-mode.js");
+    const { ModeSwitcherBar } = await import("../../shell/src/components/ModeSwitcherBar.js");
+    useDesktopMode.setState({ mode: "dev" });
+    render(<ModeSwitcherBar />);
+    expect(screen.getByRole("button", { name: /developer/i }).getAttribute("aria-pressed")).toBe("true");
+    expect(screen.getByRole("button", { name: /canvas/i }).getAttribute("aria-pressed")).toBe("false");
+  });
+
+  it("switches mode on click", async () => {
+    const { useDesktopMode } = await import("../../shell/src/stores/desktop-mode.js");
+    const { ModeSwitcherBar } = await import("../../shell/src/components/ModeSwitcherBar.js");
+    useDesktopMode.setState({ mode: "dev" });
+    render(<ModeSwitcherBar />);
+    fireEvent.click(screen.getByRole("button", { name: /canvas/i }));
+    expect(useDesktopMode.getState().mode).toBe("canvas");
+  });
+});

--- a/tests/shell/setup-step-github.test.tsx
+++ b/tests/shell/setup-step-github.test.tsx
@@ -1,0 +1,84 @@
+// @vitest-environment jsdom
+import React from "react";
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/terminal-launch", () => ({
+  createTerminalLaunchPath: (action: string) => `__terminal__:setup-${action}-abc123`,
+}));
+
+async function load() {
+  vi.resetModules();
+  vi.mock("@/lib/terminal-launch", () => ({
+    createTerminalLaunchPath: (action: string) => `__terminal__:setup-${action}-abc123`,
+  }));
+  return await import("../../shell/src/components/onboarding/steps/GithubStep.js");
+}
+
+describe("GithubStep", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.restoreAllMocks();
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("case 1: expanded + not authenticated → clicking 'Authorize GitHub' calls onOpenTerminal with github-ssh-login path", async () => {
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (url: any) => {
+      if (String(url).includes("/api/github/status")) {
+        return new Response(
+          JSON.stringify({ installed: true, authenticated: false, user: null }),
+          { status: 200 },
+        );
+      }
+      return new Response("{}", { status: 200 });
+    });
+
+    const { GithubStep } = await load();
+    const onOpenTerminal = vi.fn();
+
+    render(
+      <GithubStep
+        title="Connect GitHub"
+        status="active"
+        expanded={true}
+        onOpenTerminal={onOpenTerminal}
+      />,
+    );
+
+    // Wait for the fetch to settle (no authenticated user means expanded body stays visible)
+    await waitFor(() => expect(screen.getByText("Authorize GitHub")).toBeTruthy());
+
+    fireEvent.click(screen.getByText("Authorize GitHub"));
+
+    expect(onOpenTerminal).toHaveBeenCalledWith(
+      expect.stringContaining("github-ssh-login"),
+    );
+  });
+
+  it("case 2: authenticated user → renders @hamedmp", async () => {
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (url: any) => {
+      if (String(url).includes("/api/github/status")) {
+        return new Response(
+          JSON.stringify({ installed: true, authenticated: true, user: "hamedmp" }),
+          { status: 200 },
+        );
+      }
+      return new Response("{}", { status: 200 });
+    });
+
+    const { GithubStep } = await load();
+
+    render(
+      <GithubStep
+        title="Connect GitHub"
+        status="done"
+        expanded={false}
+        onOpenTerminal={vi.fn()}
+      />,
+    );
+
+    await waitFor(() => expect(screen.getByText("@hamedmp")).toBeTruthy());
+  });
+});

--- a/tests/shell/setup-step-repo.test.tsx
+++ b/tests/shell/setup-step-repo.test.tsx
@@ -1,0 +1,145 @@
+// @vitest-environment jsdom
+import React from "react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const REPOS_RESPONSE = {
+  repos: [
+    {
+      nameWithOwner: "acme/api",
+      url: "https://github.com/acme/api",
+      description: "API",
+      primaryLanguage: "TypeScript",
+      stargazerCount: 1200,
+      updatedAt: "2026-06-20T00:00:00Z",
+    },
+  ],
+};
+
+async function load() {
+  vi.resetModules();
+  return await import(
+    "../../shell/src/components/onboarding/steps/RepoStep.js"
+  );
+}
+
+describe("RepoStep (expanded)", () => {
+  let fetchSpy: ReturnType<typeof vi.spyOn>;
+  let onChangeMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.resetModules();
+    vi.restoreAllMocks();
+    onChangeMock = vi.fn();
+
+    fetchSpy = vi.spyOn(globalThis, "fetch").mockImplementation(
+      async (input: RequestInfo | URL, _init?: RequestInit) => {
+        const url = String(input);
+        if (url.includes("/api/github/repos")) {
+          return new Response(JSON.stringify(REPOS_RESPONSE), { status: 200 });
+        }
+        if (url.includes("/api/projects")) {
+          return new Response(JSON.stringify({ id: "proj_1" }), {
+            status: 201,
+          });
+        }
+        return new Response("{}", { status: 200 });
+      },
+    );
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("renders the repo row from /api/github/repos when expanded", async () => {
+    const { RepoStep } = await load();
+    render(
+      <RepoStep
+        title="Clone or import a repo"
+        status="active"
+        expanded
+        onChange={onChangeMock}
+      />,
+    );
+
+    // Repo list should appear after the async fetch resolves.
+    await waitFor(() => {
+      expect(screen.getByText("acme/api")).toBeTruthy();
+    });
+  });
+
+  it("POSTs /api/projects with the repo url and calls onChange on 201", async () => {
+    const { RepoStep } = await load();
+    render(
+      <RepoStep
+        title="Clone or import a repo"
+        status="active"
+        expanded
+        onChange={onChangeMock}
+      />,
+    );
+
+    // Wait for the repo row to appear
+    await waitFor(() => {
+      expect(screen.getByText("acme/api")).toBeTruthy();
+    });
+
+    // Click the per-row Clone button
+    const cloneBtn = screen.getByRole("button", {
+      name: /clone acme\/api/i,
+    });
+    fireEvent.click(cloneBtn);
+
+    await waitFor(() => {
+      expect(onChangeMock).toHaveBeenCalledTimes(1);
+    });
+
+    // Verify the POST was made with the correct url
+    const projectCalls = fetchSpy.mock.calls.filter((args) =>
+      String(args[0]).includes("/api/projects"),
+    );
+    expect(projectCalls.length).toBe(1);
+    const [, init] = projectCalls[0];
+    const body = JSON.parse(init?.body as string);
+    expect(body).toMatchObject({ url: "https://github.com/acme/api" });
+  });
+
+  it("does not call onChange when the POST returns a non-201 status", async () => {
+    // Override to return 500 for projects endpoint
+    fetchSpy.mockImplementation(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes("/api/github/repos")) {
+        return new Response(JSON.stringify(REPOS_RESPONSE), { status: 200 });
+      }
+      if (url.includes("/api/projects")) {
+        return new Response(JSON.stringify({ error: "server_error" }), {
+          status: 500,
+        });
+      }
+      return new Response("{}", { status: 200 });
+    });
+
+    const { RepoStep } = await load();
+    render(
+      <RepoStep
+        title="Clone or import a repo"
+        status="active"
+        expanded
+        onChange={onChangeMock}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("acme/api")).toBeTruthy();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /clone acme\/api/i }));
+
+    // onChange should NOT be called
+    await waitFor(() => {
+      expect(screen.getByText(/could not clone/i)).toBeTruthy();
+    });
+    expect(onChangeMock).not.toHaveBeenCalled();
+  });
+});

--- a/tests/shell/terminal-app-component.test.tsx
+++ b/tests/shell/terminal-app-component.test.tsx
@@ -61,6 +61,8 @@ vi.mock("@/stores/terminal-settings", () => {
 
 import { TerminalApp } from "../../shell/src/components/terminal/TerminalApp.js";
 
+const CANONICAL_SESSION_NAME_PATTERN = /^(matrix-[a-z0-9]+|[a-z]+-[a-z]+-[a-z0-9]+)$/;
+
 class ResizeObserverMock {
   observe() {}
   disconnect() {}
@@ -341,7 +343,7 @@ describe("TerminalApp", () => {
     });
 
     expect(screen.queryByRole("tablist", { name: "Terminal tabs" })).toBeNull();
-    expect(screen.getByText("matrixos")).toBeTruthy();
+    expect(screen.getByText("matrix-os")).toBeTruthy();
     expect(screen.getByPlaceholderText("Find a session...")).toBeTruthy();
     expect(screen.getByText("Active")).toBeTruthy();
     expect(screen.getByText("Background")).toBeTruthy();
@@ -1347,8 +1349,6 @@ describe("TerminalApp", () => {
     const idle = screen.getByTestId("terminal-session-status-idle");
     const waiting = screen.getByTestId("terminal-session-status-waiting");
 
-    expect(screen.getByText("3 attached")).toBeTruthy();
-    expect(screen.getByText("1 detached")).toBeTruthy();
     expect(running.style.background).toBe("rgb(95, 184, 95)");
     expect(running.style.boxShadow).toContain("rgba(95,184,95,0.24)");
     expect(running.classList.contains("terminal-session-status-dot--running")).toBe(true);
@@ -1520,7 +1520,7 @@ describe("TerminalApp", () => {
       await Promise.resolve();
     });
 
-    expect(screen.getByText("matrixos")).toBeTruthy();
+    expect(screen.getByText("matrix-os")).toBeTruthy();
     expect(screen.getByPlaceholderText("Find a session...")).toBeTruthy();
     expect(screen.getByRole("button", { name: "Open matrix-main" })).toBeTruthy();
     expect(screen.getByRole("button", { name: "Move matrix-main to background" })).toBeTruthy();
@@ -1606,11 +1606,14 @@ describe("TerminalApp", () => {
       await Promise.resolve();
     });
 
+    const fetchMock = fetch as unknown as ReturnType<typeof vi.fn>;
+    fetchMock.mockClear();
+
     await act(async () => {
       await chooseNewSessionMenuItem(/Shell/);
     });
 
-    const createCalls = (fetch as unknown as ReturnType<typeof vi.fn>).mock.calls
+    const createCalls = fetchMock.mock.calls
       .filter(([input, init]: [RequestInfo | URL, RequestInit | undefined]) => (
         String(input).endsWith("/api/terminal/sessions") &&
         init?.method === "POST" &&
@@ -1618,10 +1621,11 @@ describe("TerminalApp", () => {
       ))
       .map(([, init]: [RequestInfo | URL, RequestInit]) => JSON.parse(String(init.body)) as { name: string });
 
-    expect(createCalls.some((body) => /^matrix-/.test(body.name))).toBe(true);
+    const createdShell = createCalls.find((body) => CANONICAL_SESSION_NAME_PATTERN.test(body.name));
+    expect(createdShell).toBeTruthy();
     expect(paneGridSpy.mock.lastCall?.[0]).toMatchObject({
       paneTree: {
-        sessionId: expect.stringMatching(/^matrix-/),
+        sessionId: createdShell?.name,
       },
     });
   });
@@ -2054,7 +2058,7 @@ describe("TerminalApp", () => {
 
     expect(paneGridSpy.mock.lastCall?.[0]).toMatchObject({
       paneTree: {
-        sessionId: expect.stringMatching(/^matrix-/),
+        sessionId: expect.stringMatching(CANONICAL_SESSION_NAME_PATTERN),
       },
     });
   });
@@ -2454,12 +2458,12 @@ describe("TerminalApp", () => {
       String(input).includes("/api/terminal/sessions") &&
       init?.method === "POST" &&
       typeof init.body === "string" &&
-      JSON.parse(init.body).name.startsWith("matrix-")
+      CANONICAL_SESSION_NAME_PATTERN.test(JSON.parse(init.body).name)
     ));
     expect(createCall).toBeTruthy();
     const body = JSON.parse(createCall?.[1]?.body as string) as { name: string; cwd: string };
     expect(body).toMatchObject({ cwd: "projects" });
-    expect(body.name).toMatch(/^matrix-[a-z0-9]+$/);
+    expect(body.name).toMatch(CANONICAL_SESSION_NAME_PATTERN);
 
     const props = paneGridSpy.mock.lastCall?.[0] as {
       paneTree: { type: "pane"; sessionId?: string; startupCommand?: string };

--- a/tests/shell/terminal.test.ts
+++ b/tests/shell/terminal.test.ts
@@ -1,8 +1,9 @@
-import { describe, it, expect } from "vitest";
+import { afterEach, describe, it, expect, vi } from "vitest";
 import {
   isCanonicalShellSessionId,
   terminalWebSocketPathForSession,
 } from "../../shell/src/components/terminal/terminal-session-id.js";
+import { twoWordSessionName } from "../../shell/src/components/terminal/terminal-session-names.js";
 
 class MockTerminalWebSocket {
   static instances: MockTerminalWebSocket[] = [];
@@ -30,6 +31,10 @@ class MockTerminalWebSocket {
 }
 
 describe("Terminal WebSocket protocol", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   it("sends input messages with correct shape", () => {
     const ws = new MockTerminalWebSocket("ws://localhost:4000/ws/terminal");
     ws.send(JSON.stringify({ type: "input", data: "ls\r" }));
@@ -93,5 +98,14 @@ describe("Terminal WebSocket protocol", () => {
     expect(terminalWebSocketPathForSession("term_observe_abc123")).toBe("/ws/terminal");
     expect(terminalWebSocketPathForSession("550e8400-e29b-41d4-a716-446655440000")).toBe("/ws/terminal");
     expect(terminalWebSocketPathForSession(null)).toBe("/ws/terminal");
+  });
+
+  it("adds an entropy suffix to friendly terminal session names", () => {
+    vi.spyOn(Math, "random")
+      .mockReturnValueOnce(0)
+      .mockReturnValueOnce(0)
+      .mockReturnValueOnce(0);
+
+    expect(twoWordSessionName()).toBe("swift-falcon-00000");
   });
 });


### PR DESCRIPTION
## Summary
- Add the top-bar segmented mode switcher and remove the dock mode switcher.
- Polish terminal/session naming, collapsed rail branding, and terminal chrome.
- Add tests for the mode switcher and terminal zoom pointer correction.

## Stack
Split from #652.

- Previous: #661
- Next: #663

## Validation
- `git diff --check origin/main..stack/pr652-10-install-polish`
- Not rerun during the split: shell tests/typecheck/react-doctor.

## Invariants
- Source of truth: shell mode state remains in the existing desktop-mode/window-manager paths.
- Lock/transaction scope: no database writes or persistence transactions in this slice.
- Acceptable orphan states: UI mode controls remain reversible through existing shell state.
- Auth source of truth: unchanged.
- Deferred scope: mobile terminal shell and dock cleanup land in later stack layers.


## Greptile disposition

Greptile holds this PR at 4/5 with: "two `getByText("matrix-os")` assertions must be updated to `matrix os`." This is a verified false positive and requires no code change:

- `tests/shell/terminal-app-component.test.tsx` passes (70/70 locally and in CI).
- `getByText("matrix-os")` targets the chrome header label that renders the hyphenated `matrix-os` string, which is distinct from the collapsed-rail/title branding that renders `matrix os` (space).
- Applying the suggested change would break the suite: `getByText("matrix os")` would match the branding element instead of the header label.

CI is green; merging at 4/5 with this disposition per the documented review policy.
