### PR TITLE
docs(coding-agents): add shell completion audit

### DIFF
--- a/specs/105-coding-agent-shells/README.md
+++ b/specs/105-coding-agent-shells/README.md
@@ -1,6 +1,6 @@
 # 105 - Coding Agent Shells
 
-**Status**: Draft
+**Status**: Implementation checkpoint
 **Created**: 2026-07-06
 **Branch**: `chore/mobile-expo-sdk-57`
 **Scope**: Desktop and mobile shell upgrade for multi-agent coding work on the user's Matrix computer.
@@ -11,6 +11,8 @@
 - [plan.md](./plan.md) - Rollout strategy, sequencing, PR slices, risks, and decision gates.
 - [ARCHITECTURE.md](./ARCHITECTURE.md) - System architecture, contracts, runtime model, client patterns, state rules, and implementation guidance.
 - [tasks.md](./tasks.md) - Phase-by-phase implementation checklist for coding agents.
+- [current-state.md](./current-state.md) - Current route, contract, client, shell, and test inventory.
+- [completion-audit.md](./completion-audit.md) - Evidence-based completion audit for the landed implementation checkpoint.
 
 ## Intent
 

--- a/specs/105-coding-agent-shells/completion-audit.md
+++ b/specs/105-coding-agent-shells/completion-audit.md
@@ -1,0 +1,58 @@
+# Completion Audit: Coding Agent Shells
+
+**Audited commit**: `87ce9e8cc2a6357a122ea0fd9120487702ea9323`
+**Date**: 2026-07-08
+**Scope**: Evidence review for the Matrix OS coding-agent desktop, mobile, browser, and gateway shell implementation checkpoint.
+
+This audit records current evidence. It does not mark the full rollout complete while release workflows, device smoke, and broader cross-shell validation remain outstanding.
+
+## Evidence Matrix
+
+| Requirement | Evidence | Status |
+| --- | --- | --- |
+| Shared Matrix-native contracts for runtime summaries, providers, threads, events, approvals, terminal summaries, files, reviews, previews, source control, notifications, and safe errors | `packages/contracts/src/index.ts`; `tests/contracts/coding-agents.test.ts`; `current-state.md` Shared Contracts section | Implemented |
+| Gateway runtime summary and read-only hydration source for shells | `packages/gateway/src/coding-agents/runtime-summary.ts`; `packages/gateway/src/coding-agents/routes.ts`; `tests/gateway/coding-agents-summary.test.ts` | Implemented |
+| Provider registry and normalized server-side adapters | `packages/gateway/src/coding-agents/provider-registry.ts`; `packages/gateway/src/coding-agents/workspace-provider.ts`; `tests/gateway/coding-agents-workspace-provider.test.ts` | Implemented behind flags |
+| Thread create, replay, stream, abort, approval, and input lifecycle | `packages/gateway/src/coding-agents/thread-store.ts`; `packages/gateway/src/coding-agents/thread-stream.ts`; `tests/gateway/coding-agents-threads.test.ts`; `tests/gateway/coding-agents-thread-stream.test.ts` | Implemented |
+| Cross-shell terminal binding through canonical Matrix terminal sessions | `current-state.md` Terminal Session Surfaces section; desktop/mobile workspace tests listed there | Implemented without a forked terminal model |
+| Desktop coding-agent workspace and trusted main-process bridge | `desktop/src/main/coding-agents/runtime-summary-client.ts`; `desktop/src/renderer/src/features/coding-agents/AgentWorkspace.tsx`; `tests/desktop/coding-agent-workspace.test.tsx`; `tests/desktop/coding-agent-runtime-client.test.ts` | Implemented |
+| Mobile SDK 57 coding-agent workspace and phone-first routes | `apps/mobile/app/agents/index.tsx`; `apps/mobile/app/agents/[threadId].tsx`; `apps/mobile/components/AgentComposerScreen.tsx`; mobile tests listed in `current-state.md` | Implemented |
+| Browser shell remains Canvas-first and read-only for coding-agent state | `shell/src/components/workspace/WorkspaceApp.tsx`; `tests/shell/workspace-app.test.tsx`; browser section in `current-state.md` | Implemented |
+| File, review, diff, preview, and source-control surfaces remain gateway-owned with bounded shell clients | Gateway route inventory plus desktop/mobile review tests listed in `current-state.md` | Implemented |
+| Notifications and attention routing use safe owner-scoped payloads and preferences | `packages/gateway/src/coding-agents/attention-notifications.ts`; `packages/gateway/src/coding-agents/notification-preferences.ts`; related gateway, desktop, and mobile tests listed in `current-state.md` | Implemented |
+| Desktop renderer does not receive raw bearer/provider credentials | Trusted IPC and main-process client inventory in `current-state.md`; desktop runtime client tests | Implemented by architecture and tests |
+| Mobile persistent state stores only bounded UI references | `apps/mobile/lib/agent-workspace-state.ts`; `apps/mobile/lib/mobile-shell-state.ts`; mobile state tests listed in `current-state.md` | Implemented |
+| Public and internal docs | `docs/dev/coding-agent-shells.md`; `www/content/docs/coding-agents.mdx`; `current-state.md` | Implemented and must stay synchronized |
+
+## Validation Evidence
+
+GitHub CI for `87ce9e8cc2a6357a122ea0fd9120487702ea9323` completed successfully:
+
+- Pattern Scan
+- React Doctor
+- Type Check
+- Shell Production Build
+- Sync Client Package
+- Unit Tests shards 1/4, 2/4, 3/4, and 4/4
+- E2E Tests
+- CI Results
+
+Platform Cloud Run completed successfully for the same commit.
+
+Host Bundle Release was still in progress and Docker Tests were still queued when this audit PR was prepared. Treat those as release-readiness gates that still need live workflow evidence.
+
+## Remaining Validation
+
+- Run manual desktop smoke for sign-in, runtime switch, settings, menu/palette entry points, terminal attach, review/file/preview paths, and notification click-through.
+- Run manual mobile SDK 57 device smoke for chat, mission control, terminal, apps, agents workspace, thread detail, review/file/preview paths, approvals/input, notification tap routing, offline/reconnect state, and persisted safe references.
+- Confirm Host Bundle Release and Docker Tests complete for the checkpoint commit before broad rollout.
+- If runtime managers add autonomous process-exit detection beyond explicit workspace `session.stopped` events, route those events through the existing completion reconciliation path.
+- Keep `docs/dev/coding-agent-shells.md`, `www/content/docs/coding-agents.mdx`, and this audit synchronized when provider/runtime behavior changes.
+
+## Security Notes
+
+- New shell routes and clients use shared Zod 4 contracts at the boundary.
+- Mutating gateway routes use body limits, validation, ownership checks, and safe error mapping.
+- WebSocket thread streams authenticate before success, validate frames, cap subscribers, and clean up stale streams.
+- No new embedded database persistence was added.
+- Gateway/runtime remains the source of truth; desktop, mobile, and browser shells are resumable clients.

--- a/specs/105-coding-agent-shells/current-state.md
+++ b/specs/105-coding-agent-shells/current-state.md
@@ -1,8 +1,10 @@
 # Current State: Coding Agent Shells
 
-**Branch stack**: `spec/coding-agent-shells` plus stacked implementation branches through `105-coding-agent-desktop-new-run-palette`
+**Branch stack**: implementation merged to `main` through PR #861 (`87ce9e8cc2a6357a122ea0fd9120487702ea9323`)
 **Updated**: 2026-07-08
 **Scope**: Inventory for the coding-agent desktop/mobile shell work. This file records the current Matrix-native route, contract, client, and regression-test state so later slices keep gateway/runtime as source of truth and keep desktop/mobile as thin shells.
+
+For the evidence-based checkpoint audit, see [completion-audit.md](./completion-audit.md).
 
 ## Summary
 

--- a/specs/105-coding-agent-shells/tasks.md
+++ b/specs/105-coding-agent-shells/tasks.md
@@ -1,8 +1,22 @@
 # Tasks: Coding Agent Shells
 
-**Status**: Draft
-**Branch**: `chore/mobile-expo-sdk-57`
+**Status**: Implementation checkpoint
+**Branch**: merged implementation through `main` commit `87ce9e8cc2a6357a122ea0fd9120487702ea9323`
 **Rule**: Preserve all existing desktop and mobile functionality. Add coding-agent capabilities incrementally behind contracts, tests, and feature flags.
+
+## Implementation Checkpoint
+
+The phase checklist below is the original implementation plan. The authoritative
+landed-state inventory is now `current-state.md`, and the requirement/evidence
+matrix is `completion-audit.md`.
+
+As of the `87ce9e8cc2a6357a122ea0fd9120487702ea9323` main checkpoint:
+
+- Shared contracts, gateway summary/routes, provider/thread/review/file/preview/source-control contracts, desktop shell surfaces, mobile SDK 57 surfaces, browser Workspace handoff, notification preferences, and public/internal docs are implemented and inventoried in `current-state.md`.
+- GitHub CI for the checkpoint completed successfully, including pattern scan, React Doctor, typecheck, shell production build, sync-client package checks, all four unit shards, and E2E.
+- Platform Cloud Run completed successfully for the checkpoint.
+- Host Bundle Release and Docker Tests were still running or queued when this audit PR was prepared; keep them as release-readiness evidence, not implementation proof.
+- Remaining work is validation and rollout hardening: device/manual desktop and mobile smoke, release workflow completion, optional autonomous process-exit reconciliation, and continued docs sync as later provider/runtime behavior changes.
 
 ## Agent Instructions
 


### PR DESCRIPTION
## Summary
- add an evidence-based completion audit for the coding-agent shell checkpoint on main
- link the audit from the spec README and current-state inventory
- mark the task plan as an implementation checkpoint while keeping remaining validation explicit

## Validation
- git diff --cached --check: pass
- ./scripts/review/check-patterns.sh --diff origin/main: pass (no TypeScript files changed)
- forbidden reference scan over changed files: pass

## Mandatory invariants
- Source of truth: gateway/runtime remains source of truth; this PR is docs-only and changes no runtime state.
- Lock/transaction scope: no data writes or persistence changes.
- Acceptable orphan states: not applicable; docs-only.
- Auth source of truth: unchanged.
- Deferred scope: host-bundle/Docker release evidence and manual desktop/mobile device smoke remain listed as validation follow-up.