### PR TITLE
feat(www): add MDX blog

### DIFF
--- a/tests/observability/posthog-error-tracking.test.ts
+++ b/tests/observability/posthog-error-tracking.test.ts
@@ -607,7 +607,7 @@ describe("PostHog error tracking", () => {
     expect(shellPostHogClient).not.toContain("__loaded");
 
     const wwwPostHogClient = await readFile("www/src/lib/posthog-client.ts", "utf8");
-    expect(wwwPostHogClient).toContain("ensurePostHogInitialized(config)");
+    expect(wwwPostHogClient).toContain("ensurePostHogInitialized(posthog, config)");
     expect(wwwPostHogClient).toContain("posthog.init(currentConfig.token");
     expect(wwwPostHogClient).toContain("buildPostHogCookieConsentInitOptions");
     expect(wwwPostHogClient).not.toContain("__loaded");

--- a/tests/www/posthog-session-replay.test.ts
+++ b/tests/www/posthog-session-replay.test.ts
@@ -42,7 +42,7 @@ describe("www session replay init", () => {
   it("enables masked session recording with console log capture", async () => {
     const { initializeWwwPostHog } = await importWwwPostHog();
 
-    initializeWwwPostHog("US", TEST_CONFIG);
+    await initializeWwwPostHog("US", TEST_CONFIG);
 
     expect(posthogMock.init).toHaveBeenCalledTimes(1);
     const [, options] = posthogMock.init.mock.calls[0] as [string, Record<string, unknown>];
@@ -55,7 +55,7 @@ describe("www session replay init", () => {
     vi.stubEnv("NEXT_PUBLIC_POSTHOG_DISABLE_REPLAY", "1");
     const { initializeWwwPostHog } = await importWwwPostHog();
 
-    initializeWwwPostHog("US", TEST_CONFIG);
+    await initializeWwwPostHog("US", TEST_CONFIG);
 
     expect(posthogMock.init).toHaveBeenCalledTimes(1);
     const [, options] = posthogMock.init.mock.calls[0] as [string, Record<string, unknown>];

--- a/www/content/blog/canvas-first-workspace.mdx
+++ b/www/content/blog/canvas-first-workspace.mdx
@@ -1,0 +1,53 @@
+---
+title: "Canvas first, desktop still matters"
+description: "How Matrix OS thinks about the shell: a spatial canvas for active work, with desktop compatibility where familiar windowing still helps."
+publishedAt: "2026-06-17"
+updatedAt: "2026-06-17"
+author: "Matrix OS"
+category: "Design"
+readTime: "5 min read"
+keywords:
+  - AI workspace
+  - canvas interface
+  - background agents
+  - Matrix OS shell
+featured: false
+---
+
+The Matrix shell has two familiar ideas living side by side: a desktop and a canvas.
+
+The desktop gives people an immediate model. Apps open as windows. Terminals can sit next to previews. The dock and file browser are recognizable.
+
+The canvas is where the product is heading.
+
+## Why canvas works for agent supervision
+
+Agent work is spatial. A coding session has a repo, a terminal, a preview, a pull request, a log stream, and notes. A research session has source material, drafts, browser state, and follow-up actions.
+
+Putting those surfaces on a canvas makes the system easier to scan. The user can leave the active context arranged as a map instead of compressing everything into tabs.
+
+That matters when work runs in the background. Returning to a canvas should feel like returning to the state of the project, not reopening a collection of disconnected panels.
+
+## Familiar mechanics still matter
+
+Canvas-first does not mean novelty for its own sake. Matrix still needs predictable window behavior, keyboard focus, persistent positions, stable icons, and clean app launch rules.
+
+The product should feel calm under repeated use:
+
+- click to open,
+- click the same spot to close,
+- dismiss with Escape,
+- preserve layout across reloads,
+- keep panels overlaying instead of pushing content around.
+
+These rules are not cosmetic. They make the workspace reliable enough to supervise long-running agents.
+
+## The shell is a renderer
+
+The deeper architectural point is that neither canvas nor desktop owns the system.
+
+Matrix keeps the core headless. The shell discovers apps and renders state. The same workspace should eventually be controllable from web, mobile, CLI, and messaging channels.
+
+Canvas is the flagship visual expression because it matches how agent work spreads across artifacts. Desktop compatibility stays important because people already understand it.
+
+The best shell is the one that lets the computer keep working while the human stays oriented.

--- a/www/content/blog/cloud-computer-for-agents.mdx
+++ b/www/content/blog/cloud-computer-for-agents.mdx
@@ -1,0 +1,61 @@
+---
+title: "Agents need a computer, not another chat box"
+description: "Why Matrix OS treats background AI work as an operating-system problem: persistent files, terminals, apps, previews, and human control."
+publishedAt: "2026-06-29"
+updatedAt: "2026-06-29"
+author: "Matrix OS"
+category: "Product"
+readTime: "6 min read"
+keywords:
+  - cloud computer for AI agents
+  - AI agents
+  - persistent AI workspace
+  - Matrix OS
+featured: true
+---
+
+Most AI products still begin with a blank prompt. That is useful for answers, but it is a thin surface for work.
+Real work needs state. It needs a repo, a terminal, screenshots, logs, credentials, notes, and a place to return after the tab closes.
+
+Matrix OS starts from a different premise: if agents are going to do meaningful background work, they need a computer.
+
+## The session is the wrong unit
+
+Chat sessions are comfortable because they feel lightweight. They are also fragile. A session has a transcript, but it rarely owns the project state around it. The user still has to carry context between the IDE, browser, deploy logs, docs, task tracker, and terminal.
+
+When the model is asked to keep working, the session becomes a coordination layer over tools it does not really inhabit.
+
+Matrix makes the workspace the durable unit:
+
+- repos live on the machine,
+- shells keep running,
+- files are inspectable,
+- app state is persisted,
+- previews and logs are part of the same surface,
+- humans can pause, steer, or replace the agent.
+
+The agent is no longer borrowing a momentary tool call. It is operating inside a place.
+
+## Persistence changes the product shape
+
+Persistent state makes agent work easier to trust because every decision leaves artifacts behind. A pull request, a test log, a changed file, a terminal tab, and a note in the project are all more inspectable than a stream of confident prose.
+
+It also makes the interface quieter. Instead of asking users to paste error text and restate context, Matrix can put the agent next to the source material. The shell becomes the review surface.
+
+That is why the Matrix home screen is not a marketing dashboard. It is a computer: windows, files, apps, terminals, agents, and previews.
+
+## Background work still needs human control
+
+Autonomy without control is not the goal. Matrix is designed around long-running work that stays interruptible.
+
+The user can open the workspace, inspect the live state, stop a session, start another agent, review a diff, or move to a different device. The important part is continuity: the work does not vanish when a laptop sleeps or a browser tab is closed.
+
+This is the practical version of AI-native computing. Not a new chat window. A persistent operating environment for agents and the people supervising them.
+
+## What comes next
+
+The next frontier is making these workspaces feel less like remote boxes and more like personal computers that happen to be reachable from everywhere.
+
+That means better app surfaces, better mobile control, better identity, better permissions, and a public developer workflow that makes it natural to hand real tasks to agents.
+
+Agents need a place to work. Matrix OS is that place.

--- a/www/content/blog/keep-claude-code-running-after-laptop-closes.mdx
+++ b/www/content/blog/keep-claude-code-running-after-laptop-closes.mdx
@@ -1,0 +1,143 @@
+---
+title: "How to keep Claude Code running after you close your laptop"
+description: "Run Claude Code in a persistent cloud computer so agent sessions keep working after your laptop sleeps, disconnects, or runs out of battery."
+publishedAt: "2026-06-29"
+updatedAt: "2026-06-29"
+author: "Matrix OS"
+category: "Guides"
+readTime: "9 min read"
+keywords:
+  - keep Claude Code running
+  - Claude Code cloud computer
+  - run Claude Code 24/7
+  - AI coding agents
+  - persistent cloud session
+featured: true
+---
+
+Your Claude Code session dies the moment your laptop sleeps. Every developer who runs agents has hit this wall.
+
+You queue up a meaningful task: refactoring a module, triaging a backlog of Sentry errors, drafting a PR description for a gnarly diff, or working through a test failure. Then you close the lid. When you come back, the terminal is dead. The work stopped when your machine went to sleep.
+
+That is the core problem with running AI coding agents locally: your laptop becomes the uptime guarantee.
+
+## Why Claude Code sessions die when you disconnect
+
+Claude Code runs as a process on your machine. When your laptop sleeps, suspends, loses network, or runs out of battery, that process can stop. The terminal is local, the runtime is local, and the session is only as persistent as the device under it.
+
+You can fight this with `tmux` or `screen` on a remote VPS you configure yourself. That works, and many developers are doing exactly that. But it creates a second job: provisioning the machine, installing dependencies, configuring SSH, managing keys, keeping repo state in sync, and rebuilding the setup when something drifts.
+
+The underlying need is simpler: Claude Code needs a computer that stays on. Your laptop is not that computer.
+
+## The straightforward fix: a persistent cloud session
+
+The right mental model is a dedicated machine in the cloud that runs your agents continuously. You start Claude Code there, hand it a task, disconnect, and come back to progress. Your devices become viewers and control surfaces. The work lives on the cloud computer.
+
+[Matrix OS](https://matrix-os.com) provisions that kind of workspace: a dedicated hosted machine with your files, repositories, terminals, previews, and agent sessions in one place.
+
+Sessions survive because they run on the hosted machine, not on your laptop. You can close your laptop, switch to a phone browser, or step away entirely. Claude Code keeps working.
+
+## Setting up a persistent Claude Code session
+
+Here is what the workflow looks like in practice.
+
+### 1. Provision your cloud machine
+
+Sign up at [matrix-os.com](https://matrix-os.com) and pick a hosted runtime plan. The Starter tier is enough for most single-agent workflows. If you want to run Claude Code alongside Codex, Cursor, or another agent in parallel, the Builder tier gives you more headroom.
+
+Once your machine provisions, you have a dedicated Linux environment with persistent files, repos, terminals, and runtime state.
+
+### 2. Open the web shell
+
+Open `app.matrix-os.com`, launch a terminal, and you are working directly on your cloud machine. No local SSH ceremony is required for the browser workflow.
+
+Clone your repo, install dependencies, authenticate the tools you use, and set up Claude Code the same way you would on any Linux machine. The difference is that this environment stays on after your laptop disconnects.
+
+### 3. Start Claude Code and hand it a task
+
+With the repo ready, start Claude Code inside the Matrix terminal and give it scoped work:
+
+```bash
+claude "Fix the open bug-tagged issues in this repo. Create one branch per fix, run the relevant tests, and open draft PRs."
+```
+
+Claude Code can read the codebase, make changes, run tests, and leave branch or PR artifacts behind.
+
+### 4. Close your laptop
+
+This is the part that changes the habit. Close the lid. The session keeps running on the Matrix machine.
+
+When you reopen the workspace from any browser, the terminal is still there. The files are still there. The agent did not depend on your laptop staying awake.
+
+### 5. Attach from the CLI
+
+If you prefer a terminal over the browser, the Matrix CLI is designed around the same durable workspace model. You can attach to running work from another machine instead of recreating the setup locally.
+
+The important point is that the session was never paused. You are reconnecting to work that stayed alive.
+
+## What to hand to Claude Code overnight
+
+Persistent sessions are most useful when the task has clear inputs and outputs and does not need your attention every few minutes. Good candidates include:
+
+- **Bug triage from Linear, GitHub, or Sentry** - point Claude Code at a bounded list of issues and ask for one branch per attempted fix.
+- **Dependency updates** - upgrade packages, run the test suite, and summarize what broke.
+- **Test coverage** - generate focused tests for modules below a coverage threshold.
+- **Release notes** - summarize merged PRs into a draft changelog.
+- **Code review prep** - clean up a diff, add missing docs, and prepare a PR description before human review.
+
+Tasks that require judgment calls still need human checkpoints. The goal is not to remove you from the loop. It is to stop making your laptop the thing that keeps the loop alive.
+
+## Running multiple agents in parallel
+
+One benefit of a persistent cloud computer is that you are not constrained to one local terminal session. You can run Claude Code on one branch, Codex on another task, and Cursor in a third terminal without tying up your laptop CPU, RAM, or battery.
+
+Matrix OS is built around this kind of agent workspace. Terminals, repos, previews, files, and review artifacts live together, so parallel work is easier to inspect when you return.
+
+The practical workflow becomes:
+
+- give each agent a bounded task,
+- keep each task on a separate branch,
+- let the sessions continue in the background,
+- review the diffs and logs from any device.
+
+## Matrix OS vs a raw VPS
+
+A raw VPS is the right instinct. It gives Claude Code a machine that stays on. The tradeoff is that you own every layer of the developer experience.
+
+With a raw VPS, you handle OS setup, SSH, keys, package installs, browser access, session tools, mobile access, previews, and cleanup. That can be a good fit if you want total control.
+
+Matrix OS is for developers who want the persistent machine plus the product layer around it: browser shell, durable terminals, files, app surfaces, CLI access, agent-oriented workflows, and a workspace that is designed for long-running coding agents from the start.
+
+## The practical difference
+
+Running Claude Code locally means the session is only as reliable as your laptop. A sleep cycle, dead battery, network drop, or accidental terminal close can stop the work.
+
+Running Claude Code on a persistent cloud computer means the session is tied to the uptime of the hosted machine. You can come back to progress instead of a dead terminal.
+
+That is the whole shift: stop treating AI coding agents like a local tab. Give them a computer that stays on.
+
+## FAQs
+
+### Does Claude Code work out of the box on Matrix OS?
+
+You install and configure Claude Code on your Matrix machine the same way you would on any Linux machine. Matrix OS does not need to change how Claude Code works. It gives Claude Code a persistent computer to run on.
+
+### Can I run Claude Code and Cursor at the same time?
+
+Yes. Open separate terminal sessions and run each tool independently. For parallel agent work, use separate branches or worktrees so the agents do not collide on the same files.
+
+### Is my code private on Matrix OS?
+
+Matrix OS gives each user an isolated hosted workspace with owner-controlled files and runtime state. Your code and agent artifacts live in your environment, not in a shared short-lived sandbox.
+
+### Why not just use a VPS?
+
+You can. A raw VPS is flexible and powerful, but it leaves the workflow layer to you. Matrix OS packages the persistent machine with a web shell, CLI access, session continuity, and agent-oriented workspace surfaces.
+
+### Can I check progress from my phone?
+
+Yes. The web workspace is available from a browser, including mobile browsers, so you can inspect progress without reopening the original laptop.
+
+### How much does it cost?
+
+The current hosted runtime plans start at $14/month for a dedicated Starter machine. Heavier parallel agent workflows fit better on larger plans.

--- a/www/content/blog/web4-operating-system.mdx
+++ b/www/content/blog/web4-operating-system.mdx
@@ -1,0 +1,60 @@
+---
+title: "Web 4 is an operating system"
+description: "A practical definition of Web 4: AI as the kernel, files as memory, and every interface as a shell over the same durable computer."
+publishedAt: "2026-06-24"
+updatedAt: "2026-06-24"
+author: "Matrix OS"
+category: "Architecture"
+readTime: "7 min read"
+keywords:
+  - Web 4
+  - AI operating system
+  - AI kernel
+  - cloud computer
+featured: true
+---
+
+Web 1 published pages. Web 2 made them social. Web 3 tried to make ownership programmable.
+
+Web 4 is the moment the web becomes an operating system for AI work.
+
+That sounds abstract until you translate it into product requirements. A Web 4 system needs durable identity, a real filesystem, long-running processes, connected channels, local ownership of data, and an AI kernel that can route work across tools.
+
+## The kernel is the agent loop
+
+In Matrix OS, the AI kernel is not a sidebar assistant. It is the process that receives intent, gathers context, calls tools, launches sub-agents, and writes state back to disk or Postgres.
+
+That kernel must work headlessly. The web shell is important, but it is only one renderer. The same core should be reachable from CLI, mobile, Telegram, Slack, Discord, and API surfaces.
+
+This gives the system a simple rule: shells come and go, but the computer keeps running.
+
+## Files are still the right primitive
+
+AI systems often hide their memory behind opaque databases and product-specific history panes. That makes them hard to inspect and hard to move.
+
+Matrix keeps identity and configuration as files:
+
+- apps,
+- skills,
+- agent definitions,
+- theme and desktop state,
+- channel configuration,
+- system notes.
+
+User and app data can still live in Postgres where relational queries matter. The principle is not "everything must be text." The principle is that the owner can inspect, export, and carry the system forward.
+
+## Web 4 needs multiple shells
+
+People will not use one interface for all AI work. A developer may start a job from CLI, monitor it from mobile, review it in a browser, and get a notification in chat.
+
+That only works if every shell points at the same durable core. Otherwise the product becomes a collection of disconnected assistant surfaces.
+
+The OS metaphor matters because it keeps the boundary honest. A shell renders. The kernel coordinates. Files persist. Apps declare what they need. Permissions and logs sit at the edges.
+
+## The web gets a computer
+
+The browser is good at documents and apps. It is less good at being a persistent workspace by itself.
+
+Web 4 does not replace the browser. It gives the browser a computer to connect to: one with state, processes, files, agents, and recoverable work.
+
+That is the shape Matrix OS is building toward.

--- a/www/instrumentation-client.ts
+++ b/www/instrumentation-client.ts
@@ -1,3 +1,29 @@
+export {};
+
 import { initializeWwwPostHog } from "./src/lib/posthog-client";
 
-initializeWwwPostHog(document.documentElement.dataset.posthogVisitorCountry);
+type MatrixIdleDeadline = { didTimeout: boolean; timeRemaining(): number };
+type IdleCallbackHandle = ReturnType<typeof setTimeout>;
+type IdleWindow = Window &
+  typeof globalThis & {
+    requestIdleCallback?: (callback: (deadline: MatrixIdleDeadline) => void, options?: { timeout: number }) => IdleCallbackHandle;
+  };
+
+function initializePostHogWhenIdle() {
+  const idleWindow = window as IdleWindow;
+  const initialize = () => initializeWwwPostHog(document.documentElement.dataset.posthogVisitorCountry);
+
+  if (idleWindow.requestIdleCallback) {
+    idleWindow.requestIdleCallback(initialize, { timeout: 3000 });
+    return;
+  }
+
+  if (document.readyState === "complete") {
+    setTimeout(initialize, 0);
+    return;
+  }
+
+  window.addEventListener("load", initialize, { once: true });
+}
+
+initializePostHogWhenIdle();

--- a/www/source.config.ts
+++ b/www/source.config.ts
@@ -1,4 +1,5 @@
-import { applyMdxPreset, defineDocs, defineConfig } from 'fumadocs-mdx/config';
+import { z } from 'zod/v4';
+import { applyMdxPreset, defineCollections, defineDocs, defineConfig } from 'fumadocs-mdx/config';
 import lastModified from 'fumadocs-mdx/plugins/last-modified';
 
 export const docs = defineDocs({
@@ -47,6 +48,42 @@ export const docs = defineDocs({
         remarkPlugins: [remarkSteps, remarkMdxMermaid],
       })(environment);
     },
+  },
+});
+
+export const blog = defineCollections({
+  type: 'doc',
+  dir: 'content/blog',
+  schema: z.object({
+    title: z.string(),
+    description: z.string(),
+    publishedAt: z.string(),
+    updatedAt: z.string().optional(),
+    author: z.string().default('Matrix OS'),
+    category: z.string().default('Field notes'),
+    readTime: z.string(),
+    keywords: z.array(z.string()).default([]),
+    featured: z.boolean().default(false),
+  }),
+  postprocess: {
+    includeProcessedMarkdown: true,
+    extractLinkReferences: true,
+  },
+  async mdxOptions(environment) {
+    return applyMdxPreset({
+      rehypeCodeOptions: {
+        themes: {
+          light: 'catppuccin-latte',
+          dark: 'catppuccin-mocha',
+        },
+      },
+      remarkCodeTabOptions: {
+        parseMdx: true,
+      },
+      remarkNpmOptions: {
+        persist: { id: 'package-manager' },
+      },
+    })(environment);
   },
 });
 

--- a/www/src/app/blog/[slug]/page.tsx
+++ b/www/src/app/blog/[slug]/page.tsx
@@ -1,0 +1,247 @@
+import type { Metadata } from "next";
+import { headers } from "next/headers";
+import { notFound } from "next/navigation";
+import { InlineTOC } from "fumadocs-ui/components/inline-toc";
+import defaultMdxComponents from "fumadocs-ui/mdx";
+import { BlogPostActions } from "@/components/blog/BlogPostActions";
+import { BlogTableOfContents } from "@/components/blog/BlogTableOfContents";
+import { BlogPostMeta, BlogShell } from "@/components/blog/BlogChrome";
+import { Mermaid } from "@/components/mdx/mermaid";
+import { formatBlogDate, getBlogPost, getBlogPostCanonicalUrl, getBlogPostUrl, getBlogPosts } from "@/lib/blog";
+import { palette as c, fonts } from "@/components/landing/theme";
+
+export function generateStaticParams() {
+  return getBlogPosts().map((post) => ({
+    slug: getBlogPostUrl(post).replace("/blog/", ""),
+  }));
+}
+
+export async function generateMetadata(props: {
+  params: Promise<{ slug: string }>;
+}): Promise<Metadata> {
+  const { slug } = await props.params;
+  const post = getBlogPost(slug);
+
+  if (!post) notFound();
+
+  return {
+    title: `${post.title} | Matrix OS Blog`,
+    description: post.description,
+    keywords: post.keywords,
+    alternates: {
+      canonical: getBlogPostUrl(post),
+    },
+    openGraph: {
+      title: post.title,
+      description: post.description,
+      url: getBlogPostCanonicalUrl(post),
+      siteName: "Matrix OS",
+      type: "article",
+      publishedTime: post.publishedAt,
+      modifiedTime: post.updatedAt ?? post.publishedAt,
+      authors: [post.author],
+      images: ["/opengraph-image.png"],
+      tags: post.keywords,
+    },
+    twitter: {
+      card: "summary_large_image",
+      title: post.title,
+      description: post.description,
+      images: ["/opengraph-image.png"],
+    },
+  };
+}
+
+export default async function BlogPostPage(props: {
+  params: Promise<{ slug: string }>;
+}) {
+  const { slug } = await props.params;
+  const nonce = (await headers()).get("x-nonce") ?? undefined;
+  const post = getBlogPost(slug);
+
+  if (!post) notFound();
+
+  const Mdx = post.body;
+  const toc = post.toc;
+  const canonicalUrl = getBlogPostCanonicalUrl(post);
+  const jsonLd = JSON.stringify({
+    "@context": "https://schema.org",
+    "@type": "BlogPosting",
+    headline: post.title,
+    description: post.description,
+    datePublished: post.publishedAt,
+    dateModified: post.updatedAt ?? post.publishedAt,
+    mainEntityOfPage: canonicalUrl,
+    url: canonicalUrl,
+    image: "https://matrix-os.com/opengraph-image.png",
+    keywords: post.keywords,
+    articleSection: post.category,
+    author: {
+      "@type": "Organization",
+      name: post.author,
+      url: "https://matrix-os.com",
+    },
+    publisher: {
+      "@type": "Organization",
+      name: "Matrix OS",
+      url: "https://matrix-os.com",
+      logo: "https://matrix-os.com/rabbit.svg",
+    },
+  });
+
+  return (
+    <BlogShell>
+      {/* react-doctor-disable-next-line react-doctor/no-danger -- jsonLd is JSON.stringify of static MDX frontmatter from the repository */}
+      <script
+        id="blog-post-json-ld"
+        type="application/ld+json"
+        nonce={nonce}
+        suppressHydrationWarning
+        dangerouslySetInnerHTML={{ __html: jsonLd }}
+      />
+      <main>
+        <article className="mx-auto w-full max-w-[1240px] px-5 pt-20 pb-20 md:px-10 md:pt-28 md:pb-28">
+          <div className="grid gap-12 xl:grid-cols-[minmax(0,780px)_240px] xl:items-start xl:gap-16">
+            <div>
+              <header className="mb-10 border-b pb-10 md:mb-10 md:pb-12" style={{ borderColor: c.border }}>
+                <div className="mb-8 grid gap-5 rounded-2xl border bg-white/35 p-5 sm:grid-cols-[1fr_1fr_auto]" style={{ borderColor: c.border }}>
+                  <div>
+                    <p className="text-xs font-medium uppercase tracking-[0.16em]" style={{ color: c.subtle }}>
+                      Written by
+                    </p>
+                    <p className="mt-2 text-sm font-medium" style={{ color: c.deep }}>
+                      {post.author}
+                    </p>
+                  </div>
+                  <div>
+                    <p className="text-xs font-medium uppercase tracking-[0.16em]" style={{ color: c.subtle }}>
+                      At
+                    </p>
+                    <p className="mt-2 text-sm font-medium" style={{ color: c.deep }}>
+                      <time dateTime={post.publishedAt}>{formatBlogDate(post.publishedAt)}</time>
+                    </p>
+                  </div>
+                  <div className="sm:justify-self-end">
+                    <BlogPostActions url={canonicalUrl} />
+                  </div>
+                </div>
+                <p className="mb-5 text-sm font-medium uppercase tracking-[0.16em]" style={{ color: c.ember }}>
+                  {post.category}
+                </p>
+                <h1 className="max-w-[920px] text-5xl font-normal leading-[0.98] md:text-7xl" style={{ fontFamily: fonts.display }}>
+                  {post.title}
+                </h1>
+                <p className="mt-7 max-w-[760px] text-lg leading-8 md:text-xl" style={{ color: c.mutedFg }}>
+                  {post.description}
+                </p>
+                <div className="mt-7">
+                  <BlogPostMeta post={post} />
+                </div>
+              </header>
+
+              {toc.length > 0 ? (
+                <InlineTOC
+                  items={toc}
+                  className="mb-10 border bg-white/55 shadow-[0_1rem_3rem_rgba(50,53,46,0.06)] xl:hidden"
+                  style={{ borderColor: c.border }}
+                >
+                  On this page
+                </InlineTOC>
+              ) : null}
+
+              <style>{`
+                .blog-prose {
+                  color: ${c.deep};
+                  font-size: 1.0625rem;
+                  line-height: 1.9;
+                }
+                .blog-prose > * + * { margin-top: 1.45rem; }
+                .blog-prose h2 {
+                  margin-top: 3rem;
+                  color: ${c.deep};
+                  font-family: ${fonts.display};
+                  font-size: clamp(2rem, 4vw, 3rem);
+                  font-weight: 400;
+                  line-height: 1.08;
+                }
+                .blog-prose h3 {
+                  margin-top: 2.25rem;
+                  color: ${c.deep};
+                  font-size: 1.35rem;
+                  font-weight: 600;
+                  line-height: 1.25;
+                }
+                .blog-prose h2 a,
+                .blog-prose h3 a {
+                  color: inherit;
+                  text-decoration: none;
+                }
+                .blog-prose p,
+                .blog-prose li {
+                  max-width: 760px;
+                  color: ${c.mutedFg};
+                }
+                .blog-prose a {
+                  color: ${c.forest};
+                  text-decoration: underline;
+                  text-decoration-color: rgba(67, 78, 63, 0.25);
+                  text-underline-offset: 0.2em;
+                }
+                .blog-prose ul,
+                .blog-prose ol {
+                  max-width: 760px;
+                  padding-left: 1.35rem;
+                }
+                .blog-prose ul { list-style: disc; }
+                .blog-prose ol { list-style: decimal; }
+                .blog-prose li + li { margin-top: 0.55rem; }
+                .blog-prose strong { color: ${c.deep}; }
+                .blog-prose blockquote {
+                  max-width: 820px;
+                  margin-left: 0;
+                  border-left: 3px solid ${c.ember};
+                  padding: 0.2rem 0 0.2rem 1.35rem;
+                  color: ${c.forestDeep};
+                  font-family: ${fonts.display};
+                  font-size: 1.65rem;
+                  line-height: 1.35;
+                }
+                .blog-prose code {
+                  border-radius: 0.35rem;
+                  background: rgba(67, 78, 63, 0.09);
+                  padding: 0.12rem 0.35rem;
+                  color: ${c.forestDeep};
+                  font-size: 0.92em;
+                }
+                .blog-prose pre {
+                  max-width: 920px;
+                  overflow-x: auto;
+                  border-radius: 0.85rem;
+                  background: ${c.deep};
+                  padding: 1.15rem;
+                  color: #F4F2E6;
+                }
+                .blog-prose pre code {
+                  background: transparent;
+                  padding: 0;
+                  color: inherit;
+                }
+                .blog-prose hr {
+                  margin: 3rem 0;
+                  max-width: 760px;
+                  border: 0;
+                  border-top: 1px solid ${c.border};
+                }
+              `}</style>
+              <div className="blog-prose">
+                <Mdx components={{ ...defaultMdxComponents, Mermaid }} />
+              </div>
+            </div>
+
+            <BlogTableOfContents items={toc} />
+          </div>
+        </article>
+      </main>
+    </BlogShell>
+  );
+}

--- a/www/src/app/blog/page.tsx
+++ b/www/src/app/blog/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from "next";
 import { headers } from "next/headers";
 import { BlogCard, BlogIndexHero, BlogShell } from "@/components/blog/BlogChrome";
-import { getBlogPosts } from "@/lib/blog";
+import { getBlogPostCanonicalUrl, getBlogPosts } from "@/lib/blog";
 import { palette as c } from "@/components/landing/theme";
 
 export const metadata: Metadata = {
@@ -54,7 +54,7 @@ export default async function BlogIndexPage() {
       datePublished: post.publishedAt,
       dateModified: post.updatedAt ?? post.publishedAt,
       author: { "@type": "Organization", name: post.author },
-      url: `https://matrix-os.com/blog/${post.info.path.replace(/\.mdx$/, "")}`,
+      url: getBlogPostCanonicalUrl(post),
     })),
   });
 

--- a/www/src/app/blog/page.tsx
+++ b/www/src/app/blog/page.tsx
@@ -1,0 +1,89 @@
+import type { Metadata } from "next";
+import { headers } from "next/headers";
+import { BlogCard, BlogIndexHero, BlogShell } from "@/components/blog/BlogChrome";
+import { getBlogPosts } from "@/lib/blog";
+import { palette as c } from "@/components/landing/theme";
+
+export const metadata: Metadata = {
+  title: "Blog | Matrix OS",
+  description:
+    "Field notes from Matrix OS on AI-native computing, cloud computers, background agents, and Web 4.",
+  alternates: {
+    canonical: "/blog",
+    types: {
+      "application/rss+xml": "/blog/rss.xml",
+    },
+  },
+  openGraph: {
+    title: "Matrix OS Blog",
+    description:
+      "Product thinking, engineering notes, release stories, and operating-system ideas behind Matrix OS.",
+    url: "https://matrix-os.com/blog",
+    siteName: "Matrix OS",
+    type: "website",
+    images: ["/opengraph-image.png"],
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "Matrix OS Blog",
+    description:
+      "Field notes on AI-native computing, cloud computers, background agents, and Web 4.",
+    images: ["/opengraph-image.png"],
+  },
+};
+
+export default async function BlogIndexPage() {
+  const nonce = (await headers()).get("x-nonce") ?? undefined;
+  const posts = getBlogPosts();
+  const jsonLd = JSON.stringify({
+    "@context": "https://schema.org",
+    "@type": "Blog",
+    name: "Matrix OS Blog",
+    description: metadata.description,
+    url: "https://matrix-os.com/blog",
+    publisher: {
+      "@type": "Organization",
+      name: "Matrix OS",
+      url: "https://matrix-os.com",
+      logo: "https://matrix-os.com/rabbit.svg",
+    },
+    blogPost: posts.map((post) => ({
+      "@type": "BlogPosting",
+      headline: post.title,
+      description: post.description,
+      datePublished: post.publishedAt,
+      dateModified: post.updatedAt ?? post.publishedAt,
+      author: { "@type": "Organization", name: post.author },
+      url: `https://matrix-os.com/blog/${post.info.path.replace(/\.mdx$/, "")}`,
+    })),
+  });
+
+  return (
+    <BlogShell>
+      {/* react-doctor-disable-next-line react-doctor/no-danger -- jsonLd is JSON.stringify of static MDX frontmatter from the repository */}
+      <script
+        id="blog-json-ld"
+        type="application/ld+json"
+        nonce={nonce}
+        suppressHydrationWarning
+        dangerouslySetInnerHTML={{ __html: jsonLd }}
+      />
+      <main>
+        <BlogIndexHero />
+        <section className="mx-auto w-full max-w-[1400px] px-5 pb-20 md:px-10 md:pb-28">
+          {posts.length > 0 ? (
+            <div className="grid gap-5 md:grid-cols-2 lg:grid-cols-3">
+              {posts.map((post) => (
+                <BlogCard key={post.info.path} post={post} priority={post.featured} />
+              ))}
+            </div>
+          ) : (
+            <div className="rounded-2xl border p-8" style={{ backgroundColor: c.card, borderColor: c.border }}>
+              No posts published yet.
+            </div>
+          )}
+        </section>
+      </main>
+    </BlogShell>
+  );
+}

--- a/www/src/app/blog/rss.xml/route.ts
+++ b/www/src/app/blog/rss.xml/route.ts
@@ -11,6 +11,10 @@ function escapeXml(value: string) {
     .replaceAll("'", "&apos;");
 }
 
+function escapeCdata(value: string) {
+  return value.replaceAll("]]>", "]]]]><![CDATA[>");
+}
+
 export async function GET() {
   const posts = getBlogPosts();
   const items = await Promise.all(
@@ -26,7 +30,7 @@ export async function GET() {
         `<author>${escapeXml(post.author)}</author>`,
         `<category>${escapeXml(post.category)}</category>`,
         `<pubDate>${new Date(post.publishedAt).toUTCString()}</pubDate>`,
-        `<content:encoded><![CDATA[${markdown}]]></content:encoded>`,
+        `<content:encoded><![CDATA[${escapeCdata(markdown)}]]></content:encoded>`,
         "</item>",
       ].join("\n");
     }),

--- a/www/src/app/blog/rss.xml/route.ts
+++ b/www/src/app/blog/rss.xml/route.ts
@@ -1,0 +1,54 @@
+import { getBlogPostCanonicalUrl, getBlogPostMarkdown, getBlogPosts } from "@/lib/blog";
+
+export const revalidate = false;
+
+function escapeXml(value: string) {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&apos;");
+}
+
+export async function GET() {
+  const posts = getBlogPosts();
+  const items = await Promise.all(
+    posts.map(async (post) => {
+      const markdown = await getBlogPostMarkdown(post);
+      const url = getBlogPostCanonicalUrl(post);
+      return [
+        "<item>",
+        `<title>${escapeXml(post.title)}</title>`,
+        `<link>${escapeXml(url)}</link>`,
+        `<guid>${escapeXml(url)}</guid>`,
+        `<description>${escapeXml(post.description)}</description>`,
+        `<author>${escapeXml(post.author)}</author>`,
+        `<category>${escapeXml(post.category)}</category>`,
+        `<pubDate>${new Date(post.publishedAt).toUTCString()}</pubDate>`,
+        `<content:encoded><![CDATA[${markdown}]]></content:encoded>`,
+        "</item>",
+      ].join("\n");
+    }),
+  );
+
+  const xml = [
+    '<?xml version="1.0" encoding="UTF-8"?>',
+    '<rss version="2.0" xmlns:content="http://purl.org/rss/1.0/modules/content/">',
+    "<channel>",
+    "<title>Matrix OS Blog</title>",
+    "<link>https://matrix-os.com/blog</link>",
+    "<description>Field notes on AI-native computing, cloud computers, background agents, and Web 4.</description>",
+    "<language>en</language>",
+    `<lastBuildDate>${new Date().toUTCString()}</lastBuildDate>`,
+    ...items,
+    "</channel>",
+    "</rss>",
+  ].join("\n");
+
+  return new Response(xml, {
+    headers: {
+      "Content-Type": "application/rss+xml; charset=utf-8",
+    },
+  });
+}

--- a/www/src/app/llms-full.txt/route.ts
+++ b/www/src/app/llms-full.txt/route.ts
@@ -1,11 +1,17 @@
 import { source } from '@/lib/source';
 import { getLLMText } from '@/lib/get-llm-text';
+import { getBlogPostMarkdown, getBlogPostUrl, getBlogPosts } from '@/lib/blog';
 
 export const revalidate = false;
 
 export async function GET() {
   const scan = source.getPages().map(getLLMText);
   const scanned = await Promise.all(scan);
+  const blogScan = getBlogPosts().map(async (post) => {
+    const markdown = await getBlogPostMarkdown(post);
+    return [`# ${post.title}`, '', `URL: ${getBlogPostUrl(post)}`, '', post.description, '', markdown].join('\n');
+  });
+  const blogScanned = await Promise.all(blogScan);
 
-  return new Response(scanned.join('\n\n'));
+  return new Response([...scanned, ...blogScanned].join('\n\n'));
 }

--- a/www/src/app/llms.txt/route.ts
+++ b/www/src/app/llms.txt/route.ts
@@ -1,15 +1,21 @@
 import { source } from '@/lib/source';
+import { getBlogPostUrl, getBlogPosts } from '@/lib/blog';
 
 export const revalidate = false;
 
 export async function GET() {
   const pages = source.getPages();
+  const posts = getBlogPosts();
   const lines = [
     '# Matrix OS Documentation',
     '',
     '> Matrix OS is an AI-native operating system where software is generated from conversation.',
     '',
     ...pages.map((p) => `- [${p.data.title}](${p.url}): ${p.data.description ?? ''}`),
+    '',
+    '## Blog',
+    '',
+    ...posts.map((p) => `- [${p.title}](${getBlogPostUrl(p)}): ${p.description}`),
   ];
 
   return new Response(lines.join('\n'));

--- a/www/src/app/page.tsx
+++ b/www/src/app/page.tsx
@@ -12,6 +12,7 @@ import { TemplatesShowcase } from "@/components/landing/TemplatesShowcase";
 import { SymphonySection } from "@/components/landing/SymphonySection";
 import { QuoteStats } from "@/components/landing/QuoteStats";
 import { HermesSection } from "@/components/landing/HermesSection";
+import { BlogPreviewSection } from "@/components/landing/BlogPreviewSection";
 import { PilotBand } from "@/components/landing/PilotBand";
 import { FaqSection } from "@/components/landing/FaqSection";
 import { FinalCtaSection } from "@/components/landing/FinalCtaSection";
@@ -35,7 +36,7 @@ const jsonLd = JSON.stringify({
 export const metadata: Metadata = {
   title: "Matrix OS - A cloud computer for background AI agents",
   description:
-    "Matrix gives background agents their own computer. Run Claude, Codex, Cursor, OpenCode, and Hermes in a private hosted workspace with persistent terminals, repos, previews, and workflows that keep going after your laptop closes.",
+    "Give AI agents their own cloud computer. Run Claude, Codex, Cursor, and more in a persistent hosted workspace, even when your laptop sleeps.",
 };
 
 export default async function LandingPage() {
@@ -65,6 +66,7 @@ export default async function LandingPage() {
         <QuoteStats />
         <HermesSection exploreHref="/hermes" />
         <LandingBilling />
+        <BlogPreviewSection />
         <PilotBand />
         <FaqSection />
         <FinalCtaSection />

--- a/www/src/app/sitemap.ts
+++ b/www/src/app/sitemap.ts
@@ -79,7 +79,7 @@ export default function sitemap(): MetadataRoute.Sitemap {
 
   const blogPages: MetadataRoute.Sitemap = getBlogPosts().map((post) => ({
     url: `${BASE_URL}${getBlogPostUrl(post)}`,
-    lastModified: new Date(post.publishedAt),
+    lastModified: new Date(post.updatedAt ?? post.publishedAt),
     changeFrequency: "monthly" as const,
     priority: 0.65,
   }));

--- a/www/src/app/sitemap.ts
+++ b/www/src/app/sitemap.ts
@@ -1,5 +1,6 @@
 import type { MetadataRoute } from "next";
 import { source } from "@/lib/source";
+import { getBlogPostUrl, getBlogPosts } from "@/lib/blog";
 import { solutionPages } from "./solutions/data";
 
 const BASE_URL = "https://matrix-os.com";
@@ -29,6 +30,12 @@ export default function sitemap(): MetadataRoute.Sitemap {
       lastModified: new Date(),
       changeFrequency: "monthly",
       priority: 0.9,
+    },
+    {
+      url: `${BASE_URL}/blog`,
+      lastModified: new Date(),
+      changeFrequency: "weekly",
+      priority: 0.75,
     },
     {
       url: `${BASE_URL}/team`,
@@ -70,5 +77,12 @@ export default function sitemap(): MetadataRoute.Sitemap {
     priority: 0.75,
   }));
 
-  return [...staticPages, ...solutionSitemapPages, ...docPages];
+  const blogPages: MetadataRoute.Sitemap = getBlogPosts().map((post) => ({
+    url: `${BASE_URL}${getBlogPostUrl(post)}`,
+    lastModified: new Date(post.publishedAt),
+    changeFrequency: "monthly" as const,
+    priority: 0.65,
+  }));
+
+  return [...staticPages, ...solutionSitemapPages, ...blogPages, ...docPages];
 }

--- a/www/src/app/team/page.tsx
+++ b/www/src/app/team/page.tsx
@@ -99,9 +99,9 @@ function XLogoIcon({ className }: { className?: string }) {
 
 export default function TeamPage() {
   return (
-    <div style={{ backgroundColor: c.pageBg, color: c.deep, fontFamily: fonts.sans }}>
+    <div className="flex min-h-dvh flex-col" style={{ backgroundColor: c.pageBg, color: c.deep, fontFamily: fonts.sans }}>
       <SiteHeader />
-      <main>
+      <main className="flex-1">
         <SectionShell className="pt-10 pb-16 md:pt-20 md:pb-24">
           <section aria-labelledby="team-heading" className="mx-auto max-w-[50rem] text-center">
             <p

--- a/www/src/components/PostHogCookieBanner.tsx
+++ b/www/src/components/PostHogCookieBanner.tsx
@@ -1,7 +1,7 @@
 "use client";
 
+import { useEffect, useState } from "react";
 import { getPostHogClientConfig } from "@matrix-os/observability/client";
-import { PostHogCookieBanner as SharedPostHogCookieBanner } from "@matrix-os/observability/cookie-consent";
 
 const config = getPostHogClientConfig({
   NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN: process.env.NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN,
@@ -10,6 +10,55 @@ const config = getPostHogClientConfig({
   NEXT_PUBLIC_POSTHOG_API_HOST: process.env.NEXT_PUBLIC_POSTHOG_API_HOST ?? "/ingest",
 });
 
+type SharedPostHogCookieBanner = typeof import("@matrix-os/observability/cookie-consent").PostHogCookieBanner;
+type MatrixIdleDeadline = { didTimeout: boolean; timeRemaining(): number };
+type IdleCallbackHandle = ReturnType<typeof setTimeout>;
+type IdleWindow = Window &
+  typeof globalThis & {
+    requestIdleCallback?: (callback: (deadline: MatrixIdleDeadline) => void, options?: { timeout: number }) => IdleCallbackHandle;
+    cancelIdleCallback?: (handle: IdleCallbackHandle) => void;
+  };
+
+let cookieBannerPromise: Promise<SharedPostHogCookieBanner> | null = null;
+
+function loadCookieBanner(): Promise<SharedPostHogCookieBanner> {
+  cookieBannerPromise ??= import("@matrix-os/observability/cookie-consent").then(
+    (module) => module.PostHogCookieBanner,
+  );
+  return cookieBannerPromise;
+}
+
 export function PostHogCookieBanner({ visitorCountry }: { visitorCountry: string | null }) {
-  return <SharedPostHogCookieBanner config={config} visitorCountry={visitorCountry} />;
+  const [Banner, setBanner] = useState<SharedPostHogCookieBanner | null>(null);
+
+  useEffect(() => {
+    const idleWindow = window as IdleWindow;
+    let cancelled = false;
+
+    const loadBannerAfterIdle = () => {
+      void loadCookieBanner()
+        .then((CookieBanner) => {
+          if (!cancelled) setBanner(() => CookieBanner);
+        })
+        .catch((err: unknown) => {
+          console.warn("[posthog] Failed to load cookie banner:", err instanceof Error ? err.name : typeof err);
+        });
+    };
+
+    if (idleWindow.requestIdleCallback) {
+      const handle = idleWindow.requestIdleCallback(loadBannerAfterIdle, { timeout: 2500 });
+      return () => {
+        cancelled = true;
+        idleWindow.cancelIdleCallback?.(handle);
+      };
+    }
+
+    const handle = window.setTimeout(loadBannerAfterIdle, 0);
+    return () => {
+      cancelled = true;
+      window.clearTimeout(handle);
+    };
+  }, []);
+
+  return Banner ? <Banner config={config} visitorCountry={visitorCountry} /> : null;
 }

--- a/www/src/components/blog/BlogChrome.tsx
+++ b/www/src/components/blog/BlogChrome.tsx
@@ -1,0 +1,91 @@
+import Link from "next/link";
+import { ArrowRightIcon } from "lucide-react";
+import { SiteHeader } from "@/components/landing/SiteHeader";
+import { SiteFooter } from "@/components/landing/SiteFooter";
+import { Logo } from "@/components/landing/Logo";
+import { palette as c, cardShadow, cardShadowSmall, fonts } from "@/components/landing/theme";
+import type { BlogPost } from "@/lib/blog";
+import { formatBlogDate, getBlogPostUrl } from "@/lib/blog";
+
+export function BlogShell({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="flex min-h-dvh flex-col" style={{ backgroundColor: c.pageBg, color: c.deep, fontFamily: fonts.sans }}>
+      <SiteHeader />
+      <div className="flex-1">
+        {children}
+      </div>
+      <SiteFooter />
+    </div>
+  );
+}
+
+export function BlogIndexHero() {
+  return (
+    <section className="mx-auto w-full max-w-[1400px] px-5 pt-20 pb-10 md:px-10 md:pt-28">
+      <div className="grid gap-8 lg:grid-cols-[1.08fr_0.92fr] lg:items-end">
+        <div>
+          <Link
+            href="/"
+            className="mb-7 inline-flex items-center gap-2 rounded-lg border px-3 py-2 text-sm transition hover:bg-white"
+            style={{ borderColor: c.border, color: c.mutedFg }}
+          >
+            <Logo className="size-4" style={{ color: c.forest }} />
+            Matrix OS field notes
+          </Link>
+          <h1 className="max-w-[820px] text-5xl font-normal leading-[0.98] md:text-7xl" style={{ fontFamily: fonts.display }}>
+            Essays from the edge of AI-native computing.
+          </h1>
+        </div>
+        <p className="max-w-[560px] text-lg leading-8 md:text-xl" style={{ color: c.mutedFg }}>
+          Product thinking, engineering notes, release stories, and the operating-system ideas behind Matrix.
+          Written for people building with agents, cloud computers, and persistent workspaces.
+        </p>
+      </div>
+    </section>
+  );
+}
+
+export function BlogCard({ post, priority = false }: { post: BlogPost; priority?: boolean }) {
+  return (
+    <Link
+      href={getBlogPostUrl(post)}
+      className="group flex flex-col rounded-2xl border p-6 transition duration-200 hover:-translate-y-1 md:p-7"
+      style={{
+        backgroundColor: c.card,
+        borderColor: c.border,
+        boxShadow: priority ? cardShadow : cardShadowSmall,
+      }}
+    >
+      <div className="mb-8 flex flex-wrap items-center gap-2 text-sm" style={{ color: c.subtle }}>
+        <span className="rounded-full px-3 py-1" style={{ backgroundColor: "rgba(67,78,63,0.08)", color: c.forest }}>
+          {post.category}
+        </span>
+        <span>{formatBlogDate(post.publishedAt)}</span>
+        <span aria-hidden="true">/</span>
+        <span>{post.readTime}</span>
+      </div>
+      <h2 className="text-3xl font-normal leading-tight md:text-4xl" style={{ fontFamily: fonts.display }}>
+        {post.title}
+      </h2>
+      <p className="mt-5 flex-1 text-base leading-7" style={{ color: c.mutedFg }}>
+        {post.description}
+      </p>
+      <span className="mt-8 inline-flex items-center gap-2 text-sm font-medium" style={{ color: c.deep }}>
+        Read article
+        <ArrowRightIcon className="size-4 transition group-hover:translate-x-1" strokeWidth={1.75} />
+      </span>
+    </Link>
+  );
+}
+
+export function BlogPostMeta({ post }: { post: BlogPost }) {
+  return (
+    <div className="flex flex-wrap items-center gap-2 text-sm" style={{ color: c.subtle }}>
+      <span>{post.author}</span>
+      <span aria-hidden="true">/</span>
+      <time dateTime={post.publishedAt}>{formatBlogDate(post.publishedAt)}</time>
+      <span aria-hidden="true">/</span>
+      <span>{post.readTime}</span>
+    </div>
+  );
+}

--- a/www/src/components/blog/BlogPostActions.tsx
+++ b/www/src/components/blog/BlogPostActions.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import { ArrowLeftIcon, CheckIcon, Share2Icon } from "lucide-react";
+import { palette as c } from "@/components/landing/theme";
+
+export function BlogPostActions({ url }: { url: string }) {
+  const [copied, setCopied] = useState(false);
+  const [failed, setFailed] = useState(false);
+
+  async function sharePost() {
+    const shareData = {
+      title: document.title,
+      url,
+    };
+
+    setFailed(false);
+
+    try {
+      if (navigator.share && (navigator.canShare?.(shareData) ?? true)) {
+        await navigator.share(shareData);
+        return;
+      }
+
+      await navigator.clipboard.writeText(url);
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 1800);
+    } catch (error) {
+      if (error instanceof DOMException && error.name === "AbortError") {
+        return;
+      }
+      console.warn("[blog-share]", error);
+      setFailed(true);
+      window.setTimeout(() => setFailed(false), 2200);
+    }
+  }
+
+  return (
+    <div className="flex flex-wrap items-center gap-2">
+      <button
+        type="button"
+        onClick={sharePost}
+        className="inline-flex items-center gap-2 rounded-lg border px-3 py-2 text-sm font-medium transition hover:bg-white"
+        style={{ borderColor: c.border, color: c.deep }}
+      >
+        {copied ? <CheckIcon className="size-4" strokeWidth={1.75} /> : <Share2Icon className="size-4" strokeWidth={1.75} />}
+        {failed ? "Share failed" : copied ? "Copied" : "Share Post"}
+      </button>
+      <Link
+        href="/blog"
+        className="inline-flex items-center gap-2 rounded-lg border px-3 py-2 text-sm font-medium transition hover:bg-white"
+        style={{ borderColor: c.border, color: c.mutedFg }}
+      >
+        <ArrowLeftIcon className="size-4" strokeWidth={1.75} />
+        Back
+      </Link>
+    </div>
+  );
+}

--- a/www/src/components/blog/BlogTableOfContents.tsx
+++ b/www/src/components/blog/BlogTableOfContents.tsx
@@ -1,0 +1,100 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { ListTreeIcon } from "lucide-react";
+import type { TOCItemType } from "fumadocs-core/toc";
+import { palette as c } from "@/components/landing/theme";
+
+function getItemId(item: TOCItemType) {
+  return item.url.startsWith("#") ? item.url.slice(1) : item.url;
+}
+
+export function BlogTableOfContents({ items }: { items: TOCItemType[] }) {
+  const ids = useMemo(() => items.map(getItemId), [items]);
+  const [activeId, setActiveId] = useState(ids[0] ?? "");
+
+  useEffect(() => {
+    if (ids.length === 0) return;
+
+    const headings = ids
+      .map((id) => document.getElementById(decodeURIComponent(id)))
+      .filter((heading): heading is HTMLElement => heading !== null);
+
+    if (headings.length === 0) return;
+
+    const visible = new Map<string, number>();
+    const observer = new IntersectionObserver(
+      (entries) => {
+        for (const entry of entries) {
+          const id = entry.target.id;
+          if (entry.isIntersecting) {
+            visible.set(id, entry.boundingClientRect.top);
+          } else {
+            visible.delete(id);
+          }
+        }
+
+        if (visible.size > 0) {
+          const [nextId] = [...visible.entries()].sort((a, b) => a[1] - b[1])[0];
+          setActiveId(nextId);
+          return;
+        }
+
+        const previous = [...headings].reverse().find((heading) => heading.getBoundingClientRect().top < 140);
+        if (previous) setActiveId(previous.id);
+      },
+      {
+        rootMargin: "-112px 0px -62% 0px",
+        threshold: [0, 1],
+      },
+    );
+
+    for (const heading of headings) {
+      observer.observe(heading);
+    }
+
+    return () => observer.disconnect();
+  }, [ids]);
+
+  if (items.length === 0) return null;
+
+  return (
+    <aside className="hidden xl:block">
+      <div className="sticky top-28 rounded-2xl border bg-white/45 p-5 shadow-[0_1rem_3rem_rgba(50,53,46,0.06)]" style={{ borderColor: c.border }}>
+        <div className="mb-4 flex items-center gap-2 text-sm font-medium" style={{ color: c.deep }}>
+          <ListTreeIcon className="size-4" strokeWidth={1.75} />
+          On this page
+        </div>
+        <nav aria-label="Table of contents" className="relative flex flex-col gap-1 border-l pl-4" style={{ borderColor: c.border }}>
+          {items.map((item) => {
+            const id = getItemId(item);
+            const active = activeId === id;
+
+            return (
+              <a
+                key={item.url}
+                href={item.url}
+                aria-current={active ? "location" : undefined}
+                className="group relative rounded-md py-1.5 text-sm leading-5 transition hover:translate-x-0.5 focus:outline-none focus:ring-2 focus:ring-offset-2"
+                style={{
+                  color: active ? c.deep : c.mutedFg,
+                  fontWeight: active ? 600 : 400,
+                  paddingLeft: `${Math.max(item.depth - 2, 0) * 12}px`,
+                  ["--tw-ring-color" as string]: c.forest,
+                  ["--tw-ring-offset-color" as string]: c.pageBg,
+                }}
+              >
+                <span
+                  aria-hidden="true"
+                  className="absolute top-1.5 -left-[1.0625rem] h-5 w-0.5 rounded-full transition-opacity"
+                  style={{ backgroundColor: c.ember, opacity: active ? 1 : 0 }}
+                />
+                {item.title}
+              </a>
+            );
+          })}
+        </nav>
+      </div>
+    </aside>
+  );
+}

--- a/www/src/components/blog/BlogTableOfContents.tsx
+++ b/www/src/components/blog/BlogTableOfContents.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useState } from "react";
 import { ListTreeIcon } from "lucide-react";
 import type { TOCItemType } from "fumadocs-core/toc";
 import { palette as c } from "@/components/landing/theme";
@@ -10,10 +10,10 @@ function getItemId(item: TOCItemType) {
 }
 
 export function BlogTableOfContents({ items }: { items: TOCItemType[] }) {
-  const ids = useMemo(() => items.map(getItemId), [items]);
-  const [activeId, setActiveId] = useState(ids[0] ?? "");
+  const [activeId, setActiveId] = useState(() => (items[0] ? getItemId(items[0]) : ""));
 
   useEffect(() => {
+    const ids = items.map(getItemId);
     if (ids.length === 0) return;
 
     const headings = ids
@@ -34,14 +34,28 @@ export function BlogTableOfContents({ items }: { items: TOCItemType[] }) {
           }
         }
 
+        let nextActiveId = "";
         if (visible.size > 0) {
-          const [nextId] = [...visible.entries()].sort((a, b) => a[1] - b[1])[0];
-          setActiveId(nextId);
-          return;
+          let nearestTop = Number.POSITIVE_INFINITY;
+          for (const [id, top] of visible) {
+            if (top < nearestTop) {
+              nextActiveId = id;
+              nearestTop = top;
+            }
+          }
+        } else {
+          for (let index = headings.length - 1; index >= 0; index -= 1) {
+            const heading = headings[index];
+            if (heading && heading.getBoundingClientRect().top < 140) {
+              nextActiveId = heading.id;
+              break;
+            }
+          }
         }
 
-        const previous = [...headings].reverse().find((heading) => heading.getBoundingClientRect().top < 140);
-        if (previous) setActiveId(previous.id);
+        if (nextActiveId) {
+          setActiveId((current) => (current === nextActiveId ? current : nextActiveId));
+        }
       },
       {
         rootMargin: "-112px 0px -62% 0px",
@@ -54,7 +68,7 @@ export function BlogTableOfContents({ items }: { items: TOCItemType[] }) {
     }
 
     return () => observer.disconnect();
-  }, [ids]);
+  }, [items]);
 
   if (items.length === 0) return null;
 

--- a/www/src/components/landing/BlogPreviewSection.tsx
+++ b/www/src/components/landing/BlogPreviewSection.tsx
@@ -1,0 +1,37 @@
+import Link from "next/link";
+import { ArrowRightIcon } from "lucide-react";
+import { BlogCard } from "@/components/blog/BlogChrome";
+import { getFeaturedBlogPosts } from "@/lib/blog";
+import { palette as c, fonts } from "./theme";
+
+export function BlogPreviewSection() {
+  const posts = getFeaturedBlogPosts(3);
+
+  return (
+    <section className="mx-auto w-full max-w-[1400px] px-5 py-14 md:px-10 md:py-20">
+      <div className="mb-8 flex flex-col gap-5 md:mb-10 md:flex-row md:items-end md:justify-between">
+        <div>
+          <p className="mb-3 text-sm font-medium uppercase tracking-[0.16em]" style={{ color: c.ember }}>
+            From the blog
+          </p>
+          <h2 className="max-w-[720px] text-4xl font-normal leading-tight md:text-5xl" style={{ fontFamily: fonts.display }}>
+            Notes on cloud computers, agents, and Web 4.
+          </h2>
+        </div>
+        <Link
+          href="/blog"
+          className="inline-flex w-fit items-center gap-2 rounded-lg border px-4 py-2.5 text-sm font-medium transition hover:bg-white"
+          style={{ borderColor: c.border, color: c.deep }}
+        >
+          View all posts
+          <ArrowRightIcon className="size-4" strokeWidth={1.75} />
+        </Link>
+      </div>
+      <div className="grid gap-5 md:grid-cols-3">
+        {posts.map((post) => (
+          <BlogCard key={post.info.path} post={post} />
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/www/src/components/landing/SiteFooter.tsx
+++ b/www/src/components/landing/SiteFooter.tsx
@@ -15,6 +15,7 @@ const footerColumns: ReadonlyArray<{ title: string; links: readonly FooterLinkIt
       { label: "Pricing", href: "/#pricing" },
       { label: "Releases", href: "/releases" },
       { label: "Whitepaper", href: "/whitepaper" },
+      { label: "Blog", href: "/blog" },
     ],
   },
   {
@@ -33,6 +34,7 @@ const footerColumns: ReadonlyArray<{ title: string; links: readonly FooterLinkIt
       { label: "Quickstart", href: "/docs/users/quickstart" },
       { label: "Agent skill", href: "/skills.md" },
       { label: "Technical", href: "/technical" },
+      { label: "Blog", href: "/blog" },
       { label: "Early access", href: "/early-access" },
     ],
   },

--- a/www/src/components/landing/SiteHeader.tsx
+++ b/www/src/components/landing/SiteHeader.tsx
@@ -29,6 +29,7 @@ const navItems: NavItem[] = [
         { label: "Hermes", desc: "The resident agent for everything else", href: "/hermes" },
         { label: "Every screen", desc: "Web, CLI, mobile, and desktop", href: "/#surfaces" },
         { label: "Whitepaper", desc: "How Matrix works under the hood", href: "/whitepaper" },
+        { label: "Blog", desc: "Field notes from the Matrix team", href: "/blog" },
       ],
       featured: {
         title: "Agents that keep working after your laptop closes",
@@ -57,6 +58,7 @@ const navItems: NavItem[] = [
     },
   },
   { label: "Pricing", href: "/#pricing" },
+  { label: "Blog", href: "/blog" },
   { label: "About us", href: "/team" },
   { label: "Docs", href: "/docs" },
 ];

--- a/www/src/lib/blog.ts
+++ b/www/src/lib/blog.ts
@@ -1,0 +1,44 @@
+import { blog } from 'fumadocs-mdx:collections/server';
+
+export type BlogPost = (typeof blog)[number];
+
+export function getBlogSlug(post: BlogPost) {
+  return post.info.path.replace(/(?:\/index)?\.mdx$/, '');
+}
+
+export function getBlogPostUrl(post: BlogPost) {
+  return `/blog/${getBlogSlug(post)}`;
+}
+
+export function getBlogPostCanonicalUrl(post: BlogPost) {
+  return `https://matrix-os.com${getBlogPostUrl(post)}`;
+}
+
+export function getBlogPosts() {
+  return [...blog].sort((a, b) => {
+    return new Date(b.publishedAt).getTime() - new Date(a.publishedAt).getTime();
+  });
+}
+
+export function getFeaturedBlogPosts(limit = 3) {
+  const posts = getBlogPosts();
+  const featured = posts.filter((post) => post.featured);
+  return (featured.length > 0 ? featured : posts).slice(0, limit);
+}
+
+export function getBlogPost(slug: string) {
+  return getBlogPosts().find((post) => getBlogSlug(post) === slug);
+}
+
+export function formatBlogDate(value: string) {
+  return new Intl.DateTimeFormat('en', {
+    month: 'long',
+    day: 'numeric',
+    year: 'numeric',
+    timeZone: 'UTC',
+  }).format(new Date(value));
+}
+
+export async function getBlogPostMarkdown(post: BlogPost) {
+  return post.getText('processed').catch(() => post.getText('raw'));
+}

--- a/www/src/lib/blog.ts
+++ b/www/src/lib/blog.ts
@@ -40,5 +40,9 @@ export function formatBlogDate(value: string) {
 }
 
 export async function getBlogPostMarkdown(post: BlogPost) {
-  return post.getText('processed').catch(() => post.getText('raw'));
+  return post.getText('processed').catch((err: unknown) => {
+    const reason = err instanceof Error ? err.name : typeof err;
+    console.warn(`[blog] processed markdown unavailable (${reason}); falling back to raw`);
+    return post.getText('raw');
+  });
 }

--- a/www/src/lib/posthog-client.ts
+++ b/www/src/lib/posthog-client.ts
@@ -1,6 +1,5 @@
 "use client";
 
-import posthog from "posthog-js";
 import {
   buildPostHogCookieConsentInitOptions,
   getPostHogClientConfig,
@@ -8,7 +7,8 @@ import {
 } from "@matrix-os/observability/client";
 
 type ClientProperties = Record<string, string | number | boolean | undefined>;
-type PostHogInitOptions = Parameters<typeof posthog.init>[1];
+type PostHogClient = typeof import("posthog-js").default;
+type PostHogInitOptions = Parameters<PostHogClient["init"]>[1];
 
 // Replay kill switch. NEXT_PUBLIC_* is inlined at build time, so the build
 // flag alone needs a rebuild to change. The layout additionally exposes the
@@ -29,25 +29,35 @@ const config = getPostHogClientConfig({
   NEXT_PUBLIC_POSTHOG_API_HOST: process.env.NEXT_PUBLIC_POSTHOG_API_HOST ?? "/relay",
 });
 let initialized = false;
+let posthogClientPromise: Promise<PostHogClient> | null = null;
+
+function loadPostHogClient(): Promise<PostHogClient> {
+  posthogClientPromise ??= import("posthog-js").then((module) => module.default);
+  return posthogClientPromise;
+}
 
 export function capturePostHogException(error: unknown, properties: ClientProperties = {}) {
   if (!config) return;
-  try {
-    ensurePostHogInitialized(config);
-    posthog.captureException(error, sanitizeProperties(properties));
-  } catch (err: unknown) {
-    console.warn("[posthog] Failed to capture client exception:", err instanceof Error ? err.name : typeof err);
-  }
+  void loadPostHogClient()
+    .then((posthog) => {
+      ensurePostHogInitialized(posthog, config);
+      posthog.captureException(error, sanitizeProperties(properties));
+    })
+    .catch((err: unknown) => {
+      console.warn("[posthog] Failed to capture client exception:", err instanceof Error ? err.name : typeof err);
+    });
 }
 
 export function capturePostHogEvent(event: string, properties: ClientProperties = {}) {
   if (!config) return;
-  try {
-    ensurePostHogInitialized(config);
-    posthog.capture(event, sanitizeProperties(properties));
-  } catch (err: unknown) {
-    console.warn("[posthog] Failed to capture client event:", err instanceof Error ? err.name : typeof err);
-  }
+  void loadPostHogClient()
+    .then((posthog) => {
+      ensurePostHogInitialized(posthog, config);
+      posthog.capture(event, sanitizeProperties(properties));
+    })
+    .catch((err: unknown) => {
+      console.warn("[posthog] Failed to capture client event:", err instanceof Error ? err.name : typeof err);
+    });
 }
 
 export function identifyPostHogUser(
@@ -56,33 +66,50 @@ export function identifyPostHogUser(
   currentConfig: typeof config = config,
 ) {
   if (!currentConfig || !distinctId) return;
-  try {
-    ensurePostHogInitialized(currentConfig);
-    posthog.identify(distinctId, sanitizeProperties(properties));
-  } catch (err: unknown) {
-    console.warn("[posthog] Failed to identify user:", err instanceof Error ? err.name : typeof err);
-  }
+  void loadPostHogClient()
+    .then((posthog) => {
+      ensurePostHogInitialized(posthog, currentConfig);
+      posthog.identify(distinctId, sanitizeProperties(properties));
+    })
+    .catch((err: unknown) => {
+      console.warn("[posthog] Failed to identify user:", err instanceof Error ? err.name : typeof err);
+    });
 }
 
 export function resetPostHogIdentity(currentConfig: typeof config = config) {
   if (!currentConfig || !initialized) return;
-  try {
-    // Only reset provably identified sessions; resetting an anonymous session
-    // would rotate its distinct id on every signed-out page load. If the
-    // identity check is unavailable, skip the reset rather than risk it.
-    const withIdentity = posthog as typeof posthog & { _isIdentified?: () => boolean };
-    if (typeof withIdentity._isIdentified !== "function" || !withIdentity._isIdentified()) return;
-    posthog.reset();
-  } catch (err: unknown) {
-    console.warn("[posthog] Failed to reset identity:", err instanceof Error ? err.name : typeof err);
-  }
+  void loadPostHogClient()
+    .then((posthog) => {
+      // Only reset provably identified sessions; resetting an anonymous session
+      // would rotate its distinct id on every signed-out page load. If the
+      // identity check is unavailable, skip the reset rather than risk it.
+      const withIdentity = posthog as PostHogClient & { _isIdentified?: () => boolean };
+      if (typeof withIdentity._isIdentified !== "function" || !withIdentity._isIdentified()) return;
+      posthog.reset();
+    })
+    .catch((err: unknown) => {
+      console.warn("[posthog] Failed to reset identity:", err instanceof Error ? err.name : typeof err);
+    });
 }
 
-function ensurePostHogInitialized(currentConfig: NonNullable<typeof config>) {
-  initializeWwwPostHog(getPostHogVisitorCountry(), currentConfig);
+function ensurePostHogInitialized(posthog: PostHogClient, currentConfig: NonNullable<typeof config>) {
+  initializeLoadedPostHog(posthog, getPostHogVisitorCountry(), currentConfig);
 }
 
 export function initializeWwwPostHog(
+  visitorCountry?: string | null,
+  currentConfig: typeof config = config,
+) {
+  if (!currentConfig || initialized) return Promise.resolve();
+  return loadPostHogClient()
+    .then((posthog) => initializeLoadedPostHog(posthog, visitorCountry, currentConfig))
+    .catch((err: unknown) => {
+      console.warn("[posthog] Failed to initialize client:", err instanceof Error ? err.name : typeof err);
+    });
+}
+
+function initializeLoadedPostHog(
+  posthog: PostHogClient,
   visitorCountry?: string | null,
   currentConfig: typeof config = config,
 ) {


### PR DESCRIPTION
## Summary

- Add a Fumadocs-backed MDX blog at `/blog` with article routes, RSS, sitemap entries, and llms feed coverage.
- Add Fumadocs-style article chrome: author/date metadata, share post, back link, inline mobile TOC, and sticky desktop TOC with active-section tracking.
- Seed four initial posts, including the SEO-focused Claude Code persistent cloud session article.
- Add a landing blog preview section, navigation/footer blog links, a shorter landing meta description, and tall-screen footer fixes for blog/team pages.
- Use the current generated `/opengraph-image.png` path for blog OpenGraph metadata and defer PostHog/client consent loading off the initial paint path.

## Tests

- `bun run typecheck`
- `bun run check:patterns` (0 violations, 5 existing warning groups)
- `pnpm --dir www build` (passes; existing observability Edge Runtime warning about `process.exit`)
- `npx react-doctor@latest --verbose --scope changed www`
- `bun run test tests/observability/posthog-cookie-banner.test.tsx tests/shell/posthog-identify.test.tsx tests/www/posthog-session-replay.test.ts tests/shell/posthog-session-replay.test.tsx`
- `bun run test tests/platform/proxy-routing.test.ts`
- `curl -I http://localhost:3011/blog`
- `curl -I http://localhost:3011/blog/keep-claude-code-running-after-laptop-closes`
- `curl -I http://localhost:3011/blog/rss.xml`
- `bun run test` failed once in the full suite: `tests/platform/proxy-routing.test.ts` timed out in `beforeEach` for `falls through to Clerk auth when a Clerk JWT is not a valid Matrix sync JWT`; isolated retry of the full file passed all 120 tests.

## Screenshot Evidence

- `/tmp/matrix-os-blog-large.png`
- `/tmp/matrix-os-team-large.png`
- `/tmp/matrix-os-blog-toc.png`

## Invariants

- **Source of truth**: Blog source lives in `www/content/blog/*.mdx`; public blog routes, RSS, sitemap, and llms entries derive from the Fumadocs collection.
- **Lock/transaction scope**: No database writes or network mutations are introduced; this is static website content and client-side UI only.
- **Acceptable orphan states**: A malformed blog post fails build/frontmatter validation instead of partially publishing.
- **Auth source of truth**: Blog, RSS, sitemap, llms, landing, and team pages remain public marketing surfaces; no auth behavior changes.
- **Deferred scope**: Exact X post ingestion is deferred until tweet text or safe out-of-band API access is available; this PR does not add an X API integration.
