### PR TITLE
fix(mobile): persist agent workspace references

### DIFF
--- a/apps/mobile/__tests__/agent-workspace-state.test.ts
+++ b/apps/mobile/__tests__/agent-workspace-state.test.ts
@@ -1,11 +1,22 @@
+jest.mock("@react-native-async-storage/async-storage", () => ({
+  getItem: jest.fn(),
+  setItem: jest.fn(),
+}));
+
 import {
+  AGENT_WORKSPACE_STATE_STORAGE_KEY,
+  loadAgentWorkspaceState,
   parseAgentWorkspaceState,
   reconcileAgentWorkspaceState,
+  saveAgentWorkspaceState,
 } from "../lib/agent-workspace-state";
 
 const summary = {
   activeThreads: {
     items: [{ id: "thread_keep" }],
+  },
+  attentionThreads: {
+    items: [{ id: "thread_attention" }],
   },
   terminalSessions: {
     items: [{ id: "matrix-abc1234" }],
@@ -49,5 +60,53 @@ describe("agent workspace state", () => {
       selectedTerminalSessionId: null,
       updatedAt: "2026-07-06T00:00:00.000Z",
     });
+  });
+
+  it("keeps selected attention thread references from the runtime summary", () => {
+    const state = parseAgentWorkspaceState({
+      selectedThreadId: "thread_attention",
+      selectedTerminalSessionId: "matrix-abc1234",
+      updatedAt: "2026-07-06T00:00:00.000Z",
+    });
+
+    expect(reconcileAgentWorkspaceState(state, summary)).toEqual({
+      selectedThreadId: "thread_attention",
+      selectedTerminalSessionId: "matrix-abc1234",
+      updatedAt: "2026-07-06T00:00:00.000Z",
+    });
+  });
+
+  it("loads and saves only sanitized safe references", async () => {
+    const storage = {
+      getItem: jest.fn().mockResolvedValue(JSON.stringify({
+        selectedThreadId: "thread_keep",
+        selectedTerminalSessionId: "matrix-abc1234",
+        updatedAt: "2026-07-06T00:00:00.000Z",
+        transcript: "do not store me",
+        fileContents: "/home/matrix/private",
+      })),
+      setItem: jest.fn().mockResolvedValue(undefined),
+    };
+
+    await expect(loadAgentWorkspaceState(storage)).resolves.toEqual({
+      selectedThreadId: "thread_keep",
+      selectedTerminalSessionId: "matrix-abc1234",
+      updatedAt: "2026-07-06T00:00:00.000Z",
+    });
+
+    await saveAgentWorkspaceState({
+      selectedThreadId: "thread_keep",
+      selectedTerminalSessionId: "../bad",
+      updatedAt: "2026-07-06T00:00:00.000Z",
+    }, storage);
+
+    expect(storage.setItem).toHaveBeenCalledWith(
+      AGENT_WORKSPACE_STATE_STORAGE_KEY,
+      JSON.stringify({
+        selectedThreadId: "thread_keep",
+        selectedTerminalSessionId: null,
+        updatedAt: "2026-07-06T00:00:00.000Z",
+      }),
+    );
   });
 });

--- a/apps/mobile/__tests__/agents-screen.test.tsx
+++ b/apps/mobile/__tests__/agents-screen.test.tsx
@@ -27,6 +27,7 @@ import AsyncStorage from "@react-native-async-storage/async-storage";
 import { Linking } from "react-native";
 import AgentsScreen from "../app/agents";
 import { useGateway } from "@/app/_layout";
+import { AGENT_WORKSPACE_STATE_STORAGE_KEY } from "../lib/agent-workspace-state";
 import { MOBILE_SHELL_STATE_STORAGE_KEY } from "../lib/mobile-shell-state";
 import type { GatewayClient } from "../lib/gateway-client";
 
@@ -704,6 +705,144 @@ describe("AgentsScreen", () => {
     expect(mockRouterPush).toHaveBeenCalledWith("/agents/thread_mobile");
   });
 
+  it("persists only the bounded selected thread reference before opening thread details", async () => {
+    const client = {
+      getCodingAgentRuntimeSummary: jest.fn().mockResolvedValue({
+        ok: true,
+        summary: summaryFixture(),
+      }),
+      getCodingAgentReviews: jest.fn().mockResolvedValue({
+        ok: true,
+        reviews: reviewsFixture(),
+      }),
+    };
+    useGatewayMock.mockReturnValue(gatewayContext({
+      client: client as unknown as GatewayClient,
+      connectionState: "connected",
+    }));
+
+    render(<AgentsScreen />);
+
+    await screen.findAllByText("Repair mobile route");
+    await act(async () => {
+      fireEvent.press(screen.getByLabelText("Open thread Repair mobile route"));
+    });
+
+    expect(AsyncStorage.setItem).toHaveBeenCalledWith(
+      AGENT_WORKSPACE_STATE_STORAGE_KEY,
+      expect.stringContaining("\"selectedThreadId\":\"thread_mobile\""),
+    );
+    expect(AsyncStorage.setItem).toHaveBeenCalledWith(
+      AGENT_WORKSPACE_STATE_STORAGE_KEY,
+      expect.not.stringMatching(/transcript|terminalOutput|fileContents|approvalPayload|secret|\/home\/matrix/i),
+    );
+    expect(mockRouterPush).toHaveBeenCalledWith("/agents/thread_mobile");
+  });
+
+  it("keeps user thread selections when background workspace reconcile finishes later", async () => {
+    const reconcileLoad = deferred<string | null>();
+    let agentWorkspaceReads = 0;
+    jest.mocked(AsyncStorage.getItem).mockImplementation(async (key: string) => {
+      if (key !== AGENT_WORKSPACE_STATE_STORAGE_KEY) return null;
+      agentWorkspaceReads += 1;
+      if (agentWorkspaceReads === 1) {
+        return reconcileLoad.promise;
+      }
+      return JSON.stringify({
+        selectedThreadId: null,
+        selectedTerminalSessionId: null,
+        updatedAt: "2026-07-06T00:00:00.000Z",
+      });
+    });
+    const client = {
+      getCodingAgentRuntimeSummary: jest.fn().mockResolvedValue({
+        ok: true,
+        summary: summaryFixture(),
+      }),
+      getCodingAgentReviews: jest.fn().mockResolvedValue({
+        ok: true,
+        reviews: reviewsFixture(),
+      }),
+    };
+    useGatewayMock.mockReturnValue(gatewayContext({
+      client: client as unknown as GatewayClient,
+      connectionState: "connected",
+    }));
+
+    render(<AgentsScreen />);
+
+    await screen.findAllByText("Repair mobile route");
+    await act(async () => {
+      fireEvent.press(screen.getByLabelText("Open thread Repair mobile route"));
+    });
+
+    expect(AsyncStorage.setItem).toHaveBeenCalledWith(
+      AGENT_WORKSPACE_STATE_STORAGE_KEY,
+      expect.stringContaining("\"selectedThreadId\":\"thread_mobile\""),
+    );
+
+    await act(async () => {
+      reconcileLoad.resolve(JSON.stringify({
+        selectedThreadId: "thread_missing",
+        selectedTerminalSessionId: null,
+        updatedAt: "2026-07-06T00:00:00.000Z",
+      }));
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    const agentWorkspaceWrites = jest.mocked(AsyncStorage.setItem).mock.calls
+      .filter(([key]) => key === AGENT_WORKSPACE_STATE_STORAGE_KEY);
+    const lastAgentWorkspaceWrite = agentWorkspaceWrites[agentWorkspaceWrites.length - 1]?.[1];
+    expect(lastAgentWorkspaceWrite).toEqual(
+      expect.stringContaining("\"selectedThreadId\":\"thread_mobile\""),
+    );
+    expect(mockRouterPush).toHaveBeenCalledWith("/agents/thread_mobile");
+  });
+
+  it("reconciles stale persisted agent workspace refs from the runtime summary", async () => {
+    jest.mocked(AsyncStorage.getItem).mockImplementation(async (key: string) => {
+      if (key === AGENT_WORKSPACE_STATE_STORAGE_KEY) {
+        return JSON.stringify({
+          selectedThreadId: "thread_missing",
+          selectedTerminalSessionId: "matrix-missing",
+          updatedAt: "2026-07-06T00:00:00.000Z",
+          transcript: "do not keep",
+        });
+      }
+      return null;
+    });
+    const client = {
+      getCodingAgentRuntimeSummary: jest.fn().mockResolvedValue({
+        ok: true,
+        summary: summaryFixture(),
+      }),
+      getCodingAgentReviews: jest.fn().mockResolvedValue({
+        ok: true,
+        reviews: reviewsFixture(),
+      }),
+    };
+    useGatewayMock.mockReturnValue(gatewayContext({
+      client: client as unknown as GatewayClient,
+      connectionState: "connected",
+    }));
+
+    render(<AgentsScreen />);
+
+    await screen.findByText("Codex");
+
+    await waitFor(() => {
+      expect(AsyncStorage.setItem).toHaveBeenCalledWith(
+        AGENT_WORKSPACE_STATE_STORAGE_KEY,
+        JSON.stringify({
+          selectedThreadId: null,
+          selectedTerminalSessionId: null,
+          updatedAt: "2026-07-06T00:00:00.000Z",
+        }),
+      );
+    });
+  });
+
   it("renders reachable in-app attention badges for active coding-agent threads", async () => {
     const client = {
       getCodingAgentRuntimeSummary: jest.fn().mockResolvedValue({
@@ -796,6 +935,10 @@ describe("AgentsScreen", () => {
       fireEvent.press(screen.getByLabelText("Open recent terminal matrix-newer"));
     });
     expect(AsyncStorage.setItem).toHaveBeenCalledWith(
+      AGENT_WORKSPACE_STATE_STORAGE_KEY,
+      expect.stringContaining("\"selectedTerminalSessionId\":\"matrix-newer\""),
+    );
+    expect(AsyncStorage.setItem).toHaveBeenCalledWith(
       MOBILE_SHELL_STATE_STORAGE_KEY,
       expect.stringContaining("\"lastActiveTerminalSessionId\":\"matrix-newer\""),
     );
@@ -879,6 +1022,42 @@ describe("AgentsScreen", () => {
       expect.stringContaining("\"terminalHandoffSessionId\":\"matrix-abc1234\""),
     );
     expect(mockRouterPush).toHaveBeenCalledWith("/terminal");
+  });
+
+  it("does not persist terminal workspace refs when terminal handoff save fails", async () => {
+    jest.mocked(AsyncStorage.setItem).mockImplementation(async (key: string) => {
+      if (key === MOBILE_SHELL_STATE_STORAGE_KEY) {
+        throw new Error("storage unavailable");
+      }
+    });
+    const client = {
+      getCodingAgentRuntimeSummary: jest.fn().mockResolvedValue({
+        ok: true,
+        summary: summaryFixture(),
+      }),
+      getCodingAgentReviews: jest.fn().mockResolvedValue({
+        ok: true,
+        reviews: reviewsFixture(),
+      }),
+    };
+    useGatewayMock.mockReturnValue(gatewayContext({
+      client: client as unknown as GatewayClient,
+      connectionState: "connected",
+    }));
+
+    render(<AgentsScreen />);
+
+    await screen.findByText("Terminals");
+    await act(async () => {
+      fireEvent.press(screen.getByLabelText("Open terminal session matrix-abc1234"));
+    });
+
+    expect(AsyncStorage.setItem).not.toHaveBeenCalledWith(
+      AGENT_WORKSPACE_STATE_STORAGE_KEY,
+      expect.stringContaining("\"selectedTerminalSessionId\":\"matrix-abc1234\""),
+    );
+    expect(mockRouterPush).not.toHaveBeenCalledWith("/terminal");
+    expect(await screen.findByText("Terminal session unavailable. Try again.")).toBeTruthy();
   });
 
   it("keeps non-running attachable terminal summary rows disabled", async () => {

--- a/apps/mobile/app/agents/index.tsx
+++ b/apps/mobile/app/agents/index.tsx
@@ -6,6 +6,12 @@ import { StyleSheet, useUnistyles } from "react-native-unistyles";
 import { ReviewIdSchema, type CodingAgentNotificationPreferences, type CodingAgentNotificationPreferencesUpdate, type FileBrowseResponse, type FileReadRequest, type FileReadResponse, type FileSearchResponse, type FileWriteRequest, type PreviewSessionSummary, type ReviewSnapshot, type ReviewSummary, type RuntimeSummary, type SourceControlCreatePullRequestRequest, type SourceControlCreatePullRequestResponse, type SourceControlPrepareCommitRequest } from "@matrix-os/contracts";
 import { useGateway } from "@/app/_layout";
 import { ConnectionBanner } from "@/components/ConnectionBanner";
+import {
+  loadAgentWorkspaceState,
+  reconcileAgentWorkspaceState,
+  saveAgentWorkspaceState,
+  type AgentWorkspaceState,
+} from "@/lib/agent-workspace-state";
 import { CODING_AGENTS_MOBILE_WORKSPACE } from "@/lib/feature-flags";
 import { loadMobileShellState, saveMobileShellState } from "@/lib/mobile-shell-state";
 import { isSafeShellSessionName } from "@/lib/terminal-state";
@@ -288,6 +294,11 @@ function fileReferenceMatches(left: FileReference | null, right: FileReference):
   return left?.projectId === right.projectId && left.worktreeId === right.worktreeId && left.path === right.path;
 }
 
+function agentWorkspaceStateEquals(left: AgentWorkspaceState, right: AgentWorkspaceState): boolean {
+  return left.selectedThreadId === right.selectedThreadId
+    && left.selectedTerminalSessionId === right.selectedTerminalSessionId;
+}
+
 function formatHunkRange(hunk: ReviewSnapshotHunk): string {
   return `@@ -${hunk.oldStart},${hunk.oldLines} +${hunk.newStart},${hunk.newLines} @@`;
 }
@@ -393,6 +404,45 @@ export default function AgentsScreen() {
   const selectedReviewIdRef = useRef<string | null>(null);
   const selectedFileReferenceRef = useRef<FileReference | null>(null);
   const activeFileSaveReferenceRef = useRef<FileReference | null>(null);
+  const agentWorkspaceUserWriteGenerationRef = useRef(0);
+  const activeAgentWorkspaceUserWritesRef = useRef(0);
+
+  const reconcilePersistedAgentWorkspaceState = useCallback(async (summary: RuntimeSummary) => {
+    const writeGeneration = agentWorkspaceUserWriteGenerationRef.current;
+    if (activeAgentWorkspaceUserWritesRef.current > 0) return;
+    try {
+      const savedState = await loadAgentWorkspaceState();
+      const reconciled = reconcileAgentWorkspaceState(savedState, summary);
+      if (
+        activeAgentWorkspaceUserWritesRef.current > 0
+        || agentWorkspaceUserWriteGenerationRef.current !== writeGeneration
+      ) {
+        return;
+      }
+      if (!agentWorkspaceStateEquals(savedState, reconciled)) {
+        await saveAgentWorkspaceState(reconciled);
+      }
+    } catch (err) {
+      console.warn("[mobile] failed to reconcile agent workspace state", err);
+    }
+  }, []);
+
+  const rememberAgentWorkspaceReference = useCallback(async (patch: Partial<AgentWorkspaceState>) => {
+    agentWorkspaceUserWriteGenerationRef.current += 1;
+    activeAgentWorkspaceUserWritesRef.current += 1;
+    try {
+      const savedState = await loadAgentWorkspaceState();
+      await saveAgentWorkspaceState({
+        ...savedState,
+        ...patch,
+        updatedAt: new Date().toISOString(),
+      });
+    } catch (err) {
+      console.warn("[mobile] failed to save agent workspace state", err);
+    } finally {
+      activeAgentWorkspaceUserWritesRef.current = Math.max(0, activeAgentWorkspaceUserWritesRef.current - 1);
+    }
+  }, []);
 
   const clearFileContent = useCallback(() => {
     fileContentGeneration.current += 1;
@@ -628,6 +678,7 @@ export default function AgentsScreen() {
     if (generation !== requestGeneration.current) return;
     if (result.ok) {
       setState({ status: "ready", summary: result.summary, error: null });
+      void reconcilePersistedAgentWorkspaceState(result.summary);
       if (!capabilityEnabled(result.summary, "codingAgentsReview")) {
         setReviewState(INITIAL_REVIEW_STATE);
         clearReviewSnapshot();
@@ -654,7 +705,7 @@ export default function AgentsScreen() {
     setState({ status: "error", summary: null, error: "Runtime summary unavailable" });
     setReviewState(INITIAL_REVIEW_STATE);
     clearReviewSnapshot();
-  }, [clearReviewSnapshot, client, loadReviewSnapshot]);
+  }, [clearReviewSnapshot, client, loadReviewSnapshot, reconcilePersistedAgentWorkspaceState]);
 
   const loadNotificationPreferences = useCallback(async () => {
     const generation = notificationPreferencesGeneration.current + 1;
@@ -809,8 +860,14 @@ export default function AgentsScreen() {
       setTerminalOpenError("Terminal session unavailable. Try again.");
       return;
     }
+    await rememberAgentWorkspaceReference({ selectedTerminalSessionId: session.name });
     router.push("/terminal");
-  }, [router]);
+  }, [rememberAgentWorkspaceReference, router]);
+
+  const openThread = useCallback(async (thread: SummaryThread) => {
+    await rememberAgentWorkspaceReference({ selectedThreadId: thread.id });
+    router.push(`/agents/${thread.id}` as any);
+  }, [rememberAgentWorkspaceReference, router]);
 
   const selectReview = useCallback((reviewId: string) => {
     void loadReviewSnapshot(reviewId);
@@ -916,7 +973,7 @@ export default function AgentsScreen() {
         canCreate={canCreate}
         terminalOpenError={terminalOpenError}
         onCreate={() => router.push("/agents/new")}
-        onOpenThread={(thread) => router.push(`/agents/${thread.id}` as any)}
+        onOpenThread={(thread) => void openThread(thread)}
         onOpenTerminal={(session) => void openTerminalSession(session)}
       />
 
@@ -948,7 +1005,7 @@ export default function AgentsScreen() {
               key={thread.id}
               accessibilityRole="button"
               accessibilityLabel={`Open attention thread ${thread.title}, ${attentionLabel}`}
-              onPress={() => router.push(`/agents/${thread.id}` as any)}
+              onPress={() => void openThread(thread)}
               style={styles.row}
             >
               <View style={styles.rowIcon}>
@@ -977,7 +1034,7 @@ export default function AgentsScreen() {
               accessibilityLabel={attentionLabel
                 ? `Open thread ${thread.title}, ${attentionLabel}`
                 : `Open thread ${thread.title}`}
-              onPress={() => router.push(`/agents/${thread.id}` as any)}
+              onPress={() => void openThread(thread)}
               style={styles.row}
             >
               <View style={styles.rowIcon}>

--- a/apps/mobile/lib/agent-workspace-state.ts
+++ b/apps/mobile/lib/agent-workspace-state.ts
@@ -1,3 +1,5 @@
+import AsyncStorage from "@react-native-async-storage/async-storage";
+
 export const AGENT_WORKSPACE_STATE_STORAGE_KEY = "matrix.agentWorkspaceState.v1";
 
 export interface AgentWorkspaceState {
@@ -5,6 +7,8 @@ export interface AgentWorkspaceState {
   selectedTerminalSessionId: string | null;
   updatedAt: string | null;
 }
+
+type AgentWorkspaceStorage = Pick<typeof AsyncStorage, "getItem" | "setItem">;
 
 const SAFE_THREAD_ID = /^thread_[A-Za-z0-9_-]{1,128}$/;
 const SAFE_TERMINAL_SESSION_ID = /^[A-Za-z0-9][A-Za-z0-9_.:-]{0,127}$/;
@@ -25,11 +29,15 @@ export function reconcileAgentWorkspaceState(
   state: AgentWorkspaceState,
   summary: {
     activeThreads?: { items?: Array<{ id?: unknown }> };
+    attentionThreads?: { items?: Array<{ id?: unknown }> };
     terminalSessions?: { items?: Array<{ id?: unknown }> };
   },
 ): AgentWorkspaceState {
   const threadIds = new Set(
-    (summary.activeThreads?.items ?? [])
+    [
+      ...(summary.activeThreads?.items ?? []),
+      ...(summary.attentionThreads?.items ?? []),
+    ]
       .map((thread) => thread.id)
       .filter((id): id is string => typeof id === "string"),
   );
@@ -46,6 +54,27 @@ export function reconcileAgentWorkspaceState(
         ? state.selectedTerminalSessionId
         : null,
   };
+}
+
+export async function loadAgentWorkspaceState(
+  storage: AgentWorkspaceStorage = AsyncStorage,
+): Promise<AgentWorkspaceState> {
+  try {
+    const raw = await storage.getItem(AGENT_WORKSPACE_STATE_STORAGE_KEY);
+    if (!raw) return createEmptyAgentWorkspaceState();
+    return parseAgentWorkspaceState(JSON.parse(raw));
+  } catch (err) {
+    console.warn("[mobile] failed to load agent workspace state", err);
+    return createEmptyAgentWorkspaceState();
+  }
+}
+
+export async function saveAgentWorkspaceState(
+  state: AgentWorkspaceState,
+  storage: AgentWorkspaceStorage = AsyncStorage,
+): Promise<void> {
+  const safeState = parseAgentWorkspaceState(state);
+  await storage.setItem(AGENT_WORKSPACE_STATE_STORAGE_KEY, JSON.stringify(safeState));
 }
 
 function createEmptyAgentWorkspaceState(): AgentWorkspaceState {


### PR DESCRIPTION
## Summary

- Persist the mobile coding-agent workspace's selected thread and terminal session as bounded safe UI references.
- Reconcile stale saved thread and terminal references against the runtime summary during Agents screen hydration.
- Keep mobile terminal handoff behavior unchanged while recording the selected terminal session for workspace resume.

## Tests

- `pnpm --filter matrix-os-mobile exec jest __tests__/agent-workspace-state.test.ts __tests__/agents-screen.test.tsx --runInBand`
- `pnpm --filter matrix-os-mobile exec tsc --noEmit`
- `pnpm --filter matrix-os-mobile run lint`
- `pnpm --filter matrix-os-mobile run test`
- `bun run check:patterns` (passes with existing warnings outside this mobile diff)
- `bun run typecheck`
- `git diff --check`

## Review/Monitoring

- Latest local validation passed on commit `fdb17cd516`.
- Addressed Greptile feedback by keeping terminal workspace refs consistent with successful shell handoff storage.
- Addressed Greptile feedback by skipping stale background reconcile writes when a user workspace selection starts concurrently.
- Waiting for current-head review before applying `ready-for-ci`.

## Invariants

- Source of truth: runtime summary remains gateway/runtime-owned; mobile only stores resumable UI references.
- Stored state: AsyncStorage stores selected thread ID, selected terminal session ID, and timestamp only.
- Excluded state: no transcripts, terminal output, file contents, diffs, provider credentials, approval payloads, launch tokens, filesystem paths, or raw errors are stored.
- Auth and routes: no backend routes, WebSockets, IPC, or provider calls changed.
- Deferred scope: manual device smoke remains part of the broader mobile rollout validation.
