### PR TITLE
fix(shell): name terminal menu z-index

### DIFF
--- a/shell/src/components/terminal/TerminalApp.tsx
+++ b/shell/src/components/terminal/TerminalApp.tsx
@@ -29,6 +29,7 @@ import { type PaneNode, countPanes as countPanesFromStore, getAllPaneIds } from 
 import { PaneGrid } from "./PaneGrid";
 import { useTheme } from "@/hooks/useTheme";
 import { getGatewayUrl } from "@/lib/gateway";
+import { SHELL_Z_INDEX } from "@/lib/shell-layering";
 import { isTerminalDebugEnabled } from "@/lib/terminal-debug";
 import { drainTerminalLaunchQueue, TERMINAL_LAUNCH_EVENT } from "@/lib/terminal-launch";
 import { MATRIX_OS_APP_THEME_OPTIONS } from "@/lib/theme-presets";
@@ -6006,7 +6007,7 @@ function ShellCard({
         position: "relative",
         transform: dragging ? "translateY(-2px)" : undefined,
         transition: "border-color 150ms ease, box-shadow 150ms ease, opacity 120ms ease, transform 150ms ease",
-        zIndex: contextMenuOpen ? 30 : dragging ? 1 : undefined,
+        zIndex: contextMenuOpen ? SHELL_Z_INDEX.terminalSessionMenuCard : dragging ? 1 : undefined,
       }}
     >
       {dropTarget && (

--- a/shell/src/lib/shell-layering.ts
+++ b/shell/src/lib/shell-layering.ts
@@ -1,4 +1,7 @@
 export const SHELL_Z_INDEX = {
+  // Panel-local card elevation. This stays below app windows and only orders
+  // sibling rows inside a shell surface.
+  terminalSessionMenuCard: 30,
   appWindowMax: 500,
   fullscreenWindow: 600,
   fullscreenExit: 601,


### PR DESCRIPTION
## Summary
- Follow-up to #691 after that PR was merged before the Greptile cleanup commit landed.
- Moves the terminal session menu card elevation into the shared shell layering constants.
- Keeps the existing inline menu and focused ShellCard stacking behavior from #691 unchanged.

## Tests
- PASS: pnpm exec vitest run tests/shell/terminal-app-component.test.tsx -t "keeps session action menu above later session cards"
- PASS: pnpm run typecheck:build-kernel
- PASS: pnpm --filter '@matrix-os/observability' exec tsc --noEmit
- PASS: pnpm --filter '@matrix-os/gateway' exec tsc --noEmit
- PASS: pnpm --filter '@matrix-os/platform' exec tsc --noEmit -p tsconfig.typecheck.json
- PASS: pnpm --filter '@matrix-os/proxy' exec tsc --noEmit
- PASS: pnpm --filter '@matrix-os/edge-router' exec tsc --noEmit
- PASS: pnpm --filter desktop run typecheck
- PASS: ./scripts/review/check-patterns.sh --diff origin/main (0 violations; scanner warnings are existing broad TerminalApp heuristics)
- PASS: npx react-doctor@latest --verbose --scope changed --base origin/main shell
- NOTE: pnpm run typecheck cannot run in this environment because bun is not installed, so the script was run via the direct package equivalents above.
- NOTE: pnpm exec vitest run tests/shell/terminal-app-component.test.tsx currently has two unrelated upstream theme-background failures outside this diff.

## Review/Monitoring
- This PR resolves the Greptile P2 from #691 about avoiding a hardcoded terminal menu z-index.
- Please wait for the latest Greptile review to report 5/5 before merging.

## Invariants
- Source of truth: shell-only UI state; no backend source of truth changes.
- Lock/transaction scope: no database writes or transactions.
- Acceptable orphan states: none; this only changes render-layer constants.
- Auth source of truth: unchanged; no auth paths touched.
- Deferred scope: no portal/menu refactor; inline focus, keyboard, and outside-click behavior remains as implemented in #691.