### PR TITLE
chore(cli): prepare 0.3.8 release

### DIFF
--- a/docs/dev/cli-release.md
+++ b/docs/dev/cli-release.md
@@ -4,7 +4,7 @@ The installable Matrix CLI is the `@finnaai/matrix` package in `packages/sync-cl
 
 ## Current Prepared Release
 
-`0.3.7` is the prepared CLI patch release after `0.3.6`, including Node 20+ package-runner support and standalone CLI binaries for no-Node installs.
+`0.3.8` is the prepared CLI patch release after `0.3.7`, including the Matrix shell reconnect banner fix while preserving Node 20+ package-runner support and standalone CLI binaries for no-Node installs.
 
 ## Versioning
 
@@ -34,7 +34,7 @@ git tag -l 'cli-v*'
 
 ## Release
 
-Use the manual GitHub Actions workflow named `CLI Release` with `version=0.3.7` and `update_homebrew=true`. The workflow:
+Use the manual GitHub Actions workflow named `CLI Release` with `version=0.3.8` and `update_homebrew=true`. The workflow:
 
 1. Validates the requested semver, local package version, npm availability, and `cli-v<version>` tag availability.
 2. Installs the workspace and runs the sync-client build, tests, and publish-shape check.
@@ -51,7 +51,7 @@ npm view @finnaai/matrix dist.tarball
 npx --yes @finnaai/matrix --version
 pnpm dlx @finnaai/matrix --version
 brew update && brew info finnaai/tap/matrix
-MATRIX_VERSION=0.3.7 sh scripts/install.sh
+MATRIX_VERSION=0.3.8 sh scripts/install.sh
 matrix --version
 matrix login --help
 matrix run --help
@@ -69,17 +69,17 @@ matrix forward 5173
 
 For standalone binaries, also verify the GitHub release contains:
 
-- `matrix-0.3.7-linux-x64`
-- `matrix-0.3.7-linux-arm64`
-- `matrix-0.3.7-darwin-x64`
-- `matrix-0.3.7-darwin-arm64`
+- `matrix-0.3.8-linux-x64`
+- `matrix-0.3.8-linux-arm64`
+- `matrix-0.3.8-darwin-x64`
+- `matrix-0.3.8-darwin-arm64`
 
-For macOS app packaging, also verify the GitHub release contains `MatrixSync-0.3.7.pkg` when the macOS job was enabled.
+For macOS app packaging, also verify the GitHub release contains `MatrixSync-0.3.8.pkg` when the macOS job was enabled.
 
 ## Rollback
 
-npm package versions are immutable. If a bad CLI release is published, ship a patch release such as `0.3.7` and update Homebrew through the release workflow. Only deprecate the bad npm version when the replacement is available:
+npm package versions are immutable. If a bad CLI release is published, ship a patch release such as `0.3.9` and update Homebrew through the release workflow. Only deprecate the bad npm version when the replacement is available:
 
 ```bash
-npm deprecate @finnaai/matrix@0.3.7 "Use @finnaai/matrix@0.3.8"
+npm deprecate @finnaai/matrix@0.3.8 "Use @finnaai/matrix@0.3.9"
 ```

--- a/packages/sync-client/package.json
+++ b/packages/sync-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@finnaai/matrix",
-  "version": "0.3.7",
+  "version": "0.3.8",
   "description": "Matrix OS command-line client — login, sync, and peer management for matrix-os.com",
   "type": "module",
   "license": "AGPL-3.0-or-later",


### PR DESCRIPTION
## Summary
- bump `@finnaai/matrix` from `0.3.7` to `0.3.8`
- update the CLI release runbook and artifact examples for the `0.3.8` patch release
- document the next rollback patch as `0.3.9`

## Tests
- `pnpm --filter @finnaai/matrix build`
- `pnpm --filter @finnaai/matrix test` (33 files, 319 tests)
- `pnpm --filter @finnaai/matrix exec node ./scripts/check-publish.mjs`
- `pnpm --filter @finnaai/matrix exec node ./scripts/validate-package-runners.mjs`
- `git diff --check`

## Review/Monitoring
- `0.3.8` is not published on npm (`npm view @finnaai/matrix@0.3.8 version` returns 404)
- `cli-v0.3.8` tag does not exist
- `CLI Release` workflow is active
- waiting for trusted Greptile 5/5 before adding `ready-for-ci`

## Invariants
- Source of truth: `packages/sync-client/package.json` remains the CLI version source used by `.github/workflows/cli-release.yml`
- Lock/transaction scope: no persistence or lockfile changes
- Acceptable orphan states: no runtime state is created by this release-prep PR
- Auth source of truth: unchanged
- Deferred scope: actual npm/GitHub/Homebrew publish occurs only after this bump lands on `main` and `CLI Release` is dispatched with `version=0.3.8`