### PR TITLE
docs(coding-agents): record real runtime smoke helper

### DIFF
--- a/specs/105-coding-agent-shells/completion-audit.md
+++ b/specs/105-coding-agent-shells/completion-audit.md
@@ -109,10 +109,20 @@ The desktop palette and menu-entry checkpoint in PR #869 added and passed focuse
 
 That automated desktop smoke now also covers opening the Agents workspace from the command palette after the terminal smoke path, and unit coverage confirms the native Agents menu accelerator matches the renderer shortcut.
 
+The real-runtime smoke helper checkpoint in PR #879 added repeatable read-only deployed-runtime validation:
+
+- `pnpm exec vitest run tests/scripts/coding-agent-real-runtime-smoke.test.ts`
+- `git diff --check`
+- sanitized forbidden-reference scan over the touched script, tests, and docs
+- `bun run check:patterns`
+- `bun run typecheck`
+
+That helper validates authenticated deployed-runtime `summary`, `threads`, `reviews`, and `notification-preferences` responses through bounded schemas, preserves `/vm/<handle>` base paths, rejects token CLI arguments, redacts bearer material, caps response bodies, and prints no raw response bodies. It is not evidence that a human has completed the desktop or mobile visual smoke on a deployed runtime.
+
 ## Remaining Validation
 
-- Run the Manual Desktop Real-Runtime Smoke checklist in `docs/dev/coding-agent-shells.md` against a real Matrix computer for runtime switch, native menu entry points, review/file/preview paths, notification click-through, non-stub provider setup, and cross-shell terminal binding. The automated desktop operator smoke now covers sign-in, project board, terminal attach, current Agents workspace create, command-palette Agents entry, Terminal, Apps, Settings, Chat, and hosted-shell detach through the stub gateway.
-- Run the manual mobile SDK 57 device smoke checklist in `docs/dev/mobile-shell.md` for chat, mission control, terminal, apps, agents workspace, thread detail, terminal handoff, review/file/preview paths, approvals/input, notification tap routing, offline/reconnect state, and persisted safe references.
+- Run the real-runtime smoke helper against the deployed Matrix computer, then run the Manual Desktop Real-Runtime Smoke checklist in `docs/dev/coding-agent-shells.md` for runtime switch, native menu entry points, review/file/preview paths, notification click-through, non-stub provider setup, and cross-shell terminal binding. The automated desktop operator smoke now covers sign-in, project board, terminal attach, current Agents workspace create, command-palette Agents entry, Terminal, Apps, Settings, Chat, and hosted-shell detach through the stub gateway.
+- Run the real-runtime smoke helper against the deployed Matrix computer before manual mobile validation, then run the manual mobile SDK 57 device smoke checklist in `docs/dev/mobile-shell.md` for chat, mission control, terminal, apps, agents workspace, thread detail, terminal handoff, review/file/preview paths, approvals/input, notification tap routing, offline/reconnect state, and persisted safe references.
 - Keep `docs/dev/coding-agent-shells.md`, `www/content/docs/coding-agents.mdx`, and this audit synchronized when provider/runtime behavior changes.
 
 ## Security Notes

--- a/specs/105-coding-agent-shells/current-state.md
+++ b/specs/105-coding-agent-shells/current-state.md
@@ -126,6 +126,7 @@ Post-merge checkpoint updates:
 
 - PR #868 confirmed mobile thread detail terminal handoff persists the bounded canonical terminal session reference needed by the Terminal route without persisting terminal output or transcript data.
 - PR #869 confirmed the desktop command-palette Agents entry still opens after terminal interaction, and menu-template tests cover the native Agents accelerator used to focus the same workspace.
+- PR #879 adds an opt-in real-runtime smoke helper at `scripts/coding-agents/real-runtime-smoke.mjs` that validates deployed `/api/coding-agents/summary`, `/threads`, `/reviews`, and `/notification-preferences` responses through bounded Zod schemas without writing runtime state. This is rollout hardening only; deployed desktop/mobile visual smoke remains a separate manual validation step.
 
 ## Shared Contracts
 
@@ -569,6 +570,12 @@ Mobile diagnostics:
 
 ```bash
 pnpm --filter matrix-os-mobile exec jest __tests__/coding-agent-diagnostics.test.ts __tests__/gateway-client.test.ts --runInBand
+```
+
+Real-runtime smoke helper:
+
+```bash
+MATRIX_RUNTIME_URL="https://app.matrix-os.com/vm/<handle>" MATRIX_RUNTIME_TOKEN="<short-lived runtime token>" node scripts/coding-agents/real-runtime-smoke.mjs
 ```
 
 Desktop typecheck:

--- a/specs/105-coding-agent-shells/tasks.md
+++ b/specs/105-coding-agent-shells/tasks.md
@@ -22,7 +22,8 @@ As of the `056b3da668ed6d1753712120316d2d5accfafdcf` main checkpoint:
 - PR #869 desktop validation now confirms the command-palette Agents entry still opens after terminal interaction, and menu-template tests cover the native Agents accelerator used to focus the same workspace.
 - The mobile SDK 57 coding-agent device smoke runbook now lives in `docs/dev/mobile-shell.md`.
 - The desktop coding-agent real-runtime smoke runbook now lives in `docs/dev/coding-agent-shells.md`.
-- Remaining work is validation and rollout hardening: manual real-runtime desktop smoke, manual mobile SDK 57 device smoke, mobile workspace reference persistence wired into the new Agents cockpit, and continued docs sync as later provider/runtime behavior changes.
+- PR #879 adds an opt-in read-only real-runtime smoke helper for deployed `/api/coding-agents` route validation without writing runtime state.
+- Remaining work is validation and rollout hardening: run the real-runtime smoke helper against a deployed Matrix computer, complete real-runtime desktop visual smoke, complete mobile SDK 57 device smoke, wire mobile workspace reference persistence into the new Agents cockpit, and continue docs sync as later provider/runtime behavior changes.
 
 That checkpoint is not the clarified final product. The active backlog now requires a project-first hierarchy, same-thread conversation turns, tasks with multiple threads, and Conversation/Kanban views. `acceptance-tests.md` is the authoritative test matrix for this follow-up work.
 


### PR DESCRIPTION
## Summary
- Record PR #879's real-runtime smoke helper in the spec 105 current-state inventory.
- Add the helper's focused validation evidence to the completion audit.
- Keep desktop visual smoke and mobile SDK 57 device smoke explicitly listed as remaining rollout validation.

## Tests
- rg -n "real-runtime smoke helper|scripts/coding-agents/real-runtime-smoke.mjs|Run the real-runtime smoke helper" specs/105-coding-agent-shells/current-state.md specs/105-coding-agent-shells/completion-audit.md specs/105-coding-agent-shells/tasks.md
- git diff --check
- sanitized forbidden-reference scan over touched spec docs
- bun run check:patterns (0 violations; existing warnings only)

## Review/Monitoring
- Stacked on PR #879 (`105-coding-agent-real-runtime-smoke`); do not merge before #879.
- Greptile confidence 5/5 on head `ed1fa19b55856b53eb8ad1f5ed8f368df19519fc`.
- `ready-for-ci` added after Greptile reached 5/5.
- PR Title was rerun after a queued job was cancelled before executing any steps; Preview VPS Gate is still queued.

## Invariants
- Source of truth: docs-only evidence update; gateway/runtime remains the source of coding-agent state.
- Lock/transaction scope: no runtime writes, locks, transactions, or persistence changed.
- Acceptable orphan states: none introduced.
- Auth source of truth: unchanged.
- Deferred scope: real desktop visual smoke and mobile SDK 57 device smoke remain open rollout validation.
