### PR TITLE
fix(self-host): harden standalone installer

### DIFF
--- a/home/apps/_shared/default-apps.tsx
+++ b/home/apps/_shared/default-apps.tsx
@@ -26,6 +26,14 @@ type Metric = {
   tone?: string;
 };
 
+declare global {
+  interface Window {
+    MatrixOS?: {
+      openApp?: (name: string, path: string) => void;
+    };
+  }
+}
+
 const appMeta: Record<AppId, { title: string; subtitle: string; accent: string; metrics?: Metric[] }> = {
   "2048": {
     title: "2048",
@@ -305,7 +313,13 @@ function GameCenterApp() {
           <div className="game-card-art">{appMeta[id].title.slice(0, 2).toUpperCase()}</div>
           <h2>{appMeta[id].title}</h2>
           <p>{appMeta[id].subtitle}</p>
-          <button className="btn btn-ghost" type="button">Open</button>
+          <button
+            className="btn btn-ghost"
+            type="button"
+            onClick={() => window.MatrixOS?.openApp?.(appMeta[id].title, `apps/${id}/index.html`)}
+          >
+            Open
+          </button>
         </article>
       ))}
     </main>

--- a/home/apps/symphony/matrix.json
+++ b/home/apps/symphony/matrix.json
@@ -7,6 +7,7 @@
   "version": "1.0.0",
   "runtime": "vite",
   "slug": "symphony",
+  "hidden": true,
   "runtimeVersion": "^1.0.0",
   "scope": "personal",
   "build": {

--- a/scripts/install-server.sh
+++ b/scripts/install-server.sh
@@ -102,6 +102,25 @@ restart_optional_service() {
   fi
 }
 
+wait_http_ok() {
+  local description url log_hint attempt code
+  description="$1"
+  url="$2"
+  log_hint="$3"
+  for attempt in $(seq 1 30); do
+    code="$(curl --silent --show-error --output /dev/null --write-out "%{http_code}" --max-time 5 "$url" 2>>"$MATRIX_INSTALL_LOG" || true)"
+    if [ "$code" = "200" ]; then
+      ok "${description} is reachable"
+      return 0
+    fi
+    if [ "$code" = "500" ]; then
+      fail "${description} returned HTTP 500. ${log_hint}"
+    fi
+    sleep 2
+  done
+  fail "${description} did not become reachable. ${log_hint}"
+}
+
 fail() {
   local failed_phase
   failed_phase="${INSTALL_PHASE:-unknown}"
@@ -535,6 +554,12 @@ start_services() {
   restart_required_service nginx
 }
 
+verify_services() {
+  section "Verifying Matrix OS"
+  wait_http_ok "Matrix gateway" "http://127.0.0.1:4000/health" "Check: journalctl -u matrix-gateway -n 200 --no-pager"
+  wait_http_ok "Matrix shell" "http://127.0.0.1:3000/" "Check: journalctl -u matrix-shell -n 200 --no-pager"
+}
+
 print_summary() {
   local ip password_line ui_url
   ip="$(hostname -I 2>/dev/null | awk '{print $1}')"
@@ -596,6 +621,8 @@ main() {
   configure_nginx
   INSTALL_PHASE="services"
   start_services
+  INSTALL_PHASE="verify"
+  verify_services
   INSTALL_PHASE="complete"
   INSTALL_COMPLETED=1
   capture_install_telemetry "matrix_manual_install_completed" "completed" 0

--- a/scripts/install-server.sh
+++ b/scripts/install-server.sh
@@ -446,6 +446,21 @@ install_bundle() {
   INSTALL_TMP_SUM=""
 }
 
+prepare_runtime_permissions() {
+  section "Preparing runtime permissions"
+  if [ -d /opt/matrix/runtime/node ]; then
+    run_required "setting Node runtime owner group" chown -R root:matrix /opt/matrix/runtime/node
+    run_required "allowing matrix user Node runtime writes" chmod -R g+rwX /opt/matrix/runtime/node
+    if find /opt/matrix/runtime/node -type d -exec chmod g+s {} + >>"$MATRIX_INSTALL_LOG" 2>&1; then
+      ok "Runtime permissions ready"
+      return
+    fi
+    warn "could not set setgid bit on all Node runtime directories; agent installs may need sudo"
+    return
+  fi
+  warn "Node runtime prefix not found at /opt/matrix/runtime/node; skipping agent install permissions"
+}
+
 write_self_host_restore_service() {
   cat >/etc/systemd/system/matrix-restore.service <<'EOF'
 [Unit]
@@ -553,6 +568,16 @@ server {
     proxy_pass http://127.0.0.1:4000/;
   }
 
+  location /cli/ {
+    auth_basic off;
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade \$http_upgrade;
+    proxy_set_header Connection "upgrade";
+    proxy_read_timeout 3600s;
+    rewrite ^/cli/?(.*)\$ /\$1 break;
+    proxy_pass http://127.0.0.1:4000;
+  }
+
   location /ws {
     proxy_http_version 1.1;
     proxy_set_header Upgrade \$http_upgrade;
@@ -638,12 +663,15 @@ User: matrix
 ${password_line}
 
 Code editor: ${ui_url%/}/code/
+CLI gateway: ${ui_url%/}/cli
 Home: ${MATRIX_HOME_DIR}
 
 Useful commands:
   systemctl status matrix-gateway matrix-shell matrix-code nginx --no-pager
   journalctl -u matrix-gateway -u matrix-shell -u matrix-code -n 200 --no-pager
-  sudo -u matrix bash
+  sudo -iu matrix
+  MATRIX_TOKEN=\$(sudo awk -F= '\$1=="MATRIX_AUTH_TOKEN"{print \$2}' /opt/matrix/env/host.env)
+  matrix status --gateway ${ui_url%/}/cli --token "\$MATRIX_TOKEN"
 
 This preview protects the web UI with nginx Basic Auth. Put the host behind
 HTTPS, Tailscale, Cloudflare Access, or another trusted edge before long-term use.
@@ -666,6 +694,8 @@ main() {
   write_env
   INSTALL_PHASE="bundle"
   install_bundle
+  INSTALL_PHASE="runtime_permissions"
+  prepare_runtime_permissions
   INSTALL_PHASE="systemd"
   install_systemd_units
   INSTALL_PHASE="nginx"

--- a/scripts/install-server.sh
+++ b/scripts/install-server.sh
@@ -593,12 +593,27 @@ server {
     proxy_set_header Connection "upgrade";
     proxy_read_timeout 3600s;
     proxy_set_header Authorization "";
+    proxy_set_header X-Forwarded-Prefix /code;
     include /opt/matrix/env/code-proxy-token.conf;
     rewrite ^/code/?(.*)\$ /\$1 break;
     proxy_pass http://127.0.0.1:8787;
   }
 
+  location @matrix_code_root_ws {
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade \$http_upgrade;
+    proxy_set_header Connection "upgrade";
+    proxy_read_timeout 3600s;
+    proxy_set_header Authorization "";
+    include /opt/matrix/env/code-proxy-token.conf;
+    proxy_pass http://127.0.0.1:8787;
+  }
+
   location / {
+    if (\$arg_reconnectionToken != "") {
+      return 418;
+    }
+    error_page 418 = @matrix_code_root_ws;
     proxy_set_header Authorization "";
     proxy_pass http://127.0.0.1:3000;
   }

--- a/scripts/install-server.sh
+++ b/scripts/install-server.sh
@@ -4,7 +4,7 @@ set -Eeuo pipefail
 # Matrix OS standalone server installer.
 # Public copy is served from https://matrix-os.com/install-server.sh.
 
-DEFAULT_CHANNEL="${MATRIX_CHANNEL:-stable}"
+DEFAULT_CHANNEL="${MATRIX_CHANNEL:-dev}"
 DEFAULT_BUNDLE_BASE="https://app.matrix-os.com/system-bundles/${DEFAULT_CHANNEL}"
 MATRIX_HOST_BUNDLE_URL="${MATRIX_HOST_BUNDLE_URL:-${DEFAULT_BUNDLE_BASE}/matrix-host-bundle.tar.gz}"
 MATRIX_INSTALL_HANDLE="${MATRIX_INSTALL_HANDLE:-matrix}"
@@ -13,6 +13,7 @@ MATRIX_HOME_DIR="${MATRIX_HOME:-/home/matrix/home}"
 MATRIX_DEVELOPER_TOOLS="${MATRIX_DEVELOPER_TOOLS:-codex claude-code opencode pi}"
 MATRIX_INSTALL_TELEMETRY_URL="${MATRIX_INSTALL_TELEMETRY_URL:-https://matrix-os.com/api/install-telemetry}"
 MATRIX_INSTALL_TELEMETRY_ID="${MATRIX_INSTALL_TELEMETRY_ID:-}"
+MATRIX_INSTALL_LOG="${MATRIX_INSTALL_LOG:-/tmp/matrix-server-install.log}"
 INSTALL_TMP_BUNDLE=""
 INSTALL_TMP_SUM=""
 INSTALL_PHASE="init"
@@ -26,15 +27,65 @@ cleanup_install_tmp() {
 trap cleanup_install_tmp EXIT
 trap 'capture_install_failure $? $LINENO' ERR
 
+if [ "${MATRIX_INSTALL_COLOR:-auto}" = "always" ] || { [ "${MATRIX_INSTALL_COLOR:-auto}" = "auto" ] && [ -t 1 ] && [ "${TERM:-dumb}" != "dumb" ]; }; then
+  COLOR_RESET="$(printf '\033[0m')"
+  COLOR_BOLD="$(printf '\033[1m')"
+  COLOR_DIM="$(printf '\033[2m')"
+  COLOR_BLUE="$(printf '\033[34m')"
+  COLOR_GREEN="$(printf '\033[32m')"
+  COLOR_YELLOW="$(printf '\033[33m')"
+  COLOR_RED="$(printf '\033[31m')"
+else
+  COLOR_RESET=""
+  COLOR_BOLD=""
+  COLOR_DIM=""
+  COLOR_BLUE=""
+  COLOR_GREEN=""
+  COLOR_YELLOW=""
+  COLOR_RED=""
+fi
+
+section() {
+  printf '\n%s%s==> %s%s\n' "$COLOR_BLUE" "$COLOR_BOLD" "$*" "$COLOR_RESET"
+}
+
+banner() {
+  cat <<EOF
+
+${COLOR_BLUE}${COLOR_BOLD}███╗   ███╗ █████╗ ████████╗██████╗ ██╗██╗  ██╗     ██████╗ ███████╗
+████╗ ████║██╔══██╗╚══██╔══╝██╔══██╗██║╚██╗██╔╝    ██╔═══██╗██╔════╝
+██╔████╔██║███████║   ██║   ██████╔╝██║ ╚███╔╝     ██║   ██║███████╗
+██║╚██╔╝██║██╔══██║   ██║   ██╔══██╗██║ ██╔██╗     ██║   ██║╚════██║
+██║ ╚═╝ ██║██║  ██║   ██║   ██║  ██║██║██╔╝ ██╗    ╚██████╔╝███████║
+╚═╝     ╚═╝╚═╝  ╚═╝   ╚═╝   ╚═╝  ╚═╝╚═╝╚═╝  ╚═╝     ╚═════╝ ╚══════╝${COLOR_RESET}
+
+        ${COLOR_BOLD}Matrix OS server installer${COLOR_RESET}
+        ${COLOR_DIM}Browser shell + gateway + code-server + agents${COLOR_RESET}
+
+EOF
+}
+
 log() {
-  printf 'matrix-server-install: %s\n' "$*"
+  printf '%s    %s%s\n' "$COLOR_DIM" "$*" "$COLOR_RESET"
+}
+
+ok() {
+  printf '%s%sOK%s  %s\n' "$COLOR_GREEN" "$COLOR_BOLD" "$COLOR_RESET" "$*"
+}
+
+warn() {
+  printf '%s%sWARN%s  %s\n' "$COLOR_YELLOW" "$COLOR_BOLD" "$COLOR_RESET" "$*" >&2
 }
 
 fail() {
-  printf 'matrix-server-install: %s\n' "$*" >&2
+  local failed_phase
+  failed_phase="${INSTALL_PHASE:-unknown}"
+  printf '\n%s%sERROR%s %s\n' "$COLOR_RED" "$COLOR_BOLD" "$COLOR_RESET" "$*" >&2
   if declare -F capture_install_failure >/dev/null 2>&1; then
     capture_install_failure 1 "${BASH_LINENO[0]:-0}" || true
   fi
+  printf '%s\n' "Installer phase: ${failed_phase}" >&2
+  printf '%s\n\n' "Detailed log: ${MATRIX_INSTALL_LOG}" >&2
   exit 1
 }
 
@@ -175,6 +226,28 @@ validate_config() {
   esac
 }
 
+preflight_bundle_url() {
+  [ "${MATRIX_SKIP_BUNDLE_PREFLIGHT:-0}" != "1" ] || return 0
+
+  section "Checking Matrix OS host bundle"
+  log "Channel: ${DEFAULT_CHANNEL}"
+  log "Bundle: ${MATRIX_HOST_BUNDLE_URL}"
+
+  if ! curl --fail --silent --show-error --location --head \
+    --connect-timeout 10 --max-time 30 \
+    "$MATRIX_HOST_BUNDLE_URL" >/dev/null; then
+    fail "host bundle is not reachable: ${MATRIX_HOST_BUNDLE_URL}. Use MATRIX_CHANNEL=dev or pass MATRIX_HOST_BUNDLE_URL to a published bundle."
+  fi
+
+  if ! curl --fail --silent --show-error --location --head \
+    --connect-timeout 10 --max-time 30 \
+    "${MATRIX_HOST_BUNDLE_URL}.sha256" >/dev/null; then
+    fail "host bundle checksum is not reachable: ${MATRIX_HOST_BUNDLE_URL}.sha256"
+  fi
+
+  ok "Host bundle is reachable"
+}
+
 apt_get_update() {
   apt-get update \
     -o Acquire::Retries=5 \
@@ -185,9 +258,13 @@ apt_get_update() {
 install_packages() {
   export DEBIAN_FRONTEND=noninteractive
   if command -v apt-get >/dev/null 2>&1; then
-    log "installing OS packages"
-    apt_get_update
-    apt-get install -y ca-certificates curl docker.io git nginx openssl postgresql-client procps sudo tar
+    section "Installing OS packages"
+    : >"$MATRIX_INSTALL_LOG"
+    log "Writing apt output to ${MATRIX_INSTALL_LOG}"
+    apt_get_update >>"$MATRIX_INSTALL_LOG" 2>&1 || fail "apt-get update failed"
+    apt-get install -y ca-certificates curl docker.io git nginx openssl postgresql-client procps sudo tar >>"$MATRIX_INSTALL_LOG" 2>&1 \
+      || fail "apt-get install failed"
+    ok "OS packages installed"
     return
   fi
   fail "only apt-based Linux distributions are supported in this preview"
@@ -272,11 +349,18 @@ install_bundle() {
   INSTALL_TMP_BUNDLE="$tmp_bundle"
   INSTALL_TMP_SUM="$tmp_sum"
 
-  log "downloading host bundle"
-  curl --fail --location --retry 3 --retry-delay 5 --retry-all-errors \
-    --connect-timeout 10 --max-time 900 \
-    "$MATRIX_HOST_BUNDLE_URL" -o "$tmp_bundle"
-  curl --fail --location --retry 3 --retry-delay 5 --retry-all-errors \
+  section "Downloading Matrix OS"
+  log "Bundle: ${MATRIX_HOST_BUNDLE_URL}"
+  if [ -t 1 ]; then
+    curl --fail --location --progress-bar --retry 3 --retry-delay 5 --retry-all-errors \
+      --connect-timeout 10 --max-time 900 \
+      "$MATRIX_HOST_BUNDLE_URL" -o "$tmp_bundle"
+  else
+    curl --fail --silent --show-error --location --retry 3 --retry-delay 5 --retry-all-errors \
+      --connect-timeout 10 --max-time 900 \
+      "$MATRIX_HOST_BUNDLE_URL" -o "$tmp_bundle"
+  fi
+  curl --fail --silent --show-error --location --retry 3 --retry-delay 5 --retry-all-errors \
     --connect-timeout 10 --max-time 30 \
     "${MATRIX_HOST_BUNDLE_URL}.sha256" -o "$tmp_sum"
 
@@ -285,7 +369,8 @@ install_bundle() {
   [ -n "$expected" ] || fail "empty bundle checksum"
   [ "$expected" = "$actual" ] || fail "bundle checksum mismatch"
 
-  log "extracting host bundle"
+  ok "Host bundle checksum verified"
+  section "Extracting Matrix OS"
   tar -xzf "$tmp_bundle" -C /opt/matrix
   chmod 0755 /opt/matrix/bin/matrix-* /opt/matrix/bin/zellij 2>/dev/null || true
   cleanup_install_tmp
@@ -315,7 +400,7 @@ EOF
 }
 
 install_systemd_units() {
-  log "installing systemd units"
+  section "Installing systemd units"
   install -m 0644 /opt/matrix/systemd/matrix-gateway.service /etc/systemd/system/matrix-gateway.service
   install -m 0644 /opt/matrix/systemd/matrix-shell.service /etc/systemd/system/matrix-shell.service
   install -m 0644 /opt/matrix/systemd/matrix-code.service /etc/systemd/system/matrix-code.service
@@ -406,7 +491,7 @@ EOF
 }
 
 start_services() {
-  log "starting services"
+  section "Starting Matrix OS services"
   systemctl enable --now docker >/dev/null
   systemctl restart matrix-restore
   systemctl restart matrix-gateway
@@ -439,7 +524,7 @@ print_summary() {
 
   cat <<EOF
 
-Matrix OS standalone install complete.
+${COLOR_GREEN}${COLOR_BOLD}Matrix OS standalone install complete.${COLOR_RESET}
 
 Open: ${ui_url}
 User: matrix
@@ -460,10 +545,12 @@ EOF
 
 main() {
   INSTALL_PHASE="preflight"
+  banner
   require_root
   require_linux_systemd
   validate_config
   capture_install_telemetry "matrix_manual_install_started" "started" 0
+  preflight_bundle_url
   INSTALL_PHASE="packages"
   install_packages
   INSTALL_PHASE="user"

--- a/scripts/install-server.sh
+++ b/scripts/install-server.sh
@@ -77,6 +77,31 @@ warn() {
   printf '%s%sWARN%s  %s\n' "$COLOR_YELLOW" "$COLOR_BOLD" "$COLOR_RESET" "$*" >&2
 }
 
+run_required() {
+  local description
+  description="$1"
+  shift
+  "$@" >>"$MATRIX_INSTALL_LOG" 2>&1 || fail "${description} failed"
+}
+
+restart_required_service() {
+  local unit
+  unit="$1"
+  run_required "starting ${unit}" systemctl restart "$unit"
+  ok "${unit} started"
+}
+
+restart_optional_service() {
+  local unit label
+  unit="$1"
+  label="$2"
+  if systemctl restart "$unit" >>"$MATRIX_INSTALL_LOG" 2>&1; then
+    ok "${unit} started"
+  else
+    warn "${label} failed; Matrix OS core is still installed. Details: journalctl -u ${unit} -n 100 --no-pager"
+  fi
+}
+
 fail() {
   local failed_phase
   failed_phase="${INSTALL_PHASE:-unknown}"
@@ -273,16 +298,17 @@ install_packages() {
 }
 
 ensure_matrix_user() {
+  section "Preparing Matrix OS user"
   if ! getent group matrix >/dev/null 2>&1; then
-    groupadd --system matrix
+    run_required "creating matrix group" groupadd --system matrix
   fi
   if ! getent group docker >/dev/null 2>&1; then
-    groupadd --system docker
+    run_required "creating docker group" groupadd --system docker
   fi
   if ! id matrix >/dev/null 2>&1; then
-    useradd --system --gid matrix --groups docker --home-dir /home/matrix --shell /bin/bash matrix
+    run_required "creating matrix user" useradd --system --gid matrix --groups docker --home-dir /home/matrix --shell /bin/bash matrix
   else
-    usermod -aG docker matrix
+    run_required "updating matrix user groups" usermod -aG docker matrix
   fi
 
   install -d -o root -g matrix -m 0770 /opt/matrix
@@ -290,7 +316,8 @@ ensure_matrix_user() {
   install -d -o matrix -g matrix -m 0755 /home/matrix "$MATRIX_HOME_DIR" "$MATRIX_HOME_DIR/projects"
   install -d -o matrix -g matrix -m 0755 "$MATRIX_HOME_DIR/.local" "$MATRIX_HOME_DIR/.local/bin" "$MATRIX_HOME_DIR/.local/share"
   install -d -o matrix -g matrix -m 0755 "$MATRIX_HOME_DIR/.cache" "$MATRIX_HOME_DIR/.config"
-  usermod -d "$MATRIX_HOME_DIR" matrix
+  run_required "setting matrix home directory" usermod -d "$MATRIX_HOME_DIR" matrix
+  ok "Matrix OS user ready"
 }
 
 random_secret() {
@@ -411,11 +438,12 @@ install_systemd_units() {
     install -m 0644 /opt/matrix/systemd/matrix-developer-tools.service /etc/systemd/system/matrix-developer-tools.service
   fi
   write_self_host_restore_service
-  systemctl daemon-reload
-  systemctl enable docker matrix-restore matrix-gateway matrix-shell matrix-code matrix-code-server >/dev/null
+  run_required "reloading systemd" systemctl daemon-reload
+  run_required "enabling Matrix OS services" systemctl enable docker matrix-restore matrix-gateway matrix-shell matrix-code matrix-code-server
   if [ -f /etc/systemd/system/matrix-developer-tools.service ] && [ -n "$MATRIX_DEVELOPER_TOOLS" ]; then
-    systemctl enable matrix-developer-tools >/dev/null
+    run_required "enabling optional developer tools service" systemctl enable matrix-developer-tools
   fi
+  ok "Systemd units installed"
 }
 
 configure_nginx() {
@@ -488,22 +516,23 @@ EOF
 
   rm -f /etc/nginx/sites-enabled/default
   ln -sfn /etc/nginx/sites-available/matrix-self-host /etc/nginx/sites-enabled/matrix-self-host
-  nginx -t
-  systemctl enable nginx >/dev/null
+  run_required "testing nginx configuration" nginx -t
+  run_required "enabling nginx" systemctl enable nginx
+  ok "nginx configured"
 }
 
 start_services() {
   section "Starting Matrix OS services"
-  systemctl enable --now docker >/dev/null
-  systemctl restart matrix-restore
-  systemctl restart matrix-gateway
-  systemctl restart matrix-shell
-  systemctl restart matrix-code-server || true
-  systemctl restart matrix-code || true
+  run_required "starting docker" systemctl enable --now docker
+  restart_required_service matrix-restore
+  restart_required_service matrix-gateway
+  restart_required_service matrix-shell
+  restart_optional_service matrix-code-server "code-server proxy"
+  restart_optional_service matrix-code "code service"
   if systemctl list-unit-files matrix-developer-tools.service >/dev/null 2>&1; then
-    systemctl restart matrix-developer-tools || true
+    restart_optional_service matrix-developer-tools "optional developer tools installer"
   fi
-  systemctl restart nginx
+  restart_required_service nginx
 }
 
 print_summary() {

--- a/scripts/install-server.sh
+++ b/scripts/install-server.sh
@@ -594,9 +594,8 @@ server {
     proxy_read_timeout 3600s;
     proxy_set_header Authorization "";
     proxy_set_header X-Forwarded-Prefix /code;
-    include /opt/matrix/env/code-proxy-token.conf;
     rewrite ^/code/?(.*)\$ /\$1 break;
-    proxy_pass http://127.0.0.1:8787;
+    proxy_pass http://127.0.0.1:8788;
   }
 
   location @matrix_code_root_ws {
@@ -605,8 +604,7 @@ server {
     proxy_set_header Connection "upgrade";
     proxy_read_timeout 3600s;
     proxy_set_header Authorization "";
-    include /opt/matrix/env/code-proxy-token.conf;
-    proxy_pass http://127.0.0.1:8787;
+    proxy_pass http://127.0.0.1:8788;
   }
 
   location / {

--- a/scripts/install-server.sh
+++ b/scripts/install-server.sh
@@ -121,6 +121,26 @@ wait_http_ok() {
   fail "${description} did not become reachable. ${log_hint}"
 }
 
+wait_http_ok_auth() {
+  local description url password log_hint attempt code
+  description="$1"
+  url="$2"
+  password="$3"
+  log_hint="$4"
+  for attempt in $(seq 1 30); do
+    code="$(curl --silent --show-error --output /dev/null --write-out "%{http_code}" --max-time 5 --user "matrix:${password}" "$url" 2>>"$MATRIX_INSTALL_LOG" || true)"
+    if [ "$code" = "200" ]; then
+      ok "${description} is reachable"
+      return 0
+    fi
+    if [ "$code" = "401" ] || [ "$code" = "500" ]; then
+      fail "${description} returned HTTP ${code}. ${log_hint}"
+    fi
+    sleep 2
+  done
+  fail "${description} did not become reachable. ${log_hint}"
+}
+
 fail() {
   local failed_phase
   failed_phase="${INSTALL_PHASE:-unknown}"
@@ -466,7 +486,8 @@ install_systemd_units() {
 }
 
 configure_nginx() {
-  local code_proxy_token password hash server_name
+  local auth_token code_proxy_token password hash server_name
+  auth_token="$(read_env_value /opt/matrix/env/host.env MATRIX_AUTH_TOKEN)" || fail "MATRIX_AUTH_TOKEN is missing from host.env"
   code_proxy_token="$(read_env_value /opt/matrix/env/host.env MATRIX_CODE_PROXY_TOKEN)" || fail "MATRIX_CODE_PROXY_TOKEN is missing from host.env"
   server_name="$MATRIX_DOMAIN"
 
@@ -479,6 +500,9 @@ configure_nginx() {
   fi
   chmod 0640 /opt/matrix/env/nginx.htpasswd
   chown root:www-data /opt/matrix/env/nginx.htpasswd
+  printf 'proxy_set_header Authorization "Bearer %s";\n' "$auth_token" >/opt/matrix/env/gateway-auth-token.conf
+  chmod 0600 /opt/matrix/env/gateway-auth-token.conf
+  chown root:root /opt/matrix/env/gateway-auth-token.conf
   printf 'proxy_set_header X-Matrix-Code-Proxy-Token "%s";\n' "$code_proxy_token" >/opt/matrix/env/code-proxy-token.conf
   chmod 0600 /opt/matrix/env/code-proxy-token.conf
   chown root:root /opt/matrix/env/code-proxy-token.conf
@@ -497,23 +521,39 @@ server {
   proxy_set_header X-Forwarded-Proto \$scheme;
   proxy_set_header X-Real-IP \$remote_addr;
 
-  location /api/ { proxy_pass http://127.0.0.1:4000; }
-  location /files/ { proxy_pass http://127.0.0.1:4000; }
-  location /icons/ { proxy_pass http://127.0.0.1:4000; }
-  location /apps/ { proxy_pass http://127.0.0.1:4000; }
+  location /api/ {
+    include /opt/matrix/env/gateway-auth-token.conf;
+    proxy_pass http://127.0.0.1:4000;
+  }
+  location /files/ {
+    include /opt/matrix/env/gateway-auth-token.conf;
+    proxy_pass http://127.0.0.1:4000;
+  }
+  location /icons/ {
+    include /opt/matrix/env/gateway-auth-token.conf;
+    proxy_pass http://127.0.0.1:4000;
+  }
+  location /apps/ {
+    include /opt/matrix/env/gateway-auth-token.conf;
+    proxy_pass http://127.0.0.1:4000;
+  }
   location = /health {
     auth_basic off;
     access_log off;
     default_type application/json;
     return 200 '{"ok":true}';
   }
-  location /gateway/ { proxy_pass http://127.0.0.1:4000/; }
+  location /gateway/ {
+    include /opt/matrix/env/gateway-auth-token.conf;
+    proxy_pass http://127.0.0.1:4000/;
+  }
 
   location /ws {
     proxy_http_version 1.1;
     proxy_set_header Upgrade \$http_upgrade;
     proxy_set_header Connection "upgrade";
     proxy_read_timeout 3600s;
+    include /opt/matrix/env/gateway-auth-token.conf;
     proxy_pass http://127.0.0.1:4000;
   }
 
@@ -522,12 +562,14 @@ server {
     proxy_set_header Upgrade \$http_upgrade;
     proxy_set_header Connection "upgrade";
     proxy_read_timeout 3600s;
+    proxy_set_header Authorization "";
     include /opt/matrix/env/code-proxy-token.conf;
     rewrite ^/code/?(.*)\$ /\$1 break;
     proxy_pass http://127.0.0.1:8787;
   }
 
   location / {
+    proxy_set_header Authorization "";
     proxy_pass http://127.0.0.1:3000;
   }
 }
@@ -555,9 +597,13 @@ start_services() {
 }
 
 verify_services() {
+  local password
   section "Verifying Matrix OS"
   wait_http_ok "Matrix gateway" "http://127.0.0.1:4000/health" "Check: journalctl -u matrix-gateway -n 200 --no-pager"
   wait_http_ok "Matrix shell" "http://127.0.0.1:3000/" "Check: journalctl -u matrix-shell -n 200 --no-pager"
+  password="$(cat /opt/matrix/env/initial-ui-password)"
+  wait_http_ok_auth "nginx shell" "http://127.0.0.1/" "$password" "Check: journalctl -u nginx -n 120 --no-pager; journalctl -u matrix-shell -n 200 --no-pager"
+  wait_http_ok_auth "nginx gateway API" "http://127.0.0.1/api/identity" "$password" "Check: journalctl -u nginx -n 120 --no-pager; journalctl -u matrix-gateway -n 200 --no-pager"
 }
 
 print_summary() {

--- a/scripts/install-server.sh
+++ b/scripts/install-server.sh
@@ -486,20 +486,25 @@ install_systemd_units() {
 }
 
 configure_nginx() {
-  local auth_token code_proxy_token password hash server_name
+  local auth_token code_proxy_token password hash server_name htpasswd_file legacy_htpasswd_file
   auth_token="$(read_env_value /opt/matrix/env/host.env MATRIX_AUTH_TOKEN)" || fail "MATRIX_AUTH_TOKEN is missing from host.env"
   code_proxy_token="$(read_env_value /opt/matrix/env/host.env MATRIX_CODE_PROXY_TOKEN)" || fail "MATRIX_CODE_PROXY_TOKEN is missing from host.env"
   server_name="$MATRIX_DOMAIN"
+  htpasswd_file="/etc/nginx/matrix-self-host.htpasswd"
+  legacy_htpasswd_file="/opt/matrix/env/nginx.htpasswd"
 
-  if [ ! -f /opt/matrix/env/nginx.htpasswd ]; then
+  if [ ! -f "$htpasswd_file" ] && [ -f "$legacy_htpasswd_file" ]; then
+    install -m 0640 -o root -g www-data "$legacy_htpasswd_file" "$htpasswd_file"
+  fi
+  if [ ! -f "$htpasswd_file" ]; then
     password="$(openssl rand -base64 18 | tr -d '\n')"
     hash="$(openssl passwd -apr1 "$password")"
-    printf 'matrix:%s\n' "$hash" >/opt/matrix/env/nginx.htpasswd
+    printf 'matrix:%s\n' "$hash" >"$htpasswd_file"
     printf '%s\n' "$password" >/opt/matrix/env/initial-ui-password
     chmod 0600 /opt/matrix/env/initial-ui-password
   fi
-  chmod 0640 /opt/matrix/env/nginx.htpasswd
-  chown root:www-data /opt/matrix/env/nginx.htpasswd
+  chmod 0640 "$htpasswd_file"
+  chown root:www-data "$htpasswd_file"
   printf 'proxy_set_header Authorization "Bearer %s";\n' "$auth_token" >/opt/matrix/env/gateway-auth-token.conf
   chmod 0600 /opt/matrix/env/gateway-auth-token.conf
   chown root:root /opt/matrix/env/gateway-auth-token.conf
@@ -514,7 +519,7 @@ server {
 
   client_max_body_size 10m;
   auth_basic "Matrix OS";
-  auth_basic_user_file /opt/matrix/env/nginx.htpasswd;
+  auth_basic_user_file ${htpasswd_file};
 
   proxy_set_header Host \$host;
   proxy_set_header X-Forwarded-Host \$host;
@@ -602,8 +607,8 @@ verify_services() {
   wait_http_ok "Matrix gateway" "http://127.0.0.1:4000/health" "Check: journalctl -u matrix-gateway -n 200 --no-pager"
   wait_http_ok "Matrix shell" "http://127.0.0.1:3000/" "Check: journalctl -u matrix-shell -n 200 --no-pager"
   password="$(cat /opt/matrix/env/initial-ui-password)"
-  wait_http_ok_auth "nginx shell" "http://127.0.0.1/" "$password" "Check: journalctl -u nginx -n 120 --no-pager; journalctl -u matrix-shell -n 200 --no-pager"
-  wait_http_ok_auth "nginx gateway API" "http://127.0.0.1/api/identity" "$password" "Check: journalctl -u nginx -n 120 --no-pager; journalctl -u matrix-gateway -n 200 --no-pager"
+  wait_http_ok_auth "nginx shell" "http://127.0.0.1/" "$password" "Check: tail -120 /var/log/nginx/error.log; journalctl -u matrix-shell -n 200 --no-pager"
+  wait_http_ok_auth "nginx gateway API" "http://127.0.0.1/api/identity" "$password" "Check: tail -120 /var/log/nginx/error.log; journalctl -u matrix-gateway -n 200 --no-pager"
 }
 
 print_summary() {

--- a/scripts/install-server.sh
+++ b/scripts/install-server.sh
@@ -233,10 +233,12 @@ preflight_bundle_url() {
   log "Channel: ${DEFAULT_CHANNEL}"
   log "Bundle: ${MATRIX_HOST_BUNDLE_URL}"
 
-  if ! curl --fail --silent --show-error --location --head \
+  # Do not follow this HEAD redirect: the platform returns a signed R2 GET URL,
+  # and R2 rejects following that signature as a HEAD request.
+  if ! curl --fail --silent --show-error --head \
     --connect-timeout 10 --max-time 30 \
     "$MATRIX_HOST_BUNDLE_URL" >/dev/null; then
-    fail "host bundle is not reachable: ${MATRIX_HOST_BUNDLE_URL}. Use MATRIX_CHANNEL=dev or pass MATRIX_HOST_BUNDLE_URL to a published bundle."
+    fail "host bundle is not reachable: ${MATRIX_HOST_BUNDLE_URL}. Use a published MATRIX_CHANNEL or pass MATRIX_HOST_BUNDLE_URL to a published bundle."
   fi
 
   if ! curl --fail --silent --show-error --location --head \

--- a/scripts/install-server.sh
+++ b/scripts/install-server.sh
@@ -640,13 +640,19 @@ start_services() {
 }
 
 verify_services() {
-  local password
+  local password status
   section "Verifying Matrix OS"
   wait_http_ok "Matrix gateway" "http://127.0.0.1:4000/health" "Check: journalctl -u matrix-gateway -n 200 --no-pager"
   wait_http_ok "Matrix shell" "http://127.0.0.1:3000/" "Check: journalctl -u matrix-shell -n 200 --no-pager"
-  password="$(cat /opt/matrix/env/initial-ui-password)"
-  wait_http_ok_auth "nginx shell" "http://127.0.0.1/" "$password" "Check: tail -120 /var/log/nginx/error.log; journalctl -u matrix-shell -n 200 --no-pager"
-  wait_http_ok_auth "nginx gateway API" "http://127.0.0.1/api/identity" "$password" "Check: tail -120 /var/log/nginx/error.log; journalctl -u matrix-gateway -n 200 --no-pager"
+  if [ -f /opt/matrix/env/initial-ui-password ]; then
+    password="$(cat /opt/matrix/env/initial-ui-password)"
+    wait_http_ok_auth "nginx shell" "http://127.0.0.1/" "$password" "Check: tail -120 /var/log/nginx/error.log; journalctl -u matrix-shell -n 200 --no-pager"
+    wait_http_ok_auth "nginx gateway API" "http://127.0.0.1/api/identity" "$password" "Check: tail -120 /var/log/nginx/error.log; journalctl -u matrix-gateway -n 200 --no-pager"
+  else
+    status="$(curl -sS --max-time 10 -o /dev/null -w "%{http_code}" "http://127.0.0.1/" || true)"
+    [ "$status" = "401" ] || fail "nginx Basic Auth challenge returned HTTP ${status}, expected 401"
+    ok "nginx Basic Auth is configured"
+  fi
 }
 
 print_summary() {

--- a/shell/src/app/layout.tsx
+++ b/shell/src/app/layout.tsx
@@ -88,6 +88,7 @@ export default async function RootLayout({
     <html
       lang="en"
       data-posthog-visitor-country={visitorCountry ?? undefined}
+      data-matrix-self-hosted={selfHostedMode ? "1" : undefined}
       // Runtime replay kill switch: read on the server per request, so
       // setting POSTHOG_DISABLE_REPLAY and restarting matrix-shell stops
       // replay without rebuilding the bundle.
@@ -103,13 +104,17 @@ export default async function RootLayout({
     </html>
   );
 
+  if (selfHostedMode) {
+    return renderDocument(false);
+  }
+
   return (
     // ClerkProvider reads NEXT_PUBLIC_CLERK_SIGN_IN_URL / _SIGN_UP_URL to keep
     // sign-in/up cross-links on the in-app routes. Those vars are baked at
     // build time (default /sign-in and /sign-up); without them Clerk falls
     // back to the hosted Account Portal (accounts.matrix-os.com).
     <ClerkProvider>
-      {renderDocument(!selfHostedMode)}
+      {renderDocument(true)}
     </ClerkProvider>
   );
 }

--- a/shell/src/app/layout.tsx
+++ b/shell/src/app/layout.tsx
@@ -83,6 +83,7 @@ export default async function RootLayout({
   children: React.ReactNode;
 }>) {
   const visitorCountry = getPostHogVisitorCountry(await headers());
+  const selfHostedMode = process.env.MATRIX_SELF_HOSTED === "1";
   const renderDocument = (includePostHogIdentify: boolean) => (
     <html
       lang="en"
@@ -102,17 +103,13 @@ export default async function RootLayout({
     </html>
   );
 
-  if (process.env.MATRIX_SELF_HOSTED === "1") {
-    return renderDocument(false);
-  }
-
   return (
     // ClerkProvider reads NEXT_PUBLIC_CLERK_SIGN_IN_URL / _SIGN_UP_URL to keep
     // sign-in/up cross-links on the in-app routes. Those vars are baked at
     // build time (default /sign-in and /sign-up); without them Clerk falls
     // back to the hosted Account Portal (accounts.matrix-os.com).
     <ClerkProvider>
-      {renderDocument(true)}
+      {renderDocument(!selfHostedMode)}
     </ClerkProvider>
   );
 }

--- a/shell/src/app/page.tsx
+++ b/shell/src/app/page.tsx
@@ -10,7 +10,8 @@ export const metadata: Metadata = {
 };
 
 export default async function Home() {
-  const platformSessionActive = hasServerVerifiedMatrixSession(await headers());
+  const selfHostedMode = process.env.MATRIX_SELF_HOSTED === "1";
+  const platformSessionActive = selfHostedMode || hasServerVerifiedMatrixSession(await headers());
 
   return (
     <OnboardingGate platformSessionActive={platformSessionActive}>

--- a/shell/src/components/Desktop.tsx
+++ b/shell/src/components/Desktop.tsx
@@ -64,7 +64,7 @@ import { DeveloperModeDashboard } from "./developer/DeveloperModeDashboard";
 import { versionedIconUrl } from "@/lib/icon-url";
 import { cn, nameToSlug } from "@/lib/utils";
 import { iconUrlForSlug } from "@/lib/app-launch";
-import { HERMES_CHAT_HIDDEN, VOICE_HIDDEN, VSCODE_URL } from "@/lib/feature-flags";
+import { HERMES_CHAT_HIDDEN, VOICE_HIDDEN, getCodeEditorUrl } from "@/lib/feature-flags";
 import { isMainSectionApp, applyOrder } from "@/lib/dock-sections";
 import { MATRIX_ONBOARDING_BRAND_VERSION } from "@/lib/onboarding-brand";
 import { SHELL_Z_INDEX } from "@/lib/shell-layering";
@@ -1634,7 +1634,7 @@ export function Desktop({ launchAppPath, onOpenCommandPalette, chat }: DesktopPr
                     <button
                       type="button"
                       data-testid="dock-vscode"
-                      onClick={() => window.open(VSCODE_URL, "_blank", "noopener,noreferrer")}
+                      onClick={() => window.open(getCodeEditorUrl(), "_blank", "noopener,noreferrer")}
                       className="flex items-center justify-center rounded-xl border shadow-sm hover:shadow-md hover:scale-105 active:scale-95 transition-all bg-card border-border/60"
                       style={{ width: dock.iconSize, height: dock.iconSize }}
                     >

--- a/shell/src/components/Desktop.tsx
+++ b/shell/src/components/Desktop.tsx
@@ -1811,10 +1811,6 @@ export function Desktop({ launchAppPath, onOpenCommandPalette, chat }: DesktopPr
                 completeOnboarding();
                 focusOrOpen("Terminal", "__terminal__");
               }}
-              onOpenSymphony={() => {
-                completeOnboarding();
-                focusOrOpen("Symphony", "apps/symphony/index.html");
-              }}
               onSwitchCanvas={() => {
                 setDesktopMode("canvas");
                 setManualSetupVisible(true);

--- a/shell/src/components/MenuBar.tsx
+++ b/shell/src/components/MenuBar.tsx
@@ -9,6 +9,7 @@ import { AppSettingsDialog } from "./AppSettingsDialog";
 import { useMatrixBillingAccess } from "@/hooks/useMatrixBillingAccess";
 import { UserButton } from "./UserButton";
 import { ModeSwitcherBar } from "./ModeSwitcherBar";
+import { isSelfHostedDocument } from "@/lib/self-host-mode";
 
 const FALLBACK_APP_ICON = "/icon-192.png";
 
@@ -65,15 +66,31 @@ function MenuBarClock() {
 
 function MenuBarUser({ onOpenSettings }: { onOpenSettings?: () => void }) {
   const mounted = useIsClient();
+
+  if (!mounted) {
+    return <MenuBarUserPlaceholder />;
+  }
+  if (isSelfHostedDocument()) {
+    return <UserButton variant="menubar" onOpenSettings={onOpenSettings} />;
+  }
+
+  return <AuthenticatedMenuBarUser onOpenSettings={onOpenSettings} />;
+}
+
+function MenuBarUserPlaceholder() {
+  return (
+    <div className="px-1 py-0.5 rounded hover:bg-foreground/10">
+      <UserIcon className="size-[14px] text-foreground/70" />
+    </div>
+  );
+}
+
+function AuthenticatedMenuBarUser({ onOpenSettings }: { onOpenSettings?: () => void }) {
   const { isLoaded, isSignedIn } = useAuth();
   const { active: billingActive } = useMatrixBillingAccess();
 
-  if (!mounted || !isLoaded || !isSignedIn) {
-    return (
-      <div className="px-1 py-0.5 rounded hover:bg-foreground/10">
-        <UserIcon className="size-[14px] text-foreground/70" />
-      </div>
-    );
+  if (!isLoaded || !isSignedIn) {
+    return <MenuBarUserPlaceholder />;
   }
 
   // Only surface a billing chip when action is required. An active subscription

--- a/shell/src/components/Settings.tsx
+++ b/shell/src/components/Settings.tsx
@@ -26,6 +26,7 @@ import { BillingSection } from "./settings/sections/BillingSection";
 import { useMatrixBillingAccess } from "@/hooks/useMatrixBillingAccess";
 import { UserButton as AccountButton } from "./UserButton";
 import { SHELL_Z_INDEX } from "@/lib/shell-layering";
+import { isSelfHostedRuntime } from "@/lib/self-host-mode";
 
 
 const sections = [
@@ -120,17 +121,47 @@ interface SettingsProps {
 }
 
 export function Settings({
+  ...props
+}: SettingsProps) {
+  if (isSelfHostedRuntime()) {
+    return <SettingsFrame {...props} billingActive={true} showBillingSection={false} />;
+  }
+  return <ManagedSettings {...props} />;
+}
+
+function ManagedSettings(props: SettingsProps) {
+  const matrixBilling = useMatrixBillingAccess();
+  const billingActive =
+    props.billingActiveOverride !== undefined
+      ? props.billingActiveOverride
+      : matrixBilling.active;
+
+  return <SettingsFrame {...props} billingActive={billingActive} showBillingSection />;
+}
+
+interface SettingsFrameProps extends SettingsProps {
+  billingActive: boolean | null;
+  showBillingSection: boolean;
+}
+
+function SettingsFrame({
   open,
   onOpenChange,
   defaultSection = "appearance",
   lockedSection,
-  billingActiveOverride,
   closeDisabled = false,
   billingMode = "settings",
   onBillingCheckoutIntent,
   billingCheckoutReturnPath,
-}: SettingsProps) {
-  const [activeSection, setActiveSection] = useState<SectionId>(defaultSection);
+  billingActive,
+  showBillingSection,
+}: SettingsFrameProps) {
+  const resolvedDefaultSection = !showBillingSection && defaultSection === "billing" ? "appearance" : defaultSection;
+  const resolvedLockedSection = !showBillingSection && lockedSection === "billing" ? undefined : lockedSection;
+  const frameVisibleSections = showBillingSection
+    ? visibleSections
+    : visibleSections.filter((section) => section.id !== "billing");
+  const [activeSection, setActiveSection] = useState<SectionId>(resolvedDefaultSection);
   // Tracks the prior `open` value so the render-time section adjustment below
   // can detect the open transition. Uses the React-documented "store previous
   // prop in state" pattern (state, not a ref): reading/writing a ref during
@@ -139,12 +170,6 @@ export function Settings({
   // react-doctor-disable-next-line react-doctor/no-derived-useState -- transition tracker, not a mirror of `open`: it stores the previous `open` value so the render-time section adjustment below can detect the open->close edge
   // react-doctor-disable-next-line react-doctor/rerender-state-only-in-handlers -- intentionally state, not a ref: it IS read during render (in `justOpened` below) to drive the adjustment; the rule's "use useRef" advice would force ref reads/writes during render, which React Compiler flags as unoptimizable
   const [prevOpen, setPrevOpen] = useState(open);
-  const matrixBilling = useMatrixBillingAccess();
-  const billingActive =
-    billingActiveOverride !== undefined
-      ? billingActiveOverride
-      : matrixBilling.active;
-
   // Delayed unmount so the exit animation has time to play. `visible`
   // flips one frame after mount so the enter transition has a distinct
   // "from" state to animate out of. Same pattern as VocalPanel.
@@ -186,12 +211,12 @@ export function Settings({
   // it — so it cannot be a pure render-time derivation.
   const justOpened = open && !prevOpen;
   if (open !== prevOpen) setPrevOpen(open);
-  if (open && lockedSection) {
-    if (activeSection !== lockedSection) setActiveSection(lockedSection);
-  } else if (justOpened && billingActive === false) {
+  if (open && resolvedLockedSection) {
+    if (activeSection !== resolvedLockedSection) setActiveSection(resolvedLockedSection);
+  } else if (justOpened && showBillingSection && billingActive === false) {
     if (activeSection !== "billing") setActiveSection("billing");
   } else if (!open) {
-    if (activeSection !== defaultSection) setActiveSection(defaultSection);
+    if (activeSection !== resolvedDefaultSection) setActiveSection(resolvedDefaultSection);
   }
 
   if (!mounted) return null;
@@ -234,10 +259,10 @@ export function Settings({
                 aria-label="Settings sections"
                 className="flex gap-1 overflow-x-auto pb-1 sm:min-h-0 sm:flex-1 sm:flex-col sm:gap-0.5 sm:overflow-x-visible sm:overflow-y-auto sm:pb-0"
               >
-                {visibleSections.map((section) => {
+                {frameVisibleSections.map((section) => {
                   const Icon = section.icon;
                   const active = activeSection === section.id;
-                  const locked = Boolean(lockedSection && section.id !== lockedSection);
+                  const locked = Boolean(resolvedLockedSection && section.id !== resolvedLockedSection);
                   return (
                     <button
                       key={section.id}
@@ -277,7 +302,7 @@ export function Settings({
               {activeSection === "skills" && <SkillsSection />}
               {activeSection === "cron" && <CronSection />}
               {activeSection === "security" && <SecuritySection />}
-              {activeSection === "billing" && (
+              {showBillingSection && activeSection === "billing" && (
                 <BillingSection
                   mode={billingMode}
                   onCheckoutIntent={onBillingCheckoutIntent}

--- a/shell/src/components/UserButton.tsx
+++ b/shell/src/components/UserButton.tsx
@@ -14,6 +14,7 @@ import Link from "next/link";
 import { DropdownMenu as DropdownMenuPrimitive } from "radix-ui";
 import { useState } from "react";
 import { SHELL_Z_INDEX } from "@/lib/shell-layering";
+import { isSelfHostedDocument } from "@/lib/self-host-mode";
 
 const SIGN_OUT_TIMEOUT_MS = 10_000;
 
@@ -111,8 +112,62 @@ export function UserButton({
   if (!mounted) {
     return <Placeholder variant={variant} />;
   }
+  if (isSelfHostedDocument()) {
+    return <SelfHostedUserButton variant={variant} onOpenSettings={onOpenSettings} />;
+  }
 
   return <MountedUserButton variant={variant} onOpenSettings={onOpenSettings} />;
+}
+
+function SelfHostedUserButton({
+  variant,
+  onOpenSettings,
+}: {
+  variant: UserButtonVariant;
+  onOpenSettings?: () => void;
+}) {
+  const isSettings = variant === "settings";
+  const isMenubar = variant === "menubar";
+  const label = "Self-hosted Matrix OS";
+  const button = (
+    <button
+      type="button"
+      aria-label={label}
+      onClick={onOpenSettings}
+      className={cn(
+        "flex items-center justify-center rounded-xl border border-border/60 bg-card text-foreground shadow-sm transition-colors hover:bg-muted/70 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+        isMenubar ? "size-[18px] rounded-full border-0 bg-transparent shadow-none" : "size-10",
+        isSettings && "min-h-12 w-full justify-start gap-3 rounded-2xl px-2",
+      )}
+    >
+      <span
+        className={cn(
+          "grid shrink-0 place-items-center rounded-full bg-emerald-600/12 text-emerald-700 dark:text-emerald-300",
+          isMenubar ? "size-[18px]" : "size-10",
+        )}
+      >
+        <ServerIcon className={cn("size-5", isMenubar && "size-3")} aria-hidden="true" />
+      </span>
+      {isSettings ? (
+        <span className="min-w-0 truncate text-left text-sm font-semibold">
+          Self-hosted
+        </span>
+      ) : null}
+    </button>
+  );
+
+  if (isSettings) {
+    return button;
+  }
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>{button}</TooltipTrigger>
+      <TooltipContent side={isMenubar ? "bottom" : "right"} sideOffset={8}>
+        {label}
+      </TooltipContent>
+    </Tooltip>
+  );
 }
 
 function MountedUserButton({

--- a/shell/src/components/developer/DeveloperModeDashboard.tsx
+++ b/shell/src/components/developer/DeveloperModeDashboard.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { CheckCircle2Icon, ClipboardIcon, GitBranchIcon, SparklesIcon, TerminalIcon } from "lucide-react";
+import { CheckCircle2Icon, ClipboardIcon, GitBranchIcon, TerminalIcon } from "lucide-react";
 
 export const DEVELOPER_SETUP_PROMPT = `Set up Matrix OS as my remote developer computer.
 
@@ -12,7 +12,6 @@ Do not upload local private keys, scan my laptop for secrets, or paste credentia
 interface DeveloperModeDashboardProps {
   setupPrompt?: string;
   onOpenTerminal: () => void;
-  onOpenSymphony: () => void;
   onSwitchCanvas: () => void;
 }
 
@@ -28,7 +27,6 @@ const SETUP_STEPS = [
 export function DeveloperModeDashboard({
   setupPrompt = DEVELOPER_SETUP_PROMPT,
   onOpenTerminal,
-  onOpenSymphony,
   onSwitchCanvas,
 }: DeveloperModeDashboardProps) {
   const [copied, setCopied] = useState(false);
@@ -50,7 +48,7 @@ export function DeveloperModeDashboard({
           <p className="mb-2 text-xs font-medium uppercase tracking-[0.28em] text-amber-200/70">Developer Fast Path</p>
           <h1 className="text-3xl font-semibold tracking-tight">Developer mode</h1>
           <p className="mt-3 text-sm leading-6 text-white/64">
-            Terminal is the primary surface. Symphony is next after your runtime, repo, and coding agent are ready.
+            Terminal is the primary surface. Bring your coding agent into the Matrix computer once the runtime and repo are ready.
           </p>
           <ol className="mt-6 grid gap-3 text-sm">
             {SETUP_STEPS.map((step, index) => (
@@ -74,7 +72,7 @@ export function DeveloperModeDashboard({
                   Copy the setup prompt into your local agent, or open Terminal and run the GitHub auth step directly inside Matrix.
                 </p>
               </div>
-              <div className="grid gap-2 sm:grid-cols-2 lg:min-w-[320px] lg:grid-cols-1">
+              <div className="grid gap-2 lg:min-w-[320px]">
                 <button
                   type="button"
                   onClick={onOpenTerminal}
@@ -82,14 +80,6 @@ export function DeveloperModeDashboard({
                 >
                   <TerminalIcon className="size-4" aria-hidden="true" />
                   Open Terminal
-                </button>
-                <button
-                  type="button"
-                  onClick={onOpenSymphony}
-                  className="inline-flex items-center justify-center gap-2 rounded-2xl border border-white/12 bg-white/8 px-4 py-3 text-sm font-semibold text-white transition hover:bg-white/12"
-                >
-                  <SparklesIcon className="size-4" aria-hidden="true" />
-                  Open Symphony
                 </button>
               </div>
             </div>

--- a/shell/src/components/settings/sections/BillingPanel.tsx
+++ b/shell/src/components/settings/sections/BillingPanel.tsx
@@ -32,6 +32,7 @@ import type {
   BillingEntitlementSummary,
 } from "@/hooks/useMatrixBillingAccess";
 import { capturePostHogEvent, capturePostHogLog } from "@/lib/posthog-client";
+import { isSelfHostedDocument } from "@/lib/self-host-mode";
 
 function preselectedFeatureSlug(selectedPlan: unknown): string | null {
   if (typeof selectedPlan !== "string") return null;
@@ -927,10 +928,56 @@ export function BillingPanel({
   onCheckoutIntent?: () => void;
   checkoutReturnPath?: string;
 }) {
+  const props = {
+    active,
+    entitlement,
+    accessReason,
+    accessIssue,
+    mode,
+    onCheckoutIntent,
+    checkoutReturnPath,
+  };
+  if (isSelfHostedDocument()) {
+    return <BillingPanelInner {...props} selectedPlan={undefined} />;
+  }
+  return <ManagedBillingPanel {...props} />;
+}
+
+function ManagedBillingPanel(props: {
+  active: boolean | null;
+  entitlement?: BillingEntitlementSummary | null;
+  accessReason?: string | null;
+  accessIssue?: BillingAccessIssue;
+  mode: BillingPanelMode;
+  onCheckoutIntent?: () => void;
+  checkoutReturnPath?: string;
+}) {
   const { user } = useUser();
+  return <BillingPanelInner {...props} selectedPlan={user?.publicMetadata?.selectedPlan} />;
+}
+
+function BillingPanelInner({
+  active,
+  entitlement,
+  accessReason,
+  accessIssue,
+  mode = "settings",
+  onCheckoutIntent,
+  checkoutReturnPath,
+  selectedPlan,
+}: {
+  active: boolean | null;
+  entitlement?: BillingEntitlementSummary | null;
+  accessReason?: string | null;
+  accessIssue?: BillingAccessIssue;
+  mode?: BillingPanelMode;
+  onCheckoutIntent?: () => void;
+  checkoutReturnPath?: string;
+  selectedPlan?: unknown;
+}) {
   const [selectedProfileSlug, setSelectedProfileSlug] = useState<string>(
     () =>
-      preselectedFeatureSlug(user?.publicMetadata?.selectedPlan) ??
+      preselectedFeatureSlug(selectedPlan) ??
       MATRIX_BILLING_SERVER_PROFILES[1]?.featureSlug ??
       MATRIX_BILLING_SERVER_PROFILES[0]?.featureSlug ??
       "",

--- a/shell/src/components/workspace/WorkspaceApp.tsx
+++ b/shell/src/components/workspace/WorkspaceApp.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import type { FormEvent, ReactNode } from "react";
 import { BotIcon, CodeIcon, GitBranchIcon, PanelRightOpenIcon, PlayIcon, PlusIcon, RefreshCwIcon } from "lucide-react";
 import { getGatewayUrl } from "@/lib/gateway";
+import { getCodeEditorUrl } from "@/lib/feature-flags";
 
 const GATEWAY_URL = getGatewayUrl();
 const FETCH_TIMEOUT_MS = 10_000;
@@ -402,7 +403,7 @@ export function WorkspaceApp({ initialProjectSlug }: WorkspaceAppProps) {
       .some((value) => value.toLowerCase().includes(normalizedSessionSearch));
   });
   const ideFolder = selectedProject?.localPath ?? (activeSlug ? `/home/matrixos/home/projects/${activeSlug}` : "/home/matrixos/home");
-  const ideHref = `https://code.matrix-os.com/?folder=${encodeURIComponent(ideFolder)}`;
+  const ideHref = getCodeEditorUrl(ideFolder);
 
   return (
     <div

--- a/shell/src/hooks/useMatrixBillingAccess.ts
+++ b/shell/src/hooks/useMatrixBillingAccess.ts
@@ -3,7 +3,6 @@
 import { useAuth } from "@clerk/nextjs";
 import { useEffect, useMemo, useState } from "react";
 import { hasMatrixBillingAccess } from "@/lib/billing";
-import { isSelfHostedDocument } from "@/lib/self-host-mode";
 
 const BILLING_STATUS_TIMEOUT_MS = 10_000;
 const BILLING_STATUS_CACHE_TTL_MS = 30_000;
@@ -55,16 +54,6 @@ type BillingAccessRemoteState = {
 };
 
 export function useMatrixBillingAccess(): BillingAccessState {
-  if (isSelfHostedDocument()) {
-    return {
-      active: true,
-      checking: false,
-      entitlement: null,
-      accessReason: "self_hosted",
-      accessIssue: null,
-    };
-  }
-
   return useManagedMatrixBillingAccess();
 }
 

--- a/shell/src/hooks/useMatrixBillingAccess.ts
+++ b/shell/src/hooks/useMatrixBillingAccess.ts
@@ -3,6 +3,7 @@
 import { useAuth } from "@clerk/nextjs";
 import { useEffect, useMemo, useState } from "react";
 import { hasMatrixBillingAccess } from "@/lib/billing";
+import { isSelfHostedDocument } from "@/lib/self-host-mode";
 
 const BILLING_STATUS_TIMEOUT_MS = 10_000;
 const BILLING_STATUS_CACHE_TTL_MS = 30_000;
@@ -54,6 +55,20 @@ type BillingAccessRemoteState = {
 };
 
 export function useMatrixBillingAccess(): BillingAccessState {
+  if (isSelfHostedDocument()) {
+    return {
+      active: true,
+      checking: false,
+      entitlement: null,
+      accessReason: "self_hosted",
+      accessIssue: null,
+    };
+  }
+
+  return useManagedMatrixBillingAccess();
+}
+
+function useManagedMatrixBillingAccess(): BillingAccessState {
   const { isLoaded, isSignedIn, has, userId } = useAuth();
   // react-doctor-disable-next-line react-doctor/react-compiler-no-manual-memoization -- returned hook API / stable identity for effect dep
   const legacyActive = useMemo(

--- a/shell/src/lib/feature-flags.ts
+++ b/shell/src/lib/feature-flags.ts
@@ -10,6 +10,19 @@ export const HERMES_CHAT_HIDDEN = true;
 // out of the minimal flow. The vocal store/overlay wiring stays intact.
 export const VOICE_HIDDEN = true;
 
-// VSCode (code-server) editor — opened from a dock icon. The hosted editor
-// lives at code.matrix-os.com in production; override per environment as needed.
+import { isSelfHostedDocument } from "./self-host-mode";
+
+// VSCode (code-server) editor -- opened from a dock icon. Managed Matrix Cloud
+// routes through code.matrix-os.com; standalone installs expose code-server on
+// the same host under /code/.
 export const VSCODE_URL = "https://code.matrix-os.com";
+
+export function getCodeEditorUrl(folder?: string): string {
+  const base = isSelfHostedDocument() ? "/code/" : VSCODE_URL;
+  if (!folder) {
+    return base;
+  }
+  const url = new URL(base, typeof window === "undefined" ? "https://app.matrix-os.com" : window.location.origin);
+  url.searchParams.set("folder", folder);
+  return isSelfHostedDocument() ? `${url.pathname}${url.search}` : url.toString();
+}

--- a/shell/src/lib/self-host-mode.ts
+++ b/shell/src/lib/self-host-mode.ts
@@ -4,3 +4,10 @@ export function isSelfHostedDocument(): boolean {
   }
   return document.documentElement?.dataset.matrixSelfHosted === "1";
 }
+
+export function isSelfHostedRuntime(): boolean {
+  if (isSelfHostedDocument()) {
+    return true;
+  }
+  return typeof process !== "undefined" && process.env.MATRIX_SELF_HOSTED === "1";
+}

--- a/shell/src/lib/self-host-mode.ts
+++ b/shell/src/lib/self-host-mode.ts
@@ -1,0 +1,6 @@
+export function isSelfHostedDocument(): boolean {
+  if (typeof document === "undefined") {
+    return false;
+  }
+  return document.documentElement?.dataset.matrixSelfHosted === "1";
+}

--- a/shell/src/lib/websocket-auth.ts
+++ b/shell/src/lib/websocket-auth.ts
@@ -1,4 +1,5 @@
 import { getGatewayUrl, getGatewayWs } from "./gateway";
+import { isSelfHostedDocument } from "./self-host-mode";
 
 const WS_AUTH_PATH = "/api/auth/ws-token";
 const WS_TOKEN_REFRESH_SKEW_MS = 30_000;
@@ -74,6 +75,10 @@ export async function buildAuthenticatedWebSocketUrl(
     if (typeof value === "string" && value.length > 0) {
       gatewayUrl.searchParams.set(key, value);
     }
+  }
+
+  if (isSelfHostedDocument()) {
+    return gatewayUrl.toString();
   }
 
   const token = await getWebSocketAuthToken();

--- a/tests/gateway/apps.test.ts
+++ b/tests/gateway/apps.test.ts
@@ -117,6 +117,28 @@ describe("T711: GET /api/apps", () => {
     expect(apps.map((app) => app.name)).toEqual(["Good App"]);
   });
 
+  it("does not list hidden runtime apps", async () => {
+    mkdirSync(join(homePath, "apps/symphony/dist"), { recursive: true });
+    writeFileSync(join(homePath, "apps/symphony/dist/index.html"), "<html></html>");
+    writeFileSync(
+      join(homePath, "apps/symphony/matrix.json"),
+      JSON.stringify({
+        name: "Symphony",
+        slug: "symphony",
+        version: "1.0.0",
+        runtimeVersion: "^1.0.0",
+        category: "developer",
+        runtime: "vite",
+        hidden: true,
+        build: { command: "vite build", output: "dist" },
+      }),
+    );
+
+    const apps = await listApps(homePath);
+
+    expect(apps.map((app) => app.name)).not.toContain("Symphony");
+  });
+
   it("does not warn for ordinary nested directories without manifests", async () => {
     mkdirSync(join(homePath, "apps/generated/app/api/health"), { recursive: true });
     mkdirSync(join(homePath, "apps/generated/src/components"), { recursive: true });

--- a/tests/gateway/games.test.ts
+++ b/tests/gateway/games.test.ts
@@ -85,5 +85,7 @@ describe("T1420-T1427: Pre-installed games", () => {
       expect(shared).toContain(slug);
     }
     expect(shared).toContain("gameCards");
+    expect(shared).toContain("window.MatrixOS?.openApp");
+    expect(shared).toContain("apps/${id}/index.html");
   });
 });

--- a/tests/scripts/self-host-installer.test.ts
+++ b/tests/scripts/self-host-installer.test.ts
@@ -22,7 +22,8 @@ describe("self-host server installer", () => {
     expect(script).toContain("MATRIX_HOST_BUNDLE_URL");
     expect(script).toContain("${MATRIX_HOST_BUNDLE_URL}.sha256");
     expect(script).toContain("preflight_bundle_url");
-    expect(script).toContain("curl --fail --silent --show-error --location --head");
+    expect(script).toContain("signed R2 GET URL");
+    expect(script).toContain("curl --fail --silent --show-error --head");
     expect(script).toContain("host bundle is not reachable");
     expect(script).toContain("Host bundle is reachable");
     expect(script).toContain("sha256sum \"$tmp_bundle\"");

--- a/tests/scripts/self-host-installer.test.ts
+++ b/tests/scripts/self-host-installer.test.ts
@@ -98,8 +98,12 @@ describe("self-host server installer", () => {
     expect(script).toContain("openssl passwd -apr1");
     expect(script).toContain("if [ ! -f /opt/matrix/env/nginx.htpasswd ]; then");
     expect(script).toContain("existing nginx Basic Auth credentials");
+    expect(script).toContain("gateway-auth-token.conf");
+    expect(script).toContain("proxy_set_header Authorization \"Bearer %s\"");
+    expect(script).toContain("proxy_set_header Authorization \"\"");
     expect(script).toContain("code-proxy-token.conf");
     expect(script).toContain("chmod 0600 /opt/matrix/env/code-proxy-token.conf");
+    expect(script).toContain("include /opt/matrix/env/gateway-auth-token.conf");
     expect(script).toContain("include /opt/matrix/env/code-proxy-token.conf");
     expect(script).toContain("proxy_read_timeout 3600s");
     expect(script).toContain("proxy_pass http://127.0.0.1:3000");
@@ -126,10 +130,15 @@ describe("self-host server installer", () => {
     expect(script).toContain("wait_http_ok");
     expect(script).toContain("Verifying Matrix OS");
     expect(script).toContain('${description} returned HTTP 500');
+    expect(script).toContain("wait_http_ok_auth");
     expect(script).toContain('wait_http_ok "Matrix shell"');
+    expect(script).toContain('wait_http_ok_auth "nginx shell"');
+    expect(script).toContain('wait_http_ok_auth "nginx gateway API"');
     expect(script).toContain("journalctl -u matrix-shell -n 200 --no-pager");
+    expect(script).toContain("journalctl -u nginx -n 120 --no-pager");
     expect(script).toContain("http://127.0.0.1:3000/");
     expect(script).toContain("http://127.0.0.1:4000/health");
+    expect(script).toContain("http://127.0.0.1/api/identity");
     expect(script).toContain("optional developer tools installer");
     expect(script).toContain("Matrix OS core is still installed");
     expect(script).toContain("usermod -aG docker matrix");

--- a/tests/scripts/self-host-installer.test.ts
+++ b/tests/scripts/self-host-installer.test.ts
@@ -123,6 +123,13 @@ describe("self-host server installer", () => {
     expect(script).toContain("run_required");
     expect(script).toContain("restart_required_service matrix-gateway");
     expect(script).toContain("restart_optional_service matrix-developer-tools");
+    expect(script).toContain("wait_http_ok");
+    expect(script).toContain("Verifying Matrix OS");
+    expect(script).toContain('${description} returned HTTP 500');
+    expect(script).toContain('wait_http_ok "Matrix shell"');
+    expect(script).toContain("journalctl -u matrix-shell -n 200 --no-pager");
+    expect(script).toContain("http://127.0.0.1:3000/");
+    expect(script).toContain("http://127.0.0.1:4000/health");
     expect(script).toContain("optional developer tools installer");
     expect(script).toContain("Matrix OS core is still installed");
     expect(script).toContain("usermod -aG docker matrix");

--- a/tests/scripts/self-host-installer.test.ts
+++ b/tests/scripts/self-host-installer.test.ts
@@ -17,9 +17,14 @@ describe("self-host server installer", () => {
   it("installs from a verified host bundle and writes standalone self-host configuration", () => {
     const script = readFileSync(join(root, "scripts/install-server.sh"), "utf8");
 
+    expect(script).toContain('DEFAULT_CHANNEL="${MATRIX_CHANNEL:-dev}"');
     expect(script).toContain("https://app.matrix-os.com/system-bundles/${DEFAULT_CHANNEL}");
     expect(script).toContain("MATRIX_HOST_BUNDLE_URL");
     expect(script).toContain("${MATRIX_HOST_BUNDLE_URL}.sha256");
+    expect(script).toContain("preflight_bundle_url");
+    expect(script).toContain("curl --fail --silent --show-error --location --head");
+    expect(script).toContain("host bundle is not reachable");
+    expect(script).toContain("Host bundle is reachable");
     expect(script).toContain("sha256sum \"$tmp_bundle\"");
     expect(script).toContain("[ \"$expected\" = \"$actual\" ] || fail \"bundle checksum mismatch\"");
     expect(script).toContain("tar -xzf \"$tmp_bundle\" -C /opt/matrix");
@@ -46,6 +51,12 @@ describe("self-host server installer", () => {
 
     expect(script).toContain("MATRIX_INSTALL_TELEMETRY_URL");
     expect(script).toContain("MATRIX_NO_TELEMETRY");
+    expect(script).toContain("MATRIX_INSTALL_LOG");
+    expect(script).toContain("MATRIX_INSTALL_COLOR");
+    expect(script).toContain("Matrix OS server installer");
+    expect(script).toContain("Browser shell + gateway + code-server + agents");
+    expect(script).toContain("███╗   ███╗");
+    expect(script).toContain("██████╗ ██╗██╗  ██╗");
     expect(script).toContain("[ \"${MATRIX_INSTALL_TELEMETRY:-1}\" != \"0\" ]");
     expect(script).toContain("matrix_manual_install_started");
     expect(script).toContain("matrix_manual_install_completed");
@@ -102,6 +113,12 @@ describe("self-host server installer", () => {
   it("installs the core Matrix services without enabling managed-cloud backup requirements", () => {
     const script = readFileSync(join(root, "scripts/install-server.sh"), "utf8");
 
+    expect(script).toContain("Installing OS packages");
+    expect(script).toContain("Writing apt output to ${MATRIX_INSTALL_LOG}");
+    expect(script).toContain("apt_get_update >>\"$MATRIX_INSTALL_LOG\" 2>&1");
+    expect(script).toContain("apt-get install -y ca-certificates curl docker.io git nginx openssl postgresql-client procps sudo tar >>\"$MATRIX_INSTALL_LOG\" 2>&1");
+    expect(script).toContain("Downloading Matrix OS");
+    expect(script).toContain("--progress-bar");
     expect(script).toContain("install -m 0644 /opt/matrix/systemd/matrix-gateway.service");
     expect(script).toContain("install -m 0644 /opt/matrix/systemd/matrix-shell.service");
     expect(script).toContain("install -m 0644 /opt/matrix/systemd/matrix-code.service");

--- a/tests/scripts/self-host-installer.test.ts
+++ b/tests/scripts/self-host-installer.test.ts
@@ -114,6 +114,8 @@ describe("self-host server installer", () => {
     expect(script).toContain("openssl passwd -apr1");
     expect(script).toContain('if [ ! -f "$htpasswd_file" ]; then');
     expect(script).toContain("existing nginx Basic Auth credentials");
+    expect(script).toContain('if [ -f /opt/matrix/env/initial-ui-password ]; then');
+    expect(script).toContain("nginx Basic Auth challenge returned HTTP ${status}, expected 401");
     expect(script).toContain("gateway-auth-token.conf");
     expect(script).toContain("proxy_set_header Authorization \"Bearer %s\"");
     expect(script).toContain("proxy_set_header Authorization \"\"");

--- a/tests/scripts/self-host-installer.test.ts
+++ b/tests/scripts/self-host-installer.test.ts
@@ -46,6 +46,19 @@ describe("self-host server installer", () => {
     expect(script).toContain("trap cleanup_install_tmp EXIT");
   });
 
+  it("prepares the bundled Node runtime for owner-user agent installs", () => {
+    const script = readFileSync(join(root, "scripts/install-server.sh"), "utf8");
+
+    expect(script).toContain("prepare_runtime_permissions");
+    expect(script).toContain("Preparing runtime permissions");
+    expect(script).toContain("[ -d /opt/matrix/runtime/node ]");
+    expect(script).toContain("chown -R root:matrix /opt/matrix/runtime/node");
+    expect(script).toContain("chmod -R g+rwX /opt/matrix/runtime/node");
+    expect(script).toContain('find /opt/matrix/runtime/node -type d -exec chmod g+s {} +');
+    expect(script).toContain("Runtime permissions ready");
+    expect(script).toContain("sudo -iu matrix");
+  });
+
   it("reports privacy-scoped manual install telemetry with an opt-out", () => {
     const script = readFileSync(join(root, "scripts/install-server.sh"), "utf8");
     const route = readFileSync(join(root, "www/src/app/api/install-telemetry/route.ts"), "utf8");
@@ -114,6 +127,11 @@ describe("self-host server installer", () => {
     expect(script).toContain("proxy_pass http://127.0.0.1:8787");
     expect(script).toContain("proxy_set_header X-Matrix-Code-Proxy-Token \"%s\"");
     expect(script).toContain("-p 127.0.0.1:5432:5432");
+    expect(script).toContain("location /cli/");
+    expect(script).toContain("auth_basic off");
+    expect(script).toContain("rewrite ^/cli/?(.*)\\$ /\\$1 break");
+    expect(script).toContain("CLI gateway: ${ui_url%/}/cli");
+    expect(script).toContain("matrix status --gateway ${ui_url%/}/cli --token \"\\$MATRIX_TOKEN\"");
     expect(script).not.toContain("-p 5432:5432");
     expect(script).not.toContain("grep '^MATRIX_CODE_PROXY_TOKEN='");
   });

--- a/tests/scripts/self-host-installer.test.ts
+++ b/tests/scripts/self-host-installer.test.ts
@@ -120,6 +120,13 @@ describe("self-host server installer", () => {
     expect(script).toContain("apt-get install -y ca-certificates curl docker.io git nginx openssl postgresql-client procps sudo tar >>\"$MATRIX_INSTALL_LOG\" 2>&1");
     expect(script).toContain("Downloading Matrix OS");
     expect(script).toContain("--progress-bar");
+    expect(script).toContain("run_required");
+    expect(script).toContain("restart_required_service matrix-gateway");
+    expect(script).toContain("restart_optional_service matrix-developer-tools");
+    expect(script).toContain("optional developer tools installer");
+    expect(script).toContain("Matrix OS core is still installed");
+    expect(script).toContain("usermod -aG docker matrix");
+    expect(script).toContain("testing nginx configuration");
     expect(script).toContain("install -m 0644 /opt/matrix/systemd/matrix-gateway.service");
     expect(script).toContain("install -m 0644 /opt/matrix/systemd/matrix-shell.service");
     expect(script).toContain("install -m 0644 /opt/matrix/systemd/matrix-code.service");

--- a/tests/scripts/self-host-installer.test.ts
+++ b/tests/scripts/self-host-installer.test.ts
@@ -91,12 +91,15 @@ describe("self-host server installer", () => {
     const script = readFileSync(join(root, "scripts/install-server.sh"), "utf8");
 
     expect(script).toContain("auth_basic \"Matrix OS\"");
-    expect(script).toContain("auth_basic_user_file /opt/matrix/env/nginx.htpasswd");
+    expect(script).toContain("htpasswd_file=\"/etc/nginx/matrix-self-host.htpasswd\"");
+    expect(script).toContain("legacy_htpasswd_file=\"/opt/matrix/env/nginx.htpasswd\"");
+    expect(script).toContain('install -m 0640 -o root -g www-data "$legacy_htpasswd_file" "$htpasswd_file"');
+    expect(script).toContain("auth_basic_user_file ${htpasswd_file}");
     expect(script).toContain("location = /health");
     expect(script).toContain("auth_basic off");
     expect(script).toContain("return 200 '{\"ok\":true}'");
     expect(script).toContain("openssl passwd -apr1");
-    expect(script).toContain("if [ ! -f /opt/matrix/env/nginx.htpasswd ]; then");
+    expect(script).toContain('if [ ! -f "$htpasswd_file" ]; then');
     expect(script).toContain("existing nginx Basic Auth credentials");
     expect(script).toContain("gateway-auth-token.conf");
     expect(script).toContain("proxy_set_header Authorization \"Bearer %s\"");
@@ -135,7 +138,7 @@ describe("self-host server installer", () => {
     expect(script).toContain('wait_http_ok_auth "nginx shell"');
     expect(script).toContain('wait_http_ok_auth "nginx gateway API"');
     expect(script).toContain("journalctl -u matrix-shell -n 200 --no-pager");
-    expect(script).toContain("journalctl -u nginx -n 120 --no-pager");
+    expect(script).toContain("tail -120 /var/log/nginx/error.log");
     expect(script).toContain("http://127.0.0.1:3000/");
     expect(script).toContain("http://127.0.0.1:4000/health");
     expect(script).toContain("http://127.0.0.1/api/identity");

--- a/tests/scripts/self-host-installer.test.ts
+++ b/tests/scripts/self-host-installer.test.ts
@@ -121,6 +121,10 @@ describe("self-host server installer", () => {
     expect(script).toContain("chmod 0600 /opt/matrix/env/code-proxy-token.conf");
     expect(script).toContain("include /opt/matrix/env/gateway-auth-token.conf");
     expect(script).toContain("include /opt/matrix/env/code-proxy-token.conf");
+    expect(script).toContain("location @matrix_code_root_ws");
+    expect(script).toContain('if (\\$arg_reconnectionToken != "")');
+    expect(script).toContain("error_page 418 = @matrix_code_root_ws");
+    expect(script).toContain("proxy_set_header X-Forwarded-Prefix /code");
     expect(script).toContain("proxy_read_timeout 3600s");
     expect(script).toContain("proxy_pass http://127.0.0.1:3000");
     expect(script).toContain("proxy_pass http://127.0.0.1:4000");

--- a/tests/scripts/self-host-installer.test.ts
+++ b/tests/scripts/self-host-installer.test.ts
@@ -120,15 +120,15 @@ describe("self-host server installer", () => {
     expect(script).toContain("code-proxy-token.conf");
     expect(script).toContain("chmod 0600 /opt/matrix/env/code-proxy-token.conf");
     expect(script).toContain("include /opt/matrix/env/gateway-auth-token.conf");
-    expect(script).toContain("include /opt/matrix/env/code-proxy-token.conf");
     expect(script).toContain("location @matrix_code_root_ws");
     expect(script).toContain('if (\\$arg_reconnectionToken != "")');
     expect(script).toContain("error_page 418 = @matrix_code_root_ws");
     expect(script).toContain("proxy_set_header X-Forwarded-Prefix /code");
     expect(script).toContain("proxy_read_timeout 3600s");
+    expect(script).toContain("proxy_pass http://127.0.0.1:8788");
     expect(script).toContain("proxy_pass http://127.0.0.1:3000");
     expect(script).toContain("proxy_pass http://127.0.0.1:4000");
-    expect(script).toContain("proxy_pass http://127.0.0.1:8787");
+    expect(script).not.toContain("proxy_pass http://127.0.0.1:8787");
     expect(script).toContain("proxy_set_header X-Matrix-Code-Proxy-Token \"%s\"");
     expect(script).toContain("-p 127.0.0.1:5432:5432");
     expect(script).toContain("location /cli/");

--- a/tests/shell/code-editor-url.test.ts
+++ b/tests/shell/code-editor-url.test.ts
@@ -1,0 +1,26 @@
+// @vitest-environment jsdom
+
+import { afterEach, describe, expect, it } from "vitest";
+import { getCodeEditorUrl } from "../../shell/src/lib/feature-flags.js";
+
+describe("code editor URL", () => {
+  afterEach(() => {
+    delete document.documentElement.dataset.matrixSelfHosted;
+  });
+
+  it("uses managed code domain outside self-host mode", () => {
+    expect(getCodeEditorUrl()).toBe("https://code.matrix-os.com");
+    expect(getCodeEditorUrl("/home/matrix/home/projects/app")).toBe(
+      "https://code.matrix-os.com/?folder=%2Fhome%2Fmatrix%2Fhome%2Fprojects%2Fapp",
+    );
+  });
+
+  it("uses same-origin code-server path in self-host mode", () => {
+    document.documentElement.dataset.matrixSelfHosted = "1";
+
+    expect(getCodeEditorUrl()).toBe("/code/");
+    expect(getCodeEditorUrl("/home/matrix/home/projects/app")).toBe(
+      "/code/?folder=%2Fhome%2Fmatrix%2Fhome%2Fprojects%2Fapp",
+    );
+  });
+});

--- a/tests/shell/developer-mode-dashboard.test.tsx
+++ b/tests/shell/developer-mode-dashboard.test.tsx
@@ -11,33 +11,29 @@ describe("DeveloperModeDashboard", () => {
     vi.restoreAllMocks();
   });
 
-  it("presents Terminal first, Symphony second, setup status, and Canvas as an explicit switch", () => {
+  it("presents Terminal first, setup status, and Canvas as an explicit switch", () => {
     const onOpenTerminal = vi.fn();
-    const onOpenSymphony = vi.fn();
     const onSwitchCanvas = vi.fn();
 
     render(
       <DeveloperModeDashboard
         setupPrompt="Install Matrix CLI, run matrix login, then matrix run -it --session setup -- gh auth login."
         onOpenTerminal={onOpenTerminal}
-        onOpenSymphony={onOpenSymphony}
         onSwitchCanvas={onSwitchCanvas}
       />,
     );
 
     expect(screen.getByRole("heading", { name: /developer mode/i })).toBeTruthy();
     expect(screen.getByText(/Terminal is the primary surface/i)).toBeTruthy();
-    expect(screen.getByText(/Symphony is next/i)).toBeTruthy();
+    expect(screen.queryByText(/Symphony/i)).toBeNull();
     expect(screen.getAllByText(/Matrix-managed SSH key/i).length).toBeGreaterThan(0);
     expect(screen.getByText(/Do not upload local private keys/i)).toBeTruthy();
     expect(screen.getByDisplayValue(/matrix run -it --session setup -- gh auth login/i)).toBeTruthy();
 
     fireEvent.click(screen.getByRole("button", { name: /open terminal/i }));
-    fireEvent.click(screen.getByRole("button", { name: /open symphony/i }));
     fireEvent.click(screen.getByRole("button", { name: /switch to canvas/i }));
 
     expect(onOpenTerminal).toHaveBeenCalledTimes(1);
-    expect(onOpenSymphony).toHaveBeenCalledTimes(1);
     expect(onSwitchCanvas).toHaveBeenCalledTimes(1);
   });
 
@@ -53,7 +49,6 @@ describe("DeveloperModeDashboard", () => {
       <DeveloperModeDashboard
         setupPrompt="matrix login"
         onOpenTerminal={vi.fn()}
-        onOpenSymphony={vi.fn()}
         onSwitchCanvas={vi.fn()}
       />,
     );

--- a/tests/shell/proxy-auth.test.ts
+++ b/tests/shell/proxy-auth.test.ts
@@ -465,14 +465,15 @@ describe("proxy auth: self-host mode", () => {
     expect(response.status).toBe(403);
   });
 
-  it("keeps ClerkProvider while disabling managed-cloud identity work in self-host mode", () => {
+  it("skips ClerkProvider while disabling managed-cloud identity work in self-host mode", () => {
     const layout = readFileSync(join(process.cwd(), "shell/src/app/layout.tsx"), "utf8");
     const page = readFileSync(join(process.cwd(), "shell/src/app/page.tsx"), "utf8");
 
     expect(layout).toContain('const selfHostedMode = process.env.MATRIX_SELF_HOSTED === "1"');
-    expect(layout).toContain("{renderDocument(!selfHostedMode)}");
+    expect(layout).toContain('data-matrix-self-hosted={selfHostedMode ? "1" : undefined}');
+    expect(layout).toContain("return renderDocument(false);");
+    expect(layout).toContain("{renderDocument(true)}");
     expect(layout).toContain("{includePostHogIdentify ? <PostHogIdentify /> : null}");
-    expect(layout).not.toContain("return renderDocument(false);");
     expect(page).toContain('const selfHostedMode = process.env.MATRIX_SELF_HOSTED === "1"');
     expect(page).toContain("selfHostedMode || hasServerVerifiedMatrixSession");
   });

--- a/tests/shell/proxy-auth.test.ts
+++ b/tests/shell/proxy-auth.test.ts
@@ -465,18 +465,16 @@ describe("proxy auth: self-host mode", () => {
     expect(response.status).toBe(403);
   });
 
-  it("skips ClerkProvider at shell render time in self-host mode", () => {
+  it("keeps ClerkProvider while disabling managed-cloud identity work in self-host mode", () => {
     const layout = readFileSync(join(process.cwd(), "shell/src/app/layout.tsx"), "utf8");
+    const page = readFileSync(join(process.cwd(), "shell/src/app/page.tsx"), "utf8");
 
-    expect(layout).toContain('process.env.MATRIX_SELF_HOSTED === "1"');
-    expect(layout).toContain("return renderDocument(false);");
+    expect(layout).toContain('const selfHostedMode = process.env.MATRIX_SELF_HOSTED === "1"');
+    expect(layout).toContain("{renderDocument(!selfHostedMode)}");
     expect(layout).toContain("{includePostHogIdentify ? <PostHogIdentify /> : null}");
-    expect(layout.indexOf('process.env.MATRIX_SELF_HOSTED === "1"')).toBeLessThan(
-      layout.indexOf("<ClerkProvider>"),
-    );
-    expect(layout.indexOf("return renderDocument(false);")).toBeLessThan(
-      layout.indexOf("renderDocument(true)"),
-    );
+    expect(layout).not.toContain("return renderDocument(false);");
+    expect(page).toContain('const selfHostedMode = process.env.MATRIX_SELF_HOSTED === "1"');
+    expect(page).toContain("selfHostedMode || hasServerVerifiedMatrixSession");
   });
 });
 

--- a/tests/shell/self-host-shell-mode.test.ts
+++ b/tests/shell/self-host-shell-mode.test.ts
@@ -5,14 +5,23 @@ import { describe, expect, it } from "vitest";
 const root = process.cwd();
 
 describe("self-host shell mode", () => {
-  it("bypasses managed-cloud onboarding while preserving Clerk context for shared shell chrome", () => {
+  it("bypasses managed-cloud onboarding without loading Clerk on bare IP installs", () => {
     const page = readFileSync(join(root, "shell/src/app/page.tsx"), "utf8");
     const layout = readFileSync(join(root, "shell/src/app/layout.tsx"), "utf8");
+    const menuBar = readFileSync(join(root, "shell/src/components/MenuBar.tsx"), "utf8");
+    const userButton = readFileSync(join(root, "shell/src/components/UserButton.tsx"), "utf8");
+    const billingAccess = readFileSync(join(root, "shell/src/hooks/useMatrixBillingAccess.ts"), "utf8");
 
     expect(page).toContain('const selfHostedMode = process.env.MATRIX_SELF_HOSTED === "1"');
     expect(page).toContain("selfHostedMode || hasServerVerifiedMatrixSession");
     expect(layout).toContain('const selfHostedMode = process.env.MATRIX_SELF_HOSTED === "1"');
-    expect(layout).toContain("{renderDocument(!selfHostedMode)}");
-    expect(layout).not.toContain("return renderDocument(false);");
+    expect(layout).toContain('data-matrix-self-hosted={selfHostedMode ? "1" : undefined}');
+    expect(layout).toContain("if (selfHostedMode) {");
+    expect(layout).toContain("return renderDocument(false);");
+    expect(layout).toContain("<ClerkProvider>");
+    expect(layout).toContain("{renderDocument(true)}");
+    expect(menuBar).toContain("isSelfHostedDocument()");
+    expect(userButton).toContain("SelfHostedUserButton");
+    expect(billingAccess).toContain("useManagedMatrixBillingAccess");
   });
 });

--- a/tests/shell/self-host-shell-mode.test.ts
+++ b/tests/shell/self-host-shell-mode.test.ts
@@ -1,0 +1,18 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const root = process.cwd();
+
+describe("self-host shell mode", () => {
+  it("bypasses managed-cloud onboarding while preserving Clerk context for shared shell chrome", () => {
+    const page = readFileSync(join(root, "shell/src/app/page.tsx"), "utf8");
+    const layout = readFileSync(join(root, "shell/src/app/layout.tsx"), "utf8");
+
+    expect(page).toContain('const selfHostedMode = process.env.MATRIX_SELF_HOSTED === "1"');
+    expect(page).toContain("selfHostedMode || hasServerVerifiedMatrixSession");
+    expect(layout).toContain('const selfHostedMode = process.env.MATRIX_SELF_HOSTED === "1"');
+    expect(layout).toContain("{renderDocument(!selfHostedMode)}");
+    expect(layout).not.toContain("return renderDocument(false);");
+  });
+});

--- a/tests/shell/self-host-shell-mode.test.ts
+++ b/tests/shell/self-host-shell-mode.test.ts
@@ -11,6 +11,8 @@ describe("self-host shell mode", () => {
     const menuBar = readFileSync(join(root, "shell/src/components/MenuBar.tsx"), "utf8");
     const userButton = readFileSync(join(root, "shell/src/components/UserButton.tsx"), "utf8");
     const billingAccess = readFileSync(join(root, "shell/src/hooks/useMatrixBillingAccess.ts"), "utf8");
+    const settings = readFileSync(join(root, "shell/src/components/Settings.tsx"), "utf8");
+    const selfHostMode = readFileSync(join(root, "shell/src/lib/self-host-mode.ts"), "utf8");
 
     expect(page).toContain('const selfHostedMode = process.env.MATRIX_SELF_HOSTED === "1"');
     expect(page).toContain("selfHostedMode || hasServerVerifiedMatrixSession");
@@ -23,5 +25,10 @@ describe("self-host shell mode", () => {
     expect(menuBar).toContain("isSelfHostedDocument()");
     expect(userButton).toContain("SelfHostedUserButton");
     expect(billingAccess).toContain("useManagedMatrixBillingAccess");
+    expect(billingAccess).not.toContain("isSelfHostedDocument");
+    expect(settings).toContain("isSelfHostedRuntime()");
+    expect(settings).toContain("showBillingSection={false}");
+    expect(settings).toContain("function ManagedSettings");
+    expect(selfHostMode).toContain('process.env.MATRIX_SELF_HOSTED === "1"');
   });
 });

--- a/tests/shell/useSocket.test.ts
+++ b/tests/shell/useSocket.test.ts
@@ -40,6 +40,39 @@ Object.assign(MockWebSocket, {
   CONNECTING: 0,
 });
 
+describe("websocket auth in self-host mode", () => {
+  afterEach(() => {
+    vi.resetModules();
+    vi.unstubAllGlobals();
+  });
+
+  it("does not fetch a managed ws token when nginx injects standalone gateway auth", async () => {
+    vi.resetModules();
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    vi.stubGlobal("window", {
+      location: {
+        protocol: "http:",
+        host: "167.233.232.103",
+      },
+    });
+    vi.stubGlobal("document", {
+      documentElement: {
+        dataset: {
+          matrixSelfHosted: "1",
+        },
+      },
+    });
+
+    const { buildAuthenticatedWebSocketUrl } = await import("../../shell/src/lib/websocket-auth.js");
+
+    await expect(
+      buildAuthenticatedWebSocketUrl("/ws", undefined, { requireToken: true }),
+    ).resolves.toBe("ws://167.233.232.103/ws");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});
+
 describe("useSocket message protocol", () => {
   it("sends messages as JSON with correct shape", () => {
     const ws = new MockWebSocket("ws://localhost:4000/ws");

--- a/tests/shell/workspace-app.test.tsx
+++ b/tests/shell/workspace-app.test.tsx
@@ -94,6 +94,7 @@ describe("WorkspaceApp", () => {
 
   afterEach(() => {
     vi.restoreAllMocks();
+    delete document.documentElement.dataset.matrixSelfHosted;
   });
 
   it("renders project/task cockpit panels with bounded task virtualization and IDE links", async () => {
@@ -176,6 +177,19 @@ describe("WorkspaceApp", () => {
     expect(screen.getByTestId("workspace-task-grid").className).toContain("grid-cols-1");
     expect(screen.getByTestId("workspace-task-grid").className).toContain("md:grid-cols-2");
     expect(screen.getByTestId("workspace-task-grid").className).toContain("xl:grid-cols-3");
+  });
+
+  it("points IDE links at same-origin code-server in self-host mode", async () => {
+    document.documentElement.dataset.matrixSelfHosted = "1";
+
+    render(<WorkspaceApp initialProjectSlug="repo" />);
+
+    await waitFor(() => expect(screen.getAllByText("Repo").length).toBeGreaterThan(0));
+
+    const ideLink = screen.getByText("Open IDE").closest("a");
+    expect(ideLink?.getAttribute("href")).toBe(
+      "/code/?folder=%2Fhome%2Fmatrixos%2Fhome%2Fprojects%2Frepo",
+    );
   });
 
   it("creates a project from the Workspace sidebar", async () => {

--- a/www/public/install-server.sh
+++ b/www/public/install-server.sh
@@ -102,6 +102,25 @@ restart_optional_service() {
   fi
 }
 
+wait_http_ok() {
+  local description url log_hint attempt code
+  description="$1"
+  url="$2"
+  log_hint="$3"
+  for attempt in $(seq 1 30); do
+    code="$(curl --silent --show-error --output /dev/null --write-out "%{http_code}" --max-time 5 "$url" 2>>"$MATRIX_INSTALL_LOG" || true)"
+    if [ "$code" = "200" ]; then
+      ok "${description} is reachable"
+      return 0
+    fi
+    if [ "$code" = "500" ]; then
+      fail "${description} returned HTTP 500. ${log_hint}"
+    fi
+    sleep 2
+  done
+  fail "${description} did not become reachable. ${log_hint}"
+}
+
 fail() {
   local failed_phase
   failed_phase="${INSTALL_PHASE:-unknown}"
@@ -535,6 +554,12 @@ start_services() {
   restart_required_service nginx
 }
 
+verify_services() {
+  section "Verifying Matrix OS"
+  wait_http_ok "Matrix gateway" "http://127.0.0.1:4000/health" "Check: journalctl -u matrix-gateway -n 200 --no-pager"
+  wait_http_ok "Matrix shell" "http://127.0.0.1:3000/" "Check: journalctl -u matrix-shell -n 200 --no-pager"
+}
+
 print_summary() {
   local ip password_line ui_url
   ip="$(hostname -I 2>/dev/null | awk '{print $1}')"
@@ -596,6 +621,8 @@ main() {
   configure_nginx
   INSTALL_PHASE="services"
   start_services
+  INSTALL_PHASE="verify"
+  verify_services
   INSTALL_PHASE="complete"
   INSTALL_COMPLETED=1
   capture_install_telemetry "matrix_manual_install_completed" "completed" 0

--- a/www/public/install-server.sh
+++ b/www/public/install-server.sh
@@ -446,6 +446,21 @@ install_bundle() {
   INSTALL_TMP_SUM=""
 }
 
+prepare_runtime_permissions() {
+  section "Preparing runtime permissions"
+  if [ -d /opt/matrix/runtime/node ]; then
+    run_required "setting Node runtime owner group" chown -R root:matrix /opt/matrix/runtime/node
+    run_required "allowing matrix user Node runtime writes" chmod -R g+rwX /opt/matrix/runtime/node
+    if find /opt/matrix/runtime/node -type d -exec chmod g+s {} + >>"$MATRIX_INSTALL_LOG" 2>&1; then
+      ok "Runtime permissions ready"
+      return
+    fi
+    warn "could not set setgid bit on all Node runtime directories; agent installs may need sudo"
+    return
+  fi
+  warn "Node runtime prefix not found at /opt/matrix/runtime/node; skipping agent install permissions"
+}
+
 write_self_host_restore_service() {
   cat >/etc/systemd/system/matrix-restore.service <<'EOF'
 [Unit]
@@ -553,6 +568,16 @@ server {
     proxy_pass http://127.0.0.1:4000/;
   }
 
+  location /cli/ {
+    auth_basic off;
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade \$http_upgrade;
+    proxy_set_header Connection "upgrade";
+    proxy_read_timeout 3600s;
+    rewrite ^/cli/?(.*)\$ /\$1 break;
+    proxy_pass http://127.0.0.1:4000;
+  }
+
   location /ws {
     proxy_http_version 1.1;
     proxy_set_header Upgrade \$http_upgrade;
@@ -638,12 +663,15 @@ User: matrix
 ${password_line}
 
 Code editor: ${ui_url%/}/code/
+CLI gateway: ${ui_url%/}/cli
 Home: ${MATRIX_HOME_DIR}
 
 Useful commands:
   systemctl status matrix-gateway matrix-shell matrix-code nginx --no-pager
   journalctl -u matrix-gateway -u matrix-shell -u matrix-code -n 200 --no-pager
-  sudo -u matrix bash
+  sudo -iu matrix
+  MATRIX_TOKEN=\$(sudo awk -F= '\$1=="MATRIX_AUTH_TOKEN"{print \$2}' /opt/matrix/env/host.env)
+  matrix status --gateway ${ui_url%/}/cli --token "\$MATRIX_TOKEN"
 
 This preview protects the web UI with nginx Basic Auth. Put the host behind
 HTTPS, Tailscale, Cloudflare Access, or another trusted edge before long-term use.
@@ -666,6 +694,8 @@ main() {
   write_env
   INSTALL_PHASE="bundle"
   install_bundle
+  INSTALL_PHASE="runtime_permissions"
+  prepare_runtime_permissions
   INSTALL_PHASE="systemd"
   install_systemd_units
   INSTALL_PHASE="nginx"

--- a/www/public/install-server.sh
+++ b/www/public/install-server.sh
@@ -593,12 +593,27 @@ server {
     proxy_set_header Connection "upgrade";
     proxy_read_timeout 3600s;
     proxy_set_header Authorization "";
+    proxy_set_header X-Forwarded-Prefix /code;
     include /opt/matrix/env/code-proxy-token.conf;
     rewrite ^/code/?(.*)\$ /\$1 break;
     proxy_pass http://127.0.0.1:8787;
   }
 
+  location @matrix_code_root_ws {
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade \$http_upgrade;
+    proxy_set_header Connection "upgrade";
+    proxy_read_timeout 3600s;
+    proxy_set_header Authorization "";
+    include /opt/matrix/env/code-proxy-token.conf;
+    proxy_pass http://127.0.0.1:8787;
+  }
+
   location / {
+    if (\$arg_reconnectionToken != "") {
+      return 418;
+    }
+    error_page 418 = @matrix_code_root_ws;
     proxy_set_header Authorization "";
     proxy_pass http://127.0.0.1:3000;
   }

--- a/www/public/install-server.sh
+++ b/www/public/install-server.sh
@@ -4,7 +4,7 @@ set -Eeuo pipefail
 # Matrix OS standalone server installer.
 # Public copy is served from https://matrix-os.com/install-server.sh.
 
-DEFAULT_CHANNEL="${MATRIX_CHANNEL:-stable}"
+DEFAULT_CHANNEL="${MATRIX_CHANNEL:-dev}"
 DEFAULT_BUNDLE_BASE="https://app.matrix-os.com/system-bundles/${DEFAULT_CHANNEL}"
 MATRIX_HOST_BUNDLE_URL="${MATRIX_HOST_BUNDLE_URL:-${DEFAULT_BUNDLE_BASE}/matrix-host-bundle.tar.gz}"
 MATRIX_INSTALL_HANDLE="${MATRIX_INSTALL_HANDLE:-matrix}"
@@ -13,6 +13,7 @@ MATRIX_HOME_DIR="${MATRIX_HOME:-/home/matrix/home}"
 MATRIX_DEVELOPER_TOOLS="${MATRIX_DEVELOPER_TOOLS:-codex claude-code opencode pi}"
 MATRIX_INSTALL_TELEMETRY_URL="${MATRIX_INSTALL_TELEMETRY_URL:-https://matrix-os.com/api/install-telemetry}"
 MATRIX_INSTALL_TELEMETRY_ID="${MATRIX_INSTALL_TELEMETRY_ID:-}"
+MATRIX_INSTALL_LOG="${MATRIX_INSTALL_LOG:-/tmp/matrix-server-install.log}"
 INSTALL_TMP_BUNDLE=""
 INSTALL_TMP_SUM=""
 INSTALL_PHASE="init"
@@ -26,15 +27,65 @@ cleanup_install_tmp() {
 trap cleanup_install_tmp EXIT
 trap 'capture_install_failure $? $LINENO' ERR
 
+if [ "${MATRIX_INSTALL_COLOR:-auto}" = "always" ] || { [ "${MATRIX_INSTALL_COLOR:-auto}" = "auto" ] && [ -t 1 ] && [ "${TERM:-dumb}" != "dumb" ]; }; then
+  COLOR_RESET="$(printf '\033[0m')"
+  COLOR_BOLD="$(printf '\033[1m')"
+  COLOR_DIM="$(printf '\033[2m')"
+  COLOR_BLUE="$(printf '\033[34m')"
+  COLOR_GREEN="$(printf '\033[32m')"
+  COLOR_YELLOW="$(printf '\033[33m')"
+  COLOR_RED="$(printf '\033[31m')"
+else
+  COLOR_RESET=""
+  COLOR_BOLD=""
+  COLOR_DIM=""
+  COLOR_BLUE=""
+  COLOR_GREEN=""
+  COLOR_YELLOW=""
+  COLOR_RED=""
+fi
+
+section() {
+  printf '\n%s%s==> %s%s\n' "$COLOR_BLUE" "$COLOR_BOLD" "$*" "$COLOR_RESET"
+}
+
+banner() {
+  cat <<EOF
+
+${COLOR_BLUE}${COLOR_BOLD}███╗   ███╗ █████╗ ████████╗██████╗ ██╗██╗  ██╗     ██████╗ ███████╗
+████╗ ████║██╔══██╗╚══██╔══╝██╔══██╗██║╚██╗██╔╝    ██╔═══██╗██╔════╝
+██╔████╔██║███████║   ██║   ██████╔╝██║ ╚███╔╝     ██║   ██║███████╗
+██║╚██╔╝██║██╔══██║   ██║   ██╔══██╗██║ ██╔██╗     ██║   ██║╚════██║
+██║ ╚═╝ ██║██║  ██║   ██║   ██║  ██║██║██╔╝ ██╗    ╚██████╔╝███████║
+╚═╝     ╚═╝╚═╝  ╚═╝   ╚═╝   ╚═╝  ╚═╝╚═╝╚═╝  ╚═╝     ╚═════╝ ╚══════╝${COLOR_RESET}
+
+        ${COLOR_BOLD}Matrix OS server installer${COLOR_RESET}
+        ${COLOR_DIM}Browser shell + gateway + code-server + agents${COLOR_RESET}
+
+EOF
+}
+
 log() {
-  printf 'matrix-server-install: %s\n' "$*"
+  printf '%s    %s%s\n' "$COLOR_DIM" "$*" "$COLOR_RESET"
+}
+
+ok() {
+  printf '%s%sOK%s  %s\n' "$COLOR_GREEN" "$COLOR_BOLD" "$COLOR_RESET" "$*"
+}
+
+warn() {
+  printf '%s%sWARN%s  %s\n' "$COLOR_YELLOW" "$COLOR_BOLD" "$COLOR_RESET" "$*" >&2
 }
 
 fail() {
-  printf 'matrix-server-install: %s\n' "$*" >&2
+  local failed_phase
+  failed_phase="${INSTALL_PHASE:-unknown}"
+  printf '\n%s%sERROR%s %s\n' "$COLOR_RED" "$COLOR_BOLD" "$COLOR_RESET" "$*" >&2
   if declare -F capture_install_failure >/dev/null 2>&1; then
     capture_install_failure 1 "${BASH_LINENO[0]:-0}" || true
   fi
+  printf '%s\n' "Installer phase: ${failed_phase}" >&2
+  printf '%s\n\n' "Detailed log: ${MATRIX_INSTALL_LOG}" >&2
   exit 1
 }
 
@@ -175,6 +226,28 @@ validate_config() {
   esac
 }
 
+preflight_bundle_url() {
+  [ "${MATRIX_SKIP_BUNDLE_PREFLIGHT:-0}" != "1" ] || return 0
+
+  section "Checking Matrix OS host bundle"
+  log "Channel: ${DEFAULT_CHANNEL}"
+  log "Bundle: ${MATRIX_HOST_BUNDLE_URL}"
+
+  if ! curl --fail --silent --show-error --location --head \
+    --connect-timeout 10 --max-time 30 \
+    "$MATRIX_HOST_BUNDLE_URL" >/dev/null; then
+    fail "host bundle is not reachable: ${MATRIX_HOST_BUNDLE_URL}. Use MATRIX_CHANNEL=dev or pass MATRIX_HOST_BUNDLE_URL to a published bundle."
+  fi
+
+  if ! curl --fail --silent --show-error --location --head \
+    --connect-timeout 10 --max-time 30 \
+    "${MATRIX_HOST_BUNDLE_URL}.sha256" >/dev/null; then
+    fail "host bundle checksum is not reachable: ${MATRIX_HOST_BUNDLE_URL}.sha256"
+  fi
+
+  ok "Host bundle is reachable"
+}
+
 apt_get_update() {
   apt-get update \
     -o Acquire::Retries=5 \
@@ -185,9 +258,13 @@ apt_get_update() {
 install_packages() {
   export DEBIAN_FRONTEND=noninteractive
   if command -v apt-get >/dev/null 2>&1; then
-    log "installing OS packages"
-    apt_get_update
-    apt-get install -y ca-certificates curl docker.io git nginx openssl postgresql-client procps sudo tar
+    section "Installing OS packages"
+    : >"$MATRIX_INSTALL_LOG"
+    log "Writing apt output to ${MATRIX_INSTALL_LOG}"
+    apt_get_update >>"$MATRIX_INSTALL_LOG" 2>&1 || fail "apt-get update failed"
+    apt-get install -y ca-certificates curl docker.io git nginx openssl postgresql-client procps sudo tar >>"$MATRIX_INSTALL_LOG" 2>&1 \
+      || fail "apt-get install failed"
+    ok "OS packages installed"
     return
   fi
   fail "only apt-based Linux distributions are supported in this preview"
@@ -272,11 +349,18 @@ install_bundle() {
   INSTALL_TMP_BUNDLE="$tmp_bundle"
   INSTALL_TMP_SUM="$tmp_sum"
 
-  log "downloading host bundle"
-  curl --fail --location --retry 3 --retry-delay 5 --retry-all-errors \
-    --connect-timeout 10 --max-time 900 \
-    "$MATRIX_HOST_BUNDLE_URL" -o "$tmp_bundle"
-  curl --fail --location --retry 3 --retry-delay 5 --retry-all-errors \
+  section "Downloading Matrix OS"
+  log "Bundle: ${MATRIX_HOST_BUNDLE_URL}"
+  if [ -t 1 ]; then
+    curl --fail --location --progress-bar --retry 3 --retry-delay 5 --retry-all-errors \
+      --connect-timeout 10 --max-time 900 \
+      "$MATRIX_HOST_BUNDLE_URL" -o "$tmp_bundle"
+  else
+    curl --fail --silent --show-error --location --retry 3 --retry-delay 5 --retry-all-errors \
+      --connect-timeout 10 --max-time 900 \
+      "$MATRIX_HOST_BUNDLE_URL" -o "$tmp_bundle"
+  fi
+  curl --fail --silent --show-error --location --retry 3 --retry-delay 5 --retry-all-errors \
     --connect-timeout 10 --max-time 30 \
     "${MATRIX_HOST_BUNDLE_URL}.sha256" -o "$tmp_sum"
 
@@ -285,7 +369,8 @@ install_bundle() {
   [ -n "$expected" ] || fail "empty bundle checksum"
   [ "$expected" = "$actual" ] || fail "bundle checksum mismatch"
 
-  log "extracting host bundle"
+  ok "Host bundle checksum verified"
+  section "Extracting Matrix OS"
   tar -xzf "$tmp_bundle" -C /opt/matrix
   chmod 0755 /opt/matrix/bin/matrix-* /opt/matrix/bin/zellij 2>/dev/null || true
   cleanup_install_tmp
@@ -315,7 +400,7 @@ EOF
 }
 
 install_systemd_units() {
-  log "installing systemd units"
+  section "Installing systemd units"
   install -m 0644 /opt/matrix/systemd/matrix-gateway.service /etc/systemd/system/matrix-gateway.service
   install -m 0644 /opt/matrix/systemd/matrix-shell.service /etc/systemd/system/matrix-shell.service
   install -m 0644 /opt/matrix/systemd/matrix-code.service /etc/systemd/system/matrix-code.service
@@ -406,7 +491,7 @@ EOF
 }
 
 start_services() {
-  log "starting services"
+  section "Starting Matrix OS services"
   systemctl enable --now docker >/dev/null
   systemctl restart matrix-restore
   systemctl restart matrix-gateway
@@ -439,7 +524,7 @@ print_summary() {
 
   cat <<EOF
 
-Matrix OS standalone install complete.
+${COLOR_GREEN}${COLOR_BOLD}Matrix OS standalone install complete.${COLOR_RESET}
 
 Open: ${ui_url}
 User: matrix
@@ -460,10 +545,12 @@ EOF
 
 main() {
   INSTALL_PHASE="preflight"
+  banner
   require_root
   require_linux_systemd
   validate_config
   capture_install_telemetry "matrix_manual_install_started" "started" 0
+  preflight_bundle_url
   INSTALL_PHASE="packages"
   install_packages
   INSTALL_PHASE="user"

--- a/www/public/install-server.sh
+++ b/www/public/install-server.sh
@@ -77,6 +77,31 @@ warn() {
   printf '%s%sWARN%s  %s\n' "$COLOR_YELLOW" "$COLOR_BOLD" "$COLOR_RESET" "$*" >&2
 }
 
+run_required() {
+  local description
+  description="$1"
+  shift
+  "$@" >>"$MATRIX_INSTALL_LOG" 2>&1 || fail "${description} failed"
+}
+
+restart_required_service() {
+  local unit
+  unit="$1"
+  run_required "starting ${unit}" systemctl restart "$unit"
+  ok "${unit} started"
+}
+
+restart_optional_service() {
+  local unit label
+  unit="$1"
+  label="$2"
+  if systemctl restart "$unit" >>"$MATRIX_INSTALL_LOG" 2>&1; then
+    ok "${unit} started"
+  else
+    warn "${label} failed; Matrix OS core is still installed. Details: journalctl -u ${unit} -n 100 --no-pager"
+  fi
+}
+
 fail() {
   local failed_phase
   failed_phase="${INSTALL_PHASE:-unknown}"
@@ -273,16 +298,17 @@ install_packages() {
 }
 
 ensure_matrix_user() {
+  section "Preparing Matrix OS user"
   if ! getent group matrix >/dev/null 2>&1; then
-    groupadd --system matrix
+    run_required "creating matrix group" groupadd --system matrix
   fi
   if ! getent group docker >/dev/null 2>&1; then
-    groupadd --system docker
+    run_required "creating docker group" groupadd --system docker
   fi
   if ! id matrix >/dev/null 2>&1; then
-    useradd --system --gid matrix --groups docker --home-dir /home/matrix --shell /bin/bash matrix
+    run_required "creating matrix user" useradd --system --gid matrix --groups docker --home-dir /home/matrix --shell /bin/bash matrix
   else
-    usermod -aG docker matrix
+    run_required "updating matrix user groups" usermod -aG docker matrix
   fi
 
   install -d -o root -g matrix -m 0770 /opt/matrix
@@ -290,7 +316,8 @@ ensure_matrix_user() {
   install -d -o matrix -g matrix -m 0755 /home/matrix "$MATRIX_HOME_DIR" "$MATRIX_HOME_DIR/projects"
   install -d -o matrix -g matrix -m 0755 "$MATRIX_HOME_DIR/.local" "$MATRIX_HOME_DIR/.local/bin" "$MATRIX_HOME_DIR/.local/share"
   install -d -o matrix -g matrix -m 0755 "$MATRIX_HOME_DIR/.cache" "$MATRIX_HOME_DIR/.config"
-  usermod -d "$MATRIX_HOME_DIR" matrix
+  run_required "setting matrix home directory" usermod -d "$MATRIX_HOME_DIR" matrix
+  ok "Matrix OS user ready"
 }
 
 random_secret() {
@@ -411,11 +438,12 @@ install_systemd_units() {
     install -m 0644 /opt/matrix/systemd/matrix-developer-tools.service /etc/systemd/system/matrix-developer-tools.service
   fi
   write_self_host_restore_service
-  systemctl daemon-reload
-  systemctl enable docker matrix-restore matrix-gateway matrix-shell matrix-code matrix-code-server >/dev/null
+  run_required "reloading systemd" systemctl daemon-reload
+  run_required "enabling Matrix OS services" systemctl enable docker matrix-restore matrix-gateway matrix-shell matrix-code matrix-code-server
   if [ -f /etc/systemd/system/matrix-developer-tools.service ] && [ -n "$MATRIX_DEVELOPER_TOOLS" ]; then
-    systemctl enable matrix-developer-tools >/dev/null
+    run_required "enabling optional developer tools service" systemctl enable matrix-developer-tools
   fi
+  ok "Systemd units installed"
 }
 
 configure_nginx() {
@@ -488,22 +516,23 @@ EOF
 
   rm -f /etc/nginx/sites-enabled/default
   ln -sfn /etc/nginx/sites-available/matrix-self-host /etc/nginx/sites-enabled/matrix-self-host
-  nginx -t
-  systemctl enable nginx >/dev/null
+  run_required "testing nginx configuration" nginx -t
+  run_required "enabling nginx" systemctl enable nginx
+  ok "nginx configured"
 }
 
 start_services() {
   section "Starting Matrix OS services"
-  systemctl enable --now docker >/dev/null
-  systemctl restart matrix-restore
-  systemctl restart matrix-gateway
-  systemctl restart matrix-shell
-  systemctl restart matrix-code-server || true
-  systemctl restart matrix-code || true
+  run_required "starting docker" systemctl enable --now docker
+  restart_required_service matrix-restore
+  restart_required_service matrix-gateway
+  restart_required_service matrix-shell
+  restart_optional_service matrix-code-server "code-server proxy"
+  restart_optional_service matrix-code "code service"
   if systemctl list-unit-files matrix-developer-tools.service >/dev/null 2>&1; then
-    systemctl restart matrix-developer-tools || true
+    restart_optional_service matrix-developer-tools "optional developer tools installer"
   fi
-  systemctl restart nginx
+  restart_required_service nginx
 }
 
 print_summary() {

--- a/www/public/install-server.sh
+++ b/www/public/install-server.sh
@@ -594,9 +594,8 @@ server {
     proxy_read_timeout 3600s;
     proxy_set_header Authorization "";
     proxy_set_header X-Forwarded-Prefix /code;
-    include /opt/matrix/env/code-proxy-token.conf;
     rewrite ^/code/?(.*)\$ /\$1 break;
-    proxy_pass http://127.0.0.1:8787;
+    proxy_pass http://127.0.0.1:8788;
   }
 
   location @matrix_code_root_ws {
@@ -605,8 +604,7 @@ server {
     proxy_set_header Connection "upgrade";
     proxy_read_timeout 3600s;
     proxy_set_header Authorization "";
-    include /opt/matrix/env/code-proxy-token.conf;
-    proxy_pass http://127.0.0.1:8787;
+    proxy_pass http://127.0.0.1:8788;
   }
 
   location / {

--- a/www/public/install-server.sh
+++ b/www/public/install-server.sh
@@ -121,6 +121,26 @@ wait_http_ok() {
   fail "${description} did not become reachable. ${log_hint}"
 }
 
+wait_http_ok_auth() {
+  local description url password log_hint attempt code
+  description="$1"
+  url="$2"
+  password="$3"
+  log_hint="$4"
+  for attempt in $(seq 1 30); do
+    code="$(curl --silent --show-error --output /dev/null --write-out "%{http_code}" --max-time 5 --user "matrix:${password}" "$url" 2>>"$MATRIX_INSTALL_LOG" || true)"
+    if [ "$code" = "200" ]; then
+      ok "${description} is reachable"
+      return 0
+    fi
+    if [ "$code" = "401" ] || [ "$code" = "500" ]; then
+      fail "${description} returned HTTP ${code}. ${log_hint}"
+    fi
+    sleep 2
+  done
+  fail "${description} did not become reachable. ${log_hint}"
+}
+
 fail() {
   local failed_phase
   failed_phase="${INSTALL_PHASE:-unknown}"
@@ -466,7 +486,8 @@ install_systemd_units() {
 }
 
 configure_nginx() {
-  local code_proxy_token password hash server_name
+  local auth_token code_proxy_token password hash server_name
+  auth_token="$(read_env_value /opt/matrix/env/host.env MATRIX_AUTH_TOKEN)" || fail "MATRIX_AUTH_TOKEN is missing from host.env"
   code_proxy_token="$(read_env_value /opt/matrix/env/host.env MATRIX_CODE_PROXY_TOKEN)" || fail "MATRIX_CODE_PROXY_TOKEN is missing from host.env"
   server_name="$MATRIX_DOMAIN"
 
@@ -479,6 +500,9 @@ configure_nginx() {
   fi
   chmod 0640 /opt/matrix/env/nginx.htpasswd
   chown root:www-data /opt/matrix/env/nginx.htpasswd
+  printf 'proxy_set_header Authorization "Bearer %s";\n' "$auth_token" >/opt/matrix/env/gateway-auth-token.conf
+  chmod 0600 /opt/matrix/env/gateway-auth-token.conf
+  chown root:root /opt/matrix/env/gateway-auth-token.conf
   printf 'proxy_set_header X-Matrix-Code-Proxy-Token "%s";\n' "$code_proxy_token" >/opt/matrix/env/code-proxy-token.conf
   chmod 0600 /opt/matrix/env/code-proxy-token.conf
   chown root:root /opt/matrix/env/code-proxy-token.conf
@@ -497,23 +521,39 @@ server {
   proxy_set_header X-Forwarded-Proto \$scheme;
   proxy_set_header X-Real-IP \$remote_addr;
 
-  location /api/ { proxy_pass http://127.0.0.1:4000; }
-  location /files/ { proxy_pass http://127.0.0.1:4000; }
-  location /icons/ { proxy_pass http://127.0.0.1:4000; }
-  location /apps/ { proxy_pass http://127.0.0.1:4000; }
+  location /api/ {
+    include /opt/matrix/env/gateway-auth-token.conf;
+    proxy_pass http://127.0.0.1:4000;
+  }
+  location /files/ {
+    include /opt/matrix/env/gateway-auth-token.conf;
+    proxy_pass http://127.0.0.1:4000;
+  }
+  location /icons/ {
+    include /opt/matrix/env/gateway-auth-token.conf;
+    proxy_pass http://127.0.0.1:4000;
+  }
+  location /apps/ {
+    include /opt/matrix/env/gateway-auth-token.conf;
+    proxy_pass http://127.0.0.1:4000;
+  }
   location = /health {
     auth_basic off;
     access_log off;
     default_type application/json;
     return 200 '{"ok":true}';
   }
-  location /gateway/ { proxy_pass http://127.0.0.1:4000/; }
+  location /gateway/ {
+    include /opt/matrix/env/gateway-auth-token.conf;
+    proxy_pass http://127.0.0.1:4000/;
+  }
 
   location /ws {
     proxy_http_version 1.1;
     proxy_set_header Upgrade \$http_upgrade;
     proxy_set_header Connection "upgrade";
     proxy_read_timeout 3600s;
+    include /opt/matrix/env/gateway-auth-token.conf;
     proxy_pass http://127.0.0.1:4000;
   }
 
@@ -522,12 +562,14 @@ server {
     proxy_set_header Upgrade \$http_upgrade;
     proxy_set_header Connection "upgrade";
     proxy_read_timeout 3600s;
+    proxy_set_header Authorization "";
     include /opt/matrix/env/code-proxy-token.conf;
     rewrite ^/code/?(.*)\$ /\$1 break;
     proxy_pass http://127.0.0.1:8787;
   }
 
   location / {
+    proxy_set_header Authorization "";
     proxy_pass http://127.0.0.1:3000;
   }
 }
@@ -555,9 +597,13 @@ start_services() {
 }
 
 verify_services() {
+  local password
   section "Verifying Matrix OS"
   wait_http_ok "Matrix gateway" "http://127.0.0.1:4000/health" "Check: journalctl -u matrix-gateway -n 200 --no-pager"
   wait_http_ok "Matrix shell" "http://127.0.0.1:3000/" "Check: journalctl -u matrix-shell -n 200 --no-pager"
+  password="$(cat /opt/matrix/env/initial-ui-password)"
+  wait_http_ok_auth "nginx shell" "http://127.0.0.1/" "$password" "Check: journalctl -u nginx -n 120 --no-pager; journalctl -u matrix-shell -n 200 --no-pager"
+  wait_http_ok_auth "nginx gateway API" "http://127.0.0.1/api/identity" "$password" "Check: journalctl -u nginx -n 120 --no-pager; journalctl -u matrix-gateway -n 200 --no-pager"
 }
 
 print_summary() {

--- a/www/public/install-server.sh
+++ b/www/public/install-server.sh
@@ -486,20 +486,25 @@ install_systemd_units() {
 }
 
 configure_nginx() {
-  local auth_token code_proxy_token password hash server_name
+  local auth_token code_proxy_token password hash server_name htpasswd_file legacy_htpasswd_file
   auth_token="$(read_env_value /opt/matrix/env/host.env MATRIX_AUTH_TOKEN)" || fail "MATRIX_AUTH_TOKEN is missing from host.env"
   code_proxy_token="$(read_env_value /opt/matrix/env/host.env MATRIX_CODE_PROXY_TOKEN)" || fail "MATRIX_CODE_PROXY_TOKEN is missing from host.env"
   server_name="$MATRIX_DOMAIN"
+  htpasswd_file="/etc/nginx/matrix-self-host.htpasswd"
+  legacy_htpasswd_file="/opt/matrix/env/nginx.htpasswd"
 
-  if [ ! -f /opt/matrix/env/nginx.htpasswd ]; then
+  if [ ! -f "$htpasswd_file" ] && [ -f "$legacy_htpasswd_file" ]; then
+    install -m 0640 -o root -g www-data "$legacy_htpasswd_file" "$htpasswd_file"
+  fi
+  if [ ! -f "$htpasswd_file" ]; then
     password="$(openssl rand -base64 18 | tr -d '\n')"
     hash="$(openssl passwd -apr1 "$password")"
-    printf 'matrix:%s\n' "$hash" >/opt/matrix/env/nginx.htpasswd
+    printf 'matrix:%s\n' "$hash" >"$htpasswd_file"
     printf '%s\n' "$password" >/opt/matrix/env/initial-ui-password
     chmod 0600 /opt/matrix/env/initial-ui-password
   fi
-  chmod 0640 /opt/matrix/env/nginx.htpasswd
-  chown root:www-data /opt/matrix/env/nginx.htpasswd
+  chmod 0640 "$htpasswd_file"
+  chown root:www-data "$htpasswd_file"
   printf 'proxy_set_header Authorization "Bearer %s";\n' "$auth_token" >/opt/matrix/env/gateway-auth-token.conf
   chmod 0600 /opt/matrix/env/gateway-auth-token.conf
   chown root:root /opt/matrix/env/gateway-auth-token.conf
@@ -514,7 +519,7 @@ server {
 
   client_max_body_size 10m;
   auth_basic "Matrix OS";
-  auth_basic_user_file /opt/matrix/env/nginx.htpasswd;
+  auth_basic_user_file ${htpasswd_file};
 
   proxy_set_header Host \$host;
   proxy_set_header X-Forwarded-Host \$host;
@@ -602,8 +607,8 @@ verify_services() {
   wait_http_ok "Matrix gateway" "http://127.0.0.1:4000/health" "Check: journalctl -u matrix-gateway -n 200 --no-pager"
   wait_http_ok "Matrix shell" "http://127.0.0.1:3000/" "Check: journalctl -u matrix-shell -n 200 --no-pager"
   password="$(cat /opt/matrix/env/initial-ui-password)"
-  wait_http_ok_auth "nginx shell" "http://127.0.0.1/" "$password" "Check: journalctl -u nginx -n 120 --no-pager; journalctl -u matrix-shell -n 200 --no-pager"
-  wait_http_ok_auth "nginx gateway API" "http://127.0.0.1/api/identity" "$password" "Check: journalctl -u nginx -n 120 --no-pager; journalctl -u matrix-gateway -n 200 --no-pager"
+  wait_http_ok_auth "nginx shell" "http://127.0.0.1/" "$password" "Check: tail -120 /var/log/nginx/error.log; journalctl -u matrix-shell -n 200 --no-pager"
+  wait_http_ok_auth "nginx gateway API" "http://127.0.0.1/api/identity" "$password" "Check: tail -120 /var/log/nginx/error.log; journalctl -u matrix-gateway -n 200 --no-pager"
 }
 
 print_summary() {

--- a/www/public/install-server.sh
+++ b/www/public/install-server.sh
@@ -233,10 +233,12 @@ preflight_bundle_url() {
   log "Channel: ${DEFAULT_CHANNEL}"
   log "Bundle: ${MATRIX_HOST_BUNDLE_URL}"
 
-  if ! curl --fail --silent --show-error --location --head \
+  # Do not follow this HEAD redirect: the platform returns a signed R2 GET URL,
+  # and R2 rejects following that signature as a HEAD request.
+  if ! curl --fail --silent --show-error --head \
     --connect-timeout 10 --max-time 30 \
     "$MATRIX_HOST_BUNDLE_URL" >/dev/null; then
-    fail "host bundle is not reachable: ${MATRIX_HOST_BUNDLE_URL}. Use MATRIX_CHANNEL=dev or pass MATRIX_HOST_BUNDLE_URL to a published bundle."
+    fail "host bundle is not reachable: ${MATRIX_HOST_BUNDLE_URL}. Use a published MATRIX_CHANNEL or pass MATRIX_HOST_BUNDLE_URL to a published bundle."
   fi
 
   if ! curl --fail --silent --show-error --location --head \

--- a/www/public/install-server.sh
+++ b/www/public/install-server.sh
@@ -640,13 +640,19 @@ start_services() {
 }
 
 verify_services() {
-  local password
+  local password status
   section "Verifying Matrix OS"
   wait_http_ok "Matrix gateway" "http://127.0.0.1:4000/health" "Check: journalctl -u matrix-gateway -n 200 --no-pager"
   wait_http_ok "Matrix shell" "http://127.0.0.1:3000/" "Check: journalctl -u matrix-shell -n 200 --no-pager"
-  password="$(cat /opt/matrix/env/initial-ui-password)"
-  wait_http_ok_auth "nginx shell" "http://127.0.0.1/" "$password" "Check: tail -120 /var/log/nginx/error.log; journalctl -u matrix-shell -n 200 --no-pager"
-  wait_http_ok_auth "nginx gateway API" "http://127.0.0.1/api/identity" "$password" "Check: tail -120 /var/log/nginx/error.log; journalctl -u matrix-gateway -n 200 --no-pager"
+  if [ -f /opt/matrix/env/initial-ui-password ]; then
+    password="$(cat /opt/matrix/env/initial-ui-password)"
+    wait_http_ok_auth "nginx shell" "http://127.0.0.1/" "$password" "Check: tail -120 /var/log/nginx/error.log; journalctl -u matrix-shell -n 200 --no-pager"
+    wait_http_ok_auth "nginx gateway API" "http://127.0.0.1/api/identity" "$password" "Check: tail -120 /var/log/nginx/error.log; journalctl -u matrix-gateway -n 200 --no-pager"
+  else
+    status="$(curl -sS --max-time 10 -o /dev/null -w "%{http_code}" "http://127.0.0.1/" || true)"
+    [ "$status" = "401" ] || fail "nginx Basic Auth challenge returned HTTP ${status}, expected 401"
+    ok "nginx Basic Auth is configured"
+  fi
 }
 
 print_summary() {


### PR DESCRIPTION
## Summary
- polish the standalone Linux VPS installer output and host-bundle download checks
- make optional developer-tool failures non-blocking and verify gateway/shell HTTP readiness before success
- bypass managed-cloud onboarding for self-hosted shells while preserving Clerk context needed by shared shell chrome

## Validation
- bash -n scripts/install-server.sh
- cmp -s scripts/install-server.sh www/public/install-server.sh
- git diff --check
- bun run test tests/scripts/self-host-installer.test.ts tests/shell/self-host-shell-mode.test.ts

## Required invariants
- Source of truth: published host bundles remain the runtime payload; the installer only selects and verifies the bundle URL/checksum.
- Lock/transaction scope: no database writes are introduced; local systemd/nginx changes remain host-local.
- Acceptable orphan states: optional code-server/developer-tool service failures may remain for systemd retry while core gateway/shell readiness must pass.
- Auth source of truth: standalone preview access is nginx Basic Auth; gateway/code proxy internals remain loopback plus bearer token headers.
- Deferred scope: TLS automation, custom identity providers, and managed backup/upgrade UX remain outside this script-hardening PR.