### PR TITLE
fix(vps): self-heal code editor service startup

### DIFF
--- a/distro/customer-vps/cloud-init.yaml
+++ b/distro/customer-vps/cloud-init.yaml
@@ -127,7 +127,6 @@ write_files:
       Requires=matrix-restore.service
       ConditionPathExists=/opt/matrix/restore-complete
       ConditionPathExists=/opt/matrix/bin/matrix-code
-      ConditionPathExists=/opt/matrix/runtime/code-server/bin/code-server
 
       [Service]
       User=matrix
@@ -137,6 +136,7 @@ write_files:
       ExecStart=/opt/matrix/bin/matrix-code
       Restart=on-failure
       RestartSec=5
+      TimeoutStartSec=1800
 
       [Install]
       WantedBy=multi-user.target
@@ -585,6 +585,7 @@ runcmd:
     systemctl enable matrix-restore.service matrix-gateway.service matrix-shell.service matrix-code-server.service matrix-code.service matrix-sync-agent.service matrix-symphony.service matrix-hermes.service matrix-hermes-dashboard.service matrix-linux-tools.service matrix-developer-tools.service matrix-db-backup.timer nginx
     systemctl start matrix-restore.service matrix-gateway.service matrix-shell.service matrix-sync-agent.service matrix-symphony.service
     systemctl start --no-block matrix-code-server.service || echo "matrix-host: code-server runtime install will retry via systemd" >&2
+    systemctl start --no-block matrix-code.service || echo "matrix-host: code editor will retry via systemd" >&2
     systemctl start --no-block matrix-hermes.service || echo "matrix-host: optional Hermes install will retry via systemd" >&2
     systemctl start --no-block matrix-hermes-dashboard.service || echo "matrix-host: optional Hermes dashboard will retry via systemd" >&2
     systemctl start --no-block matrix-linux-tools.service || echo "matrix-host: optional Linux tools install will retry via systemd" >&2

--- a/distro/customer-vps/host-bin/matrix-code
+++ b/distro/customer-vps/host-bin/matrix-code
@@ -21,6 +21,26 @@ fi
 CODE_SERVER_ROOT="$MATRIX_HOME/system/code-server"
 
 if ! command -v code-server >/dev/null 2>&1; then
+  if [ -x /opt/matrix/bin/matrix-install-tool-pack ]; then
+    echo "matrix-code: code-server is missing; attempting install" >&2
+    install_status=0
+    sudo -n /opt/matrix/bin/matrix-install-tool-pack code-server || install_status=$?
+    if [ "$install_status" = "75" ]; then
+      echo "matrix-code: code-server install already running; waiting" >&2
+      for _ in $(seq 1 180); do
+        if command -v code-server >/dev/null 2>&1; then
+          break
+        fi
+        sleep 5
+      done
+    elif [ "$install_status" != "0" ]; then
+      echo "matrix-code: code-server install failed" >&2
+      exit 1
+    fi
+  fi
+fi
+
+if ! command -v code-server >/dev/null 2>&1; then
   echo "matrix-code: code-server is not installed" >&2
   exit 1
 fi

--- a/distro/customer-vps/host-bin/matrix-sync-agent
+++ b/distro/customer-vps/host-bin/matrix-sync-agent
@@ -303,6 +303,11 @@ apply_update() {
       sudo systemctl start --no-block matrix-code-server.service || true
       log "Code-server runtime service enabled"
     fi
+    if [ -f "$extract_dir/systemd/matrix-code.service" ]; then
+      sudo systemctl enable matrix-code.service
+      sudo systemctl start --no-block matrix-code.service || true
+      log "Code editor service enabled"
+    fi
     if [ -f "$extract_dir/systemd/matrix-symphony.service" ]; then
       sudo systemctl enable matrix-symphony.service
       sudo systemctl start --no-block matrix-symphony.service || true

--- a/distro/customer-vps/systemd/matrix-code.service
+++ b/distro/customer-vps/systemd/matrix-code.service
@@ -1,0 +1,20 @@
+[Unit]
+Description=Matrix OS customer code editor
+After=matrix-restore.service matrix-code-server.service
+Wants=matrix-code-server.service
+Requires=matrix-restore.service
+ConditionPathExists=/opt/matrix/restore-complete
+ConditionPathExists=/opt/matrix/bin/matrix-code
+
+[Service]
+User=matrix
+Group=matrix
+EnvironmentFile=/opt/matrix/env/host.env
+WorkingDirectory=/opt/matrix
+ExecStart=/opt/matrix/bin/matrix-code
+Restart=on-failure
+RestartSec=5
+TimeoutStartSec=1800
+
+[Install]
+WantedBy=multi-user.target

--- a/tests/deploy/customer-vps/symphony-systemd.test.ts
+++ b/tests/deploy/customer-vps/symphony-systemd.test.ts
@@ -56,6 +56,7 @@ describe("customer VPS Symphony systemd unit", () => {
     expect(cloudInit).toContain("systemctl enable matrix-restore.service matrix-gateway.service matrix-shell.service matrix-code-server.service matrix-code.service matrix-sync-agent.service matrix-symphony.service");
     expect(cloudInit).toContain("systemctl start matrix-restore.service matrix-gateway.service matrix-shell.service matrix-sync-agent.service matrix-symphony.service");
     expect(cloudInit).toContain("systemctl start --no-block matrix-code-server.service");
+    expect(cloudInit).toContain("systemctl start --no-block matrix-code.service");
   });
 
   it("packages the adapted Elixir Symphony source and license in the host bundle app tree", async () => {

--- a/tests/platform/customer-vps-cloud-init.test.ts
+++ b/tests/platform/customer-vps-cloud-init.test.ts
@@ -274,6 +274,7 @@ exit 99
       'systemctl start matrix-restore.service matrix-gateway.service matrix-shell.service matrix-code.service matrix-sync-agent.service matrix-symphony.service',
     );
     expect(cloudInit).toContain('systemctl start --no-block matrix-code-server.service || echo "matrix-host: code-server runtime install will retry via systemd" >&2');
+    expect(cloudInit).toContain('systemctl start --no-block matrix-code.service || echo "matrix-host: code editor will retry via systemd" >&2');
     expect(cloudInit).toContain('systemctl start --no-block matrix-hermes.service || echo "matrix-host: optional Hermes install will retry via systemd" >&2');
     expect(cloudInit).toContain('systemctl start --no-block matrix-hermes-dashboard.service || echo "matrix-host: optional Hermes dashboard will retry via systemd" >&2');
     expect(cloudInit.indexOf('systemctl start matrix-restore.service matrix-gateway.service')).toBeLessThan(
@@ -513,12 +514,17 @@ exit 99
     expect(cloudInit).toContain('After=matrix-restore.service matrix-code-server.service');
     expect(cloudInit).toContain('Wants=matrix-code-server.service');
     expect(cloudInit).toContain('ExecStart=/opt/matrix/bin/matrix-code');
+    expect(cloudInit).toContain('TimeoutStartSec=1800');
     expect(cloudInit).toContain('ConditionPathExists=/opt/matrix/bin/matrix-code');
-    expect(cloudInit).toContain('ConditionPathExists=/opt/matrix/runtime/code-server/bin/code-server');
+    expect(cloudInit).not.toContain('ConditionPathExists=/opt/matrix/runtime/code-server/bin/code-server');
     expect(cloudInit).toContain('Description=Install Matrix OS code-server runtime');
     expect(cloudInit).toContain('ExecStart=/opt/matrix/bin/matrix-install-tool-pack code-server');
     expect(cloudInit).toContain('ExecStartPost=-/bin/systemctl start matrix-code.service');
     expect(code).toContain('MATRIX_CODE_PROXY_TOKEN');
+    expect(code).toContain('matrix-code: code-server is missing; attempting install');
+    expect(code).toContain('sudo -n /opt/matrix/bin/matrix-install-tool-pack code-server');
+    expect(code).toContain('matrix-code: code-server install already running; waiting');
+    expect(code).toContain('for _ in $(seq 1 180); do');
     expect(code).toContain('code-server');
     expect(code).toContain('crypto.timingSafeEqual');
   });

--- a/tests/platform/customer-vps-host-bundle.test.ts
+++ b/tests/platform/customer-vps-host-bundle.test.ts
@@ -159,6 +159,7 @@ describe('customer VPS host bundle', () => {
     const root = process.cwd();
     const unit = readFileSync(join(root, 'distro/customer-vps/systemd/matrix-developer-tools.service'), 'utf8');
     const codeServerUnit = readFileSync(join(root, 'distro/customer-vps/systemd/matrix-code-server.service'), 'utf8');
+    const codeUnit = readFileSync(join(root, 'distro/customer-vps/systemd/matrix-code.service'), 'utf8');
     const installer = readFileSync(join(root, 'distro/customer-vps/host-bin/matrix-install-developer-tools'), 'utf8');
 
     expect(unit).toContain('Description=Matrix OS optional developer tools');
@@ -174,6 +175,13 @@ describe('customer VPS host bundle', () => {
     expect(codeServerUnit).toContain('Description=Install Matrix OS code-server runtime');
     expect(codeServerUnit).toContain('ExecStart=/opt/matrix/bin/matrix-install-tool-pack code-server');
     expect(codeServerUnit).toContain('ExecStartPost=-/bin/systemctl start matrix-code.service');
+    expect(codeUnit).toContain('Description=Matrix OS customer code editor');
+    expect(codeUnit).toContain('After=matrix-restore.service matrix-code-server.service');
+    expect(codeUnit).toContain('Wants=matrix-code-server.service');
+    expect(codeUnit).toContain('ExecStart=/opt/matrix/bin/matrix-code');
+    expect(codeUnit).toContain('TimeoutStartSec=1800');
+    expect(codeUnit).toContain('ConditionPathExists=/opt/matrix/bin/matrix-code');
+    expect(codeUnit).not.toContain('ConditionPathExists=/opt/matrix/runtime/code-server/bin/code-server');
   });
 
   it('owner env canonicalizes Hermes home and migrates legacy Hermes data', () => {
@@ -765,6 +773,9 @@ test "$(readlink "$MATRIX_LEGACY_HOME/.hermes")" = "$MATRIX_HOME/.hermes"
     expect(syncAgent).toContain('sudo systemctl enable matrix-code-server.service');
     expect(syncAgent).toContain('sudo systemctl start --no-block matrix-code-server.service || true');
     expect(syncAgent).toContain('Code-server runtime service enabled');
+    expect(syncAgent).toContain('sudo systemctl enable matrix-code.service');
+    expect(syncAgent).toContain('sudo systemctl start --no-block matrix-code.service || true');
+    expect(syncAgent).toContain('Code editor service enabled');
     expect(syncAgent).toContain('Messaging runtimes missing; units installed but not enabled');
     expect(syncAgent).toContain('sudo systemctl enable matrix-homeserver.service matrix-bridge-telegram.service matrix-bridge-whatsapp.service');
   });


### PR DESCRIPTION
## Summary
- ship matrix-code.service in host bundles so existing VPSes receive code service unit updates
- let matrix-code run even when code-server is missing, then install code-server before starting the proxy
- have cloud-init and sync-agent start matrix-code.service asynchronously so fresh and updated VPSes retry code editor startup

## Verification
- bun run test tests/platform/customer-vps-cloud-init.test.ts tests/platform/customer-vps-host-bundle.test.ts tests/deploy/customer-vps/symphony-systemd.test.ts

## Incident context
- khorma9 applied v2026.06.29-510 and app health is 200, but direct code.matrix-os.com to the VPS still returns nginx 502.
- hamedmp returns the expected 401 on code health, consistent with existing hosts already having code-server installed.
- The previous bundle shipped matrix-code-server.service but not an updated matrix-code.service unit, so existing VPSes could keep the old ConditionPathExists gate and never run the wrapper when code-server is absent.

## Mandatory invariants
- Source of truth: host bundle systemd files and cloud-init define the same code editor service behavior; matrix-code is the runtime wrapper source of truth for code-server startup.
- Lock/transaction scope: no database writes or transactional paths are changed.
- Acceptable orphan states: code-server install may fail or still be in progress; matrix-code.service remains restartable and retries through systemd instead of leaving nginx permanently pointed at no local service.
- Auth source of truth: unchanged; MATRIX_CODE_PROXY_TOKEN remains required by the local code proxy, and platform/edge token handling is untouched.
- Deferred scope: no new platform health surface in this PR; live service-status observability can be added separately.