### PR TITLE
test(coding-agents): add runtime smoke harness

### DIFF
--- a/docs/dev/coding-agent-shells.md
+++ b/docs/dev/coding-agent-shells.md
@@ -150,6 +150,28 @@ Use this checklist for every coding-agent shell PR:
 
 Use this section when a coding-agent shell surface is enabled but a user cannot continue work from desktop or mobile. Keep support notes public-safe: do not paste customer identifiers, bearer tokens, provider credentials, private hostnames, VPS IPs, or raw provider output into GitHub, docs, or PR comments.
 
+### Runtime Smoke Command
+
+Before a manual desktop or mobile smoke, validate the selected Matrix computer's coding-agent contract surface with the read-only runtime smoke:
+
+```bash
+MATRIX_CODING_AGENTS_SMOKE_ORIGIN="https://app.matrix-os.com" \
+MATRIX_CODING_AGENTS_SMOKE_TOKEN="<operator-auth-token>" \
+pnpm run smoke:coding-agents
+```
+
+The command validates the authenticated runtime summary, notification preferences, review summaries, and one existing thread snapshot when a thread is present. It parses every response through the shared contracts and prints only aggregate counts and statuses. It does not print bearer tokens, provider credentials, terminal output, transcripts, file contents, diffs, private hostnames, or raw gateway/provider errors.
+
+The command is read-only by default. To create one smoke agent run after the read-only checks pass, opt in explicitly:
+
+```bash
+MATRIX_CODING_AGENTS_SMOKE_ORIGIN="https://app.matrix-os.com" \
+MATRIX_CODING_AGENTS_SMOKE_TOKEN="<operator-auth-token>" \
+pnpm run smoke:coding-agents -- --create-thread --prompt "Matrix coding-agent runtime smoke"
+```
+
+Use `--runtime <slot>` only when validating a non-primary runtime slot. Record pass/fail status and aggregate counts in the PR or release note; keep the origin, token, owner handle, private hostnames, and raw response bodies out of public artifacts.
+
 ### Provider Setup Failure
 
 Symptoms:

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "docker:build": "docker compose -f docker-compose.dev.yml build --no-cache",
     "cleanup:local-artifacts": "node scripts/cleanup-local-artifacts.mjs",
     "observability:posthog-alerts": "node scripts/observability/setup-posthog-alerts.mjs",
+    "smoke:coding-agents": "tsx scripts/coding-agent-runtime-smoke.ts",
     "test": "sh -c 'pnpm --filter @matrix-os/observability build && pnpm --filter @matrix-os/kernel build && vitest run \"$@\"' --",
     "test:watch": "sh -c 'pnpm --filter @matrix-os/observability build && pnpm --filter @matrix-os/kernel build && vitest \"$@\"' --",
     "test:integration": "vitest run --config vitest.integration.config.ts",

--- a/scripts/coding-agent-runtime-smoke.ts
+++ b/scripts/coding-agent-runtime-smoke.ts
@@ -1,0 +1,335 @@
+#!/usr/bin/env tsx
+import { randomUUID } from "node:crypto";
+import {
+  AgentThreadSnapshotSchema,
+  CodingAgentNotificationPreferencesSchema,
+  CreateAgentThreadRequestSchema,
+  ReviewSummarySchema,
+  RuntimeSummarySchema,
+  boundedListSchema,
+  type AgentThreadSnapshot,
+  type RuntimeSummary,
+} from "@matrix-os/contracts";
+import { z } from "zod/v4";
+
+const DEFAULT_TIMEOUT_MS = 10_000;
+const DEFAULT_PROMPT = "Matrix coding-agent runtime smoke";
+const ReviewSummaryListSchema = boundedListSchema(ReviewSummarySchema, 50);
+const NotificationPreferencesResponseSchema = z.object({
+  preferences: CodingAgentNotificationPreferencesSchema,
+}).strict();
+
+export interface SmokeOptions {
+  origin: string;
+  token: string;
+  runtime?: string;
+  timeoutMs?: number;
+  createThread?: boolean;
+  providerId?: string;
+  prompt?: string;
+  json?: boolean;
+  fetchFn?: typeof fetch;
+}
+
+export interface SmokeReport {
+  ok: true;
+  summary: {
+    runtimeStatus: RuntimeSummary["runtime"]["status"];
+    capabilityCount: number;
+    providerCount: number;
+    readyProviderCount: number;
+    activeThreadCount: number;
+    attentionThreadCount: number;
+    terminalSessionCount: number;
+    previewSessionCount: number;
+    reviewCount: number;
+    notificationPreferencesReachable: boolean;
+    checkedThreadSnapshot: boolean;
+    createdThreadStatus: AgentThreadSnapshot["thread"]["status"] | null;
+  };
+}
+
+interface RuntimeUrlOptions {
+  origin: string;
+  path: string;
+  runtime?: string;
+}
+
+export function buildRuntimeUrl(options: RuntimeUrlOptions): URL {
+  const origin = normalizeOrigin(options.origin);
+  const url = new URL(options.path, origin);
+  if (options.runtime && options.runtime !== "primary") {
+    url.searchParams.set("runtime", options.runtime);
+  }
+  return url;
+}
+
+export function parseArgs(argv: string[], env: NodeJS.ProcessEnv = process.env): SmokeOptions & { help?: true } {
+  const options: Partial<SmokeOptions> = {
+    origin: env.MATRIX_CODING_AGENTS_SMOKE_ORIGIN,
+    token: env.MATRIX_CODING_AGENTS_SMOKE_TOKEN,
+    runtime: env.MATRIX_CODING_AGENTS_SMOKE_RUNTIME,
+    timeoutMs: env.MATRIX_CODING_AGENTS_SMOKE_TIMEOUT_MS
+      ? parsePositiveInteger(env.MATRIX_CODING_AGENTS_SMOKE_TIMEOUT_MS, "MATRIX_CODING_AGENTS_SMOKE_TIMEOUT_MS")
+      : DEFAULT_TIMEOUT_MS,
+    createThread: false,
+    prompt: DEFAULT_PROMPT,
+    json: false,
+  };
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    const readValue = () => {
+      const value = argv[i + 1];
+      if (!value || value.startsWith("--")) throw new Error(`Missing value for ${arg}`);
+      i += 1;
+      return value;
+    };
+
+    if (arg === "--") continue;
+    if (arg === "--help" || arg === "-h") return { ...(options as SmokeOptions), help: true };
+    if (arg === "--origin") options.origin = readValue();
+    else if (arg === "--token") options.token = readValue();
+    else if (arg === "--runtime") options.runtime = readValue();
+    else if (arg === "--timeout-ms") options.timeoutMs = parsePositiveInteger(readValue(), "timeout-ms");
+    else if (arg === "--create-thread") options.createThread = true;
+    else if (arg === "--provider") options.providerId = readValue();
+    else if (arg === "--prompt") options.prompt = readValue();
+    else if (arg === "--json") options.json = true;
+    else throw new Error(`Unknown argument: ${arg}`);
+  }
+
+  if (!options.origin) throw new Error("Missing --origin or MATRIX_CODING_AGENTS_SMOKE_ORIGIN");
+  if (!options.token) throw new Error("Missing --token or MATRIX_CODING_AGENTS_SMOKE_TOKEN");
+  normalizeOrigin(options.origin);
+  return options as SmokeOptions;
+}
+
+export async function runCodingAgentRuntimeSmoke(options: SmokeOptions): Promise<SmokeReport> {
+  const fetchFn = options.fetchFn ?? fetch;
+  const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const summary = await requestJson({
+    label: "runtime summary",
+    schema: RuntimeSummarySchema,
+    fetchFn,
+    url: buildRuntimeUrl({ origin: options.origin, path: "/api/coding-agents/summary", runtime: options.runtime }),
+    token: options.token,
+    timeoutMs,
+  });
+
+  const notificationPreferences = await requestJson({
+    label: "notification preferences",
+    schema: NotificationPreferencesResponseSchema,
+    fetchFn,
+    url: buildRuntimeUrl({
+      origin: options.origin,
+      path: "/api/coding-agents/notification-preferences",
+      runtime: options.runtime,
+    }),
+    token: options.token,
+    timeoutMs,
+  });
+
+  const reviews = await requestJson({
+    label: "review summaries",
+    schema: ReviewSummaryListSchema,
+    fetchFn,
+    url: buildRuntimeUrl({ origin: options.origin, path: "/api/coding-agents/reviews", runtime: options.runtime }),
+    token: options.token,
+    timeoutMs,
+  });
+
+  let checkedThreadSnapshot = false;
+  const firstThreadId = summary.activeThreads.items[0]?.id ?? summary.attentionThreads.items[0]?.id;
+  if (firstThreadId) {
+    await requestJson({
+      label: "thread snapshot",
+      schema: AgentThreadSnapshotSchema,
+      fetchFn,
+      url: buildRuntimeUrl({
+        origin: options.origin,
+        path: `/api/coding-agents/threads/${encodeURIComponent(firstThreadId)}`,
+        runtime: options.runtime,
+      }),
+      token: options.token,
+      timeoutMs,
+    });
+    checkedThreadSnapshot = true;
+  }
+
+  let createdThreadStatus: AgentThreadSnapshot["thread"]["status"] | null = null;
+  if (options.createThread) {
+    const providerId = options.providerId ?? selectProviderId(summary);
+    const createRequest = CreateAgentThreadRequestSchema.parse({
+      providerId,
+      prompt: options.prompt ?? DEFAULT_PROMPT,
+      mode: "default",
+      approvalPolicy: "on_request",
+      sandboxMode: "workspace_write",
+      clientRequestId: buildClientRequestId(),
+    });
+    const created = await requestJson({
+      label: "thread creation",
+      schema: AgentThreadSnapshotSchema,
+      fetchFn,
+      url: buildRuntimeUrl({ origin: options.origin, path: "/api/coding-agents/threads", runtime: options.runtime }),
+      token: options.token,
+      timeoutMs,
+      method: "POST",
+      body: createRequest,
+    });
+    createdThreadStatus = created.thread.status;
+  }
+
+  return {
+    ok: true,
+    summary: {
+      runtimeStatus: summary.runtime.status,
+      capabilityCount: summary.capabilities.length,
+      providerCount: summary.providers.length,
+      readyProviderCount: summary.providers.filter(isReadyProvider).length,
+      activeThreadCount: summary.activeThreads.items.length,
+      attentionThreadCount: summary.attentionThreads.items.length,
+      terminalSessionCount: summary.terminalSessions.items.length,
+      previewSessionCount: summary.previewSessions.items.length,
+      reviewCount: reviews.items.length,
+      notificationPreferencesReachable: Boolean(notificationPreferences.preferences),
+      checkedThreadSnapshot,
+      createdThreadStatus,
+    },
+  };
+}
+
+function normalizeOrigin(value: string): string {
+  let parsed: URL;
+  try {
+    parsed = new URL(value);
+  } catch {
+    throw new Error("Runtime origin must be a valid HTTP(S) URL");
+  }
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    throw new Error("Runtime origin must be a valid HTTP(S) URL");
+  }
+  return parsed.origin;
+}
+
+function parsePositiveInteger(value: string, label: string): number {
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed <= 0 || parsed > 120_000) {
+    throw new Error(`${label} must be a positive integer up to 120000`);
+  }
+  return parsed;
+}
+
+function isReadyProvider(provider: RuntimeSummary["providers"][number]): boolean {
+  return provider.availability === "available" &&
+    provider.installStatus === "installed" &&
+    provider.authStatus === "authenticated";
+}
+
+function selectProviderId(summary: RuntimeSummary): string {
+  const provider = summary.providers.find(isReadyProvider) ?? summary.providers[0];
+  if (!provider) throw new Error("thread creation unavailable");
+  return provider.id;
+}
+
+function buildClientRequestId(): string {
+  return `req_smoke_${randomUUID().replace(/-/g, "").slice(0, 24)}`;
+}
+
+async function requestJson<TSchema extends z.ZodType>(options: {
+  label: string;
+  schema: TSchema;
+  fetchFn: typeof fetch;
+  url: URL;
+  token: string;
+  timeoutMs: number;
+  method?: "GET" | "POST";
+  body?: unknown;
+}): Promise<z.infer<TSchema>> {
+  let response: Response;
+  try {
+    response = await options.fetchFn(options.url.toString(), {
+      method: options.method ?? "GET",
+      headers: {
+        Authorization: `Bearer ${options.token}`,
+        Accept: "application/json",
+        ...(options.body === undefined ? {} : { "Content-Type": "application/json" }),
+      },
+      body: options.body === undefined ? undefined : JSON.stringify(options.body),
+      signal: AbortSignal.timeout(options.timeoutMs),
+    });
+  } catch {
+    throw new Error(`${options.label} unavailable`);
+  }
+
+  if (!response.ok) {
+    throw new Error(`${options.label} unavailable`);
+  }
+
+  let body: unknown;
+  try {
+    body = await response.json();
+  } catch {
+    throw new Error(`${options.label} unavailable`);
+  }
+
+  const parsed = options.schema.safeParse(body);
+  if (!parsed.success) {
+    throw new Error(`${options.label} unavailable`);
+  }
+  return parsed.data;
+}
+
+function printHelp(): void {
+  console.log(`Usage: pnpm exec tsx scripts/coding-agent-runtime-smoke.ts --origin <url> --token <token> [options]
+
+Options:
+  --runtime <slot>       Runtime slot query value when validating a non-primary runtime.
+  --timeout-ms <ms>      Per-request timeout. Defaults to ${DEFAULT_TIMEOUT_MS}.
+  --create-thread        Also create one smoke thread. Read-only by default.
+  --provider <id>        Provider id for --create-thread. Defaults to first ready provider.
+  --prompt <text>        Prompt for --create-thread.
+  --json                 Print JSON summary.
+
+Environment:
+  MATRIX_CODING_AGENTS_SMOKE_ORIGIN
+  MATRIX_CODING_AGENTS_SMOKE_TOKEN
+  MATRIX_CODING_AGENTS_SMOKE_RUNTIME
+  MATRIX_CODING_AGENTS_SMOKE_TIMEOUT_MS`);
+}
+
+function printReport(report: SmokeReport, json: boolean): void {
+  if (json) {
+    console.log(JSON.stringify(report, null, 2));
+    return;
+  }
+  console.log("Coding-agent runtime smoke passed");
+  console.log(`runtime status: ${report.summary.runtimeStatus}`);
+  console.log(`providers: ${report.summary.readyProviderCount}/${report.summary.providerCount} ready`);
+  console.log(`threads: ${report.summary.activeThreadCount} active, ${report.summary.attentionThreadCount} attention`);
+  console.log(`terminals: ${report.summary.terminalSessionCount}`);
+  console.log(`previews: ${report.summary.previewSessionCount}`);
+  console.log(`reviews: ${report.summary.reviewCount}`);
+  console.log(`thread snapshot checked: ${report.summary.checkedThreadSnapshot ? "yes" : "no"}`);
+  if (report.summary.createdThreadStatus) {
+    console.log(`created thread status: ${report.summary.createdThreadStatus}`);
+  }
+}
+
+async function main(): Promise<void> {
+  const options = parseArgs(process.argv.slice(2));
+  if (options.help) {
+    printHelp();
+    return;
+  }
+  const report = await runCodingAgentRuntimeSmoke(options);
+  printReport(report, Boolean(options.json));
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().catch((err: unknown) => {
+    console.error(err instanceof Error ? err.message : "coding-agent runtime smoke failed");
+    process.exitCode = 1;
+  });
+}

--- a/scripts/coding-agent-runtime-smoke.ts
+++ b/scripts/coding-agent-runtime-smoke.ts
@@ -117,7 +117,7 @@ export async function runCodingAgentRuntimeSmoke(options: SmokeOptions): Promise
     timeoutMs,
   });
 
-  const notificationPreferences = await requestJson({
+  await requestJson({
     label: "notification preferences",
     schema: NotificationPreferencesResponseSchema,
     fetchFn,
@@ -193,7 +193,7 @@ export async function runCodingAgentRuntimeSmoke(options: SmokeOptions): Promise
       terminalSessionCount: summary.terminalSessions.items.length,
       previewSessionCount: summary.previewSessions.items.length,
       reviewCount: reviews.items.length,
-      notificationPreferencesReachable: Boolean(notificationPreferences.preferences),
+      notificationPreferencesReachable: true,
       checkedThreadSnapshot,
       createdThreadStatus,
     },
@@ -258,6 +258,7 @@ async function requestJson<TSchema extends z.ZodType>(options: {
       },
       body: options.body === undefined ? undefined : JSON.stringify(options.body),
       signal: AbortSignal.timeout(options.timeoutMs),
+      redirect: "error",
     });
   } catch {
     throw new Error(`${options.label} unavailable`);

--- a/scripts/coding-agent-runtime-smoke.ts
+++ b/scripts/coding-agent-runtime-smoke.ts
@@ -89,7 +89,7 @@ export function parseArgs(argv: string[], env: NodeJS.ProcessEnv = process.env):
     if (arg === "--") continue;
     if (arg === "--help" || arg === "-h") return { ...(options as SmokeOptions), help: true };
     if (arg === "--origin") options.origin = readValue();
-    else if (arg === "--token") options.token = readValue();
+    else if (arg === "--token") throw new Error("Unknown argument: --token");
     else if (arg === "--runtime") options.runtime = readValue();
     else if (arg === "--timeout-ms") options.timeoutMs = parsePositiveInteger(readValue(), "timeout-ms");
     else if (arg === "--create-thread") options.createThread = true;
@@ -100,7 +100,7 @@ export function parseArgs(argv: string[], env: NodeJS.ProcessEnv = process.env):
   }
 
   if (!options.origin) throw new Error("Missing --origin or MATRIX_CODING_AGENTS_SMOKE_ORIGIN");
-  if (!options.token) throw new Error("Missing --token or MATRIX_CODING_AGENTS_SMOKE_TOKEN");
+  if (!options.token) throw new Error("Missing MATRIX_CODING_AGENTS_SMOKE_TOKEN");
   normalizeOrigin(options.origin);
   return options as SmokeOptions;
 }
@@ -283,7 +283,7 @@ async function requestJson<TSchema extends z.ZodType>(options: {
 }
 
 function printHelp(): void {
-  console.log(`Usage: pnpm exec tsx scripts/coding-agent-runtime-smoke.ts --origin <url> --token <token> [options]
+  console.log(`Usage: MATRIX_CODING_AGENTS_SMOKE_TOKEN=<token> pnpm exec tsx scripts/coding-agent-runtime-smoke.ts --origin <url> [options]
 
 Options:
   --runtime <slot>       Runtime slot query value when validating a non-primary runtime.

--- a/tests/scripts/coding-agent-runtime-smoke.test.ts
+++ b/tests/scripts/coding-agent-runtime-smoke.test.ts
@@ -137,6 +137,14 @@ describe("coding-agent runtime smoke", () => {
     });
   });
 
+  it("requires bearer tokens through the environment instead of CLI args", () => {
+    expect(() => parseArgs(["--origin", "https://app.matrix-os.com", "--token", "secret-token"], {}))
+      .toThrow(/Unknown argument: --token/);
+
+    expect(() => parseArgs(["--origin", "https://app.matrix-os.com"], {}))
+      .toThrow("Missing MATRIX_CODING_AGENTS_SMOKE_TOKEN");
+  });
+
   it("runs read-only smoke by default and validates shared contracts", async () => {
     const fetchFn = vi.fn(async (input: string, init?: RequestInit) => {
       expect(init?.headers).toEqual(expect.objectContaining({ Authorization: "Bearer secret-token" }));

--- a/tests/scripts/coding-agent-runtime-smoke.test.ts
+++ b/tests/scripts/coding-agent-runtime-smoke.test.ts
@@ -1,0 +1,210 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  buildRuntimeUrl,
+  parseArgs,
+  runCodingAgentRuntimeSmoke,
+} from "../../scripts/coding-agent-runtime-smoke";
+
+const NOW = "2026-07-09T00:00:00.000Z";
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+function runtimeSummary(overrides: Record<string, unknown> = {}) {
+  return {
+    runtime: {
+      id: "rt_smoke",
+      label: "Smoke runtime",
+      status: "available",
+    },
+    capabilities: [
+      { id: "codingAgentsRuntimeSummary", enabled: true },
+      { id: "codingAgentsThreadCreate", enabled: true },
+    ],
+    providers: [
+      {
+        id: "codex",
+        displayName: "Codex",
+        kind: "codex",
+        availability: "available",
+        installStatus: "installed",
+        authStatus: "authenticated",
+        supportedModes: ["default"],
+        defaultMode: "default",
+        setupActions: [],
+        lastCheckedAt: NOW,
+      },
+    ],
+    projects: { items: [], hasMore: false, limit: 50 },
+    activeThreads: {
+      items: [
+        {
+          id: "thread_smoke_1",
+          providerId: "codex",
+          title: "Smoke thread",
+          status: "running",
+          attention: "none",
+          terminalSessionId: "matrix-smoke",
+          createdAt: NOW,
+          updatedAt: NOW,
+        },
+      ],
+      hasMore: false,
+      limit: 50,
+    },
+    attentionThreads: { items: [], hasMore: false, limit: 50 },
+    terminalSessions: {
+      items: [
+        {
+          id: "matrix-smoke",
+          name: "Matrix smoke",
+          status: "running",
+          attachable: true,
+          createdAt: NOW,
+          updatedAt: NOW,
+        },
+      ],
+      hasMore: false,
+      limit: 50,
+    },
+    previewSessions: { items: [], hasMore: false, limit: 50 },
+    recentActivity: { items: [], hasMore: false, limit: 100 },
+    limits: {
+      maxPromptBytes: 96 * 1024,
+      maxAttachmentCount: 8,
+      maxTerminalInputBytes: 64 * 1024,
+      maxListItems: 50,
+    },
+    serverTime: NOW,
+    ...overrides,
+  };
+}
+
+function threadSnapshot(threadId = "thread_smoke_1") {
+  return {
+    thread: {
+      id: threadId,
+      providerId: "codex",
+      title: "Smoke thread",
+      status: "completed",
+      attention: "completed",
+      terminalSessionId: "matrix-smoke",
+      createdAt: NOW,
+      updatedAt: NOW,
+    },
+    events: {
+      items: [
+        {
+          type: "thread.completed",
+          eventId: "evt_smoke_completed",
+          threadId,
+          occurredAt: NOW,
+          outcome: "completed",
+        },
+      ],
+      hasMore: false,
+      limit: 200,
+    },
+  };
+}
+
+describe("coding-agent runtime smoke", () => {
+  it("builds runtime URLs without leaking the token into query params", () => {
+    const url = buildRuntimeUrl({
+      origin: "https://app.matrix-os.com/vm/demo",
+      path: "/api/coding-agents/summary",
+      runtime: "secondary",
+    });
+
+    expect(url.toString()).toBe("https://app.matrix-os.com/api/coding-agents/summary?runtime=secondary");
+    expect(url.toString()).not.toContain("secret-token");
+  });
+
+  it("parses args from flags and environment", () => {
+    expect(
+      parseArgs(["--", "--origin", "https://app.matrix-os.com", "--json"], {
+        MATRIX_CODING_AGENTS_SMOKE_TOKEN: "secret-token",
+      }),
+    ).toMatchObject({
+      origin: "https://app.matrix-os.com",
+      token: "secret-token",
+      json: true,
+      createThread: false,
+    });
+  });
+
+  it("runs read-only smoke by default and validates shared contracts", async () => {
+    const fetchFn = vi.fn(async (input: string, init?: RequestInit) => {
+      expect(init?.headers).toEqual(expect.objectContaining({ Authorization: "Bearer secret-token" }));
+      if (input.endsWith("/api/coding-agents/summary")) return jsonResponse(runtimeSummary());
+      if (input.endsWith("/api/coding-agents/notification-preferences")) {
+        return jsonResponse({ preferences: { attentionPush: { approval: true, input: true, failed: true, completed: true } } });
+      }
+      if (input.endsWith("/api/coding-agents/reviews")) {
+        return jsonResponse({ items: [], hasMore: false, limit: 50 });
+      }
+      if (input.endsWith("/api/coding-agents/threads/thread_smoke_1")) return jsonResponse(threadSnapshot());
+      throw new Error(`unexpected request ${input}`);
+    });
+
+    const report = await runCodingAgentRuntimeSmoke({
+      origin: "https://app.matrix-os.com",
+      token: "secret-token",
+      fetchFn,
+      timeoutMs: 1000,
+    });
+
+    expect(report.ok).toBe(true);
+    expect(report.summary.activeThreadCount).toBe(1);
+    expect(report.summary.createdThreadStatus).toBeNull();
+    expect(fetchFn.mock.calls.some(([, init]) => init?.method === "POST")).toBe(false);
+    expect(JSON.stringify(report)).not.toContain("secret-token");
+  });
+
+  it("can create a thread only when explicitly requested", async () => {
+    const fetchFn = vi.fn(async (input: string, init?: RequestInit) => {
+      if (input.endsWith("/api/coding-agents/summary")) return jsonResponse(runtimeSummary({ activeThreads: { items: [], hasMore: false, limit: 50 } }));
+      if (input.endsWith("/api/coding-agents/notification-preferences")) {
+        return jsonResponse({ preferences: { attentionPush: { approval: true, input: true, failed: true, completed: true } } });
+      }
+      if (input.endsWith("/api/coding-agents/reviews")) return jsonResponse({ items: [], hasMore: false, limit: 50 });
+      if (input.endsWith("/api/coding-agents/threads")) {
+        const body = JSON.parse(String(init?.body));
+        expect(body).toMatchObject({
+          providerId: "codex",
+          prompt: "run smoke",
+        });
+        expect(body.clientRequestId).toMatch(/^req_/);
+        return jsonResponse(threadSnapshot("thread_created_smoke"));
+      }
+      throw new Error(`unexpected request ${input}`);
+    });
+
+    const report = await runCodingAgentRuntimeSmoke({
+      origin: "https://app.matrix-os.com",
+      token: "secret-token",
+      createThread: true,
+      prompt: "run smoke",
+      fetchFn,
+      timeoutMs: 1000,
+    });
+
+    expect(report.summary.createdThreadStatus).toBe("completed");
+    expect(fetchFn.mock.calls.some(([, init]) => init?.method === "POST")).toBe(true);
+  });
+
+  it("returns generic failures for invalid runtime payloads", async () => {
+    await expect(
+      runCodingAgentRuntimeSmoke({
+        origin: "https://app.matrix-os.com",
+        token: "secret-token",
+        fetchFn: vi.fn(async () => jsonResponse({ error: "/home/matrix/private" })),
+        timeoutMs: 1000,
+      }),
+    ).rejects.toThrow("runtime summary unavailable");
+  });
+});

--- a/tests/scripts/coding-agent-runtime-smoke.test.ts
+++ b/tests/scripts/coding-agent-runtime-smoke.test.ts
@@ -161,6 +161,7 @@ describe("coding-agent runtime smoke", () => {
     expect(report.ok).toBe(true);
     expect(report.summary.activeThreadCount).toBe(1);
     expect(report.summary.createdThreadStatus).toBeNull();
+    expect(fetchFn.mock.calls.every(([, init]) => init?.redirect === "error")).toBe(true);
     expect(fetchFn.mock.calls.some(([, init]) => init?.method === "POST")).toBe(false);
     expect(JSON.stringify(report)).not.toContain("secret-token");
   });


### PR DESCRIPTION
## Summary
- add a read-only coding-agent runtime smoke command that validates live gateway responses through shared contracts
- allow an explicit `--create-thread` opt-in for one smoke run while keeping the default non-mutating
- document the operator runbook usage and safe reporting expectations

## Tests
- `pnpm exec vitest run tests/scripts/coding-agent-runtime-smoke.test.ts`
- `pnpm run smoke:coding-agents -- --help`
- `bun run check:patterns`
- `bun run typecheck`

## Review/Monitoring
- Greptile review pending on PR head `040f4a8548`
- `ready-for-ci` intentionally not added until Greptile is 5/5

## Invariants
- Source of truth: gateway/runtime contracts remain authoritative; the script only validates live responses through shared schemas.
- Lock/transaction scope: no persistence or database writes are introduced.
- Acceptable orphan states: an interrupted read-only smoke leaves no runtime state; `--create-thread` may leave a normal smoke thread owned by the runtime.
- Auth source of truth: bearer auth is supplied only through `MATRIX_CODING_AGENTS_SMOKE_TOKEN`, sent only to outbound smoke requests, and never printed in reports.
- Deferred scope: this does not replace manual desktop/mobile device smoke; it adds a repeatable preflight for the remaining real-runtime validation gap.