### PR TITLE
feat(mobile): show agent workspace connection banner

### DIFF
--- a/apps/mobile/__tests__/ConnectionBanner.test.tsx
+++ b/apps/mobile/__tests__/ConnectionBanner.test.tsx
@@ -52,4 +52,18 @@ describe("ConnectionBanner", () => {
     );
     expect(queryByText("Retry")).toBeNull();
   });
+
+  it("supports surface-specific recovery labels", () => {
+    const { getByText } = render(
+      <ConnectionBanner
+        state="error"
+        queueCount={0}
+        labels={{
+          error: "Agent workspace reconnecting",
+        }}
+      />
+    );
+
+    expect(getByText("Agent workspace reconnecting")).toBeTruthy();
+  });
 });

--- a/apps/mobile/__tests__/agents-screen.test.tsx
+++ b/apps/mobile/__tests__/agents-screen.test.tsx
@@ -578,6 +578,58 @@ describe("AgentsScreen", () => {
     expect(screen.getAllByText("matrix-abc1234").length).toBeGreaterThan(0);
   });
 
+  it("shows an agent workspace offline banner without hiding the hydrated summary", async () => {
+    const client = {
+      getCodingAgentRuntimeSummary: jest.fn().mockResolvedValue({
+        ok: true,
+        summary: summaryFixture(),
+      }),
+      getCodingAgentReviews: jest.fn().mockResolvedValue({
+        ok: true,
+        reviews: reviewsFixture(),
+      }),
+    };
+    useGatewayMock.mockReturnValue(gatewayContext({
+      client: client as unknown as GatewayClient,
+      connectionState: "disconnected",
+    }));
+
+    render(<AgentsScreen />);
+
+    expect(await screen.findByText("Agent workspace offline")).toBeTruthy();
+    expect(screen.getAllByText("Repair mobile route").length).toBeGreaterThan(0);
+    expect(screen.queryByText(/token|bearer|secret|\/home\/matrix/i)).toBeNull();
+  });
+
+  it("offers a safe reconnect action from the agent workspace banner", async () => {
+    const connect = jest.fn();
+    const client = {
+      connect,
+      getCodingAgentRuntimeSummary: jest.fn().mockResolvedValue({
+        ok: true,
+        summary: summaryFixture(),
+      }),
+      getCodingAgentReviews: jest.fn().mockResolvedValue({
+        ok: true,
+        reviews: reviewsFixture(),
+      }),
+    };
+    useGatewayMock.mockReturnValue(gatewayContext({
+      client: client as unknown as GatewayClient,
+      connectionState: "error",
+    }));
+
+    render(<AgentsScreen />);
+
+    expect(await screen.findByText("Agent workspace reconnecting")).toBeTruthy();
+    await act(async () => {
+      fireEvent.press(screen.getByText("Retry"));
+    });
+
+    expect(connect).toHaveBeenCalledTimes(1);
+    expect(screen.queryByText(/token|bearer|secret|\/home\/matrix/i)).toBeNull();
+  });
+
   it("hydrates and updates notification preferences", async () => {
     const client = {
       getCodingAgentRuntimeSummary: jest.fn().mockResolvedValue({

--- a/apps/mobile/app/agents/index.tsx
+++ b/apps/mobile/app/agents/index.tsx
@@ -5,6 +5,7 @@ import { useRouter } from "expo-router";
 import { StyleSheet, useUnistyles } from "react-native-unistyles";
 import type { CodingAgentNotificationPreferences, CodingAgentNotificationPreferencesUpdate, FileBrowseResponse, FileReadRequest, FileReadResponse, FileSearchResponse, FileWriteRequest, PreviewSessionSummary, ReviewSnapshot, ReviewSummary, RuntimeSummary, SourceControlCreatePullRequestRequest, SourceControlCreatePullRequestResponse, SourceControlPrepareCommitRequest } from "@matrix-os/contracts";
 import { useGateway } from "@/app/_layout";
+import { ConnectionBanner } from "@/components/ConnectionBanner";
 import { CODING_AGENTS_MOBILE_WORKSPACE } from "@/lib/feature-flags";
 import { loadMobileShellState, saveMobileShellState } from "@/lib/mobile-shell-state";
 import { isSafeShellSessionName } from "@/lib/terminal-state";
@@ -133,6 +134,11 @@ const NOTIFICATION_TOGGLES: { key: NotificationPreferenceKey; label: string; det
   { key: "input", label: "Input request alerts", detail: "Runs waiting for a response" },
   { key: "failed", label: "Failed run alerts", detail: "Runs that need recovery" },
 ];
+const AGENT_WORKSPACE_CONNECTION_LABELS = {
+  connecting: "Connecting to agent workspace",
+  disconnected: "Agent workspace offline",
+  error: "Agent workspace reconnecting",
+} as const;
 const MAX_RECENT_WORK_ITEMS = 6;
 
 const INITIAL_FILE_CONTENT_STATE: FileContentState = {
@@ -356,7 +362,7 @@ function ReviewDiffLines({ lines }: { lines: ReviewSnapshotLine[] }) {
 export default function AgentsScreen() {
   const { theme } = useUnistyles();
   const router = useRouter();
-  const { client } = useGateway();
+  const { client, connectionState } = useGateway();
   const [state, setState] = useState<ScreenState>(INITIAL_STATE);
   const [notificationPreferencesState, setNotificationPreferencesState] = useState<NotificationPreferencesState>(INITIAL_NOTIFICATION_PREFERENCES_STATE);
   const [reviewState, setReviewState] = useState<ReviewState>(INITIAL_REVIEW_STATE);
@@ -823,6 +829,12 @@ export default function AgentsScreen() {
       accessibilityLabel="Refresh agent workspace"
       refreshControl={<RefreshControl refreshing={refreshing} onRefresh={onRefresh} tintColor={theme.colors.forest} />}
     >
+      <ConnectionBanner
+        state={connectionState}
+        queueCount={0}
+        onRetry={() => client?.connect()}
+        labels={AGENT_WORKSPACE_CONNECTION_LABELS}
+      />
       <View style={styles.header}>
         <View style={styles.headerIcon}>
           <Ionicons name="sparkles-outline" size={22} color={theme.colors.forest} />

--- a/apps/mobile/components/ConnectionBanner.tsx
+++ b/apps/mobile/components/ConnectionBanner.tsx
@@ -7,6 +7,7 @@ interface ConnectionBannerProps {
   state: ConnectionState;
   queueCount: number;
   onRetry?: () => void;
+  labels?: Partial<Record<Exclude<ConnectionState, "connected">, string>>;
 }
 
 const STATE_CONFIG: Record<ConnectionState, { label: string; icon: keyof typeof Ionicons.glyphMap } | null> = {
@@ -16,16 +17,17 @@ const STATE_CONFIG: Record<ConnectionState, { label: string; icon: keyof typeof 
   error: { label: "Chat reconnecting", icon: "radio-outline" },
 };
 
-export function ConnectionBanner({ state, queueCount, onRetry }: ConnectionBannerProps) {
+export function ConnectionBanner({ state, queueCount, onRetry, labels }: ConnectionBannerProps) {
   const { theme } = useUnistyles();
-  const config = STATE_CONFIG[state];
-  if (!config) return null;
+  if (state === "connected") return null;
+  const config = STATE_CONFIG[state]!;
+  const label = labels?.[state] ?? config.label;
 
   return (
     <View style={styles.container}>
       <Ionicons name={config.icon} size={14} color={theme.colors.forest} />
       <Text style={styles.label}>
-        {config.label}
+        {label}
         {queueCount > 0 ? ` (${queueCount} queued)` : ""}
       </Text>
       {state === "error" && onRetry && (

--- a/specs/105-coding-agent-shells/current-state.md
+++ b/specs/105-coding-agent-shells/current-state.md
@@ -302,6 +302,7 @@ Screen:
 - `apps/mobile/app/agents/new.tsx`
 - `apps/mobile/app/agents/[threadId].tsx`
 - Read-only phone-first dashboard with a capped Recent Work section, providers, gateway-owned attention threads, active threads, and terminal sessions.
+- The dashboard renders the shared mobile connection banner with agent-workspace labels for connecting, offline, and reconnecting states; the banner can retry the existing gateway client connection and does not hide the last hydrated gateway summary.
 - Recent Work is derived only from `RuntimeSummarySchema`: attention threads sort before normal active threads, running attachable terminal sessions appear after thread work, and the quick new-run action uses the existing `/agents/new` route when thread creation is enabled.
 - Provider Setup warnings are derived only from `RuntimeSummarySchema.providers`, show coarse install/auth/availability states plus safe setup action labels, and do not render foreground terminal setup commands, credentials, or raw provider errors.
 - Notification controls render approval, input, and failed-run attention push switches, load them through the authenticated gateway client, submit full replacement updates, and keep preference state transient in component memory.

--- a/www/content/docs/coding-agents.mdx
+++ b/www/content/docs/coding-agents.mdx
@@ -181,7 +181,7 @@ Running app previews and local dev servers can appear in the coding workspace wh
 
 ## Mobile workflow
 
-On mobile, use the coding-agent workspace to check recent work, answer approvals, inspect safe review details, and jump into a bound terminal session. The Recent Work section promotes approval or input requests before normal running work, then shows attachable terminal sessions from the same runtime summary. Provider setup warnings use safe status and action labels only; setup commands and credentials stay out of the mobile view. The mobile app stores only small UI references such as selected thread, terminal, or preview ids; thread snapshots, file contents, diffs, and terminal output are reloaded from your Matrix computer when needed.
+On mobile, use the coding-agent workspace to check recent work, answer approvals, inspect safe review details, and jump into a bound terminal session. The Recent Work section promotes approval or input requests before normal running work, then shows attachable terminal sessions from the same runtime summary. If the connection drops, the workspace shows a reconnecting or offline banner while keeping the last hydrated summary visible. Provider setup warnings use safe status and action labels only; setup commands and credentials stay out of the mobile view. The mobile app stores only small UI references such as selected thread, terminal, or preview ids; thread snapshots, file contents, diffs, and terminal output are reloaded from your Matrix computer when needed.
 
 ## Desktop workflow
 


### PR DESCRIPTION
## Summary
- add surface-specific labels to the shared mobile connection banner
- show offline/reconnecting state on the mobile coding-agent workspace without hiding the hydrated summary
- document the mobile recovery behavior in the spec state and public coding-agent docs

## Tests
- pnpm --filter matrix-os-mobile run test -- ConnectionBanner.test.tsx agents-screen.test.tsx
- pnpm --filter matrix-os-mobile run lint
- pnpm --filter matrix-os-mobile exec tsc --noEmit
- git diff --check
- bun run check:patterns
- bun run typecheck
- rg -n "t3code|reference repo|external inspiration" apps/mobile/app/agents/index.tsx apps/mobile/components/ConnectionBanner.tsx apps/mobile/__tests__/ConnectionBanner.test.tsx apps/mobile/__tests__/agents-screen.test.tsx specs/105-coding-agent-shells/current-state.md www/content/docs/coding-agents.mdx

## Review / Monitoring
- Stacked above #832.
- Keep review gated on Greptile 5/5 before enabling CI.

## Invariants
- Source of truth remains the gateway/runtime summary; the mobile shell only renders connection state and retries the existing gateway client.
- No new persistence is introduced; mobile storage remains limited to bounded safe UI references.
- No provider credentials, bearer tokens, transcripts, terminal output, file contents, diffs, raw approvals, or launch tokens are stored or rendered.
- No backend routes, database writes, IPC, or WebSocket contracts change in this slice.
- User-facing recovery text remains generic and does not expose provider, filesystem, network, database, or credential details.
- Deferred scope: device/manual validation of native connectivity behavior remains part of the broader mobile pass.