### PR TITLE
fix(tests): align telemetry assertions with canonical events

### DIFF
--- a/tests/cli/doctor.test.ts
+++ b/tests/cli/doctor.test.ts
@@ -13,11 +13,19 @@ afterEach(() => {
 
 const originalHome = process.env.HOME;
 
+async function withIsolatedHome<T>(run: () => Promise<T>): Promise<T> {
+  const root = await mkdtemp(join(tmpdir(), "matrix-doctor-cli-"));
+  try {
+    process.env.HOME = root;
+    return await run();
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+}
+
 describe("doctor CLI command", () => {
   it("reports profile, auth, daemon, gateway, and protocol checks in JSON", async () => {
-    const root = await mkdtemp(join(tmpdir(), "matrix-doctor-cli-"));
-    try {
-      process.env.HOME = root;
+    await withIsolatedHome(async () => {
       const fetchImpl = vi.fn(async () => new Response(JSON.stringify({ status: "ok" })));
       vi.stubGlobal("fetch", fetchImpl);
       const logs: string[] = [];
@@ -52,138 +60,140 @@ describe("doctor CLI command", () => {
         code: "daemon_unavailable",
         hint: "Start sync with `mos sync`.",
       });
-    } finally {
-      await rm(root, { recursive: true, force: true });
-    }
+    });
   });
 
   it("reports shell backend failures with a safe doctor hint", async () => {
-    const fetchImpl = vi.fn(async (url: string) => {
-      if (url.endsWith("/api/terminal/health")) {
-        return new Response(JSON.stringify({ shell: { ok: false, code: "zellij_failed" } }), { status: 503 });
-      }
-      return new Response(JSON.stringify({ status: "ok" }));
-    });
-    vi.stubGlobal("fetch", fetchImpl);
-    const logs: string[] = [];
-    vi.spyOn(console, "log").mockImplementation((line?: unknown) => {
-      logs.push(String(line));
-    });
+    await withIsolatedHome(async () => {
+      const fetchImpl = vi.fn(async (url: string) => {
+        if (url.endsWith("/api/terminal/health")) {
+          return new Response(JSON.stringify({ shell: { ok: false, code: "zellij_failed" } }), { status: 503 });
+        }
+        return new Response(JSON.stringify({ status: "ok" }));
+      });
+      vi.stubGlobal("fetch", fetchImpl);
+      const logs: string[] = [];
+      vi.spyOn(console, "log").mockImplementation((line?: unknown) => {
+        logs.push(String(line));
+      });
 
-    await doctorCommand.run!({ args: { dev: true, token: "tok", json: true } } as never);
+      await doctorCommand.run!({ args: { dev: true, token: "tok", json: true } } as never);
 
-    const parsed = JSON.parse(logs[0]);
-    expect(parsed.data.checks.find((check: { name: string }) => check.name === "shell-backend")).toEqual({
-      name: "shell-backend",
-      ok: false,
-      code: "zellij_failed",
-      hint: "Run `mos doctor --profile local`; managed VPSes may need the latest host bundle deployed.",
+      const parsed = JSON.parse(logs[0]);
+      expect(parsed.data.checks.find((check: { name: string }) => check.name === "shell-backend")).toEqual({
+        name: "shell-backend",
+        ok: false,
+        code: "zellij_failed",
+        hint: "Run `mos doctor --profile local`; managed VPSes may need the latest host bundle deployed.",
+      });
     });
   });
 
   it("uses saved profile auth when probing the gateway", async () => {
-    const root = await mkdtemp(join(tmpdir(), "matrix-doctor-cli-"));
-    process.env.HOME = root;
-    await saveProfileAuth("cloud", {
-      accessToken: "cloud-token",
-      expiresAt: Date.now() + 60_000,
-      userId: "user_cloud",
-      handle: "cloud",
-    });
-    const fetchImpl = vi.fn(async () => new Response(JSON.stringify({ status: "ok" })));
-    vi.stubGlobal("fetch", fetchImpl);
-    const logs: string[] = [];
-    vi.spyOn(console, "log").mockImplementation((line?: unknown) => {
-      logs.push(String(line));
-    });
+    await withIsolatedHome(async () => {
+      await saveProfileAuth("cloud", {
+        accessToken: "cloud-token",
+        expiresAt: Date.now() + 60_000,
+        userId: "user_cloud",
+        handle: "cloud",
+      });
+      const fetchImpl = vi.fn(async () => new Response(JSON.stringify({ status: "ok" })));
+      vi.stubGlobal("fetch", fetchImpl);
+      const logs: string[] = [];
+      vi.spyOn(console, "log").mockImplementation((line?: unknown) => {
+        logs.push(String(line));
+      });
 
-    await doctorCommand.run!({ args: { json: true } } as never);
+      await doctorCommand.run!({ args: { json: true } } as never);
 
-    const parsed = JSON.parse(logs[0]);
-    expect(parsed.data.checks.find((check: { name: string }) => check.name === "gateway").ok).toBe(true);
-    expect(fetchImpl).toHaveBeenCalledWith("https://app.matrix-os.com/api/system/info", {
-      headers: { Authorization: "Bearer cloud-token" },
-      signal: expect.any(AbortSignal),
+      const parsed = JSON.parse(logs[0]);
+      expect(parsed.data.checks.find((check: { name: string }) => check.name === "gateway").ok).toBe(true);
+      expect(fetchImpl).toHaveBeenCalledWith("https://app.matrix-os.com/api/system/info", {
+        headers: { Authorization: "Bearer cloud-token" },
+        signal: expect.any(AbortSignal),
+      });
     });
-    await rm(root, { recursive: true, force: true });
   });
 
   it("prompts to refresh expired profile auth", async () => {
-    const root = await mkdtemp(join(tmpdir(), "matrix-doctor-cli-"));
-    process.env.HOME = root;
-    await saveProfileAuth("cloud", {
-      accessToken: "expired-token",
-      expiresAt: Date.parse("2026-05-29T23:24:06.000Z"),
-      userId: "user_cloud",
-      handle: "cloud",
-    });
-    const fetchImpl = vi.fn(async () => new Response(JSON.stringify({ status: "ok" })));
-    vi.stubGlobal("fetch", fetchImpl);
-    const logs: string[] = [];
-    vi.spyOn(console, "log").mockImplementation((line?: unknown) => {
-      logs.push(String(line));
-    });
+    await withIsolatedHome(async () => {
+      await saveProfileAuth("cloud", {
+        accessToken: "expired-token",
+        expiresAt: Date.parse("2026-05-29T23:24:06.000Z"),
+        userId: "user_cloud",
+        handle: "cloud",
+      });
+      const fetchImpl = vi.fn(async () => new Response(JSON.stringify({ status: "ok" })));
+      vi.stubGlobal("fetch", fetchImpl);
+      const logs: string[] = [];
+      vi.spyOn(console, "log").mockImplementation((line?: unknown) => {
+        logs.push(String(line));
+      });
 
-    await doctorCommand.run!({ args: { json: true } } as never);
+      await doctorCommand.run!({ args: { json: true } } as never);
 
-    const parsed = JSON.parse(logs[0]);
-    expect(parsed.data.checks.find((check: { name: string }) => check.name === "auth")).toEqual({
-      name: "auth",
-      ok: false,
-      code: "auth_expired",
-      hint: "Run `mos login --profile cloud` to refresh.",
+      const parsed = JSON.parse(logs[0]);
+      expect(parsed.data.checks.find((check: { name: string }) => check.name === "auth")).toEqual({
+        name: "auth",
+        ok: false,
+        code: "auth_expired",
+        hint: "Run `mos login --profile cloud` to refresh.",
+      });
+      expect(fetchImpl).toHaveBeenCalledWith("https://app.matrix-os.com/api/system/info", {
+        signal: expect.any(AbortSignal),
+      });
     });
-    expect(fetchImpl).toHaveBeenCalledWith("https://app.matrix-os.com/api/system/info", {
-      signal: expect.any(AbortSignal),
-    });
-    await rm(root, { recursive: true, force: true });
   });
 
   it("maps terminal health auth failures to auth_expired instead of shell backend failure", async () => {
-    const fetchImpl = vi.fn(async (url: string) => {
-      if (url.endsWith("/api/terminal/health")) {
-        return new Response(JSON.stringify({ error: { code: "auth_expired" } }), { status: 401 });
-      }
-      return new Response(JSON.stringify({ status: "ok" }));
-    });
-    vi.stubGlobal("fetch", fetchImpl);
-    const logs: string[] = [];
-    vi.spyOn(console, "log").mockImplementation((line?: unknown) => {
-      logs.push(String(line));
-    });
+    await withIsolatedHome(async () => {
+      const fetchImpl = vi.fn(async (url: string) => {
+        if (url.endsWith("/api/terminal/health")) {
+          return new Response(JSON.stringify({ error: { code: "auth_expired" } }), { status: 401 });
+        }
+        return new Response(JSON.stringify({ status: "ok" }));
+      });
+      vi.stubGlobal("fetch", fetchImpl);
+      const logs: string[] = [];
+      vi.spyOn(console, "log").mockImplementation((line?: unknown) => {
+        logs.push(String(line));
+      });
 
-    await doctorCommand.run!({ args: { dev: true, json: true } } as never);
+      await doctorCommand.run!({ args: { dev: true, json: true } } as never);
 
-    const parsed = JSON.parse(logs[0]);
-    expect(parsed.data.checks.find((check: { name: string }) => check.name === "shell-backend")).toEqual({
-      name: "shell-backend",
-      ok: false,
-      code: "auth_expired",
-      hint: "Run `mos login --profile local` to refresh.",
+      const parsed = JSON.parse(logs[0]);
+      expect(parsed.data.checks.find((check: { name: string }) => check.name === "shell-backend")).toEqual({
+        name: "shell-backend",
+        ok: false,
+        code: "auth_expired",
+        hint: "Run `mos login --profile local` to refresh.",
+      });
     });
   });
 
   it("does not reflect unknown terminal health codes", async () => {
-    const fetchImpl = vi.fn(async (url: string) => {
-      if (url.endsWith("/api/terminal/health")) {
-        return new Response(JSON.stringify({ shell: { ok: false, code: "internal_path_leak" } }), { status: 503 });
-      }
-      return new Response(JSON.stringify({ status: "ok" }));
-    });
-    vi.stubGlobal("fetch", fetchImpl);
-    const logs: string[] = [];
-    vi.spyOn(console, "log").mockImplementation((line?: unknown) => {
-      logs.push(String(line));
-    });
+    await withIsolatedHome(async () => {
+      const fetchImpl = vi.fn(async (url: string) => {
+        if (url.endsWith("/api/terminal/health")) {
+          return new Response(JSON.stringify({ shell: { ok: false, code: "internal_path_leak" } }), { status: 503 });
+        }
+        return new Response(JSON.stringify({ status: "ok" }));
+      });
+      vi.stubGlobal("fetch", fetchImpl);
+      const logs: string[] = [];
+      vi.spyOn(console, "log").mockImplementation((line?: unknown) => {
+        logs.push(String(line));
+      });
 
-    await doctorCommand.run!({ args: { dev: true, token: "tok", json: true } } as never);
+      await doctorCommand.run!({ args: { dev: true, token: "tok", json: true } } as never);
 
-    const parsed = JSON.parse(logs[0]);
-    expect(parsed.data.checks.find((check: { name: string }) => check.name === "shell-backend")).toEqual({
-      name: "shell-backend",
-      ok: false,
-      code: "zellij_failed",
-      hint: "Run `mos doctor --profile local`; managed VPSes may need the latest host bundle deployed.",
+      const parsed = JSON.parse(logs[0]);
+      expect(parsed.data.checks.find((check: { name: string }) => check.name === "shell-backend")).toEqual({
+        name: "shell-backend",
+        ok: false,
+        code: "zellij_failed",
+        hint: "Run `mos doctor --profile local`; managed VPSes may need the latest host bundle deployed.",
+      });
     });
   });
 });

--- a/tests/cli/doctor.test.ts
+++ b/tests/cli/doctor.test.ts
@@ -15,40 +15,46 @@ const originalHome = process.env.HOME;
 
 describe("doctor CLI command", () => {
   it("reports profile, auth, daemon, gateway, and protocol checks in JSON", async () => {
-    const fetchImpl = vi.fn(async () => new Response(JSON.stringify({ status: "ok" })));
-    vi.stubGlobal("fetch", fetchImpl);
-    const logs: string[] = [];
-    vi.spyOn(console, "log").mockImplementation((line?: unknown) => {
-      logs.push(String(line));
-    });
+    const root = await mkdtemp(join(tmpdir(), "matrix-doctor-cli-"));
+    try {
+      process.env.HOME = root;
+      const fetchImpl = vi.fn(async () => new Response(JSON.stringify({ status: "ok" })));
+      vi.stubGlobal("fetch", fetchImpl);
+      const logs: string[] = [];
+      vi.spyOn(console, "log").mockImplementation((line?: unknown) => {
+        logs.push(String(line));
+      });
 
-    await doctorCommand.run!({ args: { dev: true, token: "tok", json: true } } as never);
+      await doctorCommand.run!({ args: { dev: true, token: "tok", json: true } } as never);
 
-    const parsed = JSON.parse(logs[0]);
-    expect(parsed.v).toBe(1);
-    expect(parsed.ok).toBe(true);
-    expect(parsed.data.checks.map((check: { name: string }) => check.name)).toEqual([
-      "profile",
-      "auth",
-      "daemon",
-      "gateway",
-      "shell-backend",
-      "protocol",
-    ]);
-    expect(fetchImpl).toHaveBeenCalledWith("http://localhost:4000/api/system/info", {
-      headers: { Authorization: "Bearer tok" },
-      signal: expect.any(AbortSignal),
-    });
-    expect(fetchImpl).toHaveBeenCalledWith("http://localhost:4000/api/terminal/health", {
-      headers: { Authorization: "Bearer tok" },
-      signal: expect.any(AbortSignal),
-    });
-    expect(parsed.data.checks.find((check: { name: string }) => check.name === "daemon")).toEqual({
-      name: "daemon",
-      ok: false,
-      code: "daemon_unavailable",
-      hint: "Start sync with `mos sync`.",
-    });
+      const parsed = JSON.parse(logs[0]);
+      expect(parsed.v).toBe(1);
+      expect(parsed.ok).toBe(true);
+      expect(parsed.data.checks.map((check: { name: string }) => check.name)).toEqual([
+        "profile",
+        "auth",
+        "daemon",
+        "gateway",
+        "shell-backend",
+        "protocol",
+      ]);
+      expect(fetchImpl).toHaveBeenCalledWith("http://localhost:4000/api/system/info", {
+        headers: { Authorization: "Bearer tok" },
+        signal: expect.any(AbortSignal),
+      });
+      expect(fetchImpl).toHaveBeenCalledWith("http://localhost:4000/api/terminal/health", {
+        headers: { Authorization: "Bearer tok" },
+        signal: expect.any(AbortSignal),
+      });
+      expect(parsed.data.checks.find((check: { name: string }) => check.name === "daemon")).toEqual({
+        name: "daemon",
+        ok: false,
+        code: "daemon_unavailable",
+        hint: "Start sync with `mos sync`.",
+      });
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
   });
 
   it("reports shell backend failures with a safe doctor hint", async () => {

--- a/tests/www/landing-billing-clickable.test.ts
+++ b/tests/www/landing-billing-clickable.test.ts
@@ -1,6 +1,7 @@
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
+import { MATRIX_TELEMETRY_EVENTS } from "../../packages/observability/src/events.js";
 
 const src = readFileSync(
   join(process.cwd(), "www/src/components/landing/LandingBilling.tsx"),
@@ -17,8 +18,11 @@ describe("landing billing is clickable", () => {
     expect(src).toContain("/sign-up?plan=${plan.urlSlug}");
   });
 
-  it("emits plan-click telemetry", () => {
-    expect(src).toContain("marketing_billing_plan_clicked");
+  it("emits plan-click telemetry through the canonical event", () => {
+    expect(src).toContain("MATRIX_TELEMETRY_EVENTS.MARKETING_BILLING_PLAN_CLICKED");
+    expect(MATRIX_TELEMETRY_EVENTS.MARKETING_BILLING_PLAN_CLICKED).toBe(
+      "matrix_marketing_billing_plan_clicked",
+    );
   });
 
   it("drops the duplicated inline plans array", () => {


### PR DESCRIPTION
## Summary

- Fixes the failing `tests/www/landing-billing-clickable.test.ts` assertion from the latest `main` CI run by checking the canonical telemetry event constant introduced by #694.
- Keeps the telemetry value assertion tied to `MATRIX_TELEMETRY_EVENTS.MARKETING_BILLING_PLAN_CLICKED` so future source-level refactors do not break on stale raw strings.
- Isolates doctor CLI tests with temporary HOME directories so developer-local profile config cannot change expected `--dev` behavior.

## Failure Cause

The failing CI shard expected `LandingBilling.tsx` to contain the old raw event string `marketing_billing_plan_clicked`. PR #694 moved the component to the shared observability constant, whose canonical value is now `matrix_marketing_billing_plan_clicked`, so the source-text test was stale even though the component was wired to the intended event.

## Tests

- `CI=true corepack pnpm exec vitest run tests/www/landing-billing-clickable.test.ts`
- `CI=true corepack pnpm exec vitest run tests/cli/doctor.test.ts`
- `CI=true corepack pnpm exec vitest run tests/www/landing-billing-clickable.test.ts tests/cli/doctor.test.ts`
- `CI=true corepack pnpm exec vitest run tests/cli/doctor.test.ts tests/www/landing-billing-clickable.test.ts`
- `pnpm run check:patterns`
- `pnpm run typecheck:build-kernel`
- `pnpm --filter '@matrix-os/observability' exec tsc --noEmit`
- `pnpm --filter '@matrix-os/gateway' exec tsc --noEmit`
- `pnpm --filter '@matrix-os/platform' exec tsc --noEmit -p tsconfig.typecheck.json`
- `pnpm --filter '@matrix-os/proxy' exec tsc --noEmit`
- `pnpm --filter '@matrix-os/edge-router' exec tsc --noEmit`
- `pnpm --filter desktop run typecheck`
- `pnpm run test`

Note: `bun` is not installed in this local shell, so I used the equivalent `pnpm` commands plus the full root `pnpm run test`.

## Review/Monitoring

- Initial Greptile review on `d0e6df6e` reported `4/5` with one finding about sibling `dev: true` doctor tests lacking HOME isolation.
- Follow-up commit `b04782d7` addresses that finding by centralizing temporary HOME setup in a helper and applying it across the doctor CLI test file.
- Monitoring is still in progress for the latest CI and Greptile result.

## Invariants

- Source of truth: Telemetry event names remain centralized in `packages/observability/src/events.ts`; tests assert that canonical export instead of duplicating an obsolete inline string.
- Lock/transaction scope: Not applicable; test-only change with no data writes or runtime critical section changes.
- Acceptable orphan states: Not applicable; no persisted state is created by runtime code. The updated doctor tests clean up temporary HOME directories in a shared `finally` path.
- Auth source of truth: Not applicable; no auth behavior changes.
- Deferred scope: No production code changes, no telemetry rename, and no CI workflow changes.
