### PR TITLE
docs(agent-shells): spec coding agent desktop and mobile

### DIFF
--- a/apps/mobile/__tests__/apps-screen.test.tsx
+++ b/apps/mobile/__tests__/apps-screen.test.tsx
@@ -62,8 +62,8 @@ describe("AppsScreen", () => {
     render(<AppsScreen />);
 
     await waitFor(() => expect(screen.getByText("Terminal")).toBeTruthy());
-    // "Apps" appears twice now: the screen title and the native Apps card.
-    expect(screen.getAllByText("Apps").length).toBeGreaterThanOrEqual(2);
+    // Apps is the current surface, so it is intentionally hidden from the grid.
+    expect(screen.getAllByText("Apps")).toHaveLength(1);
     expect(screen.getByText("Tasks")).toBeTruthy();
     expect(screen.getByText("Settings")).toBeTruthy();
     // Chat is intentionally hidden from the launcher grid.
@@ -136,6 +136,19 @@ describe("AppsScreen", () => {
       MOBILE_SHELL_STATE_STORAGE_KEY,
       expect.stringContaining("\"lastActiveAppSlug\":\"notes\""),
     ));
+  });
+
+  it("keeps the native Tasks app available in the continue card", async () => {
+    jest.mocked(AsyncStorage.getItem).mockResolvedValue(JSON.stringify({
+      mode: "app",
+      lastActiveAppSlug: "tasks",
+      updatedAt: "2026-05-13T00:00:00.000Z",
+    }));
+    useGatewayMock.mockReturnValue(gatewayContext({}));
+
+    render(<AppsScreen />);
+
+    await waitFor(() => expect(screen.getByLabelText("Continue Tasks")).toBeTruthy());
   });
 
   it("groups visible apps into main, my apps, and games sections", async () => {

--- a/apps/mobile/__tests__/canvas-entry.test.tsx
+++ b/apps/mobile/__tests__/canvas-entry.test.tsx
@@ -3,10 +3,10 @@ jest.mock("@react-native-async-storage/async-storage", () => ({
   setItem: jest.fn(),
 }));
 
-const mockReplace = jest.fn();
+const mockDismissTo = jest.fn();
 
 jest.mock("expo-router", () => ({
-  useRouter: () => ({ replace: mockReplace }),
+  useRouter: () => ({ dismissTo: mockDismissTo }),
 }));
 
 jest.mock("react-native-safe-area-context", () => ({
@@ -38,6 +38,6 @@ describe("CanvasEntryScreen", () => {
     ));
 
     fireEvent.press(screen.getByLabelText("Apps"));
-    expect(mockReplace).toHaveBeenCalledWith("/(tabs)/apps");
+    expect(mockDismissTo).toHaveBeenCalledWith("/(tabs)/apps");
   });
 });

--- a/apps/mobile/__tests__/canvas-entry.test.tsx
+++ b/apps/mobile/__tests__/canvas-entry.test.tsx
@@ -3,10 +3,10 @@ jest.mock("@react-native-async-storage/async-storage", () => ({
   setItem: jest.fn(),
 }));
 
-const mockDismissTo = jest.fn();
+const mockReplace = jest.fn();
 
 jest.mock("expo-router", () => ({
-  useRouter: () => ({ dismissTo: mockDismissTo }),
+  useRouter: () => ({ replace: mockReplace }),
 }));
 
 jest.mock("react-native-safe-area-context", () => ({
@@ -38,6 +38,6 @@ describe("CanvasEntryScreen", () => {
     ));
 
     fireEvent.press(screen.getByLabelText("Apps"));
-    expect(mockDismissTo).toHaveBeenCalledWith("/(tabs)/apps");
+    expect(mockReplace).toHaveBeenCalledWith("/(tabs)/apps");
   });
 });

--- a/apps/mobile/lib/apps.ts
+++ b/apps/mobile/lib/apps.ts
@@ -69,6 +69,7 @@ const NATIVE_MATRIX_APPS: MatrixAppEntry[] = [
     description: "Track tasks, cron jobs, and background work.",
     icon: "task-manager",
     category: "System",
+    slug: "tasks",
     file: "tasks/index.html",
     path: "/files/apps/tasks/index.html",
   },

--- a/specs/105-coding-agent-shells/ARCHITECTURE.md
+++ b/specs/105-coding-agent-shells/ARCHITECTURE.md
@@ -1,0 +1,900 @@
+# Architecture: Coding Agent Shells
+
+**Status**: Draft  
+**Last Updated**: 2026-07-06  
+**Audience**: Agents implementing gateway, desktop, mobile, shell, and runtime changes.
+
+## Design Thesis
+
+Matrix OS should have one headless coding-agent runtime and many shells. Desktop, mobile, browser shell, CLI, and future channels render the same runtime state through shell-appropriate interfaces.
+
+Do not create separate "desktop agent threads" or "mobile terminal sessions." Create owner-scoped runtime primitives behind the gateway, then build clients as resumable projections over those primitives.
+
+## Architecture Pattern
+
+### Selected Pattern
+
+**Headless Runtime + Typed Gateway Contracts + Thin Shells**
+
+```
+Desktop Renderer       Mobile App         Browser Shell          CLI
+       |                   |                   |                  |
+       v                   v                   v                  v
+Validated IPC       Typed Gateway Client  Typed Gateway Client  CLI Client
+       |                   |                   |                  |
+       v                   v                   v                  v
+Desktop Trusted Core -----> Matrix Gateway HTTP/WS <-------------+
+                              |
+                              v
+                 Runtime Services on Matrix Computer
+          Agent providers, terminal sessions, files, diffs,
+          previews, app runtime, source control, activity log
+                              |
+                              v
+                 Owner files + owner PostgreSQL + project repos
+```
+
+### Key Characteristics
+
+- **Source of truth**: Matrix computer runtime, owner files, owner PostgreSQL, and repositories.
+- **Contracts**: Zod 4 schemas at every public boundary. Export inferred types for clients.
+- **Transport**: HTTP for commands/snapshots, WebSocket streams for terminal/thread/runtime events.
+- **Client state**: bounded, serializable UI state; no local source-of-truth copies.
+- **Desktop trust boundary**: Electron main/preload are trusted; renderer is not trusted.
+- **Mobile trust boundary**: mobile app JS can hold short-lived session material according to existing auth design, but never provider credentials or raw privileged tokens.
+- **Failure model**: reconnect and resume by cursor/reference; distinguish runtime process state from client attachment state.
+
+## Package And Module Plan
+
+### New Or Expanded Contract Package
+
+Preferred path:
+
+```
+packages/contracts/
+  package.json
+  tsconfig.json
+  src/
+    ids.ts
+    runtime.ts
+    agents.ts
+    threads.ts
+    approvals.ts
+    terminal.ts
+    files.ts
+    review.ts
+    preview.ts
+    activity.ts
+    errors.ts
+    index.ts
+```
+
+If adding a package is too large for the first PR, start inside `packages/gateway/src/contracts/` and move to `packages/contracts` in a follow-up. The end state should be a package imported by gateway, shell, desktop, mobile, and tests.
+
+Rules:
+
+- Use `zod/v4`.
+- Export both schemas and inferred types.
+- Keep contracts schema-only; no runtime service logic.
+- Avoid barrel files that hide ownership if the repo pattern discourages them. If using `index.ts`, export only stable public schemas.
+- Use additive versioning: `AgentThreadEventV1`, `TerminalFrameV1`, etc. when changing existing frames.
+- Tests must parse representative payloads and reject malformed/oversized payloads.
+
+### Gateway Runtime Modules
+
+Recommended layout:
+
+```
+packages/gateway/src/coding-agents/
+  contracts.ts              # Re-exports shared schemas if package not created yet
+  routes.ts                 # HTTP route registration
+  ws.ts                     # Thread/runtime WebSocket handlers
+  runtime-summary.ts        # Hydration projection
+  provider-registry.ts      # Configured providers and health
+  thread-store.ts           # Thread CRUD/projections
+  thread-events.ts          # Append/read/replay event model
+  approval-service.ts       # Approval lifecycle and idempotency
+  terminal-binding.ts       # Thread/session relationships
+  review-service.ts         # Diff snapshots and limits
+  preview-service.ts        # Preview coordination where not already covered
+  safe-errors.ts            # Error mapper
+```
+
+This module should integrate with existing `agent-session-manager.ts`, `dispatcher.ts`, `preview-manager.ts`, terminal routes, workspace events, and onboarding agent credential routes instead of replacing them.
+
+### Desktop Modules
+
+Recommended layout:
+
+```
+desktop/src/shared/
+  ipc-contract.ts           # Expand or compose coding-agent IPC schemas
+  coding-agent-contract.ts  # Optional if IPC file becomes too large
+
+desktop/src/main/
+  runtime/runtime-client.ts      # Gateway HTTP/WS client in trusted core
+  runtime/runtime-session.ts     # Runtime selection, reconnect, token expiry
+  runtime/stream-registry.ts     # Bounded WS stream ownership
+  notifications/agent-events.ts  # Notification mapping
+
+desktop/src/renderer/src/features/agents/
+  AgentMissionControl.tsx
+  AgentProviderPicker.tsx
+  AgentComposer.tsx
+  AgentThreadList.tsx
+  AgentThreadView.tsx
+  ApprovalCard.tsx
+  RuntimeStatus.tsx
+
+desktop/src/renderer/src/features/workspace/
+  ProjectWorkspace.tsx
+  WorkspacePanelStrip.tsx
+  FilePanel.tsx
+  ReviewPanel.tsx
+  PreviewPanel.tsx
+  ActivityTimeline.tsx
+```
+
+Rules:
+
+- Renderer uses typed IPC/preload APIs, not direct privileged credential access.
+- Main process owns bearer injection, embedded session handoff, runtime switching, and trusted launch token handling.
+- Renderer stores only UI state in Zustand or local stores.
+- Every IPC channel validates request and response.
+- Keep existing desktop features: embeds, auth, settings, updater, menu, notifications, window state.
+
+### Mobile Modules
+
+Recommended layout for Expo SDK 57:
+
+```
+apps/mobile/lib/
+  runtime-client.ts          # Typed HTTP/WS gateway client wrapper
+  coding-agent-contract.ts   # Re-export shared types or local import facade
+  agent-state.ts             # Reducers/helpers, pure and tested
+  thread-events.ts           # Parse/reduce thread events
+  approval-state.ts          # Approval reducer/helpers
+  workspace-state.ts         # Project/thread/session resume helpers
+
+apps/mobile/components/agents/
+  AgentProviderPicker.tsx
+  AgentComposer.tsx
+  AgentThreadCard.tsx
+  AgentStatusPill.tsx
+  ApprovalCard.tsx
+  ToolActivity.tsx
+
+apps/mobile/app/agents/
+  index.tsx                  # Recent work / active threads
+  new.tsx                    # New agent run
+  [threadId].tsx             # Thread detail
+  [threadId]/review.tsx
+  [threadId]/files.tsx
+  [threadId]/terminal.tsx
+
+apps/mobile/modules/
+  matrix-terminal-native/    # Future native terminal module after spike
+```
+
+Rules:
+
+- Preserve existing routes and tabs. Add new routes; do not break current imports.
+- Keep current WebView terminal as fallback until native terminal is proven.
+- Every persisted reference in AsyncStorage must pass a parser and reconcile with live runtime state.
+- Use reducers for thread/terminal state transitions; unit-test reducers.
+- Use phone-first layouts: list -> detail -> sheet, not dense desktop panels.
+- Treat app backgrounding as expected. Reconnect from runtime summary and stream cursors.
+
+### Browser Shell Modules
+
+The browser shell should consume the same contracts so Canvas/Desktop and mobile web routes do not drift.
+
+Recommended areas:
+
+```
+shell/src/lib/coding-agents/
+  client.ts
+  contracts.ts
+  reducers.ts
+  runtime-summary.ts
+
+shell/src/components/agents/
+  ...
+```
+
+Canvas and Desktop shell modes must both route built-in agent/workspace paths correctly. Do not let built-in `__...` paths fall through to file/app viewers.
+
+## Contract Sketches
+
+These sketches are intentionally precise enough for implementation tests, but final code should live in Zod schemas.
+
+### IDs
+
+Use branded or schema-validated string aliases:
+
+- `runtimeId`: `rt_[A-Za-z0-9_-]{1,128}` or existing runtime slot ID if already canonical.
+- `providerId`: safe slug, lower-case preferred.
+- `projectId`: existing project slug/ID contract.
+- `taskId`: `task_[A-Za-z0-9_-]{1,128}` or existing task ID.
+- `threadId`: `thread_[A-Za-z0-9_-]{1,128}`.
+- `eventId`: `evt_[A-Za-z0-9_-]{1,128}`.
+- `approvalId`: `appr_[A-Za-z0-9_-]{1,128}`.
+- `terminalSessionId`: existing named session/UUID schema; do not invent a second ID if canonical names already exist.
+
+### Runtime Summary
+
+```ts
+type RuntimeSummary = {
+  runtime: RuntimeTarget;
+  capabilities: RuntimeCapability[];
+  providers: AgentProviderSummary[];
+  projects: ProjectSummary[];
+  activeThreads: AgentThreadSummary[];
+  terminalSessions: TerminalSessionSummary[];
+  recentActivity: ActivityEventSummary[];
+  serverTime: string;
+  limits: RuntimeLimits;
+};
+```
+
+Rules:
+
+- Summary is bounded and safe for first hydration.
+- Include `hasMore` or cursors where lists are truncated.
+- Include capability flags so clients do not assume unavailable features.
+- Include `serverTime` so clients can reason about expiry without trusting local clock.
+
+### Agent Provider
+
+```ts
+type AgentProviderSummary = {
+  id: string;
+  displayName: string;
+  kind: "claude" | "codex" | "opencode" | "cursor" | "custom";
+  availability: "available" | "setup_required" | "auth_required" | "installing" | "unavailable" | "unknown";
+  installStatus: "installed" | "missing" | "installing" | "failed" | "unknown";
+  authStatus: "authenticated" | "missing" | "expired" | "unknown";
+  supportedModes: Array<"default" | "plan" | "review" | "full_access">;
+  defaultMode: "default" | "plan" | "review" | "full_access";
+  defaultModel?: string;
+  setupActions: SafeSetupAction[];
+  lastCheckedAt?: string;
+};
+```
+
+Guidance:
+
+- `displayName` is safe UI text controlled by the server.
+- `setupActions` should contain safe action IDs and labels, not raw arbitrary commands unless explicitly marked as foreground terminal actions.
+- Health checks must be timeout-bound.
+
+### Thread Create
+
+```ts
+type CreateAgentThreadRequest = {
+  providerId: string;
+  prompt: string;
+  projectId?: string;
+  taskId?: string;
+  terminalSessionId?: string;
+  worktreeId?: string;
+  mode?: "default" | "plan" | "review" | "full_access";
+  approvalPolicy?: "untrusted" | "on_request" | "on_failure" | "never";
+  sandboxMode?: "read_only" | "workspace_write" | "full_access";
+  attachments?: AgentAttachment[];
+  clientRequestId: string;
+};
+```
+
+Rules:
+
+- `clientRequestId` makes create idempotent.
+- Prompt and attachments are bounded.
+- Provider/mode/sandbox/approval combinations are validated server-side.
+- Create should return accepted thread snapshot quickly; streaming happens separately.
+
+### Thread Events
+
+```ts
+type AgentThreadEvent =
+  | { type: "thread.created"; eventId: string; thread: AgentThreadSummary }
+  | { type: "thread.status"; eventId: string; threadId: string; status: AgentThreadStatus }
+  | { type: "assistant.text.delta"; eventId: string; threadId: string; messageId: string; delta: string }
+  | { type: "assistant.text.completed"; eventId: string; threadId: string; messageId: string }
+  | { type: "tool.started"; eventId: string; threadId: string; toolCallId: string; displayName: string; kind: string }
+  | { type: "tool.output"; eventId: string; threadId: string; toolCallId: string; text: string; truncated?: boolean }
+  | { type: "tool.completed"; eventId: string; threadId: string; toolCallId: string; outcome: "success" | "failed" | "cancelled" }
+  | { type: "approval.requested"; eventId: string; threadId: string; approval: AgentApprovalRequest }
+  | { type: "approval.resolved"; eventId: string; threadId: string; approvalId: string; decision: string }
+  | { type: "user_input.requested"; eventId: string; threadId: string; request: UserInputRequest }
+  | { type: "file.changed"; eventId: string; threadId: string; path: string; changeKind: string }
+  | { type: "review.ready"; eventId: string; threadId: string; reviewId: string; summary: ReviewSummary }
+  | { type: "terminal.bound"; eventId: string; threadId: string; terminalSessionId: string }
+  | { type: "thread.error"; eventId: string; threadId: string; safeMessage: string; retryable: boolean }
+  | { type: "thread.completed"; eventId: string; threadId: string; outcome: "completed" | "failed" | "aborted" };
+```
+
+Reduction rules:
+
+- Events are append-only and ordered per thread.
+- Clients reduce events into read models.
+- Delta events append to the target message by `messageId`.
+- Tool events group by `toolCallId`.
+- Unknown event types are ignored with diagnostics, not crashes.
+- Replayed events must be idempotent.
+
+### Approval
+
+```ts
+type AgentApprovalRequest = {
+  approvalId: string;
+  threadId: string;
+  title: string;
+  safeDescription: string;
+  risk: "low" | "medium" | "high";
+  actionKind: "command" | "file_change" | "network" | "provider" | "other";
+  preview?: ApprovalPreview;
+  allowedDecisions: Array<"approve" | "approve_for_session" | "decline" | "cancel">;
+  expiresAt?: string;
+  correlationId: string;
+};
+```
+
+Rules:
+
+- `preview` is bounded and redacted.
+- Decision endpoint must be idempotent by `approvalId` and `correlationId`.
+- If two clients decide concurrently, one wins and all clients receive resolved event.
+
+### Terminal Frame
+
+Prefer extending the existing terminal contract instead of replacing it.
+
+```ts
+type TerminalClientFrame =
+  | { type: "attach"; sessionId: string; fromSeq?: number; cols?: number; rows?: number }
+  | { type: "input"; data: string }
+  | { type: "resize"; cols: number; rows: number }
+  | { type: "detach" };
+
+type TerminalServerFrame =
+  | { type: "attached"; sessionId: string; cwd?: string; nextSeq?: number; replay?: string }
+  | { type: "replay-start"; fromSeq?: number; toSeq?: number }
+  | { type: "output"; seq?: number; data: string }
+  | { type: "replay-gap"; fromSeq?: number; nextSeq: number }
+  | { type: "replay-end"; nextSeq?: number }
+  | { type: "exit"; exitCode?: number | null }
+  | { type: "error"; code: "session_not_found" | "unauthorized" | "unavailable" | "invalid_frame"; safeMessage: string };
+```
+
+Rules:
+
+- Existing clients may not support `seq`; add compatibility carefully.
+- If a requested replay cursor is too old, emit `replay-gap`.
+- Fatal errors stop reconnect loops.
+- Nonfatal disconnects trigger bounded reconnect.
+
+## Runtime Service Patterns
+
+### Provider Registry Pattern
+
+Provider registry is server-owned and returns safe projections.
+
+Implementation pattern:
+
+1. Discover configured providers from owner runtime config and installed tool state.
+2. Validate provider IDs against known provider adapters or custom provider config.
+3. Run health checks with `AbortSignal.timeout`.
+4. Normalize output into `AgentProviderSummary`.
+5. Cache health results with TTL and cap.
+6. Never expose raw check command output.
+
+### Thread Store Pattern
+
+Thread creation and event append must be safe under retries.
+
+Implementation pattern:
+
+1. `createThread(input)` validates route payload.
+2. Check `clientRequestId` for existing accepted create.
+3. Insert thread and initial event in one transaction.
+4. Start provider runtime asynchronously through a queue/worker.
+5. Append lifecycle events as runtime progresses.
+6. Publish events after persistence succeeds.
+
+### Event Stream Pattern
+
+Thread streams use cursor replay and live subscription.
+
+Implementation pattern:
+
+1. Client opens stream with `threadId` and optional `afterEventId` or cursor.
+2. Gateway authenticates and authorizes before sending success frame.
+3. Gateway replays bounded history.
+4. Gateway subscribes to live events.
+5. Send keepalive or heartbeat if required by infrastructure.
+6. On disconnect, remove subscriber; stale subscribers are swept by TTL.
+7. On shutdown, drain subscribers with a safe close frame.
+
+### Terminal Attachment Pattern
+
+Terminal process state is separate from client attachment.
+
+Implementation pattern:
+
+1. List sessions from canonical terminal/session registry.
+2. Attach creates a client attachment, not a new process unless requested.
+3. Client sends resize after attach/open.
+4. Output is replayed from cursor when possible.
+5. Detach closes only the attachment.
+6. Terminate endpoint kills the named session after confirmation/auth.
+7. All clients observe session ended.
+
+### Runtime Summary Pattern
+
+Summary is a safe hydration projection, not a dump.
+
+Implementation pattern:
+
+1. Gather bounded provider/project/thread/session/activity summaries.
+2. Include limits and capability flags.
+3. Return coarse runtime health.
+4. Omit secrets, raw logs, file contents, terminal content, and provider output.
+5. Make every list stable sorted.
+6. Include `serverTime`.
+
+## Client State Patterns
+
+### General State Rules
+
+- Keep state serializable.
+- Store arrays/records, not `Map`/`Set`, in Zustand/React state.
+- Derive filtered/sorted lists with pure helpers and `useMemo`.
+- Persist only small UI resume state.
+- Reconcile persisted IDs with live runtime summary before rendering detail screens.
+- Use generation guards for async actions that can race route changes.
+- Abort or ignore stale requests when switching runtime, project, task, or thread.
+- Show stale-but-revalidating state when safe.
+
+### Thread Reducer Pattern
+
+Use pure reducers for event streams.
+
+Reducer responsibilities:
+
+- Create/update thread summary.
+- Append text deltas by `messageId`.
+- Group tool activity by `toolCallId`.
+- Track approvals by `approvalId`.
+- Track input requests by request ID.
+- Track review availability.
+- Track terminal binding.
+- Track status and attention reason.
+- Ignore duplicate event IDs.
+- Cap arrays and mark truncation.
+
+Do not:
+
+- Mutate nested state in place.
+- Render raw event payloads directly.
+- Let unknown events crash the thread.
+- Assume events arrive only once.
+
+### Desktop Stream Ownership
+
+Desktop should avoid opening unbounded sockets.
+
+Pattern:
+
+- Main process owns long-lived gateway stream clients if credentials are needed.
+- Renderer subscribes through typed IPC or preload event bridge.
+- One stream per active runtime summary/event channel.
+- One terminal attachment per focused terminal session per app instance.
+- Background workspaces release live sockets but keep bounded read models.
+- Runtime switch closes streams for old runtime and clears embedded sessions as needed.
+
+### Mobile Stream Ownership
+
+Mobile should assume suspension at any time.
+
+Pattern:
+
+- Use runtime summary on focus/app resume.
+- Attach streams only for visible thread/detail/terminal screens.
+- Persist last selected IDs, not event caches.
+- Use event cursor from current session memory when available.
+- On app resume, fetch snapshot before trusting old stream.
+- Treat WebSocket close as expected; surface reconnect only when user is actively viewing the stream.
+
+### Approval UI Pattern
+
+Approval cards should be consistent across shells.
+
+Display:
+
+- Provider display name.
+- Thread/project context.
+- Risk label.
+- Safe action description.
+- Bounded preview.
+- Expiry/timeout if present.
+- Approve/decline buttons matching allowed decisions.
+
+Behavior:
+
+- Disable buttons after decision submit.
+- Treat duplicate/stale decision as resolved, not fatal.
+- Show safe resolution state.
+- Never expose hidden raw payloads in expandable UI unless explicitly redacted and bounded.
+
+## Desktop Implementation Guide
+
+### Trusted Core
+
+Responsibilities:
+
+- Credential storage.
+- Gateway auth injection.
+- Runtime selection.
+- Embedded session handoff.
+- Native notifications.
+- Deep link validation.
+- Update state.
+- Bounded diagnostic logs.
+
+Renderer must call trusted core for:
+
+- Auth state.
+- Runtime selection.
+- Embedded app/session launch.
+- Native notification focus targets.
+- Any operation requiring bearer credential handling.
+
+### IPC Design
+
+Add grouped channels or a typed method object:
+
+- `runtime:get-summary`
+- `runtime:select`
+- `agents:create-thread`
+- `agents:abort-thread`
+- `agents:submit-approval`
+- `agents:submit-input`
+- `agents:subscribe-thread`
+- `terminal:list-sessions`
+- `terminal:create-session`
+- `terminal:terminate-session`
+- `workspace:get-review`
+- `workspace:read-file`
+- `workspace:write-file`
+- `preview:open`
+
+Every channel:
+
+- Has request schema.
+- Has response schema.
+- Maps internal errors to safe errors.
+- Logs rejected malformed requests.
+- Does not return raw credential/token.
+
+### Desktop UI Layout
+
+Recommended first screen after sign-in:
+
+```
+┌────────────────────────────────────────────────────────────┐
+│ Top bar: runtime, project switcher, global composer, status │
+├──────────────┬──────────────────────────────┬──────────────┤
+│ Projects /   │ Active thread or task         │ Inspector    │
+│ threads      │ transcript / terminal / files │ review/info  │
+│              │                              │              │
+└──────────────┴──────────────────────────────┴──────────────┘
+```
+
+Use dense operational UI, not a marketing layout:
+
+- Sidebar for projects/tasks/threads.
+- Main panel for selected thread/workspace.
+- Inspector for approvals, review, preview, metadata.
+- Keyboard shortcuts for new thread, command palette, terminal focus, review toggle, file search.
+
+### Desktop Regression Checklist
+
+Before merging each desktop phase:
+
+- Sign in/out.
+- Runtime switch.
+- Hosted shell embed.
+- Matrix app embed.
+- Deep link focus.
+- Native notification click.
+- Update status check.
+- Window bounds persistence.
+- Menu actions.
+- Settings sections.
+- Terminal attach/reconnect.
+- Existing desktop typecheck.
+
+## Mobile Implementation Guide
+
+### SDK 57 Constraints
+
+- Expo Go is not a supported runtime for native-module work.
+- Use Expo dev client for native changes.
+- Keep React Native 0.86 and Expo SDK 57 dependency constraints intact.
+- Add native modules only after spike and lockfile update.
+- Mobile tests use Jest and `@testing-library/react-native`; add reducer/unit tests before UI.
+
+### Mobile Navigation
+
+Add agent routes without breaking current tabs:
+
+```
+/(tabs)
+  chat
+  mission-control
+  terminal
+  apps
+  settings
+
+/agents
+  index
+  new
+  [threadId]
+  [threadId]/review
+  [threadId]/files
+  [threadId]/terminal
+```
+
+Phone-first hierarchy:
+
+1. Recent work/inbox.
+2. Thread list.
+3. Thread detail.
+4. Sheets for approvals, provider picker, file actions.
+5. Separate full-screen routes for terminal, review, files, preview.
+
+Tablet/foldable:
+
+- May use split view when width allows.
+- Do not make split view required for phone.
+
+### Mobile State
+
+Persist:
+
+- Last selected runtime ID.
+- Last active thread ID.
+- Last active project ID.
+- Last active terminal session ID.
+- Last active surface/mode.
+- Updated timestamp.
+
+Do not persist:
+
+- Terminal output.
+- Thread transcript content.
+- Provider credentials.
+- Approval raw payloads.
+- File contents.
+- Diff contents.
+- App launch tokens.
+
+Every load:
+
+1. Parse persisted state.
+2. Fetch runtime summary.
+3. Drop stale IDs not present in summary.
+4. Navigate to best valid resume target.
+5. Fall back to recent work/home.
+
+### Mobile Terminal Path
+
+Phase 1:
+
+- Preserve existing WebView terminal.
+- Add typed frame parser tests.
+- Add replay/cursor handling if gateway supports it.
+- Add stronger reconnect/attach lifecycle.
+
+Phase 2:
+
+- Spike native terminal module with feature flag.
+- Keep WebView fallback.
+- Validate hardware keyboard, soft keyboard, paste, resize, colors, scrollback, and performance.
+- Do not remove fallback until native path passes device validation.
+
+### Mobile Review Path
+
+Start with JS-rendered diffs:
+
+- File list.
+- Per-file hunks.
+- Additions/deletions.
+- Partial diff notice.
+- Ask-agent-follow-up action.
+
+Later native/performance path:
+
+- Add native diff renderer only after large-diff profiling shows need.
+- Keep JS fallback.
+
+### Mobile Regression Checklist
+
+Before merging each mobile phase:
+
+- Existing Jest suite.
+- Sign in.
+- Chat tab.
+- Mission control.
+- Terminal create/attach/delete.
+- Apps tab and app launch.
+- Canvas entry/return.
+- Settings.
+- Push/offline handling.
+- Persisted mobile shell resume.
+- Safe area and keyboard behavior on iPhone-sized viewport/device.
+
+## Gateway Implementation Guide
+
+### Route Design
+
+Prefer routes under `/api/coding-agents` or an equivalent clear namespace:
+
+- `GET /api/coding-agents/summary`
+- `GET /api/coding-agents/providers`
+- `POST /api/coding-agents/threads`
+- `GET /api/coding-agents/threads`
+- `GET /api/coding-agents/threads/:threadId`
+- `POST /api/coding-agents/threads/:threadId/abort`
+- `POST /api/coding-agents/approvals/:approvalId/decision`
+- `POST /api/coding-agents/input/:requestId/answer`
+- `GET /api/coding-agents/threads/:threadId/events`
+- `GET /api/coding-agents/threads/:threadId/review`
+- `GET /api/coding-agents/projects/:projectId/files`
+- `GET /api/coding-agents/projects/:projectId/files/read`
+- `PUT /api/coding-agents/projects/:projectId/files/write`
+
+WebSocket:
+
+- `/ws/coding-agents/runtime`
+- `/ws/coding-agents/threads/:threadId`
+
+Compatibility:
+
+- Existing terminal and shell routes may remain where they are.
+- If adding aliases, document canonical routes and deprecate old ones later.
+
+### Route Checklist
+
+For every new route:
+
+- Auth.
+- Body limit on mutating routes.
+- Zod parse params/query/body.
+- Ownership check.
+- Timeout external calls.
+- Safe error mapper.
+- Tests for valid, invalid, unauthorized, oversized, not found, stale/concurrent where relevant.
+
+### WebSocket Checklist
+
+For every new WS:
+
+- Auth before success frame.
+- Query token support only where required and allowlisted.
+- Max message size.
+- JSON parse error handling.
+- Frame schema validation.
+- Subscriber cap.
+- Stale connection sweep.
+- Shutdown drain.
+- Per-subscriber send isolation.
+- Cursor replay tests.
+- Malformed frame tests.
+
+## Data Ownership And Persistence
+
+Canonical persistence:
+
+- Thread metadata/history: owner Postgres or existing kernel conversation store, depending on current architecture.
+- Runtime/provider config: owner files and/or Postgres according to existing Matrix ownership rules.
+- App/project files: owner filesystem under scoped project/app directories.
+- App/user data: owner Postgres.
+- Client UI state: local bounded desktop/mobile storage.
+
+Do not add new SQLite/better-sqlite/drizzle persistence for this feature. Existing legacy dependencies should not be expanded.
+
+## Testing Strategy
+
+### Contract Tests
+
+- Runtime summary accepts valid payload.
+- Provider summary rejects unsafe status/action shapes.
+- Thread create bounds prompt and attachments.
+- Thread events reduce idempotently.
+- Approval decisions are idempotent.
+- Terminal frames reject invalid sizes/input.
+- File paths reject traversal.
+- Diff snapshots enforce size limits.
+
+### Gateway Unit Tests
+
+- Provider registry health normalization.
+- Safe error mapper.
+- Thread create idempotency.
+- Event append/replay.
+- Approval lifecycle.
+- Runtime summary caps and stable sort.
+- Route auth/validation/body limits.
+
+### Desktop Tests
+
+- IPC schema request/response validation.
+- Runtime switch closes old streams.
+- Notification payload validation.
+- Agent event reducer.
+- Thread list rendering.
+- Approval action handling.
+- Existing desktop typecheck.
+
+### Mobile Tests
+
+- Runtime summary parser.
+- Mobile resume state reconciliation.
+- Thread reducer.
+- Approval reducer.
+- Terminal client frame parser.
+- New agent route smoke tests.
+- Existing mobile Jest suite.
+
+### End-To-End Tests
+
+- Desktop create thread and receive completion.
+- Mobile attach to existing thread and submit follow-up.
+- Cross-shell terminal attach.
+- Approval opened on desktop, resolved on mobile.
+- Runtime switch recovery.
+- Network loss replay.
+
+## Migration And Rollout
+
+### Feature Flags
+
+Use flags/capabilities for:
+
+- New agent workspace UI.
+- Multi-provider thread creation.
+- Approval UI.
+- Review panel.
+- Preview automation.
+- Native mobile terminal.
+- Push notifications for agent attention.
+
+### Compatibility Stages
+
+1. Contracts compile, tests pass, no UI usage.
+2. Gateway summary read-only.
+3. Desktop read-only dashboard.
+4. Mobile read-only dashboard.
+5. Thread creation for one provider.
+6. Multi-provider thread creation.
+7. Approvals/input.
+8. Terminal binding.
+9. Files/review/preview.
+10. Native terminal improvement.
+
+Each stage must be revertible without losing user data.
+
+## Implementation Invariants
+
+- Core runtime works without desktop or mobile.
+- Desktop and mobile use the same runtime contracts.
+- Clients never become source of truth.
+- Every external boundary validates.
+- Every mutating route has body limit and ownership check.
+- Every long-lived stream has caps, stale cleanup, and shutdown drain.
+- Every user-visible error is safe.
+- Existing desktop/mobile behavior remains intact unless replaced by a tested superset.
+- Mobile SDK 57 remains the target for native mobile work.
+- New plans, comments, code, docs, and tests must use Matrix-native terminology only.

--- a/specs/105-coding-agent-shells/ARCHITECTURE.md
+++ b/specs/105-coding-agent-shells/ARCHITECTURE.md
@@ -1,7 +1,7 @@
 # Architecture: Coding Agent Shells
 
-**Status**: Draft  
-**Last Updated**: 2026-07-06  
+**Status**: Draft
+**Last Updated**: 2026-07-06
 **Audience**: Agents implementing gateway, desktop, mobile, shell, and runtime changes.
 
 ## Design Thesis

--- a/specs/105-coding-agent-shells/README.md
+++ b/specs/105-coding-agent-shells/README.md
@@ -1,0 +1,30 @@
+# 105 - Coding Agent Shells
+
+**Status**: Draft  
+**Created**: 2026-07-06  
+**Branch**: `chore/mobile-expo-sdk-57`  
+**Scope**: Desktop and mobile shell upgrade for multi-agent coding work on the user's Matrix computer.
+
+## Documents
+
+- [SPEC.md](./SPEC.md) - Product requirements, user stories, security model, success criteria, and non-goals.
+- [plan.md](./plan.md) - Rollout strategy, sequencing, PR slices, risks, and decision gates.
+- [ARCHITECTURE.md](./ARCHITECTURE.md) - System architecture, contracts, runtime model, client patterns, state rules, and implementation guidance.
+- [tasks.md](./tasks.md) - Phase-by-phase implementation checklist for coding agents.
+
+## Intent
+
+Matrix OS already has the pieces of a developer operating environment: per-user VPS runtime, terminal sessions, sync client, desktop shell, mobile shell, app runtime, file access, channels, and an AI kernel. This spec turns those pieces into a cohesive coding-agent cockpit across desktop and mobile.
+
+The work must preserve all current mobile and desktop functionality. The upgrade adds first-class coding-agent workflows:
+
+- Manage multiple coding agents and agent threads.
+- Connect desktop and mobile shells to the same remote Matrix computer.
+- Create, attach, resume, and terminate named remote terminal sessions.
+- Open projects, files, diffs, previews, apps, and task workspaces from either shell.
+- Keep mobile and desktop as thin interfaces over the same headless runtime.
+- Use typed, validated contracts across gateway, desktop trusted core, renderer, mobile, and shell clients.
+
+## Implementation Rule
+
+Do not fork core behavior into desktop-only or mobile-only implementations. Core runtime state belongs on the Matrix computer behind the gateway. Desktop and mobile may cache bounded UI state, but they must never become sources of truth for projects, threads, terminal sessions, files, diffs, app state, credentials, or agent history.

--- a/specs/105-coding-agent-shells/README.md
+++ b/specs/105-coding-agent-shells/README.md
@@ -1,8 +1,8 @@
 # 105 - Coding Agent Shells
 
-**Status**: Draft  
-**Created**: 2026-07-06  
-**Branch**: `chore/mobile-expo-sdk-57`  
+**Status**: Draft
+**Created**: 2026-07-06
+**Branch**: `chore/mobile-expo-sdk-57`
 **Scope**: Desktop and mobile shell upgrade for multi-agent coding work on the user's Matrix computer.
 
 ## Documents

--- a/specs/105-coding-agent-shells/SPEC.md
+++ b/specs/105-coding-agent-shells/SPEC.md
@@ -1,8 +1,8 @@
 # Feature Specification: Coding Agent Shells
 
-**Feature Branch**: `chore/mobile-expo-sdk-57`  
-**Created**: 2026-07-06  
-**Status**: Draft  
+**Feature Branch**: `chore/mobile-expo-sdk-57`
+**Created**: 2026-07-06
+**Status**: Draft
 **Input**: Upgrade Matrix OS desktop and mobile shells into first-class interfaces for managing multiple coding agents on the user's remote Matrix computer, while preserving every existing desktop and mobile capability.
 
 ## Overview

--- a/specs/105-coding-agent-shells/SPEC.md
+++ b/specs/105-coding-agent-shells/SPEC.md
@@ -1,0 +1,353 @@
+# Feature Specification: Coding Agent Shells
+
+**Feature Branch**: `chore/mobile-expo-sdk-57`  
+**Created**: 2026-07-06  
+**Status**: Draft  
+**Input**: Upgrade Matrix OS desktop and mobile shells into first-class interfaces for managing multiple coding agents on the user's remote Matrix computer, while preserving every existing desktop and mobile capability.
+
+## Overview
+
+Matrix OS should feel like a remote development computer with native-feeling shells on desktop and mobile. The user signs in once, chooses their Matrix computer, opens a project, starts one or more coding agents, watches live work, reviews files and diffs, uses terminal sessions, opens previews, and resumes the same work from another device.
+
+The headless runtime remains the source of truth. The desktop app and mobile app are interfaces, not separate runtimes. Every project, terminal session, agent thread, approval, diff, file read/write, app launch, and preview route must flow through authenticated gateway contracts backed by the user's Matrix computer.
+
+This spec intentionally builds on the existing Matrix OS pieces:
+
+- `packages/gateway`: HTTP and WebSocket gateway for terminal, apps, files, messages, agents, cron, and system state.
+- `packages/kernel`: AI kernel, agents, tools, approvals, memory, and prompt system.
+- `packages/sync-client`: CLI, remote run/attach, file sync, and local daemon patterns.
+- `shell`: browser/canvas shell and web terminal.
+- `desktop`: Electron desktop shell with trusted main process, validated IPC, auth handoff, embeds, updater, and native notifications.
+- `apps/mobile`: Expo SDK 57 native shell with terminal, apps, chat, canvas entry, offline state, and mobile persistence.
+
+## Product Goals
+
+1. **Remote computer first**: desktop and mobile connect to the user's Matrix computer and never require users to manage SSH keys, hostnames, VPS IPs, or raw credentials.
+2. **Multi-agent by default**: users can configure and run multiple coding agents side by side, with independent sessions, transcripts, terminals, statuses, approvals, and notifications.
+3. **Thread/task/workspace model**: each agent run can be standalone or bound to a project/task/worktree. Opening a thread reveals the relevant terminal, files, diff, preview, logs, and actions.
+4. **Cross-shell continuity**: work started on desktop resumes on mobile and vice versa. The same named terminal session, agent thread, project, diff, and app launch inventory are visible from both shells.
+5. **Native-feeling clients**: desktop uses Electron's trusted core and native notifications/menus. Mobile uses Expo SDK 57 and phone-first layouts. Both retain current features.
+6. **Reliability under interruption**: reconnects, sleep/wake, token expiry, runtime switch, network loss, and mobile app suspension must produce recoverable states, not lost work.
+7. **Safe by construction**: every endpoint, WebSocket frame, IPC message, app launch, deep link, and persisted reference is validated and owner-scoped.
+
+## Non-Goals
+
+- Replacing the Matrix kernel or moving core orchestration into desktop/mobile.
+- Making desktop or mobile run local PTYs as the canonical terminal source.
+- Requiring SSH setup as the user-facing path.
+- Duplicating project/task/session storage in local client databases.
+- Replacing the existing Canvas, app launcher, mobile terminal, desktop embeds, auth flow, update flow, or sync client.
+- Implementing every possible provider-specific capability in the first PR.
+- Storing provider credentials in desktop renderer, mobile JS state, embedded app frames, or local shell stores.
+- Adding unreviewed third-party native dependencies before a spike and explicit license/security review.
+
+## User Stories
+
+### US1 - Connect Desktop To My Matrix Computer (P1)
+
+As a user, I want the desktop app to sign in, select my Matrix computer, and show a connected developer workspace without manual server setup.
+
+**Independent Test**: Fresh desktop install, sign in via device flow, select runtime, see connection status, list projects, open terminal, run `pwd`, disconnect network briefly, reconnect, and verify the terminal resumes.
+
+**Acceptance Criteria**
+
+1. Given the user is signed out, when they start sign-in, then the app opens the existing secure auth flow and stores the credential only in the trusted desktop core.
+2. Given the user has one or more runtimes, when sign-in completes, then the app shows the selected runtime and allows switching through an authenticated runtime selector.
+3. Given the runtime is reachable, when the app opens, then project/task/thread/terminal summaries load through gateway contracts.
+4. Given connectivity is lost, when the app reconnects, then open views recover without clearing local UI state or duplicating terminal output.
+
+### US2 - Connect Mobile To The Same Work (P1)
+
+As a user, I want the mobile app to open the same Matrix computer, resume recent work, and provide a phone-first interface for agent threads and terminals.
+
+**Independent Test**: Start a terminal and agent run on desktop, open mobile SDK 57 app, sign in, see the same active thread/session, attach, send input or follow-up, background the app, return, and verify state resumes.
+
+**Acceptance Criteria**
+
+1. Given the user is signed in on mobile, when the app opens, then it loads the authenticated runtime profile and shows recent work without requiring SSH details.
+2. Given a terminal session exists, when the user opens Terminal on mobile, then the app can attach to that named session or create a new one.
+3. Given an agent thread is running, when the user opens mobile, then the thread appears with live or resumable status.
+4. Given the app is backgrounded, when the user returns, then mobile reconciles live runtime state before trusting stale local resume state.
+
+### US3 - Manage Multiple Coding Agents (P1)
+
+As a user, I want to see installed/configured coding agents, start runs with a chosen agent, and manage concurrent runs without state mixing.
+
+**Independent Test**: Configure at least two agent providers, start two runs against the same project and one run against another project, switch between threads, approve/decline requests, abort one run, and verify the others continue.
+
+**Acceptance Criteria**
+
+1. Given multiple agent providers are available, when the user opens the agent picker, then every provider has a safe display name, availability status, install/auth status, default model or mode, and last health check.
+2. Given the user starts a run, when they pick an agent, project, task, and prompt, then the gateway creates an owner-scoped agent thread and begins streaming events.
+3. Given multiple threads are running, when the user switches between them, then each thread preserves its own transcript, tool activity, terminal binding, approvals, and status.
+4. Given a thread needs approval or input, when the event arrives, then desktop and mobile show a safe, actionable attention state.
+5. Given the user aborts one thread, when abort succeeds, then only that thread stops; other threads and terminal sessions remain unaffected.
+
+### US4 - Work In A Project Workspace (P2)
+
+As a user, I want every project/task/thread to open into a workspace with terminal, files, diff, preview, logs, and agent transcript.
+
+**Independent Test**: Open a project, create a task, start an agent, inspect changed files, open a file, view diff, open preview, send follow-up, and verify the same workspace is visible on desktop and mobile with shell-appropriate layout.
+
+**Acceptance Criteria**
+
+1. Given a project is selected, when the user opens its workspace, then the shell shows project identity, repository status, active tasks, active threads, terminals, and recent activity.
+2. Given the user opens files, when edits occur, then saves go through gateway file contracts with conflict detection.
+3. Given an agent changes files, when diff data is available, then the shell shows per-file status and review actions.
+4. Given a dev server or generated app is running, when preview opens, then the preview route is owner-scoped and origin-restricted.
+5. Given the viewport is mobile, when the same workspace opens, then it uses stacked panes/sheets/tabs instead of desktop panel density.
+
+### US5 - Review And Ship Agent Work (P2)
+
+As a user, I want to review diffs created by agents, ask for follow-up fixes, and prepare changes for PR without leaving Matrix.
+
+**Independent Test**: Agent modifies a repo, diff appears, user reviews file-by-file, selects a hunk, asks the agent to adjust it, commits or opens a PR through gateway-backed source-control actions.
+
+**Acceptance Criteria**
+
+1. Given a thread has file changes, when the user opens Review, then changed files and diff hunks render with additions/deletions.
+2. Given a hunk is selected, when the user chooses "ask agent to fix", then the composer opens with structured context for that hunk and target thread/project.
+3. Given source control credentials are available server-side, when the user creates a PR, then the operation runs through the gateway and no GitHub token is stored in the client.
+4. Given diff data is too large, when review opens, then the shell shows partial/summary state and explicit fetch-more behavior instead of freezing.
+
+### US6 - Use Remote Terminal Sessions Everywhere (P1)
+
+As a user, I want named remote terminal sessions that survive reloads, device switches, network loss, and app restarts.
+
+**Independent Test**: Create session on desktop, attach on mobile, run long command, detach mobile, reattach desktop, resize, terminate intentionally, and verify lifecycle state is consistent everywhere.
+
+**Acceptance Criteria**
+
+1. Given a session exists on the Matrix computer, when a shell lists sessions, then it shows only owner-scoped attachable sessions.
+2. Given a shell attaches, when output arrives, then sequence/replay behavior prevents duplicate lines and marks replay gaps.
+3. Given a client detaches or disconnects, when the terminal process is still running, then session state remains running.
+4. Given the user intentionally terminates a session, when confirmation succeeds, then all attached clients see ended state.
+5. Given paste/input is large, when sent, then frames are bounded and chunked according to gateway limits.
+
+### US7 - Keep Existing Desktop Features (P1)
+
+As a current desktop user, I want auth, runtime switching, embeds, settings, updates, notifications, local UI state, and app launch behavior to continue working.
+
+**Independent Test**: Run existing desktop flows before and after agent shell changes: sign in/out, runtime switch, hosted shell embed, app embed, notification click, update check, window state persistence, menu shortcuts, settings.
+
+**Acceptance Criteria**
+
+1. Existing validated IPC channels remain compatible or migrate with compatibility wrappers.
+2. Embedded apps remain isolated from privileged APIs and credentials.
+3. Deep links and notification click-through validate payloads before navigation.
+4. The updater remains non-destructive; it never force-restarts active work.
+
+### US8 - Keep Existing Mobile Features (P1)
+
+As a current mobile user, I want chat, terminal, apps, canvas entry, settings, push, offline state, auth, and mobile shell resume behavior to keep working after the upgrade.
+
+**Independent Test**: Run current mobile Jest tests and manual SDK 57 flows, then repeat after new agent workspace screens land.
+
+**Acceptance Criteria**
+
+1. Existing app tabs/routes keep their behavior unless replaced by a tested superset.
+2. Current terminal session behavior is preserved while new state/contracts are added.
+3. Mobile safe areas, keyboard avoidance, orientation, offline banners, and persisted mobile shell state keep working.
+4. No route introduces Expo Go assumptions; native builds use the Expo dev client.
+
+## Functional Requirements
+
+### Runtime And Contracts
+
+- **FR-001**: Matrix MUST define a shared coding-agent contract layer for projects, agent providers, agent threads, thread events, approvals, terminals, files, diffs, previews, runtime health, and shell summaries.
+- **FR-002**: Contracts MUST use Zod 4 at route/WebSocket/IPC boundaries and export inferred TypeScript types for desktop, mobile, shell, gateway, and tests.
+- **FR-003**: Contracts MUST be source-compatible with current gateway behavior where possible, using additive fields and explicit versioning for changed frames.
+- **FR-004**: Runtime state MUST be canonical on the Matrix computer. Clients may store bounded caches and last-viewed UI state only.
+- **FR-005**: The gateway MUST expose a single runtime summary endpoint that desktop and mobile can use to hydrate: active runtime, available agents, projects, active threads, terminal sessions, recent activity, and feature availability.
+
+### Agent Providers
+
+- **FR-010**: The runtime MUST support multiple coding-agent providers as configured tools, not hardcoded UI-only options.
+- **FR-011**: Each provider MUST report `id`, `displayName`, `kind`, `availability`, `authStatus`, `installStatus`, `defaultModel`, `supportedModes`, and safe setup actions.
+- **FR-012**: Provider setup/install actions MUST run on the Matrix computer in foreground terminal sessions when user interaction may be required.
+- **FR-013**: Provider health checks MUST be timeout-bound and return coarse status only.
+- **FR-014**: Provider-specific errors MUST never be rendered raw to users; clients receive safe states and recovery actions.
+
+### Agent Threads
+
+- **FR-020**: Users MUST be able to create a thread with provider, prompt, optional project, optional task, optional worktree, optional terminal session, model/mode options, approval policy, and sandbox policy.
+- **FR-021**: Threads MUST stream typed events: lifecycle, assistant text, reasoning/plan, tool activity, terminal activity, file changes, diffs, approvals, user-input requests, errors, and completion.
+- **FR-022**: Threads MUST be resumable by ID across desktop, mobile, browser shell, and CLI.
+- **FR-023**: Threads MUST have explicit statuses: `queued`, `starting`, `running`, `waiting_for_approval`, `waiting_for_input`, `completed`, `failed`, `aborted`, `stale`, and `archived`.
+- **FR-024**: Thread abort MUST target one thread/run and leave project, terminal, and other threads intact.
+- **FR-025**: Thread transcript memory in clients MUST be capped; clients fetch historical windows or snapshots from the runtime.
+
+### Approvals And User Input
+
+- **FR-030**: Approval requests MUST include bounded display data, provider/thread/project context, requested action kind, risk level, allowed decisions, expiry, and correlation ID.
+- **FR-031**: Desktop and mobile MUST support approve, approve for session when allowed, decline, cancel, and provide user-input answers.
+- **FR-032**: Approval decisions MUST be idempotent server-side; repeated client sends after reconnect must not double-apply.
+- **FR-033**: Approval and input surfaces MUST use safe copy and never expose raw command env vars, secret-looking tokens, or full private paths unless explicitly designed as user-owned project paths.
+
+### Terminal Sessions
+
+- **FR-040**: Terminal sessions MUST be named, owner-scoped, runtime-scoped, and attachable from desktop, mobile, web shell, and CLI.
+- **FR-041**: Terminal attachments MUST include sequence/replay support or an equivalent monotonic output cursor.
+- **FR-042**: Terminal clients MUST distinguish process state from attachment state.
+- **FR-043**: Resize values MUST be clamped and coalesced.
+- **FR-044**: Input frames MUST be size-limited and validated.
+- **FR-045**: Session lists MUST cap returned items and include pagination or `hasMore`.
+- **FR-046**: Ending a session MUST require explicit confirmation in clients and use a mutating endpoint with body limits and ownership checks.
+
+### Files, Diff, Review, Preview
+
+- **FR-050**: Project file APIs MUST support browse, search, read, write, and metadata with path validation inside owner/project scope.
+- **FR-051**: File writes MUST include base revision/etag and conflict-safe behavior.
+- **FR-052**: Diff APIs MUST support thread diff, working tree diff, file-level diff, hunk metadata, partial diff notices, and large-diff limits.
+- **FR-053**: Review comments/follow-up prompts MUST carry structured references, not raw unvalidated strings.
+- **FR-054**: Preview APIs MUST support owner-scoped local dev servers and app previews with origin validation and safe status reporting.
+
+### Desktop Shell
+
+- **FR-060**: Desktop MUST keep all privileged behavior in the trusted main process or validated preload bridge.
+- **FR-061**: Desktop renderer MUST never receive raw bearer tokens, provider credentials, platform secrets, or app launch tokens not intended for that surface.
+- **FR-062**: Desktop MUST add a mission-control style agent workspace: project/task sidebar, active thread list, global composer, terminal panel, file/diff/preview panels, activity timeline, and provider setup surface.
+- **FR-063**: Desktop MUST preserve existing embeds, auth handoff, runtime switching, settings, updater, single-instance, deep links, menus, notifications, and persisted window state.
+- **FR-064**: Desktop MUST validate every IPC request and response with shared or local schemas.
+- **FR-065**: Desktop notifications MUST deep-link to exact thread/task/session targets using validated payloads.
+
+### Mobile Shell
+
+- **FR-070**: Mobile SDK 57 MUST add an agent workspace optimized for phone and tablet: inbox/recent work, provider picker, composer, thread detail, approvals, terminal, files, review, and preview.
+- **FR-071**: Mobile MUST preserve existing tabs/routes: chat, mission control, terminal, apps, settings, canvas, sessions, auth, push, and offline handling.
+- **FR-072**: Mobile MUST use current gateway auth/token patterns and must not require SSH key management.
+- **FR-073**: Mobile terminal MUST remain available and evolve toward a native terminal surface behind a capability flag; the existing WebView terminal stays as fallback until the native path is verified.
+- **FR-074**: Mobile thread, approval, terminal, and review screens MUST handle app backgrounding, orientation, safe areas, keyboard, and network transitions.
+- **FR-075**: Mobile local persistence MUST store only bounded resume/UI state and safe runtime references; every persisted reference must reconcile against live runtime state on read.
+
+### Observability And Diagnostics
+
+- **FR-080**: Gateway, desktop, mobile, and shell MUST emit redacted diagnostics for runtime connection lifecycle, thread lifecycle, terminal attach/replay, approval decisions, provider setup, and preview failures.
+- **FR-081**: Client diagnostics MUST be opt-in or follow current product telemetry policy and must exclude terminal content, chat content, file contents, secrets, and raw provider errors.
+- **FR-082**: Desktop local logs MUST be rotated and size-capped.
+- **FR-083**: Mobile debug logs MUST remain bounded and not persist sensitive content.
+
+## Key Entities
+
+### RuntimeTarget
+
+The selected Matrix computer/runtime. Contains stable ID, display label, health, capabilities, current channel, gateway origin, and selected owner handle. It does not contain secrets.
+
+### AgentProvider
+
+A configured coding-agent provider available on the Matrix computer. Includes display metadata, setup state, auth/install state, supported launch modes, and safe actions.
+
+### AgentThread
+
+A single coding-agent run or resumable conversation. Belongs to owner/runtime, may be bound to project/task/worktree/session, has status, transcript cursor, event cursor, attention state, and lifecycle timestamps.
+
+### AgentEvent
+
+Typed append-only event emitted by runtime: text, tool, reasoning, approval, input request, file change, terminal signal, diff ready, preview ready, error, or lifecycle transition.
+
+### AgentApprovalRequest
+
+A pending decision that blocks or gates a thread action. Must be idempotent, expiring, correlation-aware, and safe to render.
+
+### ProjectWorkspace
+
+Shell projection for one project/task/thread: project metadata, repository state, active sessions, files, diffs, previews, artifacts, processes, and activity.
+
+### TerminalSession
+
+Remote named terminal process state. Distinguished from `TerminalAttachment`, which is the client connection to a session.
+
+### ReviewSnapshot
+
+A bounded projection of changed files and diffs for a thread/task/project. Can be partial and must declare limits.
+
+### PreviewSession
+
+Owner-scoped preview target for app/runtime/dev server with origin policy, status, viewport metadata, and launch context.
+
+### ShellResumeState
+
+Local client UI state for last selected runtime/project/thread/session/screen. It is advisory only and reconciled against runtime state on every load.
+
+## Security Architecture
+
+### Auth Matrix
+
+| Surface | Operation | Auth Requirement | Public? | Notes |
+| --- | --- | --- | --- | --- |
+| Desktop trusted core | Store credential, inject gateway auth, manage embedded sessions | OS-encrypted credential from existing device flow | No | Renderer never receives raw credential. |
+| Desktop renderer | Invoke privileged actions | Validated IPC to trusted core | No | Every request/response schema-checked. |
+| Mobile app | Gateway HTTP/WS calls | Existing mobile auth and short-lived gateway token | No | Query token allowed only where browser/native WS APIs need it. |
+| Browser shell | Agent workspace routes | Existing shell auth/session | No | Must use query-token allowlist for browser WS routes. |
+| Gateway REST | Runtime summary, providers, threads, files, diffs, previews | Owner session or trusted platform-to-runtime auth | No | Body limits on mutating routes. |
+| Gateway WS | Thread events, terminal attach, runtime events | Owner session; setup awaited before success frame | No | Frame size and shape validation required. |
+| Provider setup | Install/auth/check provider | Authenticated owner, explicit user action | No | Runs on Matrix computer, foreground when interactive. |
+| App embeds/previews | Open app/shell/preview | Short-lived owner-scoped launch handoff | No | Origin allowlist and isolated session partitions. |
+| Notifications/deep links | Focus target thread/task/session | Local validated payload + existing signed-in state | No | Deep link only selects UI target, never authenticates. |
+
+### Validation Rules
+
+- Validate all IDs with strict prefixes or safe slug patterns.
+- Validate provider IDs against configured provider registry.
+- Validate route params and query params before service calls.
+- Validate every WebSocket frame after JSON parsing and before state mutation.
+- Validate IPC messages on both sides of desktop bridge.
+- Validate mobile persisted resume state before use; reconcile references against live runtime.
+- Validate app launch URLs and preview origins before navigation.
+- Validate file paths server-side with resolve-within-project/home helpers.
+- Validate diff and file sizes before rendering or storing client-side.
+
+### Resource Limits
+
+- Runtime summaries must be bounded and paginated for projects, threads, sessions, and activity.
+- Thread event streams must support cursors and replay windows.
+- Client transcript caches must cap message/event count.
+- Terminal output buffers must use ring buffers with explicit limits.
+- In-memory registries for subscribers, providers, sessions, previews, launch tokens, and diagnostics must have caps and eviction.
+- Desktop IPC and mobile gateway clients must reject oversized payloads before rendering.
+- Preview/session launch tokens must be short-lived and LRU-cached only where necessary.
+
+### Error Policy
+
+- Never show raw provider, database, filesystem, platform, gateway, or process errors.
+- Client copy should say what the user can do: retry, reconnect, sign in, pick runtime, install provider, open terminal setup, resume, start new session, return home.
+- Detailed errors go to redacted server logs and bounded local diagnostics.
+- Health checks return coarse statuses: available, setup_required, auth_required, unavailable, unknown.
+- Runtime offline state must not reveal VPS IPs, private hostnames, or internal routes.
+
+## Integration Wiring
+
+### Required End-To-End Paths
+
+1. Desktop sign-in -> runtime summary -> provider list -> create thread -> stream events -> complete notification -> focus thread.
+2. Mobile sign-in -> runtime summary -> attach existing thread -> send follow-up -> receive approval -> approve -> stream resumes.
+3. Desktop create terminal -> mobile attach -> desktop detach -> mobile input -> desktop reattach -> intentional terminate.
+4. Agent changes files -> review snapshot -> open file -> conflict-safe save -> diff refresh.
+5. Provider setup required -> open foreground terminal install/setup command -> provider health refresh -> provider becomes selectable.
+6. Runtime switch -> all clients close old runtime streams -> clear embedded sessions where needed -> hydrate selected runtime.
+7. Network loss -> clients mark reconnecting -> streams resume by cursor -> no duplicate terminal output or thread events.
+
+## Success Criteria
+
+- **SC-001**: Desktop signed-in launch hydrates runtime summary and renders the agent workspace in under 5 seconds on typical broadband.
+- **SC-002**: Mobile signed-in launch hydrates recent threads/sessions in under 5 seconds and remains usable on phone-sized screens.
+- **SC-003**: User can start two agent runs with different providers and switch between them without transcript, approval, or terminal state mixing.
+- **SC-004**: Terminal sessions created on one shell can be attached from another shell with no process restart.
+- **SC-005**: Network interruption and resume produce zero duplicate terminal output lines in scripted tests.
+- **SC-006**: Desktop and mobile can both handle an approval request for the same thread, with idempotent server-side decision handling.
+- **SC-007**: Existing desktop feature regression checklist passes: auth, embeds, runtime switch, settings, notifications, updates, window state, command palette/menu basics.
+- **SC-008**: Existing mobile feature regression checklist passes: chat, terminal, apps, canvas entry, sessions, settings, push/offline, auth, persisted shell state.
+- **SC-009**: Error-path audit finds no raw provider names, secret-looking tokens, filesystem paths, database errors, or upstream stack traces in user-visible UI.
+- **SC-010**: Typecheck and test gates pass for changed packages, with focused contract tests around every new gateway route/WS/IPC surface.
+
+## Rollout Strategy
+
+1. Ship contracts and read-only runtime summary behind feature flags.
+2. Add desktop and mobile read-only agent dashboards.
+3. Enable thread creation for one provider path.
+4. Add multi-provider creation, approvals, and abort.
+5. Add file/diff/review/preview panels.
+6. Add native/mobile terminal rendering improvements behind capability detection.
+7. Expand provider setup, health, and cross-shell notifications.
+
+Every phase must preserve current desktop and mobile behavior and include compatibility checks before replacing existing surfaces.

--- a/specs/105-coding-agent-shells/plan.md
+++ b/specs/105-coding-agent-shells/plan.md
@@ -1,7 +1,7 @@
 # Implementation Plan: Coding Agent Shells
 
-**Status**: Draft  
-**Created**: 2026-07-06  
+**Status**: Draft
+**Created**: 2026-07-06
 **Planning horizon**: Incremental PR series, not a single mega-branch.
 
 ## Summary

--- a/specs/105-coding-agent-shells/plan.md
+++ b/specs/105-coding-agent-shells/plan.md
@@ -1,0 +1,675 @@
+# Implementation Plan: Coding Agent Shells
+
+**Status**: Draft  
+**Created**: 2026-07-06  
+**Planning horizon**: Incremental PR series, not a single mega-branch.
+
+## Summary
+
+This plan upgrades Matrix OS desktop and mobile into first-class coding-agent interfaces while preserving current behavior. The sequence intentionally starts with contracts and read-only projections, then adds agent thread creation, streaming, approvals, terminal binding, review, preview, and notification polish.
+
+The guiding rule is simple: build shared runtime primitives first, then render them differently per shell.
+
+## Strategic Choices
+
+### Choice 1 - Shared Runtime Contracts First
+
+Start with shared schemas before UI work.
+
+Why:
+
+- Desktop, mobile, browser shell, CLI, and gateway need the same vocabulary.
+- Contract tests prevent drift between clients.
+- Read-only rollout lets us verify state shape before mutating runtime behavior.
+
+How:
+
+- Add or expand a schema-only contract module/package.
+- Keep Zod 4 schemas close to gateway route validation.
+- Export inferred types for clients.
+- Add parse/reject tests before any UI imports the schemas.
+
+### Choice 2 - Runtime Summary As First Integration Point
+
+Add a safe `RuntimeSummary` projection before thread creation.
+
+Why:
+
+- It gives every shell one hydration path.
+- It makes feature availability explicit.
+- It prevents clients from calling many ad hoc endpoints at startup.
+- It provides a compatibility bridge while deeper thread/review APIs mature.
+
+Summary should include:
+
+- Selected runtime.
+- Capabilities.
+- Provider status.
+- Projects/tasks overview.
+- Active threads.
+- Terminal sessions.
+- Recent activity.
+- Limits.
+- Server time.
+
+Summary must not include:
+
+- Terminal output.
+- File contents.
+- Thread transcript bodies beyond bounded summaries.
+- Provider raw logs.
+- Tokens.
+- Internal hostnames.
+- Raw errors.
+
+### Choice 3 - Thin Clients, Strong Reducers
+
+Clients should render runtime state with pure reducers and bounded caches.
+
+Why:
+
+- Agent streams are event-heavy and reconnect-prone.
+- Mobile suspension and desktop sleep/wake are normal.
+- Idempotent reducers make replay safe.
+
+Pattern:
+
+- Gateway streams typed events.
+- Client parses and reduces events.
+- Reducers ignore duplicate event IDs.
+- Reducers tolerate unknown event types.
+- Reducers cap transcript/tool arrays.
+- Client fetches snapshots when cursors are stale.
+
+### Choice 4 - Terminal Sessions Stay Canonical
+
+Do not create a parallel terminal model for agent threads.
+
+Why:
+
+- Matrix already has named shell sessions.
+- CLI, web terminal, mobile, and desktop should attach to the same sessions.
+- Thread-to-terminal binding can be metadata, not a duplicate process model.
+
+Pattern:
+
+- `TerminalSession` is remote process state.
+- `TerminalAttachment` is a client connection.
+- Detach does not kill the process.
+- Terminate is an explicit user action.
+- Attachments support replay/cursor or a compatibility equivalent.
+
+### Choice 5 - Native Desktop Trust Boundary
+
+Desktop main/preload remain the trusted boundary.
+
+Why:
+
+- Renderer can be compromised like any web surface.
+- Embedded apps and hosted shell content must never see privileged APIs.
+- Credentials belong in OS-encrypted trusted core storage.
+
+Pattern:
+
+- Trusted core owns credential and bearer injection.
+- Renderer calls validated IPC/preload APIs.
+- IPC schemas validate request and response.
+- Notification/deep-link payloads only focus UI after validation.
+
+### Choice 6 - Mobile SDK 57 First, Native Terminal Later
+
+Preserve the current mobile terminal and add native terminal behind capability detection only after a spike.
+
+Why:
+
+- Mobile is on Expo SDK 57 in this branch.
+- Existing terminal behavior must not regress.
+- Native modules require dev-client/device validation.
+
+Pattern:
+
+- Phase 1 keeps WebView terminal fallback.
+- Improve state, parser, reconnect, and thread binding first.
+- Add native renderer as optional capability after spike.
+- Keep fallback until native is proven across required devices.
+
+## Phase Roadmap
+
+### Phase A - Foundation
+
+Scope:
+
+- Current-state inventory.
+- Feature flag plan.
+- Shared contracts.
+- Runtime summary route.
+- Provider registry read path.
+- Terminal session summary adapter.
+
+Exit criteria:
+
+- Contract tests pass.
+- Runtime summary returns bounded safe payload.
+- No desktop/mobile UI changes required.
+- No existing route behavior changes.
+
+Primary PRs:
+
+1. `contracts(agent-shells): add coding-agent schemas`
+2. `feat(gateway): expose coding-agent runtime summary`
+
+### Phase B - Read-Only Shells
+
+Scope:
+
+- Desktop read-only agent dashboard.
+- Mobile read-only recent work/agent dashboard.
+- Runtime status, providers, active threads, terminal sessions, recent activity.
+- Safe empty/offline/setup-required states.
+
+Exit criteria:
+
+- Desktop and mobile hydrate from the same summary.
+- Existing desktop and mobile features still pass regression checks.
+- Feature flags can disable new UI.
+
+Primary PRs:
+
+1. `feat(desktop): add read-only agent workspace`
+2. `feat(mobile): add read-only agent workspace`
+
+### Phase C - Thread Lifecycle
+
+Scope:
+
+- Thread store.
+- Thread create route.
+- Thread event append/replay.
+- Thread WebSocket.
+- Fake provider adapter tests.
+- First real provider adapter behind flag.
+
+Exit criteria:
+
+- Threads can be created idempotently.
+- Events replay and stream.
+- Clients can show live thread detail.
+- Abort works for one thread without affecting others.
+
+Primary PRs:
+
+1. `feat(gateway): add agent thread store and event stream`
+2. `feat(agents): connect first provider adapter`
+3. `feat(desktop): create and follow agent threads`
+4. `feat(mobile): create and follow agent threads`
+
+### Phase D - Approvals And Input
+
+Scope:
+
+- Approval request events.
+- Approval decision route.
+- User input answer route.
+- Desktop approval UI.
+- Mobile approval UI.
+- Attention state.
+
+Exit criteria:
+
+- Approval can be resolved from either shell.
+- Duplicate/racing decisions are idempotent.
+- All shells see resolved state.
+- User-facing copy is safe.
+
+Primary PRs:
+
+1. `feat(agents): add approval lifecycle`
+2. `feat(desktop): handle agent approvals`
+3. `feat(mobile): handle agent approvals`
+
+### Phase E - Terminal Binding
+
+Scope:
+
+- Thread-to-terminal binding.
+- Terminal panel in desktop workspace.
+- Thread terminal route in mobile.
+- Cross-shell attach/resume tests.
+- Replay gap and fatal session error handling.
+
+Exit criteria:
+
+- Desktop-created session can be attached from mobile.
+- Mobile-created session can be attached from desktop.
+- Detach does not kill process.
+- Termination updates all shells.
+
+Primary PRs:
+
+1. `feat(gateway): bind terminal sessions to agent threads`
+2. `feat(desktop): add workspace terminal panel`
+3. `feat(mobile): add thread terminal route`
+
+### Phase F - Files And Review
+
+Scope:
+
+- File browse/search/read/write contracts.
+- Conflict-safe saves.
+- Review snapshot/diff service.
+- Desktop review panel.
+- Mobile review route.
+- Ask-agent-follow-up action with structured references.
+
+Exit criteria:
+
+- Agent changes are visible as review snapshots.
+- Large diffs do not freeze clients.
+- File writes detect conflicts.
+- Follow-up prompts reference structured file/hunk context.
+
+Primary PRs:
+
+1. `feat(gateway): add agent workspace file and review APIs`
+2. `feat(desktop): add review panel`
+3. `feat(mobile): add review screens`
+
+### Phase G - Preview And App Runtime
+
+Scope:
+
+- Preview capability in runtime summary.
+- Safe preview session metadata.
+- Desktop preview panel using existing embed isolation.
+- Mobile preview route.
+- App/session launch handoff reuse.
+
+Exit criteria:
+
+- Preview origins are validated.
+- Embedded auth failure does not destroy native sign-in.
+- Existing app launch remains intact.
+
+Primary PRs:
+
+1. `feat(gateway): expose safe workspace previews`
+2. `feat(desktop): add preview panel`
+3. `feat(mobile): add preview route`
+
+### Phase H - Native Quality And Polish
+
+Scope:
+
+- Desktop command palette and keyboard flow.
+- Desktop workspace layout persistence/LRU.
+- Mobile recent work home polish.
+- Mobile ergonomics.
+- Notification routing.
+- Native mobile terminal spike and optional rollout.
+
+Exit criteria:
+
+- Desktop is keyboard-first for core agent workflows.
+- Mobile can manage daily agent work from phone.
+- Notifications route to exact thread/task/session.
+- Native terminal lands only if fallback remains and device validation passes.
+
+Primary PRs:
+
+1. `feat(desktop): polish agent mission control`
+2. `feat(mobile): polish agent daily workflow`
+3. `feat(notifications): route coding-agent attention`
+4. `feat(mobile): add native terminal capability`
+
+## Workstream Ownership
+
+### Gateway/Core Workstream
+
+Owns:
+
+- Contracts at route boundary.
+- Runtime summary.
+- Provider registry.
+- Thread store/events.
+- Approval lifecycle.
+- Terminal binding.
+- File/review/preview APIs.
+- Safe errors.
+- Auth/resource limits.
+
+Must coordinate with:
+
+- Kernel provider/session implementation.
+- Terminal session reliability.
+- Platform auth/runtime routing.
+- Public docs.
+
+### Desktop Workstream
+
+Owns:
+
+- Trusted-core runtime client.
+- Validated IPC/preload API.
+- Agent mission control UI.
+- Desktop composer.
+- Thread streams.
+- Terminal/review/preview panels.
+- Notifications/deep links.
+- Runtime switch behavior.
+
+Must preserve:
+
+- Existing auth.
+- Existing embeds.
+- Existing settings.
+- Existing updater.
+- Existing menu/window behavior.
+- Existing terminal behavior.
+
+### Mobile Workstream
+
+Owns:
+
+- SDK 57 runtime client.
+- Mobile agent routes.
+- Mobile composer.
+- Thread detail.
+- Approval UI.
+- Thread terminal route.
+- Review/files/preview screens.
+- Mobile resume state.
+- Native terminal spike.
+
+Must preserve:
+
+- Existing chat.
+- Existing terminal tab.
+- Existing apps tab.
+- Existing mission control.
+- Existing canvas entry.
+- Existing settings.
+- Existing auth/push/offline behavior.
+
+### Shell/CLI Workstream
+
+Owns:
+
+- Browser shell parity where needed.
+- Canvas/Desktop built-in route wiring.
+- CLI compatibility for terminal/session operations.
+- Shared contracts usage.
+
+Must preserve:
+
+- Canvas as primary browser shell.
+- Terminal built-in route behavior.
+- App launcher/app runtime behavior.
+
+## Decision Gates
+
+### Gate 1 - Contract Acceptance
+
+Proceed only when:
+
+- Schemas cover all planned runtime primitives.
+- Tests reject malformed payloads.
+- At least gateway and one client can import types without circular dependencies.
+- Sensitive-field audit passes.
+
+### Gate 2 - Summary Acceptance
+
+Proceed only when:
+
+- Summary route works for authenticated owner.
+- Summary is safe when providers/runtime are unavailable.
+- Lists are capped.
+- Desktop and mobile can render read-only dashboards from summary.
+
+### Gate 3 - Thread Creation Acceptance
+
+Proceed only when:
+
+- Thread create is idempotent.
+- Event stream supports replay.
+- Fake provider test covers lifecycle.
+- First real provider path is behind flag.
+- Abort does not affect unrelated work.
+
+### Gate 4 - Cross-Shell Continuity Acceptance
+
+Proceed only when:
+
+- Desktop and mobile can open the same thread.
+- Terminal session created in one shell can attach in another.
+- Approval resolved in one shell updates the other.
+- Runtime switch closes stale streams.
+
+### Gate 5 - Review/Preview Acceptance
+
+Proceed only when:
+
+- File read/write paths are conflict-safe.
+- Diff snapshots are bounded.
+- Preview origins are validated.
+- Existing app embeds still pass regression checks.
+
+### Gate 6 - Rollout Acceptance
+
+Proceed only when:
+
+- Desktop and mobile regression checklists pass.
+- Error-path audit passes.
+- Public docs are updated or explicitly deferred.
+- Deployment path is documented for platform/app-shell/host-bundle/native mobile impacts.
+
+## Risk Register
+
+### Risk: Contract Drift
+
+Clients may implement local shapes instead of shared schemas.
+
+Mitigation:
+
+- Contract package or single gateway-local contract source.
+- Contract tests in every client adapter.
+- PR review checks for duplicate schema definitions.
+
+### Risk: Desktop Renderer Credential Exposure
+
+New runtime client code may accidentally pass credentials to renderer.
+
+Mitigation:
+
+- Trusted core owns credential.
+- Renderer receives safe projections only.
+- IPC response schemas exclude tokens.
+- Add tests scanning IPC response fixtures for forbidden keys.
+
+### Risk: Mobile Resume Uses Stale Runtime IDs
+
+AsyncStorage may point to deleted threads/sessions.
+
+Mitigation:
+
+- Parse then reconcile against runtime summary.
+- Drop stale references.
+- Fall back to recent work.
+
+### Risk: Terminal Session Model Fork
+
+Agent work may introduce separate terminal session logic.
+
+Mitigation:
+
+- Thread binding references canonical terminal session IDs/names.
+- Reuse existing session list/attach/delete behavior.
+- Add cross-shell attach tests.
+
+### Risk: Unbounded Streams And Memory
+
+Agent threads and terminal output can grow indefinitely.
+
+Mitigation:
+
+- Event cursors.
+- Transcript windows.
+- Ring buffers.
+- Subscriber caps.
+- Stale connection cleanup.
+- LRU workspace panels.
+
+### Risk: Raw Errors Leak To UI
+
+Provider setup and command execution may return sensitive details.
+
+Mitigation:
+
+- Central safe error mapper.
+- Client allowlist/cap error strings.
+- Error-path tests.
+- Detailed logs only in redacted diagnostics.
+
+### Risk: Existing Mobile/Desktop Regression
+
+New agent workspace could break current terminal/app/canvas/settings flows.
+
+Mitigation:
+
+- Feature flags.
+- Read-only rollout first.
+- Regression checklist per phase.
+- Avoid replacing existing screens until supersets are verified.
+
+### Risk: Native Mobile Terminal Complexity
+
+Native terminal may destabilize SDK 57 builds.
+
+Mitigation:
+
+- Separate spike.
+- Capability flag.
+- WebView fallback.
+- Device validation.
+- No removal of existing terminal until native is proven.
+
+## Implementation Patterns
+
+### Pattern: Additive Route
+
+1. Add schema.
+2. Add focused tests.
+3. Add service function.
+4. Add route with auth/body limit/validation.
+5. Add safe error mapper.
+6. Add client adapter.
+7. Add UI behind flag.
+
+### Pattern: Event Reducer
+
+1. Define event union.
+2. Write reducer tests for every event.
+3. Add duplicate-event handling.
+4. Add unknown-event handling.
+5. Add cap/truncation behavior.
+6. Wire stream.
+7. Render projection, not raw events.
+
+### Pattern: Cross-Shell Feature
+
+1. Gateway contract.
+2. Browser shell or CLI compatibility check.
+3. Desktop adapter.
+4. Mobile adapter.
+5. Shared test fixtures.
+6. Cross-shell E2E.
+
+### Pattern: Provider Setup
+
+1. Provider registry returns setup required.
+2. UI shows setup action.
+3. Setup opens foreground terminal command/session.
+4. User completes auth/install.
+5. Provider health refreshes.
+6. Provider becomes selectable.
+
+### Pattern: Runtime Switch
+
+1. User selects runtime.
+2. Client cancels old in-flight requests.
+3. Client closes old streams.
+4. Trusted core clears embedded sessions if needed.
+5. Client fetches new summary.
+6. Client drops stale local references.
+7. Client renders new runtime safely.
+
+## Documentation Plan
+
+Internal:
+
+- `docs/dev/coding-agent-shells.md`
+- Include contracts, route map, event reducer guide, provider adapter guide, terminal binding guide, approval lifecycle, and client state rules.
+
+Public:
+
+- Add/update docs under `www/content/docs/`.
+- Explain desktop/mobile coding-agent workflows.
+- Explain remote Matrix computer model.
+- Explain provider setup.
+- Explain session continuity.
+
+Support:
+
+- Add troubleshooting for provider setup, runtime offline, terminal attach failure, mobile native terminal if applicable.
+- Keep public repo safe: no customer identifiers, secrets, private hostnames, or incident-only commands.
+
+## Recommended First Three PRs
+
+### PR 1 - Contracts
+
+Deliver:
+
+- Shared schemas for IDs, safe errors, runtime summary, providers, threads, events, approvals, terminal summaries.
+- Tests.
+- No UI.
+
+Why first:
+
+- Gives every later agent a stable vocabulary.
+
+### PR 2 - Gateway Summary
+
+Deliver:
+
+- Authenticated runtime summary route.
+- Provider summary adapter.
+- Terminal summary adapter.
+- Caps and safe errors.
+- Tests.
+
+Why second:
+
+- Enables desktop/mobile read-only work without provider execution risk.
+
+### PR 3 - Read-Only Clients
+
+Deliver:
+
+- Desktop runtime summary IPC and dashboard behind flag.
+- Mobile runtime summary client and recent work screen behind flag.
+- Existing behavior preserved.
+
+Why third:
+
+- Verifies cross-client shape early and gives product feedback before mutating runtime.
+
+## Stop Conditions
+
+Stop and ask for design review if:
+
+- A task requires changing canonical auth flow.
+- A task requires storing provider credentials client-side.
+- A task requires new persistence technology.
+- A task requires removing existing mobile terminal fallback.
+- A task requires changing production VPS deployment model.
+- A task requires bypassing route/WS validation.
+- A task cannot be tested without relying on manual happy path only.

--- a/specs/105-coding-agent-shells/tasks.md
+++ b/specs/105-coding-agent-shells/tasks.md
@@ -1,0 +1,1136 @@
+# Tasks: Coding Agent Shells
+
+**Status**: Draft  
+**Branch**: `chore/mobile-expo-sdk-57`  
+**Rule**: Preserve all existing desktop and mobile functionality. Add coding-agent capabilities incrementally behind contracts, tests, and feature flags.
+
+## Agent Instructions
+
+Before starting any task:
+
+- Read `AGENTS.md` and `.specify/memory/constitution.md`.
+- Read this spec package: `README.md`, `SPEC.md`, `ARCHITECTURE.md`, and `tasks.md`.
+- Read the relevant existing spec before editing a subsystem:
+  - `specs/075-mobile-shell/spec.md` for mobile shell.
+  - `specs/094-electron-macos-shell/spec.md` for desktop shell.
+  - `specs/104-terminal-refactor-foundation/spec.md` for terminal refactor boundaries.
+  - `specs/069-cloud-coding-workspaces/spec.md` if changing cloud coding workspace behavior.
+  - `specs/098-terminal-session-reliability/spec.md` if changing terminal session lifecycle.
+- Write failing tests first for implementation work.
+- Use Zod 4 (`zod/v4`) for new runtime contracts.
+- Keep new persistence in owner Postgres/Kysely or existing owner files according to current Matrix architecture. Do not add new embedded database persistence.
+- Do not expose provider errors, raw paths, stack traces, tokens, or internal hostnames in UI.
+- Do not move core runtime behavior into desktop or mobile clients.
+
+## Completion Gates
+
+Every PR slice must satisfy the relevant gates:
+
+- [ ] Focused tests added before implementation.
+- [ ] `bun run check:patterns` passes when touching Matrix OS source.
+- [ ] `bun run typecheck` passes when changed package graph allows it.
+- [ ] `bun run test -- <focused pattern>` passes for touched gateway/kernel/shared modules.
+- [ ] `pnpm --filter desktop run typecheck` passes for desktop changes.
+- [ ] `pnpm --filter matrix-os-mobile run test` or equivalent mobile Jest command passes for mobile changes.
+- [ ] Existing desktop regression checklist passes manually or by smoke test when desktop behavior changes.
+- [ ] Existing mobile regression checklist passes manually or by test when mobile behavior changes.
+- [ ] No generated docs/code/comments mention external reference project names.
+- [ ] Public docs update task is completed or explicitly deferred with reason.
+
+## Phase 0 - Discovery And Baseline
+
+Goal: establish exact current behavior and regression gates before adding new runtime surfaces.
+
+### 0.1 Inventory Current Runtime Surfaces
+
+- [ ] List current gateway routes for terminal sessions, apps, files, previews, agent credentials, and shell auth.
+- [ ] List current WebSocket endpoints and frame shapes.
+- [ ] List current desktop IPC channels in `desktop/src/shared/ipc-contract.ts`.
+- [ ] List current mobile gateway methods in `apps/mobile/lib/gateway-client.ts`.
+- [ ] List current terminal client methods in `apps/mobile/lib/terminal-client.ts`.
+- [ ] List current desktop renderer agent/session/task stores under `desktop/src/renderer/src/stores`.
+- [ ] List current shell terminal/session helpers under `shell/src`.
+- [ ] Document which current flows are canonical and which are compatibility paths.
+
+Deliverable:
+
+- [ ] Add `specs/105-coding-agent-shells/current-state.md` with route/contract inventory and open questions.
+
+Tests:
+
+- [ ] No code tests required unless inventory finds existing broken tests. Run `git status` and keep this docs-only unless implementation is needed.
+
+### 0.2 Establish Regression Scripts
+
+- [ ] Identify existing focused tests for mobile terminal, gateway client, shell sessions, desktop IPC, and desktop renderer stores.
+- [ ] Add missing smoke-test commands to `current-state.md`.
+- [ ] Confirm mobile SDK 57 test command in this branch.
+- [ ] Confirm desktop typecheck command in this branch.
+- [ ] Confirm gateway focused test command for terminal/session routes.
+
+Deliverable:
+
+- [ ] `current-state.md` includes a "Baseline Commands" section.
+
+### 0.3 Define Feature Flags
+
+- [ ] Find existing feature flag mechanism in shell/desktop/mobile.
+- [ ] Define flags:
+  - `codingAgentsRuntimeSummary`
+  - `codingAgentsDesktopWorkspace`
+  - `codingAgentsMobileWorkspace`
+  - `codingAgentsThreadCreate`
+  - `codingAgentsApprovals`
+  - `codingAgentsReview`
+  - `codingAgentsNativeMobileTerminal`
+- [ ] Decide whether flags are server capabilities, build-time flags, local dev flags, or a combination.
+
+Deliverable:
+
+- [ ] Add feature flag plan to `current-state.md` or a separate `flags.md`.
+
+## Phase 1 - Shared Contracts
+
+Goal: create Matrix-native typed contracts consumed by gateway, desktop, mobile, shell, and tests.
+
+### 1.1 Contract Package Decision
+
+- [ ] Check whether `packages/contracts` exists in this branch.
+- [ ] If it exists, add coding-agent schemas there.
+- [ ] If it does not exist, decide between:
+  - Create `packages/contracts`.
+  - Start in `packages/gateway/src/contracts` and schedule package extraction.
+- [ ] Update `pnpm-workspace.yaml` if a new package is added.
+- [ ] Update package imports without creating circular dependencies.
+
+Tests:
+
+- [ ] Add package-level typecheck/test scripts if creating a new package.
+- [ ] Add schema parse tests.
+
+### 1.2 ID And Error Schemas
+
+- [ ] Add schemas for runtime ID, provider ID, project ID/slug, task ID, thread ID, event ID, approval ID, terminal session ID, cursor, ISO timestamp, safe display string, bounded text.
+- [ ] Add `SafeClientError` schema with `code`, `safeMessage`, `retryable`, optional `recoveryActions`.
+- [ ] Add helper tests for valid/invalid IDs and text bounds.
+
+Acceptance:
+
+- [ ] Invalid IDs reject traversal, empty strings, whitespace-only, overly long values, and unsafe characters.
+- [ ] Safe errors reject long/internal-looking messages.
+
+### 1.3 Runtime Summary Schemas
+
+- [ ] Add `RuntimeTarget`.
+- [ ] Add `RuntimeCapability`.
+- [ ] Add `RuntimeLimits`.
+- [ ] Add `RuntimeSummary`.
+- [ ] Add bounded list metadata: `hasMore`, `nextCursor`, `limit`.
+- [ ] Add parse tests for truncated lists and missing optional capabilities.
+
+Acceptance:
+
+- [ ] Summary cannot include terminal output, file contents, provider logs, tokens, or raw errors.
+
+### 1.4 Agent Provider Schemas
+
+- [ ] Add `AgentProviderSummary`.
+- [ ] Add `SafeSetupAction`.
+- [ ] Add provider availability/auth/install enums.
+- [ ] Add supported modes and sandbox/approval policy enums.
+- [ ] Add tests rejecting raw command setup actions unless explicitly marked foreground terminal and bounded.
+
+Acceptance:
+
+- [ ] Unknown providers can be represented only through validated custom provider shape.
+- [ ] Provider display metadata is safe.
+
+### 1.5 Agent Thread Schemas
+
+- [ ] Add `CreateAgentThreadRequest`.
+- [ ] Add `AgentThreadSummary`.
+- [ ] Add `AgentThreadStatus`.
+- [ ] Add `AgentAttachment`.
+- [ ] Add `AgentThreadSnapshot`.
+- [ ] Add idempotency via `clientRequestId`.
+- [ ] Add tests for prompt/attachment bounds.
+
+Acceptance:
+
+- [ ] Create request requires provider and prompt.
+- [ ] Optional project/task/session/worktree references validate independently.
+
+### 1.6 Thread Event Schemas
+
+- [ ] Add discriminated union for thread events.
+- [ ] Include lifecycle, text delta, tool activity, approval, input request, file change, review ready, terminal bound, safe error, completion.
+- [ ] Add schema tests for each event type.
+- [ ] Add tests rejecting unknown required fields, unsafe text lengths, and malformed nested payloads.
+
+Acceptance:
+
+- [ ] Event union is extensible without crashing older clients.
+
+### 1.7 Approval Schemas
+
+- [ ] Add `AgentApprovalRequest`.
+- [ ] Add `ApprovalDecisionRequest`.
+- [ ] Add `UserInputRequest`.
+- [ ] Add `UserInputAnswerRequest`.
+- [ ] Add allowed decision enum.
+- [ ] Add risk/action kind enums.
+- [ ] Add preview bounds.
+
+Acceptance:
+
+- [ ] Approval preview cannot contain unbounded raw command output.
+- [ ] Decisions include idempotency/correlation.
+
+### 1.8 Terminal Schemas
+
+- [ ] Align with existing terminal frame contracts.
+- [ ] Add or extend client/server frame schemas with attach, input, resize, detach, attached, output, replay gap, replay end, exit, safe error.
+- [ ] Add clamp bounds for cols/rows.
+- [ ] Add input size bounds.
+- [ ] Add terminal session summary schema.
+
+Acceptance:
+
+- [ ] Existing mobile terminal parser can migrate to shared frame schema or adapter tests.
+
+### 1.9 File, Review, Preview Schemas
+
+- [ ] Add project file browse/search/read/write request and response schemas if not already canonical.
+- [ ] Add file metadata with etag/base revision.
+- [ ] Add review snapshot, file diff, hunk metadata, partial diff notice.
+- [ ] Add preview session summary and status.
+- [ ] Add tests for path traversal rejection and large diff truncation markers.
+
+Acceptance:
+
+- [ ] File write schema includes conflict token.
+- [ ] Review schema supports partial data safely.
+
+## Phase 2 - Gateway Read Models And Summary
+
+Goal: expose a read-only runtime summary that desktop/mobile/shell can hydrate from without changing existing behavior.
+
+### 2.1 Runtime Summary Service
+
+- [ ] Create gateway service module for runtime summary.
+- [ ] Gather selected runtime target.
+- [ ] Gather capability flags.
+- [ ] Gather safe provider summaries from current agent/tool install state.
+- [ ] Gather bounded projects/tasks if available.
+- [ ] Gather bounded active threads once thread store exists; initially return empty list.
+- [ ] Gather bounded terminal sessions from existing canonical session list.
+- [ ] Gather bounded recent activity from existing workspace events.
+- [ ] Include server time and limits.
+
+Tests:
+
+- [ ] Unit test caps and stable sort.
+- [ ] Unit test no sensitive fields.
+- [ ] Unit test unavailable dependencies produce safe partial summary.
+
+### 2.2 Runtime Summary Route
+
+- [ ] Add authenticated `GET /api/coding-agents/summary` or chosen canonical route.
+- [ ] Validate auth source.
+- [ ] Map errors to safe errors.
+- [ ] Add route tests for authenticated success, unauthenticated failure, dependency unavailable, and capped lists.
+
+Acceptance:
+
+- [ ] No public access.
+- [ ] No raw internal errors.
+
+### 2.3 Provider Registry Read Path
+
+- [ ] Add provider registry service that normalizes current coding tools and setup state.
+- [ ] Integrate existing onboarding agent credential status where applicable.
+- [ ] Add timeout-bound health checks.
+- [ ] Add TTL cache with max size.
+- [ ] Add safe setup actions.
+
+Tests:
+
+- [ ] Provider installed/authenticated.
+- [ ] Provider missing.
+- [ ] Provider auth required.
+- [ ] Health timeout.
+- [ ] Unknown provider config rejected or marked unavailable safely.
+
+### 2.4 Terminal Session Summary Adapter
+
+- [ ] Reuse canonical `/api/terminal/sessions` model where possible.
+- [ ] Add adapter to shared `TerminalSessionSummary`.
+- [ ] Mark attachable vs non-attachable sessions explicitly.
+- [ ] Do not show orchestrator-only records as attachable.
+
+Tests:
+
+- [ ] Attachable session appears.
+- [ ] Non-attachable session excluded or marked non-attachable.
+- [ ] Session list capped.
+
+## Phase 3 - Thread Store And Events
+
+Goal: introduce canonical agent thread lifecycle without requiring clients to know provider internals.
+
+### 3.1 Storage Design
+
+- [ ] Decide canonical store for thread metadata/events: owner Postgres/Kysely or existing kernel conversation store.
+- [ ] Document source of truth in `current-state.md` or `storage-decision.md`.
+- [ ] Define transaction boundaries.
+- [ ] Define acceptable orphan states.
+- [ ] Define event retention and compaction strategy.
+
+Acceptance:
+
+- [ ] No new embedded DB persistence.
+- [ ] Multi-write operations use transaction or atomic statement.
+
+### 3.2 Thread Create Service
+
+- [ ] Add `createThread` service with idempotent `clientRequestId`.
+- [ ] Validate provider and runtime availability.
+- [ ] Insert thread + initial event atomically.
+- [ ] Return accepted snapshot.
+- [ ] Enqueue provider start separately.
+
+Tests:
+
+- [ ] Valid create.
+- [ ] Duplicate `clientRequestId` returns existing thread.
+- [ ] Invalid provider rejected safely.
+- [ ] Missing auth rejected.
+- [ ] Transaction failure does not create orphan event.
+
+### 3.3 Thread Events Service
+
+- [ ] Add append event function.
+- [ ] Add replay by cursor.
+- [ ] Add bounded event window.
+- [ ] Add live subscriber registry with cap and stale cleanup.
+- [ ] Add shutdown drain.
+- [ ] Add idempotent event handling if provider emits duplicates.
+
+Tests:
+
+- [ ] Replay ordered events.
+- [ ] Replay from cursor.
+- [ ] Cursor too old reports gap or bounded replay state.
+- [ ] Subscriber failure isolated.
+- [ ] Stale subscriber evicted.
+
+### 3.4 Thread Routes
+
+- [ ] `POST /api/coding-agents/threads`
+- [ ] `GET /api/coding-agents/threads`
+- [ ] `GET /api/coding-agents/threads/:threadId`
+- [ ] `POST /api/coding-agents/threads/:threadId/abort`
+- [ ] `GET /api/coding-agents/threads/:threadId/events`
+
+Tests:
+
+- [ ] Body limit on mutating routes.
+- [ ] Route param validation.
+- [ ] Ownership checks.
+- [ ] Safe error mapping.
+- [ ] Abort idempotency.
+
+### 3.5 Thread WebSocket
+
+- [ ] Add thread event stream WebSocket or extend existing runtime WS.
+- [ ] Authenticate before success.
+- [ ] Support cursor replay.
+- [ ] Validate incoming client frames if bidirectional.
+- [ ] Keep max subscribers per owner/runtime/thread.
+- [ ] Add keepalive if needed.
+
+Tests:
+
+- [ ] Unauthenticated rejected.
+- [ ] Malformed frame rejected.
+- [ ] Replay then live event delivered.
+- [ ] Shutdown drains.
+
+## Phase 4 - Provider Runtime Integration
+
+Goal: make threads start actual coding-agent provider work through the Matrix runtime.
+
+### 4.1 Provider Adapter Interface
+
+- [ ] Define provider adapter interface:
+  - `getSummary`
+  - `healthCheck`
+  - `buildSetupAction`
+  - `startThread`
+  - `abortThread`
+  - `submitApproval`
+  - `submitInput`
+- [ ] Keep provider-specific logic out of clients.
+- [ ] Normalize provider events to `AgentThreadEvent`.
+
+Tests:
+
+- [ ] Fake provider emits normalized events.
+- [ ] Provider error maps to safe thread error.
+- [ ] Abort maps correctly.
+
+### 4.2 First Provider Path
+
+- [ ] Select the first existing provider path already most integrated with Matrix.
+- [ ] Implement adapter through existing kernel/dispatcher/session manager.
+- [ ] Bind provider run to project/task/session when supplied.
+- [ ] Stream assistant text, tool activity, status, approval/input requests, and completion.
+
+Tests:
+
+- [ ] Start run with fake provider.
+- [ ] Start run with real provider behind integration flag if safe.
+- [ ] Completion updates thread.
+- [ ] Failure updates thread safely.
+
+### 4.3 Multi-Provider Registry
+
+- [ ] Add additional configured providers after first path is stable.
+- [ ] Add provider-specific setup actions that open foreground terminal sessions.
+- [ ] Add provider auth status refresh.
+- [ ] Add provider model/mode options as safe metadata.
+
+Tests:
+
+- [ ] Multiple providers can be listed.
+- [ ] Thread create picks provider by ID.
+- [ ] Missing provider does not crash dashboard.
+
+### 4.4 Approvals And Input
+
+- [ ] Connect provider approval requests to approval service.
+- [ ] Add approval decision route.
+- [ ] Add user input answer route.
+- [ ] Ensure repeated decisions are idempotent.
+- [ ] Broadcast resolved state to all connected shells.
+
+Tests:
+
+- [ ] Desktop and mobile simulated clients race decision; only one applies.
+- [ ] Expired approval safely rejected.
+- [ ] Decline/cancel unblock thread correctly.
+
+## Phase 5 - Desktop Read-Only Agent Workspace
+
+Goal: desktop can view runtime summary, providers, threads, terminal sessions, and safe statuses without creating runs yet.
+
+### 5.1 Desktop Runtime Client
+
+- [ ] Add trusted-core runtime client for summary route.
+- [ ] Add safe error mapper.
+- [ ] Add typed IPC channel `runtime:get-summary`.
+- [ ] Add tests for IPC validation.
+- [ ] Add reconnect/refresh state in renderer store.
+
+Acceptance:
+
+- [ ] Renderer does not receive bearer credential.
+- [ ] Runtime switch refreshes summary.
+
+### 5.2 Desktop Agent Dashboard UI
+
+- [ ] Add feature-flagged dashboard route/view.
+- [ ] Show runtime status.
+- [ ] Show provider cards.
+- [ ] Show active threads.
+- [ ] Show terminal sessions.
+- [ ] Show recent activity.
+- [ ] Add empty states and setup-required states.
+
+Tests:
+
+- [ ] Renderer unit tests for summary states.
+- [ ] Safe error rendering tests.
+
+Manual:
+
+- [ ] Sign in.
+- [ ] Runtime switch.
+- [ ] Existing embeds still work.
+- [ ] Existing settings still work.
+
+### 5.3 Desktop Navigation Integration
+
+- [ ] Add command palette/menu entry for agent workspace.
+- [ ] Add notification focus target parser without sending notifications yet.
+- [ ] Persist last selected thread/project UI state safely.
+- [ ] Validate deep link targets.
+
+Tests:
+
+- [ ] Invalid target rejected.
+- [ ] Last selected stale target falls back.
+
+## Phase 6 - Mobile Read-Only Agent Workspace
+
+Goal: mobile SDK 57 can view the same runtime summary and recent coding-agent state without creating runs yet.
+
+### 6.1 Mobile Runtime Client
+
+- [ ] Add typed runtime summary fetch wrapper to `apps/mobile/lib`.
+- [ ] Reuse current `GatewayClient` auth/token behavior.
+- [ ] Add parser tests.
+- [ ] Add timeout and safe error handling.
+
+Tests:
+
+- [ ] Summary success.
+- [ ] Auth failure.
+- [ ] Safe partial summary.
+- [ ] Invalid payload rejected safely.
+
+### 6.2 Mobile State And Resume
+
+- [ ] Add mobile agent/workspace resume parser.
+- [ ] Store only safe IDs and timestamp.
+- [ ] Reconcile persisted state against summary.
+- [ ] Add reducer/helper tests.
+
+Acceptance:
+
+- [ ] Stale thread/session/project references are dropped.
+
+### 6.3 Mobile Agent Screens
+
+- [ ] Add `/agents` recent work screen.
+- [ ] Add provider list section.
+- [ ] Add active threads list.
+- [ ] Add terminal sessions section.
+- [ ] Add safe empty/loading/offline states.
+- [ ] Preserve existing tabs/routes.
+
+Tests:
+
+- [ ] Render loading.
+- [ ] Render empty.
+- [ ] Render providers/threads/sessions.
+- [ ] Render safe error.
+
+Manual:
+
+- [ ] Chat tab works.
+- [ ] Terminal tab works.
+- [ ] Apps tab works.
+- [ ] Canvas entry works.
+- [ ] Settings works.
+
+## Phase 7 - Thread Creation And Composer
+
+Goal: desktop and mobile can create new coding-agent runs through the same gateway contract.
+
+### 7.1 Shared Composer Model
+
+- [ ] Define composer view model fields:
+  - provider ID
+  - prompt
+  - project/task/session target
+  - mode
+  - approval policy
+  - sandbox mode
+  - attachments
+- [ ] Add pure validation helpers.
+- [ ] Add tests.
+
+### 7.2 Desktop Composer
+
+- [ ] Add global composer UI.
+- [ ] Add provider picker.
+- [ ] Add project/task/session target picker.
+- [ ] Add create thread IPC.
+- [ ] Navigate to thread on accepted create.
+- [ ] Show safe create failure.
+
+Tests:
+
+- [ ] Composer validation.
+- [ ] IPC request validation.
+- [ ] Create success navigation.
+- [ ] Safe failure.
+
+### 7.3 Mobile Composer
+
+- [ ] Add `/agents/new`.
+- [ ] Add provider picker sheet.
+- [ ] Add project/task/session selectors with mobile layout.
+- [ ] Submit create request.
+- [ ] Navigate to thread detail on accepted create.
+- [ ] Preserve typed prompt when provider picker opens/closes.
+
+Tests:
+
+- [ ] Required prompt/provider validation.
+- [ ] Create success.
+- [ ] Create failure safe message.
+- [ ] Keyboard/safe-area snapshot or component test where feasible.
+
+### 7.4 Thread Event Subscription
+
+- [ ] Desktop subscribes to thread stream on thread detail.
+- [ ] Mobile subscribes to thread stream on detail route.
+- [ ] Reducers handle replay + live events.
+- [ ] Unknown events do not crash UI.
+
+Tests:
+
+- [ ] Reducer idempotency.
+- [ ] Text delta accumulation.
+- [ ] Tool event grouping.
+- [ ] Completion status.
+
+## Phase 8 - Approvals, Input Requests, And Attention
+
+Goal: users can respond to provider approval and input prompts from desktop or mobile.
+
+### 8.1 Gateway Approval Routes
+
+- [ ] Add decision route.
+- [ ] Add user input answer route.
+- [ ] Add idempotency.
+- [ ] Add event broadcast on resolution.
+- [ ] Add expiry handling.
+
+Tests:
+
+- [ ] Approve.
+- [ ] Approve for session when allowed.
+- [ ] Decline.
+- [ ] Cancel.
+- [ ] Stale duplicate.
+- [ ] Expired.
+- [ ] Unauthorized.
+
+### 8.2 Desktop Approval UI
+
+- [ ] Add approval card in thread detail.
+- [ ] Add approval inspector/attention badge.
+- [ ] Add notification when unfocused.
+- [ ] Add click-through to thread.
+- [ ] Coalesce repeated notifications.
+
+Tests:
+
+- [ ] Approval card renders safe preview.
+- [ ] Decision submit disables buttons.
+- [ ] Notification payload validates.
+
+### 8.3 Mobile Approval UI
+
+- [ ] Add approval card/sheet in thread detail.
+- [ ] Add push/local notification integration if existing push path supports it.
+- [ ] Add safe decision states.
+- [ ] Ensure app resume refreshes pending approvals.
+
+Tests:
+
+- [ ] Approval render.
+- [ ] Decision submit.
+- [ ] Duplicate resolved event.
+- [ ] Background/resume reconciliation helper.
+
+## Phase 9 - Terminal Binding And Cross-Shell Sessions
+
+Goal: agent threads and project workspaces can bind to named remote terminal sessions across desktop and mobile.
+
+### 9.1 Gateway Terminal Binding
+
+- [ ] Add thread-to-terminal binding model.
+- [ ] Add create/attach session helpers if missing.
+- [ ] Add terminal session summary to thread snapshot.
+- [ ] Ensure process state and attachment state remain distinct.
+
+Tests:
+
+- [ ] Bind existing session.
+- [ ] Create new session for thread.
+- [ ] Detach does not end process.
+- [ ] Terminate ends process and updates summaries.
+
+### 9.2 Desktop Terminal Panel Integration
+
+- [ ] Add terminal panel to agent workspace.
+- [ ] Reuse existing terminal runtime where possible.
+- [ ] Attach only focused terminal.
+- [ ] Background panels keep bounded buffer.
+- [ ] Add replay gap marker.
+
+Tests:
+
+- [ ] Attach/detach lifecycle.
+- [ ] Resize coalescing.
+- [ ] Fatal `session_not_found` stops retry.
+
+### 9.3 Mobile Terminal Integration
+
+- [ ] Add thread terminal route linking to existing terminal client.
+- [ ] Preserve existing terminal tab.
+- [ ] Add from-thread attach path.
+- [ ] Add resume state update.
+- [ ] Add safe ended-session state.
+
+Tests:
+
+- [ ] Thread terminal attach.
+- [ ] Existing terminal tab unaffected.
+- [ ] Ended state.
+
+### 9.4 Native Mobile Terminal Spike
+
+- [ ] Create separate spike branch or PR.
+- [ ] Evaluate native terminal rendering against SDK 57.
+- [ ] Verify iOS and Android build constraints.
+- [ ] Verify hardware keyboard, soft keyboard, paste, resize, ANSI, scrollback.
+- [ ] Add feature flag.
+- [ ] Keep WebView fallback.
+
+Acceptance:
+
+- [ ] No native terminal replacement lands without device validation.
+
+## Phase 10 - Files, Review, And Diff
+
+Goal: users can inspect files and review agent changes from both shells.
+
+### 10.1 Gateway File Contracts
+
+- [ ] Add/normalize browse/search/read/write file endpoints.
+- [ ] Server-side path validation.
+- [ ] Etag/base revision on reads.
+- [ ] Conflict-safe write.
+- [ ] Body limits.
+
+Tests:
+
+- [ ] Traversal rejected.
+- [ ] Read valid file.
+- [ ] Write with matching etag.
+- [ ] Write conflict.
+- [ ] Oversized write rejected.
+
+### 10.2 Gateway Review Snapshot
+
+- [ ] Add review snapshot service for thread/project/task.
+- [ ] Include file list, hunks, additions/deletions, partial/truncated markers.
+- [ ] Add large diff limits.
+- [ ] Add safe error mapping.
+
+Tests:
+
+- [ ] Small diff full snapshot.
+- [ ] Large diff partial snapshot.
+- [ ] Binary file marker.
+- [ ] Unauthorized project rejected.
+
+### 10.3 Desktop Review Panel
+
+- [ ] Add file list.
+- [ ] Add diff renderer.
+- [ ] Add hunk selection.
+- [ ] Add ask-agent-follow-up action.
+- [ ] Add partial diff notice.
+
+Tests:
+
+- [ ] Render diff.
+- [ ] Render partial notice.
+- [ ] Follow-up prompt context generated with structured refs.
+
+### 10.4 Mobile Review Screens
+
+- [ ] Add `[threadId]/review`.
+- [ ] Add file navigator.
+- [ ] Add hunk rendering.
+- [ ] Add follow-up action.
+- [ ] Ensure large diffs remain scrollable.
+
+Tests:
+
+- [ ] Render changed files.
+- [ ] Render hunk.
+- [ ] Partial notice.
+- [ ] Follow-up action.
+
+## Phase 11 - Preview And App Runtime Integration
+
+Goal: agent workspaces can open safe previews and Matrix apps without weakening existing embed/session isolation.
+
+### 11.1 Preview Summary
+
+- [ ] Add preview capability to runtime summary.
+- [ ] List running local dev servers or app previews safely.
+- [ ] Use origin allowlist.
+- [ ] Return coarse health.
+
+Tests:
+
+- [ ] Safe preview listed.
+- [ ] Foreign origin rejected.
+- [ ] Health failure safe.
+
+### 11.2 Desktop Preview Panel
+
+- [ ] Reuse existing embed/session isolation.
+- [ ] Add preview panel in workspace.
+- [ ] Add reload/open-external controls.
+- [ ] Validate navigation.
+
+Tests:
+
+- [ ] Launch safe preview.
+- [ ] Reject unsafe URL.
+- [ ] Embedded auth failure does not sign out native session.
+
+### 11.3 Mobile Preview
+
+- [ ] Add preview route/screen using existing app runtime frame patterns.
+- [ ] Validate launch URLs.
+- [ ] Provide fallback to open in external browser only for safe HTTPS links.
+- [ ] Preserve app launcher behavior.
+
+Tests:
+
+- [ ] Safe preview route.
+- [ ] Unsafe URL rejected.
+- [ ] Return to thread.
+
+## Phase 12 - Notifications And Attention Routing
+
+Goal: users are notified when agent work completes, fails, or needs input, and click-through focuses the correct shell target.
+
+### 12.1 Attention Model
+
+- [ ] Add attention state to thread summary.
+- [ ] Add attention event types.
+- [ ] Add coalescing rules.
+- [ ] Add read/ack behavior if needed.
+
+Tests:
+
+- [ ] Attention derived from approval request.
+- [ ] Attention clears on approval resolution.
+- [ ] Completion notification created once.
+
+### 12.2 Desktop Notifications
+
+- [ ] Map thread attention/completion to native notifications.
+- [ ] Validate click payload.
+- [ ] Focus existing window.
+- [ ] Navigate to thread.
+- [ ] Set badge count for active attention.
+
+Tests:
+
+- [ ] Payload schema rejects invalid thread IDs.
+- [ ] Coalescing.
+
+### 12.3 Mobile Notifications
+
+- [ ] Evaluate existing push/local notification path.
+- [ ] Add notification type for thread attention if supported.
+- [ ] Ensure tapping notification opens thread safely after auth.
+- [ ] If unsupported in first phase, show in-app attention only and document follow-up.
+
+Tests:
+
+- [ ] Notification payload parser.
+- [ ] Stale target fallback.
+
+## Phase 13 - Desktop Polish And Power User Flow
+
+Goal: desktop feels like a high-quality developer cockpit.
+
+### 13.1 Keyboard Flow
+
+- [ ] Command palette actions:
+  - New agent thread.
+  - Open thread.
+  - Open project.
+  - Open terminal.
+  - Open review.
+  - Open provider setup.
+- [ ] Shortcuts for terminal focus, composer, thread list, review, file search.
+- [ ] Menu entries for agent workspace.
+
+Tests:
+
+- [ ] Shortcut/command model helpers.
+- [ ] Command availability by runtime capability.
+
+### 13.2 Workspace Layout
+
+- [ ] Add resizable panel strip.
+- [ ] Persist per-project/task/thread layout.
+- [ ] Use LRU for heavy live panels.
+- [ ] Respect minimum widths.
+- [ ] Avoid card-inside-card layout.
+
+Tests:
+
+- [ ] Layout parser.
+- [ ] Stale panel references dropped.
+- [ ] LRU releases background live sockets.
+
+### 13.3 Settings
+
+- [ ] Add provider settings section.
+- [ ] Show install/auth status.
+- [ ] Open foreground setup terminal.
+- [ ] Refresh health.
+- [ ] Keep existing account/runtime/billing/integration settings.
+
+Tests:
+
+- [ ] Provider setting state.
+- [ ] Setup action validation.
+
+## Phase 14 - Mobile Polish And Daily Use
+
+Goal: mobile becomes a strong day-to-day interface, not just a companion viewer.
+
+### 14.1 Recent Work Home
+
+- [ ] Add recent active threads.
+- [ ] Add pending approvals.
+- [ ] Add running terminal sessions.
+- [ ] Add provider setup warnings.
+- [ ] Add quick new prompt.
+
+Tests:
+
+- [ ] Recent work sorting.
+- [ ] Pending approval prominence.
+
+### 14.2 Thread Detail UX
+
+- [ ] Improve transcript rendering.
+- [ ] Group tool activity.
+- [ ] Add jump to latest.
+- [ ] Add status/attention banner.
+- [ ] Add follow-up composer.
+- [ ] Add terminal/review/files actions.
+
+Tests:
+
+- [ ] Transcript reducer/rendering.
+- [ ] Tool group collapsed/expanded state.
+
+### 14.3 Mobile Ergonomics
+
+- [ ] Keyboard avoidance.
+- [ ] Safe area support.
+- [ ] Landscape support.
+- [ ] Offline/reconnecting banners.
+- [ ] Pull-to-refresh summary.
+- [ ] Haptics for successful approval/submit where appropriate.
+
+Tests:
+
+- [ ] Layout helper tests where possible.
+- [ ] Manual device checklist.
+
+## Phase 15 - Public Docs And Developer Guides
+
+Goal: users and future agents can understand and extend the feature.
+
+### 15.1 Internal Developer Guide
+
+- [ ] Add docs for contracts, event reducers, provider adapters, terminal binding, approval flow, and client state ownership.
+- [ ] Include examples of adding a new provider.
+- [ ] Include examples of adding a new thread event type.
+- [ ] Include security checklist.
+
+Suggested path:
+
+- [ ] `docs/dev/coding-agent-shells.md`
+
+### 15.2 Public Docs
+
+- [ ] Add or update public docs under `www/content/docs/`.
+- [ ] Explain desktop/mobile coding-agent workflows.
+- [ ] Explain remote Matrix computer model without implementation secrets.
+- [ ] Explain provider setup at a user level.
+- [ ] Explain terminal/session continuity.
+
+### 15.3 Operator Runbook
+
+- [ ] Add support notes for provider setup failures.
+- [ ] Add runtime offline troubleshooting.
+- [ ] Add mobile SDK/native terminal validation notes if native terminal lands.
+- [ ] Keep private/customer identifiers out of public repo docs.
+
+## Phase 16 - End-To-End Validation
+
+Goal: prove cross-shell coding-agent workflows before broad rollout.
+
+### 16.1 E2E Scenarios
+
+- [ ] Desktop sign in -> create thread -> stream completion.
+- [ ] Mobile sign in -> open same thread -> send follow-up.
+- [ ] Desktop approval request -> mobile approves -> desktop sees resolved.
+- [ ] Desktop creates terminal -> mobile attaches -> desktop reattaches.
+- [ ] Agent changes file -> desktop review -> mobile review.
+- [ ] Runtime switch -> old streams close -> new summary hydrates.
+- [ ] Network loss -> replay resumes without duplicate terminal output.
+- [ ] Provider setup required -> foreground terminal setup -> provider appears available.
+
+### 16.2 Security Validation
+
+- [ ] Unauthenticated routes reject.
+- [ ] Invalid IDs reject.
+- [ ] Path traversal rejects.
+- [ ] Oversized frame rejects.
+- [ ] Oversized prompt/attachment rejects.
+- [ ] WebSocket auth setup awaited before success.
+- [ ] Subscriber cap enforced.
+- [ ] Safe errors only in UI.
+- [ ] Desktop renderer never receives credential.
+- [ ] Mobile persisted state contains no sensitive data.
+
+### 16.3 Performance Validation
+
+- [ ] Runtime summary p95 under target.
+- [ ] Thread event reduction remains responsive for long transcripts.
+- [ ] Terminal output ring buffer caps memory.
+- [ ] Desktop with multiple cached workspaces stays responsive.
+- [ ] Mobile thread detail scroll remains responsive.
+- [ ] Large diff opens partial view instead of freezing.
+
+## Phase 17 - Rollout And Cleanup
+
+### 17.1 Flag Rollout
+
+- [ ] Enable read-only summary in dev.
+- [ ] Enable desktop dashboard in dev.
+- [ ] Enable mobile dashboard in dev.
+- [ ] Enable thread creation for internal users.
+- [ ] Enable approvals.
+- [ ] Enable review/preview.
+- [ ] Enable native terminal only after spike and fallback validation.
+
+### 17.2 Compatibility Cleanup
+
+- [ ] Remove temporary compatibility adapters only after all clients migrate.
+- [ ] Keep old route aliases until release notes and host-bundle compatibility are clear.
+- [ ] Document deprecations.
+- [ ] Verify host-bundle and app-shell deployment implications.
+
+### 17.3 Release Checklist
+
+- [ ] Host-bundle build path documented if gateway/shell changes affect customer VPS.
+- [ ] Platform/app-shell deployment path documented if pre-VPS auth/settings surfaces changed.
+- [ ] Desktop release channel impact documented.
+- [ ] Mobile SDK 57 native build impact documented.
+- [ ] Rollback path documented.
+
+## Cross-Cutting Guardrails
+
+### Do
+
+- [ ] Build shared contracts first.
+- [ ] Keep runtime source of truth server-side.
+- [ ] Use feature flags.
+- [ ] Reuse existing terminal/session routes where possible.
+- [ ] Reuse existing desktop auth/embed/updater patterns.
+- [ ] Reuse existing mobile auth/offline/persistence patterns.
+- [ ] Add pure reducers for event state.
+- [ ] Make every stream resumable.
+- [ ] Cap every list, cache, buffer, and subscriber set.
+- [ ] Prefer additive migrations.
+
+### Do Not
+
+- [ ] Do not put provider-specific branching into mobile/desktop UI when the gateway can normalize it.
+- [ ] Do not show raw provider command output as errors.
+- [ ] Do not store terminal output or transcripts in mobile AsyncStorage.
+- [ ] Do not pass bearer credentials through desktop renderer.
+- [ ] Do not create a second terminal session model just for agent threads.
+- [ ] Do not make desktop/mobile required for the kernel to work.
+- [ ] Do not break Canvas or current mobile launcher behavior.
+- [ ] Do not replace mobile terminal rendering without fallback.
+- [ ] Do not introduce new persistence tech for this feature.
+- [ ] Do not hide interactive provider setup in a background job when the user needs to act.
+
+## Suggested PR Slices
+
+1. **contracts(agent-shells): add schemas and tests**
+   - Contract package or gateway-local contracts only.
+   - No runtime behavior.
+
+2. **feat(gateway): expose read-only coding agent summary**
+   - Runtime summary route.
+   - Provider/session adapters.
+   - Focused tests.
+
+3. **feat(desktop): add read-only agent workspace**
+   - Trusted-core summary IPC.
+   - Renderer dashboard.
+   - Feature flag.
+
+4. **feat(mobile): add read-only agent workspace**
+   - Summary client.
+   - Recent work screen.
+   - State reconciliation.
+
+5. **feat(gateway): create and stream agent threads**
+   - Thread store/events/routes/WS.
+   - Fake provider tests.
+
+6. **feat(desktop): create and monitor agent threads**
+   - Composer.
+   - Thread detail stream.
+   - Reducer tests.
+
+7. **feat(mobile): create and monitor agent threads**
+   - Mobile composer.
+   - Thread detail stream.
+   - Reducer tests.
+
+8. **feat(agents): support approvals and input requests**
+   - Gateway lifecycle.
+   - Desktop/mobile UI.
+   - Idempotency tests.
+
+9. **feat(agents): bind terminal sessions to threads**
+   - Gateway binding.
+   - Desktop/mobile terminal integration.
+
+10. **feat(review): add file and diff review surfaces**
+    - Gateway review snapshots.
+    - Desktop review panel.
+    - Mobile review route.
+
+11. **feat(preview): add workspace preview integration**
+    - Safe previews.
+    - Desktop panel.
+    - Mobile screen.
+
+12. **feat(notifications): route agent attention**
+    - Desktop native notifications.
+    - Mobile notification path or documented in-app-only first stage.
+
+13. **docs(agent-shells): publish developer and user docs**
+    - Internal developer guide.
+    - Public docs.
+    - Support notes.
+
+## Open Questions
+
+- [ ] What is the canonical existing source of truth for project/task/thread records today: gateway workspace files, owner Postgres, kernel conversation store, or a combination?
+- [ ] Which first provider path should be used for thread creation in the first implementation PR?
+- [ ] Does the current terminal WebSocket already carry monotonic sequence numbers in all environments, or do we need a compatibility replay adapter?
+- [ ] Should desktop renderer subscribe to thread streams directly with injected auth headers, or should trusted core own streams and bridge events through IPC?
+- [ ] Which mobile route should be the default entry point for agent work: existing Mission Control or new `/agents` stack?
+- [ ] What is the minimum public-doc update required before internal rollout?
+- [ ] Which provider setup actions must be foreground terminal sessions because they need user interaction?
+- [ ] What is the safe cap for active thread event subscribers per runtime?
+- [ ] What are the exact memory limits for desktop cached workspaces and mobile transcript windows?
+- [ ] When native mobile terminal lands, which devices and OS versions are required for validation?

--- a/specs/105-coding-agent-shells/tasks.md
+++ b/specs/105-coding-agent-shells/tasks.md
@@ -1,7 +1,7 @@
 # Tasks: Coding Agent Shells
 
-**Status**: Draft  
-**Branch**: `chore/mobile-expo-sdk-57`  
+**Status**: Draft
+**Branch**: `chore/mobile-expo-sdk-57`
 **Rule**: Preserve all existing desktop and mobile functionality. Add coding-agent capabilities incrementally behind contracts, tests, and feature flags.
 
 ## Agent Instructions


### PR DESCRIPTION
## Summary
- Establish the coding-agent desktop/mobile shell spec package on the Expo SDK 57 mobile base.
- Document the headless runtime, multi-shell boundaries, phased implementation plan, and security gates for the stacked implementation.
- Carry the mobile SDK 57 base required by this feature branch.

## Tests
- `bun run typecheck` passed from the current stack worktree.
- Mobile Jest was run during the post-#740 stack rebase after aligning the SDK 57 mocks.
- This PR is the spec/base layer; implementation tests live in the follow-on stack PRs.

## Mandatory Invariants
- Source of truth: this layer defines spec artifacts and preserves Matrix gateway/runtime as source of truth for coding-agent state.
- Lock/transaction scope: no new runtime mutation path is introduced by the spec documents.
- Acceptable orphan states: implementation slices must document and test orphan handling before adding mutating runtime behavior.
- Auth source of truth: the spec requires gateway auth and validated contracts at every HTTP, WebSocket, IPC, persisted-state, and external-input boundary.
- Deferred scope: runtime behavior, desktop/mobile UI, approvals, terminal binding, review, preview, and docs publication are implemented in follow-on stacked PRs.