### PR TITLE
fix(terminal): upload pasted images into shell sessions

### DIFF
--- a/docs/dev/cli-release.md
+++ b/docs/dev/cli-release.md
@@ -4,7 +4,7 @@ The installable Matrix CLI is the `@finnaai/matrix` package in `packages/sync-cl
 
 ## Current Prepared Release
 
-`0.3.8` is the prepared CLI patch release after `0.3.7`, including the Matrix shell reconnect banner fix while preserving Node 20+ package-runner support and standalone CLI binaries for no-Node installs.
+`0.3.9` is the prepared CLI patch release after `0.3.8`, including terminal image paste upload fixes while preserving Node 20+ package-runner support and standalone CLI binaries for no-Node installs.
 
 ## Versioning
 
@@ -34,7 +34,7 @@ git tag -l 'cli-v*'
 
 ## Release
 
-Use the manual GitHub Actions workflow named `CLI Release` with `version=0.3.8` and `update_homebrew=true`. The workflow:
+Use the manual GitHub Actions workflow named `CLI Release` with `version=0.3.9` and `update_homebrew=true`. This follows the existing `cli-v0.3.9` workflow/tag release path after the PR merges. The workflow:
 
 1. Validates the requested semver, local package version, npm availability, and `cli-v<version>` tag availability.
 2. Installs the workspace and runs the sync-client build, tests, and publish-shape check.
@@ -51,7 +51,7 @@ npm view @finnaai/matrix dist.tarball
 npx --yes @finnaai/matrix --version
 pnpm dlx @finnaai/matrix --version
 brew update && brew info finnaai/tap/matrix
-MATRIX_VERSION=0.3.8 sh scripts/install.sh
+MATRIX_VERSION=0.3.9 sh scripts/install.sh
 matrix --version
 matrix login --help
 matrix run --help
@@ -69,17 +69,17 @@ matrix forward 5173
 
 For standalone binaries, also verify the GitHub release contains:
 
-- `matrix-0.3.8-linux-x64`
-- `matrix-0.3.8-linux-arm64`
-- `matrix-0.3.8-darwin-x64`
-- `matrix-0.3.8-darwin-arm64`
+- `matrix-0.3.9-linux-x64`
+- `matrix-0.3.9-linux-arm64`
+- `matrix-0.3.9-darwin-x64`
+- `matrix-0.3.9-darwin-arm64`
 
-For macOS app packaging, also verify the GitHub release contains `MatrixSync-0.3.8.pkg` when the macOS job was enabled.
+For macOS app packaging, also verify the GitHub release contains `MatrixSync-0.3.9.pkg` when the macOS job was enabled.
 
 ## Rollback
 
-npm package versions are immutable. If a bad CLI release is published, ship a patch release such as `0.3.9` and update Homebrew through the release workflow. Only deprecate the bad npm version when the replacement is available:
+npm package versions are immutable. If a bad CLI release is published, ship a patch release such as `0.3.10` and update Homebrew through the release workflow. Only deprecate the bad npm version when the replacement is available:
 
 ```bash
-npm deprecate @finnaai/matrix@0.3.8 "Use @finnaai/matrix@0.3.9"
+npm deprecate @finnaai/matrix@0.3.9 "Use @finnaai/matrix@0.3.10"
 ```

--- a/packages/gateway/src/server.ts
+++ b/packages/gateway/src/server.ts
@@ -1483,6 +1483,7 @@ export async function createGateway(config: GatewayConfig) {
   app.route("/api/support-growth", createDraftActionRoutes({ service: draftActionService }));
   const shellSessionCreateRateLimiter = createRateLimiter(SHELL_SESSION_CREATE_RATE_LIMIT);
   const shellRouteDeps = {
+    homePath,
     registry: zellijShellRegistry,
     preferences: shellPreferencesStore,
     workspace: zellijAdapter,
@@ -1490,6 +1491,7 @@ export async function createGateway(config: GatewayConfig) {
     shellBackend: zellijAdapter,
     shellThemeConfig: zellijAdapter,
     commandRunner: createShellCommandRunner({ homePath }),
+    terminalInput: zellijAdapter,
     sessionCreateRateLimiter: shellSessionCreateRateLimiter,
   };
   const systemActivityCandidates = new CleanupCandidateRegistry();

--- a/packages/gateway/src/shell/paste-assets.ts
+++ b/packages/gateway/src/shell/paste-assets.ts
@@ -1,0 +1,142 @@
+import { randomUUID } from "node:crypto";
+import { mkdir, open, rename, unlink } from "node:fs/promises";
+import { join, relative, sep } from "node:path";
+import { resolveWritableFileApiPath } from "../path-security.js";
+import { shellError } from "./errors.js";
+
+export const TERMINAL_PASTE_ASSET_BODY_LIMIT = 10 * 1024 * 1024;
+
+const SUPPORTED_MIME_TYPES = new Set([
+  "image/png",
+  "image/jpeg",
+  "image/gif",
+  "image/webp",
+]);
+const SAFE_CLIENT_FILENAME = /^[^/\\\0]{1,255}$/;
+
+interface PasteAssetKind {
+  mimeType: "image/png" | "image/jpeg" | "image/gif" | "image/webp";
+  extension: ".png" | ".jpg" | ".gif" | ".webp";
+}
+
+export interface TerminalPasteAssetInput {
+  homePath: string;
+  cwd: string;
+  bytes: Uint8Array;
+  contentType?: string;
+  filename?: string;
+  now?: Date;
+}
+
+export interface TerminalPasteAssetResult {
+  path: string;
+  terminalPath: string;
+  size: number;
+  mimeType: string;
+}
+
+export async function saveTerminalPasteAsset(input: TerminalPasteAssetInput): Promise<TerminalPasteAssetResult> {
+  if (input.bytes.byteLength < 1 || input.bytes.byteLength > TERMINAL_PASTE_ASSET_BODY_LIMIT) {
+    throw shellError("payload_too_large", "Request too large", 413);
+  }
+  validateClientFilename(input.filename);
+  const declaredMime = normalizeContentType(input.contentType);
+  if (declaredMime && !SUPPORTED_MIME_TYPES.has(declaredMime)) {
+    throw shellError("unsupported_media_type", "Invalid request", 400);
+  }
+  const kind = detectPasteAssetKind(input.bytes);
+  if (!kind || (declaredMime && declaredMime !== kind.mimeType)) {
+    throw shellError("unsupported_media_type", "Invalid request", 400);
+  }
+
+  const date = formatPasteAssetDate(input.now ?? new Date());
+  const relativeDir = join(input.cwd, ".matrix-terminal-pastes", date);
+  const filename = `${Date.now()}-${randomUUID()}${kind.extension}`;
+  const relativePath = join(relativeDir, filename);
+  const absolutePath = resolveWritableFileApiPath(input.homePath, relativePath);
+  if (!absolutePath) {
+    throw shellError("invalid_request", "Invalid request", 400);
+  }
+  const absoluteDir = resolveWritableFileApiPath(input.homePath, relativeDir);
+  if (!absoluteDir) {
+    throw shellError("invalid_request", "Invalid request", 400);
+  }
+
+  await mkdir(absoluteDir, { recursive: true });
+  const tempPath = join(absoluteDir, `.${filename}.tmp`);
+  const handle = await open(tempPath, "wx");
+  try {
+    await handle.writeFile(input.bytes);
+  } finally {
+    await handle.close();
+  }
+  try {
+    await rename(tempPath, absolutePath);
+  } catch (err: unknown) {
+    await unlink(tempPath).catch((cleanupErr: unknown) => {
+      console.warn(
+        "[shell] failed to clean up terminal paste temp file:",
+        cleanupErr instanceof Error ? cleanupErr.message : String(cleanupErr),
+      );
+    });
+    throw err;
+  }
+
+  return {
+    path: relative(input.homePath, absolutePath).split(sep).join("/"),
+    terminalPath: absolutePath,
+    size: input.bytes.byteLength,
+    mimeType: kind.mimeType,
+  };
+}
+
+function normalizeContentType(contentType: string | undefined): string | undefined {
+  const normalized = contentType?.split(";", 1)[0]?.trim().toLowerCase();
+  return normalized || undefined;
+}
+
+function validateClientFilename(filename: string | undefined): void {
+  if (filename === undefined || filename === "") {
+    return;
+  }
+  if (!SAFE_CLIENT_FILENAME.test(filename) || filename === "." || filename === "..") {
+    throw shellError("invalid_request", "Invalid request", 400);
+  }
+}
+
+function detectPasteAssetKind(bytes: Uint8Array): PasteAssetKind | null {
+  if (
+    bytes.length >= 8 &&
+    bytes[0] === 0x89 &&
+    bytes[1] === 0x50 &&
+    bytes[2] === 0x4e &&
+    bytes[3] === 0x47 &&
+    bytes[4] === 0x0d &&
+    bytes[5] === 0x0a &&
+    bytes[6] === 0x1a &&
+    bytes[7] === 0x0a
+  ) {
+    return { mimeType: "image/png", extension: ".png" };
+  }
+  if (bytes.length >= 3 && bytes[0] === 0xff && bytes[1] === 0xd8 && bytes[2] === 0xff) {
+    return { mimeType: "image/jpeg", extension: ".jpg" };
+  }
+  if (bytes.length >= 6) {
+    const header = String.fromCharCode(...bytes.slice(0, 6));
+    if (header === "GIF87a" || header === "GIF89a") {
+      return { mimeType: "image/gif", extension: ".gif" };
+    }
+  }
+  if (bytes.length >= 12) {
+    const riff = String.fromCharCode(...bytes.slice(0, 4));
+    const webp = String.fromCharCode(...bytes.slice(8, 12));
+    if (riff === "RIFF" && webp === "WEBP") {
+      return { mimeType: "image/webp", extension: ".webp" };
+    }
+  }
+  return null;
+}
+
+function formatPasteAssetDate(date: Date): string {
+  return date.toISOString().slice(0, 10);
+}

--- a/packages/gateway/src/shell/routes.ts
+++ b/packages/gateway/src/shell/routes.ts
@@ -5,6 +5,10 @@ import { createRateLimiter, type RateLimiter } from "../security/rate-limiter.js
 import { toShellError } from "./errors.js";
 import { SESSION_NAME_PATTERN } from "./names.js";
 import {
+  saveTerminalPasteAsset,
+  TERMINAL_PASTE_ASSET_BODY_LIMIT,
+} from "./paste-assets.js";
+import {
   ShellPreferencesSchema,
   type ShellThemeId,
   type ShellPreferencesStore,
@@ -13,6 +17,7 @@ import type { ShellCommandRunner } from "./command-runner.js";
 
 interface SessionRegistryRoutes {
   list(): Promise<unknown[]>;
+  get?(name: string): Promise<unknown>;
   create(input: {
     name: string;
     cwd?: string;
@@ -70,7 +75,12 @@ interface ShellThemeConfigRoutes {
   setShellTheme(themeId: ShellThemeId): Promise<void>;
 }
 
+interface TerminalInputRoutes {
+  sendInput(name: string, data: string): Promise<void>;
+}
+
 export interface ShellRouteDeps {
+  homePath?: string;
   registry: SessionRegistryRoutes;
   preferences?: ShellPreferencesStore;
   workspace?: ShellWorkspaceRoutes;
@@ -78,6 +88,7 @@ export interface ShellRouteDeps {
   shellBackend?: ShellBackendHealthRoutes;
   shellThemeConfig?: ShellThemeConfigRoutes;
   commandRunner?: ShellCommandRunner;
+  terminalInput?: TerminalInputRoutes;
   sessionCreateRateLimiter?: RateLimiter;
 }
 
@@ -117,6 +128,12 @@ const RunBodySchema = z.object({
   cwd: SafeCwdSchema.optional(),
   timeoutMs: z.number().int().positive().max(30 * 60 * 1000).optional(),
 });
+const TerminalInputBodySchema = z.object({
+  data: z.string().min(1).max(65_536),
+}).strict();
+const PasteAssetQuerySchema = z.object({
+  cwd: SafeCwdSchema.default("projects"),
+}).strict();
 const SessionUiStateBodySchema = z.object({
   placement: z.enum(["active", "background"]).optional(),
   lastSeenSeq: z.number().int().nonnegative().nullable().optional(),
@@ -148,6 +165,11 @@ export function createShellRoutes(deps: ShellRouteDeps): Hono {
   const layoutBodyLimit = bodyLimit({ maxSize: 128_000 });
   const deleteBodyLimit = bodyLimit({ maxSize: 512 });
   const runBodyLimit = bodyLimit({ maxSize: 16_384 });
+  const terminalInputBodyLimit = bodyLimit({ maxSize: 70_000 });
+  const terminalPasteAssetBodyLimit = bodyLimit({
+    maxSize: TERMINAL_PASTE_ASSET_BODY_LIMIT,
+    onError: bodyTooLarge,
+  });
 
   app.get("/health", async (c) => {
     if (!deps.shellBackend) {
@@ -274,6 +296,44 @@ export function createShellRoutes(deps: ShellRouteDeps): Hono {
       if (!deps.commandRunner) return unavailable(c, "run_unavailable");
       const body = RunBodySchema.parse(await c.req.json());
       return c.json(await deps.commandRunner.run(body));
+    } catch (err) {
+      return safeError(c, err);
+    }
+  });
+
+  app.post("/sessions/:name/input", terminalInputBodyLimit, async (c) => {
+    try {
+      if (!deps.terminalInput) return unavailable(c, "terminal_input_unavailable");
+      const name = SafeSessionNameSchema.parse(c.req.param("name"));
+      const body = TerminalInputBodySchema.parse(await c.req.json());
+      await assertSessionExists(deps.registry, name);
+      await deps.terminalInput.sendInput(name, body.data);
+      return c.json({ ok: true });
+    } catch (err) {
+      return safeError(c, err);
+    }
+  });
+
+  app.post("/sessions/:name/paste-assets", terminalPasteAssetBodyLimit, async (c) => {
+    try {
+      if (!deps.homePath) return unavailable(c, "paste_assets_unavailable");
+      const name = SafeSessionNameSchema.parse(c.req.param("name"));
+      const query = PasteAssetQuerySchema.parse({
+        cwd: c.req.query("cwd") ?? "projects",
+      });
+      const bytes = new Uint8Array(await c.req.arrayBuffer());
+      if (bytes.byteLength > TERMINAL_PASTE_ASSET_BODY_LIMIT) {
+        return c.json({ error: { code: "payload_too_large", message: "Request too large" } }, 413);
+      }
+      await assertSessionExists(deps.registry, name);
+      const result = await saveTerminalPasteAsset({
+        homePath: deps.homePath,
+        cwd: query.cwd,
+        contentType: c.req.header("Content-Type"),
+        filename: c.req.header("X-Matrix-Filename"),
+        bytes,
+      });
+      return c.json(result, 201);
     } catch (err) {
       return safeError(c, err);
     }
@@ -482,10 +542,35 @@ function unavailable(c: Context, code: string) {
   return c.json({ error: { code, message: "Request failed" } }, 503);
 }
 
+function bodyTooLarge(c: Context) {
+  return c.json({ error: { code: "payload_too_large", message: "Request too large" } }, 413);
+}
+
+async function assertSessionExists(registry: SessionRegistryRoutes, name: string): Promise<void> {
+  if (registry.get) {
+    await registry.get(name);
+    return;
+  }
+  const sessions = await registry.list();
+  if (sessions.some((session) => (
+    typeof session === "object" &&
+    session !== null &&
+    "name" in session &&
+    (session as { name?: unknown }).name === name
+  ))) {
+    return;
+  }
+  throw toShellError(Object.assign(new Error("Session not found"), {
+    code: "session_not_found",
+    safeMessage: "Session not found",
+    status: 404,
+  }));
+}
+
 function safeError(c: Context, err: unknown) {
   if (hasHttpStatus(err, 413) || isBodyLimitError(err)) {
     return c.json(
-      { error: { code: "payload_too_large", message: "Request failed" } },
+      { error: { code: "payload_too_large", message: "Request too large" } },
       413,
     );
   }

--- a/packages/gateway/src/shell/zellij.ts
+++ b/packages/gateway/src/shell/zellij.ts
@@ -485,13 +485,7 @@ export function createZellijAdapter(deps: ZellijAdapterDeps = {}): ZellijAdapter
       return attachProcess(name, options);
     },
     async sendInput(name, data) {
-      const pty = attachProcess(name);
-      try {
-        pty.write(data);
-        await new Promise((resolve) => setTimeout(resolve, 50));
-      } finally {
-        pty.kill();
-      }
+      await run(["--session", name, "action", "write-chars", "--", data]);
     },
     async listTabs(name) {
       const stdout = await run(["--session", name, "action", "query-tab-names"]);

--- a/packages/gateway/src/shell/zellij.ts
+++ b/packages/gateway/src/shell/zellij.ts
@@ -89,6 +89,7 @@ export interface ZellijAdapter {
   renameSession(name: string, nextName: string): Promise<void>;
   validateLayout(path: string): Promise<void>;
   attachSession(name: string, options?: AttachOptions): ShellAttachProcess;
+  sendInput(name: string, data: string): Promise<void>;
   listTabs(name: string): Promise<unknown[]>;
   createTab(name: string, input: { name?: string; cwd?: string; cmd?: string }): Promise<unknown>;
   switchTab(name: string, tab: number): Promise<unknown>;
@@ -347,6 +348,29 @@ export function createZellijAdapter(deps: ZellijAdapterDeps = {}): ZellijAdapter
     });
   }
 
+  function attachProcess(name: string, options: AttachOptions = {}): ShellAttachProcess {
+    const pty = spawnPty("zellij", ["attach", name], {
+      name: "xterm-256color",
+      cols: 120,
+      rows: 40,
+      cwd,
+      env: attachEnv(deps.env, zellijConfigPaths),
+    });
+    const abort = () => {
+      pty.kill();
+    };
+    const exitDisposable = pty.onExit(() => {
+      options.signal?.removeEventListener("abort", abort);
+      exitDisposable.dispose();
+    });
+    if (options.signal?.aborted) {
+      abort();
+    } else {
+      options.signal?.addEventListener("abort", abort, { once: true });
+    }
+    return pty;
+  }
+
   return {
     async health() {
       try {
@@ -458,26 +482,16 @@ export function createZellijAdapter(deps: ZellijAdapterDeps = {}): ZellijAdapter
       await run(["setup", "--check", "--layout", path], 5_000);
     },
     attachSession(name, options = {}) {
-      const pty = spawnPty("zellij", ["attach", name], {
-        name: "xterm-256color",
-        cols: 120,
-        rows: 40,
-        cwd,
-        env: attachEnv(deps.env, zellijConfigPaths),
-      });
-      const abort = () => {
+      return attachProcess(name, options);
+    },
+    async sendInput(name, data) {
+      const pty = attachProcess(name);
+      try {
+        pty.write(data);
+        await new Promise((resolve) => setTimeout(resolve, 50));
+      } finally {
         pty.kill();
-      };
-      const exitDisposable = pty.onExit(() => {
-        options.signal?.removeEventListener("abort", abort);
-        exitDisposable.dispose();
-      });
-      if (options.signal?.aborted) {
-        abort();
-      } else {
-        options.signal?.addEventListener("abort", abort, { once: true });
       }
-      return pty;
     },
     async listTabs(name) {
       const stdout = await run(["--session", name, "action", "query-tab-names"]);

--- a/packages/sync-client/package.json
+++ b/packages/sync-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@finnaai/matrix",
-  "version": "0.3.8",
+  "version": "0.3.9",
   "description": "Matrix OS command-line client — login, sync, and peer management for matrix-os.com",
   "type": "module",
   "license": "AGPL-3.0-or-later",

--- a/packages/sync-client/src/cli/commands/run.ts
+++ b/packages/sync-client/src/cli/commands/run.ts
@@ -167,6 +167,12 @@ export const runCommand = defineCommand({
       default: false,
       description: "Drop local terminal mouse escape sequences before forwarding input",
     },
+    noRichPaste: {
+      type: "boolean",
+      required: false,
+      default: false,
+      description: "Forward pasted image paths as text instead of uploading them into the shell session",
+    },
     json: { type: "boolean", required: false, default: false },
   },
   run: async ({ args, rawArgs }) => {
@@ -207,7 +213,11 @@ export const runCommand = defineCommand({
         command,
         sessionProvided,
         mouse: args.noMouse === true ? false : undefined,
-        attachOptions: json ? { output: process.stderr } : undefined,
+        attachOptions: {
+          ...(json ? { output: process.stderr } : {}),
+          ...(typeof args.cwd === "string" ? { cwd: args.cwd } : {}),
+          ...(args.noRichPaste === true ? { noRichPaste: true } : {}),
+        },
       });
       console.log(
         json

--- a/packages/sync-client/src/cli/commands/shell.ts
+++ b/packages/sync-client/src/cli/commands/shell.ts
@@ -125,6 +125,12 @@ function attachOptionsFromArgs(args: Record<string, unknown>) {
   if (args.noMouse === true) {
     options.mouse = false;
   }
+  if (args.noRichPaste === true) {
+    options.noRichPaste = true;
+  }
+  if (typeof args.cwd === "string") {
+    options.cwd = args.cwd;
+  }
   if (typeof args.WebSocketImpl === "function") {
     options.WebSocketImpl = args.WebSocketImpl as ShellAttachOptions["WebSocketImpl"];
   }
@@ -194,6 +200,7 @@ function attachCommand(name: string, description: string) {
       layout: { type: "string", required: false },
       cmd: { type: "string", required: false },
       noMouse: { type: "boolean", required: false, default: false },
+      noRichPaste: { type: "boolean", required: false, default: false },
       fromSeq: { type: "string", required: false },
       ...commonArgs,
     },
@@ -259,6 +266,7 @@ export const shellCommand = defineCommand({
         cmd: { type: "string", required: false },
         attach: { type: "boolean", required: false, default: false },
         noMouse: { type: "boolean", required: false, default: false },
+        noRichPaste: { type: "boolean", required: false, default: false },
         ...commonArgs,
       },
       run: async ({ args }) => {

--- a/packages/sync-client/src/cli/commands/shell.ts
+++ b/packages/sync-client/src/cli/commands/shell.ts
@@ -7,7 +7,7 @@ import { defineCommand } from "citty";
 import { resolveCliProfile } from "../profiles.js";
 import { formatCliError, formatCliErrorMessage, formatCliSuccess } from "../output.js";
 import { createShellClient } from "../shell-client.js";
-import type { ShellAttachOptions, ShellSendInputOptions } from "../shell-client.js";
+import type { ShellAttachOptions } from "../shell-client.js";
 import { requireCliAuthToken } from "../auth-state.js";
 import { uploadLocalFile } from "../file-transfer-client.js";
 
@@ -390,9 +390,6 @@ async function pasteLocalFileIntoShell(args: Record<string, unknown>, input: {
     { force: args.force === true },
   );
   const client = createShellClient({ gatewayUrl: profile.gatewayUrl, token });
-  const sendInputOptions: ShellSendInputOptions = typeof args.WebSocketImpl === "function"
-    ? { WebSocketImpl: args.WebSocketImpl as ShellSendInputOptions["WebSocketImpl"] }
-    : {};
   const text = formatPasteText({
     remotePath: result.path,
     format: parsePasteFormat(args.format),
@@ -401,7 +398,6 @@ async function pasteLocalFileIntoShell(args: Record<string, unknown>, input: {
   await client.sendInput(
     String(args.session),
     `${bracketTerminalPaste(text)}${args.enter === true ? "\r" : ""}`,
-    sendInputOptions,
   );
   return { path: result.path, size: result.size, session: String(args.session) };
 }

--- a/packages/sync-client/src/cli/shell-client.ts
+++ b/packages/sync-client/src/cli/shell-client.ts
@@ -35,9 +35,8 @@ export interface ShellClient {
   deleteLayout(name: string): Promise<Record<string, unknown>>;
   applyLayout(session: string, layout: string): Promise<Record<string, unknown>>;
   dumpLayout(session: string): Promise<Record<string, unknown>>;
-  sendInput(name: string, data: string): Promise<void>;
   createAttachUrl(name: string, options?: { fromSeq?: number; token?: string }): string;
-  sendInput(name: string, data: string, options?: ShellSendInputOptions): Promise<void>;
+  sendInput(name: string, data: string): Promise<void>;
   attachSession(name: string, options?: ShellAttachOptions): Promise<{ detached: boolean }>;
 }
 
@@ -60,11 +59,6 @@ interface AttachWebSocket {
   close(): void;
   on(event: "open" | "message" | "close" | "error", listener: (...args: unknown[]) => void): AttachWebSocket;
   off?(event: "open" | "message" | "close" | "error", listener: (...args: unknown[]) => void): AttachWebSocket;
-}
-
-export interface ShellSendInputOptions {
-  WebSocketImpl?: new (url: string, options?: { headers?: Record<string, string> }) => AttachWebSocket;
-  timeoutMs?: number;
 }
 
 export interface ShellAttachOptions {
@@ -581,80 +575,11 @@ export function createShellClient(options: ShellClientOptions): ShellClient {
     async dumpLayout(session) {
       return (await request(`${terminalSessionsPath}/${encodeURIComponent(session)}/layout`)) as Record<string, unknown>;
     },
+    createAttachUrl,
     async sendInput(name, data) {
       await request(`${terminalSessionsPath}/${encodeURIComponent(name)}/input`, {
         method: "POST",
         body: JSON.stringify({ data }),
-      });
-    },
-    createAttachUrl,
-    async sendInput(name, data, sendOptions = {}) {
-      const WebSocketImpl =
-        sendOptions.WebSocketImpl ??
-        (await import("ws").then((mod) => mod.WebSocket as unknown as ShellSendInputOptions["WebSocketImpl"]));
-      if (!WebSocketImpl) {
-        throw Object.assign(new Error("Request failed"), { code: "websocket_unavailable" });
-      }
-      if (data.length > 65_536) {
-        throw Object.assign(new Error("Request failed"), { code: "invalid_request" });
-      }
-
-      const headers = options.token ? { Authorization: `Bearer ${options.token}` } : undefined;
-      const timeout = sendOptions.timeoutMs ?? timeoutMs;
-      const ws = new WebSocketImpl(createAttachUrl(name), headers ? { headers } : undefined);
-
-      await new Promise<void>((resolve, reject) => {
-        let settled = false;
-        const timer = setTimeout(() => {
-          finish(() => reject(Object.assign(new Error("Request failed"), { code: "attach_timeout" })));
-        }, timeout);
-        timer.unref?.();
-
-        const finish = (fn: () => void) => {
-          if (settled) return;
-          settled = true;
-          clearTimeout(timer);
-          try {
-            ws.close();
-          } catch (_err: unknown) {
-            // Best effort close after the input frame has been sent.
-          }
-          fn();
-        };
-
-        ws.on("message", (raw: unknown) => {
-          let parsed: unknown;
-          try {
-            const text = Buffer.isBuffer(raw) ? raw.toString("utf8") : String(raw);
-            parsed = JSON.parse(text);
-          } catch (_err: unknown) {
-            return;
-          }
-          if (!parsed || typeof parsed !== "object") return;
-          const msg = parsed as { type?: unknown; code?: unknown };
-          if (msg.type === "attached") {
-            try {
-              ws.send(JSON.stringify({ type: "input", data }));
-              ws.send(JSON.stringify({ type: "detach" }));
-              finish(resolve);
-            } catch (_err: unknown) {
-              finish(() => reject(Object.assign(new Error("Request failed"), { code: "attach_failed" })));
-            }
-            return;
-          }
-          if (msg.type === "error") {
-            const code = typeof msg.code === "string" && SAFE_SHELL_SERVER_ERROR_CODES.has(msg.code)
-              ? msg.code
-              : "attach_failed";
-            finish(() => reject(Object.assign(new Error("Request failed"), { code })));
-          }
-        });
-        ws.on("close", () => {
-          finish(() => reject(Object.assign(new Error("Request failed"), { code: "attach_failed" })));
-        });
-        ws.on("error", () => {
-          finish(() => reject(Object.assign(new Error("Request failed"), { code: "attach_failed" })));
-        });
       });
     },
     async attachSession(name, attachOptions = {}) {

--- a/packages/sync-client/src/cli/shell-client.ts
+++ b/packages/sync-client/src/cli/shell-client.ts
@@ -1,3 +1,5 @@
+import { readFile, stat } from "node:fs/promises";
+import { basename, extname, isAbsolute } from "node:path";
 import { SHELL_ATTACH_LIVE_TAIL_FROM_SEQ } from "../protocol/shell.js";
 
 export interface ShellClientOptions {
@@ -33,6 +35,7 @@ export interface ShellClient {
   deleteLayout(name: string): Promise<Record<string, unknown>>;
   applyLayout(session: string, layout: string): Promise<Record<string, unknown>>;
   dumpLayout(session: string): Promise<Record<string, unknown>>;
+  sendInput(name: string, data: string): Promise<void>;
   createAttachUrl(name: string, options?: { fromSeq?: number; token?: string }): string;
   attachSession(name: string, options?: ShellAttachOptions): Promise<{ detached: boolean }>;
 }
@@ -71,10 +74,17 @@ export interface ShellAttachOptions {
   reconnectBaseDelayMs?: number;
   reconnectMaxDelayMs?: number;
   WebSocketImpl?: new (url: string, options?: { headers?: Record<string, string> }) => AttachWebSocket;
+  noRichPaste?: boolean;
+  cwd?: string;
 }
 
 export const SHELL_ATTACH_MAX_QUEUED_BYTES = 65_536;
 export { SHELL_ATTACH_LIVE_TAIL_FROM_SEQ };
+const BRACKETED_PASTE_OPEN = "\u001b[200~";
+const BRACKETED_PASTE_CLOSE = "\u001b[201~";
+const BRACKETED_PASTE_OVERHEAD = BRACKETED_PASTE_OPEN.length + BRACKETED_PASTE_CLOSE.length;
+const SHELL_INPUT_FRAME_MAX_BYTES = 60_000;
+const TERMINAL_PASTE_ASSET_BODY_LIMIT = 10 * 1024 * 1024;
 const DEFAULT_RUN_TIMEOUT_MS = 10 * 60 * 1000;
 const RUN_RESPONSE_GRACE_MS = 30_000;
 const SHELL_ATTACH_HEARTBEAT_INTERVAL_MS = 20_000;
@@ -102,6 +112,13 @@ const SAFE_SHELL_SERVER_ERROR_CODES = new Set([
   "auth_expired",
   "session_not_found",
   "zellij_failed",
+]);
+const LOCAL_IMAGE_MIME_BY_EXTENSION = new Map([
+  [".png", "image/png"],
+  [".jpg", "image/jpeg"],
+  [".jpeg", "image/jpeg"],
+  [".gif", "image/gif"],
+  [".webp", "image/webp"],
 ]);
 
 type MaybeTtyStream = NodeJS.ReadStream & {
@@ -241,6 +258,136 @@ function createTerminalInputFilter(options: {
   };
 }
 
+function createUnsupportedTerminalControlDropper() {
+  let dropping: "osc" | "string" | null = null;
+  let pendingEsc = false;
+
+  return {
+    filter(chunk: string): string {
+      let output = "";
+      for (let i = 0; i < chunk.length; i += 1) {
+        const char = chunk[i] ?? "";
+        const next = chunk[i + 1];
+
+        if (dropping) {
+          if (dropping === "osc" && char === "\u0007") {
+            dropping = null;
+            continue;
+          }
+          if (char === "\u001b" && next === "\\") {
+            dropping = null;
+            i += 1;
+          }
+          continue;
+        }
+
+        if (pendingEsc) {
+          pendingEsc = false;
+          if (startsUnsupportedStringControl(char)) {
+            dropping = char === "]" ? "osc" : "string";
+            continue;
+          }
+          output += `\u001b${char}`;
+          continue;
+        }
+
+        if (char !== "\u001b") {
+          output += char;
+          continue;
+        }
+
+        if (next === undefined) {
+          pendingEsc = true;
+          continue;
+        }
+        if (startsUnsupportedStringControl(next)) {
+          dropping = next === "]" ? "osc" : "string";
+          i += 1;
+          continue;
+        }
+        output += char;
+      }
+      return output;
+    },
+    reset() {
+      dropping = null;
+      pendingEsc = false;
+    },
+  };
+}
+
+function startsUnsupportedStringControl(char: string | undefined): boolean {
+  return char === "]" || char === "P" || char === "_" || char === "^" || char === "X";
+}
+
+function splitTerminalInputFrames(data: string): string[] {
+  const frames: string[] = [];
+  let current = "";
+  let currentBytes = 0;
+  for (const char of Array.from(data)) {
+    const charBytes = Buffer.byteLength(char, "utf8");
+    if (current && currentBytes + charBytes > SHELL_INPUT_FRAME_MAX_BYTES) {
+      frames.push(current);
+      current = "";
+      currentBytes = 0;
+    }
+    current += char;
+    currentBytes += charBytes;
+  }
+  if (current) {
+    frames.push(current);
+  }
+  return frames;
+}
+
+function parseSingleLocalImagePath(raw: string): string | null {
+  let text = raw.replace(/\x1b\[200~/g, "").replace(/\x1b\[201~/g, "").trim();
+  if ((text.startsWith("\"") && text.endsWith("\"")) || (text.startsWith("'") && text.endsWith("'"))) {
+    text = text.slice(1, -1);
+  }
+  text = text.trim();
+  if (!text || !isAbsolute(text) || text.includes("\0")) {
+    return null;
+  }
+  const ext = extname(text).toLowerCase();
+  return LOCAL_IMAGE_MIME_BY_EXTENSION.has(ext) ? text : null;
+}
+
+function detectLocalImageMime(bytes: Uint8Array): string | null {
+  if (
+    bytes.length >= 8 &&
+    bytes[0] === 0x89 &&
+    bytes[1] === 0x50 &&
+    bytes[2] === 0x4e &&
+    bytes[3] === 0x47 &&
+    bytes[4] === 0x0d &&
+    bytes[5] === 0x0a &&
+    bytes[6] === 0x1a &&
+    bytes[7] === 0x0a
+  ) return "image/png";
+  if (bytes.length >= 3 && bytes[0] === 0xff && bytes[1] === 0xd8 && bytes[2] === 0xff) return "image/jpeg";
+  if (bytes.length >= 6) {
+    const header = String.fromCharCode(...bytes.slice(0, 6));
+    if (header === "GIF87a" || header === "GIF89a") return "image/gif";
+  }
+  if (bytes.length >= 12) {
+    const riff = String.fromCharCode(...bytes.slice(0, 4));
+    const webp = String.fromCharCode(...bytes.slice(8, 12));
+    if (riff === "RIFF" && webp === "WEBP") return "image/webp";
+  }
+  return null;
+}
+
+function isLocalFileAccessMiss(err: unknown): boolean {
+  const code = err instanceof Error && "code" in err ? (err as { code?: unknown }).code : undefined;
+  return code === "ENOENT" || code === "ENOTDIR" || code === "EACCES" || code === "EPERM";
+}
+
+function bracketPasteData(data: string): string {
+  const capped = data.slice(0, SHELL_INPUT_FRAME_MAX_BYTES - BRACKETED_PASTE_OVERHEAD);
+  return `${BRACKETED_PASTE_OPEN}${capped}${BRACKETED_PASTE_CLOSE}`;
+}
+
 export function createShellClient(options: ShellClientOptions): ShellClient {
   const fetchImpl = options.fetch ?? fetch;
   const timeoutMs = options.timeoutMs ?? 10_000;
@@ -263,9 +410,17 @@ export function createShellClient(options: ShellClientOptions): ShellClient {
 
   async function request(path: string, init: RequestInit = {}, requestTimeoutMs = timeoutMs): Promise<unknown> {
     const headers: Record<string, string> = {};
-    new Headers(init.headers).forEach((value, key) => {
-      headers[key] = value;
-    });
+    if (init.headers instanceof Headers) {
+      init.headers.forEach((value, key) => {
+        headers[key] = value;
+      });
+    } else if (Array.isArray(init.headers)) {
+      for (const [key, value] of init.headers) {
+        headers[key] = value;
+      }
+    } else if (init.headers) {
+      Object.assign(headers, init.headers);
+    }
     if (options.token) {
       headers.Authorization = `Bearer ${options.token}`;
     }
@@ -420,6 +575,12 @@ export function createShellClient(options: ShellClientOptions): ShellClient {
     async dumpLayout(session) {
       return (await request(`${terminalSessionsPath}/${encodeURIComponent(session)}/layout`)) as Record<string, unknown>;
     },
+    async sendInput(name, data) {
+      await request(`${terminalSessionsPath}/${encodeURIComponent(name)}/input`, {
+        method: "POST",
+        body: JSON.stringify({ data }),
+      });
+    },
     createAttachUrl,
     async attachSession(name, attachOptions = {}) {
       const WebSocketImpl =
@@ -442,6 +603,7 @@ export function createShellClient(options: ShellClientOptions): ShellClient {
         dropMouse,
         resetLocalInputModes,
       });
+      const controlDropper = createUnsupportedTerminalControlDropper();
       const heartbeatIntervalMs = attachOptions.heartbeatIntervalMs ?? SHELL_ATTACH_HEARTBEAT_INTERVAL_MS;
       const heartbeatTimeoutMs = attachOptions.heartbeatTimeoutMs ?? SHELL_ATTACH_HEARTBEAT_TIMEOUT_MS;
       const heartbeatMissesBeforeReconnect =
@@ -449,6 +611,53 @@ export function createShellClient(options: ShellClientOptions): ShellClient {
       const reconnectBaseDelayMs = attachOptions.reconnectBaseDelayMs ?? SHELL_ATTACH_RECONNECT_BASE_DELAY_MS;
       const reconnectMaxDelayMs = attachOptions.reconnectMaxDelayMs ?? SHELL_ATTACH_RECONNECT_MAX_DELAY_MS;
       let pendingInput = "";
+      let inputQueue = Promise.resolve();
+      let queuedAsyncInputs = 0;
+
+      const uploadTerminalPasteAsset = async (filePath: string): Promise<string | null> => {
+        const ext = extname(filePath).toLowerCase();
+        const expectedMime = LOCAL_IMAGE_MIME_BY_EXTENSION.get(ext);
+        if (!expectedMime) {
+          return null;
+        }
+        let fileStat;
+        try {
+          fileStat = await stat(filePath);
+        } catch (err: unknown) {
+          if (isLocalFileAccessMiss(err)) {
+            return null;
+          }
+          throw err;
+        }
+        if (!fileStat.isFile() || fileStat.size < 1 || fileStat.size > TERMINAL_PASTE_ASSET_BODY_LIMIT) {
+          return null;
+        }
+        const bytes = await readFile(filePath);
+        if (detectLocalImageMime(bytes) !== expectedMime) {
+          return null;
+        }
+        const body = bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength);
+        const pasteAssetPath = `${terminalSessionsPath}/${encodeURIComponent(name)}/paste-assets${
+          attachOptions.cwd ? `?${new URLSearchParams({ cwd: attachOptions.cwd }).toString()}` : ""
+        }`;
+        const payload = await request(pasteAssetPath, {
+          method: "POST",
+          headers: {
+            "Content-Type": expectedMime,
+            "X-Matrix-Filename": basename(filePath),
+          },
+          body,
+        }, 30_000);
+        if (
+          typeof payload === "object" &&
+          payload !== null &&
+          "terminalPath" in payload &&
+          typeof (payload as { terminalPath?: unknown }).terminalPath === "string"
+        ) {
+          return (payload as { terminalPath: string }).terminalPath;
+        }
+        throw Object.assign(new Error("Request failed"), { code: "invalid_response" });
+      };
 
       return new Promise<{ detached: boolean }>((resolve, reject) => {
         let settled = false;
@@ -480,6 +689,7 @@ export function createShellClient(options: ShellClientOptions): ShellClient {
           process.off("exit", onProcessExit);
           pendingInput = "";
           inputFilter.reset();
+          controlDropper.reset();
           resetLocalInputModes();
           if (rawModeEnabled) {
             input.setRawMode?.(false);
@@ -654,26 +864,53 @@ export function createShellClient(options: ShellClientOptions): ShellClient {
             })));
           }
         };
+        const sendInputData = (data: string) => {
+          for (const frameData of splitTerminalInputFrames(data)) {
+            sendFrame(JSON.stringify({ type: "input", data: frameData }));
+          }
+        };
         const detachLocal = () => {
           const wsToClose = currentWs;
           sendFrame(JSON.stringify({ type: "detach" }));
           settle(() => resolve({ detached: true }));
           wsToClose?.close();
         };
-        const onInput = (chunk: Buffer | string) => {
+        const handleInputFailure = (err: unknown) => {
+          errorOutput.write("Shell attach failed\n");
+          settle(() => reject(Object.assign(new Error("Request failed"), {
+            code: err instanceof Error && "code" in err ? (err as { code?: string }).code ?? "attach_failed" : "attach_failed",
+          })));
+        };
+        const processInput = (chunk: Buffer | string): Promise<void> | void => {
           const rawData = Buffer.isBuffer(chunk) ? chunk.toString("utf-8") : String(chunk);
           if (rawModeEnabled && !everAttached && rawData.includes("\u0003")) {
             detachLocal();
             return;
           }
-          const data = inputFilter.filter(rawData);
+          const droppedControls = controlDropper.filter(rawData);
+          if (!attachOptions.noRichPaste) {
+            const localImagePath = parseSingleLocalImagePath(droppedControls);
+            if (localImagePath) {
+              return uploadTerminalPasteAsset(localImagePath).then((terminalPath) => {
+                if (terminalPath) {
+                  sendInputData(bracketPasteData(terminalPath));
+                  return;
+                }
+                processPlainInput(droppedControls);
+              });
+            }
+          }
+          processPlainInput(droppedControls);
+        };
+        const processPlainInput = (inputData: string) => {
+          const data = inputFilter.filter(inputData);
           let outbound = "";
           for (const char of data) {
             pendingInput += char;
             if (pendingInput === detachSequence) {
               pendingInput = "";
               if (outbound.length > 0) {
-                sendFrame(JSON.stringify({ type: "input", data: outbound }));
+                sendInputData(outbound);
               }
               detachLocal();
               return;
@@ -687,7 +924,40 @@ export function createShellClient(options: ShellClientOptions): ShellClient {
             }
           }
           if (outbound.length > 0) {
-            sendFrame(JSON.stringify({ type: "input", data: outbound }));
+            sendInputData(outbound);
+          }
+        };
+        const onInput = (chunk: Buffer | string) => {
+          const run = () => {
+            try {
+              const result = processInput(chunk);
+              return Promise.resolve(result);
+            } catch (err: unknown) {
+              return Promise.reject(err);
+            }
+          };
+          if (queuedAsyncInputs > 0) {
+            queuedAsyncInputs += 1;
+            inputQueue = inputQueue
+              .then(run)
+              .catch(handleInputFailure)
+              .finally(() => {
+                queuedAsyncInputs -= 1;
+              });
+            return;
+          }
+          try {
+            const result = processInput(chunk);
+            if (result && typeof (result as Promise<void>).then === "function") {
+              queuedAsyncInputs = 1;
+              inputQueue = Promise.resolve(result)
+                .catch(handleInputFailure)
+                .finally(() => {
+                  queuedAsyncInputs -= 1;
+                });
+            }
+          } catch (err: unknown) {
+            handleInputFailure(err);
           }
         };
         const sendResizeFrame = () => {

--- a/packages/sync-client/tests/unit/shell-client.test.ts
+++ b/packages/sync-client/tests/unit/shell-client.test.ts
@@ -263,27 +263,29 @@ describe("createShellClient attachSession", () => {
     expect(input.pause).toHaveBeenCalled();
   });
 
-  it("sends one-shot input to an attached shell session", async () => {
+  it("sends one-shot input over HTTP without opening a websocket attach", async () => {
+    const fetchImpl = vi.fn(async () => new Response(JSON.stringify({ ok: true })));
     const client = createShellClient({
       gatewayUrl: "https://matrix.example",
       token: "token-123",
+      fetch: fetchImpl,
       timeoutMs: 100,
     });
 
-    const sent = client.sendInput("main", "\x1b[200~~/data/terminal-paste/paste.png\x1b[201~", {
-      WebSocketImpl: FakeWebSocket as never,
-    });
+    await expect(client.sendInput("main", "\x1b[200~~/data/terminal-paste/paste.png\x1b[201~")).resolves.toBeUndefined();
 
-    expect(FakeWebSocket.last?.url).toContain("/ws/terminal/session");
-    expect(FakeWebSocket.last?.url).toContain("session=main");
-    FakeWebSocket.last?.emit("message", JSON.stringify({ type: "attached" }));
-
-    await expect(sent).resolves.toBeUndefined();
-    expect(FakeWebSocket.last?.sent).toEqual([
-      JSON.stringify({ type: "input", data: "\x1b[200~~/data/terminal-paste/paste.png\x1b[201~" }),
-      JSON.stringify({ type: "detach" }),
-    ]);
-    expect(FakeWebSocket.last?.closed).toBe(true);
+    expect(fetchImpl).toHaveBeenCalledWith(
+      "https://matrix.example/api/terminal/sessions/main/input",
+      expect.objectContaining({
+        method: "POST",
+        headers: expect.objectContaining({
+          Authorization: "Bearer token-123",
+          "Content-Type": "application/json",
+        }),
+        body: JSON.stringify({ data: "\x1b[200~~/data/terminal-paste/paste.png\x1b[201~" }),
+      }),
+    );
+    expect(FakeWebSocket.instances).toHaveLength(0);
   });
 
 });

--- a/shell/src/components/terminal/TerminalPane.tsx
+++ b/shell/src/components/terminal/TerminalPane.tsx
@@ -6,7 +6,7 @@ import { capturePostHogEvent, capturePostHogLog } from "@/lib/posthog-client";
 import { createSocketHealth } from "@/lib/socket-health";
 import { isTerminalDebugEnabled } from "@/lib/terminal-debug";
 import { useTerminalSettings } from "@/stores/terminal-settings";
-import { buildAuthenticatedWebSocketUrl } from "@/lib/websocket-auth";
+import { buildAuthenticatedWebSocketUrl, getWebSocketAuthToken } from "@/lib/websocket-auth";
 import type { Theme } from "@/hooks/useTheme";
 import { useVisualViewport } from "@/hooks/useVisualViewport";
 import { ImageAddon, type IImageAddonOptions } from "@xterm/addon-image";
@@ -38,6 +38,7 @@ const MAX_TERMINAL_INPUT = 65_536;
 const MAX_OSC52_BASE64_LENGTH = 1_000_000;
 const OSC52_ALLOWED_TARGETS = new Set(["", "c", "p", "s", "0", "1", "2", "3", "4", "5", "6", "7"]);
 const SUPPORTED_TERMINAL_PASTE_MIME_TYPES = new Set(["image/png", "image/jpeg", "image/gif", "image/webp"]);
+const TERMINAL_PASTE_UPLOAD_TIMEOUT_MS = 30_000;
 const TERMINAL_PASTE_MIME_BY_EXTENSION = new Map([
   [".png", "image/png"],
   [".jpg", "image/jpeg"],
@@ -105,6 +106,22 @@ function filesFromTerminalFilePayload(payload: DataTransfer | ClipboardEvent["cl
     return files;
   }
   return Array.from(payload.files ?? []).filter(isSupportedTerminalPasteFile);
+}
+
+function terminalPasteUploadSignal(): AbortSignal | undefined {
+  return typeof AbortSignal !== "undefined" && typeof AbortSignal.timeout === "function"
+    ? AbortSignal.timeout(TERMINAL_PASTE_UPLOAD_TIMEOUT_MS)
+    : undefined;
+}
+
+function splitBracketedPastePayload(parts: string[]): string[] {
+  const maxPayloadLength = MAX_TERMINAL_INPUT - BRACKETED_PASTE_OVERHEAD;
+  const payload = parts.filter((part) => part.length > 0).join(" ");
+  const chunks: string[] = [];
+  for (let index = 0; index < payload.length; index += maxPayloadLength) {
+    chunks.push(payload.slice(index, index + maxPayloadLength));
+  }
+  return chunks;
 }
 
 function scrollTerminalViewportToBottom(term: Terminal | null): void {
@@ -572,13 +589,15 @@ export function TerminalPane({
     const container = containerRef.current;
     if (!container) return;
 
-    const sendBracketedPaste = (terminalPath: string) => {
+    const sendBracketedPaste = (terminalPaths: string[]) => {
       const ws = wsRef.current;
       if (ws && ws.readyState === WebSocket.OPEN) {
-        ws.send(JSON.stringify({
-          type: "input",
-          data: `${BRACKETED_PASTE_OPEN}${terminalPath}${BRACKETED_PASTE_CLOSE}`,
-        }));
+        for (const chunk of splitBracketedPastePayload(terminalPaths)) {
+          ws.send(JSON.stringify({
+            type: "input",
+            data: `${BRACKETED_PASTE_OPEN}${chunk}${BRACKETED_PASTE_CLOSE}`,
+          }));
+        }
       }
     };
 
@@ -588,20 +607,32 @@ export function TerminalPane({
         return;
       }
       const terminalPaths: string[] = [];
+      let authToken: string | null = null;
+      try {
+        authToken = await getWebSocketAuthToken();
+      } catch (err: unknown) {
+        console.warn("Terminal paste auth token unavailable:", err instanceof Error ? err.message : err);
+      }
       for (const file of files) {
         const mimeType = terminalPasteMimeType(file);
         if (!mimeType) {
           continue;
         }
         try {
+          const headers: Record<string, string> = {
+            "Content-Type": mimeType,
+            "X-Matrix-Filename": file.name,
+          };
+          if (authToken) {
+            headers.Authorization = `Bearer ${authToken}`;
+          }
           const url = new URL(`${getGatewayUrl()}/api/terminal/sessions/${encodeURIComponent(sessionId)}/paste-assets`);
           url.searchParams.set("cwd", cwd || "projects");
           const res = await fetch(url.toString(), {
             method: "POST",
-            headers: {
-              "Content-Type": mimeType,
-              "X-Matrix-Filename": file.name,
-            },
+            credentials: "same-origin",
+            headers,
+            signal: terminalPasteUploadSignal(),
             body: file,
           });
           if (!res.ok) {
@@ -617,7 +648,7 @@ export function TerminalPane({
         }
       }
       if (terminalPaths.length > 0) {
-        sendBracketedPaste(terminalPaths.join(" "));
+        sendBracketedPaste(terminalPaths);
       }
     };
 

--- a/shell/src/components/terminal/TerminalPane.tsx
+++ b/shell/src/components/terminal/TerminalPane.tsx
@@ -37,6 +37,14 @@ const BRACKETED_PASTE_OVERHEAD = BRACKETED_PASTE_OPEN.length + BRACKETED_PASTE_C
 const MAX_TERMINAL_INPUT = 65_536;
 const MAX_OSC52_BASE64_LENGTH = 1_000_000;
 const OSC52_ALLOWED_TARGETS = new Set(["", "c", "p", "s", "0", "1", "2", "3", "4", "5", "6", "7"]);
+const SUPPORTED_TERMINAL_PASTE_MIME_TYPES = new Set(["image/png", "image/jpeg", "image/gif", "image/webp"]);
+const TERMINAL_PASTE_MIME_BY_EXTENSION = new Map([
+  [".png", "image/png"],
+  [".jpg", "image/jpeg"],
+  [".jpeg", "image/jpeg"],
+  [".gif", "image/gif"],
+  [".webp", "image/webp"],
+]);
 const TERMINAL_SCROLLBACK_LINES = 10_000;
 const TERMINAL_SCROLL_SENSITIVITY = 1;
 const TERMINAL_FAST_SCROLL_SENSITIVITY = 5;
@@ -61,6 +69,42 @@ function shouldDisableWebglRenderer(suppressNativeKeyboard: boolean): boolean {
     || (userAgent.includes("Macintosh") && navigator.maxTouchPoints > 1);
   const isSafari = /Safari\//.test(userAgent) && !/(Chrome|CriOS|FxiOS|EdgiOS)\//.test(userAgent);
   return isAppleMobile && isSafari;
+}
+
+function terminalPasteMimeType(file: File): string | null {
+  const typed = file.type.trim().toLowerCase();
+  if (SUPPORTED_TERMINAL_PASTE_MIME_TYPES.has(typed)) {
+    return typed;
+  }
+  const dot = file.name.lastIndexOf(".");
+  if (dot < 0) {
+    return null;
+  }
+  return TERMINAL_PASTE_MIME_BY_EXTENSION.get(file.name.slice(dot).toLowerCase()) ?? null;
+}
+
+function isSupportedTerminalPasteFile(file: File | null | undefined): file is File {
+  return Boolean(file && terminalPasteMimeType(file));
+}
+
+function filesFromTerminalFilePayload(payload: DataTransfer | ClipboardEvent["clipboardData"] | null): File[] {
+  if (!payload) {
+    return [];
+  }
+  const files: File[] = [];
+  const items = Array.from(payload.items ?? []);
+  for (const item of items) {
+    if (item.kind === "file") {
+      const file = item.getAsFile();
+      if (isSupportedTerminalPasteFile(file)) {
+        files.push(file);
+      }
+    }
+  }
+  if (files.length > 0) {
+    return files;
+  }
+  return Array.from(payload.files ?? []).filter(isSupportedTerminalPasteFile);
 }
 
 function scrollTerminalViewportToBottom(term: Terminal | null): void {
@@ -523,6 +567,102 @@ export function TerminalPane({
       sessionIdRef.current = initialSessionId;
     }
   }, [initialSessionId]);
+
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+
+    const sendBracketedPaste = (terminalPath: string) => {
+      const ws = wsRef.current;
+      if (ws && ws.readyState === WebSocket.OPEN) {
+        ws.send(JSON.stringify({
+          type: "input",
+          data: `${BRACKETED_PASTE_OPEN}${terminalPath}${BRACKETED_PASTE_CLOSE}`,
+        }));
+      }
+    };
+
+    const uploadAndPasteFiles = async (files: File[]) => {
+      const sessionId = sessionIdRef.current;
+      if (!sessionId) {
+        return;
+      }
+      const terminalPaths: string[] = [];
+      for (const file of files) {
+        const mimeType = terminalPasteMimeType(file);
+        if (!mimeType) {
+          continue;
+        }
+        try {
+          const url = new URL(`${getGatewayUrl()}/api/terminal/sessions/${encodeURIComponent(sessionId)}/paste-assets`);
+          url.searchParams.set("cwd", cwd || "projects");
+          const res = await fetch(url.toString(), {
+            method: "POST",
+            headers: {
+              "Content-Type": mimeType,
+              "X-Matrix-Filename": file.name,
+            },
+            body: file,
+          });
+          if (!res.ok) {
+            console.warn(`Terminal paste upload failed: ${res.status}`);
+            continue;
+          }
+          const payload = await res.json() as { terminalPath?: unknown };
+          if (typeof payload.terminalPath === "string") {
+            terminalPaths.push(payload.terminalPath);
+          }
+        } catch (err: unknown) {
+          console.warn("Terminal paste upload failed:", err instanceof Error ? err.message : err);
+        }
+      }
+      if (terminalPaths.length > 0) {
+        sendBracketedPaste(terminalPaths.join(" "));
+      }
+    };
+
+    const captureImagePayload = (event: ClipboardEvent | DragEvent): File[] => {
+      const files = "clipboardData" in event
+        ? filesFromTerminalFilePayload(event.clipboardData)
+        : filesFromTerminalFilePayload(event.dataTransfer);
+      if (files.length === 0) {
+        return [];
+      }
+      event.preventDefault();
+      event.stopPropagation();
+      if ("stopImmediatePropagation" in event) {
+        event.stopImmediatePropagation();
+      }
+      return files;
+    };
+
+    const onPaste = (event: ClipboardEvent) => {
+      const files = captureImagePayload(event);
+      if (files.length > 0) {
+        void uploadAndPasteFiles(files);
+      }
+    };
+    const onDrag = (event: DragEvent) => {
+      captureImagePayload(event);
+    };
+    const onDrop = (event: DragEvent) => {
+      const files = captureImagePayload(event);
+      if (files.length > 0) {
+        void uploadAndPasteFiles(files);
+      }
+    };
+
+    container.addEventListener("paste", onPaste, { capture: true });
+    container.addEventListener("dragenter", onDrag, { capture: true });
+    container.addEventListener("dragover", onDrag, { capture: true });
+    container.addEventListener("drop", onDrop, { capture: true });
+    return () => {
+      container.removeEventListener("paste", onPaste, { capture: true });
+      container.removeEventListener("dragenter", onDrag, { capture: true });
+      container.removeEventListener("dragover", onDrag, { capture: true });
+      container.removeEventListener("drop", onDrop, { capture: true });
+    };
+  }, [cwd]);
 
   // Bridge for the mobile accessory key bar. TerminalApp dispatches a custom
   // window event with the target paneId; we forward to this pane's PTY if it

--- a/shell/src/components/terminal/TerminalPane.tsx
+++ b/shell/src/components/terminal/TerminalPane.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useRef, useState, type ClipboardEvent, type CSSProperties, type KeyboardEvent as ReactKeyboardEvent } from "react";
+import { useEffect, useRef, useState, type CSSProperties } from "react";
 import { getGatewayUrl, getGatewayWs } from "@/lib/gateway";
 import { capturePostHogEvent, capturePostHogLog } from "@/lib/posthog-client";
 import { createSocketHealth } from "@/lib/socket-health";
@@ -24,8 +24,6 @@ import { buildTerminalFontStack } from "./terminal-fonts";
 import { createCodexTuiCompatTransform, transformTerminalOutputForCompat, type CodexTuiCompatTransform } from "./codex-tui-compat";
 import { sendTerminalResize } from "./terminal-remote-resize";
 import {
-  clipboardDataHasImage,
-  pasteClipboardDataIntoTerminal,
   pasteClipboardIntoTerminal,
 } from "./terminal-rich-paste";
 import {
@@ -38,6 +36,10 @@ import type { TerminalCompatMode } from "@/stores/terminal-store";
 
 const MAX_OSC52_BASE64_LENGTH = 1_000_000;
 const OSC52_ALLOWED_TARGETS = new Set(["", "c", "p", "s", "0", "1", "2", "3", "4", "5", "6", "7"]);
+const BRACKETED_PASTE_OPEN = "\u001b[200~";
+const BRACKETED_PASTE_CLOSE = "\u001b[201~";
+const BRACKETED_PASTE_OVERHEAD = BRACKETED_PASTE_OPEN.length + BRACKETED_PASTE_CLOSE.length;
+const MAX_TERMINAL_INPUT = 65_536;
 const SUPPORTED_TERMINAL_PASTE_MIME_TYPES = new Set(["image/png", "image/jpeg", "image/gif", "image/webp"]);
 const TERMINAL_PASTE_UPLOAD_TIMEOUT_MS = 30_000;
 const TERMINAL_PASTE_MIME_BY_EXTENSION = new Map([
@@ -444,7 +446,6 @@ export function TerminalPane({
   const heartbeatRef = useRef<ReturnType<typeof createSocketHealth> | null>(null);
   const isFocusedRef = useRef(isFocused);
   const allowRemoteResizeRef = useRef(allowRemoteResize);
-  const pasteSubmitRequestedRef = useRef(false);
   const compatModeRef = useRef<TerminalCompatMode | undefined>(compatMode);
   const codexCompatTransformRef = useRef<CodexTuiCompatTransform | null>(null);
 
@@ -579,34 +580,6 @@ export function TerminalPane({
 
   const showPasteError = (message = "Image paste failed. Try a smaller image or paste a saved file with `mos shell paste-file`.") => {
     setPasteError(message);
-  };
-
-  const handleKeyDownCapture = (event: ReactKeyboardEvent<HTMLDivElement>) => {
-    if ((event.metaKey || event.ctrlKey) && event.altKey && event.key.toLowerCase() === "v") {
-      pasteSubmitRequestedRef.current = true;
-      window.setTimeout(() => {
-        pasteSubmitRequestedRef.current = false;
-      }, 750);
-    }
-  };
-
-  const handlePaste = (event: ClipboardEvent<HTMLDivElement>) => {
-    if (!clipboardDataHasImage(event.clipboardData)) {
-      return;
-    }
-    event.preventDefault();
-    handleFocus();
-    const submit = pasteSubmitRequestedRef.current;
-    pasteSubmitRequestedRef.current = false;
-    pasteClipboardDataIntoTerminal({
-      clipboardData: event.clipboardData,
-      gatewayUrl: getGatewayUrl(),
-      ws: wsRef.current,
-      submit,
-    }).catch((err: unknown) => {
-      console.warn("Clipboard image paste failed:", err instanceof Error ? err.message : err);
-      showPasteError();
-    });
   };
 
   useEffect(() => {
@@ -1751,8 +1724,6 @@ export function TerminalPane({
       }}
       onPointerDown={handleFocus}
       onClick={handleFocus}
-      onKeyDownCapture={handleKeyDownCapture}
-      onPasteCapture={handlePaste}
     >
       {pasteError && (
         <div

--- a/shell/src/components/terminal/TerminalPane.tsx
+++ b/shell/src/components/terminal/TerminalPane.tsx
@@ -111,10 +111,16 @@ function filesFromTerminalFilePayload(payload: DataTransfer | ClipboardEvent["cl
   return Array.from(payload.files ?? []).filter(isSupportedTerminalPasteFile);
 }
 
-function terminalPasteUploadSignal(): AbortSignal | undefined {
-  return typeof AbortSignal !== "undefined" && typeof AbortSignal.timeout === "function"
-    ? AbortSignal.timeout(TERMINAL_PASTE_UPLOAD_TIMEOUT_MS)
-    : undefined;
+function terminalPasteUploadTimeout(): { signal: AbortSignal; cleanup: () => void } {
+  if (typeof AbortSignal !== "undefined" && typeof AbortSignal.timeout === "function") {
+    return { signal: AbortSignal.timeout(TERMINAL_PASTE_UPLOAD_TIMEOUT_MS), cleanup: () => {} };
+  }
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), TERMINAL_PASTE_UPLOAD_TIMEOUT_MS);
+  return {
+    signal: controller.signal,
+    cleanup: () => clearTimeout(timeout),
+  };
 }
 
 function splitBracketedPastePayload(parts: string[]): string[] {
@@ -626,6 +632,7 @@ export function TerminalPane({
         if (!mimeType) {
           continue;
         }
+        const uploadTimeout = terminalPasteUploadTimeout();
         try {
           const headers: Record<string, string> = {
             "Content-Type": mimeType,
@@ -640,7 +647,7 @@ export function TerminalPane({
             method: "POST",
             credentials: "same-origin",
             headers,
-            signal: terminalPasteUploadSignal(),
+            signal: uploadTimeout.signal,
             body: file,
           });
           if (!res.ok) {
@@ -653,6 +660,8 @@ export function TerminalPane({
           }
         } catch (err: unknown) {
           console.warn("Terminal paste upload failed:", err instanceof Error ? err.message : err);
+        } finally {
+          uploadTimeout.cleanup();
         }
       }
       if (terminalPaths.length > 0) {

--- a/tests/cli/run.test.ts
+++ b/tests/cli/run.test.ts
@@ -122,6 +122,7 @@ async function runMatrixCli(args: string[]) {
 describe("run CLI command", () => {
   it("exports the developer run command", () => {
     expect(runCommand.meta?.name).toBe("run");
+    expect(runCommand.args).toHaveProperty("noRichPaste");
     expect(PUBLISHED_CLI_COMMANDS.has("run")).toBe(true);
     expect(resolvePublishedCliRedirect(["run", "-it", "--", "claude"])).toEqual([
       "run",
@@ -181,6 +182,24 @@ describe("run CLI command", () => {
       }),
     ).resolves.toEqual({ detached: true });
     expect(client.attachSession).toHaveBeenCalledWith("setup", { mouse: false });
+  });
+
+  it("passes no-rich-paste mode through interactive run attach", async () => {
+    const client = {
+      createSession: vi.fn(async () => ({ name: "setup" })),
+      attachSession: vi.fn(async () => ({ detached: true })),
+    };
+
+    await expect(
+      createOrAttachRunSession(client, {
+        name: "setup",
+        cwd: "projects/app",
+        command: ["codex"],
+        sessionProvided: true,
+        attachOptions: { cwd: "projects/app", noRichPaste: true },
+      }),
+    ).resolves.toEqual({ detached: true });
+    expect(client.attachSession).toHaveBeenCalledWith("setup", { cwd: "projects/app", noRichPaste: true });
   });
 
   it("keeps stdout JSON-only for run -it --json", async () => {

--- a/tests/cli/shell-client.test.ts
+++ b/tests/cli/shell-client.test.ts
@@ -1,4 +1,7 @@
 import { EventEmitter } from "node:events";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import {
   createShellClient,
@@ -7,6 +10,10 @@ import {
 } from "../../packages/sync-client/src/cli/shell-client.js";
 
 const LOCAL_TERMINAL_INPUT_RESET = "\u001b[?1000l\u001b[?1002l\u001b[?1003l\u001b[?1006l\u001b[?1015l\u001b[?1004l\u001b[?2004l\u001b[>4;0m\u001b[<1u";
+const BRACKETED_PASTE_OPEN = "\u001b[200~";
+const BRACKETED_PASTE_CLOSE = "\u001b[201~";
+const PNG_BYTES = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00]);
+const roots: string[] = [];
 
 class ControlledWebSocket {
   static last: ControlledWebSocket | null = null;
@@ -76,6 +83,7 @@ describe("shell REST client", () => {
 
   afterEach(() => {
     vi.useRealTimers();
+    return Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
   });
 
   it("lists sessions with bearer auth, JSON parsing, and fetch timeout", async () => {
@@ -199,6 +207,30 @@ describe("shell REST client", () => {
     expect(client.createAttachUrl("main", { token: "query-token" })).toBe(
       "wss://gateway.example/ws/terminal/session?session=main&token=query-token",
     );
+  });
+
+  it("sends one-shot input over HTTP without opening a websocket attach", async () => {
+    const fetchImpl = vi.fn(async () => new Response(JSON.stringify({ ok: true })));
+    const client = createShellClient({
+      gatewayUrl: "http://gateway",
+      token: "tok",
+      fetch: fetchImpl,
+    });
+
+    await expect(client.sendInput("main", "pwd\r")).resolves.toBeUndefined();
+
+    expect(fetchImpl).toHaveBeenCalledWith(
+      "http://gateway/api/terminal/sessions/main/input",
+      expect.objectContaining({
+        method: "POST",
+        headers: expect.objectContaining({
+          Authorization: "Bearer tok",
+          "Content-Type": "application/json",
+        }),
+        body: JSON.stringify({ data: "pwd\r" }),
+      }),
+    );
+    expect(ControlledWebSocket.instances).toHaveLength(0);
   });
 
   it("times out terminal websocket attach attempts", async () => {
@@ -677,6 +709,153 @@ describe("shell REST client", () => {
     ControlledWebSocket.last?.emit("message", JSON.stringify({ type: "attached" }));
     ControlledWebSocket.last?.emit("message", JSON.stringify({ type: "exit", code: 0 }));
     await expect(attached).resolves.toEqual({ detached: false });
+  });
+
+  it("uploads a pasted quoted macOS screenshot path and sends the VPS terminal path", async () => {
+    const root = await mkdtemp(join(tmpdir(), "matrix-shell-rich-paste-"));
+    roots.push(root);
+    const imagePath = join(root, "Screenshot 2026-07-07 at 6.50.39 PM.png");
+    await writeFile(imagePath, PNG_BYTES, { flag: "wx" });
+    const fetchImpl = vi.fn(async (url: string, init?: RequestInit) => {
+      if (url === "http://gateway/api/terminal/sessions/main/paste-assets?cwd=projects%2Fapp") {
+        expect(init?.method).toBe("POST");
+        expect(init?.headers).toEqual(expect.objectContaining({
+          Authorization: "Bearer tok",
+          "Content-Type": "image/png",
+          "X-Matrix-Filename": "Screenshot 2026-07-07 at 6.50.39 PM.png",
+        }));
+        expect(Buffer.from(init?.body as BodyInit as ArrayBuffer)).toEqual(PNG_BYTES);
+        return new Response(JSON.stringify({
+          path: "projects/.matrix-terminal-pastes/2026-07-07/upload.png",
+          terminalPath: "/home/matrix/home/projects/.matrix-terminal-pastes/2026-07-07/upload.png",
+          size: PNG_BYTES.length,
+          mimeType: "image/png",
+        }));
+      }
+      throw new Error(`unexpected fetch ${url}`);
+    });
+    const client = createShellClient({
+      gatewayUrl: "http://gateway",
+      token: "tok",
+      fetch: fetchImpl,
+      timeoutMs: 50,
+    });
+    const input = new FakeTtyInput() as unknown as NodeJS.ReadStream;
+    const output = { write: vi.fn(), columns: 80, rows: 24 } as unknown as NodeJS.WriteStream;
+    const errorOutput = { write: vi.fn() } as unknown as NodeJS.WriteStream;
+
+    const attached = client.attachSession("main", {
+      WebSocketImpl: ControlledWebSocket,
+      input,
+      output,
+      errorOutput,
+      cwd: "projects/app",
+    });
+    ControlledWebSocket.last?.emit("open");
+    ControlledWebSocket.last?.emit("message", JSON.stringify({ type: "attached" }));
+    input.emit("data", `"${imagePath}"`);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    ControlledWebSocket.last?.emit("message", JSON.stringify({ type: "exit", code: 0 }));
+
+    await expect(attached).resolves.toEqual({ detached: false });
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    expect(ControlledWebSocket.last?.sent.map((frame) => JSON.parse(frame))).toContainEqual({
+      type: "input",
+      data: `${BRACKETED_PASTE_OPEN}/home/matrix/home/projects/.matrix-terminal-pastes/2026-07-07/upload.png${BRACKETED_PASTE_CLOSE}`,
+    });
+    expect(ControlledWebSocket.last?.sent.join("")).not.toContain(imagePath);
+  });
+
+  it("does not intercept local image paths when rich paste is disabled", async () => {
+    const root = await mkdtemp(join(tmpdir(), "matrix-shell-no-rich-paste-"));
+    roots.push(root);
+    const imagePath = join(root, "Screenshot 2026-07-07 at 6.50.39 PM.png");
+    await writeFile(imagePath, PNG_BYTES, { flag: "wx" });
+    const fetchImpl = vi.fn(async () => {
+      throw new Error("rich paste upload should not run");
+    });
+    const client = createShellClient({
+      gatewayUrl: "http://gateway",
+      token: "tok",
+      fetch: fetchImpl,
+      timeoutMs: 50,
+    });
+    const input = new FakeTtyInput() as unknown as NodeJS.ReadStream;
+    const output = { write: vi.fn(), columns: 80, rows: 24 } as unknown as NodeJS.WriteStream;
+    const errorOutput = { write: vi.fn() } as unknown as NodeJS.WriteStream;
+
+    const attached = client.attachSession("main", {
+      WebSocketImpl: ControlledWebSocket,
+      input,
+      output,
+      errorOutput,
+      noRichPaste: true,
+    });
+    ControlledWebSocket.last?.emit("open");
+    ControlledWebSocket.last?.emit("message", JSON.stringify({ type: "attached" }));
+    input.emit("data", `"${imagePath}"`);
+    ControlledWebSocket.last?.emit("message", JSON.stringify({ type: "exit", code: 0 }));
+
+    await expect(attached).resolves.toEqual({ detached: false });
+    expect(fetchImpl).not.toHaveBeenCalled();
+    expect(ControlledWebSocket.last?.sent.map((frame) => JSON.parse(frame))).toContainEqual({
+      type: "input",
+      data: `"${imagePath}"`,
+    });
+  });
+
+  it("chunks oversized terminal input frames below the gateway input cap", async () => {
+    const client = createShellClient({ gatewayUrl: "http://gateway", timeoutMs: 50 });
+    const input = new FakeTtyInput() as unknown as NodeJS.ReadStream;
+    const output = { write: vi.fn(), columns: 80, rows: 24 } as unknown as NodeJS.WriteStream;
+    const errorOutput = { write: vi.fn() } as unknown as NodeJS.WriteStream;
+    const largeInput = "x".repeat(140_000);
+
+    const attached = client.attachSession("main", {
+      WebSocketImpl: ControlledWebSocket,
+      input,
+      output,
+      errorOutput,
+    });
+    ControlledWebSocket.last?.emit("open");
+    ControlledWebSocket.last?.emit("message", JSON.stringify({ type: "attached" }));
+    input.emit("data", largeInput);
+    ControlledWebSocket.last?.emit("message", JSON.stringify({ type: "exit", code: 0 }));
+
+    await expect(attached).resolves.toEqual({ detached: false });
+    const inputFrames = ControlledWebSocket.last!.sent
+      .map((frame) => JSON.parse(frame))
+      .filter((frame) => frame.type === "input") as Array<{ data: string }>;
+    expect(inputFrames.length).toBeGreaterThan(1);
+    expect(inputFrames.every((frame) => frame.data.length < 65_536)).toBe(true);
+    expect(inputFrames.map((frame) => frame.data).join("")).toBe(largeInput);
+  });
+
+  it("drops pasted OSC and APC image/control sequences instead of forwarding them as keystrokes", async () => {
+    const client = createShellClient({ gatewayUrl: "http://gateway", timeoutMs: 50 });
+    const input = new FakeTtyInput() as unknown as NodeJS.ReadStream;
+    const output = { write: vi.fn(), columns: 80, rows: 24 } as unknown as NodeJS.WriteStream;
+    const errorOutput = { write: vi.fn() } as unknown as NodeJS.WriteStream;
+
+    const attached = client.attachSession("main", {
+      WebSocketImpl: ControlledWebSocket,
+      input,
+      output,
+      errorOutput,
+    });
+    ControlledWebSocket.last?.emit("open");
+    ControlledWebSocket.last?.emit("message", JSON.stringify({ type: "attached" }));
+    input.emit("data", "a\u001b]1337;File=name=x.png;inline=1:AAAA\u0007b\u001b_Gf=100;AAAA\u001b\\c");
+    ControlledWebSocket.last?.emit("message", JSON.stringify({ type: "exit", code: 0 }));
+
+    await expect(attached).resolves.toEqual({ detached: false });
+    expect(ControlledWebSocket.last?.sent.map((frame) => JSON.parse(frame))).toContainEqual({
+      type: "input",
+      data: "abc",
+    });
+    expect(ControlledWebSocket.last?.sent.join("")).not.toContain("1337;File");
+    expect(ControlledWebSocket.last?.sent.join("")).not.toContain("_Gf=100");
   });
 
   it("rejects when pre-open stdin exceeds the queued frame cap", async () => {

--- a/tests/cli/shell.test.ts
+++ b/tests/cli/shell.test.ts
@@ -117,6 +117,12 @@ describe("shell CLI command", () => {
     ]);
   });
 
+  it("declares --no-rich-paste on shell attach and new --attach paths", () => {
+    expect(shellCommand.subCommands!.attach.args).toHaveProperty("noRichPaste");
+    expect(shellCommand.subCommands!.connect.args).toHaveProperty("noRichPaste");
+    expect(shellCommand.subCommands!.new.args).toHaveProperty("noRichPaste");
+  });
+
   it("keeps aliases as distinct command objects with canonical names", () => {
     expect(shellCommand.subCommands!.connect).not.toBe(shellCommand.subCommands!.attach);
     expect(shellCommand.subCommands!.connect.meta?.name).toBe("connect");

--- a/tests/cli/shell.test.ts
+++ b/tests/cli/shell.test.ts
@@ -79,6 +79,23 @@ function createInputWebSocket(sentInputs: string[]) {
   };
 }
 
+function createPasteFetch(uploadPayload: Record<string, unknown>, sentInputs: string[]) {
+  return vi.fn(async (url: RequestInfo | URL, init?: RequestInit) => {
+    const href = String(url);
+    if (href.includes("/api/files/blob")) {
+      return new Response(JSON.stringify(uploadPayload));
+    }
+    if (href.includes("/api/terminal/sessions/main/input")) {
+      const body = JSON.parse(String(init?.body ?? "{}")) as { data?: unknown };
+      if (typeof body.data === "string") {
+        sentInputs.push(body.data);
+      }
+      return new Response(JSON.stringify({ ok: true }));
+    }
+    throw new Error(`unexpected fetch ${href}`);
+  });
+}
+
 async function runMatrixCli(args: string[]) {
   const bin = join(process.cwd(), "packages/sync-client/bin/matrix.mjs");
   return await new Promise<{
@@ -379,15 +396,8 @@ describe("shell CLI command", () => {
     await writeFile(localPath, "paste me");
     const sentInputs: string[] = [];
     const longRemotePath = `data/terminal-paste/${"x".repeat(70_000)}.txt`;
-    const fetchImpl = vi.fn(async (url: string) => {
-      if (url.includes("/api/files/blob")) {
-        return new Response(JSON.stringify({ path: longRemotePath, size: 8 }));
-      }
-      throw new Error(`unexpected fetch ${url}`);
-    });
-    vi.stubGlobal("fetch", fetchImpl);
+    vi.stubGlobal("fetch", createPasteFetch({ path: longRemotePath, size: 8 }, sentInputs));
     vi.spyOn(console, "log").mockImplementation(() => {});
-    const InputWebSocket = createInputWebSocket(sentInputs);
 
     await shellCommand.subCommands!["paste-file"].run!({
       args: {
@@ -397,7 +407,6 @@ describe("shell CLI command", () => {
         dev: true,
         token: "tok",
         force: true,
-        WebSocketImpl: InputWebSocket,
       },
     } as never);
 
@@ -413,10 +422,10 @@ describe("shell CLI command", () => {
     const localPath = join(root, "screenshot.png");
     await writeFile(localPath, "fake image");
     const sentInputs: string[] = [];
-    vi.stubGlobal("fetch", vi.fn(async () => new Response(JSON.stringify({
+    vi.stubGlobal("fetch", createPasteFetch({
       path: "data/terminal-paste/paste-1.png",
       size: 10,
-    }))));
+    }, sentInputs));
     vi.spyOn(console, "log").mockImplementation(() => {});
 
     await shellCommand.subCommands!["paste-file"].run!({
@@ -425,7 +434,6 @@ describe("shell CLI command", () => {
         local: localPath,
         dev: true,
         token: "tok",
-        WebSocketImpl: createInputWebSocket(sentInputs),
       },
     } as never);
 
@@ -439,10 +447,10 @@ describe("shell CLI command", () => {
     const localPath = join(root, "notes.txt");
     await writeFile(localPath, "notes");
     const sentInputs: string[] = [];
-    vi.stubGlobal("fetch", vi.fn(async () => new Response(JSON.stringify({
+    vi.stubGlobal("fetch", createPasteFetch({
       path: "data/terminal-paste/notes.txt",
       size: 5,
-    }))));
+    }, sentInputs));
     vi.spyOn(console, "log").mockImplementation(() => {});
 
     await shellCommand.subCommands!["paste-file"].run!({
@@ -453,7 +461,6 @@ describe("shell CLI command", () => {
         token: "tok",
         format: "path",
         enter: true,
-        WebSocketImpl: createInputWebSocket(sentInputs),
       },
     } as never);
 
@@ -462,10 +469,10 @@ describe("shell CLI command", () => {
 
   it("uploads clipboard images and pastes an agent prompt into the target shell", async () => {
     const sentInputs: string[] = [];
-    vi.stubGlobal("fetch", vi.fn(async () => new Response(JSON.stringify({
+    vi.stubGlobal("fetch", createPasteFetch({
       path: "data/terminal-paste/clipboard.png",
       size: 12,
-    }))));
+    }, sentInputs));
     vi.spyOn(console, "log").mockImplementation(() => {});
 
     await shellCommand.subCommands!["paste-clipboard"].run!({
@@ -479,7 +486,6 @@ describe("shell CLI command", () => {
           extension: "png",
           basename: "clipboard.png",
         }),
-        WebSocketImpl: createInputWebSocket(sentInputs),
       },
     } as never);
 
@@ -493,10 +499,10 @@ describe("shell CLI command", () => {
     const screenshotPath = join(root, "captured.png");
     await writeFile(screenshotPath, "fake captured png");
     const sentInputs: string[] = [];
-    vi.stubGlobal("fetch", vi.fn(async () => new Response(JSON.stringify({
+    vi.stubGlobal("fetch", createPasteFetch({
       path: "data/terminal-paste/captured.png",
       size: 17,
-    }))));
+    }, sentInputs));
     vi.spyOn(console, "log").mockImplementation(() => {});
 
     await shellCommand.subCommands!["paste-screenshot"].run!({
@@ -506,7 +512,6 @@ describe("shell CLI command", () => {
         token: "tok",
         area: true,
         captureScreenshot: async () => ({ path: screenshotPath, cleanup: async () => {} }),
-        WebSocketImpl: createInputWebSocket(sentInputs),
       },
     } as never);
 

--- a/tests/gateway/shell-routes.test.ts
+++ b/tests/gateway/shell-routes.test.ts
@@ -1,13 +1,15 @@
-import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { Hono } from "hono";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createShellRoutes } from "../../packages/gateway/src/shell/routes.js";
+import { shellError } from "../../packages/gateway/src/shell/errors.js";
 import { ShellRegistry } from "../../packages/gateway/src/shell/registry.js";
 import { createRateLimiter } from "../../packages/gateway/src/security/rate-limiter.js";
 
 const roots: string[] = [];
+const PNG_BYTES = Uint8Array.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00, 0x00, 0x0d]);
 
 async function tempRoot() {
   const root = await mkdtemp(join(tmpdir(), "matrix-shell-routes-"));
@@ -22,14 +24,15 @@ afterEach(async () => {
 describe("gateway shell routes", () => {
   function appWithRegistry(registry: {
     list: () => Promise<unknown[]>;
+    get?: (name: string) => Promise<unknown>;
     create: (input: unknown) => Promise<unknown>;
     delete: (name: string, options?: { force?: boolean }) => Promise<void>;
     rename?: (name: string, nextName: string) => Promise<unknown>;
     reorder?: (order: string[]) => Promise<unknown[]>;
-  }, shellBackend?: { health: () => Promise<{ ok: boolean; code: string }> }) {
+  }, shellBackend?: { health: () => Promise<{ ok: boolean; code: string }> }, extraDeps: Record<string, unknown> = {}) {
     const app = new Hono();
-    app.route("/api/terminal", createShellRoutes({ registry, shellBackend }));
-    app.route("/api", createShellRoutes({ registry, shellBackend }));
+    app.route("/api/terminal", createShellRoutes({ registry, shellBackend, ...extraDeps }));
+    app.route("/api", createShellRoutes({ registry, shellBackend, ...extraDeps }));
     return app;
   }
 
@@ -231,6 +234,154 @@ describe("gateway shell routes", () => {
       durationMs: 12,
     });
     expect(commandRunner.run).toHaveBeenCalledWith({ command: ["ls"], cwd: "projects/app" });
+  });
+
+  it("uploads pasted terminal image assets into the project-local paste directory", async () => {
+    const root = await tempRoot();
+    await mkdir(join(root, "projects", "app"), { recursive: true });
+    const registry = {
+      list: vi.fn(async () => [{ name: "main", status: "active" }]),
+      get: vi.fn(async () => ({ name: "main", status: "active" })),
+      create: vi.fn(),
+      delete: vi.fn(),
+    };
+    const app = appWithRegistry(registry, undefined, { homePath: root });
+
+    const res = await app.request("/api/terminal/sessions/main/paste-assets?cwd=projects/app", {
+      method: "POST",
+      headers: {
+        "Content-Type": "image/png",
+        "X-Matrix-Filename": "Screenshot 2026-07-07 at 6.50.39 PM.png",
+      },
+      body: PNG_BYTES,
+    });
+
+    expect(res.status).toBe(201);
+    const body = await res.json() as {
+      path: string;
+      terminalPath: string;
+      size: number;
+      mimeType: string;
+    };
+    expect(body).toMatchObject({
+      size: PNG_BYTES.length,
+      mimeType: "image/png",
+    });
+    expect(body.path).toMatch(/^projects\/app\/\.matrix-terminal-pastes\/\d{4}-\d{2}-\d{2}\//);
+    expect(body.path.endsWith(".png")).toBe(true);
+    expect(body.terminalPath).toBe(join(root, body.path));
+    await expect(readFile(body.terminalPath)).resolves.toEqual(Buffer.from(PNG_BYTES));
+    expect(registry.get).toHaveBeenCalledWith("main");
+  });
+
+  it("rejects unsafe terminal paste uploads with generic client errors", async () => {
+    const root = await tempRoot();
+    await mkdir(join(root, "projects", "app"), { recursive: true });
+    const registry = {
+      list: vi.fn(async () => [{ name: "main", status: "active" }]),
+      get: vi.fn(async () => ({ name: "main", status: "active" })),
+      create: vi.fn(),
+      delete: vi.fn(),
+    };
+    const app = appWithRegistry(registry, undefined, { homePath: root });
+
+    const unsupportedMagic = await app.request("/api/terminal/sessions/main/paste-assets?cwd=projects/app", {
+      method: "POST",
+      headers: { "Content-Type": "image/png" },
+      body: "<svg><script>alert(1)</script></svg>",
+    });
+    const traversalCwd = await app.request("/api/terminal/sessions/main/paste-assets?cwd=../outside", {
+      method: "POST",
+      headers: { "Content-Type": "image/png" },
+      body: PNG_BYTES,
+    });
+    const unsafeFilename = await app.request("/api/terminal/sessions/main/paste-assets?cwd=projects/app", {
+      method: "POST",
+      headers: {
+        "Content-Type": "image/png",
+        "X-Matrix-Filename": "../bad.png",
+      },
+      body: PNG_BYTES,
+    });
+    const missingSession = await appWithRegistry({
+      list: vi.fn(async () => []),
+      get: vi.fn(async () => {
+        throw shellError("session_not_found", "Session not found", 404);
+      }),
+      create: vi.fn(),
+      delete: vi.fn(),
+    }, undefined, { homePath: root }).request("/api/terminal/sessions/missing/paste-assets?cwd=projects/app", {
+      method: "POST",
+      headers: { "Content-Type": "image/png" },
+      body: PNG_BYTES,
+    });
+
+    expect(unsupportedMagic.status).toBe(400);
+    await expect(unsupportedMagic.json()).resolves.toEqual({
+      error: { code: "unsupported_media_type", message: "Invalid request" },
+    });
+    expect(traversalCwd.status).toBe(400);
+    await expect(traversalCwd.json()).resolves.toEqual({
+      error: { code: "invalid_request", message: "Invalid request" },
+    });
+    expect(unsafeFilename.status).toBe(400);
+    await expect(unsafeFilename.json()).resolves.toEqual({
+      error: { code: "invalid_request", message: "Invalid request" },
+    });
+    expect(missingSession.status).toBe(404);
+    await expect(missingSession.json()).resolves.toEqual({
+      error: { code: "session_not_found", message: "Session not found" },
+    });
+  });
+
+  it("applies the 10 MiB body limit before terminal paste upload handling", async () => {
+    const root = await tempRoot();
+    await mkdir(join(root, "projects", "app"), { recursive: true });
+    const registry = {
+      list: vi.fn(async () => [{ name: "main", status: "active" }]),
+      get: vi.fn(async () => ({ name: "main", status: "active" })),
+      create: vi.fn(),
+      delete: vi.fn(),
+    };
+    const app = appWithRegistry(registry, undefined, { homePath: root });
+    const oversized = new Uint8Array(10 * 1024 * 1024 + 1);
+    oversized.set(PNG_BYTES, 0);
+
+    const res = await app.request("/api/terminal/sessions/main/paste-assets?cwd=projects/app", {
+      method: "POST",
+      headers: { "Content-Type": "image/png" },
+      body: oversized,
+    });
+
+    expect(res.status).toBe(413);
+    await expect(res.json()).resolves.toEqual({
+      error: { code: "payload_too_large", message: "Request too large" },
+    });
+    expect(registry.get).not.toHaveBeenCalled();
+  });
+
+  it("sends one-shot terminal input without attaching a subscriber", async () => {
+    const registry = {
+      list: vi.fn(async () => [{ name: "main", status: "active" }]),
+      get: vi.fn(async () => ({ name: "main", status: "active" })),
+      create: vi.fn(),
+      delete: vi.fn(),
+    };
+    const terminalInput = {
+      sendInput: vi.fn(async () => undefined),
+    };
+    const app = appWithRegistry(registry, undefined, { terminalInput });
+
+    const res = await app.request("/api/terminal/sessions/main/input", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ data: "pwd\r" }),
+    });
+
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual({ ok: true });
+    expect(registry.get).toHaveBeenCalledWith("main");
+    expect(terminalInput.sendInput).toHaveBeenCalledWith("main", "pwd\r");
   });
 
   it("allows digit-leading session names consistently across create and route params", async () => {

--- a/tests/gateway/shell-zellij.test.ts
+++ b/tests/gateway/shell-zellij.test.ts
@@ -253,6 +253,24 @@ describe("zellij adapter", () => {
     expect(pty.resize).toHaveBeenCalledWith(140, 50);
   });
 
+  it("sends one-shot input through a transient attach PTY", async () => {
+    const pty = ptyProcess();
+    const spawnPty = vi.fn(() => pty);
+    const adapter = createZellijAdapter({ execFile: vi.fn(), spawnPty, timeoutMs: 25 });
+
+    const sent = adapter.sendInput("main", "pwd\r");
+
+    expect(spawnPty).toHaveBeenCalledWith(
+      "zellij",
+      ["attach", "main"],
+      expect.objectContaining({ name: "xterm-256color", cols: 120, rows: 40 }),
+    );
+    expect(pty.writes).toEqual(["pwd\r"]);
+    expect(pty.kill).not.toHaveBeenCalled();
+    await sent;
+    expect(pty.kill).toHaveBeenCalledTimes(1);
+  });
+
   it("creates sessions in the requested cwd using a retained PTY", async () => {
     const pty = ptyProcess();
     const execFile = vi.fn();

--- a/tests/gateway/shell-zellij.test.ts
+++ b/tests/gateway/shell-zellij.test.ts
@@ -253,22 +253,38 @@ describe("zellij adapter", () => {
     expect(pty.resize).toHaveBeenCalledWith(140, 50);
   });
 
-  it("sends one-shot input through a transient attach PTY", async () => {
-    const pty = ptyProcess();
-    const spawnPty = vi.fn(() => pty);
-    const adapter = createZellijAdapter({ execFile: vi.fn(), spawnPty, timeoutMs: 25 });
+  it("sends one-shot input through the zellij action API", async () => {
+    const child = childProcess();
+    const execFile = vi.fn((_file, _args, _opts, cb) => {
+      cb(null, "", "");
+      return child;
+    });
+    const spawnPty = vi.fn();
+    const adapter = createZellijAdapter({ execFile, spawnPty, timeoutMs: 25 });
 
-    const sent = adapter.sendInput("main", "pwd\r");
+    await adapter.sendInput("main", "pwd\r");
 
-    expect(spawnPty).toHaveBeenCalledWith(
+    expect(spawnPty).not.toHaveBeenCalled();
+    expect(execFile).toHaveBeenCalledWith(
       "zellij",
-      ["attach", "main"],
-      expect.objectContaining({ name: "xterm-256color", cols: 120, rows: 40 }),
+      ["--session", "main", "action", "write-chars", "--", "pwd\r"],
+      expect.objectContaining({ timeout: 25, signal: expect.any(AbortSignal) }),
+      expect.any(Function),
     );
-    expect(pty.writes).toEqual(["pwd\r"]);
-    expect(pty.kill).not.toHaveBeenCalled();
-    await sent;
-    expect(pty.kill).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects one-shot input when the zellij action fails", async () => {
+    const child = childProcess();
+    const execFile = vi.fn((_file, _args, _opts, cb) => {
+      cb(new Error("boom"), "", "failed in /home/alice/project");
+      return child;
+    });
+    const adapter = createZellijAdapter({ execFile, spawnPty: vi.fn(), timeoutMs: 25 });
+
+    await expect(adapter.sendInput("main", "pwd\r")).rejects.toMatchObject({
+      code: "zellij_failed",
+      safeMessage: "Shell operation failed",
+    });
   });
 
   it("creates sessions in the requested cwd using a retained PTY", async () => {

--- a/tests/shell/terminal-pane-privacy.test.tsx
+++ b/tests/shell/terminal-pane-privacy.test.tsx
@@ -27,8 +27,13 @@ const stubWs = vi.hoisted(() => ({
   onclose: null as (() => void) | null,
   onerror: null as (() => void) | null,
 }));
+const wsAuth = vi.hoisted(() => ({
+  buildAuthenticatedWebSocketUrl: vi.fn(async () => "ws://gateway.test/ws/terminal/session?session=main&token=ws-token"),
+  getWebSocketAuthToken: vi.fn(async () => "ws-token"),
+}));
 const BRACKETED_PASTE_OPEN = "\u001b[200~";
 const BRACKETED_PASTE_CLOSE = "\u001b[201~";
+const MAX_TERMINAL_INPUT = 65_536;
 
 vi.mock("../../shell/src/components/terminal/terminal-cache.js", () => ({
   cacheTerminal: vi.fn(),
@@ -76,6 +81,8 @@ vi.mock("@/stores/terminal-settings", () => {
   };
 });
 
+vi.mock("@/lib/websocket-auth", () => wsAuth);
+
 import { TerminalPane } from "../../shell/src/components/terminal/TerminalPane.js";
 
 const theme = {
@@ -96,6 +103,9 @@ describe("TerminalPane session replay privacy", () => {
     stubWs.readyState = 1;
     stubWs.send.mockClear();
     stubWs.close.mockClear();
+    wsAuth.buildAuthenticatedWebSocketUrl.mockClear();
+    wsAuth.getWebSocketAuthToken.mockClear();
+    wsAuth.getWebSocketAuthToken.mockResolvedValue("ws-token");
     vi.stubGlobal("fetch", vi.fn(async () => new Response(JSON.stringify({
       path: "projects/.matrix-terminal-pastes/2026-07-07/upload.png",
       terminalPath: "/home/matrix/home/projects/.matrix-terminal-pastes/2026-07-07/upload.png",
@@ -174,12 +184,16 @@ describe("TerminalPane session replay privacy", () => {
         expect.objectContaining({
           method: "POST",
           headers: expect.objectContaining({
+            Authorization: "Bearer ws-token",
             "Content-Type": "image/png",
             "X-Matrix-Filename": "screen shot.png",
           }),
+          credentials: "same-origin",
+          signal: expect.any(AbortSignal),
         }),
       );
     });
+    expect(wsAuth.getWebSocketAuthToken).toHaveBeenCalled();
     await waitFor(() => {
       expect(stubWs.send).toHaveBeenCalledWith(JSON.stringify({
         type: "input",
@@ -221,6 +235,69 @@ describe("TerminalPane session replay privacy", () => {
     expect(dispatchResult).toBe(true);
     expect(event.defaultPrevented).toBe(false);
     expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("splits uploaded terminal paths into bounded bracketed paste frames", async () => {
+    const longA = `/home/matrix/home/projects/.matrix-terminal-pastes/2026-07-07/${"a".repeat(40_000)}.png`;
+    const longB = `/home/matrix/home/projects/.matrix-terminal-pastes/2026-07-07/${"b".repeat(40_000)}.png`;
+    vi.stubGlobal("fetch", vi.fn()
+      .mockResolvedValueOnce(new Response(JSON.stringify({
+        path: "projects/.matrix-terminal-pastes/2026-07-07/a.png",
+        terminalPath: longA,
+        size: 12,
+        mimeType: "image/png",
+      })))
+      .mockResolvedValueOnce(new Response(JSON.stringify({
+        path: "projects/.matrix-terminal-pastes/2026-07-07/b.png",
+        terminalPath: longB,
+        size: 12,
+        mimeType: "image/png",
+      }))));
+    const files = [
+      new File([Uint8Array.from([0x89, 0x50, 0x4e, 0x47])], "a.png", { type: "image/png" }),
+      new File([Uint8Array.from([0x89, 0x50, 0x4e, 0x47])], "b.png", { type: "image/png" }),
+    ];
+    const { container } = render(
+      <TerminalPane
+        paneId="pane-image-chunked-paste"
+        cwd="projects"
+        theme={theme}
+        isFocused={false}
+        sessionId="main"
+        isClosing={false}
+        shouldCacheOnUnmount={() => true}
+        shouldDestroyOnUnmount={() => false}
+        onFocus={() => {}}
+      />,
+    );
+    await Promise.resolve();
+    const root = container.firstElementChild as HTMLElement;
+    const event = new Event("paste", { bubbles: true, cancelable: true });
+    Object.defineProperty(event, "clipboardData", {
+      value: {
+        items: files.map((file) => ({ kind: "file", type: file.type, getAsFile: () => file })),
+        files,
+        types: ["Files"],
+        getData: vi.fn(() => ""),
+      },
+    });
+
+    root.dispatchEvent(event);
+
+    await waitFor(() => {
+      const inputFrames = stubWs.send.mock.calls
+        .map(([frame]) => JSON.parse(String(frame)) as { type?: string })
+        .filter((frame) => frame.type === "input");
+      expect(inputFrames.length).toBeGreaterThan(1);
+    });
+    const frames = stubWs.send.mock.calls
+      .map(([frame]) => JSON.parse(String(frame)) as { type?: string; data?: string })
+      .filter((frame): frame is { type: "input"; data: string } => frame.type === "input");
+    expect(frames.every((frame) => frame.data.length <= MAX_TERMINAL_INPUT)).toBe(true);
+    const pasted = frames
+      .map((frame) => frame.data.replace(BRACKETED_PASTE_OPEN, "").replace(BRACKETED_PASTE_CLOSE, ""))
+      .join("");
+    expect(pasted).toBe(`${longA} ${longB}`);
   });
 
   it("captures dropped image files and does not close or reconnect the terminal socket on upload failure", async () => {

--- a/tests/shell/terminal-pane-privacy.test.tsx
+++ b/tests/shell/terminal-pane-privacy.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import React from "react";
-import { render } from "@testing-library/react";
+import { render, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const stubTerminal = vi.hoisted(() => ({
@@ -27,6 +27,8 @@ const stubWs = vi.hoisted(() => ({
   onclose: null as (() => void) | null,
   onerror: null as (() => void) | null,
 }));
+const BRACKETED_PASTE_OPEN = "\u001b[200~";
+const BRACKETED_PASTE_CLOSE = "\u001b[201~";
 
 vi.mock("../../shell/src/components/terminal/terminal-cache.js", () => ({
   cacheTerminal: vi.fn(),
@@ -91,6 +93,15 @@ class ResizeObserverMock {
 describe("TerminalPane session replay privacy", () => {
   beforeEach(() => {
     stubTerminal.element = document.createElement("div");
+    stubWs.readyState = 1;
+    stubWs.send.mockClear();
+    stubWs.close.mockClear();
+    vi.stubGlobal("fetch", vi.fn(async () => new Response(JSON.stringify({
+      path: "projects/.matrix-terminal-pastes/2026-07-07/upload.png",
+      terminalPath: "/home/matrix/home/projects/.matrix-terminal-pastes/2026-07-07/upload.png",
+      size: 12,
+      mimeType: "image/png",
+    }))));
     globalThis.ResizeObserver = ResizeObserverMock as unknown as typeof ResizeObserver;
     if (typeof globalThis.requestAnimationFrame !== "function") {
       globalThis.requestAnimationFrame = ((cb: FrameRequestCallback) =>
@@ -116,5 +127,140 @@ describe("TerminalPane session replay privacy", () => {
     const root = container.firstElementChild;
     expect(root).not.toBeNull();
     expect(root?.classList.contains("ph-no-capture")).toBe(true);
+  });
+
+  it("captures pasted image files before the browser can navigate and pastes the uploaded terminal path", async () => {
+    const host = document.createElement("div");
+    document.body.appendChild(host);
+    const bubbleSpy = vi.fn();
+    host.addEventListener("paste", bubbleSpy);
+    const file = new File([Uint8Array.from([0x89, 0x50, 0x4e, 0x47])], "screen shot.png", {
+      type: "image/png",
+    });
+    const { container, unmount } = render(
+      <TerminalPane
+        paneId="pane-image-paste"
+        cwd="projects"
+        theme={theme}
+        isFocused={false}
+        sessionId="main"
+        isClosing={false}
+        shouldCacheOnUnmount={() => true}
+        shouldDestroyOnUnmount={() => false}
+        onFocus={() => {}}
+      />,
+      { container: host },
+    );
+    await Promise.resolve();
+    const root = container.firstElementChild as HTMLElement;
+    const event = new Event("paste", { bubbles: true, cancelable: true });
+    Object.defineProperty(event, "clipboardData", {
+      value: {
+        items: [{ kind: "file", type: "image/png", getAsFile: () => file }],
+        files: [file],
+        types: ["Files"],
+        getData: vi.fn(() => ""),
+      },
+    });
+
+    const dispatchResult = root.dispatchEvent(event);
+
+    expect(dispatchResult).toBe(false);
+    expect(event.defaultPrevented).toBe(true);
+    expect(bubbleSpy).not.toHaveBeenCalled();
+    await waitFor(() => {
+      expect(fetch).toHaveBeenCalledWith(
+        expect.stringContaining("/api/terminal/sessions/main/paste-assets"),
+        expect.objectContaining({
+          method: "POST",
+          headers: expect.objectContaining({
+            "Content-Type": "image/png",
+            "X-Matrix-Filename": "screen shot.png",
+          }),
+        }),
+      );
+    });
+    await waitFor(() => {
+      expect(stubWs.send).toHaveBeenCalledWith(JSON.stringify({
+        type: "input",
+        data: `${BRACKETED_PASTE_OPEN}/home/matrix/home/projects/.matrix-terminal-pastes/2026-07-07/upload.png${BRACKETED_PASTE_CLOSE}`,
+      }));
+    });
+    unmount();
+    host.remove();
+  });
+
+  it("lets text-only paste continue through xterm without uploading", async () => {
+    const { container } = render(
+      <TerminalPane
+        paneId="pane-text-paste"
+        cwd="projects"
+        theme={theme}
+        isFocused={false}
+        sessionId="main"
+        isClosing={false}
+        shouldCacheOnUnmount={() => true}
+        shouldDestroyOnUnmount={() => false}
+        onFocus={() => {}}
+      />,
+    );
+    await Promise.resolve();
+    const root = container.firstElementChild as HTMLElement;
+    const event = new Event("paste", { bubbles: true, cancelable: true });
+    Object.defineProperty(event, "clipboardData", {
+      value: {
+        items: [],
+        files: [],
+        types: ["text/plain"],
+        getData: vi.fn(() => "hello"),
+      },
+    });
+
+    const dispatchResult = root.dispatchEvent(event);
+
+    expect(dispatchResult).toBe(true);
+    expect(event.defaultPrevented).toBe(false);
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("captures dropped image files and does not close or reconnect the terminal socket on upload failure", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () => new Response(
+      JSON.stringify({ error: { code: "upload_failed", message: "Request failed" } }),
+      { status: 500 },
+    )));
+    const file = new File([Uint8Array.from([0xff, 0xd8, 0xff])], "photo.jpg", {
+      type: "image/jpeg",
+    });
+    const { container } = render(
+      <TerminalPane
+        paneId="pane-image-drop"
+        cwd="projects"
+        theme={theme}
+        isFocused={false}
+        sessionId="main"
+        isClosing={false}
+        shouldCacheOnUnmount={() => true}
+        shouldDestroyOnUnmount={() => false}
+        onFocus={() => {}}
+      />,
+    );
+    await Promise.resolve();
+    const root = container.firstElementChild as HTMLElement;
+    const event = new Event("drop", { bubbles: true, cancelable: true });
+    Object.defineProperty(event, "dataTransfer", {
+      value: {
+        items: [{ kind: "file", type: "image/jpeg", getAsFile: () => file }],
+        files: [file],
+        types: ["Files"],
+      },
+    });
+
+    const dispatchResult = root.dispatchEvent(event);
+
+    expect(dispatchResult).toBe(false);
+    expect(event.defaultPrevented).toBe(true);
+    await waitFor(() => expect(fetch).toHaveBeenCalledTimes(1));
+    expect(stubWs.close).not.toHaveBeenCalled();
+    expect(stubWs.send).not.toHaveBeenCalledWith(expect.stringContaining("photo.jpg"));
   });
 });


### PR DESCRIPTION
## Summary

- add terminal paste asset upload support under project-local `.matrix-terminal-pastes/YYYY-MM-DD/`, with image magic-byte validation, filename/cwd validation, 10 MiB body limits, and atomic temp-file writes
- add one-shot terminal input over `POST /api/terminal/sessions/:session/input` and route CLI send-input through HTTP instead of a second WebSocket attach/detach
- intercept browser terminal image paste/drop in native capture phase so Chrome does not open screenshots, then upload and bracket-paste the returned VPS path
- add CLI rich paste handling for quoted local image paths, input chunking below the gateway cap, terminal image/control sequence dropping, and `--no-rich-paste` opt-outs for `shell attach`, `shell new --attach`, and `matrix run -it`
- bump `@finnaai/matrix` to `0.3.9` and update CLI release docs for the existing `cli-v0.3.9` workflow/tag path after merge

## Tests

- `NODE_NO_WARNINGS=1 /Users/nimanaderi/matrix-os/node_modules/.bin/vitest run tests/gateway/shell-routes.test.ts tests/gateway/shell-zellij.test.ts tests/shell/terminal-pane-privacy.test.tsx tests/shell/terminal-rich-paste.test.ts tests/cli/shell-client.test.ts tests/cli/shell.test.ts tests/cli/run.test.ts`
  - passed with localhost bind permission: 7 files, 146 tests
- `NODE_NO_WARNINGS=1 /Users/nimanaderi/matrix-os/node_modules/.bin/vitest --config vitest.config.ts run tests/unit/shell-client.test.ts` from `packages/sync-client`
  - passed: 7 tests
- `/Users/nimanaderi/matrix-os/node_modules/.bin/tsc --noEmit -p packages/gateway/tsconfig.json`
- `/Users/nimanaderi/matrix-os/node_modules/.bin/tsc --noEmit -p packages/sync-client/tsconfig.json`
- `bun run check:patterns` (0 violations; existing repo warnings only)
- `git diff --check`

`bun run typecheck` was not rerun locally after the main merge because the isolated worktree dependency layout causes pnpm to manage `node_modules` before TypeScript diagnostics. Direct TypeScript checks for the changed gateway and sync-client packages pass, and CI Type Check passed on the final `ready-for-ci` run.

## Review / Monitoring

- Initial Greptile review on `3b2bcea0` was 4/5 and flagged four issues: transient zellij attach success, missing browser upload auth token, unbounded browser paste frames, and missing browser upload abort signal.
- Follow-up commit `50b06327` addressed those findings; Greptile returned 5/5 on that commit.
- After `ready-for-ci`, CI failed `Sync Client Package` because `origin/main` had introduced an overlapping WebSocket-based one-shot `sendInput` on the PR merge commit. I removed `ready-for-ci`, merged latest `origin/main`, and fixed the overlap in `b534a0a3` so the branch keeps the HTTP non-subscriber input path.
- Greptile review on `b534a0a3` was 4/5 because the browser upload timeout helper returned no signal when `AbortSignal.timeout` was unavailable.
- Commit `b167c4a4` adds an explicit `AbortController` timer fallback and cleanup for browser paste uploads.
- Greptile returned 5/5 on `b167c4a4`, with no blocking findings.
- `ready-for-ci` is applied and label-gated CI passed: Type Check, Sync Client Package, Shell Production Build, Unit Tests (1/4 through 4/4), E2E Tests, Docker Test Image, Docker Smoke Test, Pattern Scan, React Doctor, Docs Contract Tests, Gate, and PR Title. Preview VPS/Platform deploy jobs were skipped by their workflow conditions.

## Invariants

### Source of truth
- Named terminal session existence remains the shell registry/zellij runtime.
- Pasted image assets are durable user-owned project files under `${MATRIX_HOME}/<cwd>/.matrix-terminal-pastes/YYYY-MM-DD/`; no DB metadata is introduced.
- The installable CLI version source of truth is `packages/sync-client/package.json`; the release is still cut by the existing `CLI Release` workflow and `cli-v0.3.9` tag path after merge.

### Lock/transaction scope
- No DB transactions are added.
- Paste upload critical section is filesystem-only: validate route/query/header/body, sniff supported image bytes, create the destination directory, write an exclusive temp file with `wx`, then rename into place.
- One-shot input validates the session before writing to zellij and does not register a WebSocket/replay subscriber or emit a WebSocket `detach`.

### Acceptable orphan states
- If temp-file rename fails, the temp file cleanup is attempted and cleanup failures are logged.
- If upload succeeds but a later input/paste send fails, the uploaded file remains as a normal project artifact.
- Paste asset TTL/GC is deferred; assets are intentionally durable project-local files for this PR.

### Auth source of truth
- HTTP paste/input routes rely on the existing terminal API auth mounting and reuse the same safe session-name validation as terminal attach.
- CLI requests use the existing bearer-token ShellClient request path; browser upload requests use the same WebSocket auth token path as browser terminal connections.

### Deferred scope
- Canvas image nodes are unchanged.
- Browser clipboard path strings without file bytes are not readable by the web app and remain out of scope.
- Automatic cleanup/retention policies for `.matrix-terminal-pastes` are deferred.
