### PR TITLE
feat(desktop): open agents from command palette

### DIFF
--- a/desktop/src/renderer/src/features/palette/CommandPalette.tsx
+++ b/desktop/src/renderer/src/features/palette/CommandPalette.tsx
@@ -1,6 +1,6 @@
 import { Command } from "cmdk";
 import { useEffect } from "react";
-import { Home, Kanban, LayoutGrid, MessageSquarePlus, PanelsTopLeft, Plus, Settings, Sparkles, SquareTerminal } from "lucide-react";
+import { Bot, Home, Kanban, LayoutGrid, MessageSquarePlus, PanelsTopLeft, Plus, Settings, Sparkles, SquareTerminal } from "lucide-react";
 import { appIconUrl, useApps } from "../../stores/apps";
 import { useBoard } from "../../stores/board";
 import { useConnection } from "../../stores/connection";
@@ -8,6 +8,7 @@ import { useShellSessions } from "../../stores/shell-sessions";
 import { useTabs } from "../../stores/tabs";
 import { useThreads } from "../../stores/threads";
 import { useUi } from "../../stores/ui";
+import { CODING_AGENTS_DESKTOP_WORKSPACE } from "../../lib/feature-flags";
 
 export default function CommandPalette() {
   const open = useUi((s) => s.paletteOpen);
@@ -102,6 +103,9 @@ export default function CommandPalette() {
               }
             />
             <PaletteItem icon={<MessageSquarePlus size={14} />} label="New agent run" shortcut="⌘J" onSelect={() => run(() => setComposerOpen(true))} />
+            {CODING_AGENTS_DESKTOP_WORKSPACE ? (
+              <PaletteItem icon={<Bot size={14} />} label="Open Agents" onSelect={() => run(() => openTab({ kind: "agents", title: "Agents" }))} />
+            ) : null}
             <PaletteItem icon={<Home size={14} />} label="Go to Home" onSelect={() => run(() => openTab({ kind: "home", title: "Home", closable: false }))} />
             <PaletteItem icon={<SquareTerminal size={14} />} label="Open Terminal" onSelect={() => run(() => openTab({ kind: "terminals", title: "Terminal" }))} />
             <PaletteItem icon={<LayoutGrid size={14} />} label="Open Apps" onSelect={() => run(() => openTab({ kind: "apps", title: "Apps" }))} />

--- a/specs/105-coding-agent-shells/current-state.md
+++ b/specs/105-coding-agent-shells/current-state.md
@@ -245,7 +245,7 @@ Renderer:
 
 Current behavior:
 
-- Read-only dashboard renders providers, gateway-owned attention threads, active threads, and terminals.
+- Read-only dashboard renders providers, gateway-owned attention threads, active threads, and terminals. The desktop command palette opens the same Agents tab through the existing tab store when the desktop coding-agent workspace flag is enabled.
 - Notification controls render approval, input, and failed-run attention push preferences, load them through trusted IPC, and submit full replacement updates through trusted IPC with generic error states.
 - Attention thread rows read only from `RuntimeSummarySchema.attentionThreads`, show safe attention labels such as approval/input/failed, and open the existing bounded thread detail path through trusted IPC.
 - Active thread rows with a matching attachable `terminalSessionId` can open the existing desktop Terminal tab for that canonical session; stale or unavailable terminal bindings do not render an action.

--- a/tests/desktop/command-palette.test.tsx
+++ b/tests/desktop/command-palette.test.tsx
@@ -3,6 +3,11 @@
 import React from "react";
 import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../desktop/src/renderer/src/lib/feature-flags", () => ({
+  CODING_AGENTS_DESKTOP_WORKSPACE: true,
+}));
+
 import CommandPalette from "../../desktop/src/renderer/src/features/palette/CommandPalette";
 import { useApps } from "../../desktop/src/renderer/src/stores/apps";
 import { useBoard } from "../../desktop/src/renderer/src/stores/board";
@@ -80,6 +85,20 @@ describe("CommandPalette", () => {
       kind: "terminal",
       sessionName: "matrix-main",
       title: "matrix-main",
+    });
+  });
+
+  it("opens the coding-agent workspace from the command palette", async () => {
+    const openTab = vi.fn();
+    useTabs.setState({ openTab });
+
+    render(<CommandPalette />);
+
+    fireEvent.click(screen.getByText("Open Agents"));
+
+    expect(openTab).toHaveBeenCalledWith({
+      kind: "agents",
+      title: "Agents",
     });
   });
 });

--- a/www/content/docs/coding-agents.mdx
+++ b/www/content/docs/coding-agents.mdx
@@ -181,7 +181,7 @@ On mobile, use the coding-agent workspace to check active work, answer approvals
 
 ## Desktop workflow
 
-On desktop, the coding-agent workspace is the mission-control view for multiple threads. Use it to compare active work, open bound terminals, inspect reviews, answer approvals, and open safe previews without exposing provider credentials to the renderer.
+On desktop, the coding-agent workspace is the mission-control view for multiple threads. Open it from the sidebar or command palette, then use it to compare active work, open bound terminals, inspect reviews, answer approvals, and open safe previews without exposing provider credentials to the renderer.
 
 ## Related
 


### PR DESCRIPTION
## Summary
- Add a gated `Open Agents` command palette action that opens the existing Agents tab.
- Reuse the existing tab store and desktop workspace flag; no runtime behavior changes.
- Update command palette coverage plus coding-agent docs/current-state notes.

## Tests
- `pnpm exec vitest run tests/desktop/command-palette.test.tsx`
- `pnpm --filter desktop run typecheck`
- `bun run check:patterns`
- `bun run typecheck`
- `git diff --check`
- Scoped hygiene scan over changed paths: no prohibited strings

## Review/Monitoring
- Awaiting automated review on the latest head.
- `ready-for-ci` will be added only after latest trusted review is 5/5.

## Invariants
- Source of truth: desktop tab store and gateway-owned Agents workspace remain authoritative; the palette only opens the existing tab.
- Lock/transaction scope: no backend writes or persistence changes.
- Acceptable orphan states: if the desktop workspace flag is disabled, the command is not rendered.
- Auth source of truth: no credentials added or exposed; no IPC/gateway auth changes.
- Deferred scope: deeper command actions for specific threads, reviews, and provider setup remain later slices.