### PR TITLE
refactor(platform): extract session routing middleware

### DIFF
--- a/packages/platform/src/main.ts
+++ b/packages/platform/src/main.ts
@@ -1,4 +1,3 @@
-import { randomBytes } from 'node:crypto';
 import { Hono, type Context } from 'hono';
 import { bodyLimit } from 'hono/body-limit';
 import { serve } from '@hono/node-server';
@@ -75,10 +74,7 @@ import {
 import { createBillingRoutes } from './billing-routes.js';
 import { createJourneyRoutes, createJourneyUserResolver } from './journey-routes.js';
 import { backfillFirstRunRecords } from './journey.js';
-import { appDomainServiceWorkerResponse } from './app-domain-service-worker.js';
-import { isPostHogRelayPath, proxyPostHogRelay } from './posthog-relay.js';
 import {
-  applyNoStoreResponseHeaders,
   sanitizeProxyResponseHeaders,
 } from './proxy-headers.js';
 import { appOrigin } from './origins.js';
@@ -110,7 +106,6 @@ import {
   selectProvisionIdentityForClerkUser,
 } from './provisioning-identity.js';
 import {
-  buildRuntimePickerMachines,
   probeCustomerVpsRelease,
   probeCustomerVpsRuntime,
   releaseVersionFromProbe,
@@ -123,66 +118,29 @@ import {
 } from './runtime-mode.js';
 import { resolvePlatformIntegrationConfig } from './integration-config.js';
 import {
-  CLERK_SCRIPT_ORIGIN,
-  getAuthPage,
-  getNoContainerPage,
-  getRuntimePickerPage,
-  getVpsBootPage,
-} from './auth-pages.js';
-import {
   APP_SESSION_COOKIE,
-  CODE_SESSION_EXPIRES_IN_SEC,
-  NATIVE_APP_SESSION_PROXY_HEADER,
-  buildCodeSessionCookie,
   readCookie,
 } from './session-cookies.js';
 import {
-  buildBillingSetupPath,
   buildForwardedQueryString,
-  buildPostAuthRedirectPath,
-  getAuthShellOrigin,
-  isAppDomainGatewayPath,
-  isBillingSetupPath,
   readRuntimeSlot,
-  readRuntimeSlotSelection,
-  shouldProxyAuthShellForUnroutedUser,
-  shouldProxyShellForBillingGate,
 } from './request-routing.js';
 import {
   APP_ASSET_ROUTE_OMITTED_QUERY_PARAMS,
   EDGE_SECRET_HEADER,
-  applyAppDomainRuntimeAssetCacheHeaders,
-  applyCookieRoutedShellAssetCacheHeaders,
-  applySandboxedAppAssetCorsHeaders,
-  buildAppDomainProxyResponse,
-  buildCodeDomainProxyHeaders,
-  isAppDomainStaticAssetPath,
-  isCodeDomainStaticAssetPath,
-  isViteAppAssetPath,
-  hasValidExplicitVmAppAssetToken,
-  readAppAssetRouteToken,
   shouldForwardProxyHeader,
 } from './session-routing-proxy.js';
 import {
-  buildAppRouteCookie,
-  buildShellRouteCookie,
-  readAppDomainRouteCookie,
-  readExplicitVmRoute,
-  readMobileAppRouteCookie,
-  readMobileAppSessionRoutingHandle,
-  readShellRouteCookie,
   resolveAppDomainIdentity,
-  shouldMarkNativeAppSession,
   type AppDomainIdentity,
 } from './session-routing-identity.js';
 import {
-  buildPlatformUserProof,
   buildPlatformWebSocketUpgradeHeaders,
   classifySessionRoutedHost,
   classifyWebSocketPath,
-  getTrustedSessionRouteHost,
   getTrustedSessionRoutedWebSocketHost,
 } from './session-routing-websocket.js';
+import { createSessionRoutingMiddleware } from './session-routing-middleware.js';
 import {
   resolveContainerEndpoint,
 } from './container-endpoint.js';
@@ -458,18 +416,6 @@ function jsonCustomerVpsError(c: import('hono').Context, err: unknown, context: 
   return c.json({ error: 'Provisioning failed', code: 'provisioning_failed' }, 503);
 }
 
-function applyAuthPageHeaders(
-  c: import('hono').Context,
-  scriptNonce: string,
-): void {
-  applyNoStoreHeaders(c);
-  c.header('X-Frame-Options', 'DENY');
-  c.header(
-    'Content-Security-Policy',
-    `frame-ancestors 'none'; script-src 'self' 'nonce-${scriptNonce}' ${CLERK_SCRIPT_ORIGIN} https://challenges.cloudflare.com; worker-src 'self' blob:; frame-src https://challenges.cloudflare.com; object-src 'none'; base-uri 'none'`,
-  );
-}
-
 export function checkUnsafeDefaultSecrets(
   env: NodeJS.ProcessEnv = process.env,
   log: (msg: string) => void = console.error,
@@ -651,61 +597,6 @@ export function createApp(deps: {
       return;
     }
     capturePlatformEvent(event, options?.properties ?? {}, { distinctId: options?.distinctId });
-  }
-
-  async function proxyAuthShell(
-    c: Context,
-    host: string,
-    opts: { redirectToBillingOnFailure?: boolean } = {},
-  ): Promise<Response> {
-    const upstream = new URL(c.req.url);
-    const targetUrl = `${getAuthShellOrigin(appEnv)}${upstream.pathname}${upstream.search}`;
-    const headers = new Headers();
-    for (const [key, value] of Object.entries(c.req.header())) {
-      const lowerKey = key.toLowerCase();
-      if (lowerKey !== 'host' && value) {
-        headers.set(key, value);
-      }
-    }
-    headers.set('host', new URL(getAuthShellOrigin(appEnv)).host);
-    headers.set('x-forwarded-host', host);
-    // The auth shell is a local plain-HTTP Next server. Forwarding "https" here
-    // makes Next 16 attempt internal self-proxy requests to https://localhost:3200.
-    headers.set('x-forwarded-proto', 'http');
-    headers.set('accept-encoding', 'identity');
-    headers.set('connection', 'close');
-
-    try {
-      const response = await fetch(targetUrl, {
-        method: c.req.method,
-        headers,
-        redirect: 'manual',
-        signal: AbortSignal.timeout(AUTH_SHELL_PROXY_TIMEOUT_MS),
-      });
-      const responseHeaders = sanitizeProxyResponseHeaders(response.headers);
-      applyNoStoreResponseHeaders(responseHeaders);
-      return new Response(response.body, {
-        status: response.status,
-        headers: responseHeaders,
-      });
-    } catch (err: unknown) {
-      logPlatformRouteError('app-domain auth-shell proxy', err);
-      if (opts.redirectToBillingOnFailure !== false && !isBillingSetupPath(c.req.url)) {
-        return c.redirect(buildBillingSetupPath(c.req.url), 302);
-      }
-      const publishableKey = appEnv.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY;
-      if (!publishableKey) {
-        return c.text('Matrix OS shell unavailable', 503);
-      }
-      applyNoStoreHeaders(c);
-      const scriptNonce = randomBytes(16).toString('base64');
-      applyAuthPageHeaders(c, scriptNonce);
-      const authMode = c.req.path.startsWith('/sign-up') ? 'sign-up' : 'sign-in';
-      return c.html(
-        getAuthPage(publishableKey, authMode, scriptNonce, buildPostAuthRedirectPath(c.req.url), appOrigin(appEnv)),
-        200,
-      );
-    }
   }
 
   const BILLING_AUTH_FAILURE_HEADER = 'X-Auth-Failure';
@@ -921,703 +812,27 @@ export function createApp(deps: {
   // Session-based routing:
   // - app.matrix-os.com -> Clerk session -> Matrix OS shell/gateway
   // - code.matrix-os.com -> Clerk session -> code-server on the user's VPS
-  app.use('*', bodyLimit({ maxSize: PROXY_BODY_LIMIT }), async (c, next) => {
-    const host = getTrustedSessionRouteHost(
-      c.req.header('host'),
-      c.req.header('x-forwarded-host'),
-      c.req.header(EDGE_SECRET_HEADER),
-      appEnv.EDGE_ROUTER_SECRET,
-    );
-    const isAppDomain = isAppDomainHost(host);
-    const isCodeDomain = isCodeDomainHost(host);
-    if (!isAppDomain && !isCodeDomain) return next();
-
-    // Device-flow paths are served directly by the platform's auth-routes.ts
-    // (registered above). In normal dispatch they never reach this middleware,
-    // but we short-circuit explicitly so a misconfigured PLATFORM_JWT_SECRET or
-    // a future refactor can't accidentally proxy them into a user container.
-    const reqPath = c.req.path;
-    if (isAppDomain && reqPath === '/service-worker.js') {
-      return appDomainServiceWorkerResponse();
-    }
-    if (isAppDomain && isPostHogRelayPath(reqPath)) {
-      return proxyPostHogRelay(c, { logRouteError: logPlatformRouteError });
-    }
-    if (isAppDomain && (
-      reqPath === '/auth/device' ||
-      reqPath.startsWith('/auth/device/') ||
-      reqPath.startsWith('/api/auth/device/') ||
-      reqPath === '/api/auth/app-session' ||
-      reqPath === '/api/auth/provision-runtime' ||
-      reqPath === '/api/journey' ||
-      reqPath === '/api/journey/retry-provision'
-    )) {
-      return next();
-    }
-    if ((isAppDomain || isCodeDomain) && (reqPath === '/vps' || reqPath.startsWith('/vps/'))) {
-      return next();
-    }
-    if ((isAppDomain || isCodeDomain) && reqPath.startsWith('/internal/containers/')) {
-      return next();
-    }
-    const isPublicIntegrationPath =
-      reqPath === '/api/integrations/available' ||
-      reqPath.startsWith('/api/integrations/webhook/');
-    const isIntegrationPath =
-      reqPath === '/api/integrations' || reqPath.startsWith('/api/integrations/');
-    if (isAppDomain && isPublicIntegrationPath) {
-      return next();
-    }
-    if (isAppDomain && reqPath === '/voice/webhook/twilio') {
-      const webhookUrl = new URL(c.req.url);
-      const handle = webhookUrl.searchParams.get('handle') ?? '';
-      if (!HANDLE_PATTERN.test(handle)) {
-        return c.json({ error: 'Invalid handle' }, 400);
-      }
-
-      const runningMachine = await getRunningUserMachineByHandle(db, handle);
-      if (!runningMachine) {
-        return c.json({ error: 'VPS unavailable' }, 404);
-      }
-
-      const qs = buildForwardedQueryString(c.req.url, APP_ASSET_ROUTE_OMITTED_QUERY_PARAMS);
-      const targetUrl = buildCustomerVpsProxyUrl(runningMachine, reqPath, qs);
-      if (!targetUrl) {
-        return c.json({ error: 'VPS unreachable' }, 502);
-      }
-
-      const headers = new Headers();
-      for (const [key, value] of Object.entries(c.req.header())) {
-        if (shouldForwardProxyHeader(key, value)) {
-          headers.set(key, value);
-        }
-      }
-      headers.set('host', 'app.matrix-os.com');
-      headers.set('x-forwarded-host', host);
-      headers.set('x-forwarded-proto', 'https');
-      headers.set('accept-encoding', 'identity');
-      headers.set('connection', 'close');
-      if (platformSecret) {
-        headers.set('authorization', `Bearer ${buildPlatformVerificationToken(handle, platformSecret)}`);
-      }
-
-      try {
-        const upstream = await fetch(targetUrl, {
-          method: c.req.method,
-          headers,
-          redirect: 'manual',
-          signal: AbortSignal.timeout(PROXY_TIMEOUT_MS),
-          body: ['GET', 'HEAD'].includes(c.req.method) ? undefined : await c.req.blob(),
-          dispatcher: customerVpsProxyDispatcher,
-        } as RequestInit & { dispatcher: Agent });
-
-        return new Response(upstream.body, {
-          status: upstream.status,
-          headers: sanitizeProxyResponseHeaders(upstream.headers),
-        });
-      } catch (err: unknown) {
-        logPlatformRouteError('app-domain voice webhook proxy', err);
-        return c.json({ error: 'VPS unreachable' }, 502);
-      }
-    }
-
-    const authHeader = c.req.header('authorization');
-    const cookieHeader = c.req.header('cookie');
-    const path = c.req.path;
-    const explicitVmRoute = isAppDomain ? readExplicitVmRoute(path) : null;
-    const explicitVmRouteHasValidAppAssetToken = Boolean(
-      explicitVmRoute &&
-      hasValidExplicitVmAppAssetToken({
-        method: c.req.method,
-        rawUrl: c.req.url,
-        route: explicitVmRoute,
-        platformSecret,
-      }),
-    );
-    const runtimeSelection = readRuntimeSlotSelection(c.req.url);
-    const requestRuntimeSlot = runtimeSelection.slot;
-    let singleMachineRuntimeSlot: string | null = null;
-
-    const isGatewayPath = isAppDomain && isAppDomainGatewayPath(path);
-    const allowAuthShellUnroutedIdentity = !legacyContainerRoutingEnabled && shouldProxyAuthShellForUnroutedUser({
-      isAppDomain,
-      method: c.req.method,
-      path,
-    });
-    const publishableKey = process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY;
-    const authMode = path.startsWith('/sign-up') ? 'sign-up' : 'sign-in';
-    const requestedRouteHandle = !explicitVmRoute && isAppDomain
-      ? readAppDomainRouteCookie(path, cookieHeader)
-      : null;
-
-    let identity = await resolveAppDomainIdentity({
-      authHeader,
-      cookieHeader,
-      clerkAuth,
-      db,
-      platformJwtSecret,
-      legacyContainerRoutingEnabled,
-      allowUnroutedClerkIdentity: Boolean(explicitVmRoute) || allowAuthShellUnroutedIdentity,
-      requestedHandle: requestedRouteHandle,
-      runtimeSlot: requestRuntimeSlot,
-    });
-    if (!identity && isAppDomain) {
-      const mobileSessionHandle =
-        readMobileAppSessionRoutingHandle(path, c.req.url) ??
-        readMobileAppRouteCookie(path, cookieHeader);
-      if (mobileSessionHandle) {
-        identity = {
-          handle: mobileSessionHandle,
-          userId: '',
-          source: 'mobile-session',
-        };
-      }
-    }
-    if (
-      !identity &&
-      explicitVmRoute &&
-      explicitVmRouteHasValidAppAssetToken
-    ) {
-      identity = {
-        handle: explicitVmRoute.handle,
-        userId: '',
-        source: 'static-route',
-      };
-    }
-    if (!identity && isAppDomain && isAppDomainStaticAssetPath(path)) {
-      const shellRouteHandle = readShellRouteCookie(path, cookieHeader);
-      if (shellRouteHandle) {
-        identity = {
-          handle: shellRouteHandle,
-          userId: '',
-          source: 'static-route',
-        };
-      }
-    }
-    const isCookieRoutedShellAsset = Boolean(
-      identity &&
-      requestedRouteHandle &&
-      identity.handle === requestedRouteHandle &&
-      isAppDomain &&
-      isAppDomainStaticAssetPath(path),
-    );
-
-    // No session/JWT -- serve Clerk auth directly from the platform.
-    if (!identity) {
-      console.log(`[${isCodeDomain ? 'code' : 'app'}] no token path=${path}`);
-      if (isAppDomain && allowAuthShellUnroutedIdentity) {
-        return proxyAuthShell(c, host, { redirectToBillingOnFailure: false });
-      }
-      if (isCodeDomain && isCodeDomainStaticAssetPath(path)) {
-        applyNoStoreHeaders(c);
-        return c.text('Unauthorized', 401);
-      }
-      if (isAppDomain && explicitVmRoute && isViteAppAssetPath(explicitVmRoute.upstreamPath)) {
-        applyNoStoreHeaders(c);
-        return c.text('Unauthorized', 401);
-      }
-      if (isAppDomain && isAppDomainStaticAssetPath(path)) {
-        applyNoStoreHeaders(c);
-        return c.text('Unauthorized', 401);
-      }
-      if (isGatewayPath && requestedRouteHandle) {
-        applyNoStoreHeaders(c);
-        return c.json({ error: 'Matrix computer unavailable', code: 'machine_unavailable' }, 410);
-      }
-      if (isGatewayPath) {
-        return c.json({ error: 'Unauthorized' }, 401);
-      }
-      if (!publishableKey || !clerkAuth) {
-        return c.text('Clerk publishable key not configured', 500);
-      }
-      const scriptNonce = randomBytes(16).toString('base64');
-      applyAuthPageHeaders(c, scriptNonce);
-      return c.html(getAuthPage(publishableKey, authMode, scriptNonce, buildPostAuthRedirectPath(c.req.url), appOrigin(appEnv)));
-    }
-
-    console.log(`[${isCodeDomain ? 'code' : 'app'}] verified request path=${path}`);
-    if (isAppDomain && path === '/vm') {
-      return c.redirect('/runtime');
-    }
-    if (isAppDomain && path.startsWith('/vm/') && !explicitVmRoute) {
-      return c.text('Invalid Matrix OS computer', 400);
-    }
-    if (isAppDomain && explicitVmRoute) {
-      if ((!identity.userId || identity.source === 'mobile-session' || identity.source === 'static-route') && !explicitVmRouteHasValidAppAssetToken) {
-        applyNoStoreHeaders(c);
-        return c.text('Unauthorized', 401);
-      }
-      const machine = await getActiveUserMachineByHandle(db, explicitVmRoute.handle);
-      if (!machine || (identity.userId && machine.clerkUserId !== identity.userId)) {
-        applyNoStoreHeaders(c);
-        return c.text('Matrix OS computer unavailable', 404);
-      }
-      const entitlement = await getRuntimeEntitlementDecisionForUser(db, machine.clerkUserId, appEnv);
-      if (
-        !entitlement.runtimeProxyAllowed &&
-        !shouldProxyShellForBillingGate({
-          isAppDomain,
-          method: c.req.method,
-          upstreamPath: explicitVmRoute.upstreamPath,
-        })
-      ) {
-        applyNoStoreHeaders(c);
-        return c.json({ error: 'Paid beta access required' }, 402);
-      }
-      if (machine.status !== 'running') {
-        if (isGatewayPath) {
-          applyNoStoreHeaders(c);
-          return c.json({
-            error: 'VPS provisioning',
-            status: machine.status,
-          }, 503);
-        }
-        applyNoStoreHeaders(c);
-        return c.html(getVpsBootPage({ status: machine.status }), 503);
-      }
-      const qs = buildForwardedQueryString(c.req.url, APP_ASSET_ROUTE_OMITTED_QUERY_PARAMS);
-      const targetUrl = buildCustomerVpsProxyUrl(machine, explicitVmRoute.upstreamPath, qs);
-      if (!targetUrl) {
-        return c.json({ error: 'VPS unreachable' }, 502);
-      }
-      const headers = new Headers();
-      for (const [key, value] of Object.entries(c.req.header())) {
-        if (shouldForwardProxyHeader(key, value)) {
-          headers.set(key, value);
-        }
-      }
-      const rawCookie = c.req.header('cookie');
-      if (rawCookie) {
-        const forwarded = rawCookie
-          .split(';')
-          .map((p) => p.trim())
-          .filter((p) => p.startsWith('matrix_app_session__'))
-          .join('; ');
-        if (forwarded) headers.set('cookie', forwarded);
-      }
-      headers.set('host', `${machine.handle}.matrix-os.com`);
-      headers.set('x-forwarded-host', host);
-      headers.set('x-forwarded-proto', 'https');
-      headers.set('accept-encoding', 'identity');
-      headers.set('connection', 'close');
-      if (platformSecret) {
-        headers.set('authorization', `Bearer ${buildPlatformVerificationToken(machine.handle, platformSecret)}`);
-        if (identity.userId) {
-          headers.set('x-platform-user-id', identity.userId);
-          headers.set('x-platform-verified', buildPlatformUserProof(machine.handle, identity.userId, platformSecret));
-        }
-      }
-      if (shouldMarkNativeAppSession(identity, authHeader, cookieHeader, platformJwtSecret)) {
-        headers.set(NATIVE_APP_SESSION_PROXY_HEADER, '1');
-      }
-
-      try {
-        const upstream = await fetch(targetUrl, {
-          method: c.req.method,
-          headers,
-          redirect: 'manual',
-          signal: AbortSignal.timeout(PROXY_TIMEOUT_MS),
-          body: ['GET', 'HEAD'].includes(c.req.method) ? undefined : await c.req.blob(),
-          dispatcher: customerVpsProxyDispatcher,
-        } as RequestInit & { dispatcher: Agent });
-
-        const responseHeaders = sanitizeProxyResponseHeaders(upstream.headers);
-        applySandboxedAppAssetCorsHeaders(responseHeaders, explicitVmRoute.upstreamPath, c.req.header('origin'));
-        applyAppDomainRuntimeAssetCacheHeaders(responseHeaders, explicitVmRoute.upstreamPath, c.req.url);
-        responseHeaders.append('set-cookie', buildShellRouteCookie(machine.handle));
-        return await buildAppDomainProxyResponse({
-          upstream,
-          responseHeaders,
-          path: explicitVmRoute.upstreamPath,
-          handle: machine.handle,
-          platformSecret,
-          assetRouteToken: readAppAssetRouteToken(c.req.url),
-        });
-      } catch (err: unknown) {
-        logPlatformRouteError('app-domain explicit vps proxy', err);
-        return c.json({ error: 'VPS unreachable' }, 502);
-      }
-    }
-
-    if (isAppDomain && isIntegrationPath) {
-      c.set('platformUserId', identity.userId);
-      c.set('platformHandle', identity.handle);
-      return next();
-    }
-
-    if (isAppDomain && path === '/api/auth/ws-token') {
-      if (!platformJwtSecret) {
-        return c.json({ error: 'WebSocket auth unavailable' }, 503);
-      }
-      const issued = await issueSyncJwt({
-        secret: platformJwtSecret,
-        clerkUserId: identity.userId,
-        handle: identity.handle,
-        gatewayUrl: getGatewayUrlForHandle(identity.handle),
-        runtimeSlot: identity.runtimeSlot ?? requestRuntimeSlot,
-        expiresInSec: WS_TOKEN_EXPIRES_IN_SEC,
-      });
-      return c.json({
-        token: issued.token,
-        expiresAt: issued.expiresAt,
-      });
-    }
-
-    const shouldOfferRuntimePicker =
-      isAppDomain &&
-      identity.userId &&
-      identity.source !== 'mobile-session' &&
-      identity.source !== 'static-route' &&
-      path === '/runtime';
-    if (shouldOfferRuntimePicker) {
-      const machines = await listActiveUserMachinesByClerkId(db, identity.userId);
-      if (machines.length === 0 && path === '/runtime') {
-        return c.redirect('/');
-      }
-      if (path === '/runtime' || machines.length > 1) {
-        const pickerMachines = await buildRuntimePickerMachines(machines, platformSecret, customerVpsProxyDispatcher);
-        applyNoStoreHeaders(c);
-        c.header('X-Frame-Options', 'DENY');
-        c.header('Content-Security-Policy', "frame-ancestors 'none'; object-src 'none'; base-uri 'none'");
-        return c.html(getRuntimePickerPage({ machines: pickerMachines, selectedHandle: identity.handle }));
-      }
-      if (machines.length === 1 && runtimeSelection.source === 'default') {
-        singleMachineRuntimeSlot = machines[0]!.runtimeSlot;
-      }
-    }
-
-    let runtimeSlot = identity.runtimeSlot ?? singleMachineRuntimeSlot ?? requestRuntimeSlot;
-    let requestedActiveMachine: UserMachineRecord | undefined;
-    let runningMachine = identity.userId
-      ? await getRunningUserMachineByClerkId(db, identity.userId, runtimeSlot)
-      : await getRunningUserMachineByHandle(db, identity.handle);
-    if (!runningMachine && identity.userId) {
-      requestedActiveMachine = await getActiveUserMachineByClerkId(db, identity.userId, runtimeSlot);
-      if (!requestedActiveMachine) {
-        const handleMachine = await getRunningUserMachineByHandle(db, identity.handle);
-        if (handleMachine?.clerkUserId === identity.userId) {
-          runningMachine = handleMachine;
-        }
-      }
-    }
-    if (runningMachine) {
-      runtimeSlot = runningMachine.runtimeSlot;
-    }
-    const entitlement = runningMachine
-      ? await getRuntimeEntitlementDecisionForUser(db, runningMachine.clerkUserId, appEnv)
-      : requestedActiveMachine
-        ? await getRuntimeEntitlementDecisionForUser(db, requestedActiveMachine.clerkUserId, appEnv)
-      : getRuntimeEntitlementDecision(appEnv);
-    if (runningMachine) {
-      const qs = buildForwardedQueryString(c.req.url, APP_ASSET_ROUTE_OMITTED_QUERY_PARAMS);
-      if (
-        !entitlement.runtimeProxyAllowed &&
-        !shouldProxyShellForBillingGate({
-          isAppDomain,
-          method: c.req.method,
-          upstreamPath: path,
-        })
-      ) {
-        applyNoStoreHeaders(c);
-        return c.json({ error: 'Paid beta access required' }, 402);
-      }
-      const targetUrl = buildCustomerVpsProxyUrl(runningMachine, path, qs);
-      if (!targetUrl) {
-        return c.json({ error: 'VPS unreachable' }, 502);
-      }
-      const body = ['GET', 'HEAD'].includes(c.req.method) ? undefined : await c.req.blob();
-      const headers = isCodeDomain
-        ? buildCodeDomainProxyHeaders(
-            c.req.header(),
-            host,
-            platformSecret ? buildPlatformVerificationToken(runningMachine.handle, platformSecret) : undefined,
-          )
-        : new Headers();
-      if (!isCodeDomain) {
-        for (const [key, value] of Object.entries(c.req.header())) {
-          if (shouldForwardProxyHeader(key, value)) {
-            headers.set(key, value);
-          }
-        }
-        const rawCookie = c.req.header('cookie');
-        if (rawCookie) {
-          const forwarded = rawCookie
-            .split(';')
-            .map((p) => p.trim())
-            .filter((p) => p.startsWith('matrix_app_session__'))
-            .join('; ');
-          if (forwarded) headers.set('cookie', forwarded);
-        }
-        headers.set('host', `${runningMachine.handle}.matrix-os.com`);
-        headers.set('x-forwarded-host', host);
-        headers.set('x-forwarded-proto', 'https');
-        headers.set('accept-encoding', 'identity');
-        headers.set('connection', 'close');
-      }
-      if (platformSecret) {
-        headers.set('authorization', `Bearer ${buildPlatformVerificationToken(runningMachine.handle, platformSecret)}`);
-        const platformUserId =
-          identity.source === 'static-route' ? runningMachine.clerkUserId : identity.userId;
-        if (platformUserId) {
-          headers.set('x-platform-user-id', platformUserId);
-          if (identity.source !== 'mobile-session' && identity.source !== 'static-route') {
-            headers.set('x-platform-verified', buildPlatformUserProof(runningMachine.handle, platformUserId, platformSecret));
-          }
-        }
-      }
-      if (isAppDomain && shouldMarkNativeAppSession(identity, authHeader, cookieHeader, platformJwtSecret)) {
-        headers.set(NATIVE_APP_SESSION_PROXY_HEADER, '1');
-      }
-
-      try {
-        const upstream = await fetch(targetUrl, {
-          method: c.req.method,
-          headers,
-          redirect: 'manual',
-          signal: AbortSignal.timeout(PROXY_TIMEOUT_MS),
-          body,
-          dispatcher: customerVpsProxyDispatcher,
-        } as RequestInit & { dispatcher: Agent });
-        if (isCodeDomain && upstream.status >= 500) {
-          logCodeDomainUpstreamFailure({
-            handle: runningMachine.handle,
-            runtimeSlot: runningMachine.runtimeSlot,
-            publicIPv4: runningMachine.publicIPv4,
-            path,
-            status: upstream.status,
-          });
-        }
-
-        const responseHeaders = sanitizeProxyResponseHeaders(upstream.headers);
-        applySandboxedAppAssetCorsHeaders(responseHeaders, path, c.req.header('origin'));
-        if ((identity.source === 'static-route' || isCookieRoutedShellAsset) && isAppDomainStaticAssetPath(path)) {
-          applyCookieRoutedShellAssetCacheHeaders(responseHeaders);
-        }
-        applyAppDomainRuntimeAssetCacheHeaders(responseHeaders, path, c.req.url);
-        if (identity.source === 'mobile-session') {
-          const routeCookie = buildAppRouteCookie(runningMachine.handle, path);
-          if (routeCookie) responseHeaders.append('set-cookie', routeCookie);
-        }
-        if (isAppDomain && identity.source !== 'static-route') {
-          responseHeaders.append('set-cookie', buildShellRouteCookie(runningMachine.handle));
-        }
-        if (isCodeDomain && platformJwtSecret) {
-          const issued = await issueSyncJwt({
-            secret: platformJwtSecret,
-            clerkUserId: identity.userId,
-            handle: runningMachine.handle,
-            gatewayUrl: 'https://code.matrix-os.com',
-            runtimeSlot,
-            expiresInSec: CODE_SESSION_EXPIRES_IN_SEC,
-          });
-          responseHeaders.append('set-cookie', buildCodeSessionCookie(issued.token));
-        }
-
-        if (isAppDomain) {
-          return await buildAppDomainProxyResponse({
-            upstream,
-            responseHeaders,
-            path,
-            handle: runningMachine.handle,
-            platformSecret,
-            assetRouteToken: readAppAssetRouteToken(c.req.url),
-          });
-        }
-        return new Response(upstream.body, {
-          status: upstream.status,
-          headers: responseHeaders,
-        });
-      } catch (err: unknown) {
-        logPlatformRouteError(isCodeDomain ? 'code-domain vps proxy' : 'app-domain vps proxy', err);
-        return c.json({ error: 'VPS unreachable' }, 502);
-      }
-    }
-
-    const activeMachine = requestedActiveMachine ?? (identity.userId
-      ? await getActiveUserMachineByClerkId(db, identity.userId, runtimeSlot)
-      : await getActiveUserMachineByHandle(db, identity.handle));
-    if (activeMachine) {
-      if (
-        !entitlement.runtimeProxyAllowed &&
-        !shouldProxyShellForBillingGate({
-          isAppDomain,
-          method: c.req.method,
-          upstreamPath: path,
-        })
-      ) {
-        applyNoStoreHeaders(c);
-        return c.json({ error: 'Paid beta access required' }, 402);
-      }
-      if (isCodeDomain || isGatewayPath) {
-        applyNoStoreHeaders(c);
-        return c.json({
-          error: 'VPS provisioning',
-          status: activeMachine.status,
-        }, 503);
-      }
-      applyNoStoreHeaders(c);
-      return c.html(getVpsBootPage({ status: activeMachine.status }), 503);
-    }
-
-    if (!legacyContainerRoutingEnabled) {
-      applyNoStoreHeaders(c);
-      if (isCodeDomain || isGatewayPath) {
-        return c.json({ error: 'Matrix computer unavailable' }, 503);
-      }
-      if (allowAuthShellUnroutedIdentity && identity.handle === '') {
-        return proxyAuthShell(c, host);
-      }
-      return c.html(getNoContainerPage(), 503);
-    }
-
-    const record = await getContainer(db, identity.handle);
-    if (!record) return c.html(getNoContainerPage());
-
-    if (
-      !entitlement.runtimeProxyAllowed &&
-      !shouldProxyShellForBillingGate({
-        isAppDomain,
-        method: c.req.method,
-        upstreamPath: path,
-      })
-    ) {
-      applyNoStoreHeaders(c);
-      return c.json({ error: 'Paid beta access required' }, 402);
-    }
-
-    if (record.status === 'stopped') {
-      try {
-        await orchestrator.start(record.handle);
-      } catch (err: unknown) {
-        logPlatformRouteError('app-domain container start', err);
-        return c.json({ error: 'Failed to wake container' }, 503);
-      }
-    }
-
-    await updateLastActive(db, record.handle);
-
-    const qs = buildForwardedQueryString(c.req.url, APP_ASSET_ROUTE_OMITTED_QUERY_PARAMS);
-    const targetPort = isCodeDomain ? CODE_SERVER_PORT : (isGatewayPath || path === '/apps' || path.startsWith('/apps/')) ? 4000 : 3000;
-    const body = ['GET', 'HEAD'].includes(c.req.method) ? undefined : await c.req.blob();
-    const headers = isCodeDomain
-      ? buildCodeDomainProxyHeaders(
-          c.req.header(),
-          host,
-          platformSecret ? buildPlatformVerificationToken(record.handle, platformSecret) : undefined,
-        )
-      : new Headers();
-    if (!isCodeDomain) {
-      for (const [key, value] of Object.entries(c.req.header())) {
-        if (shouldForwardProxyHeader(key, value)) {
-          headers.set(key, value);
-        }
-      }
-    }
-    // Forward only the app-session cookies (spec 063). Clerk and other
-    // cookies are stripped because gateway auth goes via the bearer token
-    // set below; forwarding them would leak the user's Clerk session into
-    // the container process.
-    if (!isCodeDomain) {
-      const rawCookie = c.req.header('cookie');
-      if (rawCookie) {
-        const forwarded = rawCookie
-          .split(';')
-          .map((p) => p.trim())
-          .filter((p) => p.startsWith('matrix_app_session__'))
-          .join('; ');
-        if (forwarded) headers.set('cookie', forwarded);
-      }
-      headers.set('x-forwarded-host', host);
-      headers.set('x-forwarded-proto', 'https');
-      headers.set('accept-encoding', 'identity');
-      headers.set('connection', 'close');
-    }
-    if (platformSecret && isAppDomain) {
-      headers.set('authorization', `Bearer ${buildPlatformVerificationToken(record.handle, platformSecret)}`);
-      const platformUserId =
-        identity.source === 'static-route' ? record.clerkUserId : identity.userId;
-      if (platformUserId) {
-        headers.set('x-platform-user-id', platformUserId);
-        if (identity.source !== 'mobile-session' && identity.source !== 'static-route') {
-          headers.set('x-platform-verified', buildPlatformUserProof(record.handle, platformUserId, platformSecret));
-        }
-      }
-    }
-    if (isAppDomain && shouldMarkNativeAppSession(identity, authHeader, cookieHeader, platformJwtSecret)) {
-      headers.set(NATIVE_APP_SESSION_PROXY_HEADER, '1');
-    }
-
-    let lastErr: unknown = null;
-    for (let attempt = 0; attempt < 2; attempt += 1) {
-      const endpoint = await resolveContainerEndpoint(docker, db, record.handle, record.containerId);
-      if (!endpoint) {
-        console.warn(
-          `[platform] session-domain proxy unresolved handle=${record.handle} attempt=${attempt + 1} path=${path} targetPort=${targetPort}`,
-        );
-        return c.json({ error: 'Container unreachable' }, 502);
-      }
-
-      const targetUrl = `http://${endpoint.host}:${targetPort}${path}${qs}`;
-      try {
-        const upstream = await fetch(targetUrl, {
-          method: c.req.method,
-          headers,
-          redirect: 'manual',
-          signal: AbortSignal.timeout(PROXY_TIMEOUT_MS),
-          body,
-          dispatcher: containerProxyDispatcher,
-        } as RequestInit & { dispatcher: Agent });
-
-        const responseHeaders = sanitizeProxyResponseHeaders(upstream.headers);
-        applySandboxedAppAssetCorsHeaders(responseHeaders, path, c.req.header('origin'));
-        if ((identity.source === 'static-route' || isCookieRoutedShellAsset) && isAppDomainStaticAssetPath(path)) {
-          applyCookieRoutedShellAssetCacheHeaders(responseHeaders);
-        }
-        applyAppDomainRuntimeAssetCacheHeaders(responseHeaders, path, c.req.url);
-        if (identity.source === 'mobile-session') {
-          const routeCookie = buildAppRouteCookie(record.handle, path);
-          if (routeCookie) responseHeaders.append('set-cookie', routeCookie);
-        }
-        if (isAppDomain && identity.source !== 'static-route') {
-          responseHeaders.append('set-cookie', buildShellRouteCookie(record.handle));
-        }
-        if (isCodeDomain && platformJwtSecret) {
-          const issued = await issueSyncJwt({
-            secret: platformJwtSecret,
-            clerkUserId: identity.userId,
-            handle: record.handle,
-            gatewayUrl: 'https://code.matrix-os.com',
-            expiresInSec: CODE_SESSION_EXPIRES_IN_SEC,
-          });
-          responseHeaders.append('set-cookie', buildCodeSessionCookie(issued.token));
-        }
-
-        if (isAppDomain) {
-          return await buildAppDomainProxyResponse({
-            upstream,
-            responseHeaders,
-            path,
-            handle: record.handle,
-            platformSecret,
-            assetRouteToken: readAppAssetRouteToken(c.req.url),
-          });
-        }
-        return new Response(upstream.body, {
-          status: upstream.status,
-          headers: responseHeaders,
-        });
-      } catch (err: unknown) {
-        lastErr = err;
-        const routeName = isCodeDomain ? 'code-domain' : 'app-domain';
-        console.warn(
-          `[platform] ${routeName} proxy retry attempt=${attempt + 1} handle=${record.handle} target=${targetUrl} source=${endpoint.source} containerId=${endpoint.containerId ?? 'null'} error=${describeError(err)}`,
-        );
-      }
-    }
-
-    logPlatformRouteError(isCodeDomain ? 'code-domain proxy' : 'app-domain proxy', lastErr);
-    return c.json({ error: 'Container unreachable' }, 502);
-  });
+  app.use('*', bodyLimit({ maxSize: PROXY_BODY_LIMIT }), createSessionRoutingMiddleware({
+    db,
+    docker,
+    orchestrator,
+    clerkAuth,
+    appEnv,
+    platformSecret,
+    platformJwtSecret,
+    legacyContainerRoutingEnabled,
+    proxyTimeoutMs: PROXY_TIMEOUT_MS,
+    authShellProxyTimeoutMs: AUTH_SHELL_PROXY_TIMEOUT_MS,
+    codeServerPort: CODE_SERVER_PORT,
+    wsTokenExpiresInSec: WS_TOKEN_EXPIRES_IN_SEC,
+    containerProxyDispatcher,
+    customerVpsProxyDispatcher,
+    applyNoStoreHeaders,
+    getRuntimeEntitlementDecision,
+    getRuntimeEntitlementDecisionForUser,
+    getGatewayUrlForHandle,
+    logRouteError: logPlatformRouteError,
+  }));
 
   if (deps.integrationRoutes) {
     app.route('/api/integrations', deps.integrationRoutes);

--- a/packages/platform/src/session-routing-middleware.ts
+++ b/packages/platform/src/session-routing-middleware.ts
@@ -1,0 +1,922 @@
+import { randomBytes } from 'node:crypto';
+import type { Context, MiddlewareHandler } from 'hono';
+import type Dockerode from 'dockerode';
+import type { Agent } from 'undici';
+import type { Orchestrator } from './orchestrator.js';
+import type { ClerkAuth } from './clerk-auth.js';
+import {
+  type PlatformDB,
+  type UserMachineRecord,
+  getActiveUserMachineByClerkId,
+  getActiveUserMachineByHandle,
+  getContainer,
+  getRunningUserMachineByClerkId,
+  getRunningUserMachineByHandle,
+  listActiveUserMachinesByClerkId,
+  updateLastActive,
+} from './db.js';
+import { issueSyncJwt } from './sync-jwt.js';
+import {
+  buildCustomerVpsProxyUrl,
+  type EntitlementAccessDecision,
+} from './profile-routing.js';
+import {
+  buildPlatformVerificationToken,
+  timingSafeTokenEquals,
+} from './platform-token.js';
+import {
+  applyNoStoreResponseHeaders,
+  sanitizeProxyResponseHeaders,
+} from './proxy-headers.js';
+import {
+  buildBillingSetupPath,
+  buildForwardedQueryString,
+  buildPostAuthRedirectPath,
+  getAuthShellOrigin,
+  isAppDomainGatewayPath,
+  isBillingSetupPath,
+  readRuntimeSlotSelection,
+  shouldProxyAuthShellForUnroutedUser,
+  shouldProxyShellForBillingGate,
+} from './request-routing.js';
+import { isAppDomainHost, isCodeDomainHost } from './ws-upgrade.js';
+import { appOrigin } from './origins.js';
+import {
+  CLERK_SCRIPT_ORIGIN,
+  getAuthPage,
+  getNoContainerPage,
+  getRuntimePickerPage,
+  getVpsBootPage,
+} from './auth-pages.js';
+import { appDomainServiceWorkerResponse } from './app-domain-service-worker.js';
+import { isPostHogRelayPath, proxyPostHogRelay } from './posthog-relay.js';
+import {
+  CODE_SESSION_EXPIRES_IN_SEC,
+  NATIVE_APP_SESSION_PROXY_HEADER,
+  buildCodeSessionCookie,
+} from './session-cookies.js';
+import {
+  buildRuntimePickerMachines,
+} from './runtime-probes.js';
+import { HANDLE_PATTERN, describeError } from './platform-route-utils.js';
+import {
+  APP_ASSET_ROUTE_OMITTED_QUERY_PARAMS,
+  EDGE_SECRET_HEADER,
+  applyAppDomainRuntimeAssetCacheHeaders,
+  applyCookieRoutedShellAssetCacheHeaders,
+  applySandboxedAppAssetCorsHeaders,
+  buildAppDomainProxyResponse,
+  buildCodeDomainProxyHeaders,
+  hasValidExplicitVmAppAssetToken,
+  isAppDomainStaticAssetPath,
+  isCodeDomainStaticAssetPath,
+  isViteAppAssetPath,
+  readAppAssetRouteToken,
+  shouldForwardProxyHeader,
+} from './session-routing-proxy.js';
+import {
+  buildAppRouteCookie,
+  buildShellRouteCookie,
+  readAppDomainRouteCookie,
+  readExplicitVmRoute,
+  readMobileAppRouteCookie,
+  readMobileAppSessionRoutingHandle,
+  readShellRouteCookie,
+  resolveAppDomainIdentity,
+  shouldMarkNativeAppSession,
+} from './session-routing-identity.js';
+import {
+  buildPlatformUserProof,
+  getTrustedSessionRouteHost,
+} from './session-routing-websocket.js';
+import {
+  resolveContainerEndpoint,
+} from './container-endpoint.js';
+
+interface CreateSessionRoutingMiddlewareOpts {
+  db: PlatformDB;
+  docker?: Dockerode;
+  orchestrator: Orchestrator;
+  clerkAuth?: ClerkAuth;
+  appEnv: NodeJS.ProcessEnv;
+  platformSecret: string;
+  platformJwtSecret: string;
+  legacyContainerRoutingEnabled: boolean;
+  proxyTimeoutMs: number;
+  authShellProxyTimeoutMs: number;
+  codeServerPort: number;
+  wsTokenExpiresInSec: number;
+  containerProxyDispatcher: Agent;
+  customerVpsProxyDispatcher: Agent;
+  applyNoStoreHeaders: (c: Context) => void;
+  getRuntimeEntitlementDecision: (env: NodeJS.ProcessEnv) => EntitlementAccessDecision;
+  getRuntimeEntitlementDecisionForUser: (
+    db: PlatformDB,
+    clerkUserId: string,
+    env: NodeJS.ProcessEnv,
+  ) => Promise<EntitlementAccessDecision>;
+  getGatewayUrlForHandle: (handle: string) => string;
+  logRouteError: (context: string, err: unknown) => void;
+}
+
+function logCodeDomainUpstreamFailure(opts: {
+  handle: string;
+  runtimeSlot?: string | null;
+  publicIPv4?: string | null;
+  path: string;
+  status: number;
+}): void {
+  console.warn(
+    `[platform] code-domain vps upstream 5xx handle=${opts.handle} runtimeSlot=${opts.runtimeSlot ?? 'unknown'} publicIPv4=${opts.publicIPv4 ?? 'unknown'} path=${JSON.stringify(opts.path)} status=${opts.status}`,
+  );
+}
+
+function applyAuthPageHeaders(
+  c: Context,
+  scriptNonce: string,
+  applyNoStoreHeaders: (c: Context) => void,
+): void {
+  applyNoStoreHeaders(c);
+  c.header('X-Frame-Options', 'DENY');
+  c.header(
+    'Content-Security-Policy',
+    `frame-ancestors 'none'; script-src 'self' 'nonce-${scriptNonce}' ${CLERK_SCRIPT_ORIGIN} https://challenges.cloudflare.com; worker-src 'self' blob:; frame-src https://challenges.cloudflare.com; object-src 'none'; base-uri 'none'`,
+  );
+}
+
+export function createSessionRoutingMiddleware(opts: CreateSessionRoutingMiddlewareOpts): MiddlewareHandler {
+  const {
+    db,
+    docker,
+    orchestrator,
+    clerkAuth,
+    appEnv,
+    platformSecret,
+    platformJwtSecret,
+    legacyContainerRoutingEnabled,
+    proxyTimeoutMs,
+    authShellProxyTimeoutMs,
+    codeServerPort,
+    wsTokenExpiresInSec,
+    containerProxyDispatcher,
+    customerVpsProxyDispatcher,
+    applyNoStoreHeaders,
+    getRuntimeEntitlementDecision,
+    getRuntimeEntitlementDecisionForUser,
+    getGatewayUrlForHandle,
+    logRouteError,
+  } = opts;
+
+  async function proxyAuthShell(
+    c: Context,
+    host: string,
+    proxyOpts: { redirectToBillingOnFailure?: boolean } = {},
+  ): Promise<Response> {
+    const upstream = new URL(c.req.url);
+    const targetUrl = `${getAuthShellOrigin(appEnv)}${upstream.pathname}${upstream.search}`;
+    const headers = new Headers();
+    for (const [key, value] of Object.entries(c.req.header())) {
+      const lowerKey = key.toLowerCase();
+      if (lowerKey !== 'host' && value) {
+        headers.set(key, value);
+      }
+    }
+    headers.set('host', new URL(getAuthShellOrigin(appEnv)).host);
+    headers.set('x-forwarded-host', host);
+    // The auth shell is a local plain-HTTP Next server. Forwarding "https" here
+    // makes Next 16 attempt internal self-proxy requests to https://localhost:3200.
+    headers.set('x-forwarded-proto', 'http');
+    headers.set('accept-encoding', 'identity');
+    headers.set('connection', 'close');
+
+    try {
+      const response = await fetch(targetUrl, {
+        method: c.req.method,
+        headers,
+        redirect: 'manual',
+        signal: AbortSignal.timeout(authShellProxyTimeoutMs),
+      });
+      const responseHeaders = sanitizeProxyResponseHeaders(response.headers);
+      applyNoStoreResponseHeaders(responseHeaders);
+      return new Response(response.body, {
+        status: response.status,
+        headers: responseHeaders,
+      });
+    } catch (err: unknown) {
+      logRouteError('app-domain auth-shell proxy', err);
+      if (proxyOpts.redirectToBillingOnFailure !== false && !isBillingSetupPath(c.req.url)) {
+        return c.redirect(buildBillingSetupPath(c.req.url), 302);
+      }
+      const publishableKey = appEnv.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY;
+      if (!publishableKey) {
+        return c.text('Matrix OS shell unavailable', 503);
+      }
+      applyNoStoreHeaders(c);
+      const scriptNonce = randomBytes(16).toString('base64');
+      applyAuthPageHeaders(c, scriptNonce, applyNoStoreHeaders);
+      const authMode = c.req.path.startsWith('/sign-up') ? 'sign-up' : 'sign-in';
+      return c.html(
+        getAuthPage(publishableKey, authMode, scriptNonce, buildPostAuthRedirectPath(c.req.url), appOrigin(appEnv)),
+        200,
+      );
+    }
+  }
+
+  return async (c, next) => {
+    const host = getTrustedSessionRouteHost(
+      c.req.header('host'),
+      c.req.header('x-forwarded-host'),
+      c.req.header(EDGE_SECRET_HEADER),
+      appEnv.EDGE_ROUTER_SECRET,
+    );
+    const isAppDomain = isAppDomainHost(host);
+    const isCodeDomain = isCodeDomainHost(host);
+    if (!isAppDomain && !isCodeDomain) return next();
+
+    // Device-flow paths are served directly by the platform's auth-routes.ts
+    // (registered above). In normal dispatch they never reach this middleware,
+    // but we short-circuit explicitly so a misconfigured PLATFORM_JWT_SECRET or
+    // a future refactor can't accidentally proxy them into a user container.
+    const reqPath = c.req.path;
+    if (isAppDomain && reqPath === '/service-worker.js') {
+      return appDomainServiceWorkerResponse();
+    }
+    if (isAppDomain && isPostHogRelayPath(reqPath)) {
+      return proxyPostHogRelay(c, { logRouteError: logRouteError });
+    }
+    if (isAppDomain && (
+      reqPath === '/auth/device' ||
+      reqPath.startsWith('/auth/device/') ||
+      reqPath.startsWith('/api/auth/device/') ||
+      reqPath === '/api/auth/app-session' ||
+      reqPath === '/api/auth/provision-runtime' ||
+      reqPath === '/api/journey' ||
+      reqPath === '/api/journey/retry-provision'
+    )) {
+      return next();
+    }
+    if ((isAppDomain || isCodeDomain) && (reqPath === '/vps' || reqPath.startsWith('/vps/'))) {
+      return next();
+    }
+    if ((isAppDomain || isCodeDomain) && reqPath.startsWith('/internal/containers/')) {
+      return next();
+    }
+    const isPublicIntegrationPath =
+      reqPath === '/api/integrations/available' ||
+      reqPath.startsWith('/api/integrations/webhook/');
+    const isIntegrationPath =
+      reqPath === '/api/integrations' || reqPath.startsWith('/api/integrations/');
+    if (isAppDomain && isPublicIntegrationPath) {
+      return next();
+    }
+    if (isAppDomain && reqPath === '/voice/webhook/twilio') {
+      const webhookUrl = new URL(c.req.url);
+      const handle = webhookUrl.searchParams.get('handle') ?? '';
+      if (!HANDLE_PATTERN.test(handle)) {
+        return c.json({ error: 'Invalid handle' }, 400);
+      }
+
+      const runningMachine = await getRunningUserMachineByHandle(db, handle);
+      if (!runningMachine) {
+        return c.json({ error: 'VPS unavailable' }, 404);
+      }
+
+      const qs = buildForwardedQueryString(c.req.url, APP_ASSET_ROUTE_OMITTED_QUERY_PARAMS);
+      const targetUrl = buildCustomerVpsProxyUrl(runningMachine, reqPath, qs);
+      if (!targetUrl) {
+        return c.json({ error: 'VPS unreachable' }, 502);
+      }
+
+      const headers = new Headers();
+      for (const [key, value] of Object.entries(c.req.header())) {
+        if (shouldForwardProxyHeader(key, value)) {
+          headers.set(key, value);
+        }
+      }
+      headers.set('host', 'app.matrix-os.com');
+      headers.set('x-forwarded-host', host);
+      headers.set('x-forwarded-proto', 'https');
+      headers.set('accept-encoding', 'identity');
+      headers.set('connection', 'close');
+      if (platformSecret) {
+        headers.set('authorization', `Bearer ${buildPlatformVerificationToken(handle, platformSecret)}`);
+      }
+
+      try {
+        const upstream = await fetch(targetUrl, {
+          method: c.req.method,
+          headers,
+          redirect: 'manual',
+          signal: AbortSignal.timeout(proxyTimeoutMs),
+          body: ['GET', 'HEAD'].includes(c.req.method) ? undefined : await c.req.blob(),
+          dispatcher: customerVpsProxyDispatcher,
+        } as RequestInit & { dispatcher: Agent });
+
+        return new Response(upstream.body, {
+          status: upstream.status,
+          headers: sanitizeProxyResponseHeaders(upstream.headers),
+        });
+      } catch (err: unknown) {
+        logRouteError('app-domain voice webhook proxy', err);
+        return c.json({ error: 'VPS unreachable' }, 502);
+      }
+    }
+
+    const authHeader = c.req.header('authorization');
+    const cookieHeader = c.req.header('cookie');
+    const path = c.req.path;
+    const explicitVmRoute = isAppDomain ? readExplicitVmRoute(path) : null;
+    const explicitVmRouteHasValidAppAssetToken = Boolean(
+      explicitVmRoute &&
+      hasValidExplicitVmAppAssetToken({
+        method: c.req.method,
+        rawUrl: c.req.url,
+        route: explicitVmRoute,
+        platformSecret,
+      }),
+    );
+    const runtimeSelection = readRuntimeSlotSelection(c.req.url);
+    const requestRuntimeSlot = runtimeSelection.slot;
+    let singleMachineRuntimeSlot: string | null = null;
+
+    const isGatewayPath = isAppDomain && isAppDomainGatewayPath(path);
+    const allowAuthShellUnroutedIdentity = !legacyContainerRoutingEnabled && shouldProxyAuthShellForUnroutedUser({
+      isAppDomain,
+      method: c.req.method,
+      path,
+    });
+    const publishableKey = appEnv.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY;
+    const authMode = path.startsWith('/sign-up') ? 'sign-up' : 'sign-in';
+    const requestedRouteHandle = !explicitVmRoute && isAppDomain
+      ? readAppDomainRouteCookie(path, cookieHeader)
+      : null;
+
+    let identity = await resolveAppDomainIdentity({
+      authHeader,
+      cookieHeader,
+      clerkAuth,
+      db,
+      platformJwtSecret,
+      legacyContainerRoutingEnabled,
+      allowUnroutedClerkIdentity: Boolean(explicitVmRoute) || allowAuthShellUnroutedIdentity,
+      requestedHandle: requestedRouteHandle,
+      runtimeSlot: requestRuntimeSlot,
+    });
+    if (!identity && isAppDomain) {
+      const mobileSessionHandle =
+        readMobileAppSessionRoutingHandle(path, c.req.url) ??
+        readMobileAppRouteCookie(path, cookieHeader);
+      if (mobileSessionHandle) {
+        identity = {
+          handle: mobileSessionHandle,
+          userId: '',
+          source: 'mobile-session',
+        };
+      }
+    }
+    if (
+      !identity &&
+      explicitVmRoute &&
+      explicitVmRouteHasValidAppAssetToken
+    ) {
+      identity = {
+        handle: explicitVmRoute.handle,
+        userId: '',
+        source: 'static-route',
+      };
+    }
+    if (!identity && isAppDomain && isAppDomainStaticAssetPath(path)) {
+      const shellRouteHandle = readShellRouteCookie(path, cookieHeader);
+      if (shellRouteHandle) {
+        identity = {
+          handle: shellRouteHandle,
+          userId: '',
+          source: 'static-route',
+        };
+      }
+    }
+    const isCookieRoutedShellAsset = Boolean(
+      identity &&
+      requestedRouteHandle &&
+      identity.handle === requestedRouteHandle &&
+      isAppDomain &&
+      isAppDomainStaticAssetPath(path),
+    );
+
+    // No session/JWT -- serve Clerk auth directly from the platform.
+    if (!identity) {
+      console.log(`[${isCodeDomain ? 'code' : 'app'}] no token path=${path}`);
+      if (isAppDomain && allowAuthShellUnroutedIdentity) {
+        return proxyAuthShell(c, host, { redirectToBillingOnFailure: false });
+      }
+      if (isCodeDomain && isCodeDomainStaticAssetPath(path)) {
+        applyNoStoreHeaders(c);
+        return c.text('Unauthorized', 401);
+      }
+      if (isAppDomain && explicitVmRoute && isViteAppAssetPath(explicitVmRoute.upstreamPath)) {
+        applyNoStoreHeaders(c);
+        return c.text('Unauthorized', 401);
+      }
+      if (isAppDomain && isAppDomainStaticAssetPath(path)) {
+        applyNoStoreHeaders(c);
+        return c.text('Unauthorized', 401);
+      }
+      if (isGatewayPath && requestedRouteHandle) {
+        applyNoStoreHeaders(c);
+        return c.json({ error: 'Matrix computer unavailable', code: 'machine_unavailable' }, 410);
+      }
+      if (isGatewayPath) {
+        return c.json({ error: 'Unauthorized' }, 401);
+      }
+      if (!publishableKey || !clerkAuth) {
+        return c.text('Clerk publishable key not configured', 500);
+      }
+      const scriptNonce = randomBytes(16).toString('base64');
+      applyAuthPageHeaders(c, scriptNonce, applyNoStoreHeaders);
+      return c.html(getAuthPage(publishableKey, authMode, scriptNonce, buildPostAuthRedirectPath(c.req.url), appOrigin(appEnv)));
+    }
+
+    console.log(`[${isCodeDomain ? 'code' : 'app'}] verified request path=${path}`);
+    if (isAppDomain && path === '/vm') {
+      return c.redirect('/runtime');
+    }
+    if (isAppDomain && path.startsWith('/vm/') && !explicitVmRoute) {
+      return c.text('Invalid Matrix OS computer', 400);
+    }
+    if (isAppDomain && explicitVmRoute) {
+      if ((!identity.userId || identity.source === 'mobile-session' || identity.source === 'static-route') && !explicitVmRouteHasValidAppAssetToken) {
+        applyNoStoreHeaders(c);
+        return c.text('Unauthorized', 401);
+      }
+      const machine = await getActiveUserMachineByHandle(db, explicitVmRoute.handle);
+      if (!machine || (identity.userId && machine.clerkUserId !== identity.userId)) {
+        applyNoStoreHeaders(c);
+        return c.text('Matrix OS computer unavailable', 404);
+      }
+      const entitlement = await getRuntimeEntitlementDecisionForUser(db, machine.clerkUserId, appEnv);
+      if (
+        !entitlement.runtimeProxyAllowed &&
+        !shouldProxyShellForBillingGate({
+          isAppDomain,
+          method: c.req.method,
+          upstreamPath: explicitVmRoute.upstreamPath,
+        })
+      ) {
+        applyNoStoreHeaders(c);
+        return c.json({ error: 'Paid beta access required' }, 402);
+      }
+      if (machine.status !== 'running') {
+        if (isGatewayPath) {
+          applyNoStoreHeaders(c);
+          return c.json({
+            error: 'VPS provisioning',
+            status: machine.status,
+          }, 503);
+        }
+        applyNoStoreHeaders(c);
+        return c.html(getVpsBootPage({ status: machine.status }), 503);
+      }
+      const qs = buildForwardedQueryString(c.req.url, APP_ASSET_ROUTE_OMITTED_QUERY_PARAMS);
+      const targetUrl = buildCustomerVpsProxyUrl(machine, explicitVmRoute.upstreamPath, qs);
+      if (!targetUrl) {
+        return c.json({ error: 'VPS unreachable' }, 502);
+      }
+      const headers = new Headers();
+      for (const [key, value] of Object.entries(c.req.header())) {
+        if (shouldForwardProxyHeader(key, value)) {
+          headers.set(key, value);
+        }
+      }
+      const rawCookie = c.req.header('cookie');
+      if (rawCookie) {
+        const forwarded = rawCookie
+          .split(';')
+          .map((p) => p.trim())
+          .filter((p) => p.startsWith('matrix_app_session__'))
+          .join('; ');
+        if (forwarded) headers.set('cookie', forwarded);
+      }
+      headers.set('host', `${machine.handle}.matrix-os.com`);
+      headers.set('x-forwarded-host', host);
+      headers.set('x-forwarded-proto', 'https');
+      headers.set('accept-encoding', 'identity');
+      headers.set('connection', 'close');
+      if (platformSecret) {
+        headers.set('authorization', `Bearer ${buildPlatformVerificationToken(machine.handle, platformSecret)}`);
+        if (identity.userId) {
+          headers.set('x-platform-user-id', identity.userId);
+          headers.set('x-platform-verified', buildPlatformUserProof(machine.handle, identity.userId, platformSecret));
+        }
+      }
+      if (shouldMarkNativeAppSession(identity, authHeader, cookieHeader, platformJwtSecret)) {
+        headers.set(NATIVE_APP_SESSION_PROXY_HEADER, '1');
+      }
+
+      try {
+        const upstream = await fetch(targetUrl, {
+          method: c.req.method,
+          headers,
+          redirect: 'manual',
+          signal: AbortSignal.timeout(proxyTimeoutMs),
+          body: ['GET', 'HEAD'].includes(c.req.method) ? undefined : await c.req.blob(),
+          dispatcher: customerVpsProxyDispatcher,
+        } as RequestInit & { dispatcher: Agent });
+
+        const responseHeaders = sanitizeProxyResponseHeaders(upstream.headers);
+        applySandboxedAppAssetCorsHeaders(responseHeaders, explicitVmRoute.upstreamPath, c.req.header('origin'));
+        applyAppDomainRuntimeAssetCacheHeaders(responseHeaders, explicitVmRoute.upstreamPath, c.req.url);
+        responseHeaders.append('set-cookie', buildShellRouteCookie(machine.handle));
+        return await buildAppDomainProxyResponse({
+          upstream,
+          responseHeaders,
+          path: explicitVmRoute.upstreamPath,
+          handle: machine.handle,
+          platformSecret,
+          assetRouteToken: readAppAssetRouteToken(c.req.url),
+        });
+      } catch (err: unknown) {
+        logRouteError('app-domain explicit vps proxy', err);
+        return c.json({ error: 'VPS unreachable' }, 502);
+      }
+    }
+
+    if (isAppDomain && isIntegrationPath) {
+      c.set('platformUserId', identity.userId);
+      c.set('platformHandle', identity.handle);
+      return next();
+    }
+
+    if (isAppDomain && path === '/api/auth/ws-token') {
+      if (!platformJwtSecret) {
+        return c.json({ error: 'WebSocket auth unavailable' }, 503);
+      }
+      const issued = await issueSyncJwt({
+        secret: platformJwtSecret,
+        clerkUserId: identity.userId,
+        handle: identity.handle,
+        gatewayUrl: getGatewayUrlForHandle(identity.handle),
+        runtimeSlot: identity.runtimeSlot ?? requestRuntimeSlot,
+        expiresInSec: wsTokenExpiresInSec,
+      });
+      return c.json({
+        token: issued.token,
+        expiresAt: issued.expiresAt,
+      });
+    }
+
+    const shouldOfferRuntimePicker =
+      isAppDomain &&
+      identity.userId &&
+      identity.source !== 'mobile-session' &&
+      identity.source !== 'static-route' &&
+      path === '/runtime';
+    if (shouldOfferRuntimePicker) {
+      const machines = await listActiveUserMachinesByClerkId(db, identity.userId);
+      if (machines.length === 0 && path === '/runtime') {
+        return c.redirect('/');
+      }
+      if (path === '/runtime' || machines.length > 1) {
+        const pickerMachines = await buildRuntimePickerMachines(machines, platformSecret, customerVpsProxyDispatcher);
+        applyNoStoreHeaders(c);
+        c.header('X-Frame-Options', 'DENY');
+        c.header('Content-Security-Policy', "frame-ancestors 'none'; object-src 'none'; base-uri 'none'");
+        return c.html(getRuntimePickerPage({ machines: pickerMachines, selectedHandle: identity.handle }));
+      }
+      if (machines.length === 1 && runtimeSelection.source === 'default') {
+        singleMachineRuntimeSlot = machines[0]!.runtimeSlot;
+      }
+    }
+
+    let runtimeSlot = identity.runtimeSlot ?? singleMachineRuntimeSlot ?? requestRuntimeSlot;
+    let requestedActiveMachine: UserMachineRecord | undefined;
+    let runningMachine = identity.userId
+      ? await getRunningUserMachineByClerkId(db, identity.userId, runtimeSlot)
+      : await getRunningUserMachineByHandle(db, identity.handle);
+    if (!runningMachine && identity.userId) {
+      requestedActiveMachine = await getActiveUserMachineByClerkId(db, identity.userId, runtimeSlot);
+      if (!requestedActiveMachine) {
+        const handleMachine = await getRunningUserMachineByHandle(db, identity.handle);
+        if (handleMachine?.clerkUserId === identity.userId) {
+          runningMachine = handleMachine;
+        }
+      }
+    }
+    if (runningMachine) {
+      runtimeSlot = runningMachine.runtimeSlot;
+    }
+    const entitlement = runningMachine
+      ? await getRuntimeEntitlementDecisionForUser(db, runningMachine.clerkUserId, appEnv)
+      : requestedActiveMachine
+        ? await getRuntimeEntitlementDecisionForUser(db, requestedActiveMachine.clerkUserId, appEnv)
+        : getRuntimeEntitlementDecision(appEnv);
+    if (runningMachine) {
+      const qs = buildForwardedQueryString(c.req.url, APP_ASSET_ROUTE_OMITTED_QUERY_PARAMS);
+      if (
+        !entitlement.runtimeProxyAllowed &&
+        !shouldProxyShellForBillingGate({
+          isAppDomain,
+          method: c.req.method,
+          upstreamPath: path,
+        })
+      ) {
+        applyNoStoreHeaders(c);
+        return c.json({ error: 'Paid beta access required' }, 402);
+      }
+      const targetUrl = buildCustomerVpsProxyUrl(runningMachine, path, qs);
+      if (!targetUrl) {
+        return c.json({ error: 'VPS unreachable' }, 502);
+      }
+      const body = ['GET', 'HEAD'].includes(c.req.method) ? undefined : await c.req.blob();
+      const headers = isCodeDomain
+        ? buildCodeDomainProxyHeaders(
+            c.req.header(),
+            host,
+            platformSecret ? buildPlatformVerificationToken(runningMachine.handle, platformSecret) : undefined,
+          )
+        : new Headers();
+      if (!isCodeDomain) {
+        for (const [key, value] of Object.entries(c.req.header())) {
+          if (shouldForwardProxyHeader(key, value)) {
+            headers.set(key, value);
+          }
+        }
+        const rawCookie = c.req.header('cookie');
+        if (rawCookie) {
+          const forwarded = rawCookie
+            .split(';')
+            .map((p) => p.trim())
+            .filter((p) => p.startsWith('matrix_app_session__'))
+            .join('; ');
+          if (forwarded) headers.set('cookie', forwarded);
+        }
+        headers.set('host', `${runningMachine.handle}.matrix-os.com`);
+        headers.set('x-forwarded-host', host);
+        headers.set('x-forwarded-proto', 'https');
+        headers.set('accept-encoding', 'identity');
+        headers.set('connection', 'close');
+      }
+      if (platformSecret) {
+        headers.set('authorization', `Bearer ${buildPlatformVerificationToken(runningMachine.handle, platformSecret)}`);
+        const platformUserId =
+          identity.source === 'static-route' ? runningMachine.clerkUserId : identity.userId;
+        if (platformUserId) {
+          headers.set('x-platform-user-id', platformUserId);
+          if (identity.source !== 'mobile-session' && identity.source !== 'static-route') {
+            headers.set('x-platform-verified', buildPlatformUserProof(runningMachine.handle, platformUserId, platformSecret));
+          }
+        }
+      }
+      if (isAppDomain && shouldMarkNativeAppSession(identity, authHeader, cookieHeader, platformJwtSecret)) {
+        headers.set(NATIVE_APP_SESSION_PROXY_HEADER, '1');
+      }
+
+      try {
+        const upstream = await fetch(targetUrl, {
+          method: c.req.method,
+          headers,
+          redirect: 'manual',
+          signal: AbortSignal.timeout(proxyTimeoutMs),
+          body,
+          dispatcher: customerVpsProxyDispatcher,
+        } as RequestInit & { dispatcher: Agent });
+        if (isCodeDomain && upstream.status >= 500) {
+          logCodeDomainUpstreamFailure({
+            handle: runningMachine.handle,
+            runtimeSlot: runningMachine.runtimeSlot,
+            publicIPv4: runningMachine.publicIPv4,
+            path,
+            status: upstream.status,
+          });
+        }
+
+        const responseHeaders = sanitizeProxyResponseHeaders(upstream.headers);
+        applySandboxedAppAssetCorsHeaders(responseHeaders, path, c.req.header('origin'));
+        if ((identity.source === 'static-route' || isCookieRoutedShellAsset) && isAppDomainStaticAssetPath(path)) {
+          applyCookieRoutedShellAssetCacheHeaders(responseHeaders);
+        }
+        applyAppDomainRuntimeAssetCacheHeaders(responseHeaders, path, c.req.url);
+        if (identity.source === 'mobile-session') {
+          const routeCookie = buildAppRouteCookie(runningMachine.handle, path);
+          if (routeCookie) responseHeaders.append('set-cookie', routeCookie);
+        }
+        if (isAppDomain && identity.source !== 'static-route') {
+          responseHeaders.append('set-cookie', buildShellRouteCookie(runningMachine.handle));
+        }
+        if (isCodeDomain && platformJwtSecret) {
+          const issued = await issueSyncJwt({
+            secret: platformJwtSecret,
+            clerkUserId: identity.userId,
+            handle: runningMachine.handle,
+            gatewayUrl: 'https://code.matrix-os.com',
+            runtimeSlot,
+            expiresInSec: CODE_SESSION_EXPIRES_IN_SEC,
+          });
+          responseHeaders.append('set-cookie', buildCodeSessionCookie(issued.token));
+        }
+
+        if (isAppDomain) {
+          return await buildAppDomainProxyResponse({
+            upstream,
+            responseHeaders,
+            path,
+            handle: runningMachine.handle,
+            platformSecret,
+            assetRouteToken: readAppAssetRouteToken(c.req.url),
+          });
+        }
+        return new Response(upstream.body, {
+          status: upstream.status,
+          headers: responseHeaders,
+        });
+      } catch (err: unknown) {
+        logRouteError(isCodeDomain ? 'code-domain vps proxy' : 'app-domain vps proxy', err);
+        return c.json({ error: 'VPS unreachable' }, 502);
+      }
+    }
+
+    const activeMachine = requestedActiveMachine ?? (identity.userId
+      ? await getActiveUserMachineByClerkId(db, identity.userId, runtimeSlot)
+      : await getActiveUserMachineByHandle(db, identity.handle));
+    if (activeMachine) {
+      if (
+        !entitlement.runtimeProxyAllowed &&
+        !shouldProxyShellForBillingGate({
+          isAppDomain,
+          method: c.req.method,
+          upstreamPath: path,
+        })
+      ) {
+        applyNoStoreHeaders(c);
+        return c.json({ error: 'Paid beta access required' }, 402);
+      }
+      if (isCodeDomain || isGatewayPath) {
+        applyNoStoreHeaders(c);
+        return c.json({
+          error: 'VPS provisioning',
+          status: activeMachine.status,
+        }, 503);
+      }
+      applyNoStoreHeaders(c);
+      return c.html(getVpsBootPage({ status: activeMachine.status }), 503);
+    }
+
+    if (!legacyContainerRoutingEnabled) {
+      applyNoStoreHeaders(c);
+      if (isCodeDomain || isGatewayPath) {
+        return c.json({ error: 'Matrix computer unavailable' }, 503);
+      }
+      if (allowAuthShellUnroutedIdentity && identity.handle === '') {
+        return proxyAuthShell(c, host);
+      }
+      return c.html(getNoContainerPage(), 503);
+    }
+
+    const record = await getContainer(db, identity.handle);
+    if (!record) return c.html(getNoContainerPage());
+
+    if (
+      !entitlement.runtimeProxyAllowed &&
+      !shouldProxyShellForBillingGate({
+        isAppDomain,
+        method: c.req.method,
+        upstreamPath: path,
+      })
+    ) {
+      applyNoStoreHeaders(c);
+      return c.json({ error: 'Paid beta access required' }, 402);
+    }
+
+    if (record.status === 'stopped') {
+      try {
+        await orchestrator.start(record.handle);
+      } catch (err: unknown) {
+        logRouteError('app-domain container start', err);
+        return c.json({ error: 'Failed to wake container' }, 503);
+      }
+    }
+
+    await updateLastActive(db, record.handle);
+
+    const qs = buildForwardedQueryString(c.req.url, APP_ASSET_ROUTE_OMITTED_QUERY_PARAMS);
+    const targetPort = isCodeDomain ? codeServerPort : (isGatewayPath || path === '/apps' || path.startsWith('/apps/')) ? 4000 : 3000;
+    const body = ['GET', 'HEAD'].includes(c.req.method) ? undefined : await c.req.blob();
+    const headers = isCodeDomain
+      ? buildCodeDomainProxyHeaders(
+          c.req.header(),
+          host,
+          platformSecret ? buildPlatformVerificationToken(record.handle, platformSecret) : undefined,
+        )
+      : new Headers();
+    if (!isCodeDomain) {
+      for (const [key, value] of Object.entries(c.req.header())) {
+        if (shouldForwardProxyHeader(key, value)) {
+          headers.set(key, value);
+        }
+      }
+    }
+    // Forward only the app-session cookies (spec 063). Clerk and other
+    // cookies are stripped because gateway auth goes via the bearer token
+    // set below; forwarding them would leak the user's Clerk session into
+    // the container process.
+    if (!isCodeDomain) {
+      const rawCookie = c.req.header('cookie');
+      if (rawCookie) {
+        const forwarded = rawCookie
+          .split(';')
+          .map((p) => p.trim())
+          .filter((p) => p.startsWith('matrix_app_session__'))
+          .join('; ');
+        if (forwarded) headers.set('cookie', forwarded);
+      }
+      headers.set('x-forwarded-host', host);
+      headers.set('x-forwarded-proto', 'https');
+      headers.set('accept-encoding', 'identity');
+      headers.set('connection', 'close');
+    }
+    if (platformSecret && isAppDomain) {
+      headers.set('authorization', `Bearer ${buildPlatformVerificationToken(record.handle, platformSecret)}`);
+      const platformUserId =
+        identity.source === 'static-route' ? record.clerkUserId : identity.userId;
+      if (platformUserId) {
+        headers.set('x-platform-user-id', platformUserId);
+        if (identity.source !== 'mobile-session' && identity.source !== 'static-route') {
+          headers.set('x-platform-verified', buildPlatformUserProof(record.handle, platformUserId, platformSecret));
+        }
+      }
+    }
+    if (isAppDomain && shouldMarkNativeAppSession(identity, authHeader, cookieHeader, platformJwtSecret)) {
+      headers.set(NATIVE_APP_SESSION_PROXY_HEADER, '1');
+    }
+
+    let lastErr: unknown = null;
+    for (let attempt = 0; attempt < 2; attempt += 1) {
+      const endpoint = await resolveContainerEndpoint(docker, db, record.handle, record.containerId);
+      if (!endpoint) {
+        console.warn(
+          `[platform] session-domain proxy unresolved handle=${record.handle} attempt=${attempt + 1} path=${path} targetPort=${targetPort}`,
+        );
+        return c.json({ error: 'Container unreachable' }, 502);
+      }
+
+      const targetUrl = `http://${endpoint.host}:${targetPort}${path}${qs}`;
+      try {
+        const upstream = await fetch(targetUrl, {
+          method: c.req.method,
+          headers,
+          redirect: 'manual',
+          signal: AbortSignal.timeout(proxyTimeoutMs),
+          body,
+          dispatcher: containerProxyDispatcher,
+        } as RequestInit & { dispatcher: Agent });
+
+        const responseHeaders = sanitizeProxyResponseHeaders(upstream.headers);
+        applySandboxedAppAssetCorsHeaders(responseHeaders, path, c.req.header('origin'));
+        if ((identity.source === 'static-route' || isCookieRoutedShellAsset) && isAppDomainStaticAssetPath(path)) {
+          applyCookieRoutedShellAssetCacheHeaders(responseHeaders);
+        }
+        applyAppDomainRuntimeAssetCacheHeaders(responseHeaders, path, c.req.url);
+        if (identity.source === 'mobile-session') {
+          const routeCookie = buildAppRouteCookie(record.handle, path);
+          if (routeCookie) responseHeaders.append('set-cookie', routeCookie);
+        }
+        if (isAppDomain && identity.source !== 'static-route') {
+          responseHeaders.append('set-cookie', buildShellRouteCookie(record.handle));
+        }
+        if (isCodeDomain && platformJwtSecret) {
+          const issued = await issueSyncJwt({
+            secret: platformJwtSecret,
+            clerkUserId: identity.userId,
+            handle: record.handle,
+            gatewayUrl: 'https://code.matrix-os.com',
+            expiresInSec: CODE_SESSION_EXPIRES_IN_SEC,
+          });
+          responseHeaders.append('set-cookie', buildCodeSessionCookie(issued.token));
+        }
+
+        if (isAppDomain) {
+          return await buildAppDomainProxyResponse({
+            upstream,
+            responseHeaders,
+            path,
+            handle: record.handle,
+            platformSecret,
+            assetRouteToken: readAppAssetRouteToken(c.req.url),
+          });
+        }
+        return new Response(upstream.body, {
+          status: upstream.status,
+          headers: responseHeaders,
+        });
+      } catch (err: unknown) {
+        lastErr = err;
+        const routeName = isCodeDomain ? 'code-domain' : 'app-domain';
+        console.warn(
+          `[platform] ${routeName} proxy retry attempt=${attempt + 1} handle=${record.handle} target=${targetUrl} source=${endpoint.source} containerId=${endpoint.containerId ?? 'null'} error=${describeError(err)}`,
+        );
+      }
+    }
+
+    logRouteError(isCodeDomain ? 'code-domain proxy' : 'app-domain proxy', lastErr);
+    return c.json({ error: 'Container unreachable' }, 502);
+  };
+}


### PR DESCRIPTION
Summary
- Move the app/code-domain session-routing middleware out of packages/platform/src/main.ts into createSessionRoutingMiddleware().
- Keep createApp focused on Hono composition while preserving the same auth-shell, explicit VM, customer VPS, code-domain, and legacy-container routing behavior.
- Reduce packages/platform/src/main.ts to 1773 LOC; the new middleware module is 922 LOC and should be split further after review.

Tests
- pnpm --filter '@matrix-os/platform' exec tsc --noEmit -p tsconfig.typecheck.json
- bun run test -- tests/platform/proxy-routing.test.ts tests/platform/proxy-routing-billing.test.ts
- git diff --check

Review/Monitoring
- Waiting for Greptile on current head 661406f81d42f6e2196f5a89f336b3e2f9b87c85.
- ready-for-ci will be added only after current-head Greptile reaches 5/5.

Invariants
- Source of truth: session host/routing decisions remain in the moved middleware; createApp only mounts the middleware with explicit dependencies.
- Lock/transaction scope: no DB write or transaction semantics changed.
- Acceptable orphan states: unchanged; no-runtime, provisioning, stale route-cookie, and legacy-container fallbacks are covered by proxy-routing tests.
- Auth source of truth: Clerk, sync JWT, platform verification token, and edge-router forwarded-host checks are preserved through the same helper calls.
- Deferred scope: split session-routing-middleware.ts below 500 LOC and continue trimming startup/social/proxy code in follow-up stack slices.