### PR TITLE
feat(coding-agents): add notification preferences

### DIFF
--- a/docs/dev/coding-agent-shells.md
+++ b/docs/dev/coding-agent-shells.md
@@ -23,6 +23,8 @@ The coding-agent route module is `packages/gateway/src/coding-agents/routes.ts`,
 - `POST /threads/:threadId/inputs/:inputRequestId/answer` records a bounded user-input answer.
 - `GET /reviews` and `GET /reviews/:reviewId` expose bounded review summaries and snapshots.
 - `GET /files/read` exposes bounded owner-worktree text snapshots.
+- `GET /notification-preferences` returns coding-agent notification preferences for the authenticated owner.
+- `PUT /notification-preferences` updates coding-agent notification preferences for the authenticated owner with a small body limit and atomic per-owner file persistence.
 
 Every mutating route needs auth, `bodyLimit`, Zod validation, an ownership check, safe error mapping, and focused tests.
 
@@ -84,6 +86,10 @@ Approval and input requests are gateway-owned lifecycle events.
 - Other shells update from the returned snapshot or stream event.
 
 Client UI must disable duplicate submission while a decision is in flight and recover by rehydrating the thread snapshot on failure. User-facing errors should be generic and recovery-oriented.
+
+## Attention Notifications
+
+Coding-agent attention notifications are gateway-owned. Thread events for approval requests, user-input requests, and failed runs may emit safe push-channel payloads with generic copy plus a bounded thread id. The bridge deduplicates owner/thread/kind notifications in a capped TTL registry and checks owner notification preferences before sending. Missing preferences default to enabled; corrupt or unavailable preferences must fail closed for push delivery and log details server-side only.
 
 ## Client State Rules
 

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -138,6 +138,25 @@ export const RuntimeLimitsSchema = z.object({
   maxListItems: z.number().int().min(1).max(200),
 }).strict();
 
+export const CodingAgentAttentionNotificationKindSchema = z.enum(["approval", "input", "failed"]);
+
+export const CodingAgentNotificationPreferencesSchema = z.object({
+  attentionPush: z.object({
+    approval: z.boolean(),
+    input: z.boolean(),
+    failed: z.boolean(),
+  }).strict(),
+}).strict();
+
+export const CodingAgentNotificationPreferencesUpdateSchema = CodingAgentNotificationPreferencesSchema;
+
+export type CodingAgentAttentionNotificationKind =
+  z.infer<typeof CodingAgentAttentionNotificationKindSchema>;
+export type CodingAgentNotificationPreferences =
+  z.infer<typeof CodingAgentNotificationPreferencesSchema>;
+export type CodingAgentNotificationPreferencesUpdate =
+  z.infer<typeof CodingAgentNotificationPreferencesUpdateSchema>;
+
 export const ProviderKindSchema = z.enum(["claude", "codex", "opencode", "cursor", "custom"]);
 export const ProviderAvailabilitySchema = z.enum([
   "available",

--- a/packages/gateway/src/coding-agents/attention-notifications.ts
+++ b/packages/gateway/src/coding-agents/attention-notifications.ts
@@ -1,4 +1,9 @@
-import { ThreadIdSchema, type AgentThreadEvent } from "@matrix-os/contracts";
+import {
+  CodingAgentAttentionNotificationKindSchema,
+  ThreadIdSchema,
+  type AgentThreadEvent,
+  type CodingAgentAttentionNotificationKind,
+} from "@matrix-os/contracts";
 import type { ChannelReply } from "../channels/types.js";
 import type { CodingAgentThreadStore } from "./thread-store.js";
 
@@ -6,31 +11,40 @@ const PUSH_CHAT_ID = "coding-agents";
 const DEFAULT_DEDUPE_WINDOW_MS = 2 * 60 * 1000;
 const DEFAULT_MAX_DEDUPE_ENTRIES = 512;
 
-type AttentionNotificationKind = "approval" | "input" | "failed";
-
 export interface CodingAgentAttentionNotificationSender {
   send(reply: ChannelReply): Promise<void>;
+}
+
+export interface CodingAgentAttentionNotificationPreferences {
+  isAttentionPushEnabled(input: {
+    ownerId: string;
+    threadId: string;
+    kind: CodingAgentAttentionNotificationKind;
+  }): boolean | Promise<boolean>;
 }
 
 export interface CodingAgentAttentionNotificationsOptions {
   threads: CodingAgentThreadStore;
   send: (reply: ChannelReply) => Promise<void>;
+  preferences?: CodingAgentAttentionNotificationPreferences;
   now?: () => number;
   dedupeWindowMs?: number;
   maxDedupeEntries?: number;
 }
 
-function notificationKindFor(events: AgentThreadEvent[]): AttentionNotificationKind | null {
+function notificationKindFor(events: AgentThreadEvent[]): CodingAgentAttentionNotificationKind | null {
   for (const event of events) {
-    if (event.type === "approval.requested") return "approval";
-    if (event.type === "user_input.requested") return "input";
-    if (event.type === "thread.error") return "failed";
-    if (event.type === "thread.completed" && event.outcome === "failed") return "failed";
+    if (event.type === "approval.requested") return CodingAgentAttentionNotificationKindSchema.parse("approval");
+    if (event.type === "user_input.requested") return CodingAgentAttentionNotificationKindSchema.parse("input");
+    if (event.type === "thread.error") return CodingAgentAttentionNotificationKindSchema.parse("failed");
+    if (event.type === "thread.completed" && event.outcome === "failed") {
+      return CodingAgentAttentionNotificationKindSchema.parse("failed");
+    }
   }
   return null;
 }
 
-function bodyFor(kind: AttentionNotificationKind): string {
+function bodyFor(kind: CodingAgentAttentionNotificationKind): string {
   if (kind === "approval") return "Agent needs approval.";
   if (kind === "input") return "Agent needs input.";
   return "Agent run needs attention.";
@@ -93,12 +107,29 @@ export function registerCodingAgentAttentionNotifications(options: CodingAgentAt
     if (!kind) return;
     const notification = buildCodingAgentAttentionNotification({ ownerId, threadId, events });
     if (!notification) return;
-    const currentTime = now();
-    if (!remember(`${ownerId}:${threadId}:${kind}`, currentTime)) return;
+    const safeNotification = notification;
+    const dedupeKey = `${ownerId}:${threadId}:${kind}`;
 
-    void options.send(notification).catch((err: unknown) => {
-      console.warn("[coding-agents] attention notification failed:", err instanceof Error ? err.message : String(err));
-    });
+    function sendIfEligible(): void {
+      if (!remember(dedupeKey, now())) return;
+      void options.send(safeNotification).catch((err: unknown) => {
+        console.warn("[coding-agents] attention notification failed:", err instanceof Error ? err.message : String(err));
+      });
+    }
+
+    if (options.preferences) {
+      void Promise.resolve(options.preferences.isAttentionPushEnabled({ ownerId, threadId, kind }))
+        .then((enabled) => {
+          if (!enabled) return;
+          sendIfEligible();
+        })
+        .catch((err: unknown) => {
+          console.warn("[coding-agents] attention notification preference check failed:", err instanceof Error ? err.message : String(err));
+        });
+      return;
+    }
+
+    sendIfEligible();
   });
   return {
     dispose() {

--- a/packages/gateway/src/coding-agents/notification-preferences.ts
+++ b/packages/gateway/src/coding-agents/notification-preferences.ts
@@ -1,0 +1,83 @@
+import { createHash } from "node:crypto";
+import { join } from "node:path";
+import {
+  CodingAgentNotificationPreferencesSchema,
+  CodingAgentNotificationPreferencesUpdateSchema,
+  type CodingAgentAttentionNotificationKind,
+  type CodingAgentNotificationPreferences,
+  type CodingAgentNotificationPreferencesUpdate,
+} from "@matrix-os/contracts";
+import type { RequestPrincipal } from "../request-principal.js";
+import { atomicWriteJson, readJsonFile } from "../state-ops.js";
+
+const NOTIFICATION_PREFERENCES_RELATIVE_PATH = ["system", "coding-agents", "notification-preferences"] as const;
+const SAFE_OWNER_FILE_NAME = /^[A-Za-z0-9_-]{1,128}$/;
+
+export const DEFAULT_CODING_AGENT_NOTIFICATION_PREFERENCES: CodingAgentNotificationPreferences =
+  CodingAgentNotificationPreferencesSchema.parse({
+    attentionPush: {
+      approval: true,
+      input: true,
+      failed: true,
+    },
+  });
+
+export interface CodingAgentNotificationPreferenceStore {
+  load(principal: RequestPrincipal): Promise<CodingAgentNotificationPreferences>;
+  save(
+    principal: RequestPrincipal,
+    preferences: CodingAgentNotificationPreferencesUpdate,
+  ): Promise<CodingAgentNotificationPreferences>;
+  isAttentionPushEnabled(input: {
+    ownerId: string;
+    threadId?: string;
+    kind: CodingAgentAttentionNotificationKind;
+  }): Promise<boolean>;
+}
+
+export interface CodingAgentNotificationPreferenceStoreOptions {
+  homePath: string;
+}
+
+function ownerFileName(ownerId: string): string {
+  if (SAFE_OWNER_FILE_NAME.test(ownerId)) return `${ownerId}.json`;
+  return `owner_${createHash("sha256").update(ownerId).digest("hex")}.json`;
+}
+
+function preferencesPath(homePath: string, ownerId: string): string {
+  return join(homePath, ...NOTIFICATION_PREFERENCES_RELATIVE_PATH, ownerFileName(ownerId));
+}
+
+function isNotFound(err: unknown): boolean {
+  return err instanceof Error
+    && "code" in err
+    && (err as NodeJS.ErrnoException).code === "ENOENT";
+}
+
+export function createCodingAgentNotificationPreferenceStore(
+  options: CodingAgentNotificationPreferenceStoreOptions,
+): CodingAgentNotificationPreferenceStore {
+  async function load(principal: RequestPrincipal): Promise<CodingAgentNotificationPreferences> {
+    const path = preferencesPath(options.homePath, principal.userId);
+    try {
+      return CodingAgentNotificationPreferencesSchema.parse(await readJsonFile(path));
+    } catch (err: unknown) {
+      if (isNotFound(err)) return DEFAULT_CODING_AGENT_NOTIFICATION_PREFERENCES;
+      throw err;
+    }
+  }
+
+  return {
+    load,
+    async save(principal, preferences) {
+      const path = preferencesPath(options.homePath, principal.userId);
+      const parsed = CodingAgentNotificationPreferencesUpdateSchema.parse(preferences);
+      await atomicWriteJson(path, parsed);
+      return parsed;
+    },
+    async isAttentionPushEnabled({ ownerId, kind }) {
+      const preferences = await load({ userId: ownerId, source: "jwt" });
+      return preferences.attentionPush[kind];
+    },
+  };
+}

--- a/packages/gateway/src/coding-agents/routes.ts
+++ b/packages/gateway/src/coding-agents/routes.ts
@@ -29,6 +29,8 @@ import {
   SourceControlCreatePullRequestResponseSchema,
   SourceControlPrepareCommitRequestSchema,
   SourceControlPrepareCommitResponseSchema,
+  CodingAgentNotificationPreferencesSchema,
+  CodingAgentNotificationPreferencesUpdateSchema,
 } from "@matrix-os/contracts";
 import {
   isRequestPrincipalError,
@@ -55,6 +57,7 @@ import {
   CodingAgentSourceControlError,
   type CodingAgentSourceControlStore,
 } from "./source-control.js";
+import type { CodingAgentNotificationPreferenceStore } from "./notification-preferences.js";
 
 export interface CodingAgentRouteDeps {
   service: CodingAgentRuntimeSummaryService;
@@ -62,6 +65,7 @@ export interface CodingAgentRouteDeps {
   reviews?: CodingAgentReviewSummaryStore;
   files?: CodingAgentFileStore;
   sourceControl?: CodingAgentSourceControlStore;
+  notificationPreferences?: CodingAgentNotificationPreferenceStore;
   getPrincipal?: (c: Context) => RequestPrincipal;
 }
 
@@ -71,6 +75,7 @@ const THREAD_APPROVAL_BODY_LIMIT = 8 * 1024;
 const THREAD_INPUT_BODY_LIMIT = 40 * 1024;
 const FILE_WRITE_BODY_LIMIT = 512 * 1024;
 const SOURCE_CONTROL_BODY_LIMIT = 256 * 1024;
+const NOTIFICATION_PREFERENCES_BODY_LIMIT = 4 * 1024;
 
 const AbortThreadBodySchema = z.object({
   clientRequestId: RequestIdSchema,
@@ -142,6 +147,15 @@ function sourceControlNoChanges() {
     code: "source_control_no_changes",
     safeMessage: "No source changes are ready to commit.",
     retryable: false,
+  });
+}
+
+function notificationPreferencesUnavailable() {
+  return SafeClientErrorSchema.parse({
+    code: "notification_preferences_unavailable",
+    safeMessage: "Notification preferences are temporarily unavailable. Try again.",
+    retryable: true,
+    recoveryActions: ["retry"],
   });
 }
 
@@ -219,6 +233,10 @@ export function createCodingAgentRoutes(deps: CodingAgentRouteDeps): Hono {
   });
   const sourceControlBodyLimit = bodyLimit({
     maxSize: SOURCE_CONTROL_BODY_LIMIT,
+    onError: (c) => c.json({ error: bodyTooLarge() }, 413),
+  });
+  const notificationPreferencesBodyLimit = bodyLimit({
+    maxSize: NOTIFICATION_PREFERENCES_BODY_LIMIT,
     onError: (c) => c.json({ error: bodyTooLarge() }, 413),
   });
 
@@ -537,6 +555,49 @@ export function createCodingAgentRoutes(deps: CodingAgentRouteDeps): Hono {
         }
         console.warn("[coding-agents] source-control pull request route failed:", err instanceof Error ? err.message : String(err));
         return c.json({ error: sourceControlUnavailable() }, 503);
+      }
+    });
+  }
+
+  if (deps.notificationPreferences) {
+    app.get("/notification-preferences", async (c) => {
+      try {
+        const principal = principalFor(c);
+        const preferences = CodingAgentNotificationPreferencesSchema.parse(
+          await deps.notificationPreferences!.load(principal),
+        );
+        return c.json({ preferences });
+      } catch (err: unknown) {
+        if (isRequestPrincipalError(err)) {
+          const mapped = mapRequestPrincipalError(err);
+          return c.json(mapped.body, mapped.status as ContentfulStatusCode);
+        }
+        console.warn("[coding-agents] notification preferences route failed:", err instanceof Error ? err.message : String(err));
+        return c.json({ error: notificationPreferencesUnavailable() }, 503);
+      }
+    });
+
+    app.put("/notification-preferences", notificationPreferencesBodyLimit, async (c) => {
+      try {
+        const principal = principalFor(c);
+        const request = CodingAgentNotificationPreferencesUpdateSchema.parse(await c.req.json());
+        const preferences = CodingAgentNotificationPreferencesSchema.parse(
+          await deps.notificationPreferences!.save(principal, request),
+        );
+        return c.json({ preferences });
+      } catch (err: unknown) {
+        if (isBodyLimitError(err)) {
+          return c.json({ error: bodyTooLarge() }, 413);
+        }
+        if (isRequestPrincipalError(err)) {
+          const mapped = mapRequestPrincipalError(err);
+          return c.json(mapped.body, mapped.status as ContentfulStatusCode);
+        }
+        if (err instanceof z.ZodError || err instanceof SyntaxError) {
+          return c.json({ error: validationFailed() }, 400);
+        }
+        console.warn("[coding-agents] notification preferences update failed:", err instanceof Error ? err.message : String(err));
+        return c.json({ error: notificationPreferencesUnavailable() }, 503);
       }
     });
   }

--- a/packages/gateway/src/server.ts
+++ b/packages/gateway/src/server.ts
@@ -108,6 +108,7 @@ import { createCodingAgentPreviewSummaryStore } from "./coding-agents/preview-su
 import { createCodingAgentFileStore } from "./coding-agents/file-read.js";
 import { createCodingAgentSourceControlStore } from "./coding-agents/source-control.js";
 import { registerCodingAgentAttentionNotifications } from "./coding-agents/attention-notifications.js";
+import { createCodingAgentNotificationPreferenceStore } from "./coding-agents/notification-preferences.js";
 import { createAgentActionAuditService } from "./onboarding/agent-action-audit.js";
 import { capabilityIdsForConnectedServices, createIntegrationCapabilityService } from "./onboarding/integration-capabilities.js";
 import { createIntegrationCapabilityRoutes } from "./onboarding/integration-capability-routes.js";
@@ -512,6 +513,7 @@ export async function createGateway(config: GatewayConfig) {
     ownerId: process.env.MATRIX_USER_ID,
     principalOwnerIds: codingAgentOwnerIds,
   });
+  const codingAgentNotificationPreferenceStore = createCodingAgentNotificationPreferenceStore({ homePath });
   const workspaceEventPublisher = createWorkspaceEventPublisher({
     eventStore: workspaceEventStore,
     onSessionStopped: (session) => codingAgentSessionStopReconciler.handleSessionStopped(session),
@@ -1453,6 +1455,7 @@ export async function createGateway(config: GatewayConfig) {
     ? registerCodingAgentAttentionNotifications({
       threads: codingAgentThreadStore,
       send: (reply) => channelManager.send(reply),
+      preferences: codingAgentNotificationPreferenceStore,
     })
     : undefined;
 
@@ -1606,6 +1609,7 @@ export async function createGateway(config: GatewayConfig) {
     reviews: codingAgentReviewSummaryStore,
     files: codingAgentFileStore,
     sourceControl: codingAgentSourceControlStore,
+    notificationPreferences: codingAgentNotificationPreferenceStore,
   }));
   app.route("/api/integrations", createIntegrationCapabilityRoutes({
     service: integrationCapabilityService,

--- a/specs/105-coding-agent-shells/current-state.md
+++ b/specs/105-coding-agent-shells/current-state.md
@@ -1,6 +1,6 @@
 # Current State: Coding Agent Shells
 
-**Branch stack**: `spec/coding-agent-shells` plus stacked implementation branches through `105-coding-agent-notification-dedupe`
+**Branch stack**: `spec/coding-agent-shells` plus stacked implementation branches through `105-coding-agent-notification-prefs`
 **Updated**: 2026-07-07
 **Scope**: Inventory for the coding-agent desktop/mobile shell work. This file records the current Matrix-native route, contract, client, and regression-test state so later slices keep gateway/runtime as source of truth and keep desktop/mobile as thin shells.
 
@@ -26,6 +26,7 @@ Implemented coding-agent schemas:
 
 - IDs and bounds: `RuntimeIdSchema`, `ProviderIdSchema`, `ProjectIdSchema`, `TaskIdSchema`, `ThreadIdSchema`, `EventIdSchema`, `ApprovalIdSchema`, `RequestIdSchema`, `CorrelationIdSchema`, `TerminalSessionIdSchema`, `WorktreeIdSchema`, `CursorSchema`, `IsoTimestampSchema`, `SafeDisplayStringSchema`, `SafeClientErrorSchema`.
 - Runtime summary: `RuntimeTargetSchema`, `RuntimeCapabilitySchema`, `RuntimeLimitsSchema`, `RuntimeSummarySchema` with bounded `activeThreads`, separate bounded `attentionThreads`, and bounded `previewSessions`.
+- Notifications: `CodingAgentAttentionNotificationKindSchema`, `CodingAgentNotificationPreferencesSchema`, and `CodingAgentNotificationPreferencesUpdateSchema` for owner-scoped attention push preferences.
 - Providers: `AgentProviderSummarySchema`, provider availability/install/auth enums, `AgentModeSchema`, `ApprovalPolicySchema`, `SandboxModeSchema`, `SafeSetupActionSchema`.
 - Threads: `CreateAgentThreadRequestSchema`, `AgentThreadSummarySchema`, `AgentThreadStatusSchema`, `AgentAttachmentSchema`, `AgentThreadSnapshotSchema`.
 - Events: `AgentThreadEventSchema` discriminated union with lifecycle, text delta, tool activity, approval/input, file change, review ready, terminal bound, safe error, and completion event variants.
@@ -62,6 +63,8 @@ Implemented routes:
 | `/api/coding-agents/files/write` | `POST` | Implemented | Authenticated owner-worktree UTF-8 write. Validates `FileWriteRequestSchema`, applies a 512 KiB JSON body limit for escaped 64 KiB content, rejects traversal/symlinks, caps content at 64 KiB, preserves existing file mode on replace, rejects updates from truncated snapshots, requires matching `baseEtag` for updates or `baseEtag: null` for creates, and returns `FileWriteResponseSchema` or safe conflict errors. |
 | `/api/coding-agents/source-control/prepare-commit` | `POST` | Implemented | Authenticated owner-worktree local commit preparation. Validates `SourceControlPrepareCommitRequestSchema`, uses a body limit and bounded git operations, preserves previous staged state on rollback, and returns only `SourceControlPrepareCommitResponseSchema` metadata. |
 | `/api/coding-agents/source-control/pull-requests` | `POST` | Implemented | Authenticated owner-worktree pull request creation. Validates `SourceControlCreatePullRequestRequestSchema`, detects the current branch and GitHub origin server-side, returns an existing PR for the same head branch when present, otherwise pushes the branch and creates a PR through gateway-owned credentials. Returns only `SourceControlCreatePullRequestResponseSchema` metadata. |
+| `/api/coding-agents/notification-preferences` | `GET` | Implemented | Authenticated per-owner preference read. Returns `CodingAgentNotificationPreferencesSchema` defaults when no preference file exists for the authenticated owner. |
+| `/api/coding-agents/notification-preferences` | `PUT` | Implemented | Authenticated per-owner preference update. Uses a 4 KiB body limit, validates `CodingAgentNotificationPreferencesUpdateSchema`, atomically writes the authenticated owner's preference file, and returns only validated preference booleans. |
 
 Security and ownership:
 
@@ -150,7 +153,7 @@ Thread store behavior:
 - Idempotent thread creation, aborts, approval decisions, and input answers by bounded request-id arrays.
 - Event replay with bounded per-thread event storage; default thread snapshots return the latest bounded event window, while explicit cursors continue forward from the cursor.
 - Safe terminal statuses and attention states derived from events.
-- Thread-event sinks can bridge approval, input, and failed attention events to the existing push channel with owner scope, generic copy, and bounded `threadId` metadata only.
+- Thread-event sinks can bridge approval, input, and failed attention events to the existing push channel with owner scope, generic copy, bounded `threadId` metadata only, capped TTL dedupe, and owner notification preferences.
 
 Review summary behavior:
 
@@ -165,6 +168,7 @@ Focused tests:
 
 - `tests/gateway/coding-agents-threads.test.ts`
 - `tests/gateway/coding-agents-attention-notifications.test.ts`
+- `tests/gateway/coding-agents-notification-preferences.test.ts`
 - `tests/gateway/push-adapter.test.ts`
 - `tests/gateway/coding-agents-workspace-provider.test.ts`
 - `tests/gateway/agent-launcher.test.ts`
@@ -414,5 +418,5 @@ git diff --check
 - File/review/preview/source-control shell surfaces: read-only review summaries now have coding-agent contracts/routes/desktop IPC/mobile clients plus desktop and mobile read-only review panels. A read-only review snapshot route now exposes bounded diff hunk metadata and capped hunk line bodies from safe owner worktrees plus partial findings-derived fallback metadata for shell diff panels. Runtime summaries now include safe preview summary rows from existing workspace preview records, and the desktop/mobile Agents workspaces render those rows read-only. Desktop also has a read-only preview inspector with HTTPS-only external launch through the existing safe IPC path, mobile has an HTTPS-only preview route using the existing app runtime frame, and the browser Workspace preview panel renders validated active-project coding-agent preview origin/status rows with direct launch limited to HTTPS origins. Gateway now has bounded browse/search/read and conflict-safe write routes for owner worktree files, desktop/mobile review details can render one selected bounded file snapshot through trusted clients, desktop/mobile review details can prepare a local source-control commit through trusted clients, the gateway can create or return a GitHub pull request from a validated owner worktree without exposing credentials, and desktop/mobile review details can trigger that PR creation through trusted clients with generic safe error states and safe HTTPS open actions for the returned pull request URL. Remaining work: browser-shell source-control entry if needed.
 - Approval/input shell actions: desktop and mobile approval decisions plus user-input answers now use trusted gateway clients, bounded UI controls, idempotent request ids, and focused tests. Remaining work: cross-shell resolved-state refresh tests and richer mobile action-sheet polish.
 - Browser shell entry point: Canvas-first placement is still undecided.
-- Notifications/attention routing: desktop notification IPC exists and notification clicks focus the coding-agent workspace thread in the Agents tab with a visible current-thread marker. Gateway runtime summaries expose bounded `attentionThreads` separately from `activeThreads`, allowing failed or waiting attention to be surfaced without reclassifying terminal threads as active. Desktop and mobile dashboards now render the `attentionThreads` list directly. Gateway thread-event sinks can emit safe push-channel payloads for approval-required, input-required, and failed attention events through a capped TTL dedupe registry, and mobile push notification taps can route bounded coding-agent `threadId` payloads into the existing thread detail route. Remaining work: user notification preferences and cross-device delivery policy are not yet implemented.
+- Notifications/attention routing: desktop notification IPC exists and notification clicks focus the coding-agent workspace thread in the Agents tab with a visible current-thread marker. Gateway runtime summaries expose bounded `attentionThreads` separately from `activeThreads`, allowing failed or waiting attention to be surfaced without reclassifying terminal threads as active. Desktop and mobile dashboards now render the `attentionThreads` list directly. Gateway thread-event sinks can emit safe push-channel payloads for approval-required, input-required, and failed attention events through a capped TTL dedupe registry, per-owner notification preferences can disable approval/input/failed attention push delivery before channel send, and mobile push notification taps can route bounded coding-agent `threadId` payloads into the existing thread detail route. Remaining work: desktop/mobile preference controls and cross-device delivery policy are not yet implemented.
 - Public docs: public Matrix OS docs and the internal operator runbook are present. Remaining work is keeping them synchronized with later write/source-control, provider setup, and browser entry slices.

--- a/tests/contracts/coding-agents.test.ts
+++ b/tests/contracts/coding-agents.test.ts
@@ -16,6 +16,8 @@ import {
   SourceControlPrepareCommitResponseSchema,
   SourceControlCreatePullRequestRequestSchema,
   SourceControlCreatePullRequestResponseSchema,
+  CodingAgentNotificationPreferencesSchema,
+  CodingAgentNotificationPreferencesUpdateSchema,
   FileWriteRequestSchema,
   FileWriteResponseSchema,
   FileMetadataSchema,
@@ -274,6 +276,41 @@ describe("coding agent contracts", () => {
       createdAt: now,
       updatedAt: now,
     }).status).toBe("running");
+  });
+
+  it("validates coding-agent notification preferences without accepting extra payload data", () => {
+    expect(CodingAgentNotificationPreferencesSchema.parse({
+      attentionPush: {
+        approval: true,
+        input: false,
+        failed: true,
+      },
+    })).toEqual({
+      attentionPush: {
+        approval: true,
+        input: false,
+        failed: true,
+      },
+    });
+
+    expect(CodingAgentNotificationPreferencesUpdateSchema.parse({
+      attentionPush: {
+        approval: false,
+        input: false,
+        failed: false,
+      },
+    }).attentionPush.approval).toBe(false);
+
+    expect(() =>
+      CodingAgentNotificationPreferencesSchema.parse({
+        attentionPush: {
+          approval: true,
+          input: true,
+          failed: true,
+          provider: "raw",
+        },
+      }),
+    ).toThrow();
   });
 
   it("validates decision, input, file, review, preview, and server frame contracts", () => {

--- a/tests/gateway/coding-agents-attention-notifications.test.ts
+++ b/tests/gateway/coding-agents-attention-notifications.test.ts
@@ -286,4 +286,79 @@ describe("coding agent attention notifications", () => {
 
     subscription.dispose();
   });
+
+  it("honors owner notification preferences before sending attention push payloads", async () => {
+    const homePath = await mkdtemp(join(tmpdir(), "matrix-coding-agent-attention-notifications-"));
+    const send = vi.fn<(reply: ChannelReply) => Promise<void>>().mockResolvedValue(undefined);
+    const threads = createCodingAgentThreadStore({
+      homePath,
+      now: () => now,
+      providers: [approvalProvider()],
+    });
+    const subscription = registerCodingAgentAttentionNotifications({
+      threads,
+      send,
+      preferences: {
+        isAttentionPushEnabled: async ({ ownerId, kind }) => ownerId !== principal.userId || kind !== "approval",
+      },
+    });
+
+    await threads.createThread(principal, {
+      providerId: "codex",
+      prompt: "Review the next command.",
+      clientRequestId: "req_attention_preferences",
+    });
+
+    expect(send).not.toHaveBeenCalled();
+
+    subscription.dispose();
+  });
+
+  it("does not consume dedupe state when preferences skip an attention notification", async () => {
+    const homePath = await mkdtemp(join(tmpdir(), "matrix-coding-agent-attention-notifications-"));
+    let enabled = false;
+    const send = vi.fn<(reply: ChannelReply) => Promise<void>>().mockResolvedValue(undefined);
+    const threads = createCodingAgentThreadStore({
+      homePath,
+      now: () => now,
+      providers: [repeatedApprovalProvider()],
+    });
+    const subscription = registerCodingAgentAttentionNotifications({
+      threads,
+      send,
+      now: () => 1_000,
+      dedupeWindowMs: 60_000,
+      preferences: {
+        isAttentionPushEnabled: async () => enabled,
+      },
+    });
+
+    const created = await threads.createThread(principal, {
+      providerId: "codex",
+      prompt: "Review the next command.",
+      clientRequestId: "req_attention_preferences_dedupe",
+    });
+    await Promise.resolve();
+    expect(send).not.toHaveBeenCalled();
+
+    enabled = true;
+    await threads.submitApproval(principal, created.snapshot.thread.id, "appr_safe_action", {
+      decision: "approve",
+      correlationId: "corr_safe_action",
+      clientRequestId: "req_attention_preferences_dedupe_approval",
+    });
+    await Promise.resolve();
+
+    expect(send).toHaveBeenCalledTimes(1);
+    expect(send).toHaveBeenCalledWith(expect.objectContaining({
+      ownerId: principal.userId,
+      text: "Agent needs approval.",
+      metadata: {
+        category: "agent",
+        threadId: created.snapshot.thread.id,
+      },
+    }));
+
+    subscription.dispose();
+  });
 });

--- a/tests/gateway/coding-agents-notification-preferences.test.ts
+++ b/tests/gateway/coding-agents-notification-preferences.test.ts
@@ -1,0 +1,184 @@
+import { mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Hono } from "hono";
+import { describe, expect, it } from "vitest";
+import { createCodingAgentNotificationPreferenceStore } from "../../packages/gateway/src/coding-agents/notification-preferences.js";
+import { createCodingAgentRoutes } from "../../packages/gateway/src/coding-agents/routes.js";
+import type { RequestPrincipal } from "../../packages/gateway/src/request-principal.js";
+
+const principal: RequestPrincipal = { userId: "owner_user", source: "jwt" };
+
+function jsonRequest(path: string, body: unknown): Request {
+  return new Request(`http://localhost${path}`, {
+    method: "PUT",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+function appWithStore(homePath: string) {
+  const app = new Hono();
+  const notificationPreferences = createCodingAgentNotificationPreferenceStore({ homePath });
+  let activePrincipal = principal;
+  app.route("/api/coding-agents", createCodingAgentRoutes({
+    service: { getSummary: async () => {
+      throw new Error("not used");
+    } },
+    getPrincipal: () => activePrincipal,
+    notificationPreferences,
+  }));
+  return {
+    app,
+    notificationPreferences,
+    setPrincipal(nextPrincipal: RequestPrincipal) {
+      activePrincipal = nextPrincipal;
+    },
+  };
+}
+
+describe("coding agent notification preferences", () => {
+  it("serves default owner-scoped notification preferences", async () => {
+    const homePath = await mkdtemp(join(tmpdir(), "matrix-coding-agent-notification-prefs-"));
+    const { app } = appWithStore(homePath);
+
+    const res = await app.request("/api/coding-agents/notification-preferences");
+
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual({
+      preferences: {
+        attentionPush: {
+          approval: true,
+          input: true,
+          failed: true,
+        },
+      },
+    });
+  });
+
+  it("persists validated owner-scoped notification preferences atomically", async () => {
+    const homePath = await mkdtemp(join(tmpdir(), "matrix-coding-agent-notification-prefs-"));
+    const { app } = appWithStore(homePath);
+
+    const res = await app.request(jsonRequest("/api/coding-agents/notification-preferences", {
+      attentionPush: {
+        approval: false,
+        input: true,
+        failed: false,
+      },
+    }));
+
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual({
+      preferences: {
+        attentionPush: {
+          approval: false,
+          input: true,
+          failed: false,
+        },
+      },
+    });
+
+    const stored = await readFile(
+      join(homePath, "system", "coding-agents", "notification-preferences", "owner_user.json"),
+      "utf-8",
+    );
+    expect(JSON.parse(stored)).toEqual({
+      attentionPush: {
+        approval: false,
+        input: true,
+        failed: false,
+      },
+    });
+  });
+
+  it("keeps notification preferences isolated by authenticated owner principal", async () => {
+    const homePath = await mkdtemp(join(tmpdir(), "matrix-coding-agent-notification-prefs-"));
+    const { app, setPrincipal } = appWithStore(homePath);
+
+    const ownerUpdate = await app.request(jsonRequest("/api/coding-agents/notification-preferences", {
+      attentionPush: {
+        approval: false,
+        input: false,
+        failed: false,
+      },
+    }));
+    expect(ownerUpdate.status).toBe(200);
+
+    setPrincipal({ userId: "other_user", source: "jwt" });
+    const otherRead = await app.request("/api/coding-agents/notification-preferences");
+
+    expect(otherRead.status).toBe(200);
+    await expect(otherRead.json()).resolves.toEqual({
+      preferences: {
+        attentionPush: {
+          approval: true,
+          input: true,
+          failed: true,
+        },
+      },
+    });
+  });
+
+  it("rejects malformed or oversized preference updates with safe errors", async () => {
+    const homePath = await mkdtemp(join(tmpdir(), "matrix-coding-agent-notification-prefs-"));
+    const { app } = appWithStore(homePath);
+
+    const malformed = await app.request(jsonRequest("/api/coding-agents/notification-preferences", {
+      attentionPush: {
+        approval: true,
+        input: true,
+        failed: true,
+        rawProviderSetting: "/home/matrix/provider.log",
+      },
+    }));
+    expect(malformed.status).toBe(400);
+    await expect(malformed.json()).resolves.toMatchObject({
+      error: {
+        code: "validation_failed",
+        safeMessage: "Request could not be processed. Check the inputs and try again.",
+      },
+    });
+
+    const oversized = await app.request(new Request("http://localhost/api/coding-agents/notification-preferences", {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ attentionPush: { approval: true, input: true, failed: true }, padding: "x".repeat(10_000) }),
+    }));
+    expect(oversized.status).toBe(413);
+    await expect(oversized.json()).resolves.toMatchObject({
+      error: {
+        code: "payload_too_large",
+        safeMessage: "Request is too large. Reduce the content and try again.",
+      },
+    });
+  });
+
+  it("maps invalid persisted preferences to a generic unavailable error", async () => {
+    const homePath = await mkdtemp(join(tmpdir(), "matrix-coding-agent-notification-prefs-"));
+    const { app } = appWithStore(homePath);
+    await mkdir(join(homePath, "system", "coding-agents", "notification-preferences"), { recursive: true });
+    await writeFile(
+      join(homePath, "system", "coding-agents", "notification-preferences", "owner_user.json"),
+      JSON.stringify({
+        attentionPush: {
+          approval: true,
+          input: true,
+          failed: true,
+          rawProviderSetting: "/home/matrix/provider.log",
+        },
+      }),
+      "utf-8",
+    );
+
+    const res = await app.request("/api/coding-agents/notification-preferences");
+
+    expect(res.status).toBe(503);
+    await expect(res.json()).resolves.toMatchObject({
+      error: {
+        code: "notification_preferences_unavailable",
+        safeMessage: "Notification preferences are temporarily unavailable. Try again.",
+      },
+    });
+  });
+});

--- a/www/content/docs/coding-agents.mdx
+++ b/www/content/docs/coding-agents.mdx
@@ -118,7 +118,7 @@ Threads may need attention when an agent:
 - fails and needs review;
 - finishes with results to inspect.
 
-Attention appears in the workspace and can route you to the matching thread. Mobile notification taps and desktop notification clicks use bounded thread references and rehydrate the current thread state before rendering.
+Attention appears in the workspace and can route you to the matching thread. Mobile notification taps and desktop notification clicks use bounded thread references and rehydrate the current thread state before rendering. When notification preferences are configured, Matrix applies them on the gateway before sending approval, input, or failure alerts.
 
 ## Approvals and input
 


### PR DESCRIPTION
Summary
- Add shared coding-agent notification preference schemas for approval, input, and failed attention push alerts.
- Add a gateway per-owner preference store plus authenticated GET/PUT /api/coding-agents/notification-preferences routes with body limits, Zod validation, atomic writes, and safe errors.
- Gate coding-agent attention push delivery through preferences before sending and document the current state.

Tests
- pnpm exec vitest run tests/contracts/coding-agents.test.ts tests/gateway/coding-agents-notification-preferences.test.ts tests/gateway/coding-agents-attention-notifications.test.ts
- pnpm exec vitest run tests/gateway/coding-agents-threads.test.ts tests/gateway/coding-agents-summary.test.ts tests/gateway/coding-agents-notification-preferences.test.ts tests/gateway/coding-agents-attention-notifications.test.ts tests/contracts/coding-agents.test.ts
- pnpm --filter @matrix-os/gateway exec tsc --noEmit
- bun run check:patterns (0 violations; existing warnings only)
- bun run typecheck
- git diff --check
- rg forbidden-reference scan over touched files: no matches

Review/Monitoring
- Opened as ready for review in the coding-agent shell stack.
- Addressed initial review findings by isolating preferences per owner and recording dedupe only after preference eligibility.
- Do not add ready-for-ci until the latest trusted review is 5/5.

Invariants
- Source of truth: gateway/runtime owns coding-agent notification preferences in per-owner files under system/coding-agents/notification-preferences/; desktop/mobile are not source of truth.
- Lock/transaction scope: each preference update is a single atomic per-owner file write; no new DB or embedded persistence is introduced.
- Acceptable orphan states: missing per-owner preference files default to enabled alerts; invalid or unavailable persisted preferences return generic unavailable errors and the push bridge fails closed before channel send.
- Auth source of truth: HTTP preference routes use the existing gateway request principal; push delivery checks the owner id from the gateway thread event sink.
- Deferred scope: desktop/mobile preference controls and cross-device delivery policy remain follow-up work.