### PR TITLE
feat(shell): polish install and billing screens

### DIFF
--- a/shell/src/components/BillingGate.tsx
+++ b/shell/src/components/BillingGate.tsx
@@ -3,13 +3,14 @@
 import { Suspense, useEffect, useRef, useState, type ReactNode } from "react";
 import { useAuth } from "@clerk/nextjs";
 import { useRouter, useSearchParams } from "next/navigation";
-import { AlertCircleIcon, CircleDollarSignIcon, Loader2Icon, LogInIcon } from "lucide-react";
+import { AlertCircleIcon, Loader2Icon } from "lucide-react";
 import {
   getMatrixBillingSuccessRedirectUrl,
 } from "@/lib/billing";
 import { useMatrixBillingAccess } from "@/hooks/useMatrixBillingAccess";
 import { capturePostHogEvent, capturePostHogLog } from "@/lib/posthog-client";
 import { SHELL_Z_INDEX } from "@/lib/shell-layering";
+import { MatrixBootMark } from "@/components/MatrixBootMark";
 import {
   DefaultInstallsStep,
 } from "@/components/onboarding/DefaultInstallsStep";
@@ -133,9 +134,7 @@ function SignInRedirecting() {
           }}
           aria-hidden="true"
         />
-        <div className="relative flex size-14 items-center justify-center rounded-2xl border border-forest/15 bg-cream/50 shadow-sm">
-          <LogInIcon className="size-6 text-ember" aria-hidden="true" />
-        </div>
+        <MatrixBootMark size={60} className="relative" />
         <div className="relative space-y-2">
           <h1 className="text-xl font-semibold tracking-tight text-deep">
             Opening Matrix OS sign in
@@ -178,15 +177,14 @@ function SubscriptionConfirmationPending({
         />
 
         <div className="relative flex flex-col items-center gap-5 p-8 text-center">
-          <div className="flex size-14 items-center justify-center rounded-2xl border border-forest/15 bg-white shadow-sm">
-            {failed ? (
-              <AlertCircleIcon className="size-6 text-ember" aria-hidden="true" />
-            ) : (
-              <Loader2Icon className="size-6 animate-spin text-ember" aria-hidden="true" />
-            )}
-          </div>
+          <MatrixBootMark size={64} />
           <div className="space-y-2">
-            <p className="text-xs font-semibold uppercase tracking-[0.2em] text-forest/60">
+            <p className="flex items-center justify-center gap-2 text-xs font-semibold uppercase tracking-[0.2em] text-forest/60">
+              {failed ? (
+                <AlertCircleIcon className="size-3.5 text-ember" aria-hidden="true" />
+              ) : (
+                <Loader2Icon className="size-3.5 animate-spin text-ember" aria-hidden="true" />
+              )}
               Matrix OS · Billing
             </p>
             <h1 className="text-2xl font-semibold tracking-tight text-deep">
@@ -245,9 +243,7 @@ function BillingStatusLoading() {
         className="flex w-full max-w-md flex-col items-center gap-4 rounded-lg border border-forest/15 bg-white/85 p-6 text-center shadow-[0_24px_80px_rgba(50,53,46,0.16)]"
         aria-live="polite"
       >
-        <span className="flex size-12 items-center justify-center rounded-md border border-forest/15 bg-cream/60">
-          <CircleDollarSignIcon className="size-5 text-ember" aria-hidden="true" />
-        </span>
+        <MatrixBootMark size={56} />
         <span className="flex items-center gap-2 text-sm font-medium text-forest">
           <Loader2Icon className="size-4 animate-spin text-ember" aria-hidden="true" />
           Loading billing status

--- a/shell/src/components/BootSequence.tsx
+++ b/shell/src/components/BootSequence.tsx
@@ -12,6 +12,7 @@ import {
   ServerIcon,
 } from "lucide-react";
 import { useJourney, type JourneyState } from "@/hooks/useJourney";
+import { MatrixBootMark } from "@/components/MatrixBootMark";
 import {
   DefaultInstallsStep,
 } from "@/components/onboarding/DefaultInstallsStep";
@@ -77,9 +78,7 @@ function BootShell({
         className="flex w-full max-w-5xl flex-col items-center gap-6 rounded-lg border border-forest/15 bg-white/85 p-6 shadow-[0_24px_80px_rgba(50,53,46,0.16)]"
         aria-live="polite"
       >
-        <div className="flex size-12 items-center justify-center rounded-md border border-forest/15 bg-cream/60">
-          <ServerIcon className="size-5 text-ember" aria-hidden="true" />
-        </div>
+        <MatrixBootMark size={60} />
         <div className="flex w-full flex-wrap items-center justify-center gap-2 text-xs font-medium text-forest/70">
           {STEP_ORDER.map((step, index) => {
             const state = getStepState(step, activeStep);

--- a/shell/src/components/MatrixBootMark.tsx
+++ b/shell/src/components/MatrixBootMark.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import type { CSSProperties } from "react";
+
+// The Matrix wordmark/glyph rendered as a CSS mask over a forest→gold shimmer,
+// matching the onboarding hero. Shared by the boot/billing screens so every
+// "loading / booting your computer" state shows the same branded mark instead
+// of a generic lucide icon. Self-contained keyframe so it works on any route.
+const SHIMMER =
+  "linear-gradient(90deg, #2F392C 0%, #2F392C 24%, #C4A265 50%, #2F392C 76%, #2F392C 100%)";
+
+export function MatrixBootMark({
+  size = 72,
+  className = "",
+  style,
+}: {
+  size?: number;
+  className?: string;
+  style?: CSSProperties;
+}) {
+  return (
+    <>
+      <style>{
+        "@keyframes matrix-boot-shimmer{0%,100%{background-position:0% 0}50%{background-position:100% 0}}"
+      }</style>
+      <div
+        // react-doctor-disable-next-line react-doctor/prefer-tag-over-role -- not a plain <img>: the logo is a CSS mask of the SVG over an animated shimmer gradient, which an <img> cannot reproduce
+        role="img"
+        aria-label="Matrix OS"
+        className={className}
+        style={{
+          width: size,
+          height: size,
+          WebkitMask: "url('/matrix-logo.svg') no-repeat center / contain",
+          mask: "url('/matrix-logo.svg') no-repeat center / contain",
+          background: `${SHIMMER} 0 0 / 300% 100%`,
+          animation: "matrix-boot-shimmer 7s ease-in-out infinite",
+          ...style,
+        }}
+      />
+    </>
+  );
+}

--- a/shell/src/components/onboarding/DefaultInstallsStep.tsx
+++ b/shell/src/components/onboarding/DefaultInstallsStep.tsx
@@ -14,7 +14,7 @@ import {
 function DeveloperToolLogo({ logoPath }: { logoPath: string }) {
   return (
     <span
-      className="flex size-9 shrink-0 items-center justify-center rounded-lg border border-forest/10 bg-white p-2 shadow-sm"
+      className="flex size-9 shrink-0 items-center justify-center overflow-hidden rounded-lg border border-white/15 bg-[#2F392C] p-1.5 shadow-sm"
       aria-hidden="true"
     >
       <Image src={logoPath} alt="" width={20} height={20} className="size-full object-contain" draggable={false} />

--- a/shell/src/components/onboarding/DefaultInstallsStep.tsx
+++ b/shell/src/components/onboarding/DefaultInstallsStep.tsx
@@ -84,12 +84,12 @@ export function DefaultInstallsStep({
   return (
     <div className="flex w-full max-w-4xl flex-col gap-4 text-left">
       <section className="rounded-[22px] border border-forest/15 bg-[#fbf7ed] p-4 shadow-[0_24px_80px_rgba(50,53,46,0.12)] sm:p-5">
-        <p className="text-xs font-semibold uppercase tracking-[0.2em] text-forest/60">Default installs</p>
+        <p className="text-xs font-semibold uppercase tracking-[0.2em] text-forest/60">Optional · Coding agents</p>
         <h1 className="mt-2 text-2xl font-semibold tracking-tight text-deep sm:text-3xl">
-          Choose what Matrix installs first
+          Preinstall coding agents?
         </h1>
         <p className="mt-2 max-w-2xl text-sm leading-6 text-forest/70">
-          Choose command-line agents to preinstall on this VPS.
+          Pick any to have ready on your VPS — or skip and install them later anytime from the terminal’s + menu.
         </p>
       </section>
 
@@ -101,23 +101,33 @@ export function DefaultInstallsStep({
         </p>
       ) : null}
 
-      <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
         <p className="text-xs text-forest/55">
-          CLI login happens after the VPS is ready. Tool authentication is completed inside each CLI.
+          You can install or sign into agents anytime from the terminal’s + menu after the VPS is ready.
         </p>
-        <button
-          type="button"
-          onClick={() => onBuild(selectedTools)}
-          disabled={loading}
-          className="inline-flex h-11 items-center justify-center gap-2 rounded-xl bg-forest px-5 text-sm font-semibold text-white shadow-[0_14px_30px_rgba(63,74,58,0.18)] transition hover:bg-forest/90 disabled:cursor-not-allowed disabled:opacity-60"
-        >
-          {loading ? (
-            <Loader2Icon className="size-4 animate-spin" aria-hidden="true" />
-          ) : (
-            <ServerIcon className="size-4" aria-hidden="true" />
-          )}
-          Build VPS
-        </button>
+        <div className="flex items-center gap-2">
+          <button
+            type="button"
+            onClick={() => onBuild([])}
+            disabled={loading}
+            className="inline-flex h-11 items-center justify-center rounded-xl border border-forest/15 bg-white px-4 text-sm font-semibold text-forest transition hover:bg-cream/60 disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            Skip for now
+          </button>
+          <button
+            type="button"
+            onClick={() => onBuild(selectedTools)}
+            disabled={loading}
+            className="inline-flex h-11 items-center justify-center gap-2 rounded-xl bg-forest px-5 text-sm font-semibold text-white shadow-[0_14px_30px_rgba(63,74,58,0.18)] transition hover:bg-forest/90 disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            {loading ? (
+              <Loader2Icon className="size-4 animate-spin" aria-hidden="true" />
+            ) : (
+              <ServerIcon className="size-4" aria-hidden="true" />
+            )}
+            {selectedTools.length > 0 ? "Install & build" : "Build VPS"}
+          </button>
+        </div>
       </div>
     </div>
   );

--- a/shell/src/components/onboarding/developer-tools.ts
+++ b/shell/src/components/onboarding/developer-tools.ts
@@ -1,10 +1,12 @@
 export type DeveloperToolId = "codex" | "claude-code" | "opencode" | "pi";
 
+// Same brand logos the terminal's new-session menu uses (/agent-logos/*.png).
+// These are light-on-dark, so the installs chip renders them on a dark tile.
 export const developerToolOptions: Array<{ id: DeveloperToolId; label: string; logoPath: string }> = [
-  { id: "codex", label: "Codex", logoPath: "/agents/codex.svg" },
-  { id: "claude-code", label: "Claude Code", logoPath: "/agents/claude-code.svg" },
-  { id: "opencode", label: "OpenCode", logoPath: "/agents/opencode.svg" },
-  { id: "pi", label: "Pi", logoPath: "/agents/pi.svg" },
+  { id: "codex", label: "Codex", logoPath: "/agent-logos/codex.png" },
+  { id: "claude-code", label: "Claude Code", logoPath: "/agent-logos/claude-code.png" },
+  { id: "opencode", label: "OpenCode", logoPath: "/agent-logos/opencode-white.png" },
+  { id: "pi", label: "Pi", logoPath: "/agent-logos/pi-coding-agent.png" },
 ];
 
 export const defaultDeveloperTools: DeveloperToolId[] = developerToolOptions.map((tool) => tool.id);

--- a/shell/src/components/terminal/TerminalApp.tsx
+++ b/shell/src/components/terminal/TerminalApp.tsx
@@ -4832,7 +4832,6 @@ function NewSessionMenu({
       </div>
       <NewSessionMenuItem
         label="Shell"
-        shortcut="⌘T"
         active
         icon={(
           <TerminalIcon
@@ -4850,7 +4849,6 @@ function NewSessionMenu({
           <NewSessionMenuItem
             key={option.id}
             label={option.label}
-            shortcut={installed ? option.shortcut : undefined}
             install={!installed}
             icon={<TerminalAgentLogo muted={!installed} option={option} />}
             onClick={() => onCreateAgent(option, installed)}
@@ -4887,14 +4885,12 @@ function TerminalAgentLogo({ option, muted }: { option: TerminalAgentOption; mut
 
 function NewSessionMenuItem({
   label,
-  shortcut,
   icon,
   active = false,
   install = false,
   onClick,
 }: {
   label: string;
-  shortcut?: string;
   icon: React.ReactNode;
   active?: boolean;
   install?: boolean;
@@ -4941,17 +4937,15 @@ function NewSessionMenuItem({
       >
         {label}
       </span>
-      <span
-        style={{
-          color: "var(--terminal-drawer-subtle)",
-          alignItems: "center",
-          display: "flex",
-          flex: "0 0 62px",
-          justifyContent: "flex-end",
-          minWidth: 62,
-        }}
-      >
-        {install ? (
+      {install ? (
+        <span
+          style={{
+            alignItems: "center",
+            display: "flex",
+            flexShrink: 0,
+            justifyContent: "flex-end",
+          }}
+        >
           <span
             data-testid="terminal-agent-install-pill"
             style={{
@@ -4972,32 +4966,8 @@ function NewSessionMenuItem({
           >
             Install
           </span>
-        ) : (
-          <span
-            style={{
-              alignItems: "center",
-              background: shortcut ? "var(--terminal-drawer-action-bg)" : "transparent",
-              border: shortcut ? "1px solid var(--terminal-drawer-action-border)" : "1px solid transparent",
-              borderRadius: 6,
-              boxSizing: "border-box",
-              color: "var(--terminal-drawer-action-fg)",
-              display: "inline-flex",
-              fontFamily: "Inter, system-ui, sans-serif",
-              fontSize: 11,
-              fontWeight: 800,
-              height: 22,
-              justifyContent: "center",
-              letterSpacing: "0.02em",
-              lineHeight: "14px",
-              minWidth: shortcut ? 38 : 0,
-              padding: shortcut ? "0 6px" : 0,
-              textAlign: "center",
-            }}
-          >
-            {shortcut ?? ""}
-          </span>
-        )}
-      </span>
+        </span>
+      ) : null}
     </button>
   );
 }

--- a/shell/src/hooks/useWindowManager.ts
+++ b/shell/src/hooks/useWindowManager.ts
@@ -4,6 +4,7 @@ import { TERMINAL_MIN_WINDOW_HEIGHT, TERMINAL_MIN_WINDOW_WIDTH } from "@/lib/bui
 import { getGatewayUrl } from "@/lib/gateway";
 import { isPreVpsBillingSetupRoute } from "@/lib/pre-vps-shell";
 import { SHELL_WINDOW_Z_INDEX_MAX, SHELL_WINDOW_Z_INDEX_START } from "@/lib/shell-layering";
+import { useDesktopMode } from "@/stores/desktop-mode";
 
 export interface AppWindow {
   id: string;
@@ -149,6 +150,30 @@ function debouncedSave(state: WindowManagerState) {
   }, 500);
 }
 
+function computeDefaultWindowSize(path: string): { width: number; height: number } {
+  const vw = typeof window !== "undefined" ? window.innerWidth : 1280;
+  const vh = typeof window !== "undefined" ? window.innerHeight : 800;
+  const minSize = getMinimumWindowSize(path);
+  return {
+    width: Math.round(Math.min(1200, Math.max(minSize.width, vw * 0.6))),
+    height: Math.round(Math.min(900, Math.max(minSize.height, vh * 0.7))),
+  };
+}
+
+// Float a fresh window centered on the viewport (dev/desktop modes). A small
+// per-window step keeps stacked opens from perfectly overlapping while staying
+// near the middle — never marching off to the right like the canvas cascade.
+function centeredWindowPosition(path: string, offsetIndex: number): { x: number; y: number } {
+  const vw = typeof window !== "undefined" ? window.innerWidth : 1280;
+  const vh = typeof window !== "undefined" ? window.innerHeight : 800;
+  const { width, height } = computeDefaultWindowSize(path);
+  const step = (offsetIndex % 6) * 28;
+  return {
+    x: Math.max(20, Math.round((vw - width) / 2) + step),
+    y: Math.max(20, Math.round((vh - height) / 2) + step),
+  };
+}
+
 function createWindowRecord(
   state: WindowManagerState,
   name: string,
@@ -157,11 +182,8 @@ function createWindowRecord(
   fallbackY: number,
 ): AppWindow {
   const saved = state.closedLayouts.get(path);
-  const vw = typeof window !== "undefined" ? window.innerWidth : 1280;
-  const vh = typeof window !== "undefined" ? window.innerHeight : 800;
   const minSize = getMinimumWindowSize(path);
-  const defaultWidth = Math.round(Math.min(1200, Math.max(minSize.width, vw * 0.6)));
-  const defaultHeight = Math.round(Math.min(900, Math.max(minSize.height, vh * 0.7)));
+  const { width: defaultWidth, height: defaultHeight } = computeDefaultWindowSize(path);
 
   return {
     id: `win-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`,
@@ -232,16 +254,27 @@ export const useWindowManager = create<WindowManagerState & WindowManagerActions
           };
         }
 
-        // Compute fallback position to the right of the rightmost visible window
-        let fallbackX = dockXOffset + 20;
-        let fallbackY = 20;
+        // Position the new window. Canvas pans to the window after it opens, so
+        // a spatial cascade to the right of the rightmost window is fine there.
+        // Dev/desktop windows float in place, so center them on the viewport
+        // instead of marching off to the right of the last one.
         const visible = zState.windows.filter((w) => !w.minimized);
-        if (visible.length > 0) {
-          const rightmost = visible.reduce((best, w) =>
-            (w.x + w.width) > (best.x + best.width) ? w : best,
-          );
-          fallbackX = rightmost.x + rightmost.width + 24;
-          fallbackY = rightmost.y;
+        let fallbackX: number;
+        let fallbackY: number;
+        if (useDesktopMode.getState().mode === "canvas") {
+          fallbackX = dockXOffset + 20;
+          fallbackY = 20;
+          if (visible.length > 0) {
+            const rightmost = visible.reduce((best, w) =>
+              (w.x + w.width) > (best.x + best.width) ? w : best,
+            );
+            fallbackX = rightmost.x + rightmost.width + 24;
+            fallbackY = rightmost.y;
+          }
+        } else {
+          const pos = centeredWindowPosition(path, visible.length);
+          fallbackX = pos.x;
+          fallbackY = pos.y;
         }
 
         const nextWindow = createWindowRecord(
@@ -284,12 +317,15 @@ export const useWindowManager = create<WindowManagerState & WindowManagerActions
           };
         }
 
+        const exclusivePos = useDesktopMode.getState().mode === "canvas"
+          ? { x: dockXOffset + 20, y: 48 }
+          : centeredWindowPosition(path, 0);
         const nextWindow = createWindowRecord(
           { ...state, windows: zState.windows, nextZ: zState.nextZ },
           name,
           path,
-          dockXOffset + 20,
-          48,
+          exclusivePos.x,
+          exclusivePos.y,
         );
         return {
           windows: [...withMinimized, nextWindow],

--- a/tests/shell/billing-gate.test.tsx
+++ b/tests/shell/billing-gate.test.tsx
@@ -505,13 +505,13 @@ describe("BillingGate", () => {
       </BillingGate>,
     );
 
-    expect(await screen.findByText("Default installs")).toBeTruthy();
+    expect(await screen.findByText("Preinstall coding agents?")).toBeTruthy();
     for (const label of ["Codex", "Claude Code", "OpenCode", "Pi"]) {
       expect(screen.getByRole("checkbox", { name: label })).toHaveProperty("checked", true);
     }
     expect(fetchMock.mock.calls.some(([url]) => url === "/api/auth/provision-runtime")).toBe(false);
     fireEvent.click(screen.getByRole("checkbox", { name: "Pi" }));
-    fireEvent.click(screen.getByRole("button", { name: "Build VPS" }));
+    fireEvent.click(screen.getByRole("button", { name: "Install & build" }));
     await waitFor(() =>
       expect(fetchMock).toHaveBeenCalledWith(
         "/api/auth/provision-runtime",
@@ -566,8 +566,8 @@ describe("BillingGate", () => {
       </BillingGate>,
     );
 
-    expect(await screen.findByText("Default installs")).toBeTruthy();
-    fireEvent.click(screen.getByRole("button", { name: "Build VPS" }));
+    expect(await screen.findByText("Preinstall coding agents?")).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: "Install & build" }));
     expect(await screen.findByText("Matrix setup needs attention")).toBeTruthy();
     expect(screen.getByRole("button", { name: "Try again" })).toBeTruthy();
     expect(screen.queryByText("Confirming your subscription")).toBeNull();
@@ -606,8 +606,8 @@ describe("BillingGate", () => {
       </BillingGate>,
     );
 
-    expect(await screen.findByText("Default installs")).toBeTruthy();
-    fireEvent.click(screen.getByRole("button", { name: "Build VPS" }));
+    expect(await screen.findByText("Preinstall coding agents?")).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: "Install & build" }));
     expect(await screen.findByText("Matrix setup needs attention")).toBeTruthy();
     expect(screen.getByRole("button", { name: "Try again" })).toBeTruthy();
     expect(screen.queryByText("Confirming your subscription")).toBeNull();

--- a/tests/shell/boot-sequence.test.tsx
+++ b/tests/shell/boot-sequence.test.tsx
@@ -125,12 +125,12 @@ describe("BootSequence", () => {
 
     render(<BootSequence><div data-testid="shell">SHELL</div></BootSequence>);
 
-    expect(await screen.findByText("Default installs")).toBeTruthy();
+    expect(await screen.findByText("Preinstall coding agents?")).toBeTruthy();
     for (const label of ["Codex", "Claude Code", "OpenCode", "Pi"]) {
       expect(screen.getByRole("checkbox", { name: label })).toHaveProperty("checked", true);
     }
     fireEvent.click(screen.getByRole("checkbox", { name: "OpenCode" }));
-    fireEvent.click(screen.getByRole("button", { name: "Build VPS" }));
+    fireEvent.click(screen.getByRole("button", { name: "Install & build" }));
 
     await waitFor(() =>
       expect(fetchMock).toHaveBeenCalledWith(

--- a/tests/shell/window-manager.test.ts
+++ b/tests/shell/window-manager.test.ts
@@ -10,12 +10,14 @@ import {
   SHELL_WINDOW_Z_INDEX_MAX,
   SHELL_Z_INDEX,
 } from "../../shell/src/lib/shell-layering.js";
+import { useDesktopMode } from "../../shell/src/stores/desktop-mode.js";
 
 const fetchSpy = vi.fn().mockResolvedValue({ ok: true });
 vi.stubGlobal("fetch", fetchSpy);
 
 function resetStore() {
   resetWindowManagerLayoutPersistenceForTests();
+  useDesktopMode.setState({ mode: "dev", previousMode: null, _hydrated: true });
   useWindowManager.setState({
     windows: [],
     nextZ: 1,
@@ -66,7 +68,17 @@ describe("Window Manager Store", () => {
       expect(windows[0].minimized).toBe(false);
     });
 
-    it("places second window to the right of the first", () => {
+    it("centers dev-mode windows with a small cascade offset", () => {
+      const { openWindow } = useWindowManager.getState();
+      openWindow("App1", "apps/app1.html", 80);
+      openWindow("App2", "apps/app2.html", 80);
+      const [w1, w2] = useWindowManager.getState().windows;
+      expect(w2.x).toBe(w1.x + 28);
+      expect(w2.y).toBe(w1.y + 28);
+    });
+
+    it("places second canvas window to the right of the first", () => {
+      useDesktopMode.getState().setMode("canvas");
       const { openWindow } = useWindowManager.getState();
       openWindow("App1", "apps/app1.html", 80);
       openWindow("App2", "apps/app2.html", 80);


### PR DESCRIPTION
## Summary
- Polish boot/billing/install screens with Matrix brand treatment.
- Center new desktop windows and remove no-op terminal menu shortcuts.
- Make coding-agent installs optional with a Skip-for-now path.

## Stack
Split from #652.

- Previous: #665
- Top of stack.

## Validation
- `git diff --check origin/main..stack/pr652-10-install-polish`
- Not rerun during the split: shell tests/typecheck/react-doctor.

## Invariants
- Source of truth: setup/install progression remains in existing shell onboarding state.
- Lock/transaction scope: no database writes or persistence transactions in this slice.
- Acceptable orphan states: coding-agent install can be skipped and retried later.
- Auth source of truth: unchanged.
- Deferred scope: no further #652 changes after this layer.
