### PR TITLE
feat(mobile): handle coding agent thread actions

### DIFF
--- a/apps/mobile/__tests__/agent-thread-screen.test.tsx
+++ b/apps/mobile/__tests__/agent-thread-screen.test.tsx
@@ -74,6 +74,176 @@ function threadSnapshotFixture() {
   };
 }
 
+function approvalRequestedSnapshotFixture() {
+  const snapshot = threadSnapshotFixture();
+  return {
+    ...snapshot,
+    events: {
+      ...snapshot.events,
+      items: [
+        ...snapshot.events.items,
+        {
+          eventId: "evt_mobile_approval_requested",
+          threadId: "thread_mobile",
+          type: "approval.requested",
+          approval: {
+            approvalId: "appr_mobile_1",
+            threadId: "thread_mobile",
+            title: "Run focused tests",
+            safeDescription: "Run the focused mobile thread test command.",
+            risk: "low",
+            actionKind: "command",
+            allowedDecisions: ["approve", "decline"],
+            correlationId: "corr_mobile_approval_1",
+          },
+          occurredAt: "2026-07-06T00:02:00.000Z",
+        },
+      ],
+    },
+  };
+}
+
+function approvalResolvedSnapshotFixture() {
+  const snapshot = threadSnapshotFixture();
+  return {
+    ...snapshot,
+    events: {
+      ...snapshot.events,
+      items: [
+        ...snapshot.events.items,
+        {
+          eventId: "evt_mobile_approval_resolved",
+          threadId: "thread_mobile",
+          type: "approval.resolved",
+          approvalId: "appr_mobile_1",
+          decision: "approve",
+          occurredAt: "2026-07-06T00:03:00.000Z",
+        },
+      ],
+    },
+  };
+}
+
+function approvalRequestedAndResolvedSnapshotFixture() {
+  const requested = approvalRequestedSnapshotFixture();
+  return {
+    ...requested,
+    events: {
+      ...requested.events,
+      items: [
+        ...requested.events.items,
+        {
+          eventId: "evt_mobile_approval_resolved",
+          threadId: "thread_mobile",
+          type: "approval.resolved",
+          approvalId: "appr_mobile_1",
+          decision: "approve",
+          occurredAt: "2026-07-06T00:03:00.000Z",
+        },
+      ],
+    },
+  };
+}
+
+function twoApprovalRequestsSnapshotFixture() {
+  const snapshot = approvalRequestedSnapshotFixture();
+  return {
+    ...snapshot,
+    events: {
+      ...snapshot.events,
+      items: [
+        ...snapshot.events.items,
+        {
+          eventId: "evt_mobile_approval_requested_2",
+          threadId: "thread_mobile",
+          type: "approval.requested",
+          approval: {
+            approvalId: "appr_mobile_2",
+            threadId: "thread_mobile",
+            title: "Update fixture",
+            safeDescription: "Update the focused mobile fixture.",
+            risk: "low",
+            actionKind: "file_change",
+            allowedDecisions: ["approve", "decline"],
+            correlationId: "corr_mobile_approval_2",
+          },
+          occurredAt: "2026-07-06T00:02:30.000Z",
+        },
+      ],
+    },
+  };
+}
+
+function inputRequestedSnapshotFixture() {
+  const snapshot = threadSnapshotFixture();
+  return {
+    ...snapshot,
+    events: {
+      ...snapshot.events,
+      items: [
+        ...snapshot.events.items,
+        {
+          eventId: "evt_mobile_input_requested",
+          threadId: "thread_mobile",
+          type: "user_input.requested",
+          request: {
+            requestId: "req_mobile_prompt_1",
+            threadId: "thread_mobile",
+            title: "Clarify command",
+            safeDescription: "Provide the next safe instruction for this run.",
+            placeholder: "Type an instruction",
+            required: true,
+            correlationId: "corr_mobile_input_1",
+          },
+          occurredAt: "2026-07-06T00:02:00.000Z",
+        },
+      ],
+    },
+  };
+}
+
+function inputAnsweredSnapshotFixture() {
+  const snapshot = threadSnapshotFixture();
+  return {
+    ...snapshot,
+    events: {
+      ...snapshot.events,
+      items: [
+        ...snapshot.events.items,
+        {
+          eventId: "evt_mobile_input_answered",
+          threadId: "thread_mobile",
+          type: "user_input.answered",
+          requestId: "req_mobile_prompt_1",
+          correlationId: "corr_mobile_input_1",
+          occurredAt: "2026-07-06T00:03:00.000Z",
+        },
+      ],
+    },
+  };
+}
+
+function inputRequestedAndAnsweredSnapshotFixture() {
+  const requested = inputRequestedSnapshotFixture();
+  return {
+    ...requested,
+    events: {
+      ...requested.events,
+      items: [
+        ...requested.events.items,
+        {
+          eventId: "evt_mobile_input_answered",
+          threadId: "thread_mobile",
+          type: "user_input.answered",
+          requestId: "req_mobile_prompt_1",
+          correlationId: "corr_mobile_input_1",
+          occurredAt: "2026-07-06T00:03:00.000Z",
+        },
+      ],
+    },
+  };
+}
+
 function deferred<T>() {
   let resolve!: (value: T) => void;
   const promise = new Promise<T>((promiseResolve) => {
@@ -137,6 +307,183 @@ describe("AgentThreadRoute", () => {
       expect.stringContaining('"lastActiveTerminalSessionId":"matrix-abc1234"'),
     );
     expect(mockRouterPush).toHaveBeenCalledWith("/terminal");
+  });
+
+  it("submits an approval decision and applies the returned thread snapshot", async () => {
+    const client = {
+      getCodingAgentThreadSnapshot: jest.fn().mockResolvedValue({
+        ok: true,
+        snapshot: approvalRequestedSnapshotFixture(),
+      }),
+      submitCodingAgentApprovalDecision: jest.fn().mockResolvedValue({
+        ok: true,
+        snapshot: approvalResolvedSnapshotFixture(),
+      }),
+    };
+    useGatewayMock.mockReturnValue(gatewayContext({
+      client: client as unknown as GatewayClient,
+      connectionState: "connected",
+    }));
+
+    render(<AgentThreadRoute />);
+
+    expect(await screen.findByText("Approval needed")).toBeTruthy();
+    expect(screen.getByText("Run the focused mobile thread test command.")).toBeTruthy();
+    await act(async () => {
+      fireEvent.press(screen.getByLabelText("Approve Run focused tests"));
+    });
+
+    expect(client.submitCodingAgentApprovalDecision).toHaveBeenCalledWith(expect.objectContaining({
+      threadId: "thread_mobile",
+      approvalId: "appr_mobile_1",
+      decision: "approve",
+      correlationId: "corr_mobile_approval_1",
+      clientRequestId: expect.stringMatching(/^req_mobile_/),
+    }));
+    expect(await screen.findByText("Approval resolved")).toBeTruthy();
+    expect(screen.queryByText("Run the focused mobile thread test command.")).toBeNull();
+  });
+
+  it("submits a user input answer and applies the returned thread snapshot", async () => {
+    const client = {
+      getCodingAgentThreadSnapshot: jest.fn().mockResolvedValue({
+        ok: true,
+        snapshot: inputRequestedSnapshotFixture(),
+      }),
+      submitCodingAgentInputAnswer: jest.fn().mockResolvedValue({
+        ok: true,
+        snapshot: inputAnsweredSnapshotFixture(),
+      }),
+    };
+    useGatewayMock.mockReturnValue(gatewayContext({
+      client: client as unknown as GatewayClient,
+      connectionState: "connected",
+    }));
+
+    render(<AgentThreadRoute />);
+
+    expect(await screen.findByText("Input needed")).toBeTruthy();
+    fireEvent.changeText(screen.getByLabelText("Answer Clarify command"), "Run the focused mobile screen test.");
+    await act(async () => {
+      fireEvent.press(screen.getByLabelText("Send Clarify command"));
+    });
+
+    expect(client.submitCodingAgentInputAnswer).toHaveBeenCalledWith(expect.objectContaining({
+      threadId: "thread_mobile",
+      inputRequestId: "req_mobile_prompt_1",
+      answer: "Run the focused mobile screen test.",
+      correlationId: "corr_mobile_input_1",
+      clientRequestId: expect.stringMatching(/^req_mobile_/),
+    }));
+    expect(await screen.findByText("Input answered")).toBeTruthy();
+    expect(screen.queryByLabelText("Answer Clarify command")).toBeNull();
+  });
+
+  it("does not render approval actions once the approval is resolved", async () => {
+    const client = {
+      getCodingAgentThreadSnapshot: jest.fn().mockResolvedValue({
+        ok: true,
+        snapshot: approvalRequestedAndResolvedSnapshotFixture(),
+      }),
+      submitCodingAgentApprovalDecision: jest.fn(),
+    };
+    useGatewayMock.mockReturnValue(gatewayContext({
+      client: client as unknown as GatewayClient,
+      connectionState: "connected",
+    }));
+
+    render(<AgentThreadRoute />);
+
+    expect(await screen.findByText("Approval needed")).toBeTruthy();
+    expect(screen.getByText("Approval resolved")).toBeTruthy();
+    expect(screen.queryByLabelText("Approve Run focused tests")).toBeNull();
+  });
+
+  it("does not render an input composer once the input is answered", async () => {
+    const client = {
+      getCodingAgentThreadSnapshot: jest.fn().mockResolvedValue({
+        ok: true,
+        snapshot: inputRequestedAndAnsweredSnapshotFixture(),
+      }),
+      submitCodingAgentInputAnswer: jest.fn(),
+    };
+    useGatewayMock.mockReturnValue(gatewayContext({
+      client: client as unknown as GatewayClient,
+      connectionState: "connected",
+    }));
+
+    render(<AgentThreadRoute />);
+
+    expect(await screen.findByText("Input needed")).toBeTruthy();
+    expect(screen.getByText("Input answered")).toBeTruthy();
+    expect(screen.queryByLabelText("Answer Clarify command")).toBeNull();
+  });
+
+  it("keeps pending approval decisions scoped to the matching row", async () => {
+    const pendingDecision = deferred<{ ok: true; snapshot: ReturnType<typeof twoApprovalRequestsSnapshotFixture> }>();
+    const client = {
+      getCodingAgentThreadSnapshot: jest.fn().mockResolvedValue({
+        ok: true,
+        snapshot: twoApprovalRequestsSnapshotFixture(),
+      }),
+      submitCodingAgentApprovalDecision: jest.fn()
+        .mockImplementationOnce(() => pendingDecision.promise)
+        .mockResolvedValueOnce({
+          ok: true,
+          snapshot: twoApprovalRequestsSnapshotFixture(),
+        }),
+    };
+    useGatewayMock.mockReturnValue(gatewayContext({
+      client: client as unknown as GatewayClient,
+      connectionState: "connected",
+    }));
+
+    render(<AgentThreadRoute />);
+
+    expect(await screen.findByLabelText("Approve Run focused tests")).toBeTruthy();
+    await act(async () => {
+      fireEvent.press(screen.getByLabelText("Approve Run focused tests"));
+    });
+    await act(async () => {
+      fireEvent.press(screen.getByLabelText("Approve Update fixture"));
+    });
+
+    expect(client.submitCodingAgentApprovalDecision).toHaveBeenCalledTimes(2);
+    expect(client.submitCodingAgentApprovalDecision).toHaveBeenLastCalledWith(expect.objectContaining({
+      approvalId: "appr_mobile_2",
+    }));
+
+    await act(async () => {
+      pendingDecision.resolve({ ok: true, snapshot: twoApprovalRequestsSnapshotFixture() });
+      await pendingDecision.promise;
+    });
+  });
+
+  it("keeps approval errors scoped to the matching row", async () => {
+    const client = {
+      getCodingAgentThreadSnapshot: jest.fn().mockResolvedValue({
+        ok: true,
+        snapshot: twoApprovalRequestsSnapshotFixture(),
+      }),
+      submitCodingAgentApprovalDecision: jest.fn().mockResolvedValue({
+        ok: false,
+        error: "Approval could not be sent. Try again.",
+      }),
+    };
+    useGatewayMock.mockReturnValue(gatewayContext({
+      client: client as unknown as GatewayClient,
+      connectionState: "connected",
+    }));
+
+    render(<AgentThreadRoute />);
+
+    expect(await screen.findByLabelText("Approve Run focused tests")).toBeTruthy();
+    await act(async () => {
+      fireEvent.press(screen.getByLabelText("Approve Run focused tests"));
+    });
+
+    expect(await screen.findByText("Approval could not be sent. Try again.")).toBeTruthy();
+    expect(screen.getAllByText("Approval could not be sent. Try again.")).toHaveLength(1);
   });
 
   it("does not open a stale terminal session when safe resume state cannot be saved", async () => {

--- a/apps/mobile/__tests__/gateway-client.test.ts
+++ b/apps/mobile/__tests__/gateway-client.test.ts
@@ -330,6 +330,124 @@ describe("GatewayClient", () => {
     fetchMock.mockRestore();
   });
 
+  it("submits coding agent approval decisions with the existing auth header", async () => {
+    const snapshot = {
+      thread: {
+        id: "thread_mobile",
+        providerId: "codex",
+        title: "Repair mobile route",
+        status: "running",
+        attention: "none",
+        createdAt: "2026-07-06T00:00:00.000Z",
+        updatedAt: "2026-07-06T00:02:00.000Z",
+      },
+      events: {
+        items: [
+          {
+            eventId: "evt_mobile_approval_resolved",
+            threadId: "thread_mobile",
+            type: "approval.resolved",
+            approvalId: "appr_mobile_1",
+            decision: "approve",
+            occurredAt: "2026-07-06T00:02:00.000Z",
+          },
+        ],
+        hasMore: false,
+        limit: 200,
+      },
+    };
+    const fetchMock = jest.spyOn(global, "fetch").mockResolvedValueOnce(jsonResponse(snapshot));
+
+    const client = new GatewayClient("http://localhost:4000", "token");
+    await expect(client.submitCodingAgentApprovalDecision({
+      threadId: "thread_mobile",
+      approvalId: "appr_mobile_1",
+      decision: "approve",
+      correlationId: "corr_mobile_1",
+      clientRequestId: "req_mobile_approval_1",
+    })).resolves.toEqual({
+      ok: true,
+      snapshot,
+    });
+    expect(fetchMock).toHaveBeenCalledWith(
+      "http://localhost:4000/api/coding-agents/threads/thread_mobile/approvals/appr_mobile_1/decision",
+      expect.objectContaining({
+        method: "POST",
+        headers: expect.objectContaining({
+          Authorization: "Bearer token",
+          "Content-Type": "application/json",
+        }),
+        signal: expect.any(Object),
+      }),
+    );
+    expect(JSON.parse(String(fetchMock.mock.calls[0]?.[1]?.body))).toEqual({
+      decision: "approve",
+      correlationId: "corr_mobile_1",
+      clientRequestId: "req_mobile_approval_1",
+    });
+
+    fetchMock.mockRestore();
+  });
+
+  it("submits coding agent input answers with the existing auth header", async () => {
+    const snapshot = {
+      thread: {
+        id: "thread_mobile",
+        providerId: "codex",
+        title: "Repair mobile route",
+        status: "running",
+        attention: "none",
+        createdAt: "2026-07-06T00:00:00.000Z",
+        updatedAt: "2026-07-06T00:03:00.000Z",
+      },
+      events: {
+        items: [
+          {
+            eventId: "evt_mobile_input_answered",
+            threadId: "thread_mobile",
+            type: "user_input.answered",
+            requestId: "req_mobile_prompt_1",
+            correlationId: "corr_input_mobile_1",
+            occurredAt: "2026-07-06T00:03:00.000Z",
+          },
+        ],
+        hasMore: false,
+        limit: 200,
+      },
+    };
+    const fetchMock = jest.spyOn(global, "fetch").mockResolvedValueOnce(jsonResponse(snapshot));
+
+    const client = new GatewayClient("http://localhost:4000", "token");
+    await expect(client.submitCodingAgentInputAnswer({
+      threadId: "thread_mobile",
+      inputRequestId: "req_mobile_prompt_1",
+      answer: "Run the focused mobile thread test.",
+      correlationId: "corr_input_mobile_1",
+      clientRequestId: "req_mobile_input_1",
+    })).resolves.toEqual({
+      ok: true,
+      snapshot,
+    });
+    expect(fetchMock).toHaveBeenCalledWith(
+      "http://localhost:4000/api/coding-agents/threads/thread_mobile/inputs/req_mobile_prompt_1/answer",
+      expect.objectContaining({
+        method: "POST",
+        headers: expect.objectContaining({
+          Authorization: "Bearer token",
+          "Content-Type": "application/json",
+        }),
+        signal: expect.any(Object),
+      }),
+    );
+    expect(JSON.parse(String(fetchMock.mock.calls[0]?.[1]?.body))).toEqual({
+      answer: "Run the focused mobile thread test.",
+      correlationId: "corr_input_mobile_1",
+      clientRequestId: "req_mobile_input_1",
+    });
+
+    fetchMock.mockRestore();
+  });
+
   it("creates coding agent threads with the existing auth header", async () => {
     const snapshot = {
       thread: {
@@ -583,6 +701,36 @@ describe("GatewayClient", () => {
     })).resolves.toEqual({
       ok: false,
       error: "Agent run could not be started. Try again.",
+    });
+
+    fetchMock.mockRestore();
+  });
+
+  it("returns safe mobile action errors for invalid approval and input payloads", async () => {
+    const fetchMock = jest.spyOn(global, "fetch")
+      .mockResolvedValueOnce(jsonResponse({ token: "/home/matrix/secret" }))
+      .mockResolvedValueOnce(jsonResponse({ token: "sk_live_secret" }));
+
+    const client = new GatewayClient("http://localhost:4000", "token");
+    await expect(client.submitCodingAgentApprovalDecision({
+      threadId: "thread_mobile",
+      approvalId: "appr_mobile_1",
+      decision: "approve",
+      correlationId: "corr_mobile_1",
+      clientRequestId: "req_mobile_approval_1",
+    })).resolves.toEqual({
+      ok: false,
+      error: "Approval could not be sent. Try again.",
+    });
+    await expect(client.submitCodingAgentInputAnswer({
+      threadId: "thread_mobile",
+      inputRequestId: "req_mobile_prompt_1",
+      answer: "Proceed.",
+      correlationId: "corr_mobile_1",
+      clientRequestId: "req_mobile_input_1",
+    })).resolves.toEqual({
+      ok: false,
+      error: "Input could not be sent. Try again.",
     });
 
     fetchMock.mockRestore();

--- a/apps/mobile/app/agents/[threadId].tsx
+++ b/apps/mobile/app/agents/[threadId].tsx
@@ -1,9 +1,9 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useLocalSearchParams, useRouter } from "expo-router";
-import { ActivityIndicator, Pressable, ScrollView, Text, View } from "react-native";
+import { ActivityIndicator, Pressable, ScrollView, Text, TextInput, View } from "react-native";
 import { Ionicons } from "@expo/vector-icons";
 import { StyleSheet, useUnistyles } from "react-native-unistyles";
-import type { AgentThreadEvent, AgentThreadSnapshot } from "@matrix-os/contracts";
+import type { AgentThreadEvent, AgentThreadSnapshot, ApprovalDecisionRequest } from "@matrix-os/contracts";
 import { useGateway } from "@/app/_layout";
 import { loadMobileShellState, saveMobileShellState } from "@/lib/mobile-shell-state";
 import { isSafeShellSessionName } from "@/lib/terminal-state";
@@ -14,6 +14,9 @@ type ThreadRouteState =
   | { status: "error"; snapshot: null; error: "Thread state unavailable" };
 
 type TerminalOpenError = "Terminal session unavailable. Try again.";
+type ThreadActionError =
+  | "Approval could not be sent. Try again."
+  | "Input could not be sent. Try again.";
 
 export default function AgentThreadRoute() {
   const { theme } = useUnistyles();
@@ -28,9 +31,13 @@ export default function AgentThreadRoute() {
     error: null,
   });
   const [terminalOpenError, setTerminalOpenError] = useState<TerminalOpenError | null>(null);
+  const [pendingActionIds, setPendingActionIds] = useState<Record<string, true>>({});
+  const [threadActionErrors, setThreadActionErrors] = useState<Record<string, ThreadActionError>>({});
+  const [inputAnswers, setInputAnswers] = useState<Record<string, string>>({});
 
   const loadSnapshot = useCallback(async (cancelled: () => boolean = () => false) => {
     setTerminalOpenError(null);
+    setThreadActionErrors({});
     if (!client || !threadId) {
       setState((current) => current.status === "ready"
         ? { ...current, error: "Thread state unavailable", refreshing: false }
@@ -63,6 +70,91 @@ export default function AgentThreadRoute() {
       clearTimeout(timer);
     };
   }, [loadSnapshot]);
+
+  const submitApprovalDecision = useCallback(async (
+    event: Extract<AgentThreadEvent, { type: "approval.requested" }>,
+    decision: ApprovalDecisionRequest["decision"],
+  ) => {
+    if (!client || state.status !== "ready") return;
+    const actionId = `${event.approval.approvalId}:${decision}`;
+    setPendingActionIds((current) => ({ ...current, [actionId]: true }));
+    setThreadActionErrors((current) => {
+      const next = { ...current };
+      delete next[actionId];
+      return next;
+    });
+    const result = await client.submitCodingAgentApprovalDecision({
+      threadId: state.snapshot.thread.id,
+      approvalId: event.approval.approvalId,
+      decision,
+      correlationId: event.approval.correlationId,
+      clientRequestId: createMobileClientRequestId(),
+    });
+    setPendingActionIds((current) => {
+      const next = { ...current };
+      delete next[actionId];
+      return next;
+    });
+    if (result.ok) {
+      setState((current) => current.status === "ready"
+        ? { ...current, snapshot: result.snapshot, error: null, refreshing: false }
+        : current);
+      return;
+    }
+    setThreadActionErrors((current) => ({
+      ...current,
+      [actionId]: "Approval could not be sent. Try again.",
+    }));
+  }, [client, state]);
+
+  const setInputAnswer = useCallback((requestId: string, answer: string) => {
+    setInputAnswers((current) => ({
+      ...current,
+      [requestId]: answer,
+    }));
+  }, []);
+
+  const submitInputAnswer = useCallback(async (
+    event: Extract<AgentThreadEvent, { type: "user_input.requested" }>,
+  ) => {
+    if (!client || state.status !== "ready") return;
+    const answer = inputAnswers[event.request.requestId] ?? "";
+    if (!answer.trim()) return;
+    const actionId = `${event.request.requestId}:answer`;
+    setPendingActionIds((current) => ({ ...current, [actionId]: true }));
+    setThreadActionErrors((current) => {
+      const next = { ...current };
+      delete next[actionId];
+      return next;
+    });
+    const result = await client.submitCodingAgentInputAnswer({
+      threadId: state.snapshot.thread.id,
+      inputRequestId: event.request.requestId,
+      answer,
+      correlationId: event.request.correlationId,
+      clientRequestId: createMobileClientRequestId(),
+    });
+    setPendingActionIds((current) => {
+      const next = { ...current };
+      delete next[actionId];
+      return next;
+    });
+    if (result.ok) {
+      setInputAnswers((current) => {
+        const next = { ...current };
+        delete next[event.request.requestId];
+        return next;
+      });
+      setState((current) => current.status === "ready"
+        ? { ...current, snapshot: result.snapshot, error: null, refreshing: false }
+        : current);
+      return;
+    }
+    setThreadActionErrors((current) => ({
+      ...current,
+      [actionId]: "Input could not be sent. Try again.",
+    }));
+  }, [client, inputAnswers, state]);
 
   const boundTerminalSessionId = state.status === "ready" ? state.snapshot.thread.terminalSessionId ?? null : null;
   const openBoundTerminal = useCallback(async () => {
@@ -109,6 +201,12 @@ export default function AgentThreadRoute() {
 
   const { thread, events } = state.snapshot;
   const terminalSessionId = thread.terminalSessionId ?? "No terminal bound";
+  const resolvedApprovalIds = new Set(events.items
+    .filter((event): event is Extract<AgentThreadEvent, { type: "approval.resolved" }> => event.type === "approval.resolved")
+    .map((event) => event.approvalId));
+  const answeredInputRequestIds = new Set(events.items
+    .filter((event): event is Extract<AgentThreadEvent, { type: "user_input.answered" }> => event.type === "user_input.answered")
+    .map((event) => event.requestId));
 
   return (
     <ScrollView
@@ -169,7 +267,19 @@ export default function AgentThreadRoute() {
         <View style={styles.timeline}>
           <Text style={styles.sectionTitle}>Activity timeline</Text>
           {events.items.map((event) => (
-            <ThreadEventItem key={event.eventId} event={event} />
+            <ThreadEventItem
+              key={event.eventId}
+              event={event}
+              pendingActionIds={pendingActionIds}
+              actionErrors={threadActionErrors}
+              resolved={event.type === "approval.requested"
+                ? resolvedApprovalIds.has(event.approval.approvalId)
+                : event.type === "user_input.requested" && answeredInputRequestIds.has(event.request.requestId)}
+              inputAnswer={event.type === "user_input.requested" ? inputAnswers[event.request.requestId] ?? "" : ""}
+              onInputAnswerChange={setInputAnswer}
+              onInputAnswerSubmit={submitInputAnswer}
+              onApprovalDecision={submitApprovalDecision}
+            />
           ))}
         </View>
       ) : null}
@@ -186,7 +296,28 @@ function MetaItem({ label, value }: { label: string; value: string }) {
   );
 }
 
-function ThreadEventItem({ event }: { event: AgentThreadEvent }) {
+function ThreadEventItem({
+  event,
+  pendingActionIds,
+  actionErrors,
+  resolved,
+  inputAnswer,
+  onInputAnswerChange,
+  onInputAnswerSubmit,
+  onApprovalDecision,
+}: {
+  event: AgentThreadEvent;
+  pendingActionIds: Record<string, true>;
+  actionErrors: Record<string, ThreadActionError>;
+  resolved: boolean;
+  inputAnswer: string;
+  onInputAnswerChange: (requestId: string, answer: string) => void;
+  onInputAnswerSubmit: (event: Extract<AgentThreadEvent, { type: "user_input.requested" }>) => void;
+  onApprovalDecision: (
+    event: Extract<AgentThreadEvent, { type: "approval.requested" }>,
+    decision: ApprovalDecisionRequest["decision"],
+  ) => void;
+}) {
   const { theme } = useUnistyles();
   const copy = describeThreadEvent(event);
   return (
@@ -197,6 +328,76 @@ function ThreadEventItem({ event }: { event: AgentThreadEvent }) {
       <View style={styles.eventText}>
         <Text style={styles.eventTitle}>{copy.title}</Text>
         <Text selectable style={styles.eventDetail}>{copy.detail}</Text>
+        {event.type === "approval.requested" && !resolved ? (
+          <View style={styles.inlineActionGroup}>
+            {event.approval.allowedDecisions.map((decision) => {
+              const label = formatApprovalDecision(decision);
+              const actionId = `${event.approval.approvalId}:${decision}`;
+              const pending = Boolean(pendingActionIds[actionId]);
+              const rowPending = event.approval.allowedDecisions.some((allowedDecision) =>
+                Boolean(pendingActionIds[`${event.approval.approvalId}:${allowedDecision}`]));
+              return (
+                <Pressable
+                  accessibilityRole="button"
+                  accessibilityLabel={`${label} ${event.approval.title}`}
+                  disabled={rowPending}
+                  key={decision}
+                  onPress={() => onApprovalDecision(event, decision)}
+                  style={[
+                    decision === "approve" || decision === "approve_for_session"
+                      ? styles.inlinePrimaryButton
+                      : styles.inlineSecondaryButton,
+                    pending ? styles.inlineButtonDisabled : null,
+                  ]}
+                >
+                  <Text
+                    style={decision === "approve" || decision === "approve_for_session"
+                      ? styles.inlinePrimaryButtonText
+                      : styles.inlineSecondaryButtonText}
+                  >
+                    {pending ? "Sending" : label}
+                  </Text>
+                </Pressable>
+              );
+            })}
+            {findApprovalActionError(event, actionErrors) ? (
+              <Text style={styles.inlineError}>{findApprovalActionError(event, actionErrors)}</Text>
+            ) : null}
+          </View>
+        ) : null}
+        {event.type === "user_input.requested" && !resolved ? (
+          <View style={styles.inputComposer}>
+            <TextInput
+              accessibilityLabel={`Answer ${event.request.title}`}
+              multiline
+              numberOfLines={3}
+              onChangeText={(value) => onInputAnswerChange(event.request.requestId, value)}
+              placeholder={event.request.placeholder ?? "Answer"}
+              placeholderTextColor={theme.colors.mutedForeground}
+              style={styles.inputField}
+              value={inputAnswer}
+            />
+            <Pressable
+              accessibilityRole="button"
+              accessibilityLabel={`Send ${event.request.title}`}
+              disabled={Boolean(pendingActionIds[`${event.request.requestId}:answer`]) || !inputAnswer.trim()}
+              onPress={() => onInputAnswerSubmit(event)}
+              style={[
+                styles.inlinePrimaryButton,
+                Boolean(pendingActionIds[`${event.request.requestId}:answer`]) || !inputAnswer.trim()
+                  ? styles.inlineButtonDisabled
+                  : null,
+              ]}
+            >
+              <Text style={styles.inlinePrimaryButtonText}>
+                {pendingActionIds[`${event.request.requestId}:answer`] ? "Sending" : "Send"}
+              </Text>
+            </Pressable>
+            {actionErrors[`${event.request.requestId}:answer`] ? (
+              <Text style={styles.inlineError}>{actionErrors[`${event.request.requestId}:answer`]}</Text>
+            ) : null}
+          </View>
+        ) : null}
       </View>
     </View>
   );
@@ -256,6 +457,35 @@ function describeThreadEvent(event: AgentThreadEvent): { icon: keyof typeof Ioni
 
 function capitalize(value: string): string {
   return `${value.slice(0, 1).toUpperCase()}${value.slice(1)}`;
+}
+
+function formatApprovalDecision(decision: ApprovalDecisionRequest["decision"]): string {
+  switch (decision) {
+    case "approve":
+      return "Approve";
+    case "approve_for_session":
+      return "Approve for session";
+    case "decline":
+      return "Decline";
+    case "cancel":
+      return "Cancel";
+  }
+}
+
+function findApprovalActionError(
+  event: Extract<AgentThreadEvent, { type: "approval.requested" }>,
+  actionErrors: Record<string, ThreadActionError>,
+): ThreadActionError | null {
+  for (const decision of event.approval.allowedDecisions) {
+    const error = actionErrors[`${event.approval.approvalId}:${decision}`];
+    if (error) return error;
+  }
+  return null;
+}
+
+function createMobileClientRequestId(): `req_${string}` {
+  const random = Math.random().toString(36).slice(2, 10).padEnd(8, "0");
+  return `req_mobile_${Date.now().toString(36)}_${random}`;
 }
 
 const styles = StyleSheet.create((theme, rt) => ({
@@ -427,5 +657,61 @@ const styles = StyleSheet.create((theme, rt) => ({
     fontFamily: theme.fonts.mono,
     fontSize: 12,
     color: theme.colors.mutedForeground,
+  },
+  inlineActionGroup: {
+    marginTop: theme.spacing.sm,
+    flexDirection: "row",
+    flexWrap: "wrap",
+    gap: theme.spacing.sm,
+    alignItems: "center",
+  },
+  inlinePrimaryButton: {
+    minHeight: 36,
+    borderRadius: 18,
+    paddingHorizontal: theme.spacing.md,
+    alignItems: "center",
+    justifyContent: "center",
+    backgroundColor: theme.colors.forest,
+  },
+  inlinePrimaryButtonText: {
+    fontFamily: theme.fonts.sansSemiBold,
+    fontSize: 12,
+    color: theme.colors.background,
+  },
+  inlineSecondaryButton: {
+    minHeight: 36,
+    borderRadius: 18,
+    paddingHorizontal: theme.spacing.md,
+    alignItems: "center",
+    justifyContent: "center",
+    backgroundColor: theme.colors.background,
+    borderWidth: 1,
+    borderColor: theme.colors.border,
+  },
+  inlineSecondaryButtonText: {
+    fontFamily: theme.fonts.sansSemiBold,
+    fontSize: 12,
+    color: theme.colors.forest,
+  },
+  inlineButtonDisabled: {
+    opacity: 0.55,
+  },
+  inputComposer: {
+    marginTop: theme.spacing.sm,
+    gap: theme.spacing.sm,
+  },
+  inputField: {
+    minHeight: 84,
+    borderRadius: 12,
+    borderCurve: "continuous" as const,
+    borderWidth: 1,
+    borderColor: theme.colors.border,
+    backgroundColor: theme.colors.background,
+    paddingHorizontal: theme.spacing.md,
+    paddingVertical: theme.spacing.sm,
+    fontFamily: theme.fonts.sans,
+    fontSize: 14,
+    color: theme.colors.foreground,
+    textAlignVertical: "top",
   },
 }));

--- a/apps/mobile/lib/gateway-client.ts
+++ b/apps/mobile/lib/gateway-client.ts
@@ -6,11 +6,15 @@ import {
 } from "@/lib/terminal-state";
 import {
   AgentThreadSnapshotSchema,
+  ApprovalDecisionRequestSchema,
+  ApprovalIdSchema,
   CursorSchema,
+  RequestIdSchema,
   ReviewSnapshotSchema,
   ReviewSummarySchema,
   RuntimeSummarySchema,
   ThreadIdSchema,
+  UserInputAnswerRequestSchema,
   type CreateAgentThreadRequest,
   type ReviewSnapshot,
   type RuntimeSummary,
@@ -91,6 +95,14 @@ export type CodingAgentThreadCreateResult =
 export type CodingAgentThreadSnapshotResult =
   | { ok: true; snapshot: z.infer<typeof AgentThreadSnapshotSchema> }
   | { ok: false; error: "Thread state unavailable" };
+
+export type CodingAgentApprovalDecisionResult =
+  | { ok: true; snapshot: z.infer<typeof AgentThreadSnapshotSchema> }
+  | { ok: false; error: "Approval could not be sent. Try again." };
+
+export type CodingAgentInputAnswerResult =
+  | { ok: true; snapshot: z.infer<typeof AgentThreadSnapshotSchema> }
+  | { ok: false; error: "Input could not be sent. Try again." };
 
 const CodingAgentReviewListSchema = boundedListSchema(ReviewSummarySchema, 50);
 
@@ -598,6 +610,90 @@ export class GatewayClient {
     } catch {
       console.warn("[mobile] /api/coding-agents/threads/:threadId unavailable");
       return { ok: false, error: "Thread state unavailable" };
+    }
+  }
+
+  async submitCodingAgentApprovalDecision(options: {
+    threadId: string;
+    approvalId: string;
+    decision: unknown;
+    correlationId: string;
+    clientRequestId: string;
+  }): Promise<CodingAgentApprovalDecisionResult> {
+    try {
+      const parsedThreadId = ThreadIdSchema.safeParse(options.threadId);
+      const parsedApprovalId = ApprovalIdSchema.safeParse(options.approvalId);
+      const parsedBody = ApprovalDecisionRequestSchema.safeParse({
+        decision: options.decision,
+        correlationId: options.correlationId,
+        clientRequestId: options.clientRequestId,
+      });
+      if (!parsedThreadId.success || !parsedApprovalId.success || !parsedBody.success) {
+        return { ok: false, error: "Approval could not be sent. Try again." };
+      }
+      const res = await this.fetchGateway(
+        `/api/coding-agents/threads/${encodeURIComponent(parsedThreadId.data)}/approvals/${encodeURIComponent(parsedApprovalId.data)}/decision`,
+        {
+          method: "POST",
+          body: JSON.stringify(parsedBody.data),
+        },
+      );
+      if (!res.ok) {
+        console.warn("[mobile] /api/coding-agents/threads/:threadId/approvals/:approvalId/decision unavailable", res.status);
+        return { ok: false, error: "Approval could not be sent. Try again." };
+      }
+      const body = await res.json();
+      const parsed = AgentThreadSnapshotSchema.safeParse(body);
+      if (!parsed.success) {
+        console.warn("[mobile] /api/coding-agents/threads/:threadId/approvals/:approvalId/decision returned invalid payload");
+        return { ok: false, error: "Approval could not be sent. Try again." };
+      }
+      return { ok: true, snapshot: parsed.data };
+    } catch {
+      console.warn("[mobile] /api/coding-agents/threads/:threadId/approvals/:approvalId/decision unavailable");
+      return { ok: false, error: "Approval could not be sent. Try again." };
+    }
+  }
+
+  async submitCodingAgentInputAnswer(options: {
+    threadId: string;
+    inputRequestId: string;
+    answer: string;
+    correlationId: string;
+    clientRequestId: string;
+  }): Promise<CodingAgentInputAnswerResult> {
+    try {
+      const parsedThreadId = ThreadIdSchema.safeParse(options.threadId);
+      const parsedInputRequestId = RequestIdSchema.safeParse(options.inputRequestId);
+      const parsedBody = UserInputAnswerRequestSchema.safeParse({
+        answer: options.answer,
+        correlationId: options.correlationId,
+        clientRequestId: options.clientRequestId,
+      });
+      if (!parsedThreadId.success || !parsedInputRequestId.success || !parsedBody.success) {
+        return { ok: false, error: "Input could not be sent. Try again." };
+      }
+      const res = await this.fetchGateway(
+        `/api/coding-agents/threads/${encodeURIComponent(parsedThreadId.data)}/inputs/${encodeURIComponent(parsedInputRequestId.data)}/answer`,
+        {
+          method: "POST",
+          body: JSON.stringify(parsedBody.data),
+        },
+      );
+      if (!res.ok) {
+        console.warn("[mobile] /api/coding-agents/threads/:threadId/inputs/:inputRequestId/answer unavailable", res.status);
+        return { ok: false, error: "Input could not be sent. Try again." };
+      }
+      const body = await res.json();
+      const parsed = AgentThreadSnapshotSchema.safeParse(body);
+      if (!parsed.success) {
+        console.warn("[mobile] /api/coding-agents/threads/:threadId/inputs/:inputRequestId/answer returned invalid payload");
+        return { ok: false, error: "Input could not be sent. Try again." };
+      }
+      return { ok: true, snapshot: parsed.data };
+    } catch {
+      console.warn("[mobile] /api/coding-agents/threads/:threadId/inputs/:inputRequestId/answer unavailable");
+      return { ok: false, error: "Input could not be sent. Try again." };
     }
   }
 

--- a/specs/105-coding-agent-shells/current-state.md
+++ b/specs/105-coding-agent-shells/current-state.md
@@ -1,12 +1,12 @@
 # Current State: Coding Agent Shells
 
-**Branch stack**: `spec/coding-agent-shells` plus stacked implementation branches through `105-coding-agent-desktop-input-actions`
+**Branch stack**: `spec/coding-agent-shells` plus stacked implementation branches through `105-coding-agent-mobile-thread-actions`
 **Updated**: 2026-07-07
 **Scope**: Inventory for the coding-agent desktop/mobile shell work. This file records the current Matrix-native route, contract, client, and regression-test state so later slices keep gateway/runtime as source of truth and keep desktop/mobile as thin shells.
 
 ## Summary
 
-The stack currently has shared contracts, a gateway runtime summary read model, read-only desktop and mobile workspaces behind flags, thread create/replay/abort/event streaming, provider adapters, a workspace-backed provider, approval/input route handling, a read-only coding-agent review summary route/client contract, desktop/mobile read-only review summary panels, and a read-only coding-agent review snapshot route with bounded file metadata from safe owner worktree diffs plus findings fallback metadata. Review snapshots can include bounded per-hunk diff lines with truncation markers. Desktop and mobile review details render changed-file counts, selectable hunk coordinate metadata, and gateway-bounded diff lines. Desktop and mobile can seed their existing agent composers from a selected review hunk using bounded prompt context and a `structured_ref` attachment. Mobile active thread rows now open a bounded thread detail route that hydrates `AgentThreadSnapshotSchema` through the authenticated gateway client, renders safe thread metadata, event counts, and a read-only snapshot event timeline, and can hand a bound canonical terminal session to the existing mobile Terminal tab. Desktop active thread rows can open a matching attachable bound canonical terminal session in the existing Terminal tab model and selected desktop threads now hydrate `AgentThreadSnapshotSchema` through trusted main-process IPC for safe metadata and event timeline rendering. Desktop approval-request events can submit allowed decisions, and desktop user-input request events can submit bounded answers, through trusted main-process IPC and replace local details with the gateway-returned bounded thread snapshot. Desktop native notification clicks focus the Agents tab and visibly select the bounded coding-agent workspace thread reference in the active thread list. Full file content and preview coding-agent surfaces are contract-only or existing workspace routes; dedicated preview shell UI is not yet integrated.
+The stack currently has shared contracts, a gateway runtime summary read model, read-only desktop and mobile workspaces behind flags, thread create/replay/abort/event streaming, provider adapters, a workspace-backed provider, approval/input route handling, a read-only coding-agent review summary route/client contract, desktop/mobile read-only review summary panels, and a read-only coding-agent review snapshot route with bounded file metadata from safe owner worktree diffs plus findings fallback metadata. Review snapshots can include bounded per-hunk diff lines with truncation markers. Desktop and mobile review details render changed-file counts, selectable hunk coordinate metadata, and gateway-bounded diff lines. Desktop and mobile can seed their existing agent composers from a selected review hunk using bounded prompt context and a `structured_ref` attachment. Mobile active thread rows now open a bounded thread detail route that hydrates `AgentThreadSnapshotSchema` through the authenticated gateway client, renders safe thread metadata, event counts, and snapshot event timeline, can hand a bound canonical terminal session to the existing mobile Terminal tab, and can submit approval decisions plus user-input answers through the authenticated gateway client. Desktop active thread rows can open a matching attachable bound canonical terminal session in the existing Terminal tab model and selected desktop threads now hydrate `AgentThreadSnapshotSchema` through trusted main-process IPC for safe metadata and event timeline rendering. Desktop approval-request events can submit allowed decisions, and desktop user-input request events can submit bounded answers, through trusted main-process IPC and replace local details with the gateway-returned bounded thread snapshot. Desktop native notification clicks focus the Agents tab and visibly select the bounded coding-agent workspace thread reference in the active thread list. Full file content and preview coding-agent surfaces are contract-only or existing workspace routes; dedicated preview shell UI is not yet integrated.
 
 Current source-of-truth boundaries:
 
@@ -240,6 +240,8 @@ Gateway client:
 - `apps/mobile/lib/gateway-client.ts`
 - `getCodingAgentRuntimeSummary()` calls `GET /api/coding-agents/summary`, validates `RuntimeSummarySchema`, and returns the safe `"Runtime summary unavailable"` error on failure.
 - `getCodingAgentThreadSnapshot()` calls `GET /api/coding-agents/threads/:threadId`, validates `AgentThreadSnapshotSchema`, and returns the safe `"Thread state unavailable"` error on failure.
+- `submitCodingAgentApprovalDecision()` posts bounded approval decisions to `POST /api/coding-agents/threads/:threadId/approvals/:approvalId/decision`, validates `AgentThreadSnapshotSchema`, and returns the safe `"Approval could not be sent. Try again."` error on failure.
+- `submitCodingAgentInputAnswer()` posts bounded answers to `POST /api/coding-agents/threads/:threadId/inputs/:inputRequestId/answer`, validates `AgentThreadSnapshotSchema`, and returns the safe `"Input could not be sent. Try again."` error on failure.
 - `getCodingAgentReviews()` calls `GET /api/coding-agents/reviews`, validates a bounded review summary list, and returns the safe `"Review state unavailable"` error on failure.
 - Existing terminal session methods call `/api/terminal/sessions`.
 
@@ -253,7 +255,9 @@ Screen:
 - Review snapshot details render bounded file paths, additions/deletions, partial markers, selectable hunk coordinate metadata, gateway-bounded hunk lines, and safe finding summaries.
 - Safe generic review error state if review summaries are unavailable; review failures do not drop the runtime summary dashboard.
 - Composer route for creating accepted coding-agent threads.
-- Active thread rows navigate to `/agents/:threadId`; the thread route hydrates a bounded thread snapshot, shows provider/status/terminal metadata, event counts, loading, refresh, safe generic error states, and a read-only event timeline for gateway-bounded snapshot events. Assistant text and file-change events render generic summaries instead of raw event text or paths. Live replay/subscription and richer transcript grouping remain follow-up work.
+- Active thread rows navigate to `/agents/:threadId`; the thread route hydrates a bounded thread snapshot, shows provider/status/terminal metadata, event counts, loading, refresh, safe generic error states, and an event timeline for gateway-bounded snapshot events. Assistant text and file-change events render generic summaries instead of raw event text or paths. Live replay/subscription and richer transcript grouping remain follow-up work.
+- Approval-request events render allowed decisions in the mobile thread route. Decisions use mobile-generated idempotency request ids, go through the authenticated gateway client, and replace local thread details with the gateway-returned bounded snapshot. Failed decisions show a generic recovery-oriented message.
+- User-input request events render a transient bounded answer composer in the mobile thread route. Answers use mobile-generated idempotency request ids, go through the authenticated gateway client, and replace local thread details with the gateway-returned bounded snapshot. Failed submissions show a generic recovery-oriented message.
 - Thread details with a bound `terminalSessionId` can open the existing `/terminal` tab after persisting only the safe canonical shell-session reference in `mobile-shell-state`; terminal output and transcripts remain outside AsyncStorage.
 - Flag: `apps/mobile/lib/feature-flags.ts` with `EXPO_PUBLIC_CODING_AGENTS_MOBILE_WORKSPACE === "1"`.
 
@@ -268,6 +272,7 @@ Focused tests:
 
 - `apps/mobile/__tests__/gateway-client.test.ts`
 - `apps/mobile/__tests__/agents-screen.test.tsx`
+- `apps/mobile/__tests__/agent-thread-screen.test.tsx`
 - `apps/mobile/__tests__/agent-workspace-state.test.ts`
 
 ## Browser Shell State


### PR DESCRIPTION
## Summary
- Add mobile gateway-client methods for coding-agent approval decisions and input answers using shared contract validation.
- Add mobile thread-route approval buttons and transient input composer that replace local state with gateway-returned snapshots.
- Update the coding-agent shell current-state note for this mobile action slice.

## Required invariants
- Source of truth: gateway/runtime thread snapshots remain authoritative; mobile only renders returned bounded snapshots.
- Lock/transaction scope: no database or persisted-state migration is introduced in this slice.
- Acceptable orphan states: an in-flight mobile action may fail locally and leave the previous snapshot visible with a generic recovery message.
- Auth source of truth: mobile uses the existing authenticated gateway client; no provider credentials or raw bearer credentials are persisted by this route.
- Deferred scope: live thread event subscription, richer transcript grouping, and dedicated preview/file surfaces remain follow-up work.

## Validation
- pnpm --filter matrix-os-mobile run test -- --runTestsByPath __tests__/gateway-client.test.ts __tests__/agent-thread-screen.test.tsx --runInBand
- pnpm --filter matrix-os-mobile run test
- pnpm --filter matrix-os-mobile run lint
- pnpm --filter matrix-os-mobile exec tsc --noEmit
- bun run check:patterns
- bun run typecheck
- git diff --check
- restricted wording scan for this slice

## Notes
- vp check, vp run typecheck, and vp run lint:mobile could not run because vp is not installed in this environment.