### PR TITLE
feat(gateway): reconcile coding agent session stops

### DIFF
--- a/packages/gateway/src/coding-agents/session-stop-reconciler.ts
+++ b/packages/gateway/src/coding-agents/session-stop-reconciler.ts
@@ -5,9 +5,13 @@ import type { CodingAgentThreadStore } from "./thread-store.js";
 const DEFAULT_MAX_PENDING_STOPS = 100;
 const DEFAULT_RETRY_DELAY_MS = 1_000;
 const MAX_RETRY_DELAY_MS = 60_000;
+const OwnerIdSchema = z.string().min(1).max(160).regex(/^[A-Za-z0-9_.:@-]+$/);
+const WorkspaceSessionIdSchema = z.string().min(1).max(160).regex(/^sess_[A-Za-z0-9_-]+$/);
 
 const SessionStopInputSchema = z.object({
+  id: WorkspaceSessionIdSchema,
   kind: z.enum(["shell", "agent"]),
+  ownerId: OwnerIdSchema,
   runtime: z.object({
     status: z.enum(["starting", "running", "idle", "waiting", "exited", "failed", "degraded"]),
   }).passthrough(),
@@ -16,6 +20,8 @@ const SessionStopInputSchema = z.object({
 
 type SessionStopInput = z.infer<typeof SessionStopInputSchema>;
 type PendingStop = {
+  ownerId: string;
+  workspaceSessionId: string;
   terminalSessionId: string;
   runtimeStatus: "exited" | "failed" | "degraded";
 };
@@ -37,7 +43,11 @@ export function createCodingAgentSessionStopReconciler(options: {
 
   function enqueue(stop: PendingStop): void {
     pendingStops = [
-      ...pendingStops.filter((candidate) => candidate.terminalSessionId !== stop.terminalSessionId),
+      ...pendingStops.filter((candidate) =>
+        candidate.ownerId !== stop.ownerId ||
+        candidate.workspaceSessionId !== stop.workspaceSessionId ||
+        candidate.terminalSessionId !== stop.terminalSessionId
+      ),
       stop,
     ].slice(-maxPending);
   }
@@ -71,6 +81,8 @@ export function createCodingAgentSessionStopReconciler(options: {
     }
     try {
       await store.reconcileTerminalSessionStopped({
+        ownerId: stop.ownerId,
+        workspaceSessionId: stop.workspaceSessionId,
         terminalSessionId: stop.terminalSessionId,
         runtimeStatus: stop.runtimeStatus,
       });
@@ -114,6 +126,8 @@ export function createCodingAgentSessionStopReconciler(options: {
       }
       try {
         await reconcileOrRetain({
+          ownerId: parsed.ownerId,
+          workspaceSessionId: parsed.id,
           terminalSessionId: parsed.terminalSessionId,
           runtimeStatus: parsed.runtime.status,
         });

--- a/packages/gateway/src/coding-agents/session-stop-reconciler.ts
+++ b/packages/gateway/src/coding-agents/session-stop-reconciler.ts
@@ -1,0 +1,136 @@
+import { z } from "zod/v4";
+import { TerminalSessionIdSchema } from "@matrix-os/contracts";
+import type { CodingAgentThreadStore } from "./thread-store.js";
+
+const DEFAULT_MAX_PENDING_STOPS = 100;
+const DEFAULT_RETRY_DELAY_MS = 1_000;
+const MAX_RETRY_DELAY_MS = 60_000;
+
+const SessionStopInputSchema = z.object({
+  kind: z.enum(["shell", "agent"]),
+  runtime: z.object({
+    status: z.enum(["starting", "running", "idle", "waiting", "exited", "failed", "degraded"]),
+  }).passthrough(),
+  terminalSessionId: TerminalSessionIdSchema,
+}).passthrough();
+
+type SessionStopInput = z.infer<typeof SessionStopInputSchema>;
+type PendingStop = {
+  terminalSessionId: string;
+  runtimeStatus: "exited" | "failed" | "degraded";
+};
+
+function stoppedRuntimeStatus(status: SessionStopInput["runtime"]["status"]): status is PendingStop["runtimeStatus"] {
+  return status === "exited" || status === "failed" || status === "degraded";
+}
+
+export function createCodingAgentSessionStopReconciler(options: {
+  maxPending?: number;
+  retryDelayMs?: number;
+} = {}) {
+  const maxPending = Math.max(1, Math.min(options.maxPending ?? DEFAULT_MAX_PENDING_STOPS, DEFAULT_MAX_PENDING_STOPS));
+  const retryDelayMs = Math.max(10, Math.min(options.retryDelayMs ?? DEFAULT_RETRY_DELAY_MS, MAX_RETRY_DELAY_MS));
+  let threadStore: Pick<CodingAgentThreadStore, "reconcileTerminalSessionStopped"> | undefined;
+  let pendingStops: PendingStop[] = [];
+  let retryTimer: ReturnType<typeof setTimeout> | undefined;
+  let disposed = false;
+
+  function enqueue(stop: PendingStop): void {
+    pendingStops = [
+      ...pendingStops.filter((candidate) => candidate.terminalSessionId !== stop.terminalSessionId),
+      stop,
+    ].slice(-maxPending);
+  }
+
+  function clearRetry(): void {
+    if (!retryTimer) return;
+    clearTimeout(retryTimer);
+    retryTimer = undefined;
+  }
+
+  function scheduleRetry(): void {
+    if (disposed || retryTimer || !threadStore || pendingStops.length === 0) return;
+    retryTimer = setTimeout(() => {
+      retryTimer = undefined;
+      void drainPendingStops().catch((err: unknown) => {
+        console.warn(
+          "[coding-agents] Retained session stop retry failed:",
+          err instanceof Error ? err.message : String(err),
+        );
+        scheduleRetry();
+      });
+    }, retryDelayMs);
+    retryTimer.unref?.();
+  }
+
+  async function reconcileOrRetain(stop: PendingStop): Promise<void> {
+    const store = threadStore;
+    if (!store) {
+      enqueue(stop);
+      return;
+    }
+    try {
+      await store.reconcileTerminalSessionStopped({
+        terminalSessionId: stop.terminalSessionId,
+        runtimeStatus: stop.runtimeStatus,
+      });
+    } catch (err: unknown) {
+      enqueue(stop);
+      scheduleRetry();
+      throw err;
+    }
+  }
+
+  async function drainPendingStops(): Promise<void> {
+    if (!threadStore || pendingStops.length === 0) return;
+    clearRetry();
+    const stopsToFlush = pendingStops;
+    pendingStops = [];
+    let firstError: unknown;
+    for (const stop of stopsToFlush) {
+      try {
+        await reconcileOrRetain(stop);
+      } catch (err: unknown) {
+        firstError ??= err;
+      }
+    }
+    if (firstError) {
+      scheduleRetry();
+      throw firstError;
+    }
+  }
+
+  return {
+    async handleSessionStopped(input: unknown): Promise<void> {
+      const parsed = SessionStopInputSchema.parse(input);
+      if (parsed.kind !== "agent" || !stoppedRuntimeStatus(parsed.runtime.status)) {
+        return;
+      }
+      let firstError: unknown;
+      try {
+        await drainPendingStops();
+      } catch (err: unknown) {
+        firstError = err;
+      }
+      try {
+        await reconcileOrRetain({
+          terminalSessionId: parsed.terminalSessionId,
+          runtimeStatus: parsed.runtime.status,
+        });
+      } catch (err: unknown) {
+        firstError ??= err;
+      }
+      if (firstError) throw firstError;
+    },
+
+    async attachThreadStore(store: Pick<CodingAgentThreadStore, "reconcileTerminalSessionStopped">): Promise<void> {
+      threadStore = store;
+      await drainPendingStops();
+    },
+
+    dispose(): void {
+      disposed = true;
+      clearRetry();
+    },
+  };
+}

--- a/packages/gateway/src/coding-agents/thread-store.ts
+++ b/packages/gateway/src/coding-agents/thread-store.ts
@@ -7,9 +7,11 @@ import {
   AgentThreadSnapshotSchema,
   AgentThreadSummarySchema,
   ApprovalIdSchema,
+  IsoTimestampSchema,
   ProviderIdSchema,
   RequestIdSchema,
   SafeClientErrorSchema,
+  TerminalSessionIdSchema,
   type AgentProviderSummary,
   type AgentThreadEvent,
   type AgentThreadSummary,
@@ -29,6 +31,7 @@ const MAX_EVENTS_PER_THREAD = 500;
 const MAX_ABORT_REQUEST_IDS = 50;
 const MAX_APPROVAL_DECISION_REQUEST_IDS = 50;
 const MAX_INPUT_ANSWER_REQUEST_IDS = 50;
+const MAX_PENDING_TERMINAL_STOPS = 100;
 
 const OwnerIdSchema = z.string().min(1).max(160).regex(/^[A-Za-z0-9_.:@-]+$/);
 
@@ -40,17 +43,31 @@ const StoredThreadSchema = AgentThreadSummarySchema.extend({
   inputAnswerClientRequestIds: z.array(RequestIdSchema).max(MAX_INPUT_ANSWER_REQUEST_IDS).default([]),
 }).strict();
 
+const TerminalSessionStoppedReconciliationSchema = z.object({
+  terminalSessionId: TerminalSessionIdSchema,
+  runtimeStatus: z.enum(["starting", "running", "idle", "waiting", "exited", "failed", "degraded"]),
+}).strict();
+const TerminalStoppedStatusSchema = z.enum(["exited", "failed", "degraded"]);
+const PendingTerminalStopSchema = z.object({
+  terminalSessionId: TerminalSessionIdSchema,
+  runtimeStatus: TerminalStoppedStatusSchema,
+  occurredAt: IsoTimestampSchema,
+}).strict();
+
 const StoredThreadStateSchema = z.object({
   version: z.literal(1),
   threads: z.array(StoredThreadSchema).max(MAX_STORED_THREADS),
   events: z.array(AgentThreadEventSchema).max(MAX_STORED_THREADS * MAX_EVENTS_PER_THREAD),
+  pendingTerminalStops: z.array(PendingTerminalStopSchema).max(MAX_PENDING_TERMINAL_STOPS).default([]),
 }).strict();
 
 type StoredThread = z.infer<typeof StoredThreadSchema>;
 type StoredThreadState = z.infer<typeof StoredThreadStateSchema>;
+type PendingTerminalStop = z.infer<typeof PendingTerminalStopSchema>;
 type AgentThreadSnapshot = z.infer<typeof AgentThreadSnapshotSchema>;
 type ThreadCreateResult = { snapshot: AgentThreadSnapshot; existing: boolean };
 type ThreadCreateMutationResult = ThreadCreateResult & { eventsToPublish: AgentThreadEvent[] };
+type TerminalSessionStoppedReconciliation = z.infer<typeof TerminalSessionStoppedReconciliationSchema>;
 type ThreadEventSink = (input: {
   ownerId: string;
   threadId: string;
@@ -126,6 +143,7 @@ export interface CodingAgentThreadStore {
     inputRequestId: string,
     request: UserInputAnswerRequest,
   ): Promise<AgentThreadSnapshot>;
+  reconcileTerminalSessionStopped(input: TerminalSessionStoppedReconciliation): Promise<AgentThreadSnapshot[]>;
   registerEventSink(sink: ThreadEventSink): { dispose(): void };
 }
 
@@ -197,7 +215,7 @@ export function createFakeCodingAgentProvider(options: { providerId: string; del
 }
 
 function emptyState(): StoredThreadState {
-  return { version: 1, threads: [], events: [] };
+  return { version: 1, threads: [], events: [], pendingTerminalStops: [] };
 }
 
 function statePath(homePath: string): string {
@@ -310,7 +328,12 @@ function trimState(state: StoredThreadState): StoredThreadState {
       return kept;
     }, []);
   const events = latestEvents.reverse();
-  return { version: 1, threads, events };
+  return {
+    version: 1,
+    threads,
+    events,
+    pendingTerminalStops: state.pendingTerminalStops.slice(-MAX_PENDING_TERMINAL_STOPS),
+  };
 }
 
 function activeThread(thread: StoredThread): boolean {
@@ -319,6 +342,39 @@ function activeThread(thread: StoredThread): boolean {
 
 function terminalThread(thread: StoredThread): boolean {
   return !activeThread(thread);
+}
+
+function stoppedRuntimeStatus(
+  runtimeStatus: TerminalSessionStoppedReconciliation["runtimeStatus"],
+): runtimeStatus is PendingTerminalStop["runtimeStatus"] {
+  return TerminalStoppedStatusSchema.safeParse(runtimeStatus).success;
+}
+
+function appendPendingTerminalStop(
+  pendingTerminalStops: PendingTerminalStop[],
+  stop: PendingTerminalStop,
+): PendingTerminalStop[] {
+  return [
+    ...pendingTerminalStops.filter((candidate) => candidate.terminalSessionId !== stop.terminalSessionId),
+    stop,
+  ].slice(-MAX_PENDING_TERMINAL_STOPS);
+}
+
+function consumePendingTerminalStop(
+  pendingTerminalStops: PendingTerminalStop[],
+  terminalSessionId: string | undefined,
+): { pendingStop?: PendingTerminalStop; pendingTerminalStops: PendingTerminalStop[] } {
+  if (!terminalSessionId) {
+    return { pendingTerminalStops };
+  }
+  const pendingStop = pendingTerminalStops.find((candidate) => candidate.terminalSessionId === terminalSessionId);
+  if (!pendingStop) {
+    return { pendingTerminalStops };
+  }
+  return {
+    pendingStop,
+    pendingTerminalStops: pendingTerminalStops.filter((candidate) => candidate.terminalSessionId !== terminalSessionId),
+  };
 }
 
 function safeProviderRunFailureEvents(threadId: string, now: () => Date, eventId: () => string): AgentThreadEvent[] {
@@ -360,6 +416,31 @@ function defaultAbortEvents(threadId: string, now: () => Date, eventId: () => st
       threadId,
       occurredAt: now().toISOString(),
       outcome: "aborted",
+    }),
+  ];
+}
+
+function terminalStoppedEvents(
+  threadId: string,
+  runtimeStatus: TerminalSessionStoppedReconciliation["runtimeStatus"],
+  now: () => Date,
+  eventId: () => string,
+): AgentThreadEvent[] {
+  const failed = runtimeStatus !== "exited";
+  return [
+    AgentThreadEventSchema.parse({
+      type: "thread.status",
+      eventId: eventId(),
+      threadId,
+      occurredAt: now().toISOString(),
+      status: failed ? "failed" : "completed",
+    }),
+    AgentThreadEventSchema.parse({
+      type: "thread.completed",
+      eventId: eventId(),
+      threadId,
+      occurredAt: now().toISOString(),
+      outcome: failed ? "failed" : "completed",
     }),
   ];
 }
@@ -554,10 +635,19 @@ export function createCodingAgentThreadStore(options: CodingAgentThreadStoreOpti
         for (const event of events.slice(1)) {
           thread = applyEvent(thread, event);
         }
+        const pending = consumePendingTerminalStop(state.pendingTerminalStops, thread.terminalSessionId);
+        if (pending.pendingStop && activeThread(thread)) {
+          const stopEvents = terminalStoppedEvents(thread.id, pending.pendingStop.runtimeStatus, now, nextEventId);
+          events.push(...stopEvents);
+          for (const event of stopEvents) {
+            thread = applyEvent(thread, event);
+          }
+        }
         const nextState = {
           version: 1 as const,
           threads: [thread, ...state.threads],
           events: [...state.events, ...events],
+          pendingTerminalStops: pending.pendingTerminalStops,
         };
         const result: ThreadCreateMutationResult = {
           snapshot: snapshotFor(thread, nextState.events),
@@ -635,6 +725,7 @@ export function createCodingAgentThreadStore(options: CodingAgentThreadStoreOpti
           version: 1 as const,
           threads: state.threads.map((candidate) => candidate.id === thread.id ? nextThread : candidate),
           events: [...state.events, ...abortEvents],
+          pendingTerminalStops: state.pendingTerminalStops,
         };
         return {
           state: nextState,
@@ -689,6 +780,7 @@ export function createCodingAgentThreadStore(options: CodingAgentThreadStoreOpti
           version: 1 as const,
           threads: state.threads.map((candidate) => candidate.id === thread.id ? nextThread : candidate),
           events: [...state.events, ...approvalEvents],
+          pendingTerminalStops: state.pendingTerminalStops,
         };
         return {
           state: nextState,
@@ -743,6 +835,7 @@ export function createCodingAgentThreadStore(options: CodingAgentThreadStoreOpti
           version: 1 as const,
           threads: state.threads.map((candidate) => candidate.id === thread.id ? nextThread : candidate),
           events: [...state.events, ...inputEvents],
+          pendingTerminalStops: state.pendingTerminalStops,
         };
         return {
           state: nextState,
@@ -751,6 +844,90 @@ export function createCodingAgentThreadStore(options: CodingAgentThreadStoreOpti
       });
       publish(principal.userId, threadId, result.eventsToPublish);
       return result.snapshot;
+    },
+    async reconcileTerminalSessionStopped(input) {
+      const parsed = TerminalSessionStoppedReconciliationSchema.parse(input);
+      if (!stoppedRuntimeStatus(parsed.runtimeStatus)) {
+        return [];
+      }
+      const runtimeStatus = parsed.runtimeStatus;
+
+      const result = await mutate(async (state) => {
+        const threadsForTerminal = state.threads.filter((thread) => thread.terminalSessionId === parsed.terminalSessionId);
+        const matchingThreads = threadsForTerminal.filter(activeThread);
+        if (matchingThreads.length === 0) {
+          if (threadsForTerminal.length > 0) {
+            return {
+              state: {
+                ...state,
+                pendingTerminalStops: state.pendingTerminalStops.filter((stop) =>
+                  stop.terminalSessionId !== parsed.terminalSessionId
+                ),
+              },
+              result: {
+                snapshots: [] as AgentThreadSnapshot[],
+                eventsToPublish: [] as Array<{ ownerId: string; threadId: string; events: AgentThreadEvent[] }>,
+              },
+            };
+          }
+          const nextState = {
+            ...state,
+            pendingTerminalStops: appendPendingTerminalStop(state.pendingTerminalStops, {
+              terminalSessionId: parsed.terminalSessionId,
+              runtimeStatus,
+              occurredAt: now().toISOString(),
+            }),
+          };
+          return {
+            state: nextState,
+            result: {
+              snapshots: [] as AgentThreadSnapshot[],
+              eventsToPublish: [] as Array<{ ownerId: string; threadId: string; events: AgentThreadEvent[] }>,
+            },
+          };
+        }
+
+        const reconciledThreads = matchingThreads.map((thread) => {
+          const events = terminalStoppedEvents(thread.id, runtimeStatus, now, nextEventId);
+          let nextThread = thread;
+          for (const event of events) {
+            nextThread = applyEvent(nextThread, event);
+          }
+          return { thread, nextThread, events };
+        });
+
+        const nextEvents = [
+          ...state.events,
+          ...reconciledThreads.flatMap((entry) => entry.events),
+        ];
+        const nextState = {
+          version: 1 as const,
+          threads: state.threads.map((thread) =>
+            reconciledThreads.find((entry) => entry.thread.id === thread.id)?.nextThread ?? thread
+          ),
+          events: nextEvents,
+          pendingTerminalStops: state.pendingTerminalStops.filter((stop) =>
+            stop.terminalSessionId !== parsed.terminalSessionId
+          ),
+        };
+        const snapshots = reconciledThreads.map((entry) => snapshotFor(entry.nextThread, nextState.events));
+        return {
+          state: nextState,
+          result: {
+            snapshots,
+            eventsToPublish: reconciledThreads.map((entry) => ({
+              ownerId: entry.thread.ownerId,
+              threadId: entry.thread.id,
+              events: entry.events,
+            })),
+          },
+        };
+      });
+
+      for (const item of result.eventsToPublish) {
+        publish(item.ownerId, item.threadId, item.events);
+      }
+      return result.snapshots;
     },
     registerEventSink(sink) {
       if (eventSinks.length >= 8) {

--- a/packages/gateway/src/coding-agents/thread-store.ts
+++ b/packages/gateway/src/coding-agents/thread-store.ts
@@ -34,6 +34,7 @@ const MAX_INPUT_ANSWER_REQUEST_IDS = 50;
 const MAX_PENDING_TERMINAL_STOPS = 100;
 
 const OwnerIdSchema = z.string().min(1).max(160).regex(/^[A-Za-z0-9_.:@-]+$/);
+const WorkspaceSessionIdSchema = z.string().min(1).max(160).regex(/^sess_[A-Za-z0-9_-]+$/);
 
 const StoredThreadSchema = AgentThreadSummarySchema.extend({
   ownerId: OwnerIdSchema,
@@ -44,11 +45,15 @@ const StoredThreadSchema = AgentThreadSummarySchema.extend({
 }).strict();
 
 const TerminalSessionStoppedReconciliationSchema = z.object({
+  ownerId: OwnerIdSchema,
+  workspaceSessionId: WorkspaceSessionIdSchema.optional(),
   terminalSessionId: TerminalSessionIdSchema,
   runtimeStatus: z.enum(["starting", "running", "idle", "waiting", "exited", "failed", "degraded"]),
 }).strict();
 const TerminalStoppedStatusSchema = z.enum(["exited", "failed", "degraded"]);
 const PendingTerminalStopSchema = z.object({
+  ownerId: OwnerIdSchema,
+  workspaceSessionId: WorkspaceSessionIdSchema.optional(),
   terminalSessionId: TerminalSessionIdSchema,
   runtimeStatus: TerminalStoppedStatusSchema,
   occurredAt: IsoTimestampSchema,
@@ -355,25 +360,39 @@ function appendPendingTerminalStop(
   stop: PendingTerminalStop,
 ): PendingTerminalStop[] {
   return [
-    ...pendingTerminalStops.filter((candidate) => candidate.terminalSessionId !== stop.terminalSessionId),
+    ...pendingTerminalStops.filter((candidate) =>
+      candidate.ownerId !== stop.ownerId ||
+      candidate.workspaceSessionId !== stop.workspaceSessionId ||
+      candidate.terminalSessionId !== stop.terminalSessionId
+    ),
     stop,
   ].slice(-MAX_PENDING_TERMINAL_STOPS);
 }
 
+function workspaceSessionIdForThread(threadId: string): string {
+  return `sess_${threadId.slice("thread_".length)}`;
+}
+
+function terminalStopMatchesThread(stop: Pick<PendingTerminalStop, "ownerId" | "workspaceSessionId" | "terminalSessionId">, thread: StoredThread): boolean {
+  return thread.ownerId === stop.ownerId &&
+    thread.terminalSessionId === stop.terminalSessionId &&
+    (stop.workspaceSessionId === undefined || stop.workspaceSessionId === workspaceSessionIdForThread(thread.id));
+}
+
 function consumePendingTerminalStop(
   pendingTerminalStops: PendingTerminalStop[],
-  terminalSessionId: string | undefined,
+  thread: StoredThread,
 ): { pendingStop?: PendingTerminalStop; pendingTerminalStops: PendingTerminalStop[] } {
-  if (!terminalSessionId) {
+  if (!thread.terminalSessionId) {
     return { pendingTerminalStops };
   }
-  const pendingStop = pendingTerminalStops.find((candidate) => candidate.terminalSessionId === terminalSessionId);
+  const pendingStop = pendingTerminalStops.find((candidate) => terminalStopMatchesThread(candidate, thread));
   if (!pendingStop) {
     return { pendingTerminalStops };
   }
   return {
     pendingStop,
-    pendingTerminalStops: pendingTerminalStops.filter((candidate) => candidate.terminalSessionId !== terminalSessionId),
+    pendingTerminalStops: pendingTerminalStops.filter((candidate) => candidate !== pendingStop),
   };
 }
 
@@ -635,7 +654,7 @@ export function createCodingAgentThreadStore(options: CodingAgentThreadStoreOpti
         for (const event of events.slice(1)) {
           thread = applyEvent(thread, event);
         }
-        const pending = consumePendingTerminalStop(state.pendingTerminalStops, thread.terminalSessionId);
+        const pending = consumePendingTerminalStop(state.pendingTerminalStops, thread);
         if (pending.pendingStop && activeThread(thread)) {
           const stopEvents = terminalStoppedEvents(thread.id, pending.pendingStop.runtimeStatus, now, nextEventId);
           events.push(...stopEvents);
@@ -853,15 +872,24 @@ export function createCodingAgentThreadStore(options: CodingAgentThreadStoreOpti
       const runtimeStatus = parsed.runtimeStatus;
 
       const result = await mutate(async (state) => {
-        const threadsForTerminal = state.threads.filter((thread) => thread.terminalSessionId === parsed.terminalSessionId);
+        const stopKey = {
+          ownerId: parsed.ownerId,
+          workspaceSessionId: parsed.workspaceSessionId,
+          terminalSessionId: parsed.terminalSessionId,
+        };
+        const threadsForTerminal = state.threads.filter((thread) => terminalStopMatchesThread(stopKey, thread));
         const matchingThreads = threadsForTerminal.filter(activeThread);
         if (matchingThreads.length === 0) {
-          if (threadsForTerminal.length > 0) {
+          if (threadsForTerminal.some(terminalThread)) {
             return {
               state: {
                 ...state,
                 pendingTerminalStops: state.pendingTerminalStops.filter((stop) =>
-                  stop.terminalSessionId !== parsed.terminalSessionId
+                  !(
+                    stop.ownerId === parsed.ownerId &&
+                    stop.workspaceSessionId === parsed.workspaceSessionId &&
+                    stop.terminalSessionId === parsed.terminalSessionId
+                  )
                 ),
               },
               result: {
@@ -873,6 +901,8 @@ export function createCodingAgentThreadStore(options: CodingAgentThreadStoreOpti
           const nextState = {
             ...state,
             pendingTerminalStops: appendPendingTerminalStop(state.pendingTerminalStops, {
+              ownerId: parsed.ownerId,
+              workspaceSessionId: parsed.workspaceSessionId,
               terminalSessionId: parsed.terminalSessionId,
               runtimeStatus,
               occurredAt: now().toISOString(),
@@ -907,7 +937,11 @@ export function createCodingAgentThreadStore(options: CodingAgentThreadStoreOpti
           ),
           events: nextEvents,
           pendingTerminalStops: state.pendingTerminalStops.filter((stop) =>
-            stop.terminalSessionId !== parsed.terminalSessionId
+            !(
+              stop.ownerId === parsed.ownerId &&
+              stop.workspaceSessionId === parsed.workspaceSessionId &&
+              stop.terminalSessionId === parsed.terminalSessionId
+            )
           ),
         };
         const snapshots = reconciledThreads.map((entry) => snapshotFor(entry.nextThread, nextState.events));

--- a/packages/gateway/src/server.ts
+++ b/packages/gateway/src/server.ts
@@ -41,6 +41,8 @@ import { createAgentSessionManager } from "./agent-session-manager.js";
 import { createAgentSandbox } from "./agent-sandbox.js";
 import { createWorktreeManager } from "./worktree-manager.js";
 import { createWorkspaceSessionOrchestrator } from "./workspace-session-orchestrator.js";
+import { createWorkspaceEventStore } from "./workspace-events.js";
+import { createWorkspaceEventPublisher } from "./workspace-event-publisher.js";
 import { createZellijRuntime } from "./zellij-runtime.js";
 import { createSessionRuntimeBridge } from "./session-runtime-bridge.js";
 import { createWorkspaceStartupRecovery } from "./workspace-startup-recovery.js";
@@ -95,9 +97,10 @@ import { createAgentCredentialStatusService } from "./onboarding/agent-credentia
 import { createAgentCredentialRoutes } from "./onboarding/agent-credential-routes.js";
 import { createCodingAgentRuntimeSummaryService } from "./coding-agents/runtime-summary.js";
 import { createCodingAgentRoutes } from "./coding-agents/routes.js";
-import { createCodingAgentThreadStore, createFakeCodingAgentProvider, type CodingAgentProviderAdapter } from "./coding-agents/thread-store.js";
+import { createCodingAgentThreadStore, createFakeCodingAgentProvider, type CodingAgentProviderAdapter, type CodingAgentThreadStore } from "./coding-agents/thread-store.js";
 import { createCodingAgentThreadStream, threadStreamFrameDataToString } from "./coding-agents/thread-stream.js";
 import { createWorkspaceCodingAgentProvider } from "./coding-agents/workspace-provider.js";
+import { createCodingAgentSessionStopReconciler } from "./coding-agents/session-stop-reconciler.js";
 import { createAgentActionAuditService } from "./onboarding/agent-action-audit.js";
 import { capabilityIdsForConnectedServices, createIntegrationCapabilityService } from "./onboarding/integration-capabilities.js";
 import { createIntegrationCapabilityRoutes } from "./onboarding/integration-capability-routes.js";
@@ -469,6 +472,13 @@ export async function createGateway(config: GatewayConfig) {
       };
     },
   });
+  let codingAgentThreadStore: CodingAgentThreadStore | undefined;
+  const codingAgentSessionStopReconciler = createCodingAgentSessionStopReconciler();
+  const workspaceEventStore = createWorkspaceEventStore({ homePath });
+  const workspaceEventPublisher = createWorkspaceEventPublisher({
+    eventStore: workspaceEventStore,
+    onSessionStopped: (session) => codingAgentSessionStopReconciler.handleSessionStopped(session),
+  });
   const codingAgentProviders: CodingAgentProviderAdapter[] = [];
   if (process.env.MATRIX_CODING_AGENTS_WORKSPACE_PROVIDER === "1") {
     const codingAgentWorktreeManager = createWorktreeManager({ homePath });
@@ -484,6 +494,7 @@ export async function createGateway(config: GatewayConfig) {
       agentSessionManager: codingAgentSessionManager,
       agentSandbox: createAgentSandbox({ homePath }),
       sessionRuntimeBridge: workspaceSessionRuntimeBridge,
+      eventPublisher: workspaceEventPublisher,
     });
     codingAgentProviders.push(createWorkspaceCodingAgentProvider({
       providerId: "codex",
@@ -493,13 +504,18 @@ export async function createGateway(config: GatewayConfig) {
   } else if (process.env.MATRIX_CODING_AGENTS_FAKE_PROVIDER === "1") {
     codingAgentProviders.push(createFakeCodingAgentProvider({ providerId: "codex" }));
   }
-  const codingAgentThreadStore = codingAgentProviders.length > 0
+  codingAgentThreadStore = codingAgentProviders.length > 0
     ? createCodingAgentThreadStore({
       homePath,
       providers: codingAgentProviders,
     })
     : undefined;
   const codingAgentWorkspaceEnabled = Boolean(codingAgentThreadStore);
+  if (codingAgentThreadStore) {
+    void codingAgentSessionStopReconciler.attachThreadStore(codingAgentThreadStore).catch((err: unknown) => {
+      console.warn("[coding-agents] Failed to flush pending session stops:", err instanceof Error ? err.message : String(err));
+    });
+  }
   const codingAgentThreadStream = codingAgentThreadStore
     ? createCodingAgentThreadStream({ threads: codingAgentThreadStore })
     : undefined;
@@ -2667,6 +2683,8 @@ export async function createGateway(config: GatewayConfig) {
     homePath,
     zellijRuntime: workspaceZellijRuntime,
     sessionRuntimeBridge: workspaceSessionRuntimeBridge,
+    eventStore: workspaceEventStore,
+    eventPublisher: workspaceEventPublisher,
     getOwnerScope: (c) => ({ type: "user", id: requireRequestPrincipal(c).userId }),
   }));
   app.route("/api/symphony", createElixirSymphonyProxyRoutes({
@@ -4030,6 +4048,7 @@ export async function createGateway(config: GatewayConfig) {
       proactiveHeartbeat.stop();
       cronService.stop();
       codingAgentThreadStream?.shutdown();
+      codingAgentSessionStopReconciler.dispose();
       drainReconnectableAbortEntries(reconnectableAbortControllers);
       if (canvasCleanupTimer) clearInterval(canvasCleanupTimer);
       canvasSubscriptionHub?.close();

--- a/packages/gateway/src/workspace-event-publisher.ts
+++ b/packages/gateway/src/workspace-event-publisher.ts
@@ -12,6 +12,10 @@ type PublishFailure = {
   status: number;
   error: WorkspaceError;
 };
+type SessionLifecyclePick = Pick<
+  WorkspaceSessionView,
+  "id" | "kind" | "projectSlug" | "taskId" | "worktreeId" | "pr" | "agent" | "runtime" | "terminalSessionId"
+>;
 
 function isPublishFailure(result: unknown): result is PublishFailure {
   return typeof result === "object" &&
@@ -27,6 +31,7 @@ function isPublishFailure(result: unknown): result is PublishFailure {
 
 export function createWorkspaceEventPublisher(options: {
   eventStore: WorkspaceEventStore;
+  onSessionStopped?: (session: SessionLifecyclePick) => Promise<void> | void;
 }) {
   async function publish(input: PublishEventInput): Promise<void> {
     try {
@@ -39,6 +44,24 @@ export function createWorkspaceEventPublisher(options: {
         "[workspace-event-publisher] Unexpected workspace event publish error:",
         err instanceof Error ? err.message : String(err),
       );
+    }
+  }
+
+  function logSessionStoppedHookFailure(err: unknown): void {
+    console.warn(
+      "[workspace-event-publisher] Session stopped hook failed:",
+      err instanceof Error ? err.message : String(err),
+    );
+  }
+
+  function notifySessionStopped(session: SessionLifecyclePick): void {
+    try {
+      const result = options.onSessionStopped?.(session);
+      if (result && typeof result === "object" && "then" in result) {
+        void Promise.resolve(result).catch(logSessionStoppedHookFailure);
+      }
+    } catch (err: unknown) {
+      logSessionStoppedHookFailure(err);
     }
   }
 
@@ -93,10 +116,7 @@ export function createWorkspaceEventPublisher(options: {
       });
     },
 
-    async publishSessionStarted(session: Pick<
-      WorkspaceSessionView,
-      "id" | "kind" | "projectSlug" | "taskId" | "worktreeId" | "pr" | "agent" | "runtime" | "terminalSessionId"
-    >): Promise<void> {
+    async publishSessionStarted(session: SessionLifecyclePick): Promise<void> {
       await publish({
         type: "session.started",
         scope: { projectSlug: session.projectSlug, taskId: session.taskId, sessionId: session.id },
@@ -111,10 +131,7 @@ export function createWorkspaceEventPublisher(options: {
       });
     },
 
-    async publishSessionStopped(session: Pick<
-      WorkspaceSessionView,
-      "id" | "kind" | "projectSlug" | "taskId" | "worktreeId" | "pr" | "agent" | "runtime" | "terminalSessionId"
-    >): Promise<void> {
+    async publishSessionStopped(session: SessionLifecyclePick): Promise<void> {
       await publish({
         type: "session.stopped",
         scope: { projectSlug: session.projectSlug, taskId: session.taskId, sessionId: session.id },
@@ -127,6 +144,7 @@ export function createWorkspaceEventPublisher(options: {
           worktreeId: session.worktreeId,
         },
       });
+      notifySessionStopped(session);
     },
   };
 }

--- a/packages/gateway/src/workspace-event-publisher.ts
+++ b/packages/gateway/src/workspace-event-publisher.ts
@@ -14,7 +14,7 @@ type PublishFailure = {
 };
 type SessionLifecyclePick = Pick<
   WorkspaceSessionView,
-  "id" | "kind" | "projectSlug" | "taskId" | "worktreeId" | "pr" | "agent" | "runtime" | "terminalSessionId"
+  "id" | "kind" | "projectSlug" | "taskId" | "worktreeId" | "pr" | "agent" | "runtime" | "terminalSessionId" | "ownerId"
 >;
 
 function isPublishFailure(result: unknown): result is PublishFailure {

--- a/specs/105-coding-agent-shells/current-state.md
+++ b/specs/105-coding-agent-shells/current-state.md
@@ -303,7 +303,7 @@ git diff --check
 
 ## Open Questions And Deferred Work
 
-- Session completion reconciliation: workspace-backed sessions need a runtime event path that marks coding-agent threads completed/failed when the underlying workspace session exits without a user abort.
+- Session completion reconciliation: implemented for workspace `session.stopped` events that carry a bound `terminalSessionId`; the gateway thread store marks matching active coding-agent threads completed or failed server-side. Remaining work: if runtime managers add autonomous process-exit detection beyond explicit workspace stop events, route those through the same `session.stopped` publisher path.
 - File/review/preview shell surfaces: contracts exist and workspace routes exist, but coding-agent-specific UI integration is not implemented yet.
 - Browser shell entry point: Canvas-first placement is still undecided.
 - Notifications/attention routing: desktop notification IPC exists, but thread attention notifications are not yet wired end-to-end from gateway events.

--- a/tests/gateway/coding-agents-session-stop-reconciler.test.ts
+++ b/tests/gateway/coding-agents-session-stop-reconciler.test.ts
@@ -1,0 +1,165 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createCodingAgentSessionStopReconciler } from "../../packages/gateway/src/coding-agents/session-stop-reconciler.js";
+
+function stoppedSession(terminalSessionId: string, runtimeStatus: "exited" | "failed" | "degraded" = "exited") {
+  return {
+    id: `sess_${terminalSessionId.replace(/[^A-Za-z0-9_-]/g, "_")}`,
+    kind: "agent",
+    runtime: { status: runtimeStatus },
+    terminalSessionId,
+  };
+}
+
+describe("coding agent session stop reconciler", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("buffers stopped sessions until the thread store is attached", async () => {
+    const store = {
+      reconcileTerminalSessionStopped: vi.fn(async () => []),
+    };
+    const reconciler = createCodingAgentSessionStopReconciler({ maxPending: 4 });
+
+    await reconciler.handleSessionStopped(stoppedSession("term_sess_early", "failed"));
+    expect(store.reconcileTerminalSessionStopped).not.toHaveBeenCalled();
+
+    await reconciler.attachThreadStore(store);
+
+    expect(store.reconcileTerminalSessionStopped).toHaveBeenCalledWith({
+      terminalSessionId: "term_sess_early",
+      runtimeStatus: "failed",
+    });
+  });
+
+  it("caps pending stopped sessions and evicts the oldest before attach", async () => {
+    const store = {
+      reconcileTerminalSessionStopped: vi.fn(async () => []),
+    };
+    const reconciler = createCodingAgentSessionStopReconciler({ maxPending: 2 });
+
+    await reconciler.handleSessionStopped(stoppedSession("term_sess_one"));
+    await reconciler.handleSessionStopped(stoppedSession("term_sess_two"));
+    await reconciler.handleSessionStopped(stoppedSession("term_sess_three"));
+    await reconciler.attachThreadStore(store);
+
+    expect(store.reconcileTerminalSessionStopped).toHaveBeenCalledTimes(2);
+    expect(store.reconcileTerminalSessionStopped).toHaveBeenNthCalledWith(1, {
+      terminalSessionId: "term_sess_two",
+      runtimeStatus: "exited",
+    });
+    expect(store.reconcileTerminalSessionStopped).toHaveBeenNthCalledWith(2, {
+      terminalSessionId: "term_sess_three",
+      runtimeStatus: "exited",
+    });
+  });
+
+  it("retains only failed buffered stops when startup flush partially fails", async () => {
+    let failFirstStop = true;
+    const store = {
+      reconcileTerminalSessionStopped: vi.fn(async (input: { terminalSessionId: string }) => {
+        if (input.terminalSessionId === "term_sess_one" && failFirstStop) {
+          throw new Error("store unavailable");
+        }
+        return [];
+      }),
+    };
+    const reconciler = createCodingAgentSessionStopReconciler({ maxPending: 4 });
+    await reconciler.handleSessionStopped(stoppedSession("term_sess_one"));
+    await reconciler.handleSessionStopped(stoppedSession("term_sess_two"));
+
+    await expect(reconciler.attachThreadStore(store)).rejects.toThrow("store unavailable");
+    failFirstStop = false;
+    await reconciler.attachThreadStore(store);
+
+    expect(store.reconcileTerminalSessionStopped).toHaveBeenCalledTimes(3);
+    expect(store.reconcileTerminalSessionStopped).toHaveBeenNthCalledWith(1, {
+      terminalSessionId: "term_sess_one",
+      runtimeStatus: "exited",
+    });
+    expect(store.reconcileTerminalSessionStopped).toHaveBeenNthCalledWith(2, {
+      terminalSessionId: "term_sess_two",
+      runtimeStatus: "exited",
+    });
+    expect(store.reconcileTerminalSessionStopped).toHaveBeenNthCalledWith(3, {
+      terminalSessionId: "term_sess_one",
+      runtimeStatus: "exited",
+    });
+  });
+
+  it("drains retained startup failures before handling later stop events", async () => {
+    let failFirstStop = true;
+    const store = {
+      reconcileTerminalSessionStopped: vi.fn(async (input: { terminalSessionId: string }) => {
+        if (input.terminalSessionId === "term_sess_one" && failFirstStop) {
+          throw new Error("store unavailable");
+        }
+        return [];
+      }),
+    };
+    const reconciler = createCodingAgentSessionStopReconciler({ maxPending: 4 });
+    await reconciler.handleSessionStopped(stoppedSession("term_sess_one"));
+    await expect(reconciler.attachThreadStore(store)).rejects.toThrow("store unavailable");
+
+    failFirstStop = false;
+    await reconciler.handleSessionStopped(stoppedSession("term_sess_two"));
+
+    expect(store.reconcileTerminalSessionStopped).toHaveBeenCalledTimes(3);
+    expect(store.reconcileTerminalSessionStopped).toHaveBeenNthCalledWith(1, {
+      terminalSessionId: "term_sess_one",
+      runtimeStatus: "exited",
+    });
+    expect(store.reconcileTerminalSessionStopped).toHaveBeenNthCalledWith(2, {
+      terminalSessionId: "term_sess_one",
+      runtimeStatus: "exited",
+    });
+    expect(store.reconcileTerminalSessionStopped).toHaveBeenNthCalledWith(3, {
+      terminalSessionId: "term_sess_two",
+      runtimeStatus: "exited",
+    });
+  });
+
+  it("retries retained startup failures without requiring a later stop event", async () => {
+    vi.useFakeTimers();
+    let failFirstStop = true;
+    const store = {
+      reconcileTerminalSessionStopped: vi.fn(async (input: { terminalSessionId: string }) => {
+        if (input.terminalSessionId === "term_sess_one" && failFirstStop) {
+          throw new Error("store unavailable");
+        }
+        return [];
+      }),
+    };
+    const reconciler = createCodingAgentSessionStopReconciler({ maxPending: 4, retryDelayMs: 25 });
+    await reconciler.handleSessionStopped(stoppedSession("term_sess_one"));
+    await expect(reconciler.attachThreadStore(store)).rejects.toThrow("store unavailable");
+
+    failFirstStop = false;
+    await vi.advanceTimersByTimeAsync(25);
+
+    expect(store.reconcileTerminalSessionStopped).toHaveBeenCalledTimes(2);
+    expect(store.reconcileTerminalSessionStopped).toHaveBeenNthCalledWith(2, {
+      terminalSessionId: "term_sess_one",
+      runtimeStatus: "exited",
+    });
+
+    reconciler.dispose();
+  });
+
+  it("cancels retained-stop retries on dispose", async () => {
+    vi.useFakeTimers();
+    const store = {
+      reconcileTerminalSessionStopped: vi.fn(async () => {
+        throw new Error("store unavailable");
+      }),
+    };
+    const reconciler = createCodingAgentSessionStopReconciler({ maxPending: 4, retryDelayMs: 25 });
+    await reconciler.handleSessionStopped(stoppedSession("term_sess_one"));
+    await expect(reconciler.attachThreadStore(store)).rejects.toThrow("store unavailable");
+
+    reconciler.dispose();
+    await vi.advanceTimersByTimeAsync(100);
+
+    expect(store.reconcileTerminalSessionStopped).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/gateway/coding-agents-session-stop-reconciler.test.ts
+++ b/tests/gateway/coding-agents-session-stop-reconciler.test.ts
@@ -5,6 +5,7 @@ function stoppedSession(terminalSessionId: string, runtimeStatus: "exited" | "fa
   return {
     id: `sess_${terminalSessionId.replace(/[^A-Za-z0-9_-]/g, "_")}`,
     kind: "agent",
+    ownerId: "owner_user",
     runtime: { status: runtimeStatus },
     terminalSessionId,
   };
@@ -27,6 +28,8 @@ describe("coding agent session stop reconciler", () => {
     await reconciler.attachThreadStore(store);
 
     expect(store.reconcileTerminalSessionStopped).toHaveBeenCalledWith({
+      ownerId: "owner_user",
+      workspaceSessionId: "sess_term_sess_early",
       terminalSessionId: "term_sess_early",
       runtimeStatus: "failed",
     });
@@ -45,10 +48,14 @@ describe("coding agent session stop reconciler", () => {
 
     expect(store.reconcileTerminalSessionStopped).toHaveBeenCalledTimes(2);
     expect(store.reconcileTerminalSessionStopped).toHaveBeenNthCalledWith(1, {
+      ownerId: "owner_user",
+      workspaceSessionId: "sess_term_sess_two",
       terminalSessionId: "term_sess_two",
       runtimeStatus: "exited",
     });
     expect(store.reconcileTerminalSessionStopped).toHaveBeenNthCalledWith(2, {
+      ownerId: "owner_user",
+      workspaceSessionId: "sess_term_sess_three",
       terminalSessionId: "term_sess_three",
       runtimeStatus: "exited",
     });
@@ -74,14 +81,20 @@ describe("coding agent session stop reconciler", () => {
 
     expect(store.reconcileTerminalSessionStopped).toHaveBeenCalledTimes(3);
     expect(store.reconcileTerminalSessionStopped).toHaveBeenNthCalledWith(1, {
+      ownerId: "owner_user",
+      workspaceSessionId: "sess_term_sess_one",
       terminalSessionId: "term_sess_one",
       runtimeStatus: "exited",
     });
     expect(store.reconcileTerminalSessionStopped).toHaveBeenNthCalledWith(2, {
+      ownerId: "owner_user",
+      workspaceSessionId: "sess_term_sess_two",
       terminalSessionId: "term_sess_two",
       runtimeStatus: "exited",
     });
     expect(store.reconcileTerminalSessionStopped).toHaveBeenNthCalledWith(3, {
+      ownerId: "owner_user",
+      workspaceSessionId: "sess_term_sess_one",
       terminalSessionId: "term_sess_one",
       runtimeStatus: "exited",
     });
@@ -106,14 +119,20 @@ describe("coding agent session stop reconciler", () => {
 
     expect(store.reconcileTerminalSessionStopped).toHaveBeenCalledTimes(3);
     expect(store.reconcileTerminalSessionStopped).toHaveBeenNthCalledWith(1, {
+      ownerId: "owner_user",
+      workspaceSessionId: "sess_term_sess_one",
       terminalSessionId: "term_sess_one",
       runtimeStatus: "exited",
     });
     expect(store.reconcileTerminalSessionStopped).toHaveBeenNthCalledWith(2, {
+      ownerId: "owner_user",
+      workspaceSessionId: "sess_term_sess_one",
       terminalSessionId: "term_sess_one",
       runtimeStatus: "exited",
     });
     expect(store.reconcileTerminalSessionStopped).toHaveBeenNthCalledWith(3, {
+      ownerId: "owner_user",
+      workspaceSessionId: "sess_term_sess_two",
       terminalSessionId: "term_sess_two",
       runtimeStatus: "exited",
     });
@@ -139,6 +158,8 @@ describe("coding agent session stop reconciler", () => {
 
     expect(store.reconcileTerminalSessionStopped).toHaveBeenCalledTimes(2);
     expect(store.reconcileTerminalSessionStopped).toHaveBeenNthCalledWith(2, {
+      ownerId: "owner_user",
+      workspaceSessionId: "sess_term_sess_one",
       terminalSessionId: "term_sess_one",
       runtimeStatus: "exited",
     });

--- a/tests/gateway/coding-agents-threads.test.ts
+++ b/tests/gateway/coding-agents-threads.test.ts
@@ -261,6 +261,97 @@ describe("coding agent thread lifecycle", () => {
     );
   });
 
+  it("reconciles active threads when the bound terminal session exits", async () => {
+    const homePath = await mkdtemp(join(tmpdir(), "matrix-coding-agent-threads-"));
+    const published: Array<{ ownerId: string; threadId: string; events: unknown[] }> = [];
+    const threads = createCodingAgentThreadStore({
+      homePath,
+      now: () => baseNow,
+      providers: [createFakeCodingAgentProvider({ providerId: "codex" })],
+    });
+    threads.registerEventSink((event) => {
+      published.push(event);
+    });
+    const created = await threads.createThread(ownerPrincipal, createBody);
+
+    const reconciled = await threads.reconcileTerminalSessionStopped({
+      terminalSessionId: "main",
+      runtimeStatus: "exited",
+    });
+    const duplicate = await threads.reconcileTerminalSessionStopped({
+      terminalSessionId: "main",
+      runtimeStatus: "exited",
+    });
+
+    expect(reconciled).toHaveLength(1);
+    expect(reconciled[0]?.thread).toMatchObject({
+      id: created.snapshot.thread.id,
+      status: "completed",
+      attention: "none",
+    });
+    expect(reconciled[0]?.events.items.at(-2)).toMatchObject({
+      type: "thread.status",
+      status: "completed",
+    });
+    expect(reconciled[0]?.events.items.at(-1)).toMatchObject({
+      type: "thread.completed",
+      outcome: "completed",
+    });
+    expect(duplicate).toEqual([]);
+    expect(published.at(-1)).toMatchObject({
+      ownerId: ownerPrincipal.userId,
+      threadId: created.snapshot.thread.id,
+      events: [
+        expect.objectContaining({ type: "thread.status", status: "completed" }),
+        expect.objectContaining({ type: "thread.completed", outcome: "completed" }),
+      ],
+    });
+  });
+
+  it("applies a pending terminal stop when a later thread binds the same terminal", async () => {
+    const homePath = await mkdtemp(join(tmpdir(), "matrix-coding-agent-threads-"));
+    const threads = createCodingAgentThreadStore({
+      homePath,
+      now: () => baseNow,
+      providers: [createFakeCodingAgentProvider({ providerId: "codex" })],
+    });
+
+    const early = await threads.reconcileTerminalSessionStopped({
+      terminalSessionId: "main",
+      runtimeStatus: "failed",
+    });
+    const created = await threads.createThread(ownerPrincipal, createBody);
+    const duplicate = await threads.reconcileTerminalSessionStopped({
+      terminalSessionId: "main",
+      runtimeStatus: "failed",
+    });
+    const later = await threads.createThread(ownerPrincipal, {
+      ...createBody,
+      clientRequestId: "req_create_after_duplicate_stop",
+    });
+
+    expect(early).toEqual([]);
+    expect(created.snapshot.thread).toMatchObject({
+      status: "failed",
+      attention: "failed",
+      terminalSessionId: "main",
+    });
+    expect(created.snapshot.events.items.at(-2)).toMatchObject({
+      type: "thread.status",
+      status: "failed",
+    });
+    expect(created.snapshot.events.items.at(-1)).toMatchObject({
+      type: "thread.completed",
+      outcome: "failed",
+    });
+    expect(duplicate).toEqual([]);
+    expect(later.snapshot.thread).toMatchObject({
+      status: "running",
+      attention: "none",
+      terminalSessionId: "main",
+    });
+  });
+
   it("submits approval decisions idempotently through the provider adapter", async () => {
     const homePath = await mkdtemp(join(tmpdir(), "matrix-coding-agent-threads-"));
     let approvalCalls = 0;

--- a/tests/gateway/coding-agents-threads.test.ts
+++ b/tests/gateway/coding-agents-threads.test.ts
@@ -74,6 +74,10 @@ const createBody = {
   clientRequestId: "req_create_1",
 };
 
+function workspaceSessionIdForThread(threadId: string): string {
+  return `sess_${threadId.slice("thread_".length)}`;
+}
+
 describe("coding agent thread lifecycle", () => {
   it("creates a thread idempotently and replays fake-provider events", async () => {
     const { app } = await createHarness();
@@ -275,10 +279,12 @@ describe("coding agent thread lifecycle", () => {
     const created = await threads.createThread(ownerPrincipal, createBody);
 
     const reconciled = await threads.reconcileTerminalSessionStopped({
+      ownerId: ownerPrincipal.userId,
       terminalSessionId: "main",
       runtimeStatus: "exited",
     });
     const duplicate = await threads.reconcileTerminalSessionStopped({
+      ownerId: ownerPrincipal.userId,
       terminalSessionId: "main",
       runtimeStatus: "exited",
     });
@@ -308,6 +314,73 @@ describe("coding agent thread lifecycle", () => {
     });
   });
 
+  it("reconciles stopped terminal sessions only for the matching owner and workspace session", async () => {
+    const homePath = await mkdtemp(join(tmpdir(), "matrix-coding-agent-threads-"));
+    const threads = createCodingAgentThreadStore({
+      homePath,
+      now: () => baseNow,
+      providers: [createFakeCodingAgentProvider({ providerId: "codex" })],
+    });
+    const ownerThread = await threads.createThread(ownerPrincipal, createBody);
+    const otherThread = await threads.createThread(otherPrincipal, {
+      ...createBody,
+      clientRequestId: "req_create_other_owner",
+    });
+
+    const reconciled = await threads.reconcileTerminalSessionStopped({
+      ownerId: otherPrincipal.userId,
+      workspaceSessionId: workspaceSessionIdForThread(otherThread.snapshot.thread.id),
+      terminalSessionId: "main",
+      runtimeStatus: "exited",
+    });
+
+    expect(reconciled).toHaveLength(1);
+    expect(reconciled[0]?.thread).toMatchObject({
+      id: otherThread.snapshot.thread.id,
+      status: "completed",
+    });
+    expect(await threads.getThread(ownerPrincipal, ownerThread.snapshot.thread.id)).toMatchObject({
+      thread: {
+        id: ownerThread.snapshot.thread.id,
+        status: "running",
+      },
+    });
+  });
+
+  it("retains pending stops for reused terminal ids when the workspace session id is different", async () => {
+    const homePath = await mkdtemp(join(tmpdir(), "matrix-coding-agent-threads-"));
+    const threads = createCodingAgentThreadStore({
+      homePath,
+      now: () => baseNow,
+      providers: [createFakeCodingAgentProvider({ providerId: "codex" })],
+    });
+    const created = await threads.createThread(ownerPrincipal, createBody);
+    await threads.reconcileTerminalSessionStopped({
+      ownerId: ownerPrincipal.userId,
+      workspaceSessionId: workspaceSessionIdForThread(created.snapshot.thread.id),
+      terminalSessionId: "main",
+      runtimeStatus: "exited",
+    });
+
+    const reused = await threads.reconcileTerminalSessionStopped({
+      ownerId: ownerPrincipal.userId,
+      workspaceSessionId: "sess_reused_terminal",
+      terminalSessionId: "main",
+      runtimeStatus: "failed",
+    });
+    const raw = JSON.parse(await readFile(join(homePath, "system", "coding-agents", "threads.json"), "utf-8"));
+
+    expect(reused).toEqual([]);
+    expect(raw.pendingTerminalStops).toEqual([
+      expect.objectContaining({
+        ownerId: ownerPrincipal.userId,
+        workspaceSessionId: "sess_reused_terminal",
+        terminalSessionId: "main",
+        runtimeStatus: "failed",
+      }),
+    ]);
+  });
+
   it("applies a pending terminal stop when a later thread binds the same terminal", async () => {
     const homePath = await mkdtemp(join(tmpdir(), "matrix-coding-agent-threads-"));
     const threads = createCodingAgentThreadStore({
@@ -317,11 +390,13 @@ describe("coding agent thread lifecycle", () => {
     });
 
     const early = await threads.reconcileTerminalSessionStopped({
+      ownerId: ownerPrincipal.userId,
       terminalSessionId: "main",
       runtimeStatus: "failed",
     });
     const created = await threads.createThread(ownerPrincipal, createBody);
     const duplicate = await threads.reconcileTerminalSessionStopped({
+      ownerId: ownerPrincipal.userId,
       terminalSessionId: "main",
       runtimeStatus: "failed",
     });

--- a/tests/gateway/workspace-event-publisher.test.ts
+++ b/tests/gateway/workspace-event-publisher.test.ts
@@ -123,4 +123,100 @@ describe("workspace event publisher", () => {
 
     expect(warn).toHaveBeenCalledWith("[workspace-event-publisher] Unexpected workspace event publish error:", "disk full");
   });
+
+  it("notifies a server-side stopped-session hook after publishing the workspace event", async () => {
+    const eventStore = {
+      publishEvent: vi.fn(async () => ({ ok: true, event: { id: "evt_abc123" } })),
+    };
+    const onSessionStopped = vi.fn(async () => undefined);
+    const publisher = createWorkspaceEventPublisher({ eventStore, onSessionStopped });
+    const session = {
+      id: "sess_abc123",
+      kind: "agent" as const,
+      projectSlug: "repo",
+      taskId: "task_abc123",
+      worktreeId: "wt_abc123def456",
+      pr: 42,
+      agent: "codex" as const,
+      runtime: { type: "zellij" as const, status: "exited" as const },
+      terminalSessionId: "term_sess_abc123",
+    };
+
+    await publisher.publishSessionStopped(session);
+
+    expect(eventStore.publishEvent).toHaveBeenCalledWith({
+      type: "session.stopped",
+      scope: {
+        projectSlug: "repo",
+        taskId: "task_abc123",
+        sessionId: "sess_abc123",
+      },
+      payload: {
+        agent: "codex",
+        kind: "agent",
+        pr: 42,
+        runtimeStatus: "exited",
+        terminalSessionId: "term_sess_abc123",
+        worktreeId: "wt_abc123def456",
+      },
+    });
+    expect(onSessionStopped).toHaveBeenCalledWith(session);
+  });
+
+  it("does not block session-stop publishing on the stopped-session hook", async () => {
+    const eventStore = {
+      publishEvent: vi.fn(async () => ({ ok: true, event: { id: "evt_abc123" } })),
+    };
+    const publisher = createWorkspaceEventPublisher({
+      eventStore,
+      onSessionStopped: vi.fn(() => new Promise(() => undefined)),
+    });
+    const publish = publisher.publishSessionStopped({
+      id: "sess_abc123",
+      kind: "agent",
+      projectSlug: "repo",
+      taskId: "task_abc123",
+      worktreeId: "wt_abc123def456",
+      pr: 42,
+      agent: "codex",
+      runtime: { type: "zellij", status: "exited" },
+      terminalSessionId: "term_sess_abc123",
+    });
+
+    await expect(Promise.race([
+      publish.then(() => "published"),
+      new Promise((resolve) => setTimeout(() => resolve("blocked"), 20)),
+    ])).resolves.toBe("published");
+  });
+
+  it("logs and suppresses stopped-session hook failures", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    const eventStore = {
+      publishEvent: vi.fn(async () => ({ ok: true, event: { id: "evt_abc123" } })),
+    };
+    const publisher = createWorkspaceEventPublisher({
+      eventStore,
+      onSessionStopped: vi.fn(async () => {
+        throw new Error("thread store unavailable");
+      }),
+    });
+
+    await expect(publisher.publishSessionStopped({
+      id: "sess_abc123",
+      kind: "agent",
+      projectSlug: "repo",
+      taskId: "task_abc123",
+      worktreeId: "wt_abc123def456",
+      pr: 42,
+      agent: "codex",
+      runtime: { type: "zellij", status: "failed" },
+      terminalSessionId: "term_sess_abc123",
+    })).resolves.toBeUndefined();
+    await Promise.resolve();
+
+    expect(warn).toHaveBeenCalledWith(
+      "[workspace-event-publisher] Session stopped hook failed:",
+      "thread store unavailable",
+    );
+  });
 });

--- a/tests/gateway/workspace-event-publisher.test.ts
+++ b/tests/gateway/workspace-event-publisher.test.ts
@@ -24,6 +24,7 @@ describe("workspace event publisher", () => {
     });
     await publisher.publishSessionStarted({
       id: "sess_abc123",
+      ownerId: "owner_user",
       kind: "agent",
       projectSlug: "repo",
       taskId: "task_abc123",
@@ -35,6 +36,7 @@ describe("workspace event publisher", () => {
     });
     await publisher.publishSessionStopped({
       id: "sess_abc123",
+      ownerId: "owner_user",
       kind: "agent",
       projectSlug: "repo",
       taskId: "task_abc123",
@@ -132,6 +134,7 @@ describe("workspace event publisher", () => {
     const publisher = createWorkspaceEventPublisher({ eventStore, onSessionStopped });
     const session = {
       id: "sess_abc123",
+      ownerId: "owner_user",
       kind: "agent" as const,
       projectSlug: "repo",
       taskId: "task_abc123",
@@ -173,6 +176,7 @@ describe("workspace event publisher", () => {
     });
     const publish = publisher.publishSessionStopped({
       id: "sess_abc123",
+      ownerId: "owner_user",
       kind: "agent",
       projectSlug: "repo",
       taskId: "task_abc123",
@@ -203,6 +207,7 @@ describe("workspace event publisher", () => {
 
     await expect(publisher.publishSessionStopped({
       id: "sess_abc123",
+      ownerId: "owner_user",
       kind: "agent",
       projectSlug: "repo",
       taskId: "task_abc123",


### PR DESCRIPTION
## Summary
- Add server-side coding-agent thread reconciliation for stopped workspace terminal sessions.
- Publish workspace session stops through a shared gateway event publisher and dispatch reconciliation without blocking the stop path.
- Buffer unmatched stopped terminal sessions through bounded owner-file and startup-window queues so early stops are replayed once the thread/store binding exists.
- Update the 105 current-state note to record the implemented lifecycle boundary.

## Invariants
- Source of truth: gateway/runtime remains authoritative for workspace sessions and coding-agent thread state; desktop and mobile receive no new state ownership.
- Lock/transaction scope: thread reconciliation uses the existing serialized thread-store mutation queue and owner-file atomic writes.
- Acceptable orphan states: if a stopped terminal has no matching thread yet, the gateway records a bounded pending stop for later reconciliation; if a matching terminal thread is already terminal, the duplicate stop is a no-op and clears stale pending state.
- Auth source of truth: no new client route is exposed; existing authenticated workspace and coding-agent routes remain unchanged.
- Deferred scope: autonomous process-exit detection beyond emitted workspace session stop events, file/review/preview UI, browser shell placement, and attention notifications remain follow-up work.

## Validation
- pnpm exec vitest run tests/gateway/coding-agents-threads.test.ts tests/gateway/coding-agents-session-stop-reconciler.test.ts tests/gateway/workspace-event-publisher.test.ts tests/gateway/coding-agents-workspace-provider.test.ts
- pnpm --filter @matrix-os/gateway exec tsc --noEmit
- bun run check:patterns
- bun run typecheck
- git diff --check

## Docs
- Updated specs/105-coding-agent-shells/current-state.md.
- Public docs deferred because this slice is internal lifecycle plumbing, not a stable user-facing shell flow.