### PR TITLE
feat(coding-agents): add mobile review summary panel

### DIFF
--- a/apps/mobile/__tests__/agents-screen.test.tsx
+++ b/apps/mobile/__tests__/agents-screen.test.tsx
@@ -46,6 +46,10 @@ function summaryFixture() {
         id: "codingAgentsRuntimeSummary",
         enabled: true,
       },
+      {
+        id: "codingAgentsReview",
+        enabled: true,
+      },
     ],
     providers: [
       {
@@ -100,6 +104,33 @@ function summaryFixture() {
   };
 }
 
+function reviewsFixture() {
+  return {
+    items: [
+      {
+        id: "rev_mobile_1",
+        projectId: "matrix-os",
+        worktreeId: "wt_mobile_1",
+        status: "reviewing",
+        pullRequestNumber: 759,
+        round: 2,
+        maxRounds: 3,
+        reviewer: "matrix-reviewer",
+        implementer: "matrix-implementer",
+        findings: {
+          total: 2,
+          high: 1,
+          medium: 1,
+          low: 0,
+        },
+        updatedAt: "2026-07-06T00:02:00.000Z",
+      },
+    ],
+    hasMore: false,
+    limit: 50,
+  };
+}
+
 function deferred<T>() {
   let resolve!: (value: T) => void;
   const promise = new Promise<T>((promiseResolve) => {
@@ -119,6 +150,10 @@ describe("AgentsScreen", () => {
         ok: true,
         summary: summaryFixture(),
       }),
+      getCodingAgentReviews: jest.fn().mockResolvedValue({
+        ok: true,
+        reviews: reviewsFixture(),
+      }),
     };
     useGatewayMock.mockReturnValue(gatewayContext({
       client: client as unknown as GatewayClient,
@@ -133,12 +168,62 @@ describe("AgentsScreen", () => {
     expect(screen.getByText("matrix-abc1234")).toBeTruthy();
   });
 
+  it("renders read-only review summaries", async () => {
+    const client = {
+      getCodingAgentRuntimeSummary: jest.fn().mockResolvedValue({
+        ok: true,
+        summary: summaryFixture(),
+      }),
+      getCodingAgentReviews: jest.fn().mockResolvedValue({
+        ok: true,
+        reviews: reviewsFixture(),
+      }),
+    };
+    useGatewayMock.mockReturnValue(gatewayContext({
+      client: client as unknown as GatewayClient,
+      connectionState: "connected",
+    }));
+
+    render(<AgentsScreen />);
+
+    await screen.findByText("Review");
+    expect(screen.getByText("matrix-os")).toBeTruthy();
+    expect(screen.getByText(/PR #759/)).toBeTruthy();
+    expect(screen.getByText(/Round 2 of 3/)).toBeTruthy();
+    expect(screen.getByText("1 high")).toBeTruthy();
+    expect(client.getCodingAgentReviews).toHaveBeenCalledWith();
+  });
+
+  it("renders a generic review error without dropping the runtime summary", async () => {
+    const client = {
+      getCodingAgentRuntimeSummary: jest.fn().mockResolvedValue({
+        ok: true,
+        summary: summaryFixture(),
+      }),
+      getCodingAgentReviews: jest.fn().mockResolvedValue({
+        ok: false,
+        error: "review store failed at /home/matrix/private token secret",
+      }),
+    };
+    useGatewayMock.mockReturnValue(gatewayContext({
+      client: client as unknown as GatewayClient,
+      connectionState: "connected",
+    }));
+
+    render(<AgentsScreen />);
+
+    await screen.findByText("Primary");
+    expect(await screen.findByText("Review state unavailable")).toBeTruthy();
+    expect(screen.queryByText(/home\/matrix|token|secret/i)).toBeNull();
+  });
+
   it("renders a safe error when the runtime summary is unavailable", async () => {
     const client = {
       getCodingAgentRuntimeSummary: jest.fn().mockResolvedValue({
         ok: false,
         error: "Runtime summary unavailable",
       }),
+      getCodingAgentReviews: jest.fn(),
     };
     useGatewayMock.mockReturnValue(gatewayContext({
       client: client as unknown as GatewayClient,
@@ -155,6 +240,7 @@ describe("AgentsScreen", () => {
     const oldRequest = deferred<{ ok: true; summary: ReturnType<typeof summaryFixture> }>();
     const oldClient = {
       getCodingAgentRuntimeSummary: jest.fn(() => oldRequest.promise),
+      getCodingAgentReviews: jest.fn(),
     };
     const newClient = {
       getCodingAgentRuntimeSummary: jest.fn().mockResolvedValue({
@@ -167,6 +253,10 @@ describe("AgentsScreen", () => {
             status: "available",
           },
         },
+      }),
+      getCodingAgentReviews: jest.fn().mockResolvedValue({
+        ok: true,
+        reviews: reviewsFixture(),
       }),
     };
     useGatewayMock.mockReturnValue(gatewayContext({

--- a/apps/mobile/app/agents/index.tsx
+++ b/apps/mobile/app/agents/index.tsx
@@ -3,7 +3,7 @@ import { ActivityIndicator, Pressable, RefreshControl, ScrollView, Text, View } 
 import { Ionicons } from "@expo/vector-icons";
 import { useRouter } from "expo-router";
 import { StyleSheet, useUnistyles } from "react-native-unistyles";
-import type { RuntimeSummary } from "@matrix-os/contracts";
+import type { ReviewSummary, RuntimeSummary } from "@matrix-os/contracts";
 import { useGateway } from "@/app/_layout";
 import { CODING_AGENTS_MOBILE_WORKSPACE } from "@/lib/feature-flags";
 
@@ -14,6 +14,14 @@ type ScreenState =
 
 const INITIAL_STATE: ScreenState = { status: "loading", summary: null, error: null };
 
+type ReviewState =
+  | { status: "idle"; reviews: null; error: null }
+  | { status: "loading"; reviews: null; error: null }
+  | { status: "ready"; reviews: { items: ReviewSummary[]; hasMore: boolean; nextCursor?: string; limit: number }; error: null }
+  | { status: "error"; reviews: null; error: "Review state unavailable" };
+
+const INITIAL_REVIEW_STATE: ReviewState = { status: "idle", reviews: null, error: null };
+
 function capabilityEnabled(summary: RuntimeSummary, id: string): boolean {
   return summary.capabilities.some((capability) => capability.id === id && capability.enabled);
 }
@@ -23,6 +31,7 @@ export default function AgentsScreen() {
   const router = useRouter();
   const { client } = useGateway();
   const [state, setState] = useState<ScreenState>(INITIAL_STATE);
+  const [reviewState, setReviewState] = useState<ReviewState>(INITIAL_REVIEW_STATE);
   const [refreshing, setRefreshing] = useState(false);
   const requestGeneration = useRef(0);
 
@@ -31,19 +40,34 @@ export default function AgentsScreen() {
     requestGeneration.current = generation;
     if (!CODING_AGENTS_MOBILE_WORKSPACE) {
       setState({ status: "error", summary: null, error: "Runtime summary unavailable" });
+      setReviewState(INITIAL_REVIEW_STATE);
       return;
     }
     if (!client) {
       setState({ status: "error", summary: null, error: "Runtime summary unavailable" });
+      setReviewState(INITIAL_REVIEW_STATE);
       return;
     }
     const result = await client.getCodingAgentRuntimeSummary();
     if (generation !== requestGeneration.current) return;
     if (result.ok) {
       setState({ status: "ready", summary: result.summary, error: null });
+      if (!capabilityEnabled(result.summary, "codingAgentsReview")) {
+        setReviewState(INITIAL_REVIEW_STATE);
+        return;
+      }
+      setReviewState((current) => (current.reviews ? current : { status: "loading", reviews: null, error: null }));
+      const reviewsResult = await client.getCodingAgentReviews();
+      if (generation !== requestGeneration.current) return;
+      if (reviewsResult.ok) {
+        setReviewState({ status: "ready", reviews: reviewsResult.reviews, error: null });
+        return;
+      }
+      setReviewState({ status: "error", reviews: null, error: "Review state unavailable" });
       return;
     }
     setState({ status: "error", summary: null, error: "Runtime summary unavailable" });
+    setReviewState(INITIAL_REVIEW_STATE);
   }, [client]);
 
   useEffect(() => {
@@ -158,7 +182,44 @@ export default function AgentsScreen() {
           </View>
         ))}
       </Section>
+
+      {capabilityEnabled(summary, "codingAgentsReview") ? <ReviewSection state={reviewState} /> : null}
     </ScrollView>
+  );
+}
+
+function reviewStatusLabel(status: ReviewSummary["status"]): string {
+  return status.replace(/_/g, " ");
+}
+
+function ReviewSection({ state }: { state: ReviewState }) {
+  const { theme } = useUnistyles();
+  const items = state.reviews?.items ?? [];
+
+  return (
+    <Section title="Review" count={items.length}>
+      {state.status === "error" ? <Text style={styles.reviewError}>{state.error}</Text> : null}
+      {items.length === 0 && state.status !== "loading" && state.status !== "error" ? <EmptyText>No reviews.</EmptyText> : null}
+      {items.map((review) => (
+        <View key={review.id} style={styles.row}>
+          <View style={styles.rowIcon}>
+            <Ionicons name="checkmark-done-outline" size={18} color={theme.colors.moss} />
+          </View>
+          <View style={styles.rowText}>
+            <Text style={styles.rowTitle}>{review.projectId}</Text>
+            <Text style={styles.rowSubtitle}>{`PR #${review.pullRequestNumber} - Round ${review.round} of ${review.maxRounds}`}</Text>
+          </View>
+          <View style={styles.reviewMeta}>
+            <Text style={styles.rowMeta}>{reviewStatusLabel(review.status)}</Text>
+            {review.findings ? (
+              <Text style={[styles.reviewHigh, review.findings.high > 0 ? styles.reviewHighActive : null]}>
+                {review.findings.high} high
+              </Text>
+            ) : null}
+          </View>
+        </View>
+      ))}
+    </Section>
   );
 }
 
@@ -333,6 +394,28 @@ const styles = StyleSheet.create((theme, rt) => ({
     fontSize: 12,
     color: theme.colors.moss,
     textTransform: "capitalize",
+  },
+  reviewMeta: {
+    alignItems: "flex-end",
+    gap: 2,
+  },
+  reviewHigh: {
+    fontFamily: theme.fonts.sansMedium,
+    fontSize: 12,
+    color: theme.colors.mutedForeground,
+  },
+  reviewHighActive: {
+    color: theme.colors.destructive,
+  },
+  reviewError: {
+    borderRadius: 14,
+    borderCurve: "continuous" as const,
+    borderWidth: 1,
+    borderColor: theme.colors.border,
+    backgroundColor: theme.colors.card,
+    padding: theme.spacing.md,
+    fontFamily: theme.fonts.sans,
+    color: theme.colors.destructive,
   },
   emptyText: {
     borderRadius: 14,

--- a/specs/105-coding-agent-shells/current-state.md
+++ b/specs/105-coding-agent-shells/current-state.md
@@ -6,7 +6,7 @@
 
 ## Summary
 
-The stack currently has shared contracts, a gateway runtime summary read model, read-only desktop and mobile workspaces behind flags, thread create/replay/abort/event streaming, provider adapters, a workspace-backed provider, approval/input route handling, a read-only coding-agent review summary route/client contract, and a desktop read-only review summary panel. File diff and preview coding-agent surfaces are contract-only or existing workspace routes; mobile review UI is not yet integrated into the coding-agent shell UI.
+The stack currently has shared contracts, a gateway runtime summary read model, read-only desktop and mobile workspaces behind flags, thread create/replay/abort/event streaming, provider adapters, a workspace-backed provider, approval/input route handling, a read-only coding-agent review summary route/client contract, and desktop/mobile read-only review summary panels. File diff and preview coding-agent surfaces are contract-only or existing workspace routes; dedicated diff and preview coding-agent shell UI is not yet integrated.
 
 Current source-of-truth boundaries:
 
@@ -221,6 +221,8 @@ Screen:
 - `apps/mobile/app/agents/new.tsx`
 - `apps/mobile/app/agents/[threadId].tsx`
 - Read-only phone-first dashboard with providers, active threads, and terminal sessions.
+- When the runtime advertises `codingAgentsReview`, the dashboard fetches bounded review summaries through the authenticated gateway client and renders project, PR, round, status, and high-severity count.
+- Safe generic review error state if review summaries are unavailable; review failures do not drop the runtime summary dashboard.
 - Composer route for creating accepted coding-agent threads; thread route is a bounded placeholder until replay/review surfaces are wired.
 - Flag: `apps/mobile/lib/feature-flags.ts` with `EXPO_PUBLIC_CODING_AGENTS_MOBILE_WORKSPACE === "1"`.
 
@@ -249,7 +251,7 @@ Relevant existing browser shell paths:
 
 Open follow-up: decide whether a browser-shell coding-agent entry belongs in Canvas, Developer mode, or both after desktop/mobile read-only shells settle.
 
-Public docs note: public docs remain deferred for this desktop review-summary slice because the cross-shell review flow still lacks mobile review UI, file diffs, and preview integration. Update `www/content/docs/` when the file/review/preview surfaces become stable in desktop, mobile, or browser shell navigation.
+Public docs note: public docs remain deferred for these review-summary slices because the cross-shell review flow still lacks file diffs and preview integration. Update `www/content/docs/` when the file/review/preview surfaces become stable in desktop, mobile, or browser shell navigation.
 
 ## Feature Flags
 
@@ -323,7 +325,7 @@ git diff --check
 ## Open Questions And Deferred Work
 
 - Session completion reconciliation: implemented for workspace `session.stopped` events that carry owner id, workspace session id, and bound `terminalSessionId`; the gateway thread store marks matching active coding-agent threads completed or failed server-side without matching unrelated owners or reused terminal ids. Remaining work: if runtime managers add autonomous process-exit detection beyond explicit workspace stop events, route those through the same `session.stopped` publisher path.
-- File/review/preview shell surfaces: read-only review summaries now have coding-agent contracts/routes/desktop IPC/mobile clients plus a desktop read-only review panel. File diffs, previews, and mobile review UI integration are not implemented yet.
+- File/review/preview shell surfaces: read-only review summaries now have coding-agent contracts/routes/desktop IPC/mobile clients plus desktop and mobile read-only review panels. File diffs and previews are not implemented yet.
 - Browser shell entry point: Canvas-first placement is still undecided.
 - Notifications/attention routing: desktop notification IPC exists, but thread attention notifications are not yet wired end-to-end from gateway events.
 - Public docs: public Matrix OS docs should be updated once the user-facing coding-agent shell flow is stable enough to document.


### PR DESCRIPTION
## Summary

- Add a mobile read-only review summary section to the feature-flagged agents workspace.
- Load review summaries through the existing authenticated `GatewayClient` when `codingAgentsReview` is advertised.
- Keep review failures generic and non-fatal so runtime providers, threads, and terminals remain visible.
- Update spec 105 current-state notes for desktop/mobile review summary panels and remaining diff/preview gaps.

## Invariants

- Source of truth: gateway/runtime remains authoritative for review summaries; mobile only renders bounded gateway-client data.
- Lock/transaction scope: no persistence or multi-write workflow changes in this slice.
- Acceptable orphan states: if review summary loading fails, the mobile runtime dashboard still renders with a generic recoverable review error.
- Auth source of truth: the existing authenticated mobile gateway client is the only review data path; AsyncStorage is unchanged and stores no review payloads.
- Deferred scope: file diff snapshots, preview integration, and public docs remain follow-up work after cross-shell review surfaces stabilize.

## Validation

- `pnpm --filter matrix-os-mobile exec jest __tests__/agents-screen.test.tsx --runInBand`
- `pnpm --filter matrix-os-mobile exec jest __tests__/gateway-client.test.ts __tests__/apps-screen.test.tsx __tests__/agents-screen.test.tsx __tests__/agent-workspace-state.test.ts --runInBand`
- `pnpm --filter matrix-os-mobile exec jest --runInBand` passed; existing terminal screen act warning printed, suite passed.
- `pnpm --filter matrix-os-mobile run lint`
- `pnpm --filter matrix-os-mobile exec tsc --noEmit`
- `git diff --check`
- `bun run check:patterns` passed with existing warning-only scanner output, 0 violations.
- `bun run typecheck`
- Restricted wording scan across changed files: no matches.

Note: `pnpm --filter matrix-os-mobile run test -- --runInBand` is not the correct invocation for this package because the script passes the extra argument as a Jest pattern; the direct `exec jest --runInBand` suite was run instead.
