### PR TITLE
test(vps): update code-server bootstrap assertion

### DIFF
--- a/tests/deploy/customer-vps/symphony-systemd.test.ts
+++ b/tests/deploy/customer-vps/symphony-systemd.test.ts
@@ -53,8 +53,9 @@ describe("customer VPS Symphony systemd unit", () => {
     expect(cloudInit).toContain("PLATFORM_INTERNAL_URL={{platformInternalUrl}}");
     expect(cloudInit).toContain("UPGRADE_TOKEN={{platformVerificationToken}}");
     expect(cloudInit).toContain("Environment=SYMPHONY_PORT=4766");
-    expect(cloudInit).toContain("systemctl enable matrix-restore.service matrix-gateway.service matrix-shell.service matrix-code.service matrix-sync-agent.service matrix-symphony.service");
-    expect(cloudInit).toContain("systemctl start matrix-restore.service matrix-gateway.service matrix-shell.service matrix-code.service matrix-sync-agent.service matrix-symphony.service");
+    expect(cloudInit).toContain("systemctl enable matrix-restore.service matrix-gateway.service matrix-shell.service matrix-code-server.service matrix-code.service matrix-sync-agent.service matrix-symphony.service");
+    expect(cloudInit).toContain("systemctl start matrix-restore.service matrix-gateway.service matrix-shell.service matrix-sync-agent.service matrix-symphony.service");
+    expect(cloudInit).toContain("systemctl start --no-block matrix-code-server.service");
   });
 
   it("packages the adapted Elixir Symphony source and license in the host bundle app tree", async () => {


### PR DESCRIPTION
## Summary
- update the Symphony cloud-init test to include the new matrix-code-server bootstrap service
- assert matrix-code-server starts asynchronously while core services stay synchronous

## Verification
- bun run test tests/deploy/customer-vps/symphony-systemd.test.ts

## Mandatory invariants
- Source of truth: cloud-init remains the VPS first-boot source for enabled and started systemd units; tests assert the shipped cloud-init text.
- Lock/transaction scope: no database or shared-state writes are changed.
- Acceptable orphan states: code-server install may retry independently via systemd; core gateway/shell/sync/symphony startup remains synchronous.
- Auth source of truth: unchanged; no auth or token handling changes.
- Deferred scope: no runtime/service behavior change in this PR; this only fixes the missed test assertion from PR #670.