### PR TITLE
fix(shell): keep terminal session menu above rows

### DIFF
--- a/shell/src/components/terminal/TerminalApp.tsx
+++ b/shell/src/components/terminal/TerminalApp.tsx
@@ -5949,8 +5949,9 @@ function ShellCard({
         opacity: dragging ? 0.94 : foreground ? 1 : 0.86,
         padding: "0 12px",
         position: "relative",
-        transform: dragging ? "translateY(-2px)" : "translateY(0)",
+        transform: dragging ? "translateY(-2px)" : undefined,
         transition: "border-color 150ms ease, box-shadow 150ms ease, opacity 120ms ease, transform 150ms ease",
+        zIndex: contextMenuOpen ? 30 : dragging ? 1 : undefined,
       }}
     >
       {dropTarget && (

--- a/tests/shell/terminal-app-component.test.tsx
+++ b/tests/shell/terminal-app-component.test.tsx
@@ -752,6 +752,51 @@ describe("TerminalApp", () => {
     expect(within(actions).queryByText("matrix shell connect")).toBeNull();
   });
 
+  it("keeps session action menu above later session cards", async () => {
+    vi.mocked(fetch).mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.includes("/api/terminal/layout") && init?.method === "PUT") {
+        return Promise.resolve({ ok: true, json: async () => ({ ok: true }) } as Response);
+      }
+      if (url.includes("/api/terminal/layout")) {
+        return Promise.resolve({ ok: true, json: async () => ({}) } as Response);
+      }
+      if (url.endsWith("/api/terminal/sessions") && init?.method !== "POST") {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            sessions: [
+              { name: "main", status: "active", placement: "active", attachCommand: "mos shell attach main", attachedClients: 1, tabs: [{ idx: 0, name: "main", focused: true }] },
+              { name: "docs", status: "active", placement: "active", attachCommand: "mos shell attach docs", attachedClients: 0, tabs: [{ idx: 0, name: "docs", focused: true }] },
+              { name: "bench", status: "idle", placement: "active", attachCommand: "mos shell attach bench", attachedClients: 0, tabs: [{ idx: 0, name: "bench", focused: true }] },
+            ],
+          }),
+        } as Response);
+      }
+      return Promise.resolve({ ok: true, json: async () => ({}) } as Response);
+    });
+
+    render(<TerminalApp />);
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    const mainCard = screen.getByTestId("terminal-session-card-main");
+    const docsCard = screen.getByTestId("terminal-session-card-docs");
+    const benchCard = screen.getByTestId("terminal-session-card-bench");
+
+    await openSessionContextMenu("main");
+
+    expect(screen.getByRole("menu", { name: "Actions for matrix-main" })).toBeTruthy();
+    expect(Number(mainCard.style.zIndex)).toBeGreaterThan(Number(docsCard.style.zIndex || "0"));
+    expect(Number(mainCard.style.zIndex)).toBeGreaterThan(Number(benchCard.style.zIndex || "0"));
+    expect(docsCard.style.transform).toBe("");
+    expect(benchCard.style.transform).toBe("");
+  });
+
   it("copies with the synchronous selection fallback and still shows the Paper copy confirmation", async () => {
     const writeText = vi.fn(async () => {
       throw new Error("clipboard denied");


### PR DESCRIPTION
## Summary

- Fixed Terminal session overflow menus painting behind later rows by lifting only the open `ShellCard` stacking context.
- Removed the idle `translateY(0)` transform so non-dragging session cards do not create unnecessary stacking contexts.
- Added a regression with multiple shell sessions that opens a non-last row menu and asserts the open card is above sibling rows.

## Tests

- Red check before fix: `pnpm exec vitest run tests/shell/terminal-app-component.test.tsx -t "keeps session action menu above later session cards"` failed with the expected `zIndex` assertion.
- `pnpm exec vitest run tests/shell/terminal-app-component.test.tsx -t "keeps session action menu above later session cards"`
- `pnpm exec vitest run tests/shell/terminal-app-component.test.tsx`
- Typecheck equivalent of `bun run typecheck` passed:
  - `pnpm run typecheck:build-kernel`
  - `pnpm --filter '@matrix-os/observability' exec tsc --noEmit`
  - `pnpm --filter '@matrix-os/gateway' exec tsc --noEmit`
  - `pnpm --filter '@matrix-os/platform' exec tsc --noEmit -p tsconfig.typecheck.json`
  - `pnpm --filter '@matrix-os/proxy' exec tsc --noEmit`
  - `pnpm --filter '@matrix-os/edge-router' exec tsc --noEmit`
  - `pnpm --filter desktop run typecheck`
- `pnpm run check:patterns:diff`
- `npx react-doctor@latest --verbose --scope changed --base origin/main shell`
- Local Playwright screenshot captured at `/tmp/terminal-session-menu-layering.png`; computed open card `z-index` was `30` and sibling row transform was `none`.

Note: the agent environment did not have `bun` on PATH, so validation used the equivalent `pnpm`/direct Vitest commands.

## Review/Monitoring

- Monitor CI and Greptile. This PR should not require backend review because it only changes shell UI rendering state and a shell component regression test.

## Invariants

- Source of truth: shell-only UI state in the `ShellCard`; no backend source of truth changes.
- Lock/transaction scope: none; no database writes or multi-step persistence changes.
- Acceptable orphan states: none introduced; the menu remains inline and existing focus/dismiss behavior is preserved.
- Auth source of truth: unchanged; no auth, gateway, or API behavior changed.
- Deferred scope: no portal migration, no Terminal menu redesign, and no Desktop/Canvas window-state changes.
