### PR TITLE
fix(www): make landing CSP cache-safe so client JS runs

### DIFF
--- a/tests/www/security-headers.test.ts
+++ b/tests/www/security-headers.test.ts
@@ -20,6 +20,8 @@ function expectSecurityHeaders(response: Response) {
   expect(csp).toContain("https://*.clerk.com");
   expect(csp).toContain("https://*.clerk.accounts.dev");
   expect(csp).toContain("https://eu-assets.i.posthog.com");
+  expect(csp).toContain("script-src 'self' 'unsafe-inline' https://clerk.matrix-os.com https://*.clerk.com https://*.clerk.accounts.dev https://eu-assets.i.posthog.com https://tally.so");
+  expect(csp).toContain("frame-src 'self' https://app.matrix-os.com https://clerk.matrix-os.com https://*.clerk.com https://*.clerk.accounts.dev https://tally.so");
   expect(csp).not.toContain("'nonce-");
   expect(csp).not.toContain("'strict-dynamic'");
   expect(csp).toContain("connect-src 'self'");

--- a/tests/www/security-headers.test.ts
+++ b/tests/www/security-headers.test.ts
@@ -21,6 +21,7 @@ function expectSecurityHeaders(response: Response) {
   expect(csp).toContain("https://*.clerk.accounts.dev");
   expect(csp).toContain("https://eu-assets.i.posthog.com");
   expect(csp).toContain("script-src 'self' 'unsafe-inline' https://clerk.matrix-os.com https://*.clerk.com https://*.clerk.accounts.dev https://eu-assets.i.posthog.com https://tally.so");
+  expect(csp).toContain("connect-src 'self' https://app.matrix-os.com https://api.matrix-os.com https://clerk.matrix-os.com https://*.clerk.com https://*.clerk.accounts.dev https://eu.i.posthog.com https://eu-assets.i.posthog.com https://tally.so");
   expect(csp).toContain("frame-src 'self' https://app.matrix-os.com https://clerk.matrix-os.com https://*.clerk.com https://*.clerk.accounts.dev https://tally.so");
   expect(csp).not.toContain("'nonce-");
   expect(csp).not.toContain("'strict-dynamic'");

--- a/tests/www/security-headers.test.ts
+++ b/tests/www/security-headers.test.ts
@@ -15,17 +15,22 @@ function expectSecurityHeaders(response: Response) {
   const csp = response.headers.get("Content-Security-Policy");
   expect(csp).toBeTruthy();
   expect(csp).toContain("default-src 'self'");
-  expect(csp).toContain("script-src 'self' 'nonce-");
-  expect(csp).toContain("'strict-dynamic'");
+  expect(csp).toContain("script-src 'self' 'unsafe-inline'");
+  expect(csp).toContain("https://clerk.matrix-os.com");
+  expect(csp).toContain("https://*.clerk.com");
+  expect(csp).toContain("https://*.clerk.accounts.dev");
+  expect(csp).toContain("https://eu-assets.i.posthog.com");
+  expect(csp).not.toContain("'nonce-");
+  expect(csp).not.toContain("'strict-dynamic'");
   expect(csp).toContain("connect-src 'self'");
   expect(csp).not.toContain("Content-Security-Policy-Report-Only");
-  expect(csp).not.toContain("'unsafe-inline' 'unsafe-eval'");
+  expect(csp).not.toContain("'unsafe-eval'");
   expect(response.headers.get("Cross-Origin-Opener-Policy")).toBe("same-origin");
   expect(response.headers.get("Permissions-Policy")).toBe("browsing-topics=(), interest-cohort=()");
 }
 
 describe("www Lighthouse security headers", () => {
-  it("sets an enforced nonce CSP and COOP on public route responses", async () => {
+  it("sets an enforced cache-safe CSP and COOP on public route responses", async () => {
     const authorizeProtectedRoute = vi.fn();
     const response = await proxyWithSecurity(
       makeRequest("/"),
@@ -34,7 +39,7 @@ describe("www Lighthouse security headers", () => {
     );
 
     expectSecurityHeaders(response);
-    expect(response.headers.get("x-middleware-request-x-nonce")).toBeTruthy();
+    expect(response.headers.get("x-middleware-request-x-nonce")).toBeNull();
     expect(response.headers.get("x-middleware-request-content-security-policy")).toBeNull();
     expect(authorizeProtectedRoute).not.toHaveBeenCalled();
   });
@@ -57,13 +62,12 @@ describe("www Lighthouse security headers", () => {
     expect(authorizeProtectedRoute).toHaveBeenCalledOnce();
     expect(response.headers.get("x-clerk-checked")).toBe("1");
     expectSecurityHeaders(response);
-    expect(response.headers.get("x-middleware-request-x-nonce")).toBeTruthy();
+    expect(response.headers.get("x-middleware-request-x-nonce")).toBeNull();
     expect(response.headers.get("x-middleware-request-x-clerk-auth-status")).toBe("signed-in");
     expect(response.headers.get("x-middleware-request-x-clerk-auth-token")).toBe("token");
     expect(response.headers.get("x-middleware-override-headers")?.split(",")).toEqual([
       "x-clerk-auth-status",
       "x-clerk-auth-token",
-      "x-nonce",
     ]);
     expect(response.headers.get("x-middleware-request-content-security-policy")).toBeNull();
   });

--- a/www/src/app/page.tsx
+++ b/www/src/app/page.tsx
@@ -1,5 +1,4 @@
 import type { Metadata } from "next";
-import { headers } from "next/headers";
 import { BodyOverflow } from "@/components/landing/ScrollScreenshot";
 import { LandingBilling } from "@/components/landing/LandingBilling";
 import { LandingTelemetry } from "@/components/landing/LandingTelemetry";
@@ -38,16 +37,13 @@ export const metadata: Metadata = {
     "Matrix gives background agents their own computer. Run Claude, Codex, Cursor, OpenCode, and Hermes in a private hosted workspace with persistent terminals, repos, previews, and workflows that keep going after your laptop closes.",
 };
 
-export default async function LandingPage() {
-  const nonce = (await headers()).get("x-nonce") ?? undefined;
-
+export default function LandingPage() {
   return (
     <div style={{ backgroundColor: c.pageBg, color: c.deep, fontFamily: fonts.sans }}>
       {/* react-doctor-disable-next-line react-doctor/no-danger -- jsonLd is JSON.stringify of a static module-scope object (trusted, no user input); standard JSON-LD injection */}
       <script
         id="landing-json-ld"
         type="application/ld+json"
-        nonce={nonce}
         suppressHydrationWarning
         dangerouslySetInnerHTML={{ __html: jsonLd }}
       />

--- a/www/src/app/page.tsx
+++ b/www/src/app/page.tsx
@@ -44,7 +44,6 @@ export default function LandingPage() {
       <script
         id="landing-json-ld"
         type="application/ld+json"
-        suppressHydrationWarning
         dangerouslySetInnerHTML={{ __html: jsonLd }}
       />
       <LandingTelemetry />

--- a/www/src/proxy.ts
+++ b/www/src/proxy.ts
@@ -32,7 +32,7 @@ function buildContentSecurityPolicy(): string {
     font-src 'self' data:;
     style-src 'self' 'unsafe-inline';
     script-src 'self' 'unsafe-inline' https://clerk.matrix-os.com https://*.clerk.com https://*.clerk.accounts.dev https://eu-assets.i.posthog.com https://tally.so${devScriptPolicy};
-    connect-src 'self' https://app.matrix-os.com https://api.matrix-os.com https://clerk.matrix-os.com https://*.clerk.com https://*.clerk.accounts.dev https://eu.i.posthog.com https://eu-assets.i.posthog.com;
+    connect-src 'self' https://app.matrix-os.com https://api.matrix-os.com https://clerk.matrix-os.com https://*.clerk.com https://*.clerk.accounts.dev https://eu.i.posthog.com https://eu-assets.i.posthog.com https://tally.so;
     frame-src 'self' https://app.matrix-os.com https://clerk.matrix-os.com https://*.clerk.com https://*.clerk.accounts.dev https://tally.so;
     worker-src 'self' blob:;
     upgrade-insecure-requests;

--- a/www/src/proxy.ts
+++ b/www/src/proxy.ts
@@ -20,7 +20,7 @@ function normalizeCsp(policy: string): string {
   return policy.replace(/\s{2,}/g, " ").trim();
 }
 
-function buildContentSecurityPolicy(nonce: string): string {
+function buildContentSecurityPolicy(): string {
   const devScriptPolicy = process.env.NODE_ENV === "development" ? " 'unsafe-eval' http:" : "";
   return normalizeCsp(`
     default-src 'self';
@@ -31,7 +31,7 @@ function buildContentSecurityPolicy(nonce: string): string {
     img-src 'self' blob: data: https:;
     font-src 'self' data:;
     style-src 'self' 'unsafe-inline';
-    script-src 'self' 'nonce-${nonce}' 'strict-dynamic' https:${devScriptPolicy};
+    script-src 'self' 'unsafe-inline' https://clerk.matrix-os.com https://*.clerk.com https://*.clerk.accounts.dev https://eu-assets.i.posthog.com${devScriptPolicy};
     connect-src 'self' https://app.matrix-os.com https://api.matrix-os.com https://clerk.matrix-os.com https://*.clerk.com https://*.clerk.accounts.dev https://eu.i.posthog.com https://eu-assets.i.posthog.com;
     frame-src 'self' https://app.matrix-os.com https://clerk.matrix-os.com https://*.clerk.com https://*.clerk.accounts.dev;
     worker-src 'self' blob:;
@@ -39,17 +39,9 @@ function buildContentSecurityPolicy(nonce: string): string {
   `);
 }
 
-function createSecurityResponse(request: ProxyRequest) {
-  const nonce = btoa(crypto.randomUUID());
-  const requestHeaders = new Headers(request.headers);
-  const csp = buildContentSecurityPolicy(nonce);
-  requestHeaders.set("x-nonce", nonce);
-
-  const response = NextResponse.next({
-    request: {
-      headers: requestHeaders,
-    },
-  });
+function createSecurityResponse() {
+  const csp = buildContentSecurityPolicy();
+  const response = NextResponse.next();
   return applySecurityHeaders(response, csp);
 }
 
@@ -91,7 +83,7 @@ export async function proxyWithSecurity(
   event: ProxyEvent,
   authorizeProtectedRoute: ProtectedRouteAuthorizer = withClerk,
 ) {
-  const securityResponse = createSecurityResponse(request);
+  const securityResponse = createSecurityResponse();
   if (isProtectedRoute(request)) {
     const clerkResponse = await authorizeProtectedRoute(request, event);
     return applySecurityResponseHeaders(clerkResponse ?? NextResponse.next(), securityResponse);

--- a/www/src/proxy.ts
+++ b/www/src/proxy.ts
@@ -31,9 +31,9 @@ function buildContentSecurityPolicy(): string {
     img-src 'self' blob: data: https:;
     font-src 'self' data:;
     style-src 'self' 'unsafe-inline';
-    script-src 'self' 'unsafe-inline' https://clerk.matrix-os.com https://*.clerk.com https://*.clerk.accounts.dev https://eu-assets.i.posthog.com${devScriptPolicy};
+    script-src 'self' 'unsafe-inline' https://clerk.matrix-os.com https://*.clerk.com https://*.clerk.accounts.dev https://eu-assets.i.posthog.com https://tally.so${devScriptPolicy};
     connect-src 'self' https://app.matrix-os.com https://api.matrix-os.com https://clerk.matrix-os.com https://*.clerk.com https://*.clerk.accounts.dev https://eu.i.posthog.com https://eu-assets.i.posthog.com;
-    frame-src 'self' https://app.matrix-os.com https://clerk.matrix-os.com https://*.clerk.com https://*.clerk.accounts.dev;
+    frame-src 'self' https://app.matrix-os.com https://clerk.matrix-os.com https://*.clerk.com https://*.clerk.accounts.dev https://tally.so;
     worker-src 'self' blob:;
     upgrade-insecure-requests;
   `);


### PR DESCRIPTION
## Summary

- Replace the per-request nonce + `strict-dynamic` landing CSP with a cache-safe script source allowlist.
- Remove the now-dead `x-nonce` request header plumbing and the landing page JSON-LD nonce read.
- Keep Tally's waitlist script and embedded forms working under the host allowlist.
- Update the `www` security header tests so they assert the CSP contains no per-request nonce and no `strict-dynamic`.

## Tradeoff

This intentionally drops nonce-strength script CSP on the cached marketing surface in favor of host allowlisting plus `'unsafe-inline'`. The landing HTML is edge-cached, so per-request nonces can diverge between the CSP response header and cached `<script>` tags, blocking hydration on cache hits. Keeping nonce-strength would require forcing the affected routes dynamic, for example with `export const dynamic = 'force-dynamic'`, which would trade away edge caching for the landing page.

## Invariants

- Source of truth: `www/src/proxy.ts` owns the enforced security headers for `matrix-os.com` document routes.
- Lock/transaction scope: none; this is header construction and page rendering only.
- Acceptable orphan states: none introduced; cached HTML no longer depends on request-specific nonce state.
- Auth source of truth: unchanged; Clerk middleware still protects `/dashboard` and `/admin`.
- Deferred scope: no production verification here; post-deploy validation should confirm the CSP has no nonce, cached HTML has zero `nonce=` attributes, and browser traffic records the landing PostHog event through `/relay`.

## Tests

- `pnpm install --frozen-lockfile`
- `pnpm exec vitest run tests/www`
- `bun run check:patterns`
- `npx react-doctor@latest --verbose --scope changed www`

## Deployment

This is `www/` only and ships via Vercel. It does not require a customer host-bundle rebuild or publish.
