### PR TITLE
docs(coding-agents): refresh checkpoint audit

### DIFF
--- a/specs/105-coding-agent-shells/completion-audit.md
+++ b/specs/105-coding-agent-shells/completion-audit.md
@@ -1,10 +1,10 @@
 # Completion Audit: Coding Agent Shells
 
-**Audited commit**: `b437ef39b0dfe3ee0b5bc3238e3597be85205c12`
+**Audited commit**: `87bc72d0fdd9067fcec395c479de80fcaccfe641`
 **Date**: 2026-07-08
 **Scope**: Evidence review for the Matrix OS coding-agent desktop, mobile, browser, and gateway shell implementation checkpoint.
 
-This audit records current evidence. It does not mark the full rollout complete while release workflows, device smoke, and broader cross-shell validation remain outstanding.
+This audit records current evidence. It does not mark the full rollout complete while device smoke and broader cross-shell validation remain outstanding.
 
 ## Evidence Matrix
 
@@ -13,7 +13,7 @@ This audit records current evidence. It does not mark the full rollout complete 
 | Shared Matrix-native contracts for runtime summaries, providers, threads, events, approvals, terminal summaries, files, reviews, previews, source control, notifications, and safe errors | `packages/contracts/src/index.ts`; `tests/contracts/coding-agents.test.ts`; `current-state.md` Shared Contracts section | Implemented |
 | Gateway runtime summary and read-only hydration source for shells | `packages/gateway/src/coding-agents/runtime-summary.ts`; `packages/gateway/src/coding-agents/routes.ts`; `tests/gateway/coding-agents-summary.test.ts` | Implemented |
 | Provider registry and normalized server-side adapters | `packages/gateway/src/coding-agents/provider-registry.ts`; `packages/gateway/src/coding-agents/workspace-provider.ts`; `tests/gateway/coding-agents-workspace-provider.test.ts` | Implemented behind flags |
-| Thread create, replay, stream, abort, approval, and input lifecycle | `packages/gateway/src/coding-agents/thread-store.ts`; `packages/gateway/src/coding-agents/thread-stream.ts`; `tests/gateway/coding-agents-threads.test.ts`; `tests/gateway/coding-agents-thread-stream.test.ts` | Implemented |
+| Thread create, replay, stream, abort, approval, input lifecycle, and startup-stopped session reconciliation | `packages/gateway/src/coding-agents/thread-store.ts`; `packages/gateway/src/coding-agents/thread-stream.ts`; `packages/gateway/src/workspace-startup-recovery.ts`; `tests/gateway/coding-agents-threads.test.ts`; `tests/gateway/coding-agents-thread-stream.test.ts`; `tests/gateway/coding-agents-session-stop-reconciler.test.ts`; `tests/gateway/workspace-startup-recovery.test.ts`; `tests/gateway/agent-session-manager.test.ts` | Implemented |
 | Cross-shell terminal binding through canonical Matrix terminal sessions | `current-state.md` Terminal Session Surfaces section; desktop/mobile workspace tests listed there | Implemented without a forked terminal model |
 | Desktop coding-agent workspace and trusted main-process bridge | `desktop/src/main/coding-agents/runtime-summary-client.ts`; `desktop/src/renderer/src/features/coding-agents/AgentWorkspace.tsx`; `tests/desktop/coding-agent-workspace.test.tsx`; `tests/desktop/coding-agent-runtime-client.test.ts` | Implemented |
 | Mobile SDK 57 coding-agent workspace and phone-first routes | `apps/mobile/app/agents/index.tsx`; `apps/mobile/app/agents/[threadId].tsx`; `apps/mobile/components/AgentComposerScreen.tsx`; mobile tests listed in `current-state.md` | Implemented |
@@ -26,7 +26,7 @@ This audit records current evidence. It does not mark the full rollout complete 
 
 ## Validation Evidence
 
-GitHub CI for `b437ef39b0dfe3ee0b5bc3238e3597be85205c12` completed successfully:
+GitHub CI for `87bc72d0fdd9067fcec395c479de80fcaccfe641` completed successfully:
 
 - Pattern Scan
 - React Doctor
@@ -39,7 +39,13 @@ GitHub CI for `b437ef39b0dfe3ee0b5bc3238e3597be85205c12` completed successfully:
 
 Docker Tests and Host Bundle Release completed successfully for the same commit. The Host Bundle Release built the bundle, published the release, and triggered the exact-version VPS deploy job.
 
-Platform Cloud Run completed successfully for the implementation checkpoint commit `87ce9e8cc2a6357a122ea0fd9120487702ea9323`.
+Platform Cloud Run completed successfully for the browser Workspace implementation checkpoint commit `87ce9e8cc2a6357a122ea0fd9120487702ea9323`. The later `87bc72d0fdd9067fcec395c479de80fcaccfe641` checkpoint changed gateway/spec state and did not require a platform app-shell deploy.
+
+Focused local validation on `87bc72d0fdd9067fcec395c479de80fcaccfe641` also passed:
+
+- `pnpm exec vitest run tests/contracts/coding-agents.test.ts tests/gateway/coding-agents-summary.test.ts tests/gateway/coding-agents-threads.test.ts tests/gateway/coding-agents-thread-stream.test.ts tests/gateway/coding-agents-session-stop-reconciler.test.ts tests/gateway/agent-session-manager.test.ts tests/gateway/workspace-startup-recovery.test.ts`
+- `pnpm exec vitest run tests/desktop/coding-agent-runtime-client.test.ts tests/desktop/coding-agent-thread-stream.test.ts tests/desktop/coding-agent-workspace.test.tsx tests/desktop/ipc-contract.test.ts`
+- `pnpm --filter matrix-os-mobile exec jest __tests__/agents-screen.test.tsx __tests__/agent-thread-screen.test.tsx __tests__/agents-preview-screen.test.tsx __tests__/agent-workspace-state.test.ts __tests__/gateway-client.test.ts --runInBand`
 
 ## Remaining Validation
 

--- a/specs/105-coding-agent-shells/current-state.md
+++ b/specs/105-coding-agent-shells/current-state.md
@@ -1,6 +1,6 @@
 # Current State: Coding Agent Shells
 
-**Branch stack**: implementation checkpoint merged to `main` through PR #862 (`b437ef39b0dfe3ee0b5bc3238e3597be85205c12`)
+**Branch stack**: implementation checkpoint merged to `main` through PR #863 (`87bc72d0fdd9067fcec395c479de80fcaccfe641`)
 **Updated**: 2026-07-08
 **Scope**: Inventory for the coding-agent desktop/mobile shell work. This file records the current Matrix-native route, contract, client, and regression-test state so later slices keep gateway/runtime as source of truth and keep desktop/mobile as thin shells.
 

--- a/specs/105-coding-agent-shells/tasks.md
+++ b/specs/105-coding-agent-shells/tasks.md
@@ -1,7 +1,7 @@
 # Tasks: Coding Agent Shells
 
 **Status**: Implementation checkpoint
-**Branch**: merged implementation checkpoint through `main` commit `b437ef39b0dfe3ee0b5bc3238e3597be85205c12`
+**Branch**: merged implementation checkpoint through `main` commit `87bc72d0fdd9067fcec395c479de80fcaccfe641`
 **Rule**: Preserve all existing desktop and mobile functionality. Add coding-agent capabilities incrementally behind contracts, tests, and feature flags.
 
 ## Implementation Checkpoint
@@ -10,12 +10,13 @@ The phase checklist below is the original implementation plan. The authoritative
 landed-state inventory is now `current-state.md`, and the requirement/evidence
 matrix is `completion-audit.md`.
 
-As of the `b437ef39b0dfe3ee0b5bc3238e3597be85205c12` main checkpoint:
+As of the `87bc72d0fdd9067fcec395c479de80fcaccfe641` main checkpoint:
 
 - Shared contracts, gateway summary/routes, provider/thread/review/file/preview/source-control contracts, desktop shell surfaces, mobile SDK 57 surfaces, browser Workspace handoff, notification preferences, and public/internal docs are implemented and inventoried in `current-state.md`.
+- Startup/runtime degradation recovery now routes closed coding-agent sessions through the same workspace `session.stopped` publisher path used by live session completion reconciliation.
 - GitHub CI for the checkpoint completed successfully, including pattern scan, React Doctor, typecheck, shell production build, sync-client package checks, all four unit shards, and E2E.
 - Docker Tests and Host Bundle Release completed successfully for the checkpoint; Host Bundle Release built the bundle, published the release, and triggered exact-version VPS deploy.
-- Platform Cloud Run completed successfully for the implementation checkpoint commit `87ce9e8cc2a6357a122ea0fd9120487702ea9323`.
+- Platform Cloud Run completed successfully for the browser Workspace implementation checkpoint commit `87ce9e8cc2a6357a122ea0fd9120487702ea9323`; the later `87bc72d0fdd9067fcec395c479de80fcaccfe641` checkpoint changed gateway/spec state and did not require a platform app-shell deploy.
 - Remaining work is validation and rollout hardening: device/manual desktop and mobile smoke, and continued docs sync as later provider/runtime behavior changes.
 
 ## Agent Instructions


### PR DESCRIPTION
## Summary
- updates the 105 coding-agent shell audit/checkpoint docs to the #863 main commit
- records startup-stopped session reconciliation as implemented evidence
- adds the focused gateway, desktop, and mobile validation commands that passed on the checkpoint

## Invariants
- Source of truth: documentation only; runtime behavior remains gateway-owned.
- Lock/transaction scope: no persistence or runtime writes changed.
- Acceptable orphan states: not applicable; docs-only checkpoint update.
- Auth source of truth: unchanged.
- Deferred scope: manual desktop and mobile device smoke remain outstanding and documented.

## Validation
- git diff --check
- bun run check:patterns
- pnpm exec vitest run tests/contracts/coding-agents.test.ts tests/gateway/coding-agents-summary.test.ts tests/gateway/coding-agents-threads.test.ts tests/gateway/coding-agents-thread-stream.test.ts tests/gateway/coding-agents-session-stop-reconciler.test.ts tests/gateway/agent-session-manager.test.ts tests/gateway/workspace-startup-recovery.test.ts
- pnpm exec vitest run tests/desktop/coding-agent-runtime-client.test.ts tests/desktop/coding-agent-thread-stream.test.ts tests/desktop/coding-agent-workspace.test.tsx tests/desktop/ipc-contract.test.ts
- pnpm --filter matrix-os-mobile exec jest __tests__/agents-screen.test.tsx __tests__/agent-thread-screen.test.tsx __tests__/agents-preview-screen.test.tsx __tests__/agent-workspace-state.test.ts __tests__/gateway-client.test.ts --runInBand

## Notes
- No lower-stack review issues were changed.