### PR TITLE
feat(desktop): add review snapshot details

### DIFF
--- a/desktop/src/main/coding-agents/runtime-summary-client.ts
+++ b/desktop/src/main/coding-agents/runtime-summary-client.ts
@@ -1,8 +1,10 @@
 import {
   AgentThreadSnapshotSchema,
+  ReviewSnapshotSchema,
   ReviewSummarySchema,
   RuntimeSummarySchema,
   type CreateAgentThreadRequest,
+  type ReviewSnapshot,
   type ReviewSummary,
   type RuntimeSummary,
   boundedListSchema,
@@ -12,6 +14,7 @@ import type { AuthService } from "../auth/auth-service";
 
 const RUNTIME_SUMMARY_TIMEOUT_MS = 10_000;
 const REVIEW_SUMMARY_TIMEOUT_MS = 10_000;
+const REVIEW_SNAPSHOT_TIMEOUT_MS = 10_000;
 const THREAD_CREATE_TIMEOUT_MS = 15_000;
 
 type FetchFn = (input: string, init?: RequestInit) => Promise<Response>;
@@ -119,6 +122,40 @@ export async function fetchCodingAgentReviewSummaries(
 
   const body = await res.json();
   const parsed = ReviewSummaryListSchema.safeParse(body);
+  if (!parsed.success) {
+    throw new Error("review state unavailable");
+  }
+  return parsed.data;
+}
+
+export async function fetchCodingAgentReviewSnapshot(
+  auth: AuthService,
+  options: { reviewId: string },
+  fetchFn: FetchFn = fetch,
+): Promise<ReviewSnapshot> {
+  const token = auth.getToken();
+  if (!token) {
+    throw new Error("review state unavailable");
+  }
+
+  const url = new URL(
+    `/api/coding-agents/reviews/${encodeURIComponent(options.reviewId)}`,
+    auth.getGatewayOrigin(),
+  );
+  const res = await fetchFn(url.toString(), {
+    method: "GET",
+    headers: {
+      Authorization: `Bearer ${token}`,
+      Accept: "application/json",
+    },
+    signal: AbortSignal.timeout(REVIEW_SNAPSHOT_TIMEOUT_MS),
+  });
+  if (!res.ok) {
+    throw new Error("review state unavailable");
+  }
+
+  const body = await res.json();
+  const parsed = ReviewSnapshotSchema.safeParse(body);
   if (!parsed.success) {
     throw new Error("review state unavailable");
   }

--- a/desktop/src/main/index.ts
+++ b/desktop/src/main/index.ts
@@ -6,6 +6,7 @@ import { installGatewayCors, installHeaderInjection } from "./auth/header-inject
 import { EmbedService } from "./embeds/embed-service";
 import {
   createCodingAgentThread,
+  fetchCodingAgentReviewSnapshot,
   fetchCodingAgentReviewSummaries,
   fetchCodingAgentRuntimeSummary,
 } from "./coding-agents/runtime-summary-client";
@@ -233,6 +234,7 @@ if (!gotLock) {
         getUpdateStatus: () => updater.status(),
         fetchRuntimeSummary: () => fetchCodingAgentRuntimeSummary(auth),
         fetchReviewSummaries: (options) => fetchCodingAgentReviewSummaries(auth, options),
+        fetchReviewSnapshot: (options) => fetchCodingAgentReviewSnapshot(auth, options),
         createAgentThread: (request) => createCodingAgentThread(auth, request),
       });
 

--- a/desktop/src/main/ipc/handlers.ts
+++ b/desktop/src/main/ipc/handlers.ts
@@ -6,7 +6,7 @@ import type { AuthService } from "../auth/auth-service";
 import type { EmbedService } from "../embeds/embed-service";
 import type { LocalStore, LocalStoreKey } from "../persistence/local-store";
 import type { UpdateStatus } from "../updates";
-import type { CreateAgentThreadRequest, ReviewSummary, RuntimeSummary } from "@matrix-os/contracts";
+import type { CreateAgentThreadRequest, ReviewSnapshot, ReviewSummary, RuntimeSummary } from "@matrix-os/contracts";
 import type { z } from "zod/v4";
 import { AgentThreadSnapshotSchema } from "@matrix-os/contracts";
 
@@ -30,6 +30,7 @@ export interface HandlerContext {
   fetchReviewSummaries: (
     options: { cursor?: string },
   ) => Promise<{ items: ReviewSummary[]; hasMore: boolean; limit: number; nextCursor?: string }>;
+  fetchReviewSnapshot: (options: { reviewId: string }) => Promise<ReviewSnapshot>;
   createAgentThread: (
     request: CreateAgentThreadRequest,
   ) => Promise<z.infer<typeof AgentThreadSnapshotSchema>>;
@@ -90,6 +91,7 @@ export function registerIpcHandlers(ipcMain: IpcMainLike, ctx: HandlerContext): 
   });
   handle("runtime:get-summary", () => ctx.fetchRuntimeSummary());
   handle("runtime:get-reviews", (request) => ctx.fetchReviewSummaries(request));
+  handle("runtime:get-review-snapshot", (request) => ctx.fetchReviewSnapshot(request));
   handle("runtime:create-thread", (request) => ctx.createAgentThread(request));
 
   handle("state:get", async ({ key }) => ({

--- a/desktop/src/renderer/src/features/coding-agents/AgentWorkspace.tsx
+++ b/desktop/src/renderer/src/features/coding-agents/AgentWorkspace.tsx
@@ -1,8 +1,9 @@
-import { Bot, ClipboardCheck, GitBranch, Play, RefreshCw, Server, SquareTerminal } from "lucide-react";
+import { Bot, ChevronRight, ClipboardCheck, FileText, GitBranch, Play, RefreshCw, Server, SquareTerminal } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
 import {
   defaultAgentThreadComposerDraft,
   type AgentThreadComposerDraft,
+  type ReviewSnapshot,
   type ReviewSummary,
   type RuntimeSummary,
 } from "@matrix-os/contracts";
@@ -26,6 +27,7 @@ const STATUS_COLOR: Record<string, string> = {
   unknown: "var(--text-tertiary)",
 };
 const DEFAULT_STATUS_COLOR = "var(--text-tertiary)";
+type ReviewDetailStatus = "idle" | "loading" | "ready" | "error";
 
 function capabilityEnabled(summary: RuntimeSummary, id: string): boolean {
   return summary.capabilities.some((capability) => capability.id === id && capability.enabled);
@@ -331,21 +333,32 @@ function ReviewList() {
   const reviewsStatus = useCodingAgentWorkspace((s) => s.reviewsStatus);
   const reviews = useCodingAgentWorkspace((s) => s.reviews);
   const reviewsError = useCodingAgentWorkspace((s) => s.reviewsError);
+  const selectedReviewId = useCodingAgentWorkspace((s) => s.selectedReviewId);
+  const reviewSnapshotStatus = useCodingAgentWorkspace((s) => s.reviewSnapshotStatus);
+  const reviewSnapshot = useCodingAgentWorkspace((s) => s.reviewSnapshot);
+  const reviewSnapshotError = useCodingAgentWorkspace((s) => s.reviewSnapshotError);
+  const selectReview = useCodingAgentWorkspace((s) => s.selectReview);
   const items = reviews?.items ?? [];
 
   return (
     <Section title="Review" count={items.length}>
-      <div className="grid gap-2">
+      <div className="grid gap-3">
         {reviewsStatus === "error" ? (
           <p className="rounded-md border p-3 text-sm" style={{ borderColor: "var(--border-subtle)", color: "var(--danger)" }}>
             {reviewsError ?? "Review state unavailable"}
           </p>
         ) : null}
         {items.map((review) => (
-          <article
+          <button
             key={review.id}
-            className="flex items-center justify-between gap-3 rounded-md border p-3"
-            style={{ borderColor: "var(--border-subtle)", background: "var(--bg-surface)" }}
+            type="button"
+            aria-label={`Open review PR #${review.pullRequestNumber}`}
+            className="no-drag flex min-h-[68px] w-full items-center justify-between gap-3 rounded-md border p-3 text-left transition-colors duration-100 hover:brightness-105"
+            onClick={() => void selectReview(review.id)}
+            style={{
+              borderColor: selectedReviewId === review.id ? "var(--accent)" : "var(--border-subtle)",
+              background: "var(--bg-surface)",
+            }}
           >
             <div className="flex min-w-0 items-center gap-2">
               <ClipboardCheck size={15} style={{ color: "var(--text-tertiary)" }} />
@@ -366,8 +379,14 @@ function ReviewList() {
                 </p>
               ) : null}
             </div>
-          </article>
+            <ChevronRight size={15} style={{ color: "var(--text-tertiary)" }} />
+          </button>
         ))}
+        <ReviewSnapshotPanel
+          status={reviewSnapshotStatus}
+          snapshot={reviewSnapshot}
+          error={reviewSnapshotError}
+        />
         {reviewsStatus !== "error" && reviewsStatus !== "loading" && items.length === 0 ? (
           <p className="rounded-md border p-3 text-sm" style={{ borderColor: "var(--border-subtle)", color: "var(--text-secondary)" }}>
             No reviews.
@@ -375,6 +394,90 @@ function ReviewList() {
         ) : null}
       </div>
     </Section>
+  );
+}
+
+function ReviewSnapshotPanel({
+  status,
+  snapshot,
+  error,
+}: {
+  status: ReviewDetailStatus;
+  snapshot: ReviewSnapshot | null;
+  error: string | null;
+}) {
+  if (status === "idle") return null;
+  if (status === "loading") {
+    return (
+      <p className="rounded-md border p-3 text-sm" style={{ borderColor: "var(--border-subtle)", color: "var(--text-secondary)" }}>
+        Loading review details...
+      </p>
+    );
+  }
+  if (status === "error") {
+    return (
+      <p className="rounded-md border p-3 text-sm" style={{ borderColor: "var(--border-subtle)", color: "var(--danger)" }}>
+        {error ?? "Review details unavailable"}
+      </p>
+    );
+  }
+  if (!snapshot) return null;
+
+  return (
+    <article className="grid gap-3 rounded-md border p-3" style={{ borderColor: "var(--border-subtle)", background: "var(--bg-surface)" }}>
+      <div className="flex items-center justify-between gap-3">
+        <div className="min-w-0">
+          <h3 className="truncate text-sm font-medium" style={{ color: "var(--text-primary)" }}>
+            {`PR #${snapshot.review.pullRequestNumber} review details`}
+          </h3>
+          <p className="text-xs" style={{ color: "var(--text-tertiary)" }}>
+            {`${snapshot.files.items.length} files${snapshot.partial ? " - partial" : ""}`}
+          </p>
+        </div>
+        <span className="shrink-0 text-xs capitalize" style={{ color: "var(--text-secondary)" }}>
+          {reviewStatusLabel(snapshot.review.status)}
+        </span>
+      </div>
+      {snapshot.safeNotice ? (
+        <p className="rounded-md border px-3 py-2 text-xs" style={{ borderColor: "var(--border-subtle)", color: "var(--text-secondary)" }}>
+          {snapshot.safeNotice}
+        </p>
+      ) : null}
+      <div className="grid gap-2">
+        {snapshot.files.items.map((file) => (
+          <div
+            key={file.path}
+            className="grid gap-2 rounded-md border px-3 py-2"
+            style={{ borderColor: "var(--border-subtle)", background: "var(--bg-overlay)" }}
+          >
+            <div className="flex items-center justify-between gap-3">
+              <div className="flex min-w-0 items-center gap-2">
+                <FileText size={14} style={{ color: "var(--text-tertiary)" }} />
+                <span className="truncate text-sm" style={{ color: "var(--text-primary)" }}>
+                  {file.path}
+                </span>
+              </div>
+              <span className="shrink-0 text-xs capitalize" style={{ color: "var(--text-tertiary)" }}>
+                {file.status}
+              </span>
+            </div>
+            {file.findings?.length ? (
+              <div className="grid gap-1">
+                {file.findings.map((finding) => (
+                  <p key={finding.id} className="text-xs" style={{ color: finding.severity === "high" ? "var(--danger)" : "var(--text-secondary)" }}>
+                    {finding.summary}
+                  </p>
+                ))}
+              </div>
+            ) : (
+              <p className="text-xs" style={{ color: "var(--text-tertiary)" }}>
+                No findings in this file.
+              </p>
+            )}
+          </div>
+        ))}
+      </div>
+    </article>
   );
 }
 

--- a/desktop/src/renderer/src/stores/coding-agent-workspace.ts
+++ b/desktop/src/renderer/src/stores/coding-agent-workspace.ts
@@ -1,6 +1,7 @@
 import {
   buildCreateAgentThreadRequestFromComposer,
   type AgentThreadComposerDraft,
+  type ReviewSnapshot,
   type ReviewSummary,
   type RuntimeSummary,
 } from "@matrix-os/contracts";
@@ -24,16 +25,32 @@ interface CodingAgentWorkspaceState {
   reviewsStatus: ReviewStatus;
   reviews: ReviewSummaryList | null;
   reviewsError: string | null;
+  selectedReviewId: string | null;
+  reviewSnapshotStatus: ReviewStatus;
+  reviewSnapshot: ReviewSnapshot | null;
+  reviewSnapshotError: string | null;
   createStatus: CreateStatus;
   createError: string | null;
   activeThreadId: string | null;
   refresh: () => Promise<void>;
+  selectReview: (reviewId: string) => Promise<void>;
   createThread: (draft: AgentThreadComposerDraft) => Promise<string | null>;
 }
 
 let refreshSeq = 0;
 let reviewsSeq = 0;
+let reviewSnapshotSeq = 0;
 let createRequestSeq = 0;
+
+function clearReviewSelectionState() {
+  reviewSnapshotSeq += 1;
+  return {
+    selectedReviewId: null,
+    reviewSnapshotStatus: "idle" as const,
+    reviewSnapshot: null,
+    reviewSnapshotError: null,
+  };
+}
 
 function nextCreateRequestId(): string {
   createRequestSeq += 1;
@@ -47,6 +64,10 @@ export const useCodingAgentWorkspace = create<CodingAgentWorkspaceState>()((set)
   reviewsStatus: "idle",
   reviews: null,
   reviewsError: null,
+  selectedReviewId: null,
+  reviewSnapshotStatus: "idle",
+  reviewSnapshot: null,
+  reviewSnapshotError: null,
   createStatus: "idle",
   createError: null,
   activeThreadId: null,
@@ -62,7 +83,12 @@ export const useCodingAgentWorkspace = create<CodingAgentWorkspaceState>()((set)
       if (seq !== refreshSeq) return;
       set({ status: "ready", summary, error: null });
       if (!summary.capabilities.some((capability) => capability.id === "codingAgentsReview" && capability.enabled)) {
-        set({ reviewsStatus: "idle", reviews: null, reviewsError: null });
+        set({
+          reviewsStatus: "idle",
+          reviews: null,
+          reviewsError: null,
+          ...clearReviewSelectionState(),
+        });
         return;
       }
       const reviewSeq = ++reviewsSeq;
@@ -73,16 +99,68 @@ export const useCodingAgentWorkspace = create<CodingAgentWorkspaceState>()((set)
       try {
         const reviews = await invoke("runtime:get-reviews", {});
         if (reviewSeq !== reviewsSeq) return;
-        set({ reviewsStatus: "ready", reviews, reviewsError: null });
+        set((state) => {
+          const selectedReviewStillPresent = state.selectedReviewId
+            ? reviews.items.some((review) => review.id === state.selectedReviewId)
+            : true;
+          return {
+            reviewsStatus: "ready",
+            reviews,
+            reviewsError: null,
+            ...(selectedReviewStillPresent
+              ? {}
+              : clearReviewSelectionState()),
+          };
+        });
       } catch {
         console.warn("[coding-agents] review summary refresh failed");
         if (reviewSeq !== reviewsSeq) return;
-        set({ reviewsStatus: "error", reviewsError: "Review state unavailable" });
+        set({
+          reviewsStatus: "error",
+          reviewsError: "Review state unavailable",
+          ...clearReviewSelectionState(),
+        });
       }
     } catch {
       console.warn("[coding-agents] summary refresh failed");
       if (seq !== refreshSeq) return;
-      set({ status: "error", error: "Runtime summary unavailable" });
+      set({
+        status: "error",
+        error: "Runtime summary unavailable",
+        reviewsStatus: "idle",
+        reviews: null,
+        reviewsError: null,
+        ...clearReviewSelectionState(),
+      });
+    }
+  },
+
+  selectReview: async (reviewId) => {
+    const seq = ++reviewSnapshotSeq;
+    set((state) => ({
+      selectedReviewId: reviewId,
+      reviewSnapshotStatus: state.reviewSnapshot?.review.id === reviewId ? "ready" : "loading",
+      reviewSnapshotError: null,
+      reviewSnapshot: state.reviewSnapshot?.review.id === reviewId ? state.reviewSnapshot : null,
+    }));
+    try {
+      const snapshot = await invoke("runtime:get-review-snapshot", { reviewId });
+      if (seq !== reviewSnapshotSeq) return;
+      set({
+        selectedReviewId: reviewId,
+        reviewSnapshotStatus: "ready",
+        reviewSnapshot: snapshot,
+        reviewSnapshotError: null,
+      });
+    } catch {
+      console.warn("[coding-agents] review snapshot refresh failed");
+      if (seq !== reviewSnapshotSeq) return;
+      set({
+        selectedReviewId: reviewId,
+        reviewSnapshotStatus: "error",
+        reviewSnapshot: null,
+        reviewSnapshotError: "Review details unavailable",
+      });
     }
   },
 

--- a/desktop/src/shared/ipc-contract.ts
+++ b/desktop/src/shared/ipc-contract.ts
@@ -7,6 +7,7 @@ import {
   AgentThreadSnapshotSchema,
   CreateAgentThreadRequestSchema,
   CursorSchema,
+  ReviewSnapshotSchema,
   ReviewSummarySchema,
   RuntimeSummarySchema,
   boundedListSchema,
@@ -16,6 +17,7 @@ const Empty = z.object({}).strict();
 
 const Ok = z.object({ ok: z.boolean() }).strict();
 const EmbedStateSchema = z.enum(["loading", "ready", "auth-required", "failed"]);
+const ReviewIdSchema = z.string().regex(/^rev_[A-Za-z0-9_-]{1,128}$/);
 
 const ProfileSchema = z
   .object({
@@ -109,6 +111,10 @@ export const INVOKE_CHANNELS = {
   "runtime:get-reviews": {
     request: z.object({ cursor: CursorSchema.optional() }).strict(),
     response: boundedListSchema(ReviewSummarySchema, 50),
+  },
+  "runtime:get-review-snapshot": {
+    request: z.object({ reviewId: ReviewIdSchema }).strict(),
+    response: ReviewSnapshotSchema,
   },
   "runtime:create-thread": {
     request: CreateAgentThreadRequestSchema,

--- a/tests/desktop/coding-agent-runtime-client.test.ts
+++ b/tests/desktop/coding-agent-runtime-client.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  fetchCodingAgentReviewSnapshot,
+} from "../../desktop/src/main/coding-agents/runtime-summary-client";
+import type { AuthService } from "../../desktop/src/main/auth/auth-service";
+
+function auth(): AuthService {
+  return {
+    getToken: () => "desktop-token",
+    getGatewayOrigin: () => "https://runtime.test",
+    getStatus: () => ({
+      signedIn: true,
+      handle: "operator",
+      runtimeSlot: "primary",
+      platformHost: "https://runtime.test",
+    }),
+  } as unknown as AuthService;
+}
+
+function snapshotBody() {
+  return {
+    review: {
+      id: "rev_desktop_1",
+      projectId: "matrix-os",
+      worktreeId: "wt_abc123def456",
+      status: "reviewing",
+      pullRequestNumber: 757,
+      round: 1,
+      maxRounds: 3,
+      reviewer: "codex",
+      implementer: "claude",
+      findings: { total: 1, high: 1, medium: 0, low: 0 },
+      updatedAt: "2026-07-06T00:00:00.000Z",
+    },
+    files: {
+      items: [
+        {
+          path: "packages/gateway/src/coding-agents/routes.ts",
+          status: "modified",
+          additions: 0,
+          deletions: 0,
+          partial: true,
+          hunks: [],
+          findings: [{
+            id: "HIGH-1",
+            severity: "high",
+            line: 42,
+            summary: "Validate ownership before returning snapshots.",
+          }],
+        },
+      ],
+      hasMore: false,
+      limit: 100,
+    },
+    partial: true,
+    safeNotice: "Diff content is not available yet. Showing bounded review findings.",
+    updatedAt: "2026-07-06T00:00:00.000Z",
+  };
+}
+
+describe("coding agent desktop runtime client", () => {
+  it("fetches review snapshots with bearer auth and validates safe output", async () => {
+    const fetchFn = vi.fn().mockResolvedValue(new Response(JSON.stringify(snapshotBody()), { status: 200 }));
+
+    const snapshot = await fetchCodingAgentReviewSnapshot(auth(), { reviewId: "rev_desktop_1" }, fetchFn);
+
+    expect(fetchFn).toHaveBeenCalledWith(
+      "https://runtime.test/api/coding-agents/reviews/rev_desktop_1",
+      expect.objectContaining({
+        method: "GET",
+        headers: expect.objectContaining({
+          Authorization: "Bearer desktop-token",
+          Accept: "application/json",
+        }),
+        signal: expect.any(AbortSignal),
+      }),
+    );
+    expect(snapshot.files.items[0]?.path).toBe("packages/gateway/src/coding-agents/routes.ts");
+  });
+
+  it("rejects unsafe or malformed review snapshot responses with a generic error", async () => {
+    const fetchFn = vi.fn().mockResolvedValue(new Response(JSON.stringify({
+      ...snapshotBody(),
+      files: {
+        ...snapshotBody().files,
+        items: [{ ...snapshotBody().files.items[0], path: "/home/matrix/private/secret.ts" }],
+      },
+    }), { status: 200 }));
+
+    await expect(fetchCodingAgentReviewSnapshot(auth(), { reviewId: "rev_desktop_1" }, fetchFn)).rejects.toThrow("review state unavailable");
+    await expect(fetchCodingAgentReviewSnapshot(auth(), { reviewId: "rev_desktop_1" }, fetchFn)).rejects.not.toThrow("/home/matrix");
+  });
+});

--- a/tests/desktop/coding-agent-workspace.test.tsx
+++ b/tests/desktop/coding-agent-workspace.test.tsx
@@ -117,6 +117,47 @@ function reviewsFixture() {
   };
 }
 
+function reviewSnapshotFixture() {
+  return {
+    review: reviewsFixture().items[0],
+    files: {
+      items: [
+        {
+          path: "packages/gateway/src/coding-agents/routes.ts",
+          status: "modified",
+          additions: 0,
+          deletions: 0,
+          partial: true,
+          hunks: [
+            {
+              id: "hunk_rev_desktop_1_0_0",
+              oldStart: 42,
+              oldLines: 1,
+              newStart: 42,
+              newLines: 1,
+              heading: "Finding HIGH-1",
+              partial: true,
+            },
+          ],
+          findings: [
+            {
+              id: "HIGH-1",
+              severity: "high",
+              line: 42,
+              summary: "Validate ownership before returning snapshots.",
+            },
+          ],
+        },
+      ],
+      hasMore: false,
+      limit: 100,
+    },
+    partial: true,
+    safeNotice: "Diff content is not available yet. Showing bounded review findings.",
+    updatedAt: "2026-07-06T00:02:00.000Z",
+  };
+}
+
 describe("AgentWorkspace", () => {
   beforeEach(() => {
     useCodingAgentWorkspace.setState({
@@ -126,6 +167,10 @@ describe("AgentWorkspace", () => {
       reviewsStatus: "idle",
       reviews: null,
       reviewsError: null,
+      selectedReviewId: null,
+      reviewSnapshotStatus: "idle",
+      reviewSnapshot: null,
+      reviewSnapshotError: null,
       createStatus: "idle",
       createError: null,
       activeThreadId: null,
@@ -141,6 +186,7 @@ describe("AgentWorkspace", () => {
       invoke: vi.fn((channel: string) => {
         if (channel === "runtime:get-summary") return Promise.resolve(summaryFixture());
         if (channel === "runtime:get-reviews") return Promise.resolve(reviewsFixture());
+        if (channel === "runtime:get-review-snapshot") return Promise.resolve(reviewSnapshotFixture());
         return Promise.reject(new Error("unexpected channel"));
       }),
       on: vi.fn(() => () => undefined),
@@ -174,6 +220,21 @@ describe("AgentWorkspace", () => {
     expect(window.operator.invoke).toHaveBeenCalledWith("runtime:get-reviews", {});
   });
 
+  it("loads a read-only review snapshot when a review is selected", async () => {
+    render(<AgentWorkspace />);
+
+    await screen.findByText("matrix-os");
+    fireEvent.click(screen.getByRole("button", { name: /Open review PR #758/i }));
+
+    expect(window.operator.invoke).toHaveBeenCalledWith("runtime:get-review-snapshot", {
+      reviewId: "rev_desktop_1",
+    });
+    expect(await screen.findByText("packages/gateway/src/coding-agents/routes.ts")).toBeTruthy();
+    expect(screen.getByText("Validate ownership before returning snapshots.")).toBeTruthy();
+    expect(screen.getByText("Diff content is not available yet. Showing bounded review findings.")).toBeTruthy();
+    expect(screen.queryByText(/home\/matrix|token|secret/i)).toBeNull();
+  });
+
   it("shows a generic safe review error without dropping the runtime summary", async () => {
     window.operator.invoke = vi.fn((channel: string) => {
       if (channel === "runtime:get-summary") return Promise.resolve(summaryFixture());
@@ -188,6 +249,86 @@ describe("AgentWorkspace", () => {
     await screen.findByText("Primary");
     expect(await screen.findByText("Review state unavailable")).toBeTruthy();
     expect(screen.queryByText(/home\/matrix|token|secret/i)).toBeNull();
+  });
+
+  it("clears loaded review details when review summaries become unavailable", async () => {
+    render(<AgentWorkspace />);
+
+    await screen.findByText("matrix-os");
+    fireEvent.click(screen.getByRole("button", { name: /Open review PR #758/i }));
+    expect(await screen.findByText("Validate ownership before returning snapshots.")).toBeTruthy();
+
+    window.operator.invoke = vi.fn((channel: string) => {
+      if (channel === "runtime:get-summary") return Promise.resolve(summaryFixture());
+      if (channel === "runtime:get-reviews") {
+        return Promise.reject(new Error("review store failed at /home/matrix/private token secret"));
+      }
+      return Promise.reject(new Error("unexpected channel"));
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Refresh agent workspace" }));
+
+    expect(await screen.findByText("Review state unavailable")).toBeTruthy();
+    expect(screen.queryByText("Validate ownership before returning snapshots.")).toBeNull();
+    expect(screen.queryByText("packages/gateway/src/coding-agents/routes.ts")).toBeNull();
+    expect(screen.queryByText(/home\/matrix|token|secret/i)).toBeNull();
+  });
+
+  it("clears loaded review details when runtime summary refresh fails", async () => {
+    render(<AgentWorkspace />);
+
+    await screen.findByText("matrix-os");
+    fireEvent.click(screen.getByRole("button", { name: /Open review PR #758/i }));
+    expect(await screen.findByText("Validate ownership before returning snapshots.")).toBeTruthy();
+
+    window.operator.invoke = vi.fn((channel: string) => {
+      if (channel === "runtime:get-summary") {
+        return Promise.reject(new Error("summary failed at /home/matrix/private token secret"));
+      }
+      return Promise.reject(new Error("unexpected channel"));
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Refresh agent workspace" }));
+
+    await waitFor(() => {
+      expect(screen.queryByText("Validate ownership before returning snapshots.")).toBeNull();
+    });
+    expect(screen.queryByText("packages/gateway/src/coding-agents/routes.ts")).toBeNull();
+    expect(screen.queryByText(/home\/matrix|token|secret/i)).toBeNull();
+  });
+
+  it("does not restore an in-flight review snapshot after refresh removes the review", async () => {
+    let resolveSnapshot: (value: unknown) => void = () => undefined;
+    window.operator.invoke = vi.fn((channel: string) => {
+      if (channel === "runtime:get-summary") return Promise.resolve(summaryFixture());
+      if (channel === "runtime:get-reviews") return Promise.resolve(reviewsFixture());
+      if (channel === "runtime:get-review-snapshot") {
+        return new Promise((resolve) => {
+          resolveSnapshot = resolve;
+        });
+      }
+      return Promise.reject(new Error("unexpected channel"));
+    });
+    render(<AgentWorkspace />);
+
+    await screen.findByText("matrix-os");
+    fireEvent.click(screen.getByRole("button", { name: /Open review PR #758/i }));
+    expect(await screen.findByText("Loading review details...")).toBeTruthy();
+
+    window.operator.invoke = vi.fn((channel: string) => {
+      if (channel === "runtime:get-summary") return Promise.resolve(summaryFixture());
+      if (channel === "runtime:get-reviews") return Promise.resolve({ items: [], hasMore: false, limit: 50 });
+      return Promise.reject(new Error("unexpected channel"));
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Refresh agent workspace" }));
+    await screen.findByText("No reviews.");
+
+    resolveSnapshot(reviewSnapshotFixture());
+
+    await waitFor(() => {
+      expect(screen.queryByText("Validate ownership before returning snapshots.")).toBeNull();
+    });
+    expect(screen.queryByText("packages/gateway/src/coding-agents/routes.ts")).toBeNull();
   });
 
   it("creates a thread from the desktop composer and focuses the new thread", async () => {

--- a/tests/desktop/ipc-contract.test.ts
+++ b/tests/desktop/ipc-contract.test.ts
@@ -14,6 +14,7 @@ describe("IPC contract", () => {
       "auth:status",
       "auth:sign-out",
       "runtime:create-thread",
+      "runtime:get-review-snapshot",
       "runtime:get-reviews",
       "runtime:get-summary",
       "runtime:select",
@@ -145,6 +146,73 @@ describe("IPC contract", () => {
     expect(schema.safeParse({
       ...valid,
       items: [{ ...valid.items[0], safeStatus: "Postgres failed at /home/matrix/home" }],
+    }).success).toBe(false);
+  });
+
+  it("validates runtime:get-review-snapshot responses and rejects credential leakage shapes", () => {
+    const requestSchema = INVOKE_CHANNELS["runtime:get-review-snapshot"].request;
+    const schema = INVOKE_CHANNELS["runtime:get-review-snapshot"].response;
+    const valid = {
+      review: {
+        id: "rev_desktop_1",
+        projectId: "matrix-os",
+        worktreeId: "wt_abc123def456",
+        status: "reviewing",
+        pullRequestNumber: 757,
+        round: 1,
+        maxRounds: 3,
+        reviewer: "codex",
+        implementer: "claude",
+        findings: { total: 1, high: 1, medium: 0, low: 0 },
+        updatedAt: "2026-07-06T00:00:00.000Z",
+      },
+      files: {
+        items: [
+          {
+            path: "packages/gateway/src/coding-agents/routes.ts",
+            status: "modified",
+            additions: 0,
+            deletions: 0,
+            partial: true,
+            hunks: [
+              {
+                id: "hunk_rev_desktop_1_0_0",
+                oldStart: 42,
+                oldLines: 1,
+                newStart: 42,
+                newLines: 1,
+                heading: "Finding HIGH-1",
+                partial: true,
+              },
+            ],
+            findings: [
+              {
+                id: "HIGH-1",
+                severity: "high",
+                line: 42,
+                summary: "Validate ownership before returning snapshots.",
+              },
+            ],
+          },
+        ],
+        hasMore: false,
+        limit: 100,
+      },
+      partial: true,
+      safeNotice: "Diff content is not available yet. Showing bounded review findings.",
+      updatedAt: "2026-07-06T00:00:00.000Z",
+    };
+
+    expect(requestSchema.safeParse({ reviewId: "rev_desktop_1" }).success).toBe(true);
+    expect(requestSchema.safeParse({ reviewId: "../secret" }).success).toBe(false);
+    expect(schema.safeParse(valid).success).toBe(true);
+    expect(schema.safeParse({ ...valid, accessToken: "secret" }).success).toBe(false);
+    expect(schema.safeParse({
+      ...valid,
+      files: {
+        ...valid.files,
+        items: [{ ...valid.files.items[0], path: "/home/matrix/private/secret.ts" }],
+      },
     }).success).toBe(false);
   });
 

--- a/tests/desktop/ipc-handlers.test.ts
+++ b/tests/desktop/ipc-handlers.test.ts
@@ -38,6 +38,7 @@ function makeHarness(overrides: Partial<HandlerContext> = {}) {
     getUpdateStatus: vi.fn(() => "disabled"),
     fetchRuntimeSummary: vi.fn(),
     fetchReviewSummaries: vi.fn(),
+    fetchReviewSnapshot: vi.fn(),
     createAgentThread: vi.fn(),
     ...overrides,
   } as unknown as HandlerContext;
@@ -206,6 +207,63 @@ describe("registerIpcHandlers", () => {
 
     await expect(harness.invoke("runtime:get-reviews")).rejects.toThrow("internal error");
     await expect(harness.invoke("runtime:get-reviews")).rejects.not.toThrow("/home/matrix");
+  });
+
+  it("returns a coding agent review snapshot through a strict trusted-core IPC channel", async () => {
+    const snapshot = {
+      review: {
+        id: "rev_desktop_1",
+        projectId: "matrix-os",
+        worktreeId: "wt_abc123def456",
+        status: "reviewing",
+        pullRequestNumber: 757,
+        round: 1,
+        maxRounds: 3,
+        reviewer: "codex",
+        implementer: "claude",
+        findings: { total: 1, high: 1, medium: 0, low: 0 },
+        updatedAt: "2026-07-06T00:00:00.000Z",
+      },
+      files: {
+        items: [
+          {
+            path: "packages/gateway/src/coding-agents/routes.ts",
+            status: "modified",
+            additions: 0,
+            deletions: 0,
+            partial: true,
+            hunks: [],
+            findings: [
+              {
+                id: "HIGH-1",
+                severity: "high",
+                line: 42,
+                summary: "Validate ownership before returning snapshots.",
+              },
+            ],
+          },
+        ],
+        hasMore: false,
+        limit: 100,
+      },
+      partial: true,
+      updatedAt: "2026-07-06T00:00:00.000Z",
+    };
+    const fetchReviewSnapshot = vi.fn().mockResolvedValue(snapshot);
+    const harness = makeHarness({ fetchReviewSnapshot } as Partial<HandlerContext>);
+
+    await expect(harness.invoke("runtime:get-review-snapshot", { reviewId: "rev_desktop_1" })).resolves.toEqual(snapshot);
+    expect(fetchReviewSnapshot).toHaveBeenCalledWith({ reviewId: "rev_desktop_1" });
+  });
+
+  it("maps review snapshot failures to a generic IPC error", async () => {
+    const fetchReviewSnapshot = vi
+      .fn()
+      .mockRejectedValue(new Error("Postgres failed at /home/matrix/home with token secret"));
+    const harness = makeHarness({ fetchReviewSnapshot } as Partial<HandlerContext>);
+
+    await expect(harness.invoke("runtime:get-review-snapshot", { reviewId: "rev_desktop_1" })).rejects.toThrow("internal error");
+    await expect(harness.invoke("runtime:get-review-snapshot", { reviewId: "rev_desktop_1" })).rejects.not.toThrow("/home/matrix");
   });
 
   it("creates agent threads through trusted-core IPC without exposing credentials", async () => {


### PR DESCRIPTION
## Summary

- Add a strict desktop IPC channel for read-only coding-agent review snapshots.
- Fetch review snapshots from the trusted Electron main process with bearer auth and contract validation.
- Let the desktop Agent workspace open a bounded review detail panel showing safe file metadata and finding summaries only.

## Tests

- `bun run test -- tests/desktop/ipc-contract.test.ts tests/desktop/ipc-handlers.test.ts tests/desktop/coding-agent-runtime-client.test.ts tests/desktop/coding-agent-workspace.test.tsx`
- `pnpm --filter desktop run typecheck`
- `bun run check:patterns` (0 violations, existing warnings only)
- `bun run typecheck`
- `git diff --check`
- `git diff --cached --check`
- Diff-only wording scan for private reference terms

`vp check` and `vp run typecheck` were not run because `vp` is not installed in this environment.

## Review/Monitoring

- Opened as a stacked PR above #761.
- Current head `d0c48dcd3572ae25e18b572ef2d20ada939841bd` is mergeable clean.
- Greptile reviewed the current head at 5/5.
- `ready-for-ci` is applied; label-triggered checks are passing or skipped by workflow conditions.

## Invariants

- Source of truth remains the gateway/runtime review snapshot endpoint; desktop only hydrates a read-only view.
- Desktop renderer never receives bearer credentials or provider credentials.
- All IPC request/response payloads use Zod 4 schemas and reject unexpected credential-shaped fields.
- Review details shown in the renderer are bounded contract data: safe relative paths, file metadata, hunk metadata, and finding summaries only.
- User-facing failures stay generic and do not render raw provider, filesystem, token, database, or stack details.
- No persistence or runtime source of truth is added to desktop.

## Docs

- Deferred for this desktop-only read-only shell slice. Public/internal docs are planned for the consolidated coding-agent shell milestone once the stacked runtime, desktop, and mobile surfaces are complete.
