### PR TITLE
fix(vps): install code-server before code proxy startup

### DIFF
--- a/distro/customer-vps/cloud-init.yaml
+++ b/distro/customer-vps/cloud-init.yaml
@@ -122,7 +122,8 @@ write_files:
     content: |
       [Unit]
       Description=Matrix OS customer code editor
-      After=matrix-restore.service
+      After=matrix-restore.service matrix-code-server.service
+      Wants=matrix-code-server.service
       Requires=matrix-restore.service
       ConditionPathExists=/opt/matrix/restore-complete
       ConditionPathExists=/opt/matrix/bin/matrix-code
@@ -136,6 +137,31 @@ write_files:
       ExecStart=/opt/matrix/bin/matrix-code
       Restart=on-failure
       RestartSec=5
+
+      [Install]
+      WantedBy=multi-user.target
+  - path: /etc/systemd/system/matrix-code-server.service
+    owner: root:root
+    permissions: "0644"
+    content: |
+      [Unit]
+      Description=Install Matrix OS code-server runtime
+      After=network-online.target matrix-restore.service
+      Wants=network-online.target
+      Requires=matrix-restore.service
+      ConditionPathExists=/opt/matrix/restore-complete
+      ConditionPathExists=/opt/matrix/bin/matrix-install-tool-pack
+
+      [Service]
+      Type=oneshot
+      User=root
+      Group=root
+      EnvironmentFile=/opt/matrix/env/host.env
+      ExecStart=/opt/matrix/bin/matrix-install-tool-pack code-server
+      ExecStartPost=-/bin/systemctl start matrix-code.service
+      Restart=on-failure
+      RestartSec=10m
+      TimeoutStartSec=900
 
       [Install]
       WantedBy=multi-user.target
@@ -556,8 +582,9 @@ runcmd:
     systemctl daemon-reload
     loginctl enable-linger matrix
     systemctl start "user@$(id -u matrix).service"
-    systemctl enable matrix-restore.service matrix-gateway.service matrix-shell.service matrix-code.service matrix-sync-agent.service matrix-symphony.service matrix-hermes.service matrix-hermes-dashboard.service matrix-linux-tools.service matrix-developer-tools.service matrix-db-backup.timer nginx
-    systemctl start matrix-restore.service matrix-gateway.service matrix-shell.service matrix-code.service matrix-sync-agent.service matrix-symphony.service
+    systemctl enable matrix-restore.service matrix-gateway.service matrix-shell.service matrix-code-server.service matrix-code.service matrix-sync-agent.service matrix-symphony.service matrix-hermes.service matrix-hermes-dashboard.service matrix-linux-tools.service matrix-developer-tools.service matrix-db-backup.timer nginx
+    systemctl start matrix-restore.service matrix-gateway.service matrix-shell.service matrix-sync-agent.service matrix-symphony.service
+    systemctl start --no-block matrix-code-server.service || echo "matrix-host: code-server runtime install will retry via systemd" >&2
     systemctl start --no-block matrix-hermes.service || echo "matrix-host: optional Hermes install will retry via systemd" >&2
     systemctl start --no-block matrix-hermes-dashboard.service || echo "matrix-host: optional Hermes dashboard will retry via systemd" >&2
     systemctl start --no-block matrix-linux-tools.service || echo "matrix-host: optional Linux tools install will retry via systemd" >&2

--- a/distro/customer-vps/host-bin/matrix-sync-agent
+++ b/distro/customer-vps/host-bin/matrix-sync-agent
@@ -298,6 +298,11 @@ apply_update() {
     sudo find "$extract_dir/systemd" -maxdepth 1 -name 'matrix-*.service' -exec install -o root -g root -m 0644 {} /etc/systemd/system/ \;
     sudo systemctl daemon-reload
     log "Installed systemd units"
+    if [ -f "$extract_dir/systemd/matrix-code-server.service" ]; then
+      sudo systemctl enable matrix-code-server.service
+      sudo systemctl start --no-block matrix-code-server.service || true
+      log "Code-server runtime service enabled"
+    fi
     if [ -f "$extract_dir/systemd/matrix-symphony.service" ]; then
       sudo systemctl enable matrix-symphony.service
       sudo systemctl start --no-block matrix-symphony.service || true

--- a/distro/customer-vps/systemd/matrix-code-server.service
+++ b/distro/customer-vps/systemd/matrix-code-server.service
@@ -1,0 +1,21 @@
+[Unit]
+Description=Install Matrix OS code-server runtime
+After=network-online.target matrix-restore.service
+Wants=network-online.target
+Requires=matrix-restore.service
+ConditionPathExists=/opt/matrix/restore-complete
+ConditionPathExists=/opt/matrix/bin/matrix-install-tool-pack
+
+[Service]
+Type=oneshot
+User=root
+Group=root
+EnvironmentFile=/opt/matrix/env/host.env
+ExecStart=/opt/matrix/bin/matrix-install-tool-pack code-server
+ExecStartPost=-/bin/systemctl start matrix-code.service
+Restart=on-failure
+RestartSec=10m
+TimeoutStartSec=900
+
+[Install]
+WantedBy=multi-user.target

--- a/packages/platform/src/main.ts
+++ b/packages/platform/src/main.ts
@@ -454,6 +454,18 @@ function logPlatformRouteError(route: string, err: unknown): void {
   );
 }
 
+function logCodeDomainUpstreamFailure(opts: {
+  handle: string;
+  runtimeSlot?: string | null;
+  publicIPv4?: string | null;
+  path: string;
+  status: number;
+}): void {
+  console.warn(
+    `[platform] code-domain vps upstream 5xx handle=${opts.handle} runtimeSlot=${opts.runtimeSlot ?? 'unknown'} publicIPv4=${opts.publicIPv4 ?? 'unknown'} path=${JSON.stringify(opts.path)} status=${opts.status}`,
+  );
+}
+
 function isObjectNotFoundError(err: unknown): boolean {
   if (!err || typeof err !== 'object') return false;
   const candidate = err as { name?: unknown; $metadata?: { httpStatusCode?: unknown } };
@@ -3365,6 +3377,15 @@ export function createApp(deps: {
           body,
           dispatcher: customerVpsProxyDispatcher,
         } as RequestInit & { dispatcher: Agent });
+        if (isCodeDomain && upstream.status >= 500) {
+          logCodeDomainUpstreamFailure({
+            handle: runningMachine.handle,
+            runtimeSlot: runningMachine.runtimeSlot,
+            publicIPv4: runningMachine.publicIPv4,
+            path,
+            status: upstream.status,
+          });
+        }
 
         const responseHeaders = sanitizeProxyResponseHeaders(upstream.headers);
         applySandboxedAppAssetCorsHeaders(responseHeaders, path, c.req.header('origin'));

--- a/tests/platform/customer-vps-cloud-init.test.ts
+++ b/tests/platform/customer-vps-cloud-init.test.ts
@@ -260,13 +260,20 @@ exit 99
     expect(cloudInit).toContain('path: /etc/systemd/system/matrix-hermes.service');
     expect(cloudInit).toContain('ExecStart=/opt/matrix/bin/matrix-install-hermes');
     expect(cloudInit).toContain('ExecStartPost=-/bin/systemctl start matrix-code.service');
+    expect(cloudInit).toContain('path: /etc/systemd/system/matrix-code-server.service');
+    expect(cloudInit).toContain('Description=Install Matrix OS code-server runtime');
+    expect(cloudInit).toContain('ExecStart=/opt/matrix/bin/matrix-install-tool-pack code-server');
     expect(cloudInit).toContain('TimeoutStartSec=1800');
     expect(cloudInit).toContain(
-      'systemctl enable matrix-restore.service matrix-gateway.service matrix-shell.service matrix-code.service matrix-sync-agent.service matrix-symphony.service matrix-hermes.service matrix-hermes-dashboard.service matrix-linux-tools.service matrix-developer-tools.service matrix-db-backup.timer nginx',
+      'systemctl enable matrix-restore.service matrix-gateway.service matrix-shell.service matrix-code-server.service matrix-code.service matrix-sync-agent.service matrix-symphony.service matrix-hermes.service matrix-hermes-dashboard.service matrix-linux-tools.service matrix-developer-tools.service matrix-db-backup.timer nginx',
     );
     expect(cloudInit).toContain(
+      'systemctl start matrix-restore.service matrix-gateway.service matrix-shell.service matrix-sync-agent.service matrix-symphony.service',
+    );
+    expect(cloudInit).not.toContain(
       'systemctl start matrix-restore.service matrix-gateway.service matrix-shell.service matrix-code.service matrix-sync-agent.service matrix-symphony.service',
     );
+    expect(cloudInit).toContain('systemctl start --no-block matrix-code-server.service || echo "matrix-host: code-server runtime install will retry via systemd" >&2');
     expect(cloudInit).toContain('systemctl start --no-block matrix-hermes.service || echo "matrix-host: optional Hermes install will retry via systemd" >&2');
     expect(cloudInit).toContain('systemctl start --no-block matrix-hermes-dashboard.service || echo "matrix-host: optional Hermes dashboard will retry via systemd" >&2');
     expect(cloudInit.indexOf('systemctl start matrix-restore.service matrix-gateway.service')).toBeLessThan(
@@ -311,7 +318,7 @@ exit 99
     const cloudInit = await loadCustomerVpsCloudInitTemplate();
 
     expect(cloudInit).toContain('runcmd:');
-    expect(cloudInit).toContain('systemctl enable matrix-restore.service matrix-gateway.service matrix-shell.service matrix-code.service matrix-sync-agent.service matrix-symphony.service matrix-hermes.service matrix-hermes-dashboard.service matrix-linux-tools.service matrix-developer-tools.service matrix-db-backup.timer');
+    expect(cloudInit).toContain('systemctl enable matrix-restore.service matrix-gateway.service matrix-shell.service matrix-code-server.service matrix-code.service matrix-sync-agent.service matrix-symphony.service matrix-hermes.service matrix-hermes-dashboard.service matrix-linux-tools.service matrix-developer-tools.service matrix-db-backup.timer');
     expect(cloudInit).toContain('install -o root -g root -m 0644 /opt/matrix/systemd/*.service /etc/systemd/system/');
     expect(cloudInit).toContain('/opt/matrix/messaging /opt/matrix/messaging/bin');
     expect(cloudInit).toContain('if [ -x /opt/matrix/messaging/bin/synapse ] && [ -x /opt/matrix/messaging/bin/mautrix-telegram ] && [ -x /opt/matrix/messaging/bin/mautrix-whatsapp ]; then');
@@ -503,9 +510,14 @@ exit 99
     const code = readFileSync(join(root, 'distro/customer-vps/host-bin/matrix-code'), 'utf8');
 
     expect(cloudInit).toContain('Description=Matrix OS customer code editor');
+    expect(cloudInit).toContain('After=matrix-restore.service matrix-code-server.service');
+    expect(cloudInit).toContain('Wants=matrix-code-server.service');
     expect(cloudInit).toContain('ExecStart=/opt/matrix/bin/matrix-code');
     expect(cloudInit).toContain('ConditionPathExists=/opt/matrix/bin/matrix-code');
     expect(cloudInit).toContain('ConditionPathExists=/opt/matrix/runtime/code-server/bin/code-server');
+    expect(cloudInit).toContain('Description=Install Matrix OS code-server runtime');
+    expect(cloudInit).toContain('ExecStart=/opt/matrix/bin/matrix-install-tool-pack code-server');
+    expect(cloudInit).toContain('ExecStartPost=-/bin/systemctl start matrix-code.service');
     expect(code).toContain('MATRIX_CODE_PROXY_TOKEN');
     expect(code).toContain('code-server');
     expect(code).toContain('crypto.timingSafeEqual');
@@ -632,7 +644,7 @@ exit 99
     expect(cloudInit).toContain('https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip');
     expect(cloudInit).toContain('/tmp/aws/install --bin-dir /usr/local/bin --install-dir /usr/local/aws-cli');
     expect(cloudInit).toContain('docker run -d');
-    expect(cloudInit).toContain('systemctl enable matrix-restore.service matrix-gateway.service matrix-shell.service matrix-code.service matrix-sync-agent.service matrix-symphony.service matrix-hermes.service matrix-hermes-dashboard.service matrix-linux-tools.service matrix-developer-tools.service matrix-db-backup.timer');
+    expect(cloudInit).toContain('systemctl enable matrix-restore.service matrix-gateway.service matrix-shell.service matrix-code-server.service matrix-code.service matrix-sync-agent.service matrix-symphony.service matrix-hermes.service matrix-hermes-dashboard.service matrix-linux-tools.service matrix-developer-tools.service matrix-db-backup.timer');
   });
 
   it('includes a bounded matrixctl recovery wrapper', () => {

--- a/tests/platform/customer-vps-host-bundle.test.ts
+++ b/tests/platform/customer-vps-host-bundle.test.ts
@@ -158,6 +158,7 @@ describe('customer VPS host bundle', () => {
   it('packages an asynchronous developer tools first-boot service', () => {
     const root = process.cwd();
     const unit = readFileSync(join(root, 'distro/customer-vps/systemd/matrix-developer-tools.service'), 'utf8');
+    const codeServerUnit = readFileSync(join(root, 'distro/customer-vps/systemd/matrix-code-server.service'), 'utf8');
     const installer = readFileSync(join(root, 'distro/customer-vps/host-bin/matrix-install-developer-tools'), 'utf8');
 
     expect(unit).toContain('Description=Matrix OS optional developer tools');
@@ -170,6 +171,9 @@ describe('customer VPS host bundle', () => {
     expect(installer).toContain('optional developer tool ${tool} already installed; skipping');
     expect(installer).toContain('TOOLS="${MATRIX_DEVELOPER_TOOLS-codex claude-code opencode pi}"');
     expect(installer).not.toContain('TOOLS="${MATRIX_DEVELOPER_TOOLS:-codex claude-code opencode pi}"');
+    expect(codeServerUnit).toContain('Description=Install Matrix OS code-server runtime');
+    expect(codeServerUnit).toContain('ExecStart=/opt/matrix/bin/matrix-install-tool-pack code-server');
+    expect(codeServerUnit).toContain('ExecStartPost=-/bin/systemctl start matrix-code.service');
   });
 
   it('owner env canonicalizes Hermes home and migrates legacy Hermes data', () => {
@@ -758,6 +762,9 @@ test "$(readlink "$MATRIX_LEGACY_HOME/.hermes")" = "$MATRIX_HOME/.hermes"
     expect(syncAgent).toContain('rm -f "$temp_file"');
     expect(syncAgent).toContain("sudo find \"$extract_dir/systemd\" -maxdepth 1 -name 'matrix-*.service'");
     expect(syncAgent).toContain('sudo systemctl daemon-reload');
+    expect(syncAgent).toContain('sudo systemctl enable matrix-code-server.service');
+    expect(syncAgent).toContain('sudo systemctl start --no-block matrix-code-server.service || true');
+    expect(syncAgent).toContain('Code-server runtime service enabled');
     expect(syncAgent).toContain('Messaging runtimes missing; units installed but not enabled');
     expect(syncAgent).toContain('sudo systemctl enable matrix-homeserver.service matrix-bridge-telegram.service matrix-bridge-whatsapp.service');
   });

--- a/tests/platform/proxy-routing.test.ts
+++ b/tests/platform/proxy-routing.test.ts
@@ -1294,6 +1294,87 @@ describe("platform proxy routing", () => {
     expect(fetchMock.mock.calls[0]?.[1]?.dispatcher).toBeDefined();
   });
 
+  it("logs sanitized VPS upstream 5xx metadata for code-domain routing", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    await deleteContainer(db, "alice");
+    await insertUserMachine(db, {
+      machineId: "9f05824c-8d0a-4d83-9cb4-b312d43ff116",
+      clerkUserId: "user_alice",
+      handle: "alice",
+      runtimeSlot: "primary",
+      status: "running",
+      hetznerServerId: 123460,
+      publicIPv4: "203.0.113.14",
+      imageVersion: "matrix-os-host-2026.04.26-1",
+      provisionedAt: "2026-04-26T12:00:00.000Z",
+    });
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response("Editor unavailable", { status: 502 }),
+    );
+    const app = createApp({
+      db,
+      orchestrator: stubOrchestrator(),
+      clerkAuth: createClerkAuth({
+        verifyToken: vi.fn().mockResolvedValue({ sub: "user_alice" }),
+      }),
+      platformSecret: "platform-secret-123",
+    });
+
+    const res = await app.request("/?folder=/home/matrix/home", {
+      headers: {
+        host: "code.matrix-os.com",
+        authorization: "Bearer clerk-session",
+      },
+    });
+
+    expect(res.status).toBe(502);
+    expect(await res.text()).toBe("Editor unavailable");
+    expect(warnSpy).toHaveBeenCalledWith(
+      "[platform] code-domain vps upstream 5xx handle=alice runtimeSlot=primary publicIPv4=203.0.113.14 path=\"/\" status=502",
+    );
+    expect(warnSpy.mock.calls.join("\n")).not.toContain("clerk-session");
+    expect(warnSpy.mock.calls.join("\n")).not.toContain("platform-secret-123");
+    expect(warnSpy.mock.calls.join("\n")).not.toContain("folder=/home/matrix/home");
+  });
+
+  it("does not log code-domain upstream metadata for successful VPS responses", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    await deleteContainer(db, "alice");
+    await insertUserMachine(db, {
+      machineId: "9f05824c-8d0a-4d83-9cb4-b312d43ff117",
+      clerkUserId: "user_alice",
+      handle: "alice",
+      runtimeSlot: "primary",
+      status: "running",
+      hetznerServerId: 123461,
+      publicIPv4: "203.0.113.15",
+      imageVersion: "matrix-os-host-2026.04.26-1",
+      provisionedAt: "2026-04-26T12:00:00.000Z",
+    });
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response("editor", { status: 200 }),
+    );
+    const app = createApp({
+      db,
+      orchestrator: stubOrchestrator(),
+      clerkAuth: createClerkAuth({
+        verifyToken: vi.fn().mockResolvedValue({ sub: "user_alice" }),
+      }),
+      platformSecret: "platform-secret-123",
+    });
+
+    const res = await app.request("/", {
+      headers: {
+        host: "code.matrix-os.com",
+        authorization: "Bearer clerk-session",
+      },
+    });
+
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe("editor");
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
   it("ignores stale legacy containers on app.matrix-os.com when VPS-native routing is configured", async () => {
     await updateContainerStatus(db, "alice", "stopped", "stale-container-id");
     const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(


### PR DESCRIPTION
## Summary
- Add a first-class matrix-code-server.service that installs code-server after restore completion and starts matrix-code.service afterward.
- Enable/start the code-server service from cloud-init for new VPSes and from matrix-sync-agent when host bundles update existing VPSes.
- Log sanitized code-domain VPS upstream 5xx metadata so future Cloudflare 502 reports identify the failing handle/IP/status without leaking tokens.

## Why
matrix-code.service was conditioned on /opt/matrix/runtime/code-server/bin/code-server, but first boot only started matrix-code before code-server was installed. The async developer tools installer does not install code-server, so new VPSes could leave nginx proxying code.matrix-os.com to a missing local code proxy on 127.0.0.1:8787, producing 502s.

## Verification
- bun run test tests/platform/customer-vps-cloud-init.test.ts tests/platform/customer-vps-host-bundle.test.ts tests/platform/proxy-routing.test.ts

## Mandatory invariants
- Source of truth: customer VPS code-domain runtime readiness is owned by systemd units and host-bundle update flow.
- Lock/transaction scope: no persistence changes or database writes.
- Acceptable orphan states: if code-server download fails, the retryable systemd unit remains failed and matrix-code stays stopped; app/gateway readiness is not blocked.
- Auth source of truth: no change to Clerk, platform JWT, edge secret, or code proxy token verification.
- Deferred scope: Cloudflare Worker observability remains separate; this PR adds platform-side sanitized upstream failure logs only.