### PR TITLE
refactor(terminal): extract pane layout helpers

### DIFF
--- a/shell/src/components/terminal/TerminalApp.tsx
+++ b/shell/src/components/terminal/TerminalApp.tsx
@@ -14,7 +14,7 @@ import {
   SquareTerminalIcon,
   Trash2Icon,
 } from "lucide-react";
-import { type PaneNode, countPanes as countPanesFromStore, getAllPaneIds } from "@/stores/terminal-store";
+import { countPanes as countPanesFromStore, getAllPaneIds } from "@/stores/terminal-store";
 import { PaneGrid } from "./PaneGrid";
 import { useTheme } from "@/hooks/useTheme";
 import { getGatewayUrl } from "@/lib/gateway";
@@ -24,11 +24,34 @@ import { MATRIX_OS_APP_THEME_OPTIONS } from "@/lib/theme-presets";
 import { DEFAULT_TERMINAL_APP_THEME_ID, useTerminalSettings, type ShellThemeId, type TerminalAppThemeId, type TerminalThemeId } from "@/stores/terminal-settings";
 import { getTerminalThemePreset } from "./terminal-themes";
 import { TerminalKeyBar } from "./TerminalKeyBar";
-import { isCanonicalShellSessionId, isLegacyPtySessionId } from "./terminal-session-id";
-import { twoWordSessionName } from "./terminal-session-names";
+import { isCanonicalShellSessionId } from "./terminal-session-id";
 import { TERMINAL_INPUT_EVENT, type TerminalInputEventDetail } from "./terminal-input-event";
 import { MOBILE_TERMINAL_INPUT_ACTIVE_EVENT, type MobileTerminalInputActiveDetail } from "./mobile-terminal-events";
 import { NewSessionMenu } from "./NewSessionMenu";
+import {
+  DEFAULT_CWD,
+  applyCompatModeToTabs,
+  closePaneInTree,
+  compatModeForShellSession,
+  destroyTerminalSessions,
+  formatCwd,
+  getCanonicalShellSessionIds,
+  getFirstPaneId,
+  getPaneCwd,
+  getPaneIdsForSession,
+  getPaneSessionId,
+  getSessionIds,
+  genId,
+  hasPaneId,
+  layoutUsesOnlyCanonicalShellSessions,
+  removeSessionFromPaneTree,
+  renameSessionInTree,
+  setPaneSessionId,
+  splitPaneInTree,
+  terminalSessionName,
+  type Tab,
+  type TerminalLayout,
+} from "./terminal-layout";
 import {
   parseTerminalAgentStatuses,
   terminalAgentVisibleInstallCommand,
@@ -791,38 +814,6 @@ function dispatchPaneAction(paneId: string | null, action: NonNullable<TerminalI
   );
 }
 
-const DEFAULT_CWD = "projects";
-
-interface Tab {
-  id: string;
-  label: string;
-  paneTree: PaneNode;
-}
-
-interface TerminalLayout {
-  tabs?: Tab[];
-  activeTabId?: string;
-  sidebarOpen?: boolean;
-}
-
-function genId() {
-  return Math.random().toString(36).slice(2, 9);
-}
-
-function terminalSessionName(prefix = "matrix") {
-  const normalized = prefix.toLowerCase();
-  // A meaningful prefix (e.g. a project name) keeps the prefixed form; the
-  // default produces a friendly two-word handle instead of matrix-<random>.
-  if (normalized && normalized !== "matrix") {
-    const safePrefix = normalized
-      .replace(/[^a-z0-9-]/g, "-")
-      .replace(/^-+/, "")
-      .slice(0, 22) || "matrix";
-    return `${safePrefix}-${genId()}`.slice(0, 31);
-  }
-  return twoWordSessionName();
-}
-
 async function readShellErrorCode(res: Response): Promise<string | null> {
   try {
     const data = await res.clone().json() as { error?: { code?: unknown } };
@@ -830,196 +821,6 @@ async function readShellErrorCode(res: Response): Promise<string | null> {
   } catch (err: unknown) {
     console.warn("Failed to parse shell error response:", err instanceof Error ? err.message : String(err));
     return null;
-  }
-}
-
-function splitPaneInTree(node: PaneNode, paneId: string, dir: "horizontal" | "vertical"): PaneNode {
-  if (node.type === "pane") {
-    if (node.id === paneId) {
-      return { type: "split", direction: dir, children: [node, { type: "pane", id: genId(), cwd: node.cwd }], ratio: 0.5 };
-    }
-    return node;
-  }
-  return { ...node, children: [splitPaneInTree(node.children[0], paneId, dir), splitPaneInTree(node.children[1], paneId, dir)] };
-}
-
-function closePaneInTree(node: PaneNode, paneId: string): PaneNode | null {
-  if (node.type === "pane") return node.id === paneId ? null : node;
-  const l = node.children[0], r = node.children[1];
-  if (l.type === "pane" && l.id === paneId) return r;
-  if (r.type === "pane" && r.id === paneId) return l;
-  const nl = closePaneInTree(l, paneId);
-  const nr = closePaneInTree(r, paneId);
-  if (!nl) return nr;
-  if (!nr) return nl;
-  return { ...node, children: [nl, nr] };
-}
-
-function getFirstPaneId(node: PaneNode): string {
-  if (node.type === "pane") return node.id;
-  return getFirstPaneId(node.children[0]);
-}
-
-function setPaneSessionId(node: PaneNode, paneId: string, sessionId: string): PaneNode {
-  if (node.type === "pane") {
-    if (node.id !== paneId || node.sessionId === sessionId) {
-      return node;
-    }
-    return { ...node, sessionId, compatMode: compatModeForShellSession(sessionId) };
-  }
-
-  const left = setPaneSessionId(node.children[0], paneId, sessionId);
-  const right = setPaneSessionId(node.children[1], paneId, sessionId);
-  if (left === node.children[0] && right === node.children[1]) {
-    return node;
-  }
-  return { ...node, children: [left, right] };
-}
-
-function renameSessionInTree(node: PaneNode, fromSessionId: string, toSessionId: string): PaneNode {
-  if (node.type === "pane") {
-    return node.sessionId === fromSessionId
-      ? { ...node, sessionId: toSessionId, compatMode: compatModeForShellSession(toSessionId) }
-      : node;
-  }
-  const left = renameSessionInTree(node.children[0], fromSessionId, toSessionId);
-  const right = renameSessionInTree(node.children[1], fromSessionId, toSessionId);
-  if (left === node.children[0] && right === node.children[1]) {
-    return node;
-  }
-  return { ...node, children: [left, right] };
-}
-
-function hasPaneId(node: PaneNode, paneId: string): boolean {
-  if (node.type === "pane") {
-    return node.id === paneId;
-  }
-  return hasPaneId(node.children[0], paneId) || hasPaneId(node.children[1], paneId);
-}
-
-function getPaneSessionId(node: PaneNode, paneId: string): string | null {
-  if (node.type === "pane") {
-    return node.id === paneId ? node.sessionId ?? null : null;
-  }
-  return getPaneSessionId(node.children[0], paneId) ?? getPaneSessionId(node.children[1], paneId);
-}
-
-function getPaneCwd(node: PaneNode, paneId: string): string | null {
-  if (node.type === "pane") {
-    return node.id === paneId ? node.cwd : null;
-  }
-  return getPaneCwd(node.children[0], paneId) ?? getPaneCwd(node.children[1], paneId);
-}
-
-function formatCwd(value: string): string {
-  if (value === DEFAULT_CWD) return "~/projects";
-  if (value.startsWith(DEFAULT_CWD + "/")) return `~/${value}`;
-  return value;
-}
-
-function getSessionIds(node: PaneNode): string[] {
-  if (node.type === "pane") {
-    return node.sessionId ? [node.sessionId] : [];
-  }
-  return [...getSessionIds(node.children[0]), ...getSessionIds(node.children[1])];
-}
-
-function getPaneIdsForSession(node: PaneNode, sessionId: string): string[] {
-  if (node.type === "pane") {
-    return node.sessionId === sessionId ? [node.id] : [];
-  }
-  return [
-    ...getPaneIdsForSession(node.children[0], sessionId),
-    ...getPaneIdsForSession(node.children[1], sessionId),
-  ];
-}
-
-function removeSessionFromPaneTree(node: PaneNode, sessionId: string): PaneNode | null {
-  if (node.type === "pane") {
-    return node.sessionId === sessionId ? null : node;
-  }
-  const left = removeSessionFromPaneTree(node.children[0], sessionId);
-  const right = removeSessionFromPaneTree(node.children[1], sessionId);
-  if (!left) return right;
-  if (!right) return left;
-  if (left === node.children[0] && right === node.children[1]) {
-    return node;
-  }
-  return { ...node, children: [left, right] };
-}
-
-function layoutUsesOnlyCanonicalShellSessions(layout: TerminalLayout): boolean {
-  if (!Array.isArray(layout.tabs) || layout.tabs.length === 0) {
-    return false;
-  }
-  const sessionIds = layout.tabs.flatMap((tab) => getSessionIds(tab.paneTree));
-  return sessionIds.length > 0 && sessionIds.every((sessionId) => isCanonicalShellSessionId(sessionId));
-}
-
-function getCanonicalShellSessionIds(layout: TerminalLayout): string[] {
-  if (!Array.isArray(layout.tabs)) {
-    return [];
-  }
-  const seen = new Set<string>();
-  for (const tab of layout.tabs) {
-    for (const sessionId of getSessionIds(tab.paneTree)) {
-      if (isCanonicalShellSessionId(sessionId)) {
-        seen.add(sessionId);
-      }
-    }
-  }
-  return Array.from(seen);
-}
-
-function compatModeForShellSession(sessionId: string | undefined) {
-  return sessionId?.startsWith("codex-") ? "codex-tui" as const : undefined;
-}
-
-function applyCompatModeToPaneTree(node: PaneNode): PaneNode {
-  if (node.type === "pane") {
-    return {
-      ...node,
-      compatMode: node.compatMode ?? compatModeForShellSession(node.sessionId),
-    };
-  }
-  return {
-    ...node,
-    children: [
-      applyCompatModeToPaneTree(node.children[0]),
-      applyCompatModeToPaneTree(node.children[1]),
-    ],
-  };
-}
-
-function applyCompatModeToTabs(tabs: Tab[]): Tab[] {
-  return tabs.map((tab) => ({ ...tab, paneTree: applyCompatModeToPaneTree(tab.paneTree) }));
-}
-
-function destroyTerminalSessions(sessionIds: string[]) {
-  const uniqueIds = Array.from(new Set(sessionIds.filter((sessionId) => sessionId.length > 0)));
-  for (const sessionId of uniqueIds) {
-    const isCanonical = isCanonicalShellSessionId(sessionId);
-    const isLegacyPty = isLegacyPtySessionId(sessionId);
-    if (!isCanonical && !isLegacyPty) {
-      continue;
-    }
-    const path = isCanonical
-      ? `/api/terminal/sessions/${encodeURIComponent(sessionId)}?force=1`
-      : `/api/terminal/pty-sessions/${encodeURIComponent(sessionId)}`;
-    void fetch(`${getGatewayUrl()}${path}`, {
-      method: "DELETE",
-      keepalive: true,
-      signal: AbortSignal.timeout(5_000),
-    }).then((res) => {
-      if (!res.ok && res.status !== 404) {
-        console.warn(`Failed to destroy terminal session "${sessionId}" on explicit close: ${res.status}`);
-      }
-    }).catch((err: unknown) => {
-      console.warn(
-        `Failed to destroy terminal session "${sessionId}" on explicit close:`,
-        err instanceof Error ? err.message : err,
-      );
-    });
   }
 }
 

--- a/shell/src/components/terminal/terminal-layout.ts
+++ b/shell/src/components/terminal/terminal-layout.ts
@@ -1,0 +1,227 @@
+import { getGatewayUrl } from "@/lib/gateway";
+import type { PaneNode } from "@/stores/terminal-store";
+import { isCanonicalShellSessionId, isLegacyPtySessionId } from "./terminal-session-id";
+import { twoWordSessionName } from "./terminal-session-names";
+
+export const DEFAULT_CWD = "projects";
+
+export interface Tab {
+  id: string;
+  label: string;
+  paneTree: PaneNode;
+}
+
+export interface TerminalLayout {
+  tabs?: Tab[];
+  activeTabId?: string;
+  sidebarOpen?: boolean;
+}
+
+export function genId() {
+  return Math.random().toString(36).slice(2, 9);
+}
+
+export function terminalSessionName(prefix = "matrix") {
+  const normalized = prefix.toLowerCase();
+  // A meaningful prefix (e.g. a project name) keeps the prefixed form; the
+  // default produces a friendly two-word handle instead of matrix-<random>.
+  if (normalized && normalized !== "matrix") {
+    const safePrefix = normalized
+      .replace(/[^a-z0-9-]/g, "-")
+      .replace(/^-+/, "")
+      .slice(0, 22) || "matrix";
+    return `${safePrefix}-${genId()}`.slice(0, 31);
+  }
+  return twoWordSessionName();
+}
+
+export function splitPaneInTree(node: PaneNode, paneId: string, dir: "horizontal" | "vertical"): PaneNode {
+  if (node.type === "pane") {
+    if (node.id === paneId) {
+      return { type: "split", direction: dir, children: [node, { type: "pane", id: genId(), cwd: node.cwd }], ratio: 0.5 };
+    }
+    return node;
+  }
+  return { ...node, children: [splitPaneInTree(node.children[0], paneId, dir), splitPaneInTree(node.children[1], paneId, dir)] };
+}
+
+export function closePaneInTree(node: PaneNode, paneId: string): PaneNode | null {
+  if (node.type === "pane") return node.id === paneId ? null : node;
+  const l = node.children[0], r = node.children[1];
+  if (l.type === "pane" && l.id === paneId) return r;
+  if (r.type === "pane" && r.id === paneId) return l;
+  const nl = closePaneInTree(l, paneId);
+  const nr = closePaneInTree(r, paneId);
+  if (!nl) return nr;
+  if (!nr) return nl;
+  if (nl === l && nr === r) return node;
+  return { ...node, children: [nl, nr] };
+}
+
+export function getFirstPaneId(node: PaneNode): string {
+  if (node.type === "pane") return node.id;
+  return getFirstPaneId(node.children[0]);
+}
+
+export function compatModeForShellSession(sessionId: string | undefined) {
+  return sessionId?.startsWith("codex-") ? "codex-tui" as const : undefined;
+}
+
+export function setPaneSessionId(node: PaneNode, paneId: string, sessionId: string): PaneNode {
+  if (node.type === "pane") {
+    if (node.id !== paneId || node.sessionId === sessionId) {
+      return node;
+    }
+    return { ...node, sessionId, compatMode: compatModeForShellSession(sessionId) };
+  }
+
+  const left = setPaneSessionId(node.children[0], paneId, sessionId);
+  const right = setPaneSessionId(node.children[1], paneId, sessionId);
+  if (left === node.children[0] && right === node.children[1]) {
+    return node;
+  }
+  return { ...node, children: [left, right] };
+}
+
+export function renameSessionInTree(node: PaneNode, fromSessionId: string, toSessionId: string): PaneNode {
+  if (node.type === "pane") {
+    return node.sessionId === fromSessionId
+      ? { ...node, sessionId: toSessionId, compatMode: compatModeForShellSession(toSessionId) }
+      : node;
+  }
+  const left = renameSessionInTree(node.children[0], fromSessionId, toSessionId);
+  const right = renameSessionInTree(node.children[1], fromSessionId, toSessionId);
+  if (left === node.children[0] && right === node.children[1]) {
+    return node;
+  }
+  return { ...node, children: [left, right] };
+}
+
+export function hasPaneId(node: PaneNode, paneId: string): boolean {
+  if (node.type === "pane") {
+    return node.id === paneId;
+  }
+  return hasPaneId(node.children[0], paneId) || hasPaneId(node.children[1], paneId);
+}
+
+export function getPaneSessionId(node: PaneNode, paneId: string): string | null {
+  if (node.type === "pane") {
+    return node.id === paneId ? node.sessionId ?? null : null;
+  }
+  return getPaneSessionId(node.children[0], paneId) ?? getPaneSessionId(node.children[1], paneId);
+}
+
+export function getPaneCwd(node: PaneNode, paneId: string): string | null {
+  if (node.type === "pane") {
+    return node.id === paneId ? node.cwd : null;
+  }
+  return getPaneCwd(node.children[0], paneId) ?? getPaneCwd(node.children[1], paneId);
+}
+
+export function formatCwd(value: string): string {
+  if (value === DEFAULT_CWD) return "~/projects";
+  if (value.startsWith(DEFAULT_CWD + "/")) return `~/${value}`;
+  return value;
+}
+
+export function getSessionIds(node: PaneNode): string[] {
+  if (node.type === "pane") {
+    return node.sessionId ? [node.sessionId] : [];
+  }
+  return [...getSessionIds(node.children[0]), ...getSessionIds(node.children[1])];
+}
+
+export function getPaneIdsForSession(node: PaneNode, sessionId: string): string[] {
+  if (node.type === "pane") {
+    return node.sessionId === sessionId ? [node.id] : [];
+  }
+  return [
+    ...getPaneIdsForSession(node.children[0], sessionId),
+    ...getPaneIdsForSession(node.children[1], sessionId),
+  ];
+}
+
+export function removeSessionFromPaneTree(node: PaneNode, sessionId: string): PaneNode | null {
+  if (node.type === "pane") {
+    return node.sessionId === sessionId ? null : node;
+  }
+  const left = removeSessionFromPaneTree(node.children[0], sessionId);
+  const right = removeSessionFromPaneTree(node.children[1], sessionId);
+  if (!left) return right;
+  if (!right) return left;
+  if (left === node.children[0] && right === node.children[1]) {
+    return node;
+  }
+  return { ...node, children: [left, right] };
+}
+
+export function layoutUsesOnlyCanonicalShellSessions(layout: TerminalLayout): boolean {
+  if (!Array.isArray(layout.tabs) || layout.tabs.length === 0) {
+    return false;
+  }
+  const sessionIds = layout.tabs.flatMap((tab) => getSessionIds(tab.paneTree));
+  return sessionIds.length > 0 && sessionIds.every((sessionId) => isCanonicalShellSessionId(sessionId));
+}
+
+export function getCanonicalShellSessionIds(layout: TerminalLayout): string[] {
+  if (!Array.isArray(layout.tabs)) {
+    return [];
+  }
+  const seen = new Set<string>();
+  for (const tab of layout.tabs) {
+    for (const sessionId of getSessionIds(tab.paneTree)) {
+      if (isCanonicalShellSessionId(sessionId)) {
+        seen.add(sessionId);
+      }
+    }
+  }
+  return Array.from(seen);
+}
+
+export function applyCompatModeToPaneTree(node: PaneNode): PaneNode {
+  if (node.type === "pane") {
+    return {
+      ...node,
+      compatMode: node.compatMode ?? compatModeForShellSession(node.sessionId),
+    };
+  }
+  return {
+    ...node,
+    children: [
+      applyCompatModeToPaneTree(node.children[0]),
+      applyCompatModeToPaneTree(node.children[1]),
+    ],
+  };
+}
+
+export function applyCompatModeToTabs(tabs: Tab[]): Tab[] {
+  return tabs.map((tab) => ({ ...tab, paneTree: applyCompatModeToPaneTree(tab.paneTree) }));
+}
+
+export function destroyTerminalSessions(sessionIds: string[]) {
+  const uniqueIds = Array.from(new Set(sessionIds.filter((sessionId) => sessionId.length > 0)));
+  for (const sessionId of uniqueIds) {
+    const isCanonical = isCanonicalShellSessionId(sessionId);
+    const isLegacyPty = isLegacyPtySessionId(sessionId);
+    if (!isCanonical && !isLegacyPty) {
+      continue;
+    }
+    const path = isCanonical
+      ? `/api/terminal/sessions/${encodeURIComponent(sessionId)}?force=1`
+      : `/api/terminal/pty-sessions/${encodeURIComponent(sessionId)}`;
+    void fetch(`${getGatewayUrl()}${path}`, {
+      method: "DELETE",
+      keepalive: true,
+      signal: AbortSignal.timeout(5_000),
+    }).then((res) => {
+      if (!res.ok && res.status !== 404) {
+        console.warn(`Failed to destroy terminal session "${sessionId}" on explicit close: ${res.status}`);
+      }
+    }).catch((err: unknown) => {
+      console.warn(
+        `Failed to destroy terminal session "${sessionId}" on explicit close:`,
+        err instanceof Error ? err.message : err,
+      );
+    });
+  }
+}

--- a/tests/shell/terminal-layout.test.ts
+++ b/tests/shell/terminal-layout.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from "vitest";
+import type { PaneNode } from "@/stores/terminal-store";
+import {
+  DEFAULT_CWD,
+  applyCompatModeToTabs,
+  closePaneInTree,
+  formatCwd,
+  getCanonicalShellSessionIds,
+  getFirstPaneId,
+  getPaneIdsForSession,
+  getPaneSessionId,
+  getSessionIds,
+  layoutUsesOnlyCanonicalShellSessions,
+  removeSessionFromPaneTree,
+  renameSessionInTree,
+  setPaneSessionId,
+  splitPaneInTree,
+  type TerminalLayout,
+} from "@/components/terminal/terminal-layout";
+
+const splitTree: PaneNode = {
+  type: "split",
+  direction: "horizontal",
+  ratio: 0.5,
+  children: [
+    { type: "pane", id: "left", cwd: "projects/app", sessionId: "shell-main" },
+    { type: "pane", id: "right", cwd: DEFAULT_CWD, sessionId: "codex-build" },
+  ],
+};
+
+describe("terminal layout helpers", () => {
+  it("splits, closes, and finds panes without mutating the original tree", () => {
+    const split = splitPaneInTree(splitTree, "left", "vertical");
+
+    expect(split).not.toBe(splitTree);
+    expect(splitTree.children[0]).toEqual({
+      type: "pane",
+      id: "left",
+      cwd: "projects/app",
+      sessionId: "shell-main",
+    });
+    expect(getFirstPaneId(split)).toBe("left");
+    expect(getPaneSessionId(split, "left")).toBe("shell-main");
+
+    const leftBranch = split.type === "split" ? split.children[0] : null;
+    expect(leftBranch?.type).toBe("split");
+    if (leftBranch?.type !== "split") {
+      throw new Error("expected left branch to be split");
+    }
+    const newPane = leftBranch.children[1];
+    expect(newPane.type).toBe("pane");
+    expect(newPane.id).not.toBe("left");
+    expect(newPane.cwd).toBe("projects/app");
+
+    const closed = closePaneInTree(split, "right");
+    expect(closed).not.toBeNull();
+    expect(getSessionIds(closed!)).toEqual(["shell-main"]);
+
+    const nestedClosed = closePaneInTree(split, newPane.id);
+    expect(nestedClosed).not.toBeNull();
+    const nestedLeft = nestedClosed?.type === "split" ? nestedClosed.children[0] : null;
+    expect(nestedLeft).toEqual({
+      type: "pane",
+      id: "left",
+      cwd: "projects/app",
+      sessionId: "shell-main",
+    });
+
+    expect(closePaneInTree(splitTree, "missing-pane")).toBe(splitTree);
+  });
+
+  it("renames and removes shell sessions across pane trees", () => {
+    const renamed = renameSessionInTree(splitTree, "codex-build", "codex-run");
+    expect(getPaneSessionId(renamed, "right")).toBe("codex-run");
+    expect(getPaneIdsForSession(renamed, "codex-run")).toEqual(["right"]);
+
+    const reassigned = setPaneSessionId(renamed, "left", "codex-left");
+    expect(getPaneSessionId(reassigned, "left")).toBe("codex-left");
+    expect(
+      reassigned.type === "split" && reassigned.children[0].type === "pane"
+        ? reassigned.children[0].compatMode
+        : null,
+    ).toBe("codex-tui");
+
+    const removed = removeSessionFromPaneTree(reassigned, "codex-left");
+    expect(removed).toEqual({
+      type: "pane",
+      id: "right",
+      cwd: DEFAULT_CWD,
+      sessionId: "codex-run",
+      compatMode: "codex-tui",
+    });
+  });
+
+  it("detects canonical shell-session layouts and formats cwd labels", () => {
+    const layout: TerminalLayout = {
+      tabs: [
+        { id: "one", label: "Main", paneTree: splitTree },
+        { id: "two", label: "PTY", paneTree: { type: "pane", id: "pty", cwd: DEFAULT_CWD, sessionId: "pty_session" } },
+      ],
+    };
+
+    expect(layoutUsesOnlyCanonicalShellSessions(layout)).toBe(false);
+    expect(getCanonicalShellSessionIds(layout)).toEqual(["shell-main", "codex-build"]);
+    expect(formatCwd(DEFAULT_CWD)).toBe("~/projects");
+    expect(formatCwd("projects/matrix-os")).toBe("~/projects/matrix-os");
+    expect(formatCwd("/tmp")).toBe("/tmp");
+
+    expect(applyCompatModeToTabs(layout.tabs ?? [])[0]?.paneTree).toEqual({
+      ...splitTree,
+      children: [
+        { type: "pane", id: "left", cwd: "projects/app", sessionId: "shell-main", compatMode: undefined },
+        { type: "pane", id: "right", cwd: DEFAULT_CWD, sessionId: "codex-build", compatMode: "codex-tui" },
+      ],
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Extracts terminal pane layout/session helpers from `TerminalApp.tsx` into `terminal-layout.ts`.
- Adds focused unit coverage for split, close, rename, remove, canonical-session detection, cwd formatting, and compat-mode behavior.
- Shrinks `TerminalApp.tsx` while preserving the existing terminal container behavior.

## Stack

1. #708 docs(dev): add large file refactor guidance
2. #709 refactor(platform): extract posthog relay helpers
3. #710 refactor(terminal): extract pane layout helpers
4. #711 refactor(gateway): extract session and cors helpers

## Validation

- `bun run test -- tests/shell/terminal-layout.test.ts`
- `bun run typecheck`
- `git diff --check`

## Invariants

- Source of truth: terminal pane tree operations now live in `shell/src/components/terminal/terminal-layout.ts`; `TerminalApp.tsx` remains the UI container.
- Lock/transaction scope: no database writes, locks, transactions, or persistence changes.
- Acceptable orphan states: terminal session cleanup behavior is preserved; no new orphan state is introduced.
- Auth source of truth: unchanged.
- Deferred scope: terminal theme/sidebar/mobile UI sections are still large and should be extracted in later PRs.
