### PR TITLE
feat(mobile): add review snapshot details

### DIFF
--- a/apps/mobile/__tests__/agents-screen.test.tsx
+++ b/apps/mobile/__tests__/agents-screen.test.tsx
@@ -13,7 +13,7 @@ jest.mock("expo-router", () => ({
 }));
 
 import React from "react";
-import { act, render, screen, waitFor } from "@testing-library/react-native";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react-native";
 import AgentsScreen from "../app/agents";
 import { useGateway } from "@/app/_layout";
 import type { GatewayClient } from "../lib/gateway-client";
@@ -131,6 +131,54 @@ function reviewsFixture() {
   };
 }
 
+function reviewSnapshotFixture() {
+  return {
+    review: reviewsFixture().items[0],
+    files: {
+      items: [
+        {
+          path: "packages/gateway/src/coding-agents/routes.ts",
+          status: "modified",
+          additions: 0,
+          deletions: 0,
+          partial: true,
+          hunks: [],
+          findings: [
+            {
+              id: "HIGH-1",
+              severity: "high",
+              line: 42,
+              summary: "Validate ownership before returning snapshots.",
+            },
+          ],
+        },
+      ],
+      hasMore: false,
+      limit: 100,
+    },
+    partial: true,
+    safeNotice: "Diff content is not available yet. Showing bounded review findings.",
+    updatedAt: "2026-07-06T00:02:00.000Z",
+  };
+}
+
+function reviewSnapshotWithFinding(summary: string) {
+  const snapshot = reviewSnapshotFixture();
+  return {
+    ...snapshot,
+    files: {
+      ...snapshot.files,
+      items: snapshot.files.items.map((file) => ({
+        ...file,
+        findings: file.findings?.map((finding) => ({
+          ...finding,
+          summary,
+        })),
+      })),
+    },
+  };
+}
+
 function deferred<T>() {
   let resolve!: (value: T) => void;
   const promise = new Promise<T>((promiseResolve) => {
@@ -194,6 +242,40 @@ describe("AgentsScreen", () => {
     expect(client.getCodingAgentReviews).toHaveBeenCalledWith();
   });
 
+  it("loads a read-only review snapshot when a review is selected", async () => {
+    const client = {
+      getCodingAgentRuntimeSummary: jest.fn().mockResolvedValue({
+        ok: true,
+        summary: summaryFixture(),
+      }),
+      getCodingAgentReviews: jest.fn().mockResolvedValue({
+        ok: true,
+        reviews: reviewsFixture(),
+      }),
+      getCodingAgentReviewSnapshot: jest.fn().mockResolvedValue({
+        ok: true,
+        snapshot: reviewSnapshotFixture(),
+      }),
+    };
+    useGatewayMock.mockReturnValue(gatewayContext({
+      client: client as unknown as GatewayClient,
+      connectionState: "connected",
+    }));
+
+    render(<AgentsScreen />);
+
+    await screen.findByText("matrix-os");
+    await act(async () => {
+      fireEvent.press(screen.getByLabelText("Open review PR #759"));
+    });
+
+    expect(client.getCodingAgentReviewSnapshot).toHaveBeenCalledWith({ reviewId: "rev_mobile_1" });
+    expect(await screen.findByText("packages/gateway/src/coding-agents/routes.ts")).toBeTruthy();
+    expect(screen.getByText("Validate ownership before returning snapshots.")).toBeTruthy();
+    expect(screen.getByText("Diff content is not available yet. Showing bounded review findings.")).toBeTruthy();
+    expect(screen.queryByText(/home\/matrix|token|secret/i)).toBeNull();
+  });
+
   it("renders a generic review error without dropping the runtime summary", async () => {
     const client = {
       getCodingAgentRuntimeSummary: jest.fn().mockResolvedValue({
@@ -215,6 +297,337 @@ describe("AgentsScreen", () => {
     await screen.findByText("Primary");
     expect(await screen.findByText("Review state unavailable")).toBeTruthy();
     expect(screen.queryByText(/home\/matrix|token|secret/i)).toBeNull();
+  });
+
+  it("clears loaded review details when review summaries become unavailable", async () => {
+    const client = {
+      getCodingAgentRuntimeSummary: jest.fn().mockResolvedValue({
+        ok: true,
+        summary: summaryFixture(),
+      }),
+      getCodingAgentReviews: jest.fn()
+        .mockResolvedValueOnce({
+          ok: true,
+          reviews: reviewsFixture(),
+        })
+        .mockResolvedValueOnce({
+          ok: false,
+          error: "Review state unavailable",
+        }),
+      getCodingAgentReviewSnapshot: jest.fn().mockResolvedValue({
+        ok: true,
+        snapshot: reviewSnapshotFixture(),
+      }),
+    };
+    useGatewayMock.mockReturnValue(gatewayContext({
+      client: client as unknown as GatewayClient,
+      connectionState: "connected",
+    }));
+
+    render(<AgentsScreen />);
+
+    await screen.findByText("matrix-os");
+    await act(async () => {
+      fireEvent.press(screen.getByLabelText("Open review PR #759"));
+    });
+    expect(await screen.findByText("Validate ownership before returning snapshots.")).toBeTruthy();
+
+    await act(async () => {
+      screen.getByLabelText("Refresh agent workspace").props.refreshControl.props.onRefresh();
+    });
+
+    expect(await screen.findByText("Review state unavailable")).toBeTruthy();
+    expect(screen.queryByText("Validate ownership before returning snapshots.")).toBeNull();
+    expect(screen.queryByText("packages/gateway/src/coding-agents/routes.ts")).toBeNull();
+    expect(screen.queryByText(/home\/matrix|token|secret/i)).toBeNull();
+  });
+
+  it("reloads selected review details when refreshed summaries still include the review", async () => {
+    const client = {
+      getCodingAgentRuntimeSummary: jest.fn().mockResolvedValue({
+        ok: true,
+        summary: summaryFixture(),
+      }),
+      getCodingAgentReviews: jest.fn().mockResolvedValue({
+        ok: true,
+        reviews: reviewsFixture(),
+      }),
+      getCodingAgentReviewSnapshot: jest.fn()
+        .mockResolvedValueOnce({
+          ok: true,
+          snapshot: reviewSnapshotWithFinding("Initial review finding."),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          snapshot: reviewSnapshotWithFinding("Fresh review finding after refresh."),
+        }),
+    };
+    useGatewayMock.mockReturnValue(gatewayContext({
+      client: client as unknown as GatewayClient,
+      connectionState: "connected",
+    }));
+
+    render(<AgentsScreen />);
+
+    await screen.findByText("matrix-os");
+    await act(async () => {
+      fireEvent.press(screen.getByLabelText("Open review PR #759"));
+    });
+    expect(await screen.findByText("Initial review finding.")).toBeTruthy();
+
+    await act(async () => {
+      screen.getByLabelText("Refresh agent workspace").props.refreshControl.props.onRefresh();
+    });
+
+    expect(await screen.findByText("Fresh review finding after refresh.")).toBeTruthy();
+    expect(screen.queryByText("Initial review finding.")).toBeNull();
+    expect(client.getCodingAgentReviewSnapshot).toHaveBeenCalledTimes(2);
+  });
+
+  it.each([
+    `${"ghs_"}abcdefghijklmnopqrstuvwxyz1234567890`,
+    `${"glpat-"}abcdefghijklmnopqrstuvwxyz1234567890`,
+    `${"npm_"}abcdefghijklmnopqrstuvwxyz1234567890`,
+    `${"ya29"}abcdefghijklmnopqrstuvwxyz1234567890`,
+    `sk_${"live"}_abcdefghijklmnopqrstuvwxyz1234567890`,
+  ])("redacts token-shaped finding summaries in the review snapshot panel", async (credential) => {
+    const client = {
+      getCodingAgentRuntimeSummary: jest.fn().mockResolvedValue({
+        ok: true,
+        summary: summaryFixture(),
+      }),
+      getCodingAgentReviews: jest.fn().mockResolvedValue({
+        ok: true,
+        reviews: reviewsFixture(),
+      }),
+      getCodingAgentReviewSnapshot: jest.fn().mockResolvedValue({
+        ok: true,
+        snapshot: reviewSnapshotWithFinding(`Rotate ${credential} before merge.`),
+      }),
+    };
+    useGatewayMock.mockReturnValue(gatewayContext({
+      client: client as unknown as GatewayClient,
+      connectionState: "connected",
+    }));
+
+    render(<AgentsScreen />);
+
+    await screen.findByText("matrix-os");
+    await act(async () => {
+      fireEvent.press(screen.getByLabelText("Open review PR #759"));
+    });
+
+    expect(await screen.findByText("Finding summary hidden for safety.")).toBeTruthy();
+    expect(screen.queryByText(new RegExp(`ghs_|glpat-|npm_|ya29|sk_${"live"}_|token|secret`, "i"))).toBeNull();
+  });
+
+  it("redacts token-shaped review notices and file paths", async () => {
+    const snapshot = {
+      ...reviewSnapshotFixture(),
+      safeNotice: `Rotate ${"ghs_"}abcdefghijklmnopqrstuvwxyz1234567890 before showing details.`,
+      files: {
+        ...reviewSnapshotFixture().files,
+        items: reviewSnapshotFixture().files.items.map((file) => ({
+          ...file,
+          path: `src/${"ghp_"}abcdefghijklmnopqrstuvwxyz1234567890/config.ts`,
+        })),
+      },
+    };
+    const client = {
+      getCodingAgentRuntimeSummary: jest.fn().mockResolvedValue({
+        ok: true,
+        summary: summaryFixture(),
+      }),
+      getCodingAgentReviews: jest.fn().mockResolvedValue({
+        ok: true,
+        reviews: reviewsFixture(),
+      }),
+      getCodingAgentReviewSnapshot: jest.fn().mockResolvedValue({
+        ok: true,
+        snapshot,
+      }),
+    };
+    useGatewayMock.mockReturnValue(gatewayContext({
+      client: client as unknown as GatewayClient,
+      connectionState: "connected",
+    }));
+
+    render(<AgentsScreen />);
+
+    await screen.findByText("matrix-os");
+    await act(async () => {
+      fireEvent.press(screen.getByLabelText("Open review PR #759"));
+    });
+
+    expect(await screen.findByText("Review notice hidden for safety.")).toBeTruthy();
+    expect(screen.getByText("File path hidden for safety.")).toBeTruthy();
+    expect(screen.queryByText(/ghs_|ghp_|token|secret/i)).toBeNull();
+  });
+
+  it("renders duplicate file paths and finding ids without duplicate key warnings", async () => {
+    const consoleError = jest.spyOn(console, "error").mockImplementation(() => undefined);
+    const snapshot = {
+      ...reviewSnapshotFixture(),
+      files: {
+        items: [
+          {
+            path: "packages/gateway/src/coding-agents/routes.ts",
+            status: "modified",
+            additions: 0,
+            deletions: 0,
+            partial: true,
+            hunks: [],
+            findings: [
+              {
+                id: "HIGH-1",
+                severity: "high",
+                line: 42,
+                summary: "First duplicate-key finding.",
+              },
+              {
+                id: "HIGH-1",
+                severity: "high",
+                line: 43,
+                summary: "Second duplicate-key finding.",
+              },
+            ],
+          },
+          {
+            path: "packages/gateway/src/coding-agents/routes.ts",
+            status: "modified",
+            additions: 0,
+            deletions: 0,
+            partial: true,
+            hunks: [],
+            findings: [],
+          },
+        ],
+        hasMore: false,
+        limit: 100,
+      },
+    };
+    const client = {
+      getCodingAgentRuntimeSummary: jest.fn().mockResolvedValue({
+        ok: true,
+        summary: summaryFixture(),
+      }),
+      getCodingAgentReviews: jest.fn().mockResolvedValue({
+        ok: true,
+        reviews: reviewsFixture(),
+      }),
+      getCodingAgentReviewSnapshot: jest.fn().mockResolvedValue({
+        ok: true,
+        snapshot,
+      }),
+    };
+    useGatewayMock.mockReturnValue(gatewayContext({
+      client: client as unknown as GatewayClient,
+      connectionState: "connected",
+    }));
+
+    render(<AgentsScreen />);
+
+    await screen.findByText("matrix-os");
+    await act(async () => {
+      fireEvent.press(screen.getByLabelText("Open review PR #759"));
+    });
+
+    expect(await screen.findByText("First duplicate-key finding.")).toBeTruthy();
+    expect(screen.getByText("Second duplicate-key finding.")).toBeTruthy();
+    expect(screen.getAllByText("packages/gateway/src/coding-agents/routes.ts")).toHaveLength(2);
+    expect(consoleError).not.toHaveBeenCalledWith(expect.stringContaining("Encountered two children with the same key"), expect.anything());
+    consoleError.mockRestore();
+  });
+
+  it("clears loaded review details when runtime summary refresh fails", async () => {
+    const client = {
+      getCodingAgentRuntimeSummary: jest.fn()
+        .mockResolvedValueOnce({
+          ok: true,
+          summary: summaryFixture(),
+        })
+        .mockResolvedValueOnce({
+          ok: false,
+          error: "Runtime summary unavailable",
+        }),
+      getCodingAgentReviews: jest.fn().mockResolvedValue({
+        ok: true,
+        reviews: reviewsFixture(),
+      }),
+      getCodingAgentReviewSnapshot: jest.fn().mockResolvedValue({
+        ok: true,
+        snapshot: reviewSnapshotFixture(),
+      }),
+    };
+    useGatewayMock.mockReturnValue(gatewayContext({
+      client: client as unknown as GatewayClient,
+      connectionState: "connected",
+    }));
+
+    render(<AgentsScreen />);
+
+    await screen.findByText("matrix-os");
+    await act(async () => {
+      fireEvent.press(screen.getByLabelText("Open review PR #759"));
+    });
+    expect(await screen.findByText("Validate ownership before returning snapshots.")).toBeTruthy();
+
+    await act(async () => {
+      screen.getByLabelText("Refresh agent workspace").props.refreshControl.props.onRefresh();
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByText("Validate ownership before returning snapshots.")).toBeNull();
+    });
+    expect(screen.queryByText("packages/gateway/src/coding-agents/routes.ts")).toBeNull();
+    expect(screen.queryByText(/home\/matrix|token|secret/i)).toBeNull();
+  });
+
+  it("does not restore an in-flight review snapshot after refresh removes the review", async () => {
+    const snapshotRequest = deferred<{ ok: true; snapshot: ReturnType<typeof reviewSnapshotFixture> }>();
+    const client = {
+      getCodingAgentRuntimeSummary: jest.fn().mockResolvedValue({
+        ok: true,
+        summary: summaryFixture(),
+      }),
+      getCodingAgentReviews: jest.fn()
+        .mockResolvedValueOnce({
+          ok: true,
+          reviews: reviewsFixture(),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          reviews: { items: [], hasMore: false, limit: 50 },
+        }),
+      getCodingAgentReviewSnapshot: jest.fn(() => snapshotRequest.promise),
+    };
+    useGatewayMock.mockReturnValue(gatewayContext({
+      client: client as unknown as GatewayClient,
+      connectionState: "connected",
+    }));
+
+    render(<AgentsScreen />);
+
+    await screen.findByText("matrix-os");
+    await act(async () => {
+      fireEvent.press(screen.getByLabelText("Open review PR #759"));
+    });
+    expect(await screen.findByText("Loading review details...")).toBeTruthy();
+
+    await act(async () => {
+      screen.getByLabelText("Refresh agent workspace").props.refreshControl.props.onRefresh();
+    });
+    expect(await screen.findByText("No reviews.")).toBeTruthy();
+
+    await act(async () => {
+      snapshotRequest.resolve({ ok: true, snapshot: reviewSnapshotFixture() });
+      await snapshotRequest.promise;
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByText("Validate ownership before returning snapshots.")).toBeNull();
+    });
+    expect(screen.queryByText("packages/gateway/src/coding-agents/routes.ts")).toBeNull();
   });
 
   it("renders a safe error when the runtime summary is unavailable", async () => {

--- a/apps/mobile/__tests__/gateway-client.test.ts
+++ b/apps/mobile/__tests__/gateway-client.test.ts
@@ -6,6 +6,54 @@ import {
 import type { CreateAgentThreadRequest } from "@matrix-os/contracts";
 import { jsonResponse } from "./mobile-shell-test-utils";
 
+function reviewSnapshotPayload(id = "rev_mobile_1") {
+  return {
+    review: {
+      id,
+      projectId: "matrix-os",
+      worktreeId: "wt_abc123def456",
+      status: "reviewing",
+      pullRequestNumber: 757,
+      round: 1,
+      maxRounds: 3,
+      reviewer: "codex",
+      implementer: "claude",
+      findings: {
+        total: 1,
+        high: 1,
+        medium: 0,
+        low: 0,
+      },
+      updatedAt: "2026-07-06T00:00:00.000Z",
+    },
+    files: {
+      items: [
+        {
+          path: "packages/gateway/src/coding-agents/routes.ts",
+          status: "modified",
+          additions: 0,
+          deletions: 0,
+          partial: true,
+          hunks: [],
+          findings: [
+            {
+              id: "HIGH-1",
+              severity: "high",
+              line: 42,
+              summary: "Validate ownership before returning snapshots.",
+            },
+          ],
+        },
+      ],
+      hasMore: false,
+      limit: 100,
+    },
+    partial: true,
+    safeNotice: "Diff content is not available yet. Showing bounded review findings.",
+    updatedAt: "2026-07-06T00:00:00.000Z",
+  };
+}
+
 describe("GatewayClient", () => {
   it("initializes with disconnected state", () => {
     const client = new GatewayClient("http://localhost:4000");
@@ -337,6 +385,138 @@ describe("GatewayClient", () => {
         signal: expect.any(Object),
       }),
     );
+
+    fetchMock.mockRestore();
+  });
+
+  it("fetches coding agent review snapshots with the existing auth header", async () => {
+    const snapshot = {
+      review: {
+        id: "rev_mobile_1",
+        projectId: "matrix-os",
+        worktreeId: "wt_abc123def456",
+        status: "reviewing",
+        pullRequestNumber: 757,
+        round: 1,
+        maxRounds: 3,
+        reviewer: "codex",
+        implementer: "claude",
+        findings: {
+          total: 1,
+          high: 1,
+          medium: 0,
+          low: 0,
+        },
+        updatedAt: "2026-07-06T00:00:00.000Z",
+      },
+      files: {
+        items: [
+          {
+            path: "packages/gateway/src/coding-agents/routes.ts",
+            status: "modified",
+            additions: 0,
+            deletions: 0,
+            partial: true,
+            hunks: [],
+            findings: [
+              {
+                id: "HIGH-1",
+                severity: "high",
+                line: 42,
+                summary: "Validate ownership before returning snapshots.",
+              },
+            ],
+          },
+        ],
+        hasMore: false,
+        limit: 100,
+      },
+      partial: true,
+      safeNotice: "Diff content is not available yet. Showing bounded review findings.",
+      updatedAt: "2026-07-06T00:00:00.000Z",
+    };
+    const fetchMock = jest.spyOn(global, "fetch").mockResolvedValue(jsonResponse(snapshot));
+
+    const client = new GatewayClient("http://localhost:4000", "token");
+    await expect(client.getCodingAgentReviewSnapshot({ reviewId: "rev_mobile_1" })).resolves.toEqual({
+      ok: true,
+      snapshot,
+    });
+    expect(fetchMock).toHaveBeenCalledWith("http://localhost:4000/api/coding-agents/reviews/rev_mobile_1", expect.objectContaining({
+      headers: expect.objectContaining({
+        Authorization: "Bearer token",
+        "Content-Type": "application/json",
+      }),
+      signal: expect.any(Object),
+    }));
+
+    fetchMock.mockRestore();
+  });
+
+  it("accepts contract-valid review references when fetching snapshots", async () => {
+    const snapshot = {
+      ...reviewSnapshotPayload(),
+      review: {
+        ...reviewSnapshotPayload().review,
+        id: "rev_mobile:round.2",
+      },
+    };
+    const fetchMock = jest.spyOn(global, "fetch").mockResolvedValue(jsonResponse(snapshot));
+
+    const client = new GatewayClient("http://localhost:4000", "token");
+    await expect(client.getCodingAgentReviewSnapshot({ reviewId: "rev_mobile:round.2" })).resolves.toEqual({
+      ok: true,
+      snapshot,
+    });
+    expect(fetchMock).toHaveBeenCalledWith(
+      "http://localhost:4000/api/coding-agents/reviews/rev_mobile%3Around.2",
+      expect.any(Object),
+    );
+
+    fetchMock.mockRestore();
+  });
+
+  it("returns a safe mobile review details error for invalid gateway payloads", async () => {
+    const fetchMock = jest.spyOn(global, "fetch").mockResolvedValueOnce(jsonResponse({
+      review: {
+        id: "rev_mobile_1",
+        projectId: "matrix-os",
+        worktreeId: "wt_abc123def456",
+        status: "reviewing",
+        pullRequestNumber: 757,
+        round: 1,
+        maxRounds: 3,
+        reviewer: "codex",
+        implementer: "claude",
+        updatedAt: "2026-07-06T00:00:00.000Z",
+      },
+      files: {
+        items: [
+          {
+            path: "/home/matrix/private/secret.ts",
+            status: "modified",
+            additions: 0,
+            deletions: 0,
+            partial: true,
+            hunks: [],
+          },
+        ],
+        hasMore: false,
+        limit: 100,
+      },
+      partial: true,
+      updatedAt: "2026-07-06T00:00:00.000Z",
+    }));
+
+    const client = new GatewayClient("http://localhost:4000", "token");
+    await expect(client.getCodingAgentReviewSnapshot({ reviewId: "rev_mobile_1" })).resolves.toEqual({
+      ok: false,
+      error: "Review details unavailable",
+    });
+    await expect(client.getCodingAgentReviewSnapshot({ reviewId: "../secret" })).resolves.toEqual({
+      ok: false,
+      error: "Review details unavailable",
+    });
 
     fetchMock.mockRestore();
   });

--- a/apps/mobile/app/agents/index.tsx
+++ b/apps/mobile/app/agents/index.tsx
@@ -3,7 +3,7 @@ import { ActivityIndicator, Pressable, RefreshControl, ScrollView, Text, View } 
 import { Ionicons } from "@expo/vector-icons";
 import { useRouter } from "expo-router";
 import { StyleSheet, useUnistyles } from "react-native-unistyles";
-import type { ReviewSummary, RuntimeSummary } from "@matrix-os/contracts";
+import type { ReviewSnapshot, ReviewSummary, RuntimeSummary } from "@matrix-os/contracts";
 import { useGateway } from "@/app/_layout";
 import { CODING_AGENTS_MOBILE_WORKSPACE } from "@/lib/feature-flags";
 
@@ -22,8 +22,35 @@ type ReviewState =
 
 const INITIAL_REVIEW_STATE: ReviewState = { status: "idle", reviews: null, error: null };
 
+type ReviewSnapshotState =
+  | { status: "idle"; selectedReviewId: null; snapshot: null; error: null }
+  | { status: "loading"; selectedReviewId: string; snapshot: null; error: null }
+  | { status: "ready"; selectedReviewId: string; snapshot: ReviewSnapshot; error: null }
+  | { status: "error"; selectedReviewId: string; snapshot: null; error: "Review details unavailable" };
+
+const INITIAL_REVIEW_SNAPSHOT_STATE: ReviewSnapshotState = {
+  status: "idle",
+  selectedReviewId: null,
+  snapshot: null,
+  error: null,
+};
+
+const SECRET_LIKE_FINDING_TEXT =
+  /(gh[psuor]_[A-Za-z0-9_]{20,}|github_pat_[A-Za-z0-9_]{20,}|glpat-[A-Za-z0-9_-]{20,}|npm_[A-Za-z0-9_]{20,}|ya29[A-Za-z0-9._-]{20,}|xox[baprs]-[A-Za-z0-9-]{10,}|(?:A3T|AKIA|ASIA)[A-Z0-9]{16}|bearer\s+[A-Za-z0-9._-]{12,}|sk(?:_live|_test)?[_-][A-Za-z0-9_-]{16,})/i;
+const HIDDEN_FINDING_SUMMARY = "Finding summary hidden for safety.";
+const HIDDEN_REVIEW_NOTICE = "Review notice hidden for safety.";
+const HIDDEN_FILE_PATH = "File path hidden for safety.";
+
 function capabilityEnabled(summary: RuntimeSummary, id: string): boolean {
   return summary.capabilities.some((capability) => capability.id === id && capability.enabled);
+}
+
+function safeFindingSummary(summary: string): string {
+  return SECRET_LIKE_FINDING_TEXT.test(summary) ? HIDDEN_FINDING_SUMMARY : summary;
+}
+
+function safeSnapshotText(value: string, fallback: string): string {
+  return SECRET_LIKE_FINDING_TEXT.test(value) ? fallback : value;
 }
 
 export default function AgentsScreen() {
@@ -32,8 +59,58 @@ export default function AgentsScreen() {
   const { client } = useGateway();
   const [state, setState] = useState<ScreenState>(INITIAL_STATE);
   const [reviewState, setReviewState] = useState<ReviewState>(INITIAL_REVIEW_STATE);
+  const [reviewSnapshotState, setReviewSnapshotState] = useState<ReviewSnapshotState>(INITIAL_REVIEW_SNAPSHOT_STATE);
   const [refreshing, setRefreshing] = useState(false);
   const requestGeneration = useRef(0);
+  const reviewSnapshotGeneration = useRef(0);
+  const selectedReviewIdRef = useRef<string | null>(null);
+
+  const clearReviewSnapshot = useCallback(() => {
+    reviewSnapshotGeneration.current += 1;
+    selectedReviewIdRef.current = null;
+    setReviewSnapshotState(INITIAL_REVIEW_SNAPSHOT_STATE);
+  }, []);
+
+  const loadReviewSnapshot = useCallback(async (reviewId: string) => {
+    if (!client) {
+      selectedReviewIdRef.current = reviewId;
+      setReviewSnapshotState({
+        status: "error",
+        selectedReviewId: reviewId,
+        snapshot: null,
+        error: "Review details unavailable",
+      });
+      return;
+    }
+    const generation = reviewSnapshotGeneration.current + 1;
+    reviewSnapshotGeneration.current = generation;
+    selectedReviewIdRef.current = reviewId;
+    setReviewSnapshotState({
+      status: "loading",
+      selectedReviewId: reviewId,
+      snapshot: null,
+      error: null,
+    });
+    const result = await client.getCodingAgentReviewSnapshot({ reviewId });
+    if (generation !== reviewSnapshotGeneration.current) return;
+    if (result.ok) {
+      selectedReviewIdRef.current = reviewId;
+      setReviewSnapshotState({
+        status: "ready",
+        selectedReviewId: reviewId,
+        snapshot: result.snapshot,
+        error: null,
+      });
+      return;
+    }
+    selectedReviewIdRef.current = reviewId;
+    setReviewSnapshotState({
+      status: "error",
+      selectedReviewId: reviewId,
+      snapshot: null,
+      error: "Review details unavailable",
+    });
+  }, [client]);
 
   const loadSummary = useCallback(async () => {
     const generation = requestGeneration.current + 1;
@@ -41,11 +118,13 @@ export default function AgentsScreen() {
     if (!CODING_AGENTS_MOBILE_WORKSPACE) {
       setState({ status: "error", summary: null, error: "Runtime summary unavailable" });
       setReviewState(INITIAL_REVIEW_STATE);
+      clearReviewSnapshot();
       return;
     }
     if (!client) {
       setState({ status: "error", summary: null, error: "Runtime summary unavailable" });
       setReviewState(INITIAL_REVIEW_STATE);
+      clearReviewSnapshot();
       return;
     }
     const result = await client.getCodingAgentRuntimeSummary();
@@ -54,6 +133,7 @@ export default function AgentsScreen() {
       setState({ status: "ready", summary: result.summary, error: null });
       if (!capabilityEnabled(result.summary, "codingAgentsReview")) {
         setReviewState(INITIAL_REVIEW_STATE);
+        clearReviewSnapshot();
         return;
       }
       setReviewState((current) => (current.reviews ? current : { status: "loading", reviews: null, error: null }));
@@ -61,14 +141,23 @@ export default function AgentsScreen() {
       if (generation !== requestGeneration.current) return;
       if (reviewsResult.ok) {
         setReviewState({ status: "ready", reviews: reviewsResult.reviews, error: null });
+        const selectedReviewId = selectedReviewIdRef.current;
+        if (!selectedReviewId) return;
+        if (reviewsResult.reviews.items.some((review) => review.id === selectedReviewId)) {
+          void loadReviewSnapshot(selectedReviewId);
+          return;
+        }
+        clearReviewSnapshot();
         return;
       }
       setReviewState({ status: "error", reviews: null, error: "Review state unavailable" });
+      clearReviewSnapshot();
       return;
     }
     setState({ status: "error", summary: null, error: "Runtime summary unavailable" });
     setReviewState(INITIAL_REVIEW_STATE);
-  }, [client]);
+    clearReviewSnapshot();
+  }, [clearReviewSnapshot, client, loadReviewSnapshot]);
 
   useEffect(() => {
     setState((current) => (current.summary ? current : INITIAL_STATE));
@@ -83,6 +172,10 @@ export default function AgentsScreen() {
       setRefreshing(false);
     }
   }, [loadSummary]);
+
+  const selectReview = useCallback((reviewId: string) => {
+    void loadReviewSnapshot(reviewId);
+  }, [loadReviewSnapshot]);
 
   if (state.status === "loading") {
     return (
@@ -112,6 +205,7 @@ export default function AgentsScreen() {
     <ScrollView
       style={styles.container}
       contentContainerStyle={styles.content}
+      accessibilityLabel="Refresh agent workspace"
       refreshControl={<RefreshControl refreshing={refreshing} onRefresh={onRefresh} tintColor={theme.colors.forest} />}
     >
       <View style={styles.header}>
@@ -183,7 +277,13 @@ export default function AgentsScreen() {
         ))}
       </Section>
 
-      {capabilityEnabled(summary, "codingAgentsReview") ? <ReviewSection state={reviewState} /> : null}
+      {capabilityEnabled(summary, "codingAgentsReview") ? (
+        <ReviewSection
+          state={reviewState}
+          snapshotState={reviewSnapshotState}
+          onSelectReview={selectReview}
+        />
+      ) : null}
     </ScrollView>
   );
 }
@@ -192,7 +292,15 @@ function reviewStatusLabel(status: ReviewSummary["status"]): string {
   return status.replace(/_/g, " ");
 }
 
-function ReviewSection({ state }: { state: ReviewState }) {
+function ReviewSection({
+  state,
+  snapshotState,
+  onSelectReview,
+}: {
+  state: ReviewState;
+  snapshotState: ReviewSnapshotState;
+  onSelectReview: (reviewId: string) => void;
+}) {
   const { theme } = useUnistyles();
   const items = state.reviews?.items ?? [];
 
@@ -201,7 +309,16 @@ function ReviewSection({ state }: { state: ReviewState }) {
       {state.status === "error" ? <Text style={styles.reviewError}>{state.error}</Text> : null}
       {items.length === 0 && state.status !== "loading" && state.status !== "error" ? <EmptyText>No reviews.</EmptyText> : null}
       {items.map((review) => (
-        <View key={review.id} style={styles.row}>
+        <Pressable
+          key={review.id}
+          accessibilityRole="button"
+          accessibilityLabel={`Open review PR #${review.pullRequestNumber}`}
+          onPress={() => onSelectReview(review.id)}
+          style={[
+            styles.row,
+            snapshotState.selectedReviewId === review.id ? styles.selectedReviewRow : null,
+          ]}
+        >
           <View style={styles.rowIcon}>
             <Ionicons name="checkmark-done-outline" size={18} color={theme.colors.moss} />
           </View>
@@ -217,9 +334,69 @@ function ReviewSection({ state }: { state: ReviewState }) {
               </Text>
             ) : null}
           </View>
+        </Pressable>
+      ))}
+      <ReviewSnapshotPanel state={snapshotState} />
+    </Section>
+  );
+}
+
+function ReviewSnapshotPanel({ state }: { state: ReviewSnapshotState }) {
+  const { theme } = useUnistyles();
+  if (state.status === "idle") return null;
+  if (state.status === "loading") {
+    return <Text style={styles.reviewDetailNotice}>Loading review details...</Text>;
+  }
+  if (state.status === "error") {
+    return <Text style={styles.reviewError}>{state.error}</Text>;
+  }
+
+  return (
+    <View style={styles.reviewDetailPanel}>
+      <View style={styles.reviewDetailHeader}>
+        <View style={styles.rowText}>
+          <Text style={styles.rowTitle}>{`PR #${state.snapshot.review.pullRequestNumber} review details`}</Text>
+          <Text style={styles.rowSubtitle}>{`${state.snapshot.files.items.length} files${state.snapshot.partial ? " - partial" : ""}`}</Text>
+        </View>
+        <Text style={styles.rowMeta}>{reviewStatusLabel(state.snapshot.review.status)}</Text>
+      </View>
+      {state.snapshot.safeNotice ? (
+        <Text style={styles.reviewDetailNotice}>{safeSnapshotText(state.snapshot.safeNotice, HIDDEN_REVIEW_NOTICE)}</Text>
+      ) : null}
+      {state.snapshot.files.items.map((file, fileIndex) => (
+        <View key={`${file.path}:${fileIndex}`} style={styles.reviewFileRow}>
+          <View style={styles.reviewDetailHeader}>
+            <View style={styles.rowIcon}>
+              <Ionicons name="document-text-outline" size={17} color={theme.colors.moss} />
+            </View>
+            <View style={styles.rowText}>
+              <Text
+                selectable={!SECRET_LIKE_FINDING_TEXT.test(file.path)}
+                style={styles.rowTitle}
+              >
+                {safeSnapshotText(file.path, HIDDEN_FILE_PATH)}
+              </Text>
+              <Text style={styles.rowSubtitle}>{file.status}</Text>
+            </View>
+          </View>
+          {file.findings?.length ? (
+            file.findings.map((finding, findingIndex) => (
+              <Text
+                key={`${finding.id}:${finding.line}:${findingIndex}`}
+                style={[
+                  styles.reviewFinding,
+                  finding.severity === "high" ? styles.reviewHighActive : null,
+                ]}
+              >
+                {safeFindingSummary(finding.summary)}
+              </Text>
+            ))
+          ) : (
+            <Text style={styles.rowSubtitle}>No findings in this file.</Text>
+          )}
         </View>
       ))}
-    </Section>
+    </View>
   );
 }
 
@@ -364,6 +541,9 @@ const styles = StyleSheet.create((theme, rt) => ({
     alignItems: "center",
     gap: theme.spacing.sm,
   },
+  selectedReviewRow: {
+    borderColor: theme.colors.forest,
+  },
   rowIcon: {
     width: 34,
     height: 34,
@@ -416,6 +596,46 @@ const styles = StyleSheet.create((theme, rt) => ({
     padding: theme.spacing.md,
     fontFamily: theme.fonts.sans,
     color: theme.colors.destructive,
+  },
+  reviewDetailPanel: {
+    borderRadius: 14,
+    borderCurve: "continuous" as const,
+    borderWidth: 1,
+    borderColor: theme.colors.border,
+    backgroundColor: theme.colors.card,
+    padding: theme.spacing.md,
+    gap: theme.spacing.sm,
+  },
+  reviewDetailHeader: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    gap: theme.spacing.sm,
+  },
+  reviewDetailNotice: {
+    borderRadius: 12,
+    borderCurve: "continuous" as const,
+    borderWidth: 1,
+    borderColor: theme.colors.border,
+    backgroundColor: theme.colors.secondary,
+    padding: theme.spacing.sm,
+    fontFamily: theme.fonts.sans,
+    fontSize: 12,
+    color: theme.colors.mutedForeground,
+  },
+  reviewFileRow: {
+    borderRadius: 12,
+    borderCurve: "continuous" as const,
+    borderWidth: 1,
+    borderColor: theme.colors.border,
+    backgroundColor: theme.colors.secondary,
+    padding: theme.spacing.sm,
+    gap: theme.spacing.xs,
+  },
+  reviewFinding: {
+    fontFamily: theme.fonts.sans,
+    fontSize: 12,
+    color: theme.colors.mutedForeground,
   },
   emptyText: {
     borderRadius: 14,

--- a/apps/mobile/lib/gateway-client.ts
+++ b/apps/mobile/lib/gateway-client.ts
@@ -7,9 +7,11 @@ import {
 import {
   AgentThreadSnapshotSchema,
   CursorSchema,
+  ReviewSnapshotSchema,
   ReviewSummarySchema,
   RuntimeSummarySchema,
   type CreateAgentThreadRequest,
+  type ReviewSnapshot,
   type RuntimeSummary,
   boundedListSchema,
 } from "@matrix-os/contracts";
@@ -91,6 +93,10 @@ export type CodingAgentReviewsResult =
   | { ok: true; reviews: z.infer<typeof CodingAgentReviewListSchema> }
   | { ok: false; error: "Review state unavailable" };
 
+export type CodingAgentReviewSnapshotResult =
+  | { ok: true; snapshot: ReviewSnapshot }
+  | { ok: false; error: "Review details unavailable" };
+
 type ClientMessage =
   | { type: "message"; text: string; sessionId?: string }
   | { type: "switch_session"; sessionId: string }
@@ -109,6 +115,7 @@ type ReactNativeWebSocketConstructor = new (
 const RECONNECT_BASE_MS = 1000;
 const RECONNECT_MAX_MS = 30000;
 export const DEFAULT_GATEWAY_FETCH_TIMEOUT_MS = 10_000;
+const SAFE_REVIEW_REFERENCE = /^[A-Za-z0-9][A-Za-z0-9_.:-]{0,127}$/;
 const SECURE_TOKEN_TRANSPORT_ERROR =
   "Matrix OS Cloud requires HTTPS/WSS.";
 const CLEARTEXT_HOST_ERROR =
@@ -588,6 +595,32 @@ export class GatewayClient {
     } catch {
       console.warn("[mobile] /api/coding-agents/reviews unavailable");
       return { ok: false, error: "Review state unavailable" };
+    }
+  }
+
+  async getCodingAgentReviewSnapshot(
+    options: { reviewId: string },
+  ): Promise<CodingAgentReviewSnapshotResult> {
+    try {
+      if (!SAFE_REVIEW_REFERENCE.test(options.reviewId) || options.reviewId.includes("..")) {
+        return { ok: false, error: "Review details unavailable" };
+      }
+      const res = await this.fetchGateway(`/api/coding-agents/reviews/${encodeURIComponent(options.reviewId)}`);
+      if (!res.ok) {
+        console.warn("[mobile] /api/coding-agents/reviews/:reviewId unavailable", res.status);
+        return { ok: false, error: "Review details unavailable" };
+      }
+      const body = await res.json();
+      const parsed = ReviewSnapshotSchema.safeParse(body);
+      if (!parsed.success) {
+        console.warn("[mobile] /api/coding-agents/reviews/:reviewId returned invalid payload");
+        return { ok: false, error: "Review details unavailable" };
+      }
+      return { ok: true, snapshot: parsed.data };
+    } catch (err: unknown) {
+      const reason = err instanceof Error && err.name === "AbortError" ? "aborted" : "unavailable";
+      console.warn(`[mobile] /api/coding-agents/reviews/:reviewId ${reason}`);
+      return { ok: false, error: "Review details unavailable" };
     }
   }
 

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -68,6 +68,7 @@ export const ApprovalIdSchema = prefixedId("appr_");
 export const RequestIdSchema = prefixedId("req_");
 export const CorrelationIdSchema = prefixedId("corr_");
 export const TerminalSessionIdSchema = referenceId(128);
+export const ReviewIdSchema = referenceId(128);
 export const WorktreeIdSchema = z.string().regex(/^wt_[a-z0-9]{12,40}$/, "Invalid worktree id");
 export const CursorSchema = referenceId(160);
 export const IsoTimestampSchema = z.string().regex(ISO_DATETIME, "Invalid ISO timestamp");
@@ -395,7 +396,7 @@ export const AgentThreadEventSchema = z.discriminatedUnion("type", [
   }).strict(),
   BaseThreadEventSchema.extend({
     type: z.literal("review.ready"),
-    reviewId: referenceId(128),
+    reviewId: ReviewIdSchema,
     summary: z.object({
       changedFileCount: z.number().int().min(0).max(10_000),
       additions: z.number().int().min(0).max(1_000_000),
@@ -675,7 +676,7 @@ export const ReviewSnapshotFileSchema = ReviewFileDiffSchema.extend({
 }).strict();
 
 export const ReviewSummarySchema = z.object({
-  id: referenceId(128),
+  id: ReviewIdSchema,
   projectId: ProjectIdSchema,
   worktreeId: WorktreeIdSchema,
   status: z.enum([

--- a/packages/gateway/src/coding-agents/routes.ts
+++ b/packages/gateway/src/coding-agents/routes.ts
@@ -13,6 +13,7 @@ import {
   UserInputAnswerRequestSchema,
   boundedListSchema,
   AgentThreadSummarySchema,
+  ReviewIdSchema,
   ReviewSnapshotSchema,
   ReviewSummarySchema,
 } from "@matrix-os/contracts";
@@ -51,7 +52,6 @@ const AbortThreadBodySchema = z.object({
 
 const ThreadListSchema = boundedListSchema(AgentThreadSummarySchema, 50);
 const ReviewListSchema = boundedListSchema(ReviewSummarySchema, 50);
-const ReviewIdSchema = z.string().regex(/^rev_[A-Za-z0-9_-]{1,128}$/);
 
 function summaryUnavailable() {
   return SafeClientErrorSchema.parse({

--- a/packages/gateway/src/review-store.ts
+++ b/packages/gateway/src/review-store.ts
@@ -1,6 +1,7 @@
 import { readdir } from "node:fs/promises";
 import { join, resolve } from "node:path";
 import { z } from "zod/v4";
+import { ReviewIdSchema } from "@matrix-os/contracts";
 import type { WorkspaceError } from "./project-manager.js";
 import { atomicWriteJson, readJsonFile } from "./state-ops.js";
 import type { ReviewLoopRecord } from "./review-loop.js";
@@ -11,7 +12,6 @@ type Failure = {
   error: WorkspaceError;
 };
 
-const ReviewIdSchema = z.string().regex(/^rev_[A-Za-z0-9_-]{1,128}$/);
 const ListReviewsSchema = z.object({
   projectSlug: z.string().min(1).max(63).optional(),
   limit: z.number().int().min(1).max(100).optional(),

--- a/tests/gateway/coding-agents-summary.test.ts
+++ b/tests/gateway/coding-agents-summary.test.ts
@@ -494,6 +494,45 @@ describe("coding agent runtime summary", () => {
     expect(JSON.stringify(body)).not.toMatch(/\/home\/matrix|Postgres|token|secret/i);
   });
 
+  it("accepts contract-valid encoded review references for snapshots", async () => {
+    const requestedReviewIds: string[] = [];
+    const app = new Hono();
+    app.route("/api/coding-agents", createCodingAgentRoutes({
+      service: { getSummary: vi.fn() },
+      reviews: {
+        listReviews: async () => ({ items: [], hasMore: false, limit: 50 }),
+        getReviewSnapshot: async (_principal, reviewId) => {
+          requestedReviewIds.push(reviewId);
+          return ReviewSnapshotSchema.parse({
+            review: {
+              id: reviewId,
+              projectId: "matrix-os",
+              worktreeId: "wt_abc123def456",
+              status: "reviewing",
+              pullRequestNumber: 758,
+              round: 1,
+              maxRounds: 3,
+              reviewer: "codex",
+              implementer: "claude",
+              updatedAt: now.toISOString(),
+            },
+            files: { items: [], hasMore: false, limit: 100 },
+            partial: false,
+            updatedAt: now.toISOString(),
+          });
+        },
+      },
+      getPrincipal: () => testPrincipal,
+    }));
+
+    const res = await app.request("/api/coding-agents/reviews/rev_mobile%3Around.2");
+
+    expect(res.status).toBe(200);
+    expect(requestedReviewIds).toEqual(["rev_mobile:round.2"]);
+    const body = ReviewSnapshotSchema.parse(await res.json());
+    expect(body.review.id).toBe("rev_mobile:round.2");
+  });
+
   it("maps missing review snapshots to a stable safe not-found response", async () => {
     const app = new Hono();
     app.route("/api/coding-agents", createCodingAgentRoutes({

--- a/tests/gateway/review-store.test.ts
+++ b/tests/gateway/review-store.test.ts
@@ -54,6 +54,23 @@ describe("review-store", () => {
     });
   });
 
+  it("persists contract-valid review references with dots and colons", async () => {
+    const store = createReviewStore({ homePath });
+    const reviewId = "rev_mobile:round.2";
+
+    await expect(store.saveReview(record(reviewId))).resolves.toEqual({ ok: true });
+
+    const path = join(homePath, "system", "reviews", `${reviewId}.json`);
+    await expect(stat(path)).resolves.toMatchObject({ isFile: expect.any(Function) });
+    await expect(store.getReview(reviewId)).resolves.toMatchObject({
+      ok: true,
+      review: { id: reviewId, status: "queued" },
+    });
+    await expect(store.listReviews({ limit: 1, cursor: reviewId })).resolves.toMatchObject({
+      ok: true,
+    });
+  });
+
   it("lists review records sorted by updated time and supports project filters", async () => {
     const store = createReviewStore({ homePath });
     await store.saveReview(record("rev_older"));


### PR DESCRIPTION
## Summary

- Adds a mobile gateway client method for bounded coding-agent review snapshots using the shared Matrix contracts.
- Adds a read-only mobile review details panel behind the existing coding-agent workspace flag.
- Clears stale review details when review summaries disappear, refresh fails, or an in-flight snapshot resolves after the selected review is gone.
- Aligns review ID validation across shared contracts, gateway routes, and the owner-file review store.

## Base / Rebase

- PR #733 is merged into `main`; local `main` is up to date at `f8fcc47359`.
- This branch is stacked above `105-coding-agent-desktop-review-snapshot`; `origin/main` is an ancestor of the stack head, so no SDK 57 conflict rebase was required.

## Tests

- `pnpm --filter matrix-os-mobile run test -- gateway-client.test.ts agents-screen.test.tsx`
- `bun run test -- tests/contracts/coding-agents.test.ts tests/gateway/review-store.test.ts tests/gateway/coding-agents-summary.test.ts`
- `pnpm --filter matrix-os-mobile exec tsc --noEmit`
- `pnpm --filter matrix-os-mobile run lint`
- `bun run check:patterns`
- `bun run typecheck`
- `git diff --check`
- Changed-file private-reference wording scan

Not run:

- `vp check` / `vp run typecheck` because `vp` is not available on PATH in this environment.

## Invariants

- Source of truth: gateway/runtime contracts remain authoritative; mobile only hydrates read-only snapshots.
- Persistence: no new mobile persistence and no AsyncStorage writes.
- Lock/transaction scope: no mutating route, DB write, or file write in this slice.
- Auth source of truth: the existing authenticated `GatewayClient` path is reused; no bearer or provider credentials are exposed to UI state.
- Safe errors: invalid IDs, unavailable routes, and invalid payloads collapse to generic mobile recovery errors.
- Deferred scope: public docs remain deferred to the broader coding-agent shell docs slice because this is an internal stacked read-only mobile UI increment.
