### PR TITLE
docs(coding-agents): record mobile reference persistence

### DIFF
--- a/specs/105-coding-agent-shells/completion-audit.md
+++ b/specs/105-coding-agent-shells/completion-audit.md
@@ -1,10 +1,10 @@
 # Completion Audit: Coding Agent Shells
 
 **Audited commit**: `056b3da668ed6d1753712120316d2d5accfafdcf`
-**Date**: 2026-07-08
+**Date**: 2026-07-09
 **Scope**: Evidence review for the Matrix OS coding-agent desktop, mobile, browser, and gateway shell implementation checkpoint.
 
-This audit records current evidence through the desktop operator palette smoke and mobile terminal handoff checkpoint. It does not mark the full rollout complete while real-device smoke and broader cross-shell validation remain outstanding.
+This audit records current evidence through the desktop operator palette smoke, mobile terminal handoff checkpoint, and mobile workspace reference-persistence checkpoint. It does not mark the full rollout complete while real-device smoke and broader cross-shell validation remain outstanding.
 
 ## Evidence Matrix
 
@@ -21,7 +21,7 @@ This audit records current evidence through the desktop operator palette smoke a
 | File, review, diff, preview, and source-control surfaces remain gateway-owned with bounded shell clients | Gateway route inventory plus desktop/mobile review tests listed in `current-state.md` | Implemented |
 | Notifications and attention routing use safe owner-scoped payloads and preferences | `packages/gateway/src/coding-agents/attention-notifications.ts`; `packages/gateway/src/coding-agents/notification-preferences.ts`; related gateway, desktop, and mobile tests listed in `current-state.md` | Implemented |
 | Desktop renderer does not receive raw bearer/provider credentials | Trusted IPC and main-process client inventory in `current-state.md`; desktop runtime client tests | Implemented by architecture and tests |
-| Mobile persistent state stores only bounded UI references | `apps/mobile/lib/agent-workspace-state.ts`; `apps/mobile/lib/mobile-shell-state.ts`; mobile state tests listed in `current-state.md` | Implemented |
+| Mobile persistent state stores only bounded UI references | `apps/mobile/lib/agent-workspace-state.ts`; `apps/mobile/lib/mobile-shell-state.ts`; `apps/mobile/__tests__/agent-workspace-state.test.ts`; mobile state tests listed in `current-state.md` | Implemented |
 | Public and internal docs | `docs/dev/coding-agent-shells.md`; `www/content/docs/coding-agents.mdx`; `current-state.md` | Implemented and must stay synchronized |
 
 ## Validation Evidence
@@ -64,6 +64,15 @@ The mobile terminal handoff checkpoint in PR #868 added and passed focused PR va
 - `bun run check:patterns`
 
 That mobile validation confirms a coding-agent thread detail handoff persists both the last active terminal session and the explicit terminal handoff reference without storing terminal output or transcript data.
+
+The mobile workspace reference-persistence checkpoint in PR #877 added and passed focused PR validation:
+
+- `pnpm --filter matrix-os-mobile exec jest __tests__/agent-workspace-state.test.ts __tests__/agents-screen.test.tsx --runInBand`
+- `pnpm --filter matrix-os-mobile exec tsc --noEmit`
+- `pnpm --filter matrix-os-mobile run lint`
+- `bun run check:patterns`
+
+That mobile validation confirms the Agents workspace persists only bounded selected thread and terminal session ids, reconciles selected threads against active and attention summaries, drops stale references, skips saving terminal workspace handoff refs when the canonical mobile shell terminal handoff write fails, and avoids a background reconcile write overriding an in-flight user selection.
 
 The desktop palette and menu-entry checkpoint in PR #869 added and passed focused PR validation:
 

--- a/specs/105-coding-agent-shells/current-state.md
+++ b/specs/105-coding-agent-shells/current-state.md
@@ -22,6 +22,7 @@ Post-merge checkpoint updates:
 
 - PR #868 confirmed mobile thread detail terminal handoff persists the bounded canonical terminal session reference needed by the Terminal route without persisting terminal output or transcript data.
 - PR #869 confirmed the desktop command-palette Agents entry still opens after terminal interaction, and menu-template tests cover the native Agents accelerator used to focus the same workspace.
+- PR #877 confirms the mobile Agents workspace persists and reconciles only bounded selected thread and terminal session references, including attention-thread selections, and does not save a terminal workspace reference when terminal handoff persistence fails.
 
 ## Shared Contracts
 
@@ -344,7 +345,8 @@ Persisted UI references:
 
 - `apps/mobile/lib/agent-workspace-state.ts` stores only `selectedThreadId`, `selectedTerminalSessionId`, and `updatedAt`.
 - `apps/mobile/lib/mobile-shell-state.ts` stores only the current shell mode plus safe bounded app or terminal session references, including canonical named shell sessions such as `main` or `matrix-abc1234`.
-- Agent workspace state reconciles stale references against runtime summary items.
+- Agent workspace state loads through schema validation, reconciles stale selected thread references against both `activeThreads` and `attentionThreads`, reconciles stale selected terminal references against runtime terminal summaries, and skips background reconcile writes if a user selection starts concurrently.
+- Terminal workspace handoff references are saved only after the existing mobile shell terminal handoff state is accepted.
 - Does not store transcripts, terminal output, file contents, diffs, credentials, approvals payloads, file write payloads, or launch tokens.
 
 Focused tests:

--- a/specs/105-coding-agent-shells/tasks.md
+++ b/specs/105-coding-agent-shells/tasks.md
@@ -20,6 +20,7 @@ As of the `056b3da668ed6d1753712120316d2d5accfafdcf` main checkpoint:
 - PR #866 desktop operator e2e smoke validation now covers the stubbed sign-in/device-auth flow, project board hydration, canonical terminal attach and echo, the current Agents workspace summary/create path, Terminal Shells, Apps, Settings, Chat, and hosted-shell detach behavior.
 - PR #868 mobile validation now confirms thread detail terminal handoff persists the bounded canonical terminal session reference needed by the mobile Terminal route without persisting terminal output or transcript data.
 - PR #869 desktop validation now confirms the command-palette Agents entry still opens after terminal interaction, and menu-template tests cover the native Agents accelerator used to focus the same workspace.
+- PR #877 mobile validation now confirms the Agents workspace persists and reconciles only bounded selected thread and terminal session references, including attention-thread selections, without storing transcripts, terminal output, file contents, diffs, credentials, approval payloads, or launch tokens.
 - Remaining work is validation and rollout hardening: real-runtime desktop smoke, mobile SDK 57 device smoke, and continued docs sync as later provider/runtime behavior changes.
 
 ## Agent Instructions


### PR DESCRIPTION
## Summary
- record the mobile Agents workspace safe-reference persistence checkpoint in the 105 current-state inventory
- add the PR #877 validation evidence to the completion audit and task checkpoint notes
- clarify that mobile workspace state reconciles selected threads against both active and attention summaries and only saves terminal workspace refs after canonical shell-state handoff succeeds

## Validation
- `git diff --check`
- `rg -n "t3code|reference repo|external inspiration" specs/105-coding-agent-shells/current-state.md specs/105-coding-agent-shells/completion-audit.md specs/105-coding-agent-shells/tasks.md` returned no matches

## Invariants
- Source of truth: gateway/runtime remains source of truth; this PR only updates spec evidence for mobile shell persisted UI references.
- Lock/transaction scope: no runtime writes, locks, transactions, or persistence behavior changed.
- Acceptable orphan states: none introduced; docs describe already-tested stale-reference reconciliation.
- Auth source of truth: unchanged; mobile continues to use the authenticated gateway client for runtime state.
- Deferred scope: manual real-device SDK 57 smoke remains tracked as rollout validation work.