### PR TITLE
fix(terminal): keep shell after agent exit

### DIFF
--- a/packages/gateway/src/shell/zellij-config.ts
+++ b/packages/gateway/src/shell/zellij-config.ts
@@ -135,6 +135,12 @@ if [ -z "\${MATRIX_TERMINAL_PROMPT:-}" ]; then
   fi
 fi
 
+if [ "$#" -gt 0 ]; then
+  set +e
+  "$@"
+  set -e
+fi
+
 exec bash --noprofile --rcfile ${shellSingleQuote(bashrcPath)} -i
 `;
 }

--- a/packages/gateway/src/shell/zellij-config.ts
+++ b/packages/gateway/src/shell/zellij-config.ts
@@ -137,7 +137,7 @@ fi
 
 if [ "$#" -gt 0 ]; then
   set +e
-  "$@"
+  ( "$@" )
   set -e
 fi
 

--- a/packages/gateway/src/shell/zellij.ts
+++ b/packages/gateway/src/shell/zellij.ts
@@ -412,7 +412,7 @@ export function createZellijAdapter(deps: ZellijAdapterDeps = {}): ZellijAdapter
         if (options.cmd) {
           tempLayoutDir = await mkdtemp(join(tmpdir(), "matrix-zellij-layout-"));
           const layoutPath = join(tempLayoutDir, "layout.kdl");
-          await writeFile(layoutPath, initialCommandLayout(options.cmd, options.cwd), { mode: 0o600 });
+          await writeFile(layoutPath, initialCommandLayout(options.cmd, options.cwd, zellijConfigPaths?.shellFile), { mode: 0o600 });
           args.push("--new-session-with-layout", layoutPath);
         } else if (options.layout) {
           args.push("--layout", options.layout);
@@ -590,8 +590,9 @@ function splitCommand(command: string): string[] {
   return parts;
 }
 
-function initialCommandLayout(command: string, cwd?: string): string {
-  const [binary, ...args] = splitCommand(command);
+function initialCommandLayout(command: string, cwd?: string, shellFile?: string): string {
+  const commandArgs = splitCommand(command);
+  const [binary, ...args] = shellFile ? [shellFile, ...commandArgs] : commandArgs;
   const paneAttrs = [
     cwd ? `cwd=${kdlString(cwd)}` : null,
     `command=${kdlString(binary)}`,

--- a/tests/gateway/shell-zellij.test.ts
+++ b/tests/gateway/shell-zellij.test.ts
@@ -354,6 +354,8 @@ describe("zellij adapter", () => {
       expect(config).toContain('default_layout "matrix"');
       expect(config).toContain(`default_shell ${JSON.stringify(shellPath)}`);
       expect(shell).toContain(`exec bash --noprofile --rcfile '${bashrcPath}' -i`);
+      expect(shell).toContain('if [ "$#" -gt 0 ]; then');
+      expect(shell).toContain('  set +e\n  "$@"\n  set -e');
       expect(shell).toContain(`node '${promptLabelPath}'`);
       expect(shell).not.toContain("/bin/bash");
       expect(shellMode & 0o700).toBe(0o700);
@@ -452,42 +454,48 @@ describe("zellij adapter", () => {
     const pty = ptyProcess();
     let layoutPath: string | undefined;
     let layoutText = "";
+    const homePath = await mkdtemp(join(tmpdir(), "matrix-shell-command-home-"));
     const spawnPty = vi.fn((_command, args) => {
       layoutPath = String(args[3]);
       layoutText = readFileSync(layoutPath, "utf8");
       return pty;
     });
-    const adapter = createZellijAdapter({ execFile: vi.fn(), spawnPty, timeoutMs: 25, startupDelayMs: 1 });
+    try {
+      const adapter = createZellijAdapter({ execFile: vi.fn(), spawnPty, timeoutMs: 25, startupDelayMs: 1, homePath });
 
-    await adapter.createSession({
-      name: "bench",
-      cwd: "/home/alice/work",
-      cmd: "node -e 'process.stdout.write(\"MATRIX_BENCH_READY\\n\")'",
-    });
+      await adapter.createSession({
+        name: "bench",
+        cwd: "/home/alice/work",
+        cmd: "node -e 'process.stdout.write(\"MATRIX_BENCH_READY\\n\")'",
+      });
 
-    expect(spawnPty).toHaveBeenCalledTimes(1);
-    const args = spawnPty.mock.calls[0]?.[1];
-    expect(args).toEqual([
-      "--session",
-      "bench",
-      "--new-session-with-layout",
-      expect.stringMatching(/matrix-zellij-layout-/),
-    ]);
-    expect(layoutText).toContain('cwd="/home/alice/work"');
-    expect(layoutText).toContain('command="node"');
-    expect(layoutText).toContain('args "-e"');
-    expect(layoutText).toContain("MATRIX_BENCH_READY");
-    expect(layoutText).toContain('tab name="main"');
-    expect(layoutText).not.toContain("compact-bar");
-    expect(layoutText).not.toContain("tab-bar");
-    expect(layoutText).not.toContain("status-bar");
-    expect(layoutPath).toEqual(expect.any(String));
-    expect(existsSync(layoutPath!)).toBe(true);
+      expect(spawnPty).toHaveBeenCalledTimes(1);
+      const args = spawnPty.mock.calls[0]?.[1];
+      expect(args).toEqual([
+        "--session",
+        "bench",
+        "--new-session-with-layout",
+        expect.stringMatching(/matrix-zellij-layout-/),
+      ]);
+      expect(layoutText).toContain('cwd="/home/alice/work"');
+      expect(layoutText).toContain(`command="${homePath}/system/zellij/matrix-terminal-shell"`);
+      expect(layoutText).toContain('args "node" "-e"');
+      expect(layoutText).toContain("MATRIX_BENCH_READY");
+      expect(layoutText).not.toContain('command="node"');
+      expect(layoutText).toContain('tab name="main"');
+      expect(layoutText).not.toContain("compact-bar");
+      expect(layoutText).not.toContain("tab-bar");
+      expect(layoutText).not.toContain("status-bar");
+      expect(layoutPath).toEqual(expect.any(String));
+      expect(existsSync(layoutPath!)).toBe(true);
 
-    pty.emitExit(0);
-    await vi.waitFor(() => {
-      expect(existsSync(layoutPath!)).toBe(false);
-    });
+      pty.emitExit(0);
+      await vi.waitFor(() => {
+        expect(existsSync(layoutPath!)).toBe(false);
+      });
+    } finally {
+      await rm(homePath, { recursive: true, force: true });
+    }
   });
 
   it("rejects session creation when the retained PTY exits during startup", async () => {
@@ -639,6 +647,7 @@ describe("zellij adapter", () => {
     const script = matrixTerminalShellScript(path, promptLabelPath);
 
     expect(script).toContain(`exec bash --noprofile --rcfile '/tmp/matrix "owner"/it'\\''works/bashrc' -i`);
+    expect(script).toContain('  "$@"');
     expect(script).toContain(`node '/tmp/matrix "owner"/it'\\''works/prompt-label.mjs'`);
     expect(script).not.toContain("/bin/bash");
   });

--- a/tests/gateway/shell-zellij.test.ts
+++ b/tests/gateway/shell-zellij.test.ts
@@ -355,7 +355,7 @@ describe("zellij adapter", () => {
       expect(config).toContain(`default_shell ${JSON.stringify(shellPath)}`);
       expect(shell).toContain(`exec bash --noprofile --rcfile '${bashrcPath}' -i`);
       expect(shell).toContain('if [ "$#" -gt 0 ]; then');
-      expect(shell).toContain('  set +e\n  "$@"\n  set -e');
+      expect(shell).toContain('  set +e\n  ( "$@" )\n  set -e');
       expect(shell).toContain(`node '${promptLabelPath}'`);
       expect(shell).not.toContain("/bin/bash");
       expect(shellMode & 0o700).toBe(0o700);
@@ -647,7 +647,7 @@ describe("zellij adapter", () => {
     const script = matrixTerminalShellScript(path, promptLabelPath);
 
     expect(script).toContain(`exec bash --noprofile --rcfile '/tmp/matrix "owner"/it'\\''works/bashrc' -i`);
-    expect(script).toContain('  "$@"');
+    expect(script).toContain('  ( "$@" )');
     expect(script).toContain(`node '/tmp/matrix "owner"/it'\\''works/prompt-label.mjs'`);
     expect(script).not.toContain("/bin/bash");
   });


### PR DESCRIPTION

## Summary
- Run command-created zellij sessions through the generated Matrix terminal shell instead of making the requested command the pane process.
- Let the generated shell execute the startup command and then fall through to the normal interactive bash prompt, so exiting Claude Code or Codex keeps the same terminal session alive.
- Add zellij adapter regressions that verify command sessions use the shell wrapper and keep command startup behavior scoped to one visible session.

## Tests
- `flox activate -- bun run test tests/gateway/shell-zellij.test.ts`
- `flox activate -- bun run typecheck`
- `flox activate -- bun run check:patterns` reported 0 violations and existing warnings only.

## Review/Monitoring
- Waiting for Greptile review. Do not add `ready-for-ci` until the latest trusted Greptile result is 5/5.
- `ready-for-ci` repository label verified present before PR creation.

## Invariants
- Source of truth: canonical shell sessions remain zellij-backed terminal sessions; panes stay an internal implementation detail.
- Lock/transaction scope: no database writes or transaction semantics changed.
- Acceptable orphan states: existing retained create PTY cleanup and temp layout cleanup behavior is preserved.
- Auth source of truth: terminal session auth and WebSocket attach routing are unchanged.
- Deferred scope: no new visible split-pane UI, no workspace session lifecycle changes, and no host-bundle publish in this PR.
