### PR TITLE
feat(gateway): add coding agent review diff metadata

### DIFF
--- a/packages/gateway/src/coding-agents/review-summary.ts
+++ b/packages/gateway/src/coding-agents/review-summary.ts
@@ -5,7 +5,10 @@ import {
   type ReviewSnapshot,
   type ReviewSummary,
 } from "@matrix-os/contracts";
+import { execFile } from "node:child_process";
+import { access } from "node:fs/promises";
 import { resolve, sep } from "node:path";
+import { promisify } from "node:util";
 import type { RequestPrincipal } from "../request-principal.js";
 import type { ReviewLoopRecord } from "../review-loop.js";
 import {
@@ -20,8 +23,22 @@ const RAW_REVIEW_SCAN_LIMIT = 100;
 const MAX_REVIEW_SCAN_PAGES = 5;
 const REVIEW_SNAPSHOT_FILE_LIMIT = 100;
 const REVIEW_SNAPSHOT_FINDINGS_PER_FILE_LIMIT = 100;
+const REVIEW_DIFF_OUTPUT_BYTES = 256 * 1024;
+const REVIEW_DIFF_TIMEOUT_MS = 5_000;
+
+const execFileAsync = promisify(execFile);
 
 type ReviewSnapshotErrorCode = "review_not_found" | "review_state_unavailable";
+type ReviewSnapshotFile = ReviewSnapshot["files"]["items"][number];
+type ReviewDiffReadResult = {
+  ok: true;
+  files: ReviewSnapshotFile[];
+  hasMore: boolean;
+  partial: boolean;
+} | {
+  ok: false;
+};
+type ReviewDiffReader = (worktreeRoot: string) => Promise<ReviewDiffReadResult>;
 
 export class CodingAgentReviewSnapshotError extends Error {
   constructor(public readonly code: ReviewSnapshotErrorCode) {
@@ -133,6 +150,297 @@ function safeFindingsPath(input: { homePath?: string; review: ReviewLoopRecord; 
   return resolved.startsWith(`${worktreeRoot}${sep}`) ? resolved : null;
 }
 
+function safeWorktreeRoot(input: { homePath?: string; review: ReviewLoopRecord }): string | null {
+  if (!input.homePath) return null;
+  const safeProject = /^[A-Za-z0-9][A-Za-z0-9_-]{0,62}$/.test(input.review.projectSlug);
+  const safeWorktree = /^wt_[A-Za-z0-9_-]{1,128}$/.test(input.review.worktreeId);
+  if (!safeProject || !safeWorktree) return null;
+  return resolve(input.homePath, "projects", input.review.projectSlug, "worktrees", input.review.worktreeId);
+}
+
+function hunkIdFor(path: string, index: number): string {
+  return `hunk_${path.replace(/[^A-Za-z0-9_-]+/g, "_").slice(0, 96)}_${index}`;
+}
+
+function parseRangeStart(value: string | undefined): number {
+  const parsed = Number.parseInt(value ?? "0", 10);
+  return Number.isSafeInteger(parsed) && parsed >= 0 ? parsed : 0;
+}
+
+function parseRangeLines(value: string | undefined): number {
+  if (value === undefined) return 1;
+  const parsed = Number.parseInt(value, 10);
+  return Number.isSafeInteger(parsed) && parsed >= 0 ? parsed : 0;
+}
+
+function readGitPathToken(input: string, startIndex = 0): { token: string; nextIndex: number } | null {
+  let index = startIndex;
+  while (input[index] === " ") index += 1;
+  if (index >= input.length) return null;
+  if (input[index] !== '"') {
+    const end = input.indexOf(" ", index);
+    const nextIndex = end === -1 ? input.length : end;
+    return { token: input.slice(index, nextIndex), nextIndex };
+  }
+
+  index += 1;
+  let token = "";
+  while (index < input.length) {
+    const char = input[index]!;
+    if (char === '"') {
+      return { token, nextIndex: index + 1 };
+    }
+    if (char !== "\\") {
+      token += char;
+      index += 1;
+      continue;
+    }
+    const escaped = input[index + 1];
+    if (!escaped) return null;
+    if (/[0-7]/.test(escaped)) {
+      const octal = input.slice(index + 1, index + 4).match(/^[0-7]{1,3}/)?.[0] ?? escaped;
+      token += String.fromCharCode(Number.parseInt(octal, 8));
+      index += 1 + octal.length;
+      continue;
+    }
+    token += escaped === "t" ? "\t" : escaped === "n" ? "\n" : escaped;
+    index += 2;
+  }
+  return null;
+}
+
+function cleanGitPathToken(token: string, options: { stripTabMetadata?: boolean } = {}): string {
+  const value = options.stripTabMetadata ? token.split("\t")[0] ?? token : token;
+  return value.startsWith("a/") || value.startsWith("b/")
+    ? value.slice(2)
+    : value;
+}
+
+function parseDiffGitHeader(line: string): { oldPath: string; newPath: string } | null {
+  if (!line.startsWith("diff --git ")) return null;
+  const rest = line.slice("diff --git ".length);
+  if (rest.startsWith("a/")) {
+    const candidates: Array<{ oldPath: string; newPath: string }> = [];
+    let separator = rest.indexOf(" b/");
+    while (separator !== -1) {
+      const oldRaw = rest.slice(0, separator);
+      const newRaw = rest.slice(separator + 1);
+      if (oldRaw.startsWith("a/") && newRaw.startsWith("b/")) {
+        candidates.push({
+          oldPath: cleanGitPathToken(oldRaw),
+          newPath: cleanGitPathToken(newRaw),
+        });
+      }
+      separator = rest.indexOf(" b/", separator + 1);
+    }
+    return candidates.find((candidate) => candidate.oldPath === candidate.newPath)
+      ?? candidates[candidates.length - 1]
+      ?? null;
+  }
+  const oldToken = readGitPathToken(rest);
+  if (!oldToken) return null;
+  const newToken = readGitPathToken(rest, oldToken.nextIndex);
+  if (!newToken) return null;
+  return {
+    oldPath: cleanGitPathToken(oldToken.token),
+    newPath: cleanGitPathToken(newToken.token),
+  };
+}
+
+function markDiffReadResultPartial(result: ReviewDiffReadResult): ReviewDiffReadResult {
+  if (!result.ok) return result;
+  return {
+    ...result,
+    files: result.files.map((file) => ({ ...file, partial: true })),
+    hasMore: true,
+    partial: true,
+  };
+}
+
+function parseDiffFileMarker(line: string, marker: "--- " | "+++ "): string | null {
+  if (!line.startsWith(marker)) return null;
+  const raw = line.slice(marker.length);
+  if (raw.startsWith('"')) {
+    const token = readGitPathToken(raw);
+    if (!token || token.token === "/dev/null") return null;
+    return cleanGitPathToken(token.token);
+  }
+  if (raw === "/dev/null") return null;
+  return cleanGitPathToken(raw, { stripTabMetadata: true });
+}
+
+function parseUnifiedDiff(stdout: string): ReviewDiffReadResult {
+  const files: ReviewSnapshotFile[] = [];
+  let current: {
+    path: string;
+    status: ReviewSnapshotFile["status"];
+    additions: number;
+    deletions: number;
+    hunks: ReviewSnapshotFile["hunks"];
+    partial: boolean;
+  } | null = null;
+  let hasMore = false;
+
+  const pushCurrent = () => {
+    if (!current) return;
+    const parsed = ReviewSnapshotFileSchema.safeParse({
+      path: current.path,
+      status: current.status,
+      additions: current.additions,
+      deletions: current.deletions,
+      partial: current.partial,
+      hunks: current.hunks.slice(0, 100),
+    });
+    if (!parsed.success) {
+      current = null;
+      return;
+    }
+    if (files.length >= REVIEW_SNAPSHOT_FILE_LIMIT) {
+      hasMore = true;
+      current = null;
+      return;
+    }
+    files.push(parsed.data);
+    current = null;
+  };
+
+  for (const line of stdout.split("\n")) {
+    const diffHeader = parseDiffGitHeader(line);
+    if (diffHeader) {
+      pushCurrent();
+      current = {
+        path: diffHeader.newPath || diffHeader.oldPath,
+        status: "modified",
+        additions: 0,
+        deletions: 0,
+        hunks: [],
+        partial: false,
+      };
+      continue;
+    }
+    if (!current) continue;
+    if (line.startsWith("new file mode")) {
+      current.status = "added";
+      continue;
+    }
+    if (line.startsWith("deleted file mode")) {
+      current.status = "deleted";
+      continue;
+    }
+    if (line.startsWith("similarity index") || line.startsWith("rename from ") || line.startsWith("rename to ")) {
+      current.status = "renamed";
+      continue;
+    }
+    if (line.startsWith("Binary files ")) {
+      current.status = "binary";
+      current.partial = true;
+      continue;
+    }
+    const newPath = parseDiffFileMarker(line, "+++ ");
+    if (newPath) {
+      current.path = newPath;
+      continue;
+    }
+    const hunk = /^@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@(.*)$/.exec(line);
+    if (hunk) {
+      if (current.hunks.length >= 100) {
+        current.partial = true;
+        hasMore = true;
+        continue;
+      }
+      current.hunks.push({
+        id: hunkIdFor(current.path, current.hunks.length),
+        oldStart: parseRangeStart(hunk[1]),
+        oldLines: parseRangeLines(hunk[2]),
+        newStart: parseRangeStart(hunk[3]),
+        newLines: parseRangeLines(hunk[4]),
+        heading: line.slice(0, 120),
+        partial: false,
+      });
+      continue;
+    }
+    if (line.startsWith("+") && !line.startsWith("+++")) current.additions += 1;
+    if (line.startsWith("-") && !line.startsWith("---")) current.deletions += 1;
+  }
+  pushCurrent();
+  return {
+    ok: true,
+    files,
+    hasMore,
+    partial: hasMore || files.some((file) => file.partial),
+  };
+}
+
+async function execGit(worktreeRoot: string, args: string[], options: { maxBuffer?: number; logFailure?: boolean } = {}) {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), REVIEW_DIFF_TIMEOUT_MS);
+  try {
+    const { stdout } = await execFileAsync(
+      "git",
+      ["-C", worktreeRoot, ...args],
+      {
+        encoding: "utf8",
+        maxBuffer: options.maxBuffer ?? REVIEW_DIFF_OUTPUT_BYTES,
+        signal: controller.signal,
+      },
+    );
+    return stdout;
+  } catch (error) {
+    const code = typeof error === "object" && error !== null && "code" in error ? String(error.code) : "";
+    if (options.logFailure ?? true) {
+      console.warn("[coding-agents] review diff unavailable", code ? `(${code})` : "");
+    }
+    return null;
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+async function readGitReviewDiff(worktreeRoot: string): Promise<ReviewDiffReadResult> {
+  try {
+    await access(worktreeRoot);
+  } catch (error) {
+    const code = typeof error === "object" && error !== null && "code" in error ? String(error.code) : "";
+    if (["ENOENT", "ENOTDIR", "EACCES"].includes(code)) {
+      return { ok: false };
+    }
+    console.warn("[coding-agents] review worktree unavailable");
+    return { ok: false };
+  }
+  const diffArgs = ["diff", "--no-ext-diff", "--no-textconv", "--find-renames", "--unified=0"];
+  let base: string | undefined;
+  for (const candidate of ["origin/HEAD", "origin/main", "origin/master", "origin/develop"]) {
+    base = (await execGit(worktreeRoot, ["merge-base", "HEAD", candidate], {
+      maxBuffer: 64 * 1024,
+      logFailure: false,
+    }))?.trim();
+    if (base) break;
+  }
+  const baseStdout = base
+    ? await execGit(worktreeRoot, [...diffArgs, base, "--", "."], { logFailure: false })
+    : null;
+  if (base && baseStdout === null) {
+    return { ok: true, files: [], hasMore: true, partial: true };
+  }
+  if (!base) {
+    const headStdout = await execGit(worktreeRoot, [...diffArgs, "HEAD", "--", "."], { logFailure: false });
+    if (headStdout !== null) {
+      if (headStdout.trim().length === 0) {
+        return { ok: true, files: [], hasMore: true, partial: true };
+      }
+      return markDiffReadResultPartial(parseUnifiedDiff(headStdout));
+    }
+    const workingTreeStdout = await execGit(worktreeRoot, [...diffArgs, "--", "."]);
+    if (workingTreeStdout === null) return { ok: false };
+    if (workingTreeStdout.trim().length === 0) {
+      return { ok: true, files: [], hasMore: true, partial: true };
+    }
+    return markDiffReadResultPartial(parseUnifiedDiff(workingTreeStdout));
+  }
+  const stdout = baseStdout;
+  return stdout === null ? { ok: false } : parseUnifiedDiff(stdout);
+}
+
 function snapshotFilesFromFindings(review: ReviewLoopRecord, findings: ParsedFinding[]) {
   const files = new Map<string, ParsedFinding[]>();
   let hasMore = false;
@@ -178,9 +486,43 @@ function snapshotFilesFromFindings(review: ReviewLoopRecord, findings: ParsedFin
   return { items, hasMore };
 }
 
+function mergeDiffAndFindings(input: {
+  diff: ReviewDiffReadResult | null;
+  findings: ReturnType<typeof snapshotFilesFromFindings>;
+}) {
+  if (!input.diff?.ok) return input.findings;
+  if (input.diff.files.length === 0) {
+    return {
+      items: input.findings.items,
+      hasMore: input.diff.hasMore || input.diff.partial || input.findings.hasMore,
+    };
+  }
+  const findingsByPath = new Map(input.findings.items.map((file) => [file.path, file.findings ?? []]));
+  const files: ReviewSnapshotFile[] = [];
+  let hasMore = input.diff.hasMore || input.findings.hasMore;
+  for (const file of input.diff.files) {
+    const parsed = ReviewSnapshotFileSchema.safeParse({
+      ...file,
+      findings: findingsByPath.get(file.path),
+    });
+    if (!parsed.success) continue;
+    files.push(parsed.data);
+  }
+  const diffPaths = new Set(files.map((file) => file.path));
+  for (const findingFile of input.findings.items) {
+    if (diffPaths.has(findingFile.path)) continue;
+    if (files.length >= REVIEW_SNAPSHOT_FILE_LIMIT) {
+      hasMore = true;
+      break;
+    }
+    files.push(findingFile);
+  }
+  return { items: files.slice(0, REVIEW_SNAPSHOT_FILE_LIMIT), hasMore };
+}
+
 async function toPartialReviewSnapshot(
   review: ReviewLoopRecord,
-  options: { findingsReader: FindingsReader; homePath?: string },
+  options: { findingsReader: FindingsReader; diffReader: ReviewDiffReader; homePath?: string },
 ): Promise<ReviewSnapshot | null> {
   const summary = toReviewSummary(review);
   if (!summary) return null;
@@ -194,7 +536,11 @@ async function toPartialReviewSnapshot(
     })
     : null;
   const parsedFindings = findingsPath ? await options.findingsReader(findingsPath) : null;
-  const files = parsedFindings?.ok ? snapshotFilesFromFindings(review, parsedFindings.findings) : { items: [], hasMore: false };
+  const worktreeRoot = safeWorktreeRoot({ homePath: options.homePath, review });
+  const parsedDiff = worktreeRoot ? await options.diffReader(worktreeRoot) : null;
+  const findingsFiles = parsedFindings?.ok ? snapshotFilesFromFindings(review, parsedFindings.findings) : { items: [], hasMore: false };
+  const files = mergeDiffAndFindings({ diff: parsedDiff, findings: findingsFiles });
+  const snapshotPartial = !parsedDiff?.ok || parsedDiff.partial || files.hasMore || files.items.some((file) => file.partial);
   const parsed = ReviewSnapshotSchema.safeParse({
     review: summary,
     files: {
@@ -202,10 +548,12 @@ async function toPartialReviewSnapshot(
       hasMore: files.hasMore,
       limit: REVIEW_SNAPSHOT_FILE_LIMIT,
     },
-    partial: true,
-    safeNotice: files.items.length > 0
-      ? "Diff content is not available yet. Showing bounded review findings."
-      : "Diff content is not available yet. Showing bounded review state.",
+    partial: snapshotPartial,
+    safeNotice: snapshotPartial
+      ? files.items.length > 0
+        ? "Some diff content is unavailable. Showing bounded review metadata."
+        : "Diff content is not available yet. Showing bounded review state."
+      : undefined,
     updatedAt: review.updatedAt,
   });
   return parsed.success ? parsed.data : null;
@@ -213,10 +561,17 @@ async function toPartialReviewSnapshot(
 
 export function createCodingAgentReviewSummaryStore(
   store: ReviewLoopStore,
-  options: { ownerId?: string; principalOwnerIds?: readonly string[]; findingsReader?: FindingsReader; homePath?: string } = {},
+  options: {
+    ownerId?: string;
+    principalOwnerIds?: readonly string[];
+    findingsReader?: FindingsReader;
+    diffReader?: ReviewDiffReader;
+    homePath?: string;
+  } = {},
 ): CodingAgentReviewSummaryStore {
   const ownerIds = ownerIdsFor(options);
   const findingsReader = options.findingsReader ?? parseFindingsFile;
+  const diffReader = options.diffReader ?? readGitReviewDiff;
   return {
     async listReviews(principal: RequestPrincipal, listOptions: { cursor?: string } = {}) {
       if (!canReadReviewSummaries(principal, ownerIds)) {
@@ -270,7 +625,7 @@ export function createCodingAgentReviewSummaryStore(
       if (!reviewOwnerMatchesPrincipal(result.review, principal, ownerIds)) {
         throw new CodingAgentReviewSnapshotError("review_not_found");
       }
-      const snapshot = await toPartialReviewSnapshot(result.review, { findingsReader, homePath: options.homePath });
+      const snapshot = await toPartialReviewSnapshot(result.review, { findingsReader, diffReader, homePath: options.homePath });
       if (!snapshot) {
         throw new CodingAgentReviewSnapshotError("review_state_unavailable");
       }

--- a/specs/105-coding-agent-shells/current-state.md
+++ b/specs/105-coding-agent-shells/current-state.md
@@ -6,7 +6,7 @@
 
 ## Summary
 
-The stack currently has shared contracts, a gateway runtime summary read model, read-only desktop and mobile workspaces behind flags, thread create/replay/abort/event streaming, provider adapters, a workspace-backed provider, approval/input route handling, a read-only coding-agent review summary route/client contract, desktop/mobile read-only review summary panels, and a read-only coding-agent review snapshot route with partial findings-derived file metadata. Full file diff and preview coding-agent surfaces are contract-only or existing workspace routes; dedicated diff and preview shell UI is not yet integrated.
+The stack currently has shared contracts, a gateway runtime summary read model, read-only desktop and mobile workspaces behind flags, thread create/replay/abort/event streaming, provider adapters, a workspace-backed provider, approval/input route handling, a read-only coding-agent review summary route/client contract, desktop/mobile read-only review summary panels, and a read-only coding-agent review snapshot route with bounded file metadata from safe owner worktree diffs plus findings fallback metadata. Full file content and preview coding-agent surfaces are contract-only or existing workspace routes; dedicated diff and preview shell UI is not yet integrated.
 
 Current source-of-truth boundaries:
 
@@ -142,10 +142,11 @@ Thread store behavior:
 Review summary behavior:
 
 - Adapts existing owner-local review-loop records into bounded `ReviewSummarySchema` rows.
-- Adapts existing owner-local review-loop records and structured findings into bounded partial `ReviewSnapshotSchema` rows for the review detail route.
+- Adapts existing owner-local review-loop records, safe owner worktree git diffs, and structured findings into bounded `ReviewSnapshotSchema` rows for the review detail route.
 - Drops malformed legacy records instead of exposing raw review state.
 - Caps the coding-agent route response at 50 items.
 - Drops unsafe findings paths or display text instead of exposing raw filesystem paths, provider output, or parse errors.
+- Reads git diff metadata only from the validated owner worktree root, uses a bounded no-shell `git diff` call with timeout/output cap, and falls back to partial findings metadata when diff state is unavailable.
 
 Focused tests:
 
@@ -328,7 +329,7 @@ git diff --check
 ## Open Questions And Deferred Work
 
 - Session completion reconciliation: implemented for workspace `session.stopped` events that carry owner id, workspace session id, and bound `terminalSessionId`; the gateway thread store marks matching active coding-agent threads completed or failed server-side without matching unrelated owners or reused terminal ids. Remaining work: if runtime managers add autonomous process-exit detection beyond explicit workspace stop events, route those through the same `session.stopped` publisher path.
-- File/review/preview shell surfaces: read-only review summaries now have coding-agent contracts/routes/desktop IPC/mobile clients plus desktop and mobile read-only review panels. A read-only review snapshot route now exposes partial findings-derived file metadata for later shell diff panels. Full file diffs and previews are not implemented yet.
+- File/review/preview shell surfaces: read-only review summaries now have coding-agent contracts/routes/desktop IPC/mobile clients plus desktop and mobile read-only review panels. A read-only review snapshot route now exposes bounded diff hunk metadata from safe owner worktrees and partial findings-derived fallback metadata for later shell diff panels. Full file contents, desktop/mobile diff rendering, and previews are not implemented yet.
 - Browser shell entry point: Canvas-first placement is still undecided.
 - Notifications/attention routing: desktop notification IPC exists, but thread attention notifications are not yet wired end-to-end from gateway events.
 - Public docs: public Matrix OS docs should be updated once the user-facing coding-agent shell flow is stable enough to document.

--- a/tests/gateway/coding-agents-summary.test.ts
+++ b/tests/gateway/coding-agents-summary.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it, vi } from "vitest";
+import { execFile } from "node:child_process";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { Hono } from "hono";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { promisify } from "node:util";
 import {
   ReviewSnapshotSchema,
   ReviewSummarySchema,
@@ -21,6 +26,7 @@ import { MissingRequestPrincipalError } from "../../packages/gateway/src/request
 import { testPrincipal } from "../helpers/activation-readiness.js";
 
 const now = new Date("2026-07-06T12:00:00.000Z");
+const execFileAsync = promisify(execFile);
 
 function reviewRecord(overrides: Record<string, unknown> = {}) {
   return {
@@ -640,6 +646,354 @@ describe("coding agent runtime summary", () => {
     });
     expect(reader).toHaveBeenCalledWith("/home/matrix/home/projects/matrix-os/worktrees/wt_abc123def456/.matrix/review-round-1.md");
     expect(JSON.stringify(snapshot)).not.toMatch(/\/home\/matrix|secret|Postgres|token/i);
+  });
+
+  it("adds bounded diff hunk metadata for safe owner review worktrees", async () => {
+    const diffReader = vi.fn(async () => ({
+      ok: true as const,
+      files: [
+        {
+          path: "packages/gateway/src/coding-agents/routes.ts",
+          status: "modified" as const,
+          additions: 2,
+          deletions: 1,
+          partial: false,
+          hunks: [
+            {
+              id: "hunk_packages_gateway_src_coding_agents_routes_ts_0",
+              oldStart: 10,
+              oldLines: 2,
+              newStart: 10,
+              newLines: 3,
+              heading: "@@ -10,2 +10,3 @@",
+              partial: false,
+            },
+          ],
+        },
+      ],
+      hasMore: false,
+      partial: false,
+    }));
+    const store = createCodingAgentReviewSummaryStore({
+      getReview: async () => ({
+        ok: true,
+        review: reviewRecord({ ownerId: testPrincipal.userId, rounds: [successfulFindingsRound()] }),
+      }),
+      listReviews: async () => ({ ok: true, reviews: [], nextCursor: null }),
+    } as ReviewLoopStore, {
+      ownerId: testPrincipal.userId,
+      homePath: "/home/matrix/home",
+      diffReader,
+      findingsReader: async () => ({
+        ok: true,
+        parserStatus: "success",
+        findingsCount: 0,
+        severityCounts: { high: 0, medium: 0, low: 0 },
+        findings: [],
+      }),
+    });
+
+    const snapshot = await store.getReviewSnapshot!(testPrincipal, "rev_1");
+
+    expect(diffReader).toHaveBeenCalledWith("/home/matrix/home/projects/matrix-os/worktrees/wt_abc123def456");
+    expect(snapshot.partial).toBe(false);
+    expect(snapshot.files).toMatchObject({
+      items: [
+        {
+          path: "packages/gateway/src/coding-agents/routes.ts",
+          status: "modified",
+          additions: 2,
+          deletions: 1,
+          partial: false,
+          hunks: [expect.objectContaining({ oldStart: 10, oldLines: 2, newStart: 10, newLines: 3, partial: false })],
+        },
+      ],
+      hasMore: false,
+      limit: 100,
+    });
+    expect(JSON.stringify(snapshot)).not.toContain("/home/matrix/home");
+  });
+
+  it("summarizes a small git diff from a safe owner review worktree", async () => {
+    const homePath = await mkdtemp(join(tmpdir(), "matrix-review-diff-"));
+    try {
+      const worktreeRoot = join(homePath, "projects", "matrix-os", "worktrees", "wt_abc123def456");
+      const sourceDir = join(worktreeRoot, "packages", "gateway", "src", "coding-agents");
+      const spacedSourceDir = join(worktreeRoot, "packages", "gateway", "src", "coding agents");
+      const tabbedSourceDir = join(worktreeRoot, "packages", "gateway", "src", "tabbed\tagents");
+      await mkdir(sourceDir, { recursive: true });
+      await mkdir(spacedSourceDir, { recursive: true });
+      await mkdir(tabbedSourceDir, { recursive: true });
+      await mkdir(join(worktreeRoot, ".matrix"), { recursive: true });
+      await execFileAsync("git", ["init"], { cwd: worktreeRoot });
+      await writeFile(join(sourceDir, "routes.ts"), "export const value = 1;\n");
+      await writeFile(join(spacedSourceDir, "quoted.ts"), "export const quoted = 1;\n");
+      await writeFile(join(tabbedSourceDir, "quoted.ts"), "export const tabbed = 1;\n");
+      await execFileAsync("git", ["add", "."], { cwd: worktreeRoot });
+      await writeFile(join(sourceDir, "routes.ts"), "export const value = 2;\nexport const next = 3;\n");
+      await writeFile(join(spacedSourceDir, "quoted.ts"), "export const quoted = 2;\n");
+      await writeFile(join(tabbedSourceDir, "quoted.ts"), "export const tabbed = 2;\n");
+      await writeFile(join(worktreeRoot, ".matrix", "review-round-1.md"), "## Findings\n\nNo findings.\n");
+      const store = createCodingAgentReviewSummaryStore({
+        getReview: async () => ({
+          ok: true,
+          review: reviewRecord({ ownerId: testPrincipal.userId, rounds: [successfulFindingsRound()] }),
+        }),
+        listReviews: async () => ({ ok: true, reviews: [], nextCursor: null }),
+      } as ReviewLoopStore, {
+        ownerId: testPrincipal.userId,
+        homePath,
+      });
+
+      const snapshot = await store.getReviewSnapshot!(testPrincipal, "rev_1");
+
+      expect(snapshot.partial).toBe(true);
+      expect(snapshot.safeNotice).toBe("Some diff content is unavailable. Showing bounded review metadata.");
+      expect(snapshot.files.items).toEqual(expect.arrayContaining([
+        expect.objectContaining({
+          path: "packages/gateway/src/coding-agents/routes.ts",
+          status: "modified",
+          additions: 2,
+          deletions: 1,
+          partial: true,
+          hunks: [expect.objectContaining({ oldStart: 1, oldLines: 1, newStart: 1, newLines: 2 })],
+        }),
+        expect.objectContaining({
+          path: "packages/gateway/src/coding agents/quoted.ts",
+          status: "modified",
+          additions: 1,
+          deletions: 1,
+          partial: true,
+          hunks: [expect.objectContaining({ oldStart: 1, oldLines: 1, newStart: 1, newLines: 1 })],
+        }),
+        expect.objectContaining({
+          path: "packages/gateway/src/tabbed\tagents/quoted.ts",
+          status: "modified",
+          additions: 1,
+          deletions: 1,
+          partial: true,
+          hunks: [expect.objectContaining({ oldStart: 1, oldLines: 1, newStart: 1, newLines: 1 })],
+        }),
+      ]));
+      expect(snapshot.files.items).toHaveLength(3);
+      expect(JSON.stringify(snapshot)).not.toContain(homePath);
+    } finally {
+      await rm(homePath, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps unquoted binary diff headers aligned when paths contain the header separator text", async () => {
+    const homePath = await mkdtemp(join(tmpdir(), "matrix-review-binary-header-diff-"));
+    try {
+      const worktreeRoot = join(homePath, "projects", "matrix-os", "worktrees", "wt_abc123def456");
+      const sourceDir = join(worktreeRoot, "packages", "foo", " b");
+      await mkdir(sourceDir, { recursive: true });
+      await mkdir(join(worktreeRoot, ".matrix"), { recursive: true });
+      await execFileAsync("git", ["init"], { cwd: worktreeRoot });
+      await execFileAsync("git", ["config", "core.quotePath", "false"], { cwd: worktreeRoot });
+      await execFileAsync("git", ["config", "user.email", "matrix@example.invalid"], { cwd: worktreeRoot });
+      await execFileAsync("git", ["config", "user.name", "Matrix Review"], { cwd: worktreeRoot });
+      await writeFile(join(sourceDir, "bar.bin"), Buffer.from([0, 1, 2, 3, 4, 5]));
+      await execFileAsync("git", ["add", "."], { cwd: worktreeRoot });
+      await execFileAsync("git", ["commit", "-m", "base"], { cwd: worktreeRoot });
+      await execFileAsync("git", ["update-ref", "refs/remotes/origin/develop", "HEAD"], { cwd: worktreeRoot });
+      await writeFile(join(sourceDir, "bar.bin"), Buffer.from([0, 1, 2, 9, 4, 5]));
+      await writeFile(join(worktreeRoot, ".matrix", "review-round-1.md"), "## Findings\n\nNo findings.\n");
+      const store = createCodingAgentReviewSummaryStore({
+        getReview: async () => ({
+          ok: true,
+          review: reviewRecord({ ownerId: testPrincipal.userId, rounds: [successfulFindingsRound()] }),
+        }),
+        listReviews: async () => ({ ok: true, reviews: [], nextCursor: null }),
+      } as ReviewLoopStore, {
+        ownerId: testPrincipal.userId,
+        homePath,
+      });
+
+      const snapshot = await store.getReviewSnapshot!(testPrincipal, "rev_1");
+
+      expect(snapshot.partial).toBe(true);
+      expect(snapshot.safeNotice).toBe("Some diff content is unavailable. Showing bounded review metadata.");
+      expect(snapshot.files.items).toEqual([
+        expect.objectContaining({
+          path: "packages/foo/ b/bar.bin",
+          status: "binary",
+          partial: true,
+        }),
+      ]);
+    } finally {
+      await rm(homePath, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps snapshots partial when an empty diff falls back to findings metadata", async () => {
+    const store = createCodingAgentReviewSummaryStore({
+      getReview: async () => ({
+        ok: true,
+        review: reviewRecord({ ownerId: testPrincipal.userId, rounds: [successfulFindingsRound()] }),
+      }),
+      listReviews: async () => ({ ok: true, reviews: [], nextCursor: null }),
+    } as ReviewLoopStore, {
+      ownerId: testPrincipal.userId,
+      homePath: "/home/matrix/home",
+      diffReader: async () => ({
+        ok: true,
+        files: [],
+        hasMore: false,
+        partial: false,
+      }),
+      findingsReader: async () => ({
+        ok: true,
+        parserStatus: "success",
+        findingsCount: 1,
+        severityCounts: { high: 1, medium: 0, low: 0 },
+        findings: [{
+          id: "HIGH-1",
+          severity: "high",
+          file: "packages/gateway/src/coding-agents/routes.ts",
+          line: 42,
+          summary: "Finding-only metadata remains partial.",
+        }],
+      }),
+    });
+
+    const snapshot = await store.getReviewSnapshot!(testPrincipal, "rev_1");
+
+    expect(snapshot.partial).toBe(true);
+    expect(snapshot.safeNotice).toBe("Some diff content is unavailable. Showing bounded review metadata.");
+    expect(snapshot.files.items[0]).toMatchObject({
+      path: "packages/gateway/src/coding-agents/routes.ts",
+      partial: true,
+    });
+  });
+
+  it("summarizes committed review branch changes against the tracked base", async () => {
+    const homePath = await mkdtemp(join(tmpdir(), "matrix-review-branch-diff-"));
+    try {
+      const worktreeRoot = join(homePath, "projects", "matrix-os", "worktrees", "wt_abc123def456");
+      const sourceDir = join(worktreeRoot, "packages", "gateway", "src", "coding-agents");
+      await mkdir(sourceDir, { recursive: true });
+      await mkdir(join(worktreeRoot, ".matrix"), { recursive: true });
+      await execFileAsync("git", ["init"], { cwd: worktreeRoot });
+      await execFileAsync("git", ["config", "user.email", "matrix@example.invalid"], { cwd: worktreeRoot });
+      await execFileAsync("git", ["config", "user.name", "Matrix Review"], { cwd: worktreeRoot });
+      await writeFile(join(sourceDir, "routes.ts"), "export const value = 1;\n");
+      await execFileAsync("git", ["add", "."], { cwd: worktreeRoot });
+      await execFileAsync("git", ["commit", "-m", "base"], { cwd: worktreeRoot });
+      await execFileAsync("git", ["update-ref", "refs/remotes/origin/develop", "HEAD"], { cwd: worktreeRoot });
+      await writeFile(join(sourceDir, "routes.ts"), "export const value = 2;\nexport const next = 3;\n");
+      await execFileAsync("git", ["add", "."], { cwd: worktreeRoot });
+      await execFileAsync("git", ["commit", "-m", "review change"], { cwd: worktreeRoot });
+      await writeFile(join(worktreeRoot, ".matrix", "review-round-1.md"), "## Findings\n\nNo findings.\n");
+      const store = createCodingAgentReviewSummaryStore({
+        getReview: async () => ({
+          ok: true,
+          review: reviewRecord({ ownerId: testPrincipal.userId, rounds: [successfulFindingsRound()] }),
+        }),
+        listReviews: async () => ({ ok: true, reviews: [], nextCursor: null }),
+      } as ReviewLoopStore, {
+        ownerId: testPrincipal.userId,
+        homePath,
+      });
+
+      const snapshot = await store.getReviewSnapshot!(testPrincipal, "rev_1");
+
+      expect(snapshot.partial).toBe(false);
+      expect(snapshot.files.items).toEqual([
+        expect.objectContaining({
+          path: "packages/gateway/src/coding-agents/routes.ts",
+          status: "modified",
+          additions: 2,
+          deletions: 1,
+          partial: false,
+          hunks: [expect.objectContaining({ oldStart: 1, oldLines: 1, newStart: 1, newLines: 2 })],
+        }),
+      ]);
+    } finally {
+      await rm(homePath, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps committed review snapshots partial when no trusted base ref exists", async () => {
+    const homePath = await mkdtemp(join(tmpdir(), "matrix-review-no-base-diff-"));
+    try {
+      const worktreeRoot = join(homePath, "projects", "matrix-os", "worktrees", "wt_abc123def456");
+      const sourceDir = join(worktreeRoot, "packages", "gateway", "src", "coding-agents");
+      await mkdir(sourceDir, { recursive: true });
+      await mkdir(join(worktreeRoot, ".matrix"), { recursive: true });
+      await execFileAsync("git", ["init"], { cwd: worktreeRoot });
+      await execFileAsync("git", ["config", "user.email", "matrix@example.invalid"], { cwd: worktreeRoot });
+      await execFileAsync("git", ["config", "user.name", "Matrix Review"], { cwd: worktreeRoot });
+      await writeFile(join(sourceDir, "routes.ts"), "export const value = 1;\n");
+      await execFileAsync("git", ["add", "."], { cwd: worktreeRoot });
+      await execFileAsync("git", ["commit", "-m", "base"], { cwd: worktreeRoot });
+      await writeFile(join(sourceDir, "routes.ts"), "export const value = 2;\nexport const next = 3;\n");
+      await execFileAsync("git", ["add", "."], { cwd: worktreeRoot });
+      await execFileAsync("git", ["commit", "-m", "review change"], { cwd: worktreeRoot });
+      await writeFile(join(worktreeRoot, ".matrix", "review-round-1.md"), "## Findings\n\nNo findings.\n");
+      const store = createCodingAgentReviewSummaryStore({
+        getReview: async () => ({
+          ok: true,
+          review: reviewRecord({ ownerId: testPrincipal.userId, rounds: [successfulFindingsRound()] }),
+        }),
+        listReviews: async () => ({ ok: true, reviews: [], nextCursor: null }),
+      } as ReviewLoopStore, {
+        ownerId: testPrincipal.userId,
+        homePath,
+      });
+
+      const snapshot = await store.getReviewSnapshot!(testPrincipal, "rev_1");
+
+      expect(snapshot.partial).toBe(true);
+      expect(snapshot.files).toMatchObject({ items: [], hasMore: true, limit: 100 });
+      expect(snapshot.safeNotice).toBe("Diff content is not available yet. Showing bounded review state.");
+    } finally {
+      await rm(homePath, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps no-base snapshots partial even when local edits produce diff metadata", async () => {
+    const homePath = await mkdtemp(join(tmpdir(), "matrix-review-no-base-local-diff-"));
+    try {
+      const worktreeRoot = join(homePath, "projects", "matrix-os", "worktrees", "wt_abc123def456");
+      const sourceDir = join(worktreeRoot, "packages", "gateway", "src", "coding-agents");
+      await mkdir(sourceDir, { recursive: true });
+      await mkdir(join(worktreeRoot, ".matrix"), { recursive: true });
+      await execFileAsync("git", ["init"], { cwd: worktreeRoot });
+      await execFileAsync("git", ["config", "user.email", "matrix@example.invalid"], { cwd: worktreeRoot });
+      await execFileAsync("git", ["config", "user.name", "Matrix Review"], { cwd: worktreeRoot });
+      await writeFile(join(sourceDir, "routes.ts"), "export const value = 1;\n");
+      await execFileAsync("git", ["add", "."], { cwd: worktreeRoot });
+      await execFileAsync("git", ["commit", "-m", "base"], { cwd: worktreeRoot });
+      await writeFile(join(sourceDir, "routes.ts"), "export const value = 2;\nexport const next = 3;\n");
+      await execFileAsync("git", ["add", "."], { cwd: worktreeRoot });
+      await execFileAsync("git", ["commit", "-m", "review change"], { cwd: worktreeRoot });
+      await writeFile(join(sourceDir, "routes.ts"), "export const value = 4;\nexport const next = 3;\n");
+      await writeFile(join(worktreeRoot, ".matrix", "review-round-1.md"), "## Findings\n\nNo findings.\n");
+      const store = createCodingAgentReviewSummaryStore({
+        getReview: async () => ({
+          ok: true,
+          review: reviewRecord({ ownerId: testPrincipal.userId, rounds: [successfulFindingsRound()] }),
+        }),
+        listReviews: async () => ({ ok: true, reviews: [], nextCursor: null }),
+      } as ReviewLoopStore, {
+        ownerId: testPrincipal.userId,
+        homePath,
+      });
+
+      const snapshot = await store.getReviewSnapshot!(testPrincipal, "rev_1");
+
+      expect(snapshot.partial).toBe(true);
+      expect(snapshot.safeNotice).toBe("Some diff content is unavailable. Showing bounded review metadata.");
+      expect(snapshot.files.items).toEqual([
+        expect.objectContaining({
+          path: "packages/gateway/src/coding-agents/routes.ts",
+          partial: true,
+        }),
+      ]);
+    } finally {
+      await rm(homePath, { recursive: true, force: true });
+    }
   });
 
   it("returns safe not-found for owner-mismatched review snapshots", async () => {


### PR DESCRIPTION
## Summary

- Adds bounded review diff hunk metadata to the coding-agent review snapshot read model when a safe owner worktree is available.
- Keeps findings-derived partial metadata fallback when diff state is unavailable or not authoritative.
- Updates the 105 current-state note to record the gateway diff metadata behavior and the remaining shell UI work.

## Tests

- `bun run test -- tests/gateway/coding-agents-summary.test.ts` (36 tests)
- `pnpm --filter @matrix-os/gateway exec tsc --noEmit`
- `bun run check:patterns` (0 violations; existing warnings only)
- `bun run typecheck`
- `pnpm --filter matrix-os-mobile run test` (27 suites, 235 tests)
- `pnpm --filter matrix-os-mobile run lint`
- `pnpm --filter matrix-os-mobile exec tsc --noEmit`
- `git diff --check`

## Review/Monitoring

- Greptile is 5/5 on `8dd837d3935be31727612542f66c9d37f4ada09a`.
- `ready-for-ci` is applied.
- Changed-file forbidden reference wording scan returned no matches.
- `vp` is not installed on this host, so direct repo/package commands were used.

## Invariants

- Gateway/runtime remains the source of truth for coding-agent review state; desktop and mobile behavior is unchanged in this slice.
- No new persistence is introduced.
- Diff metadata is read only from a validated owner worktree root, via a no-shell `git diff` call with timeout and output bounds.
- Review snapshot responses continue to expose only contract-validated relative paths, counts, hunk coordinates, safe notices, and finding summaries.
- File contents, terminal output, provider payloads, credentials, raw git errors, and filesystem paths are not sent to clients.
- If diff metadata is unavailable or not authoritative, the route safely degrades to partial review metadata.
