### PR TITLE
fix(ci): restore main test stability

### DIFF
--- a/packages/platform/src/db.ts
+++ b/packages/platform/src/db.ts
@@ -1716,9 +1716,9 @@ export async function upsertBillingOverride(db: PlatformDB, record: NewBillingEn
 export async function getBillingOverride(
   db: PlatformDB,
   clerkUserId: string,
+  nowIso = new Date().toISOString(),
 ): Promise<BillingEntitlementOverrideRecord | undefined> {
   await db.ready;
-  const now = new Date().toISOString();
   const row = await db.executor
     .selectFrom('billing_entitlement_overrides')
     .selectAll()
@@ -1726,7 +1726,7 @@ export async function getBillingOverride(
     .where('revoked_at', 'is', null)
     .where((eb) => eb.or([
       eb('expires_at', 'is', null),
-      eb('expires_at', '>', now),
+      eb('expires_at', '>', nowIso),
     ]))
     .orderBy('created_at', 'desc')
     .executeTakeFirst();

--- a/shell/src/components/terminal/TerminalPane.tsx
+++ b/shell/src/components/terminal/TerminalPane.tsx
@@ -656,7 +656,7 @@ export function TerminalPane({
         try {
           fitAddon.fit();
           sendTerminalResize(wsRef.current, term, allowRemoteResizeRef.current);
-          if (isFocusedRef.current) {
+          if (isFocusedRef.current && !suppressNativeKeyboard) {
             term.focus();
           }
         } catch (err: unknown) {
@@ -902,7 +902,7 @@ export function TerminalPane({
         }
       }
 
-      if (isFocusedRef.current) {
+      if (isFocusedRef.current && !suppressNativeKeyboard) {
         requestAnimationFrame(() => {
           if (!disposed) {
             term.focus();
@@ -1457,10 +1457,10 @@ export function TerminalPane({
   ]);
 
   useEffect(() => {
-    if (isFocused && termRef.current) {
+    if (isFocused && !suppressNativeKeyboard && termRef.current) {
       (termRef.current as { focus: () => void }).focus();
     }
-  }, [isFocused]);
+  }, [isFocused, suppressNativeKeyboard]);
 
   // Re-fit the terminal whenever the visual viewport changes (soft keyboard
   // open/close, URL-bar collapse, orientation). The container also shrinks via

--- a/tests/gateway/sync/home-mirror.test.ts
+++ b/tests/gateway/sync/home-mirror.test.ts
@@ -516,25 +516,27 @@ describe("createHomeMirror", () => {
         peerRegistry: registry,
         logger,
       });
-      await mirror.start();
+      try {
+        await mirror.start();
 
-      registry.broadcastChange("alice", "laptop-1", {
-        type: "sync:change",
-        files: [{ path: traversalPath, hash: sha256(Buffer.from("evil")), size: 4, action: "update" }],
-        peerId: "laptop-1",
-        manifestVersion: 2,
-      });
+        registry.broadcastChange("alice", "laptop-1", {
+          type: "sync:change",
+          files: [{ path: traversalPath, hash: sha256(Buffer.from("evil")), size: 4, action: "update" }],
+          peerId: "laptop-1",
+          manifestVersion: 2,
+        });
 
-      await settle(80);
+        await settle(80);
 
-      await expect(stat(outsidePath)).rejects.toThrow(/ENOENT/);
-      expect(logger.error).toHaveBeenCalledWith(
-        expect.stringContaining(`remote-change failed for ${traversalPath}:`),
-        expect.stringMatching(/invalid/i),
-      );
-
-      await mirror.stop();
-      await rm(outsideRoot, { recursive: true, force: true });
+        await expect(stat(outsidePath)).rejects.toThrow(/ENOENT/);
+        expect(logger.error).toHaveBeenCalledWith(
+          expect.stringContaining(`remote-change failed for ${traversalPath}:`),
+          expect.stringMatching(/invalid/i),
+        );
+      } finally {
+        await mirror.stop();
+        await rm(outsideRoot, { recursive: true, force: true });
+      }
     });
 
     it("does not follow local symlinks on remote writes", async () => {
@@ -558,25 +560,27 @@ describe("createHomeMirror", () => {
         peerRegistry: registry,
         logger,
       });
-      await mirror.start();
+      try {
+        await mirror.start();
 
-      registry.broadcastChange("alice", "laptop-1", {
-        type: "sync:change",
-        files: [{ path: "linked.txt", hash: sha256(Buffer.from("replacement")), size: 11, action: "update" }],
-        peerId: "laptop-1",
-        manifestVersion: 2,
-      });
+        registry.broadcastChange("alice", "laptop-1", {
+          type: "sync:change",
+          files: [{ path: "linked.txt", hash: sha256(Buffer.from("replacement")), size: 11, action: "update" }],
+          peerId: "laptop-1",
+          manifestVersion: 2,
+        });
 
-      await settle(80);
+        await settle(80);
 
-      expect(await readFile(target, "utf8")).toBe("outside");
-      expect(logger.error).toHaveBeenCalledWith(
-        expect.stringContaining("remote-change failed for linked.txt:"),
-        expect.stringMatching(/symlink/i),
-      );
-
-      await mirror.stop();
-      await rm(outsideRoot, { recursive: true, force: true });
+        expect(await readFile(target, "utf8")).toBe("outside");
+        expect(logger.error).toHaveBeenCalledWith(
+          expect.stringContaining("remote-change failed for linked.txt:"),
+          expect.stringMatching(/symlink/i),
+        );
+      } finally {
+        await mirror.stop();
+        await rm(outsideRoot, { recursive: true, force: true });
+      }
     });
 
     it("logs non-Error failures during remote pulls without losing the reason", async () => {
@@ -689,26 +693,28 @@ describe("createHomeMirror", () => {
         peerRegistry: registry,
         logger,
       });
-      await mirror.start();
+      try {
+        await mirror.start();
 
-      registry.broadcastChange("alice", "laptop-1", {
-        type: "sync:change",
-        files: [{ path: traversalPath, hash: "sha256:" + "0".repeat(64), size: 0, action: "delete" }],
-        peerId: "laptop-1",
-        manifestVersion: 2,
-      });
+        registry.broadcastChange("alice", "laptop-1", {
+          type: "sync:change",
+          files: [{ path: traversalPath, hash: "sha256:" + "0".repeat(64), size: 0, action: "delete" }],
+          peerId: "laptop-1",
+          manifestVersion: 2,
+        });
 
-      await settle(80);
+        await settle(80);
 
-      const remaining = await readFile(outsidePath, "utf8");
-      expect(remaining).toBe("keep me");
-      expect(logger.error).toHaveBeenCalledWith(
-        expect.stringContaining(`remote-change failed for ${traversalPath}:`),
-        expect.stringMatching(/invalid/i),
-      );
-
-      await mirror.stop();
-      await rm(outsideRoot, { recursive: true, force: true });
+        const remaining = await readFile(outsidePath, "utf8");
+        expect(remaining).toBe("keep me");
+        expect(logger.error).toHaveBeenCalledWith(
+          expect.stringContaining(`remote-change failed for ${traversalPath}:`),
+          expect.stringMatching(/invalid/i),
+        );
+      } finally {
+        await mirror.stop();
+        await rm(outsideRoot, { recursive: true, force: true });
+      }
     });
 
     it("ignores broadcasts for ignored paths (e.g. node_modules and browser profiles)", async () => {

--- a/tests/gateway/sync/home-mirror.test.ts
+++ b/tests/gateway/sync/home-mirror.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { mkdtemp, readFile, rm, stat, writeFile, mkdir, unlink } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { join, relative } from "node:path";
 import { createHomeMirror as createHomeMirrorImpl } from "../../../packages/gateway/src/sync/home-mirror.js";
 import {
   createPeerRegistry,
@@ -504,7 +504,9 @@ describe("createHomeMirror", () => {
 
     it("refuses traversal paths on remote writes", async () => {
       const logger = { info: vi.fn(), error: vi.fn() };
-      const outsidePath = join(tmpRoot, "..", "escaped-write.txt");
+      const outsideRoot = await mkdtemp(join(tmpdir(), "home-mirror-outside-"));
+      const outsidePath = join(outsideRoot, "escaped-write.txt");
+      const traversalPath = relative(tmpRoot, outsidePath);
       const mirror = createHomeMirror({
         r2,
         manifestDb: db,
@@ -518,7 +520,7 @@ describe("createHomeMirror", () => {
 
       registry.broadcastChange("alice", "laptop-1", {
         type: "sync:change",
-        files: [{ path: "../escaped-write.txt", hash: sha256(Buffer.from("evil")), size: 4, action: "update" }],
+        files: [{ path: traversalPath, hash: sha256(Buffer.from("evil")), size: 4, action: "update" }],
         peerId: "laptop-1",
         manifestVersion: 2,
       });
@@ -527,16 +529,18 @@ describe("createHomeMirror", () => {
 
       await expect(stat(outsidePath)).rejects.toThrow(/ENOENT/);
       expect(logger.error).toHaveBeenCalledWith(
-        expect.stringContaining("remote-change failed for ../escaped-write.txt:"),
+        expect.stringContaining(`remote-change failed for ${traversalPath}:`),
         expect.stringMatching(/invalid/i),
       );
 
       await mirror.stop();
+      await rm(outsideRoot, { recursive: true, force: true });
     });
 
     it("does not follow local symlinks on remote writes", async () => {
       const logger = { info: vi.fn(), error: vi.fn() };
-      const target = join(tmpRoot, "..", "outside-target.txt");
+      const outsideRoot = await mkdtemp(join(tmpdir(), "home-mirror-outside-"));
+      const target = join(outsideRoot, "outside-target.txt");
       const link = join(tmpRoot, "linked.txt");
       await writeFile(target, "outside");
       await (await import("node:fs/promises")).symlink(target, link);
@@ -572,6 +576,7 @@ describe("createHomeMirror", () => {
       );
 
       await mirror.stop();
+      await rm(outsideRoot, { recursive: true, force: true });
     });
 
     it("logs non-Error failures during remote pulls without losing the reason", async () => {
@@ -670,7 +675,9 @@ describe("createHomeMirror", () => {
 
     it("refuses traversal paths on remote deletes", async () => {
       const logger = { info: vi.fn(), error: vi.fn() };
-      const outsidePath = join(tmpRoot, "..", "escaped-delete.txt");
+      const outsideRoot = await mkdtemp(join(tmpdir(), "home-mirror-outside-"));
+      const outsidePath = join(outsideRoot, "escaped-delete.txt");
+      const traversalPath = relative(tmpRoot, outsidePath);
       await writeFile(outsidePath, "keep me");
 
       const mirror = createHomeMirror({
@@ -686,7 +693,7 @@ describe("createHomeMirror", () => {
 
       registry.broadcastChange("alice", "laptop-1", {
         type: "sync:change",
-        files: [{ path: "../escaped-delete.txt", hash: "sha256:" + "0".repeat(64), size: 0, action: "delete" }],
+        files: [{ path: traversalPath, hash: "sha256:" + "0".repeat(64), size: 0, action: "delete" }],
         peerId: "laptop-1",
         manifestVersion: 2,
       });
@@ -696,11 +703,12 @@ describe("createHomeMirror", () => {
       const remaining = await readFile(outsidePath, "utf8");
       expect(remaining).toBe("keep me");
       expect(logger.error).toHaveBeenCalledWith(
-        expect.stringContaining("remote-change failed for ../escaped-delete.txt:"),
+        expect.stringContaining(`remote-change failed for ${traversalPath}:`),
         expect.stringMatching(/invalid/i),
       );
 
       await mirror.stop();
+      await rm(outsideRoot, { recursive: true, force: true });
     });
 
     it("ignores broadcasts for ignored paths (e.g. node_modules and browser profiles)", async () => {

--- a/tests/mcp-browser/server.test.ts
+++ b/tests/mcp-browser/server.test.ts
@@ -1,4 +1,7 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createBrowserMcpServer } from "../../packages/mcp-browser/src/server.js";
 
 const playwrightMocks = vi.hoisted(() => ({
@@ -14,13 +17,20 @@ vi.mock("playwright", () => ({
 }));
 
 describe("Browser MCP server", () => {
-  beforeEach(() => {
+  let homePath: string;
+
+  beforeEach(async () => {
     vi.clearAllMocks();
+    homePath = await mkdtemp(join(tmpdir(), "mcp-browser-server-"));
+  });
+
+  afterEach(async () => {
+    await rm(homePath, { recursive: true, force: true });
   });
 
   it("creates an MCP server with browser tool", () => {
     const server = createBrowserMcpServer({
-      homePath: "/tmp/test",
+      homePath,
       headless: true,
       timeout: 5000,
     });
@@ -49,7 +59,7 @@ describe("Browser MCP server", () => {
     playwrightMocks.launchPersistentContext.mockResolvedValue(context);
 
     const server = createBrowserMcpServer({
-      homePath: "/tmp/test",
+      homePath,
       headless: true,
       timeout: 5000,
     });
@@ -64,7 +74,7 @@ describe("Browser MCP server", () => {
     await registered._registeredTools.browser.handler({ action: "launch" });
 
     expect(playwrightMocks.launchPersistentContext).toHaveBeenCalledWith(
-      "/tmp/test/data/browser-profiles/default",
+      join(homePath, "data", "browser-profiles", "default"),
       expect.objectContaining({
         headless: true,
         serviceWorkers: "block",
@@ -92,7 +102,7 @@ describe("Browser MCP server", () => {
     playwrightMocks.launchPersistentContext.mockResolvedValue(context);
 
     const server = createBrowserMcpServer({
-      homePath: "/tmp/test",
+      homePath,
       headless: true,
       timeout: 5000,
     });

--- a/tests/platform/billing-db.test.ts
+++ b/tests/platform/billing-db.test.ts
@@ -155,7 +155,7 @@ describe('platform billing db', () => {
     };
 
     await upsertBillingOverride(db, override);
-    await expect(getBillingOverride(db, 'user_123')).resolves.toMatchObject({
+    await expect(getBillingOverride(db, 'user_123', '2026-06-01T00:00:00.000Z')).resolves.toMatchObject({
       id: 'override_123',
       reason: 'engineer test',
       revokedAt: null,
@@ -164,7 +164,7 @@ describe('platform billing db', () => {
     await expect(revokeBillingOverride(db, 'override_123', '2026-06-01T00:00:00.000Z')).resolves.toBe(true);
     await expect(revokeBillingOverride(db, 'override_123', '2026-06-02T00:00:00.000Z')).resolves.toBe(false);
 
-    await expect(getBillingOverride(db, 'user_123')).resolves.toBeUndefined();
+    await expect(getBillingOverride(db, 'user_123', '2026-06-01T00:00:00.000Z')).resolves.toBeUndefined();
     await expect(
       db.executor
         .selectFrom('billing_entitlement_overrides')
@@ -179,7 +179,7 @@ describe('platform billing db', () => {
       revokedAt: null,
     });
 
-    await expect(getBillingOverride(db, 'user_123')).resolves.toBeUndefined();
+    await expect(getBillingOverride(db, 'user_123', '2026-06-01T00:00:00.000Z')).resolves.toBeUndefined();
     await expect(revokeBillingOverride(db, 'missing_override', '2026-06-01T00:00:00.000Z')).resolves.toBe(false);
   });
 

--- a/tests/shell/terminal-app-component.test.tsx
+++ b/tests/shell/terminal-app-component.test.tsx
@@ -62,6 +62,15 @@ vi.mock("@/stores/terminal-settings", () => {
 });
 
 import { TerminalApp } from "../../shell/src/components/terminal/TerminalApp.js";
+import { getTerminalThemePreset } from "../../shell/src/components/terminal/terminal-themes.js";
+
+function normalizeCssColor(color: string) {
+  const element = document.createElement("div");
+  element.style.background = color;
+  return element.style.background;
+}
+
+const expectedDarkTerminalBackground = normalizeCssColor(getTerminalThemePreset("dark").background);
 
 class ResizeObserverMock {
   observe() {}
@@ -219,7 +228,7 @@ describe("TerminalApp", () => {
     const contentSurface = screen.getByTestId("terminal-content-surface");
 
     expect(contentSurface.style.padding).toBe("0px");
-    expect(contentSurface.style.background).toBe("rgb(12, 12, 12)");
+    expect(contentSurface.style.background).toBe(expectedDarkTerminalBackground);
   });
 
   it("does not immediately save after hydrating a saved terminal layout", async () => {
@@ -547,7 +556,7 @@ describe("TerminalApp", () => {
 
     let terminalApp = screen.getByRole("application", { name: "Terminal" });
     const contentSurface = screen.getByTestId("terminal-content-surface");
-    expect(contentSurface.style.background).toBe("rgb(12, 12, 12)");
+    expect(contentSurface.style.background).toBe(expectedDarkTerminalBackground);
     expect(terminalApp.style.getPropertyValue("--terminal-drawer-bg")).toBe("#15180F");
     expect(terminalApp.style.getPropertyValue("--terminal-drawer-card-bg")).toBe("#20241C");
 
@@ -567,7 +576,7 @@ describe("TerminalApp", () => {
     expect(terminalApp.style.getPropertyValue("--terminal-drawer-card-bg")).toBe("#FFFDF7");
     expect(screen.getByTestId("terminal-sidebar-shell").style.background).toBe("var(--terminal-drawer-bg)");
     expect(screen.getByTestId("terminal-session-card-main").style.background).toBe("var(--terminal-drawer-card-bg)");
-    expect(screen.getByTestId("terminal-content-surface").style.background).toBe("rgb(12, 12, 12)");
+    expect(screen.getByTestId("terminal-content-surface").style.background).toBe(expectedDarkTerminalBackground);
 
     await act(async () => {
       fireEvent.click(screen.getByRole("button", { name: "Theme" }));
@@ -585,7 +594,7 @@ describe("TerminalApp", () => {
     expect(terminalApp.style.getPropertyValue("--terminal-drawer-card-bg")).toBe("#0F1A12");
     expect(terminalApp.style.getPropertyValue("--terminal-drawer-fg")).toBe("#9BFFB5");
     expect(screen.getByTestId("terminal-session-name-main").style.color).toBe("var(--terminal-drawer-fg)");
-    expect(screen.getByTestId("terminal-content-surface").style.background).toBe("rgb(12, 12, 12)");
+    expect(screen.getByTestId("terminal-content-surface").style.background).toBe(expectedDarkTerminalBackground);
     expect(terminalSettingsState.setThemeId).not.toHaveBeenCalled();
     expect(saveThemeSpy).not.toHaveBeenCalled();
   });

--- a/tests/shell/terminal-pane-scrolling.test.tsx
+++ b/tests/shell/terminal-pane-scrolling.test.tsx
@@ -380,4 +380,30 @@ describe("TerminalPane scrolling", () => {
     await waitFor(() => expect(fitAddon.fit).toHaveBeenCalled());
     expect(terminal.focus).not.toHaveBeenCalled();
   });
+
+  it("does not programmatically focus xterm on mount when native keyboard is suppressed", async () => {
+    render(
+      <TerminalPane
+        paneId="pane-mobile-initial-focus-test"
+        cwd=""
+        theme={theme}
+        isFocused
+        isClosing={false}
+        shouldCacheOnUnmount={() => false}
+        shouldDestroyOnUnmount={() => false}
+        suppressNativeKeyboard
+        onFocus={() => {}}
+      />,
+    );
+
+    await waitFor(() => expect(createdTerminals).toHaveLength(1));
+    await waitFor(() => expect(createdFitAddons).toHaveLength(1));
+
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 300));
+    });
+
+    expect(createdFitAddons[0].fit).toHaveBeenCalled();
+    expect(createdTerminals[0].focus).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
## Summary
- Stabilize billing override lookup tests by letting getBillingOverride use a fixed nowIso in tests.
- Update terminal theme assertions to derive the current dark preset color and prevent suppressed mobile keyboard mode from programmatically focusing xterm.
- Isolate fixed temp fixtures that were failing CI shards when stale /tmp paths were owned by another user.

## Tests
- pnpm exec vitest run tests/platform/billing-db.test.ts tests/shell/terminal-app-component.test.tsx tests/shell/terminal-pane-scrolling.test.tsx
- pnpm exec vitest run tests/gateway/sync/home-mirror.test.ts
- pnpm exec vitest run tests/mcp-browser/server.test.ts
- pnpm exec vitest run --shard=2/4
- pnpm exec vitest run --shard=3/4
- pnpm exec vitest run --shard=4/4
- pnpm run typecheck:build-kernel plus each pnpm package tsc command from the typecheck script because bun is unavailable in this shell
- pnpm run check:patterns
- npx react-doctor@latest shell (advisory baseline findings only; CI currently continue-on-error)
- npx react-doctor@latest --verbose --scope changed shell (same unrelated baseline/onboarding findings)

## Review/Monitoring
- Monitor PR checks and review feedback until CI is green.
- Wait for latest trusted Greptile result to be 5/5 before applying ready-for-ci and merging.
- After merge, monitor main CI and follow up with the minimum additional PRs only if main remains red.

## Invariants
- Source of truth: platform billing entitlement overrides remain stored in Postgres via Kysely; tests now pass an explicit clock value instead of relying on wall-clock time.
- Lock/transaction scope: no new multi-write flow is added; this PR only changes a read-time expiry predicate and frontend focus behavior.
- Acceptable orphan states: none introduced; temp test homes are isolated per test and cleaned after the test.
- Auth source of truth: unchanged; billing and terminal auth/session behavior are not modified.
- Deferred scope: no release workflow changes, no broad React Doctor baseline cleanup, and no host-bundle release changes.