### PR TITLE
fix(platform): keep checkout handoff on app shell

### DIFF
--- a/packages/platform/src/auth-pages.ts
+++ b/packages/platform/src/auth-pages.ts
@@ -14,6 +14,14 @@ function deviceReturnTargetFromRedirectPath(redirectTarget: string): string {
   }
 }
 
+export function buildBillingSetupTarget(appShellOrigin: string, redirectTarget: string): string {
+  const url = new URL('/', appShellOrigin);
+  url.searchParams.set('billing', 'setup');
+  const deviceReturnTarget = deviceReturnTargetFromRedirectPath(redirectTarget);
+  if (deviceReturnTarget) url.searchParams.set('device_return', deviceReturnTarget);
+  return url.toString();
+}
+
 export function escapeHtmlAttr(value: string): string {
   return value
     .replaceAll("&", "&amp;")
@@ -39,11 +47,13 @@ export function getAuthPage(
   mode: 'sign-in' | 'sign-up',
   scriptNonce: string,
   redirectTarget: string,
+  appShellOrigin: string,
 ) {
   const escapedPublishableKey = escapeHtmlAttr(publishableKey);
   const redirectTargetJson = escapeInlineScriptJson(redirectTarget);
   const deviceReturnTargetJson = escapeInlineScriptJson(deviceReturnTargetFromRedirectPath(redirectTarget));
   const signOutTargetJson = escapeInlineScriptJson(mode === 'sign-up' ? '/sign-up' : '/sign-in');
+  const billingSetupTargetJson = escapeInlineScriptJson(buildBillingSetupTarget(appShellOrigin, redirectTarget));
   const modeLabel = mode === 'sign-up' ? 'Create your free Matrix account' : 'Welcome back to Matrix';
   const modeDetail = mode === 'sign-up'
     ? 'Start with a free account. The 3-day hosted Matrix trial begins only when you provision your cloud computer.'
@@ -451,6 +461,7 @@ export function getAuthPage(
     var redirectTarget = ${redirectTargetJson};
     var deviceReturnTarget = ${deviceReturnTargetJson};
     var signOutTarget = ${signOutTargetJson};
+    var billingSetupTarget = ${billingSetupTargetJson};
     var SIGN_OUT_TIMEOUT_MS = ${BROWSER_CLERK_SIGN_OUT_TIMEOUT_MS};
     var requestedRuntime = new URLSearchParams(redirectTarget.split('?')[1] || '').get('runtime');
     var checkoutAttemptStorageKey = 'matrix.billing.checkoutAttemptAt';
@@ -773,10 +784,9 @@ export function getAuthPage(
       );
     }
     function billingSetupPath() {
-      var url = new URL('/', window.location.origin);
-      url.searchParams.set('billing', 'setup');
-      if (deviceReturnTarget) url.searchParams.set('device_return', deviceReturnTarget);
-      return url.pathname + url.search;
+      var url = new URL(billingSetupTarget);
+      if (url.origin === window.location.origin) return url.pathname + url.search;
+      return url.toString();
     }
     function openBillingSettingsFromClerkSession() {
       var target = billingSetupPath();
@@ -792,74 +802,6 @@ export function getAuthPage(
       }
       clearBillingSetupRetryCount();
       window.location.replace(target);
-    }
-    function showCheckoutUnavailableState() {
-      renderSessionState(
-        'Checkout unavailable',
-        'Billing checkout is temporarily unavailable. Try again shortly.',
-        'Try again',
-        startBillingCheckoutFromClerkSession
-      );
-    }
-    function rememberBillingCheckoutAttempt() {
-      try {
-        window.sessionStorage.setItem(checkoutAttemptStorageKey, String(Date.now()));
-      } catch (err) {
-        console.warn('[matrix] Unable to write checkout attempt state', err instanceof Error ? err.message : String(err));
-      }
-    }
-    function startBillingCheckoutFromClerkSession() {
-      showLoadingState('Opening secure checkout...');
-      if (!window.Clerk.session) {
-        showSignedInRecoveryState();
-        return;
-      }
-      window.Clerk.session.getToken()
-        .then(function(token) {
-          if (!token) {
-            showSignedInRecoveryState();
-            return null;
-          }
-          var controller = new AbortController();
-          var timeoutId = window.setTimeout(function() { controller.abort(); }, 10000);
-          var checkoutBody = {
-            planSlug: 'matrix_builder',
-            interval: 'monthly',
-            regionSlug: 'region_fsn1'
-          };
-          if (deviceReturnTarget) checkoutBody.returnPath = redirectTarget;
-          return fetch('/billing/checkout', {
-            method: 'POST',
-            headers: {
-              Authorization: 'Bearer ' + token,
-              'Content-Type': 'application/json',
-              Accept: 'application/json'
-            },
-            body: JSON.stringify(checkoutBody),
-            credentials: 'same-origin',
-            signal: controller.signal
-          }).finally(function() {
-            window.clearTimeout(timeoutId);
-          });
-        })
-        .then(function(res) {
-          if (!res) return null;
-          return res.json().catch(function(err) {
-            console.warn('[matrix] Unable to parse checkout response', err instanceof Error ? err.message : String(err));
-            return null;
-          }).then(function(body) {
-            if (!res.ok || !body || typeof body.url !== 'string') {
-              showCheckoutUnavailableState();
-              return;
-            }
-            rememberBillingCheckoutAttempt();
-            window.location.assign(body.url);
-          });
-        })
-        .catch(function(err) {
-          console.error('[matrix] Billing checkout failed', err instanceof Error ? err.message : String(err));
-          showCheckoutUnavailableState();
-        });
     }
     function pollProvisioningSession() {
       provisioningPolls += 1;

--- a/packages/platform/src/main.ts
+++ b/packages/platform/src/main.ts
@@ -2246,7 +2246,10 @@ export function createApp(deps: {
       const scriptNonce = randomBytes(16).toString('base64');
       applyAuthPageHeaders(c, scriptNonce);
       const authMode = c.req.path.startsWith('/sign-up') ? 'sign-up' : 'sign-in';
-      return c.html(getAuthPage(publishableKey, authMode, scriptNonce, buildPostAuthRedirectPath(c.req.url)), 200);
+      return c.html(
+        getAuthPage(publishableKey, authMode, scriptNonce, buildPostAuthRedirectPath(c.req.url), appOrigin(appEnv)),
+        200,
+      );
     }
   }
 
@@ -3289,7 +3292,7 @@ export function createApp(deps: {
       }
       const scriptNonce = randomBytes(16).toString('base64');
       applyAuthPageHeaders(c, scriptNonce);
-      return c.html(getAuthPage(publishableKey, authMode, scriptNonce, buildPostAuthRedirectPath(c.req.url)));
+      return c.html(getAuthPage(publishableKey, authMode, scriptNonce, buildPostAuthRedirectPath(c.req.url), appOrigin(appEnv)));
     }
 
     console.log(`[${isCodeDomain ? 'code' : 'app'}] verified request path=${path}`);

--- a/tests/platform/proxy-routing.test.ts
+++ b/tests/platform/proxy-routing.test.ts
@@ -24,6 +24,7 @@ import {
 } from "../../packages/platform/src/main.js";
 import type { Orchestrator } from "../../packages/platform/src/orchestrator.js";
 import { createClerkAuth } from "../../packages/platform/src/clerk-auth.js";
+import { buildBillingSetupTarget } from "../../packages/platform/src/auth-pages.js";
 import { issueSyncJwt } from "../../packages/platform/src/sync-jwt.js";
 import * as syncJwt from "../../packages/platform/src/sync-jwt.js";
 import { buildPlatformVerificationToken } from "../../packages/platform/src/platform-token.js";
@@ -3003,15 +3004,16 @@ describe("platform proxy routing", () => {
     expect(html).toContain("var maxBillingSetupReloads = 3;");
     expect(html).toContain("Billing settings are still loading");
     expect(html).toContain("2000 + retryCount * 1000");
-    expect(html).toContain("url.searchParams.set('billing', 'setup');");
+    expect(html).toContain("var billingSetupTarget = ");
+    expect(html).toContain("var url = new URL(billingSetupTarget);");
     expect(html).toContain("window.location.replace(target);");
     expect(html).not.toContain("Open Billing settings");
     expect(html).not.toContain("Stripe opens only after you continue from Billing.");
-    expect(html).toContain("fetch('/billing/checkout'");
-    expect(html).toContain("planSlug: 'matrix_builder'");
-    expect(html).toContain("Checkout unavailable");
-    expect(html).toContain("showCheckoutUnavailableState();");
-    expect(html).toContain("Opening secure checkout");
+    expect(html).not.toContain("fetch('/billing/checkout'");
+    expect(html).not.toContain("planSlug: 'matrix_builder'");
+    expect(html).not.toContain("Checkout unavailable");
+    expect(html).not.toContain("showCheckoutUnavailableState();");
+    expect(html).not.toContain("Opening secure checkout");
     expect(html).toContain("retryProvisioningAfterBillingDelay(developerTools)");
     expect(html).toContain("Confirming billing");
     expect(html).toContain("provisioning_conflict");
@@ -3047,10 +3049,55 @@ describe("platform proxy routing", () => {
     expect(html).toContain("matrix.billing.setupRetryCount");
     expect(html).toContain("var maxBillingSetupReloads = 3;");
     expect(html).toContain("Billing settings are still loading");
-    expect(html).toContain("url.searchParams.set('billing', 'setup');");
+    expect(html).toContain("var billingSetupTarget = ");
+    expect(html).toContain("var url = new URL(billingSetupTarget);");
     expect(html).toContain("window.location.replace(target);");
     expect(html).not.toContain("Open Billing settings");
     expect(html).not.toContain("'Start checkout',\n        startBillingCheckoutFromClerkSession");
+    expect(html).not.toContain("fetch('/billing/checkout'");
+  });
+
+  it("builds billing setup targets on the app origin while preserving device return", () => {
+    expect(buildBillingSetupTarget(
+      "https://app.matrix-os.com",
+      "/?device_return=%2Fauth%2Fdevice%3Fuser_code%3DBCDF-GHJK",
+    )).toBe(
+      "https://app.matrix-os.com/?billing=setup&device_return=%2Fauth%2Fdevice%3Fuser_code%3DBCDF-GHJK",
+    );
+    expect(buildBillingSetupTarget(
+      "https://app.matrix-os.com",
+      "/?device_return=https%3A%2F%2Fevil.example%2Fauth%2Fdevice%3Fuser_code%3DBCDF-GHJK",
+    )).toBe("https://app.matrix-os.com/?billing=setup");
+  });
+
+  it("sends code-domain billing setup handoffs back to the app shell origin", async () => {
+    process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY = "pk_test_matrix";
+    delete process.env.MATRIX_APP_ORIGIN;
+    const app = createApp({
+      db,
+      env: {
+        ...process.env,
+        MATRIX_APP_ORIGIN: "https://staging-app.matrix-os.com",
+      },
+      orchestrator: stubOrchestrator(),
+      clerkAuth: createClerkAuth({
+        verifyToken: vi.fn().mockResolvedValue(null),
+      }),
+      platformSecret: "platform-secret-123",
+    });
+
+    const res = await app.request("/sign-up?device_return=%2Fauth%2Fdevice%3Fuser_code%3DBCDF-GHJK", {
+      headers: { host: "code.matrix-os.com" },
+    });
+
+    expect(res.status).toBe(200);
+    const html = await res.text();
+    expect(html).toContain(
+      'var billingSetupTarget = "https://staging-app.matrix-os.com/?billing=setup\\u0026device_return=%2Fauth%2Fdevice%3Fuser_code%3DBCDF-GHJK";',
+    );
+    expect(html).toContain("var url = new URL(billingSetupTarget);");
+    expect(html).toContain("return url.toString();");
+    expect(html).not.toContain("var url = new URL('/', window.location.origin);");
   });
 
   it("returns billing_required for signed-in app-session exchange before a Stripe entitlement exists", async () => {
@@ -3344,7 +3391,8 @@ describe("platform proxy routing", () => {
     expect(html).toContain("var maxBillingSetupReloads = 3;");
     expect(html).toContain("Billing settings are still loading");
     expect(html).toContain("2000 + retryCount * 1000");
-    expect(html).toContain("url.searchParams.set('billing', 'setup');");
+    expect(html).toContain("var billingSetupTarget = ");
+    expect(html).toContain("var url = new URL(billingSetupTarget);");
     expect(html).toContain("window.location.replace(target);");
     expect(html).not.toContain("Matrix OS shell unavailable");
     expect(html).not.toContain("Open Billing settings");
@@ -3383,7 +3431,8 @@ describe("platform proxy routing", () => {
     expect(html).toContain('var redirectTarget = "/?device_return=%2Fauth%2Fdevice%3Fuser_code%3DBCDF-GHJK";');
     expect(html).toContain('var deviceReturnTarget = "/auth/device?user_code=BCDF-GHJK";');
     expect(html).toContain("Opening Billing settings");
-    expect(html).toContain("url.searchParams.set('billing', 'setup');");
+    expect(html).toContain("var billingSetupTarget = ");
+    expect(html).toContain("var url = new URL(billingSetupTarget);");
     expect(html).toContain("window.location.replace(target);");
     expect(html).toContain("window.location.replace(deviceReturnTarget || payload.redirectTo || redirectTarget);");
     expect(html).toContain("fetch('/api/auth/provision-runtime'");
@@ -3425,7 +3474,8 @@ describe("platform proxy routing", () => {
     expect(html).toContain('var redirectTarget = "/";');
     expect(html).toContain('var deviceReturnTarget = "";');
     expect(html).toContain("Opening Billing settings");
-    expect(html).toContain("url.searchParams.set('billing', 'setup');");
+    expect(html).toContain("var billingSetupTarget = ");
+    expect(html).toContain("var url = new URL(billingSetupTarget);");
     expect(html).toContain("window.location.replace(target);");
     expect(html).not.toContain("Open Billing settings");
     expect(html).not.toContain("Stripe opens only after you continue from Billing.");


### PR DESCRIPTION
## Summary
- Route platform auth-page billing setup through the canonical app shell origin instead of the current host, so code.matrix-os.com handoffs return to app.matrix-os.com billing.
- Remove the inline platform auth-page direct Stripe checkout fallback that could bypass the shell billing/agent-selection flow.
- Add proxy-routing regressions for code-domain billing handoffs and for the absence of direct auth-page checkout launchers.

## Validation
- bun run test -- tests/platform/proxy-routing.test.ts tests/platform/billing-routes.test.ts tests/shell/billing-gate.test.tsx tests/shell/billing-section.test.tsx tests/shell/boot-sequence.test.tsx
- pnpm --filter @matrix-os/platform exec tsc --noEmit -p tsconfig.typecheck.json
- git diff --check

## Invariants
- Source of truth: platform canonical origin helpers remain the source for app-shell origin resolution; Stripe entitlement and customer state stay in platform Postgres.
- Lock/transaction scope: no database writes or transaction boundaries changed.
- Acceptable orphan states: if billing/provisioning is not ready, users stay in the existing billing setup, retry, or provisioning states; no runtime is marked ready by this handoff.
- Auth source of truth: Clerk session tokens remain the browser auth source; device_return is only preserved as a same-origin device path through the existing normalizer.
- Deferred scope: this PR does not change Stripe webhook timing, checkout pricing, or VPS provisioning semantics.