### PR TITLE
test(ci): restore main sentinel coverage

### DIFF
--- a/tests/platform/agent-cli-install-matrix.test.ts
+++ b/tests/platform/agent-cli-install-matrix.test.ts
@@ -12,10 +12,12 @@ describe("agent CLI install matrix", () => {
   });
 
   it("keeps Terminal install rows on direct npm commands with the Matrix node prefix fallback", () => {
-    const terminalApp = readFileSync(join(root, "shell/src/components/terminal/TerminalApp.tsx"), "utf8");
+    const terminalSidebar = readFileSync(join(root, "shell/src/components/terminal/TerminalSidebar.tsx"), "utf8");
+    const mobileTerminalControls = readFileSync(join(root, "shell/src/components/terminal/MobileTerminalControls.tsx"), "utf8");
     const terminalAgentOptions = readFileSync(join(root, "shell/src/components/terminal/terminal-agent-options.ts"), "utf8");
 
-    expect(terminalApp).toContain("terminalAgentVisibleInstallCommand");
+    expect(terminalSidebar).toContain("terminalAgentVisibleInstallCommand");
+    expect(mobileTerminalControls).toContain("terminalAgentVisibleInstallCommand");
     expect(terminalAgentOptions).toContain('export MATRIX_NODE_PREFIX="${MATRIX_NODE_PREFIX:-/opt/matrix/runtime/node}"');
 
     for (const agent of AGENT_INSTALLS) {
@@ -28,8 +30,8 @@ describe("agent CLI install matrix", () => {
       }
     }
 
-    expect(`${terminalApp}\n${terminalAgentOptions}`).not.toContain("matrix-install-tool-pack");
-    expect(`${terminalApp}\n${terminalAgentOptions}`).not.toContain("MATRIX_INSTALL_TOOL_PACK");
+    expect(`${terminalSidebar}\n${mobileTerminalControls}\n${terminalAgentOptions}`).not.toContain("matrix-install-tool-pack");
+    expect(`${terminalSidebar}\n${mobileTerminalControls}\n${terminalAgentOptions}`).not.toContain("MATRIX_INSTALL_TOOL_PACK");
   });
 
   it("defines npm-compatible install commands for popular package managers", () => {

--- a/tests/scripts/start-platform-cloud-run.test.ts
+++ b/tests/scripts/start-platform-cloud-run.test.ts
@@ -33,11 +33,11 @@ describe('start-platform-cloud-run.sh', () => {
   it('packages compiled gateway integration modules used by platform startup', () => {
     const root = process.cwd();
     const dockerfile = readFileSync(join(root, 'Dockerfile.platform'), 'utf8');
-    const main = readFileSync(join(root, 'packages/platform/src/main.ts'), 'utf8');
+    const platformStartup = readFileSync(join(root, 'packages/platform/src/platform-startup.ts'), 'utf8');
 
-    expect(main).toContain("../../gateway/dist/integrations/routes.js");
-    expect(main).toContain("../../gateway/dist/integrations/pipedream.js");
-    expect(main).toContain("../../gateway/dist/platform-db.js");
+    expect(platformStartup).toContain("../../gateway/dist/integrations/routes.js");
+    expect(platformStartup).toContain("../../gateway/dist/integrations/pipedream.js");
+    expect(platformStartup).toContain("../../gateway/dist/platform-db.js");
     expect(dockerfile).toContain("COPY packages/gateway/package.json packages/gateway/package.json");
     expect(dockerfile).toContain("COPY packages/kernel/package.json packages/kernel/package.json");
     expect(dockerfile).toContain("COPY packages/mcp-browser/package.json packages/mcp-browser/package.json");


### PR DESCRIPTION
## Summary
- Update stale CI sentinel tests after the landed terminal and platform startup extractions.
- Keep assertions on the same production behavior: visible terminal agent install commands and packaged gateway integration runtime imports.

## Tests
- bun run test -- tests/platform/agent-cli-install-matrix.test.ts
- bun run test -- tests/scripts/start-platform-cloud-run.test.ts
- pnpm --filter '@matrix-os/platform' exec tsc --noEmit -p tsconfig.typecheck.json
- git diff --check

## Review/Monitoring
- Opened via Graphite as the bottom hotfix for the current red main baseline.
- Waiting for current-head Greptile before adding ready-for-ci.

## Invariants
- Source of truth: production ownership stays in TerminalSidebar/MobileTerminalControls/terminal-agent-options and platform-startup.ts; tests now follow those owners.
- Lock/transaction scope: no database or persistence changes.
- Acceptable orphan states: no runtime state changes.
- Auth source of truth: unchanged.
- Deferred scope: no production refactor in this PR; gateway large-file split continues after this baseline is green.