### PR TITLE
feat(mobile): polish terminal PWA shell

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -956,6 +956,9 @@ importers:
       siriwave:
         specifier: ^2.4.0
         version: 2.4.0
+      sonner:
+        specifier: ^2.0.7
+        version: 2.0.7(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       streamdown:
         specifier: ^2.2.0
         version: 2.5.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
@@ -968,6 +971,9 @@ importers:
       use-stick-to-bottom:
         specifier: ^1.1.4
         version: 1.1.4(react@19.2.6)
+      vaul:
+        specifier: ^1.1.2
+        version: 1.1.2(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       vis-data:
         specifier: ^8.0.4
         version: 8.0.4(uuid@14.0.0)(vis-util@6.0.0(@egjs/hammerjs@2.0.17)(component-emitter@2.0.0))
@@ -34304,7 +34310,6 @@ snapshots:
     transitivePeerDependencies:
       - '@types/react'
       - '@types/react-dom'
-    optional: true
 
   verror@1.10.0:
     dependencies:

--- a/shell/package.json
+++ b/shell/package.json
@@ -56,10 +56,12 @@
     "remark-gfm": "^4.0.1",
     "shiki": "^3.22.0",
     "siriwave": "^2.4.0",
+    "sonner": "^2.0.7",
     "streamdown": "^2.2.0",
     "tailwind-merge": "^3.6.0",
     "three": "^0.184.0",
     "use-stick-to-bottom": "^1.1.4",
+    "vaul": "^1.1.2",
     "vis-data": "^8.0.4",
     "vis-network": "^10.1.0",
     "zustand": "^5.0.13"

--- a/shell/public/manifest.json
+++ b/shell/public/manifest.json
@@ -8,8 +8,8 @@
   "display": "standalone",
   "display_override": ["window-controls-overlay", "standalone", "minimal-ui"],
   "orientation": "any",
-  "background_color": "#3f4a3a",
-  "theme_color": "#3f4a3a",
+  "background_color": "#434E3F",
+  "theme_color": "#434E3F",
   "categories": ["productivity", "developer", "utilities"],
   "lang": "en",
   "dir": "ltr",
@@ -39,21 +39,21 @@
       "short_name": "Terminal",
       "description": "Open the Matrix OS terminal",
       "url": "/?launch=__terminal__",
-      "icons": [{ "src": "/icons/terminal.png", "sizes": "192x192" }]
+      "icons": [{ "src": "/icon-192.png", "sizes": "192x192", "type": "image/png" }]
     },
     {
       "name": "Chat",
       "short_name": "Chat",
       "description": "Open the chat with Aoede",
       "url": "/?launch=__chat__",
-      "icons": [{ "src": "/icons/aoede.png", "sizes": "192x192" }]
+      "icons": [{ "src": "/icon-192.png", "sizes": "192x192", "type": "image/png" }]
     },
     {
       "name": "Files",
       "short_name": "Files",
       "description": "Browse files",
       "url": "/?launch=__file-browser__",
-      "icons": [{ "src": "/icons/finder.png", "sizes": "192x192" }]
+      "icons": [{ "src": "/icon-192.png", "sizes": "192x192", "type": "image/png" }]
     }
   ],
   "prefer_related_applications": false

--- a/shell/src/app/globals.css
+++ b/shell/src/app/globals.css
@@ -116,6 +116,34 @@
   --neu-distance: 0px;
   --neu-blur: 0px;
 
+  /* ─── Semantic surface / elevation / motion tokens (spec 102) ───
+     Layered on the brand palette above. Mobile chrome, sheets, toasts and
+     the terminal share these so glass + depth + easing stay consistent. */
+
+  /* Glass surfaces: brand bg at ~80% opacity, paired with a backdrop blur.
+     --surface-glass sits on light page chrome; --surface-glass-strong is a
+     denser variant for headers/sheets that overlap busy content. */
+  --surface-glass: color-mix(in srgb, var(--card) 80%, transparent);
+  --surface-glass-strong: color-mix(in srgb, var(--card) 92%, transparent);
+  --surface-glass-deep: color-mix(in srgb, var(--deep) 78%, transparent);
+  --surface-glass-blur: 16px;
+  --surface-glass-border: color-mix(in srgb, var(--foreground) 10%, transparent);
+
+  /* Elevation shadow scale — soft, brand-tinted (deep instead of pure black)
+     so raised surfaces read warm rather than clinical. */
+  --elevation-1: 0 1px 2px color-mix(in srgb, var(--deep) 8%, transparent);
+  --elevation-2: 0 2px 8px color-mix(in srgb, var(--deep) 12%, transparent);
+  --elevation-3: 0 8px 24px color-mix(in srgb, var(--deep) 16%, transparent);
+  --elevation-4: 0 16px 48px color-mix(in srgb, var(--deep) 22%, transparent);
+
+  /* Emphasized easing (iOS-style decelerate) for sheets/app transitions. */
+  --ease-emphasized: cubic-bezier(0.32, 0.72, 0, 1);
+  --ease-standard: cubic-bezier(0.4, 0, 0.2, 1);
+
+  /* Live keyboard height, published by useVisualViewport on mobile so the
+     key bar / toasts can offset above the on-screen keyboard. */
+  --terminal-keyboard-height: 0px;
+
   /* Page background gradient tokens (separate from app --background) */
   --gradient-deep: #323D2E;
   --gradient-mid: #9AA48C;
@@ -191,7 +219,10 @@ body {
   font-family: var(--font-sans);
   overflow: hidden;
   overscroll-behavior: none;
+  /* dvh tracks the dynamic viewport (URL bar / keyboard) on mobile; the vh
+     fallback keeps older browsers from collapsing the shell to 0 height. */
   height: 100vh;
+  height: 100dvh;
 }
 
 ::-webkit-scrollbar {
@@ -847,4 +878,68 @@ pre {
     scroll-behavior: auto !important;
     transition-duration: 1ms !important;
   }
+}
+
+/* ═══════════════════════════════════════════════
+   Mobile primitives (spec 102) — glass surfaces,
+   safe-area helpers, elevation. Brand-tinted; share
+   one implementation across chrome / sheets / terminal.
+   ═══════════════════════════════════════════════ */
+
+/* Glass surface: brand-tinted translucency + backdrop blur. Pair with a
+   border (--surface-glass-border) for the frosted-edge look. */
+.surface-glass {
+  background: var(--surface-glass);
+  backdrop-filter: blur(var(--surface-glass-blur)) saturate(140%);
+  -webkit-backdrop-filter: blur(var(--surface-glass-blur)) saturate(140%);
+  border-color: var(--surface-glass-border);
+}
+
+.surface-glass-strong {
+  background: var(--surface-glass-strong);
+  backdrop-filter: blur(var(--surface-glass-blur)) saturate(150%);
+  -webkit-backdrop-filter: blur(var(--surface-glass-blur)) saturate(150%);
+  border-color: var(--surface-glass-border);
+}
+
+/* Dark glass for surfaces over the deep brand backdrop (e.g. terminal chrome). */
+.surface-glass-deep {
+  background: var(--surface-glass-deep);
+  backdrop-filter: blur(var(--surface-glass-blur)) saturate(140%);
+  -webkit-backdrop-filter: blur(var(--surface-glass-blur)) saturate(140%);
+  border-color: color-mix(in srgb, var(--cream) 12%, transparent);
+}
+
+/* Elevation utilities mapping to the shadow scale. */
+.elevation-1 { box-shadow: var(--elevation-1); }
+.elevation-2 { box-shadow: var(--elevation-2); }
+.elevation-3 { box-shadow: var(--elevation-3); }
+.elevation-4 { box-shadow: var(--elevation-4); }
+
+/* Safe-area helpers — apply device insets as padding so chrome clears the
+   notch / home indicator / rounded corners on installed PWAs. */
+.safe-top { padding-top: env(safe-area-inset-top); }
+.safe-bottom { padding-bottom: env(safe-area-inset-bottom); }
+.safe-left { padding-left: env(safe-area-inset-left); }
+.safe-right { padding-right: env(safe-area-inset-right); }
+.safe-x {
+  padding-left: env(safe-area-inset-left);
+  padding-right: env(safe-area-inset-right);
+}
+.safe-area {
+  padding-top: env(safe-area-inset-top);
+  padding-right: env(safe-area-inset-right);
+  padding-bottom: env(safe-area-inset-bottom);
+  padding-left: env(safe-area-inset-left);
+}
+/* Margin variant for bottom-pinned UI (toasts/sheets) above the home bar. */
+.safe-mb { margin-bottom: env(safe-area-inset-bottom); }
+
+/* Neumorphic theme drops the frosted look in favor of solid bevels. */
+[data-theme-style="neumorphic"] .surface-glass,
+[data-theme-style="neumorphic"] .surface-glass-strong,
+[data-theme-style="neumorphic"] .surface-glass-deep {
+  backdrop-filter: none;
+  -webkit-backdrop-filter: none;
+  background: var(--card);
 }

--- a/shell/src/app/layout.tsx
+++ b/shell/src/app/layout.tsx
@@ -13,6 +13,7 @@ import "./globals.css";
 import { PwaRegister } from "@/components/pwa/PwaRegister";
 import { InstallPrompt } from "@/components/pwa/InstallPrompt";
 import { PostHogIdentify } from "@/components/PostHogIdentify";
+import { Toaster } from "@/components/ui/sonner";
 
 const inter = Inter({
   variable: "--font-inter",
@@ -43,7 +44,20 @@ const orbitron = Orbitron({
 });
 
 export async function generateMetadata(): Promise<Metadata> {
-  return buildShellMetadata(process.env.GATEWAY_URL);
+  const metadata = await buildShellMetadata(process.env.GATEWAY_URL);
+  return {
+    ...metadata,
+    // apple-touch-icon for iOS home-screen install. Next emits this from
+    // icons.apple; reuse the existing app icon (iOS scales 192px down to its
+    // expected 180px target).
+    icons: {
+      icon: [
+        { url: "/icon-192.png", sizes: "192x192", type: "image/png" },
+        { url: "/icon-512.png", sizes: "512x512", type: "image/png" },
+      ],
+      apple: [{ url: "/icon-192.png", sizes: "192x192", type: "image/png" }],
+    },
+  };
 }
 
 export const viewport: Viewport = {
@@ -51,10 +65,15 @@ export const viewport: Viewport = {
   initialScale: 1,
   maximumScale: 1,
   userScalable: false,
+  // Cover the notch/safe-area; let the layout opt into safe-area insets.
   viewportFit: "cover",
+  // On-screen keyboard resizes the layout viewport instead of overlaying it,
+  // so keyboard-aware UI (terminal key bar, toasts) tracks the real height.
+  interactiveWidget: "resizes-content",
+  // Brand-aligned status-bar tint: cream surface in light, forest in dark.
   themeColor: [
-    { media: "(prefers-color-scheme: light)", color: "#f4ede0" },
-    { media: "(prefers-color-scheme: dark)", color: "#3f4a3a" },
+    { media: "(prefers-color-scheme: light)", color: "#E0E1CA" },
+    { media: "(prefers-color-scheme: dark)", color: "#434E3F" },
   ],
 };
 
@@ -84,6 +103,7 @@ export default async function RootLayout({
           <PostHogIdentify />
           <PwaRegister />
           <InstallPrompt />
+          <Toaster />
         </body>
       </html>
     </ClerkProvider>

--- a/shell/src/components/ChatApp.tsx
+++ b/shell/src/components/ChatApp.tsx
@@ -155,6 +155,8 @@ export function ChatApp({
   const [model, setModel] = useState(() => getInitialHermesSetup().model);
   // react-doctor-disable-next-line react-hooks-js/refs -- lazy useState initializer reading the same one-time cached Hermes setup (see model above); ref read is first-render-only.
   const [channels, setChannels] = useState(() => new Set(getInitialHermesSetup().channels));
+  // Comfortable ≥44px touch targets on mobile; unchanged on desktop.
+  const touchIcon = mobile ? "size-9" : "size-8";
   const grouped = groupMessages(messages);
   // react-doctor-disable-next-line react-doctor/react-compiler-no-manual-memoization -- identity is consumed by the writeHermesSetup useEffect dependency array below; keep an explicit useMemo so the persisted-setup effect only re-runs when the channel set actually changes, not on every render.
   const selectedChannels = useMemo(() => Array.from(channels).sort(), [channels]);
@@ -196,7 +198,7 @@ export function ChatApp({
           <Button
             variant="ghost"
             size="icon"
-            className="size-8 text-muted-foreground hover:text-foreground"
+            className={`${touchIcon} text-muted-foreground hover:text-foreground`}
             onClick={() => setSidebarOpen(false)}
           >
             <PanelLeftIcon className="size-4" />
@@ -204,7 +206,7 @@ export function ChatApp({
           <Button
             variant="ghost"
             size="icon"
-            className="size-8 text-muted-foreground hover:text-foreground"
+            className={`${touchIcon} text-muted-foreground hover:text-foreground`}
             onClick={onNewChat}
             title="New chat"
           >
@@ -214,7 +216,7 @@ export function ChatApp({
 
         {/* Search */}
         <div className="px-3 pb-2">
-          <div className="flex items-center gap-2 rounded-lg bg-background/60 px-2.5 py-1.5 text-xs">
+          <div className={`flex items-center gap-2 rounded-lg bg-background/60 px-2.5 text-xs ${mobile ? "py-2.5" : "py-1.5"}`}>
             <SearchIcon className="size-3.5 text-muted-foreground" />
             <input
               type="text"
@@ -240,7 +242,7 @@ export function ChatApp({
                     key={conv.id}
                     type="button"
                     onClick={() => onSwitchConversation(conv.id)}
-                    className={`group flex w-full items-center gap-2 rounded-lg px-2.5 py-2 text-left text-[13px] transition-colors ${
+                    className={`group flex w-full items-center gap-2 rounded-lg px-2.5 text-left text-[13px] transition-colors ${mobile ? "py-3" : "py-2"} ${
                       conv.id === sessionId
                         ? "bg-accent/50 text-foreground"
                         : "text-foreground/70 hover:bg-accent/30 hover:text-foreground"
@@ -256,8 +258,11 @@ export function ChatApp({
               </div>
             ))}
             {conversations.length === 0 && (
-              <div className="px-3 py-8 text-center text-xs text-muted-foreground/50">
-                No conversations yet
+              <div className="flex flex-col items-center gap-2 px-3 py-10 text-center">
+                <span className="inline-flex size-9 items-center justify-center rounded-full bg-foreground/5 text-muted-foreground/60">
+                  <MessageSquareIcon className="size-4" aria-hidden="true" />
+                </span>
+                <p className="text-xs text-muted-foreground/60">No conversations yet</p>
               </div>
             )}
           </div>
@@ -267,13 +272,13 @@ export function ChatApp({
       {/* Main content */}
       <main className="flex flex-1 flex-col min-w-0">
         {/* Top bar */}
-        <header className="flex min-h-12 items-center gap-2 border-b border-border/30 px-3">
+        <header className={`flex items-center gap-2 border-b px-3 ${mobile ? "surface-glass min-h-14" : "min-h-12 border-border/30"}`}>
           {!sidebarOpen && (
             <>
               <Button
                 variant="ghost"
                 size="icon"
-                className="size-8 text-muted-foreground hover:text-foreground"
+                className={`${touchIcon} text-muted-foreground hover:text-foreground`}
                 onClick={() => setSidebarOpen(true)}
               >
                 <PanelLeftIcon className="size-4" />
@@ -281,7 +286,7 @@ export function ChatApp({
               <Button
                 variant="ghost"
                 size="icon"
-                className="size-8 text-muted-foreground hover:text-foreground"
+                className={`${touchIcon} text-muted-foreground hover:text-foreground`}
                 onClick={onNewChat}
                 title="New chat"
               >
@@ -433,7 +438,7 @@ function EmptyState({
                 key={s}
                 type="button"
                 onClick={() => onSubmit(s)}
-                className="rounded-full border border-border/60 bg-card/50 px-3.5 py-1.5 text-xs text-foreground/70 transition-all hover:bg-accent/40 hover:text-foreground hover:border-border"
+                className={`rounded-full border border-border/60 bg-card/50 px-3.5 text-xs text-foreground/70 transition-all hover:bg-accent/40 hover:text-foreground hover:border-border ${mobile ? "py-2.5" : "py-1.5"}`}
               >
                 {s}
               </button>

--- a/shell/src/components/Settings.tsx
+++ b/shell/src/components/Settings.tsx
@@ -247,7 +247,7 @@ export function Settings({
                       }}
                       disabled={locked}
                       aria-label={locked ? `${section.label} Locked until billing is active` : section.label}
-                      className={`flex shrink-0 items-center gap-2.5 rounded-md px-2.5 py-1.5 text-[13px] transition-colors ${
+                      className={`flex shrink-0 items-center gap-2.5 rounded-md px-3 py-2.5 text-[13px] transition-colors sm:px-2.5 sm:py-1.5 ${
                         active
                           ? "bg-ember/12 text-deep font-semibold"
                           : locked

--- a/shell/src/components/file-browser/FileBrowserContent.tsx
+++ b/shell/src/components/file-browser/FileBrowserContent.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { FolderOpenIcon, Loader2Icon } from "lucide-react";
 import { useFileBrowser } from "@/hooks/useFileBrowser";
 import { IconView } from "./IconView";
 import { ListView } from "./ListView";
@@ -24,7 +25,8 @@ export function FileBrowserContent({
 
   if (loading) {
     return (
-      <div className="flex items-center justify-center h-full text-muted-foreground text-sm">
+      <div className="flex items-center justify-center gap-2 h-full text-muted-foreground text-sm">
+        <Loader2Icon className="size-4 animate-spin" aria-hidden="true" />
         Loading...
       </div>
     );
@@ -32,9 +34,14 @@ export function FileBrowserContent({
 
   if (entries.length === 0) {
     return (
-      <div className="flex flex-col items-center justify-center h-full text-muted-foreground gap-2">
-        <div className="text-lg">Empty folder</div>
-        <div className="text-xs">Right-click to create a file or folder</div>
+      <div className="flex flex-col items-center justify-center h-full gap-3 px-6 text-center">
+        <span className="inline-flex size-12 items-center justify-center rounded-2xl bg-foreground/5 text-muted-foreground/60">
+          <FolderOpenIcon className="size-6" aria-hidden="true" />
+        </span>
+        <div className="space-y-1">
+          <p className="text-sm font-medium text-foreground/80">Empty folder</p>
+          <p className="text-xs text-muted-foreground">Nothing here yet</p>
+        </div>
       </div>
     );
   }

--- a/shell/src/components/file-browser/FileBrowserToolbar.tsx
+++ b/shell/src/components/file-browser/FileBrowserToolbar.tsx
@@ -47,14 +47,21 @@ export function FileBrowserToolbar({ mobile = false }: { mobile?: boolean }) {
   };
 
   const pathSegments = currentPath ? currentPath.split("/") : [];
+  // Comfortable ≥44px touch targets on mobile; unchanged on desktop.
+  const navBtn = mobile ? "size-9" : "size-7";
 
   return (
-    <div className="flex items-center gap-2 px-3 py-1.5 border-b border-border bg-background/80 overflow-x-auto">
+    <div
+      className={cn(
+        "flex items-center gap-2 border-b overflow-x-auto",
+        mobile ? "surface-glass px-3 py-2" : "px-3 py-1.5 border-border bg-background/80",
+      )}
+    >
       <div className="flex items-center gap-0.5">
         <Button
           variant="ghost"
           size="icon"
-          className="size-7"
+          className={navBtn}
           disabled={historyIndex <= 0}
           onClick={goBack}
           aria-label="Go back"
@@ -64,7 +71,7 @@ export function FileBrowserToolbar({ mobile = false }: { mobile?: boolean }) {
         <Button
           variant="ghost"
           size="icon"
-          className="size-7"
+          className={navBtn}
           disabled={historyIndex >= history.length - 1}
           onClick={goForward}
           aria-label="Go forward"
@@ -108,7 +115,8 @@ export function FileBrowserToolbar({ mobile = false }: { mobile?: boolean }) {
             variant="ghost"
             size="icon"
             className={cn(
-              "size-7 rounded-none first:rounded-l-md last:rounded-r-md",
+              navBtn,
+              "rounded-none first:rounded-l-md last:rounded-r-md",
               viewMode === mode && "bg-accent",
             )}
             onClick={() => setViewMode(mode)}

--- a/shell/src/components/mobile/MobileAppSurface.tsx
+++ b/shell/src/components/mobile/MobileAppSurface.tsx
@@ -7,23 +7,41 @@ interface MobileAppSurfaceProps {
   title: string;
   onHome: () => void;
   children?: ReactNode;
+  /** Optional actions rendered on the trailing edge of the header. */
+  trailing?: ReactNode;
   unavailableMessage?: string;
 }
 
-export function MobileAppSurface({ title, onHome, children, unavailableMessage }: MobileAppSurfaceProps) {
+export function MobileAppSurface({
+  title,
+  onHome,
+  children,
+  trailing,
+  unavailableMessage,
+}: MobileAppSurfaceProps) {
   return (
-    <section data-testid="mobile-app-surface" className="absolute inset-0 flex flex-col overflow-hidden bg-background text-foreground">
-      <header className="flex min-h-14 shrink-0 items-center gap-3 border-b border-border/50 px-3 pt-[env(safe-area-inset-top)]">
-        <button
-          type="button"
-          data-testid="mobile-home-button"
-          onClick={onHome}
-          className="inline-flex size-10 items-center justify-center rounded-lg border border-border/60 bg-card text-foreground transition active:scale-95"
-          aria-label="Home"
-        >
-          <HomeIcon className="size-4" />
-        </button>
-        <h1 className="min-w-0 flex-1 truncate text-sm font-medium">{title}</h1>
+    <section
+      data-testid="mobile-app-surface"
+      className="absolute inset-0 flex flex-col overflow-hidden bg-background text-foreground"
+    >
+      <header className="surface-glass-strong sticky top-0 z-10 flex shrink-0 items-center gap-2 border-b px-2 pt-[env(safe-area-inset-top)]">
+        <div className="flex min-h-11 w-full items-center gap-2">
+          <button
+            type="button"
+            data-testid="mobile-home-button"
+            onClick={onHome}
+            className="inline-flex size-11 shrink-0 items-center justify-center rounded-xl border border-border/60 bg-card/70 text-foreground transition-transform duration-150 ease-[var(--ease-emphasized)] active:scale-90"
+            aria-label="Home"
+          >
+            <HomeIcon className="size-5" />
+          </button>
+          <h1 className="min-w-0 flex-1 truncate text-center text-[0.95rem] font-medium tracking-tight">
+            {title}
+          </h1>
+          <div className="flex min-h-11 min-w-11 shrink-0 items-center justify-end gap-1">
+            {trailing}
+          </div>
+        </div>
       </header>
       <div className="relative min-h-0 flex-1 overflow-hidden">
         {children ?? (

--- a/shell/src/components/mobile/MobileLauncher.tsx
+++ b/shell/src/components/mobile/MobileLauncher.tsx
@@ -2,6 +2,8 @@
 
 import type { AppEntry } from "@/hooks/useWindowManager";
 import { BrushIcon, ExternalLinkIcon, HomeIcon } from "lucide-react";
+import { motion } from "framer-motion";
+import { fadeUp, staggerContainer, tapScale } from "@/lib/motion";
 
 interface MobileLauncherProps {
   apps: AppEntry[];
@@ -10,7 +12,11 @@ interface MobileLauncherProps {
   resumeApp?: AppEntry | null;
   onResumeApp?: (name: string, path: string) => void;
   onOpenCanvas?: () => void;
+  /** Show placeholder skeletons while the app registry loads. */
+  loading?: boolean;
 }
+
+const SKELETON_KEYS = ["s0", "s1", "s2", "s3", "s4", "s5"] as const;
 
 export function MobileLauncher({
   apps,
@@ -19,16 +25,17 @@ export function MobileLauncher({
   resumeApp,
   onResumeApp,
   onOpenCanvas,
+  loading = false,
 }: MobileLauncherProps) {
   return (
     <section data-testid="mobile-launcher" className="absolute inset-0 flex flex-col bg-background text-foreground">
-      <header className="shrink-0 border-b border-border/50 px-5 pb-4 pt-[calc(env(safe-area-inset-top)+1rem)]">
+      <header className="surface-glass-strong shrink-0 border-b px-5 pb-4 pt-[calc(env(safe-area-inset-top)+1rem)]">
         <div className="flex items-center gap-3">
           <div className="flex size-10 items-center justify-center rounded-xl border border-border/60 bg-card">
             <HomeIcon className="size-5 text-primary" />
           </div>
           <div className="min-w-0">
-            <h1 className="truncate text-lg font-semibold">Matrix</h1>
+            <h1 className="truncate text-lg font-semibold tracking-tight">Matrix</h1>
             <p className="truncate text-xs text-muted-foreground">Apps</p>
           </div>
         </div>
@@ -37,11 +44,12 @@ export function MobileLauncher({
       <div className="min-h-0 flex-1 overflow-y-auto px-4 py-4">
         <div className="mb-3 grid gap-3">
           {resumeApp ? (
-            <button
+            <motion.button
               type="button"
               data-testid="mobile-resume-app"
               onClick={() => (onResumeApp ?? onOpenApp)(resumeApp.name, resumeApp.path)}
-              className="flex min-h-[72px] items-center gap-3 rounded-lg border border-primary/50 bg-card p-3 text-left shadow-sm transition active:scale-[0.98]"
+              {...tapScale}
+              className="flex min-h-[72px] items-center gap-3 rounded-2xl border border-primary/50 bg-card p-3 text-left elevation-2"
             >
               <div className="flex size-11 items-center justify-center rounded-xl bg-primary/15 text-sm font-semibold text-primary">
                 {resumeApp.name.charAt(0).toUpperCase()}
@@ -51,14 +59,15 @@ export function MobileLauncher({
                 <div className="truncate text-sm font-medium">{resumeApp.name}</div>
               </div>
               <ExternalLinkIcon className="size-4 text-primary" aria-hidden />
-            </button>
+            </motion.button>
           ) : null}
           {onOpenCanvas ? (
-            <button
+            <motion.button
               type="button"
               data-testid="mobile-open-canvas"
               onClick={onOpenCanvas}
-              className="flex min-h-[64px] items-center gap-3 rounded-lg border border-border/60 bg-card p-3 text-left shadow-sm transition active:scale-[0.98]"
+              {...tapScale}
+              className="flex min-h-[64px] items-center gap-3 rounded-2xl border border-border/60 bg-card p-3 text-left elevation-1"
             >
               <div className="flex size-10 items-center justify-center rounded-xl bg-secondary text-secondary-foreground">
                 <BrushIcon className="size-4" aria-hidden />
@@ -67,40 +76,64 @@ export function MobileLauncher({
                 <div className="truncate text-sm font-medium">Canvas</div>
                 <div className="truncate text-xs text-muted-foreground">Open spatial workspace</div>
               </div>
-            </button>
+            </motion.button>
           ) : null}
         </div>
-        <div className="grid grid-cols-2 gap-3">
-          {apps.map((app) => {
-            const open = openWindowPaths.has(app.path);
-            return (
-              <button
-                key={app.path}
-                type="button"
-                data-testid={`mobile-launcher-app-${app.path}`}
-                onClick={() => onOpenApp(app.name, app.path)}
-                className="min-h-[118px] rounded-lg border border-border/60 bg-card p-3 text-left shadow-sm transition active:scale-[0.98]"
+
+        {loading ? (
+          <div className="grid grid-cols-2 gap-3" aria-hidden>
+            {SKELETON_KEYS.map((key) => (
+              <div
+                key={key}
+                data-slot="skeleton"
+                className="min-h-[118px] animate-pulse rounded-2xl border border-border/40 bg-card/60 p-3"
               >
-                <div className="flex items-start justify-between gap-2">
-                  <div className="flex size-12 items-center justify-center rounded-xl bg-secondary text-sm font-semibold text-secondary-foreground">
-                    {app.name.charAt(0).toUpperCase()}
+                <div className="size-12 rounded-xl bg-muted/70" />
+                <div className="mt-4 h-3 w-2/3 rounded bg-muted/70" />
+                <div className="mt-2 h-2.5 w-1/2 rounded bg-muted/50" />
+              </div>
+            ))}
+          </div>
+        ) : (
+          <motion.div
+            className="grid grid-cols-2 gap-3"
+            variants={staggerContainer()}
+            initial="initial"
+            animate="animate"
+          >
+            {apps.map((app) => {
+              const open = openWindowPaths.has(app.path);
+              return (
+                <motion.button
+                  key={app.path}
+                  type="button"
+                  data-testid={`mobile-launcher-app-${app.path}`}
+                  onClick={() => onOpenApp(app.name, app.path)}
+                  variants={fadeUp}
+                  {...tapScale}
+                  className="min-h-[118px] rounded-2xl border border-border/60 bg-card p-3 text-left elevation-1"
+                >
+                  <div className="flex items-start justify-between gap-2">
+                    <div className="flex size-12 items-center justify-center rounded-xl bg-secondary text-sm font-semibold text-secondary-foreground">
+                      {app.name.charAt(0).toUpperCase()}
+                    </div>
+                    {open ? (
+                      <span className="inline-flex size-2.5 rounded-full bg-primary" aria-label="Open" />
+                    ) : (
+                      <ExternalLinkIcon className="size-4 text-muted-foreground" aria-hidden />
+                    )}
                   </div>
-                  {open ? (
-                    <span className="inline-flex size-2.5 rounded-full bg-primary" aria-label="Open" />
-                  ) : (
-                    <ExternalLinkIcon className="size-4 text-muted-foreground" aria-hidden />
-                  )}
-                </div>
-                <div className="mt-3 min-w-0">
-                  <div className="truncate text-sm font-medium">{app.name}</div>
-                  <div className="mt-1 truncate text-xs text-muted-foreground">
-                    {open ? "Open" : app.path.replace(/^apps\//, "").replace(/\/index\.html$/, "")}
+                  <div className="mt-3 min-w-0">
+                    <div className="truncate text-sm font-medium">{app.name}</div>
+                    <div className="mt-1 truncate text-xs text-muted-foreground">
+                      {open ? "Open" : app.path.replace(/^apps\//, "").replace(/\/index\.html$/, "")}
+                    </div>
                   </div>
-                </div>
-              </button>
-            );
-          })}
-        </div>
+                </motion.button>
+              );
+            })}
+          </motion.div>
+        )}
       </div>
     </section>
   );

--- a/shell/src/components/mobile/MobileQuickActions.tsx
+++ b/shell/src/components/mobile/MobileQuickActions.tsx
@@ -1,0 +1,120 @@
+"use client";
+
+import type { ReactNode } from "react";
+import { useState } from "react";
+import { LayersIcon, SettingsIcon, XCircleIcon, type LucideIcon } from "lucide-react";
+import {
+  Drawer,
+  DrawerClose,
+  DrawerContent,
+  DrawerHeader,
+  DrawerTitle,
+  DrawerTrigger,
+} from "@/components/ui/drawer";
+
+interface MobileQuickActionsProps {
+  openStackCount: number;
+  onOpenSettings: () => void;
+  onShowSwitcher: () => void;
+  onCloseAll: () => void;
+}
+
+/**
+ * Launcher quick-actions menu rendered as a brand-themed vaul bottom-sheet
+ * (drag handle, snap-to-dismiss). Establishes the mobile bottom-sheet pattern
+ * for the shell. Each action closes the sheet before invoking its handler.
+ */
+export function MobileQuickActions({
+  openStackCount,
+  onOpenSettings,
+  onShowSwitcher,
+  onCloseAll,
+}: MobileQuickActionsProps) {
+  const [open, setOpen] = useState(false);
+  const hasOpenApps = openStackCount > 0;
+
+  const run = (action: () => void) => {
+    setOpen(false);
+    action();
+  };
+
+  return (
+    <Drawer open={open} onOpenChange={setOpen}>
+      <DrawerTrigger asChild>
+        <button
+          type="button"
+          aria-label="Quick actions"
+          className="inline-flex size-9 items-center justify-center rounded-full border border-[var(--surface-glass-border)] bg-[color-mix(in_srgb,var(--foreground)_6%,transparent)] text-foreground transition-transform duration-150 ease-[var(--ease-emphasized)] active:scale-90"
+        >
+          <SettingsIcon className="size-4" />
+        </button>
+      </DrawerTrigger>
+      <DrawerContent>
+        <DrawerHeader>
+          <DrawerTitle>Quick actions</DrawerTitle>
+        </DrawerHeader>
+        <div className="flex flex-col gap-1.5 px-4 pb-2">
+          <ActionRow
+            icon={SettingsIcon}
+            label="Settings"
+            onClick={() => run(onOpenSettings)}
+          />
+          {hasOpenApps && (
+            <ActionRow
+              icon={LayersIcon}
+              label="App switcher"
+              detail={`${openStackCount} open`}
+              onClick={() => run(onShowSwitcher)}
+            />
+          )}
+          {hasOpenApps && (
+            <ActionRow
+              icon={XCircleIcon}
+              label="Close all apps"
+              destructive
+              onClick={() => run(onCloseAll)}
+            />
+          )}
+        </div>
+        <div className="px-4 pb-4 pt-1">
+          <DrawerClose asChild>
+            <button
+              type="button"
+              className="w-full rounded-xl border border-[var(--surface-glass-border)] bg-[color-mix(in_srgb,var(--foreground)_6%,transparent)] py-3 text-sm font-medium text-foreground transition-transform duration-150 ease-[var(--ease-emphasized)] active:scale-[0.98]"
+            >
+              Cancel
+            </button>
+          </DrawerClose>
+        </div>
+      </DrawerContent>
+    </Drawer>
+  );
+}
+
+function ActionRow({
+  icon: Icon,
+  label,
+  detail,
+  destructive,
+  onClick,
+}: {
+  icon: LucideIcon;
+  label: string;
+  detail?: string;
+  destructive?: boolean;
+  onClick: () => void;
+}): ReactNode {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={`flex min-h-12 w-full items-center gap-3 rounded-xl px-3 text-left text-sm transition-colors active:bg-[color-mix(in_srgb,var(--foreground)_8%,transparent)] ${
+        destructive ? "text-destructive" : "text-foreground"
+      }`}
+    >
+      <Icon className="size-5 shrink-0 opacity-80" />
+      <span className="flex-1 font-medium">{label}</span>
+      {detail && <span className="text-xs text-muted-foreground">{detail}</span>}
+    </button>
+  );
+}

--- a/shell/src/components/mobile/MobileShell.tsx
+++ b/shell/src/components/mobile/MobileShell.tsx
@@ -21,6 +21,8 @@
 import type { CSSProperties } from "react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { AnimatePresence, motion, MotionConfig, type PanInfo } from "framer-motion";
+import { toast } from "sonner";
+import { MobileQuickActions } from "@/components/mobile/MobileQuickActions";
 import {
   appTransition,
   EASE_EMPHASIZED,
@@ -248,6 +250,7 @@ export function MobileShell({ launchAppPath, onOpenCommandPalette }: MobileShell
   }, [apps, launchAppPath, openApp]);
 
   const closeApp = (openId: string) => {
+    const closed = stackRef.current.find((o) => o.id === openId);
     setOpenStack((prev) => {
       const next = prev.filter((o) => o.id !== openId);
       if (next.length === 0) {
@@ -255,11 +258,14 @@ export function MobileShell({ launchAppPath, onOpenCommandPalette }: MobileShell
       }
       return next;
     });
+    if (closed) toast(`Closed ${closed.app.name}`);
   };
 
   const closeAll = () => {
+    const count = stackRef.current.length;
     setOpenStack([]);
     setView("launcher");
+    if (count > 0) toast(`Closed ${count} app${count === 1 ? "" : "s"}`);
   };
 
   const showSwitcher = () => {
@@ -383,6 +389,7 @@ export function MobileShell({ launchAppPath, onOpenCommandPalette }: MobileShell
                 onOpenSettings={() => setSettingsOpen(true)}
                 openStackCount={openStack.length}
                 onShowSwitcher={showSwitcher}
+                onCloseAll={closeAll}
               />
             </motion.div>
           )}
@@ -532,9 +539,10 @@ interface LauncherProps {
   onOpenSettings: () => void;
   openStackCount: number;
   onShowSwitcher: () => void;
+  onCloseAll: () => void;
 }
 
-function Launcher({ apps, onOpen, onOpenSettings, openStackCount, onShowSwitcher }: LauncherProps) {
+function Launcher({ apps, onOpen, onOpenSettings, openStackCount, onShowSwitcher, onCloseAll }: LauncherProps) {
   return (
     <div className="flex h-full flex-col">
       <div className="flex items-center justify-between px-5 pt-4 pb-3">
@@ -544,39 +552,12 @@ function Launcher({ apps, onOpen, onOpenSettings, openStackCount, onShowSwitcher
             {apps.length} installed{openStackCount > 0 ? ` · ${openStackCount} open` : ""}
           </div>
         </div>
-        <div style={{ display: "flex", gap: 8 }}>
-          {openStackCount > 0 && (
-            <button
-              onClick={onShowSwitcher}
-              type="button"
-              style={{
-                background: "rgba(244,237,224,0.08)",
-                color: "inherit",
-                border: "1px solid rgba(244,237,224,0.12)",
-                borderRadius: 999,
-                padding: "6px 12px",
-                fontSize: 12,
-              }}
-            >
-              Switcher
-            </button>
-          )}
-          <button
-            onClick={onOpenSettings}
-            type="button"
-            aria-label="Settings"
-            style={{
-              background: "rgba(244,237,224,0.08)",
-              color: "inherit",
-              border: "1px solid rgba(244,237,224,0.12)",
-              borderRadius: 999,
-              padding: "6px 10px",
-              fontSize: 12,
-            }}
-          >
-            ⚙
-          </button>
-        </div>
+        <MobileQuickActions
+          openStackCount={openStackCount}
+          onOpenSettings={onOpenSettings}
+          onShowSwitcher={onShowSwitcher}
+          onCloseAll={onCloseAll}
+        />
       </div>
       <motion.div
         className="flex-1 overflow-y-auto"

--- a/shell/src/components/mobile/MobileShell.tsx
+++ b/shell/src/components/mobile/MobileShell.tsx
@@ -20,6 +20,14 @@
 
 import type { CSSProperties } from "react";
 import { useCallback, useEffect, useRef, useState } from "react";
+import { AnimatePresence, motion, MotionConfig, type PanInfo } from "framer-motion";
+import {
+  appTransition,
+  EASE_EMPHASIZED,
+  fadeUp,
+  staggerContainer,
+  tapScale,
+} from "@/lib/motion";
 import { useChatContext } from "@/stores/chat-context";
 import { iconUrlForSlug } from "@/lib/app-launch";
 import { getGatewayUrl } from "@/lib/gateway";
@@ -80,15 +88,20 @@ const LAUNCHER_APP_LABEL_STYLE: CSSProperties = {
 };
 
 const SWITCHER_CLOSE_BUTTON_STYLE: CSSProperties = {
-  background: "transparent",
-  border: "1px solid rgba(244,237,224,0.18)",
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "center",
+  flexShrink: 0,
+  background: "color-mix(in srgb, var(--foreground) 6%, transparent)",
+  border: "1px solid color-mix(in srgb, var(--foreground) 14%, transparent)",
   color: "inherit",
   borderRadius: 999,
-  width: 28,
-  height: 28,
+  width: 44,
+  height: 44,
   cursor: "pointer",
-  opacity: 0.75,
-  fontSize: 12,
+  opacity: 0.85,
+  fontSize: 20,
+  lineHeight: 1,
 };
 
 const SWITCHER_RESUME_BUTTON_STYLE: CSSProperties = {
@@ -287,6 +300,7 @@ export function MobileShell({ launchAppPath, onOpenCommandPalette }: MobileShell
   }, []);
 
   return (
+    <MotionConfig reducedMotion="user">
     <div
       data-testid="mobile-shell"
       className="flex h-full w-full flex-col"
@@ -327,53 +341,82 @@ export function MobileShell({ launchAppPath, onOpenCommandPalette }: MobileShell
           const isTop = i === openStack.length - 1;
           const visible = view === "app" && isTop;
           return (
-            <div
+            <motion.div
               key={o.id}
               aria-hidden={!visible}
+              // Kept mounted (never unmounted) to preserve live app state such as
+              // terminal sessions; we animate opacity/transform instead of
+              // toggling `visibility`, so foregrounding an app slides + fades in.
+              initial={false}
+              animate={
+                visible
+                  ? { opacity: 1, y: 0, scale: 1 }
+                  : { opacity: 0, y: 16, scale: 0.985 }
+              }
+              transition={{ duration: 0.32, ease: EASE_EMPHASIZED }}
               style={{
                 position: "absolute",
                 inset: 0,
-                display: "block",
-                visibility: visible ? "visible" : "hidden",
                 pointerEvents: visible ? "auto" : "none",
                 background: "var(--background)",
               }}
             >
               <MobileAppFrame app={o.app} openId={o.id} chat={chat} />
-            </div>
+            </motion.div>
           );
         })}
 
-        {view === "launcher" && (
-          <Launcher
-            apps={apps}
-            onOpen={openApp}
-            onOpenSettings={() => setSettingsOpen(true)}
-            openStackCount={openStack.length}
-            onShowSwitcher={showSwitcher}
-          />
-        )}
+        <AnimatePresence initial={false}>
+          {view === "launcher" && (
+            <motion.div
+              key="launcher"
+              className="absolute inset-0"
+              style={{ background: "var(--background)" }}
+              variants={appTransition}
+              initial="initial"
+              animate="animate"
+              exit="exit"
+            >
+              <Launcher
+                apps={apps}
+                onOpen={openApp}
+                onOpenSettings={() => setSettingsOpen(true)}
+                openStackCount={openStack.length}
+                onShowSwitcher={showSwitcher}
+              />
+            </motion.div>
+          )}
 
-        {view === "switcher" && (
-          <AppSwitcher
-            open={openStack}
-            onResume={() => setView("app")}
-            onSelect={(id) => {
-              setOpenStack((prev) => {
-                const idx = prev.findIndex((o) => o.id === id);
-                if (idx < 0) return prev;
-                const next = prev.slice();
-                const [taken] = next.splice(idx, 1);
-                next.push(taken);
-                return next;
-              });
-              setView("app");
-            }}
-            onClose={closeApp}
-            onCloseAll={closeAll}
-            onBack={() => setView(top ? "app" : "launcher")}
-          />
-        )}
+          {view === "switcher" && (
+            <motion.div
+              key="switcher"
+              className="absolute inset-0"
+              variants={appTransition}
+              initial="initial"
+              animate="animate"
+              exit="exit"
+            >
+              <AppSwitcher
+                open={openStack}
+                onResume={() => setView("app")}
+                onSelect={(id) => {
+                  setOpenStack((prev) => {
+                    const idx = prev.findIndex((o) => o.id === id);
+                    if (idx < 0) return prev;
+                    const next = prev.slice();
+                    const [taken] = next.splice(idx, 1);
+                    next.push(taken);
+                    return next;
+                  });
+                  setView("app");
+                }}
+                onClose={closeApp}
+                onCloseAll={closeAll}
+                onBack={() => setView(top ? "app" : "launcher")}
+              />
+            </motion.div>
+          )}
+        </AnimatePresence>
       </main>
 
       <nav
@@ -423,6 +466,7 @@ export function MobileShell({ launchAppPath, onOpenCommandPalette }: MobileShell
 
       <Settings open={settingsOpen} onOpenChange={setSettingsOpen} />
     </div>
+    </MotionConfig>
   );
 }
 
@@ -534,8 +578,11 @@ function Launcher({ apps, onOpen, onOpenSettings, openStackCount, onShowSwitcher
           </button>
         </div>
       </div>
-      <div
+      <motion.div
         className="flex-1 overflow-y-auto"
+        variants={staggerContainer()}
+        initial="initial"
+        animate="animate"
         style={{
           display: "grid",
           gridTemplateColumns: "repeat(4, minmax(0,1fr))",
@@ -545,17 +592,19 @@ function Launcher({ apps, onOpen, onOpenSettings, openStackCount, onShowSwitcher
         }}
       >
         {apps.map((app) => (
-          <button
+          <motion.button
             key={app.id}
             type="button"
             onClick={() => onOpen(app)}
+            variants={fadeUp}
+            {...tapScale}
             style={LAUNCHER_APP_BUTTON_STYLE}
           >
             <AppIcon slug={app.iconSlug} size={56} />
             <span style={LAUNCHER_APP_LABEL_STYLE}>{app.name}</span>
-          </button>
+          </motion.button>
         ))}
-      </div>
+      </motion.div>
     </div>
   );
 }
@@ -606,7 +655,10 @@ function AppSwitcher({
           Close all
         </button>
       </div>
-      <div
+      <motion.div
+        variants={staggerContainer(0.05)}
+        initial="initial"
+        animate="animate"
         style={{
           flex: 1,
           overflowY: "auto",
@@ -620,16 +672,26 @@ function AppSwitcher({
           .slice()
           .reverse()
           .map((o) => (
-            <div
+            <motion.div
               key={o.id}
+              layout
+              variants={fadeUp}
+              // Swipe a card left/right to dismiss the app (≥96px throw).
+              drag="x"
+              dragConstraints={{ left: 0, right: 0 }}
+              dragElastic={0.12}
+              onDragEnd={(_, info: PanInfo) => {
+                if (Math.abs(info.offset.x) > 96) onClose(o.id);
+              }}
+              whileDrag={{ scale: 0.98, cursor: "grabbing" }}
+              className="surface-glass elevation-2 border"
               style={{
-                background: "var(--card, rgba(244,237,224,0.06))",
-                border: "1px solid rgba(244,237,224,0.12)",
                 borderRadius: 18,
                 padding: 14,
                 display: "flex",
                 gap: 12,
                 alignItems: "center",
+                touchAction: "pan-y",
               }}
             >
               <AppIcon slug={o.app.iconSlug} size={44} />
@@ -651,22 +713,38 @@ function AppSwitcher({
                   Opened {new Date(o.openedAt).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" })}
                 </div>
               </button>
-              <button
+              <motion.button
                 onClick={() => onClose(o.id)}
                 type="button"
                 aria-label={`Close ${o.app.name}`}
+                whileTap={{ scale: 0.85 }}
+                whileHover={{ rotate: 90 }}
+                transition={{ duration: 0.18, ease: EASE_EMPHASIZED }}
                 style={SWITCHER_CLOSE_BUTTON_STYLE}
               >
                 ×
-              </button>
-            </div>
+              </motion.button>
+            </motion.div>
           ))}
         {open.length > 0 && (
-          <button onClick={onResume} type="button" style={SWITCHER_RESUME_BUTTON_STYLE}>
-            Resume foreground app
-          </button>
+          <>
+            <p
+              aria-hidden
+              style={{ fontSize: 11, textAlign: "center", opacity: 0.4, marginTop: 2 }}
+            >
+              Swipe a card aside to close
+            </p>
+            <motion.button
+              onClick={onResume}
+              type="button"
+              {...tapScale}
+              style={SWITCHER_RESUME_BUTTON_STYLE}
+            >
+              Resume foreground app
+            </motion.button>
+          </>
         )}
-      </div>
+      </motion.div>
     </div>
   );
 }

--- a/shell/src/components/terminal/TerminalKeyBar.tsx
+++ b/shell/src/components/terminal/TerminalKeyBar.tsx
@@ -269,7 +269,8 @@ export function TerminalKeyBar({
           setPasteFallbackOpen(true);
         }
       })
-      .catch(() => {
+      .catch((err: unknown) => {
+        console.warn("[TerminalKeyBar] clipboard read failed:", err instanceof Error ? err.message : typeof err);
         setPasteFallbackOpen(true);
       });
   };

--- a/shell/src/components/terminal/TerminalKeyBar.tsx
+++ b/shell/src/components/terminal/TerminalKeyBar.tsx
@@ -238,6 +238,7 @@ export function TerminalKeyBar({
     };
   }, [viewportHeight, keyboardOpen]);
 
+  // react-doctor-disable-next-line react-doctor/exhaustive-deps -- unmount cleanup must clear the latest long-press timeout ref; capturing the initial value would leak timers created after mount
   useEffect(() => {
     return () => {
       if (longPressTimerRef.current) clearTimeout(longPressTimerRef.current);

--- a/shell/src/components/terminal/TerminalKeyBar.tsx
+++ b/shell/src/components/terminal/TerminalKeyBar.tsx
@@ -1,14 +1,22 @@
 "use client";
 
 /**
- * Compact mobile terminal keyboard.
+ * Compact mobile terminal keyboard (spec 102 — terminal mobile polish).
  *
- * Collapsed mode is a one-row command strip. Expanded mode switches to a
- * fitted keyboard with ABC/Sym/Nav layers so phone users can type without
- * losing most of the terminal viewport or fighting horizontal clipping.
+ * Collapsed mode is a one-row, horizontally-scrollable command strip. Expanded
+ * mode switches to a fitted keyboard with ABC/Sym/Nav layers so phone users can
+ * type without losing most of the terminal viewport or fighting horizontal
+ * clipping.
+ *
+ * Styling is driven by brand tokens (radius / elevation / emphasized easing)
+ * layered on the terminal chrome colors passed in as props, so the bar always
+ * matches the active terminal theme. Pressed/active states, ≥44px touch targets
+ * and a paste affordance (clipboard read + iOS <input> fallback) live here.
  */
 
-import { useEffect, useState, type CSSProperties } from "react";
+import { useEffect, useRef, useState, type CSSProperties } from "react";
+import { ClipboardPasteIcon } from "lucide-react";
+import { useVisualViewport } from "@/hooks/useVisualViewport";
 
 type KeyboardMode = "abc" | "sym" | "nav";
 
@@ -81,56 +89,112 @@ const NAV_ROWS: KeyDef[][] = [
   ],
 ];
 
-interface TerminalKeyBarProps {
-  onSend: (data: string) => void;
-  background?: string;
-  foreground?: string;
-  accent?: string;
-}
-
 const MODE_LABELS: Record<KeyboardMode, string> = {
   abc: "ABC",
   sym: "Sym",
   nav: "Nav",
 };
 
-const KEY_BUTTON_BASE_STYLE: CSSProperties = {
-  height: 34,
-  minWidth: 34,
-  borderRadius: 7,
-  fontFamily: "var(--font-mono, ui-monospace, monospace)",
-  fontSize: 15,
-  lineHeight: 1,
-  cursor: "pointer",
-  touchAction: "manipulation",
-};
+// Bracketed-paste so multi-line clipboard content lands on the prompt as a
+// single literal block (no implicit execution) — the user reviews it before
+// pressing Enter. Mirrors the terminal pane's paste handling.
+const BRACKETED_PASTE_OPEN = "\x1b[200~";
+const BRACKETED_PASTE_CLOSE = "\x1b[201~";
+const MAX_PASTE_LENGTH = 65_536 - BRACKETED_PASTE_OPEN.length - BRACKETED_PASTE_CLOSE.length;
+const LONG_PRESS_MS = 450;
 
-function readVisualViewportKeyboardInset(): number {
-  if (typeof window === "undefined" || !window.visualViewport) return 0;
-  const inset = window.innerHeight - window.visualViewport.height - window.visualViewport.offsetTop;
-  return Math.max(0, Math.round(inset));
+// Brand-token-driven styling for the whole bar. Scoped under .mtk-bar so it
+// never leaks; colors resolve from per-instance --mtk-* vars set from props.
+const KEYBAR_CSS = `
+.mtk-bar {
+  --mtk-key-bg: color-mix(in srgb, var(--mtk-fg) 9%, transparent);
+  --mtk-key-bg-press: color-mix(in srgb, var(--mtk-accent) 26%, transparent);
+  --mtk-key-border: color-mix(in srgb, var(--mtk-fg) 16%, transparent);
+  --mtk-muted: color-mix(in srgb, var(--mtk-fg) 62%, transparent);
 }
+.mtk-key,
+.mtk-tab,
+.mtk-ghost {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  min-height: 44px;
+  border-radius: var(--radius-sm, 8px);
+  font-family: var(--font-mono, ui-monospace, monospace);
+  line-height: 1;
+  cursor: pointer;
+  touch-action: manipulation;
+  user-select: none;
+  -webkit-user-select: none;
+  -webkit-tap-highlight-color: transparent;
+  transition:
+    transform 140ms var(--ease-emphasized, ease),
+    background-color 140ms var(--ease-emphasized, ease),
+    border-color 140ms var(--ease-emphasized, ease);
+}
+.mtk-key {
+  min-width: 36px;
+  padding: 0 6px;
+  border: 1px solid var(--mtk-key-border);
+  background: var(--mtk-key-bg);
+  color: var(--mtk-fg);
+  font-size: 15px;
+  font-weight: 650;
+}
+.mtk-key:active {
+  transform: scale(0.93);
+  background: var(--mtk-key-bg-press);
+  border-color: color-mix(in srgb, var(--mtk-accent) 55%, transparent);
+}
+.mtk-key--wide { font-weight: 700; }
+.mtk-key--accent {
+  border-color: color-mix(in srgb, var(--mtk-accent) 60%, transparent);
+  background: color-mix(in srgb, var(--mtk-accent) 18%, transparent);
+}
+.mtk-tab {
+  padding: 0 8px;
+  border: 1px solid var(--mtk-key-border);
+  background: var(--mtk-key-bg);
+  color: var(--mtk-fg);
+  font-size: 12px;
+  font-weight: 700;
+}
+.mtk-tab[aria-selected="true"] {
+  border-color: color-mix(in srgb, var(--mtk-accent) 70%, transparent);
+  background: color-mix(in srgb, var(--mtk-accent) 24%, transparent);
+}
+.mtk-tab:active { transform: scale(0.95); }
+.mtk-ghost {
+  min-width: 48px;
+  padding: 0 10px;
+  border: 1px dashed color-mix(in srgb, var(--mtk-accent) 55%, transparent);
+  background: transparent;
+  color: var(--mtk-muted);
+  font-size: 12px;
+  font-weight: 650;
+}
+.mtk-ghost:active { transform: scale(0.95); }
+.mtk-scroll {
+  -ms-overflow-style: none;
+  scrollbar-width: none;
+}
+.mtk-scroll::-webkit-scrollbar { display: none; }
+@media (prefers-reduced-motion: reduce) {
+  .mtk-key,
+  .mtk-tab,
+  .mtk-ghost { transition: none; }
+  .mtk-key:active,
+  .mtk-tab:active,
+  .mtk-ghost:active { transform: none; }
+}
+`;
 
-function useVisualViewportKeyboardInset(): number {
-  const [inset, setInset] = useState(0);
-
-  useEffect(() => {
-    if (typeof window === "undefined" || !window.visualViewport) return;
-    const viewport = window.visualViewport;
-    const update = () => setInset(readVisualViewportKeyboardInset());
-    // react-doctor-disable-next-line react-doctor/no-initialize-state -- viewport subscription: initial SSR-safe 0 is resynced once on mount and then from visualViewport callbacks.
-    update();
-    viewport.addEventListener("resize", update);
-    viewport.addEventListener("scroll", update, { passive: true });
-    window.addEventListener("orientationchange", update);
-    return () => {
-      viewport.removeEventListener("resize", update);
-      viewport.removeEventListener("scroll", update);
-      window.removeEventListener("orientationchange", update);
-    };
-  }, []);
-
-  return inset;
+interface TerminalKeyBarProps {
+  onSend: (data: string) => void;
+  background?: string;
+  foreground?: string;
+  accent?: string;
 }
 
 function rowsForMode(mode: KeyboardMode): KeyDef[][] {
@@ -139,11 +203,11 @@ function rowsForMode(mode: KeyboardMode): KeyDef[][] {
   return ABC_ROWS;
 }
 
-function compactWidthForKey(keyDef: KeyDef): number {
-  if (keyDef.ariaLabel === "Enter") return 50;
-  if (keyDef.ariaLabel === "Control C") return 56;
-  if (keyDef.ariaLabel?.endsWith("arrow")) return 32;
-  return 34;
+function compactFlexForKey(keyDef: KeyDef): string {
+  if (keyDef.ariaLabel === "Enter") return "0 0 56px";
+  if (keyDef.ariaLabel === "Control C") return "0 0 60px";
+  if (keyDef.ariaLabel?.endsWith("arrow")) return "0 0 40px";
+  return "0 0 44px";
 }
 
 export function TerminalKeyBar({
@@ -154,37 +218,172 @@ export function TerminalKeyBar({
 }: TerminalKeyBarProps) {
   const [expanded, setExpanded] = useState(false);
   const [mode, setMode] = useState<KeyboardMode>("abc");
-  const keyboardInset = useVisualViewportKeyboardInset();
+  const [pasteFallbackOpen, setPasteFallbackOpen] = useState(false);
+  const pasteInputRef = useRef<HTMLInputElement>(null);
+  const longPressTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const longPressedRef = useRef(false);
+  const { height: viewportHeight, keyboardOpen } = useVisualViewport();
 
-  const buttonBackground = `color-mix(in srgb, ${foreground} 10%, transparent)`;
-  const buttonBorder = `color-mix(in srgb, ${foreground} 18%, transparent)`;
-  const mutedForeground = `color-mix(in srgb, ${foreground} 66%, transparent)`;
-  const bottomInset = keyboardInset > 0 ? `${keyboardInset}px` : "env(keyboard-inset-height, 0px)";
+  // Publish the live on-screen-keyboard height so this bar (and toasts/sheets)
+  // can pin themselves just above the iOS keyboard. `innerHeight` is the layout
+  // viewport (it doesn't shrink for the keyboard on iOS); the visual viewport
+  // does, so the difference is the keyboard band. Reset to 0 on unmount.
+  useEffect(() => {
+    if (typeof document === "undefined") return;
+    const root = document.documentElement;
+    const keyboardHeight = keyboardOpen ? Math.max(0, window.innerHeight - viewportHeight) : 0;
+    root.style.setProperty("--terminal-keyboard-height", `${Math.round(keyboardHeight)}px`);
+    return () => {
+      root.style.setProperty("--terminal-keyboard-height", "0px");
+    };
+  }, [viewportHeight, keyboardOpen]);
+
+  useEffect(() => {
+    return () => {
+      if (longPressTimerRef.current) clearTimeout(longPressTimerRef.current);
+    };
+  }, []);
+
+  const sendPaste = (text: string) => {
+    const safe = text.replace(/\x1b\[20[01]~/g, "").slice(0, MAX_PASTE_LENGTH);
+    if (!safe) return;
+    // No trailing Enter — bracketed paste drops the block onto the prompt for
+    // the user to review and send themselves.
+    onSend(`${BRACKETED_PASTE_OPEN}${safe}${BRACKETED_PASTE_CLOSE}`);
+  };
+
+  const runClipboardPaste = () => {
+    // navigator.clipboard is undefined on insecure-origin mobile browsers and
+    // WebViews with a denied clipboard policy; fall back to a manual <input>.
+    const clipboard = typeof navigator !== "undefined" ? navigator.clipboard : undefined;
+    if (!clipboard?.readText) {
+      setPasteFallbackOpen(true);
+      return;
+    }
+    clipboard
+      .readText()
+      .then((text) => {
+        if (text) {
+          sendPaste(text);
+        } else {
+          setPasteFallbackOpen(true);
+        }
+      })
+      .catch(() => {
+        setPasteFallbackOpen(true);
+      });
+  };
+
+  const cancelLongPress = () => {
+    if (longPressTimerRef.current) {
+      clearTimeout(longPressTimerRef.current);
+      longPressTimerRef.current = null;
+    }
+  };
+
+  const handlePastePointerDown = () => {
+    longPressedRef.current = false;
+    cancelLongPress();
+    longPressTimerRef.current = setTimeout(() => {
+      longPressedRef.current = true;
+      setPasteFallbackOpen(true);
+    }, LONG_PRESS_MS);
+  };
+
+  const handlePasteClick = () => {
+    cancelLongPress();
+    // Long-press already opened the manual fallback; don't also read clipboard.
+    if (longPressedRef.current) {
+      longPressedRef.current = false;
+      return;
+    }
+    runClipboardPaste();
+  };
+
+  const submitPasteFallback = () => {
+    const input = pasteInputRef.current;
+    if (input && input.value) {
+      sendPaste(input.value);
+      input.value = "";
+    }
+    setPasteFallbackOpen(false);
+  };
+
+  const barStyle = {
+    "--mtk-bg": background,
+    "--mtk-fg": foreground,
+    "--mtk-accent": accent,
+    display: "flex",
+    alignItems: "stretch",
+    flexDirection: "column",
+    gap: 6,
+    padding: "7px 6px max(7px, env(safe-area-inset-bottom))",
+    position: "sticky",
+    bottom: "var(--terminal-keyboard-height, 0px)",
+    zIndex: 5,
+    background: "var(--mtk-bg)",
+    borderTop: "1px solid color-mix(in srgb, var(--mtk-fg) 16%, transparent)",
+    overflow: "hidden",
+    flexShrink: 0,
+    touchAction: "none",
+    WebkitOverflowScrolling: "touch",
+    boxShadow: "var(--elevation-3, 0 -10px 20px color-mix(in srgb, var(--mtk-bg) 70%, transparent))",
+  } as CSSProperties & Record<"--mtk-bg" | "--mtk-fg" | "--mtk-accent", string>;
 
   return (
     <div
+      className="mtk-bar"
       role="toolbar"
       aria-label="Terminal accessory keys"
       data-testid="terminal-key-bar"
-      style={{
-        "--matrix-terminal-keybar-bottom": bottomInset,
-        display: "flex",
-        alignItems: "stretch",
-        flexDirection: "column",
-        gap: 5,
-        padding: "6px 5px max(6px, env(safe-area-inset-bottom))",
-        position: "sticky",
-        bottom: "var(--matrix-terminal-keybar-bottom)",
-        zIndex: 5,
-        background,
-        borderTop: `1px solid ${buttonBorder}`,
-        overflow: "hidden",
-        flexShrink: 0,
-        touchAction: "none",
-        WebkitOverflowScrolling: "touch",
-        boxShadow: `0 -10px 20px color-mix(in srgb, ${background} 70%, transparent)`,
-      } as CSSProperties & Record<"--matrix-terminal-keybar-bottom", string>}
+      style={barStyle}
     >
+      <style>{KEYBAR_CSS}</style>
+
+      {pasteFallbackOpen && (
+        <div style={{ display: "flex", alignItems: "center", gap: 6 }}>
+          <input
+            ref={pasteInputRef}
+            aria-label="Paste text"
+            placeholder="Long-press here, paste, then Send"
+            autoCapitalize="none"
+            autoCorrect="off"
+            spellCheck={false}
+            // 16px keeps iOS Safari from zooming the viewport on focus.
+            style={{
+              flex: "1 1 auto",
+              minWidth: 0,
+              height: 44,
+              padding: "0 12px",
+              borderRadius: "var(--radius-sm, 8px)",
+              border: "1px solid color-mix(in srgb, var(--mtk-fg) 18%, transparent)",
+              background: "color-mix(in srgb, var(--mtk-fg) 8%, transparent)",
+              color: "var(--mtk-fg)",
+              fontFamily: "var(--font-mono, ui-monospace, monospace)",
+              fontSize: 16,
+            }}
+            onKeyDown={(event) => {
+              if (event.key === "Enter") {
+                event.preventDefault();
+                submitPasteFallback();
+              }
+            }}
+          />
+          <button type="button" className="mtk-key mtk-key--accent" onPointerDown={(e) => e.preventDefault()} onClick={submitPasteFallback}>
+            Send
+          </button>
+          <button
+            type="button"
+            className="mtk-ghost"
+            aria-label="Cancel paste"
+            onPointerDown={(e) => e.preventDefault()}
+            onClick={() => setPasteFallbackOpen(false)}
+          >
+            Cancel
+          </button>
+        </div>
+      )}
+
       {expanded ? (
         <>
           <div
@@ -192,8 +391,8 @@ export function TerminalKeyBar({
             aria-label="Keyboard layers"
             style={{
               display: "grid",
-              gridTemplateColumns: "repeat(3, minmax(0, 1fr)) auto",
-              gap: 5,
+              gridTemplateColumns: "repeat(3, minmax(0, 1fr)) auto auto",
+              gap: 6,
             }}
           >
             {(Object.keys(MODE_LABELS) as KeyboardMode[]).map((nextMode) => (
@@ -201,102 +400,86 @@ export function TerminalKeyBar({
                 key={nextMode}
                 type="button"
                 role="tab"
+                className="mtk-tab"
                 aria-selected={mode === nextMode}
                 aria-label={`${MODE_LABELS[nextMode]} keyboard`}
                 onClick={() => setMode(nextMode)}
-                style={{
-                  height: 30,
-                  borderRadius: 7,
-                  border: `1px solid ${mode === nextMode ? accent : buttonBorder}`,
-                  background: mode === nextMode ? `color-mix(in srgb, ${accent} 24%, transparent)` : buttonBackground,
-                  color: foreground,
-                  fontSize: 12,
-                  fontWeight: 700,
-                  touchAction: "manipulation",
-                }}
               >
                 {MODE_LABELS[nextMode]}
               </button>
             ))}
             <button
               type="button"
-              aria-label="Show fewer keys"
-              onClick={() => setExpanded(false)}
-              style={{
-                height: 30,
-                minWidth: 48,
-                borderRadius: 7,
-                border: `1px dashed ${accent}`,
-                background: "transparent",
-                color: mutedForeground,
-                fontSize: 12,
-                fontWeight: 650,
-                touchAction: "manipulation",
-              }}
+              className="mtk-tab"
+              aria-label="Paste from clipboard"
+              onPointerDown={handlePastePointerDown}
+              onPointerUp={cancelLongPress}
+              onPointerLeave={cancelLongPress}
+              onPointerCancel={cancelLongPress}
+              onClick={handlePasteClick}
             >
+              <ClipboardPasteIcon size={15} strokeWidth={1.9} aria-hidden="true" />
+              Paste
+            </button>
+            <button type="button" className="mtk-ghost" aria-label="Show fewer keys" onClick={() => setExpanded(false)}>
               Less
             </button>
           </div>
-          <KeyboardRows
-            rows={rowsForMode(mode)}
-            onSend={onSend}
-            background={buttonBackground}
-            foreground={foreground}
-            border={buttonBorder}
-          />
+          <KeyboardRows rows={rowsForMode(mode)} onSend={onSend} />
         </>
       ) : (
-        <div
-          style={{
-            display: "flex",
-            alignItems: "center",
-            gap: 3,
-          }}
-        >
-          {/* Keys scroll horizontally when they overflow; the "More" button is a
-              fixed-width sibling outside the scroll area so it stays fully
-              visible and tappable on narrow (<=360px) viewports. */}
+        <div style={{ display: "flex", alignItems: "center", gap: 6 }}>
+          {/* Keys scroll horizontally when they overflow; the Paste + More
+              buttons are fixed-width siblings outside the scroll area so they
+              stay fully tappable on narrow (<=360px) viewports. */}
           <div
+            className="mtk-scroll"
             style={{
               display: "flex",
               alignItems: "center",
-              gap: 3,
+              gap: 6,
               flex: "1 1 auto",
               minWidth: 0,
               overflowX: "auto",
-              scrollbarWidth: "none",
               WebkitOverflowScrolling: "touch",
               touchAction: "pan-x",
             }}
           >
             {PRIMARY_KEYS.map((keyDef) => (
-              <TerminalKeyButton
+              <button
                 key={keyDef.ariaLabel ?? keyDef.label}
-                keyDef={keyDef}
-                onSend={onSend}
-                background={buttonBackground}
-                foreground={foreground}
-                border={buttonBorder}
-                compact
-              />
+                type="button"
+                className="mtk-key"
+                aria-label={keyDef.ariaLabel ?? keyDef.label}
+                style={{ flex: compactFlexForKey(keyDef) }}
+                onPointerDown={(e) => {
+                  e.preventDefault();
+                  onSend(keyDef.data);
+                }}
+              >
+                {keyDef.label}
+              </button>
             ))}
           </div>
           <button
             type="button"
+            className="mtk-key mtk-key--accent"
+            aria-label="Paste from clipboard"
+            style={{ flex: "0 0 auto", minWidth: 44, padding: "0 12px", fontSize: 13 }}
+            onPointerDown={handlePastePointerDown}
+            onPointerUp={cancelLongPress}
+            onPointerLeave={cancelLongPress}
+            onPointerCancel={cancelLongPress}
+            onClick={handlePasteClick}
+          >
+            <ClipboardPasteIcon size={16} strokeWidth={1.9} aria-hidden="true" />
+          </button>
+          <button
+            type="button"
+            className="mtk-ghost"
             aria-label="Show more keys"
+            style={{ flex: "0 0 auto" }}
             onClick={() => setExpanded(true)}
-            style={{
-              height: 34,
-              width: 44,
-              borderRadius: 7,
-              border: `1px dashed ${accent}`,
-              background: "transparent",
-              color: mutedForeground,
-              fontSize: 12,
-              fontWeight: 650,
-              flex: "0 0 44px",
-              touchAction: "manipulation",
-            }}
           >
             More
           </button>
@@ -306,87 +489,36 @@ export function TerminalKeyBar({
   );
 }
 
-function KeyboardRows({
-  rows,
-  onSend,
-  background,
-  foreground,
-  border,
-}: {
-  rows: KeyDef[][];
-  onSend: (data: string) => void;
-  background: string;
-  foreground: string;
-  border: string;
-}) {
+function KeyboardRows({ rows, onSend }: { rows: KeyDef[][]; onSend: (data: string) => void }) {
   return (
-    <div style={{ display: "grid", gap: 5 }}>
+    <div style={{ display: "grid", gap: 6 }}>
       {rows.map((row) => (
         <div
           key={row.map((keyDef) => keyDef.ariaLabel ?? keyDef.label).join("|")}
           style={{
             display: "grid",
             gridTemplateColumns: row.map((keyDef) => (keyDef.wide ? "minmax(112px, 3fr)" : "minmax(0, 1fr)")).join(" "),
-            gap: 5,
+            gap: 6,
             minWidth: 0,
           }}
         >
           {row.map((keyDef) => (
-            <TerminalKeyButton
+            <button
               key={keyDef.ariaLabel ?? keyDef.label}
-              keyDef={keyDef}
-              onSend={onSend}
-              background={background}
-              foreground={foreground}
-              border={border}
-              wide={keyDef.wide}
-            />
+              type="button"
+              className={keyDef.wide ? "mtk-key mtk-key--wide" : "mtk-key"}
+              aria-label={keyDef.ariaLabel ?? keyDef.label}
+              style={{ minWidth: 0 }}
+              onPointerDown={(e) => {
+                e.preventDefault();
+                onSend(keyDef.data);
+              }}
+            >
+              {keyDef.label}
+            </button>
           ))}
         </div>
       ))}
     </div>
-  );
-}
-
-function TerminalKeyButton({
-  keyDef,
-  onSend,
-  background,
-  foreground,
-  border,
-  wide,
-  compact,
-}: {
-  keyDef: KeyDef;
-  onSend: (data: string) => void;
-  background: string;
-  foreground: string;
-  border: string;
-  wide?: boolean;
-  compact?: boolean;
-}) {
-  const compactWidth = compact ? compactWidthForKey(keyDef) : undefined;
-  return (
-    <button
-      type="button"
-      aria-label={keyDef.ariaLabel ?? keyDef.label}
-      onPointerDown={(e) => {
-        e.preventDefault();
-        onSend(keyDef.data);
-      }}
-      style={{
-        ...KEY_BUTTON_BASE_STYLE,
-        minWidth: compact ? 0 : wide ? 112 : 34,
-        width: compactWidth,
-        background,
-        color: foreground,
-        border: `1px solid ${border}`,
-        flex: compact ? `0 0 ${compactWidth}px` : "0 0 auto",
-        padding: compact ? 0 : undefined,
-        fontWeight: wide ? 700 : 650,
-      }}
-    >
-      {keyDef.label}
-    </button>
   );
 }

--- a/shell/src/components/terminal/TerminalPane.tsx
+++ b/shell/src/components/terminal/TerminalPane.tsx
@@ -8,6 +8,7 @@ import { isTerminalDebugEnabled } from "@/lib/terminal-debug";
 import { useTerminalSettings } from "@/stores/terminal-settings";
 import { buildAuthenticatedWebSocketUrl } from "@/lib/websocket-auth";
 import type { Theme } from "@/hooks/useTheme";
+import { useVisualViewport } from "@/hooks/useVisualViewport";
 import { ImageAddon, type IImageAddonOptions } from "@xterm/addon-image";
 import type { FitAddon } from "@xterm/addon-fit";
 import type { Terminal } from "@xterm/xterm";
@@ -337,6 +338,10 @@ export function TerminalPane({
   const terminalCursorStyle = useTerminalSettings((s) => s.cursorStyle);
   const terminalSmoothScroll = useTerminalSettings((s) => s.smoothScroll);
   const cursorBlink = useTerminalSettings((s) => s.cursorBlink);
+  // Visual-viewport state drives keyboard-aware re-fitting on mobile: when the
+  // iOS soft keyboard opens the layout viewport doesn't shrink, so the terminal
+  // host must re-fit to the visible band or the prompt hides behind the keyboard.
+  const { height: viewportHeight, offsetTop: viewportOffsetTop, keyboardOpen } = useVisualViewport();
   const containerRef = useRef<HTMLDivElement>(null);
   const wsRef = useRef<WebSocket | null>(null);
   const termRef = useRef<unknown>(null);
@@ -1360,6 +1365,32 @@ export function TerminalPane({
     }
   }, [isFocused]);
 
+  // Re-fit the terminal whenever the visual viewport changes (soft keyboard
+  // open/close, URL-bar collapse, orientation). The container also shrinks via
+  // the --terminal-keyboard-height var so its ResizeObserver fires, but an
+  // explicit fit here covers the cases where the host height is unchanged yet
+  // the visible band moved (iOS keyboard over a full-height layout viewport).
+  useEffect(() => {
+    const fit = fitAddonRef.current as { fit?: () => void } | null;
+    if (!fit?.fit) return;
+    const id = requestAnimationFrame(() => {
+      try {
+        fit.fit?.();
+        sendTerminalResize(
+          wsRef.current,
+          termRef.current as Parameters<typeof sendTerminalResize>[1],
+          allowRemoteResizeRef.current,
+        );
+        if (isFocusedRef.current) {
+          (termRef.current as { focus?: () => void } | null)?.focus?.();
+        }
+      } catch (err: unknown) {
+        console.warn("Terminal viewport re-fit failed:", err instanceof Error ? err.message : err);
+      }
+    });
+    return () => cancelAnimationFrame(id);
+  }, [viewportHeight, viewportOffsetTop, keyboardOpen]);
+
   return (
     // react-doctor-disable-next-line react-doctor/no-static-element-interactions, react-doctor/click-events-have-key-events -- presentational click-to-focus wrapper: clicking anywhere in the pane forwards focus to the embedded xterm terminal, which is itself the keyboard-interactive element (its textarea is in natural tab order). This div is not a control, so a role/tabIndex would be misleading; keyboard users interact with the terminal directly.
     <div
@@ -1372,6 +1403,11 @@ export function TerminalPane({
         outlineOffset: "-1px",
         // Left gutter so the prompt isn't jammed against the window edge.
         paddingLeft: 12,
+        // Pin the terminal host to the visible band: the var is 0px until the
+        // mobile soft keyboard opens (published by TerminalKeyBar), so this is a
+        // no-op on desktop. When the keyboard opens the host shrinks and its
+        // ResizeObserver re-fits the grid above the keyboard.
+        height: "calc(100% - var(--terminal-keyboard-height, 0px))",
       }}
       onPointerDown={handleFocus}
       onClick={handleFocus}

--- a/shell/src/components/terminal/TerminalPane.tsx
+++ b/shell/src/components/terminal/TerminalPane.tsx
@@ -351,8 +351,9 @@ export function TerminalPane({
   const onSessionAttachedRef = useRef(onSessionAttached);
   const shouldCacheOnUnmountRef = useRef(shouldCacheOnUnmount);
   const shouldDestroyOnUnmountRef = useRef(shouldDestroyOnUnmount);
-  const webglCanvasRef = useRef<HTMLCanvasElement | null>(null);
-  const webglContextLostHandlerRef = useRef<((event: Event) => void) | null>(null);
+  const webglAddonRef = useRef<{ dispose: () => void } | null>(null);
+  const webglContextLossDisposableRef = useRef<{ dispose: () => void } | null>(null);
+  const webglRecreateAttemptedRef = useRef(false);
   const onDataDisposableRef = useRef<{ dispose: () => void } | null>(null);
   const onResizeDisposableRef = useRef<{ dispose: () => void } | null>(null);
   const initialStartupCommandRef = useRef(startupCommand);
@@ -495,12 +496,28 @@ export function TerminalPane({
         }
       };
 
-      const detachWebglContextLostHandler = () => {
-        if (webglCanvasRef.current && webglContextLostHandlerRef.current) {
-          webglCanvasRef.current.removeEventListener("webglcontextlost", webglContextLostHandlerRef.current);
+      // Tears down only the context-loss subscription (the closure that drives
+      // DOM-renderer fallback). Safe to call on every cleanup path: on a cache
+      // for tab-switch the WebGL addon itself stays loaded on the retained
+      // terminal, while on a destroy path term.dispose() disposes the addon.
+      const teardownWebglSubscription = () => {
+        webglContextLossDisposableRef.current?.dispose();
+        webglContextLossDisposableRef.current = null;
+      };
+
+      // Fully disposes the WebGL renderer, dropping back to xterm's DOM
+      // renderer (the default once no WebGL addon is loaded).
+      const disposeWebgl = () => {
+        teardownWebglSubscription();
+        const addon = webglAddonRef.current;
+        webglAddonRef.current = null;
+        if (addon) {
+          try {
+            addon.dispose();
+          } catch (err: unknown) {
+            console.warn("WebGL addon dispose failed:", err instanceof Error ? err.message : err);
+          }
         }
-        webglCanvasRef.current = null;
-        webglContextLostHandlerRef.current = null;
       };
 
       const container = containerRef.current;
@@ -551,6 +568,56 @@ export function TerminalPane({
         window.setTimeout(refitAndFocus, 250);
       };
 
+      // Subscribe to GPU context loss (common on mobile Safari, which drops GL
+      // contexts under memory pressure / backgrounding). On loss: dispose the
+      // WebGL renderer so xterm falls back to its DOM renderer, then attempt a
+      // single re-create. We never leave a blank pane — the DOM renderer keeps
+      // working even if re-creation fails.
+      const wireWebglContextLoss = (addon: {
+        onContextLoss: (cb: () => void) => { dispose: () => void };
+      }) => {
+        teardownWebglSubscription();
+        webglContextLossDisposableRef.current = addon.onContextLoss(() => {
+          log("webgl-context-loss", { recreateAttempted: webglRecreateAttemptedRef.current });
+          disposeWebgl();
+          if (!webglRecreateAttemptedRef.current && !disposed) {
+            webglRecreateAttemptedRef.current = true;
+            void enableWebgl();
+          }
+        });
+      };
+
+      // Instantiates and loads the WebGL renderer. Must run only after
+      // term.open() + an initial fit(), and only client-side (browser-only
+      // addon). Returns the addon, or null when WebGL is unavailable / fails —
+      // in which case xterm keeps using the DOM renderer.
+      const enableWebgl = async (): Promise<unknown> => {
+        if (disposed) {
+          return null;
+        }
+        try {
+          // react-doctor-disable-next-line react-hooks-js/todo -- React Compiler cannot lower dynamic import() expressions; lazy-loading the WebGL addon this way is intentional code-splitting, not a defect.
+          const { WebglAddon } = await import("@xterm/addon-webgl");
+          if (disposed) {
+            return null;
+          }
+          const addon = new WebglAddon();
+          term.loadAddon(addon);
+          webglAddonRef.current = addon;
+          wireWebglContextLoss(addon);
+          log("webgl-enabled");
+          return addon;
+        } catch (err: unknown) {
+          log("webgl-unavailable", { message: err instanceof Error ? err.message : String(err) });
+          console.warn("WebGL renderer unavailable, using DOM renderer:", err instanceof Error ? err.message : err);
+          disposeWebgl();
+          return null;
+        }
+      };
+
+      // Each init run starts with a fresh re-create budget (one retry).
+      webglRecreateAttemptedRef.current = false;
+
       if (canReuseCachedTerminal && cached) {
         const termElement = (cached.terminal as { element?: HTMLElement }).element;
         if (termElement) {
@@ -565,6 +632,22 @@ export function TerminalPane({
         fitAddon = cached.fitAddon;
         searchAddon = cached.searchAddon;
         webglAddon = cached.webglAddon;
+        // The cached terminal kept its WebGL addon loaded, but the old
+        // context-loss subscription was torn down on cache. Re-wire it (or
+        // re-create the renderer if a prior context loss left it on the DOM
+        // renderer).
+        webglAddonRef.current = (cached.webglAddon as { dispose: () => void } | null) ?? null;
+        if (webglAddonRef.current) {
+          wireWebglContextLoss(
+            webglAddonRef.current as unknown as {
+              onContextLoss: (cb: () => void) => { dispose: () => void };
+            },
+          );
+        } else {
+          void enableWebgl().then((addon) => {
+            webglAddon = addon;
+          });
+        }
         fitAddon.fit();
         termRef.current = cached.terminal;
         fitAddonRef.current = cached.fitAddon;
@@ -623,6 +706,11 @@ export function TerminalPane({
         termRef.current = xterm;
         fitAddonRef.current = nextFitAddon;
         scheduleStableFit();
+
+        // GPU renderer — instantiated after open() + initial fit(). Falls back
+        // to the DOM renderer automatically if WebGL is unavailable or the GL
+        // context is later lost (see enableWebgl / wireWebglContextLoss).
+        webglAddon = await enableWebgl();
 
         // Search addon
         try {
@@ -1157,7 +1245,11 @@ export function TerminalPane({
         clearReconnectTimer();
         clearPendingReconnectBanner();
         heartbeatRef.current?.stop();
-        detachWebglContextLostHandler();
+        // Drop the context-loss subscription on every path. On a cache (tab
+        // switch) the WebGL addon stays loaded on the retained terminal and is
+        // re-wired on reattach; on a destroy path term.dispose() below disposes
+        // the addon along with the terminal.
+        teardownWebglSubscription();
         onDataDisposableRef.current?.dispose();
         onDataDisposableRef.current = null;
         onResizeDisposableRef.current?.dispose();
@@ -1187,7 +1279,8 @@ export function TerminalPane({
           }
           ws?.close();
           removeCached(paneId);
-          term.dispose();
+          term.dispose(); // disposes loaded addons, including the WebGL renderer
+          webglAddonRef.current = null;
         } else if (wsRef.current) {
           // Tab switch — cache the terminal for instant restore
           log("cleanup-cache-terminal");
@@ -1201,7 +1294,10 @@ export function TerminalPane({
           cacheTerminal(paneId, {
             terminal: term,
             fitAddon,
-            webglAddon,
+            // The live addon ref is authoritative: it tracks the renderer
+            // through any context-loss re-create that may have replaced the
+            // addon captured in the local `webglAddon` binding.
+            webglAddon: webglAddonRef.current ?? webglAddon,
             searchAddon,
             ws: wsRef.current,
             lastSeq: lastSeqRef.current,
@@ -1210,7 +1306,8 @@ export function TerminalPane({
         } else {
           // WS never established — dispose, don't cache
           log("cleanup-dispose-no-ws");
-          term.dispose();
+          term.dispose(); // disposes loaded addons, including the WebGL renderer
+          webglAddonRef.current = null;
         }
       };
     }

--- a/shell/src/components/ui/drawer.tsx
+++ b/shell/src/components/ui/drawer.tsx
@@ -1,0 +1,122 @@
+"use client";
+
+import * as React from "react";
+import { Drawer as DrawerPrimitive } from "vaul";
+
+import { cn } from "@/lib/utils";
+
+function Drawer({ ...props }: React.ComponentProps<typeof DrawerPrimitive.Root>) {
+  return <DrawerPrimitive.Root data-slot="drawer" {...props} />;
+}
+
+function DrawerTrigger({ ...props }: React.ComponentProps<typeof DrawerPrimitive.Trigger>) {
+  return <DrawerPrimitive.Trigger data-slot="drawer-trigger" {...props} />;
+}
+
+function DrawerPortal({ ...props }: React.ComponentProps<typeof DrawerPrimitive.Portal>) {
+  return <DrawerPrimitive.Portal data-slot="drawer-portal" {...props} />;
+}
+
+function DrawerClose({ ...props }: React.ComponentProps<typeof DrawerPrimitive.Close>) {
+  return <DrawerPrimitive.Close data-slot="drawer-close" {...props} />;
+}
+
+function DrawerOverlay({
+  className,
+  ...props
+}: React.ComponentProps<typeof DrawerPrimitive.Overlay>) {
+  return (
+    <DrawerPrimitive.Overlay
+      data-slot="drawer-overlay"
+      className={cn(
+        "fixed inset-0 z-[70] bg-[color-mix(in_srgb,var(--deep)_60%,transparent)] data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=closed]:animate-out data-[state=closed]:fade-out-0",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function DrawerContent({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof DrawerPrimitive.Content>) {
+  return (
+    <DrawerPortal data-slot="drawer-portal">
+      <DrawerOverlay />
+      <DrawerPrimitive.Content
+        data-slot="drawer-content"
+        className={cn(
+          // Brand glass sheet, bottom-anchored, respecting the safe-area inset.
+          "group/drawer-content surface-glass-strong elevation-4 fixed inset-x-0 bottom-0 z-[70] mt-24 flex h-auto max-h-[85vh] flex-col rounded-t-[var(--radius-3xl)] border-t pb-[env(safe-area-inset-bottom,0px)] text-sm",
+          className,
+        )}
+        {...props}
+      >
+        {/* Drag handle */}
+        <div className="mx-auto mt-3 h-1.5 w-12 shrink-0 rounded-full bg-[color-mix(in_srgb,var(--foreground)_24%,transparent)]" />
+        {children}
+      </DrawerPrimitive.Content>
+    </DrawerPortal>
+  );
+}
+
+function DrawerHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="drawer-header"
+      className={cn("flex flex-col gap-0.5 px-5 pt-4 pb-2 text-center", className)}
+      {...props}
+    />
+  );
+}
+
+function DrawerFooter({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="drawer-footer"
+      className={cn("mt-auto flex flex-col gap-2 px-5 pb-5", className)}
+      {...props}
+    />
+  );
+}
+
+function DrawerTitle({
+  className,
+  ...props
+}: React.ComponentProps<typeof DrawerPrimitive.Title>) {
+  return (
+    <DrawerPrimitive.Title
+      data-slot="drawer-title"
+      className={cn("text-base font-medium tracking-tight text-foreground", className)}
+      {...props}
+    />
+  );
+}
+
+function DrawerDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof DrawerPrimitive.Description>) {
+  return (
+    <DrawerPrimitive.Description
+      data-slot="drawer-description"
+      className={cn("text-sm text-muted-foreground", className)}
+      {...props}
+    />
+  );
+}
+
+export {
+  Drawer,
+  DrawerPortal,
+  DrawerOverlay,
+  DrawerTrigger,
+  DrawerClose,
+  DrawerContent,
+  DrawerHeader,
+  DrawerFooter,
+  DrawerTitle,
+  DrawerDescription,
+};

--- a/shell/src/components/ui/sonner.tsx
+++ b/shell/src/components/ui/sonner.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import { Toaster as Sonner, type ToasterProps } from "sonner";
+import { CircleCheckIcon, InfoIcon, TriangleAlertIcon, OctagonXIcon } from "lucide-react";
+
+/**
+ * Brand-themed sonner Toaster.
+ *
+ * - No theme provider in this shell, so colors are driven directly off the
+ *   Matrix CSS-var tokens (popover / foreground / border) rather than a
+ *   light/dark switch.
+ * - Anchored above the bottom safe-area inset *and* the 64px mobile dock, and
+ *   it rises with the on-screen keyboard via --terminal-keyboard-height so a
+ *   toast is never hidden behind chrome or the keyboard.
+ */
+function Toaster({ ...props }: ToasterProps) {
+  const bottomOffset =
+    "calc(env(safe-area-inset-bottom, 0px) + 5rem + var(--terminal-keyboard-height, 0px))";
+
+  return (
+    <Sonner
+      className="toaster group"
+      icons={{
+        success: <CircleCheckIcon className="size-4" />,
+        info: <InfoIcon className="size-4" />,
+        warning: <TriangleAlertIcon className="size-4" />,
+        error: <OctagonXIcon className="size-4" />,
+        loading: <div className="size-4 animate-pulse rounded-full bg-current/20" />,
+      }}
+      offset={{
+        bottom: bottomOffset,
+        top: "calc(env(safe-area-inset-top, 0px) + 1rem)",
+      }}
+      mobileOffset={{
+        bottom: bottomOffset,
+        top: "calc(env(safe-area-inset-top, 0px) + 0.75rem)",
+      }}
+      style={
+        {
+          "--normal-bg": "var(--surface-glass-strong)",
+          "--normal-text": "var(--popover-foreground)",
+          "--normal-border": "var(--surface-glass-border)",
+          "--border-radius": "var(--radius-lg)",
+          "--width": "min(20rem, calc(100vw - 2rem))",
+          "--toast-icon-margin-end": "8px",
+          fontFamily: "var(--font-sans)",
+        } as React.CSSProperties
+      }
+      toastOptions={{
+        classNames: {
+          toast:
+            "surface-glass-strong elevation-3 !gap-2 !rounded-xl !border !px-3.5 !py-2.5 !text-[13px] !leading-snug !text-popover-foreground font-sans",
+          title: "!font-medium",
+          description: "!text-muted-foreground",
+          icon: "!mx-0 !size-4 [&>svg]:!size-4",
+          success: "!text-[var(--success)]",
+          error: "!text-destructive",
+          warning: "!text-[var(--warning)]",
+        },
+      }}
+      {...props}
+    />
+  );
+}
+
+export { Toaster };

--- a/shell/src/hooks/useVisualViewport.ts
+++ b/shell/src/hooks/useVisualViewport.ts
@@ -1,0 +1,83 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+/**
+ * Live `window.visualViewport` state for keyboard-aware mobile layout (spec 102).
+ *
+ * On iOS the layout viewport (`innerHeight`) does not shrink when the on-screen
+ * keyboard opens — only the *visual* viewport does. Reading `visualViewport`
+ * lets keyboard-adjacent UI (terminal key bar, toasts, sheets) pin itself above
+ * the keyboard and the terminal re-`fit()` so the prompt stays visible.
+ *
+ * - `height`   — visual viewport height in px (visible band).
+ * - `offsetTop`— how far the visual viewport is scrolled down from the layout
+ *                viewport; translate pinned roots by this to re-anchor them.
+ * - `keyboardOpen` — heuristic: layout height − visual height exceeds a
+ *                threshold (clears URL-bar jitter, catches real keyboards).
+ *
+ * SSR-safe: returns sensible defaults until mounted.
+ */
+
+export interface VisualViewportState {
+  height: number;
+  offsetTop: number;
+  keyboardOpen: boolean;
+}
+
+/** Below this (px) the gap is URL-bar/toolbar jitter, not a real keyboard. */
+const KEYBOARD_THRESHOLD = 120;
+
+function readSnapshot(): VisualViewportState {
+  if (typeof window === "undefined") {
+    return { height: 0, offsetTop: 0, keyboardOpen: false };
+  }
+  const vv = window.visualViewport;
+  if (!vv) {
+    return { height: window.innerHeight, offsetTop: 0, keyboardOpen: false };
+  }
+  const height = vv.height;
+  const keyboard = Math.max(0, window.innerHeight - height);
+  return {
+    height: Math.round(height),
+    offsetTop: Math.round(vv.offsetTop),
+    keyboardOpen: keyboard > KEYBOARD_THRESHOLD,
+  };
+}
+
+export function useVisualViewport(): VisualViewportState {
+  const [state, setState] = useState<VisualViewportState>(() =>
+    typeof window === "undefined"
+      ? { height: 0, offsetTop: 0, keyboardOpen: false }
+      : readSnapshot(),
+  );
+
+  useEffect(() => {
+    const vv = window.visualViewport;
+    if (!vv) return;
+
+    const sync = () => {
+      setState((prev) => {
+        const next = readSnapshot();
+        if (
+          prev.height === next.height &&
+          prev.offsetTop === next.offsetTop &&
+          prev.keyboardOpen === next.keyboardOpen
+        ) {
+          return prev;
+        }
+        return next;
+      });
+    };
+
+    sync();
+    vv.addEventListener("resize", sync);
+    vv.addEventListener("scroll", sync);
+    return () => {
+      vv.removeEventListener("resize", sync);
+      vv.removeEventListener("scroll", sync);
+    };
+  }, []);
+
+  return state;
+}

--- a/shell/src/lib/motion.ts
+++ b/shell/src/lib/motion.ts
@@ -1,0 +1,115 @@
+"use client";
+
+/**
+ * Shared framer-motion variants for the mobile shell (spec 102).
+ *
+ * One implementation so app transitions, bottom-sheets and incidental UI all
+ * move with the same emphasized easing. Everything degrades to an instant cut
+ * under `prefers-reduced-motion` via `reducedMotion()`.
+ */
+
+import type { Transition, Variants } from "framer-motion";
+
+/** iOS-style emphasized decelerate — mirrors `--ease-emphasized` in globals.css. */
+export const EASE_EMPHASIZED: [number, number, number, number] = [
+  0.32, 0.72, 0, 1,
+];
+
+/** True when the user has asked the OS to minimize motion (SSR-safe). */
+export function prefersReducedMotion(): boolean {
+  if (typeof window === "undefined" || !window.matchMedia) return false;
+  return window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+}
+
+/** A near-instant transition used to collapse animations for reduced motion. */
+export const instantTransition: Transition = { duration: 0 };
+
+const baseTransition: Transition = {
+  duration: 0.32,
+  ease: EASE_EMPHASIZED,
+};
+
+/**
+ * Resolve a transition, collapsing to instant when reduced motion is on.
+ * Pass into `transition={reducedMotion(myTransition)}` at render time so the
+ * preference is read on the client, not baked at module load.
+ */
+export function reducedMotion(transition: Transition = baseTransition): Transition {
+  return prefersReducedMotion() ? instantTransition : transition;
+}
+
+/**
+ * App switch: a new app slides up + fades in, the outgoing one fades + sinks.
+ * Use with `<AnimatePresence>` around the active app surface.
+ */
+export const appEnter: Variants = {
+  initial: { opacity: 0, y: 16, scale: 0.985 },
+  animate: {
+    opacity: 1,
+    y: 0,
+    scale: 1,
+    transition: baseTransition,
+  },
+};
+
+export const appExit: Variants = {
+  exit: {
+    opacity: 0,
+    y: 12,
+    scale: 0.99,
+    transition: { duration: 0.22, ease: EASE_EMPHASIZED },
+  },
+};
+
+/** Combined app-transition variants (enter + exit) for a single motion node. */
+export const appTransition: Variants = {
+  ...appEnter,
+  ...appExit,
+};
+
+/** Bottom-sheet: rises from below the viewport, settles with emphasized ease. */
+export const sheet: Variants = {
+  initial: { y: "100%" },
+  animate: { y: 0, transition: baseTransition },
+  exit: { y: "100%", transition: { duration: 0.24, ease: EASE_EMPHASIZED } },
+};
+
+/** Scrim/backdrop behind a sheet or modal. */
+export const scrim: Variants = {
+  initial: { opacity: 0 },
+  animate: { opacity: 1, transition: { duration: 0.24, ease: EASE_EMPHASIZED } },
+  exit: { opacity: 0, transition: { duration: 0.2, ease: EASE_EMPHASIZED } },
+};
+
+/** Subtle fade + rise for list rows, cards, empty states. */
+export const fadeUp: Variants = {
+  initial: { opacity: 0, y: 10 },
+  animate: {
+    opacity: 1,
+    y: 0,
+    transition: { duration: 0.28, ease: EASE_EMPHASIZED },
+  },
+};
+
+/**
+ * Stagger container for entrance animations (e.g. launcher grid). Children
+ * should use `fadeUp`. Stagger collapses to 0 under reduced motion.
+ */
+export function staggerContainer(stagger = 0.04): Variants {
+  const reduce = prefersReducedMotion();
+  return {
+    initial: {},
+    animate: {
+      transition: {
+        staggerChildren: reduce ? 0 : stagger,
+        delayChildren: reduce ? 0 : stagger,
+      },
+    },
+  };
+}
+
+/** Press feedback for tappable cards/buttons (scale-on-tap). */
+export const tapScale = {
+  whileTap: { scale: 0.97 },
+  transition: { duration: 0.12, ease: EASE_EMPHASIZED },
+} as const;

--- a/specs/102-mobile-pwa-terminal-polish/spec.md
+++ b/specs/102-mobile-pwa-terminal-polish/spec.md
@@ -3,7 +3,7 @@
 **Status:** Draft (design approved, not yet implemented)
 **Branch:** `102-mobile-pwa-terminal-polish` (forked off `fix/www-onboarding-flow`)
 **Surface:** `shell/` (Next.js web shell PWA) only
-**Inspiration:** [BennyKok/lfg](https://github.com/BennyKok/lfg) — adapt its mobile/terminal *techniques*, keep Matrix OS brand.
+**Approach:** adapt best-in-class mobile-terminal-PWA *techniques*, keep the Matrix OS brand.
 
 ---
 
@@ -60,7 +60,7 @@ Several in-flight worktrees/branches touch the same area. Reconcile before start
 
 ## 4. Design Principles
 
-1. **Adapt techniques, keep the brand.** No new design language; reuse forest/cream/ember + existing CSS-var tokens. Port lfg's *methods* (glass surfaces, motion, drawers, viewport handling), not its iOS-blue palette.
+1. **Adapt techniques, keep the brand.** No new design language; reuse forest/cream/ember + existing CSS-var tokens. Port proven *methods* (glass surfaces, motion, drawers, viewport handling), never another product's palette.
 2. **Surgical, not a rewrite.** Do **not** rewrite the `TerminalPane` monolith. Insert the WebGL addon and extend viewport handling in place; only extract a component when it already has a seam (the key bar is already its own file).
 3. **Reusable primitives.** Add a small shared layer — motion variants, a glass-surface utility, a `useVisualViewport` hook — so mobile and terminal share one implementation.
 4. **Desktop must not regress.** Any shared component change is verified against `Desktop.tsx`.
@@ -94,7 +94,7 @@ Several in-flight worktrees/branches touch the same area. Reconcile before start
 - Keep changes presentational; no behavior/data-flow changes.
 
 ### A6. Toasts + drawers/sheets (new deps)
-- Add `sonner` for toasts; position above safe-area bottom (mirror lfg's offset approach) and themed to brand.
+- Add `sonner` for toasts; position above the bottom safe-area inset and theme to brand.
 - Add `vaul` for mobile bottom-sheets (menus/dialogs) with drag handle; use for at least one real surface (e.g. app actions / a settings menu) to establish the pattern.
 
 ### A7. PWA meta/manifest polish
@@ -114,7 +114,7 @@ Several in-flight worktrees/branches touch the same area. Reconcile before start
 
 ### B3. Key bar restyle + paste UX (`TerminalKeyBar.tsx`)
 - Replace raw inline styles with brand tokens; proper pressed/active states; ≥44px targets; scrollable extra-keys row.
-- Add long-press / explicit **Paste** affordance (clipboard read with `<input>` fallback for iOS), matching lfg's paste flow (no trailing Enter).
+- Add long-press / explicit **Paste** affordance (clipboard read with `<input>` fallback for iOS; no trailing Enter — user reviews before sending).
 
 ### B4. Font + theme alignment
 - Align terminal theme tokens (the 3 themes: `light`, `matrix-dark`, `matrix`) with brand palette; ensure JetBrains Mono stack.

--- a/specs/102-mobile-pwa-terminal-polish/spec.md
+++ b/specs/102-mobile-pwa-terminal-polish/spec.md
@@ -1,0 +1,147 @@
+# Spec 102 — Mobile PWA Polish + Terminal Refinement (Web Shell)
+
+**Status:** Draft (design approved, not yet implemented)
+**Branch:** `102-mobile-pwa-terminal-polish` (forked off `fix/www-onboarding-flow`)
+**Surface:** `shell/` (Next.js web shell PWA) only
+**Inspiration:** [BennyKok/lfg](https://github.com/BennyKok/lfg) — adapt its mobile/terminal *techniques*, keep Matrix OS brand.
+
+---
+
+## 1. Goal
+
+Make the Matrix OS **web shell PWA** look and feel polished on mobile, and refine the existing
+xterm.js terminal — without changing the terminal engine or the agent layer.
+
+Two independent workstreams, sequenced **B (terminal) → A (mobile)** so the lowest-risk, highest-visibility
+win (WebGL renderer) lands first, then the broader restyle.
+
+## 2. Scope
+
+**In scope (web shell `shell/` only):**
+- A. Mobile PWA restyle: shell chrome, app switcher + transitions, built-in app interiors, toasts + drawers/sheets, PWA meta/manifest polish.
+- B. xterm terminal polish: enable WebGL renderer, refine mobile keyboard handling, restyle key bar + paste UX, font/theme token alignment.
+
+**Explicitly OUT of scope (do not touch in this spec):**
+- ❌ Swapping xterm.js for Ghostty / `ghostty-web`. (Engine stays xterm.)
+- ❌ Swapping the Claude Agent SDK for the Vercel AI SDK. (Agent layer unchanged.)
+- ❌ Any Hermes changes (messaging/capability/automation layer).
+- ❌ The Expo native app (`apps/mobile/`) — it is a separate first-class client with its own UI; this spec does not modify it. Visual *parity ideas* may be shared later but are not part of this work.
+- ❌ Desktop shell (`Desktop.tsx`) behavior — must remain functionally unchanged (shared components must not regress desktop).
+
+## 3. Current State (findings)
+
+### Mobile shell
+- Lives in **3 files**: `shell/src/components/mobile/MobileShell.tsx` (~24KB; contains the app-switcher logic inline), `MobileLauncher.tsx`, `MobileAppSurface.tsx`.
+- Single-app-fullscreen model; `useMobileViewport()` (≤767px) branches `ShellHome.tsx` → `MobileShell` vs `Desktop`.
+- **App swaps are instant** — `framer-motion` is *not* used anywhere under `components/mobile/` (it is a repo dependency, so it's available).
+- Launcher = 2-col grid of letter-tile cards; app-switcher close buttons are basic inline-styled circles; no micro-interactions, no skeletons.
+- `MobileAppSurface` header = home button + title with `pt-[env(safe-area-inset-top)]`.
+
+### Terminal
+- `shell/src/components/terminal/TerminalPane.tsx` — one **~1,300-line lifecycle effect** owning xterm creation, WS attach, addons, caching, keybindings, OSC handlers, resize.
+- xterm v6 runs on the **default DOM renderer**. `@xterm/addon-webgl@^0.19.0` is **installed but never instantiated** — `webglAddon` appears only in cache/cleanup plumbing (`terminal-cache.ts`, `TerminalPane.tsx`).
+- Active addons: Fit, Search, Image (sixel/iTerm2), Serialize. OSC-52 clipboard via `parser.registerOscHandler(52, …)`. Custom keys via `attachCustomKeyEventHandler`. Block-marks (A/B/C/D) + seq-based replay buffer for Zellij reattach.
+- **`visualViewport` handling already exists** in `shell/src/components/terminal/TerminalKeyBar.tsx` — partial; to be extended/hardened.
+- I/O protocol is clean JSON over WS: `{type:"input"|"resize"|"detach"|"ping"}` up, `{type:"output"|"attached"|"block-mark"|"replay-start/end"|"exit"|"error"}` down. **Unchanged by this spec.**
+
+### Shared infra
+- Tailwind **v4** via `@tailwindcss/postcss`; tokens are CSS variables in `shell/src/app/globals.css`. No `tailwind.config.ts`.
+- Brand: forest `#434E3F`, cream `#E0E1CA`, ember `#D06F25`, deep `#32352E`; accent lichen `#9AA48C`. Fonts: Orbitron (display/brand only), Inter (UI), JetBrains Mono (code). See `DESIGN.md`.
+- **No `vaul`, no `sonner`** in `shell/` today — both are new (small) additions.
+- PWA: `shell/public/manifest.json` exists (theme-color `#3f4a3a`, 192/512/maskable icons, Terminal/Chat/Files shortcuts).
+- Playwright screenshot tests exist for the shell.
+
+### ⚠️ Possible overlap to check before implementing
+Several in-flight worktrees/branches touch the same area. Reconcile before starting to avoid conflicts:
+- `fix-mobile-terminal-ui`
+- `fix-pwa-icon-safe-area`
+- `mobile-workspace-stores` (worktree `matrix-os-mobile-refresh`)
+- Recent commit `ff3dbe23c feat(shell): unify terminal window chrome across Desktop, Canvas, and mobile`
+
+## 4. Design Principles
+
+1. **Adapt techniques, keep the brand.** No new design language; reuse forest/cream/ember + existing CSS-var tokens. Port lfg's *methods* (glass surfaces, motion, drawers, viewport handling), not its iOS-blue palette.
+2. **Surgical, not a rewrite.** Do **not** rewrite the `TerminalPane` monolith. Insert the WebGL addon and extend viewport handling in place; only extract a component when it already has a seam (the key bar is already its own file).
+3. **Reusable primitives.** Add a small shared layer — motion variants, a glass-surface utility, a `useVisualViewport` hook — so mobile and terminal share one implementation.
+4. **Desktop must not regress.** Any shared component change is verified against `Desktop.tsx`.
+5. **Respect `prefers-reduced-motion`.** All transitions degrade to instant.
+6. **Performance on real phones.** Animate transform/opacity only; lazy-load heavy bits; keep WebGL fallback robust (Safari drops GL contexts).
+
+---
+
+## 5. Workstream A — Mobile PWA Restyle
+
+### A1. Design tokens & primitives (`globals.css` + small utils)
+- Add semantic **surface/elevation/glass** tokens layered on existing brand vars: e.g. `--surface-glass` (brand bg @ ~80% + `backdrop-blur`), elevation shadow scale, iOS-style spring easing token `--ease-emphasized: cubic-bezier(0.32, 0.72, 0, 1)`.
+- Add safe-area helper classes and a `100dvh` root convention (verify shell root uses `dvh`, not `vh`).
+- New: `shell/src/lib/motion.ts` — shared `framer-motion` variants (app-enter/exit, sheet, fade-up) honoring reduced-motion.
+
+### A2. Shell chrome (`MobileAppSurface.tsx`, `MobileShell.tsx`)
+- Glass-morphism header (`--surface-glass` + blur), refined safe-area padding (top inset + comfortable touch height ~44px).
+- Consistent header layout: leading home/back, centered title, trailing slot for app actions.
+
+### A3. Launcher polish (`MobileLauncher.tsx`)
+- Refine grid: spacing rhythm, card press states (scale-on-tap), entrance stagger animation, optional real app icons/colors instead of letter tiles.
+- Loading skeletons for app list.
+
+### A4. App switcher + transitions (`MobileShell.tsx`)
+- Replace instant app swaps with `framer-motion` `AnimatePresence` slide/fade using A1 variants.
+- Polish recent-apps switcher: card depth, animated close buttons with hit-area ≥44px, swipe affordance.
+- Consider extracting switcher into `MobileAppSwitcher.tsx` to shrink the 24KB `MobileShell.tsx` (only if it lowers risk).
+
+### A5. Built-in app interiors (Chat / Files / Settings)
+- Apply token + spacing pass inside the built-in app surfaces (not just OS chrome): consistent headers, list rows, empty states, touch targets.
+- Keep changes presentational; no behavior/data-flow changes.
+
+### A6. Toasts + drawers/sheets (new deps)
+- Add `sonner` for toasts; position above safe-area bottom (mirror lfg's offset approach) and themed to brand.
+- Add `vaul` for mobile bottom-sheets (menus/dialogs) with drag handle; use for at least one real surface (e.g. app actions / a settings menu) to establish the pattern.
+
+### A7. PWA meta/manifest polish
+- Audit `shell/` document head: `viewport-fit=cover`, `interactive-widget=resizes-content`, light/dark `theme-color`, `apple-mobile-web-app-*`, `apple-touch-icon`.
+- Verify `manifest.json` icons/maskable + shortcuts render correctly when installed. (Coordinate with `fix-pwa-icon-safe-area` if still open.)
+
+## 6. Workstream B — Terminal Polish
+
+### B1. Enable WebGL renderer  ⟵ ship first
+- Instantiate `WebglAddon` after `xterm.open()` and `fit()`, load it, and wire `onContextLoss` → dispose + fall back to DOM renderer (and attempt one re-create).
+- Reuse the existing `webglAddon` cache slot in `terminal-cache.ts`; ensure proper dispose on unmount (context-lost handler already partially present).
+- Verify interplay with `ImageAddon` (sixel) under WebGL.
+
+### B2. Mobile keyboard handling (`TerminalKeyBar.tsx` + new `useVisualViewport`)
+- Extract a reusable `shell/src/hooks/useVisualViewport.ts` (height, offsetTop, keyboard-open) and hook it into terminal layout: pin terminal viewport to `visualViewport.height`, translate by `offsetTop`, re-`fit()` on change so the prompt isn't hidden behind the keyboard.
+- Publish a `--terminal-keyboard-height` CSS var for the key bar / toasts to offset against.
+
+### B3. Key bar restyle + paste UX (`TerminalKeyBar.tsx`)
+- Replace raw inline styles with brand tokens; proper pressed/active states; ≥44px targets; scrollable extra-keys row.
+- Add long-press / explicit **Paste** affordance (clipboard read with `<input>` fallback for iOS), matching lfg's paste flow (no trailing Enter).
+
+### B4. Font + theme alignment
+- Align terminal theme tokens (the 3 themes: `light`, `matrix-dark`, `matrix`) with brand palette; ensure JetBrains Mono stack.
+- iOS anti-zoom: ensure any terminal-adjacent `<input>` is ≥16px.
+
+---
+
+## 7. Risks & Mitigations
+- **WebGL context loss on mobile Safari** → robust DOM fallback + single re-create attempt; never leave a blank pane.
+- **Shared-component regressions on desktop** → test `Desktop.tsx` paths; gate mobile-only changes behind `useMobileViewport`.
+- **Branch overlap** (§3 ⚠️) → diff against the listed worktrees before coding; rebase as needed.
+- **Motion jank on low-end devices** → transform/opacity only; respect reduced-motion; cap durations.
+- **New deps (`sonner`, `vaul`)** → small, tree-shakeable; confirm SSR/Next 16 compatibility.
+
+## 8. Testing
+- Extend Playwright shell screenshot tests with **mobile-viewport** captures: launcher, app switcher mid-transition, built-in app, terminal (WebGL on), terminal with keyboard open.
+- Manual device checklist: installed PWA on iOS Safari + Android Chrome — safe areas, keyboard, app-switch transitions, toasts/sheets, terminal render + paste.
+- Regression: desktop shell unaffected; terminal reattach/replay still works after WebGL enable.
+
+## 9. Sequencing
+1. **B1** (WebGL) — isolated, immediate visible win.
+2. **A1** (tokens/primitives) — unblocks the rest.
+3. **B2–B4** (terminal mobile polish).
+4. **A2–A4** (chrome, launcher, transitions).
+5. **A6** (toasts/sheets), **A5** (app interiors), **A7** (PWA meta).
+
+## 10. Open Questions
+- Real app icons for the launcher, or keep letter tiles styled up? (A3)
+- Adopt `vaul`/`sonner`, or build minimal in-house equivalents to avoid deps? (A6)
+- Is `ff3dbe23c` (terminal chrome unification) the canonical base for the key bar work, or superseded? (§3)

--- a/specs/102-mobile-pwa-terminal-polish/spec.md
+++ b/specs/102-mobile-pwa-terminal-polish/spec.md
@@ -90,8 +90,8 @@ Several in-flight worktrees/branches touch the same area. Reconcile before start
 - Consider extracting switcher into `MobileAppSwitcher.tsx` to shrink the 24KB `MobileShell.tsx` (only if it lowers risk).
 
 ### A5. Built-in app interiors (Chat / Files / Settings)
-- Apply token + spacing pass inside the built-in app surfaces (not just OS chrome): consistent headers, list rows, empty states, touch targets.
-- Keep changes presentational; no behavior/data-flow changes.
+- **Bounded:** a *presentational* token + spacing + touch-target pass on exactly these three built-in apps — consistent headers, list rows, empty states. Enumerate the files up front; do not expand to other apps.
+- **No behavior, data-flow, or state changes.** If a change requires touching logic, it's out of scope for this task.
 
 ### A6. Toasts + drawers/sheets (new deps)
 - Add `sonner` for toasts; position above the bottom safe-area inset and theme to brand.
@@ -140,6 +140,20 @@ Several in-flight worktrees/branches touch the same area. Reconcile before start
 3. **B2–B4** (terminal mobile polish).
 4. **A2–A4** (chrome, launcher, transitions).
 5. **A6** (toasts/sheets), **A5** (app interiors), **A7** (PWA meta).
+
+## 11. Implementation Guardrails (reviewer addendum)
+
+These are correctness/process constraints surfaced in review; they bind implementation regardless of how work is parallelized.
+
+1. **File-ownership waves, not flat parallelism.** Several tasks edit the *same* files and must be serialized by file owner:
+   - `TerminalPane.tsx` — B1 (WebGL) then B2 (viewport) ⇒ same agent/sequence.
+   - `globals.css` — A1 tokens + the `dvh` check ⇒ one owner.
+   - `MobileShell.tsx` — A4 transitions + switcher + optional extraction ⇒ one owner.
+   File-disjoint groups (terminal/* vs mobile/* vs app interiors vs PWA meta) may run concurrently.
+2. **Client-only boundaries (Next 16 RSC).** `WebglAddon`, `vaul`, and `sonner` are browser-only — keep them in `"use client"` modules / dynamic client imports; never import into a server component. WebGL must instantiate only after mount.
+3. **Preserve the user's terminal theme.** Aligning the three themes (`light`/`matrix-dark`/`matrix`) to brand must keep the *active selection* working — do not hard-default to one theme.
+4. **PWA meta via Next metadata API**, not a raw `index.html` — use the shell's document head / `metadata`/`viewport` exports.
+5. **Verification gate per wave.** After each wave: `pnpm typecheck` (root) and `pnpm --dir shell lint` must pass; desktop path (`Desktop.tsx`) must not regress. The 102 worktree must have `pnpm install` run before any verification.
 
 ## 10. Open Questions
 - Real app icons for the launcher, or keep letter tiles styled up? (A3)

--- a/specs/102-mobile-pwa-terminal-polish/tasks.md
+++ b/specs/102-mobile-pwa-terminal-polish/tasks.md
@@ -1,0 +1,53 @@
+# Tasks — Spec 102: Mobile PWA Polish + Terminal Refinement
+
+Surface: `shell/` (web shell PWA) only. Out of scope: Ghostty, Agent SDK swap, Hermes, `apps/mobile` (Expo), desktop behavior.
+
+Legend: `[ ]` todo · est. = rough size (S/M/L) · ⚠️ = check branch overlap first.
+
+---
+
+## Phase 0 — Setup & reconciliation
+- [ ] **0.1** ⚠️ Diff this branch against in-flight worktrees touching the same area: `fix-mobile-terminal-ui`, `fix-pwa-icon-safe-area`, `mobile-workspace-stores`, and commit `ff3dbe23c` (terminal chrome unification). Decide canonical base / rebase. (S)
+- [ ] **0.2** Confirm `framer-motion`, and add `sonner` + `vaul` to `shell/package.json`; verify Next 16 / React 19 SSR compatibility. (S)
+
+## Phase 1 — Terminal: WebGL renderer (ship first)
+- [ ] **1.1** In `TerminalPane.tsx`, instantiate + `loadAddon(WebglAddon)` after `xterm.open()` + initial `fit()`. (M)
+- [ ] **1.2** Wire `WebglAddon.onContextLoss` → dispose, fall back to DOM renderer, attempt one re-create; never leave a blank pane. (M)
+- [ ] **1.3** Reuse the `webglAddon` slot in `terminal-cache.ts`; ensure correct dispose on unmount and on cached reattach. (S)
+- [ ] **1.4** Verify `ImageAddon` (sixel/iTerm2) still renders under WebGL; verify Serialize/Search unaffected. (S)
+- [ ] **1.5** Regression: terminal reattach + seq replay + block-marks still work. (S)
+
+## Phase 2 — Shared primitives
+- [ ] **2.1** `globals.css`: add semantic tokens — `--surface-glass`, elevation shadow scale, `--ease-emphasized: cubic-bezier(0.32,0.72,0,1)`, safe-area helpers. (M)
+- [ ] **2.2** Confirm shell root uses `100dvh` (not `vh`); fix if needed. (S)
+- [ ] **2.3** `shell/src/lib/motion.ts`: shared framer-motion variants (app-enter/exit, sheet, fade-up) honoring `prefers-reduced-motion`. (S)
+- [ ] **2.4** `shell/src/hooks/useVisualViewport.ts`: reusable hook (height, offsetTop, keyboardOpen) — used by terminal (Phase 3) and any keyboard-aware mobile UI. (M)
+
+## Phase 3 — Terminal: mobile polish
+- [ ] **3.1** Hook `useVisualViewport` into terminal layout: pin viewport to `visualViewport.height`, translate by `offsetTop`, re-`fit()` on change; publish `--terminal-keyboard-height`. (M)
+- [ ] **3.2** `TerminalKeyBar.tsx`: replace inline styles with brand tokens; pressed/active states; ≥44px targets; scrollable extra-keys row. (M)
+- [ ] **3.3** Add long-press / explicit **Paste** affordance (clipboard read + `<input>` fallback for iOS; no trailing Enter). (M)
+- [ ] **3.4** Align terminal themes (`light`/`matrix-dark`/`matrix`) with brand palette; JetBrains Mono stack; ≥16px on terminal-adjacent inputs (iOS anti-zoom). (S)
+
+## Phase 4 — Mobile chrome & launcher
+- [ ] **4.1** `MobileAppSurface.tsx`: glass header, refined safe-area padding, consistent leading/title/trailing layout. (M)
+- [ ] **4.2** `MobileLauncher.tsx`: grid rhythm, tap scale states, entrance stagger, loading skeletons; decide letter-tiles vs real icons (Open Q). (M)
+- [ ] **4.3** `MobileShell.tsx`: app-switch transitions via `AnimatePresence` + motion variants (slide/fade). (L)
+- [ ] **4.4** Polish recent-apps switcher: card depth, animated close buttons (≥44px hit area), swipe affordance. (M)
+- [ ] **4.5** (Optional) Extract `MobileAppSwitcher.tsx` from `MobileShell.tsx` if it reduces risk/size. (M)
+
+## Phase 5 — Surfaces, toasts, sheets, PWA meta
+- [ ] **5.1** Integrate `sonner`: brand theme, position above bottom safe-area; replace ad-hoc notifications on mobile. (M)
+- [ ] **5.2** Integrate `vaul` bottom-sheet (drag handle) for ≥1 real surface (app actions / settings menu) to establish the pattern. (M)
+- [ ] **5.3** Built-in app interiors (Chat/Files/Settings): presentational token + spacing + touch-target pass; no behavior changes. (L)
+- [ ] **5.4** ⚠️ PWA meta/manifest audit: `viewport-fit=cover`, `interactive-widget=resizes-content`, light/dark `theme-color`, `apple-mobile-web-app-*`, `apple-touch-icon`; verify maskable icons + shortcuts. Coordinate with `fix-pwa-icon-safe-area`. (M)
+
+## Phase 6 — Testing & verification
+- [ ] **6.1** Extend Playwright shell screenshots (mobile viewport): launcher, switcher mid-transition, built-in app, terminal WebGL-on, terminal keyboard-open. (M)
+- [ ] **6.2** Manual device checklist: installed PWA on iOS Safari + Android Chrome (safe areas, keyboard, transitions, toasts/sheets, terminal render + paste). (M)
+- [ ] **6.3** Desktop regression: `Desktop.tsx` + shared components unaffected. (S)
+
+---
+
+### Suggested order
+`1.x` → `2.x` → `3.x` → `4.x` → `5.x` → `6.x`. Phases 1 and 2 can proceed in parallel; everything after depends on Phase 2 primitives.

--- a/specs/102-mobile-pwa-terminal-polish/tasks.md
+++ b/specs/102-mobile-pwa-terminal-polish/tasks.md
@@ -51,3 +51,21 @@ Legend: `[ ]` todo · est. = rough size (S/M/L) · ⚠️ = check branch overlap
 
 ### Suggested order
 `1.x` → `2.x` → `3.x` → `4.x` → `5.x` → `6.x`. Phases 1 and 2 can proceed in parallel; everything after depends on Phase 2 primitives.
+
+### Wave map (swarm orchestration — disjoint files per wave; typecheck between waves)
+All agents work in the `102-mobile-pwa-terminal-polish` worktree (deps installed). Group by file owner to avoid collisions:
+
+- **Wave 1 (parallel):**
+  - W1a — Phase 1 WebGL → `TerminalPane.tsx`, `terminal-cache.ts`
+  - W1b — Phase 0.2 + Phase 2 primitives → `package.json` (add `sonner`,`vaul`), `globals.css`, `lib/motion.ts`, `hooks/useVisualViewport.ts`
+  - *(verify: `pnpm install` if package.json changed, then `pnpm typecheck`)*
+- **Wave 2 (parallel, after W1):**
+  - W2a — Phase 3 terminal mobile → `TerminalKeyBar.tsx`, `TerminalPane.tsx` (needs W1a + W1b)
+  - W2b — Phase 4 mobile chrome → `MobileAppSurface.tsx`, `MobileLauncher.tsx`, `MobileShell.tsx` (needs W1b)
+- **Wave 3 (parallel, after W2):**
+  - W3a — Phase 5.1/5.2 `sonner`+`vaul` integration (after W2b owns MobileShell)
+  - W3b — Phase 5.3 app interiors → Chat/Files/Settings (disjoint files)
+  - W3c — Phase 5.4 PWA meta/manifest (disjoint: document head + `manifest.json`)
+- **Wave 4 (after W3):** Phase 6 screenshots + final `pnpm typecheck` + `pnpm --dir shell lint` + desktop regression check.
+
+Single owner per shared file: `TerminalPane.tsx` (W1a→W2a), `globals.css` (W1b), `MobileShell.tsx` (W2b→W3a).

--- a/tests/shell/terminal-app-component.test.tsx
+++ b/tests/shell/terminal-app-component.test.tsx
@@ -312,10 +312,11 @@ describe("TerminalApp", () => {
 
     const keyBar = screen.getByTestId("terminal-key-bar");
     expect(keyBar.style.position).toBe("sticky");
-    expect(keyBar.style.bottom).toBe("var(--matrix-terminal-keybar-bottom)");
-    expect(keyBar.style.getPropertyValue("--matrix-terminal-keybar-bottom")).toBe("env(keyboard-inset-height, 0px)");
-    expect(keyBar.style.background).toContain("21, 24, 15");
-    expect(screen.getByRole("button", { name: "Control C" }).style.color).toContain("201, 199, 183");
+    expect(keyBar.style.bottom).toBe("var(--terminal-keyboard-height, 0px)");
+    expect(document.documentElement.style.getPropertyValue("--terminal-keyboard-height")).toBe("0px");
+    expect(keyBar.style.background).toBe("var(--mtk-bg)");
+    expect(keyBar.style.getPropertyValue("--mtk-bg")).toBe("#15180F");
+    expect(keyBar.style.getPropertyValue("--mtk-fg")).toBe("#C9C7B7");
     expect(screen.getByRole("button", { name: "Enter" })).toBeTruthy();
   });
 

--- a/tests/shell/terminal-app-component.test.tsx
+++ b/tests/shell/terminal-app-component.test.tsx
@@ -4,6 +4,8 @@ import React from "react";
 import { act, fireEvent, render, screen, within } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi, afterEach } from "vitest";
 
+const CANONICAL_SESSION_NAME_PATTERN = /^[a-z0-9][a-z0-9-]{0,30}$/;
+
 const paneGridSpy = vi.fn();
 const { saveThemeSpy, terminalSettingsState } = vi.hoisted(() => ({
   saveThemeSpy: vi.fn(async () => {}),
@@ -60,8 +62,6 @@ vi.mock("@/stores/terminal-settings", () => {
 });
 
 import { TerminalApp } from "../../shell/src/components/terminal/TerminalApp.js";
-
-const CANONICAL_SESSION_NAME_PATTERN = /^(matrix-[a-z0-9]+|[a-z]+-[a-z]+-[a-z0-9]+)$/;
 
 class ResizeObserverMock {
   observe() {}
@@ -344,7 +344,7 @@ describe("TerminalApp", () => {
     });
 
     expect(screen.queryByRole("tablist", { name: "Terminal tabs" })).toBeNull();
-    expect(screen.getByText("matrix-os")).toBeTruthy();
+    expect(screen.getByText("matrix os")).toBeTruthy();
     expect(screen.getByPlaceholderText("Find a session...")).toBeTruthy();
     expect(screen.getByText("Active")).toBeTruthy();
     expect(screen.getByText("Background")).toBeTruthy();

--- a/tests/shell/terminal-keybar.test.tsx
+++ b/tests/shell/terminal-keybar.test.tsx
@@ -45,27 +45,27 @@ describe("TerminalKeyBar", () => {
     restoreWindowProperty("visualViewport", originalVisualViewport);
   });
 
-  it("uses virtual keyboard env inset when visualViewport has no keyboard overlap", () => {
+  it("resets the shared terminal keyboard height when visualViewport has no keyboard overlap", () => {
     render(<TerminalKeyBar onSend={vi.fn()} />);
 
     const keyBar = screen.getByTestId("terminal-key-bar");
-    expect(keyBar.style.getPropertyValue("--matrix-terminal-keybar-bottom")).toBe("env(keyboard-inset-height, 0px)");
+    expect(keyBar.style.bottom).toBe("var(--terminal-keyboard-height, 0px)");
+    expect(document.documentElement.style.getPropertyValue("--terminal-keyboard-height")).toBe("0px");
   });
 
-  it("tracks visualViewport keyboard overlap for mobile browsers without keyboard-inset env support", () => {
+  it("tracks visualViewport keyboard overlap in the shared terminal keyboard height", () => {
     const viewport = installVisualViewportMock({ height: 560, offsetTop: 0 });
 
     render(<TerminalKeyBar onSend={vi.fn()} />);
 
-    const keyBar = screen.getByTestId("terminal-key-bar");
-    expect(keyBar.style.getPropertyValue("--matrix-terminal-keybar-bottom")).toBe("240px");
+    expect(document.documentElement.style.getPropertyValue("--terminal-keyboard-height")).toBe("240px");
 
     act(() => {
       viewport.height = 800;
       viewport.dispatch("resize");
     });
 
-    expect(keyBar.style.getPropertyValue("--matrix-terminal-keybar-bottom")).toBe("env(keyboard-inset-height, 0px)");
+    expect(document.documentElement.style.getPropertyValue("--terminal-keyboard-height")).toBe("0px");
   });
 
   it("sends enter from the primary mobile key row", () => {
@@ -96,9 +96,9 @@ describe("TerminalKeyBar", () => {
 
     const moreButton = screen.getByRole("button", { name: "Show more keys" });
     // Fixed-width control, never subject to the key row's horizontal scroll/clip.
-    expect(moreButton.style.flex).toBe("0 0 44px");
+    expect(moreButton.style.flex).toBe("0 0 auto");
     expect(moreButton.style.marginLeft).toBe("");
-    expect(moreButton.style.touchAction).toBe("manipulation");
+    expect(moreButton.className).toContain("mtk-ghost");
 
     // Primary keys live in a sibling scroller that falls back to horizontal
     // scrolling when they overflow a narrow (<=360px) viewport.
@@ -116,13 +116,14 @@ describe("TerminalKeyBar", () => {
     fireEvent.click(screen.getByRole("button", { name: "Show more keys" }));
     fireEvent.click(screen.getByRole("tab", { name: "Sym keyboard" }));
 
-    expect(screen.getByRole("tab", { name: "Sym keyboard" }).getAttribute("aria-selected")).toBe("true");
-    expect(screen.getByRole("tab", { name: "Sym keyboard" }).style.touchAction).toBe("manipulation");
+    const symTab = screen.getByRole("tab", { name: "Sym keyboard" });
+    expect(symTab.getAttribute("aria-selected")).toBe("true");
+    expect(symTab.className).toContain("mtk-tab");
     expect(screen.getByRole("button", { name: "$" })).toBeTruthy();
 
     fireEvent.click(screen.getByRole("tab", { name: "Nav keyboard" }));
 
     expect(screen.getByRole("button", { name: "Control U" })).toBeTruthy();
-    expect(screen.getByRole("button", { name: "Show fewer keys" }).style.touchAction).toBe("manipulation");
+    expect(screen.getByRole("button", { name: "Show fewer keys" }).className).toContain("mtk-ghost");
   });
 });


### PR DESCRIPTION
## Summary
- Add spec 102 for mobile PWA/terminal polish.
- Move mobile terminal into the tab layout and add mobile terminal surface primitives.
- Add sheet/toast/mobile shell chrome polish and associated mobile tests.

## Stack
Split from #652.

- Previous: #662
- Next: #664

## Validation
- `git diff --check origin/main..stack/pr652-10-install-polish`
- Not rerun during the split: mobile/shell tests, typecheck, react-doctor.

## Invariants
- Source of truth: terminal session state remains in the existing gateway-backed terminal state/client paths.
- Lock/transaction scope: no database writes or persistence transactions in this slice.
- Acceptable orphan states: mobile chrome changes preserve existing runtime routes and session retry behavior.
- Auth source of truth: unchanged.
- Deferred scope: dock cleanup, Hermes proxy, and final install polish are later stack layers.
