### PR TITLE
feat(desktop): add review hunk metadata panel

### DIFF
--- a/desktop/src/renderer/src/features/coding-agents/AgentWorkspace.tsx
+++ b/desktop/src/renderer/src/features/coding-agents/AgentWorkspace.tsx
@@ -329,6 +329,10 @@ function reviewStatusLabel(status: ReviewSummary["status"]): string {
   return status.replace(/_/g, " ");
 }
 
+function formatHunkRange(hunk: ReviewSnapshot["files"]["items"][number]["hunks"][number]): string {
+  return `@@ -${hunk.oldStart},${hunk.oldLines} +${hunk.newStart},${hunk.newLines} @@`;
+}
+
 function ReviewList() {
   const reviewsStatus = useCodingAgentWorkspace((s) => s.reviewsStatus);
   const reviews = useCodingAgentWorkspace((s) => s.reviews);
@@ -406,6 +410,12 @@ function ReviewSnapshotPanel({
   snapshot: ReviewSnapshot | null;
   error: string | null;
 }) {
+  const [selectedHunkKey, setSelectedHunkKey] = useState<string | null>(null);
+
+  useEffect(() => {
+    setSelectedHunkKey(null);
+  }, [snapshot?.review.id]);
+
   if (status === "idle") return null;
   if (status === "loading") {
     return (
@@ -444,9 +454,9 @@ function ReviewSnapshotPanel({
         </p>
       ) : null}
       <div className="grid gap-2">
-        {snapshot.files.items.map((file) => (
+        {snapshot.files.items.map((file, fileIndex) => (
           <div
-            key={file.path}
+            key={`${file.path}:${fileIndex}`}
             className="grid gap-2 rounded-md border px-3 py-2"
             style={{ borderColor: "var(--border-subtle)", background: "var(--bg-overlay)" }}
           >
@@ -474,6 +484,53 @@ function ReviewSnapshotPanel({
                 No findings in this file.
               </p>
             )}
+            <div className="flex flex-wrap items-center gap-2 text-xs">
+              <span className="rounded border px-2 py-1" style={{ borderColor: "var(--border-subtle)", color: "var(--success)" }}>
+                +{file.additions}
+              </span>
+              <span className="rounded border px-2 py-1" style={{ borderColor: "var(--border-subtle)", color: "var(--danger)" }}>
+                -{file.deletions}
+              </span>
+              {file.partial ? (
+                <span className="rounded border px-2 py-1" style={{ borderColor: "var(--border-subtle)", color: "var(--text-tertiary)" }}>
+                  Partial file
+                </span>
+              ) : null}
+            </div>
+            {file.hunks.length ? (
+              <div className="grid gap-1">
+                {file.hunks.map((hunk, hunkIndex) => {
+                  const hunkKey = `${fileIndex}\u0000${file.path}\u0000${hunk.id}\u0000${hunkIndex}`;
+                  const selected = selectedHunkKey === hunkKey;
+                  return (
+                    <button
+                      key={`${file.path}:${fileIndex}:${hunk.id}:${hunkIndex}`}
+                      type="button"
+                      aria-label={`Select hunk ${hunkIndex + 1} in ${file.path}`}
+                      aria-pressed={selected}
+                      className="no-drag grid gap-1 rounded-md border px-3 py-2 text-left transition-colors duration-100 hover:brightness-105"
+                      onClick={() => setSelectedHunkKey(hunkKey)}
+                      style={{
+                        borderColor: selected ? "var(--accent)" : "var(--border-subtle)",
+                        background: selected ? "var(--accent-muted)" : "transparent",
+                      }}
+                    >
+                      <span className="text-xs font-medium" style={{ color: "var(--text-secondary)" }}>
+                        {`Hunk ${hunkIndex + 1}`}
+                      </span>
+                      <span className="font-mono text-xs" style={{ color: "var(--text-primary)" }}>
+                        {formatHunkRange(hunk)}
+                      </span>
+                      {hunk.partial ? (
+                        <span className="text-xs" style={{ color: "var(--text-tertiary)" }}>
+                          Partial hunk
+                        </span>
+                      ) : null}
+                    </button>
+                  );
+                })}
+              </div>
+            ) : null}
           </div>
         ))}
       </div>

--- a/specs/105-coding-agent-shells/current-state.md
+++ b/specs/105-coding-agent-shells/current-state.md
@@ -6,7 +6,7 @@
 
 ## Summary
 
-The stack currently has shared contracts, a gateway runtime summary read model, read-only desktop and mobile workspaces behind flags, thread create/replay/abort/event streaming, provider adapters, a workspace-backed provider, approval/input route handling, a read-only coding-agent review summary route/client contract, desktop/mobile read-only review summary panels, and a read-only coding-agent review snapshot route with bounded file metadata from safe owner worktree diffs plus findings fallback metadata. Full file content and preview coding-agent surfaces are contract-only or existing workspace routes; dedicated diff and preview shell UI is not yet integrated.
+The stack currently has shared contracts, a gateway runtime summary read model, read-only desktop and mobile workspaces behind flags, thread create/replay/abort/event streaming, provider adapters, a workspace-backed provider, approval/input route handling, a read-only coding-agent review summary route/client contract, desktop/mobile read-only review summary panels, and a read-only coding-agent review snapshot route with bounded file metadata from safe owner worktree diffs plus findings fallback metadata. Desktop review details render changed-file counts and selectable hunk coordinate metadata. Full file content, raw diff lines, mobile hunk navigation, follow-up actions, and preview coding-agent surfaces are contract-only or existing workspace routes; dedicated preview shell UI is not yet integrated.
 
 Current source-of-truth boundaries:
 
@@ -206,6 +206,7 @@ Current behavior:
 
 - Read-only dashboard renders providers, active threads, and terminals.
 - When the runtime advertises `codingAgentsReview`, the dashboard fetches bounded review summaries through the trusted main-process IPC route and renders project, PR, round, status, and high-severity count.
+- Review snapshot details render bounded file paths, additions/deletions, partial markers, selectable hunk coordinate metadata, and safe finding summaries. They do not render raw diff lines or file contents.
 - Safe generic error state if the runtime summary is unavailable.
 - Safe generic review error state if review summaries are unavailable; review failures do not drop the runtime summary dashboard.
 - No provider credentials or bearer tokens are exposed to the renderer.

--- a/tests/desktop/coding-agent-workspace.test.tsx
+++ b/tests/desktop/coding-agent-workspace.test.tsx
@@ -125,18 +125,27 @@ function reviewSnapshotFixture() {
         {
           path: "packages/gateway/src/coding-agents/routes.ts",
           status: "modified",
-          additions: 0,
-          deletions: 0,
+          additions: 12,
+          deletions: 4,
           partial: true,
           hunks: [
             {
               id: "hunk_rev_desktop_1_0_0",
               oldStart: 42,
-              oldLines: 1,
-              newStart: 42,
-              newLines: 1,
+              oldLines: 3,
+              newStart: 45,
+              newLines: 5,
               heading: "Finding HIGH-1",
               partial: true,
+            },
+            {
+              id: "hunk_rev_desktop_1_0_1",
+              oldStart: 88,
+              oldLines: 1,
+              newStart: 93,
+              newLines: 2,
+              heading: "@@ -88 +93 @@",
+              partial: false,
             },
           ],
           findings: [
@@ -233,6 +242,124 @@ describe("AgentWorkspace", () => {
     expect(screen.getByText("Validate ownership before returning snapshots.")).toBeTruthy();
     expect(screen.getByText("Diff content is not available yet. Showing bounded review findings.")).toBeTruthy();
     expect(screen.queryByText(/home\/matrix|token|secret/i)).toBeNull();
+  });
+
+  it("renders selectable review hunk metadata without raw diff contents", async () => {
+    render(<AgentWorkspace />);
+
+    await screen.findByText("matrix-os");
+    fireEvent.click(screen.getByRole("button", { name: /Open review PR #758/i }));
+
+    expect(await screen.findByText("packages/gateway/src/coding-agents/routes.ts")).toBeTruthy();
+    expect(screen.getByText("+12")).toBeTruthy();
+    expect(screen.getByText("-4")).toBeTruthy();
+    expect(screen.getByText("@@ -42,3 +45,5 @@")).toBeTruthy();
+    expect(screen.getByText("@@ -88,1 +93,2 @@")).toBeTruthy();
+    expect(screen.getByText("Partial hunk")).toBeTruthy();
+
+    const hunk = screen.getByRole("button", { name: /Select hunk 2 in packages\/gateway\/src\/coding-agents\/routes\.ts/i });
+    fireEvent.click(hunk);
+    expect(hunk.getAttribute("aria-pressed")).toBe("true");
+    expect(screen.queryByText(/export const|function create|raw diff/i)).toBeNull();
+  });
+
+  it("keeps hunk selection scoped to the file when hunk ids collide", async () => {
+    const collisionSnapshot = {
+      ...reviewSnapshotFixture(),
+      files: {
+        ...reviewSnapshotFixture().files,
+        items: [
+          {
+            ...reviewSnapshotFixture().files.items[0],
+            path: "packages/alpha/src/review-target.ts",
+            hunks: [
+              {
+                ...reviewSnapshotFixture().files.items[0]!.hunks[0],
+                id: "hunk_collision_0",
+              },
+            ],
+          },
+          {
+            ...reviewSnapshotFixture().files.items[0],
+            path: "packages/beta/src/review-target.ts",
+            hunks: [
+              {
+                ...reviewSnapshotFixture().files.items[0]!.hunks[0],
+                id: "hunk_collision_0",
+              },
+            ],
+            findings: [],
+          },
+        ],
+      },
+    };
+    window.operator.invoke = vi.fn((channel: string) => {
+      if (channel === "runtime:get-summary") return Promise.resolve(summaryFixture());
+      if (channel === "runtime:get-reviews") return Promise.resolve(reviewsFixture());
+      if (channel === "runtime:get-review-snapshot") return Promise.resolve(collisionSnapshot);
+      return Promise.reject(new Error("unexpected channel"));
+    });
+
+    render(<AgentWorkspace />);
+
+    await screen.findByText("matrix-os");
+    fireEvent.click(screen.getByRole("button", { name: /Open review PR #758/i }));
+
+    const firstHunk = await screen.findByRole("button", { name: /Select hunk 1 in packages\/alpha\/src\/review-target\.ts/i });
+    const secondHunk = screen.getByRole("button", { name: /Select hunk 1 in packages\/beta\/src\/review-target\.ts/i });
+    fireEvent.click(secondHunk);
+
+    expect(firstHunk.getAttribute("aria-pressed")).toBe("false");
+    expect(secondHunk.getAttribute("aria-pressed")).toBe("true");
+  });
+
+  it("keeps hunk selection scoped to duplicate rendered file rows", async () => {
+    const collisionSnapshot = {
+      ...reviewSnapshotFixture(),
+      files: {
+        ...reviewSnapshotFixture().files,
+        items: [
+          {
+            ...reviewSnapshotFixture().files.items[0],
+            hunks: [
+              {
+                ...reviewSnapshotFixture().files.items[0]!.hunks[0],
+                id: "hunk_collision_0",
+              },
+            ],
+          },
+          {
+            ...reviewSnapshotFixture().files.items[0],
+            hunks: [
+              {
+                ...reviewSnapshotFixture().files.items[0]!.hunks[0],
+                id: "hunk_collision_0",
+              },
+            ],
+            findings: [],
+          },
+        ],
+      },
+    };
+    window.operator.invoke = vi.fn((channel: string) => {
+      if (channel === "runtime:get-summary") return Promise.resolve(summaryFixture());
+      if (channel === "runtime:get-reviews") return Promise.resolve(reviewsFixture());
+      if (channel === "runtime:get-review-snapshot") return Promise.resolve(collisionSnapshot);
+      return Promise.reject(new Error("unexpected channel"));
+    });
+
+    render(<AgentWorkspace />);
+
+    await screen.findByText("matrix-os");
+    fireEvent.click(screen.getByRole("button", { name: /Open review PR #758/i }));
+
+    const hunkButtons = await screen.findAllByRole("button", {
+      name: /Select hunk 1 in packages\/gateway\/src\/coding-agents\/routes\.ts/i,
+    });
+    fireEvent.click(hunkButtons[1]!);
+
+    expect(hunkButtons[0]!.getAttribute("aria-pressed")).toBe("false");
+    expect(hunkButtons[1]!.getAttribute("aria-pressed")).toBe("true");
   });
 
   it("shows a generic safe review error without dropping the runtime summary", async () => {


### PR DESCRIPTION
## Summary

- Adds desktop review snapshot hunk metadata rendering for changed files.
- Shows bounded additions/deletions, partial file markers, hunk coordinate rows, and selectable hunk state without rendering raw file contents or diff lines.
- Scopes hunk selection to the rendered file row so duplicate paths or hunk ids cannot select multiple rows.
- Updates the 105 current-state note to record the desktop review hunk metadata behavior and remaining review/preview follow-ups.

## Tests

- `bun run test -- tests/desktop/coding-agent-workspace.test.tsx` (14 tests)
- `pnpm --filter desktop run typecheck`
- `bun run check:patterns` (0 violations; existing warnings only)
- `bun run typecheck`
- `pnpm --filter matrix-os-mobile run test` (235 tests)
- `pnpm --filter matrix-os-mobile run lint`
- `pnpm --filter matrix-os-mobile exec tsc --noEmit`
- `git diff --check origin/105-coding-agent-review-diff...HEAD`
- Changed-branch forbidden reference wording scan returned no matches.

## Review/Monitoring

- Rebasing onto the post-Expo SDK 57 `main` is complete for this branch stack.
- Greptile is running on the current head.
- `ready-for-ci` will be added after the latest Greptile result is 5/5.

## Invariants

- Gateway/runtime remains the source of truth for review snapshot data; desktop only renders contract-validated metadata.
- No new persistence, endpoint, WebSocket, or credential path is introduced.
- Desktop renderer still receives no bearer credentials or provider credentials.
- Review UI renders bounded file paths, counts, hunk coordinates, partial markers, and finding summaries only.
- Raw diff lines, file contents, terminal output, provider payloads, filesystem paths, and unsafe errors are not rendered.
- Mobile product behavior is unchanged in this slice; the mobile change in the stack base is a test fixture alignment for the SDK 57 router mock.
