### PR TITLE
feat(gateway): summarize agent attention threads

### DIFF
--- a/apps/mobile/__tests__/gateway-client.test.ts
+++ b/apps/mobile/__tests__/gateway-client.test.ts
@@ -250,6 +250,11 @@ describe("GatewayClient", () => {
         hasMore: false,
         limit: 20,
       },
+      attentionThreads: {
+        items: [],
+        hasMore: false,
+        limit: 20,
+      },
       terminalSessions: {
         items: [],
         limit: 20,

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -539,6 +539,11 @@ export const RuntimeSummarySchema = z.object({
   providers: z.array(AgentProviderSummarySchema).max(20),
   projects: boundedListSchema(ProjectSummarySchema, 50),
   activeThreads: boundedListSchema(AgentThreadSummarySchema, 50),
+  attentionThreads: boundedListSchema(AgentThreadSummarySchema, 50).default({
+    items: [],
+    hasMore: false,
+    limit: 20,
+  }),
   terminalSessions: boundedListSchema(TerminalSessionSummarySchema, 50),
   recentActivity: boundedListSchema(ActivityEventSummarySchema, 100),
   limits: RuntimeLimitsSchema,

--- a/packages/gateway/src/coding-agents/runtime-summary.ts
+++ b/packages/gateway/src/coding-agents/runtime-summary.ts
@@ -37,6 +37,7 @@ export interface CodingAgentRuntimeSummaryService {
 
 export interface CodingAgentThreadSummaryStore {
   listThreads(principal: RequestPrincipal): Promise<{ items: AgentThreadSummary[]; hasMore: boolean; limit: number }>;
+  listAttentionThreads?(principal: RequestPrincipal): Promise<{ items: AgentThreadSummary[]; hasMore: boolean; limit: number }>;
 }
 
 export interface CodingAgentRuntimeSummaryOptions {
@@ -182,6 +183,19 @@ async function readActiveThreads(
   }
 }
 
+async function readAttentionThreads(
+  store: CodingAgentThreadSummaryStore | undefined,
+  principal: RequestPrincipal,
+): Promise<{ items: AgentThreadSummary[]; hasMore: boolean; limit: number }> {
+  if (!store?.listAttentionThreads) return { items: [], hasMore: false, limit: 20 };
+  try {
+    return await store.listAttentionThreads(principal);
+  } catch (err: unknown) {
+    console.warn("[coding-agents] attention summary unavailable:", err instanceof Error ? err.message : String(err));
+    return { items: [], hasMore: false, limit: 20 };
+  }
+}
+
 async function readTerminalSessions(
   registry: CodingAgentTerminalSessionRegistry | undefined,
   homePath: string,
@@ -227,6 +241,7 @@ export function createCodingAgentRuntimeSummaryService(
       );
       const providers = await readProviders(options.agentCredentials, principal);
       const activeThreads = await readActiveThreads(options.threads, principal);
+      const attentionThreads = await readAttentionThreads(options.threads, principal);
       const threadsEnabled = Boolean(options.threads);
       const workspaceEnabled = threadsEnabled && options.capabilities?.workspace === true;
       const approvalsEnabled = threadsEnabled && options.capabilities?.approvals === true;
@@ -254,6 +269,7 @@ export function createCodingAgentRuntimeSummaryService(
         providers,
         projects: { items: [], hasMore: false, limit: 20 },
         activeThreads,
+        attentionThreads,
         terminalSessions: await terminalSessions,
         recentActivity: { items: [], hasMore: false, limit: 30 },
         limits: {

--- a/packages/gateway/src/coding-agents/thread-store.ts
+++ b/packages/gateway/src/coding-agents/thread-store.ts
@@ -134,6 +134,7 @@ export interface CodingAgentThreadStoreOptions {
 export interface CodingAgentThreadStore {
   createThread(principal: RequestPrincipal, request: CreateAgentThreadRequest): Promise<ThreadCreateResult>;
   listThreads(principal: RequestPrincipal): Promise<{ items: AgentThreadSummary[]; hasMore: boolean; limit: number }>;
+  listAttentionThreads(principal: RequestPrincipal): Promise<{ items: AgentThreadSummary[]; hasMore: boolean; limit: number }>;
   getThread(principal: RequestPrincipal, threadId: string, cursor?: string): Promise<AgentThreadSnapshot>;
   abortThread(principal: RequestPrincipal, threadId: string, clientRequestId: string): Promise<AgentThreadSnapshot>;
   submitApproval(
@@ -230,7 +231,11 @@ function statePath(homePath: string): string {
 async function readState(homePath: string): Promise<StoredThreadState> {
   try {
     const raw = await readFile(statePath(homePath), "utf-8");
-    return StoredThreadStateSchema.parse(JSON.parse(raw));
+    const parsed = StoredThreadStateSchema.parse(JSON.parse(raw));
+    return {
+      ...parsed,
+      threads: parsed.threads.map(normalizeThreadAttention),
+    };
   } catch (err: unknown) {
     if (err instanceof Error && "code" in err && (err as NodeJS.ErrnoException).code === "ENOENT") {
       return emptyState();
@@ -258,7 +263,7 @@ function genericTitle(): string {
 function applyEvent(thread: StoredThread, event: AgentThreadEvent): StoredThread {
   const updatedAt = event.occurredAt;
   if (event.type === "thread.status") {
-    return { ...thread, status: event.status, updatedAt };
+    return normalizeThreadAttention({ ...thread, status: event.status, updatedAt });
   }
   if (event.type === "thread.completed") {
     return {
@@ -347,8 +352,22 @@ function activeThread(thread: StoredThread): boolean {
   return !["completed", "failed", "aborted", "archived"].includes(thread.status);
 }
 
+function normalizeThreadAttention(thread: StoredThread): StoredThread {
+  if (thread.status === "failed") return { ...thread, attention: "failed" };
+  if (thread.status === "waiting_for_approval") return { ...thread, attention: "approval_required" };
+  if (thread.status === "waiting_for_input") return { ...thread, attention: "input_required" };
+  if (["queued", "starting", "running", "completed", "aborted", "archived"].includes(thread.status)) {
+    return { ...thread, attention: "none" };
+  }
+  return thread;
+}
+
 function terminalThread(thread: StoredThread): boolean {
   return !activeThread(thread);
+}
+
+function attentionThread(thread: StoredThread): boolean {
+  return thread.attention !== "none" && thread.status !== "archived";
 }
 
 function stoppedRuntimeStatus(
@@ -686,6 +705,17 @@ export function createCodingAgentThreadStore(options: CodingAgentThreadStoreOpti
       const state = await readState(options.homePath);
       const ownerThreads = state.threads
         .filter((thread) => thread.ownerId === principal.userId && activeThread(thread))
+        .sort((a, b) => Date.parse(b.updatedAt) - Date.parse(a.updatedAt));
+      return {
+        items: ownerThreads.slice(0, THREAD_LIST_LIMIT).map(stripOwner),
+        hasMore: ownerThreads.length > THREAD_LIST_LIMIT,
+        limit: THREAD_LIST_LIMIT,
+      };
+    },
+    async listAttentionThreads(principal) {
+      const state = await readState(options.homePath);
+      const ownerThreads = state.threads
+        .filter((thread) => thread.ownerId === principal.userId && attentionThread(thread))
         .sort((a, b) => Date.parse(b.updatedAt) - Date.parse(a.updatedAt));
       return {
         items: ownerThreads.slice(0, THREAD_LIST_LIMIT).map(stripOwner),

--- a/specs/105-coding-agent-shells/current-state.md
+++ b/specs/105-coding-agent-shells/current-state.md
@@ -1,12 +1,12 @@
 # Current State: Coding Agent Shells
 
-**Branch stack**: `spec/coding-agent-shells` plus stacked implementation branches through `105-coding-agent-mobile-attention`
+**Branch stack**: `spec/coding-agent-shells` plus stacked implementation branches through `105-coding-agent-attention-summary`
 **Updated**: 2026-07-07
 **Scope**: Inventory for the coding-agent desktop/mobile shell work. This file records the current Matrix-native route, contract, client, and regression-test state so later slices keep gateway/runtime as source of truth and keep desktop/mobile as thin shells.
 
 ## Summary
 
-The stack currently has shared contracts, a gateway runtime summary read model, read-only desktop and mobile workspaces behind flags, thread create/replay/abort/event streaming, provider adapters, a workspace-backed provider, approval/input route handling, a read-only coding-agent review summary route/client contract, desktop/mobile read-only review summary panels, and a read-only coding-agent review snapshot route with bounded file metadata from safe owner worktree diffs plus findings fallback metadata. Review snapshots can include bounded per-hunk diff lines with truncation markers. Desktop and mobile review details render changed-file counts, selectable hunk coordinate metadata, and gateway-bounded diff lines. Desktop and mobile can seed their existing agent composers from a selected review hunk using bounded prompt context and a `structured_ref` attachment. Mobile active thread rows now open a bounded thread detail route that hydrates `AgentThreadSnapshotSchema` through the authenticated gateway client, renders safe thread metadata, event counts, in-app attention labels, and snapshot event timeline, can hand a bound canonical terminal session to the existing mobile Terminal tab, and can submit approval decisions plus user-input answers through the authenticated gateway client. Desktop active thread rows can open a matching attachable bound canonical terminal session in the existing Terminal tab model and selected desktop threads now hydrate `AgentThreadSnapshotSchema` through trusted main-process IPC for safe metadata and event timeline rendering. Desktop approval-request events can submit allowed decisions, and desktop user-input request events can submit bounded answers, through trusted main-process IPC and replace local details with the gateway-returned bounded thread snapshot. Desktop native notification clicks focus the Agents tab and visibly select the bounded coding-agent workspace thread reference in the active thread list. Full file content and preview coding-agent surfaces are contract-only or existing workspace routes; dedicated preview shell UI is not yet integrated.
+The stack currently has shared contracts, a gateway runtime summary read model, a gateway-owned bounded attention summary, read-only desktop and mobile workspaces behind flags, thread create/replay/abort/event streaming, provider adapters, a workspace-backed provider, approval/input route handling, a read-only coding-agent review summary route/client contract, desktop/mobile read-only review summary panels, and a read-only coding-agent review snapshot route with bounded file metadata from safe owner worktree diffs plus findings fallback metadata. Review snapshots can include bounded per-hunk diff lines with truncation markers. Desktop and mobile review details render changed-file counts, selectable hunk coordinate metadata, and gateway-bounded diff lines. Desktop and mobile can seed their existing agent composers from a selected review hunk using bounded prompt context and a `structured_ref` attachment. Mobile active thread rows now open a bounded thread detail route that hydrates `AgentThreadSnapshotSchema` through the authenticated gateway client, renders safe thread metadata, event counts, in-app attention labels, and snapshot event timeline, can hand a bound canonical terminal session to the existing mobile Terminal tab, and can submit approval decisions plus user-input answers through the authenticated gateway client. Desktop active thread rows can open a matching attachable bound canonical terminal session in the existing Terminal tab model and selected desktop threads now hydrate `AgentThreadSnapshotSchema` through trusted main-process IPC for safe metadata and event timeline rendering. Desktop approval-request events can submit allowed decisions, and desktop user-input request events can submit bounded answers, through trusted main-process IPC and replace local details with the gateway-returned bounded thread snapshot. Desktop native notification clicks focus the Agents tab and visibly select the bounded coding-agent workspace thread reference in the active thread list. Full file content and preview coding-agent surfaces are contract-only or existing workspace routes; dedicated preview shell UI is not yet integrated.
 
 Current source-of-truth boundaries:
 
@@ -22,7 +22,7 @@ Package: `packages/contracts/src/index.ts`
 Implemented coding-agent schemas:
 
 - IDs and bounds: `RuntimeIdSchema`, `ProviderIdSchema`, `ProjectIdSchema`, `TaskIdSchema`, `ThreadIdSchema`, `EventIdSchema`, `ApprovalIdSchema`, `RequestIdSchema`, `CorrelationIdSchema`, `TerminalSessionIdSchema`, `WorktreeIdSchema`, `CursorSchema`, `IsoTimestampSchema`, `SafeDisplayStringSchema`, `SafeClientErrorSchema`.
-- Runtime summary: `RuntimeTargetSchema`, `RuntimeCapabilitySchema`, `RuntimeLimitsSchema`, `RuntimeSummarySchema`.
+- Runtime summary: `RuntimeTargetSchema`, `RuntimeCapabilitySchema`, `RuntimeLimitsSchema`, `RuntimeSummarySchema` with bounded `activeThreads` and separate bounded `attentionThreads`.
 - Providers: `AgentProviderSummarySchema`, provider availability/install/auth enums, `AgentModeSchema`, `ApprovalPolicySchema`, `SandboxModeSchema`, `SafeSetupActionSchema`.
 - Threads: `CreateAgentThreadRequestSchema`, `AgentThreadSummarySchema`, `AgentThreadStatusSchema`, `AgentAttachmentSchema`, `AgentThreadSnapshotSchema`.
 - Events: `AgentThreadEventSchema` discriminated union with lifecycle, text delta, tool activity, approval/input, file change, review ready, terminal bound, safe error, and completion event variants.
@@ -98,13 +98,14 @@ Current summary sources:
 - Capability flags.
 - Provider summaries from the coding-agent provider registry.
 - Active thread summaries from the thread store when present.
+- Attention thread summaries from the thread store when present, including failed or waiting threads without changing the active-thread list semantics.
 - Terminal session summaries from the existing terminal registry adapter.
 - Bounded list metadata and runtime limits.
 
 Safe degradation:
 
 - Optional dependency failures return partial safe summaries.
-- Summary tests assert caps, stable sort, and no sensitive fields.
+- Summary tests assert caps, stable sort, attention list separation, and no sensitive fields.
 
 Focused tests:
 
@@ -365,5 +366,5 @@ git diff --check
 - File/review/preview shell surfaces: read-only review summaries now have coding-agent contracts/routes/desktop IPC/mobile clients plus desktop and mobile read-only review panels. A read-only review snapshot route now exposes bounded diff hunk metadata and capped hunk line bodies from safe owner worktrees plus partial findings-derived fallback metadata for later shell diff panels. Full file contents and previews are not implemented yet.
 - Approval/input shell actions: desktop approval decisions and user-input answers now have trusted IPC, main-process gateway submission, bounded UI controls, and focused tests. Remaining work: mobile approval/input action sheets and cross-shell resolved-state refresh tests.
 - Browser shell entry point: Canvas-first placement is still undecided.
-- Notifications/attention routing: desktop notification IPC exists and notification clicks focus the coding-agent workspace thread in the Agents tab with a visible current-thread marker. Mobile now shows in-app active-thread attention badges and thread-detail banners from gateway-owned thread attention state. Remaining work: OS-level thread attention notifications are not yet wired end-to-end from gateway events, and failed-thread list surfacing still needs a gateway summary model beyond active threads.
+- Notifications/attention routing: desktop notification IPC exists and notification clicks focus the coding-agent workspace thread in the Agents tab with a visible current-thread marker. Gateway runtime summaries now expose bounded `attentionThreads` separately from `activeThreads`, allowing failed or waiting attention to be surfaced without reclassifying terminal threads as active. Mobile now shows in-app active-thread attention badges and thread-detail banners from gateway-owned thread attention state. Remaining work: OS-level thread attention notifications are not yet wired end-to-end from gateway events, and desktop/mobile dashboards do not yet render the new `attentionThreads` list directly.
 - Public docs: public Matrix OS docs should be updated once the user-facing coding-agent shell flow is stable enough to document.

--- a/tests/contracts/coding-agents.test.ts
+++ b/tests/contracts/coding-agents.test.ts
@@ -66,6 +66,21 @@ describe("coding agent contracts", () => {
       providers: [],
       projects: { items: [], hasMore: false, limit: 20 },
       activeThreads: { items: [], hasMore: false, limit: 20 },
+      attentionThreads: {
+        items: [
+          {
+            id: "thread_attention",
+            providerId: "codex",
+            title: "Approve deployment",
+            status: "waiting_for_approval",
+            attention: "approval_required",
+            createdAt: now,
+            updatedAt: now,
+          },
+        ],
+        hasMore: false,
+        limit: 20,
+      },
       terminalSessions: {
         items: [
           {
@@ -90,6 +105,10 @@ describe("coding agent contracts", () => {
       serverTime: now,
     });
 
+    expect(summary.attentionThreads.items[0]).toMatchObject({
+      id: "thread_attention",
+      attention: "approval_required",
+    });
     expect(summary.terminalSessions.items[0]?.attachable).toBe(true);
     expect(() =>
       RuntimeSummarySchema.parse({

--- a/tests/gateway/coding-agents-summary.test.ts
+++ b/tests/gateway/coding-agents-summary.test.ts
@@ -287,6 +287,51 @@ describe("coding agent runtime summary", () => {
     expect(capability(summary, "codingAgentsApprovals")).toMatchObject({ enabled: false });
   });
 
+  it("exposes bounded attention threads separately from active threads", async () => {
+    const activeThread = {
+      id: "thread_running",
+      providerId: "codex",
+      title: "Continue implementation",
+      status: "running",
+      attention: "none",
+      createdAt: now.toISOString(),
+      updatedAt: now.toISOString(),
+    } as const;
+    const failedThread = {
+      id: "thread_failed",
+      providerId: "codex",
+      title: "Repair failed run",
+      status: "failed",
+      attention: "failed",
+      createdAt: now.toISOString(),
+      updatedAt: new Date(now.getTime() + 1000).toISOString(),
+    } as const;
+    const approvalThread = {
+      id: "thread_approval",
+      providerId: "codex",
+      title: "Approve deployment",
+      status: "waiting_for_approval",
+      attention: "approval_required",
+      createdAt: now.toISOString(),
+      updatedAt: new Date(now.getTime() + 2000).toISOString(),
+    } as const;
+    const service = createCodingAgentRuntimeSummaryService({
+      homePath: "/home/matrix/home",
+      threads: {
+        listThreads: async () => ({ items: [activeThread, approvalThread], hasMore: false, limit: 50 }),
+        listAttentionThreads: async () => ({ items: [approvalThread, failedThread], hasMore: false, limit: 50 }),
+      },
+      now: () => now,
+      runtime: { id: "rt_primary", label: "Primary Matrix computer" },
+    });
+
+    const summary = RuntimeSummarySchema.parse(await service.getSummary(testPrincipal));
+
+    expect(summary.activeThreads.items.map((thread) => thread.id)).toEqual(["thread_running", "thread_approval"]);
+    expect(summary.attentionThreads.items.map((thread) => thread.id)).toEqual(["thread_approval", "thread_failed"]);
+    expect(JSON.stringify(summary)).not.toMatch(/\/home\/matrix|Postgres|token|secret/i);
+  });
+
   it("keeps approvals disabled for workspace providers without approval decision bridging", async () => {
     const service = createCodingAgentRuntimeSummaryService({
       homePath: "/home/matrix/home",

--- a/tests/gateway/coding-agents-threads.test.ts
+++ b/tests/gateway/coding-agents-threads.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, readFile } from "node:fs/promises";
+import { mkdtemp, readFile, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { Hono } from "hono";
@@ -430,6 +430,7 @@ describe("coding agent thread lifecycle", () => {
       ...createBody,
       clientRequestId: "req_create_after_duplicate_stop",
     });
+    const attention = await threads.listAttentionThreads(ownerPrincipal);
 
     expect(early).toEqual([]);
     expect(created.snapshot.thread).toMatchObject({
@@ -450,6 +451,88 @@ describe("coding agent thread lifecycle", () => {
       status: "running",
       attention: "none",
       terminalSessionId: "main",
+    });
+    expect(attention.items).toEqual([
+      expect.objectContaining({
+        id: created.snapshot.thread.id,
+        status: "failed",
+        attention: "failed",
+      }),
+    ]);
+    expect(attention.hasMore).toBe(false);
+  });
+
+  it("surfaces failed status-only threads in the attention list", async () => {
+    const homePath = await mkdtemp(join(tmpdir(), "matrix-coding-agent-threads-"));
+    const provider: CodingAgentProviderAdapter = {
+      providerId: "codex",
+      startThread({ thread, now: providerNow, nextEventId }) {
+        return [
+          AgentThreadEventSchema.parse({
+            type: "thread.status",
+            eventId: nextEventId(),
+            threadId: thread.id,
+            occurredAt: providerNow().toISOString(),
+            status: "failed",
+          }),
+        ];
+      },
+    };
+    const threads = createCodingAgentThreadStore({
+      homePath,
+      now: () => baseNow,
+      providers: [provider],
+    });
+
+    const created = await threads.createThread(ownerPrincipal, createBody);
+    const active = await threads.listThreads(ownerPrincipal);
+    const attention = await threads.listAttentionThreads(ownerPrincipal);
+
+    expect(created.snapshot.thread).toMatchObject({
+      status: "failed",
+      attention: "failed",
+    });
+    expect(active.items).toEqual([]);
+    expect(attention.items).toEqual([
+      expect.objectContaining({
+        id: created.snapshot.thread.id,
+        status: "failed",
+        attention: "failed",
+      }),
+    ]);
+  });
+
+  it("normalizes legacy failed threads with missing attention on read", async () => {
+    const homePath = await mkdtemp(join(tmpdir(), "matrix-coding-agent-threads-"));
+    const threads = createCodingAgentThreadStore({
+      homePath,
+      now: () => baseNow,
+      providers: [createFakeCodingAgentProvider({ providerId: "codex" })],
+    });
+    const created = await threads.createThread(ownerPrincipal, createBody);
+    const statePath = join(homePath, "system", "coding-agents", "threads.json");
+    const raw = JSON.parse(await readFile(statePath, "utf-8"));
+    raw.threads = raw.threads.map((thread: { id: string }) => (
+      thread.id === created.snapshot.thread.id
+        ? { ...thread, status: "failed", attention: "none" }
+        : thread
+    ));
+    await writeFile(statePath, JSON.stringify(raw), "utf-8");
+
+    const attention = await threads.listAttentionThreads(ownerPrincipal);
+    const snapshot = await threads.getThread(ownerPrincipal, created.snapshot.thread.id);
+
+    expect(attention.items).toEqual([
+      expect.objectContaining({
+        id: created.snapshot.thread.id,
+        status: "failed",
+        attention: "failed",
+      }),
+    ]);
+    expect(snapshot.thread).toMatchObject({
+      id: created.snapshot.thread.id,
+      status: "failed",
+      attention: "failed",
     });
   });
 


### PR DESCRIPTION
## Summary

- Add a bounded `attentionThreads` list to the shared runtime summary contract.
- Populate `attentionThreads` from the gateway thread store without changing `activeThreads` semantics.
- Keep failed/waiting attention available through gateway-owned summary state for later desktop/mobile shell rendering.
- Update the coding-agent current-state note for this contract/gateway slice.

## Tests

- RED: `pnpm exec vitest run tests/contracts/coding-agents.test.ts --reporter=dot` failed before implementation because `RuntimeSummarySchema` rejected `attentionThreads`.
- RED: `pnpm exec vitest run tests/gateway/coding-agents-summary.test.ts --reporter=dot` failed before implementation because summaries did not expose `attentionThreads`.
- PASS: `pnpm exec vitest run tests/contracts/coding-agents.test.ts tests/gateway/coding-agents-summary.test.ts tests/gateway/coding-agents-threads.test.ts --reporter=dot`
- PASS: `bun run typecheck`
- PASS: `bun run check:patterns` (0 violations; existing warnings only)
- PASS: `git diff --check`
- RED after mobile validation: `pnpm --filter matrix-os-mobile run test` failed because the mobile runtime-summary fixture expected the pre-`attentionThreads` shape.
- PASS: `pnpm --filter matrix-os-mobile run test`
- PASS: `pnpm --filter matrix-os-mobile run lint`
- PASS: `pnpm --filter matrix-os-mobile exec tsc --noEmit`
- PASS: `pnpm --filter desktop run typecheck`
- RED after review fix: `pnpm exec vitest run tests/gateway/coding-agents-threads.test.ts --reporter=dot` failed because status-only failed threads still had `attention: "none"`.
- PASS: `pnpm exec vitest run tests/gateway/coding-agents-threads.test.ts --reporter=dot`
- PASS: `pnpm exec vitest run tests/contracts/coding-agents.test.ts tests/gateway/coding-agents-summary.test.ts tests/gateway/coding-agents-threads.test.ts --reporter=dot`
- PASS: `bun run typecheck`
- PASS: `bun run check:patterns` (0 violations; existing warnings only)
- RED after persisted-state review fix: `pnpm exec vitest run tests/gateway/coding-agents-threads.test.ts --reporter=dot` failed because legacy failed threads with `attention: "none"` were absent from `attentionThreads`.
- PASS: `pnpm exec vitest run tests/gateway/coding-agents-threads.test.ts --reporter=dot`
- PASS: `pnpm exec vitest run tests/contracts/coding-agents.test.ts tests/gateway/coding-agents-summary.test.ts tests/gateway/coding-agents-threads.test.ts --reporter=dot`
- PASS: `bun run typecheck`
- PASS: `bun run check:patterns` (0 violations; existing warnings only)
- PASS: restricted wording scan over touched packages/spec files returned no matches.

## Review/Monitoring

- Stacked on #781.
- Latest branch head is `ebb4f45302d4418f971f6a1ba7b7ef330cc0fe8d`.
- `ready-for-ci` is applied; latest trusted Greptile result is 5/5 on this amended head.
- Automated review threads are resolved.

## Invariants

- Source of truth: gateway/thread store remains the source of runtime attention state; shells only consume summary contracts.
- Persistence: no new persistence technology; existing owner-file thread state is reused.
- Ownership: `listAttentionThreads` is owner-scoped through the same `RequestPrincipal` as active thread summaries.
- Bounded state: `attentionThreads` uses the same bounded list contract and thread summary schema as active thread summaries.
- Auth and routing: no new routes or auth paths; the existing authenticated runtime summary route carries the new field.
- Safe errors: optional attention summary failures degrade to an empty list and log details server-side only.

## Docs

- Internal current-state note updated. Public docs are deferred until desktop/mobile render the new attention list directly.
