### PR TITLE
docs(dev): add large file refactor guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,6 +45,7 @@ Key principles:
 - **Landing-adjacent UI uses `@matrix-os/brand`**: auth, onboarding, billing, provisioning, and related shell/www surfaces should consume tokens/primitives from `packages/brand/` instead of ad-hoc hex values or forked brand helpers
 - **Kernel prompt**: keep under 7K tokens
 - **Spike before spec**: test undocumented SDK behavior with throwaway code first
+- **Large files are refactor debt**: aim for <500 LOC for composition entrypoints, containers, hooks, helpers, and focused tests. Treat 500-1000 LOC as a review smell that needs one clear responsibility; do not add behavior to 1000+ LOC files without an extraction plan, and split 2000+ LOC files before adding behavior. See `docs/dev/large-file-refactoring.md`.
 - After major features: run `/update-docs` to sync all documentation
 
 ## Mandatory Code Patterns

--- a/docs/dev/large-file-refactoring.md
+++ b/docs/dev/large-file-refactoring.md
@@ -1,0 +1,74 @@
+# Large File Refactoring
+
+Matrix OS should stay easy to review, test, and modify. Large files are allowed
+only when they are intentionally generated, data-heavy, or a short-lived
+transition during an active extraction stack.
+
+## File Size Budget
+
+Use these as review signals, not hard style-law:
+
+| File size | Expected action |
+|-----------|-----------------|
+| <= 500 LOC | Preferred size for route composition, React containers, hooks, helpers, and focused tests. |
+| 500-1000 LOC | Acceptable when the file has one clear responsibility and a local table of contents is still obvious. |
+| 1000-2000 LOC | Needs an extraction plan in the PR body or a follow-up issue unless it is generated or fixture-heavy. |
+| > 2000 LOC | Split before adding more behavior. If touching it, strongly prefer extracting a module first. |
+| > 5000 LOC | Treat as refactor debt. Do not add behavior without also starting or extending a decomposition stack. |
+
+The goal is not to chase line counts mechanically. The goal is that a reviewer
+can answer "what owns this behavior?" without reading thousands of lines.
+
+## Extraction Order
+
+Prefer low-risk extractions before behavior changes:
+
+1. Move pure helpers and constants into domain-named modules.
+2. Move presentational React components out of stateful containers.
+3. Move route families out of omnibus server files.
+4. Move repeated test fixtures into `*-test-utils.ts`.
+5. Split tests by behavior while keeping assertion text unchanged.
+
+Avoid mixing extraction with logic changes. If behavior must change, put the
+mechanical extraction in a lower stack layer and the behavior change in a later
+layer.
+
+## Entry Point Shape
+
+Entry points should compose modules, not own the whole product surface:
+
+- Platform `main.ts`: dependency wiring, middleware mounting, route composition.
+- Gateway `server.ts`: server construction, shared middleware, route mounting.
+- Shell container components: state orchestration plus child component wiring.
+- Test root files: describe high-level behavior and import shared fixtures.
+
+If an entrypoint crosses 500 LOC, check whether route groups, hooks, view
+sections, schemas, or response builders can move into focused modules.
+
+## Stacked PR Guidance
+
+Use Graphite for large refactors. Good stack layers are:
+
+1. Documentation and guardrails.
+2. Pure helper extraction with focused tests.
+3. Route/component extraction by one behavior family.
+4. Test split for the moved behavior.
+5. Follow-up cleanup after Greptile feedback.
+
+Every stack layer should remain reviewable on its own and include exact
+validation. Backend layers still need the required `Invariants` section from
+`docs/dev/review-pipeline.md`.
+
+## Review Checklist
+
+Before opening a PR that touches a large file:
+
+- Did this reduce or contain file size instead of increasing it?
+- Is the new module name tied to domain behavior rather than generic "utils"?
+- Are public exports minimal and tested?
+- Did assertion text stay unchanged for mechanical test splits?
+- Did you avoid moving unrelated code just to satisfy line count?
+- Did the PR body explain any file that remains above 1000 LOC?
+
+If the honest answer is "this PR made a large file larger," split the PR or add
+a lower-layer extraction first.

--- a/docs/dev/stacked-prs.md
+++ b/docs/dev/stacked-prs.md
@@ -17,6 +17,11 @@ Prefer stacked PRs when a feature crosses review boundaries such as:
 Keep each PR under the normal review target: ideally under 1000 additions and
 20 files, never over 3000 additions or 50 files without splitting.
 
+For refactors of large source files, follow `docs/dev/large-file-refactoring.md`:
+put guardrails in the base layer, keep mechanical extraction separate from
+behavior changes, and aim for small composition files rather than moving code
+around only to satisfy line-count targets.
+
 ## Setup
 
 Install and authenticate the Graphite CLI, then initialize it once in the repo:


### PR DESCRIPTION
## Summary

- Adds `docs/dev/large-file-refactoring.md` with practical file-size budgets, extraction order, stack guidance, and review checklist.
- Updates `AGENTS.md` so future agents treat 1000+ LOC files as refactor debt and avoid adding behavior without an extraction plan.
- Links the large-file guidance from the stacked PR workflow guide.

## Stack

1. #708 docs(dev): add large file refactor guidance
2. #709 refactor(platform): extract posthog relay helpers
3. #710 refactor(terminal): extract pane layout helpers
4. #711 refactor(gateway): extract session and cors helpers

## Validation

- `git diff --check`

## Invariants

- Source of truth: `AGENTS.md` remains the agent entrypoint; `docs/dev/large-file-refactoring.md` is the detailed refactor guide.
- Lock/transaction scope: no runtime data, database, or lock behavior changes.
- Acceptable orphan states: not applicable; docs-only layer.
- Auth source of truth: unchanged.
- Deferred scope: continued large-file decomposition happens in later stack layers and future PRs.
