### PR TITLE
feat(coding-agents): add notification controls

### DIFF
--- a/apps/mobile/__tests__/agents-screen.test.tsx
+++ b/apps/mobile/__tests__/agents-screen.test.tsx
@@ -482,6 +482,51 @@ describe("AgentsScreen", () => {
     expect(screen.getByText("matrix-abc1234")).toBeTruthy();
   });
 
+  it("hydrates and updates notification preferences", async () => {
+    const client = {
+      getCodingAgentRuntimeSummary: jest.fn().mockResolvedValue({
+        ok: true,
+        summary: summaryFixture(),
+      }),
+      getCodingAgentReviews: jest.fn().mockResolvedValue({
+        ok: true,
+        reviews: reviewsFixture(),
+      }),
+      getCodingAgentNotificationPreferences: jest.fn()
+        .mockResolvedValueOnce({
+          ok: true,
+          preferences: { attentionPush: { approval: true, input: true, failed: false } },
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          preferences: { attentionPush: { approval: false, input: true, failed: false } },
+        }),
+      updateCodingAgentNotificationPreferences: jest.fn().mockResolvedValue({
+        ok: true,
+        preferences: { attentionPush: { approval: false, input: true, failed: true } },
+      }),
+    };
+    useGatewayMock.mockReturnValue(gatewayContext({
+      client: client as unknown as GatewayClient,
+      connectionState: "connected",
+    }));
+
+    render(<AgentsScreen />);
+
+    const failedSwitch = await screen.findByRole("switch", { name: "Failed run alerts" });
+    expect(failedSwitch.props.value).toBe(false);
+
+    fireEvent(failedSwitch, "valueChange", true);
+
+    await waitFor(() => {
+      expect(client.updateCodingAgentNotificationPreferences).toHaveBeenCalledWith({
+        attentionPush: { approval: false, input: true, failed: true },
+      });
+    });
+    expect((await screen.findByRole("switch", { name: "Failed run alerts" })).props.value).toBe(true);
+    expect(screen.queryByText(/token|bearer|secret|\/home\/matrix/i)).toBeNull();
+  });
+
   it("opens a mobile thread detail route from active threads", async () => {
     const client = {
       getCodingAgentRuntimeSummary: jest.fn().mockResolvedValue({

--- a/apps/mobile/__tests__/gateway-client.test.ts
+++ b/apps/mobile/__tests__/gateway-client.test.ts
@@ -538,6 +538,42 @@ describe("GatewayClient", () => {
     fetchMock.mockRestore();
   });
 
+  it("fetches and updates coding agent notification preferences with the existing auth header", async () => {
+    const fetchMock = jest.spyOn(global, "fetch")
+      .mockResolvedValueOnce(jsonResponse({ preferences: { attentionPush: { approval: true, input: true, failed: false } } }))
+      .mockResolvedValueOnce(jsonResponse({ preferences: { attentionPush: { approval: true, input: true, failed: true } } }));
+
+    try {
+      const client = new GatewayClient("http://localhost:4000", "token");
+      await expect(client.getCodingAgentNotificationPreferences()).resolves.toEqual({
+        ok: true,
+        preferences: { attentionPush: { approval: true, input: true, failed: false } },
+      });
+      await expect(client.updateCodingAgentNotificationPreferences({ attentionPush: { approval: true, input: true, failed: true } })).resolves.toEqual({
+        ok: true,
+        preferences: { attentionPush: { approval: true, input: true, failed: true } },
+      });
+      expect(fetchMock).toHaveBeenNthCalledWith(1, "http://localhost:4000/api/coding-agents/notification-preferences", expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: "Bearer token",
+          "Content-Type": "application/json",
+        }),
+        signal: expect.any(Object),
+      }));
+      expect(fetchMock).toHaveBeenNthCalledWith(2, "http://localhost:4000/api/coding-agents/notification-preferences", expect.objectContaining({
+        method: "PUT",
+        body: JSON.stringify({ attentionPush: { approval: true, input: true, failed: true } }),
+        headers: expect.objectContaining({
+          Authorization: "Bearer token",
+          "Content-Type": "application/json",
+        }),
+        signal: expect.any(Object),
+      }));
+    } finally {
+      fetchMock.mockRestore();
+    }
+  });
+
   it("submits coding agent approval decisions with the existing auth header", async () => {
     const snapshot = {
       thread: {

--- a/apps/mobile/app/agents/index.tsx
+++ b/apps/mobile/app/agents/index.tsx
@@ -1,9 +1,9 @@
 import { useCallback, useEffect, useRef, useState } from "react";
-import { ActivityIndicator, Linking, Pressable, RefreshControl, ScrollView, Text, TextInput, View } from "react-native";
+import { ActivityIndicator, Linking, Pressable, RefreshControl, ScrollView, Switch, Text, TextInput, View } from "react-native";
 import { Ionicons } from "@expo/vector-icons";
 import { useRouter } from "expo-router";
 import { StyleSheet, useUnistyles } from "react-native-unistyles";
-import type { FileBrowseResponse, FileReadRequest, FileReadResponse, FileSearchResponse, FileWriteRequest, PreviewSessionSummary, ReviewSnapshot, ReviewSummary, RuntimeSummary, SourceControlCreatePullRequestRequest, SourceControlCreatePullRequestResponse, SourceControlPrepareCommitRequest } from "@matrix-os/contracts";
+import type { CodingAgentNotificationPreferences, CodingAgentNotificationPreferencesUpdate, FileBrowseResponse, FileReadRequest, FileReadResponse, FileSearchResponse, FileWriteRequest, PreviewSessionSummary, ReviewSnapshot, ReviewSummary, RuntimeSummary, SourceControlCreatePullRequestRequest, SourceControlCreatePullRequestResponse, SourceControlPrepareCommitRequest } from "@matrix-os/contracts";
 import { useGateway } from "@/app/_layout";
 import { CODING_AGENTS_MOBILE_WORKSPACE } from "@/lib/feature-flags";
 
@@ -21,6 +21,13 @@ type ReviewState =
   | { status: "error"; reviews: null; error: "Review state unavailable" };
 
 const INITIAL_REVIEW_STATE: ReviewState = { status: "idle", reviews: null, error: null };
+
+type NotificationPreferencesState =
+  | { status: "idle"; preferences: null; error: null }
+  | { status: "loading"; preferences: null; error: null }
+  | { status: "ready"; preferences: CodingAgentNotificationPreferences; error: null }
+  | { status: "saving"; preferences: CodingAgentNotificationPreferences; error: null }
+  | { status: "error"; preferences: CodingAgentNotificationPreferences | null; error: "Notification settings unavailable" | "Notification settings could not be saved. Try again." };
 
 type ReviewSnapshotState =
   | { status: "idle"; selectedReviewId: null; snapshot: null; error: null }
@@ -86,6 +93,19 @@ const INITIAL_REVIEW_SNAPSHOT_STATE: ReviewSnapshotState = {
   snapshot: null,
   error: null,
 };
+
+const INITIAL_NOTIFICATION_PREFERENCES_STATE: NotificationPreferencesState = {
+  status: "idle",
+  preferences: null,
+  error: null,
+};
+
+type NotificationPreferenceKey = keyof CodingAgentNotificationPreferences["attentionPush"];
+const NOTIFICATION_TOGGLES: { key: NotificationPreferenceKey; label: string; detail: string }[] = [
+  { key: "approval", label: "Approval alerts", detail: "Approval-required runs" },
+  { key: "input", label: "Input request alerts", detail: "Runs waiting for a response" },
+  { key: "failed", label: "Failed run alerts", detail: "Runs that need recovery" },
+];
 
 const INITIAL_FILE_CONTENT_STATE: FileContentState = {
   status: "idle",
@@ -216,6 +236,7 @@ export default function AgentsScreen() {
   const router = useRouter();
   const { client } = useGateway();
   const [state, setState] = useState<ScreenState>(INITIAL_STATE);
+  const [notificationPreferencesState, setNotificationPreferencesState] = useState<NotificationPreferencesState>(INITIAL_NOTIFICATION_PREFERENCES_STATE);
   const [reviewState, setReviewState] = useState<ReviewState>(INITIAL_REVIEW_STATE);
   const [reviewSnapshotState, setReviewSnapshotState] = useState<ReviewSnapshotState>(INITIAL_REVIEW_SNAPSHOT_STATE);
   const [fileContentState, setFileContentState] = useState<FileContentState>(INITIAL_FILE_CONTENT_STATE);
@@ -224,6 +245,10 @@ export default function AgentsScreen() {
   const [sourcePullRequestState, setSourcePullRequestState] = useState<SourcePullRequestState>(INITIAL_SOURCE_PULL_REQUEST_STATE);
   const [refreshing, setRefreshing] = useState(false);
   const requestGeneration = useRef(0);
+  const notificationPreferencesGeneration = useRef(0);
+  const notificationPreferencesRef = useRef<CodingAgentNotificationPreferences | null>(null);
+  const notificationPreferenceSaveActiveRef = useRef(false);
+  const pendingNotificationPreferencePatchRef = useRef<Partial<CodingAgentNotificationPreferences["attentionPush"]>>({});
   const reviewSnapshotGeneration = useRef(0);
   const fileContentGeneration = useRef(0);
   const selectedReviewIdRef = useRef<string | null>(null);
@@ -484,19 +509,138 @@ export default function AgentsScreen() {
     clearReviewSnapshot();
   }, [clearReviewSnapshot, client, loadReviewSnapshot]);
 
+  const loadNotificationPreferences = useCallback(async () => {
+    const generation = notificationPreferencesGeneration.current + 1;
+    notificationPreferencesGeneration.current = generation;
+    if (!client || typeof client.getCodingAgentNotificationPreferences !== "function") {
+      setNotificationPreferencesState({
+        status: "error",
+        preferences: null,
+        error: "Notification settings unavailable",
+      });
+      return;
+    }
+    setNotificationPreferencesState((current) => (
+      current.preferences ? current : { status: "loading", preferences: null, error: null }
+    ));
+    const result = await client.getCodingAgentNotificationPreferences();
+    if (generation !== notificationPreferencesGeneration.current) return;
+    if (result.ok) {
+      notificationPreferencesRef.current = result.preferences;
+      setNotificationPreferencesState({ status: "ready", preferences: result.preferences, error: null });
+      return;
+    }
+    setNotificationPreferencesState({
+      status: "error",
+      preferences: null,
+      error: "Notification settings unavailable",
+    });
+  }, [client]);
+
+  const flushNotificationPreferenceUpdates = useCallback(async () => {
+    if (
+      !client
+      || typeof client.getCodingAgentNotificationPreferences !== "function"
+      || typeof client.updateCodingAgentNotificationPreferences !== "function"
+      || notificationPreferenceSaveActiveRef.current
+    ) {
+      return;
+    }
+    notificationPreferenceSaveActiveRef.current = true;
+    try {
+      while (Object.keys(pendingNotificationPreferencePatchRef.current).length > 0) {
+        const patch = pendingNotificationPreferencePatchRef.current;
+        pendingNotificationPreferencePatchRef.current = {};
+        const previous = notificationPreferencesRef.current;
+        if (!previous) {
+          pendingNotificationPreferencePatchRef.current = {};
+          setNotificationPreferencesState({
+            status: "error",
+            preferences: null,
+            error: "Notification settings could not be saved. Try again.",
+          });
+          return;
+        }
+        setNotificationPreferencesState({
+          status: "saving",
+          preferences: previous,
+          error: null,
+        });
+        const latest = await client.getCodingAgentNotificationPreferences();
+        if (!latest.ok) {
+          setNotificationPreferencesState({
+            status: "error",
+            preferences: previous,
+            error: "Notification settings could not be saved. Try again.",
+          });
+          return;
+        }
+        const request: CodingAgentNotificationPreferencesUpdate = {
+          attentionPush: {
+            ...latest.preferences.attentionPush,
+            ...patch,
+          },
+        };
+        const result = await client.updateCodingAgentNotificationPreferences(request);
+        if (!result.ok) {
+          setNotificationPreferencesState({
+            status: "error",
+            preferences: previous,
+            error: "Notification settings could not be saved. Try again.",
+          });
+          return;
+        }
+        notificationPreferencesRef.current = result.preferences;
+        setNotificationPreferencesState({ status: "ready", preferences: result.preferences, error: null });
+      }
+    } finally {
+      notificationPreferenceSaveActiveRef.current = false;
+    }
+    if (Object.keys(pendingNotificationPreferencePatchRef.current).length > 0) {
+      void flushNotificationPreferenceUpdates();
+    }
+  }, [client]);
+
+  const updateNotificationPreferences = useCallback((
+    request: { attentionPush: Partial<CodingAgentNotificationPreferences["attentionPush"]> },
+  ) => {
+    const previous = notificationPreferencesRef.current;
+    if (!previous) return;
+    pendingNotificationPreferencePatchRef.current = {
+      ...pendingNotificationPreferencePatchRef.current,
+      ...request.attentionPush,
+    };
+    const optimistic = {
+      ...previous,
+      attentionPush: {
+        ...previous.attentionPush,
+        ...request.attentionPush,
+      },
+    };
+    notificationPreferencesRef.current = optimistic;
+    setNotificationPreferencesState({
+      status: "saving",
+      preferences: optimistic,
+      error: null,
+    });
+    void flushNotificationPreferenceUpdates();
+  }, [flushNotificationPreferenceUpdates]);
+
   useEffect(() => {
     setState((current) => (current.summary ? current : INITIAL_STATE));
     void loadSummary();
-  }, [loadSummary]);
+    void loadNotificationPreferences();
+  }, [loadNotificationPreferences, loadSummary]);
 
   const onRefresh = useCallback(async () => {
     setRefreshing(true);
     try {
       await loadSummary();
+      await loadNotificationPreferences();
     } finally {
       setRefreshing(false);
     }
-  }, [loadSummary]);
+  }, [loadNotificationPreferences, loadSummary]);
 
   const selectReview = useCallback((reviewId: string) => {
     void loadReviewSnapshot(reviewId);
@@ -554,6 +698,42 @@ export default function AgentsScreen() {
           </Pressable>
         ) : null}
       </View>
+
+      <Section title="Notifications" count={NOTIFICATION_TOGGLES.length}>
+        <View style={styles.notificationPanel}>
+          {NOTIFICATION_TOGGLES.map((item) => {
+            const preferences = notificationPreferencesState.preferences;
+            const disabled = notificationPreferencesState.status === "loading"
+              || notificationPreferencesState.status === "saving"
+              || !preferences;
+            return (
+              <View key={item.key} style={styles.notificationRow}>
+                <View style={styles.notificationText}>
+                  <Text style={styles.rowTitle}>{item.label}</Text>
+                  <Text style={styles.rowSubtitle}>{item.detail}</Text>
+                </View>
+                <Switch
+                  accessibilityLabel={item.label}
+                  accessibilityRole="switch"
+                  value={Boolean(preferences?.attentionPush[item.key])}
+                  disabled={disabled}
+                  onValueChange={(value) => {
+                    if (!preferences) return;
+                    void updateNotificationPreferences({
+                      attentionPush: { [item.key]: value },
+                    });
+                  }}
+                  trackColor={{ false: theme.colors.border, true: theme.colors.moss }}
+                  thumbColor={theme.colors.background}
+                />
+              </View>
+            );
+          })}
+          {notificationPreferencesState.error ? (
+            <Text style={styles.notificationError}>{notificationPreferencesState.error}</Text>
+          ) : null}
+        </View>
+      </Section>
 
       <Section title="Providers" count={summary.providers.length}>
         {summary.providers.length === 0 ? <EmptyText>No providers are ready.</EmptyText> : null}
@@ -1542,6 +1722,35 @@ const styles = StyleSheet.create((theme, rt) => ({
     fontFamily: theme.fonts.sansSemiBold,
     fontSize: 13,
     color: theme.colors.background,
+  },
+  notificationPanel: {
+    borderRadius: 14,
+    borderCurve: "continuous" as const,
+    borderWidth: 1,
+    borderColor: theme.colors.border,
+    backgroundColor: theme.colors.card,
+    overflow: "hidden",
+  },
+  notificationRow: {
+    minHeight: 56,
+    paddingHorizontal: theme.spacing.md,
+    paddingVertical: theme.spacing.sm,
+    borderBottomWidth: 1,
+    borderColor: theme.colors.border,
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    gap: theme.spacing.md,
+  },
+  notificationText: {
+    flex: 1,
+    minWidth: 0,
+  },
+  notificationError: {
+    padding: theme.spacing.sm,
+    fontFamily: theme.fonts.sans,
+    fontSize: 12,
+    color: theme.colors.destructive,
   },
   title: {
     fontFamily: theme.fonts.displaySemiBold,

--- a/apps/mobile/lib/gateway-client.ts
+++ b/apps/mobile/lib/gateway-client.ts
@@ -9,6 +9,8 @@ import {
   AgentThreadSnapshotSchema,
   ApprovalDecisionRequestSchema,
   ApprovalIdSchema,
+  CodingAgentNotificationPreferencesSchema,
+  CodingAgentNotificationPreferencesUpdateSchema,
   CursorSchema,
   FileBrowseRequestSchema,
   FileBrowseResponseSchema,
@@ -31,6 +33,8 @@ import {
   UserInputAnswerRequestSchema,
   type CreateAgentThreadRequest,
   type AgentThreadEvent,
+  type CodingAgentNotificationPreferences,
+  type CodingAgentNotificationPreferencesUpdate,
   type FileBrowseRequest,
   type FileBrowseResponse,
   type FileReadRequest,
@@ -114,6 +118,18 @@ export interface MatrixAppManifestResponse {
 export type CodingAgentRuntimeSummaryResult =
   | { ok: true; summary: RuntimeSummary }
   | { ok: false; error: "Runtime summary unavailable" };
+
+const CodingAgentNotificationPreferencesRouteResponseSchema = z.object({
+  preferences: CodingAgentNotificationPreferencesSchema,
+}).strict();
+
+export type CodingAgentNotificationPreferencesResult =
+  | { ok: true; preferences: CodingAgentNotificationPreferences }
+  | { ok: false; error: "Notification settings unavailable" };
+
+export type CodingAgentNotificationPreferencesUpdateResult =
+  | { ok: true; preferences: CodingAgentNotificationPreferences }
+  | { ok: false; error: "Notification settings could not be saved. Try again." };
 
 export type CodingAgentThreadCreateResult =
   | { ok: true; snapshot: z.infer<typeof AgentThreadSnapshotSchema> }
@@ -734,6 +750,55 @@ export class GatewayClient {
     } catch {
       console.warn("[mobile] /api/coding-agents/summary unavailable");
       return { ok: false, error: "Runtime summary unavailable" };
+    }
+  }
+
+  async getCodingAgentNotificationPreferences(): Promise<CodingAgentNotificationPreferencesResult> {
+    try {
+      const res = await this.fetchGateway("/api/coding-agents/notification-preferences");
+      if (!res.ok) {
+        console.warn("[mobile] /api/coding-agents/notification-preferences unavailable", res.status);
+        return { ok: false, error: "Notification settings unavailable" };
+      }
+      const body = await res.json();
+      const parsed = CodingAgentNotificationPreferencesRouteResponseSchema.safeParse(body);
+      if (!parsed.success) {
+        console.warn("[mobile] /api/coding-agents/notification-preferences returned invalid payload");
+        return { ok: false, error: "Notification settings unavailable" };
+      }
+      return { ok: true, preferences: parsed.data.preferences };
+    } catch {
+      console.warn("[mobile] /api/coding-agents/notification-preferences unavailable");
+      return { ok: false, error: "Notification settings unavailable" };
+    }
+  }
+
+  async updateCodingAgentNotificationPreferences(
+    request: CodingAgentNotificationPreferencesUpdate,
+  ): Promise<CodingAgentNotificationPreferencesUpdateResult> {
+    try {
+      const parsedRequest = CodingAgentNotificationPreferencesUpdateSchema.safeParse(request);
+      if (!parsedRequest.success) {
+        return { ok: false, error: "Notification settings could not be saved. Try again." };
+      }
+      const res = await this.fetchGateway("/api/coding-agents/notification-preferences", {
+        method: "PUT",
+        body: JSON.stringify(parsedRequest.data),
+      });
+      if (!res.ok) {
+        console.warn("[mobile] /api/coding-agents/notification-preferences update unavailable", res.status);
+        return { ok: false, error: "Notification settings could not be saved. Try again." };
+      }
+      const body = await res.json();
+      const parsed = CodingAgentNotificationPreferencesRouteResponseSchema.safeParse(body);
+      if (!parsed.success) {
+        console.warn("[mobile] /api/coding-agents/notification-preferences update returned invalid payload");
+        return { ok: false, error: "Notification settings could not be saved. Try again." };
+      }
+      return { ok: true, preferences: parsed.data.preferences };
+    } catch {
+      console.warn("[mobile] /api/coding-agents/notification-preferences update unavailable");
+      return { ok: false, error: "Notification settings could not be saved. Try again." };
     }
   }
 

--- a/desktop/src/main/coding-agents/runtime-summary-client.ts
+++ b/desktop/src/main/coding-agents/runtime-summary-client.ts
@@ -1,5 +1,7 @@
 import {
   AgentThreadSnapshotSchema,
+  CodingAgentNotificationPreferencesSchema,
+  CodingAgentNotificationPreferencesUpdateSchema,
   FileBrowseRequestSchema,
   FileBrowseResponseSchema,
   FileReadRequestSchema,
@@ -16,6 +18,8 @@ import {
   SourceControlPrepareCommitRequestSchema,
   SourceControlPrepareCommitResponseSchema,
   type ApprovalDecisionRequest,
+  type CodingAgentNotificationPreferences,
+  type CodingAgentNotificationPreferencesUpdate,
   type CreateAgentThreadRequest,
   type FileBrowseRequest,
   type FileBrowseResponse,
@@ -35,10 +39,11 @@ import {
   type UserInputAnswerRequest,
   boundedListSchema,
 } from "@matrix-os/contracts";
-import type { z } from "zod/v4";
+import { z } from "zod/v4";
 import type { AuthService } from "../auth/auth-service";
 
 const RUNTIME_SUMMARY_TIMEOUT_MS = 10_000;
+const NOTIFICATION_PREFERENCES_TIMEOUT_MS = 10_000;
 const REVIEW_SUMMARY_TIMEOUT_MS = 10_000;
 const REVIEW_SNAPSHOT_TIMEOUT_MS = 10_000;
 const FILE_BROWSE_TIMEOUT_MS = 10_000;
@@ -55,6 +60,9 @@ type FetchFn = (input: string, init?: RequestInit) => Promise<Response>;
 type AgentThreadSnapshot = z.infer<typeof AgentThreadSnapshotSchema>;
 const ReviewSummaryListSchema = boundedListSchema(ReviewSummarySchema, 50);
 type ReviewSummaryList = z.infer<typeof ReviewSummaryListSchema>;
+const NotificationPreferencesResponseSchema = z.object({
+  preferences: CodingAgentNotificationPreferencesSchema,
+}).strict();
 
 function buildSummaryUrl(origin: string, runtimeSlot: string): string {
   const url = new URL("/api/coding-agents/summary", origin);
@@ -93,6 +101,74 @@ export async function fetchCodingAgentRuntimeSummary(
     throw new Error("runtime summary unavailable");
   }
   return parsed.data;
+}
+
+export async function fetchCodingAgentNotificationPreferences(
+  auth: AuthService,
+  fetchFn: FetchFn = fetch,
+): Promise<CodingAgentNotificationPreferences> {
+  const token = auth.getToken();
+  if (!token) {
+    throw new Error("notification settings unavailable");
+  }
+
+  const url = new URL("/api/coding-agents/notification-preferences", auth.getGatewayOrigin());
+  const res = await fetchFn(url.toString(), {
+    method: "GET",
+    headers: {
+      Authorization: `Bearer ${token}`,
+      Accept: "application/json",
+    },
+    signal: AbortSignal.timeout(NOTIFICATION_PREFERENCES_TIMEOUT_MS),
+  });
+  if (!res.ok) {
+    throw new Error("notification settings unavailable");
+  }
+
+  const body = await res.json();
+  const parsed = NotificationPreferencesResponseSchema.safeParse(body);
+  if (!parsed.success) {
+    throw new Error("notification settings unavailable");
+  }
+  return parsed.data.preferences;
+}
+
+export async function updateCodingAgentNotificationPreferences(
+  auth: AuthService,
+  request: CodingAgentNotificationPreferencesUpdate,
+  fetchFn: FetchFn = fetch,
+): Promise<CodingAgentNotificationPreferences> {
+  const token = auth.getToken();
+  if (!token) {
+    throw new Error("notification settings unavailable");
+  }
+
+  const parsedRequest = CodingAgentNotificationPreferencesUpdateSchema.safeParse(request);
+  if (!parsedRequest.success) {
+    throw new Error("notification settings unavailable");
+  }
+
+  const url = new URL("/api/coding-agents/notification-preferences", auth.getGatewayOrigin());
+  const res = await fetchFn(url.toString(), {
+    method: "PUT",
+    headers: {
+      Authorization: `Bearer ${token}`,
+      Accept: "application/json",
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(parsedRequest.data),
+    signal: AbortSignal.timeout(NOTIFICATION_PREFERENCES_TIMEOUT_MS),
+  });
+  if (!res.ok) {
+    throw new Error("notification settings unavailable");
+  }
+
+  const body = await res.json();
+  const parsed = NotificationPreferencesResponseSchema.safeParse(body);
+  if (!parsed.success) {
+    throw new Error("notification settings unavailable");
+  }
+  return parsed.data.preferences;
 }
 
 export async function createCodingAgentThread(

--- a/desktop/src/main/index.ts
+++ b/desktop/src/main/index.ts
@@ -10,6 +10,7 @@ import {
   fetchCodingAgentFileBrowse,
   fetchCodingAgentFileContent,
   fetchCodingAgentFileSearch,
+  fetchCodingAgentNotificationPreferences,
   fetchCodingAgentThreadSnapshot,
   fetchCodingAgentReviewSnapshot,
   fetchCodingAgentReviewSummaries,
@@ -18,6 +19,7 @@ import {
   saveCodingAgentFileContent,
   submitCodingAgentApprovalDecision,
   submitCodingAgentInputAnswer,
+  updateCodingAgentNotificationPreferences,
 } from "./coding-agents/runtime-summary-client";
 import { registerIpcHandlers } from "./ipc/handlers";
 import { createLocalStore } from "./persistence/local-store";
@@ -242,6 +244,8 @@ if (!gotLock) {
         },
         getUpdateStatus: () => updater.status(),
         fetchRuntimeSummary: () => fetchCodingAgentRuntimeSummary(auth),
+        fetchNotificationPreferences: () => fetchCodingAgentNotificationPreferences(auth),
+        updateNotificationPreferences: (request) => updateCodingAgentNotificationPreferences(auth, request),
         fetchReviewSummaries: (options) => fetchCodingAgentReviewSummaries(auth, options),
         fetchReviewSnapshot: (options) => fetchCodingAgentReviewSnapshot(auth, options),
         fetchFileBrowse: (request) => fetchCodingAgentFileBrowse(auth, request),

--- a/desktop/src/main/ipc/handlers.ts
+++ b/desktop/src/main/ipc/handlers.ts
@@ -6,7 +6,7 @@ import type { AuthService } from "../auth/auth-service";
 import type { EmbedService } from "../embeds/embed-service";
 import type { LocalStore, LocalStoreKey } from "../persistence/local-store";
 import type { UpdateStatus } from "../updates";
-import type { CreateAgentThreadRequest, FileBrowseRequest, FileBrowseResponse, FileReadRequest, FileReadResponse, FileSearchRequest, FileSearchResponse, FileWriteRequest, FileWriteResponse, ReviewSnapshot, ReviewSummary, RuntimeSummary, SourceControlCreatePullRequestRequest, SourceControlCreatePullRequestResponse, SourceControlPrepareCommitRequest, SourceControlPrepareCommitResponse } from "@matrix-os/contracts";
+import type { CodingAgentNotificationPreferences, CodingAgentNotificationPreferencesUpdate, CreateAgentThreadRequest, FileBrowseRequest, FileBrowseResponse, FileReadRequest, FileReadResponse, FileSearchRequest, FileSearchResponse, FileWriteRequest, FileWriteResponse, ReviewSnapshot, ReviewSummary, RuntimeSummary, SourceControlCreatePullRequestRequest, SourceControlCreatePullRequestResponse, SourceControlPrepareCommitRequest, SourceControlPrepareCommitResponse } from "@matrix-os/contracts";
 import type { z } from "zod/v4";
 import { AgentThreadSnapshotSchema } from "@matrix-os/contracts";
 
@@ -27,6 +27,10 @@ export interface HandlerContext {
   onRuntimeChanged: (slot: string) => void;
   getUpdateStatus: () => UpdateStatus;
   fetchRuntimeSummary: () => Promise<RuntimeSummary>;
+  fetchNotificationPreferences: () => Promise<CodingAgentNotificationPreferences>;
+  updateNotificationPreferences: (
+    request: CodingAgentNotificationPreferencesUpdate,
+  ) => Promise<CodingAgentNotificationPreferences>;
   fetchReviewSummaries: (
     options: { cursor?: string },
   ) => Promise<{ items: ReviewSummary[]; hasMore: boolean; limit: number; nextCursor?: string }>;
@@ -109,6 +113,8 @@ export function registerIpcHandlers(ipcMain: IpcMainLike, ctx: HandlerContext): 
     return { ok: true };
   });
   handle("runtime:get-summary", () => ctx.fetchRuntimeSummary());
+  handle("runtime:get-notification-preferences", () => ctx.fetchNotificationPreferences());
+  handle("runtime:update-notification-preferences", (request) => ctx.updateNotificationPreferences(request));
   handle("runtime:get-reviews", (request) => ctx.fetchReviewSummaries(request));
   handle("runtime:get-review-snapshot", (request) => ctx.fetchReviewSnapshot(request));
   handle("runtime:browse-files", (request) => ctx.fetchFileBrowse(request));

--- a/desktop/src/renderer/src/features/coding-agents/AgentWorkspace.tsx
+++ b/desktop/src/renderer/src/features/coding-agents/AgentWorkspace.tsx
@@ -1,4 +1,4 @@
-import { Bot, ChevronRight, ClipboardCheck, ExternalLink, FileText, FolderOpen, GitBranch, GitCommitHorizontal, GitPullRequest, Monitor, Play, RefreshCw, Save, Search, Server, SquareTerminal } from "lucide-react";
+import { Bell, Bot, ChevronRight, ClipboardCheck, ExternalLink, FileText, FolderOpen, GitBranch, GitCommitHorizontal, GitPullRequest, Monitor, Play, RefreshCw, Save, Search, Server, SquareTerminal } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
 import {
   defaultAgentThreadComposerDraft,
@@ -50,6 +50,7 @@ type ComposerSeed = {
   seedId: number;
   draft: AgentThreadComposerDraft;
 };
+type NotificationPreferenceKey = "approval" | "input" | "failed";
 type SelectedReviewHunk = {
   key: string;
   file: ReviewSnapshotFile;
@@ -115,6 +116,65 @@ function RuntimeHeader({ summary, onRefresh }: { summary: RuntimeSummary; onRefr
         Refresh
       </Button>
     </div>
+  );
+}
+
+const NOTIFICATION_TOGGLES: Array<{ key: NotificationPreferenceKey; label: string; detail: string }> = [
+  { key: "approval", label: "Approval alerts", detail: "Approval-required runs" },
+  { key: "input", label: "Input request alerts", detail: "Runs waiting for a response" },
+  { key: "failed", label: "Failed run alerts", detail: "Runs that need recovery" },
+];
+
+function NotificationPreferencesPanel() {
+  const status = useCodingAgentWorkspace((s) => s.notificationPreferencesStatus);
+  const preferences = useCodingAgentWorkspace((s) => s.notificationPreferences);
+  const error = useCodingAgentWorkspace((s) => s.notificationPreferencesError);
+  const updateNotificationPreferences = useCodingAgentWorkspace((s) => s.updateNotificationPreferences);
+  const disabled = status === "loading" || status === "saving" || !preferences;
+
+  return (
+    <Section title="Notifications">
+      <div
+        className="grid gap-2 rounded-md border p-3 md:grid-cols-3"
+        style={{ borderColor: "var(--border-subtle)", background: "var(--bg-surface)" }}
+      >
+        {NOTIFICATION_TOGGLES.map((item) => (
+          <label
+            key={item.key}
+            className="flex min-w-0 items-center justify-between gap-3 rounded-md border px-3 py-2"
+            style={{ borderColor: "var(--border-subtle)", color: "var(--text-primary)" }}
+          >
+            <span className="flex min-w-0 items-center gap-2">
+              <Bell size={14} aria-hidden="true" />
+              <span className="min-w-0">
+                <span className="block truncate text-sm font-medium">{item.label}</span>
+                <span className="block truncate text-xs" style={{ color: "var(--text-tertiary)" }}>
+                  {item.detail}
+                </span>
+              </span>
+            </span>
+            <input
+              aria-label={item.label}
+              type="checkbox"
+              className="h-4 w-4 shrink-0"
+              checked={Boolean(preferences?.attentionPush[item.key])}
+              disabled={disabled}
+              onChange={(event) => {
+                if (!preferences) return;
+                void updateNotificationPreferences({
+                  attentionPush: { [item.key]: event.currentTarget.checked },
+                });
+              }}
+            />
+          </label>
+        ))}
+        {error ? (
+          <p className="md:col-span-3 text-xs" style={{ color: "var(--danger)" }}>
+            {error}
+          </p>
+        ) : null}
+      </div>
+    </Section>
   );
 }
 
@@ -1713,11 +1773,13 @@ export default function AgentWorkspace() {
   const threadSnapshot = useCodingAgentWorkspace((s) => s.threadSnapshot);
   const threadSnapshotError = useCodingAgentWorkspace((s) => s.threadSnapshotError);
   const loadThreadSnapshot = useCodingAgentWorkspace((s) => s.loadThreadSnapshot);
+  const loadNotificationPreferences = useCodingAgentWorkspace((s) => s.loadNotificationPreferences);
   const [composerSeed, setComposerSeed] = useState<ComposerSeed | null>(null);
 
   useEffect(() => {
     void refresh();
-  }, [refresh, runtimeSlot]);
+    void loadNotificationPreferences();
+  }, [loadNotificationPreferences, refresh, runtimeSlot]);
 
   useEffect(() => {
     if (!activeThreadId) return;
@@ -1755,6 +1817,7 @@ export default function AgentWorkspace() {
       <RuntimeHeader summary={summary} onRefresh={() => void refresh()} />
       <div className="grid min-h-0 flex-1 gap-4 overflow-y-auto p-5">
         <AgentComposer summary={summary} seed={composerSeed} />
+        <NotificationPreferencesPanel />
         <ProviderList summary={summary} />
         <AttentionThreadList summary={summary} />
         <div className="grid gap-4 xl:grid-cols-2">

--- a/desktop/src/renderer/src/stores/coding-agent-workspace.ts
+++ b/desktop/src/renderer/src/stores/coding-agent-workspace.ts
@@ -3,6 +3,8 @@ import {
   type ApprovalDecisionRequest,
   type AgentThreadSnapshot,
   type AgentThreadComposerDraft,
+  type CodingAgentNotificationPreferences,
+  type CodingAgentNotificationPreferencesUpdate,
   type FileReadRequest,
   type FileReadResponse,
   type FileWriteRequest,
@@ -24,10 +26,12 @@ type FileReadStatus = "idle" | "loading" | "ready" | "error";
 type FileWriteStatus = "idle" | "saving" | "saved" | "error";
 type SourceCommitStatus = "idle" | "preparing" | "prepared" | "error";
 type SourcePullRequestStatus = "idle" | "creating" | "ready" | "error";
+type NotificationPreferencesStatus = "idle" | "loading" | "ready" | "saving" | "error";
 type CreateStatus = "idle" | "submitting";
 type ActionStatus = "idle" | "submitting";
 type AgentThreadSnapshotEvent = AgentThreadSnapshot["events"]["items"][number];
 type FileReference = Pick<FileReadRequest, "projectId" | "worktreeId" | "path">;
+type AttentionPushPreferences = CodingAgentNotificationPreferences["attentionPush"];
 type ReviewSummaryList = {
   items: ReviewSummary[];
   hasMore: boolean;
@@ -39,6 +43,9 @@ interface CodingAgentWorkspaceState {
   status: WorkspaceStatus;
   summary: RuntimeSummary | null;
   error: string | null;
+  notificationPreferencesStatus: NotificationPreferencesStatus;
+  notificationPreferences: CodingAgentNotificationPreferences | null;
+  notificationPreferencesError: string | null;
   reviewsStatus: ReviewStatus;
   reviews: ReviewSummaryList | null;
   reviewsError: string | null;
@@ -76,6 +83,8 @@ interface CodingAgentWorkspaceState {
   inputActionErrors: Record<string, string>;
   activeThreadId: string | null;
   refresh: () => Promise<void>;
+  loadNotificationPreferences: () => Promise<void>;
+  updateNotificationPreferences: (request: { attentionPush: Partial<AttentionPushPreferences> }) => Promise<void>;
   selectReview: (reviewId: string) => Promise<void>;
   loadFileContent: (request: FileReadRequest) => Promise<void>;
   saveFileContent: (request: Omit<FileWriteRequest, "encoding" | "clientRequestId">) => Promise<void>;
@@ -102,6 +111,9 @@ let reviewsSeq = 0;
 let reviewSnapshotSeq = 0;
 let fileReadSeq = 0;
 let threadSnapshotSeq = 0;
+let notificationPreferencesSeq = 0;
+let notificationPreferencesSaveActive = false;
+let pendingNotificationPreferencePatch: Partial<AttentionPushPreferences> = {};
 let createRequestSeq = 0;
 let actionRequestSeq = 0;
 
@@ -233,10 +245,57 @@ export function codingAgentInputActionKey(threadId: string, inputRequestId: stri
   return `${threadId}:${inputRequestId}`;
 }
 
+async function flushNotificationPreferenceUpdates(): Promise<void> {
+  if (notificationPreferencesSaveActive) return;
+  notificationPreferencesSaveActive = true;
+  try {
+    while (Object.keys(pendingNotificationPreferencePatch).length > 0) {
+      const patch = pendingNotificationPreferencePatch;
+      pendingNotificationPreferencePatch = {};
+      const previous = useCodingAgentWorkspace.getState().notificationPreferences;
+      useCodingAgentWorkspace.setState({
+        notificationPreferencesStatus: "saving",
+        notificationPreferencesError: null,
+      });
+      try {
+        const latest = await invoke("runtime:get-notification-preferences", {});
+        const preferences = await invoke("runtime:update-notification-preferences", {
+          attentionPush: {
+            ...latest.attentionPush,
+            ...patch,
+          },
+        } satisfies CodingAgentNotificationPreferencesUpdate);
+        useCodingAgentWorkspace.setState({
+          notificationPreferencesStatus: "ready",
+          notificationPreferences: preferences,
+          notificationPreferencesError: null,
+        });
+      } catch {
+        console.warn("[coding-agents] notification preferences update failed");
+        pendingNotificationPreferencePatch = {};
+        useCodingAgentWorkspace.setState({
+          notificationPreferencesStatus: "error",
+          notificationPreferences: previous,
+          notificationPreferencesError: "Notification settings could not be saved. Try again.",
+        });
+        return;
+      }
+    }
+  } finally {
+    notificationPreferencesSaveActive = false;
+  }
+  if (Object.keys(pendingNotificationPreferencePatch).length > 0) {
+    await flushNotificationPreferenceUpdates();
+  }
+}
+
 export const useCodingAgentWorkspace = create<CodingAgentWorkspaceState>()((set) => ({
   status: "idle",
   summary: null,
   error: null,
+  notificationPreferencesStatus: "idle",
+  notificationPreferences: null,
+  notificationPreferencesError: null,
   reviewsStatus: "idle",
   reviews: null,
   reviewsError: null,
@@ -351,6 +410,51 @@ export const useCodingAgentWorkspace = create<CodingAgentWorkspaceState>()((set)
         ...clearThreadSnapshotState(),
       });
     }
+  },
+
+  loadNotificationPreferences: async () => {
+    const seq = ++notificationPreferencesSeq;
+    set((state) => ({
+      notificationPreferencesStatus: state.notificationPreferences ? "ready" : "loading",
+      notificationPreferencesError: null,
+    }));
+    try {
+      const preferences = await invoke("runtime:get-notification-preferences", {});
+      if (seq !== notificationPreferencesSeq) return;
+      set({
+        notificationPreferencesStatus: "ready",
+        notificationPreferences: preferences,
+        notificationPreferencesError: null,
+      });
+    } catch {
+      console.warn("[coding-agents] notification preferences refresh failed");
+      if (seq !== notificationPreferencesSeq) return;
+      set({
+        notificationPreferencesStatus: "error",
+        notificationPreferencesError: "Notification settings unavailable",
+      });
+    }
+  },
+
+  updateNotificationPreferences: async (request) => {
+    pendingNotificationPreferencePatch = {
+      ...pendingNotificationPreferencePatch,
+      ...request.attentionPush,
+    };
+    set((state) => ({
+      notificationPreferencesStatus: "saving",
+      notificationPreferences: state.notificationPreferences
+        ? {
+            ...state.notificationPreferences,
+            attentionPush: {
+              ...state.notificationPreferences.attentionPush,
+              ...request.attentionPush,
+            },
+          }
+        : state.notificationPreferences,
+      notificationPreferencesError: null,
+    }));
+    await flushNotificationPreferenceUpdates();
   },
 
   selectReview: async (reviewId) => {

--- a/desktop/src/shared/ipc-contract.ts
+++ b/desktop/src/shared/ipc-contract.ts
@@ -7,6 +7,8 @@ import {
   ApprovalDecisionRequestSchema,
   ApprovalIdSchema,
   AgentThreadSnapshotSchema,
+  CodingAgentNotificationPreferencesSchema,
+  CodingAgentNotificationPreferencesUpdateSchema,
   CreateAgentThreadRequestSchema,
   CursorSchema,
   FileBrowseRequestSchema,
@@ -124,6 +126,14 @@ export const INVOKE_CHANNELS = {
   "runtime:get-summary": {
     request: Empty,
     response: RuntimeSummarySchema,
+  },
+  "runtime:get-notification-preferences": {
+    request: Empty,
+    response: CodingAgentNotificationPreferencesSchema,
+  },
+  "runtime:update-notification-preferences": {
+    request: CodingAgentNotificationPreferencesUpdateSchema,
+    response: CodingAgentNotificationPreferencesSchema,
   },
   "runtime:get-reviews": {
     request: z.object({ cursor: CursorSchema.optional() }).strict(),

--- a/docs/dev/coding-agent-shells.md
+++ b/docs/dev/coding-agent-shells.md
@@ -91,6 +91,8 @@ Client UI must disable duplicate submission while a decision is in flight and re
 
 Coding-agent attention notifications are gateway-owned. Thread events for approval requests, user-input requests, and failed runs may emit safe push-channel payloads with generic copy plus a bounded thread id. The bridge deduplicates owner/thread/kind notifications in a capped TTL registry and checks owner notification preferences before sending. Missing preferences default to enabled; corrupt or unavailable preferences must fail closed for push delivery and log details server-side only.
 
+Desktop and mobile may expose controls for approval, input, and failed-run attention push preferences. Desktop must route reads and writes through trusted main-process IPC so bearer credentials stay out of the renderer. Mobile must use the authenticated gateway client and keep preference state transient; do not persist notification preference payloads in AsyncStorage. Preference updates are full replacements validated with `CodingAgentNotificationPreferencesUpdateSchema`.
+
 ## Client State Rules
 
 Desktop renderer stores may cache selected IDs, panel state, and validated summaries. They must not cache credentials, raw provider errors, terminal output, file contents beyond the current read-only render state, or unbounded transcripts.

--- a/specs/105-coding-agent-shells/current-state.md
+++ b/specs/105-coding-agent-shells/current-state.md
@@ -1,6 +1,6 @@
 # Current State: Coding Agent Shells
 
-**Branch stack**: `spec/coding-agent-shells` plus stacked implementation branches through `105-coding-agent-notification-prefs`
+**Branch stack**: `spec/coding-agent-shells` plus stacked implementation branches through `105-coding-agent-notification-controls`
 **Updated**: 2026-07-07
 **Scope**: Inventory for the coding-agent desktop/mobile shell work. This file records the current Matrix-native route, contract, client, and regression-test state so later slices keep gateway/runtime as source of truth and keep desktop/mobile as thin shells.
 
@@ -202,6 +202,8 @@ IPC contract:
 
 - `desktop/src/shared/ipc-contract.ts`
 - `runtime:get-summary` returns `RuntimeSummarySchema`.
+- `runtime:get-notification-preferences` returns `CodingAgentNotificationPreferencesSchema` through the trusted main process.
+- `runtime:update-notification-preferences` accepts `CodingAgentNotificationPreferencesUpdateSchema` and returns `CodingAgentNotificationPreferencesSchema` through the trusted main process.
 - `runtime:get-thread-snapshot` accepts a bounded `threadId` and returns `AgentThreadSnapshotSchema`.
 - `runtime:submit-approval-decision` accepts bounded thread/approval ids plus `ApprovalDecisionRequestSchema` fields and returns `AgentThreadSnapshotSchema`.
 - `runtime:submit-input-answer` accepts bounded thread/input request ids plus `UserInputAnswerRequestSchema` fields and returns `AgentThreadSnapshotSchema`.
@@ -218,6 +220,7 @@ Main process:
 
 - `desktop/src/main/coding-agents/runtime-summary-client.ts`
 - Fetches `/api/coding-agents/summary` from the selected runtime origin with bearer auth in the main process.
+- Fetches and updates `/api/coding-agents/notification-preferences` from the selected runtime origin with bearer auth in the main process, validates the gateway `{ preferences }` envelope, and returns only the preference object to the renderer.
 - Fetches `/api/coding-agents/threads/:threadId` from the selected runtime origin with bearer auth in the main process and validates `AgentThreadSnapshotSchema`.
 - Posts approval decisions to `/api/coding-agents/threads/:threadId/approvals/:approvalId/decision` from the main process with bearer auth, a timeout, and `AgentThreadSnapshotSchema` response validation.
 - Posts user-input answers to `/api/coding-agents/threads/:threadId/inputs/:inputRequestId/answer` from the main process with bearer auth, a timeout, and `AgentThreadSnapshotSchema` response validation.
@@ -238,6 +241,7 @@ Renderer:
 Current behavior:
 
 - Read-only dashboard renders providers, gateway-owned attention threads, active threads, and terminals.
+- Notification controls render approval, input, and failed-run attention push preferences, load them through trusted IPC, and submit full replacement updates through trusted IPC with generic error states.
 - Attention thread rows read only from `RuntimeSummarySchema.attentionThreads`, show safe attention labels such as approval/input/failed, and open the existing bounded thread detail path through trusted IPC.
 - Active thread rows with a matching attachable `terminalSessionId` can open the existing desktop Terminal tab for that canonical session; stale or unavailable terminal bindings do not render an action.
 - Selected active threads hydrate a bounded thread snapshot through `runtime:get-thread-snapshot`, show provider/status/terminal metadata, event counts, loading and safe generic error states, and render gateway-bounded snapshot events with generic copy for assistant text, tool output, file changes, approval/input prompts, and unsafe runtime errors.
@@ -271,6 +275,8 @@ Gateway client:
 
 - `apps/mobile/lib/gateway-client.ts`
 - `getCodingAgentRuntimeSummary()` calls `GET /api/coding-agents/summary`, validates `RuntimeSummarySchema`, and returns the safe `"Runtime summary unavailable"` error on failure.
+- `getCodingAgentNotificationPreferences()` calls `GET /api/coding-agents/notification-preferences`, validates the gateway `{ preferences }` envelope with `CodingAgentNotificationPreferencesSchema`, and returns the safe `"Notification settings unavailable"` error on failure.
+- `updateCodingAgentNotificationPreferences()` sends a full `CodingAgentNotificationPreferencesUpdateSchema` body to `PUT /api/coding-agents/notification-preferences`, validates the gateway `{ preferences }` envelope, and returns the safe `"Notification settings could not be saved. Try again."` error on failure.
 - `getCodingAgentThreadSnapshot()` calls `GET /api/coding-agents/threads/:threadId`, validates `AgentThreadSnapshotSchema`, and returns the safe `"Thread state unavailable"` error on failure.
 - `submitCodingAgentApprovalDecision()` posts bounded approval decisions to `POST /api/coding-agents/threads/:threadId/approvals/:approvalId/decision`, validates `AgentThreadSnapshotSchema`, and returns the safe `"Approval could not be sent. Try again."` error on failure.
 - `submitCodingAgentInputAnswer()` posts bounded answers to `POST /api/coding-agents/threads/:threadId/inputs/:inputRequestId/answer`, validates `AgentThreadSnapshotSchema`, and returns the safe `"Input could not be sent. Try again."` error on failure.
@@ -288,6 +294,7 @@ Screen:
 - `apps/mobile/app/agents/new.tsx`
 - `apps/mobile/app/agents/[threadId].tsx`
 - Read-only phone-first dashboard with providers, gateway-owned attention threads, active threads, and terminal sessions.
+- Notification controls render approval, input, and failed-run attention push switches, load them through the authenticated gateway client, submit full replacement updates, and keep preference state transient in component memory.
 - Attention thread rows read only from `RuntimeSummarySchema.attentionThreads`, show safe attention labels such as approval/input/failed, and navigate to the existing bounded thread detail route.
 - When the runtime advertises `codingAgentsReview`, the dashboard fetches bounded review summaries through the authenticated gateway client and renders project, PR, round, status, and high-severity count.
 - Review snapshot details render bounded file paths, additions/deletions, partial markers, selectable hunk coordinate metadata, gateway-bounded hunk lines, and safe finding summaries.
@@ -418,5 +425,5 @@ git diff --check
 - File/review/preview/source-control shell surfaces: read-only review summaries now have coding-agent contracts/routes/desktop IPC/mobile clients plus desktop and mobile read-only review panels. A read-only review snapshot route now exposes bounded diff hunk metadata and capped hunk line bodies from safe owner worktrees plus partial findings-derived fallback metadata for shell diff panels. Runtime summaries now include safe preview summary rows from existing workspace preview records, and the desktop/mobile Agents workspaces render those rows read-only. Desktop also has a read-only preview inspector with HTTPS-only external launch through the existing safe IPC path, mobile has an HTTPS-only preview route using the existing app runtime frame, and the browser Workspace preview panel renders validated active-project coding-agent preview origin/status rows with direct launch limited to HTTPS origins. Gateway now has bounded browse/search/read and conflict-safe write routes for owner worktree files, desktop/mobile review details can render one selected bounded file snapshot through trusted clients, desktop/mobile review details can prepare a local source-control commit through trusted clients, the gateway can create or return a GitHub pull request from a validated owner worktree without exposing credentials, and desktop/mobile review details can trigger that PR creation through trusted clients with generic safe error states and safe HTTPS open actions for the returned pull request URL. Remaining work: browser-shell source-control entry if needed.
 - Approval/input shell actions: desktop and mobile approval decisions plus user-input answers now use trusted gateway clients, bounded UI controls, idempotent request ids, and focused tests. Remaining work: cross-shell resolved-state refresh tests and richer mobile action-sheet polish.
 - Browser shell entry point: Canvas-first placement is still undecided.
-- Notifications/attention routing: desktop notification IPC exists and notification clicks focus the coding-agent workspace thread in the Agents tab with a visible current-thread marker. Gateway runtime summaries expose bounded `attentionThreads` separately from `activeThreads`, allowing failed or waiting attention to be surfaced without reclassifying terminal threads as active. Desktop and mobile dashboards now render the `attentionThreads` list directly. Gateway thread-event sinks can emit safe push-channel payloads for approval-required, input-required, and failed attention events through a capped TTL dedupe registry, per-owner notification preferences can disable approval/input/failed attention push delivery before channel send, and mobile push notification taps can route bounded coding-agent `threadId` payloads into the existing thread detail route. Remaining work: desktop/mobile preference controls and cross-device delivery policy are not yet implemented.
+- Notifications/attention routing: desktop notification IPC exists and notification clicks focus the coding-agent workspace thread in the Agents tab with a visible current-thread marker. Gateway runtime summaries expose bounded `attentionThreads` separately from `activeThreads`, allowing failed or waiting attention to be surfaced without reclassifying terminal threads as active. Desktop and mobile dashboards now render the `attentionThreads` list directly. Gateway thread-event sinks can emit safe push-channel payloads for approval-required, input-required, and failed attention events through a capped TTL dedupe registry, per-owner notification preferences can disable approval/input/failed attention push delivery before channel send, mobile push notification taps can route bounded coding-agent `threadId` payloads into the existing thread detail route, and desktop/mobile Agents workspaces expose transient controls for the three owner-scoped attention push preferences. Remaining work: cross-device delivery policy is not yet implemented.
 - Public docs: public Matrix OS docs and the internal operator runbook are present. Remaining work is keeping them synchronized with later write/source-control, provider setup, and browser entry slices.

--- a/tests/desktop/coding-agent-runtime-client.test.ts
+++ b/tests/desktop/coding-agent-runtime-client.test.ts
@@ -4,12 +4,14 @@ import {
   fetchCodingAgentFileBrowse,
   fetchCodingAgentFileContent,
   fetchCodingAgentFileSearch,
+  fetchCodingAgentNotificationPreferences,
   fetchCodingAgentThreadSnapshot,
   fetchCodingAgentReviewSnapshot,
   prepareCodingAgentSourceCommit,
   saveCodingAgentFileContent,
   submitCodingAgentApprovalDecision,
   submitCodingAgentInputAnswer,
+  updateCodingAgentNotificationPreferences,
 } from "../../desktop/src/main/coding-agents/runtime-summary-client";
 import type { AuthService } from "../../desktop/src/main/auth/auth-service";
 
@@ -186,6 +188,42 @@ function threadSnapshotBody() {
 }
 
 describe("coding agent desktop runtime client", () => {
+  it("fetches and updates notification preferences with bearer auth", async () => {
+    const fetchFn = vi.fn()
+      .mockResolvedValueOnce(new Response(JSON.stringify({ preferences: { attentionPush: { approval: true, input: true, failed: false } } }), { status: 200 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({ preferences: { attentionPush: { approval: true, input: true, failed: true } } }), { status: 200 }));
+
+    await expect(fetchCodingAgentNotificationPreferences(auth(), fetchFn)).resolves.toEqual({
+      attentionPush: { approval: true, input: true, failed: false },
+    });
+    await expect(updateCodingAgentNotificationPreferences(auth(), { attentionPush: { approval: true, input: true, failed: true } }, fetchFn)).resolves.toEqual({
+      attentionPush: { approval: true, input: true, failed: true },
+    });
+    expect(fetchFn).toHaveBeenNthCalledWith(1, "https://runtime.test/api/coding-agents/notification-preferences", expect.objectContaining({
+      method: "GET",
+      headers: expect.objectContaining({ Authorization: "Bearer desktop-token" }),
+      signal: expect.any(Object),
+    }));
+    expect(fetchFn).toHaveBeenNthCalledWith(2, "https://runtime.test/api/coding-agents/notification-preferences", expect.objectContaining({
+      method: "PUT",
+      headers: expect.objectContaining({ Authorization: "Bearer desktop-token" }),
+      body: JSON.stringify({ attentionPush: { approval: true, input: true, failed: true } }),
+      signal: expect.any(Object),
+    }));
+  });
+
+  it("rejects unsafe notification preference payloads with generic errors", async () => {
+    const fetchFn = vi.fn().mockResolvedValue(new Response(JSON.stringify({
+      preferences: {
+        attentionPush: { approval: true, input: true, failed: false },
+        token: "secret",
+      },
+    }), { status: 200 }));
+
+    await expect(fetchCodingAgentNotificationPreferences(auth(), fetchFn)).rejects.toThrow("notification settings unavailable");
+    await expect(updateCodingAgentNotificationPreferences(auth(), { attentionPush: { failed: true } } as never, fetchFn)).rejects.toThrow("notification settings unavailable");
+  });
+
   it("fetches thread snapshots with bearer auth and validates safe output", async () => {
     const fetchFn = vi.fn().mockResolvedValue(new Response(JSON.stringify(threadSnapshotBody()), { status: 200 }));
 

--- a/tests/desktop/coding-agent-workspace.test.tsx
+++ b/tests/desktop/coding-agent-workspace.test.tsx
@@ -673,6 +673,9 @@ describe("AgentWorkspace", () => {
       invoke: vi.fn((channel: string) => {
         if (channel === "runtime:get-summary") return Promise.resolve(summaryFixture());
         if (channel === "runtime:get-reviews") return Promise.resolve(reviewsFixture());
+        if (channel === "runtime:get-notification-preferences") {
+          return Promise.resolve({ attentionPush: { approval: true, input: true, failed: true } });
+        }
         if (channel === "runtime:get-review-snapshot") return Promise.resolve(reviewSnapshotFixture());
         if (channel === "runtime:get-thread-snapshot") return Promise.resolve(threadSnapshotFixture());
         return Promise.reject(new Error("unexpected channel"));
@@ -695,6 +698,39 @@ describe("AgentWorkspace", () => {
     expect(screen.getByText("Fix settings route")).toBeTruthy();
     expect(screen.getByText("matrix-abc1234")).toBeTruthy();
     expect(window.operator.invoke).toHaveBeenCalledWith("runtime:get-summary", {});
+  });
+
+  it("hydrates and updates notification preferences through trusted IPC", async () => {
+    let preferenceReads = 0;
+    window.operator.invoke = vi.fn((channel: string, payload?: unknown) => {
+      if (channel === "runtime:get-summary") return Promise.resolve(summaryFixture());
+      if (channel === "runtime:get-reviews") return Promise.resolve(reviewsFixture());
+      if (channel === "runtime:get-notification-preferences") {
+        preferenceReads += 1;
+        return Promise.resolve(preferenceReads === 1
+          ? { attentionPush: { approval: true, input: true, failed: false } }
+          : { attentionPush: { approval: false, input: true, failed: false } });
+      }
+      if (channel === "runtime:update-notification-preferences") {
+        return Promise.resolve({ attentionPush: { approval: false, input: true, failed: true } });
+      }
+      return Promise.reject(new Error(`unexpected channel ${channel}`));
+    });
+
+    render(<AgentWorkspace />);
+
+    const failedToggle = await screen.findByRole("checkbox", { name: "Failed run alerts" });
+    expect((failedToggle as HTMLInputElement).checked).toBe(false);
+
+    fireEvent.click(failedToggle);
+
+    await waitFor(() => {
+      expect(window.operator.invoke).toHaveBeenCalledWith("runtime:update-notification-preferences", {
+        attentionPush: { approval: false, input: true, failed: true },
+      });
+    });
+    expect((await screen.findByRole("checkbox", { name: "Failed run alerts" }) as HTMLInputElement).checked).toBe(true);
+    expect(screen.queryByText(/token|bearer|secret|\/home\/matrix/i)).toBeNull();
   });
 
   it("marks the active coding-agent thread as current in the thread list", async () => {

--- a/tests/desktop/ipc-contract.test.ts
+++ b/tests/desktop/ipc-contract.test.ts
@@ -14,6 +14,8 @@ describe("IPC contract", () => {
       "auth:status",
       "auth:sign-out",
       "runtime:create-thread",
+      "runtime:get-notification-preferences",
+      "runtime:update-notification-preferences",
       "runtime:submit-approval-decision",
       "runtime:submit-input-answer",
       "runtime:get-thread-snapshot",
@@ -251,6 +253,18 @@ describe("IPC contract", () => {
 
     expect(schema.safeParse(valid).success).toBe(true);
     expect(schema.safeParse({ ...valid, accessToken: "secret" }).success).toBe(false);
+  });
+
+  it("validates notification preference IPC without credential fields", () => {
+    const getSchema = INVOKE_CHANNELS["runtime:get-notification-preferences"].response;
+    const updateRequestSchema = INVOKE_CHANNELS["runtime:update-notification-preferences"].request;
+    const updateResponseSchema = INVOKE_CHANNELS["runtime:update-notification-preferences"].response;
+
+    expect(getSchema.safeParse({ attentionPush: { approval: true, input: true, failed: false } }).success).toBe(true);
+    expect(getSchema.safeParse({ attentionPush: { approval: true, input: true, failed: false }, accessToken: "secret" }).success).toBe(false);
+    expect(updateRequestSchema.safeParse({ attentionPush: { approval: false, input: true, failed: true } }).success).toBe(true);
+    expect(updateRequestSchema.safeParse({ attentionPush: { approval: false, input: true, failed: true }, bearerToken: "secret" }).success).toBe(false);
+    expect(updateResponseSchema.safeParse({ attentionPush: { approval: false, input: true, failed: true } }).success).toBe(true);
   });
 
   it("validates runtime:get-reviews responses and rejects credential leakage shapes", () => {

--- a/www/content/docs/coding-agents.mdx
+++ b/www/content/docs/coding-agents.mdx
@@ -118,7 +118,7 @@ Threads may need attention when an agent:
 - fails and needs review;
 - finishes with results to inspect.
 
-Attention appears in the workspace and can route you to the matching thread. Mobile notification taps and desktop notification clicks use bounded thread references and rehydrate the current thread state before rendering. When notification preferences are configured, Matrix applies them on the gateway before sending approval, input, or failure alerts.
+Attention appears in the workspace and can route you to the matching thread. Mobile notification taps and desktop notification clicks use bounded thread references and rehydrate the current thread state before rendering. Desktop and mobile can also turn approval, input, and failed-run push alerts on or off from the coding workspace. Matrix applies those preferences on the gateway before sending attention alerts.
 
 ## Approvals and input
 


### PR DESCRIPTION
## Summary
- add desktop trusted IPC and main-process clients for coding-agent notification preferences
- add desktop and mobile Agents workspace controls for approval, input, and failed-run attention push preferences
- serialize preference updates by rehydrating latest gateway preferences before each full replacement save, avoiding stale cross-shell overwrites and rapid-toggle drops
- add mobile gateway-client methods and update internal/public docs for the preference control boundary

## Tests
- pnpm exec vitest run tests/desktop/ipc-contract.test.ts tests/desktop/coding-agent-runtime-client.test.ts tests/desktop/coding-agent-workspace.test.tsx
- pnpm --filter matrix-os-mobile exec jest __tests__/gateway-client.test.ts __tests__/agents-screen.test.tsx --runInBand
- pnpm --filter desktop run typecheck
- pnpm --filter matrix-os-mobile exec tsc --noEmit
- pnpm --filter matrix-os-mobile run lint
- pnpm --filter matrix-os-mobile run test --runInBand
- bun run check:patterns
- bun run typecheck
- git diff --check
- forbidden-reference scan over touched files

Note: `vp` is not installed in this worktree environment (`command -v vp` returned no path), so the equivalent package gates above were run directly.

## Review/Monitoring
- Stacked on #815 / `105-coding-agent-notification-prefs`
- Current head includes fixes for stale cross-shell preference replacement and rapid local toggle coalescing
- Do not add `ready-for-ci` until the latest trusted Greptile review on this head is 5/5

## Invariants
- Source of truth: gateway-owned notification preference routes and owner-scoped persistence remain authoritative; shells only render and submit validated preferences.
- Lock/transaction scope: no new database writes or lock scopes; existing owner-file atomic write behavior is reused by the gateway route from the parent stack.
- Acceptable orphan states: if preference reads or writes fail, shells keep runtime summaries usable and show generic recovery-oriented errors.
- Auth source of truth: desktop bearer auth stays in the main process; mobile uses the authenticated gateway client; renderer/mobile UI never receives provider credentials.
- Deferred scope: cross-device delivery policy remains a follow-up; this PR only adds read/update controls for the existing owner-scoped attention push preferences.