### PR TITLE
docs(coding-agents): record desktop smoke checkpoint

### DIFF
--- a/specs/105-coding-agent-shells/completion-audit.md
+++ b/specs/105-coding-agent-shells/completion-audit.md
@@ -1,10 +1,10 @@
 # Completion Audit: Coding Agent Shells
 
-**Audited commit**: `87bc72d0fdd9067fcec395c479de80fcaccfe641`
+**Audited commit**: `545ab794be9983c66ca0010ec44bc6b880e9c1a1`
 **Date**: 2026-07-08
 **Scope**: Evidence review for the Matrix OS coding-agent desktop, mobile, browser, and gateway shell implementation checkpoint.
 
-This audit records current evidence. It does not mark the full rollout complete while device smoke and broader cross-shell validation remain outstanding.
+This audit records current evidence through the desktop operator smoke checkpoint. It does not mark the full rollout complete while device smoke and broader cross-shell validation remain outstanding.
 
 ## Evidence Matrix
 
@@ -47,9 +47,17 @@ Focused local validation on `87bc72d0fdd9067fcec395c479de80fcaccfe641` also pass
 - `pnpm exec vitest run tests/desktop/coding-agent-runtime-client.test.ts tests/desktop/coding-agent-thread-stream.test.ts tests/desktop/coding-agent-workspace.test.tsx tests/desktop/ipc-contract.test.ts`
 - `pnpm --filter matrix-os-mobile exec jest __tests__/agents-screen.test.tsx __tests__/agent-thread-screen.test.tsx __tests__/agents-preview-screen.test.tsx __tests__/agent-workspace-state.test.ts __tests__/gateway-client.test.ts --runInBand`
 
+The desktop operator smoke checkpoint in PR #866 added and passed focused PR validation:
+
+- `bun run build:desktop`
+- `pnpm --filter desktop run typecheck`
+- `xvfb-run -a bun run test:e2e tests/e2e/desktop/operator.e2e.test.ts`
+
+That automated desktop smoke covers the stubbed sign-in/device-auth flow, project board hydration, canonical terminal attach and echo, the current Agents workspace summary and create path, the Terminal Shells workspace, Apps, Settings, Chat, and hosted-shell detach behavior.
+
 ## Remaining Validation
 
-- Run manual desktop smoke for sign-in, runtime switch, settings, menu/palette entry points, terminal attach, review/file/preview paths, and notification click-through.
+- Run manual desktop smoke against a real Matrix computer for runtime switch, menu/palette entry points, review/file/preview paths, notification click-through, non-stub provider setup, and cross-shell terminal binding. The automated desktop operator smoke now covers sign-in, project board, terminal attach, current Agents workspace create, Terminal, Apps, Settings, Chat, and hosted-shell detach through the stub gateway.
 - Run manual mobile SDK 57 device smoke for chat, mission control, terminal, apps, agents workspace, thread detail, review/file/preview paths, approvals/input, notification tap routing, offline/reconnect state, and persisted safe references.
 - Keep `docs/dev/coding-agent-shells.md`, `www/content/docs/coding-agents.mdx`, and this audit synchronized when provider/runtime behavior changes.
 

--- a/specs/105-coding-agent-shells/current-state.md
+++ b/specs/105-coding-agent-shells/current-state.md
@@ -1,6 +1,6 @@
 # Current State: Coding Agent Shells
 
-**Branch stack**: implementation checkpoint merged to `main` through PR #863 (`87bc72d0fdd9067fcec395c479de80fcaccfe641`)
+**Branch stack**: implementation checkpoint merged to `main` through PR #866 (`545ab794be9983c66ca0010ec44bc6b880e9c1a1`)
 **Updated**: 2026-07-08
 **Scope**: Inventory for the coding-agent desktop/mobile shell work. This file records the current Matrix-native route, contract, client, and regression-test state so later slices keep gateway/runtime as source of truth and keep desktop/mobile as thin shells.
 
@@ -281,6 +281,7 @@ Focused tests:
 - `tests/desktop/kernel-wiring.test.ts`
 - `tests/desktop/agent-section.test.tsx`
 - `tests/desktop/command-palette.test.tsx`
+- `tests/e2e/desktop/operator.e2e.test.ts`
 
 ## Mobile Shell State
 
@@ -424,6 +425,13 @@ Desktop typecheck:
 
 ```bash
 pnpm --filter desktop run typecheck
+```
+
+Desktop operator e2e smoke:
+
+```bash
+bun run build:desktop
+xvfb-run -a bun run test:e2e tests/e2e/desktop/operator.e2e.test.ts
 ```
 
 Repo gates:

--- a/specs/105-coding-agent-shells/tasks.md
+++ b/specs/105-coding-agent-shells/tasks.md
@@ -1,7 +1,7 @@
 # Tasks: Coding Agent Shells
 
 **Status**: Implementation checkpoint
-**Branch**: merged implementation checkpoint through `main` commit `87bc72d0fdd9067fcec395c479de80fcaccfe641`
+**Branch**: merged implementation checkpoint through `main` commit `545ab794be9983c66ca0010ec44bc6b880e9c1a1`
 **Rule**: Preserve all existing desktop and mobile functionality. Add coding-agent capabilities incrementally behind contracts, tests, and feature flags.
 
 ## Implementation Checkpoint
@@ -10,14 +10,15 @@ The phase checklist below is the original implementation plan. The authoritative
 landed-state inventory is now `current-state.md`, and the requirement/evidence
 matrix is `completion-audit.md`.
 
-As of the `87bc72d0fdd9067fcec395c479de80fcaccfe641` main checkpoint:
+As of the `545ab794be9983c66ca0010ec44bc6b880e9c1a1` main checkpoint:
 
 - Shared contracts, gateway summary/routes, provider/thread/review/file/preview/source-control contracts, desktop shell surfaces, mobile SDK 57 surfaces, browser Workspace handoff, notification preferences, and public/internal docs are implemented and inventoried in `current-state.md`.
 - Startup/runtime degradation recovery now routes closed coding-agent sessions through the same workspace `session.stopped` publisher path used by live session completion reconciliation.
-- GitHub CI for the checkpoint completed successfully, including pattern scan, React Doctor, typecheck, shell production build, sync-client package checks, all four unit shards, and E2E.
-- Docker Tests and Host Bundle Release completed successfully for the checkpoint; Host Bundle Release built the bundle, published the release, and triggered exact-version VPS deploy.
+- GitHub CI for the `87bc72d0fdd9067fcec395c479de80fcaccfe641` implementation checkpoint completed successfully, including pattern scan, React Doctor, typecheck, shell production build, sync-client package checks, all four unit shards, and E2E.
+- Docker Tests and Host Bundle Release completed successfully for the `87bc72d0fdd9067fcec395c479de80fcaccfe641` implementation checkpoint; Host Bundle Release built the bundle, published the release, and triggered exact-version VPS deploy.
 - Platform Cloud Run completed successfully for the browser Workspace implementation checkpoint commit `87ce9e8cc2a6357a122ea0fd9120487702ea9323`; the later `87bc72d0fdd9067fcec395c479de80fcaccfe641` checkpoint changed gateway/spec state and did not require a platform app-shell deploy.
-- Remaining work is validation and rollout hardening: device/manual desktop and mobile smoke, and continued docs sync as later provider/runtime behavior changes.
+- PR #866 desktop operator e2e smoke validation now covers the stubbed sign-in/device-auth flow, project board hydration, canonical terminal attach and echo, the current Agents workspace summary/create path, Terminal Shells, Apps, Settings, Chat, and hosted-shell detach behavior.
+- Remaining work is validation and rollout hardening: real-runtime desktop smoke, mobile SDK 57 device smoke, and continued docs sync as later provider/runtime behavior changes.
 
 ## Agent Instructions
 


### PR DESCRIPTION
## Summary
- Refresh the coding-agent shell audit/current-state/tasks docs through the merged desktop operator smoke checkpoint.
- Record the automated desktop e2e coverage added in PR #866.
- Narrow the remaining validation list to real-runtime desktop smoke and mobile SDK 57 device smoke.

## Mandatory invariants
- Source of truth: documentation only; gateway/runtime remain the source of truth for coding-agent state.
- Lock/transaction scope: none; no runtime code or persistence changed.
- Acceptable orphan states: none; docs-only checkpoint.
- Auth source of truth: unchanged; no auth, credential, IPC, or gateway route changes.
- Deferred scope: real-runtime desktop smoke, mobile SDK 57 device smoke, provider setup validation, review/file/preview manual validation, notification click-through, and cross-shell terminal binding remain open validation items.

## Validation
- git diff --check
- rg -n "t3code|reference repo|external inspiration" specs/105-coding-agent-shells docs/dev/coding-agent-shells.md www/content/docs/coding-agents.mdx
- bun run check:patterns (0 violations; existing warnings only)

## Notes
- Lower-stack review fixes are intentionally deferred to avoid churn across dependent work.