### PR TITLE
fix(mobile): avoid rejected composer navigation import

### DIFF
--- a/apps/mobile/__tests__/agent-composer-screen.test.tsx
+++ b/apps/mobile/__tests__/agent-composer-screen.test.tsx
@@ -6,8 +6,10 @@ jest.mock("@/lib/feature-flags", () => ({
   CODING_AGENTS_MOBILE_WORKSPACE: true,
 }));
 
-jest.mock("@react-navigation/elements", () => ({
-  useHeaderHeight: () => 88,
+let mockSafeAreaInsets = { top: 24, right: 0, bottom: 0, left: 0 };
+
+jest.mock("react-native-safe-area-context", () => ({
+  useSafeAreaInsets: () => mockSafeAreaInsets,
 }));
 
 const mockRouterPush = jest.fn();
@@ -128,6 +130,7 @@ describe("AgentComposerScreen", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockSearchParams = {};
+    mockSafeAreaInsets = { top: 24, right: 0, bottom: 0, left: 0 };
   });
 
   it("requires a prompt before creating a run", async () => {
@@ -499,7 +502,7 @@ describe("AgentComposerScreen", () => {
     const view = render(<AgentComposerScreen />);
 
     expect(await screen.findByLabelText("Agent composer keyboard area")).toBeTruthy();
-    expect(view.UNSAFE_getByType(KeyboardAvoidingView).props.keyboardVerticalOffset).toBe(88);
+    expect(view.UNSAFE_getByType(KeyboardAvoidingView).props.keyboardVerticalOffset).toBe(24);
     expect(screen.getByLabelText("Agent run prompt")).toBeTruthy();
     expect(screen.getByRole("button", { name: "Start run" })).toBeTruthy();
   });

--- a/apps/mobile/__tests__/agent-composer-sdk57.test.ts
+++ b/apps/mobile/__tests__/agent-composer-sdk57.test.ts
@@ -1,0 +1,25 @@
+type EslintConfigEntry = {
+  rules?: Record<string, unknown>;
+};
+
+const eslintConfig = require("../eslint.config.js") as EslintConfigEntry[];
+
+describe("AgentComposerScreen SDK 57 compatibility", () => {
+  it("restricts React Navigation element imports at the lint boundary", () => {
+    const restrictedImportsRule = eslintConfig
+      .flatMap((entry) => Object.entries(entry.rules ?? {}))
+      .find(([ruleName]) => ruleName === "no-restricted-imports")?.[1];
+
+    expect(restrictedImportsRule).toEqual([
+      "error",
+      {
+        paths: [
+          {
+            name: "@react-navigation/elements",
+            message: "Use Expo Router and React Native safe-area primitives in the mobile app.",
+          },
+        ],
+      },
+    ]);
+  });
+});

--- a/apps/mobile/components/AgentComposerScreen.tsx
+++ b/apps/mobile/components/AgentComposerScreen.tsx
@@ -1,8 +1,8 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { ActivityIndicator, KeyboardAvoidingView, Platform, Pressable, ScrollView, Text, TextInput, View } from "react-native";
 import { Ionicons } from "@expo/vector-icons";
-import { useHeaderHeight } from "@react-navigation/elements";
 import { useLocalSearchParams, useRouter } from "expo-router";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { StyleSheet, useUnistyles } from "react-native-unistyles";
 import { z } from "zod/v4";
 import {
@@ -216,10 +216,10 @@ function mergeSeededDraft(
 
 export default function AgentComposerScreen() {
   const { theme } = useUnistyles();
-  const headerHeight = useHeaderHeight();
   const router = useRouter();
   const routeParams = useLocalSearchParams();
   const { client } = useGateway();
+  const insets = useSafeAreaInsets();
   const reviewIdParam = firstRouteParam(routeParams.reviewId);
   const projectIdParam = firstRouteParam(routeParams.projectId);
   const pullRequestNumberParam = firstRouteParam(routeParams.pullRequestNumber);
@@ -381,7 +381,7 @@ export default function AgentComposerScreen() {
     <KeyboardAvoidingView
       accessibilityLabel="Agent composer keyboard area"
       behavior={Platform.OS === "ios" ? "padding" : "height"}
-      keyboardVerticalOffset={Math.max(0, headerHeight)}
+      keyboardVerticalOffset={Platform.OS === "ios" ? Math.max(0, insets.top) : 0}
       style={styles.keyboardArea}
     >
       <ScrollView

--- a/apps/mobile/eslint.config.js
+++ b/apps/mobile/eslint.config.js
@@ -5,6 +5,22 @@ const expoConfig = require("eslint-config-expo/flat");
 module.exports = defineConfig([
   expoConfig,
   {
+    files: ["**/*.{js,jsx,ts,tsx}"],
+    rules: {
+      "no-restricted-imports": [
+        "error",
+        {
+          paths: [
+            {
+              name: "@react-navigation/elements",
+              message: "Use Expo Router and React Native safe-area primitives in the mobile app.",
+            },
+          ],
+        },
+      ],
+    },
+  },
+  {
     ignores: ["dist/*"],
   }
 ]);


### PR DESCRIPTION
## Summary

- remove the direct `@react-navigation/elements` import from the mobile coding-agent composer route
- keep the keyboard-aware composer layout using the existing safe-area dependency
- add an SDK 57 regression test so the composer route does not reintroduce the import Expo Router rejects

## Tests

- Red: `pnpm --filter matrix-os-mobile exec jest __tests__/agent-composer-sdk57.test.ts --runInBand`
- `pnpm --filter matrix-os-mobile exec jest __tests__/agent-composer-sdk57.test.ts __tests__/agent-composer-screen.test.tsx --runInBand`
- `pnpm --filter matrix-os-mobile exec expo export --platform web --clear`
- `pnpm --filter matrix-os-mobile exec tsc --noEmit`
- `pnpm --filter matrix-os-mobile run lint`
- `bun run check:patterns`
- `git diff --check`

## Review/Monitoring

- Ready for review.
- Found while previewing the merged checkpoint: Metro failed on `/agents/new` because Expo Router 57 rejects direct React Navigation imports.
- Lower-stack review issues intentionally untouched.

## Invariants

- Source of truth: unchanged; gateway/runtime remain source of truth for coding-agent state.
- Lock/transaction scope: no persistence, database, lock, or transaction changes.
- Acceptable orphan states: not applicable; this is a mobile render/bundle compatibility fix.
- Auth source of truth: unchanged.
- Deferred scope: real-device SDK 57 smoke is still required after this bundling fix; no native terminal replacement is included.
