### PR TITLE
feat(desktop): focus agent notifications

### DIFF
--- a/desktop/src/renderer/src/features/coding-agents/AgentWorkspace.tsx
+++ b/desktop/src/renderer/src/features/coding-agents/AgentWorkspace.tsx
@@ -336,6 +336,7 @@ function AgentComposer({ summary, seed }: { summary: RuntimeSummary; seed: Compo
 
 function ThreadList({ summary }: { summary: RuntimeSummary }) {
   const openTab = useTabs((s) => s.openTab);
+  const activeThreadId = useCodingAgentWorkspace((s) => s.activeThreadId);
   const findAttachableSessionName = (sessionId: string): string | null =>
     summary.terminalSessions.items.find((session) => session.id === sessionId && session.attachable)?.name ?? null;
 
@@ -346,12 +347,18 @@ function ThreadList({ summary }: { summary: RuntimeSummary }) {
           const terminalSessionName = thread.terminalSessionId
             ? findAttachableSessionName(thread.terminalSessionId)
             : null;
+          const active = activeThreadId === thread.id;
 
           return (
             <article
               key={thread.id}
+              aria-current={active ? "true" : undefined}
+              aria-label={active ? `Active thread ${thread.title}` : `Thread ${thread.title}`}
               className="flex items-center justify-between gap-3 rounded-md border p-3"
-              style={{ borderColor: "var(--border-subtle)", background: "var(--bg-surface)" }}
+              style={{
+                borderColor: active ? "var(--accent)" : "var(--border-subtle)",
+                background: active ? "var(--accent-muted)" : "var(--bg-surface)",
+              }}
             >
               <div className="flex min-w-0 items-center gap-2">
                 <GitBranch size={15} style={{ color: "var(--text-tertiary)" }} />

--- a/desktop/src/renderer/src/lib/kernel-wiring.ts
+++ b/desktop/src/renderer/src/lib/kernel-wiring.ts
@@ -10,6 +10,7 @@ import {
 } from "../stores/board";
 import { useConnection } from "../stores/connection";
 import { useHermesChat } from "../stores/hermes-chat";
+import { useCodingAgentWorkspace } from "../stores/coding-agent-workspace";
 import { useTabs } from "../stores/tabs";
 import { useThreads } from "../stores/threads";
 
@@ -126,6 +127,7 @@ export function wireKernel(): () => void {
   // Clicking a native notification focuses the thread in the Agents tab.
   const offNotificationClick = onEvent("notification:clicked", ({ threadId }) => {
     useThreads.getState().setActiveThread(threadId);
+    useCodingAgentWorkspace.setState({ activeThreadId: threadId });
     useTabs.getState().openTab({ kind: "agents", title: "Agents" });
   });
 

--- a/specs/105-coding-agent-shells/current-state.md
+++ b/specs/105-coding-agent-shells/current-state.md
@@ -1,12 +1,12 @@
 # Current State: Coding Agent Shells
 
-**Branch stack**: `spec/coding-agent-shells` plus stacked implementation branches through `105-coding-agent-desktop-thread-terminal`
+**Branch stack**: `spec/coding-agent-shells` plus stacked implementation branches through `105-coding-agent-desktop-notification-focus`
 **Updated**: 2026-07-07
 **Scope**: Inventory for the coding-agent desktop/mobile shell work. This file records the current Matrix-native route, contract, client, and regression-test state so later slices keep gateway/runtime as source of truth and keep desktop/mobile as thin shells.
 
 ## Summary
 
-The stack currently has shared contracts, a gateway runtime summary read model, read-only desktop and mobile workspaces behind flags, thread create/replay/abort/event streaming, provider adapters, a workspace-backed provider, approval/input route handling, a read-only coding-agent review summary route/client contract, desktop/mobile read-only review summary panels, and a read-only coding-agent review snapshot route with bounded file metadata from safe owner worktree diffs plus findings fallback metadata. Review snapshots can include bounded per-hunk diff lines with truncation markers. Desktop and mobile review details render changed-file counts, selectable hunk coordinate metadata, and gateway-bounded diff lines. Desktop and mobile can seed their existing agent composers from a selected review hunk using bounded prompt context and a `structured_ref` attachment. Mobile active thread rows now open a bounded thread detail route that hydrates `AgentThreadSnapshotSchema` through the authenticated gateway client, renders safe thread metadata, event counts, and a read-only snapshot event timeline, and can hand a bound canonical terminal session to the existing mobile Terminal tab. Desktop active thread rows can open a matching attachable bound canonical terminal session in the existing Terminal tab model. Full file content and preview coding-agent surfaces are contract-only or existing workspace routes; dedicated preview shell UI is not yet integrated.
+The stack currently has shared contracts, a gateway runtime summary read model, read-only desktop and mobile workspaces behind flags, thread create/replay/abort/event streaming, provider adapters, a workspace-backed provider, approval/input route handling, a read-only coding-agent review summary route/client contract, desktop/mobile read-only review summary panels, and a read-only coding-agent review snapshot route with bounded file metadata from safe owner worktree diffs plus findings fallback metadata. Review snapshots can include bounded per-hunk diff lines with truncation markers. Desktop and mobile review details render changed-file counts, selectable hunk coordinate metadata, and gateway-bounded diff lines. Desktop and mobile can seed their existing agent composers from a selected review hunk using bounded prompt context and a `structured_ref` attachment. Mobile active thread rows now open a bounded thread detail route that hydrates `AgentThreadSnapshotSchema` through the authenticated gateway client, renders safe thread metadata, event counts, and a read-only snapshot event timeline, and can hand a bound canonical terminal session to the existing mobile Terminal tab. Desktop active thread rows can open a matching attachable bound canonical terminal session in the existing Terminal tab model. Desktop native notification clicks focus the Agents tab and visibly select the bounded coding-agent workspace thread reference in the active thread list. Full file content and preview coding-agent surfaces are contract-only or existing workspace routes; dedicated preview shell UI is not yet integrated.
 
 Current source-of-truth boundaries:
 
@@ -207,6 +207,7 @@ Current behavior:
 
 - Read-only dashboard renders providers, active threads, and terminals.
 - Active thread rows with a matching attachable `terminalSessionId` can open the existing desktop Terminal tab for that canonical session; stale or unavailable terminal bindings do not render an action.
+- Native notification clicks carrying a bounded `threadId` focus the existing Agents tab and visibly mark that thread current in the coding-agent workspace thread list while preserving the legacy thread-store selection path.
 - When the runtime advertises `codingAgentsReview`, the dashboard fetches bounded review summaries through the trusted main-process IPC route and renders project, PR, round, status, and high-severity count.
 - Review snapshot details render bounded file paths, additions/deletions, partial markers, selectable hunk coordinate metadata, gateway-bounded hunk lines, and safe finding summaries. Diff line containers are blocked from session recording.
 - When thread creation is enabled, selecting a review hunk can open the mobile composer with bounded review metadata and a `structured_ref` attachment for the target file/hunk; the existing authenticated `createCodingAgentThread` gateway client performs the mutation.
@@ -214,6 +215,11 @@ Current behavior:
 - Safe generic error state if the runtime summary is unavailable.
 - Safe generic review error state if review summaries are unavailable; review failures do not drop the runtime summary dashboard.
 - No provider credentials or bearer tokens are exposed to the renderer.
+
+Focused tests:
+
+- `tests/desktop/coding-agent-workspace.test.tsx`
+- `tests/desktop/kernel-wiring.test.ts`
 
 ## Mobile Shell State
 
@@ -340,5 +346,5 @@ git diff --check
 - Session completion reconciliation: implemented for workspace `session.stopped` events that carry owner id, workspace session id, and bound `terminalSessionId`; the gateway thread store marks matching active coding-agent threads completed or failed server-side without matching unrelated owners or reused terminal ids. Remaining work: if runtime managers add autonomous process-exit detection beyond explicit workspace stop events, route those through the same `session.stopped` publisher path.
 - File/review/preview shell surfaces: read-only review summaries now have coding-agent contracts/routes/desktop IPC/mobile clients plus desktop and mobile read-only review panels. A read-only review snapshot route now exposes bounded diff hunk metadata and capped hunk line bodies from safe owner worktrees plus partial findings-derived fallback metadata for later shell diff panels. Full file contents and previews are not implemented yet.
 - Browser shell entry point: Canvas-first placement is still undecided.
-- Notifications/attention routing: desktop notification IPC exists, but thread attention notifications are not yet wired end-to-end from gateway events.
+- Notifications/attention routing: desktop notification IPC exists and notification clicks focus the coding-agent workspace thread in the Agents tab with a visible current-thread marker. Remaining work: thread attention notifications are not yet wired end-to-end from gateway events.
 - Public docs: public Matrix OS docs should be updated once the user-facing coding-agent shell flow is stable enough to document.

--- a/tests/desktop/coding-agent-workspace.test.tsx
+++ b/tests/desktop/coding-agent-workspace.test.tsx
@@ -246,6 +246,15 @@ describe("AgentWorkspace", () => {
     expect(window.operator.invoke).toHaveBeenCalledWith("runtime:get-summary", {});
   });
 
+  it("marks the active coding-agent thread as current in the thread list", async () => {
+    useCodingAgentWorkspace.setState({ activeThreadId: "thread_alpha" });
+
+    render(<AgentWorkspace />);
+
+    const activeThread = await screen.findByLabelText("Active thread Fix settings route");
+    expect(activeThread.getAttribute("aria-current")).toBe("true");
+  });
+
   it("opens a bound thread terminal in the existing terminal tab model", async () => {
     window.operator.invoke = vi.fn((channel: string) => {
       if (channel === "runtime:get-summary") {

--- a/tests/desktop/kernel-wiring.test.ts
+++ b/tests/desktop/kernel-wiring.test.ts
@@ -1,0 +1,89 @@
+// @vitest-environment jsdom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { wireKernel } from "../../desktop/src/renderer/src/lib/kernel-wiring";
+import { useCodingAgentWorkspace } from "../../desktop/src/renderer/src/stores/coding-agent-workspace";
+import { useConnection } from "../../desktop/src/renderer/src/stores/connection";
+import { useTabs } from "../../desktop/src/renderer/src/stores/tabs";
+import { useThreads } from "../../desktop/src/renderer/src/stores/threads";
+
+type MockKernelSocket = {
+  subscribe: ReturnType<typeof vi.fn>;
+  connect: ReturnType<typeof vi.fn>;
+  dispose: ReturnType<typeof vi.fn>;
+};
+
+const kernelSocketMocks = vi.hoisted(() => ({
+  instances: [] as MockKernelSocket[],
+}));
+
+vi.mock("../../desktop/src/renderer/src/lib/kernel-socket", () => ({
+  KernelSocket: vi.fn().mockImplementation(function MockKernelSocketConstructor() {
+    const instance: MockKernelSocket = {
+      subscribe: vi.fn(() => () => undefined),
+      connect: vi.fn(),
+      dispose: vi.fn(),
+    };
+    kernelSocketMocks.instances.push(instance);
+    return instance;
+  }),
+}));
+
+describe("kernel wiring", () => {
+  let notificationClick: ((payload: { threadId: string }) => void) | null = null;
+
+  beforeEach(() => {
+    notificationClick = null;
+    kernelSocketMocks.instances.length = 0;
+    useConnection.setState({
+      status: "signed-in",
+      handle: "operator",
+      platformHost: "https://platform.test",
+      runtimeSlot: "primary",
+      api: null,
+    });
+    useTabs.setState({ tabs: [], activeTabId: null });
+    useThreads.setState({ threads: [], activeThreadId: null });
+    useCodingAgentWorkspace.setState({
+      status: "idle",
+      summary: null,
+      error: null,
+      reviewsStatus: "idle",
+      reviews: null,
+      reviewsError: null,
+      selectedReviewId: null,
+      reviewSnapshotStatus: "idle",
+      reviewSnapshot: null,
+      reviewSnapshotError: null,
+      createStatus: "idle",
+      createError: null,
+      activeThreadId: null,
+    });
+    window.operator = {
+      invoke: vi.fn().mockResolvedValue(undefined),
+      on: vi.fn((channel: string, callback: (payload: unknown) => void) => {
+        if (channel === "notification:clicked") {
+          notificationClick = callback as (payload: { threadId: string }) => void;
+        }
+        return () => undefined;
+      }),
+    };
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("focuses the coding-agent workspace thread when a native notification is clicked", () => {
+    const cleanup = wireKernel();
+
+    expect(notificationClick).not.toBeNull();
+    notificationClick?.({ threadId: "thread_alpha" });
+
+    expect(useCodingAgentWorkspace.getState().activeThreadId).toBe("thread_alpha");
+    const tabs = useTabs.getState();
+    expect(tabs.tabs.find((tab) => tab.id === tabs.activeTabId)?.kind).toBe("agents");
+
+    cleanup();
+  });
+});


### PR DESCRIPTION
## Summary

- Focus the desktop coding-agent workspace when a native notification click carries a bounded thread id.
- Preserve the existing legacy thread-store selection path and reuse the existing Agents tab.
- Add a desktop kernel-wiring regression test and update the coding-agent shell current-state inventory.

## Validation

- `pnpm exec vitest run tests/desktop/kernel-wiring.test.ts tests/desktop/coding-agent-workspace.test.tsx`
- `pnpm --filter desktop run typecheck`
- `bun run check:patterns` passed with existing scanner warnings and 0 violations.
- `bun run typecheck`
- `git diff --cached --check`
- Restricted wording scan passed for changed files.

## Invariants

- Source of truth: gateway/runtime remains the source of truth for coding-agent state; desktop only focuses a bounded thread reference already delivered through validated IPC.
- Lock/transaction scope: no persistence or database writes are added.
- Acceptable orphan states: a clicked thread id may no longer be present in the latest runtime summary; the shell still opens the Agents tab with a safe reference and relies on normal summary refresh to reconcile display state.
- Auth source of truth: desktop renderer receives only the validated `notification:clicked` IPC payload and never receives bearer or provider credentials.
- Deferred scope: gateway-origin attention notification production and public docs remain deferred until the end-to-end notification and file/preview flows are stable.
