### PR TITLE
fix(terminal): normalize Codex replay output

### DIFF
--- a/packages/gateway/src/shell/ws.ts
+++ b/packages/gateway/src/shell/ws.ts
@@ -196,6 +196,9 @@ export function createShellWsHandler(options: ShellWsHandlerOptions) {
         if (data.length > 0) {
           sendJson(ws, { ...event, data });
         }
+        // A replay chunk can contain only the start of an escape sequence. The
+        // compat stream buffers it and emits bytes with the later completing
+        // chunk, matching the live-output path even when delivered seqs skip.
         continue;
       }
       sendJson(ws, event);

--- a/packages/gateway/src/shell/ws.ts
+++ b/packages/gateway/src/shell/ws.ts
@@ -186,14 +186,21 @@ export function createShellWsHandler(options: ShellWsHandlerOptions) {
       fromSeq: effectiveFromSeq,
     });
 
+    const outputCompat = createTerminalOutputCompatStream({ sessionName: safeName });
     for (const event of await replayBuffer.replayFromSeq(effectiveFromSeq)) {
       if (event.type === "replay-evicted") {
+        continue;
+      }
+      if (event.type === "output") {
+        const data = outputCompat.write(event.data);
+        if (data.length > 0) {
+          sendJson(ws, { ...event, data });
+        }
         continue;
       }
       sendJson(ws, event);
     }
 
-    const outputCompat = createTerminalOutputCompatStream({ sessionName: safeName });
     const persistOutput = async (data: string) => {
       if (data.length === 0) {
         return;

--- a/tests/gateway/terminal-zellij-ws.test.ts
+++ b/tests/gateway/terminal-zellij-ws.test.ts
@@ -107,6 +107,46 @@ describe("zellij terminal WebSocket", () => {
     expect(replayWs.sent).not.toContainEqual({ type: "output", seq: 0, data: raw });
   });
 
+  it("rewrites persisted Codex replay and keeps detection active for later live output", async () => {
+    const pty = new FakePty();
+    const ws = socket();
+    const append = vi.fn(async () => undefined);
+    const banner = "OpenAI Codex (v0.142.5)\n";
+    const rawReplayPrompt = "\x1b[7mold prompt\x1b[27m";
+    const rawLivePrompt = "\x1b[7mlive prompt\x1b[27m";
+    const readableReplayPrompt = "\x1b[38;2;214;216;221;48;2;48;54;61mold prompt\x1b[39;49m";
+    const readableLivePrompt = "\x1b[38;2;214;216;221;48;2;48;54;61mlive prompt\x1b[39;49m";
+    const handler = createShellWsHandler({
+      registry: {
+        list: vi.fn(async () => [{ name: "main", status: "active" }]),
+      },
+      adapter: {
+        attachSession: vi.fn(() => pty),
+      },
+      scrollbackStore: {
+        latestSeq: vi.fn(async () => 41),
+        readSince: vi.fn(async () => [
+          { type: "output", seq: 40, data: banner },
+          { type: "output", seq: 41, data: rawReplayPrompt },
+        ]),
+        append,
+        cleanup: vi.fn(async () => undefined),
+        pathForSession: vi.fn(() => ""),
+      },
+      maxReplayBytes: 4096,
+    });
+
+    await handler.open({ ws, session: "main", fromSeq: 40 });
+    pty.emitData(rawLivePrompt);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(ws.sent).toContainEqual({ type: "output", seq: 40, data: banner });
+    expect(ws.sent).toContainEqual({ type: "output", seq: 41, data: readableReplayPrompt });
+    expect(ws.sent).not.toContainEqual({ type: "output", seq: 41, data: rawReplayPrompt });
+    expect(ws.sent).toContainEqual({ type: "output", seq: 42, data: readableLivePrompt });
+    expect(append).toHaveBeenCalledWith("main", [{ type: "output", seq: 42, data: readableLivePrompt }]);
+  });
+
   it("keeps non-Codex reverse-video output unchanged", async () => {
     const pty = new FakePty();
     const ws = socket();


### PR DESCRIPTION
## Summary
- Normalize persisted zellij replay output through the Codex TUI compatibility stream before sending it to Canvas or CLI attach clients.
- Prime the same compatibility stream from replayed Codex banner output so later live prompt echoes in a manual `codex` session are rewritten too.
- Add a regression covering a `main` shell session whose persisted replay contains `OpenAI Codex (` plus raw reverse-video prompt bytes.

## Tests
- `./node_modules/.bin/vitest run tests/gateway/terminal-zellij-ws.test.ts` (red before fix, green after)
- `./node_modules/.bin/vitest run tests/gateway/terminal-output-compat.test.ts tests/gateway/terminal-zellij-ws.test.ts tests/gateway/session-registry.test.ts tests/shell/codex-tui-compat.test.ts` (84 tests)
- `bun run check:patterns` (warnings only, 0 violations)
- Attempted `./node_modules/.bin/tsc --noEmit -p packages/gateway/tsconfig.json`, but the local shared `node_modules` symlink is stale for latest `origin/main` and cannot resolve the new `@matrix-os/contracts` workspace package. CI should run this against a fresh install.

## Review/Monitoring
- Greptile monitoring pending after PR creation.
- `ready-for-ci` should only be added after the latest trusted Greptile review is 5/5.

## Invariants
- Source of truth: zellij/PTY output remains the source stream; this only normalizes replayed output before client delivery and primes the already-existing output compatibility stream.
- Lock/transaction scope: no database writes, filesystem writes, locks, or transactions are introduced.
- Acceptable orphan states: non-Codex replay remains byte-for-byte unchanged; Codex replay may be normalized for client delivery without mutating existing historical scrollback records.
- Auth source of truth: no auth, principal, token, or WebSocket authorization behavior changes.
- Deferred scope: this does not rewrite already persisted scrollback on disk; it normalizes it at replay/attach time and persists future live output in normalized form.
