### PR TITLE
refactor(terminal): extract new session menu helpers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -298,7 +298,7 @@ https://github.com/millionco/react-doctor. CI runs this on the project dirs of c
 
 **Focused test reruns**: if `bun run test -- <path>` or `pnpm run test -- <path>` ignores the file filter and fans out into a broad repo run, fall back to `pnpm exec vitest run <path>` (or `pnpm exec vitest <path>` for watch mode) after the usual prerequisite builds are up to date.
 
-**Agent CLI matrix changes need cross-surface sync**: if you add, remove, or rename a supported coding agent, keep `packages/platform/src/developer-tools.ts`, `shell/src/components/terminal/TerminalApp.tsx`, `distro/customer-vps/host-bin/matrix-install-tool-pack`, `tests/platform/agent-install-matrix.ts`, `.github/workflows/agent-install-smoke.yml`, and the user docs aligned. The scheduled smoke path currently exercises `npm,pnpm,bun,yarn`.
+**Agent CLI matrix changes need cross-surface sync**: if you add, remove, or rename a supported coding agent, keep `packages/platform/src/developer-tools.ts`, `shell/src/components/terminal/terminal-agent-options.ts`, `shell/src/components/terminal/TerminalApp.tsx`, `distro/customer-vps/host-bin/matrix-install-tool-pack`, `tests/platform/agent-install-matrix.ts`, `.github/workflows/agent-install-smoke.yml`, and the user docs aligned. The scheduled smoke path currently exercises `npm,pnpm,bun,yarn`.
 
 **Screenshot evidence (mandatory for frontend-facing changes)**: every PR that changes
 user-visible UI, visual styling, layout, frontend copy, app surfaces, or screenshots must include

--- a/shell/src/components/terminal/NewSessionMenu.tsx
+++ b/shell/src/components/terminal/NewSessionMenu.tsx
@@ -1,0 +1,257 @@
+"use client";
+
+import Image from "next/image";
+import { TerminalIcon } from "lucide-react";
+import { useEffect, useEffectEvent, useRef, type CSSProperties, type ReactNode, type RefObject } from "react";
+import {
+  TERMINAL_AGENT_OPTIONS,
+  type TerminalAgentId,
+  type TerminalAgentOption,
+} from "./terminal-agent-options";
+
+const TERMINAL_AGENT_LOGO_STYLE: CSSProperties = {
+  alignItems: "center",
+  border: "1px solid rgba(255, 255, 255, 0.56)",
+  borderRadius: 7,
+  boxShadow: "0 1px 0 rgba(255, 255, 255, 0.36) inset, 0 4px 9px rgba(49, 54, 45, 0.14)",
+  boxSizing: "border-box",
+  color: "#FFFDF7",
+  display: "flex",
+  flex: "0 0 22px",
+  fontFamily: "Inter, system-ui, sans-serif",
+  fontSize: 11,
+  fontWeight: 900,
+  height: 22,
+  justifyContent: "center",
+  letterSpacing: 0,
+  lineHeight: "22px",
+  overflow: "hidden",
+  width: 22,
+};
+
+const TERMINAL_AGENT_LOGO_IMAGE_STYLE: CSSProperties = {
+  display: "block",
+  height: 15,
+  objectFit: "contain",
+  width: 15,
+};
+
+export function NewSessionMenu({
+  align,
+  onClose,
+  onCreateShell,
+  onCreateAgent,
+  agentStatuses,
+  ignoreLightDismissRef,
+}: {
+  align: "left" | "right" | "mobile";
+  onClose: () => void;
+  onCreateShell: () => void;
+  onCreateAgent: (option: TerminalAgentOption, installed: boolean) => void;
+  agentStatuses: Record<TerminalAgentId, boolean> | null;
+  ignoreLightDismissRef?: RefObject<HTMLElement | null>;
+}) {
+  const menuRef = useRef<HTMLDivElement | null>(null);
+  const closeMenu = useEffectEvent(onClose);
+
+  useEffect(() => {
+    const onKeyDown = (event: globalThis.KeyboardEvent) => {
+      if (event.key === "Escape") closeMenu();
+    };
+    const onPointerDown = (event: globalThis.PointerEvent) => {
+      const target = event.target;
+      if (target instanceof Node && menuRef.current?.contains(target)) return;
+      if (target instanceof Node && ignoreLightDismissRef?.current?.contains(target)) return;
+      closeMenu();
+    };
+    document.addEventListener("keydown", onKeyDown);
+    document.addEventListener("pointerdown", onPointerDown, true);
+    return () => {
+      document.removeEventListener("keydown", onKeyDown);
+      document.removeEventListener("pointerdown", onPointerDown, true);
+    };
+  }, [ignoreLightDismissRef]);
+
+  return (
+    <div
+      ref={menuRef}
+      role="menu"
+      aria-label="New session menu"
+      onPointerDown={(event) => event.stopPropagation()}
+      onMouseDown={(event) => event.stopPropagation()}
+      style={{
+        background: "var(--terminal-drawer-card-bg)",
+        border: "1px solid var(--terminal-drawer-card-border)",
+        borderRadius: 9,
+        boxShadow: "0 16px 36px var(--terminal-drawer-card-shadow)",
+        boxSizing: "border-box",
+        display: "flex",
+        flexDirection: "column",
+        gap: 4,
+        padding: 8,
+        position: "absolute",
+        ...(align === "mobile"
+          ? { bottom: "calc(100% + 8px)", left: 0 }
+          : align === "right"
+            ? { right: 0, top: "calc(100% + 8px)" }
+            : { left: "calc(100% + 8px)", top: 0 }),
+        width: 244,
+        zIndex: 120,
+      }}
+    >
+      <div style={{ padding: "0 4px 1px" }}>
+        <div
+          style={{
+            color: "var(--terminal-drawer-subtle)",
+            fontFamily: "Inter, system-ui, sans-serif",
+            fontSize: 12,
+            fontWeight: 800,
+            letterSpacing: "0.08em",
+            lineHeight: "15px",
+            textTransform: "uppercase",
+          }}
+        >
+          NEW TAB
+        </div>
+      </div>
+      <NewSessionMenuItem
+        label="Shell"
+        active
+        icon={(
+          <TerminalIcon
+            aria-hidden="true"
+            size={16}
+            strokeWidth={2.1}
+            style={{ color: "var(--terminal-drawer-selected-stripe)", flexShrink: 0 }}
+          />
+        )}
+        onClick={onCreateShell}
+      />
+      {TERMINAL_AGENT_OPTIONS.map((option) => {
+        const installed = agentStatuses?.[option.id] ?? option.fallbackInstalled;
+        return (
+          <NewSessionMenuItem
+            key={option.id}
+            label={option.label}
+            install={!installed}
+            icon={<TerminalAgentLogo muted={!installed} option={option} />}
+            onClick={() => onCreateAgent(option, installed)}
+          />
+        );
+      })}
+    </div>
+  );
+}
+
+function TerminalAgentLogo({ option, muted }: { option: TerminalAgentOption; muted: boolean }) {
+  return (
+    <span
+      aria-hidden="true"
+      data-testid={`terminal-agent-logo-${option.id}`}
+      style={{
+        ...TERMINAL_AGENT_LOGO_STYLE,
+        background: option.color,
+        opacity: muted ? 0.86 : 1,
+      }}
+    >
+      <Image
+        alt=""
+        data-testid={`terminal-agent-logo-image-${option.id}`}
+        draggable={false}
+        height={17}
+        src={option.logoSrc}
+        style={TERMINAL_AGENT_LOGO_IMAGE_STYLE}
+        width={17}
+      />
+    </span>
+  );
+}
+
+function NewSessionMenuItem({
+  label,
+  icon,
+  active = false,
+  install = false,
+  onClick,
+}: {
+  label: string;
+  icon: ReactNode;
+  active?: boolean;
+  install?: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      role="menuitem"
+      onClick={onClick}
+      style={{
+        alignItems: "center",
+        background: active ? "var(--terminal-drawer-action-bg)" : install ? "var(--terminal-drawer-card-muted-bg)" : "transparent",
+        border: 0,
+        borderRadius: 7,
+        boxSizing: "border-box",
+        color: "var(--terminal-drawer-fg)",
+        cursor: "pointer",
+        display: "flex",
+        flexShrink: 0,
+        gap: 9,
+        height: 32,
+        padding: "0 9px",
+        textAlign: "left",
+      }}
+      onMouseEnter={(event) => {
+        event.currentTarget.style.background = "var(--terminal-drawer-action-bg)";
+      }}
+      onMouseLeave={(event) => {
+        event.currentTarget.style.background = active ? "var(--terminal-drawer-action-bg)" : install ? "var(--terminal-drawer-card-muted-bg)" : "transparent";
+      }}
+    >
+      {icon}
+      <span
+        style={{
+          flex: "1 1 auto",
+          fontFamily: "Inter, system-ui, sans-serif",
+          fontSize: 13,
+          fontWeight: active ? 700 : 600,
+          lineHeight: "17px",
+          minWidth: 0,
+          color: install ? "var(--terminal-drawer-muted)" : "var(--terminal-drawer-fg)",
+        }}
+      >
+        {label}
+      </span>
+      {install ? (
+        <span
+          style={{
+            alignItems: "center",
+            display: "flex",
+            flexShrink: 0,
+            justifyContent: "flex-end",
+          }}
+        >
+          <span
+            data-testid="terminal-agent-install-pill"
+            style={{
+              alignItems: "center",
+              background: "var(--terminal-drawer-action-bg)",
+              border: "1px solid var(--terminal-drawer-action-border)",
+              borderRadius: 999,
+              boxSizing: "border-box",
+              color: "var(--terminal-drawer-action-fg)",
+              display: "flex",
+              fontFamily: "Inter, system-ui, sans-serif",
+              fontSize: 12,
+              fontWeight: 700,
+              height: 18,
+              lineHeight: "14px",
+              padding: "0 6px",
+            }}
+          >
+            Install
+          </span>
+        </span>
+      ) : null}
+    </button>
+  );
+}

--- a/shell/src/components/terminal/TerminalApp.tsx
+++ b/shell/src/components/terminal/TerminalApp.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { createContext, use, useCallback, useEffect, useEffectEvent, useRef, useState, type CSSProperties, type KeyboardEvent, type MouseEventHandler, type PointerEvent as ReactPointerEvent, type PointerEventHandler } from "react";
-import Image from "next/image";
 import {
   BotIcon,
   ChevronLeftIcon,
@@ -22,7 +21,6 @@ import {
   Rows2Icon,
   SearchIcon,
   SquareTerminalIcon,
-  TerminalIcon,
   Trash2Icon,
 } from "lucide-react";
 import { type PaneNode, countPanes as countPanesFromStore, getAllPaneIds } from "@/stores/terminal-store";
@@ -40,6 +38,13 @@ import { isCanonicalShellSessionId, isLegacyPtySessionId } from "./terminal-sess
 import { sessionAccent, twoWordSessionName } from "./terminal-session-names";
 import { TERMINAL_INPUT_EVENT, type TerminalInputEventDetail } from "./terminal-input-event";
 import { MOBILE_TERMINAL_INPUT_ACTIVE_EVENT, type MobileTerminalInputActiveDetail } from "./mobile-terminal-events";
+import { NewSessionMenu } from "./NewSessionMenu";
+import {
+  parseTerminalAgentStatuses,
+  terminalAgentVisibleInstallCommand,
+  type TerminalAgentId,
+  type TerminalAgentOption,
+} from "./terminal-agent-options";
 import {
   applyShellRefreshFailure,
   applyShellRefreshSilentFailure,
@@ -1014,10 +1019,6 @@ function terminalSessionName(prefix = "matrix") {
     return `${safePrefix}-${genId()}`.slice(0, 31);
   }
   return twoWordSessionName();
-}
-
-function shellQuote(value: string) {
-  return `'${value.replaceAll("'", "'\\''")}'`;
 }
 
 async function readShellErrorCode(res: Response): Promise<string | null> {
@@ -3570,127 +3571,6 @@ interface WorkspaceSessionSummary {
   transcriptPath?: string;
 }
 
-type TerminalAgentId = "claude" | "codex" | "opencode" | "pi";
-
-interface TerminalAgentOption {
-  id: TerminalAgentId;
-  label: string;
-  color: string;
-  logoSrc: string;
-  shortcut?: string;
-  launchCommand?: string;
-  installPackage: string;
-  installFlags?: string[];
-  claudeMode?: boolean;
-  fallbackInstalled: boolean;
-}
-
-interface TerminalAgentStatus {
-  id: TerminalAgentId;
-  installed: boolean;
-}
-
-const TERMINAL_AGENT_OPTIONS: TerminalAgentOption[] = [
-  {
-    id: "claude",
-    label: "Claude Code",
-    color: "#D8792C",
-    logoSrc: "/agent-logos/claude-code.png",
-    shortcut: "⌘⇧C",
-    installPackage: "@anthropic-ai/claude-code@latest",
-    claudeMode: true,
-    fallbackInstalled: true,
-  },
-  {
-    id: "codex",
-    label: "Codex",
-    color: "#465243",
-    logoSrc: "/agent-logos/codex.png",
-    shortcut: "⌘⇧X",
-    launchCommand: "codex",
-    installPackage: "@openai/codex@latest",
-    fallbackInstalled: true,
-  },
-  {
-    id: "opencode",
-    label: "OpenCode",
-    color: "#111111",
-    logoSrc: "/agent-logos/opencode-white.png",
-    launchCommand: "opencode",
-    installPackage: "opencode-ai@latest",
-    fallbackInstalled: false,
-  },
-  {
-    id: "pi",
-    label: "Pi",
-    color: "#1E2F5C",
-    logoSrc: "/agent-logos/pi-coding-agent.png",
-    launchCommand: "pi",
-    installPackage: "@earendil-works/pi-coding-agent@latest",
-    installFlags: ["--ignore-scripts"],
-    fallbackInstalled: false,
-  },
-];
-
-const TERMINAL_AGENT_LOGO_STYLE: CSSProperties = {
-  alignItems: "center",
-  border: "1px solid rgba(255, 255, 255, 0.56)",
-  borderRadius: 7,
-  boxShadow: "0 1px 0 rgba(255, 255, 255, 0.36) inset, 0 4px 9px rgba(49, 54, 45, 0.14)",
-  boxSizing: "border-box",
-  color: "#FFFDF7",
-  display: "flex",
-  flex: "0 0 22px",
-  fontFamily: "Inter, system-ui, sans-serif",
-  fontSize: 11,
-  fontWeight: 900,
-  height: 22,
-  justifyContent: "center",
-  letterSpacing: 0,
-  lineHeight: "22px",
-  overflow: "hidden",
-  width: 22,
-};
-
-const TERMINAL_AGENT_LOGO_IMAGE_STYLE: CSSProperties = {
-  display: "block",
-  height: 15,
-  objectFit: "contain",
-  width: 15,
-};
-
-function isTerminalAgentId(value: unknown): value is TerminalAgentId {
-  return value === "claude" || value === "codex" || value === "opencode" || value === "pi";
-}
-
-function parseTerminalAgentStatuses(value: unknown): TerminalAgentStatus[] {
-  if (!value || typeof value !== "object" || !("agents" in value) || !Array.isArray(value.agents)) {
-    return [];
-  }
-  return value.agents
-    .filter((agent): agent is { id: TerminalAgentId; installed: boolean } => (
-      Boolean(agent) &&
-      typeof agent === "object" &&
-      isTerminalAgentId((agent as { id?: unknown }).id) &&
-      typeof (agent as { installed?: unknown }).installed === "boolean"
-    ))
-    .map((agent) => ({ id: agent.id, installed: agent.installed }));
-}
-
-function terminalAgentInstallCommand(option: TerminalAgentOption): string {
-  const flags = option.installFlags?.join(" ") ?? "";
-  const extraFlags = flags ? `${flags} ` : "";
-  return [
-    'export MATRIX_NODE_PREFIX="${MATRIX_NODE_PREFIX:-/opt/matrix/runtime/node}"',
-    `npm install -g ${extraFlags}--prefix "$MATRIX_NODE_PREFIX" ${option.installPackage}`,
-  ].join("; ");
-}
-
-function terminalAgentVisibleInstallCommand(option: TerminalAgentOption): string {
-  const command = terminalAgentInstallCommand(option);
-  return `sh -lc ${shellQuote(`printf '%s\\n' ${shellQuote(command)}; ${command}; exec "\${SHELL:-sh}" -l`)}`;
-}
-
 function getShellTabCount(shell: ShellSessionSummary): number | null {
   if (!Array.isArray(shell.tabs)) return null;
   return shell.tabs.reduce((count, tab) => {
@@ -4833,228 +4713,6 @@ function formatCloseConfirmationMeta(shell: ShellSessionSummary): string {
     ? Math.max(0, shell.latestSeq - shell.lastSeenSeq)
     : shell.unread ? 1 : 0;
   return unreadCount > 0 ? `${placement} · ${unreadCount} unread` : placement;
-}
-
-function NewSessionMenu({
-  align,
-  onClose,
-  onCreateShell,
-  onCreateAgent,
-  agentStatuses,
-  ignoreLightDismissRef,
-}: {
-  align: "left" | "right" | "mobile";
-  onClose: () => void;
-  onCreateShell: () => void;
-  onCreateAgent: (option: TerminalAgentOption, installed: boolean) => void;
-  agentStatuses: Record<TerminalAgentId, boolean> | null;
-  ignoreLightDismissRef?: React.RefObject<HTMLElement | null>;
-}) {
-  const menuRef = useRef<HTMLDivElement | null>(null);
-  const closeMenu = useEffectEvent(onClose);
-
-  useEffect(() => {
-    const onKeyDown = (event: globalThis.KeyboardEvent) => {
-      if (event.key === "Escape") closeMenu();
-    };
-    const onPointerDown = (event: globalThis.PointerEvent) => {
-      const target = event.target;
-      if (target instanceof Node && menuRef.current?.contains(target)) return;
-      if (target instanceof Node && ignoreLightDismissRef?.current?.contains(target)) return;
-      closeMenu();
-    };
-    document.addEventListener("keydown", onKeyDown);
-    document.addEventListener("pointerdown", onPointerDown, true);
-    return () => {
-      document.removeEventListener("keydown", onKeyDown);
-      document.removeEventListener("pointerdown", onPointerDown, true);
-    };
-  }, [ignoreLightDismissRef]);
-
-  return (
-    <div
-      ref={menuRef}
-      role="menu"
-      aria-label="New session menu"
-      onPointerDown={(event) => event.stopPropagation()}
-      onMouseDown={(event) => event.stopPropagation()}
-      style={{
-        background: "var(--terminal-drawer-card-bg)",
-        border: "1px solid var(--terminal-drawer-card-border)",
-        borderRadius: 9,
-        boxShadow: "0 16px 36px var(--terminal-drawer-card-shadow)",
-        boxSizing: "border-box",
-        display: "flex",
-        flexDirection: "column",
-        gap: 4,
-        padding: 8,
-        position: "absolute",
-        ...(align === "mobile"
-          ? { bottom: "calc(100% + 8px)", left: 0 }
-          : align === "right"
-          ? { right: 0, top: "calc(100% + 8px)" }
-          : { left: "calc(100% + 8px)", top: 0 }),
-        width: 244,
-        // Sits above the collapsed rail's right divider and the terminal
-        // content so the NEW TAB menu never paints behind that edge.
-        zIndex: 120,
-      }}
-    >
-      <div style={{ padding: "0 4px 1px" }}>
-        <div
-          style={{
-            color: "var(--terminal-drawer-subtle)",
-            fontFamily: "Inter, system-ui, sans-serif",
-            fontSize: 12,
-            fontWeight: 800,
-            letterSpacing: "0.08em",
-            lineHeight: "15px",
-            textTransform: "uppercase",
-          }}
-        >
-          NEW TAB
-        </div>
-      </div>
-      <NewSessionMenuItem
-        label="Shell"
-        active
-        icon={(
-          <TerminalIcon
-            aria-hidden="true"
-            size={16}
-            strokeWidth={2.1}
-            style={{ color: "var(--terminal-drawer-selected-stripe)", flexShrink: 0 }}
-          />
-        )}
-        onClick={onCreateShell}
-      />
-      {TERMINAL_AGENT_OPTIONS.map((option) => {
-        const installed = agentStatuses?.[option.id] ?? option.fallbackInstalled;
-        return (
-          <NewSessionMenuItem
-            key={option.id}
-            label={option.label}
-            install={!installed}
-            icon={<TerminalAgentLogo muted={!installed} option={option} />}
-            onClick={() => onCreateAgent(option, installed)}
-          />
-        );
-      })}
-    </div>
-  );
-}
-
-function TerminalAgentLogo({ option, muted }: { option: TerminalAgentOption; muted: boolean }) {
-  return (
-    <span
-      aria-hidden="true"
-      data-testid={`terminal-agent-logo-${option.id}`}
-      style={{
-        ...TERMINAL_AGENT_LOGO_STYLE,
-        background: option.color,
-        opacity: muted ? 0.86 : 1,
-      }}
-    >
-      <Image
-        alt=""
-        data-testid={`terminal-agent-logo-image-${option.id}`}
-        draggable={false}
-        height={17}
-        src={option.logoSrc}
-        style={TERMINAL_AGENT_LOGO_IMAGE_STYLE}
-        width={17}
-      />
-    </span>
-  );
-}
-
-function NewSessionMenuItem({
-  label,
-  icon,
-  active = false,
-  install = false,
-  onClick,
-}: {
-  label: string;
-  icon: React.ReactNode;
-  active?: boolean;
-  install?: boolean;
-  onClick: () => void;
-}) {
-  return (
-    <button
-      type="button"
-      role="menuitem"
-      onClick={onClick}
-      style={{
-        alignItems: "center",
-        background: active ? "var(--terminal-drawer-action-bg)" : install ? "var(--terminal-drawer-card-muted-bg)" : "transparent",
-        border: 0,
-        borderRadius: 7,
-        boxSizing: "border-box",
-        color: "var(--terminal-drawer-fg)",
-        cursor: "pointer",
-        display: "flex",
-        flexShrink: 0,
-        gap: 9,
-        height: 32,
-        padding: "0 9px",
-        textAlign: "left",
-      }}
-      onMouseEnter={(event) => {
-        event.currentTarget.style.background = "var(--terminal-drawer-action-bg)";
-      }}
-      onMouseLeave={(event) => {
-        event.currentTarget.style.background = active ? "var(--terminal-drawer-action-bg)" : install ? "var(--terminal-drawer-card-muted-bg)" : "transparent";
-      }}
-    >
-      {icon}
-      <span
-        style={{
-          flex: "1 1 auto",
-          fontFamily: "Inter, system-ui, sans-serif",
-          fontSize: 13,
-          fontWeight: active ? 700 : 600,
-          lineHeight: "17px",
-          minWidth: 0,
-          color: install ? "var(--terminal-drawer-muted)" : "var(--terminal-drawer-fg)",
-        }}
-      >
-        {label}
-      </span>
-      {install ? (
-        <span
-          style={{
-            alignItems: "center",
-            display: "flex",
-            flexShrink: 0,
-            justifyContent: "flex-end",
-          }}
-        >
-          <span
-            data-testid="terminal-agent-install-pill"
-            style={{
-              alignItems: "center",
-              background: "var(--terminal-drawer-action-bg)",
-              border: "1px solid var(--terminal-drawer-action-border)",
-              borderRadius: 999,
-              boxSizing: "border-box",
-              color: "var(--terminal-drawer-action-fg)",
-              display: "flex",
-              fontFamily: "Inter, system-ui, sans-serif",
-              fontSize: 12,
-              fontWeight: 700,
-              height: 18,
-              lineHeight: "14px",
-              padding: "0 6px",
-            }}
-          >
-            Install
-          </span>
-        </span>
-      ) : null}
-    </button>
-  );
 }
 
 function ShellCloseConfirmation({

--- a/shell/src/components/terminal/terminal-agent-options.ts
+++ b/shell/src/components/terminal/terminal-agent-options.ts
@@ -1,0 +1,97 @@
+export type TerminalAgentId = "claude" | "codex" | "opencode" | "pi";
+
+export interface TerminalAgentOption {
+  id: TerminalAgentId;
+  label: string;
+  color: string;
+  logoSrc: string;
+  shortcut?: string;
+  launchCommand?: string;
+  installPackage: string;
+  installFlags?: string[];
+  claudeMode?: boolean;
+  fallbackInstalled: boolean;
+}
+
+export interface TerminalAgentStatus {
+  id: TerminalAgentId;
+  installed: boolean;
+}
+
+export const TERMINAL_AGENT_OPTIONS: TerminalAgentOption[] = [
+  {
+    id: "claude",
+    label: "Claude Code",
+    color: "#D8792C",
+    logoSrc: "/agent-logos/claude-code.png",
+    shortcut: "⌘⇧C",
+    installPackage: "@anthropic-ai/claude-code@latest",
+    claudeMode: true,
+    fallbackInstalled: true,
+  },
+  {
+    id: "codex",
+    label: "Codex",
+    color: "#465243",
+    logoSrc: "/agent-logos/codex.png",
+    shortcut: "⌘⇧X",
+    launchCommand: "codex",
+    installPackage: "@openai/codex@latest",
+    fallbackInstalled: true,
+  },
+  {
+    id: "opencode",
+    label: "OpenCode",
+    color: "#111111",
+    logoSrc: "/agent-logos/opencode-white.png",
+    launchCommand: "opencode",
+    installPackage: "opencode-ai@latest",
+    fallbackInstalled: false,
+  },
+  {
+    id: "pi",
+    label: "Pi",
+    color: "#1E2F5C",
+    logoSrc: "/agent-logos/pi-coding-agent.png",
+    launchCommand: "pi",
+    installPackage: "@earendil-works/pi-coding-agent@latest",
+    installFlags: ["--ignore-scripts"],
+    fallbackInstalled: false,
+  },
+];
+
+export function isTerminalAgentId(value: unknown): value is TerminalAgentId {
+  return value === "claude" || value === "codex" || value === "opencode" || value === "pi";
+}
+
+export function parseTerminalAgentStatuses(value: unknown): TerminalAgentStatus[] {
+  if (!value || typeof value !== "object" || !("agents" in value) || !Array.isArray(value.agents)) {
+    return [];
+  }
+  return value.agents
+    .filter((agent): agent is { id: TerminalAgentId; installed: boolean } => (
+      Boolean(agent) &&
+      typeof agent === "object" &&
+      isTerminalAgentId((agent as { id?: unknown }).id) &&
+      typeof (agent as { installed?: unknown }).installed === "boolean"
+    ))
+    .map((agent) => ({ id: agent.id, installed: agent.installed }));
+}
+
+export function terminalAgentInstallCommand(option: TerminalAgentOption): string {
+  const flags = option.installFlags?.join(" ") ?? "";
+  const extraFlags = flags ? `${flags} ` : "";
+  return [
+    'export MATRIX_NODE_PREFIX="${MATRIX_NODE_PREFIX:-/opt/matrix/runtime/node}"',
+    `npm install -g ${extraFlags}--prefix "$MATRIX_NODE_PREFIX" ${option.installPackage}`,
+  ].join("; ");
+}
+
+export function terminalAgentVisibleInstallCommand(option: TerminalAgentOption): string {
+  const command = terminalAgentInstallCommand(option);
+  return `sh -lc ${shellQuote(`printf '%s\\n' ${shellQuote(command)}; ${command}; exec "\${SHELL:-sh}" -l`)}`;
+}
+
+function shellQuote(value: string): string {
+  return `'${value.replaceAll("'", "'\\''")}'`;
+}

--- a/specs/104-terminal-refactor-foundation/spec.md
+++ b/specs/104-terminal-refactor-foundation/spec.md
@@ -1,0 +1,100 @@
+# Feature Specification: Terminal Refactor Foundation
+
+**Feature Branch**: `codex/104-terminal-refactor-foundation`
+**Created**: 2026-07-02
+**Status**: In Progress
+**Input**: User request: "do a proper spec/task list for this in a new worktree ... start working on this" after identifying `TerminalApp.tsx` as a 6,000+ LOC refactor hotspot.
+
+## Scope Boundary
+
+This spec owns behavior-preserving refactors that reduce the size and coupling of the shell terminal surface. It does not change terminal runtime semantics, zellij session behavior, WebSocket protocols, native app support, or customer VPS deployment flows.
+
+The parallel `/home/deploy/matrix-os.worktrees/native-linux-apps-mvp/` worktree owns native Linux app support. This work must avoid native app runtime files and app packaging behavior unless a later explicit integration task coordinates both branches.
+
+## User Scenarios & Testing
+
+### User Story 1 - Safer Terminal Iteration (Priority: P1)
+
+An engineer changing terminal session UI can work in focused modules instead of editing one giant component that owns session layout, agent launchers, mobile actions, shell rows, file tree state, and terminal chrome at once.
+
+**Independent Test**: Terminal session/agent helper behavior is covered by focused unit tests, and existing `TerminalApp` component tests continue to pass after extraction.
+
+**Acceptance Scenarios**:
+
+1. **Given** terminal agent menu helpers are extracted, **When** tests import them directly, **Then** install command generation and agent-status parsing are verified without rendering `TerminalApp`.
+2. **Given** `TerminalApp` renders the new-session menu, **When** users choose Shell, Claude, Codex, OpenCode, or Pi, **Then** existing menu behavior and labels remain unchanged.
+3. **Given** a future session-sidebar change, **When** the engineer edits session refresh logic, **Then** unrelated file-tree and agent-logo code does not need to be touched.
+
+### User Story 2 - Incremental Extraction Without Regression (Priority: P1)
+
+A developer can land refactor slices one at a time with small diffs, preserving terminal behavior and the existing test contract at every step.
+
+**Independent Test**: Each extraction slice must pass focused shell terminal tests plus `bun run check:patterns`; broader typecheck/test gates are run before PR readiness when feasible.
+
+**Acceptance Scenarios**:
+
+1. **Given** a refactor slice moves code out of `TerminalApp.tsx`, **When** tests run, **Then** no user-visible terminal behavior changes.
+2. **Given** a slice would touch runtime or backend behavior, **When** the change is reviewed, **Then** it is either split into a separate spec or explicitly added to this spec with auth/resource invariants.
+3. **Given** the native Linux app worktree is active, **When** this branch changes files, **Then** it does not edit native-app support files.
+
+## Requirements
+
+### Functional Requirements
+
+- **FR-001**: Extract terminal new-session/agent menu model code from `TerminalApp.tsx` into a focused terminal module with direct tests.
+- **FR-002**: Extract the new-session menu component from `TerminalApp.tsx` into a focused component file while preserving DOM roles, labels, styling, and light-dismiss behavior.
+- **FR-003**: Keep `TerminalApp` as the composition owner during this PR; do not rewrite terminal layout/session runtime behavior in the same slice.
+- **FR-004**: Keep all external calls timeout-guarded and preserve existing safe user-facing error messages.
+- **FR-005**: Preserve existing mobile and desktop terminal menu behavior, including visible install commands that run in a foreground terminal session.
+- **FR-006**: Add follow-up tasks for larger extractions: shell/session sidebar controller, shell row/card components, project/file sidebar modules, and terminal layout controller.
+- **FR-007**: Document the native app support branch as out of scope for this PR.
+
+### Non-Goals
+
+- Replacing xterm, zellij, terminal WebSocket protocols, or gateway terminal routes.
+- Adding new dependencies.
+- Changing native app runtime support.
+- Refactoring `packages/platform/src/main.ts`, `packages/gateway/src/server.ts`, or `packages/platform/src/db.ts` in this PR.
+- Changing terminal visual design beyond preserving existing styles in extracted components.
+
+## Security Architecture
+
+### Auth Matrix
+
+| Surface | Actor | Required Authorization | Notes |
+| --- | --- | --- | --- |
+| Terminal agent install session | Runtime owner | Existing terminal session creation auth | This PR preserves existing foreground install command behavior. |
+| Terminal session menu | Runtime owner | Existing shell access | UI-only extraction; no new route or privilege. |
+| Terminal helper tests | Developer | Local test only | No production surface. |
+
+### Input Validation and Error Policy
+
+- Agent IDs remain allowlisted to `claude`, `codex`, `opencode`, and `pi`.
+- Parsed `/api/agents` responses must ignore unknown IDs and malformed install status values.
+- Generated install commands must preserve shell quoting and the `/opt/matrix/runtime/node` default prefix.
+- No raw provider, filesystem, or platform errors may be introduced into user-facing menu copy.
+
+### Resource Management
+
+- This PR must not add new in-memory registries, timers, WebSocket subscribers, or polling loops.
+- Extracted menu light-dismiss listeners must still be removed on unmount.
+
+### Integration Wiring
+
+- `TerminalApp` remains the parent for `createShellSessionTab`.
+- `NewSessionMenu` receives callbacks and parsed status state via props.
+- Agent command helpers are pure and testable without React.
+
+## Success Criteria
+
+- **SC-001**: `TerminalApp.tsx` loses the terminal agent option/model code and new-session menu component without behavior changes.
+- **SC-002**: New focused tests cover agent status parsing, install command construction, and visible install command wrapping.
+- **SC-003**: Existing terminal app component tests for new-session menu and agent install state continue to pass.
+- **SC-004**: `bun run check:patterns` reports 0 violations.
+- **SC-005**: The PR description lists the native Linux app worktree as intentionally out of scope.
+
+## Assumptions
+
+- The safest first slice is extracting pure terminal agent/menu code, not changing runtime lifecycle behavior.
+- Larger state-machine extractions should follow once the menu/model code has a reviewed module boundary.
+- The native Linux app support branch may later touch app runtime and launcher surfaces; this branch should stay terminal-only.

--- a/specs/104-terminal-refactor-foundation/tasks.md
+++ b/specs/104-terminal-refactor-foundation/tasks.md
@@ -1,0 +1,38 @@
+# Tasks: Terminal Refactor Foundation
+
+## Phase 1 - Spec and Safety Boundary
+
+- [x] T001 Create `specs/104-terminal-refactor-foundation/spec.md` with scope, auth/resource invariants, non-goals, and native Linux app worktree boundary.
+- [x] T002 Create this task list with incremental extraction phases.
+- [x] T003 Include PR body note that `/home/deploy/matrix-os.worktrees/native-linux-apps-mvp/` is out of scope and was not modified.
+
+## Phase 2 - First Extraction Slice
+
+- [x] T004 Add focused tests for terminal agent status parsing and install command generation.
+- [x] T005 Extract terminal agent option types, status parsing, and install command helpers from `TerminalApp.tsx` to `shell/src/components/terminal/terminal-agent-options.ts`.
+- [x] T006 Extract `NewSessionMenu`, `NewSessionMenuItem`, and `TerminalAgentLogo` from `TerminalApp.tsx` to `shell/src/components/terminal/NewSessionMenu.tsx`.
+- [x] T007 Update `TerminalApp.tsx` imports/usages and remove now-local agent/menu code.
+
+## Phase 3 - Verification
+
+- [x] T008 Run focused helper tests: `bun run test -- tests/shell/terminal-agent-options.test.ts`.
+- [x] T009 Run focused terminal component tests that cover the new-session menu: `bun run test -- tests/shell/terminal-app-component.test.tsx`.
+- [x] T010 Run `bun run check:patterns`.
+- [x] T011 Run `bun run typecheck` if the worktree is hydrated enough for broad validation; otherwise record the exact environment blocker.
+
+## Phase 4 - PR and Monitoring
+
+- [x] T012 Commit with a Conventional Commit message.
+- [x] T013 Push `codex/104-terminal-refactor-foundation`.
+- [x] T014 Open PR with `Summary`, `Tests`, `Review/Monitoring`, and `Invariants`.
+- [ ] T015 Monitor review feedback until latest trusted Greptile is `5/5`.
+- [ ] T016 Add `ready-for-ci` only after Greptile is `5/5`.
+- [ ] T017 Monitor label-triggered CI to completion.
+
+## Deferred Follow-Up Refactors
+
+- [ ] F001 Extract shell/session sidebar state controller from `LocalTerminalSidebar`.
+- [ ] F002 Split shell cards, collapsed rail, session cards, project cards, and file tree into separate files.
+- [ ] F003 Extract terminal layout persistence/hydration controller from `TerminalApp`.
+- [ ] F004 Split `tests/shell/terminal-app-component.test.tsx` by behavior area.
+- [ ] F005 Plan separate platform/gateway/database refactor specs for `packages/platform/src/main.ts`, `packages/gateway/src/server.ts`, and `packages/platform/src/db.ts`.

--- a/tests/platform/agent-cli-install-matrix.test.ts
+++ b/tests/platform/agent-cli-install-matrix.test.ts
@@ -13,11 +13,13 @@ describe("agent CLI install matrix", () => {
 
   it("keeps Terminal install rows on direct npm commands with the Matrix node prefix fallback", () => {
     const terminalApp = readFileSync(join(root, "shell/src/components/terminal/TerminalApp.tsx"), "utf8");
+    const terminalAgentOptions = readFileSync(join(root, "shell/src/components/terminal/terminal-agent-options.ts"), "utf8");
 
-    expect(terminalApp).toContain('export MATRIX_NODE_PREFIX="${MATRIX_NODE_PREFIX:-/opt/matrix/runtime/node}"');
+    expect(terminalApp).toContain("terminalAgentVisibleInstallCommand");
+    expect(terminalAgentOptions).toContain('export MATRIX_NODE_PREFIX="${MATRIX_NODE_PREFIX:-/opt/matrix/runtime/node}"');
 
     for (const agent of AGENT_INSTALLS) {
-      expect(terminalApp).toContain(`installPackage: "${agent.npmPackage}"`);
+      expect(terminalAgentOptions).toContain(`installPackage: "${agent.npmPackage}"`);
       expect(terminalNpmInstallCommand(agent)).toContain(`--prefix "$MATRIX_NODE_PREFIX" ${agent.npmPackage}`);
       if (agent.ignoreScripts) {
         expect(terminalNpmInstallCommand(agent)).toContain("npm install -g --ignore-scripts --prefix");
@@ -26,8 +28,8 @@ describe("agent CLI install matrix", () => {
       }
     }
 
-    expect(terminalApp).not.toContain("matrix-install-tool-pack");
-    expect(terminalApp).not.toContain("MATRIX_INSTALL_TOOL_PACK");
+    expect(`${terminalApp}\n${terminalAgentOptions}`).not.toContain("matrix-install-tool-pack");
+    expect(`${terminalApp}\n${terminalAgentOptions}`).not.toContain("MATRIX_INSTALL_TOOL_PACK");
   });
 
   it("defines npm-compatible install commands for popular package managers", () => {

--- a/tests/shell/terminal-agent-options.test.ts
+++ b/tests/shell/terminal-agent-options.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import {
+  TERMINAL_AGENT_OPTIONS,
+  parseTerminalAgentStatuses,
+  terminalAgentInstallCommand,
+  terminalAgentVisibleInstallCommand,
+} from "../../shell/src/components/terminal/terminal-agent-options.js";
+
+describe("terminal agent options", () => {
+  it("parses only allowlisted agent install statuses", () => {
+    expect(parseTerminalAgentStatuses({
+      agents: [
+        { id: "claude", installed: true },
+        { id: "codex", installed: false },
+        { id: "unknown", installed: true },
+        { id: "pi", installed: "yes" },
+        null,
+      ],
+    })).toEqual([
+      { id: "claude", installed: true },
+      { id: "codex", installed: false },
+    ]);
+  });
+
+  it("builds foreground install commands with the runtime node prefix", () => {
+    const codex = TERMINAL_AGENT_OPTIONS.find((option) => option.id === "codex");
+    expect(codex).toBeDefined();
+
+    expect(terminalAgentInstallCommand(codex!)).toBe(
+      'export MATRIX_NODE_PREFIX="${MATRIX_NODE_PREFIX:-/opt/matrix/runtime/node}"; npm install -g --prefix "$MATRIX_NODE_PREFIX" @openai/codex@latest',
+    );
+  });
+
+  it("preserves agent-specific install flags in visible installer sessions", () => {
+    const pi = TERMINAL_AGENT_OPTIONS.find((option) => option.id === "pi");
+    expect(pi).toBeDefined();
+
+    const command = terminalAgentVisibleInstallCommand(pi!);
+    expect(command).toContain("sh -lc ");
+    expect(command).toContain("--ignore-scripts --prefix");
+    expect(command).toContain("@earendil-works/pi-coding-agent@latest");
+    expect(command).toContain('exec "${SHELL:-sh}" -l');
+  });
+});


### PR DESCRIPTION
## Summary

- Adds a scoped spec/task list for the Terminal refactor foundation.
- Extracts terminal agent option/status/install-command helpers from `TerminalApp.tsx`.
- Extracts the new-session menu UI into `NewSessionMenu.tsx` while keeping `TerminalApp` as the composition owner.
- Keeps `/home/deploy/matrix-os.worktrees/native-linux-apps-mvp/` out of scope and untouched.

## Tests

- `bun run test -- tests/shell/terminal-agent-options.test.ts`
- `bun run test -- tests/platform/agent-cli-install-matrix.test.ts`
- `bun run test -- tests/shell/terminal-app-component.test.tsx`
- `bun run test -- tests/platform/customer-vps.test.ts`
- `bun run test -- tests/platform/proxy-routing.test.ts`
- `bun run check:patterns` (0 violations; existing warning buckets only)
- `bun run typecheck`
- `git diff --check`

Full `bun run test` was attempted and ran for ~25 minutes, but exited nonzero under full-suite load after the in-scope install-contract assertion and several platform timeout/runner-load failures. The in-scope install-contract failure was fixed and rerun green. The platform timeout files both pass in isolation (`customer-vps`: 59/59, `proxy-routing`: 128/128).

## Review/Monitoring

- Wait for trusted Greptile review on the latest head.
- Add `ready-for-ci` only after Greptile is 5/5.
- Monitor label-triggered CI after the label is applied.

## Invariants

- No backend routes, auth, database, zellij, WebSocket, or native app runtime behavior changes.
- Foreground agent install commands still use the `MATRIX_NODE_PREFIX` fallback to `/opt/matrix/runtime/node`.
- Unknown/malformed agent install status payloads remain ignored.
