### PR TITLE
feat(contracts): add coding agent schemas

### DIFF
--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@matrix-os/contracts",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "scripts": {
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "zod": "^4.4.3"
+  },
+  "devDependencies": {
+    "typescript": "^5.9.3"
+  }
+}

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -1,0 +1,494 @@
+import { z } from "zod/v4";
+
+const SAFE_ID_BODY = /^[A-Za-z0-9_-]+$/;
+const SAFE_SLUG = /^[a-z0-9][a-z0-9_-]{0,79}$/;
+const SAFE_REFERENCE = /^[A-Za-z0-9][A-Za-z0-9_.:-]{0,127}$/;
+const ISO_DATETIME = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{3})?Z$/;
+const UNSAFE_DISPLAY_TEXT = /(stack trace|\/home\/|\/tmp\/|\/var\/|\.ssh\/|id_rsa|bearer\s+[A-Za-z0-9._-]+|sk-[A-Za-z0-9_-]+)/i;
+const UNSAFE_ERROR_TEXT =
+  /(postgres|sqlite|mysql|pipedream|twilio|openai|anthropic|constraint|stack trace|zod|issues|\/home\/|\/tmp\/|\/var\/|\.ssh\/|id_rsa|bearer\s+[A-Za-z0-9._-]+|sk-[A-Za-z0-9_-]+)/i;
+
+const textEncoder = new TextEncoder();
+
+function byteLength(value: string): number {
+  return textEncoder.encode(value).byteLength;
+}
+
+function boundedText(maxChars: number, maxBytes = maxChars * 4) {
+  return z.string()
+    .trim()
+    .min(1)
+    .max(maxChars)
+    .refine((value) => byteLength(value) <= maxBytes, { message: "Text exceeds byte limit" });
+}
+
+function boundedDisplayText(maxChars: number, maxBytes = maxChars * 4) {
+  return boundedText(maxChars, maxBytes)
+    .refine((value) => !UNSAFE_DISPLAY_TEXT.test(value), { message: "Text is not safe for display" });
+}
+
+function boundedSafeErrorText(maxChars: number, maxBytes = maxChars * 4) {
+  return boundedText(maxChars, maxBytes)
+    .refine((value) => !UNSAFE_ERROR_TEXT.test(value), { message: "Text is not safe for clients" });
+}
+
+function prefixedId(prefix: string, maxBody = 128) {
+  return z.string()
+    .min(prefix.length + 1)
+    .max(prefix.length + maxBody)
+    .startsWith(prefix)
+    .refine((value) => SAFE_ID_BODY.test(value.slice(prefix.length)), { message: "Invalid identifier" });
+}
+
+function referenceId(max = 128) {
+  return z.string()
+    .min(1)
+    .max(max)
+    .regex(SAFE_REFERENCE, "Invalid reference identifier")
+    .refine((value) => !value.includes(".."), { message: "Reference cannot contain traversal" });
+}
+
+function safeRelativePath(max = 512) {
+  return z.string()
+    .min(1)
+    .max(max)
+    .refine((value) => !value.startsWith("/") && !value.includes("\0"), { message: "Invalid path" })
+    .refine((value) => !value.split(/[\\/]+/).some((part) => part === "" || part === "." || part === ".."), {
+      message: "Path traversal is not allowed",
+    });
+}
+
+export const RuntimeIdSchema = prefixedId("rt_");
+export const ProviderIdSchema = z.string().min(1).max(80).regex(SAFE_SLUG, "Invalid provider id");
+export const ProjectIdSchema = referenceId(160);
+export const TaskIdSchema = prefixedId("task_");
+export const ThreadIdSchema = prefixedId("thread_");
+export const EventIdSchema = prefixedId("evt_");
+export const ApprovalIdSchema = prefixedId("appr_");
+export const RequestIdSchema = prefixedId("req_");
+export const CorrelationIdSchema = prefixedId("corr_");
+export const TerminalSessionIdSchema = referenceId(128);
+export const CursorSchema = referenceId(160);
+export const IsoTimestampSchema = z.string().regex(ISO_DATETIME, "Invalid ISO timestamp");
+export const SafeDisplayStringSchema = boundedDisplayText(120, 512);
+export const BoundedTextSchema = (maxChars = 4000, maxBytes = 16 * 1024) => boundedText(maxChars, maxBytes);
+
+export const RecoveryActionSchema = z.enum([
+  "retry",
+  "sign_in",
+  "select_runtime",
+  "open_setup_terminal",
+  "resume",
+  "start_new_session",
+  "return_home",
+]);
+
+export const SafeClientErrorSchema = z.object({
+  code: z.string().min(1).max(80).regex(SAFE_SLUG),
+  safeMessage: boundedSafeErrorText(180, 720),
+  retryable: z.boolean(),
+  recoveryActions: z.array(RecoveryActionSchema).max(6).optional(),
+}).strict();
+
+export type SafeClientError = z.infer<typeof SafeClientErrorSchema>;
+
+export function boundedListSchema<T extends z.ZodType>(itemSchema: T, maxItems: number) {
+  return z.object({
+    items: z.array(itemSchema).max(maxItems),
+    hasMore: z.boolean(),
+    nextCursor: CursorSchema.optional(),
+    limit: z.number().int().min(1).max(maxItems),
+  }).strict();
+}
+
+export const RuntimeStatusSchema = z.enum(["available", "degraded", "offline", "unknown"]);
+export const RuntimeCapabilityIdSchema = z.enum([
+  "codingAgentsRuntimeSummary",
+  "codingAgentsDesktopWorkspace",
+  "codingAgentsMobileWorkspace",
+  "codingAgentsThreadCreate",
+  "codingAgentsApprovals",
+  "codingAgentsReview",
+  "codingAgentsNativeMobileTerminal",
+]);
+
+export const RuntimeTargetSchema = z.object({
+  id: RuntimeIdSchema,
+  label: SafeDisplayStringSchema,
+  status: RuntimeStatusSchema,
+  channel: z.string().min(1).max(40).regex(SAFE_SLUG).optional(),
+  ownerHandle: z.string().min(1).max(80).regex(SAFE_SLUG).optional(),
+}).strict();
+
+export const RuntimeCapabilitySchema = z.object({
+  id: RuntimeCapabilityIdSchema,
+  enabled: z.boolean(),
+  reason: SafeDisplayStringSchema.optional(),
+}).strict();
+
+export const RuntimeLimitsSchema = z.object({
+  maxPromptBytes: z.number().int().min(1).max(256 * 1024),
+  maxAttachmentCount: z.number().int().min(0).max(32),
+  maxTerminalInputBytes: z.number().int().min(1).max(256 * 1024),
+  maxListItems: z.number().int().min(1).max(200),
+}).strict();
+
+export const ProviderKindSchema = z.enum(["claude", "codex", "opencode", "cursor", "custom"]);
+export const ProviderAvailabilitySchema = z.enum([
+  "available",
+  "setup_required",
+  "auth_required",
+  "installing",
+  "unavailable",
+  "unknown",
+]);
+export const ProviderInstallStatusSchema = z.enum(["installed", "missing", "installing", "failed", "unknown"]);
+export const ProviderAuthStatusSchema = z.enum(["authenticated", "missing", "expired", "unknown"]);
+export const AgentModeSchema = z.enum(["default", "plan", "review", "full_access"]);
+export const ApprovalPolicySchema = z.enum(["untrusted", "on_request", "on_failure", "never"]);
+export const SandboxModeSchema = z.enum(["read_only", "workspace_write", "full_access"]);
+
+export const SafeSetupActionSchema = z.discriminatedUnion("kind", [
+  z.object({
+    id: ProviderIdSchema,
+    kind: z.literal("open_settings"),
+    label: SafeDisplayStringSchema,
+  }).strict(),
+  z.object({
+    id: ProviderIdSchema,
+    kind: z.literal("foreground_terminal"),
+    label: SafeDisplayStringSchema,
+    command: boundedDisplayText(280, 1024),
+  }).strict(),
+]);
+
+export const AgentProviderSummarySchema = z.object({
+  id: ProviderIdSchema,
+  displayName: SafeDisplayStringSchema,
+  kind: ProviderKindSchema,
+  availability: ProviderAvailabilitySchema,
+  installStatus: ProviderInstallStatusSchema,
+  authStatus: ProviderAuthStatusSchema,
+  supportedModes: z.array(AgentModeSchema).min(1).max(8),
+  defaultMode: AgentModeSchema,
+  defaultModel: SafeDisplayStringSchema.optional(),
+  setupActions: z.array(SafeSetupActionSchema).max(6),
+  lastCheckedAt: IsoTimestampSchema.optional(),
+}).strict().superRefine((value, ctx) => {
+  if (!value.supportedModes.includes(value.defaultMode)) {
+    ctx.addIssue({ code: "custom", message: "Default mode must be supported", path: ["defaultMode"] });
+  }
+});
+
+export type AgentProviderSummary = z.infer<typeof AgentProviderSummarySchema>;
+
+export const AgentThreadStatusSchema = z.enum([
+  "queued",
+  "starting",
+  "running",
+  "waiting_for_approval",
+  "waiting_for_input",
+  "completed",
+  "failed",
+  "aborted",
+  "stale",
+  "archived",
+]);
+
+export const AgentAttentionSchema = z.enum(["none", "approval_required", "input_required", "failed", "completed"]);
+
+export const AgentAttachmentSchema = z.object({
+  id: referenceId(128),
+  kind: z.enum(["file", "diff", "image", "log_excerpt", "structured_ref"]),
+  label: SafeDisplayStringSchema,
+  path: safeRelativePath().optional(),
+  mimeType: z.string().min(1).max(120).regex(/^[A-Za-z0-9][A-Za-z0-9.+/-]+$/).optional(),
+  sizeBytes: z.number().int().min(0).max(5 * 1024 * 1024).optional(),
+}).strict();
+
+export const CreateAgentThreadRequestSchema = z.object({
+  providerId: ProviderIdSchema,
+  prompt: boundedText(24_000, 96 * 1024),
+  projectId: ProjectIdSchema.optional(),
+  taskId: TaskIdSchema.optional(),
+  terminalSessionId: TerminalSessionIdSchema.optional(),
+  worktreeId: referenceId(160).optional(),
+  mode: AgentModeSchema.optional(),
+  approvalPolicy: ApprovalPolicySchema.optional(),
+  sandboxMode: SandboxModeSchema.optional(),
+  attachments: z.array(AgentAttachmentSchema).max(8).optional(),
+  clientRequestId: RequestIdSchema,
+}).strict();
+
+export type CreateAgentThreadRequest = z.infer<typeof CreateAgentThreadRequestSchema>;
+
+export const AgentThreadSummarySchema = z.object({
+  id: ThreadIdSchema,
+  providerId: ProviderIdSchema,
+  title: SafeDisplayStringSchema,
+  status: AgentThreadStatusSchema,
+  attention: AgentAttentionSchema.default("none"),
+  projectId: ProjectIdSchema.optional(),
+  taskId: TaskIdSchema.optional(),
+  terminalSessionId: TerminalSessionIdSchema.optional(),
+  eventCursor: CursorSchema.optional(),
+  createdAt: IsoTimestampSchema,
+  updatedAt: IsoTimestampSchema,
+}).strict();
+
+export type AgentThreadSummary = z.infer<typeof AgentThreadSummarySchema>;
+
+export const AgentThreadSnapshotSchema = z.object({
+  thread: AgentThreadSummarySchema,
+  events: boundedListSchema(z.unknown(), 200),
+}).strict();
+
+export const ApprovalDecisionSchema = z.enum(["approve", "approve_for_session", "decline", "cancel"]);
+export const ApprovalRiskSchema = z.enum(["low", "medium", "high"]);
+export const ApprovalActionKindSchema = z.enum(["command", "file_change", "network", "provider", "other"]);
+
+export const ApprovalPreviewSchema = z.object({
+  title: SafeDisplayStringSchema.optional(),
+  body: boundedDisplayText(2000, 8 * 1024).optional(),
+  truncated: z.boolean().default(false),
+}).strict();
+
+export const AgentApprovalRequestSchema = z.object({
+  approvalId: ApprovalIdSchema,
+  threadId: ThreadIdSchema,
+  title: SafeDisplayStringSchema,
+  safeDescription: boundedDisplayText(600, 2400),
+  risk: ApprovalRiskSchema,
+  actionKind: ApprovalActionKindSchema,
+  preview: ApprovalPreviewSchema.optional(),
+  allowedDecisions: z.array(ApprovalDecisionSchema).min(1).max(4),
+  expiresAt: IsoTimestampSchema.optional(),
+  correlationId: CorrelationIdSchema,
+}).strict();
+
+export const ApprovalDecisionRequestSchema = z.object({
+  decision: ApprovalDecisionSchema,
+  clientRequestId: RequestIdSchema,
+  correlationId: CorrelationIdSchema,
+}).strict();
+
+export const UserInputRequestSchema = z.object({
+  requestId: RequestIdSchema,
+  threadId: ThreadIdSchema,
+  title: SafeDisplayStringSchema,
+  safeDescription: boundedDisplayText(600, 2400),
+  placeholder: SafeDisplayStringSchema.optional(),
+  required: z.boolean().default(true),
+  expiresAt: IsoTimestampSchema.optional(),
+  correlationId: CorrelationIdSchema,
+}).strict();
+
+export const UserInputAnswerRequestSchema = z.object({
+  answer: boundedText(8000, 32 * 1024),
+  clientRequestId: RequestIdSchema,
+  correlationId: CorrelationIdSchema,
+}).strict();
+
+const BaseThreadEventSchema = z.object({
+  eventId: EventIdSchema,
+  threadId: ThreadIdSchema,
+  occurredAt: IsoTimestampSchema,
+});
+
+export const AgentThreadEventSchema = z.discriminatedUnion("type", [
+  BaseThreadEventSchema.extend({
+    type: z.literal("thread.created"),
+    thread: AgentThreadSummarySchema,
+  }).strict(),
+  BaseThreadEventSchema.extend({
+    type: z.literal("thread.status"),
+    status: AgentThreadStatusSchema,
+  }).strict(),
+  BaseThreadEventSchema.extend({
+    type: z.literal("assistant.text.delta"),
+    messageId: referenceId(128),
+    delta: boundedText(4000, 16 * 1024),
+  }).strict(),
+  BaseThreadEventSchema.extend({
+    type: z.literal("assistant.text.completed"),
+    messageId: referenceId(128),
+  }).strict(),
+  BaseThreadEventSchema.extend({
+    type: z.literal("tool.started"),
+    toolCallId: referenceId(128),
+    displayName: SafeDisplayStringSchema,
+    kind: SafeDisplayStringSchema,
+  }).strict(),
+  BaseThreadEventSchema.extend({
+    type: z.literal("tool.output"),
+    toolCallId: referenceId(128),
+    text: boundedText(4000, 16 * 1024),
+    truncated: z.boolean().optional(),
+  }).strict(),
+  BaseThreadEventSchema.extend({
+    type: z.literal("tool.completed"),
+    toolCallId: referenceId(128),
+    outcome: z.enum(["success", "failed", "cancelled"]),
+  }).strict(),
+  BaseThreadEventSchema.extend({
+    type: z.literal("approval.requested"),
+    approval: AgentApprovalRequestSchema,
+  }).strict(),
+  BaseThreadEventSchema.extend({
+    type: z.literal("approval.resolved"),
+    approvalId: ApprovalIdSchema,
+    decision: ApprovalDecisionSchema,
+  }).strict(),
+  BaseThreadEventSchema.extend({
+    type: z.literal("user_input.requested"),
+    request: UserInputRequestSchema,
+  }).strict(),
+  BaseThreadEventSchema.extend({
+    type: z.literal("file.changed"),
+    path: safeRelativePath(),
+    changeKind: z.enum(["created", "updated", "deleted", "renamed"]),
+  }).strict(),
+  BaseThreadEventSchema.extend({
+    type: z.literal("review.ready"),
+    reviewId: referenceId(128),
+    summary: z.object({
+      changedFileCount: z.number().int().min(0).max(10_000),
+      additions: z.number().int().min(0).max(1_000_000),
+      deletions: z.number().int().min(0).max(1_000_000),
+      partial: z.boolean(),
+    }).strict(),
+  }).strict(),
+  BaseThreadEventSchema.extend({
+    type: z.literal("terminal.bound"),
+    terminalSessionId: TerminalSessionIdSchema,
+  }).strict(),
+  BaseThreadEventSchema.extend({
+    type: z.literal("thread.error"),
+    error: SafeClientErrorSchema,
+  }).strict(),
+  BaseThreadEventSchema.extend({
+    type: z.literal("thread.completed"),
+    outcome: z.enum(["completed", "failed", "aborted"]),
+  }).strict(),
+]);
+
+export type AgentThreadEvent = z.infer<typeof AgentThreadEventSchema>;
+
+export const TerminalStatusSchema = z.enum(["starting", "running", "idle", "exited", "stale", "unavailable"]);
+
+export const TerminalSessionSummarySchema = z.object({
+  id: TerminalSessionIdSchema,
+  name: SafeDisplayStringSchema,
+  status: TerminalStatusSchema,
+  attachable: z.boolean(),
+  cwdLabel: SafeDisplayStringSchema.optional(),
+  createdAt: IsoTimestampSchema,
+  updatedAt: IsoTimestampSchema,
+}).strict();
+
+export type TerminalSessionSummary = z.infer<typeof TerminalSessionSummarySchema>;
+
+export const TerminalClientFrameSchema = z.discriminatedUnion("type", [
+  z.object({
+    type: z.literal("attach"),
+    sessionId: TerminalSessionIdSchema,
+    fromSeq: z.number().int().min(0).optional(),
+    cols: z.number().int().min(20).max(500).optional(),
+    rows: z.number().int().min(5).max(200).optional(),
+  }).strict(),
+  z.object({
+    type: z.literal("input"),
+    data: z.string().min(1).max(64 * 1024),
+  }).strict(),
+  z.object({
+    type: z.literal("resize"),
+    cols: z.number().int().min(20).max(500),
+    rows: z.number().int().min(5).max(200),
+  }).strict(),
+  z.object({
+    type: z.literal("detach"),
+  }).strict(),
+]);
+
+export const TerminalServerFrameSchema = z.discriminatedUnion("type", [
+  z.object({
+    type: z.literal("attached"),
+    sessionId: TerminalSessionIdSchema,
+    nextSeq: z.number().int().min(0).optional(),
+  }).strict(),
+  z.object({
+    type: z.literal("output"),
+    seq: z.number().int().min(0).optional(),
+    data: z.string().min(1).max(64 * 1024),
+  }).strict(),
+  z.object({
+    type: z.literal("replay-gap"),
+    fromSeq: z.number().int().min(0).optional(),
+    nextSeq: z.number().int().min(0),
+  }).strict(),
+  z.object({
+    type: z.literal("replay-end"),
+    nextSeq: z.number().int().min(0).optional(),
+  }).strict(),
+  z.object({
+    type: z.literal("exit"),
+    exitCode: z.number().int().nullable().optional(),
+  }).strict(),
+  z.object({
+    type: z.literal("safe-error"),
+    error: SafeClientErrorSchema,
+  }).strict(),
+]);
+
+export const ProjectSummarySchema = z.object({
+  id: ProjectIdSchema,
+  label: SafeDisplayStringSchema,
+  status: z.enum(["available", "missing", "stale", "unknown"]).default("unknown"),
+  updatedAt: IsoTimestampSchema.optional(),
+}).strict();
+
+export const ActivityEventSummarySchema = z.object({
+  id: EventIdSchema,
+  kind: z.enum(["thread", "terminal", "provider", "runtime", "review", "preview"]),
+  label: SafeDisplayStringSchema,
+  occurredAt: IsoTimestampSchema,
+}).strict();
+
+export const RuntimeSummarySchema = z.object({
+  runtime: RuntimeTargetSchema,
+  capabilities: z.array(RuntimeCapabilitySchema).max(32),
+  providers: z.array(AgentProviderSummarySchema).max(20),
+  projects: boundedListSchema(ProjectSummarySchema, 50),
+  activeThreads: boundedListSchema(AgentThreadSummarySchema, 50),
+  terminalSessions: boundedListSchema(TerminalSessionSummarySchema, 50),
+  recentActivity: boundedListSchema(ActivityEventSummarySchema, 100),
+  limits: RuntimeLimitsSchema,
+  serverTime: IsoTimestampSchema,
+}).strict();
+
+export type RuntimeSummary = z.infer<typeof RuntimeSummarySchema>;
+
+export const FilePathSchema = safeRelativePath();
+export const FileMetadataSchema = z.object({
+  path: FilePathSchema,
+  kind: z.enum(["file", "directory", "symlink", "unknown"]),
+  sizeBytes: z.number().int().min(0).max(100 * 1024 * 1024).optional(),
+  etag: referenceId(160).optional(),
+  updatedAt: IsoTimestampSchema.optional(),
+}).strict();
+
+export const ReviewFileDiffSchema = z.object({
+  path: FilePathSchema,
+  status: z.enum(["added", "modified", "deleted", "renamed", "binary"]),
+  additions: z.number().int().min(0).max(1_000_000),
+  deletions: z.number().int().min(0).max(1_000_000),
+  partial: z.boolean(),
+}).strict();
+
+export const PreviewSessionSummarySchema = z.object({
+  id: referenceId(128),
+  label: SafeDisplayStringSchema,
+  status: z.enum(["starting", "running", "failed", "stopped", "unknown"]),
+  origin: z.string().url().max(512).optional(),
+  updatedAt: IsoTimestampSchema.optional(),
+}).strict();

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -16,9 +16,9 @@ function byteLength(value: string): number {
 
 function boundedText(maxChars: number, maxBytes = maxChars * 4) {
   return z.string()
-    .trim()
     .min(1)
     .max(maxChars)
+    .refine((value) => value.trim().length > 0, { message: "Text cannot be blank" })
     .refine((value) => byteLength(value) <= maxBytes, { message: "Text exceeds byte limit" });
 }
 
@@ -68,6 +68,7 @@ export const ApprovalIdSchema = prefixedId("appr_");
 export const RequestIdSchema = prefixedId("req_");
 export const CorrelationIdSchema = prefixedId("corr_");
 export const TerminalSessionIdSchema = referenceId(128);
+export const WorktreeIdSchema = z.string().regex(/^wt_[a-z0-9]{12,40}$/, "Invalid worktree id");
 export const CursorSchema = referenceId(160);
 export const IsoTimestampSchema = z.string().regex(ISO_DATETIME, "Invalid ISO timestamp");
 export const SafeDisplayStringSchema = boundedDisplayText(120, 512);
@@ -212,7 +213,7 @@ export const CreateAgentThreadRequestSchema = z.object({
   projectId: ProjectIdSchema.optional(),
   taskId: TaskIdSchema.optional(),
   terminalSessionId: TerminalSessionIdSchema.optional(),
-  worktreeId: referenceId(160).optional(),
+  worktreeId: WorktreeIdSchema.optional(),
   mode: AgentModeSchema.optional(),
   approvalPolicy: ApprovalPolicySchema.optional(),
   sandboxMode: SandboxModeSchema.optional(),
@@ -237,11 +238,6 @@ export const AgentThreadSummarySchema = z.object({
 }).strict();
 
 export type AgentThreadSummary = z.infer<typeof AgentThreadSummarySchema>;
-
-export const AgentThreadSnapshotSchema = z.object({
-  thread: AgentThreadSummarySchema,
-  events: boundedListSchema(z.unknown(), 200),
-}).strict();
 
 export const ApprovalDecisionSchema = z.enum(["approve", "approve_for_session", "decline", "cancel"]);
 export const ApprovalRiskSchema = z.enum(["low", "medium", "high"]);
@@ -374,6 +370,11 @@ export const AgentThreadEventSchema = z.discriminatedUnion("type", [
 
 export type AgentThreadEvent = z.infer<typeof AgentThreadEventSchema>;
 
+export const AgentThreadSnapshotSchema = z.object({
+  thread: AgentThreadSummarySchema,
+  events: boundedListSchema(AgentThreadEventSchema, 200),
+}).strict();
+
 export const TerminalStatusSchema = z.enum(["starting", "running", "idle", "exited", "stale", "unavailable"]);
 
 export const TerminalSessionSummarySchema = z.object({
@@ -413,13 +414,30 @@ export const TerminalClientFrameSchema = z.discriminatedUnion("type", [
 export const TerminalServerFrameSchema = z.discriminatedUnion("type", [
   z.object({
     type: z.literal("attached"),
-    sessionId: TerminalSessionIdSchema,
+    sessionId: TerminalSessionIdSchema.optional(),
+    session: TerminalSessionIdSchema.optional(),
+    state: z.enum(["running", "exited"]).optional(),
+    exitCode: z.number().int().nullable().optional(),
+    fromSeq: z.number().int().min(0).optional(),
     nextSeq: z.number().int().min(0).optional(),
-  }).strict(),
+  }).strict().superRefine((value, ctx) => {
+    if (!value.sessionId && !value.session) {
+      ctx.addIssue({ code: "custom", message: "Attached frame requires a session identifier", path: ["sessionId"] });
+    }
+  }),
   z.object({
     type: z.literal("output"),
     seq: z.number().int().min(0).optional(),
     data: z.string().min(1).max(64 * 1024),
+  }).strict(),
+  z.object({
+    type: z.literal("replay-start"),
+    fromSeq: z.number().int().min(0).optional(),
+  }).strict(),
+  z.object({
+    type: z.literal("replay-evicted"),
+    fromSeq: z.number().int().min(0).optional(),
+    nextSeq: z.number().int().min(0),
   }).strict(),
   z.object({
     type: z.literal("replay-gap"),
@@ -429,10 +447,17 @@ export const TerminalServerFrameSchema = z.discriminatedUnion("type", [
   z.object({
     type: z.literal("replay-end"),
     nextSeq: z.number().int().min(0).optional(),
+    toSeq: z.number().int().min(0).nullable().optional(),
   }).strict(),
   z.object({
     type: z.literal("exit"),
     exitCode: z.number().int().nullable().optional(),
+    code: z.number().int().nullable().optional(),
+  }).strict(),
+  z.object({
+    type: z.literal("error"),
+    code: z.string().min(1).max(80).regex(SAFE_SLUG),
+    message: boundedSafeErrorText(180, 720),
   }).strict(),
   z.object({
     type: z.literal("safe-error"),
@@ -489,6 +514,6 @@ export const PreviewSessionSummarySchema = z.object({
   id: referenceId(128),
   label: SafeDisplayStringSchema,
   status: z.enum(["starting", "running", "failed", "stopped", "unknown"]),
-  origin: z.string().url().max(512).optional(),
+  origin: z.string().url().max(2048).optional(),
   updatedAt: IsoTimestampSchema.optional(),
 }).strict();

--- a/packages/contracts/tsconfig.json
+++ b/packages/contracts/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "declaration": true,
+    "outDir": "dist"
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -426,6 +426,16 @@ importers:
         specifier: ^5.9.3
         version: 5.9.3
 
+  packages/contracts:
+    dependencies:
+      zod:
+        specifier: ^4.4.3
+        version: 4.4.3
+    devDependencies:
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+
   packages/edge-router:
     devDependencies:
       '@cloudflare/workers-types':

--- a/tests/contracts/coding-agents.test.ts
+++ b/tests/contracts/coding-agents.test.ts
@@ -1,0 +1,230 @@
+import { describe, expect, it } from "vitest";
+import {
+  AgentProviderSummarySchema,
+  AgentThreadEventSchema,
+  ApprovalDecisionRequestSchema,
+  CreateAgentThreadRequestSchema,
+  FileMetadataSchema,
+  PreviewSessionSummarySchema,
+  ReviewFileDiffSchema,
+  RuntimeSummarySchema,
+  SafeClientErrorSchema,
+  TerminalClientFrameSchema,
+  TerminalServerFrameSchema,
+  TerminalSessionSummarySchema,
+  ThreadIdSchema,
+  UserInputAnswerRequestSchema,
+} from "../../packages/contracts/src/index.js";
+
+const now = "2026-07-06T12:00:00.000Z";
+
+describe("coding agent contracts", () => {
+  it("rejects unsafe identifiers and unsafe client error text", () => {
+    expect(ThreadIdSchema.parse("thread_abc-123")).toBe("thread_abc-123");
+    expect(() => ThreadIdSchema.parse("../thread_abc")).toThrow();
+    expect(() => ThreadIdSchema.parse("thread_")).toThrow();
+
+    expect(SafeClientErrorSchema.parse({
+      code: "runtime_unavailable",
+      safeMessage: "Workspace is temporarily unavailable. Try again.",
+      retryable: true,
+      recoveryActions: ["retry"],
+    })).toEqual({
+      code: "runtime_unavailable",
+      safeMessage: "Workspace is temporarily unavailable. Try again.",
+      retryable: true,
+      recoveryActions: ["retry"],
+    });
+
+    expect(() =>
+      SafeClientErrorSchema.parse({
+        code: "server_error",
+        safeMessage: "Postgres constraint failed in /home/matrix/project",
+        retryable: false,
+      }),
+    ).toThrow();
+  });
+
+  it("parses bounded runtime summaries without sensitive runtime data", () => {
+    const summary = RuntimeSummarySchema.parse({
+      runtime: {
+        id: "rt_primary",
+        label: "Primary Matrix computer",
+        status: "available",
+      },
+      capabilities: [
+        { id: "codingAgentsRuntimeSummary", enabled: true },
+        { id: "codingAgentsThreadCreate", enabled: false, reason: "Not enabled yet" },
+      ],
+      providers: [],
+      projects: { items: [], hasMore: false, limit: 20 },
+      activeThreads: { items: [], hasMore: false, limit: 20 },
+      terminalSessions: {
+        items: [
+          {
+            id: "term_main",
+            name: "main",
+            status: "running",
+            attachable: true,
+            createdAt: now,
+            updatedAt: now,
+          },
+        ],
+        hasMore: false,
+        limit: 20,
+      },
+      recentActivity: { items: [], hasMore: false, limit: 30 },
+      limits: {
+        maxPromptBytes: 24000,
+        maxAttachmentCount: 8,
+        maxTerminalInputBytes: 65536,
+        maxListItems: 50,
+      },
+      serverTime: now,
+    });
+
+    expect(summary.terminalSessions.items[0]?.attachable).toBe(true);
+    expect(() =>
+      RuntimeSummarySchema.parse({
+        ...summary,
+        terminalOutput: "secret output",
+      }),
+    ).toThrow();
+  });
+
+  it("validates providers, thread creation, events, approvals, and terminal frames", () => {
+    expect(AgentProviderSummarySchema.parse({
+      id: "codex",
+      displayName: "Codex",
+      kind: "codex",
+      availability: "available",
+      installStatus: "installed",
+      authStatus: "authenticated",
+      supportedModes: ["default", "review"],
+      defaultMode: "default",
+      setupActions: [],
+      lastCheckedAt: now,
+    }).id).toBe("codex");
+
+    expect(() =>
+      AgentProviderSummarySchema.parse({
+        id: "bad provider",
+        displayName: "/tmp/provider.log",
+        kind: "custom",
+        availability: "available",
+        installStatus: "installed",
+        authStatus: "authenticated",
+        supportedModes: ["default"],
+        defaultMode: "default",
+        setupActions: [{ id: "setup", label: "Run setup", kind: "raw_command", command: "cat ~/.ssh/id_rsa" }],
+      }),
+    ).toThrow();
+
+    expect(CreateAgentThreadRequestSchema.parse({
+      providerId: "codex",
+      prompt: "Fix the failing gateway tests.",
+      clientRequestId: "req_123",
+      mode: "default",
+      approvalPolicy: "on_request",
+      sandboxMode: "workspace_write",
+    }).providerId).toBe("codex");
+    expect(() =>
+      CreateAgentThreadRequestSchema.parse({
+        providerId: "codex",
+        prompt: "",
+        clientRequestId: "req_123",
+      }),
+    ).toThrow();
+
+    expect(AgentThreadEventSchema.parse({
+      type: "approval.requested",
+      eventId: "evt_1",
+      threadId: "thread_1",
+      occurredAt: now,
+      approval: {
+        approvalId: "appr_1",
+        threadId: "thread_1",
+        title: "Approve command",
+        safeDescription: "The agent wants to run a workspace command.",
+        risk: "medium",
+        actionKind: "command",
+        allowedDecisions: ["approve", "decline"],
+        correlationId: "corr_1",
+      },
+    }).type).toBe("approval.requested");
+
+    expect(TerminalClientFrameSchema.parse({ type: "resize", cols: 120, rows: 40 })).toEqual({
+      type: "resize",
+      cols: 120,
+      rows: 40,
+    });
+    expect(() => TerminalClientFrameSchema.parse({ type: "resize", cols: 2000, rows: 40 })).toThrow();
+
+    expect(TerminalSessionSummarySchema.parse({
+      id: "term_main",
+      name: "main",
+      status: "running",
+      attachable: true,
+      createdAt: now,
+      updatedAt: now,
+    }).status).toBe("running");
+  });
+
+  it("validates decision, input, file, review, preview, and server frame contracts", () => {
+    expect(ApprovalDecisionRequestSchema.parse({
+      decision: "approve",
+      clientRequestId: "req_approve",
+      correlationId: "corr_approve",
+    }).decision).toBe("approve");
+
+    expect(UserInputAnswerRequestSchema.parse({
+      answer: "Please continue with the safer implementation.",
+      clientRequestId: "req_answer",
+      correlationId: "corr_answer",
+    }).answer).toBe("Please continue with the safer implementation.");
+
+    expect(FileMetadataSchema.parse({
+      path: "src/index.ts",
+      kind: "file",
+      sizeBytes: 512,
+      etag: "etag_123",
+      updatedAt: now,
+    }).path).toBe("src/index.ts");
+    expect(() => FileMetadataSchema.parse({ path: "../secret", kind: "file" })).toThrow();
+
+    expect(ReviewFileDiffSchema.parse({
+      path: "src/index.ts",
+      status: "modified",
+      additions: 12,
+      deletions: 4,
+      partial: true,
+    }).partial).toBe(true);
+    expect(() =>
+      ReviewFileDiffSchema.parse({
+        path: "src/index.ts",
+        status: "modified",
+        additions: 1_000_001,
+        deletions: 0,
+        partial: false,
+      }),
+    ).toThrow();
+
+    expect(PreviewSessionSummarySchema.parse({
+      id: "preview_main",
+      label: "Development preview",
+      status: "running",
+      origin: "https://preview.example.com",
+      updatedAt: now,
+    }).status).toBe("running");
+
+    expect(TerminalServerFrameSchema.parse({
+      type: "safe-error",
+      error: {
+        code: "session_unavailable",
+        safeMessage: "Terminal session is unavailable. Start a new session.",
+        retryable: false,
+        recoveryActions: ["start_new_session"],
+      },
+    }).type).toBe("safe-error");
+  });
+});

--- a/tests/contracts/coding-agents.test.ts
+++ b/tests/contracts/coding-agents.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   AgentProviderSummarySchema,
   AgentThreadEventSchema,
+  AgentThreadSnapshotSchema,
   ApprovalDecisionRequestSchema,
   CreateAgentThreadRequestSchema,
   FileMetadataSchema,
@@ -135,6 +136,26 @@ describe("coding agent contracts", () => {
         clientRequestId: "req_123",
       }),
     ).toThrow();
+    const promptWithWhitespace = "  cat <<'EOF'\n  keep indentation\nEOF\n";
+    expect(CreateAgentThreadRequestSchema.parse({
+      providerId: "codex",
+      prompt: promptWithWhitespace,
+      clientRequestId: "req_preserve",
+    }).prompt).toBe(promptWithWhitespace);
+    expect(CreateAgentThreadRequestSchema.parse({
+      providerId: "codex",
+      prompt: "Use the selected worktree.",
+      worktreeId: "wt_abc123def456",
+      clientRequestId: "req_worktree",
+    }).worktreeId).toBe("wt_abc123def456");
+    expect(() =>
+      CreateAgentThreadRequestSchema.parse({
+        providerId: "codex",
+        prompt: "Use a worktree.",
+        worktreeId: "WT_bad:ref",
+        clientRequestId: "req_worktree",
+      }),
+    ).toThrow();
 
     expect(AgentThreadEventSchema.parse({
       type: "approval.requested",
@@ -152,6 +173,46 @@ describe("coding agent contracts", () => {
         correlationId: "corr_1",
       },
     }).type).toBe("approval.requested");
+    expect(AgentThreadSnapshotSchema.parse({
+      thread: {
+        id: "thread_1",
+        providerId: "codex",
+        title: "Fix tests",
+        status: "running",
+        createdAt: now,
+        updatedAt: now,
+      },
+      events: {
+        items: [
+          {
+            type: "thread.status",
+            eventId: "evt_snapshot",
+            threadId: "thread_1",
+            occurredAt: now,
+            status: "running",
+          },
+        ],
+        hasMore: false,
+        limit: 200,
+      },
+    }).events.items[0]?.type).toBe("thread.status");
+    expect(() =>
+      AgentThreadSnapshotSchema.parse({
+        thread: {
+          id: "thread_1",
+          providerId: "codex",
+          title: "Fix tests",
+          status: "running",
+          createdAt: now,
+          updatedAt: now,
+        },
+        events: {
+          items: [{ rawProviderPayload: "do not accept unknown event shapes" }],
+          hasMore: false,
+          limit: 200,
+        },
+      }),
+    ).toThrow();
 
     expect(TerminalClientFrameSchema.parse({ type: "resize", cols: 120, rows: 40 })).toEqual({
       type: "resize",
@@ -182,6 +243,12 @@ describe("coding agent contracts", () => {
       clientRequestId: "req_answer",
       correlationId: "corr_answer",
     }).answer).toBe("Please continue with the safer implementation.");
+    const answerWithWhitespace = "\n  keep this exact answer  \n";
+    expect(UserInputAnswerRequestSchema.parse({
+      answer: answerWithWhitespace,
+      clientRequestId: "req_answer_preserve",
+      correlationId: "corr_answer",
+    }).answer).toBe(answerWithWhitespace);
 
     expect(FileMetadataSchema.parse({
       path: "src/index.ts",
@@ -213,10 +280,29 @@ describe("coding agent contracts", () => {
       id: "preview_main",
       label: "Development preview",
       status: "running",
-      origin: "https://preview.example.com",
+      origin: `https://preview.example.com/${"a".repeat(700)}?token=${"b".repeat(700)}`,
       updatedAt: now,
     }).status).toBe("running");
 
+    expect(TerminalServerFrameSchema.parse({
+      type: "attached",
+      session: "main",
+      state: "running",
+      fromSeq: 0,
+    }).type).toBe("attached");
+    expect(TerminalServerFrameSchema.parse({
+      type: "attached",
+      sessionId: "550e8400-e29b-41d4-a716-446655440000",
+      state: "running",
+    }).type).toBe("attached");
+    expect(TerminalServerFrameSchema.parse({ type: "replay-start", fromSeq: 0 }).type).toBe("replay-start");
+    expect(TerminalServerFrameSchema.parse({ type: "replay-end", toSeq: null }).type).toBe("replay-end");
+    expect(TerminalServerFrameSchema.parse({ type: "replay-evicted", fromSeq: 0, nextSeq: 10 }).type).toBe("replay-evicted");
+    expect(TerminalServerFrameSchema.parse({
+      type: "error",
+      code: "invalid_message",
+      message: "Invalid message",
+    }).type).toBe("error");
     expect(TerminalServerFrameSchema.parse({
       type: "safe-error",
       error: {


### PR DESCRIPTION
## Summary
- Add schema-only @matrix-os/contracts workspace package for coding-agent runtime contracts.
- Cover IDs, safe client errors, runtime summaries, providers, thread create/events, approvals/input, terminal summaries/frames, file metadata, review diffs, and preview summaries.
- Address review feedback for free-form text preservation, worktree IDs, snapshot event validation, deployed terminal frame compatibility, and preview URL length.
- Add focused Vitest contract coverage and update pnpm lockfile workspace importers.

## Invariants
- Source of truth: this PR defines validation contracts only; gateway/runtime persistence remains unchanged and server-side.
- Lock/transaction scope: no writes, migrations, or runtime state mutations are introduced.
- Acceptable orphan states: none introduced; schemas are not wired into runtime behavior yet.
- Auth source of truth: unchanged; all future routes must apply existing owner/runtime auth at the gateway boundary.
- Deferred scope: runtime summary route, provider registry adapters, desktop/mobile dashboards, thread stores, WebSockets, approvals, files/review/preview services, and docs are deferred to follow-up PRs.

## Validation
- pnpm exec vitest run tests/contracts/coding-agents.test.ts
- pnpm --filter @matrix-os/contracts run typecheck
- bun run check:patterns
- bun run typecheck
- git diff --check

## Notes
- UI screenshots are not applicable; this slice has no UI changes.
- No runtime behavior changes.