### PR TITLE
feat(gateway): add coding agent thread lifecycle

### DIFF
--- a/packages/gateway/src/coding-agents/routes.ts
+++ b/packages/gateway/src/coding-agents/routes.ts
@@ -1,6 +1,16 @@
 import { Hono, type Context } from "hono";
+import { bodyLimit } from "hono/body-limit";
 import type { ContentfulStatusCode } from "hono/utils/http-status";
-import { SafeClientErrorSchema } from "@matrix-os/contracts";
+import { z } from "zod/v4";
+import {
+  CreateAgentThreadRequestSchema,
+  CursorSchema,
+  RequestIdSchema,
+  ThreadIdSchema,
+  SafeClientErrorSchema,
+  boundedListSchema,
+  AgentThreadSummarySchema,
+} from "@matrix-os/contracts";
 import {
   isRequestPrincipalError,
   mapRequestPrincipalError,
@@ -8,11 +18,26 @@ import {
   type RequestPrincipal,
 } from "../request-principal.js";
 import type { CodingAgentRuntimeSummaryService } from "./runtime-summary.js";
+import {
+  CodingAgentThreadError,
+  safeThreadError,
+  type CodingAgentThreadStore,
+} from "./thread-store.js";
 
 export interface CodingAgentRouteDeps {
   service: CodingAgentRuntimeSummaryService;
+  threads?: CodingAgentThreadStore;
   getPrincipal?: (c: Context) => RequestPrincipal;
 }
+
+const THREAD_MUTATION_BODY_LIMIT = 128 * 1024;
+const THREAD_ABORT_BODY_LIMIT = 1024;
+
+const AbortThreadBodySchema = z.object({
+  clientRequestId: RequestIdSchema,
+}).strict();
+
+const ThreadListSchema = boundedListSchema(AgentThreadSummarySchema, 50);
 
 function summaryUnavailable() {
   return SafeClientErrorSchema.parse({
@@ -23,9 +48,44 @@ function summaryUnavailable() {
   });
 }
 
+function threadsUnavailable() {
+  return SafeClientErrorSchema.parse({
+    code: "thread_store_unavailable",
+    safeMessage: "Agent thread state is temporarily unavailable. Try again.",
+    retryable: true,
+    recoveryActions: ["retry"],
+  });
+}
+
+function validationFailed() {
+  return SafeClientErrorSchema.parse({
+    code: "validation_failed",
+    safeMessage: "Request could not be processed. Check the inputs and try again.",
+    retryable: false,
+  });
+}
+
+function mapThreadRouteError(c: Context, err: unknown) {
+  if (isRequestPrincipalError(err)) {
+    const mapped = mapRequestPrincipalError(err);
+    return c.json(mapped.body, mapped.status as ContentfulStatusCode);
+  }
+  if (err instanceof CodingAgentThreadError) {
+    const status = err.code === "thread_not_found" ? 404 : err.code === "provider_unavailable" ? 400 : 503;
+    return c.json({ error: safeThreadError(err.code) }, status);
+  }
+  if (err instanceof z.ZodError) {
+    return c.json({ error: validationFailed() }, 400);
+  }
+  console.warn("[coding-agents] thread route failed:", err instanceof Error ? err.message : String(err));
+  return c.json({ error: threadsUnavailable() }, 503);
+}
+
 export function createCodingAgentRoutes(deps: CodingAgentRouteDeps): Hono {
   const app = new Hono();
   const principalFor = (c: Context) => deps.getPrincipal?.(c) ?? requireRequestPrincipal(c);
+  const threadMutationBodyLimit = bodyLimit({ maxSize: THREAD_MUTATION_BODY_LIMIT });
+  const threadAbortBodyLimit = bodyLimit({ maxSize: THREAD_ABORT_BODY_LIMIT });
 
   app.get("/summary", async (c) => {
     try {
@@ -40,6 +100,61 @@ export function createCodingAgentRoutes(deps: CodingAgentRouteDeps): Hono {
       return c.json({ error: summaryUnavailable() }, 503);
     }
   });
+
+  if (deps.threads) {
+    app.post("/threads", threadMutationBodyLimit, async (c) => {
+      try {
+        const principal = principalFor(c);
+        const request = CreateAgentThreadRequestSchema.parse(await c.req.json());
+        const result = await deps.threads!.createThread(principal, request);
+        return c.json(result.snapshot, result.existing ? 200 : 202);
+      } catch (err: unknown) {
+        return mapThreadRouteError(c, err);
+      }
+    });
+
+    app.get("/threads", async (c) => {
+      try {
+        const principal = principalFor(c);
+        return c.json(ThreadListSchema.parse(await deps.threads!.listThreads(principal)));
+      } catch (err: unknown) {
+        return mapThreadRouteError(c, err);
+      }
+    });
+
+    app.get("/threads/:threadId", async (c) => {
+      try {
+        const principal = principalFor(c);
+        const threadId = ThreadIdSchema.parse(c.req.param("threadId"));
+        return c.json(await deps.threads!.getThread(principal, threadId));
+      } catch (err: unknown) {
+        return mapThreadRouteError(c, err);
+      }
+    });
+
+    app.get("/threads/:threadId/events", async (c) => {
+      try {
+        const principal = principalFor(c);
+        const threadId = ThreadIdSchema.parse(c.req.param("threadId"));
+        const rawCursor = c.req.query("cursor");
+        const cursor = rawCursor ? CursorSchema.parse(rawCursor) : undefined;
+        return c.json(await deps.threads!.getThread(principal, threadId, cursor));
+      } catch (err: unknown) {
+        return mapThreadRouteError(c, err);
+      }
+    });
+
+    app.post("/threads/:threadId/abort", threadAbortBodyLimit, async (c) => {
+      try {
+        const principal = principalFor(c);
+        const threadId = ThreadIdSchema.parse(c.req.param("threadId"));
+        const body = AbortThreadBodySchema.parse(await c.req.json());
+        return c.json(await deps.threads!.abortThread(principal, threadId, body.clientRequestId));
+      } catch (err: unknown) {
+        return mapThreadRouteError(c, err);
+      }
+    });
+  }
 
   return app;
 }

--- a/packages/gateway/src/coding-agents/runtime-summary.ts
+++ b/packages/gateway/src/coding-agents/runtime-summary.ts
@@ -3,6 +3,7 @@ import {
   SafeDisplayStringSchema,
   TerminalSessionIdSchema,
   type AgentProviderSummary,
+  type AgentThreadSummary,
   type RuntimeSummary,
   type TerminalSessionSummary,
 } from "@matrix-os/contracts";
@@ -34,10 +35,15 @@ export interface CodingAgentRuntimeSummaryService {
   getSummary(principal: RequestPrincipal): Promise<RuntimeSummary>;
 }
 
+export interface CodingAgentThreadSummaryStore {
+  listThreads(principal: RequestPrincipal): Promise<{ items: AgentThreadSummary[]; hasMore: boolean; limit: number }>;
+}
+
 export interface CodingAgentRuntimeSummaryOptions {
   homePath: string;
   terminalRegistry?: CodingAgentTerminalSessionRegistry;
   agentCredentials?: Pick<AgentCredentialStatusService, "getStatus">;
+  threads?: CodingAgentThreadSummaryStore;
   terminalOwnerId?: string;
   now?: () => Date;
   runtime?: {
@@ -152,6 +158,19 @@ async function readProviders(
   }
 }
 
+async function readActiveThreads(
+  store: CodingAgentThreadSummaryStore | undefined,
+  principal: RequestPrincipal,
+): Promise<{ items: AgentThreadSummary[]; hasMore: boolean; limit: number }> {
+  if (!store) return { items: [], hasMore: false, limit: 20 };
+  try {
+    return await store.listThreads(principal);
+  } catch (err: unknown) {
+    console.warn("[coding-agents] thread summary unavailable:", err instanceof Error ? err.message : String(err));
+    return { items: [], hasMore: false, limit: 20 };
+  }
+}
+
 async function readTerminalSessions(
   registry: CodingAgentTerminalSessionRegistry | undefined,
   homePath: string,
@@ -196,6 +215,7 @@ export function createCodingAgentRuntimeSummaryService(
         options.terminalOwnerId,
       );
       const providers = await readProviders(options.agentCredentials, principal);
+      const activeThreads = await readActiveThreads(options.threads, principal);
 
       return RuntimeSummarySchema.parse({
         runtime: {
@@ -209,14 +229,18 @@ export function createCodingAgentRuntimeSummaryService(
           { id: "codingAgentsRuntimeSummary", enabled: true },
           { id: "codingAgentsDesktopWorkspace", enabled: false, reason: "Not enabled yet" },
           { id: "codingAgentsMobileWorkspace", enabled: false, reason: "Not enabled yet" },
-          { id: "codingAgentsThreadCreate", enabled: false, reason: "Not enabled yet" },
+          {
+            id: "codingAgentsThreadCreate",
+            enabled: Boolean(options.threads),
+            reason: options.threads ? undefined : "Not enabled yet",
+          },
           { id: "codingAgentsApprovals", enabled: false, reason: "Not enabled yet" },
           { id: "codingAgentsReview", enabled: false, reason: "Not enabled yet" },
           { id: "codingAgentsNativeMobileTerminal", enabled: false, reason: "Not enabled yet" },
         ],
         providers,
         projects: { items: [], hasMore: false, limit: 20 },
-        activeThreads: { items: [], hasMore: false, limit: 20 },
+        activeThreads,
         terminalSessions: await terminalSessions,
         recentActivity: { items: [], hasMore: false, limit: 30 },
         limits: {

--- a/packages/gateway/src/coding-agents/thread-store.ts
+++ b/packages/gateway/src/coding-agents/thread-store.ts
@@ -1,0 +1,376 @@
+import { randomUUID } from "node:crypto";
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { z } from "zod/v4";
+import {
+  AgentThreadEventSchema,
+  AgentThreadSnapshotSchema,
+  AgentThreadSummarySchema,
+  ProviderIdSchema,
+  RequestIdSchema,
+  SafeClientErrorSchema,
+  type AgentThreadEvent,
+  type AgentThreadSummary,
+  type CreateAgentThreadRequest,
+} from "@matrix-os/contracts";
+import { atomicWriteJson } from "../state-ops.js";
+import type { RequestPrincipal } from "../request-principal.js";
+
+const THREAD_STORE_RELATIVE_PATH = ["system", "coding-agents", "threads.json"] as const;
+const THREAD_LIST_LIMIT = 50;
+const EVENT_REPLAY_LIMIT = 200;
+const MAX_STORED_THREADS = 200;
+const MAX_EVENTS_PER_THREAD = 500;
+const MAX_ABORT_REQUEST_IDS = 50;
+
+const OwnerIdSchema = z.string().min(1).max(160).regex(/^[A-Za-z0-9_.:@-]+$/);
+
+const StoredThreadSchema = AgentThreadSummarySchema.extend({
+  ownerId: OwnerIdSchema,
+  clientRequestId: RequestIdSchema,
+  abortClientRequestIds: z.array(RequestIdSchema).max(MAX_ABORT_REQUEST_IDS).default([]),
+}).strict();
+
+const StoredThreadStateSchema = z.object({
+  version: z.literal(1),
+  threads: z.array(StoredThreadSchema).max(MAX_STORED_THREADS),
+  events: z.array(AgentThreadEventSchema).max(MAX_STORED_THREADS * MAX_EVENTS_PER_THREAD),
+}).strict();
+
+type StoredThread = z.infer<typeof StoredThreadSchema>;
+type StoredThreadState = z.infer<typeof StoredThreadStateSchema>;
+type AgentThreadSnapshot = z.infer<typeof AgentThreadSnapshotSchema>;
+type ThreadCreateResult = { snapshot: AgentThreadSnapshot; existing: boolean };
+
+export interface CodingAgentProviderAdapter {
+  providerId: string;
+  startThread(input: {
+    thread: AgentThreadSummary;
+    request: CreateAgentThreadRequest;
+    now: () => Date;
+    nextEventId: () => string;
+  }): Promise<AgentThreadEvent[]> | AgentThreadEvent[];
+}
+
+export interface CodingAgentThreadStoreOptions {
+  homePath: string;
+  now?: () => Date;
+  providers: CodingAgentProviderAdapter[];
+}
+
+export interface CodingAgentThreadStore {
+  createThread(principal: RequestPrincipal, request: CreateAgentThreadRequest): Promise<ThreadCreateResult>;
+  listThreads(principal: RequestPrincipal): Promise<{ items: AgentThreadSummary[]; hasMore: boolean; limit: number }>;
+  getThread(principal: RequestPrincipal, threadId: string, cursor?: string): Promise<AgentThreadSnapshot>;
+  abortThread(principal: RequestPrincipal, threadId: string, clientRequestId: string): Promise<AgentThreadSnapshot>;
+}
+
+export class CodingAgentThreadError extends Error {
+  constructor(
+    readonly code: "provider_unavailable" | "thread_not_found" | "thread_store_unavailable",
+    message: string,
+  ) {
+    super(message);
+    this.name = "CodingAgentThreadError";
+  }
+}
+
+export function createFakeCodingAgentProvider(options: { providerId: string }): CodingAgentProviderAdapter {
+  const providerId = ProviderIdSchema.parse(options.providerId);
+  return {
+    providerId,
+    startThread({ thread, now, nextEventId }) {
+      return [
+        {
+          type: "thread.status",
+          eventId: nextEventId(),
+          threadId: thread.id,
+          occurredAt: now().toISOString(),
+          status: "running",
+        },
+        {
+          type: "assistant.text.delta",
+          eventId: nextEventId(),
+          threadId: thread.id,
+          occurredAt: now().toISOString(),
+          messageId: "msg_fake_provider_started",
+          delta: "Agent run started.",
+        },
+      ];
+    },
+  };
+}
+
+function emptyState(): StoredThreadState {
+  return { version: 1, threads: [], events: [] };
+}
+
+function statePath(homePath: string): string {
+  return join(homePath, ...THREAD_STORE_RELATIVE_PATH);
+}
+
+async function readState(homePath: string): Promise<StoredThreadState> {
+  try {
+    const raw = await readFile(statePath(homePath), "utf-8");
+    return StoredThreadStateSchema.parse(JSON.parse(raw));
+  } catch (err: unknown) {
+    if (err instanceof Error && "code" in err && (err as NodeJS.ErrnoException).code === "ENOENT") {
+      return emptyState();
+    }
+    throw err;
+  }
+}
+
+async function writeState(homePath: string, state: StoredThreadState): Promise<void> {
+  await atomicWriteJson(statePath(homePath), StoredThreadStateSchema.parse(state));
+}
+
+function nextThreadId(): string {
+  return `thread_${randomUUID()}`;
+}
+
+function nextEventId(): string {
+  return `evt_${randomUUID()}`;
+}
+
+function genericTitle(): string {
+  return "Coding agent run";
+}
+
+function applyEvent(thread: StoredThread, event: AgentThreadEvent): StoredThread {
+  const updatedAt = event.occurredAt;
+  if (event.type === "thread.status") {
+    return { ...thread, status: event.status, updatedAt };
+  }
+  if (event.type === "thread.completed") {
+    return {
+      ...thread,
+      status: event.outcome === "completed" ? "completed" : event.outcome === "aborted" ? "aborted" : "failed",
+      attention: event.outcome === "failed" ? "failed" : thread.attention,
+      updatedAt,
+    };
+  }
+  if (event.type === "approval.requested") {
+    return { ...thread, status: "waiting_for_approval", attention: "approval_required", updatedAt };
+  }
+  if (event.type === "user_input.requested") {
+    return { ...thread, status: "waiting_for_input", attention: "input_required", updatedAt };
+  }
+  if (event.type === "thread.error") {
+    return { ...thread, status: "failed", attention: "failed", updatedAt };
+  }
+  return { ...thread, updatedAt };
+}
+
+function snapshotFor(thread: StoredThread, allEvents: AgentThreadEvent[], cursor?: string): AgentThreadSnapshot {
+  const eventsForThread = allEvents.filter((event) => event.threadId === thread.id);
+  const startIndex = cursor ? eventsForThread.findIndex((event) => event.eventId === cursor) + 1 : 0;
+  const window = eventsForThread.slice(Math.max(0, startIndex)).slice(-EVENT_REPLAY_LIMIT);
+  return AgentThreadSnapshotSchema.parse({
+    thread: stripOwner(thread),
+    events: {
+      items: window,
+      hasMore: eventsForThread.length - Math.max(0, startIndex) > window.length,
+      nextCursor: window.at(-1)?.eventId,
+      limit: EVENT_REPLAY_LIMIT,
+    },
+  });
+}
+
+function stripOwner(thread: StoredThread): AgentThreadSummary {
+  const { ownerId: _ownerId, clientRequestId: _clientRequestId, abortClientRequestIds: _abortClientRequestIds, ...summary } = thread;
+  return AgentThreadSummarySchema.parse(summary);
+}
+
+function trimState(state: StoredThreadState): StoredThreadState {
+  const threads = state.threads
+    .slice()
+    .sort((a, b) => Date.parse(b.updatedAt) - Date.parse(a.updatedAt))
+    .slice(0, MAX_STORED_THREADS);
+  const activeThreadIds = threads.map((thread) => thread.id);
+  const latestEvents = state.events
+    .slice()
+    .reverse()
+    .filter((event) => activeThreadIds.includes(event.threadId))
+    .reduce<AgentThreadEvent[]>((kept, event) => {
+      const countForThread = kept.filter((candidate) => candidate.threadId === event.threadId).length;
+      if (countForThread < MAX_EVENTS_PER_THREAD) kept.push(event);
+      return kept;
+    }, []);
+  const events = latestEvents.reverse();
+  return { version: 1, threads, events };
+}
+
+function activeThread(thread: StoredThread): boolean {
+  return !["completed", "failed", "aborted", "archived"].includes(thread.status);
+}
+
+export function safeThreadError(code: CodingAgentThreadError["code"]) {
+  if (code === "provider_unavailable") {
+    return SafeClientErrorSchema.parse({
+      code,
+      safeMessage: "Selected provider is unavailable. Choose another provider or try again.",
+      retryable: true,
+      recoveryActions: ["retry"],
+    });
+  }
+  if (code === "thread_not_found") {
+    return SafeClientErrorSchema.parse({
+      code,
+      safeMessage: "Thread is unavailable. Refresh and try again.",
+      retryable: true,
+      recoveryActions: ["retry"],
+    });
+  }
+  return SafeClientErrorSchema.parse({
+    code,
+    safeMessage: "Agent thread state is temporarily unavailable. Try again.",
+    retryable: true,
+    recoveryActions: ["retry"],
+  });
+}
+
+export function createCodingAgentThreadStore(options: CodingAgentThreadStoreOptions): CodingAgentThreadStore {
+  const now = options.now ?? (() => new Date());
+  const providers = options.providers.map((provider) => ({
+    ...provider,
+    providerId: ProviderIdSchema.parse(provider.providerId),
+  }));
+  let queue = Promise.resolve();
+
+  async function mutate<T>(fn: (state: StoredThreadState) => Promise<{ state: StoredThreadState; result: T }>): Promise<T> {
+    const run = queue.then(async () => {
+      const current = await readState(options.homePath);
+      const { state, result } = await fn(current);
+      await writeState(options.homePath, trimState(state));
+      return result;
+    });
+    queue = run.then(() => undefined, () => undefined);
+    return run;
+  }
+
+  function providerFor(providerId: string): CodingAgentProviderAdapter {
+    const provider = providers.find((candidate) => candidate.providerId === providerId);
+    if (!provider) {
+      throw new CodingAgentThreadError("provider_unavailable", "Provider unavailable");
+    }
+    return provider;
+  }
+
+  return {
+    async createThread(principal, request) {
+      const provider = providerFor(request.providerId);
+      return mutate(async (state) => {
+        const existing = state.threads.find((thread) =>
+          thread.ownerId === principal.userId && thread.clientRequestId === request.clientRequestId
+        );
+        if (existing) {
+          const result: ThreadCreateResult = { snapshot: snapshotFor(existing, state.events), existing: true };
+          return { state, result };
+        }
+
+        const createdAt = now().toISOString();
+        let thread: StoredThread = {
+          id: nextThreadId(),
+          ownerId: principal.userId,
+          clientRequestId: request.clientRequestId,
+          abortClientRequestIds: [],
+          providerId: request.providerId,
+          title: genericTitle(),
+          status: "queued",
+          attention: "none",
+          projectId: request.projectId,
+          taskId: request.taskId,
+          terminalSessionId: request.terminalSessionId,
+          createdAt,
+          updatedAt: createdAt,
+        };
+        const createdEvent = AgentThreadEventSchema.parse({
+          type: "thread.created",
+          eventId: nextEventId(),
+          threadId: thread.id,
+          occurredAt: createdAt,
+          thread: stripOwner(thread),
+        });
+        const providerEvents = await provider.startThread({
+          thread: stripOwner(thread),
+          request,
+          now,
+          nextEventId,
+        });
+        const events = [createdEvent, ...providerEvents.map((event) => AgentThreadEventSchema.parse(event))];
+        for (const event of events.slice(1)) {
+          thread = applyEvent(thread, event);
+        }
+        const nextState = {
+          version: 1 as const,
+          threads: [thread, ...state.threads],
+          events: [...state.events, ...events],
+        };
+        const result: ThreadCreateResult = { snapshot: snapshotFor(thread, nextState.events), existing: false };
+        return { state: nextState, result };
+      });
+    },
+    async listThreads(principal) {
+      const state = await readState(options.homePath);
+      const ownerThreads = state.threads
+        .filter((thread) => thread.ownerId === principal.userId && activeThread(thread))
+        .sort((a, b) => Date.parse(b.updatedAt) - Date.parse(a.updatedAt));
+      return {
+        items: ownerThreads.slice(0, THREAD_LIST_LIMIT).map(stripOwner),
+        hasMore: ownerThreads.length > THREAD_LIST_LIMIT,
+        limit: THREAD_LIST_LIMIT,
+      };
+    },
+    async getThread(principal, threadId, cursor) {
+      const state = await readState(options.homePath);
+      const thread = state.threads.find((candidate) => candidate.ownerId === principal.userId && candidate.id === threadId);
+      if (!thread) throw new CodingAgentThreadError("thread_not_found", "Thread not found");
+      return snapshotFor(thread, state.events, cursor);
+    },
+    async abortThread(principal, threadId, clientRequestId) {
+      return mutate(async (state) => {
+        const thread = state.threads.find((candidate) => candidate.ownerId === principal.userId && candidate.id === threadId);
+        if (!thread) throw new CodingAgentThreadError("thread_not_found", "Thread not found");
+        if (thread.abortClientRequestIds.includes(clientRequestId) || thread.status === "aborted") {
+          const abortClientRequestIds = thread.abortClientRequestIds.includes(clientRequestId)
+            ? thread.abortClientRequestIds
+            : [...thread.abortClientRequestIds, clientRequestId].slice(-MAX_ABORT_REQUEST_IDS);
+          const nextThread = {
+            ...thread,
+            abortClientRequestIds,
+          };
+          const nextThreads = state.threads.map((candidate) => candidate.id === thread.id ? nextThread : candidate);
+          const nextState = { ...state, threads: nextThreads };
+          return { state: nextState, result: snapshotFor(nextThread, state.events) };
+        }
+        const occurredAt = now().toISOString();
+        const statusEvent = AgentThreadEventSchema.parse({
+          type: "thread.status",
+          eventId: nextEventId(),
+          threadId,
+          occurredAt,
+          status: "aborted",
+        });
+        const completedEvent = AgentThreadEventSchema.parse({
+          type: "thread.completed",
+          eventId: nextEventId(),
+          threadId,
+          occurredAt: now().toISOString(),
+          outcome: "aborted",
+        });
+        let nextThread = applyEvent(thread, statusEvent);
+        nextThread = {
+          ...applyEvent(nextThread, completedEvent),
+          abortClientRequestIds: [...nextThread.abortClientRequestIds, clientRequestId].slice(-MAX_ABORT_REQUEST_IDS),
+        };
+        const nextState = {
+          version: 1 as const,
+          threads: state.threads.map((candidate) => candidate.id === thread.id ? nextThread : candidate),
+          events: [...state.events, statusEvent, completedEvent],
+        };
+        return { state: nextState, result: snapshotFor(nextThread, nextState.events) };
+      });
+    },
+  };
+}

--- a/packages/gateway/src/coding-agents/thread-store.ts
+++ b/packages/gateway/src/coding-agents/thread-store.ts
@@ -75,8 +75,9 @@ export class CodingAgentThreadError extends Error {
   }
 }
 
-export function createFakeCodingAgentProvider(options: { providerId: string }): CodingAgentProviderAdapter {
+export function createFakeCodingAgentProvider(options: { providerId: string; deltaCount?: number }): CodingAgentProviderAdapter {
   const providerId = ProviderIdSchema.parse(options.providerId);
+  const deltaCount = Math.max(1, Math.min(options.deltaCount ?? 1, 300));
   return {
     providerId,
     startThread({ thread, now, nextEventId }) {
@@ -88,14 +89,14 @@ export function createFakeCodingAgentProvider(options: { providerId: string }): 
           occurredAt: now().toISOString(),
           status: "running",
         },
-        {
+        ...Array.from({ length: deltaCount }, (_, index) => ({
           type: "assistant.text.delta",
           eventId: nextEventId(),
           threadId: thread.id,
           occurredAt: now().toISOString(),
           messageId: "msg_fake_provider_started",
-          delta: "Agent run started.",
-        },
+          delta: index === 0 ? "Agent run started." : `Agent event ${index + 1}.`,
+        } satisfies AgentThreadEvent)),
       ];
     },
   };
@@ -146,7 +147,7 @@ function applyEvent(thread: StoredThread, event: AgentThreadEvent): StoredThread
     return {
       ...thread,
       status: event.outcome === "completed" ? "completed" : event.outcome === "aborted" ? "aborted" : "failed",
-      attention: event.outcome === "failed" ? "failed" : thread.attention,
+      attention: event.outcome === "failed" ? "failed" : "none",
       updatedAt,
     };
   }
@@ -164,8 +165,12 @@ function applyEvent(thread: StoredThread, event: AgentThreadEvent): StoredThread
 
 function snapshotFor(thread: StoredThread, allEvents: AgentThreadEvent[], cursor?: string): AgentThreadSnapshot {
   const eventsForThread = allEvents.filter((event) => event.threadId === thread.id);
-  const startIndex = cursor ? eventsForThread.findIndex((event) => event.eventId === cursor) + 1 : 0;
-  const window = eventsForThread.slice(Math.max(0, startIndex)).slice(-EVENT_REPLAY_LIMIT);
+  const cursorIndex = cursor ? eventsForThread.findIndex((event) => event.eventId === cursor) : -1;
+  if (cursor && cursorIndex < 0) {
+    throw new CodingAgentThreadError("thread_not_found", "Thread cursor not found");
+  }
+  const startIndex = cursor ? cursorIndex + 1 : 0;
+  const window = eventsForThread.slice(startIndex, startIndex + EVENT_REPLAY_LIMIT);
   return AgentThreadSnapshotSchema.parse({
     thread: stripOwner(thread),
     events: {
@@ -203,6 +208,10 @@ function trimState(state: StoredThreadState): StoredThreadState {
 
 function activeThread(thread: StoredThread): boolean {
   return !["completed", "failed", "aborted", "archived"].includes(thread.status);
+}
+
+function terminalThread(thread: StoredThread): boolean {
+  return !activeThread(thread);
 }
 
 export function safeThreadError(code: CodingAgentThreadError["code"]) {
@@ -332,17 +341,8 @@ export function createCodingAgentThreadStore(options: CodingAgentThreadStoreOpti
       return mutate(async (state) => {
         const thread = state.threads.find((candidate) => candidate.ownerId === principal.userId && candidate.id === threadId);
         if (!thread) throw new CodingAgentThreadError("thread_not_found", "Thread not found");
-        if (thread.abortClientRequestIds.includes(clientRequestId) || thread.status === "aborted") {
-          const abortClientRequestIds = thread.abortClientRequestIds.includes(clientRequestId)
-            ? thread.abortClientRequestIds
-            : [...thread.abortClientRequestIds, clientRequestId].slice(-MAX_ABORT_REQUEST_IDS);
-          const nextThread = {
-            ...thread,
-            abortClientRequestIds,
-          };
-          const nextThreads = state.threads.map((candidate) => candidate.id === thread.id ? nextThread : candidate);
-          const nextState = { ...state, threads: nextThreads };
-          return { state: nextState, result: snapshotFor(nextThread, state.events) };
+        if (thread.abortClientRequestIds.includes(clientRequestId) || terminalThread(thread)) {
+          return { state, result: snapshotFor(thread, state.events) };
         }
         const occurredAt = now().toISOString();
         const statusEvent = AgentThreadEventSchema.parse({

--- a/packages/gateway/src/server.ts
+++ b/packages/gateway/src/server.ts
@@ -91,6 +91,7 @@ import { createAgentCredentialStatusService } from "./onboarding/agent-credentia
 import { createAgentCredentialRoutes } from "./onboarding/agent-credential-routes.js";
 import { createCodingAgentRuntimeSummaryService } from "./coding-agents/runtime-summary.js";
 import { createCodingAgentRoutes } from "./coding-agents/routes.js";
+import { createCodingAgentThreadStore, createFakeCodingAgentProvider } from "./coding-agents/thread-store.js";
 import { createAgentActionAuditService } from "./onboarding/agent-action-audit.js";
 import { capabilityIdsForConnectedServices, createIntegrationCapabilityService } from "./onboarding/integration-capabilities.js";
 import { createIntegrationCapabilityRoutes } from "./onboarding/integration-capability-routes.js";
@@ -462,10 +463,17 @@ export async function createGateway(config: GatewayConfig) {
       };
     },
   });
+  const codingAgentThreadStore = process.env.MATRIX_CODING_AGENTS_FAKE_PROVIDER === "1"
+    ? createCodingAgentThreadStore({
+      homePath,
+      providers: [createFakeCodingAgentProvider({ providerId: "codex" })],
+    })
+    : undefined;
   const codingAgentRuntimeSummaryService = createCodingAgentRuntimeSummaryService({
     homePath,
     terminalRegistry: zellijShellRegistry,
     agentCredentials: agentCredentialService,
+    threads: codingAgentThreadStore,
     terminalOwnerId: process.env.MATRIX_USER_ID,
   });
   const integrationCapabilityService = createIntegrationCapabilityService({
@@ -1482,7 +1490,10 @@ export async function createGateway(config: GatewayConfig) {
   app.route("/api/onboarding", createReadinessRoutes({ service: readinessService }));
   app.route("/api/onboarding", createToolPackRoutes({ service: toolPackService }));
   app.route("/api/agents", createAgentCredentialRoutes({ service: agentCredentialService }));
-  app.route("/api/coding-agents", createCodingAgentRoutes({ service: codingAgentRuntimeSummaryService }));
+  app.route("/api/coding-agents", createCodingAgentRoutes({
+    service: codingAgentRuntimeSummaryService,
+    threads: codingAgentThreadStore,
+  }));
   app.route("/api/integrations", createIntegrationCapabilityRoutes({
     service: integrationCapabilityService,
     audit: agentActionAuditService,

--- a/specs/105-coding-agent-shells/storage-decision.md
+++ b/specs/105-coding-agent-shells/storage-decision.md
@@ -1,0 +1,70 @@
+# Coding Agent Thread Storage Decision
+
+## Scope
+
+This note covers the first gateway thread lifecycle slice: thread metadata, safe summaries, replayable events, idempotent create requests, and abort markers.
+
+## Source Of Truth
+
+The source of truth for this slice is the owner-controlled Matrix home file:
+
+`system/coding-agents/threads.json`
+
+This follows existing owner-file conventions for Matrix runtime metadata while avoiding a new embedded database. Desktop and mobile do not persist thread transcripts or event payloads; they read summaries and event windows from the gateway.
+
+## Persisted Data
+
+Persisted thread records include:
+
+- owner ID
+- thread ID
+- provider ID
+- safe title
+- status and attention state
+- optional project, task, terminal, and worktree references
+- idempotency request IDs
+- bounded typed events
+
+The store intentionally does not persist create prompts, terminal output, file contents, diffs, provider logs, raw errors, credentials, tokens, hostnames, or filesystem paths.
+
+## Transaction Boundary
+
+Each create or abort operation runs through a per-store mutation queue:
+
+- read and validate the persisted file
+- apply the thread metadata and event change together in memory
+- validate the full next persisted shape with Zod
+- atomically write the next file with temp-file plus rename
+
+For create, the thread record and initial events are written together. For abort, the terminal/provider process is not killed in this slice; only the thread lifecycle state is marked aborted.
+
+## Idempotency
+
+Thread creation is idempotent by `ownerId + clientRequestId`. A repeated create request returns the existing thread snapshot and does not append duplicate events.
+
+Abort is idempotent by thread plus abort `clientRequestId`; repeated abort requests return the existing aborted snapshot and do not append duplicate events.
+
+## Bounds And Eviction
+
+The first store caps persisted state to:
+
+- 200 threads
+- 500 events per retained thread
+- 50 abort request IDs per thread
+- 50 active threads in list responses
+- 200 events in replay responses
+
+When the thread cap is exceeded, the oldest updated threads are evicted from this owner-file projection along with their events. A future Postgres-backed store may preserve deeper history without changing the gateway contracts.
+
+## Acceptable Orphan States
+
+This slice may contain a thread marked `running` whose fake provider has no live external process, because provider execution is still behind a feature flag. Clients must treat thread status as runtime metadata and recover by refreshing the summary or replaying events.
+
+If a write fails after validation, the previous file remains intact. If provider startup fails before the file write, no thread is committed for this slice.
+
+## Deferred Work
+
+- WebSocket thread streaming with subscriber caps, stale cleanup, and shutdown drain
+- real provider adapter start and abort behavior
+- approval and input request state
+- durable compaction beyond the bounded owner-file projection

--- a/tests/gateway/coding-agents-threads.test.ts
+++ b/tests/gateway/coding-agents-threads.test.ts
@@ -4,6 +4,7 @@ import { join } from "node:path";
 import { Hono } from "hono";
 import { describe, expect, it } from "vitest";
 import {
+  AgentThreadEventSchema,
   AgentThreadSnapshotSchema,
   RuntimeSummarySchema,
 } from "../../packages/contracts/src/index.js";
@@ -125,6 +126,49 @@ describe("coding agent thread lifecycle", () => {
     ]);
   });
 
+  it("rejects stale cursors instead of replaying from the beginning", async () => {
+    const { app } = await createHarness();
+    const created = await app.request(jsonRequest("/api/coding-agents/threads", createBody));
+    const snapshot = AgentThreadSnapshotSchema.parse(await created.json());
+
+    const replay = await app.request(`/api/coding-agents/threads/${snapshot.thread.id}/events?cursor=evt_missing`);
+
+    expect(replay.status).toBe(404);
+    expect(await replay.json()).toEqual({
+      error: {
+        code: "thread_not_found",
+        safeMessage: "Thread is unavailable. Refresh and try again.",
+        retryable: true,
+        recoveryActions: ["retry"],
+      },
+    });
+  });
+
+  it("returns the first replay window after the cursor", async () => {
+    const homePath = await mkdtemp(join(tmpdir(), "matrix-coding-agent-threads-"));
+    const threads = createCodingAgentThreadStore({
+      homePath,
+      now: () => baseNow,
+      providers: [createFakeCodingAgentProvider({ providerId: "codex", deltaCount: 250 })],
+    });
+    const app = new Hono();
+    app.route("/api/coding-agents", createCodingAgentRoutes({
+      service: createCodingAgentRuntimeSummaryService({ homePath, now: () => baseNow }),
+      threads,
+      getPrincipal: () => ownerPrincipal,
+    }));
+    const created = await app.request(jsonRequest("/api/coding-agents/threads", createBody));
+    const snapshot = AgentThreadSnapshotSchema.parse(await created.json());
+    const createdCursor = snapshot.events.items[0]!.eventId;
+
+    const replay = await app.request(`/api/coding-agents/threads/${snapshot.thread.id}/events?cursor=${createdCursor}`);
+    const replayBody = AgentThreadSnapshotSchema.parse(await replay.json());
+
+    expect(replayBody.events.items).toHaveLength(200);
+    expect(replayBody.events.items[0]).toMatchObject({ type: "thread.status" });
+    expect(replayBody.events.hasMore).toBe(true);
+  });
+
   it("keeps thread ownership isolated and maps missing threads to safe errors", async () => {
     const { app, setPrincipal } = await createHarness();
     const created = await app.request(jsonRequest("/api/coding-agents/threads", createBody));
@@ -158,6 +202,7 @@ describe("coding agent thread lifecycle", () => {
     const aborted = AgentThreadSnapshotSchema.parse(await firstAbort.json());
     const duplicate = AgentThreadSnapshotSchema.parse(await duplicateAbort.json());
     expect(aborted.thread.status).toBe("aborted");
+    expect(aborted.thread.attention).toBe("none");
     expect(duplicate.events.items.map((event) => event.eventId)).toEqual(
       aborted.events.items.map((event) => event.eventId),
     );
@@ -165,6 +210,54 @@ describe("coding agent thread lifecycle", () => {
       type: "thread.completed",
       outcome: "aborted",
     });
+  });
+
+  it("clears pending attention on abort and preserves already-final threads", async () => {
+    const homePath = await mkdtemp(join(tmpdir(), "matrix-coding-agent-threads-"));
+    let tick = 0;
+    const now = () => new Date(baseNow.getTime() + tick++ * 1000);
+    const threads = createCodingAgentThreadStore({
+      homePath,
+      now,
+      providers: [
+        {
+          providerId: "codex",
+          startThread({ thread, now: providerNow, nextEventId }) {
+            return [
+              AgentThreadEventSchema.parse({
+                type: "approval.requested",
+                eventId: nextEventId(),
+                threadId: thread.id,
+                occurredAt: providerNow().toISOString(),
+                approval: {
+                  approvalId: "appr_test",
+                  threadId: thread.id,
+                  title: "Confirm action",
+                  safeDescription: "Approve the next step.",
+                  risk: "low",
+                  actionKind: "other",
+                  allowedDecisions: ["approve", "decline"],
+                  correlationId: "corr_test",
+                },
+              }),
+            ];
+          },
+        },
+      ],
+    });
+    const created = await threads.createThread(ownerPrincipal, createBody);
+
+    const aborted = await threads.abortThread(ownerPrincipal, created.snapshot.thread.id, "req_abort_attention");
+    const duplicate = await threads.abortThread(ownerPrincipal, created.snapshot.thread.id, "req_abort_after_final");
+
+    expect(created.snapshot.thread).toMatchObject({
+      status: "waiting_for_approval",
+      attention: "approval_required",
+    });
+    expect(aborted.thread).toMatchObject({ status: "aborted", attention: "none" });
+    expect(duplicate.events.items.map((event) => event.eventId)).toEqual(
+      aborted.events.items.map((event) => event.eventId),
+    );
   });
 
   it("rejects unauthenticated, oversized, invalid provider, and unsafe route input", async () => {

--- a/tests/gateway/coding-agents-threads.test.ts
+++ b/tests/gateway/coding-agents-threads.test.ts
@@ -1,0 +1,217 @@
+import { mkdtemp, readFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Hono } from "hono";
+import { describe, expect, it } from "vitest";
+import {
+  AgentThreadSnapshotSchema,
+  RuntimeSummarySchema,
+} from "../../packages/contracts/src/index.js";
+import { createCodingAgentRoutes } from "../../packages/gateway/src/coding-agents/routes.js";
+import { createCodingAgentRuntimeSummaryService } from "../../packages/gateway/src/coding-agents/runtime-summary.js";
+import {
+  createCodingAgentThreadStore,
+  createFakeCodingAgentProvider,
+} from "../../packages/gateway/src/coding-agents/thread-store.js";
+import type { RequestPrincipal } from "../../packages/gateway/src/request-principal.js";
+import { MissingRequestPrincipalError } from "../../packages/gateway/src/request-principal.js";
+
+const ownerPrincipal: RequestPrincipal = { userId: "owner_user", source: "jwt" };
+const otherPrincipal: RequestPrincipal = { userId: "other_user", source: "jwt" };
+const baseNow = new Date("2026-07-06T12:00:00.000Z");
+
+function jsonRequest(path: string, body: unknown): Request {
+  return new Request(`http://localhost${path}`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+async function createHarness() {
+  const homePath = await mkdtemp(join(tmpdir(), "matrix-coding-agent-threads-"));
+  let currentPrincipal = ownerPrincipal;
+  let tick = 0;
+  const now = () => new Date(baseNow.getTime() + tick++ * 1000);
+  const threads = createCodingAgentThreadStore({
+    homePath,
+    now,
+    providers: [
+      createFakeCodingAgentProvider({ providerId: "codex" }),
+    ],
+  });
+  const summary = createCodingAgentRuntimeSummaryService({
+    homePath,
+    now,
+    runtime: { id: "rt_primary", label: "Primary Matrix computer" },
+    threads,
+  });
+  const app = new Hono();
+  app.route("/api/coding-agents", createCodingAgentRoutes({
+    service: summary,
+    threads,
+    getPrincipal: () => currentPrincipal,
+  }));
+  return {
+    app,
+    homePath,
+    setPrincipal: (principal: RequestPrincipal) => {
+      currentPrincipal = principal;
+    },
+  };
+}
+
+const createBody = {
+  providerId: "codex",
+  prompt: "Inspect the failing tests and propose a small fix.",
+  projectId: "repo-main",
+  terminalSessionId: "main",
+  mode: "default",
+  approvalPolicy: "on_request",
+  sandboxMode: "workspace_write",
+  clientRequestId: "req_create_1",
+};
+
+describe("coding agent thread lifecycle", () => {
+  it("creates a thread idempotently and replays fake-provider events", async () => {
+    const { app } = await createHarness();
+
+    const first = await app.request(jsonRequest("/api/coding-agents/threads", createBody));
+    const duplicate = await app.request(jsonRequest("/api/coding-agents/threads", createBody));
+
+    expect(first.status).toBe(202);
+    expect(duplicate.status).toBe(200);
+    const firstSnapshot = AgentThreadSnapshotSchema.parse(await first.json());
+    const duplicateSnapshot = AgentThreadSnapshotSchema.parse(await duplicate.json());
+    expect(duplicateSnapshot.thread.id).toBe(firstSnapshot.thread.id);
+    expect(duplicateSnapshot.events.items.map((event) => event.eventId)).toEqual(
+      firstSnapshot.events.items.map((event) => event.eventId),
+    );
+    expect(firstSnapshot.thread).toMatchObject({
+      providerId: "codex",
+      projectId: "repo-main",
+      terminalSessionId: "main",
+      status: "running",
+      attention: "none",
+    });
+    expect(firstSnapshot.events.items.map((event) => event.type)).toEqual([
+      "thread.created",
+      "thread.status",
+      "assistant.text.delta",
+    ]);
+
+    const replay = await app.request(`/api/coding-agents/threads/${firstSnapshot.thread.id}/events`);
+    expect(replay.status).toBe(200);
+    expect(AgentThreadSnapshotSchema.parse(await replay.json()).events.items).toHaveLength(3);
+  });
+
+  it("replays events after a cursor and includes active threads in the runtime summary", async () => {
+    const { app } = await createHarness();
+    const created = await app.request(jsonRequest("/api/coding-agents/threads", createBody));
+    const snapshot = AgentThreadSnapshotSchema.parse(await created.json());
+    const firstCursor = snapshot.events.items[0]!.eventId;
+
+    const replay = await app.request(`/api/coding-agents/threads/${snapshot.thread.id}/events?cursor=${firstCursor}`);
+    const summary = await app.request("/api/coding-agents/summary");
+
+    expect(replay.status).toBe(200);
+    const replayBody = AgentThreadSnapshotSchema.parse(await replay.json());
+    expect(replayBody.events.items.map((event) => event.type)).toEqual([
+      "thread.status",
+      "assistant.text.delta",
+    ]);
+    expect(RuntimeSummarySchema.parse(await summary.json()).activeThreads.items).toEqual([
+      expect.objectContaining({ id: snapshot.thread.id, status: "running" }),
+    ]);
+  });
+
+  it("keeps thread ownership isolated and maps missing threads to safe errors", async () => {
+    const { app, setPrincipal } = await createHarness();
+    const created = await app.request(jsonRequest("/api/coding-agents/threads", createBody));
+    const snapshot = AgentThreadSnapshotSchema.parse(await created.json());
+
+    setPrincipal(otherPrincipal);
+    const read = await app.request(`/api/coding-agents/threads/${snapshot.thread.id}`);
+
+    expect(read.status).toBe(404);
+    expect(await read.json()).toEqual({
+      error: {
+        code: "thread_not_found",
+        safeMessage: "Thread is unavailable. Refresh and try again.",
+        retryable: true,
+        recoveryActions: ["retry"],
+      },
+    });
+  });
+
+  it("aborts one thread idempotently without duplicating terminal or provider state", async () => {
+    const { app } = await createHarness();
+    const created = await app.request(jsonRequest("/api/coding-agents/threads", createBody));
+    const snapshot = AgentThreadSnapshotSchema.parse(await created.json());
+    const abortBody = { clientRequestId: "req_abort_1" };
+
+    const firstAbort = await app.request(jsonRequest(`/api/coding-agents/threads/${snapshot.thread.id}/abort`, abortBody));
+    const duplicateAbort = await app.request(jsonRequest(`/api/coding-agents/threads/${snapshot.thread.id}/abort`, abortBody));
+
+    expect(firstAbort.status).toBe(200);
+    expect(duplicateAbort.status).toBe(200);
+    const aborted = AgentThreadSnapshotSchema.parse(await firstAbort.json());
+    const duplicate = AgentThreadSnapshotSchema.parse(await duplicateAbort.json());
+    expect(aborted.thread.status).toBe("aborted");
+    expect(duplicate.events.items.map((event) => event.eventId)).toEqual(
+      aborted.events.items.map((event) => event.eventId),
+    );
+    expect(aborted.events.items.at(-1)).toMatchObject({
+      type: "thread.completed",
+      outcome: "aborted",
+    });
+  });
+
+  it("rejects unauthenticated, oversized, invalid provider, and unsafe route input", async () => {
+    const { app, setPrincipal } = await createHarness();
+
+    const invalidProvider = await app.request(jsonRequest("/api/coding-agents/threads", {
+      ...createBody,
+      providerId: "opencode",
+      clientRequestId: "req_create_2",
+    }));
+    const unsafeThreadId = await app.request("/api/coding-agents/threads/../secret");
+    const oversized = await app.request(new Request("http://localhost/api/coding-agents/threads", {
+      method: "POST",
+      headers: { "content-type": "application/json", "content-length": String(150_000) },
+      body: JSON.stringify({ ...createBody, prompt: "x".repeat(150_000), clientRequestId: "req_create_3" }),
+    }));
+    setPrincipal({
+      get userId(): string {
+        throw new MissingRequestPrincipalError();
+      },
+      source: "jwt",
+    } as RequestPrincipal);
+    const unauthenticated = await app.request(jsonRequest("/api/coding-agents/threads", createBody));
+
+    expect(invalidProvider.status).toBe(400);
+    expect(await invalidProvider.json()).toEqual({
+      error: {
+        code: "provider_unavailable",
+        safeMessage: "Selected provider is unavailable. Choose another provider or try again.",
+        retryable: true,
+        recoveryActions: ["retry"],
+      },
+    });
+    expect(unsafeThreadId.status).toBe(404);
+    expect(oversized.status).toBe(413);
+    expect(unauthenticated.status).toBe(401);
+  });
+
+  it("persists thread state in owner files instead of client-local storage", async () => {
+    const { app, homePath } = await createHarness();
+    const created = await app.request(jsonRequest("/api/coding-agents/threads", createBody));
+    const snapshot = AgentThreadSnapshotSchema.parse(await created.json());
+
+    const raw = await readFile(join(homePath, "system", "coding-agents", "threads.json"), "utf-8");
+
+    expect(raw).toContain(snapshot.thread.id);
+    expect(raw).toContain("owner_user");
+    expect(raw).not.toMatch(/Inspect the failing tests/);
+  });
+});


### PR DESCRIPTION
## Summary

- add an owner-file-backed coding-agent thread store with idempotent create and abort
- add authenticated, body-limited thread create/list/read/events/abort routes
- feed active thread summaries into the runtime summary projection when the thread lifecycle flag is enabled
- add a fake provider adapter behind `MATRIX_CODING_AGENTS_FAKE_PROVIDER=1` for contract and lifecycle tests

## Validation

- `pnpm exec vitest run tests/gateway/coding-agents-threads.test.ts tests/gateway/coding-agents-summary.test.ts tests/contracts/coding-agents.test.ts`
- `pnpm --filter @matrix-os/gateway exec tsc --noEmit`
- `bun run check:patterns`
- `bun run typecheck`
- `git diff --check`
- prohibited-term scan clean

## Invariants

- Source of truth: gateway-owned owner file `system/coding-agents/threads.json` is the source of truth for this first bounded thread lifecycle projection; clients only read contracts.
- Lock/transaction scope: create and abort each run through a per-store mutation queue and one atomic validated file write.
- Acceptable orphan states: fake-provider threads may be `running` without a real provider process while the provider path is feature-flagged; clients recover by refreshing summary or replaying events.
- Auth source of truth: routes use the gateway request principal and owner checks before returning thread data.
- Deferred scope: WebSocket streaming, real provider start/abort, approvals/input, terminal binding side effects, review/diff, and preview controls remain deferred.
