### PR TITLE
feat(review): add bounded review diff lines

### DIFF
--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -655,6 +655,30 @@ export const ReviewFileDiffSchema = z.object({
   partial: z.boolean(),
 }).strict();
 
+const ReviewDiffLineNumberSchema = z.number().int().min(1).max(1_000_000);
+const ReviewDiffLineContentSchema = z.string()
+  .max(1_000)
+  .refine((value) => byteLength(value) <= 4_000, { message: "Diff line exceeds byte limit" });
+
+export const ReviewDiffLineSchema = z.discriminatedUnion("kind", [
+  z.object({
+    kind: z.literal("context"),
+    oldLine: ReviewDiffLineNumberSchema,
+    newLine: ReviewDiffLineNumberSchema,
+    content: ReviewDiffLineContentSchema,
+  }).strict(),
+  z.object({
+    kind: z.literal("add"),
+    newLine: ReviewDiffLineNumberSchema,
+    content: ReviewDiffLineContentSchema,
+  }).strict(),
+  z.object({
+    kind: z.literal("remove"),
+    oldLine: ReviewDiffLineNumberSchema,
+    content: ReviewDiffLineContentSchema,
+  }).strict(),
+]);
+
 export const ReviewDiffHunkSchema = z.object({
   id: referenceId(128),
   oldStart: z.number().int().min(0).max(1_000_000),
@@ -663,6 +687,7 @@ export const ReviewDiffHunkSchema = z.object({
   newLines: z.number().int().min(0).max(1_000_000),
   heading: SafeDisplayStringSchema.optional(),
   partial: z.boolean(),
+  lines: z.array(ReviewDiffLineSchema).max(120).optional(),
 }).strict();
 
 export const ReviewFindingSummarySchema = z.object({

--- a/packages/gateway/src/coding-agents/review-summary.ts
+++ b/packages/gateway/src/coding-agents/review-summary.ts
@@ -23,6 +23,8 @@ const RAW_REVIEW_SCAN_LIMIT = 100;
 const MAX_REVIEW_SCAN_PAGES = 5;
 const REVIEW_SNAPSHOT_FILE_LIMIT = 100;
 const REVIEW_SNAPSHOT_FINDINGS_PER_FILE_LIMIT = 100;
+const REVIEW_DIFF_HUNK_LINE_LIMIT = 120;
+const REVIEW_DIFF_LINE_CHAR_LIMIT = 1_000;
 const REVIEW_DIFF_OUTPUT_BYTES = 256 * 1024;
 const REVIEW_DIFF_TIMEOUT_MS = 5_000;
 
@@ -30,6 +32,8 @@ const execFileAsync = promisify(execFile);
 
 type ReviewSnapshotErrorCode = "review_not_found" | "review_state_unavailable";
 type ReviewSnapshotFile = ReviewSnapshot["files"]["items"][number];
+type ReviewSnapshotHunk = ReviewSnapshotFile["hunks"][number];
+type ReviewDiffLine = NonNullable<ReviewSnapshotHunk["lines"]>[number];
 type ReviewDiffReadResult = {
   ok: true;
   files: ReviewSnapshotFile[];
@@ -280,6 +284,8 @@ function parseUnifiedDiff(stdout: string): ReviewDiffReadResult {
     partial: boolean;
   } | null = null;
   let hasMore = false;
+  let oldLine = 0;
+  let newLine = 0;
 
   const pushCurrent = () => {
     if (!current) return;
@@ -304,6 +310,28 @@ function parseUnifiedDiff(stdout: string): ReviewDiffReadResult {
     current = null;
   };
 
+  const markCurrentPartial = () => {
+    if (!current) return;
+    current.partial = true;
+    hasMore = true;
+    const hunk = current.hunks[current.hunks.length - 1];
+    if (hunk) hunk.partial = true;
+  };
+
+  const addCurrentHunkLine = (line: ReviewDiffLine) => {
+    if (!current) return;
+    const hunk = current.hunks[current.hunks.length - 1];
+    if (!hunk) return;
+    if ((hunk.lines?.length ?? 0) >= REVIEW_DIFF_HUNK_LINE_LIMIT) {
+      markCurrentPartial();
+      return;
+    }
+    const content = line.content.slice(0, REVIEW_DIFF_LINE_CHAR_LIMIT);
+    const partial = content.length < line.content.length;
+    hunk.lines = [...(hunk.lines ?? []), { ...line, content }];
+    if (partial) markCurrentPartial();
+  };
+
   for (const line of stdout.split("\n")) {
     const diffHeader = parseDiffGitHeader(line);
     if (diffHeader) {
@@ -316,6 +344,8 @@ function parseUnifiedDiff(stdout: string): ReviewDiffReadResult {
         hunks: [],
         partial: false,
       };
+      oldLine = 0;
+      newLine = 0;
       continue;
     }
     if (!current) continue;
@@ -348,19 +378,42 @@ function parseUnifiedDiff(stdout: string): ReviewDiffReadResult {
         hasMore = true;
         continue;
       }
+      oldLine = parseRangeStart(hunk[1]);
+      newLine = parseRangeStart(hunk[3]);
       current.hunks.push({
         id: hunkIdFor(current.path, current.hunks.length),
-        oldStart: parseRangeStart(hunk[1]),
+        oldStart: oldLine,
         oldLines: parseRangeLines(hunk[2]),
-        newStart: parseRangeStart(hunk[3]),
+        newStart: newLine,
         newLines: parseRangeLines(hunk[4]),
         heading: line.slice(0, 120),
         partial: false,
+        lines: [],
       });
       continue;
     }
-    if (line.startsWith("+") && !line.startsWith("+++")) current.additions += 1;
-    if (line.startsWith("-") && !line.startsWith("---")) current.deletions += 1;
+    if (line.startsWith("\\ No newline")) continue;
+    if (line.startsWith(" ") && current.hunks.length > 0) {
+      addCurrentHunkLine({ kind: "context", oldLine, newLine, content: line.slice(1) });
+      oldLine += 1;
+      newLine += 1;
+      continue;
+    }
+    if (line.startsWith("+") && !line.startsWith("+++")) {
+      current.additions += 1;
+      if (current.hunks.length > 0) {
+        addCurrentHunkLine({ kind: "add", newLine, content: line.slice(1) });
+        newLine += 1;
+      }
+      continue;
+    }
+    if (line.startsWith("-") && !line.startsWith("---")) {
+      current.deletions += 1;
+      if (current.hunks.length > 0) {
+        addCurrentHunkLine({ kind: "remove", oldLine, content: line.slice(1) });
+        oldLine += 1;
+      }
+    }
   }
   pushCurrent();
   return {
@@ -368,6 +421,30 @@ function parseUnifiedDiff(stdout: string): ReviewDiffReadResult {
     files,
     hasMore,
     partial: hasMore || files.some((file) => file.partial),
+  };
+}
+
+function capReviewHunkLines(hunk: ReviewSnapshotHunk): ReviewSnapshotHunk {
+  let partial = hunk.partial;
+  const lines = (hunk.lines ?? []).slice(0, REVIEW_DIFF_HUNK_LINE_LIMIT).map((line) => {
+    const content = line.content.slice(0, REVIEW_DIFF_LINE_CHAR_LIMIT);
+    if (content.length < line.content.length) partial = true;
+    return { ...line, content } as ReviewDiffLine;
+  });
+  if ((hunk.lines?.length ?? 0) > REVIEW_DIFF_HUNK_LINE_LIMIT) partial = true;
+  return {
+    ...hunk,
+    partial,
+    lines: lines.length > 0 ? lines : hunk.lines,
+  };
+}
+
+function capReviewSnapshotFile(file: ReviewSnapshotFile): ReviewSnapshotFile {
+  const hunks = file.hunks.map(capReviewHunkLines);
+  return {
+    ...file,
+    partial: file.partial || hunks.some((hunk) => hunk.partial),
+    hunks,
   };
 }
 
@@ -407,7 +484,7 @@ async function readGitReviewDiff(worktreeRoot: string): Promise<ReviewDiffReadRe
     console.warn("[coding-agents] review worktree unavailable");
     return { ok: false };
   }
-  const diffArgs = ["diff", "--no-ext-diff", "--no-textconv", "--find-renames", "--unified=0"];
+  const diffArgs = ["diff", "--no-ext-diff", "--no-textconv", "--find-renames", "--unified=3"];
   let base: string | undefined;
   for (const candidate of ["origin/HEAD", "origin/main", "origin/master", "origin/develop"]) {
     base = (await execGit(worktreeRoot, ["merge-base", "HEAD", candidate], {
@@ -501,9 +578,10 @@ function mergeDiffAndFindings(input: {
   const files: ReviewSnapshotFile[] = [];
   let hasMore = input.diff.hasMore || input.findings.hasMore;
   for (const file of input.diff.files) {
+    const cappedFile = capReviewSnapshotFile(file);
     const parsed = ReviewSnapshotFileSchema.safeParse({
-      ...file,
-      findings: findingsByPath.get(file.path),
+      ...cappedFile,
+      findings: findingsByPath.get(cappedFile.path),
     });
     if (!parsed.success) continue;
     files.push(parsed.data);

--- a/specs/105-coding-agent-shells/current-state.md
+++ b/specs/105-coding-agent-shells/current-state.md
@@ -1,12 +1,12 @@
 # Current State: Coding Agent Shells
 
-**Branch stack**: `spec/coding-agent-shells` plus stacked implementation branches through `105-coding-agent-review-summary`
-**Updated**: 2026-07-06
+**Branch stack**: `spec/coding-agent-shells` plus stacked implementation branches through `105-coding-agent-review-diff-lines`
+**Updated**: 2026-07-07
 **Scope**: Inventory for the coding-agent desktop/mobile shell work. This file records the current Matrix-native route, contract, client, and regression-test state so later slices keep gateway/runtime as source of truth and keep desktop/mobile as thin shells.
 
 ## Summary
 
-The stack currently has shared contracts, a gateway runtime summary read model, read-only desktop and mobile workspaces behind flags, thread create/replay/abort/event streaming, provider adapters, a workspace-backed provider, approval/input route handling, a read-only coding-agent review summary route/client contract, desktop/mobile read-only review summary panels, and a read-only coding-agent review snapshot route with bounded file metadata from safe owner worktree diffs plus findings fallback metadata. Desktop and mobile review details render changed-file counts and selectable hunk coordinate metadata. Desktop and mobile can seed their existing agent composers from a selected review hunk using bounded prompt context and a `structured_ref` attachment. Full file content, raw diff lines, and preview coding-agent surfaces are contract-only or existing workspace routes; dedicated preview shell UI is not yet integrated.
+The stack currently has shared contracts, a gateway runtime summary read model, read-only desktop and mobile workspaces behind flags, thread create/replay/abort/event streaming, provider adapters, a workspace-backed provider, approval/input route handling, a read-only coding-agent review summary route/client contract, desktop/mobile read-only review summary panels, and a read-only coding-agent review snapshot route with bounded file metadata from safe owner worktree diffs plus findings fallback metadata. Review snapshots can include bounded per-hunk diff lines with truncation markers. Desktop and mobile review details render changed-file counts and selectable hunk coordinate metadata. Desktop and mobile can seed their existing agent composers from a selected review hunk using bounded prompt context and a `structured_ref` attachment. Full file content and preview coding-agent surfaces are contract-only or existing workspace routes; dedicated preview shell UI is not yet integrated.
 
 Current source-of-truth boundaries:
 
@@ -28,7 +28,7 @@ Implemented coding-agent schemas:
 - Events: `AgentThreadEventSchema` discriminated union with lifecycle, text delta, tool activity, approval/input, file change, review ready, terminal bound, safe error, and completion event variants.
 - Approvals/input: `AgentApprovalRequestSchema`, `ApprovalDecisionRequestSchema`, `UserInputRequestSchema`, `UserInputAnswerRequestSchema`.
 - Terminal frames/summaries: `TerminalSessionSummarySchema`, `TerminalClientFrameSchema`, `TerminalServerFrameSchema`.
-- File/review/preview: `FilePathSchema`, `FileMetadataSchema`, `ReviewSummarySchema`, `ReviewFileDiffSchema`, `ReviewDiffHunkSchema`, `ReviewFindingSummarySchema`, `ReviewSnapshotFileSchema`, `ReviewSnapshotSchema`, `PreviewSessionSummarySchema`.
+- File/review/preview: `FilePathSchema`, `FileMetadataSchema`, `ReviewSummarySchema`, `ReviewFileDiffSchema`, `ReviewDiffLineSchema`, `ReviewDiffHunkSchema`, `ReviewFindingSummarySchema`, `ReviewSnapshotFileSchema`, `ReviewSnapshotSchema`, `PreviewSessionSummarySchema`.
 
 Contract tests:
 
@@ -207,7 +207,7 @@ Current behavior:
 
 - Read-only dashboard renders providers, active threads, and terminals.
 - When the runtime advertises `codingAgentsReview`, the dashboard fetches bounded review summaries through the trusted main-process IPC route and renders project, PR, round, status, and high-severity count.
-- Review snapshot details render bounded file paths, additions/deletions, partial markers, selectable hunk coordinate metadata, and safe finding summaries. They do not render raw diff lines or file contents.
+- Review snapshot details render bounded file paths, additions/deletions, partial markers, selectable hunk coordinate metadata, and safe finding summaries. The gateway snapshot can include bounded hunk lines, but desktop rendering of those lines is not wired in this slice.
 - When thread creation is enabled, selecting a review hunk can open the mobile composer with bounded review metadata and a `structured_ref` attachment for the target file/hunk; the existing authenticated `createCodingAgentThread` gateway client performs the mutation.
 - When thread creation is enabled, selecting a review hunk can seed the existing desktop composer with bounded review metadata and a `structured_ref` attachment for the target file/hunk; the normal trusted `runtime:create-thread` IPC path performs the mutation.
 - Safe generic error state if the runtime summary is unavailable.
@@ -230,7 +230,7 @@ Screen:
 - `apps/mobile/app/agents/[threadId].tsx`
 - Read-only phone-first dashboard with providers, active threads, and terminal sessions.
 - When the runtime advertises `codingAgentsReview`, the dashboard fetches bounded review summaries through the authenticated gateway client and renders project, PR, round, status, and high-severity count.
-- Review snapshot details render bounded file paths, additions/deletions, partial markers, selectable hunk coordinate metadata, and safe finding summaries. They do not render raw diff lines or file contents.
+- Review snapshot details render bounded file paths, additions/deletions, partial markers, selectable hunk coordinate metadata, and safe finding summaries. The gateway snapshot can include bounded hunk lines, but mobile rendering of those lines is not wired in this slice.
 - Safe generic review error state if review summaries are unavailable; review failures do not drop the runtime summary dashboard.
 - Composer route for creating accepted coding-agent threads; thread route is a bounded placeholder until replay/review surfaces are wired.
 - Flag: `apps/mobile/lib/feature-flags.ts` with `EXPO_PUBLIC_CODING_AGENTS_MOBILE_WORKSPACE === "1"`.
@@ -260,7 +260,7 @@ Relevant existing browser shell paths:
 
 Open follow-up: decide whether a browser-shell coding-agent entry belongs in Canvas, Developer mode, or both after desktop/mobile read-only shells settle.
 
-Public docs note: public docs remain deferred for these review-summary/snapshot/follow-up slices because the cross-shell review flow still lacks full file diffs and preview integration. Update `www/content/docs/` when the file/review/preview surfaces become stable in desktop, mobile, or browser shell navigation.
+Public docs note: public docs remain deferred for these review-summary/snapshot/follow-up slices because the cross-shell review flow still lacks shell-rendered full diff views and preview integration. Update `www/content/docs/` when the file/review/preview surfaces become stable in desktop, mobile, or browser shell navigation.
 
 ## Feature Flags
 
@@ -334,7 +334,7 @@ git diff --check
 ## Open Questions And Deferred Work
 
 - Session completion reconciliation: implemented for workspace `session.stopped` events that carry owner id, workspace session id, and bound `terminalSessionId`; the gateway thread store marks matching active coding-agent threads completed or failed server-side without matching unrelated owners or reused terminal ids. Remaining work: if runtime managers add autonomous process-exit detection beyond explicit workspace stop events, route those through the same `session.stopped` publisher path.
-- File/review/preview shell surfaces: read-only review summaries now have coding-agent contracts/routes/desktop IPC/mobile clients plus desktop and mobile read-only review panels. A read-only review snapshot route now exposes bounded diff hunk metadata from safe owner worktrees and partial findings-derived fallback metadata for later shell diff panels. Full file contents, desktop/mobile diff rendering, and previews are not implemented yet.
+- File/review/preview shell surfaces: read-only review summaries now have coding-agent contracts/routes/desktop IPC/mobile clients plus desktop and mobile read-only review panels. A read-only review snapshot route now exposes bounded diff hunk metadata and capped hunk line bodies from safe owner worktrees plus partial findings-derived fallback metadata for later shell diff panels. Full file contents, desktop/mobile diff rendering, and previews are not implemented yet.
 - Browser shell entry point: Canvas-first placement is still undecided.
 - Notifications/attention routing: desktop notification IPC exists, but thread attention notifications are not yet wired end-to-end from gateway events.
 - Public docs: public Matrix OS docs should be updated once the user-facing coding-agent shell flow is stable enough to document.

--- a/tests/contracts/coding-agents.test.ts
+++ b/tests/contracts/coding-agents.test.ts
@@ -8,6 +8,7 @@ import {
   CreateAgentThreadRequestSchema,
   FileMetadataSchema,
   PreviewSessionSummarySchema,
+  ReviewDiffLineSchema,
   ReviewFileDiffSchema,
   ReviewSnapshotSchema,
   ReviewSummarySchema,
@@ -353,6 +354,18 @@ describe("coding agent contracts", () => {
                 newLines: 1,
                 heading: "Finding HIGH-1",
                 partial: true,
+                lines: [
+                  {
+                    kind: "remove",
+                    oldLine: 12,
+                    content: "const unsafe = true;",
+                  },
+                  {
+                    kind: "add",
+                    newLine: 12,
+                    content: "const safe = true;",
+                  },
+                ],
               },
             ],
             findings: [
@@ -373,6 +386,32 @@ describe("coding agent contracts", () => {
       updatedAt: now,
     });
     expect(reviewSnapshot.files.items[0]?.hunks[0]?.partial).toBe(true);
+    expect(reviewSnapshot.files.items[0]?.hunks[0]?.lines?.[1]).toMatchObject({
+      kind: "add",
+      newLine: 12,
+      content: "const safe = true;",
+    });
+    expect(ReviewDiffLineSchema.parse({
+      kind: "context",
+      oldLine: 14,
+      newLine: 14,
+      content: "return value;",
+    }).kind).toBe("context");
+    expect(() =>
+      ReviewDiffLineSchema.parse({
+        kind: "add",
+        newLine: 1,
+        content: "x".repeat(1001),
+      }),
+    ).toThrow();
+    expect(() =>
+      ReviewDiffLineSchema.parse({
+        kind: "context",
+        oldLine: 0,
+        newLine: 1,
+        content: "return value;",
+      }),
+    ).toThrow();
     expect(() =>
       ReviewSnapshotSchema.parse({
         ...reviewSnapshot,

--- a/tests/gateway/coding-agents-summary.test.ts
+++ b/tests/gateway/coding-agents-summary.test.ts
@@ -782,6 +782,117 @@ describe("coding agent runtime summary", () => {
     }
   });
 
+  it("includes bounded hunk lines for a small git diff from a safe owner review worktree", async () => {
+    const homePath = await mkdtemp(join(tmpdir(), "matrix-review-diff-lines-"));
+    try {
+      const worktreeRoot = join(homePath, "projects", "matrix-os", "worktrees", "wt_abc123def456");
+      const sourceDir = join(worktreeRoot, "packages", "gateway", "src", "coding-agents");
+      await mkdir(sourceDir, { recursive: true });
+      await mkdir(join(worktreeRoot, ".matrix"), { recursive: true });
+      await execFileAsync("git", ["init"], { cwd: worktreeRoot });
+      await execFileAsync("git", ["config", "user.email", "matrix@example.invalid"], { cwd: worktreeRoot });
+      await execFileAsync("git", ["config", "user.name", "Matrix Review"], { cwd: worktreeRoot });
+      await writeFile(join(sourceDir, "routes.ts"), [
+        "export function route() {",
+        "  return 1;",
+        "}",
+        "",
+      ].join("\n"));
+      await execFileAsync("git", ["add", "."], { cwd: worktreeRoot });
+      await execFileAsync("git", ["commit", "-m", "base"], { cwd: worktreeRoot });
+      await execFileAsync("git", ["update-ref", "refs/remotes/origin/develop", "HEAD"], { cwd: worktreeRoot });
+      await writeFile(join(sourceDir, "routes.ts"), [
+        "export function route() {",
+        "  const next = 2;",
+        "  return next;",
+        "}",
+        "",
+      ].join("\n"));
+      await writeFile(join(worktreeRoot, ".matrix", "review-round-1.md"), "## Findings\n\nNo findings.\n");
+      const store = createCodingAgentReviewSummaryStore({
+        getReview: async () => ({
+          ok: true,
+          review: reviewRecord({ ownerId: testPrincipal.userId, rounds: [successfulFindingsRound()] }),
+        }),
+        listReviews: async () => ({ ok: true, reviews: [], nextCursor: null }),
+      } as ReviewLoopStore, {
+        ownerId: testPrincipal.userId,
+        homePath,
+      });
+
+      const snapshot = await store.getReviewSnapshot!(testPrincipal, "rev_1");
+      const hunk = snapshot.files.items[0]?.hunks[0];
+
+      expect(snapshot.partial).toBe(false);
+      expect(hunk?.partial).toBe(false);
+      expect(hunk?.lines).toEqual([
+        { kind: "context", oldLine: 1, newLine: 1, content: "export function route() {" },
+        { kind: "remove", oldLine: 2, content: "  return 1;" },
+        { kind: "add", newLine: 2, content: "  const next = 2;" },
+        { kind: "add", newLine: 3, content: "  return next;" },
+        { kind: "context", oldLine: 3, newLine: 4, content: "}" },
+      ]);
+      expect(JSON.stringify(snapshot)).not.toContain(homePath);
+    } finally {
+      await rm(homePath, { recursive: true, force: true });
+    }
+  });
+
+  it("caps large diff hunk line bodies and marks the snapshot partial", async () => {
+    const diffReader = vi.fn(async () => ({
+      ok: true as const,
+      files: [{
+        path: "packages/gateway/src/coding-agents/routes.ts",
+        status: "modified" as const,
+        additions: 160,
+        deletions: 0,
+        partial: false,
+        hunks: [{
+          id: "hunk_large",
+          oldStart: 1,
+          oldLines: 1,
+          newStart: 1,
+          newLines: 160,
+          partial: false,
+          lines: Array.from({ length: 160 }, (_, index) => ({
+            kind: "add" as const,
+            newLine: index + 1,
+            content: `const value${index} = ${index};`,
+          })),
+        }],
+      }],
+      hasMore: false,
+      partial: false,
+    }));
+    const store = createCodingAgentReviewSummaryStore({
+      getReview: async () => ({
+        ok: true,
+        review: reviewRecord({ ownerId: testPrincipal.userId, rounds: [successfulFindingsRound()] }),
+      }),
+      listReviews: async () => ({ ok: true, reviews: [], nextCursor: null }),
+    } as ReviewLoopStore, {
+      ownerId: testPrincipal.userId,
+      homePath: "/home/matrix/home",
+      diffReader,
+      findingsReader: async () => ({
+        ok: true,
+        parserStatus: "success",
+        findingsCount: 0,
+        severityCounts: { high: 0, medium: 0, low: 0 },
+        findings: [],
+      }),
+    });
+
+    const snapshot = await store.getReviewSnapshot!(testPrincipal, "rev_1");
+    const hunk = snapshot.files.items[0]?.hunks[0];
+
+    expect(hunk?.lines).toHaveLength(120);
+    expect(hunk?.partial).toBe(true);
+    expect(snapshot.files.items[0]?.partial).toBe(true);
+    expect(snapshot.partial).toBe(true);
+    expect(snapshot.safeNotice).toBe("Some diff content is unavailable. Showing bounded review metadata.");
+  });
+
   it("keeps unquoted binary diff headers aligned when paths contain the header separator text", async () => {
     const homePath = await mkdtemp(join(tmpdir(), "matrix-review-binary-header-diff-"));
     try {


### PR DESCRIPTION
## Summary

- Extend the review snapshot contract with bounded per-hunk diff line records.
- Parse safe owner worktree git diffs with unified context and return capped hunk line bodies.
- Mark hunks/files/snapshots partial when line caps or content caps are applied.
- Update the coding-agent current-state note; desktop/mobile rendering remains a later shell slice.

## Tests

- `pnpm exec vitest run tests/contracts/coding-agents.test.ts tests/gateway/coding-agents-summary.test.ts`
- `pnpm --filter @matrix-os/gateway exec tsc --noEmit`
- `bun run check:patterns` (0 violations, existing warnings only)
- `bun run typecheck`
- `git diff --check`
- Restricted wording scan across touched contract/gateway/spec/test files (no matches)

## Invariants

- Gateway/runtime remains the source of truth; shells receive parsed contract data only.
- Diff line bodies are capped per line and per hunk, with partial markers when truncated.
- Review snapshots still come from authenticated owner-scoped routes and validated owner worktree roots.
- No new persistence is added.
- Desktop/mobile UI rendering of diff lines is intentionally deferred to the next shell-focused slice.
