### PR TITLE
fix(terminal): normalize Codex TUI reverse video

### DIFF
--- a/packages/gateway/src/session-registry.ts
+++ b/packages/gateway/src/session-registry.ts
@@ -7,6 +7,7 @@ import { createRequire } from "node:module";
 import { RingBuffer } from "./ring-buffer.js";
 import { resolveWithinHome } from "./path-security.js";
 import { applyTerminalTruecolorEnv } from "./terminal-env.js";
+import { createTerminalOutputCompatStream } from "./terminal-output-compat.js";
 
 const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 const TERMINAL_DEBUG_ENABLED = process.env.TERMINAL_DEBUG === "1";
@@ -200,8 +201,13 @@ class PtySession {
     this.createdAt = metadata?.createdAt ?? Date.now();
     this.lastAttachedAt = metadata?.lastAttachedAt ?? this.createdAt;
 
+    const outputCompat = createTerminalOutputCompatStream({ sessionName: sessionId });
     this.ptyProcess.onData((data: string) => {
-      for (const chunk of splitByUtf8Bytes(data, this.buffer.capacityBytes)) {
+      const compatibleData = outputCompat.write(data);
+      if (compatibleData.length === 0) {
+        return;
+      }
+      for (const chunk of splitByUtf8Bytes(compatibleData, this.buffer.capacityBytes)) {
         const seq = this.buffer.write(chunk);
         if (seq === null) {
           console.warn("Dropped oversized terminal output chunk");

--- a/packages/gateway/src/session-registry.ts
+++ b/packages/gateway/src/session-registry.ts
@@ -7,7 +7,7 @@ import { createRequire } from "node:module";
 import { RingBuffer } from "./ring-buffer.js";
 import { resolveWithinHome } from "./path-security.js";
 import { applyTerminalTruecolorEnv } from "./terminal-env.js";
-import { createTerminalOutputCompatStream } from "./terminal-output-compat.js";
+import { createTerminalOutputCompatStream, type TerminalOutputCompatStream } from "./terminal-output-compat.js";
 
 const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 const TERMINAL_DEBUG_ENABLED = process.env.TERMINAL_DEBUG === "1";
@@ -184,6 +184,7 @@ class PtySession {
   private static readonly MAX_SUBSCRIBERS = 10;
   private subscribers = new Set<SubscriberFn>();
   private _attachedClients = 0;
+  private readonly outputCompat: TerminalOutputCompatStream;
 
   constructor(
     sessionId: string,
@@ -200,27 +201,14 @@ class PtySession {
     this.shell = shell;
     this.createdAt = metadata?.createdAt ?? Date.now();
     this.lastAttachedAt = metadata?.lastAttachedAt ?? this.createdAt;
+    this.outputCompat = createTerminalOutputCompatStream({ sessionName: sessionId });
 
-    const outputCompat = createTerminalOutputCompatStream({ sessionName: sessionId });
     this.ptyProcess.onData((data: string) => {
-      const compatibleData = outputCompat.write(data);
-      if (compatibleData.length === 0) {
-        return;
-      }
-      for (const chunk of splitByUtf8Bytes(compatibleData, this.buffer.capacityBytes)) {
-        const seq = this.buffer.write(chunk);
-        if (seq === null) {
-          console.warn("Dropped oversized terminal output chunk");
-          continue;
-        }
-        const msg: PtyServerMessage = { type: "output", data: chunk, seq };
-        for (const sub of this.subscribers) {
-          sub(msg);
-        }
-      }
+      this.emitOutput(this.outputCompat.write(data));
     });
 
     this.ptyProcess.onExit(({ exitCode }: { exitCode: number }) => {
+      this.emitOutput(this.outputCompat.flush());
       this.state = "exited";
       this.exitCode = exitCode;
       const msg: PtyServerMessage = { type: "exit", code: exitCode };
@@ -228,6 +216,23 @@ class PtySession {
         sub(msg);
       }
     });
+  }
+
+  private emitOutput(data: string): void {
+    if (data.length === 0) {
+      return;
+    }
+    for (const chunk of splitByUtf8Bytes(data, this.buffer.capacityBytes)) {
+      const seq = this.buffer.write(chunk);
+      if (seq === null) {
+        console.warn("Dropped oversized terminal output chunk");
+        continue;
+      }
+      const msg: PtyServerMessage = { type: "output", data: chunk, seq };
+      for (const sub of this.subscribers) {
+        sub(msg);
+      }
+    }
   }
 
   get attachedClients(): number {
@@ -273,6 +278,7 @@ class PtySession {
   }
 
   kill(): void {
+    this.emitOutput(this.outputCompat.flush());
     if (this.state === "running") {
       this.ptyProcess.kill();
     }

--- a/packages/gateway/src/shell/ws.ts
+++ b/packages/gateway/src/shell/ws.ts
@@ -194,20 +194,22 @@ export function createShellWsHandler(options: ShellWsHandlerOptions) {
     }
 
     const outputCompat = createTerminalOutputCompatStream({ sessionName: safeName });
-    const onData = (data: string) => {
-      const compatibleData = outputCompat.write(data);
-      if (compatibleData.length === 0) {
+    const persistOutput = async (data: string) => {
+      if (data.length === 0) {
         return;
       }
-      void replayBuffer.writePersistent(compatibleData)
+      await replayBuffer.writePersistent(data)
         .then((result) => {
           if (result.seq !== null) {
-            sendJson(ws, { type: "output", seq: result.seq, data: compatibleData });
+            sendJson(ws, { type: "output", seq: result.seq, data });
           }
         })
         .catch((err: unknown) => {
           console.warn("[shell] failed to persist terminal output:", err instanceof Error ? err.message : String(err));
         });
+    };
+    const onData = (data: string) => {
+      void persistOutput(outputCompat.write(data));
     };
     const onExit = (event: { exitCode: number }) => {
       if (closed) {
@@ -215,7 +217,9 @@ export function createShellWsHandler(options: ShellWsHandlerOptions) {
       }
       closed = true;
       cleanupProcessListeners();
-      sendJson(ws, { type: "exit", code: event.exitCode });
+      void persistOutput(outputCompat.flush()).finally(() => {
+        sendJson(ws, { type: "exit", code: event.exitCode });
+      });
     };
     dataDisposable = child.onData(onData);
     exitDisposable = child.onExit(onExit);
@@ -225,6 +229,7 @@ export function createShellWsHandler(options: ShellWsHandlerOptions) {
         return;
       }
       closed = true;
+      void persistOutput(outputCompat.flush());
       abortController.abort();
       cleanupProcessListeners();
       child.kill();

--- a/packages/gateway/src/shell/ws.ts
+++ b/packages/gateway/src/shell/ws.ts
@@ -4,6 +4,7 @@ import { ShellReplayBuffer } from "./replay-buffer.js";
 import type { ScrollbackStore } from "./scrollback-store.js";
 import { validateSessionName } from "./names.js";
 import type { ShellAttachProcess } from "./zellij.js";
+import { createTerminalOutputCompatStream } from "../terminal-output-compat.js";
 
 const ShellWsInputSchema = z.object({
   type: z.literal("input"),
@@ -192,11 +193,16 @@ export function createShellWsHandler(options: ShellWsHandlerOptions) {
       sendJson(ws, event);
     }
 
+    const outputCompat = createTerminalOutputCompatStream({ sessionName: safeName });
     const onData = (data: string) => {
-      void replayBuffer.writePersistent(data)
+      const compatibleData = outputCompat.write(data);
+      if (compatibleData.length === 0) {
+        return;
+      }
+      void replayBuffer.writePersistent(compatibleData)
         .then((result) => {
           if (result.seq !== null) {
-            sendJson(ws, { type: "output", seq: result.seq, data });
+            sendJson(ws, { type: "output", seq: result.seq, data: compatibleData });
           }
         })
         .catch((err: unknown) => {

--- a/packages/gateway/src/shell/ws.ts
+++ b/packages/gateway/src/shell/ws.ts
@@ -224,12 +224,12 @@ export function createShellWsHandler(options: ShellWsHandlerOptions) {
     dataDisposable = child.onData(onData);
     exitDisposable = child.onExit(onExit);
 
-    const closeSession = () => {
+    const closeSession = async () => {
       if (closed) {
         return;
       }
       closed = true;
-      void persistOutput(outputCompat.flush());
+      await persistOutput(outputCompat.flush());
       abortController.abort();
       cleanupProcessListeners();
       child.kill();
@@ -258,8 +258,9 @@ export function createShellWsHandler(options: ShellWsHandlerOptions) {
           return;
         }
         if (msg.type === "detach" || msg.type === "destroy") {
-          closeSession();
-          ws.close?.();
+          void closeSession().finally(() => {
+            ws.close?.();
+          });
           return;
         }
         if (msg.type === "input") {
@@ -270,7 +271,9 @@ export function createShellWsHandler(options: ShellWsHandlerOptions) {
           child.resize(msg.cols, msg.rows);
         }
       },
-      onClose: closeSession,
+      onClose() {
+        void closeSession();
+      },
     };
   }
 

--- a/packages/gateway/src/terminal-output-compat.ts
+++ b/packages/gateway/src/terminal-output-compat.ts
@@ -8,6 +8,7 @@ const CODEX_TUI_BANNER = "OpenAI Codex (";
 export interface TerminalOutputCompatStream {
   readonly codexTuiActive: boolean;
   write(data: string): string;
+  flush(): string;
 }
 
 interface CodexTuiCompatTheme {
@@ -17,6 +18,14 @@ interface CodexTuiCompatTheme {
 
 interface CodexTuiCompatTransform {
   write(data: string): string;
+  flush(): string;
+}
+
+type SgrColor = string[] | null;
+
+interface SgrColorState {
+  foreground: SgrColor;
+  background: SgrColor;
 }
 
 function parseHexColor(value: string, fallback: string): [number, number, number] {
@@ -49,11 +58,60 @@ function sgrColorGroupLength(params: string[], index: number): number {
   return 0;
 }
 
-function rewriteSgr(sequence: string, theme: CodexTuiCompatTheme): string {
+function cloneColorState(state: SgrColorState): SgrColorState {
+  return {
+    foreground: state.foreground ? [...state.foreground] : null,
+    background: state.background ? [...state.background] : null,
+  };
+}
+
+function restoreColorParams(state: SgrColorState): string[] {
+  return [
+    ...(state.foreground ?? ["39"]),
+    ...(state.background ?? ["49"]),
+  ];
+}
+
+function applyColorParamToState(param: string, state: SgrColorState): void {
+  const value = Number.parseInt(param, 10);
+  if ((value >= 30 && value <= 37) || (value >= 90 && value <= 97)) {
+    state.foreground = [param];
+    return;
+  }
+  if ((value >= 40 && value <= 47) || (value >= 100 && value <= 107)) {
+    state.background = [param];
+    return;
+  }
+  if (param === "39") {
+    state.foreground = null;
+    return;
+  }
+  if (param === "49") {
+    state.background = null;
+  }
+}
+
+function applyColorGroupToState(group: string[], state: SgrColorState): void {
+  const target = group[0];
+  if (target === "38") {
+    state.foreground = [...group];
+  } else if (target === "48") {
+    state.background = [...group];
+  }
+}
+
+function rewriteSgr(
+  sequence: string,
+  theme: CodexTuiCompatTheme,
+  colorState: SgrColorState,
+  reverseSnapshot: { current: SgrColorState | null },
+): string {
   const body = sequence.slice(2, -1);
   const params = body.length === 0 ? ["0"] : body.split(";");
   const foreground = parseHexColor(theme.foreground, CODEX_TUI_FOREGROUND);
   const reverseBackground = parseHexColor(theme.reverseBackground, CODEX_TUI_REVERSE_BG);
+  const foregroundParams = rgbSgr(38, foreground).split(";");
+  const backgroundParams = rgbSgr(48, reverseBackground).split(";");
   const output: string[] = [];
   let pending: string[] = [];
 
@@ -66,7 +124,9 @@ function rewriteSgr(sequence: string, theme: CodexTuiCompatTheme): string {
   for (let index = 0; index < params.length; index += 1) {
     const colorGroupLength = sgrColorGroupLength(params, index);
     if (colorGroupLength > 0) {
-      pending.push(...params.slice(index, index + colorGroupLength));
+      const group = params.slice(index, index + colorGroupLength);
+      applyColorGroupToState(group, colorState);
+      pending.push(...group);
       index += colorGroupLength - 1;
       continue;
     }
@@ -75,18 +135,32 @@ function rewriteSgr(sequence: string, theme: CodexTuiCompatTheme): string {
     if (param === "0" || param === "") {
       flushPending();
       output.push("\x1b[0m");
+      colorState.foreground = null;
+      colorState.background = null;
+      reverseSnapshot.current = null;
       continue;
     }
     if (param === "7") {
       flushPending();
+      reverseSnapshot.current = cloneColorState(colorState);
+      colorState.foreground = foregroundParams;
+      colorState.background = backgroundParams;
       output.push(`\x1b[${rgbSgr(38, foreground)};${rgbSgr(48, reverseBackground)}m`);
       continue;
     }
     if (param === "27") {
       flushPending();
-      output.push("\x1b[39;49m");
+      if (reverseSnapshot.current) {
+        colorState.foreground = reverseSnapshot.current.foreground;
+        colorState.background = reverseSnapshot.current.background;
+        output.push(`\x1b[${restoreColorParams(colorState).join(";")}m`);
+        reverseSnapshot.current = null;
+      } else {
+        output.push("\x1b[27m");
+      }
       continue;
     }
+    applyColorParamToState(param, colorState);
     pending.push(param);
   }
 
@@ -109,6 +183,8 @@ function findOscTerminator(value: string, start: number): number | null {
 
 function createCodexTuiCompatTransform(theme: CodexTuiCompatTheme): CodexTuiCompatTransform {
   let pending = "";
+  const colorState: SgrColorState = { foreground: null, background: null };
+  const reverseSnapshot: { current: SgrColorState | null } = { current: null };
 
   return {
     write(data: string): string {
@@ -141,7 +217,9 @@ function createCodexTuiCompatTransform(theme: CodexTuiCompatTheme): CodexTuiComp
             break;
           }
           const sequence = input.slice(escapeIndex, finalIndex + 1);
-          output += input[finalIndex] === "m" ? rewriteSgr(sequence, theme) : sequence;
+          output += input[finalIndex] === "m"
+            ? rewriteSgr(sequence, theme, colorState, reverseSnapshot)
+            : sequence;
           index = finalIndex + 1;
           continue;
         }
@@ -166,6 +244,11 @@ function createCodexTuiCompatTransform(theme: CodexTuiCompatTheme): CodexTuiComp
         pending = "";
       }
 
+      return output;
+    },
+    flush(): string {
+      const output = pending;
+      pending = "";
       return output;
     },
   };
@@ -253,6 +336,9 @@ export function createTerminalOutputCompatStream(options: {
         codexTuiActive = detectionText.includes(CODEX_TUI_BANNER);
       }
       return codexTuiActive ? codexTuiTransform.write(data) : data;
+    },
+    flush(): string {
+      return codexTuiActive ? codexTuiTransform.flush() : "";
     },
   };
 }

--- a/packages/gateway/src/terminal-output-compat.ts
+++ b/packages/gateway/src/terminal-output-compat.ts
@@ -74,6 +74,15 @@ function restoreColorParams(state: SgrColorState): string[] {
 }
 
 function applyColorParamToState(param: string, state: SgrColorState): void {
+  if (param.startsWith("38:")) {
+    state.foreground = [param];
+    return;
+  }
+  if (param.startsWith("48:")) {
+    state.background = [param];
+    return;
+  }
+
   const value = Number.parseInt(param, 10);
   if ((value >= 30 && value <= 37) || (value >= 90 && value <= 97)) {
     state.foreground = [param];

--- a/packages/gateway/src/terminal-output-compat.ts
+++ b/packages/gateway/src/terminal-output-compat.ts
@@ -149,6 +149,9 @@ function rewriteSgr(
     if (colorGroupLength > 0) {
       const group = params.slice(index, index + colorGroupLength);
       applyColorGroupToState(group, colorState);
+      if (reverseSnapshot.current) {
+        applyColorGroupToState(group, reverseSnapshot.current);
+      }
       pending.push(...group);
       index += colorGroupLength - 1;
       continue;
@@ -165,7 +168,7 @@ function rewriteSgr(
     }
     if (param === "7") {
       flushPending();
-      reverseSnapshot.current = cloneColorState(colorState);
+      reverseSnapshot.current ??= cloneColorState(colorState);
       colorState.foreground = foregroundParams;
       colorState.background = backgroundParams;
       output.push(`\x1b[${rgbSgr(38, foreground)};${rgbSgr(48, reverseBackground)}m`);
@@ -184,6 +187,9 @@ function rewriteSgr(
       continue;
     }
     applyColorParamToState(param, colorState);
+    if (reverseSnapshot.current) {
+      applyColorParamToState(param, reverseSnapshot.current);
+    }
     pending.push(param);
   }
 

--- a/packages/gateway/src/terminal-output-compat.ts
+++ b/packages/gateway/src/terminal-output-compat.ts
@@ -1,0 +1,258 @@
+const CSI_FINAL_BYTE = /[\x40-\x7e]/;
+const MAX_PENDING_ESCAPE_BYTES = 1_000_000;
+const MAX_DETECTION_TEXT_BYTES = 4096;
+const CODEX_TUI_FOREGROUND = "#D6D8DD";
+const CODEX_TUI_REVERSE_BG = "#30363D";
+const CODEX_TUI_BANNER = "OpenAI Codex (";
+
+export interface TerminalOutputCompatStream {
+  readonly codexTuiActive: boolean;
+  write(data: string): string;
+}
+
+interface CodexTuiCompatTheme {
+  foreground: string;
+  reverseBackground: string;
+}
+
+interface CodexTuiCompatTransform {
+  write(data: string): string;
+}
+
+function parseHexColor(value: string, fallback: string): [number, number, number] {
+  const hex = value.trim().match(/^#?([0-9a-fA-F]{6})/);
+  const color = hex?.[1] ?? fallback.replace("#", "");
+  return [
+    parseInt(color.slice(0, 2), 16),
+    parseInt(color.slice(2, 4), 16),
+    parseInt(color.slice(4, 6), 16),
+  ];
+}
+
+function rgbSgr(prefix: 38 | 48, color: [number, number, number]): string {
+  return `${prefix};2;${color[0]};${color[1]};${color[2]}`;
+}
+
+function sgrColorGroupLength(params: string[], index: number): number {
+  const colorTarget = params[index];
+  if (colorTarget !== "38" && colorTarget !== "48") {
+    return 0;
+  }
+
+  const colorMode = params[index + 1];
+  if (colorMode === "2" && params.length >= index + 5) {
+    return 5;
+  }
+  if (colorMode === "5" && params.length >= index + 3) {
+    return 3;
+  }
+  return 0;
+}
+
+function rewriteSgr(sequence: string, theme: CodexTuiCompatTheme): string {
+  const body = sequence.slice(2, -1);
+  const params = body.length === 0 ? ["0"] : body.split(";");
+  const foreground = parseHexColor(theme.foreground, CODEX_TUI_FOREGROUND);
+  const reverseBackground = parseHexColor(theme.reverseBackground, CODEX_TUI_REVERSE_BG);
+  const output: string[] = [];
+  let pending: string[] = [];
+
+  const flushPending = () => {
+    if (pending.length === 0) return;
+    output.push(`\x1b[${pending.join(";")}m`);
+    pending = [];
+  };
+
+  for (let index = 0; index < params.length; index += 1) {
+    const colorGroupLength = sgrColorGroupLength(params, index);
+    if (colorGroupLength > 0) {
+      pending.push(...params.slice(index, index + colorGroupLength));
+      index += colorGroupLength - 1;
+      continue;
+    }
+
+    const param = params[index] ?? "";
+    if (param === "0" || param === "") {
+      flushPending();
+      output.push("\x1b[0m");
+      continue;
+    }
+    if (param === "7") {
+      flushPending();
+      output.push(`\x1b[${rgbSgr(38, foreground)};${rgbSgr(48, reverseBackground)}m`);
+      continue;
+    }
+    if (param === "27") {
+      flushPending();
+      output.push("\x1b[39;49m");
+      continue;
+    }
+    pending.push(param);
+  }
+
+  flushPending();
+  return output.join("");
+}
+
+function findOscTerminator(value: string, start: number): number | null {
+  for (let index = start; index < value.length; index += 1) {
+    const code = value.charCodeAt(index);
+    if (code === 0x07) {
+      return index + 1;
+    }
+    if (code === 0x1b && value[index + 1] === "\\") {
+      return index + 2;
+    }
+  }
+  return null;
+}
+
+function createCodexTuiCompatTransform(theme: CodexTuiCompatTheme): CodexTuiCompatTransform {
+  let pending = "";
+
+  return {
+    write(data: string): string {
+      const input = pending + data;
+      pending = "";
+      let output = "";
+      let index = 0;
+
+      while (index < input.length) {
+        const escapeIndex = input.indexOf("\x1b", index);
+        if (escapeIndex === -1) {
+          output += input.slice(index);
+          break;
+        }
+
+        output += input.slice(index, escapeIndex);
+        if (escapeIndex + 1 >= input.length) {
+          pending = input.slice(escapeIndex);
+          break;
+        }
+
+        const next = input[escapeIndex + 1];
+        if (next === "[") {
+          let finalIndex = escapeIndex + 2;
+          while (finalIndex < input.length && !CSI_FINAL_BYTE.test(input[finalIndex] ?? "")) {
+            finalIndex += 1;
+          }
+          if (finalIndex >= input.length) {
+            pending = input.slice(escapeIndex);
+            break;
+          }
+          const sequence = input.slice(escapeIndex, finalIndex + 1);
+          output += input[finalIndex] === "m" ? rewriteSgr(sequence, theme) : sequence;
+          index = finalIndex + 1;
+          continue;
+        }
+
+        if (next === "]") {
+          const terminator = findOscTerminator(input, escapeIndex + 2);
+          if (terminator === null) {
+            pending = input.slice(escapeIndex);
+            break;
+          }
+          output += input.slice(escapeIndex, terminator);
+          index = terminator;
+          continue;
+        }
+
+        output += input.slice(escapeIndex, escapeIndex + 2);
+        index = escapeIndex + 2;
+      }
+
+      if (pending.length > MAX_PENDING_ESCAPE_BYTES) {
+        output += pending;
+        pending = "";
+      }
+
+      return output;
+    },
+  };
+}
+
+function stripAnsiForDetection(input: string): string {
+  let output = "";
+  let index = 0;
+
+  while (index < input.length) {
+    const escapeIndex = input.indexOf("\x1b", index);
+    if (escapeIndex === -1) {
+      output += input.slice(index);
+      break;
+    }
+
+    output += input.slice(index, escapeIndex);
+    if (escapeIndex + 1 >= input.length) {
+      break;
+    }
+
+    const next = input[escapeIndex + 1];
+    if (next === "[") {
+      let finalIndex = escapeIndex + 2;
+      while (finalIndex < input.length && !CSI_FINAL_BYTE.test(input[finalIndex] ?? "")) {
+        finalIndex += 1;
+      }
+      index = finalIndex < input.length ? finalIndex + 1 : input.length;
+      continue;
+    }
+
+    if (next === "]") {
+      const terminator = findOscTerminator(input, escapeIndex + 2);
+      index = terminator ?? input.length;
+      continue;
+    }
+
+    index = escapeIndex + 2;
+  }
+
+  return output;
+}
+
+function trimDetectionText(value: string): string {
+  const bytes = Buffer.byteLength(value);
+  if (bytes <= MAX_DETECTION_TEXT_BYTES) {
+    return value;
+  }
+
+  let output = "";
+  let outputBytes = 0;
+  for (let index = value.length - 1; index >= 0; index -= 1) {
+    const char = value[index]!;
+    const charBytes = Buffer.byteLength(char);
+    if (outputBytes + charBytes > MAX_DETECTION_TEXT_BYTES) {
+      break;
+    }
+    output = char + output;
+    outputBytes += charBytes;
+  }
+  return output;
+}
+
+function isCodexTuiSessionName(sessionName: string | undefined): boolean {
+  return sessionName?.startsWith("codex-") === true;
+}
+
+export function createTerminalOutputCompatStream(options: {
+  sessionName?: string;
+} = {}): TerminalOutputCompatStream {
+  let codexTuiActive = isCodexTuiSessionName(options.sessionName);
+  let detectionText = "";
+  const codexTuiTransform = createCodexTuiCompatTransform({
+    foreground: CODEX_TUI_FOREGROUND,
+    reverseBackground: CODEX_TUI_REVERSE_BG,
+  });
+
+  return {
+    get codexTuiActive() {
+      return codexTuiActive;
+    },
+    write(data: string): string {
+      if (!codexTuiActive) {
+        detectionText = trimDetectionText(detectionText + stripAnsiForDetection(data));
+        codexTuiActive = detectionText.includes(CODEX_TUI_BANNER);
+      }
+      return codexTuiActive ? codexTuiTransform.write(data) : data;
+    },
+  };
+}

--- a/packages/gateway/src/terminal-output-compat.ts
+++ b/packages/gateway/src/terminal-output-compat.ts
@@ -17,6 +17,7 @@ interface CodexTuiCompatTheme {
 }
 
 interface CodexTuiCompatTransform {
+  observe(data: string): void;
   write(data: string): string;
   flush(): string;
 }
@@ -97,6 +98,28 @@ function applyColorGroupToState(group: string[], state: SgrColorState): void {
     state.foreground = [...group];
   } else if (target === "48") {
     state.background = [...group];
+  }
+}
+
+function observeSgr(sequence: string, colorState: SgrColorState): void {
+  const body = sequence.slice(2, -1);
+  const params = body.length === 0 ? ["0"] : body.split(";");
+
+  for (let index = 0; index < params.length; index += 1) {
+    const colorGroupLength = sgrColorGroupLength(params, index);
+    if (colorGroupLength > 0) {
+      applyColorGroupToState(params.slice(index, index + colorGroupLength), colorState);
+      index += colorGroupLength - 1;
+      continue;
+    }
+
+    const param = params[index] ?? "";
+    if (param === "0" || param === "") {
+      colorState.foreground = null;
+      colorState.background = null;
+      continue;
+    }
+    applyColorParamToState(param, colorState);
   }
 }
 
@@ -183,10 +206,57 @@ function findOscTerminator(value: string, start: number): number | null {
 
 function createCodexTuiCompatTransform(theme: CodexTuiCompatTheme): CodexTuiCompatTransform {
   let pending = "";
+  let trackingPending = "";
   const colorState: SgrColorState = { foreground: null, background: null };
   const reverseSnapshot: { current: SgrColorState | null } = { current: null };
 
   return {
+    observe(data: string): void {
+      const input = trackingPending + data;
+      trackingPending = "";
+      let index = 0;
+
+      while (index < input.length) {
+        const escapeIndex = input.indexOf("\x1b", index);
+        if (escapeIndex === -1) {
+          break;
+        }
+
+        if (escapeIndex + 1 >= input.length) {
+          trackingPending = input.slice(escapeIndex);
+          break;
+        }
+
+        const next = input[escapeIndex + 1];
+        if (next === "[") {
+          let finalIndex = escapeIndex + 2;
+          while (finalIndex < input.length && !CSI_FINAL_BYTE.test(input[finalIndex] ?? "")) {
+            finalIndex += 1;
+          }
+          if (finalIndex >= input.length) {
+            trackingPending = input.slice(escapeIndex);
+            break;
+          }
+          if (input[finalIndex] === "m") {
+            observeSgr(input.slice(escapeIndex, finalIndex + 1), colorState);
+          }
+          index = finalIndex + 1;
+          continue;
+        }
+
+        if (next === "]") {
+          const terminator = findOscTerminator(input, escapeIndex + 2);
+          index = terminator ?? input.length;
+          continue;
+        }
+
+        index = escapeIndex + 2;
+      }
+
+      if (trackingPending.length > MAX_PENDING_ESCAPE_BYTES) {
+        trackingPending = "";
+      }
+    },
     write(data: string): string {
       const input = pending + data;
       pending = "";
@@ -249,6 +319,7 @@ function createCodexTuiCompatTransform(theme: CodexTuiCompatTheme): CodexTuiComp
     flush(): string {
       const output = pending;
       pending = "";
+      trackingPending = "";
       return output;
     },
   };
@@ -334,6 +405,9 @@ export function createTerminalOutputCompatStream(options: {
       if (!codexTuiActive) {
         detectionText = trimDetectionText(detectionText + stripAnsiForDetection(data));
         codexTuiActive = detectionText.includes(CODEX_TUI_BANNER);
+        if (!codexTuiActive) {
+          codexTuiTransform.observe(data);
+        }
       }
       return codexTuiActive ? codexTuiTransform.write(data) : data;
     },

--- a/tests/gateway/session-registry.test.ts
+++ b/tests/gateway/session-registry.test.ts
@@ -499,6 +499,46 @@ describe("SessionRegistry", () => {
   });
 
   describe("output from PTY is sent to subscribed clients", () => {
+    it("rewrites detected Codex TUI reverse-video output for subscribers and replay", () => {
+      const mockPty = createMockPty();
+      const mockSpawn = createMockSpawn(mockPty);
+      const registry = createRegistry({}, mockSpawn);
+      const id = registry.create("/home");
+
+      const handle = registry.attach(id)!;
+      const received: PtyServerMessage[] = [];
+      handle.subscribe((msg) => received.push(msg));
+
+      const raw = "OpenAI Codex (v0.142.5)\n\x1b[7mprompt\x1b[27m";
+      const readable = "OpenAI Codex (v0.142.5)\n\x1b[38;2;214;216;221;48;2;48;54;61mprompt\x1b[39;49m";
+      const dataCb = mockPty.onData.mock.calls[0][0];
+      dataCb(raw);
+
+      expect(received).toContainEqual({ type: "output", data: readable, seq: 0 });
+
+      received.length = 0;
+      handle.replay(0);
+      expect(received).toContainEqual({ type: "output", data: readable, seq: 0 });
+      expect(received).not.toContainEqual({ type: "output", data: raw, seq: 0 });
+    });
+
+    it("keeps non-Codex reverse-video PTY output unchanged", () => {
+      const mockPty = createMockPty();
+      const mockSpawn = createMockSpawn(mockPty);
+      const registry = createRegistry({}, mockSpawn);
+      const id = registry.create("/home");
+
+      const handle = registry.attach(id)!;
+      const received: PtyServerMessage[] = [];
+      handle.subscribe((msg) => received.push(msg));
+
+      const raw = "plain \x1b[7mselected\x1b[27m";
+      const dataCb = mockPty.onData.mock.calls[0][0];
+      dataCb(raw);
+
+      expect(received).toContainEqual({ type: "output", data: raw, seq: 0 });
+    });
+
     it("sends output with seq numbers to subscribers", () => {
       const mockPty = createMockPty();
       const mockSpawn = createMockSpawn(mockPty);

--- a/tests/gateway/session-registry.test.ts
+++ b/tests/gateway/session-registry.test.ts
@@ -539,6 +539,27 @@ describe("SessionRegistry", () => {
       expect(received).toContainEqual({ type: "output", data: raw, seq: 0 });
     });
 
+    it("flushes partial Codex compatibility escape bytes before PTY exit", () => {
+      const mockPty = createMockPty();
+      const mockSpawn = createMockSpawn(mockPty);
+      const registry = createRegistry({}, mockSpawn);
+      const id = registry.create("/home");
+
+      const handle = registry.attach(id)!;
+      const received: PtyServerMessage[] = [];
+      handle.subscribe((msg) => received.push(msg));
+
+      const dataCb = mockPty.onData.mock.calls[0][0];
+      dataCb("OpenAI Codex (v0.142.5)\n");
+      dataCb("prompt\x1b[");
+      const exitCb = mockPty.onExit.mock.calls[0][0];
+      exitCb({ exitCode: 0, signal: 0 });
+
+      expect(received).toContainEqual({ type: "output", data: "prompt", seq: 1 });
+      expect(received).toContainEqual({ type: "output", data: "\x1b[", seq: 2 });
+      expect(received.at(-1)).toEqual({ type: "exit", code: 0 });
+    });
+
     it("sends output with seq numbers to subscribers", () => {
       const mockPty = createMockPty();
       const mockSpawn = createMockSpawn(mockPty);

--- a/tests/gateway/terminal-output-compat.test.ts
+++ b/tests/gateway/terminal-output-compat.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import { createTerminalOutputCompatStream } from "../../packages/gateway/src/terminal-output-compat.js";
+
+const READABLE_PROMPT = "\x1b[38;2;214;216;221;48;2;48;54;61mprompt\x1b[39;49m";
+const RAW_PROMPT = "\x1b[7mprompt\x1b[27m";
+
+describe("terminal output compatibility stream", () => {
+  it("leaves ordinary reverse-video output unchanged before Codex detection", () => {
+    const stream = createTerminalOutputCompatStream({ sessionName: "main" });
+
+    expect(stream.write(`plain ${RAW_PROMPT}`)).toBe(`plain ${RAW_PROMPT}`);
+  });
+
+  it("rewrites Codex-named sessions immediately", () => {
+    const stream = createTerminalOutputCompatStream({ sessionName: "codex-backend" });
+
+    expect(stream.write(RAW_PROMPT)).toBe(READABLE_PROMPT);
+  });
+
+  it("detects manual Codex launches from a later banner chunk", () => {
+    const stream = createTerminalOutputCompatStream({ sessionName: "main" });
+
+    expect(stream.write("plain shell output\n")).toBe("plain shell output\n");
+    expect(stream.write("OpenAI Codex (v0.142.5)\n")).toBe("OpenAI Codex (v0.142.5)\n");
+    expect(stream.write(RAW_PROMPT)).toBe(READABLE_PROMPT);
+  });
+
+  it("detects Codex and rewrites reverse video in the same chunk", () => {
+    const stream = createTerminalOutputCompatStream({ sessionName: "main" });
+
+    expect(stream.write(`OpenAI Codex (v0.142.5)\n${RAW_PROMPT}`)).toBe(
+      `OpenAI Codex (v0.142.5)\n${READABLE_PROMPT}`,
+    );
+  });
+
+  it("detects Codex banners split across chunks", () => {
+    const stream = createTerminalOutputCompatStream({ sessionName: "main" });
+
+    expect(stream.write("OpenAI ")).toBe("OpenAI ");
+    expect(stream.write(`Codex (v0.142.5)\n${RAW_PROMPT}`)).toBe(
+      `Codex (v0.142.5)\n${READABLE_PROMPT}`,
+    );
+  });
+
+  it("handles chunked SGR escape sequences once Codex compatibility is active", () => {
+    const stream = createTerminalOutputCompatStream({ sessionName: "codex-backend" });
+
+    expect(stream.write("a\x1b[")).toBe("a");
+    expect(stream.write("7")).toBe("");
+    expect(stream.write("mprompt\x1b[2")).toBe("\x1b[38;2;214;216;221;48;2;48;54;61mprompt");
+    expect(stream.write("7m")).toBe("\x1b[39;49m");
+  });
+
+  it("preserves OSC and non-SGR escape sequences", () => {
+    const stream = createTerminalOutputCompatStream({ sessionName: "codex-backend" });
+    const osc52 = "\x1b]52;c;SGVsbG8=\x07";
+    const cursorMove = "\x1b[2J\x1b[3;4H";
+
+    expect(stream.write(`${osc52}${cursorMove}`)).toBe(`${osc52}${cursorMove}`);
+  });
+});

--- a/tests/gateway/terminal-output-compat.test.ts
+++ b/tests/gateway/terminal-output-compat.test.ts
@@ -67,6 +67,14 @@ describe("terminal output compatibility stream", () => {
     );
   });
 
+  it("preserves colon-form extended colors set while reverse video is active", () => {
+    const stream = createTerminalOutputCompatStream({ sessionName: "codex-backend" });
+
+    expect(stream.write("\x1b[7;38:2::100:200:100mselected\x1b[27mstill colored")).toBe(
+      "\x1b[38;2;214;216;221;48;2;48;54;61m\x1b[38:2::100:200:100mselected\x1b[38:2::100:200:100;49mstill colored",
+    );
+  });
+
   it("tracks color state before manual Codex detection activates", () => {
     const stream = createTerminalOutputCompatStream({ sessionName: "main" });
 

--- a/tests/gateway/terminal-output-compat.test.ts
+++ b/tests/gateway/terminal-output-compat.test.ts
@@ -59,6 +59,16 @@ describe("terminal output compatibility stream", () => {
     );
   });
 
+  it("tracks color state before manual Codex detection activates", () => {
+    const stream = createTerminalOutputCompatStream({ sessionName: "main" });
+
+    expect(stream.write("\x1b[32mgreen shell output\n")).toBe("\x1b[32mgreen shell output\n");
+    expect(stream.write("OpenAI Codex (v0.142.5)\n")).toBe("OpenAI Codex (v0.142.5)\n");
+    expect(stream.write("\x1b[7mprompt\x1b[27mstill green")).toBe(
+      "\x1b[38;2;214;216;221;48;2;48;54;61mprompt\x1b[32;49mstill green",
+    );
+  });
+
   it("flushes partial escape bytes so terminal replay is not truncated", () => {
     const stream = createTerminalOutputCompatStream({ sessionName: "codex-backend" });
 

--- a/tests/gateway/terminal-output-compat.test.ts
+++ b/tests/gateway/terminal-output-compat.test.ts
@@ -59,6 +59,14 @@ describe("terminal output compatibility stream", () => {
     );
   });
 
+  it("preserves colors set in the same SGR as reverse video", () => {
+    const stream = createTerminalOutputCompatStream({ sessionName: "codex-backend" });
+
+    expect(stream.write("\x1b[7;32mselected\x1b[27mstill green")).toBe(
+      "\x1b[38;2;214;216;221;48;2;48;54;61m\x1b[32mselected\x1b[32;49mstill green",
+    );
+  });
+
   it("tracks color state before manual Codex detection activates", () => {
     const stream = createTerminalOutputCompatStream({ sessionName: "main" });
 

--- a/tests/gateway/terminal-output-compat.test.ts
+++ b/tests/gateway/terminal-output-compat.test.ts
@@ -51,6 +51,22 @@ describe("terminal output compatibility stream", () => {
     expect(stream.write("7m")).toBe("\x1b[39;49m");
   });
 
+  it("restores the pre-reverse color state when reverse video turns off", () => {
+    const stream = createTerminalOutputCompatStream({ sessionName: "codex-backend" });
+
+    expect(stream.write("\x1b[32mgreen\x1b[7mselected\x1b[27mstill green")).toBe(
+      "\x1b[32mgreen\x1b[38;2;214;216;221;48;2;48;54;61mselected\x1b[32;49mstill green",
+    );
+  });
+
+  it("flushes partial escape bytes so terminal replay is not truncated", () => {
+    const stream = createTerminalOutputCompatStream({ sessionName: "codex-backend" });
+
+    expect(stream.write("prompt\x1b[")).toBe("prompt");
+    expect(stream.flush()).toBe("\x1b[");
+    expect(stream.flush()).toBe("");
+  });
+
   it("preserves OSC and non-SGR escape sequences", () => {
     const stream = createTerminalOutputCompatStream({ sessionName: "codex-backend" });
     const osc52 = "\x1b]52;c;SGVsbG8=\x07";

--- a/tests/gateway/terminal-zellij-ws.test.ts
+++ b/tests/gateway/terminal-zellij-ws.test.ts
@@ -65,6 +65,69 @@ function socket(): ShellWsSocket & { sent: unknown[]; closed: boolean } {
 }
 
 describe("zellij terminal WebSocket", () => {
+  it("rewrites detected Codex TUI reverse-video output before send and replay persistence", async () => {
+    const pty = new FakePty();
+    const secondPty = new FakePty();
+    const ws = socket();
+    const append = vi.fn(async () => undefined);
+    const handler = createShellWsHandler({
+      registry: {
+        list: vi.fn(async () => [{ name: "main", status: "active" }]),
+      },
+      adapter: {
+        attachSession: vi.fn()
+          .mockReturnValueOnce(pty)
+          .mockReturnValueOnce(secondPty),
+      },
+      scrollbackStore: {
+        latestSeq: vi.fn(async () => null),
+        readSince: vi.fn(async () => []),
+        append,
+        cleanup: vi.fn(async () => undefined),
+        pathForSession: vi.fn(() => ""),
+      },
+      maxReplayBytes: 4096,
+    });
+    const raw = "OpenAI Codex (v0.142.5)\n\x1b[7mprompt\x1b[27m";
+    const readable = "OpenAI Codex (v0.142.5)\n\x1b[38;2;214;216;221;48;2;48;54;61mprompt\x1b[39;49m";
+
+    const first = await handler.open({ ws, session: "main", fromSeq: 0 });
+    pty.emitData(raw);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    first.onClose();
+
+    expect(ws.sent).toContainEqual({ type: "output", seq: 0, data: readable });
+    expect(append).toHaveBeenCalledWith("main", [{ type: "output", seq: 0, data: readable }]);
+
+    const replayWs = socket();
+    const second = await handler.open({ ws: replayWs, session: "main", fromSeq: 0 });
+    second.onClose();
+
+    expect(replayWs.sent).toContainEqual({ type: "output", seq: 0, data: readable });
+    expect(replayWs.sent).not.toContainEqual({ type: "output", seq: 0, data: raw });
+  });
+
+  it("keeps non-Codex reverse-video output unchanged", async () => {
+    const pty = new FakePty();
+    const ws = socket();
+    const handler = createShellWsHandler({
+      registry: {
+        list: vi.fn(async () => [{ name: "main", status: "active" }]),
+      },
+      adapter: {
+        attachSession: vi.fn(() => pty),
+      },
+      maxReplayBytes: 4096,
+    });
+    const raw = "plain \x1b[7mselected\x1b[27m";
+
+    await handler.open({ ws, session: "main", fromSeq: 0 });
+    pty.emitData(raw);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(ws.sent).toContainEqual({ type: "output", seq: 0, data: raw });
+  });
+
   it("attaches to a named session, replays from seq, forwards input, and cleans up", async () => {
     const pty = new FakePty();
     const ws = socket();

--- a/tests/gateway/terminal-zellij-ws.test.ts
+++ b/tests/gateway/terminal-zellij-ws.test.ts
@@ -128,6 +128,29 @@ describe("zellij terminal WebSocket", () => {
     expect(ws.sent).toContainEqual({ type: "output", seq: 0, data: raw });
   });
 
+  it("flushes partial Codex compatibility escape bytes before attach close", async () => {
+    const pty = new FakePty();
+    const ws = socket();
+    const handler = createShellWsHandler({
+      registry: {
+        list: vi.fn(async () => [{ name: "codex-main", status: "active" }]),
+      },
+      adapter: {
+        attachSession: vi.fn(() => pty),
+      },
+      maxReplayBytes: 4096,
+    });
+
+    const session = await handler.open({ ws, session: "codex-main", fromSeq: 0 });
+    pty.emitData("prompt\x1b[");
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    session.onClose();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(ws.sent).toContainEqual({ type: "output", seq: 0, data: "prompt" });
+    expect(ws.sent).toContainEqual({ type: "output", seq: 1, data: "\x1b[" });
+  });
+
   it("attaches to a named session, replays from seq, forwards input, and cleans up", async () => {
     const pty = new FakePty();
     const ws = socket();
@@ -174,6 +197,7 @@ describe("zellij terminal WebSocket", () => {
 
     await handler.open({ ws, session: "main", fromSeq: 0 });
     pty.emitExit({ exitCode: 101 });
+    await new Promise((resolve) => setTimeout(resolve, 0));
 
     expect(ws.sent).toContainEqual({ type: "exit", code: 101 });
   });

--- a/tests/gateway/terminal-zellij-ws.test.ts
+++ b/tests/gateway/terminal-zellij-ws.test.ts
@@ -130,7 +130,17 @@ describe("zellij terminal WebSocket", () => {
 
   it("flushes partial Codex compatibility escape bytes before attach close", async () => {
     const pty = new FakePty();
-    const ws = socket();
+    const ws: ShellWsSocket & { sent: unknown[]; closed: boolean } = {
+      sent: [],
+      closed: false,
+      send(data: string) {
+        this.sent.push(JSON.parse(data));
+      },
+      close() {
+        this.closed = true;
+        this.sent.push({ type: "closed" });
+      },
+    };
     const handler = createShellWsHandler({
       registry: {
         list: vi.fn(async () => [{ name: "codex-main", status: "active" }]),
@@ -144,11 +154,16 @@ describe("zellij terminal WebSocket", () => {
     const session = await handler.open({ ws, session: "codex-main", fromSeq: 0 });
     pty.emitData("prompt\x1b[");
     await new Promise((resolve) => setTimeout(resolve, 0));
-    session.onClose();
+    session.onMessage(JSON.stringify({ type: "detach" }));
     await new Promise((resolve) => setTimeout(resolve, 0));
 
     expect(ws.sent).toContainEqual({ type: "output", seq: 0, data: "prompt" });
     expect(ws.sent).toContainEqual({ type: "output", seq: 1, data: "\x1b[" });
+    const flushedIndex = ws.sent.findIndex((event) => JSON.stringify(event) === JSON.stringify({ type: "output", seq: 1, data: "\x1b[" }));
+    const closedIndex = ws.sent.findIndex((event) => JSON.stringify(event) === JSON.stringify({ type: "closed" }));
+    expect(flushedIndex).toBeGreaterThan(-1);
+    expect(closedIndex).toBeGreaterThan(-1);
+    expect(flushedIndex).toBeLessThan(closedIndex);
   });
 
   it("attaches to a named session, replays from seq, forwards input, and cleans up", async () => {
@@ -175,6 +190,7 @@ describe("zellij terminal WebSocket", () => {
     session.onMessage(JSON.stringify({ type: "input", data: "pwd\r" }));
     session.onMessage(JSON.stringify({ type: "resize", cols: 100, rows: 30 }));
     session.onClose();
+    await new Promise((resolve) => setTimeout(resolve, 0));
 
     expect(ws.sent).toContainEqual({ type: "attached", session: "main", state: "running", fromSeq: 0 });
     expect(ws.sent).toContainEqual({ type: "output", seq: 0, data: "hello" });
@@ -235,6 +251,7 @@ describe("zellij terminal WebSocket", () => {
 
     const session = await handler.open({ ws, session: "main", fromSeq: 0 });
     session.onMessage(JSON.stringify({ type: "destroy" }));
+    await new Promise((resolve) => setTimeout(resolve, 0));
 
     expect(pty.killed).toBe(true);
     expect(ws.closed).toBe(true);


### PR DESCRIPTION
## Summary
- Add a gateway-side terminal output compatibility stream for Codex TUI reverse-video prompt rows.
- Detect Codex TUI sessions by `codex-*` session names or the `OpenAI Codex (` banner for manual launches inside normal shells.
- Apply the transform before zellij shell output is persisted/sent and before legacy PTY output enters its replay buffer.
- Preserve ANSI color state across reverse-video rewrites, including same-sequence and colon-form extended SGR colors, and flush pending escape bytes on close/exit.

## Tests
- `./node_modules/.bin/vitest run tests/gateway/terminal-output-compat.test.ts tests/gateway/terminal-zellij-ws.test.ts tests/gateway/session-registry.test.ts tests/shell/codex-tui-compat.test.ts` (83 tests)
- `./node_modules/.bin/tsc --noEmit -p packages/gateway/tsconfig.json`
- `bun run check:patterns` (warnings only, 0 violations)
- Ready-for-CI GitHub checks passed: Type Check, Pattern Scan, React Doctor, Docs Contract Tests, Shell Production Build, Sync Client Package, Unit Tests (1/4-4/4), E2E Tests, Build Docker Test Image, Docker Smoke Test, and CI Results.
- Attempted `bun run typecheck` locally in the isolated worktree, but pnpm aborted before typecheck with `[ERR_PNPM_ABORTED_REMOVE_MODULES_DIR_NO_TTY]` while trying to run dependency status/install checks.

## Review/Monitoring
- Latest trusted Greptile review is 5/5 on commit `b9575033f12d6179112cadf22d8e5fe49b128858`.
- `ready-for-ci` is applied and the label-triggered CI run passed.

## Invariants
- Source of truth: terminal output remains the PTY/zellij stream; the gateway only normalizes Codex TUI ANSI reverse-video bytes before client delivery and replay persistence.
- Lock/transaction scope: no database writes, filesystem mutations, or cross-request transactions are introduced.
- Acceptable orphan states: if detection never sees Codex, output remains byte-for-byte unchanged; if Codex is detected, compatibility stays enabled for that attach/session stream until it exits.
- Auth source of truth: no auth, principal, token, or WebSocket authorization behavior changes.
- Deferred scope: standalone local Codex outside Matrix-controlled terminal surfaces remains an upstream/local terminal concern.
