### PR TITLE
chore(cli): prepare 0.3.10 release

### DIFF
--- a/docs/dev/cli-release.md
+++ b/docs/dev/cli-release.md
@@ -4,7 +4,7 @@ The installable Matrix CLI is the `@finnaai/matrix` package in `packages/sync-cl
 
 ## Current Prepared Release
 
-`0.3.9` is the prepared CLI patch release after `0.3.8`, including terminal image paste upload fixes while preserving Node 20+ package-runner support and standalone CLI binaries for no-Node installs.
+`0.3.10` is the prepared CLI patch release after `0.3.9`, including attached terminal rich image paste fixes while preserving Node 20+ package-runner support and standalone CLI binaries for no-Node installs.
 
 ## Versioning
 
@@ -34,7 +34,7 @@ git tag -l 'cli-v*'
 
 ## Release
 
-Use the manual GitHub Actions workflow named `CLI Release` with `version=0.3.9` and `update_homebrew=true`. This follows the existing `cli-v0.3.9` workflow/tag release path after the PR merges. The workflow:
+Use the manual GitHub Actions workflow named `CLI Release` with `version=0.3.10` and `update_homebrew=true`. This follows the existing `cli-v0.3.10` workflow/tag release path after the PR merges. The workflow:
 
 1. Validates the requested semver, local package version, npm availability, and `cli-v<version>` tag availability.
 2. Installs the workspace and runs the sync-client build, tests, and publish-shape check.
@@ -51,7 +51,7 @@ npm view @finnaai/matrix dist.tarball
 npx --yes @finnaai/matrix --version
 pnpm dlx @finnaai/matrix --version
 brew update && brew info finnaai/tap/matrix
-MATRIX_VERSION=0.3.9 sh scripts/install.sh
+MATRIX_VERSION=0.3.10 sh scripts/install.sh
 matrix --version
 matrix login --help
 matrix run --help
@@ -69,17 +69,17 @@ matrix forward 5173
 
 For standalone binaries, also verify the GitHub release contains:
 
-- `matrix-0.3.9-linux-x64`
-- `matrix-0.3.9-linux-arm64`
-- `matrix-0.3.9-darwin-x64`
-- `matrix-0.3.9-darwin-arm64`
+- `matrix-0.3.10-linux-x64`
+- `matrix-0.3.10-linux-arm64`
+- `matrix-0.3.10-darwin-x64`
+- `matrix-0.3.10-darwin-arm64`
 
-For macOS app packaging, also verify the GitHub release contains `MatrixSync-0.3.9.pkg` when the macOS job was enabled.
+For macOS app packaging, also verify the GitHub release contains `MatrixSync-0.3.10.pkg` when the macOS job was enabled.
 
 ## Rollback
 
-npm package versions are immutable. If a bad CLI release is published, ship a patch release such as `0.3.10` and update Homebrew through the release workflow. Only deprecate the bad npm version when the replacement is available:
+npm package versions are immutable. If a bad CLI release is published, ship a patch release such as `0.3.11` and update Homebrew through the release workflow. Only deprecate the bad npm version when the replacement is available:
 
 ```bash
-npm deprecate @finnaai/matrix@0.3.9 "Use @finnaai/matrix@0.3.10"
+npm deprecate @finnaai/matrix@0.3.10 "Use @finnaai/matrix@0.3.11"
 ```

--- a/packages/sync-client/package.json
+++ b/packages/sync-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@finnaai/matrix",
-  "version": "0.3.9",
+  "version": "0.3.10",
   "description": "Matrix OS command-line client — login, sync, and peer management for matrix-os.com",
   "type": "module",
   "license": "AGPL-3.0-or-later",


### PR DESCRIPTION
Summary
- Bump @finnaai/matrix from 0.3.9 to 0.3.10 for the next installable CLI release.
- Update the CLI release process doc and verification examples to reference 0.3.10.

Tests
- node -p "require('./packages/sync-client/package.json').version"
- git diff --check
- Attempted focused pnpm CLI preflight locally; stopped because the fresh worktree needed registry access under the sandbox. The CLI Release workflow will run build, test, publish-shape, and package-runner checks on a clean GitHub runner.

Review/Monitoring
- 0.3.10 is currently unpublished on npm and no cli-v0.3.10 GitHub release exists.
- After this PR lands on main, dispatch the CLI Release workflow with version=0.3.10, update_homebrew=true, allow_existing_npm=false.

Invariants
- Source of truth: packages/sync-client/package.json version must match the CLI Release workflow input.
- Version uniqueness: npm package versions and cli-v* release tags are immutable and must not be reused.
- Release boundary: this only prepares the installable CLI; host-bundle/VPS release remains separate.