### PR TITLE
docs(coding-agents): refresh post-871 audit

### DIFF
--- a/specs/105-coding-agent-shells/completion-audit.md
+++ b/specs/105-coding-agent-shells/completion-audit.md
@@ -1,10 +1,10 @@
 # Completion Audit: Coding Agent Shells
 
-**Audited commit**: `056b3da668ed6d1753712120316d2d5accfafdcf`
-**Date**: 2026-07-08
+**Audited commit**: `7ca8ae8875a7b0e13edebd607d7ff71ca8a1a876`
+**Date**: 2026-07-09
 **Scope**: Evidence review for the Matrix OS coding-agent desktop, mobile, browser, and gateway shell implementation checkpoint.
 
-This audit records current evidence through the desktop operator palette smoke and mobile terminal handoff checkpoint. It does not mark the full rollout complete while real-device smoke and broader cross-shell validation remain outstanding.
+This audit records current evidence through the desktop operator palette smoke, mobile terminal handoff, Expo SDK 57 composer export, and post-merge host-bundle deployment checkpoints. It does not mark the full rollout complete while real-runtime desktop smoke, real-device mobile smoke, and broader cross-shell validation remain outstanding.
 
 ## Evidence Matrix
 
@@ -25,6 +25,21 @@ This audit records current evidence through the desktop operator palette smoke a
 | Public and internal docs | `docs/dev/coding-agent-shells.md`; `www/content/docs/coding-agents.mdx`; `current-state.md` | Implemented and must stay synchronized |
 
 ## Validation Evidence
+
+GitHub CI for `7ca8ae8875a7b0e13edebd607d7ff71ca8a1a876` completed successfully after rerunning an unrelated Clock app test flake:
+
+- Pattern Scan
+- React Doctor
+- Type Check
+- Shell Production Build
+- Sync Client Package
+- Unit Tests shards 1/4, 2/4, 3/4, and 4/4
+- E2E Tests
+- CI Results
+
+Docker Tests completed successfully for `7ca8ae8875a7b0e13edebd607d7ff71ca8a1a876`, including Docker image build, smoke coverage, and scenario jobs for fresh install, upgrade, customized files, channels, and recovery.
+
+Host Bundle Release completed successfully for `7ca8ae8875a7b0e13edebd607d7ff71ca8a1a876`; the workflow built the host bundle, uploaded the artifact, published to R2, and triggered exact-version VPS deploy.
 
 GitHub CI for `87bc72d0fdd9067fcec395c479de80fcaccfe641` completed successfully:
 
@@ -75,6 +90,16 @@ The desktop palette and menu-entry checkpoint in PR #869 added and passed focuse
 - `bun run check:patterns`
 
 That automated desktop smoke now also covers opening the Agents workspace from the command palette after the terminal smoke path, and unit coverage confirms the native Agents menu accelerator matches the renderer shortcut.
+
+The mobile SDK 57 composer export checkpoint in PR #871 added and passed focused PR validation:
+
+- `pnpm --filter matrix-os-mobile exec jest __tests__/agent-composer-sdk57.test.ts __tests__/agent-composer-screen.test.tsx --runInBand`
+- `pnpm --filter matrix-os-mobile run lint`
+- `pnpm --filter matrix-os-mobile exec tsc --noEmit`
+- `bun run check:patterns`
+- `EXPO_PUBLIC_CODING_AGENTS_MOBILE_WORKSPACE=1 pnpm --filter matrix-os-mobile exec expo export --platform web --clear`
+
+That mobile validation confirms the coding-agent composer route graph exports under Expo SDK 57, avoids rejected dynamic route imports, and keeps iOS keyboard avoidance safe-area aware.
 
 ## Remaining Validation
 

--- a/specs/105-coding-agent-shells/current-state.md
+++ b/specs/105-coding-agent-shells/current-state.md
@@ -1,7 +1,7 @@
 # Current State: Coding Agent Shells
 
-**Branch stack**: implementation checkpoint merged to `main` through PR #869 (`056b3da668ed6d1753712120316d2d5accfafdcf`)
-**Updated**: 2026-07-08
+**Branch stack**: implementation checkpoint merged to `main` through PR #871 (`7ca8ae8875a7b0e13edebd607d7ff71ca8a1a876`)
+**Updated**: 2026-07-09
 **Scope**: Inventory for the coding-agent desktop/mobile shell work. This file records the current Matrix-native route, contract, client, and regression-test state so later slices keep gateway/runtime as source of truth and keep desktop/mobile as thin shells.
 
 For the evidence-based checkpoint audit, see [completion-audit.md](./completion-audit.md).
@@ -22,6 +22,8 @@ Post-merge checkpoint updates:
 
 - PR #868 confirmed mobile thread detail terminal handoff persists the bounded canonical terminal session reference needed by the Terminal route without persisting terminal output or transcript data.
 - PR #869 confirmed the desktop command-palette Agents entry still opens after terminal interaction, and menu-template tests cover the native Agents accelerator used to focus the same workspace.
+- PR #871 confirmed the Expo SDK 57 mobile composer route graph exports successfully with `EXPO_PUBLIC_CODING_AGENTS_MOBILE_WORKSPACE=1` after keeping navigation imports in SDK-accepted static shapes, and preserved iOS keyboard avoidance through safe-area-aware offset handling.
+- The #871 post-merge checkpoint completed GitHub CI, Docker Tests, Host Bundle build, R2 publish, and exact-version VPS deploy on `7ca8ae8875a7b0e13edebd607d7ff71ca8a1a876`.
 
 ## Shared Contracts
 

--- a/specs/105-coding-agent-shells/tasks.md
+++ b/specs/105-coding-agent-shells/tasks.md
@@ -1,7 +1,7 @@
 # Tasks: Coding Agent Shells
 
 **Status**: Implementation checkpoint
-**Branch**: merged implementation checkpoint through `main` commit `056b3da668ed6d1753712120316d2d5accfafdcf`
+**Branch**: merged implementation checkpoint through `main` commit `7ca8ae8875a7b0e13edebd607d7ff71ca8a1a876`
 **Rule**: Preserve all existing desktop and mobile functionality. Add coding-agent capabilities incrementally behind contracts, tests, and feature flags.
 
 ## Implementation Checkpoint
@@ -10,16 +10,19 @@ The phase checklist below is the original implementation plan. The authoritative
 landed-state inventory is now `current-state.md`, and the requirement/evidence
 matrix is `completion-audit.md`.
 
-As of the `056b3da668ed6d1753712120316d2d5accfafdcf` main checkpoint:
+As of the `7ca8ae8875a7b0e13edebd607d7ff71ca8a1a876` main checkpoint:
 
 - Shared contracts, gateway summary/routes, provider/thread/review/file/preview/source-control contracts, desktop shell surfaces, mobile SDK 57 surfaces, browser Workspace handoff, notification preferences, and public/internal docs are implemented and inventoried in `current-state.md`.
 - Startup/runtime degradation recovery now routes closed coding-agent sessions through the same workspace `session.stopped` publisher path used by live session completion reconciliation.
+- GitHub CI for `7ca8ae8875a7b0e13edebd607d7ff71ca8a1a876` completed successfully after rerunning an unrelated Clock app test flake; the rerun passed all CI jobs, including typecheck, pattern scan, shell production build, sync-client package checks, all four unit shards, E2E, and the aggregate CI Results job.
+- Docker Tests and Host Bundle Release completed successfully for `7ca8ae8875a7b0e13edebd607d7ff71ca8a1a876`; Host Bundle Release built the bundle, published it to R2, and triggered exact-version VPS deploy.
 - GitHub CI for the `87bc72d0fdd9067fcec395c479de80fcaccfe641` implementation checkpoint completed successfully, including pattern scan, React Doctor, typecheck, shell production build, sync-client package checks, all four unit shards, and E2E.
 - Docker Tests and Host Bundle Release completed successfully for the `87bc72d0fdd9067fcec395c479de80fcaccfe641` implementation checkpoint; Host Bundle Release built the bundle, published the release, and triggered exact-version VPS deploy.
 - Platform Cloud Run completed successfully for the browser Workspace implementation checkpoint commit `87ce9e8cc2a6357a122ea0fd9120487702ea9323`; the later `87bc72d0fdd9067fcec395c479de80fcaccfe641` checkpoint changed gateway/spec state and did not require a platform app-shell deploy.
 - PR #866 desktop operator e2e smoke validation now covers the stubbed sign-in/device-auth flow, project board hydration, canonical terminal attach and echo, the current Agents workspace summary/create path, Terminal Shells, Apps, Settings, Chat, and hosted-shell detach behavior.
 - PR #868 mobile validation now confirms thread detail terminal handoff persists the bounded canonical terminal session reference needed by the mobile Terminal route without persisting terminal output or transcript data.
 - PR #869 desktop validation now confirms the command-palette Agents entry still opens after terminal interaction, and menu-template tests cover the native Agents accelerator used to focus the same workspace.
+- PR #871 mobile validation confirms the Expo SDK 57 web export accepts the coding-agent composer route graph after removing the rejected dynamic navigation import path.
 - Remaining work is validation and rollout hardening: real-runtime desktop smoke, mobile SDK 57 device smoke, and continued docs sync as later provider/runtime behavior changes.
 
 ## Agent Instructions


### PR DESCRIPTION
## Summary
- Update spec 105 checkpoint docs to the #871 merge commit.
- Record the post-merge CI, Docker, host-bundle publish, and exact-version deploy evidence.
- Add the SDK 57 mobile composer export validation while keeping real-runtime desktop and real-device mobile smoke listed as remaining validation.

## Tests
- git diff --check
- rg -n "t3code|reference repo|external inspiration" specs/105-coding-agent-shells docs www packages shell desktop tests home apps/mobile (no matches)
- bun run check:patterns (0 violations; existing warnings only)

## Review/Monitoring
- Opened ready for review.
- `ready-for-ci` is intentionally not added until the latest trusted Greptile review reaches 5/5 on this head.

## Invariants
- Source of truth: documentation-only refresh of already-merged validation evidence; runtime/gateway remain source of truth.
- Lock/transaction scope: no runtime writes, migrations, locks, or transactions changed.
- Acceptable orphan states: none introduced.
- Auth source of truth: unchanged.
- Deferred scope: real-runtime desktop smoke and real-device mobile SDK 57 smoke remain explicitly documented as unproven validation.