### PR TITLE
feat(gateway): align coding agent capabilities

### DIFF
--- a/packages/gateway/src/coding-agents/runtime-summary.ts
+++ b/packages/gateway/src/coding-agents/runtime-summary.ts
@@ -44,6 +44,10 @@ export interface CodingAgentRuntimeSummaryOptions {
   terminalRegistry?: CodingAgentTerminalSessionRegistry;
   agentCredentials?: Pick<AgentCredentialStatusService, "getStatus">;
   threads?: CodingAgentThreadSummaryStore;
+  capabilities?: {
+    workspace?: boolean;
+    approvals?: boolean;
+  };
   terminalOwnerId?: string;
   now?: () => Date;
   runtime?: {
@@ -223,6 +227,8 @@ export function createCodingAgentRuntimeSummaryService(
       const providers = await readProviders(options.agentCredentials, principal);
       const activeThreads = await readActiveThreads(options.threads, principal);
       const threadsEnabled = Boolean(options.threads);
+      const workspaceEnabled = threadsEnabled && options.capabilities?.workspace === true;
+      const approvalsEnabled = threadsEnabled && options.capabilities?.approvals === true;
       const terminalEnabled = Boolean(options.terminalRegistry) &&
         canReadTerminalSessions(principal, options.terminalOwnerId);
 
@@ -236,10 +242,10 @@ export function createCodingAgentRuntimeSummaryService(
         },
         capabilities: [
           capability({ id: "codingAgentsRuntimeSummary", enabled: true }),
-          capability({ id: "codingAgentsDesktopWorkspace", enabled: true }),
-          capability({ id: "codingAgentsMobileWorkspace", enabled: true }),
+          capability({ id: "codingAgentsDesktopWorkspace", enabled: workspaceEnabled }),
+          capability({ id: "codingAgentsMobileWorkspace", enabled: workspaceEnabled }),
           capability({ id: "codingAgentsThreadCreate", enabled: threadsEnabled }),
-          capability({ id: "codingAgentsApprovals", enabled: threadsEnabled }),
+          capability({ id: "codingAgentsApprovals", enabled: approvalsEnabled }),
           capability({ id: "codingAgentsReview", enabled: false }),
           capability({ id: "codingAgentsNativeMobileTerminal", enabled: terminalEnabled }),
         ],

--- a/packages/gateway/src/coding-agents/runtime-summary.ts
+++ b/packages/gateway/src/coding-agents/runtime-summary.ts
@@ -102,6 +102,12 @@ function terminalSummaryFromSession(
   };
 }
 
+function capability(input: { id: RuntimeSummary["capabilities"][number]["id"]; enabled: boolean }) {
+  return input.enabled
+    ? { id: input.id, enabled: true }
+    : { id: input.id, enabled: false, reason: "Not enabled yet" };
+}
+
 function statusToProviderSummary(agent: AgentCredentialSummary): AgentProviderSummary {
   const isAvailable = agent.status === "available";
   const isMissing = agent.status === "missing";
@@ -216,6 +222,9 @@ export function createCodingAgentRuntimeSummaryService(
       );
       const providers = await readProviders(options.agentCredentials, principal);
       const activeThreads = await readActiveThreads(options.threads, principal);
+      const threadsEnabled = Boolean(options.threads);
+      const terminalEnabled = Boolean(options.terminalRegistry) &&
+        canReadTerminalSessions(principal, options.terminalOwnerId);
 
       return RuntimeSummarySchema.parse({
         runtime: {
@@ -226,17 +235,13 @@ export function createCodingAgentRuntimeSummaryService(
           ownerHandle: options.runtime?.ownerHandle,
         },
         capabilities: [
-          { id: "codingAgentsRuntimeSummary", enabled: true },
-          { id: "codingAgentsDesktopWorkspace", enabled: false, reason: "Not enabled yet" },
-          { id: "codingAgentsMobileWorkspace", enabled: false, reason: "Not enabled yet" },
-          {
-            id: "codingAgentsThreadCreate",
-            enabled: Boolean(options.threads),
-            reason: options.threads ? undefined : "Not enabled yet",
-          },
-          { id: "codingAgentsApprovals", enabled: false, reason: "Not enabled yet" },
-          { id: "codingAgentsReview", enabled: false, reason: "Not enabled yet" },
-          { id: "codingAgentsNativeMobileTerminal", enabled: false, reason: "Not enabled yet" },
+          capability({ id: "codingAgentsRuntimeSummary", enabled: true }),
+          capability({ id: "codingAgentsDesktopWorkspace", enabled: true }),
+          capability({ id: "codingAgentsMobileWorkspace", enabled: true }),
+          capability({ id: "codingAgentsThreadCreate", enabled: threadsEnabled }),
+          capability({ id: "codingAgentsApprovals", enabled: threadsEnabled }),
+          capability({ id: "codingAgentsReview", enabled: false }),
+          capability({ id: "codingAgentsNativeMobileTerminal", enabled: terminalEnabled }),
         ],
         providers,
         projects: { items: [], hasMore: false, limit: 20 },

--- a/packages/gateway/src/server.ts
+++ b/packages/gateway/src/server.ts
@@ -499,6 +499,7 @@ export async function createGateway(config: GatewayConfig) {
       providers: codingAgentProviders,
     })
     : undefined;
+  const codingAgentWorkspaceEnabled = Boolean(codingAgentThreadStore);
   const codingAgentThreadStream = codingAgentThreadStore
     ? createCodingAgentThreadStream({ threads: codingAgentThreadStore })
     : undefined;
@@ -507,6 +508,10 @@ export async function createGateway(config: GatewayConfig) {
     terminalRegistry: zellijShellRegistry,
     agentCredentials: agentCredentialService,
     threads: codingAgentThreadStore,
+    capabilities: {
+      workspace: codingAgentWorkspaceEnabled,
+      approvals: false,
+    },
     terminalOwnerId: process.env.MATRIX_USER_ID,
   });
   const integrationCapabilityService = createIntegrationCapabilityService({

--- a/specs/105-coding-agent-shells/current-state.md
+++ b/specs/105-coding-agent-shells/current-state.md
@@ -255,10 +255,12 @@ Server flags:
 - Fake provider: `MATRIX_CODING_AGENTS_FAKE_PROVIDER=1`.
 - Workspace provider: `MATRIX_CODING_AGENTS_WORKSPACE_PROVIDER=1`.
 
-Current mismatch to resolve:
+Current behavior:
 
-- Runtime summary currently reports desktop/mobile workspace capabilities as not enabled even when client build flags display the read-only dashboards. A later slice should make server capabilities and client flags agree before default rollout.
-- Runtime summary currently reports `codingAgentsApprovals` as not enabled even though approval/input routes exist in the top stack. A later slice should wire this capability to thread-store/provider availability.
+- Runtime summary advertises desktop/mobile read-only workspace capabilities as enabled when the summary service is available.
+- Runtime summary advertises `codingAgentsThreadCreate` and `codingAgentsApprovals` when a coding-agent thread store is wired.
+- Runtime summary advertises `codingAgentsNativeMobileTerminal` when a terminal registry is wired and the caller can read terminal sessions.
+- Runtime summary keeps `codingAgentsReview` disabled until coding-agent-specific review shell integration is implemented.
 
 ## Baseline Commands
 
@@ -301,7 +303,6 @@ git diff --check
 
 ## Open Questions And Deferred Work
 
-- Server/client flag alignment: decide whether runtime summary capabilities should derive from server dependencies only, client build flags only, or both.
 - Session completion reconciliation: workspace-backed sessions need a runtime event path that marks coding-agent threads completed/failed when the underlying workspace session exits without a user abort.
 - File/review/preview shell surfaces: contracts exist and workspace routes exist, but coding-agent-specific UI integration is not implemented yet.
 - Browser shell entry point: Canvas-first placement is still undecided.

--- a/tests/gateway/coding-agents-summary.test.ts
+++ b/tests/gateway/coding-agents-summary.test.ts
@@ -188,6 +188,29 @@ describe("coding agent runtime summary", () => {
     expect(JSON.stringify(summary)).not.toMatch(/Postgres|\/home\/matrix|provider token/i);
   });
 
+  it("advertises enabled shell capabilities when runtime dependencies are wired", async () => {
+    const service = createCodingAgentRuntimeSummaryService({
+      homePath: "/home/matrix/home",
+      terminalRegistry: registryWith(1),
+      threads: {
+        listThreads: async () => ({ items: [], hasMore: false, limit: 50 }),
+      },
+      now: () => now,
+      runtime: { id: "rt_primary", label: "Primary Matrix computer" },
+    });
+
+    const summary = RuntimeSummarySchema.parse(await service.getSummary(testPrincipal));
+
+    expect(summary.capabilities).toEqual(expect.arrayContaining([
+      expect.objectContaining({ id: "codingAgentsRuntimeSummary", enabled: true }),
+      expect.objectContaining({ id: "codingAgentsDesktopWorkspace", enabled: true }),
+      expect.objectContaining({ id: "codingAgentsMobileWorkspace", enabled: true }),
+      expect.objectContaining({ id: "codingAgentsThreadCreate", enabled: true }),
+      expect.objectContaining({ id: "codingAgentsApprovals", enabled: true }),
+      expect.objectContaining({ id: "codingAgentsNativeMobileTerminal", enabled: true }),
+    ]));
+  });
+
   it("serves authenticated summaries through a safe route", async () => {
     const service = createCodingAgentRuntimeSummaryService({
       homePath: "/home/matrix/home",

--- a/tests/gateway/coding-agents-summary.test.ts
+++ b/tests/gateway/coding-agents-summary.test.ts
@@ -24,6 +24,12 @@ function registryWith(count: number): CodingAgentTerminalSessionRegistry {
   };
 }
 
+function capability(summary: ReturnType<typeof RuntimeSummarySchema.parse>, id: string) {
+  const match = summary.capabilities.find((candidate) => candidate.id === id);
+  expect(match).toBeDefined();
+  return match!;
+}
+
 describe("coding agent runtime summary", () => {
   it("returns a capped safe runtime summary from provider and terminal state", async () => {
     const service = createCodingAgentRuntimeSummaryService({
@@ -195,6 +201,10 @@ describe("coding agent runtime summary", () => {
       threads: {
         listThreads: async () => ({ items: [], hasMore: false, limit: 50 }),
       },
+      capabilities: {
+        workspace: true,
+        approvals: true,
+      },
       now: () => now,
       runtime: { id: "rt_primary", label: "Primary Matrix computer" },
     });
@@ -209,6 +219,46 @@ describe("coding agent runtime summary", () => {
       expect.objectContaining({ id: "codingAgentsApprovals", enabled: true }),
       expect.objectContaining({ id: "codingAgentsNativeMobileTerminal", enabled: true }),
     ]));
+  });
+
+  it("does not expose workspace or approval capabilities from thread storage alone", async () => {
+    const service = createCodingAgentRuntimeSummaryService({
+      homePath: "/home/matrix/home",
+      threads: {
+        listThreads: async () => ({ items: [], hasMore: false, limit: 50 }),
+      },
+      now: () => now,
+      runtime: { id: "rt_primary", label: "Primary Matrix computer" },
+    });
+
+    const summary = RuntimeSummarySchema.parse(await service.getSummary(testPrincipal));
+
+    expect(capability(summary, "codingAgentsThreadCreate")).toMatchObject({ enabled: true });
+    expect(capability(summary, "codingAgentsDesktopWorkspace")).toMatchObject({ enabled: false });
+    expect(capability(summary, "codingAgentsMobileWorkspace")).toMatchObject({ enabled: false });
+    expect(capability(summary, "codingAgentsApprovals")).toMatchObject({ enabled: false });
+  });
+
+  it("keeps approvals disabled for workspace providers without approval decision bridging", async () => {
+    const service = createCodingAgentRuntimeSummaryService({
+      homePath: "/home/matrix/home",
+      threads: {
+        listThreads: async () => ({ items: [], hasMore: false, limit: 50 }),
+      },
+      capabilities: {
+        workspace: true,
+        approvals: false,
+      },
+      now: () => now,
+      runtime: { id: "rt_primary", label: "Primary Matrix computer" },
+    });
+
+    const summary = RuntimeSummarySchema.parse(await service.getSummary(testPrincipal));
+
+    expect(capability(summary, "codingAgentsDesktopWorkspace")).toMatchObject({ enabled: true });
+    expect(capability(summary, "codingAgentsMobileWorkspace")).toMatchObject({ enabled: true });
+    expect(capability(summary, "codingAgentsThreadCreate")).toMatchObject({ enabled: true });
+    expect(capability(summary, "codingAgentsApprovals")).toMatchObject({ enabled: false });
   });
 
   it("serves authenticated summaries through a safe route", async () => {


### PR DESCRIPTION
## Summary
- derive runtime capability flags from wired coding-agent dependencies instead of hardcoded disabled values
- report desktop/mobile read-only workspace capabilities, approvals, and native mobile terminal availability when supported
- update the current-state inventory to reflect the resolved capability alignment

## Tests
- pnpm exec vitest run tests/gateway/coding-agents-summary.test.ts tests/gateway/coding-agents-threads.test.ts tests/contracts/coding-agents.test.ts
- pnpm --filter @matrix-os/gateway exec tsc --noEmit
- bun run check:patterns
- bun run typecheck
- git diff --check
- rg -n "t3code|reference repo|external inspiration" packages/gateway/src/coding-agents/runtime-summary.ts tests/gateway/coding-agents-summary.test.ts specs/105-coding-agent-shells/current-state.md