### PR TITLE
feat(terminal): add attached rich image paste

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/103-self-host-installer"
+  "feature_directory": "specs/106-terminal-rich-paste"
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -420,12 +420,15 @@ Read these on demand, not every session:
 - Owner-local Postgres on the customer VPS for Matrix OS permission/audit data; separate homeserver database; separate Telegram bridge database; separate WhatsApp bridge database; owner-local media/cache paths covered by backup/restore policy (077-matrix-messaging-bridge)
 - TypeScript 5.5+ strict, ES modules, Node.js 24+, React 19, Next.js 16 shell/platform, Hono gateway + Hono, Zod 4 via `zod/v4`, Kysely/Postgres, existing onboarding WebSocket, existing Symphony routes, existing integrations registry/Pipedream proxy, existing terminal stack, lucide-react, Playwright/Vitest, always-on Hermes with Claude/Codex augmentation, Finna-inspired admin/control surface patterns (082-paid-beta-readiness)
 - Owner-controlled Postgres/Kysely for readiness, integration capability, agent action, admin/control activity, company context, and audit data; owner home files for inspectable onboarding completion/profile/config exports under `~/system/`; no new embedded database or ORM (082-paid-beta-readiness)
+- TypeScript 5.9+, strict mode, ES modules; runtime target Node.js 24+ + Existing sync-client CLI, gateway shell routes, Hono, Zod 4, native Fetch/FormData/Blob, existing `ws` attach transport (106-terminal-rich-paste)
+- Owner-controlled filesystem under Matrix home for paste assets; no new database persistence (106-terminal-rich-paste)
 
 - TypeScript 5.5+ strict, ES modules + node-pty (backend), @xterm/xterm + addon-webgl + addon-search + addon-serialize + addon-fit (frontend), Hono WebSocket (gateway), Zod 4 (validation) (056-terminal-upgrade)
 - Files — `~/system/terminal-sessions.json` (session metadata), `~/system/terminal-layout.json` (layout with sessionId) (056-terminal-upgrade)
 
 ## Recent Changes
 
+- 106-terminal-rich-paste: Planned attached CLI rich paste for local image paths and observable clipboard image pastes, with owner-scoped gateway paste assets and safe prompt rewriting.
 - 077-matrix-messaging-bridge: Planned owner-controlled Matrix messaging bridge for Telegram and WhatsApp first, with homeserver/appservice spike gates, per-room Hermes permissions, and separate owner-local bridge/homeserver/permission storage.
 - 056-terminal-upgrade: Added TypeScript 5.5+ strict, ES modules + node-pty (backend), @xterm/xterm + addon-webgl + addon-search + addon-serialize + addon-fit (frontend), Hono WebSocket (gateway), Zod 4 (validation)
 
@@ -475,5 +478,5 @@ Five canonical roles using default label names. See `docs/agents/triage-labels.m
 Single-context: `CONTEXT.md` + `docs/adr/` at repo root. See `docs/agents/domain.md`.
 
 <!-- SPECKIT START -->
-Current Spec Kit plan: `specs/088-macos-dev-experience/plan.md`.
+Current Spec Kit plan: `specs/106-terminal-rich-paste/plan.md`.
 <!-- SPECKIT END -->

--- a/packages/gateway/src/server.ts
+++ b/packages/gateway/src/server.ts
@@ -208,6 +208,7 @@ import {
   LayoutStore,
   ScrollbackStore,
   ShellPreferencesStore,
+  createTerminalPasteAssetService,
   createPendingTerminalInputQueue,
   createShellCommandRunner,
   createShellWsHandler,
@@ -1482,6 +1483,7 @@ export async function createGateway(config: GatewayConfig) {
   app.route("/api/company-brain", createCompanyBrainRoutes({ service: companyBrainService }));
   app.route("/api/support-growth", createDraftActionRoutes({ service: draftActionService }));
   const shellSessionCreateRateLimiter = createRateLimiter(SHELL_SESSION_CREATE_RATE_LIMIT);
+  const terminalPasteAssets = createTerminalPasteAssetService({ homePath });
   const shellRouteDeps = {
     registry: zellijShellRegistry,
     preferences: shellPreferencesStore,
@@ -1490,6 +1492,7 @@ export async function createGateway(config: GatewayConfig) {
     shellBackend: zellijAdapter,
     shellThemeConfig: zellijAdapter,
     commandRunner: createShellCommandRunner({ homePath }),
+    pasteAssets: terminalPasteAssets,
     sessionCreateRateLimiter: shellSessionCreateRateLimiter,
   };
   const systemActivityCandidates = new CleanupCandidateRegistry();
@@ -3865,6 +3868,7 @@ export async function createGateway(config: GatewayConfig) {
       cronService.stop();
       drainReconnectableAbortEntries(reconnectableAbortControllers);
       if (canvasCleanupTimer) clearInterval(canvasCleanupTimer);
+      terminalPasteAssets.close();
       canvasSubscriptionHub?.close();
       systemActivityCandidates.clear();
       await channelManager.stop();

--- a/packages/gateway/src/shell/index.ts
+++ b/packages/gateway/src/shell/index.ts
@@ -5,6 +5,7 @@ export * from "./command-runner.js";
 export * from "./errors.js";
 export * from "./layouts.js";
 export * from "./pending-input.js";
+export * from "./paste-assets.js";
 export * from "./preferences.js";
 export * from "./registry.js";
 export * from "./replay-buffer.js";

--- a/packages/gateway/src/shell/paste-assets.ts
+++ b/packages/gateway/src/shell/paste-assets.ts
@@ -1,0 +1,358 @@
+import { randomUUID } from "node:crypto";
+import { lstat, mkdir, readdir, rename, unlink, writeFile } from "node:fs/promises";
+import { join, relative } from "node:path";
+import { SESSION_NAME_PATTERN } from "./names.js";
+
+export const TERMINAL_PASTE_ASSET_ROOT = "projects/.matrix-terminal-pastes";
+export const TERMINAL_PASTE_ASSET_FIELD = "asset";
+export const TERMINAL_PASTE_ASSET_TRANSACTION_FIELD = "transactionId";
+export const TERMINAL_PASTE_ASSET_MAX_FILES = 5;
+export const TERMINAL_PASTE_ASSET_MAX_FILE_BYTES = 10 * 1024 * 1024;
+export const TERMINAL_PASTE_ASSET_BODY_LIMIT_BYTES = 52 * 1024 * 1024;
+export const TERMINAL_PASTE_ASSET_DEFAULT_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000;
+export const TERMINAL_PASTE_ASSET_DEFAULT_MAX_FILES_PER_SESSION = 200;
+export const TERMINAL_PASTE_ASSET_CLEANUP_INTERVAL_MS = 60 * 60 * 1000;
+
+export const TERMINAL_PASTE_IMAGE_TYPES = {
+  png: {
+    mimeType: "image/png",
+    extension: ".png",
+  },
+  jpeg: {
+    mimeType: "image/jpeg",
+    extension: ".jpg",
+  },
+  gif: {
+    mimeType: "image/gif",
+    extension: ".gif",
+  },
+  webp: {
+    mimeType: "image/webp",
+    extension: ".webp",
+  },
+} as const;
+
+export type TerminalPasteAssetMimeType =
+  (typeof TERMINAL_PASTE_IMAGE_TYPES)[keyof typeof TERMINAL_PASTE_IMAGE_TYPES]["mimeType"];
+
+export type TerminalPasteAssetErrorCode =
+  | "invalid_request"
+  | "payload_too_large"
+  | "session_not_found"
+  | "write_failed";
+
+export interface TerminalPasteAssetCleanupPolicy {
+  maxAgeMs: number;
+  maxAssetsPerSession: number;
+  cleanupIntervalMs: number;
+}
+
+export interface TerminalPasteAssetUploadFile {
+  name: string;
+  type: string;
+  size: number;
+  arrayBuffer(): Promise<ArrayBuffer>;
+}
+
+export interface TerminalPasteAssetUploadInput {
+  sessionName: string;
+  transactionId?: string;
+  files: TerminalPasteAssetUploadFile[];
+}
+
+export interface StoredTerminalPasteAsset {
+  assetId: string;
+  path: string;
+  homeRelativePath: string;
+  mimeType: TerminalPasteAssetMimeType;
+  size: number;
+}
+
+export interface TerminalPasteAssetUploadResult {
+  assets: StoredTerminalPasteAsset[];
+}
+
+export interface TerminalPasteAssetService {
+  upload(input: TerminalPasteAssetUploadInput): Promise<TerminalPasteAssetUploadResult>;
+  sweepExpired(): Promise<void>;
+  close(): void;
+}
+
+export interface TerminalPasteAssetServiceOptions {
+  homePath: string;
+  cleanupPolicy?: Partial<TerminalPasteAssetCleanupPolicy>;
+  now?: () => Date;
+}
+
+export class TerminalPasteAssetError extends Error {
+  readonly code: TerminalPasteAssetErrorCode;
+  readonly status: 400 | 413 | 404 | 500;
+
+  constructor(code: TerminalPasteAssetErrorCode, status: 400 | 413 | 404 | 500) {
+    super("Request failed");
+    this.name = "TerminalPasteAssetError";
+    this.code = code;
+    this.status = status;
+  }
+}
+
+export function createTerminalPasteAssetError(
+  code: TerminalPasteAssetErrorCode,
+  status: 400 | 413 | 404 | 500,
+): TerminalPasteAssetError {
+  return new TerminalPasteAssetError(code, status);
+}
+
+export function createTerminalPasteAssetService(
+  options: TerminalPasteAssetServiceOptions,
+): TerminalPasteAssetService {
+  return new DefaultTerminalPasteAssetService(options);
+}
+
+class DefaultTerminalPasteAssetService implements TerminalPasteAssetService {
+  readonly homePath: string;
+  readonly cleanupPolicy: TerminalPasteAssetCleanupPolicy;
+  readonly now: () => Date;
+  private cleanupTimer: ReturnType<typeof setInterval> | undefined;
+
+  constructor(options: TerminalPasteAssetServiceOptions) {
+    this.homePath = options.homePath;
+    this.cleanupPolicy = {
+      maxAgeMs: options.cleanupPolicy?.maxAgeMs ?? TERMINAL_PASTE_ASSET_DEFAULT_MAX_AGE_MS,
+      maxAssetsPerSession:
+        options.cleanupPolicy?.maxAssetsPerSession ?? TERMINAL_PASTE_ASSET_DEFAULT_MAX_FILES_PER_SESSION,
+      cleanupIntervalMs:
+        options.cleanupPolicy?.cleanupIntervalMs ?? TERMINAL_PASTE_ASSET_CLEANUP_INTERVAL_MS,
+    };
+    this.now = options.now ?? (() => new Date());
+    if (this.cleanupPolicy.cleanupIntervalMs > 0) {
+      void this.sweepExpired().catch((err: unknown) => {
+        logCleanupFailure(err);
+      });
+      this.cleanupTimer = setInterval(() => {
+        void this.sweepExpired().catch((err: unknown) => {
+          logCleanupFailure(err);
+        });
+      }, this.cleanupPolicy.cleanupIntervalMs);
+      this.cleanupTimer.unref?.();
+    }
+  }
+
+  async upload(input: TerminalPasteAssetUploadInput): Promise<TerminalPasteAssetUploadResult> {
+    if (!SESSION_NAME_PATTERN.test(input.sessionName) || !isSafeTransactionId(input.transactionId)) {
+      throw createTerminalPasteAssetError("invalid_request", 400);
+    }
+    if (input.files.length < 1 || input.files.length > TERMINAL_PASTE_ASSET_MAX_FILES) {
+      throw createTerminalPasteAssetError("invalid_request", 400);
+    }
+
+    const assets: StoredTerminalPasteAsset[] = [];
+    const dateSegment = this.now().toISOString().slice(0, 10);
+    const homeRelativeDirectory = [
+      TERMINAL_PASTE_ASSET_ROOT,
+      input.sessionName,
+      dateSegment,
+    ].join("/");
+    const targetDirectory = join(this.homePath, homeRelativeDirectory);
+
+    for (const file of input.files) {
+      if (file.size > TERMINAL_PASTE_ASSET_MAX_FILE_BYTES) {
+        throw createTerminalPasteAssetError("payload_too_large", 413);
+      }
+      const bytes = Buffer.from(await file.arrayBuffer());
+      if (bytes.byteLength < 1) {
+        throw createTerminalPasteAssetError("invalid_request", 400);
+      }
+      if (bytes.byteLength > TERMINAL_PASTE_ASSET_MAX_FILE_BYTES) {
+        throw createTerminalPasteAssetError("payload_too_large", 413);
+      }
+      const imageType = detectImageType(bytes);
+      if (!imageType) {
+        throw createTerminalPasteAssetError("invalid_request", 400);
+      }
+
+      const assetId = `paste_${randomUUID().replaceAll("-", "")}`;
+      const filename = `${assetId}${imageType.extension}`;
+      const homeRelativePath = `${homeRelativeDirectory}/${filename}`;
+      const destinationPath = join(this.homePath, homeRelativePath);
+      const tmpPath = join(targetDirectory, `.${filename}.${randomUUID()}.tmp`);
+
+      try {
+        await mkdir(targetDirectory, { recursive: true, mode: 0o700 });
+        await writeFile(tmpPath, bytes, { flag: "wx", mode: 0o600 });
+        await rename(tmpPath, destinationPath);
+      } catch (err: unknown) {
+        await safeUnlink(tmpPath);
+        console.warn("[shell] terminal paste asset write failed:", err instanceof Error ? err.message : String(err));
+        throw createTerminalPasteAssetError("write_failed", 500);
+      }
+
+      assets.push({
+        assetId,
+        path: destinationPath,
+        homeRelativePath,
+        mimeType: imageType.mimeType,
+        size: bytes.byteLength,
+      });
+    }
+
+    return { assets };
+  }
+
+  async sweepExpired(): Promise<void> {
+    const root = join(this.homePath, TERMINAL_PASTE_ASSET_ROOT);
+    const files = await collectCleanupFiles(root);
+    const retainedBySession: Record<string, CleanupFile[]> = Object.create(null);
+    const nowMs = this.now().getTime();
+
+    for (const file of files) {
+      if (nowMs - file.mtimeMs > this.cleanupPolicy.maxAgeMs) {
+        await safeUnlink(file.path);
+        continue;
+      }
+      const sessionName = relative(root, file.path).split(/[\\/]/)[0];
+      if (!sessionName || !SESSION_NAME_PATTERN.test(sessionName)) {
+        continue;
+      }
+      retainedBySession[sessionName] = retainedBySession[sessionName] ?? [];
+      retainedBySession[sessionName].push(file);
+    }
+
+    for (const retained of Object.values(retainedBySession)) {
+      retained.sort((left, right) => right.mtimeMs - left.mtimeMs);
+      for (const stale of retained.slice(this.cleanupPolicy.maxAssetsPerSession)) {
+        await safeUnlink(stale.path);
+      }
+    }
+  }
+
+  close(): void {
+    if (this.cleanupTimer) {
+      clearInterval(this.cleanupTimer);
+      this.cleanupTimer = undefined;
+    }
+  }
+}
+
+interface CleanupFile {
+  path: string;
+  mtimeMs: number;
+}
+
+async function collectCleanupFiles(directory: string): Promise<CleanupFile[]> {
+  let entries;
+  try {
+    entries = await readdir(directory, { withFileTypes: true });
+  } catch (err: unknown) {
+    if (
+      err instanceof Error &&
+      "code" in err &&
+      (err as NodeJS.ErrnoException).code === "ENOENT"
+    ) {
+      return [];
+    }
+    throw err;
+  }
+
+  const files: CleanupFile[] = [];
+  for (const entry of entries) {
+    const entryPath = join(directory, entry.name);
+    let stats;
+    try {
+      stats = await lstat(entryPath);
+    } catch (err: unknown) {
+      if (
+        err instanceof Error &&
+        "code" in err &&
+        (err as NodeJS.ErrnoException).code === "ENOENT"
+      ) {
+        continue;
+      }
+      throw err;
+    }
+    if (stats.isSymbolicLink()) {
+      continue;
+    }
+    if (stats.isDirectory()) {
+      files.push(...await collectCleanupFiles(entryPath));
+      continue;
+    }
+    if (stats.isFile()) {
+      files.push({ path: entryPath, mtimeMs: stats.mtimeMs });
+    }
+  }
+  return files;
+}
+
+function isSafeTransactionId(value: string | undefined): boolean {
+  return value === undefined || /^[a-zA-Z0-9_.:-]{1,80}$/.test(value);
+}
+
+function detectImageType(bytes: Uint8Array): {
+  mimeType: TerminalPasteAssetMimeType;
+  extension: string;
+} | null {
+  if (
+    bytes.length >= 8 &&
+    bytes[0] === 0x89 &&
+    bytes[1] === 0x50 &&
+    bytes[2] === 0x4e &&
+    bytes[3] === 0x47 &&
+    bytes[4] === 0x0d &&
+    bytes[5] === 0x0a &&
+    bytes[6] === 0x1a &&
+    bytes[7] === 0x0a
+  ) {
+    return TERMINAL_PASTE_IMAGE_TYPES.png;
+  }
+  if (
+    bytes.length >= 3 &&
+    bytes[0] === 0xff &&
+    bytes[1] === 0xd8 &&
+    bytes[2] === 0xff
+  ) {
+    return TERMINAL_PASTE_IMAGE_TYPES.jpeg;
+  }
+  if (
+    bytes.length >= 6 &&
+    bytes[0] === 0x47 &&
+    bytes[1] === 0x49 &&
+    bytes[2] === 0x46 &&
+    bytes[3] === 0x38
+  ) {
+    return TERMINAL_PASTE_IMAGE_TYPES.gif;
+  }
+  if (
+    bytes.length >= 12 &&
+    bytes[0] === 0x52 &&
+    bytes[1] === 0x49 &&
+    bytes[2] === 0x46 &&
+    bytes[3] === 0x46 &&
+    bytes[8] === 0x57 &&
+    bytes[9] === 0x45 &&
+    bytes[10] === 0x42 &&
+    bytes[11] === 0x50
+  ) {
+    return TERMINAL_PASTE_IMAGE_TYPES.webp;
+  }
+  return null;
+}
+
+async function safeUnlink(path: string): Promise<void> {
+  try {
+    await unlink(path);
+  } catch (err: unknown) {
+    if (
+      err instanceof Error &&
+      "code" in err &&
+      (err as NodeJS.ErrnoException).code === "ENOENT"
+    ) {
+      return;
+    }
+    console.warn("[shell] terminal paste temp cleanup failed:", err instanceof Error ? err.message : String(err));
+  }
+}
+
+function logCleanupFailure(err: unknown): void {
+  console.warn("[shell] terminal paste cleanup failed:", err instanceof Error ? err.message : String(err));
+}

--- a/packages/gateway/src/shell/routes.ts
+++ b/packages/gateway/src/shell/routes.ts
@@ -10,6 +10,13 @@ import {
   type ShellPreferencesStore,
 } from "./preferences.js";
 import type { ShellCommandRunner } from "./command-runner.js";
+import {
+  TERMINAL_PASTE_ASSET_BODY_LIMIT_BYTES,
+  TERMINAL_PASTE_ASSET_FIELD,
+  TERMINAL_PASTE_ASSET_TRANSACTION_FIELD,
+  TerminalPasteAssetError,
+  type TerminalPasteAssetService,
+} from "./paste-assets.js";
 
 interface SessionRegistryRoutes {
   list(): Promise<unknown[]>;
@@ -78,6 +85,7 @@ export interface ShellRouteDeps {
   shellBackend?: ShellBackendHealthRoutes;
   shellThemeConfig?: ShellThemeConfigRoutes;
   commandRunner?: ShellCommandRunner;
+  pasteAssets?: TerminalPasteAssetService;
   sessionCreateRateLimiter?: RateLimiter;
 }
 
@@ -148,6 +156,13 @@ export function createShellRoutes(deps: ShellRouteDeps): Hono {
   const layoutBodyLimit = bodyLimit({ maxSize: 128_000 });
   const deleteBodyLimit = bodyLimit({ maxSize: 512 });
   const runBodyLimit = bodyLimit({ maxSize: 16_384 });
+  const pasteAssetBodyLimit = bodyLimit({
+    maxSize: TERMINAL_PASTE_ASSET_BODY_LIMIT_BYTES,
+    onError: (c) => c.json(
+      { error: { code: "payload_too_large", message: "Request failed" } },
+      413,
+    ),
+  });
 
   app.get("/health", async (c) => {
     if (!deps.shellBackend) {
@@ -274,6 +289,25 @@ export function createShellRoutes(deps: ShellRouteDeps): Hono {
       if (!deps.commandRunner) return unavailable(c, "run_unavailable");
       const body = RunBodySchema.parse(await c.req.json());
       return c.json(await deps.commandRunner.run(body));
+    } catch (err) {
+      return safeError(c, err);
+    }
+  });
+
+  app.post("/sessions/:name/paste-assets", pasteAssetBodyLimit, async (c) => {
+    try {
+      if (!deps.pasteAssets) return unavailable(c, "paste_assets_unavailable");
+      const sessionName = SafeSessionNameSchema.parse(c.req.param("name"));
+      const form = await c.req.formData();
+      const transactionIdValue = form.get(TERMINAL_PASTE_ASSET_TRANSACTION_FIELD);
+      const transactionId = typeof transactionIdValue === "string" ? transactionIdValue : undefined;
+      const files = form.getAll(TERMINAL_PASTE_ASSET_FIELD).filter(isUploadFile);
+      const result = await deps.pasteAssets.upload({
+        sessionName,
+        transactionId,
+        files,
+      });
+      return c.json(result, 201);
     } catch (err) {
       return safeError(c, err);
     }
@@ -495,6 +529,17 @@ function safeError(c: Context, err: unknown) {
       400,
     );
   }
+  if (err instanceof TerminalPasteAssetError) {
+    return c.json(
+      {
+        error: {
+          code: err.code,
+          message: err.code === "invalid_request" ? "Invalid request" : "Request failed",
+        },
+      },
+      err.status as 500,
+    );
+  }
   const shellErr = toShellError(err);
   if (shellErr.diagnostic) {
     console.warn("[shell] route failed:", {
@@ -508,6 +553,19 @@ function safeError(c: Context, err: unknown) {
   return c.json(
     { error: { code: shellErr.code, message: shellErr.safeMessage } },
     (shellErr.status ?? 500) as 500,
+  );
+}
+
+function isUploadFile(value: FormDataEntryValue): value is File {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "arrayBuffer" in value &&
+    typeof (value as { arrayBuffer?: unknown }).arrayBuffer === "function" &&
+    "size" in value &&
+    typeof (value as { size?: unknown }).size === "number" &&
+    "type" in value &&
+    typeof (value as { type?: unknown }).type === "string"
   );
 }
 

--- a/packages/sync-client/src/cli/clipboard-image.ts
+++ b/packages/sync-client/src/cli/clipboard-image.ts
@@ -1,0 +1,198 @@
+import { execFile } from "node:child_process";
+import type { ClipboardImageCandidate } from "./rich-paste.js";
+import {
+  RICH_PASTE_MAX_IMAGE_BYTES,
+  type RichPasteImageMimeType,
+} from "./rich-paste.js";
+
+export const CLIPBOARD_IMAGE_TIMEOUT_MS = 2_000;
+
+export type ClipboardImageUnavailableReason =
+  | "unsupported_platform"
+  | "missing_helper"
+  | "empty_clipboard"
+  | "timeout"
+  | "read_failed";
+
+export type ClipboardImageReaderResult =
+  | {
+      status: "available";
+      candidate: ClipboardImageCandidate;
+    }
+  | {
+      status: "unavailable";
+      reason: ClipboardImageUnavailableReason;
+    };
+
+export interface ClipboardImageReader {
+  readImage(): Promise<ClipboardImageReaderResult>;
+}
+
+export interface ClipboardImageCommandRunner {
+  execFile(input: {
+    file: string;
+    args: string[];
+    timeoutMs: number;
+  }): Promise<{
+    stdout: Uint8Array;
+    stderr: Uint8Array;
+  }>;
+}
+
+export interface MacOsClipboardImageReaderOptions {
+  platform?: NodeJS.Platform;
+  commandRunner?: ClipboardImageCommandRunner;
+  timeoutMs?: number;
+  now?: () => Date;
+}
+
+export function createUnsupportedClipboardImageReader(
+  reason: ClipboardImageUnavailableReason = "unsupported_platform",
+): ClipboardImageReader {
+  return {
+    async readImage() {
+      return { status: "unavailable", reason };
+    },
+  };
+}
+
+export function createMacOsClipboardImageReader(
+  options: MacOsClipboardImageReaderOptions = {},
+): ClipboardImageReader {
+  const platform = options.platform ?? process.platform;
+  const timeoutMs = options.timeoutMs ?? CLIPBOARD_IMAGE_TIMEOUT_MS;
+  const now = options.now ?? (() => new Date());
+  const commandRunner = options.commandRunner ?? createNodeClipboardImageCommandRunner();
+
+  return {
+    async readImage() {
+      if (platform !== "darwin") {
+        return { status: "unavailable", reason: "unsupported_platform" };
+      }
+
+      let output: Uint8Array;
+      try {
+        const result = await commandRunner.execFile({
+          file: "pngpaste",
+          args: ["-"],
+          timeoutMs,
+        });
+        output = result.stdout;
+      } catch (err: unknown) {
+        return { status: "unavailable", reason: reasonForCommandFailure(err) };
+      }
+
+      if (output.byteLength < 1) {
+        return { status: "unavailable", reason: "empty_clipboard" };
+      }
+      if (output.byteLength > RICH_PASTE_MAX_IMAGE_BYTES) {
+        return { status: "unavailable", reason: "read_failed" };
+      }
+
+      const mimeType = sniffImageMimeType(output);
+      if (!mimeType) {
+        return { status: "unavailable", reason: "empty_clipboard" };
+      }
+
+      const bytes = new Uint8Array(output);
+      return {
+        status: "available",
+        candidate: {
+          kind: "clipboard",
+          capturedAt: now(),
+          sizeBytes: bytes.byteLength,
+          mimeType,
+          bytes,
+        } satisfies ClipboardImageCandidate,
+      };
+    },
+  };
+}
+
+function createNodeClipboardImageCommandRunner(): ClipboardImageCommandRunner {
+  return {
+    execFile(input) {
+      return new Promise((resolve, reject) => {
+        execFile(
+          input.file,
+          input.args,
+          {
+            encoding: "buffer",
+            maxBuffer: RICH_PASTE_MAX_IMAGE_BYTES + 1,
+            timeout: input.timeoutMs,
+          },
+          (err, stdout, stderr) => {
+            if (err) {
+              reject(err);
+              return;
+            }
+            resolve({
+              stdout: new Uint8Array(stdout),
+              stderr: new Uint8Array(stderr),
+            });
+          },
+        );
+      });
+    },
+  };
+}
+
+function reasonForCommandFailure(err: unknown): ClipboardImageUnavailableReason {
+  if (err instanceof Error) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code === "ENOENT") {
+      return "missing_helper";
+    }
+    if (code === "ETIMEDOUT" || err.name === "TimeoutError") {
+      return "timeout";
+    }
+  }
+  return "read_failed";
+}
+
+function sniffImageMimeType(bytes: Uint8Array): RichPasteImageMimeType | null {
+  if (
+    bytes.length >= 8 &&
+    bytes[0] === 0x89 &&
+    bytes[1] === 0x50 &&
+    bytes[2] === 0x4e &&
+    bytes[3] === 0x47 &&
+    bytes[4] === 0x0d &&
+    bytes[5] === 0x0a &&
+    bytes[6] === 0x1a &&
+    bytes[7] === 0x0a
+  ) {
+    return "image/png";
+  }
+  if (
+    bytes.length >= 3 &&
+    bytes[0] === 0xff &&
+    bytes[1] === 0xd8 &&
+    bytes[2] === 0xff
+  ) {
+    return "image/jpeg";
+  }
+  if (
+    bytes.length >= 6 &&
+    bytes[0] === 0x47 &&
+    bytes[1] === 0x49 &&
+    bytes[2] === 0x46 &&
+    bytes[3] === 0x38
+  ) {
+    return "image/gif";
+  }
+  if (
+    bytes.length >= 12 &&
+    bytes[0] === 0x52 &&
+    bytes[1] === 0x49 &&
+    bytes[2] === 0x46 &&
+    bytes[3] === 0x46 &&
+    bytes[8] === 0x57 &&
+    bytes[9] === 0x45 &&
+    bytes[10] === 0x42 &&
+    bytes[11] === 0x50
+  ) {
+    return "image/webp";
+  }
+  return null;
+}

--- a/packages/sync-client/src/cli/rich-paste.ts
+++ b/packages/sync-client/src/cli/rich-paste.ts
@@ -1,0 +1,664 @@
+import { randomUUID } from "node:crypto";
+import { lstat, readFile, realpath, stat } from "node:fs/promises";
+import { homedir } from "node:os";
+import { basename, extname, resolve } from "node:path";
+import type { ClipboardImageReader } from "./clipboard-image.js";
+
+export const RICH_PASTE_MAX_ASSETS = 5;
+export const RICH_PASTE_MAX_IMAGE_BYTES = 10 * 1024 * 1024;
+export const RICH_PASTE_UPLOAD_TIMEOUT_MS = 30_000;
+
+export const RICH_PASTE_LOCAL_FAILURE_MESSAGES = {
+  local_read_failed: "Image paste failed: local image could not be read.",
+  image_too_large: "Image paste failed: image is too large.",
+  upload_failed: "Image paste failed: upload did not complete.",
+  unsupported_paste_event: "Image paste is not supported by this terminal paste event.",
+} as const;
+
+export const RICH_PASTE_IMAGE_TYPES = {
+  png: {
+    mimeType: "image/png",
+    extensions: [".png"],
+  },
+  jpeg: {
+    mimeType: "image/jpeg",
+    extensions: [".jpg", ".jpeg"],
+  },
+  gif: {
+    mimeType: "image/gif",
+    extensions: [".gif"],
+  },
+  webp: {
+    mimeType: "image/webp",
+    extensions: [".webp"],
+  },
+} as const;
+
+export type RichPasteImageMimeType =
+  (typeof RICH_PASTE_IMAGE_TYPES)[keyof typeof RICH_PASTE_IMAGE_TYPES]["mimeType"];
+
+export type PasteTransactionState =
+  | "collecting"
+  | "validating"
+  | "uploading"
+  | "rewriting"
+  | "forwarded"
+  | "failed";
+
+export type RichPasteFailureCode = keyof typeof RICH_PASTE_LOCAL_FAILURE_MESSAGES;
+
+export interface PasteTextRange {
+  start: number;
+  end: number;
+}
+
+export interface PasteTransaction {
+  transactionId: string;
+  sessionName: string;
+  rawText: string;
+  detectedCandidates: LocalImageCandidate[];
+  clipboardCandidate?: ClipboardImageCandidate;
+  assetCount: number;
+  state: PasteTransactionState;
+  failureCode?: RichPasteFailureCode;
+}
+
+export interface LocalImageCandidate {
+  kind: "local-path";
+  sourceTextRange: PasteTextRange;
+  displayText: string;
+  localPath: string;
+  dedupeKey: string;
+  sizeBytes: number;
+  mimeType: RichPasteImageMimeType;
+  bytes?: Uint8Array;
+}
+
+export interface ClipboardImageCandidate {
+  kind: "clipboard";
+  capturedAt: Date;
+  sizeBytes: number;
+  mimeType: RichPasteImageMimeType;
+  bytes: Uint8Array;
+}
+
+export interface RemotePasteAsset {
+  assetId: string;
+  path: string;
+  homeRelativePath: string;
+  mimeType: RichPasteImageMimeType;
+  size: number;
+}
+
+export type RewriteResult =
+  | {
+      status: "passthrough";
+      outgoingText: string;
+      assets: [];
+      localMessage?: undefined;
+    }
+  | {
+      status: "rewritten";
+      outgoingText: string;
+      assets: RemotePasteAsset[];
+      localMessage?: undefined;
+    }
+  | {
+      status: "failed";
+      outgoingText?: undefined;
+      assets: [];
+      localMessage: string;
+      failureCode: RichPasteFailureCode;
+    };
+
+export interface RichPasteUploadAsset {
+  name: string;
+  mimeType: RichPasteImageMimeType;
+  bytes: Uint8Array;
+}
+
+export interface RichPasteUploadClient {
+  uploadPasteAssets(input: {
+    sessionName: string;
+    transactionId: string;
+    assets: RichPasteUploadAsset[];
+  }): Promise<RemotePasteAsset[]>;
+}
+
+export interface RichPasteRewriteInput {
+  sessionName: string;
+  text: string;
+  observablePaste: boolean;
+}
+
+export interface RichPasteRewriter {
+  rewrite(input: RichPasteRewriteInput): Promise<RewriteResult>;
+}
+
+export interface ProcessRichPasteTransactionInput extends RichPasteRewriteInput {
+  uploadClient: RichPasteUploadClient;
+  clipboardReader?: ClipboardImageReader;
+}
+
+export interface RichPasteUploadClientOptions {
+  gatewayUrl: string;
+  token?: string;
+  fetch?: typeof fetch;
+  timeoutMs?: number;
+}
+
+export interface RichPasteInputSegment {
+  text: string;
+  observablePaste: boolean;
+}
+
+type InternalCandidate = LocalImageCandidate & {
+  quote?: "\"" | "'";
+  uploadIndex?: number;
+};
+
+const IMAGE_EXTENSIONS = Object.values(RICH_PASTE_IMAGE_TYPES)
+  .flatMap((type) => type.extensions);
+const IMAGE_EXTENSION_PATTERN = IMAGE_EXTENSIONS
+  .map((extension) => extension.replace(".", "\\."))
+  .join("|");
+const QUOTED_PATH_PATTERN = new RegExp(`(["'])([^"'\\r\\n]+?(?:${IMAGE_EXTENSION_PATTERN}))\\1`, "gi");
+const UNQUOTED_PATH_PATTERN = new RegExp(`(^|[\\s(])((?:~\\/|\\/)[^\\s"'<>]+?(?:${IMAGE_EXTENSION_PATTERN}))`, "gi");
+
+export function shouldProcessRichPasteText(text: string): boolean {
+  return /(?:~\/|\/)[^\r\n]*\.(?:png|jpe?g|gif|webp)(?=$|[\s)"'.,:;!?])/i.test(text);
+}
+
+export function splitBracketedPasteInput(input: string): RichPasteInputSegment[] | null {
+  const startMarker = "\u001b[200~";
+  const endMarker = "\u001b[201~";
+  if (!input.includes(startMarker)) {
+    return null;
+  }
+
+  const segments: RichPasteInputSegment[] = [];
+  let cursor = 0;
+  while (cursor < input.length) {
+    const start = input.indexOf(startMarker, cursor);
+    if (start === -1) {
+      const tail = input.slice(cursor);
+      if (tail.length > 0) {
+        segments.push({ text: tail, observablePaste: false });
+      }
+      break;
+    }
+    if (start > cursor) {
+      segments.push({ text: input.slice(cursor, start), observablePaste: false });
+    }
+    const contentStart = start + startMarker.length;
+    const end = input.indexOf(endMarker, contentStart);
+    if (end === -1) {
+      return null;
+    }
+    segments.push({ text: input.slice(contentStart, end), observablePaste: true });
+    cursor = end + endMarker.length;
+  }
+
+  return segments;
+}
+
+export function createRichPasteUploadClient(options: RichPasteUploadClientOptions): RichPasteUploadClient {
+  const fetchImpl = options.fetch ?? fetch;
+  const timeoutMs = options.timeoutMs ?? RICH_PASTE_UPLOAD_TIMEOUT_MS;
+  const base = options.gatewayUrl.replace(/\/+$/, "");
+
+  return {
+    async uploadPasteAssets(input) {
+      const form = new FormData();
+      form.set("transactionId", input.transactionId);
+      for (const asset of input.assets) {
+        form.append(
+          "asset",
+          new Blob([Buffer.from(asset.bytes)], { type: asset.mimeType }),
+          asset.name,
+        );
+      }
+      const headers: Record<string, string> = {};
+      if (options.token) {
+        headers.Authorization = `Bearer ${options.token}`;
+      }
+
+      let res: Response;
+      try {
+        res = await fetchImpl(
+          `${base}/api/terminal/sessions/${encodeURIComponent(input.sessionName)}/paste-assets`,
+          {
+            method: "POST",
+            headers,
+            body: form,
+            signal: AbortSignal.timeout(timeoutMs),
+          },
+        );
+      } catch (err: unknown) {
+        throw codedError("Image paste failed", "upload_failed", err);
+      }
+
+      if (!res.ok) {
+        throw codedError("Image paste failed", "upload_failed");
+      }
+
+      let payload: unknown;
+      try {
+        payload = await res.json();
+      } catch (err: unknown) {
+        throw codedError("Image paste failed", "upload_failed", err);
+      }
+
+      return parseUploadResponse(payload);
+    },
+  };
+}
+
+export function createRichPasteRewriter(input: {
+  uploadClient: RichPasteUploadClient;
+  clipboardReader?: ClipboardImageReader;
+}): RichPasteRewriter {
+  return {
+    rewrite: (transaction) => processRichPasteTransaction({
+      ...transaction,
+      uploadClient: input.uploadClient,
+      clipboardReader: input.clipboardReader,
+    }),
+  };
+}
+
+export async function processRichPasteTransaction(
+  input: ProcessRichPasteTransactionInput,
+): Promise<RewriteResult> {
+  if (!shouldProcessRichPasteText(input.text) && !(input.observablePaste && input.text.length === 0)) {
+    return { status: "passthrough", outgoingText: input.text, assets: [] };
+  }
+
+  const validation = await collectLocalImageCandidates(input.text);
+  if (validation.status === "failed") {
+    return failedResult(validation.failureCode);
+  }
+  const candidates = validation.candidates;
+  if (candidates.length === 0) {
+    if (input.observablePaste && input.text.length === 0) {
+      return processClipboardOnlyPaste(input);
+    }
+    return { status: "passthrough", outgoingText: input.text, assets: [] };
+  }
+
+  const deduped = dedupeCandidates(candidates);
+  if (deduped.length > RICH_PASTE_MAX_ASSETS) {
+    return failedResult("upload_failed");
+  }
+
+  let remoteAssets: RemotePasteAsset[];
+  try {
+    remoteAssets = await input.uploadClient.uploadPasteAssets({
+      sessionName: input.sessionName,
+      transactionId: randomUUID(),
+      assets: deduped.map((candidate) => ({
+        name: basename(candidate.localPath),
+        mimeType: candidate.mimeType,
+        bytes: candidate.bytes ?? new Uint8Array(),
+      })),
+    });
+  } catch (err: unknown) {
+    if (err instanceof Error) {
+      return failedResult("upload_failed");
+    }
+    return failedResult("upload_failed");
+  }
+
+  if (remoteAssets.length !== deduped.length) {
+    return failedResult("upload_failed");
+  }
+
+  return {
+    status: "rewritten",
+    outgoingText: rewriteText(input.text, candidates, remoteAssets),
+    assets: remoteAssets,
+  };
+}
+
+async function processClipboardOnlyPaste(
+  input: ProcessRichPasteTransactionInput,
+): Promise<RewriteResult> {
+  if (!input.clipboardReader) {
+    return failedResult("unsupported_paste_event");
+  }
+  const clipboard = await input.clipboardReader.readImage();
+  if (clipboard.status !== "available") {
+    return failedResult("unsupported_paste_event");
+  }
+  if (clipboard.candidate.sizeBytes > RICH_PASTE_MAX_IMAGE_BYTES) {
+    return failedResult("image_too_large");
+  }
+
+  let remoteAssets: RemotePasteAsset[];
+  try {
+    remoteAssets = await input.uploadClient.uploadPasteAssets({
+      sessionName: input.sessionName,
+      transactionId: randomUUID(),
+      assets: [{
+        name: "clipboard.png",
+        mimeType: clipboard.candidate.mimeType,
+        bytes: clipboard.candidate.bytes,
+      }],
+    });
+  } catch (err: unknown) {
+    if (err instanceof Error) {
+      return failedResult("upload_failed");
+    }
+    return failedResult("upload_failed");
+  }
+  if (remoteAssets.length !== 1 || !remoteAssets[0]) {
+    return failedResult("upload_failed");
+  }
+  return {
+    status: "rewritten",
+    outgoingText: `Please inspect this image: ${remoteAssets[0].path}`,
+    assets: remoteAssets,
+  };
+}
+
+async function collectLocalImageCandidates(text: string): Promise<
+  | { status: "ok"; candidates: InternalCandidate[] }
+  | { status: "failed"; failureCode: RichPasteFailureCode }
+> {
+  const rawCandidates = findRawCandidates(text);
+  const candidates: InternalCandidate[] = [];
+
+  for (const raw of rawCandidates) {
+    const result = await validateLocalCandidate(raw);
+    if (result.status === "skip") {
+      continue;
+    }
+    if (result.status === "failed") {
+      return { status: "failed", failureCode: result.failureCode };
+    }
+    candidates.push(result.candidate);
+  }
+
+  return { status: "ok", candidates };
+}
+
+function findRawCandidates(text: string): InternalCandidate[] {
+  const candidates: InternalCandidate[] = [];
+  const occupiedRanges: PasteTextRange[] = [];
+
+  for (const match of text.matchAll(QUOTED_PATH_PATTERN)) {
+    const fullMatch = match[0];
+    const quote = match[1] as "\"" | "'";
+    const rawPath = match[2];
+    if (!rawPath || match.index === undefined) {
+      continue;
+    }
+    const start = match.index;
+    const end = start + fullMatch.length;
+    occupiedRanges.push({ start, end });
+    candidates.push(createRawCandidate({
+      text,
+      start,
+      end,
+      displayText: fullMatch,
+      rawPath,
+      quote,
+    }));
+  }
+
+  for (const match of text.matchAll(UNQUOTED_PATH_PATTERN)) {
+    const prefix = match[1] ?? "";
+    const rawPath = match[2];
+    if (!rawPath || match.index === undefined) {
+      continue;
+    }
+    const start = match.index + prefix.length;
+    const end = start + rawPath.length;
+    if (occupiedRanges.some((range) => rangesOverlap({ start, end }, range))) {
+      continue;
+    }
+    candidates.push(createRawCandidate({
+      text,
+      start,
+      end,
+      displayText: text.slice(start, end),
+      rawPath,
+    }));
+  }
+
+  return candidates.sort((left, right) => left.sourceTextRange.start - right.sourceTextRange.start);
+}
+
+function createRawCandidate(input: {
+  text: string;
+  start: number;
+  end: number;
+  displayText: string;
+  rawPath: string;
+  quote?: "\"" | "'";
+}): InternalCandidate {
+  const localPath = expandLocalPath(input.rawPath);
+  return {
+    kind: "local-path",
+    sourceTextRange: { start: input.start, end: input.end },
+    displayText: input.displayText,
+    localPath,
+    dedupeKey: localPath,
+    sizeBytes: 0,
+    mimeType: mimeTypeFromExtension(input.rawPath) ?? "image/png",
+    quote: input.quote,
+  };
+}
+
+async function validateLocalCandidate(candidate: InternalCandidate): Promise<
+  | { status: "ok"; candidate: InternalCandidate }
+  | { status: "skip" }
+  | { status: "failed"; failureCode: RichPasteFailureCode }
+> {
+  const extensionMimeType = mimeTypeFromExtension(candidate.localPath);
+  if (!extensionMimeType) {
+    return { status: "skip" };
+  }
+
+  try {
+    const linkStats = await lstat(candidate.localPath);
+    if (linkStats.isSymbolicLink() || !linkStats.isFile()) {
+      return { status: "failed", failureCode: "local_read_failed" };
+    }
+    if (linkStats.size > RICH_PASTE_MAX_IMAGE_BYTES) {
+      return { status: "failed", failureCode: "image_too_large" };
+    }
+    const [stats, bytes, resolvedRealPath] = await Promise.all([
+      stat(candidate.localPath),
+      readFile(candidate.localPath),
+      realpath(candidate.localPath),
+    ]);
+    if (!stats.isFile()) {
+      return { status: "failed", failureCode: "local_read_failed" };
+    }
+    if (bytes.byteLength > RICH_PASTE_MAX_IMAGE_BYTES) {
+      return { status: "failed", failureCode: "image_too_large" };
+    }
+    const sniffedMimeType = sniffImageMimeType(bytes);
+    if (!sniffedMimeType || sniffedMimeType !== extensionMimeType) {
+      return { status: "failed", failureCode: "local_read_failed" };
+    }
+    return {
+      status: "ok",
+      candidate: {
+        ...candidate,
+        localPath: resolvedRealPath,
+        dedupeKey: resolvedRealPath,
+        sizeBytes: bytes.byteLength,
+        mimeType: sniffedMimeType,
+        bytes,
+      },
+    };
+  } catch (err: unknown) {
+    if (err instanceof Error) {
+      return { status: "failed", failureCode: "local_read_failed" };
+    }
+    return { status: "failed", failureCode: "local_read_failed" };
+  }
+}
+
+function dedupeCandidates(candidates: InternalCandidate[]): InternalCandidate[] {
+  const uploadCandidates: InternalCandidate[] = [];
+  const seen: Array<{ key: string; index: number }> = [];
+  for (const candidate of candidates) {
+    const existing = seen.find((entry) => entry.key === candidate.dedupeKey);
+    if (existing) {
+      candidate.uploadIndex = existing.index;
+      continue;
+    }
+    candidate.uploadIndex = uploadCandidates.length;
+    seen.push({ key: candidate.dedupeKey, index: candidate.uploadIndex });
+    uploadCandidates.push(candidate);
+  }
+  return uploadCandidates;
+}
+
+function rewriteText(
+  text: string,
+  candidates: InternalCandidate[],
+  remoteAssets: RemotePasteAsset[],
+): string {
+  let output = "";
+  let cursor = 0;
+  for (const candidate of candidates) {
+    const replacement = remoteAssets[candidate.uploadIndex ?? 0]?.path;
+    if (!replacement) {
+      continue;
+    }
+    output += text.slice(cursor, candidate.sourceTextRange.start);
+    output += candidate.quote ? `${candidate.quote}${replacement}${candidate.quote}` : replacement;
+    cursor = candidate.sourceTextRange.end;
+  }
+  output += text.slice(cursor);
+  return output;
+}
+
+function failedResult(failureCode: RichPasteFailureCode): RewriteResult {
+  return {
+    status: "failed",
+    assets: [],
+    failureCode,
+    localMessage: RICH_PASTE_LOCAL_FAILURE_MESSAGES[failureCode],
+  };
+}
+
+function expandLocalPath(path: string): string {
+  if (path === "~") {
+    return homedir();
+  }
+  if (path.startsWith("~/")) {
+    return resolve(homedir(), path.slice(2));
+  }
+  return resolve(path);
+}
+
+function mimeTypeFromExtension(path: string): RichPasteImageMimeType | null {
+  const extension = extname(path).toLowerCase();
+  for (const type of Object.values(RICH_PASTE_IMAGE_TYPES)) {
+    if ((type.extensions as readonly string[]).includes(extension)) {
+      return type.mimeType;
+    }
+  }
+  return null;
+}
+
+function sniffImageMimeType(bytes: Uint8Array): RichPasteImageMimeType | null {
+  if (
+    bytes.length >= 8 &&
+    bytes[0] === 0x89 &&
+    bytes[1] === 0x50 &&
+    bytes[2] === 0x4e &&
+    bytes[3] === 0x47 &&
+    bytes[4] === 0x0d &&
+    bytes[5] === 0x0a &&
+    bytes[6] === 0x1a &&
+    bytes[7] === 0x0a
+  ) {
+    return "image/png";
+  }
+  if (
+    bytes.length >= 3 &&
+    bytes[0] === 0xff &&
+    bytes[1] === 0xd8 &&
+    bytes[2] === 0xff
+  ) {
+    return "image/jpeg";
+  }
+  if (
+    bytes.length >= 6 &&
+    bytes[0] === 0x47 &&
+    bytes[1] === 0x49 &&
+    bytes[2] === 0x46 &&
+    bytes[3] === 0x38
+  ) {
+    return "image/gif";
+  }
+  if (
+    bytes.length >= 12 &&
+    bytes[0] === 0x52 &&
+    bytes[1] === 0x49 &&
+    bytes[2] === 0x46 &&
+    bytes[3] === 0x46 &&
+    bytes[8] === 0x57 &&
+    bytes[9] === 0x45 &&
+    bytes[10] === 0x42 &&
+    bytes[11] === 0x50
+  ) {
+    return "image/webp";
+  }
+  return null;
+}
+
+function parseUploadResponse(payload: unknown): RemotePasteAsset[] {
+  if (
+    typeof payload !== "object" ||
+    payload === null ||
+    !("assets" in payload) ||
+    !Array.isArray((payload as { assets: unknown }).assets)
+  ) {
+    throw codedError("Image paste failed", "upload_failed");
+  }
+
+  const assets: RemotePasteAsset[] = [];
+  for (const item of (payload as { assets: unknown[] }).assets) {
+    if (typeof item !== "object" || item === null) {
+      throw codedError("Image paste failed", "upload_failed");
+    }
+    const candidate = item as Record<string, unknown>;
+    if (
+      typeof candidate.assetId !== "string" ||
+      typeof candidate.path !== "string" ||
+      typeof candidate.homeRelativePath !== "string" ||
+      typeof candidate.mimeType !== "string" ||
+      typeof candidate.size !== "number" ||
+      !isSupportedMimeType(candidate.mimeType)
+    ) {
+      throw codedError("Image paste failed", "upload_failed");
+    }
+    assets.push({
+      assetId: candidate.assetId,
+      path: candidate.path,
+      homeRelativePath: candidate.homeRelativePath,
+      mimeType: candidate.mimeType,
+      size: candidate.size,
+    });
+  }
+  return assets;
+}
+
+function isSupportedMimeType(value: string): value is RichPasteImageMimeType {
+  return Object.values(RICH_PASTE_IMAGE_TYPES).some((type) => type.mimeType === value);
+}
+
+function rangesOverlap(left: PasteTextRange, right: PasteTextRange): boolean {
+  return left.start < right.end && right.start < left.end;
+}
+
+function codedError(message: string, code: string, cause?: unknown): Error {
+  return Object.assign(new Error(message), { code, cause });
+}

--- a/packages/sync-client/src/cli/shell-client.ts
+++ b/packages/sync-client/src/cli/shell-client.ts
@@ -99,6 +99,7 @@ export { SHELL_ATTACH_LIVE_TAIL_FROM_SEQ };
 const BRACKETED_PASTE_OPEN = "\u001b[200~";
 const BRACKETED_PASTE_CLOSE = "\u001b[201~";
 const SHELL_ATTACH_MAX_PENDING_BRACKETED_PASTE_CHARS = 1024 * 1024;
+const BRACKETED_PASTE_INCOMPLETE_TIMEOUT_MS = 250;
 const SHELL_INPUT_FRAME_MAX_BYTES = 60_000;
 const DEFAULT_RUN_TIMEOUT_MS = 10 * 60 * 1000;
 const RUN_RESPONSE_GRACE_MS = 30_000;
@@ -129,6 +130,7 @@ const SAFE_SHELL_SERVER_ERROR_CODES = new Set([
   "zellij_failed",
 ]);
 const RICH_PASTE_UPLOAD_FAILED_MESSAGE = "Image paste failed: upload did not complete.";
+const INCOMPLETE_BRACKETED_PASTE_MESSAGE = "Image paste failed: paste did not complete.";
 
 type MaybeTtyStream = NodeJS.ReadStream & {
   isTTY?: boolean;
@@ -349,13 +351,44 @@ function splitTerminalInputFrames(data: string): string[] {
   return frames;
 }
 
-function createBracketedPasteStreamParser() {
+function createBracketedPasteStreamParser(options: {
+  onIncompletePaste?: () => void;
+  incompletePasteTimeoutMs?: number;
+} = {}) {
   let pending = "";
+  let incompletePasteTimer: ReturnType<typeof setTimeout> | undefined;
+
+  const clearIncompletePasteTimer = () => {
+    clearTimeout(incompletePasteTimer);
+    incompletePasteTimer = undefined;
+  };
+
+  const discardIncompletePaste = () => {
+    if (pending.startsWith(BRACKETED_PASTE_OPEN)) {
+      options.onIncompletePaste?.();
+    }
+    pending = "";
+    clearIncompletePasteTimer();
+  };
+
+  const setPending = (value: string) => {
+    pending = value;
+    clearIncompletePasteTimer();
+    if (!pending.startsWith(BRACKETED_PASTE_OPEN)) {
+      return;
+    }
+    const timeoutMs = options.incompletePasteTimeoutMs ?? BRACKETED_PASTE_INCOMPLETE_TIMEOUT_MS;
+    if (timeoutMs < 1) {
+      return;
+    }
+    incompletePasteTimer = setTimeout(discardIncompletePaste, timeoutMs);
+    incompletePasteTimer.unref?.();
+  };
 
   return {
     push(chunk: string): RichPasteInputSegment[] {
       const input = pending + chunk;
-      pending = "";
+      setPending("");
       const segments: RichPasteInputSegment[] = [];
       let cursor = 0;
 
@@ -368,7 +401,7 @@ function createBracketedPasteStreamParser() {
           if (ready.length > 0) {
             segments.push({ text: ready, observablePaste: false });
           }
-          pending = tail.slice(tail.length - heldLength);
+          setPending(tail.slice(tail.length - heldLength));
           break;
         }
 
@@ -379,7 +412,7 @@ function createBracketedPasteStreamParser() {
         const contentStart = start + BRACKETED_PASTE_OPEN.length;
         const end = input.indexOf(BRACKETED_PASTE_CLOSE, contentStart);
         if (end === -1) {
-          pending = input.slice(start);
+          setPending(input.slice(start));
           break;
         }
 
@@ -391,13 +424,14 @@ function createBracketedPasteStreamParser() {
       }
 
       if (pending.length > SHELL_ATTACH_MAX_PENDING_BRACKETED_PASTE_CHARS) {
-        pending = "";
+        discardIncompletePaste();
       }
 
       return segments;
     },
     reset() {
       pending = "";
+      clearIncompletePasteTimer();
     },
   };
 }
@@ -628,7 +662,11 @@ export function createShellClient(options: ShellClientOptions): ShellClient {
         resetLocalInputModes,
       });
       const controlDropper = createUnsupportedTerminalControlDropper();
-      const bracketedPasteParser = createBracketedPasteStreamParser();
+      const bracketedPasteParser = createBracketedPasteStreamParser({
+        onIncompletePaste: () => {
+          errorOutput.write(`\r\n${INCOMPLETE_BRACKETED_PASTE_MESSAGE}\r\n`);
+        },
+      });
       const richPasteEnabled = attachOptions.noRichPaste !== true && attachOptions.richPaste?.enabled !== false;
       const richPasteRewriter: RichPasteRewriter | undefined = richPasteEnabled
         ? attachOptions.richPaste?.rewriter ?? createRichPasteRewriter({

--- a/packages/sync-client/src/cli/shell-client.ts
+++ b/packages/sync-client/src/cli/shell-client.ts
@@ -1,4 +1,16 @@
 import { SHELL_ATTACH_LIVE_TAIL_FROM_SEQ } from "../protocol/shell.js";
+import {
+  createMacOsClipboardImageReader,
+  type ClipboardImageReader,
+} from "./clipboard-image.js";
+import {
+  createRichPasteRewriter,
+  createRichPasteUploadClient,
+  shouldProcessRichPasteText,
+  splitBracketedPasteInput,
+  type RichPasteRewriter,
+  type RichPasteUploadClient,
+} from "./rich-paste.js";
 
 export interface ShellClientOptions {
   gatewayUrl: string;
@@ -71,6 +83,12 @@ export interface ShellAttachOptions {
   reconnectBaseDelayMs?: number;
   reconnectMaxDelayMs?: number;
   WebSocketImpl?: new (url: string, options?: { headers?: Record<string, string> }) => AttachWebSocket;
+  richPaste?: {
+    enabled?: boolean;
+    rewriter?: RichPasteRewriter;
+    uploadClient?: RichPasteUploadClient;
+    clipboardReader?: ClipboardImageReader;
+  };
 }
 
 export const SHELL_ATTACH_MAX_QUEUED_BYTES = 65_536;
@@ -103,6 +121,7 @@ const SAFE_SHELL_SERVER_ERROR_CODES = new Set([
   "session_not_found",
   "zellij_failed",
 ]);
+const RICH_PASTE_UPLOAD_FAILED_MESSAGE = "Image paste failed: upload did not complete.";
 
 type MaybeTtyStream = NodeJS.ReadStream & {
   isTTY?: boolean;
@@ -442,6 +461,17 @@ export function createShellClient(options: ShellClientOptions): ShellClient {
         dropMouse,
         resetLocalInputModes,
       });
+      const richPasteEnabled = attachOptions.richPaste?.enabled !== false;
+      const richPasteRewriter: RichPasteRewriter | undefined = richPasteEnabled
+        ? attachOptions.richPaste?.rewriter ?? createRichPasteRewriter({
+          uploadClient: attachOptions.richPaste?.uploadClient ?? createRichPasteUploadClient({
+            gatewayUrl: base,
+            token: options.token,
+            fetch: fetchImpl,
+          }),
+          clipboardReader: attachOptions.richPaste?.clipboardReader ?? createMacOsClipboardImageReader(),
+        })
+        : undefined;
       const heartbeatIntervalMs = attachOptions.heartbeatIntervalMs ?? SHELL_ATTACH_HEARTBEAT_INTERVAL_MS;
       const heartbeatTimeoutMs = attachOptions.heartbeatTimeoutMs ?? SHELL_ATTACH_HEARTBEAT_TIMEOUT_MS;
       const heartbeatMissesBeforeReconnect =
@@ -660,20 +690,41 @@ export function createShellClient(options: ShellClientOptions): ShellClient {
           settle(() => resolve({ detached: true }));
           wsToClose?.close();
         };
-        const onInput = (chunk: Buffer | string) => {
-          const rawData = Buffer.isBuffer(chunk) ? chunk.toString("utf-8") : String(chunk);
-          if (rawModeEnabled && !everAttached && rawData.includes("\u0003")) {
-            detachLocal();
+        const sendInputFrame = (data: string, observablePaste: boolean) => {
+          const shouldRewrite = observablePaste
+            ? data.length === 0 || shouldProcessRichPasteText(data)
+            : shouldProcessRichPasteText(data);
+          if (!richPasteRewriter || !shouldRewrite) {
+            sendFrame(JSON.stringify({ type: "input", data }));
             return;
           }
-          const data = inputFilter.filter(rawData);
+          void richPasteRewriter.rewrite({
+            sessionName: name,
+            text: data,
+            observablePaste,
+          }).then((result) => {
+            if (settled) {
+              return;
+            }
+            if (result.status === "failed") {
+              errorOutput.write(`\r\n${result.localMessage}\r\n`);
+              return;
+            }
+            sendFrame(JSON.stringify({ type: "input", data: result.outgoingText }));
+          }).catch(() => {
+            if (!settled) {
+              errorOutput.write(`\r\n${RICH_PASTE_UPLOAD_FAILED_MESSAGE}\r\n`);
+            }
+          });
+        };
+        const processInputData = (data: string, observablePaste: boolean) => {
           let outbound = "";
           for (const char of data) {
             pendingInput += char;
             if (pendingInput === detachSequence) {
               pendingInput = "";
               if (outbound.length > 0) {
-                sendFrame(JSON.stringify({ type: "input", data: outbound }));
+                sendInputFrame(outbound, false);
               }
               detachLocal();
               return;
@@ -686,9 +737,27 @@ export function createShellClient(options: ShellClientOptions): ShellClient {
               pendingInput = pendingInput.slice(1);
             }
           }
-          if (outbound.length > 0) {
-            sendFrame(JSON.stringify({ type: "input", data: outbound }));
+          if (outbound.length > 0 || observablePaste) {
+            sendInputFrame(outbound, observablePaste);
           }
+        };
+        const onInput = (chunk: Buffer | string) => {
+          const rawData = Buffer.isBuffer(chunk) ? chunk.toString("utf-8") : String(chunk);
+          if (rawModeEnabled && !everAttached && rawData.includes("\u0003")) {
+            detachLocal();
+            return;
+          }
+          const bracketedSegments = splitBracketedPasteInput(rawData);
+          if (bracketedSegments) {
+            for (const segment of bracketedSegments) {
+              processInputData(
+                segment.observablePaste ? segment.text : inputFilter.filter(segment.text),
+                segment.observablePaste,
+              );
+            }
+            return;
+          }
+          processInputData(inputFilter.filter(rawData), false);
         };
         const sendResizeFrame = () => {
           const size = terminalSize(input, output);

--- a/packages/sync-client/src/cli/shell-client.ts
+++ b/packages/sync-client/src/cli/shell-client.ts
@@ -951,9 +951,10 @@ export function createShellClient(options: ShellClientOptions): ShellClient {
               return;
             }
             sendInputData(result.outgoingText);
-          }).catch(() => {
+          }).catch((err: unknown) => {
             if (!settled) {
               errorOutput.write(`\r\n${RICH_PASTE_UPLOAD_FAILED_MESSAGE}\r\n`);
+              errorOutput.write(`[debug] rich paste rewrite failed: ${err instanceof Error ? err.name : typeof err}\r\n`);
             }
           });
         };

--- a/packages/sync-client/src/cli/shell-client.ts
+++ b/packages/sync-client/src/cli/shell-client.ts
@@ -7,7 +7,7 @@ import {
   createRichPasteRewriter,
   createRichPasteUploadClient,
   shouldProcessRichPasteText,
-  splitBracketedPasteInput,
+  type RichPasteInputSegment,
   type RichPasteRewriter,
   type RichPasteUploadClient,
 } from "./rich-paste.js";
@@ -96,6 +96,9 @@ export interface ShellAttachOptions {
 
 export const SHELL_ATTACH_MAX_QUEUED_BYTES = 65_536;
 export { SHELL_ATTACH_LIVE_TAIL_FROM_SEQ };
+const BRACKETED_PASTE_OPEN = "\u001b[200~";
+const BRACKETED_PASTE_CLOSE = "\u001b[201~";
+const SHELL_ATTACH_MAX_PENDING_BRACKETED_PASTE_CHARS = 1024 * 1024;
 const SHELL_INPUT_FRAME_MAX_BYTES = 60_000;
 const DEFAULT_RUN_TIMEOUT_MS = 10 * 60 * 1000;
 const RUN_RESPONSE_GRACE_MS = 30_000;
@@ -346,6 +349,69 @@ function splitTerminalInputFrames(data: string): string[] {
   return frames;
 }
 
+function createBracketedPasteStreamParser() {
+  let pending = "";
+
+  return {
+    push(chunk: string): RichPasteInputSegment[] {
+      const input = pending + chunk;
+      pending = "";
+      const segments: RichPasteInputSegment[] = [];
+      let cursor = 0;
+
+      while (cursor < input.length) {
+        const start = input.indexOf(BRACKETED_PASTE_OPEN, cursor);
+        if (start === -1) {
+          const tail = input.slice(cursor);
+          const heldLength = longestSuffixPrefixLength(tail, BRACKETED_PASTE_OPEN);
+          const ready = tail.slice(0, tail.length - heldLength);
+          if (ready.length > 0) {
+            segments.push({ text: ready, observablePaste: false });
+          }
+          pending = tail.slice(tail.length - heldLength);
+          break;
+        }
+
+        if (start > cursor) {
+          segments.push({ text: input.slice(cursor, start), observablePaste: false });
+        }
+
+        const contentStart = start + BRACKETED_PASTE_OPEN.length;
+        const end = input.indexOf(BRACKETED_PASTE_CLOSE, contentStart);
+        if (end === -1) {
+          pending = input.slice(start);
+          break;
+        }
+
+        segments.push({
+          text: input.slice(contentStart, end),
+          observablePaste: true,
+        });
+        cursor = end + BRACKETED_PASTE_CLOSE.length;
+      }
+
+      if (pending.length > SHELL_ATTACH_MAX_PENDING_BRACKETED_PASTE_CHARS) {
+        pending = "";
+      }
+
+      return segments;
+    },
+    reset() {
+      pending = "";
+    },
+  };
+}
+
+function longestSuffixPrefixLength(value: string, prefix: string): number {
+  const maxLength = Math.min(value.length, prefix.length - 1);
+  for (let length = maxLength; length > 0; length -= 1) {
+    if (prefix.startsWith(value.slice(value.length - length))) {
+      return length;
+    }
+  }
+  return 0;
+}
+
 export function createShellClient(options: ShellClientOptions): ShellClient {
   const fetchImpl = options.fetch ?? fetch;
   const timeoutMs = options.timeoutMs ?? 10_000;
@@ -562,6 +628,7 @@ export function createShellClient(options: ShellClientOptions): ShellClient {
         resetLocalInputModes,
       });
       const controlDropper = createUnsupportedTerminalControlDropper();
+      const bracketedPasteParser = createBracketedPasteStreamParser();
       const richPasteEnabled = attachOptions.noRichPaste !== true && attachOptions.richPaste?.enabled !== false;
       const richPasteRewriter: RichPasteRewriter | undefined = richPasteEnabled
         ? attachOptions.richPaste?.rewriter ?? createRichPasteRewriter({
@@ -615,6 +682,7 @@ export function createShellClient(options: ShellClientOptions): ShellClient {
           pendingInput = "";
           inputFilter.reset();
           controlDropper.reset();
+          bracketedPasteParser.reset();
           resetLocalInputModes();
           if (rawModeEnabled) {
             input.setRawMode?.(false);
@@ -872,18 +940,29 @@ export function createShellClient(options: ShellClientOptions): ShellClient {
             return;
           }
           const droppedControls = controlDropper.filter(rawData);
-          const bracketedSegments = splitBracketedPasteInput(droppedControls);
-          if (bracketedSegments) {
-            let sequence = Promise.resolve();
-            for (const segment of bracketedSegments) {
-              sequence = sequence.then(() => Promise.resolve(processInputData(
-                segment.observablePaste ? segment.text : inputFilter.filter(segment.text),
-                segment.observablePaste,
-              )));
-            }
-            return sequence;
+          const bracketedSegments = bracketedPasteParser.push(droppedControls);
+          if (bracketedSegments.length === 0) {
+            return;
           }
-          return processInputData(inputFilter.filter(droppedControls), false);
+          let sequence: Promise<void> | undefined;
+          for (const segment of bracketedSegments) {
+            const runSegment = () => Promise.resolve(processInputData(
+              segment.observablePaste ? segment.text : inputFilter.filter(segment.text),
+              segment.observablePaste,
+            ));
+            if (sequence) {
+              sequence = sequence.then(runSegment);
+              continue;
+            }
+            const result = processInputData(
+              segment.observablePaste ? segment.text : inputFilter.filter(segment.text),
+              segment.observablePaste,
+            );
+            if (result) {
+              sequence = result;
+            }
+          }
+          return sequence;
         };
         const onInput = (chunk: Buffer | string) => {
           const run = () => {

--- a/packages/sync-client/src/cli/shell-client.ts
+++ b/packages/sync-client/src/cli/shell-client.ts
@@ -356,6 +356,7 @@ function createBracketedPasteStreamParser(options: {
   incompletePasteTimeoutMs?: number;
 } = {}) {
   let pending = "";
+  let suppressedCloseMarkerTail = "";
   let incompletePasteTimer: ReturnType<typeof setTimeout> | undefined;
 
   const clearIncompletePasteTimer = () => {
@@ -365,6 +366,10 @@ function createBracketedPasteStreamParser(options: {
 
   const discardIncompletePaste = () => {
     if (pending.startsWith(BRACKETED_PASTE_OPEN)) {
+      const closePrefixLength = longestSuffixPrefixLength(pending, BRACKETED_PASTE_CLOSE);
+      suppressedCloseMarkerTail = closePrefixLength > 0
+        ? BRACKETED_PASTE_CLOSE.slice(closePrefixLength)
+        : "";
       options.onIncompletePaste?.();
     }
     pending = "";
@@ -387,7 +392,19 @@ function createBracketedPasteStreamParser(options: {
 
   return {
     push(chunk: string): RichPasteInputSegment[] {
-      const input = pending + chunk;
+      let nextChunk = chunk;
+      if (suppressedCloseMarkerTail) {
+        if (suppressedCloseMarkerTail.startsWith(nextChunk)) {
+          suppressedCloseMarkerTail = suppressedCloseMarkerTail.slice(nextChunk.length);
+          return [];
+        }
+        if (nextChunk.startsWith(suppressedCloseMarkerTail)) {
+          nextChunk = nextChunk.slice(suppressedCloseMarkerTail.length);
+        }
+        suppressedCloseMarkerTail = "";
+      }
+
+      const input = pending + nextChunk;
       setPending("");
       const segments: RichPasteInputSegment[] = [];
       let cursor = 0;
@@ -431,6 +448,7 @@ function createBracketedPasteStreamParser(options: {
     },
     reset() {
       pending = "";
+      suppressedCloseMarkerTail = "";
       clearIncompletePasteTimer();
     },
   };

--- a/packages/sync-client/tests/unit/clipboard-image.test.ts
+++ b/packages/sync-client/tests/unit/clipboard-image.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  createMacOsClipboardImageReader,
+  CLIPBOARD_IMAGE_TIMEOUT_MS,
+  type ClipboardImageCommandRunner,
+} from "../../src/cli/clipboard-image.js";
+
+const pngBytes = Buffer.from([
+  0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
+  0x00, 0x00, 0x00, 0x0d,
+]);
+
+describe("cli/clipboard-image", () => {
+  it("reads macOS clipboard image bytes with an injectable pngpaste runner", async () => {
+    const commandRunner: ClipboardImageCommandRunner = {
+      execFile: vi.fn(async () => ({ stdout: pngBytes, stderr: new Uint8Array() })),
+    };
+    const reader = createMacOsClipboardImageReader({
+      platform: "darwin",
+      commandRunner,
+      now: () => new Date("2026-07-08T12:00:00.000Z"),
+    });
+
+    const result = await reader.readImage();
+
+    expect(result).toEqual({
+      status: "available",
+      candidate: {
+        kind: "clipboard",
+        capturedAt: new Date("2026-07-08T12:00:00.000Z"),
+        sizeBytes: pngBytes.byteLength,
+        mimeType: "image/png",
+        bytes: new Uint8Array(pngBytes),
+      },
+    });
+    expect(commandRunner.execFile).toHaveBeenCalledWith({
+      file: "pngpaste",
+      args: ["-"],
+      timeoutMs: CLIPBOARD_IMAGE_TIMEOUT_MS,
+    });
+  });
+
+  it("reports unsupported platforms without executing helpers", async () => {
+    const commandRunner: ClipboardImageCommandRunner = {
+      execFile: vi.fn(),
+    };
+    const reader = createMacOsClipboardImageReader({
+      platform: "linux",
+      commandRunner,
+    });
+
+    await expect(reader.readImage()).resolves.toEqual({
+      status: "unavailable",
+      reason: "unsupported_platform",
+    });
+    expect(commandRunner.execFile).not.toHaveBeenCalled();
+  });
+
+  it("maps a missing pngpaste helper to a safe unavailable result", async () => {
+    const commandRunner: ClipboardImageCommandRunner = {
+      execFile: vi.fn(async () => {
+        throw Object.assign(new Error("spawn pngpaste ENOENT"), { code: "ENOENT" });
+      }),
+    };
+    const reader = createMacOsClipboardImageReader({
+      platform: "darwin",
+      commandRunner,
+    });
+
+    await expect(reader.readImage()).resolves.toEqual({
+      status: "unavailable",
+      reason: "missing_helper",
+    });
+  });
+
+  it("reports an empty clipboard without claiming success", async () => {
+    const commandRunner: ClipboardImageCommandRunner = {
+      execFile: vi.fn(async () => ({ stdout: new Uint8Array(), stderr: new Uint8Array() })),
+    };
+    const reader = createMacOsClipboardImageReader({
+      platform: "darwin",
+      commandRunner,
+    });
+
+    await expect(reader.readImage()).resolves.toEqual({
+      status: "unavailable",
+      reason: "empty_clipboard",
+    });
+  });
+
+  it("maps helper timeout to a safe timeout result", async () => {
+    const commandRunner: ClipboardImageCommandRunner = {
+      execFile: vi.fn(async () => {
+        throw Object.assign(new Error("timed out"), { code: "ETIMEDOUT" });
+      }),
+    };
+    const reader = createMacOsClipboardImageReader({
+      platform: "darwin",
+      commandRunner,
+    });
+
+    await expect(reader.readImage()).resolves.toEqual({
+      status: "unavailable",
+      reason: "timeout",
+    });
+  });
+});

--- a/packages/sync-client/tests/unit/rich-paste.test.ts
+++ b/packages/sync-client/tests/unit/rich-paste.test.ts
@@ -1,0 +1,259 @@
+import { mkdir, mkdtemp, rm, symlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  RICH_PASTE_MAX_IMAGE_BYTES,
+  processRichPasteTransaction,
+  type RichPasteUploadClient,
+} from "../../src/cli/rich-paste.js";
+
+const pngBytes = Buffer.from([
+  0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
+  0x00, 0x00, 0x00, 0x0d,
+]);
+
+describe("cli/rich-paste", () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), "matrix-rich-paste-"));
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  function uploadClient(remotePaths: string[]): RichPasteUploadClient {
+    return {
+      uploadPasteAssets: vi.fn(async ({ assets }) => assets.map((asset, index) => ({
+        assetId: `paste_${index}`,
+        path: remotePaths[index] ?? `/home/matrix/home/projects/.matrix-terminal-pastes/main/2026-07-08/paste_${index}.png`,
+        homeRelativePath: `projects/.matrix-terminal-pastes/main/2026-07-08/paste_${index}.png`,
+        mimeType: asset.mimeType,
+        size: asset.bytes.byteLength,
+      }))),
+    };
+  }
+
+  it("rewrites quoted image paths with spaces while preserving surrounding prompt text", async () => {
+    const localPath = join(tempDir, "Screenshot 2026-07-08 at 10.31.00.png");
+    await writeFile(localPath, pngBytes);
+    const client = uploadClient(["/home/matrix/home/projects/.matrix-terminal-pastes/main/2026-07-08/paste_0.png"]);
+
+    const result = await processRichPasteTransaction({
+      sessionName: "main",
+      text: `"${localPath}" what about this?`,
+      observablePaste: true,
+      uploadClient: client,
+    });
+
+    expect(result.status).toBe("rewritten");
+    expect(result.outgoingText).toBe(
+      '"/home/matrix/home/projects/.matrix-terminal-pastes/main/2026-07-08/paste_0.png" what about this?',
+    );
+    expect(result.outgoingText).not.toContain(localPath);
+    expect(client.uploadPasteAssets).toHaveBeenCalledTimes(1);
+  });
+
+  it("rewrites unquoted image paths with trailing punctuation", async () => {
+    const localPath = join(tempDir, "screen.png");
+    await writeFile(localPath, pngBytes);
+    const client = uploadClient(["/home/matrix/home/projects/.matrix-terminal-pastes/main/2026-07-08/paste_0.png"]);
+
+    const result = await processRichPasteTransaction({
+      sessionName: "main",
+      text: `inspect ${localPath}.`,
+      observablePaste: true,
+      uploadClient: client,
+    });
+
+    expect(result.status).toBe("rewritten");
+    expect(result.outgoingText).toBe(
+      "inspect /home/matrix/home/projects/.matrix-terminal-pastes/main/2026-07-08/paste_0.png.",
+    );
+  });
+
+  it("passes through non-image paths without uploading", async () => {
+    const localPath = join(tempDir, "notes.txt");
+    await writeFile(localPath, "not an image");
+    const client = uploadClient([]);
+
+    const result = await processRichPasteTransaction({
+      sessionName: "main",
+      text: `read ${localPath}`,
+      observablePaste: true,
+      uploadClient: client,
+    });
+
+    expect(result).toEqual({
+      status: "passthrough",
+      outgoingText: `read ${localPath}`,
+      assets: [],
+    });
+    expect(client.uploadPasteAssets).not.toHaveBeenCalled();
+  });
+
+  it("uploads multiple image paths once and preserves text order", async () => {
+    const first = join(tempDir, "first.png");
+    const second = join(tempDir, "second.png");
+    await writeFile(first, pngBytes);
+    await writeFile(second, pngBytes);
+    const client = uploadClient([
+      "/home/matrix/home/projects/.matrix-terminal-pastes/main/2026-07-08/first.png",
+      "/home/matrix/home/projects/.matrix-terminal-pastes/main/2026-07-08/second.png",
+    ]);
+
+    const result = await processRichPasteTransaction({
+      sessionName: "main",
+      text: `compare ${first}\nwith "${second}"`,
+      observablePaste: true,
+      uploadClient: client,
+    });
+
+    expect(result.status).toBe("rewritten");
+    expect(result.outgoingText).toBe(
+      'compare /home/matrix/home/projects/.matrix-terminal-pastes/main/2026-07-08/first.png\nwith "/home/matrix/home/projects/.matrix-terminal-pastes/main/2026-07-08/second.png"',
+    );
+    expect(client.uploadPasteAssets).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(client.uploadPasteAssets).mock.calls[0]?.[0].assets).toHaveLength(2);
+  });
+
+  it("dedupes repeated image paths in one paste transaction", async () => {
+    const localPath = join(tempDir, "same.png");
+    await writeFile(localPath, pngBytes);
+    const client = uploadClient(["/home/matrix/home/projects/.matrix-terminal-pastes/main/2026-07-08/same.png"]);
+
+    const result = await processRichPasteTransaction({
+      sessionName: "main",
+      text: `${localPath} and again "${localPath}"`,
+      observablePaste: true,
+      uploadClient: client,
+    });
+
+    expect(result.status).toBe("rewritten");
+    expect(result.outgoingText).toBe(
+      '/home/matrix/home/projects/.matrix-terminal-pastes/main/2026-07-08/same.png and again "/home/matrix/home/projects/.matrix-terminal-pastes/main/2026-07-08/same.png"',
+    );
+    expect(vi.mocked(client.uploadPasteAssets).mock.calls[0]?.[0].assets).toHaveLength(1);
+  });
+
+  it("fails locally for missing image paths without uploading or forwarding local paths", async () => {
+    const localPath = join(tempDir, "missing.png");
+    const client = uploadClient([]);
+
+    const result = await processRichPasteTransaction({
+      sessionName: "main",
+      text: `inspect ${localPath}`,
+      observablePaste: true,
+      uploadClient: client,
+    });
+
+    expect(result).toEqual({
+      status: "failed",
+      assets: [],
+      failureCode: "local_read_failed",
+      localMessage: "Image paste failed: local image could not be read.",
+    });
+    expect(client.uploadPasteAssets).not.toHaveBeenCalled();
+  });
+
+  it("fails locally for unreadable non-file image paths", async () => {
+    const localPath = join(tempDir, "directory.png");
+    await mkdir(localPath);
+    const client = uploadClient([]);
+
+    const result = await processRichPasteTransaction({
+      sessionName: "main",
+      text: `inspect ${localPath}`,
+      observablePaste: true,
+      uploadClient: client,
+    });
+
+    expect(result.status).toBe("failed");
+    expect(result.localMessage).toBe("Image paste failed: local image could not be read.");
+    expect(client.uploadPasteAssets).not.toHaveBeenCalled();
+  });
+
+  it("fails locally for unsupported image content", async () => {
+    const localPath = join(tempDir, "fake.png");
+    await writeFile(localPath, "not a png");
+    const client = uploadClient([]);
+
+    const result = await processRichPasteTransaction({
+      sessionName: "main",
+      text: `inspect ${localPath}`,
+      observablePaste: true,
+      uploadClient: client,
+    });
+
+    expect(result.status).toBe("failed");
+    expect(result.localMessage).toBe("Image paste failed: local image could not be read.");
+    expect(client.uploadPasteAssets).not.toHaveBeenCalled();
+  });
+
+  it("fails locally for oversized images", async () => {
+    const localPath = join(tempDir, "huge.png");
+    await writeFile(localPath, Buffer.concat([
+      pngBytes,
+      Buffer.alloc(RICH_PASTE_MAX_IMAGE_BYTES + 1 - pngBytes.byteLength),
+    ]));
+    const client = uploadClient([]);
+
+    const result = await processRichPasteTransaction({
+      sessionName: "main",
+      text: `inspect ${localPath}`,
+      observablePaste: true,
+      uploadClient: client,
+    });
+
+    expect(result.status).toBe("failed");
+    expect(result.localMessage).toBe("Image paste failed: image is too large.");
+    expect(client.uploadPasteAssets).not.toHaveBeenCalled();
+  });
+
+  it("rejects symlinked image paths", async () => {
+    const target = join(tempDir, "target.png");
+    const link = join(tempDir, "link.png");
+    await writeFile(target, pngBytes);
+    await symlink(target, link);
+    const client = uploadClient([]);
+
+    const result = await processRichPasteTransaction({
+      sessionName: "main",
+      text: `inspect ${link}`,
+      observablePaste: true,
+      uploadClient: client,
+    });
+
+    expect(result.status).toBe("failed");
+    expect(result.localMessage).toBe("Image paste failed: local image could not be read.");
+    expect(client.uploadPasteAssets).not.toHaveBeenCalled();
+  });
+
+  it("fails locally on upload failure without returning outgoing text", async () => {
+    const localPath = join(tempDir, "screen.png");
+    await writeFile(localPath, pngBytes);
+    const client: RichPasteUploadClient = {
+      uploadPasteAssets: vi.fn(async () => {
+        throw new Error("/home/matrix/internal write failed");
+      }),
+    };
+
+    const result = await processRichPasteTransaction({
+      sessionName: "main",
+      text: `inspect ${localPath}`,
+      observablePaste: true,
+      uploadClient: client,
+    });
+
+    expect(result).toEqual({
+      status: "failed",
+      assets: [],
+      failureCode: "upload_failed",
+      localMessage: "Image paste failed: upload did not complete.",
+    });
+    expect("outgoingText" in result).toBe(false);
+  });
+});

--- a/packages/sync-client/tests/unit/shell-client.test.ts
+++ b/packages/sync-client/tests/unit/shell-client.test.ts
@@ -42,6 +42,13 @@ async function waitForFakeSocketCount(expectedCount: number): Promise<void> {
   }
 }
 
+function sentInputData(): string[] {
+  return FakeWebSocket.last?.sent
+    .map((frame) => JSON.parse(frame) as { type?: unknown; data?: unknown })
+    .filter((frame) => frame.type === "input" && typeof frame.data === "string")
+    .map((frame) => frame.data as string) ?? [];
+}
+
 describe("createShellClient attachSession", () => {
   beforeEach(() => {
     FakeWebSocket.last = null;
@@ -243,6 +250,137 @@ describe("createShellClient attachSession", () => {
       type: "input",
       data: "remote paste text",
     }));
+
+    FakeWebSocket.last?.emit("message", JSON.stringify({ type: "exit" }));
+    await expect(attach).resolves.toEqual({ detached: false });
+  });
+
+  it("keeps later input queued behind an in-flight rich paste rewrite", async () => {
+    const input = new PassThrough() as PassThrough & {
+      isTTY: true;
+      rows: number;
+      columns: number;
+      setRawMode: ReturnType<typeof vi.fn>;
+      pause: ReturnType<typeof vi.fn>;
+    };
+    input.isTTY = true;
+    input.rows = 24;
+    input.columns = 80;
+    input.setRawMode = vi.fn();
+    input.pause = vi.fn();
+
+    let finishRewrite!: (value: {
+      status: "rewritten";
+      outgoingText: string;
+      assets: [];
+    }) => void;
+    const rewritePromise = new Promise<{
+      status: "rewritten";
+      outgoingText: string;
+      assets: [];
+    }>((resolve) => {
+      finishRewrite = resolve;
+    });
+    const rewriter = {
+      rewrite: vi.fn(() => rewritePromise),
+    };
+    const client = createShellClient({
+      gatewayUrl: "https://matrix.example",
+      token: "token-123",
+      timeoutMs: 100,
+    });
+    const attach = client.attachSession("main", {
+      input,
+      output: new PassThrough(),
+      WebSocketImpl: FakeWebSocket as never,
+      richPaste: { rewriter },
+    });
+
+    FakeWebSocket.last?.emit("message", JSON.stringify({ type: "attached" }));
+    input.write("/var/folders/t5/screen.png");
+    input.write("\r");
+    await new Promise((resolve) => {
+      setTimeout(resolve, 10);
+    });
+
+    expect(sentInputData()).toEqual([]);
+
+    finishRewrite({
+      status: "rewritten",
+      outgoingText: "/home/matrix/home/projects/.matrix-terminal-pastes/main/2026-07-08/screen.png",
+      assets: [],
+    });
+    const deadline = Date.now() + 250;
+    while (sentInputData().length < 2) {
+      if (Date.now() > deadline) break;
+      await new Promise((resolve) => {
+        setTimeout(resolve, 1);
+      });
+    }
+
+    expect(sentInputData()).toEqual([
+      "/home/matrix/home/projects/.matrix-terminal-pastes/main/2026-07-08/screen.png",
+      "\r",
+    ]);
+
+    FakeWebSocket.last?.emit("message", JSON.stringify({ type: "exit" }));
+    await expect(attach).resolves.toEqual({ detached: false });
+  });
+
+  it("buffers bracketed paste markers split across stdin chunks", async () => {
+    const input = new PassThrough() as PassThrough & {
+      isTTY: true;
+      rows: number;
+      columns: number;
+      setRawMode: ReturnType<typeof vi.fn>;
+      pause: ReturnType<typeof vi.fn>;
+    };
+    input.isTTY = true;
+    input.rows = 24;
+    input.columns = 80;
+    input.setRawMode = vi.fn();
+    input.pause = vi.fn();
+
+    const rewriter = {
+      rewrite: vi.fn(async () => ({
+        status: "rewritten" as const,
+        outgoingText: "remote paste text",
+        assets: [],
+      })),
+    };
+    const client = createShellClient({
+      gatewayUrl: "https://matrix.example",
+      token: "token-123",
+      timeoutMs: 100,
+    });
+    const attach = client.attachSession("main", {
+      input,
+      output: new PassThrough(),
+      WebSocketImpl: FakeWebSocket as never,
+      richPaste: { rewriter },
+    });
+
+    FakeWebSocket.last?.emit("message", JSON.stringify({ type: "attached" }));
+    input.write("\u001b[200~");
+    input.write("/var/folders/t5/screen.png");
+    input.write(" what about this?\u001b[201~");
+
+    const deadline = Date.now() + 250;
+    while (!FakeWebSocket.last?.sent.some((frame) => frame.includes("remote paste text"))) {
+      if (Date.now() > deadline) break;
+      await new Promise((resolve) => {
+        setTimeout(resolve, 1);
+      });
+    }
+
+    expect(rewriter.rewrite).toHaveBeenCalledWith({
+      sessionName: "main",
+      text: "/var/folders/t5/screen.png what about this?",
+      observablePaste: true,
+    });
+    expect(sentInputData()).toEqual(["remote paste text"]);
+    expect(FakeWebSocket.last?.sent.join("\n")).not.toContain("\u001b[200~");
+    expect(FakeWebSocket.last?.sent.join("\n")).not.toContain("\u001b[201~");
 
     FakeWebSocket.last?.emit("message", JSON.stringify({ type: "exit" }));
     await expect(attach).resolves.toEqual({ detached: false });

--- a/packages/sync-client/tests/unit/shell-client.test.ts
+++ b/packages/sync-client/tests/unit/shell-client.test.ts
@@ -386,6 +386,63 @@ describe("createShellClient attachSession", () => {
     await expect(attach).resolves.toEqual({ detached: false });
   });
 
+  it("recovers after an incomplete bracketed paste without forwarding paste control bytes", async () => {
+    vi.useFakeTimers();
+    try {
+      const input = new PassThrough() as PassThrough & {
+        isTTY: true;
+        rows: number;
+        columns: number;
+        setRawMode: ReturnType<typeof vi.fn>;
+        pause: ReturnType<typeof vi.fn>;
+      };
+      input.isTTY = true;
+      input.rows = 24;
+      input.columns = 80;
+      input.setRawMode = vi.fn();
+      input.pause = vi.fn();
+      const errorOutput = new PassThrough();
+      const errors: string[] = [];
+      errorOutput.on("data", (chunk) => errors.push(String(chunk)));
+
+      const rewriter = {
+        rewrite: vi.fn(async () => ({
+          status: "rewritten" as const,
+          outgoingText: "remote paste text",
+          assets: [],
+        })),
+      };
+      const client = createShellClient({
+        gatewayUrl: "https://matrix.example",
+        token: "token-123",
+        timeoutMs: 100,
+      });
+      const attach = client.attachSession("main", {
+        input,
+        output: new PassThrough(),
+        errorOutput: errorOutput as NodeJS.WriteStream,
+        WebSocketImpl: FakeWebSocket as never,
+        richPaste: { rewriter },
+      });
+
+      FakeWebSocket.last?.emit("message", JSON.stringify({ type: "attached" }));
+      input.write("\u001b[200~/var/folders/t5/screen.png");
+      await vi.advanceTimersByTimeAsync(300);
+      input.write("pwd\r");
+
+      expect(errors.join("")).toContain("Image paste failed: paste did not complete.");
+      expect(rewriter.rewrite).not.toHaveBeenCalled();
+      expect(sentInputData()).toEqual(["pwd\r"]);
+      expect(FakeWebSocket.last?.sent.join("\n")).not.toContain("\u001b[200~");
+      expect(FakeWebSocket.last?.sent.join("\n")).not.toContain("/var/folders/t5");
+
+      FakeWebSocket.last?.emit("message", JSON.stringify({ type: "exit" }));
+      await expect(attach).resolves.toEqual({ detached: false });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("uses observable empty bracketed paste events for image-only clipboard fallback", async () => {
     const input = new PassThrough() as PassThrough & {
       isTTY: true;

--- a/packages/sync-client/tests/unit/shell-client.test.ts
+++ b/packages/sync-client/tests/unit/shell-client.test.ts
@@ -426,9 +426,9 @@ describe("createShellClient attachSession", () => {
       });
 
       FakeWebSocket.last?.emit("message", JSON.stringify({ type: "attached" }));
-      input.write("\u001b[200~/var/folders/t5/screen.png");
+      input.write("\u001b[200~/var/folders/t5/screen.png\u001b[201");
       await vi.advanceTimersByTimeAsync(300);
-      input.write("pwd\r");
+      input.write("~pwd\r");
 
       expect(errors.join("")).toContain("Image paste failed: paste did not complete.");
       expect(rewriter.rewrite).not.toHaveBeenCalled();

--- a/packages/sync-client/tests/unit/shell-client.test.ts
+++ b/packages/sync-client/tests/unit/shell-client.test.ts
@@ -127,6 +127,240 @@ describe("createShellClient attachSession", () => {
     await expect(attach).resolves.toEqual({ detached: false });
   });
 
+  it("rewrites rich paste text before sending terminal input frames", async () => {
+    const input = new PassThrough() as PassThrough & {
+      isTTY: true;
+      rows: number;
+      columns: number;
+      setRawMode: ReturnType<typeof vi.fn>;
+      pause: ReturnType<typeof vi.fn>;
+    };
+    input.isTTY = true;
+    input.rows = 24;
+    input.columns = 80;
+    input.setRawMode = vi.fn();
+    input.pause = vi.fn();
+
+    const output = new PassThrough();
+    const rewriter = {
+      rewrite: vi.fn(async () => ({
+        status: "rewritten" as const,
+        outgoingText: '"/home/matrix/home/projects/.matrix-terminal-pastes/main/2026-07-08/upload.png" what about this?',
+        assets: [],
+      })),
+    };
+    const client = createShellClient({
+      gatewayUrl: "https://matrix.example",
+      token: "token-123",
+      timeoutMs: 100,
+    });
+
+    const attach = client.attachSession("main", {
+      input,
+      output,
+      WebSocketImpl: FakeWebSocket as never,
+      richPaste: { rewriter },
+    });
+
+    FakeWebSocket.last?.emit("message", JSON.stringify({ type: "attached" }));
+    input.write('"/var/folders/t5/Screenshot 2026-07-08 at 10.31.00.png" what about this?');
+
+    const deadline = Date.now() + 250;
+    while (!FakeWebSocket.last?.sent.some((frame) => frame.includes(".matrix-terminal-pastes"))) {
+      if (Date.now() > deadline) {
+        break;
+      }
+      await new Promise((resolve) => {
+        setTimeout(resolve, 1);
+      });
+    }
+
+    expect(rewriter.rewrite).toHaveBeenCalledWith({
+      sessionName: "main",
+      text: '"/var/folders/t5/Screenshot 2026-07-08 at 10.31.00.png" what about this?',
+      observablePaste: false,
+    });
+    expect(FakeWebSocket.last?.sent).toContain(JSON.stringify({
+      type: "input",
+      data: '"/home/matrix/home/projects/.matrix-terminal-pastes/main/2026-07-08/upload.png" what about this?',
+    }));
+    expect(FakeWebSocket.last?.sent.join("\n")).not.toContain("/var/folders/t5");
+
+    FakeWebSocket.last?.emit("message", JSON.stringify({ type: "exit" }));
+    await expect(attach).resolves.toEqual({ detached: false });
+  });
+
+  it("treats bracketed paste text as one observable rich paste transaction", async () => {
+    const input = new PassThrough() as PassThrough & {
+      isTTY: true;
+      rows: number;
+      columns: number;
+      setRawMode: ReturnType<typeof vi.fn>;
+      pause: ReturnType<typeof vi.fn>;
+    };
+    input.isTTY = true;
+    input.rows = 24;
+    input.columns = 80;
+    input.setRawMode = vi.fn();
+    input.pause = vi.fn();
+
+    const rewriter = {
+      rewrite: vi.fn(async () => ({
+        status: "rewritten" as const,
+        outgoingText: "remote paste text",
+        assets: [],
+      })),
+    };
+    const client = createShellClient({
+      gatewayUrl: "https://matrix.example",
+      token: "token-123",
+      timeoutMs: 100,
+    });
+    const attach = client.attachSession("main", {
+      input,
+      output: new PassThrough(),
+      WebSocketImpl: FakeWebSocket as never,
+      richPaste: { rewriter },
+    });
+
+    FakeWebSocket.last?.emit("message", JSON.stringify({ type: "attached" }));
+    input.write("\u001b[200~/var/folders/t5/screen.png what about this?\u001b[201~");
+
+    const deadline = Date.now() + 250;
+    while (!FakeWebSocket.last?.sent.some((frame) => frame.includes("remote paste text"))) {
+      if (Date.now() > deadline) break;
+      await new Promise((resolve) => {
+        setTimeout(resolve, 1);
+      });
+    }
+
+    expect(rewriter.rewrite).toHaveBeenCalledWith({
+      sessionName: "main",
+      text: "/var/folders/t5/screen.png what about this?",
+      observablePaste: true,
+    });
+    expect(FakeWebSocket.last?.sent).toContain(JSON.stringify({
+      type: "input",
+      data: "remote paste text",
+    }));
+
+    FakeWebSocket.last?.emit("message", JSON.stringify({ type: "exit" }));
+    await expect(attach).resolves.toEqual({ detached: false });
+  });
+
+  it("uses observable empty bracketed paste events for image-only clipboard fallback", async () => {
+    const input = new PassThrough() as PassThrough & {
+      isTTY: true;
+      rows: number;
+      columns: number;
+      setRawMode: ReturnType<typeof vi.fn>;
+      pause: ReturnType<typeof vi.fn>;
+    };
+    input.isTTY = true;
+    input.rows = 24;
+    input.columns = 80;
+    input.setRawMode = vi.fn();
+    input.pause = vi.fn();
+
+    const rewriter = {
+      rewrite: vi.fn(async () => ({
+        status: "rewritten" as const,
+        outgoingText: "Please inspect this image: /home/matrix/home/projects/.matrix-terminal-pastes/main/2026-07-08/clipboard.png",
+        assets: [],
+      })),
+    };
+    const client = createShellClient({
+      gatewayUrl: "https://matrix.example",
+      token: "token-123",
+      timeoutMs: 100,
+    });
+    const attach = client.attachSession("main", {
+      input,
+      output: new PassThrough(),
+      WebSocketImpl: FakeWebSocket as never,
+      richPaste: { rewriter },
+    });
+
+    FakeWebSocket.last?.emit("message", JSON.stringify({ type: "attached" }));
+    input.write("\u001b[200~\u001b[201~");
+
+    const deadline = Date.now() + 250;
+    while (!FakeWebSocket.last?.sent.some((frame) => frame.includes("Please inspect this image"))) {
+      if (Date.now() > deadline) break;
+      await new Promise((resolve) => {
+        setTimeout(resolve, 1);
+      });
+    }
+
+    expect(rewriter.rewrite).toHaveBeenCalledWith({
+      sessionName: "main",
+      text: "",
+      observablePaste: true,
+    });
+    expect(FakeWebSocket.last?.sent).toContain(JSON.stringify({
+      type: "input",
+      data: "Please inspect this image: /home/matrix/home/projects/.matrix-terminal-pastes/main/2026-07-08/clipboard.png",
+    }));
+
+    FakeWebSocket.last?.emit("message", JSON.stringify({ type: "exit" }));
+    await expect(attach).resolves.toEqual({ detached: false });
+  });
+
+  it("prints safe local feedback and sends no local image path when rich paste fails", async () => {
+    const input = new PassThrough() as PassThrough & {
+      isTTY: true;
+      rows: number;
+      columns: number;
+      setRawMode: ReturnType<typeof vi.fn>;
+      pause: ReturnType<typeof vi.fn>;
+    };
+    input.isTTY = true;
+    input.rows = 24;
+    input.columns = 80;
+    input.setRawMode = vi.fn();
+    input.pause = vi.fn();
+    const errorOutput = new PassThrough();
+    const errors: string[] = [];
+    errorOutput.on("data", (chunk) => errors.push(String(chunk)));
+    const rewriter = {
+      rewrite: vi.fn(async () => ({
+        status: "failed" as const,
+        assets: [],
+        failureCode: "upload_failed" as const,
+        localMessage: "Image paste failed: upload did not complete.",
+      })),
+    };
+    const client = createShellClient({
+      gatewayUrl: "https://matrix.example",
+      token: "token-123",
+      timeoutMs: 100,
+    });
+    const attach = client.attachSession("main", {
+      input,
+      output: new PassThrough(),
+      errorOutput: errorOutput as NodeJS.WriteStream,
+      WebSocketImpl: FakeWebSocket as never,
+      richPaste: { rewriter },
+    });
+
+    FakeWebSocket.last?.emit("message", JSON.stringify({ type: "attached" }));
+    input.write("/var/folders/t5/screen.png what about this?");
+
+    const deadline = Date.now() + 250;
+    while (!errors.join("").includes("Image paste failed")) {
+      if (Date.now() > deadline) break;
+      await new Promise((resolve) => {
+        setTimeout(resolve, 1);
+      });
+    }
+
+    expect(errors.join("")).toContain("Image paste failed: upload did not complete.");
+    expect(FakeWebSocket.last?.sent.join("\n")).not.toContain("/var/folders/t5");
+
+    FakeWebSocket.last?.emit("message", JSON.stringify({ type: "exit" }));
+    await expect(attach).resolves.toEqual({ detached: false });
+  });
+
   it("uses live tail by default so attach does not replay stale full-screen frames", async () => {
     const client = createShellClient({
       gatewayUrl: "https://matrix.example",

--- a/specs/106-terminal-rich-paste/checklists/requirements.md
+++ b/specs/106-terminal-rich-paste/checklists/requirements.md
@@ -1,0 +1,34 @@
+# Specification Quality Checklist: Attached Terminal Rich Paste
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-07-08
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Validation pass 1 completed on 2026-07-08. No clarification markers or blocking quality issues remain.

--- a/specs/106-terminal-rich-paste/contracts/cli-rich-paste.md
+++ b/specs/106-terminal-rich-paste/contracts/cli-rich-paste.md
@@ -1,0 +1,44 @@
+# Contract: Attached CLI Rich Paste
+
+## Scope
+
+Applies to `matrix shell attach`, `mos shell attach`, and create-if-missing attach flows that use the same local attach loop.
+
+## Input Contract
+
+The CLI receives terminal stdin bytes while attached. It MUST classify input as one of:
+
+- Ordinary input: no image candidates; forward unchanged after existing terminal filtering.
+- Text paste with image paths: pasted text contains one or more readable local image file references.
+- Observable image-only paste: paste action is observable and local clipboard image bytes can be read.
+- Failed rich paste: image intent was detected, but local read, validation, upload, or rewrite failed.
+
+## Text Path Rewrite Rules
+
+- Detect image paths anywhere in pasted text, including quoted paths with spaces.
+- Preserve surrounding prose and line breaks.
+- Upload each unique local image once per paste transaction.
+- Replace each detected local image reference with the returned remote Matrix path.
+- If adding context is needed, prepend concise inspection wording without hiding user prose.
+- Do not upload non-image paths.
+- Do not forward detected local image paths if upload or rewrite fails.
+
+## Clipboard Image Rules
+
+- Only attempt clipboard image reads during an observable paste transaction.
+- Do not continuously monitor the clipboard.
+- Do not use stale clipboard image data for ordinary text paste.
+- If the terminal emits no paste bytes and no paste boundary, the CLI cannot detect the pure image paste and must not claim success.
+
+## Output Contract
+
+Successful rich paste sends exactly one rewritten terminal input frame sequence equivalent to the final prompt text.
+
+Failure shows a local safe message and leaves the user able to retry. Safe local messages:
+
+- `Image paste failed: local image could not be read.`
+- `Image paste failed: image is too large.`
+- `Image paste failed: upload did not complete.`
+- `Image paste is not supported by this terminal paste event.`
+
+Raw local paths, raw gateway errors, stack traces, and provider/internal details MUST NOT be shown in remote prompts.

--- a/specs/106-terminal-rich-paste/contracts/paste-assets.md
+++ b/specs/106-terminal-rich-paste/contracts/paste-assets.md
@@ -1,0 +1,87 @@
+# Contract: Terminal Paste Assets
+
+## Endpoint
+
+`POST /api/terminal/sessions/:name/paste-assets`
+
+Copies one paste transaction's accepted images into the authenticated user's Matrix home and returns prompt-safe remote paths.
+
+## Auth Matrix
+
+| Route | Auth Method | Public | Authorization Rule |
+|-------|-------------|--------|--------------------|
+| `POST /api/terminal/sessions/:name/paste-assets` | Existing Matrix gateway auth for `/api/terminal` routes | No | Authenticated user may upload only to their own Matrix home and a valid terminal session name |
+
+## Request
+
+Content type: `multipart/form-data`
+
+Fields:
+
+- `transactionId`: optional string, 1-80 chars, safe diagnostic identifier.
+- `asset`: repeated file field, 1-5 files.
+
+Validation:
+
+- `:name` must match the existing safe terminal session name schema.
+- Request body must be capped by `bodyLimit` before parsing.
+- Each `asset` must be a supported image type.
+- Each `asset` must fit within the per-image size limit.
+- Total asset count must not exceed 5.
+- Original local paths and local filenames are ignored for storage naming.
+
+## Successful Response
+
+Status: `201 Created`
+
+```json
+{
+  "assets": [
+    {
+      "assetId": "paste_01H...",
+      "path": "/home/matrix/home/projects/.matrix-terminal-pastes/main/2026-07-08/paste_01H.png",
+      "homeRelativePath": "projects/.matrix-terminal-pastes/main/2026-07-08/paste_01H.png",
+      "mimeType": "image/png",
+      "size": 184203
+    }
+  ]
+}
+```
+
+Response rules:
+
+- `path` is the VPS-local path the CLI may insert into the outgoing prompt.
+- `homeRelativePath` is owner-home-relative for file browser or cleanup flows.
+- Response MUST NOT include original local paths.
+
+## Error Responses
+
+All errors use generic messages:
+
+```json
+{
+  "error": {
+    "code": "invalid_request",
+    "message": "Invalid request"
+  }
+}
+```
+
+Codes:
+
+- `invalid_request` for invalid session name, malformed multipart data, too many files, or unsupported image type.
+- `payload_too_large` for body or image size limit violations.
+- `session_not_found` when the target terminal session does not exist and the implementation can check it.
+- `write_failed` for server-side storage failure.
+- `auth_expired` or the existing auth failure code for unauthenticated requests.
+
+Server logs may include diagnostics, but client responses must remain generic.
+
+## Storage Contract
+
+- Destination root: `projects/.matrix-terminal-pastes/`.
+- Session segment: sanitized terminal session name.
+- Date segment: UTC date.
+- Filename: server-generated ID plus extension derived from validated image type.
+- Write policy: exclusive temp create, write, chmod, atomic rename.
+- Cleanup: recurring, symlink-safe pruning by max age and max count.

--- a/specs/106-terminal-rich-paste/data-model.md
+++ b/specs/106-terminal-rich-paste/data-model.md
@@ -1,0 +1,118 @@
+# Data Model: Attached Terminal Rich Paste
+
+## PasteTransaction
+
+Represents one observed paste action during an attached CLI terminal session.
+
+**Fields**:
+
+- `transactionId`: Local unique identifier for logging and request correlation.
+- `sessionName`: Target terminal session name.
+- `rawText`: Text bytes received from stdin for the paste transaction, if any.
+- `detectedCandidates`: Ordered list of local image candidates found in text.
+- `clipboardCandidate`: Optional image candidate read from the local clipboard.
+- `assetCount`: Number of unique image assets selected for upload.
+- `state`: `collecting`, `validating`, `uploading`, `rewriting`, `forwarded`, or `failed`.
+- `failureCode`: Safe local failure code when the transaction fails.
+
+**Validation rules**:
+
+- `sessionName` must match the existing safe terminal session name rules.
+- `assetCount` must not exceed 5.
+- A transaction with no image candidates must pass through as ordinary terminal input.
+- A failed transaction must not forward detected local image paths.
+
+## LocalImageCandidate
+
+Represents a local image file path detected inside pasted text.
+
+**Fields**:
+
+- `sourceTextRange`: Start and end offsets in the pasted text.
+- `displayText`: The exact text segment to replace, including quotes when present.
+- `localPath`: Resolved local absolute path.
+- `dedupeKey`: Stable key for avoiding repeated uploads within the same transaction.
+- `sizeBytes`: Local file size.
+- `mimeType`: Detected image type.
+
+**Validation rules**:
+
+- Must resolve to a regular local file.
+- Must not be a directory, socket, FIFO, or symlink target outside the local path resolution policy.
+- Must have an allowed image type.
+- Must fit within the per-image size limit.
+
+## ClipboardImageCandidate
+
+Represents image bytes read from the local operating system clipboard during an observable paste transaction.
+
+**Fields**:
+
+- `capturedAt`: Local timestamp.
+- `sizeBytes`: Clipboard image size.
+- `mimeType`: Detected image type.
+- `bytes`: Image payload held only long enough to upload.
+
+**Validation rules**:
+
+- Must only be read during a user paste transaction.
+- Must not be used when text path rewriting already handled the current paste in a way that would duplicate the same user intent.
+- Must fit within the per-image size limit.
+
+## RemotePasteAsset
+
+Represents a copied image inside the user's Matrix environment.
+
+**Fields**:
+
+- `assetId`: Server-generated unique identifier.
+- `sessionName`: Terminal session associated with the paste transaction.
+- `homeRelativePath`: Owner-home-relative path to the stored image.
+- `absolutePath`: VPS-local absolute path suitable for terminal prompts.
+- `mimeType`: Stored image MIME type.
+- `sizeBytes`: Stored image size.
+- `createdAt`: Server timestamp.
+
+**Validation rules**:
+
+- Filename is generated server-side and must not include local path fragments.
+- Path must stay under `projects/.matrix-terminal-pastes/`.
+- Writes must be atomic and exclusive.
+- Assets are owned by the authenticated Matrix user.
+
+## RewriteResult
+
+Represents the final local outcome of a paste transaction.
+
+**Fields**:
+
+- `status`: `passthrough`, `rewritten`, or `failed`.
+- `outgoingText`: Text to send over the terminal WebSocket when successful.
+- `assets`: Uploaded remote assets referenced by `outgoingText`.
+- `localMessage`: Safe local feedback shown to the user when failed.
+
+**State transitions**:
+
+```text
+collecting -> validating -> passthrough
+collecting -> validating -> uploading -> rewriting -> forwarded
+collecting -> validating -> failed
+collecting -> validating -> uploading -> failed
+```
+
+## PasteAssetCleanupPolicy
+
+Represents retention limits for remote paste assets.
+
+**Fields**:
+
+- `maxAgeMs`: Maximum asset age before pruning.
+- `maxAssetsPerSession`: Maximum retained asset files per session before oldest files are pruned.
+- `lastSweepAt`: Last cleanup timestamp.
+
+**Validation rules**:
+
+- Cleanup must use `lstat()` and skip symlinks.
+- Cleanup must only operate under the paste asset directory.
+- Cleanup must run at startup or first use and recur while the gateway is alive.
+- Shutdown must clear cleanup timers.

--- a/specs/106-terminal-rich-paste/plan.md
+++ b/specs/106-terminal-rich-paste/plan.md
@@ -1,0 +1,129 @@
+# Implementation Plan: Attached Terminal Rich Paste
+
+**Branch**: `106-terminal-rich-paste` | **Date**: 2026-07-08 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `specs/106-terminal-rich-paste/spec.md`
+
+## Summary
+
+Attached CLI terminal sessions should treat paste input as a bounded rich paste transaction. The local CLI will detect image paths embedded inside pasted text, best-effort read image-only macOS clipboard data when a paste is observable, upload accepted images to the user's Matrix environment, rewrite the outgoing prompt to use remote Matrix paths, and only then forward input over the existing attached terminal session.
+
+The design adds a small local paste preprocessor to the sync-client attach loop and a terminal-aware paste asset route in the gateway. The gateway owns remote path selection, validation, atomic writes, safe errors, and cleanup policy so local filenames and local filesystem paths never leak into remote prompts or durable owner state.
+
+## Technical Context
+
+**Language/Version**: TypeScript 5.9+, strict mode, ES modules; runtime target Node.js 24+  
+**Primary Dependencies**: Existing sync-client CLI, gateway shell routes, Hono, Zod 4, native Fetch/FormData/Blob, existing `ws` attach transport  
+**Storage**: Owner-controlled filesystem under Matrix home for paste assets; no new database persistence  
+**Testing**: Vitest unit and gateway route tests, plus a manual attached-session quickstart  
+**Target Platform**: macOS local CLI attached to a per-user Matrix VPS gateway; Linux gateway runtime  
+**Project Type**: CLI plus gateway HTTP route  
+**Performance Goals**: Rewrite successful paste transactions in under 3 seconds for accepted image sizes; provide local failure feedback within 2 seconds  
+**Constraints**: Authenticated mutating route, bodyLimit before parsing, no local path leakage, no continuous clipboard monitoring, bounded asset count and size, symlink-safe cleanup  
+**Scale/Scope**: One attached session paste transaction at a time per local CLI process; at least 5 image references per paste transaction
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+- **Data Belongs to Its Owner**: PASS. Paste assets are written only into the authenticated user's Matrix home and are owner-visible/exportable/deletable. The route must not store platform-owned copies.
+- **AI Is the Kernel**: PASS. The feature improves a shell input path and does not bypass or fork kernel behavior.
+- **Headless Core, Multi-Shell**: PASS. The gateway route is shell-agnostic enough to remain a terminal capability, while this feature's UX is scoped to attached CLI sessions.
+- **Defense in Depth**: PASS with design requirements. The new mutating route needs explicit auth, path-param validation, bodyLimit, image validation, size/count limits, atomic writes, generic client errors, server-side diagnostics, and cleanup.
+- **TDD**: PASS with required next step. Implementation must start with failing sync-client and gateway tests before production code.
+- **Worktree, PR, and Greptile 5/5**: CONDITIONAL PASS. Code implementation must happen in a manual git worktree and ship through a PR. This planning branch exists for Spec Kit bookkeeping; do not begin implementation until the working checkout satisfies the manual-worktree rule.
+- **Documentation-Driven Development**: PASS with required task. Update public CLI/terminal docs in `www/content/docs/` during implementation.
+
+No gate violations require a complexity exception.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/106-terminal-rich-paste/
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+│   ├── cli-rich-paste.md
+│   └── paste-assets.md
+└── tasks.md
+```
+
+### Source Code (repository root)
+
+```text
+packages/sync-client/src/cli/
+├── shell-client.ts              # attach loop integration point
+├── rich-paste.ts                # new local paste transaction parser/rewriter
+└── clipboard-image.ts           # new macOS clipboard image adapter
+
+packages/sync-client/tests/unit/
+├── rich-paste.test.ts           # new parser, rewrite, and failure tests
+└── shell-client.test.ts         # attach loop integration tests
+
+packages/gateway/src/shell/
+├── routes.ts                    # terminal route registration
+└── paste-assets.ts              # new paste asset validation/write/cleanup helper
+
+tests/gateway/
+└── shell-routes.test.ts         # route contract and security tests
+
+www/content/docs/
+└── ...                          # CLI terminal paste documentation update
+```
+
+**Structure Decision**: Keep local paste detection and clipboard access inside `packages/sync-client` because only the local CLI can read local files or the local clipboard. Keep remote path selection and asset writing inside `packages/gateway/src/shell` so the server enforces owner scoping, cleanup, validation, and safe error behavior for every client.
+
+## Phase 0: Research
+
+Resolved in [research.md](./research.md). Key decisions:
+
+- Use a local rich paste transaction preprocessor before WebSocket input frames.
+- Add a terminal-aware paste asset route instead of reusing generic file upload directly from the CLI.
+- Use bounded multipart asset upload with gateway-selected remote filenames.
+- Support pure image clipboard paste only when the paste action is observable.
+- Implement paste asset retention as owner-visible temporary files with recurring, symlink-safe cleanup.
+
+## Phase 1: Design & Contracts
+
+Design artifacts:
+
+- [data-model.md](./data-model.md)
+- [contracts/cli-rich-paste.md](./contracts/cli-rich-paste.md)
+- [contracts/paste-assets.md](./contracts/paste-assets.md)
+- [quickstart.md](./quickstart.md)
+
+### Auth Matrix
+
+| Interface | Auth Method | Public? | Notes |
+|-----------|-------------|---------|-------|
+| `POST /api/terminal/sessions/:name/paste-assets` | Existing Matrix gateway bearer/session auth for terminal routes | No | Validates `:name`; writes only to authenticated user's Matrix home |
+| Attached terminal WebSocket input | Existing terminal WebSocket auth | No | Receives rewritten prompt only after upload succeeds |
+| Local clipboard/file reads | Local CLI process permissions | N/A | Reads only during a user paste transaction; no background monitoring |
+
+### Input Validation & Resource Limits
+
+- Validate terminal session names with the existing session-name schema.
+- Apply bodyLimit before parsing the asset upload body.
+- Accept only bounded image assets with allowed MIME/signature/extension combinations.
+- Limit one paste transaction to 5 image assets and bounded total bytes.
+- Generate remote filenames server-side; never persist original local paths.
+- Use atomic file writes with exclusive temp files and rename.
+- Use local and remote request timeouts so paste handling cannot hang indefinitely.
+- Return generic client errors and log diagnostics server-side.
+- Clean old paste assets with lstat-based symlink checks, max-age, max-count, and a recurring cleanup timer that is cleared on gateway shutdown.
+
+## Post-Design Constitution Check
+
+- **Data ownership** remains satisfied because assets are owner files under Matrix home.
+- **Defense in Depth** remains satisfied because the route contract includes auth, validation, body limits, atomic writes, safe errors, and cleanup.
+- **TDD** remains satisfied because quickstart and future tasks require failing tests first.
+- **Worktree/PR gate** remains conditional until implementation begins in a manual worktree and PR workflow.
+
+No complexity exceptions are needed.
+
+## Complexity Tracking
+
+No constitution violations or exceptional complexity are planned.

--- a/specs/106-terminal-rich-paste/pr-invariants.md
+++ b/specs/106-terminal-rich-paste/pr-invariants.md
@@ -1,0 +1,38 @@
+# PR Invariants: Attached Terminal Rich Paste
+
+## Source of truth
+
+- Local files and macOS clipboard bytes are read only by the local CLI during an observed paste transaction.
+- Remote paste assets are owner-controlled files under `~/projects/.matrix-terminal-pastes/` in the authenticated Matrix home.
+- No database or platform-owned object store is added for paste assets.
+
+## Lock/Transaction Scope
+
+- Each accepted image is written with an exclusive temp file and atomic rename.
+- Multipart upload validation happens before any prompt rewrite reaches the attached WebSocket.
+- Network upload happens before terminal input forwarding; the terminal stream is not used to carry local image bytes.
+
+## Acceptable Orphan States
+
+- If one asset write succeeds and a later write fails, the completed file may remain under `.matrix-terminal-pastes/`.
+- Orphaned paste files are acceptable because they are owner-visible temporary files and are pruned by max-age and max-count cleanup.
+- Failed local validation or upload returns local feedback and forwards no detected local image path.
+
+## Auth Source of Truth
+
+- `POST /api/terminal/sessions/:name/paste-assets` uses the existing gateway auth middleware shared by `/api/terminal`.
+- Session names are validated at the route boundary before the paste asset service writes paths.
+- Auth failures use the gateway's existing generic auth response path.
+
+## Resource Limits
+
+- Mutating paste asset upload uses Hono `bodyLimit` before multipart parsing.
+- A paste transaction accepts at most five images.
+- Each image is capped at 10 MB and must match a supported image signature.
+- Cleanup skips symlinks with `lstat()` and clears its recurring timer on gateway shutdown.
+
+## Deferred Scope
+
+- Browser shell and mobile rich image paste are not included.
+- Terminals that emit no stdin bytes and no bracketed paste boundary cannot trigger image-only clipboard upload.
+- Clipboard image reading is macOS best-effort through `pngpaste`; no global clipboard polling or keyboard hooks are added.

--- a/specs/106-terminal-rich-paste/quickstart.md
+++ b/specs/106-terminal-rich-paste/quickstart.md
@@ -1,0 +1,121 @@
+# Quickstart: Attached Terminal Rich Paste
+
+## 1. Start With Failing Tests
+
+From the repository root:
+
+```bash
+pnpm --filter @finnaai/matrix test -- tests/unit/rich-paste.test.ts tests/unit/shell-client.test.ts
+bun run test tests/gateway/shell-routes.test.ts
+```
+
+Expected initial failures before implementation:
+
+- Embedded quoted image path inside prompt is not detected and rewritten.
+- Multiple image paths in one paste are not deduped and uploaded as one transaction.
+- Upload failure still allows local-only paths to reach the remote session.
+- Pure image clipboard paste has no observable best-effort handling.
+- Gateway has no terminal paste asset route.
+
+## 2. Implement Gateway Contract First
+
+Add route and helper tests for:
+
+- Authenticated `POST /api/terminal/sessions/:name/paste-assets`.
+- Body limit before parsing.
+- Session-name validation.
+- Image count and size limits.
+- Server-generated owner-scoped paths.
+- Atomic writes and generic error responses.
+- Symlink-safe cleanup behavior.
+
+## 3. Implement Local Parser/Rewriter
+
+Add sync-client tests for:
+
+- Quoted macOS screenshot paths with spaces and surrounding text.
+- Unquoted image paths with trailing punctuation.
+- Multiple and repeated image references.
+- Non-image path passthrough.
+- Missing, unreadable, unsupported, and oversized local files.
+- No forwarding of detected local image paths on failure.
+
+## 4. Integrate With Attach Loop
+
+Extend the attach loop so rich paste processing happens before `{ type: "input", data }` frames are sent. Preserve:
+
+- Detach sequence behavior.
+- Ctrl-C behavior before and after attach.
+- Reconnect behavior.
+- Existing terminal input filtering.
+- Ordinary non-image paste behavior.
+
+## 5. Manual Validation
+
+1. Start a local Matrix gateway and shell session.
+2. Attach from macOS with `mos shell attach main`.
+3. Paste a prompt like:
+
+   ```text
+   "/var/folders/.../Screenshot 2026-07-08 at 10.31.00.png" what about this?
+   ```
+
+4. Verify the remote terminal receives a prompt with a `/home/matrix/home/projects/.matrix-terminal-pastes/...` path and the original question text.
+5. Copy an image to the macOS clipboard and paste during attach.
+6. Verify best-effort upload succeeds when the terminal emits an observable paste transaction, or local feedback explains that the paste event was not observable.
+
+## 6. Documentation
+
+Update public CLI/terminal docs under `www/content/docs/` to explain:
+
+- Pasting screenshots while attached.
+- Supported image path and clipboard behavior.
+- Size limits and safe failure behavior.
+- The limitation when a terminal sends no paste bytes or paste boundary.
+
+## US1 Validation
+
+Validated the screenshot-path MVP after implementation:
+
+```bash
+cd packages/sync-client
+vitest run tests/unit/rich-paste.test.ts tests/unit/shell-client.test.ts
+
+cd ../..
+vitest run tests/gateway/shell-routes.test.ts
+```
+
+Results:
+
+- Sync-client rich paste/parser and attach-loop tests: 12 passed.
+- Gateway shell route tests, including terminal paste asset upload: 25 passed.
+
+## US2 Validation
+
+Validated observable paste and macOS clipboard image support after implementation:
+
+```bash
+cd packages/sync-client
+vitest run tests/unit/clipboard-image.test.ts tests/unit/shell-client.test.ts tests/unit/rich-paste.test.ts
+```
+
+Results:
+
+- Clipboard image reader, rich paste parser, and attach-loop bracketed paste tests: 19 passed.
+
+## US3 Validation
+
+Validated failure-safe handling and cleanup after implementation:
+
+```bash
+cd packages/sync-client
+vitest run tests/unit/rich-paste.test.ts tests/unit/clipboard-image.test.ts tests/unit/shell-client.test.ts
+
+cd ../..
+vitest run tests/gateway/shell-routes.test.ts
+```
+
+Results:
+
+- Sync-client rich paste, clipboard, and attach-loop tests: 26 passed.
+- Gateway shell route tests, including limits, generic errors, and cleanup sweep: 28 passed.

--- a/specs/106-terminal-rich-paste/research.md
+++ b/specs/106-terminal-rich-paste/research.md
@@ -1,0 +1,55 @@
+# Research: Attached Terminal Rich Paste
+
+## Decision: Process Rich Paste Locally Before Terminal Input Frames
+
+**Rationale**: The local CLI is the only component that can read local macOS screenshot files or clipboard data. Rewriting before WebSocket input frames lets the existing attached terminal transport remain the delivery mechanism for the final prompt.
+
+**Alternatives considered**:
+
+- Send local paths to the remote shell and let the remote side resolve them: rejected because local `/var/folders/...` paths do not exist on the VPS and leak local filesystem details.
+- Add image bytes to the terminal WebSocket protocol: rejected for this feature because it expands a latency-sensitive stream protocol and makes failures harder to isolate from ordinary terminal input.
+
+## Decision: Detect Paths Inside Larger Pasted Text
+
+**Rationale**: Real pastes often look like `"Screenshot 2026-07-08 at 10.31.00.png" what about this?`. The parser must find quoted and unquoted image paths within surrounding text, verify they exist as local regular files, and preserve the user's prose in order.
+
+**Alternatives considered**:
+
+- Only handle pastes where the entire value is a single path: rejected because the previous narrow behavior misses the target UX.
+- Treat every path-like string as an upload candidate: rejected because ordinary text and non-image paths should remain unchanged.
+
+## Decision: Add a Terminal-Aware Paste Asset Route
+
+**Rationale**: Generic file upload requires the client to choose a destination path and can accidentally expose source filenames. A terminal-aware route can validate the session, generate safe remote names, enforce asset count/size limits, and return Matrix-owned paths suitable for prompt rewriting.
+
+**Alternatives considered**:
+
+- Reuse `/api/files/blob` directly from the rich paste rewriter: rejected because the route has no terminal paste semantics, no transaction response shape, and no paste-specific cleanup policy.
+- Store paste assets in platform object storage: rejected because this is user shell context and should stay in the owner's Matrix home.
+
+## Decision: Use Bounded Multipart Uploads
+
+**Rationale**: Multipart upload supports binary image data without base64 inflation and keeps each paste transaction atomic from the client's perspective. The gateway can reject the whole transaction before prompt forwarding when validation fails.
+
+**Alternatives considered**:
+
+- JSON with base64 data: rejected because it increases request size and makes body limits less intuitive.
+- One request per asset through the generic file API: rejected because it complicates all-or-nothing prompt rewrite behavior.
+
+## Decision: Pure Image Clipboard Paste Is Best-Effort and Paste-Boundary Driven
+
+**Rationale**: A normal terminal cannot send image bytes over stdin if the terminal emulator does not emit text or a paste boundary. The CLI can attempt clipboard image reads only when it observes a paste transaction or receives paste text that indicates image intent.
+
+**Alternatives considered**:
+
+- Continuous clipboard polling: rejected because it is surprising, privacy-sensitive, and outside a user-initiated paste transaction.
+- Global keyboard hooks: rejected because they require OS-level permissions and are beyond the CLI attach surface.
+
+## Decision: Owner-Visible Temporary Paste Asset Retention
+
+**Rationale**: Pasted screenshots should remain available long enough for the remote AI and user to inspect them, but the hidden paste directory must not grow forever. Assets should live under the user's Matrix home, be safe to delete, and be pruned by a recurring symlink-safe cleanup policy.
+
+**Alternatives considered**:
+
+- Delete immediately after forwarding the prompt: rejected because the remote AI or terminal program may read the path after prompt delivery.
+- Retain forever: rejected because screenshots are often temporary and can accumulate quickly.

--- a/specs/106-terminal-rich-paste/spec.md
+++ b/specs/106-terminal-rich-paste/spec.md
@@ -1,0 +1,117 @@
+# Feature Specification: Attached Terminal Rich Paste
+
+**Feature Branch**: `106-terminal-rich-paste`  
+**Created**: 2026-07-08  
+**Status**: Draft  
+**Input**: User description: "While attached with Matrix shell, pasted local screenshot paths and image-only clipboard pastes should become owner-scoped remote image references before the prompt reaches the attached terminal session."
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Paste Screenshot Path Inside Prompt (Priority: P1)
+
+As a Matrix CLI user attached to a remote terminal session, I want to paste a local screenshot path together with normal prompt text so the remote AI can inspect the image without me manually uploading or moving the file.
+
+**Why this priority**: This is the common failure case today. Users paste a screenshot path from macOS and expect the attached session to receive the actual image context, not an unusable local-only path.
+
+**Independent Test**: Can be fully tested by attaching to a session, pasting a prompt that contains a quoted local screenshot path with spaces plus extra text, and verifying the remote session receives a rewritten prompt that references an owner-scoped remote image path while preserving the user's text.
+
+**Acceptance Scenarios**:
+
+1. **Given** an active attached terminal session and a readable local screenshot file, **When** the user pastes `"local screenshot path.png" what about this?`, **Then** the remote session receives an image-inspection prompt containing a remote Matrix path and the text `what about this?`.
+2. **Given** an active attached terminal session and a paste containing two readable local image paths with surrounding prose, **When** the paste is submitted, **Then** both image paths are copied to remote Matrix-owned paths and the rest of the prompt remains in the same order.
+3. **Given** an active attached terminal session and a paste containing a non-image local path, **When** the paste is submitted, **Then** the non-image path is not uploaded as an image asset.
+
+---
+
+### User Story 2 - Paste Image Clipboard Without Path Text (Priority: P2)
+
+As a Matrix CLI user with an image copied to the macOS clipboard, I want pressing paste during an attached session to insert a usable remote image reference even when the terminal does not provide a file path in the pasted text.
+
+**Why this priority**: This makes image paste feel natural when the clipboard contains only image bytes. It completes the user expectation that paste means "send this image to the conversation."
+
+**Independent Test**: Can be tested by copying an image to the clipboard, attaching to a session, pasting with no text path available, and verifying a remote image reference is inserted into the outgoing prompt when the paste action is observable.
+
+**Acceptance Scenarios**:
+
+1. **Given** an active attached terminal session and an observable paste action with an image-only clipboard, **When** the user pastes, **Then** the image is copied to a remote Matrix-owned path and the outgoing prompt includes a concise request to inspect that image.
+2. **Given** an active attached terminal session where the terminal provides no paste signal and no input bytes for an image-only clipboard, **When** the user presses paste, **Then** the system does not hang, does not insert stale data, and does not claim that an image was sent.
+
+---
+
+### User Story 3 - Fail Safely Without Leaking Local Paths (Priority: P3)
+
+As a privacy-conscious user, I want failed image paste attempts to be handled locally and clearly so that local filesystem paths or clipboard data are not exposed to the remote session by accident.
+
+**Why this priority**: Rich paste touches local files and clipboard content. Failures must preserve trust even when the happy path cannot complete.
+
+**Independent Test**: Can be tested by pasting an unreadable image path, an oversized image, and a disconnected session, then verifying the user sees local feedback and the remote session does not receive local-only image paths.
+
+**Acceptance Scenarios**:
+
+1. **Given** an active attached terminal session and a pasted local image path that cannot be read, **When** the paste is submitted, **Then** the user receives a local failure message and the detected local image path is not forwarded to the remote session.
+2. **Given** an active attached terminal session and an image that exceeds the accepted size, **When** the user pastes it, **Then** the user receives a local size-limit message and no partial image reference is inserted.
+3. **Given** a remote upload failure during a rich paste transaction, **When** the paste cannot be completed, **Then** the user receives local feedback and can retry without losing the original prompt text.
+
+### Edge Cases
+
+- Pasted paths may be quoted or unquoted, contain spaces, include punctuation near the path, or appear in the middle of a larger prompt.
+- A single paste transaction may contain multiple image references, repeated references, ordinary text, and non-image paths.
+- Image file names may contain sensitive local details; the remote asset path must not depend on exposing the original local path.
+- The clipboard may contain both text and an image; text path rewriting takes precedence, and a clipboard image is used only when doing so will not duplicate a path already handled in the same paste.
+- The user may paste while the session is disconnected, reconnecting, or unable to accept uploads.
+- The local file may disappear between paste detection and upload.
+- The terminal may not provide an observable paste boundary for image-only clipboard content.
+- Failed sends must not leave orphaned partial prompt text in the remote session.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The system MUST treat paste input during an active attached terminal session as a single paste transaction before forwarding it to the remote session.
+- **FR-002**: The system MUST detect readable local image file references embedded anywhere in pasted text, including quoted paths with spaces and text before or after the path.
+- **FR-003**: The system MUST copy each detected local image to an owner-scoped remote Matrix location before the rewritten prompt reaches the remote session.
+- **FR-004**: The system MUST replace each uploaded local image reference with the corresponding remote Matrix path in the outgoing prompt.
+- **FR-005**: The system MUST preserve user-authored text, line breaks, and ordering around rewritten image references unless minimal wording is needed to make image inspection explicit.
+- **FR-006**: The system MUST support multiple detected image references in one paste transaction and avoid duplicate uploads for the same local image within that transaction.
+- **FR-007**: The system MUST support image-only clipboard paste when the paste action is observable and an image can be read from the local operating system clipboard.
+- **FR-008**: The system MUST avoid using stale clipboard images when the current paste transaction already contains text that does not indicate an image paste.
+- **FR-009**: The system MUST reject unsupported, unreadable, missing, or oversized image assets with local feedback.
+- **FR-010**: The system MUST NOT forward detected local-only image paths to the remote session when copying or rewriting fails.
+- **FR-011**: The system MUST keep image paste assets scoped to the owning user's Matrix environment and unavailable to other users by default.
+- **FR-012**: The system MUST avoid exposing original local filesystem paths, raw provider errors, or internal upload details in remote prompts or user-facing failure messages.
+- **FR-013**: The system MUST complete successful rich paste transactions without requiring an additional manual upload command.
+- **FR-014**: The system MUST leave ordinary non-image paste behavior unchanged.
+- **FR-015**: The system MUST present retryable local feedback when a rich paste transaction fails after user input is captured.
+
+### Key Entities
+
+- **Paste Transaction**: One user paste action observed during an attached terminal session. Includes pasted text, optional clipboard image availability, detected image references, and the final rewritten prompt.
+- **Local Image Reference**: A readable image file path or clipboard image available on the user's local machine during the paste transaction.
+- **Remote Paste Asset**: An owner-scoped copy of the pasted image inside the user's Matrix environment, represented to the remote session by a remote path.
+- **Rewrite Result**: The outcome of processing a paste transaction, including uploaded assets, replacement text, failure state, and safe local feedback if needed.
+
+### Scope Boundaries
+
+- This feature covers attached Matrix CLI terminal sessions.
+- This feature does not add rich image paste to browser shell surfaces, mobile shells, or unrelated channel adapters.
+- This feature does not upload arbitrary non-image files.
+- This feature does not continuously monitor the clipboard outside a user-initiated paste transaction.
+- This feature does not guarantee image-only paste support in terminals that provide no observable paste event or input.
+
+### Assumptions
+
+- Users expect pasted screenshots to become usable by the remote AI without learning a separate upload command.
+- Remote paste assets are temporary working-session assets owned by the user and should follow the product's existing owner-data retention and cleanup policies.
+- A clear local error is preferable to silently sending a prompt that contains unusable local image paths.
+- macOS screenshot paths with spaces are the primary path-paste case, but the behavior should not be limited to one screenshot naming pattern.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: At least 95% of valid pasted local image paths embedded in prompts are converted to remote Matrix references within 3 seconds for images up to the accepted size limit.
+- **SC-002**: In validation tests, 100% of successfully handled image paste transactions reach the remote session without local-only image file paths.
+- **SC-003**: Users can paste a screenshot path plus a natural language question into an attached session and receive a usable remote prompt in one paste action.
+- **SC-004**: A single paste transaction can handle at least 5 image references while preserving surrounding user-authored text.
+- **SC-005**: For unreadable, missing, unsupported, oversized, or failed-upload images, users receive local feedback within 2 seconds and no detected local image path is forwarded to the remote session.
+- **SC-006**: At least 90% of user validation attempts for "paste screenshot and ask about it" succeed without requiring a separate manual upload step.

--- a/specs/106-terminal-rich-paste/tasks.md
+++ b/specs/106-terminal-rich-paste/tasks.md
@@ -1,0 +1,229 @@
+# Tasks: Attached Terminal Rich Paste
+
+**Input**: Design documents from `specs/106-terminal-rich-paste/`
+**Prerequisites**: [plan.md](./plan.md), [spec.md](./spec.md), [research.md](./research.md), [data-model.md](./data-model.md), [contracts/](./contracts/), [quickstart.md](./quickstart.md)
+
+**Tests**: Required. The Matrix OS constitution and this feature's quickstart require TDD, so each user story begins with failing Vitest/gateway tests.
+
+**Organization**: Tasks are grouped by user story so each story can be implemented, reviewed, and validated independently.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel because it touches different files or depends only on completed setup/foundation.
+- **[Story]**: Required only for user story phases.
+- Each task includes exact repository file paths.
+
+## Phase 1: Setup
+
+**Purpose**: Confirm implementation guardrails and documentation targets before changing product code.
+
+- [X] T001 Verify implementation work is happening in a manual git worktree and planned Graphite stack per `docs/dev/stacked-prs.md` and `docs/dev/review-pipeline.md`
+- [X] T002 [P] Confirm public documentation update targets for the feature in `www/content/docs/cli.mdx`, `www/content/docs/guide/cli.mdx`, and `www/content/docs/shell.mdx`
+
+---
+
+## Phase 2: Foundational
+
+**Purpose**: Add shared scaffolding that all three stories need before behavior implementation.
+
+**CRITICAL**: No user story implementation should begin until these shared scaffolds exist.
+
+- [X] T003 [P] Define `PasteTransaction`, `LocalImageCandidate`, `ClipboardImageCandidate`, `RemotePasteAsset`, and `RewriteResult` types with constants in `packages/sync-client/src/cli/rich-paste.ts`
+- [X] T004 [P] Define injectable clipboard image reader interfaces and unsupported-platform result types in `packages/sync-client/src/cli/clipboard-image.ts`
+- [X] T005 [P] Define paste asset route constants, image type metadata, cleanup policy types, and safe error codes in `packages/gateway/src/shell/paste-assets.ts`
+- [X] T006 Add rich paste dependency injection options to `ShellAttachOptions` in `packages/sync-client/src/cli/shell-client.ts`
+- [X] T007 Add paste asset service dependencies to `ShellRouteDeps` in `packages/gateway/src/shell/routes.ts`
+- [X] T008 Instantiate the paste asset service and cleanup lifecycle placeholders near shell route wiring in `packages/gateway/src/server.ts`
+
+**Checkpoint**: Shared types, dependency seams, and lifecycle seams exist with no rich paste behavior yet.
+
+---
+
+## Phase 3: User Story 1 - Paste Screenshot Path Inside Prompt (Priority: P1)
+
+**Goal**: A user can paste a local screenshot path inside a larger prompt and the attached remote session receives a prompt containing an owner-scoped Matrix path plus the original surrounding text.
+
+**Independent Test**: Attach to a session, paste `"local screenshot path.png" what about this?`, and verify the outgoing terminal input frame contains a remote Matrix path and the user's question, with no local `/var/folders/...` path.
+
+### Tests for User Story 1
+
+> Write these tests first and confirm they fail before implementation.
+
+- [X] T009 [P] [US1] Add failing gateway contract tests for successful multipart image upload and server-generated paths in `tests/gateway/shell-routes.test.ts`
+- [X] T010 [P] [US1] Add failing parser tests for quoted paths with spaces, unquoted image paths, non-image path passthrough, multiple image paths, and repeated image dedupe in `packages/sync-client/tests/unit/rich-paste.test.ts`
+- [X] T011 [US1] Add failing attach-loop test that embedded local image paths are rewritten before `{ type: "input" }` frames in `packages/sync-client/tests/unit/shell-client.test.ts`
+
+### Implementation for User Story 1
+
+- [X] T012 [US1] Implement local image path tokenization for quoted and unquoted embedded paths in `packages/sync-client/src/cli/rich-paste.ts`
+- [X] T013 [US1] Implement per-transaction dedupe and prompt rewrite output preserving text order and line breaks in `packages/sync-client/src/cli/rich-paste.ts`
+- [X] T014 [US1] Implement gateway paste asset storage with server-generated owner-scoped paths under `projects/.matrix-terminal-pastes/` in `packages/gateway/src/shell/paste-assets.ts`
+- [X] T015 [US1] Wire `POST /api/terminal/sessions/:name/paste-assets` into terminal routes with session-name validation in `packages/gateway/src/shell/routes.ts`
+- [X] T016 [US1] Implement CLI multipart upload and response parsing for terminal paste assets in `packages/sync-client/src/cli/rich-paste.ts`
+- [X] T017 [US1] Integrate rich paste rewriting into the attached-session input path before WebSocket input frames in `packages/sync-client/src/cli/shell-client.ts`
+- [X] T018 [US1] Run and update the US1 quickstart validation commands in `specs/106-terminal-rich-paste/quickstart.md`
+
+**Checkpoint**: User Story 1 is independently shippable as the MVP.
+
+---
+
+## Phase 4: User Story 2 - Paste Image Clipboard Without Path Text (Priority: P2)
+
+**Goal**: When the terminal exposes an observable paste transaction and the macOS clipboard contains image bytes but no path text, the CLI inserts a usable remote Matrix image path.
+
+**Independent Test**: Copy an image to the macOS clipboard, trigger an observable paste during `mos shell attach main`, and verify the outgoing prompt includes a Matrix-owned remote image path or a safe local unsupported-paste message when no paste signal exists.
+
+### Tests for User Story 2
+
+> Write these tests first and confirm they fail before implementation.
+
+- [X] T019 [P] [US2] Add failing clipboard reader tests for supported macOS image output, unsupported platform, missing helper, empty clipboard, and timeout in `packages/sync-client/tests/unit/clipboard-image.test.ts`
+- [X] T020 [P] [US2] Add failing observable paste tests for bracketed paste boundaries and image-only clipboard fallback in `packages/sync-client/tests/unit/shell-client.test.ts`
+
+### Implementation for User Story 2
+
+- [X] T021 [US2] Implement macOS clipboard image reader with injectable command execution, timeout handling, and safe unsupported results in `packages/sync-client/src/cli/clipboard-image.ts`
+- [X] T022 [US2] Implement bracketed paste transaction collection without breaking ordinary terminal input filtering in `packages/sync-client/src/cli/rich-paste.ts`
+- [X] T023 [US2] Add clipboard image candidates to the upload and rewrite pipeline without duplicating text-path uploads in `packages/sync-client/src/cli/rich-paste.ts`
+- [X] T024 [US2] Wire observable paste handling and clipboard reader invocation into attach input handling in `packages/sync-client/src/cli/shell-client.ts`
+- [X] T025 [US2] Run and update the US2 quickstart validation commands in `specs/106-terminal-rich-paste/quickstart.md`
+
+**Checkpoint**: User Stories 1 and 2 both work independently.
+
+---
+
+## Phase 5: User Story 3 - Fail Safely Without Leaking Local Paths (Priority: P3)
+
+**Goal**: Rich paste failures are local, retryable, bounded, and never forward detected local image paths or raw internal errors to the remote session.
+
+**Independent Test**: Paste unreadable, missing, unsupported, oversized, and failed-upload images and verify local feedback appears while no detected local path reaches the remote terminal input stream.
+
+### Tests for User Story 3
+
+> Write these tests first and confirm they fail before implementation.
+
+- [X] T026 [P] [US3] Add failing local validation tests for unreadable, missing, unsupported, oversized, symlink, and upload-failure cases in `packages/sync-client/tests/unit/rich-paste.test.ts`
+- [X] T027 [P] [US3] Add failing gateway tests for bodyLimit, invalid session name, invalid image type, too many assets, oversized asset, generic error response, and temp cleanup in `tests/gateway/shell-routes.test.ts`
+- [X] T028 [US3] Add failing attach-loop test that rich paste failures print safe local feedback and send no local image path frame in `packages/sync-client/tests/unit/shell-client.test.ts`
+
+### Implementation for User Story 3
+
+- [X] T029 [US3] Implement local image validation with regular-file checks, image signature/type checks, size caps, and symlink rejection in `packages/sync-client/src/cli/rich-paste.ts`
+- [X] T030 [US3] Implement safe local error mapping and retryable feedback strings in `packages/sync-client/src/cli/rich-paste.ts`
+- [X] T031 [US3] Enforce gateway bodyLimit, asset count, type, size, atomic exclusive writes, and generic error codes in `packages/gateway/src/shell/paste-assets.ts`
+- [X] T032 [US3] Map paste asset route failures to generic client responses while logging diagnostics server-side in `packages/gateway/src/shell/routes.ts`
+- [X] T033 [US3] Implement recurring paste asset cleanup with `lstat()` symlink skips, max age, and max count in `packages/gateway/src/shell/paste-assets.ts`
+- [X] T034 [US3] Register paste asset cleanup startup and shutdown disposal in the gateway lifecycle in `packages/gateway/src/server.ts`
+- [X] T035 [US3] Run and update the US3 quickstart validation commands in `specs/106-terminal-rich-paste/quickstart.md`
+
+**Checkpoint**: All user stories are independently functional and failure-safe.
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: Documentation, validation, release readiness, and review preparation.
+
+- [X] T036 [P] Document attached-session screenshot path paste behavior, limits, and safe failures in `www/content/docs/cli.mdx`
+- [X] T037 [P] Document rich paste examples and terminal limitations in the guide CLI page `www/content/docs/guide/cli.mdx`
+- [X] T038 [P] Document shared session behavior and rich paste scope for shell users in `www/content/docs/shell.mdx`
+- [X] T039 Run targeted sync-client tests for parser, clipboard, and attach integration in `packages/sync-client/package.json`
+- [X] T040 Run gateway route tests for terminal paste assets in `tests/gateway/shell-routes.test.ts`
+- [X] T041 Run repository review gates from `docs/dev/review-pipeline.md`, including `bun run typecheck`, `bun run check:patterns:diff`, and targeted tests
+- [X] T042 Prepare backend PR invariants covering source of truth, cleanup/orphan states, auth source of truth, body limits, and deferred scope using `docs/dev/review-pipeline.md`
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Phase 1 Setup**: No dependencies.
+- **Phase 2 Foundational**: Depends on Phase 1.
+- **Phase 3 User Story 1**: Depends on Phase 2 and is the MVP.
+- **Phase 4 User Story 2**: Depends on Phase 2; can start after the shared upload/rewrite seam exists, but should validate alongside US1 to avoid duplicate image intent.
+- **Phase 5 User Story 3**: Depends on Phase 2; can be developed in parallel with US1/US2 by another implementer after shared constants and seams exist.
+- **Phase 6 Polish**: Depends on completed user stories selected for the release.
+
+### User Story Dependencies
+
+- **US1 (P1)**: No dependency on other stories after Phase 2. Delivers the MVP path-paste behavior.
+- **US2 (P2)**: Depends on shared rich paste pipeline from Phase 2 and should remain independently testable with injected clipboard readers.
+- **US3 (P3)**: Depends on shared rich paste and paste asset seams from Phase 2. Hardens US1/US2 but has independent failure-mode tests.
+
+### Within Each User Story
+
+- Tests must be written and observed failing before implementation tasks.
+- Local parser/service tasks precede attach-loop integration.
+- Gateway route tests precede gateway route implementation.
+- Each story must pass its own targeted tests before the next priority story is considered complete.
+
+## Parallel Opportunities
+
+- **Setup**: T002 can run in parallel with T001.
+- **Foundational**: T003, T004, and T005 can run in parallel after T001.
+- **US1**: T009 and T010 can run in parallel; T012 and T014 can run in parallel after tests fail; T015 waits for T014; T017 waits for T012, T013, and T016.
+- **US2**: T019 and T020 can run in parallel; T021 and T022 can run in parallel after tests fail; T024 waits for T021-T023.
+- **US3**: T026 and T027 can run in parallel; T029 and T031 can run in parallel after tests fail; T034 waits for T033.
+- **Polish**: T036, T037, and T038 can run in parallel after the user-facing behavior is stable.
+
+## Parallel Example: User Story 1
+
+```text
+Task: "T009 [P] [US1] Add failing gateway contract tests for successful multipart image upload and server-generated paths in tests/gateway/shell-routes.test.ts"
+Task: "T010 [P] [US1] Add failing parser tests for quoted paths with spaces, unquoted image paths, non-image path passthrough, multiple image paths, and repeated image dedupe in packages/sync-client/tests/unit/rich-paste.test.ts"
+```
+
+## Parallel Example: User Story 2
+
+```text
+Task: "T019 [P] [US2] Add failing clipboard reader tests for supported macOS image output, unsupported platform, missing helper, empty clipboard, and timeout in packages/sync-client/tests/unit/clipboard-image.test.ts"
+Task: "T020 [P] [US2] Add failing observable paste tests for bracketed paste boundaries and image-only clipboard fallback in packages/sync-client/tests/unit/shell-client.test.ts"
+```
+
+## Parallel Example: User Story 3
+
+```text
+Task: "T026 [P] [US3] Add failing local validation tests for unreadable, missing, unsupported, oversized, symlink, and upload-failure cases in packages/sync-client/tests/unit/rich-paste.test.ts"
+Task: "T027 [P] [US3] Add failing gateway tests for bodyLimit, invalid session name, invalid image type, too many assets, oversized asset, generic error response, and temp cleanup in tests/gateway/shell-routes.test.ts"
+```
+
+## Implementation Strategy
+
+### MVP First
+
+1. Complete Phase 1 and Phase 2.
+2. Complete Phase 3 only.
+3. Validate that embedded local image paths inside larger pasted prompts upload and rewrite correctly.
+4. Ship or demo US1 before adding clipboard-only image paste.
+
+### Incremental Delivery
+
+1. **US1**: Path paste with text becomes usable and safe enough for the common screenshot prompt.
+2. **US2**: Observable clipboard-only image paste adds the more natural macOS paste experience.
+3. **US3**: Failure hardening and cleanup make the feature trustworthy under bad inputs and partial failures.
+4. **Polish**: Docs and gates make the behavior discoverable and review-ready.
+
+## Graphite Stack Plan
+
+This feature crosses sync-client, gateway, docs, and security boundaries, so keep it as a stacked PR series per `docs/dev/stacked-prs.md`.
+
+- **Stack 1: `feat(cli): scaffold terminal rich paste`**  
+  Covers T001-T008. Adds shared types, dependency seams, and lifecycle placeholders without behavior.
+- **Stack 2: `feat(terminal): upload pasted image paths`**  
+  Covers T009-T018. Delivers MVP US1 with gateway paste assets and local path rewrite.
+- **Stack 3: `feat(cli): support clipboard image paste`**  
+  Covers T019-T025. Adds observable clipboard-only image paste support.
+- **Stack 4: `fix(terminal): harden rich paste failures`**  
+  Covers T026-T035. Adds validation, generic errors, no-forward guarantees, and cleanup.
+- **Stack 5: `docs(cli): document terminal rich paste`**  
+  Covers T036-T042. Updates public docs, runs gates, and prepares PR invariants.
+
+Each stack layer should stay under the review size guidance in `docs/dev/review-pipeline.md`, include `Stack: N/5` in the PR body, and preserve the backend invariants section for layers touching `packages/gateway/`.
+
+## Format Validation
+
+- All task rows use `- [ ] T###` checklist format.
+- User story task rows include `[US1]`, `[US2]`, or `[US3]`.
+- Parallel markers are only used for tasks that can run independently after their dependencies.
+- Every task description includes at least one exact repository file path.

--- a/tests/gateway/shell-routes.test.ts
+++ b/tests/gateway/shell-routes.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { lstat, mkdir, mkdtemp, readdir, readFile, rm, symlink, utimes, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { Hono } from "hono";
@@ -6,8 +6,16 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { createShellRoutes } from "../../packages/gateway/src/shell/routes.js";
 import { ShellRegistry } from "../../packages/gateway/src/shell/registry.js";
 import { createRateLimiter } from "../../packages/gateway/src/security/rate-limiter.js";
+import {
+  createTerminalPasteAssetService,
+  TERMINAL_PASTE_ASSET_MAX_FILE_BYTES,
+} from "../../packages/gateway/src/shell/paste-assets.js";
 
 const roots: string[] = [];
+const pngBytes = Buffer.from([
+  0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
+  0x00, 0x00, 0x00, 0x0d,
+]);
 
 async function tempRoot() {
   const root = await mkdtemp(join(tmpdir(), "matrix-shell-routes-"));
@@ -231,6 +239,185 @@ describe("gateway shell routes", () => {
       durationMs: 12,
     });
     expect(commandRunner.run).toHaveBeenCalledWith({ command: ["ls"], cwd: "projects/app" });
+  });
+
+  it("uploads terminal paste image assets with server-generated owner-scoped paths", async () => {
+    const root = await tempRoot();
+    const registry = {
+      list: vi.fn(async () => [{ name: "main", status: "active" }]),
+      create: vi.fn(),
+      delete: vi.fn(),
+    };
+    const app = new Hono();
+    app.route("/api/terminal", createShellRoutes({
+      registry,
+      pasteAssets: createTerminalPasteAssetService({
+        homePath: root,
+        now: () => new Date("2026-07-08T12:00:00.000Z"),
+      }),
+    }));
+    const form = new FormData();
+    form.append("transactionId", "txn-1");
+    form.append("asset", new Blob([pngBytes], { type: "image/png" }), "Screenshot 2026-07-08 at 10.31.00.png");
+
+    const res = await app.request("/api/terminal/sessions/main/paste-assets", {
+      method: "POST",
+      body: form,
+    });
+
+    expect(res.status).toBe(201);
+    const payload = await res.json() as {
+      assets: Array<{
+        assetId: string;
+        path: string;
+        homeRelativePath: string;
+        mimeType: string;
+        size: number;
+      }>;
+    };
+    expect(payload.assets).toHaveLength(1);
+    expect(payload.assets[0]).toMatchObject({
+      mimeType: "image/png",
+      size: pngBytes.byteLength,
+    });
+    expect(payload.assets[0].assetId).toMatch(/^paste_/);
+    expect(payload.assets[0].homeRelativePath).toMatch(
+      /^projects\/\.matrix-terminal-pastes\/main\/2026-07-08\/paste_[a-zA-Z0-9_-]+\.png$/,
+    );
+    expect(payload.assets[0].path).toBe(join(root, payload.assets[0].homeRelativePath));
+    expect(payload.assets[0].path).not.toContain("Screenshot");
+    await expect(readFile(payload.assets[0].path)).resolves.toEqual(pngBytes);
+    const entries = await readdir(join(root, "projects", ".matrix-terminal-pastes", "main", "2026-07-08"));
+    expect(entries.some((entry) => entry.endsWith(".tmp"))).toBe(false);
+  });
+
+  it("enforces paste asset body, session, type, count, and size limits with generic responses", async () => {
+    const root = await tempRoot();
+    const registry = {
+      list: vi.fn(async () => [{ name: "main", status: "active" }]),
+      create: vi.fn(),
+      delete: vi.fn(),
+    };
+    const app = new Hono();
+    app.route("/api/terminal", createShellRoutes({
+      registry,
+      pasteAssets: createTerminalPasteAssetService({ homePath: root }),
+    }));
+
+    const tooLargeBody = await app.request("/api/terminal/sessions/main/paste-assets", {
+      method: "POST",
+      headers: { "Content-Type": "application/octet-stream", "Content-Length": String(60 * 1024 * 1024) },
+      body: "x",
+    });
+    const invalidSession = await app.request("/api/terminal/sessions/Main/paste-assets", {
+      method: "POST",
+      body: new FormData(),
+    });
+    const invalidTypeForm = new FormData();
+    invalidTypeForm.append("asset", new Blob(["not image"], { type: "text/plain" }), "notes.txt");
+    const invalidType = await app.request("/api/terminal/sessions/main/paste-assets", {
+      method: "POST",
+      body: invalidTypeForm,
+    });
+    const tooManyForm = new FormData();
+    for (let index = 0; index < 6; index += 1) {
+      tooManyForm.append("asset", new Blob([pngBytes], { type: "image/png" }), `screen-${index}.png`);
+    }
+    const tooMany = await app.request("/api/terminal/sessions/main/paste-assets", {
+      method: "POST",
+      body: tooManyForm,
+    });
+    const oversizedForm = new FormData();
+    oversizedForm.append(
+      "asset",
+      new Blob([Buffer.alloc(TERMINAL_PASTE_ASSET_MAX_FILE_BYTES + 1)], { type: "image/png" }),
+      "huge.png",
+    );
+    const oversized = await app.request("/api/terminal/sessions/main/paste-assets", {
+      method: "POST",
+      body: oversizedForm,
+    });
+
+    expect(tooLargeBody.status).toBe(413);
+    await expect(tooLargeBody.json()).resolves.toEqual({
+      error: { code: "payload_too_large", message: "Request failed" },
+    });
+    expect(invalidSession.status).toBe(400);
+    await expect(invalidSession.json()).resolves.toEqual({
+      error: { code: "invalid_request", message: "Invalid request" },
+    });
+    expect(invalidType.status).toBe(400);
+    await expect(invalidType.json()).resolves.toEqual({
+      error: { code: "invalid_request", message: "Invalid request" },
+    });
+    expect(tooMany.status).toBe(400);
+    await expect(tooMany.json()).resolves.toEqual({
+      error: { code: "invalid_request", message: "Invalid request" },
+    });
+    expect(oversized.status).toBe(413);
+    await expect(oversized.json()).resolves.toEqual({
+      error: { code: "payload_too_large", message: "Request failed" },
+    });
+  });
+
+  it("maps paste asset service failures to generic responses", async () => {
+    const registry = {
+      list: vi.fn(async () => [{ name: "main", status: "active" }]),
+      create: vi.fn(),
+      delete: vi.fn(),
+    };
+    const app = new Hono();
+    app.route("/api/terminal", createShellRoutes({
+      registry,
+      pasteAssets: {
+        upload: vi.fn(async () => {
+          throw new Error("/home/matrix/home/projects/.matrix-terminal-pastes leaked");
+        }),
+        sweepExpired: vi.fn(),
+        close: vi.fn(),
+      },
+    }));
+    const form = new FormData();
+    form.append("asset", new Blob([pngBytes], { type: "image/png" }), "screen.png");
+
+    const res = await app.request("/api/terminal/sessions/main/paste-assets", {
+      method: "POST",
+      body: form,
+    });
+
+    expect(res.status).toBe(500);
+    await expect(res.json()).resolves.toEqual({
+      error: { code: "shell_failed", message: "Request failed" },
+    });
+  });
+
+  it("sweeps expired paste assets without following symlinks", async () => {
+    const root = await tempRoot();
+    const service = createTerminalPasteAssetService({
+      homePath: root,
+      cleanupPolicy: {
+        maxAgeMs: 60_000,
+        maxAssetsPerSession: 10,
+        cleanupIntervalMs: 0,
+      },
+      now: () => new Date("2026-07-08T12:00:00.000Z"),
+    });
+    const pasteDir = join(root, "projects", ".matrix-terminal-pastes", "main", "2026-07-08");
+    await mkdir(pasteDir, { recursive: true });
+    const expired = join(pasteDir, "expired.png");
+    const current = join(pasteDir, "current.png");
+    const link = join(pasteDir, "link.png");
+    await writeFile(expired, pngBytes);
+    await writeFile(current, pngBytes);
+    await symlink(expired, link);
+    await utimes(expired, new Date("2026-07-08T11:00:00.000Z"), new Date("2026-07-08T11:00:00.000Z"));
+    await utimes(current, new Date("2026-07-08T12:00:00.000Z"), new Date("2026-07-08T12:00:00.000Z"));
+
+    await service.sweepExpired();
+
+    await expect(readFile(expired)).rejects.toMatchObject({ code: "ENOENT" });
+    await expect(readFile(current)).resolves.toEqual(pngBytes);
+    expect((await lstat(link)).isSymbolicLink()).toBe(true);
   });
 
   it("allows digit-leading session names consistently across create and route params", async () => {

--- a/www/content/docs/cli.mdx
+++ b/www/content/docs/cli.mdx
@@ -134,6 +134,18 @@ Detach without stopping the session: press `Ctrl-\` twice quickly. Reconnect any
 If `matrix run -it`, `matrix shell new`, or `matrix shell attach` fails to start a session, run `matrix shell ls` and connect to an existing session rather than retrying the same create path.
 </Callout>
 
+### Paste screenshots while attached
+
+When you paste local image paths into `matrix shell attach`, the CLI copies those images into your Matrix computer before forwarding the prompt. This works even when the path is part of a larger question:
+
+```text
+"/var/folders/.../Screenshot 2026-07-08 at 10.31.00.png" what about this?
+```
+
+The attached session receives the same prompt with a Matrix-owned path under `~/projects/.matrix-terminal-pastes/` instead of the local macOS path. Up to five PNG, JPEG, GIF, or WebP images can be handled in one paste transaction, with a 10 MB limit per image.
+
+Image-only clipboard paste is best-effort on macOS when the terminal exposes a bracketed paste event and `pngpaste` is available. If the terminal sends no text and no paste boundary, the CLI cannot observe the paste and will not claim an image was sent. Missing, unreadable, unsupported, oversized, or failed uploads show a local retryable message and do not forward detected local image paths to the remote session.
+
 ## File sync
 
 The sync daemon mirrors a local folder against your Matrix home directory and runs as a background service.

--- a/www/content/docs/guide/cli.mdx
+++ b/www/content/docs/guide/cli.mdx
@@ -132,6 +132,18 @@ matrix shell rm code --force            # destroy a session
 **Detaching.** Press `Ctrl-\` twice in quick succession to leave the session running and return to your shell — the same combo whether you're in `attach`, `connect`, or just created a session with `new --attach`. To kill it instead, exit the shell normally inside the session or run `matrix shell rm <name>`.
 </Callout>
 
+### Rich image paste
+
+Attached CLI sessions rewrite pasted local screenshots before the prompt reaches the Matrix computer. If you paste a macOS screenshot path together with text, such as:
+
+```text
+"/var/folders/.../Screenshot.png" what about this?
+```
+
+the CLI uploads the image to `~/projects/.matrix-terminal-pastes/` on your Matrix computer and replaces the local path with the remote path. Repeated references in the same paste are uploaded once, and surrounding text and line breaks are preserved.
+
+Pure image clipboard paste is supported only when the terminal provides an observable paste event. On macOS, install `pngpaste` for image-only clipboard capture. When the terminal emits no bytes or paste boundary, there is nothing for the CLI to read, so no stale clipboard image is inserted.
+
 ### Tabs
 
 Tabs may be anonymous (zellij assigns an index) but **named tabs are recommended** so you can address them from scripts and the VSCode extension.
@@ -320,6 +332,10 @@ Usually means the zellij session exited on your instance. Check `matrix shell ls
 **`session "foo" not found` when connecting**
 
 The session does not exist on your instance. `mos shell attach` is intentionally strict unless you pass `-c`. Use `mos shell new foo` or `mos shell attach -c foo` to create it.
+
+**Pasted screenshot path was not sent**
+
+Only PNG, JPEG, GIF, and WebP images up to 10 MB are accepted. Missing files, symlinks, unsupported content, failed uploads, or terminals that hide image-only clipboard paste from stdin produce local feedback and leave the remote session untouched.
 
 **`matrix port forward` returns `invalid_forward_spec`**
 

--- a/www/content/docs/shell.mdx
+++ b/www/content/docs/shell.mdx
@@ -49,6 +49,12 @@ The Terminal is a persistent shell that keeps running after you close the browse
   The web Terminal, `matrix shell connect`, and the desktop app all attach to the same named session model. A session you open in the browser is immediately available from the CLI and vice versa.
 </Callout>
 
+### CLI image paste
+
+When attached from the CLI, pasted local screenshot paths are copied into the same Matrix home used by the web Terminal. The CLI replaces local paths with files under `~/projects/.matrix-terminal-pastes/` before sending input to the shared session, so browser and CLI users see a remote path the Matrix computer can read.
+
+This rich paste behavior is scoped to CLI attach. Browser and desktop terminals already run inside the Matrix shell context, while the CLI is the surface that can read local macOS files or, when a terminal exposes an observable paste event, a macOS image clipboard through `pngpaste`.
+
 ## GitHub auth
 
 Run `gh auth login` inside a terminal session to authenticate with GitHub. The credentials are stored on your Matrix computer and persist across sessions.


### PR DESCRIPTION
## Summary

- Add attached-session rich paste rewriting for local image paths embedded in larger prompts.
- Add macOS image-only clipboard paste support when the terminal exposes an observable bracketed paste event.
- Add `POST /api/terminal/sessions/:name/paste-assets` with validation, body limits, generated owner-scoped paths, atomic writes, safe errors, and cleanup.
- Add Spec Kit artifacts and public CLI/shell docs for behavior, limits, and terminal limitations.

## Tests

- `tsc -p packages/sync-client/tsconfig.json --noEmit`
- `tsc -p packages/gateway/tsconfig.json --noEmit`
- `vitest run tests/unit/rich-paste.test.ts tests/unit/clipboard-image.test.ts tests/unit/shell-client.test.ts`
- `vitest run tests/gateway/shell-routes.test.ts`
- `git diff --check`
- `bun run typecheck` attempted, but pnpm dependency installation timed out on package tarball fetches before TypeScript ran.

## Invariants

### Source of truth

- Local screenshot files and clipboard bytes are read only by the local CLI during an observed paste transaction.
- Remote paste assets are owner-controlled files under `~/projects/.matrix-terminal-pastes/` in the authenticated Matrix home.
- No database or platform-owned object store is added for paste assets.

### Lock/transaction scope

- Each accepted image write uses an exclusive temp file followed by atomic rename.
- Multipart upload validation completes before any rewritten prompt is sent over the attached WebSocket.
- The terminal WebSocket remains the transport for rewritten prompt text only; local image bytes never travel through terminal input frames.

### Acceptable orphan states

- If an image write succeeds and a later transaction step fails, the completed file may remain under `.matrix-terminal-pastes/`.
- Orphaned paste files are acceptable because they are owner-visible temporary files and are pruned by max-age and max-count cleanup.
- Failed local validation or upload returns local feedback and forwards no detected local image path.

### Auth source of truth

- `POST /api/terminal/sessions/:name/paste-assets` uses the existing gateway auth middleware shared by `/api/terminal`.
- Session names are validated at the route boundary before the paste asset service writes paths.
- Auth failures use the gateway's existing generic auth response path.

### Deferred scope

- Browser shell and mobile rich image paste are not included.
- Terminals that emit no stdin bytes and no bracketed paste boundary cannot trigger image-only clipboard upload.
- Clipboard image reading is macOS best-effort through `pngpaste`; no global clipboard polling or keyboard hooks are added.
