### PR TITLE
docs(coding-agents): refresh post-merge audit

### DIFF
--- a/specs/105-coding-agent-shells/completion-audit.md
+++ b/specs/105-coding-agent-shells/completion-audit.md
@@ -1,10 +1,10 @@
 # Completion Audit: Coding Agent Shells
 
-**Audited commit**: `545ab794be9983c66ca0010ec44bc6b880e9c1a1`
+**Audited commit**: `056b3da668ed6d1753712120316d2d5accfafdcf`
 **Date**: 2026-07-08
 **Scope**: Evidence review for the Matrix OS coding-agent desktop, mobile, browser, and gateway shell implementation checkpoint.
 
-This audit records current evidence through the desktop operator smoke checkpoint. It does not mark the full rollout complete while device smoke and broader cross-shell validation remain outstanding.
+This audit records current evidence through the desktop operator palette smoke and mobile terminal handoff checkpoint. It does not mark the full rollout complete while real-device smoke and broader cross-shell validation remain outstanding.
 
 ## Evidence Matrix
 
@@ -55,10 +55,31 @@ The desktop operator smoke checkpoint in PR #866 added and passed focused PR val
 
 That automated desktop smoke covers the stubbed sign-in/device-auth flow, project board hydration, canonical terminal attach and echo, the current Agents workspace summary and create path, the Terminal Shells workspace, Apps, Settings, Chat, and hosted-shell detach behavior.
 
+The mobile terminal handoff checkpoint in PR #868 added and passed focused PR validation:
+
+- `pnpm --filter matrix-os-mobile exec jest __tests__/agent-thread-screen.test.tsx --runInBand`
+- `pnpm --filter matrix-os-mobile exec jest __tests__/agents-screen.test.tsx __tests__/agent-thread-screen.test.tsx __tests__/agent-workspace-state.test.ts --runInBand`
+- `pnpm --filter matrix-os-mobile exec tsc --noEmit`
+- `pnpm --filter matrix-os-mobile run lint`
+- `bun run check:patterns`
+
+That mobile validation confirms a coding-agent thread detail handoff persists both the last active terminal session and the explicit terminal handoff reference without storing terminal output or transcript data.
+
+The desktop palette and menu-entry checkpoint in PR #869 added and passed focused PR validation:
+
+- `pnpm exec vitest run tests/desktop/menu-template.test.ts tests/desktop/shortcuts.test.ts`
+- `pnpm exec vitest run tests/desktop/menu-template.test.ts tests/desktop/shortcuts.test.ts tests/desktop/command-palette.test.tsx`
+- `bun run build:desktop`
+- `pnpm --filter desktop run typecheck`
+- `xvfb-run -a bun run test:e2e tests/e2e/desktop/operator.e2e.test.ts`
+- `bun run check:patterns`
+
+That automated desktop smoke now also covers opening the Agents workspace from the command palette after the terminal smoke path, and unit coverage confirms the native Agents menu accelerator matches the renderer shortcut.
+
 ## Remaining Validation
 
-- Run manual desktop smoke against a real Matrix computer for runtime switch, menu/palette entry points, review/file/preview paths, notification click-through, non-stub provider setup, and cross-shell terminal binding. The automated desktop operator smoke now covers sign-in, project board, terminal attach, current Agents workspace create, Terminal, Apps, Settings, Chat, and hosted-shell detach through the stub gateway.
-- Run manual mobile SDK 57 device smoke for chat, mission control, terminal, apps, agents workspace, thread detail, review/file/preview paths, approvals/input, notification tap routing, offline/reconnect state, and persisted safe references.
+- Run manual desktop smoke against a real Matrix computer for runtime switch, native menu entry points, review/file/preview paths, notification click-through, non-stub provider setup, and cross-shell terminal binding. The automated desktop operator smoke now covers sign-in, project board, terminal attach, current Agents workspace create, command-palette Agents entry, Terminal, Apps, Settings, Chat, and hosted-shell detach through the stub gateway.
+- Run manual mobile SDK 57 device smoke for chat, mission control, terminal, apps, agents workspace, thread detail, terminal handoff, review/file/preview paths, approvals/input, notification tap routing, offline/reconnect state, and persisted safe references.
 - Keep `docs/dev/coding-agent-shells.md`, `www/content/docs/coding-agents.mdx`, and this audit synchronized when provider/runtime behavior changes.
 
 ## Security Notes

--- a/specs/105-coding-agent-shells/current-state.md
+++ b/specs/105-coding-agent-shells/current-state.md
@@ -1,6 +1,6 @@
 # Current State: Coding Agent Shells
 
-**Branch stack**: implementation checkpoint merged to `main` through PR #866 (`545ab794be9983c66ca0010ec44bc6b880e9c1a1`)
+**Branch stack**: implementation checkpoint merged to `main` through PR #869 (`056b3da668ed6d1753712120316d2d5accfafdcf`)
 **Updated**: 2026-07-08
 **Scope**: Inventory for the coding-agent desktop/mobile shell work. This file records the current Matrix-native route, contract, client, and regression-test state so later slices keep gateway/runtime as source of truth and keep desktop/mobile as thin shells.
 
@@ -17,6 +17,11 @@ Current source-of-truth boundaries:
 - Mobile gets coding-agent data through the existing authenticated gateway client and stores only bounded UI references.
 - Browser shell reads coding-agent preview summaries through the authenticated gateway route and validates `RuntimeSummarySchema` before rendering bounded origin/status metadata scoped to the active Workspace project.
 - Canonical terminal sessions remain the existing Matrix shell/session primitives under `/api/terminal/sessions` and `/ws/terminal`.
+
+Post-merge checkpoint updates:
+
+- PR #868 confirmed mobile thread detail terminal handoff persists the bounded canonical terminal session reference needed by the Terminal route without persisting terminal output or transcript data.
+- PR #869 confirmed the desktop command-palette Agents entry still opens after terminal interaction, and menu-template tests cover the native Agents accelerator used to focus the same workspace.
 
 ## Shared Contracts
 

--- a/specs/105-coding-agent-shells/tasks.md
+++ b/specs/105-coding-agent-shells/tasks.md
@@ -1,7 +1,7 @@
 # Tasks: Coding Agent Shells
 
 **Status**: Implementation checkpoint
-**Branch**: merged implementation checkpoint through `main` commit `545ab794be9983c66ca0010ec44bc6b880e9c1a1`
+**Branch**: merged implementation checkpoint through `main` commit `056b3da668ed6d1753712120316d2d5accfafdcf`
 **Rule**: Preserve all existing desktop and mobile functionality. Add coding-agent capabilities incrementally behind contracts, tests, and feature flags.
 
 ## Implementation Checkpoint
@@ -10,7 +10,7 @@ The phase checklist below is the original implementation plan. The authoritative
 landed-state inventory is now `current-state.md`, and the requirement/evidence
 matrix is `completion-audit.md`.
 
-As of the `545ab794be9983c66ca0010ec44bc6b880e9c1a1` main checkpoint:
+As of the `056b3da668ed6d1753712120316d2d5accfafdcf` main checkpoint:
 
 - Shared contracts, gateway summary/routes, provider/thread/review/file/preview/source-control contracts, desktop shell surfaces, mobile SDK 57 surfaces, browser Workspace handoff, notification preferences, and public/internal docs are implemented and inventoried in `current-state.md`.
 - Startup/runtime degradation recovery now routes closed coding-agent sessions through the same workspace `session.stopped` publisher path used by live session completion reconciliation.
@@ -18,6 +18,8 @@ As of the `545ab794be9983c66ca0010ec44bc6b880e9c1a1` main checkpoint:
 - Docker Tests and Host Bundle Release completed successfully for the `87bc72d0fdd9067fcec395c479de80fcaccfe641` implementation checkpoint; Host Bundle Release built the bundle, published the release, and triggered exact-version VPS deploy.
 - Platform Cloud Run completed successfully for the browser Workspace implementation checkpoint commit `87ce9e8cc2a6357a122ea0fd9120487702ea9323`; the later `87bc72d0fdd9067fcec395c479de80fcaccfe641` checkpoint changed gateway/spec state and did not require a platform app-shell deploy.
 - PR #866 desktop operator e2e smoke validation now covers the stubbed sign-in/device-auth flow, project board hydration, canonical terminal attach and echo, the current Agents workspace summary/create path, Terminal Shells, Apps, Settings, Chat, and hosted-shell detach behavior.
+- PR #868 mobile validation now confirms thread detail terminal handoff persists the bounded canonical terminal session reference needed by the mobile Terminal route without persisting terminal output or transcript data.
+- PR #869 desktop validation now confirms the command-palette Agents entry still opens after terminal interaction, and menu-template tests cover the native Agents accelerator used to focus the same workspace.
 - Remaining work is validation and rollout hardening: real-runtime desktop smoke, mobile SDK 57 device smoke, and continued docs sync as later provider/runtime behavior changes.
 
 ## Agent Instructions


### PR DESCRIPTION
## Summary

- refresh the coding-agent shell completion audit to the latest merged checkpoint
- record PR #868 mobile terminal handoff validation and PR #869 desktop palette/menu validation
- keep the remaining validation list scoped to real-runtime desktop smoke and mobile SDK 57 device smoke

## Tests

- `git diff --check`
- `rg -n "t3code|reference repo|external inspiration" specs/105-coding-agent-shells docs www packages apps shell desktop tests home`
- `bun run check:patterns`

## Review/Monitoring

- Ready for review.
- This is a docs-only checkpoint and does not touch lower-stack review issues.
- Main workflows for `056b3da668ed6d1753712120316d2d5accfafdcf` were still in progress when this PR was opened.

## Invariants

- Source of truth: gateway/runtime remain source of truth; this PR only records checkpoint evidence.
- Lock/transaction scope: no runtime writes, database changes, locks, or transactions.
- Acceptable orphan states: not applicable; no persisted runtime resources are created.
- Auth source of truth: unchanged.
- Deferred scope: real-runtime desktop smoke, mobile SDK 57 device smoke, and lower-stack review issues remain deferred.
