### PR TITLE
feat(coding-agents): add desktop review summary panel

### DIFF
--- a/desktop/src/renderer/src/features/coding-agents/AgentWorkspace.tsx
+++ b/desktop/src/renderer/src/features/coding-agents/AgentWorkspace.tsx
@@ -1,8 +1,9 @@
-import { Bot, GitBranch, Play, RefreshCw, Server, SquareTerminal } from "lucide-react";
+import { Bot, ClipboardCheck, GitBranch, Play, RefreshCw, Server, SquareTerminal } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
 import {
   defaultAgentThreadComposerDraft,
   type AgentThreadComposerDraft,
+  type ReviewSummary,
   type RuntimeSummary,
 } from "@matrix-os/contracts";
 import { Button, EmptyState, StatusDot } from "../../design/primitives";
@@ -322,6 +323,61 @@ function TerminalList({ summary }: { summary: RuntimeSummary }) {
   );
 }
 
+function reviewStatusLabel(status: ReviewSummary["status"]): string {
+  return status.replace(/_/g, " ");
+}
+
+function ReviewList() {
+  const reviewsStatus = useCodingAgentWorkspace((s) => s.reviewsStatus);
+  const reviews = useCodingAgentWorkspace((s) => s.reviews);
+  const reviewsError = useCodingAgentWorkspace((s) => s.reviewsError);
+  const items = reviews?.items ?? [];
+
+  return (
+    <Section title="Review" count={items.length}>
+      <div className="grid gap-2">
+        {reviewsStatus === "error" ? (
+          <p className="rounded-md border p-3 text-sm" style={{ borderColor: "var(--border-subtle)", color: "var(--danger)" }}>
+            {reviewsError ?? "Review state unavailable"}
+          </p>
+        ) : null}
+        {items.map((review) => (
+          <article
+            key={review.id}
+            className="flex items-center justify-between gap-3 rounded-md border p-3"
+            style={{ borderColor: "var(--border-subtle)", background: "var(--bg-surface)" }}
+          >
+            <div className="flex min-w-0 items-center gap-2">
+              <ClipboardCheck size={15} style={{ color: "var(--text-tertiary)" }} />
+              <div className="min-w-0">
+                <h3 className="truncate text-sm font-medium" style={{ color: "var(--text-primary)" }}>
+                  {review.projectId}
+                </h3>
+                <p className="text-xs" style={{ color: "var(--text-tertiary)" }}>
+                  {`PR #${review.pullRequestNumber} - Round ${review.round} of ${review.maxRounds}`}
+                </p>
+              </div>
+            </div>
+            <div className="shrink-0 text-right text-xs" style={{ color: "var(--text-secondary)" }}>
+              <p className="capitalize">{reviewStatusLabel(review.status)}</p>
+              {review.findings ? (
+                <p style={{ color: review.findings.high > 0 ? "var(--danger)" : "var(--text-tertiary)" }}>
+                  {review.findings.high} high
+                </p>
+              ) : null}
+            </div>
+          </article>
+        ))}
+        {reviewsStatus !== "error" && reviewsStatus !== "loading" && items.length === 0 ? (
+          <p className="rounded-md border p-3 text-sm" style={{ borderColor: "var(--border-subtle)", color: "var(--text-secondary)" }}>
+            No reviews.
+          </p>
+        ) : null}
+      </div>
+    </Section>
+  );
+}
+
 export default function AgentWorkspace() {
   const runtimeSlot = useConnection((s) => s.runtimeSlot);
   const status = useCodingAgentWorkspace((s) => s.status);
@@ -366,6 +422,7 @@ export default function AgentWorkspace() {
           <ThreadList summary={summary} />
           <TerminalList summary={summary} />
         </div>
+        {capabilityEnabled(summary, "codingAgentsReview") ? <ReviewList /> : null}
       </div>
     </div>
   );

--- a/desktop/src/renderer/src/stores/coding-agent-workspace.ts
+++ b/desktop/src/renderer/src/stores/coding-agent-workspace.ts
@@ -1,18 +1,29 @@
 import {
   buildCreateAgentThreadRequestFromComposer,
   type AgentThreadComposerDraft,
+  type ReviewSummary,
   type RuntimeSummary,
 } from "@matrix-os/contracts";
 import { create } from "zustand";
 import { invoke } from "../lib/operator";
 
 type WorkspaceStatus = "idle" | "loading" | "ready" | "error";
+type ReviewStatus = "idle" | "loading" | "ready" | "error";
 type CreateStatus = "idle" | "submitting";
+type ReviewSummaryList = {
+  items: ReviewSummary[];
+  hasMore: boolean;
+  nextCursor?: string;
+  limit: number;
+};
 
 interface CodingAgentWorkspaceState {
   status: WorkspaceStatus;
   summary: RuntimeSummary | null;
   error: string | null;
+  reviewsStatus: ReviewStatus;
+  reviews: ReviewSummaryList | null;
+  reviewsError: string | null;
   createStatus: CreateStatus;
   createError: string | null;
   activeThreadId: string | null;
@@ -21,6 +32,7 @@ interface CodingAgentWorkspaceState {
 }
 
 let refreshSeq = 0;
+let reviewsSeq = 0;
 let createRequestSeq = 0;
 
 function nextCreateRequestId(): string {
@@ -32,6 +44,9 @@ export const useCodingAgentWorkspace = create<CodingAgentWorkspaceState>()((set)
   status: "idle",
   summary: null,
   error: null,
+  reviewsStatus: "idle",
+  reviews: null,
+  reviewsError: null,
   createStatus: "idle",
   createError: null,
   activeThreadId: null,
@@ -46,6 +61,24 @@ export const useCodingAgentWorkspace = create<CodingAgentWorkspaceState>()((set)
       const summary = await invoke("runtime:get-summary", {});
       if (seq !== refreshSeq) return;
       set({ status: "ready", summary, error: null });
+      if (!summary.capabilities.some((capability) => capability.id === "codingAgentsReview" && capability.enabled)) {
+        set({ reviewsStatus: "idle", reviews: null, reviewsError: null });
+        return;
+      }
+      const reviewSeq = ++reviewsSeq;
+      set((state) => ({
+        reviewsStatus: state.reviews ? "ready" : "loading",
+        reviewsError: null,
+      }));
+      try {
+        const reviews = await invoke("runtime:get-reviews", {});
+        if (reviewSeq !== reviewsSeq) return;
+        set({ reviewsStatus: "ready", reviews, reviewsError: null });
+      } catch {
+        console.warn("[coding-agents] review summary refresh failed");
+        if (reviewSeq !== reviewsSeq) return;
+        set({ reviewsStatus: "error", reviewsError: "Review state unavailable" });
+      }
     } catch {
       console.warn("[coding-agents] summary refresh failed");
       if (seq !== refreshSeq) return;

--- a/specs/105-coding-agent-shells/current-state.md
+++ b/specs/105-coding-agent-shells/current-state.md
@@ -6,7 +6,7 @@
 
 ## Summary
 
-The stack currently has shared contracts, a gateway runtime summary read model, read-only desktop and mobile workspaces behind flags, thread create/replay/abort/event streaming, provider adapters, a workspace-backed provider, approval/input route handling, and a read-only coding-agent review summary route/client contract. File diff and preview coding-agent surfaces are contract-only or existing workspace routes; they are not yet integrated into the coding-agent shell UI.
+The stack currently has shared contracts, a gateway runtime summary read model, read-only desktop and mobile workspaces behind flags, thread create/replay/abort/event streaming, provider adapters, a workspace-backed provider, approval/input route handling, a read-only coding-agent review summary route/client contract, and a desktop read-only review summary panel. File diff and preview coding-agent surfaces are contract-only or existing workspace routes; mobile review UI is not yet integrated into the coding-agent shell UI.
 
 Current source-of-truth boundaries:
 
@@ -201,7 +201,9 @@ Renderer:
 Current behavior:
 
 - Read-only dashboard renders providers, active threads, and terminals.
+- When the runtime advertises `codingAgentsReview`, the dashboard fetches bounded review summaries through the trusted main-process IPC route and renders project, PR, round, status, and high-severity count.
 - Safe generic error state if the runtime summary is unavailable.
+- Safe generic review error state if review summaries are unavailable; review failures do not drop the runtime summary dashboard.
 - No provider credentials or bearer tokens are exposed to the renderer.
 
 ## Mobile Shell State
@@ -247,7 +249,7 @@ Relevant existing browser shell paths:
 
 Open follow-up: decide whether a browser-shell coding-agent entry belongs in Canvas, Developer mode, or both after desktop/mobile read-only shells settle.
 
-Public docs note: public docs remain deferred for this review-summary slice because it is an internal read contract with no user-visible review UI yet. Update `www/content/docs/` when the file/review/preview surfaces become visible in desktop, mobile, or browser shell navigation.
+Public docs note: public docs remain deferred for this desktop review-summary slice because the cross-shell review flow still lacks mobile review UI, file diffs, and preview integration. Update `www/content/docs/` when the file/review/preview surfaces become stable in desktop, mobile, or browser shell navigation.
 
 ## Feature Flags
 
@@ -321,7 +323,7 @@ git diff --check
 ## Open Questions And Deferred Work
 
 - Session completion reconciliation: implemented for workspace `session.stopped` events that carry owner id, workspace session id, and bound `terminalSessionId`; the gateway thread store marks matching active coding-agent threads completed or failed server-side without matching unrelated owners or reused terminal ids. Remaining work: if runtime managers add autonomous process-exit detection beyond explicit workspace stop events, route those through the same `session.stopped` publisher path.
-- File/review/preview shell surfaces: read-only review summaries now have coding-agent contracts/routes/desktop IPC/mobile clients. File diffs, previews, and visible review UI integration are not implemented yet.
+- File/review/preview shell surfaces: read-only review summaries now have coding-agent contracts/routes/desktop IPC/mobile clients plus a desktop read-only review panel. File diffs, previews, and mobile review UI integration are not implemented yet.
 - Browser shell entry point: Canvas-first placement is still undecided.
 - Notifications/attention routing: desktop notification IPC exists, but thread attention notifications are not yet wired end-to-end from gateway events.
 - Public docs: public Matrix OS docs should be updated once the user-facing coding-agent shell flow is stable enough to document.

--- a/tests/desktop/coding-agent-workspace.test.tsx
+++ b/tests/desktop/coding-agent-workspace.test.tsx
@@ -24,6 +24,10 @@ function summaryFixture({ threadCreate = false }: { threadCreate?: boolean } = {
         enabled: threadCreate,
         ...(threadCreate ? {} : { reason: "Not enabled yet" }),
       },
+      {
+        id: "codingAgentsReview",
+        enabled: true,
+      },
     ],
     providers: [
       {
@@ -86,12 +90,42 @@ function summaryFixture({ threadCreate = false }: { threadCreate?: boolean } = {
   };
 }
 
+function reviewsFixture() {
+  return {
+    items: [
+      {
+        id: "rev_desktop_1",
+        projectId: "matrix-os",
+        worktreeId: "wt_desktop_1",
+        status: "reviewing",
+        pullRequestNumber: 758,
+        round: 2,
+        maxRounds: 3,
+        reviewer: "matrix-reviewer",
+        implementer: "matrix-implementer",
+        findings: {
+          total: 3,
+          high: 1,
+          medium: 1,
+          low: 1,
+        },
+        updatedAt: "2026-07-06T00:02:00.000Z",
+      },
+    ],
+    hasMore: false,
+    limit: 50,
+  };
+}
+
 describe("AgentWorkspace", () => {
   beforeEach(() => {
     useCodingAgentWorkspace.setState({
       status: "idle",
       summary: null,
       error: null,
+      reviewsStatus: "idle",
+      reviews: null,
+      reviewsError: null,
       createStatus: "idle",
       createError: null,
       activeThreadId: null,
@@ -104,7 +138,11 @@ describe("AgentWorkspace", () => {
       api: null,
     });
     window.operator = {
-      invoke: vi.fn().mockResolvedValue(summaryFixture()),
+      invoke: vi.fn((channel: string) => {
+        if (channel === "runtime:get-summary") return Promise.resolve(summaryFixture());
+        if (channel === "runtime:get-reviews") return Promise.resolve(reviewsFixture());
+        return Promise.reject(new Error("unexpected channel"));
+      }),
       on: vi.fn(() => () => undefined),
     };
   });
@@ -125,9 +163,37 @@ describe("AgentWorkspace", () => {
     expect(window.operator.invoke).toHaveBeenCalledWith("runtime:get-summary", {});
   });
 
+  it("renders read-only review summaries through trusted IPC", async () => {
+    render(<AgentWorkspace />);
+
+    await screen.findByText("Review");
+    expect(screen.getByText("matrix-os")).toBeTruthy();
+    expect(screen.getByText(/PR #758/)).toBeTruthy();
+    expect(screen.getByText("1 high")).toBeTruthy();
+    expect(screen.getByText(/Round 2 of 3/)).toBeTruthy();
+    expect(window.operator.invoke).toHaveBeenCalledWith("runtime:get-reviews", {});
+  });
+
+  it("shows a generic safe review error without dropping the runtime summary", async () => {
+    window.operator.invoke = vi.fn((channel: string) => {
+      if (channel === "runtime:get-summary") return Promise.resolve(summaryFixture());
+      if (channel === "runtime:get-reviews") {
+        return Promise.reject(new Error("review store failed at /home/matrix/private token secret"));
+      }
+      return Promise.reject(new Error("unexpected channel"));
+    });
+
+    render(<AgentWorkspace />);
+
+    await screen.findByText("Primary");
+    expect(await screen.findByText("Review state unavailable")).toBeTruthy();
+    expect(screen.queryByText(/home\/matrix|token|secret/i)).toBeNull();
+  });
+
   it("creates a thread from the desktop composer and focuses the new thread", async () => {
     window.operator.invoke = vi.fn((channel: string) => {
       if (channel === "runtime:get-summary") return Promise.resolve(summaryFixture({ threadCreate: true }));
+      if (channel === "runtime:get-reviews") return Promise.resolve(reviewsFixture());
       if (channel === "runtime:create-thread") {
         return Promise.resolve({
           thread: {
@@ -173,6 +239,7 @@ describe("AgentWorkspace", () => {
   it("shows safe composer validation and create failures", async () => {
     window.operator.invoke = vi.fn((channel: string) => {
       if (channel === "runtime:get-summary") return Promise.resolve(summaryFixture({ threadCreate: true }));
+      if (channel === "runtime:get-reviews") return Promise.resolve(reviewsFixture());
       if (channel === "runtime:create-thread") {
         return Promise.reject(new Error("provider failed on /home/matrix/private with token secret"));
       }


### PR DESCRIPTION
## Summary

- Add a desktop read-only review summary panel to the feature-flagged coding-agent workspace.
- Load review summaries through trusted main-process IPC after the runtime advertises `codingAgentsReview`.
- Keep review failures generic and non-fatal so the runtime dashboard remains visible.
- Update spec 105 current-state notes for the desktop review panel and remaining mobile/diff/preview gaps.

## Invariants

- Source of truth: gateway/runtime remains authoritative for review summaries; the desktop renderer only consumes bounded IPC data.
- Lock/transaction scope: no persistence or multi-write workflow changes in this slice.
- Acceptable orphan states: if review summary loading fails, the runtime summary can still render with a generic recoverable review error.
- Auth source of truth: desktop main-process runtime auth and existing IPC validation remain the only path to `/api/coding-agents/reviews`; renderer receives no bearer credentials.
- Deferred scope: mobile review UI, file diff snapshots, preview integration, and public docs remain follow-up work after cross-shell review surfaces stabilize.

## Validation

- `bun run test -- tests/desktop/coding-agent-workspace.test.tsx`
- `bun run test -- tests/desktop/coding-agent-workspace.test.tsx tests/desktop/ipc-contract.test.ts tests/desktop/ipc-handlers.test.ts`
- `pnpm --filter desktop run typecheck`
- `git diff --check`
- `bun run check:patterns` passed with existing warning-only scanner output, 0 violations.
- `bun run typecheck`
- Restricted wording scan across changed files: no matches.
