### PR TITLE
feat(desktop): add review hunk follow-up action

### DIFF
--- a/desktop/src/renderer/src/features/coding-agents/AgentWorkspace.tsx
+++ b/desktop/src/renderer/src/features/coding-agents/AgentWorkspace.tsx
@@ -28,6 +28,18 @@ const STATUS_COLOR: Record<string, string> = {
 };
 const DEFAULT_STATUS_COLOR = "var(--text-tertiary)";
 type ReviewDetailStatus = "idle" | "loading" | "ready" | "error";
+type ReviewSnapshotFile = ReviewSnapshot["files"]["items"][number];
+type ReviewSnapshotHunk = ReviewSnapshotFile["hunks"][number];
+type ComposerSeed = {
+  seedId: number;
+  draft: AgentThreadComposerDraft;
+};
+type SelectedReviewHunk = {
+  key: string;
+  file: ReviewSnapshotFile;
+  hunk: ReviewSnapshotHunk;
+  hunkIndex: number;
+};
 
 function capabilityEnabled(summary: RuntimeSummary, id: string): boolean {
   return summary.capabilities.some((capability) => capability.id === id && capability.enabled);
@@ -133,7 +145,66 @@ function ProviderList({ summary }: { summary: RuntimeSummary }) {
   );
 }
 
-function AgentComposer({ summary }: { summary: RuntimeSummary }) {
+export function mergeAttachments(
+  current: AgentThreadComposerDraft["attachments"],
+  seeded: AgentThreadComposerDraft["attachments"],
+): AgentThreadComposerDraft["attachments"] {
+  const currentAttachments = current ?? [];
+  const seededById = new Map((seeded ?? []).map((attachment) => [attachment.id, attachment]));
+  const merged = currentAttachments.map((attachment) => seededById.get(attachment.id) ?? attachment);
+  const seen = new Set(merged.map((attachment) => attachment.id));
+  for (const attachment of seeded ?? []) {
+    if (seen.has(attachment.id) || merged.length >= 8) continue;
+    seen.add(attachment.id);
+    merged.push(attachment);
+  }
+  return merged.length ? merged : undefined;
+}
+
+export function mergeComposerSeed(current: AgentThreadComposerDraft, seeded: AgentThreadComposerDraft): AgentThreadComposerDraft {
+  const currentPrompt = current.prompt.trim();
+  const seededPrompt = seeded.prompt.trim();
+  const attachments = mergeAttachments(current.attachments, seeded.attachments);
+  const missingRequiredReference = (seeded.attachments ?? [])
+    .some((attachment) => attachment.kind === "structured_ref"
+      && !attachments?.some((candidate) => candidate.id === attachment.id));
+  if (missingRequiredReference) return current;
+
+  return {
+    ...seeded,
+    providerId: current.providerId ?? seeded.providerId,
+    mode: current.mode ?? seeded.mode,
+    approvalPolicy: current.approvalPolicy ?? seeded.approvalPolicy,
+    sandboxMode: current.sandboxMode ?? seeded.sandboxMode,
+    prompt: currentPrompt && currentPrompt !== seededPrompt
+      ? `${current.prompt.trimEnd()}\n\n---\n\n${seeded.prompt}`
+      : seeded.prompt,
+    attachments,
+  };
+}
+
+export function clearComposerLaunchContext(current: AgentThreadComposerDraft): AgentThreadComposerDraft {
+  const attachments = current.attachments?.filter((attachment) => attachment.kind !== "structured_ref");
+  return {
+    ...current,
+    projectId: undefined,
+    taskId: undefined,
+    terminalSessionId: undefined,
+    worktreeId: undefined,
+    attachments: attachments?.length ? attachments : undefined,
+  };
+}
+
+function hasComposerContent(current: AgentThreadComposerDraft): boolean {
+  return current.prompt.trim().length > 0
+    || Boolean(current.projectId)
+    || Boolean(current.taskId)
+    || Boolean(current.terminalSessionId)
+    || Boolean(current.worktreeId)
+    || Boolean(current.attachments?.length);
+}
+
+function AgentComposer({ summary, seed }: { summary: RuntimeSummary; seed: ComposerSeed | null }) {
   const initialDraft = useMemo(() => defaultAgentThreadComposerDraft(summary), [summary]);
   const [draft, setDraft] = useState<AgentThreadComposerDraft>(initialDraft);
   const createStatus = useCodingAgentWorkspace((s) => s.createStatus);
@@ -143,8 +214,13 @@ function AgentComposer({ summary }: { summary: RuntimeSummary }) {
   const canCreate = capabilityEnabled(summary, "codingAgentsThreadCreate");
 
   useEffect(() => {
-    setDraft(initialDraft);
+    setDraft((current) => hasComposerContent(current) ? current : initialDraft);
   }, [initialDraft]);
+
+  useEffect(() => {
+    if (!seed) return;
+    setDraft((current) => mergeComposerSeed(current, seed.draft));
+  }, [seed]);
 
   if (!canCreate) return null;
 
@@ -153,8 +229,12 @@ function AgentComposer({ summary }: { summary: RuntimeSummary }) {
 
   async function submit(event: React.FormEvent<HTMLFormElement>) {
     event.preventDefault();
-    const threadId = await createThread(draft);
-    if (!threadId) return;
+    const submittedDraft = draft;
+    const threadId = await createThread(submittedDraft);
+    if (!threadId) {
+      setDraft((current) => clearComposerLaunchContext(current));
+      return;
+    }
     const thread = useCodingAgentWorkspace
       .getState()
       .summary?.activeThreads.items.find((candidate) => candidate.id === threadId);
@@ -164,7 +244,7 @@ function AgentComposer({ summary }: { summary: RuntimeSummary }) {
       title: thread?.title ?? "Agent thread",
       closable: true,
     });
-    setDraft((current) => ({ ...current, prompt: "" }));
+    setDraft(initialDraft);
   }
 
   return (
@@ -333,7 +413,13 @@ function formatHunkRange(hunk: ReviewSnapshot["files"]["items"][number]["hunks"]
   return `@@ -${hunk.oldStart},${hunk.oldLines} +${hunk.newStart},${hunk.newLines} @@`;
 }
 
-function ReviewList() {
+function ReviewList({
+  canCreateFollowUp,
+  onAskHunkFollowUp,
+}: {
+  canCreateFollowUp: boolean;
+  onAskHunkFollowUp: (snapshot: ReviewSnapshot, selected: SelectedReviewHunk) => void;
+}) {
   const reviewsStatus = useCodingAgentWorkspace((s) => s.reviewsStatus);
   const reviews = useCodingAgentWorkspace((s) => s.reviews);
   const reviewsError = useCodingAgentWorkspace((s) => s.reviewsError);
@@ -390,6 +476,8 @@ function ReviewList() {
           status={reviewSnapshotStatus}
           snapshot={reviewSnapshot}
           error={reviewSnapshotError}
+          canCreateFollowUp={canCreateFollowUp}
+          onAskHunkFollowUp={onAskHunkFollowUp}
         />
         {reviewsStatus !== "error" && reviewsStatus !== "loading" && items.length === 0 ? (
           <p className="rounded-md border p-3 text-sm" style={{ borderColor: "var(--border-subtle)", color: "var(--text-secondary)" }}>
@@ -405,16 +493,30 @@ function ReviewSnapshotPanel({
   status,
   snapshot,
   error,
+  canCreateFollowUp,
+  onAskHunkFollowUp,
 }: {
   status: ReviewDetailStatus;
   snapshot: ReviewSnapshot | null;
   error: string | null;
+  canCreateFollowUp: boolean;
+  onAskHunkFollowUp: (snapshot: ReviewSnapshot, selected: SelectedReviewHunk) => void;
 }) {
   const [selectedHunkKey, setSelectedHunkKey] = useState<string | null>(null);
+  const selectedHunk = useMemo(() => {
+    if (!snapshot || !selectedHunkKey) return null;
+    for (const [fileIndex, file] of snapshot.files.items.entries()) {
+      for (const [hunkIndex, hunk] of file.hunks.entries()) {
+        const key = reviewHunkKey(fileIndex, file, hunk, hunkIndex);
+        if (key === selectedHunkKey) return { key, file, hunk, hunkIndex };
+      }
+    }
+    return null;
+  }, [selectedHunkKey, snapshot]);
 
   useEffect(() => {
     setSelectedHunkKey(null);
-  }, [snapshot?.review.id]);
+  }, [snapshot?.review.id, snapshot?.updatedAt]);
 
   if (status === "idle") return null;
   if (status === "loading") {
@@ -500,8 +602,8 @@ function ReviewSnapshotPanel({
             {file.hunks.length ? (
               <div className="grid gap-1">
                 {file.hunks.map((hunk, hunkIndex) => {
-                  const hunkKey = `${fileIndex}\u0000${file.path}\u0000${hunk.id}\u0000${hunkIndex}`;
-                  const selected = selectedHunkKey === hunkKey;
+                  const hunkKey = reviewHunkKey(fileIndex, file, hunk, hunkIndex);
+                  const selected = selectedHunk?.key === hunkKey;
                   return (
                     <button
                       key={`${file.path}:${fileIndex}:${hunk.id}:${hunkIndex}`}
@@ -534,8 +636,58 @@ function ReviewSnapshotPanel({
           </div>
         ))}
       </div>
+      {selectedHunk ? (
+        <div className="flex justify-end">
+          <Button
+            variant="ghost"
+            type="button"
+            disabled={!canCreateFollowUp}
+            onClick={() => onAskHunkFollowUp(snapshot, selectedHunk)}
+            aria-label="Ask agent about selected hunk"
+          >
+            <Bot size={14} />
+            Ask agent about selected hunk
+          </Button>
+        </div>
+      ) : null}
     </article>
   );
+}
+
+function reviewHunkKey(fileIndex: number, file: ReviewSnapshotFile, hunk: ReviewSnapshotHunk, hunkIndex: number): string {
+  return `${fileIndex}\u0000${file.path}\u0000${hunk.id}\u0000${hunkIndex}`;
+}
+
+function safeReferenceSegment(value: string): string {
+  return value.replace(/[^A-Za-z0-9_.:-]+/g, "_").replace(/\.\.+/g, "_").slice(0, 64) || "ref";
+}
+
+function reviewHunkFollowUpDraft(summary: RuntimeSummary, snapshot: ReviewSnapshot, selected: SelectedReviewHunk): AgentThreadComposerDraft {
+  const base = defaultAgentThreadComposerDraft(summary);
+  const range = formatHunkRange(selected.hunk);
+  const hunkNumber = selected.hunkIndex + 1;
+  return {
+    ...base,
+    projectId: snapshot.review.projectId,
+    prompt: [
+      "Please follow up on this review hunk.",
+      "",
+      `Review: PR #${snapshot.review.pullRequestNumber}, round ${snapshot.review.round} of ${snapshot.review.maxRounds}`,
+      `Project: ${snapshot.review.projectId}`,
+      `File: ${selected.file.path}`,
+      `Hunk: ${range}`,
+      "",
+      "Use the structured reference attached to inspect the current source and propose the smallest safe fix.",
+    ].join("\n"),
+    attachments: [
+      {
+        id: `review:${safeReferenceSegment(snapshot.review.id)}:hunk:${safeReferenceSegment(selected.hunk.id)}`,
+        kind: "structured_ref",
+        label: `Review hunk ${hunkNumber}`,
+        path: selected.file.path,
+      },
+    ],
+  };
 }
 
 export default function AgentWorkspace() {
@@ -544,6 +696,7 @@ export default function AgentWorkspace() {
   const summary = useCodingAgentWorkspace((s) => s.summary);
   const error = useCodingAgentWorkspace((s) => s.error);
   const refresh = useCodingAgentWorkspace((s) => s.refresh);
+  const [composerSeed, setComposerSeed] = useState<ComposerSeed | null>(null);
 
   useEffect(() => {
     void refresh();
@@ -572,17 +725,29 @@ export default function AgentWorkspace() {
 
   if (!summary) return null;
 
+  const canCreateFollowUp = capabilityEnabled(summary, "codingAgentsThreadCreate");
+
   return (
     <div className="flex min-h-0 flex-1 flex-col">
       <RuntimeHeader summary={summary} onRefresh={() => void refresh()} />
       <div className="grid min-h-0 flex-1 gap-4 overflow-y-auto p-5">
-        <AgentComposer summary={summary} />
+        <AgentComposer summary={summary} seed={composerSeed} />
         <ProviderList summary={summary} />
         <div className="grid gap-4 xl:grid-cols-2">
           <ThreadList summary={summary} />
           <TerminalList summary={summary} />
         </div>
-        {capabilityEnabled(summary, "codingAgentsReview") ? <ReviewList /> : null}
+        {capabilityEnabled(summary, "codingAgentsReview") ? (
+          <ReviewList
+            canCreateFollowUp={canCreateFollowUp}
+            onAskHunkFollowUp={(snapshot, selected) => {
+              setComposerSeed({
+                seedId: Date.now(),
+                draft: reviewHunkFollowUpDraft(summary, snapshot, selected),
+              });
+            }}
+          />
+        ) : null}
       </div>
     </div>
   );

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -210,6 +210,8 @@ export const AgentAttachmentSchema = z.object({
   sizeBytes: z.number().int().min(0).max(5 * 1024 * 1024).optional(),
 }).strict();
 
+export type AgentAttachment = z.infer<typeof AgentAttachmentSchema>;
+
 export const CreateAgentThreadRequestSchema = z.object({
   providerId: ProviderIdSchema,
   prompt: boundedText(24_000, 96 * 1024),

--- a/packages/gateway/src/agent-session-manager.ts
+++ b/packages/gateway/src/agent-session-manager.ts
@@ -4,11 +4,15 @@ import { access, readdir } from "node:fs/promises";
 import { join, resolve } from "node:path";
 import { z } from "zod/v4";
 import {
+  AgentAttachmentSchema,
+  type AgentAttachment,
+} from "@matrix-os/contracts";
+import {
   SupportedAgentSchema,
   type AgentLaunchSandbox,
   type SupportedAgent,
 } from "./agent-launcher.js";
-import { PromptContentSchema } from "./prompt-validation.js";
+import { MAX_PROMPT_CONTENT_LENGTH, PromptContentSchema } from "./prompt-validation.js";
 import { PROJECT_SLUG_REGEX, type ProjectConfig, type WorkspaceError } from "./project-manager.js";
 import { atomicWriteJson, readJsonFile } from "./state-ops.js";
 import type { createAgentLauncher } from "./agent-launcher.js";
@@ -88,6 +92,7 @@ const StartSessionSchema = z.object({
   pr: z.number().int().positive().optional(),
   agent: SupportedAgentSchema.optional(),
   prompt: PromptContentSchema.optional(),
+  attachments: z.array(AgentAttachmentSchema).max(8).optional(),
   mode: z.enum(["default", "plan", "review", "full_access"]).optional(),
   approvalPolicy: z.enum(["untrusted", "on_request", "on_failure", "never"]).optional(),
   sandboxMode: z.enum(["read_only", "workspace_write", "full_access"]).optional(),
@@ -116,6 +121,32 @@ function toAgentApprovalPolicy(policy?: SessionApprovalPolicy): "untrusted" | "o
   if (policy === "on_request") return "on-request";
   if (policy === "on_failure") return "on-failure";
   return policy;
+}
+
+function launchPromptWithReferences(prompt: string | undefined, attachments: AgentAttachment[] | undefined): string | undefined {
+  const references = (attachments ?? [])
+    .filter((attachment) => attachment.kind === "structured_ref")
+    .map((attachment) => {
+      const target = attachment.path ? `: ${attachment.path}` : "";
+      return `- [${attachment.kind}] ${attachment.label}${target}`;
+    });
+  if (references.length === 0) return prompt;
+  const context = ["Context references:", ...references].join("\n");
+  const nextPrompt = prompt && prompt.trim().length > 0 ? `${prompt}\n\n${context}` : context;
+  const parsed = PromptContentSchema.safeParse(nextPrompt);
+  if (parsed.success) return parsed.data;
+
+  const contextOnly = PromptContentSchema.safeParse(context);
+  if (!contextOnly.success) return prompt;
+  if (!prompt || prompt.trim().length === 0) return contextOnly.data;
+
+  const separator = "\n\n";
+  const promptBudget = MAX_PROMPT_CONTENT_LENGTH - context.length - separator.length;
+  if (promptBudget <= 0) return contextOnly.data;
+
+  const truncatedPrompt = prompt.slice(0, promptBudget);
+  const boundedPrompt = PromptContentSchema.safeParse(`${truncatedPrompt}${separator}${context}`);
+  return boundedPrompt.success ? boundedPrompt.data : contextOnly.data;
 }
 
 async function pathExists(path: string): Promise<boolean> {
@@ -295,7 +326,7 @@ export function createAgentSessionManager(options: {
           ? options.agentLauncher.buildLaunch({
             agent: request.agent!,
             cwd,
-            prompt: request.prompt,
+            prompt: launchPromptWithReferences(request.prompt, request.attachments),
             mode: request.mode,
             sandbox: request.sandbox,
             approvalPolicy: toAgentApprovalPolicy(request.approvalPolicy),

--- a/packages/gateway/src/coding-agents/workspace-provider.ts
+++ b/packages/gateway/src/coding-agents/workspace-provider.ts
@@ -126,6 +126,7 @@ export function createWorkspaceCodingAgentProvider(
           kind: "agent",
           agent,
           prompt: request.prompt,
+          attachments: request.attachments,
           projectSlug: request.projectId,
           taskId: request.taskId,
           worktreeId: request.worktreeId,

--- a/packages/gateway/src/prompt-validation.ts
+++ b/packages/gateway/src/prompt-validation.ts
@@ -2,8 +2,9 @@ import { z } from "zod/v4";
 
 export const DANGEROUS_CONTROL_CHARS = /[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]/;
 export const DANGEROUS_CONTROL_CHARS_GLOBAL = /[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]/g;
+export const MAX_PROMPT_CONTENT_LENGTH = 100_000;
 
-export const PromptContentSchema = z.string().max(100_000).refine(
+export const PromptContentSchema = z.string().max(MAX_PROMPT_CONTENT_LENGTH).refine(
   (s) => !DANGEROUS_CONTROL_CHARS.test(s),
   "Prompt contains invalid control characters",
 );

--- a/packages/gateway/src/workspace-session-orchestrator.ts
+++ b/packages/gateway/src/workspace-session-orchestrator.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from "node:crypto";
+import type { AgentAttachment } from "@matrix-os/contracts";
 import type {
   WorkspaceSessionView,
   createAgentSessionManager,
@@ -38,6 +39,7 @@ export interface StartWorkspaceSessionRequest {
   kind: "shell" | "agent";
   agent?: SupportedAgent;
   prompt?: string;
+  attachments?: AgentAttachment[];
   mode?: "default" | "plan" | "review" | "full_access";
   approvalPolicy?: "untrusted" | "on_request" | "on_failure" | "never";
   sandboxMode?: "read_only" | "workspace_write" | "full_access";

--- a/specs/105-coding-agent-shells/current-state.md
+++ b/specs/105-coding-agent-shells/current-state.md
@@ -6,7 +6,7 @@
 
 ## Summary
 
-The stack currently has shared contracts, a gateway runtime summary read model, read-only desktop and mobile workspaces behind flags, thread create/replay/abort/event streaming, provider adapters, a workspace-backed provider, approval/input route handling, a read-only coding-agent review summary route/client contract, desktop/mobile read-only review summary panels, and a read-only coding-agent review snapshot route with bounded file metadata from safe owner worktree diffs plus findings fallback metadata. Desktop and mobile review details render changed-file counts and selectable hunk coordinate metadata. Full file content, raw diff lines, follow-up actions, and preview coding-agent surfaces are contract-only or existing workspace routes; dedicated preview shell UI is not yet integrated.
+The stack currently has shared contracts, a gateway runtime summary read model, read-only desktop and mobile workspaces behind flags, thread create/replay/abort/event streaming, provider adapters, a workspace-backed provider, approval/input route handling, a read-only coding-agent review summary route/client contract, desktop/mobile read-only review summary panels, and a read-only coding-agent review snapshot route with bounded file metadata from safe owner worktree diffs plus findings fallback metadata. Desktop and mobile review details render changed-file counts and selectable hunk coordinate metadata. Desktop can seed the existing agent composer from a selected review hunk using bounded prompt context and a `structured_ref` attachment. Full file content, raw diff lines, mobile follow-up actions, and preview coding-agent surfaces are contract-only or existing workspace routes; dedicated preview shell UI is not yet integrated.
 
 Current source-of-truth boundaries:
 
@@ -128,6 +128,7 @@ Workspace provider behavior:
 
 - Starts deterministic workspace agent sessions through `WorkspaceSessionOrchestrator`.
 - Passes through prompt, project, task, worktree, mode, approval policy, sandbox mode, and zellij runtime preference.
+- Passes bounded `structured_ref` attachments into the runtime launch prompt as safe reference metadata so review follow-up runs can inspect the selected file/hunk without client-side diff contents.
 - Binds coding-agent threads to canonical `terminalSessionId` from the workspace session.
 - Aborts through the deterministic workspace session id.
 - Keeps provider startup failures safe in the returned thread snapshot.
@@ -207,6 +208,7 @@ Current behavior:
 - Read-only dashboard renders providers, active threads, and terminals.
 - When the runtime advertises `codingAgentsReview`, the dashboard fetches bounded review summaries through the trusted main-process IPC route and renders project, PR, round, status, and high-severity count.
 - Review snapshot details render bounded file paths, additions/deletions, partial markers, selectable hunk coordinate metadata, and safe finding summaries. They do not render raw diff lines or file contents.
+- When thread creation is enabled, selecting a review hunk can seed the existing desktop composer with bounded review metadata and a `structured_ref` attachment for the target file/hunk; the normal trusted `runtime:create-thread` IPC path performs the mutation.
 - Safe generic error state if the runtime summary is unavailable.
 - Safe generic review error state if review summaries are unavailable; review failures do not drop the runtime summary dashboard.
 - No provider credentials or bearer tokens are exposed to the renderer.
@@ -257,7 +259,7 @@ Relevant existing browser shell paths:
 
 Open follow-up: decide whether a browser-shell coding-agent entry belongs in Canvas, Developer mode, or both after desktop/mobile read-only shells settle.
 
-Public docs note: public docs remain deferred for these review-summary/snapshot slices because the cross-shell review flow still lacks full file diffs and preview integration. Update `www/content/docs/` when the file/review/preview surfaces become stable in desktop, mobile, or browser shell navigation.
+Public docs note: public docs remain deferred for these review-summary/snapshot/follow-up slices because the cross-shell review flow still lacks full file diffs, mobile follow-up actions, and preview integration. Update `www/content/docs/` when the file/review/preview surfaces become stable in desktop, mobile, or browser shell navigation.
 
 ## Feature Flags
 

--- a/tests/desktop/coding-agent-workspace.test.tsx
+++ b/tests/desktop/coding-agent-workspace.test.tsx
@@ -3,7 +3,10 @@
 import React from "react";
 import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import AgentWorkspace from "../../desktop/src/renderer/src/features/coding-agents/AgentWorkspace";
+import AgentWorkspace, {
+  clearComposerLaunchContext,
+  mergeComposerSeed,
+} from "../../desktop/src/renderer/src/features/coding-agents/AgentWorkspace";
 import { useCodingAgentWorkspace } from "../../desktop/src/renderer/src/stores/coding-agent-workspace";
 import { useConnection } from "../../desktop/src/renderer/src/stores/connection";
 
@@ -261,6 +264,371 @@ describe("AgentWorkspace", () => {
     fireEvent.click(hunk);
     expect(hunk.getAttribute("aria-pressed")).toBe("true");
     expect(screen.queryByText(/export const|function create|raw diff/i)).toBeNull();
+  });
+
+  it("seeds the desktop composer with structured review hunk follow-up context", async () => {
+    window.operator.invoke = vi.fn((channel: string) => {
+      if (channel === "runtime:get-summary") return Promise.resolve(summaryFixture({ threadCreate: true }));
+      if (channel === "runtime:get-reviews") return Promise.resolve(reviewsFixture());
+      if (channel === "runtime:get-review-snapshot") return Promise.resolve(reviewSnapshotFixture());
+      if (channel === "runtime:create-thread") {
+        return Promise.resolve({
+          thread: {
+            id: "thread_review_followup",
+            providerId: "codex",
+            title: "Follow up on review hunk",
+            status: "queued",
+            attention: "none",
+            createdAt: "2026-07-06T00:00:00.000Z",
+            updatedAt: "2026-07-06T00:00:00.000Z",
+          },
+          events: {
+            items: [],
+            hasMore: false,
+            limit: 200,
+          },
+        });
+      }
+      return Promise.reject(new Error("unexpected channel"));
+    });
+
+    render(<AgentWorkspace />);
+
+    await screen.findByText("matrix-os");
+    fireEvent.click(screen.getByRole("button", { name: /Open review PR #758/i }));
+
+    const hunk = await screen.findByRole("button", {
+      name: /Select hunk 2 in packages\/gateway\/src\/coding-agents\/routes\.ts/i,
+    });
+    fireEvent.click(hunk);
+    fireEvent.click(screen.getByRole("button", { name: "Ask agent about selected hunk" }));
+
+    const prompt = screen.getByLabelText("Agent run prompt") as HTMLTextAreaElement;
+    expect(prompt.value).toContain("PR #758");
+    expect(prompt.value).toContain("packages/gateway/src/coding-agents/routes.ts");
+    expect(prompt.value).toContain("@@ -88,1 +93,2 @@");
+    expect(prompt.value).not.toMatch(/export const|function create|raw diff/i);
+
+    fireEvent.click(screen.getByRole("button", { name: "Start run" }));
+
+    await waitFor(() => {
+      expect(window.operator.invoke).toHaveBeenCalledWith(
+        "runtime:create-thread",
+        expect.objectContaining({
+          prompt: expect.stringContaining("Please follow up on this review hunk"),
+          attachments: [
+            expect.objectContaining({
+              kind: "structured_ref",
+              label: expect.stringContaining("Review hunk"),
+              path: "packages/gateway/src/coding-agents/routes.ts",
+            }),
+          ],
+        }),
+      );
+    });
+  });
+
+  it("preserves existing desktop composer text when seeding review hunk follow-up context", async () => {
+    window.operator.invoke = vi.fn((channel: string) => {
+      if (channel === "runtime:get-summary") return Promise.resolve(summaryFixture({ threadCreate: true }));
+      if (channel === "runtime:get-reviews") return Promise.resolve(reviewsFixture());
+      if (channel === "runtime:get-review-snapshot") return Promise.resolve(reviewSnapshotFixture());
+      return Promise.reject(new Error("unexpected channel"));
+    });
+
+    render(<AgentWorkspace />);
+
+    await screen.findByLabelText("Agent run prompt");
+    fireEvent.change(screen.getByLabelText("Agent run prompt"), {
+      target: { value: "Keep my existing investigation notes." },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /Open review PR #758/i }));
+
+    const hunk = await screen.findByRole("button", {
+      name: /Select hunk 1 in packages\/gateway\/src\/coding-agents\/routes\.ts/i,
+    });
+    fireEvent.click(hunk);
+    fireEvent.click(screen.getByRole("button", { name: "Ask agent about selected hunk" }));
+
+    const prompt = screen.getByLabelText("Agent run prompt") as HTMLTextAreaElement;
+    expect(prompt.value).toContain("Keep my existing investigation notes.");
+    expect(prompt.value).toContain("Please follow up on this review hunk.");
+  });
+
+  it("leaves the desktop composer unchanged when a required follow-up reference cannot fit", () => {
+    const currentAttachments = Array.from({ length: 8 }, (_, index) => ({
+      id: `file_${index}`,
+      kind: "file" as const,
+      label: `Existing file ${index}`,
+      path: `packages/example/${index}.ts`,
+    }));
+
+    const draft = mergeComposerSeed(
+      {
+        providerId: "codex",
+        prompt: "Existing draft",
+        mode: "default",
+        approvalPolicy: "on_request",
+        sandboxMode: "workspace_write",
+        attachments: currentAttachments,
+      },
+      {
+        providerId: "codex",
+        prompt: "Seeded review prompt",
+        mode: "default",
+        approvalPolicy: "on_request",
+        sandboxMode: "workspace_write",
+        projectId: "matrix-os",
+        attachments: [
+          {
+            id: "review:rev_desktop_1:hunk:hunk_2",
+            kind: "structured_ref",
+            label: "Review hunk 2",
+            path: "packages/gateway/src/coding-agents/routes.ts",
+          },
+        ],
+      },
+    );
+
+    expect(draft.attachments).toHaveLength(8);
+    expect(draft.attachments?.map((attachment) => attachment.id)).toEqual(currentAttachments.map((attachment) => attachment.id));
+    expect(draft.prompt).toBe("Existing draft");
+    expect(draft.projectId).toBeUndefined();
+  });
+
+  it("preserves user attachments when clearing failed desktop follow-up launch context", () => {
+    const cleaned = clearComposerLaunchContext({
+      providerId: "codex",
+      prompt: "Retry with my attached file.",
+      mode: "default",
+      approvalPolicy: "on_request",
+      sandboxMode: "workspace_write",
+      projectId: "matrix-os",
+      attachments: [
+        {
+          id: "file_existing_1",
+          kind: "file",
+          label: "Existing file",
+          path: "packages/example/existing.ts",
+        },
+        {
+          id: "review:rev_desktop_1:hunk:hunk_2",
+          kind: "structured_ref",
+          label: "Review hunk 2",
+          path: "packages/gateway/src/coding-agents/routes.ts",
+        },
+      ],
+    });
+
+    expect(cleaned.projectId).toBeUndefined();
+    expect(cleaned.attachments).toEqual([
+      expect.objectContaining({
+        id: "file_existing_1",
+        kind: "file",
+      }),
+    ]);
+  });
+
+  it("clears seeded review project context after a desktop follow-up run starts", async () => {
+    window.operator.invoke = vi.fn((channel: string) => {
+      if (channel === "runtime:get-summary") return Promise.resolve(summaryFixture({ threadCreate: true }));
+      if (channel === "runtime:get-reviews") return Promise.resolve(reviewsFixture());
+      if (channel === "runtime:get-review-snapshot") return Promise.resolve(reviewSnapshotFixture());
+      if (channel === "runtime:create-thread") {
+        return Promise.resolve({
+          thread: {
+            id: "thread_review_followup",
+            providerId: "codex",
+            title: "Follow up on review hunk",
+            status: "queued",
+            attention: "none",
+            createdAt: "2026-07-06T00:00:00.000Z",
+            updatedAt: "2026-07-06T00:00:00.000Z",
+          },
+          events: {
+            items: [],
+            hasMore: false,
+            limit: 200,
+          },
+        });
+      }
+      return Promise.reject(new Error("unexpected channel"));
+    });
+
+    render(<AgentWorkspace />);
+
+    await screen.findByText("matrix-os");
+    fireEvent.click(screen.getByRole("button", { name: /Open review PR #758/i }));
+    const hunk = await screen.findByRole("button", {
+      name: /Select hunk 1 in packages\/gateway\/src\/coding-agents\/routes\.ts/i,
+    });
+    fireEvent.click(hunk);
+    fireEvent.click(screen.getByRole("button", { name: "Ask agent about selected hunk" }));
+    fireEvent.click(screen.getByRole("button", { name: "Start run" }));
+
+    await waitFor(() => {
+      expect(window.operator.invoke).toHaveBeenCalledWith(
+        "runtime:create-thread",
+        expect.objectContaining({ projectId: "matrix-os" }),
+      );
+    });
+
+    fireEvent.change(screen.getByLabelText("Agent run prompt"), {
+      target: { value: "Start an unrelated desktop run." },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Start run" }));
+
+    await waitFor(() => {
+      const createCalls = vi.mocked(window.operator.invoke).mock.calls
+        .filter(([channel]) => channel === "runtime:create-thread");
+      expect(createCalls).toHaveLength(2);
+      expect(createCalls[1]?.[1]).toEqual(expect.not.objectContaining({ projectId: "matrix-os" }));
+    });
+  });
+
+  it("clears seeded review project context after a desktop follow-up start fails", async () => {
+    let createCount = 0;
+    let rejectFirstCreate: (reason?: unknown) => void = () => undefined;
+    window.operator.invoke = vi.fn((channel: string) => {
+      if (channel === "runtime:get-summary") return Promise.resolve(summaryFixture({ threadCreate: true }));
+      if (channel === "runtime:get-reviews") return Promise.resolve(reviewsFixture());
+      if (channel === "runtime:get-review-snapshot") return Promise.resolve(reviewSnapshotFixture());
+      if (channel === "runtime:create-thread") {
+        createCount += 1;
+        if (createCount === 1) {
+          return new Promise((_, reject) => {
+            rejectFirstCreate = reject;
+          });
+        }
+        return Promise.resolve({
+          thread: {
+            id: "thread_unrelated_after_failure",
+            providerId: "codex",
+            title: "Unrelated desktop run",
+            status: "queued",
+            attention: "none",
+            createdAt: "2026-07-06T00:00:00.000Z",
+            updatedAt: "2026-07-06T00:00:00.000Z",
+          },
+          events: {
+            items: [],
+            hasMore: false,
+            limit: 200,
+          },
+        });
+      }
+      return Promise.reject(new Error("unexpected channel"));
+    });
+
+    render(<AgentWorkspace />);
+
+    await screen.findByText("matrix-os");
+    fireEvent.click(screen.getByRole("button", { name: /Open review PR #758/i }));
+    const hunk = await screen.findByRole("button", {
+      name: /Select hunk 1 in packages\/gateway\/src\/coding-agents\/routes\.ts/i,
+    });
+    fireEvent.click(hunk);
+    fireEvent.click(screen.getByRole("button", { name: "Ask agent about selected hunk" }));
+    fireEvent.click(screen.getByRole("button", { name: "Start run" }));
+
+    fireEvent.change(screen.getByLabelText("Agent run prompt"), {
+      target: { value: "Start an unrelated desktop run after a failed follow-up." },
+    });
+    rejectFirstCreate(new Error("provider failed at /home/matrix/private token secret"));
+
+    expect(await screen.findByText("Agent run could not be started. Try again.")).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("button", { name: "Start run" }));
+
+    await waitFor(() => {
+      const createCalls = vi.mocked(window.operator.invoke).mock.calls
+        .filter(([channel]) => channel === "runtime:create-thread");
+      expect(createCalls).toHaveLength(2);
+      expect(createCalls[0]?.[1]).toEqual(expect.objectContaining({
+        projectId: "matrix-os",
+        attachments: [expect.objectContaining({ kind: "structured_ref" })],
+      }));
+      expect(createCalls[1]?.[1]).toEqual(expect.not.objectContaining({ projectId: "matrix-os" }));
+      expect(createCalls[1]?.[1]).toEqual(expect.not.objectContaining({ attachments: expect.anything() }));
+    });
+  });
+
+  it("keeps a seeded desktop follow-up draft across runtime summary refreshes", async () => {
+    window.operator.invoke = vi.fn((channel: string) => {
+      if (channel === "runtime:get-summary") return Promise.resolve(summaryFixture({ threadCreate: true }));
+      if (channel === "runtime:get-reviews") return Promise.resolve(reviewsFixture());
+      if (channel === "runtime:get-review-snapshot") return Promise.resolve(reviewSnapshotFixture());
+      return Promise.reject(new Error("unexpected channel"));
+    });
+
+    render(<AgentWorkspace />);
+
+    await screen.findByText("matrix-os");
+    fireEvent.click(screen.getByRole("button", { name: /Open review PR #758/i }));
+    const hunk = await screen.findByRole("button", {
+      name: /Select hunk 2 in packages\/gateway\/src\/coding-agents\/routes\.ts/i,
+    });
+    fireEvent.click(hunk);
+    fireEvent.click(screen.getByRole("button", { name: "Ask agent about selected hunk" }));
+
+    const prompt = screen.getByLabelText("Agent run prompt") as HTMLTextAreaElement;
+    expect(prompt.value).toContain("PR #758");
+
+    fireEvent.click(screen.getByRole("button", { name: "Refresh agent workspace" }));
+
+    await waitFor(() => {
+      expect((screen.getByLabelText("Agent run prompt") as HTMLTextAreaElement).value).toContain("PR #758");
+    });
+    expect((screen.getByLabelText("Agent run prompt") as HTMLTextAreaElement).value).toContain("@@ -88,1 +93,2 @@");
+  });
+
+  it("uses refreshed review hunk data when reseeding desktop follow-up context", async () => {
+    const refreshedSnapshot = {
+      ...reviewSnapshotFixture(),
+      files: {
+        ...reviewSnapshotFixture().files,
+        items: reviewSnapshotFixture().files.items.map((file) => ({
+          ...file,
+          hunks: file.hunks.map((hunk, hunkIndex) => hunkIndex === 1
+            ? {
+                ...hunk,
+                oldStart: 120,
+                oldLines: 4,
+                newStart: 130,
+                newLines: 6,
+              }
+            : hunk),
+        })),
+      },
+    };
+    window.operator.invoke = vi.fn((channel: string) => {
+      if (channel === "runtime:get-summary") return Promise.resolve(summaryFixture({ threadCreate: true }));
+      if (channel === "runtime:get-reviews") return Promise.resolve(reviewsFixture());
+      if (channel === "runtime:get-review-snapshot") {
+        const calls = vi.mocked(window.operator.invoke).mock.calls
+          .filter(([candidate]) => candidate === "runtime:get-review-snapshot");
+        return Promise.resolve(calls.length === 1 ? reviewSnapshotFixture() : refreshedSnapshot);
+      }
+      return Promise.reject(new Error("unexpected channel"));
+    });
+
+    render(<AgentWorkspace />);
+
+    await screen.findByText("matrix-os");
+    const reviewButton = screen.getByRole("button", { name: /Open review PR #758/i });
+    fireEvent.click(reviewButton);
+    const hunk = await screen.findByRole("button", {
+      name: /Select hunk 2 in packages\/gateway\/src\/coding-agents\/routes\.ts/i,
+    });
+    fireEvent.click(hunk);
+    fireEvent.click(reviewButton);
+    expect(await screen.findByText("@@ -120,4 +130,6 @@")).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("button", { name: "Ask agent about selected hunk" }));
+
+    const prompt = screen.getByLabelText("Agent run prompt") as HTMLTextAreaElement;
+    expect(prompt.value).toContain("@@ -120,4 +130,6 @@");
+    expect(prompt.value).not.toContain("@@ -88,1 +93,2 @@");
   });
 
   it("keeps hunk selection scoped to the file when hunk ids collide", async () => {

--- a/tests/gateway/agent-session-manager.test.ts
+++ b/tests/gateway/agent-session-manager.test.ts
@@ -152,6 +152,66 @@ describe("agent-session-manager", () => {
     expect(record.ownerId).toBe("user_a");
   });
 
+  it("includes bounded structured attachments in the agent launch prompt", async () => {
+    const { manager, agentLauncher } = createManager();
+
+    await manager.startSession({
+      kind: "agent",
+      agent: "codex",
+      ownerId: "user_a",
+      projectSlug: "repo",
+      worktreeId,
+      prompt: "Please follow up on this review hunk.",
+      attachments: [
+        {
+          id: "review:rev_desktop_1:hunk:hunk_1",
+          kind: "structured_ref",
+          label: "Review hunk 1",
+          path: "packages/gateway/src/coding-agents/routes.ts",
+        },
+      ],
+    });
+
+    expect(agentLauncher.buildLaunch).toHaveBeenCalledWith(expect.objectContaining({
+      prompt: expect.stringContaining("Please follow up on this review hunk."),
+    }));
+    expect(agentLauncher.buildLaunch).toHaveBeenCalledWith(expect.objectContaining({
+      prompt: expect.stringContaining("[structured_ref] Review hunk 1: packages/gateway/src/coding-agents/routes.ts"),
+    }));
+    expect(agentLauncher.buildLaunch).not.toHaveBeenCalledWith(expect.objectContaining({
+      prompt: expect.stringMatching(/export const|function create|raw diff/i),
+    }));
+  });
+
+  it("keeps structured references when the launch prompt is near the prompt bound", async () => {
+    const { manager, agentLauncher } = createManager();
+    const maxPrompt = "x".repeat(100_000);
+
+    await manager.startSession({
+      kind: "agent",
+      agent: "codex",
+      ownerId: "user_a",
+      projectSlug: "repo",
+      worktreeId,
+      prompt: maxPrompt,
+      attachments: [
+        {
+          id: "review:rev_desktop_1:hunk:hunk_2",
+          kind: "structured_ref",
+          label: "Review hunk 2",
+          path: "packages/gateway/src/agent-session-manager.ts",
+        },
+      ],
+    });
+
+    expect(agentLauncher.buildLaunch).toHaveBeenCalledWith(expect.objectContaining({
+      prompt: expect.stringContaining("[structured_ref] Review hunk 2: packages/gateway/src/agent-session-manager.ts"),
+    }));
+    const launchPrompt = vi.mocked(agentLauncher.buildLaunch).mock.calls.at(-1)?.[0].prompt;
+    expect(launchPrompt).toBeDefined();
+    expect(launchPrompt?.length).toBeLessThanOrEqual(100_000);
+  });
+
   it("rejects competing write sessions before launching a runtime", async () => {
     const { manager, worktreeManager, zellijRuntime } = createManager();
     await worktreeManager.acquireLease({

--- a/tests/gateway/coding-agents-workspace-provider.test.ts
+++ b/tests/gateway/coding-agents-workspace-provider.test.ts
@@ -99,6 +99,51 @@ describe("coding agent workspace provider", () => {
     ]);
   });
 
+  it("forwards structured review references to the workspace runtime session", async () => {
+    const homePath = await mkdtemp(join(tmpdir(), "matrix-coding-agent-workspace-provider-"));
+    const runtime = {
+      startSession: vi.fn(async () => ({ ok: true, status: 201, session: workspaceSession() })),
+      stopSession: vi.fn(async () => ({ ok: true, session: workspaceSession({ runtime: { type: "zellij", status: "exited" } }) })),
+    };
+    const threads = createCodingAgentThreadStore({
+      homePath,
+      now: () => baseNow,
+      providers: [
+        createWorkspaceCodingAgentProvider({
+          providerId: "codex",
+          agent: "codex",
+          runtime,
+        }),
+      ],
+    });
+
+    await threads.createThread(ownerPrincipal, {
+      ...createBody,
+      clientRequestId: "req_workspace_attachment_1",
+      attachments: [
+        {
+          id: "review:rev_desktop_1:hunk:hunk_1",
+          kind: "structured_ref",
+          label: "Review hunk 1",
+          path: "packages/gateway/src/coding-agents/routes.ts",
+        },
+      ],
+    });
+
+    expect(runtime.startSession).toHaveBeenCalledWith({
+      ownerScope: { type: "user", id: "owner_user" },
+      request: expect.objectContaining({
+        attachments: [
+          expect.objectContaining({
+            kind: "structured_ref",
+            label: "Review hunk 1",
+            path: "packages/gateway/src/coding-agents/routes.ts",
+          }),
+        ],
+      }),
+    });
+  });
+
   it("maps workspace session startup failures to safe thread errors", async () => {
     const homePath = await mkdtemp(join(tmpdir(), "matrix-coding-agent-workspace-provider-"));
     const runtime = {


### PR DESCRIPTION
## Summary

- Adds a desktop review hunk follow-up action in the coding-agent workspace.
- Seeds the existing desktop composer with bounded review metadata and a `structured_ref` attachment for the selected file/hunk.
- Keeps thread creation on the existing trusted `runtime:create-thread` IPC path; no raw diff lines or file contents are sent to the renderer action.
- Forwards bounded structured references through the workspace provider/session manager into launch prompt context so the runtime receives the selected reference metadata.
- Updates the 105 current-state note to document desktop follow-up and remaining mobile/preview gaps.

## Invariants

- Source of truth: gateway/runtime review snapshots and thread creation remain canonical; desktop only renders and submits through typed IPC.
- Lock/transaction scope: no new persistence or multi-write storage behavior in this slice.
- Acceptable orphan states: a seeded composer draft can be abandoned without creating a thread or changing gateway state.
- Auth source of truth: existing desktop main-process runtime credentials and IPC handlers remain the only network path.
- Deferred scope: mobile review follow-up, full diff/file content rendering, and preview panel integration remain separate slices.

## Tests

- `pnpm exec vitest run tests/desktop/coding-agent-workspace.test.tsx`
- `pnpm exec vitest run tests/desktop/coding-agent-workspace.test.tsx tests/gateway/coding-agents-workspace-provider.test.ts tests/gateway/agent-session-manager.test.ts tests/contracts/coding-agents.test.ts`
- `pnpm --filter desktop run typecheck`
- `bun run check:patterns`
- `bun run typecheck`
- `git diff --check`
- `rg -n "t3code|reference repo|external inspiration" desktop/src/renderer/src/features/coding-agents/AgentWorkspace.tsx tests/desktop/coding-agent-workspace.test.tsx specs/105-coding-agent-shells/current-state.md packages/contracts/src/index.ts packages/gateway/src/agent-session-manager.ts packages/gateway/src/workspace-session-orchestrator.ts packages/gateway/src/coding-agents/workspace-provider.ts tests/gateway/agent-session-manager.test.ts tests/gateway/coding-agents-workspace-provider.test.ts` (no matches)

## Review/Monitoring

- Stacked on #766.
- Addressed Greptile findings from the first review: composer draft preservation, post-submit seeded context reset, refreshed hunk selection, and runtime structured-reference delivery.
- Awaiting Greptile on current head `af2624c0782d073427b77f1d61ab1baf45c60a2f`.
