### PR TITLE
feat(vps): add safe machine resizing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -208,6 +208,13 @@ Production customer runtime ships as VPS-native host bundles. R2 stores immutabl
 - **R2 cleanup**: old `system-bundles/*` versions may be deleted after the new version is published, deployed, and verified. Keep the currently promoted/live version and its `.sha256`; do not delete objects still referenced by active channel pointers or rollback plans.
 - **Optional developer tools provision out of band**: the post-payment Default installs step stores selected `codex`, `claude-code`, `opencode`, and `pi` tool IDs for provisioning, then first boot runs `matrix-developer-tools.service` to install them asynchronously. Failures should show up under `/var/lib/matrix-developer-tools/` (`*.log`, `failed-tools`, `installed-tools`) and retry via systemd; they must not block core Matrix readiness.
 
+## Customer Support Notes
+
+- **Public repo boundary**: support docs in this repository must stay public-safe. Document product behavior, invariants, validation steps, and escalation boundaries; do not include customer identifiers, IPs, access tokens, hostnames tied to private incidents, billing IDs, or copy-paste commands that expose secrets. Keep private operator runbooks in the private support system or secret manager.
+- **Machine resizing exists as a platform-internal support primitive**: `POST /vps/:machineId/resize` is protected by platform auth and is intended for support or platform automation, not direct customer UI use. It performs an in-place Hetzner `change_type` flow with graceful shutdown first, `upgrade_disk: false`, guarded `running -> resizing -> running` state, and stale resize reconciliation.
+- **Resize compatibility is constrained by Hetzner disk rules**: local root disks cannot shrink. Treat same-or-larger local disk x86 moves as eligible; reject smaller-disk downgrades before shutting down the customer VPS. For current plan shapes, `cpx22 -> cpx32/cpx52` and `cpx32 -> cpx52` are valid, while `cpx32 -> cpx22` and `cpx52 -> cpx32/cpx22` are not safe unless a separate migration/storage architecture proves the root data fits.
+- **Customer-facing plan changes are separate**: billing/Stripe may change a user's plan entitlement, but existing VPS resizing should remain support/platform-controlled until preflight compatibility checks and UX copy explicitly handle unsupported downgrades.
+
 ## Desktop Release Workflow
 
 - **Desktop OTA channels include `dev`**: treat `dev`, `canary`, `beta`, and `stable` as first-class update channels. Unsigned prerelease packaging must omit empty mac signing env vars rather than exporting blank values.

--- a/docs/agents/customer-support.md
+++ b/docs/agents/customer-support.md
@@ -1,0 +1,49 @@
+# Customer Support Agent Notes
+
+This repo is public. Keep support guidance here limited to behavior, safety
+invariants, and escalation boundaries. Do not add customer identifiers, IP
+addresses, private hostnames, billing IDs, tokens, or incident-specific
+commands. Private runbooks belong in the private support system or the relevant
+secret manager.
+
+## Machine Resize Support Boundary
+
+Matrix OS has a platform-internal customer VPS resize primitive:
+`POST /vps/:machineId/resize`.
+
+Use it as a support or platform-automation primitive, not as a direct customer
+self-serve control. The route is protected by platform auth and performs a
+Hetzner in-place server type change using a guarded state machine:
+
+- claim the machine from `running` to `resizing` before provider mutation
+- gracefully shut down first, with hard poweroff only as a bounded fallback
+- call Hetzner `change_type` with `upgrade_disk: false`
+- wait for the resize to settle, power on, and complete back to `running`
+- leave ambiguous accepted provider actions in `resizing` for reconciliation
+
+## Compatibility Rules
+
+Hetzner local root disks cannot shrink. A support resize must reject smaller
+disk targets before shutting down a customer VPS.
+
+Current public plan shape:
+
+| Current type | Safe data-preserving target |
+| --- | --- |
+| `cpx22` | `cpx32`, `cpx52` |
+| `cpx32` | `cpx52` |
+| `cpx52` | none in the default plan ladder |
+
+Do not present unsupported downgrades as customer self-serve. If a customer
+needs a lower plan after their root disk has grown beyond the target type, that
+is a migration project rather than an in-place resize.
+
+## What Agents Should Say
+
+- Safe phrasing: "We can upgrade an existing Matrix computer in place when the
+  target machine has at least as much local disk as the current one."
+- Safe phrasing: "Downgrades that would shrink the root disk need a migration
+  path and are not supported by the current in-place resize primitive."
+- Unsafe phrasing: "Any plan can be upgraded or downgraded without constraints."
+- Unsafe action: publishing private operator steps, API tokens, customer host
+  names, or incident-specific evidence in this public repo.

--- a/packages/platform/src/customer-vps-hetzner.ts
+++ b/packages/platform/src/customer-vps-hetzner.ts
@@ -25,9 +25,15 @@ export interface CreateHetznerServerInput {
   serverType?: string;
 }
 
+export interface ResizeHetznerServerInput {
+  serverType: string;
+  upgradeDisk: boolean;
+}
+
 export interface HetznerServer {
   id: number;
   status: string;
+  serverType?: string;
   publicIPv4?: string;
   publicIPv6?: string;
   labels?: Record<string, string>;
@@ -36,6 +42,10 @@ export interface HetznerServer {
 export interface HetznerClient {
   createServer(input: CreateHetznerServerInput): Promise<HetznerServer>;
   getServer(serverId: number): Promise<HetznerServer | null>;
+  shutdownServer(serverId: number): Promise<void>;
+  powerOffServer(serverId: number): Promise<void>;
+  powerOnServer(serverId: number): Promise<void>;
+  resizeServer(serverId: number, input: ResizeHetznerServerInput): Promise<void>;
   deleteServer(serverId: number): Promise<void>;
   listServersByLabel?(labelSelector: string): Promise<HetznerServer[]>;
 }
@@ -50,6 +60,7 @@ function requireToken(config: CustomerVpsConfig): string {
 function mapServer(server: {
   id?: unknown;
   status?: unknown;
+  server_type?: { name?: unknown };
   public_net?: { ipv4?: { ip?: unknown }; ipv6?: { ip?: unknown } };
   labels?: unknown;
 }): HetznerServer {
@@ -59,6 +70,7 @@ function mapServer(server: {
   return {
     id: server.id,
     status: server.status,
+    serverType: typeof server.server_type?.name === 'string' ? server.server_type.name : undefined,
     publicIPv4: typeof server.public_net?.ipv4?.ip === 'string' ? server.public_net.ipv4.ip : undefined,
     publicIPv6: typeof server.public_net?.ipv6?.ip === 'string' ? server.public_net.ipv6.ip : undefined,
     labels: server.labels && typeof server.labels === 'object'
@@ -156,6 +168,56 @@ export function createHetznerClient(
         throw new CustomerVpsError(500, 'provider_unavailable', 'Provisioning provider unavailable');
       }
       return parseServer(await parseJson(res));
+    },
+
+    async shutdownServer(serverId) {
+      const res = await request(`/servers/${serverId}/actions/shutdown`, { method: 'POST' });
+      if (res.status === 429) {
+        throw new CustomerVpsError(429, 'quota_exceeded', 'Provisioning capacity unavailable');
+      }
+      if (!res.ok) {
+        await logProviderRejection('shutdownServer', res);
+        throw new CustomerVpsError(500, 'provider_unavailable', 'Provisioning provider unavailable');
+      }
+    },
+
+    async powerOffServer(serverId) {
+      const res = await request(`/servers/${serverId}/actions/poweroff`, { method: 'POST' });
+      if (res.status === 429) {
+        throw new CustomerVpsError(429, 'quota_exceeded', 'Provisioning capacity unavailable');
+      }
+      if (!res.ok) {
+        await logProviderRejection('powerOffServer', res);
+        throw new CustomerVpsError(500, 'provider_unavailable', 'Provisioning provider unavailable');
+      }
+    },
+
+    async powerOnServer(serverId) {
+      const res = await request(`/servers/${serverId}/actions/poweron`, { method: 'POST' });
+      if (res.status === 429) {
+        throw new CustomerVpsError(429, 'quota_exceeded', 'Provisioning capacity unavailable');
+      }
+      if (!res.ok) {
+        await logProviderRejection('powerOnServer', res);
+        throw new CustomerVpsError(500, 'provider_unavailable', 'Provisioning provider unavailable');
+      }
+    },
+
+    async resizeServer(serverId, input) {
+      const res = await request(`/servers/${serverId}/actions/change_type`, {
+        method: 'POST',
+        body: JSON.stringify({
+          server_type: input.serverType,
+          upgrade_disk: input.upgradeDisk,
+        }),
+      });
+      if (res.status === 429) {
+        throw new CustomerVpsError(429, 'quota_exceeded', 'Provisioning capacity unavailable');
+      }
+      if (!res.ok) {
+        await logProviderRejection('resizeServer', res);
+        throw new CustomerVpsError(500, 'provider_unavailable', 'Provisioning provider unavailable');
+      }
     },
 
     async deleteServer(serverId) {

--- a/packages/platform/src/customer-vps-routes.ts
+++ b/packages/platform/src/customer-vps-routes.ts
@@ -8,6 +8,7 @@ import {
   ProvisionRequestSchema,
   RegisterRequestSchema,
   RecoverRequestSchema,
+  ResizeMachineRequestSchema,
   DeployRequestSchema,
 } from './customer-vps-schema.js';
 import type { CustomerVpsService } from './customer-vps.js';
@@ -204,6 +205,27 @@ export function createCustomerVpsRoutes(deps: CustomerVpsRoutesDeps): Hono {
       return c.json(await deps.service.recover(parsed.data), 202);
     } catch (err: unknown) {
       return jsonError(c, err, '/vps/recover');
+    }
+  });
+
+  app.post('/:machineId/resize', bodyLimit({ maxSize: VPS_BODY_LIMIT }), async (c) => {
+    const authError = requirePlatformAuth(c);
+    if (authError) return authError;
+    const params = MachineIdParamSchema.safeParse({ machineId: c.req.param('machineId') });
+    if (!params.success) {
+      return c.json({ error: 'Invalid request' }, 400);
+    }
+    try {
+      const parsed = ResizeMachineRequestSchema.safeParse(await readJson(c));
+      if (!parsed.success) {
+        return c.json({ error: 'Invalid request' }, 400);
+      }
+      return c.json(await deps.service.resize({
+        machineId: params.data.machineId,
+        ...parsed.data,
+      }), 200);
+    } catch (err: unknown) {
+      return jsonError(c, err, '/vps/:machineId/resize');
     }
   });
 

--- a/packages/platform/src/customer-vps-schema.ts
+++ b/packages/platform/src/customer-vps-schema.ts
@@ -6,6 +6,7 @@ export const CustomerVpsStatusSchema = z.enum([
   'running',
   'failed',
   'recovering',
+  'resizing',
   'deleted',
 ]);
 
@@ -48,6 +49,10 @@ export const RecoverRequestSchema = z.object({
   allowEmpty: z.boolean().optional().default(false),
 });
 
+export const ResizeMachineRequestSchema = z.object({
+  serverType: HetznerServerTypeSchema,
+});
+
 export const MachineIdParamSchema = z.object({
   machineId: z.uuid(),
 });
@@ -63,4 +68,5 @@ export const DeployRequestSchema = z.object({
 export type ProvisionRequest = z.infer<typeof ProvisionRequestSchema>;
 export type RegisterRequest = z.infer<typeof RegisterRequestSchema>;
 export type RecoverRequest = z.infer<typeof RecoverRequestSchema>;
+export type ResizeMachineRequest = z.infer<typeof ResizeMachineRequestSchema>;
 export type DeployRequest = z.infer<typeof DeployRequestSchema>;

--- a/packages/platform/src/customer-vps.ts
+++ b/packages/platform/src/customer-vps.ts
@@ -13,12 +13,15 @@ import {
   listPendingProviderDeletions,
   listAllUserMachines,
   listRunningUserMachines,
+  listStaleResizingUserMachines,
   listStaleUserMachines,
   lockUserMachineProvisioning,
   retireUserMachine,
   markProviderDeletionCompleted,
   markProviderDeletionFailed,
   runInPlatformTransaction,
+  claimRunningUserMachineResize,
+  completeUserMachineResize,
   updateUserMachine,
 } from './db.js';
 import type { CustomerVpsConfig } from './customer-vps-config.js';
@@ -45,6 +48,7 @@ import type {
   ProvisionRequest,
   RegisterRequest,
   RecoverRequest,
+  ResizeMachineRequest,
 } from './customer-vps-schema.js';
 import {
   getRuntimeAccessDecision,
@@ -82,6 +86,12 @@ export interface RecoverResponse {
   etaSeconds: number;
 }
 
+export interface ResizeResponse {
+  machineId: string;
+  serverType: string;
+  status: 'running';
+}
+
 export interface StatusResponse {
   machineId: string;
   clerkUserId: string;
@@ -114,6 +124,7 @@ export interface CustomerVpsService {
   provision(input: ProvisionRequest): Promise<ProvisionResponse>;
   register(token: string | undefined, input: RegisterRequest): Promise<RegisterResponse>;
   recover(input: RecoverRequest): Promise<RecoverResponse>;
+  resize(input: ResizeMachineRequest & { machineId: string }): Promise<ResizeResponse>;
   status(machineId: string): Promise<StatusResponse>;
   delete(machineId: string): Promise<DeleteResponse>;
   deploy(target?: DeployTarget): Promise<DeployResult>;
@@ -184,6 +195,8 @@ const DEFAULT_CLOUD_INIT_TEMPLATE = [
 
 const PROVIDER_DELETION_RETRY_BASE_MS = 60_000;
 const PROVIDER_DELETION_RETRY_MAX_MS = 60 * 60_000;
+const RESIZE_STATUS_POLL_INTERVAL_MS = 1_000;
+const RESIZE_STATUS_POLL_TIMEOUT_MS = 90_000;
 
 function activeProvisionResponse(row: UserMachineRecord, etaSeconds: number): ProvisionResponse {
   if (row.status !== 'provisioning' && row.status !== 'running') {
@@ -361,11 +374,66 @@ async function resolveBillingRecoveryContext(
   return { serverType };
 }
 
+async function assertBillingResizeAllowed(
+  deps: CustomerVpsServiceDeps,
+  clerkUserId: string,
+  serverType: string,
+  now: Date,
+): Promise<void> {
+  if (!deps.resolveBillingEntitlement) {
+    return;
+  }
+  const entitlement = await deps.resolveBillingEntitlement(clerkUserId);
+  const access = getRuntimeAccessDecision(entitlement, now);
+  if (!entitlement || !access.runtimeProxyAllowed || !entitlement.allowedServerTypes.includes(serverType)) {
+    throw billingUpgradeRequired();
+  }
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
 export function createCustomerVpsService(deps: CustomerVpsServiceDeps): CustomerVpsService {
   const machineIdFactory = deps.machineIdFactory ?? randomUUID;
   const tokenFactory = deps.tokenFactory ?? createRegistrationToken;
   const postgresPasswordFactory = deps.postgresPasswordFactory ?? (() => randomBytes(24).toString('base64url'));
   const now = deps.now ?? (() => new Date());
+
+  async function waitForServerStatus(
+    serverId: number,
+    expectedStatus: string,
+    context: string,
+  ): Promise<void> {
+    const deadline = Date.now() + RESIZE_STATUS_POLL_TIMEOUT_MS;
+    for (;;) {
+      let server: Awaited<ReturnType<typeof deps.hetzner.getServer>>;
+      try {
+        server = await deps.hetzner.getServer(serverId);
+      } catch (err: unknown) {
+        if (Date.now() >= deadline) {
+          throw new CustomerVpsError(500, 'provider_timeout', 'Provisioning provider unavailable');
+        }
+        logCustomerVpsError(`resize ${context} server read failed serverId=${serverId}`, err);
+        await sleep(RESIZE_STATUS_POLL_INTERVAL_MS);
+        continue;
+      }
+      if (!server) {
+        throw new CustomerVpsError(500, 'provider_unavailable', 'Provisioning provider unavailable');
+      }
+      if (server.status === expectedStatus) {
+        return;
+      }
+      if (Date.now() >= deadline) {
+        throw new CustomerVpsError(500, 'provider_timeout', 'Provisioning provider unavailable');
+      }
+      logCustomerVpsError(
+        `resize ${context} waiting for serverId=${serverId}`,
+        new Error(`expected ${expectedStatus}, got ${server.status}`),
+      );
+      await sleep(RESIZE_STATUS_POLL_INTERVAL_MS);
+    }
+  }
 
   async function queueProviderDeletion(input: {
     providerServerId: number;
@@ -712,6 +780,9 @@ export function createCustomerVpsService(deps: CustomerVpsServiceDeps): Customer
       if (active.status === 'recovering') {
         throw new CustomerVpsError(409, 'invalid_state', 'Recovery already in progress');
       }
+      if (active.status === 'resizing') {
+        throw new CustomerVpsError(409, 'invalid_state', 'Machine cannot recover');
+      }
       // This R2 check is an advisory fast-fail before the DB claim. The
       // claimUserMachineRecovery WHERE clause below remains the authoritative
       // concurrency guard; keeping the backup check before the claim avoids
@@ -844,6 +915,159 @@ export function createCustomerVpsService(deps: CustomerVpsServiceDeps): Customer
       };
     },
 
+    async resize(input) {
+      const row = await getUserMachine(deps.db, input.machineId);
+      if (!row || row.deletedAt) {
+        throw new CustomerVpsError(404, 'not_found', 'Machine not found');
+      }
+      if (row.status !== 'running' || row.hetznerServerId === null) {
+        throw new CustomerVpsError(409, 'invalid_state', 'Machine cannot resize');
+      }
+      if (row.serverType === input.serverType) {
+        return {
+          machineId: row.machineId,
+          serverType: input.serverType,
+          status: 'running',
+        };
+      }
+
+      await assertBillingResizeAllowed(deps, row.clerkUserId, input.serverType, now());
+      const claimed = await claimRunningUserMachineResize(
+        deps.db,
+        row.machineId,
+        row.hetznerServerId,
+        now().toISOString(),
+        input.serverType,
+      );
+      if (!claimed) {
+        throw new CustomerVpsError(409, 'invalid_state', 'Machine cannot resize');
+      }
+
+      let serverConfirmedOff = false;
+      let resizeAccepted = false;
+      let powerOffAccepted = false;
+      let powerOnAccepted = false;
+      try {
+        try {
+          await deps.hetzner.shutdownServer(claimed.hetznerServerId!);
+          await waitForServerStatus(claimed.hetznerServerId!, 'off', 'shutdown');
+        } catch (shutdownErr: unknown) {
+          logCustomerVpsError(`resize graceful shutdown failed machineId=${claimed.machineId}`, shutdownErr);
+          await deps.hetzner.powerOffServer(claimed.hetznerServerId!);
+          powerOffAccepted = true;
+          await waitForServerStatus(claimed.hetznerServerId!, 'off', 'poweroff');
+        }
+        serverConfirmedOff = true;
+        await deps.hetzner.resizeServer(claimed.hetznerServerId!, {
+          serverType: input.serverType,
+          upgradeDisk: false,
+        });
+        resizeAccepted = true;
+        await waitForServerStatus(claimed.hetznerServerId!, 'off', 'resize');
+        await deps.hetzner.powerOnServer(claimed.hetznerServerId!);
+        serverConfirmedOff = false;
+        powerOnAccepted = true;
+        await waitForServerStatus(claimed.hetznerServerId!, 'running', 'poweron');
+        const updated = await completeUserMachineResize(
+          deps.db,
+          claimed.machineId,
+          claimed.hetznerServerId!,
+          {
+            status: 'running',
+            serverType: input.serverType,
+            failureCode: null,
+            failureAt: null,
+            resizeStartedAt: null,
+            resizeTargetServerType: null,
+          },
+        );
+        if (!updated) {
+          logCustomerVpsError(
+            `resize completion lost machineId=${claimed.machineId} hetznerServerId=${claimed.hetznerServerId}`,
+            new Error('resizing row no longer matched guarded completion update'),
+          );
+          throw new CustomerVpsError(409, 'invalid_state', 'Machine cannot resize');
+        }
+        return {
+          machineId: updated.machineId,
+          serverType: updated.serverType ?? input.serverType,
+          status: 'running',
+        };
+      } catch (err: unknown) {
+        const mapped = genericProviderError(err);
+        if (powerOnAccepted) {
+          logCustomerVpsError(
+            `resize poweron pending machineId=${claimed.machineId}`,
+            new Error('poweron accepted but running status was not confirmed'),
+          );
+          throw mapped;
+        }
+        if (powerOffAccepted && !serverConfirmedOff) {
+          logCustomerVpsError(
+            `resize poweroff pending machineId=${claimed.machineId}`,
+            new Error('poweroff accepted but off status was not confirmed'),
+          );
+          throw mapped;
+        }
+        if (resizeAccepted && serverConfirmedOff) {
+          logCustomerVpsError(
+            `resize provider change pending machineId=${claimed.machineId}`,
+            new Error('resize accepted but settled off status was not confirmed'),
+          );
+          throw mapped;
+        }
+        let restoredRunning = !serverConfirmedOff;
+        if (serverConfirmedOff) {
+          let rollbackPowerOnAccepted = false;
+          try {
+            await deps.hetzner.powerOnServer(claimed.hetznerServerId!);
+            rollbackPowerOnAccepted = true;
+            await waitForServerStatus(claimed.hetznerServerId!, 'running', 'rollback-poweron');
+            restoredRunning = true;
+          } catch (powerOnErr: unknown) {
+            logCustomerVpsError(`resize rollback poweron failed machineId=${claimed.machineId}`, powerOnErr);
+            if (rollbackPowerOnAccepted) {
+              logCustomerVpsError(
+                `resize rollback poweron pending machineId=${claimed.machineId}`,
+                new Error('rollback poweron accepted but running status was not confirmed'),
+              );
+              throw mapped;
+            }
+          }
+        }
+
+        const restored = await completeUserMachineResize(
+          deps.db,
+          claimed.machineId,
+          claimed.hetznerServerId!,
+          restoredRunning
+            ? {
+                status: 'running',
+                serverType: resizeAccepted ? input.serverType : row.serverType,
+                failureCode: null,
+                failureAt: null,
+                resizeStartedAt: null,
+                resizeTargetServerType: null,
+              }
+            : {
+                status: 'failed',
+                serverType: resizeAccepted ? input.serverType : row.serverType,
+                failureCode: toFailureCode(err),
+                failureAt: now().toISOString(),
+                resizeStartedAt: null,
+                resizeTargetServerType: null,
+              },
+        );
+        if (!restored) {
+          logCustomerVpsError(
+            `resize rollback lost machineId=${claimed.machineId} hetznerServerId=${claimed.hetznerServerId}`,
+            new Error('resizing row no longer matched guarded rollback update'),
+          );
+        }
+        throw mapped;
+      }
+    },
+
     async status(machineId) {
       const row = await getUserMachine(deps.db, machineId);
       if (!row) {
@@ -855,6 +1079,10 @@ export function createCustomerVpsService(deps: CustomerVpsServiceDeps): Customer
     async delete(machineId) {
       const row = await claimUserMachineDelete(deps.db, machineId, now().toISOString());
       if (!row) {
+        const existing = await getUserMachine(deps.db, machineId);
+        if (existing && !existing.deletedAt) {
+          throw new CustomerVpsError(409, 'invalid_state', 'Machine cannot delete');
+        }
         throw new CustomerVpsError(404, 'not_found', 'Machine not found');
       }
       if (row.hetznerServerId) {
@@ -935,6 +1163,11 @@ export function createCustomerVpsService(deps: CustomerVpsServiceDeps): Customer
         staleBefore,
         deps.config.reconciliationBatchSize,
       );
+      const resizingRows = await listStaleResizingUserMachines(
+        deps.db,
+        staleBefore,
+        deps.config.reconciliationBatchSize,
+      );
       let failed = 0;
       let running = 0;
       for (const row of rows) {
@@ -997,9 +1230,108 @@ export function createCustomerVpsService(deps: CustomerVpsServiceDeps): Customer
           running += 1;
         }
       }
+      for (const row of resizingRows) {
+        if (!row.hetznerServerId) {
+          await updateUserMachine(deps.db, row.machineId, {
+            status: 'failed',
+            failureCode: 'provider_unavailable',
+            failureAt: now().toISOString(),
+            resizeStartedAt: null,
+            resizeTargetServerType: null,
+          });
+          failed += 1;
+          continue;
+        }
+        const server = await deps.hetzner.getServer(row.hetznerServerId);
+        if (!server) {
+          await updateUserMachine(deps.db, row.machineId, {
+            status: 'failed',
+            failureCode: 'not_found',
+            failureAt: now().toISOString(),
+            resizeStartedAt: null,
+            resizeTargetServerType: null,
+          });
+          failed += 1;
+          continue;
+        }
+        if (server.status === 'off') {
+          try {
+            await deps.hetzner.powerOnServer(row.hetznerServerId);
+            await waitForServerStatus(row.hetznerServerId, 'running', 'reconcile-resize-poweron');
+          } catch (err: unknown) {
+            logCustomerVpsError(`resize reconcile poweron failed machineId=${row.machineId}`, err);
+            continue;
+          }
+        } else if (server.status !== 'running') {
+          logCustomerVpsError(
+            `resize reconcile waiting machineId=${row.machineId}`,
+            new Error(`server status ${server.status}`),
+          );
+          continue;
+        }
+        let latestServer = server.status === 'running' ? server : null;
+        if (!latestServer) {
+          try {
+            latestServer = await deps.hetzner.getServer(row.hetznerServerId);
+          } catch (err: unknown) {
+            logCustomerVpsError(`resize reconcile server refresh failed machineId=${row.machineId}`, err);
+            continue;
+          }
+        }
+        if (!latestServer || latestServer.status !== 'running') {
+          continue;
+        }
+        const targetServerType = row.resizeTargetServerType;
+        if (targetServerType && !latestServer.serverType) {
+          logCustomerVpsError(
+            `resize reconcile missing server type machineId=${row.machineId}`,
+            new Error(`target ${targetServerType}`),
+          );
+          continue;
+        }
+        if (targetServerType && latestServer.serverType !== targetServerType) {
+          const completed = await completeUserMachineResize(
+            deps.db,
+            row.machineId,
+            row.hetznerServerId,
+            {
+              status: 'running',
+              serverType: latestServer.serverType,
+              publicIPv4: latestServer.publicIPv4 ?? row.publicIPv4,
+              publicIPv6: latestServer.publicIPv6 ?? row.publicIPv6,
+              failureCode: 'resize_interrupted',
+              failureAt: now().toISOString(),
+              resizeStartedAt: null,
+              resizeTargetServerType: null,
+            },
+          );
+          if (completed) {
+            failed += 1;
+          }
+          continue;
+        }
+        const completed = await completeUserMachineResize(
+          deps.db,
+          row.machineId,
+          row.hetznerServerId,
+          {
+            status: 'running',
+            serverType: latestServer.serverType ?? row.resizeTargetServerType ?? row.serverType,
+            publicIPv4: latestServer.publicIPv4 ?? row.publicIPv4,
+            publicIPv6: latestServer.publicIPv6 ?? row.publicIPv6,
+            failureCode: null,
+            failureAt: null,
+            resizeStartedAt: null,
+            resizeTargetServerType: null,
+          },
+        );
+        if (completed) {
+          running += 1;
+        }
+      }
       await retryProviderDeletions();
       await retryRunningMachineMetadata();
-      return { checked: rows.length, failed, running };
+      return { checked: rows.length + resizingRows.length, failed, running };
     },
   };
 }

--- a/packages/platform/src/db.ts
+++ b/packages/platform/src/db.ts
@@ -64,6 +64,8 @@ interface UserMachinesTable {
   deleted_at: string | null;
   failure_code: string | null;
   failure_at: string | null;
+  resize_started_at: string | null;
+  resize_target_server_type: string | null;
   attempt: number;
 }
 
@@ -387,6 +389,8 @@ export interface UserMachineRecord {
   deletedAt: string | null;
   failureCode: string | null;
   failureAt: string | null;
+  resizeStartedAt: string | null;
+  resizeTargetServerType: string | null;
   attempt: number;
 }
 
@@ -577,6 +581,8 @@ export interface NewUserMachine {
   deletedAt?: string | null;
   failureCode?: string | null;
   failureAt?: string | null;
+  resizeStartedAt?: string | null;
+  resizeTargetServerType?: string | null;
   attempt?: number;
 }
 
@@ -667,12 +673,16 @@ async function migrate(db: Kysely<PlatformDatabase>): Promise<void> {
       deleted_at TEXT,
       failure_code TEXT,
       failure_at TEXT,
+      resize_started_at TEXT,
+      resize_target_server_type TEXT,
       attempt INTEGER NOT NULL DEFAULT 1
     )
   `.execute(db);
   await sql`ALTER TABLE user_machines ADD COLUMN IF NOT EXISTS runtime_slot TEXT NOT NULL DEFAULT 'primary'`.execute(db);
   await sql`ALTER TABLE user_machines ADD COLUMN IF NOT EXISTS developer_tools TEXT NOT NULL DEFAULT '["codex","claude-code","opencode","pi"]'`.execute(db);
   await sql`ALTER TABLE user_machines ADD COLUMN IF NOT EXISTS server_type TEXT`.execute(db);
+  await sql`ALTER TABLE user_machines ADD COLUMN IF NOT EXISTS resize_started_at TEXT`.execute(db);
+  await sql`ALTER TABLE user_machines ADD COLUMN IF NOT EXISTS resize_target_server_type TEXT`.execute(db);
   await sql`ALTER TABLE user_machines ADD COLUMN IF NOT EXISTS attempt INTEGER NOT NULL DEFAULT 1`.execute(db);
   await sql`CREATE INDEX IF NOT EXISTS idx_user_machines_status ON user_machines(status)`.execute(db);
   await sql`ALTER TABLE user_machines DROP CONSTRAINT IF EXISTS user_machines_clerk_user_id_key`.execute(db);
@@ -1155,6 +1165,8 @@ function mapUserMachine(row: UserMachinesTable): UserMachineRecord {
     deletedAt: row.deleted_at,
     failureCode: row.failure_code,
     failureAt: row.failure_at,
+    resizeStartedAt: row.resize_started_at,
+    resizeTargetServerType: row.resize_target_server_type,
     attempt: row.attempt,
   };
 }
@@ -1179,6 +1191,8 @@ function toUserMachineRow(record: NewUserMachine): UserMachinesTable {
     deleted_at: record.deletedAt ?? null,
     failure_code: record.failureCode ?? null,
     failure_at: record.failureAt ?? null,
+    resize_started_at: record.resizeStartedAt ?? null,
+    resize_target_server_type: record.resizeTargetServerType ?? null,
     attempt: record.attempt ?? 1,
   };
 }
@@ -1203,6 +1217,8 @@ function toUserMachineUpdate(values: Partial<NewUserMachine>): Partial<UserMachi
   if (values.deletedAt !== undefined) update.deleted_at = values.deletedAt;
   if (values.failureCode !== undefined) update.failure_code = values.failureCode;
   if (values.failureAt !== undefined) update.failure_at = values.failureAt;
+  if (values.resizeStartedAt !== undefined) update.resize_started_at = values.resizeStartedAt;
+  if (values.resizeTargetServerType !== undefined) update.resize_target_server_type = values.resizeTargetServerType;
   if (values.attempt !== undefined) update.attempt = values.attempt;
   return update;
 }
@@ -1914,7 +1930,7 @@ export async function listActiveUserMachinesByClerkId(
     .selectAll()
     .where('clerk_user_id', '=', clerkUserId)
     .where('deleted_at', 'is', null)
-    .where('status', 'in', ['running', 'provisioning', 'recovering'])
+    .where('status', 'in', ['running', 'provisioning', 'recovering', 'resizing'])
     .orderBy(sql`CASE WHEN runtime_slot = 'primary' THEN 0 ELSE 1 END`)
     .orderBy('provisioned_at', 'desc')
     .execute();
@@ -1932,6 +1948,70 @@ export async function updateUserMachine(
     .set(toUserMachineUpdate(values))
     .where('machine_id', '=', machineId)
     .execute();
+}
+
+export async function claimRunningUserMachineResize(
+  db: PlatformDB,
+  machineId: string,
+  hetznerServerId: number,
+  resizeStartedAt: string,
+  resizeTargetServerType: string,
+): Promise<UserMachineRecord | undefined> {
+  await db.ready;
+  const row = await db.executor
+    .updateTable('user_machines')
+    .set({
+      status: 'resizing',
+      failure_code: null,
+      failure_at: null,
+      resize_started_at: resizeStartedAt,
+      resize_target_server_type: resizeTargetServerType,
+    })
+    .where('machine_id', '=', machineId)
+    .where('hetzner_server_id', '=', hetznerServerId)
+    .where('status', '=', 'running')
+    .where('deleted_at', 'is', null)
+    .returningAll()
+    .executeTakeFirst();
+  return row ? mapUserMachine(row) : undefined;
+}
+
+export async function completeUserMachineResize(
+  db: PlatformDB,
+  machineId: string,
+  hetznerServerId: number,
+  values: Partial<NewUserMachine>,
+): Promise<UserMachineRecord | undefined> {
+  await db.ready;
+  const row = await db.executor
+    .updateTable('user_machines')
+    .set(toUserMachineUpdate(values))
+    .where('machine_id', '=', machineId)
+    .where('hetzner_server_id', '=', hetznerServerId)
+    .where('status', '=', 'resizing')
+    .where('deleted_at', 'is', null)
+    .returningAll()
+    .executeTakeFirst();
+  return row ? mapUserMachine(row) : undefined;
+}
+
+export async function listStaleResizingUserMachines(
+  db: PlatformDB,
+  olderThanIso: string,
+  limit: number,
+): Promise<UserMachineRecord[]> {
+  await db.ready;
+  const rows = await db.executor
+    .selectFrom('user_machines')
+    .selectAll()
+    .where('status', '=', 'resizing')
+    .where('resize_started_at', 'is not', null)
+    .where('resize_started_at', '<', olderThanIso)
+    .where('deleted_at', 'is', null)
+    .orderBy('resize_started_at')
+    .limit(limit)
+    .execute();
+  return rows.map(mapUserMachine);
 }
 
 export async function completeUserMachineRegistration(
@@ -1977,6 +2057,7 @@ export async function claimUserMachineRecovery(
     .where('runtime_slot', '=', runtimeSlot)
     .where('deleted_at', 'is', null)
     .where('status', '!=', 'recovering')
+    .where('status', '!=', 'resizing')
     .returningAll()
     .executeTakeFirst();
   return row ? mapUserMachine(row) : undefined;
@@ -2016,6 +2097,7 @@ export async function claimUserMachineDelete(
     .set({ status: 'deleted', deleted_at: deletedAt })
     .where('machine_id', '=', machineId)
     .where('deleted_at', 'is', null)
+    .where('status', '!=', 'resizing')
     .returningAll()
     .executeTakeFirst();
   return row ? mapUserMachine(row) : undefined;

--- a/tests/platform/customer-vps-fixtures.ts
+++ b/tests/platform/customer-vps-fixtures.ts
@@ -6,12 +6,17 @@ export function createMockHetznerClient(overrides: Partial<HetznerClient> = {}):
   const defaultServer: HetznerServer = {
     id: 123456,
     status: 'running',
+    serverType: 'cpx22',
     publicIPv4: '203.0.113.10',
     publicIPv6: '2001:db8::/64',
   };
   return {
     createServer: vi.fn().mockResolvedValue(defaultServer),
     getServer: vi.fn().mockResolvedValue(defaultServer),
+    shutdownServer: vi.fn().mockResolvedValue(undefined),
+    powerOffServer: vi.fn().mockResolvedValue(undefined),
+    powerOnServer: vi.fn().mockResolvedValue(undefined),
+    resizeServer: vi.fn().mockResolvedValue(undefined),
     deleteServer: vi.fn().mockResolvedValue(undefined),
     listServersByLabel: vi.fn().mockResolvedValue([]),
     ...overrides,

--- a/tests/platform/customer-vps-hetzner.test.ts
+++ b/tests/platform/customer-vps-hetzner.test.ts
@@ -61,4 +61,63 @@ describe('platform/customer-vps-hetzner', () => {
       status: 429,
     });
   });
+
+  it('changes server type without upgrading disk so future downgrades remain possible', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(new Response('{"action":{"id":42}}', { status: 201 }));
+    const client = createHetznerClient(config, fetchImpl as unknown as typeof fetch);
+
+    await client.resizeServer(123456, { serverType: 'cpx32', upgradeDisk: false });
+
+    expect(fetchImpl).toHaveBeenCalledWith(
+      'https://api.hetzner.cloud/v1/servers/123456/actions/change_type',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({ server_type: 'cpx32', upgrade_disk: false }),
+      }),
+    );
+  });
+
+  it('shuts servers down and powers them off or on through Hetzner actions', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(new Response('{"action":{"id":42}}', { status: 201 }));
+    const client = createHetznerClient(config, fetchImpl as unknown as typeof fetch);
+
+    await client.shutdownServer(123456);
+    await client.powerOffServer(123456);
+    await client.powerOnServer(123456);
+
+    expect(fetchImpl).toHaveBeenNthCalledWith(
+      1,
+      'https://api.hetzner.cloud/v1/servers/123456/actions/shutdown',
+      expect.objectContaining({ method: 'POST' }),
+    );
+    expect(fetchImpl).toHaveBeenNthCalledWith(
+      2,
+      'https://api.hetzner.cloud/v1/servers/123456/actions/poweroff',
+      expect.objectContaining({ method: 'POST' }),
+    );
+    expect(fetchImpl).toHaveBeenNthCalledWith(
+      3,
+      'https://api.hetzner.cloud/v1/servers/123456/actions/poweron',
+      expect.objectContaining({ method: 'POST' }),
+    );
+  });
+
+  it('maps provider server type from server reads', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(new Response(JSON.stringify({
+      server: {
+        id: 123456,
+        status: 'running',
+        server_type: { name: 'cpx32' },
+        public_net: { ipv4: { ip: '203.0.113.10' } },
+      },
+    }), { status: 200 }));
+    const client = createHetznerClient(config, fetchImpl as unknown as typeof fetch);
+
+    await expect(client.getServer(123456)).resolves.toMatchObject({
+      id: 123456,
+      status: 'running',
+      serverType: 'cpx32',
+      publicIPv4: '203.0.113.10',
+    });
+  });
 });

--- a/tests/platform/customer-vps-routes.test.ts
+++ b/tests/platform/customer-vps-routes.test.ts
@@ -157,6 +157,57 @@ describe('platform/customer-vps-routes', () => {
     expect(service.recover).toHaveBeenCalledWith({ clerkUserId: 'user_123', runtimeSlot: 'staging', allowEmpty: true });
   });
 
+  it('protects and validates the machine resize route contract', async () => {
+    const service = {
+      resize: vi.fn().mockResolvedValue({
+        machineId: '9f05824c-8d0a-4d83-9cb4-b312d43ff112',
+        serverType: 'cpx32',
+        status: 'running',
+      }),
+    } as unknown as Parameters<typeof createCustomerVpsRoutes>[0]['service'];
+    const app = new Hono();
+    app.route('/vps', createCustomerVpsRoutes({ service, platformSecret }));
+
+    const unauthorized = await app.request('/vps/9f05824c-8d0a-4d83-9cb4-b312d43ff112/resize', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ serverType: 'cpx32' }),
+    });
+    expect(unauthorized.status).toBe(401);
+
+    const invalidBody = await app.request('/vps/9f05824c-8d0a-4d83-9cb4-b312d43ff112/resize', {
+      method: 'POST',
+      headers: { authorization: `Bearer ${platformSecret}`, 'content-type': 'application/json' },
+      body: JSON.stringify({ serverType: '../../cpx32' }),
+    });
+    expect(invalidBody.status).toBe(400);
+    expect(await invalidBody.json()).toEqual({ error: 'Invalid request' });
+
+    const invalidMachine = await app.request('/vps/not-a-uuid/resize', {
+      method: 'POST',
+      headers: { authorization: `Bearer ${platformSecret}`, 'content-type': 'application/json' },
+      body: JSON.stringify({ serverType: 'cpx32' }),
+    });
+    expect(invalidMachine.status).toBe(400);
+    expect(await invalidMachine.json()).toEqual({ error: 'Invalid request' });
+
+    const resized = await app.request('/vps/9f05824c-8d0a-4d83-9cb4-b312d43ff112/resize', {
+      method: 'POST',
+      headers: { authorization: `Bearer ${platformSecret}`, 'content-type': 'application/json' },
+      body: JSON.stringify({ serverType: 'cpx32' }),
+    });
+    expect(resized.status).toBe(200);
+    expect(await resized.json()).toEqual({
+      machineId: '9f05824c-8d0a-4d83-9cb4-b312d43ff112',
+      serverType: 'cpx32',
+      status: 'running',
+    });
+    expect(service.resize).toHaveBeenCalledWith({
+      machineId: '9f05824c-8d0a-4d83-9cb4-b312d43ff112',
+      serverType: 'cpx32',
+    });
+  });
+
   it('rejects invalid request bodies with generic validation errors', async () => {
     const app = createApp();
     const res = await app.request('/vps/provision', {
@@ -234,6 +285,21 @@ describe('platform/customer-vps-routes', () => {
         'content-length': '5001',
       },
       body: JSON.stringify({ clerkUserId: 'user_123', handle: 'alice', padding: 'x'.repeat(5000) }),
+    });
+
+    expect(res.status).toBe(413);
+  });
+
+  it('rejects resize bodies over 4096 bytes before parsing', async () => {
+    const app = createApp();
+    const res = await app.request('/vps/9f05824c-8d0a-4d83-9cb4-b312d43ff112/resize', {
+      method: 'POST',
+      headers: {
+        authorization: `Bearer ${platformSecret}`,
+        'content-type': 'application/json',
+        'content-length': '5001',
+      },
+      body: JSON.stringify({ serverType: 'cpx32', padding: 'x'.repeat(5000) }),
     });
 
     expect(res.status).toBe(413);

--- a/tests/platform/customer-vps.test.ts
+++ b/tests/platform/customer-vps.test.ts
@@ -3,6 +3,7 @@ import { readFileSync } from 'node:fs';
 import { createHmac } from 'node:crypto';
 import {
   claimUserMachineDelete,
+  claimRunningUserMachineResize,
   completeUserMachineRegistration,
   getActiveUserMachineByClerkId,
   getActiveUserMachineByHandle,
@@ -36,15 +37,13 @@ describe('platform/customer-vps', () => {
   });
 
   afterEach(async () => {
+    vi.useRealTimers();
     await destroyTestPlatformDb(db);
   });
 
-  function createService(overrides: Parameters<typeof createCustomerVpsService>[0] = {} as any) {
-    const hetzner = createMockHetznerClient(overrides.hetzner);
-    const systemStore = createMockCustomerVpsSystemStore(overrides.systemStore);
-    const service = createCustomerVpsService({
-      db,
-      config: loadCustomerVpsConfig({
+  function createTestConfig(overrides: Partial<ReturnType<typeof loadCustomerVpsConfig>> = {}) {
+    return {
+      ...loadCustomerVpsConfig({
         PLATFORM_PORT: '9000',
         PLATFORM_SECRET: 'platform-secret',
         HETZNER_API_TOKEN: 'token',
@@ -57,6 +56,16 @@ describe('platform/customer-vps', () => {
         POSTHOG_HOST: 'https://eu.i.posthog.com',
         NEXT_PUBLIC_POSTHOG_API_HOST: '/ingest',
       }),
+      ...overrides,
+    };
+  }
+
+  function createService(overrides: Parameters<typeof createCustomerVpsService>[0] = {} as any) {
+    const hetzner = createMockHetznerClient(overrides.hetzner);
+    const systemStore = createMockCustomerVpsSystemStore(overrides.systemStore);
+    const service = createCustomerVpsService({
+      db,
+      config: createTestConfig(),
       hetzner,
       systemStore,
       tokenFactory: () => ({
@@ -229,6 +238,414 @@ describe('platform/customer-vps', () => {
       publicMessage: 'Billing upgrade required',
     });
     expect(hetzner.createServer).not.toHaveBeenCalled();
+  });
+
+  it('resizes a running machine in place without deleting or recreating owner data', async () => {
+    const getServer = vi.fn()
+      .mockResolvedValueOnce({ id: 123456, status: 'off', serverType: 'cpx22', publicIPv4: '203.0.113.10' })
+      .mockResolvedValueOnce({ id: 123456, status: 'migrating', serverType: 'cpx22', publicIPv4: '203.0.113.10' })
+      .mockResolvedValueOnce({ id: 123456, status: 'off', serverType: 'cpx32', publicIPv4: '203.0.113.10' })
+      .mockResolvedValueOnce({ id: 123456, status: 'running', serverType: 'cpx32', publicIPv4: '203.0.113.10' });
+    const { service, hetzner } = createService({
+      hetzner: createMockHetznerClient({ getServer }),
+      resolveBillingEntitlement: vi.fn().mockResolvedValue(activeEntitlement({
+        allowedServerTypes: ['cpx22', 'cpx32'],
+        defaultServerType: 'cpx32',
+      })),
+    });
+    const provisioned = await service.provision({ clerkUserId: 'user_123', handle: 'alice', serverType: 'cpx22' });
+    await service.register('registration-token', {
+      machineId: provisioned.machineId,
+      hetznerServerId: 123456,
+      publicIPv4: '203.0.113.10',
+      imageVersion: 'matrix-os-host-2026.04.26-1',
+    });
+
+    await expect(service.resize({
+      machineId: provisioned.machineId,
+      serverType: 'cpx32',
+    })).resolves.toEqual({
+      machineId: provisioned.machineId,
+      serverType: 'cpx32',
+      status: 'running',
+    });
+
+    expect(hetzner.shutdownServer).toHaveBeenCalledWith(123456);
+    expect(hetzner.powerOffServer).not.toHaveBeenCalled();
+    expect(hetzner.resizeServer).toHaveBeenCalledWith(123456, { serverType: 'cpx32', upgradeDisk: false });
+    expect(hetzner.powerOnServer).toHaveBeenCalledWith(123456);
+    expect(vi.mocked(hetzner.shutdownServer).mock.invocationCallOrder[0]).toBeLessThan(
+      vi.mocked(hetzner.resizeServer).mock.invocationCallOrder[0],
+    );
+    expect(vi.mocked(hetzner.resizeServer).mock.invocationCallOrder[0]).toBeLessThan(
+      vi.mocked(hetzner.powerOnServer).mock.invocationCallOrder[0],
+    );
+    expect(getServer).toHaveBeenCalledTimes(4);
+    expect(getServer.mock.invocationCallOrder[2]).toBeLessThan(
+      vi.mocked(hetzner.powerOnServer).mock.invocationCallOrder[0],
+    );
+    expect(hetzner.createServer).toHaveBeenCalledTimes(1);
+    expect(hetzner.deleteServer).not.toHaveBeenCalled();
+    await expect(getUserMachine(db, provisioned.machineId)).resolves.toMatchObject({
+      machineId: provisioned.machineId,
+      hetznerServerId: 123456,
+      publicIPv4: '203.0.113.10',
+      status: 'running',
+      serverType: 'cpx32',
+      deletedAt: null,
+    });
+  });
+
+  it('falls back to hard poweroff when graceful resize shutdown is rejected', async () => {
+    const getServer = vi.fn()
+      .mockResolvedValueOnce({ id: 123456, status: 'off', serverType: 'cpx22', publicIPv4: '203.0.113.10' })
+      .mockResolvedValueOnce({ id: 123456, status: 'off', serverType: 'cpx32', publicIPv4: '203.0.113.10' })
+      .mockResolvedValueOnce({ id: 123456, status: 'running', serverType: 'cpx32', publicIPv4: '203.0.113.10' });
+    const shutdownServer = vi.fn().mockRejectedValue(new CustomerVpsError(
+      500,
+      'provider_unavailable',
+      'Provisioning provider unavailable',
+    ));
+    const { service, hetzner } = createService({
+      hetzner: createMockHetznerClient({ getServer, shutdownServer }),
+      resolveBillingEntitlement: vi.fn().mockResolvedValue(activeEntitlement({
+        allowedServerTypes: ['cpx22', 'cpx32'],
+        defaultServerType: 'cpx32',
+      })),
+    });
+    const provisioned = await service.provision({ clerkUserId: 'user_123', handle: 'alice', serverType: 'cpx22' });
+    await service.register('registration-token', {
+      machineId: provisioned.machineId,
+      hetznerServerId: 123456,
+      publicIPv4: '203.0.113.10',
+      imageVersion: 'matrix-os-host-2026.04.26-1',
+    });
+
+    await expect(service.resize({
+      machineId: provisioned.machineId,
+      serverType: 'cpx32',
+    })).resolves.toMatchObject({
+      machineId: provisioned.machineId,
+      serverType: 'cpx32',
+      status: 'running',
+    });
+
+    expect(hetzner.shutdownServer).toHaveBeenCalledWith(123456);
+    expect(hetzner.powerOffServer).toHaveBeenCalledWith(123456);
+    expect(vi.mocked(hetzner.shutdownServer).mock.invocationCallOrder[0]).toBeLessThan(
+      vi.mocked(hetzner.powerOffServer).mock.invocationCallOrder[0],
+    );
+    expect(vi.mocked(hetzner.powerOffServer).mock.invocationCallOrder[0]).toBeLessThan(
+      vi.mocked(hetzner.resizeServer).mock.invocationCallOrder[0],
+    );
+  });
+
+  it('keeps resize claimed when hard poweroff is accepted but off state is not confirmed', async () => {
+    vi.useFakeTimers();
+    const getServer = vi.fn().mockResolvedValue({
+      id: 123456,
+      status: 'stopping',
+      serverType: 'cpx22',
+      publicIPv4: '203.0.113.10',
+    });
+    const shutdownServer = vi.fn().mockRejectedValue(new CustomerVpsError(
+      500,
+      'provider_unavailable',
+      'Provisioning provider unavailable',
+    ));
+    const { service, hetzner } = createService({
+      hetzner: createMockHetznerClient({ getServer, shutdownServer }),
+      resolveBillingEntitlement: vi.fn().mockResolvedValue(activeEntitlement({
+        allowedServerTypes: ['cpx22', 'cpx32'],
+        defaultServerType: 'cpx32',
+      })),
+    });
+    const provisioned = await service.provision({ clerkUserId: 'user_123', handle: 'alice', serverType: 'cpx22' });
+    await service.register('registration-token', {
+      machineId: provisioned.machineId,
+      hetznerServerId: 123456,
+      publicIPv4: '203.0.113.10',
+      imageVersion: 'matrix-os-host-2026.04.26-1',
+    });
+
+    const resize = service.resize({ machineId: provisioned.machineId, serverType: 'cpx32' });
+    const resizeExpectation = expect(resize).rejects.toMatchObject({
+      code: 'provider_timeout',
+    });
+    await vi.advanceTimersByTimeAsync(91_000);
+
+    await resizeExpectation;
+    expect(hetzner.powerOffServer).toHaveBeenCalledTimes(1);
+    expect(hetzner.resizeServer).not.toHaveBeenCalled();
+    await expect(getUserMachine(db, provisioned.machineId)).resolves.toMatchObject({
+      status: 'resizing',
+      serverType: 'cpx22',
+      failureCode: null,
+      resizeTargetServerType: 'cpx32',
+    });
+  });
+
+  it('keeps resize claimed when provider change_type is accepted but does not settle', async () => {
+    vi.useFakeTimers();
+    const getServer = vi.fn()
+      .mockResolvedValueOnce({ id: 123456, status: 'off', serverType: 'cpx22', publicIPv4: '203.0.113.10' })
+      .mockResolvedValue({ id: 123456, status: 'migrating', serverType: 'cpx22', publicIPv4: '203.0.113.10' });
+    const { service, hetzner } = createService({
+      hetzner: createMockHetznerClient({ getServer }),
+      resolveBillingEntitlement: vi.fn().mockResolvedValue(activeEntitlement({
+        allowedServerTypes: ['cpx22', 'cpx32'],
+        defaultServerType: 'cpx32',
+      })),
+    });
+    const provisioned = await service.provision({ clerkUserId: 'user_123', handle: 'alice', serverType: 'cpx22' });
+    await service.register('registration-token', {
+      machineId: provisioned.machineId,
+      hetznerServerId: 123456,
+      publicIPv4: '203.0.113.10',
+      imageVersion: 'matrix-os-host-2026.04.26-1',
+    });
+
+    const resize = service.resize({ machineId: provisioned.machineId, serverType: 'cpx32' });
+    const resizeExpectation = expect(resize).rejects.toMatchObject({
+      code: 'provider_timeout',
+    });
+    await vi.advanceTimersByTimeAsync(91_000);
+
+    await resizeExpectation;
+    expect(hetzner.resizeServer).toHaveBeenCalledWith(123456, {
+      serverType: 'cpx32',
+      upgradeDisk: false,
+    });
+    expect(hetzner.powerOnServer).not.toHaveBeenCalled();
+    await expect(getUserMachine(db, provisioned.machineId)).resolves.toMatchObject({
+      status: 'resizing',
+      serverType: 'cpx22',
+      failureCode: null,
+      resizeTargetServerType: 'cpx32',
+    });
+  });
+
+  it('keeps waiting on graceful shutdown after a transient provider read failure', async () => {
+    vi.useFakeTimers();
+    const getServer = vi.fn()
+      .mockRejectedValueOnce(new CustomerVpsError(500, 'provider_unavailable', 'Provisioning provider unavailable'))
+      .mockResolvedValueOnce({ id: 123456, status: 'off', serverType: 'cpx22', publicIPv4: '203.0.113.10' })
+      .mockResolvedValueOnce({ id: 123456, status: 'off', serverType: 'cpx32', publicIPv4: '203.0.113.10' })
+      .mockResolvedValueOnce({ id: 123456, status: 'running', serverType: 'cpx32', publicIPv4: '203.0.113.10' });
+    const { service, hetzner } = createService({
+      hetzner: createMockHetznerClient({ getServer }),
+      resolveBillingEntitlement: vi.fn().mockResolvedValue(activeEntitlement({
+        allowedServerTypes: ['cpx22', 'cpx32'],
+        defaultServerType: 'cpx32',
+      })),
+    });
+    const provisioned = await service.provision({ clerkUserId: 'user_123', handle: 'alice', serverType: 'cpx22' });
+    await service.register('registration-token', {
+      machineId: provisioned.machineId,
+      hetznerServerId: 123456,
+      publicIPv4: '203.0.113.10',
+      imageVersion: 'matrix-os-host-2026.04.26-1',
+    });
+
+    const resize = service.resize({ machineId: provisioned.machineId, serverType: 'cpx32' });
+    await vi.advanceTimersByTimeAsync(1_000);
+
+    await expect(resize).resolves.toMatchObject({
+      machineId: provisioned.machineId,
+      serverType: 'cpx32',
+      status: 'running',
+    });
+    expect(hetzner.shutdownServer).toHaveBeenCalledWith(123456);
+    expect(hetzner.powerOffServer).not.toHaveBeenCalled();
+  });
+
+  it('does not issue duplicate poweron when the resize poweron wait times out', async () => {
+    vi.useFakeTimers();
+    const getServer = vi.fn()
+      .mockResolvedValueOnce({ id: 123456, status: 'off', serverType: 'cpx22', publicIPv4: '203.0.113.10' })
+      .mockResolvedValueOnce({ id: 123456, status: 'off', serverType: 'cpx32', publicIPv4: '203.0.113.10' })
+      .mockResolvedValue({ id: 123456, status: 'starting', serverType: 'cpx32', publicIPv4: '203.0.113.10' });
+    const { service, hetzner } = createService({
+      hetzner: createMockHetznerClient({ getServer }),
+      resolveBillingEntitlement: vi.fn().mockResolvedValue(activeEntitlement({
+        allowedServerTypes: ['cpx22', 'cpx32'],
+        defaultServerType: 'cpx32',
+      })),
+    });
+    const provisioned = await service.provision({ clerkUserId: 'user_123', handle: 'alice', serverType: 'cpx22' });
+    await service.register('registration-token', {
+      machineId: provisioned.machineId,
+      hetznerServerId: 123456,
+      publicIPv4: '203.0.113.10',
+      imageVersion: 'matrix-os-host-2026.04.26-1',
+    });
+
+    const resize = service.resize({ machineId: provisioned.machineId, serverType: 'cpx32' });
+    const resizeExpectation = expect(resize).rejects.toMatchObject({
+      code: 'provider_timeout',
+    });
+    await vi.advanceTimersByTimeAsync(91_000);
+
+    await resizeExpectation;
+    expect(hetzner.powerOnServer).toHaveBeenCalledTimes(1);
+    await expect(getUserMachine(db, provisioned.machineId)).resolves.toMatchObject({
+      status: 'resizing',
+      serverType: 'cpx22',
+      failureCode: null,
+      resizeTargetServerType: 'cpx32',
+    });
+  });
+
+  it('keeps resize claimed when rollback poweron is accepted but not confirmed', async () => {
+    vi.useFakeTimers();
+    const getServer = vi.fn()
+      .mockResolvedValueOnce({ id: 123456, status: 'off', serverType: 'cpx22', publicIPv4: '203.0.113.10' })
+      .mockResolvedValue({ id: 123456, status: 'starting', serverType: 'cpx22', publicIPv4: '203.0.113.10' });
+    const { service, hetzner } = createService({
+      hetzner: createMockHetznerClient({
+        getServer,
+        resizeServer: vi.fn().mockRejectedValue(new CustomerVpsError(
+          500,
+          'provider_unavailable',
+          'Provisioning provider unavailable',
+        )),
+      }),
+      resolveBillingEntitlement: vi.fn().mockResolvedValue(activeEntitlement({
+        allowedServerTypes: ['cpx22', 'cpx32'],
+        defaultServerType: 'cpx32',
+      })),
+    });
+    const provisioned = await service.provision({ clerkUserId: 'user_123', handle: 'alice', serverType: 'cpx22' });
+    await service.register('registration-token', {
+      machineId: provisioned.machineId,
+      hetznerServerId: 123456,
+      publicIPv4: '203.0.113.10',
+      imageVersion: 'matrix-os-host-2026.04.26-1',
+    });
+
+    const resize = service.resize({ machineId: provisioned.machineId, serverType: 'cpx32' });
+    const resizeExpectation = expect(resize).rejects.toMatchObject({
+      code: 'provider_unavailable',
+    });
+    await vi.advanceTimersByTimeAsync(91_000);
+
+    await resizeExpectation;
+    expect(hetzner.powerOnServer).toHaveBeenCalledTimes(1);
+    await expect(getUserMachine(db, provisioned.machineId)).resolves.toMatchObject({
+      status: 'resizing',
+      serverType: 'cpx22',
+      failureCode: null,
+      resizeTargetServerType: 'cpx32',
+    });
+  });
+
+  it('returns running without provider work when the machine is already on the requested type', async () => {
+    const { service, hetzner } = createService({
+      resolveBillingEntitlement: vi.fn().mockResolvedValue(activeEntitlement()),
+    });
+    const provisioned = await service.provision({ clerkUserId: 'user_123', handle: 'alice', serverType: 'cpx32' });
+    await service.register('registration-token', {
+      machineId: provisioned.machineId,
+      hetznerServerId: 123456,
+      publicIPv4: '203.0.113.10',
+      imageVersion: 'matrix-os-host-2026.04.26-1',
+    });
+
+    await expect(service.resize({
+      machineId: provisioned.machineId,
+      serverType: 'cpx32',
+    })).resolves.toEqual({
+      machineId: provisioned.machineId,
+      serverType: 'cpx32',
+      status: 'running',
+    });
+
+    expect(hetzner.shutdownServer).not.toHaveBeenCalled();
+    expect(hetzner.powerOffServer).not.toHaveBeenCalled();
+    expect(hetzner.resizeServer).not.toHaveBeenCalled();
+    expect(hetzner.powerOnServer).not.toHaveBeenCalled();
+  });
+
+  it('rejects a second resize while the first resize has claimed the machine', async () => {
+    let markResizeStarted!: () => void;
+    let releaseResize!: () => void;
+    const resizeStarted = new Promise<void>((resolve) => {
+      markResizeStarted = resolve;
+    });
+    const getServer = vi.fn()
+      .mockResolvedValueOnce({ id: 123456, status: 'off', publicIPv4: '203.0.113.10' })
+      .mockResolvedValueOnce({ id: 123456, status: 'off', publicIPv4: '203.0.113.10' })
+      .mockResolvedValueOnce({ id: 123456, status: 'running', publicIPv4: '203.0.113.10' });
+    const resizeServer = vi.fn().mockImplementation(async () => {
+      markResizeStarted();
+      await new Promise<void>((resolve) => {
+        releaseResize = resolve;
+      });
+    });
+    const { service, hetzner } = createService({
+      hetzner: createMockHetznerClient({ getServer, resizeServer }),
+      resolveBillingEntitlement: vi.fn().mockResolvedValue(activeEntitlement({
+        allowedServerTypes: ['cpx22', 'cpx32', 'cpx52'],
+        defaultServerType: 'cpx32',
+      })),
+    });
+    const provisioned = await service.provision({ clerkUserId: 'user_123', handle: 'alice', serverType: 'cpx22' });
+    await service.register('registration-token', {
+      machineId: provisioned.machineId,
+      hetznerServerId: 123456,
+      publicIPv4: '203.0.113.10',
+      imageVersion: 'matrix-os-host-2026.04.26-1',
+    });
+
+    const firstResize = service.resize({ machineId: provisioned.machineId, serverType: 'cpx32' });
+    await resizeStarted;
+    await expect(service.resize({ machineId: provisioned.machineId, serverType: 'cpx52' })).rejects.toMatchObject({
+      status: 409,
+      publicMessage: 'Machine cannot resize',
+    });
+    await expect(service.delete(provisioned.machineId)).rejects.toMatchObject({
+      status: 409,
+      publicMessage: 'Machine cannot delete',
+    });
+    await expect(service.recover({ clerkUserId: 'user_123', allowEmpty: true })).rejects.toMatchObject({
+      status: 409,
+      publicMessage: 'Machine cannot recover',
+    });
+    expect(hetzner.resizeServer).toHaveBeenCalledTimes(1);
+
+    releaseResize();
+    await firstResize;
+  });
+
+  it('rejects machine resize requests outside the active entitlement without provider mutation', async () => {
+    const { service, hetzner } = createService({
+      resolveBillingEntitlement: vi.fn().mockResolvedValue(activeEntitlement({
+        allowedServerTypes: ['cpx22'],
+        defaultServerType: 'cpx22',
+      })),
+    });
+    const provisioned = await service.provision({ clerkUserId: 'user_123', handle: 'alice', serverType: 'cpx22' });
+    await service.register('registration-token', {
+      machineId: provisioned.machineId,
+      hetznerServerId: 123456,
+      publicIPv4: '203.0.113.10',
+      imageVersion: 'matrix-os-host-2026.04.26-1',
+    });
+
+    await expect(service.resize({
+      machineId: provisioned.machineId,
+      serverType: 'cpx52',
+    })).rejects.toMatchObject({
+      status: 402,
+      publicMessage: 'Billing upgrade required',
+    });
+
+    expect(hetzner.resizeServer).not.toHaveBeenCalled();
+    await expect(getUserMachine(db, provisioned.machineId)).resolves.toMatchObject({
+      serverType: 'cpx22',
+      status: 'running',
+      deletedAt: null,
+    });
   });
 
   it('pins channel image versions to the current immutable host bundle release at provision time', async () => {
@@ -1086,6 +1503,279 @@ describe('platform/customer-vps', () => {
 
     expect(deleteServer).toHaveBeenCalledTimes(2);
     expect(await listPendingProviderDeletions(db, '2026-04-26T12:00:00.000Z', 10)).toHaveLength(0);
+  });
+
+  it('reconciles stale resizing machines even when other stale rows fill the batch', async () => {
+    const serverReads = new Map<number, number>();
+    const getServer = vi.fn(async (serverId: number) => {
+      if (serverId !== 222222) return null;
+      const readCount = serverReads.get(serverId) ?? 0;
+      serverReads.set(serverId, readCount + 1);
+      return readCount === 0
+        ? { id: serverId, status: 'off', serverType: 'cpx32', publicIPv4: '203.0.113.20' }
+        : { id: serverId, status: 'running', serverType: 'cpx32', publicIPv4: '203.0.113.20' };
+    });
+    const machineIds = [
+      '9f05824c-8d0a-4d83-9cb4-b312d43ff112',
+      'bd30b7f2-68bb-4aa7-9c15-8be106a83f9f',
+    ];
+    const { service, hetzner } = createService({
+      config: createTestConfig({ reconciliationBatchSize: 1 }),
+      hetzner: createMockHetznerClient({ getServer }),
+      machineIdFactory: () => machineIds.shift()!,
+      resolveBillingEntitlement: vi.fn().mockResolvedValue(activeEntitlement({
+        maxRuntimeSlots: 2,
+        includedRuntimeSlots: 2,
+        allowedServerTypes: ['cpx22', 'cpx32'],
+        defaultServerType: 'cpx32',
+      })),
+    });
+    const staleProvisioning = await service.provision({
+      clerkUserId: 'user_123',
+      handle: 'alice',
+      runtimeSlot: 'primary',
+      serverType: 'cpx22',
+    });
+    const resizing = await service.provision({
+      clerkUserId: 'user_123',
+      handle: 'alice-staging',
+      runtimeSlot: 'staging',
+      serverType: 'cpx22',
+    });
+    await updateUserMachine(db, staleProvisioning.machineId, {
+      hetznerServerId: null,
+      provisionedAt: '2026-04-26T10:00:00.000Z',
+    });
+    await updateUserMachine(db, resizing.machineId, {
+      status: 'running',
+      hetznerServerId: 222222,
+      publicIPv4: '203.0.113.20',
+      serverType: 'cpx22',
+    });
+    const claimed = await claimRunningUserMachineResize(
+      db,
+      resizing.machineId,
+      222222,
+      '2026-04-26T10:00:00.000Z',
+      'cpx32',
+    );
+    expect(claimed?.status).toBe('resizing');
+
+    const result = await service.reconcileProvisioning();
+
+    expect(result).toMatchObject({ checked: 2, failed: 1, running: 1 });
+    expect(hetzner.powerOnServer).toHaveBeenCalledWith(222222);
+    await expect(getUserMachine(db, resizing.machineId)).resolves.toMatchObject({
+      status: 'running',
+      serverType: 'cpx32',
+      resizeStartedAt: null,
+      resizeTargetServerType: null,
+    });
+  });
+
+  it('reconciles stale resizing machines back to running from provider state', async () => {
+    const getServer = vi.fn()
+      .mockResolvedValueOnce({
+        id: 123456,
+        status: 'off',
+        serverType: 'cpx32',
+        publicIPv4: '203.0.113.10',
+      })
+      .mockResolvedValueOnce({
+        id: 123456,
+        status: 'running',
+        serverType: 'cpx32',
+        publicIPv4: '203.0.113.10',
+        publicIPv6: '2001:db8::/64',
+      })
+      .mockResolvedValueOnce({
+        id: 123456,
+        status: 'running',
+        serverType: 'cpx32',
+        publicIPv4: '203.0.113.10',
+        publicIPv6: '2001:db8::/64',
+      });
+    const { service, hetzner } = createService({
+      hetzner: createMockHetznerClient({ getServer }),
+    });
+    const provisioned = await service.provision({ clerkUserId: 'user_123', handle: 'alice', serverType: 'cpx22' });
+    await service.register('registration-token', {
+      machineId: provisioned.machineId,
+      hetznerServerId: 123456,
+      publicIPv4: '203.0.113.10',
+      imageVersion: 'matrix-os-host-2026.04.26-1',
+    });
+    const claimed = await claimRunningUserMachineResize(
+      db,
+      provisioned.machineId,
+      123456,
+      '2026-04-26T10:00:00.000Z',
+      'cpx32',
+    );
+    expect(claimed?.status).toBe('resizing');
+
+    const result = await service.reconcileProvisioning();
+
+    expect(result).toMatchObject({ checked: 1, failed: 0, running: 1 });
+    expect(hetzner.powerOnServer).toHaveBeenCalledWith(123456);
+    await expect(getUserMachine(db, provisioned.machineId)).resolves.toMatchObject({
+      status: 'running',
+      serverType: 'cpx32',
+      resizeStartedAt: null,
+      resizeTargetServerType: null,
+      publicIPv4: '203.0.113.10',
+      publicIPv6: '2001:db8::/64',
+    });
+  });
+
+  it('continues stale resize reconciliation when a provider refresh fails after poweron', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const serverReads = new Map<number, number>();
+    const getServer = vi.fn(async (serverId: number) => {
+      const readCount = serverReads.get(serverId) ?? 0;
+      serverReads.set(serverId, readCount + 1);
+      if (serverId === 123456) {
+        if (readCount === 0) {
+          return {
+            id: serverId,
+            status: 'off',
+            serverType: 'cpx32',
+            publicIPv4: '203.0.113.10',
+          };
+        }
+        if (readCount === 1) {
+          return {
+            id: serverId,
+            status: 'running',
+            serverType: 'cpx32',
+            publicIPv4: '203.0.113.10',
+          };
+        }
+        throw new Error('transient provider refresh failure');
+      }
+      return {
+        id: serverId,
+        status: 'running',
+        serverType: 'cpx32',
+        publicIPv4: '203.0.113.20',
+      };
+    });
+    const machineIds = [
+      '9f05824c-8d0a-4d83-9cb4-b312d43ff112',
+      'bd30b7f2-68bb-4aa7-9c15-8be106a83f9f',
+    ];
+    const { service } = createService({
+      hetzner: createMockHetznerClient({ getServer }),
+      machineIdFactory: () => machineIds.shift()!,
+      resolveBillingEntitlement: vi.fn().mockResolvedValue(activeEntitlement({
+        maxRuntimeSlots: 2,
+        includedRuntimeSlots: 2,
+        allowedServerTypes: ['cpx22', 'cpx32'],
+        defaultServerType: 'cpx32',
+      })),
+    });
+    const first = await service.provision({
+      clerkUserId: 'user_123',
+      handle: 'alice',
+      runtimeSlot: 'primary',
+      serverType: 'cpx22',
+    });
+    const second = await service.provision({
+      clerkUserId: 'user_123',
+      handle: 'alice-staging',
+      runtimeSlot: 'staging',
+      serverType: 'cpx22',
+    });
+    await updateUserMachine(db, first.machineId, {
+      status: 'running',
+      hetznerServerId: 123456,
+      publicIPv4: '203.0.113.10',
+      serverType: 'cpx22',
+    });
+    await updateUserMachine(db, second.machineId, {
+      status: 'running',
+      hetznerServerId: 222222,
+      publicIPv4: '203.0.113.20',
+      serverType: 'cpx22',
+    });
+    await claimRunningUserMachineResize(db, first.machineId, 123456, '2026-04-26T10:00:00.000Z', 'cpx32');
+    await claimRunningUserMachineResize(db, second.machineId, 222222, '2026-04-26T10:00:00.000Z', 'cpx32');
+
+    const result = await service.reconcileProvisioning();
+
+    expect(result).toMatchObject({ checked: 2, failed: 0, running: 1 });
+    await expect(getUserMachine(db, first.machineId)).resolves.toMatchObject({
+      status: 'resizing',
+      serverType: 'cpx22',
+      resizeTargetServerType: 'cpx32',
+    });
+    await expect(getUserMachine(db, second.machineId)).resolves.toMatchObject({
+      status: 'running',
+      serverType: 'cpx32',
+      resizeStartedAt: null,
+      resizeTargetServerType: null,
+    });
+    expect(errorSpy).toHaveBeenCalledWith(
+      '[customer-vps] resize reconcile server refresh failed machineId=9f05824c-8d0a-4d83-9cb4-b312d43ff112: transient provider refresh failure',
+    );
+    errorSpy.mockRestore();
+  });
+
+  it('surfaces stale resizing machines that never reached the target server type', async () => {
+    const getServer = vi.fn()
+      .mockResolvedValueOnce({
+        id: 123456,
+        status: 'off',
+        serverType: 'cpx22',
+        publicIPv4: '203.0.113.10',
+      })
+      .mockResolvedValueOnce({
+        id: 123456,
+        status: 'running',
+        serverType: 'cpx22',
+        publicIPv4: '203.0.113.10',
+        publicIPv6: '2001:db8::/64',
+      })
+      .mockResolvedValueOnce({
+        id: 123456,
+        status: 'running',
+        serverType: 'cpx22',
+        publicIPv4: '203.0.113.10',
+        publicIPv6: '2001:db8::/64',
+      });
+    const { service, hetzner } = createService({
+      hetzner: createMockHetznerClient({ getServer }),
+    });
+    const provisioned = await service.provision({ clerkUserId: 'user_123', handle: 'alice', serverType: 'cpx22' });
+    await service.register('registration-token', {
+      machineId: provisioned.machineId,
+      hetznerServerId: 123456,
+      publicIPv4: '203.0.113.10',
+      imageVersion: 'matrix-os-host-2026.04.26-1',
+    });
+    const claimed = await claimRunningUserMachineResize(
+      db,
+      provisioned.machineId,
+      123456,
+      '2026-04-26T10:00:00.000Z',
+      'cpx32',
+    );
+    expect(claimed?.status).toBe('resizing');
+
+    const result = await service.reconcileProvisioning();
+
+    expect(result).toMatchObject({ checked: 1, failed: 1, running: 0 });
+    expect(hetzner.powerOnServer).toHaveBeenCalledWith(123456);
+    await expect(getUserMachine(db, provisioned.machineId)).resolves.toMatchObject({
+      status: 'running',
+      serverType: 'cpx22',
+      failureCode: 'resize_interrupted',
+      failureAt: '2026-04-26T12:00:00.000Z',
+      resizeStartedAt: null,
+      resizeTargetServerType: null,
+      publicIPv4: '203.0.113.10',
+      publicIPv6: '2001:db8::/64',
+    });
   });
 
   it('cleans up stale provider servers labeled for a machine that never recorded a Hetzner ID', async () => {

--- a/www/content/docs/developer/deployment/billing.mdx
+++ b/www/content/docs/developer/deployment/billing.mdx
@@ -23,6 +23,8 @@ Stripe subscription webhooks project into Matrix billing entitlements. The platf
 
 Internal engineers can receive a production or staging override entitlement for testing plan changes without paying. Overrides are audit records with an expiry or revocation path; they must not delete, downgrade, or recreate a user's existing machines.
 
+Machine resize uses the same entitlement allowlist as provisioning. A running VPS may move only to a server type currently allowed by the effective entitlement. The resize path changes the Hetzner server type in place with disk growth disabled, so billing downgrades can move CPU/RAM down without replacing the machine or deleting owner data.
+
 ## Add-ons
 
 Extra machines, storage, and future Hetzner-backed capacity should be modeled as separate Stripe Prices. Matrix maps those prices to entitlement fields such as additional runtime slots or allowed machine capacity. Do not hardcode Hetzner prices into Stripe plan names; keep provider cost data in the Matrix runtime catalog so Hetzner price changes can be updated without renaming public plans.

--- a/www/content/docs/developer/deployment/vps-per-user.mdx
+++ b/www/content/docs/developer/deployment/vps-per-user.mdx
@@ -19,6 +19,7 @@ Included:
 - Shared `code.matrix-os.com` routing to the authenticated user's VPS-hosted code-server gateway.
 - Customer host restore gate, hourly Postgres backups, and R2 metadata pointers.
 - Manual recovery through `POST /vps/recover` or `matrixctl recover`.
+- In-place machine capacity changes through `POST /vps/:machineId/resize`.
 - Host-bundle based updates for shell, gateway, code, default apps, and runtime CLIs.
 - Local owner-controlled Postgres on each customer VPS at `127.0.0.1:5432`.
 
@@ -175,6 +176,29 @@ Not restored in this slice:
 - A failed backup that did not update `system/db/latest`.
 
 If restore fails, `matrix-restore.service` exits non-zero and `matrix-gateway.service` remains gated by `ConditionPathExists=/opt/matrix/restore-complete`.
+
+## Machine Resize
+
+Use resize when a running customer VPS needs more or less CPU/RAM without replacing the machine or restoring from backup.
+
+```bash
+curl -sS -X POST "$PLATFORM_PUBLIC_URL/vps/$MACHINE_ID/resize" \
+  -H "Authorization: Bearer $PLATFORM_SECRET" \
+  -H "Content-Type: application/json" \
+  -d '{"serverType":"cpx32"}'
+```
+
+Expected behavior:
+
+- The endpoint is platform-internal only and requires the same platform bearer token as provision, status, recovery, delete, deploy, and fleet routes.
+- The route validates the UUID path parameter and the `serverType` body with Zod before touching the service.
+- The service only resizes `running`, undeleted machines that still have a Hetzner server ID.
+- The target server type must be allowed by the user's active billing entitlement when billing enforcement is configured.
+- The platform marks the machine `resizing`, powers the server off, calls Hetzner's in-place server-type action with disk upgrade disabled, powers the server back on, then marks it `running` with the accepted target type.
+- The platform does not create, delete, recover, or reprovision the machine. Owner data under `/home/matrix/home` and the customer-local Postgres volume stay on the same VPS.
+- Provider failures return a generic provisioning error to the caller while server-side logs retain provider details.
+
+Do not use recovery for ordinary capacity changes. Recovery intentionally replaces the server and restores from the latest backup; resize keeps the current machine and data volume in place.
 
 ## Rollback
 


### PR DESCRIPTION
## Summary

- add a platform-internal `POST /vps/:machineId/resize` endpoint for in-place VPS server-type changes
- claim a running machine into a guarded `resizing` state before provider mutation, block concurrent resize/delete/recover, and complete back to `running` only after the VM is back online
- gracefully shut down the Hetzner server, tolerate transient status-read blips until the bounded poll deadline, fall back to hard `poweroff` only if graceful shutdown cannot complete, call `change_type` with `upgrade_disk: false`, wait for the async resize action to settle back to `off`, then power the server on
- reconcile stale `resizing` rows from provider state, including interrupted pre-`change_type` cases where the old server type is powered back on and marked with `resize_interrupted`
- enforce active billing entitlement allowlists before provider mutation and document the public-safe support/operator boundary in `AGENTS.md` and `docs/agents/customer-support.md`

## Validation

- `bun run test tests/platform/customer-vps.test.ts tests/platform/customer-vps-routes.test.ts tests/platform/customer-vps-hetzner.test.ts` - 79 passed
- `bun run typecheck`
- `bun run check:patterns` - 0 violations, existing broad warning buckets only
- `git diff --check`

## Review/Monitoring

- Addressed first Greptile/Codex feedback by adding explicit stop/power-on orchestration, a transient `resizing` DB state, guarded completion/rollback updates, same-type no-op `running` response, and concurrent mutation tests.
- Addressed second Greptile/Codex feedback by waiting for Hetzner `change_type` completion before `powerOnServer`, adding provider server-type reads, and adding stale `resizing` reconciliation coverage.
- Addressed current-head Codex feedback by using Hetzner graceful `shutdown` before resize and reserving hard `poweroff` for a bounded fallback path.
- Addressed latest Greptile/Codex feedback by clearing the offline rollback flag immediately after accepted `powerOnServer`, retrying transient status-read failures until the poll deadline, surfacing stale pre-`change_type` rows as `resize_interrupted`, returning retryable `409` for delete races, isolating transient resize reconciliation refresh failures per row, and keeping a resize claim for reconciliation if rollback power-on is accepted but not confirmed.
- Waiting for checks and Greptile review on head `7595d3911bbb80983df97a408cfb6ecd5cead8e2`.

## Mandatory Invariants

- Source of truth: platform Postgres `user_machines.server_type` records the target server type after provider resize completion; stale resize reconciliation can restore it from Hetzner `server_type.name` when recovering an interrupted flow.
- Lock/transaction scope: resize uses guarded DB writes keyed by `machine_id`, `hetzner_server_id`, `status`, and `deleted_at IS NULL`: `running -> resizing` before provider mutation, then `resizing -> running` or `resizing -> failed` after completion/rollback.
- Acceptable orphan states: if provider work succeeds but DB completion is interrupted, owner data remains attached to the same server and `reconcileProvisioning()` can power on an off server and complete the `resizing -> running` transition from provider state; if the server is still on the old type, reconciliation powers it back on, records `resize_interrupted`, and clears resize metadata; if rollback power-on was accepted but running was not confirmed, the row stays `resizing` so reconciliation can finish from provider state; if the server is missing, the row is marked failed with a generic failure code.
- Auth source of truth: the route uses the existing platform bearer token gate, validates the UUID path parameter and Zod body schema, and never trusts client-supplied identity.
- Deferred scope: customer-facing plan-change UI, background worker orchestration, richer Hetzner action-ID polling, automatic local-disk shrink migrations, and broader provider-state reconciliation jobs are outside this PR.
