### PR TITLE
feat(coding-agents): add review snapshot route

### DIFF
--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -652,6 +652,28 @@ export const ReviewFileDiffSchema = z.object({
   partial: z.boolean(),
 }).strict();
 
+export const ReviewDiffHunkSchema = z.object({
+  id: referenceId(128),
+  oldStart: z.number().int().min(0).max(1_000_000),
+  oldLines: z.number().int().min(0).max(1_000_000),
+  newStart: z.number().int().min(0).max(1_000_000),
+  newLines: z.number().int().min(0).max(1_000_000),
+  heading: SafeDisplayStringSchema.optional(),
+  partial: z.boolean(),
+}).strict();
+
+export const ReviewFindingSummarySchema = z.object({
+  id: referenceId(128),
+  severity: z.enum(["high", "medium", "low"]),
+  line: z.number().int().min(1).max(1_000_000),
+  summary: SafeDisplayStringSchema,
+}).strict();
+
+export const ReviewSnapshotFileSchema = ReviewFileDiffSchema.extend({
+  hunks: z.array(ReviewDiffHunkSchema).max(100),
+  findings: z.array(ReviewFindingSummarySchema).max(100).optional(),
+}).strict();
+
 export const ReviewSummarySchema = z.object({
   id: referenceId(128),
   projectId: ProjectIdSchema,
@@ -684,6 +706,16 @@ export const ReviewSummarySchema = z.object({
 }).strict();
 
 export type ReviewSummary = z.infer<typeof ReviewSummarySchema>;
+
+export const ReviewSnapshotSchema = z.object({
+  review: ReviewSummarySchema,
+  files: boundedListSchema(ReviewSnapshotFileSchema, 100),
+  partial: z.boolean(),
+  safeNotice: SafeDisplayStringSchema.optional(),
+  updatedAt: IsoTimestampSchema,
+}).strict();
+
+export type ReviewSnapshot = z.infer<typeof ReviewSnapshotSchema>;
 
 export const PreviewSessionSummarySchema = z.object({
   id: referenceId(128),

--- a/packages/gateway/src/coding-agents/review-summary.ts
+++ b/packages/gateway/src/coding-agents/review-summary.ts
@@ -118,7 +118,7 @@ function latestSuccessfulFindingsRound(review: ReviewLoopRecord) {
 
 function reviewOwnerMatchesPrincipal(review: ReviewLoopRecord, principal: RequestPrincipal, ownerIds: readonly string[]): boolean {
   if (!canReadReviewSummaries(principal, ownerIds)) return false;
-  if (!review.ownerId) return true;
+  if (!review.ownerId) return false;
   return ownerIds.includes(review.ownerId);
 }
 
@@ -142,7 +142,10 @@ function snapshotFilesFromFindings(review: ReviewLoopRecord, findings: ParsedFin
       continue;
     }
     const current = files.get(finding.file) ?? [];
-    if (current.length >= REVIEW_SNAPSHOT_FINDINGS_PER_FILE_LIMIT) continue;
+    if (current.length >= REVIEW_SNAPSHOT_FINDINGS_PER_FILE_LIMIT) {
+      hasMore = true;
+      continue;
+    }
     current.push(finding);
     files.set(finding.file, current);
   }

--- a/packages/gateway/src/coding-agents/review-summary.ts
+++ b/packages/gateway/src/coding-agents/review-summary.ts
@@ -1,22 +1,41 @@
 import {
+  ReviewSnapshotFileSchema,
+  ReviewSnapshotSchema,
   ReviewSummarySchema,
+  type ReviewSnapshot,
   type ReviewSummary,
 } from "@matrix-os/contracts";
 import type { RequestPrincipal } from "../request-principal.js";
 import type { ReviewLoopRecord } from "../review-loop.js";
+import {
+  parseFindingsFile,
+  type FindingsParseFailure,
+  type FindingsParseSuccess,
+  type ParsedFinding,
+} from "../findings-parser.js";
 
 const REVIEW_SUMMARY_LIMIT = 50;
 const RAW_REVIEW_SCAN_LIMIT = 100;
 const MAX_REVIEW_SCAN_PAGES = 5;
+const REVIEW_SNAPSHOT_FILE_LIMIT = 100;
+const REVIEW_SNAPSHOT_FINDINGS_PER_FILE_LIMIT = 100;
 
 export interface CodingAgentReviewSummaryStore {
   listReviews(
     principal: RequestPrincipal,
     options?: { cursor?: string },
   ): Promise<{ items: ReviewSummary[]; hasMore: boolean; limit: number; nextCursor?: string }>;
+  getReviewSnapshot?(
+    principal: RequestPrincipal,
+    reviewId: string,
+  ): Promise<ReviewSnapshot>;
 }
 
 export interface ReviewLoopStore {
+  getReview?(reviewId: string): Promise<
+    { ok: true; review: ReviewLoopRecord } |
+    { ok: false; status: number; error: { code: string; message: string } }
+  >;
   listReviews(input?: unknown): Promise<
     { ok: true; reviews: ReviewLoopRecord[]; nextCursor: string | null } |
     { ok: false; status: number; error: { code: string; message: string } }
@@ -79,11 +98,81 @@ function toReviewSummary(review: ReviewLoopRecord): ReviewSummary | null {
   return parsed.success ? parsed.data : null;
 }
 
+type FindingsReader = (path: string) => Promise<FindingsParseSuccess | FindingsParseFailure>;
+
+function latestSuccessfulFindingsPath(review: ReviewLoopRecord): string | undefined {
+  return review.rounds
+    .slice()
+    .reverse()
+    .find((round) => round.parserStatus === "success" && typeof round.findingsPath === "string" && round.findingsPath.length > 0)
+    ?.findingsPath;
+}
+
+function snapshotFilesFromFindings(review: ReviewLoopRecord, findings: ParsedFinding[]) {
+  const files = new Map<string, ParsedFinding[]>();
+  for (const finding of findings) {
+    if (files.size >= REVIEW_SNAPSHOT_FILE_LIMIT && !files.has(finding.file)) break;
+    const current = files.get(finding.file) ?? [];
+    if (current.length >= REVIEW_SNAPSHOT_FINDINGS_PER_FILE_LIMIT) continue;
+    current.push(finding);
+    files.set(finding.file, current);
+  }
+
+  return [...files.entries()]
+    .map(([path, fileFindings], fileIndex) => ReviewSnapshotFileSchema.safeParse({
+      path,
+      status: "modified",
+      additions: 0,
+      deletions: 0,
+      partial: true,
+      hunks: fileFindings.map((finding, findingIndex) => ({
+        id: `hunk_${review.id}_${fileIndex}_${findingIndex}`,
+        oldStart: finding.line,
+        oldLines: 1,
+        newStart: finding.line,
+        newLines: 1,
+        heading: `Finding ${finding.id}`,
+        partial: true,
+      })),
+      findings: fileFindings.map((finding) => ({
+        id: finding.id,
+        severity: finding.severity,
+        line: finding.line,
+        summary: finding.summary,
+      })),
+    }))
+    .filter((parsed) => parsed.success)
+    .map((parsed) => parsed.data);
+}
+
+async function toPartialReviewSnapshot(review: ReviewLoopRecord, findingsReader: FindingsReader): Promise<ReviewSnapshot | null> {
+  const summary = toReviewSummary(review);
+  if (!summary) return null;
+  const findingsPath = latestSuccessfulFindingsPath(review);
+  const parsedFindings = findingsPath ? await findingsReader(findingsPath) : null;
+  const files = parsedFindings?.ok ? snapshotFilesFromFindings(review, parsedFindings.findings) : [];
+  const parsed = ReviewSnapshotSchema.safeParse({
+    review: summary,
+    files: {
+      items: files.slice(0, REVIEW_SNAPSHOT_FILE_LIMIT),
+      hasMore: files.length > REVIEW_SNAPSHOT_FILE_LIMIT,
+      limit: REVIEW_SNAPSHOT_FILE_LIMIT,
+    },
+    partial: true,
+    safeNotice: files.length > 0
+      ? "Diff content is not available yet. Showing bounded review findings."
+      : "Diff content is not available yet. Showing bounded review state.",
+    updatedAt: review.updatedAt,
+  });
+  return parsed.success ? parsed.data : null;
+}
+
 export function createCodingAgentReviewSummaryStore(
   store: ReviewLoopStore,
-  options: { ownerId?: string; principalOwnerIds?: readonly string[] } = {},
+  options: { ownerId?: string; principalOwnerIds?: readonly string[]; findingsReader?: FindingsReader } = {},
 ): CodingAgentReviewSummaryStore {
   const ownerIds = ownerIdsFor(options);
+  const findingsReader = options.findingsReader ?? parseFindingsFile;
   return {
     async listReviews(principal: RequestPrincipal, listOptions: { cursor?: string } = {}) {
       if (!canReadReviewSummaries(principal, ownerIds)) {
@@ -121,6 +210,24 @@ export function createCodingAgentReviewSummaryStore(
         nextCursor: hasMore ? items[items.length - 1]?.id ?? rawContinuationCursor : undefined,
         limit: REVIEW_SUMMARY_LIMIT,
       };
+    },
+
+    async getReviewSnapshot(principal: RequestPrincipal, reviewId: string) {
+      if (!canReadReviewSummaries(principal, ownerIds)) {
+        throw new Error("Review state unavailable");
+      }
+      if (!("getReview" in store) || typeof store.getReview !== "function") {
+        throw new Error("Review state unavailable");
+      }
+      const result = await store.getReview(reviewId);
+      if (!result.ok) {
+        throw new Error("Review state unavailable");
+      }
+      const snapshot = await toPartialReviewSnapshot(result.review, findingsReader);
+      if (!snapshot) {
+        throw new Error("Review state unavailable");
+      }
+      return snapshot;
     },
   };
 }

--- a/packages/gateway/src/coding-agents/review-summary.ts
+++ b/packages/gateway/src/coding-agents/review-summary.ts
@@ -5,6 +5,7 @@ import {
   type ReviewSnapshot,
   type ReviewSummary,
 } from "@matrix-os/contracts";
+import { resolve, sep } from "node:path";
 import type { RequestPrincipal } from "../request-principal.js";
 import type { ReviewLoopRecord } from "../review-loop.js";
 import {
@@ -19,6 +20,14 @@ const RAW_REVIEW_SCAN_LIMIT = 100;
 const MAX_REVIEW_SCAN_PAGES = 5;
 const REVIEW_SNAPSHOT_FILE_LIMIT = 100;
 const REVIEW_SNAPSHOT_FINDINGS_PER_FILE_LIMIT = 100;
+
+type ReviewSnapshotErrorCode = "review_not_found" | "review_state_unavailable";
+
+export class CodingAgentReviewSnapshotError extends Error {
+  constructor(public readonly code: ReviewSnapshotErrorCode) {
+    super(code === "review_not_found" ? "Review was not found" : "Review state unavailable");
+  }
+}
 
 export interface CodingAgentReviewSummaryStore {
   listReviews(
@@ -100,25 +109,45 @@ function toReviewSummary(review: ReviewLoopRecord): ReviewSummary | null {
 
 type FindingsReader = (path: string) => Promise<FindingsParseSuccess | FindingsParseFailure>;
 
-function latestSuccessfulFindingsPath(review: ReviewLoopRecord): string | undefined {
+function latestSuccessfulFindingsRound(review: ReviewLoopRecord) {
   return review.rounds
     .slice()
     .reverse()
     .find((round) => round.parserStatus === "success" && typeof round.findingsPath === "string" && round.findingsPath.length > 0)
-    ?.findingsPath;
+}
+
+function reviewOwnerMatchesPrincipal(review: ReviewLoopRecord, principal: RequestPrincipal, ownerIds: readonly string[]): boolean {
+  if (!canReadReviewSummaries(principal, ownerIds)) return false;
+  if (!review.ownerId) return true;
+  return ownerIds.includes(review.ownerId);
+}
+
+function safeFindingsPath(input: { homePath?: string; review: ReviewLoopRecord; round: number; findingsPath?: string }): string | null {
+  if (!input.homePath || !input.findingsPath) return null;
+  if (input.findingsPath !== `.matrix/review-round-${input.round}.md`) return null;
+  const safeProject = /^[A-Za-z0-9][A-Za-z0-9_-]{0,62}$/.test(input.review.projectSlug);
+  const safeWorktree = /^wt_[A-Za-z0-9_-]{1,128}$/.test(input.review.worktreeId);
+  if (!safeProject || !safeWorktree) return null;
+  const worktreeRoot = resolve(input.homePath, "projects", input.review.projectSlug, "worktrees", input.review.worktreeId);
+  const resolved = resolve(worktreeRoot, input.findingsPath);
+  return resolved.startsWith(`${worktreeRoot}${sep}`) ? resolved : null;
 }
 
 function snapshotFilesFromFindings(review: ReviewLoopRecord, findings: ParsedFinding[]) {
   const files = new Map<string, ParsedFinding[]>();
+  let hasMore = false;
   for (const finding of findings) {
-    if (files.size >= REVIEW_SNAPSHOT_FILE_LIMIT && !files.has(finding.file)) break;
+    if (files.size >= REVIEW_SNAPSHOT_FILE_LIMIT && !files.has(finding.file)) {
+      hasMore = true;
+      continue;
+    }
     const current = files.get(finding.file) ?? [];
     if (current.length >= REVIEW_SNAPSHOT_FINDINGS_PER_FILE_LIMIT) continue;
     current.push(finding);
     files.set(finding.file, current);
   }
 
-  return [...files.entries()]
+  const items = [...files.entries()]
     .map(([path, fileFindings], fileIndex) => ReviewSnapshotFileSchema.safeParse({
       path,
       status: "modified",
@@ -143,23 +172,35 @@ function snapshotFilesFromFindings(review: ReviewLoopRecord, findings: ParsedFin
     }))
     .filter((parsed) => parsed.success)
     .map((parsed) => parsed.data);
+  return { items, hasMore };
 }
 
-async function toPartialReviewSnapshot(review: ReviewLoopRecord, findingsReader: FindingsReader): Promise<ReviewSnapshot | null> {
+async function toPartialReviewSnapshot(
+  review: ReviewLoopRecord,
+  options: { findingsReader: FindingsReader; homePath?: string },
+): Promise<ReviewSnapshot | null> {
   const summary = toReviewSummary(review);
   if (!summary) return null;
-  const findingsPath = latestSuccessfulFindingsPath(review);
-  const parsedFindings = findingsPath ? await findingsReader(findingsPath) : null;
-  const files = parsedFindings?.ok ? snapshotFilesFromFindings(review, parsedFindings.findings) : [];
+  const findingsRound = latestSuccessfulFindingsRound(review);
+  const findingsPath = findingsRound
+    ? safeFindingsPath({
+      homePath: options.homePath,
+      review,
+      round: findingsRound.round,
+      findingsPath: findingsRound.findingsPath,
+    })
+    : null;
+  const parsedFindings = findingsPath ? await options.findingsReader(findingsPath) : null;
+  const files = parsedFindings?.ok ? snapshotFilesFromFindings(review, parsedFindings.findings) : { items: [], hasMore: false };
   const parsed = ReviewSnapshotSchema.safeParse({
     review: summary,
     files: {
-      items: files.slice(0, REVIEW_SNAPSHOT_FILE_LIMIT),
-      hasMore: files.length > REVIEW_SNAPSHOT_FILE_LIMIT,
+      items: files.items.slice(0, REVIEW_SNAPSHOT_FILE_LIMIT),
+      hasMore: files.hasMore,
       limit: REVIEW_SNAPSHOT_FILE_LIMIT,
     },
     partial: true,
-    safeNotice: files.length > 0
+    safeNotice: files.items.length > 0
       ? "Diff content is not available yet. Showing bounded review findings."
       : "Diff content is not available yet. Showing bounded review state.",
     updatedAt: review.updatedAt,
@@ -169,7 +210,7 @@ async function toPartialReviewSnapshot(review: ReviewLoopRecord, findingsReader:
 
 export function createCodingAgentReviewSummaryStore(
   store: ReviewLoopStore,
-  options: { ownerId?: string; principalOwnerIds?: readonly string[]; findingsReader?: FindingsReader } = {},
+  options: { ownerId?: string; principalOwnerIds?: readonly string[]; findingsReader?: FindingsReader; homePath?: string } = {},
 ): CodingAgentReviewSummaryStore {
   const ownerIds = ownerIdsFor(options);
   const findingsReader = options.findingsReader ?? parseFindingsFile;
@@ -214,18 +255,21 @@ export function createCodingAgentReviewSummaryStore(
 
     async getReviewSnapshot(principal: RequestPrincipal, reviewId: string) {
       if (!canReadReviewSummaries(principal, ownerIds)) {
-        throw new Error("Review state unavailable");
+        throw new CodingAgentReviewSnapshotError("review_not_found");
       }
       if (!("getReview" in store) || typeof store.getReview !== "function") {
-        throw new Error("Review state unavailable");
+        throw new CodingAgentReviewSnapshotError("review_state_unavailable");
       }
       const result = await store.getReview(reviewId);
       if (!result.ok) {
-        throw new Error("Review state unavailable");
+        throw new CodingAgentReviewSnapshotError(result.status === 404 || result.status === 403 ? "review_not_found" : "review_state_unavailable");
       }
-      const snapshot = await toPartialReviewSnapshot(result.review, findingsReader);
+      if (!reviewOwnerMatchesPrincipal(result.review, principal, ownerIds)) {
+        throw new CodingAgentReviewSnapshotError("review_not_found");
+      }
+      const snapshot = await toPartialReviewSnapshot(result.review, { findingsReader, homePath: options.homePath });
       if (!snapshot) {
-        throw new Error("Review state unavailable");
+        throw new CodingAgentReviewSnapshotError("review_state_unavailable");
       }
       return snapshot;
     },

--- a/packages/gateway/src/coding-agents/routes.ts
+++ b/packages/gateway/src/coding-agents/routes.ts
@@ -28,7 +28,10 @@ import {
   safeThreadError,
   type CodingAgentThreadStore,
 } from "./thread-store.js";
-import type { CodingAgentReviewSummaryStore } from "./review-summary.js";
+import {
+  CodingAgentReviewSnapshotError,
+  type CodingAgentReviewSummaryStore,
+} from "./review-summary.js";
 
 export interface CodingAgentRouteDeps {
   service: CodingAgentRuntimeSummaryService;
@@ -74,6 +77,14 @@ function reviewsUnavailable() {
     safeMessage: "Review state is temporarily unavailable. Try again.",
     retryable: true,
     recoveryActions: ["retry"],
+  });
+}
+
+function reviewNotFound() {
+  return SafeClientErrorSchema.parse({
+    code: "review_not_found",
+    safeMessage: "Review is unavailable. Refresh and try again.",
+    retryable: false,
   });
 }
 
@@ -237,6 +248,10 @@ export function createCodingAgentRoutes(deps: CodingAgentRouteDeps): Hono {
         }
         if (err instanceof z.ZodError) {
           return c.json({ error: validationFailed() }, 400);
+        }
+        if (err instanceof CodingAgentReviewSnapshotError) {
+          const status = err.code === "review_not_found" ? 404 : 503;
+          return c.json({ error: err.code === "review_not_found" ? reviewNotFound() : reviewsUnavailable() }, status);
         }
         console.warn("[coding-agents] review snapshot route failed:", err instanceof Error ? err.message : String(err));
         return c.json({ error: reviewsUnavailable() }, 503);

--- a/packages/gateway/src/coding-agents/routes.ts
+++ b/packages/gateway/src/coding-agents/routes.ts
@@ -13,6 +13,7 @@ import {
   UserInputAnswerRequestSchema,
   boundedListSchema,
   AgentThreadSummarySchema,
+  ReviewSnapshotSchema,
   ReviewSummarySchema,
 } from "@matrix-os/contracts";
 import {
@@ -47,6 +48,7 @@ const AbortThreadBodySchema = z.object({
 
 const ThreadListSchema = boundedListSchema(AgentThreadSummarySchema, 50);
 const ReviewListSchema = boundedListSchema(ReviewSummarySchema, 50);
+const ReviewIdSchema = z.string().regex(/^rev_[A-Za-z0-9_-]{1,128}$/);
 
 function summaryUnavailable() {
   return SafeClientErrorSchema.parse({
@@ -216,6 +218,27 @@ export function createCodingAgentRoutes(deps: CodingAgentRouteDeps): Hono {
           return c.json({ error: validationFailed() }, 400);
         }
         console.warn("[coding-agents] review route failed:", err instanceof Error ? err.message : String(err));
+        return c.json({ error: reviewsUnavailable() }, 503);
+      }
+    });
+
+    app.get("/reviews/:reviewId", async (c) => {
+      try {
+        const principal = principalFor(c);
+        const reviewId = ReviewIdSchema.parse(c.req.param("reviewId"));
+        if (typeof deps.reviews!.getReviewSnapshot !== "function") {
+          return c.json({ error: reviewsUnavailable() }, 503);
+        }
+        return c.json(ReviewSnapshotSchema.parse(await deps.reviews!.getReviewSnapshot(principal, reviewId)));
+      } catch (err: unknown) {
+        if (isRequestPrincipalError(err)) {
+          const mapped = mapRequestPrincipalError(err);
+          return c.json(mapped.body, mapped.status as ContentfulStatusCode);
+        }
+        if (err instanceof z.ZodError) {
+          return c.json({ error: validationFailed() }, 400);
+        }
+        console.warn("[coding-agents] review snapshot route failed:", err instanceof Error ? err.message : String(err));
         return c.json({ error: reviewsUnavailable() }, 503);
       }
     });

--- a/packages/gateway/src/review-loop.ts
+++ b/packages/gateway/src/review-loop.ts
@@ -32,6 +32,7 @@ export interface ReviewRoundRecord {
 
 export interface ReviewLoopRecord {
   id: string;
+  ownerId?: string;
   projectSlug: string;
   worktreeId: string;
   pr: number;
@@ -73,8 +74,14 @@ function replaceCurrentRound(review: ReviewLoopRecord, round: ReviewRoundRecord)
   return review.rounds.map((entry, index) => index === review.rounds.length - 1 ? round : entry);
 }
 
+function safeRoundFindingsPath(round: number, findingsPath?: string): string | undefined {
+  const expected = `.matrix/review-round-${round}.md`;
+  return findingsPath === expected ? findingsPath : undefined;
+}
+
 export function createReviewLoopRecord(input: {
   id: string;
+  ownerId?: string;
   projectSlug: string;
   worktreeId: string;
   pr: number;
@@ -88,6 +95,7 @@ export function createReviewLoopRecord(input: {
   const timestamp = nowIso(input.now);
   return {
     id: input.id,
+    ownerId: input.ownerId,
     projectSlug: input.projectSlug,
     worktreeId: input.worktreeId,
     pr: input.pr,
@@ -150,6 +158,7 @@ export function completeReview(
   review: ReviewLoopRecord,
   input: {
     parseResult: FindingsParseSuccess | FindingsParseFailure;
+    findingsPath?: string;
     now?: () => string;
   },
 ): Result {
@@ -180,6 +189,7 @@ export function completeReview(
   const round: ReviewRoundRecord = {
     ...current,
     parserStatus: "success",
+    findingsPath: safeRoundFindingsPath(current.round, input.findingsPath) ?? current.findingsPath,
     findingsCount: input.parseResult.findingsCount,
     severityCounts: input.parseResult.severityCounts,
     completedAt: timestamp,

--- a/packages/gateway/src/server.ts
+++ b/packages/gateway/src/server.ts
@@ -479,6 +479,7 @@ export async function createGateway(config: GatewayConfig) {
   const workspaceEventStore = createWorkspaceEventStore({ homePath });
   const reviewStore = createReviewStore({ homePath });
   const codingAgentReviewSummaryStore = createCodingAgentReviewSummaryStore(reviewStore, {
+    homePath,
     ownerId: process.env.MATRIX_USER_ID,
     principalOwnerIds: [process.env.MATRIX_USER_ID, process.env.MATRIX_CLERK_USER_ID].filter(
       (id): id is string => Boolean(id),

--- a/packages/gateway/src/workspace-routes.ts
+++ b/packages/gateway/src/workspace-routes.ts
@@ -549,8 +549,10 @@ export function createWorkspaceRoutes(options: {
   app.post("/api/reviews", limited, async (c) => {
     const body = await parseJson(c, CreateReviewSchema);
     if (!body.ok) return c.json(errorBody(body.code, body.message), status(body.status));
+    const ownerScope = options.getOwnerScope?.(c);
     const review = createReviewLoopRecord({
       id: `rev_${randomUUID()}`,
+      ownerId: ownerScope?.id,
       ...body.value,
     });
     const saved = await reviewStore.saveReview(review);

--- a/specs/105-coding-agent-shells/current-state.md
+++ b/specs/105-coding-agent-shells/current-state.md
@@ -6,7 +6,7 @@
 
 ## Summary
 
-The stack currently has shared contracts, a gateway runtime summary read model, read-only desktop and mobile workspaces behind flags, thread create/replay/abort/event streaming, provider adapters, a workspace-backed provider, approval/input route handling, a read-only coding-agent review summary route/client contract, and desktop/mobile read-only review summary panels. File diff and preview coding-agent surfaces are contract-only or existing workspace routes; dedicated diff and preview coding-agent shell UI is not yet integrated.
+The stack currently has shared contracts, a gateway runtime summary read model, read-only desktop and mobile workspaces behind flags, thread create/replay/abort/event streaming, provider adapters, a workspace-backed provider, approval/input route handling, a read-only coding-agent review summary route/client contract, desktop/mobile read-only review summary panels, and a read-only coding-agent review snapshot route with partial findings-derived file metadata. Full file diff and preview coding-agent surfaces are contract-only or existing workspace routes; dedicated diff and preview shell UI is not yet integrated.
 
 Current source-of-truth boundaries:
 
@@ -28,7 +28,7 @@ Implemented coding-agent schemas:
 - Events: `AgentThreadEventSchema` discriminated union with lifecycle, text delta, tool activity, approval/input, file change, review ready, terminal bound, safe error, and completion event variants.
 - Approvals/input: `AgentApprovalRequestSchema`, `ApprovalDecisionRequestSchema`, `UserInputRequestSchema`, `UserInputAnswerRequestSchema`.
 - Terminal frames/summaries: `TerminalSessionSummarySchema`, `TerminalClientFrameSchema`, `TerminalServerFrameSchema`.
-- File/review/preview: `FilePathSchema`, `FileMetadataSchema`, `ReviewSummarySchema`, `ReviewFileDiffSchema`, `PreviewSessionSummarySchema`.
+- File/review/preview: `FilePathSchema`, `FileMetadataSchema`, `ReviewSummarySchema`, `ReviewFileDiffSchema`, `ReviewDiffHunkSchema`, `ReviewFindingSummarySchema`, `ReviewSnapshotFileSchema`, `ReviewSnapshotSchema`, `PreviewSessionSummarySchema`.
 
 Contract tests:
 
@@ -51,6 +51,7 @@ Implemented routes:
 | `/api/coding-agents/threads/:threadId/approvals/:approvalId/decision` | `POST` | Implemented | Body limit 8 KiB, validates approval id and decision payload. |
 | `/api/coding-agents/threads/:threadId/inputs/:inputRequestId/answer` | `POST` | Implemented | Body limit 40 KiB, validates bounded answer payload. |
 | `/api/coding-agents/reviews` | `GET` | Implemented | Authenticated read-only review summary list. Returns bounded `ReviewSummarySchema` items only. |
+| `/api/coding-agents/reviews/:reviewId` | `GET` | Implemented | Authenticated read-only review snapshot. Returns bounded `ReviewSnapshotSchema` with partial findings-derived file metadata; no diff content or file contents. |
 
 Security and ownership:
 
@@ -141,8 +142,10 @@ Thread store behavior:
 Review summary behavior:
 
 - Adapts existing owner-local review-loop records into bounded `ReviewSummarySchema` rows.
+- Adapts existing owner-local review-loop records and structured findings into bounded partial `ReviewSnapshotSchema` rows for the review detail route.
 - Drops malformed legacy records instead of exposing raw review state.
 - Caps the coding-agent route response at 50 items.
+- Drops unsafe findings paths or display text instead of exposing raw filesystem paths, provider output, or parse errors.
 
 Focused tests:
 
@@ -251,7 +254,7 @@ Relevant existing browser shell paths:
 
 Open follow-up: decide whether a browser-shell coding-agent entry belongs in Canvas, Developer mode, or both after desktop/mobile read-only shells settle.
 
-Public docs note: public docs remain deferred for these review-summary slices because the cross-shell review flow still lacks file diffs and preview integration. Update `www/content/docs/` when the file/review/preview surfaces become stable in desktop, mobile, or browser shell navigation.
+Public docs note: public docs remain deferred for these review-summary/snapshot slices because the cross-shell review flow still lacks full file diffs and preview integration. Update `www/content/docs/` when the file/review/preview surfaces become stable in desktop, mobile, or browser shell navigation.
 
 ## Feature Flags
 
@@ -325,7 +328,7 @@ git diff --check
 ## Open Questions And Deferred Work
 
 - Session completion reconciliation: implemented for workspace `session.stopped` events that carry owner id, workspace session id, and bound `terminalSessionId`; the gateway thread store marks matching active coding-agent threads completed or failed server-side without matching unrelated owners or reused terminal ids. Remaining work: if runtime managers add autonomous process-exit detection beyond explicit workspace stop events, route those through the same `session.stopped` publisher path.
-- File/review/preview shell surfaces: read-only review summaries now have coding-agent contracts/routes/desktop IPC/mobile clients plus desktop and mobile read-only review panels. File diffs and previews are not implemented yet.
+- File/review/preview shell surfaces: read-only review summaries now have coding-agent contracts/routes/desktop IPC/mobile clients plus desktop and mobile read-only review panels. A read-only review snapshot route now exposes partial findings-derived file metadata for later shell diff panels. Full file diffs and previews are not implemented yet.
 - Browser shell entry point: Canvas-first placement is still undecided.
 - Notifications/attention routing: desktop notification IPC exists, but thread attention notifications are not yet wired end-to-end from gateway events.
 - Public docs: public Matrix OS docs should be updated once the user-facing coding-agent shell flow is stable enough to document.

--- a/tests/contracts/coding-agents.test.ts
+++ b/tests/contracts/coding-agents.test.ts
@@ -9,6 +9,7 @@ import {
   FileMetadataSchema,
   PreviewSessionSummarySchema,
   ReviewFileDiffSchema,
+  ReviewSnapshotSchema,
   ReviewSummarySchema,
   RuntimeSummarySchema,
   SafeClientErrorSchema,
@@ -319,6 +320,81 @@ describe("coding agent contracts", () => {
         additions: 1_000_001,
         deletions: 0,
         partial: false,
+      }),
+    ).toThrow();
+
+    const reviewSnapshot = ReviewSnapshotSchema.parse({
+      review: {
+        id: "rev_123",
+        projectId: "matrix-os",
+        worktreeId: "wt_abc123def456",
+        status: "reviewing",
+        pullRequestNumber: 757,
+        round: 1,
+        maxRounds: 3,
+        reviewer: "codex",
+        implementer: "claude",
+        updatedAt: now,
+      },
+      files: {
+        items: [
+          {
+            path: "src/index.ts",
+            status: "modified",
+            additions: 0,
+            deletions: 0,
+            partial: true,
+            hunks: [
+              {
+                id: "hunk_rev_123_0_0",
+                oldStart: 12,
+                oldLines: 1,
+                newStart: 12,
+                newLines: 1,
+                heading: "Finding HIGH-1",
+                partial: true,
+              },
+            ],
+            findings: [
+              {
+                id: "HIGH-1",
+                severity: "high",
+                line: 12,
+                summary: "Validate the request before reading review state.",
+              },
+            ],
+          },
+        ],
+        hasMore: false,
+        limit: 100,
+      },
+      partial: true,
+      safeNotice: "Diff content is not available yet. Showing bounded review findings.",
+      updatedAt: now,
+    });
+    expect(reviewSnapshot.files.items[0]?.hunks[0]?.partial).toBe(true);
+    expect(() =>
+      ReviewSnapshotSchema.parse({
+        ...reviewSnapshot,
+        files: {
+          ...reviewSnapshot.files,
+          items: [{ ...reviewSnapshot.files.items[0], path: "../secret.ts" }],
+        },
+      }),
+    ).toThrow();
+    expect(() =>
+      ReviewSnapshotSchema.parse({
+        ...reviewSnapshot,
+        files: {
+          ...reviewSnapshot.files,
+          items: [{
+            ...reviewSnapshot.files.items[0],
+            findings: [{
+              ...reviewSnapshot.files.items[0]!.findings![0],
+              summary: "Postgres failed at /home/matrix/home",
+            }],
+          }],
+        },
       }),
     ).toThrow();
 

--- a/tests/gateway/coding-agents-summary.test.ts
+++ b/tests/gateway/coding-agents-summary.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import { Hono } from "hono";
 import {
+  ReviewSnapshotSchema,
   ReviewSummarySchema,
   RuntimeSummarySchema,
   boundedListSchema,
@@ -400,6 +401,86 @@ describe("coding agent runtime summary", () => {
     expect(JSON.stringify(body)).not.toMatch(/\/home\/matrix|Postgres|token|secret/i);
   });
 
+  it("serves an authenticated safe review snapshot with partial file metadata", async () => {
+    const service = createCodingAgentRuntimeSummaryService({
+      homePath: "/home/matrix/home",
+      terminalRegistry: registryWith(0),
+      now: () => now,
+      runtime: { id: "rt_primary", label: "Primary Matrix computer" },
+    });
+    const app = new Hono();
+    app.route("/api/coding-agents", createCodingAgentRoutes({
+      service,
+      reviews: {
+        listReviews: async () => ({ items: [], hasMore: false, limit: 50 }),
+        getReviewSnapshot: async () => ReviewSnapshotSchema.parse({
+          review: {
+            id: "rev_1",
+            projectId: "matrix-os",
+            worktreeId: "wt_abc123def456",
+            status: "reviewing",
+            pullRequestNumber: 758,
+            round: 1,
+            maxRounds: 3,
+            reviewer: "codex",
+            implementer: "claude",
+            findings: { total: 1, high: 1, medium: 0, low: 0 },
+            updatedAt: now.toISOString(),
+          },
+          files: {
+            items: [
+              {
+                path: "packages/gateway/src/coding-agents/routes.ts",
+                status: "modified",
+                additions: 0,
+                deletions: 0,
+                partial: true,
+                hunks: [
+                  {
+                    id: "hunk_rev_1_1",
+                    oldStart: 42,
+                    oldLines: 1,
+                    newStart: 42,
+                    newLines: 1,
+                    heading: "Finding HIGH-1",
+                    partial: true,
+                  },
+                ],
+                findings: [
+                  {
+                    id: "HIGH-1",
+                    severity: "high",
+                    line: 42,
+                    summary: "Validate review identifiers before lookup.",
+                  },
+                ],
+              },
+            ],
+            hasMore: false,
+            limit: 100,
+          },
+          partial: true,
+          safeNotice: "Diff content is not available yet. Showing bounded review findings.",
+          updatedAt: now.toISOString(),
+        }),
+      },
+      getPrincipal: () => testPrincipal,
+    }));
+
+    const res = await app.request("/api/coding-agents/reviews/rev_1");
+
+    expect(res.status).toBe(200);
+    const body = ReviewSnapshotSchema.parse(await res.json());
+    expect(body.review.id).toBe("rev_1");
+    expect(body.files.items[0]).toMatchObject({
+      path: "packages/gateway/src/coding-agents/routes.ts",
+      partial: true,
+      hunks: [expect.objectContaining({ id: "hunk_rev_1_1", partial: true })],
+      findings: [expect.objectContaining({ severity: "high", line: 42 })],
+    });
+    expect(JSON.stringify(body)).not.toMatch(/\/home\/matrix|Postgres|token|secret/i);
+  });
+
   it("withholds owner-local review summaries from other principals", async () => {
     const store = createCodingAgentReviewSummaryStore({
       listReviews: async () => ({ ok: true, reviews: [reviewRecord()], nextCursor: null }),
@@ -411,6 +492,68 @@ describe("coding agent runtime summary", () => {
       hasMore: false,
       limit: 50,
     });
+  });
+
+  it("derives partial review snapshot files from safe structured findings only", async () => {
+    const store = createCodingAgentReviewSummaryStore({
+      getReview: async () => ({
+        ok: true,
+        review: reviewRecord({
+          rounds: [
+            {
+              round: 1,
+              phase: "review",
+              parserStatus: "success",
+              findingsPath: "/home/matrix/private/review-findings.md",
+              startedAt: now.toISOString(),
+              completedAt: now.toISOString(),
+            },
+          ],
+        }),
+      }),
+      listReviews: async () => ({ ok: true, reviews: [], nextCursor: null }),
+    } as ReviewLoopStore, {
+      findingsReader: async () => ({
+        ok: true,
+        parserStatus: "success",
+        findingsCount: 2,
+        severityCounts: { high: 1, medium: 1, low: 0 },
+        findings: [
+          {
+            id: "HIGH-1",
+            severity: "high",
+            file: "packages/gateway/src/coding-agents/routes.ts",
+            line: 42,
+            summary: "Validate review identifiers before lookup.",
+          },
+          {
+            id: "MED-1",
+            severity: "medium",
+            file: "/home/matrix/private/secret.ts",
+            line: 7,
+            summary: "Unsafe path must be dropped.",
+          },
+        ],
+      }),
+    });
+
+    const snapshot = await store.getReviewSnapshot!(testPrincipal, "rev_1");
+
+    expect(snapshot.partial).toBe(true);
+    expect(snapshot.files).toMatchObject({
+      items: [
+        {
+          path: "packages/gateway/src/coding-agents/routes.ts",
+          status: "modified",
+          partial: true,
+          hunks: [expect.objectContaining({ oldStart: 42, newStart: 42, partial: true })],
+          findings: [expect.objectContaining({ id: "HIGH-1", severity: "high", line: 42 })],
+        },
+      ],
+      hasMore: false,
+      limit: 100,
+    });
+    expect(JSON.stringify(snapshot)).not.toMatch(/\/home\/matrix|secret|Postgres|token/i);
   });
 
   it("allows validated jwt review readers even when the configured owner id uses another owner identifier", async () => {

--- a/tests/gateway/coding-agents-summary.test.ts
+++ b/tests/gateway/coding-agents-summary.test.ts
@@ -572,11 +572,13 @@ describe("coding agent runtime summary", () => {
       getReview: async () => ({
         ok: true,
         review: reviewRecord({
+          ownerId: testPrincipal.userId,
           rounds: [successfulFindingsRound()],
         }),
       }),
       listReviews: async () => ({ ok: true, reviews: [], nextCursor: null }),
     } as ReviewLoopStore, {
+      ownerId: testPrincipal.userId,
       homePath: "/home/matrix/home",
       findingsReader: reader,
     });
@@ -612,7 +614,31 @@ describe("coding agent runtime summary", () => {
       }),
       listReviews: async () => ({ ok: true, reviews: [], nextCursor: null }),
     } as ReviewLoopStore, {
-      ownerId: "owner_user",
+      ownerId: testPrincipal.userId,
+      homePath: "/home/matrix/home",
+      findingsReader: async () => ({
+        ok: true,
+        parserStatus: "success",
+        findingsCount: 0,
+        severityCounts: { high: 0, medium: 0, low: 0 },
+        findings: [],
+      }),
+    });
+
+    await expect(store.getReviewSnapshot!(testPrincipal, "rev_1")).rejects.toMatchObject({
+      code: "review_not_found",
+    });
+  });
+
+  it("returns safe not-found for unowned review snapshots", async () => {
+    const store = createCodingAgentReviewSummaryStore({
+      getReview: async () => ({
+        ok: true,
+        review: reviewRecord({ rounds: [successfulFindingsRound()] }),
+      }),
+      listReviews: async () => ({ ok: true, reviews: [], nextCursor: null }),
+    } as ReviewLoopStore, {
+      ownerId: testPrincipal.userId,
       homePath: "/home/matrix/home",
       findingsReader: async () => ({
         ok: true,
@@ -646,11 +672,12 @@ describe("coding agent runtime summary", () => {
       getReview: async () => ({
         ok: true,
         review: reviewRecord({
+          ownerId: testPrincipal.userId,
           rounds: [successfulFindingsRound({ findingsPath: "/home/matrix/private/review-findings.md" })],
         }),
       }),
       listReviews: async () => ({ ok: true, reviews: [], nextCursor: null }),
-    } as ReviewLoopStore, { homePath: "/home/matrix/home", findingsReader: reader });
+    } as ReviewLoopStore, { ownerId: testPrincipal.userId, homePath: "/home/matrix/home", findingsReader: reader });
 
     const snapshot = await store.getReviewSnapshot!(testPrincipal, "rev_1");
 
@@ -663,10 +690,11 @@ describe("coding agent runtime summary", () => {
     const store = createCodingAgentReviewSummaryStore({
       getReview: async () => ({
         ok: true,
-        review: reviewRecord({ rounds: [successfulFindingsRound()] }),
+        review: reviewRecord({ ownerId: testPrincipal.userId, rounds: [successfulFindingsRound()] }),
       }),
       listReviews: async () => ({ ok: true, reviews: [], nextCursor: null }),
     } as ReviewLoopStore, {
+      ownerId: testPrincipal.userId,
       homePath: "/home/matrix/home",
       findingsReader: async () => ({
         ok: true,
@@ -686,6 +714,38 @@ describe("coding agent runtime summary", () => {
     const snapshot = await store.getReviewSnapshot!(testPrincipal, "rev_1");
 
     expect(snapshot.files.items).toHaveLength(100);
+    expect(snapshot.files.hasMore).toBe(true);
+  });
+
+  it("reports snapshot overflow when one file exceeds the per-file finding cap", async () => {
+    const store = createCodingAgentReviewSummaryStore({
+      getReview: async () => ({
+        ok: true,
+        review: reviewRecord({ ownerId: testPrincipal.userId, rounds: [successfulFindingsRound()] }),
+      }),
+      listReviews: async () => ({ ok: true, reviews: [], nextCursor: null }),
+    } as ReviewLoopStore, {
+      ownerId: testPrincipal.userId,
+      homePath: "/home/matrix/home",
+      findingsReader: async () => ({
+        ok: true,
+        parserStatus: "success",
+        findingsCount: 101,
+        severityCounts: { high: 101, medium: 0, low: 0 },
+        findings: Array.from({ length: 101 }, (_, index) => ({
+          id: `HIGH-${index}`,
+          severity: "high" as const,
+          file: "packages/example/shared.ts",
+          line: index + 1,
+          summary: "Bounded finding.",
+        })),
+      }),
+    });
+
+    const snapshot = await store.getReviewSnapshot!(testPrincipal, "rev_1");
+
+    expect(snapshot.files.items).toHaveLength(1);
+    expect(snapshot.files.items[0]?.findings).toHaveLength(100);
     expect(snapshot.files.hasMore).toBe(true);
   });
 

--- a/tests/gateway/coding-agents-summary.test.ts
+++ b/tests/gateway/coding-agents-summary.test.ts
@@ -11,6 +11,7 @@ import {
   type CodingAgentTerminalSessionRegistry,
 } from "../../packages/gateway/src/coding-agents/runtime-summary.js";
 import {
+  CodingAgentReviewSnapshotError,
   createCodingAgentReviewSummaryStore,
   type ReviewLoopStore,
 } from "../../packages/gateway/src/coding-agents/review-summary.js";
@@ -37,6 +38,18 @@ function reviewRecord(overrides: Record<string, unknown> = {}) {
     rounds: [],
     createdAt: now.toISOString(),
     updatedAt: now.toISOString(),
+    ...overrides,
+  };
+}
+
+function successfulFindingsRound(overrides: Record<string, unknown> = {}) {
+  return {
+    round: 1,
+    phase: "review",
+    parserStatus: "success",
+    findingsPath: ".matrix/review-round-1.md",
+    startedAt: now.toISOString(),
+    completedAt: now.toISOString(),
     ...overrides,
   };
 }
@@ -481,6 +494,44 @@ describe("coding agent runtime summary", () => {
     expect(JSON.stringify(body)).not.toMatch(/\/home\/matrix|Postgres|token|secret/i);
   });
 
+  it("maps missing review snapshots to a stable safe not-found response", async () => {
+    const app = new Hono();
+    app.route("/api/coding-agents", createCodingAgentRoutes({
+      service: { getSummary: async () => RuntimeSummarySchema.parse({
+        runtime: {
+          status: "online",
+          statusText: "Ready",
+          activeThreads: 0,
+          attentionRequired: 0,
+          terminals: { items: [], hasMore: false, limit: 20 },
+          updatedAt: now.toISOString(),
+        },
+        capabilities: [],
+        providers: { items: [], hasMore: false, limit: 20 },
+        threads: { items: [], hasMore: false, limit: 50 },
+        reviews: { items: [], hasMore: false, limit: 50 },
+        updatedAt: now.toISOString(),
+      }) },
+      reviews: {
+        listReviews: async () => ({ items: [], hasMore: false, limit: 50 }),
+        getReviewSnapshot: async () => {
+          throw new CodingAgentReviewSnapshotError("review_not_found");
+        },
+      },
+      getPrincipal: () => testPrincipal,
+    }));
+
+    const res = await app.request("/api/coding-agents/reviews/rev_missing");
+
+    expect(res.status).toBe(404);
+    const body = await res.json();
+    expect(body.error).toMatchObject({
+      code: "review_not_found",
+      retryable: false,
+    });
+    expect(JSON.stringify(body)).not.toMatch(/\/home\/matrix|Postgres|token|secret/i);
+  });
+
   it("withholds owner-local review summaries from other principals", async () => {
     const store = createCodingAgentReviewSummaryStore({
       listReviews: async () => ({ ok: true, reviews: [reviewRecord()], nextCursor: null }),
@@ -495,46 +546,39 @@ describe("coding agent runtime summary", () => {
   });
 
   it("derives partial review snapshot files from safe structured findings only", async () => {
+    const reader = vi.fn(async () => ({
+      ok: true as const,
+      parserStatus: "success" as const,
+      findingsCount: 2,
+      severityCounts: { high: 1, medium: 1, low: 0 },
+      findings: [
+        {
+          id: "HIGH-1",
+          severity: "high" as const,
+          file: "packages/gateway/src/coding-agents/routes.ts",
+          line: 42,
+          summary: "Validate review identifiers before lookup.",
+        },
+        {
+          id: "MED-1",
+          severity: "medium" as const,
+          file: "/home/matrix/private/secret.ts",
+          line: 7,
+          summary: "Unsafe path must be dropped.",
+        },
+      ],
+    }));
     const store = createCodingAgentReviewSummaryStore({
       getReview: async () => ({
         ok: true,
         review: reviewRecord({
-          rounds: [
-            {
-              round: 1,
-              phase: "review",
-              parserStatus: "success",
-              findingsPath: "/home/matrix/private/review-findings.md",
-              startedAt: now.toISOString(),
-              completedAt: now.toISOString(),
-            },
-          ],
+          rounds: [successfulFindingsRound()],
         }),
       }),
       listReviews: async () => ({ ok: true, reviews: [], nextCursor: null }),
     } as ReviewLoopStore, {
-      findingsReader: async () => ({
-        ok: true,
-        parserStatus: "success",
-        findingsCount: 2,
-        severityCounts: { high: 1, medium: 1, low: 0 },
-        findings: [
-          {
-            id: "HIGH-1",
-            severity: "high",
-            file: "packages/gateway/src/coding-agents/routes.ts",
-            line: 42,
-            summary: "Validate review identifiers before lookup.",
-          },
-          {
-            id: "MED-1",
-            severity: "medium",
-            file: "/home/matrix/private/secret.ts",
-            line: 7,
-            summary: "Unsafe path must be dropped.",
-          },
-        ],
-      }),
+      homePath: "/home/matrix/home",
+      findingsReader: reader,
     });
 
     const snapshot = await store.getReviewSnapshot!(testPrincipal, "rev_1");
@@ -553,7 +597,96 @@ describe("coding agent runtime summary", () => {
       hasMore: false,
       limit: 100,
     });
+    expect(reader).toHaveBeenCalledWith("/home/matrix/home/projects/matrix-os/worktrees/wt_abc123def456/.matrix/review-round-1.md");
     expect(JSON.stringify(snapshot)).not.toMatch(/\/home\/matrix|secret|Postgres|token/i);
+  });
+
+  it("returns safe not-found for owner-mismatched review snapshots", async () => {
+    const store = createCodingAgentReviewSummaryStore({
+      getReview: async () => ({
+        ok: true,
+        review: reviewRecord({
+          ownerId: "other_owner",
+          rounds: [successfulFindingsRound()],
+        }),
+      }),
+      listReviews: async () => ({ ok: true, reviews: [], nextCursor: null }),
+    } as ReviewLoopStore, {
+      ownerId: "owner_user",
+      homePath: "/home/matrix/home",
+      findingsReader: async () => ({
+        ok: true,
+        parserStatus: "success",
+        findingsCount: 0,
+        severityCounts: { high: 0, medium: 0, low: 0 },
+        findings: [],
+      }),
+    });
+
+    await expect(store.getReviewSnapshot!(testPrincipal, "rev_1")).rejects.toMatchObject({
+      code: "review_not_found",
+    });
+  });
+
+  it("does not read unsafe persisted findings paths", async () => {
+    const reader = vi.fn(async () => ({
+      ok: true as const,
+      parserStatus: "success" as const,
+      findingsCount: 1,
+      severityCounts: { high: 1, medium: 0, low: 0 },
+      findings: [{
+        id: "HIGH-1",
+        severity: "high" as const,
+        file: "packages/gateway/src/coding-agents/routes.ts",
+        line: 42,
+        summary: "Should not be read.",
+      }],
+    }));
+    const store = createCodingAgentReviewSummaryStore({
+      getReview: async () => ({
+        ok: true,
+        review: reviewRecord({
+          rounds: [successfulFindingsRound({ findingsPath: "/home/matrix/private/review-findings.md" })],
+        }),
+      }),
+      listReviews: async () => ({ ok: true, reviews: [], nextCursor: null }),
+    } as ReviewLoopStore, { homePath: "/home/matrix/home", findingsReader: reader });
+
+    const snapshot = await store.getReviewSnapshot!(testPrincipal, "rev_1");
+
+    expect(snapshot.files).toMatchObject({ items: [], hasMore: false, limit: 100 });
+    expect(reader).not.toHaveBeenCalled();
+    expect(JSON.stringify(snapshot)).not.toMatch(/\/home\/matrix|secret|token/i);
+  });
+
+  it("reports snapshot overflow when distinct findings files exceed the cap", async () => {
+    const store = createCodingAgentReviewSummaryStore({
+      getReview: async () => ({
+        ok: true,
+        review: reviewRecord({ rounds: [successfulFindingsRound()] }),
+      }),
+      listReviews: async () => ({ ok: true, reviews: [], nextCursor: null }),
+    } as ReviewLoopStore, {
+      homePath: "/home/matrix/home",
+      findingsReader: async () => ({
+        ok: true,
+        parserStatus: "success",
+        findingsCount: 101,
+        severityCounts: { high: 101, medium: 0, low: 0 },
+        findings: Array.from({ length: 101 }, (_, index) => ({
+          id: `HIGH-${index}`,
+          severity: "high" as const,
+          file: `packages/example/file-${index}.ts`,
+          line: 1,
+          summary: "Bounded finding.",
+        })),
+      }),
+    });
+
+    const snapshot = await store.getReviewSnapshot!(testPrincipal, "rev_1");
+
+    expect(snapshot.files.items).toHaveLength(100);
+    expect(snapshot.files.hasMore).toBe(true);
   });
 
   it("allows validated jwt review readers even when the configured owner id uses another owner identifier", async () => {

--- a/tests/gateway/review-loop.test.ts
+++ b/tests/gateway/review-loop.test.ts
@@ -73,13 +73,21 @@ describe("review-loop", () => {
     expect(started.ok).toBe(true);
     if (!started.ok) return;
 
-    const needsImplementation = completeReview(started.review, { parseResult: parsedWithFindings, now });
+    const needsImplementation = completeReview(started.review, {
+      parseResult: parsedWithFindings,
+      findingsPath: ".matrix/review-round-1.md",
+      now,
+    });
     expect(needsImplementation).toMatchObject({
       ok: true,
       review: {
         status: "implementing",
         round: 1,
-        rounds: [expect.objectContaining({ findingsCount: 1, severityCounts: { high: 1, medium: 0, low: 0 } })],
+        rounds: [expect.objectContaining({
+          findingsCount: 1,
+          findingsPath: ".matrix/review-round-1.md",
+          severityCounts: { high: 1, medium: 0, low: 0 },
+        })],
       },
     });
     if (!needsImplementation.ok) return;


### PR DESCRIPTION
## Summary

- Adds shared Matrix coding-agent review snapshot contracts for bounded file metadata, findings, and partial diff hunks.
- Adds a read-only gateway route at `GET /api/coding-agents/reviews/:reviewId`.
- Derives a safe partial snapshot from persisted review state plus parsed review findings when full diff content is not available.

## Invariants

- Source of truth stays in the gateway/runtime review store; desktop and mobile shells remain thin clients.
- No new persistence layer is introduced.
- The route is read-only, authenticated through the existing request principal path, path-param validated with Zod 4, and returns generic safe errors.
- Snapshot file paths, finding summaries, notices, and list sizes are schema-bounded before returning to clients.
- Full diff hydration, file content reads, review preview UI, and mutating review actions remain deferred to later PR slices.

## Validation

- `bun run test -- tests/contracts/coding-agents.test.ts tests/gateway/review-loop.test.ts tests/gateway/coding-agents-summary.test.ts`
- `pnpm --filter @matrix-os/gateway exec tsc --noEmit`
- `bun run check:patterns` (0 violations; existing warning classes only)
- `bun run typecheck`
- `git diff --check`
- Restricted wording scan over changed files

## Docs

- Public docs are deferred for this internal source-of-truth slice; `specs/105-coding-agent-shells/current-state.md` is updated with the current implementation state.
