### PR TITLE
fix(terminal): normalize Codex explicit prompt bands

### DIFF
--- a/packages/gateway/src/terminal-output-compat.ts
+++ b/packages/gateway/src/terminal-output-compat.ts
@@ -4,6 +4,7 @@ const MAX_DETECTION_TEXT_BYTES = 4096;
 const CODEX_TUI_FOREGROUND = "#D6D8DD";
 const CODEX_TUI_REVERSE_BG = "#30363D";
 const CODEX_TUI_BANNER = "OpenAI Codex (";
+const CODEX_TUI_PROMPT_BG = ["48", "2", "240", "240", "239"];
 
 export interface TerminalOutputCompatStream {
   readonly codexTuiActive: boolean;
@@ -57,6 +58,43 @@ function sgrColorGroupLength(params: string[], index: number): number {
     return 3;
   }
   return 0;
+}
+
+function isForegroundColorParam(param: string): boolean {
+  if (param.startsWith("38:")) {
+    return true;
+  }
+  const value = Number.parseInt(param, 10);
+  return (value >= 30 && value <= 37) || (value >= 90 && value <= 97);
+}
+
+function isBackgroundColorParam(param: string): boolean {
+  if (param.startsWith("48:")) {
+    return true;
+  }
+  const value = Number.parseInt(param, 10);
+  return (value >= 40 && value <= 47) || (value >= 100 && value <= 107);
+}
+
+function sgrColorGroupsEqual(left: string[], right: string[]): boolean {
+  return left.length === right.length && left.every((value, index) => value === right[index]);
+}
+
+function hasExplicitNonDefaultForeground(params: string[]): boolean {
+  for (let index = 0; index < params.length; index += 1) {
+    const colorGroupLength = sgrColorGroupLength(params, index);
+    if (colorGroupLength > 0) {
+      if (params[index] === "38") {
+        return true;
+      }
+      index += colorGroupLength - 1;
+      continue;
+    }
+    if (isForegroundColorParam(params[index] ?? "")) {
+      return true;
+    }
+  }
+  return false;
 }
 
 function cloneColorState(state: SgrColorState): SgrColorState {
@@ -137,9 +175,11 @@ function rewriteSgr(
   theme: CodexTuiCompatTheme,
   colorState: SgrColorState,
   reverseSnapshot: { current: SgrColorState | null },
+  promptBand: { active: boolean },
 ): string {
   const body = sequence.slice(2, -1);
   const params = body.length === 0 ? ["0"] : body.split(";");
+  const hasForegroundInSequence = hasExplicitNonDefaultForeground(params);
   const foreground = parseHexColor(theme.foreground, CODEX_TUI_FOREGROUND);
   const reverseBackground = parseHexColor(theme.reverseBackground, CODEX_TUI_REVERSE_BG);
   const foregroundParams = rgbSgr(38, foreground).split(";");
@@ -157,6 +197,26 @@ function rewriteSgr(
     const colorGroupLength = sgrColorGroupLength(params, index);
     if (colorGroupLength > 0) {
       const group = params.slice(index, index + colorGroupLength);
+      if (sgrColorGroupsEqual(group, CODEX_TUI_PROMPT_BG)) {
+        promptBand.active = true;
+        if (!hasForegroundInSequence) {
+          colorState.foreground = foregroundParams;
+          if (reverseSnapshot.current) {
+            reverseSnapshot.current.foreground = foregroundParams;
+          }
+          pending.push(...foregroundParams);
+        }
+        colorState.background = backgroundParams;
+        if (reverseSnapshot.current) {
+          reverseSnapshot.current.background = backgroundParams;
+        }
+        pending.push(...backgroundParams);
+        index += colorGroupLength - 1;
+        continue;
+      }
+      if (group[0] === "48") {
+        promptBand.active = false;
+      }
       applyColorGroupToState(group, colorState);
       if (reverseSnapshot.current) {
         applyColorGroupToState(group, reverseSnapshot.current);
@@ -173,6 +233,7 @@ function rewriteSgr(
       colorState.foreground = null;
       colorState.background = null;
       reverseSnapshot.current = null;
+      promptBand.active = false;
       continue;
     }
     if (param === "7") {
@@ -194,6 +255,17 @@ function rewriteSgr(
         output.push("\x1b[27m");
       }
       continue;
+    }
+    if (param === "39" && promptBand.active) {
+      colorState.foreground = foregroundParams;
+      if (reverseSnapshot.current) {
+        reverseSnapshot.current.foreground = foregroundParams;
+      }
+      pending.push(...foregroundParams);
+      continue;
+    }
+    if (param === "49" || isBackgroundColorParam(param)) {
+      promptBand.active = false;
     }
     applyColorParamToState(param, colorState);
     if (reverseSnapshot.current) {
@@ -224,6 +296,7 @@ function createCodexTuiCompatTransform(theme: CodexTuiCompatTheme): CodexTuiComp
   let trackingPending = "";
   const colorState: SgrColorState = { foreground: null, background: null };
   const reverseSnapshot: { current: SgrColorState | null } = { current: null };
+  const promptBand = { active: false };
 
   return {
     observe(data: string): void {
@@ -303,7 +376,7 @@ function createCodexTuiCompatTransform(theme: CodexTuiCompatTheme): CodexTuiComp
           }
           const sequence = input.slice(escapeIndex, finalIndex + 1);
           output += input[finalIndex] === "m"
-            ? rewriteSgr(sequence, theme, colorState, reverseSnapshot)
+            ? rewriteSgr(sequence, theme, colorState, reverseSnapshot, promptBand)
             : sequence;
           index = finalIndex + 1;
           continue;

--- a/packages/sync-client/src/cli/shell-client.ts
+++ b/packages/sync-client/src/cli/shell-client.ts
@@ -141,6 +141,12 @@ type MaybeTtyStream = NodeJS.ReadStream & {
   pause?: () => unknown;
 };
 
+type AttachWriter = (data: string, options?: { allowAfterSettled?: boolean }) => boolean;
+
+function isEpipeError(err: unknown): boolean {
+  return err instanceof Error && "code" in err && (err as { code?: unknown }).code === "EPIPE";
+}
+
 function terminalSize(input: MaybeTtyStream, output: NodeJS.WriteStream): {
   cols: number;
   rows: number;
@@ -672,8 +678,30 @@ export function createShellClient(options: ShellClientOptions): ShellClient {
       const input = (attachOptions.input ?? process.stdin) as MaybeTtyStream;
       const detachSequence = attachOptions.detachSequence ?? "\u001c\u001c";
       const dropMouse = attachOptions.mouse === false;
+      let writeAttachOutput: AttachWriter = (data: string) => {
+        try {
+          output.write(data);
+          return true;
+        } catch (err: unknown) {
+          if (!isEpipeError(err)) {
+            console.warn("[shell] failed to write attach output:", err instanceof Error ? err.message : String(err));
+          }
+          return false;
+        }
+      };
+      let writeAttachError: AttachWriter = (data: string) => {
+        try {
+          errorOutput.write(data);
+          return true;
+        } catch (err: unknown) {
+          if (!isEpipeError(err)) {
+            console.warn("[shell] failed to write attach error output:", err instanceof Error ? err.message : String(err));
+          }
+          return false;
+        }
+      };
       const resetLocalInputModes = () => {
-        output.write(LOCAL_TERMINAL_INPUT_RESET);
+        writeAttachOutput(LOCAL_TERMINAL_INPUT_RESET, { allowAfterSettled: true });
       };
       const inputFilter = createTerminalInputFilter({
         dropMouse,
@@ -682,7 +710,7 @@ export function createShellClient(options: ShellClientOptions): ShellClient {
       const controlDropper = createUnsupportedTerminalControlDropper();
       const bracketedPasteParser = createBracketedPasteStreamParser({
         onIncompletePaste: () => {
-          errorOutput.write(`\r\n${INCOMPLETE_BRACKETED_PASTE_MESSAGE}\r\n`);
+          writeAttachError(`\r\n${INCOMPLETE_BRACKETED_PASTE_MESSAGE}\r\n`);
         },
       });
       const richPasteEnabled = attachOptions.noRichPaste !== true && attachOptions.richPaste?.enabled !== false;
@@ -725,6 +753,59 @@ export function createShellClient(options: ShellClientOptions): ShellClient {
         let heartbeatPending = false;
         let missedHeartbeats = 0;
         let reconnectNoticeVisible = false;
+        const detachForClosedLocalPipe = () => {
+          if (settled) {
+            return;
+          }
+          const wsToClose = currentWs;
+          if (socketOpen) {
+            try {
+              wsToClose?.send(JSON.stringify({ type: "detach" }));
+            } catch (err: unknown) {
+              console.warn("[shell] failed to send detach after local pipe closed:", err instanceof Error ? err.message : String(err));
+            }
+          }
+          settle(() => resolve({ detached: true }));
+          wsToClose?.close();
+        };
+        const handleLocalStreamError = (err: unknown) => {
+          if (isEpipeError(err)) {
+            detachForClosedLocalPipe();
+            return;
+          }
+          const wsToClose = currentWs;
+          settle(() => reject(Object.assign(new Error("Request failed"), { code: "attach_failed" })));
+          wsToClose?.close();
+        };
+        const writeOutput: AttachWriter = (data, writeOptions = {}) => {
+          if (settled && !writeOptions.allowAfterSettled) {
+            return false;
+          }
+          try {
+            output.write(data);
+            return true;
+          } catch (err: unknown) {
+            handleLocalStreamError(err);
+            return false;
+          }
+        };
+        const writeError: AttachWriter = (data, writeOptions = {}) => {
+          if (settled && !writeOptions.allowAfterSettled) {
+            return false;
+          }
+          try {
+            errorOutput.write(data);
+            return true;
+          } catch (err: unknown) {
+            handleLocalStreamError(err);
+            return false;
+          }
+        };
+        writeAttachOutput = writeOutput;
+        writeAttachError = writeError;
+        const onLocalStreamError = (err: unknown) => {
+          handleLocalStreamError(err);
+        };
         const cleanup = () => {
           clearTimeout(attachTimeout);
           clearTimeout(reconnectTimer);
@@ -735,6 +816,8 @@ export function createShellClient(options: ShellClientOptions): ShellClient {
           process.off("SIGINT", onSignal);
           process.off("SIGTERM", onSignal);
           process.off("exit", onProcessExit);
+          output.off?.("error", onLocalStreamError);
+          errorOutput.off?.("error", onLocalStreamError);
           pendingInput = "";
           inputFilter.reset();
           controlDropper.reset();
@@ -856,8 +939,8 @@ export function createShellClient(options: ShellClientOptions): ShellClient {
             return;
           }
           if (!reconnecting) {
-            errorOutput.write("\r\nConnection lost. Reconnecting...\r\n");
-            output.write(SHELL_ATTACH_RECONNECT_NOTICE);
+            writeError("\r\nConnection lost. Reconnecting...\r\n");
+            writeOutput(SHELL_ATTACH_RECONNECT_NOTICE);
             reconnectNoticeVisible = true;
           }
           reconnecting = true;
@@ -889,7 +972,7 @@ export function createShellClient(options: ShellClientOptions): ShellClient {
           if (!socketOpen) {
             const nextQueuedBytes = queuedFrameBytes + Buffer.byteLength(frame, "utf8");
             if (nextQueuedBytes > SHELL_ATTACH_MAX_QUEUED_BYTES) {
-              errorOutput.write("Shell attach failed\n");
+              writeError("Shell attach failed\n");
               currentWs?.close();
               settle(() => reject(Object.assign(new Error("Request failed"), {
                 code: "attach_failed",
@@ -907,7 +990,7 @@ export function createShellClient(options: ShellClientOptions): ShellClient {
               currentWs?.close();
               return;
             }
-            errorOutput.write("Shell attach failed\n");
+            writeError("Shell attach failed\n");
             settle(() => reject(Object.assign(new Error("Request failed"), {
               code: err instanceof Error ? "attach_failed" : "request_failed",
             })));
@@ -925,7 +1008,7 @@ export function createShellClient(options: ShellClientOptions): ShellClient {
           wsToClose?.close();
         };
         const handleInputFailure = (err: unknown) => {
-          errorOutput.write("Shell attach failed\n");
+          writeError("Shell attach failed\n");
           settle(() => reject(Object.assign(new Error("Request failed"), {
             code: err instanceof Error && "code" in err ? (err as { code?: string }).code ?? "attach_failed" : "attach_failed",
           })));
@@ -947,14 +1030,14 @@ export function createShellClient(options: ShellClientOptions): ShellClient {
               return;
             }
             if (result.status === "failed") {
-              errorOutput.write(`\r\n${result.localMessage}\r\n`);
+              writeError(`\r\n${result.localMessage}\r\n`);
               return;
             }
             sendInputData(result.outgoingText);
           }).catch((err: unknown) => {
             if (!settled) {
-              errorOutput.write(`\r\n${RICH_PASTE_UPLOAD_FAILED_MESSAGE}\r\n`);
-              errorOutput.write(`[debug] rich paste rewrite failed: ${err instanceof Error ? err.name : typeof err}\r\n`);
+              writeError(`\r\n${RICH_PASTE_UPLOAD_FAILED_MESSAGE}\r\n`);
+              writeError(`[debug] rich paste rewrite failed: ${err instanceof Error ? err.name : typeof err}\r\n`);
             }
           });
         };
@@ -1109,9 +1192,9 @@ export function createShellClient(options: ShellClientOptions): ShellClient {
             startHeartbeat();
             if (reconnecting) {
               reconnecting = false;
-              errorOutput.write("\r\nConnection restored.\r\n");
+              writeError("\r\nConnection restored.\r\n");
               if (reconnectNoticeVisible) {
-                output.write(SHELL_ATTACH_RECONNECT_NOTICE_CLEAR);
+                writeOutput(SHELL_ATTACH_RECONNECT_NOTICE_CLEAR);
                 reconnectNoticeVisible = false;
               }
             }
@@ -1122,7 +1205,7 @@ export function createShellClient(options: ShellClientOptions): ShellClient {
             }
             noteRemoteActivity();
             inputFilter.noteRemoteOutput();
-            output.write(msg.data);
+            writeOutput(msg.data);
           } else if (msg.type === "pong") {
             noteRemoteActivity();
           } else if (msg.type === "error") {
@@ -1152,7 +1235,7 @@ export function createShellClient(options: ShellClientOptions): ShellClient {
             currentWs?.close();
             return;
           }
-          errorOutput.write("Shell attach failed\n");
+          writeError("Shell attach failed\n");
           settle(() => reject(Object.assign(new Error("Request failed"), {
             code: err instanceof Error ? "attach_failed" : "request_failed",
           })));
@@ -1168,6 +1251,8 @@ export function createShellClient(options: ShellClientOptions): ShellClient {
         process.once("SIGINT", onSignal);
         process.once("SIGTERM", onSignal);
         process.once("exit", onProcessExit);
+        output.on?.("error", onLocalStreamError);
+        errorOutput.on?.("error", onLocalStreamError);
         input.on?.("data", onInput);
         connect();
       });

--- a/tests/cli/shell-client.test.ts
+++ b/tests/cli/shell-client.test.ts
@@ -1138,4 +1138,75 @@ describe("shell REST client", () => {
       { type: "input", data: "bc" },
     ]);
   });
+
+  it("detaches cleanly when attach output hits EPIPE", async () => {
+    const client = createShellClient({ gatewayUrl: "http://gateway", timeoutMs: 50 });
+    const input = new EventEmitter() as NodeJS.ReadStream;
+    const epipe = Object.assign(new Error("write EPIPE"), { code: "EPIPE" });
+    const output = {
+      write: vi.fn(() => {
+        throw epipe;
+      }),
+    } as unknown as NodeJS.WriteStream;
+    const errorOutput = { write: vi.fn() } as unknown as NodeJS.WriteStream;
+
+    const attached = client.attachSession("main", {
+      WebSocketImpl: ControlledWebSocket,
+      input,
+      output,
+      errorOutput,
+    });
+    ControlledWebSocket.last?.emit("open");
+    ControlledWebSocket.last?.emit("message", JSON.stringify({ type: "attached" }));
+    ControlledWebSocket.last?.emit("message", JSON.stringify({ type: "output", data: "ready", seq: 0 }));
+
+    await expect(attached).resolves.toEqual({ detached: true });
+    expect(ControlledWebSocket.last?.closed).toBe(true);
+    expect(errorOutput.write).not.toHaveBeenCalledWith("Shell attach failed\n");
+  });
+
+  it("writes local terminal input reset when attach exits", async () => {
+    const client = createShellClient({ gatewayUrl: "http://gateway", timeoutMs: 50 });
+    const input = new FakeTtyInput() as unknown as NodeJS.ReadStream;
+    const output = { write: vi.fn(), columns: 80, rows: 24 } as unknown as NodeJS.WriteStream;
+    const errorOutput = { write: vi.fn() } as unknown as NodeJS.WriteStream;
+
+    const attached = client.attachSession("main", {
+      WebSocketImpl: ControlledWebSocket,
+      input,
+      output,
+      errorOutput,
+    });
+    ControlledWebSocket.last?.emit("open");
+    ControlledWebSocket.last?.emit("message", JSON.stringify({ type: "attached" }));
+    ControlledWebSocket.last?.emit("message", JSON.stringify({ type: "exit", code: 0 }));
+
+    await expect(attached).resolves.toEqual({ detached: false });
+    const resetWrites = vi.mocked(output.write).mock.calls.filter(([data]) => data === LOCAL_TERMINAL_INPUT_RESET);
+    expect(resetWrites).toHaveLength(2);
+  });
+
+  it("fails attach when local output hits a non-EPIPE stream error", async () => {
+    const client = createShellClient({ gatewayUrl: "http://gateway", timeoutMs: 50 });
+    const input = new EventEmitter() as NodeJS.ReadStream;
+    const output = {
+      write: vi.fn(() => {
+        throw Object.assign(new Error("stream failed"), { code: "ERR_STREAM_DESTROYED" });
+      }),
+    } as unknown as NodeJS.WriteStream;
+    const errorOutput = { write: vi.fn() } as unknown as NodeJS.WriteStream;
+
+    const attached = client.attachSession("main", {
+      WebSocketImpl: ControlledWebSocket,
+      input,
+      output,
+      errorOutput,
+    });
+    ControlledWebSocket.last?.emit("open");
+    ControlledWebSocket.last?.emit("message", JSON.stringify({ type: "attached" }));
+    ControlledWebSocket.last?.emit("message", JSON.stringify({ type: "output", data: "ready", seq: 0 }));
+
+    await expect(attached).rejects.toMatchObject({ code: "attach_failed" });
+    expect(ControlledWebSocket.last?.closed).toBe(true);
+  });
 });

--- a/tests/gateway/session-registry.test.ts
+++ b/tests/gateway/session-registry.test.ts
@@ -522,6 +522,29 @@ describe("SessionRegistry", () => {
       expect(received).not.toContainEqual({ type: "output", data: raw, seq: 0 });
     });
 
+    it("rewrites detected Codex explicit prompt backgrounds for subscribers and replay", () => {
+      const mockPty = createMockPty();
+      const mockSpawn = createMockSpawn(mockPty);
+      const registry = createRegistry({}, mockSpawn);
+      const id = registry.create("/home");
+
+      const handle = registry.attach(id)!;
+      const received: PtyServerMessage[] = [];
+      handle.subscribe((msg) => received.push(msg));
+
+      const raw = "OpenAI Codex (v0.142.5)\n\x1b[39m\x1b[48;2;240;240;239mprompt\x1b[39;49m";
+      const readable = "OpenAI Codex (v0.142.5)\n\x1b[39m\x1b[38;2;214;216;221;48;2;48;54;61mprompt\x1b[38;2;214;216;221;49m";
+      const dataCb = mockPty.onData.mock.calls[0][0];
+      dataCb(raw);
+
+      expect(received).toContainEqual({ type: "output", data: readable, seq: 0 });
+
+      received.length = 0;
+      handle.replay(0);
+      expect(received).toContainEqual({ type: "output", data: readable, seq: 0 });
+      expect(received).not.toContainEqual({ type: "output", data: raw, seq: 0 });
+    });
+
     it("keeps non-Codex reverse-video PTY output unchanged", () => {
       const mockPty = createMockPty();
       const mockSpawn = createMockSpawn(mockPty);

--- a/tests/gateway/terminal-output-compat.test.ts
+++ b/tests/gateway/terminal-output-compat.test.ts
@@ -3,6 +3,8 @@ import { createTerminalOutputCompatStream } from "../../packages/gateway/src/ter
 
 const READABLE_PROMPT = "\x1b[38;2;214;216;221;48;2;48;54;61mprompt\x1b[39;49m";
 const RAW_PROMPT = "\x1b[7mprompt\x1b[27m";
+const RAW_EXPLICIT_PROMPT_BG = "\x1b[39m\x1b[48;2;240;240;239mprompt\x1b[39;49m";
+const READABLE_EXPLICIT_PROMPT_BG = "\x1b[39m\x1b[38;2;214;216;221;48;2;48;54;61mprompt\x1b[38;2;214;216;221;49m";
 
 describe("terminal output compatibility stream", () => {
   it("leaves ordinary reverse-video output unchanged before Codex detection", () => {
@@ -17,6 +19,12 @@ describe("terminal output compatibility stream", () => {
     expect(stream.write(RAW_PROMPT)).toBe(READABLE_PROMPT);
   });
 
+  it("rewrites Codex prompt rows with explicit light RGB backgrounds immediately", () => {
+    const stream = createTerminalOutputCompatStream({ sessionName: "codex-backend" });
+
+    expect(stream.write(RAW_EXPLICIT_PROMPT_BG)).toBe(READABLE_EXPLICIT_PROMPT_BG);
+  });
+
   it("detects manual Codex launches from a later banner chunk", () => {
     const stream = createTerminalOutputCompatStream({ sessionName: "main" });
 
@@ -25,11 +33,27 @@ describe("terminal output compatibility stream", () => {
     expect(stream.write(RAW_PROMPT)).toBe(READABLE_PROMPT);
   });
 
+  it("rewrites explicit light prompt backgrounds only after manual Codex detection", () => {
+    const stream = createTerminalOutputCompatStream({ sessionName: "main" });
+
+    expect(stream.write(RAW_EXPLICIT_PROMPT_BG)).toBe(RAW_EXPLICIT_PROMPT_BG);
+    expect(stream.write("OpenAI Codex (v0.142.5)\n")).toBe("OpenAI Codex (v0.142.5)\n");
+    expect(stream.write(RAW_EXPLICIT_PROMPT_BG)).toBe(READABLE_EXPLICIT_PROMPT_BG);
+  });
+
   it("detects Codex and rewrites reverse video in the same chunk", () => {
     const stream = createTerminalOutputCompatStream({ sessionName: "main" });
 
     expect(stream.write(`OpenAI Codex (v0.142.5)\n${RAW_PROMPT}`)).toBe(
       `OpenAI Codex (v0.142.5)\n${READABLE_PROMPT}`,
+    );
+  });
+
+  it("detects Codex and rewrites explicit light prompt backgrounds in the same chunk", () => {
+    const stream = createTerminalOutputCompatStream({ sessionName: "main" });
+
+    expect(stream.write(`OpenAI Codex (v0.142.5)\n${RAW_EXPLICIT_PROMPT_BG}`)).toBe(
+      `OpenAI Codex (v0.142.5)\n${READABLE_EXPLICIT_PROMPT_BG}`,
     );
   });
 
@@ -49,6 +73,29 @@ describe("terminal output compatibility stream", () => {
     expect(stream.write("7")).toBe("");
     expect(stream.write("mprompt\x1b[2")).toBe("\x1b[38;2;214;216;221;48;2;48;54;61mprompt");
     expect(stream.write("7m")).toBe("\x1b[39;49m");
+  });
+
+  it("handles chunked explicit light RGB background SGR once Codex compatibility is active", () => {
+    const stream = createTerminalOutputCompatStream({ sessionName: "codex-backend" });
+
+    expect(stream.write("\x1b[48;2;240;")).toBe("");
+    expect(stream.write("240;239mprompt\x1b[39m")).toBe(
+      "\x1b[38;2;214;216;221;48;2;48;54;61mprompt\x1b[38;2;214;216;221m",
+    );
+  });
+
+  it("keeps non-Codex explicit light RGB backgrounds unchanged", () => {
+    const stream = createTerminalOutputCompatStream({ sessionName: "main" });
+
+    expect(stream.write(RAW_EXPLICIT_PROMPT_BG)).toBe(RAW_EXPLICIT_PROMPT_BG);
+  });
+
+  it("preserves explicit non-default foregrounds set with prompt background", () => {
+    const stream = createTerminalOutputCompatStream({ sessionName: "codex-backend" });
+
+    expect(stream.write("\x1b[32;48;2;240;240;239mselected\x1b[39mstill band")).toBe(
+      "\x1b[32;48;2;48;54;61mselected\x1b[38;2;214;216;221mstill band",
+    );
   });
 
   it("restores the pre-reverse color state when reverse video turns off", () => {

--- a/tests/gateway/terminal-zellij-ws.test.ts
+++ b/tests/gateway/terminal-zellij-ws.test.ts
@@ -107,6 +107,48 @@ describe("zellij terminal WebSocket", () => {
     expect(replayWs.sent).not.toContainEqual({ type: "output", seq: 0, data: raw });
   });
 
+  it("rewrites detected Codex explicit prompt background before send and replay persistence", async () => {
+    const pty = new FakePty();
+    const secondPty = new FakePty();
+    const ws = socket();
+    const append = vi.fn(async () => undefined);
+    const handler = createShellWsHandler({
+      registry: {
+        list: vi.fn(async () => [{ name: "main", status: "active" }]),
+      },
+      adapter: {
+        attachSession: vi.fn()
+          .mockReturnValueOnce(pty)
+          .mockReturnValueOnce(secondPty),
+      },
+      scrollbackStore: {
+        latestSeq: vi.fn(async () => null),
+        readSince: vi.fn(async () => []),
+        append,
+        cleanup: vi.fn(async () => undefined),
+        pathForSession: vi.fn(() => ""),
+      },
+      maxReplayBytes: 4096,
+    });
+    const raw = "OpenAI Codex (v0.142.5)\n\x1b[39m\x1b[48;2;240;240;239mprompt\x1b[39;49m";
+    const readable = "OpenAI Codex (v0.142.5)\n\x1b[39m\x1b[38;2;214;216;221;48;2;48;54;61mprompt\x1b[38;2;214;216;221;49m";
+
+    const first = await handler.open({ ws, session: "main", fromSeq: 0 });
+    pty.emitData(raw);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    first.onClose();
+
+    expect(ws.sent).toContainEqual({ type: "output", seq: 0, data: readable });
+    expect(append).toHaveBeenCalledWith("main", [{ type: "output", seq: 0, data: readable }]);
+
+    const replayWs = socket();
+    const second = await handler.open({ ws: replayWs, session: "main", fromSeq: 0 });
+    second.onClose();
+
+    expect(replayWs.sent).toContainEqual({ type: "output", seq: 0, data: readable });
+    expect(replayWs.sent).not.toContainEqual({ type: "output", seq: 0, data: raw });
+  });
+
   it("rewrites persisted Codex replay and keeps detection active for later live output", async () => {
     const pty = new FakePty();
     const ws = socket();


### PR DESCRIPTION
## Summary
- Normalize Codex TUI explicit prompt bands from `48;2;240;240;239` to the dark readable prompt palette when Codex compatibility is active.
- Preserve the existing reverse-video rewrite, OSC/CSI chunking behavior, replay persistence path, and non-Codex byte-for-byte output.
- Detach CLI shell attach cleanly on local stdout/stderr `EPIPE` instead of crashing on closed pipes.

## Tests
- `pnpm exec vitest run tests/gateway/terminal-output-compat.test.ts tests/gateway/terminal-zellij-ws.test.ts tests/gateway/session-registry.test.ts tests/cli/shell-client.test.ts`
- `pnpm --filter @matrix-os/gateway exec tsc --noEmit`
- `pnpm --filter @finnaai/matrix exec tsc --noEmit`
- `pnpm run check:patterns`

Notes:
- `bun` is not installed in this environment, so I used direct `pnpm` commands for focused validation.
- An initial `pnpm test -- ...` invocation expanded into unrelated broad tests; I interrupted it after confirming it was outside scope and ran direct Vitest against the four requested files.

## Review/Monitoring
- Please wait for CI and Greptile review. This PR is not ready to merge until the latest trusted Greptile result is 5/5 and required checks are green.

## Invariants
- Source of truth: terminal output bytes are normalized in the gateway compatibility stream before zellij scrollback persistence and before legacy `SessionRegistry` ring-buffer replay. CLI attach only consumes the already-normalized gateway stream.
- Lock/transaction scope: no database writes or transactions are introduced; the transform is deterministic per stream and bounded by the existing pending escape buffer limits.
- Acceptable orphan states: if CLI local output closes with `EPIPE`, the client best-effort sends a detach frame, closes the WebSocket, restores local terminal state, and resolves as detached. Remote sessions remain alive.
- Auth source of truth: no WebSocket/API auth behavior changes; existing gateway auth and session validation remain authoritative.
- Deferred scope: browser-side `codex-tui` fallback remains in place; manual host-bundle deployment and live CLI visual verification are deferred to release validation after merge.
