### PR TITLE
feat(desktop): open agents from app menu

### DIFF
--- a/desktop/electron.vite.config.ts
+++ b/desktop/electron.vite.config.ts
@@ -5,12 +5,15 @@ import { resolve } from "node:path";
 
 const desktopUpdateChannel =
   process.env.MATRIX_DESKTOP_UPDATE_CHANNEL || process.env.OPERATOR_UPDATE_CHANNEL || "";
+const codingAgentsDesktopWorkspace =
+  process.env.VITE_CODING_AGENTS_DESKTOP_WORKSPACE !== "0";
 
 export default defineConfig({
   main: {
     plugins: [externalizeDepsPlugin()],
     define: {
       __MATRIX_DESKTOP_UPDATE_CHANNEL__: JSON.stringify(desktopUpdateChannel),
+      __CODING_AGENTS_DESKTOP_WORKSPACE__: JSON.stringify(codingAgentsDesktopWorkspace),
     },
     build: {
       rollupOptions: {

--- a/desktop/src/main/platform/menu-feature-flags.ts
+++ b/desktop/src/main/platform/menu-feature-flags.ts
@@ -1,0 +1,13 @@
+declare const __CODING_AGENTS_DESKTOP_WORKSPACE__: boolean | undefined;
+
+function bundledCodingAgentsDesktopWorkspace(): boolean | undefined {
+  return typeof __CODING_AGENTS_DESKTOP_WORKSPACE__ === "boolean"
+    ? __CODING_AGENTS_DESKTOP_WORKSPACE__
+    : undefined;
+}
+
+export function resolveCodingAgentsDesktopWorkspaceFlag(
+  bundledFlag: boolean | undefined = bundledCodingAgentsDesktopWorkspace(),
+): boolean {
+  return bundledFlag !== false;
+}

--- a/desktop/src/main/platform/menu-template.ts
+++ b/desktop/src/main/platform/menu-template.ts
@@ -1,0 +1,103 @@
+import type { MenuItemConstructorOptions } from "electron";
+
+type MenuEventSender = (channel: string, payload: unknown) => void;
+
+interface AppMenuTemplateOptions {
+  appName: string;
+  codingAgentsWorkspace: boolean;
+  isPackaged: boolean;
+  openExternal(url: string): void;
+  send: MenuEventSender;
+}
+
+export function createAppMenuTemplate({
+  appName,
+  codingAgentsWorkspace,
+  isPackaged,
+  openExternal,
+  send,
+}: AppMenuTemplateOptions): MenuItemConstructorOptions[] {
+  const viewSubmenu: MenuItemConstructorOptions[] = [
+    {
+      label: "Command Palette",
+      accelerator: "Cmd+K",
+      click: () => send("menu:action", { action: "palette" }),
+    },
+    {
+      label: "Go to File",
+      accelerator: "Cmd+P",
+      click: () => send("menu:action", { action: "quick-open" }),
+    },
+  ];
+
+  if (codingAgentsWorkspace) {
+    viewSubmenu.push({
+      label: "Agents",
+      accelerator: "Cmd+Shift+A",
+      click: () => send("menu:navigate", { kind: "agents" }),
+    });
+  }
+
+  viewSubmenu.push(
+    { type: "separator" },
+    { role: "togglefullscreen" },
+    ...(isPackaged
+      ? []
+      : ([{ type: "separator" }, { role: "reload" }, { role: "toggleDevTools" }] as MenuItemConstructorOptions[])),
+  );
+
+  return [
+    {
+      label: appName,
+      submenu: [
+        { role: "about" },
+        { type: "separator" },
+        {
+          label: "Settings…",
+          accelerator: "Cmd+,",
+          click: () => send("menu:navigate", { kind: "settings" }),
+        },
+        { type: "separator" },
+        { role: "services" },
+        { type: "separator" },
+        { role: "hide" },
+        { role: "hideOthers" },
+        { role: "unhide" },
+        { type: "separator" },
+        { role: "quit" },
+      ],
+    },
+    {
+      label: "File",
+      submenu: [
+        {
+          label: "New Task",
+          accelerator: "Cmd+N",
+          click: () => send("menu:action", { action: "new-task" }),
+        },
+        {
+          label: "New Agent Thread",
+          accelerator: "Cmd+J",
+          click: () => send("menu:action", { action: "new-thread" }),
+        },
+        { type: "separator" },
+        { role: "close" },
+      ],
+    },
+    { role: "editMenu" },
+    {
+      label: "View",
+      submenu: viewSubmenu,
+    },
+    { role: "windowMenu" },
+    {
+      role: "help",
+      submenu: [
+        {
+          label: "Matrix OS Documentation",
+          click: () => openExternal("https://matrix-os.com/docs"),
+        },
+      ],
+    },
+  ];
+}

--- a/desktop/src/main/platform/menu.ts
+++ b/desktop/src/main/platform/menu.ts
@@ -1,84 +1,23 @@
 // macOS application menu (US6): standard roles so copy/paste, window
 // management, and full-screen behave like a first-class Mac app.
-import { app, Menu, shell, type BrowserWindow, type MenuItemConstructorOptions } from "electron";
+import { app, Menu, shell, type BrowserWindow } from "electron";
+import { resolveCodingAgentsDesktopWorkspaceFlag } from "./menu-feature-flags";
+import { createAppMenuTemplate } from "./menu-template";
 
 export function installAppMenu(getWindow: () => BrowserWindow | null): void {
   const send = (channel: string, payload: unknown) => {
     getWindow()?.webContents.send(channel, payload);
   };
 
-  const template: MenuItemConstructorOptions[] = [
-    {
-      label: app.name,
-      submenu: [
-        { role: "about" },
-        { type: "separator" },
-        {
-          label: "Settings…",
-          accelerator: "Cmd+,",
-          click: () => send("menu:navigate", { kind: "settings" }),
-        },
-        { type: "separator" },
-        { role: "services" },
-        { type: "separator" },
-        { role: "hide" },
-        { role: "hideOthers" },
-        { role: "unhide" },
-        { type: "separator" },
-        { role: "quit" },
-      ],
+  const template = createAppMenuTemplate({
+    appName: app.name,
+    codingAgentsWorkspace: resolveCodingAgentsDesktopWorkspaceFlag(),
+    isPackaged: app.isPackaged,
+    openExternal: (url) => {
+      void shell.openExternal(url);
     },
-    {
-      label: "File",
-      submenu: [
-        {
-          label: "New Task",
-          accelerator: "Cmd+N",
-          click: () => send("menu:action", { action: "new-task" }),
-        },
-        {
-          label: "New Agent Thread",
-          accelerator: "Cmd+J",
-          click: () => send("menu:action", { action: "new-thread" }),
-        },
-        { type: "separator" },
-        { role: "close" },
-      ],
-    },
-    { role: "editMenu" },
-    {
-      label: "View",
-      submenu: [
-        {
-          label: "Command Palette",
-          accelerator: "Cmd+K",
-          click: () => send("menu:action", { action: "palette" }),
-        },
-        {
-          label: "Go to File",
-          accelerator: "Cmd+P",
-          click: () => send("menu:action", { action: "quick-open" }),
-        },
-        { type: "separator" },
-        { role: "togglefullscreen" },
-        ...(app.isPackaged
-          ? []
-          : ([{ type: "separator" }, { role: "reload" }, { role: "toggleDevTools" }] as MenuItemConstructorOptions[])),
-      ],
-    },
-    { role: "windowMenu" },
-    {
-      role: "help",
-      submenu: [
-        {
-          label: "Matrix OS Documentation",
-          click: () => {
-            void shell.openExternal("https://matrix-os.com/docs");
-          },
-        },
-      ],
-    },
-  ];
+    send,
+  });
 
   Menu.setApplicationMenu(Menu.buildFromTemplate(template));
 }

--- a/desktop/src/renderer/src/features/mission-control/shortcuts.ts
+++ b/desktop/src/renderer/src/features/mission-control/shortcuts.ts
@@ -27,6 +27,10 @@ export function handleMenuNavigate(kind: string): void {
     useTabs.getState().openTab({ kind: "settings", title: "Settings" });
     return;
   }
+  if (kind === "agents") {
+    useTabs.getState().openTab({ kind: "agents", title: "Agents" });
+    return;
+  }
   if (kind === "board") {
     const { activeProjectSlug, projects } = useBoard.getState();
     const project = projects.find((candidate) => candidate.slug === activeProjectSlug) ?? projects[0];

--- a/desktop/src/shared/ipc-contract.ts
+++ b/desktop/src/shared/ipc-contract.ts
@@ -321,7 +321,7 @@ export const EVENT_CHANNELS = {
   "menu:action": z
     .object({ action: z.enum(["new-task", "new-thread", "palette", "quick-open"]) })
     .strict(),
-  "menu:navigate": z.object({ kind: z.enum(["settings", "board"]) }).strict(),
+  "menu:navigate": z.object({ kind: z.enum(["settings", "board", "agents"]) }).strict(),
 } as const;
 
 export type InvokeChannel = keyof typeof INVOKE_CHANNELS;

--- a/specs/105-coding-agent-shells/current-state.md
+++ b/specs/105-coding-agent-shells/current-state.md
@@ -245,7 +245,7 @@ Renderer:
 
 Current behavior:
 
-- Read-only dashboard renders providers, gateway-owned attention threads, active threads, and terminals. The desktop command palette opens the same Agents tab through the existing tab store when the desktop coding-agent workspace flag is enabled.
+- Read-only dashboard renders providers, gateway-owned attention threads, active threads, and terminals. The desktop command palette and app menu open the same Agents tab through the existing tab store when the desktop coding-agent workspace flag is enabled.
 - Notification controls render approval, input, and failed-run attention push preferences, load them through trusted IPC, and submit full replacement updates through trusted IPC with generic error states.
 - Attention thread rows read only from `RuntimeSummarySchema.attentionThreads`, show safe attention labels such as approval/input/failed, and open the existing bounded thread detail path through trusted IPC.
 - Active thread rows with a matching attachable `terminalSessionId` can open the existing desktop Terminal tab for that canonical session; stale or unavailable terminal bindings do not render an action.

--- a/tests/desktop/ipc-contract.test.ts
+++ b/tests/desktop/ipc-contract.test.ts
@@ -707,5 +707,6 @@ describe("IPC contract", () => {
       EVENT_CHANNELS["embed:state"].safeParse({ embedId: "e", state: "auth-required" }).success,
     ).toBe(true);
     expect(EVENT_CHANNELS["embed:state"].safeParse({ embedId: "e", state: "??" }).success).toBe(false);
+    expect(EVENT_CHANNELS["menu:navigate"].safeParse({ kind: "agents" }).success).toBe(true);
   });
 });

--- a/tests/desktop/menu-feature-flags.test.ts
+++ b/tests/desktop/menu-feature-flags.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "vitest";
+import { resolveCodingAgentsDesktopWorkspaceFlag } from "../../desktop/src/main/platform/menu-feature-flags";
+
+describe("resolveCodingAgentsDesktopWorkspaceFlag", () => {
+  it("keeps the Agents menu enabled by default", () => {
+    expect(resolveCodingAgentsDesktopWorkspaceFlag(undefined)).toBe(true);
+  });
+
+  it("uses the bundled desktop workspace build flag when present", () => {
+    expect(resolveCodingAgentsDesktopWorkspaceFlag(true)).toBe(true);
+    expect(resolveCodingAgentsDesktopWorkspaceFlag(false)).toBe(false);
+  });
+});

--- a/tests/desktop/menu-template.test.ts
+++ b/tests/desktop/menu-template.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it, vi } from "vitest";
+import { createAppMenuTemplate } from "../../desktop/src/main/platform/menu-template";
+
+describe("createAppMenuTemplate", () => {
+  it("adds a gated Agents menu entry that navigates to the coding-agent workspace", () => {
+    const send = vi.fn();
+    const template = createAppMenuTemplate({
+      appName: "Matrix OS",
+      codingAgentsWorkspace: true,
+      isPackaged: true,
+      openExternal: vi.fn(),
+      send,
+    });
+
+    const viewMenu = template.find((item) => item.label === "View");
+    const agentsItem = Array.isArray(viewMenu?.submenu)
+      ? viewMenu.submenu.find((item) => "label" in item && item.label === "Agents")
+      : null;
+
+    expect(agentsItem).toBeTruthy();
+    if (!agentsItem || !("click" in agentsItem) || typeof agentsItem.click !== "function") {
+      throw new Error("Agents menu item is not clickable");
+    }
+
+    agentsItem.click({} as never, {} as never, {} as never);
+
+    expect(send).toHaveBeenCalledWith("menu:navigate", { kind: "agents" });
+  });
+
+  it("omits the Agents menu entry when the desktop workspace flag is disabled", () => {
+    const template = createAppMenuTemplate({
+      appName: "Matrix OS",
+      codingAgentsWorkspace: false,
+      isPackaged: true,
+      openExternal: vi.fn(),
+      send: vi.fn(),
+    });
+
+    const viewMenu = template.find((item) => item.label === "View");
+    const agentsItem = Array.isArray(viewMenu?.submenu)
+      ? viewMenu.submenu.find((item) => "label" in item && item.label === "Agents")
+      : null;
+
+    expect(agentsItem).toBeUndefined();
+  });
+});

--- a/tests/desktop/shortcuts.test.ts
+++ b/tests/desktop/shortcuts.test.ts
@@ -107,6 +107,15 @@ describe("handleMenuNavigate", () => {
     });
   });
 
+  it("opens the coding-agent workspace from menu navigation", () => {
+    handleMenuNavigate("agents");
+
+    expect(useTabs.getState().tabs[0]).toMatchObject({
+      kind: "agents",
+      title: "Agents",
+    });
+  });
+
   it("falls back to home and logs unsupported menu kinds", () => {
     const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
 

--- a/www/content/docs/coding-agents.mdx
+++ b/www/content/docs/coding-agents.mdx
@@ -181,7 +181,7 @@ On mobile, use the coding-agent workspace to check active work, answer approvals
 
 ## Desktop workflow
 
-On desktop, the coding-agent workspace is the mission-control view for multiple threads. Open it from the sidebar or command palette, then use it to compare active work, open bound terminals, inspect reviews, answer approvals, and open safe previews without exposing provider credentials to the renderer.
+On desktop, the coding-agent workspace is the mission-control view for multiple threads. Open it from the sidebar, command palette, or app menu, then use it to compare active work, open bound terminals, inspect reviews, answer approvals, and open safe previews without exposing provider credentials to the renderer.
 
 ## Related
 


### PR DESCRIPTION
## Summary
- Add a gated desktop app menu entry for opening the Agents workspace.
- Extend the typed `menu:navigate` IPC schema and renderer shortcut handler to support the existing Agents tab.
- Extract the desktop app menu template into a pure helper with focused tests, and update coding-agent docs/current-state.

## Tests
- `pnpm exec vitest run tests/desktop/shortcuts.test.ts tests/desktop/ipc-contract.test.ts tests/desktop/menu-template.test.ts`
- `pnpm --filter desktop run typecheck`
- `bun run check:patterns`
- `bun run typecheck`
- `git diff --check`
- Scoped hygiene scan over changed paths: no prohibited strings

## Review/Monitoring
- Awaiting automated review on the latest head.
- `ready-for-ci` will be added only after latest trusted review is 5/5.

## Invariants
- Source of truth: desktop tab store and the existing Agents workspace remain authoritative; the app menu only sends typed navigation to open that tab.
- Lock/transaction scope: no backend writes, persistence, or transaction changes.
- Acceptable orphan states: if the desktop workspace flag is disabled, the app menu omits the Agents item.
- Auth source of truth: no credentials added or exposed; IPC schema is schema-only and carries only a bounded navigation kind.
- Deferred scope: deeper menu actions for specific threads, reviews, provider setup, and file search remain later slices.