### PR TITLE
feat(mobile): hydrate agent thread detail

### DIFF
--- a/apps/mobile/__tests__/agent-thread-screen.test.tsx
+++ b/apps/mobile/__tests__/agent-thread-screen.test.tsx
@@ -1,0 +1,219 @@
+jest.mock("@/app/_layout", () => ({
+  useGateway: jest.fn(),
+}));
+
+const mockParams = { threadId: "thread_mobile" };
+
+jest.mock("expo-router", () => ({
+  useLocalSearchParams: () => mockParams,
+}));
+
+import React from "react";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react-native";
+import AgentThreadRoute from "../app/agents/[threadId]";
+import { useGateway } from "@/app/_layout";
+import type { GatewayClient } from "../lib/gateway-client";
+
+const useGatewayMock = useGateway as jest.MockedFunction<typeof useGateway>;
+type GatewayContextValue = ReturnType<typeof useGateway>;
+
+function gatewayContext(overrides: Partial<GatewayContextValue>): GatewayContextValue {
+  return {
+    client: null,
+    connectionState: "disconnected",
+    gateway: null,
+    setGateway: jest.fn(),
+    unreadCount: 0,
+    incrementUnread: jest.fn(),
+    clearUnread: jest.fn(),
+    ...overrides,
+  };
+}
+
+function threadSnapshotFixture() {
+  return {
+    thread: {
+      id: "thread_mobile",
+      providerId: "codex",
+      title: "Repair mobile route",
+      status: "running",
+      attention: "none",
+      terminalSessionId: "matrix-abc1234",
+      createdAt: "2026-07-06T00:00:00.000Z",
+      updatedAt: "2026-07-06T00:01:00.000Z",
+    },
+    events: {
+      items: [
+        {
+          eventId: "evt_mobile_1",
+          threadId: "thread_mobile",
+          type: "thread.status",
+          status: "running",
+          occurredAt: "2026-07-06T00:01:00.000Z",
+        },
+        {
+          eventId: "evt_mobile_2",
+          threadId: "thread_mobile",
+          type: "terminal.bound",
+          terminalSessionId: "matrix-abc1234",
+          occurredAt: "2026-07-06T00:01:30.000Z",
+        },
+      ],
+      hasMore: false,
+      limit: 200,
+    },
+  };
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((promiseResolve) => {
+    resolve = promiseResolve;
+  });
+  return { promise, resolve };
+}
+
+describe("AgentThreadRoute", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockParams.threadId = "thread_mobile";
+  });
+
+  it("hydrates a bounded coding-agent thread snapshot from the gateway", async () => {
+    const client = {
+      getCodingAgentThreadSnapshot: jest.fn().mockResolvedValue({
+        ok: true,
+        snapshot: threadSnapshotFixture(),
+      }),
+    };
+    useGatewayMock.mockReturnValue(gatewayContext({
+      client: client as unknown as GatewayClient,
+      connectionState: "connected",
+    }));
+
+    render(<AgentThreadRoute />);
+
+    expect(screen.getByText("Loading thread...")).toBeTruthy();
+    expect(await screen.findByText("Repair mobile route")).toBeTruthy();
+    expect(screen.getByText("running")).toBeTruthy();
+    expect(screen.getByText("codex")).toBeTruthy();
+    expect(screen.getByText("matrix-abc1234")).toBeTruthy();
+    expect(screen.getByText("2 events")).toBeTruthy();
+    expect(client.getCodingAgentThreadSnapshot).toHaveBeenCalledWith({ threadId: "thread_mobile" });
+  });
+
+  it("renders a generic thread error without exposing raw gateway details", async () => {
+    const client = {
+      getCodingAgentThreadSnapshot: jest.fn().mockResolvedValue({
+        ok: false,
+        error: "Thread state unavailable",
+      }),
+    };
+    useGatewayMock.mockReturnValue(gatewayContext({
+      client: client as unknown as GatewayClient,
+      connectionState: "connected",
+    }));
+
+    render(<AgentThreadRoute />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Thread state unavailable")).toBeTruthy();
+    });
+    expect(screen.queryByText(/home\/matrix|token|secret/i)).toBeNull();
+  });
+
+  it("keeps the last good thread snapshot visible when refresh fails", async () => {
+    const client = {
+      getCodingAgentThreadSnapshot: jest.fn()
+        .mockResolvedValueOnce({
+          ok: true,
+          snapshot: threadSnapshotFixture(),
+        })
+        .mockResolvedValueOnce({
+          ok: false,
+          error: "Thread state unavailable",
+        }),
+    };
+    useGatewayMock.mockReturnValue(gatewayContext({
+      client: client as unknown as GatewayClient,
+      connectionState: "connected",
+    }));
+
+    render(<AgentThreadRoute />);
+
+    expect(await screen.findByText("Repair mobile route")).toBeTruthy();
+    await act(async () => {
+      fireEvent.press(screen.getByLabelText("Refresh thread"));
+    });
+
+    expect(await screen.findByText("Thread state unavailable")).toBeTruthy();
+    expect(screen.getByText("Repair mobile route")).toBeTruthy();
+    expect(screen.getByText("2 events")).toBeTruthy();
+    expect(screen.queryByText(/home\/matrix|token|secret/i)).toBeNull();
+  });
+
+  it("ignores stale thread refresh responses that resolve after newer snapshots", async () => {
+    const staleRefresh = deferred<{ ok: true; snapshot: ReturnType<typeof threadSnapshotFixture> }>();
+    const freshRefresh = deferred<{ ok: true; snapshot: ReturnType<typeof threadSnapshotFixture> }>();
+    const staleSnapshot = {
+      ...threadSnapshotFixture(),
+      thread: {
+        ...threadSnapshotFixture().thread,
+        title: "Stale mobile route",
+        updatedAt: "2026-07-06T00:02:00.000Z",
+      },
+    };
+    const freshSnapshot = {
+      ...threadSnapshotFixture(),
+      thread: {
+        ...threadSnapshotFixture().thread,
+        title: "Fresh mobile route",
+        updatedAt: "2026-07-06T00:03:00.000Z",
+      },
+      events: {
+        ...threadSnapshotFixture().events,
+        items: threadSnapshotFixture().events.items.slice(0, 1),
+      },
+    };
+    const client = {
+      getCodingAgentThreadSnapshot: jest.fn()
+        .mockResolvedValueOnce({
+          ok: true,
+          snapshot: threadSnapshotFixture(),
+        })
+        .mockImplementationOnce(() => staleRefresh.promise)
+        .mockImplementationOnce(() => freshRefresh.promise),
+    };
+    useGatewayMock.mockReturnValue(gatewayContext({
+      client: client as unknown as GatewayClient,
+      connectionState: "connected",
+    }));
+
+    render(<AgentThreadRoute />);
+
+    expect(await screen.findByText("Repair mobile route")).toBeTruthy();
+    await act(async () => {
+      fireEvent.press(screen.getByLabelText("Refresh thread"));
+      fireEvent.press(screen.getByLabelText("Refresh thread"));
+    });
+
+    await act(async () => {
+      freshRefresh.resolve({ ok: true, snapshot: freshSnapshot });
+      await freshRefresh.promise;
+    });
+
+    expect(await screen.findByText("Fresh mobile route")).toBeTruthy();
+    expect(screen.getByText("1 event")).toBeTruthy();
+
+    await act(async () => {
+      staleRefresh.resolve({ ok: true, snapshot: staleSnapshot });
+      await staleRefresh.promise;
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByText("Stale mobile route")).toBeNull();
+    });
+    expect(screen.getByText("Fresh mobile route")).toBeTruthy();
+    expect(screen.getByText("1 event")).toBeTruthy();
+  });
+});

--- a/apps/mobile/__tests__/agents-screen.test.tsx
+++ b/apps/mobile/__tests__/agents-screen.test.tsx
@@ -296,6 +296,32 @@ describe("AgentsScreen", () => {
     expect(screen.getByText("matrix-abc1234")).toBeTruthy();
   });
 
+  it("opens a mobile thread detail route from active threads", async () => {
+    const client = {
+      getCodingAgentRuntimeSummary: jest.fn().mockResolvedValue({
+        ok: true,
+        summary: summaryFixture(),
+      }),
+      getCodingAgentReviews: jest.fn().mockResolvedValue({
+        ok: true,
+        reviews: reviewsFixture(),
+      }),
+    };
+    useGatewayMock.mockReturnValue(gatewayContext({
+      client: client as unknown as GatewayClient,
+      connectionState: "connected",
+    }));
+
+    render(<AgentsScreen />);
+
+    await screen.findByText("Repair mobile route");
+    await act(async () => {
+      fireEvent.press(screen.getByLabelText("Open thread Repair mobile route"));
+    });
+
+    expect(mockRouterPush).toHaveBeenCalledWith("/agents/thread_mobile");
+  });
+
   it("renders read-only review summaries", async () => {
     const client = {
       getCodingAgentRuntimeSummary: jest.fn().mockResolvedValue({

--- a/apps/mobile/__tests__/gateway-client.test.ts
+++ b/apps/mobile/__tests__/gateway-client.test.ts
@@ -286,6 +286,50 @@ describe("GatewayClient", () => {
     fetchMock.mockRestore();
   });
 
+  it("fetches coding agent thread snapshots with the existing auth header", async () => {
+    const snapshot = {
+      thread: {
+        id: "thread_mobile",
+        providerId: "codex",
+        title: "Repair mobile route",
+        status: "running",
+        attention: "none",
+        terminalSessionId: "matrix-abc1234",
+        createdAt: "2026-07-06T00:00:00.000Z",
+        updatedAt: "2026-07-06T00:01:00.000Z",
+      },
+      events: {
+        items: [
+          {
+            eventId: "evt_mobile_1",
+            threadId: "thread_mobile",
+            type: "thread.status",
+            status: "running",
+            occurredAt: "2026-07-06T00:01:00.000Z",
+          },
+        ],
+        hasMore: false,
+        limit: 200,
+      },
+    };
+    const fetchMock = jest.spyOn(global, "fetch").mockResolvedValueOnce(jsonResponse(snapshot));
+
+    const client = new GatewayClient("http://localhost:4000", "token");
+    await expect(client.getCodingAgentThreadSnapshot({ threadId: "thread_mobile" })).resolves.toEqual({
+      ok: true,
+      snapshot,
+    });
+    expect(fetchMock).toHaveBeenCalledWith("http://localhost:4000/api/coding-agents/threads/thread_mobile", expect.objectContaining({
+      headers: expect.objectContaining({
+        Authorization: "Bearer token",
+        "Content-Type": "application/json",
+      }),
+      signal: expect.any(Object),
+    }));
+
+    fetchMock.mockRestore();
+  });
+
   it("creates coding agent threads with the existing auth header", async () => {
     const snapshot = {
       thread: {

--- a/apps/mobile/app/agents/[threadId].tsx
+++ b/apps/mobile/app/agents/[threadId].tsx
@@ -1,10 +1,83 @@
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useLocalSearchParams } from "expo-router";
-import { ScrollView, Text, View } from "react-native";
-import { StyleSheet } from "react-native-unistyles";
+import { ActivityIndicator, Pressable, ScrollView, Text, View } from "react-native";
+import { Ionicons } from "@expo/vector-icons";
+import { StyleSheet, useUnistyles } from "react-native-unistyles";
+import type { AgentThreadSnapshot } from "@matrix-os/contracts";
+import { useGateway } from "@/app/_layout";
+
+type ThreadRouteState =
+  | { status: "loading"; snapshot: null; error: null }
+  | { status: "ready"; snapshot: AgentThreadSnapshot; error: "Thread state unavailable" | null; refreshing: boolean }
+  | { status: "error"; snapshot: null; error: "Thread state unavailable" };
 
 export default function AgentThreadRoute() {
+  const { theme } = useUnistyles();
   const params = useLocalSearchParams<{ threadId?: string }>();
   const threadId = typeof params.threadId === "string" ? params.threadId : "thread";
+  const { client } = useGateway();
+  const requestGeneration = useRef(0);
+  const [state, setState] = useState<ThreadRouteState>({
+    status: "loading",
+    snapshot: null,
+    error: null,
+  });
+
+  const loadSnapshot = useCallback(async (cancelled: () => boolean = () => false) => {
+    if (!client || !threadId) {
+      setState((current) => current.status === "ready"
+        ? { ...current, error: "Thread state unavailable", refreshing: false }
+        : { status: "error", snapshot: null, error: "Thread state unavailable" });
+      return;
+    }
+    const generation = requestGeneration.current + 1;
+    requestGeneration.current = generation;
+    setState((current) => current.status === "ready"
+      ? { ...current, error: null, refreshing: true }
+      : { status: "loading", snapshot: null, error: null });
+    const result = await client.getCodingAgentThreadSnapshot({ threadId });
+    if (cancelled() || generation !== requestGeneration.current) return;
+    if (result.ok) {
+      setState({ status: "ready", snapshot: result.snapshot, error: null, refreshing: false });
+      return;
+    }
+    setState((current) => current.status === "ready"
+      ? { ...current, error: "Thread state unavailable", refreshing: false }
+      : { status: "error", snapshot: null, error: "Thread state unavailable" });
+  }, [client, threadId]);
+
+  useEffect(() => {
+    let cancelled = false;
+    const timer = setTimeout(() => {
+      void loadSnapshot(() => cancelled);
+    }, 0);
+    return () => {
+      cancelled = true;
+      clearTimeout(timer);
+    };
+  }, [loadSnapshot]);
+
+  if (state.status === "loading") {
+    return (
+      <View style={styles.centered}>
+        <ActivityIndicator color={theme.colors.forest} />
+        <Text style={styles.title}>Loading thread...</Text>
+      </View>
+    );
+  }
+
+  if (state.status === "error") {
+    return (
+      <View style={styles.centered}>
+        <Ionicons name="warning-outline" size={28} color={theme.colors.moss} />
+        <Text style={styles.title}>{state.error}</Text>
+        <Text style={styles.body}>Refresh the workspace or open the thread again.</Text>
+      </View>
+    );
+  }
+
+  const { thread, events } = state.snapshot;
+  const terminalSessionId = thread.terminalSessionId ?? "No terminal bound";
 
   return (
     <ScrollView
@@ -13,16 +86,62 @@ export default function AgentThreadRoute() {
       contentContainerStyle={styles.content}
     >
       <View style={styles.panel}>
-        <Text selectable style={styles.title}>Agent thread</Text>
-        <Text selectable style={styles.body}>{threadId}</Text>
+        <View style={styles.headerRow}>
+          <View style={styles.threadIcon}>
+            <Ionicons name="git-branch-outline" size={18} color={theme.colors.moss} />
+          </View>
+          <View style={styles.headerText}>
+            <Text selectable style={styles.title}>{thread.title}</Text>
+            <Text selectable style={styles.body}>{thread.providerId}</Text>
+          </View>
+          <Text style={styles.status}>{thread.status.replace(/_/g, " ")}</Text>
+        </View>
+        <View style={styles.metaGrid}>
+          <MetaItem label="Thread" value={thread.id} />
+          <MetaItem label="Terminal" value={terminalSessionId} />
+          <MetaItem label="Updated" value={thread.updatedAt} />
+          <MetaItem label="Activity" value={`${events.items.length} ${events.items.length === 1 ? "event" : "events"}`} />
+        </View>
+        {events.hasMore ? (
+          <Text style={styles.body}>Older activity is available from the runtime.</Text>
+        ) : null}
+        {state.error ? (
+          <Text style={styles.inlineError}>{state.error}</Text>
+        ) : null}
+        <Pressable
+          accessibilityRole="button"
+          accessibilityLabel="Refresh thread"
+          onPress={() => void loadSnapshot()}
+          style={styles.refreshButton}
+        >
+          <Ionicons name="refresh-outline" size={16} color={theme.colors.background} />
+          <Text style={styles.refreshText}>{state.refreshing ? "Refreshing" : "Refresh"}</Text>
+        </Pressable>
       </View>
     </ScrollView>
+  );
+}
+
+function MetaItem({ label, value }: { label: string; value: string }) {
+  return (
+    <View style={styles.metaItem}>
+      <Text style={styles.metaLabel}>{label}</Text>
+      <Text selectable style={styles.metaValue}>{value}</Text>
+    </View>
   );
 }
 
 const styles = StyleSheet.create((theme, rt) => ({
   container: {
     flex: 1,
+    backgroundColor: theme.colors.background,
+  },
+  centered: {
+    flex: 1,
+    alignItems: "center",
+    justifyContent: "center",
+    gap: theme.spacing.md,
+    paddingHorizontal: theme.spacing.xl,
     backgroundColor: theme.colors.background,
   },
   content: {
@@ -39,6 +158,25 @@ const styles = StyleSheet.create((theme, rt) => ({
     padding: theme.spacing.lg,
     gap: theme.spacing.sm,
   },
+  headerRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: theme.spacing.sm,
+  },
+  threadIcon: {
+    width: 36,
+    height: 36,
+    borderRadius: 12,
+    alignItems: "center",
+    justifyContent: "center",
+    backgroundColor: theme.colors.background,
+    borderWidth: 1,
+    borderColor: theme.colors.border,
+  },
+  headerText: {
+    flex: 1,
+    minWidth: 0,
+  },
   title: {
     fontFamily: theme.fonts.sansSemiBold,
     fontSize: 17,
@@ -48,5 +186,54 @@ const styles = StyleSheet.create((theme, rt) => ({
     fontFamily: theme.fonts.mono,
     fontSize: 13,
     color: theme.colors.mutedForeground,
+  },
+  status: {
+    fontFamily: theme.fonts.sansSemiBold,
+    fontSize: 12,
+    color: theme.colors.forest,
+  },
+  metaGrid: {
+    gap: theme.spacing.sm,
+    marginTop: theme.spacing.sm,
+  },
+  metaItem: {
+    borderRadius: 12,
+    borderCurve: "continuous" as const,
+    borderWidth: 1,
+    borderColor: theme.colors.border,
+    backgroundColor: theme.colors.background,
+    padding: theme.spacing.md,
+    gap: 2,
+  },
+  metaLabel: {
+    fontFamily: theme.fonts.sans,
+    fontSize: 12,
+    color: theme.colors.mutedForeground,
+  },
+  metaValue: {
+    fontFamily: theme.fonts.mono,
+    fontSize: 13,
+    color: theme.colors.foreground,
+  },
+  refreshButton: {
+    marginTop: theme.spacing.sm,
+    minHeight: 40,
+    borderRadius: 20,
+    paddingHorizontal: theme.spacing.lg,
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "center",
+    gap: theme.spacing.xs,
+    backgroundColor: theme.colors.forest,
+  },
+  refreshText: {
+    fontFamily: theme.fonts.sansSemiBold,
+    fontSize: 13,
+    color: theme.colors.background,
+  },
+  inlineError: {
+    fontFamily: theme.fonts.sansSemiBold,
+    fontSize: 13,
+    color: theme.colors.moss,
   },
 }));

--- a/apps/mobile/app/agents/index.tsx
+++ b/apps/mobile/app/agents/index.tsx
@@ -342,7 +342,13 @@ export default function AgentsScreen() {
       <Section title="Active Threads" count={summary.activeThreads.items.length}>
         {summary.activeThreads.items.length === 0 ? <EmptyText>No active threads.</EmptyText> : null}
         {summary.activeThreads.items.map((thread) => (
-          <View key={thread.id} style={styles.row}>
+          <Pressable
+            key={thread.id}
+            accessibilityRole="button"
+            accessibilityLabel={`Open thread ${thread.title}`}
+            onPress={() => router.push(`/agents/${thread.id}` as any)}
+            style={styles.row}
+          >
             <View style={styles.rowIcon}>
               <Ionicons name="git-branch-outline" size={18} color={theme.colors.moss} />
             </View>
@@ -351,7 +357,7 @@ export default function AgentsScreen() {
               <Text style={styles.rowSubtitle}>{thread.providerId}</Text>
             </View>
             <Text style={styles.rowMeta}>{thread.status.replace(/_/g, " ")}</Text>
-          </View>
+          </Pressable>
         ))}
       </Section>
 

--- a/apps/mobile/lib/gateway-client.ts
+++ b/apps/mobile/lib/gateway-client.ts
@@ -10,6 +10,7 @@ import {
   ReviewSnapshotSchema,
   ReviewSummarySchema,
   RuntimeSummarySchema,
+  ThreadIdSchema,
   type CreateAgentThreadRequest,
   type ReviewSnapshot,
   type RuntimeSummary,
@@ -86,6 +87,10 @@ export type CodingAgentRuntimeSummaryResult =
 export type CodingAgentThreadCreateResult =
   | { ok: true; snapshot: z.infer<typeof AgentThreadSnapshotSchema> }
   | { ok: false; error: "Agent run could not be started. Try again." };
+
+export type CodingAgentThreadSnapshotResult =
+  | { ok: true; snapshot: z.infer<typeof AgentThreadSnapshotSchema> }
+  | { ok: false; error: "Thread state unavailable" };
 
 const CodingAgentReviewListSchema = boundedListSchema(ReviewSummarySchema, 50);
 
@@ -567,6 +572,32 @@ export class GatewayClient {
     } catch {
       console.warn("[mobile] /api/coding-agents/threads unavailable");
       return { ok: false, error: "Agent run could not be started. Try again." };
+    }
+  }
+
+  async getCodingAgentThreadSnapshot(
+    options: { threadId: string },
+  ): Promise<CodingAgentThreadSnapshotResult> {
+    try {
+      const parsedThreadId = ThreadIdSchema.safeParse(options.threadId);
+      if (!parsedThreadId.success) {
+        return { ok: false, error: "Thread state unavailable" };
+      }
+      const res = await this.fetchGateway(`/api/coding-agents/threads/${encodeURIComponent(parsedThreadId.data)}`);
+      if (!res.ok) {
+        console.warn("[mobile] /api/coding-agents/threads/:threadId unavailable", res.status);
+        return { ok: false, error: "Thread state unavailable" };
+      }
+      const body = await res.json();
+      const parsed = AgentThreadSnapshotSchema.safeParse(body);
+      if (!parsed.success) {
+        console.warn("[mobile] /api/coding-agents/threads/:threadId returned invalid payload");
+        return { ok: false, error: "Thread state unavailable" };
+      }
+      return { ok: true, snapshot: parsed.data };
+    } catch {
+      console.warn("[mobile] /api/coding-agents/threads/:threadId unavailable");
+      return { ok: false, error: "Thread state unavailable" };
     }
   }
 

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -427,6 +427,8 @@ export const AgentThreadSnapshotSchema = z.object({
   events: boundedListSchema(AgentThreadEventSchema, 200),
 }).strict();
 
+export type AgentThreadSnapshot = z.infer<typeof AgentThreadSnapshotSchema>;
+
 export const TerminalStatusSchema = z.enum(["starting", "running", "idle", "exited", "stale", "unavailable"]);
 
 export const TerminalSessionSummarySchema = z.object({

--- a/specs/105-coding-agent-shells/current-state.md
+++ b/specs/105-coding-agent-shells/current-state.md
@@ -1,12 +1,12 @@
 # Current State: Coding Agent Shells
 
-**Branch stack**: `spec/coding-agent-shells` plus stacked implementation branches through `105-coding-agent-mobile-review-diff-lines`
+**Branch stack**: `spec/coding-agent-shells` plus stacked implementation branches through `105-coding-agent-mobile-thread-detail`
 **Updated**: 2026-07-07
 **Scope**: Inventory for the coding-agent desktop/mobile shell work. This file records the current Matrix-native route, contract, client, and regression-test state so later slices keep gateway/runtime as source of truth and keep desktop/mobile as thin shells.
 
 ## Summary
 
-The stack currently has shared contracts, a gateway runtime summary read model, read-only desktop and mobile workspaces behind flags, thread create/replay/abort/event streaming, provider adapters, a workspace-backed provider, approval/input route handling, a read-only coding-agent review summary route/client contract, desktop/mobile read-only review summary panels, and a read-only coding-agent review snapshot route with bounded file metadata from safe owner worktree diffs plus findings fallback metadata. Review snapshots can include bounded per-hunk diff lines with truncation markers. Desktop and mobile review details render changed-file counts, selectable hunk coordinate metadata, and gateway-bounded diff lines. Desktop and mobile can seed their existing agent composers from a selected review hunk using bounded prompt context and a `structured_ref` attachment. Full file content and preview coding-agent surfaces are contract-only or existing workspace routes; dedicated preview shell UI is not yet integrated.
+The stack currently has shared contracts, a gateway runtime summary read model, read-only desktop and mobile workspaces behind flags, thread create/replay/abort/event streaming, provider adapters, a workspace-backed provider, approval/input route handling, a read-only coding-agent review summary route/client contract, desktop/mobile read-only review summary panels, and a read-only coding-agent review snapshot route with bounded file metadata from safe owner worktree diffs plus findings fallback metadata. Review snapshots can include bounded per-hunk diff lines with truncation markers. Desktop and mobile review details render changed-file counts, selectable hunk coordinate metadata, and gateway-bounded diff lines. Desktop and mobile can seed their existing agent composers from a selected review hunk using bounded prompt context and a `structured_ref` attachment. Mobile active thread rows now open a bounded thread detail route that hydrates `AgentThreadSnapshotSchema` through the authenticated gateway client and renders safe thread metadata/event counts. Full file content and preview coding-agent surfaces are contract-only or existing workspace routes; dedicated preview shell UI is not yet integrated.
 
 Current source-of-truth boundaries:
 
@@ -220,6 +220,7 @@ Gateway client:
 
 - `apps/mobile/lib/gateway-client.ts`
 - `getCodingAgentRuntimeSummary()` calls `GET /api/coding-agents/summary`, validates `RuntimeSummarySchema`, and returns the safe `"Runtime summary unavailable"` error on failure.
+- `getCodingAgentThreadSnapshot()` calls `GET /api/coding-agents/threads/:threadId`, validates `AgentThreadSnapshotSchema`, and returns the safe `"Thread state unavailable"` error on failure.
 - `getCodingAgentReviews()` calls `GET /api/coding-agents/reviews`, validates a bounded review summary list, and returns the safe `"Review state unavailable"` error on failure.
 - Existing terminal session methods call `/api/terminal/sessions`.
 
@@ -232,7 +233,8 @@ Screen:
 - When the runtime advertises `codingAgentsReview`, the dashboard fetches bounded review summaries through the authenticated gateway client and renders project, PR, round, status, and high-severity count.
 - Review snapshot details render bounded file paths, additions/deletions, partial markers, selectable hunk coordinate metadata, gateway-bounded hunk lines, and safe finding summaries.
 - Safe generic review error state if review summaries are unavailable; review failures do not drop the runtime summary dashboard.
-- Composer route for creating accepted coding-agent threads; thread route is a bounded placeholder until replay/review surfaces are wired.
+- Composer route for creating accepted coding-agent threads.
+- Active thread rows navigate to `/agents/:threadId`; the thread route hydrates a bounded thread snapshot, shows provider/status/terminal metadata, event counts, loading, refresh, and safe generic error states. Live replay/subscription and transcript rendering remain follow-up work.
 - Flag: `apps/mobile/lib/feature-flags.ts` with `EXPO_PUBLIC_CODING_AGENTS_MOBILE_WORKSPACE === "1"`.
 
 Persisted UI references:
@@ -309,7 +311,7 @@ pnpm --filter @matrix-os/gateway exec tsc --noEmit
 Mobile focused Jest:
 
 ```bash
-pnpm --filter matrix-os-mobile exec jest __tests__/gateway-client.test.ts __tests__/apps-screen.test.tsx __tests__/agents-screen.test.tsx __tests__/agent-workspace-state.test.ts --runInBand
+pnpm --filter matrix-os-mobile exec jest __tests__/gateway-client.test.ts __tests__/apps-screen.test.tsx __tests__/agents-screen.test.tsx __tests__/agent-thread-screen.test.tsx __tests__/agent-workspace-state.test.ts --runInBand
 ```
 
 Desktop typecheck:
@@ -334,7 +336,7 @@ git diff --check
 ## Open Questions And Deferred Work
 
 - Session completion reconciliation: implemented for workspace `session.stopped` events that carry owner id, workspace session id, and bound `terminalSessionId`; the gateway thread store marks matching active coding-agent threads completed or failed server-side without matching unrelated owners or reused terminal ids. Remaining work: if runtime managers add autonomous process-exit detection beyond explicit workspace stop events, route those through the same `session.stopped` publisher path.
-- File/review/preview shell surfaces: read-only review summaries now have coding-agent contracts/routes/desktop IPC/mobile clients plus desktop and mobile read-only review panels. A read-only review snapshot route now exposes bounded diff hunk metadata and capped hunk line bodies from safe owner worktrees plus partial findings-derived fallback metadata for later shell diff panels. Full file contents, desktop/mobile diff rendering, and previews are not implemented yet.
+- File/review/preview shell surfaces: read-only review summaries now have coding-agent contracts/routes/desktop IPC/mobile clients plus desktop and mobile read-only review panels. A read-only review snapshot route now exposes bounded diff hunk metadata and capped hunk line bodies from safe owner worktrees plus partial findings-derived fallback metadata for later shell diff panels. Full file contents and previews are not implemented yet.
 - Browser shell entry point: Canvas-first placement is still undecided.
 - Notifications/attention routing: desktop notification IPC exists, but thread attention notifications are not yet wired end-to-end from gateway events.
 - Public docs: public Matrix OS docs should be updated once the user-facing coding-agent shell flow is stable enough to document.


### PR DESCRIPTION
## Summary

- Add an authenticated mobile gateway client method for bounded coding-agent thread snapshots.
- Make active thread rows in the mobile agent workspace open the existing thread detail route.
- Hydrate `/agents/:threadId` from `AgentThreadSnapshotSchema` and render safe thread metadata, terminal binding, event count, refresh, loading, and generic error states.
- Keep the last good thread snapshot visible when refresh fails and ignore stale out-of-order refresh responses.
- Update spec 105 current-state notes for the mobile thread-detail slice.

## Tests

- Red first: `pnpm --filter matrix-os-mobile run test -- gateway-client.test.ts agents-screen.test.tsx agent-thread-screen.test.tsx` failed for the missing client method, non-clickable thread row, and placeholder thread route.
- Red review fix: `pnpm --filter matrix-os-mobile run test -- agent-thread-screen.test.tsx` failed for refresh failure clearing the snapshot and stale refresh responses overwriting newer data.
- `pnpm --filter matrix-os-mobile run test -- gateway-client.test.ts agents-screen.test.tsx agent-thread-screen.test.tsx`
- `pnpm --filter matrix-os-mobile run lint`
- `pnpm --filter matrix-os-mobile exec tsc --noEmit`
- `pnpm exec vitest run tests/contracts/coding-agents.test.ts`
- `bun run check:patterns`
- `bun run typecheck`
- `git diff --check`
- Restricted wording scan across touched files: no matches.

## Review/Monitoring

- PR is ready for review.
- Greptile completed successfully on head `7e7bfb25ae31fc630c1e5aded37a4c76607649a7`.
- `ready-for-ci` label is applied.

## Invariants

- Source of truth: gateway thread snapshots remain the source of truth; mobile only renders bounded `AgentThreadSnapshotSchema` data from the authenticated gateway client.
- Lock/transaction scope: no persistence, database writes, locks, or transactions are introduced.
- Acceptable orphan states: if the first thread snapshot cannot be loaded, mobile shows the safe generic thread error; if a refresh fails after a successful load, the last good bounded snapshot stays visible with a safe inline error.
- Auth source of truth: mobile uses the existing gateway client auth path and stores no transcripts, terminal output, file contents, diffs, credentials, approvals payloads, or launch tokens.
- Deferred scope: live thread event subscription, transcript rendering, terminal attach-from-thread, and dedicated preview/file surfaces remain follow-up slices.
