### PR TITLE
test(coding-agents): add runtime smoke assertions

### DIFF
--- a/docs/dev/coding-agent-shells.md
+++ b/docs/dev/coding-agent-shells.md
@@ -319,7 +319,9 @@ Add `--require-thread-snapshot`, `--min-active-threads`,
 `--min-terminal-sessions`, `--min-preview-sessions`, or `--min-reviews` only
 when the manual scenario requires an existing live resource. These assertions
 fail with generic recovery-oriented output; collect detailed runtime evidence
-from server-side logs, not from the shell or CLI report.
+from server-side logs, not from the shell or CLI report. Active-thread,
+terminal-session, and preview-session minimums are capped to the summary page
+size. Review minimums follow review cursors when the gateway includes them.
 
 ## Validation Commands
 

--- a/docs/dev/coding-agent-shells.md
+++ b/docs/dev/coding-agent-shells.md
@@ -282,6 +282,45 @@ Before enabling a mobile coding-agent shell change broadly:
 5. Confirm Chat, Apps, Terminal, and Settings tabs still open.
 6. Keep the existing terminal fallback. Do not land native terminal replacement behavior without separate device validation.
 
+### Live Runtime Smoke Assertions
+
+Use the runtime smoke command before manual desktop or mobile checks when you need
+to prove the selected Matrix computer exposes the gateway-owned coding-agent
+surfaces that the shell will hydrate. The command reads the bearer token only
+from `MATRIX_CODING_AGENTS_SMOKE_TOKEN`; do not pass tokens as CLI arguments or
+paste them into reports.
+
+Read-only desktop preflight:
+
+```bash
+MATRIX_CODING_AGENTS_SMOKE_TOKEN=<token> pnpm run smoke:coding-agents -- \
+  --origin https://app.matrix-os.com \
+  --require-capability codingAgentsRuntimeSummary \
+  --require-capability codingAgentsDesktopWorkspace \
+  --require-capability codingAgentsThreadCreate \
+  --require-capability codingAgentsReview \
+  --require-capability codingAgentsFiles \
+  --require-ready-provider
+```
+
+Read-only mobile SDK 57 preflight:
+
+```bash
+MATRIX_CODING_AGENTS_SMOKE_TOKEN=<token> pnpm run smoke:coding-agents -- \
+  --origin https://app.matrix-os.com \
+  --require-capability codingAgentsRuntimeSummary \
+  --require-capability codingAgentsMobileWorkspace \
+  --require-capability codingAgentsNativeMobileTerminal \
+  --require-capability codingAgentsReview \
+  --require-ready-provider
+```
+
+Add `--require-thread-snapshot`, `--min-active-threads`,
+`--min-terminal-sessions`, `--min-preview-sessions`, or `--min-reviews` only
+when the manual scenario requires an existing live resource. These assertions
+fail with generic recovery-oriented output; collect detailed runtime evidence
+from server-side logs, not from the shell or CLI report.
+
 ## Validation Commands
 
 Run the smallest focused tests for the touched surface, then the shared gates that apply:

--- a/scripts/coding-agent-runtime-smoke.ts
+++ b/scripts/coding-agent-runtime-smoke.ts
@@ -15,7 +15,10 @@ import { z } from "zod/v4";
 
 const DEFAULT_TIMEOUT_MS = 10_000;
 const DEFAULT_PROMPT = "Matrix coding-agent runtime smoke";
+const MAX_SUMMARY_COUNT_ASSERTION = 50;
+const MAX_REVIEW_PAGES = 20;
 const ReviewSummaryListSchema = boundedListSchema(ReviewSummarySchema, 50);
+type ReviewSummaryList = z.infer<typeof ReviewSummaryListSchema>;
 const NotificationPreferencesResponseSchema = z.object({
   preferences: CodingAgentNotificationPreferencesSchema,
 }).strict();
@@ -114,9 +117,9 @@ export function parseArgs(argv: string[], env: NodeJS.ProcessEnv = process.env):
     }
     else if (arg === "--require-ready-provider") options.requireReadyProvider = true;
     else if (arg === "--require-thread-snapshot") options.requireThreadSnapshot = true;
-    else if (arg === "--min-active-threads") options.minActiveThreads = parseMinimumCount(readValue(), "min-active-threads");
-    else if (arg === "--min-terminal-sessions") options.minTerminalSessions = parseMinimumCount(readValue(), "min-terminal-sessions");
-    else if (arg === "--min-preview-sessions") options.minPreviewSessions = parseMinimumCount(readValue(), "min-preview-sessions");
+    else if (arg === "--min-active-threads") options.minActiveThreads = parseSummaryMinimumCount(readValue(), "min-active-threads");
+    else if (arg === "--min-terminal-sessions") options.minTerminalSessions = parseSummaryMinimumCount(readValue(), "min-terminal-sessions");
+    else if (arg === "--min-preview-sessions") options.minPreviewSessions = parseSummaryMinimumCount(readValue(), "min-preview-sessions");
     else if (arg === "--min-reviews") options.minReviews = parseMinimumCount(readValue(), "min-reviews");
     else if (arg === "--json") options.json = true;
     else throw new Error(`Unknown argument: ${arg}`);
@@ -153,11 +156,21 @@ export async function runCodingAgentRuntimeSmoke(options: SmokeOptions): Promise
     timeoutMs,
   });
 
+  const reviewsUrl = buildRuntimeUrl({ origin: options.origin, path: "/api/coding-agents/reviews", runtime: options.runtime });
   const reviews = await requestJson({
     label: "review summaries",
     schema: ReviewSummaryListSchema,
     fetchFn,
-    url: buildRuntimeUrl({ origin: options.origin, path: "/api/coding-agents/reviews", runtime: options.runtime }),
+    url: reviewsUrl,
+    token: options.token,
+    timeoutMs,
+  });
+  const reviewCount = await countReviewsForMinimum({
+    initial: reviews,
+    minReviews: options.minReviews,
+    origin: options.origin,
+    runtime: options.runtime,
+    fetchFn,
     token: options.token,
     timeoutMs,
   });
@@ -179,6 +192,13 @@ export async function runCodingAgentRuntimeSmoke(options: SmokeOptions): Promise
     });
     checkedThreadSnapshot = true;
   }
+
+  const assertionsChecked = evaluateRequirements({
+    summary,
+    reviewCount,
+    checkedThreadSnapshot,
+    request: options,
+  });
 
   let createdThreadStatus: AgentThreadSnapshot["thread"]["status"] | null = null;
   if (options.createThread) {
@@ -204,13 +224,6 @@ export async function runCodingAgentRuntimeSmoke(options: SmokeOptions): Promise
     createdThreadStatus = created.thread.status;
   }
 
-  const assertionsChecked = evaluateRequirements({
-    summary,
-    reviewCount: reviews.items.length,
-    checkedThreadSnapshot,
-    request: options,
-  });
-
   return {
     ok: true,
     summary: {
@@ -222,7 +235,7 @@ export async function runCodingAgentRuntimeSmoke(options: SmokeOptions): Promise
       attentionThreadCount: summary.attentionThreads.items.length,
       terminalSessionCount: summary.terminalSessions.items.length,
       previewSessionCount: summary.previewSessions.items.length,
-      reviewCount: reviews.items.length,
+      reviewCount,
       notificationPreferencesReachable: true,
       checkedThreadSnapshot,
       assertionsChecked,
@@ -256,6 +269,14 @@ function parseMinimumCount(value: string, label: string): number {
   const parsed = Number(value);
   if (!Number.isInteger(parsed) || parsed <= 0 || parsed > 1000) {
     throw new Error(`${label} must be a positive integer up to 1000`);
+  }
+  return parsed;
+}
+
+function parseSummaryMinimumCount(value: string, label: string): number {
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed <= 0 || parsed > MAX_SUMMARY_COUNT_ASSERTION) {
+    throw new Error(`${label} must be a positive integer up to ${MAX_SUMMARY_COUNT_ASSERTION}`);
   }
   return parsed;
 }
@@ -305,6 +326,46 @@ function assertMinimum(actual: number, expected: number | undefined, fail: () =>
   if (expected === undefined) return 0;
   if (actual < expected) fail();
   return 1;
+}
+
+async function countReviewsForMinimum(options: {
+  initial: ReviewSummaryList;
+  minReviews: number | undefined;
+  origin: string;
+  runtime?: string;
+  fetchFn: typeof fetch;
+  token: string;
+  timeoutMs: number;
+}): Promise<number> {
+  let count = options.initial.items.length;
+  let hasMore = options.initial.hasMore;
+  let nextCursor = options.initial.nextCursor;
+  let pagesRead = 1;
+
+  while (
+    options.minReviews !== undefined &&
+    count < options.minReviews &&
+    hasMore &&
+    nextCursor &&
+    pagesRead < MAX_REVIEW_PAGES
+  ) {
+    const url = buildRuntimeUrl({ origin: options.origin, path: "/api/coding-agents/reviews", runtime: options.runtime });
+    url.searchParams.set("cursor", nextCursor);
+    const page = await requestJson({
+      label: "review summaries",
+      schema: ReviewSummaryListSchema,
+      fetchFn: options.fetchFn,
+      url,
+      token: options.token,
+      timeoutMs: options.timeoutMs,
+    });
+    count += page.items.length;
+    hasMore = page.hasMore;
+    nextCursor = page.nextCursor;
+    pagesRead += 1;
+  }
+
+  return count;
 }
 
 function selectProviderId(summary: RuntimeSummary): string {
@@ -378,12 +439,12 @@ Options:
   --require-thread-snapshot
                          Require the smoke to validate at least one existing thread snapshot.
   --min-active-threads <count>
-                         Require at least this many active threads.
+                         Require at least this many active threads from the summary page, max ${MAX_SUMMARY_COUNT_ASSERTION}.
   --min-terminal-sessions <count>
-                         Require at least this many terminal sessions.
+                         Require at least this many terminal sessions from the summary page, max ${MAX_SUMMARY_COUNT_ASSERTION}.
   --min-preview-sessions <count>
-                         Require at least this many preview sessions.
-  --min-reviews <count>  Require at least this many review summaries.
+                         Require at least this many preview sessions from the summary page, max ${MAX_SUMMARY_COUNT_ASSERTION}.
+  --min-reviews <count>  Require at least this many review summaries; follows review cursors when present.
   --json                 Print JSON summary.
 
 Environment:

--- a/scripts/coding-agent-runtime-smoke.ts
+++ b/scripts/coding-agent-runtime-smoke.ts
@@ -114,10 +114,10 @@ export function parseArgs(argv: string[], env: NodeJS.ProcessEnv = process.env):
     }
     else if (arg === "--require-ready-provider") options.requireReadyProvider = true;
     else if (arg === "--require-thread-snapshot") options.requireThreadSnapshot = true;
-    else if (arg === "--min-active-threads") options.minActiveThreads = parseNonNegativeInteger(readValue(), "min-active-threads");
-    else if (arg === "--min-terminal-sessions") options.minTerminalSessions = parseNonNegativeInteger(readValue(), "min-terminal-sessions");
-    else if (arg === "--min-preview-sessions") options.minPreviewSessions = parseNonNegativeInteger(readValue(), "min-preview-sessions");
-    else if (arg === "--min-reviews") options.minReviews = parseNonNegativeInteger(readValue(), "min-reviews");
+    else if (arg === "--min-active-threads") options.minActiveThreads = parseMinimumCount(readValue(), "min-active-threads");
+    else if (arg === "--min-terminal-sessions") options.minTerminalSessions = parseMinimumCount(readValue(), "min-terminal-sessions");
+    else if (arg === "--min-preview-sessions") options.minPreviewSessions = parseMinimumCount(readValue(), "min-preview-sessions");
+    else if (arg === "--min-reviews") options.minReviews = parseMinimumCount(readValue(), "min-reviews");
     else if (arg === "--json") options.json = true;
     else throw new Error(`Unknown argument: ${arg}`);
   }
@@ -252,10 +252,10 @@ function parsePositiveInteger(value: string, label: string): number {
   return parsed;
 }
 
-function parseNonNegativeInteger(value: string, label: string): number {
+function parseMinimumCount(value: string, label: string): number {
   const parsed = Number(value);
-  if (!Number.isInteger(parsed) || parsed < 0 || parsed > 1000) {
-    throw new Error(`${label} must be a non-negative integer up to 1000`);
+  if (!Number.isInteger(parsed) || parsed <= 0 || parsed > 1000) {
+    throw new Error(`${label} must be a positive integer up to 1000`);
   }
   return parsed;
 }

--- a/scripts/coding-agent-runtime-smoke.ts
+++ b/scripts/coding-agent-runtime-smoke.ts
@@ -5,6 +5,7 @@ import {
   CodingAgentNotificationPreferencesSchema,
   CreateAgentThreadRequestSchema,
   ReviewSummarySchema,
+  RuntimeCapabilityIdSchema,
   RuntimeSummarySchema,
   boundedListSchema,
   type AgentThreadSnapshot,
@@ -27,6 +28,13 @@ export interface SmokeOptions {
   createThread?: boolean;
   providerId?: string;
   prompt?: string;
+  requiredCapabilities?: Array<z.infer<typeof RuntimeCapabilityIdSchema>>;
+  requireReadyProvider?: boolean;
+  requireThreadSnapshot?: boolean;
+  minActiveThreads?: number;
+  minTerminalSessions?: number;
+  minPreviewSessions?: number;
+  minReviews?: number;
   json?: boolean;
   fetchFn?: typeof fetch;
 }
@@ -45,6 +53,7 @@ export interface SmokeReport {
     reviewCount: number;
     notificationPreferencesReachable: boolean;
     checkedThreadSnapshot: boolean;
+    assertionsChecked: number;
     createdThreadStatus: AgentThreadSnapshot["thread"]["status"] | null;
   };
 }
@@ -74,6 +83,9 @@ export function parseArgs(argv: string[], env: NodeJS.ProcessEnv = process.env):
       : DEFAULT_TIMEOUT_MS,
     createThread: false,
     prompt: DEFAULT_PROMPT,
+    requiredCapabilities: [],
+    requireReadyProvider: false,
+    requireThreadSnapshot: false,
     json: false,
   };
 
@@ -95,6 +107,17 @@ export function parseArgs(argv: string[], env: NodeJS.ProcessEnv = process.env):
     else if (arg === "--create-thread") options.createThread = true;
     else if (arg === "--provider") options.providerId = readValue();
     else if (arg === "--prompt") options.prompt = readValue();
+    else if (arg === "--require-capability") {
+      const parsed = RuntimeCapabilityIdSchema.safeParse(readValue());
+      if (!parsed.success) throw new Error("Invalid required capability");
+      options.requiredCapabilities = [...(options.requiredCapabilities ?? []), parsed.data];
+    }
+    else if (arg === "--require-ready-provider") options.requireReadyProvider = true;
+    else if (arg === "--require-thread-snapshot") options.requireThreadSnapshot = true;
+    else if (arg === "--min-active-threads") options.minActiveThreads = parseNonNegativeInteger(readValue(), "min-active-threads");
+    else if (arg === "--min-terminal-sessions") options.minTerminalSessions = parseNonNegativeInteger(readValue(), "min-terminal-sessions");
+    else if (arg === "--min-preview-sessions") options.minPreviewSessions = parseNonNegativeInteger(readValue(), "min-preview-sessions");
+    else if (arg === "--min-reviews") options.minReviews = parseNonNegativeInteger(readValue(), "min-reviews");
     else if (arg === "--json") options.json = true;
     else throw new Error(`Unknown argument: ${arg}`);
   }
@@ -181,6 +204,13 @@ export async function runCodingAgentRuntimeSmoke(options: SmokeOptions): Promise
     createdThreadStatus = created.thread.status;
   }
 
+  const assertionsChecked = evaluateRequirements({
+    summary,
+    reviewCount: reviews.items.length,
+    checkedThreadSnapshot,
+    request: options,
+  });
+
   return {
     ok: true,
     summary: {
@@ -195,6 +225,7 @@ export async function runCodingAgentRuntimeSmoke(options: SmokeOptions): Promise
       reviewCount: reviews.items.length,
       notificationPreferencesReachable: true,
       checkedThreadSnapshot,
+      assertionsChecked,
       createdThreadStatus,
     },
   };
@@ -221,10 +252,59 @@ function parsePositiveInteger(value: string, label: string): number {
   return parsed;
 }
 
+function parseNonNegativeInteger(value: string, label: string): number {
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed < 0 || parsed > 1000) {
+    throw new Error(`${label} must be a non-negative integer up to 1000`);
+  }
+  return parsed;
+}
+
 function isReadyProvider(provider: RuntimeSummary["providers"][number]): boolean {
   return provider.availability === "available" &&
     provider.installStatus === "installed" &&
     provider.authStatus === "authenticated";
+}
+
+function evaluateRequirements(options: {
+  summary: RuntimeSummary;
+  reviewCount: number;
+  checkedThreadSnapshot: boolean;
+  request: SmokeOptions;
+}): number {
+  let checked = 0;
+  const fail = () => {
+    throw new Error("coding-agent runtime requirements unavailable");
+  };
+  const capabilities = new Map(options.summary.capabilities.map((capability) => [capability.id, capability.enabled]));
+
+  for (const capabilityId of options.request.requiredCapabilities ?? []) {
+    checked += 1;
+    if (capabilities.get(capabilityId) !== true) fail();
+  }
+
+  if (options.request.requireReadyProvider) {
+    checked += 1;
+    if (!options.summary.providers.some(isReadyProvider)) fail();
+  }
+
+  if (options.request.requireThreadSnapshot) {
+    checked += 1;
+    if (!options.checkedThreadSnapshot) fail();
+  }
+
+  checked += assertMinimum(options.summary.activeThreads.items.length, options.request.minActiveThreads, fail);
+  checked += assertMinimum(options.summary.terminalSessions.items.length, options.request.minTerminalSessions, fail);
+  checked += assertMinimum(options.summary.previewSessions.items.length, options.request.minPreviewSessions, fail);
+  checked += assertMinimum(options.reviewCount, options.request.minReviews, fail);
+
+  return checked;
+}
+
+function assertMinimum(actual: number, expected: number | undefined, fail: () => never): number {
+  if (expected === undefined) return 0;
+  if (actual < expected) fail();
+  return 1;
 }
 
 function selectProviderId(summary: RuntimeSummary): string {
@@ -291,6 +371,19 @@ Options:
   --create-thread        Also create one smoke thread. Read-only by default.
   --provider <id>        Provider id for --create-thread. Defaults to first ready provider.
   --prompt <text>        Prompt for --create-thread.
+  --require-capability <id>
+                         Require a runtime capability to be enabled. Repeatable.
+  --require-ready-provider
+                         Require at least one installed and authenticated provider.
+  --require-thread-snapshot
+                         Require the smoke to validate at least one existing thread snapshot.
+  --min-active-threads <count>
+                         Require at least this many active threads.
+  --min-terminal-sessions <count>
+                         Require at least this many terminal sessions.
+  --min-preview-sessions <count>
+                         Require at least this many preview sessions.
+  --min-reviews <count>  Require at least this many review summaries.
   --json                 Print JSON summary.
 
 Environment:
@@ -313,6 +406,7 @@ function printReport(report: SmokeReport, json: boolean): void {
   console.log(`previews: ${report.summary.previewSessionCount}`);
   console.log(`reviews: ${report.summary.reviewCount}`);
   console.log(`thread snapshot checked: ${report.summary.checkedThreadSnapshot ? "yes" : "no"}`);
+  console.log(`assertions checked: ${report.summary.assertionsChecked}`);
   if (report.summary.createdThreadStatus) {
     console.log(`created thread status: ${report.summary.createdThreadStatus}`);
   }

--- a/tests/scripts/coding-agent-runtime-smoke.test.ts
+++ b/tests/scripts/coding-agent-runtime-smoke.test.ts
@@ -112,6 +112,39 @@ function threadSnapshot(threadId = "thread_smoke_1") {
   };
 }
 
+function reviewSummary() {
+  return {
+    id: "review_smoke",
+    projectId: "project-smoke",
+    worktreeId: "wt_123456789abc",
+    status: "reviewing",
+    pullRequestNumber: 874,
+    round: 1,
+    maxRounds: 3,
+    reviewer: "codex",
+    implementer: "codex",
+    findings: { total: 1, high: 0, medium: 1, low: 0 },
+    updatedAt: NOW,
+  };
+}
+
+function smokeFetch(options: {
+  summary?: Record<string, unknown>;
+  reviews?: unknown[];
+} = {}) {
+  return vi.fn(async (input: string) => {
+    if (input.endsWith("/api/coding-agents/summary")) return jsonResponse(runtimeSummary(options.summary ?? {}));
+    if (input.endsWith("/api/coding-agents/notification-preferences")) {
+      return jsonResponse({ preferences: { attentionPush: { approval: true, input: true, failed: true, completed: true } } });
+    }
+    if (input.endsWith("/api/coding-agents/reviews")) {
+      return jsonResponse({ items: options.reviews ?? [], hasMore: false, limit: 50 });
+    }
+    if (input.endsWith("/api/coding-agents/threads/thread_smoke_1")) return jsonResponse(threadSnapshot());
+    throw new Error(`unexpected request ${input}`);
+  });
+}
+
 describe("coding-agent runtime smoke", () => {
   it("builds runtime URLs without leaking the token into query params", () => {
     const url = buildRuntimeUrl({
@@ -170,11 +203,13 @@ describe("coding-agent runtime smoke", () => {
       }),
     ).toThrow("Invalid required capability");
 
-    expect(() =>
-      parseArgs(["--origin", "https://app.matrix-os.com", "--min-active-threads", "-1"], {
-        MATRIX_CODING_AGENTS_SMOKE_TOKEN: "secret-token",
-      }),
-    ).toThrow("min-active-threads must be a non-negative integer up to 1000");
+    for (const value of ["-1", "0"]) {
+      expect(() =>
+        parseArgs(["--origin", "https://app.matrix-os.com", "--min-active-threads", value], {
+          MATRIX_CODING_AGENTS_SMOKE_TOKEN: "secret-token",
+        }),
+      ).toThrow("min-active-threads must be a positive integer up to 1000");
+    }
   });
 
   it("requires bearer tokens through the environment instead of CLI args", () => {
@@ -243,25 +278,7 @@ describe("coding-agent runtime smoke", () => {
         return jsonResponse({ preferences: { attentionPush: { approval: true, input: true, failed: true, completed: true } } });
       }
       if (input.endsWith("/api/coding-agents/reviews")) {
-        return jsonResponse({
-          items: [
-            {
-              id: "review_smoke",
-              projectId: "project-smoke",
-              worktreeId: "wt_123456789abc",
-              status: "reviewing",
-              pullRequestNumber: 874,
-              round: 1,
-              maxRounds: 3,
-              reviewer: "codex",
-              implementer: "codex",
-              findings: { total: 1, high: 0, medium: 1, low: 0 },
-              updatedAt: NOW,
-            },
-          ],
-          hasMore: false,
-          limit: 50,
-        });
+        return jsonResponse({ items: [reviewSummary()], hasMore: false, limit: 50 });
       }
       if (input.endsWith("/api/coding-agents/threads/thread_smoke_1")) return jsonResponse(threadSnapshot());
       throw new Error(`unexpected request ${input}`);
@@ -284,39 +301,87 @@ describe("coding-agent runtime smoke", () => {
     expect(report.summary.assertionsChecked).toBe(8);
   });
 
-  it("fails with generic messages when requested smoke assertions are unmet", async () => {
-    const fetchFn = vi.fn(async (input: string) => {
-      if (input.endsWith("/api/coding-agents/summary")) {
-        return jsonResponse(runtimeSummary({
-          capabilities: [
-            { id: "codingAgentsRuntimeSummary", enabled: true },
-            { id: "codingAgentsPreview", enabled: false, reason: "Not enabled yet" },
-          ],
-          providers: [],
-          activeThreads: { items: [], hasMore: false, limit: 50 },
-          terminalSessions: { items: [], hasMore: false, limit: 50 },
-        }));
-      }
-      if (input.endsWith("/api/coding-agents/notification-preferences")) {
-        return jsonResponse({ preferences: { attentionPush: { approval: true, input: true, failed: true, completed: true } } });
-      }
-      if (input.endsWith("/api/coding-agents/reviews")) return jsonResponse({ items: [], hasMore: false, limit: 50 });
-      throw new Error(`unexpected request ${input}`);
-    });
-
+  it("fails with generic messages when required capabilities are disabled", async () => {
     await expect(
       runCodingAgentRuntimeSmoke({
         origin: "https://app.matrix-os.com",
         token: "secret-token",
-        fetchFn,
+        fetchFn: smokeFetch({
+          summary: {
+            capabilities: [
+              { id: "codingAgentsRuntimeSummary", enabled: true },
+              { id: "codingAgentsPreview", enabled: false, reason: "Not enabled yet" },
+            ],
+          },
+        }),
         timeoutMs: 1000,
         requiredCapabilities: ["codingAgentsPreview"],
+      }),
+    ).rejects.toThrow("coding-agent runtime requirements unavailable");
+  });
+
+  it("fails with generic messages when a ready provider is required but unavailable", async () => {
+    await expect(
+      runCodingAgentRuntimeSmoke({
+        origin: "https://app.matrix-os.com",
+        token: "secret-token",
+        fetchFn: smokeFetch({ summary: { providers: [] } }),
+        timeoutMs: 1000,
         requireReadyProvider: true,
+      }),
+    ).rejects.toThrow("coding-agent runtime requirements unavailable");
+  });
+
+  it("fails with generic messages when an existing thread snapshot is required but unavailable", async () => {
+    await expect(
+      runCodingAgentRuntimeSmoke({
+        origin: "https://app.matrix-os.com",
+        token: "secret-token",
+        fetchFn: smokeFetch({
+          summary: {
+            activeThreads: { items: [], hasMore: false, limit: 50 },
+            attentionThreads: { items: [], hasMore: false, limit: 50 },
+          },
+        }),
+        timeoutMs: 1000,
         requireThreadSnapshot: true,
-        minActiveThreads: 1,
-        minTerminalSessions: 1,
-        minPreviewSessions: 1,
-        minReviews: 1,
+      }),
+    ).rejects.toThrow("coding-agent runtime requirements unavailable");
+  });
+
+  it.each([
+    [
+      "active threads",
+      { activeThreads: { items: [], hasMore: false, limit: 50 } },
+      { minActiveThreads: 1 },
+      [],
+    ],
+    [
+      "terminal sessions",
+      { terminalSessions: { items: [], hasMore: false, limit: 50 } },
+      { minTerminalSessions: 1 },
+      [],
+    ],
+    [
+      "preview sessions",
+      { previewSessions: { items: [], hasMore: false, limit: 50 } },
+      { minPreviewSessions: 1 },
+      [],
+    ],
+    [
+      "reviews",
+      {},
+      { minReviews: 1 },
+      [],
+    ],
+  ])("fails with generic messages when minimum %s are unmet", async (_label, summary, minimums, reviews) => {
+    await expect(
+      runCodingAgentRuntimeSmoke({
+        origin: "https://app.matrix-os.com",
+        token: "secret-token",
+        fetchFn: smokeFetch({ summary, reviews }),
+        timeoutMs: 1000,
+        ...minimums,
       }),
     ).rejects.toThrow("coding-agent runtime requirements unavailable");
   });

--- a/tests/scripts/coding-agent-runtime-smoke.test.ts
+++ b/tests/scripts/coding-agent-runtime-smoke.test.ts
@@ -126,7 +126,26 @@ describe("coding-agent runtime smoke", () => {
 
   it("parses args from flags and environment", () => {
     expect(
-      parseArgs(["--", "--origin", "https://app.matrix-os.com", "--json"], {
+      parseArgs([
+        "--",
+        "--origin",
+        "https://app.matrix-os.com",
+        "--json",
+        "--require-capability",
+        "codingAgentsPreview",
+        "--require-capability",
+        "codingAgentsFiles",
+        "--require-ready-provider",
+        "--require-thread-snapshot",
+        "--min-active-threads",
+        "1",
+        "--min-terminal-sessions",
+        "1",
+        "--min-preview-sessions",
+        "1",
+        "--min-reviews",
+        "1",
+      ], {
         MATRIX_CODING_AGENTS_SMOKE_TOKEN: "secret-token",
       }),
     ).toMatchObject({
@@ -134,7 +153,28 @@ describe("coding-agent runtime smoke", () => {
       token: "secret-token",
       json: true,
       createThread: false,
+      requiredCapabilities: ["codingAgentsPreview", "codingAgentsFiles"],
+      requireReadyProvider: true,
+      requireThreadSnapshot: true,
+      minActiveThreads: 1,
+      minTerminalSessions: 1,
+      minPreviewSessions: 1,
+      minReviews: 1,
     });
+  });
+
+  it("rejects unsafe assertion arguments before making requests", () => {
+    expect(() =>
+      parseArgs(["--origin", "https://app.matrix-os.com", "--require-capability", "codingAgentsSecrets"], {
+        MATRIX_CODING_AGENTS_SMOKE_TOKEN: "secret-token",
+      }),
+    ).toThrow("Invalid required capability");
+
+    expect(() =>
+      parseArgs(["--origin", "https://app.matrix-os.com", "--min-active-threads", "-1"], {
+        MATRIX_CODING_AGENTS_SMOKE_TOKEN: "secret-token",
+      }),
+    ).toThrow("min-active-threads must be a non-negative integer up to 1000");
   });
 
   it("requires bearer tokens through the environment instead of CLI args", () => {
@@ -169,9 +209,116 @@ describe("coding-agent runtime smoke", () => {
     expect(report.ok).toBe(true);
     expect(report.summary.activeThreadCount).toBe(1);
     expect(report.summary.createdThreadStatus).toBeNull();
+    expect(report.summary.assertionsChecked).toBe(0);
     expect(fetchFn.mock.calls.every(([, init]) => init?.redirect === "error")).toBe(true);
     expect(fetchFn.mock.calls.some(([, init]) => init?.method === "POST")).toBe(false);
     expect(JSON.stringify(report)).not.toContain("secret-token");
+  });
+
+  it("checks requested capability and count assertions against the live summary", async () => {
+    const fetchFn = vi.fn(async (input: string) => {
+      if (input.endsWith("/api/coding-agents/summary")) {
+        return jsonResponse(runtimeSummary({
+          capabilities: [
+            { id: "codingAgentsRuntimeSummary", enabled: true },
+            { id: "codingAgentsPreview", enabled: true },
+            { id: "codingAgentsFiles", enabled: true },
+          ],
+          previewSessions: {
+            items: [
+              {
+                id: "preview_smoke",
+                label: "Smoke preview",
+                status: "running",
+                origin: "https://preview.example.com",
+                updatedAt: NOW,
+              },
+            ],
+            hasMore: false,
+            limit: 50,
+          },
+        }));
+      }
+      if (input.endsWith("/api/coding-agents/notification-preferences")) {
+        return jsonResponse({ preferences: { attentionPush: { approval: true, input: true, failed: true, completed: true } } });
+      }
+      if (input.endsWith("/api/coding-agents/reviews")) {
+        return jsonResponse({
+          items: [
+            {
+              id: "review_smoke",
+              projectId: "project-smoke",
+              worktreeId: "wt_123456789abc",
+              status: "reviewing",
+              pullRequestNumber: 874,
+              round: 1,
+              maxRounds: 3,
+              reviewer: "codex",
+              implementer: "codex",
+              findings: { total: 1, high: 0, medium: 1, low: 0 },
+              updatedAt: NOW,
+            },
+          ],
+          hasMore: false,
+          limit: 50,
+        });
+      }
+      if (input.endsWith("/api/coding-agents/threads/thread_smoke_1")) return jsonResponse(threadSnapshot());
+      throw new Error(`unexpected request ${input}`);
+    });
+
+    const report = await runCodingAgentRuntimeSmoke({
+      origin: "https://app.matrix-os.com",
+      token: "secret-token",
+      fetchFn,
+      timeoutMs: 1000,
+      requiredCapabilities: ["codingAgentsPreview", "codingAgentsFiles"],
+      requireReadyProvider: true,
+      requireThreadSnapshot: true,
+      minActiveThreads: 1,
+      minTerminalSessions: 1,
+      minPreviewSessions: 1,
+      minReviews: 1,
+    });
+
+    expect(report.summary.assertionsChecked).toBe(8);
+  });
+
+  it("fails with generic messages when requested smoke assertions are unmet", async () => {
+    const fetchFn = vi.fn(async (input: string) => {
+      if (input.endsWith("/api/coding-agents/summary")) {
+        return jsonResponse(runtimeSummary({
+          capabilities: [
+            { id: "codingAgentsRuntimeSummary", enabled: true },
+            { id: "codingAgentsPreview", enabled: false, reason: "Not enabled yet" },
+          ],
+          providers: [],
+          activeThreads: { items: [], hasMore: false, limit: 50 },
+          terminalSessions: { items: [], hasMore: false, limit: 50 },
+        }));
+      }
+      if (input.endsWith("/api/coding-agents/notification-preferences")) {
+        return jsonResponse({ preferences: { attentionPush: { approval: true, input: true, failed: true, completed: true } } });
+      }
+      if (input.endsWith("/api/coding-agents/reviews")) return jsonResponse({ items: [], hasMore: false, limit: 50 });
+      throw new Error(`unexpected request ${input}`);
+    });
+
+    await expect(
+      runCodingAgentRuntimeSmoke({
+        origin: "https://app.matrix-os.com",
+        token: "secret-token",
+        fetchFn,
+        timeoutMs: 1000,
+        requiredCapabilities: ["codingAgentsPreview"],
+        requireReadyProvider: true,
+        requireThreadSnapshot: true,
+        minActiveThreads: 1,
+        minTerminalSessions: 1,
+        minPreviewSessions: 1,
+        minReviews: 1,
+      }),
+    ).rejects.toThrow("coding-agent runtime requirements unavailable");
   });
 
   it("can create a thread only when explicitly requested", async () => {

--- a/tests/scripts/coding-agent-runtime-smoke.test.ts
+++ b/tests/scripts/coding-agent-runtime-smoke.test.ts
@@ -112,9 +112,9 @@ function threadSnapshot(threadId = "thread_smoke_1") {
   };
 }
 
-function reviewSummary() {
+function reviewSummary(id = "review_smoke") {
   return {
-    id: "review_smoke",
+    id,
     projectId: "project-smoke",
     worktreeId: "wt_123456789abc",
     status: "reviewing",
@@ -208,8 +208,14 @@ describe("coding-agent runtime smoke", () => {
         parseArgs(["--origin", "https://app.matrix-os.com", "--min-active-threads", value], {
           MATRIX_CODING_AGENTS_SMOKE_TOKEN: "secret-token",
         }),
-      ).toThrow("min-active-threads must be a positive integer up to 1000");
+      ).toThrow("min-active-threads must be a positive integer up to 50");
     }
+
+    expect(() =>
+      parseArgs(["--origin", "https://app.matrix-os.com", "--min-active-threads", "51"], {
+        MATRIX_CODING_AGENTS_SMOKE_TOKEN: "secret-token",
+      }),
+    ).toThrow("min-active-threads must be a positive integer up to 50");
   });
 
   it("requires bearer tokens through the environment instead of CLI args", () => {
@@ -301,6 +307,38 @@ describe("coding-agent runtime smoke", () => {
     expect(report.summary.assertionsChecked).toBe(8);
   });
 
+  it("paginates review summaries until the requested minimum is verified", async () => {
+    const firstPage = Array.from({ length: 50 }, (_, index) => reviewSummary(`review_smoke_${index}`));
+    const secondPage = [reviewSummary("review_smoke_50")];
+    const fetchFn = vi.fn(async (input: string) => {
+      const url = new URL(input);
+      if (url.pathname === "/api/coding-agents/summary") return jsonResponse(runtimeSummary());
+      if (url.pathname === "/api/coding-agents/notification-preferences") {
+        return jsonResponse({ preferences: { attentionPush: { approval: true, input: true, failed: true, completed: true } } });
+      }
+      if (url.pathname === "/api/coding-agents/reviews" && url.searchParams.get("cursor") === "review_cursor_2") {
+        return jsonResponse({ items: secondPage, hasMore: false, limit: 50 });
+      }
+      if (url.pathname === "/api/coding-agents/reviews") {
+        return jsonResponse({ items: firstPage, hasMore: true, nextCursor: "review_cursor_2", limit: 50 });
+      }
+      if (url.pathname === "/api/coding-agents/threads/thread_smoke_1") return jsonResponse(threadSnapshot());
+      throw new Error(`unexpected request ${input}`);
+    });
+
+    const report = await runCodingAgentRuntimeSmoke({
+      origin: "https://app.matrix-os.com",
+      token: "secret-token",
+      fetchFn,
+      timeoutMs: 1000,
+      minReviews: 51,
+    });
+
+    expect(report.summary.reviewCount).toBe(51);
+    expect(report.summary.assertionsChecked).toBe(1);
+    expect(fetchFn.mock.calls.some(([input]) => String(input).endsWith("/api/coding-agents/reviews?cursor=review_cursor_2"))).toBe(true);
+  });
+
   it("fails with generic messages when required capabilities are disabled", async () => {
     await expect(
       runCodingAgentRuntimeSmoke({
@@ -318,6 +356,39 @@ describe("coding-agent runtime smoke", () => {
         requiredCapabilities: ["codingAgentsPreview"],
       }),
     ).rejects.toThrow("coding-agent runtime requirements unavailable");
+  });
+
+  it("checks assertions before creating a smoke thread", async () => {
+    const fetchFn = vi.fn(async (input: string, init?: RequestInit) => {
+      if (input.endsWith("/api/coding-agents/summary")) {
+        return jsonResponse(runtimeSummary({
+          capabilities: [
+            { id: "codingAgentsRuntimeSummary", enabled: true },
+            { id: "codingAgentsPreview", enabled: false, reason: "Not enabled yet" },
+          ],
+        }));
+      }
+      if (input.endsWith("/api/coding-agents/notification-preferences")) {
+        return jsonResponse({ preferences: { attentionPush: { approval: true, input: true, failed: true, completed: true } } });
+      }
+      if (input.endsWith("/api/coding-agents/reviews")) return jsonResponse({ items: [], hasMore: false, limit: 50 });
+      if (input.endsWith("/api/coding-agents/threads/thread_smoke_1")) return jsonResponse(threadSnapshot());
+      if (input.endsWith("/api/coding-agents/threads")) return jsonResponse(threadSnapshot("thread_created_smoke"));
+      throw new Error(`unexpected request ${input}`);
+    });
+
+    await expect(
+      runCodingAgentRuntimeSmoke({
+        origin: "https://app.matrix-os.com",
+        token: "secret-token",
+        fetchFn,
+        timeoutMs: 1000,
+        createThread: true,
+        requiredCapabilities: ["codingAgentsPreview"],
+      }),
+    ).rejects.toThrow("coding-agent runtime requirements unavailable");
+
+    expect(fetchFn.mock.calls.some(([, init]) => init?.method === "POST")).toBe(false);
   });
 
   it("fails with generic messages when a ready provider is required but unavailable", async () => {


### PR DESCRIPTION
## Summary
- add repeatable runtime smoke assertions for required coding-agent capabilities, ready providers, existing thread snapshots, and minimum live resource counts
- evaluate runtime assertions before the explicit `--create-thread` mutation so failed preflights do not create smoke threads
- page review-summary counts through gateway cursors when `--min-reviews` needs more than the first page, while keeping summary-list minimums capped to the summary page
- keep assertion failures generic while preserving the existing read-only default and env-only bearer token handling
- document desktop and mobile SDK 57 preflight examples for real-runtime smoke validation

## Tests
- `pnpm exec vitest run tests/scripts/coding-agent-runtime-smoke.test.ts`
- `pnpm run smoke:coding-agents -- --help`
- `bun run check:patterns`
- `bun run typecheck`
- `git diff --check`

## Review/Monitoring
- Stacked on #874 (`105-coding-agent-runtime-smoke`); do not merge before #874.
- Latest pushed head: `1dc4a29dbdd2f8e7d30e98a9111cdee375108a83`.
- Greptile confidence 5/5 on the latest head.
- `ready-for-ci` added after Greptile reached 5/5.
- Label-triggered checks on the stacked base ran PR Title and Preview VPS/Platform; broad CI did not fan out because the PR base is `105-coding-agent-runtime-smoke`, not `main`.

## Invariants
- Source of truth: gateway/runtime responses remain the only source of coding-agent state; this script only validates live summaries and snapshots.
- Lock/transaction scope: none; no persistence or mutations are added unless the existing explicit `--create-thread` path is used.
- Acceptable orphan states: failed smoke assertions leave no runtime state in the default read-only path, and now also run before the explicit smoke-thread mutation.
- Auth source of truth: bearer token stays in `MATRIX_CODING_AGENTS_SMOKE_TOKEN`; no token CLI args or query params are introduced.
- Deferred scope: manual desktop and real-device mobile smoke still require an operator to run the validated preflight and then exercise the shell UI.
