### PR TITLE
fix(test): restore coding agent shard stability

### DIFF
--- a/tests/default-apps/mocks/tiptap-react.ts
+++ b/tests/default-apps/mocks/tiptap-react.ts
@@ -1,0 +1,34 @@
+import React from "react";
+import { vi } from "vitest";
+
+export const fakeEditor = {
+  isFocused: true,
+  getHTML: vi.fn(() => "<p></p>"),
+  getJSON: vi.fn(() => ({ type: "doc", content: [] })),
+  chain: vi.fn(() => fakeEditor),
+  focus: vi.fn(() => fakeEditor),
+  toggleBold: vi.fn(() => fakeEditor),
+  toggleItalic: vi.fn(() => fakeEditor),
+  toggleStrike: vi.fn(() => fakeEditor),
+  toggleHeading: vi.fn(() => fakeEditor),
+  toggleBulletList: vi.fn(() => fakeEditor),
+  toggleOrderedList: vi.fn(() => fakeEditor),
+  toggleBlockquote: vi.fn(() => fakeEditor),
+  toggleCodeBlock: vi.fn(() => fakeEditor),
+  run: vi.fn(() => true),
+  isActive: vi.fn(() => false),
+  commands: {
+    focus: vi.fn(),
+    setContent: vi.fn(),
+  },
+};
+
+export function EditorContent() {
+  return React.createElement("div", { "data-testid": "editor-content" });
+}
+
+export function useEditor() {
+  return fakeEditor;
+}
+
+export type Editor = typeof fakeEditor;

--- a/tests/default-apps/mocks/tiptap-starter-kit.ts
+++ b/tests/default-apps/mocks/tiptap-starter-kit.ts
@@ -1,0 +1,3 @@
+const StarterKit = {};
+
+export default StarterKit;

--- a/tests/default-apps/notes-rich-editor.test.tsx
+++ b/tests/default-apps/notes-rich-editor.test.tsx
@@ -2,35 +2,8 @@
 import { fireEvent, render, screen } from "@testing-library/react";
 import React from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { fakeEditor } from "./mocks/tiptap-react";
 import type { Note } from "../../home/apps/notes/src/notes-model";
-
-const fakeEditor = {
-  isFocused: true,
-  getHTML: vi.fn(() => "<p></p>"),
-  getJSON: vi.fn(() => ({ type: "doc", content: [] })),
-  chain: vi.fn(() => fakeEditor),
-  focus: vi.fn(() => fakeEditor),
-  toggleHeading: vi.fn(() => fakeEditor),
-  toggleBulletList: vi.fn(() => fakeEditor),
-  toggleOrderedList: vi.fn(() => fakeEditor),
-  toggleBlockquote: vi.fn(() => fakeEditor),
-  toggleCodeBlock: vi.fn(() => fakeEditor),
-  run: vi.fn(() => true),
-  isActive: vi.fn(() => false),
-  commands: {
-    focus: vi.fn(),
-    setContent: vi.fn(),
-  },
-};
-
-vi.mock("@tiptap/react", () => ({
-  EditorContent: () => React.createElement("div", { "data-testid": "editor-content" }),
-  useEditor: () => fakeEditor,
-}));
-
-vi.mock("@tiptap/starter-kit", () => ({
-  default: {},
-}));
 
 const { default: RichEditor } = await import("../../home/apps/notes/src/RichEditor");
 

--- a/tests/gateway/workspace-routes.test.ts
+++ b/tests/gateway/workspace-routes.test.ts
@@ -359,7 +359,11 @@ describe("workspace API routes", () => {
     expect(agentSessionManager.startSession).toHaveBeenCalledWith(expect.objectContaining({
       agent: "codex",
       ownerId: "user_workspace",
-      sandbox: { enabled: true, writableRoots: [homePath] },
+      sandbox: expect.objectContaining({
+        enabled: true,
+        mode: "workspace-write",
+        writableRoots: [homePath],
+      }),
     }));
 
     await expect((await app.request("/api/sessions?projectSlug=repo&limit=10")).json()).resolves.toMatchObject({

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -7,8 +7,21 @@ export default defineConfig({
       name: "chess-app-test-mock",
       enforce: "pre",
       resolveId(source, importer) {
-        if (source !== "chess.js" || !importer) return null;
+        if (!importer) return null;
         const normalized = importer.split(path.sep).join("/");
+        if (
+          source === "@tiptap/react" &&
+          normalized.endsWith("/home/apps/notes/src/RichEditor.tsx")
+        ) {
+          return path.resolve(__dirname, "tests/default-apps/mocks/tiptap-react.ts");
+        }
+        if (
+          source === "@tiptap/starter-kit" &&
+          normalized.endsWith("/home/apps/notes/src/RichEditor.tsx")
+        ) {
+          return path.resolve(__dirname, "tests/default-apps/mocks/tiptap-starter-kit.ts");
+        }
+        if (source !== "chess.js") return null;
         // Keep FakeChess scoped to the chess app integration test and the
         // component it renders so lower-level chess unit tests opt in explicitly.
         if (
@@ -28,6 +41,7 @@ export default defineConfig({
       "@desktop": path.resolve(__dirname, "desktop/src"),
       "@renderer": path.resolve(__dirname, "desktop/src/renderer/src"),
       "@matrix-os/brand": path.resolve(__dirname, "packages/brand/src/index.ts"),
+      "@matrix-os/contracts": path.resolve(__dirname, "packages/contracts/src/index.ts"),
       "@matrix-os/observability/client": path.resolve(
         __dirname,
         "packages/observability/src/client.ts",


### PR DESCRIPTION
## Summary
- update the workspace-route assertion for the current sandbox payload shape
- scope TipTap mocks through Vitest resolution so Notes rich-editor tests do not load an app-local React copy
- keep the fix test/config-only with no lockfile or package metadata churn

## Validation
- pnpm exec vitest run tests/gateway/workspace-routes.test.ts tests/default-apps/notes-rich-editor.test.tsx tests/contracts/coding-agents.test.ts tests/desktop/coding-agent-runtime-client.test.ts
- bun run test -- --shard=4/4
- bun run check:patterns
- bun run typecheck
- git diff --check

## Mandatory Invariants
- Source of truth: unchanged; gateway/runtime contracts remain authoritative and tests now assert the current normalized sandbox payload.
- Lock/transaction scope: no runtime writes, migrations, or transaction changes.
- Acceptable orphan states: unchanged; this PR only adjusts tests and test-only module resolution.
- Auth source of truth: unchanged; no endpoint, IPC, WebSocket, or auth behavior changes.
- Deferred scope: lower-stack review nits are intentionally left for follow-up so this PR only repairs the current main CI failure.