### PR TITLE
feat(desktop): add terminal focus shortcut

### DIFF
--- a/desktop/src/main/platform/menu-template.ts
+++ b/desktop/src/main/platform/menu-template.ts
@@ -28,6 +28,11 @@ export function createAppMenuTemplate({
       accelerator: "Cmd+P",
       click: () => send("menu:action", { action: "quick-open" }),
     },
+    {
+      label: "Terminal",
+      accelerator: "Cmd+Alt+T",
+      click: () => send("menu:navigate", { kind: "terminals" }),
+    },
   ];
 
   if (codingAgentsWorkspace) {

--- a/desktop/src/renderer/src/features/mission-control/shortcuts.ts
+++ b/desktop/src/renderer/src/features/mission-control/shortcuts.ts
@@ -16,10 +16,23 @@ interface CycleTabShortcutState {
   focusTab(id: string): void;
 }
 
+interface TerminalFocusShortcutState {
+  tabs: Array<{ id: string; kind: string }>;
+  focusTab(id: string): void;
+  openTab(spec: { kind: "terminals"; title: string }): void;
+}
+
 function isTypingTarget(target: EventTarget | null): boolean {
   if (!(target instanceof HTMLElement)) return false;
   const tag = target.tagName;
   return tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT" || target.isContentEditable;
+}
+
+export function isTerminalFocusShortcut(
+  event: Pick<KeyboardEvent, "altKey" | "ctrlKey" | "key" | "metaKey" | "shiftKey">,
+): boolean {
+  const meta = event.metaKey || event.ctrlKey;
+  return meta && event.altKey && !event.shiftKey && event.key.toLowerCase() === "t";
 }
 
 export function handleMenuNavigate(kind: string): void {
@@ -29,6 +42,10 @@ export function handleMenuNavigate(kind: string): void {
   }
   if (kind === "agents") {
     useTabs.getState().openTab({ kind: "agents", title: "Agents" });
+    return;
+  }
+  if (kind === "terminals") {
+    handleTerminalFocusShortcut({ preventDefault: () => undefined }, useTabs.getState());
     return;
   }
   if (kind === "board") {
@@ -78,6 +95,19 @@ export function handleCycleTabShortcut(
   if (next) tabs.focusTab(next.id);
 }
 
+export function handleTerminalFocusShortcut(
+  event: Pick<KeyboardEvent, "preventDefault">,
+  tabs: TerminalFocusShortcutState,
+): void {
+  event.preventDefault();
+  const existing = tabs.tabs.find((tab) => tab.kind === "terminal" || tab.kind === "terminals");
+  if (existing) {
+    tabs.focusTab(existing.id);
+    return;
+  }
+  tabs.openTab({ kind: "terminals", title: "Terminal" });
+}
+
 export function useGlobalShortcuts(): void {
   useEffect(() => {
     const onKeyDown = (e: KeyboardEvent) => {
@@ -99,6 +129,10 @@ export function useGlobalShortcuts(): void {
       if (meta && key === "p") {
         e.preventDefault();
         ui.setQuickOpenOpen(!ui.quickOpenOpen);
+        return;
+      }
+      if (isTerminalFocusShortcut(e)) {
+        handleTerminalFocusShortcut(e, tabs);
         return;
       }
       // New chat with the OS agent.

--- a/desktop/src/shared/ipc-contract.ts
+++ b/desktop/src/shared/ipc-contract.ts
@@ -321,7 +321,7 @@ export const EVENT_CHANNELS = {
   "menu:action": z
     .object({ action: z.enum(["new-task", "new-thread", "palette", "quick-open"]) })
     .strict(),
-  "menu:navigate": z.object({ kind: z.enum(["settings", "board", "agents"]) }).strict(),
+  "menu:navigate": z.object({ kind: z.enum(["settings", "board", "agents", "terminals"]) }).strict(),
 } as const;
 
 export type InvokeChannel = keyof typeof INVOKE_CHANNELS;

--- a/specs/105-coding-agent-shells/current-state.md
+++ b/specs/105-coding-agent-shells/current-state.md
@@ -246,6 +246,7 @@ Renderer:
 Current behavior:
 
 - Read-only dashboard renders providers, gateway-owned attention threads, active threads, and terminals. The desktop command palette and app menu open the same Agents tab through the existing tab store when the desktop coding-agent workspace flag is enabled.
+- Desktop keyboard flow can focus an existing Terminal tab or open the Terminal workspace through the app menu `Terminal` action and the matching global shortcut.
 - Notification controls render approval, input, and failed-run attention push preferences, load them through trusted IPC, and submit full replacement updates through trusted IPC with generic error states.
 - Attention thread rows read only from `RuntimeSummarySchema.attentionThreads`, show safe attention labels such as approval/input/failed, and open the existing bounded thread detail path through trusted IPC.
 - Active thread rows with a matching attachable `terminalSessionId` can open the existing desktop Terminal tab for that canonical session; stale or unavailable terminal bindings do not render an action.

--- a/tests/desktop/ipc-contract.test.ts
+++ b/tests/desktop/ipc-contract.test.ts
@@ -708,5 +708,6 @@ describe("IPC contract", () => {
     ).toBe(true);
     expect(EVENT_CHANNELS["embed:state"].safeParse({ embedId: "e", state: "??" }).success).toBe(false);
     expect(EVENT_CHANNELS["menu:navigate"].safeParse({ kind: "agents" }).success).toBe(true);
+    expect(EVENT_CHANNELS["menu:navigate"].safeParse({ kind: "terminals" }).success).toBe(true);
   });
 });

--- a/tests/desktop/menu-template.test.ts
+++ b/tests/desktop/menu-template.test.ts
@@ -2,6 +2,32 @@ import { describe, expect, it, vi } from "vitest";
 import { createAppMenuTemplate } from "../../desktop/src/main/platform/menu-template";
 
 describe("createAppMenuTemplate", () => {
+  it("adds a Terminal menu entry that navigates to the terminal workspace", () => {
+    const send = vi.fn();
+    const template = createAppMenuTemplate({
+      appName: "Matrix OS",
+      codingAgentsWorkspace: true,
+      isPackaged: true,
+      openExternal: vi.fn(),
+      send,
+    });
+
+    const viewMenu = template.find((item) => item.label === "View");
+    const terminalItem = Array.isArray(viewMenu?.submenu)
+      ? viewMenu.submenu.find((item) => "label" in item && item.label === "Terminal")
+      : null;
+
+    expect(terminalItem).toBeTruthy();
+    expect(terminalItem && "accelerator" in terminalItem ? terminalItem.accelerator : null).toBe("Cmd+Alt+T");
+    if (!terminalItem || !("click" in terminalItem) || typeof terminalItem.click !== "function") {
+      throw new Error("Terminal menu item is not clickable");
+    }
+
+    terminalItem.click({} as never, {} as never, {} as never);
+
+    expect(send).toHaveBeenCalledWith("menu:navigate", { kind: "terminals" });
+  });
+
   it("adds a gated Agents menu entry that navigates to the coding-agent workspace", () => {
     const send = vi.fn();
     const template = createAppMenuTemplate({

--- a/tests/desktop/shortcuts.test.ts
+++ b/tests/desktop/shortcuts.test.ts
@@ -3,6 +3,8 @@ import {
   handleCycleTabShortcut,
   handleCloseTabShortcut,
   handleMenuNavigate,
+  handleTerminalFocusShortcut,
+  isTerminalFocusShortcut,
 } from "@desktop/renderer/src/features/mission-control/shortcuts";
 import { useBoard } from "@desktop/renderer/src/stores/board";
 import { useTabs } from "@desktop/renderer/src/stores/tabs";
@@ -81,6 +83,66 @@ describe("handleCycleTabShortcut", () => {
   });
 });
 
+describe("handleTerminalFocusShortcut", () => {
+  it("matches only the exact terminal focus modifier chord", () => {
+    expect(isTerminalFocusShortcut({
+      altKey: true,
+      ctrlKey: false,
+      key: "t",
+      metaKey: true,
+      shiftKey: false,
+    })).toBe(true);
+    expect(isTerminalFocusShortcut({
+      altKey: true,
+      ctrlKey: false,
+      key: "t",
+      metaKey: true,
+      shiftKey: true,
+    })).toBe(false);
+  });
+
+  it("prevents default and focuses an existing terminal tab", () => {
+    const preventDefault = vi.fn();
+    const focusTab = vi.fn();
+    const openTab = vi.fn();
+
+    handleTerminalFocusShortcut(
+      { preventDefault },
+      {
+        tabs: [
+          { id: "home", kind: "home" },
+          { id: "term", kind: "terminal" },
+        ],
+        focusTab,
+        openTab,
+      },
+    );
+
+    expect(preventDefault).toHaveBeenCalledTimes(1);
+    expect(focusTab).toHaveBeenCalledWith("term");
+    expect(openTab).not.toHaveBeenCalled();
+  });
+
+  it("opens the terminal workspace when no terminal tab exists", () => {
+    const preventDefault = vi.fn();
+    const focusTab = vi.fn();
+    const openTab = vi.fn();
+
+    handleTerminalFocusShortcut(
+      { preventDefault },
+      {
+        tabs: [{ id: "home", kind: "home" }],
+        focusTab,
+        openTab,
+      },
+    );
+
+    expect(preventDefault).toHaveBeenCalledTimes(1);
+    expect(focusTab).not.toHaveBeenCalled();
+    expect(openTab).toHaveBeenCalledWith({ kind: "terminals", title: "Terminal" });
+  });
+});
+
 describe("handleMenuNavigate", () => {
   beforeEach(() => {
     useBoard.setState({
@@ -114,6 +176,15 @@ describe("handleMenuNavigate", () => {
       kind: "agents",
       title: "Agents",
     });
+  });
+
+  it("focuses an existing terminal tab from menu navigation", () => {
+    const terminalId = useTabs.getState().openTab({ kind: "terminal", sessionName: "matrix-main", title: "matrix-main" });
+    useTabs.getState().openTab({ kind: "home", title: "Home", closable: false });
+
+    handleMenuNavigate("terminals");
+
+    expect(useTabs.getState().activeTabId).toBe(terminalId);
   });
 
   it("falls back to home and logs unsupported menu kinds", () => {

--- a/www/content/docs/coding-agents.mdx
+++ b/www/content/docs/coding-agents.mdx
@@ -181,7 +181,7 @@ On mobile, use the coding-agent workspace to check active work, answer approvals
 
 ## Desktop workflow
 
-On desktop, the coding-agent workspace is the mission-control view for multiple threads. Open it from the sidebar, command palette, or app menu, then use it to compare active work, open bound terminals, inspect reviews, answer approvals, and open safe previews without exposing provider credentials to the renderer.
+On desktop, the coding-agent workspace is the mission-control view for multiple threads. Open it from the sidebar, command palette, or app menu, then use it to compare active work, open bound terminals, inspect reviews, answer approvals, and open safe previews without exposing provider credentials to the renderer. The desktop app menu also includes a Terminal action that focuses an existing terminal tab or opens the Terminal workspace.
 
 ## Related
 


### PR DESCRIPTION
## Summary
- Add a desktop Terminal app-menu action with `Cmd+Alt+T` accelerator.
- Extend typed `menu:navigate` IPC and shortcut handling so Terminal focus reuses existing tabs before opening the Terminal workspace.
- Update focused shortcut/menu/schema tests plus coding-agent docs/current-state.

## Tests
- `pnpm exec vitest run tests/desktop/shortcuts.test.ts tests/desktop/ipc-contract.test.ts tests/desktop/menu-template.test.ts`
- `pnpm --filter desktop run typecheck`
- `bun run check:patterns`
- `bun run typecheck`
- `git diff --check`
- Scoped hygiene scan over changed paths: no prohibited strings

## Review/Monitoring
- Awaiting automated review on the latest head.
- `ready-for-ci` will be added only after latest trusted review is 5/5.

## Invariants
- Source of truth: existing desktop tab store remains authoritative; the shortcut/menu path only focuses or opens existing terminal tab types.
- Lock/transaction scope: no backend writes, persistence, or transaction changes.
- Acceptable orphan states: if no terminal tab exists, the Terminal workspace tab is opened through the existing tab contract.
- Auth source of truth: no credentials added or exposed; IPC schema carries only a bounded navigation kind.
- Deferred scope: thread-list, review, provider setup, and file-search shortcuts remain later slices.