### PR TITLE
feat(mobile): open thread terminal sessions

### DIFF
--- a/apps/mobile/__tests__/agent-thread-screen.test.tsx
+++ b/apps/mobile/__tests__/agent-thread-screen.test.tsx
@@ -165,6 +165,32 @@ describe("AgentThreadRoute", () => {
     warnSpy.mockRestore();
   });
 
+  it("does not open terminal fallback when the bound session id is not attachable", async () => {
+    const snapshot = threadSnapshotFixture();
+    snapshot.thread.terminalSessionId = "term_sess_workspace_1";
+    const client = {
+      getCodingAgentThreadSnapshot: jest.fn().mockResolvedValue({
+        ok: true,
+        snapshot,
+      }),
+    };
+    useGatewayMock.mockReturnValue(gatewayContext({
+      client: client as unknown as GatewayClient,
+      connectionState: "connected",
+    }));
+
+    render(<AgentThreadRoute />);
+
+    expect(await screen.findByText("Repair mobile route")).toBeTruthy();
+    await act(async () => {
+      fireEvent.press(screen.getByLabelText("Open bound terminal"));
+    });
+
+    expect(AsyncStorage.setItem).not.toHaveBeenCalled();
+    expect(mockRouterPush).not.toHaveBeenCalled();
+    expect(await screen.findByText("Terminal session unavailable. Try again.")).toBeTruthy();
+  });
+
   it("renders a readable bounded event timeline from the thread snapshot", async () => {
     const snapshot = {
       ...threadSnapshotFixture(),

--- a/apps/mobile/__tests__/agent-thread-screen.test.tsx
+++ b/apps/mobile/__tests__/agent-thread-screen.test.tsx
@@ -139,6 +139,32 @@ describe("AgentThreadRoute", () => {
     expect(mockRouterPush).toHaveBeenCalledWith("/terminal");
   });
 
+  it("does not open a stale terminal session when safe resume state cannot be saved", async () => {
+    jest.mocked(AsyncStorage.setItem).mockRejectedValueOnce(new Error("storage unavailable"));
+    const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => undefined);
+    const client = {
+      getCodingAgentThreadSnapshot: jest.fn().mockResolvedValue({
+        ok: true,
+        snapshot: threadSnapshotFixture(),
+      }),
+    };
+    useGatewayMock.mockReturnValue(gatewayContext({
+      client: client as unknown as GatewayClient,
+      connectionState: "connected",
+    }));
+
+    render(<AgentThreadRoute />);
+
+    expect(await screen.findByText("Repair mobile route")).toBeTruthy();
+    await act(async () => {
+      fireEvent.press(screen.getByLabelText("Open bound terminal"));
+    });
+
+    expect(mockRouterPush).not.toHaveBeenCalled();
+    expect(await screen.findByText("Terminal session unavailable. Try again.")).toBeTruthy();
+    warnSpy.mockRestore();
+  });
+
   it("renders a readable bounded event timeline from the thread snapshot", async () => {
     const snapshot = {
       ...threadSnapshotFixture(),

--- a/apps/mobile/__tests__/agent-thread-screen.test.tsx
+++ b/apps/mobile/__tests__/agent-thread-screen.test.tsx
@@ -2,16 +2,25 @@ jest.mock("@/app/_layout", () => ({
   useGateway: jest.fn(),
 }));
 
+jest.mock("@react-native-async-storage/async-storage", () => ({
+  getItem: jest.fn(),
+  setItem: jest.fn(),
+}));
+
 const mockParams = { threadId: "thread_mobile" };
+const mockRouterPush = jest.fn();
 
 jest.mock("expo-router", () => ({
   useLocalSearchParams: () => mockParams,
+  useRouter: () => ({ push: mockRouterPush }),
 }));
 
 import React from "react";
+import AsyncStorage from "@react-native-async-storage/async-storage";
 import { act, fireEvent, render, screen, waitFor } from "@testing-library/react-native";
 import AgentThreadRoute from "../app/agents/[threadId]";
 import { useGateway } from "@/app/_layout";
+import { MOBILE_SHELL_STATE_STORAGE_KEY } from "../lib/mobile-shell-state";
 import type { GatewayClient } from "../lib/gateway-client";
 
 const useGatewayMock = useGateway as jest.MockedFunction<typeof useGateway>;
@@ -77,6 +86,8 @@ describe("AgentThreadRoute", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockParams.threadId = "thread_mobile";
+    jest.mocked(AsyncStorage.getItem).mockResolvedValue(null);
+    jest.mocked(AsyncStorage.setItem).mockResolvedValue();
   });
 
   it("hydrates a bounded coding-agent thread snapshot from the gateway", async () => {
@@ -100,6 +111,32 @@ describe("AgentThreadRoute", () => {
     expect(screen.getAllByText("matrix-abc1234").length).toBeGreaterThanOrEqual(1);
     expect(screen.getByText("2 events")).toBeTruthy();
     expect(client.getCodingAgentThreadSnapshot).toHaveBeenCalledWith({ threadId: "thread_mobile" });
+  });
+
+  it("opens the bound terminal through the existing terminal tab and safe resume state", async () => {
+    const client = {
+      getCodingAgentThreadSnapshot: jest.fn().mockResolvedValue({
+        ok: true,
+        snapshot: threadSnapshotFixture(),
+      }),
+    };
+    useGatewayMock.mockReturnValue(gatewayContext({
+      client: client as unknown as GatewayClient,
+      connectionState: "connected",
+    }));
+
+    render(<AgentThreadRoute />);
+
+    expect(await screen.findByText("Repair mobile route")).toBeTruthy();
+    await act(async () => {
+      fireEvent.press(screen.getByLabelText("Open bound terminal"));
+    });
+
+    expect(AsyncStorage.setItem).toHaveBeenCalledWith(
+      MOBILE_SHELL_STATE_STORAGE_KEY,
+      expect.stringContaining('"lastActiveTerminalSessionId":"matrix-abc1234"'),
+    );
+    expect(mockRouterPush).toHaveBeenCalledWith("/terminal");
   });
 
   it("renders a readable bounded event timeline from the thread snapshot", async () => {

--- a/apps/mobile/__tests__/mobile-shell-state.test.ts
+++ b/apps/mobile/__tests__/mobile-shell-state.test.ts
@@ -21,14 +21,14 @@ describe("mobile shell state", () => {
       surface: "native-mobile",
       mode: "app",
       lastActiveAppSlug: "games/snake",
-      lastActiveTerminalSessionId: "550e8400-e29b-41d4-a716-446655440000",
+      lastActiveTerminalSessionId: "main",
       canvasEnteredAt: "2026-05-12T00:00:00.000Z",
       updatedAt: "2026-05-12T00:01:00.000Z",
     })).toMatchObject({
       surface: "native-mobile",
       mode: "app",
       lastActiveAppSlug: "games/snake",
-      lastActiveTerminalSessionId: "550e8400-e29b-41d4-a716-446655440000",
+      lastActiveTerminalSessionId: "main",
       canvasEnteredAt: "2026-05-12T00:00:00.000Z",
       updatedAt: "2026-05-12T00:01:00.000Z",
     });
@@ -136,6 +136,17 @@ describe("mobile shell state", () => {
     expect(saved).toMatchObject({
       mode: "terminal",
       lastActiveTerminalSessionId: "main",
+    });
+  });
+
+  it("drops legacy UUID terminal references that cannot resume named shell sessions", () => {
+    expect(parseMobileShellState({
+      mode: "terminal",
+      lastActiveTerminalSessionId: "550e8400-e29b-41d4-a716-446655440000",
+      updatedAt: "2026-05-16T00:00:00.000Z",
+    })).toMatchObject({
+      mode: "terminal",
+      lastActiveTerminalSessionId: null,
     });
   });
 });

--- a/apps/mobile/__tests__/mobile-shell-state.test.ts
+++ b/apps/mobile/__tests__/mobile-shell-state.test.ts
@@ -110,4 +110,32 @@ describe("mobile shell state", () => {
       lastActiveAppSlug: "games/minesweeper",
     });
   });
+
+  it("keeps safe named shell-session references for cross-shell terminal resume", async () => {
+    jest.mocked(AsyncStorage.setItem).mockResolvedValueOnce();
+
+    expect(parseMobileShellState({
+      mode: "terminal",
+      lastActiveTerminalSessionId: "matrix-abc1234",
+      updatedAt: "2026-05-15T00:00:00.000Z",
+    })).toMatchObject({
+      mode: "terminal",
+      lastActiveTerminalSessionId: "matrix-abc1234",
+    });
+
+    await saveMobileShellState({
+      surface: "native-mobile",
+      mode: "terminal",
+      lastActiveAppSlug: null,
+      lastActiveTerminalSessionId: "main",
+      canvasEnteredAt: null,
+      updatedAt: "2026-05-15T00:00:00.000Z",
+    });
+
+    const saved = JSON.parse(jest.mocked(AsyncStorage.setItem).mock.calls[0][1]);
+    expect(saved).toMatchObject({
+      mode: "terminal",
+      lastActiveTerminalSessionId: "main",
+    });
+  });
 });

--- a/apps/mobile/__tests__/terminal-screen.test.tsx
+++ b/apps/mobile/__tests__/terminal-screen.test.tsx
@@ -12,7 +12,7 @@ import {
   webViewInjections,
 } from "../__mocks__/react-native-webview";
 
-const SESSION_ID = "c4319d6a-a24c-4820-a0f8-f6f8a6ce76b9";
+const SESSION_ID = "matrix-abc1234";
 
 // Auto-confirm the End-session / Detach confirmation dialogs in tests.
 function autoConfirmAlerts() {

--- a/apps/mobile/app/agents/[threadId].tsx
+++ b/apps/mobile/app/agents/[threadId].tsx
@@ -1,10 +1,11 @@
 import { useCallback, useEffect, useRef, useState } from "react";
-import { useLocalSearchParams } from "expo-router";
+import { useLocalSearchParams, useRouter } from "expo-router";
 import { ActivityIndicator, Pressable, ScrollView, Text, View } from "react-native";
 import { Ionicons } from "@expo/vector-icons";
 import { StyleSheet, useUnistyles } from "react-native-unistyles";
 import type { AgentThreadEvent, AgentThreadSnapshot } from "@matrix-os/contracts";
 import { useGateway } from "@/app/_layout";
+import { loadMobileShellState, saveMobileShellState } from "@/lib/mobile-shell-state";
 
 type ThreadRouteState =
   | { status: "loading"; snapshot: null; error: null }
@@ -14,6 +15,7 @@ type ThreadRouteState =
 export default function AgentThreadRoute() {
   const { theme } = useUnistyles();
   const params = useLocalSearchParams<{ threadId?: string }>();
+  const router = useRouter();
   const threadId = typeof params.threadId === "string" ? params.threadId : "thread";
   const { client } = useGateway();
   const requestGeneration = useRef(0);
@@ -56,6 +58,23 @@ export default function AgentThreadRoute() {
       clearTimeout(timer);
     };
   }, [loadSnapshot]);
+
+  const boundTerminalSessionId = state.status === "ready" ? state.snapshot.thread.terminalSessionId ?? null : null;
+  const openBoundTerminal = useCallback(async () => {
+    if (!boundTerminalSessionId) return;
+    try {
+      const savedState = await loadMobileShellState();
+      await saveMobileShellState({
+        ...savedState,
+        mode: "terminal",
+        lastActiveTerminalSessionId: boundTerminalSessionId,
+        updatedAt: new Date().toISOString(),
+      });
+    } catch {
+      console.warn("[mobile] failed to remember bound terminal session");
+    }
+    router.push("/terminal");
+  }, [boundTerminalSessionId, router]);
 
   if (state.status === "loading") {
     return (
@@ -108,15 +127,28 @@ export default function AgentThreadRoute() {
         {state.error ? (
           <Text style={styles.inlineError}>{state.error}</Text>
         ) : null}
-        <Pressable
-          accessibilityRole="button"
-          accessibilityLabel="Refresh thread"
-          onPress={() => void loadSnapshot()}
-          style={styles.refreshButton}
-        >
-          <Ionicons name="refresh-outline" size={16} color={theme.colors.background} />
-          <Text style={styles.refreshText}>{state.refreshing ? "Refreshing" : "Refresh"}</Text>
-        </Pressable>
+        <View style={styles.actionRow}>
+          {thread.terminalSessionId ? (
+            <Pressable
+              accessibilityRole="button"
+              accessibilityLabel="Open bound terminal"
+              onPress={() => void openBoundTerminal()}
+              style={styles.secondaryButton}
+            >
+              <Ionicons name="terminal-outline" size={16} color={theme.colors.forest} />
+              <Text style={styles.secondaryText}>Terminal</Text>
+            </Pressable>
+          ) : null}
+          <Pressable
+            accessibilityRole="button"
+            accessibilityLabel="Refresh thread"
+            onPress={() => void loadSnapshot()}
+            style={styles.refreshButton}
+          >
+            <Ionicons name="refresh-outline" size={16} color={theme.colors.background} />
+            <Text style={styles.refreshText}>{state.refreshing ? "Refreshing" : "Refresh"}</Text>
+          </Pressable>
+        </View>
       </View>
       {events.items.length > 0 ? (
         <View style={styles.timeline}>
@@ -295,8 +327,14 @@ const styles = StyleSheet.create((theme, rt) => ({
     fontSize: 13,
     color: theme.colors.foreground,
   },
-  refreshButton: {
+  actionRow: {
     marginTop: theme.spacing.sm,
+    flexDirection: "row",
+    flexWrap: "wrap",
+    gap: theme.spacing.sm,
+  },
+  refreshButton: {
+    flexGrow: 1,
     minHeight: 40,
     borderRadius: 20,
     paddingHorizontal: theme.spacing.lg,
@@ -310,6 +348,23 @@ const styles = StyleSheet.create((theme, rt) => ({
     fontFamily: theme.fonts.sansSemiBold,
     fontSize: 13,
     color: theme.colors.background,
+  },
+  secondaryButton: {
+    minHeight: 40,
+    borderRadius: 20,
+    paddingHorizontal: theme.spacing.lg,
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "center",
+    gap: theme.spacing.xs,
+    backgroundColor: theme.colors.background,
+    borderWidth: 1,
+    borderColor: theme.colors.border,
+  },
+  secondaryText: {
+    fontFamily: theme.fonts.sansSemiBold,
+    fontSize: 13,
+    color: theme.colors.forest,
   },
   inlineError: {
     fontFamily: theme.fonts.sansSemiBold,

--- a/apps/mobile/app/agents/[threadId].tsx
+++ b/apps/mobile/app/agents/[threadId].tsx
@@ -12,6 +12,8 @@ type ThreadRouteState =
   | { status: "ready"; snapshot: AgentThreadSnapshot; error: "Thread state unavailable" | null; refreshing: boolean }
   | { status: "error"; snapshot: null; error: "Thread state unavailable" };
 
+type TerminalOpenError = "Terminal session unavailable. Try again.";
+
 export default function AgentThreadRoute() {
   const { theme } = useUnistyles();
   const params = useLocalSearchParams<{ threadId?: string }>();
@@ -24,8 +26,10 @@ export default function AgentThreadRoute() {
     snapshot: null,
     error: null,
   });
+  const [terminalOpenError, setTerminalOpenError] = useState<TerminalOpenError | null>(null);
 
   const loadSnapshot = useCallback(async (cancelled: () => boolean = () => false) => {
+    setTerminalOpenError(null);
     if (!client || !threadId) {
       setState((current) => current.status === "ready"
         ? { ...current, error: "Thread state unavailable", refreshing: false }
@@ -62,6 +66,7 @@ export default function AgentThreadRoute() {
   const boundTerminalSessionId = state.status === "ready" ? state.snapshot.thread.terminalSessionId ?? null : null;
   const openBoundTerminal = useCallback(async () => {
     if (!boundTerminalSessionId) return;
+    setTerminalOpenError(null);
     try {
       const savedState = await loadMobileShellState();
       await saveMobileShellState({
@@ -72,6 +77,8 @@ export default function AgentThreadRoute() {
       });
     } catch {
       console.warn("[mobile] failed to remember bound terminal session");
+      setTerminalOpenError("Terminal session unavailable. Try again.");
+      return;
     }
     router.push("/terminal");
   }, [boundTerminalSessionId, router]);
@@ -126,6 +133,9 @@ export default function AgentThreadRoute() {
         ) : null}
         {state.error ? (
           <Text style={styles.inlineError}>{state.error}</Text>
+        ) : null}
+        {terminalOpenError ? (
+          <Text style={styles.inlineError}>{terminalOpenError}</Text>
         ) : null}
         <View style={styles.actionRow}>
           {thread.terminalSessionId ? (

--- a/apps/mobile/app/agents/[threadId].tsx
+++ b/apps/mobile/app/agents/[threadId].tsx
@@ -6,6 +6,7 @@ import { StyleSheet, useUnistyles } from "react-native-unistyles";
 import type { AgentThreadEvent, AgentThreadSnapshot } from "@matrix-os/contracts";
 import { useGateway } from "@/app/_layout";
 import { loadMobileShellState, saveMobileShellState } from "@/lib/mobile-shell-state";
+import { isSafeShellSessionName } from "@/lib/terminal-state";
 
 type ThreadRouteState =
   | { status: "loading"; snapshot: null; error: null }
@@ -67,6 +68,10 @@ export default function AgentThreadRoute() {
   const openBoundTerminal = useCallback(async () => {
     if (!boundTerminalSessionId) return;
     setTerminalOpenError(null);
+    if (!isSafeShellSessionName(boundTerminalSessionId)) {
+      setTerminalOpenError("Terminal session unavailable. Try again.");
+      return;
+    }
     try {
       const savedState = await loadMobileShellState();
       await saveMobileShellState({

--- a/apps/mobile/lib/mobile-shell-state.ts
+++ b/apps/mobile/lib/mobile-shell-state.ts
@@ -1,4 +1,5 @@
 import AsyncStorage from "@react-native-async-storage/async-storage";
+import { isSafeShellSessionName } from "@/lib/terminal-state";
 
 export const MOBILE_SHELL_STATE_STORAGE_KEY = "matrix.mobileShellState.v1";
 
@@ -84,7 +85,7 @@ function safeAppSlug(value: unknown): string | null {
 function safeTerminalSessionId(value: unknown): string | null {
   if (typeof value !== "string") return null;
   const sessionId = value.trim();
-  return SAFE_TERMINAL_SESSION_ID.test(sessionId) ? sessionId : null;
+  return SAFE_TERMINAL_SESSION_ID.test(sessionId) || isSafeShellSessionName(sessionId) ? sessionId : null;
 }
 
 function safeIsoTimestamp(value: unknown): string | null {

--- a/apps/mobile/lib/mobile-shell-state.ts
+++ b/apps/mobile/lib/mobile-shell-state.ts
@@ -19,8 +19,6 @@ type MobileShellStorage = Pick<typeof AsyncStorage, "getItem" | "setItem">;
 
 const MOBILE_SHELL_MODES = new Set<MobileShellMode>(["launcher", "app", "terminal", "canvas"]);
 const SAFE_APP_SLUG = /^[a-z0-9][a-z0-9_-]*(?:\/[a-z0-9][a-z0-9_-]*)*$/;
-const SAFE_TERMINAL_SESSION_ID =
-  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
 function createDefaultMobileShellState(surface: MobileShellSurface = "native-mobile"): MobileShellState {
   return {
@@ -85,7 +83,7 @@ function safeAppSlug(value: unknown): string | null {
 function safeTerminalSessionId(value: unknown): string | null {
   if (typeof value !== "string") return null;
   const sessionId = value.trim();
-  return SAFE_TERMINAL_SESSION_ID.test(sessionId) || isSafeShellSessionName(sessionId) ? sessionId : null;
+  return isSafeShellSessionName(sessionId) ? sessionId : null;
 }
 
 function safeIsoTimestamp(value: unknown): string | null {

--- a/specs/105-coding-agent-shells/current-state.md
+++ b/specs/105-coding-agent-shells/current-state.md
@@ -1,12 +1,12 @@
 # Current State: Coding Agent Shells
 
-**Branch stack**: `spec/coding-agent-shells` plus stacked implementation branches through `105-coding-agent-mobile-thread-events`
+**Branch stack**: `spec/coding-agent-shells` plus stacked implementation branches through `105-coding-agent-mobile-thread-terminal`
 **Updated**: 2026-07-07
 **Scope**: Inventory for the coding-agent desktop/mobile shell work. This file records the current Matrix-native route, contract, client, and regression-test state so later slices keep gateway/runtime as source of truth and keep desktop/mobile as thin shells.
 
 ## Summary
 
-The stack currently has shared contracts, a gateway runtime summary read model, read-only desktop and mobile workspaces behind flags, thread create/replay/abort/event streaming, provider adapters, a workspace-backed provider, approval/input route handling, a read-only coding-agent review summary route/client contract, desktop/mobile read-only review summary panels, and a read-only coding-agent review snapshot route with bounded file metadata from safe owner worktree diffs plus findings fallback metadata. Review snapshots can include bounded per-hunk diff lines with truncation markers. Desktop and mobile review details render changed-file counts, selectable hunk coordinate metadata, and gateway-bounded diff lines. Desktop and mobile can seed their existing agent composers from a selected review hunk using bounded prompt context and a `structured_ref` attachment. Mobile active thread rows now open a bounded thread detail route that hydrates `AgentThreadSnapshotSchema` through the authenticated gateway client and renders safe thread metadata, event counts, and a read-only snapshot event timeline. Full file content and preview coding-agent surfaces are contract-only or existing workspace routes; dedicated preview shell UI is not yet integrated.
+The stack currently has shared contracts, a gateway runtime summary read model, read-only desktop and mobile workspaces behind flags, thread create/replay/abort/event streaming, provider adapters, a workspace-backed provider, approval/input route handling, a read-only coding-agent review summary route/client contract, desktop/mobile read-only review summary panels, and a read-only coding-agent review snapshot route with bounded file metadata from safe owner worktree diffs plus findings fallback metadata. Review snapshots can include bounded per-hunk diff lines with truncation markers. Desktop and mobile review details render changed-file counts, selectable hunk coordinate metadata, and gateway-bounded diff lines. Desktop and mobile can seed their existing agent composers from a selected review hunk using bounded prompt context and a `structured_ref` attachment. Mobile active thread rows now open a bounded thread detail route that hydrates `AgentThreadSnapshotSchema` through the authenticated gateway client, renders safe thread metadata, event counts, and a read-only snapshot event timeline, and can hand a bound canonical terminal session to the existing mobile Terminal tab. Full file content and preview coding-agent surfaces are contract-only or existing workspace routes; dedicated preview shell UI is not yet integrated.
 
 Current source-of-truth boundaries:
 
@@ -235,13 +235,14 @@ Screen:
 - Safe generic review error state if review summaries are unavailable; review failures do not drop the runtime summary dashboard.
 - Composer route for creating accepted coding-agent threads.
 - Active thread rows navigate to `/agents/:threadId`; the thread route hydrates a bounded thread snapshot, shows provider/status/terminal metadata, event counts, loading, refresh, safe generic error states, and a read-only event timeline for gateway-bounded snapshot events. Assistant text and file-change events render generic summaries instead of raw event text or paths. Live replay/subscription and richer transcript grouping remain follow-up work.
+- Thread details with a bound `terminalSessionId` can open the existing `/terminal` tab after persisting only the safe canonical shell-session reference in `mobile-shell-state`; terminal output and transcripts remain outside AsyncStorage.
 - Flag: `apps/mobile/lib/feature-flags.ts` with `EXPO_PUBLIC_CODING_AGENTS_MOBILE_WORKSPACE === "1"`.
 
 Persisted UI references:
 
-- `apps/mobile/lib/agent-workspace-state.ts`
-- Stores only `selectedThreadId`, `selectedTerminalSessionId`, and `updatedAt`.
-- Reconciles stale references against runtime summary items.
+- `apps/mobile/lib/agent-workspace-state.ts` stores only `selectedThreadId`, `selectedTerminalSessionId`, and `updatedAt`.
+- `apps/mobile/lib/mobile-shell-state.ts` stores only the current shell mode plus safe bounded app or terminal session references, including canonical named shell sessions such as `main` or `matrix-abc1234`.
+- Agent workspace state reconciles stale references against runtime summary items.
 - Does not store transcripts, terminal output, file contents, diffs, credentials, approvals payloads, or launch tokens.
 
 Focused tests:


### PR DESCRIPTION
## Summary

- Adds a mobile thread-detail Terminal action for coding-agent threads with a bound `terminalSessionId`.
- Persists only safe canonical named terminal session references, then routes through the existing `/terminal` tab and mobile terminal client.
- Keeps invalid or unsaved terminal handoffs on the thread screen with a generic recovery message instead of falling through to another session.
- Updates the coding-agent shell current-state note for this mobile terminal handoff.

## Invariants

- Source of truth: gateway/runtime remain the source of thread and terminal state; mobile stores only bounded UI references.
- Lock/transaction scope: no database or runtime mutation is introduced by this slice.
- Acceptable orphan states: if the bound terminal reference is stale or not attachable, mobile does not overwrite terminal state or navigate into fallback selection.
- Auth source of truth: terminal attach and thread hydration continue to use the existing authenticated gateway/mobile terminal client paths.
- Deferred scope: live thread replay subscriptions, transcript grouping, file/review preview integration, and richer terminal recovery UI remain follow-up work.

## Validation

- `pnpm --filter matrix-os-mobile run test -- mobile-shell-state.test.ts`
- `pnpm --filter matrix-os-mobile run test -- agent-thread-screen.test.tsx`
- `pnpm --filter matrix-os-mobile run test -- mobile-shell-state.test.ts terminal-screen.test.tsx agent-thread-screen.test.tsx`
- `pnpm --filter matrix-os-mobile run lint`
- `pnpm --filter matrix-os-mobile exec tsc --noEmit`
- `pnpm --filter matrix-os-mobile run test`
- `bun run check:patterns` (0 violations; existing warnings only)
- `bun run typecheck`
- `git diff --check`
- Restricted wording scan for changed mobile/spec paths (no matches)

## Docs

- Updated `specs/105-coding-agent-shells/current-state.md`.
