### PR TITLE
feat(desktop): open thread terminal sessions

### DIFF
--- a/desktop/src/renderer/src/features/coding-agents/AgentWorkspace.tsx
+++ b/desktop/src/renderer/src/features/coding-agents/AgentWorkspace.tsx
@@ -335,31 +335,53 @@ function AgentComposer({ summary, seed }: { summary: RuntimeSummary; seed: Compo
 }
 
 function ThreadList({ summary }: { summary: RuntimeSummary }) {
+  const openTab = useTabs((s) => s.openTab);
+  const findAttachableSessionName = (sessionId: string): string | null =>
+    summary.terminalSessions.items.find((session) => session.id === sessionId && session.attachable)?.name ?? null;
+
   return (
     <Section title="Active Threads" count={summary.activeThreads.items.length}>
       <div className="grid gap-2">
-        {summary.activeThreads.items.map((thread) => (
-          <article
-            key={thread.id}
-            className="flex items-center justify-between gap-3 rounded-md border p-3"
-            style={{ borderColor: "var(--border-subtle)", background: "var(--bg-surface)" }}
-          >
-            <div className="flex min-w-0 items-center gap-2">
-              <GitBranch size={15} style={{ color: "var(--text-tertiary)" }} />
-              <div className="min-w-0">
-                <h3 className="truncate text-sm font-medium" style={{ color: "var(--text-primary)" }}>
-                  {thread.title}
-                </h3>
-                <p className="text-xs" style={{ color: "var(--text-tertiary)" }}>
-                  {thread.providerId}
-                </p>
+        {summary.activeThreads.items.map((thread) => {
+          const terminalSessionName = thread.terminalSessionId
+            ? findAttachableSessionName(thread.terminalSessionId)
+            : null;
+
+          return (
+            <article
+              key={thread.id}
+              className="flex items-center justify-between gap-3 rounded-md border p-3"
+              style={{ borderColor: "var(--border-subtle)", background: "var(--bg-surface)" }}
+            >
+              <div className="flex min-w-0 items-center gap-2">
+                <GitBranch size={15} style={{ color: "var(--text-tertiary)" }} />
+                <div className="min-w-0">
+                  <h3 className="truncate text-sm font-medium" style={{ color: "var(--text-primary)" }}>
+                    {thread.title}
+                  </h3>
+                  <p className="text-xs" style={{ color: "var(--text-tertiary)" }}>
+                    {thread.providerId}
+                  </p>
+                </div>
               </div>
-            </div>
-            <span className="shrink-0 text-xs capitalize" style={{ color: "var(--text-secondary)" }}>
-              {thread.status.replace(/_/g, " ")}
-            </span>
-          </article>
-        ))}
+              <div className="flex shrink-0 items-center gap-2">
+                {terminalSessionName ? (
+                  <Button
+                    variant="ghost"
+                    aria-label={`Open terminal for ${thread.title}`}
+                    title={`Open terminal for ${thread.title}`}
+                    onClick={() => openTab({ kind: "terminal", sessionName: thread.terminalSessionId, title: terminalSessionName })}
+                  >
+                    <SquareTerminal size={14} />
+                  </Button>
+                ) : null}
+                <span className="text-xs capitalize" style={{ color: "var(--text-secondary)" }}>
+                  {thread.status.replace(/_/g, " ")}
+                </span>
+              </div>
+            </article>
+          );
+        })}
         {summary.activeThreads.items.length === 0 ? (
           <p className="rounded-md border p-3 text-sm" style={{ borderColor: "var(--border-subtle)", color: "var(--text-secondary)" }}>
             No active threads.

--- a/specs/105-coding-agent-shells/current-state.md
+++ b/specs/105-coding-agent-shells/current-state.md
@@ -1,12 +1,12 @@
 # Current State: Coding Agent Shells
 
-**Branch stack**: `spec/coding-agent-shells` plus stacked implementation branches through `105-coding-agent-mobile-thread-terminal`
+**Branch stack**: `spec/coding-agent-shells` plus stacked implementation branches through `105-coding-agent-desktop-thread-terminal`
 **Updated**: 2026-07-07
 **Scope**: Inventory for the coding-agent desktop/mobile shell work. This file records the current Matrix-native route, contract, client, and regression-test state so later slices keep gateway/runtime as source of truth and keep desktop/mobile as thin shells.
 
 ## Summary
 
-The stack currently has shared contracts, a gateway runtime summary read model, read-only desktop and mobile workspaces behind flags, thread create/replay/abort/event streaming, provider adapters, a workspace-backed provider, approval/input route handling, a read-only coding-agent review summary route/client contract, desktop/mobile read-only review summary panels, and a read-only coding-agent review snapshot route with bounded file metadata from safe owner worktree diffs plus findings fallback metadata. Review snapshots can include bounded per-hunk diff lines with truncation markers. Desktop and mobile review details render changed-file counts, selectable hunk coordinate metadata, and gateway-bounded diff lines. Desktop and mobile can seed their existing agent composers from a selected review hunk using bounded prompt context and a `structured_ref` attachment. Mobile active thread rows now open a bounded thread detail route that hydrates `AgentThreadSnapshotSchema` through the authenticated gateway client, renders safe thread metadata, event counts, and a read-only snapshot event timeline, and can hand a bound canonical terminal session to the existing mobile Terminal tab. Full file content and preview coding-agent surfaces are contract-only or existing workspace routes; dedicated preview shell UI is not yet integrated.
+The stack currently has shared contracts, a gateway runtime summary read model, read-only desktop and mobile workspaces behind flags, thread create/replay/abort/event streaming, provider adapters, a workspace-backed provider, approval/input route handling, a read-only coding-agent review summary route/client contract, desktop/mobile read-only review summary panels, and a read-only coding-agent review snapshot route with bounded file metadata from safe owner worktree diffs plus findings fallback metadata. Review snapshots can include bounded per-hunk diff lines with truncation markers. Desktop and mobile review details render changed-file counts, selectable hunk coordinate metadata, and gateway-bounded diff lines. Desktop and mobile can seed their existing agent composers from a selected review hunk using bounded prompt context and a `structured_ref` attachment. Mobile active thread rows now open a bounded thread detail route that hydrates `AgentThreadSnapshotSchema` through the authenticated gateway client, renders safe thread metadata, event counts, and a read-only snapshot event timeline, and can hand a bound canonical terminal session to the existing mobile Terminal tab. Desktop active thread rows can open a matching attachable bound canonical terminal session in the existing Terminal tab model. Full file content and preview coding-agent surfaces are contract-only or existing workspace routes; dedicated preview shell UI is not yet integrated.
 
 Current source-of-truth boundaries:
 
@@ -206,6 +206,7 @@ Renderer:
 Current behavior:
 
 - Read-only dashboard renders providers, active threads, and terminals.
+- Active thread rows with a matching attachable `terminalSessionId` can open the existing desktop Terminal tab for that canonical session; stale or unavailable terminal bindings do not render an action.
 - When the runtime advertises `codingAgentsReview`, the dashboard fetches bounded review summaries through the trusted main-process IPC route and renders project, PR, round, status, and high-severity count.
 - Review snapshot details render bounded file paths, additions/deletions, partial markers, selectable hunk coordinate metadata, gateway-bounded hunk lines, and safe finding summaries. Diff line containers are blocked from session recording.
 - When thread creation is enabled, selecting a review hunk can open the mobile composer with bounded review metadata and a `structured_ref` attachment for the target file/hunk; the existing authenticated `createCodingAgentThread` gateway client performs the mutation.

--- a/tests/desktop/coding-agent-workspace.test.tsx
+++ b/tests/desktop/coding-agent-workspace.test.tsx
@@ -9,8 +9,13 @@ import AgentWorkspace, {
 } from "../../desktop/src/renderer/src/features/coding-agents/AgentWorkspace";
 import { useCodingAgentWorkspace } from "../../desktop/src/renderer/src/stores/coding-agent-workspace";
 import { useConnection } from "../../desktop/src/renderer/src/stores/connection";
+import { useTabs } from "../../desktop/src/renderer/src/stores/tabs";
 
-function summaryFixture({ threadCreate = false }: { threadCreate?: boolean } = {}) {
+function summaryFixture({
+  threadCreate = false,
+  threadTerminalSessionId,
+  terminalSessionName = "matrix-abc1234",
+}: { threadCreate?: boolean; threadTerminalSessionId?: string; terminalSessionName?: string } = {}) {
   return {
     runtime: {
       id: "rt_primary",
@@ -57,6 +62,7 @@ function summaryFixture({ threadCreate = false }: { threadCreate?: boolean } = {
           providerId: "codex",
           title: "Fix settings route",
           status: "running",
+          ...(threadTerminalSessionId ? { terminalSessionId: threadTerminalSessionId } : {}),
           createdAt: "2026-07-06T00:00:00.000Z",
           updatedAt: "2026-07-06T00:01:00.000Z",
         },
@@ -68,7 +74,7 @@ function summaryFixture({ threadCreate = false }: { threadCreate?: boolean } = {
       items: [
         {
           id: "matrix-abc1234",
-          name: "matrix-abc1234",
+          name: terminalSessionName,
           status: "running",
           attachable: true,
           createdAt: "2026-07-06T00:00:00.000Z",
@@ -212,6 +218,7 @@ describe("AgentWorkspace", () => {
       runtimeSlot: "primary",
       api: null,
     });
+    useTabs.setState({ tabs: [], activeTabId: null });
     window.operator = {
       invoke: vi.fn((channel: string) => {
         if (channel === "runtime:get-summary") return Promise.resolve(summaryFixture());
@@ -237,6 +244,72 @@ describe("AgentWorkspace", () => {
     expect(screen.getByText("Fix settings route")).toBeTruthy();
     expect(screen.getByText("matrix-abc1234")).toBeTruthy();
     expect(window.operator.invoke).toHaveBeenCalledWith("runtime:get-summary", {});
+  });
+
+  it("opens a bound thread terminal in the existing terminal tab model", async () => {
+    window.operator.invoke = vi.fn((channel: string) => {
+      if (channel === "runtime:get-summary") {
+        return Promise.resolve(summaryFixture({ threadTerminalSessionId: "matrix-abc1234" }));
+      }
+      if (channel === "runtime:get-reviews") return Promise.resolve(reviewsFixture());
+      return Promise.reject(new Error("unexpected channel"));
+    });
+
+    render(<AgentWorkspace />);
+
+    await screen.findByText("Fix settings route");
+    fireEvent.click(screen.getByRole("button", { name: "Open terminal for Fix settings route" }));
+
+    const tabs = useTabs.getState().tabs;
+    expect(tabs).toHaveLength(1);
+    expect(tabs[0]).toMatchObject({
+      kind: "terminal",
+      sessionName: "matrix-abc1234",
+      title: "matrix-abc1234",
+    });
+    expect(useTabs.getState().activeTabId).toBe(tabs[0]?.id);
+  });
+
+  it("opens a bound thread terminal by canonical session id when the display name differs", async () => {
+    window.operator.invoke = vi.fn((channel: string) => {
+      if (channel === "runtime:get-summary") {
+        return Promise.resolve(summaryFixture({
+          threadTerminalSessionId: "matrix-abc1234",
+          terminalSessionName: "friendly-shell",
+        }));
+      }
+      if (channel === "runtime:get-reviews") return Promise.resolve(reviewsFixture());
+      return Promise.reject(new Error("unexpected channel"));
+    });
+
+    render(<AgentWorkspace />);
+
+    await screen.findByText("Fix settings route");
+    fireEvent.click(screen.getByRole("button", { name: "Open terminal for Fix settings route" }));
+
+    const tabs = useTabs.getState().tabs;
+    expect(tabs).toHaveLength(1);
+    expect(tabs[0]).toMatchObject({
+      kind: "terminal",
+      sessionName: "matrix-abc1234",
+      title: "friendly-shell",
+    });
+  });
+
+  it("does not open stale thread terminal bindings", async () => {
+    window.operator.invoke = vi.fn((channel: string) => {
+      if (channel === "runtime:get-summary") {
+        return Promise.resolve(summaryFixture({ threadTerminalSessionId: "matrix-missing" }));
+      }
+      if (channel === "runtime:get-reviews") return Promise.resolve(reviewsFixture());
+      return Promise.reject(new Error("unexpected channel"));
+    });
+
+    render(<AgentWorkspace />);
+
+    await screen.findByText("Fix settings route");
+    expect(screen.queryByRole("button", { name: "Open terminal for Fix settings route" })).toBeNull();
+    expect(useTabs.getState().tabs).toHaveLength(0);
   });
 
   it("renders read-only review summaries through trusted IPC", async () => {


### PR DESCRIPTION
## Summary

- Adds a desktop coding-agent workspace action that opens a bound thread terminal in the existing Terminal tab model.
- Requires the thread `terminalSessionId` to match an attachable terminal session from the runtime summary before rendering the action.
- Updates the coding-agent shell current-state note for the new desktop handoff.

## Invariants

- Source of truth: gateway/runtime summary remains authoritative for thread and terminal bindings.
- Lock/transaction scope: no persistence, database writes, locks, or transactions are added.
- Acceptable orphan states: stale or unavailable terminal bindings render no action and do not create local terminal state.
- Auth source of truth: desktop renderer continues to receive only trusted IPC summary data, with credentials held in the main process.
- Deferred scope: live transcript replay, file surfaces, preview surfaces, and terminal lifecycle changes remain outside this slice.

## Validation

- `pnpm exec vitest run tests/desktop/coding-agent-workspace.test.tsx`
- `pnpm --filter desktop run typecheck`
- `bun run check:patterns`
- `bun run typecheck`
- `git diff --check`
