### PR TITLE
refactor(gateway): extract server foundation helpers

### DIFF
--- a/packages/gateway/src/server.ts
+++ b/packages/gateway/src/server.ts
@@ -15,7 +15,7 @@ import type { ContentfulStatusCode } from "hono/utils/http-status";
 import { serve } from "@hono/node-server";
 import { createNodeWebSocket } from "@hono/node-ws";
 import { installPostHogHonoErrorTracking, resolveOwnerTelemetryDistinctId } from "@matrix-os/observability";
-import { createDispatcher, type Dispatcher, type BatchEntry, type DispatchContext, type SpawnFn } from "./dispatcher.js";
+import { createDispatcher, type Dispatcher, type BatchEntry, type DispatchContext } from "./dispatcher.js";
 import { createAllowedOriginController } from "./allowed-origins.js";
 import { createAiGenerationRecorder } from "./ai-analytics.js";
 import { createWatcher, type Watcher } from "./watcher.js";
@@ -52,7 +52,7 @@ import { fileDelete, trashList, trashRestore, trashEmpty } from "./trash.js";
 import { listProjects } from "./projects.js";
 import { createWorkspaceRoutes } from "./workspace-routes.js";
 import { createElixirSymphonyProxyRoutes } from "./symphony/proxy.js";
-import { createSymphonyRunner, SymphonyConfigLoadError } from "./symphony-runner.js";
+import { createSymphonyRunner } from "./symphony-runner.js";
 import { createAgentLauncher } from "./agent-launcher.js";
 import { createZellijRuntime } from "./zellij-runtime.js";
 import { createSessionRuntimeBridge } from "./session-runtime-bridge.js";
@@ -217,6 +217,16 @@ import {
   MainWsClientMessageSchema,
   type MainWsClientMessage,
 } from "./ws-message-schema.js";
+import type { GatewayConfig, ServerMessage } from "./server/types.js";
+import {
+  kernelEventToServerMessage,
+  send,
+  sendClientAck,
+} from "./server/main-ws-messages.js";
+import {
+  resolveInitialSymphonyPort,
+  symphonyUpstreamOriginForPort,
+} from "./server/symphony-origin.js";
 import {
   metricsRegistry,
   httpRequestsTotal,
@@ -254,6 +264,11 @@ export {
   TERMINAL_SESSION_DELETE_BODY_LIMIT_BYTES,
   type TerminalSessionRouteRegistry,
 } from "./terminal-session-routes.js";
+export type { GatewayConfig, ServerMessage } from "./server/types.js";
+export {
+  readInitialSymphonyPort,
+  resolveInitialSymphonyPort,
+} from "./server/symphony-origin.js";
 
 const SAFE_ICON_STEM = /^[a-zA-Z0-9_-]+$/;
 
@@ -288,165 +303,11 @@ export async function resetVolatilePtySessionList(persistPath: string): Promise<
 const INTEGRATION_PROXY_BODY_LIMIT = 64 * 1024;
 const HANDLE_PATTERN = /^[a-z][a-z0-9-]{2,30}$/;
 
-export interface GatewayConfig {
-  homePath: string;
-  port?: number;
-  model?: string;
-  maxTurns?: number;
-  spawnFn?: SpawnFn;
-  syncReport?: { added: string[]; updated: string[]; skipped: string[] };
-}
-
-export type ServerMessage =
-  | { type: "kernel:init"; sessionId: string; requestId?: string; eventId?: string }
-  | { type: "kernel:text"; text: string; requestId?: string; eventId?: string }
-  | { type: "kernel:tool_start"; tool: string; requestId?: string; eventId?: string }
-  | { type: "kernel:tool_end"; input?: Record<string, unknown>; requestId?: string; eventId?: string }
-  | { type: "kernel:result"; data: unknown; requestId?: string; eventId?: string }
-  | { type: "kernel:error"; message: string; requestId?: string; eventId?: string }
-  | { type: "kernel:aborted"; requestId?: string; eventId?: string }
-  | { type: "file:change"; path: string; event: string }
-  | { type: "task:created"; task: { id: string; type: string; status: string; input: string } }
-  | { type: "task:updated"; taskId: string; status: string }
-  | { type: "provision:start"; appCount: number }
-  | { type: "provision:complete"; total: number; succeeded: number; failed: number }
-  | { type: "session:switched"; sessionId: string }
-  | {
-      type: "approval:request";
-      id: string;
-      toolName: string;
-      args: unknown;
-      timeout: number;
-      requestId?: string;
-      eventId?: string;
-    }
-  | {
-      type: "client:ack";
-      actionId: string;
-      actionType: string;
-      status: "accepted" | "rejected";
-      retryable?: boolean;
-    }
-  | { type: "os:sync-report"; payload: { added: string[]; updated: string[]; skipped: string[] } }
-  | { type: "data:change"; app: string; key: string }
-  | { type: "integration:connected"; service: string; accountLabel: string }
-  | { type: "integration:disconnected"; service: string; id: string }
-  | { type: "integration:expired"; service: string; id: string; accountLabel: string }
-  | { type: "pong" }
-  | { type: "sync:change"; files: Array<{ path: string; hash: string; size: number; action: string }>; peerId: string; manifestVersion: number }
-  | { type: "sync:conflict"; path: string; localHash: string; remoteHash: string; remotePeerId: string; conflictPath: string }
-  | { type: "sync:peer-join"; peerId: string; hostname: string; platform: string }
-  | { type: "sync:peer-leave"; peerId: string }
-  | { type: "sync:share-invite"; shareId: string; ownerHandle: string; path: string; role: string }
-  | { type: "sync:access-revoked"; shareId: string; ownerHandle: string; path: string };
-
-function kernelEventToServerMessage(event: KernelEvent, requestId?: string): ServerMessage {
-  switch (event.type) {
-    case "init":
-      return { type: "kernel:init", sessionId: event.sessionId, requestId };
-    case "text":
-      return { type: "kernel:text", text: event.text, requestId };
-    case "tool_start":
-      return { type: "kernel:tool_start", tool: event.tool, requestId };
-    case "tool_end":
-      return { type: "kernel:tool_end", input: event.input, requestId };
-    case "result":
-      return { type: "kernel:result", data: event.data, requestId };
-    case "aborted":
-      return { type: "kernel:aborted", requestId };
-  }
-}
-
-function send(ws: WSContext, msg: ServerMessage): boolean {
-  try {
-    ws.send(JSON.stringify(msg));
-    return true;
-  } catch (err: unknown) {
-    console.warn("[gateway] Main WebSocket send failed:", err instanceof Error ? err.name : typeof err);
-    return false;
-  }
-}
-
-function actionIdForClientMessage(message: MainWsClientMessage): string | null {
-  if ("requestId" in message && typeof message.requestId === "string" && message.requestId.length > 0) {
-    return message.requestId;
-  }
-  if (message.type === "approval_response") return message.id;
-  if (message.type === "switch_session") return `switch_session:${message.sessionId}`;
-  return null;
-}
-
-function sendClientAck(
-  ws: WSContext,
-  message: MainWsClientMessage,
-  status: "accepted" | "rejected",
-  retryable = status !== "accepted",
-) {
-  const actionId = actionIdForClientMessage(message);
-  if (!actionId) return;
-  send(ws, {
-    type: "client:ack",
-    actionId,
-    actionType: message.type,
-    status,
-    retryable,
-  });
-}
-
 const CONVERSATION_REPLAY_BATCH_SIZE = 100;
 const CONVERSATION_RECONNECT_GRACE_MS = 30_000;
 const MAX_RECONNECTABLE_ABORT_CONTROLLERS = 100;
 const CLIENT_KERNEL_ERROR_MESSAGE = "Request failed";
 const MAX_MAIN_WS_CLIENTS = 100;
-
-type SymphonyRunner = ReturnType<typeof createSymphonyRunner>;
-
-export async function readInitialSymphonyPort(runner: Pick<SymphonyRunner, "getConfig">): Promise<number | undefined> {
-  try {
-    return (await runner.getConfig()).port;
-  } catch (err: unknown) {
-    if (err instanceof SymphonyConfigLoadError) {
-      console.warn("[gateway] Ignoring invalid Symphony config while seeding CORS origins");
-      return undefined;
-    }
-    throw err;
-  }
-}
-
-function parseSymphonyPort(value: string | undefined): number | undefined {
-  if (!value || !/^(?:0|[1-9]\d*)$/.test(value)) return undefined;
-  const port = Number(value);
-  return Number.isInteger(port) && port >= 1024 && port <= 65535 ? port : undefined;
-}
-
-function parseLoopbackOriginPort(value: string | undefined): number | undefined {
-  if (!value) return undefined;
-  try {
-    const url = new URL(value);
-    if (url.protocol !== "http:" || !["127.0.0.1", "localhost", "[::1]"].includes(url.hostname)) {
-      return undefined;
-    }
-    return parseSymphonyPort(url.port);
-  } catch (err: unknown) {
-    if (!(err instanceof TypeError)) {
-      console.warn("[gateway] Ignoring invalid Symphony upstream origin:", err);
-    }
-    return undefined;
-  }
-}
-
-export async function resolveInitialSymphonyPort(
-  runner: Pick<SymphonyRunner, "getConfig">,
-  env: NodeJS.ProcessEnv = process.env,
-): Promise<number | undefined> {
-  return parseLoopbackOriginPort(env.SYMPHONY_UPSTREAM_ORIGIN) ??
-    parseSymphonyPort(env.SYMPHONY_PORT) ??
-    await readInitialSymphonyPort(runner);
-}
-
-function symphonyUpstreamOriginForPort(port: number | undefined): string | undefined {
-  return port ? `http://127.0.0.1:${port}` : undefined;
-}
 
 export async function createGateway(config: GatewayConfig) {
   const { homePath: rawHomePath, port = 4000, syncReport } = config;

--- a/packages/gateway/src/server/main-ws-messages.ts
+++ b/packages/gateway/src/server/main-ws-messages.ts
@@ -1,0 +1,60 @@
+import type { KernelEvent } from "@matrix-os/kernel";
+import type { MainWsClientMessage } from "../ws-message-schema.js";
+import type { ServerMessage } from "./types.js";
+
+type WebSocketSender = {
+  send(data: string): void;
+};
+
+export function kernelEventToServerMessage(event: KernelEvent, requestId?: string): ServerMessage {
+  switch (event.type) {
+    case "init":
+      return { type: "kernel:init", sessionId: event.sessionId, requestId };
+    case "text":
+      return { type: "kernel:text", text: event.text, requestId };
+    case "tool_start":
+      return { type: "kernel:tool_start", tool: event.tool, requestId };
+    case "tool_end":
+      return { type: "kernel:tool_end", input: event.input, requestId };
+    case "result":
+      return { type: "kernel:result", data: event.data, requestId };
+    case "aborted":
+      return { type: "kernel:aborted", requestId };
+  }
+}
+
+export function send(ws: WebSocketSender, msg: ServerMessage): boolean {
+  try {
+    ws.send(JSON.stringify(msg));
+    return true;
+  } catch (err: unknown) {
+    console.warn("[gateway] Main WebSocket send failed:", err instanceof Error ? err.name : typeof err);
+    return false;
+  }
+}
+
+export function actionIdForClientMessage(message: MainWsClientMessage): string | null {
+  if ("requestId" in message && typeof message.requestId === "string" && message.requestId.length > 0) {
+    return message.requestId;
+  }
+  if (message.type === "approval_response") return message.id;
+  if (message.type === "switch_session") return `switch_session:${message.sessionId}`;
+  return null;
+}
+
+export function sendClientAck(
+  ws: WebSocketSender,
+  message: MainWsClientMessage,
+  status: "accepted" | "rejected",
+  retryable = status !== "accepted",
+): void {
+  const actionId = actionIdForClientMessage(message);
+  if (!actionId) return;
+  send(ws, {
+    type: "client:ack",
+    actionId,
+    actionType: message.type,
+    status,
+    retryable,
+  });
+}

--- a/packages/gateway/src/server/route-inventory.ts
+++ b/packages/gateway/src/server/route-inventory.ts
@@ -1,0 +1,100 @@
+export interface GatewayRouteGroup {
+  id: string;
+  label: string;
+  paths: string[];
+  plannedModule: string;
+}
+
+export const GATEWAY_ROUTE_GROUPS: GatewayRouteGroup[] = [
+  {
+    id: "middleware",
+    label: "Global middleware and metrics",
+    paths: ["*", "/metrics"],
+    plannedModule: "server/middleware.ts",
+  },
+  {
+    id: "readiness",
+    label: "Onboarding, agent readiness, and admin controls",
+    paths: [
+      "/api/onboarding",
+      "/api/agents",
+      "/api/integrations",
+      "/api/admin",
+      "/api/company-brain",
+      "/api/support-growth",
+    ],
+    plannedModule: "server/routes/readiness.ts",
+  },
+  {
+    id: "shell-terminal",
+    label: "Shell terminal HTTP and WebSocket routes",
+    paths: ["/api/terminal", "/api", "/ws/terminal", "/ws/terminal/session"],
+    plannedModule: "server/routes/shell-terminal.ts",
+  },
+  {
+    id: "app-runtime",
+    label: "Installed app runtime sessions and dispatch",
+    paths: ["/api/apps/:slug/manifest", "/api/apps/:slug/ack", "/api/apps/:slug/session", "/api/apps/:slug/session-token", "/apps/:slug/*"],
+    plannedModule: "server/routes/app-runtime.ts",
+  },
+  {
+    id: "websockets",
+    label: "Main, sync, forward, onboarding, and vocal WebSockets",
+    paths: ["/ws", "/ws/forward", "/ws/onboarding", "/ws/vocal"],
+    plannedModule: "server/websockets.ts",
+  },
+  {
+    id: "files-workspace",
+    label: "Files, projects, static file serving, and workspace routes",
+    paths: ["/api/files", "/api/projects", "/files/*", "/"],
+    plannedModule: "server/routes/files-workspace.ts",
+  },
+  {
+    id: "bridge",
+    label: "App bridge query, data, proxy, and integration service calls",
+    paths: ["/api/bridge/query", "/api/bridge/proxy", "/api/bridge/data", "/api/bridge/service"],
+    plannedModule: "server/routes/bridge.ts",
+  },
+  {
+    id: "system",
+    label: "System activity, update, settings, health, and Hermes routes",
+    paths: ["/api/system", "/system/backup", "/api/settings", "/api/hermes", "/health"],
+    plannedModule: "server/routes/system.ts",
+  },
+  {
+    id: "data-features",
+    label: "Conversations, canvas, messaging, sync, social, cron, plugins, and games",
+    paths: ["/api/conversations", "/api/canvases", "/api/messages", "/api/sync", "/api/social", "/api/cron", "/api/plugins", "/api/games"],
+    plannedModule: "server/routes/data-features.ts",
+  },
+];
+
+export function gatewayRouteGroupForPath(path: string): GatewayRouteGroup | undefined {
+  const matches = GATEWAY_ROUTE_GROUPS.flatMap((group) =>
+    group.paths
+      .filter((pattern) => routePatternMatches(pattern, path))
+      .map((pattern) => ({ group, pattern })),
+  );
+  matches.sort((a, b) => routePatternSpecificity(b.pattern) - routePatternSpecificity(a.pattern));
+  return matches[0]?.group;
+}
+
+function routePatternMatches(pattern: string, path: string): boolean {
+  if (pattern === "*" || pattern === path) return true;
+  if (pattern.endsWith("/*")) {
+    const prefix = pattern.slice(0, -1);
+    return path.startsWith(prefix);
+  }
+  if (pattern.includes(":")) {
+    const patternParts = pattern.split("/");
+    const pathParts = path.split("/");
+    if (patternParts.length !== pathParts.length) return false;
+    return patternParts.every((part, index) => part.startsWith(":") || part === pathParts[index]);
+  }
+  return path.startsWith(`${pattern}/`);
+}
+
+function routePatternSpecificity(pattern: string): number {
+  if (pattern === "*") return 0;
+  return pattern.replaceAll(":", "").replaceAll("*", "").length;
+}

--- a/packages/gateway/src/server/symphony-origin.ts
+++ b/packages/gateway/src/server/symphony-origin.ts
@@ -1,0 +1,52 @@
+import { SymphonyConfigLoadError } from "../symphony-runner.js";
+
+export interface SymphonyConfigReader {
+  getConfig(): Promise<{ port?: number }>;
+}
+
+export async function readInitialSymphonyPort(runner: SymphonyConfigReader): Promise<number | undefined> {
+  try {
+    return (await runner.getConfig()).port;
+  } catch (err: unknown) {
+    if (err instanceof SymphonyConfigLoadError) {
+      console.warn("[gateway] Ignoring invalid Symphony config while seeding CORS origins");
+      return undefined;
+    }
+    throw err;
+  }
+}
+
+function parseSymphonyPort(value: string | undefined): number | undefined {
+  if (!value || !/^(?:0|[1-9]\d*)$/.test(value)) return undefined;
+  const port = Number(value);
+  return Number.isInteger(port) && port >= 1024 && port <= 65535 ? port : undefined;
+}
+
+function parseLoopbackOriginPort(value: string | undefined): number | undefined {
+  if (!value) return undefined;
+  try {
+    const url = new URL(value);
+    if (url.protocol !== "http:" || !["127.0.0.1", "localhost", "[::1]"].includes(url.hostname)) {
+      return undefined;
+    }
+    return parseSymphonyPort(url.port);
+  } catch (err: unknown) {
+    if (!(err instanceof TypeError)) {
+      console.warn("[gateway] Ignoring invalid Symphony upstream origin:", err);
+    }
+    return undefined;
+  }
+}
+
+export async function resolveInitialSymphonyPort(
+  runner: SymphonyConfigReader,
+  env: NodeJS.ProcessEnv = process.env,
+): Promise<number | undefined> {
+  return parseLoopbackOriginPort(env.SYMPHONY_UPSTREAM_ORIGIN) ??
+    parseSymphonyPort(env.SYMPHONY_PORT) ??
+    await readInitialSymphonyPort(runner);
+}
+
+export function symphonyUpstreamOriginForPort(port: number | undefined): string | undefined {
+  return port ? `http://127.0.0.1:${port}` : undefined;
+}

--- a/packages/gateway/src/server/types.ts
+++ b/packages/gateway/src/server/types.ts
@@ -1,0 +1,53 @@
+import type { SpawnFn } from "../dispatcher.js";
+
+export interface GatewayConfig {
+  homePath: string;
+  port?: number;
+  model?: string;
+  maxTurns?: number;
+  spawnFn?: SpawnFn;
+  syncReport?: { added: string[]; updated: string[]; skipped: string[] };
+}
+
+export type ServerMessage =
+  | { type: "kernel:init"; sessionId: string; requestId?: string; eventId?: string }
+  | { type: "kernel:text"; text: string; requestId?: string; eventId?: string }
+  | { type: "kernel:tool_start"; tool: string; requestId?: string; eventId?: string }
+  | { type: "kernel:tool_end"; input?: Record<string, unknown>; requestId?: string; eventId?: string }
+  | { type: "kernel:result"; data: unknown; requestId?: string; eventId?: string }
+  | { type: "kernel:error"; message: string; requestId?: string; eventId?: string }
+  | { type: "kernel:aborted"; requestId?: string; eventId?: string }
+  | { type: "file:change"; path: string; event: string }
+  | { type: "task:created"; task: { id: string; type: string; status: string; input: string } }
+  | { type: "task:updated"; taskId: string; status: string }
+  | { type: "provision:start"; appCount: number }
+  | { type: "provision:complete"; total: number; succeeded: number; failed: number }
+  | { type: "session:switched"; sessionId: string }
+  | {
+      type: "approval:request";
+      id: string;
+      toolName: string;
+      args: unknown;
+      timeout: number;
+      requestId?: string;
+      eventId?: string;
+    }
+  | {
+      type: "client:ack";
+      actionId: string;
+      actionType: string;
+      status: "accepted" | "rejected";
+      retryable?: boolean;
+    }
+  | { type: "os:sync-report"; payload: { added: string[]; updated: string[]; skipped: string[] } }
+  | { type: "data:change"; app: string; key: string }
+  | { type: "integration:connected"; service: string; accountLabel: string }
+  | { type: "integration:disconnected"; service: string; id: string }
+  | { type: "integration:expired"; service: string; id: string; accountLabel: string }
+  | { type: "pong" }
+  | { type: "sync:change"; files: Array<{ path: string; hash: string; size: number; action: string }>; peerId: string; manifestVersion: number }
+  | { type: "sync:conflict"; path: string; localHash: string; remoteHash: string; remotePeerId: string; conflictPath: string }
+  | { type: "sync:peer-join"; peerId: string; hostname: string; platform: string }
+  | { type: "sync:peer-leave"; peerId: string }
+  | { type: "sync:share-invite"; shareId: string; ownerHandle: string; path: string; role: string }
+  | { type: "sync:access-revoked"; shareId: string; ownerHandle: string; path: string };

--- a/tests/gateway/route-inventory.test.ts
+++ b/tests/gateway/route-inventory.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import {
+  GATEWAY_ROUTE_GROUPS,
+  gatewayRouteGroupForPath,
+} from "../../packages/gateway/src/server/route-inventory.js";
+
+describe("gateway route inventory", () => {
+  it("keeps oversized server route split targets explicit", () => {
+    expect(GATEWAY_ROUTE_GROUPS.map((group) => group.id)).toEqual([
+      "middleware",
+      "readiness",
+      "shell-terminal",
+      "app-runtime",
+      "websockets",
+      "files-workspace",
+      "bridge",
+      "system",
+      "data-features",
+    ]);
+
+    expect(new Set(GATEWAY_ROUTE_GROUPS.map((group) => group.plannedModule)).size).toBe(GATEWAY_ROUTE_GROUPS.length);
+  });
+
+  it("maps representative routes to their planned modules", () => {
+    expect(gatewayRouteGroupForPath("/api/apps/weather/session")?.id).toBe("app-runtime");
+    expect(gatewayRouteGroupForPath("/ws/terminal/session")?.id).toBe("shell-terminal");
+    expect(gatewayRouteGroupForPath("/api/bridge/data")?.id).toBe("bridge");
+    expect(gatewayRouteGroupForPath("/api/canvases/abc")?.id).toBe("data-features");
+    expect(gatewayRouteGroupForPath("/files/system/icons/app.png")?.id).toBe("files-workspace");
+  });
+});

--- a/tests/gateway/server-message-helpers.test.ts
+++ b/tests/gateway/server-message-helpers.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  actionIdForClientMessage,
+  kernelEventToServerMessage,
+  send,
+  sendClientAck,
+} from "../../packages/gateway/src/server/main-ws-messages.js";
+
+describe("gateway main WebSocket message helpers", () => {
+  it("maps kernel events to shell server messages without exposing raw errors", () => {
+    expect(kernelEventToServerMessage({ type: "init", sessionId: "s1" }, "r1")).toEqual({
+      type: "kernel:init",
+      sessionId: "s1",
+      requestId: "r1",
+    });
+    expect(kernelEventToServerMessage({ type: "text", text: "hello" }, "r1")).toEqual({
+      type: "kernel:text",
+      text: "hello",
+      requestId: "r1",
+    });
+    expect(kernelEventToServerMessage({ type: "tool_start", tool: "Read" }, "r1")).toEqual({
+      type: "kernel:tool_start",
+      tool: "Read",
+      requestId: "r1",
+    });
+    expect(kernelEventToServerMessage({ type: "tool_end", input: { ok: true } }, "r1")).toEqual({
+      type: "kernel:tool_end",
+      input: { ok: true },
+      requestId: "r1",
+    });
+    expect(kernelEventToServerMessage({ type: "result", data: { done: true } }, "r1")).toEqual({
+      type: "kernel:result",
+      data: { done: true },
+      requestId: "r1",
+    });
+    expect(kernelEventToServerMessage({ type: "aborted" }, "r1")).toEqual({
+      type: "kernel:aborted",
+      requestId: "r1",
+    });
+  });
+
+  it("derives stable ack ids for client actions", () => {
+    expect(actionIdForClientMessage({ type: "message", text: "hi", requestId: "req-1" })).toBe("req-1");
+    expect(actionIdForClientMessage({ type: "approval_response", id: "approval-1", approved: true })).toBe("approval-1");
+    expect(actionIdForClientMessage({ type: "switch_session", sessionId: "s1" })).toBe("switch_session:s1");
+    expect(actionIdForClientMessage({ type: "ping" })).toBeNull();
+  });
+
+  it("sends client acknowledgements only for actions with ids", () => {
+    const ws = { send: vi.fn() };
+
+    sendClientAck(ws, { type: "message", text: "hi", requestId: "req-1" }, "accepted", false);
+    sendClientAck(ws, { type: "ping" }, "accepted", false);
+
+    expect(ws.send).toHaveBeenCalledTimes(1);
+    expect(JSON.parse(ws.send.mock.calls[0][0] as string)).toEqual({
+      type: "client:ack",
+      actionId: "req-1",
+      actionType: "message",
+      status: "accepted",
+      retryable: false,
+    });
+  });
+
+  it("returns false when a WebSocket send throws", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const ws = {
+      send: vi.fn(() => {
+        throw new Error("closed");
+      }),
+    };
+
+    expect(send(ws, { type: "pong" })).toBe(false);
+    expect(warn).toHaveBeenCalledWith("[gateway] Main WebSocket send failed:", "Error");
+
+    warn.mockRestore();
+  });
+});

--- a/tests/gateway/symphony-origin.test.ts
+++ b/tests/gateway/symphony-origin.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import { SymphonyConfigLoadError } from "../../packages/gateway/src/symphony-runner.js";
+import {
+  readInitialSymphonyPort,
+  resolveInitialSymphonyPort,
+  symphonyUpstreamOriginForPort,
+} from "../../packages/gateway/src/server/symphony-origin.js";
+
+describe("gateway Symphony origin helpers", () => {
+  it("does not require readable Symphony config to seed gateway CORS", async () => {
+    await expect(readInitialSymphonyPort({
+      getConfig: async () => {
+        throw new SymphonyConfigLoadError();
+      },
+    })).resolves.toBeUndefined();
+  });
+
+  it("prefers explicit Symphony service environment over stored config", async () => {
+    await expect(resolveInitialSymphonyPort({
+      getConfig: async () => ({ port: 4777 }) as never,
+    }, {
+      SYMPHONY_PORT: "4888",
+    })).resolves.toBe(4888);
+
+    await expect(resolveInitialSymphonyPort({
+      getConfig: async () => ({ port: 4777 }) as never,
+    }, {
+      SYMPHONY_UPSTREAM_ORIGIN: "http://127.0.0.1:4999",
+      SYMPHONY_PORT: "4888",
+    })).resolves.toBe(4999);
+  });
+
+  it("rejects invalid upstream origins and formats loopback origins", async () => {
+    await expect(resolveInitialSymphonyPort({
+      getConfig: async () => ({ port: 4777 }) as never,
+    }, {
+      SYMPHONY_UPSTREAM_ORIGIN: "https://127.0.0.1:4999",
+      SYMPHONY_PORT: "4888",
+    })).resolves.toBe(4888);
+
+    expect(symphonyUpstreamOriginForPort(undefined)).toBeUndefined();
+    expect(symphonyUpstreamOriginForPort(4999)).toBe("http://127.0.0.1:4999");
+  });
+});


### PR DESCRIPTION
## Summary
- Extract gateway server types and main WebSocket message helpers from the oversized server entrypoint.
- Extract Symphony upstream-origin resolution helpers behind stable compatibility exports from server.ts.
- Add a test-backed gateway route inventory that names the next router split targets without changing route behavior.

## Tests
- bun run test -- tests/gateway/server-message-helpers.test.ts tests/gateway/symphony-origin.test.ts tests/gateway/route-inventory.test.ts tests/gateway/server-cors.test.ts tests/gateway/provisioner.test.ts
- pnpm --filter '@matrix-os/gateway' exec tsc --noEmit
- bun run check:patterns
- git diff --check

## Review/Monitoring
- Opened via Graphite as PR 1 of the next large-file refactor stack.
- Waiting for current-head Greptile before adding ready-for-ci.
- Post-#740 main runs are still being monitored separately so this stack is based on a green trunk.

## Invariants
- Source of truth: route behavior remains in packages/gateway/src/server.ts; extracted modules are pure helper/type/inventory seams only.
- Lock/transaction scope: no database writes or transaction behavior changed.
- Acceptable orphan states: no runtime or persisted state shape changed.
- Auth source of truth: auth middleware, request principal, app-session, and WebSocket auth behavior are unchanged.
- Deferred scope: route bodies remain in server.ts for follow-up PRs that will split Hono routers by the inventory groups.