### PR TITLE
fix(platform): proxy app-domain PostHog relay before auth

### DIFF
--- a/packages/platform/src/main.ts
+++ b/packages/platform/src/main.ts
@@ -784,7 +784,9 @@ async function proxyPostHogRelay(c: Context): Promise<Response> {
   const upstreamBase = isPostHogAssetRelayPath(upstreamPath)
     ? POSTHOG_ASSET_HOST
     : POSTHOG_INGEST_HOST;
-  const upstream = new URL(`${upstreamPath}${requestUrl.search}`, upstreamBase);
+  const upstream = new URL(upstreamBase);
+  upstream.pathname = upstreamPath;
+  upstream.search = requestUrl.search;
 
   try {
     const response = await fetch(upstream.toString(), {

--- a/packages/platform/src/main.ts
+++ b/packages/platform/src/main.ts
@@ -169,6 +169,9 @@ const ADMIN_BODY_LIMIT = 64 * 1024;
 const PROXY_BODY_LIMIT = 10 * 1024 * 1024;
 const PROXY_TIMEOUT_MS = 30_000;
 const AUTH_SHELL_PROXY_TIMEOUT_MS = 5_000;
+const POSTHOG_RELAY_TIMEOUT_MS = 10_000;
+const POSTHOG_INGEST_HOST = 'https://eu.i.posthog.com';
+const POSTHOG_ASSET_HOST = 'https://eu-assets.i.posthog.com';
 const EDGE_SECRET_HEADER = 'x-matrix-edge-secret';
 const VPS_RELEASE_PROBE_TIMEOUT_MS = 10_000;
 const CLERK_USER_LOOKUP_TIMEOUT_MS = 10_000;
@@ -241,6 +244,15 @@ const HOP_BY_HOP_RESPONSE_HEADERS = new Set([
 const DECODED_FETCH_RESPONSE_HEADERS = new Set([
   'content-encoding',
   'content-length',
+]);
+const POSTHOG_RELAY_FORWARD_HEADERS = new Set([
+  'accept',
+  'accept-language',
+  'content-type',
+  'dnt',
+  'origin',
+  'referer',
+  'user-agent',
 ]);
 
 const HostBundleReleaseBodySchema = z.object({
@@ -734,6 +746,73 @@ function appDomainServiceWorkerResponse(): Response {
       'service-worker-allowed': '/',
     },
   });
+}
+
+function isPostHogRelayPath(path: string): boolean {
+  return path === '/relay' || path.startsWith('/relay/');
+}
+
+function isPostHogAssetRelayPath(upstreamPath: string): boolean {
+  return (
+    upstreamPath === '/static' ||
+    upstreamPath.startsWith('/static/') ||
+    upstreamPath === '/array' ||
+    upstreamPath.startsWith('/array/')
+  );
+}
+
+function buildPostHogRelayHeaders(c: Context, upstream: URL): Headers {
+  const headers = new Headers();
+  for (const [key, value] of Object.entries(c.req.header())) {
+    const lowerKey = key.toLowerCase();
+    if (
+      value &&
+      (POSTHOG_RELAY_FORWARD_HEADERS.has(lowerKey) || lowerKey.startsWith('sec-ch-ua'))
+    ) {
+      headers.set(key, value);
+    }
+  }
+  headers.set('host', upstream.host);
+  headers.set('accept-encoding', 'identity');
+  headers.set('connection', 'close');
+  return headers;
+}
+
+async function proxyPostHogRelay(c: Context): Promise<Response> {
+  const requestUrl = new URL(c.req.url);
+  const upstreamPath = requestUrl.pathname.slice('/relay'.length) || '/';
+  const upstreamBase = isPostHogAssetRelayPath(upstreamPath)
+    ? POSTHOG_ASSET_HOST
+    : POSTHOG_INGEST_HOST;
+  const upstream = new URL(`${upstreamPath}${requestUrl.search}`, upstreamBase);
+
+  try {
+    const response = await fetch(upstream.toString(), {
+      method: c.req.method,
+      headers: buildPostHogRelayHeaders(c, upstream),
+      redirect: 'manual',
+      signal: AbortSignal.timeout(POSTHOG_RELAY_TIMEOUT_MS),
+      body: ['GET', 'HEAD'].includes(c.req.method) ? undefined : await c.req.blob(),
+    });
+    const responseHeaders = sanitizeProxyResponseHeaders(response.headers);
+    if (!isPostHogAssetRelayPath(upstreamPath)) {
+      applyNoStoreResponseHeaders(responseHeaders);
+    }
+    return new Response(response.body, {
+      status: response.status,
+      headers: responseHeaders,
+    });
+  } catch (err: unknown) {
+    logPlatformRouteError('app-domain posthog relay proxy', err);
+    return new Response('Telemetry relay unavailable', {
+      status: 502,
+      headers: {
+        'cache-control': 'no-store, private',
+        'cdn-cache-control': 'no-store',
+        'cloudflare-cdn-cache-control': 'no-store',
+      },
+    });
+  }
 }
 
 function isPostgresUniqueViolation(err: unknown): boolean {
@@ -2942,6 +3021,9 @@ export function createApp(deps: {
     const reqPath = c.req.path;
     if (isAppDomain && reqPath === '/service-worker.js') {
       return appDomainServiceWorkerResponse();
+    }
+    if (isAppDomain && isPostHogRelayPath(reqPath)) {
+      return proxyPostHogRelay(c);
     }
     if (isAppDomain && (
       reqPath === '/auth/device' ||

--- a/tests/platform/proxy-routing.test.ts
+++ b/tests/platform/proxy-routing.test.ts
@@ -4889,6 +4889,89 @@ describe("platform proxy routing", () => {
     }
   });
 
+  it("keeps protocol-relative app-domain PostHog relay paths on the PostHog host", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(null, { status: 204 }),
+    );
+    const verifyToken = vi.fn().mockResolvedValue({ authenticated: false });
+    const app = createApp({
+      db,
+      orchestrator: stubOrchestrator(),
+      clerkAuth: createClerkAuth({
+        verifyToken,
+      }),
+      platformSecret: "platform-secret-123",
+    });
+
+    process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY = "pk_test_123";
+    try {
+      const res = await app.request("/relay//internal-metadata.svc/api?x=1", {
+        method: "POST",
+        headers: {
+          host: "app.matrix-os.com",
+          "content-type": "application/json",
+        },
+        body: "{}",
+      });
+
+      expect(res.status).toBe(204);
+      expect(verifyToken).not.toHaveBeenCalled();
+      expect(fetchMock).toHaveBeenCalledOnce();
+      const [target, init] = fetchMock.mock.calls[0]!;
+      expect(target).toBe("https://eu.i.posthog.com//internal-metadata.svc/api?x=1");
+      const headers = init?.headers as Headers;
+      expect(headers.get("host")).toBe("eu.i.posthog.com");
+    } finally {
+      delete process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY;
+    }
+  });
+
+  it("proxies app-domain PostHog relay static assets to the asset host with upstream caching", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response("asset", {
+        status: 200,
+        headers: {
+          "content-type": "text/javascript",
+          "cache-control": "public, max-age=31536000",
+        },
+      }),
+    );
+    const verifyToken = vi.fn().mockResolvedValue({ authenticated: false });
+    const app = createApp({
+      db,
+      orchestrator: stubOrchestrator(),
+      clerkAuth: createClerkAuth({
+        verifyToken,
+      }),
+      platformSecret: "platform-secret-123",
+    });
+
+    process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY = "pk_test_123";
+    try {
+      const res = await app.request("/relay/static/array.js", {
+        headers: {
+          host: "app.matrix-os.com",
+          authorization: "Bearer clerk-session",
+          cookie: "__session=clerk-cookie",
+        },
+      });
+
+      expect(res.status).toBe(200);
+      expect(await res.text()).toBe("asset");
+      expect(res.headers.get("cache-control")).toBe("public, max-age=31536000");
+      expect(verifyToken).not.toHaveBeenCalled();
+      expect(fetchMock).toHaveBeenCalledOnce();
+      const [target, init] = fetchMock.mock.calls[0]!;
+      expect(target).toBe("https://eu-assets.i.posthog.com/static/array.js");
+      const headers = init?.headers as Headers;
+      expect(headers.get("authorization")).toBeNull();
+      expect(headers.get("cookie")).toBeNull();
+      expect(headers.get("host")).toBe("eu-assets.i.posthog.com");
+    } finally {
+      delete process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY;
+    }
+  });
+
   it("routes app-domain icons directly to the runtime gateway", async () => {
     const verifyToken = vi.fn().mockResolvedValue({ sub: "user_alice" });
     const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(

--- a/tests/platform/proxy-routing.test.ts
+++ b/tests/platform/proxy-routing.test.ts
@@ -4844,6 +4844,51 @@ describe("platform proxy routing", () => {
     }
   });
 
+  it("proxies app-domain PostHog relay logs without auth or session headers", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(null, { status: 204 }),
+    );
+    const verifyToken = vi.fn().mockResolvedValue({ authenticated: false });
+    const app = createApp({
+      db,
+      orchestrator: stubOrchestrator(),
+      clerkAuth: createClerkAuth({
+        verifyToken,
+      }),
+      platformSecret: "platform-secret-123",
+    });
+
+    process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY = "pk_test_123";
+    try {
+      const res = await app.request("/relay/i/v1/logs?verbose=true", {
+        method: "POST",
+        headers: {
+          host: "app.matrix-os.com",
+          authorization: "Bearer clerk-session",
+          cookie: "__session=clerk-cookie; matrix_app_session__alice=session",
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({ api_key: "phc_test", batch: [] }),
+      });
+
+      expect(res.status).toBe(204);
+      expect(verifyToken).not.toHaveBeenCalled();
+      expect(fetchMock).toHaveBeenCalledOnce();
+      const [target, init] = fetchMock.mock.calls[0]!;
+      expect(target).toBe("https://eu.i.posthog.com/i/v1/logs?verbose=true");
+      expect(init?.method).toBe("POST");
+      expect(init?.signal).toBeInstanceOf(AbortSignal);
+      expect(init?.headers).toBeInstanceOf(Headers);
+      const headers = init?.headers as Headers;
+      expect(headers.get("content-type")).toBe("application/json");
+      expect(headers.get("authorization")).toBeNull();
+      expect(headers.get("cookie")).toBeNull();
+      expect(headers.get("host")).toBe("eu.i.posthog.com");
+    } finally {
+      delete process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY;
+    }
+  });
+
   it("routes app-domain icons directly to the runtime gateway", async () => {
     const verifyToken = vi.fn().mockResolvedValue({ sub: "user_alice" });
     const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(


### PR DESCRIPTION
## Summary
- Proxy app-domain /relay/* requests before Clerk/session routing so signed-out auth-shell telemetry can reach PostHog.
- Route PostHog static/array assets to the EU asset host and ingest/logs paths to the EU ingest host.
- Strip auth/session cookies from relay requests and enforce a 10s upstream timeout.

## Tests
- bun run test tests/platform/proxy-routing.test.ts -t "proxies app-domain PostHog relay logs"
- bun run test tests/platform/proxy-routing.test.ts
- pnpm --filter @matrix-os/platform build

## Review/Monitoring
- Draft until latest trusted Greptile result is 5/5.
- After Greptile 5/5, mark ready for CI and monitor required checks before merge.

## Invariants
- Source of truth: PostHog relay destinations are hardcoded platform constants matching the shell/www same-origin /relay contract; this is not a user-controlled proxy.
- Lock/transaction scope: no persistent writes or DB transactions are introduced.
- Acceptable orphan states: a PostHog relay outage returns a generic 502 and does not affect auth, billing, runtime routing, or customer data.
- Auth source of truth: /relay/* is intentionally public telemetry transport; browser authorization and Matrix app-session cookies are stripped before forwarding.
- Deferred scope: this does not enable automatic shell console-log capture or change PostHog project/dashboard configuration.