### PR TITLE
fix(cli): clear shell reconnect banner after restore

### DIFF
--- a/packages/sync-client/src/cli/shell-client.ts
+++ b/packages/sync-client/src/cli/shell-client.ts
@@ -83,7 +83,7 @@ const SHELL_ATTACH_RECONNECT_BASE_DELAY_MS = 500;
 const SHELL_ATTACH_RECONNECT_MAX_DELAY_MS = 5_000;
 const SHELL_ATTACH_HEARTBEAT_MISSES_BEFORE_RECONNECT = 2;
 const SHELL_ATTACH_RECONNECT_NOTICE = "\r\n\u001b[7m Matrix shell disconnected. Waiting for the gateway to come back; this session will reconnect automatically. \u001b[0m\r\n";
-const SHELL_ATTACH_RESTORED_NOTICE = "\r\n\u001b[7m Matrix shell connection restored. \u001b[0m\r\n";
+const SHELL_ATTACH_RECONNECT_NOTICE_CLEAR = "\r\u001b[2K\u001b[1A\r\u001b[2K";
 const LOCAL_TERMINAL_INPUT_RESET = [
   "\u001b[?1000l",
   "\u001b[?1002l",
@@ -467,6 +467,7 @@ export function createShellClient(options: ShellClientOptions): ShellClient {
         let heartbeatTimeout: ReturnType<typeof setTimeout> | undefined;
         let heartbeatPending = false;
         let missedHeartbeats = 0;
+        let reconnectNoticeVisible = false;
         const cleanup = () => {
           clearTimeout(attachTimeout);
           clearTimeout(reconnectTimer);
@@ -598,6 +599,7 @@ export function createShellClient(options: ShellClientOptions): ShellClient {
           if (!reconnecting) {
             errorOutput.write("\r\nConnection lost. Reconnecting...\r\n");
             output.write(SHELL_ATTACH_RECONNECT_NOTICE);
+            reconnectNoticeVisible = true;
           }
           reconnecting = true;
           const backoffExponent = Math.min(reconnectAttempt, 31);
@@ -744,7 +746,10 @@ export function createShellClient(options: ShellClientOptions): ShellClient {
             if (reconnecting) {
               reconnecting = false;
               errorOutput.write("\r\nConnection restored.\r\n");
-              output.write(SHELL_ATTACH_RESTORED_NOTICE);
+              if (reconnectNoticeVisible) {
+                output.write(SHELL_ATTACH_RECONNECT_NOTICE_CLEAR);
+                reconnectNoticeVisible = false;
+              }
             }
             schedulePostAttachResizeFrames();
           } else if (msg.type === "output" && typeof msg.data === "string") {

--- a/packages/sync-client/src/cli/shell-client.ts
+++ b/packages/sync-client/src/cli/shell-client.ts
@@ -83,7 +83,7 @@ const SHELL_ATTACH_RECONNECT_BASE_DELAY_MS = 500;
 const SHELL_ATTACH_RECONNECT_MAX_DELAY_MS = 5_000;
 const SHELL_ATTACH_HEARTBEAT_MISSES_BEFORE_RECONNECT = 2;
 const SHELL_ATTACH_RECONNECT_NOTICE = "\r\n\u001b[7m Matrix shell disconnected. Waiting for the gateway to come back; this session will reconnect automatically. \u001b[0m\r\n";
-const SHELL_ATTACH_RECONNECT_NOTICE_CLEAR = "\r\u001b[2K\u001b[1A\r\u001b[2K";
+const SHELL_ATTACH_RECONNECT_NOTICE_CLEAR = "\r\u001b[2K\u001b[1A\r\u001b[2K\u001b[1A\r\u001b[2K";
 const LOCAL_TERMINAL_INPUT_RESET = [
   "\u001b[?1000l",
   "\u001b[?1002l",

--- a/tests/cli/shell-client.test.ts
+++ b/tests/cli/shell-client.test.ts
@@ -429,7 +429,7 @@ describe("shell REST client", () => {
     ControlledWebSocket.last?.emit("open");
     ControlledWebSocket.last?.emit("message", JSON.stringify({ type: "attached" }));
 
-    expect(output.write).toHaveBeenLastCalledWith("\r\u001b[2K\u001b[1A\r\u001b[2K");
+    expect(output.write).toHaveBeenLastCalledWith("\r\u001b[2K\u001b[1A\r\u001b[2K\u001b[1A\r\u001b[2K");
     ControlledWebSocket.last?.emit("message", JSON.stringify({ type: "exit", code: 0 }));
     await expect(attached).resolves.toEqual({ detached: false });
   });

--- a/tests/cli/shell-client.test.ts
+++ b/tests/cli/shell-client.test.ts
@@ -396,9 +396,40 @@ describe("shell REST client", () => {
     ControlledWebSocket.last?.emit("message", JSON.stringify({ type: "attached" }));
     const second = ControlledWebSocket.last!;
     expect(errorOutput.write).toHaveBeenCalledWith("\r\nConnection restored.\r\n");
-    expect(output.write).toHaveBeenCalledWith(expect.stringContaining("connection restored"));
+    expect(output.write).toHaveBeenCalledWith(expect.stringContaining("\u001b[1A"));
+    expect(output.write).not.toHaveBeenCalledWith(expect.stringContaining("connection restored"));
     await vi.advanceTimersByTimeAsync(80);
     expect(second.closed).toBe(false);
+    ControlledWebSocket.last?.emit("message", JSON.stringify({ type: "exit", code: 0 }));
+    await expect(attached).resolves.toEqual({ detached: false });
+  });
+
+  it("clears the reconnect banner from terminal output once attach is restored", async () => {
+    vi.useFakeTimers();
+    const client = createShellClient({ gatewayUrl: "http://gateway", timeoutMs: 50 });
+    const input = new EventEmitter() as NodeJS.ReadStream;
+    const output = { write: vi.fn() } as unknown as NodeJS.WriteStream;
+    const errorOutput = { write: vi.fn() } as unknown as NodeJS.WriteStream;
+
+    const attached = client.attachSession("main", {
+      WebSocketImpl: ControlledWebSocket,
+      input,
+      output,
+      errorOutput,
+      reconnectBaseDelayMs: 5,
+      reconnectMaxDelayMs: 5,
+    });
+    ControlledWebSocket.last?.emit("open");
+    ControlledWebSocket.last?.emit("message", JSON.stringify({ type: "attached" }));
+    ControlledWebSocket.last?.emit("close");
+    await vi.advanceTimersByTimeAsync(5);
+
+    expect(output.write).toHaveBeenCalledWith(expect.stringContaining("Matrix shell disconnected"));
+
+    ControlledWebSocket.last?.emit("open");
+    ControlledWebSocket.last?.emit("message", JSON.stringify({ type: "attached" }));
+
+    expect(output.write).toHaveBeenLastCalledWith("\r\u001b[2K\u001b[1A\r\u001b[2K");
     ControlledWebSocket.last?.emit("message", JSON.stringify({ type: "exit", code: 0 }));
     await expect(attached).resolves.toEqual({ detached: false });
   });


### PR DESCRIPTION
## Summary

- Clear the CLI shell reconnect banner from terminal output after a successful reattach.
- Keep the plain stderr restore notice for non-TUI/logging contexts.
- Add regression coverage for the stale disconnected banner behavior.
- Clear three physical terminal lines so the banner is removed cleanly after wrapping in normal narrow terminals.

## Tests

Local/worktree:
- `bun run test tests/cli/shell-client.test.ts`
- `pnpm --filter @finnaai/matrix test -- tests/unit/shell-client.test.ts`
- `pnpm --filter @finnaai/matrix build`
- `git diff --check`
- `bun run check:patterns` (passes with warnings only)

GitHub after `ready-for-ci`:
- CI Results: pass
- Type Check: pass
- Pattern Scan: pass
- React Doctor: pass
- Sync Client Package: pass
- Shell Production Build: pass
- Unit Tests (1/4-4/4): pass
- E2E Tests: pass
- Docker Smoke Test: pass

## Review/Monitoring

- Greptile latest trusted review on `41d226d19381ec7f1f8554f4bafba62f5389aeaf`: `5/5`.
- Stale bot review threads from the previous head were fixed and resolved.
- `ready-for-ci` is applied and label-triggered CI passed.

## Invariants

- Source of truth: CLI attach websocket state remains the source of reconnect/restore state.
- Lock/transaction scope: no database or filesystem persistence changed.
- Acceptable orphan states: reconnect notice visibility is local-process UI state and is discarded on process exit/cleanup.
- Auth source of truth: no auth or token behavior changed.
- Deferred scope: no changes to web shell terminal reconnect UI.
