### PR TITLE
fix(shell): clean up terminal drawer divider

### DIFF
--- a/shell/src/app/globals.css
+++ b/shell/src/app/globals.css
@@ -622,6 +622,61 @@ pre {
     -1px -1px 2px var(--neu-shadow-light);
 }
 
+.terminal-sessions-scroll {
+  scrollbar-color: var(--terminal-drawer-scrollbar-thumb) transparent;
+  scrollbar-width: thin;
+}
+
+.terminal-sessions-scroll::-webkit-scrollbar {
+  width: 8px;
+}
+
+.terminal-sessions-scroll::-webkit-scrollbar-track {
+  background: var(--terminal-drawer-scrollbar-track);
+}
+
+.terminal-sessions-scroll::-webkit-scrollbar-thumb {
+  background: var(--terminal-drawer-scrollbar-thumb);
+  background-clip: padding-box;
+  border: 2px solid transparent;
+  border-radius: 999px;
+}
+
+.terminal-sessions-scroll::-webkit-scrollbar-thumb:hover {
+  background: var(--terminal-drawer-scrollbar-thumb-hover);
+  background-clip: padding-box;
+}
+
+[data-theme-style="neumorphic"] .terminal-sessions-scroll::-webkit-scrollbar-thumb {
+  background: var(--terminal-drawer-scrollbar-thumb);
+  background-clip: padding-box;
+  box-shadow: none;
+}
+
+[data-theme-style="neumorphic"] .terminal-sessions-scroll::-webkit-scrollbar-thumb:hover {
+  background: var(--terminal-drawer-scrollbar-thumb-hover);
+  background-clip: padding-box;
+}
+
+.terminal-drawer-resize-handle {
+  transition: background-color 140ms ease-out;
+}
+
+.terminal-drawer-resize-handle:hover,
+.terminal-drawer-resize-handle:active {
+  background: var(--terminal-drawer-resize-handle-hover) !important;
+}
+
+.terminal-drawer-resize-handle:focus {
+  outline: none;
+}
+
+.terminal-drawer-resize-handle:focus-visible {
+  background: var(--terminal-drawer-resize-handle-hover) !important;
+  outline: 1px solid var(--terminal-drawer-resize-handle-focus) !important;
+  outline-offset: -2px;
+}
+
 /* --- Skeleton: inset --- */
 [data-theme-style="neumorphic"] [data-slot="skeleton"] {
   box-shadow:

--- a/shell/src/components/terminal/TerminalApp.tsx
+++ b/shell/src/components/terminal/TerminalApp.tsx
@@ -4224,7 +4224,6 @@ function LocalTerminalSidebar() {
   const activeShellName = activePaneSessionId && isCanonicalShellSessionId(activePaneSessionId)
     ? activePaneSessionId
     : null;
-  const terminalDividerColor = "var(--terminal-drawer-border)";
   const drawerWidth = ctx.mobile ? "100%" : clampTerminalSidebarWidth(ctx.sidebarWidth);
   const startSidebarResize = (event: ReactPointerEvent<HTMLElement>) => {
     if (ctx.mobile) return;
@@ -4442,7 +4441,7 @@ function LocalTerminalSidebar() {
           <CollapsedSessionsRail
             shells={unfilteredRenderedShells}
             selectedShellName={activeShellName}
-            terminalDividerColor={terminalDividerColor}
+            terminalDividerColor="var(--terminal-drawer-border)"
             onExpand={() => ctx.setSidebarOpen(true)}
             creatingShell={creatingShell}
             newSessionMenuOpen={newSessionMenuAnchor === "rail"}
@@ -4470,7 +4469,7 @@ function LocalTerminalSidebar() {
         className="shrink-0 overflow-hidden"
         style={{
           background: "var(--terminal-drawer-bg)",
-          borderRight: ctx.mobile ? "none" : `1px solid ${terminalDividerColor}`,
+          borderRight: ctx.mobile ? "none" : "1px solid var(--terminal-drawer-border)",
           borderBottom: ctx.mobile ? "1px solid var(--terminal-drawer-border)" : "none",
           color: "var(--terminal-drawer-fg)",
           display: "flex",

--- a/shell/src/components/terminal/TerminalApp.tsx
+++ b/shell/src/components/terminal/TerminalApp.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { createContext, use, useEffect, useEffectEvent, useRef, useCallback, useState, type CSSProperties, type KeyboardEvent, type MouseEventHandler, type PointerEvent as ReactPointerEvent, type PointerEventHandler } from "react";
+import { createContext, use, useCallback, useEffect, useEffectEvent, useRef, useState, type CSSProperties, type KeyboardEvent, type MouseEventHandler, type PointerEvent as ReactPointerEvent, type PointerEventHandler } from "react";
 import Image from "next/image";
 import {
   BotIcon,
@@ -698,6 +698,12 @@ function getTerminalAppChromeCssVars(theme: TerminalAppChromeTheme): TerminalApp
     "--terminal-drawer-toggle-off-fg": theme.drawerToggleOffForeground,
     "--terminal-drawer-toggle-off-knob": theme.drawerToggleOffKnob,
     "--terminal-drawer-drop-line": theme.drawerDropLine,
+    "--terminal-drawer-scrollbar-thumb": "color-mix(in srgb, var(--terminal-drawer-border) 72%, transparent)",
+    "--terminal-drawer-scrollbar-thumb-hover": "var(--terminal-drawer-border)",
+    "--terminal-drawer-scrollbar-track": "var(--terminal-drawer-bg)",
+    "--terminal-drawer-resize-handle-bg": "color-mix(in srgb, var(--terminal-drawer-border) 58%, transparent)",
+    "--terminal-drawer-resize-handle-hover": "var(--terminal-drawer-border)",
+    "--terminal-drawer-resize-handle-focus": "var(--terminal-drawer-selected-border)",
     "--terminal-mobile-primary-bg": theme.drawerPrimaryButtonBackground,
     "--terminal-mobile-primary-fg": theme.drawerPrimaryButtonForeground,
   };
@@ -3250,9 +3256,9 @@ function MobileTerminalActions({
     if (shouldOpen) void fetchAgentStatuses();
   };
 
-  const closeNewSessionMenu = useCallback(() => {
+  const closeNewSessionMenu = () => {
     setNewSessionMenuOpen(false);
-  }, []);
+  };
 
   const createShellSession = () => {
     setNewSessionMenuOpen(false);
@@ -4218,7 +4224,7 @@ function LocalTerminalSidebar() {
   const activeShellName = activePaneSessionId && isCanonicalShellSessionId(activePaneSessionId)
     ? activePaneSessionId
     : null;
-  const terminalDividerColor = ctx.terminalBackground || "#080A08";
+  const terminalDividerColor = "var(--terminal-drawer-border)";
   const drawerWidth = ctx.mobile ? "100%" : clampTerminalSidebarWidth(ctx.sidebarWidth);
   const startSidebarResize = (event: ReactPointerEvent<HTMLElement>) => {
     if (ctx.mobile) return;
@@ -4646,7 +4652,12 @@ function LocalTerminalSidebar() {
         </div>
       </div>
 
-      <div className="min-h-0 flex-1 overflow-y-auto" style={{ display: "flex", flexDirection: "column", gap: 18, padding: ctx.mobile ? 20 : 18 }}>
+      <div
+        data-testid="terminal-sessions-scroll"
+        data-terminal-scrollbar="drawer"
+        className="terminal-sessions-scroll min-h-0 flex-1 overflow-y-auto"
+        style={{ display: "flex", flexDirection: "column", gap: 18, padding: ctx.mobile ? 20 : 18 }}
+      >
         {shellsLoading && (
           <div style={{ color: "var(--terminal-drawer-muted)", fontSize: 12, padding: "24px 0", textAlign: "center" }}>Loading sessions...</div>
         )}
@@ -4735,14 +4746,16 @@ function LocalTerminalSidebar() {
         <button
           type="button"
           aria-label="Resize sessions drawer"
+          className="terminal-drawer-resize-handle"
           onPointerDown={startSidebarResize}
           onKeyDown={resizeSidebarWithKeyboard}
           style={{
-            background: terminalDividerColor,
+            background: "var(--terminal-drawer-resize-handle-bg)",
             border: 0,
             bottom: 0,
             cursor: "col-resize",
             margin: 0,
+            outline: "none",
             position: "absolute",
             right: 0,
             top: 0,
@@ -4781,16 +4794,17 @@ function NewSessionMenu({
   ignoreLightDismissRef?: React.RefObject<HTMLElement | null>;
 }) {
   const menuRef = useRef<HTMLDivElement | null>(null);
+  const closeMenu = useEffectEvent(onClose);
 
   useEffect(() => {
     const onKeyDown = (event: globalThis.KeyboardEvent) => {
-      if (event.key === "Escape") onClose();
+      if (event.key === "Escape") closeMenu();
     };
     const onPointerDown = (event: globalThis.PointerEvent) => {
       const target = event.target;
       if (target instanceof Node && menuRef.current?.contains(target)) return;
       if (target instanceof Node && ignoreLightDismissRef?.current?.contains(target)) return;
-      onClose();
+      closeMenu();
     };
     document.addEventListener("keydown", onKeyDown);
     document.addEventListener("pointerdown", onPointerDown, true);
@@ -4798,7 +4812,7 @@ function NewSessionMenu({
       document.removeEventListener("keydown", onKeyDown);
       document.removeEventListener("pointerdown", onPointerDown, true);
     };
-  }, [ignoreLightDismissRef, onClose]);
+  }, [ignoreLightDismissRef]);
 
   return (
     <div

--- a/tests/shell/terminal-app-component.test.tsx
+++ b/tests/shell/terminal-app-component.test.tsx
@@ -1,5 +1,6 @@
 // @vitest-environment jsdom
 
+import { readFileSync } from "node:fs";
 import React from "react";
 import { act, fireEvent, render, screen, within } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi, afterEach } from "vitest";
@@ -517,6 +518,39 @@ describe("TerminalApp", () => {
 
     expect(screen.queryByRole("menu", { name: "Theme" })).toBeNull();
     expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("terminal-scopes the sessions drawer scrollbar and resize boundary", async () => {
+    render(<TerminalApp />);
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    const scrollSurface = screen.getByTestId("terminal-sessions-scroll");
+    expect(scrollSurface.classList.contains("terminal-sessions-scroll")).toBe(true);
+    expect(scrollSurface.getAttribute("data-terminal-scrollbar")).toBe("drawer");
+
+    const resizeHandle = screen.getByRole("button", { name: "Resize sessions drawer" });
+    expect(resizeHandle.classList.contains("terminal-drawer-resize-handle")).toBe(true);
+    expect(resizeHandle.style.background).toBe("var(--terminal-drawer-resize-handle-bg)");
+    expect(resizeHandle.style.outline).toBe("none");
+    expect(resizeHandle.getAttribute("style")).toContain("--terminal-drawer-resize-handle-bg");
+    expect(resizeHandle.getAttribute("style")).not.toContain("--muted-foreground");
+
+    const terminalApp = screen.getByRole("application", { name: "Terminal" });
+    expect(terminalApp.style.getPropertyValue("--terminal-drawer-resize-handle-bg")).toContain("--terminal-drawer-border");
+    expect(terminalApp.style.getPropertyValue("--terminal-drawer-resize-handle-hover")).toBe("var(--terminal-drawer-border)");
+    expect(terminalApp.style.getPropertyValue("--terminal-drawer-scrollbar-thumb")).toContain("--terminal-drawer-border");
+    expect(terminalApp.style.getPropertyValue("--terminal-drawer-scrollbar-thumb-hover")).toBe("var(--terminal-drawer-border)");
+
+    const globalsCss = readFileSync("shell/src/app/globals.css", "utf8");
+    expect(globalsCss).toContain(".terminal-sessions-scroll::-webkit-scrollbar-thumb");
+    expect(globalsCss).toContain("[data-theme-style=\"neumorphic\"] .terminal-sessions-scroll::-webkit-scrollbar-thumb");
+    expect(globalsCss).toContain("background: var(--terminal-drawer-scrollbar-thumb)");
+    expect(globalsCss).not.toMatch(/terminal-sessions-scroll[\s\S]{0,400}--muted-foreground/);
   });
 
   it("updates terminal app theme without saving the global Matrix OS theme", async () => {
@@ -2027,14 +2061,16 @@ describe("TerminalApp", () => {
     const sidebarShell = screen.getByTestId("terminal-sidebar-shell");
     const resizeHandle = screen.getByRole("button", { name: "Resize sessions drawer" });
 
-    expect(sidebarShell.style.borderRight).toBe("1px solid rgb(36, 39, 31)");
-    expect(resizeHandle.style.background).toBe("rgb(36, 39, 31)");
+    expect(sidebarShell.style.borderRight).toBe("1px solid var(--terminal-drawer-border)");
+    expect(resizeHandle.style.background).toBe("var(--terminal-drawer-resize-handle-bg)");
+    expect(resizeHandle.getAttribute("style")).toContain("--terminal-drawer-resize-handle-bg");
+    expect(resizeHandle.getAttribute("style")).not.toContain("--muted-foreground");
     expect(resizeHandle.style.background).not.toContain("transparent");
     expect(resizeHandle.style.background).not.toContain("197, 196, 180");
 
     fireEvent.click(screen.getByRole("button", { name: "Hide sessions drawer" }));
 
-    expect(screen.getByTestId("terminal-collapsed-rail").style.borderRight).toBe("1px solid rgb(36, 39, 31)");
+    expect(screen.getByTestId("terminal-collapsed-rail").style.borderRight).toBe("1px solid var(--terminal-drawer-border)");
   });
 
   it("stops terminal drawer resizing when the drag is canceled", async () => {

--- a/tests/shell/terminal-app-component.test.tsx
+++ b/tests/shell/terminal-app-component.test.tsx
@@ -1,6 +1,5 @@
 // @vitest-environment jsdom
 
-import { readFileSync } from "node:fs";
 import React from "react";
 import { act, fireEvent, render, screen, within } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi, afterEach } from "vitest";
@@ -546,11 +545,6 @@ describe("TerminalApp", () => {
     expect(terminalApp.style.getPropertyValue("--terminal-drawer-scrollbar-thumb")).toContain("--terminal-drawer-border");
     expect(terminalApp.style.getPropertyValue("--terminal-drawer-scrollbar-thumb-hover")).toBe("var(--terminal-drawer-border)");
 
-    const globalsCss = readFileSync("shell/src/app/globals.css", "utf8");
-    expect(globalsCss).toContain(".terminal-sessions-scroll::-webkit-scrollbar-thumb");
-    expect(globalsCss).toContain("[data-theme-style=\"neumorphic\"] .terminal-sessions-scroll::-webkit-scrollbar-thumb");
-    expect(globalsCss).toContain("background: var(--terminal-drawer-scrollbar-thumb)");
-    expect(globalsCss).not.toMatch(/terminal-sessions-scroll[\s\S]{0,400}--muted-foreground/);
   });
 
   it("updates terminal app theme without saving the global Matrix OS theme", async () => {

--- a/tests/shell/terminal-globals-css.test.ts
+++ b/tests/shell/terminal-globals-css.test.ts
@@ -1,0 +1,16 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const globalsCssPath = fileURLToPath(new URL("../../shell/src/app/globals.css", import.meta.url));
+
+describe("terminal global CSS", () => {
+  it("scopes the sessions drawer scrollbar to terminal chrome variables", () => {
+    const globalsCss = readFileSync(globalsCssPath, "utf8");
+
+    expect(globalsCss).toContain(".terminal-sessions-scroll::-webkit-scrollbar-thumb");
+    expect(globalsCss).toContain("[data-theme-style=\"neumorphic\"] .terminal-sessions-scroll::-webkit-scrollbar-thumb");
+    expect(globalsCss).toContain("background: var(--terminal-drawer-scrollbar-thumb)");
+    expect(globalsCss).not.toMatch(/terminal-sessions-scroll[\s\S]{0,400}--muted-foreground/);
+  });
+});


### PR DESCRIPTION
## Summary

- Added a terminal-scoped scrollbar hook to the sessions drawer scroll container.
- Styled the drawer scrollbar and resize handle with terminal chrome variables, including the neumorphic override path.
- Kept xterm viewport scrolling unchanged and preserved the existing 8px resizable drawer boundary.

## Tests

- `pnpm exec vitest run tests/www/landing-billing-clickable.test.ts tests/shell/terminal-app-component.test.tsx tests/shell/terminal-globals-css.test.ts` - passed, 80 tests after rebasing over `origin/main`.
- `pnpm run check:patterns` - passed with scanner warnings only.
- `pnpm --filter './shell' exec tsc --noEmit` - passed.
- `pnpm run typecheck` - blocked locally because the root script invokes `bun`, which is not installed in this environment.
- `npx react-doctor@latest shell` / changed-scope rerun - audits still report pre-existing issues outside this diff; `TerminalApp.tsx` has no remaining changed-scope findings.
- Manual Canvas/Desktop verification was attempted with the local shell dev server, but the surface stayed at the Clerk/runtime workspace loading gate despite E2E bypass flags, so live Terminal screenshot evidence is still pending from a runnable Matrix runtime.

## Review/Monitoring

- Opened via the required manual worktree workflow.
- Latest trusted Greptile result is `5/5` on commit `531379f5ea31f1460d5922ae8a4fbbdb15c6ee92`.
- Rebased onto current `origin/main` to clear the PR conflict; the duplicate www telemetry assertion fix is now supplied by main.
- Added the `ready-for-ci` label after Greptile reached `5/5`; re-triggered it after the rebase so the broad suite ran against the latest commit.
- Ready-for-ci suite passed: CI Results, Type Check, Pattern Scan, React Doctor, Shell Production Build, Sync Client Package, Unit Tests 1-4, E2E Tests, Build Docker Test Image, and Docker Smoke Test.

## Invariants

- **Source of truth**: terminal chrome CSS variables are the source of truth for the sessions drawer scrollbar, divider, and resize boundary colors.
- **Lock/transaction scope**: N/A. This is a frontend-only styling/test change with no database writes, network calls, or persistence changes.
- **Acceptable orphan states**: N/A. The drawer remains scrollable/resizable; xterm viewport scrolling is explicitly unchanged.
- **Auth source of truth**: N/A. No auth, route, API, or backend behavior changes.
- **Deferred scope**: live Canvas/Desktop visual verification remains pending because the local runtime did not reach the Terminal surface in this environment.
