### PR TITLE
feat(gateway): stream coding agent thread events

### DIFF
--- a/packages/gateway/src/auth.ts
+++ b/packages/gateway/src/auth.ts
@@ -92,7 +92,10 @@ const ROUTE_SCOPED_BEARER_PATHS = [
 const MESSAGE_APPSERVICE_PREFIX = "/api/messages/appservice/";
 const MESSAGE_HERMES_REPLY_PATH = /^\/api\/messages\/conversations\/[^/]+\/reply$/;
 const WS_QUERY_TOKEN_PATHS = ["/ws", "/ws/voice", "/ws/terminal", "/ws/terminal/session", "/ws/onboarding", "/ws/vocal"];
-const WS_QUERY_TOKEN_PATH_PATTERNS = [/^\/api\/canvases\/[^/]+\/ws$/];
+const WS_QUERY_TOKEN_PATH_PATTERNS = [
+  /^\/api\/canvases\/[^/]+\/ws$/,
+  /^\/ws\/coding-agents\/thread\/thread_[A-Za-z0-9_-]+$/,
+];
 
 // Constant-time string compare. Previously, the length-mismatch branch ran
 // timingSafeEqual(bufB, bufB) as a dummy call -- but the work done in

--- a/packages/gateway/src/coding-agents/thread-store.ts
+++ b/packages/gateway/src/coding-agents/thread-store.ts
@@ -41,6 +41,12 @@ type StoredThread = z.infer<typeof StoredThreadSchema>;
 type StoredThreadState = z.infer<typeof StoredThreadStateSchema>;
 type AgentThreadSnapshot = z.infer<typeof AgentThreadSnapshotSchema>;
 type ThreadCreateResult = { snapshot: AgentThreadSnapshot; existing: boolean };
+type ThreadCreateMutationResult = ThreadCreateResult & { eventsToPublish: AgentThreadEvent[] };
+type ThreadEventSink = (input: {
+  ownerId: string;
+  threadId: string;
+  events: AgentThreadEvent[];
+}) => void;
 
 export interface CodingAgentProviderAdapter {
   providerId: string;
@@ -63,6 +69,7 @@ export interface CodingAgentThreadStore {
   listThreads(principal: RequestPrincipal): Promise<{ items: AgentThreadSummary[]; hasMore: boolean; limit: number }>;
   getThread(principal: RequestPrincipal, threadId: string, cursor?: string): Promise<AgentThreadSnapshot>;
   abortThread(principal: RequestPrincipal, threadId: string, clientRequestId: string): Promise<AgentThreadSnapshot>;
+  registerEventSink(sink: ThreadEventSink): { dispose(): void };
 }
 
 export class CodingAgentThreadError extends Error {
@@ -245,6 +252,7 @@ export function createCodingAgentThreadStore(options: CodingAgentThreadStoreOpti
     ...provider,
     providerId: ProviderIdSchema.parse(provider.providerId),
   }));
+  const eventSinks: ThreadEventSink[] = [];
   let queue = Promise.resolve();
 
   async function mutate<T>(fn: (state: StoredThreadState) => Promise<{ state: StoredThreadState; result: T }>): Promise<T> {
@@ -266,15 +274,30 @@ export function createCodingAgentThreadStore(options: CodingAgentThreadStoreOpti
     return provider;
   }
 
+  function publish(ownerId: string, threadId: string, events: AgentThreadEvent[]): void {
+    if (events.length === 0) return;
+    for (const sink of eventSinks) {
+      try {
+        sink({ ownerId, threadId, events });
+      } catch (err: unknown) {
+        console.warn("[coding-agents] thread event sink failed:", err instanceof Error ? err.message : String(err));
+      }
+    }
+  }
+
   return {
     async createThread(principal, request) {
       const provider = providerFor(request.providerId);
-      return mutate(async (state) => {
+      const result = await mutate(async (state) => {
         const existing = state.threads.find((thread) =>
           thread.ownerId === principal.userId && thread.clientRequestId === request.clientRequestId
         );
         if (existing) {
-          const result: ThreadCreateResult = { snapshot: snapshotFor(existing, state.events), existing: true };
+          const result: ThreadCreateMutationResult = {
+            snapshot: snapshotFor(existing, state.events),
+            existing: true,
+            eventsToPublish: [],
+          };
           return { state, result };
         }
 
@@ -316,9 +339,17 @@ export function createCodingAgentThreadStore(options: CodingAgentThreadStoreOpti
           threads: [thread, ...state.threads],
           events: [...state.events, ...events],
         };
-        const result: ThreadCreateResult = { snapshot: snapshotFor(thread, nextState.events), existing: false };
+        const result: ThreadCreateMutationResult = {
+          snapshot: snapshotFor(thread, nextState.events),
+          existing: false,
+          eventsToPublish: events,
+        };
         return { state: nextState, result };
       });
+      if (!result.existing) {
+        publish(principal.userId, result.snapshot.thread.id, result.eventsToPublish);
+      }
+      return { snapshot: result.snapshot, existing: result.existing };
     },
     async listThreads(principal) {
       const state = await readState(options.homePath);
@@ -338,11 +369,11 @@ export function createCodingAgentThreadStore(options: CodingAgentThreadStoreOpti
       return snapshotFor(thread, state.events, cursor);
     },
     async abortThread(principal, threadId, clientRequestId) {
-      return mutate(async (state) => {
+      const result = await mutate(async (state) => {
         const thread = state.threads.find((candidate) => candidate.ownerId === principal.userId && candidate.id === threadId);
         if (!thread) throw new CodingAgentThreadError("thread_not_found", "Thread not found");
         if (thread.abortClientRequestIds.includes(clientRequestId) || terminalThread(thread)) {
-          return { state, result: snapshotFor(thread, state.events) };
+          return { state, result: { snapshot: snapshotFor(thread, state.events), eventsToPublish: [] } };
         }
         const occurredAt = now().toISOString();
         const statusEvent = AgentThreadEventSchema.parse({
@@ -369,8 +400,27 @@ export function createCodingAgentThreadStore(options: CodingAgentThreadStoreOpti
           threads: state.threads.map((candidate) => candidate.id === thread.id ? nextThread : candidate),
           events: [...state.events, statusEvent, completedEvent],
         };
-        return { state: nextState, result: snapshotFor(nextThread, nextState.events) };
+        return {
+          state: nextState,
+          result: { snapshot: snapshotFor(nextThread, nextState.events), eventsToPublish: [statusEvent, completedEvent] },
+        };
       });
+      publish(principal.userId, threadId, result.eventsToPublish);
+      return result.snapshot;
+    },
+    registerEventSink(sink) {
+      if (eventSinks.length >= 8) {
+        eventSinks.shift();
+      }
+      eventSinks.push(sink);
+      return {
+        dispose() {
+          const index = eventSinks.indexOf(sink);
+          if (index >= 0) {
+            eventSinks.splice(index, 1);
+          }
+        },
+      };
     },
   };
 }

--- a/packages/gateway/src/coding-agents/thread-store.ts
+++ b/packages/gateway/src/coding-agents/thread-store.ts
@@ -410,7 +410,7 @@ export function createCodingAgentThreadStore(options: CodingAgentThreadStoreOpti
     },
     registerEventSink(sink) {
       if (eventSinks.length >= 8) {
-        eventSinks.shift();
+        throw new CodingAgentThreadError("thread_store_unavailable", "Too many thread event sinks");
       }
       eventSinks.push(sink);
       return {

--- a/packages/gateway/src/coding-agents/thread-stream.ts
+++ b/packages/gateway/src/coding-agents/thread-stream.ts
@@ -15,6 +15,7 @@ import {
 const MAX_INBOUND_FRAME_BYTES = 4096;
 const DEFAULT_MAX_SUBSCRIBERS = 64;
 const DEFAULT_SUBSCRIBER_TTL_MS = 5 * 60 * 1000;
+const MAX_BUFFERED_ATTACH_EVENTS = 200;
 
 const ThreadStreamClientFrameSchema = z.discriminatedUnion("type", [
   z.object({ type: z.literal("ping") }).strict(),
@@ -44,6 +45,8 @@ interface Subscriber {
   threadId: string;
   ws: CodingAgentThreadStreamSocket;
   lastTouched: number;
+  replaying: boolean;
+  bufferedEvents: AgentThreadEvent[];
 }
 
 export function threadStreamFrameDataToString(data: unknown): string | null {
@@ -87,6 +90,7 @@ export function createCodingAgentThreadStream(options: CodingAgentThreadStreamOp
   const subscriberTtlMs = options.subscriberTtlMs ?? DEFAULT_SUBSCRIBER_TTL_MS;
   const now = options.now ?? (() => Date.now());
   let nextSubscriberId = 0;
+  let shuttingDown = false;
 
   const eventSink = options.threads.registerEventSink(({ ownerId, threadId, events }) => {
     broadcast(ownerId, threadId, events);
@@ -134,6 +138,13 @@ export function createCodingAgentThreadStream(options: CodingAgentThreadStreamOp
         continue;
       }
       subscriber.lastTouched = now();
+      if (subscriber.replaying) {
+        subscriber.bufferedEvents.push(...events.map((event) => AgentThreadEventSchema.parse(event)));
+        if (subscriber.bufferedEvents.length > MAX_BUFFERED_ATTACH_EVENTS) {
+          deadSubscriberIds.push(id);
+        }
+        continue;
+      }
       for (const event of events) {
         const parsed = AgentThreadEventSchema.parse(event);
         if (!sendJson(subscriber.ws, { type: "thread.event", event: parsed })) {
@@ -154,9 +165,14 @@ export function createCodingAgentThreadStream(options: CodingAgentThreadStreamOp
     cursor?: string;
   }): Promise<CodingAgentThreadStreamSession> {
     let threadId: string;
+    let openedSubscriberId: string | null = null;
     try {
+      if (shuttingDown) {
+        sendJson(input.ws, { type: "thread.stream.closing", reason: "server_shutdown" });
+        closeSocket(input.ws);
+        return { onMessage: () => undefined, onClose: () => undefined };
+      }
       threadId = ThreadIdSchema.parse(input.threadId);
-      const snapshot = await options.threads.getThread(input.principal, threadId, input.cursor);
       enforceSubscriberCap();
       const id = `thread_sub_${++nextSubscriberId}`;
       const subscriber: Subscriber = {
@@ -165,13 +181,23 @@ export function createCodingAgentThreadStream(options: CodingAgentThreadStreamOp
         threadId,
         ws: input.ws,
         lastTouched: now(),
+        replaying: true,
+        bufferedEvents: [],
       };
       subscribers.set(id, subscriber);
+      openedSubscriberId = id;
+
+      const snapshot = await options.threads.getThread(input.principal, threadId, input.cursor);
+      const currentSubscriber = subscribers.get(id);
+      if (!currentSubscriber) {
+        return { onMessage: () => undefined, onClose: () => undefined };
+      }
 
       if (!sendJson(input.ws, { type: "thread.stream.attached", threadId })) {
         evictSubscriber(id, "send_failed");
         return { onMessage: () => undefined, onClose: () => undefined };
       }
+      const replayedEventIds = snapshot.events.items.map((event) => event.eventId);
       for (const event of snapshot.events.items) {
         if (!sendJson(input.ws, { type: "thread.event", event })) {
           evictSubscriber(id, "send_failed");
@@ -179,6 +205,10 @@ export function createCodingAgentThreadStream(options: CodingAgentThreadStreamOp
         }
       }
       sendJson(input.ws, { type: "thread.replay.end", nextCursor: snapshot.events.nextCursor });
+      currentSubscriber.replaying = false;
+      const bufferedEvents = currentSubscriber.bufferedEvents.filter((event) => !replayedEventIds.includes(event.eventId));
+      currentSubscriber.bufferedEvents = [];
+      broadcast(input.principal.userId, threadId, bufferedEvents);
 
       return {
         onMessage(raw) {
@@ -216,6 +246,9 @@ export function createCodingAgentThreadStream(options: CodingAgentThreadStreamOp
         },
       };
     } catch (err: unknown) {
+      if (openedSubscriberId) {
+        subscribers.delete(openedSubscriberId);
+      }
       const safeError = err instanceof CodingAgentThreadError
         ? safeThreadError(err.code)
         : SafeClientErrorSchema.parse({
@@ -234,6 +267,7 @@ export function createCodingAgentThreadStream(options: CodingAgentThreadStreamOp
   }
 
   function shutdown(): void {
+    shuttingDown = true;
     for (const id of Array.from(subscribers.keys())) {
       evictSubscriber(id, "server_shutdown");
     }

--- a/packages/gateway/src/coding-agents/thread-stream.ts
+++ b/packages/gateway/src/coding-agents/thread-stream.ts
@@ -1,0 +1,249 @@
+import { z } from "zod/v4";
+import {
+  AgentThreadEventSchema,
+  SafeClientErrorSchema,
+  ThreadIdSchema,
+  type AgentThreadEvent,
+} from "@matrix-os/contracts";
+import type { RequestPrincipal } from "../request-principal.js";
+import {
+  CodingAgentThreadError,
+  safeThreadError,
+  type CodingAgentThreadStore,
+} from "./thread-store.js";
+
+const MAX_INBOUND_FRAME_BYTES = 4096;
+const DEFAULT_MAX_SUBSCRIBERS = 64;
+const DEFAULT_SUBSCRIBER_TTL_MS = 5 * 60 * 1000;
+
+const ThreadStreamClientFrameSchema = z.discriminatedUnion("type", [
+  z.object({ type: z.literal("ping") }).strict(),
+  z.object({ type: z.literal("detach") }).strict(),
+]);
+
+export interface CodingAgentThreadStreamSocket {
+  send(data: string): void;
+  close?: () => void;
+}
+
+export interface CodingAgentThreadStreamSession {
+  onMessage(raw: string): void;
+  onClose(): void;
+}
+
+export interface CodingAgentThreadStreamOptions {
+  threads: CodingAgentThreadStore;
+  maxSubscribers?: number;
+  subscriberTtlMs?: number;
+  now?: () => number;
+}
+
+interface Subscriber {
+  id: string;
+  ownerId: string;
+  threadId: string;
+  ws: CodingAgentThreadStreamSocket;
+  lastTouched: number;
+}
+
+export function threadStreamFrameDataToString(data: unknown): string | null {
+  if (typeof data === "string") return data;
+  if (Buffer.isBuffer(data)) return data.toString("utf8");
+  if (data instanceof ArrayBuffer) return Buffer.from(data).toString("utf8");
+  if (ArrayBuffer.isView(data)) return Buffer.from(data.buffer, data.byteOffset, data.byteLength).toString("utf8");
+  return null;
+}
+
+function invalidFrameError() {
+  return SafeClientErrorSchema.parse({
+    code: "invalid_frame",
+    safeMessage: "Stream message was invalid. Refresh and try again.",
+    retryable: true,
+    recoveryActions: ["retry"],
+  });
+}
+
+function sendJson(ws: CodingAgentThreadStreamSocket, frame: unknown): boolean {
+  try {
+    ws.send(JSON.stringify(frame));
+    return true;
+  } catch (err: unknown) {
+    console.warn("[coding-agents] thread stream send failed:", err instanceof Error ? err.message : String(err));
+    return false;
+  }
+}
+
+function closeSocket(ws: CodingAgentThreadStreamSocket): void {
+  try {
+    ws.close?.();
+  } catch (err: unknown) {
+    console.warn("[coding-agents] thread stream close failed:", err instanceof Error ? err.message : String(err));
+  }
+}
+
+export function createCodingAgentThreadStream(options: CodingAgentThreadStreamOptions) {
+  const subscribers = new Map<string, Subscriber>();
+  const maxSubscribers = options.maxSubscribers ?? DEFAULT_MAX_SUBSCRIBERS;
+  const subscriberTtlMs = options.subscriberTtlMs ?? DEFAULT_SUBSCRIBER_TTL_MS;
+  const now = options.now ?? (() => Date.now());
+  let nextSubscriberId = 0;
+
+  const eventSink = options.threads.registerEventSink(({ ownerId, threadId, events }) => {
+    broadcast(ownerId, threadId, events);
+  });
+
+  function evictSubscriber(id: string, reason?: "subscriber_cap" | "stale" | "send_failed" | "server_shutdown"): void {
+    const subscriber = subscribers.get(id);
+    if (!subscriber) return;
+    subscribers.delete(id);
+    if (reason === "server_shutdown") {
+      sendJson(subscriber.ws, { type: "thread.stream.closing", reason: "server_shutdown" });
+    }
+    closeSocket(subscriber.ws);
+  }
+
+  function evictStaleSubscribers(): void {
+    const cutoff = now() - subscriberTtlMs;
+    for (const [id, subscriber] of subscribers) {
+      if (subscriber.lastTouched < cutoff) {
+        evictSubscriber(id, "stale");
+      }
+    }
+  }
+
+  function enforceSubscriberCap(): void {
+    evictStaleSubscribers();
+    while (subscribers.size >= maxSubscribers) {
+      let oldestId: string | null = null;
+      let oldestTouched = Number.POSITIVE_INFINITY;
+      for (const [id, subscriber] of subscribers) {
+        if (subscriber.lastTouched < oldestTouched) {
+          oldestId = id;
+          oldestTouched = subscriber.lastTouched;
+        }
+      }
+      if (!oldestId) return;
+      evictSubscriber(oldestId, "subscriber_cap");
+    }
+  }
+
+  function broadcast(ownerId: string, threadId: string, events: AgentThreadEvent[]): void {
+    const deadSubscriberIds: string[] = [];
+    for (const [id, subscriber] of subscribers) {
+      if (subscriber.ownerId !== ownerId || subscriber.threadId !== threadId) {
+        continue;
+      }
+      subscriber.lastTouched = now();
+      for (const event of events) {
+        const parsed = AgentThreadEventSchema.parse(event);
+        if (!sendJson(subscriber.ws, { type: "thread.event", event: parsed })) {
+          deadSubscriberIds.push(id);
+          break;
+        }
+      }
+    }
+    for (const id of deadSubscriberIds) {
+      evictSubscriber(id, "send_failed");
+    }
+  }
+
+  async function open(input: {
+    ws: CodingAgentThreadStreamSocket;
+    principal: RequestPrincipal;
+    threadId: string;
+    cursor?: string;
+  }): Promise<CodingAgentThreadStreamSession> {
+    let threadId: string;
+    try {
+      threadId = ThreadIdSchema.parse(input.threadId);
+      const snapshot = await options.threads.getThread(input.principal, threadId, input.cursor);
+      enforceSubscriberCap();
+      const id = `thread_sub_${++nextSubscriberId}`;
+      const subscriber: Subscriber = {
+        id,
+        ownerId: input.principal.userId,
+        threadId,
+        ws: input.ws,
+        lastTouched: now(),
+      };
+      subscribers.set(id, subscriber);
+
+      if (!sendJson(input.ws, { type: "thread.stream.attached", threadId })) {
+        evictSubscriber(id, "send_failed");
+        return { onMessage: () => undefined, onClose: () => undefined };
+      }
+      for (const event of snapshot.events.items) {
+        if (!sendJson(input.ws, { type: "thread.event", event })) {
+          evictSubscriber(id, "send_failed");
+          return { onMessage: () => undefined, onClose: () => undefined };
+        }
+      }
+      sendJson(input.ws, { type: "thread.replay.end", nextCursor: snapshot.events.nextCursor });
+
+      return {
+        onMessage(raw) {
+          const current = subscribers.get(id);
+          if (!current) return;
+          current.lastTouched = now();
+          if (Buffer.byteLength(raw, "utf8") > MAX_INBOUND_FRAME_BYTES) {
+            sendJson(input.ws, { type: "thread.stream.error", error: invalidFrameError() });
+            evictSubscriber(id, "send_failed");
+            return;
+          }
+          let parsed: unknown;
+          try {
+            parsed = JSON.parse(raw);
+          } catch (err: unknown) {
+            if (!(err instanceof SyntaxError)) {
+              console.warn("[coding-agents] thread stream JSON parse failed:", err instanceof Error ? err.message : String(err));
+            }
+            sendJson(input.ws, { type: "thread.stream.error", error: invalidFrameError() });
+            return;
+          }
+          const frame = ThreadStreamClientFrameSchema.safeParse(parsed);
+          if (!frame.success) {
+            sendJson(input.ws, { type: "thread.stream.error", error: invalidFrameError() });
+            return;
+          }
+          if (frame.data.type === "ping") {
+            sendJson(input.ws, { type: "pong" });
+            return;
+          }
+          evictSubscriber(id);
+        },
+        onClose() {
+          subscribers.delete(id);
+        },
+      };
+    } catch (err: unknown) {
+      const safeError = err instanceof CodingAgentThreadError
+        ? safeThreadError(err.code)
+        : SafeClientErrorSchema.parse({
+          code: "thread_stream_unavailable",
+          safeMessage: "Thread stream is temporarily unavailable. Try again.",
+          retryable: true,
+          recoveryActions: ["retry"],
+        });
+      if (!(err instanceof CodingAgentThreadError)) {
+        console.warn("[coding-agents] thread stream open failed:", err instanceof Error ? err.message : String(err));
+      }
+      sendJson(input.ws, { type: "thread.stream.error", error: safeError });
+      closeSocket(input.ws);
+      return { onMessage: () => undefined, onClose: () => undefined };
+    }
+  }
+
+  function shutdown(): void {
+    for (const id of Array.from(subscribers.keys())) {
+      evictSubscriber(id, "server_shutdown");
+    }
+    eventSink.dispose();
+  }
+
+  return {
+    open,
+    evictStaleSubscribers,
+    shutdown,
+    activeSubscriberCount: () => subscribers.size,
+  };
+}

--- a/packages/gateway/src/server.ts
+++ b/packages/gateway/src/server.ts
@@ -92,6 +92,7 @@ import { createAgentCredentialRoutes } from "./onboarding/agent-credential-route
 import { createCodingAgentRuntimeSummaryService } from "./coding-agents/runtime-summary.js";
 import { createCodingAgentRoutes } from "./coding-agents/routes.js";
 import { createCodingAgentThreadStore, createFakeCodingAgentProvider } from "./coding-agents/thread-store.js";
+import { createCodingAgentThreadStream, threadStreamFrameDataToString } from "./coding-agents/thread-stream.js";
 import { createAgentActionAuditService } from "./onboarding/agent-action-audit.js";
 import { capabilityIdsForConnectedServices, createIntegrationCapabilityService } from "./onboarding/integration-capabilities.js";
 import { createIntegrationCapabilityRoutes } from "./onboarding/integration-capability-routes.js";
@@ -468,6 +469,9 @@ export async function createGateway(config: GatewayConfig) {
       homePath,
       providers: [createFakeCodingAgentProvider({ providerId: "codex" })],
     })
+    : undefined;
+  const codingAgentThreadStream = codingAgentThreadStore
+    ? createCodingAgentThreadStream({ threads: codingAgentThreadStore })
     : undefined;
   const codingAgentRuntimeSummaryService = createCodingAgentRuntimeSummaryService({
     homePath,
@@ -2078,6 +2082,112 @@ export async function createGateway(config: GatewayConfig) {
       };
     }),
   );
+
+  if (codingAgentThreadStream) {
+    app.get(
+      "/ws/coding-agents/thread/:threadId",
+      upgradeWebSocket((c) => {
+        const threadId = c.req.param("threadId") ?? "";
+        const cursor = c.req.query("cursor");
+        let streamHandle: { onMessage(raw: string): void; onClose(): void } | null = null;
+        let socketClosed = false;
+        const pendingFrames: string[] = [];
+        const pendingLimit = 8;
+
+        return {
+          onOpen(_evt, ws) {
+            let principal;
+            try {
+              principal = requireRequestPrincipal(c);
+            } catch (err: unknown) {
+              logBestEffortFailure("Coding agent thread stream principal rejected", err);
+              try {
+                ws.send(JSON.stringify({
+                  type: "thread.stream.error",
+                  error: {
+                    code: "thread_stream_unavailable",
+                    safeMessage: "Thread stream is temporarily unavailable. Try again.",
+                    retryable: true,
+                    recoveryActions: ["retry"],
+                  },
+                }));
+              } catch (sendErr: unknown) {
+                logUnexpectedWsSendFailure("Coding agent thread WebSocket rejected error send failed", sendErr);
+              }
+              ws.close();
+              return;
+            }
+
+            void codingAgentThreadStream.open({
+              ws,
+              principal,
+              threadId,
+              cursor,
+            }).then((session) => {
+              if (socketClosed) {
+                session.onClose();
+                return;
+              }
+              streamHandle = session;
+              for (const frame of pendingFrames.splice(0)) {
+                session.onMessage(frame);
+              }
+            }).catch((err: unknown) => {
+              logBestEffortFailure("Coding agent thread stream attach failed", err);
+              pendingFrames.splice(0);
+              if (socketClosed) return;
+              try {
+                ws.send(JSON.stringify({
+                  type: "thread.stream.error",
+                  error: {
+                    code: "thread_stream_unavailable",
+                    safeMessage: "Thread stream is temporarily unavailable. Try again.",
+                    retryable: true,
+                    recoveryActions: ["retry"],
+                  },
+                }));
+              } catch (sendErr: unknown) {
+                logUnexpectedWsSendFailure("Coding agent thread WebSocket send failed", sendErr);
+              }
+              ws.close();
+            });
+          },
+          onMessage(evt, ws) {
+            const raw = threadStreamFrameDataToString(evt.data);
+            if (raw === null) return;
+            if (streamHandle) {
+              streamHandle.onMessage(raw);
+              return;
+            }
+            if (pendingFrames.length >= pendingLimit) {
+              try {
+                ws.send(JSON.stringify({
+                  type: "thread.stream.error",
+                  error: {
+                    code: "invalid_frame",
+                    safeMessage: "Stream message was invalid. Refresh and try again.",
+                    retryable: true,
+                    recoveryActions: ["retry"],
+                  },
+                }));
+              } catch (sendErr: unknown) {
+                logUnexpectedWsSendFailure("Coding agent thread WebSocket send failed", sendErr);
+              }
+              ws.close();
+              return;
+            }
+            pendingFrames.push(raw);
+          },
+          onClose() {
+            socketClosed = true;
+            pendingFrames.splice(0);
+            streamHandle?.onClose();
+            streamHandle = null;
+          },
+        };
+      }),
+    );
+  }
 
   app.get(
     "/ws/terminal",
@@ -3885,6 +3995,7 @@ export async function createGateway(config: GatewayConfig) {
       watchdog.stop();
       proactiveHeartbeat.stop();
       cronService.stop();
+      codingAgentThreadStream?.shutdown();
       drainReconnectableAbortEntries(reconnectableAbortControllers);
       if (canvasCleanupTimer) clearInterval(canvasCleanupTimer);
       canvasSubscriptionHub?.close();

--- a/specs/105-coding-agent-shells/storage-decision.md
+++ b/specs/105-coding-agent-shells/storage-decision.md
@@ -62,9 +62,14 @@ This slice may contain a thread marked `running` whose fake provider has no live
 
 If a write fails after validation, the previous file remains intact. If provider startup fails before the file write, no thread is committed for this slice.
 
+## Event Streaming
+
+Thread event streaming is gateway-owned and reuses the persisted event window. A stream attach validates the owner principal, replays events after the supplied cursor, then subscribes the socket to live events emitted after successful thread-store writes.
+
+The stream registry is process-local and capped. It evicts the oldest subscriber when the cap is reached, evicts stale subscribers by TTL, removes failed senders after broadcast, and drains subscribers during gateway shutdown.
+
 ## Deferred Work
 
-- WebSocket thread streaming with subscriber caps, stale cleanup, and shutdown drain
 - real provider adapter start and abort behavior
 - approval and input request state
 - durable compaction beyond the bounded owner-file projection

--- a/tests/gateway/coding-agents-thread-stream.test.ts
+++ b/tests/gateway/coding-agents-thread-stream.test.ts
@@ -3,8 +3,16 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import {
+  AgentThreadEventSchema,
+  AgentThreadSnapshotSchema,
+  type AgentThreadEvent,
+  type AgentThreadSummary,
+} from "@matrix-os/contracts";
+import {
+  CodingAgentThreadError,
   createCodingAgentThreadStore,
   createFakeCodingAgentProvider,
+  type CodingAgentThreadStore,
 } from "../../packages/gateway/src/coding-agents/thread-store.js";
 import {
   createCodingAgentThreadStream,
@@ -78,6 +86,81 @@ describe("coding agent thread stream", () => {
     expect(ws.sent.at(-1)).toMatchObject({
       type: "thread.event",
       event: { type: "thread.completed", outcome: "aborted" },
+    });
+    session.onClose();
+  });
+
+  it("does not drop events committed while attach replay is loading", async () => {
+    const threadId = "thread_attach_race";
+    const thread: AgentThreadSummary = {
+      id: threadId,
+      providerId: "codex",
+      title: "Run tests.",
+      status: "running",
+      attention: "none",
+      createdAt: now.toISOString(),
+      updatedAt: now.toISOString(),
+    };
+    const createdEvent = AgentThreadEventSchema.parse({
+      type: "thread.created",
+      eventId: "evt_created",
+      threadId,
+      occurredAt: now.toISOString(),
+      thread,
+    });
+    const liveEvent = AgentThreadEventSchema.parse({
+      type: "thread.completed",
+      eventId: "evt_live_completed",
+      threadId,
+      occurredAt: now.toISOString(),
+      outcome: "completed",
+    });
+    let eventSink: ((input: { ownerId: string; threadId: string; events: AgentThreadEvent[] }) => void) | undefined;
+    const threads: CodingAgentThreadStore = {
+      async createThread() {
+        throw new Error("not used");
+      },
+      async listThreads() {
+        return { items: [], hasMore: false, limit: 50 };
+      },
+      async getThread() {
+        eventSink?.({ ownerId: testPrincipal.userId, threadId, events: [liveEvent] });
+        return AgentThreadSnapshotSchema.parse({
+          thread,
+          events: {
+            items: [createdEvent],
+            hasMore: false,
+            nextCursor: createdEvent.eventId,
+            limit: 200,
+          },
+        });
+      },
+      async abortThread() {
+        throw new Error("not used");
+      },
+      registerEventSink(sink) {
+        eventSink = sink;
+        return {
+          dispose() {
+            eventSink = undefined;
+          },
+        };
+      },
+    };
+    const stream = createCodingAgentThreadStream({ threads });
+    const ws = socket();
+
+    const session = await stream.open({ ws, principal: testPrincipal, threadId });
+
+    expect(ws.sent.map((frame) => (frame as { type?: string }).type)).toEqual([
+      "thread.stream.attached",
+      "thread.event",
+      "thread.replay.end",
+      "thread.event",
+    ]);
+    expect(ws.sent.at(-1)).toMatchObject({
+      type: "thread.event",
+      event: { type: "thread.completed", outcome: "completed" },
     });
     session.onClose();
   });
@@ -168,6 +251,45 @@ describe("coding agent thread stream", () => {
     });
     expect(ws.closed).toBe(true);
     expect(stream.activeSubscriberCount()).toBe(0);
+  });
+
+  it("closes a pending attach if shutdown races with replay loading", async () => {
+    const { threads, threadId } = await createHarness();
+    let releaseReplay!: () => void;
+    const replayReady = new Promise<void>((resolve) => {
+      releaseReplay = resolve;
+    });
+    const delayedThreads: CodingAgentThreadStore = {
+      ...threads,
+      async getThread(principal, requestedThreadId, cursor) {
+        await replayReady;
+        return threads.getThread(principal, requestedThreadId, cursor);
+      },
+    };
+    const stream = createCodingAgentThreadStream({ threads: delayedThreads });
+    const ws = socket();
+
+    const opened = stream.open({ ws, principal: testPrincipal, threadId });
+    stream.shutdown();
+    releaseReplay();
+    await opened;
+
+    expect(ws.sent.at(-1)).toEqual({
+      type: "thread.stream.closing",
+      reason: "server_shutdown",
+    });
+    expect(ws.closed).toBe(true);
+    expect(stream.activeSubscriberCount()).toBe(0);
+  });
+
+  it("rejects extra stream sink registrations instead of detaching existing streams silently", async () => {
+    const { threads } = await createHarness();
+
+    for (let index = 0; index < 7; index += 1) {
+      createCodingAgentThreadStream({ threads });
+    }
+
+    expect(() => createCodingAgentThreadStream({ threads })).toThrow(CodingAgentThreadError);
   });
 
   it("allows coding-agent thread WebSocket query-token auth through the shared middleware", async () => {

--- a/tests/gateway/coding-agents-thread-stream.test.ts
+++ b/tests/gateway/coding-agents-thread-stream.test.ts
@@ -1,0 +1,199 @@
+import { mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  createCodingAgentThreadStore,
+  createFakeCodingAgentProvider,
+} from "../../packages/gateway/src/coding-agents/thread-store.js";
+import {
+  createCodingAgentThreadStream,
+  threadStreamFrameDataToString,
+  type CodingAgentThreadStreamSocket,
+} from "../../packages/gateway/src/coding-agents/thread-stream.js";
+import { authMiddleware } from "../../packages/gateway/src/auth.js";
+import { testPrincipal } from "../helpers/activation-readiness.js";
+
+const now = new Date("2026-07-06T12:00:00.000Z");
+
+function socket(options: { throwOnSend?: boolean } = {}): CodingAgentThreadStreamSocket & { sent: unknown[]; closed: boolean } {
+  return {
+    sent: [],
+    closed: false,
+    send(data: string) {
+      if (options.throwOnSend) {
+        throw new Error("send failed");
+      }
+      this.sent.push(JSON.parse(data));
+    },
+    close() {
+      this.closed = true;
+    },
+  };
+}
+
+async function createHarness(options: { maxSubscribers?: number; subscriberTtlMs?: number } = {}) {
+  const homePath = await mkdtemp(join(tmpdir(), "matrix-coding-agent-stream-"));
+  const threads = createCodingAgentThreadStore({
+    homePath,
+    now: () => now,
+    providers: [createFakeCodingAgentProvider({ providerId: "codex" })],
+  });
+  const stream = createCodingAgentThreadStream({
+    threads,
+    maxSubscribers: options.maxSubscribers,
+    subscriberTtlMs: options.subscriberTtlMs,
+  });
+  const created = await threads.createThread(testPrincipal, {
+    providerId: "codex",
+    prompt: "Run tests.",
+    clientRequestId: "req_stream_create",
+  });
+  return { threads, stream, threadId: created.snapshot.thread.id };
+}
+
+describe("coding agent thread stream", () => {
+  it("replays the thread snapshot before delivering live events", async () => {
+    const { threads, stream, threadId } = await createHarness();
+    const ws = socket();
+
+    const session = await stream.open({
+      ws,
+      principal: testPrincipal,
+      threadId,
+      cursor: undefined,
+    });
+    await threads.abortThread(testPrincipal, threadId, "req_abort_stream");
+
+    expect(ws.sent[0]).toEqual({ type: "thread.stream.attached", threadId });
+    expect(ws.sent.map((frame) => (frame as { type?: string }).type)).toEqual([
+      "thread.stream.attached",
+      "thread.event",
+      "thread.event",
+      "thread.event",
+      "thread.replay.end",
+      "thread.event",
+      "thread.event",
+    ]);
+    expect(ws.sent.at(-1)).toMatchObject({
+      type: "thread.event",
+      event: { type: "thread.completed", outcome: "aborted" },
+    });
+    session.onClose();
+  });
+
+  it("supports cursor replay and rejects stale cursors safely", async () => {
+    const { stream, threadId } = await createHarness();
+    const first = socket();
+    await stream.open({ ws: first, principal: testPrincipal, threadId });
+    const cursor = (first.sent.find((frame) =>
+      (frame as { event?: { type?: string } }).event?.type === "thread.created"
+    ) as { event: { eventId: string } }).event.eventId;
+
+    const afterCursor = socket();
+    await stream.open({ ws: afterCursor, principal: testPrincipal, threadId, cursor });
+    const stale = socket();
+    await stream.open({ ws: stale, principal: testPrincipal, threadId, cursor: "evt_missing" });
+
+    expect(afterCursor.sent.map((frame) => (frame as { event?: { type?: string } }).event?.type).filter(Boolean)).toEqual([
+      "thread.status",
+      "assistant.text.delta",
+    ]);
+    expect(stale.sent).toEqual([
+      {
+        type: "thread.stream.error",
+        error: {
+          code: "thread_not_found",
+          safeMessage: "Thread is unavailable. Refresh and try again.",
+          retryable: true,
+          recoveryActions: ["retry"],
+        },
+      },
+    ]);
+    expect(stale.closed).toBe(true);
+  });
+
+  it("validates inbound frames, closes on detach, and normalizes binary frames", async () => {
+    const { stream, threadId } = await createHarness();
+    const ws = socket();
+    const session = await stream.open({ ws, principal: testPrincipal, threadId });
+
+    session.onMessage("{");
+    session.onMessage(JSON.stringify({ type: "unknown" }));
+    session.onMessage(threadStreamFrameDataToString(Buffer.from(JSON.stringify({ type: "ping" })))!);
+    session.onMessage(JSON.stringify({ type: "detach" }));
+
+    expect(ws.sent).toContainEqual({
+      type: "thread.stream.error",
+      error: {
+        code: "invalid_frame",
+        safeMessage: "Stream message was invalid. Refresh and try again.",
+        retryable: true,
+        recoveryActions: ["retry"],
+      },
+    });
+    expect(ws.sent).toContainEqual({ type: "pong" });
+    expect(ws.closed).toBe(true);
+  });
+
+  it("enforces subscriber caps, evicts stale subscribers, and removes failed senders", async () => {
+    const { threads, stream, threadId } = await createHarness({ maxSubscribers: 1, subscriberTtlMs: 1 });
+    const first = socket();
+    const second = socket();
+    const dead = socket({ throwOnSend: true });
+
+    await stream.open({ ws: first, principal: testPrincipal, threadId });
+    await stream.open({ ws: second, principal: testPrincipal, threadId });
+    expect(first.closed).toBe(true);
+
+    await new Promise((resolve) => setTimeout(resolve, 5));
+    stream.evictStaleSubscribers();
+    expect(second.closed).toBe(true);
+
+    await stream.open({ ws: dead, principal: testPrincipal, threadId });
+    await threads.abortThread(testPrincipal, threadId, "req_abort_dead_sender");
+    expect(stream.activeSubscriberCount()).toBe(0);
+  });
+
+  it("drains subscribers on shutdown", async () => {
+    const { stream, threadId } = await createHarness();
+    const ws = socket();
+
+    await stream.open({ ws, principal: testPrincipal, threadId });
+    stream.shutdown();
+
+    expect(ws.sent.at(-1)).toEqual({
+      type: "thread.stream.closing",
+      reason: "server_shutdown",
+    });
+    expect(ws.closed).toBe(true);
+    expect(stream.activeSubscriberCount()).toBe(0);
+  });
+
+  it("allows coding-agent thread WebSocket query-token auth through the shared middleware", async () => {
+    const next = async () => undefined;
+    const calls: string[] = [];
+    const middleware = authMiddleware("secret-token");
+    const makeContext = (path: string, token?: string) => ({
+      req: {
+        path,
+        url: `http://localhost${path}${token ? `?token=${token}` : ""}`,
+        header: () => undefined,
+      },
+      json: (body: unknown, status: number) => ({ body, status }),
+      set: () => undefined,
+    });
+
+    await middleware(makeContext("/ws/coding-agents/thread/thread_abc", "secret-token") as never, async () => {
+      calls.push("ok");
+      return next();
+    });
+    const rejected = await middleware(
+      makeContext("/ws/coding-agents/thread/thread_abc", "wrong-token") as never,
+      async () => next(),
+    );
+
+    expect(calls).toEqual(["ok"]);
+    expect(rejected).toEqual({ body: { error: "Unauthorized" }, status: 401 });
+  });
+});


### PR DESCRIPTION
## Summary

- add a bounded coding-agent thread event stream with replay-before-live delivery
- broadcast persisted thread events after successful create/abort writes
- add browser WebSocket query-token auth for `/ws/coding-agents/thread/:threadId`
- drain stream subscribers on gateway shutdown and document stream bounds

## Validation

- `pnpm exec vitest run tests/gateway/coding-agents-thread-stream.test.ts tests/gateway/coding-agents-threads.test.ts tests/gateway/auth.test.ts tests/contracts/coding-agents.test.ts`
- `pnpm --filter @matrix-os/gateway exec tsc --noEmit`
- `bun run check:patterns`
- `bun run typecheck`
- `git diff --check`
- prohibited-term scan clean

## Invariants

- Source of truth: thread events remain persisted by the gateway thread store; WebSocket subscribers only receive validated replay/live projections.
- Lock/transaction scope: event broadcasts happen after the store mutation queue completes a validated atomic write.
- Acceptable orphan states: process-local stream subscribers can disconnect or be evicted; clients recover by replaying from the last cursor or refreshing the thread snapshot.
- Auth source of truth: global gateway auth validates bearer/query token first, then the stream opens only after resolving the gateway request principal.
- Deferred scope: real provider start/abort, approvals/input, terminal binding side effects, review/diff, and preview controls remain deferred.
