### PR TITLE
feat(self-host): add Linux VPS installer

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/097-developer-fast-path"
+  "feature_directory": "specs/103-self-host-installer"
 }

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Run Matrix OS on an existing Linux VPS you control:
 curl -fsSL https://matrix-os.com/install-server.sh | sudo bash
 ```
 
-The self-host installer downloads a verified host bundle, creates the `matrix` user, starts local Postgres, the Matrix gateway, web shell, code-server, nginx, and optional coding-agent tools under systemd. Self-host users own DNS, TLS, backups, updates, and server security. See [Self-host docs](https://matrix-os.com/docs/self-host) for prerequisites and tradeoffs.
+The self-host installer downloads a verified host bundle, creates the `matrix` user, starts local Postgres, the Matrix gateway, web shell, code-server, nginx, and optional coding-agent tools under systemd. A domain is optional: by default nginx answers on the server IP address with Basic Auth. Self-host users own DNS, TLS, backups, updates, and server security. See [Self-host docs](https://matrix-os.com/docs/self-host) for prerequisites and tradeoffs.
 
 ### Matrix CLI
 

--- a/README.md
+++ b/README.md
@@ -57,15 +57,15 @@ Matrix OS is the foundation for **Web 4**: a unified environment where operating
 
 ---
 
-## Quick Start
+## Install Matrix OS
 
-### Hosted Cloud Computer
+### Managed Matrix Cloud
 
 Start at the landing page: [matrix-os.com](https://matrix-os.com).
 
-Sign up or log in from there, choose a Matrix handle, provision your private runtime, and open the browser desktop. Hosted Matrix OS uses a platform control plane plus one VPS-native runtime per active user. That VPS is where your files, terminal sessions, generated apps, integrations, and coding agents live.
+Sign up or log in from there, choose a Matrix handle, provision your private runtime, and open the browser desktop. Managed Matrix OS uses a platform control plane plus one VPS-native runtime per active user. Matrix manages routing, auth, updates, backups, billing, and integrations. Your VPS is where your files, terminal sessions, generated apps, integrations, and coding agents live.
 
-### Self-host on Your VPS
+### Manual VPS Install
 
 Run Matrix OS on an existing Linux VPS you control:
 
@@ -73,7 +73,7 @@ Run Matrix OS on an existing Linux VPS you control:
 curl -fsSL https://matrix-os.com/install-server.sh | sudo bash
 ```
 
-The self-host installer downloads a verified host bundle, creates the `matrix` user, starts local Postgres, the Matrix gateway, web shell, code-server, nginx, and optional coding-agent tools under systemd. A domain is optional: by default nginx answers on the server IP address with Basic Auth. Self-host users own DNS, TLS, backups, updates, and server security. See [Self-host docs](https://matrix-os.com/docs/self-host) for prerequisites and tradeoffs.
+The manual installer downloads a verified host bundle, creates the `matrix` user, starts local Postgres, the Matrix gateway, web shell, code-server, nginx, and optional coding-agent tools under systemd. A domain is optional: by default nginx answers on the server IP address with Basic Auth. Manual VPS operators own DNS, TLS, backups, updates, integrations, and server security. See [Self-host docs](https://matrix-os.com/docs/self-host) for prerequisites, telemetry, and tradeoffs.
 
 ### Matrix CLI
 

--- a/README.md
+++ b/README.md
@@ -65,6 +65,16 @@ Start at the landing page: [matrix-os.com](https://matrix-os.com).
 
 Sign up or log in from there, choose a Matrix handle, provision your private runtime, and open the browser desktop. Hosted Matrix OS uses a platform control plane plus one VPS-native runtime per active user. That VPS is where your files, terminal sessions, generated apps, integrations, and coding agents live.
 
+### Self-host on Your VPS
+
+Run Matrix OS on an existing Linux VPS you control:
+
+```bash
+curl -fsSL https://matrix-os.com/install-server.sh | sudo bash
+```
+
+The self-host installer downloads a verified host bundle, creates the `matrix` user, starts local Postgres, the Matrix gateway, web shell, code-server, nginx, and optional coding-agent tools under systemd. Self-host users own DNS, TLS, backups, updates, and server security. See [Self-host docs](https://matrix-os.com/docs/self-host) for prerequisites and tradeoffs.
+
 ### Matrix CLI
 
 Install the CLI:

--- a/scripts/install-server.sh
+++ b/scripts/install-server.sh
@@ -11,6 +11,14 @@ MATRIX_INSTALL_HANDLE="${MATRIX_INSTALL_HANDLE:-matrix}"
 MATRIX_DOMAIN="${MATRIX_DOMAIN:-_}"
 MATRIX_HOME_DIR="${MATRIX_HOME:-/home/matrix/home}"
 MATRIX_DEVELOPER_TOOLS="${MATRIX_DEVELOPER_TOOLS:-codex claude-code opencode pi}"
+INSTALL_TMP_BUNDLE=""
+INSTALL_TMP_SUM=""
+
+cleanup_install_tmp() {
+  [ -z "$INSTALL_TMP_BUNDLE" ] || rm -f "$INSTALL_TMP_BUNDLE"
+  [ -z "$INSTALL_TMP_SUM" ] || rm -f "$INSTALL_TMP_SUM"
+}
+trap cleanup_install_tmp EXIT
 
 log() {
   printf 'matrix-server-install: %s\n' "$*"
@@ -99,11 +107,21 @@ random_secret() {
   openssl rand -base64 32 | tr -d '\n'
 }
 
+read_env_value() {
+  local file key value
+  file="$1"
+  key="$2"
+  [ -f "$file" ] || return 1
+  value="$(awk -F= -v key="$key" '$1 == key {sub(/^[^=]*=/, ""); print; exit}' "$file")"
+  [ -n "$value" ] || return 1
+  printf '%s\n' "$value"
+}
+
 write_env() {
   local auth_token code_token postgres_password
-  auth_token="$(random_secret)"
-  code_token="$(random_secret)"
-  postgres_password="$(random_secret | tr '/+' 'ab')"
+  auth_token="$(read_env_value /opt/matrix/env/host.env MATRIX_AUTH_TOKEN || random_secret)"
+  code_token="$(read_env_value /opt/matrix/env/host.env MATRIX_CODE_PROXY_TOKEN || random_secret)"
+  postgres_password="$(read_env_value /opt/matrix/env/postgres.env POSTGRES_PASSWORD || random_secret | tr '/+' 'ab')"
 
   cat >/opt/matrix/env/postgres.env <<EOF
 POSTGRES_DB=matrix
@@ -138,8 +156,10 @@ EOF
 
 install_bundle() {
   local tmp_bundle tmp_sum expected actual
-  tmp_bundle="/tmp/matrix-host-bundle.tar.gz"
-  tmp_sum="/tmp/matrix-host-bundle.tar.gz.sha256"
+  tmp_bundle="$(mktemp /tmp/matrix-host-bundle.XXXXXX.tar.gz)"
+  tmp_sum="$(mktemp /tmp/matrix-host-bundle.XXXXXX.tar.gz.sha256)"
+  INSTALL_TMP_BUNDLE="$tmp_bundle"
+  INSTALL_TMP_SUM="$tmp_sum"
 
   log "downloading host bundle"
   curl --fail --location --retry 3 --retry-delay 5 --retry-all-errors \
@@ -157,25 +177,9 @@ install_bundle() {
   log "extracting host bundle"
   tar -xzf "$tmp_bundle" -C /opt/matrix
   chmod 0755 /opt/matrix/bin/matrix-* /opt/matrix/bin/zellij 2>/dev/null || true
-}
-
-write_postgres_compose() {
-  cat >/opt/matrix/postgres-compose.yml <<'EOF'
-services:
-  postgres:
-    image: postgres:16
-    restart: unless-stopped
-    env_file:
-      - /opt/matrix/env/postgres.env
-    volumes:
-      - matrix-postgres:/var/lib/postgresql/data
-    ports:
-      - "127.0.0.1:5432:5432"
-
-volumes:
-  matrix-postgres:
-EOF
-  chmod 0644 /opt/matrix/postgres-compose.yml
+  cleanup_install_tmp
+  INSTALL_TMP_BUNDLE=""
+  INSTALL_TMP_SUM=""
 }
 
 write_self_host_restore_service() {
@@ -217,9 +221,10 @@ install_systemd_units() {
 }
 
 configure_nginx() {
-  local password hash server_name
+  local code_proxy_token password hash server_name
   password="$(openssl rand -base64 18 | tr -d '\n')"
   hash="$(openssl passwd -apr1 "$password")"
+  code_proxy_token="$(read_env_value /opt/matrix/env/host.env MATRIX_CODE_PROXY_TOKEN)" || fail "MATRIX_CODE_PROXY_TOKEN is missing from host.env"
   server_name="$MATRIX_DOMAIN"
 
   printf 'matrix:%s\n' "$hash" >/opt/matrix/env/nginx.htpasswd
@@ -227,6 +232,9 @@ configure_nginx() {
   chown root:www-data /opt/matrix/env/nginx.htpasswd
   printf '%s\n' "$password" >/opt/matrix/env/initial-ui-password
   chmod 0600 /opt/matrix/env/initial-ui-password
+  printf 'proxy_set_header X-Matrix-Code-Proxy-Token "%s";\n' "$code_proxy_token" >/opt/matrix/env/code-proxy-token.conf
+  chmod 0600 /opt/matrix/env/code-proxy-token.conf
+  chown root:root /opt/matrix/env/code-proxy-token.conf
 
   cat >/etc/nginx/sites-available/matrix-self-host <<EOF
 server {
@@ -260,7 +268,7 @@ server {
     proxy_http_version 1.1;
     proxy_set_header Upgrade \$http_upgrade;
     proxy_set_header Connection "upgrade";
-    proxy_set_header X-Matrix-Code-Proxy-Token "$(grep '^MATRIX_CODE_PROXY_TOKEN=' /opt/matrix/env/host.env | cut -d= -f2-)";
+    include /opt/matrix/env/code-proxy-token.conf;
     rewrite ^/code/?(.*)\$ /\$1 break;
     proxy_pass http://127.0.0.1:8787;
   }
@@ -333,7 +341,6 @@ main() {
   ensure_matrix_user
   write_env
   install_bundle
-  write_postgres_compose
   install_systemd_units
   configure_nginx
   start_services

--- a/scripts/install-server.sh
+++ b/scripts/install-server.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -euo pipefail
+set -Eeuo pipefail
 
 # Matrix OS standalone server installer.
 # Public copy is served from https://matrix-os.com/install-server.sh.
@@ -11,14 +11,20 @@ MATRIX_INSTALL_HANDLE="${MATRIX_INSTALL_HANDLE:-matrix}"
 MATRIX_DOMAIN="${MATRIX_DOMAIN:-_}"
 MATRIX_HOME_DIR="${MATRIX_HOME:-/home/matrix/home}"
 MATRIX_DEVELOPER_TOOLS="${MATRIX_DEVELOPER_TOOLS:-codex claude-code opencode pi}"
+MATRIX_INSTALL_TELEMETRY_URL="${MATRIX_INSTALL_TELEMETRY_URL:-https://matrix-os.com/api/install-telemetry}"
+MATRIX_INSTALL_TELEMETRY_ID="${MATRIX_INSTALL_TELEMETRY_ID:-}"
 INSTALL_TMP_BUNDLE=""
 INSTALL_TMP_SUM=""
+INSTALL_PHASE="init"
+INSTALL_COMPLETED=0
+INSTALL_FAILURE_CAPTURED=0
 
 cleanup_install_tmp() {
   [ -z "$INSTALL_TMP_BUNDLE" ] || rm -f "$INSTALL_TMP_BUNDLE"
   [ -z "$INSTALL_TMP_SUM" ] || rm -f "$INSTALL_TMP_SUM"
 }
 trap cleanup_install_tmp EXIT
+trap 'capture_install_failure $? $LINENO' ERR
 
 log() {
   printf 'matrix-server-install: %s\n' "$*"
@@ -26,7 +32,111 @@ log() {
 
 fail() {
   printf 'matrix-server-install: %s\n' "$*" >&2
+  if declare -F capture_install_failure >/dev/null 2>&1; then
+    capture_install_failure 1 "${BASH_LINENO[0]:-0}" || true
+  fi
   exit 1
+}
+
+telemetry_enabled() {
+  [ -z "${MATRIX_NO_TELEMETRY:-}" ] || return 1
+  [ "${MATRIX_INSTALL_TELEMETRY:-1}" != "0" ] || return 1
+  [ -n "$MATRIX_INSTALL_TELEMETRY_URL" ] || return 1
+}
+
+telemetry_id() {
+  if [ -n "$MATRIX_INSTALL_TELEMETRY_ID" ]; then
+    printf '%s\n' "$MATRIX_INSTALL_TELEMETRY_ID"
+    return
+  fi
+  if command -v openssl >/dev/null 2>&1; then
+    MATRIX_INSTALL_TELEMETRY_ID="$(openssl rand -hex 16 2>/dev/null || true)"
+  fi
+  if [ -z "$MATRIX_INSTALL_TELEMETRY_ID" ]; then
+    MATRIX_INSTALL_TELEMETRY_ID="$(date -u +%Y%m%d%H%M%S)-$$"
+  fi
+  printf '%s\n' "$MATRIX_INSTALL_TELEMETRY_ID"
+}
+
+telemetry_value() {
+  printf '%s' "${1:-unknown}" | tr -c 'A-Za-z0-9._:/@+-' '_' | cut -c1-120
+}
+
+developer_tool_count() {
+  local count tool
+  count=0
+  for tool in $MATRIX_DEVELOPER_TOOLS; do
+    [ -n "$tool" ] || continue
+    count=$((count + 1))
+  done
+  printf '%s\n' "$count"
+}
+
+bundle_source() {
+  case "$MATRIX_HOST_BUNDLE_URL" in
+    "${DEFAULT_BUNDLE_BASE}/matrix-host-bundle.tar.gz") printf 'default\n' ;;
+    *) printf 'custom\n' ;;
+  esac
+}
+
+domain_mode() {
+  if [ "$MATRIX_DOMAIN" = "_" ]; then
+    printf 'ip\n'
+  else
+    printf 'dns\n'
+  fi
+}
+
+installed_version() {
+  if [ -f /opt/matrix/app/BUNDLE_VERSION ]; then
+    head -n1 /opt/matrix/app/BUNDLE_VERSION
+    return
+  fi
+  if [ -f /opt/matrix/BUNDLE_VERSION ]; then
+    head -n1 /opt/matrix/BUNDLE_VERSION
+    return
+  fi
+  if [ -f /opt/matrix/release.json ]; then
+    sed -n 's/.*"version"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' /opt/matrix/release.json | head -n1
+    return
+  fi
+  printf 'unknown\n'
+}
+
+capture_install_telemetry() {
+  local event status exit_code payload version
+  event="$1"
+  status="$2"
+  exit_code="${3:-0}"
+  telemetry_enabled || return 0
+  version="$(telemetry_value "$(installed_version 2>/dev/null || printf 'unknown')")"
+  payload="$(printf '{"event":"%s","installId":"%s","channel":"%s","version":"%s","domainMode":"%s","bundleSource":"%s","developerToolsCount":%s,"phase":"%s","status":"%s","exitCode":%s}\n' \
+    "$(telemetry_value "$event")" \
+    "$(telemetry_value "$(telemetry_id)")" \
+    "$(telemetry_value "$DEFAULT_CHANNEL")" \
+    "$version" \
+    "$(telemetry_value "$(domain_mode)")" \
+    "$(telemetry_value "$(bundle_source)")" \
+    "$(developer_tool_count)" \
+    "$(telemetry_value "$INSTALL_PHASE")" \
+    "$(telemetry_value "$status")" \
+    "$exit_code")"
+  curl --fail --silent --show-error --connect-timeout 2 --max-time 3 \
+    -H 'content-type: application/json' \
+    -X POST \
+    --data "$payload" \
+    "$MATRIX_INSTALL_TELEMETRY_URL" >/dev/null 2>&1 || true
+}
+
+capture_install_failure() {
+  local exit_code line
+  exit_code="$1"
+  line="$2"
+  [ "$INSTALL_COMPLETED" = "0" ] || return 0
+  [ "$INSTALL_FAILURE_CAPTURED" = "0" ] || return 0
+  INSTALL_FAILURE_CAPTURED=1
+  INSTALL_PHASE="${INSTALL_PHASE:-failed}-line-${line}"
+  capture_install_telemetry "matrix_manual_install_failed" "failed" "$exit_code"
 }
 
 require_root() {
@@ -344,16 +454,28 @@ EOF
 }
 
 main() {
+  INSTALL_PHASE="preflight"
   require_root
   require_linux_systemd
   validate_config
+  capture_install_telemetry "matrix_manual_install_started" "started" 0
+  INSTALL_PHASE="packages"
   install_packages
+  INSTALL_PHASE="user"
   ensure_matrix_user
+  INSTALL_PHASE="env"
   write_env
+  INSTALL_PHASE="bundle"
   install_bundle
+  INSTALL_PHASE="systemd"
   install_systemd_units
+  INSTALL_PHASE="nginx"
   configure_nginx
+  INSTALL_PHASE="services"
   start_services
+  INSTALL_PHASE="complete"
+  INSTALL_COMPLETED=1
+  capture_install_telemetry "matrix_manual_install_completed" "completed" 0
   print_summary
 }
 

--- a/scripts/install-server.sh
+++ b/scripts/install-server.sh
@@ -222,16 +222,18 @@ install_systemd_units() {
 
 configure_nginx() {
   local code_proxy_token password hash server_name
-  password="$(openssl rand -base64 18 | tr -d '\n')"
-  hash="$(openssl passwd -apr1 "$password")"
   code_proxy_token="$(read_env_value /opt/matrix/env/host.env MATRIX_CODE_PROXY_TOKEN)" || fail "MATRIX_CODE_PROXY_TOKEN is missing from host.env"
   server_name="$MATRIX_DOMAIN"
 
-  printf 'matrix:%s\n' "$hash" >/opt/matrix/env/nginx.htpasswd
+  if [ ! -f /opt/matrix/env/nginx.htpasswd ]; then
+    password="$(openssl rand -base64 18 | tr -d '\n')"
+    hash="$(openssl passwd -apr1 "$password")"
+    printf 'matrix:%s\n' "$hash" >/opt/matrix/env/nginx.htpasswd
+    printf '%s\n' "$password" >/opt/matrix/env/initial-ui-password
+    chmod 0600 /opt/matrix/env/initial-ui-password
+  fi
   chmod 0640 /opt/matrix/env/nginx.htpasswd
   chown root:www-data /opt/matrix/env/nginx.htpasswd
-  printf '%s\n' "$password" >/opt/matrix/env/initial-ui-password
-  chmod 0600 /opt/matrix/env/initial-ui-password
   printf 'proxy_set_header X-Matrix-Code-Proxy-Token "%s";\n' "$code_proxy_token" >/opt/matrix/env/code-proxy-token.conf
   chmod 0600 /opt/matrix/env/code-proxy-token.conf
   chown root:root /opt/matrix/env/code-proxy-token.conf
@@ -261,6 +263,7 @@ server {
     proxy_http_version 1.1;
     proxy_set_header Upgrade \$http_upgrade;
     proxy_set_header Connection "upgrade";
+    proxy_read_timeout 3600s;
     proxy_pass http://127.0.0.1:4000;
   }
 
@@ -268,6 +271,7 @@ server {
     proxy_http_version 1.1;
     proxy_set_header Upgrade \$http_upgrade;
     proxy_set_header Connection "upgrade";
+    proxy_read_timeout 3600s;
     include /opt/matrix/env/code-proxy-token.conf;
     rewrite ^/code/?(.*)\$ /\$1 break;
     proxy_pass http://127.0.0.1:8787;
@@ -300,7 +304,7 @@ start_services() {
 }
 
 print_summary() {
-  local ip ui_url
+  local ip password_line ui_url
   ip="$(hostname -I 2>/dev/null | awk '{print $1}')"
   if [ -n "${MATRIX_PUBLIC_URL:-}" ]; then
     ui_url="$MATRIX_PUBLIC_URL"
@@ -311,6 +315,11 @@ print_summary() {
   else
     ui_url="http://<server-ip>"
   fi
+  if [ -f /opt/matrix/env/initial-ui-password ]; then
+    password_line="Password: $(cat /opt/matrix/env/initial-ui-password)"
+  else
+    password_line="Password: existing nginx Basic Auth credentials"
+  fi
 
   cat <<EOF
 
@@ -318,7 +327,7 @@ Matrix OS standalone install complete.
 
 Open: ${ui_url}
 User: matrix
-Password: $(cat /opt/matrix/env/initial-ui-password)
+${password_line}
 
 Code editor: ${ui_url%/}/code/
 Home: ${MATRIX_HOME_DIR}

--- a/scripts/install-server.sh
+++ b/scripts/install-server.sh
@@ -47,10 +47,11 @@ validate_config() {
   case "$MATRIX_INSTALL_HANDLE" in
     ""|*[!A-Za-z0-9_-]*) fail "MATRIX_INSTALL_HANDLE may only contain letters, numbers, underscore, and dash" ;;
   esac
-  case "$MATRIX_DOMAIN" in
-    "_"|[A-Za-z0-9.-]*) ;;
-    *) fail "MATRIX_DOMAIN may only be '_' or a DNS name" ;;
-  esac
+  if [ "$MATRIX_DOMAIN" != "_" ]; then
+    [ "${#MATRIX_DOMAIN}" -le 253 ] || fail "MATRIX_DOMAIN may only be '_' or a DNS name"
+    [[ "$MATRIX_DOMAIN" =~ ^[A-Za-z0-9]([A-Za-z0-9-]{0,61}[A-Za-z0-9])?(\.[A-Za-z0-9]([A-Za-z0-9-]{0,61}[A-Za-z0-9])?)*$ ]] \
+      || fail "MATRIX_DOMAIN may only be '_' or a DNS name"
+  fi
   case "$MATRIX_HOME_DIR" in
     /home/matrix/*|/home/matrix) ;;
     *) fail "MATRIX_HOME must stay under /home/matrix for standalone installs" ;;

--- a/scripts/install-server.sh
+++ b/scripts/install-server.sh
@@ -1,0 +1,343 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Matrix OS standalone server installer.
+# Public copy is served from https://matrix-os.com/install-server.sh.
+
+DEFAULT_CHANNEL="${MATRIX_CHANNEL:-stable}"
+DEFAULT_BUNDLE_BASE="https://app.matrix-os.com/system-bundles/${DEFAULT_CHANNEL}"
+MATRIX_HOST_BUNDLE_URL="${MATRIX_HOST_BUNDLE_URL:-${DEFAULT_BUNDLE_BASE}/matrix-host-bundle.tar.gz}"
+MATRIX_INSTALL_HANDLE="${MATRIX_INSTALL_HANDLE:-matrix}"
+MATRIX_DOMAIN="${MATRIX_DOMAIN:-_}"
+MATRIX_HOME_DIR="${MATRIX_HOME:-/home/matrix/home}"
+MATRIX_DEVELOPER_TOOLS="${MATRIX_DEVELOPER_TOOLS:-codex claude-code opencode pi}"
+
+log() {
+  printf 'matrix-server-install: %s\n' "$*"
+}
+
+fail() {
+  printf 'matrix-server-install: %s\n' "$*" >&2
+  exit 1
+}
+
+require_root() {
+  if [ "$(id -u)" != "0" ]; then
+    fail "run as root, for example: curl -fsSL https://matrix-os.com/install-server.sh | sudo bash"
+  fi
+}
+
+require_linux_systemd() {
+  [ "$(uname -s)" = "Linux" ] || fail "Linux is required"
+  command -v systemctl >/dev/null 2>&1 || fail "systemd is required"
+}
+
+validate_config() {
+  case "$DEFAULT_CHANNEL" in
+    ""|*[!A-Za-z0-9._-]*) fail "MATRIX_CHANNEL contains unsupported characters" ;;
+  esac
+  case "$MATRIX_INSTALL_HANDLE" in
+    ""|*[!A-Za-z0-9_-]*) fail "MATRIX_INSTALL_HANDLE may only contain letters, numbers, underscore, and dash" ;;
+  esac
+  case "$MATRIX_DOMAIN" in
+    "_"|[A-Za-z0-9.-]*) ;;
+    *) fail "MATRIX_DOMAIN may only be '_' or a DNS name" ;;
+  esac
+  case "$MATRIX_HOME_DIR" in
+    /home/matrix/*|/home/matrix) ;;
+    *) fail "MATRIX_HOME must stay under /home/matrix for standalone installs" ;;
+  esac
+  case "$MATRIX_HOST_BUNDLE_URL" in
+    https://*) ;;
+    *) fail "MATRIX_HOST_BUNDLE_URL must be https" ;;
+  esac
+  case "$MATRIX_DEVELOPER_TOOLS" in
+    *[!A-Za-z0-9._\ -]*) fail "MATRIX_DEVELOPER_TOOLS contains unsupported characters" ;;
+  esac
+}
+
+apt_get_update() {
+  apt-get update \
+    -o Acquire::Retries=5 \
+    -o Acquire::http::Timeout=20 \
+    -o Acquire::https::Timeout=20
+}
+
+install_packages() {
+  export DEBIAN_FRONTEND=noninteractive
+  if command -v apt-get >/dev/null 2>&1; then
+    log "installing OS packages"
+    apt_get_update
+    apt-get install -y ca-certificates curl docker.io git nginx openssl postgresql-client procps sudo tar
+    return
+  fi
+  fail "only apt-based Linux distributions are supported in this preview"
+}
+
+ensure_matrix_user() {
+  if ! getent group matrix >/dev/null 2>&1; then
+    groupadd --system matrix
+  fi
+  if ! getent group docker >/dev/null 2>&1; then
+    groupadd --system docker
+  fi
+  if ! id matrix >/dev/null 2>&1; then
+    useradd --system --gid matrix --groups docker --home-dir /home/matrix --shell /bin/bash matrix
+  else
+    usermod -aG docker matrix
+  fi
+
+  install -d -o root -g matrix -m 0770 /opt/matrix
+  install -d -o root -g matrix -m 0750 /opt/matrix/env /opt/matrix/bin /opt/matrix/tls
+  install -d -o matrix -g matrix -m 0755 /home/matrix "$MATRIX_HOME_DIR" "$MATRIX_HOME_DIR/projects"
+  install -d -o matrix -g matrix -m 0755 "$MATRIX_HOME_DIR/.local" "$MATRIX_HOME_DIR/.local/bin" "$MATRIX_HOME_DIR/.local/share"
+  install -d -o matrix -g matrix -m 0755 "$MATRIX_HOME_DIR/.cache" "$MATRIX_HOME_DIR/.config"
+  usermod -d "$MATRIX_HOME_DIR" matrix
+}
+
+random_secret() {
+  openssl rand -base64 32 | tr -d '\n'
+}
+
+write_env() {
+  local auth_token code_token postgres_password
+  auth_token="$(random_secret)"
+  code_token="$(random_secret)"
+  postgres_password="$(random_secret | tr '/+' 'ab')"
+
+  cat >/opt/matrix/env/postgres.env <<EOF
+POSTGRES_DB=matrix
+POSTGRES_USER=matrix
+POSTGRES_PASSWORD=${postgres_password}
+EOF
+  chmod 0640 /opt/matrix/env/postgres.env
+  chown root:matrix /opt/matrix/env/postgres.env
+
+  cat >/opt/matrix/env/host.env <<EOF
+MATRIX_SELF_HOSTED=1
+MATRIX_MACHINE_ID=self-host-${MATRIX_INSTALL_HANDLE}
+MATRIX_CLERK_USER_ID=self-host-${MATRIX_INSTALL_HANDLE}
+MATRIX_USER_ID=self-host-${MATRIX_INSTALL_HANDLE}
+MATRIX_HANDLE=${MATRIX_INSTALL_HANDLE}
+MATRIX_RUNTIME_SLOT=primary
+MATRIX_DEVELOPER_TOOLS='${MATRIX_DEVELOPER_TOOLS}'
+MATRIX_IMAGE_VERSION=${DEFAULT_CHANNEL}
+MATRIX_UPDATE_CHANNEL=${DEFAULT_CHANNEL}
+MATRIX_AUTH_TOKEN=${auth_token}
+MATRIX_CODE_PROXY_TOKEN=${code_token}
+MATRIX_HOST_BUNDLE_URL=${MATRIX_HOST_BUNDLE_URL}
+MATRIX_HOME=${MATRIX_HOME_DIR}
+DATABASE_URL=postgresql://matrix:${postgres_password}@127.0.0.1:5432/matrix
+GATEWAY_URL=http://127.0.0.1:4000
+NEXT_PUBLIC_GATEWAY_URL=http://127.0.0.1:4000
+NEXT_PUBLIC_GATEWAY_WS=/ws
+EOF
+  chmod 0640 /opt/matrix/env/host.env
+  chown root:matrix /opt/matrix/env/host.env
+}
+
+install_bundle() {
+  local tmp_bundle tmp_sum expected actual
+  tmp_bundle="/tmp/matrix-host-bundle.tar.gz"
+  tmp_sum="/tmp/matrix-host-bundle.tar.gz.sha256"
+
+  log "downloading host bundle"
+  curl --fail --location --retry 3 --retry-delay 5 --retry-all-errors \
+    --connect-timeout 10 --max-time 900 \
+    "$MATRIX_HOST_BUNDLE_URL" -o "$tmp_bundle"
+  curl --fail --location --retry 3 --retry-delay 5 --retry-all-errors \
+    --connect-timeout 10 --max-time 30 \
+    "${MATRIX_HOST_BUNDLE_URL}.sha256" -o "$tmp_sum"
+
+  expected="$(awk '{print $1}' "$tmp_sum")"
+  actual="$(sha256sum "$tmp_bundle" | awk '{print $1}')"
+  [ -n "$expected" ] || fail "empty bundle checksum"
+  [ "$expected" = "$actual" ] || fail "bundle checksum mismatch"
+
+  log "extracting host bundle"
+  tar -xzf "$tmp_bundle" -C /opt/matrix
+  chmod 0755 /opt/matrix/bin/matrix-* /opt/matrix/bin/zellij 2>/dev/null || true
+}
+
+write_postgres_compose() {
+  cat >/opt/matrix/postgres-compose.yml <<'EOF'
+services:
+  postgres:
+    image: postgres:16
+    restart: unless-stopped
+    env_file:
+      - /opt/matrix/env/postgres.env
+    volumes:
+      - matrix-postgres:/var/lib/postgresql/data
+    ports:
+      - "127.0.0.1:5432:5432"
+
+volumes:
+  matrix-postgres:
+EOF
+  chmod 0644 /opt/matrix/postgres-compose.yml
+}
+
+write_self_host_restore_service() {
+  cat >/etc/systemd/system/matrix-restore.service <<'EOF'
+[Unit]
+Description=Matrix OS standalone database gate
+After=docker.service
+Requires=docker.service
+
+[Service]
+Type=oneshot
+User=matrix
+Group=matrix
+EnvironmentFile=/opt/matrix/env/host.env
+EnvironmentFile=/opt/matrix/env/postgres.env
+ExecStart=/bin/bash -lc 'set -euo pipefail; if docker ps --format "{{.Names}}" | grep -qx matrix-postgres; then :; elif docker ps -a --format "{{.Names}}" | grep -qx matrix-postgres; then docker start matrix-postgres >/dev/null; else docker volume create matrix-postgres >/dev/null; docker run -d --name matrix-postgres --restart unless-stopped --env-file /opt/matrix/env/postgres.env -v matrix-postgres:/var/lib/postgresql/data -p 127.0.0.1:5432:5432 postgres:16 >/dev/null; fi; for _ in $(seq 1 60); do pg_isready --host=127.0.0.1 --username="${POSTGRES_USER:-matrix}" --dbname="${POSTGRES_DB:-matrix}" >/dev/null 2>&1 && break; sleep 2; done; pg_isready --host=127.0.0.1 --username="${POSTGRES_USER:-matrix}" --dbname="${POSTGRES_DB:-matrix}" >/dev/null 2>&1; touch /opt/matrix/restore-complete'
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target
+EOF
+}
+
+install_systemd_units() {
+  log "installing systemd units"
+  install -m 0644 /opt/matrix/systemd/matrix-gateway.service /etc/systemd/system/matrix-gateway.service
+  install -m 0644 /opt/matrix/systemd/matrix-shell.service /etc/systemd/system/matrix-shell.service
+  install -m 0644 /opt/matrix/systemd/matrix-code.service /etc/systemd/system/matrix-code.service
+  install -m 0644 /opt/matrix/systemd/matrix-code-server.service /etc/systemd/system/matrix-code-server.service
+  if [ -f /opt/matrix/systemd/matrix-developer-tools.service ]; then
+    install -m 0644 /opt/matrix/systemd/matrix-developer-tools.service /etc/systemd/system/matrix-developer-tools.service
+  fi
+  write_self_host_restore_service
+  systemctl daemon-reload
+  systemctl enable docker matrix-restore matrix-gateway matrix-shell matrix-code matrix-code-server >/dev/null
+  if [ -f /etc/systemd/system/matrix-developer-tools.service ] && [ -n "$MATRIX_DEVELOPER_TOOLS" ]; then
+    systemctl enable matrix-developer-tools >/dev/null
+  fi
+}
+
+configure_nginx() {
+  local password hash server_name
+  password="$(openssl rand -base64 18 | tr -d '\n')"
+  hash="$(openssl passwd -apr1 "$password")"
+  server_name="$MATRIX_DOMAIN"
+
+  printf 'matrix:%s\n' "$hash" >/opt/matrix/env/nginx.htpasswd
+  chmod 0640 /opt/matrix/env/nginx.htpasswd
+  chown root:www-data /opt/matrix/env/nginx.htpasswd
+  printf '%s\n' "$password" >/opt/matrix/env/initial-ui-password
+  chmod 0600 /opt/matrix/env/initial-ui-password
+
+  cat >/etc/nginx/sites-available/matrix-self-host <<EOF
+server {
+  listen 80 default_server;
+  server_name ${server_name};
+
+  client_max_body_size 10m;
+  auth_basic "Matrix OS";
+  auth_basic_user_file /opt/matrix/env/nginx.htpasswd;
+
+  proxy_set_header Host \$host;
+  proxy_set_header X-Forwarded-Host \$host;
+  proxy_set_header X-Forwarded-Proto \$scheme;
+  proxy_set_header X-Real-IP \$remote_addr;
+
+  location /api/ { proxy_pass http://127.0.0.1:4000; }
+  location /files/ { proxy_pass http://127.0.0.1:4000; }
+  location /icons/ { proxy_pass http://127.0.0.1:4000; }
+  location /apps/ { proxy_pass http://127.0.0.1:4000; }
+  location /health { proxy_pass http://127.0.0.1:4000; }
+  location /gateway/ { proxy_pass http://127.0.0.1:4000/; }
+
+  location /ws {
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade \$http_upgrade;
+    proxy_set_header Connection "upgrade";
+    proxy_pass http://127.0.0.1:4000;
+  }
+
+  location /code/ {
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade \$http_upgrade;
+    proxy_set_header Connection "upgrade";
+    proxy_set_header X-Matrix-Code-Proxy-Token "$(grep '^MATRIX_CODE_PROXY_TOKEN=' /opt/matrix/env/host.env | cut -d= -f2-)";
+    rewrite ^/code/?(.*)\$ /\$1 break;
+    proxy_pass http://127.0.0.1:8787;
+  }
+
+  location / {
+    proxy_pass http://127.0.0.1:3000;
+  }
+}
+EOF
+
+  rm -f /etc/nginx/sites-enabled/default
+  ln -sfn /etc/nginx/sites-available/matrix-self-host /etc/nginx/sites-enabled/matrix-self-host
+  nginx -t
+  systemctl enable nginx >/dev/null
+}
+
+start_services() {
+  log "starting services"
+  systemctl enable --now docker >/dev/null
+  systemctl restart matrix-restore
+  systemctl restart matrix-gateway
+  systemctl restart matrix-shell
+  systemctl restart matrix-code-server || true
+  systemctl restart matrix-code || true
+  if systemctl list-unit-files matrix-developer-tools.service >/dev/null 2>&1; then
+    systemctl restart matrix-developer-tools || true
+  fi
+  systemctl restart nginx
+}
+
+print_summary() {
+  local ip ui_url
+  ip="$(hostname -I 2>/dev/null | awk '{print $1}')"
+  if [ -n "${MATRIX_PUBLIC_URL:-}" ]; then
+    ui_url="$MATRIX_PUBLIC_URL"
+  elif [ "$MATRIX_DOMAIN" != "_" ]; then
+    ui_url="http://${MATRIX_DOMAIN}"
+  elif [ -n "$ip" ]; then
+    ui_url="http://${ip}"
+  else
+    ui_url="http://<server-ip>"
+  fi
+
+  cat <<EOF
+
+Matrix OS standalone install complete.
+
+Open: ${ui_url}
+User: matrix
+Password: $(cat /opt/matrix/env/initial-ui-password)
+
+Code editor: ${ui_url%/}/code/
+Home: ${MATRIX_HOME_DIR}
+
+Useful commands:
+  systemctl status matrix-gateway matrix-shell matrix-code nginx --no-pager
+  journalctl -u matrix-gateway -u matrix-shell -u matrix-code -n 200 --no-pager
+  sudo -u matrix bash
+
+This preview protects the web UI with nginx Basic Auth. Put the host behind
+HTTPS, Tailscale, Cloudflare Access, or another trusted edge before long-term use.
+EOF
+}
+
+main() {
+  require_root
+  require_linux_systemd
+  validate_config
+  install_packages
+  ensure_matrix_user
+  write_env
+  install_bundle
+  write_postgres_compose
+  install_systemd_units
+  configure_nginx
+  start_services
+  print_summary
+}
+
+main "$@"

--- a/scripts/install-server.sh
+++ b/scripts/install-server.sh
@@ -367,7 +367,12 @@ server {
   location /files/ { proxy_pass http://127.0.0.1:4000; }
   location /icons/ { proxy_pass http://127.0.0.1:4000; }
   location /apps/ { proxy_pass http://127.0.0.1:4000; }
-  location /health { proxy_pass http://127.0.0.1:4000; }
+  location = /health {
+    auth_basic off;
+    access_log off;
+    default_type application/json;
+    return 200 '{"ok":true}';
+  }
   location /gateway/ { proxy_pass http://127.0.0.1:4000/; }
 
   location /ws {

--- a/shell/src/app/layout.tsx
+++ b/shell/src/app/layout.tsx
@@ -83,7 +83,7 @@ export default async function RootLayout({
   children: React.ReactNode;
 }>) {
   const visitorCountry = getPostHogVisitorCountry(await headers());
-  const document = (
+  const renderDocument = (includePostHogIdentify: boolean) => (
     <html
       lang="en"
       data-posthog-visitor-country={visitorCountry ?? undefined}
@@ -94,7 +94,7 @@ export default async function RootLayout({
     >
       <body className={`${inter.variable} ${instrumentSans.variable} ${jetbrainsMono.variable} ${cormorant.variable} ${orbitron.variable}`}>
         {children}
-        <PostHogIdentify />
+        {includePostHogIdentify ? <PostHogIdentify /> : null}
         <PwaRegister />
         <InstallPrompt />
         <Toaster />
@@ -103,7 +103,7 @@ export default async function RootLayout({
   );
 
   if (process.env.MATRIX_SELF_HOSTED === "1") {
-    return document;
+    return renderDocument(false);
   }
 
   return (
@@ -112,7 +112,7 @@ export default async function RootLayout({
     // build time (default /sign-in and /sign-up); without them Clerk falls
     // back to the hosted Account Portal (accounts.matrix-os.com).
     <ClerkProvider>
-      {document}
+      {renderDocument(true)}
     </ClerkProvider>
   );
 }

--- a/shell/src/app/layout.tsx
+++ b/shell/src/app/layout.tsx
@@ -83,6 +83,28 @@ export default async function RootLayout({
   children: React.ReactNode;
 }>) {
   const visitorCountry = getPostHogVisitorCountry(await headers());
+  const document = (
+    <html
+      lang="en"
+      data-posthog-visitor-country={visitorCountry ?? undefined}
+      // Runtime replay kill switch: read on the server per request, so
+      // setting POSTHOG_DISABLE_REPLAY and restarting matrix-shell stops
+      // replay without rebuilding the bundle.
+      data-posthog-disable-replay={process.env.POSTHOG_DISABLE_REPLAY ? "1" : undefined}
+    >
+      <body className={`${inter.variable} ${instrumentSans.variable} ${jetbrainsMono.variable} ${cormorant.variable} ${orbitron.variable}`}>
+        {children}
+        <PostHogIdentify />
+        <PwaRegister />
+        <InstallPrompt />
+        <Toaster />
+      </body>
+    </html>
+  );
+
+  if (process.env.MATRIX_SELF_HOSTED === "1") {
+    return document;
+  }
 
   return (
     // ClerkProvider reads NEXT_PUBLIC_CLERK_SIGN_IN_URL / _SIGN_UP_URL to keep
@@ -90,22 +112,7 @@ export default async function RootLayout({
     // build time (default /sign-in and /sign-up); without them Clerk falls
     // back to the hosted Account Portal (accounts.matrix-os.com).
     <ClerkProvider>
-      <html
-        lang="en"
-        data-posthog-visitor-country={visitorCountry ?? undefined}
-        // Runtime replay kill switch: read on the server per request, so
-        // setting POSTHOG_DISABLE_REPLAY and restarting matrix-shell stops
-        // replay without rebuilding the bundle.
-        data-posthog-disable-replay={process.env.POSTHOG_DISABLE_REPLAY ? "1" : undefined}
-      >
-        <body className={`${inter.variable} ${instrumentSans.variable} ${jetbrainsMono.variable} ${cormorant.variable} ${orbitron.variable}`}>
-          {children}
-          <PostHogIdentify />
-          <PwaRegister />
-          <InstallPrompt />
-          <Toaster />
-        </body>
-      </html>
+      {document}
     </ClerkProvider>
   );
 }

--- a/shell/src/proxy.ts
+++ b/shell/src/proxy.ts
@@ -16,6 +16,7 @@ const authToken = process.env.MATRIX_AUTH_TOKEN;
 const expectedClerkUserId = process.env.MATRIX_CLERK_USER_ID;
 const platformUpgradeToken = process.env.UPGRADE_TOKEN;
 const configuredSignInUrl = process.env.NEXT_PUBLIC_CLERK_SIGN_IN_URL;
+const selfHostedMode = process.env.MATRIX_SELF_HOSTED === "1";
 
 interface ProxyRequestLike {
   headers: Headers;
@@ -125,6 +126,21 @@ export function proxy(
   // built app with production semantics. Use the explicit bypass flag alone so
   // screenshot runs can skip auth without depending on NODE_ENV.
   if (process.env.E2E_TEST_BYPASS === "1") {
+    if (isGatewayProxy(request)) {
+      return rewriteGatewayRequest(request);
+    }
+    return NextResponse.next();
+  }
+  // Standalone installs are protected at the local reverse proxy layer
+  // (nginx Basic Auth by default). The shell still injects the internal gateway
+  // bearer for same-origin API/file/WebSocket requests.
+  if (selfHostedMode) {
+    if (
+      request.headers.has(MATRIX_NATIVE_APP_SESSION_HEADER) ||
+      request.headers.has(MATRIX_PLATFORM_SESSION_HEADER)
+    ) {
+      return new NextResponse("Forbidden", { status: 403 });
+    }
     if (isGatewayProxy(request)) {
       return rewriteGatewayRequest(request);
     }

--- a/specs/103-self-host-installer/checklists/requirements.md
+++ b/specs/103-self-host-installer/checklists/requirements.md
@@ -1,0 +1,34 @@
+# Specification Quality Checklist: Self-Host Server Installer
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning  
+**Created**: 2026-06-30  
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- The spec intentionally treats bring-your-own Clerk and managed backup/integration parity as out of scope for the first self-host installer.

--- a/specs/103-self-host-installer/spec.md
+++ b/specs/103-self-host-installer/spec.md
@@ -1,0 +1,105 @@
+# Feature Specification: Self-Host Server Installer
+
+**Feature Branch**: `103-self-host-installer`  
+**Created**: 2026-06-30  
+**Status**: Draft  
+**Input**: User description: "sync with main, spec this out, and let's do it. We need proper docs on the docs page, update GitHub README as an option, add it to landing as one option, and host the script on the main domain."
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Install Matrix on an Existing VPS (Priority: P1)
+
+A developer with a fresh Linux VPS can run one command from `matrix-os.com`, answer no mandatory interactive prompts, and get a browser-accessible Matrix OS shell with gateway, terminal services, code-server, local Postgres, and optional coding tools starting under systemd.
+
+**Why this priority**: This is the core public promise for developers who want cloud coding without signing up for managed Matrix Cloud first.
+
+**Independent Test**: Run the installer against a supported apt-based Linux host or a fixture that validates the generated files, then confirm the documented URL, credentials, and services are produced.
+
+**Acceptance Scenarios**:
+
+1. **Given** a fresh supported VPS, **When** the user runs `curl -fsSL https://matrix-os.com/install-server.sh | sudo bash`, **Then** Matrix OS installs from a verified host bundle and starts the shell, gateway, code-server proxy, local Postgres, and nginx.
+2. **Given** the installer finishes, **When** the user opens the printed URL, **Then** the UI is protected by generated credentials and same-origin Matrix API calls reach the local gateway.
+3. **Given** code-server is not installed yet, **When** Matrix code services start, **Then** the existing tool-pack installer installs code-server asynchronously and the `/code/` path is available after startup.
+
+---
+
+### User Story 2 - Understand Self-Host Tradeoffs (Priority: P2)
+
+A developer comparing hosted Matrix Cloud and self-host Matrix can see exactly what they gain and miss before running the script.
+
+**Why this priority**: The public pitch must avoid overpromising managed-cloud parity while making the self-host option easy to choose.
+
+**Independent Test**: Review the docs, landing page, and README and confirm each surface names self-host as an option, shows the main-domain install command, and distinguishes managed features from self-host responsibilities.
+
+**Acceptance Scenarios**:
+
+1. **Given** a visitor on the landing page, **When** they review deployment options, **Then** self-host appears alongside hosted Matrix with a main-domain install command or docs link.
+2. **Given** a GitHub visitor, **When** they read the README quick start, **Then** they can choose hosted, self-hosted VPS, CLI, or source development without confusing the paths.
+3. **Given** a docs reader, **When** they open self-host docs, **Then** they see prerequisites, command, configuration, what is included, what is not included, and verification commands.
+
+---
+
+### User Story 3 - Keep the Installer Maintainable (Priority: P3)
+
+Maintainers can update the source installer and trust that the public website-hosted copy stays identical.
+
+**Why this priority**: The website must host the script on the main domain, but duplicated installer scripts are risky without drift prevention.
+
+**Independent Test**: Run a focused test that compares `scripts/install-server.sh` with `www/public/install-server.sh` and checks the installer contract for auth, checksum verification, systemd services, and main-domain docs.
+
+**Acceptance Scenarios**:
+
+1. **Given** the source installer changes, **When** tests run, **Then** they fail unless the `www/public` copy is updated.
+2. **Given** a future edit weakens auth or checksum behavior, **When** focused tests run, **Then** they catch the missing required behavior.
+
+### Edge Cases
+
+- Unsupported Linux distributions must fail before partial installation rather than attempting unknown package-manager commands.
+- Missing systemd must fail before writing service files.
+- Host bundle download or checksum mismatch must abort before extraction.
+- Existing Matrix installs must reuse the `matrix` user and Matrix directories without deleting owner data under `/home/matrix/home`.
+- Direct shell exposure on port 3000 must remain loopback-only; public access goes through nginx.
+- Browser requests carrying reserved Matrix platform/native session headers must be rejected in self-host mode.
+- Self-host docs must not imply managed routing, managed backups, Pipedream, Clerk session routing, mobile/desktop handoff, or fleet upgrades are available by default.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The system MUST provide a main-domain installer URL at `https://matrix-os.com/install-server.sh`.
+- **FR-002**: The installer MUST run as root and fail fast when root, Linux, or systemd prerequisites are missing.
+- **FR-003**: The installer MUST install only from a published host bundle and MUST verify the downloaded bundle against its `.sha256` before extraction.
+- **FR-004**: The installer MUST create or reuse a dedicated `matrix` system user and preserve owner-controlled data under the Matrix home directory.
+- **FR-005**: The installer MUST generate fresh local secrets for gateway bearer auth, code-server proxy auth, Postgres, and initial browser access.
+- **FR-006**: The installed shell MUST support an explicit self-host mode that bypasses Clerk while preserving gateway bearer injection for same-origin API, file, app, and WebSocket paths.
+- **FR-007**: The public browser surface MUST be protected by a local reverse proxy authentication layer by default.
+- **FR-008**: The installer MUST start Matrix services using systemd and provide verification commands to inspect status and logs.
+- **FR-009**: The docs MUST describe what self-host users gain and what they miss compared with managed Matrix Cloud.
+- **FR-010**: The README and landing page MUST present self-host install as a first-class option without replacing the hosted cloud path.
+- **FR-011**: The implementation MUST include tests that prevent drift between the source installer and website-hosted installer copy.
+
+### Security Architecture
+
+| Surface | Default auth | Notes |
+|---------|--------------|-------|
+| Public shell UI | nginx Basic Auth with generated password | Preview default for easy VPS installs; docs recommend HTTPS, Tailscale, Cloudflare Access, or equivalent for long-term use. |
+| Gateway API/files/apps/WebSocket | Internal `MATRIX_AUTH_TOKEN` injected by shell proxy | Public requests should reach these paths through the shell/nginx route, not directly to port 4000. |
+| code-server | Internal `MATRIX_CODE_PROXY_TOKEN` injected by nginx `/code/` route | code-server itself stays loopback and auth-free behind the Matrix proxy token. |
+| Local Postgres | Loopback only with generated password | App data remains owner-local on the VPS. |
+| Managed platform features | Not configured by default | Clerk/Pipedream/platform routing remain managed-cloud concerns unless a later BYO control-plane feature exists. |
+
+### Key Entities *(include if feature involves data)*
+
+- **Standalone Install Profile**: The generated local configuration that declares self-host mode, handle, local URLs, and generated secrets.
+- **Host Bundle**: The immutable runtime artifact containing Matrix app, shell, gateway, launchers, and systemd unit templates.
+- **Public Installer Copy**: The static website copy served from `matrix-os.com` and validated against the source installer.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: A supported VPS can reach a Matrix OS browser shell with one public command and no source build.
+- **SC-002**: The installer aborts before extraction on checksum mismatch.
+- **SC-003**: The shell runs in self-host mode without requiring Clerk, while gateway proxy requests still carry the internal bearer token.
+- **SC-004**: Public docs, README, and landing page all show self-host install as an option and use the main-domain script URL.
+- **SC-005**: Focused tests fail if the website-hosted installer copy diverges from the source installer.

--- a/tests/scripts/self-host-installer.test.ts
+++ b/tests/scripts/self-host-installer.test.ts
@@ -40,6 +40,31 @@ describe("self-host server installer", () => {
     expect(script).toContain("trap cleanup_install_tmp EXIT");
   });
 
+  it("reports privacy-scoped manual install telemetry with an opt-out", () => {
+    const script = readFileSync(join(root, "scripts/install-server.sh"), "utf8");
+    const route = readFileSync(join(root, "www/src/app/api/install-telemetry/route.ts"), "utf8");
+
+    expect(script).toContain("MATRIX_INSTALL_TELEMETRY_URL");
+    expect(script).toContain("MATRIX_NO_TELEMETRY");
+    expect(script).toContain("[ \"${MATRIX_INSTALL_TELEMETRY:-1}\" != \"0\" ]");
+    expect(script).toContain("matrix_manual_install_started");
+    expect(script).toContain("matrix_manual_install_completed");
+    expect(script).toContain("matrix_manual_install_failed");
+    expect(script).toContain("--max-time 3");
+    expect(script).toContain("installed_version");
+    expect(script).toContain("domain_mode");
+    expect(script).toContain("bundle_source");
+    expect(script).not.toContain("\"handle\"");
+    expect(script).not.toContain("MATRIX_INSTALL_HANDLE\",\"");
+
+    expect(route).toContain("MAX_BODY_BYTES = 4096");
+    expect(route).toContain("installTelemetrySchema");
+    expect(route).toContain("getPostHogClient().capture");
+    expect(route).toContain("matrix_manual_install_completed");
+    expect(route).toContain("install_surface: 'linux_vps_script'");
+    expect(route).toContain("$ip: '0.0.0.0'");
+  });
+
   it("protects the public surface with nginx basic auth and keeps services loopback", () => {
     const script = readFileSync(join(root, "scripts/install-server.sh"), "utf8");
 

--- a/tests/scripts/self-host-installer.test.ts
+++ b/tests/scripts/self-host-installer.test.ts
@@ -58,6 +58,10 @@ describe("self-host server installer", () => {
     expect(script).not.toContain("MATRIX_INSTALL_HANDLE\",\"");
 
     expect(route).toContain("MAX_BODY_BYTES = 4096");
+    expect(route).toContain("RATE_LIMIT_MAX_INSTALL_IDS");
+    expect(route).toContain("installTelemetryBuckets");
+    expect(route).toContain("allowInstallTelemetryEvent(input.installId)");
+    expect(route).toContain("return jsonResponse(429)");
     expect(route).toContain("readBoundedJson");
     expect(route).toContain("request.body?.getReader()");
     expect(route).toContain("totalBytes > MAX_BODY_BYTES");
@@ -76,6 +80,9 @@ describe("self-host server installer", () => {
 
     expect(script).toContain("auth_basic \"Matrix OS\"");
     expect(script).toContain("auth_basic_user_file /opt/matrix/env/nginx.htpasswd");
+    expect(script).toContain("location = /health");
+    expect(script).toContain("auth_basic off");
+    expect(script).toContain("return 200 '{\"ok\":true}'");
     expect(script).toContain("openssl passwd -apr1");
     expect(script).toContain("if [ ! -f /opt/matrix/env/nginx.htpasswd ]; then");
     expect(script).toContain("existing nginx Basic Auth credentials");

--- a/tests/scripts/self-host-installer.test.ts
+++ b/tests/scripts/self-host-installer.test.ts
@@ -58,8 +58,14 @@ describe("self-host server installer", () => {
     expect(script).not.toContain("MATRIX_INSTALL_HANDLE\",\"");
 
     expect(route).toContain("MAX_BODY_BYTES = 4096");
+    expect(route).toContain("readBoundedJson");
+    expect(route).toContain("request.body?.getReader()");
+    expect(route).toContain("totalBytes > MAX_BODY_BYTES");
+    expect(route).toContain("await reader.cancel()");
     expect(route).toContain("installTelemetrySchema");
-    expect(route).toContain("getPostHogClient().capture");
+    expect(route).toContain("const posthog = getPostHogClient()");
+    expect(route).toContain("posthog.capture");
+    expect(route).toContain("await shutdownPostHog()");
     expect(route).toContain("matrix_manual_install_completed");
     expect(route).toContain("install_surface: 'linux_vps_script'");
     expect(route).toContain("$ip: '0.0.0.0'");

--- a/tests/scripts/self-host-installer.test.ts
+++ b/tests/scripts/self-host-installer.test.ts
@@ -44,9 +44,12 @@ describe("self-host server installer", () => {
     expect(script).toContain("auth_basic \"Matrix OS\"");
     expect(script).toContain("auth_basic_user_file /opt/matrix/env/nginx.htpasswd");
     expect(script).toContain("openssl passwd -apr1");
+    expect(script).toContain("if [ ! -f /opt/matrix/env/nginx.htpasswd ]; then");
+    expect(script).toContain("existing nginx Basic Auth credentials");
     expect(script).toContain("code-proxy-token.conf");
     expect(script).toContain("chmod 0600 /opt/matrix/env/code-proxy-token.conf");
     expect(script).toContain("include /opt/matrix/env/code-proxy-token.conf");
+    expect(script).toContain("proxy_read_timeout 3600s");
     expect(script).toContain("proxy_pass http://127.0.0.1:3000");
     expect(script).toContain("proxy_pass http://127.0.0.1:4000");
     expect(script).toContain("proxy_pass http://127.0.0.1:8787");

--- a/tests/scripts/self-host-installer.test.ts
+++ b/tests/scripts/self-host-installer.test.ts
@@ -31,6 +31,11 @@ describe("self-host server installer", () => {
     expect(script).toContain("validate_config");
     expect(script).toContain("MATRIX_HOST_BUNDLE_URL must be https");
     expect(script).toContain("MATRIX_HOME must stay under /home/matrix");
+    expect(script).toContain("read_env_value /opt/matrix/env/host.env MATRIX_AUTH_TOKEN || random_secret");
+    expect(script).toContain("read_env_value /opt/matrix/env/host.env MATRIX_CODE_PROXY_TOKEN || random_secret");
+    expect(script).toContain("read_env_value /opt/matrix/env/postgres.env POSTGRES_PASSWORD || random_secret");
+    expect(script).toContain("cleanup_install_tmp");
+    expect(script).toContain("trap cleanup_install_tmp EXIT");
   });
 
   it("protects the public surface with nginx basic auth and keeps services loopback", () => {
@@ -39,12 +44,16 @@ describe("self-host server installer", () => {
     expect(script).toContain("auth_basic \"Matrix OS\"");
     expect(script).toContain("auth_basic_user_file /opt/matrix/env/nginx.htpasswd");
     expect(script).toContain("openssl passwd -apr1");
+    expect(script).toContain("code-proxy-token.conf");
+    expect(script).toContain("chmod 0600 /opt/matrix/env/code-proxy-token.conf");
+    expect(script).toContain("include /opt/matrix/env/code-proxy-token.conf");
     expect(script).toContain("proxy_pass http://127.0.0.1:3000");
     expect(script).toContain("proxy_pass http://127.0.0.1:4000");
     expect(script).toContain("proxy_pass http://127.0.0.1:8787");
-    expect(script).toContain("proxy_set_header X-Matrix-Code-Proxy-Token");
+    expect(script).toContain("proxy_set_header X-Matrix-Code-Proxy-Token \"%s\"");
     expect(script).toContain("-p 127.0.0.1:5432:5432");
     expect(script).not.toContain("-p 5432:5432");
+    expect(script).not.toContain("grep '^MATRIX_CODE_PROXY_TOKEN='");
   });
 
   it("installs the core Matrix services without enabling managed-cloud backup requirements", () => {
@@ -58,6 +67,8 @@ describe("self-host server installer", () => {
     expect(script).toContain("systemctl enable docker matrix-restore matrix-gateway matrix-shell matrix-code matrix-code-server");
     expect(script).toContain("systemctl enable --now docker");
     expect(script).not.toContain("systemctl restart docker");
+    expect(script).not.toContain("write_postgres_compose");
+    expect(script).not.toContain("postgres-compose.yml");
     expect(script).not.toContain("NOPASSWD:ALL");
     expect(script).not.toContain("systemctl enable matrix-db-backup");
     expect(script).not.toContain("systemctl enable matrix-sync-agent");

--- a/tests/scripts/self-host-installer.test.ts
+++ b/tests/scripts/self-host-installer.test.ts
@@ -1,0 +1,65 @@
+import { readFileSync, statSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const root = process.cwd();
+
+describe("self-host server installer", () => {
+  it("keeps the website-hosted installer identical to the source installer", () => {
+    const source = readFileSync(join(root, "scripts/install-server.sh"), "utf8");
+    const website = readFileSync(join(root, "www/public/install-server.sh"), "utf8");
+
+    expect(website).toBe(source);
+    expect(statSync(join(root, "scripts/install-server.sh")).mode & 0o111).not.toBe(0);
+    expect(statSync(join(root, "www/public/install-server.sh")).mode & 0o111).not.toBe(0);
+  });
+
+  it("installs from a verified host bundle and writes standalone self-host configuration", () => {
+    const script = readFileSync(join(root, "scripts/install-server.sh"), "utf8");
+
+    expect(script).toContain("https://app.matrix-os.com/system-bundles/${DEFAULT_CHANNEL}");
+    expect(script).toContain("MATRIX_HOST_BUNDLE_URL");
+    expect(script).toContain("${MATRIX_HOST_BUNDLE_URL}.sha256");
+    expect(script).toContain("sha256sum \"$tmp_bundle\"");
+    expect(script).toContain("[ \"$expected\" = \"$actual\" ] || fail \"bundle checksum mismatch\"");
+    expect(script).toContain("tar -xzf \"$tmp_bundle\" -C /opt/matrix");
+    expect(script).toContain("MATRIX_SELF_HOSTED=1");
+    expect(script).toContain("MATRIX_AUTH_TOKEN=${auth_token}");
+    expect(script).toContain("MATRIX_CODE_PROXY_TOKEN=${code_token}");
+    expect(script).toContain("DATABASE_URL=postgresql://matrix:${postgres_password}@127.0.0.1:5432/matrix");
+    expect(script).toContain("NEXT_PUBLIC_GATEWAY_WS=/ws");
+    expect(script).toContain("validate_config");
+    expect(script).toContain("MATRIX_HOST_BUNDLE_URL must be https");
+    expect(script).toContain("MATRIX_HOME must stay under /home/matrix");
+  });
+
+  it("protects the public surface with nginx basic auth and keeps services loopback", () => {
+    const script = readFileSync(join(root, "scripts/install-server.sh"), "utf8");
+
+    expect(script).toContain("auth_basic \"Matrix OS\"");
+    expect(script).toContain("auth_basic_user_file /opt/matrix/env/nginx.htpasswd");
+    expect(script).toContain("openssl passwd -apr1");
+    expect(script).toContain("proxy_pass http://127.0.0.1:3000");
+    expect(script).toContain("proxy_pass http://127.0.0.1:4000");
+    expect(script).toContain("proxy_pass http://127.0.0.1:8787");
+    expect(script).toContain("proxy_set_header X-Matrix-Code-Proxy-Token");
+    expect(script).toContain("-p 127.0.0.1:5432:5432");
+    expect(script).not.toContain("-p 5432:5432");
+  });
+
+  it("installs the core Matrix services without enabling managed-cloud backup requirements", () => {
+    const script = readFileSync(join(root, "scripts/install-server.sh"), "utf8");
+
+    expect(script).toContain("install -m 0644 /opt/matrix/systemd/matrix-gateway.service");
+    expect(script).toContain("install -m 0644 /opt/matrix/systemd/matrix-shell.service");
+    expect(script).toContain("install -m 0644 /opt/matrix/systemd/matrix-code.service");
+    expect(script).toContain("install -m 0644 /opt/matrix/systemd/matrix-code-server.service");
+    expect(script).toContain("write_self_host_restore_service");
+    expect(script).toContain("systemctl enable docker matrix-restore matrix-gateway matrix-shell matrix-code matrix-code-server");
+    expect(script).toContain("systemctl enable --now docker");
+    expect(script).not.toContain("systemctl restart docker");
+    expect(script).not.toContain("NOPASSWD:ALL");
+    expect(script).not.toContain("systemctl enable matrix-db-backup");
+    expect(script).not.toContain("systemctl enable matrix-sync-agent");
+  });
+});

--- a/tests/scripts/self-host-installer.test.ts
+++ b/tests/scripts/self-host-installer.test.ts
@@ -31,6 +31,8 @@ describe("self-host server installer", () => {
     expect(script).toContain("validate_config");
     expect(script).toContain("MATRIX_HOST_BUNDLE_URL must be https");
     expect(script).toContain("MATRIX_HOME must stay under /home/matrix");
+    expect(script).toContain("[ \"${#MATRIX_DOMAIN}\" -le 253 ]");
+    expect(script).toContain("[[ \"$MATRIX_DOMAIN\" =~ ^[A-Za-z0-9]");
     expect(script).toContain("read_env_value /opt/matrix/env/host.env MATRIX_AUTH_TOKEN || random_secret");
     expect(script).toContain("read_env_value /opt/matrix/env/host.env MATRIX_CODE_PROXY_TOKEN || random_secret");
     expect(script).toContain("read_env_value /opt/matrix/env/postgres.env POSTGRES_PASSWORD || random_secret");

--- a/tests/shell/proxy-auth.test.ts
+++ b/tests/shell/proxy-auth.test.ts
@@ -1,4 +1,6 @@
 import { afterEach, describe, it, expect, vi } from "vitest";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
 import {
   isPlatformMobileAppSessionRequest,
   isPublicShellPath,
@@ -361,6 +363,116 @@ describe("proxy auth: trusted platform native app sessions", () => {
 
     expect(response).toBeInstanceOf(Response);
     expect(response.status).toBe(403);
+  });
+});
+
+describe("proxy auth: self-host mode", () => {
+  afterEach(() => {
+    vi.resetModules();
+    vi.unstubAllEnvs();
+    vi.doUnmock("@clerk/nextjs/server");
+    vi.doUnmock("next/server");
+  });
+
+  it("serves shell pages without Clerk and still injects gateway auth for proxy paths", async () => {
+    vi.resetModules();
+    vi.stubEnv("MATRIX_SELF_HOSTED", "1");
+    vi.stubEnv("MATRIX_AUTH_TOKEN", "self-host-gateway-token");
+    vi.stubEnv("GATEWAY_URL", "http://127.0.0.1:4000");
+
+    const clerkRequestHandler = vi.fn(async (request: unknown, event: unknown) => ({
+      kind: "clerk",
+      request,
+      event,
+    }));
+    const clerkMiddleware = vi.fn(() => clerkRequestHandler);
+    vi.doMock("@clerk/nextjs/server", () => ({ clerkMiddleware }));
+
+    const nextResponseNext = vi.fn((init?: unknown) => ({ kind: "next", init }));
+    const nextResponseRewrite = vi.fn((url: URL, init?: { request?: { headers?: Headers } }) => ({
+      kind: "rewrite",
+      url,
+      init,
+    }));
+    class MockNextResponse extends Response {
+      static next = nextResponseNext;
+      static rewrite = nextResponseRewrite;
+      static redirect = vi.fn((url: URL) => ({ kind: "redirect", url }));
+    }
+    vi.doMock("next/server", () => ({ NextResponse: MockNextResponse }));
+
+    const { proxy } = await import("../../shell/src/proxy");
+
+    const shellResponse = proxy({
+      headers: new Headers(),
+      nextUrl: {
+        host: "matrix.example.com",
+        pathname: "/",
+        protocol: "http:",
+        search: "",
+      },
+    } as Parameters<typeof proxy>[0], {} as Parameters<typeof proxy>[1]);
+
+    proxy({
+      headers: new Headers(),
+      nextUrl: {
+        host: "matrix.example.com",
+        pathname: "/api/shell/bootstrap",
+        protocol: "http:",
+        search: "",
+      },
+    } as Parameters<typeof proxy>[0], {} as Parameters<typeof proxy>[1]);
+
+    expect(shellResponse).toEqual({ kind: "next", init: undefined });
+    expect(clerkMiddleware).toHaveBeenCalledTimes(1);
+    expect(clerkRequestHandler).not.toHaveBeenCalled();
+    expect(nextResponseRewrite).toHaveBeenCalledTimes(1);
+    const [url, init] = nextResponseRewrite.mock.calls[0] ?? [];
+    expect(url?.toString()).toBe("http://127.0.0.1:4000/api/shell/bootstrap");
+    expect(init?.request?.headers?.get("authorization")).toBe("Bearer self-host-gateway-token");
+  });
+
+  it("rejects reserved platform session markers in self-host mode", async () => {
+    vi.resetModules();
+    vi.stubEnv("MATRIX_SELF_HOSTED", "1");
+
+    vi.doMock("@clerk/nextjs/server", () => ({
+      clerkMiddleware: vi.fn((handler) => handler),
+    }));
+
+    class MockNextResponse extends Response {
+      static next = vi.fn((init?: unknown) => ({ kind: "next", init }));
+      static rewrite = vi.fn((url: URL, init?: unknown) => ({ kind: "rewrite", url, init }));
+      static redirect = vi.fn((url: URL) => ({ kind: "redirect", url }));
+    }
+    vi.doMock("next/server", () => ({ NextResponse: MockNextResponse }));
+
+    const { proxy } = await import("../../shell/src/proxy");
+
+    const response = proxy({
+      headers: new Headers({
+        "x-matrix-platform-session": "platform",
+      }),
+      nextUrl: {
+        host: "matrix.example.com",
+        pathname: "/",
+        protocol: "http:",
+        search: "",
+      },
+    } as Parameters<typeof proxy>[0], {} as Parameters<typeof proxy>[1]);
+
+    expect(response).toBeInstanceOf(Response);
+    expect(response.status).toBe(403);
+  });
+
+  it("skips ClerkProvider at shell render time in self-host mode", () => {
+    const layout = readFileSync(join(process.cwd(), "shell/src/app/layout.tsx"), "utf8");
+
+    expect(layout).toContain('process.env.MATRIX_SELF_HOSTED === "1"');
+    expect(layout).toContain("return document;");
+    expect(layout.indexOf('process.env.MATRIX_SELF_HOSTED === "1"')).toBeLessThan(
+      layout.indexOf("<ClerkProvider>"),
+    );
   });
 });
 

--- a/tests/shell/proxy-auth.test.ts
+++ b/tests/shell/proxy-auth.test.ts
@@ -469,9 +469,13 @@ describe("proxy auth: self-host mode", () => {
     const layout = readFileSync(join(process.cwd(), "shell/src/app/layout.tsx"), "utf8");
 
     expect(layout).toContain('process.env.MATRIX_SELF_HOSTED === "1"');
-    expect(layout).toContain("return document;");
+    expect(layout).toContain("return renderDocument(false);");
+    expect(layout).toContain("{includePostHogIdentify ? <PostHogIdentify /> : null}");
     expect(layout.indexOf('process.env.MATRIX_SELF_HOSTED === "1"')).toBeLessThan(
       layout.indexOf("<ClerkProvider>"),
+    );
+    expect(layout.indexOf("return renderDocument(false);")).toBeLessThan(
+      layout.indexOf("renderDocument(true)"),
     );
   });
 });

--- a/tests/www/self-host-docs.test.ts
+++ b/tests/www/self-host-docs.test.ts
@@ -18,13 +18,19 @@ describe("self-host public docs", () => {
     expect(docs).toContain("nginx Basic Auth");
     expect(docs).toContain("server IP address");
     expect(docs).toContain("No domain is required");
+    expect(docs).toContain("Manual Install Telemetry");
+    expect(docs).toContain("MATRIX_NO_TELEMETRY=1");
+    expect(docs).toContain("does not send your Matrix handle");
     expect(docs).toContain("Do not expose ports `3000`, `4000`, `8787`, or `5432` publicly");
     expect(meta).toContain("\"self-host\"");
-    expect(readme).toContain("### Self-host on Your VPS");
+    expect(readme).toContain("### Managed Matrix Cloud");
+    expect(readme).toContain("### Manual VPS Install");
     expect(readme).toContain(installUrl);
     expect(readme).toContain("A domain is optional");
     expect(readme).toContain("Self-host docs");
-    expect(quickstart).toContain("[Self-host](/docs/self-host)");
+    expect(quickstart).toContain("Managed Matrix Cloud");
+    expect(quickstart).toContain("Manual VPS install");
+    expect(quickstart).toContain("A domain is optional for first boot");
   });
 
   it("adds self-host as a landing-page deployment option", () => {
@@ -32,9 +38,11 @@ describe("self-host public docs", () => {
     const deployment = readFileSync(join(root, "www/src/components/landing/DeploymentSection.tsx"), "utf8");
 
     expect(page).toContain("<DeploymentSection />");
-    expect(deployment).toContain("Self-host Matrix");
+    expect(deployment).toContain("Managed Matrix Cloud");
+    expect(deployment).toContain("Manual VPS install");
     expect(deployment).toContain("Install from the main domain on your own Linux VPS");
     expect(deployment).toContain("href=\"/docs/self-host\"");
-    expect(deployment).toContain("Hosted, self-hosted, or guided for organizations.");
+    expect(deployment).toContain("Choose managed or manual install.");
+    expect(deployment).toContain("Start with Matrix Cloud, or bring your own Linux VPS.");
   });
 });

--- a/tests/www/self-host-docs.test.ts
+++ b/tests/www/self-host-docs.test.ts
@@ -16,10 +16,13 @@ describe("self-host public docs", () => {
     expect(docs).toContain("Matrix Cloud");
     expect(docs).toContain("Self-host preview");
     expect(docs).toContain("nginx Basic Auth");
+    expect(docs).toContain("server IP address");
+    expect(docs).toContain("No domain is required");
     expect(docs).toContain("Do not expose ports `3000`, `4000`, `8787`, or `5432` publicly");
     expect(meta).toContain("\"self-host\"");
     expect(readme).toContain("### Self-host on Your VPS");
     expect(readme).toContain(installUrl);
+    expect(readme).toContain("A domain is optional");
     expect(readme).toContain("Self-host docs");
     expect(quickstart).toContain("[Self-host](/docs/self-host)");
   });

--- a/tests/www/self-host-docs.test.ts
+++ b/tests/www/self-host-docs.test.ts
@@ -1,0 +1,37 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const root = process.cwd();
+const installUrl = "https://matrix-os.com/install-server.sh";
+
+describe("self-host public docs", () => {
+  it("documents the main-domain server installer in docs and README", () => {
+    const docs = readFileSync(join(root, "www/content/docs/self-host.mdx"), "utf8");
+    const meta = readFileSync(join(root, "www/content/docs/meta.json"), "utf8");
+    const readme = readFileSync(join(root, "README.md"), "utf8");
+    const quickstart = readFileSync(join(root, "www/content/docs/quickstart.mdx"), "utf8");
+
+    expect(docs).toContain(installUrl);
+    expect(docs).toContain("Matrix Cloud");
+    expect(docs).toContain("Self-host preview");
+    expect(docs).toContain("nginx Basic Auth");
+    expect(docs).toContain("Do not expose ports `3000`, `4000`, `8787`, or `5432` publicly");
+    expect(meta).toContain("\"self-host\"");
+    expect(readme).toContain("### Self-host on Your VPS");
+    expect(readme).toContain(installUrl);
+    expect(readme).toContain("Self-host docs");
+    expect(quickstart).toContain("[Self-host](/docs/self-host)");
+  });
+
+  it("adds self-host as a landing-page deployment option", () => {
+    const page = readFileSync(join(root, "www/src/app/page.tsx"), "utf8");
+    const deployment = readFileSync(join(root, "www/src/components/landing/DeploymentSection.tsx"), "utf8");
+
+    expect(page).toContain("<DeploymentSection />");
+    expect(deployment).toContain("Self-host Matrix");
+    expect(deployment).toContain("Install from the main domain on your own Linux VPS");
+    expect(deployment).toContain("href=\"/docs/self-host\"");
+    expect(deployment).toContain("Hosted, self-hosted, or guided for organizations.");
+  });
+});

--- a/www/content/docs/meta.json
+++ b/www/content/docs/meta.json
@@ -2,6 +2,7 @@
   "pages": [
     "index",
     "quickstart",
+    "self-host",
     "cli",
     "shell",
     "coding-agents",

--- a/www/content/docs/quickstart.mdx
+++ b/www/content/docs/quickstart.mdx
@@ -9,6 +9,10 @@ import { Step, Steps } from 'fumadocs-ui/components/steps';
 
 This guide walks you through signing up, choosing a compute plan, completing billing, waiting for your Matrix computer to provision, and then authenticating GitHub and cloning a repository inside the web shell.
 
+<Callout type="info" title="Want to bring your own VPS?">
+  Use [Self-host](/docs/self-host) if you want to install Matrix OS on an existing Linux VPS instead of using managed Matrix Cloud.
+</Callout>
+
 ## Fastest path: paste the setup prompt
 
 If you prefer to hand setup to an agent, paste this prompt into Claude Code, Codex, or another terminal agent after your Matrix computer is provisioned:
@@ -116,6 +120,9 @@ Use `Ctrl-\ Ctrl-\` to detach from an attached terminal session without killing 
 <Cards>
   <Card title="Matrix CLI" href="/docs/cli">
     Install the CLI on your laptop to attach to shell sessions, sync files, and run coding agents from your local terminal.
+  </Card>
+  <Card title="Self-host" href="/docs/self-host">
+    Install Matrix OS on your own Linux VPS with the main-domain server installer.
   </Card>
   <Card title="Web shell" href="/docs/shell">
     Learn Terminal tabs, Canvas mode, the app sidebar, and shell keyboard shortcuts.

--- a/www/content/docs/quickstart.mdx
+++ b/www/content/docs/quickstart.mdx
@@ -7,10 +7,21 @@ import { Callout } from 'fumadocs-ui/components/callout';
 import { Card, Cards } from 'fumadocs-ui/components/card';
 import { Step, Steps } from 'fumadocs-ui/components/steps';
 
-This guide walks you through signing up, choosing a compute plan, completing billing, waiting for your Matrix computer to provision, and then authenticating GitHub and cloning a repository inside the web shell.
+This guide walks you through the two Matrix OS install paths: managed Matrix Cloud, or a manual VPS install for operators who want to bring their own Linux server.
 
-<Callout type="info" title="Want to bring your own VPS?">
-  Use [Self-host](/docs/self-host) if you want to install Matrix OS on an existing Linux VPS instead of using managed Matrix Cloud.
+## Choose your install path
+
+<Cards>
+  <Card title="Managed Matrix Cloud" href="https://app.matrix-os.com">
+    Matrix provisions the cloud computer, routing, auth, updates, backups, billing, and integrations. This is the recommended path for daily work, teams, and pilots.
+  </Card>
+  <Card title="Manual VPS install" href="/docs/self-host">
+    Run the main-domain installer on an apt-based Linux VPS you control. You operate DNS, TLS, backups, upgrades, integrations, and server security.
+  </Card>
+</Cards>
+
+<Callout type="info" title="Manual installs can start from a server IP">
+  A domain is optional for first boot. For long-running public use, put the instance behind DNS plus TLS, Tailscale, Cloudflare Access, or another trusted edge.
 </Callout>
 
 ## Fastest path: paste the setup prompt
@@ -35,7 +46,7 @@ Do not scan my local machine for credentials. Do not upload local private keys. 
 
 Use `Ctrl-\ Ctrl-\` to detach from an attached terminal session without killing the remote process.
 
-## Manual setup
+## Managed setup
 
 <Steps>
   <Step>

--- a/www/content/docs/self-host.mdx
+++ b/www/content/docs/self-host.mdx
@@ -110,9 +110,11 @@ IP-only installs are acceptable for first boot and private-network testing, but 
 
 Do not expose ports `3000`, `4000`, `8787`, or `5432` publicly. Keep them on loopback and expose only your hardened reverse proxy.
 
+The installer leaves `GET /health` open at nginx and returns only `{"ok":true}` so basic uptime monitors can check the public edge without credentials or gateway details. For deeper checks, use systemd status or local-only gateway health from the server.
+
 ## Manual Install Telemetry
 
-The installer sends lightweight, best-effort telemetry to Matrix OS so we can see how many people choose the manual path, which release channel/version they reach, whether installs finish, and where failures happen. It records an anonymous install id, channel, installed version, IP-vs-DNS mode, default-vs-custom bundle source, selected developer-tool count, phase, status, and exit code.
+The installer sends lightweight, best-effort telemetry to Matrix OS so we can see how many people choose the manual path, which release channel/version they reach, whether installs finish, and where failures happen. The endpoint has a bounded request body and short-window rate limits to keep the signal useful. It records an anonymous install id, channel, installed version, IP-vs-DNS mode, default-vs-custom bundle source, selected developer-tool count, phase, status, and exit code.
 
 It does not send your Matrix handle, password, auth tokens, Postgres password, domain name, project files, shell output, or code-server URL. The website telemetry endpoint also asks PostHog to discard client IP by setting `$ip` to `0.0.0.0`.
 

--- a/www/content/docs/self-host.mdx
+++ b/www/content/docs/self-host.mdx
@@ -110,6 +110,24 @@ IP-only installs are acceptable for first boot and private-network testing, but 
 
 Do not expose ports `3000`, `4000`, `8787`, or `5432` publicly. Keep them on loopback and expose only your hardened reverse proxy.
 
+## Manual Install Telemetry
+
+The installer sends lightweight, best-effort telemetry to Matrix OS so we can see how many people choose the manual path, which release channel/version they reach, whether installs finish, and where failures happen. It records an anonymous install id, channel, installed version, IP-vs-DNS mode, default-vs-custom bundle source, selected developer-tool count, phase, status, and exit code.
+
+It does not send your Matrix handle, password, auth tokens, Postgres password, domain name, project files, shell output, or code-server URL. The website telemetry endpoint also asks PostHog to discard client IP by setting `$ip` to `0.0.0.0`.
+
+Opt out per install:
+
+```bash
+curl -fsSL https://matrix-os.com/install-server.sh | sudo MATRIX_NO_TELEMETRY=1 bash
+```
+
+Or disable only installer telemetry:
+
+```bash
+curl -fsSL https://matrix-os.com/install-server.sh | sudo MATRIX_INSTALL_TELEMETRY=0 bash
+```
+
 ## Next Steps
 
 <Cards>

--- a/www/content/docs/self-host.mdx
+++ b/www/content/docs/self-host.mdx
@@ -1,0 +1,118 @@
+---
+title: Self-host
+description: Install Matrix OS on your own Linux VPS with the main-domain server installer.
+---
+
+import { Callout } from 'fumadocs-ui/components/callout';
+import { Card, Cards } from 'fumadocs-ui/components/card';
+import { Step, Steps } from 'fumadocs-ui/components/steps';
+
+Self-host Matrix OS when you want the cloud-coding computer on infrastructure you control. The installer uses the same published host bundle shape as Matrix Cloud, then configures a standalone profile with local Postgres, systemd services, nginx, the web shell, gateway, code-server, and optional coding-agent tools.
+
+```bash
+curl -fsSL https://matrix-os.com/install-server.sh | sudo bash
+```
+
+<Callout type="warn" title="Preview self-host path">
+The self-host installer is for developers comfortable operating a VPS. Matrix Cloud still provides managed routing, Clerk auth, backups, updates, billing, and integrations. Self-host installs start with nginx Basic Auth and should be put behind HTTPS, Tailscale, Cloudflare Access, or another trusted edge for long-term use.
+</Callout>
+
+## Requirements
+
+- A fresh apt-based Linux VPS with systemd.
+- Root or sudo access.
+- Ports 80 and the internal loopback service ports available.
+- Enough disk for the Matrix host bundle, local Postgres, projects, and coding tools.
+- Optional DNS record pointing at the server before install.
+
+## Install
+
+<Steps>
+  <Step>
+    ### Create or choose a VPS
+
+    Start from a clean Ubuntu or Debian-style server. A small development host works for evaluation; use more CPU and memory if you plan to run multiple coding agents and dev servers.
+  </Step>
+
+  <Step>
+    ### Run the main-domain installer
+
+    ```bash
+    curl -fsSL https://matrix-os.com/install-server.sh | sudo bash
+    ```
+
+    Optional configuration:
+
+    ```bash
+    curl -fsSL https://matrix-os.com/install-server.sh | sudo \
+      MATRIX_DOMAIN=matrix.example.com \
+      MATRIX_INSTALL_HANDLE=alice \
+      MATRIX_DEVELOPER_TOOLS="codex claude-code opencode" \
+      bash
+    ```
+  </Step>
+
+  <Step>
+    ### Open the printed URL
+
+    The installer prints the URL, username, generated password, and code-server path. Store the initial password somewhere safe, then replace the edge auth with your preferred HTTPS and access-control setup.
+  </Step>
+
+  <Step>
+    ### Verify services
+
+    ```bash
+    systemctl status matrix-gateway matrix-shell matrix-code nginx --no-pager
+    journalctl -u matrix-gateway -u matrix-shell -u matrix-code -n 200 --no-pager
+    sudo -u matrix bash
+    ```
+  </Step>
+</Steps>
+
+## What You Get
+
+- Matrix web shell on your VPS.
+- Gateway API and WebSocket services protected by an internal bearer token.
+- Local owner-controlled Postgres on `127.0.0.1`.
+- code-server behind the Matrix code proxy at `/code/`.
+- Persistent home directory at `/home/matrix/home`.
+- Optional Claude Code, Codex, OpenCode, and Pi CLI installs through Matrix tool packs.
+- Source-free install from a verified host bundle.
+
+## What You Manage
+
+- DNS and TLS.
+- Server firewalling, OS updates, and SSH access.
+- Backups and restore policy.
+- Upgrades to newer Matrix host bundles.
+- Edge auth hardening beyond the generated nginx Basic Auth.
+- Any external integration secrets.
+
+## Differences From Matrix Cloud
+
+| Capability | Matrix Cloud | Self-host preview |
+|------------|--------------|-------------------|
+| Provisioning | Managed VPS creation | Bring your own VPS |
+| Auth | Clerk and platform sessions | Generated nginx Basic Auth |
+| Routing | `app.matrix-os.com` and `code.matrix-os.com` | Your domain or server IP |
+| Backups | Managed platform path | You configure backups |
+| Updates | Platform release fan-out | Manual installer/update path |
+| Integrations | Platform-owned Pipedream | Not configured by default |
+| Mobile and desktop handoff | Upcoming managed surfaces | Not included yet |
+
+## Security Notes
+
+The shell runs in explicit standalone mode. Public browser access is expected to go through nginx, while same-origin API, file, app, and WebSocket requests are rewritten by the shell proxy with the internal `MATRIX_AUTH_TOKEN`. code-server runs loopback-only and is reached through a token-protected Matrix proxy.
+
+Do not expose ports `3000`, `4000`, `8787`, or `5432` publicly. Keep them on loopback and expose only your hardened reverse proxy.
+
+## Next Steps
+
+<Cards>
+  <Card title="CLI" href="/docs/cli">
+    Install the Matrix CLI on your laptop for hosted Matrix Cloud workflows.
+  </Card>
+  <Card title="Coding Agents" href="/docs/coding-agents">
+    Install and authenticate Claude, Codex, OpenCode, or Pi inside your Matrix computer.
+  </Card>
+</Cards>

--- a/www/content/docs/self-host.mdx
+++ b/www/content/docs/self-host.mdx
@@ -14,7 +14,7 @@ curl -fsSL https://matrix-os.com/install-server.sh | sudo bash
 ```
 
 <Callout type="warn" title="Preview self-host path">
-The self-host installer is for developers comfortable operating a VPS. Matrix Cloud still provides managed routing, Clerk auth, backups, updates, billing, and integrations. Self-host installs start with nginx Basic Auth and should be put behind HTTPS, Tailscale, Cloudflare Access, or another trusted edge for long-term use.
+The self-host installer is for developers comfortable operating a VPS. Matrix Cloud still provides managed routing, Clerk auth, backups, updates, billing, and integrations. Self-host installs start with nginx Basic Auth and can work from the server IP address; put the host behind HTTPS, Tailscale, Cloudflare Access, or another trusted edge for long-term use.
 </Callout>
 
 ## Requirements
@@ -23,7 +23,7 @@ The self-host installer is for developers comfortable operating a VPS. Matrix Cl
 - Root or sudo access.
 - Ports 80 and the internal loopback service ports available.
 - Enough disk for the Matrix host bundle, local Postgres, projects, and coding tools.
-- Optional DNS record pointing at the server before install.
+- Optional DNS record pointing at the server before install. If you skip DNS, the installer uses the server IP/default nginx vhost.
 
 ## Install
 
@@ -40,6 +40,8 @@ The self-host installer is for developers comfortable operating a VPS. Matrix Cl
     ```bash
     curl -fsSL https://matrix-os.com/install-server.sh | sudo bash
     ```
+
+    No domain is required. The default `MATRIX_DOMAIN=_` makes nginx answer on the server IP address and the installer prints an `http://<server-ip>` URL.
 
     Optional configuration:
 
@@ -103,6 +105,8 @@ The self-host installer is for developers comfortable operating a VPS. Matrix Cl
 ## Security Notes
 
 The shell runs in explicit standalone mode. Public browser access is expected to go through nginx, while same-origin API, file, app, and WebSocket requests are rewritten by the shell proxy with the internal `MATRIX_AUTH_TOKEN`. code-server runs loopback-only and is reached through a token-protected Matrix proxy.
+
+IP-only installs are acceptable for first boot and private-network testing, but they are plain HTTP unless you add a trusted TLS/access layer. For a public VPS, prefer DNS plus TLS, Tailscale, Cloudflare Access/Tunnel, or another authenticated reverse proxy before storing long-lived work there.
 
 Do not expose ports `3000`, `4000`, `8787`, or `5432` publicly. Keep them on loopback and expose only your hardened reverse proxy.
 

--- a/www/public/install-server.sh
+++ b/www/public/install-server.sh
@@ -11,6 +11,14 @@ MATRIX_INSTALL_HANDLE="${MATRIX_INSTALL_HANDLE:-matrix}"
 MATRIX_DOMAIN="${MATRIX_DOMAIN:-_}"
 MATRIX_HOME_DIR="${MATRIX_HOME:-/home/matrix/home}"
 MATRIX_DEVELOPER_TOOLS="${MATRIX_DEVELOPER_TOOLS:-codex claude-code opencode pi}"
+INSTALL_TMP_BUNDLE=""
+INSTALL_TMP_SUM=""
+
+cleanup_install_tmp() {
+  [ -z "$INSTALL_TMP_BUNDLE" ] || rm -f "$INSTALL_TMP_BUNDLE"
+  [ -z "$INSTALL_TMP_SUM" ] || rm -f "$INSTALL_TMP_SUM"
+}
+trap cleanup_install_tmp EXIT
 
 log() {
   printf 'matrix-server-install: %s\n' "$*"
@@ -99,11 +107,21 @@ random_secret() {
   openssl rand -base64 32 | tr -d '\n'
 }
 
+read_env_value() {
+  local file key value
+  file="$1"
+  key="$2"
+  [ -f "$file" ] || return 1
+  value="$(awk -F= -v key="$key" '$1 == key {sub(/^[^=]*=/, ""); print; exit}' "$file")"
+  [ -n "$value" ] || return 1
+  printf '%s\n' "$value"
+}
+
 write_env() {
   local auth_token code_token postgres_password
-  auth_token="$(random_secret)"
-  code_token="$(random_secret)"
-  postgres_password="$(random_secret | tr '/+' 'ab')"
+  auth_token="$(read_env_value /opt/matrix/env/host.env MATRIX_AUTH_TOKEN || random_secret)"
+  code_token="$(read_env_value /opt/matrix/env/host.env MATRIX_CODE_PROXY_TOKEN || random_secret)"
+  postgres_password="$(read_env_value /opt/matrix/env/postgres.env POSTGRES_PASSWORD || random_secret | tr '/+' 'ab')"
 
   cat >/opt/matrix/env/postgres.env <<EOF
 POSTGRES_DB=matrix
@@ -138,8 +156,10 @@ EOF
 
 install_bundle() {
   local tmp_bundle tmp_sum expected actual
-  tmp_bundle="/tmp/matrix-host-bundle.tar.gz"
-  tmp_sum="/tmp/matrix-host-bundle.tar.gz.sha256"
+  tmp_bundle="$(mktemp /tmp/matrix-host-bundle.XXXXXX.tar.gz)"
+  tmp_sum="$(mktemp /tmp/matrix-host-bundle.XXXXXX.tar.gz.sha256)"
+  INSTALL_TMP_BUNDLE="$tmp_bundle"
+  INSTALL_TMP_SUM="$tmp_sum"
 
   log "downloading host bundle"
   curl --fail --location --retry 3 --retry-delay 5 --retry-all-errors \
@@ -157,25 +177,9 @@ install_bundle() {
   log "extracting host bundle"
   tar -xzf "$tmp_bundle" -C /opt/matrix
   chmod 0755 /opt/matrix/bin/matrix-* /opt/matrix/bin/zellij 2>/dev/null || true
-}
-
-write_postgres_compose() {
-  cat >/opt/matrix/postgres-compose.yml <<'EOF'
-services:
-  postgres:
-    image: postgres:16
-    restart: unless-stopped
-    env_file:
-      - /opt/matrix/env/postgres.env
-    volumes:
-      - matrix-postgres:/var/lib/postgresql/data
-    ports:
-      - "127.0.0.1:5432:5432"
-
-volumes:
-  matrix-postgres:
-EOF
-  chmod 0644 /opt/matrix/postgres-compose.yml
+  cleanup_install_tmp
+  INSTALL_TMP_BUNDLE=""
+  INSTALL_TMP_SUM=""
 }
 
 write_self_host_restore_service() {
@@ -217,9 +221,10 @@ install_systemd_units() {
 }
 
 configure_nginx() {
-  local password hash server_name
+  local code_proxy_token password hash server_name
   password="$(openssl rand -base64 18 | tr -d '\n')"
   hash="$(openssl passwd -apr1 "$password")"
+  code_proxy_token="$(read_env_value /opt/matrix/env/host.env MATRIX_CODE_PROXY_TOKEN)" || fail "MATRIX_CODE_PROXY_TOKEN is missing from host.env"
   server_name="$MATRIX_DOMAIN"
 
   printf 'matrix:%s\n' "$hash" >/opt/matrix/env/nginx.htpasswd
@@ -227,6 +232,9 @@ configure_nginx() {
   chown root:www-data /opt/matrix/env/nginx.htpasswd
   printf '%s\n' "$password" >/opt/matrix/env/initial-ui-password
   chmod 0600 /opt/matrix/env/initial-ui-password
+  printf 'proxy_set_header X-Matrix-Code-Proxy-Token "%s";\n' "$code_proxy_token" >/opt/matrix/env/code-proxy-token.conf
+  chmod 0600 /opt/matrix/env/code-proxy-token.conf
+  chown root:root /opt/matrix/env/code-proxy-token.conf
 
   cat >/etc/nginx/sites-available/matrix-self-host <<EOF
 server {
@@ -260,7 +268,7 @@ server {
     proxy_http_version 1.1;
     proxy_set_header Upgrade \$http_upgrade;
     proxy_set_header Connection "upgrade";
-    proxy_set_header X-Matrix-Code-Proxy-Token "$(grep '^MATRIX_CODE_PROXY_TOKEN=' /opt/matrix/env/host.env | cut -d= -f2-)";
+    include /opt/matrix/env/code-proxy-token.conf;
     rewrite ^/code/?(.*)\$ /\$1 break;
     proxy_pass http://127.0.0.1:8787;
   }
@@ -333,7 +341,6 @@ main() {
   ensure_matrix_user
   write_env
   install_bundle
-  write_postgres_compose
   install_systemd_units
   configure_nginx
   start_services

--- a/www/public/install-server.sh
+++ b/www/public/install-server.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -euo pipefail
+set -Eeuo pipefail
 
 # Matrix OS standalone server installer.
 # Public copy is served from https://matrix-os.com/install-server.sh.
@@ -11,14 +11,20 @@ MATRIX_INSTALL_HANDLE="${MATRIX_INSTALL_HANDLE:-matrix}"
 MATRIX_DOMAIN="${MATRIX_DOMAIN:-_}"
 MATRIX_HOME_DIR="${MATRIX_HOME:-/home/matrix/home}"
 MATRIX_DEVELOPER_TOOLS="${MATRIX_DEVELOPER_TOOLS:-codex claude-code opencode pi}"
+MATRIX_INSTALL_TELEMETRY_URL="${MATRIX_INSTALL_TELEMETRY_URL:-https://matrix-os.com/api/install-telemetry}"
+MATRIX_INSTALL_TELEMETRY_ID="${MATRIX_INSTALL_TELEMETRY_ID:-}"
 INSTALL_TMP_BUNDLE=""
 INSTALL_TMP_SUM=""
+INSTALL_PHASE="init"
+INSTALL_COMPLETED=0
+INSTALL_FAILURE_CAPTURED=0
 
 cleanup_install_tmp() {
   [ -z "$INSTALL_TMP_BUNDLE" ] || rm -f "$INSTALL_TMP_BUNDLE"
   [ -z "$INSTALL_TMP_SUM" ] || rm -f "$INSTALL_TMP_SUM"
 }
 trap cleanup_install_tmp EXIT
+trap 'capture_install_failure $? $LINENO' ERR
 
 log() {
   printf 'matrix-server-install: %s\n' "$*"
@@ -26,7 +32,111 @@ log() {
 
 fail() {
   printf 'matrix-server-install: %s\n' "$*" >&2
+  if declare -F capture_install_failure >/dev/null 2>&1; then
+    capture_install_failure 1 "${BASH_LINENO[0]:-0}" || true
+  fi
   exit 1
+}
+
+telemetry_enabled() {
+  [ -z "${MATRIX_NO_TELEMETRY:-}" ] || return 1
+  [ "${MATRIX_INSTALL_TELEMETRY:-1}" != "0" ] || return 1
+  [ -n "$MATRIX_INSTALL_TELEMETRY_URL" ] || return 1
+}
+
+telemetry_id() {
+  if [ -n "$MATRIX_INSTALL_TELEMETRY_ID" ]; then
+    printf '%s\n' "$MATRIX_INSTALL_TELEMETRY_ID"
+    return
+  fi
+  if command -v openssl >/dev/null 2>&1; then
+    MATRIX_INSTALL_TELEMETRY_ID="$(openssl rand -hex 16 2>/dev/null || true)"
+  fi
+  if [ -z "$MATRIX_INSTALL_TELEMETRY_ID" ]; then
+    MATRIX_INSTALL_TELEMETRY_ID="$(date -u +%Y%m%d%H%M%S)-$$"
+  fi
+  printf '%s\n' "$MATRIX_INSTALL_TELEMETRY_ID"
+}
+
+telemetry_value() {
+  printf '%s' "${1:-unknown}" | tr -c 'A-Za-z0-9._:/@+-' '_' | cut -c1-120
+}
+
+developer_tool_count() {
+  local count tool
+  count=0
+  for tool in $MATRIX_DEVELOPER_TOOLS; do
+    [ -n "$tool" ] || continue
+    count=$((count + 1))
+  done
+  printf '%s\n' "$count"
+}
+
+bundle_source() {
+  case "$MATRIX_HOST_BUNDLE_URL" in
+    "${DEFAULT_BUNDLE_BASE}/matrix-host-bundle.tar.gz") printf 'default\n' ;;
+    *) printf 'custom\n' ;;
+  esac
+}
+
+domain_mode() {
+  if [ "$MATRIX_DOMAIN" = "_" ]; then
+    printf 'ip\n'
+  else
+    printf 'dns\n'
+  fi
+}
+
+installed_version() {
+  if [ -f /opt/matrix/app/BUNDLE_VERSION ]; then
+    head -n1 /opt/matrix/app/BUNDLE_VERSION
+    return
+  fi
+  if [ -f /opt/matrix/BUNDLE_VERSION ]; then
+    head -n1 /opt/matrix/BUNDLE_VERSION
+    return
+  fi
+  if [ -f /opt/matrix/release.json ]; then
+    sed -n 's/.*"version"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' /opt/matrix/release.json | head -n1
+    return
+  fi
+  printf 'unknown\n'
+}
+
+capture_install_telemetry() {
+  local event status exit_code payload version
+  event="$1"
+  status="$2"
+  exit_code="${3:-0}"
+  telemetry_enabled || return 0
+  version="$(telemetry_value "$(installed_version 2>/dev/null || printf 'unknown')")"
+  payload="$(printf '{"event":"%s","installId":"%s","channel":"%s","version":"%s","domainMode":"%s","bundleSource":"%s","developerToolsCount":%s,"phase":"%s","status":"%s","exitCode":%s}\n' \
+    "$(telemetry_value "$event")" \
+    "$(telemetry_value "$(telemetry_id)")" \
+    "$(telemetry_value "$DEFAULT_CHANNEL")" \
+    "$version" \
+    "$(telemetry_value "$(domain_mode)")" \
+    "$(telemetry_value "$(bundle_source)")" \
+    "$(developer_tool_count)" \
+    "$(telemetry_value "$INSTALL_PHASE")" \
+    "$(telemetry_value "$status")" \
+    "$exit_code")"
+  curl --fail --silent --show-error --connect-timeout 2 --max-time 3 \
+    -H 'content-type: application/json' \
+    -X POST \
+    --data "$payload" \
+    "$MATRIX_INSTALL_TELEMETRY_URL" >/dev/null 2>&1 || true
+}
+
+capture_install_failure() {
+  local exit_code line
+  exit_code="$1"
+  line="$2"
+  [ "$INSTALL_COMPLETED" = "0" ] || return 0
+  [ "$INSTALL_FAILURE_CAPTURED" = "0" ] || return 0
+  INSTALL_FAILURE_CAPTURED=1
+  INSTALL_PHASE="${INSTALL_PHASE:-failed}-line-${line}"
+  capture_install_telemetry "matrix_manual_install_failed" "failed" "$exit_code"
 }
 
 require_root() {
@@ -344,16 +454,28 @@ EOF
 }
 
 main() {
+  INSTALL_PHASE="preflight"
   require_root
   require_linux_systemd
   validate_config
+  capture_install_telemetry "matrix_manual_install_started" "started" 0
+  INSTALL_PHASE="packages"
   install_packages
+  INSTALL_PHASE="user"
   ensure_matrix_user
+  INSTALL_PHASE="env"
   write_env
+  INSTALL_PHASE="bundle"
   install_bundle
+  INSTALL_PHASE="systemd"
   install_systemd_units
+  INSTALL_PHASE="nginx"
   configure_nginx
+  INSTALL_PHASE="services"
   start_services
+  INSTALL_PHASE="complete"
+  INSTALL_COMPLETED=1
+  capture_install_telemetry "matrix_manual_install_completed" "completed" 0
   print_summary
 }
 

--- a/www/public/install-server.sh
+++ b/www/public/install-server.sh
@@ -222,16 +222,18 @@ install_systemd_units() {
 
 configure_nginx() {
   local code_proxy_token password hash server_name
-  password="$(openssl rand -base64 18 | tr -d '\n')"
-  hash="$(openssl passwd -apr1 "$password")"
   code_proxy_token="$(read_env_value /opt/matrix/env/host.env MATRIX_CODE_PROXY_TOKEN)" || fail "MATRIX_CODE_PROXY_TOKEN is missing from host.env"
   server_name="$MATRIX_DOMAIN"
 
-  printf 'matrix:%s\n' "$hash" >/opt/matrix/env/nginx.htpasswd
+  if [ ! -f /opt/matrix/env/nginx.htpasswd ]; then
+    password="$(openssl rand -base64 18 | tr -d '\n')"
+    hash="$(openssl passwd -apr1 "$password")"
+    printf 'matrix:%s\n' "$hash" >/opt/matrix/env/nginx.htpasswd
+    printf '%s\n' "$password" >/opt/matrix/env/initial-ui-password
+    chmod 0600 /opt/matrix/env/initial-ui-password
+  fi
   chmod 0640 /opt/matrix/env/nginx.htpasswd
   chown root:www-data /opt/matrix/env/nginx.htpasswd
-  printf '%s\n' "$password" >/opt/matrix/env/initial-ui-password
-  chmod 0600 /opt/matrix/env/initial-ui-password
   printf 'proxy_set_header X-Matrix-Code-Proxy-Token "%s";\n' "$code_proxy_token" >/opt/matrix/env/code-proxy-token.conf
   chmod 0600 /opt/matrix/env/code-proxy-token.conf
   chown root:root /opt/matrix/env/code-proxy-token.conf
@@ -261,6 +263,7 @@ server {
     proxy_http_version 1.1;
     proxy_set_header Upgrade \$http_upgrade;
     proxy_set_header Connection "upgrade";
+    proxy_read_timeout 3600s;
     proxy_pass http://127.0.0.1:4000;
   }
 
@@ -268,6 +271,7 @@ server {
     proxy_http_version 1.1;
     proxy_set_header Upgrade \$http_upgrade;
     proxy_set_header Connection "upgrade";
+    proxy_read_timeout 3600s;
     include /opt/matrix/env/code-proxy-token.conf;
     rewrite ^/code/?(.*)\$ /\$1 break;
     proxy_pass http://127.0.0.1:8787;
@@ -300,7 +304,7 @@ start_services() {
 }
 
 print_summary() {
-  local ip ui_url
+  local ip password_line ui_url
   ip="$(hostname -I 2>/dev/null | awk '{print $1}')"
   if [ -n "${MATRIX_PUBLIC_URL:-}" ]; then
     ui_url="$MATRIX_PUBLIC_URL"
@@ -311,6 +315,11 @@ print_summary() {
   else
     ui_url="http://<server-ip>"
   fi
+  if [ -f /opt/matrix/env/initial-ui-password ]; then
+    password_line="Password: $(cat /opt/matrix/env/initial-ui-password)"
+  else
+    password_line="Password: existing nginx Basic Auth credentials"
+  fi
 
   cat <<EOF
 
@@ -318,7 +327,7 @@ Matrix OS standalone install complete.
 
 Open: ${ui_url}
 User: matrix
-Password: $(cat /opt/matrix/env/initial-ui-password)
+${password_line}
 
 Code editor: ${ui_url%/}/code/
 Home: ${MATRIX_HOME_DIR}

--- a/www/public/install-server.sh
+++ b/www/public/install-server.sh
@@ -47,10 +47,11 @@ validate_config() {
   case "$MATRIX_INSTALL_HANDLE" in
     ""|*[!A-Za-z0-9_-]*) fail "MATRIX_INSTALL_HANDLE may only contain letters, numbers, underscore, and dash" ;;
   esac
-  case "$MATRIX_DOMAIN" in
-    "_"|[A-Za-z0-9.-]*) ;;
-    *) fail "MATRIX_DOMAIN may only be '_' or a DNS name" ;;
-  esac
+  if [ "$MATRIX_DOMAIN" != "_" ]; then
+    [ "${#MATRIX_DOMAIN}" -le 253 ] || fail "MATRIX_DOMAIN may only be '_' or a DNS name"
+    [[ "$MATRIX_DOMAIN" =~ ^[A-Za-z0-9]([A-Za-z0-9-]{0,61}[A-Za-z0-9])?(\.[A-Za-z0-9]([A-Za-z0-9-]{0,61}[A-Za-z0-9])?)*$ ]] \
+      || fail "MATRIX_DOMAIN may only be '_' or a DNS name"
+  fi
   case "$MATRIX_HOME_DIR" in
     /home/matrix/*|/home/matrix) ;;
     *) fail "MATRIX_HOME must stay under /home/matrix for standalone installs" ;;

--- a/www/public/install-server.sh
+++ b/www/public/install-server.sh
@@ -1,0 +1,343 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Matrix OS standalone server installer.
+# Public copy is served from https://matrix-os.com/install-server.sh.
+
+DEFAULT_CHANNEL="${MATRIX_CHANNEL:-stable}"
+DEFAULT_BUNDLE_BASE="https://app.matrix-os.com/system-bundles/${DEFAULT_CHANNEL}"
+MATRIX_HOST_BUNDLE_URL="${MATRIX_HOST_BUNDLE_URL:-${DEFAULT_BUNDLE_BASE}/matrix-host-bundle.tar.gz}"
+MATRIX_INSTALL_HANDLE="${MATRIX_INSTALL_HANDLE:-matrix}"
+MATRIX_DOMAIN="${MATRIX_DOMAIN:-_}"
+MATRIX_HOME_DIR="${MATRIX_HOME:-/home/matrix/home}"
+MATRIX_DEVELOPER_TOOLS="${MATRIX_DEVELOPER_TOOLS:-codex claude-code opencode pi}"
+
+log() {
+  printf 'matrix-server-install: %s\n' "$*"
+}
+
+fail() {
+  printf 'matrix-server-install: %s\n' "$*" >&2
+  exit 1
+}
+
+require_root() {
+  if [ "$(id -u)" != "0" ]; then
+    fail "run as root, for example: curl -fsSL https://matrix-os.com/install-server.sh | sudo bash"
+  fi
+}
+
+require_linux_systemd() {
+  [ "$(uname -s)" = "Linux" ] || fail "Linux is required"
+  command -v systemctl >/dev/null 2>&1 || fail "systemd is required"
+}
+
+validate_config() {
+  case "$DEFAULT_CHANNEL" in
+    ""|*[!A-Za-z0-9._-]*) fail "MATRIX_CHANNEL contains unsupported characters" ;;
+  esac
+  case "$MATRIX_INSTALL_HANDLE" in
+    ""|*[!A-Za-z0-9_-]*) fail "MATRIX_INSTALL_HANDLE may only contain letters, numbers, underscore, and dash" ;;
+  esac
+  case "$MATRIX_DOMAIN" in
+    "_"|[A-Za-z0-9.-]*) ;;
+    *) fail "MATRIX_DOMAIN may only be '_' or a DNS name" ;;
+  esac
+  case "$MATRIX_HOME_DIR" in
+    /home/matrix/*|/home/matrix) ;;
+    *) fail "MATRIX_HOME must stay under /home/matrix for standalone installs" ;;
+  esac
+  case "$MATRIX_HOST_BUNDLE_URL" in
+    https://*) ;;
+    *) fail "MATRIX_HOST_BUNDLE_URL must be https" ;;
+  esac
+  case "$MATRIX_DEVELOPER_TOOLS" in
+    *[!A-Za-z0-9._\ -]*) fail "MATRIX_DEVELOPER_TOOLS contains unsupported characters" ;;
+  esac
+}
+
+apt_get_update() {
+  apt-get update \
+    -o Acquire::Retries=5 \
+    -o Acquire::http::Timeout=20 \
+    -o Acquire::https::Timeout=20
+}
+
+install_packages() {
+  export DEBIAN_FRONTEND=noninteractive
+  if command -v apt-get >/dev/null 2>&1; then
+    log "installing OS packages"
+    apt_get_update
+    apt-get install -y ca-certificates curl docker.io git nginx openssl postgresql-client procps sudo tar
+    return
+  fi
+  fail "only apt-based Linux distributions are supported in this preview"
+}
+
+ensure_matrix_user() {
+  if ! getent group matrix >/dev/null 2>&1; then
+    groupadd --system matrix
+  fi
+  if ! getent group docker >/dev/null 2>&1; then
+    groupadd --system docker
+  fi
+  if ! id matrix >/dev/null 2>&1; then
+    useradd --system --gid matrix --groups docker --home-dir /home/matrix --shell /bin/bash matrix
+  else
+    usermod -aG docker matrix
+  fi
+
+  install -d -o root -g matrix -m 0770 /opt/matrix
+  install -d -o root -g matrix -m 0750 /opt/matrix/env /opt/matrix/bin /opt/matrix/tls
+  install -d -o matrix -g matrix -m 0755 /home/matrix "$MATRIX_HOME_DIR" "$MATRIX_HOME_DIR/projects"
+  install -d -o matrix -g matrix -m 0755 "$MATRIX_HOME_DIR/.local" "$MATRIX_HOME_DIR/.local/bin" "$MATRIX_HOME_DIR/.local/share"
+  install -d -o matrix -g matrix -m 0755 "$MATRIX_HOME_DIR/.cache" "$MATRIX_HOME_DIR/.config"
+  usermod -d "$MATRIX_HOME_DIR" matrix
+}
+
+random_secret() {
+  openssl rand -base64 32 | tr -d '\n'
+}
+
+write_env() {
+  local auth_token code_token postgres_password
+  auth_token="$(random_secret)"
+  code_token="$(random_secret)"
+  postgres_password="$(random_secret | tr '/+' 'ab')"
+
+  cat >/opt/matrix/env/postgres.env <<EOF
+POSTGRES_DB=matrix
+POSTGRES_USER=matrix
+POSTGRES_PASSWORD=${postgres_password}
+EOF
+  chmod 0640 /opt/matrix/env/postgres.env
+  chown root:matrix /opt/matrix/env/postgres.env
+
+  cat >/opt/matrix/env/host.env <<EOF
+MATRIX_SELF_HOSTED=1
+MATRIX_MACHINE_ID=self-host-${MATRIX_INSTALL_HANDLE}
+MATRIX_CLERK_USER_ID=self-host-${MATRIX_INSTALL_HANDLE}
+MATRIX_USER_ID=self-host-${MATRIX_INSTALL_HANDLE}
+MATRIX_HANDLE=${MATRIX_INSTALL_HANDLE}
+MATRIX_RUNTIME_SLOT=primary
+MATRIX_DEVELOPER_TOOLS='${MATRIX_DEVELOPER_TOOLS}'
+MATRIX_IMAGE_VERSION=${DEFAULT_CHANNEL}
+MATRIX_UPDATE_CHANNEL=${DEFAULT_CHANNEL}
+MATRIX_AUTH_TOKEN=${auth_token}
+MATRIX_CODE_PROXY_TOKEN=${code_token}
+MATRIX_HOST_BUNDLE_URL=${MATRIX_HOST_BUNDLE_URL}
+MATRIX_HOME=${MATRIX_HOME_DIR}
+DATABASE_URL=postgresql://matrix:${postgres_password}@127.0.0.1:5432/matrix
+GATEWAY_URL=http://127.0.0.1:4000
+NEXT_PUBLIC_GATEWAY_URL=http://127.0.0.1:4000
+NEXT_PUBLIC_GATEWAY_WS=/ws
+EOF
+  chmod 0640 /opt/matrix/env/host.env
+  chown root:matrix /opt/matrix/env/host.env
+}
+
+install_bundle() {
+  local tmp_bundle tmp_sum expected actual
+  tmp_bundle="/tmp/matrix-host-bundle.tar.gz"
+  tmp_sum="/tmp/matrix-host-bundle.tar.gz.sha256"
+
+  log "downloading host bundle"
+  curl --fail --location --retry 3 --retry-delay 5 --retry-all-errors \
+    --connect-timeout 10 --max-time 900 \
+    "$MATRIX_HOST_BUNDLE_URL" -o "$tmp_bundle"
+  curl --fail --location --retry 3 --retry-delay 5 --retry-all-errors \
+    --connect-timeout 10 --max-time 30 \
+    "${MATRIX_HOST_BUNDLE_URL}.sha256" -o "$tmp_sum"
+
+  expected="$(awk '{print $1}' "$tmp_sum")"
+  actual="$(sha256sum "$tmp_bundle" | awk '{print $1}')"
+  [ -n "$expected" ] || fail "empty bundle checksum"
+  [ "$expected" = "$actual" ] || fail "bundle checksum mismatch"
+
+  log "extracting host bundle"
+  tar -xzf "$tmp_bundle" -C /opt/matrix
+  chmod 0755 /opt/matrix/bin/matrix-* /opt/matrix/bin/zellij 2>/dev/null || true
+}
+
+write_postgres_compose() {
+  cat >/opt/matrix/postgres-compose.yml <<'EOF'
+services:
+  postgres:
+    image: postgres:16
+    restart: unless-stopped
+    env_file:
+      - /opt/matrix/env/postgres.env
+    volumes:
+      - matrix-postgres:/var/lib/postgresql/data
+    ports:
+      - "127.0.0.1:5432:5432"
+
+volumes:
+  matrix-postgres:
+EOF
+  chmod 0644 /opt/matrix/postgres-compose.yml
+}
+
+write_self_host_restore_service() {
+  cat >/etc/systemd/system/matrix-restore.service <<'EOF'
+[Unit]
+Description=Matrix OS standalone database gate
+After=docker.service
+Requires=docker.service
+
+[Service]
+Type=oneshot
+User=matrix
+Group=matrix
+EnvironmentFile=/opt/matrix/env/host.env
+EnvironmentFile=/opt/matrix/env/postgres.env
+ExecStart=/bin/bash -lc 'set -euo pipefail; if docker ps --format "{{.Names}}" | grep -qx matrix-postgres; then :; elif docker ps -a --format "{{.Names}}" | grep -qx matrix-postgres; then docker start matrix-postgres >/dev/null; else docker volume create matrix-postgres >/dev/null; docker run -d --name matrix-postgres --restart unless-stopped --env-file /opt/matrix/env/postgres.env -v matrix-postgres:/var/lib/postgresql/data -p 127.0.0.1:5432:5432 postgres:16 >/dev/null; fi; for _ in $(seq 1 60); do pg_isready --host=127.0.0.1 --username="${POSTGRES_USER:-matrix}" --dbname="${POSTGRES_DB:-matrix}" >/dev/null 2>&1 && break; sleep 2; done; pg_isready --host=127.0.0.1 --username="${POSTGRES_USER:-matrix}" --dbname="${POSTGRES_DB:-matrix}" >/dev/null 2>&1; touch /opt/matrix/restore-complete'
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target
+EOF
+}
+
+install_systemd_units() {
+  log "installing systemd units"
+  install -m 0644 /opt/matrix/systemd/matrix-gateway.service /etc/systemd/system/matrix-gateway.service
+  install -m 0644 /opt/matrix/systemd/matrix-shell.service /etc/systemd/system/matrix-shell.service
+  install -m 0644 /opt/matrix/systemd/matrix-code.service /etc/systemd/system/matrix-code.service
+  install -m 0644 /opt/matrix/systemd/matrix-code-server.service /etc/systemd/system/matrix-code-server.service
+  if [ -f /opt/matrix/systemd/matrix-developer-tools.service ]; then
+    install -m 0644 /opt/matrix/systemd/matrix-developer-tools.service /etc/systemd/system/matrix-developer-tools.service
+  fi
+  write_self_host_restore_service
+  systemctl daemon-reload
+  systemctl enable docker matrix-restore matrix-gateway matrix-shell matrix-code matrix-code-server >/dev/null
+  if [ -f /etc/systemd/system/matrix-developer-tools.service ] && [ -n "$MATRIX_DEVELOPER_TOOLS" ]; then
+    systemctl enable matrix-developer-tools >/dev/null
+  fi
+}
+
+configure_nginx() {
+  local password hash server_name
+  password="$(openssl rand -base64 18 | tr -d '\n')"
+  hash="$(openssl passwd -apr1 "$password")"
+  server_name="$MATRIX_DOMAIN"
+
+  printf 'matrix:%s\n' "$hash" >/opt/matrix/env/nginx.htpasswd
+  chmod 0640 /opt/matrix/env/nginx.htpasswd
+  chown root:www-data /opt/matrix/env/nginx.htpasswd
+  printf '%s\n' "$password" >/opt/matrix/env/initial-ui-password
+  chmod 0600 /opt/matrix/env/initial-ui-password
+
+  cat >/etc/nginx/sites-available/matrix-self-host <<EOF
+server {
+  listen 80 default_server;
+  server_name ${server_name};
+
+  client_max_body_size 10m;
+  auth_basic "Matrix OS";
+  auth_basic_user_file /opt/matrix/env/nginx.htpasswd;
+
+  proxy_set_header Host \$host;
+  proxy_set_header X-Forwarded-Host \$host;
+  proxy_set_header X-Forwarded-Proto \$scheme;
+  proxy_set_header X-Real-IP \$remote_addr;
+
+  location /api/ { proxy_pass http://127.0.0.1:4000; }
+  location /files/ { proxy_pass http://127.0.0.1:4000; }
+  location /icons/ { proxy_pass http://127.0.0.1:4000; }
+  location /apps/ { proxy_pass http://127.0.0.1:4000; }
+  location /health { proxy_pass http://127.0.0.1:4000; }
+  location /gateway/ { proxy_pass http://127.0.0.1:4000/; }
+
+  location /ws {
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade \$http_upgrade;
+    proxy_set_header Connection "upgrade";
+    proxy_pass http://127.0.0.1:4000;
+  }
+
+  location /code/ {
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade \$http_upgrade;
+    proxy_set_header Connection "upgrade";
+    proxy_set_header X-Matrix-Code-Proxy-Token "$(grep '^MATRIX_CODE_PROXY_TOKEN=' /opt/matrix/env/host.env | cut -d= -f2-)";
+    rewrite ^/code/?(.*)\$ /\$1 break;
+    proxy_pass http://127.0.0.1:8787;
+  }
+
+  location / {
+    proxy_pass http://127.0.0.1:3000;
+  }
+}
+EOF
+
+  rm -f /etc/nginx/sites-enabled/default
+  ln -sfn /etc/nginx/sites-available/matrix-self-host /etc/nginx/sites-enabled/matrix-self-host
+  nginx -t
+  systemctl enable nginx >/dev/null
+}
+
+start_services() {
+  log "starting services"
+  systemctl enable --now docker >/dev/null
+  systemctl restart matrix-restore
+  systemctl restart matrix-gateway
+  systemctl restart matrix-shell
+  systemctl restart matrix-code-server || true
+  systemctl restart matrix-code || true
+  if systemctl list-unit-files matrix-developer-tools.service >/dev/null 2>&1; then
+    systemctl restart matrix-developer-tools || true
+  fi
+  systemctl restart nginx
+}
+
+print_summary() {
+  local ip ui_url
+  ip="$(hostname -I 2>/dev/null | awk '{print $1}')"
+  if [ -n "${MATRIX_PUBLIC_URL:-}" ]; then
+    ui_url="$MATRIX_PUBLIC_URL"
+  elif [ "$MATRIX_DOMAIN" != "_" ]; then
+    ui_url="http://${MATRIX_DOMAIN}"
+  elif [ -n "$ip" ]; then
+    ui_url="http://${ip}"
+  else
+    ui_url="http://<server-ip>"
+  fi
+
+  cat <<EOF
+
+Matrix OS standalone install complete.
+
+Open: ${ui_url}
+User: matrix
+Password: $(cat /opt/matrix/env/initial-ui-password)
+
+Code editor: ${ui_url%/}/code/
+Home: ${MATRIX_HOME_DIR}
+
+Useful commands:
+  systemctl status matrix-gateway matrix-shell matrix-code nginx --no-pager
+  journalctl -u matrix-gateway -u matrix-shell -u matrix-code -n 200 --no-pager
+  sudo -u matrix bash
+
+This preview protects the web UI with nginx Basic Auth. Put the host behind
+HTTPS, Tailscale, Cloudflare Access, or another trusted edge before long-term use.
+EOF
+}
+
+main() {
+  require_root
+  require_linux_systemd
+  validate_config
+  install_packages
+  ensure_matrix_user
+  write_env
+  install_bundle
+  write_postgres_compose
+  install_systemd_units
+  configure_nginx
+  start_services
+  print_summary
+}
+
+main "$@"

--- a/www/public/install-server.sh
+++ b/www/public/install-server.sh
@@ -367,7 +367,12 @@ server {
   location /files/ { proxy_pass http://127.0.0.1:4000; }
   location /icons/ { proxy_pass http://127.0.0.1:4000; }
   location /apps/ { proxy_pass http://127.0.0.1:4000; }
-  location /health { proxy_pass http://127.0.0.1:4000; }
+  location = /health {
+    auth_basic off;
+    access_log off;
+    default_type application/json;
+    return 200 '{"ok":true}';
+  }
   location /gateway/ { proxy_pass http://127.0.0.1:4000/; }
 
   location /ws {

--- a/www/src/app/api/install-telemetry/route.ts
+++ b/www/src/app/api/install-telemetry/route.ts
@@ -5,6 +5,21 @@ import { getPostHogClient, shutdownPostHog } from '@/lib/posthog-server';
 export const runtime = 'nodejs';
 
 const MAX_BODY_BYTES = 4096;
+const RATE_LIMIT_WINDOW_MS = 60_000;
+const RATE_LIMIT_MAX_EVENTS_PER_INSTALL = 12;
+const RATE_LIMIT_MAX_GLOBAL_EVENTS = 240;
+const RATE_LIMIT_MAX_INSTALL_IDS = 1_000;
+
+type RateLimitBucket = {
+  count: number;
+  resetAt: number;
+};
+
+const installTelemetryBuckets = new Map<string, RateLimitBucket>();
+let globalRateLimitBucket: RateLimitBucket = {
+  count: 0,
+  resetAt: 0,
+};
 
 const installTelemetrySchema = z.object({
   event: z.enum([
@@ -25,6 +40,59 @@ const installTelemetrySchema = z.object({
 
 function jsonResponse(status: number) {
   return NextResponse.json({ ok: status < 400 }, { status });
+}
+
+function pruneExpiredInstallTelemetryBuckets(now: number) {
+  for (const [installId, bucket] of installTelemetryBuckets) {
+    if (bucket.resetAt <= now) {
+      installTelemetryBuckets.delete(installId);
+    }
+  }
+
+  while (installTelemetryBuckets.size > RATE_LIMIT_MAX_INSTALL_IDS) {
+    const oldestInstallId = installTelemetryBuckets.keys().next().value;
+    if (!oldestInstallId) {
+      break;
+    }
+    installTelemetryBuckets.delete(oldestInstallId);
+  }
+}
+
+function allowInstallTelemetryEvent(installId: string, now = Date.now()) {
+  pruneExpiredInstallTelemetryBuckets(now);
+
+  if (globalRateLimitBucket.resetAt <= now) {
+    globalRateLimitBucket = {
+      count: 0,
+      resetAt: now + RATE_LIMIT_WINDOW_MS,
+    };
+  }
+
+  if (globalRateLimitBucket.count >= RATE_LIMIT_MAX_GLOBAL_EVENTS) {
+    return false;
+  }
+
+  const existingBucket = installTelemetryBuckets.get(installId);
+  if (!existingBucket || existingBucket.resetAt <= now) {
+    installTelemetryBuckets.set(installId, {
+      count: 1,
+      resetAt: now + RATE_LIMIT_WINDOW_MS,
+    });
+    globalRateLimitBucket.count += 1;
+    return true;
+  }
+
+  if (existingBucket.count >= RATE_LIMIT_MAX_EVENTS_PER_INSTALL) {
+    return false;
+  }
+
+  installTelemetryBuckets.delete(installId);
+  installTelemetryBuckets.set(installId, {
+    count: existingBucket.count + 1,
+    resetAt: existingBucket.resetAt,
+  });
+  globalRateLimitBucket.count += 1;
+  return true;
 }
 
 async function readBoundedJson(request: Request): Promise<{ body?: unknown; tooLarge?: boolean }> {
@@ -71,6 +139,10 @@ export async function POST(request: Request) {
   }
 
   const input = parsed.data;
+  if (!allowInstallTelemetryEvent(input.installId)) {
+    return jsonResponse(429);
+  }
+
   const posthog = getPostHogClient();
   after(async () => {
     try {

--- a/www/src/app/api/install-telemetry/route.ts
+++ b/www/src/app/api/install-telemetry/route.ts
@@ -1,0 +1,67 @@
+import { NextResponse } from 'next/server';
+import { z } from 'zod/v4';
+import { getPostHogClient } from '@/lib/posthog-server';
+
+export const runtime = 'nodejs';
+
+const MAX_BODY_BYTES = 4096;
+
+const installTelemetrySchema = z.object({
+  event: z.enum([
+    'matrix_manual_install_started',
+    'matrix_manual_install_completed',
+    'matrix_manual_install_failed',
+  ]),
+  installId: z.string().regex(/^[A-Za-z0-9._:-]{1,120}$/),
+  channel: z.string().regex(/^[A-Za-z0-9._-]{1,80}$/),
+  version: z.string().regex(/^[A-Za-z0-9._:/@+-]{1,120}$/),
+  domainMode: z.enum(['ip', 'dns']),
+  bundleSource: z.enum(['default', 'custom']),
+  developerToolsCount: z.number().int().min(0).max(20),
+  phase: z.string().regex(/^[A-Za-z0-9._:/@+-]{1,120}$/),
+  status: z.enum(['started', 'completed', 'failed']),
+  exitCode: z.number().int().min(0).max(255),
+});
+
+function jsonResponse(status: number) {
+  return NextResponse.json({ ok: status < 400 }, { status });
+}
+
+export async function POST(request: Request) {
+  const contentLength = Number(request.headers.get('content-length') ?? '0');
+  if (Number.isFinite(contentLength) && contentLength > MAX_BODY_BYTES) {
+    return jsonResponse(413);
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return jsonResponse(400);
+  }
+
+  const parsed = installTelemetrySchema.safeParse(body);
+  if (!parsed.success) {
+    return jsonResponse(400);
+  }
+
+  const input = parsed.data;
+  getPostHogClient().capture({
+    distinctId: `manual-install:${input.installId}`,
+    event: input.event,
+    properties: {
+      channel: input.channel,
+      version: input.version,
+      domain_mode: input.domainMode,
+      bundle_source: input.bundleSource,
+      developer_tools_count: input.developerToolsCount,
+      phase: input.phase,
+      status: input.status,
+      exit_code: input.exitCode,
+      install_surface: 'linux_vps_script',
+      $ip: '0.0.0.0',
+    },
+  });
+
+  return new Response(null, { status: 204 });
+}

--- a/www/src/app/api/install-telemetry/route.ts
+++ b/www/src/app/api/install-telemetry/route.ts
@@ -1,6 +1,6 @@
-import { NextResponse } from 'next/server';
+import { after, NextResponse } from 'next/server';
 import { z } from 'zod/v4';
-import { getPostHogClient } from '@/lib/posthog-server';
+import { getPostHogClient, shutdownPostHog } from '@/lib/posthog-server';
 
 export const runtime = 'nodejs';
 
@@ -27,40 +27,76 @@ function jsonResponse(status: number) {
   return NextResponse.json({ ok: status < 400 }, { status });
 }
 
+async function readBoundedJson(request: Request): Promise<{ body?: unknown; tooLarge?: boolean }> {
+  const reader = request.body?.getReader();
+  if (!reader) {
+    return {};
+  }
+
+  const chunks: Uint8Array[] = [];
+  let totalBytes = 0;
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    totalBytes += value.byteLength;
+    if (totalBytes > MAX_BODY_BYTES) {
+      await reader.cancel().catch(() => undefined);
+      return { tooLarge: true };
+    }
+    chunks.push(value);
+  }
+
+  const bytes = new Uint8Array(totalBytes);
+  let offset = 0;
+  for (const chunk of chunks) {
+    bytes.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+
+  return { body: JSON.parse(new TextDecoder().decode(bytes)) };
+}
+
 export async function POST(request: Request) {
-  const contentLength = Number(request.headers.get('content-length') ?? '0');
-  if (Number.isFinite(contentLength) && contentLength > MAX_BODY_BYTES) {
+  const payload = await readBoundedJson(request).catch(() => undefined);
+  if (!payload) {
+    return jsonResponse(400);
+  }
+  if (payload.tooLarge) {
     return jsonResponse(413);
   }
 
-  let body: unknown;
-  try {
-    body = await request.json();
-  } catch {
-    return jsonResponse(400);
-  }
-
-  const parsed = installTelemetrySchema.safeParse(body);
+  const parsed = installTelemetrySchema.safeParse(payload.body);
   if (!parsed.success) {
     return jsonResponse(400);
   }
 
   const input = parsed.data;
-  getPostHogClient().capture({
-    distinctId: `manual-install:${input.installId}`,
-    event: input.event,
-    properties: {
-      channel: input.channel,
-      version: input.version,
-      domain_mode: input.domainMode,
-      bundle_source: input.bundleSource,
-      developer_tools_count: input.developerToolsCount,
-      phase: input.phase,
-      status: input.status,
-      exit_code: input.exitCode,
-      install_surface: 'linux_vps_script',
-      $ip: '0.0.0.0',
-    },
+  const posthog = getPostHogClient();
+  after(async () => {
+    try {
+      posthog.capture({
+        distinctId: `manual-install:${input.installId}`,
+        event: input.event,
+        properties: {
+          channel: input.channel,
+          version: input.version,
+          domain_mode: input.domainMode,
+          bundle_source: input.bundleSource,
+          developer_tools_count: input.developerToolsCount,
+          phase: input.phase,
+          status: input.status,
+          exit_code: input.exitCode,
+          install_surface: 'linux_vps_script',
+          $ip: '0.0.0.0',
+        },
+      });
+      await shutdownPostHog();
+    } catch (err: unknown) {
+      console.warn(
+        '[install-telemetry] Failed to capture event:',
+        err instanceof Error ? err.name : typeof err,
+      );
+    }
   });
 
   return new Response(null, { status: 204 });

--- a/www/src/app/page.tsx
+++ b/www/src/app/page.tsx
@@ -11,6 +11,7 @@ import { TemplatesShowcase } from "@/components/landing/TemplatesShowcase";
 import { SymphonySection } from "@/components/landing/SymphonySection";
 import { QuoteStats } from "@/components/landing/QuoteStats";
 import { HermesSection } from "@/components/landing/HermesSection";
+import { DeploymentSection } from "@/components/landing/DeploymentSection";
 import { BlogPreviewSection } from "@/components/landing/BlogPreviewSection";
 import { PilotBand } from "@/components/landing/PilotBand";
 import { FaqSection } from "@/components/landing/FaqSection";
@@ -60,6 +61,7 @@ export default function LandingPage() {
         <SymphonySection exploreHref="/symphony" />
         <QuoteStats />
         <HermesSection exploreHref="/hermes" />
+        <DeploymentSection />
         <LandingBilling />
         <BlogPreviewSection />
         <PilotBand />

--- a/www/src/components/landing/DeploymentSection.tsx
+++ b/www/src/components/landing/DeploymentSection.tsx
@@ -1,4 +1,4 @@
-import { ArrowRightIcon, BriefcaseBusinessIcon, CheckCircle2Icon, CloudIcon, ServerIcon } from "lucide-react";
+import { ArrowRightIcon, CheckCircle2Icon, CloudIcon, ServerIcon } from "lucide-react";
 import { palette as c, cardShadow, cardShadowSmall, fonts } from "./theme";
 import { CtaButton, SectionShell, SectionTitle } from "./primitives";
 import { Reveal } from "./Reveal";
@@ -6,22 +6,16 @@ import { SIGN_UP_HREF } from "./links";
 
 const hostedMatrixPoints = [
   "Choose region and power during signup",
-  "Managed runtime, updates, shell, CLI, and previews",
+  "Managed routing, auth, updates, backups, billing, and integrations",
   "Hermes and coding agents keep running while devices sleep",
-  "Best path for teams, pilots, professionals, and universities",
-] as const;
-
-const guidedPilotPoints = [
-  "Dedicated pilot path for teams, enterprise labs, and universities",
-  "Isolated cloud computers for AI coding experiments",
-  "Developer onboarding through CLI, docs, and Matrix skills",
-  "Clear rollout plan for tools, regions, billing, and approvals",
+  "Best path for teams, pilots, professionals, and daily work",
 ] as const;
 
 const selfHostPoints = [
   "Install from the main domain on your own Linux VPS",
   "Browser shell, gateway, local Postgres, code-server, and systemd services",
-  "You own DNS, TLS, backups, upgrades, and server security",
+  "Works from a server IP for first boot; bring DNS and TLS for public use",
+  "You own backups, upgrades, integrations, and server security",
   "Best path for hackers, open-source users, and custom infrastructure",
 ] as const;
 
@@ -31,13 +25,13 @@ export function DeploymentSection() {
       <Reveal>
         <div className="mb-8 max-w-[44rem] md:mb-10">
           <SectionTitle
-            title="Start with a private cloud computer."
-            continuation="Hosted, self-hosted, or guided for organizations."
+            title="Choose managed or manual install."
+            continuation="Start with Matrix Cloud, or bring your own Linux VPS."
           />
         </div>
       </Reveal>
 
-      <div className="grid gap-5 lg:grid-cols-3">
+      <div className="grid gap-5 lg:grid-cols-2">
         <Reveal>
           <article className="flex h-full flex-col rounded-2xl p-7 md:p-9" style={{ backgroundColor: c.card, boxShadow: cardShadow }}>
             <div className="mb-6 flex items-center gap-4">
@@ -46,7 +40,7 @@ export function DeploymentSection() {
               </span>
               <div>
                 <p className="text-[0.8125rem] font-medium" style={{ color: c.subtle }}>Recommended</p>
-                <h3 className="text-[1.1875rem] font-medium" style={{ color: c.deep, fontFamily: fonts.sans }}>Hosted Matrix</h3>
+                <h3 className="text-[1.1875rem] font-medium" style={{ color: c.deep, fontFamily: fonts.sans }}>Managed Matrix Cloud</h3>
               </div>
             </div>
             <ul className="grid gap-3">
@@ -59,7 +53,7 @@ export function DeploymentSection() {
             </ul>
             <div className="mt-auto pt-8">
               <CtaButton href={SIGN_UP_HREF} phLocation="deployment" phTarget="start_hosted">
-                Start hosted <ArrowRightIcon className="size-4" />
+                Start managed <ArrowRightIcon className="size-4" />
               </CtaButton>
             </div>
           </article>
@@ -73,7 +67,7 @@ export function DeploymentSection() {
               </span>
               <div>
                 <p className="text-[0.8125rem] font-medium" style={{ color: c.subtle }}>Run your VPS</p>
-                <h3 className="text-[1.1875rem] font-medium" style={{ color: c.deep, fontFamily: fonts.sans }}>Self-host Matrix</h3>
+                <h3 className="text-[1.1875rem] font-medium" style={{ color: c.deep, fontFamily: fonts.sans }}>Manual VPS install</h3>
               </div>
             </div>
             <ul className="grid gap-3">
@@ -86,34 +80,7 @@ export function DeploymentSection() {
             </ul>
             <div className="mt-auto pt-8">
               <CtaButton href="/docs/self-host" variant="outline" phLocation="deployment" phTarget="self_host_docs">
-                Self-host guide <ArrowRightIcon className="size-4" />
-              </CtaButton>
-            </div>
-          </article>
-        </Reveal>
-
-        <Reveal delay={180}>
-          <article className="flex h-full flex-col rounded-2xl p-7 md:p-9" style={{ backgroundColor: c.card, boxShadow: cardShadowSmall }}>
-            <div className="mb-6 flex items-center gap-4">
-              <span className="grid size-11 place-items-center rounded-lg" style={{ backgroundColor: "rgba(67,78,63,0.07)", color: c.forest }}>
-                <BriefcaseBusinessIcon className="size-5" />
-              </span>
-              <div>
-                <p className="text-[0.8125rem] font-medium" style={{ color: c.subtle }}>For organizations</p>
-                <h3 className="text-[1.1875rem] font-medium" style={{ color: c.deep, fontFamily: fonts.sans }}>Guided pilot</h3>
-              </div>
-            </div>
-            <ul className="grid gap-3">
-              {guidedPilotPoints.map((point) => (
-                <li key={point} className="flex gap-3 text-[0.9375rem] leading-[1.6]" style={{ color: c.mutedFg }}>
-                  <CheckCircle2Icon className="mt-1 size-4 shrink-0" style={{ color: c.forest }} />
-                  <span>{point}</span>
-                </li>
-              ))}
-            </ul>
-            <div className="mt-auto pt-8">
-              <CtaButton href="/contact?audience=enterprise" variant="outline">
-                Plan a pilot <ArrowRightIcon className="size-4" />
+                Install manually <ArrowRightIcon className="size-4" />
               </CtaButton>
             </div>
           </article>

--- a/www/src/components/landing/DeploymentSection.tsx
+++ b/www/src/components/landing/DeploymentSection.tsx
@@ -1,4 +1,4 @@
-import { ArrowRightIcon, BriefcaseBusinessIcon, CheckCircle2Icon, CloudIcon } from "lucide-react";
+import { ArrowRightIcon, BriefcaseBusinessIcon, CheckCircle2Icon, CloudIcon, ServerIcon } from "lucide-react";
 import { palette as c, cardShadow, cardShadowSmall, fonts } from "./theme";
 import { CtaButton, SectionShell, SectionTitle } from "./primitives";
 import { Reveal } from "./Reveal";
@@ -18,6 +18,13 @@ const guidedPilotPoints = [
   "Clear rollout plan for tools, regions, billing, and approvals",
 ] as const;
 
+const selfHostPoints = [
+  "Install from the main domain on your own Linux VPS",
+  "Browser shell, gateway, local Postgres, code-server, and systemd services",
+  "You own DNS, TLS, backups, upgrades, and server security",
+  "Best path for hackers, open-source users, and custom infrastructure",
+] as const;
+
 export function DeploymentSection() {
   return (
     <SectionShell id="deployment" className="pt-16 md:pt-28">
@@ -25,12 +32,12 @@ export function DeploymentSection() {
         <div className="mb-8 max-w-[44rem] md:mb-10">
           <SectionTitle
             title="Start with a private cloud computer."
-            continuation="Hosted today, with guided pilots for organizations."
+            continuation="Hosted, self-hosted, or guided for organizations."
           />
         </div>
       </Reveal>
 
-      <div className="grid gap-5 md:grid-cols-2">
+      <div className="grid gap-5 lg:grid-cols-3">
         <Reveal>
           <article className="flex h-full flex-col rounded-2xl p-7 md:p-9" style={{ backgroundColor: c.card, boxShadow: cardShadow }}>
             <div className="mb-6 flex items-center gap-4">
@@ -59,6 +66,33 @@ export function DeploymentSection() {
         </Reveal>
 
         <Reveal delay={90}>
+          <article className="flex h-full flex-col rounded-2xl p-7 md:p-9" style={{ backgroundColor: c.card, boxShadow: cardShadowSmall }}>
+            <div className="mb-6 flex items-center gap-4">
+              <span className="grid size-11 place-items-center rounded-lg" style={{ backgroundColor: "rgba(67,78,63,0.07)", color: c.forest }}>
+                <ServerIcon className="size-5" />
+              </span>
+              <div>
+                <p className="text-[0.8125rem] font-medium" style={{ color: c.subtle }}>Run your VPS</p>
+                <h3 className="text-[1.1875rem] font-medium" style={{ color: c.deep, fontFamily: fonts.sans }}>Self-host Matrix</h3>
+              </div>
+            </div>
+            <ul className="grid gap-3">
+              {selfHostPoints.map((point) => (
+                <li key={point} className="flex gap-3 text-[0.9375rem] leading-[1.6]" style={{ color: c.mutedFg }}>
+                  <CheckCircle2Icon className="mt-1 size-4 shrink-0" style={{ color: c.forest }} />
+                  <span>{point}</span>
+                </li>
+              ))}
+            </ul>
+            <div className="mt-auto pt-8">
+              <CtaButton href="/docs/self-host" variant="outline" phLocation="deployment" phTarget="self_host_docs">
+                Self-host guide <ArrowRightIcon className="size-4" />
+              </CtaButton>
+            </div>
+          </article>
+        </Reveal>
+
+        <Reveal delay={180}>
           <article className="flex h-full flex-col rounded-2xl p-7 md:p-9" style={{ backgroundColor: c.card, boxShadow: cardShadowSmall }}>
             <div className="mb-6 flex items-center gap-4">
               <span className="grid size-11 place-items-center rounded-lg" style={{ backgroundColor: "rgba(67,78,63,0.07)", color: c.forest }}>


### PR DESCRIPTION
## Summary
- add a root-run Linux VPS installer published as both `scripts/install-server.sh` and `www/public/install-server.sh` for `https://matrix-os.com/install-server.sh`
- add self-host shell mode with Clerk bypass plus internal gateway/code-server bearer protections
- document the two install paths, Managed Matrix Cloud and Manual VPS install, across docs, README, quickstart, and the landing deployment section
- add privacy-scoped manual install telemetry at `/api/install-telemetry` for started/completed/failed install counts, channel/version, IP-vs-DNS mode, bundle source, tool count, phase, and exit code
- harden the public self-host edge with bounded install-telemetry rate limits and an nginx-only `/health` probe that returns only `{"ok":true}`

## Validation
- `bash -n scripts/install-server.sh`
- `bun run test tests/scripts/self-host-installer.test.ts tests/shell/proxy-auth.test.ts tests/www/self-host-docs.test.ts`
- `pnpm --dir www build`
- `git diff --check`
- Earlier on this PR: `bun run typecheck`
- Earlier on this PR: `bun run build:shell:production`
- Earlier on this PR: `bun run check:patterns`
- Earlier on this PR: `bun run test`: 725 passed files, 7721 passed tests, 26 skipped

## Invariants
- Host bundles remain the runtime artifact. The installer only downloads and verifies a bundle; it does not rebuild production runtime on the VPS.
- Owner data remains under `/home/matrix/home` and the installer does not overwrite user home state during bundle updates.
- Self-host auth is explicit via `MATRIX_SELF_HOSTED=1`: Clerk is skipped in the shell, nginx Basic Auth protects the instance edge, `MATRIX_AUTH_TOKEN` protects gateway calls, and `MATRIX_CODE_PROXY_TOKEN` protects code-server proxying.
- Public `/health` is an edge-only readiness response. It does not proxy gateway internals or expose upstream status details.
- Manual install telemetry is best-effort and opt-out. It does not send handle, domain, password, auth tokens, Postgres password, project files, shell output, or code-server URL; the endpoint uses a 4 KB body cap, short-window rate limits, and sets `$ip` to `0.0.0.0`.
- Managed cloud-only services are not enabled by default: sync-agent, db-backup, platform billing/provisioning, Pipedream, and managed mobile/desktop handoff stay out of the standalone install path.
- If optional developer tools or code-server fail, core `matrix-gateway` and `matrix-shell` remain inspectable via systemd and journalctl.

## New VPS test command
To test the branch script itself against the current stable bundle:

```bash
curl -fsSL https://raw.githubusercontent.com/HamedMP/matrix-os/103-self-host-installer/www/public/install-server.sh | sudo MATRIX_DOMAIN='_' MATRIX_INSTALL_HANDLE='selfhost-test' bash
```

To test all branch shell/auth/web changes, first publish a host bundle built from this branch and pass its tarball URL, with a `.sha256` next to it:

```bash
curl -fsSL https://raw.githubusercontent.com/HamedMP/matrix-os/103-self-host-installer/www/public/install-server.sh | sudo \
  MATRIX_HOST_BUNDLE_URL='https://<branch-bundle-host>/matrix-host-bundle.tar.gz' \
  MATRIX_DOMAIN='_' \
  MATRIX_INSTALL_HANDLE='selfhost-test' \
  bash
```

To test the telemetry opt-out path:

```bash
curl -fsSL https://raw.githubusercontent.com/HamedMP/matrix-os/103-self-host-installer/www/public/install-server.sh | sudo MATRIX_NO_TELEMETRY=1 MATRIX_DOMAIN='_' bash
```

After install, use the printed Basic Auth credentials and check:

```bash
sudo systemctl status matrix-gateway matrix-shell matrix-code-server nginx --no-pager
sudo journalctl -u matrix-gateway -u matrix-shell -u matrix-code-server -n 100 --no-pager
```
