### PR TITLE
fix(vps): make code-server installer root-aware

### DIFF
--- a/distro/customer-vps/cloud-init.yaml
+++ b/distro/customer-vps/cloud-init.yaml
@@ -122,8 +122,7 @@ write_files:
     content: |
       [Unit]
       Description=Matrix OS customer code editor
-      After=matrix-restore.service matrix-code-server.service
-      Wants=matrix-code-server.service
+      After=matrix-restore.service
       Requires=matrix-restore.service
       ConditionPathExists=/opt/matrix/restore-complete
       ConditionPathExists=/opt/matrix/bin/matrix-code
@@ -151,6 +150,7 @@ write_files:
       Requires=matrix-restore.service
       ConditionPathExists=/opt/matrix/restore-complete
       ConditionPathExists=/opt/matrix/bin/matrix-install-tool-pack
+      ConditionPathExists=!/opt/matrix/runtime/code-server/bin/code-server
 
       [Service]
       Type=oneshot
@@ -158,7 +158,6 @@ write_files:
       Group=root
       EnvironmentFile=/opt/matrix/env/host.env
       ExecStart=/opt/matrix/bin/matrix-install-tool-pack code-server
-      ExecStartPost=-/bin/systemctl start matrix-code.service
       Restart=on-failure
       RestartSec=10m
       TimeoutStartSec=900

--- a/distro/customer-vps/host-bin/matrix-install-tool-pack
+++ b/distro/customer-vps/host-bin/matrix-install-tool-pack
@@ -86,6 +86,14 @@ run_as_matrix() {
     "$@"
 }
 
+run_as_root() {
+  if [ "$(id -u)" = "0" ]; then
+    "$@"
+    return
+  fi
+  sudo "$@"
+}
+
 run_npm_install() {
   local timeout_bin
   timeout_bin="$(command -v timeout 2>/dev/null || true)"
@@ -224,10 +232,10 @@ install_code_server() {
     --connect-timeout 10 --max-time 180 \
     "$CODE_SERVER_URL" -o "$tmp_dir/$CODE_SERVER_ARCHIVE"
   tar -xzf "$tmp_dir/$CODE_SERVER_ARCHIVE" -C "$tmp_dir"
-  sudo rm -rf "$MATRIX_RUNTIME_DIR/code-server"
-  sudo mv "$tmp_dir/$CODE_SERVER_DIST" "$MATRIX_RUNTIME_DIR/code-server"
-  sudo chown -R root:matrix "$MATRIX_RUNTIME_DIR/code-server"
-  sudo chmod -R g+rwX "$MATRIX_RUNTIME_DIR/code-server"
+  run_as_root rm -rf "$MATRIX_RUNTIME_DIR/code-server"
+  run_as_root mv "$tmp_dir/$CODE_SERVER_DIST" "$MATRIX_RUNTIME_DIR/code-server"
+  run_as_root chown -R root:matrix "$MATRIX_RUNTIME_DIR/code-server"
+  run_as_root chmod -R g+rwX "$MATRIX_RUNTIME_DIR/code-server"
   cat > "$NODE_PREFIX/bin/code-server" <<'EOS'
 #!/usr/bin/env sh
 exec /opt/matrix/runtime/code-server/bin/code-server "$@"

--- a/distro/customer-vps/host-bin/matrix-install-tool-pack
+++ b/distro/customer-vps/host-bin/matrix-install-tool-pack
@@ -220,7 +220,7 @@ install_coding_agents() {
 }
 
 install_code_server() {
-  if command -v code-server >/dev/null 2>&1; then
+  if [ -x "$MATRIX_RUNTIME_DIR/code-server/bin/code-server" ]; then
     log "code-server is already installed"
     return
   fi

--- a/distro/customer-vps/systemd/matrix-code-server.service
+++ b/distro/customer-vps/systemd/matrix-code-server.service
@@ -5,6 +5,7 @@ Wants=network-online.target
 Requires=matrix-restore.service
 ConditionPathExists=/opt/matrix/restore-complete
 ConditionPathExists=/opt/matrix/bin/matrix-install-tool-pack
+ConditionPathExists=!/opt/matrix/runtime/code-server/bin/code-server
 
 [Service]
 Type=oneshot
@@ -12,7 +13,6 @@ User=root
 Group=root
 EnvironmentFile=/opt/matrix/env/host.env
 ExecStart=/opt/matrix/bin/matrix-install-tool-pack code-server
-ExecStartPost=-/bin/systemctl start matrix-code.service
 Restart=on-failure
 RestartSec=10m
 TimeoutStartSec=900

--- a/distro/customer-vps/systemd/matrix-code.service
+++ b/distro/customer-vps/systemd/matrix-code.service
@@ -1,7 +1,6 @@
 [Unit]
 Description=Matrix OS customer code editor
-After=matrix-restore.service matrix-code-server.service
-Wants=matrix-code-server.service
+After=matrix-restore.service
 Requires=matrix-restore.service
 ConditionPathExists=/opt/matrix/restore-complete
 ConditionPathExists=/opt/matrix/bin/matrix-code

--- a/tests/platform/customer-vps-cloud-init.test.ts
+++ b/tests/platform/customer-vps-cloud-init.test.ts
@@ -256,13 +256,19 @@ exit 99
   it('starts Matrix services before optional Hermes install work', () => {
     const root = process.cwd();
     const cloudInit = readFileSync(join(root, 'distro/customer-vps/cloud-init.yaml'), 'utf8');
+    const codeServerBlock = cloudInit.slice(
+      cloudInit.indexOf('path: /etc/systemd/system/matrix-code-server.service'),
+      cloudInit.indexOf('path: /etc/systemd/system/matrix-sync-agent.service'),
+    );
 
     expect(cloudInit).toContain('path: /etc/systemd/system/matrix-hermes.service');
     expect(cloudInit).toContain('ExecStart=/opt/matrix/bin/matrix-install-hermes');
     expect(cloudInit).toContain('ExecStartPost=-/bin/systemctl start matrix-code.service');
     expect(cloudInit).toContain('path: /etc/systemd/system/matrix-code-server.service');
-    expect(cloudInit).toContain('Description=Install Matrix OS code-server runtime');
-    expect(cloudInit).toContain('ExecStart=/opt/matrix/bin/matrix-install-tool-pack code-server');
+    expect(codeServerBlock).toContain('Description=Install Matrix OS code-server runtime');
+    expect(codeServerBlock).toContain('ConditionPathExists=!/opt/matrix/runtime/code-server/bin/code-server');
+    expect(codeServerBlock).toContain('ExecStart=/opt/matrix/bin/matrix-install-tool-pack code-server');
+    expect(codeServerBlock).not.toContain('ExecStartPost=-/bin/systemctl start matrix-code.service');
     expect(cloudInit).toContain('TimeoutStartSec=1800');
     expect(cloudInit).toContain(
       'systemctl enable matrix-restore.service matrix-gateway.service matrix-shell.service matrix-code-server.service matrix-code.service matrix-sync-agent.service matrix-symphony.service matrix-hermes.service matrix-hermes-dashboard.service matrix-linux-tools.service matrix-developer-tools.service matrix-db-backup.timer nginx',
@@ -509,17 +515,27 @@ exit 99
     const root = process.cwd();
     const cloudInit = readFileSync(join(root, 'distro/customer-vps/cloud-init.yaml'), 'utf8');
     const code = readFileSync(join(root, 'distro/customer-vps/host-bin/matrix-code'), 'utf8');
+    const codeUnitBlock = cloudInit.slice(
+      cloudInit.indexOf('path: /etc/systemd/system/matrix-code.service'),
+      cloudInit.indexOf('path: /etc/systemd/system/matrix-code-server.service'),
+    );
+    const codeServerBlock = cloudInit.slice(
+      cloudInit.indexOf('path: /etc/systemd/system/matrix-code-server.service'),
+      cloudInit.indexOf('path: /etc/systemd/system/matrix-sync-agent.service'),
+    );
 
-    expect(cloudInit).toContain('Description=Matrix OS customer code editor');
-    expect(cloudInit).toContain('After=matrix-restore.service matrix-code-server.service');
-    expect(cloudInit).toContain('Wants=matrix-code-server.service');
-    expect(cloudInit).toContain('ExecStart=/opt/matrix/bin/matrix-code');
-    expect(cloudInit).toContain('TimeoutStartSec=1800');
-    expect(cloudInit).toContain('ConditionPathExists=/opt/matrix/bin/matrix-code');
-    expect(cloudInit).not.toContain('ConditionPathExists=/opt/matrix/runtime/code-server/bin/code-server');
-    expect(cloudInit).toContain('Description=Install Matrix OS code-server runtime');
-    expect(cloudInit).toContain('ExecStart=/opt/matrix/bin/matrix-install-tool-pack code-server');
-    expect(cloudInit).toContain('ExecStartPost=-/bin/systemctl start matrix-code.service');
+    expect(codeUnitBlock).toContain('Description=Matrix OS customer code editor');
+    expect(codeUnitBlock).toContain('After=matrix-restore.service');
+    expect(codeUnitBlock).not.toContain('After=matrix-restore.service matrix-code-server.service');
+    expect(codeUnitBlock).not.toContain('Wants=matrix-code-server.service');
+    expect(codeUnitBlock).toContain('ExecStart=/opt/matrix/bin/matrix-code');
+    expect(codeUnitBlock).toContain('TimeoutStartSec=1800');
+    expect(codeUnitBlock).toContain('ConditionPathExists=/opt/matrix/bin/matrix-code');
+    expect(codeUnitBlock).not.toContain('ConditionPathExists=/opt/matrix/runtime/code-server/bin/code-server');
+    expect(codeServerBlock).toContain('Description=Install Matrix OS code-server runtime');
+    expect(codeServerBlock).toContain('ExecStart=/opt/matrix/bin/matrix-install-tool-pack code-server');
+    expect(codeServerBlock).toContain('ConditionPathExists=!/opt/matrix/runtime/code-server/bin/code-server');
+    expect(codeServerBlock).not.toContain('ExecStartPost=-/bin/systemctl start matrix-code.service');
     expect(code).toContain('MATRIX_CODE_PROXY_TOKEN');
     expect(code).toContain('matrix-code: code-server is missing; attempting install');
     expect(code).toContain('sudo -n /opt/matrix/bin/matrix-install-tool-pack code-server');

--- a/tests/platform/customer-vps-host-bundle.test.ts
+++ b/tests/platform/customer-vps-host-bundle.test.ts
@@ -104,6 +104,10 @@ describe('customer VPS host bundle', () => {
     expect(installer).toContain('PI_CODING_AGENT_VERSION="${PI_CODING_AGENT_VERSION:-latest}"');
     expect(installer).toContain('"opencode-ai@${OPENCODE_AI_VERSION}"');
     expect(installer).toContain('run_npm_install()');
+    expect(installer).toContain('run_as_root()');
+    expect(installer).toContain('run_as_root rm -rf "$MATRIX_RUNTIME_DIR/code-server"');
+    expect(installer).toContain('run_as_root mv "$tmp_dir/$CODE_SERVER_DIST" "$MATRIX_RUNTIME_DIR/code-server"');
+    expect(installer).not.toContain('sudo rm -rf "$MATRIX_RUNTIME_DIR/code-server"');
     expect(installer).toContain('resolve_runtime_user()');
     expect(installer).toContain('runtime user ${MATRIX_RUNTIME_USER} not found; using current user ${current_user}');
     expect(installer).toContain('run_as_matrix "$timeout_bin" 900 "$NODE_PREFIX/bin/npm" "$@"');
@@ -173,11 +177,13 @@ describe('customer VPS host bundle', () => {
     expect(installer).toContain('TOOLS="${MATRIX_DEVELOPER_TOOLS-codex claude-code opencode pi}"');
     expect(installer).not.toContain('TOOLS="${MATRIX_DEVELOPER_TOOLS:-codex claude-code opencode pi}"');
     expect(codeServerUnit).toContain('Description=Install Matrix OS code-server runtime');
+    expect(codeServerUnit).toContain('ConditionPathExists=!/opt/matrix/runtime/code-server/bin/code-server');
     expect(codeServerUnit).toContain('ExecStart=/opt/matrix/bin/matrix-install-tool-pack code-server');
-    expect(codeServerUnit).toContain('ExecStartPost=-/bin/systemctl start matrix-code.service');
+    expect(codeServerUnit).not.toContain('ExecStartPost=-/bin/systemctl start matrix-code.service');
     expect(codeUnit).toContain('Description=Matrix OS customer code editor');
-    expect(codeUnit).toContain('After=matrix-restore.service matrix-code-server.service');
-    expect(codeUnit).toContain('Wants=matrix-code-server.service');
+    expect(codeUnit).toContain('After=matrix-restore.service');
+    expect(codeUnit).not.toContain('After=matrix-restore.service matrix-code-server.service');
+    expect(codeUnit).not.toContain('Wants=matrix-code-server.service');
     expect(codeUnit).toContain('ExecStart=/opt/matrix/bin/matrix-code');
     expect(codeUnit).toContain('TimeoutStartSec=1800');
     expect(codeUnit).toContain('ConditionPathExists=/opt/matrix/bin/matrix-code');

--- a/tests/platform/customer-vps-host-bundle.test.ts
+++ b/tests/platform/customer-vps-host-bundle.test.ts
@@ -105,6 +105,8 @@ describe('customer VPS host bundle', () => {
     expect(installer).toContain('"opencode-ai@${OPENCODE_AI_VERSION}"');
     expect(installer).toContain('run_npm_install()');
     expect(installer).toContain('run_as_root()');
+    expect(installer).toContain('[ -x "$MATRIX_RUNTIME_DIR/code-server/bin/code-server" ]');
+    expect(installer).not.toContain('command -v code-server >/dev/null 2>&1');
     expect(installer).toContain('run_as_root rm -rf "$MATRIX_RUNTIME_DIR/code-server"');
     expect(installer).toContain('run_as_root mv "$tmp_dir/$CODE_SERVER_DIST" "$MATRIX_RUNTIME_DIR/code-server"');
     expect(installer).not.toContain('sudo rm -rf "$MATRIX_RUNTIME_DIR/code-server"');


### PR DESCRIPTION
## Summary
- make matrix-install-tool-pack root-aware for code-server filesystem operations
- remove the code-service dependency cycle with matrix-code-server.service
- make the installer unit skip once code-server is already present

## Live root cause
On khorma9, matrix-code-server.service ran as root but install_code_server() invoked nested sudo for rm/mv/chown/chmod. Fresh VPS root had an expired password state, so sudo failed before code-server could be installed. After manual install, ExecStartPost=systemctl start matrix-code.service deadlocked with matrix-code.service Wants/After=matrix-code-server.service.

## Invariants
- Source of truth: /opt/matrix/runtime/code-server/bin/code-server is the installed runtime marker.
- Lock/transaction scope: existing /tmp/matrix-tool-pack-code-server.lock remains the only installer concurrency guard.
- Acceptable orphan states: matrix-code.service may start before the background installer and self-heal by invoking the same locked installer path.
- Auth source of truth: unchanged; code proxy auth stays in matrix-code and platform edge routing.
- Deferred scope: no broader developer-tool installer redesign in this patch.

## Tests
- bun run test tests/platform/customer-vps-host-bundle.test.ts tests/platform/customer-vps-cloud-init.test.ts tests/deploy/customer-vps/symphony-systemd.test.ts
