### PR TITLE
chore(cli): prepare 0.3.11 CLI release

### DIFF
--- a/docs/dev/cli-release.md
+++ b/docs/dev/cli-release.md
@@ -4,7 +4,7 @@ The installable Matrix CLI is the `@finnaai/matrix` package in `packages/sync-cl
 
 ## Current Prepared Release
 
-`0.3.10` is the prepared CLI patch release after `0.3.9`, including attached terminal rich image paste fixes while preserving Node 20+ package-runner support and standalone CLI binaries for no-Node installs.
+`0.3.11` is the prepared CLI patch release after `0.3.10`, including the explicit attached-session clipboard image paste command and path-only clipboard fallback fixes.
 
 ## Versioning
 
@@ -34,7 +34,7 @@ git tag -l 'cli-v*'
 
 ## Release
 
-Use the manual GitHub Actions workflow named `CLI Release` with `version=0.3.10` and `update_homebrew=true`. This follows the existing `cli-v0.3.10` workflow/tag release path after the PR merges. The workflow:
+Use the manual GitHub Actions workflow named `CLI Release` with `version=0.3.11` and `update_homebrew=true`. This follows the existing `cli-v0.3.11` workflow/tag release path after the PR merges. The workflow:
 
 1. Validates the requested semver, local package version, npm availability, and `cli-v<version>` tag availability.
 2. Installs the workspace and runs the sync-client build, tests, and publish-shape check.
@@ -51,7 +51,7 @@ npm view @finnaai/matrix dist.tarball
 npx --yes @finnaai/matrix --version
 pnpm dlx @finnaai/matrix --version
 brew update && brew info finnaai/tap/matrix
-MATRIX_VERSION=0.3.10 sh scripts/install.sh
+MATRIX_VERSION=0.3.11 sh scripts/install.sh
 matrix --version
 matrix login --help
 matrix run --help
@@ -69,17 +69,17 @@ matrix forward 5173
 
 For standalone binaries, also verify the GitHub release contains:
 
-- `matrix-0.3.10-linux-x64`
-- `matrix-0.3.10-linux-arm64`
-- `matrix-0.3.10-darwin-x64`
-- `matrix-0.3.10-darwin-arm64`
+- `matrix-0.3.11-linux-x64`
+- `matrix-0.3.11-linux-arm64`
+- `matrix-0.3.11-darwin-x64`
+- `matrix-0.3.11-darwin-arm64`
 
-For macOS app packaging, also verify the GitHub release contains `MatrixSync-0.3.10.pkg` when the macOS job was enabled.
+For macOS app packaging, also verify the GitHub release contains `MatrixSync-0.3.11.pkg` when the macOS job was enabled.
 
 ## Rollback
 
-npm package versions are immutable. If a bad CLI release is published, ship a patch release such as `0.3.11` and update Homebrew through the release workflow. Only deprecate the bad npm version when the replacement is available:
+npm package versions are immutable. If a bad CLI release is published, ship a patch release such as `0.3.12` and update Homebrew through the release workflow. Only deprecate the bad npm version when the replacement is available:
 
 ```bash
-npm deprecate @finnaai/matrix@0.3.10 "Use @finnaai/matrix@0.3.11"
+npm deprecate @finnaai/matrix@0.3.11 "Use @finnaai/matrix@0.3.12"
 ```

--- a/packages/sync-client/package.json
+++ b/packages/sync-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@finnaai/matrix",
-  "version": "0.3.10",
+  "version": "0.3.11",
   "description": "Matrix OS command-line client — login, sync, and peer management for matrix-os.com",
   "type": "module",
   "license": "AGPL-3.0-or-later",


### PR DESCRIPTION
## Summary

- Bumps `@finnaai/matrix` from `0.3.10` to `0.3.11`.
- Updates the CLI release runbook to point at the `0.3.11` release/tag/assets.

## Tests

- `npm view @finnaai/matrix@0.3.11 version` returned 404, so the npm version is available.
- `git ls-remote --exit-code --tags origin refs/tags/cli-v0.3.11` found no existing tag.
- `pnpm --filter @finnaai/matrix build`
- `pnpm --filter @finnaai/matrix test` (35 files, 349 tests passed)
- `pnpm --filter @finnaai/matrix exec node ./scripts/check-publish.mjs`
- `pnpm --filter @finnaai/matrix exec node ./scripts/validate-package-runners.mjs`
- `git diff --check`

## Review/Monitoring

- Release-prep PR for dispatching the manual `CLI Release` workflow with `version=0.3.11`, `update_homebrew=true`, `allow_existing_npm=false`.
- No React files changed, so `react-doctor` is not applicable.
- No user-visible frontend surface changed; screenshot evidence is not applicable.

## Invariants

- Source of truth: `packages/sync-client/package.json` is the npm package version the release workflow validates before publishing.
- Lock/transaction scope: no runtime/database mutations; the workflow publishes immutable npm and GitHub release artifacts only after package validation passes.
- Acceptable orphan states: if Homebrew update fails after npm publish, npm `0.3.11` remains immutable and the tap can be repaired by rerunning or manually updating the formula.
- Auth source of truth: GitHub Actions secrets (`NPM_TOKEN`, `TAP_PUSH_TOKEN`) remain the release credential source; no credentials are added to repo files.
- Deferred scope: this PR does not publish the release itself; it prepares `main` so the manual release workflow can be dispatched.
