### PR TITLE
feat(mobile): add review hunk follow-up action

### DIFF
--- a/apps/mobile/__tests__/agent-composer-screen.test.tsx
+++ b/apps/mobile/__tests__/agent-composer-screen.test.tsx
@@ -7,8 +7,10 @@ jest.mock("@/lib/feature-flags", () => ({
 }));
 
 const mockRouterPush = jest.fn();
+let mockSearchParams: Record<string, string | string[] | undefined> = {};
 
 jest.mock("expo-router", () => ({
+  useLocalSearchParams: () => mockSearchParams,
   useRouter: () => ({
     push: mockRouterPush,
     back: jest.fn(),
@@ -92,9 +94,27 @@ function summaryFixture() {
   };
 }
 
+function reviewHunkRouteParams(): Record<string, string> {
+  return {
+    reviewId: "rev_mobile_1",
+    projectId: "matrix-os",
+    pullRequestNumber: "759",
+    round: "2",
+    maxRounds: "3",
+    filePath: "packages/gateway/src/coding-agents/routes.ts",
+    hunkId: "hunk_rev_mobile_1_0_1",
+    hunkIndex: "1",
+    oldStart: "88",
+    oldLines: "1",
+    newStart: "93",
+    newLines: "2",
+  };
+}
+
 describe("AgentComposerScreen", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockSearchParams = {};
   });
 
   it("requires a prompt before creating a run", async () => {
@@ -165,6 +185,96 @@ describe("AgentComposerScreen", () => {
         pathname: "/agents/[threadId]",
         params: { threadId: "thread_mobile_create" },
       });
+    });
+  });
+
+  it("seeds and submits a selected review hunk follow-up from route params", async () => {
+    mockSearchParams = reviewHunkRouteParams();
+    const client = {
+      getCodingAgentRuntimeSummary: jest.fn().mockResolvedValue({
+        ok: true,
+        summary: summaryFixture(),
+      }),
+      createCodingAgentThread: jest.fn().mockResolvedValue({
+        ok: true,
+        snapshot: {
+          thread: {
+            id: "thread_mobile_review_followup",
+            providerId: "codex",
+            title: "Follow up on review hunk",
+            status: "queued",
+            attention: "none",
+            createdAt: "2026-07-06T00:00:00.000Z",
+            updatedAt: "2026-07-06T00:00:00.000Z",
+          },
+          events: {
+            items: [],
+            hasMore: false,
+            limit: 200,
+          },
+        },
+      }),
+    };
+    useGatewayMock.mockReturnValue(gatewayContext({
+      client: client as unknown as GatewayClient,
+      connectionState: "connected",
+    }));
+
+    render(<AgentComposerScreen />);
+
+    const prompt = await screen.findByLabelText("Agent run prompt");
+    expect(prompt.props.value).toContain("PR #759");
+    expect(prompt.props.value).toContain("packages/gateway/src/coding-agents/routes.ts");
+    expect(prompt.props.value).toContain("@@ -88,1 +93,2 @@");
+    expect(prompt.props.value).not.toMatch(/export const|function create|raw diff/i);
+
+    fireEvent.press(screen.getByRole("button", { name: "Start run" }));
+
+    await waitFor(() => {
+      expect(client.createCodingAgentThread).toHaveBeenCalledWith(expect.objectContaining({
+        providerId: "codex",
+        projectId: "matrix-os",
+        prompt: expect.stringContaining("Please follow up on this review hunk."),
+        attachments: [
+          expect.objectContaining({
+            id: "review:rev_mobile_1:hunk:hunk_rev_mobile_1_0_1",
+            kind: "structured_ref",
+            label: "Review hunk 2",
+            path: "packages/gateway/src/coding-agents/routes.ts",
+          }),
+        ],
+      }));
+      expect(mockRouterPush).toHaveBeenCalledWith({
+        pathname: "/agents/[threadId]",
+        params: { threadId: "thread_mobile_review_followup" },
+      });
+    });
+  });
+
+  it("applies review hunk route params that arrive after the initial draft", async () => {
+    const client = {
+      getCodingAgentRuntimeSummary: jest.fn().mockResolvedValue({
+        ok: true,
+        summary: summaryFixture(),
+      }),
+      createCodingAgentThread: jest.fn(),
+    };
+    useGatewayMock.mockReturnValue(gatewayContext({
+      client: client as unknown as GatewayClient,
+      connectionState: "connected",
+    }));
+
+    const view = render(<AgentComposerScreen />);
+
+    const prompt = await screen.findByLabelText("Agent run prompt");
+    expect(prompt.props.value).toBe("");
+
+    mockSearchParams = reviewHunkRouteParams();
+    view.rerender(<AgentComposerScreen />);
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("Agent run prompt").props.value).toContain("PR #759");
+      expect(screen.getByLabelText("Agent run prompt").props.value).toContain("@@ -88,1 +93,2 @@");
     });
   });
 

--- a/apps/mobile/__tests__/agents-screen.test.tsx
+++ b/apps/mobile/__tests__/agents-screen.test.tsx
@@ -6,9 +6,11 @@ jest.mock("@/lib/feature-flags", () => ({
   CODING_AGENTS_MOBILE_WORKSPACE: true,
 }));
 
+const mockRouterPush = jest.fn();
+
 jest.mock("expo-router", () => ({
   useRouter: () => ({
-    push: jest.fn(),
+    push: mockRouterPush,
   }),
 }));
 
@@ -34,7 +36,7 @@ function gatewayContext(overrides: Partial<GatewayContextValue>): GatewayContext
   };
 }
 
-function summaryFixture() {
+function summaryFixture({ threadCreate = false }: { threadCreate?: boolean } = {}) {
   return {
     runtime: {
       id: "rt_primary",
@@ -50,6 +52,10 @@ function summaryFixture() {
         id: "codingAgentsReview",
         enabled: true,
       },
+      ...(threadCreate ? [{
+        id: "codingAgentsThreadCreate",
+        enabled: true,
+      }] : []),
     ],
     providers: [
       {
@@ -373,6 +379,58 @@ describe("AgentsScreen", () => {
 
     expect(hunk.props.accessibilityState?.selected).toBe(true);
     expect(screen.queryByText(/export const|function create|raw diff/i)).toBeNull();
+  });
+
+  it("opens the mobile composer with bounded selected review hunk context", async () => {
+    const client = {
+      getCodingAgentRuntimeSummary: jest.fn().mockResolvedValue({
+        ok: true,
+        summary: summaryFixture({ threadCreate: true }),
+      }),
+      getCodingAgentReviews: jest.fn().mockResolvedValue({
+        ok: true,
+        reviews: reviewsFixture(),
+      }),
+      getCodingAgentReviewSnapshot: jest.fn().mockResolvedValue({
+        ok: true,
+        snapshot: reviewSnapshotWithHunks(),
+      }),
+    };
+    useGatewayMock.mockReturnValue(gatewayContext({
+      client: client as unknown as GatewayClient,
+      connectionState: "connected",
+    }));
+
+    render(<AgentsScreen />);
+
+    await screen.findByText("matrix-os");
+    await act(async () => {
+      fireEvent.press(screen.getByLabelText("Open review PR #759"));
+    });
+    await act(async () => {
+      fireEvent.press(screen.getByLabelText("Select hunk 2 in packages/gateway/src/coding-agents/routes.ts"));
+    });
+    await act(async () => {
+      fireEvent.press(screen.getByLabelText("Ask agent about selected hunk"));
+    });
+
+    expect(mockRouterPush).toHaveBeenCalledWith({
+      pathname: "/agents/new",
+      params: expect.objectContaining({
+        reviewId: "rev_mobile_1",
+        projectId: "matrix-os",
+        pullRequestNumber: "759",
+        round: "2",
+        maxRounds: "3",
+        filePath: "packages/gateway/src/coding-agents/routes.ts",
+        hunkId: "hunk_rev_mobile_1_0_1",
+        hunkIndex: "1",
+        oldStart: "88",
+        oldLines: "1",
+        newStart: "93",
+        newLines: "2",
+      }),
+    });
   });
 
   it("clears selected hunk state when a selected review snapshot refreshes", async () => {

--- a/apps/mobile/app/agents/index.tsx
+++ b/apps/mobile/app/agents/index.tsx
@@ -28,7 +28,18 @@ type ReviewSnapshotState =
   | { status: "ready"; selectedReviewId: string; snapshot: ReviewSnapshot; error: null }
   | { status: "error"; selectedReviewId: string; snapshot: null; error: "Review details unavailable" };
 
-type SelectedReviewHunk = { reviewId: string; snapshotKey: string; key: string };
+type SelectedReviewHunk = {
+  reviewId: string;
+  snapshotKey: string;
+  key: string;
+  filePath: string;
+  hunkId: string;
+  hunkIndex: number;
+  oldStart: number;
+  oldLines: number;
+  newStart: number;
+  newLines: number;
+};
 
 const INITIAL_REVIEW_SNAPSHOT_STATE: ReviewSnapshotState = {
   status: "idle",
@@ -300,6 +311,7 @@ export default function AgentsScreen() {
 
       {capabilityEnabled(summary, "codingAgentsReview") ? (
         <ReviewSection
+          canCreate={canCreate}
           state={reviewState}
           snapshotState={reviewSnapshotState}
           onSelectReview={selectReview}
@@ -314,10 +326,12 @@ function reviewStatusLabel(status: ReviewSummary["status"]): string {
 }
 
 function ReviewSection({
+  canCreate,
   state,
   snapshotState,
   onSelectReview,
 }: {
+  canCreate: boolean;
   state: ReviewState;
   snapshotState: ReviewSnapshotState;
   onSelectReview: (reviewId: string) => void;
@@ -357,12 +371,14 @@ function ReviewSection({
           </View>
         </Pressable>
       ))}
-      <ReviewSnapshotPanel state={snapshotState} />
+      <ReviewSnapshotPanel canCreate={canCreate} state={snapshotState} />
     </Section>
   );
 }
 
-function ReviewSnapshotPanel({ state }: { state: ReviewSnapshotState }) {
+function ReviewSnapshotPanel({ canCreate, state }: { canCreate: boolean; state: ReviewSnapshotState }) {
+  const { theme } = useUnistyles();
+  const router = useRouter();
   const [selectedHunk, setSelectedHunk] = useState<SelectedReviewHunk | null>(null);
 
   if (state.status === "idle") return null;
@@ -374,6 +390,9 @@ function ReviewSnapshotPanel({ state }: { state: ReviewSnapshotState }) {
   }
 
   const snapshotKey = reviewSnapshotSelectionKey(state.snapshot);
+  const activeSelectedHunk = selectedHunk?.reviewId === state.selectedReviewId && selectedHunk.snapshotKey === snapshotKey
+    ? selectedHunk
+    : null;
 
   return (
     <View style={styles.reviewDetailPanel}>
@@ -394,10 +413,37 @@ function ReviewSnapshotPanel({ state }: { state: ReviewSnapshotState }) {
           fileIndex={fileIndex}
           selectedReviewId={state.selectedReviewId}
           snapshotKey={snapshotKey}
-          selectedHunk={selectedHunk}
+          selectedHunk={activeSelectedHunk}
           onSelectHunk={setSelectedHunk}
         />
       ))}
+      {canCreate && activeSelectedHunk ? (
+        <Pressable
+          accessibilityRole="button"
+          accessibilityLabel="Ask agent about selected hunk"
+          onPress={() => router.push({
+            pathname: "/agents/new",
+            params: {
+              reviewId: state.snapshot.review.id,
+              projectId: state.snapshot.review.projectId,
+              pullRequestNumber: String(state.snapshot.review.pullRequestNumber),
+              round: String(state.snapshot.review.round),
+              maxRounds: String(state.snapshot.review.maxRounds),
+              filePath: activeSelectedHunk.filePath,
+              hunkId: activeSelectedHunk.hunkId,
+              hunkIndex: String(activeSelectedHunk.hunkIndex),
+              oldStart: String(activeSelectedHunk.oldStart),
+              oldLines: String(activeSelectedHunk.oldLines),
+              newStart: String(activeSelectedHunk.newStart),
+              newLines: String(activeSelectedHunk.newLines),
+            },
+          } as any)}
+          style={styles.reviewFollowUpButton}
+        >
+          <Ionicons name="chatbubble-ellipses-outline" size={16} color={theme.colors.background} />
+          <Text style={styles.reviewFollowUpText}>Ask agent about selected hunk</Text>
+        </Pressable>
+      ) : null}
     </View>
   );
 }
@@ -467,7 +513,18 @@ function ReviewSnapshotFileRow({
                 accessibilityRole="button"
                 accessibilityLabel={`Select hunk ${hunkIndex + 1} in ${displayPath}`}
                 accessibilityState={{ selected }}
-                onPress={() => onSelectHunk({ reviewId: selectedReviewId, snapshotKey, key: hunkKey })}
+                onPress={() => onSelectHunk({
+                  reviewId: selectedReviewId,
+                  snapshotKey,
+                  key: hunkKey,
+                  filePath: file.path,
+                  hunkId: hunk.id,
+                  hunkIndex,
+                  oldStart: hunk.oldStart,
+                  oldLines: hunk.oldLines,
+                  newStart: hunk.newStart,
+                  newLines: hunk.newLines,
+                })}
                 style={[
                   styles.reviewHunkRow,
                   selected ? styles.selectedReviewHunkRow : null,
@@ -790,6 +847,20 @@ const styles = StyleSheet.create((theme, rt) => ({
     fontFamily: theme.fonts.sans,
     fontSize: 11,
     color: theme.colors.mutedForeground,
+  },
+  reviewFollowUpButton: {
+    minHeight: 42,
+    borderRadius: 21,
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "center",
+    gap: theme.spacing.xs,
+    backgroundColor: theme.colors.forest,
+  },
+  reviewFollowUpText: {
+    fontFamily: theme.fonts.sansSemiBold,
+    fontSize: 13,
+    color: theme.colors.background,
   },
   emptyText: {
     borderRadius: 14,

--- a/apps/mobile/components/AgentComposerScreen.tsx
+++ b/apps/mobile/components/AgentComposerScreen.tsx
@@ -1,8 +1,9 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { ActivityIndicator, Pressable, ScrollView, Text, TextInput, View } from "react-native";
 import { Ionicons } from "@expo/vector-icons";
-import { useRouter } from "expo-router";
+import { useLocalSearchParams, useRouter } from "expo-router";
 import { StyleSheet, useUnistyles } from "react-native-unistyles";
+import { z } from "zod/v4";
 import {
   buildCreateAgentThreadRequestFromComposer,
   defaultAgentThreadComposerDraft,
@@ -19,8 +20,49 @@ type ScreenState =
   | { status: "error"; summary: null; error: "Runtime summary unavailable" };
 
 const INITIAL_STATE: ScreenState = { status: "loading", summary: null, error: null };
+const SAFE_REFERENCE = /^[A-Za-z0-9][A-Za-z0-9_.:-]{0,127}$/;
+const SAFE_PROJECT_ID = /^[A-Za-z0-9][A-Za-z0-9_.:-]{0,159}$/;
+const MAX_ROUTE_FILE_PATH_LENGTH = 512;
+
+const RouteParamStringSchema = (max: number) => z.preprocess(
+  (value) => Array.isArray(value) ? value[0] : value,
+  z.string().trim().min(1).max(max),
+);
+
+const ReviewHunkSeedParamsSchema = z.object({
+  reviewId: RouteParamStringSchema(128)
+    .refine((value) => SAFE_REFERENCE.test(value))
+    .refine((value) => !value.includes("..")),
+  projectId: RouteParamStringSchema(160)
+    .refine((value) => SAFE_PROJECT_ID.test(value))
+    .refine((value) => !value.includes("..")),
+  pullRequestNumber: z.coerce.number().int().positive(),
+  round: z.coerce.number().int().positive(),
+  maxRounds: z.coerce.number().int().positive(),
+  filePath: RouteParamStringSchema(MAX_ROUTE_FILE_PATH_LENGTH)
+    .refine((value) => !value.startsWith("/") && !value.includes("\0"))
+    .refine((value) => !value.split(/[\\/]+/).some((part) => part === "" || part === "." || part === "..")),
+  hunkId: RouteParamStringSchema(128)
+    .refine((value) => SAFE_REFERENCE.test(value))
+    .refine((value) => !value.includes("..")),
+  hunkIndex: z.coerce.number().int().min(0).max(999),
+  oldStart: z.coerce.number().int().min(0).max(1_000_000),
+  oldLines: z.coerce.number().int().min(0).max(100_000),
+  newStart: z.coerce.number().int().min(0).max(1_000_000),
+  newLines: z.coerce.number().int().min(0).max(100_000),
+}).strict();
+
+type ReviewHunkSeedParams = z.infer<typeof ReviewHunkSeedParamsSchema>;
 
 let requestCounter = 0;
+
+function firstRouteParam(value: unknown): string | undefined {
+  if (Array.isArray(value)) {
+    const [first] = value;
+    return typeof first === "string" ? first : undefined;
+  }
+  return typeof value === "string" ? value : undefined;
+}
 
 function nextClientRequestId(): string {
   requestCounter += 1;
@@ -37,10 +79,103 @@ function providerReady(provider: AgentProviderSummary): boolean {
     provider.authStatus === "authenticated";
 }
 
+function parseReviewHunkSeedParams(params: Record<string, unknown>): ReviewHunkSeedParams | null {
+  const parsed = ReviewHunkSeedParamsSchema.safeParse(params);
+  return parsed.success ? parsed.data : null;
+}
+
+function formatHunkRange(seed: ReviewHunkSeedParams): string {
+  return `@@ -${seed.oldStart},${seed.oldLines} +${seed.newStart},${seed.newLines} @@`;
+}
+
+function safeReferenceSegment(value: string): string {
+  return value.replace(/[^A-Za-z0-9_.:-]+/g, "_").replace(/\.\.+/g, "_").slice(0, 64) || "ref";
+}
+
+function reviewHunkFollowUpDraft(summary: RuntimeSummary, seed: ReviewHunkSeedParams): AgentThreadComposerDraft {
+  const base = defaultAgentThreadComposerDraft(summary);
+  const hunkNumber = seed.hunkIndex + 1;
+  return {
+    ...base,
+    projectId: seed.projectId,
+    prompt: [
+      "Please follow up on this review hunk.",
+      "",
+      `Review: PR #${seed.pullRequestNumber}, round ${seed.round} of ${seed.maxRounds}`,
+      `Project: ${seed.projectId}`,
+      `File: ${seed.filePath}`,
+      `Hunk: ${formatHunkRange(seed)}`,
+      "",
+      "Use the structured reference attached to inspect the current source and propose the smallest safe fix.",
+    ].join("\n"),
+    attachments: [
+      {
+        id: `review:${safeReferenceSegment(seed.reviewId)}:hunk:${safeReferenceSegment(seed.hunkId)}`,
+        kind: "structured_ref",
+        label: `Review hunk ${hunkNumber}`,
+        path: seed.filePath,
+      },
+    ],
+  };
+}
+
+function isUntouchedDefaultDraft(current: AgentThreadComposerDraft, defaultDraft: AgentThreadComposerDraft): boolean {
+  return current.providerId === defaultDraft.providerId &&
+    current.prompt === defaultDraft.prompt &&
+    current.projectId === defaultDraft.projectId &&
+    current.taskId === defaultDraft.taskId &&
+    current.terminalSessionId === defaultDraft.terminalSessionId &&
+    current.worktreeId === defaultDraft.worktreeId &&
+    current.mode === defaultDraft.mode &&
+    current.approvalPolicy === defaultDraft.approvalPolicy &&
+    current.sandboxMode === defaultDraft.sandboxMode &&
+    (current.attachments?.length ?? 0) === 0;
+}
+
 export default function AgentComposerScreen() {
   const { theme } = useUnistyles();
   const router = useRouter();
+  const routeParams = useLocalSearchParams();
   const { client } = useGateway();
+  const reviewIdParam = firstRouteParam(routeParams.reviewId);
+  const projectIdParam = firstRouteParam(routeParams.projectId);
+  const pullRequestNumberParam = firstRouteParam(routeParams.pullRequestNumber);
+  const roundParam = firstRouteParam(routeParams.round);
+  const maxRoundsParam = firstRouteParam(routeParams.maxRounds);
+  const filePathParam = firstRouteParam(routeParams.filePath);
+  const hunkIdParam = firstRouteParam(routeParams.hunkId);
+  const hunkIndexParam = firstRouteParam(routeParams.hunkIndex);
+  const oldStartParam = firstRouteParam(routeParams.oldStart);
+  const oldLinesParam = firstRouteParam(routeParams.oldLines);
+  const newStartParam = firstRouteParam(routeParams.newStart);
+  const newLinesParam = firstRouteParam(routeParams.newLines);
+  const reviewHunkSeed = useMemo(() => parseReviewHunkSeedParams({
+    reviewId: reviewIdParam,
+    projectId: projectIdParam,
+    pullRequestNumber: pullRequestNumberParam,
+    round: roundParam,
+    maxRounds: maxRoundsParam,
+    filePath: filePathParam,
+    hunkId: hunkIdParam,
+    hunkIndex: hunkIndexParam,
+    oldStart: oldStartParam,
+    oldLines: oldLinesParam,
+    newStart: newStartParam,
+    newLines: newLinesParam,
+  }), [
+    reviewIdParam,
+    projectIdParam,
+    pullRequestNumberParam,
+    roundParam,
+    maxRoundsParam,
+    filePathParam,
+    hunkIdParam,
+    hunkIndexParam,
+    oldStartParam,
+    oldLinesParam,
+    newStartParam,
+    newLinesParam,
+  ]);
   const [state, setState] = useState<ScreenState>(INITIAL_STATE);
   const [draft, setDraft] = useState<AgentThreadComposerDraft | null>(null);
   const [pickerOpen, setPickerOpen] = useState(false);
@@ -65,8 +200,14 @@ export default function AgentComposerScreen() {
     }
     const summary = result.summary;
     setState({ status: "ready", summary, error: null });
-    setDraft((current) => current ?? defaultAgentThreadComposerDraft(summary));
-  }, [client]);
+    const defaultDraft = defaultAgentThreadComposerDraft(summary);
+    const seededDraft = reviewHunkSeed ? reviewHunkFollowUpDraft(summary, reviewHunkSeed) : null;
+    setDraft((current) => {
+      if (!current) return seededDraft ?? defaultDraft;
+      if (seededDraft && isUntouchedDefaultDraft(current, defaultDraft)) return seededDraft;
+      return current;
+    });
+  }, [client, reviewHunkSeed]);
 
   useEffect(() => {
     void loadSummary();

--- a/specs/105-coding-agent-shells/current-state.md
+++ b/specs/105-coding-agent-shells/current-state.md
@@ -6,7 +6,7 @@
 
 ## Summary
 
-The stack currently has shared contracts, a gateway runtime summary read model, read-only desktop and mobile workspaces behind flags, thread create/replay/abort/event streaming, provider adapters, a workspace-backed provider, approval/input route handling, a read-only coding-agent review summary route/client contract, desktop/mobile read-only review summary panels, and a read-only coding-agent review snapshot route with bounded file metadata from safe owner worktree diffs plus findings fallback metadata. Desktop and mobile review details render changed-file counts and selectable hunk coordinate metadata. Desktop can seed the existing agent composer from a selected review hunk using bounded prompt context and a `structured_ref` attachment. Full file content, raw diff lines, mobile follow-up actions, and preview coding-agent surfaces are contract-only or existing workspace routes; dedicated preview shell UI is not yet integrated.
+The stack currently has shared contracts, a gateway runtime summary read model, read-only desktop and mobile workspaces behind flags, thread create/replay/abort/event streaming, provider adapters, a workspace-backed provider, approval/input route handling, a read-only coding-agent review summary route/client contract, desktop/mobile read-only review summary panels, and a read-only coding-agent review snapshot route with bounded file metadata from safe owner worktree diffs plus findings fallback metadata. Desktop and mobile review details render changed-file counts and selectable hunk coordinate metadata. Desktop and mobile can seed their existing agent composers from a selected review hunk using bounded prompt context and a `structured_ref` attachment. Full file content, raw diff lines, and preview coding-agent surfaces are contract-only or existing workspace routes; dedicated preview shell UI is not yet integrated.
 
 Current source-of-truth boundaries:
 
@@ -208,6 +208,7 @@ Current behavior:
 - Read-only dashboard renders providers, active threads, and terminals.
 - When the runtime advertises `codingAgentsReview`, the dashboard fetches bounded review summaries through the trusted main-process IPC route and renders project, PR, round, status, and high-severity count.
 - Review snapshot details render bounded file paths, additions/deletions, partial markers, selectable hunk coordinate metadata, and safe finding summaries. They do not render raw diff lines or file contents.
+- When thread creation is enabled, selecting a review hunk can open the mobile composer with bounded review metadata and a `structured_ref` attachment for the target file/hunk; the existing authenticated `createCodingAgentThread` gateway client performs the mutation.
 - When thread creation is enabled, selecting a review hunk can seed the existing desktop composer with bounded review metadata and a `structured_ref` attachment for the target file/hunk; the normal trusted `runtime:create-thread` IPC path performs the mutation.
 - Safe generic error state if the runtime summary is unavailable.
 - Safe generic review error state if review summaries are unavailable; review failures do not drop the runtime summary dashboard.
@@ -259,7 +260,7 @@ Relevant existing browser shell paths:
 
 Open follow-up: decide whether a browser-shell coding-agent entry belongs in Canvas, Developer mode, or both after desktop/mobile read-only shells settle.
 
-Public docs note: public docs remain deferred for these review-summary/snapshot/follow-up slices because the cross-shell review flow still lacks full file diffs, mobile follow-up actions, and preview integration. Update `www/content/docs/` when the file/review/preview surfaces become stable in desktop, mobile, or browser shell navigation.
+Public docs note: public docs remain deferred for these review-summary/snapshot/follow-up slices because the cross-shell review flow still lacks full file diffs and preview integration. Update `www/content/docs/` when the file/review/preview surfaces become stable in desktop, mobile, or browser shell navigation.
 
 ## Feature Flags
 


### PR DESCRIPTION
## Summary

- Add the mobile review hunk follow-up action behind the existing thread-create capability.
- Pass only bounded review metadata from the review snapshot route into `/agents/new`.
- Seed the existing mobile composer with a bounded prompt and one `structured_ref` attachment, then submit through the existing authenticated thread-create client path.

## Tests

- `pnpm --filter matrix-os-mobile exec jest __tests__/agents-screen.test.tsx __tests__/agent-composer-screen.test.tsx --runInBand`
- `pnpm --filter matrix-os-mobile run lint`
- `pnpm --filter matrix-os-mobile exec tsc --noEmit`
- `bun run check:patterns` (0 violations, existing warnings only)
- `bun run typecheck`
- `git diff --check`
- Restricted wording scan across touched mobile/spec files (no matches)

## Invariants

- Source of truth remains gateway/runtime contracts; mobile only routes bounded UI metadata into an existing composer.
- No raw diff text, file contents, transcripts, terminal output, credentials, launch tokens, or approval payloads are stored or routed.
- Route params are validated at the mobile boundary with Zod 4 before seeding composer state.
- Mutations continue through the existing authenticated `createCodingAgentThread` gateway client path.
- Public docs remain deferred until the cross-shell file/review/preview surfaces stabilize; the spec current-state note is updated for this slice.
