### PR TITLE
fix(cli): make image paste explicit in shell attach

### DIFF
--- a/packages/sync-client/src/cli/rich-paste.ts
+++ b/packages/sync-client/src/cli/rich-paste.ts
@@ -277,12 +277,22 @@ export async function processRichPasteTransaction(
 
   const validation = await collectLocalImageCandidates(input.text);
   if (validation.status === "failed") {
+    if (input.observablePaste && validation.clipboardFallbackCandidate) {
+      const fallback = await processClipboardPaste(input, {
+        candidateToReplace: validation.clipboardFallbackCandidate,
+        unsupportedFailureCode: validation.failureCode,
+      });
+      // Return fallback success, or a more specific clipboard failure such as image_too_large.
+      if (fallback.status !== "failed" || fallback.failureCode !== validation.failureCode) {
+        return fallback;
+      }
+    }
     return failedResult(validation.failureCode);
   }
   const candidates = validation.candidates;
   if (candidates.length === 0) {
     if (input.observablePaste && input.text.length === 0) {
-      return processClipboardOnlyPaste(input);
+      return processClipboardPaste(input);
     }
     return { status: "passthrough", outgoingText: input.text, assets: [] };
   }
@@ -321,15 +331,20 @@ export async function processRichPasteTransaction(
   };
 }
 
-async function processClipboardOnlyPaste(
+async function processClipboardPaste(
   input: ProcessRichPasteTransactionInput,
+  options: {
+    candidateToReplace?: InternalCandidate;
+    unsupportedFailureCode?: RichPasteFailureCode;
+  } = {},
 ): Promise<RewriteResult> {
+  const unsupportedFailureCode = options.unsupportedFailureCode ?? "unsupported_paste_event";
   if (!input.clipboardReader) {
-    return failedResult("unsupported_paste_event");
+    return failedResult(unsupportedFailureCode);
   }
   const clipboard = await input.clipboardReader.readImage();
   if (clipboard.status !== "available") {
-    return failedResult("unsupported_paste_event");
+    return failedResult(unsupportedFailureCode);
   }
   if (clipboard.candidate.sizeBytes > RICH_PASTE_MAX_IMAGE_BYTES) {
     return failedResult("image_too_large");
@@ -357,17 +372,24 @@ async function processClipboardOnlyPaste(
   }
   return {
     status: "rewritten",
-    outgoingText: `Please inspect this image: ${remoteAssets[0].path}`,
+    outgoingText: options.candidateToReplace
+      ? rewriteText(input.text, [{ ...options.candidateToReplace, uploadIndex: 0 }], remoteAssets)
+      : `Please inspect this image: ${remoteAssets[0].path}`,
     assets: remoteAssets,
   };
 }
 
 async function collectLocalImageCandidates(text: string): Promise<
   | { status: "ok"; candidates: InternalCandidate[] }
-  | { status: "failed"; failureCode: RichPasteFailureCode }
+  | {
+      status: "failed";
+      failureCode: RichPasteFailureCode;
+      clipboardFallbackCandidate?: InternalCandidate;
+    }
 > {
   const rawCandidates = findRawCandidates(text);
   const candidates: InternalCandidate[] = [];
+  const clipboardFallbackCandidate = singlePathOnlyCandidate(text, rawCandidates);
 
   for (const raw of rawCandidates) {
     const result = await validateLocalCandidate(raw);
@@ -375,7 +397,13 @@ async function collectLocalImageCandidates(text: string): Promise<
       continue;
     }
     if (result.status === "failed") {
-      return { status: "failed", failureCode: result.failureCode };
+      return {
+        status: "failed",
+        failureCode: result.failureCode,
+        clipboardFallbackCandidate: result.failureCode === "local_read_failed"
+          ? clipboardFallbackCandidate
+          : undefined,
+      };
     }
     candidates.push(result.candidate);
   }
@@ -428,6 +456,17 @@ function findRawCandidates(text: string): InternalCandidate[] {
   }
 
   return candidates.sort((left, right) => left.sourceTextRange.start - right.sourceTextRange.start);
+}
+
+function singlePathOnlyCandidate(text: string, candidates: InternalCandidate[]): InternalCandidate | undefined {
+  if (candidates.length !== 1) {
+    return undefined;
+  }
+  const candidate = candidates[0];
+  if (!candidate || text.trim() !== candidate.displayText.trim()) {
+    return undefined;
+  }
+  return candidate;
 }
 
 function createRawCandidate(input: {

--- a/packages/sync-client/src/cli/shell-client.ts
+++ b/packages/sync-client/src/cli/shell-client.ts
@@ -98,6 +98,7 @@ export const SHELL_ATTACH_MAX_QUEUED_BYTES = 65_536;
 export { SHELL_ATTACH_LIVE_TAIL_FROM_SEQ };
 const BRACKETED_PASTE_OPEN = "\u001b[200~";
 const BRACKETED_PASTE_CLOSE = "\u001b[201~";
+const LOCAL_CLIPBOARD_IMAGE_PASTE_SUFFIX = "v";
 const SHELL_ATTACH_MAX_PENDING_BRACKETED_PASTE_CHARS = 1024 * 1024;
 const BRACKETED_PASTE_INCOMPLETE_TIMEOUT_MS = 250;
 const SHELL_INPUT_FRAME_MAX_BYTES = 60_000;
@@ -677,6 +678,8 @@ export function createShellClient(options: ShellClientOptions): ShellClient {
       const errorOutput = attachOptions.errorOutput ?? process.stderr;
       const input = (attachOptions.input ?? process.stdin) as MaybeTtyStream;
       const detachSequence = attachOptions.detachSequence ?? "\u001c\u001c";
+      const localCommandPrefix = detachSequence[0] ?? "\u001c";
+      const clipboardPasteSequence = `${localCommandPrefix}${LOCAL_CLIPBOARD_IMAGE_PASTE_SUFFIX}`;
       const dropMouse = attachOptions.mouse === false;
       let writeAttachOutput: AttachWriter = (data: string) => {
         try {
@@ -1013,18 +1016,22 @@ export function createShellClient(options: ShellClientOptions): ShellClient {
             code: err instanceof Error && "code" in err ? (err as { code?: string }).code ?? "attach_failed" : "attach_failed",
           })));
         };
-        const sendInputFrame = (data: string, observablePaste: boolean): Promise<void> | void => {
-          const shouldRewrite = observablePaste
+        const sendInputFrame = (
+          data: string,
+          observablePaste: boolean,
+          options: { manualClipboardPaste?: boolean } = {},
+        ): Promise<void> | void => {
+          const shouldRewrite = options.manualClipboardPaste || (observablePaste
             ? data.length === 0 || shouldProcessRichPasteText(data)
-            : shouldProcessRichPasteText(data);
+            : shouldProcessRichPasteText(data));
           if (!richPasteRewriter || !shouldRewrite) {
             sendInputData(data);
             return;
           }
           return richPasteRewriter.rewrite({
             sessionName: name,
-            text: data,
-            observablePaste,
+            text: options.manualClipboardPaste ? "" : data,
+            observablePaste: options.manualClipboardPaste ? true : observablePaste,
           }).then((result) => {
             if (settled) {
               return;
@@ -1043,35 +1050,57 @@ export function createShellClient(options: ShellClientOptions): ShellClient {
         };
         const processInputData = (data: string, observablePaste: boolean): Promise<void> | void => {
           let outbound = "";
-          const writes: Array<Promise<void>> = [];
-          const enqueueInputFrame = (frameData: string, frameObservablePaste: boolean) => {
-            const maybeWrite = sendInputFrame(frameData, frameObservablePaste);
+          let sequence: Promise<void> | undefined;
+          const enqueueInputFrame = (
+            frameData: string,
+            frameObservablePaste: boolean,
+            frameOptions: { manualClipboardPaste?: boolean } = {},
+          ) => {
+            const run = () => Promise.resolve(sendInputFrame(frameData, frameObservablePaste, frameOptions));
+            if (sequence) {
+              sequence = sequence.then(run);
+              return;
+            }
+            const maybeWrite = sendInputFrame(frameData, frameObservablePaste, frameOptions);
             if (maybeWrite) {
-              writes.push(maybeWrite);
+              sequence = Promise.resolve(maybeWrite);
             }
           };
           for (const char of data) {
             pendingInput += char;
+            if (!observablePaste && pendingInput === clipboardPasteSequence) {
+              pendingInput = "";
+              if (outbound.length > 0) {
+                enqueueInputFrame(outbound, false);
+                outbound = "";
+              }
+              enqueueInputFrame("", false, { manualClipboardPaste: true });
+              continue;
+            }
+            if (!observablePaste && clipboardPasteSequence.startsWith(pendingInput)) {
+              continue;
+            }
             if (pendingInput === detachSequence) {
               pendingInput = "";
               if (outbound.length > 0) {
                 enqueueInputFrame(outbound, false);
               }
               detachLocal();
-              return writes.length > 0 ? Promise.all(writes).then(() => undefined) : undefined;
+              return sequence;
             }
             if (detachSequence.startsWith(pendingInput)) {
               continue;
             }
             while (pendingInput.length > 0 && !detachSequence.startsWith(pendingInput)) {
-              outbound += pendingInput[0];
+              const nextChar = pendingInput[0] ?? "";
               pendingInput = pendingInput.slice(1);
+              outbound += nextChar;
             }
           }
           if (outbound.length > 0 || observablePaste) {
             enqueueInputFrame(outbound, observablePaste);
           }
-          return writes.length > 0 ? Promise.all(writes).then(() => undefined) : undefined;
+          return sequence;
         };
         const processInput = (chunk: Buffer | string): Promise<void> | void => {
           const rawData = Buffer.isBuffer(chunk) ? chunk.toString("utf-8") : String(chunk);

--- a/packages/sync-client/tests/unit/rich-paste.test.ts
+++ b/packages/sync-client/tests/unit/rich-paste.test.ts
@@ -159,6 +159,71 @@ describe("cli/rich-paste", () => {
     expect(client.uploadPasteAssets).not.toHaveBeenCalled();
   });
 
+  it("falls back to the clipboard image for a single unreadable observable pasted image path", async () => {
+    const localPath = join(tempDir, "missing.png");
+    const client = uploadClient(["/home/matrix/home/projects/.matrix-terminal-pastes/main/2026-07-08/clipboard.png"]);
+    const clipboardReader = {
+      readImage: vi.fn(async () => ({
+        status: "available" as const,
+        candidate: {
+          kind: "clipboard" as const,
+          capturedAt: new Date("2026-07-08T10:31:00Z"),
+          sizeBytes: pngBytes.byteLength,
+          mimeType: "image/png" as const,
+          bytes: new Uint8Array(pngBytes),
+        },
+      })),
+    };
+
+    const result = await processRichPasteTransaction({
+      sessionName: "main",
+      text: localPath,
+      observablePaste: true,
+      uploadClient: client,
+      clipboardReader,
+    });
+
+    expect(result.status).toBe("rewritten");
+    expect(result.outgoingText).toBe("/home/matrix/home/projects/.matrix-terminal-pastes/main/2026-07-08/clipboard.png");
+    expect(result.outgoingText).not.toContain(localPath);
+    expect(clipboardReader.readImage).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(client.uploadPasteAssets).mock.calls[0]?.[0].assets).toEqual([{
+      name: "clipboard.png",
+      mimeType: "image/png",
+      bytes: new Uint8Array(pngBytes),
+    }]);
+  });
+
+  it("does not use clipboard fallback for prose with an unreadable image path", async () => {
+    const localPath = join(tempDir, "missing.png");
+    const client = uploadClient([]);
+    const clipboardReader = {
+      readImage: vi.fn(async () => ({
+        status: "available" as const,
+        candidate: {
+          kind: "clipboard" as const,
+          capturedAt: new Date("2026-07-08T10:31:00Z"),
+          sizeBytes: pngBytes.byteLength,
+          mimeType: "image/png" as const,
+          bytes: new Uint8Array(pngBytes),
+        },
+      })),
+    };
+
+    const result = await processRichPasteTransaction({
+      sessionName: "main",
+      text: `inspect ${localPath}`,
+      observablePaste: true,
+      uploadClient: client,
+      clipboardReader,
+    });
+
+    expect(result.status).toBe("failed");
+    expect(result.failureCode).toBe("local_read_failed");
+    expect(clipboardReader.readImage).not.toHaveBeenCalled();
+    expect(client.uploadPasteAssets).not.toHaveBeenCalled();
+  });
+
   it("fails locally for unreadable non-file image paths", async () => {
     const localPath = join(tempDir, "directory.png");
     await mkdir(localPath);

--- a/packages/sync-client/tests/unit/shell-client.test.ts
+++ b/packages/sync-client/tests/unit/shell-client.test.ts
@@ -501,6 +501,238 @@ describe("createShellClient attachSession", () => {
     await expect(attach).resolves.toEqual({ detached: false });
   });
 
+  it("uses Ctrl-backslash v as an explicit clipboard image paste command", async () => {
+    const input = new PassThrough() as PassThrough & {
+      isTTY: true;
+      rows: number;
+      columns: number;
+      setRawMode: ReturnType<typeof vi.fn>;
+      pause: ReturnType<typeof vi.fn>;
+    };
+    input.isTTY = true;
+    input.rows = 24;
+    input.columns = 80;
+    input.setRawMode = vi.fn();
+    input.pause = vi.fn();
+
+    const rewriter = {
+      rewrite: vi.fn(async () => ({
+        status: "rewritten" as const,
+        outgoingText: "Please inspect this image: /home/matrix/home/projects/.matrix-terminal-pastes/main/2026-07-08/clipboard.png",
+        assets: [],
+      })),
+    };
+    const client = createShellClient({
+      gatewayUrl: "https://matrix.example",
+      token: "token-123",
+      timeoutMs: 100,
+    });
+    const attach = client.attachSession("main", {
+      input,
+      output: new PassThrough(),
+      WebSocketImpl: FakeWebSocket as never,
+      richPaste: { rewriter },
+    });
+
+    FakeWebSocket.last?.emit("message", JSON.stringify({ type: "attached" }));
+    input.write("\u001cv");
+
+    const deadline = Date.now() + 250;
+    while (!FakeWebSocket.last?.sent.some((frame) => frame.includes("Please inspect this image"))) {
+      if (Date.now() > deadline) break;
+      await new Promise((resolve) => {
+        setTimeout(resolve, 1);
+      });
+    }
+
+    expect(rewriter.rewrite).toHaveBeenCalledWith({
+      sessionName: "main",
+      text: "",
+      observablePaste: true,
+    });
+    expect(sentInputData()).toEqual([
+      "Please inspect this image: /home/matrix/home/projects/.matrix-terminal-pastes/main/2026-07-08/clipboard.png",
+    ]);
+
+    FakeWebSocket.last?.emit("message", JSON.stringify({ type: "exit" }));
+    await expect(attach).resolves.toEqual({ detached: false });
+  });
+
+  it("prints local feedback when the explicit clipboard image paste command is unavailable", async () => {
+    const input = new PassThrough() as PassThrough & {
+      isTTY: true;
+      rows: number;
+      columns: number;
+      setRawMode: ReturnType<typeof vi.fn>;
+      pause: ReturnType<typeof vi.fn>;
+    };
+    input.isTTY = true;
+    input.rows = 24;
+    input.columns = 80;
+    input.setRawMode = vi.fn();
+    input.pause = vi.fn();
+    const errorOutput = new PassThrough();
+    const errors: string[] = [];
+    errorOutput.on("data", (chunk) => errors.push(String(chunk)));
+
+    const rewriter = {
+      rewrite: vi.fn(async () => ({
+        status: "failed" as const,
+        assets: [],
+        failureCode: "unsupported_paste_event" as const,
+        localMessage: "Image paste is not supported by this terminal paste event.",
+      })),
+    };
+    const client = createShellClient({
+      gatewayUrl: "https://matrix.example",
+      token: "token-123",
+      timeoutMs: 100,
+    });
+    const attach = client.attachSession("main", {
+      input,
+      output: new PassThrough(),
+      errorOutput: errorOutput as NodeJS.WriteStream,
+      WebSocketImpl: FakeWebSocket as never,
+      richPaste: { rewriter },
+    });
+
+    FakeWebSocket.last?.emit("message", JSON.stringify({ type: "attached" }));
+    input.write("\u001cv");
+
+    const deadline = Date.now() + 250;
+    while (!errors.join("").includes("Image paste")) {
+      if (Date.now() > deadline) break;
+      await new Promise((resolve) => {
+        setTimeout(resolve, 1);
+      });
+    }
+
+    expect(rewriter.rewrite).toHaveBeenCalledWith({
+      sessionName: "main",
+      text: "",
+      observablePaste: true,
+    });
+    expect(errors.join("")).toContain("Image paste is not supported by this terminal paste event.");
+    expect(sentInputData()).toEqual([]);
+
+    FakeWebSocket.last?.emit("message", JSON.stringify({ type: "exit" }));
+    await expect(attach).resolves.toEqual({ detached: false });
+  });
+
+  it("forwards raw Ctrl-V so readline quoted-insert keeps working", async () => {
+    const input = new PassThrough() as PassThrough & {
+      isTTY: true;
+      rows: number;
+      columns: number;
+      setRawMode: ReturnType<typeof vi.fn>;
+      pause: ReturnType<typeof vi.fn>;
+    };
+    input.isTTY = true;
+    input.rows = 24;
+    input.columns = 80;
+    input.setRawMode = vi.fn();
+    input.pause = vi.fn();
+
+    const rewriter = {
+      rewrite: vi.fn(async () => ({
+        status: "rewritten" as const,
+        outgoingText: "unexpected clipboard paste",
+        assets: [],
+      })),
+    };
+    const client = createShellClient({
+      gatewayUrl: "https://matrix.example",
+      token: "token-123",
+      timeoutMs: 100,
+    });
+    const attach = client.attachSession("main", {
+      input,
+      output: new PassThrough(),
+      WebSocketImpl: FakeWebSocket as never,
+      richPaste: { rewriter },
+    });
+
+    FakeWebSocket.last?.emit("message", JSON.stringify({ type: "attached" }));
+    input.write("\u0016");
+
+    expect(rewriter.rewrite).not.toHaveBeenCalled();
+    expect(sentInputData()).toEqual(["\u0016"]);
+
+    FakeWebSocket.last?.emit("message", JSON.stringify({ type: "exit" }));
+    await expect(attach).resolves.toEqual({ detached: false });
+  });
+
+  it("keeps same-chunk input behind an explicit clipboard image paste command", async () => {
+    const input = new PassThrough() as PassThrough & {
+      isTTY: true;
+      rows: number;
+      columns: number;
+      setRawMode: ReturnType<typeof vi.fn>;
+      pause: ReturnType<typeof vi.fn>;
+    };
+    input.isTTY = true;
+    input.rows = 24;
+    input.columns = 80;
+    input.setRawMode = vi.fn();
+    input.pause = vi.fn();
+
+    let finishRewrite!: (value: {
+      status: "rewritten";
+      outgoingText: string;
+      assets: [];
+    }) => void;
+    const rewritePromise = new Promise<{
+      status: "rewritten";
+      outgoingText: string;
+      assets: [];
+    }>((resolve) => {
+      finishRewrite = resolve;
+    });
+    const rewriter = {
+      rewrite: vi.fn(() => rewritePromise),
+    };
+    const client = createShellClient({
+      gatewayUrl: "https://matrix.example",
+      token: "token-123",
+      timeoutMs: 100,
+    });
+    const attach = client.attachSession("main", {
+      input,
+      output: new PassThrough(),
+      WebSocketImpl: FakeWebSocket as never,
+      richPaste: { rewriter },
+    });
+
+    FakeWebSocket.last?.emit("message", JSON.stringify({ type: "attached" }));
+    input.write("\u001cv\t");
+    await new Promise((resolve) => {
+      setTimeout(resolve, 10);
+    });
+
+    expect(sentInputData()).toEqual([]);
+
+    finishRewrite({
+      status: "rewritten",
+      outgoingText: "/home/matrix/home/projects/.matrix-terminal-pastes/main/2026-07-08/clipboard.png",
+      assets: [],
+    });
+    const deadline = Date.now() + 250;
+    while (sentInputData().length < 2) {
+      if (Date.now() > deadline) break;
+      await new Promise((resolve) => {
+        setTimeout(resolve, 1);
+      });
+    }
+
+    expect(sentInputData()).toEqual([
+      "/home/matrix/home/projects/.matrix-terminal-pastes/main/2026-07-08/clipboard.png",
+      "\t",
+    ]);
+
+    FakeWebSocket.last?.emit("message", JSON.stringify({ type: "exit" }));
+    await expect(attach).resolves.toEqual({ detached: false });
+  });
+
   it("prints safe local feedback and sends no local image path when rich paste fails", async () => {
     const input = new PassThrough() as PassThrough & {
       isTTY: true;

--- a/www/content/docs/cli.mdx
+++ b/www/content/docs/cli.mdx
@@ -144,7 +144,7 @@ When you paste local image paths into `matrix shell attach`, the CLI copies thos
 
 The attached session receives the same prompt with a Matrix-owned path under `~/projects/.matrix-terminal-pastes/` instead of the local macOS path. Up to five PNG, JPEG, GIF, or WebP images can be handled in one paste transaction, with a 10 MB limit per image.
 
-Image-only clipboard paste is best-effort on macOS when the terminal exposes a bracketed paste event and `pngpaste` is available. If the terminal sends no text and no paste boundary, the CLI cannot observe the paste and will not claim an image was sent. Missing, unreadable, unsupported, oversized, or failed uploads show a local retryable message and do not forward detected local image paths to the remote session.
+Image-only clipboard paste is best-effort on macOS when the terminal exposes a bracketed paste event and `pngpaste` is available. If `Cmd-V` sends no text and no paste boundary, press `Ctrl-\` then `v` while attached to explicitly ask the local CLI to read the current clipboard image. Missing, unreadable, unsupported, oversized, or failed uploads show a local retryable message and do not forward detected local image paths to the remote session.
 
 ## File sync
 

--- a/www/content/docs/guide/cli.mdx
+++ b/www/content/docs/guide/cli.mdx
@@ -142,7 +142,7 @@ Attached CLI sessions rewrite pasted local screenshots before the prompt reaches
 
 the CLI uploads the image to `~/projects/.matrix-terminal-pastes/` on your Matrix computer and replaces the local path with the remote path. Repeated references in the same paste are uploaded once, and surrounding text and line breaks are preserved.
 
-Pure image clipboard paste is supported only when the terminal provides an observable paste event. On macOS, install `pngpaste` for image-only clipboard capture. When the terminal emits no bytes or paste boundary, there is nothing for the CLI to read, so no stale clipboard image is inserted.
+Pure image clipboard paste is supported when the terminal provides an observable paste event. On macOS, install `pngpaste` for image-only clipboard capture. If `Cmd-V` emits no bytes for an image-only clipboard, press `Ctrl-\` then `v` while attached to explicitly ask the local CLI to read the current clipboard image. When neither path is observable, the CLI will not insert stale clipboard data.
 
 ### Tabs
 

--- a/www/content/docs/shell.mdx
+++ b/www/content/docs/shell.mdx
@@ -53,7 +53,7 @@ The Terminal is a persistent shell that keeps running after you close the browse
 
 When attached from the CLI, pasted local screenshot paths are copied into the same Matrix home used by the web Terminal. The CLI replaces local paths with files under `~/projects/.matrix-terminal-pastes/` before sending input to the shared session, so browser and CLI users see a remote path the Matrix computer can read.
 
-This rich paste behavior is scoped to CLI attach. Browser and desktop terminals already run inside the Matrix shell context, while the CLI is the surface that can read local macOS files or, when a terminal exposes an observable paste event, a macOS image clipboard through `pngpaste`.
+This rich paste behavior is scoped to CLI attach. Browser and desktop terminals already run inside the Matrix shell context, while the CLI is the surface that can read local macOS files or, when a terminal exposes an observable paste event or attached-session `Ctrl-\` then `v`, a macOS image clipboard through `pngpaste`.
 
 ## GitHub auth
 


### PR DESCRIPTION
## Summary

- Diagnosed terminal image paste as two local CLI issues: image-only `Cmd-V` cannot be detected when the terminal emits no stdin bytes, and path-only screenshot thumbnail drops can fail local file validation before upload.
- Adds an explicit attached-session `Ctrl-\` then `v` clipboard-image command that reuses the bounded rich paste pipeline without stealing readline `Ctrl-V`.
- Adds a narrow fallback for a single unreadable path-only observable paste to use the current clipboard image, preserving the existing no-forwarding behavior for prose with unreadable local paths.
- Updates CLI docs to explain the `Cmd-V` limitation and `Ctrl-V` fallback.

## Tests

- `/home/nima/matrix-os/node_modules/.bin/vitest run --config vitest.config.ts tests/unit/rich-paste.test.ts tests/unit/shell-client.test.ts` from `packages/sync-client` (29 passed)
- `/home/nima/matrix-os/node_modules/.bin/tsc -p packages/sync-client/tsconfig.json --noEmit`
- `/home/nima/matrix-os/node_modules/.bin/vitest run tests/cli/shell-client.test.ts tests/cli/shell.test.ts` (72 passed)
- `bash scripts/review/check-patterns.sh` (0 violations, existing warnings only)
- `git diff --check`

`bun run typecheck` was not run locally because `bun` is not installed on this host shell; the sync-client TypeScript gate above passed.

## Review/Monitoring

- Ready for CI and Greptile monitoring.
- Latest trusted Greptile result must be 5/5 before merge.
- No React files changed, so `react-doctor` is not applicable.
- No visual shell surface changed; docs text changed, so no screenshot was captured.

## Invariants

- Source of truth: local CLI can read local files/clipboard; Matrix computer receives only remote Matrix-owned paste asset paths.
- Lock/transaction scope: local validation/clipboard read and upload complete before terminal input frames are forwarded.
- Acceptable orphan states: if upload or validation fails, no detected local image path is forwarded; an uploaded paste asset may remain as an owner-scoped temp paste asset under the existing cleanup policy.
- Auth source of truth: paste upload still uses the existing authenticated terminal paste-assets API via the shell client token.
- Deferred scope: terminals that emit no bytes for `Cmd-V` remain undetectable; users must use an observable paste event, explicit `Ctrl-\` then `v`, or `mos shell paste-clipboard`.
