### PR TITLE
feat(desktop): show agent thread details

### DIFF
--- a/desktop/src/main/coding-agents/runtime-summary-client.ts
+++ b/desktop/src/main/coding-agents/runtime-summary-client.ts
@@ -16,6 +16,7 @@ const RUNTIME_SUMMARY_TIMEOUT_MS = 10_000;
 const REVIEW_SUMMARY_TIMEOUT_MS = 10_000;
 const REVIEW_SNAPSHOT_TIMEOUT_MS = 10_000;
 const THREAD_CREATE_TIMEOUT_MS = 15_000;
+const THREAD_SNAPSHOT_TIMEOUT_MS = 10_000;
 
 type FetchFn = (input: string, init?: RequestInit) => Promise<Response>;
 type AgentThreadSnapshot = z.infer<typeof AgentThreadSnapshotSchema>;
@@ -90,6 +91,40 @@ export async function createCodingAgentThread(
   const parsed = AgentThreadSnapshotSchema.safeParse(body);
   if (!parsed.success) {
     throw new Error("agent thread unavailable");
+  }
+  return parsed.data;
+}
+
+export async function fetchCodingAgentThreadSnapshot(
+  auth: AuthService,
+  options: { threadId: string },
+  fetchFn: FetchFn = fetch,
+): Promise<AgentThreadSnapshot> {
+  const token = auth.getToken();
+  if (!token) {
+    throw new Error("thread state unavailable");
+  }
+
+  const url = new URL(
+    `/api/coding-agents/threads/${encodeURIComponent(options.threadId)}`,
+    auth.getGatewayOrigin(),
+  );
+  const res = await fetchFn(url.toString(), {
+    method: "GET",
+    headers: {
+      Authorization: `Bearer ${token}`,
+      Accept: "application/json",
+    },
+    signal: AbortSignal.timeout(THREAD_SNAPSHOT_TIMEOUT_MS),
+  });
+  if (!res.ok) {
+    throw new Error("thread state unavailable");
+  }
+
+  const body = await res.json();
+  const parsed = AgentThreadSnapshotSchema.safeParse(body);
+  if (!parsed.success) {
+    throw new Error("thread state unavailable");
   }
   return parsed.data;
 }

--- a/desktop/src/main/index.ts
+++ b/desktop/src/main/index.ts
@@ -6,6 +6,7 @@ import { installGatewayCors, installHeaderInjection } from "./auth/header-inject
 import { EmbedService } from "./embeds/embed-service";
 import {
   createCodingAgentThread,
+  fetchCodingAgentThreadSnapshot,
   fetchCodingAgentReviewSnapshot,
   fetchCodingAgentReviewSummaries,
   fetchCodingAgentRuntimeSummary,
@@ -235,6 +236,7 @@ if (!gotLock) {
         fetchRuntimeSummary: () => fetchCodingAgentRuntimeSummary(auth),
         fetchReviewSummaries: (options) => fetchCodingAgentReviewSummaries(auth, options),
         fetchReviewSnapshot: (options) => fetchCodingAgentReviewSnapshot(auth, options),
+        fetchThreadSnapshot: (options) => fetchCodingAgentThreadSnapshot(auth, options),
         createAgentThread: (request) => createCodingAgentThread(auth, request),
       });
 

--- a/desktop/src/main/ipc/handlers.ts
+++ b/desktop/src/main/ipc/handlers.ts
@@ -31,6 +31,9 @@ export interface HandlerContext {
     options: { cursor?: string },
   ) => Promise<{ items: ReviewSummary[]; hasMore: boolean; limit: number; nextCursor?: string }>;
   fetchReviewSnapshot: (options: { reviewId: string }) => Promise<ReviewSnapshot>;
+  fetchThreadSnapshot: (
+    options: { threadId: string },
+  ) => Promise<z.infer<typeof AgentThreadSnapshotSchema>>;
   createAgentThread: (
     request: CreateAgentThreadRequest,
   ) => Promise<z.infer<typeof AgentThreadSnapshotSchema>>;
@@ -92,6 +95,7 @@ export function registerIpcHandlers(ipcMain: IpcMainLike, ctx: HandlerContext): 
   handle("runtime:get-summary", () => ctx.fetchRuntimeSummary());
   handle("runtime:get-reviews", (request) => ctx.fetchReviewSummaries(request));
   handle("runtime:get-review-snapshot", (request) => ctx.fetchReviewSnapshot(request));
+  handle("runtime:get-thread-snapshot", (request) => ctx.fetchThreadSnapshot(request));
   handle("runtime:create-thread", (request) => ctx.createAgentThread(request));
 
   handle("state:get", async ({ key }) => ({

--- a/desktop/src/renderer/src/features/coding-agents/AgentWorkspace.tsx
+++ b/desktop/src/renderer/src/features/coding-agents/AgentWorkspace.tsx
@@ -2,6 +2,8 @@ import { Bot, ChevronRight, ClipboardCheck, FileText, GitBranch, Play, RefreshCw
 import { useEffect, useMemo, useState } from "react";
 import {
   defaultAgentThreadComposerDraft,
+  type AgentThreadEvent,
+  type AgentThreadSnapshot,
   type AgentThreadComposerDraft,
   type ReviewSnapshot,
   type ReviewSummary,
@@ -28,6 +30,7 @@ const STATUS_COLOR: Record<string, string> = {
 };
 const DEFAULT_STATUS_COLOR = "var(--text-tertiary)";
 type ReviewDetailStatus = "idle" | "loading" | "ready" | "error";
+type ThreadDetailStatus = "idle" | "loading" | "ready" | "error";
 type ReviewSnapshotFile = ReviewSnapshot["files"]["items"][number];
 type ReviewSnapshotHunk = ReviewSnapshotFile["hunks"][number];
 type ReviewSnapshotLine = NonNullable<ReviewSnapshotHunk["lines"]>[number];
@@ -337,6 +340,7 @@ function AgentComposer({ summary, seed }: { summary: RuntimeSummary; seed: Compo
 function ThreadList({ summary }: { summary: RuntimeSummary }) {
   const openTab = useTabs((s) => s.openTab);
   const activeThreadId = useCodingAgentWorkspace((s) => s.activeThreadId);
+  const loadThreadSnapshot = useCodingAgentWorkspace((s) => s.loadThreadSnapshot);
   const findAttachableSessionName = (sessionId: string): string | null =>
     summary.terminalSessions.items.find((session) => session.id === sessionId && session.attachable)?.name ?? null;
 
@@ -385,6 +389,14 @@ function ThreadList({ summary }: { summary: RuntimeSummary }) {
                 <span className="text-xs capitalize" style={{ color: "var(--text-secondary)" }}>
                   {thread.status.replace(/_/g, " ")}
                 </span>
+                <Button
+                  variant="ghost"
+                  aria-label={`Open details for ${thread.title}`}
+                  title={`Open details for ${thread.title}`}
+                  onClick={() => void loadThreadSnapshot(thread.id)}
+                >
+                  <ChevronRight size={14} />
+                </Button>
               </div>
             </article>
           );
@@ -397,6 +409,153 @@ function ThreadList({ summary }: { summary: RuntimeSummary }) {
       </div>
     </Section>
   );
+}
+
+function ThreadSnapshotPanel({
+  status,
+  snapshot,
+  error,
+}: {
+  status: ThreadDetailStatus;
+  snapshot: AgentThreadSnapshot | null;
+  error: string | null;
+}) {
+  if (status === "idle") return null;
+  if (status === "loading") {
+    return (
+      <p className="rounded-md border p-3 text-sm" style={{ borderColor: "var(--border-subtle)", color: "var(--text-secondary)" }}>
+        Loading thread details...
+      </p>
+    );
+  }
+  if (status === "error") {
+    return (
+      <p className="rounded-md border p-3 text-sm" style={{ borderColor: "var(--border-subtle)", color: "var(--danger)" }}>
+        {error ?? "Thread state unavailable"}
+      </p>
+    );
+  }
+  if (!snapshot) return null;
+
+  return (
+    <article
+      className="ph-no-capture grid gap-3 rounded-md border p-3"
+      style={{ borderColor: "var(--border-subtle)", background: "var(--bg-surface)" }}
+    >
+      <div className="flex items-center justify-between gap-3">
+        <div className="min-w-0">
+          <h2 className="truncate text-sm font-semibold" style={{ color: "var(--text-primary)" }}>
+            Thread details
+          </h2>
+          <p className="truncate text-xs" style={{ color: "var(--text-tertiary)" }}>
+            {snapshot.thread.title}
+          </p>
+        </div>
+        <span className="shrink-0 text-xs capitalize" style={{ color: "var(--text-secondary)" }}>
+          {snapshot.thread.status.replace(/_/g, " ")}
+        </span>
+      </div>
+      <dl className="grid grid-cols-2 gap-2 text-xs md:grid-cols-4">
+        <div>
+          <dt style={{ color: "var(--text-tertiary)" }}>Provider</dt>
+          <dd className="truncate" style={{ color: "var(--text-secondary)" }}>{snapshot.thread.providerId}</dd>
+        </div>
+        <div>
+          <dt style={{ color: "var(--text-tertiary)" }}>Terminal</dt>
+          <dd className="truncate" style={{ color: "var(--text-secondary)" }}>
+            {snapshot.thread.terminalSessionId ?? "Not bound"}
+          </dd>
+        </div>
+        <div>
+          <dt style={{ color: "var(--text-tertiary)" }}>Updated</dt>
+          <dd className="truncate" style={{ color: "var(--text-secondary)" }}>{snapshot.thread.updatedAt}</dd>
+        </div>
+        <div>
+          <dt style={{ color: "var(--text-tertiary)" }}>Events</dt>
+          <dd className="truncate" style={{ color: "var(--text-secondary)" }}>{snapshot.events.items.length}</dd>
+        </div>
+      </dl>
+      <div className="grid gap-2">
+        {snapshot.events.items.map((event) => (
+          <ThreadEventRow key={event.eventId} event={event} />
+        ))}
+        {snapshot.events.items.length === 0 ? (
+          <p className="rounded-md border p-3 text-sm" style={{ borderColor: "var(--border-subtle)", color: "var(--text-secondary)" }}>
+            No thread events yet.
+          </p>
+        ) : null}
+      </div>
+    </article>
+  );
+}
+
+function ThreadEventRow({ event }: { event: AgentThreadEvent }) {
+  const copy = describeThreadEvent(event);
+  return (
+    <div
+      className="grid gap-1 rounded-md border px-3 py-2"
+      style={{ borderColor: "var(--border-subtle)", background: "var(--bg-overlay)" }}
+    >
+      <div className="flex items-center justify-between gap-3">
+        <p className="text-sm font-medium" style={{ color: "var(--text-primary)" }}>
+          {copy.title}
+        </p>
+        <span className="shrink-0 text-xs" style={{ color: "var(--text-tertiary)" }}>
+          {event.occurredAt}
+        </span>
+      </div>
+      <p className="text-xs" style={{ color: "var(--text-secondary)" }}>
+        {copy.detail}
+      </p>
+    </div>
+  );
+}
+
+function describeThreadEvent(event: AgentThreadEvent): { title: string; detail: string } {
+  switch (event.type) {
+    case "thread.created":
+      return { title: "Thread created", detail: event.thread.title };
+    case "thread.status":
+      return { title: "Status changed", detail: event.status.replace(/_/g, " ") };
+    case "assistant.text.delta":
+      return { title: "Assistant update", detail: "Text update received" };
+    case "assistant.text.completed":
+      return { title: "Assistant message complete", detail: "Message complete" };
+    case "tool.started":
+      return { title: "Tool started", detail: event.displayName };
+    case "tool.output":
+      return { title: "Tool output", detail: event.truncated ? "Output received, partial" : "Output received" };
+    case "tool.completed":
+      return { title: "Tool completed", detail: event.outcome };
+    case "approval.requested":
+      return { title: "Approval needed", detail: event.approval.safeDescription };
+    case "approval.resolved":
+      return { title: "Approval resolved", detail: event.decision };
+    case "user_input.requested":
+      return { title: "Input needed", detail: event.request.safeDescription };
+    case "user_input.answered":
+      return { title: "Input answered", detail: "Input answer received" };
+    case "file.changed":
+      return { title: `File ${event.changeKind}`, detail: `${capitalize(event.changeKind)} file` };
+    case "review.ready": {
+      const files = `${event.summary.changedFileCount} ${event.summary.changedFileCount === 1 ? "file" : "files"} changed`;
+      const partial = event.summary.partial ? ", partial" : "";
+      return { title: "Review ready", detail: `${files}, +${event.summary.additions} -${event.summary.deletions}${partial}` };
+    }
+    case "terminal.bound":
+      return { title: "Terminal bound", detail: event.terminalSessionId };
+    case "thread.error":
+      return {
+        title: "Thread needs attention",
+        detail: event.error.retryable ? "Refresh the thread or check the runtime." : "Open the workspace again.",
+      };
+    case "thread.completed":
+      return { title: "Thread completed", detail: event.outcome };
+  }
+}
+
+function capitalize(value: string): string {
+  return `${value.slice(0, 1).toUpperCase()}${value.slice(1)}`;
 }
 
 function TerminalList({ summary }: { summary: RuntimeSummary }) {
@@ -794,11 +953,22 @@ export default function AgentWorkspace() {
   const summary = useCodingAgentWorkspace((s) => s.summary);
   const error = useCodingAgentWorkspace((s) => s.error);
   const refresh = useCodingAgentWorkspace((s) => s.refresh);
+  const activeThreadId = useCodingAgentWorkspace((s) => s.activeThreadId);
+  const threadSnapshotStatus = useCodingAgentWorkspace((s) => s.threadSnapshotStatus);
+  const threadSnapshot = useCodingAgentWorkspace((s) => s.threadSnapshot);
+  const threadSnapshotError = useCodingAgentWorkspace((s) => s.threadSnapshotError);
+  const loadThreadSnapshot = useCodingAgentWorkspace((s) => s.loadThreadSnapshot);
   const [composerSeed, setComposerSeed] = useState<ComposerSeed | null>(null);
 
   useEffect(() => {
     void refresh();
   }, [refresh, runtimeSlot]);
+
+  useEffect(() => {
+    if (!activeThreadId) return;
+    if (threadSnapshotStatus === "ready" && threadSnapshot?.thread.id === activeThreadId) return;
+    void loadThreadSnapshot(activeThreadId);
+  }, [activeThreadId, loadThreadSnapshot, runtimeSlot, threadSnapshot?.thread.id, threadSnapshotStatus]);
 
   if (status === "loading" && !summary) {
     return (
@@ -833,7 +1003,14 @@ export default function AgentWorkspace() {
         <ProviderList summary={summary} />
         <div className="grid gap-4 xl:grid-cols-2">
           <ThreadList summary={summary} />
-          <TerminalList summary={summary} />
+          <div className="grid gap-4">
+            <ThreadSnapshotPanel
+              status={threadSnapshotStatus}
+              snapshot={threadSnapshot}
+              error={threadSnapshotError}
+            />
+            <TerminalList summary={summary} />
+          </div>
         </div>
         {capabilityEnabled(summary, "codingAgentsReview") ? (
           <ReviewList

--- a/desktop/src/renderer/src/stores/coding-agent-workspace.ts
+++ b/desktop/src/renderer/src/stores/coding-agent-workspace.ts
@@ -1,5 +1,6 @@
 import {
   buildCreateAgentThreadRequestFromComposer,
+  type AgentThreadSnapshot,
   type AgentThreadComposerDraft,
   type ReviewSnapshot,
   type ReviewSummary,
@@ -29,17 +30,22 @@ interface CodingAgentWorkspaceState {
   reviewSnapshotStatus: ReviewStatus;
   reviewSnapshot: ReviewSnapshot | null;
   reviewSnapshotError: string | null;
+  threadSnapshotStatus: ReviewStatus;
+  threadSnapshot: AgentThreadSnapshot | null;
+  threadSnapshotError: string | null;
   createStatus: CreateStatus;
   createError: string | null;
   activeThreadId: string | null;
   refresh: () => Promise<void>;
   selectReview: (reviewId: string) => Promise<void>;
+  loadThreadSnapshot: (threadId: string) => Promise<void>;
   createThread: (draft: AgentThreadComposerDraft) => Promise<string | null>;
 }
 
 let refreshSeq = 0;
 let reviewsSeq = 0;
 let reviewSnapshotSeq = 0;
+let threadSnapshotSeq = 0;
 let createRequestSeq = 0;
 
 function clearReviewSelectionState() {
@@ -49,6 +55,15 @@ function clearReviewSelectionState() {
     reviewSnapshotStatus: "idle" as const,
     reviewSnapshot: null,
     reviewSnapshotError: null,
+  };
+}
+
+function clearThreadSnapshotState() {
+  threadSnapshotSeq += 1;
+  return {
+    threadSnapshotStatus: "idle" as const,
+    threadSnapshot: null,
+    threadSnapshotError: null,
   };
 }
 
@@ -68,6 +83,9 @@ export const useCodingAgentWorkspace = create<CodingAgentWorkspaceState>()((set)
   reviewSnapshotStatus: "idle",
   reviewSnapshot: null,
   reviewSnapshotError: null,
+  threadSnapshotStatus: "idle",
+  threadSnapshot: null,
+  threadSnapshotError: null,
   createStatus: "idle",
   createError: null,
   activeThreadId: null,
@@ -81,7 +99,22 @@ export const useCodingAgentWorkspace = create<CodingAgentWorkspaceState>()((set)
     try {
       const summary = await invoke("runtime:get-summary", {});
       if (seq !== refreshSeq) return;
-      set({ status: "ready", summary, error: null });
+      set((state) => {
+        const activeThreadStillPresent = state.activeThreadId
+          ? summary.activeThreads.items.some((thread) => thread.id === state.activeThreadId)
+          : true;
+        return {
+          status: "ready",
+          summary,
+          error: null,
+          ...(activeThreadStillPresent
+            ? {}
+            : {
+                activeThreadId: null,
+                ...clearThreadSnapshotState(),
+              }),
+        };
+      });
       if (!summary.capabilities.some((capability) => capability.id === "codingAgentsReview" && capability.enabled)) {
         set({
           reviewsStatus: "idle",
@@ -131,6 +164,7 @@ export const useCodingAgentWorkspace = create<CodingAgentWorkspaceState>()((set)
         reviews: null,
         reviewsError: null,
         ...clearReviewSelectionState(),
+        ...clearThreadSnapshotState(),
       });
     }
   },
@@ -164,6 +198,35 @@ export const useCodingAgentWorkspace = create<CodingAgentWorkspaceState>()((set)
     }
   },
 
+  loadThreadSnapshot: async (threadId) => {
+    const seq = ++threadSnapshotSeq;
+    set((state) => ({
+      activeThreadId: threadId,
+      threadSnapshotStatus: state.threadSnapshot?.thread.id === threadId ? "ready" : "loading",
+      threadSnapshot: state.threadSnapshot?.thread.id === threadId ? state.threadSnapshot : null,
+      threadSnapshotError: null,
+    }));
+    try {
+      const snapshot = await invoke("runtime:get-thread-snapshot", { threadId });
+      if (seq !== threadSnapshotSeq) return;
+      set({
+        activeThreadId: threadId,
+        threadSnapshotStatus: "ready",
+        threadSnapshot: snapshot,
+        threadSnapshotError: null,
+      });
+    } catch {
+      console.warn("[coding-agents] thread snapshot refresh failed");
+      if (seq !== threadSnapshotSeq) return;
+      set({
+        activeThreadId: threadId,
+        threadSnapshotStatus: "error",
+        threadSnapshot: null,
+        threadSnapshotError: "Thread state unavailable",
+      });
+    }
+  },
+
   createThread: async (draft) => {
     const { summary, createStatus } = useCodingAgentWorkspace.getState();
     if (createStatus === "submitting") {
@@ -191,7 +254,14 @@ export const useCodingAgentWorkspace = create<CodingAgentWorkspaceState>()((set)
       set((state) => {
         const currentSummary = state.summary;
         if (!currentSummary) {
-          return { createStatus: "idle", activeThreadId: thread.id, createError: null };
+          return {
+            createStatus: "idle",
+            activeThreadId: thread.id,
+            threadSnapshotStatus: "ready",
+            threadSnapshot: snapshot,
+            threadSnapshotError: null,
+            createError: null,
+          };
         }
         const limit = currentSummary.activeThreads.limit;
         const items = [
@@ -201,6 +271,9 @@ export const useCodingAgentWorkspace = create<CodingAgentWorkspaceState>()((set)
         return {
           createStatus: "idle",
           activeThreadId: thread.id,
+          threadSnapshotStatus: "ready",
+          threadSnapshot: snapshot,
+          threadSnapshotError: null,
           createError: null,
           summary: {
             ...currentSummary,

--- a/desktop/src/shared/ipc-contract.ts
+++ b/desktop/src/shared/ipc-contract.ts
@@ -10,6 +10,7 @@ import {
   ReviewSnapshotSchema,
   ReviewSummarySchema,
   RuntimeSummarySchema,
+  ThreadIdSchema,
   boundedListSchema,
 } from "@matrix-os/contracts";
 
@@ -115,6 +116,10 @@ export const INVOKE_CHANNELS = {
   "runtime:get-review-snapshot": {
     request: z.object({ reviewId: ReviewIdSchema }).strict(),
     response: ReviewSnapshotSchema,
+  },
+  "runtime:get-thread-snapshot": {
+    request: z.object({ threadId: ThreadIdSchema }).strict(),
+    response: AgentThreadSnapshotSchema,
   },
   "runtime:create-thread": {
     request: CreateAgentThreadRequestSchema,

--- a/specs/105-coding-agent-shells/current-state.md
+++ b/specs/105-coding-agent-shells/current-state.md
@@ -1,12 +1,12 @@
 # Current State: Coding Agent Shells
 
-**Branch stack**: `spec/coding-agent-shells` plus stacked implementation branches through `105-coding-agent-desktop-notification-focus`
+**Branch stack**: `spec/coding-agent-shells` plus stacked implementation branches through `105-coding-agent-desktop-thread-detail`
 **Updated**: 2026-07-07
 **Scope**: Inventory for the coding-agent desktop/mobile shell work. This file records the current Matrix-native route, contract, client, and regression-test state so later slices keep gateway/runtime as source of truth and keep desktop/mobile as thin shells.
 
 ## Summary
 
-The stack currently has shared contracts, a gateway runtime summary read model, read-only desktop and mobile workspaces behind flags, thread create/replay/abort/event streaming, provider adapters, a workspace-backed provider, approval/input route handling, a read-only coding-agent review summary route/client contract, desktop/mobile read-only review summary panels, and a read-only coding-agent review snapshot route with bounded file metadata from safe owner worktree diffs plus findings fallback metadata. Review snapshots can include bounded per-hunk diff lines with truncation markers. Desktop and mobile review details render changed-file counts, selectable hunk coordinate metadata, and gateway-bounded diff lines. Desktop and mobile can seed their existing agent composers from a selected review hunk using bounded prompt context and a `structured_ref` attachment. Mobile active thread rows now open a bounded thread detail route that hydrates `AgentThreadSnapshotSchema` through the authenticated gateway client, renders safe thread metadata, event counts, and a read-only snapshot event timeline, and can hand a bound canonical terminal session to the existing mobile Terminal tab. Desktop active thread rows can open a matching attachable bound canonical terminal session in the existing Terminal tab model. Desktop native notification clicks focus the Agents tab and visibly select the bounded coding-agent workspace thread reference in the active thread list. Full file content and preview coding-agent surfaces are contract-only or existing workspace routes; dedicated preview shell UI is not yet integrated.
+The stack currently has shared contracts, a gateway runtime summary read model, read-only desktop and mobile workspaces behind flags, thread create/replay/abort/event streaming, provider adapters, a workspace-backed provider, approval/input route handling, a read-only coding-agent review summary route/client contract, desktop/mobile read-only review summary panels, and a read-only coding-agent review snapshot route with bounded file metadata from safe owner worktree diffs plus findings fallback metadata. Review snapshots can include bounded per-hunk diff lines with truncation markers. Desktop and mobile review details render changed-file counts, selectable hunk coordinate metadata, and gateway-bounded diff lines. Desktop and mobile can seed their existing agent composers from a selected review hunk using bounded prompt context and a `structured_ref` attachment. Mobile active thread rows now open a bounded thread detail route that hydrates `AgentThreadSnapshotSchema` through the authenticated gateway client, renders safe thread metadata, event counts, and a read-only snapshot event timeline, and can hand a bound canonical terminal session to the existing mobile Terminal tab. Desktop active thread rows can open a matching attachable bound canonical terminal session in the existing Terminal tab model and selected desktop threads now hydrate `AgentThreadSnapshotSchema` through trusted main-process IPC for safe read-only metadata and event timeline rendering. Desktop native notification clicks focus the Agents tab and visibly select the bounded coding-agent workspace thread reference in the active thread list. Full file content and preview coding-agent surfaces are contract-only or existing workspace routes; dedicated preview shell UI is not yet integrated.
 
 Current source-of-truth boundaries:
 
@@ -184,6 +184,7 @@ IPC contract:
 
 - `desktop/src/shared/ipc-contract.ts`
 - `runtime:get-summary` returns `RuntimeSummarySchema`.
+- `runtime:get-thread-snapshot` accepts a bounded `threadId` and returns `AgentThreadSnapshotSchema`.
 - `runtime:get-reviews` returns a bounded list of `ReviewSummarySchema` rows from the trusted main process.
 - `notify` accepts bounded notification data with `threadId`, `title`, `body`, and kind.
 - `notification:clicked` emits bounded `threadId`.
@@ -192,8 +193,9 @@ Main process:
 
 - `desktop/src/main/coding-agents/runtime-summary-client.ts`
 - Fetches `/api/coding-agents/summary` from the selected runtime origin with bearer auth in the main process.
+- Fetches `/api/coding-agents/threads/:threadId` from the selected runtime origin with bearer auth in the main process and validates `AgentThreadSnapshotSchema`.
 - Fetches `/api/coding-agents/reviews` from the selected runtime origin with bearer auth in the main process.
-- Uses `AbortSignal.timeout(10_000)` and validates `RuntimeSummarySchema` or bounded `ReviewSummarySchema` lists.
+- Uses `AbortSignal.timeout(10_000)` and validates `RuntimeSummarySchema`, `AgentThreadSnapshotSchema`, or bounded `ReviewSummarySchema` lists.
 - Renderer receives only parsed summary data through IPC.
 
 Renderer:
@@ -207,6 +209,7 @@ Current behavior:
 
 - Read-only dashboard renders providers, active threads, and terminals.
 - Active thread rows with a matching attachable `terminalSessionId` can open the existing desktop Terminal tab for that canonical session; stale or unavailable terminal bindings do not render an action.
+- Selected active threads hydrate a bounded thread snapshot through `runtime:get-thread-snapshot`, show provider/status/terminal metadata, event counts, loading and safe generic error states, and render gateway-bounded snapshot events with generic copy for assistant text, tool output, file changes, and unsafe runtime errors.
 - Native notification clicks carrying a bounded `threadId` focus the existing Agents tab and visibly mark that thread current in the coding-agent workspace thread list while preserving the legacy thread-store selection path.
 - When the runtime advertises `codingAgentsReview`, the dashboard fetches bounded review summaries through the trusted main-process IPC route and renders project, PR, round, status, and high-severity count.
 - Review snapshot details render bounded file paths, additions/deletions, partial markers, selectable hunk coordinate metadata, gateway-bounded hunk lines, and safe finding summaries. Diff line containers are blocked from session recording.
@@ -219,6 +222,9 @@ Current behavior:
 Focused tests:
 
 - `tests/desktop/coding-agent-workspace.test.tsx`
+- `tests/desktop/coding-agent-runtime-client.test.ts`
+- `tests/desktop/ipc-contract.test.ts`
+- `tests/desktop/ipc-handlers.test.ts`
 - `tests/desktop/kernel-wiring.test.ts`
 
 ## Mobile Shell State

--- a/tests/desktop/coding-agent-runtime-client.test.ts
+++ b/tests/desktop/coding-agent-runtime-client.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import {
+  fetchCodingAgentThreadSnapshot,
   fetchCodingAgentReviewSnapshot,
 } from "../../desktop/src/main/coding-agents/runtime-summary-client";
 import type { AuthService } from "../../desktop/src/main/auth/auth-service";
@@ -58,7 +59,77 @@ function snapshotBody() {
   };
 }
 
+function threadSnapshotBody() {
+  return {
+    thread: {
+      id: "thread_desktop_1",
+      providerId: "codex",
+      title: "Fix desktop notifications",
+      status: "waiting_for_approval",
+      attention: "approval_required",
+      terminalSessionId: "matrix-abc1234",
+      createdAt: "2026-07-06T00:00:00.000Z",
+      updatedAt: "2026-07-06T00:01:00.000Z",
+    },
+    events: {
+      items: [
+        {
+          type: "approval.requested",
+          eventId: "evt_approval_1",
+          threadId: "thread_desktop_1",
+          occurredAt: "2026-07-06T00:01:00.000Z",
+          approval: {
+            approvalId: "appr_desktop_1",
+            threadId: "thread_desktop_1",
+            actionKind: "command",
+            risk: "medium",
+            title: "Run tests",
+            safeDescription: "Run the focused desktop tests.",
+            allowedDecisions: ["approve", "decline"],
+            correlationId: "corr_desktop_1",
+          },
+        },
+      ],
+      hasMore: false,
+      limit: 200,
+    },
+  };
+}
+
 describe("coding agent desktop runtime client", () => {
+  it("fetches thread snapshots with bearer auth and validates safe output", async () => {
+    const fetchFn = vi.fn().mockResolvedValue(new Response(JSON.stringify(threadSnapshotBody()), { status: 200 }));
+
+    const snapshot = await fetchCodingAgentThreadSnapshot(auth(), { threadId: "thread_desktop_1" }, fetchFn);
+
+    expect(fetchFn).toHaveBeenCalledWith(
+      "https://runtime.test/api/coding-agents/threads/thread_desktop_1",
+      expect.objectContaining({
+        method: "GET",
+        headers: expect.objectContaining({
+          Authorization: "Bearer desktop-token",
+          Accept: "application/json",
+        }),
+        signal: expect.any(AbortSignal),
+      }),
+    );
+    expect(snapshot.thread.id).toBe("thread_desktop_1");
+    expect(snapshot.events.items[0]?.type).toBe("approval.requested");
+  });
+
+  it("rejects unsafe or malformed thread snapshot responses with a generic error", async () => {
+    const fetchFn = vi.fn().mockResolvedValue(new Response(JSON.stringify({
+      ...threadSnapshotBody(),
+      thread: {
+        ...threadSnapshotBody().thread,
+        accessToken: "secret",
+      },
+    }), { status: 200 }));
+
+    await expect(fetchCodingAgentThreadSnapshot(auth(), { threadId: "thread_desktop_1" }, fetchFn)).rejects.toThrow("thread state unavailable");
+    await expect(fetchCodingAgentThreadSnapshot(auth(), { threadId: "thread_desktop_1" }, fetchFn)).rejects.not.toThrow("secret");
+  });
+
   it("fetches review snapshots with bearer auth and validates safe output", async () => {
     const fetchFn = vi.fn().mockResolvedValue(new Response(JSON.stringify(snapshotBody()), { status: 200 }));
 

--- a/tests/desktop/coding-agent-workspace.test.tsx
+++ b/tests/desktop/coding-agent-workspace.test.tsx
@@ -194,6 +194,43 @@ function reviewSnapshotFixture() {
   };
 }
 
+function threadSnapshotFixture() {
+  return {
+    thread: {
+      id: "thread_alpha",
+      providerId: "codex",
+      title: "Fix settings route",
+      status: "waiting_for_approval",
+      attention: "approval_required",
+      terminalSessionId: "matrix-abc1234",
+      createdAt: "2026-07-06T00:00:00.000Z",
+      updatedAt: "2026-07-06T00:04:00.000Z",
+    },
+    events: {
+      items: [
+        {
+          type: "approval.requested",
+          eventId: "evt_approval_desktop_1",
+          threadId: "thread_alpha",
+          occurredAt: "2026-07-06T00:03:00.000Z",
+          approval: {
+            approvalId: "appr_desktop_1",
+            threadId: "thread_alpha",
+            actionKind: "command",
+            risk: "medium",
+            title: "Run tests",
+            safeDescription: "Run the focused desktop tests.",
+            allowedDecisions: ["approve", "decline"],
+            correlationId: "corr_desktop_1",
+          },
+        },
+      ],
+      hasMore: false,
+      limit: 200,
+    },
+  };
+}
+
 describe("AgentWorkspace", () => {
   beforeEach(() => {
     useCodingAgentWorkspace.setState({
@@ -207,6 +244,9 @@ describe("AgentWorkspace", () => {
       reviewSnapshotStatus: "idle",
       reviewSnapshot: null,
       reviewSnapshotError: null,
+      threadSnapshotStatus: "idle",
+      threadSnapshot: null,
+      threadSnapshotError: null,
       createStatus: "idle",
       createError: null,
       activeThreadId: null,
@@ -224,6 +264,7 @@ describe("AgentWorkspace", () => {
         if (channel === "runtime:get-summary") return Promise.resolve(summaryFixture());
         if (channel === "runtime:get-reviews") return Promise.resolve(reviewsFixture());
         if (channel === "runtime:get-review-snapshot") return Promise.resolve(reviewSnapshotFixture());
+        if (channel === "runtime:get-thread-snapshot") return Promise.resolve(threadSnapshotFixture());
         return Promise.reject(new Error("unexpected channel"));
       }),
       on: vi.fn(() => () => undefined),
@@ -253,6 +294,51 @@ describe("AgentWorkspace", () => {
 
     const activeThread = await screen.findByLabelText("Active thread Fix settings route");
     expect(activeThread.getAttribute("aria-current")).toBe("true");
+  });
+
+  it("hydrates selected thread details through trusted IPC", async () => {
+    useCodingAgentWorkspace.setState({ activeThreadId: "thread_alpha" });
+
+    render(<AgentWorkspace />);
+
+    expect(await screen.findByText("Thread details")).toBeTruthy();
+    expect(screen.getByText("waiting for approval")).toBeTruthy();
+    expect(screen.getAllByText("matrix-abc1234").length).toBeGreaterThanOrEqual(1);
+    expect(screen.getByText("Approval needed")).toBeTruthy();
+    expect(screen.getByText("Run the focused desktop tests.")).toBeTruthy();
+    expect(screen.queryByText(/home\/matrix|token|secret/i)).toBeNull();
+    expect(window.operator.invoke).toHaveBeenCalledWith("runtime:get-thread-snapshot", { threadId: "thread_alpha" });
+  });
+
+  it("clears selected thread details when the refreshed summary no longer includes the thread", async () => {
+    useCodingAgentWorkspace.setState({ activeThreadId: "thread_alpha" });
+
+    render(<AgentWorkspace />);
+
+    expect(await screen.findByText("Thread details")).toBeTruthy();
+
+    const refreshedSummary = {
+      ...summaryFixture(),
+      activeThreads: {
+        items: [],
+        hasMore: false,
+        limit: 20,
+      },
+    };
+    window.operator.invoke = vi.fn((channel: string) => {
+      if (channel === "runtime:get-summary") return Promise.resolve(refreshedSummary);
+      if (channel === "runtime:get-reviews") return Promise.resolve(reviewsFixture());
+      return Promise.reject(new Error("unexpected channel"));
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Refresh agent workspace" }));
+
+    await waitFor(() => {
+      expect(screen.queryByText("Thread details")).toBeNull();
+    });
+    expect(useCodingAgentWorkspace.getState().activeThreadId).toBeNull();
+    expect(useCodingAgentWorkspace.getState().threadSnapshot).toBeNull();
+    expect(screen.getByText("No active threads.")).toBeTruthy();
   });
 
   it("opens a bound thread terminal in the existing terminal tab model", async () => {

--- a/tests/desktop/ipc-contract.test.ts
+++ b/tests/desktop/ipc-contract.test.ts
@@ -14,6 +14,7 @@ describe("IPC contract", () => {
       "auth:status",
       "auth:sign-out",
       "runtime:create-thread",
+      "runtime:get-thread-snapshot",
       "runtime:get-review-snapshot",
       "runtime:get-reviews",
       "runtime:get-summary",
@@ -66,6 +67,53 @@ describe("IPC contract", () => {
         },
       }).success,
     ).toBe(true);
+  });
+
+  it("validates runtime:get-thread-snapshot requests and rejects credential leakage shapes", () => {
+    const requestSchema = INVOKE_CHANNELS["runtime:get-thread-snapshot"].request;
+    const schema = INVOKE_CHANNELS["runtime:get-thread-snapshot"].response;
+    const valid = {
+      thread: {
+        id: "thread_desktop_1",
+        providerId: "codex",
+        title: "Fix desktop notifications",
+        status: "waiting_for_approval",
+        attention: "approval_required",
+        createdAt: "2026-07-06T00:00:00.000Z",
+        updatedAt: "2026-07-06T00:01:00.000Z",
+      },
+      events: {
+        items: [
+          {
+            type: "approval.requested",
+            eventId: "evt_approval_1",
+            threadId: "thread_desktop_1",
+            occurredAt: "2026-07-06T00:01:00.000Z",
+            approval: {
+              approvalId: "appr_desktop_1",
+              threadId: "thread_desktop_1",
+              actionKind: "command",
+              risk: "medium",
+              title: "Run tests",
+              safeDescription: "Run the focused desktop tests.",
+              allowedDecisions: ["approve", "decline"],
+              correlationId: "corr_desktop_1",
+            },
+          },
+        ],
+        hasMore: false,
+        limit: 200,
+      },
+    };
+
+    expect(requestSchema.safeParse({ threadId: "thread_desktop_1" }).success).toBe(true);
+    expect(requestSchema.safeParse({ threadId: "../secret" }).success).toBe(false);
+    expect(schema.safeParse(valid).success).toBe(true);
+    expect(schema.safeParse({ ...valid, accessToken: "secret" }).success).toBe(false);
+    expect(schema.safeParse({
+      ...valid,
+      thread: { ...valid.thread, providerSecret: "secret" },
+    }).success).toBe(false);
   });
 
   it("validates runtime:get-summary responses and rejects credential leakage shapes", () => {

--- a/tests/desktop/ipc-handlers.test.ts
+++ b/tests/desktop/ipc-handlers.test.ts
@@ -39,6 +39,7 @@ function makeHarness(overrides: Partial<HandlerContext> = {}) {
     fetchRuntimeSummary: vi.fn(),
     fetchReviewSummaries: vi.fn(),
     fetchReviewSnapshot: vi.fn(),
+    fetchThreadSnapshot: vi.fn(),
     createAgentThread: vi.fn(),
     ...overrides,
   } as unknown as HandlerContext;
@@ -264,6 +265,57 @@ describe("registerIpcHandlers", () => {
 
     await expect(harness.invoke("runtime:get-review-snapshot", { reviewId: "rev_desktop_1" })).rejects.toThrow("internal error");
     await expect(harness.invoke("runtime:get-review-snapshot", { reviewId: "rev_desktop_1" })).rejects.not.toThrow("/home/matrix");
+  });
+
+  it("returns a coding agent thread snapshot through a strict trusted-core IPC channel", async () => {
+    const snapshot = {
+      thread: {
+        id: "thread_desktop_1",
+        providerId: "codex",
+        title: "Fix desktop notifications",
+        status: "waiting_for_approval",
+        attention: "approval_required",
+        createdAt: "2026-07-06T00:00:00.000Z",
+        updatedAt: "2026-07-06T00:01:00.000Z",
+      },
+      events: {
+        items: [
+          {
+            type: "approval.requested",
+            eventId: "evt_approval_1",
+            threadId: "thread_desktop_1",
+            occurredAt: "2026-07-06T00:01:00.000Z",
+            approval: {
+              approvalId: "appr_desktop_1",
+              threadId: "thread_desktop_1",
+              actionKind: "command",
+              risk: "medium",
+              title: "Run tests",
+              safeDescription: "Run the focused desktop tests.",
+              allowedDecisions: ["approve", "decline"],
+              correlationId: "corr_desktop_1",
+            },
+          },
+        ],
+        hasMore: false,
+        limit: 200,
+      },
+    };
+    const fetchThreadSnapshot = vi.fn().mockResolvedValue(snapshot);
+    const harness = makeHarness({ fetchThreadSnapshot } as Partial<HandlerContext>);
+
+    await expect(harness.invoke("runtime:get-thread-snapshot", { threadId: "thread_desktop_1" })).resolves.toEqual(snapshot);
+    expect(fetchThreadSnapshot).toHaveBeenCalledWith({ threadId: "thread_desktop_1" });
+  });
+
+  it("maps thread snapshot failures to a generic IPC error", async () => {
+    const fetchThreadSnapshot = vi
+      .fn()
+      .mockRejectedValue(new Error("provider failed at /home/matrix/home with token secret"));
+    const harness = makeHarness({ fetchThreadSnapshot } as Partial<HandlerContext>);
+
+    await expect(harness.invoke("runtime:get-thread-snapshot", { threadId: "thread_desktop_1" })).rejects.toThrow("internal error");
+    await expect(harness.invoke("runtime:get-thread-snapshot", { threadId: "thread_desktop_1" })).rejects.not.toThrow("/home/matrix");
   });
 
   it("creates agent threads through trusted-core IPC without exposing credentials", async () => {


### PR DESCRIPTION
## Summary

- Add trusted desktop IPC for `runtime:get-thread-snapshot` with `AgentThreadSnapshotSchema` validation.
- Hydrate selected desktop coding-agent threads through the main process and render safe read-only thread metadata plus bounded event timeline copy.
- Update the 105 current-state note and focused desktop coverage for contracts, IPC handlers, main-process fetching, and renderer behavior.

## Invariants

- Source of truth: gateway/runtime remains the source for thread snapshots and events; desktop only reads validated snapshots through main-process IPC.
- Lock/transaction scope: no persistence or write path changes in this slice.
- Acceptable orphan states: a selected thread can show a generic unavailable state if the runtime no longer returns a snapshot; existing dashboard data remains visible.
- Auth source of truth: bearer credentials stay in the Electron main process; renderer schemas do not include bearer or provider credentials.
- Deferred scope: live thread subscription, approval actions, richer transcript grouping, file content, and preview surfaces remain follow-up work.

## Validation

- `pnpm exec vitest run tests/desktop/coding-agent-runtime-client.test.ts tests/desktop/ipc-contract.test.ts tests/desktop/ipc-handlers.test.ts tests/desktop/coding-agent-workspace.test.tsx tests/desktop/kernel-wiring.test.ts --reporter=dot`
- `pnpm --filter desktop run typecheck`
- `bun run check:patterns`
- `bun run typecheck`
- `git diff --check`

## Docs

- Updated `specs/105-coding-agent-shells/current-state.md`.
