### PR TITLE
feat(coding-agents): add review summary read model

### DIFF
--- a/apps/mobile/__tests__/gateway-client.test.ts
+++ b/apps/mobile/__tests__/gateway-client.test.ts
@@ -283,6 +283,64 @@ describe("GatewayClient", () => {
     fetchMock.mockRestore();
   });
 
+  it("fetches coding agent review summaries with the existing auth header", async () => {
+    const reviews = {
+      items: [
+        {
+          id: "rev_mobile_1",
+          projectId: "matrix-os",
+          worktreeId: "wt_abc123def456",
+          status: "reviewing",
+          pullRequestNumber: 757,
+          round: 1,
+          maxRounds: 3,
+          reviewer: "codex",
+          implementer: "claude",
+          findings: {
+            total: 2,
+            high: 1,
+            medium: 1,
+            low: 0,
+          },
+          updatedAt: "2026-07-06T00:00:00.000Z",
+        },
+      ],
+      hasMore: false,
+      limit: 50,
+    };
+    const fetchMock = jest.spyOn(global, "fetch").mockResolvedValue(jsonResponse(reviews));
+
+    const client = new GatewayClient("http://localhost:4000", "token");
+    await expect(client.getCodingAgentReviews()).resolves.toEqual({
+      ok: true,
+      reviews,
+    });
+    expect(fetchMock).toHaveBeenCalledWith("http://localhost:4000/api/coding-agents/reviews", expect.objectContaining({
+      headers: expect.objectContaining({
+        Authorization: "Bearer token",
+        "Content-Type": "application/json",
+      }),
+      signal: expect.any(Object),
+    }));
+
+    await expect(client.getCodingAgentReviews({ cursor: "rev_mobile_1" })).resolves.toEqual({
+      ok: true,
+      reviews,
+    });
+    expect(fetchMock).toHaveBeenLastCalledWith(
+      "http://localhost:4000/api/coding-agents/reviews?cursor=rev_mobile_1",
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: "Bearer token",
+          "Content-Type": "application/json",
+        }),
+        signal: expect.any(Object),
+      }),
+    );
+
+    fetchMock.mockRestore();
+  });
+
   it("returns a safe mobile thread create error for invalid gateway payloads", async () => {
     const fetchMock = jest.spyOn(global, "fetch").mockResolvedValueOnce(jsonResponse({
       thread: {
@@ -301,6 +359,31 @@ describe("GatewayClient", () => {
     })).resolves.toEqual({
       ok: false,
       error: "Agent run could not be started. Try again.",
+    });
+
+    fetchMock.mockRestore();
+  });
+
+  it("returns a safe mobile review error for invalid gateway payloads", async () => {
+    const fetchMock = jest.spyOn(global, "fetch").mockResolvedValueOnce(jsonResponse({
+      items: [
+        {
+          id: "../bad",
+          projectId: "matrix-os",
+          worktreeId: "wt_abc123def456",
+          status: "reviewing",
+          safeStatus: "Postgres failed at /home/matrix/home",
+          updatedAt: "2026-07-06T00:00:00.000Z",
+        },
+      ],
+      hasMore: false,
+      limit: 50,
+    }));
+
+    const client = new GatewayClient("http://localhost:4000", "token");
+    await expect(client.getCodingAgentReviews()).resolves.toEqual({
+      ok: false,
+      error: "Review state unavailable",
     });
 
     fetchMock.mockRestore();

--- a/apps/mobile/lib/gateway-client.ts
+++ b/apps/mobile/lib/gateway-client.ts
@@ -6,9 +6,12 @@ import {
 } from "@/lib/terminal-state";
 import {
   AgentThreadSnapshotSchema,
+  CursorSchema,
+  ReviewSummarySchema,
   RuntimeSummarySchema,
   type CreateAgentThreadRequest,
   type RuntimeSummary,
+  boundedListSchema,
 } from "@matrix-os/contracts";
 import type { z } from "zod/v4";
 
@@ -81,6 +84,12 @@ export type CodingAgentRuntimeSummaryResult =
 export type CodingAgentThreadCreateResult =
   | { ok: true; snapshot: z.infer<typeof AgentThreadSnapshotSchema> }
   | { ok: false; error: "Agent run could not be started. Try again." };
+
+const CodingAgentReviewListSchema = boundedListSchema(ReviewSummarySchema, 50);
+
+export type CodingAgentReviewsResult =
+  | { ok: true; reviews: z.infer<typeof CodingAgentReviewListSchema> }
+  | { ok: false; error: "Review state unavailable" };
 
 type ClientMessage =
   | { type: "message"; text: string; sessionId?: string }
@@ -551,6 +560,34 @@ export class GatewayClient {
     } catch {
       console.warn("[mobile] /api/coding-agents/threads unavailable");
       return { ok: false, error: "Agent run could not be started. Try again." };
+    }
+  }
+
+  async getCodingAgentReviews(options: { cursor?: string } = {}): Promise<CodingAgentReviewsResult> {
+    try {
+      let path = "/api/coding-agents/reviews";
+      if (options.cursor) {
+        const parsedCursor = CursorSchema.safeParse(options.cursor);
+        if (!parsedCursor.success) {
+          return { ok: false, error: "Review state unavailable" };
+        }
+        path += `?${new URLSearchParams({ cursor: parsedCursor.data }).toString()}`;
+      }
+      const res = await this.fetchGateway(path);
+      if (!res.ok) {
+        console.warn("[mobile] /api/coding-agents/reviews unavailable", res.status);
+        return { ok: false, error: "Review state unavailable" };
+      }
+      const body = await res.json();
+      const parsed = CodingAgentReviewListSchema.safeParse(body);
+      if (!parsed.success) {
+        console.warn("[mobile] /api/coding-agents/reviews returned invalid payload");
+        return { ok: false, error: "Review state unavailable" };
+      }
+      return { ok: true, reviews: parsed.data };
+    } catch {
+      console.warn("[mobile] /api/coding-agents/reviews unavailable");
+      return { ok: false, error: "Review state unavailable" };
     }
   }
 

--- a/desktop/src/main/coding-agents/runtime-summary-client.ts
+++ b/desktop/src/main/coding-agents/runtime-summary-client.ts
@@ -1,17 +1,23 @@
 import {
   AgentThreadSnapshotSchema,
+  ReviewSummarySchema,
   RuntimeSummarySchema,
   type CreateAgentThreadRequest,
+  type ReviewSummary,
   type RuntimeSummary,
+  boundedListSchema,
 } from "@matrix-os/contracts";
 import type { z } from "zod/v4";
 import type { AuthService } from "../auth/auth-service";
 
 const RUNTIME_SUMMARY_TIMEOUT_MS = 10_000;
+const REVIEW_SUMMARY_TIMEOUT_MS = 10_000;
 const THREAD_CREATE_TIMEOUT_MS = 15_000;
 
 type FetchFn = (input: string, init?: RequestInit) => Promise<Response>;
 type AgentThreadSnapshot = z.infer<typeof AgentThreadSnapshotSchema>;
+const ReviewSummaryListSchema = boundedListSchema(ReviewSummarySchema, 50);
+type ReviewSummaryList = z.infer<typeof ReviewSummaryListSchema>;
 
 function buildSummaryUrl(origin: string, runtimeSlot: string): string {
   const url = new URL("/api/coding-agents/summary", origin);
@@ -81,6 +87,40 @@ export async function createCodingAgentThread(
   const parsed = AgentThreadSnapshotSchema.safeParse(body);
   if (!parsed.success) {
     throw new Error("agent thread unavailable");
+  }
+  return parsed.data;
+}
+
+export async function fetchCodingAgentReviewSummaries(
+  auth: AuthService,
+  options: { cursor?: string } = {},
+  fetchFn: FetchFn = fetch,
+): Promise<ReviewSummaryList> {
+  const token = auth.getToken();
+  if (!token) {
+    throw new Error("review state unavailable");
+  }
+
+  const url = new URL("/api/coding-agents/reviews", auth.getGatewayOrigin());
+  if (options.cursor) {
+    url.searchParams.set("cursor", options.cursor);
+  }
+  const res = await fetchFn(url.toString(), {
+    method: "GET",
+    headers: {
+      Authorization: `Bearer ${token}`,
+      Accept: "application/json",
+    },
+    signal: AbortSignal.timeout(REVIEW_SUMMARY_TIMEOUT_MS),
+  });
+  if (!res.ok) {
+    throw new Error("review state unavailable");
+  }
+
+  const body = await res.json();
+  const parsed = ReviewSummaryListSchema.safeParse(body);
+  if (!parsed.success) {
+    throw new Error("review state unavailable");
   }
   return parsed.data;
 }

--- a/desktop/src/main/index.ts
+++ b/desktop/src/main/index.ts
@@ -6,6 +6,7 @@ import { installGatewayCors, installHeaderInjection } from "./auth/header-inject
 import { EmbedService } from "./embeds/embed-service";
 import {
   createCodingAgentThread,
+  fetchCodingAgentReviewSummaries,
   fetchCodingAgentRuntimeSummary,
 } from "./coding-agents/runtime-summary-client";
 import { registerIpcHandlers } from "./ipc/handlers";
@@ -231,6 +232,7 @@ if (!gotLock) {
         },
         getUpdateStatus: () => updater.status(),
         fetchRuntimeSummary: () => fetchCodingAgentRuntimeSummary(auth),
+        fetchReviewSummaries: (options) => fetchCodingAgentReviewSummaries(auth, options),
         createAgentThread: (request) => createCodingAgentThread(auth, request),
       });
 

--- a/desktop/src/main/ipc/handlers.ts
+++ b/desktop/src/main/ipc/handlers.ts
@@ -6,7 +6,7 @@ import type { AuthService } from "../auth/auth-service";
 import type { EmbedService } from "../embeds/embed-service";
 import type { LocalStore, LocalStoreKey } from "../persistence/local-store";
 import type { UpdateStatus } from "../updates";
-import type { CreateAgentThreadRequest, RuntimeSummary } from "@matrix-os/contracts";
+import type { CreateAgentThreadRequest, ReviewSummary, RuntimeSummary } from "@matrix-os/contracts";
 import type { z } from "zod/v4";
 import { AgentThreadSnapshotSchema } from "@matrix-os/contracts";
 
@@ -27,6 +27,9 @@ export interface HandlerContext {
   onRuntimeChanged: (slot: string) => void;
   getUpdateStatus: () => UpdateStatus;
   fetchRuntimeSummary: () => Promise<RuntimeSummary>;
+  fetchReviewSummaries: (
+    options: { cursor?: string },
+  ) => Promise<{ items: ReviewSummary[]; hasMore: boolean; limit: number; nextCursor?: string }>;
   createAgentThread: (
     request: CreateAgentThreadRequest,
   ) => Promise<z.infer<typeof AgentThreadSnapshotSchema>>;
@@ -86,6 +89,7 @@ export function registerIpcHandlers(ipcMain: IpcMainLike, ctx: HandlerContext): 
     return { ok: true };
   });
   handle("runtime:get-summary", () => ctx.fetchRuntimeSummary());
+  handle("runtime:get-reviews", (request) => ctx.fetchReviewSummaries(request));
   handle("runtime:create-thread", (request) => ctx.createAgentThread(request));
 
   handle("state:get", async ({ key }) => ({

--- a/desktop/src/shared/ipc-contract.ts
+++ b/desktop/src/shared/ipc-contract.ts
@@ -6,7 +6,10 @@ import { z } from "zod/v4";
 import {
   AgentThreadSnapshotSchema,
   CreateAgentThreadRequestSchema,
+  CursorSchema,
+  ReviewSummarySchema,
   RuntimeSummarySchema,
+  boundedListSchema,
 } from "@matrix-os/contracts";
 
 const Empty = z.object({}).strict();
@@ -102,6 +105,10 @@ export const INVOKE_CHANNELS = {
   "runtime:get-summary": {
     request: Empty,
     response: RuntimeSummarySchema,
+  },
+  "runtime:get-reviews": {
+    request: z.object({ cursor: CursorSchema.optional() }).strict(),
+    response: boundedListSchema(ReviewSummarySchema, 50),
   },
   "runtime:create-thread": {
     request: CreateAgentThreadRequestSchema,

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -652,6 +652,39 @@ export const ReviewFileDiffSchema = z.object({
   partial: z.boolean(),
 }).strict();
 
+export const ReviewSummarySchema = z.object({
+  id: referenceId(128),
+  projectId: ProjectIdSchema,
+  worktreeId: WorktreeIdSchema,
+  status: z.enum([
+    "queued",
+    "reviewing",
+    "implementing",
+    "verifying",
+    "converged",
+    "stalled",
+    "failed",
+    "failed_parse",
+    "stopped",
+    "approved",
+  ]),
+  pullRequestNumber: z.number().int().min(1).max(10_000_000),
+  round: z.number().int().min(0).max(100),
+  maxRounds: z.number().int().min(1).max(100),
+  reviewer: ProviderIdSchema,
+  implementer: ProviderIdSchema,
+  findings: z.object({
+    total: z.number().int().min(0).max(1_000_000),
+    high: z.number().int().min(0).max(1_000_000),
+    medium: z.number().int().min(0).max(1_000_000),
+    low: z.number().int().min(0).max(1_000_000),
+  }).strict().optional(),
+  safeStatus: SafeDisplayStringSchema.optional(),
+  updatedAt: IsoTimestampSchema,
+}).strict();
+
+export type ReviewSummary = z.infer<typeof ReviewSummarySchema>;
+
 export const PreviewSessionSummarySchema = z.object({
   id: referenceId(128),
   label: SafeDisplayStringSchema,

--- a/packages/gateway/src/coding-agents/review-summary.ts
+++ b/packages/gateway/src/coding-agents/review-summary.ts
@@ -1,0 +1,126 @@
+import {
+  ReviewSummarySchema,
+  type ReviewSummary,
+} from "@matrix-os/contracts";
+import type { RequestPrincipal } from "../request-principal.js";
+import type { ReviewLoopRecord } from "../review-loop.js";
+
+const REVIEW_SUMMARY_LIMIT = 50;
+const RAW_REVIEW_SCAN_LIMIT = 100;
+const MAX_REVIEW_SCAN_PAGES = 5;
+
+export interface CodingAgentReviewSummaryStore {
+  listReviews(
+    principal: RequestPrincipal,
+    options?: { cursor?: string },
+  ): Promise<{ items: ReviewSummary[]; hasMore: boolean; limit: number; nextCursor?: string }>;
+}
+
+export interface ReviewLoopStore {
+  listReviews(input?: unknown): Promise<
+    { ok: true; reviews: ReviewLoopRecord[]; nextCursor: string | null } |
+    { ok: false; status: number; error: { code: string; message: string } }
+  >;
+}
+
+function ownerIdsFor(options: { ownerId?: string; principalOwnerIds?: readonly string[] }): string[] {
+  const ids: string[] = [];
+  for (const id of [options.ownerId, ...(options.principalOwnerIds ?? [])]) {
+    if (!id || ids.includes(id) || ids.length >= 8) continue;
+    ids.push(id);
+  }
+  return ids;
+}
+
+function canReadReviewSummaries(principal: RequestPrincipal, ownerIds: readonly string[]): boolean {
+  if (ownerIds.length > 0) return ownerIds.includes(principal.userId);
+  return principal.source === "configured-container" || principal.source === "dev-default";
+}
+
+function findingsFor(review: ReviewLoopRecord): ReviewSummary["findings"] {
+  const latest = review.rounds
+    .slice()
+    .reverse()
+    .find((round) => typeof round.findingsCount === "number" || round.severityCounts);
+  if (!latest) return undefined;
+  const high = latest.severityCounts?.high ?? 0;
+  const medium = latest.severityCounts?.medium ?? 0;
+  const low = latest.severityCounts?.low ?? 0;
+  return {
+    total: latest.findingsCount ?? high + medium + low,
+    high,
+    medium,
+    low,
+  };
+}
+
+function safeStatusFor(review: ReviewLoopRecord): string | undefined {
+  if (review.status === "failed_parse") return "Review output could not be read. Try another review run.";
+  if (review.status === "failed") return "Review stopped before completion. Try again.";
+  if (review.status === "stalled") return "Review needs attention before continuing.";
+  return undefined;
+}
+
+function toReviewSummary(review: ReviewLoopRecord): ReviewSummary | null {
+  const parsed = ReviewSummarySchema.safeParse({
+    id: review.id,
+    projectId: review.projectSlug,
+    worktreeId: review.worktreeId,
+    status: review.status,
+    pullRequestNumber: review.pr,
+    round: review.round,
+    maxRounds: review.maxRounds,
+    reviewer: review.reviewer,
+    implementer: review.implementer,
+    findings: findingsFor(review),
+    safeStatus: safeStatusFor(review),
+    updatedAt: review.updatedAt,
+  });
+  return parsed.success ? parsed.data : null;
+}
+
+export function createCodingAgentReviewSummaryStore(
+  store: ReviewLoopStore,
+  options: { ownerId?: string; principalOwnerIds?: readonly string[] } = {},
+): CodingAgentReviewSummaryStore {
+  const ownerIds = ownerIdsFor(options);
+  return {
+    async listReviews(principal: RequestPrincipal, listOptions: { cursor?: string } = {}) {
+      if (!canReadReviewSummaries(principal, ownerIds)) {
+        return { items: [], hasMore: false, limit: REVIEW_SUMMARY_LIMIT };
+      }
+      const validSummaries: ReviewSummary[] = [];
+      let cursor = listOptions.cursor;
+      let rawContinuationCursor: string | undefined;
+      const seenCursors = new Set<string>();
+      for (let page = 0; page < MAX_REVIEW_SCAN_PAGES && validSummaries.length <= REVIEW_SUMMARY_LIMIT; page += 1) {
+        if (cursor && seenCursors.has(cursor)) break;
+        if (cursor) seenCursors.add(cursor);
+        const result = await store.listReviews({ limit: RAW_REVIEW_SCAN_LIMIT, cursor });
+        if (!result.ok) {
+          throw new Error("Review state unavailable");
+        }
+        validSummaries.push(
+          ...result.reviews
+            .map(toReviewSummary)
+            .filter((summary): summary is ReviewSummary => summary !== null),
+        );
+        if (!result.nextCursor) break;
+        if (seenCursors.has(result.nextCursor)) {
+          rawContinuationCursor = undefined;
+          break;
+        }
+        rawContinuationCursor = result.nextCursor;
+        cursor = result.nextCursor;
+      }
+      const items = validSummaries.slice(0, REVIEW_SUMMARY_LIMIT);
+      const hasMore = validSummaries.length > REVIEW_SUMMARY_LIMIT || rawContinuationCursor !== undefined;
+      return {
+        items,
+        hasMore,
+        nextCursor: hasMore ? items[items.length - 1]?.id ?? rawContinuationCursor : undefined,
+        limit: REVIEW_SUMMARY_LIMIT,
+      };
+    },
+  };
+}

--- a/packages/gateway/src/coding-agents/routes.ts
+++ b/packages/gateway/src/coding-agents/routes.ts
@@ -13,6 +13,7 @@ import {
   UserInputAnswerRequestSchema,
   boundedListSchema,
   AgentThreadSummarySchema,
+  ReviewSummarySchema,
 } from "@matrix-os/contracts";
 import {
   isRequestPrincipalError,
@@ -26,10 +27,12 @@ import {
   safeThreadError,
   type CodingAgentThreadStore,
 } from "./thread-store.js";
+import type { CodingAgentReviewSummaryStore } from "./review-summary.js";
 
 export interface CodingAgentRouteDeps {
   service: CodingAgentRuntimeSummaryService;
   threads?: CodingAgentThreadStore;
+  reviews?: CodingAgentReviewSummaryStore;
   getPrincipal?: (c: Context) => RequestPrincipal;
 }
 
@@ -43,6 +46,7 @@ const AbortThreadBodySchema = z.object({
 }).strict();
 
 const ThreadListSchema = boundedListSchema(AgentThreadSummarySchema, 50);
+const ReviewListSchema = boundedListSchema(ReviewSummarySchema, 50);
 
 function summaryUnavailable() {
   return SafeClientErrorSchema.parse({
@@ -57,6 +61,15 @@ function threadsUnavailable() {
   return SafeClientErrorSchema.parse({
     code: "thread_store_unavailable",
     safeMessage: "Agent thread state is temporarily unavailable. Try again.",
+    retryable: true,
+    recoveryActions: ["retry"],
+  });
+}
+
+function reviewsUnavailable() {
+  return SafeClientErrorSchema.parse({
+    code: "review_state_unavailable",
+    safeMessage: "Review state is temporarily unavailable. Try again.",
     retryable: true,
     recoveryActions: ["retry"],
   });
@@ -183,6 +196,27 @@ export function createCodingAgentRoutes(deps: CodingAgentRouteDeps): Hono {
         return c.json(await deps.threads!.submitInput(principal, threadId, inputRequestId, body));
       } catch (err: unknown) {
         return mapThreadRouteError(c, err);
+      }
+    });
+  }
+
+  if (deps.reviews) {
+    app.get("/reviews", async (c) => {
+      try {
+        const principal = principalFor(c);
+        const rawCursor = c.req.query("cursor");
+        const cursor = rawCursor ? CursorSchema.parse(rawCursor) : undefined;
+        return c.json(ReviewListSchema.parse(await deps.reviews!.listReviews(principal, { cursor })));
+      } catch (err: unknown) {
+        if (isRequestPrincipalError(err)) {
+          const mapped = mapRequestPrincipalError(err);
+          return c.json(mapped.body, mapped.status as ContentfulStatusCode);
+        }
+        if (err instanceof z.ZodError) {
+          return c.json({ error: validationFailed() }, 400);
+        }
+        console.warn("[coding-agents] review route failed:", err instanceof Error ? err.message : String(err));
+        return c.json({ error: reviewsUnavailable() }, 503);
       }
     });
   }

--- a/packages/gateway/src/coding-agents/runtime-summary.ts
+++ b/packages/gateway/src/coding-agents/runtime-summary.ts
@@ -47,6 +47,7 @@ export interface CodingAgentRuntimeSummaryOptions {
   capabilities?: {
     workspace?: boolean;
     approvals?: boolean;
+    review?: boolean;
   };
   terminalOwnerId?: string;
   now?: () => Date;
@@ -229,6 +230,7 @@ export function createCodingAgentRuntimeSummaryService(
       const threadsEnabled = Boolean(options.threads);
       const workspaceEnabled = threadsEnabled && options.capabilities?.workspace === true;
       const approvalsEnabled = threadsEnabled && options.capabilities?.approvals === true;
+      const reviewEnabled = options.capabilities?.review === true;
       const terminalEnabled = Boolean(options.terminalRegistry) &&
         canReadTerminalSessions(principal, options.terminalOwnerId);
 
@@ -246,7 +248,7 @@ export function createCodingAgentRuntimeSummaryService(
           capability({ id: "codingAgentsMobileWorkspace", enabled: workspaceEnabled }),
           capability({ id: "codingAgentsThreadCreate", enabled: threadsEnabled }),
           capability({ id: "codingAgentsApprovals", enabled: approvalsEnabled }),
-          capability({ id: "codingAgentsReview", enabled: false }),
+          capability({ id: "codingAgentsReview", enabled: reviewEnabled }),
           capability({ id: "codingAgentsNativeMobileTerminal", enabled: terminalEnabled }),
         ],
         providers,

--- a/packages/gateway/src/review-store.ts
+++ b/packages/gateway/src/review-store.ts
@@ -15,7 +15,7 @@ const ReviewIdSchema = z.string().regex(/^rev_[A-Za-z0-9_-]{1,128}$/);
 const ListReviewsSchema = z.object({
   projectSlug: z.string().min(1).max(63).optional(),
   limit: z.number().int().min(1).max(100).optional(),
-  cursor: z.string().optional(),
+  cursor: ReviewIdSchema.optional(),
 });
 
 function failure(status: number, code: string, message: string): Failure {
@@ -60,7 +60,7 @@ export function createReviewStore(options: { homePath: string }) {
     },
 
     async listReviews(input: unknown = {}): Promise<
-      { ok: true; reviews: ReviewLoopRecord[]; nextCursor: null } | Failure
+      { ok: true; reviews: ReviewLoopRecord[]; nextCursor: string | null } | Failure
     > {
       const parsed = ListReviewsSchema.safeParse(input);
       if (!parsed.success) {
@@ -85,13 +85,22 @@ export function createReviewStore(options: { homePath: string }) {
         if (review) reviews.push(review);
       }
       const query = parsed.data;
+      const sorted = reviews
+        .filter((review) => !query.projectSlug || review.projectSlug === query.projectSlug)
+        .sort((a, b) => b.updatedAt.localeCompare(a.updatedAt));
+      const startIndex = query.cursor
+        ? sorted.findIndex((review) => review.id === query.cursor) + 1
+        : 0;
+      if (query.cursor && startIndex === 0) {
+        return failure(400, "invalid_review_cursor", "Review cursor is invalid");
+      }
+      const limit = query.limit ?? 100;
+      const page = sorted.slice(startIndex, startIndex + limit + 1);
+      const visible = page.slice(0, limit);
       return {
         ok: true,
-        reviews: reviews
-          .filter((review) => !query.projectSlug || review.projectSlug === query.projectSlug)
-          .sort((a, b) => b.updatedAt.localeCompare(a.updatedAt))
-          .slice(0, query.limit ?? 100),
-        nextCursor: null,
+        reviews: visible,
+        nextCursor: page.length > limit ? visible[visible.length - 1]?.id ?? null : null,
       };
     },
   };

--- a/packages/gateway/src/server.ts
+++ b/packages/gateway/src/server.ts
@@ -34,6 +34,7 @@ import {
 import { summarizeConversation, saveSummary } from "./conversation-summary.js";
 import { extractMemoriesLocal } from "./memory-extractor.js";
 import { createWorkspaceRoutes } from "./workspace-routes.js";
+import { createReviewStore } from "./review-store.js";
 import { createElixirSymphonyProxyRoutes } from "./symphony/proxy.js";
 import { createSymphonyRunner } from "./symphony-runner.js";
 import { createAgentLauncher } from "./agent-launcher.js";
@@ -101,6 +102,7 @@ import { createCodingAgentThreadStore, createFakeCodingAgentProvider, type Codin
 import { createCodingAgentThreadStream, threadStreamFrameDataToString } from "./coding-agents/thread-stream.js";
 import { createWorkspaceCodingAgentProvider } from "./coding-agents/workspace-provider.js";
 import { createCodingAgentSessionStopReconciler } from "./coding-agents/session-stop-reconciler.js";
+import { createCodingAgentReviewSummaryStore } from "./coding-agents/review-summary.js";
 import { createAgentActionAuditService } from "./onboarding/agent-action-audit.js";
 import { capabilityIdsForConnectedServices, createIntegrationCapabilityService } from "./onboarding/integration-capabilities.js";
 import { createIntegrationCapabilityRoutes } from "./onboarding/integration-capability-routes.js";
@@ -475,6 +477,13 @@ export async function createGateway(config: GatewayConfig) {
   let codingAgentThreadStore: CodingAgentThreadStore | undefined;
   const codingAgentSessionStopReconciler = createCodingAgentSessionStopReconciler();
   const workspaceEventStore = createWorkspaceEventStore({ homePath });
+  const reviewStore = createReviewStore({ homePath });
+  const codingAgentReviewSummaryStore = createCodingAgentReviewSummaryStore(reviewStore, {
+    ownerId: process.env.MATRIX_USER_ID,
+    principalOwnerIds: [process.env.MATRIX_USER_ID, process.env.MATRIX_CLERK_USER_ID].filter(
+      (id): id is string => Boolean(id),
+    ),
+  });
   const workspaceEventPublisher = createWorkspaceEventPublisher({
     eventStore: workspaceEventStore,
     onSessionStopped: (session) => codingAgentSessionStopReconciler.handleSessionStopped(session),
@@ -527,6 +536,7 @@ export async function createGateway(config: GatewayConfig) {
     capabilities: {
       workspace: codingAgentWorkspaceEnabled,
       approvals: false,
+      review: true,
     },
     terminalOwnerId: process.env.MATRIX_USER_ID,
   });
@@ -1547,6 +1557,7 @@ export async function createGateway(config: GatewayConfig) {
   app.route("/api/coding-agents", createCodingAgentRoutes({
     service: codingAgentRuntimeSummaryService,
     threads: codingAgentThreadStore,
+    reviews: codingAgentReviewSummaryStore,
   }));
   app.route("/api/integrations", createIntegrationCapabilityRoutes({
     service: integrationCapabilityService,
@@ -2685,6 +2696,7 @@ export async function createGateway(config: GatewayConfig) {
     sessionRuntimeBridge: workspaceSessionRuntimeBridge,
     eventStore: workspaceEventStore,
     eventPublisher: workspaceEventPublisher,
+    reviewStore,
     getOwnerScope: (c) => ({ type: "user", id: requireRequestPrincipal(c).userId }),
   }));
   app.route("/api/symphony", createElixirSymphonyProxyRoutes({

--- a/specs/105-coding-agent-shells/current-state.md
+++ b/specs/105-coding-agent-shells/current-state.md
@@ -1,12 +1,12 @@
 # Current State: Coding Agent Shells
 
-**Branch stack**: `spec/coding-agent-shells` plus stacked implementation branches through `105-coding-agent-session-reconcile`
+**Branch stack**: `spec/coding-agent-shells` plus stacked implementation branches through `105-coding-agent-review-summary`
 **Updated**: 2026-07-06
 **Scope**: Inventory for the coding-agent desktop/mobile shell work. This file records the current Matrix-native route, contract, client, and regression-test state so later slices keep gateway/runtime as source of truth and keep desktop/mobile as thin shells.
 
 ## Summary
 
-The stack currently has shared contracts, a gateway runtime summary read model, read-only desktop and mobile workspaces behind flags, thread create/replay/abort/event streaming, provider adapters, a workspace-backed provider, and approval/input route handling. File/review/preview coding-agent surfaces are contract-only or existing workspace routes; they are not yet integrated into the coding-agent shell UI.
+The stack currently has shared contracts, a gateway runtime summary read model, read-only desktop and mobile workspaces behind flags, thread create/replay/abort/event streaming, provider adapters, a workspace-backed provider, approval/input route handling, and a read-only coding-agent review summary route/client contract. File diff and preview coding-agent surfaces are contract-only or existing workspace routes; they are not yet integrated into the coding-agent shell UI.
 
 Current source-of-truth boundaries:
 
@@ -28,7 +28,7 @@ Implemented coding-agent schemas:
 - Events: `AgentThreadEventSchema` discriminated union with lifecycle, text delta, tool activity, approval/input, file change, review ready, terminal bound, safe error, and completion event variants.
 - Approvals/input: `AgentApprovalRequestSchema`, `ApprovalDecisionRequestSchema`, `UserInputRequestSchema`, `UserInputAnswerRequestSchema`.
 - Terminal frames/summaries: `TerminalSessionSummarySchema`, `TerminalClientFrameSchema`, `TerminalServerFrameSchema`.
-- File/review/preview: `FilePathSchema`, `FileMetadataSchema`, `ReviewFileDiffSchema`, `PreviewSessionSummarySchema`.
+- File/review/preview: `FilePathSchema`, `FileMetadataSchema`, `ReviewSummarySchema`, `ReviewFileDiffSchema`, `PreviewSessionSummarySchema`.
 
 Contract tests:
 
@@ -50,6 +50,7 @@ Implemented routes:
 | `/api/coding-agents/threads/:threadId/abort` | `POST` | Implemented | Body limit 8 KiB, idempotent abort by client request id. |
 | `/api/coding-agents/threads/:threadId/approvals/:approvalId/decision` | `POST` | Implemented | Body limit 8 KiB, validates approval id and decision payload. |
 | `/api/coding-agents/threads/:threadId/inputs/:inputRequestId/answer` | `POST` | Implemented | Body limit 40 KiB, validates bounded answer payload. |
+| `/api/coding-agents/reviews` | `GET` | Implemented | Authenticated read-only review summary list. Returns bounded `ReviewSummarySchema` items only. |
 
 Security and ownership:
 
@@ -115,6 +116,7 @@ Core files:
 - `packages/gateway/src/coding-agents/thread-store.ts`
 - `packages/gateway/src/coding-agents/provider-registry.ts`
 - `packages/gateway/src/coding-agents/workspace-provider.ts`
+- `packages/gateway/src/coding-agents/review-summary.ts`
 
 Implemented providers:
 
@@ -135,6 +137,12 @@ Thread store behavior:
 - Idempotent thread creation, aborts, approval decisions, and input answers by bounded request-id arrays.
 - Event replay with bounded per-thread event storage.
 - Safe terminal statuses and attention states derived from events.
+
+Review summary behavior:
+
+- Adapts existing owner-local review-loop records into bounded `ReviewSummarySchema` rows.
+- Drops malformed legacy records instead of exposing raw review state.
+- Caps the coding-agent route response at 50 items.
 
 Focused tests:
 
@@ -171,6 +179,7 @@ IPC contract:
 
 - `desktop/src/shared/ipc-contract.ts`
 - `runtime:get-summary` returns `RuntimeSummarySchema`.
+- `runtime:get-reviews` returns a bounded list of `ReviewSummarySchema` rows from the trusted main process.
 - `notify` accepts bounded notification data with `threadId`, `title`, `body`, and kind.
 - `notification:clicked` emits bounded `threadId`.
 
@@ -178,7 +187,8 @@ Main process:
 
 - `desktop/src/main/coding-agents/runtime-summary-client.ts`
 - Fetches `/api/coding-agents/summary` from the selected runtime origin with bearer auth in the main process.
-- Uses `AbortSignal.timeout(10_000)` and validates `RuntimeSummarySchema`.
+- Fetches `/api/coding-agents/reviews` from the selected runtime origin with bearer auth in the main process.
+- Uses `AbortSignal.timeout(10_000)` and validates `RuntimeSummarySchema` or bounded `ReviewSummarySchema` lists.
 - Renderer receives only parsed summary data through IPC.
 
 Renderer:
@@ -200,12 +210,16 @@ Gateway client:
 
 - `apps/mobile/lib/gateway-client.ts`
 - `getCodingAgentRuntimeSummary()` calls `GET /api/coding-agents/summary`, validates `RuntimeSummarySchema`, and returns the safe `"Runtime summary unavailable"` error on failure.
+- `getCodingAgentReviews()` calls `GET /api/coding-agents/reviews`, validates a bounded review summary list, and returns the safe `"Review state unavailable"` error on failure.
 - Existing terminal session methods call `/api/terminal/sessions`.
 
 Screen:
 
-- `apps/mobile/app/agents.tsx`
+- `apps/mobile/app/agents/index.tsx`
+- `apps/mobile/app/agents/new.tsx`
+- `apps/mobile/app/agents/[threadId].tsx`
 - Read-only phone-first dashboard with providers, active threads, and terminal sessions.
+- Composer route for creating accepted coding-agent threads; thread route is a bounded placeholder until replay/review surfaces are wired.
 - Flag: `apps/mobile/lib/feature-flags.ts` with `EXPO_PUBLIC_CODING_AGENTS_MOBILE_WORKSPACE === "1"`.
 
 Persisted UI references:
@@ -232,6 +246,8 @@ Relevant existing browser shell paths:
 - Built-in app/canvas behavior remains outside this coding-agent stack.
 
 Open follow-up: decide whether a browser-shell coding-agent entry belongs in Canvas, Developer mode, or both after desktop/mobile read-only shells settle.
+
+Public docs note: public docs remain deferred for this review-summary slice because it is an internal read contract with no user-visible review UI yet. Update `www/content/docs/` when the file/review/preview surfaces become visible in desktop, mobile, or browser shell navigation.
 
 ## Feature Flags
 
@@ -261,7 +277,7 @@ Current behavior:
 - Runtime summary advertises `codingAgentsThreadCreate` when a coding-agent thread store is wired.
 - Runtime summary advertises `codingAgentsApprovals` only when a thread store is wired and gateway summary wiring explicitly sets `capabilities.approvals`; current production wiring keeps it disabled until a provider/handler can bridge approval decisions to the running agent, not merely record local resolution events.
 - Runtime summary advertises `codingAgentsNativeMobileTerminal` when a terminal registry is wired and the caller can read terminal sessions.
-- Runtime summary keeps `codingAgentsReview` disabled until coding-agent-specific review shell integration is implemented.
+- Runtime summary advertises `codingAgentsReview` when the read-only coding-agent review summary route is wired.
 
 ## Baseline Commands
 
@@ -305,7 +321,7 @@ git diff --check
 ## Open Questions And Deferred Work
 
 - Session completion reconciliation: implemented for workspace `session.stopped` events that carry owner id, workspace session id, and bound `terminalSessionId`; the gateway thread store marks matching active coding-agent threads completed or failed server-side without matching unrelated owners or reused terminal ids. Remaining work: if runtime managers add autonomous process-exit detection beyond explicit workspace stop events, route those through the same `session.stopped` publisher path.
-- File/review/preview shell surfaces: contracts exist and workspace routes exist, but coding-agent-specific UI integration is not implemented yet.
+- File/review/preview shell surfaces: read-only review summaries now have coding-agent contracts/routes/desktop IPC/mobile clients. File diffs, previews, and visible review UI integration are not implemented yet.
 - Browser shell entry point: Canvas-first placement is still undecided.
 - Notifications/attention routing: desktop notification IPC exists, but thread attention notifications are not yet wired end-to-end from gateway events.
 - Public docs: public Matrix OS docs should be updated once the user-facing coding-agent shell flow is stable enough to document.

--- a/tests/contracts/coding-agents.test.ts
+++ b/tests/contracts/coding-agents.test.ts
@@ -9,6 +9,7 @@ import {
   FileMetadataSchema,
   PreviewSessionSummarySchema,
   ReviewFileDiffSchema,
+  ReviewSummarySchema,
   RuntimeSummarySchema,
   SafeClientErrorSchema,
   TerminalClientFrameSchema,
@@ -269,6 +270,40 @@ describe("coding agent contracts", () => {
       updatedAt: now,
     }).path).toBe("src/index.ts");
     expect(() => FileMetadataSchema.parse({ path: "../secret", kind: "file" })).toThrow();
+
+    expect(ReviewSummarySchema.parse({
+      id: "rev_123",
+      projectId: "matrix-os",
+      worktreeId: "wt_abc123def456",
+      status: "reviewing",
+      pullRequestNumber: 757,
+      round: 1,
+      maxRounds: 3,
+      reviewer: "codex",
+      implementer: "claude",
+      findings: {
+        total: 2,
+        high: 1,
+        medium: 1,
+        low: 0,
+      },
+      updatedAt: now,
+    }).findings.total).toBe(2);
+    expect(() =>
+      ReviewSummarySchema.parse({
+        id: "rev_123",
+        projectId: "matrix-os",
+        worktreeId: "wt_abc123def456",
+        status: "reviewing",
+        pullRequestNumber: 757,
+        round: 1,
+        maxRounds: 3,
+        reviewer: "codex",
+        implementer: "claude",
+        safeStatus: "Postgres failed at /home/matrix/home",
+        updatedAt: now,
+      }),
+    ).toThrow();
 
     expect(ReviewFileDiffSchema.parse({
       path: "src/index.ts",

--- a/tests/desktop/ipc-contract.test.ts
+++ b/tests/desktop/ipc-contract.test.ts
@@ -14,6 +14,7 @@ describe("IPC contract", () => {
       "auth:status",
       "auth:sign-out",
       "runtime:create-thread",
+      "runtime:get-reviews",
       "runtime:get-summary",
       "runtime:select",
       "state:get",
@@ -112,6 +113,39 @@ describe("IPC contract", () => {
 
     expect(schema.safeParse(valid).success).toBe(true);
     expect(schema.safeParse({ ...valid, accessToken: "secret" }).success).toBe(false);
+  });
+
+  it("validates runtime:get-reviews responses and rejects credential leakage shapes", () => {
+    const requestSchema = INVOKE_CHANNELS["runtime:get-reviews"].request;
+    const schema = INVOKE_CHANNELS["runtime:get-reviews"].response;
+    const valid = {
+      items: [
+        {
+          id: "rev_desktop_1",
+          projectId: "matrix-os",
+          worktreeId: "wt_abc123def456",
+          status: "reviewing",
+          pullRequestNumber: 757,
+          round: 1,
+          maxRounds: 3,
+          reviewer: "codex",
+          implementer: "claude",
+          findings: { total: 1, high: 0, medium: 1, low: 0 },
+          updatedAt: "2026-07-06T00:00:00.000Z",
+        },
+      ],
+      hasMore: false,
+      limit: 50,
+    };
+
+    expect(requestSchema.safeParse({ cursor: "rev_desktop_1" }).success).toBe(true);
+    expect(requestSchema.safeParse({ cursor: "../secret" }).success).toBe(false);
+    expect(schema.safeParse(valid).success).toBe(true);
+    expect(schema.safeParse({ ...valid, accessToken: "secret" }).success).toBe(false);
+    expect(schema.safeParse({
+      ...valid,
+      items: [{ ...valid.items[0], safeStatus: "Postgres failed at /home/matrix/home" }],
+    }).success).toBe(false);
   });
 
   it("validates auth:poll responses and rejects token leakage shapes", () => {

--- a/tests/desktop/ipc-handlers.test.ts
+++ b/tests/desktop/ipc-handlers.test.ts
@@ -37,6 +37,7 @@ function makeHarness(overrides: Partial<HandlerContext> = {}) {
     onRuntimeChanged: vi.fn(),
     getUpdateStatus: vi.fn(() => "disabled"),
     fetchRuntimeSummary: vi.fn(),
+    fetchReviewSummaries: vi.fn(),
     createAgentThread: vi.fn(),
     ...overrides,
   } as unknown as HandlerContext;
@@ -166,6 +167,45 @@ describe("registerIpcHandlers", () => {
 
     await expect(harness.invoke("runtime:get-summary")).rejects.toThrow("internal error");
     await expect(harness.invoke("runtime:get-summary")).rejects.not.toThrow("10.0.0.5");
+  });
+
+  it("returns coding agent review summaries through a strict trusted-core IPC channel", async () => {
+    const reviews = {
+      items: [
+        {
+          id: "rev_desktop_1",
+          projectId: "matrix-os",
+          worktreeId: "wt_abc123def456",
+          status: "reviewing",
+          pullRequestNumber: 757,
+          round: 1,
+          maxRounds: 3,
+          reviewer: "codex",
+          implementer: "claude",
+          findings: { total: 1, high: 0, medium: 1, low: 0 },
+          updatedAt: "2026-07-06T00:00:00.000Z",
+        },
+      ],
+      hasMore: false,
+      limit: 50,
+    };
+    const fetchReviewSummaries = vi.fn().mockResolvedValue(reviews);
+    const harness = makeHarness({ fetchReviewSummaries } as Partial<HandlerContext>);
+
+    await expect(harness.invoke("runtime:get-reviews")).resolves.toEqual(reviews);
+    await expect(harness.invoke("runtime:get-reviews", { cursor: "rev_desktop_1" })).resolves.toEqual(reviews);
+    expect(fetchReviewSummaries).toHaveBeenNthCalledWith(1, {});
+    expect(fetchReviewSummaries).toHaveBeenNthCalledWith(2, { cursor: "rev_desktop_1" });
+  });
+
+  it("maps review summary failures to a generic IPC error", async () => {
+    const fetchReviewSummaries = vi
+      .fn()
+      .mockRejectedValue(new Error("Postgres failed at /home/matrix/home"));
+    const harness = makeHarness({ fetchReviewSummaries } as Partial<HandlerContext>);
+
+    await expect(harness.invoke("runtime:get-reviews")).rejects.toThrow("internal error");
+    await expect(harness.invoke("runtime:get-reviews")).rejects.not.toThrow("/home/matrix");
   });
 
   it("creates agent threads through trusted-core IPC without exposing credentials", async () => {

--- a/tests/gateway/coding-agents-summary.test.ts
+++ b/tests/gateway/coding-agents-summary.test.ts
@@ -1,16 +1,44 @@
 import { describe, expect, it, vi } from "vitest";
 import { Hono } from "hono";
-import { RuntimeSummarySchema } from "../../packages/contracts/src/index.js";
+import {
+  ReviewSummarySchema,
+  RuntimeSummarySchema,
+  boundedListSchema,
+} from "../../packages/contracts/src/index.js";
 import {
   createCodingAgentRuntimeSummaryService,
   type CodingAgentTerminalSessionRegistry,
 } from "../../packages/gateway/src/coding-agents/runtime-summary.js";
+import {
+  createCodingAgentReviewSummaryStore,
+  type ReviewLoopStore,
+} from "../../packages/gateway/src/coding-agents/review-summary.js";
 import { createCodingAgentRoutes } from "../../packages/gateway/src/coding-agents/routes.js";
 import type { RequestPrincipal } from "../../packages/gateway/src/request-principal.js";
 import { MissingRequestPrincipalError } from "../../packages/gateway/src/request-principal.js";
 import { testPrincipal } from "../helpers/activation-readiness.js";
 
 const now = new Date("2026-07-06T12:00:00.000Z");
+
+function reviewRecord(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "rev_1",
+    projectSlug: "matrix-os",
+    worktreeId: "wt_abc123def456",
+    pr: 758,
+    status: "reviewing",
+    round: 1,
+    maxRounds: 3,
+    reviewer: "codex",
+    implementer: "claude",
+    convergenceGate: "findings_only",
+    verificationCommands: [],
+    rounds: [],
+    createdAt: now.toISOString(),
+    updatedAt: now.toISOString(),
+    ...overrides,
+  };
+}
 
 function registryWith(count: number): CodingAgentTerminalSessionRegistry {
   return {
@@ -319,5 +347,172 @@ describe("coding agent runtime summary", () => {
         recoveryActions: ["retry"],
       },
     });
+  });
+
+  it("serves authenticated capped review summaries through a safe coding-agent route", async () => {
+    const service = createCodingAgentRuntimeSummaryService({
+      homePath: "/home/matrix/home",
+      terminalRegistry: registryWith(0),
+      now: () => now,
+      runtime: { id: "rt_primary", label: "Primary Matrix computer" },
+    });
+    const app = new Hono();
+    app.route("/api/coding-agents", createCodingAgentRoutes({
+      service,
+      reviews: {
+        listReviews: async () => ({
+          items: Array.from({ length: 50 }, (_, index) => ReviewSummarySchema.parse({
+            id: `rev_${index}`,
+            projectId: "matrix-os",
+            worktreeId: "wt_abc123def456",
+            status: index === 0 ? "reviewing" : "queued",
+            pullRequestNumber: 700 + index,
+            round: index,
+            maxRounds: 3,
+            reviewer: "codex",
+            implementer: "claude",
+            findings: {
+              total: index,
+              high: 0,
+              medium: index,
+              low: 0,
+            },
+            updatedAt: new Date(now.getTime() - index * 1000).toISOString(),
+          })),
+          hasMore: true,
+          limit: 50,
+        }),
+      },
+      getPrincipal: () => testPrincipal,
+    }));
+
+    const res = await app.request("/api/coding-agents/reviews");
+
+    expect(res.status).toBe(200);
+    const body = boundedListSchema(ReviewSummarySchema, 50).parse(await res.json());
+    expect(body.items).toHaveLength(50);
+    expect(body.hasMore).toBe(true);
+    expect(body.items[0]).toMatchObject({
+      id: "rev_0",
+      status: "reviewing",
+      findings: { total: 0, high: 0, medium: 0, low: 0 },
+    });
+    expect(JSON.stringify(body)).not.toMatch(/\/home\/matrix|Postgres|token|secret/i);
+  });
+
+  it("withholds owner-local review summaries from other principals", async () => {
+    const store = createCodingAgentReviewSummaryStore({
+      listReviews: async () => ({ ok: true, reviews: [reviewRecord()], nextCursor: null }),
+    } as ReviewLoopStore, { ownerId: "owner_user" });
+    const otherPrincipal: RequestPrincipal = { userId: "other_user", source: "configured-container" };
+
+    await expect(store.listReviews(otherPrincipal)).resolves.toEqual({
+      items: [],
+      hasMore: false,
+      limit: 50,
+    });
+  });
+
+  it("allows validated jwt review readers even when the configured owner id uses another owner identifier", async () => {
+    const store = createCodingAgentReviewSummaryStore({
+      listReviews: async () => ({ ok: true, reviews: [reviewRecord()], nextCursor: null }),
+    } as ReviewLoopStore, { ownerId: "owner_user", principalOwnerIds: ["clerk_owner_subject"] });
+    const jwtPrincipal: RequestPrincipal = { userId: "clerk_owner_subject", source: "jwt" };
+
+    await expect(store.listReviews(jwtPrincipal)).resolves.toMatchObject({
+      items: [expect.objectContaining({ id: "rev_1" })],
+      hasMore: false,
+      limit: 50,
+    });
+  });
+
+  it("withholds owner-local review summaries from jwt principals outside the owner id allowlist", async () => {
+    const store = createCodingAgentReviewSummaryStore({
+      listReviews: async () => ({ ok: true, reviews: [reviewRecord()], nextCursor: null }),
+    } as ReviewLoopStore, { ownerId: "owner_user", principalOwnerIds: ["clerk_owner_subject"] });
+    const otherPrincipal: RequestPrincipal = { userId: "other_user", source: "jwt" };
+
+    await expect(store.listReviews(otherPrincipal)).resolves.toEqual({
+      items: [],
+      hasMore: false,
+      limit: 50,
+    });
+  });
+
+  it("does not report more review pages only because malformed records were dropped", async () => {
+    const store = createCodingAgentReviewSummaryStore({
+      listReviews: async () => ({
+        ok: true,
+        reviews: [
+          reviewRecord({ id: "../bad", projectSlug: "/home/matrix/private" }),
+          reviewRecord({ id: "rev_good" }),
+        ],
+        nextCursor: null,
+      }),
+    } as ReviewLoopStore);
+
+    await expect(store.listReviews(testPrincipal)).resolves.toEqual({
+      items: [expect.objectContaining({ id: "rev_good" })],
+      hasMore: false,
+      limit: 50,
+    });
+  });
+
+  it("preserves review hasMore only when valid review summaries exceed the page cap", async () => {
+    const store = createCodingAgentReviewSummaryStore({
+      listReviews: async () => ({
+        ok: true,
+        reviews: Array.from({ length: 51 }, (_, index) => reviewRecord({ id: `rev_${index}` })),
+        nextCursor: null,
+      }),
+    } as ReviewLoopStore);
+
+    const result = await store.listReviews(testPrincipal);
+
+    expect(result.items).toHaveLength(50);
+    expect(result.hasMore).toBe(true);
+    expect(result.nextCursor).toBe("rev_49");
+  });
+
+  it("skips malformed overflow records while preserving a usable review cursor", async () => {
+    const store = createCodingAgentReviewSummaryStore({
+      listReviews: async () => ({
+        ok: true,
+        reviews: [
+          ...Array.from({ length: 50 }, (_, index) => reviewRecord({ id: `rev_${index}` })),
+          reviewRecord({ id: "../bad", projectSlug: "/home/matrix/private" }),
+          reviewRecord({ id: "rev_older_valid" }),
+        ],
+        nextCursor: null,
+      }),
+    } as ReviewLoopStore);
+
+    const result = await store.listReviews(testPrincipal);
+
+    expect(result.items).toHaveLength(50);
+    expect(result.hasMore).toBe(true);
+    expect(result.nextCursor).toBe("rev_49");
+  });
+
+  it("keeps a review cursor when malformed raw pages consume the scan window", async () => {
+    let page = 0;
+    const store = createCodingAgentReviewSummaryStore({
+      listReviews: async ({ cursor }) => {
+        page += 1;
+        return {
+          ok: true,
+          reviews: cursor
+            ? Array.from({ length: 100 }, (_, index) => reviewRecord({ id: `../bad_${page}_${index}` }))
+            : Array.from({ length: 50 }, (_, index) => reviewRecord({ id: `rev_${index}` })),
+          nextCursor: cursor ? `rev_after_malformed_page_${page}` : "rev_49",
+        };
+      },
+    } as ReviewLoopStore);
+
+    const result = await store.listReviews(testPrincipal);
+
+    expect(result.items).toHaveLength(50);
+    expect(result.hasMore).toBe(true);
+    expect(result.nextCursor).toBe("rev_49");
   });
 });

--- a/tests/gateway/review-store.test.ts
+++ b/tests/gateway/review-store.test.ts
@@ -18,6 +18,14 @@ describe("review-store", () => {
   });
 
   function record(id = "rev_abc123") {
+    const minuteById: Record<string, string> = {
+      rev_abc123: "00",
+      rev_older: "00",
+      rev_newer: "01",
+      rev_oldest: "00",
+      rev_middle: "01",
+      rev_newest: "02",
+    };
     return createReviewLoopRecord({
       id,
       projectSlug: "repo",
@@ -28,7 +36,7 @@ describe("review-store", () => {
       maxRounds: 3,
       convergenceGate: "findings_only",
       verificationCommands: [],
-      now: () => id === "rev_abc123" ? "2026-04-26T00:00:00.000Z" : "2026-04-26T00:01:00.000Z",
+      now: () => `2026-04-26T00:${minuteById[id] ?? "00"}:00.000Z`,
     });
   }
 
@@ -62,6 +70,29 @@ describe("review-store", () => {
     await expect(store.listReviews({ projectSlug: "other", limit: 10 })).resolves.toMatchObject({
       ok: true,
       reviews: [expect.objectContaining({ id: "rev_newer" })],
+    });
+  });
+
+  it("paginates review records with a cursor from the last returned review", async () => {
+    const store = createReviewStore({ homePath });
+    await store.saveReview(record("rev_oldest"));
+    await store.saveReview(record("rev_middle"));
+    await store.saveReview(record("rev_newest"));
+
+    const first = await store.listReviews({ limit: 2 });
+
+    expect(first).toMatchObject({
+      ok: true,
+      reviews: [
+        expect.objectContaining({ id: "rev_newest" }),
+        expect.objectContaining({ id: "rev_middle" }),
+      ],
+      nextCursor: "rev_middle",
+    });
+    await expect(store.listReviews({ limit: 2, cursor: "rev_middle" })).resolves.toMatchObject({
+      ok: true,
+      reviews: [expect.objectContaining({ id: "rev_oldest" })],
+      nextCursor: null,
     });
   });
 


### PR DESCRIPTION
## Summary

- Add a Matrix-native `ReviewSummarySchema` for bounded coding-agent review rows.
- Add authenticated `GET /api/coding-agents/reviews` backed by the existing owner-local review store through a safe adapter.
- Add desktop trusted-core IPC and mobile gateway-client read paths for review summaries.
- Refresh the coding-agent shell current-state note for the new review read model.

## Invariants

- Source of truth: gateway/runtime remains authoritative; desktop and mobile only read bounded summaries.
- Persistence: uses the existing owner-file review store; no new database or embedded persistence is introduced.
- Auth: the coding-agent review route resolves the existing request principal before returning data.
- Validation: route, desktop IPC, mobile client, and tests validate with shared Zod 4 contracts.
- Safety: raw review-loop records, provider errors, paths, tokens, and internal failure details are not exposed to shell clients.
- Deferred scope: file diffs, previews, and visible review UI panels remain follow-up work.

## Validation

- `bun run test -- tests/contracts/coding-agents.test.ts tests/gateway/coding-agents-summary.test.ts tests/desktop/ipc-contract.test.ts tests/desktop/ipc-handlers.test.ts`
- `pnpm --filter matrix-os-mobile run test -- gateway-client.test.ts --runInBand`
- `pnpm --filter @matrix-os/gateway exec tsc --noEmit`
- `pnpm --filter desktop run typecheck`
- `pnpm --filter matrix-os-mobile exec tsc --noEmit`
- `pnpm --filter matrix-os-mobile run test`
- `pnpm --filter matrix-os-mobile run lint`
- `bun run check:patterns`
- `bun run typecheck`
- `git diff --check`
- Private-reference hygiene scan returned no matches.

Unavailable in this environment:

- `vp check`
- `vp run lint:mobile`
- `vp run typecheck`

## Docs

- Updated `specs/105-coding-agent-shells/current-state.md`.
- Public docs are deferred until the review/file/preview surfaces are visible in a user-facing shell.
