### PR TITLE
fix(www): align self-host docs port assertion

### DIFF
--- a/tests/www/self-host-docs.test.ts
+++ b/tests/www/self-host-docs.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it } from "vitest";
 
 const root = process.cwd();
 const installUrl = "https://matrix-os.com/install-server.sh";
+const privateServicePorts = ["3000", "4000", "8787", "8788", "5432"] as const;
 
 describe("self-host public docs", () => {
   it("documents the main-domain server installer in docs and README", () => {
@@ -21,7 +22,11 @@ describe("self-host public docs", () => {
     expect(docs).toContain("Manual Install Telemetry");
     expect(docs).toContain("MATRIX_NO_TELEMETRY=1");
     expect(docs).toContain("does not send your Matrix handle");
-    expect(docs).toContain("Do not expose ports `3000`, `4000`, `8787`, or `5432` publicly");
+    const publicPortWarning = docs.match(/^Do not expose ports `[^\n]+ publicly/m)?.[0] ?? "";
+    expect(publicPortWarning).toContain("Do not expose ports");
+    for (const port of privateServicePorts) {
+      expect(publicPortWarning).toContain(`\`${port}\``);
+    }
     expect(meta).toContain("\"self-host\"");
     expect(readme).toContain("### Managed Matrix Cloud");
     expect(readme).toContain("### Manual VPS Install");


### PR DESCRIPTION
Summary:
- Updates the self-host docs test to verify the private service port warning by intent instead of one exact sentence.
- Includes `8788` in the asserted private service port list so the test matches the current self-host security guidance.

Tests:
- `./node_modules/.bin/vitest run tests/www/self-host-docs.test.ts`
- `git diff --check`

Invariants:
- Source of truth: `www/content/docs/self-host.mdx` remains the public self-host security guidance; the test now verifies the warning's required protected ports.
- Lock/transaction scope: no runtime writes, database changes, locks, or transactions are introduced.
- Acceptable orphan states: none; this is a test-only assertion update.
- Auth source of truth: unchanged; no authentication or authorization behavior changes.
- Deferred scope: CI docs-only skip hardening is not changed here and can be handled separately if we want docs PRs to run this focused test subset.
