### PR TITLE
fix(self-host): harden CLI token smoke test

### DIFF
--- a/scripts/install-server.sh
+++ b/scripts/install-server.sh
@@ -360,7 +360,7 @@ ensure_matrix_user() {
 }
 
 random_secret() {
-  openssl rand -base64 32 | tr -d '\n'
+  openssl rand -hex 32 | tr -d '\n'
 }
 
 read_env_value() {
@@ -689,8 +689,8 @@ Useful commands:
   systemctl status matrix-gateway matrix-shell matrix-code nginx --no-pager
   journalctl -u matrix-gateway -u matrix-shell -u matrix-code -n 200 --no-pager
   sudo -iu matrix
-  MATRIX_TOKEN=\$(sudo awk -F= '\$1=="MATRIX_AUTH_TOKEN"{print \$2}' /opt/matrix/env/host.env)
-  matrix status --gateway ${ui_url%/}/cli --token "\$MATRIX_TOKEN"
+  MATRIX_TOKEN=\$(sudo sed -n 's/^MATRIX_AUTH_TOKEN=//p' /opt/matrix/env/host.env)
+  matrix shell ls --gateway ${ui_url%/}/cli --token "\$MATRIX_TOKEN"
 
 This preview protects the web UI with nginx Basic Auth. Put the host behind
 HTTPS, Tailscale, Cloudflare Access, or another trusted edge before long-term use.

--- a/tests/scripts/self-host-installer.test.ts
+++ b/tests/scripts/self-host-installer.test.ts
@@ -39,6 +39,7 @@ describe("self-host server installer", () => {
     expect(script).toContain("MATRIX_HOME must stay under /home/matrix");
     expect(script).toContain("[ \"${#MATRIX_DOMAIN}\" -le 253 ]");
     expect(script).toContain("[[ \"$MATRIX_DOMAIN\" =~ ^[A-Za-z0-9]");
+    expect(script).toContain("openssl rand -hex 32");
     expect(script).toContain("read_env_value /opt/matrix/env/host.env MATRIX_AUTH_TOKEN || random_secret");
     expect(script).toContain("read_env_value /opt/matrix/env/host.env MATRIX_CODE_PROXY_TOKEN || random_secret");
     expect(script).toContain("read_env_value /opt/matrix/env/postgres.env POSTGRES_PASSWORD || random_secret");
@@ -137,7 +138,9 @@ describe("self-host server installer", () => {
     expect(script).toContain("auth_basic off");
     expect(script).toContain("rewrite ^/cli/?(.*)\\$ /\\$1 break");
     expect(script).toContain("CLI gateway: ${ui_url%/}/cli");
-    expect(script).toContain("matrix status --gateway ${ui_url%/}/cli --token \"\\$MATRIX_TOKEN\"");
+    expect(script).toContain("MATRIX_TOKEN=\\$(sudo sed -n 's/^MATRIX_AUTH_TOKEN=//p' /opt/matrix/env/host.env)");
+    expect(script).toContain("matrix shell ls --gateway ${ui_url%/}/cli --token \"\\$MATRIX_TOKEN\"");
+    expect(script).not.toContain("MATRIX_TOKEN=\\$(sudo awk -F=");
     expect(script).not.toContain("-p 5432:5432");
     expect(script).not.toContain("grep '^MATRIX_CODE_PROXY_TOKEN='");
   });

--- a/www/content/docs/self-host.mdx
+++ b/www/content/docs/self-host.mdx
@@ -80,7 +80,17 @@ The self-host installer is for developers comfortable operating a VPS. Matrix Cl
     matrix shell ls --gateway http://<server-ip>/cli --token "$MATRIX_TOKEN"
     ```
 
-    From your laptop, set `MATRIX_GATEWAY` to the printed CLI gateway URL and pass the same token explicitly. Browser login is for Matrix Cloud; standalone self-host CLI access currently uses this bearer token.
+    From your laptop, set `MATRIX_GATEWAY` to the printed CLI gateway URL and pass the same token explicitly:
+
+    ```bash
+    export MATRIX_GATEWAY="http://<server-ip>/cli"
+    export MATRIX_TOKEN="$(ssh root@<server-ip> 'sudo sed -n "s/^MATRIX_AUTH_TOKEN=//p" /opt/matrix/env/host.env')"
+
+    matrix shell ls --gateway "$MATRIX_GATEWAY" --token "$MATRIX_TOKEN"
+    matrix run --gateway "$MATRIX_GATEWAY" --token "$MATRIX_TOKEN" -- echo "hello from Matrix OS"
+    ```
+
+    Browser login is for Matrix Cloud; standalone self-host CLI access currently uses this bearer token.
   </Step>
 </Steps>
 

--- a/www/content/docs/self-host.mdx
+++ b/www/content/docs/self-host.mdx
@@ -69,6 +69,19 @@ The self-host installer is for developers comfortable operating a VPS. Matrix Cl
     sudo -u matrix bash
     ```
   </Step>
+
+  <Step>
+    ### Verify CLI access
+
+    From the VPS, read the standalone gateway token and check that the terminal route lists sessions:
+
+    ```bash
+    MATRIX_TOKEN=$(sudo sed -n 's/^MATRIX_AUTH_TOKEN=//p' /opt/matrix/env/host.env)
+    matrix shell ls --gateway http://<server-ip>/cli --token "$MATRIX_TOKEN"
+    ```
+
+    From your laptop, set `MATRIX_GATEWAY` to the printed CLI gateway URL and pass the same token explicitly. Browser login is for Matrix Cloud; standalone self-host CLI access currently uses this bearer token.
+  </Step>
 </Steps>
 
 ## What You Get

--- a/www/public/install-server.sh
+++ b/www/public/install-server.sh
@@ -360,7 +360,7 @@ ensure_matrix_user() {
 }
 
 random_secret() {
-  openssl rand -base64 32 | tr -d '\n'
+  openssl rand -hex 32 | tr -d '\n'
 }
 
 read_env_value() {
@@ -689,8 +689,8 @@ Useful commands:
   systemctl status matrix-gateway matrix-shell matrix-code nginx --no-pager
   journalctl -u matrix-gateway -u matrix-shell -u matrix-code -n 200 --no-pager
   sudo -iu matrix
-  MATRIX_TOKEN=\$(sudo awk -F= '\$1=="MATRIX_AUTH_TOKEN"{print \$2}' /opt/matrix/env/host.env)
-  matrix status --gateway ${ui_url%/}/cli --token "\$MATRIX_TOKEN"
+  MATRIX_TOKEN=\$(sudo sed -n 's/^MATRIX_AUTH_TOKEN=//p' /opt/matrix/env/host.env)
+  matrix shell ls --gateway ${ui_url%/}/cli --token "\$MATRIX_TOKEN"
 
 This preview protects the web UI with nginx Basic Auth. Put the host behind
 HTTPS, Tailscale, Cloudflare Access, or another trusted edge before long-term use.


### PR DESCRIPTION
## Summary
- Generate standalone installer secrets as hex so bearer tokens do not include shell-hostile padding characters
- Replace the printed self-host CLI smoke command with sed-based token extraction and matrix shell ls
- Document self-host CLI verification with explicit bearer-token auth

## Tests
- bun run test tests/scripts/self-host-installer.test.ts

## Invariants
- Source of truth: /opt/matrix/env/host.env remains the standalone host token source; www/public/install-server.sh remains byte-for-byte synced from scripts/install-server.sh.
- Lock/transaction scope: no database writes or locks are changed.
- Acceptable orphan states: existing installed base64 tokens remain readable by read_env_value; new installs receive hex tokens.
- Auth source of truth: self-host CLI auth remains explicit MATRIX_AUTH_TOKEN bearer auth until standalone browser login is implemented.
- Deferred scope: this does not add a persistent self-host CLI profile/login flow.