### PR TITLE
feat(mobile): show provider setup warnings

### DIFF
--- a/apps/mobile/__tests__/agents-screen.test.tsx
+++ b/apps/mobile/__tests__/agents-screen.test.tsx
@@ -241,6 +241,47 @@ function recentWorkSummaryFixture() {
   };
 }
 
+function providerSetupSummaryFixture() {
+  const summary = summaryFixture();
+  return {
+    ...summary,
+    providers: [
+      {
+        ...summary.providers[0],
+        id: "codex",
+        displayName: "Codex",
+        availability: "auth_required",
+        installStatus: "installed",
+        authStatus: "missing",
+        setupActions: [
+          {
+            id: "codex",
+            kind: "foreground_terminal",
+            label: "Sign in from Terminal",
+            command: "codex login --api-key ghp_should_not_render_secret",
+          },
+        ],
+      },
+      {
+        ...summary.providers[0],
+        id: "claude",
+        kind: "claude",
+        displayName: "Claude Code",
+        availability: "setup_required",
+        installStatus: "missing",
+        authStatus: "unknown",
+        setupActions: [
+          {
+            id: "claude",
+            kind: "open_settings",
+            label: "Open agent settings",
+          },
+        ],
+      },
+    ],
+  };
+}
+
 function previewSummaryFixture() {
   const summary = summaryFixture();
   return {
@@ -745,6 +786,86 @@ describe("AgentsScreen", () => {
     await screen.findByText("Recent Work");
     expect(screen.getByLabelText("Open recent terminal matrix-abc1234")).toBeTruthy();
     expect(screen.queryByLabelText("Open recent work Active task 1")).toBeNull();
+  });
+
+  it("surfaces safe provider setup warnings without rendering setup commands", async () => {
+    const client = {
+      getCodingAgentRuntimeSummary: jest.fn().mockResolvedValue({
+        ok: true,
+        summary: providerSetupSummaryFixture(),
+      }),
+      getCodingAgentReviews: jest.fn().mockResolvedValue({
+        ok: true,
+        reviews: reviewsFixture(),
+      }),
+    };
+    useGatewayMock.mockReturnValue(gatewayContext({
+      client: client as unknown as GatewayClient,
+      connectionState: "connected",
+    }));
+
+    render(<AgentsScreen />);
+
+    await screen.findByText("Provider Setup");
+    expect(screen.getByText("Sign in from Terminal")).toBeTruthy();
+    expect(screen.getByText("Open agent settings")).toBeTruthy();
+    expect(screen.getByLabelText("Provider setup needed for Codex, auth required")).toBeTruthy();
+    expect(screen.getByLabelText("Provider setup needed for Claude Code, setup required")).toBeTruthy();
+    expect(screen.queryByText(/codex login|api-key|ghp_should_not_render_secret/i)).toBeNull();
+  });
+
+  it("does not show setup warnings for ready or non-actionable provider states", async () => {
+    const summary = summaryFixture();
+    const client = {
+      getCodingAgentRuntimeSummary: jest.fn().mockResolvedValue({
+        ok: true,
+        summary: {
+          ...summary,
+          providers: [
+            {
+              ...summary.providers[0],
+              id: "ready-with-action",
+              displayName: "Ready Provider",
+              availability: "available",
+              installStatus: "installed",
+              authStatus: "authenticated",
+              setupActions: [
+                {
+                  id: "ready-with-action",
+                  kind: "open_settings",
+                  label: "Optional settings",
+                },
+              ],
+            },
+            {
+              ...summary.providers[0],
+              id: "unknown-provider",
+              displayName: "Unknown Provider",
+              availability: "unknown",
+              installStatus: "unknown",
+              authStatus: "unknown",
+              setupActions: [],
+            },
+          ],
+        },
+      }),
+      getCodingAgentReviews: jest.fn().mockResolvedValue({
+        ok: true,
+        reviews: reviewsFixture(),
+      }),
+    };
+    useGatewayMock.mockReturnValue(gatewayContext({
+      client: client as unknown as GatewayClient,
+      connectionState: "connected",
+    }));
+
+    render(<AgentsScreen />);
+
+    await screen.findByText("Providers");
+    expect(screen.queryByText("Provider Setup")).toBeNull();
+    expect(screen.queryByLabelText(/Provider setup needed for Ready Provider/i)).toBeNull();
+    expect(screen.queryByLabelText(/Provider setup needed for Unknown Provider/i)).toBeNull();
+    expect(screen.queryByText("Optional settings")).toBeNull();
   });
 
   it("renders read-only preview summaries without unsafe origin details", async () => {

--- a/apps/mobile/app/agents/index.tsx
+++ b/apps/mobile/app/agents/index.tsx
@@ -63,6 +63,7 @@ type SourcePullRequestState =
 
 type FileReference = Pick<FileReadRequest, "projectId" | "worktreeId" | "path">;
 type FileBrowserStatus = "idle" | "loading" | "ready" | "error";
+type SummaryProvider = RuntimeSummary["providers"][number];
 type SummaryThread = RuntimeSummary["activeThreads"]["items"][number];
 type SummaryTerminalSession = RuntimeSummary["terminalSessions"]["items"][number];
 type TerminalOpenError = "Terminal session unavailable. Try again.";
@@ -238,6 +239,28 @@ function recentWorkItems(summary: RuntimeSummary): RecentWorkItem[] {
     ...threadItems.slice(0, threadLimit),
     ...terminalItems,
   ].slice(0, MAX_RECENT_WORK_ITEMS);
+}
+
+function providerStatusLabel(value: string): string {
+  return value.replace(/_/g, " ");
+}
+
+function providerNeedsSetup(provider: SummaryProvider): boolean {
+  const ready = provider.availability === "available"
+    && provider.installStatus === "installed"
+    && provider.authStatus === "authenticated";
+  if (ready) return false;
+  return provider.setupActions.length > 0
+    || provider.availability === "setup_required"
+    || provider.availability === "auth_required"
+    || provider.installStatus === "missing"
+    || provider.installStatus === "failed"
+    || provider.authStatus === "missing"
+    || provider.authStatus === "expired";
+}
+
+function setupRequiredProviders(summary: RuntimeSummary): SummaryProvider[] {
+  return summary.providers.filter(providerNeedsSetup);
 }
 
 function safeFindingSummary(summary: string): string {
@@ -866,6 +889,8 @@ export default function AgentsScreen() {
         onOpenTerminal={(session) => void openTerminalSession(session)}
       />
 
+      <ProviderSetupSection summary={summary} />
+
       <Section title="Providers" count={summary.providers.length}>
         {summary.providers.length === 0 ? <EmptyText>No providers are ready.</EmptyText> : null}
         {summary.providers.map((provider) => (
@@ -875,9 +900,9 @@ export default function AgentsScreen() {
             </View>
             <View style={styles.rowText}>
               <Text style={styles.rowTitle}>{provider.displayName}</Text>
-              <Text style={styles.rowSubtitle}>{provider.availability.replace(/_/g, " ")}</Text>
+              <Text style={styles.rowSubtitle}>{providerStatusLabel(provider.availability)}</Text>
             </View>
-            <Text style={styles.rowMeta}>{provider.authStatus.replace(/_/g, " ")}</Text>
+            <Text style={styles.rowMeta}>{providerStatusLabel(provider.authStatus)}</Text>
           </View>
         ))}
       </Section>
@@ -1083,6 +1108,45 @@ function RecentWorkSection({
         );
       })}
       {terminalOpenError ? <Text style={styles.notificationError}>{terminalOpenError}</Text> : null}
+    </Section>
+  );
+}
+
+function ProviderSetupSection({ summary }: { summary: RuntimeSummary }) {
+  const { theme } = useUnistyles();
+  const providers = setupRequiredProviders(summary);
+  if (providers.length === 0) return null;
+
+  return (
+    <Section title="Provider Setup" count={providers.length}>
+      {providers.map((provider) => (
+        <View
+          key={provider.id}
+          accessible
+          accessibilityLabel={`Provider setup needed for ${provider.displayName}, ${providerStatusLabel(provider.availability)}`}
+          style={styles.row}
+        >
+          <View style={styles.rowIcon}>
+            <Ionicons name="warning-outline" size={18} color={theme.colors.moss} />
+          </View>
+          <View style={styles.rowText}>
+            <Text style={styles.rowTitle}>{provider.displayName}</Text>
+            <Text style={styles.rowSubtitle}>
+              {`${providerStatusLabel(provider.availability)} - ${providerStatusLabel(provider.installStatus)} / ${providerStatusLabel(provider.authStatus)}`}
+            </Text>
+            {provider.setupActions.length > 0 ? (
+              <View style={styles.providerSetupActions}>
+                {provider.setupActions.map((action, index) => (
+                  <Text key={`${provider.id}:${index}:${action.id}:${action.kind}`} style={styles.attentionBadge}>
+                    {action.label}
+                  </Text>
+                ))}
+              </View>
+            ) : null}
+          </View>
+          <Text style={styles.rowMeta}>Setup</Text>
+        </View>
+      ))}
     </Section>
   );
 }
@@ -2081,6 +2145,11 @@ const styles = StyleSheet.create((theme, rt) => ({
     fontFamily: theme.fonts.sansSemiBold,
     fontSize: 11,
     color: theme.colors.moss,
+  },
+  providerSetupActions: {
+    flexDirection: "row",
+    flexWrap: "wrap",
+    gap: theme.spacing.xs,
   },
   reviewError: {
     borderRadius: 14,

--- a/specs/105-coding-agent-shells/current-state.md
+++ b/specs/105-coding-agent-shells/current-state.md
@@ -303,6 +303,7 @@ Screen:
 - `apps/mobile/app/agents/[threadId].tsx`
 - Read-only phone-first dashboard with a capped Recent Work section, providers, gateway-owned attention threads, active threads, and terminal sessions.
 - Recent Work is derived only from `RuntimeSummarySchema`: attention threads sort before normal active threads, running attachable terminal sessions appear after thread work, and the quick new-run action uses the existing `/agents/new` route when thread creation is enabled.
+- Provider Setup warnings are derived only from `RuntimeSummarySchema.providers`, show coarse install/auth/availability states plus safe setup action labels, and do not render foreground terminal setup commands, credentials, or raw provider errors.
 - Notification controls render approval, input, and failed-run attention push switches, load them through the authenticated gateway client, submit full replacement updates, and keep preference state transient in component memory.
 - Attention thread rows read only from `RuntimeSummarySchema.attentionThreads`, show safe attention labels such as approval/input/failed, and navigate to the existing bounded thread detail route.
 - When the runtime advertises `codingAgentsReview`, the dashboard fetches bounded review summaries through the authenticated gateway client and renders project, PR, round, status, and high-severity count.

--- a/www/content/docs/coding-agents.mdx
+++ b/www/content/docs/coding-agents.mdx
@@ -177,7 +177,7 @@ Running app previews and local dev servers can appear in the coding workspace wh
 
 ## Mobile workflow
 
-On mobile, use the coding-agent workspace to check recent work, answer approvals, inspect safe review details, and jump into a bound terminal session. The Recent Work section promotes approval or input requests before normal running work, then shows attachable terminal sessions from the same runtime summary. The mobile app stores only small UI references such as selected thread, terminal, or preview ids; thread snapshots, file contents, diffs, and terminal output are reloaded from your Matrix computer when needed.
+On mobile, use the coding-agent workspace to check recent work, answer approvals, inspect safe review details, and jump into a bound terminal session. The Recent Work section promotes approval or input requests before normal running work, then shows attachable terminal sessions from the same runtime summary. Provider setup warnings use safe status and action labels only; setup commands and credentials stay out of the mobile view. The mobile app stores only small UI references such as selected thread, terminal, or preview ids; thread snapshots, file contents, diffs, and terminal output are reloaded from your Matrix computer when needed.
 
 ## Desktop workflow
 


### PR DESCRIPTION
Summary
- Add a mobile Provider Setup section derived from the existing runtime summary providers.
- Surface coarse setup/install/auth states plus safe setup action labels for providers that need setup.
- Keep foreground terminal setup commands, credentials, and raw provider errors out of the mobile UI.
- Update spec current-state and public coding-agent docs.

Tests
- pnpm --filter matrix-os-mobile run test -- agents-screen.test.tsx
- pnpm --filter matrix-os-mobile run lint
- pnpm --filter matrix-os-mobile exec tsc --noEmit
- bun run check:patterns
- bun run typecheck
- git diff --check

Review/Monitoring
- Stacked on #829 / 105-coding-agent-mobile-recent-work-home.
- Greptile confirmed 5/5 on b9fb215969f024867a602438dc1b91cf752c740c.
- ready-for-ci applied; label-triggered Gate passed.

Invariants
- Gateway/runtime remains the source of truth; mobile derives provider setup warnings only from RuntimeSummarySchema.providers.
- Mobile renders only safe display labels and coarse provider states.
- Mobile does not render or persist setup commands, provider credentials, raw provider errors, transcripts, terminal output, file contents, diffs, approval payloads, or launch tokens.
- No backend routes, WebSockets, schema migrations, provider calls, or persistence formats are changed in this slice.