### PR TITLE
fix(build): wire @matrix-os/brand into host bundle and platform image

### DIFF
--- a/Dockerfile.platform
+++ b/Dockerfile.platform
@@ -11,6 +11,7 @@ COPY packages/gateway/package.json packages/gateway/package.json
 COPY packages/kernel/package.json packages/kernel/package.json
 COPY packages/mcp-browser/package.json packages/mcp-browser/package.json
 COPY packages/observability/package.json packages/observability/package.json
+COPY packages/brand/package.json packages/brand/package.json
 COPY packages/platform/package.json packages/platform/package.json
 COPY packages/sync-client/package.json packages/sync-client/package.json
 COPY shell/package.json shell/package.json
@@ -42,6 +43,7 @@ ENV NEXT_PUBLIC_POSTHOG_HOST=$NEXT_PUBLIC_POSTHOG_HOST
 ENV NEXT_PUBLIC_POSTHOG_API_HOST=$NEXT_PUBLIC_POSTHOG_API_HOST
 ENV NEXT_PUBLIC_MATRIX_APP_URL=$NEXT_PUBLIC_MATRIX_APP_URL
 RUN pnpm --filter '@matrix-os/observability' build
+RUN pnpm --filter '@matrix-os/brand' build
 RUN pnpm --filter '@matrix-os/kernel' build
 RUN pnpm --filter '@matrix-os/gateway' build
 RUN pnpm --filter '@matrix-os/platform' build
@@ -66,6 +68,7 @@ COPY --from=prod-deps --chown=matrix-platform:matrix-platform /app/packages/gate
 COPY --from=prod-deps --chown=matrix-platform:matrix-platform /app/packages/kernel/package.json ./packages/kernel/package.json
 COPY --from=prod-deps --chown=matrix-platform:matrix-platform /app/packages/mcp-browser/package.json ./packages/mcp-browser/package.json
 COPY --from=prod-deps --chown=matrix-platform:matrix-platform /app/packages/observability/package.json ./packages/observability/package.json
+COPY --from=prod-deps --chown=matrix-platform:matrix-platform /app/packages/brand/package.json ./packages/brand/package.json
 COPY --from=prod-deps --chown=matrix-platform:matrix-platform /app/packages/platform/package.json ./packages/platform/package.json
 COPY --from=prod-deps --chown=matrix-platform:matrix-platform /app/packages/sync-client/package.json ./packages/sync-client/package.json
 COPY --from=prod-deps --chown=matrix-platform:matrix-platform /app/shell/package.json ./shell/package.json
@@ -73,6 +76,7 @@ COPY --from=builder --chown=matrix-platform:matrix-platform /app/packages/clerk-
 COPY --from=builder --chown=matrix-platform:matrix-platform /app/packages/gateway/dist ./packages/gateway/dist
 COPY --from=builder --chown=matrix-platform:matrix-platform /app/packages/kernel/dist ./packages/kernel/dist
 COPY --from=builder --chown=matrix-platform:matrix-platform /app/packages/observability/dist ./packages/observability/dist
+COPY --from=builder --chown=matrix-platform:matrix-platform /app/packages/brand/dist ./packages/brand/dist
 COPY --from=builder --chown=matrix-platform:matrix-platform /app/packages/platform/dist ./packages/platform/dist
 COPY --from=builder --chown=matrix-platform:matrix-platform /app/shell ./shell
 COPY --chown=matrix-platform:matrix-platform distro/customer-vps ./distro/customer-vps

--- a/scripts/build-host-bundle.sh
+++ b/scripts/build-host-bundle.sh
@@ -25,6 +25,7 @@ mkdir -p "$STAGE_DIR/bin" "$STAGE_DIR/app" "$STAGE_DIR/runtime" "$STAGE_DIR/syst
 pnpm install --frozen-lockfile
 pnpm rebuild node-pty
 pnpm --filter '@matrix-os/observability' build
+pnpm --filter '@matrix-os/brand' build
 pnpm --filter '@matrix-os/kernel' build
 pnpm --filter '@matrix-os/gateway' build
 mkdir -p "$ROOT_DIR/packages/gateway/dist/app-runtime"


### PR DESCRIPTION
## Summary
Fixes red `main`: wire the new `@matrix-os/brand` workspace package (added in #660) into the two build pipelines that call `next build` directly and bypass the package build scripts.

## Root cause
`@matrix-os/brand` resolves to `./dist/index.js` (built via `tsc`). The `shell` and `www` build scripts build it first, but:
- `scripts/build-host-bundle.sh` built `@matrix-os/observability` but not `@matrix-os/brand` before the shell `next build`.
- `Dockerfile.platform` neither copied `packages/brand/package.json` into the deps stage nor built brand before the shell `next build`.

Both broke only after the stack merged, because **Host Bundle Release** and **Platform Cloud Run** run on push to `main`, not on PRs — so the PR CI never exercised them. Symptom: `Module not found: Can't resolve '@matrix-os/brand'`.

## Changes
- `scripts/build-host-bundle.sh`: build `@matrix-os/brand` before the shell build.
- `Dockerfile.platform`: copy `packages/brand/package.json` into the deps stage, build brand before the shell `next build`, and copy its `package.json` + `dist` into the prod stage — mirroring how `@matrix-os/observability` is already handled.

## Validation
- `pnpm --filter '@matrix-os/brand' build` produces `dist/` (`index.js`, `tokens.js`, `primitives.js`).
- Local `docker build -f Dockerfile.platform --target builder` to reproduce the previously failing shell `next build`.
- Note: PR CI does not run Host Bundle Release / Platform Cloud Run (push-to-main only); these are validated locally pre-merge and by the workflows themselves post-merge.

## Invariants
- **Source of truth**: the pnpm workspace package graph; each package's compiled output under `dist/`. No runtime/data paths touched.
- **Build order**: `@matrix-os/brand` must be built before any `shell`/`www` `next build`; this PR enforces that in both the host bundle and the platform image.
- **Acceptable orphan states**: none — pure build wiring, no partial-write or persistence concerns.
- **Auth source of truth**: unchanged.
- **Deferred scope**: none.
