### PR TITLE
feat(gateway): add coding agent workspace provider

### DIFF
--- a/packages/gateway/src/agent-launcher.ts
+++ b/packages/gateway/src/agent-launcher.ts
@@ -28,6 +28,7 @@ export interface AgentLaunchInput {
   agent: SupportedAgent;
   cwd: string;
   prompt?: string;
+  mode?: "default" | "plan" | "review" | "full_access";
   sandbox?: AgentLaunchSandbox;
   approvalPolicy?: "untrusted" | "on-request" | "on-failure" | "never";
   runtimeHome?: string;
@@ -109,6 +110,16 @@ function authStatusArgs(agent: SupportedAgent): string[] {
   return agent === "codex" ? ["login", "status"] : ["auth", "status"];
 }
 
+function codexModeArgs(mode?: AgentLaunchInput["mode"]): string[] {
+  return mode === "review" ? ["review"] : [];
+}
+
+function codexPrompt(prompt: string | undefined, mode?: AgentLaunchInput["mode"]): string | undefined {
+  if (mode !== "plan") return prompt;
+  const planPrefix = "Plan the work first. Do not modify files until the plan is clear.";
+  return prompt ? `${planPrefix}\n\n${prompt}` : planPrefix;
+}
+
 export function buildAgentLaunch(input: AgentLaunchInput): AgentLaunchSpec {
   const parsed = SupportedAgentSchema.parse(input.agent);
   const command = AGENTS[parsed].command;
@@ -125,7 +136,8 @@ export function buildAgentLaunch(input: AgentLaunchInput): AgentLaunchSpec {
           "exec",
           "--skip-git-repo-check",
           ...codexSandboxArgs(input.sandbox),
-          ...promptArgs(input.prompt),
+          ...codexModeArgs(input.mode),
+          ...promptArgs(codexPrompt(input.prompt, input.mode)),
         ],
         cwd: input.cwd,
         env,

--- a/packages/gateway/src/agent-launcher.ts
+++ b/packages/gateway/src/agent-launcher.ts
@@ -19,6 +19,7 @@ export interface AgentStatus {
 
 export interface AgentLaunchSandbox {
   enabled: boolean;
+  mode?: "read-only" | "workspace-write" | "danger-full-access";
   writableRoots?: string[];
   adminOverride?: boolean;
 }
@@ -28,6 +29,7 @@ export interface AgentLaunchInput {
   cwd: string;
   prompt?: string;
   sandbox?: AgentLaunchSandbox;
+  approvalPolicy?: "untrusted" | "on-request" | "on-failure" | "never";
   runtimeHome?: string;
 }
 
@@ -93,9 +95,12 @@ function codexSandboxArgs(sandbox?: AgentLaunchSandbox): string[] {
     }
     throw new Error("Codex sandbox preflight is required");
   }
-  const args = ["--sandbox", "workspace-write"];
-  for (const root of sandbox.writableRoots ?? []) {
-    args.push("--add-dir", root);
+  const mode = sandbox.mode ?? "workspace-write";
+  const args = ["--sandbox", mode];
+  if (mode === "workspace-write") {
+    for (const root of sandbox.writableRoots ?? []) {
+      args.push("--add-dir", root);
+    }
   }
   return args;
 }
@@ -116,7 +121,7 @@ export function buildAgentLaunch(input: AgentLaunchInput): AgentLaunchSpec {
         command,
         args: [
           "--ask-for-approval",
-          "never",
+          input.approvalPolicy ?? "never",
           "exec",
           "--skip-git-repo-check",
           ...codexSandboxArgs(input.sandbox),

--- a/packages/gateway/src/agent-session-manager.ts
+++ b/packages/gateway/src/agent-session-manager.ts
@@ -17,6 +17,7 @@ import type { createZellijRuntime } from "./zellij-runtime.js";
 
 export type SessionKind = "shell" | "agent";
 export type RuntimeStatus = "starting" | "running" | "idle" | "waiting" | "exited" | "failed" | "degraded";
+type SessionApprovalPolicy = "untrusted" | "on_request" | "on_failure" | "never";
 
 export interface WorkspaceSession {
   id: string;
@@ -73,6 +74,7 @@ const SlugSchema = z.string().regex(PROJECT_SLUG_REGEX);
 const WorktreeIdSchema = z.string().regex(/^wt_[a-z0-9]{12,40}$/);
 const AgentSandboxSchema = z.object({
   enabled: z.boolean(),
+  mode: z.enum(["read-only", "workspace-write", "danger-full-access"]).optional(),
   writableRoots: z.array(z.string().trim().min(1).max(4096)).max(20).optional(),
   adminOverride: z.boolean().optional(),
 }).strict();
@@ -86,6 +88,9 @@ const StartSessionSchema = z.object({
   pr: z.number().int().positive().optional(),
   agent: SupportedAgentSchema.optional(),
   prompt: PromptContentSchema.optional(),
+  mode: z.enum(["default", "plan", "review", "full_access"]).optional(),
+  approvalPolicy: z.enum(["untrusted", "on_request", "on_failure", "never"]).optional(),
+  sandboxMode: z.enum(["read_only", "workspace_write", "full_access"]).optional(),
   runtimePreference: z.enum(["zellij"]).optional(),
   sandbox: AgentSandboxSchema.optional(),
 });
@@ -105,6 +110,12 @@ function nowIso(now?: () => string): string {
 
 function failure(status: number, code: string, message: string, holderId?: string): Failure {
   return { ok: false, status, error: { code, message }, holderId };
+}
+
+function toAgentApprovalPolicy(policy?: SessionApprovalPolicy): "untrusted" | "on-request" | "on-failure" | "never" | undefined {
+  if (policy === "on_request") return "on-request";
+  if (policy === "on_failure") return "on-failure";
+  return policy;
 }
 
 async function pathExists(path: string): Promise<boolean> {
@@ -286,6 +297,7 @@ export function createAgentSessionManager(options: {
             cwd,
             prompt: request.prompt,
             sandbox: request.sandbox,
+            approvalPolicy: toAgentApprovalPolicy(request.approvalPolicy),
           })
           : { command: "bash", args: [], cwd, env: {} };
       } catch (err: unknown) {

--- a/packages/gateway/src/agent-session-manager.ts
+++ b/packages/gateway/src/agent-session-manager.ts
@@ -296,6 +296,7 @@ export function createAgentSessionManager(options: {
             agent: request.agent!,
             cwd,
             prompt: request.prompt,
+            mode: request.mode,
             sandbox: request.sandbox,
             approvalPolicy: toAgentApprovalPolicy(request.approvalPolicy),
           })

--- a/packages/gateway/src/coding-agents/thread-store.ts
+++ b/packages/gateway/src/coding-agents/thread-store.ts
@@ -234,6 +234,9 @@ function applyEvent(thread: StoredThread, event: AgentThreadEvent): StoredThread
   if (event.type === "user_input.requested") {
     return { ...thread, status: "waiting_for_input", attention: "input_required", updatedAt };
   }
+  if (event.type === "terminal.bound") {
+    return { ...thread, terminalSessionId: event.terminalSessionId, updatedAt };
+  }
   if (event.type === "thread.error") {
     return { ...thread, status: "failed", attention: "failed", updatedAt };
   }

--- a/packages/gateway/src/coding-agents/workspace-provider.ts
+++ b/packages/gateway/src/coding-agents/workspace-provider.ts
@@ -1,0 +1,191 @@
+import {
+  AgentThreadEventSchema,
+  ProviderIdSchema,
+  TerminalSessionIdSchema,
+  type AgentProviderSummary,
+  type AgentThreadEvent,
+  type AgentThreadSummary,
+  type SafeSetupAction,
+} from "@matrix-os/contracts";
+import { SupportedAgentSchema, type SupportedAgent } from "../agent-launcher.js";
+import type { WorkspaceSessionOrchestrator } from "../workspace-session-orchestrator.js";
+import type { CodingAgentProviderAdapter } from "./thread-store.js";
+
+type WorkspaceRuntime = Pick<WorkspaceSessionOrchestrator, "startSession" | "stopSession">;
+
+export interface WorkspaceCodingAgentProviderOptions {
+  providerId: string;
+  agent: SupportedAgent;
+  runtime: WorkspaceRuntime;
+}
+
+function sessionIdForThread(threadId: string): string {
+  return `sess_${threadId.slice("thread_".length)}`;
+}
+
+function providerDisplayName(agent: SupportedAgent): string {
+  if (agent === "claude") return "Claude";
+  if (agent === "codex") return "Codex";
+  if (agent === "opencode") return "OpenCode";
+  return "Pi";
+}
+
+function providerKind(agent: SupportedAgent): AgentProviderSummary["kind"] {
+  if (agent === "claude") return "claude";
+  if (agent === "codex") return "codex";
+  if (agent === "opencode") return "opencode";
+  return "custom";
+}
+
+function terminalSessionIdFor(session: {
+  runtime?: { zellijSession?: unknown } | null;
+  terminalSessionId?: unknown;
+  id?: unknown;
+}): string {
+  const candidates = [
+    session.runtime?.zellijSession,
+    session.terminalSessionId,
+    session.id,
+  ];
+  for (const candidate of candidates) {
+    if (typeof candidate === "string" && TerminalSessionIdSchema.safeParse(candidate).success) {
+      return candidate;
+    }
+  }
+  throw new Error("Workspace provider terminal binding failed");
+}
+
+function runningStatusFor(session: { runtime?: { status?: unknown } | null }): "starting" | "running" {
+  return session.runtime?.status === "starting" ? "starting" : "running";
+}
+
+function statusEvent(input: {
+  threadId: string;
+  status: "starting" | "running" | "aborted";
+  now: () => Date;
+  nextEventId: () => string;
+}): AgentThreadEvent {
+  return AgentThreadEventSchema.parse({
+    type: "thread.status",
+    eventId: input.nextEventId(),
+    threadId: input.threadId,
+    occurredAt: input.now().toISOString(),
+    status: input.status,
+  });
+}
+
+function completedEvent(input: {
+  threadId: string;
+  outcome: "aborted";
+  now: () => Date;
+  nextEventId: () => string;
+}): AgentThreadEvent {
+  return AgentThreadEventSchema.parse({
+    type: "thread.completed",
+    eventId: input.nextEventId(),
+    threadId: input.threadId,
+    occurredAt: input.now().toISOString(),
+    outcome: input.outcome,
+  });
+}
+
+export function createWorkspaceCodingAgentProvider(
+  options: WorkspaceCodingAgentProviderOptions,
+): CodingAgentProviderAdapter {
+  const providerId = ProviderIdSchema.parse(options.providerId);
+  const agent = SupportedAgentSchema.parse(options.agent);
+
+  return {
+    providerId,
+    getSummary({ now }) {
+      return {
+        id: providerId,
+        displayName: providerDisplayName(agent),
+        kind: providerKind(agent),
+        availability: "available",
+        installStatus: "installed",
+        authStatus: "authenticated",
+        supportedModes: ["default", "review"],
+        defaultMode: "default",
+        setupActions: [],
+        lastCheckedAt: now().toISOString(),
+      };
+    },
+    healthCheck() {
+      return { ok: true };
+    },
+    buildSetupAction(): SafeSetupAction[] {
+      return [];
+    },
+    async startThread({ principal, thread, request, now, nextEventId }) {
+      const sessionId = sessionIdForThread(thread.id);
+      const result = await options.runtime.startSession({
+        ownerScope: { type: "user", id: principal.userId },
+        request: {
+          sessionId,
+          kind: "agent",
+          agent,
+          prompt: request.prompt,
+          projectSlug: request.projectId,
+          taskId: request.taskId,
+          worktreeId: request.worktreeId,
+          runtimePreference: "zellij",
+        },
+      });
+      if (!result.ok) {
+        throw new Error("Workspace provider start failed");
+      }
+
+      const terminalSessionId = terminalSessionIdFor(result.session);
+      return [
+        statusEvent({
+          threadId: thread.id,
+          status: runningStatusFor(result.session),
+          now,
+          nextEventId,
+        }),
+        AgentThreadEventSchema.parse({
+          type: "terminal.bound",
+          eventId: nextEventId(),
+          threadId: thread.id,
+          occurredAt: now().toISOString(),
+          terminalSessionId,
+        }),
+        AgentThreadEventSchema.parse({
+          type: "assistant.text.delta",
+          eventId: nextEventId(),
+          threadId: thread.id,
+          occurredAt: now().toISOString(),
+          messageId: `msg_${thread.id}`,
+          delta: "Agent session started.",
+        }),
+      ];
+    },
+    async abortThread({ thread, now, nextEventId }) {
+      const result = await options.runtime.stopSession(sessionIdForThread(thread.id));
+      if (!result.ok) {
+        throw new Error("Workspace provider abort failed");
+      }
+      return [
+        statusEvent({
+          threadId: thread.id,
+          status: "aborted",
+          now,
+          nextEventId,
+        }),
+        completedEvent({
+          threadId: thread.id,
+          outcome: "aborted",
+          now,
+          nextEventId,
+        }),
+      ];
+    },
+    submitApproval() {
+      return [];
+    },
+    submitInput() {
+      return [];
+    },
+  };
+}

--- a/packages/gateway/src/coding-agents/workspace-provider.ts
+++ b/packages/gateway/src/coding-agents/workspace-provider.ts
@@ -43,8 +43,8 @@ function terminalSessionIdFor(session: {
   id?: unknown;
 }): string {
   const candidates = [
-    session.runtime?.zellijSession,
     session.terminalSessionId,
+    session.runtime?.zellijSession,
     session.id,
   ];
   for (const candidate of candidates) {
@@ -129,6 +129,9 @@ export function createWorkspaceCodingAgentProvider(
           projectSlug: request.projectId,
           taskId: request.taskId,
           worktreeId: request.worktreeId,
+          mode: request.mode,
+          approvalPolicy: request.approvalPolicy,
+          sandboxMode: request.sandboxMode,
           runtimePreference: "zellij",
         },
       });

--- a/packages/gateway/src/server.ts
+++ b/packages/gateway/src/server.ts
@@ -37,6 +37,10 @@ import { createWorkspaceRoutes } from "./workspace-routes.js";
 import { createElixirSymphonyProxyRoutes } from "./symphony/proxy.js";
 import { createSymphonyRunner } from "./symphony-runner.js";
 import { createAgentLauncher } from "./agent-launcher.js";
+import { createAgentSessionManager } from "./agent-session-manager.js";
+import { createAgentSandbox } from "./agent-sandbox.js";
+import { createWorktreeManager } from "./worktree-manager.js";
+import { createWorkspaceSessionOrchestrator } from "./workspace-session-orchestrator.js";
 import { createZellijRuntime } from "./zellij-runtime.js";
 import { createSessionRuntimeBridge } from "./session-runtime-bridge.js";
 import { createWorkspaceStartupRecovery } from "./workspace-startup-recovery.js";
@@ -91,8 +95,9 @@ import { createAgentCredentialStatusService } from "./onboarding/agent-credentia
 import { createAgentCredentialRoutes } from "./onboarding/agent-credential-routes.js";
 import { createCodingAgentRuntimeSummaryService } from "./coding-agents/runtime-summary.js";
 import { createCodingAgentRoutes } from "./coding-agents/routes.js";
-import { createCodingAgentThreadStore, createFakeCodingAgentProvider } from "./coding-agents/thread-store.js";
+import { createCodingAgentThreadStore, createFakeCodingAgentProvider, type CodingAgentProviderAdapter } from "./coding-agents/thread-store.js";
 import { createCodingAgentThreadStream, threadStreamFrameDataToString } from "./coding-agents/thread-stream.js";
+import { createWorkspaceCodingAgentProvider } from "./coding-agents/workspace-provider.js";
 import { createAgentActionAuditService } from "./onboarding/agent-action-audit.js";
 import { capabilityIdsForConnectedServices, createIntegrationCapabilityService } from "./onboarding/integration-capabilities.js";
 import { createIntegrationCapabilityRoutes } from "./onboarding/integration-capability-routes.js";
@@ -464,10 +469,34 @@ export async function createGateway(config: GatewayConfig) {
       };
     },
   });
-  const codingAgentThreadStore = process.env.MATRIX_CODING_AGENTS_FAKE_PROVIDER === "1"
+  const codingAgentProviders: CodingAgentProviderAdapter[] = [];
+  if (process.env.MATRIX_CODING_AGENTS_WORKSPACE_PROVIDER === "1") {
+    const codingAgentWorktreeManager = createWorktreeManager({ homePath });
+    const codingAgentLauncher = createAgentLauncher({ cwd: homePath, runtimeHome: homePath });
+    const codingAgentSessionManager = createAgentSessionManager({
+      homePath,
+      worktreeManager: codingAgentWorktreeManager,
+      agentLauncher: codingAgentLauncher,
+      zellijRuntime: workspaceZellijRuntime,
+    });
+    const codingAgentWorkspaceRuntime = createWorkspaceSessionOrchestrator({
+      worktreeManager: codingAgentWorktreeManager,
+      agentSessionManager: codingAgentSessionManager,
+      agentSandbox: createAgentSandbox({ homePath }),
+      sessionRuntimeBridge: workspaceSessionRuntimeBridge,
+    });
+    codingAgentProviders.push(createWorkspaceCodingAgentProvider({
+      providerId: "codex",
+      agent: "codex",
+      runtime: codingAgentWorkspaceRuntime,
+    }));
+  } else if (process.env.MATRIX_CODING_AGENTS_FAKE_PROVIDER === "1") {
+    codingAgentProviders.push(createFakeCodingAgentProvider({ providerId: "codex" }));
+  }
+  const codingAgentThreadStore = codingAgentProviders.length > 0
     ? createCodingAgentThreadStore({
       homePath,
-      providers: [createFakeCodingAgentProvider({ providerId: "codex" })],
+      providers: codingAgentProviders,
     })
     : undefined;
   const codingAgentThreadStream = codingAgentThreadStore

--- a/packages/gateway/src/workspace-session-orchestrator.ts
+++ b/packages/gateway/src/workspace-session-orchestrator.ts
@@ -38,6 +38,9 @@ export interface StartWorkspaceSessionRequest {
   kind: "shell" | "agent";
   agent?: SupportedAgent;
   prompt?: string;
+  mode?: "default" | "plan" | "review" | "full_access";
+  approvalPolicy?: "untrusted" | "on_request" | "on_failure" | "never";
+  sandboxMode?: "read_only" | "workspace_write" | "full_access";
   runtimePreference?: "zellij";
   adminSandboxOverride?: boolean;
 }
@@ -82,7 +85,15 @@ async function resolveCodexSandbox(options: {
       sandboxStatus: preflight.sandboxStatus,
     };
   }
-  return { ok: true, sandbox: preflight.sandbox };
+  if (options.request.sandboxMode === "read_only" && preflight.sandbox?.enabled) {
+    return { ok: true, sandbox: { ...preflight.sandbox, mode: "read-only", writableRoots: [] } };
+  }
+  return {
+    ok: true,
+    sandbox: preflight.sandbox?.enabled
+      ? { ...preflight.sandbox, mode: "workspace-write" }
+      : preflight.sandbox,
+  };
 }
 
 export function createWorkspaceSessionOrchestrator(options: {

--- a/packages/gateway/src/workspace-session-orchestrator.ts
+++ b/packages/gateway/src/workspace-session-orchestrator.ts
@@ -88,6 +88,9 @@ async function resolveCodexSandbox(options: {
   if (options.request.sandboxMode === "read_only" && preflight.sandbox?.enabled) {
     return { ok: true, sandbox: { ...preflight.sandbox, mode: "read-only", writableRoots: [] } };
   }
+  if (options.request.sandboxMode === "full_access" && preflight.sandbox?.enabled) {
+    return { ok: true, sandbox: { ...preflight.sandbox, mode: "danger-full-access", writableRoots: [] } };
+  }
   return {
     ok: true,
     sandbox: preflight.sandbox?.enabled

--- a/tests/gateway/agent-launcher.test.ts
+++ b/tests/gateway/agent-launcher.test.ts
@@ -185,6 +185,39 @@ describe("agent-launcher", () => {
     ]);
   });
 
+  it("maps Codex review and plan modes into launch controls", () => {
+    const reviewLaunch = buildAgentLaunch({
+      agent: "codex",
+      cwd: "/home/matrixos/home/projects/repo",
+      prompt: "check this PR",
+      mode: "review",
+      sandbox: { enabled: true, mode: "read-only" },
+    });
+
+    expect(reviewLaunch.args).toEqual([
+      "--ask-for-approval",
+      "never",
+      "exec",
+      "--skip-git-repo-check",
+      "--sandbox",
+      "read-only",
+      "review",
+      "--",
+      "check this PR",
+    ]);
+
+    const planLaunch = buildAgentLaunch({
+      agent: "codex",
+      cwd: "/home/matrixos/home/projects/repo",
+      prompt: "add a dashboard",
+      mode: "plan",
+      sandbox: { enabled: true, mode: "workspace-write" },
+    });
+
+    expect(planLaunch.args.at(-1)).toContain("Plan the work first");
+    expect(planLaunch.args.at(-1)).toContain("add a dashboard");
+  });
+
   it("requires Codex sandbox metadata unless explicitly overridden", () => {
     expect(() => buildAgentLaunch({
       agent: "codex",

--- a/tests/gateway/agent-launcher.test.ts
+++ b/tests/gateway/agent-launcher.test.ts
@@ -164,6 +164,27 @@ describe("agent-launcher", () => {
     expect(launch.args.at(-1)).toBe("--help");
   });
 
+  it("applies explicit Codex approval and read-only sandbox settings", () => {
+    const launch = buildAgentLaunch({
+      agent: "codex",
+      cwd: "/home/matrixos/home/projects/repo",
+      prompt: "review only",
+      approvalPolicy: "on-request",
+      sandbox: { enabled: true, mode: "read-only", writableRoots: ["/tmp/ignored"] },
+    });
+
+    expect(launch.args).toEqual([
+      "--ask-for-approval",
+      "on-request",
+      "exec",
+      "--skip-git-repo-check",
+      "--sandbox",
+      "read-only",
+      "--",
+      "review only",
+    ]);
+  });
+
   it("requires Codex sandbox metadata unless explicitly overridden", () => {
     expect(() => buildAgentLaunch({
       agent: "codex",

--- a/tests/gateway/agent-session-manager.test.ts
+++ b/tests/gateway/agent-session-manager.test.ts
@@ -111,6 +111,7 @@ describe("agent-session-manager", () => {
       worktreeId,
       pr: 42,
       prompt: "fix tests; rm -rf /",
+      mode: "review",
       sandbox: { enabled: true },
     });
 
@@ -137,6 +138,7 @@ describe("agent-session-manager", () => {
     expect(agentLauncher.buildLaunch).toHaveBeenCalledWith(expect.objectContaining({
       agent: "codex",
       prompt: "fix tests; rm -rf /",
+      mode: "review",
       cwd: join(homePath, "projects", "repo", "worktrees", worktreeId),
     }));
     expect(zellijRuntime.start).toHaveBeenCalledWith(expect.objectContaining({

--- a/tests/gateway/coding-agents-workspace-provider.test.ts
+++ b/tests/gateway/coding-agents-workspace-provider.test.ts
@@ -78,13 +78,16 @@ describe("coding agent workspace provider", () => {
         prompt: createBody.prompt,
         runtimePreference: "zellij",
         sessionId: expect.stringMatching(/^sess_[A-Za-z0-9_-]+$/),
+        mode: "default",
+        approvalPolicy: "on_request",
+        sandboxMode: "workspace_write",
       }),
     });
     expect(snapshot.thread).toMatchObject({
       providerId: "codex",
       projectId: "repo-main",
       taskId: "task_abc123",
-      terminalSessionId: "matrix-agent-workspace-1",
+      terminalSessionId: "term_sess_workspace_1",
       status: "running",
       attention: "none",
     });

--- a/tests/gateway/coding-agents-workspace-provider.test.ts
+++ b/tests/gateway/coding-agents-workspace-provider.test.ts
@@ -1,0 +1,168 @@
+import { mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it, vi } from "vitest";
+import {
+  AgentThreadEventSchema,
+  AgentThreadSnapshotSchema,
+  AgentThreadSummarySchema,
+  type AgentThreadEvent,
+} from "../../packages/contracts/src/index.js";
+import { createCodingAgentThreadStore } from "../../packages/gateway/src/coding-agents/thread-store.js";
+import { createWorkspaceCodingAgentProvider } from "../../packages/gateway/src/coding-agents/workspace-provider.js";
+import type { RequestPrincipal } from "../../packages/gateway/src/request-principal.js";
+
+const ownerPrincipal: RequestPrincipal = { userId: "owner_user", source: "jwt" };
+const baseNow = new Date("2026-07-06T12:00:00.000Z");
+
+const createBody = {
+  providerId: "codex",
+  prompt: "Inspect the failing tests and propose a small fix.",
+  projectId: "repo-main",
+  taskId: "task_abc123",
+  worktreeId: "wt_abc123def456",
+  mode: "default",
+  approvalPolicy: "on_request",
+  sandboxMode: "workspace_write",
+  clientRequestId: "req_workspace_1",
+} as const;
+
+function workspaceSession(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "sess_workspace_1",
+    kind: "agent",
+    projectSlug: "repo-main",
+    taskId: "task_abc123",
+    worktreeId: "wt_abc123def456",
+    agent: "codex",
+    runtime: {
+      type: "zellij",
+      status: "running",
+      zellijSession: "matrix-agent-workspace-1",
+    },
+    terminalSessionId: "term_sess_workspace_1",
+    ...overrides,
+  };
+}
+
+describe("coding agent workspace provider", () => {
+  it("starts a workspace agent session and binds the terminal reference to the stored thread", async () => {
+    const homePath = await mkdtemp(join(tmpdir(), "matrix-coding-agent-workspace-provider-"));
+    const runtime = {
+      startSession: vi.fn(async () => ({ ok: true, status: 201, session: workspaceSession() })),
+      stopSession: vi.fn(async () => ({ ok: true, session: workspaceSession({ runtime: { type: "zellij", status: "exited" } }) })),
+    };
+    const threads = createCodingAgentThreadStore({
+      homePath,
+      now: () => baseNow,
+      providers: [
+        createWorkspaceCodingAgentProvider({
+          providerId: "codex",
+          agent: "codex",
+          runtime,
+        }),
+      ],
+    });
+
+    const created = await threads.createThread(ownerPrincipal, createBody);
+    const snapshot = AgentThreadSnapshotSchema.parse(created.snapshot);
+
+    expect(runtime.startSession).toHaveBeenCalledWith({
+      ownerScope: { type: "user", id: "owner_user" },
+      request: expect.objectContaining({
+        agent: "codex",
+        kind: "agent",
+        projectSlug: "repo-main",
+        taskId: "task_abc123",
+        worktreeId: "wt_abc123def456",
+        prompt: createBody.prompt,
+        runtimePreference: "zellij",
+        sessionId: expect.stringMatching(/^sess_[A-Za-z0-9_-]+$/),
+      }),
+    });
+    expect(snapshot.thread).toMatchObject({
+      providerId: "codex",
+      projectId: "repo-main",
+      taskId: "task_abc123",
+      terminalSessionId: "matrix-agent-workspace-1",
+      status: "running",
+      attention: "none",
+    });
+    expect(snapshot.events.items.map((event) => event.type)).toEqual([
+      "thread.created",
+      "thread.status",
+      "terminal.bound",
+      "assistant.text.delta",
+    ]);
+  });
+
+  it("maps workspace session startup failures to safe thread errors", async () => {
+    const homePath = await mkdtemp(join(tmpdir(), "matrix-coding-agent-workspace-provider-"));
+    const runtime = {
+      startSession: vi.fn(async () => ({
+        ok: false,
+        status: 503,
+        error: { code: "runtime_unavailable", message: "zellij failed in /home/matrix/private" },
+      })),
+      stopSession: vi.fn(async () => ({ ok: true, session: workspaceSession() })),
+    };
+    const threads = createCodingAgentThreadStore({
+      homePath,
+      now: () => baseNow,
+      providers: [
+        createWorkspaceCodingAgentProvider({
+          providerId: "codex",
+          agent: "codex",
+          runtime,
+        }),
+      ],
+    });
+
+    const created = await threads.createThread(ownerPrincipal, createBody);
+
+    expect(created.snapshot.thread).toMatchObject({ status: "failed", attention: "failed" });
+    expect(created.snapshot.events.items.map((event) => event.type)).toEqual([
+      "thread.created",
+      "thread.error",
+      "thread.completed",
+    ]);
+    expect(JSON.stringify(created.snapshot)).not.toMatch(/zellij|\/home\/matrix|private/);
+  });
+
+  it("aborts the deterministic workspace session for a thread", async () => {
+    const runtime = {
+      startSession: vi.fn(async () => ({ ok: true, status: 201, session: workspaceSession() })),
+      stopSession: vi.fn(async () => ({ ok: true, session: workspaceSession({ runtime: { type: "zellij", status: "exited" } }) })),
+    };
+    const provider = createWorkspaceCodingAgentProvider({
+      providerId: "codex",
+      agent: "codex",
+      runtime,
+    });
+    const thread = AgentThreadSummarySchema.parse({
+      id: "thread_workspace_1",
+      providerId: "codex",
+      title: "Coding agent run",
+      status: "running",
+      attention: "none",
+      terminalSessionId: "matrix-agent-workspace-1",
+      createdAt: baseNow.toISOString(),
+      updatedAt: baseNow.toISOString(),
+    });
+    let eventIndex = 0;
+    const events = await provider.abortThread?.({
+      principal: ownerPrincipal,
+      thread,
+      clientRequestId: "req_abort_workspace",
+      now: () => baseNow,
+      nextEventId: () => `evt_abort_${++eventIndex}`,
+    });
+
+    expect(runtime.stopSession).toHaveBeenCalledWith("sess_workspace_1");
+    expect((events ?? []).map((event: AgentThreadEvent) => AgentThreadEventSchema.parse(event).type)).toEqual([
+      "thread.status",
+      "thread.completed",
+    ]);
+    expect(events?.at(-1)).toMatchObject({ type: "thread.completed", outcome: "aborted" });
+  });
+});

--- a/tests/gateway/workspace-session-orchestrator.test.ts
+++ b/tests/gateway/workspace-session-orchestrator.test.ts
@@ -120,6 +120,30 @@ describe("workspace session orchestrator", () => {
     expect(warn).toHaveBeenCalledWith("[workspace-session-orchestrator] Failed to publish session start event:", "event write failed");
   });
 
+  it("preserves full-access sandbox requests as Codex danger-full-access launches", async () => {
+    const d = deps();
+    const orchestrator = createWorkspaceSessionOrchestrator({
+      ...d,
+      idGenerator: () => "sess_fixed",
+    });
+
+    const result = await orchestrator.startSession({
+      ownerScope: { type: "user", id: "user_workspace" },
+      request: {
+        projectSlug: "repo",
+        worktreeId: "wt_abc123def456",
+        kind: "agent",
+        agent: "codex",
+        sandboxMode: "full_access",
+      },
+    });
+
+    expect(result).toMatchObject({ ok: true, status: 201 });
+    expect(d.agentSessionManager.startSession).toHaveBeenCalledWith(expect.objectContaining({
+      sandbox: { enabled: true, mode: "danger-full-access", writableRoots: [] },
+    }));
+  });
+
   it("returns a safe sandbox failure before launching a session", async () => {
     const d = deps({
       agentSandbox: {

--- a/tests/gateway/workspace-session-orchestrator.test.ts
+++ b/tests/gateway/workspace-session-orchestrator.test.ts
@@ -85,7 +85,7 @@ describe("workspace session orchestrator", () => {
     expect(d.agentSessionManager.startSession).toHaveBeenCalledWith(expect.objectContaining({
       agent: "codex",
       ownerId: "user_workspace",
-      sandbox: { enabled: true, writableRoots: [worktree.path] },
+      sandbox: { enabled: true, mode: "workspace-write", writableRoots: [worktree.path] },
       sessionId: "sess_fixed",
     }));
     expect(d.eventPublisher.publishSessionStarted).toHaveBeenCalledWith(session);


### PR DESCRIPTION
## Summary
- Add a workspace-backed coding-agent provider adapter that starts Matrix workspace agent sessions through the existing session orchestrator.
- Bind `terminal.bound` events into stored thread summaries so shells can hydrate the runtime terminal reference.
- Wire the provider behind `MATRIX_CODING_AGENTS_WORKSPACE_PROVIDER=1`, preserving the existing fake-provider flag for tests/dev.

## Tests
- `pnpm exec vitest run tests/gateway/coding-agents-workspace-provider.test.ts tests/gateway/coding-agents-threads.test.ts tests/gateway/coding-agents-thread-stream.test.ts tests/gateway/coding-agents-summary.test.ts tests/contracts/coding-agents.test.ts`
- `pnpm --filter @matrix-os/gateway exec tsc --noEmit`
- `bun run check:patterns` (passes with existing warnings)
- `bun run typecheck`
- `git diff --check`

## Mandatory Invariants
- Source of truth: coding-agent thread state stays in the gateway owner-file thread store; workspace agent execution stays in the existing Matrix workspace/session runtime.
- Lock/transaction scope: thread mutations continue through the serialized thread-store mutation queue and atomic owner-file writes; no new persistence technology is introduced.
- Acceptable orphan states: if workspace session startup fails, the thread records a generic safe failure; abort falls back to the existing safe abort behavior if the provider cannot stop the workspace session.
- Auth source of truth: existing `/api/coding-agents` route auth and request principal handling remain authoritative; the renderer/mobile clients receive only validated summaries and events.
- Deferred scope: live transcript/tool/approval streaming from the real provider remains for the next provider-runtime slices.