### PR TITLE
fix(mobile): persist thread terminal handoff

### DIFF
--- a/apps/mobile/__tests__/agent-thread-screen.test.tsx
+++ b/apps/mobile/__tests__/agent-thread-screen.test.tsx
@@ -633,6 +633,10 @@ describe("AgentThreadRoute", () => {
       MOBILE_SHELL_STATE_STORAGE_KEY,
       expect.stringContaining('"lastActiveTerminalSessionId":"matrix-abc1234"'),
     );
+    expect(AsyncStorage.setItem).toHaveBeenCalledWith(
+      MOBILE_SHELL_STATE_STORAGE_KEY,
+      expect.stringContaining('"terminalHandoffSessionId":"matrix-abc1234"'),
+    );
     expect(mockRouterPush).toHaveBeenCalledWith("/terminal");
   });
 

--- a/apps/mobile/app/agents/[threadId].tsx
+++ b/apps/mobile/app/agents/[threadId].tsx
@@ -162,6 +162,7 @@ export default function AgentThreadRoute() {
         ...savedState,
         mode: "terminal",
         lastActiveTerminalSessionId: boundTerminalSessionId,
+        terminalHandoffSessionId: boundTerminalSessionId,
         updatedAt: new Date().toISOString(),
       });
     } catch {


### PR DESCRIPTION
## Summary
- Persist the bounded terminal handoff session when opening a coding-agent thread's bound terminal from mobile.
- Align thread-detail terminal handoff with the Agents workspace terminal-row behavior.
- Add a focused mobile test that proves both last-active and handoff terminal refs are stored before routing to `/terminal`.

## Mandatory invariants
- Source of truth: gateway/runtime still own thread and terminal session state; mobile stores only bounded UI references.
- Lock/transaction scope: none; client-only AsyncStorage reference update.
- Acceptable orphan states: if saving the bounded UI reference fails, the existing generic terminal-unavailable path still prevents navigation.
- Auth source of truth: unchanged; no auth, token, gateway route, or credential handling changes.
- Deferred scope: mobile SDK 57 device smoke and real-runtime cross-shell terminal validation remain open.

## Validation
- Red: `pnpm --filter matrix-os-mobile exec jest __tests__/agent-thread-screen.test.tsx --runInBand` failed before implementation on missing `terminalHandoffSessionId`.
- Green: `pnpm --filter matrix-os-mobile exec jest __tests__/agent-thread-screen.test.tsx --runInBand`
- `pnpm --filter matrix-os-mobile exec jest __tests__/agents-screen.test.tsx __tests__/agent-thread-screen.test.tsx __tests__/agent-workspace-state.test.ts --runInBand`
- `pnpm --filter matrix-os-mobile exec tsc --noEmit`
- `pnpm --filter matrix-os-mobile run lint`
- `bun run check:patterns` (0 violations; existing warnings only)
- `git diff --check`
- `rg -n "t3code|reference repo|external inspiration" apps/mobile/app/agents apps/mobile/__tests__/agent-thread-screen.test.tsx`
