### PR TITLE
fix(www): restore quickstart manual setup anchor

### DIFF
--- a/www/content/docs/quickstart.mdx
+++ b/www/content/docs/quickstart.mdx
@@ -46,6 +46,10 @@ Do not scan my local machine for credentials. Do not upload local private keys. 
 
 Use `Ctrl-\ Ctrl-\` to detach from an attached terminal session without killing the remote process.
 
+## Manual setup
+
+If you prefer to perform each step yourself instead of handing the flow to an agent, use the managed cloud walkthrough below. For a VPS you operate directly, follow the [self-host guide](/docs/self-host).
+
 ## Managed setup
 
 <Steps>


### PR DESCRIPTION
## Summary
- Restore the quickstart `## Manual setup` anchor expected by the developer fast-path docs gate
- Keep the new managed cloud and self-host install path content intact

## Verification
- `bun run test tests/www/developer-fast-path-docs.test.ts tests/www/self-host-docs.test.ts`

## Invariants
- Source of truth: public quickstart docs remain in `www/content/docs/quickstart.mdx`
- Lock/transaction scope: no runtime state or persistence changes
- Acceptable orphan states: not applicable; docs-only change
- Auth source of truth: unchanged; docs continue to point users at Matrix/CLI/GitHub browser-device flows
- Deferred scope: no rewrite of self-host or managed onboarding content in this quick CI repair