### PR TITLE
feat(gateway): add coding agent provider adapters

### DIFF
--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -163,6 +163,8 @@ export const SafeSetupActionSchema = z.discriminatedUnion("kind", [
   }).strict(),
 ]);
 
+export type SafeSetupAction = z.infer<typeof SafeSetupActionSchema>;
+
 export const AgentProviderSummarySchema = z.object({
   id: ProviderIdSchema,
   displayName: SafeDisplayStringSchema,
@@ -268,6 +270,8 @@ export const ApprovalDecisionRequestSchema = z.object({
   correlationId: CorrelationIdSchema,
 }).strict();
 
+export type ApprovalDecisionRequest = z.infer<typeof ApprovalDecisionRequestSchema>;
+
 export const UserInputRequestSchema = z.object({
   requestId: RequestIdSchema,
   threadId: ThreadIdSchema,
@@ -284,6 +288,8 @@ export const UserInputAnswerRequestSchema = z.object({
   clientRequestId: RequestIdSchema,
   correlationId: CorrelationIdSchema,
 }).strict();
+
+export type UserInputAnswerRequest = z.infer<typeof UserInputAnswerRequestSchema>;
 
 const BaseThreadEventSchema = z.object({
   eventId: EventIdSchema,

--- a/packages/gateway/src/coding-agents/thread-store.ts
+++ b/packages/gateway/src/coding-agents/thread-store.ts
@@ -334,8 +334,16 @@ function defaultAbortEvents(threadId: string, now: () => Date, eventId: () => st
   ];
 }
 
-function parseProviderEvents(events: AgentThreadEvent[]): AgentThreadEvent[] {
-  return events.map((event) => AgentThreadEventSchema.parse(event));
+function parseProviderEvents(events: AgentThreadEvent[], threadId: string): AgentThreadEvent[] {
+  const parsed = events.map((event) => AgentThreadEventSchema.parse(event));
+  if (parsed.some((event) => event.threadId !== threadId)) {
+    throw new Error("Provider emitted event for another thread");
+  }
+  return parsed;
+}
+
+function includesAbortedCompletion(events: AgentThreadEvent[]): boolean {
+  return events.some((event) => event.type === "thread.completed" && event.outcome === "aborted");
 }
 
 export function safeThreadError(code: CodingAgentThreadError["code"]) {
@@ -449,7 +457,7 @@ export function createCodingAgentThreadStore(options: CodingAgentThreadStoreOpti
             request,
             now,
             nextEventId,
-          }));
+          }), thread.id);
         } catch (err: unknown) {
           console.warn("[coding-agents] provider start failed:", err instanceof Error ? err.message : String(err));
           providerEvents = safeProviderRunFailureEvents(thread.id, now, nextEventId);
@@ -509,7 +517,7 @@ export function createCodingAgentThreadStore(options: CodingAgentThreadStoreOpti
               clientRequestId,
               now,
               nextEventId,
-            }));
+            }), threadId);
             if (abortEvents.length === 0) {
               abortEvents = defaultAbortEvents(threadId, now, nextEventId);
             }
@@ -523,6 +531,13 @@ export function createCodingAgentThreadStore(options: CodingAgentThreadStoreOpti
         let nextThread = thread;
         for (const event of abortEvents) {
           nextThread = applyEvent(nextThread, event);
+        }
+        if (nextThread.status !== "aborted" || !includesAbortedCompletion(abortEvents)) {
+          const fallbackEvents = defaultAbortEvents(threadId, now, nextEventId);
+          abortEvents = [...abortEvents, ...fallbackEvents];
+          for (const event of fallbackEvents) {
+            nextThread = applyEvent(nextThread, event);
+          }
         }
         nextThread = {
           ...nextThread,

--- a/packages/gateway/src/coding-agents/thread-store.ts
+++ b/packages/gateway/src/coding-agents/thread-store.ts
@@ -9,9 +9,13 @@ import {
   ProviderIdSchema,
   RequestIdSchema,
   SafeClientErrorSchema,
+  type AgentProviderSummary,
   type AgentThreadEvent,
   type AgentThreadSummary,
+  type ApprovalDecisionRequest,
   type CreateAgentThreadRequest,
+  type SafeSetupAction,
+  type UserInputAnswerRequest,
 } from "@matrix-os/contracts";
 import { atomicWriteJson } from "../state-ops.js";
 import type { RequestPrincipal } from "../request-principal.js";
@@ -50,9 +54,45 @@ type ThreadEventSink = (input: {
 
 export interface CodingAgentProviderAdapter {
   providerId: string;
+  getSummary?(input: {
+    principal: RequestPrincipal;
+    now: () => Date;
+  }): Promise<AgentProviderSummary> | AgentProviderSummary;
+  healthCheck?(input: {
+    principal: RequestPrincipal;
+    now: () => Date;
+  }): Promise<{ ok: boolean }> | { ok: boolean };
+  buildSetupAction?(input: {
+    principal: RequestPrincipal;
+    now: () => Date;
+  }): Promise<SafeSetupAction[]> | SafeSetupAction[];
   startThread(input: {
+    principal: RequestPrincipal;
     thread: AgentThreadSummary;
     request: CreateAgentThreadRequest;
+    now: () => Date;
+    nextEventId: () => string;
+  }): Promise<AgentThreadEvent[]> | AgentThreadEvent[];
+  abortThread?(input: {
+    principal: RequestPrincipal;
+    thread: AgentThreadSummary;
+    clientRequestId: string;
+    now: () => Date;
+    nextEventId: () => string;
+  }): Promise<AgentThreadEvent[]> | AgentThreadEvent[];
+  submitApproval?(input: {
+    principal: RequestPrincipal;
+    thread: AgentThreadSummary;
+    approvalId: string;
+    request: ApprovalDecisionRequest;
+    now: () => Date;
+    nextEventId: () => string;
+  }): Promise<AgentThreadEvent[]> | AgentThreadEvent[];
+  submitInput?(input: {
+    principal: RequestPrincipal;
+    thread: AgentThreadSummary;
+    inputRequestId: string;
+    request: UserInputAnswerRequest;
     now: () => Date;
     nextEventId: () => string;
   }): Promise<AgentThreadEvent[]> | AgentThreadEvent[];
@@ -87,6 +127,27 @@ export function createFakeCodingAgentProvider(options: { providerId: string; del
   const deltaCount = Math.max(1, Math.min(options.deltaCount ?? 1, 300));
   return {
     providerId,
+    getSummary({ now }) {
+      const checkedAt = now().toISOString();
+      return {
+        id: providerId,
+        displayName: providerId === "codex" ? "Codex" : "Coding agent",
+        kind: providerId === "codex" ? "codex" : "custom",
+        availability: "available",
+        installStatus: "installed",
+        authStatus: "authenticated",
+        supportedModes: ["default", "review"],
+        defaultMode: "default",
+        setupActions: [],
+        lastCheckedAt: checkedAt,
+      };
+    },
+    healthCheck() {
+      return { ok: true };
+    },
+    buildSetupAction() {
+      return [];
+    },
     startThread({ thread, now, nextEventId }) {
       return [
         {
@@ -105,6 +166,15 @@ export function createFakeCodingAgentProvider(options: { providerId: string; del
           delta: index === 0 ? "Agent run started." : `Agent event ${index + 1}.`,
         } satisfies AgentThreadEvent)),
       ];
+    },
+    abortThread({ thread, now, nextEventId }) {
+      return defaultAbortEvents(thread.id, now, nextEventId);
+    },
+    submitApproval() {
+      return [];
+    },
+    submitInput() {
+      return [];
     },
   };
 }
@@ -221,6 +291,53 @@ function terminalThread(thread: StoredThread): boolean {
   return !activeThread(thread);
 }
 
+function safeProviderRunFailureEvents(threadId: string, now: () => Date, eventId: () => string): AgentThreadEvent[] {
+  return [
+    AgentThreadEventSchema.parse({
+      type: "thread.error",
+      eventId: eventId(),
+      threadId,
+      occurredAt: now().toISOString(),
+      error: SafeClientErrorSchema.parse({
+        code: "provider_run_failed",
+        safeMessage: "Agent run could not continue. Try again.",
+        retryable: true,
+        recoveryActions: ["retry"],
+      }),
+    }),
+    AgentThreadEventSchema.parse({
+      type: "thread.completed",
+      eventId: eventId(),
+      threadId,
+      occurredAt: now().toISOString(),
+      outcome: "failed",
+    }),
+  ];
+}
+
+function defaultAbortEvents(threadId: string, now: () => Date, eventId: () => string): AgentThreadEvent[] {
+  return [
+    AgentThreadEventSchema.parse({
+      type: "thread.status",
+      eventId: eventId(),
+      threadId,
+      occurredAt: now().toISOString(),
+      status: "aborted",
+    }),
+    AgentThreadEventSchema.parse({
+      type: "thread.completed",
+      eventId: eventId(),
+      threadId,
+      occurredAt: now().toISOString(),
+      outcome: "aborted",
+    }),
+  ];
+}
+
+function parseProviderEvents(events: AgentThreadEvent[]): AgentThreadEvent[] {
+  return events.map((event) => AgentThreadEventSchema.parse(event));
+}
+
 export function safeThreadError(code: CodingAgentThreadError["code"]) {
   if (code === "provider_unavailable") {
     return SafeClientErrorSchema.parse({
@@ -324,13 +441,20 @@ export function createCodingAgentThreadStore(options: CodingAgentThreadStoreOpti
           occurredAt: createdAt,
           thread: stripOwner(thread),
         });
-        const providerEvents = await provider.startThread({
-          thread: stripOwner(thread),
-          request,
-          now,
-          nextEventId,
-        });
-        const events = [createdEvent, ...providerEvents.map((event) => AgentThreadEventSchema.parse(event))];
+        let providerEvents: AgentThreadEvent[];
+        try {
+          providerEvents = parseProviderEvents(await provider.startThread({
+            principal,
+            thread: stripOwner(thread),
+            request,
+            now,
+            nextEventId,
+          }));
+        } catch (err: unknown) {
+          console.warn("[coding-agents] provider start failed:", err instanceof Error ? err.message : String(err));
+          providerEvents = safeProviderRunFailureEvents(thread.id, now, nextEventId);
+        }
+        const events = [createdEvent, ...providerEvents];
         for (const event of events.slice(1)) {
           thread = applyEvent(thread, event);
         }
@@ -375,34 +499,43 @@ export function createCodingAgentThreadStore(options: CodingAgentThreadStoreOpti
         if (thread.abortClientRequestIds.includes(clientRequestId) || terminalThread(thread)) {
           return { state, result: { snapshot: snapshotFor(thread, state.events), eventsToPublish: [] } };
         }
-        const occurredAt = now().toISOString();
-        const statusEvent = AgentThreadEventSchema.parse({
-          type: "thread.status",
-          eventId: nextEventId(),
-          threadId,
-          occurredAt,
-          status: "aborted",
-        });
-        const completedEvent = AgentThreadEventSchema.parse({
-          type: "thread.completed",
-          eventId: nextEventId(),
-          threadId,
-          occurredAt: now().toISOString(),
-          outcome: "aborted",
-        });
-        let nextThread = applyEvent(thread, statusEvent);
+        const provider = providers.find((candidate) => candidate.providerId === thread.providerId);
+        let abortEvents: AgentThreadEvent[];
+        if (provider?.abortThread) {
+          try {
+            abortEvents = parseProviderEvents(await provider.abortThread({
+              principal,
+              thread: stripOwner(thread),
+              clientRequestId,
+              now,
+              nextEventId,
+            }));
+            if (abortEvents.length === 0) {
+              abortEvents = defaultAbortEvents(threadId, now, nextEventId);
+            }
+          } catch (err: unknown) {
+            console.warn("[coding-agents] provider abort failed:", err instanceof Error ? err.message : String(err));
+            abortEvents = defaultAbortEvents(threadId, now, nextEventId);
+          }
+        } else {
+          abortEvents = defaultAbortEvents(threadId, now, nextEventId);
+        }
+        let nextThread = thread;
+        for (const event of abortEvents) {
+          nextThread = applyEvent(nextThread, event);
+        }
         nextThread = {
-          ...applyEvent(nextThread, completedEvent),
+          ...nextThread,
           abortClientRequestIds: [...nextThread.abortClientRequestIds, clientRequestId].slice(-MAX_ABORT_REQUEST_IDS),
         };
         const nextState = {
           version: 1 as const,
           threads: state.threads.map((candidate) => candidate.id === thread.id ? nextThread : candidate),
-          events: [...state.events, statusEvent, completedEvent],
+          events: [...state.events, ...abortEvents],
         };
         return {
           state: nextState,
-          result: { snapshot: snapshotFor(nextThread, nextState.events), eventsToPublish: [statusEvent, completedEvent] },
+          result: { snapshot: snapshotFor(nextThread, nextState.events), eventsToPublish: abortEvents },
         };
       });
       publish(principal.userId, threadId, result.eventsToPublish);

--- a/packages/gateway/src/coding-agents/thread-store.ts
+++ b/packages/gateway/src/coding-agents/thread-store.ts
@@ -346,6 +346,10 @@ function includesAbortedCompletion(events: AgentThreadEvent[]): boolean {
   return events.some((event) => event.type === "thread.completed" && event.outcome === "aborted");
 }
 
+function includesNonAbortedCompletion(events: AgentThreadEvent[]): boolean {
+  return events.some((event) => event.type === "thread.completed" && event.outcome !== "aborted");
+}
+
 export function safeThreadError(code: CodingAgentThreadError["code"]) {
   if (code === "provider_unavailable") {
     return SafeClientErrorSchema.parse({
@@ -518,7 +522,7 @@ export function createCodingAgentThreadStore(options: CodingAgentThreadStoreOpti
               now,
               nextEventId,
             }), threadId);
-            if (abortEvents.length === 0) {
+            if (abortEvents.length === 0 || includesNonAbortedCompletion(abortEvents)) {
               abortEvents = defaultAbortEvents(threadId, now, nextEventId);
             }
           } catch (err: unknown) {

--- a/specs/105-coding-agent-shells/tasks.md
+++ b/specs/105-coding-agent-shells/tasks.md
@@ -362,7 +362,7 @@ Goal: make threads start actual coding-agent provider work through the Matrix ru
 
 ### 4.1 Provider Adapter Interface
 
-- [ ] Define provider adapter interface:
+- [X] Define provider adapter interface:
   - `getSummary`
   - `healthCheck`
   - `buildSetupAction`
@@ -370,14 +370,14 @@ Goal: make threads start actual coding-agent provider work through the Matrix ru
   - `abortThread`
   - `submitApproval`
   - `submitInput`
-- [ ] Keep provider-specific logic out of clients.
-- [ ] Normalize provider events to `AgentThreadEvent`.
+- [X] Keep provider-specific logic out of clients.
+- [X] Normalize provider events to `AgentThreadEvent`.
 
 Tests:
 
-- [ ] Fake provider emits normalized events.
-- [ ] Provider error maps to safe thread error.
-- [ ] Abort maps correctly.
+- [X] Fake provider emits normalized events.
+- [X] Provider error maps to safe thread error.
+- [X] Abort maps correctly.
 
 ### 4.2 First Provider Path
 

--- a/tests/gateway/coding-agents-threads.test.ts
+++ b/tests/gateway/coding-agents-threads.test.ts
@@ -371,6 +371,100 @@ describe("coding agent thread lifecycle", () => {
     );
   });
 
+  it("forces provider abort output to finish with an aborted thread", async () => {
+    const homePath = await mkdtemp(join(tmpdir(), "matrix-coding-agent-threads-"));
+    const provider: CodingAgentProviderAdapter = {
+      providerId: "codex",
+      startThread({ thread, now: providerNow, nextEventId }) {
+        return [
+          AgentThreadEventSchema.parse({
+            type: "thread.status",
+            eventId: nextEventId(),
+            threadId: thread.id,
+            occurredAt: providerNow().toISOString(),
+            status: "running",
+          }),
+        ];
+      },
+      abortThread({ thread, now: providerNow, nextEventId }) {
+        return [
+          AgentThreadEventSchema.parse({
+            type: "thread.status",
+            eventId: nextEventId(),
+            threadId: thread.id,
+            occurredAt: providerNow().toISOString(),
+            status: "running",
+          }),
+        ];
+      },
+    };
+    const threads = createCodingAgentThreadStore({
+      homePath,
+      now: () => baseNow,
+      providers: [provider],
+    });
+    const created = await threads.createThread(ownerPrincipal, createBody);
+
+    const aborted = await threads.abortThread(ownerPrincipal, created.snapshot.thread.id, "req_abort_nonterminal");
+
+    expect(aborted.thread.status).toBe("aborted");
+    expect(aborted.events.items.at(-1)).toMatchObject({
+      type: "thread.completed",
+      outcome: "aborted",
+      threadId: created.snapshot.thread.id,
+    });
+  });
+
+  it("rejects provider events for the wrong thread before storing them", async () => {
+    const homePath = await mkdtemp(join(tmpdir(), "matrix-coding-agent-threads-"));
+    let wrongThreadId = "thread_other";
+    const provider: CodingAgentProviderAdapter = {
+      providerId: "codex",
+      startThread({ thread, now: providerNow, nextEventId }) {
+        return [
+          AgentThreadEventSchema.parse({
+            type: "thread.status",
+            eventId: nextEventId(),
+            threadId: thread.id,
+            occurredAt: providerNow().toISOString(),
+            status: "running",
+          }),
+        ];
+      },
+      abortThread({ now: providerNow, nextEventId }) {
+        return [
+          AgentThreadEventSchema.parse({
+            type: "thread.completed",
+            eventId: nextEventId(),
+            threadId: wrongThreadId,
+            occurredAt: providerNow().toISOString(),
+            outcome: "aborted",
+          }),
+        ];
+      },
+    };
+    const threads = createCodingAgentThreadStore({
+      homePath,
+      now: () => baseNow,
+      providers: [provider],
+    });
+    const created = await threads.createThread(ownerPrincipal, createBody);
+    const other = await threads.createThread(ownerPrincipal, {
+      ...createBody,
+      clientRequestId: "req_create_other",
+    });
+    wrongThreadId = other.snapshot.thread.id;
+    const rawBefore = JSON.parse(await readFile(join(homePath, "system", "coding-agents", "threads.json"), "utf-8"));
+    const wrongThreadEventCount = rawBefore.events.filter((event: { threadId?: string }) => event.threadId === wrongThreadId).length;
+
+    const aborted = await threads.abortThread(ownerPrincipal, created.snapshot.thread.id, "req_abort_wrong_thread");
+    const rawAfter = JSON.parse(await readFile(join(homePath, "system", "coding-agents", "threads.json"), "utf-8"));
+
+    expect(aborted.thread.status).toBe("aborted");
+    expect(aborted.events.items.every((event) => event.threadId === created.snapshot.thread.id)).toBe(true);
+    expect(rawAfter.events.filter((event: { threadId?: string }) => event.threadId === wrongThreadId)).toHaveLength(wrongThreadEventCount);
+  });
+
   it("rejects unauthenticated, oversized, invalid provider, and unsafe route input", async () => {
     const { app, setPrincipal } = await createHarness();
 

--- a/tests/gateway/coding-agents-threads.test.ts
+++ b/tests/gateway/coding-agents-threads.test.ts
@@ -13,6 +13,7 @@ import { createCodingAgentRuntimeSummaryService } from "../../packages/gateway/s
 import {
   createCodingAgentThreadStore,
   createFakeCodingAgentProvider,
+  type CodingAgentProviderAdapter,
 } from "../../packages/gateway/src/coding-agents/thread-store.js";
 import type { RequestPrincipal } from "../../packages/gateway/src/request-principal.js";
 import { MissingRequestPrincipalError } from "../../packages/gateway/src/request-principal.js";
@@ -255,6 +256,116 @@ describe("coding agent thread lifecycle", () => {
       attention: "approval_required",
     });
     expect(aborted.thread).toMatchObject({ status: "aborted", attention: "none" });
+    expect(duplicate.events.items.map((event) => event.eventId)).toEqual(
+      aborted.events.items.map((event) => event.eventId),
+    );
+  });
+
+  it("records a safe failed thread when a provider start fails", async () => {
+    const homePath = await mkdtemp(join(tmpdir(), "matrix-coding-agent-threads-"));
+    const threads = createCodingAgentThreadStore({
+      homePath,
+      now: () => baseNow,
+      providers: [
+        {
+          providerId: "codex",
+          startThread() {
+            throw new Error("Postgres constraint failed in /home/matrix/private/provider.log");
+          },
+        },
+      ],
+    });
+
+    const created = await threads.createThread(ownerPrincipal, createBody);
+
+    expect(created.snapshot.thread).toMatchObject({
+      status: "failed",
+      attention: "failed",
+    });
+    expect(created.snapshot.events.items.map((event) => event.type)).toEqual([
+      "thread.created",
+      "thread.error",
+      "thread.completed",
+    ]);
+    expect(created.snapshot.events.items[1]).toMatchObject({
+      type: "thread.error",
+      error: {
+        code: "provider_run_failed",
+        safeMessage: "Agent run could not continue. Try again.",
+        retryable: true,
+        recoveryActions: ["retry"],
+      },
+    });
+    expect(JSON.stringify(created.snapshot)).not.toMatch(/Postgres|\/home\/matrix|provider\.log/);
+  });
+
+  it("delegates abort to the provider adapter once and stores normalized abort events", async () => {
+    const homePath = await mkdtemp(join(tmpdir(), "matrix-coding-agent-threads-"));
+    let abortCalls = 0;
+    const provider: CodingAgentProviderAdapter = {
+      providerId: "codex",
+      startThread({ thread, now: providerNow, nextEventId }) {
+        return [
+          AgentThreadEventSchema.parse({
+            type: "thread.status",
+            eventId: nextEventId(),
+            threadId: thread.id,
+            occurredAt: providerNow().toISOString(),
+            status: "running",
+          }),
+        ];
+      },
+      abortThread({ thread, now: providerNow, nextEventId, clientRequestId }) {
+        abortCalls += 1;
+        expect(clientRequestId).toBe("req_abort_provider");
+        return [
+          AgentThreadEventSchema.parse({
+            type: "thread.status",
+            eventId: nextEventId(),
+            threadId: thread.id,
+            occurredAt: providerNow().toISOString(),
+            status: "aborted",
+          }),
+          AgentThreadEventSchema.parse({
+            type: "assistant.text.completed",
+            eventId: nextEventId(),
+            threadId: thread.id,
+            occurredAt: providerNow().toISOString(),
+            messageId: "msg_abort_ack",
+          }),
+          AgentThreadEventSchema.parse({
+            type: "thread.completed",
+            eventId: nextEventId(),
+            threadId: thread.id,
+            occurredAt: providerNow().toISOString(),
+            outcome: "aborted",
+          }),
+        ];
+      },
+    };
+    const threads = createCodingAgentThreadStore({
+      homePath,
+      now: () => baseNow,
+      providers: [provider],
+    });
+    const created = await threads.createThread(ownerPrincipal, createBody);
+
+    const aborted = await threads.abortThread(ownerPrincipal, created.snapshot.thread.id, "req_abort_provider");
+    const duplicate = await threads.abortThread(ownerPrincipal, created.snapshot.thread.id, "req_abort_provider");
+
+    expect(abortCalls).toBe(1);
+    expect(aborted.thread.status).toBe("aborted");
+    expect(aborted.events.items.map((event) => event.type)).toEqual([
+      "thread.created",
+      "thread.status",
+      "thread.status",
+      "assistant.text.completed",
+      "thread.completed",
+    ]);
+    expect(aborted.events.items.at(-2)).toMatchObject({
+      type: "assistant.text.completed",
+      messageId: "msg_abort_ack",
+    });
     expect(duplicate.events.items.map((event) => event.eventId)).toEqual(
       aborted.events.items.map((event) => event.eventId),
     );

--- a/tests/gateway/coding-agents-threads.test.ts
+++ b/tests/gateway/coding-agents-threads.test.ts
@@ -415,6 +415,53 @@ describe("coding agent thread lifecycle", () => {
     });
   });
 
+  it("replaces provider abort output that reports a completed terminal outcome", async () => {
+    const homePath = await mkdtemp(join(tmpdir(), "matrix-coding-agent-threads-"));
+    const provider: CodingAgentProviderAdapter = {
+      providerId: "codex",
+      startThread({ thread, now: providerNow, nextEventId }) {
+        return [
+          AgentThreadEventSchema.parse({
+            type: "thread.status",
+            eventId: nextEventId(),
+            threadId: thread.id,
+            occurredAt: providerNow().toISOString(),
+            status: "running",
+          }),
+        ];
+      },
+      abortThread({ thread, now: providerNow, nextEventId }) {
+        return [
+          AgentThreadEventSchema.parse({
+            type: "thread.completed",
+            eventId: nextEventId(),
+            threadId: thread.id,
+            occurredAt: providerNow().toISOString(),
+            outcome: "completed",
+          }),
+        ];
+      },
+    };
+    const threads = createCodingAgentThreadStore({
+      homePath,
+      now: () => baseNow,
+      providers: [provider],
+    });
+    const created = await threads.createThread(ownerPrincipal, createBody);
+
+    const aborted = await threads.abortThread(ownerPrincipal, created.snapshot.thread.id, "req_abort_completed_output");
+
+    expect(aborted.thread.status).toBe("aborted");
+    expect(aborted.events.items).not.toEqual(expect.arrayContaining([
+      expect.objectContaining({ type: "thread.completed", outcome: "completed" }),
+    ]));
+    expect(aborted.events.items.at(-1)).toMatchObject({
+      type: "thread.completed",
+      outcome: "aborted",
+      threadId: created.snapshot.thread.id,
+    });
+  });
+
   it("rejects provider events for the wrong thread before storing them", async () => {
     const homePath = await mkdtemp(join(tmpdir(), "matrix-coding-agent-threads-"));
     let wrongThreadId = "thread_other";


### PR DESCRIPTION
## Summary
- extend the gateway coding-agent provider adapter seam with summary, health, setup, start, abort, approval, and input methods
- normalize provider start failures into safe thread error/completion events without leaking provider internals to clients
- delegate abort to provider adapters when available while preserving idempotent abort behavior
- mark the Phase 4.1 task checklist items as complete

## Tests
- pnpm exec vitest run tests/gateway/coding-agents-thread-stream.test.ts tests/gateway/coding-agents-threads.test.ts tests/gateway/coding-agents-summary.test.ts tests/contracts/coding-agents.test.ts
- pnpm --filter @matrix-os/gateway exec tsc --noEmit
- bun run check:patterns
- bun run typecheck
- git diff --check

## Invariants
- Source of truth: gateway thread store remains the owner-file-backed source for thread metadata/events in this slice; desktop and mobile behavior is unchanged.
- Lock/transaction scope: thread mutations continue through the existing serialized mutation queue and atomic owner-file write path.
- Acceptable orphan states: provider start failure creates a failed thread with safe normalized events; no raw provider payload or client-side provider state is introduced.
- Auth source of truth: existing coding-agent routes still resolve request principals through gateway auth helpers; no client credential handling changes.
- Deferred scope: real provider execution, provider registry summary integration, approval/input routes, and public docs remain for later Phase 4/8 slices because this PR only defines and exercises the server-side adapter seam.