### PR TITLE
feat(desktop): open provider setup from palette

### DIFF
--- a/desktop/src/renderer/src/features/palette/CommandPalette.tsx
+++ b/desktop/src/renderer/src/features/palette/CommandPalette.tsx
@@ -1,6 +1,6 @@
 import { Command } from "cmdk";
 import { useEffect } from "react";
-import type { ReviewSummary } from "@matrix-os/contracts";
+import type { AgentProviderSummary, ReviewSummary, SafeSetupAction } from "@matrix-os/contracts";
 import { Bot, ClipboardCheck, Home, Kanban, LayoutGrid, MessageSquarePlus, PanelsTopLeft, Plus, Settings, Sparkles, SquareTerminal } from "lucide-react";
 import { appIconUrl, useApps } from "../../stores/apps";
 import { useBoard } from "../../stores/board";
@@ -11,10 +11,22 @@ import { useTabs } from "../../stores/tabs";
 import { useThreads } from "../../stores/threads";
 import { useUi } from "../../stores/ui";
 import { CODING_AGENTS_DESKTOP_WORKSPACE } from "../../lib/feature-flags";
+import type { ApiClient } from "../../lib/api";
 
 const EMPTY_REVIEWS: ReviewSummary[] = [];
+const EMPTY_PROVIDERS: AgentProviderSummary[] = [];
 const MAX_PALETTE_REVIEWS = 10;
+const MAX_PALETTE_SETUP_ACTIONS = 10;
 const TERMINAL_REVIEW_STATUSES: ReviewSummary["status"][] = ["approved", "converged", "stopped"];
+const SESSION_NAME_PATTERN = /^[a-z0-9][a-z0-9-]{0,30}$/;
+
+type ForegroundSetupAction = Extract<SafeSetupAction, { kind: "foreground_terminal" }>;
+type ProviderSetupCommand = {
+  key: string;
+  label: string;
+  command: string;
+  sessionName: string;
+};
 
 function isTerminalReviewStatus(status: ReviewSummary["status"]): boolean {
   return TERMINAL_REVIEW_STATUSES.includes(status);
@@ -39,6 +51,59 @@ function paletteReviewCommands(reviews: ReviewSummary[]): ReviewSummary[] {
     .slice(0, MAX_PALETTE_REVIEWS);
 }
 
+function safeSessionSegment(value: string): string {
+  const segment = value
+    .toLowerCase()
+    .replace(/[^a-z0-9-]/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^-|-$/g, "");
+  return segment || "agent";
+}
+
+function setupSessionName(providerId: string, actionId: string): string {
+  const prefix = "matrix-setup-";
+  const rawSegment = providerId === actionId ? providerId : `${providerId}-${actionId}`;
+  const segment = safeSessionSegment(rawSegment).slice(0, 31 - prefix.length).replace(/-$/g, "");
+  return `${prefix}${segment || "agent"}`;
+}
+
+function providerSetupCommands(providers: AgentProviderSummary[]): ProviderSetupCommand[] {
+  const commands: ProviderSetupCommand[] = [];
+  for (const provider of providers) {
+    for (const action of provider.setupActions) {
+      if (action.kind !== "foreground_terminal") continue;
+      const foregroundAction: ForegroundSetupAction = action;
+      commands.push({
+        key: `${provider.id}:${foregroundAction.id}`,
+        label: foregroundAction.label,
+        command: foregroundAction.command,
+        sessionName: setupSessionName(provider.id, foregroundAction.id),
+      });
+    }
+  }
+  return commands.slice(0, MAX_PALETTE_SETUP_ACTIONS);
+}
+
+async function openProviderSetupTerminal(
+  api: ApiClient,
+  setup: ProviderSetupCommand,
+  openTab: ReturnType<typeof useTabs.getState>["openTab"],
+): Promise<void> {
+  try {
+    const response = await api.post<{ name?: unknown }>("/api/terminal/sessions", {
+      name: setup.sessionName,
+      cwd: "projects",
+      cmd: setup.command,
+    });
+    const sessionName = typeof response.name === "string" && SESSION_NAME_PATTERN.test(response.name)
+      ? response.name
+      : setup.sessionName;
+    openTab({ kind: "terminal", sessionName, title: setup.label });
+  } catch (err: unknown) {
+    console.error("[palette] Failed to open provider setup terminal:", err instanceof Error ? err.name : typeof err);
+  }
+}
+
 export default function CommandPalette() {
   const open = useUi((s) => s.paletteOpen);
   const setOpen = useUi((s) => s.setPaletteOpen);
@@ -57,6 +122,7 @@ export default function CommandPalette() {
   const apps = useApps((s) => s.apps);
   const appsError = useApps((s) => s.error);
   const loadApps = useApps((s) => s.load);
+  const summary = useCodingAgentWorkspace((s) => s.summary);
   const reviews = useCodingAgentWorkspace((s) => s.reviews);
   const selectReview = useCodingAgentWorkspace((s) => s.selectReview);
   const api = useConnection((s) => s.api);
@@ -76,6 +142,7 @@ export default function CommandPalette() {
   const cards = activeSlug ? (cardsByProject[activeSlug] ?? []) : [];
   const otherTabs = tabs.filter((t) => t.id !== activeTabId);
   const reviewCommands = CODING_AGENTS_DESKTOP_WORKSPACE ? paletteReviewCommands(reviews?.items ?? EMPTY_REVIEWS) : EMPTY_REVIEWS;
+  const setupCommands = CODING_AGENTS_DESKTOP_WORKSPACE ? providerSetupCommands(summary?.providers ?? EMPTY_PROVIDERS) : [];
 
   const run = (fn: () => void) => {
     setOpen(false);
@@ -138,6 +205,18 @@ export default function CommandPalette() {
             {CODING_AGENTS_DESKTOP_WORKSPACE ? (
               <PaletteItem icon={<Bot size={14} />} label="Open Agents" onSelect={() => run(() => openTab({ kind: "agents", title: "Agents" }))} />
             ) : null}
+            {setupCommands.map((setup) => (
+              <PaletteItem
+                key={setup.key}
+                icon={<SquareTerminal size={14} />}
+                label={setup.label}
+                onSelect={() =>
+                  run(() => {
+                    if (api) void openProviderSetupTerminal(api, setup, openTab);
+                  })
+                }
+              />
+            ))}
             <PaletteItem icon={<Home size={14} />} label="Go to Home" onSelect={() => run(() => openTab({ kind: "home", title: "Home", closable: false }))} />
             <PaletteItem icon={<SquareTerminal size={14} />} label="Open Terminal" onSelect={() => run(() => openTab({ kind: "terminals", title: "Terminal" }))} />
             <PaletteItem icon={<LayoutGrid size={14} />} label="Open Apps" onSelect={() => run(() => openTab({ kind: "apps", title: "Apps" }))} />

--- a/desktop/src/renderer/src/features/palette/CommandPalette.tsx
+++ b/desktop/src/renderer/src/features/palette/CommandPalette.tsx
@@ -1,5 +1,5 @@
 import { Command } from "cmdk";
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import type { AgentProviderSummary, ReviewSummary, SafeSetupAction } from "@matrix-os/contracts";
 import { Bot, ClipboardCheck, Home, Kanban, LayoutGrid, MessageSquarePlus, PanelsTopLeft, Plus, Settings, Sparkles, SquareTerminal } from "lucide-react";
 import { appIconUrl, useApps } from "../../stores/apps";
@@ -19,6 +19,8 @@ const MAX_PALETTE_REVIEWS = 10;
 const MAX_PALETTE_SETUP_ACTIONS = 10;
 const TERMINAL_REVIEW_STATUSES: ReviewSummary["status"][] = ["approved", "converged", "stopped"];
 const SESSION_NAME_PATTERN = /^[a-z0-9][a-z0-9-]{0,30}$/;
+const SETUP_DISCONNECTED_ERROR = "Connect to your Matrix computer before opening setup.";
+const SETUP_TERMINAL_ERROR = "Could not open setup terminal. Try again from Terminal.";
 
 type ForegroundSetupAction = Extract<SafeSetupAction, { kind: "foreground_terminal" }>;
 type ProviderSetupCommand = {
@@ -60,11 +62,22 @@ function safeSessionSegment(value: string): string {
   return segment || "agent";
 }
 
+function setupSessionHash(value: string): string {
+  let hash = 2166136261;
+  for (let index = 0; index < value.length; index += 1) {
+    hash ^= value.charCodeAt(index);
+    hash = Math.imul(hash, 16777619);
+  }
+  return (hash >>> 0).toString(36).padStart(6, "0").slice(-6);
+}
+
 function setupSessionName(providerId: string, actionId: string): string {
   const prefix = "matrix-setup-";
   const rawSegment = providerId === actionId ? providerId : `${providerId}-${actionId}`;
-  const segment = safeSessionSegment(rawSegment).slice(0, 31 - prefix.length).replace(/-$/g, "");
-  return `${prefix}${segment || "agent"}`;
+  const suffix = setupSessionHash(`${providerId}:${actionId}`);
+  const maxSegmentLength = 31 - prefix.length - suffix.length - 1;
+  const segment = safeSessionSegment(rawSegment).slice(0, maxSegmentLength).replace(/-$/g, "");
+  return `${prefix}${segment || "agent"}-${suffix}`;
 }
 
 function providerSetupCommands(providers: AgentProviderSummary[]): ProviderSetupCommand[] {
@@ -88,7 +101,7 @@ async function openProviderSetupTerminal(
   api: ApiClient,
   setup: ProviderSetupCommand,
   openTab: ReturnType<typeof useTabs.getState>["openTab"],
-): Promise<void> {
+): Promise<boolean> {
   try {
     const response = await api.post<{ name?: unknown }>("/api/terminal/sessions", {
       name: setup.sessionName,
@@ -99,12 +112,15 @@ async function openProviderSetupTerminal(
       ? response.name
       : setup.sessionName;
     openTab({ kind: "terminal", sessionName, title: setup.label });
+    return true;
   } catch (err: unknown) {
     console.error("[palette] Failed to open provider setup terminal:", err instanceof Error ? err.name : typeof err);
+    return false;
   }
 }
 
 export default function CommandPalette() {
+  const [actionError, setActionError] = useState<string | null>(null);
   const open = useUi((s) => s.paletteOpen);
   const setOpen = useUi((s) => s.setPaletteOpen);
   const openTab = useTabs((s) => s.openTab);
@@ -137,6 +153,10 @@ export default function CommandPalette() {
     if (open && api) void loadShellSessions(api);
   }, [open, api, loadShellSessions]);
 
+  useEffect(() => {
+    if (open) setActionError(null);
+  }, [open]);
+
   if (!open) return null;
 
   const cards = activeSlug ? (cardsByProject[activeSlug] ?? []) : [];
@@ -145,8 +165,23 @@ export default function CommandPalette() {
   const setupCommands = CODING_AGENTS_DESKTOP_WORKSPACE ? providerSetupCommands(summary?.providers ?? EMPTY_PROVIDERS) : [];
 
   const run = (fn: () => void) => {
+    setActionError(null);
     setOpen(false);
     fn();
+  };
+
+  const runProviderSetup = async (setup: ProviderSetupCommand) => {
+    setActionError(null);
+    if (!api) {
+      setActionError(SETUP_DISCONNECTED_ERROR);
+      return;
+    }
+    const opened = await openProviderSetupTerminal(api, setup, openTab);
+    if (opened) {
+      setOpen(false);
+    } else {
+      setActionError(SETUP_TERMINAL_ERROR);
+    }
   };
 
   return (
@@ -176,6 +211,11 @@ export default function CommandPalette() {
           className="w-full border-b bg-transparent px-4 py-3 text-md outline-none"
           style={{ borderColor: "var(--border-subtle)", color: "var(--text-primary)" }}
         />
+        {actionError ? (
+          <div className="border-b px-4 py-2 text-sm" style={{ borderColor: "var(--border-subtle)", color: "var(--danger)" }}>
+            {actionError}
+          </div>
+        ) : null}
         <Command.List className="max-h-[320px] overflow-y-auto p-1.5">
           <Command.Empty
             className="px-3 py-6 text-center text-sm"
@@ -211,9 +251,7 @@ export default function CommandPalette() {
                 icon={<SquareTerminal size={14} />}
                 label={setup.label}
                 onSelect={() =>
-                  run(() => {
-                    if (api) void openProviderSetupTerminal(api, setup, openTab);
-                  })
+                  void runProviderSetup(setup)
                 }
               />
             ))}

--- a/specs/105-coding-agent-shells/current-state.md
+++ b/specs/105-coding-agent-shells/current-state.md
@@ -1,6 +1,6 @@
 # Current State: Coding Agent Shells
 
-**Branch stack**: `spec/coding-agent-shells` plus stacked implementation branches through `105-coding-agent-desktop-review-palette`
+**Branch stack**: `spec/coding-agent-shells` plus stacked implementation branches through `105-coding-agent-desktop-provider-setup-palette`
 **Updated**: 2026-07-08
 **Scope**: Inventory for the coding-agent desktop/mobile shell work. This file records the current Matrix-native route, contract, client, and regression-test state so later slices keep gateway/runtime as source of truth and keep desktop/mobile as thin shells.
 
@@ -245,7 +245,7 @@ Renderer:
 
 Current behavior:
 
-- Read-only dashboard renders providers, gateway-owned attention threads, active threads, and terminals. The desktop command palette and app menu open the same Agents tab through the existing tab store when the desktop coding-agent workspace flag is enabled. The desktop command palette also exposes a bounded set of already-loaded review summaries and routes selection through the existing Agents tab plus workspace review selection state.
+- Read-only dashboard renders providers, gateway-owned attention threads, active threads, and terminals. The desktop command palette and app menu open the same Agents tab through the existing tab store when the desktop coding-agent workspace flag is enabled. The desktop command palette also exposes a bounded set of already-loaded review summaries and routes selection through the existing Agents tab plus workspace review selection state. Provider setup actions that arrive as bounded `foreground_terminal` actions can be opened from the command palette through the existing canonical terminal session create/open path.
 - Desktop keyboard flow can focus an existing Terminal tab or open the Terminal workspace through the app menu `Terminal` action and the matching global shortcut.
 - Notification controls render approval, input, and failed-run attention push preferences, load them through trusted IPC, and submit full replacement updates through trusted IPC with generic error states.
 - Attention thread rows read only from `RuntimeSummarySchema.attentionThreads`, show safe attention labels such as approval/input/failed, and open the existing bounded thread detail path through trusted IPC.

--- a/tests/desktop/command-palette.test.tsx
+++ b/tests/desktop/command-palette.test.tsx
@@ -205,7 +205,7 @@ describe("CommandPalette", () => {
 
   it("opens provider setup actions in a foreground terminal from the command palette", async () => {
     const openTab = vi.fn();
-    const post = vi.fn().mockResolvedValue({ name: "matrix-setup-codex" });
+    const post = vi.fn().mockResolvedValue({ name: "matrix-setup-codex-a1b2c3" });
     useTabs.setState({ openTab });
     useConnection.setState({
       api: {
@@ -261,15 +261,219 @@ describe("CommandPalette", () => {
 
     await waitFor(() => {
       expect(post).toHaveBeenCalledWith("/api/terminal/sessions", {
-        name: "matrix-setup-codex",
+        name: expect.stringMatching(/^matrix-setup-codex-[a-z0-9]{6}$/),
         cwd: "projects",
         cmd: "npm install -g --prefix \"$MATRIX_NODE_PREFIX\" @openai/codex@latest",
       });
     });
     expect(openTab).toHaveBeenCalledWith({
       kind: "terminal",
-      sessionName: "matrix-setup-codex",
+      sessionName: "matrix-setup-codex-a1b2c3",
       title: "Install Codex",
     });
+  });
+
+  it("uses distinct setup session names for similar provider setup actions", async () => {
+    const openTab = vi.fn();
+    const post = vi.fn()
+      .mockResolvedValueOnce({ name: "matrix-setup-codex-alp-111111" })
+      .mockResolvedValueOnce({ name: "matrix-setup-codex-alp-222222" });
+    useTabs.setState({ openTab });
+    useConnection.setState({
+      api: {
+        get: vi.fn(),
+        post,
+      } as never,
+    });
+    useCodingAgentWorkspace.setState({
+      summary: {
+        target: {
+          id: "runtime-local",
+          label: "Local Matrix",
+          status: "available",
+        },
+        serverTime: "2026-07-07T00:00:00.000Z",
+        capabilities: [{ id: "codingAgentsDesktopWorkspace", enabled: true }],
+        limits: {
+          maxPromptBytes: 16384,
+          maxAttachmentCount: 8,
+          maxTerminalInputBytes: 4096,
+          maxListItems: 50,
+        },
+        providers: [
+          {
+            id: "codex-alpha-long-provider-one",
+            displayName: "Codex One",
+            kind: "codex",
+            availability: "setup_required",
+            installStatus: "missing",
+            authStatus: "missing",
+            supportedModes: ["default"],
+            defaultMode: "default",
+            setupActions: [
+              {
+                id: "setup",
+                kind: "foreground_terminal",
+                label: "Install Codex One",
+                command: "echo setup-one",
+              },
+            ],
+          },
+          {
+            id: "codex-alpha-long-provider-two",
+            displayName: "Codex Two",
+            kind: "codex",
+            availability: "setup_required",
+            installStatus: "missing",
+            authStatus: "missing",
+            supportedModes: ["default"],
+            defaultMode: "default",
+            setupActions: [
+              {
+                id: "setup",
+                kind: "foreground_terminal",
+                label: "Install Codex Two",
+                command: "echo setup-two",
+              },
+            ],
+          },
+        ],
+        projects: { items: [], hasMore: false, limit: 20 },
+        activeThreads: { items: [], hasMore: false, limit: 20 },
+        attentionThreads: { items: [], hasMore: false, limit: 20 },
+        terminals: { items: [], hasMore: false, limit: 20 },
+      },
+    });
+
+    render(<CommandPalette />);
+
+    fireEvent.click(screen.getByText("Install Codex One"));
+    fireEvent.click(screen.getByText("Install Codex Two"));
+
+    await waitFor(() => {
+      expect(post).toHaveBeenCalledTimes(2);
+    });
+    const firstName = (post.mock.calls[0]![1] as { name: string }).name;
+    const secondName = (post.mock.calls[1]![1] as { name: string }).name;
+    expect(firstName).not.toBe(secondName);
+    expect(firstName).toMatch(/^matrix-setup-[a-z0-9-]{1,18}$/);
+    expect(secondName).toMatch(/^matrix-setup-[a-z0-9-]{1,18}$/);
+  });
+
+  it("keeps the palette open with a generic error when provider setup cannot create a terminal", async () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const post = vi.fn().mockRejectedValue(new Error("gateway failed at /home/matrix with token secret"));
+    useConnection.setState({
+      api: {
+        get: vi.fn(),
+        post,
+      } as never,
+    });
+    useCodingAgentWorkspace.setState({
+      summary: {
+        target: {
+          id: "runtime-local",
+          label: "Local Matrix",
+          status: "available",
+        },
+        serverTime: "2026-07-07T00:00:00.000Z",
+        capabilities: [{ id: "codingAgentsDesktopWorkspace", enabled: true }],
+        limits: {
+          maxPromptBytes: 16384,
+          maxAttachmentCount: 8,
+          maxTerminalInputBytes: 4096,
+          maxListItems: 50,
+        },
+        providers: [
+          {
+            id: "codex",
+            displayName: "Codex",
+            kind: "codex",
+            availability: "setup_required",
+            installStatus: "missing",
+            authStatus: "missing",
+            supportedModes: ["default"],
+            defaultMode: "default",
+            setupActions: [
+              {
+                id: "codex",
+                kind: "foreground_terminal",
+                label: "Install Codex",
+                command: "echo setup",
+              },
+            ],
+          },
+        ],
+        projects: { items: [], hasMore: false, limit: 20 },
+        activeThreads: { items: [], hasMore: false, limit: 20 },
+        attentionThreads: { items: [], hasMore: false, limit: 20 },
+        terminals: { items: [], hasMore: false, limit: 20 },
+      },
+    });
+
+    render(<CommandPalette />);
+
+    fireEvent.click(screen.getByText("Install Codex"));
+
+    expect(await screen.findByText("Could not open setup terminal. Try again from Terminal.")).toBeTruthy();
+    expect(screen.getByLabelText("Command palette")).toBeTruthy();
+    expect(screen.queryByText("/home/matrix")).toBeNull();
+    expect(screen.queryByText("token secret")).toBeNull();
+    expect(errorSpy).toHaveBeenCalledWith("[palette] Failed to open provider setup terminal:", "Error");
+  });
+
+  it("keeps disconnected provider setup actions visible with a recovery error", async () => {
+    const openTab = vi.fn();
+    useTabs.setState({ openTab });
+    useConnection.setState({ api: null });
+    useCodingAgentWorkspace.setState({
+      summary: {
+        target: {
+          id: "runtime-local",
+          label: "Local Matrix",
+          status: "offline",
+        },
+        serverTime: "2026-07-07T00:00:00.000Z",
+        capabilities: [{ id: "codingAgentsDesktopWorkspace", enabled: true }],
+        limits: {
+          maxPromptBytes: 16384,
+          maxAttachmentCount: 8,
+          maxTerminalInputBytes: 4096,
+          maxListItems: 50,
+        },
+        providers: [
+          {
+            id: "codex",
+            displayName: "Codex",
+            kind: "codex",
+            availability: "setup_required",
+            installStatus: "missing",
+            authStatus: "missing",
+            supportedModes: ["default"],
+            defaultMode: "default",
+            setupActions: [
+              {
+                id: "codex",
+                kind: "foreground_terminal",
+                label: "Install Codex",
+                command: "echo setup",
+              },
+            ],
+          },
+        ],
+        projects: { items: [], hasMore: false, limit: 20 },
+        activeThreads: { items: [], hasMore: false, limit: 20 },
+        attentionThreads: { items: [], hasMore: false, limit: 20 },
+        terminals: { items: [], hasMore: false, limit: 20 },
+      },
+    });
+
+    render(<CommandPalette />);
+
+    fireEvent.click(screen.getByText("Install Codex"));
+
+    expect(screen.getByText("Connect to your Matrix computer before opening setup.")).toBeTruthy();
+    expect(screen.getByLabelText("Command palette")).toBeTruthy();
+    expect(openTab).not.toHaveBeenCalled();
   });
 });

--- a/tests/desktop/command-palette.test.tsx
+++ b/tests/desktop/command-palette.test.tsx
@@ -37,6 +37,7 @@ describe("CommandPalette", () => {
     useShellSessions.setState({ ...useShellSessions.getInitialState(), load: vi.fn().mockResolvedValue(undefined) }, true);
     useTabs.setState({ tabs: [], activeTabId: null, openTab: vi.fn() });
     useCodingAgentWorkspace.setState({
+      summary: null,
       reviewsStatus: "idle",
       reviews: null,
       reviewsError: null,
@@ -200,5 +201,75 @@ describe("CommandPalette", () => {
       title: "Agents",
     });
     expect(selectReview).toHaveBeenCalledWith("rev_recent");
+  });
+
+  it("opens provider setup actions in a foreground terminal from the command palette", async () => {
+    const openTab = vi.fn();
+    const post = vi.fn().mockResolvedValue({ name: "matrix-setup-codex" });
+    useTabs.setState({ openTab });
+    useConnection.setState({
+      api: {
+        get: vi.fn(),
+        post,
+      } as never,
+    });
+    useCodingAgentWorkspace.setState({
+      summary: {
+        target: {
+          id: "runtime-local",
+          label: "Local Matrix",
+          status: "available",
+        },
+        serverTime: "2026-07-07T00:00:00.000Z",
+        capabilities: [{ id: "codingAgentsDesktopWorkspace", enabled: true }],
+        limits: {
+          maxPromptBytes: 16384,
+          maxAttachmentCount: 8,
+          maxTerminalInputBytes: 4096,
+          maxListItems: 50,
+        },
+        providers: [
+          {
+            id: "codex",
+            displayName: "Codex",
+            kind: "codex",
+            availability: "setup_required",
+            installStatus: "missing",
+            authStatus: "missing",
+            supportedModes: ["default"],
+            defaultMode: "default",
+            setupActions: [
+              {
+                id: "codex",
+                kind: "foreground_terminal",
+                label: "Install Codex",
+                command: "npm install -g --prefix \"$MATRIX_NODE_PREFIX\" @openai/codex@latest",
+              },
+            ],
+          },
+        ],
+        projects: { items: [], hasMore: false, limit: 20 },
+        activeThreads: { items: [], hasMore: false, limit: 20 },
+        attentionThreads: { items: [], hasMore: false, limit: 20 },
+        terminals: { items: [], hasMore: false, limit: 20 },
+      },
+    });
+
+    render(<CommandPalette />);
+
+    fireEvent.click(screen.getByText("Install Codex"));
+
+    await waitFor(() => {
+      expect(post).toHaveBeenCalledWith("/api/terminal/sessions", {
+        name: "matrix-setup-codex",
+        cwd: "projects",
+        cmd: "npm install -g --prefix \"$MATRIX_NODE_PREFIX\" @openai/codex@latest",
+      });
+    });
+    expect(openTab).toHaveBeenCalledWith({
+      kind: "terminal",
+      sessionName: "matrix-setup-codex",
+      title: "Install Codex",
+    });
   });
 });

--- a/www/content/docs/coding-agents.mdx
+++ b/www/content/docs/coding-agents.mdx
@@ -181,7 +181,7 @@ On mobile, use the coding-agent workspace to check active work, answer approvals
 
 ## Desktop workflow
 
-On desktop, the coding-agent workspace is the mission-control view for multiple threads. Open it from the sidebar, command palette, or app menu, then use it to compare active work, open bound terminals, inspect reviews, answer approvals, and open safe previews without exposing provider credentials to the renderer. The command palette can also jump to loaded review summaries, and the desktop app menu includes a Terminal action that focuses an existing terminal tab or opens the Terminal workspace.
+On desktop, the coding-agent workspace is the mission-control view for multiple threads. Open it from the sidebar, command palette, or app menu, then use it to compare active work, open bound terminals, inspect reviews, answer approvals, and open safe previews without exposing provider credentials to the renderer. The command palette can also jump to loaded review summaries or foreground setup terminal actions, and the desktop app menu includes a Terminal action that focuses an existing terminal tab or opens the Terminal workspace.
 
 ## Related
 


### PR DESCRIPTION
## Summary
- expose bounded foreground-terminal provider setup actions in the desktop command palette
- create/open the existing canonical terminal session for selected setup actions without adding new backend behavior
- update the coding-agent current-state note and public docs for provider setup jumps

## Tests
- pnpm exec vitest run tests/desktop/command-palette.test.tsx
- pnpm --filter desktop run typecheck
- git diff --check
- rg -n "t3code|reference repo|external inspiration" tests/desktop/command-palette.test.tsx desktop/src/renderer/src/features/palette/CommandPalette.tsx specs/105-coding-agent-shells/current-state.md www/content/docs/coding-agents.mdx (no matches)
- bun run check:patterns (passes with existing warnings)
- bun run typecheck

## Review/Monitoring
- Opened as a stacked PR on top of #827.
- Do not add ready-for-ci until the latest trusted Greptile result is 5/5 on the current head.

## Invariants
- Gateway/runtime remain the source of truth for provider setup actions; the palette only uses setup actions already present in the validated runtime summary.
- No new persistence, IPC channel, provider credential exposure, or background install flow is added.
- Only bounded foreground terminal setup actions are exposed; raw command output, provider credentials, transcripts, file contents, and diffs are not stored by the renderer.