### PR TITLE
feat(mobile): render thread event timeline

### DIFF
--- a/apps/mobile/__tests__/agent-thread-screen.test.tsx
+++ b/apps/mobile/__tests__/agent-thread-screen.test.tsx
@@ -95,11 +95,97 @@ describe("AgentThreadRoute", () => {
 
     expect(screen.getByText("Loading thread...")).toBeTruthy();
     expect(await screen.findByText("Repair mobile route")).toBeTruthy();
-    expect(screen.getByText("running")).toBeTruthy();
+    expect(screen.getAllByText("running").length).toBeGreaterThanOrEqual(1);
     expect(screen.getByText("codex")).toBeTruthy();
-    expect(screen.getByText("matrix-abc1234")).toBeTruthy();
+    expect(screen.getAllByText("matrix-abc1234").length).toBeGreaterThanOrEqual(1);
     expect(screen.getByText("2 events")).toBeTruthy();
     expect(client.getCodingAgentThreadSnapshot).toHaveBeenCalledWith({ threadId: "thread_mobile" });
+  });
+
+  it("renders a readable bounded event timeline from the thread snapshot", async () => {
+    const snapshot = {
+      ...threadSnapshotFixture(),
+      events: {
+        ...threadSnapshotFixture().events,
+        items: [
+          ...threadSnapshotFixture().events.items,
+          {
+            eventId: "evt_mobile_3",
+            threadId: "thread_mobile",
+            type: "assistant.text.delta",
+            messageId: "msg_mobile_1",
+            delta: "Checking /home/matrix/secret and token_sk_live_123.",
+            occurredAt: "2026-07-06T00:02:00.000Z",
+          },
+          {
+            eventId: "evt_mobile_4",
+            threadId: "thread_mobile",
+            type: "tool.started",
+            toolCallId: "tool_mobile_1",
+            displayName: "Read source",
+            kind: "file",
+            occurredAt: "2026-07-06T00:02:30.000Z",
+          },
+          {
+            eventId: "evt_mobile_5",
+            threadId: "thread_mobile",
+            type: "file.changed",
+            path: ".ssh/id_rsa",
+            changeKind: "updated",
+            occurredAt: "2026-07-06T00:03:00.000Z",
+          },
+          {
+            eventId: "evt_mobile_6",
+            threadId: "thread_mobile",
+            type: "review.ready",
+            reviewId: "rev_mobile_1",
+            summary: {
+              changedFileCount: 2,
+              additions: 12,
+              deletions: 4,
+              partial: true,
+            },
+            occurredAt: "2026-07-06T00:04:00.000Z",
+          },
+          {
+            eventId: "evt_mobile_7",
+            threadId: "thread_mobile",
+            type: "thread.error",
+            error: {
+              code: "provider_failed",
+              safeMessage: "/home/matrix/token leaked raw detail",
+              retryable: true,
+            },
+            occurredAt: "2026-07-06T00:05:00.000Z",
+          },
+        ],
+      },
+    };
+    const client = {
+      getCodingAgentThreadSnapshot: jest.fn().mockResolvedValue({
+        ok: true,
+        snapshot,
+      }),
+    };
+    useGatewayMock.mockReturnValue(gatewayContext({
+      client: client as unknown as GatewayClient,
+      connectionState: "connected",
+    }));
+
+    render(<AgentThreadRoute />);
+
+    expect(await screen.findByText("Activity timeline")).toBeTruthy();
+    expect(screen.getByText("Assistant update")).toBeTruthy();
+    expect(screen.getByText("Text update received")).toBeTruthy();
+    expect(screen.getByText("Tool started")).toBeTruthy();
+    expect(screen.getByText("Read source")).toBeTruthy();
+    expect(screen.getByText("File updated")).toBeTruthy();
+    expect(screen.getByText("Updated file")).toBeTruthy();
+    expect(screen.getByText("Review ready")).toBeTruthy();
+    expect(screen.getByText("2 files changed, +12 -4, partial")).toBeTruthy();
+    expect(screen.getByText("Thread needs attention")).toBeTruthy();
+    expect(screen.getByText("Refresh the thread or check the runtime.")).toBeTruthy();
+    expect(screen.queryByText(/home\/matrix|token|leaked|\.ssh|id_rsa/i)).toBeNull();
   });
 
   it("renders a generic thread error without exposing raw gateway details", async () => {

--- a/apps/mobile/app/agents/[threadId].tsx
+++ b/apps/mobile/app/agents/[threadId].tsx
@@ -3,7 +3,7 @@ import { useLocalSearchParams } from "expo-router";
 import { ActivityIndicator, Pressable, ScrollView, Text, View } from "react-native";
 import { Ionicons } from "@expo/vector-icons";
 import { StyleSheet, useUnistyles } from "react-native-unistyles";
-import type { AgentThreadSnapshot } from "@matrix-os/contracts";
+import type { AgentThreadEvent, AgentThreadSnapshot } from "@matrix-os/contracts";
 import { useGateway } from "@/app/_layout";
 
 type ThreadRouteState =
@@ -118,6 +118,14 @@ export default function AgentThreadRoute() {
           <Text style={styles.refreshText}>{state.refreshing ? "Refreshing" : "Refresh"}</Text>
         </Pressable>
       </View>
+      {events.items.length > 0 ? (
+        <View style={styles.timeline}>
+          <Text style={styles.sectionTitle}>Activity timeline</Text>
+          {events.items.map((event) => (
+            <ThreadEventItem key={event.eventId} event={event} />
+          ))}
+        </View>
+      ) : null}
     </ScrollView>
   );
 }
@@ -129,6 +137,78 @@ function MetaItem({ label, value }: { label: string; value: string }) {
       <Text selectable style={styles.metaValue}>{value}</Text>
     </View>
   );
+}
+
+function ThreadEventItem({ event }: { event: AgentThreadEvent }) {
+  const { theme } = useUnistyles();
+  const copy = describeThreadEvent(event);
+  return (
+    <View style={styles.eventRow}>
+      <View style={styles.eventIcon}>
+        <Ionicons name={copy.icon} size={14} color={theme.colors.moss} />
+      </View>
+      <View style={styles.eventText}>
+        <Text style={styles.eventTitle}>{copy.title}</Text>
+        <Text selectable style={styles.eventDetail}>{copy.detail}</Text>
+      </View>
+    </View>
+  );
+}
+
+function describeThreadEvent(event: AgentThreadEvent): { icon: keyof typeof Ionicons.glyphMap; title: string; detail: string } {
+  switch (event.type) {
+    case "thread.created":
+      return { icon: "sparkles-outline", title: "Thread created", detail: event.thread.title };
+    case "thread.status":
+      return { icon: "pulse-outline", title: "Status changed", detail: event.status.replace(/_/g, " ") };
+    case "assistant.text.delta":
+      return { icon: "chatbubble-ellipses-outline", title: "Assistant update", detail: "Text update received" };
+    case "assistant.text.completed":
+      return { icon: "checkmark-circle-outline", title: "Assistant message complete", detail: event.messageId };
+    case "tool.started":
+      return { icon: "hammer-outline", title: "Tool started", detail: event.displayName };
+    case "tool.output":
+      return {
+        icon: "document-text-outline",
+        title: "Tool output",
+        detail: event.truncated ? "Output received, partial" : "Output received",
+      };
+    case "tool.completed":
+      return { icon: "checkmark-done-outline", title: "Tool completed", detail: event.outcome };
+    case "approval.requested":
+      return { icon: "shield-checkmark-outline", title: "Approval needed", detail: event.approval.safeDescription };
+    case "approval.resolved":
+      return { icon: "shield-outline", title: "Approval resolved", detail: event.decision };
+    case "user_input.requested":
+      return { icon: "create-outline", title: "Input needed", detail: event.request.safeDescription };
+    case "user_input.answered":
+      return { icon: "return-down-forward-outline", title: "Input answered", detail: event.requestId };
+    case "file.changed":
+      return { icon: "document-outline", title: `File ${event.changeKind}`, detail: `${capitalize(event.changeKind)} file` };
+    case "review.ready": {
+      const files = `${event.summary.changedFileCount} ${event.summary.changedFileCount === 1 ? "file" : "files"} changed`;
+      const partial = event.summary.partial ? ", partial" : "";
+      return {
+        icon: "git-pull-request-outline",
+        title: "Review ready",
+        detail: `${files}, +${event.summary.additions} -${event.summary.deletions}${partial}`,
+      };
+    }
+    case "terminal.bound":
+      return { icon: "terminal-outline", title: "Terminal bound", detail: event.terminalSessionId };
+    case "thread.error":
+      return {
+        icon: "warning-outline",
+        title: "Thread needs attention",
+        detail: event.error.retryable ? "Refresh the thread or check the runtime." : "Open the workspace again.",
+      };
+    case "thread.completed":
+      return { icon: "flag-outline", title: "Thread completed", detail: event.outcome };
+  }
+}
+
+function capitalize(value: string): string {
+  return `${value.slice(0, 1).toUpperCase()}${value.slice(1)}`;
 }
 
 const styles = StyleSheet.create((theme, rt) => ({
@@ -235,5 +315,47 @@ const styles = StyleSheet.create((theme, rt) => ({
     fontFamily: theme.fonts.sansSemiBold,
     fontSize: 13,
     color: theme.colors.moss,
+  },
+  timeline: {
+    marginTop: theme.spacing.lg,
+    gap: theme.spacing.md,
+  },
+  sectionTitle: {
+    fontFamily: theme.fonts.sansSemiBold,
+    fontSize: 15,
+    color: theme.colors.foreground,
+  },
+  eventRow: {
+    flexDirection: "row",
+    alignItems: "flex-start",
+    gap: theme.spacing.sm,
+  },
+  eventIcon: {
+    width: 28,
+    height: 28,
+    borderRadius: 14,
+    alignItems: "center",
+    justifyContent: "center",
+    backgroundColor: theme.colors.card,
+    borderWidth: 1,
+    borderColor: theme.colors.border,
+  },
+  eventText: {
+    flex: 1,
+    minWidth: 0,
+    paddingBottom: theme.spacing.md,
+    borderBottomWidth: 1,
+    borderBottomColor: theme.colors.border,
+    gap: 2,
+  },
+  eventTitle: {
+    fontFamily: theme.fonts.sansSemiBold,
+    fontSize: 13,
+    color: theme.colors.foreground,
+  },
+  eventDetail: {
+    fontFamily: theme.fonts.mono,
+    fontSize: 12,
+    color: theme.colors.mutedForeground,
   },
 }));

--- a/packages/gateway/src/coding-agents/thread-store.ts
+++ b/packages/gateway/src/coding-agents/thread-store.ts
@@ -292,14 +292,16 @@ function snapshotFor(thread: StoredThread, allEvents: AgentThreadEvent[], cursor
   if (cursor && cursorIndex < 0) {
     throw new CodingAgentThreadError("thread_not_found", "Thread cursor not found");
   }
-  const startIndex = cursor ? cursorIndex + 1 : 0;
+  const startIndex = cursor ? cursorIndex + 1 : Math.max(0, eventsForThread.length - EVENT_REPLAY_LIMIT);
   const window = eventsForThread.slice(startIndex, startIndex + EVENT_REPLAY_LIMIT);
   return AgentThreadSnapshotSchema.parse({
     thread: stripOwner(thread),
     events: {
       items: window,
-      hasMore: eventsForThread.length - Math.max(0, startIndex) > window.length,
-      nextCursor: window.at(-1)?.eventId,
+      hasMore: cursor
+        ? eventsForThread.length - Math.max(0, startIndex) > window.length
+        : startIndex > 0,
+      nextCursor: cursor ? window.at(-1)?.eventId : undefined,
       limit: EVENT_REPLAY_LIMIT,
     },
   });

--- a/specs/105-coding-agent-shells/current-state.md
+++ b/specs/105-coding-agent-shells/current-state.md
@@ -1,12 +1,12 @@
 # Current State: Coding Agent Shells
 
-**Branch stack**: `spec/coding-agent-shells` plus stacked implementation branches through `105-coding-agent-mobile-thread-detail`
+**Branch stack**: `spec/coding-agent-shells` plus stacked implementation branches through `105-coding-agent-mobile-thread-events`
 **Updated**: 2026-07-07
 **Scope**: Inventory for the coding-agent desktop/mobile shell work. This file records the current Matrix-native route, contract, client, and regression-test state so later slices keep gateway/runtime as source of truth and keep desktop/mobile as thin shells.
 
 ## Summary
 
-The stack currently has shared contracts, a gateway runtime summary read model, read-only desktop and mobile workspaces behind flags, thread create/replay/abort/event streaming, provider adapters, a workspace-backed provider, approval/input route handling, a read-only coding-agent review summary route/client contract, desktop/mobile read-only review summary panels, and a read-only coding-agent review snapshot route with bounded file metadata from safe owner worktree diffs plus findings fallback metadata. Review snapshots can include bounded per-hunk diff lines with truncation markers. Desktop and mobile review details render changed-file counts, selectable hunk coordinate metadata, and gateway-bounded diff lines. Desktop and mobile can seed their existing agent composers from a selected review hunk using bounded prompt context and a `structured_ref` attachment. Mobile active thread rows now open a bounded thread detail route that hydrates `AgentThreadSnapshotSchema` through the authenticated gateway client and renders safe thread metadata/event counts. Full file content and preview coding-agent surfaces are contract-only or existing workspace routes; dedicated preview shell UI is not yet integrated.
+The stack currently has shared contracts, a gateway runtime summary read model, read-only desktop and mobile workspaces behind flags, thread create/replay/abort/event streaming, provider adapters, a workspace-backed provider, approval/input route handling, a read-only coding-agent review summary route/client contract, desktop/mobile read-only review summary panels, and a read-only coding-agent review snapshot route with bounded file metadata from safe owner worktree diffs plus findings fallback metadata. Review snapshots can include bounded per-hunk diff lines with truncation markers. Desktop and mobile review details render changed-file counts, selectable hunk coordinate metadata, and gateway-bounded diff lines. Desktop and mobile can seed their existing agent composers from a selected review hunk using bounded prompt context and a `structured_ref` attachment. Mobile active thread rows now open a bounded thread detail route that hydrates `AgentThreadSnapshotSchema` through the authenticated gateway client and renders safe thread metadata, event counts, and a read-only snapshot event timeline. Full file content and preview coding-agent surfaces are contract-only or existing workspace routes; dedicated preview shell UI is not yet integrated.
 
 Current source-of-truth boundaries:
 
@@ -45,7 +45,7 @@ Implemented routes:
 | `/api/coding-agents/summary` | `GET` | Implemented | Authenticated runtime summary. Returns `RuntimeSummarySchema`. |
 | `/api/coding-agents/threads` | `POST` | Implemented | Validates `CreateAgentThreadRequestSchema`, body limit 96 KiB, idempotent by `clientRequestId`. |
 | `/api/coding-agents/threads` | `GET` | Implemented | Authenticated bounded thread list. |
-| `/api/coding-agents/threads/:threadId` | `GET` | Implemented | Authenticated snapshot replay for one thread. |
+| `/api/coding-agents/threads/:threadId` | `GET` | Implemented | Authenticated snapshot replay for one thread. No-cursor snapshots return the latest bounded event window. |
 | `/api/coding-agents/threads/:threadId/events` | `GET` | Implemented | Authenticated snapshot replay with optional cursor. |
 | `/api/coding-agents/threads/:threadId/abort` | `POST` | Implemented | Body limit 8 KiB, idempotent abort by client request id. |
 | `/api/coding-agents/threads/:threadId/approvals/:approvalId/decision` | `POST` | Implemented | Body limit 8 KiB, validates approval id and decision payload. |
@@ -137,7 +137,7 @@ Thread store behavior:
 
 - Owner-scoped thread summaries and events.
 - Idempotent thread creation, aborts, approval decisions, and input answers by bounded request-id arrays.
-- Event replay with bounded per-thread event storage.
+- Event replay with bounded per-thread event storage; default thread snapshots return the latest bounded event window, while explicit cursors continue forward from the cursor.
 - Safe terminal statuses and attention states derived from events.
 
 Review summary behavior:
@@ -234,7 +234,7 @@ Screen:
 - Review snapshot details render bounded file paths, additions/deletions, partial markers, selectable hunk coordinate metadata, gateway-bounded hunk lines, and safe finding summaries.
 - Safe generic review error state if review summaries are unavailable; review failures do not drop the runtime summary dashboard.
 - Composer route for creating accepted coding-agent threads.
-- Active thread rows navigate to `/agents/:threadId`; the thread route hydrates a bounded thread snapshot, shows provider/status/terminal metadata, event counts, loading, refresh, and safe generic error states. Live replay/subscription and transcript rendering remain follow-up work.
+- Active thread rows navigate to `/agents/:threadId`; the thread route hydrates a bounded thread snapshot, shows provider/status/terminal metadata, event counts, loading, refresh, safe generic error states, and a read-only event timeline for gateway-bounded snapshot events. Assistant text and file-change events render generic summaries instead of raw event text or paths. Live replay/subscription and richer transcript grouping remain follow-up work.
 - Flag: `apps/mobile/lib/feature-flags.ts` with `EXPO_PUBLIC_CODING_AGENTS_MOBILE_WORKSPACE === "1"`.
 
 Persisted UI references:

--- a/tests/gateway/coding-agents-threads.test.ts
+++ b/tests/gateway/coding-agents-threads.test.ts
@@ -149,7 +149,7 @@ describe("coding agent thread lifecycle", () => {
     });
   });
 
-  it("returns the first replay window after the cursor", async () => {
+  it("continues replay after a cursor from the current snapshot window", async () => {
     const homePath = await mkdtemp(join(tmpdir(), "matrix-coding-agent-threads-"));
     const threads = createCodingAgentThreadStore({
       homePath,
@@ -169,9 +169,35 @@ describe("coding agent thread lifecycle", () => {
     const replay = await app.request(`/api/coding-agents/threads/${snapshot.thread.id}/events?cursor=${createdCursor}`);
     const replayBody = AgentThreadSnapshotSchema.parse(await replay.json());
 
-    expect(replayBody.events.items).toHaveLength(200);
-    expect(replayBody.events.items[0]).toMatchObject({ type: "thread.status" });
-    expect(replayBody.events.hasMore).toBe(true);
+    expect(replayBody.events.items).toHaveLength(199);
+    expect(replayBody.events.items[0]).toMatchObject({ type: "assistant.text.delta" });
+    expect(replayBody.events.hasMore).toBe(false);
+  });
+
+  it("returns the latest bounded event window for thread snapshots without a cursor", async () => {
+    const homePath = await mkdtemp(join(tmpdir(), "matrix-coding-agent-threads-"));
+    const threads = createCodingAgentThreadStore({
+      homePath,
+      now: () => baseNow,
+      providers: [createFakeCodingAgentProvider({ providerId: "codex", deltaCount: 250 })],
+    });
+    const app = new Hono();
+    app.route("/api/coding-agents", createCodingAgentRoutes({
+      service: createCodingAgentRuntimeSummaryService({ homePath, now: () => baseNow }),
+      threads,
+      getPrincipal: () => ownerPrincipal,
+    }));
+
+    const created = await app.request(jsonRequest("/api/coding-agents/threads", createBody));
+    const snapshot = AgentThreadSnapshotSchema.parse(await created.json());
+
+    expect(snapshot.events.items).toHaveLength(200);
+    expect(snapshot.events.hasMore).toBe(true);
+    expect(snapshot.events.items.map((event) => event.type)).not.toContain("thread.created");
+    expect(snapshot.events.items.at(-1)).toMatchObject({
+      type: "assistant.text.delta",
+      delta: "Agent event 250.",
+    });
   });
 
   it("keeps thread ownership isolated and maps missing threads to safe errors", async () => {


### PR DESCRIPTION
## Summary

- Render a read-only mobile thread activity timeline from `AgentThreadSnapshotSchema` events.
- Return the latest bounded thread event window for no-cursor thread snapshots so long-running threads show recent activity.
- Keep mobile assistant text, file-change paths, and thread error events generic in the timeline UI.
- Update the coding-agent shell current-state note for this stacked slice.

## Greptile Follow-Up

- Fixed latest activity visibility by making no-cursor snapshots tail-oriented while explicit cursor replay still continues forward.
- Replaced raw assistant delta display with a generic `"Text update received"` timeline detail.
- Replaced raw file path display with generic file-change summaries.
- Greptile completed at 5/5 on head `845fa7fc028894505e2ad17d5cc85e4678b50cc6`.

## Invariants

- Source of truth: gateway/runtime thread snapshots remain authoritative; mobile renders the bounded snapshot it receives through the authenticated gateway client.
- Lock/transaction scope: no new persistence or write path changes in this slice.
- Acceptable orphan states: if an event references a runtime object the shell cannot open yet, the timeline renders bounded descriptive text only.
- Auth source of truth: unchanged existing mobile gateway auth path; no credentials are stored or passed through this UI.
- Deferred scope: live thread WebSocket subscription, richer transcript grouping, approvals UI, terminal attach actions, files, and previews remain follow-up slices.

## Validation

- `pnpm --filter matrix-os-mobile run test -- agent-thread-screen.test.tsx`
- `pnpm --filter matrix-os-mobile run test -- gateway-client.test.ts agents-screen.test.tsx agent-thread-screen.test.tsx`
- `pnpm exec vitest run tests/gateway/coding-agents-threads.test.ts`
- `pnpm --filter matrix-os-mobile run lint`
- `pnpm --filter matrix-os-mobile exec tsc --noEmit`
- `bun run check:patterns` (0 violations; existing warnings only)
- `bun run typecheck`
- `git diff --check`
- `rg -n "t3code|reference repo|external inspiration" apps/mobile packages/gateway specs/105-coding-agent-shells tests/gateway` (no matches)

`vp check` and `vp run typecheck` could not run in this environment because `vp` is not installed.

## Docs

- Updated `specs/105-coding-agent-shells/current-state.md`.
- Public docs remain deferred until the file/review/preview and live thread surfaces are stable enough for user-facing documentation.
