### PR TITLE
feat(desktop): open reviews from command palette

### DIFF
--- a/desktop/src/renderer/src/features/palette/CommandPalette.tsx
+++ b/desktop/src/renderer/src/features/palette/CommandPalette.tsx
@@ -14,6 +14,30 @@ import { CODING_AGENTS_DESKTOP_WORKSPACE } from "../../lib/feature-flags";
 
 const EMPTY_REVIEWS: ReviewSummary[] = [];
 const MAX_PALETTE_REVIEWS = 10;
+const TERMINAL_REVIEW_STATUSES: ReviewSummary["status"][] = ["approved", "converged", "stopped"];
+
+function isTerminalReviewStatus(status: ReviewSummary["status"]): boolean {
+  return TERMINAL_REVIEW_STATUSES.includes(status);
+}
+
+function reviewUpdatedAtMs(review: ReviewSummary): number {
+  const value = Date.parse(review.updatedAt);
+  return Number.isFinite(value) ? value : 0;
+}
+
+function paletteReviewCommands(reviews: ReviewSummary[]): ReviewSummary[] {
+  return [...reviews]
+    .sort((a, b) => {
+      const statusPriority = Number(isTerminalReviewStatus(a.status)) - Number(isTerminalReviewStatus(b.status));
+      if (statusPriority !== 0) return statusPriority;
+      const updatedPriority = reviewUpdatedAtMs(b) - reviewUpdatedAtMs(a);
+      if (updatedPriority !== 0) return updatedPriority;
+      const pullRequestPriority = b.pullRequestNumber - a.pullRequestNumber;
+      if (pullRequestPriority !== 0) return pullRequestPriority;
+      return a.id.localeCompare(b.id);
+    })
+    .slice(0, MAX_PALETTE_REVIEWS);
+}
 
 export default function CommandPalette() {
   const open = useUi((s) => s.paletteOpen);
@@ -51,7 +75,7 @@ export default function CommandPalette() {
 
   const cards = activeSlug ? (cardsByProject[activeSlug] ?? []) : [];
   const otherTabs = tabs.filter((t) => t.id !== activeTabId);
-  const reviewCommands = CODING_AGENTS_DESKTOP_WORKSPACE ? (reviews?.items ?? EMPTY_REVIEWS).slice(0, MAX_PALETTE_REVIEWS) : EMPTY_REVIEWS;
+  const reviewCommands = CODING_AGENTS_DESKTOP_WORKSPACE ? paletteReviewCommands(reviews?.items ?? EMPTY_REVIEWS) : EMPTY_REVIEWS;
 
   const run = (fn: () => void) => {
     setOpen(false);

--- a/desktop/src/renderer/src/features/palette/CommandPalette.tsx
+++ b/desktop/src/renderer/src/features/palette/CommandPalette.tsx
@@ -1,14 +1,19 @@
 import { Command } from "cmdk";
 import { useEffect } from "react";
-import { Bot, Home, Kanban, LayoutGrid, MessageSquarePlus, PanelsTopLeft, Plus, Settings, Sparkles, SquareTerminal } from "lucide-react";
+import type { ReviewSummary } from "@matrix-os/contracts";
+import { Bot, ClipboardCheck, Home, Kanban, LayoutGrid, MessageSquarePlus, PanelsTopLeft, Plus, Settings, Sparkles, SquareTerminal } from "lucide-react";
 import { appIconUrl, useApps } from "../../stores/apps";
 import { useBoard } from "../../stores/board";
+import { useCodingAgentWorkspace } from "../../stores/coding-agent-workspace";
 import { useConnection } from "../../stores/connection";
 import { useShellSessions } from "../../stores/shell-sessions";
 import { useTabs } from "../../stores/tabs";
 import { useThreads } from "../../stores/threads";
 import { useUi } from "../../stores/ui";
 import { CODING_AGENTS_DESKTOP_WORKSPACE } from "../../lib/feature-flags";
+
+const EMPTY_REVIEWS: ReviewSummary[] = [];
+const MAX_PALETTE_REVIEWS = 10;
 
 export default function CommandPalette() {
   const open = useUi((s) => s.paletteOpen);
@@ -28,6 +33,8 @@ export default function CommandPalette() {
   const apps = useApps((s) => s.apps);
   const appsError = useApps((s) => s.error);
   const loadApps = useApps((s) => s.load);
+  const reviews = useCodingAgentWorkspace((s) => s.reviews);
+  const selectReview = useCodingAgentWorkspace((s) => s.selectReview);
   const api = useConnection((s) => s.api);
   const platformHost = useConnection((s) => s.platformHost);
 
@@ -44,6 +51,7 @@ export default function CommandPalette() {
 
   const cards = activeSlug ? (cardsByProject[activeSlug] ?? []) : [];
   const otherTabs = tabs.filter((t) => t.id !== activeTabId);
+  const reviewCommands = CODING_AGENTS_DESKTOP_WORKSPACE ? (reviews?.items ?? EMPTY_REVIEWS).slice(0, MAX_PALETTE_REVIEWS) : EMPTY_REVIEWS;
 
   const run = (fn: () => void) => {
     setOpen(false);
@@ -133,6 +141,24 @@ export default function CommandPalette() {
                   icon={<Kanban size={14} />}
                   label={card.title}
                   onSelect={() => run(() => openTab({ kind: "task", taskId: card.id, projectSlug: card.projectSlug, title: card.title }))}
+                />
+              ))}
+            </Command.Group>
+          ) : null}
+
+          {reviewCommands.length > 0 ? (
+            <Command.Group heading="Reviews" style={{ color: "var(--text-tertiary)" }}>
+              {reviewCommands.map((review) => (
+                <PaletteItem
+                  key={review.id}
+                  icon={<ClipboardCheck size={14} />}
+                  label={`Open review PR #${review.pullRequestNumber}`}
+                  onSelect={() =>
+                    run(() => {
+                      openTab({ kind: "agents", title: "Agents" });
+                      void selectReview(review.id);
+                    })
+                  }
                 />
               ))}
             </Command.Group>

--- a/specs/105-coding-agent-shells/current-state.md
+++ b/specs/105-coding-agent-shells/current-state.md
@@ -1,7 +1,7 @@
 # Current State: Coding Agent Shells
 
-**Branch stack**: `spec/coding-agent-shells` plus stacked implementation branches through `105-coding-agent-notification-controls`
-**Updated**: 2026-07-07
+**Branch stack**: `spec/coding-agent-shells` plus stacked implementation branches through `105-coding-agent-desktop-review-palette`
+**Updated**: 2026-07-08
 **Scope**: Inventory for the coding-agent desktop/mobile shell work. This file records the current Matrix-native route, contract, client, and regression-test state so later slices keep gateway/runtime as source of truth and keep desktop/mobile as thin shells.
 
 ## Summary
@@ -245,7 +245,7 @@ Renderer:
 
 Current behavior:
 
-- Read-only dashboard renders providers, gateway-owned attention threads, active threads, and terminals. The desktop command palette and app menu open the same Agents tab through the existing tab store when the desktop coding-agent workspace flag is enabled.
+- Read-only dashboard renders providers, gateway-owned attention threads, active threads, and terminals. The desktop command palette and app menu open the same Agents tab through the existing tab store when the desktop coding-agent workspace flag is enabled. The desktop command palette also exposes a bounded set of already-loaded review summaries and routes selection through the existing Agents tab plus workspace review selection state.
 - Desktop keyboard flow can focus an existing Terminal tab or open the Terminal workspace through the app menu `Terminal` action and the matching global shortcut.
 - Notification controls render approval, input, and failed-run attention push preferences, load them through trusted IPC, and submit full replacement updates through trusted IPC with generic error states.
 - Attention thread rows read only from `RuntimeSummarySchema.attentionThreads`, show safe attention labels such as approval/input/failed, and open the existing bounded thread detail path through trusted IPC.

--- a/tests/desktop/command-palette.test.tsx
+++ b/tests/desktop/command-palette.test.tsx
@@ -16,6 +16,7 @@ import { useSessions } from "../../desktop/src/renderer/src/stores/sessions";
 import { useShellSessions } from "../../desktop/src/renderer/src/stores/shell-sessions";
 import { useTabs } from "../../desktop/src/renderer/src/stores/tabs";
 import { useUi } from "../../desktop/src/renderer/src/stores/ui";
+import { useCodingAgentWorkspace } from "../../desktop/src/renderer/src/stores/coding-agent-workspace";
 
 describe("CommandPalette", () => {
   beforeEach(() => {
@@ -35,6 +36,13 @@ describe("CommandPalette", () => {
     useSessions.setState({ sessions: [] });
     useShellSessions.setState({ ...useShellSessions.getInitialState(), load: vi.fn().mockResolvedValue(undefined) }, true);
     useTabs.setState({ tabs: [], activeTabId: null, openTab: vi.fn() });
+    useCodingAgentWorkspace.setState({
+      reviewsStatus: "idle",
+      reviews: null,
+      reviewsError: null,
+      selectedReviewId: null,
+      selectReview: vi.fn().mockResolvedValue(undefined),
+    });
     useConnection.setState({
       status: "signed-in",
       handle: "operator",
@@ -100,5 +108,44 @@ describe("CommandPalette", () => {
       kind: "agents",
       title: "Agents",
     });
+  });
+
+  it("opens loaded coding-agent reviews from the command palette", async () => {
+    const openTab = vi.fn();
+    const selectReview = vi.fn().mockResolvedValue(undefined);
+    useTabs.setState({ openTab });
+    useCodingAgentWorkspace.setState({
+      reviewsStatus: "ready",
+      reviews: {
+        items: [
+          {
+            id: "rev_desktop_1",
+            projectId: "matrix-os",
+            worktreeId: "wt_desktop_1",
+            status: "reviewing",
+            pullRequestNumber: 758,
+            round: 2,
+            maxRounds: 3,
+            reviewer: "matrix-reviewer",
+            implementer: "matrix-implementer",
+            findings: { total: 3, high: 1, medium: 1, low: 1 },
+            updatedAt: "2026-07-06T00:02:00.000Z",
+          },
+        ],
+        hasMore: false,
+        limit: 50,
+      },
+      selectReview,
+    });
+
+    render(<CommandPalette />);
+
+    fireEvent.click(screen.getByText("Open review PR #758"));
+
+    expect(openTab).toHaveBeenCalledWith({
+      kind: "agents",
+      title: "Agents",
+    });
+    expect(selectReview).toHaveBeenCalledWith("rev_desktop_1");
   });
 });

--- a/tests/desktop/command-palette.test.tsx
+++ b/tests/desktop/command-palette.test.tsx
@@ -148,4 +148,57 @@ describe("CommandPalette", () => {
     });
     expect(selectReview).toHaveBeenCalledWith("rev_desktop_1");
   });
+
+  it("prioritizes current reviews before slicing loaded command-palette reviews", async () => {
+    const openTab = vi.fn();
+    const selectReview = vi.fn().mockResolvedValue(undefined);
+    useTabs.setState({ openTab });
+    useCodingAgentWorkspace.setState({
+      reviewsStatus: "ready",
+      reviews: {
+        items: [
+          ...Array.from({ length: 10 }, (_, index) => ({
+            id: `rev_old_${index}`,
+            projectId: "matrix-os",
+            worktreeId: `wt_old_${index}`,
+            status: "approved" as const,
+            pullRequestNumber: 700 + index,
+            round: 3,
+            maxRounds: 3,
+            reviewer: "matrix-reviewer",
+            implementer: "matrix-implementer",
+            updatedAt: `2026-07-05T00:${String(index).padStart(2, "0")}:00.000Z`,
+          })),
+          {
+            id: "rev_recent",
+            projectId: "matrix-os",
+            worktreeId: "wt_recent",
+            status: "reviewing",
+            pullRequestNumber: 811,
+            round: 1,
+            maxRounds: 3,
+            reviewer: "matrix-reviewer",
+            implementer: "matrix-implementer",
+            updatedAt: "2026-07-07T00:00:00.000Z",
+          },
+        ],
+        hasMore: false,
+        limit: 50,
+      },
+      selectReview,
+    });
+
+    render(<CommandPalette />);
+
+    expect(screen.getByText("Open review PR #811")).toBeTruthy();
+    expect(screen.queryByText("Open review PR #700")).toBeNull();
+
+    fireEvent.click(screen.getByText("Open review PR #811"));
+
+    expect(openTab).toHaveBeenCalledWith({
+      kind: "agents",
+      title: "Agents",
+    });
+    expect(selectReview).toHaveBeenCalledWith("rev_recent");
+  });
 });

--- a/www/content/docs/coding-agents.mdx
+++ b/www/content/docs/coding-agents.mdx
@@ -181,7 +181,7 @@ On mobile, use the coding-agent workspace to check active work, answer approvals
 
 ## Desktop workflow
 
-On desktop, the coding-agent workspace is the mission-control view for multiple threads. Open it from the sidebar, command palette, or app menu, then use it to compare active work, open bound terminals, inspect reviews, answer approvals, and open safe previews without exposing provider credentials to the renderer. The desktop app menu also includes a Terminal action that focuses an existing terminal tab or opens the Terminal workspace.
+On desktop, the coding-agent workspace is the mission-control view for multiple threads. Open it from the sidebar, command palette, or app menu, then use it to compare active work, open bound terminals, inspect reviews, answer approvals, and open safe previews without exposing provider credentials to the renderer. The command palette can also jump to loaded review summaries, and the desktop app menu includes a Terminal action that focuses an existing terminal tab or opens the Terminal workspace.
 
 ## Related
 


### PR DESCRIPTION
## Summary
- add a gated desktop command-palette Reviews group backed by already-loaded coding-agent review summaries
- route review selection through the existing Agents tab and workspace review selection state
- update the coding-agent current-state note and public docs for the desktop review jump

## Tests
- pnpm exec vitest run tests/desktop/command-palette.test.tsx
- pnpm --filter desktop run typecheck
- git diff --check
- rg -n "t3code|reference repo|external inspiration" tests/desktop/command-palette.test.tsx desktop/src/renderer/src/features/palette/CommandPalette.tsx specs/105-coding-agent-shells/current-state.md www/content/docs/coding-agents.mdx (no matches)
- bun run check:patterns (passes with existing warnings)
- bun run typecheck

## Review/Monitoring
- Opened as a stacked PR on top of #826.
- Do not add ready-for-ci until the latest trusted Greptile result is 5/5 on the current head.

## Invariants
- Gateway/runtime remain the source of truth; this PR only reads existing renderer store review summaries.
- No new backend route, persistence, credential exposure, IPC channel, or mutating path is added.
- The palette list is bounded to already-loaded review summaries and does not fetch transcripts, diffs, file contents, terminal output, or provider credentials.