### PR TITLE
feat(mobile): render review diff lines

### DIFF
--- a/apps/mobile/__tests__/agents-screen.test.tsx
+++ b/apps/mobile/__tests__/agents-screen.test.tsx
@@ -211,6 +211,24 @@ function reviewSnapshotWithHunks() {
             newStart: 93,
             newLines: 2,
             partial: false,
+            lines: [
+              {
+                kind: "context",
+                oldLine: 88,
+                newLine: 93,
+                content: "const request = parseReviewRequest(input);",
+              },
+              {
+                kind: "remove",
+                oldLine: 89,
+                content: "return rawReviewDetails;",
+              },
+              {
+                kind: "add",
+                newLine: 94,
+                content: "return safeReviewDetails;",
+              },
+            ],
           },
         ],
       })),
@@ -379,6 +397,44 @@ describe("AgentsScreen", () => {
 
     expect(hunk.props.accessibilityState?.selected).toBe(true);
     expect(screen.queryByText(/export const|function create|raw diff/i)).toBeNull();
+  });
+
+  it("renders bounded review diff lines with mobile old and new line labels", async () => {
+    const client = {
+      getCodingAgentRuntimeSummary: jest.fn().mockResolvedValue({
+        ok: true,
+        summary: summaryFixture(),
+      }),
+      getCodingAgentReviews: jest.fn().mockResolvedValue({
+        ok: true,
+        reviews: reviewsFixture(),
+      }),
+      getCodingAgentReviewSnapshot: jest.fn().mockResolvedValue({
+        ok: true,
+        snapshot: reviewSnapshotWithHunks(),
+      }),
+    };
+    useGatewayMock.mockReturnValue(gatewayContext({
+      client: client as unknown as GatewayClient,
+      connectionState: "connected",
+    }));
+
+    render(<AgentsScreen />);
+
+    await screen.findByText("matrix-os");
+    await act(async () => {
+      fireEvent.press(screen.getByLabelText("Open review PR #759"));
+    });
+
+    const contextLine = await screen.findByLabelText("Context line old 88 new 93");
+    const removedLine = screen.getByLabelText("Removed line old 89");
+    const addedLine = screen.getByLabelText("Added line new 94");
+
+    expect(contextLine.props.children).toContain("const request = parseReviewRequest(input);");
+    expect(removedLine.props.children).toContain("return rawReviewDetails;");
+    expect(addedLine.props.children).toContain("return safeReviewDetails;");
+    expect(screen.getByText("+")).toBeTruthy();
+    expect(screen.getByText("-")).toBeTruthy();
   });
 
   it("opens the mobile composer with bounded selected review hunk context", async () => {

--- a/apps/mobile/app/agents/index.tsx
+++ b/apps/mobile/app/agents/index.tsx
@@ -28,6 +28,9 @@ type ReviewSnapshotState =
   | { status: "ready"; selectedReviewId: string; snapshot: ReviewSnapshot; error: null }
   | { status: "error"; selectedReviewId: string; snapshot: null; error: "Review details unavailable" };
 
+type ReviewSnapshotHunk = ReviewSnapshot["files"]["items"][number]["hunks"][number];
+type ReviewSnapshotLine = NonNullable<ReviewSnapshotHunk["lines"]>[number];
+
 type SelectedReviewHunk = {
   reviewId: string;
   snapshotKey: string;
@@ -66,8 +69,33 @@ function safeSnapshotText(value: string, fallback: string): string {
   return SECRET_LIKE_FINDING_TEXT.test(value) ? fallback : value;
 }
 
-function formatHunkRange(hunk: ReviewSnapshot["files"]["items"][number]["hunks"][number]): string {
+function formatHunkRange(hunk: ReviewSnapshotHunk): string {
   return `@@ -${hunk.oldStart},${hunk.oldLines} +${hunk.newStart},${hunk.newLines} @@`;
+}
+
+function reviewDiffLineMarker(line: ReviewSnapshotLine): string {
+  if (line.kind === "add") return "+";
+  if (line.kind === "remove") return "-";
+  return " ";
+}
+
+function reviewDiffOldLine(line: ReviewSnapshotLine): number | null {
+  return "oldLine" in line ? line.oldLine : null;
+}
+
+function reviewDiffNewLine(line: ReviewSnapshotLine): number | null {
+  return "newLine" in line ? line.newLine : null;
+}
+
+function reviewDiffLineLabel(line: ReviewSnapshotLine): string {
+  const parts = [
+    line.kind === "add" ? "Added line" : line.kind === "remove" ? "Removed line" : "Context line",
+  ];
+  const oldLine = reviewDiffOldLine(line);
+  const newLine = reviewDiffNewLine(line);
+  if (oldLine !== null) parts.push("old", String(oldLine));
+  if (newLine !== null) parts.push("new", String(newLine));
+  return parts.join(" ");
 }
 
 function reviewSnapshotSelectionKey(snapshot: ReviewSnapshot): string {
@@ -83,6 +111,40 @@ function reviewSnapshotSelectionKey(snapshot: ReviewSnapshot): string {
       file.hunks.map((hunk) => `${hunk.id}:${hunk.oldStart}:${hunk.oldLines}:${hunk.newStart}:${hunk.newLines}:${hunk.partial ? "partial" : "complete"}`).join("|"),
     ].join(":")).join("\u0001"),
   ].join("\u0002");
+}
+
+function ReviewDiffLines({ lines }: { lines: ReviewSnapshotLine[] }) {
+  if (!lines.length) return null;
+
+  return (
+    <View style={styles.reviewDiffLines}>
+      {lines.map((line, index) => (
+        <View
+          key={`${line.kind}:${reviewDiffOldLine(line) ?? ""}:${reviewDiffNewLine(line) ?? ""}:${index}`}
+          style={styles.reviewDiffLine}
+        >
+          <Text
+            style={[
+              styles.reviewDiffMarker,
+              line.kind === "add" ? styles.reviewDiffAdded : null,
+              line.kind === "remove" ? styles.reviewDiffRemoved : null,
+            ]}
+          >
+            {reviewDiffLineMarker(line)}
+          </Text>
+          <Text style={styles.reviewDiffLineNumber}>{reviewDiffOldLine(line) ?? ""}</Text>
+          <Text style={styles.reviewDiffLineNumber}>{reviewDiffNewLine(line) ?? ""}</Text>
+          <Text
+            accessibilityLabel={reviewDiffLineLabel(line)}
+            selectable
+            style={styles.reviewDiffContent}
+          >
+            {line.content}
+          </Text>
+        </View>
+      ))}
+    </View>
+  );
 }
 
 export default function AgentsScreen() {
@@ -508,32 +570,37 @@ function ReviewSnapshotFileRow({
             const hunkKey = `${fileIndex}\u0000${file.path}\u0000${hunk.id}\u0000${hunkIndex}`;
             const selected = selectedHunk?.reviewId === selectedReviewId && selectedHunk.snapshotKey === snapshotKey && selectedHunk.key === hunkKey;
             return (
-              <Pressable
+              <View
                 key={`${file.path}:${fileIndex}:${hunk.id}:${hunkIndex}`}
-                accessibilityRole="button"
-                accessibilityLabel={`Select hunk ${hunkIndex + 1} in ${displayPath}`}
-                accessibilityState={{ selected }}
-                onPress={() => onSelectHunk({
-                  reviewId: selectedReviewId,
-                  snapshotKey,
-                  key: hunkKey,
-                  filePath: file.path,
-                  hunkId: hunk.id,
-                  hunkIndex,
-                  oldStart: hunk.oldStart,
-                  oldLines: hunk.oldLines,
-                  newStart: hunk.newStart,
-                  newLines: hunk.newLines,
-                })}
                 style={[
                   styles.reviewHunkRow,
                   selected ? styles.selectedReviewHunkRow : null,
                 ]}
               >
-                <Text style={styles.reviewHunkLabel}>{`Hunk ${hunkIndex + 1}`}</Text>
-                <Text style={styles.reviewHunkRange}>{formatHunkRange(hunk)}</Text>
-                {hunk.partial ? <Text style={styles.reviewHunkPartial}>Partial hunk</Text> : null}
-              </Pressable>
+                <Pressable
+                  accessibilityRole="button"
+                  accessibilityLabel={`Select hunk ${hunkIndex + 1} in ${displayPath}`}
+                  accessibilityState={{ selected }}
+                  onPress={() => onSelectHunk({
+                    reviewId: selectedReviewId,
+                    snapshotKey,
+                    key: hunkKey,
+                    filePath: file.path,
+                    hunkId: hunk.id,
+                    hunkIndex,
+                    oldStart: hunk.oldStart,
+                    oldLines: hunk.oldLines,
+                    newStart: hunk.newStart,
+                    newLines: hunk.newLines,
+                  })}
+                  style={styles.reviewHunkPressable}
+                >
+                  <Text style={styles.reviewHunkLabel}>{`Hunk ${hunkIndex + 1}`}</Text>
+                  <Text style={styles.reviewHunkRange}>{formatHunkRange(hunk)}</Text>
+                  {hunk.partial ? <Text style={styles.reviewHunkPartial}>Partial hunk</Text> : null}
+                </Pressable>
+                <ReviewDiffLines lines={hunk.lines ?? []} />
+              </View>
             );
           })}
         </View>
@@ -826,12 +893,15 @@ const styles = StyleSheet.create((theme, rt) => ({
     borderWidth: 1,
     borderColor: theme.colors.border,
     backgroundColor: theme.colors.card,
-    padding: theme.spacing.sm,
-    gap: 2,
+    overflow: "hidden",
   },
   selectedReviewHunkRow: {
     borderColor: theme.colors.forest,
     backgroundColor: theme.colors.background,
+  },
+  reviewHunkPressable: {
+    padding: theme.spacing.sm,
+    gap: 2,
   },
   reviewHunkLabel: {
     fontFamily: theme.fonts.sansSemiBold,
@@ -847,6 +917,47 @@ const styles = StyleSheet.create((theme, rt) => ({
     fontFamily: theme.fonts.sans,
     fontSize: 11,
     color: theme.colors.mutedForeground,
+  },
+  reviewDiffLines: {
+    borderTopWidth: 1,
+    borderColor: theme.colors.border,
+    backgroundColor: theme.colors.secondary,
+  },
+  reviewDiffLine: {
+    minHeight: 24,
+    flexDirection: "row",
+    alignItems: "flex-start",
+    gap: theme.spacing.xs,
+    paddingHorizontal: theme.spacing.sm,
+    paddingVertical: 4,
+    borderBottomWidth: 1,
+    borderColor: theme.colors.border,
+  },
+  reviewDiffMarker: {
+    width: 14,
+    fontFamily: theme.fonts.mono,
+    fontSize: 11,
+    color: theme.colors.mutedForeground,
+  },
+  reviewDiffAdded: {
+    color: theme.colors.forest,
+  },
+  reviewDiffRemoved: {
+    color: theme.colors.destructive,
+  },
+  reviewDiffLineNumber: {
+    width: 34,
+    textAlign: "right",
+    fontFamily: theme.fonts.mono,
+    fontSize: 11,
+    color: theme.colors.mutedForeground,
+  },
+  reviewDiffContent: {
+    flex: 1,
+    minWidth: 0,
+    fontFamily: theme.fonts.mono,
+    fontSize: 11,
+    color: theme.colors.foreground,
   },
   reviewFollowUpButton: {
     minHeight: 42,

--- a/specs/105-coding-agent-shells/current-state.md
+++ b/specs/105-coding-agent-shells/current-state.md
@@ -1,12 +1,12 @@
 # Current State: Coding Agent Shells
 
-**Branch stack**: `spec/coding-agent-shells` plus stacked implementation branches through `105-coding-agent-desktop-review-diff-lines`
+**Branch stack**: `spec/coding-agent-shells` plus stacked implementation branches through `105-coding-agent-mobile-review-diff-lines`
 **Updated**: 2026-07-07
 **Scope**: Inventory for the coding-agent desktop/mobile shell work. This file records the current Matrix-native route, contract, client, and regression-test state so later slices keep gateway/runtime as source of truth and keep desktop/mobile as thin shells.
 
 ## Summary
 
-The stack currently has shared contracts, a gateway runtime summary read model, read-only desktop and mobile workspaces behind flags, thread create/replay/abort/event streaming, provider adapters, a workspace-backed provider, approval/input route handling, a read-only coding-agent review summary route/client contract, desktop/mobile read-only review summary panels, and a read-only coding-agent review snapshot route with bounded file metadata from safe owner worktree diffs plus findings fallback metadata. Review snapshots can include bounded per-hunk diff lines with truncation markers. Desktop review details render changed-file counts, selectable hunk coordinate metadata, and gateway-bounded diff lines. Mobile review details render changed-file counts and selectable hunk coordinate metadata. Desktop and mobile can seed their existing agent composers from a selected review hunk using bounded prompt context and a `structured_ref` attachment. Full file content and preview coding-agent surfaces are contract-only or existing workspace routes; dedicated preview shell UI is not yet integrated.
+The stack currently has shared contracts, a gateway runtime summary read model, read-only desktop and mobile workspaces behind flags, thread create/replay/abort/event streaming, provider adapters, a workspace-backed provider, approval/input route handling, a read-only coding-agent review summary route/client contract, desktop/mobile read-only review summary panels, and a read-only coding-agent review snapshot route with bounded file metadata from safe owner worktree diffs plus findings fallback metadata. Review snapshots can include bounded per-hunk diff lines with truncation markers. Desktop and mobile review details render changed-file counts, selectable hunk coordinate metadata, and gateway-bounded diff lines. Desktop and mobile can seed their existing agent composers from a selected review hunk using bounded prompt context and a `structured_ref` attachment. Full file content and preview coding-agent surfaces are contract-only or existing workspace routes; dedicated preview shell UI is not yet integrated.
 
 Current source-of-truth boundaries:
 
@@ -230,7 +230,7 @@ Screen:
 - `apps/mobile/app/agents/[threadId].tsx`
 - Read-only phone-first dashboard with providers, active threads, and terminal sessions.
 - When the runtime advertises `codingAgentsReview`, the dashboard fetches bounded review summaries through the authenticated gateway client and renders project, PR, round, status, and high-severity count.
-- Review snapshot details render bounded file paths, additions/deletions, partial markers, selectable hunk coordinate metadata, and safe finding summaries. The gateway snapshot can include bounded hunk lines, but mobile rendering of those lines is not wired in this slice.
+- Review snapshot details render bounded file paths, additions/deletions, partial markers, selectable hunk coordinate metadata, gateway-bounded hunk lines, and safe finding summaries.
 - Safe generic review error state if review summaries are unavailable; review failures do not drop the runtime summary dashboard.
 - Composer route for creating accepted coding-agent threads; thread route is a bounded placeholder until replay/review surfaces are wired.
 - Flag: `apps/mobile/lib/feature-flags.ts` with `EXPO_PUBLIC_CODING_AGENTS_MOBILE_WORKSPACE === "1"`.


### PR DESCRIPTION
## Summary

- Render bounded review diff lines in the mobile coding-agent review panel.
- Keep hunk selection and composer follow-up seeding on the existing authenticated mobile gateway/client flow.
- Update spec 105 current-state notes for the mobile diff-line slice.

## Tests

- `pnpm --filter matrix-os-mobile run test -- agents-screen.test.tsx`
- `pnpm --filter matrix-os-mobile run lint`
- `pnpm --filter matrix-os-mobile exec tsc --noEmit`
- `bun run check:patterns`
- `bun run typecheck`
- `git diff --check`
- Restricted wording scan across touched files: no matches.

## Review/Monitoring

- PR is ready for review.
- Greptile completed successfully on head `e5a28a640a1fcb2d22a4df7fca55b0d0514b0616`.
- `ready-for-ci` label is applied.

## Invariants

- Source of truth: gateway review snapshots remain the source of truth; mobile only renders bounded `ReviewSnapshotSchema` data from the authenticated gateway client.
- Lock/transaction scope: no persistence, database writes, locks, or transactions are introduced.
- Acceptable orphan states: if hunk lines are absent, mobile still renders the existing hunk metadata and follow-up flow.
- Auth source of truth: mobile uses the existing gateway client auth path and stores no transcripts, terminal output, diffs, file contents, credentials, approvals payloads, or launch tokens.
- Deferred scope: dedicated preview/file review surfaces remain follow-up slices.
