### PR TITLE
feat(desktop): render review diff lines

### DIFF
--- a/desktop/src/renderer/src/features/coding-agents/AgentWorkspace.tsx
+++ b/desktop/src/renderer/src/features/coding-agents/AgentWorkspace.tsx
@@ -30,6 +30,7 @@ const DEFAULT_STATUS_COLOR = "var(--text-tertiary)";
 type ReviewDetailStatus = "idle" | "loading" | "ready" | "error";
 type ReviewSnapshotFile = ReviewSnapshot["files"]["items"][number];
 type ReviewSnapshotHunk = ReviewSnapshotFile["hunks"][number];
+type ReviewSnapshotLine = NonNullable<ReviewSnapshotHunk["lines"]>[number];
 type ComposerSeed = {
   seedId: number;
   draft: AgentThreadComposerDraft;
@@ -413,6 +414,68 @@ function formatHunkRange(hunk: ReviewSnapshot["files"]["items"][number]["hunks"]
   return `@@ -${hunk.oldStart},${hunk.oldLines} +${hunk.newStart},${hunk.newLines} @@`;
 }
 
+function reviewDiffLineMarker(line: ReviewSnapshotLine): string {
+  if (line.kind === "add") return "+";
+  if (line.kind === "remove") return "-";
+  return " ";
+}
+
+function reviewDiffLineColor(line: ReviewSnapshotLine): string {
+  if (line.kind === "add") return "var(--success)";
+  if (line.kind === "remove") return "var(--danger)";
+  return "var(--text-secondary)";
+}
+
+function reviewDiffOldLine(line: ReviewSnapshotLine): number | null {
+  return "oldLine" in line ? line.oldLine : null;
+}
+
+function reviewDiffNewLine(line: ReviewSnapshotLine): number | null {
+  return "newLine" in line ? line.newLine : null;
+}
+
+function reviewDiffLineLabel(line: ReviewSnapshotLine): string {
+  const parts = [
+    line.kind === "add" ? "Added line" : line.kind === "remove" ? "Removed line" : "Context line",
+  ];
+  const oldLine = reviewDiffOldLine(line);
+  const newLine = reviewDiffNewLine(line);
+  if (oldLine !== null) parts.push("old", String(oldLine));
+  if (newLine !== null) parts.push("new", String(newLine));
+  return parts.join(" ");
+}
+
+function ReviewDiffLines({ lines }: { lines: ReviewSnapshotLine[] }) {
+  if (!lines.length) return null;
+
+  return (
+    <div
+      className="ph-no-capture mx-3 mb-2 overflow-hidden rounded border font-mono text-xs"
+      style={{ borderColor: "var(--border-subtle)", background: "var(--bg-surface)" }}
+    >
+      {lines.map((line, index) => (
+        <div
+          key={`${line.kind}:${reviewDiffOldLine(line) ?? ""}:${reviewDiffNewLine(line) ?? ""}:${index}`}
+          aria-label={reviewDiffLineLabel(line)}
+          className="grid min-h-6 grid-cols-[24px_44px_44px_minmax(0,1fr)] items-start gap-2 border-b px-2 py-1 last:border-b-0"
+          style={{ borderColor: "var(--border-subtle)", color: "var(--text-secondary)" }}
+        >
+          <span style={{ color: reviewDiffLineColor(line) }}>{reviewDiffLineMarker(line)}</span>
+          <span className="text-right tabular-nums" style={{ color: "var(--text-tertiary)" }}>
+            {reviewDiffOldLine(line) ?? ""}
+          </span>
+          <span className="text-right tabular-nums" style={{ color: "var(--text-tertiary)" }}>
+            {reviewDiffNewLine(line) ?? ""}
+          </span>
+          <code className="min-w-0 whitespace-pre-wrap break-words" style={{ color: "var(--text-primary)" }}>
+            {line.content}
+          </code>
+        </div>
+      ))}
+    </div>
+  );
+}
+
 function ReviewList({
   canCreateFollowUp,
   onAskHunkFollowUp,
@@ -605,30 +668,36 @@ function ReviewSnapshotPanel({
                   const hunkKey = reviewHunkKey(fileIndex, file, hunk, hunkIndex);
                   const selected = selectedHunk?.key === hunkKey;
                   return (
-                    <button
+                    <div
                       key={`${file.path}:${fileIndex}:${hunk.id}:${hunkIndex}`}
-                      type="button"
-                      aria-label={`Select hunk ${hunkIndex + 1} in ${file.path}`}
-                      aria-pressed={selected}
-                      className="no-drag grid gap-1 rounded-md border px-3 py-2 text-left transition-colors duration-100 hover:brightness-105"
-                      onClick={() => setSelectedHunkKey(hunkKey)}
+                      className="grid gap-1 rounded-md border transition-colors duration-100"
                       style={{
                         borderColor: selected ? "var(--accent)" : "var(--border-subtle)",
                         background: selected ? "var(--accent-muted)" : "transparent",
                       }}
                     >
-                      <span className="text-xs font-medium" style={{ color: "var(--text-secondary)" }}>
-                        {`Hunk ${hunkIndex + 1}`}
-                      </span>
-                      <span className="font-mono text-xs" style={{ color: "var(--text-primary)" }}>
-                        {formatHunkRange(hunk)}
-                      </span>
-                      {hunk.partial ? (
-                        <span className="text-xs" style={{ color: "var(--text-tertiary)" }}>
-                          Partial hunk
+                      <button
+                        type="button"
+                        aria-label={`Select hunk ${hunkIndex + 1} in ${file.path}`}
+                        aria-pressed={selected}
+                        className="no-drag grid gap-1 rounded-md px-3 py-2 text-left transition-colors duration-100 hover:brightness-105"
+                        onClick={() => setSelectedHunkKey(hunkKey)}
+                        style={{ background: "transparent" }}
+                      >
+                        <span className="text-xs font-medium" style={{ color: "var(--text-secondary)" }}>
+                          {`Hunk ${hunkIndex + 1}`}
                         </span>
-                      ) : null}
-                    </button>
+                        <span className="font-mono text-xs" style={{ color: "var(--text-primary)" }}>
+                          {formatHunkRange(hunk)}
+                        </span>
+                        {hunk.partial ? (
+                          <span className="text-xs" style={{ color: "var(--text-tertiary)" }}>
+                            Partial hunk
+                          </span>
+                        ) : null}
+                      </button>
+                      <ReviewDiffLines lines={hunk.lines ?? []} />
+                    </div>
                   );
                 })}
               </div>

--- a/specs/105-coding-agent-shells/current-state.md
+++ b/specs/105-coding-agent-shells/current-state.md
@@ -1,12 +1,12 @@
 # Current State: Coding Agent Shells
 
-**Branch stack**: `spec/coding-agent-shells` plus stacked implementation branches through `105-coding-agent-review-diff-lines`
+**Branch stack**: `spec/coding-agent-shells` plus stacked implementation branches through `105-coding-agent-desktop-review-diff-lines`
 **Updated**: 2026-07-07
 **Scope**: Inventory for the coding-agent desktop/mobile shell work. This file records the current Matrix-native route, contract, client, and regression-test state so later slices keep gateway/runtime as source of truth and keep desktop/mobile as thin shells.
 
 ## Summary
 
-The stack currently has shared contracts, a gateway runtime summary read model, read-only desktop and mobile workspaces behind flags, thread create/replay/abort/event streaming, provider adapters, a workspace-backed provider, approval/input route handling, a read-only coding-agent review summary route/client contract, desktop/mobile read-only review summary panels, and a read-only coding-agent review snapshot route with bounded file metadata from safe owner worktree diffs plus findings fallback metadata. Review snapshots can include bounded per-hunk diff lines with truncation markers. Desktop and mobile review details render changed-file counts and selectable hunk coordinate metadata. Desktop and mobile can seed their existing agent composers from a selected review hunk using bounded prompt context and a `structured_ref` attachment. Full file content and preview coding-agent surfaces are contract-only or existing workspace routes; dedicated preview shell UI is not yet integrated.
+The stack currently has shared contracts, a gateway runtime summary read model, read-only desktop and mobile workspaces behind flags, thread create/replay/abort/event streaming, provider adapters, a workspace-backed provider, approval/input route handling, a read-only coding-agent review summary route/client contract, desktop/mobile read-only review summary panels, and a read-only coding-agent review snapshot route with bounded file metadata from safe owner worktree diffs plus findings fallback metadata. Review snapshots can include bounded per-hunk diff lines with truncation markers. Desktop review details render changed-file counts, selectable hunk coordinate metadata, and gateway-bounded diff lines. Mobile review details render changed-file counts and selectable hunk coordinate metadata. Desktop and mobile can seed their existing agent composers from a selected review hunk using bounded prompt context and a `structured_ref` attachment. Full file content and preview coding-agent surfaces are contract-only or existing workspace routes; dedicated preview shell UI is not yet integrated.
 
 Current source-of-truth boundaries:
 
@@ -51,7 +51,7 @@ Implemented routes:
 | `/api/coding-agents/threads/:threadId/approvals/:approvalId/decision` | `POST` | Implemented | Body limit 8 KiB, validates approval id and decision payload. |
 | `/api/coding-agents/threads/:threadId/inputs/:inputRequestId/answer` | `POST` | Implemented | Body limit 40 KiB, validates bounded answer payload. |
 | `/api/coding-agents/reviews` | `GET` | Implemented | Authenticated read-only review summary list. Returns bounded `ReviewSummarySchema` items only. |
-| `/api/coding-agents/reviews/:reviewId` | `GET` | Implemented | Authenticated read-only review snapshot. Returns bounded `ReviewSnapshotSchema` with partial findings-derived file metadata; no diff content or file contents. |
+| `/api/coding-agents/reviews/:reviewId` | `GET` | Implemented | Authenticated read-only review snapshot. Returns bounded `ReviewSnapshotSchema` with partial findings-derived file metadata and bounded hunk diff lines when available; no full file contents. |
 
 Security and ownership:
 
@@ -207,7 +207,7 @@ Current behavior:
 
 - Read-only dashboard renders providers, active threads, and terminals.
 - When the runtime advertises `codingAgentsReview`, the dashboard fetches bounded review summaries through the trusted main-process IPC route and renders project, PR, round, status, and high-severity count.
-- Review snapshot details render bounded file paths, additions/deletions, partial markers, selectable hunk coordinate metadata, and safe finding summaries. The gateway snapshot can include bounded hunk lines, but desktop rendering of those lines is not wired in this slice.
+- Review snapshot details render bounded file paths, additions/deletions, partial markers, selectable hunk coordinate metadata, gateway-bounded hunk lines, and safe finding summaries. Diff line containers are blocked from session recording.
 - When thread creation is enabled, selecting a review hunk can open the mobile composer with bounded review metadata and a `structured_ref` attachment for the target file/hunk; the existing authenticated `createCodingAgentThread` gateway client performs the mutation.
 - When thread creation is enabled, selecting a review hunk can seed the existing desktop composer with bounded review metadata and a `structured_ref` attachment for the target file/hunk; the normal trusted `runtime:create-thread` IPC path performs the mutation.
 - Safe generic error state if the runtime summary is unavailable.

--- a/tests/desktop/coding-agent-workspace.test.tsx
+++ b/tests/desktop/coding-agent-workspace.test.tsx
@@ -149,6 +149,24 @@ function reviewSnapshotFixture() {
               newLines: 2,
               heading: "@@ -88 +93 @@",
               partial: false,
+              lines: [
+                {
+                  kind: "context",
+                  oldLine: 88,
+                  newLine: 93,
+                  content: "const request = parseReviewRequest(input);",
+                },
+                {
+                  kind: "remove",
+                  oldLine: 89,
+                  content: "return rawReviewDetails;",
+                },
+                {
+                  kind: "add",
+                  newLine: 94,
+                  content: "return safeReviewDetails;",
+                },
+              ],
             },
           ],
           findings: [
@@ -264,6 +282,26 @@ describe("AgentWorkspace", () => {
     fireEvent.click(hunk);
     expect(hunk.getAttribute("aria-pressed")).toBe("true");
     expect(screen.queryByText(/export const|function create|raw diff/i)).toBeNull();
+  });
+
+  it("renders gateway-bounded review diff lines with old and new line references", async () => {
+    render(<AgentWorkspace />);
+
+    await screen.findByText("matrix-os");
+    fireEvent.click(screen.getByRole("button", { name: /Open review PR #758/i }));
+
+    const contextLine = await screen.findByLabelText("Context line old 88 new 93");
+    const removedLine = screen.getByLabelText("Removed line old 89");
+    const addedLine = screen.getByLabelText("Added line new 94");
+
+    expect(contextLine.textContent).toContain("88");
+    expect(contextLine.textContent).toContain("93");
+    expect(contextLine.textContent).toContain("const request = parseReviewRequest(input);");
+    expect(removedLine.textContent).toContain("-");
+    expect(removedLine.textContent).toContain("return rawReviewDetails;");
+    expect(addedLine.textContent).toContain("+");
+    expect(addedLine.textContent).toContain("return safeReviewDetails;");
+    expect(addedLine.closest("button")).toBeNull();
   });
 
   it("seeds the desktop composer with structured review hunk follow-up context", async () => {


### PR DESCRIPTION
## Summary

- Render bounded review diff lines in the desktop coding-agent review panel.
- Keep hunk selection and structured follow-up seeding on the existing trusted IPC path.
- Update spec 105 current-state notes for the desktop diff-line slice.

## Tests

- `pnpm exec vitest run tests/desktop/coding-agent-workspace.test.tsx`
- `pnpm --filter desktop run typecheck`
- `bun run check:patterns`
- `bun run typecheck`
- `git diff --check`
- Restricted wording scan across touched files: no matches.

## Review/Monitoring

- PR is ready for review.
- Greptile is 5/5 on head `bcb7ac8ec8949b1698abec0476f765e039b98ea6`.
- `ready-for-ci` added after Greptile reached 5/5.

## Invariants

- Source of truth: gateway review snapshots remain the source of truth; desktop only renders bounded `ReviewSnapshotSchema` data received through trusted main-process IPC.
- Lock/transaction scope: no persistence, database writes, locks, or transactions are introduced.
- Acceptable orphan states: if hunk lines are absent, desktop still renders the existing hunk metadata and follow-up flow.
- Auth source of truth: desktop renderer receives parsed review data only; bearer credentials remain in the main process.
- Deferred scope: mobile diff-line rendering and dedicated preview/file review surfaces remain follow-up slices.
