### PR TITLE
fix(shell): restore browser and PWA cache hydration

### DIFF
--- a/packages/edge-router/src/index.ts
+++ b/packages/edge-router/src/index.ts
@@ -122,9 +122,7 @@ function withEdgeHeaders(response: Response, routeClass: EdgeRouteClass, pathnam
   const headers = new Headers(response.headers);
   if (shouldPreserveBrowserCache(routeClass, pathname, response)) {
     const upstreamCacheControl = headers.get("cache-control");
-    headers.set("cache-control", upstreamCacheControl && !upstreamCacheControl.toLowerCase().includes("no-store")
-      ? upstreamCacheControl
-      : browserCacheControlForAppStaticAsset(pathname));
+    headers.set("cache-control", upstreamCacheControl ?? browserCacheControlForAppStaticAsset(pathname));
   } else {
     headers.set("cache-control", "no-store");
   }
@@ -144,6 +142,18 @@ function shouldPreserveBrowserCache(
 }
 
 function isSafeAppStaticAssetPath(pathname: string): boolean {
+  if (
+    pathname.startsWith("/api/") ||
+    pathname.startsWith("/v1/") ||
+    pathname.startsWith("/auth/") ||
+    pathname.startsWith("/sign-in") ||
+    pathname.startsWith("/sign-up") ||
+    pathname.startsWith("/_next/data/") ||
+    pathname.startsWith("/files/apps/")
+  ) {
+    return false;
+  }
+
   return (
     pathname.startsWith("/_next/static/") ||
     pathname.startsWith("/icons/") ||
@@ -152,7 +162,7 @@ function isSafeAppStaticAssetPath(pathname: string): boolean {
     pathname.startsWith("/textures/") ||
     pathname.startsWith("/fonts/") ||
     /\.(?:png|jpg|jpeg|svg|webp|woff2?|ttf|css|js|wav|mp3)$/.test(pathname)
-  ) && !pathname.startsWith("/files/apps/");
+  );
 }
 
 function browserCacheControlForAppStaticAsset(pathname: string): string {

--- a/packages/edge-router/src/index.ts
+++ b/packages/edge-router/src/index.ts
@@ -70,7 +70,7 @@ export async function handleEdgeRouterRequest(
     });
   }
 
-  return withEdgeHeaders(response);
+  return withEdgeHeaders(response, routeClass, url.pathname);
 }
 
 function buildPlatformRequest(
@@ -118,14 +118,49 @@ async function readRequestBody(request: Request): Promise<ArrayBuffer | null | R
   return body;
 }
 
-function withEdgeHeaders(response: Response): Response {
+function withEdgeHeaders(response: Response, routeClass: EdgeRouteClass, pathname: string): Response {
   const headers = new Headers(response.headers);
-  headers.set("cache-control", "no-store");
+  if (shouldPreserveBrowserCache(routeClass, pathname, response)) {
+    const upstreamCacheControl = headers.get("cache-control");
+    headers.set("cache-control", upstreamCacheControl && !upstreamCacheControl.toLowerCase().includes("no-store")
+      ? upstreamCacheControl
+      : browserCacheControlForAppStaticAsset(pathname));
+  } else {
+    headers.set("cache-control", "no-store");
+  }
   headers.set("cdn-cache-control", "no-store");
   headers.set("cloudflare-cdn-cache-control", "no-store");
   const isWebSocketUpgrade = response.status === 101;
 
   return new Response(isWebSocketUpgrade ? null : response.body, buildEdgeResponseInit(response, headers));
+}
+
+function shouldPreserveBrowserCache(
+  routeClass: EdgeRouteClass,
+  pathname: string,
+  response: Response,
+): boolean {
+  return routeClass === "app" && response.status >= 200 && response.status < 400 && isSafeAppStaticAssetPath(pathname);
+}
+
+function isSafeAppStaticAssetPath(pathname: string): boolean {
+  return (
+    pathname.startsWith("/_next/static/") ||
+    pathname.startsWith("/icons/") ||
+    pathname.startsWith("/wallpapers/") ||
+    pathname.startsWith("/files/system/wallpapers/") ||
+    pathname.startsWith("/textures/") ||
+    pathname.startsWith("/fonts/") ||
+    /\.(?:png|jpg|jpeg|svg|webp|woff2?|ttf|css|js|wav|mp3)$/.test(pathname)
+  ) && !pathname.startsWith("/files/apps/");
+}
+
+function browserCacheControlForAppStaticAsset(pathname: string): string {
+  if (pathname.startsWith("/_next/static/")) return "public, max-age=31536000, immutable";
+  if (pathname.startsWith("/icons/") || pathname.startsWith("/wallpapers/") || pathname.startsWith("/files/system/wallpapers/")) {
+    return "public, max-age=86400, immutable";
+  }
+  return "public, max-age=86400";
 }
 
 export function buildEdgeResponseInit(response: Response, headers: Headers): EdgeResponseInit {

--- a/packages/platform/src/main.ts
+++ b/packages/platform/src/main.ts
@@ -716,7 +716,10 @@ function applyNoStoreResponseHeaders(headers: Headers): void {
   headers.set('expires', '0');
 }
 
-const APP_DOMAIN_UNREGISTER_SERVICE_WORKER = `
+const APP_DOMAIN_SAFE_SERVICE_WORKER = `
+const VERSION = "app-v1";
+const CACHE_STATIC = "matrix-os-static-" + VERSION;
+
 self.addEventListener("install", () => {
   self.skipWaiting();
 });
@@ -725,16 +728,77 @@ self.addEventListener("activate", (event) => {
   event.waitUntil((async () => {
     const keys = await caches.keys();
     await Promise.all(keys
-      .filter((key) => key.startsWith("matrix-os-"))
+      .filter((key) => key.startsWith("matrix-os-static-") && key !== CACHE_STATIC)
       .map((key) => caches.delete(key)));
     await self.clients.claim();
-    await self.registration.unregister();
   })());
 });
+
+function isBypassed(url) {
+  if (url.origin !== self.location.origin) return true;
+  const p = url.pathname;
+  return (
+    p.startsWith("/api/") ||
+    p.startsWith("/v1/") ||
+    p.startsWith("/clerk") ||
+    p.startsWith("/_clerk") ||
+    p.startsWith("/__clerk") ||
+    p.startsWith("/__session") ||
+    p.startsWith("/sign-in") ||
+    p.startsWith("/sign-up") ||
+    p.startsWith("/files/apps/") ||
+    p.includes("/__nextjs_") ||
+    p.startsWith("/_next/data/")
+  );
+}
+
+function isStaticAsset(url) {
+  const p = url.pathname;
+  return (
+    p.startsWith("/_next/static/") ||
+    p.startsWith("/icons/") ||
+    p.startsWith("/wallpapers/") ||
+    p.startsWith("/files/system/wallpapers/") ||
+    p.startsWith("/textures/") ||
+    p.startsWith("/fonts/") ||
+    /\\.(?:png|jpg|jpeg|svg|webp|woff2?|ttf|css|js|wav|mp3)$/.test(p)
+  );
+}
+
+self.addEventListener("fetch", (event) => {
+  const req = event.request;
+  if (req.method !== "GET") return;
+  const url = new URL(req.url);
+  if (isBypassed(url) || !isStaticAsset(url)) return;
+  event.respondWith(cacheFirst(req));
+});
+
+async function cacheFirst(req) {
+  const cache = await caches.open(CACHE_STATIC);
+  const cached = await cache.match(req);
+  if (cached) return cached;
+  try {
+    const res = await fetch(req, { signal: AbortSignal.timeout(30000) });
+    if (res.ok && res.type === "basic") {
+      cache.put(req, res.clone()).catch((err) => {
+        console.warn("[app sw] static cache put failed:", err?.message ?? err);
+      });
+    }
+    return res;
+  } catch (_err) {
+    return new Response("offline", {
+      status: 504,
+      headers: {
+        "content-type": "text/plain; charset=utf-8",
+        "cache-control": "no-store",
+      },
+    });
+  }
+}
 `.trim();
 
 function appDomainServiceWorkerResponse(): Response {
-  return new Response(APP_DOMAIN_UNREGISTER_SERVICE_WORKER, {
+  return new Response(APP_DOMAIN_SAFE_SERVICE_WORKER, {
     status: 200,
     headers: {
       'content-type': 'text/javascript; charset=utf-8',

--- a/shell/public/service-worker.js
+++ b/shell/public/service-worker.js
@@ -60,6 +60,7 @@ function isBypassed(url) {
     p.startsWith("/__session") ||
     p.startsWith("/sign-in") ||
     p.startsWith("/sign-up") ||
+    p.startsWith("/files/apps/") ||
     p.includes("/__nextjs_") ||
     p.startsWith("/_next/data/")
   );
@@ -71,10 +72,16 @@ function isStaticAsset(url) {
     p.startsWith("/_next/static/") ||
     p.startsWith("/icons/") ||
     p.startsWith("/wallpapers/") ||
+    p.startsWith("/files/system/wallpapers/") ||
     p.startsWith("/textures/") ||
     p.startsWith("/fonts/") ||
     /\.(?:png|jpg|jpeg|svg|webp|woff2?|ttf|css|js|wav|mp3)$/.test(p)
   );
+}
+
+function isShellNavigation(url) {
+  const p = url.pathname;
+  return p === "/" || p.startsWith("/vm/");
 }
 
 self.addEventListener("fetch", (event) => {
@@ -84,7 +91,7 @@ self.addEventListener("fetch", (event) => {
   const url = new URL(req.url);
   if (isBypassed(url)) return;
 
-  if (req.mode === "navigate" || req.headers.get("accept")?.includes("text/html")) {
+  if ((req.mode === "navigate" || req.headers.get("accept")?.includes("text/html")) && isShellNavigation(url)) {
     event.respondWith(networkFirstHtml(req));
     return;
   }

--- a/shell/src/components/Desktop.tsx
+++ b/shell/src/components/Desktop.tsx
@@ -70,6 +70,11 @@ import { MATRIX_ONBOARDING_BRAND_VERSION } from "@/lib/onboarding-brand";
 import { SHELL_Z_INDEX } from "@/lib/shell-layering";
 import { enqueueTerminalLaunch, TERMINAL_SETUP_WINDOW_PATH } from "@/lib/terminal-launch";
 import {
+  loadShellSnapshot,
+  saveShellSnapshot,
+  type ShellSnapshotScope,
+} from "@/lib/shell-snapshot-cache";
+import {
   DEFAULT_PINNED_APPS,
   isBuiltInAppPath,
   normalizeBuiltInAppPath,
@@ -465,10 +470,12 @@ interface DesktopProps {
   launchAppPath?: string | null;
   onOpenCommandPalette?: () => void;
   chat?: import("@/hooks/useChatState").ChatState;
+  cacheScope?: ShellSnapshotScope | null;
 }
 
 // react-doctor-disable-next-line react-doctor/no-giant-component, react-doctor/prefer-useReducer -- no-giant-component: cohesive root shell component; extraction tracked separately. prefer-useReducer: the state values here (interacting, settingsOpen, chatOpen, minimizingIds, firstRunStatus, manualSetupVisible, vocalMounted, plus mode flags) are independent shell concerns, not one related state machine; collapsing them into a reducer would couple unrelated transitions and obscure behavior in the core shell component
-export function Desktop({ launchAppPath, onOpenCommandPalette, chat }: DesktopProps) {
+export function Desktop({ launchAppPath, onOpenCommandPalette, chat, cacheScope }: DesktopProps) {
+  const cacheKey = cacheScope?.storageKey;
   const windows = useWindowManager((s) => s.windows);
   const apps = useWindowManager((s) => s.apps);
   const wmCloseWindow = useWindowManager((s) => s.closeWindow);
@@ -830,14 +837,10 @@ export function Desktop({ launchAppPath, onOpenCommandPalette, chat }: DesktopPr
 
   // react-doctor-disable-next-line react-doctor/react-compiler-no-manual-memoization -- identity consumed by the module-load useEffect dependency array (L~1070); a fresh function each render would re-run the layout/modules/apps fetch on every render
   const loadModules = useCallback(async () => {
-    try {
-      const bootstrapRes = await fetch(`${GATEWAY_URL}/api/shell/bootstrap`, {
-        signal: AbortSignal.timeout(GATEWAY_FETCH_TIMEOUT_MS),
-      }).catch((err) => {
-        console.warn("[desktop] Failed to fetch shell bootstrap:", err);
-        return null;
-      });
-      const bootstrap: ShellBootstrap = bootstrapRes?.ok ? await bootstrapRes.json() : {};
+    const applyBootstrap = async (
+      bootstrap: ShellBootstrap,
+      options: { resolveModuleMetadata: boolean },
+    ) => {
       const iconForSlug = (slug: string | undefined): string | undefined => {
         if (!slug) return undefined;
         return bootstrap.icons?.[slug]?.versionedUrl ?? iconUrlForSlug(slug);
@@ -889,6 +892,16 @@ export function Desktop({ launchAppPath, onOpenCommandPalette, chat }: DesktopPr
 
         for (const mod of registry) {
           if (mod.status !== "active") continue;
+          if (!options.resolveModuleMetadata) {
+            const relativeBasePath = registryPathToRelativePath(mod.path);
+            if (!relativeBasePath) continue;
+            const defaultEntryFile = mod.type === "react-app" ? "dist/index.html" : "index.html";
+            const path = normalizeBuiltInAppPath(`${relativeBasePath}/${defaultEntryFile}`);
+            addApp(mod.name, path, nameToSlug(mod.name));
+            const saved = layoutMap.get(path);
+            queueSavedLayout(saved);
+            continue;
+          }
 
           try {
             const relativeBasePath = registryPathToRelativePath(mod.path);
@@ -953,10 +966,27 @@ export function Desktop({ launchAppPath, onOpenCommandPalette, chat }: DesktopPr
       if (layoutToLoad.length > 0) {
         wmLoadLayout(layoutToLoad);
       }
+    };
+
+    try {
+      const cachedBootstrap = loadShellSnapshot(cacheScope)?.bootstrap as ShellBootstrap | undefined;
+      if (cachedBootstrap) {
+        await applyBootstrap(cachedBootstrap, { resolveModuleMetadata: false });
+      }
+
+      const bootstrapRes = await fetch(`${GATEWAY_URL}/api/shell/bootstrap`, {
+        signal: AbortSignal.timeout(GATEWAY_FETCH_TIMEOUT_MS),
+      }).catch((err) => {
+        console.warn("[desktop] Failed to fetch shell bootstrap:", err);
+        return null;
+      });
+      const bootstrap: ShellBootstrap = bootstrapRes?.ok ? await bootstrapRes.json() : {};
+      if (bootstrapRes?.ok) saveShellSnapshot(cacheScope, { bootstrap });
+      await applyBootstrap(bootstrap, { resolveModuleMetadata: true });
     } catch (err) {
       console.warn("[desktop] Failed to load desktop modules:", err);
     }
-  }, [addApp, openWindow, wmLoadLayout]);
+  }, [addApp, cacheScope, openWindow, wmLoadLayout]);
 
   useEffect(() => {
     loadModules();

--- a/shell/src/components/Desktop.tsx
+++ b/shell/src/components/Desktop.tsx
@@ -105,6 +105,11 @@ function sameIconAsset(left: string | undefined, right: string | undefined): boo
   return iconAssetPath(left) === iconAssetPath(right);
 }
 
+function gatewayFetchSignal(signal?: AbortSignal): AbortSignal {
+  const timeoutSignal = AbortSignal.timeout(GATEWAY_FETCH_TIMEOUT_MS);
+  return signal ? AbortSignal.any([signal, timeoutSignal]) : timeoutSignal;
+}
+
 const MATRIX_FIRST_RUN_LOGO_STYLE: CSSProperties = {
   WebkitMaskImage: "url('/matrix-logo.svg')",
   WebkitMaskRepeat: "no-repeat",
@@ -836,11 +841,26 @@ export function Desktop({ launchAppPath, onOpenCommandPalette, chat, cacheScope 
   }, [apps, focusOrOpen, launchAppPath]);
 
   // react-doctor-disable-next-line react-doctor/react-compiler-no-manual-memoization -- identity consumed by the module-load useEffect dependency array (L~1070); a fresh function each render would re-run the layout/modules/apps fetch on every render
-  const loadModules = useCallback(async () => {
+  const loadModules = useCallback(async (signal?: AbortSignal) => {
+    const isLoadAborted = () => signal?.aborted === true;
+    const fetchForLoad = async (input: RequestInfo | URL): Promise<Response | null> => {
+      if (isLoadAborted()) return null;
+      const response = await fetch(input, {
+        signal: gatewayFetchSignal(signal),
+      });
+      return isLoadAborted() ? null : response;
+    };
+    const readJsonForLoad = async <T,>(response: Response): Promise<T | null> => {
+      if (isLoadAborted()) return null;
+      const data = await response.json() as T;
+      return isLoadAborted() ? null : data;
+    };
     const applyBootstrap = async (
       bootstrap: ShellBootstrap,
       options: { resolveModuleMetadata: boolean },
     ) => {
+      if (isLoadAborted()) return;
+
       const iconForSlug = (slug: string | undefined): string | undefined => {
         if (!slug) return undefined;
         return bootstrap.icons?.[slug]?.versionedUrl ?? iconUrlForSlug(slug);
@@ -874,6 +894,7 @@ export function Desktop({ launchAppPath, onOpenCommandPalette, chat, cacheScope 
       if (Array.isArray(bootstrap.apps)) {
         const appsList = bootstrap.apps;
         for (const app of appsList) {
+          if (isLoadAborted()) return;
           // path from API is like "/files/apps/calculator/index.html"
           // strip leading "/files/" to get relative path for AppViewer
           const relativePath = normalizeBuiltInAppPath(app.path.replace(/^\/files\//, ""));
@@ -891,6 +912,7 @@ export function Desktop({ launchAppPath, onOpenCommandPalette, chat, cacheScope 
         const registry = bootstrap.modules;
 
         for (const mod of registry) {
+          if (isLoadAborted()) return;
           if (mod.status !== "active") continue;
           if (!options.resolveModuleMetadata) {
             const relativeBasePath = registryPathToRelativePath(mod.path);
@@ -922,9 +944,8 @@ export function Desktop({ launchAppPath, onOpenCommandPalette, chat, cacheScope 
             let metaRes: Response | undefined;
             for (const candidate of metaCandidates) {
               // react-doctor-disable-next-line react-doctor/async-await-in-loop -- sequential-by-design priority fallback: tries the candidate manifest filenames in order and breaks on the first that exists; parallelizing would always fire every request and lose the priority semantics
-              const res = await fetch(candidate, {
-                signal: AbortSignal.timeout(GATEWAY_FETCH_TIMEOUT_MS),
-              });
+              const res = await fetchForLoad(candidate);
+              if (!res) return;
               if (res.ok) {
                 metaRes = res;
                 break;
@@ -944,7 +965,8 @@ export function Desktop({ launchAppPath, onOpenCommandPalette, chat, cacheScope 
               continue;
             }
 
-            const meta: ModuleMeta = await metaRes.json();
+            const meta = await readJsonForLoad<ModuleMeta>(metaRes);
+            if (!meta) return;
             const entryFile = meta.entry ?? meta.entryPoint ?? "index.html";
             path = normalizeBuiltInAppPath(`${relativeBasePath}/${entryFile}`);
             appName = meta.name ?? mod.name;
@@ -958,11 +980,13 @@ export function Desktop({ launchAppPath, onOpenCommandPalette, chat, cacheScope 
               openWindow(appName, path);
             }
           } catch (err) {
+            if (isLoadAborted()) return;
             console.warn(`[desktop] Failed to load module "${mod.name}":`, err);
           }
         }
       }
 
+      if (isLoadAborted()) return;
       if (layoutToLoad.length > 0) {
         wmLoadLayout(layoutToLoad);
       }
@@ -974,22 +998,26 @@ export function Desktop({ launchAppPath, onOpenCommandPalette, chat, cacheScope 
         await applyBootstrap(cachedBootstrap, { resolveModuleMetadata: false });
       }
 
-      const bootstrapRes = await fetch(`${GATEWAY_URL}/api/shell/bootstrap`, {
-        signal: AbortSignal.timeout(GATEWAY_FETCH_TIMEOUT_MS),
-      }).catch((err) => {
+      const bootstrapRes = await fetchForLoad(`${GATEWAY_URL}/api/shell/bootstrap`).catch((err) => {
+        if (isLoadAborted()) return null;
         console.warn("[desktop] Failed to fetch shell bootstrap:", err);
-        return null;
+        return undefined;
       });
-      const bootstrap: ShellBootstrap = bootstrapRes?.ok ? await bootstrapRes.json() : {};
+      if (bootstrapRes === null) return;
+      const bootstrap = bootstrapRes?.ok ? await readJsonForLoad<ShellBootstrap>(bootstrapRes) : {};
+      if (bootstrap === null) return;
       if (bootstrapRes?.ok) saveShellSnapshot(cacheScope, { bootstrap });
       await applyBootstrap(bootstrap, { resolveModuleMetadata: true });
     } catch (err) {
+      if (isLoadAborted()) return;
       console.warn("[desktop] Failed to load desktop modules:", err);
     }
   }, [addApp, cacheScope, openWindow, wmLoadLayout]);
 
   useEffect(() => {
-    loadModules();
+    const controller = new AbortController();
+    void loadModules(controller.signal);
+    return () => controller.abort();
   }, [loadModules]);
 
   useFileWatcher((path: string, event: string) => {

--- a/shell/src/components/ShellHome.tsx
+++ b/shell/src/components/ShellHome.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useCallback, useEffect, useRef, useSyncExternalStore } from "react";
+import { useAuth } from "@clerk/nextjs";
 import { useTheme } from "@/hooks/useTheme";
 import { useDesktopConfig } from "@/hooks/useDesktopConfig";
 import { useChatState } from "@/hooks/useChatState";
@@ -15,6 +16,7 @@ import { MobileShell } from "@/components/mobile/MobileShell";
 import { CommandPalette } from "@/components/CommandPalette";
 import { ApprovalDialog } from "@/components/ApprovalDialog";
 import { useMobileViewport } from "@/hooks/useMobileViewport";
+import { createShellSnapshotScope } from "@/lib/shell-snapshot-cache";
 
 const LAUNCHABLE_BUILT_IN_PATHS = new Set([
   "__terminal__",
@@ -40,8 +42,11 @@ const getLaunchPathServerSnapshot = (): string | null => null;
 
 export function ShellHome() {
   const isMobile = useMobileViewport();
-  useTheme();
-  useDesktopConfig();
+  const { userId } = useAuth();
+  const cachePathname = typeof window === "undefined" ? "/" : window.location.pathname;
+  const cacheScope = createShellSnapshotScope({ userId, pathname: cachePathname });
+  useTheme({ cacheScope });
+  useDesktopConfig({ cacheScope });
 
   const chat = useChatState();
   const [paletteOpen, setPaletteOpen] = useState(false);
@@ -91,12 +96,14 @@ export function ShellHome() {
               <MobileShell
                 launchAppPath={launchAppPath}
                 onOpenCommandPalette={() => setPaletteOpen(true)}
+                cacheScope={cacheScope}
               />
             ) : (
               <Desktop
                 launchAppPath={launchAppPath}
                 onOpenCommandPalette={() => setPaletteOpen(true)}
                 chat={chat}
+                cacheScope={cacheScope}
               />
             )}
           </div>

--- a/shell/src/components/mobile/MobileShell.tsx
+++ b/shell/src/components/mobile/MobileShell.tsx
@@ -34,6 +34,12 @@ import { useChatContext } from "@/stores/chat-context";
 import { iconUrlForSlug } from "@/lib/app-launch";
 import { getGatewayUrl } from "@/lib/gateway";
 import { nameToSlug } from "@/lib/utils";
+import {
+  loadShellSnapshot,
+  saveShellSnapshot,
+  type ShellBootstrapSnapshot,
+  type ShellSnapshotScope,
+} from "@/lib/shell-snapshot-cache";
 import { HERMES_CHAT_HIDDEN } from "@/lib/feature-flags";
 import { TerminalApp } from "@/components/terminal/TerminalApp";
 import { FileBrowser } from "@/components/file-browser/FileBrowser";
@@ -66,6 +72,34 @@ const BUILT_IN_APPS: MobileApp[] = [
     ? []
     : [{ id: "chat", name: "Hermes", path: "__chat__", iconSlug: "chat" } as MobileApp]),
 ];
+
+function mobileAppsFromBootstrap(
+  bootstrap: ShellBootstrapSnapshot | { name: string; path: string; icon?: string }[] | null | undefined,
+): MobileApp[] {
+  const list = Array.isArray(bootstrap) ? bootstrap : bootstrap?.apps;
+  if (!Array.isArray(list)) return [];
+  return list.flatMap((a) => {
+    if (typeof a.name !== "string" || typeof a.path !== "string") return [];
+    const relative = a.path.replace(/^\/files\//, "");
+    return [{
+      id: `app:${relative}`,
+      name: a.name,
+      path: relative,
+      iconSlug: a.icon ?? ("slug" in a && typeof a.slug === "string" ? a.slug : nameToSlug(a.name)),
+    }];
+  });
+}
+
+function mergeMobileApps(base: MobileApp[], installed: MobileApp[]): MobileApp[] {
+  const seen = new Set(base.map((p) => p.path));
+  const merged = [...base];
+  for (const app of installed) {
+    if (seen.has(app.path)) continue;
+    seen.add(app.path);
+    merged.push(app);
+  }
+  return merged;
+}
 
 const LAUNCHER_APP_BUTTON_STYLE: CSSProperties = {
   display: "flex",
@@ -148,13 +182,18 @@ const DOCK_BADGE_STYLE: CSSProperties = {
 interface MobileShellProps {
   launchAppPath?: string | null;
   onOpenCommandPalette?: () => void;
+  cacheScope?: ShellSnapshotScope | null;
 }
 
 // react-doctor-disable-next-line react-doctor/prefer-useReducer -- the five states (apps, openStack, view, settingsOpen, time) are independent concerns with separate update sites and lifecycles (registry load, foreground stack, view mode, settings dialog, clock tick), not one related state machine; collapsing them into a reducer would couple unrelated transitions and is not a mechanical, behavior-identical change.
-export function MobileShell({ launchAppPath, onOpenCommandPalette }: MobileShellProps) {
+export function MobileShell({ launchAppPath, onOpenCommandPalette, cacheScope }: MobileShellProps) {
   const chat = useChatContext();
+  const cacheKey = cacheScope?.storageKey;
 
-  const [apps, setApps] = useState<MobileApp[]>(BUILT_IN_APPS);
+  const [apps, setApps] = useState<MobileApp[]>(() => mergeMobileApps(
+    BUILT_IN_APPS,
+    mobileAppsFromBootstrap(loadShellSnapshot(cacheScope)?.bootstrap),
+  ));
   const [openStack, setOpenStack] = useState<OpenApp[]>([]);
   const [view, setView] = useState<"launcher" | "app" | "switcher">("launcher");
   const [settingsOpen, setSettingsOpen] = useState(false);
@@ -180,37 +219,24 @@ export function MobileShell({ launchAppPath, onOpenCommandPalette }: MobileShell
     let cancelled = false;
     void (async () => {
       try {
-        const res = await fetch(`${getGatewayUrl()}/api/apps`, {
+        const res = await fetch(`${getGatewayUrl()}/api/shell/bootstrap`, {
           signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
         });
         if (!res.ok) return;
-        const list = (await res.json()) as { name: string; path: string; icon?: string }[];
+        const bootstrap = await res.json() as ShellBootstrapSnapshot | { name: string; path: string; icon?: string }[];
         if (cancelled) return;
-        const installed: MobileApp[] = list.map((a) => {
-          const relative = a.path.replace(/^\/files\//, "");
-          return {
-            id: `app:${relative}`,
-            name: a.name,
-            path: relative,
-            iconSlug: a.icon ?? nameToSlug(a.name),
-          };
-        });
-        setApps((prev) => {
-          const seen = new Set(prev.map((p) => p.path));
-          const merged = [...prev];
-          for (const a of installed) {
-            if (!seen.has(a.path)) merged.push(a);
-          }
-          return merged;
-        });
+        if (!Array.isArray(bootstrap)) {
+          saveShellSnapshot(cacheScope, { bootstrap });
+        }
+        setApps((prev) => mergeMobileApps(prev, mobileAppsFromBootstrap(bootstrap)));
       } catch (err: unknown) {
-        console.warn("[mobile-shell] failed to load /api/apps:", err instanceof Error ? err.message : err);
+        console.warn("[mobile-shell] failed to load /api/shell/bootstrap:", err instanceof Error ? err.message : err);
       }
     })();
     return () => {
       cancelled = true;
     };
-  }, []);
+  }, [cacheKey, cacheScope]);
 
   // react-doctor-disable-next-line react-doctor/react-compiler-no-manual-memoization -- stable identity is consumed by the launch-path useEffect dependency array below; removing useCallback would re-run that effect on every render and could re-open the launch app.
   const openApp = useCallback((app: MobileApp) => {
@@ -575,6 +601,7 @@ function Launcher({ apps, onOpen, onOpenSettings, openStackCount, onShowSwitcher
         {apps.map((app) => (
           <motion.button
             key={app.id}
+            data-testid={`mobile-launcher-app-${app.path}`}
             type="button"
             onClick={() => onOpen(app)}
             variants={fadeUp}

--- a/shell/src/hooks/useDesktopConfig.ts
+++ b/shell/src/hooks/useDesktopConfig.ts
@@ -1,10 +1,15 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useLayoutEffect, useState } from "react";
 import { useFileWatcher } from "./useFileWatcher";
 import { getGatewayUrl } from "@/lib/gateway";
 import { useDesktopConfigStore, type DockConfig } from "@/stores/desktop-config";
 import { DEFAULT_PINNED_APPS } from "@/lib/builtin-apps";
+import {
+  loadShellSnapshot,
+  saveShellSnapshot,
+  type ShellSnapshotScope,
+} from "@/lib/shell-snapshot-cache";
 export type { DockConfig };
 
 export interface DesktopConfig {
@@ -92,23 +97,50 @@ function applyBackground(config: DesktopConfig["background"], gatewayUrl: string
   }
 }
 
-export function useDesktopConfig() {
-  const [config, setConfig] = useState<DesktopConfig>(DEFAULT_DESKTOP_CONFIG);
+interface DesktopConfigHookOptions {
+  cacheScope?: ShellSnapshotScope | null;
+}
+
+function applyDesktopConfigSnapshot(
+  cfg: DesktopConfig,
+  gatewayUrl: string,
+  setters: {
+    setDock: (dock: DockConfig) => void;
+    setPinnedApps: (apps: string[]) => void;
+    setDockOrder: (order: DesktopConfig["dockOrder"]) => void;
+  },
+) {
+  setters.setDock(cfg.dock);
+  setters.setPinnedApps(cfg.pinnedApps);
+  setters.setDockOrder(cfg.dockOrder);
+  applyBackground(cfg.background, gatewayUrl);
+}
+
+export function useDesktopConfig(options: DesktopConfigHookOptions = {}) {
+  const cacheScope = options.cacheScope ?? null;
+  const cacheKey = cacheScope?.storageKey;
+  const [config, setConfig] = useState<DesktopConfig>(() => (
+    loadShellSnapshot(cacheScope)?.desktopConfig ?? DEFAULT_DESKTOP_CONFIG
+  ));
   const setDock = useDesktopConfigStore((s) => s.setDock);
   const setPinnedApps = useDesktopConfigStore((s) => s.setPinnedApps);
   const setDockOrder = useDesktopConfigStore((s) => s.setDockOrder);
   const gatewayUrl = getGatewayUrl();
 
+  useLayoutEffect(() => {
+    const cachedConfig = loadShellSnapshot(cacheScope)?.desktopConfig;
+    if (!cachedConfig) return;
+    applyDesktopConfigSnapshot(cachedConfig, gatewayUrl, { setDock, setPinnedApps, setDockOrder });
+  }, [cacheKey, cacheScope, gatewayUrl, setDock, setPinnedApps, setDockOrder]);
+
   // react-doctor-disable-next-line react-doctor/no-cascading-set-state -- the setConfig/setDock/setPinnedApps/setDockOrder calls all populate distinct stores from a single fetched desktop-config payload inside one async .then callback; they run together once the load resolves, not as a synchronous render-time cascade, and target separate Zustand slices that cannot be collapsed
   useEffect(() => {
     fetchDesktopConfig(gatewayUrl).then((cfg) => {
       setConfig(cfg);
-      setDock(cfg.dock);
-      setPinnedApps(cfg.pinnedApps);
-      setDockOrder(cfg.dockOrder);
-      applyBackground(cfg.background, gatewayUrl);
+      applyDesktopConfigSnapshot(cfg, gatewayUrl, { setDock, setPinnedApps, setDockOrder });
+      saveShellSnapshot(cacheScope, { desktopConfig: cfg });
     });
-  }, [gatewayUrl, setDock, setPinnedApps, setDockOrder]);
+  }, [cacheKey, cacheScope, gatewayUrl, setDock, setPinnedApps, setDockOrder]);
 
   useEffect(() => {
     applyBackground(config.background, gatewayUrl);
@@ -121,6 +153,7 @@ export function useDesktopConfig() {
         setDock(cfg.dock);
         setPinnedApps(cfg.pinnedApps);
         setDockOrder(cfg.dockOrder);
+        saveShellSnapshot(cacheScope, { desktopConfig: cfg });
       });
     }
   });
@@ -145,18 +178,25 @@ async function fetchDesktopConfig(gatewayUrl: string): Promise<DesktopConfig> {
   return DEFAULT_DESKTOP_CONFIG;
 }
 
-export async function saveDesktopConfig(config: DesktopConfig): Promise<void> {
+export function saveDesktopConfig(config: DesktopConfig): Promise<void>;
+export function saveDesktopConfig(config: DesktopConfig, options: DesktopConfigHookOptions): Promise<void>;
+export async function saveDesktopConfig(
+  config: DesktopConfig,
+  options: DesktopConfigHookOptions = {},
+): Promise<void> {
   const gatewayUrl = getGatewayUrl();
-  await fetch(`${gatewayUrl}/api/settings/desktop`, {
+  const res = await fetch(`${gatewayUrl}/api/settings/desktop`, {
     method: "PUT",
     headers: { "Content-Type": "application/json" },
     signal: AbortSignal.timeout(SETTINGS_FETCH_TIMEOUT_MS),
     body: JSON.stringify(config),
   });
+  if (res.ok) saveShellSnapshot(options.cacheScope, { desktopConfig: config });
 }
 
 export async function saveDesktopConfigPatch(
   patch: Partial<DesktopConfig>,
+  options: DesktopConfigHookOptions = {},
 ): Promise<void> {
   const gatewayUrl = getGatewayUrl();
   const url = `${gatewayUrl}/api/settings/desktop`;
@@ -169,13 +209,15 @@ export async function saveDesktopConfigPatch(
   const definedPatch = Object.fromEntries(
     Object.entries(patch).filter(([, value]) => value !== undefined),
   );
+  const nextConfig = { ...config, ...definedPatch };
   const putRes = await fetch(url, {
     method: "PUT",
     headers: { "Content-Type": "application/json" },
     signal: AbortSignal.timeout(SETTINGS_FETCH_TIMEOUT_MS),
-    body: JSON.stringify({ ...config, ...definedPatch }),
+    body: JSON.stringify(nextConfig),
   });
   if (!putRes.ok) {
     throw new Error(`PUT /api/settings/desktop ${putRes.status}`);
   }
+  saveShellSnapshot(options.cacheScope, { desktopConfig: nextConfig as DesktopConfig });
 }

--- a/shell/src/hooks/useDesktopConfig.ts
+++ b/shell/src/hooks/useDesktopConfig.ts
@@ -229,5 +229,5 @@ export async function saveDesktopConfigPatch(
   if (!putRes.ok) {
     throw new Error(`PUT /api/settings/desktop ${putRes.status}`);
   }
-  saveShellSnapshot(options.cacheScope, { desktopConfig: nextConfig as DesktopConfig });
+  saveShellSnapshot(options.cacheScope, { desktopConfig: nextConfig as unknown as DesktopConfig });
 }

--- a/shell/src/hooks/useDesktopConfig.ts
+++ b/shell/src/hooks/useDesktopConfig.ts
@@ -135,11 +135,15 @@ export function useDesktopConfig(options: DesktopConfigHookOptions = {}) {
 
   // react-doctor-disable-next-line react-doctor/no-cascading-set-state -- the setConfig/setDock/setPinnedApps/setDockOrder calls all populate distinct stores from a single fetched desktop-config payload inside one async .then callback; they run together once the load resolves, not as a synchronous render-time cascade, and target separate Zustand slices that cannot be collapsed
   useEffect(() => {
-    fetchDesktopConfig(gatewayUrl).then((cfg) => {
+    const controller = new AbortController();
+    fetchDesktopConfig(gatewayUrl, controller.signal).then((cfg) => {
+      if (controller.signal.aborted) return;
       setConfig(cfg);
       applyDesktopConfigSnapshot(cfg, gatewayUrl, { setDock, setPinnedApps, setDockOrder });
       saveShellSnapshot(cacheScope, { desktopConfig: cfg });
     });
+
+    return () => controller.abort();
   }, [cacheKey, cacheScope, gatewayUrl, setDock, setPinnedApps, setDockOrder]);
 
   useEffect(() => {
@@ -161,10 +165,15 @@ export function useDesktopConfig(options: DesktopConfigHookOptions = {}) {
   return config;
 }
 
-async function fetchDesktopConfig(gatewayUrl: string): Promise<DesktopConfig> {
+function settingsFetchSignal(signal?: AbortSignal): AbortSignal {
+  const timeoutSignal = AbortSignal.timeout(SETTINGS_FETCH_TIMEOUT_MS);
+  return signal ? AbortSignal.any([signal, timeoutSignal]) : timeoutSignal;
+}
+
+async function fetchDesktopConfig(gatewayUrl: string, signal?: AbortSignal): Promise<DesktopConfig> {
   try {
     const res = await fetch(`${gatewayUrl}/api/settings/desktop`, {
-      signal: AbortSignal.timeout(SETTINGS_FETCH_TIMEOUT_MS),
+      signal: settingsFetchSignal(signal),
     });
     if (res.ok) {
       const data = await res.json();
@@ -173,6 +182,7 @@ async function fetchDesktopConfig(gatewayUrl: string): Promise<DesktopConfig> {
       return merged;
     }
   } catch (err) {
+    if (signal?.aborted) return DEFAULT_DESKTOP_CONFIG;
     console.warn("[desktop-config] failed to load desktop config:", err instanceof Error ? err.message : String(err));
   }
   return DEFAULT_DESKTOP_CONFIG;

--- a/shell/src/hooks/useTheme.ts
+++ b/shell/src/hooks/useTheme.ts
@@ -148,10 +148,14 @@ export function useTheme(options: ShellCacheHookOptions = {}) {
 
   // Fetch theme from server on mount
   useEffect(() => {
-    fetchTheme(fallbackTheme).then((nextTheme) => {
+    const controller = new AbortController();
+    fetchTheme(fallbackTheme, controller.signal).then((nextTheme) => {
+      if (controller.signal.aborted) return;
       setTheme(nextTheme);
       saveShellSnapshot(cacheScope, { theme: nextTheme });
     });
+
+    return () => controller.abort();
   }, [fallbackTheme, cacheKey, cacheScope]);
 
   useEffect(() => {
@@ -192,14 +196,20 @@ export async function saveTheme(
   }
 }
 
-async function fetchTheme(defaultTheme: Theme = DEFAULT_THEME): Promise<Theme> {
+function settingsFetchSignal(signal?: AbortSignal): AbortSignal {
+  const timeoutSignal = AbortSignal.timeout(10_000);
+  return signal ? AbortSignal.any([signal, timeoutSignal]) : timeoutSignal;
+}
+
+async function fetchTheme(defaultTheme: Theme = DEFAULT_THEME, signal?: AbortSignal): Promise<Theme> {
   try {
     const gatewayUrl = getGatewayUrl();
     const res = await fetch(`${gatewayUrl}/api/settings/theme`, {
-      signal: AbortSignal.timeout(10_000),
+      signal: settingsFetchSignal(signal),
     });
     if (res.ok) return normalizeTheme(await res.json(), defaultTheme);
   } catch (err: unknown) {
+    if (signal?.aborted) return defaultTheme;
     console.warn("[theme] Failed to fetch theme:", err instanceof Error ? err.message : String(err));
   }
   return defaultTheme;

--- a/shell/src/hooks/useTheme.ts
+++ b/shell/src/hooks/useTheme.ts
@@ -3,6 +3,11 @@
 import { useEffect, useState } from "react";
 import { useFileWatcher } from "./useFileWatcher";
 import { getGatewayUrl } from "@/lib/gateway";
+import {
+  loadShellSnapshot,
+  saveShellSnapshot,
+  type ShellSnapshotScope,
+} from "@/lib/shell-snapshot-cache";
 
 export interface Theme {
   name: string;
@@ -123,14 +128,31 @@ export function getThemeFallback(): Theme {
   return DEFAULT_THEME;
 }
 
-export function useTheme() {
+export interface ShellCacheHookOptions {
+  cacheScope?: ShellSnapshotScope | null;
+}
+
+export function useTheme(options: ShellCacheHookOptions = {}) {
   const fallbackTheme = getThemeFallback();
-  const [theme, setTheme] = useState<Theme>(fallbackTheme);
+  const cacheScope = options.cacheScope ?? null;
+  const cacheKey = cacheScope?.storageKey;
+  const [theme, setTheme] = useState<Theme>(() => (
+    cacheScope ? normalizeTheme(loadShellSnapshot(cacheScope)?.theme, fallbackTheme) : fallbackTheme
+  ));
+
+  useEffect(() => {
+    if (!cacheScope) return;
+    const cachedTheme = loadShellSnapshot(cacheScope)?.theme;
+    if (cachedTheme) setTheme(normalizeTheme(cachedTheme, fallbackTheme));
+  }, [cacheKey, cacheScope, fallbackTheme]);
 
   // Fetch theme from server on mount
   useEffect(() => {
-    fetchTheme(fallbackTheme).then(setTheme);
-  }, [fallbackTheme]);
+    fetchTheme(fallbackTheme).then((nextTheme) => {
+      setTheme(nextTheme);
+      saveShellSnapshot(cacheScope, { theme: nextTheme });
+    });
+  }, [fallbackTheme, cacheKey, cacheScope]);
 
   useEffect(() => {
     applyTheme(theme);
@@ -138,14 +160,22 @@ export function useTheme() {
 
   useFileWatcher((path, event) => {
     if (path === "system/theme.json" && event !== "unlink") {
-      fetchTheme(fallbackTheme).then(setTheme);
+      fetchTheme(fallbackTheme).then((nextTheme) => {
+        setTheme(nextTheme);
+        saveShellSnapshot(cacheScope, { theme: nextTheme });
+      });
     }
   });
 
   return theme;
 }
 
-export async function saveTheme(theme: Theme): Promise<void> {
+export function saveTheme(theme: Theme): Promise<void>;
+export function saveTheme(theme: Theme, options: ShellCacheHookOptions): Promise<void>;
+export async function saveTheme(
+  theme: Theme,
+  options: ShellCacheHookOptions = {},
+): Promise<void> {
   const gatewayUrl = getGatewayUrl();
   const res = await fetch(`${gatewayUrl}/api/settings/theme`, {
     signal: AbortSignal.timeout(10_000),
@@ -156,6 +186,7 @@ export async function saveTheme(theme: Theme): Promise<void> {
   if (!res.ok) {
     throw new Error("Failed to save theme");
   }
+  saveShellSnapshot(options.cacheScope, { theme });
   if (typeof document !== "undefined") {
     applyTheme(theme);
   }

--- a/shell/src/lib/shell-snapshot-cache.ts
+++ b/shell/src/lib/shell-snapshot-cache.ts
@@ -1,0 +1,332 @@
+"use client";
+
+import { DEFAULT_PINNED_APPS } from "@/lib/builtin-apps";
+import type { Theme } from "@/hooks/useTheme";
+import type { DesktopConfig } from "@/hooks/useDesktopConfig";
+
+export const SHELL_SNAPSHOT_STORAGE_PREFIX = "matrix:shell-snapshot:v1";
+const SHELL_SNAPSHOT_VERSION = 1;
+const MAX_SNAPSHOT_BYTES = 128_000;
+const MAX_SNAPSHOT_AGE_MS = 14 * 24 * 60 * 60 * 1000;
+const SAFE_SLUG = /^[A-Za-z0-9_-]{1,64}$/;
+const SAFE_APP_PATH = /^(?:apps\/[A-Za-z0-9._~/-]{1,240}|__[-A-Za-z0-9_]+__)(?::[-A-Za-z0-9_]+)?$/;
+
+export interface ShellSnapshotScope {
+  userId: string;
+  runtimeScope: string;
+  storageKey: string;
+}
+
+export interface ShellBootstrapIconSnapshot {
+  url: string;
+  etag: string | null;
+  versionedUrl: string;
+}
+
+export interface ShellBootstrapSnapshot {
+  layout?: { windows?: unknown[] };
+  modules?: unknown[];
+  apps?: { name: string; path: string; icon?: string; slug?: string }[];
+  icons?: Record<string, ShellBootstrapIconSnapshot>;
+}
+
+export interface ShellSnapshot {
+  theme?: Theme;
+  desktopConfig?: DesktopConfig;
+  bootstrap?: ShellBootstrapSnapshot;
+}
+
+interface StoredShellSnapshot {
+  version: number;
+  updatedAt: number;
+  data: unknown;
+}
+
+let lastScope:
+  | { userId: string; runtimeScope: string; value: ShellSnapshotScope }
+  | null = null;
+
+export function createShellSnapshotScope({
+  userId,
+  pathname,
+}: {
+  userId: string | null | undefined;
+  pathname?: string | null;
+}): ShellSnapshotScope | null {
+  const normalizedUserId = typeof userId === "string" ? userId.trim() : "";
+  if (!normalizedUserId || normalizedUserId.length > 256 || !/^[A-Za-z0-9_-]+$/.test(normalizedUserId)) {
+    return null;
+  }
+  const runtimeScope = runtimeScopeFromPath(pathname ?? browserPathname());
+  if (lastScope?.userId === normalizedUserId && lastScope.runtimeScope === runtimeScope) {
+    return lastScope.value;
+  }
+  const value = {
+    userId: normalizedUserId,
+    runtimeScope,
+    storageKey: `${SHELL_SNAPSHOT_STORAGE_PREFIX}:${encodeURIComponent(normalizedUserId)}:${encodeURIComponent(runtimeScope)}`,
+  };
+  lastScope = { userId: normalizedUserId, runtimeScope, value };
+  return value;
+}
+
+export function loadShellSnapshot(
+  scope: ShellSnapshotScope | null | undefined,
+  storage: Storage | null = browserStorage(),
+): ShellSnapshot | null {
+  if (!scope || !storage) return null;
+  try {
+    const raw = storage.getItem(scope.storageKey);
+    if (!raw || raw.length > MAX_SNAPSHOT_BYTES) return null;
+    const stored = JSON.parse(raw) as StoredShellSnapshot;
+    if (!isRecord(stored) || stored.version !== SHELL_SNAPSHOT_VERSION || typeof stored.updatedAt !== "number") {
+      return null;
+    }
+    if (Date.now() - stored.updatedAt > MAX_SNAPSHOT_AGE_MS) return null;
+    return normalizeShellSnapshot(stored.data);
+  } catch (err: unknown) {
+    console.warn("[shell-cache] failed to load shell snapshot", err instanceof Error ? err.name : typeof err);
+    return null;
+  }
+}
+
+export function saveShellSnapshot(
+  scope: ShellSnapshotScope | null | undefined,
+  patch: ShellSnapshot,
+  storage: Storage | null = browserStorage(),
+): boolean {
+  if (!scope || !storage) return false;
+  const current = loadShellSnapshot(scope, storage) ?? {};
+  const next = normalizeShellSnapshot({ ...current, ...patch });
+  const raw = JSON.stringify({
+    version: SHELL_SNAPSHOT_VERSION,
+    updatedAt: Date.now(),
+    data: next,
+  });
+  if (raw.length > MAX_SNAPSHOT_BYTES) return false;
+  try {
+    storage.setItem(scope.storageKey, raw);
+    return true;
+  } catch (err: unknown) {
+    console.warn("[shell-cache] failed to save shell snapshot", err instanceof Error ? err.name : typeof err);
+    return false;
+  }
+}
+
+export function clearShellSnapshot(
+  scope: ShellSnapshotScope | null | undefined,
+  storage: Storage | null = browserStorage(),
+): void {
+  if (!scope || !storage) return;
+  storage.removeItem(scope.storageKey);
+}
+
+export function normalizeShellSnapshot(value: unknown): ShellSnapshot {
+  if (!isRecord(value)) return {};
+  return {
+    ...(value.theme !== undefined ? { theme: normalizeThemeSnapshot(value.theme) } : {}),
+    ...(value.desktopConfig !== undefined ? { desktopConfig: normalizeDesktopConfigSnapshot(value.desktopConfig) } : {}),
+    ...(value.bootstrap !== undefined ? { bootstrap: normalizeBootstrapSnapshot(value.bootstrap) } : {}),
+  };
+}
+
+function normalizeThemeSnapshot(value: unknown): Theme | undefined {
+  if (!isRecord(value) || !isRecord(value.colors) || !isRecord(value.fonts)) return undefined;
+  const colors = stringRecord(value.colors, 80);
+  const fonts = stringRecord(value.fonts, 40);
+  if (Object.keys(colors).length === 0 || Object.keys(fonts).length === 0) return undefined;
+  return {
+    name: safeString(value.name, 80) ?? "cached",
+    ...(value.mode === "light" || value.mode === "dark" ? { mode: value.mode } : {}),
+    ...(value.style === "flat" || value.style === "neumorphic" ? { style: value.style } : {}),
+    colors,
+    fonts,
+    radius: safeString(value.radius, 32) ?? "0.75rem",
+  };
+}
+
+function normalizeDesktopConfigSnapshot(value: unknown): DesktopConfig | undefined {
+  if (!isRecord(value)) return undefined;
+  const dock = normalizeDock(value.dock);
+  return {
+    background: normalizeBackground(value.background),
+    dock,
+    pinnedApps: normalizeAppPaths(value.pinnedApps, DEFAULT_PINNED_APPS),
+    ...(typeof value.iconStyle === "string" && value.iconStyle.length <= 240 ? { iconStyle: value.iconStyle } : {}),
+    ...(isRecord(value.dockOrder)
+      ? {
+          dockOrder: {
+            userApps: normalizeAppPaths(value.dockOrder.userApps, []),
+            systemApps: normalizeAppPaths(value.dockOrder.systemApps, []),
+          },
+        }
+      : {}),
+  };
+}
+
+function normalizeBootstrapSnapshot(value: unknown): ShellBootstrapSnapshot | undefined {
+  if (!isRecord(value)) return undefined;
+  return {
+    layout: normalizeBootstrapLayout(value.layout),
+    modules: Array.isArray(value.modules) ? value.modules.filter(isRecord).slice(0, 200) : [],
+    apps: normalizeBootstrapApps(value.apps),
+    icons: normalizeBootstrapIcons(value.icons),
+  };
+}
+
+function normalizeBootstrapLayout(value: unknown): { windows?: unknown[] } {
+  if (!isRecord(value) || !Array.isArray(value.windows)) return {};
+  return { windows: value.windows.filter(isRecord).slice(0, 100) };
+}
+
+function normalizeBootstrapApps(value: unknown): ShellBootstrapSnapshot["apps"] {
+  if (!Array.isArray(value)) return [];
+  return value.flatMap((entry) => {
+    if (!isRecord(entry)) return [];
+    const name = safeString(entry.name, 120);
+    const path = safeBootstrapAppPath(entry.path);
+    if (!name || !path) return [];
+    const icon = safeSlug(entry.icon);
+    const slug = safeSlug(entry.slug);
+    return [{ name, path, icon, slug }];
+  }).slice(0, 200);
+}
+
+function normalizeBootstrapIcons(value: unknown): Record<string, ShellBootstrapIconSnapshot> {
+  if (!isRecord(value)) return {};
+  const icons: Record<string, ShellBootstrapIconSnapshot> = {};
+  for (const [slug, icon] of Object.entries(value)) {
+    if (!SAFE_SLUG.test(slug) || !isRecord(icon)) continue;
+    const url = safeStaticPath(icon.url, "/icons/");
+    const versionedUrl = safeStaticPath(icon.versionedUrl, "/icons/");
+    if (!url || !versionedUrl) continue;
+    icons[slug] = {
+      url,
+      etag: typeof icon.etag === "string" && icon.etag.length <= 120 ? icon.etag : null,
+      versionedUrl,
+    };
+  }
+  return icons;
+}
+
+function normalizeDock(value: unknown): DesktopConfig["dock"] {
+  const fallback: DesktopConfig["dock"] = { position: "left", size: 56, iconSize: 40, autoHide: false };
+  if (!isRecord(value)) return fallback;
+  if (value.position !== "left" && value.position !== "bottom") return fallback;
+  if (!isBoundedNumber(value.size, 32, 96) || !isBoundedNumber(value.iconSize, 24, 72)) return fallback;
+  return {
+    position: value.position,
+    size: value.size,
+    iconSize: value.iconSize,
+    autoHide: false,
+  };
+}
+
+function normalizeBackground(value: unknown): DesktopConfig["background"] {
+  const fallback: DesktopConfig["background"] = { type: "wallpaper", name: "moraine-lake.jpg" };
+  if (!isRecord(value) || typeof value.type !== "string") return fallback;
+  if (value.type === "pattern") return { type: "pattern" };
+  if (value.type === "solid" && safeCssColor(value.color)) return { type: "solid", color: value.color };
+  if (value.type === "gradient" && safeCssColor(value.from) && safeCssColor(value.to)) {
+    return {
+      type: "gradient",
+      from: value.from,
+      to: value.to,
+      ...(isBoundedNumber(value.angle, 0, 360) ? { angle: value.angle } : {}),
+    };
+  }
+  if (value.type === "wallpaper") {
+    const name = safeFileName(value.name);
+    return name ? { type: "wallpaper", name } : fallback;
+  }
+  if (value.type === "image") {
+    const url = safeImageUrl(value.url);
+    return url ? { type: "image", url, fit: safeString(value.fit, 24) ?? "cover" } : fallback;
+  }
+  return fallback;
+}
+
+function normalizeAppPaths(value: unknown, fallback: string[]): string[] {
+  if (!Array.isArray(value)) return [...fallback];
+  const seen = new Set<string>();
+  const paths: string[] = [];
+  for (const item of value) {
+    if (typeof item !== "string") continue;
+    const path = item.trim();
+    if (!SAFE_APP_PATH.test(path) || path.includes("..") || seen.has(path)) continue;
+    seen.add(path);
+    paths.push(path);
+  }
+  return paths.slice(0, 120);
+}
+
+function runtimeScopeFromPath(pathname: string | null | undefined): string {
+  const match = (pathname ?? "").match(/^\/vm\/([A-Za-z0-9_-]{1,64})(?:\/|$)/);
+  return match ? `/vm/${match[1]}` : "default";
+}
+
+function browserPathname(): string {
+  return typeof window === "undefined" ? "/" : window.location.pathname;
+}
+
+function browserStorage(): Storage | null {
+  if (typeof window === "undefined") return null;
+  return window.localStorage;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function stringRecord(value: Record<string, unknown>, maxEntries: number): Record<string, string> {
+  return Object.fromEntries(
+    Object.entries(value)
+      .filter((entry): entry is [string, string] => SAFE_SLUG.test(entry[0]) && typeof entry[1] === "string" && entry[1].length <= 240)
+      .slice(0, maxEntries),
+  );
+}
+
+function safeString(value: unknown, maxLength: number): string | undefined {
+  return typeof value === "string" && value.trim() && value.length <= maxLength ? value : undefined;
+}
+
+function safeSlug(value: unknown): string | undefined {
+  return typeof value === "string" && SAFE_SLUG.test(value) ? value : undefined;
+}
+
+function safeBootstrapAppPath(value: unknown): string | undefined {
+  if (typeof value !== "string" || value.includes("..") || value.length > 260) return undefined;
+  return value.startsWith("/files/apps/") || value.startsWith("apps/") || value.startsWith("__") ? value : undefined;
+}
+
+function safeStaticPath(value: unknown, prefix: string): string | undefined {
+  if (typeof value !== "string" || value.length > 300) return undefined;
+  if (!value.startsWith(prefix) || value.includes("..") || value.includes("javascript:")) return undefined;
+  return value;
+}
+
+function safeFileName(value: unknown): string | undefined {
+  return typeof value === "string" && /^[A-Za-z0-9._-]{1,160}$/.test(value) ? value : undefined;
+}
+
+function safeCssColor(value: unknown): value is string {
+  return typeof value === "string" && value.length <= 80 && !/[;<>{}]/.test(value);
+}
+
+function safeImageUrl(value: unknown): string | undefined {
+  if (typeof value !== "string" || value.length > 500 || /javascript:/i.test(value)) return undefined;
+  try {
+    const url = new URL(value, typeof window === "undefined" ? "https://app.matrix-os.com" : window.location.origin);
+    if (url.protocol !== "https:" && url.protocol !== "http:") return undefined;
+    if (url.origin === (typeof window === "undefined" ? "https://app.matrix-os.com" : window.location.origin)) {
+      return `${url.pathname}${url.search}`;
+    }
+    return url.toString();
+  } catch {
+    return undefined;
+  }
+}
+
+function isBoundedNumber(value: unknown, min: number, max: number): value is number {
+  return typeof value === "number" && Number.isFinite(value) && value >= min && value <= max;
+}

--- a/shell/src/lib/shell-snapshot-cache.ts
+++ b/shell/src/lib/shell-snapshot-cache.ts
@@ -246,7 +246,7 @@ function normalizeBackground(value: unknown): DesktopConfig["background"] {
   return fallback;
 }
 
-function normalizeAppPaths(value: unknown, fallback: string[]): string[] {
+function normalizeAppPaths(value: unknown, fallback: readonly string[]): string[] {
   if (!Array.isArray(value)) return [...fallback];
   const seen = new Set<string>();
   const paths: string[] = [];
@@ -322,7 +322,10 @@ function safeImageUrl(value: unknown): string | undefined {
       return `${url.pathname}${url.search}`;
     }
     return url.toString();
-  } catch {
+  } catch (err: unknown) {
+    if (!(err instanceof TypeError)) {
+      console.warn("[shell-snapshot-cache] unexpected image URL parse failure:", err);
+    }
     return undefined;
   }
 }

--- a/tests/edge-router/edge-router.test.ts
+++ b/tests/edge-router/edge-router.test.ts
@@ -104,6 +104,47 @@ describe("edge router worker", () => {
     expect(response.headers.get("cloudflare-cdn-cache-control")).toBe("no-store");
   });
 
+  it("preserves browser cache headers for safe app-domain static assets while keeping CDN caches disabled", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response("asset", {
+        headers: {
+          "cache-control": "public, max-age=31536000, immutable",
+          "cdn-cache-control": "public, max-age=31536000",
+        },
+      }),
+    );
+
+    const response = await handleEdgeRouterRequest(
+      new Request("https://app.matrix-os.com/_next/static/chunks/app.js"),
+      EDGE_ENV,
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("cache-control")).toBe("public, max-age=31536000, immutable");
+    expect(response.headers.get("cdn-cache-control")).toBe("no-store");
+    expect(response.headers.get("cloudflare-cdn-cache-control")).toBe("no-store");
+  });
+
+  it("does not preserve browser cache headers for app-domain API responses", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response("api", {
+        headers: {
+          "cache-control": "public, max-age=31536000, immutable",
+        },
+      }),
+    );
+
+    const response = await handleEdgeRouterRequest(
+      new Request("https://app.matrix-os.com/api/shell/bootstrap"),
+      EDGE_ENV,
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("cache-control")).toBe("no-store");
+    expect(response.headers.get("cdn-cache-control")).toBe("no-store");
+    expect(response.headers.get("cloudflare-cdn-cache-control")).toBe("no-store");
+  });
+
   it("rejects oversized bodies before forwarding", async () => {
     const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response("nope"));
 

--- a/tests/edge-router/edge-router.test.ts
+++ b/tests/edge-router/edge-router.test.ts
@@ -125,6 +125,50 @@ describe("edge router worker", () => {
     expect(response.headers.get("cloudflare-cdn-cache-control")).toBe("no-store");
   });
 
+  it("respects upstream no-store headers for static-looking app-domain assets", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response("asset", {
+        headers: {
+          "cache-control": "no-store",
+        },
+      }),
+    );
+
+    const response = await handleEdgeRouterRequest(
+      new Request("https://app.matrix-os.com/icons/private.svg"),
+      EDGE_ENV,
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("cache-control")).toBe("no-store");
+    expect(response.headers.get("cdn-cache-control")).toBe("no-store");
+    expect(response.headers.get("cloudflare-cdn-cache-control")).toBe("no-store");
+  });
+
+  it("does not classify API or v1 paths as static assets by extension", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response("api", {
+        headers: {
+          "cache-control": "public, max-age=31536000, immutable",
+        },
+      }),
+    );
+
+    const apiResponse = await handleEdgeRouterRequest(
+      new Request("https://app.matrix-os.com/api/theme.css"),
+      EDGE_ENV,
+    );
+    const v1Response = await handleEdgeRouterRequest(
+      new Request("https://app.matrix-os.com/v1/widget.js"),
+      EDGE_ENV,
+    );
+
+    expect(apiResponse.headers.get("cache-control")).toBe("no-store");
+    expect(v1Response.headers.get("cache-control")).toBe("no-store");
+    expect(apiResponse.headers.get("cdn-cache-control")).toBe("no-store");
+    expect(v1Response.headers.get("cloudflare-cdn-cache-control")).toBe("no-store");
+  });
+
   it("does not preserve browser cache headers for app-domain API responses", async () => {
     vi.spyOn(globalThis, "fetch").mockResolvedValue(
       new Response("api", {

--- a/tests/platform/proxy-routing.test.ts
+++ b/tests/platform/proxy-routing.test.ts
@@ -4806,7 +4806,7 @@ describe("platform proxy routing", () => {
     }
   });
 
-  it("serves an unregistering app-domain service worker without auth", async () => {
+  it("serves the safe app-domain service worker without auth", async () => {
     const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
       new Response("wrong target", { status: 200 }),
     );
@@ -4834,9 +4834,10 @@ describe("platform proxy routing", () => {
       expect(res.headers.get("cdn-cache-control")).toBe("no-store");
       expect(res.headers.get("service-worker-allowed")).toBe("/");
       const body = await res.text();
-      expect(body).toContain("registration.unregister()");
-      expect(body).not.toContain("[app cleanup sw] fetch failed");
-      expect(body).not.toContain('new Response("offline",');
+      expect(body).not.toContain("registration.unregister()");
+      expect(body).toContain('p.startsWith("/api/")');
+      expect(body).toContain('p.startsWith("/files/apps/")');
+      expect(body).toContain('p.startsWith("/_next/static/")');
       expect(verifyToken).not.toHaveBeenCalled();
       expect(fetchMock).not.toHaveBeenCalled();
     } finally {

--- a/tests/shell/desktop-config.test.ts
+++ b/tests/shell/desktop-config.test.ts
@@ -1,3 +1,6 @@
+// @vitest-environment jsdom
+
+import { renderHook, waitFor } from "@testing-library/react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { useDesktopConfigStore, type DockConfig } from "../../shell/src/stores/desktop-config";
 import { DEFAULT_PINNED_APPS } from "../../shell/src/lib/builtin-apps";
@@ -5,11 +8,32 @@ import {
   buildMeshGradient,
   saveDesktopConfig,
   saveDesktopConfigPatch,
+  useDesktopConfig,
   type DesktopConfig,
 } from "../../shell/src/hooks/useDesktopConfig";
+import { createShellSnapshotScope, loadShellSnapshot, saveShellSnapshot } from "../../shell/src/lib/shell-snapshot-cache";
+
+function createMemoryStorage(): Storage {
+  const values = new Map<string, string>();
+  return {
+    get length() {
+      return values.size;
+    },
+    clear: () => values.clear(),
+    getItem: (key) => values.get(key) ?? null,
+    key: (index) => Array.from(values.keys())[index] ?? null,
+    removeItem: (key) => values.delete(key),
+    setItem: (key, value) => values.set(key, value),
+  };
+}
 
 describe("Desktop config", () => {
   beforeEach(() => {
+    const storage = createMemoryStorage();
+    Object.defineProperty(window, "localStorage", {
+      value: storage,
+      configurable: true,
+    });
     useDesktopConfigStore.setState({
       dock: { position: "left", size: 56, iconSize: 40, autoHide: false },
       pinnedApps: [...DEFAULT_PINNED_APPS],
@@ -174,5 +198,47 @@ describe("Desktop config", () => {
       pinnedApps: ["apps/test.html"],
     };
     expect(config.pinnedApps).toEqual(["apps/test.html"]);
+  });
+
+  it("initializes from the scoped shell snapshot before revalidating desktop config", async () => {
+    const scope = createShellSnapshotScope({ userId: "user_123", pathname: "/" });
+    expect(scope).not.toBeNull();
+    saveShellSnapshot(scope, {
+      desktopConfig: {
+        background: { type: "wallpaper", name: "cached-wallpaper.jpg" },
+        dock: { position: "bottom", size: 64, iconSize: 44, autoHide: false },
+        pinnedApps: ["apps/cached/index.html"],
+      },
+    });
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        background: { type: "wallpaper", name: "fresh-wallpaper.jpg" },
+        dock: { position: "left", size: 56, iconSize: 40, autoHide: false },
+        pinnedApps: ["apps/fresh/index.html"],
+      }),
+    }));
+
+    const { result } = renderHook(() => useDesktopConfig({ cacheScope: scope }));
+
+    expect(result.current.background).toEqual({ type: "wallpaper", name: "cached-wallpaper.jpg" });
+    expect(useDesktopConfigStore.getState().dock.position).toBe("bottom");
+    await waitFor(() => expect(result.current.background).toEqual({ type: "wallpaper", name: "fresh-wallpaper.jpg" }));
+    expect(loadShellSnapshot(scope)?.desktopConfig?.pinnedApps).toEqual(["apps/fresh/index.html"]);
+  });
+
+  it("updates the scoped shell snapshot only after desktop config saves succeed", async () => {
+    const scope = createShellSnapshotScope({ userId: "user_123", pathname: "/" });
+    expect(scope).not.toBeNull();
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: true }));
+    const config: DesktopConfig = {
+      background: { type: "pattern" },
+      dock: { position: "left", size: 56, iconSize: 40, autoHide: false },
+      pinnedApps: ["apps/saved/index.html"],
+    };
+
+    await saveDesktopConfig(config, { cacheScope: scope });
+
+    expect(loadShellSnapshot(scope)?.desktopConfig?.pinnedApps).toEqual(["apps/saved/index.html"]);
   });
 });

--- a/tests/shell/desktop-launcher-mode.test.tsx
+++ b/tests/shell/desktop-launcher-mode.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import React from "react";
-import { render, screen, waitFor } from "@testing-library/react";
+import { act, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { Desktop } from "../../shell/src/components/Desktop.js";
@@ -106,6 +106,14 @@ function jsonResponse(body: unknown) {
     status: 200,
     headers: { "Content-Type": "application/json" },
   }));
+}
+
+function deferredResponse() {
+  let resolve!: (response: Response) => void;
+  const promise = new Promise<Response>((next) => {
+    resolve = next;
+  });
+  return { promise, resolve };
 }
 
 type DesktopComponentType = typeof Desktop;
@@ -220,6 +228,61 @@ describe("Desktop launcher dock button by mode", () => {
 
     await waitFor(() => {
       expect(windowManagerStore.getState().apps.some((app) => app.path === "apps/notes/index.html")).toBe(true);
+    });
+  });
+
+  it("ignores stale bootstrap responses after cache scope changes", async () => {
+    const scope = createShellSnapshotScope({ userId: "user_123", pathname: "/" });
+    expect(scope).not.toBeNull();
+    const firstBootstrap = deferredResponse();
+    const secondBootstrap = deferredResponse();
+    const pendingBootstrap = [firstBootstrap, secondBootstrap];
+    vi.stubGlobal("fetch", vi.fn((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes("/api/settings/onboarding-status")) return jsonResponse({ complete: true });
+      if (url.includes("/api/shell/bootstrap")) {
+        const next = pendingBootstrap.shift();
+        if (!next) return jsonResponse({ layout: { windows: [] }, apps: [], modules: [] });
+        return next.promise;
+      }
+      return jsonResponse({});
+    }));
+    resetShellMode("dev", true);
+
+    const { rerender } = render(<DesktopComponent />);
+    await waitFor(() => {
+      expect(pendingBootstrap).toHaveLength(1);
+    });
+
+    rerender(<DesktopComponent cacheScope={scope} />);
+    await waitFor(() => {
+      expect(pendingBootstrap).toHaveLength(0);
+    });
+
+    await act(async () => {
+      secondBootstrap.resolve(new Response(JSON.stringify({
+        layout: { windows: [] },
+        apps: [{ name: "Fresh Notes", path: "/files/apps/fresh/index.html", icon: "fresh", slug: "fresh" }],
+        modules: [],
+      }), { status: 200, headers: { "Content-Type": "application/json" } }));
+    });
+
+    await waitFor(() => {
+      expect(windowManagerStore.getState().apps.some((app) => app.path === "apps/fresh/index.html")).toBe(true);
+    });
+
+    await act(async () => {
+      firstBootstrap.resolve(new Response(JSON.stringify({
+        layout: { windows: [] },
+        apps: [{ name: "Stale Notes", path: "/files/apps/stale/index.html", icon: "stale", slug: "stale" }],
+        modules: [],
+      }), { status: 200, headers: { "Content-Type": "application/json" } }));
+    });
+
+    await waitFor(() => {
+      const appPaths = windowManagerStore.getState().apps.map((app) => app.path);
+      expect(appPaths).toContain("apps/fresh/index.html");
+      expect(appPaths).not.toContain("apps/stale/index.html");
     });
   });
 });

--- a/tests/shell/desktop-launcher-mode.test.tsx
+++ b/tests/shell/desktop-launcher-mode.test.tsx
@@ -7,6 +7,7 @@ import type { Desktop } from "../../shell/src/components/Desktop.js";
 import type { useWindowManager } from "../../shell/src/hooks/useWindowManager.js";
 import type { useDesktopConfigStore } from "../../shell/src/stores/desktop-config.js";
 import type { useDesktopMode } from "../../shell/src/stores/desktop-mode.js";
+import { createShellSnapshotScope, saveShellSnapshot } from "../../shell/src/lib/shell-snapshot-cache.js";
 
 vi.mock("../../shell/src/hooks/useFileWatcher.js", () => ({
   useFileWatcher: () => undefined,
@@ -193,6 +194,32 @@ describe("Desktop launcher dock button by mode", () => {
     await waitFor(() => {
       expect(screen.getByTestId("dock-tasks")).toBeTruthy();
       expect(screen.getByTestId("dock-settings")).toBeTruthy();
+    });
+  });
+
+  it("registers apps from the scoped shell bootstrap snapshot before network bootstrap returns", async () => {
+    const scope = createShellSnapshotScope({ userId: "user_123", pathname: "/" });
+    expect(scope).not.toBeNull();
+    saveShellSnapshot(scope, {
+      bootstrap: {
+        layout: { windows: [] },
+        modules: [],
+        apps: [{ name: "Cached Notes", path: "/files/apps/notes/index.html", icon: "notes", slug: "notes" }],
+        icons: { notes: { url: "/icons/notes.png", etag: "\"abc\"", versionedUrl: "/icons/notes.png?v=abc" } },
+      },
+    });
+    vi.stubGlobal("fetch", vi.fn((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes("/api/settings/onboarding-status")) return jsonResponse({ complete: true });
+      if (url.includes("/api/shell/bootstrap")) return new Promise(() => undefined);
+      return jsonResponse({});
+    }));
+    resetShellMode("dev", true);
+
+    render(<DesktopComponent cacheScope={scope} />);
+
+    await waitFor(() => {
+      expect(windowManagerStore.getState().apps.some((app) => app.path === "apps/notes/index.html")).toBe(true);
     });
   });
 });

--- a/tests/shell/mobile-shell.test.tsx
+++ b/tests/shell/mobile-shell.test.tsx
@@ -7,6 +7,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { MobileAppSurface } from "../../shell/src/components/mobile/MobileAppSurface.js";
 import { MobileLauncher } from "../../shell/src/components/mobile/MobileLauncher.js";
 import { useMobileViewport } from "../../shell/src/hooks/useMobileViewport.js";
+import { createShellSnapshotScope, saveShellSnapshot } from "../../shell/src/lib/shell-snapshot-cache.js";
 import { setDesktopViewport, setPhoneViewport } from "./mobile-shell-test-utils.js";
 
 vi.mock("../../shell/src/components/terminal/TerminalApp.js", () => ({
@@ -61,12 +62,31 @@ function ViewportProbe() {
   return <div data-testid="viewport-mode">{mobile ? "mobile" : "desktop"}</div>;
 }
 
+function createMemoryStorage(): Storage {
+  const values = new Map<string, string>();
+  return {
+    get length() {
+      return values.size;
+    },
+    clear: () => values.clear(),
+    getItem: (key) => values.get(key) ?? null,
+    key: (index) => Array.from(values.keys())[index] ?? null,
+    removeItem: (key) => values.delete(key),
+    setItem: (key, value) => values.set(key, value),
+  };
+}
+
 async function loadMobileShell() {
   return (await import("../../shell/src/components/mobile/MobileShell.js")).MobileShell;
 }
 
 describe("mobile shell", () => {
   beforeEach(() => {
+    const storage = createMemoryStorage();
+    Object.defineProperty(window, "localStorage", {
+      value: storage,
+      configurable: true,
+    });
     setDesktopViewport();
   });
 
@@ -208,6 +228,44 @@ describe("mobile shell", () => {
     render(<MobileShell launchAppPath="__terminal__" />);
 
     await waitFor(() => expect(screen.getByTestId("terminal-app")).toBeTruthy());
+  });
+
+  it("loads installed mobile apps from the shared shell bootstrap endpoint", async () => {
+    const fetchMock = vi.fn(() => Promise.resolve({
+      ok: true,
+      json: async () => ({
+        layout: { windows: [] },
+        modules: [],
+        apps: [{ name: "Notes", path: "/files/apps/notes/index.html", icon: "notes", slug: "notes" }],
+        icons: { notes: { url: "/icons/notes.png", etag: "\"abc\"", versionedUrl: "/icons/notes.png?v=abc" } },
+      }),
+    }));
+    vi.stubGlobal("fetch", fetchMock);
+    const MobileShell = await loadMobileShell();
+
+    render(<MobileShell />);
+
+    expect(await screen.findByTestId("mobile-launcher-app-apps/notes/index.html")).toBeTruthy();
+    expect(String(fetchMock.mock.calls[0]?.[0])).toContain("/api/shell/bootstrap");
+  });
+
+  it("hydrates installed mobile apps from the scoped shell snapshot before network refresh", async () => {
+    const scope = createShellSnapshotScope({ userId: "user_123", pathname: "/" });
+    expect(scope).not.toBeNull();
+    saveShellSnapshot(scope, {
+      bootstrap: {
+        layout: { windows: [] },
+        modules: [],
+        apps: [{ name: "Cached Notes", path: "/files/apps/notes/index.html", icon: "notes", slug: "notes" }],
+        icons: { notes: { url: "/icons/notes.png", etag: "\"abc\"", versionedUrl: "/icons/notes.png?v=abc" } },
+      },
+    });
+    vi.stubGlobal("fetch", vi.fn(() => new Promise(() => undefined)));
+    const MobileShell = await loadMobileShell();
+
+    render(<MobileShell cacheScope={scope} />);
+
+    expect(screen.getByTestId("mobile-launcher-app-apps/notes/index.html")).toBeTruthy();
   });
 
   it("renders a hydration-stable clock placeholder before mounting", async () => {

--- a/tests/shell/service-worker.test.ts
+++ b/tests/shell/service-worker.test.ts
@@ -9,4 +9,24 @@ describe("shell service worker", () => {
     expect(source).toContain('new Response("offline",');
     expect(source).toContain("status: 504");
   });
+
+  it("keeps private API and app document routes out of the service worker cache", async () => {
+    const source = await readFile("shell/public/service-worker.js", "utf8");
+
+    expect(source).toContain('p.startsWith("/api/")');
+    expect(source).toContain('p.startsWith("/v1/")');
+    expect(source).toContain('p.startsWith("/files/apps/")');
+    expect(source).toContain('p.startsWith("/_next/data/")');
+    expect(source).toContain('p.startsWith("/sign-in")');
+    expect(source).toContain('p.startsWith("/sign-up")');
+  });
+
+  it("limits app-domain static caching to shell assets and safe image/font files", async () => {
+    const source = await readFile("shell/public/service-worker.js", "utf8");
+
+    expect(source).toContain('p.startsWith("/_next/static/")');
+    expect(source).toContain('p.startsWith("/icons/")');
+    expect(source).toContain('p.startsWith("/wallpapers/")');
+    expect(source).toContain('p.startsWith("/files/system/wallpapers/")');
+  });
 });

--- a/tests/shell/shell-snapshot-cache.test.ts
+++ b/tests/shell/shell-snapshot-cache.test.ts
@@ -1,0 +1,130 @@
+// @vitest-environment jsdom
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  createShellSnapshotScope,
+  loadShellSnapshot,
+  saveShellSnapshot,
+  SHELL_SNAPSHOT_STORAGE_PREFIX,
+} from "../../shell/src/lib/shell-snapshot-cache";
+
+const freshSnapshot = {
+  theme: {
+    name: "cached",
+    mode: "dark",
+    colors: { background: "#101010", foreground: "#f5f5f5" },
+    fonts: { sans: "Inter, sans-serif", mono: "JetBrains Mono, monospace" },
+    radius: "12px",
+  },
+  desktopConfig: {
+    background: { type: "wallpaper", name: "cached-wallpaper.jpg" },
+    dock: { position: "bottom", size: 64, iconSize: 44, autoHide: false },
+    pinnedApps: ["apps/notes/index.html"],
+  },
+  bootstrap: {
+    layout: { windows: [{ id: "w1", path: "__terminal__", title: "Terminal" }] },
+    apps: [{ name: "Notes", path: "/files/apps/notes/index.html", icon: "notes", slug: "notes" }],
+    modules: [],
+    icons: {
+      notes: { url: "/icons/notes.png", etag: "\"abc\"", versionedUrl: "/icons/notes.png?v=abc" },
+    },
+  },
+};
+
+function createMemoryStorage(): Storage {
+  const values = new Map<string, string>();
+  return {
+    get length() {
+      return values.size;
+    },
+    clear: () => values.clear(),
+    getItem: (key) => values.get(key) ?? null,
+    key: (index) => Array.from(values.keys())[index] ?? null,
+    removeItem: (key) => values.delete(key),
+    setItem: (key, value) => values.set(key, value),
+  };
+}
+
+describe("shell snapshot cache", () => {
+  let storage: Storage;
+
+  beforeEach(() => {
+    storage = createMemoryStorage();
+    vi.restoreAllMocks();
+  });
+
+  it("keys snapshots by Clerk user id and runtime path scope", () => {
+    const primary = createShellSnapshotScope({ userId: "user_123", pathname: "/" });
+    const vm = createShellSnapshotScope({ userId: "user_123", pathname: "/vm/staging" });
+    const otherUser = createShellSnapshotScope({ userId: "user_456", pathname: "/" });
+
+    expect(primary?.storageKey).toContain(SHELL_SNAPSHOT_STORAGE_PREFIX);
+    expect(primary?.storageKey).not.toBe(vm?.storageKey);
+    expect(primary?.storageKey).not.toBe(otherUser?.storageKey);
+  });
+
+  it("does not create a readable cache scope without a loaded user id", () => {
+    expect(createShellSnapshotScope({ userId: null, pathname: "/" })).toBeNull();
+    expect(createShellSnapshotScope({ userId: undefined, pathname: "/" })).toBeNull();
+  });
+
+  it("round-trips a sanitized snapshot", () => {
+    const scope = createShellSnapshotScope({ userId: "user_123", pathname: "/" });
+    expect(scope).not.toBeNull();
+
+    saveShellSnapshot(scope, freshSnapshot, storage);
+
+    expect(loadShellSnapshot(scope, storage)).toEqual(expect.objectContaining({
+      theme: expect.objectContaining({ name: "cached" }),
+      desktopConfig: expect.objectContaining({ background: { type: "wallpaper", name: "cached-wallpaper.jpg" } }),
+      bootstrap: expect.objectContaining({ apps: freshSnapshot.bootstrap.apps }),
+    }));
+  });
+
+  it("ignores corrupt, stale, and oversized entries", () => {
+    const scope = createShellSnapshotScope({ userId: "user_123", pathname: "/" });
+    expect(scope).not.toBeNull();
+
+    storage.setItem(scope!.storageKey, "{not json");
+    expect(loadShellSnapshot(scope, storage)).toBeNull();
+
+    storage.setItem(scope!.storageKey, JSON.stringify({
+      version: 1,
+      updatedAt: Date.now() - 15 * 24 * 60 * 60 * 1000,
+      data: freshSnapshot,
+    }));
+    expect(loadShellSnapshot(scope, storage)).toBeNull();
+
+    storage.setItem(scope!.storageKey, "x".repeat(180_000));
+    expect(loadShellSnapshot(scope, storage)).toBeNull();
+  });
+
+  it("drops unknown or unsafe bootstrap and desktop fields instead of trusting raw localStorage", () => {
+    const scope = createShellSnapshotScope({ userId: "user_123", pathname: "/" });
+    expect(scope).not.toBeNull();
+
+    saveShellSnapshot(scope, {
+      desktopConfig: {
+        background: { type: "image", url: "javascript:alert(1)" },
+        dock: { position: "sideways", size: 10000, iconSize: -1, autoHide: true },
+        pinnedApps: ["apps/safe/index.html", "../escape"],
+      },
+      bootstrap: {
+        layout: { windows: "bad" },
+        apps: [{ name: "Safe", path: "/files/apps/safe/index.html", icon: "../bad", slug: "safe" }],
+        modules: "bad",
+        icons: { "../bad": { url: "javascript:alert(1)", etag: null, versionedUrl: "javascript:alert(1)" } },
+      },
+    }, storage);
+
+    const loaded = loadShellSnapshot(scope, storage);
+
+    expect(loaded?.desktopConfig?.background).toEqual({ type: "wallpaper", name: "moraine-lake.jpg" });
+    expect(loaded?.desktopConfig?.dock).toEqual({ position: "left", size: 56, iconSize: 40, autoHide: false });
+    expect(loaded?.desktopConfig?.pinnedApps).toEqual(["apps/safe/index.html"]);
+    expect(loaded?.bootstrap?.layout).toEqual({});
+    expect(loaded?.bootstrap?.modules).toEqual([]);
+    expect(loaded?.bootstrap?.apps).toEqual([{ name: "Safe", path: "/files/apps/safe/index.html", icon: undefined, slug: "safe" }]);
+    expect(loaded?.bootstrap?.icons).toEqual({});
+  });
+});

--- a/tests/shell/useTheme.test.ts
+++ b/tests/shell/useTheme.test.ts
@@ -1,5 +1,9 @@
-import { describe, it, expect, vi } from "vitest";
-import { DEFAULT_THEME, getThemeFallback, normalizeTheme, type Theme } from "../../shell/src/hooks/useTheme";
+// @vitest-environment jsdom
+
+import { renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, it, expect, vi } from "vitest";
+import { DEFAULT_THEME, getThemeFallback, normalizeTheme, saveTheme, useTheme, type Theme } from "../../shell/src/hooks/useTheme";
+import { createShellSnapshotScope, loadShellSnapshot, saveShellSnapshot } from "../../shell/src/lib/shell-snapshot-cache";
 
 vi.mock("../../shell/src/hooks/useFileWatcher", () => ({
   useFileWatcher: () => undefined,
@@ -17,7 +21,30 @@ function themeToCssVars(theme: Theme): Record<string, string> {
   return vars;
 }
 
+function createMemoryStorage(): Storage {
+  const values = new Map<string, string>();
+  return {
+    get length() {
+      return values.size;
+    },
+    clear: () => values.clear(),
+    getItem: (key) => values.get(key) ?? null,
+    key: (index) => Array.from(values.keys())[index] ?? null,
+    removeItem: (key) => values.delete(key),
+    setItem: (key, value) => values.set(key, value),
+  };
+}
+
 describe("theme system", () => {
+  beforeEach(() => {
+    const storage = createMemoryStorage();
+    Object.defineProperty(window, "localStorage", {
+      value: storage,
+      configurable: true,
+    });
+    vi.restoreAllMocks();
+  });
+
   const REQUIRED_COLOR_KEYS = [
     "background",
     "foreground",
@@ -187,5 +214,44 @@ describe("theme system", () => {
     expect(theme.fonts.sans).toBe("system-ui, sans-serif");
     expect(theme.fonts.mono).toBe(fallback.fonts.mono);
     expect(theme.radius).toBe("1rem");
+  });
+
+  it("initializes from the scoped shell snapshot before revalidating from the server", async () => {
+    const scope = createShellSnapshotScope({ userId: "user_123", pathname: "/" });
+    expect(scope).not.toBeNull();
+    saveShellSnapshot(scope, {
+      theme: {
+        ...DEFAULT_THEME,
+        name: "cached-dark",
+        mode: "dark",
+        colors: { ...DEFAULT_THEME.colors, background: "#101010" },
+      },
+    });
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        ...DEFAULT_THEME,
+        name: "fresh-light",
+        mode: "light",
+        colors: { ...DEFAULT_THEME.colors, background: "#ffffff" },
+      }),
+    }));
+
+    const { result } = renderHook(() => useTheme({ cacheScope: scope }));
+
+    expect(result.current.name).toBe("cached-dark");
+    expect(result.current.colors.background).toBe("#101010");
+    await waitFor(() => expect(result.current.name).toBe("fresh-light"));
+    expect(loadShellSnapshot(scope)?.theme?.name).toBe("fresh-light");
+  });
+
+  it("updates the scoped shell snapshot only after theme saves succeed", async () => {
+    const scope = createShellSnapshotScope({ userId: "user_123", pathname: "/" });
+    expect(scope).not.toBeNull();
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: true }));
+
+    await saveTheme({ ...DEFAULT_THEME, name: "saved-theme" }, { cacheScope: scope });
+
+    expect(loadShellSnapshot(scope)?.theme?.name).toBe("saved-theme");
   });
 });

--- a/www/content/docs/shell.mdx
+++ b/www/content/docs/shell.mdx
@@ -76,6 +76,12 @@ Click **Files** in the sidebar to open the file browser. It shows your Matrix ho
 
 Files you create or clone in the Terminal appear immediately in the file browser. Changes sync across the web shell and persist on your Matrix computer.
 
+## Refresh and PWA cache
+
+The browser and installed PWA keep a private shell snapshot on your device so refreshes can restore your theme, wallpaper, dock, launcher apps, and saved shell bootstrap before the network finishes. The snapshot is scoped to the signed-in account and runtime path, expires automatically, and is replaced after the shell revalidates with your Matrix computer.
+
+Static shell assets such as icons, fonts, bundled wallpapers, and Next.js chunks can be cached by the browser and service worker. Private APIs, auth pages, app documents, billing/provisioning routes, and owner data stay `no-store` and are never shared through the CDN cache.
+
 ## What persists
 
 - Shell sessions and terminal output.


### PR DESCRIPTION
## Summary

- Add a browser-private shell snapshot cache scoped by Clerk user id and runtime path for first-paint theme, desktop config, and shell bootstrap data.
- Hydrate Desktop and MobileShell from the cached bootstrap before network revalidation, then refresh the snapshot after successful API/settings writes.
- Replace the app-domain cleanup service worker with a static-only PWA worker and keep API/auth/app document responses uncached.
- Preserve browser cache headers for safe app-domain static assets in the edge router while keeping shared CDN caches disabled.
- Document the browser/PWA refresh cache behavior in the public shell docs.
- Cancel stale Desktop bootstrap loads when the cache scope changes so older bootstrap responses cannot re-register apps after a newer scope wins.

## Tests

- `pnpm exec vitest run tests/shell/desktop-launcher-mode.test.tsx tests/shell/mobile-shell.test.tsx tests/shell/useTheme.test.ts tests/shell/desktop-config.test.ts tests/edge-router/edge-router.test.ts` (63 passed)
- `pnpm --filter './shell' exec tsc --noEmit --pretty false`
- `./scripts/review/check-patterns.sh` (0 violations; scanner warnings remain for manual review)
- `git diff --check`
- `npx react-doctor@latest shell` (exits 1 on existing full-shell findings outside this fix, including `useSetupChecklist.ts` and onboarding `RepoStep.tsx`)
- `npx react-doctor@latest --verbose --scope changed shell` (exits 1 on existing branch-wide findings; after the bootstrap cleanup refactor it no longer reports `Desktop.tsx`)

Notes:

- `bun run ...` commands could not be run in this worktree because `bun` is not installed in the environment. The equivalent Vitest and shell typecheck checks above were run with pnpm/Node 24.
- The worktree dependencies were linked with `pnpm install --offline --frozen-lockfile`; no lockfile changes were made.

## Review/Monitoring

- Latest trusted Greptile result: 5/5 on `4d84504d599d0f33a293277b7f4f484b8dc589d5`.
- Visible PR checks are passing or intentionally skipped preview jobs.
- Latest pushed fix commit: `4d84504d599d0f33a293277b7f4f484b8dc589d5`.

## Invariants

- Source of truth: owner files and private API responses remain the source of truth. The snapshot is only a browser-local first-paint cache and is overwritten by network revalidation.
- Lock/transaction scope: this PR adds no database writes, migrations, or shared persistence. It avoids cross-user/shared cache state by keeping runtime data in localStorage scoped by Clerk user id and runtime path.
- Acceptable orphan states: corrupt, stale, unknown-schema, oversized, or aborted snapshot/bootstrap reads are ignored and the shell falls back to normal network/default hydration.
- Auth source of truth: Clerk user id gates snapshot scope. API/auth/runtime data remain `no-store`; the service worker bypasses API, auth, `_next/data`, app documents, cross-origin, and non-GET requests.
- Deferred scope: Electron desktop native caching is intentionally deferred; this PR focuses on browser and PWA refresh behavior.
