### PR TITLE
feat(desktop): handle coding agent approvals

### DIFF
--- a/desktop/src/main/coding-agents/runtime-summary-client.ts
+++ b/desktop/src/main/coding-agents/runtime-summary-client.ts
@@ -3,6 +3,7 @@ import {
   ReviewSnapshotSchema,
   ReviewSummarySchema,
   RuntimeSummarySchema,
+  type ApprovalDecisionRequest,
   type CreateAgentThreadRequest,
   type ReviewSnapshot,
   type ReviewSummary,
@@ -17,6 +18,7 @@ const REVIEW_SUMMARY_TIMEOUT_MS = 10_000;
 const REVIEW_SNAPSHOT_TIMEOUT_MS = 10_000;
 const THREAD_CREATE_TIMEOUT_MS = 15_000;
 const THREAD_SNAPSHOT_TIMEOUT_MS = 10_000;
+const APPROVAL_DECISION_TIMEOUT_MS = 10_000;
 
 type FetchFn = (input: string, init?: RequestInit) => Promise<Response>;
 type AgentThreadSnapshot = z.infer<typeof AgentThreadSnapshotSchema>;
@@ -125,6 +127,42 @@ export async function fetchCodingAgentThreadSnapshot(
   const parsed = AgentThreadSnapshotSchema.safeParse(body);
   if (!parsed.success) {
     throw new Error("thread state unavailable");
+  }
+  return parsed.data;
+}
+
+export async function submitCodingAgentApprovalDecision(
+  auth: AuthService,
+  options: { threadId: string; approvalId: string; request: ApprovalDecisionRequest },
+  fetchFn: FetchFn = fetch,
+): Promise<AgentThreadSnapshot> {
+  const token = auth.getToken();
+  if (!token) {
+    throw new Error("approval unavailable");
+  }
+
+  const url = new URL(
+    `/api/coding-agents/threads/${encodeURIComponent(options.threadId)}/approvals/${encodeURIComponent(options.approvalId)}/decision`,
+    auth.getGatewayOrigin(),
+  );
+  const res = await fetchFn(url.toString(), {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${token}`,
+      Accept: "application/json",
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(options.request),
+    signal: AbortSignal.timeout(APPROVAL_DECISION_TIMEOUT_MS),
+  });
+  if (!res.ok) {
+    throw new Error("approval unavailable");
+  }
+
+  const body = await res.json();
+  const parsed = AgentThreadSnapshotSchema.safeParse(body);
+  if (!parsed.success) {
+    throw new Error("approval unavailable");
   }
   return parsed.data;
 }

--- a/desktop/src/main/index.ts
+++ b/desktop/src/main/index.ts
@@ -10,6 +10,7 @@ import {
   fetchCodingAgentReviewSnapshot,
   fetchCodingAgentReviewSummaries,
   fetchCodingAgentRuntimeSummary,
+  submitCodingAgentApprovalDecision,
 } from "./coding-agents/runtime-summary-client";
 import { registerIpcHandlers } from "./ipc/handlers";
 import { createLocalStore } from "./persistence/local-store";
@@ -237,6 +238,12 @@ if (!gotLock) {
         fetchReviewSummaries: (options) => fetchCodingAgentReviewSummaries(auth, options),
         fetchReviewSnapshot: (options) => fetchCodingAgentReviewSnapshot(auth, options),
         fetchThreadSnapshot: (options) => fetchCodingAgentThreadSnapshot(auth, options),
+        submitApprovalDecision: ({ threadId, approvalId, decision, clientRequestId, correlationId }) =>
+          submitCodingAgentApprovalDecision(auth, {
+            threadId,
+            approvalId,
+            request: { decision, clientRequestId, correlationId },
+          }),
         createAgentThread: (request) => createCodingAgentThread(auth, request),
       });
 

--- a/desktop/src/main/ipc/handlers.ts
+++ b/desktop/src/main/ipc/handlers.ts
@@ -34,6 +34,9 @@ export interface HandlerContext {
   fetchThreadSnapshot: (
     options: { threadId: string },
   ) => Promise<z.infer<typeof AgentThreadSnapshotSchema>>;
+  submitApprovalDecision: (
+    request: InvokeRequest<"runtime:submit-approval-decision">,
+  ) => Promise<z.infer<typeof AgentThreadSnapshotSchema>>;
   createAgentThread: (
     request: CreateAgentThreadRequest,
   ) => Promise<z.infer<typeof AgentThreadSnapshotSchema>>;
@@ -96,6 +99,7 @@ export function registerIpcHandlers(ipcMain: IpcMainLike, ctx: HandlerContext): 
   handle("runtime:get-reviews", (request) => ctx.fetchReviewSummaries(request));
   handle("runtime:get-review-snapshot", (request) => ctx.fetchReviewSnapshot(request));
   handle("runtime:get-thread-snapshot", (request) => ctx.fetchThreadSnapshot(request));
+  handle("runtime:submit-approval-decision", (request) => ctx.submitApprovalDecision(request));
   handle("runtime:create-thread", (request) => ctx.createAgentThread(request));
 
   handle("state:get", async ({ key }) => ({

--- a/desktop/src/renderer/src/features/coding-agents/AgentWorkspace.tsx
+++ b/desktop/src/renderer/src/features/coding-agents/AgentWorkspace.tsx
@@ -491,6 +491,12 @@ function ThreadSnapshotPanel({
 
 function ThreadEventRow({ event }: { event: AgentThreadEvent }) {
   const copy = describeThreadEvent(event);
+  const approvalActionStatus = useCodingAgentWorkspace((s) => s.approvalActionStatus);
+  const pendingApprovalId = useCodingAgentWorkspace((s) => s.pendingApprovalId);
+  const approvalActionError = useCodingAgentWorkspace((s) => s.approvalActionError);
+  const submitApprovalDecision = useCodingAgentWorkspace((s) => s.submitApprovalDecision);
+  const approval = event.type === "approval.requested" ? event.approval : null;
+  const approvalPending = approvalActionStatus === "submitting" && pendingApprovalId === approval?.approvalId;
   return (
     <div
       className="grid gap-1 rounded-md border px-3 py-2"
@@ -507,8 +513,52 @@ function ThreadEventRow({ event }: { event: AgentThreadEvent }) {
       <p className="text-xs" style={{ color: "var(--text-secondary)" }}>
         {copy.detail}
       </p>
+      {approval ? (
+        <div className="flex flex-wrap items-center gap-2 pt-1">
+          {approval.allowedDecisions.map((decision) => (
+            <Button
+              key={decision}
+              aria-label={`${approvalDecisionLabel(decision)} ${approval.title}`}
+              variant={approvalDecisionVariant(decision)}
+              disabled={approvalActionStatus === "submitting"}
+              onClick={() => void submitApprovalDecision({
+                threadId: approval.threadId,
+                approvalId: approval.approvalId,
+                decision,
+                correlationId: approval.correlationId,
+              })}
+            >
+              {approvalPending ? "Sending..." : approvalDecisionLabel(decision)}
+            </Button>
+          ))}
+          {approvalActionError ? (
+            <span className="text-xs" style={{ color: "var(--danger)" }}>
+              {approvalActionError}
+            </span>
+          ) : null}
+        </div>
+      ) : null}
     </div>
   );
+}
+
+function approvalDecisionLabel(decision: string): string {
+  switch (decision) {
+    case "approve":
+      return "Approve";
+    case "approve_for_session":
+      return "Approve for session";
+    case "decline":
+      return "Decline";
+    case "cancel":
+      return "Cancel";
+    default:
+      return "Decide";
+  }
+}
+
+function approvalDecisionVariant(decision: string): "primary" | "danger" | "subtle" {
+  return decision === "approve" || decision === "approve_for_session" ? "primary" : "danger";
 }
 
 function describeThreadEvent(event: AgentThreadEvent): { title: string; detail: string } {

--- a/desktop/src/renderer/src/features/coding-agents/AgentWorkspace.tsx
+++ b/desktop/src/renderer/src/features/coding-agents/AgentWorkspace.tsx
@@ -491,12 +491,12 @@ function ThreadSnapshotPanel({
 
 function ThreadEventRow({ event }: { event: AgentThreadEvent }) {
   const copy = describeThreadEvent(event);
-  const approvalActionStatus = useCodingAgentWorkspace((s) => s.approvalActionStatus);
-  const pendingApprovalId = useCodingAgentWorkspace((s) => s.pendingApprovalId);
-  const approvalActionError = useCodingAgentWorkspace((s) => s.approvalActionError);
+  const pendingApprovalIds = useCodingAgentWorkspace((s) => s.pendingApprovalIds);
+  const approvalActionErrors = useCodingAgentWorkspace((s) => s.approvalActionErrors);
   const submitApprovalDecision = useCodingAgentWorkspace((s) => s.submitApprovalDecision);
   const approval = event.type === "approval.requested" ? event.approval : null;
-  const approvalPending = approvalActionStatus === "submitting" && pendingApprovalId === approval?.approvalId;
+  const approvalPending = approval ? pendingApprovalIds.includes(approval.approvalId) : false;
+  const approvalActionError = approval ? approvalActionErrors[approval.approvalId] : undefined;
   return (
     <div
       className="grid gap-1 rounded-md border px-3 py-2"
@@ -520,7 +520,7 @@ function ThreadEventRow({ event }: { event: AgentThreadEvent }) {
               key={decision}
               aria-label={`${approvalDecisionLabel(decision)} ${approval.title}`}
               variant={approvalDecisionVariant(decision)}
-              disabled={approvalActionStatus === "submitting"}
+              disabled={approvalPending}
               onClick={() => void submitApprovalDecision({
                 threadId: approval.threadId,
                 approvalId: approval.approvalId,

--- a/desktop/src/renderer/src/features/coding-agents/AgentWorkspace.tsx
+++ b/desktop/src/renderer/src/features/coding-agents/AgentWorkspace.tsx
@@ -11,7 +11,7 @@ import {
 } from "@matrix-os/contracts";
 import { Button, EmptyState, StatusDot } from "../../design/primitives";
 import { useConnection } from "../../stores/connection";
-import { useCodingAgentWorkspace } from "../../stores/coding-agent-workspace";
+import { codingAgentApprovalActionKey, useCodingAgentWorkspace } from "../../stores/coding-agent-workspace";
 import { useTabs } from "../../stores/tabs";
 
 const STATUS_COLOR: Record<string, string> = {
@@ -491,12 +491,13 @@ function ThreadSnapshotPanel({
 
 function ThreadEventRow({ event }: { event: AgentThreadEvent }) {
   const copy = describeThreadEvent(event);
-  const pendingApprovalIds = useCodingAgentWorkspace((s) => s.pendingApprovalIds);
+  const pendingApprovalKeys = useCodingAgentWorkspace((s) => s.pendingApprovalKeys);
   const approvalActionErrors = useCodingAgentWorkspace((s) => s.approvalActionErrors);
   const submitApprovalDecision = useCodingAgentWorkspace((s) => s.submitApprovalDecision);
   const approval = event.type === "approval.requested" ? event.approval : null;
-  const approvalPending = approval ? pendingApprovalIds.includes(approval.approvalId) : false;
-  const approvalActionError = approval ? approvalActionErrors[approval.approvalId] : undefined;
+  const approvalKey = approval ? codingAgentApprovalActionKey(approval.threadId, approval.approvalId) : null;
+  const approvalPending = approvalKey ? pendingApprovalKeys.includes(approvalKey) : false;
+  const approvalActionError = approvalKey ? approvalActionErrors[approvalKey] : undefined;
   return (
     <div
       className="grid gap-1 rounded-md border px-3 py-2"

--- a/desktop/src/renderer/src/stores/coding-agent-workspace.ts
+++ b/desktop/src/renderer/src/stores/coding-agent-workspace.ts
@@ -1,5 +1,6 @@
 import {
   buildCreateAgentThreadRequestFromComposer,
+  type ApprovalDecisionRequest,
   type AgentThreadSnapshot,
   type AgentThreadComposerDraft,
   type ReviewSnapshot,
@@ -12,6 +13,7 @@ import { invoke } from "../lib/operator";
 type WorkspaceStatus = "idle" | "loading" | "ready" | "error";
 type ReviewStatus = "idle" | "loading" | "ready" | "error";
 type CreateStatus = "idle" | "submitting";
+type ActionStatus = "idle" | "submitting";
 type ReviewSummaryList = {
   items: ReviewSummary[];
   hasMore: boolean;
@@ -35,10 +37,19 @@ interface CodingAgentWorkspaceState {
   threadSnapshotError: string | null;
   createStatus: CreateStatus;
   createError: string | null;
+  approvalActionStatus: ActionStatus;
+  pendingApprovalId: string | null;
+  approvalActionError: string | null;
   activeThreadId: string | null;
   refresh: () => Promise<void>;
   selectReview: (reviewId: string) => Promise<void>;
   loadThreadSnapshot: (threadId: string) => Promise<void>;
+  submitApprovalDecision: (input: {
+    threadId: string;
+    approvalId: string;
+    decision: ApprovalDecisionRequest["decision"];
+    correlationId: string;
+  }) => Promise<void>;
   createThread: (draft: AgentThreadComposerDraft) => Promise<string | null>;
 }
 
@@ -47,6 +58,7 @@ let reviewsSeq = 0;
 let reviewSnapshotSeq = 0;
 let threadSnapshotSeq = 0;
 let createRequestSeq = 0;
+let actionRequestSeq = 0;
 
 function clearReviewSelectionState() {
   reviewSnapshotSeq += 1;
@@ -72,6 +84,11 @@ function nextCreateRequestId(): string {
   return `req_desktop_${Date.now().toString(36)}_${createRequestSeq}`;
 }
 
+function nextActionRequestId(): string {
+  actionRequestSeq += 1;
+  return `req_desktop_${Date.now().toString(36)}_${actionRequestSeq}`;
+}
+
 export const useCodingAgentWorkspace = create<CodingAgentWorkspaceState>()((set) => ({
   status: "idle",
   summary: null,
@@ -88,6 +105,9 @@ export const useCodingAgentWorkspace = create<CodingAgentWorkspaceState>()((set)
   threadSnapshotError: null,
   createStatus: "idle",
   createError: null,
+  approvalActionStatus: "idle",
+  pendingApprovalId: null,
+  approvalActionError: null,
   activeThreadId: null,
 
   refresh: async () => {
@@ -223,6 +243,57 @@ export const useCodingAgentWorkspace = create<CodingAgentWorkspaceState>()((set)
         threadSnapshotStatus: "error",
         threadSnapshot: null,
         threadSnapshotError: "Thread state unavailable",
+      });
+    }
+  },
+
+  submitApprovalDecision: async ({ threadId, approvalId, decision, correlationId }) => {
+    const { approvalActionStatus } = useCodingAgentWorkspace.getState();
+    if (approvalActionStatus === "submitting") return;
+
+    set({
+      approvalActionStatus: "submitting",
+      pendingApprovalId: approvalId,
+      approvalActionError: null,
+    });
+    try {
+      const snapshot = await invoke("runtime:submit-approval-decision", {
+        threadId,
+        approvalId,
+        decision,
+        correlationId,
+        clientRequestId: nextActionRequestId(),
+      });
+      set((state) => {
+        const currentSummary = state.summary;
+        const summary = currentSummary
+          ? {
+              ...currentSummary,
+              activeThreads: {
+                ...currentSummary.activeThreads,
+                items: currentSummary.activeThreads.items.map((thread) =>
+                  thread.id === snapshot.thread.id ? snapshot.thread : thread,
+                ),
+              },
+            }
+          : currentSummary;
+        return {
+          approvalActionStatus: "idle",
+          pendingApprovalId: null,
+          approvalActionError: null,
+          activeThreadId: snapshot.thread.id,
+          threadSnapshotStatus: "ready",
+          threadSnapshot: snapshot,
+          threadSnapshotError: null,
+          summary,
+        };
+      });
+    } catch {
+      console.warn("[coding-agents] approval decision failed");
+      set({
+        approvalActionStatus: "idle",
+        pendingApprovalId: null,
+        approvalActionError: "Approval could not be sent. Try again.",
       });
     }
   },

--- a/desktop/src/renderer/src/stores/coding-agent-workspace.ts
+++ b/desktop/src/renderer/src/stores/coding-agent-workspace.ts
@@ -40,7 +40,7 @@ interface CodingAgentWorkspaceState {
   approvalActionStatus: ActionStatus;
   pendingApprovalId: string | null;
   approvalActionError: string | null;
-  pendingApprovalIds: string[];
+  pendingApprovalKeys: string[];
   approvalActionErrors: Record<string, string>;
   activeThreadId: string | null;
   refresh: () => Promise<void>;
@@ -96,6 +96,10 @@ function withoutRecordKey<T>(record: Record<string, T>, key: string): Record<str
   return rest;
 }
 
+export function codingAgentApprovalActionKey(threadId: string, approvalId: string): string {
+  return `${threadId}:${approvalId}`;
+}
+
 export const useCodingAgentWorkspace = create<CodingAgentWorkspaceState>()((set) => ({
   status: "idle",
   summary: null,
@@ -115,7 +119,7 @@ export const useCodingAgentWorkspace = create<CodingAgentWorkspaceState>()((set)
   approvalActionStatus: "idle",
   pendingApprovalId: null,
   approvalActionError: null,
-  pendingApprovalIds: [],
+  pendingApprovalKeys: [],
   approvalActionErrors: {},
   activeThreadId: null,
 
@@ -257,15 +261,16 @@ export const useCodingAgentWorkspace = create<CodingAgentWorkspaceState>()((set)
   },
 
   submitApprovalDecision: async ({ threadId, approvalId, decision, correlationId }) => {
-    const { pendingApprovalIds } = useCodingAgentWorkspace.getState();
-    if (pendingApprovalIds.includes(approvalId)) return;
+    const approvalKey = codingAgentApprovalActionKey(threadId, approvalId);
+    const { pendingApprovalKeys } = useCodingAgentWorkspace.getState();
+    if (pendingApprovalKeys.includes(approvalKey)) return;
 
     set((state) => ({
       approvalActionStatus: "submitting",
       pendingApprovalId: approvalId,
       approvalActionError: null,
-      pendingApprovalIds: [...state.pendingApprovalIds, approvalId],
-      approvalActionErrors: withoutRecordKey(state.approvalActionErrors, approvalId),
+      pendingApprovalKeys: [...state.pendingApprovalKeys, approvalKey],
+      approvalActionErrors: withoutRecordKey(state.approvalActionErrors, approvalKey),
     }));
     try {
       const snapshot = await invoke("runtime:submit-approval-decision", {
@@ -277,7 +282,7 @@ export const useCodingAgentWorkspace = create<CodingAgentWorkspaceState>()((set)
       });
       set((state) => {
         const currentSummary = state.summary;
-        const nextPendingApprovalIds = state.pendingApprovalIds.filter((id) => id !== approvalId);
+        const nextPendingApprovalKeys = state.pendingApprovalKeys.filter((key) => key !== approvalKey);
         const visibleThreadStillSelected = state.activeThreadId === snapshot.thread.id;
         const summary = currentSummary
           ? {
@@ -291,11 +296,11 @@ export const useCodingAgentWorkspace = create<CodingAgentWorkspaceState>()((set)
             }
           : currentSummary;
         return {
-          approvalActionStatus: nextPendingApprovalIds.length > 0 ? "submitting" : "idle",
-          pendingApprovalId: nextPendingApprovalIds.at(-1) ?? null,
+          approvalActionStatus: nextPendingApprovalKeys.length > 0 ? "submitting" : "idle",
+          pendingApprovalId: null,
           approvalActionError: null,
-          pendingApprovalIds: nextPendingApprovalIds,
-          approvalActionErrors: withoutRecordKey(state.approvalActionErrors, approvalId),
+          pendingApprovalKeys: nextPendingApprovalKeys,
+          approvalActionErrors: withoutRecordKey(state.approvalActionErrors, approvalKey),
           summary,
           ...(visibleThreadStillSelected
             ? {
@@ -309,15 +314,15 @@ export const useCodingAgentWorkspace = create<CodingAgentWorkspaceState>()((set)
     } catch {
       console.warn("[coding-agents] approval decision failed");
       set((state) => {
-        const nextPendingApprovalIds = state.pendingApprovalIds.filter((id) => id !== approvalId);
+        const nextPendingApprovalKeys = state.pendingApprovalKeys.filter((key) => key !== approvalKey);
         return {
-          approvalActionStatus: nextPendingApprovalIds.length > 0 ? "submitting" : "idle",
-          pendingApprovalId: nextPendingApprovalIds.at(-1) ?? null,
+          approvalActionStatus: nextPendingApprovalKeys.length > 0 ? "submitting" : "idle",
+          pendingApprovalId: null,
           approvalActionError: "Approval could not be sent. Try again.",
-          pendingApprovalIds: nextPendingApprovalIds,
+          pendingApprovalKeys: nextPendingApprovalKeys,
           approvalActionErrors: {
             ...state.approvalActionErrors,
-            [approvalId]: "Approval could not be sent. Try again.",
+            [approvalKey]: "Approval could not be sent. Try again.",
           },
         };
       });

--- a/desktop/src/renderer/src/stores/coding-agent-workspace.ts
+++ b/desktop/src/renderer/src/stores/coding-agent-workspace.ts
@@ -40,6 +40,8 @@ interface CodingAgentWorkspaceState {
   approvalActionStatus: ActionStatus;
   pendingApprovalId: string | null;
   approvalActionError: string | null;
+  pendingApprovalIds: string[];
+  approvalActionErrors: Record<string, string>;
   activeThreadId: string | null;
   refresh: () => Promise<void>;
   selectReview: (reviewId: string) => Promise<void>;
@@ -89,6 +91,11 @@ function nextActionRequestId(): string {
   return `req_desktop_${Date.now().toString(36)}_${actionRequestSeq}`;
 }
 
+function withoutRecordKey<T>(record: Record<string, T>, key: string): Record<string, T> {
+  const { [key]: _removed, ...rest } = record;
+  return rest;
+}
+
 export const useCodingAgentWorkspace = create<CodingAgentWorkspaceState>()((set) => ({
   status: "idle",
   summary: null,
@@ -108,6 +115,8 @@ export const useCodingAgentWorkspace = create<CodingAgentWorkspaceState>()((set)
   approvalActionStatus: "idle",
   pendingApprovalId: null,
   approvalActionError: null,
+  pendingApprovalIds: [],
+  approvalActionErrors: {},
   activeThreadId: null,
 
   refresh: async () => {
@@ -248,14 +257,16 @@ export const useCodingAgentWorkspace = create<CodingAgentWorkspaceState>()((set)
   },
 
   submitApprovalDecision: async ({ threadId, approvalId, decision, correlationId }) => {
-    const { approvalActionStatus } = useCodingAgentWorkspace.getState();
-    if (approvalActionStatus === "submitting") return;
+    const { pendingApprovalIds } = useCodingAgentWorkspace.getState();
+    if (pendingApprovalIds.includes(approvalId)) return;
 
-    set({
+    set((state) => ({
       approvalActionStatus: "submitting",
       pendingApprovalId: approvalId,
       approvalActionError: null,
-    });
+      pendingApprovalIds: [...state.pendingApprovalIds, approvalId],
+      approvalActionErrors: withoutRecordKey(state.approvalActionErrors, approvalId),
+    }));
     try {
       const snapshot = await invoke("runtime:submit-approval-decision", {
         threadId,
@@ -266,6 +277,8 @@ export const useCodingAgentWorkspace = create<CodingAgentWorkspaceState>()((set)
       });
       set((state) => {
         const currentSummary = state.summary;
+        const nextPendingApprovalIds = state.pendingApprovalIds.filter((id) => id !== approvalId);
+        const visibleThreadStillSelected = state.activeThreadId === snapshot.thread.id;
         const summary = currentSummary
           ? {
               ...currentSummary,
@@ -278,22 +291,35 @@ export const useCodingAgentWorkspace = create<CodingAgentWorkspaceState>()((set)
             }
           : currentSummary;
         return {
-          approvalActionStatus: "idle",
-          pendingApprovalId: null,
+          approvalActionStatus: nextPendingApprovalIds.length > 0 ? "submitting" : "idle",
+          pendingApprovalId: nextPendingApprovalIds.at(-1) ?? null,
           approvalActionError: null,
-          activeThreadId: snapshot.thread.id,
-          threadSnapshotStatus: "ready",
-          threadSnapshot: snapshot,
-          threadSnapshotError: null,
+          pendingApprovalIds: nextPendingApprovalIds,
+          approvalActionErrors: withoutRecordKey(state.approvalActionErrors, approvalId),
           summary,
+          ...(visibleThreadStillSelected
+            ? {
+                threadSnapshotStatus: "ready" as const,
+                threadSnapshot: snapshot,
+                threadSnapshotError: null,
+              }
+            : {}),
         };
       });
     } catch {
       console.warn("[coding-agents] approval decision failed");
-      set({
-        approvalActionStatus: "idle",
-        pendingApprovalId: null,
-        approvalActionError: "Approval could not be sent. Try again.",
+      set((state) => {
+        const nextPendingApprovalIds = state.pendingApprovalIds.filter((id) => id !== approvalId);
+        return {
+          approvalActionStatus: nextPendingApprovalIds.length > 0 ? "submitting" : "idle",
+          pendingApprovalId: nextPendingApprovalIds.at(-1) ?? null,
+          approvalActionError: "Approval could not be sent. Try again.",
+          pendingApprovalIds: nextPendingApprovalIds,
+          approvalActionErrors: {
+            ...state.approvalActionErrors,
+            [approvalId]: "Approval could not be sent. Try again.",
+          },
+        };
       });
     }
   },

--- a/desktop/src/shared/ipc-contract.ts
+++ b/desktop/src/shared/ipc-contract.ts
@@ -4,6 +4,8 @@
 // (FR-081). The credential never appears in any schema.
 import { z } from "zod/v4";
 import {
+  ApprovalDecisionRequestSchema,
+  ApprovalIdSchema,
   AgentThreadSnapshotSchema,
   CreateAgentThreadRequestSchema,
   CursorSchema,
@@ -119,6 +121,16 @@ export const INVOKE_CHANNELS = {
   },
   "runtime:get-thread-snapshot": {
     request: z.object({ threadId: ThreadIdSchema }).strict(),
+    response: AgentThreadSnapshotSchema,
+  },
+  "runtime:submit-approval-decision": {
+    request: z
+      .object({
+        threadId: ThreadIdSchema,
+        approvalId: ApprovalIdSchema,
+      })
+      .extend(ApprovalDecisionRequestSchema.shape)
+      .strict(),
     response: AgentThreadSnapshotSchema,
   },
   "runtime:create-thread": {

--- a/specs/105-coding-agent-shells/current-state.md
+++ b/specs/105-coding-agent-shells/current-state.md
@@ -1,12 +1,12 @@
 # Current State: Coding Agent Shells
 
-**Branch stack**: `spec/coding-agent-shells` plus stacked implementation branches through `105-coding-agent-desktop-thread-detail`
+**Branch stack**: `spec/coding-agent-shells` plus stacked implementation branches through `105-coding-agent-desktop-approval-actions`
 **Updated**: 2026-07-07
 **Scope**: Inventory for the coding-agent desktop/mobile shell work. This file records the current Matrix-native route, contract, client, and regression-test state so later slices keep gateway/runtime as source of truth and keep desktop/mobile as thin shells.
 
 ## Summary
 
-The stack currently has shared contracts, a gateway runtime summary read model, read-only desktop and mobile workspaces behind flags, thread create/replay/abort/event streaming, provider adapters, a workspace-backed provider, approval/input route handling, a read-only coding-agent review summary route/client contract, desktop/mobile read-only review summary panels, and a read-only coding-agent review snapshot route with bounded file metadata from safe owner worktree diffs plus findings fallback metadata. Review snapshots can include bounded per-hunk diff lines with truncation markers. Desktop and mobile review details render changed-file counts, selectable hunk coordinate metadata, and gateway-bounded diff lines. Desktop and mobile can seed their existing agent composers from a selected review hunk using bounded prompt context and a `structured_ref` attachment. Mobile active thread rows now open a bounded thread detail route that hydrates `AgentThreadSnapshotSchema` through the authenticated gateway client, renders safe thread metadata, event counts, and a read-only snapshot event timeline, and can hand a bound canonical terminal session to the existing mobile Terminal tab. Desktop active thread rows can open a matching attachable bound canonical terminal session in the existing Terminal tab model and selected desktop threads now hydrate `AgentThreadSnapshotSchema` through trusted main-process IPC for safe read-only metadata and event timeline rendering. Desktop native notification clicks focus the Agents tab and visibly select the bounded coding-agent workspace thread reference in the active thread list. Full file content and preview coding-agent surfaces are contract-only or existing workspace routes; dedicated preview shell UI is not yet integrated.
+The stack currently has shared contracts, a gateway runtime summary read model, read-only desktop and mobile workspaces behind flags, thread create/replay/abort/event streaming, provider adapters, a workspace-backed provider, approval/input route handling, a read-only coding-agent review summary route/client contract, desktop/mobile read-only review summary panels, and a read-only coding-agent review snapshot route with bounded file metadata from safe owner worktree diffs plus findings fallback metadata. Review snapshots can include bounded per-hunk diff lines with truncation markers. Desktop and mobile review details render changed-file counts, selectable hunk coordinate metadata, and gateway-bounded diff lines. Desktop and mobile can seed their existing agent composers from a selected review hunk using bounded prompt context and a `structured_ref` attachment. Mobile active thread rows now open a bounded thread detail route that hydrates `AgentThreadSnapshotSchema` through the authenticated gateway client, renders safe thread metadata, event counts, and a read-only snapshot event timeline, and can hand a bound canonical terminal session to the existing mobile Terminal tab. Desktop active thread rows can open a matching attachable bound canonical terminal session in the existing Terminal tab model and selected desktop threads now hydrate `AgentThreadSnapshotSchema` through trusted main-process IPC for safe metadata and event timeline rendering. Desktop approval-request events can submit allowed decisions through trusted main-process IPC and replace local details with the gateway-returned bounded thread snapshot. Desktop native notification clicks focus the Agents tab and visibly select the bounded coding-agent workspace thread reference in the active thread list. Full file content and preview coding-agent surfaces are contract-only or existing workspace routes; dedicated preview shell UI is not yet integrated.
 
 Current source-of-truth boundaries:
 
@@ -185,6 +185,7 @@ IPC contract:
 - `desktop/src/shared/ipc-contract.ts`
 - `runtime:get-summary` returns `RuntimeSummarySchema`.
 - `runtime:get-thread-snapshot` accepts a bounded `threadId` and returns `AgentThreadSnapshotSchema`.
+- `runtime:submit-approval-decision` accepts bounded thread/approval ids plus `ApprovalDecisionRequestSchema` fields and returns `AgentThreadSnapshotSchema`.
 - `runtime:get-reviews` returns a bounded list of `ReviewSummarySchema` rows from the trusted main process.
 - `notify` accepts bounded notification data with `threadId`, `title`, `body`, and kind.
 - `notification:clicked` emits bounded `threadId`.
@@ -194,6 +195,7 @@ Main process:
 - `desktop/src/main/coding-agents/runtime-summary-client.ts`
 - Fetches `/api/coding-agents/summary` from the selected runtime origin with bearer auth in the main process.
 - Fetches `/api/coding-agents/threads/:threadId` from the selected runtime origin with bearer auth in the main process and validates `AgentThreadSnapshotSchema`.
+- Posts approval decisions to `/api/coding-agents/threads/:threadId/approvals/:approvalId/decision` from the main process with bearer auth, a timeout, and `AgentThreadSnapshotSchema` response validation.
 - Fetches `/api/coding-agents/reviews` from the selected runtime origin with bearer auth in the main process.
 - Uses `AbortSignal.timeout(10_000)` and validates `RuntimeSummarySchema`, `AgentThreadSnapshotSchema`, or bounded `ReviewSummarySchema` lists.
 - Renderer receives only parsed summary data through IPC.
@@ -209,7 +211,8 @@ Current behavior:
 
 - Read-only dashboard renders providers, active threads, and terminals.
 - Active thread rows with a matching attachable `terminalSessionId` can open the existing desktop Terminal tab for that canonical session; stale or unavailable terminal bindings do not render an action.
-- Selected active threads hydrate a bounded thread snapshot through `runtime:get-thread-snapshot`, show provider/status/terminal metadata, event counts, loading and safe generic error states, and render gateway-bounded snapshot events with generic copy for assistant text, tool output, file changes, and unsafe runtime errors.
+- Selected active threads hydrate a bounded thread snapshot through `runtime:get-thread-snapshot`, show provider/status/terminal metadata, event counts, loading and safe generic error states, and render gateway-bounded snapshot events with generic copy for assistant text, tool output, file changes, approval/input prompts, and unsafe runtime errors.
+- Approval-request events render allowed decision actions in the desktop thread detail. Decisions use desktop-generated idempotency request ids, go through trusted IPC, never expose bearer/provider credentials to the renderer, and replace the thread detail with the gateway-returned bounded snapshot. Failed decisions show a generic recovery-oriented message.
 - Native notification clicks carrying a bounded `threadId` focus the existing Agents tab and visibly mark that thread current in the coding-agent workspace thread list while preserving the legacy thread-store selection path.
 - When the runtime advertises `codingAgentsReview`, the dashboard fetches bounded review summaries through the trusted main-process IPC route and renders project, PR, round, status, and high-severity count.
 - Review snapshot details render bounded file paths, additions/deletions, partial markers, selectable hunk coordinate metadata, gateway-bounded hunk lines, and safe finding summaries. Diff line containers are blocked from session recording.
@@ -351,6 +354,7 @@ git diff --check
 
 - Session completion reconciliation: implemented for workspace `session.stopped` events that carry owner id, workspace session id, and bound `terminalSessionId`; the gateway thread store marks matching active coding-agent threads completed or failed server-side without matching unrelated owners or reused terminal ids. Remaining work: if runtime managers add autonomous process-exit detection beyond explicit workspace stop events, route those through the same `session.stopped` publisher path.
 - File/review/preview shell surfaces: read-only review summaries now have coding-agent contracts/routes/desktop IPC/mobile clients plus desktop and mobile read-only review panels. A read-only review snapshot route now exposes bounded diff hunk metadata and capped hunk line bodies from safe owner worktrees plus partial findings-derived fallback metadata for later shell diff panels. Full file contents and previews are not implemented yet.
+- Approval/input shell actions: desktop approval decisions now have trusted IPC, main-process gateway submission, bounded UI controls, and focused tests. Remaining work: user-input answer controls, mobile approval/input action sheets, and cross-shell resolved-state refresh tests.
 - Browser shell entry point: Canvas-first placement is still undecided.
 - Notifications/attention routing: desktop notification IPC exists and notification clicks focus the coding-agent workspace thread in the Agents tab with a visible current-thread marker. Remaining work: thread attention notifications are not yet wired end-to-end from gateway events.
 - Public docs: public Matrix OS docs should be updated once the user-facing coding-agent shell flow is stable enough to document.

--- a/tests/desktop/coding-agent-runtime-client.test.ts
+++ b/tests/desktop/coding-agent-runtime-client.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 import {
   fetchCodingAgentThreadSnapshot,
   fetchCodingAgentReviewSnapshot,
+  submitCodingAgentApprovalDecision,
 } from "../../desktop/src/main/coding-agents/runtime-summary-client";
 import type { AuthService } from "../../desktop/src/main/auth/auth-service";
 
@@ -128,6 +129,88 @@ describe("coding agent desktop runtime client", () => {
 
     await expect(fetchCodingAgentThreadSnapshot(auth(), { threadId: "thread_desktop_1" }, fetchFn)).rejects.toThrow("thread state unavailable");
     await expect(fetchCodingAgentThreadSnapshot(auth(), { threadId: "thread_desktop_1" }, fetchFn)).rejects.not.toThrow("secret");
+  });
+
+  it("submits approval decisions with bearer auth and validates the returned thread snapshot", async () => {
+    const resolved = {
+      ...threadSnapshotBody(),
+      thread: {
+        ...threadSnapshotBody().thread,
+        status: "running",
+        attention: "none",
+        updatedAt: "2026-07-06T00:02:00.000Z",
+      },
+      events: {
+        ...threadSnapshotBody().events,
+        items: [
+          {
+            type: "approval.resolved",
+            eventId: "evt_approval_2",
+            threadId: "thread_desktop_1",
+            occurredAt: "2026-07-06T00:02:00.000Z",
+            approvalId: "appr_desktop_1",
+            decision: "approve",
+          },
+        ],
+      },
+    };
+    const fetchFn = vi.fn().mockResolvedValue(new Response(JSON.stringify(resolved), { status: 200 }));
+
+    const snapshot = await submitCodingAgentApprovalDecision(auth(), {
+      threadId: "thread_desktop_1",
+      approvalId: "appr_desktop_1",
+      request: {
+        decision: "approve",
+        correlationId: "corr_desktop_1",
+        clientRequestId: "req_desktop_1",
+      },
+    }, fetchFn);
+
+    expect(fetchFn).toHaveBeenCalledWith(
+      "https://runtime.test/api/coding-agents/threads/thread_desktop_1/approvals/appr_desktop_1/decision",
+      expect.objectContaining({
+        method: "POST",
+        headers: expect.objectContaining({
+          Authorization: "Bearer desktop-token",
+          Accept: "application/json",
+          "Content-Type": "application/json",
+        }),
+        body: JSON.stringify({
+          decision: "approve",
+          correlationId: "corr_desktop_1",
+          clientRequestId: "req_desktop_1",
+        }),
+        signal: expect.any(AbortSignal),
+      }),
+    );
+    expect(snapshot.thread.status).toBe("running");
+    expect(snapshot.events.items[0]?.type).toBe("approval.resolved");
+  });
+
+  it("rejects unsafe approval decision responses with a generic error", async () => {
+    const fetchFn = vi.fn().mockResolvedValue(new Response(JSON.stringify({
+      ...threadSnapshotBody(),
+      accessToken: "secret",
+    }), { status: 200 }));
+
+    await expect(submitCodingAgentApprovalDecision(auth(), {
+      threadId: "thread_desktop_1",
+      approvalId: "appr_desktop_1",
+      request: {
+        decision: "approve",
+        correlationId: "corr_desktop_1",
+        clientRequestId: "req_desktop_1",
+      },
+    }, fetchFn)).rejects.toThrow("approval unavailable");
+    await expect(submitCodingAgentApprovalDecision(auth(), {
+      threadId: "thread_desktop_1",
+      approvalId: "appr_desktop_1",
+      request: {
+        decision: "approve",
+        correlationId: "corr_desktop_1",
+        clientRequestId: "req_desktop_1",
+      },
+    }, fetchFn)).rejects.not.toThrow("secret");
   });
 
   it("fetches review snapshots with bearer auth and validates safe output", async () => {

--- a/tests/desktop/coding-agent-workspace.test.tsx
+++ b/tests/desktop/coding-agent-workspace.test.tsx
@@ -276,6 +276,38 @@ function betaThreadSnapshotFixture() {
   };
 }
 
+function betaApprovalSameIdThreadSnapshotFixture() {
+  return {
+    thread: {
+      ...betaThreadSnapshotFixture().thread,
+      status: "waiting_for_approval",
+      attention: "approval_required",
+    },
+    events: {
+      items: [
+        {
+          type: "approval.requested",
+          eventId: "evt_approval_beta_1",
+          threadId: "thread_beta",
+          occurredAt: "2026-07-06T00:12:00.000Z",
+          approval: {
+            approvalId: "appr_desktop_1",
+            threadId: "thread_beta",
+            actionKind: "command",
+            risk: "low",
+            title: "Run beta tests",
+            safeDescription: "Run the beta desktop tests.",
+            allowedDecisions: ["approve", "decline"],
+            correlationId: "corr_desktop_beta_1",
+          },
+        },
+      ],
+      hasMore: false,
+      limit: 200,
+    },
+  };
+}
+
 function multiApprovalThreadSnapshotFixture() {
   const base = threadSnapshotFixture();
   return {
@@ -326,7 +358,7 @@ describe("AgentWorkspace", () => {
       approvalActionStatus: "idle",
       pendingApprovalId: null,
       approvalActionError: null,
-      pendingApprovalIds: [],
+      pendingApprovalKeys: [],
       approvalActionErrors: {},
       activeThreadId: null,
     });
@@ -491,6 +523,37 @@ describe("AgentWorkspace", () => {
     });
   });
 
+  it("does not apply pending approval state to another thread with the same approval id", async () => {
+    useCodingAgentWorkspace.setState({ activeThreadId: "thread_alpha" });
+    window.operator.invoke = vi.fn((channel: string, payload?: { approvalId?: string }) => {
+      if (channel === "runtime:get-summary") return Promise.resolve(summaryFixture());
+      if (channel === "runtime:get-reviews") return Promise.resolve(reviewsFixture());
+      if (channel === "runtime:get-thread-snapshot") return Promise.resolve(threadSnapshotFixture());
+      if (channel === "runtime:submit-approval-decision" && payload?.approvalId === "appr_desktop_1") {
+        return new Promise(() => undefined);
+      }
+      return Promise.reject(new Error("unexpected channel"));
+    });
+
+    render(<AgentWorkspace />);
+
+    const alphaApprove = await screen.findByRole("button", { name: /approve run tests/i });
+    fireEvent.click(alphaApprove);
+    await waitFor(() => expect((alphaApprove as HTMLButtonElement).disabled).toBe(true));
+
+    await act(async () => {
+      useCodingAgentWorkspace.setState({
+        activeThreadId: "thread_beta",
+        threadSnapshotStatus: "ready",
+        threadSnapshot: betaApprovalSameIdThreadSnapshotFixture(),
+      });
+    });
+
+    const betaApprove = await screen.findByRole("button", { name: /approve run beta tests/i });
+    expect((betaApprove as HTMLButtonElement).disabled).toBe(false);
+    expect(screen.queryByText("Sending...")).toBeNull();
+  });
+
   it("shows approval submission errors only on the failed approval row", async () => {
     useCodingAgentWorkspace.setState({ activeThreadId: "thread_alpha" });
     window.operator.invoke = vi.fn((channel: string, payload?: { approvalId?: string }) => {
@@ -510,6 +573,35 @@ describe("AgentWorkspace", () => {
     await waitFor(() => {
       expect(screen.getAllByText("Approval could not be sent. Try again.")).toHaveLength(1);
     });
+  });
+
+  it("does not apply approval errors to another thread with the same approval id", async () => {
+    useCodingAgentWorkspace.setState({ activeThreadId: "thread_alpha" });
+    window.operator.invoke = vi.fn((channel: string, payload?: { approvalId?: string }) => {
+      if (channel === "runtime:get-summary") return Promise.resolve(summaryFixture());
+      if (channel === "runtime:get-reviews") return Promise.resolve(reviewsFixture());
+      if (channel === "runtime:get-thread-snapshot") return Promise.resolve(threadSnapshotFixture());
+      if (channel === "runtime:submit-approval-decision" && payload?.approvalId === "appr_desktop_1") {
+        return Promise.reject(new Error("provider leaked /home/matrix"));
+      }
+      return Promise.reject(new Error("unexpected channel"));
+    });
+
+    render(<AgentWorkspace />);
+
+    fireEvent.click(await screen.findByRole("button", { name: /approve run tests/i }));
+    await screen.findByText("Approval could not be sent. Try again.");
+
+    await act(async () => {
+      useCodingAgentWorkspace.setState({
+        activeThreadId: "thread_beta",
+        threadSnapshotStatus: "ready",
+        threadSnapshot: betaApprovalSameIdThreadSnapshotFixture(),
+      });
+    });
+
+    await screen.findByRole("button", { name: /approve run beta tests/i });
+    expect(screen.queryByText("Approval could not be sent. Try again.")).toBeNull();
   });
 
   it("clears selected thread details when the refreshed summary no longer includes the thread", async () => {

--- a/tests/desktop/coding-agent-workspace.test.tsx
+++ b/tests/desktop/coding-agent-workspace.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 
 import React from "react";
-import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { act, cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import AgentWorkspace, {
   clearComposerLaunchContext,
@@ -257,6 +257,54 @@ function approvalResolvedThreadSnapshotFixture() {
   };
 }
 
+function betaThreadSnapshotFixture() {
+  return {
+    thread: {
+      id: "thread_beta",
+      providerId: "codex",
+      title: "Fix billing route",
+      status: "running",
+      attention: "none",
+      createdAt: "2026-07-06T00:10:00.000Z",
+      updatedAt: "2026-07-06T00:11:00.000Z",
+    },
+    events: {
+      items: [],
+      hasMore: false,
+      limit: 200,
+    },
+  };
+}
+
+function multiApprovalThreadSnapshotFixture() {
+  const base = threadSnapshotFixture();
+  return {
+    ...base,
+    events: {
+      ...base.events,
+      items: [
+        ...base.events.items,
+        {
+          type: "approval.requested",
+          eventId: "evt_approval_desktop_2",
+          threadId: "thread_alpha",
+          occurredAt: "2026-07-06T00:04:00.000Z",
+          approval: {
+            approvalId: "appr_desktop_2",
+            threadId: "thread_alpha",
+            actionKind: "file_change",
+            risk: "low",
+            title: "Inspect diff",
+            safeDescription: "Inspect the bounded diff.",
+            allowedDecisions: ["approve", "decline"],
+            correlationId: "corr_desktop_2",
+          },
+        },
+      ],
+    },
+  };
+}
+
 describe("AgentWorkspace", () => {
   beforeEach(() => {
     useCodingAgentWorkspace.setState({
@@ -278,6 +326,8 @@ describe("AgentWorkspace", () => {
       approvalActionStatus: "idle",
       pendingApprovalId: null,
       approvalActionError: null,
+      pendingApprovalIds: [],
+      approvalActionErrors: {},
       activeThreadId: null,
     });
     useConnection.setState({
@@ -366,6 +416,100 @@ describe("AgentWorkspace", () => {
     });
     expect(await screen.findByText("Approval resolved")).toBeTruthy();
     expect(screen.getByText("approve")).toBeTruthy();
+  });
+
+  it("does not reopen a stale approval thread after the user selects another thread", async () => {
+    let resolveApproval: ((snapshot: ReturnType<typeof approvalResolvedThreadSnapshotFixture>) => void) | null = null;
+    window.operator.invoke = vi.fn((channel: string) => {
+      if (channel === "runtime:submit-approval-decision") {
+        return new Promise((resolve) => {
+          resolveApproval = resolve;
+        });
+      }
+      return Promise.reject(new Error("unexpected channel"));
+    });
+    useCodingAgentWorkspace.setState({
+      activeThreadId: "thread_alpha",
+      threadSnapshotStatus: "ready",
+      threadSnapshot: threadSnapshotFixture(),
+      summary: summaryFixture(),
+    });
+
+    const submit = useCodingAgentWorkspace.getState().submitApprovalDecision({
+      threadId: "thread_alpha",
+      approvalId: "appr_desktop_1",
+      decision: "approve",
+      correlationId: "corr_desktop_1",
+    });
+    useCodingAgentWorkspace.setState({
+      activeThreadId: "thread_beta",
+      threadSnapshotStatus: "ready",
+      threadSnapshot: betaThreadSnapshotFixture(),
+    });
+    resolveApproval?.(approvalResolvedThreadSnapshotFixture());
+    await submit;
+
+    expect(useCodingAgentWorkspace.getState().activeThreadId).toBe("thread_beta");
+    expect(useCodingAgentWorkspace.getState().threadSnapshot?.thread.id).toBe("thread_beta");
+  });
+
+  it("keeps independent approval rows actionable while another approval is pending", async () => {
+    useCodingAgentWorkspace.setState({ activeThreadId: "thread_alpha" });
+    let resolveFirstApproval: ((snapshot: ReturnType<typeof approvalResolvedThreadSnapshotFixture>) => void) | null = null;
+    window.operator.invoke = vi.fn((channel: string, payload?: { approvalId?: string }) => {
+      if (channel === "runtime:get-summary") return Promise.resolve(summaryFixture());
+      if (channel === "runtime:get-reviews") return Promise.resolve(reviewsFixture());
+      if (channel === "runtime:get-thread-snapshot") return Promise.resolve(multiApprovalThreadSnapshotFixture());
+      if (channel === "runtime:submit-approval-decision" && payload?.approvalId === "appr_desktop_1") {
+        return new Promise((resolve) => {
+          resolveFirstApproval = resolve;
+        });
+      }
+      if (channel === "runtime:submit-approval-decision" && payload?.approvalId === "appr_desktop_2") {
+        return Promise.resolve(multiApprovalThreadSnapshotFixture());
+      }
+      return Promise.reject(new Error("unexpected channel"));
+    });
+
+    render(<AgentWorkspace />);
+
+    const firstApprove = await screen.findByRole("button", { name: /approve run tests/i });
+    const secondApprove = await screen.findByRole("button", { name: /approve inspect diff/i });
+    fireEvent.click(firstApprove);
+    await waitFor(() => expect((firstApprove as HTMLButtonElement).disabled).toBe(true));
+    expect((secondApprove as HTMLButtonElement).disabled).toBe(false);
+    fireEvent.click(secondApprove);
+
+    await waitFor(() => {
+      expect(window.operator.invoke).toHaveBeenCalledWith("runtime:submit-approval-decision", expect.objectContaining({
+        approvalId: "appr_desktop_2",
+      }));
+    });
+    await act(async () => {
+      resolveFirstApproval?.(approvalResolvedThreadSnapshotFixture());
+      await Promise.resolve();
+    });
+  });
+
+  it("shows approval submission errors only on the failed approval row", async () => {
+    useCodingAgentWorkspace.setState({ activeThreadId: "thread_alpha" });
+    window.operator.invoke = vi.fn((channel: string, payload?: { approvalId?: string }) => {
+      if (channel === "runtime:get-summary") return Promise.resolve(summaryFixture());
+      if (channel === "runtime:get-reviews") return Promise.resolve(reviewsFixture());
+      if (channel === "runtime:get-thread-snapshot") return Promise.resolve(multiApprovalThreadSnapshotFixture());
+      if (channel === "runtime:submit-approval-decision" && payload?.approvalId === "appr_desktop_1") {
+        return Promise.reject(new Error("provider leaked /home/matrix"));
+      }
+      return Promise.reject(new Error("unexpected channel"));
+    });
+
+    render(<AgentWorkspace />);
+
+    fireEvent.click(await screen.findByRole("button", { name: /approve run tests/i }));
+
+    await waitFor(() => {
+      expect(screen.getAllByText("Approval could not be sent. Try again.")).toHaveLength(1);
+    });
   });
 
   it("clears selected thread details when the refreshed summary no longer includes the thread", async () => {

--- a/tests/desktop/coding-agent-workspace.test.tsx
+++ b/tests/desktop/coding-agent-workspace.test.tsx
@@ -231,6 +231,32 @@ function threadSnapshotFixture() {
   };
 }
 
+function approvalResolvedThreadSnapshotFixture() {
+  return {
+    ...threadSnapshotFixture(),
+    thread: {
+      ...threadSnapshotFixture().thread,
+      status: "running",
+      attention: "none",
+      updatedAt: "2026-07-06T00:05:00.000Z",
+    },
+    events: {
+      ...threadSnapshotFixture().events,
+      items: [
+        ...threadSnapshotFixture().events.items,
+        {
+          type: "approval.resolved",
+          eventId: "evt_approval_desktop_2",
+          threadId: "thread_alpha",
+          occurredAt: "2026-07-06T00:05:00.000Z",
+          approvalId: "appr_desktop_1",
+          decision: "approve",
+        },
+      ],
+    },
+  };
+}
+
 describe("AgentWorkspace", () => {
   beforeEach(() => {
     useCodingAgentWorkspace.setState({
@@ -249,6 +275,9 @@ describe("AgentWorkspace", () => {
       threadSnapshotError: null,
       createStatus: "idle",
       createError: null,
+      approvalActionStatus: "idle",
+      pendingApprovalId: null,
+      approvalActionError: null,
       activeThreadId: null,
     });
     useConnection.setState({
@@ -308,6 +337,35 @@ describe("AgentWorkspace", () => {
     expect(screen.getByText("Run the focused desktop tests.")).toBeTruthy();
     expect(screen.queryByText(/home\/matrix|token|secret/i)).toBeNull();
     expect(window.operator.invoke).toHaveBeenCalledWith("runtime:get-thread-snapshot", { threadId: "thread_alpha" });
+  });
+
+  it("submits approval decisions through trusted IPC and refreshes the thread details", async () => {
+    useCodingAgentWorkspace.setState({ activeThreadId: "thread_alpha" });
+    const resolvedSnapshot = approvalResolvedThreadSnapshotFixture();
+    window.operator.invoke = vi.fn((channel: string) => {
+      if (channel === "runtime:get-summary") return Promise.resolve(summaryFixture());
+      if (channel === "runtime:get-reviews") return Promise.resolve(reviewsFixture());
+      if (channel === "runtime:get-thread-snapshot") return Promise.resolve(threadSnapshotFixture());
+      if (channel === "runtime:submit-approval-decision") return Promise.resolve(resolvedSnapshot);
+      return Promise.reject(new Error("unexpected channel"));
+    });
+
+    render(<AgentWorkspace />);
+
+    const approve = await screen.findByRole("button", { name: /approve run tests/i });
+    fireEvent.click(approve);
+
+    await waitFor(() => {
+      expect(window.operator.invoke).toHaveBeenCalledWith("runtime:submit-approval-decision", {
+        threadId: "thread_alpha",
+        approvalId: "appr_desktop_1",
+        decision: "approve",
+        correlationId: "corr_desktop_1",
+        clientRequestId: expect.stringMatching(/^req_desktop_/),
+      });
+    });
+    expect(await screen.findByText("Approval resolved")).toBeTruthy();
+    expect(screen.getByText("approve")).toBeTruthy();
   });
 
   it("clears selected thread details when the refreshed summary no longer includes the thread", async () => {

--- a/tests/desktop/ipc-contract.test.ts
+++ b/tests/desktop/ipc-contract.test.ts
@@ -14,6 +14,7 @@ describe("IPC contract", () => {
       "auth:status",
       "auth:sign-out",
       "runtime:create-thread",
+      "runtime:submit-approval-decision",
       "runtime:get-thread-snapshot",
       "runtime:get-review-snapshot",
       "runtime:get-reviews",
@@ -114,6 +115,47 @@ describe("IPC contract", () => {
       ...valid,
       thread: { ...valid.thread, providerSecret: "secret" },
     }).success).toBe(false);
+  });
+
+  it("validates runtime:submit-approval-decision requests and responses", () => {
+    const requestSchema = INVOKE_CHANNELS["runtime:submit-approval-decision"].request;
+    const responseSchema = INVOKE_CHANNELS["runtime:submit-approval-decision"].response;
+    const request = {
+      threadId: "thread_desktop_1",
+      approvalId: "appr_desktop_1",
+      decision: "approve",
+      correlationId: "corr_desktop_1",
+      clientRequestId: "req_desktop_1",
+    };
+
+    expect(requestSchema.safeParse(request).success).toBe(true);
+    expect(requestSchema.safeParse({ ...request, providerToken: "secret" }).success).toBe(false);
+    expect(requestSchema.safeParse({ ...request, approvalId: "../secret" }).success).toBe(false);
+    expect(responseSchema.safeParse({
+      thread: {
+        id: "thread_desktop_1",
+        providerId: "codex",
+        title: "Fix desktop notifications",
+        status: "running",
+        attention: "none",
+        createdAt: "2026-07-06T00:00:00.000Z",
+        updatedAt: "2026-07-06T00:02:00.000Z",
+      },
+      events: {
+        items: [
+          {
+            type: "approval.resolved",
+            eventId: "evt_approval_2",
+            threadId: "thread_desktop_1",
+            occurredAt: "2026-07-06T00:02:00.000Z",
+            approvalId: "appr_desktop_1",
+            decision: "approve",
+          },
+        ],
+        hasMore: false,
+        limit: 200,
+      },
+    }).success).toBe(true);
   });
 
   it("validates runtime:get-summary responses and rejects credential leakage shapes", () => {

--- a/tests/desktop/ipc-handlers.test.ts
+++ b/tests/desktop/ipc-handlers.test.ts
@@ -40,6 +40,7 @@ function makeHarness(overrides: Partial<HandlerContext> = {}) {
     fetchReviewSummaries: vi.fn(),
     fetchReviewSnapshot: vi.fn(),
     fetchThreadSnapshot: vi.fn(),
+    submitApprovalDecision: vi.fn(),
     createAgentThread: vi.fn(),
     ...overrides,
   } as unknown as HandlerContext;
@@ -316,6 +317,67 @@ describe("registerIpcHandlers", () => {
 
     await expect(harness.invoke("runtime:get-thread-snapshot", { threadId: "thread_desktop_1" })).rejects.toThrow("internal error");
     await expect(harness.invoke("runtime:get-thread-snapshot", { threadId: "thread_desktop_1" })).rejects.not.toThrow("/home/matrix");
+  });
+
+  it("submits approval decisions through trusted-core IPC without exposing credentials", async () => {
+    const snapshot = {
+      thread: {
+        id: "thread_desktop_1",
+        providerId: "codex",
+        title: "Fix desktop notifications",
+        status: "running",
+        attention: "none",
+        createdAt: "2026-07-06T00:00:00.000Z",
+        updatedAt: "2026-07-06T00:02:00.000Z",
+      },
+      events: {
+        items: [
+          {
+            type: "approval.resolved",
+            eventId: "evt_approval_2",
+            threadId: "thread_desktop_1",
+            occurredAt: "2026-07-06T00:02:00.000Z",
+            approvalId: "appr_desktop_1",
+            decision: "approve",
+          },
+        ],
+        hasMore: false,
+        limit: 200,
+      },
+    };
+    const submitApprovalDecision = vi.fn().mockResolvedValue(snapshot);
+    const harness = makeHarness({ submitApprovalDecision } as Partial<HandlerContext>);
+    const request = {
+      threadId: "thread_desktop_1",
+      approvalId: "appr_desktop_1",
+      decision: "approve",
+      correlationId: "corr_desktop_1",
+      clientRequestId: "req_desktop_1",
+    };
+
+    await expect(harness.invoke("runtime:submit-approval-decision", request)).resolves.toEqual(snapshot);
+    expect(submitApprovalDecision).toHaveBeenCalledWith(request);
+    await expect(harness.invoke("runtime:submit-approval-decision", {
+      ...request,
+      providerToken: "secret",
+    })).rejects.toThrow("invalid request");
+  });
+
+  it("maps approval decision failures to a generic IPC error", async () => {
+    const submitApprovalDecision = vi
+      .fn()
+      .mockRejectedValue(new Error("provider approval failed at /home/matrix/home with token secret"));
+    const harness = makeHarness({ submitApprovalDecision } as Partial<HandlerContext>);
+    const request = {
+      threadId: "thread_desktop_1",
+      approvalId: "appr_desktop_1",
+      decision: "approve",
+      correlationId: "corr_desktop_1",
+      clientRequestId: "req_desktop_1",
+    };
+
+    await expect(harness.invoke("runtime:submit-approval-decision", request)).rejects.toThrow("internal error");
+    await expect(harness.invoke("runtime:submit-approval-decision", request)).rejects.not.toThrow("/home/matrix");
   });
 
   it("creates agent threads through trusted-core IPC without exposing credentials", async () => {


### PR DESCRIPTION
## Summary

- Add trusted desktop IPC for submitting coding-agent approval decisions.
- Post approval decisions from the Electron main process to the gateway with bearer auth, timeout, and `AgentThreadSnapshotSchema` validation.
- Render allowed approval decisions in the desktop thread detail panel and refresh local details from the gateway-returned snapshot.
- Update the coding-agent shell current-state note for this desktop approval slice.

## Validation

- `pnpm exec vitest run tests/desktop/ipc-contract.test.ts tests/desktop/coding-agent-runtime-client.test.ts tests/desktop/ipc-handlers.test.ts tests/desktop/coding-agent-workspace.test.tsx --reporter=dot`
- `pnpm --filter desktop run typecheck`
- `bun run check:patterns` (0 violations; existing warnings only)
- `bun run typecheck`
- `git diff --check`

## Matrix OS Invariants

- Source of truth: gateway/runtime remain source of truth for coding-agent thread state and approval resolution; desktop stores only the bounded snapshot returned by the gateway.
- Lock/transaction scope: no new persistence, migrations, or database writes in desktop.
- Acceptable orphan states: if approval submission fails or the desktop window closes, the gateway thread remains unchanged and the user can retry from a refreshed snapshot.
- Auth source of truth: bearer credentials stay in the trusted Electron main process; renderer IPC payloads contain only bounded ids, decision fields, and desktop-generated request ids.
- Deferred scope: user-input answer controls, mobile approval/input action sheets, and cross-shell resolved-state refresh tests remain follow-up work.
