### PR TITLE
feat(gateway): expose coding agent runtime summary

### DIFF
--- a/apps/mobile/__tests__/canvas-entry.test.tsx
+++ b/apps/mobile/__tests__/canvas-entry.test.tsx
@@ -3,10 +3,10 @@ jest.mock("@react-native-async-storage/async-storage", () => ({
   setItem: jest.fn(),
 }));
 
-const mockReplace = jest.fn();
+const mockDismissTo = jest.fn();
 
 jest.mock("expo-router", () => ({
-  useRouter: () => ({ replace: mockReplace }),
+  useRouter: () => ({ dismissTo: mockDismissTo }),
 }));
 
 jest.mock("react-native-safe-area-context", () => ({
@@ -38,6 +38,6 @@ describe("CanvasEntryScreen", () => {
     ));
 
     fireEvent.press(screen.getByLabelText("Apps"));
-    expect(mockReplace).toHaveBeenCalledWith("/(tabs)/apps");
+    expect(mockDismissTo).toHaveBeenCalledWith("/(tabs)/apps");
   });
 });

--- a/apps/mobile/__tests__/canvas-entry.test.tsx
+++ b/apps/mobile/__tests__/canvas-entry.test.tsx
@@ -3,10 +3,10 @@ jest.mock("@react-native-async-storage/async-storage", () => ({
   setItem: jest.fn(),
 }));
 
-const mockDismissTo = jest.fn();
+const mockReplace = jest.fn();
 
 jest.mock("expo-router", () => ({
-  useRouter: () => ({ dismissTo: mockDismissTo }),
+  useRouter: () => ({ replace: mockReplace }),
 }));
 
 jest.mock("react-native-safe-area-context", () => ({
@@ -38,6 +38,6 @@ describe("CanvasEntryScreen", () => {
     ));
 
     fireEvent.press(screen.getByLabelText("Apps"));
-    expect(mockDismissTo).toHaveBeenCalledWith("/(tabs)/apps");
+    expect(mockReplace).toHaveBeenCalledWith("/(tabs)/apps");
   });
 });

--- a/packages/gateway/package.json
+++ b/packages/gateway/package.json
@@ -31,6 +31,7 @@
     "@hono/node-server": "^1.19.9",
     "@hono/node-ws": "^1.3.1",
     "@finnaai/matrix": "workspace:*",
+    "@matrix-os/contracts": "workspace:*",
     "@matrix-os/kernel": "workspace:*",
     "@matrix-os/observability": "workspace:*",
     "@pipedream/sdk": "^2.4.3",

--- a/packages/gateway/src/coding-agents/routes.ts
+++ b/packages/gateway/src/coding-agents/routes.ts
@@ -1,0 +1,45 @@
+import { Hono, type Context } from "hono";
+import type { ContentfulStatusCode } from "hono/utils/http-status";
+import { SafeClientErrorSchema } from "@matrix-os/contracts";
+import {
+  isRequestPrincipalError,
+  mapRequestPrincipalError,
+  requireRequestPrincipal,
+  type RequestPrincipal,
+} from "../request-principal.js";
+import type { CodingAgentRuntimeSummaryService } from "./runtime-summary.js";
+
+export interface CodingAgentRouteDeps {
+  service: CodingAgentRuntimeSummaryService;
+  getPrincipal?: (c: Context) => RequestPrincipal;
+}
+
+function summaryUnavailable() {
+  return SafeClientErrorSchema.parse({
+    code: "summary_unavailable",
+    safeMessage: "Runtime summary is temporarily unavailable. Try again.",
+    retryable: true,
+    recoveryActions: ["retry"],
+  });
+}
+
+export function createCodingAgentRoutes(deps: CodingAgentRouteDeps): Hono {
+  const app = new Hono();
+  const principalFor = (c: Context) => deps.getPrincipal?.(c) ?? requireRequestPrincipal(c);
+
+  app.get("/summary", async (c) => {
+    try {
+      const principal = principalFor(c);
+      return c.json(await deps.service.getSummary(principal));
+    } catch (err: unknown) {
+      if (isRequestPrincipalError(err)) {
+        const mapped = mapRequestPrincipalError(err);
+        return c.json(mapped.body, mapped.status as ContentfulStatusCode);
+      }
+      console.warn("[coding-agents] summary route failed:", err instanceof Error ? err.message : String(err));
+      return c.json({ error: summaryUnavailable() }, 503);
+    }
+  });
+
+  return app;
+}

--- a/packages/gateway/src/coding-agents/runtime-summary.ts
+++ b/packages/gateway/src/coding-agents/runtime-summary.ts
@@ -1,6 +1,6 @@
-import { relative } from "node:path";
 import {
   RuntimeSummarySchema,
+  SafeDisplayStringSchema,
   type AgentProviderSummary,
   type RuntimeSummary,
   type TerminalSessionSummary,
@@ -12,12 +12,21 @@ import type {
   AgentId,
 } from "../onboarding/activation-contracts.js";
 import type { AgentCredentialStatusService } from "../onboarding/agent-credential-status.js";
-import type { SessionInfo } from "../session-registry.js";
 
 const TERMINAL_SUMMARY_LIMIT = 20;
 
+export interface CodingAgentTerminalSession {
+  name: string;
+  status?: "active" | "exited";
+  visualStatus?: "running" | "finished" | "idle" | "waiting";
+  createdAt: string;
+  updatedAt: string;
+  attachedClients?: number;
+  recoverable?: boolean;
+}
+
 export interface CodingAgentTerminalSessionRegistry {
-  list(): SessionInfo[];
+  list(): Promise<CodingAgentTerminalSession[]> | CodingAgentTerminalSession[];
 }
 
 export interface CodingAgentRuntimeSummaryService {
@@ -28,6 +37,7 @@ export interface CodingAgentRuntimeSummaryOptions {
   homePath: string;
   terminalRegistry?: CodingAgentTerminalSessionRegistry;
   agentCredentials?: Pick<AgentCredentialStatusService, "getStatus">;
+  terminalOwnerId?: string;
   now?: () => Date;
   runtime?: {
     id?: string;
@@ -43,30 +53,43 @@ function safeIsoFromMillis(value: number, fallback: Date): string {
   return date.toISOString();
 }
 
-function safeCwdLabel(homePath: string, cwd: string): string {
-  const rel = relative(homePath, cwd);
-  if (!rel || rel === "") return "~";
-  if (rel.startsWith("..") || rel.includes("\0")) return "External session";
-  if (rel.length <= 120) return rel;
-  return `${rel.slice(0, 117)}...`;
+function safeDisplayLabel(value: string, fallback: string): { label: string; sanitized: boolean } {
+  const label = value.length <= 120 ? value : `${value.slice(0, 117)}...`;
+  return SafeDisplayStringSchema.safeParse(label).success
+    ? { label, sanitized: false }
+    : { label: fallback, sanitized: true };
 }
 
-function terminalStatus(session: SessionInfo): TerminalSessionSummary["status"] {
-  if (session.state === "exited") return "exited";
-  if (session.attachedClients > 0) return "running";
+function canReadTerminalSessions(principal: RequestPrincipal, terminalOwnerId: string | undefined): boolean {
+  if (terminalOwnerId) return principal.userId === terminalOwnerId;
+  return principal.source === "configured-container" || principal.source === "dev-default";
+}
+
+function terminalStatus(session: CodingAgentTerminalSession): TerminalSessionSummary["status"] {
+  if (session.status === "exited") return "exited";
+  if (session.recoverable) return "stale";
+  if (session.visualStatus === "waiting") return "idle";
+  if (session.visualStatus === "finished") return "idle";
+  if (session.visualStatus === "running") return "running";
+  if ((session.attachedClients ?? 0) > 0) return "running";
   return "idle";
 }
 
-function terminalSummaryFromSession(homePath: string, now: Date, session: SessionInfo): TerminalSessionSummary {
+function terminalSummaryFromSession(
+  _homePath: string,
+  now: Date,
+  session: CodingAgentTerminalSession,
+  index: number,
+): TerminalSessionSummary {
   const status = terminalStatus(session);
+  const safeName = safeDisplayLabel(session.name, "Private session");
   return {
-    id: session.sessionId,
-    name: safeCwdLabel(homePath, session.cwd),
+    id: safeName.sanitized ? `terminal_private_${index}` : session.name,
+    name: safeName.label,
     status,
-    attachable: session.state === "running",
-    cwdLabel: safeCwdLabel(homePath, session.cwd),
-    createdAt: safeIsoFromMillis(session.createdAt, now),
-    updatedAt: safeIsoFromMillis(session.lastAttachedAt, now),
+    attachable: !safeName.sanitized && session.status !== "exited" && !session.recoverable,
+    createdAt: safeIsoFromMillis(Date.parse(session.createdAt), now),
+    updatedAt: safeIsoFromMillis(Date.parse(session.updatedAt), now),
   };
 }
 
@@ -126,18 +149,25 @@ async function readProviders(
   }
 }
 
-function readTerminalSessions(
+async function readTerminalSessions(
   registry: CodingAgentTerminalSessionRegistry | undefined,
   homePath: string,
   now: Date,
-): { items: TerminalSessionSummary[]; hasMore: boolean; limit: number } {
+  principal: RequestPrincipal,
+  terminalOwnerId: string | undefined,
+): Promise<{ items: TerminalSessionSummary[]; hasMore: boolean; limit: number }> {
   if (!registry) return { items: [], hasMore: false, limit: TERMINAL_SUMMARY_LIMIT };
+  if (!canReadTerminalSessions(principal, terminalOwnerId)) {
+    return { items: [], hasMore: false, limit: TERMINAL_SUMMARY_LIMIT };
+  }
   try {
-    const sessions = registry.list()
+    const sessions = (await registry.list())
       .slice()
-      .sort((a, b) => b.lastAttachedAt - a.lastAttachedAt);
+      .sort((a, b) => Date.parse(b.updatedAt) - Date.parse(a.updatedAt));
     return {
-      items: sessions.slice(0, TERMINAL_SUMMARY_LIMIT).map((session) => terminalSummaryFromSession(homePath, now, session)),
+      items: sessions.slice(0, TERMINAL_SUMMARY_LIMIT).map((session, index) =>
+        terminalSummaryFromSession(homePath, now, session, index)
+      ),
       hasMore: sessions.length > TERMINAL_SUMMARY_LIMIT,
       limit: TERMINAL_SUMMARY_LIMIT,
     };
@@ -155,7 +185,13 @@ export function createCodingAgentRuntimeSummaryService(
   return {
     async getSummary(principal: RequestPrincipal): Promise<RuntimeSummary> {
       const now = nowFn();
-      const terminalSessions = readTerminalSessions(options.terminalRegistry, options.homePath, now);
+      const terminalSessions = readTerminalSessions(
+        options.terminalRegistry,
+        options.homePath,
+        now,
+        principal,
+        options.terminalOwnerId,
+      );
       const providers = await readProviders(options.agentCredentials, principal);
 
       return RuntimeSummarySchema.parse({
@@ -178,7 +214,7 @@ export function createCodingAgentRuntimeSummaryService(
         providers,
         projects: { items: [], hasMore: false, limit: 20 },
         activeThreads: { items: [], hasMore: false, limit: 20 },
-        terminalSessions,
+        terminalSessions: await terminalSessions,
         recentActivity: { items: [], hasMore: false, limit: 30 },
         limits: {
           maxPromptBytes: 24_000,

--- a/packages/gateway/src/coding-agents/runtime-summary.ts
+++ b/packages/gateway/src/coding-agents/runtime-summary.ts
@@ -1,6 +1,7 @@
 import {
   RuntimeSummarySchema,
   SafeDisplayStringSchema,
+  TerminalSessionIdSchema,
   type AgentProviderSummary,
   type RuntimeSummary,
   type TerminalSessionSummary,
@@ -83,11 +84,13 @@ function terminalSummaryFromSession(
 ): TerminalSessionSummary {
   const status = terminalStatus(session);
   const safeName = safeDisplayLabel(session.name, "Private session");
+  const safeId = TerminalSessionIdSchema.safeParse(session.name);
+  const canAttach = safeId.success && !safeName.sanitized && session.status !== "exited" && !session.recoverable;
   return {
-    id: safeName.sanitized ? `terminal_private_${index}` : session.name,
+    id: safeId.success && !safeName.sanitized ? safeId.data : `terminal_private_${index}`,
     name: safeName.label,
     status,
-    attachable: !safeName.sanitized && session.status !== "exited" && !session.recoverable,
+    attachable: canAttach,
     createdAt: safeIsoFromMillis(Date.parse(session.createdAt), now),
     updatedAt: safeIsoFromMillis(Date.parse(session.updatedAt), now),
   };

--- a/packages/gateway/src/coding-agents/runtime-summary.ts
+++ b/packages/gateway/src/coding-agents/runtime-summary.ts
@@ -1,0 +1,193 @@
+import { relative } from "node:path";
+import {
+  RuntimeSummarySchema,
+  type AgentProviderSummary,
+  type RuntimeSummary,
+  type TerminalSessionSummary,
+} from "@matrix-os/contracts";
+import type { RequestPrincipal } from "../request-principal.js";
+import type {
+  AgentCredentialStatusResponse,
+  AgentCredentialSummary,
+  AgentId,
+} from "../onboarding/activation-contracts.js";
+import type { AgentCredentialStatusService } from "../onboarding/agent-credential-status.js";
+import type { SessionInfo } from "../session-registry.js";
+
+const TERMINAL_SUMMARY_LIMIT = 20;
+
+export interface CodingAgentTerminalSessionRegistry {
+  list(): SessionInfo[];
+}
+
+export interface CodingAgentRuntimeSummaryService {
+  getSummary(principal: RequestPrincipal): Promise<RuntimeSummary>;
+}
+
+export interface CodingAgentRuntimeSummaryOptions {
+  homePath: string;
+  terminalRegistry?: CodingAgentTerminalSessionRegistry;
+  agentCredentials?: Pick<AgentCredentialStatusService, "getStatus">;
+  now?: () => Date;
+  runtime?: {
+    id?: string;
+    label?: string;
+    channel?: string;
+    ownerHandle?: string;
+  };
+}
+
+function safeIsoFromMillis(value: number, fallback: Date): string {
+  const date = Number.isFinite(value) ? new Date(value) : fallback;
+  if (Number.isNaN(date.getTime())) return fallback.toISOString();
+  return date.toISOString();
+}
+
+function safeCwdLabel(homePath: string, cwd: string): string {
+  const rel = relative(homePath, cwd);
+  if (!rel || rel === "") return "~";
+  if (rel.startsWith("..") || rel.includes("\0")) return "External session";
+  if (rel.length <= 120) return rel;
+  return `${rel.slice(0, 117)}...`;
+}
+
+function terminalStatus(session: SessionInfo): TerminalSessionSummary["status"] {
+  if (session.state === "exited") return "exited";
+  if (session.attachedClients > 0) return "running";
+  return "idle";
+}
+
+function terminalSummaryFromSession(homePath: string, now: Date, session: SessionInfo): TerminalSessionSummary {
+  const status = terminalStatus(session);
+  return {
+    id: session.sessionId,
+    name: safeCwdLabel(homePath, session.cwd),
+    status,
+    attachable: session.state === "running",
+    cwdLabel: safeCwdLabel(homePath, session.cwd),
+    createdAt: safeIsoFromMillis(session.createdAt, now),
+    updatedAt: safeIsoFromMillis(session.lastAttachedAt, now),
+  };
+}
+
+function statusToProviderSummary(agent: AgentCredentialSummary): AgentProviderSummary {
+  const isAvailable = agent.status === "available";
+  const isMissing = agent.status === "missing";
+  const isExpired = agent.status === "expired" || agent.status === "revoked";
+  const failed = agent.status === "failed";
+
+  return {
+    id: agent.agent,
+    displayName: displayNameForAgent(agent.agent),
+    kind: kindForAgent(agent.agent),
+    availability: isAvailable
+      ? "available"
+      : isExpired
+        ? "auth_required"
+        : isMissing
+          ? "setup_required"
+          : failed
+            ? "unavailable"
+            : "unknown",
+    installStatus: isAvailable || isExpired ? "installed" : isMissing ? "missing" : failed ? "failed" : "unknown",
+    authStatus: isAvailable ? "authenticated" : isExpired ? "expired" : isMissing ? "missing" : "unknown",
+    supportedModes: ["default", "review"],
+    defaultMode: "default",
+    setupActions: [],
+    lastCheckedAt: agent.verifiedAt ?? undefined,
+  };
+}
+
+function displayNameForAgent(agent: AgentId): string {
+  if (agent === "claude") return "Claude";
+  if (agent === "codex") return "Codex";
+  return "Hermes";
+}
+
+function kindForAgent(agent: AgentId): AgentProviderSummary["kind"] {
+  if (agent === "claude") return "claude";
+  if (agent === "codex") return "codex";
+  return "custom";
+}
+
+async function readProviders(
+  service: Pick<AgentCredentialStatusService, "getStatus"> | undefined,
+  principal: RequestPrincipal,
+): Promise<AgentProviderSummary[]> {
+  if (!service) return [];
+  try {
+    const status: AgentCredentialStatusResponse = await service.getStatus(principal.userId);
+    return status.agents
+      .filter((agent) => agent.agent !== "hermes")
+      .map(statusToProviderSummary);
+  } catch (err: unknown) {
+    console.warn("[coding-agents] provider summary unavailable:", err instanceof Error ? err.message : String(err));
+    return [];
+  }
+}
+
+function readTerminalSessions(
+  registry: CodingAgentTerminalSessionRegistry | undefined,
+  homePath: string,
+  now: Date,
+): { items: TerminalSessionSummary[]; hasMore: boolean; limit: number } {
+  if (!registry) return { items: [], hasMore: false, limit: TERMINAL_SUMMARY_LIMIT };
+  try {
+    const sessions = registry.list()
+      .slice()
+      .sort((a, b) => b.lastAttachedAt - a.lastAttachedAt);
+    return {
+      items: sessions.slice(0, TERMINAL_SUMMARY_LIMIT).map((session) => terminalSummaryFromSession(homePath, now, session)),
+      hasMore: sessions.length > TERMINAL_SUMMARY_LIMIT,
+      limit: TERMINAL_SUMMARY_LIMIT,
+    };
+  } catch (err: unknown) {
+    console.warn("[coding-agents] terminal summary unavailable:", err instanceof Error ? err.message : String(err));
+    return { items: [], hasMore: false, limit: TERMINAL_SUMMARY_LIMIT };
+  }
+}
+
+export function createCodingAgentRuntimeSummaryService(
+  options: CodingAgentRuntimeSummaryOptions,
+): CodingAgentRuntimeSummaryService {
+  const nowFn = options.now ?? (() => new Date());
+
+  return {
+    async getSummary(principal: RequestPrincipal): Promise<RuntimeSummary> {
+      const now = nowFn();
+      const terminalSessions = readTerminalSessions(options.terminalRegistry, options.homePath, now);
+      const providers = await readProviders(options.agentCredentials, principal);
+
+      return RuntimeSummarySchema.parse({
+        runtime: {
+          id: options.runtime?.id ?? "rt_primary",
+          label: options.runtime?.label ?? "Primary Matrix computer",
+          status: "available",
+          channel: options.runtime?.channel,
+          ownerHandle: options.runtime?.ownerHandle,
+        },
+        capabilities: [
+          { id: "codingAgentsRuntimeSummary", enabled: true },
+          { id: "codingAgentsDesktopWorkspace", enabled: false, reason: "Not enabled yet" },
+          { id: "codingAgentsMobileWorkspace", enabled: false, reason: "Not enabled yet" },
+          { id: "codingAgentsThreadCreate", enabled: false, reason: "Not enabled yet" },
+          { id: "codingAgentsApprovals", enabled: false, reason: "Not enabled yet" },
+          { id: "codingAgentsReview", enabled: false, reason: "Not enabled yet" },
+          { id: "codingAgentsNativeMobileTerminal", enabled: false, reason: "Not enabled yet" },
+        ],
+        providers,
+        projects: { items: [], hasMore: false, limit: 20 },
+        activeThreads: { items: [], hasMore: false, limit: 20 },
+        terminalSessions,
+        recentActivity: { items: [], hasMore: false, limit: 30 },
+        limits: {
+          maxPromptBytes: 24_000,
+          maxAttachmentCount: 8,
+          maxTerminalInputBytes: 65_536,
+          maxListItems: 50,
+        },
+        serverTime: now.toISOString(),
+      });
+    },
+  };
+}

--- a/packages/gateway/src/server.ts
+++ b/packages/gateway/src/server.ts
@@ -464,8 +464,9 @@ export async function createGateway(config: GatewayConfig) {
   });
   const codingAgentRuntimeSummaryService = createCodingAgentRuntimeSummaryService({
     homePath,
-    terminalRegistry: sessionRegistry,
+    terminalRegistry: zellijShellRegistry,
     agentCredentials: agentCredentialService,
+    terminalOwnerId: process.env.MATRIX_USER_ID,
   });
   const integrationCapabilityService = createIntegrationCapabilityService({
     getConnectedCapabilityIds,

--- a/packages/gateway/src/server.ts
+++ b/packages/gateway/src/server.ts
@@ -89,6 +89,8 @@ import { createToolPackRoutes } from "./onboarding/tool-pack-routes.js";
 import type { CodingSetupStatus } from "./onboarding/coding-setup.js";
 import { createAgentCredentialStatusService } from "./onboarding/agent-credential-status.js";
 import { createAgentCredentialRoutes } from "./onboarding/agent-credential-routes.js";
+import { createCodingAgentRuntimeSummaryService } from "./coding-agents/runtime-summary.js";
+import { createCodingAgentRoutes } from "./coding-agents/routes.js";
 import { createAgentActionAuditService } from "./onboarding/agent-action-audit.js";
 import { capabilityIdsForConnectedServices, createIntegrationCapabilityService } from "./onboarding/integration-capabilities.js";
 import { createIntegrationCapabilityRoutes } from "./onboarding/integration-capability-routes.js";
@@ -459,6 +461,11 @@ export async function createGateway(config: GatewayConfig) {
         missing: status?.installed === false,
       };
     },
+  });
+  const codingAgentRuntimeSummaryService = createCodingAgentRuntimeSummaryService({
+    homePath,
+    terminalRegistry: sessionRegistry,
+    agentCredentials: agentCredentialService,
   });
   const integrationCapabilityService = createIntegrationCapabilityService({
     getConnectedCapabilityIds,
@@ -1474,6 +1481,7 @@ export async function createGateway(config: GatewayConfig) {
   app.route("/api/onboarding", createReadinessRoutes({ service: readinessService }));
   app.route("/api/onboarding", createToolPackRoutes({ service: toolPackService }));
   app.route("/api/agents", createAgentCredentialRoutes({ service: agentCredentialService }));
+  app.route("/api/coding-agents", createCodingAgentRoutes({ service: codingAgentRuntimeSummaryService }));
   app.route("/api/integrations", createIntegrationCapabilityRoutes({
     service: integrationCapabilityService,
     audit: agentActionAuditService,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -468,6 +468,9 @@ importers:
       '@hono/node-ws':
         specifier: ^1.3.1
         version: 1.3.1(@hono/node-server@1.19.11(hono@4.12.8))(bufferutil@4.1.0)(hono@4.12.8)(utf-8-validate@6.0.6)
+      '@matrix-os/contracts':
+        specifier: workspace:*
+        version: link:../contracts
       '@matrix-os/kernel':
         specifier: workspace:*
         version: link:../kernel

--- a/tests/gateway/coding-agents-summary.test.ts
+++ b/tests/gateway/coding-agents-summary.test.ts
@@ -6,6 +6,7 @@ import {
   type CodingAgentTerminalSessionRegistry,
 } from "../../packages/gateway/src/coding-agents/runtime-summary.js";
 import { createCodingAgentRoutes } from "../../packages/gateway/src/coding-agents/routes.js";
+import type { RequestPrincipal } from "../../packages/gateway/src/request-principal.js";
 import { MissingRequestPrincipalError } from "../../packages/gateway/src/request-principal.js";
 import { testPrincipal } from "../helpers/activation-readiness.js";
 
@@ -14,12 +15,10 @@ const now = new Date("2026-07-06T12:00:00.000Z");
 function registryWith(count: number): CodingAgentTerminalSessionRegistry {
   return {
     list: () => Array.from({ length: count }, (_, index) => ({
-      sessionId: `550e8400-e29b-41d4-a716-44665544${String(index).padStart(4, "0")}`,
-      cwd: `/home/matrix/home/projects/project-${index}`,
-      shell: "/bin/bash",
-      state: index % 3 === 0 ? "exited" as const : "running" as const,
-      createdAt: now.getTime() - index * 1000,
-      lastAttachedAt: now.getTime() - index * 1000,
+      name: `main-${index}`,
+      status: index % 3 === 0 ? "exited" as const : "active" as const,
+      createdAt: new Date(now.getTime() - index * 1000).toISOString(),
+      updatedAt: new Date(now.getTime() - index * 1000).toISOString(),
       attachedClients: index % 2,
     })),
   };
@@ -66,11 +65,71 @@ describe("coding agent runtime summary", () => {
     expect(summary.terminalSessions.items).toHaveLength(20);
     expect(summary.terminalSessions.hasMore).toBe(true);
     expect(summary.terminalSessions.items[0]).toMatchObject({
-      cwdLabel: "projects/project-0",
+      id: "main-0",
+      name: "main-0",
       attachable: false,
       status: "exited",
     });
     expect(JSON.stringify(summary)).not.toMatch(/\/home\/matrix|\/bin\/bash|token|secret|Postgres/i);
+  });
+
+  it("withholds owner-local terminal sessions from other principals", async () => {
+    const service = createCodingAgentRuntimeSummaryService({
+      homePath: "/home/matrix/home",
+      terminalRegistry: registryWith(1),
+      now: () => now,
+      runtime: { id: "rt_primary", label: "Primary Matrix computer" },
+      terminalOwnerId: "owner_user",
+    });
+    const otherPrincipal: RequestPrincipal = { userId: "other_user", source: "jwt" };
+
+    const summary = RuntimeSummarySchema.parse(await service.getSummary(otherPrincipal));
+
+    expect(summary.terminalSessions.items).toEqual([]);
+    expect(summary.terminalSessions.hasMore).toBe(false);
+  });
+
+  it("withholds terminal sessions for jwt principals when no owner id is configured", async () => {
+    const service = createCodingAgentRuntimeSummaryService({
+      homePath: "/home/matrix/home",
+      terminalRegistry: registryWith(1),
+      now: () => now,
+      runtime: { id: "rt_primary", label: "Primary Matrix computer" },
+    });
+    const jwtPrincipal: RequestPrincipal = { userId: "owner_user", source: "jwt" };
+
+    const summary = RuntimeSummarySchema.parse(await service.getSummary(jwtPrincipal));
+
+    expect(summary.terminalSessions.items).toEqual([]);
+    expect(summary.terminalSessions.hasMore).toBe(false);
+  });
+
+  it("replaces unsafe terminal cwd labels instead of failing the whole summary", async () => {
+    const service = createCodingAgentRuntimeSummaryService({
+      homePath: "/home/matrix/home",
+      terminalRegistry: {
+        list: () => [{
+          name: "id_rsa",
+          status: "active",
+          visualStatus: "running",
+          createdAt: now.toISOString(),
+          updatedAt: now.toISOString(),
+          attachedClients: 1,
+        }],
+      },
+      now: () => now,
+      runtime: { id: "rt_primary", label: "Primary Matrix computer" },
+    });
+
+    const summary = RuntimeSummarySchema.parse(await service.getSummary(testPrincipal));
+
+    expect(summary.terminalSessions.items[0]).toMatchObject({
+      id: "terminal_private_0",
+      name: "Private session",
+      status: "running",
+      attachable: false,
+    });
+    expect(JSON.stringify(summary)).not.toMatch(/\.ssh|id_rsa|\/home\/matrix/i);
   });
 
   it("keeps the summary safe when optional dependencies fail", async () => {

--- a/tests/gateway/coding-agents-summary.test.ts
+++ b/tests/gateway/coding-agents-summary.test.ts
@@ -132,6 +132,33 @@ describe("coding agent runtime summary", () => {
     expect(JSON.stringify(summary)).not.toMatch(/\.ssh|id_rsa|\/home\/matrix/i);
   });
 
+  it("keeps display-safe terminal names with schema-unsafe ids from failing the summary", async () => {
+    const service = createCodingAgentRuntimeSummaryService({
+      homePath: "/home/matrix/home",
+      terminalRegistry: {
+        list: () => [{
+          name: "my terminal",
+          status: "active",
+          visualStatus: "running",
+          createdAt: now.toISOString(),
+          updatedAt: now.toISOString(),
+          attachedClients: 1,
+        }],
+      },
+      now: () => now,
+      runtime: { id: "rt_primary", label: "Primary Matrix computer" },
+    });
+
+    const summary = RuntimeSummarySchema.parse(await service.getSummary(testPrincipal));
+
+    expect(summary.terminalSessions.items[0]).toMatchObject({
+      id: "terminal_private_0",
+      name: "my terminal",
+      status: "running",
+      attachable: false,
+    });
+  });
+
   it("keeps the summary safe when optional dependencies fail", async () => {
     const service = createCodingAgentRuntimeSummaryService({
       homePath: "/home/matrix/home",

--- a/tests/gateway/coding-agents-summary.test.ts
+++ b/tests/gateway/coding-agents-summary.test.ts
@@ -1,0 +1,164 @@
+import { describe, expect, it, vi } from "vitest";
+import { Hono } from "hono";
+import { RuntimeSummarySchema } from "../../packages/contracts/src/index.js";
+import {
+  createCodingAgentRuntimeSummaryService,
+  type CodingAgentTerminalSessionRegistry,
+} from "../../packages/gateway/src/coding-agents/runtime-summary.js";
+import { createCodingAgentRoutes } from "../../packages/gateway/src/coding-agents/routes.js";
+import { MissingRequestPrincipalError } from "../../packages/gateway/src/request-principal.js";
+import { testPrincipal } from "../helpers/activation-readiness.js";
+
+const now = new Date("2026-07-06T12:00:00.000Z");
+
+function registryWith(count: number): CodingAgentTerminalSessionRegistry {
+  return {
+    list: () => Array.from({ length: count }, (_, index) => ({
+      sessionId: `550e8400-e29b-41d4-a716-44665544${String(index).padStart(4, "0")}`,
+      cwd: `/home/matrix/home/projects/project-${index}`,
+      shell: "/bin/bash",
+      state: index % 3 === 0 ? "exited" as const : "running" as const,
+      createdAt: now.getTime() - index * 1000,
+      lastAttachedAt: now.getTime() - index * 1000,
+      attachedClients: index % 2,
+    })),
+  };
+}
+
+describe("coding agent runtime summary", () => {
+  it("returns a capped safe runtime summary from provider and terminal state", async () => {
+    const service = createCodingAgentRuntimeSummaryService({
+      homePath: "/home/matrix/home",
+      terminalRegistry: registryWith(30),
+      agentCredentials: {
+        getStatus: async () => ({
+          systemAgent: "hermes",
+          activeAgents: ["codex", "hermes"],
+          routingExplanation: "Hermes remains available.",
+          agents: [
+            {
+              agent: "codex",
+              status: "available",
+              coordinationRole: "coding_specialist",
+              workflows: ["coding"],
+              degradedWorkflows: [],
+              verifiedAt: now.toISOString(),
+              nextAction: null,
+            },
+          ],
+        }),
+        verifyAgent: vi.fn(),
+      },
+      now: () => now,
+      runtime: { id: "rt_primary", label: "Primary Matrix computer" },
+    });
+
+    const summary = RuntimeSummarySchema.parse(await service.getSummary(testPrincipal));
+
+    expect(summary.providers).toEqual([
+      expect.objectContaining({
+        id: "codex",
+        availability: "available",
+        authStatus: "authenticated",
+        installStatus: "installed",
+      }),
+    ]);
+    expect(summary.terminalSessions.items).toHaveLength(20);
+    expect(summary.terminalSessions.hasMore).toBe(true);
+    expect(summary.terminalSessions.items[0]).toMatchObject({
+      cwdLabel: "projects/project-0",
+      attachable: false,
+      status: "exited",
+    });
+    expect(JSON.stringify(summary)).not.toMatch(/\/home\/matrix|\/bin\/bash|token|secret|Postgres/i);
+  });
+
+  it("keeps the summary safe when optional dependencies fail", async () => {
+    const service = createCodingAgentRuntimeSummaryService({
+      homePath: "/home/matrix/home",
+      terminalRegistry: {
+        list: () => {
+          throw new Error("Postgres constraint failed at /home/matrix/home");
+        },
+      },
+      agentCredentials: {
+        getStatus: async () => {
+          throw new Error("provider token expired");
+        },
+        verifyAgent: vi.fn(),
+      },
+      now: () => now,
+      runtime: { id: "rt_primary", label: "Primary Matrix computer" },
+    });
+
+    const summary = RuntimeSummarySchema.parse(await service.getSummary(testPrincipal));
+
+    expect(summary.providers).toEqual([]);
+    expect(summary.terminalSessions.items).toEqual([]);
+    expect(summary.capabilities).toEqual(expect.arrayContaining([
+      expect.objectContaining({ id: "codingAgentsRuntimeSummary", enabled: true }),
+      expect.objectContaining({ id: "codingAgentsThreadCreate", enabled: false }),
+    ]));
+    expect(JSON.stringify(summary)).not.toMatch(/Postgres|\/home\/matrix|provider token/i);
+  });
+
+  it("serves authenticated summaries through a safe route", async () => {
+    const service = createCodingAgentRuntimeSummaryService({
+      homePath: "/home/matrix/home",
+      terminalRegistry: registryWith(1),
+      now: () => now,
+      runtime: { id: "rt_primary", label: "Primary Matrix computer" },
+    });
+    const app = new Hono();
+    app.route("/api/coding-agents", createCodingAgentRoutes({ service, getPrincipal: () => testPrincipal }));
+
+    const res = await app.request("/api/coding-agents/summary");
+
+    expect(res.status).toBe(200);
+    const body = RuntimeSummarySchema.parse(await res.json());
+    expect(body.runtime.id).toBe("rt_primary");
+  });
+
+  it("rejects unauthenticated summary requests", async () => {
+    const service = createCodingAgentRuntimeSummaryService({
+      homePath: "/home/matrix/home",
+      terminalRegistry: registryWith(0),
+      now: () => now,
+      runtime: { id: "rt_primary", label: "Primary Matrix computer" },
+    });
+    const app = createCodingAgentRoutes({
+      service,
+      getPrincipal: () => {
+        throw new MissingRequestPrincipalError();
+      },
+    });
+
+    const res = await app.request("/summary");
+
+    expect(res.status).toBe(401);
+    expect(await res.json()).toEqual({ error: "Unauthorized" });
+  });
+
+  it("maps unexpected route failures to generic safe errors", async () => {
+    const app = createCodingAgentRoutes({
+      service: {
+        getSummary: async () => {
+          throw new Error("Postgres constraint failed at /home/matrix/home");
+        },
+      },
+      getPrincipal: () => testPrincipal,
+    });
+
+    const res = await app.request("/summary");
+
+    expect(res.status).toBe(503);
+    expect(await res.json()).toEqual({
+      error: {
+        code: "summary_unavailable",
+        safeMessage: "Runtime summary is temporarily unavailable. Try again.",
+        retryable: true,
+        recoveryActions: ["retry"],
+      },
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add a read-only coding agent runtime summary service under the gateway
- expose GET /api/coding-agents/summary after existing gateway auth middleware
- adapt existing agent credential status and canonical terminal session state into capped, schema-validated summary data

## Stack
- Depends on #734
- Stack layer 2: gateway read-only runtime summary

## Safety
- no UI changes
- no new persistence
- no mutating routes
- terminal data is adapted from existing Matrix terminal session primitives
- client response is parsed through shared contracts and avoids raw filesystem paths, shell paths, provider errors, tokens, and secrets
- optional provider/terminal dependency failures degrade to empty summary sections; route failures return a generic retryable error

## Validation
- pnpm exec vitest run tests/gateway/coding-agents-summary.test.ts
- pnpm exec vitest run tests/contracts/coding-agents.test.ts
- pnpm --filter @matrix-os/gateway exec tsc --noEmit
- pnpm --filter @matrix-os/contracts run typecheck
- bun run check:patterns
- bun run typecheck
- git diff --check
- local prohibited-term scan for changed paths (clean)