### PR TITLE
feat(gateway): add coding agent approval routes

### DIFF
--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -346,6 +346,11 @@ export const AgentThreadEventSchema = z.discriminatedUnion("type", [
     request: UserInputRequestSchema,
   }).strict(),
   BaseThreadEventSchema.extend({
+    type: z.literal("user_input.answered"),
+    requestId: RequestIdSchema,
+    correlationId: CorrelationIdSchema,
+  }).strict(),
+  BaseThreadEventSchema.extend({
     type: z.literal("file.changed"),
     path: safeRelativePath(),
     changeKind: z.enum(["created", "updated", "deleted", "renamed"]),

--- a/packages/gateway/src/coding-agents/routes.ts
+++ b/packages/gateway/src/coding-agents/routes.ts
@@ -3,11 +3,14 @@ import { bodyLimit } from "hono/body-limit";
 import type { ContentfulStatusCode } from "hono/utils/http-status";
 import { z } from "zod/v4";
 import {
+  ApprovalDecisionRequestSchema,
+  ApprovalIdSchema,
   CreateAgentThreadRequestSchema,
   CursorSchema,
   RequestIdSchema,
   ThreadIdSchema,
   SafeClientErrorSchema,
+  UserInputAnswerRequestSchema,
   boundedListSchema,
   AgentThreadSummarySchema,
 } from "@matrix-os/contracts";
@@ -32,6 +35,8 @@ export interface CodingAgentRouteDeps {
 
 const THREAD_MUTATION_BODY_LIMIT = 128 * 1024;
 const THREAD_ABORT_BODY_LIMIT = 1024;
+const THREAD_APPROVAL_BODY_LIMIT = 8 * 1024;
+const THREAD_INPUT_BODY_LIMIT = 40 * 1024;
 
 const AbortThreadBodySchema = z.object({
   clientRequestId: RequestIdSchema,
@@ -86,6 +91,8 @@ export function createCodingAgentRoutes(deps: CodingAgentRouteDeps): Hono {
   const principalFor = (c: Context) => deps.getPrincipal?.(c) ?? requireRequestPrincipal(c);
   const threadMutationBodyLimit = bodyLimit({ maxSize: THREAD_MUTATION_BODY_LIMIT });
   const threadAbortBodyLimit = bodyLimit({ maxSize: THREAD_ABORT_BODY_LIMIT });
+  const threadApprovalBodyLimit = bodyLimit({ maxSize: THREAD_APPROVAL_BODY_LIMIT });
+  const threadInputBodyLimit = bodyLimit({ maxSize: THREAD_INPUT_BODY_LIMIT });
 
   app.get("/summary", async (c) => {
     try {
@@ -150,6 +157,30 @@ export function createCodingAgentRoutes(deps: CodingAgentRouteDeps): Hono {
         const threadId = ThreadIdSchema.parse(c.req.param("threadId"));
         const body = AbortThreadBodySchema.parse(await c.req.json());
         return c.json(await deps.threads!.abortThread(principal, threadId, body.clientRequestId));
+      } catch (err: unknown) {
+        return mapThreadRouteError(c, err);
+      }
+    });
+
+    app.post("/threads/:threadId/approvals/:approvalId/decision", threadApprovalBodyLimit, async (c) => {
+      try {
+        const principal = principalFor(c);
+        const threadId = ThreadIdSchema.parse(c.req.param("threadId"));
+        const approvalId = ApprovalIdSchema.parse(c.req.param("approvalId"));
+        const body = ApprovalDecisionRequestSchema.parse(await c.req.json());
+        return c.json(await deps.threads!.submitApproval(principal, threadId, approvalId, body));
+      } catch (err: unknown) {
+        return mapThreadRouteError(c, err);
+      }
+    });
+
+    app.post("/threads/:threadId/inputs/:inputRequestId/answer", threadInputBodyLimit, async (c) => {
+      try {
+        const principal = principalFor(c);
+        const threadId = ThreadIdSchema.parse(c.req.param("threadId"));
+        const inputRequestId = RequestIdSchema.parse(c.req.param("inputRequestId"));
+        const body = UserInputAnswerRequestSchema.parse(await c.req.json());
+        return c.json(await deps.threads!.submitInput(principal, threadId, inputRequestId, body));
       } catch (err: unknown) {
         return mapThreadRouteError(c, err);
       }

--- a/packages/gateway/src/coding-agents/thread-store.ts
+++ b/packages/gateway/src/coding-agents/thread-store.ts
@@ -6,6 +6,7 @@ import {
   AgentThreadEventSchema,
   AgentThreadSnapshotSchema,
   AgentThreadSummarySchema,
+  ApprovalIdSchema,
   ProviderIdSchema,
   RequestIdSchema,
   SafeClientErrorSchema,
@@ -26,6 +27,8 @@ const EVENT_REPLAY_LIMIT = 200;
 const MAX_STORED_THREADS = 200;
 const MAX_EVENTS_PER_THREAD = 500;
 const MAX_ABORT_REQUEST_IDS = 50;
+const MAX_APPROVAL_DECISION_REQUEST_IDS = 50;
+const MAX_INPUT_ANSWER_REQUEST_IDS = 50;
 
 const OwnerIdSchema = z.string().min(1).max(160).regex(/^[A-Za-z0-9_.:@-]+$/);
 
@@ -33,6 +36,8 @@ const StoredThreadSchema = AgentThreadSummarySchema.extend({
   ownerId: OwnerIdSchema,
   clientRequestId: RequestIdSchema,
   abortClientRequestIds: z.array(RequestIdSchema).max(MAX_ABORT_REQUEST_IDS).default([]),
+  approvalDecisionClientRequestIds: z.array(RequestIdSchema).max(MAX_APPROVAL_DECISION_REQUEST_IDS).default([]),
+  inputAnswerClientRequestIds: z.array(RequestIdSchema).max(MAX_INPUT_ANSWER_REQUEST_IDS).default([]),
 }).strict();
 
 const StoredThreadStateSchema = z.object({
@@ -109,6 +114,18 @@ export interface CodingAgentThreadStore {
   listThreads(principal: RequestPrincipal): Promise<{ items: AgentThreadSummary[]; hasMore: boolean; limit: number }>;
   getThread(principal: RequestPrincipal, threadId: string, cursor?: string): Promise<AgentThreadSnapshot>;
   abortThread(principal: RequestPrincipal, threadId: string, clientRequestId: string): Promise<AgentThreadSnapshot>;
+  submitApproval(
+    principal: RequestPrincipal,
+    threadId: string,
+    approvalId: string,
+    request: ApprovalDecisionRequest,
+  ): Promise<AgentThreadSnapshot>;
+  submitInput(
+    principal: RequestPrincipal,
+    threadId: string,
+    inputRequestId: string,
+    request: UserInputAnswerRequest,
+  ): Promise<AgentThreadSnapshot>;
   registerEventSink(sink: ThreadEventSink): { dispose(): void };
 }
 
@@ -234,6 +251,9 @@ function applyEvent(thread: StoredThread, event: AgentThreadEvent): StoredThread
   if (event.type === "user_input.requested") {
     return { ...thread, status: "waiting_for_input", attention: "input_required", updatedAt };
   }
+  if (event.type === "approval.resolved" || event.type === "user_input.answered") {
+    return { ...thread, status: "running", attention: "none", updatedAt };
+  }
   if (event.type === "terminal.bound") {
     return { ...thread, terminalSessionId: event.terminalSessionId, updatedAt };
   }
@@ -263,7 +283,14 @@ function snapshotFor(thread: StoredThread, allEvents: AgentThreadEvent[], cursor
 }
 
 function stripOwner(thread: StoredThread): AgentThreadSummary {
-  const { ownerId: _ownerId, clientRequestId: _clientRequestId, abortClientRequestIds: _abortClientRequestIds, ...summary } = thread;
+  const {
+    ownerId: _ownerId,
+    clientRequestId: _clientRequestId,
+    abortClientRequestIds: _abortClientRequestIds,
+    approvalDecisionClientRequestIds: _approvalDecisionClientRequestIds,
+    inputAnswerClientRequestIds: _inputAnswerClientRequestIds,
+    ...summary
+  } = thread;
   return AgentThreadSummarySchema.parse(summary);
 }
 
@@ -333,6 +360,58 @@ function defaultAbortEvents(threadId: string, now: () => Date, eventId: () => st
       threadId,
       occurredAt: now().toISOString(),
       outcome: "aborted",
+    }),
+  ];
+}
+
+function defaultApprovalDecisionEvents(
+  threadId: string,
+  approvalId: string,
+  request: ApprovalDecisionRequest,
+  now: () => Date,
+  eventId: () => string,
+): AgentThreadEvent[] {
+  return [
+    AgentThreadEventSchema.parse({
+      type: "approval.resolved",
+      eventId: eventId(),
+      threadId,
+      occurredAt: now().toISOString(),
+      approvalId,
+      decision: request.decision,
+    }),
+    AgentThreadEventSchema.parse({
+      type: "thread.status",
+      eventId: eventId(),
+      threadId,
+      occurredAt: now().toISOString(),
+      status: "running",
+    }),
+  ];
+}
+
+function defaultInputAnswerEvents(
+  threadId: string,
+  inputRequestId: string,
+  request: UserInputAnswerRequest,
+  now: () => Date,
+  eventId: () => string,
+): AgentThreadEvent[] {
+  return [
+    AgentThreadEventSchema.parse({
+      type: "user_input.answered",
+      eventId: eventId(),
+      threadId,
+      occurredAt: now().toISOString(),
+      requestId: inputRequestId,
+      correlationId: request.correlationId,
+    }),
+    AgentThreadEventSchema.parse({
+      type: "thread.status",
+      eventId: eventId(),
+      threadId,
+      occurredAt: now().toISOString(),
+      status: "running",
     }),
   ];
 }
@@ -439,6 +518,8 @@ export function createCodingAgentThreadStore(options: CodingAgentThreadStoreOpti
           ownerId: principal.userId,
           clientRequestId: request.clientRequestId,
           abortClientRequestIds: [],
+          approvalDecisionClientRequestIds: [],
+          inputAnswerClientRequestIds: [],
           providerId: request.providerId,
           title: genericTitle(),
           status: "queued",
@@ -558,6 +639,114 @@ export function createCodingAgentThreadStore(options: CodingAgentThreadStoreOpti
         return {
           state: nextState,
           result: { snapshot: snapshotFor(nextThread, nextState.events), eventsToPublish: abortEvents },
+        };
+      });
+      publish(principal.userId, threadId, result.eventsToPublish);
+      return result.snapshot;
+    },
+    async submitApproval(principal, threadId, approvalId, request) {
+      const parsedApprovalId = ApprovalIdSchema.parse(approvalId);
+      const result = await mutate(async (state) => {
+        const thread = state.threads.find((candidate) => candidate.ownerId === principal.userId && candidate.id === threadId);
+        if (!thread) throw new CodingAgentThreadError("thread_not_found", "Thread not found");
+        if (thread.approvalDecisionClientRequestIds.includes(request.clientRequestId) || terminalThread(thread)) {
+          return { state, result: { snapshot: snapshotFor(thread, state.events), eventsToPublish: [] } };
+        }
+        const provider = providers.find((candidate) => candidate.providerId === thread.providerId);
+        let approvalEvents: AgentThreadEvent[];
+        if (provider?.submitApproval) {
+          try {
+            approvalEvents = parseProviderEvents(await provider.submitApproval({
+              principal,
+              thread: stripOwner(thread),
+              approvalId: parsedApprovalId,
+              request,
+              now,
+              nextEventId,
+            }), threadId);
+          } catch (err: unknown) {
+            console.warn("[coding-agents] provider approval submit failed:", err instanceof Error ? err.message : String(err));
+            throw new CodingAgentThreadError("thread_store_unavailable", "Provider approval submit failed");
+          }
+        } else {
+          approvalEvents = defaultApprovalDecisionEvents(threadId, parsedApprovalId, request, now, nextEventId);
+        }
+        if (approvalEvents.length === 0) {
+          approvalEvents = defaultApprovalDecisionEvents(threadId, parsedApprovalId, request, now, nextEventId);
+        }
+        let nextThread = thread;
+        for (const event of approvalEvents) {
+          nextThread = applyEvent(nextThread, event);
+        }
+        nextThread = {
+          ...nextThread,
+          approvalDecisionClientRequestIds: [
+            ...nextThread.approvalDecisionClientRequestIds,
+            request.clientRequestId,
+          ].slice(-MAX_APPROVAL_DECISION_REQUEST_IDS),
+        };
+        const nextState = {
+          version: 1 as const,
+          threads: state.threads.map((candidate) => candidate.id === thread.id ? nextThread : candidate),
+          events: [...state.events, ...approvalEvents],
+        };
+        return {
+          state: nextState,
+          result: { snapshot: snapshotFor(nextThread, nextState.events), eventsToPublish: approvalEvents },
+        };
+      });
+      publish(principal.userId, threadId, result.eventsToPublish);
+      return result.snapshot;
+    },
+    async submitInput(principal, threadId, inputRequestId, request) {
+      const parsedInputRequestId = RequestIdSchema.parse(inputRequestId);
+      const result = await mutate(async (state) => {
+        const thread = state.threads.find((candidate) => candidate.ownerId === principal.userId && candidate.id === threadId);
+        if (!thread) throw new CodingAgentThreadError("thread_not_found", "Thread not found");
+        if (thread.inputAnswerClientRequestIds.includes(request.clientRequestId) || terminalThread(thread)) {
+          return { state, result: { snapshot: snapshotFor(thread, state.events), eventsToPublish: [] } };
+        }
+        const provider = providers.find((candidate) => candidate.providerId === thread.providerId);
+        let inputEvents: AgentThreadEvent[];
+        if (provider?.submitInput) {
+          try {
+            inputEvents = parseProviderEvents(await provider.submitInput({
+              principal,
+              thread: stripOwner(thread),
+              inputRequestId: parsedInputRequestId,
+              request,
+              now,
+              nextEventId,
+            }), threadId);
+          } catch (err: unknown) {
+            console.warn("[coding-agents] provider input submit failed:", err instanceof Error ? err.message : String(err));
+            throw new CodingAgentThreadError("thread_store_unavailable", "Provider input submit failed");
+          }
+        } else {
+          inputEvents = defaultInputAnswerEvents(threadId, parsedInputRequestId, request, now, nextEventId);
+        }
+        if (inputEvents.length === 0) {
+          inputEvents = defaultInputAnswerEvents(threadId, parsedInputRequestId, request, now, nextEventId);
+        }
+        let nextThread = thread;
+        for (const event of inputEvents) {
+          nextThread = applyEvent(nextThread, event);
+        }
+        nextThread = {
+          ...nextThread,
+          inputAnswerClientRequestIds: [
+            ...nextThread.inputAnswerClientRequestIds,
+            request.clientRequestId,
+          ].slice(-MAX_INPUT_ANSWER_REQUEST_IDS),
+        };
+        const nextState = {
+          version: 1 as const,
+          threads: state.threads.map((candidate) => candidate.id === thread.id ? nextThread : candidate),
+          events: [...state.events, ...inputEvents],
+        };
+        return {
+          state: nextState,
+          result: { snapshot: snapshotFor(nextThread, nextState.events), eventsToPublish: inputEvents },
         };
       });
       publish(principal.userId, threadId, result.eventsToPublish);

--- a/tests/contracts/coding-agents.test.ts
+++ b/tests/contracts/coding-agents.test.ts
@@ -173,6 +173,14 @@ describe("coding agent contracts", () => {
         correlationId: "corr_1",
       },
     }).type).toBe("approval.requested");
+    expect(AgentThreadEventSchema.parse({
+      type: "user_input.answered",
+      eventId: "evt_answered",
+      threadId: "thread_1",
+      occurredAt: now,
+      requestId: "req_answer",
+      correlationId: "corr_answer",
+    }).type).toBe("user_input.answered");
     expect(AgentThreadSnapshotSchema.parse({
       thread: {
         id: "thread_1",

--- a/tests/gateway/coding-agents-threads.test.ts
+++ b/tests/gateway/coding-agents-threads.test.ts
@@ -261,6 +261,198 @@ describe("coding agent thread lifecycle", () => {
     );
   });
 
+  it("submits approval decisions idempotently through the provider adapter", async () => {
+    const homePath = await mkdtemp(join(tmpdir(), "matrix-coding-agent-threads-"));
+    let approvalCalls = 0;
+    const provider: CodingAgentProviderAdapter = {
+      providerId: "codex",
+      startThread({ thread, now: providerNow, nextEventId }) {
+        return [
+          AgentThreadEventSchema.parse({
+            type: "approval.requested",
+            eventId: nextEventId(),
+            threadId: thread.id,
+            occurredAt: providerNow().toISOString(),
+            approval: {
+              approvalId: "appr_test",
+              threadId: thread.id,
+              title: "Confirm action",
+              safeDescription: "Approve the next step.",
+              risk: "low",
+              actionKind: "other",
+              allowedDecisions: ["approve", "decline"],
+              correlationId: "corr_test",
+            },
+          }),
+        ];
+      },
+      submitApproval({ thread, approvalId, request, now: providerNow, nextEventId }) {
+        approvalCalls += 1;
+        expect(approvalId).toBe("appr_test");
+        expect(request).toEqual({
+          decision: "approve",
+          clientRequestId: "req_approval_1",
+          correlationId: "corr_test",
+        });
+        return [
+          AgentThreadEventSchema.parse({
+            type: "approval.resolved",
+            eventId: nextEventId(),
+            threadId: thread.id,
+            occurredAt: providerNow().toISOString(),
+            approvalId,
+            decision: request.decision,
+          }),
+          AgentThreadEventSchema.parse({
+            type: "thread.status",
+            eventId: nextEventId(),
+            threadId: thread.id,
+            occurredAt: providerNow().toISOString(),
+            status: "running",
+          }),
+        ];
+      },
+    };
+    const threads = createCodingAgentThreadStore({
+      homePath,
+      now: () => baseNow,
+      providers: [provider],
+    });
+    const app = new Hono();
+    app.route("/api/coding-agents", createCodingAgentRoutes({
+      service: createCodingAgentRuntimeSummaryService({ homePath, now: () => baseNow }),
+      threads,
+      getPrincipal: () => ownerPrincipal,
+    }));
+    const created = AgentThreadSnapshotSchema.parse(
+      await (await app.request(jsonRequest("/api/coding-agents/threads", createBody))).json(),
+    );
+    const body = {
+      decision: "approve",
+      clientRequestId: "req_approval_1",
+      correlationId: "corr_test",
+    };
+
+    const first = await app.request(jsonRequest(`/api/coding-agents/threads/${created.thread.id}/approvals/appr_test/decision`, body));
+    const duplicate = await app.request(jsonRequest(`/api/coding-agents/threads/${created.thread.id}/approvals/appr_test/decision`, body));
+    const oversized = await app.request(new Request(`http://localhost/api/coding-agents/threads/${created.thread.id}/approvals/appr_test/decision`, {
+      method: "POST",
+      headers: { "content-type": "application/json", "content-length": String(9_000) },
+      body: JSON.stringify(body),
+    }));
+
+    expect(first.status).toBe(200);
+    expect(duplicate.status).toBe(200);
+    expect(oversized.status).toBe(413);
+    expect(approvalCalls).toBe(1);
+    const decided = AgentThreadSnapshotSchema.parse(await first.json());
+    const duplicateSnapshot = AgentThreadSnapshotSchema.parse(await duplicate.json());
+    expect(decided.thread).toMatchObject({ status: "running", attention: "none" });
+    expect(decided.events.items.map((event) => event.type)).toEqual([
+      "thread.created",
+      "approval.requested",
+      "approval.resolved",
+      "thread.status",
+    ]);
+    expect(duplicateSnapshot.events.items.map((event) => event.eventId)).toEqual(
+      decided.events.items.map((event) => event.eventId),
+    );
+  });
+
+  it("submits user input answers idempotently and safely validates route input", async () => {
+    const homePath = await mkdtemp(join(tmpdir(), "matrix-coding-agent-threads-"));
+    let inputCalls = 0;
+    const provider: CodingAgentProviderAdapter = {
+      providerId: "codex",
+      startThread({ thread, now: providerNow, nextEventId }) {
+        return [
+          AgentThreadEventSchema.parse({
+            type: "user_input.requested",
+            eventId: nextEventId(),
+            threadId: thread.id,
+            occurredAt: providerNow().toISOString(),
+            request: {
+              requestId: "req_input_prompt",
+              threadId: thread.id,
+              title: "Need input",
+              safeDescription: "Provide the missing detail.",
+              required: true,
+              correlationId: "corr_input",
+            },
+          }),
+        ];
+      },
+      submitInput({ thread, inputRequestId, request, now: providerNow, nextEventId }) {
+        inputCalls += 1;
+        expect(inputRequestId).toBe("req_input_prompt");
+        expect(request.answer).toBe("Use the safe implementation path.");
+        return [
+          AgentThreadEventSchema.parse({
+            type: "user_input.answered",
+            eventId: nextEventId(),
+            threadId: thread.id,
+            occurredAt: providerNow().toISOString(),
+            requestId: inputRequestId,
+            correlationId: request.correlationId,
+          }),
+          AgentThreadEventSchema.parse({
+            type: "thread.status",
+            eventId: nextEventId(),
+            threadId: thread.id,
+            occurredAt: providerNow().toISOString(),
+            status: "running",
+          }),
+        ];
+      },
+    };
+    const threads = createCodingAgentThreadStore({
+      homePath,
+      now: () => baseNow,
+      providers: [provider],
+    });
+    const app = new Hono();
+    app.route("/api/coding-agents", createCodingAgentRoutes({
+      service: createCodingAgentRuntimeSummaryService({ homePath, now: () => baseNow }),
+      threads,
+      getPrincipal: () => ownerPrincipal,
+    }));
+    const created = AgentThreadSnapshotSchema.parse(
+      await (await app.request(jsonRequest("/api/coding-agents/threads", createBody))).json(),
+    );
+    const body = {
+      answer: "Use the safe implementation path.",
+      clientRequestId: "req_input_1",
+      correlationId: "corr_input",
+    };
+
+    const first = await app.request(jsonRequest(`/api/coding-agents/threads/${created.thread.id}/inputs/req_input_prompt/answer`, body));
+    const duplicate = await app.request(jsonRequest(`/api/coding-agents/threads/${created.thread.id}/inputs/req_input_prompt/answer`, body));
+    const malformed = await app.request(jsonRequest(`/api/coding-agents/threads/${created.thread.id}/inputs/../answer`, body));
+    const oversized = await app.request(new Request(`http://localhost/api/coding-agents/threads/${created.thread.id}/inputs/req_input_prompt/answer`, {
+      method: "POST",
+      headers: { "content-type": "application/json", "content-length": String(45_000) },
+      body: JSON.stringify(body),
+    }));
+
+    expect(first.status).toBe(200);
+    expect(duplicate.status).toBe(200);
+    expect(malformed.status).toBe(404);
+    expect(oversized.status).toBe(413);
+    expect(inputCalls).toBe(1);
+    const answered = AgentThreadSnapshotSchema.parse(await first.json());
+    const duplicateSnapshot = AgentThreadSnapshotSchema.parse(await duplicate.json());
+    expect(answered.thread).toMatchObject({ status: "running", attention: "none" });
+    expect(answered.events.items.map((event) => event.type)).toEqual([
+      "thread.created",
+      "user_input.requested",
+      "user_input.answered",
+      "thread.status",
+    ]);
+    expect(duplicateSnapshot.events.items.map((event) => event.eventId)).toEqual(
+      answered.events.items.map((event) => event.eventId),
+    );
+  });
+
   it("records a safe failed thread when a provider start fails", async () => {
     const homePath = await mkdtemp(join(tmpdir(), "matrix-coding-agent-threads-"));
     const threads = createCodingAgentThreadStore({


### PR DESCRIPTION
## Summary
- add validated approval decision and user-input answer routes for coding agent threads
- persist bounded idempotency keys in the thread store and replay safe lifecycle events
- extend contracts and tests for answered user-input events

## Tests
- pnpm exec vitest run tests/gateway/coding-agents-workspace-provider.test.ts tests/gateway/coding-agents-threads.test.ts tests/gateway/coding-agents-thread-stream.test.ts tests/gateway/coding-agents-summary.test.ts tests/contracts/coding-agents.test.ts
- pnpm exec vitest run tests/observability/process-error-entrypoints.test.ts
- pnpm --filter @matrix-os/gateway exec tsc --noEmit
- bun run check:patterns
- bun run typecheck
- git diff --check