### PR TITLE
test(ci): update observability sentinel paths

### DIFF
--- a/tests/observability/posthog-error-tracking.test.ts
+++ b/tests/observability/posthog-error-tracking.test.ts
@@ -819,12 +819,12 @@ describe("PostHog error tracking", () => {
   });
 
   it("allows only explicit public PostHog telemetry aliases to provisioned containers", async () => {
-    const platformMain = await readFile("packages/platform/src/main.ts", "utf8");
+    const platformStartupEnv = await readFile("packages/platform/src/platform-startup-env.ts", "utf8");
 
-    expect(platformMain).toContain("TENANT_PUBLIC_TELEMETRY_ENV_KEYS");
-    expect(platformMain).toContain("'POSTHOG_TOKEN'");
-    expect(platformMain).toContain("'POSTHOG_PROJECT_TOKEN'");
-    expect(platformMain).not.toContain("'CLERK_SECRET_KEY'");
+    expect(platformStartupEnv).toContain("TENANT_PUBLIC_TELEMETRY_ENV_KEYS");
+    expect(platformStartupEnv).toContain("'POSTHOG_TOKEN'");
+    expect(platformStartupEnv).toContain("'POSTHOG_PROJECT_TOKEN'");
+    expect(platformStartupEnv).not.toContain("'CLERK_SECRET_KEY'");
   });
 
   it("bakes public PostHog env into full-image compose shell builds", async () => {
@@ -905,11 +905,12 @@ describe("PostHog error tracking", () => {
   });
 
   it("wires shutdown for PostHog clients outside top-level Hono apps", async () => {
-    const [gatewaySocial, gatewayServer, platformSocialApi, platformMain, proxyMain, wwwServer] = await Promise.all([
+    const [gatewaySocial, gatewayServer, platformSocialApi, platformMain, platformStartup, proxyMain, wwwServer] = await Promise.all([
       readFile("packages/gateway/src/social.ts", "utf8"),
       readFile("packages/gateway/src/server.ts", "utf8"),
       readFile("packages/platform/src/social-api.ts", "utf8"),
       readFile("packages/platform/src/main.ts", "utf8"),
+      readFile("packages/platform/src/platform-startup.ts", "utf8"),
       readFile("packages/proxy/src/main.ts", "utf8"),
       readFile("www/src/lib/posthog-server.ts", "utf8"),
     ]);
@@ -917,7 +918,7 @@ describe("PostHog error tracking", () => {
     expect(gatewaySocial).toContain("shutdownPostHog");
     expect(gatewayServer).toContain("await socialRoutes?.shutdownPostHog()");
     expect(platformSocialApi).toContain("shutdownPostHog");
-    expect(platformMain).toContain("await app.shutdownPostHog()");
+    expect(platformStartup).toContain("await app.shutdownPostHog()");
     expect(platformMain).toContain("await Promise.allSettled(posthogShutdowns.map((shutdownPostHog) => shutdownPostHog()))");
     expect(platformMain).not.toContain("for (let i = posthogShutdowns.length - 1");
     expect(proxyMain).toContain("await posthogErrorTracker.shutdown()");

--- a/tests/observability/process-error-entrypoints.test.ts
+++ b/tests/observability/process-error-entrypoints.test.ts
@@ -3,17 +3,19 @@ import { describe, expect, it } from "vitest";
 
 describe("process-level PostHog error entrypoints", () => {
   it("wires gateway and platform process errors to their shared PostHog trackers", async () => {
-    const [gatewayMain, platformMain] = await Promise.all([
+    const [gatewayMain, platformMain, platformStartup] = await Promise.all([
       readFile("packages/gateway/src/main.ts", "utf8"),
       readFile("packages/platform/src/main.ts", "utf8"),
+      readFile("packages/platform/src/platform-startup.ts", "utf8"),
     ]);
 
     expect(gatewayMain).toContain("installPostHogProcessErrorTracking");
     expect(gatewayMain).toContain('service: "matrix-gateway"');
     expect(gatewayMain).toContain("resolveOwnerTelemetryDistinctId");
 
-    expect(platformMain).toContain("installPostHogProcessErrorTracking");
-    expect(platformMain).toContain("service: 'matrix-platform'");
-    expect(platformMain).toContain("posthogProcessErrors.dispose()");
+    expect(platformMain).toContain("await startPlatformServer(");
+    expect(platformStartup).toContain("installPostHogProcessErrorTracking");
+    expect(platformStartup).toContain("service: 'matrix-platform'");
+    expect(platformStartup).toContain("posthogProcessErrors.dispose()");
   });
 });


### PR DESCRIPTION
## Summary

- Update observability sentinel tests after the platform startup split moved public telemetry env allowlist logic into `platform-startup-env.ts`.
- Update process-level PostHog wiring sentinels to inspect `platform-startup.ts`, where startup/shutdown wiring now lives.
- Test-only change; no runtime behavior changes.

## Tests

- `bun run test -- tests/observability/posthog-error-tracking.test.ts tests/observability/process-error-entrypoints.test.ts`
- `bun run test -- --shard=3/4` (same shard that failed on `main` before this patch)

## Review / Monitoring

- Wait for current-head Greptile review.
- Add `ready-for-ci` only after current-head Greptile is clean/5.
- After merge, verify `main` current-head CI, Docker Tests, and Host Bundle Release.

## Invariants

- Source of truth: platform startup wiring stays in `packages/platform/src/platform-startup.ts`; public tenant telemetry env allowlist stays in `packages/platform/src/platform-startup-env.ts`.
- Lock/transaction scope: none.
- Acceptable orphan states: none.
- Auth source of truth: unchanged.
- Deferred scope: no runtime refactor in this hotfix.
