### PR TITLE
feat(mobile): add review hunk metadata panel

### DIFF
--- a/apps/mobile/__tests__/agents-screen.test.tsx
+++ b/apps/mobile/__tests__/agents-screen.test.tsx
@@ -179,6 +179,62 @@ function reviewSnapshotWithFinding(summary: string) {
   };
 }
 
+function reviewSnapshotWithHunks() {
+  const snapshot = reviewSnapshotFixture();
+  return {
+    ...snapshot,
+    files: {
+      ...snapshot.files,
+      items: snapshot.files.items.map((file) => ({
+        ...file,
+        additions: 12,
+        deletions: 4,
+        hunks: [
+          {
+            id: "hunk_rev_mobile_1_0_0",
+            oldStart: 42,
+            oldLines: 3,
+            newStart: 45,
+            newLines: 5,
+            partial: true,
+          },
+          {
+            id: "hunk_rev_mobile_1_0_1",
+            oldStart: 88,
+            oldLines: 1,
+            newStart: 93,
+            newLines: 2,
+            partial: false,
+          },
+        ],
+      })),
+    },
+  };
+}
+
+function reviewSnapshotWithChangedHunks() {
+  const snapshot = reviewSnapshotWithHunks();
+  return {
+    ...snapshot,
+    files: {
+      ...snapshot.files,
+      items: snapshot.files.items.map((file) => ({
+        ...file,
+        hunks: file.hunks.map((hunk, hunkIndex) => hunkIndex === 1
+          ? {
+              ...hunk,
+              oldStart: 120,
+              oldLines: 4,
+              newStart: 130,
+              newLines: 6,
+            }
+          : hunk),
+      })),
+    },
+    updatedAt: "2026-07-06T00:04:00.000Z",
+  };
+}
+
 function deferred<T>() {
   let resolve!: (value: T) => void;
   const promise = new Promise<T>((promiseResolve) => {
@@ -274,6 +330,96 @@ describe("AgentsScreen", () => {
     expect(screen.getByText("Validate ownership before returning snapshots.")).toBeTruthy();
     expect(screen.getByText("Diff content is not available yet. Showing bounded review findings.")).toBeTruthy();
     expect(screen.queryByText(/home\/matrix|token|secret/i)).toBeNull();
+  });
+
+  it("renders selectable review hunk metadata without raw diff contents", async () => {
+    const client = {
+      getCodingAgentRuntimeSummary: jest.fn().mockResolvedValue({
+        ok: true,
+        summary: summaryFixture(),
+      }),
+      getCodingAgentReviews: jest.fn().mockResolvedValue({
+        ok: true,
+        reviews: reviewsFixture(),
+      }),
+      getCodingAgentReviewSnapshot: jest.fn().mockResolvedValue({
+        ok: true,
+        snapshot: reviewSnapshotWithHunks(),
+      }),
+    };
+    useGatewayMock.mockReturnValue(gatewayContext({
+      client: client as unknown as GatewayClient,
+      connectionState: "connected",
+    }));
+
+    render(<AgentsScreen />);
+
+    await screen.findByText("matrix-os");
+    await act(async () => {
+      fireEvent.press(screen.getByLabelText("Open review PR #759"));
+    });
+
+    expect(await screen.findByText("packages/gateway/src/coding-agents/routes.ts")).toBeTruthy();
+    expect(screen.getByText("+12")).toBeTruthy();
+    expect(screen.getByText("-4")).toBeTruthy();
+    expect(screen.getByText("@@ -42,3 +45,5 @@")).toBeTruthy();
+    expect(screen.getByText("@@ -88,1 +93,2 @@")).toBeTruthy();
+    expect(screen.getByText("Partial hunk")).toBeTruthy();
+
+    const hunk = screen.getByLabelText("Select hunk 2 in packages/gateway/src/coding-agents/routes.ts");
+    await act(async () => {
+      fireEvent.press(hunk);
+    });
+
+    expect(hunk.props.accessibilityState?.selected).toBe(true);
+    expect(screen.queryByText(/export const|function create|raw diff/i)).toBeNull();
+  });
+
+  it("clears selected hunk state when a selected review snapshot refreshes", async () => {
+    const client = {
+      getCodingAgentRuntimeSummary: jest.fn().mockResolvedValue({
+        ok: true,
+        summary: summaryFixture(),
+      }),
+      getCodingAgentReviews: jest.fn().mockResolvedValue({
+        ok: true,
+        reviews: reviewsFixture(),
+      }),
+      getCodingAgentReviewSnapshot: jest.fn()
+        .mockResolvedValueOnce({
+          ok: true,
+          snapshot: reviewSnapshotWithHunks(),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          snapshot: reviewSnapshotWithChangedHunks(),
+        }),
+    };
+    useGatewayMock.mockReturnValue(gatewayContext({
+      client: client as unknown as GatewayClient,
+      connectionState: "connected",
+    }));
+
+    render(<AgentsScreen />);
+
+    await screen.findByText("matrix-os");
+    await act(async () => {
+      fireEvent.press(screen.getByLabelText("Open review PR #759"));
+    });
+
+    const selectedBeforeRefresh = screen.getByLabelText("Select hunk 2 in packages/gateway/src/coding-agents/routes.ts");
+    await act(async () => {
+      fireEvent.press(selectedBeforeRefresh);
+    });
+    expect(selectedBeforeRefresh.props.accessibilityState?.selected).toBe(true);
+
+    await act(async () => {
+      screen.getByLabelText("Refresh agent workspace").props.refreshControl.props.onRefresh();
+    });
+
+    expect(await screen.findByText("@@ -120,4 +130,6 @@")).toBeTruthy();
+    const refreshedHunk = screen.getByLabelText("Select hunk 2 in packages/gateway/src/coding-agents/routes.ts");
+    expect(refreshedHunk.props.accessibilityState?.selected).toBe(false);
   });
 
   it("renders a generic review error without dropping the runtime summary", async () => {

--- a/apps/mobile/app/agents/index.tsx
+++ b/apps/mobile/app/agents/index.tsx
@@ -28,6 +28,8 @@ type ReviewSnapshotState =
   | { status: "ready"; selectedReviewId: string; snapshot: ReviewSnapshot; error: null }
   | { status: "error"; selectedReviewId: string; snapshot: null; error: "Review details unavailable" };
 
+type SelectedReviewHunk = { reviewId: string; snapshotKey: string; key: string };
+
 const INITIAL_REVIEW_SNAPSHOT_STATE: ReviewSnapshotState = {
   status: "idle",
   selectedReviewId: null,
@@ -51,6 +53,25 @@ function safeFindingSummary(summary: string): string {
 
 function safeSnapshotText(value: string, fallback: string): string {
   return SECRET_LIKE_FINDING_TEXT.test(value) ? fallback : value;
+}
+
+function formatHunkRange(hunk: ReviewSnapshot["files"]["items"][number]["hunks"][number]): string {
+  return `@@ -${hunk.oldStart},${hunk.oldLines} +${hunk.newStart},${hunk.newLines} @@`;
+}
+
+function reviewSnapshotSelectionKey(snapshot: ReviewSnapshot): string {
+  return [
+    snapshot.updatedAt,
+    snapshot.files.items.length,
+    snapshot.files.items.map((file) => [
+      file.path,
+      file.status,
+      file.additions,
+      file.deletions,
+      file.partial ? "partial" : "complete",
+      file.hunks.map((hunk) => `${hunk.id}:${hunk.oldStart}:${hunk.oldLines}:${hunk.newStart}:${hunk.newLines}:${hunk.partial ? "partial" : "complete"}`).join("|"),
+    ].join(":")).join("\u0001"),
+  ].join("\u0002");
 }
 
 export default function AgentsScreen() {
@@ -342,7 +363,8 @@ function ReviewSection({
 }
 
 function ReviewSnapshotPanel({ state }: { state: ReviewSnapshotState }) {
-  const { theme } = useUnistyles();
+  const [selectedHunk, setSelectedHunk] = useState<SelectedReviewHunk | null>(null);
+
   if (state.status === "idle") return null;
   if (state.status === "loading") {
     return <Text style={styles.reviewDetailNotice}>Loading review details...</Text>;
@@ -350,6 +372,8 @@ function ReviewSnapshotPanel({ state }: { state: ReviewSnapshotState }) {
   if (state.status === "error") {
     return <Text style={styles.reviewError}>{state.error}</Text>;
   }
+
+  const snapshotKey = reviewSnapshotSelectionKey(state.snapshot);
 
   return (
     <View style={styles.reviewDetailPanel}>
@@ -364,38 +388,99 @@ function ReviewSnapshotPanel({ state }: { state: ReviewSnapshotState }) {
         <Text style={styles.reviewDetailNotice}>{safeSnapshotText(state.snapshot.safeNotice, HIDDEN_REVIEW_NOTICE)}</Text>
       ) : null}
       {state.snapshot.files.items.map((file, fileIndex) => (
-        <View key={`${file.path}:${fileIndex}`} style={styles.reviewFileRow}>
-          <View style={styles.reviewDetailHeader}>
-            <View style={styles.rowIcon}>
-              <Ionicons name="document-text-outline" size={17} color={theme.colors.moss} />
-            </View>
-            <View style={styles.rowText}>
-              <Text
-                selectable={!SECRET_LIKE_FINDING_TEXT.test(file.path)}
-                style={styles.rowTitle}
-              >
-                {safeSnapshotText(file.path, HIDDEN_FILE_PATH)}
-              </Text>
-              <Text style={styles.rowSubtitle}>{file.status}</Text>
-            </View>
-          </View>
-          {file.findings?.length ? (
-            file.findings.map((finding, findingIndex) => (
-              <Text
-                key={`${finding.id}:${finding.line}:${findingIndex}`}
+        <ReviewSnapshotFileRow
+          key={`${file.path}:${fileIndex}`}
+          file={file}
+          fileIndex={fileIndex}
+          selectedReviewId={state.selectedReviewId}
+          snapshotKey={snapshotKey}
+          selectedHunk={selectedHunk}
+          onSelectHunk={setSelectedHunk}
+        />
+      ))}
+    </View>
+  );
+}
+
+function ReviewSnapshotFileRow({
+  file,
+  fileIndex,
+  selectedReviewId,
+  snapshotKey,
+  selectedHunk,
+  onSelectHunk,
+}: {
+  file: ReviewSnapshot["files"]["items"][number];
+  fileIndex: number;
+  selectedReviewId: string;
+  snapshotKey: string;
+  selectedHunk: SelectedReviewHunk | null;
+  onSelectHunk: (hunk: SelectedReviewHunk) => void;
+}) {
+  const { theme } = useUnistyles();
+  const displayPath = safeSnapshotText(file.path, HIDDEN_FILE_PATH);
+
+  return (
+    <View style={styles.reviewFileRow}>
+      <View style={styles.reviewDetailHeader}>
+        <View style={styles.rowIcon}>
+          <Ionicons name="document-text-outline" size={17} color={theme.colors.moss} />
+        </View>
+        <View style={styles.rowText}>
+          <Text
+            selectable={!SECRET_LIKE_FINDING_TEXT.test(file.path)}
+            style={styles.rowTitle}
+          >
+            {displayPath}
+          </Text>
+          <Text style={styles.rowSubtitle}>{file.status}</Text>
+        </View>
+      </View>
+      <View style={styles.reviewFileStats}>
+        <Text style={styles.reviewAdditionBadge}>{`+${file.additions}`}</Text>
+        <Text style={styles.reviewDeletionBadge}>{`-${file.deletions}`}</Text>
+        {file.partial ? <Text style={styles.reviewPartialBadge}>Partial file</Text> : null}
+      </View>
+      {file.findings?.length ? (
+        file.findings.map((finding, findingIndex) => (
+          <Text
+            key={`${finding.id}:${finding.line}:${findingIndex}`}
+            style={[
+              styles.reviewFinding,
+              finding.severity === "high" ? styles.reviewHighActive : null,
+            ]}
+          >
+            {safeFindingSummary(finding.summary)}
+          </Text>
+        ))
+      ) : (
+        <Text style={styles.rowSubtitle}>No findings in this file.</Text>
+      )}
+      {file.hunks.length ? (
+        <View style={styles.reviewHunks}>
+          {file.hunks.map((hunk, hunkIndex) => {
+            const hunkKey = `${fileIndex}\u0000${file.path}\u0000${hunk.id}\u0000${hunkIndex}`;
+            const selected = selectedHunk?.reviewId === selectedReviewId && selectedHunk.snapshotKey === snapshotKey && selectedHunk.key === hunkKey;
+            return (
+              <Pressable
+                key={`${file.path}:${fileIndex}:${hunk.id}:${hunkIndex}`}
+                accessibilityRole="button"
+                accessibilityLabel={`Select hunk ${hunkIndex + 1} in ${displayPath}`}
+                accessibilityState={{ selected }}
+                onPress={() => onSelectHunk({ reviewId: selectedReviewId, snapshotKey, key: hunkKey })}
                 style={[
-                  styles.reviewFinding,
-                  finding.severity === "high" ? styles.reviewHighActive : null,
+                  styles.reviewHunkRow,
+                  selected ? styles.selectedReviewHunkRow : null,
                 ]}
               >
-                {safeFindingSummary(finding.summary)}
-              </Text>
-            ))
-          ) : (
-            <Text style={styles.rowSubtitle}>No findings in this file.</Text>
-          )}
+                <Text style={styles.reviewHunkLabel}>{`Hunk ${hunkIndex + 1}`}</Text>
+                <Text style={styles.reviewHunkRange}>{formatHunkRange(hunk)}</Text>
+                {hunk.partial ? <Text style={styles.reviewHunkPartial}>Partial hunk</Text> : null}
+              </Pressable>
+            );
+          })}
         </View>
-      ))}
+      ) : null}
     </View>
   );
 }
@@ -635,6 +720,75 @@ const styles = StyleSheet.create((theme, rt) => ({
   reviewFinding: {
     fontFamily: theme.fonts.sans,
     fontSize: 12,
+    color: theme.colors.mutedForeground,
+  },
+  reviewFileStats: {
+    flexDirection: "row",
+    flexWrap: "wrap",
+    gap: theme.spacing.xs,
+  },
+  reviewAdditionBadge: {
+    borderRadius: 10,
+    borderCurve: "continuous" as const,
+    borderWidth: 1,
+    borderColor: theme.colors.border,
+    paddingHorizontal: theme.spacing.sm,
+    paddingVertical: 3,
+    fontFamily: theme.fonts.mono,
+    fontSize: 11,
+    color: theme.colors.forest,
+  },
+  reviewDeletionBadge: {
+    borderRadius: 10,
+    borderCurve: "continuous" as const,
+    borderWidth: 1,
+    borderColor: theme.colors.border,
+    paddingHorizontal: theme.spacing.sm,
+    paddingVertical: 3,
+    fontFamily: theme.fonts.mono,
+    fontSize: 11,
+    color: theme.colors.destructive,
+  },
+  reviewPartialBadge: {
+    borderRadius: 10,
+    borderCurve: "continuous" as const,
+    borderWidth: 1,
+    borderColor: theme.colors.border,
+    paddingHorizontal: theme.spacing.sm,
+    paddingVertical: 3,
+    fontFamily: theme.fonts.sansMedium,
+    fontSize: 11,
+    color: theme.colors.mutedForeground,
+  },
+  reviewHunks: {
+    gap: theme.spacing.xs,
+  },
+  reviewHunkRow: {
+    borderRadius: 12,
+    borderCurve: "continuous" as const,
+    borderWidth: 1,
+    borderColor: theme.colors.border,
+    backgroundColor: theme.colors.card,
+    padding: theme.spacing.sm,
+    gap: 2,
+  },
+  selectedReviewHunkRow: {
+    borderColor: theme.colors.forest,
+    backgroundColor: theme.colors.background,
+  },
+  reviewHunkLabel: {
+    fontFamily: theme.fonts.sansSemiBold,
+    fontSize: 12,
+    color: theme.colors.mutedForeground,
+  },
+  reviewHunkRange: {
+    fontFamily: theme.fonts.mono,
+    fontSize: 12,
+    color: theme.colors.foreground,
+  },
+  reviewHunkPartial: {
+    fontFamily: theme.fonts.sans,
+    fontSize: 11,
     color: theme.colors.mutedForeground,
   },
   emptyText: {

--- a/specs/105-coding-agent-shells/current-state.md
+++ b/specs/105-coding-agent-shells/current-state.md
@@ -6,7 +6,7 @@
 
 ## Summary
 
-The stack currently has shared contracts, a gateway runtime summary read model, read-only desktop and mobile workspaces behind flags, thread create/replay/abort/event streaming, provider adapters, a workspace-backed provider, approval/input route handling, a read-only coding-agent review summary route/client contract, desktop/mobile read-only review summary panels, and a read-only coding-agent review snapshot route with bounded file metadata from safe owner worktree diffs plus findings fallback metadata. Desktop review details render changed-file counts and selectable hunk coordinate metadata. Full file content, raw diff lines, mobile hunk navigation, follow-up actions, and preview coding-agent surfaces are contract-only or existing workspace routes; dedicated preview shell UI is not yet integrated.
+The stack currently has shared contracts, a gateway runtime summary read model, read-only desktop and mobile workspaces behind flags, thread create/replay/abort/event streaming, provider adapters, a workspace-backed provider, approval/input route handling, a read-only coding-agent review summary route/client contract, desktop/mobile read-only review summary panels, and a read-only coding-agent review snapshot route with bounded file metadata from safe owner worktree diffs plus findings fallback metadata. Desktop and mobile review details render changed-file counts and selectable hunk coordinate metadata. Full file content, raw diff lines, follow-up actions, and preview coding-agent surfaces are contract-only or existing workspace routes; dedicated preview shell UI is not yet integrated.
 
 Current source-of-truth boundaries:
 
@@ -227,6 +227,7 @@ Screen:
 - `apps/mobile/app/agents/[threadId].tsx`
 - Read-only phone-first dashboard with providers, active threads, and terminal sessions.
 - When the runtime advertises `codingAgentsReview`, the dashboard fetches bounded review summaries through the authenticated gateway client and renders project, PR, round, status, and high-severity count.
+- Review snapshot details render bounded file paths, additions/deletions, partial markers, selectable hunk coordinate metadata, and safe finding summaries. They do not render raw diff lines or file contents.
 - Safe generic review error state if review summaries are unavailable; review failures do not drop the runtime summary dashboard.
 - Composer route for creating accepted coding-agent threads; thread route is a bounded placeholder until replay/review surfaces are wired.
 - Flag: `apps/mobile/lib/feature-flags.ts` with `EXPO_PUBLIC_CODING_AGENTS_MOBILE_WORKSPACE === "1"`.


### PR DESCRIPTION
## Summary

- Adds phone-first hunk metadata rendering to the mobile coding-agent review details panel.
- Shows bounded additions/deletions, partial file markers, selectable hunk coordinate rows, and partial hunk markers without rendering raw file contents or diff lines.
- Keeps hunk selection scoped to the selected review and rendered file row.
- Updates the 105 current-state note to record mobile review hunk metadata behavior.

## Tests

- `pnpm --filter matrix-os-mobile exec jest __tests__/agents-screen.test.tsx` (19 tests)
- `pnpm --filter matrix-os-mobile run test` (237 tests)
- `pnpm --filter matrix-os-mobile run lint`
- `pnpm --filter matrix-os-mobile exec tsc --noEmit`
- `bun run check:patterns` (0 violations; existing warnings only)
- `bun run typecheck`
- `git diff --check`
- Changed-file forbidden reference wording scan returned no matches.

## Review/Monitoring

- Latest Greptile finding for stale hunk selection was fixed with a focused regression test.
- Greptile is running on the current head.
- `ready-for-ci` will be added after the latest Greptile result is 5/5.

## Invariants

- Gateway/runtime remains the source of truth for review snapshot data; mobile only renders contract-validated metadata from the authenticated gateway client.
- No new persistence, endpoint, WebSocket, or credential path is introduced.
- Mobile AsyncStorage is unchanged and still stores only bounded UI references.
- Review UI renders bounded file paths, counts, hunk coordinates, partial markers, and finding summaries only.
- Raw diff lines, file contents, terminal output, provider payloads, filesystem paths, and unsafe errors are not rendered.
