### PR TITLE
fix(shell): polish mobile terminal PWA controls

### DIFF
--- a/shell/src/components/terminal/TerminalApp.tsx
+++ b/shell/src/components/terminal/TerminalApp.tsx
@@ -3220,6 +3220,7 @@ function MobileTerminalActions({
   const ctx = useTerminalAppContext();
   const [newSessionMenuOpen, setNewSessionMenuOpen] = useState(false);
   const [agentStatuses, setAgentStatuses] = useState<Record<TerminalAgentId, boolean> | null>(null);
+  const newSessionDisclosureRef = useRef<HTMLDivElement | null>(null);
   const getCwd = () => ctx.sidebarSelectedPath ?? defaultCwd;
   const focusedPaneId = ctx.focusedPaneId;
   const actionBackground = `color-mix(in srgb, ${foreground} 9%, transparent)`;
@@ -3248,6 +3249,10 @@ function MobileTerminalActions({
       return !open;
     });
   };
+
+  const closeNewSessionMenu = useCallback(() => {
+    setNewSessionMenuOpen(false);
+  }, []);
 
   const createShellSession = () => {
     setNewSessionMenuOpen(false);
@@ -3285,10 +3290,12 @@ function MobileTerminalActions({
         flexShrink: 0,
       }}
     >
-      <div style={{ position: "relative", flex: "0 0 auto" }}>
+      <div ref={newSessionDisclosureRef} style={{ position: "relative", flex: "0 0 auto" }}>
         <MobileActionButton
           label="+ Session"
           ariaLabel="New session"
+          ariaHasPopup="menu"
+          ariaExpanded={newSessionMenuOpen}
           title="New session"
           icon={<PlusIcon size={14} strokeWidth={1.8} />}
           onClick={toggleNewSessionMenu}
@@ -3300,10 +3307,11 @@ function MobileTerminalActions({
         {newSessionMenuOpen ? (
           <NewSessionMenu
             align="mobile"
-            onClose={() => setNewSessionMenuOpen(false)}
+            onClose={closeNewSessionMenu}
             onCreateShell={createShellSession}
             onCreateAgent={createAgentSession}
             agentStatuses={agentStatuses}
+            ignoreLightDismissRef={newSessionDisclosureRef}
           />
         ) : null}
       </div>
@@ -3334,6 +3342,8 @@ function MobileTerminalActions({
 function MobileActionButton({
   label,
   ariaLabel,
+  ariaHasPopup,
+  ariaExpanded,
   title,
   icon,
   onClick,
@@ -3344,6 +3354,8 @@ function MobileActionButton({
 }: {
   label: string;
   ariaLabel?: string;
+  ariaHasPopup?: "menu";
+  ariaExpanded?: boolean;
   title: string;
   icon: React.ReactNode;
   onClick: () => void;
@@ -3356,6 +3368,8 @@ function MobileActionButton({
     <button
       type="button"
       aria-label={ariaLabel ?? label}
+      aria-haspopup={ariaHasPopup}
+      aria-expanded={ariaExpanded}
       title={title}
       onClick={onClick}
       style={{
@@ -4757,12 +4771,14 @@ function NewSessionMenu({
   onCreateShell,
   onCreateAgent,
   agentStatuses,
+  ignoreLightDismissRef,
 }: {
   align: "left" | "right" | "mobile";
   onClose: () => void;
   onCreateShell: () => void;
   onCreateAgent: (option: TerminalAgentOption, installed: boolean) => void;
   agentStatuses: Record<TerminalAgentId, boolean> | null;
+  ignoreLightDismissRef?: React.RefObject<HTMLElement | null>;
 }) {
   const menuRef = useRef<HTMLDivElement | null>(null);
 
@@ -4773,6 +4789,7 @@ function NewSessionMenu({
     const onPointerDown = (event: globalThis.PointerEvent) => {
       const target = event.target;
       if (target instanceof Node && menuRef.current?.contains(target)) return;
+      if (target instanceof Node && ignoreLightDismissRef?.current?.contains(target)) return;
       onClose();
     };
     document.addEventListener("keydown", onKeyDown);
@@ -4781,7 +4798,7 @@ function NewSessionMenu({
       document.removeEventListener("keydown", onKeyDown);
       document.removeEventListener("pointerdown", onPointerDown, true);
     };
-  }, [onClose]);
+  }, [ignoreLightDismissRef, onClose]);
 
   return (
     <div

--- a/shell/src/components/terminal/TerminalApp.tsx
+++ b/shell/src/components/terminal/TerminalApp.tsx
@@ -13,7 +13,6 @@ import {
   FilesIcon,
   FolderIcon,
   GripVerticalIcon,
-  KeyboardIcon,
   LinkIcon,
   MoreHorizontalIcon,
   PanelLeftOpenIcon,
@@ -698,6 +697,8 @@ function getTerminalAppChromeCssVars(theme: TerminalAppChromeTheme): TerminalApp
     "--terminal-drawer-toggle-off-fg": theme.drawerToggleOffForeground,
     "--terminal-drawer-toggle-off-knob": theme.drawerToggleOffKnob,
     "--terminal-drawer-drop-line": theme.drawerDropLine,
+    "--terminal-mobile-primary-bg": theme.drawerPrimaryButtonBackground,
+    "--terminal-mobile-primary-fg": theme.drawerPrimaryButtonForeground,
   };
 }
 
@@ -1378,7 +1379,7 @@ export function TerminalApp({ initialCommand, initialLabel, initialClaudeMode = 
       : terminalPreset?.background ?? "var(--background)";
   const terminalChromeBackground = appChromeTheme.chromeBackground;
   const terminalChromeForeground = appChromeTheme.chromeForeground;
-  const terminalChromeAccent = appChromeTheme.chromeAccent;
+  const terminalChromeAccent = mobile ? "var(--terminal-mobile-primary-bg)" : appChromeTheme.chromeAccent;
 
   const [tabs, setTabs] = useState<Tab[]>([]);
   const [activeTabId, setActiveTabId] = useState("");
@@ -3217,10 +3218,53 @@ function MobileTerminalActions({
   accent: string;
 }) {
   const ctx = useTerminalAppContext();
+  const [newSessionMenuOpen, setNewSessionMenuOpen] = useState(false);
+  const [agentStatuses, setAgentStatuses] = useState<Record<TerminalAgentId, boolean> | null>(null);
   const getCwd = () => ctx.sidebarSelectedPath ?? defaultCwd;
   const focusedPaneId = ctx.focusedPaneId;
   const actionBackground = `color-mix(in srgb, ${foreground} 9%, transparent)`;
   const actionBorder = `color-mix(in srgb, ${foreground} 18%, transparent)`;
+  const primaryForeground = "var(--terminal-mobile-primary-fg)";
+
+  const fetchAgentStatuses = async () => {
+    try {
+      const res = await fetch(`${getGatewayUrl()}/api/agents`, {
+        signal: AbortSignal.timeout(10_000),
+      });
+      if (!res.ok) return;
+      const parsed = parseTerminalAgentStatuses(await res.json());
+      if (parsed.length === 0) return;
+      setAgentStatuses(Object.fromEntries(
+        parsed.map((agent) => [agent.id, agent.installed]),
+      ) as Record<TerminalAgentId, boolean>);
+    } catch (err: unknown) {
+      console.warn("Failed to load terminal agent status:", err instanceof Error ? err.message : String(err));
+    }
+  };
+
+  const toggleNewSessionMenu = () => {
+    setNewSessionMenuOpen((open) => {
+      if (!open) void fetchAgentStatuses();
+      return !open;
+    });
+  };
+
+  const createShellSession = () => {
+    setNewSessionMenuOpen(false);
+    void ctx.createShellSessionTab("Shell", getCwd());
+  };
+
+  const createAgentSession = (option: TerminalAgentOption, installed: boolean) => {
+    setNewSessionMenuOpen(false);
+    const label = installed ? option.label : `Install ${option.label}`;
+    const cmd = installed
+      ? option.launchCommand ?? (option.claudeMode ? "claude" : undefined)
+      : terminalAgentVisibleInstallCommand(option);
+    void ctx.createShellSessionTab(label, getCwd(), {
+      namePrefix: option.id,
+      cmd,
+    });
+  };
 
   return (
     <div
@@ -3231,8 +3275,9 @@ function MobileTerminalActions({
         display: "flex",
         alignItems: "center",
         gap: 4,
-        overflowX: "auto",
+        overflow: "visible",
         padding: "6px 2px 4px",
+        position: "relative",
         background,
         borderTop: `1px solid ${actionBorder}`,
         scrollbarWidth: "none",
@@ -3240,42 +3285,28 @@ function MobileTerminalActions({
         flexShrink: 0,
       }}
     >
-      <MobileActionButton
-        label="Shell"
-        title="Open mobile shell"
-        icon={<TerminalIcon size={14} strokeWidth={1.8} />}
-        onClick={() => { void ctx.createShellSessionTab("Mobile Shell", getCwd()); }}
-        background={accent}
-        foreground="var(--primary-foreground)"
-        border="transparent"
-      />
-      <MobileActionButton
-        label="Pane"
-        title="Split pane below"
-        icon={<Rows2Icon size={14} strokeWidth={1.8} />}
-        onClick={() => { if (focusedPaneId) ctx.splitPane(focusedPaneId, "vertical"); }}
-        background={actionBackground}
-        foreground={foreground}
-        border={actionBorder}
-      />
-      <MobileActionButton
-        label="Tab"
-        title="Open terminal tab"
-        icon={<PlusIcon size={14} strokeWidth={1.8} />}
-        onClick={() => { void ctx.createShellSessionTab("Shell", getCwd()); }}
-        background={actionBackground}
-        foreground={foreground}
-        border={actionBorder}
-      />
-      <MobileActionButton
-        label="Cmd"
-        title="Open Claude Code"
-        icon={<KeyboardIcon size={14} strokeWidth={1.8} />}
-        onClick={() => ctx.addTab(getCwd(), "Claude Code", true)}
-        background={actionBackground}
-        foreground={foreground}
-        border={actionBorder}
-      />
+      <div style={{ position: "relative", flex: "0 0 auto" }}>
+        <MobileActionButton
+          label="+ Session"
+          ariaLabel="New session"
+          title="New session"
+          icon={<PlusIcon size={14} strokeWidth={1.8} />}
+          onClick={toggleNewSessionMenu}
+          background={accent}
+          foreground={primaryForeground}
+          border="transparent"
+          minWidth={92}
+        />
+        {newSessionMenuOpen ? (
+          <NewSessionMenu
+            align="mobile"
+            onClose={() => setNewSessionMenuOpen(false)}
+            onCreateShell={createShellSession}
+            onCreateAgent={createAgentSession}
+            agentStatuses={agentStatuses}
+          />
+        ) : null}
+      </div>
       <MobileActionButton
         label="Paste"
         title="Paste clipboard"
@@ -3302,6 +3333,7 @@ function MobileTerminalActions({
 
 function MobileActionButton({
   label,
+  ariaLabel,
   title,
   icon,
   onClick,
@@ -3311,6 +3343,7 @@ function MobileActionButton({
   minWidth = 56,
 }: {
   label: string;
+  ariaLabel?: string;
   title: string;
   icon: React.ReactNode;
   onClick: () => void;
@@ -3322,7 +3355,7 @@ function MobileActionButton({
   return (
     <button
       type="button"
-      aria-label={label}
+      aria-label={ariaLabel ?? label}
       title={title}
       onClick={onClick}
       style={{
@@ -3393,6 +3426,8 @@ function MobileCommandComposer({
         placeholder="Type command..."
         autoCapitalize="none"
         autoCorrect="off"
+        autoComplete="off"
+        enterKeyHint="send"
         spellCheck={false}
         style={{
           background: `color-mix(in srgb, ${foreground} 8%, transparent)`,
@@ -3401,7 +3436,7 @@ function MobileCommandComposer({
           color: foreground,
           flex: "1 1 auto",
           fontFamily: "var(--font-mono, ui-monospace, monospace)",
-          fontSize: 13,
+          fontSize: 16,
           height: 36,
           minWidth: 0,
           padding: "0 10px",
@@ -3414,7 +3449,7 @@ function MobileCommandComposer({
           background: accent,
           border: "1px solid transparent",
           borderRadius: 9,
-          color: "#15180F",
+          color: "var(--terminal-mobile-primary-fg)",
           cursor: "pointer",
           flexShrink: 0,
           fontSize: 12,
@@ -4485,40 +4520,42 @@ function LocalTerminalSidebar() {
             </div>
           </div>
           <div className="flex shrink-0 items-center" style={{ gap: 10 }}>
-            <div style={{ position: "relative" }}>
-              <button
-                type="button"
-                aria-label="New session"
-                aria-haspopup="menu"
-                aria-expanded={newSessionMenuAnchor === "drawer"}
-                onClick={() => openNewSessionMenu("drawer")}
-                disabled={creatingShell}
-                className="flex items-center justify-center"
-                style={{
-                  background: "var(--terminal-drawer-primary-button-bg)",
-                  border: 0,
-                  borderRadius: ctx.mobile ? 13 : 10,
-                  color: "var(--terminal-drawer-primary-button-fg)",
-                  cursor: creatingShell ? "not-allowed" : "pointer",
-                  fontSize: 25,
-                  height: ctx.mobile ? 44 : 40,
-                  lineHeight: "28px",
-                  opacity: creatingShell ? 0.72 : 1,
-                  width: ctx.mobile ? 44 : 40,
-                }}
-              >
-                <PlusIcon aria-hidden="true" size={ctx.mobile ? 20 : 18} strokeWidth={2.5} />
-              </button>
-              {newSessionMenuAnchor === "drawer" ? (
-                <NewSessionMenu
-                  align="right"
-                  onClose={() => setNewSessionMenuAnchor(null)}
-                  onCreateShell={() => void createManagedShell()}
-                  onCreateAgent={createAgentSession}
-                  agentStatuses={agentStatuses}
-                />
-              ) : null}
-            </div>
+            {!ctx.mobile ? (
+              <div style={{ position: "relative" }}>
+                <button
+                  type="button"
+                  aria-label="New session"
+                  aria-haspopup="menu"
+                  aria-expanded={newSessionMenuAnchor === "drawer"}
+                  onClick={() => openNewSessionMenu("drawer")}
+                  disabled={creatingShell}
+                  className="flex items-center justify-center"
+                  style={{
+                    background: "var(--terminal-drawer-primary-button-bg)",
+                    border: 0,
+                    borderRadius: 10,
+                    color: "var(--terminal-drawer-primary-button-fg)",
+                    cursor: creatingShell ? "not-allowed" : "pointer",
+                    fontSize: 25,
+                    height: 40,
+                    lineHeight: "28px",
+                    opacity: creatingShell ? 0.72 : 1,
+                    width: 40,
+                  }}
+                >
+                  <PlusIcon aria-hidden="true" size={18} strokeWidth={2.5} />
+                </button>
+                {newSessionMenuAnchor === "drawer" ? (
+                  <NewSessionMenu
+                    align="right"
+                    onClose={() => setNewSessionMenuAnchor(null)}
+                    onCreateShell={() => void createManagedShell()}
+                    onCreateAgent={createAgentSession}
+                    agentStatuses={agentStatuses}
+                  />
+                ) : null}
+              </div>
+            ) : null}
             {!ctx.mobile && (
               <>
                 <button
@@ -4721,7 +4758,7 @@ function NewSessionMenu({
   onCreateAgent,
   agentStatuses,
 }: {
-  align: "left" | "right";
+  align: "left" | "right" | "mobile";
   onClose: () => void;
   onCreateShell: () => void;
   onCreateAgent: (option: TerminalAgentOption, installed: boolean) => void;
@@ -4764,7 +4801,9 @@ function NewSessionMenu({
         gap: 4,
         padding: 8,
         position: "absolute",
-        ...(align === "right"
+        ...(align === "mobile"
+          ? { bottom: "calc(100% + 8px)", left: 0 }
+          : align === "right"
           ? { right: 0, top: "calc(100% + 8px)" }
           : { left: "calc(100% + 8px)", top: 0 }),
         width: 244,

--- a/shell/src/components/terminal/TerminalApp.tsx
+++ b/shell/src/components/terminal/TerminalApp.tsx
@@ -3244,10 +3244,9 @@ function MobileTerminalActions({
   };
 
   const toggleNewSessionMenu = () => {
-    setNewSessionMenuOpen((open) => {
-      if (!open) void fetchAgentStatuses();
-      return !open;
-    });
+    const shouldOpen = !newSessionMenuOpen;
+    setNewSessionMenuOpen(shouldOpen);
+    if (shouldOpen) void fetchAgentStatuses();
   };
 
   const closeNewSessionMenu = useCallback(() => {

--- a/shell/src/components/terminal/TerminalPane.tsx
+++ b/shell/src/components/terminal/TerminalPane.tsx
@@ -1497,7 +1497,7 @@ export function TerminalPane({
           termRef.current as Parameters<typeof sendTerminalResize>[1],
           allowRemoteResizeRef.current,
         );
-        if (isFocusedRef.current) {
+        if (isFocusedRef.current && !suppressNativeKeyboard) {
           (termRef.current as { focus?: () => void } | null)?.focus?.();
         }
       } catch (err: unknown) {
@@ -1505,7 +1505,7 @@ export function TerminalPane({
       }
     });
     return () => cancelAnimationFrame(id);
-  }, [viewportHeight, viewportOffsetTop, keyboardOpen]);
+  }, [viewportHeight, viewportOffsetTop, keyboardOpen, suppressNativeKeyboard]);
 
   return (
     // react-doctor-disable-next-line react-doctor/no-static-element-interactions, react-doctor/click-events-have-key-events -- presentational click-to-focus wrapper: clicking anywhere in the pane forwards focus to the embedded xterm terminal, which is itself the keyboard-interactive element (its textarea is in natural tab order). This div is not a control, so a role/tabIndex would be misleading; keyboard users interact with the terminal directly.

--- a/tests/shell/terminal-mobile-actions.test.tsx
+++ b/tests/shell/terminal-mobile-actions.test.tsx
@@ -93,13 +93,23 @@ describe("TerminalApp mobile actions", () => {
 
     render(<TerminalApp mobile />);
 
-    await waitFor(() => expect(screen.getByRole("button", { name: "New session" })).toBeTruthy());
-    fireEvent.click(screen.getByRole("button", { name: "New session" }));
+    const newSession = await screen.findByRole("button", { name: "New session" });
+    expect(newSession.getAttribute("aria-haspopup")).toBe("menu");
+    expect(newSession.getAttribute("aria-expanded")).toBe("false");
+
+    fireEvent.click(newSession);
 
     const menu = await screen.findByRole("menu", { name: "New session menu" });
+    expect(newSession.getAttribute("aria-expanded")).toBe("true");
     expect(menu.textContent).toContain("NEW TAB");
     expect(screen.getByRole("menuitem", { name: /^Shell(?:\s+⌘T)?$/i })).toBeTruthy();
 
+    fireEvent.click(newSession);
+    await waitFor(() => expect(screen.queryByRole("menu", { name: "New session menu" })).toBeNull());
+    expect(newSession.getAttribute("aria-expanded")).toBe("false");
+
+    fireEvent.click(newSession);
+    await screen.findByRole("menu", { name: "New session menu" });
     fireEvent.click(screen.getByRole("menuitem", { name: /^Shell(?:\s+⌘T)?$/i }));
 
     await waitFor(() => {

--- a/tests/shell/terminal-mobile-actions.test.tsx
+++ b/tests/shell/terminal-mobile-actions.test.tsx
@@ -143,6 +143,34 @@ describe("TerminalApp mobile actions", () => {
     window.removeEventListener(TERMINAL_INPUT_EVENT, listener);
   });
 
+  it("loads mobile new-session agent status once under React Strict Mode", async () => {
+    const fetchMock = vi.mocked(fetch);
+
+    render(
+      <React.StrictMode>
+        <TerminalApp mobile />
+      </React.StrictMode>,
+    );
+
+    const newSession = await screen.findByRole("button", { name: "New session" });
+    await waitFor(() => {
+      expect(fetchMock.mock.calls.filter(([input]) => (
+        String(input).endsWith("/api/agents")
+      )).length).toBeGreaterThanOrEqual(2);
+    });
+    fetchMock.mockClear();
+
+    fireEvent.click(newSession);
+    await screen.findByRole("menu", { name: "New session menu" });
+
+    await waitFor(() => {
+      const agentStatusCalls = fetchMock.mock.calls.filter(([input]) => (
+        String(input).endsWith("/api/agents")
+      ));
+      expect(agentStatusCalls).toHaveLength(1);
+    });
+  });
+
   it("keeps mobile command input keyboard-safe and uses green primary actions", async () => {
     render(<TerminalApp mobile />);
 

--- a/tests/shell/terminal-mobile-actions.test.tsx
+++ b/tests/shell/terminal-mobile-actions.test.tsx
@@ -7,11 +7,8 @@ import type { PaneNode } from "../../shell/src/stores/terminal-store.js";
 import { TERMINAL_INPUT_EVENT, type TerminalInputEventDetail } from "../../shell/src/components/terminal/terminal-input-event.js";
 
 vi.mock("../../shell/src/components/terminal/PaneGrid.js", () => ({
-  PaneGrid: ({ paneTree, onSessionAttached }: { paneTree: PaneNode; onSessionAttached?: (paneId: string, sessionId: string) => void }) => {
+  PaneGrid: ({ paneTree }: { paneTree: PaneNode }) => {
     const paneId = paneTree.type === "pane" ? paneTree.id : "pane-1";
-    React.useEffect(() => {
-      onSessionAttached?.(paneId, "main");
-    }, [onSessionAttached, paneId]);
     return <div data-testid="pane-grid" data-pane-id={paneId} />;
   },
 }));
@@ -77,14 +74,43 @@ describe("TerminalApp mobile actions", () => {
     }));
   });
 
-  it("shows mobile terminal actions above the accessory keybar", async () => {
+  it("shows the simplified mobile terminal actions above the accessory keybar", async () => {
     render(<TerminalApp mobile />);
 
     await waitFor(() => expect(screen.getByTestId("terminal-mobile-actions")).toBeTruthy());
 
-    for (const name of ["Shell", "Pane", "Tab", "Cmd", "Paste", "Search"]) {
+    expect(screen.getByText("+ Session")).toBeTruthy();
+    for (const name of ["New session", "Paste", "Search"]) {
       expect(screen.getByRole("button", { name })).toBeTruthy();
     }
+    for (const name of ["Shell", "Pane", "Tab", "Cmd"]) {
+      expect(screen.queryByRole("button", { name })).toBeNull();
+    }
+  });
+
+  it("opens the shared new-session menu and creates a canonical shell session from mobile", async () => {
+    const fetchMock = vi.mocked(fetch);
+
+    render(<TerminalApp mobile />);
+
+    await waitFor(() => expect(screen.getByRole("button", { name: "New session" })).toBeTruthy());
+    fireEvent.click(screen.getByRole("button", { name: "New session" }));
+
+    const menu = await screen.findByRole("menu", { name: "New session menu" });
+    expect(menu.textContent).toContain("NEW TAB");
+    expect(screen.getByRole("menuitem", { name: /^Shell(?:\s+⌘T)?$/i })).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("menuitem", { name: /^Shell(?:\s+⌘T)?$/i }));
+
+    await waitFor(() => {
+      expect(fetchMock.mock.calls.some(([input, init]) => (
+        String(input).endsWith("/api/terminal/sessions") &&
+        init?.method === "POST" &&
+        typeof init.body === "string"
+      ))).toBe(true);
+    });
+
+    expect(screen.queryByText("Mobile Shell")).toBeNull();
   });
 
   it("dispatches paste and search actions to the focused pane", async () => {
@@ -105,5 +131,21 @@ describe("TerminalApp mobile actions", () => {
       expect.objectContaining({ action: "search" }),
     ]);
     window.removeEventListener(TERMINAL_INPUT_EVENT, listener);
+  });
+
+  it("keeps mobile command input keyboard-safe and uses green primary actions", async () => {
+    render(<TerminalApp mobile />);
+
+    await waitFor(() => expect(screen.getByRole("textbox", { name: "Command composer" })).toBeTruthy());
+
+    const newSession = screen.getByRole("button", { name: "New session" });
+    const composer = screen.getByRole("textbox", { name: "Command composer" });
+    const send = screen.getByRole("button", { name: "Send command" });
+
+    expect(newSession.style.background).toBe("var(--terminal-mobile-primary-bg)");
+    expect(send.style.background).toBe("var(--terminal-mobile-primary-bg)");
+    expect(composer.style.fontSize).toBe("16px");
+    expect(composer.getAttribute("autocomplete")).toBe("off");
+    expect(composer.getAttribute("enterkeyhint")).toBe("send");
   });
 });

--- a/tests/shell/terminal-pane-scrolling.test.tsx
+++ b/tests/shell/terminal-pane-scrolling.test.tsx
@@ -1,12 +1,17 @@
 // @vitest-environment jsdom
 import React from "react";
-import { render, waitFor } from "@testing-library/react";
+import { act, render, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const createdTerminals = vi.hoisted(() => [] as Array<{
   options: Record<string, unknown>;
   element: HTMLElement | null;
   viewport: HTMLElement | null;
+  focus: ReturnType<typeof vi.fn>;
+}>);
+
+const createdFitAddons = vi.hoisted(() => [] as Array<{
+  fit: ReturnType<typeof vi.fn>;
 }>);
 
 const stubWs = vi.hoisted(() => ({
@@ -91,6 +96,10 @@ vi.mock("@xterm/xterm", () => ({
 vi.mock("@xterm/addon-fit", () => ({
   FitAddon: class MockFitAddon {
     fit = vi.fn();
+
+    constructor() {
+      createdFitAddons.push(this);
+    }
   },
 }));
 
@@ -182,6 +191,28 @@ class WebSocketMock {
   constructor(_url: string) {}
 }
 
+function installVisualViewportMock(input: { height: number; offsetTop: number }) {
+  const listeners = new Map<string, Set<() => void>>();
+  const viewport = {
+    height: input.height,
+    offsetTop: input.offsetTop,
+    addEventListener: vi.fn((type: string, listener: () => void) => {
+      const set = listeners.get(type) ?? new Set<() => void>();
+      set.add(listener);
+      listeners.set(type, set);
+    }),
+    removeEventListener: vi.fn((type: string, listener: () => void) => {
+      listeners.get(type)?.delete(listener);
+    }),
+    dispatch(type: string) {
+      for (const listener of listeners.get(type) ?? []) listener();
+    },
+  };
+  Object.defineProperty(window, "innerHeight", { configurable: true, value: 800 });
+  Object.defineProperty(window, "visualViewport", { configurable: true, value: viewport });
+  return viewport;
+}
+
 function createCachedTerminal() {
   const element = document.createElement("div");
   element.className = "xterm";
@@ -211,6 +242,7 @@ function createCachedTerminal() {
 describe("TerminalPane scrolling", () => {
   beforeEach(() => {
     createdTerminals.length = 0;
+    createdFitAddons.length = 0;
     restorePlan.current = {
       cached: null,
       reuseTerminal: false,
@@ -224,6 +256,7 @@ describe("TerminalPane scrolling", () => {
       setTimeout(() => cb(0), 0)) as typeof requestAnimationFrame;
     stubWs.send.mockReset();
     stubWs.close.mockReset();
+    Reflect.deleteProperty(window, "visualViewport");
   });
 
   it("configures xterm scrollback and native viewport scrolling after mount", async () => {
@@ -312,5 +345,39 @@ describe("TerminalPane scrolling", () => {
     expect(cached.viewport.style.getPropertyValue("scrollbar-gutter")).toBe("stable");
     expect(cached.viewport.style.overscrollBehavior).toBe("contain");
     expect(cached.viewport.style.touchAction).toBe("pan-y");
+  });
+
+  it("does not refocus xterm on mobile visual viewport resize when native keyboard is suppressed", async () => {
+    const viewport = installVisualViewportMock({ height: 800, offsetTop: 0 });
+
+    render(
+      <TerminalPane
+        paneId="pane-mobile-keyboard-test"
+        cwd=""
+        theme={theme}
+        isFocused
+        isClosing={false}
+        shouldCacheOnUnmount={() => false}
+        shouldDestroyOnUnmount={() => false}
+        suppressNativeKeyboard
+        onFocus={() => {}}
+      />,
+    );
+
+    await waitFor(() => expect(createdTerminals).toHaveLength(1));
+    await waitFor(() => expect(createdFitAddons).toHaveLength(1));
+
+    const terminal = createdTerminals[0];
+    const fitAddon = createdFitAddons[0];
+    terminal.focus.mockClear();
+    fitAddon.fit.mockClear();
+
+    await act(async () => {
+      viewport.height = 560;
+      viewport.dispatch("resize");
+    });
+
+    await waitFor(() => expect(fitAddon.fit).toHaveBeenCalled());
+    expect(terminal.focus).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary

- Align the mobile Terminal PWA action row with the desktop session model: a single `+ Session` entry point opens the shared new-session menu, with no primary `Shell`, `Tab`, `Pane`, or `Cmd` controls.
- Route mobile Shell creation through the canonical `createShellSessionTab("Shell", cwd)` path and remove the special `Mobile Shell` label.
- Switch mobile primary actions and `Send` to Matrix OS Dark green/olive tokens, and hide the drawer header creation button on mobile so there is one phone creation affordance.
- Make the command composer more iOS keyboard-safe and stop visual viewport keyboard resizes from refocusing xterm when native keyboard suppression is enabled.
- Address Greptile's mobile disclosure follow-ups: `+ Session` now exposes menu ARIA state, toggles closed on a second tap, passes a stable close handler to the shared menu, and avoids Strict Mode double-fetch behavior.

## Tests

- `flox activate -- bun run typecheck` ✅
- `flox activate -- bun run check:patterns` ✅ — 0 violations, existing repo warnings only
- `node_modules/.bin/vitest run tests/shell/terminal-mobile-actions.test.tsx --reporter=dot` ✅ — review follow-up regression, 5 tests passed
- `node_modules/.bin/vitest run tests/shell/terminal-app-component.test.tsx tests/shell/terminal-keybar.test.tsx tests/shell/terminal-mobile-actions.test.tsx tests/shell/terminal-pane-scrolling.test.tsx --reporter=dot` ✅ — 87 tests passed
- Review follow-up `flox activate -- bun run typecheck` ⚠️ — blocked by the temporary root `node_modules` symlink used to avoid reinstalling dependencies in the worktree; desktop typecheck resolved mixed Vite 6/7 plugin types from the root install. The earlier clean worktree typecheck passed before the follow-up.
- `flox activate -- bun run test` ⚠️ — failed after the machine hit `ENOSPC: no space left on device` in `/var/folders/.../T`; before disk exhaustion, 5898 tests had passed and the terminal-focused suites had passed. The final Vitest summary showed ENOSPC-driven failed imports/setup across later suites.

## Review/Monitoring

- Initial Greptile review on `3f0d2f44de9f94b79f116ab8f14d31803430525f`: **4/5**.
- Follow-up commit `2318c4e47c5ae105df65f128a7c7bd120bccb9ed` addresses the three original findings: second-tap menu close race, missing disclosure ARIA, and unstable `onClose` listener churn.
- Follow-up commit `0adadad4f09b3850b8c11bf4a99e739c740bf3a9` removes the non-blocking Strict Mode side effect from the session menu toggle and adds regression coverage.
- Latest Greptile review on `0adadad4f09b3850b8c11bf4a99e739c740bf3a9`: **5/5**.
- Latest GitHub checks: PR Title, Preview VPS Gate, Vercel, Vercel Preview Comments, and Greptile Review all passing; preview deploy jobs that are intentionally skipped remain skipped.

## Invariants

### Source of truth

- No new persistent store is introduced.
- Canonical shell sessions remain owned by `/api/terminal/sessions`; the mobile action now delegates to the same `createShellSessionTab("Shell", cwd)` flow as desktop.

### Lock/transaction scope

- No backend transaction or lock scope changes.
- New client fetch for agent status uses `AbortSignal.timeout(10_000)` and does not mutate server state.

### Acceptable orphan states

- No new backend orphan state is introduced.
- Failed session creation follows the existing terminal session creation behavior and does not create a special mobile-only client tab label.

### Auth source of truth

- Existing terminal/gateway auth remains unchanged.
- The shared agent/session menu continues to call existing authenticated terminal and agent endpoints.

### Deferred scope

- No pane splitting affordance is added to a mobile More menu in this pass.
- No public docs were changed because the public docs search found no old mobile PWA `Shell`/`Tab`/`Pane` toolbar wording.
- Real iPhone/PWA manual validation is still pending; this PR covers component and focus-regression tests.
