### PR TITLE
docs(www): explain coding agent workspaces

### DIFF
--- a/www/content/docs/coding-agents.mdx
+++ b/www/content/docs/coding-agents.mdx
@@ -3,11 +3,29 @@ title: Coding Agents
 description: Install and run coding agents on your Matrix computer.
 ---
 
-import { Callout } from 'fumadocs-ui/components/callout';
-import { Card, Cards } from 'fumadocs-ui/components/card';
-import { Step, Steps } from 'fumadocs-ui/components/steps';
+import { Callout } from "fumadocs-ui/components/callout";
+import { Card, Cards } from "fumadocs-ui/components/card";
+import { Step, Steps } from "fumadocs-ui/components/steps";
 
 Matrix OS runs coding agents on your Matrix computer, not on your laptop. The agent gets the same shell, files, repository, dev server, and Matrix skills that you see in the web shell — and it keeps running after you close your browser.
+
+## Coding workspace
+
+The coding-agent workspace is a shared view of the coding work running on your Matrix computer. When enabled for your runtime, the desktop and mobile shells hydrate from the same gateway summary instead of keeping separate local state.
+
+The workspace can show:
+
+- runtime status for the selected Matrix computer;
+- installed or setup-required coding agents;
+- active agent threads and items that need attention;
+- terminal sessions bound to agent work;
+- review summaries, changed files, and safe diff metadata;
+- file snapshots selected from a review;
+- running app or dev-server previews.
+
+<Callout type="info" title="One source of truth">
+  Desktop, mobile, browser shell, and CLI sessions all reconnect to the same Matrix computer. If an agent keeps running after you close one shell, another shell can reopen the same thread, terminal, review, or preview from the gateway state.
+</Callout>
 
 ## Supported agents
 
@@ -88,3 +106,87 @@ Each agent requires its own credentials. Sign in through the agent's own CLI flo
 ## Matrix skills for agents
 
 Matrix OS syncs a curated skill pack into each agent's skill discovery path at install time. The skills teach agents how to build Matrix apps, use the shell design system, and navigate the project layout. They are stored under `~/agents/skills/` on your Matrix computer and updated when you run `matrix sync`.
+
+## Threads and attention
+
+Agent work is organized into threads. A thread records the selected provider, project or worktree context, lifecycle status, and safe event timeline. Desktop and mobile can reopen a thread to see progress without replaying terminal output into local storage.
+
+Threads may need attention when an agent:
+
+- requests approval for an action;
+- asks for user input;
+- fails and needs review;
+- finishes with results to inspect.
+
+Attention appears in the workspace and can route you to the matching thread. Mobile notification taps and desktop notification clicks use bounded thread references and rehydrate the current thread state before rendering.
+
+## Approvals and input
+
+Some agents ask before taking sensitive actions. Matrix routes those approval requests through the gateway so every shell sees the same pending state.
+
+<Steps>
+  <Step>
+    ### Review the request
+
+    Open the thread from the desktop or mobile coding workspace. The shell shows the bounded action preview, risk label, and allowed decisions.
+  </Step>
+  <Step>
+    ### Decide once
+
+    Approve, decline, or cancel from one shell. Matrix records the decision with an idempotent request id so repeated taps or reconnects do not apply it twice.
+  </Step>
+  <Step>
+    ### Resume everywhere
+
+    Other shells refresh from the gateway snapshot or stream event and show the resolved state.
+  </Step>
+</Steps>
+
+User-input requests work the same way: answer from desktop or mobile, and the thread continues from the shared runtime state.
+
+## Terminal continuity
+
+Coding-agent threads can bind to the same named terminal sessions used by the web shell, desktop app, mobile app, and CLI.
+
+- Opening a bound terminal attaches to the existing Matrix session.
+- Closing a shell does not stop the process.
+- Detaching from a terminal does not end the agent.
+- Ending a terminal session stops the process on the Matrix computer.
+
+Use the existing Terminal surfaces for command output and interactive work. The coding workspace shows enough terminal metadata to reconnect safely, but it does not persist terminal output in mobile state or desktop renderer storage.
+
+## Reviews, files, and diffs
+
+When an agent produces review output, Matrix can show a bounded review snapshot in desktop and mobile:
+
+- changed-file counts;
+- hunk coordinates and partial diff markers;
+- safe line snippets for review context;
+- selected read-only file snapshots;
+- follow-up prompts that refer to a selected file or hunk without copying full diffs into mobile storage.
+
+Large diffs may render as partial snapshots so the shell stays responsive. If a file is unavailable, moved, too large, or outside the selected worktree, the shell shows a recovery-oriented message instead of internal paths or raw errors.
+
+## Previews
+
+Running app previews and local dev servers can appear in the coding workspace when Matrix can summarize them safely. Preview rows are scoped to the active project before list limits are applied.
+
+- HTTPS preview origins can open directly.
+- Local HTTP origins are shown as status-only unless you open them from a shell surface that can safely attach to the local runtime.
+- Preview summaries never expose private paths, query strings, tokens, or internal hostnames.
+
+## Mobile workflow
+
+On mobile, use the coding-agent workspace to check active work, answer approvals, inspect safe review details, and jump into a bound terminal session. The mobile app stores only small UI references such as selected thread or preview ids; thread snapshots, file contents, diffs, and terminal output are reloaded from your Matrix computer when needed.
+
+## Desktop workflow
+
+On desktop, the coding-agent workspace is the mission-control view for multiple threads. Use it to compare active work, open bound terminals, inspect reviews, answer approvals, and open safe previews without exposing provider credentials to the renderer.
+
+## Related
+
+<Cards>
+  <Card title="Web Shell" href="/docs/shell" description="Use Terminal, Files, Canvas, apps, integrations, and settings from the browser." />
+  <Card title="Mobile" href="/docs/mobile" description="Reconnect to sessions and coding-agent work from the native mobile shell." />
+  <Card title="Developer Workflow" href="/docs/guide/developer-workflow" description="Use Matrix as the persistent workspace for AI coding tools." />
+</Cards>


### PR DESCRIPTION
## Summary\n- Expand the public Coding Agents docs with desktop/mobile coding workspace behavior\n- Explain shared thread state, approvals/input, terminal continuity, review/file/diff surfaces, and previews\n- Keep rollout language scoped to runtime-enabled workspace support\n\n## Validation\n- git diff --check\n- forbidden-name scan over www/content/docs/coding-agents.mdx\n- bun run check:patterns\n- pnpm --filter www build\n\n## Notes\n- Public docs-only slice; no runtime behavior changes.