### PR TITLE
refactor(platform): extract app domain service worker

### DIFF
--- a/packages/platform/src/app-domain-service-worker.ts
+++ b/packages/platform/src/app-domain-service-worker.ts
@@ -1,0 +1,95 @@
+const APP_DOMAIN_SAFE_SERVICE_WORKER = `
+const VERSION = "app-v1";
+const CACHE_STATIC = "matrix-os-static-" + VERSION;
+
+self.addEventListener("install", () => {
+  self.skipWaiting();
+});
+
+self.addEventListener("activate", (event) => {
+  event.waitUntil((async () => {
+    const keys = await caches.keys();
+    await Promise.all(keys
+      .filter((key) => key.startsWith("matrix-os-static-") && key !== CACHE_STATIC)
+      .map((key) => caches.delete(key)));
+    await self.clients.claim();
+  })());
+});
+
+function isBypassed(url) {
+  if (url.origin !== self.location.origin) return true;
+  const p = url.pathname;
+  return (
+    p.startsWith("/api/") ||
+    p.startsWith("/v1/") ||
+    p.startsWith("/clerk") ||
+    p.startsWith("/_clerk") ||
+    p.startsWith("/__clerk") ||
+    p.startsWith("/__session") ||
+    p.startsWith("/sign-in") ||
+    p.startsWith("/sign-up") ||
+    p.startsWith("/files/apps/") ||
+    p.includes("/__nextjs_") ||
+    p.startsWith("/_next/data/")
+  );
+}
+
+function isStaticAsset(url) {
+  const p = url.pathname;
+  return (
+    p.startsWith("/_next/static/") ||
+    p.startsWith("/icons/") ||
+    p.startsWith("/wallpapers/") ||
+    p.startsWith("/files/system/wallpapers/") ||
+    p.startsWith("/textures/") ||
+    p.startsWith("/fonts/") ||
+    /\\.(?:png|jpg|jpeg|svg|webp|woff2?|ttf|css|js|wav|mp3)$/.test(p)
+  );
+}
+
+self.addEventListener("fetch", (event) => {
+  const req = event.request;
+  if (req.method !== "GET") return;
+  const url = new URL(req.url);
+  if (isBypassed(url) || !isStaticAsset(url)) return;
+  event.respondWith(cacheFirst(req));
+});
+
+async function cacheFirst(req) {
+  const cache = await caches.open(CACHE_STATIC);
+  const cached = await cache.match(req);
+  if (cached) return cached;
+  try {
+    const res = await fetch(req, { signal: AbortSignal.timeout(30000) });
+    if (res.ok && res.type === "basic") {
+      cache.put(req, res.clone()).catch((err) => {
+        console.warn("[app sw] static cache put failed:", err?.message ?? err);
+      });
+    }
+    return res;
+  } catch (_err) {
+    return new Response("offline", {
+      status: 504,
+      headers: {
+        "content-type": "text/plain; charset=utf-8",
+        "cache-control": "no-store",
+      },
+    });
+  }
+}
+`.trim();
+
+export function appDomainServiceWorkerResponse(): Response {
+  return new Response(APP_DOMAIN_SAFE_SERVICE_WORKER, {
+    status: 200,
+    headers: {
+      'content-type': 'text/javascript; charset=utf-8',
+      'cache-control': 'no-store, private',
+      'cdn-cache-control': 'no-store',
+      'cloudflare-cdn-cache-control': 'no-store',
+      'pragma': 'no-cache',
+      'expires': '0',
+      'service-worker-allowed': '/',
+    },
+  });
+}

--- a/packages/platform/src/main.ts
+++ b/packages/platform/src/main.ts
@@ -94,6 +94,7 @@ import {
 import { createBillingRoutes } from './billing-routes.js';
 import { createJourneyRoutes, createJourneyUserResolver } from './journey-routes.js';
 import { backfillFirstRunRecords } from './journey.js';
+import { appDomainServiceWorkerResponse } from './app-domain-service-worker.js';
 import { appOrigin } from './origins.js';
 import {
   createStripeBillingClient,
@@ -714,102 +715,6 @@ function applyNoStoreResponseHeaders(headers: Headers): void {
   headers.set('cloudflare-cdn-cache-control', 'no-store');
   headers.set('pragma', 'no-cache');
   headers.set('expires', '0');
-}
-
-const APP_DOMAIN_SAFE_SERVICE_WORKER = `
-const VERSION = "app-v1";
-const CACHE_STATIC = "matrix-os-static-" + VERSION;
-
-self.addEventListener("install", () => {
-  self.skipWaiting();
-});
-
-self.addEventListener("activate", (event) => {
-  event.waitUntil((async () => {
-    const keys = await caches.keys();
-    await Promise.all(keys
-      .filter((key) => key.startsWith("matrix-os-static-") && key !== CACHE_STATIC)
-      .map((key) => caches.delete(key)));
-    await self.clients.claim();
-  })());
-});
-
-function isBypassed(url) {
-  if (url.origin !== self.location.origin) return true;
-  const p = url.pathname;
-  return (
-    p.startsWith("/api/") ||
-    p.startsWith("/v1/") ||
-    p.startsWith("/clerk") ||
-    p.startsWith("/_clerk") ||
-    p.startsWith("/__clerk") ||
-    p.startsWith("/__session") ||
-    p.startsWith("/sign-in") ||
-    p.startsWith("/sign-up") ||
-    p.startsWith("/files/apps/") ||
-    p.includes("/__nextjs_") ||
-    p.startsWith("/_next/data/")
-  );
-}
-
-function isStaticAsset(url) {
-  const p = url.pathname;
-  return (
-    p.startsWith("/_next/static/") ||
-    p.startsWith("/icons/") ||
-    p.startsWith("/wallpapers/") ||
-    p.startsWith("/files/system/wallpapers/") ||
-    p.startsWith("/textures/") ||
-    p.startsWith("/fonts/") ||
-    /\\.(?:png|jpg|jpeg|svg|webp|woff2?|ttf|css|js|wav|mp3)$/.test(p)
-  );
-}
-
-self.addEventListener("fetch", (event) => {
-  const req = event.request;
-  if (req.method !== "GET") return;
-  const url = new URL(req.url);
-  if (isBypassed(url) || !isStaticAsset(url)) return;
-  event.respondWith(cacheFirst(req));
-});
-
-async function cacheFirst(req) {
-  const cache = await caches.open(CACHE_STATIC);
-  const cached = await cache.match(req);
-  if (cached) return cached;
-  try {
-    const res = await fetch(req, { signal: AbortSignal.timeout(30000) });
-    if (res.ok && res.type === "basic") {
-      cache.put(req, res.clone()).catch((err) => {
-        console.warn("[app sw] static cache put failed:", err?.message ?? err);
-      });
-    }
-    return res;
-  } catch (_err) {
-    return new Response("offline", {
-      status: 504,
-      headers: {
-        "content-type": "text/plain; charset=utf-8",
-        "cache-control": "no-store",
-      },
-    });
-  }
-}
-`.trim();
-
-function appDomainServiceWorkerResponse(): Response {
-  return new Response(APP_DOMAIN_SAFE_SERVICE_WORKER, {
-    status: 200,
-    headers: {
-      'content-type': 'text/javascript; charset=utf-8',
-      'cache-control': 'no-store, private',
-      'cdn-cache-control': 'no-store',
-      'cloudflare-cdn-cache-control': 'no-store',
-      'pragma': 'no-cache',
-      'expires': '0',
-      'service-worker-allowed': '/',
-    },
-  });
 }
 
 function isPostHogRelayPath(path: string): boolean {


### PR DESCRIPTION
## Summary

- Move the app-domain safe service worker body and response builder out of `platform/src/main.ts`.
- Keep the service-worker response headers and script content unchanged.
- Reduce `packages/platform/src/main.ts` from 5062 LOC to 4967 LOC.

## Tests

- `bun run test -- tests/platform/proxy-routing.test.ts -t "serves the safe app-domain service worker without auth"`
- `bun run typecheck`
- `bun run check:patterns`
- `git diff --check`

## Invariants

- Source of truth: app-domain service-worker routing remains owned by `createApp`; this PR only moves the response builder to a focused module.
- Lock/transaction scope: no database writes, locks, or transactions changed.
- Acceptable orphan states: none introduced; no persistence or runtime state shape changed.
- Auth source of truth: unchanged; the service-worker route remains unauthenticated and covered by the existing proxy-routing test.
- Deferred scope: further large-file cleanup below the 5k threshold will continue in follow-up PRs after this lands.
