### PR TITLE
ci: run docs contracts for docs-only changes

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -18,11 +18,15 @@ protection is also updated when the shard list changes.
 - `React Doctor`
 - `Sync Client Package (Node 20)`
 - `Unit Tests`
+- `Docs Contract Tests`
 - `E2E Tests`
 
 The aggregate job writes a summary table and fails when any required internal
 job fails or is cancelled. Internal jobs may still be inspected directly for
 logs and artifacts.
+
+Docs-only changes still run targeted docs contract tests through `Docs Contract Tests`.
+Expensive jobs remain path-aware.
 
 ## Workflow Ownership
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -462,7 +462,7 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
           failed=false
-          for result in "$CHANGES_RESULT" "$TYPECHECK_RESULT" "$SHELL_PRODUCTION_BUILD_RESULT" "$PATTERNS_RESULT" "$SYNC_CLIENT_RESULT" "$UNIT_RESULT" "$DOCS_CONTRACT_RESULT" "$E2E_RESULT"; do
+          for result in "$CHANGES_RESULT" "$TYPECHECK_RESULT" "$SHELL_PRODUCTION_BUILD_RESULT" "$PATTERNS_RESULT" "$REACT_DOCTOR_RESULT" "$SYNC_CLIENT_RESULT" "$UNIT_RESULT" "$DOCS_CONTRACT_RESULT" "$E2E_RESULT"; do
             case "$result" in
               success|skipped)
                 ;;

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,7 @@ jobs:
     timeout-minutes: 2
     outputs:
       should_run: ${{ steps.changed.outputs.should_run }}
+      docs_contract_tests: ${{ steps.changed.outputs.docs_contract_tests }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -37,6 +38,7 @@ jobs:
           # Manual and merge-queue runs must execute CI regardless of changed paths.
           if [ "$GITHUB_EVENT_NAME" = "workflow_dispatch" ] || [ "$GITHUB_EVENT_NAME" = "merge_group" ]; then
             echo "should_run=true" >> "$GITHUB_OUTPUT"
+            echo "docs_contract_tests=false" >> "$GITHUB_OUTPUT"
             echo "CI relevant changes: true ($GITHUB_EVENT_NAME always runs)"
             exit 0
           fi
@@ -51,6 +53,7 @@ jobs:
 
           if [ "$should_run_trigger" != "true" ]; then
             echo "should_run=false" >> "$GITHUB_OUTPUT"
+            echo "docs_contract_tests=false" >> "$GITHUB_OUTPUT"
             echo "CI trigger not requested; add the ready-for-ci label, mark the PR ready for review, or run manually."
             exit 0
           fi
@@ -68,18 +71,21 @@ jobs:
           fi
 
           should_run=false
+          docs_contract_tests=false
           while IFS= read -r file; do
             [ -z "$file" ] && continue
             case "$file" in
-              docs/*|specs/*|www/*|*.md) ;;
-              *) should_run=true; break ;;
+              docs/*|specs/*|www/*|*.md) docs_contract_tests=true ;;
+              *) should_run=true; docs_contract_tests=false; break ;;
             esac
           done <<EOF
           $changed_files
           EOF
 
           echo "should_run=$should_run" >> "$GITHUB_OUTPUT"
+          echo "docs_contract_tests=$docs_contract_tests" >> "$GITHUB_OUTPUT"
           echo "CI relevant changes: $should_run"
+          echo "Docs contract tests: $docs_contract_tests"
 
   # ── Gate 1: Mechanical checks ──
   typecheck:
@@ -338,6 +344,35 @@ jobs:
       - run: bun run test -- --shard=${{ matrix.shard }}/4
         if: needs.changes.outputs.should_run == 'true'
 
+  docs-contract:
+    name: Docs Contract Tests
+    needs: changes
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Skip docs contract tests
+        if: needs.changes.outputs.docs_contract_tests != 'true'
+        run: echo "No docs-only changes detected; skipping docs contract tests."
+
+      - uses: actions/checkout@v6
+        if: needs.changes.outputs.docs_contract_tests == 'true'
+
+      - uses: pnpm/action-setup@v6
+        if: needs.changes.outputs.docs_contract_tests == 'true'
+
+      - uses: actions/setup-node@v6
+        if: needs.changes.outputs.docs_contract_tests == 'true'
+        with:
+          node-version: 24
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+        if: needs.changes.outputs.docs_contract_tests == 'true'
+
+      - name: Run docs contract tests
+        if: needs.changes.outputs.docs_contract_tests == 'true'
+        run: pnpm exec vitest run tests/www/self-host-docs.test.ts
+
   e2e:
     name: E2E Tests
     needs: [changes, sync-client, unit]
@@ -386,7 +421,7 @@ jobs:
 
   ci-results:
     name: CI Results
-    needs: [changes, typecheck, shell-production-build, patterns, react-doctor, sync-client, unit, e2e]
+    needs: [changes, typecheck, shell-production-build, patterns, react-doctor, sync-client, unit, docs-contract, e2e]
     if: always()
     runs-on: ubuntu-latest
     timeout-minutes: 2
@@ -401,6 +436,7 @@ jobs:
           REACT_DOCTOR_RESULT: ${{ needs.react-doctor.result }}
           SYNC_CLIENT_RESULT: ${{ needs.sync-client.result }}
           UNIT_RESULT: ${{ needs.unit.result }}
+          DOCS_CONTRACT_RESULT: ${{ needs.docs-contract.result }}
           E2E_RESULT: ${{ needs.e2e.result }}
         run: |
           set -euo pipefail
@@ -421,11 +457,12 @@ jobs:
             echo "| React Doctor | $REACT_DOCTOR_RESULT |"
             echo "| Sync Client Package (Node 20) | $SYNC_CLIENT_RESULT |"
             echo "| Unit Tests | $UNIT_RESULT |"
+            echo "| Docs Contract Tests | $DOCS_CONTRACT_RESULT |"
             echo "| E2E Tests | $E2E_RESULT |"
           } >> "$GITHUB_STEP_SUMMARY"
 
           failed=false
-          for result in "$CHANGES_RESULT" "$TYPECHECK_RESULT" "$SHELL_PRODUCTION_BUILD_RESULT" "$PATTERNS_RESULT" "$SYNC_CLIENT_RESULT" "$UNIT_RESULT" "$E2E_RESULT"; do
+          for result in "$CHANGES_RESULT" "$TYPECHECK_RESULT" "$SHELL_PRODUCTION_BUILD_RESULT" "$PATTERNS_RESULT" "$SYNC_CLIENT_RESULT" "$UNIT_RESULT" "$DOCS_CONTRACT_RESULT" "$E2E_RESULT"; do
             case "$result" in
               success|skipped)
                 ;;

--- a/tests/platform/ci-workflows.test.ts
+++ b/tests/platform/ci-workflows.test.ts
@@ -31,6 +31,7 @@ describe('CI workflows', () => {
     expect(workflow).toContain('needs.unit.result');
     expect(workflow).toContain('needs.docs-contract.result');
     expect(workflow).toContain('needs.e2e.result');
+    expect(workflow).toContain('"$PATTERNS_RESULT" "$REACT_DOCTOR_RESULT" "$SYNC_CLIENT_RESULT"');
     expect(workflow).toContain('Branch protection should require this aggregate job');
   });
 

--- a/tests/platform/ci-workflows.test.ts
+++ b/tests/platform/ci-workflows.test.ts
@@ -21,7 +21,7 @@ describe('CI workflows', () => {
     expect(workflow).toContain('ci-results:');
     expect(workflow).toContain('name: CI Results');
     expect(workflow).toContain('if: always()');
-    expect(workflow).toContain('needs: [changes, typecheck, shell-production-build, patterns, react-doctor, sync-client, unit, e2e]');
+    expect(workflow).toContain('needs: [changes, typecheck, shell-production-build, patterns, react-doctor, sync-client, unit, docs-contract, e2e]');
     expect(workflow).toContain('### CI Results');
     expect(workflow).toContain('needs.typecheck.result');
     expect(workflow).toContain('needs.shell-production-build.result');
@@ -29,8 +29,24 @@ describe('CI workflows', () => {
     expect(workflow).toContain('needs.react-doctor.result');
     expect(workflow).toContain('needs.sync-client.result');
     expect(workflow).toContain('needs.unit.result');
+    expect(workflow).toContain('needs.docs-contract.result');
     expect(workflow).toContain('needs.e2e.result');
     expect(workflow).toContain('Branch protection should require this aggregate job');
+  });
+
+  it('runs lightweight docs contract tests for docs-only CI changes', () => {
+    const root = process.cwd();
+    const workflow = readFileSync(join(root, '.github/workflows/ci.yml'), 'utf8');
+    const readme = readFileSync(join(root, '.github/workflows/README.md'), 'utf8');
+
+    expect(workflow).toContain('docs-contract:');
+    expect(workflow).toContain('name: Docs Contract Tests');
+    expect(workflow).toContain('docs_contract_tests: ${{ steps.changed.outputs.docs_contract_tests }}');
+    expect(workflow).toContain("if: needs.changes.outputs.docs_contract_tests == 'true'");
+    expect(workflow).toContain('pnpm exec vitest run tests/www/self-host-docs.test.ts');
+    expect(workflow).toContain('| Docs Contract Tests | $DOCS_CONTRACT_RESULT |');
+    expect(readme).toContain('- `Docs Contract Tests`');
+    expect(readme).toContain('Docs-only changes still run targeted docs contract tests');
   });
 
   it('documents workflow ownership and required checks', () => {
@@ -43,6 +59,7 @@ describe('CI workflows', () => {
     expect(readme).toContain('Host Bundle Release');
     expect(readme).toContain('host bundle release tests are blocking');
     expect(readme).toContain('React Doctor');
+    expect(readme).toContain('Docs Contract Tests');
     expect(readme).toContain('Screenshot workflow removed');
   });
 

--- a/tests/platform/ci-workflows.test.ts
+++ b/tests/platform/ci-workflows.test.ts
@@ -31,7 +31,7 @@ describe('CI workflows', () => {
     expect(workflow).toContain('needs.unit.result');
     expect(workflow).toContain('needs.docs-contract.result');
     expect(workflow).toContain('needs.e2e.result');
-    expect(workflow).toContain('"$PATTERNS_RESULT" "$REACT_DOCTOR_RESULT" "$SYNC_CLIENT_RESULT"');
+    expect(workflow).toContain('"$PATTERNS_RESULT" "$REACT_DOCTOR_RESULT" "$SYNC_CLIENT_RESULT" "$UNIT_RESULT" "$DOCS_CONTRACT_RESULT"');
     expect(workflow).toContain('Branch protection should require this aggregate job');
   });
 


### PR DESCRIPTION
Summary:
- Adds a `Docs Contract Tests` job to CI for docs-only changes.
- Runs `tests/www/self-host-docs.test.ts` when path detection skips expensive source CI.
- Wires the new job into `CI Results` and documents it in `.github/workflows/README.md`.
- Includes `React Doctor` in the aggregate failure loop so summarized failures gate `CI Results`.

Tests:
- `./node_modules/.bin/vitest run tests/platform/ci-workflows.test.ts`
- `./node_modules/.bin/vitest run tests/www/self-host-docs.test.ts`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml"); puts "ci.yml parses"'`
- `git diff --check`

Review/Monitoring:
- Added `ready-for-ci` to run the configured CI workflow.
- Addressed Greptile's 4/5 finding about `REACT_DOCTOR_RESULT` missing from the aggregate failure loop.
- Monitoring the latest CI and Greptile rerun for 5/5.

Invariants:
- Source of truth: `.github/workflows/ci.yml` owns the CI routing behavior; `.github/workflows/README.md` documents required internal checks.
- Lock/transaction scope: no runtime locks, database writes, or transactions are introduced.
- Acceptable orphan states: none; this is workflow/test-only routing hardening.
- Auth source of truth: unchanged; no authentication or authorization behavior changes.
- Deferred scope: this PR only adds the self-host docs contract test to docs-only CI; broader docs contract coverage can be added later as more docs tests become useful.
