### PR TITLE
fix(platform): ignore stale containers for VPS auth sessions

### DIFF
--- a/packages/platform/src/auth-routes.ts
+++ b/packages/platform/src/auth-routes.ts
@@ -34,6 +34,7 @@ export interface AuthRoutesConfig {
   jwtSecret: string;
   platformUrl: string; // e.g. https://platform.matrix-os.com
   gatewayUrlForHandle: (handle: string) => string;
+  ignoreLegacyContainers?: boolean;
   // Optional non-secret display profile (name/avatar) for the signing-in
   // client. Must NEVER throw or block token issuance — return null on any
   // failure (the avatar is a nice-to-have, the token is not).
@@ -722,7 +723,9 @@ export function createAuthRoutes(config: AuthRoutesConfig): Hono {
     expiresInSec: DEVICE_EXPIRES_IN_SEC,
     now: config.now,
     issueToken: async ({ clerkUserId }) => {
-      const container = await getContainerByClerkId(config.db, clerkUserId);
+      const container = config.ignoreLegacyContainers
+        ? undefined
+        : await getContainerByClerkId(config.db, clerkUserId);
       const machine = container ? undefined : await getActiveUserMachineByClerkId(config.db, clerkUserId);
       const handle = container?.handle ?? machine?.handle;
       if (!handle) {

--- a/packages/platform/src/main.ts
+++ b/packages/platform/src/main.ts
@@ -2759,6 +2759,7 @@ export function createApp(deps: {
         jwtSecret: platformJwtSecret,
         platformUrl: deviceAuthPublicUrl,
         gatewayUrlForHandle: getGatewayUrlForHandle,
+        ignoreLegacyContainers: Boolean(deps.customerVpsService),
         fetchUserProfile: (clerkUserId) => fetchDeviceDisplayProfile(clerkUserId, process.env),
         captureEvent: (event, properties) => {
           capturePlatformEvent(MATRIX_TELEMETRY_EVENTS.CLI_COMMAND_RUN, {
@@ -2962,7 +2963,9 @@ export function createApp(deps: {
       return c.json({ error: 'Unauthorized' }, 401);
     }
 
-    const record = await getContainerByClerkId(db, result.userId);
+    const record = legacyContainerRoutingEnabled
+      ? await getContainerByClerkId(db, result.userId)
+      : undefined;
     const machine = record ? undefined : await getActiveUserMachineByClerkId(db, result.userId, requestedRuntimeSlot);
     const handle = record?.handle ?? machine?.handle;
     if (!handle) {

--- a/tests/platform/device-routes.test.ts
+++ b/tests/platform/device-routes.test.ts
@@ -470,6 +470,82 @@ describe("device routes", () => {
       expect(claims.sub).toBe("user_bob");
       expect(claims.handle).toBe("bob");
     });
+
+    it("ignores stale legacy containers when issuing VPS-native device tokens", async () => {
+      await insertContainer(db, {
+        handle: "stale-bob",
+        clerkUserId: "user_bob",
+        port: 5101,
+        shellPort: 6101,
+        status: "stopped",
+      });
+      await insertUserMachine(db, {
+        machineId: "machine_bob",
+        clerkUserId: "user_bob",
+        handle: "bob",
+        status: "running",
+        provisionedAt: new Date().toISOString(),
+      });
+      const authApp = createAuthRoutes({
+        db,
+        clerkAuth: createClerkAuth({
+          verifyToken: vi.fn().mockResolvedValue({ sub: "user_bob" }),
+        }),
+        jwtSecret: JWT_SECRET,
+        platformUrl: "https://app.matrix-os.com",
+        gatewayUrlForHandle: (handle) => `https://${handle}.matrix.test`,
+        ignoreLegacyContainers: true,
+      });
+      const code = await authApp
+        .request("/api/auth/device/code", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ clientId: "matrixos-cli" }),
+        })
+        .then((r) => r.json());
+
+      const setCookieRes = await authApp.request(
+        `/auth/device?user_code=${code.userCode}`,
+      );
+      const csrf = (setCookieRes.headers.get("set-cookie") ?? "").match(
+        /device_csrf=([^;]+)/,
+      )![1];
+
+      const approveRes = await authApp.request("/auth/device/approve", {
+        method: "POST",
+        headers: {
+          "content-type": "application/x-www-form-urlencoded",
+          authorization: "Bearer clerk-bob",
+          cookie: `device_csrf=${csrf}`,
+        },
+        body: new URLSearchParams({
+          userCode: code.userCode,
+          csrf,
+        }).toString(),
+      });
+      expect(approveRes.status).toBe(200);
+
+      const tokenRes = await authApp.request("/api/auth/device/token", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          deviceCode: code.deviceCode,
+          clientId: "matrixos-cli",
+        }),
+      });
+
+      expect(tokenRes.status).toBe(200);
+      const body = await tokenRes.json();
+      expect(body).toMatchObject({
+        accessToken: expect.any(String),
+        userId: "user_bob",
+        handle: "bob",
+      });
+      const claims = await verifySyncJwt(body.accessToken, { secret: JWT_SECRET });
+      expect(claims.sub).toBe("user_bob");
+      expect(claims.handle).toBe("bob");
+      expect(claims.gateway_url).toBe("https://bob.matrix.test");
+    });
   });
 
   describe("POST /auth/device/approve", () => {

--- a/tests/platform/proxy-routing.test.ts
+++ b/tests/platform/proxy-routing.test.ts
@@ -3086,6 +3086,45 @@ describe("platform proxy routing", () => {
     expect(setCookie).toContain("Max-Age=0");
   });
 
+  it("returns billing_required for stale legacy-container users in VPS-native app-session exchange", async () => {
+    process.env.PLATFORM_JWT_SECRET = JWT_SECRET;
+    process.env.MATRIX_BILLING_PROVIDER = "stripe";
+    process.env.STRIPE_SECRET_KEY = "sk_test_matrix";
+    await updateContainerStatus(db, "alice", "stopped", "stale-container-id");
+    const app = createApp({
+      db,
+      orchestrator: stubOrchestrator(),
+      clerkAuth: createClerkAuth({
+        verifyToken: vi.fn().mockResolvedValue({ sub: "user_alice" }),
+      }),
+      platformSecret: "platform-secret-123",
+      customerVpsService: {} as CustomerVpsService,
+      env: {
+        MATRIX_LEGACY_CONTAINER_ROUTING_ENABLED: "true",
+        MATRIX_BILLING_PROVIDER: "stripe",
+        STRIPE_SECRET_KEY: "sk_test_matrix",
+      } as NodeJS.ProcessEnv,
+    });
+
+    const exchange = await app.request("/api/auth/app-session", {
+      method: "POST",
+      headers: {
+        host: "app.matrix-os.com",
+        authorization: "Bearer clerk-session",
+      },
+    });
+
+    expect(exchange.status).toBe(402);
+    await expect(exchange.json()).resolves.toEqual({
+      error: "Billing upgrade required",
+      code: "billing_required",
+    });
+    const setCookie = combinedSetCookie(exchange.headers);
+    expect(setCookie).toContain("matrix_app_session=;");
+    expect(setCookie).toContain("matrix_native_app_session=;");
+    expect(setCookie).toContain("Max-Age=0");
+  });
+
   it("serves the shell billing gate from auth-shell for signed-in users before a VPS exists", async () => {
     process.env.MATRIX_LEGACY_CONTAINER_ROUTING_ENABLED = "false";
     process.env.AUTH_SHELL_HOST = "auth-shell.test";


### PR DESCRIPTION
## Summary
- ignore legacy container rows during app-session exchange when the platform is in VPS-native mode
- ignore legacy container rows for CLI/device token issuance when customer VPS service is active
- add regressions for stale legacy-container users so browser sign-in returns billing_required and device auth selects the VPS machine

## Diagnosis
Production state for the affected old user has a stopped legacy container row for handle `groth` and no matching entry in `/vps/fleet`. The previous fix routed root app-domain requests to billing, but `/api/auth/app-session` and device auth still preferred `containers` over `user_machines`, so stale old users could still receive sessions for dead legacy handles.

## Invariants
- Source of truth: customer VPS runtime identity comes from active `user_machines` in VPS-native mode; legacy `containers` are only valid for legacy container routing.
- Lock/transaction scope: no DB writes added; read ordering only changes for auth/session lookup.
- Acceptable orphan states: stale stopped legacy container rows may remain in Postgres without blocking billing or VPS-native auth.
- Auth source of truth: Clerk still authenticates users; Matrix app/device sessions are issued only after resolving a valid runtime or billing-required state.
- Deferred scope: this PR does not delete any existing legacy container/user rows or alter Stripe/Clerk data.

## Tests
- `bun run test -- tests/platform/proxy-routing.test.ts tests/platform/device-routes.test.ts`
- `pnpm --filter @matrix-os/platform exec tsc --noEmit -p tsconfig.typecheck.json`