### PR TITLE
test(coding-agents): add smoke helper assertions

### DIFF
--- a/docs/dev/coding-agent-shells.md
+++ b/docs/dev/coding-agent-shells.md
@@ -403,6 +403,21 @@ node scripts/coding-agents/real-runtime-smoke.mjs
 
 The helper performs read-only authenticated checks for `GET /api/coding-agents/summary`, `GET /api/coding-agents/threads`, `GET /api/coding-agents/reviews`, and `GET /api/coding-agents/notification-preferences`. It validates bounded response contracts with Zod 4, applies per-request timeouts, caps response bodies, and redacts bearer tokens from logs.
 
+Add read-only assertions when the deployed runtime is expected to expose specific coding-agent surfaces:
+
+```bash
+MATRIX_RUNTIME_URL="https://app.matrix-os.com/vm/<handle>" \
+MATRIX_RUNTIME_TOKEN="<short-lived runtime token>" \
+node scripts/coding-agents/real-runtime-smoke.mjs \
+  --require-capability codingAgentsRuntimeSummary \
+  --require-capability codingAgentsMobileWorkspace \
+  --require-ready-provider \
+  --min-active-threads 1 \
+  --min-terminal-sessions 1
+```
+
+Available assertion flags are `--require-capability <id>`, `--require-ready-provider`, `--require-thread-snapshot`, `--min-active-threads <count>`, `--min-terminal-sessions <count>`, `--min-preview-sessions <count>`, and `--min-reviews <count>`. The helper remains read-only; it follows review cursors only when a minimum review count is requested and validates a thread snapshot only when `--require-thread-snapshot` is passed.
+
 Do not paste live token values, raw response bodies, transcripts, terminal output, file contents, diffs, provider errors, private hostnames, or VPS IPs into PR comments. Record only the command shape, pass/fail status, and sanitized recovery notes.
 
 ## Validation Commands

--- a/scripts/coding-agents/real-runtime-smoke.mjs
+++ b/scripts/coding-agents/real-runtime-smoke.mjs
@@ -4,6 +4,9 @@ import { fileURLToPath } from "node:url";
 
 export const DEFAULT_TIMEOUT_MS = 10_000;
 export const MAX_JSON_BYTES = 1024 * 1024;
+export const MAX_SUMMARY_COUNT_ASSERTION = 50;
+export const MAX_REVIEW_COUNT_ASSERTION = 1000;
+export const MAX_REVIEW_PAGES = 20;
 
 const SAFE_SLUG = /^[a-z0-9][a-z0-9_-]{0,79}$/;
 const SAFE_ERROR_CODE = /^[A-Za-z0-9][A-Za-z0-9_-]{0,79}$/;
@@ -17,12 +20,44 @@ const REVIEW_ID = SAFE_REFERENCE;
 const TERMINAL_ID = SAFE_REFERENCE;
 const WORKTREE_ID = /^wt_[a-z0-9]{12,40}$/;
 const EVENT_ID = /^evt_[A-Za-z0-9_-]{1,128}$/;
+const APPROVAL_ID = /^appr_[A-Za-z0-9_-]{1,128}$/;
+const REQUEST_ID = /^req_[A-Za-z0-9_-]{1,128}$/;
+const CORRELATION_ID = /^corr_[A-Za-z0-9_-]{1,128}$/;
 const ISO_DATETIME = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{3})?Z$/;
+
+const RUNTIME_CAPABILITY_IDS = [
+  "codingAgentsRuntimeSummary",
+  "codingAgentsDesktopWorkspace",
+  "codingAgentsMobileWorkspace",
+  "codingAgentsThreadCreate",
+  "codingAgentsApprovals",
+  "codingAgentsReview",
+  "codingAgentsPreview",
+  "codingAgentsFiles",
+  "codingAgentsSourceControl",
+  "codingAgentsNativeMobileTerminal",
+];
+
+const RuntimeCapabilityIdSchema = z.enum(RUNTIME_CAPABILITY_IDS);
 
 const SafeDisplayStringSchema = z.string()
   .min(1)
   .max(120)
   .refine((value) => !looksInternal(value), "Unsafe display string");
+
+const SafeLongDisplayStringSchema = z.string()
+  .min(1)
+  .max(2000)
+  .refine((value) => !looksInternal(value), "Unsafe display string");
+
+const SafeRequestDescriptionSchema = z.string()
+  .min(1)
+  .max(600)
+  .refine((value) => !looksInternal(value), "Unsafe display string");
+
+const SafeBoundedTextSchema = z.string()
+  .min(1)
+  .max(4000);
 
 const SafeSetupCommandSchema = z.string()
   .min(1)
@@ -58,18 +93,7 @@ const RuntimeTargetSchema = z.object({
 }).strict();
 
 const RuntimeCapabilitySchema = z.object({
-  id: z.enum([
-    "codingAgentsRuntimeSummary",
-    "codingAgentsDesktopWorkspace",
-    "codingAgentsMobileWorkspace",
-    "codingAgentsThreadCreate",
-    "codingAgentsApprovals",
-    "codingAgentsReview",
-    "codingAgentsPreview",
-    "codingAgentsFiles",
-    "codingAgentsSourceControl",
-    "codingAgentsNativeMobileTerminal",
-  ]),
+  id: RuntimeCapabilityIdSchema,
   enabled: z.boolean(),
   reason: SafeDisplayStringSchema.optional(),
 }).strict();
@@ -181,8 +205,167 @@ const ActivityEventSummarySchema = z.object({
   occurredAt: z.string().regex(ISO_DATETIME),
 }).strict();
 
+const BaseThreadEventSchema = z.object({
+  eventId: z.string().regex(EVENT_ID),
+  threadId: z.string().regex(THREAD_ID),
+  occurredAt: z.string().regex(ISO_DATETIME),
+});
+
+const SafeClientErrorSchema = z.object({
+  // Thread event errors mirror the shared client error contract; HTTP envelopes use SAFE_ERROR_CODE below.
+  code: z.string().min(1).max(80).regex(SAFE_SLUG),
+  safeMessage: SafeDisplayStringSchema,
+  retryable: z.boolean(),
+  recoveryActions: z.array(z.enum([
+    "retry",
+    "sign_in",
+    "select_runtime",
+    "open_setup_terminal",
+    "resume",
+    "start_new_session",
+    "return_home",
+  ])).max(6).optional(),
+}).strict();
+
+const ApprovalPreviewSchema = z.object({
+  title: SafeDisplayStringSchema.optional(),
+  body: SafeLongDisplayStringSchema.optional(),
+  truncated: z.boolean().default(false),
+}).strict();
+
+const AgentApprovalRequestSchema = z.object({
+  approvalId: z.string().regex(APPROVAL_ID),
+  threadId: z.string().regex(THREAD_ID),
+  title: SafeDisplayStringSchema,
+  safeDescription: SafeRequestDescriptionSchema,
+  risk: z.enum(["low", "medium", "high"]),
+  actionKind: z.enum(["command", "file_change", "network", "provider", "other"]),
+  preview: ApprovalPreviewSchema.optional(),
+  allowedDecisions: z.array(z.enum(["approve", "approve_for_session", "decline", "cancel"])).min(1).max(4),
+  expiresAt: z.string().regex(ISO_DATETIME).optional(),
+  correlationId: z.string().regex(CORRELATION_ID),
+}).strict();
+
+const UserInputRequestSchema = z.object({
+  requestId: z.string().regex(REQUEST_ID),
+  threadId: z.string().regex(THREAD_ID),
+  title: SafeDisplayStringSchema,
+  safeDescription: SafeRequestDescriptionSchema,
+  placeholder: SafeDisplayStringSchema.optional(),
+  required: z.boolean().default(true),
+  expiresAt: z.string().regex(ISO_DATETIME).optional(),
+  correlationId: z.string().regex(CORRELATION_ID),
+}).strict();
+
+function safeRelativePathSchema(max = 512) {
+  return z.string()
+    .min(1)
+    .max(max)
+    .refine((value) => !value.startsWith("/") && !value.includes("\0"), "Invalid path")
+    .refine((value) => !value.split(/[\\/]+/).some((part) => part === "" || part === "." || part === ".."), {
+      message: "Path traversal is not allowed",
+    });
+}
+
+const AgentThreadEventSchema = z.discriminatedUnion("type", [
+  BaseThreadEventSchema.extend({
+    type: z.literal("thread.created"),
+    thread: AgentThreadSummarySchema,
+  }).strict(),
+  BaseThreadEventSchema.extend({
+    type: z.literal("thread.status"),
+    status: z.enum([
+      "queued",
+      "starting",
+      "running",
+      "waiting_for_approval",
+      "waiting_for_input",
+      "completed",
+      "failed",
+      "aborted",
+      "stale",
+      "archived",
+    ]),
+  }).strict(),
+  BaseThreadEventSchema.extend({
+    type: z.literal("assistant.text.delta"),
+    messageId: ReferenceIdSchema,
+    delta: SafeBoundedTextSchema.max(4000),
+  }).strict(),
+  BaseThreadEventSchema.extend({
+    type: z.literal("assistant.text.completed"),
+    messageId: ReferenceIdSchema,
+  }).strict(),
+  BaseThreadEventSchema.extend({
+    type: z.literal("tool.started"),
+    toolCallId: ReferenceIdSchema,
+    displayName: SafeDisplayStringSchema,
+    kind: SafeDisplayStringSchema,
+  }).strict(),
+  BaseThreadEventSchema.extend({
+    type: z.literal("tool.output"),
+    toolCallId: ReferenceIdSchema,
+    text: SafeBoundedTextSchema,
+    truncated: z.boolean().optional(),
+  }).strict(),
+  BaseThreadEventSchema.extend({
+    type: z.literal("tool.completed"),
+    toolCallId: ReferenceIdSchema,
+    outcome: z.enum(["success", "failed", "cancelled"]),
+  }).strict(),
+  BaseThreadEventSchema.extend({
+    type: z.literal("approval.requested"),
+    approval: AgentApprovalRequestSchema,
+  }).strict(),
+  BaseThreadEventSchema.extend({
+    type: z.literal("approval.resolved"),
+    approvalId: z.string().regex(APPROVAL_ID),
+    decision: z.enum(["approve", "approve_for_session", "decline", "cancel"]),
+  }).strict(),
+  BaseThreadEventSchema.extend({
+    type: z.literal("user_input.requested"),
+    request: UserInputRequestSchema,
+  }).strict(),
+  BaseThreadEventSchema.extend({
+    type: z.literal("user_input.answered"),
+    requestId: z.string().regex(REQUEST_ID),
+    correlationId: z.string().regex(CORRELATION_ID),
+  }).strict(),
+  BaseThreadEventSchema.extend({
+    type: z.literal("file.changed"),
+    path: safeRelativePathSchema(),
+    changeKind: z.enum(["created", "updated", "deleted", "renamed"]),
+  }).strict(),
+  BaseThreadEventSchema.extend({
+    type: z.literal("review.ready"),
+    reviewId: ReferenceIdSchema,
+    summary: z.object({
+      changedFileCount: z.number().int().min(0).max(10_000),
+      additions: z.number().int().min(0).max(1_000_000),
+      deletions: z.number().int().min(0).max(1_000_000),
+      partial: z.boolean(),
+    }).strict(),
+  }).strict(),
+  BaseThreadEventSchema.extend({
+    type: z.literal("terminal.bound"),
+    terminalSessionId: z.string().regex(TERMINAL_ID),
+  }).strict(),
+  BaseThreadEventSchema.extend({
+    type: z.literal("thread.error"),
+    error: SafeClientErrorSchema,
+  }).strict(),
+  BaseThreadEventSchema.extend({
+    type: z.literal("thread.completed"),
+    outcome: z.enum(["completed", "failed", "aborted"]),
+  }).strict(),
+]);
+
 const ThreadListSchema = boundedListSchema(AgentThreadSummarySchema, 50);
 const ReviewListSchema = boundedListSchema(ReviewSummarySchema, 50);
+const AgentThreadSnapshotSchema = z.object({
+  thread: AgentThreadSummarySchema,
+  events: boundedListSchema(AgentThreadEventSchema, 200),
+}).strict();
 
 const RuntimeSummarySchema = z.object({
   runtime: RuntimeTargetSchema,
@@ -278,6 +461,13 @@ export function createSmokeConfig(argv = process.argv.slice(2), env = process.en
     timeoutMs: parsedTimeout,
     projectId: normalizeOptionalProjectId(flags.projectId ?? env.MATRIX_CODING_AGENT_SMOKE_PROJECT_ID),
     json: Boolean(flags.json),
+    requiredCapabilities: flags.requiredCapabilities ?? [],
+    requireReadyProvider: Boolean(flags.requireReadyProvider),
+    requireThreadSnapshot: Boolean(flags.requireThreadSnapshot),
+    minActiveThreads: flags.minActiveThreads,
+    minTerminalSessions: flags.minTerminalSessions,
+    minPreviewSessions: flags.minPreviewSessions,
+    minReviews: flags.minReviews,
   };
 }
 
@@ -338,6 +528,21 @@ export async function runRuntimeSmoke(options) {
     status: "passed",
     detail: `${reviews.items.length} reviews`,
   });
+  const reviewCount = await countReviewsForMinimum({
+    initial: reviews,
+    minReviews: options.minReviews,
+    runtimeUrl,
+    headers,
+    timeoutMs,
+    fetchImpl,
+  });
+  if (reviewCount > reviews.items.length) {
+    checks.push({
+      name: "review pagination",
+      status: "passed",
+      detail: `${reviewCount} reviews checked`,
+    });
+  }
 
   await runCheck({
     name: "notification preferences",
@@ -354,6 +559,47 @@ export async function runRuntimeSmoke(options) {
     status: "passed",
     detail: "owner preferences available",
   });
+
+  const threadId = summary.activeThreads.items[0]?.id ?? summary.attentionThreads.items[0]?.id;
+  let checkedThreadSnapshot = false;
+  if (options.requireThreadSnapshot && !threadId) {
+    throw new SmokeFailure(
+      "thread snapshot",
+      "thread snapshot unavailable because no active or attention thread is available. Start or select a thread and try again.",
+    );
+  }
+  if (options.requireThreadSnapshot && threadId) {
+    await runCheck({
+      name: "thread snapshot",
+      runtimeUrl,
+      path: `/api/coding-agents/threads/${encodeURIComponent(threadId)}`,
+      headers,
+      timeoutMs,
+      fetchImpl,
+      schema: AgentThreadSnapshotSchema,
+      contractName: "Thread snapshot",
+    });
+    checkedThreadSnapshot = true;
+    checks.push({
+      name: "thread snapshot",
+      status: "passed",
+      detail: "latest thread snapshot available",
+    });
+  }
+
+  const assertionsChecked = evaluateRequirements({
+    summary,
+    reviewCount,
+    checkedThreadSnapshot,
+    request: options,
+  });
+  if (assertionsChecked > 0) {
+    checks.push({
+      name: "runtime requirements",
+      status: "passed",
+      detail: `${assertionsChecked} read-only assertions checked`,
+    });
+  }
 
   return { ok: true, checks };
 }
@@ -448,6 +694,38 @@ function parseArgs(argv) {
       flags.projectId = argv[++index];
       continue;
     }
+    if (arg === "--require-capability") {
+      const result = RuntimeCapabilityIdSchema.safeParse(argv[++index]);
+      if (!result.success) {
+        throw new Error("Invalid required capability");
+      }
+      flags.requiredCapabilities = [...(flags.requiredCapabilities ?? []), result.data];
+      continue;
+    }
+    if (arg === "--require-ready-provider") {
+      flags.requireReadyProvider = true;
+      continue;
+    }
+    if (arg === "--require-thread-snapshot") {
+      flags.requireThreadSnapshot = true;
+      continue;
+    }
+    if (arg === "--min-active-threads") {
+      flags.minActiveThreads = parseSummaryMinimumCount(argv[++index], "min-active-threads");
+      continue;
+    }
+    if (arg === "--min-terminal-sessions") {
+      flags.minTerminalSessions = parseSummaryMinimumCount(argv[++index], "min-terminal-sessions");
+      continue;
+    }
+    if (arg === "--min-preview-sessions") {
+      flags.minPreviewSessions = parseSummaryMinimumCount(argv[++index], "min-preview-sessions");
+      continue;
+    }
+    if (arg === "--min-reviews") {
+      flags.minReviews = parseMinimumCount(argv[++index], "min-reviews");
+      continue;
+    }
     if (arg === "--timeout-ms") {
       flags.timeoutMs = argv[++index];
       continue;
@@ -464,6 +742,99 @@ function normalizeOptionalProjectId(value) {
     throw new Error("project id is invalid");
   }
   return result.data;
+}
+
+function parseMinimumCount(value, label) {
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed <= 0 || parsed > MAX_REVIEW_COUNT_ASSERTION) {
+    throw new Error(`${label} must be a positive integer up to ${MAX_REVIEW_COUNT_ASSERTION}`);
+  }
+  return parsed;
+}
+
+function parseSummaryMinimumCount(value, label) {
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed <= 0 || parsed > MAX_SUMMARY_COUNT_ASSERTION) {
+    throw new Error(`${label} must be a positive integer up to ${MAX_SUMMARY_COUNT_ASSERTION}`);
+  }
+  return parsed;
+}
+
+function isReadyProvider(provider) {
+  return provider.availability === "available" &&
+    provider.installStatus === "installed" &&
+    provider.authStatus === "authenticated";
+}
+
+function evaluateRequirements({ summary, reviewCount, checkedThreadSnapshot, request }) {
+  let checked = 0;
+  const fail = () => {
+    throw new SmokeFailure(
+      "runtime requirements",
+      "runtime requirements unavailable. Refresh runtime state and try again.",
+    );
+  };
+  const capabilities = new Map(summary.capabilities.map((capability) => [capability.id, capability.enabled]));
+
+  for (const capabilityId of request.requiredCapabilities ?? []) {
+    checked += 1;
+    if (capabilities.get(capabilityId) !== true) fail();
+  }
+
+  if (request.requireReadyProvider) {
+    checked += 1;
+    if (!summary.providers.some(isReadyProvider)) fail();
+  }
+
+  if (request.requireThreadSnapshot) {
+    checked += 1;
+    if (!checkedThreadSnapshot) fail();
+  }
+
+  checked += assertMinimum(summary.activeThreads.items.length, request.minActiveThreads, fail);
+  checked += assertMinimum(summary.terminalSessions.items.length, request.minTerminalSessions, fail);
+  checked += assertMinimum(summary.previewSessions.items.length, request.minPreviewSessions, fail);
+  checked += assertMinimum(reviewCount, request.minReviews, fail);
+
+  return checked;
+}
+
+function assertMinimum(actual, expected, fail) {
+  if (expected === undefined) return 0;
+  if (actual < expected) fail();
+  return 1;
+}
+
+async function countReviewsForMinimum({ initial, minReviews, runtimeUrl, headers, timeoutMs, fetchImpl }) {
+  let count = initial.items.length;
+  let hasMore = initial.hasMore;
+  let nextCursor = initial.nextCursor;
+  let pagesRead = 1;
+
+  while (
+    minReviews !== undefined &&
+    count < minReviews &&
+    hasMore &&
+    nextCursor &&
+    pagesRead < MAX_REVIEW_PAGES
+  ) {
+    const page = await runCheck({
+      name: "review pagination",
+      runtimeUrl,
+      path: `/api/coding-agents/reviews?cursor=${encodeURIComponent(nextCursor)}`,
+      headers,
+      timeoutMs,
+      fetchImpl,
+      schema: ReviewListSchema,
+      contractName: "Review list",
+    });
+    count += page.items.length;
+    hasMore = page.hasMore;
+    nextCursor = page.nextCursor;
+    pagesRead += 1;
+  }
+
+  return count;
 }
 
 async function readBoundedText(response, name) {

--- a/specs/105-coding-agent-shells/completion-audit.md
+++ b/specs/105-coding-agent-shells/completion-audit.md
@@ -117,7 +117,7 @@ The real-runtime smoke helper checkpoint in PR #879 added repeatable read-only d
 - `bun run check:patterns`
 - `bun run typecheck`
 
-That helper validates authenticated deployed-runtime `summary`, `threads`, `reviews`, and `notification-preferences` responses through bounded schemas, preserves `/vm/<handle>` base paths, rejects token CLI arguments, redacts bearer material, caps response bodies, and prints no raw response bodies. It is not evidence that a human has completed the desktop or mobile visual smoke on a deployed runtime.
+That helper validates authenticated deployed-runtime `summary`, `threads`, `reviews`, and `notification-preferences` responses through bounded schemas, preserves `/vm/<handle>` base paths, rejects token CLI arguments, redacts bearer material, caps response bodies, and prints no raw response bodies. The stacked assertion slice keeps the helper read-only while adding optional checks for required capabilities, ready providers, minimum active thread/terminal/preview/review counts, review pagination, and an existing thread snapshot. It is not evidence that a human has completed the desktop or mobile visual smoke on a deployed runtime.
 
 ## Remaining Validation
 

--- a/specs/105-coding-agent-shells/current-state.md
+++ b/specs/105-coding-agent-shells/current-state.md
@@ -126,7 +126,7 @@ Post-merge checkpoint updates:
 
 - PR #868 confirmed mobile thread detail terminal handoff persists the bounded canonical terminal session reference needed by the Terminal route without persisting terminal output or transcript data.
 - PR #869 confirmed the desktop command-palette Agents entry still opens after terminal interaction, and menu-template tests cover the native Agents accelerator used to focus the same workspace.
-- PR #879 adds an opt-in real-runtime smoke helper at `scripts/coding-agents/real-runtime-smoke.mjs` that validates deployed `/api/coding-agents/summary`, `/threads`, `/reviews`, and `/notification-preferences` responses through bounded Zod schemas without writing runtime state. This is rollout hardening only; deployed desktop/mobile visual smoke remains a separate manual validation step.
+- PR #879 adds an opt-in real-runtime smoke helper at `scripts/coding-agents/real-runtime-smoke.mjs` that validates deployed `/api/coding-agents/summary`, `/threads`, `/reviews`, and `/notification-preferences` responses through bounded Zod schemas without writing runtime state. The stacked assertion slice keeps the helper read-only while adding optional capability, ready-provider, minimum summary count, minimum review count, and thread-snapshot assertions for deployed-runtime validation. This is rollout hardening only; deployed desktop/mobile visual smoke remains a separate manual validation step.
 
 ## Shared Contracts
 
@@ -576,6 +576,7 @@ Real-runtime smoke helper:
 
 ```bash
 MATRIX_RUNTIME_URL="https://app.matrix-os.com/vm/<handle>" MATRIX_RUNTIME_TOKEN="<short-lived runtime token>" node scripts/coding-agents/real-runtime-smoke.mjs
+MATRIX_RUNTIME_URL="https://app.matrix-os.com/vm/<handle>" MATRIX_RUNTIME_TOKEN="<short-lived runtime token>" node scripts/coding-agents/real-runtime-smoke.mjs --require-capability codingAgentsRuntimeSummary --require-ready-provider --min-terminal-sessions 1
 ```
 
 Desktop typecheck:

--- a/specs/105-coding-agent-shells/tasks.md
+++ b/specs/105-coding-agent-shells/tasks.md
@@ -22,7 +22,7 @@ As of the `056b3da668ed6d1753712120316d2d5accfafdcf` main checkpoint:
 - PR #869 desktop validation now confirms the command-palette Agents entry still opens after terminal interaction, and menu-template tests cover the native Agents accelerator used to focus the same workspace.
 - The mobile SDK 57 coding-agent device smoke runbook now lives in `docs/dev/mobile-shell.md`.
 - The desktop coding-agent real-runtime smoke runbook now lives in `docs/dev/coding-agent-shells.md`.
-- PR #879 adds an opt-in read-only real-runtime smoke helper for deployed `/api/coding-agents` route validation without writing runtime state.
+- PR #879 adds an opt-in read-only real-runtime smoke helper for deployed `/api/coding-agents` route validation without writing runtime state; the stacked assertion slice adds optional read-only capability/provider/count/snapshot checks for stricter deployed-runtime validation.
 - Remaining work is validation and rollout hardening: run the real-runtime smoke helper against a deployed Matrix computer, complete real-runtime desktop visual smoke, complete mobile SDK 57 device smoke, wire mobile workspace reference persistence into the new Agents cockpit, and continue docs sync as later provider/runtime behavior changes.
 
 That checkpoint is not the clarified final product. The active backlog now requires a project-first hierarchy, same-thread conversation turns, tasks with multiple threads, and Conversation/Kanban views. `acceptance-tests.md` is the authoritative test matrix for this follow-up work.

--- a/tests/scripts/coding-agent-real-runtime-smoke.test.ts
+++ b/tests/scripts/coding-agent-real-runtime-smoke.test.ts
@@ -105,6 +105,23 @@ const reviewSummary = {
   updatedAt: "2026-07-09T10:02:00Z",
 };
 
+const threadSnapshot = {
+  thread: runtimeSummary.activeThreads.items[0],
+  events: {
+    items: [
+      {
+        eventId: "evt_live_smoke_1",
+        threadId: "thread_live_smoke",
+        type: "thread.status",
+        status: "running",
+        occurredAt: "2026-07-09T10:01:00.000Z",
+      },
+    ],
+    hasMore: false,
+    limit: 200,
+  },
+};
+
 describe("coding-agent real runtime smoke helper", () => {
   it("normalizes runtime URLs to an HTTP(S) base path and rejects unsafe protocols", () => {
     expect(normalizeRuntimeUrl("https://app.matrix-os.com/vm/test?token=secret").toString()).toBe(
@@ -145,6 +162,51 @@ describe("coding-agent real runtime smoke helper", () => {
       token: "abc",
       projectId: "proj_1",
     });
+  });
+
+  it("creates config for read-only runtime assertions", () => {
+    expect(
+      createSmokeConfig(
+        [
+          "--url",
+          "https://runtime.test",
+          "--require-capability",
+          "codingAgentsRuntimeSummary",
+          "--require-capability",
+          "codingAgentsMobileWorkspace",
+          "--require-ready-provider",
+          "--require-thread-snapshot",
+          "--min-active-threads",
+          "1",
+          "--min-terminal-sessions",
+          "1",
+          "--min-preview-sessions",
+          "1",
+          "--min-reviews",
+          "2",
+        ],
+        { MATRIX_RUNTIME_TOKEN: "abc" },
+      ),
+    ).toMatchObject({
+      requiredCapabilities: ["codingAgentsRuntimeSummary", "codingAgentsMobileWorkspace"],
+      requireReadyProvider: true,
+      requireThreadSnapshot: true,
+      minActiveThreads: 1,
+      minTerminalSessions: 1,
+      minPreviewSessions: 1,
+      minReviews: 2,
+    });
+
+    expect(() =>
+      createSmokeConfig(["--url", "https://runtime.test", "--min-active-threads", "0"], {
+        MATRIX_RUNTIME_TOKEN: "abc",
+      }),
+    ).toThrow(/positive integer/);
+    expect(() =>
+      createSmokeConfig(["--url", "https://runtime.test", "--require-capability", "unknown"], {
+        MATRIX_RUNTIME_TOKEN: "abc",
+      }),
+    ).toThrow(/Invalid required capability/);
   });
 
   it("validates the summary, thread list, review list, and preferences without exposing body content", async () => {
@@ -197,6 +259,345 @@ describe("coding-agent real runtime smoke helper", () => {
       "https://runtime.test/api/coding-agents/reviews",
       "https://runtime.test/api/coding-agents/notification-preferences",
     ]);
+  });
+
+  it("validates read-only runtime assertions, review pagination, and thread snapshots", async () => {
+    const calls: string[] = [];
+    const summaryWithPreview = {
+      ...runtimeSummary,
+      previewSessions: {
+        items: [
+          {
+            id: "preview_live_smoke",
+            projectId: "proj_1",
+            label: "Preview",
+            status: "running",
+            origin: "https://preview.example.com",
+            updatedAt: "2026-07-09T10:02:00.000Z",
+          },
+        ],
+        hasMore: false,
+        limit: 50,
+      },
+    };
+    const fetchImpl = vi.fn(async (url: URL | string) => {
+      calls.push(String(url));
+      if (String(url).endsWith("/api/coding-agents/summary")) return jsonResponse(summaryWithPreview);
+      if (String(url).endsWith("/api/coding-agents/threads")) {
+        return jsonResponse({ items: runtimeSummary.activeThreads.items, hasMore: false, limit: 50 });
+      }
+      if (String(url).endsWith("/api/coding-agents/reviews")) {
+        return jsonResponse({ items: [reviewSummary], hasMore: true, nextCursor: "next_1", limit: 50 });
+      }
+      if (String(url).endsWith("/api/coding-agents/reviews?cursor=next_1")) {
+        return jsonResponse({
+          items: [{ ...reviewSummary, id: "rev_live_smoke_2", pullRequestNumber: 880 }],
+          hasMore: false,
+          limit: 50,
+        });
+      }
+      if (String(url).endsWith("/api/coding-agents/threads/thread_live_smoke")) return jsonResponse(threadSnapshot);
+      if (String(url).endsWith("/api/coding-agents/notification-preferences")) {
+        return jsonResponse({
+          preferences: {
+            attentionPush: {
+              approval: true,
+              input: true,
+              failed: true,
+              completed: true,
+            },
+          },
+        });
+      }
+      throw new Error(`unexpected URL ${String(url)}`);
+    });
+
+    const result = await runRuntimeSmoke({
+      runtimeUrl: new URL("https://runtime.test/"),
+      token: "secret-token",
+      fetchImpl,
+      requiredCapabilities: ["codingAgentsRuntimeSummary", "codingAgentsMobileWorkspace"],
+      requireReadyProvider: true,
+      requireThreadSnapshot: true,
+      minActiveThreads: 1,
+      minTerminalSessions: 1,
+      minPreviewSessions: 1,
+      minReviews: 2,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.checks.map((check) => check.name)).toEqual([
+      "runtime summary",
+      "thread list",
+      "review list",
+      "review pagination",
+      "notification preferences",
+      "thread snapshot",
+      "runtime requirements",
+    ]);
+    expect(result.checks.find((check) => check.name === "review pagination")).toMatchObject({
+      detail: "2 reviews checked",
+    });
+    expect(result.checks.find((check) => check.name === "runtime requirements")).toMatchObject({
+      detail: "8 read-only assertions checked",
+    });
+    expect(calls).toContain("https://runtime.test/api/coding-agents/reviews?cursor=next_1");
+    expect(calls).toContain("https://runtime.test/api/coding-agents/threads/thread_live_smoke");
+  });
+
+  it("fails read-only runtime assertions with generic recovery text", async () => {
+    const unavailableSummary = {
+      ...runtimeSummary,
+      capabilities: [{ id: "codingAgentsRuntimeSummary", enabled: false }],
+      providers: [
+        {
+          ...runtimeSummary.providers[0],
+          availability: "auth_required",
+          authStatus: "missing",
+        },
+      ],
+    };
+    const fetchImpl = vi.fn(async (url: URL | string) => {
+      if (String(url).endsWith("/api/coding-agents/summary")) return jsonResponse(unavailableSummary);
+      if (String(url).endsWith("/api/coding-agents/threads")) {
+        return jsonResponse({ items: runtimeSummary.activeThreads.items, hasMore: false, limit: 50 });
+      }
+      if (String(url).endsWith("/api/coding-agents/reviews")) {
+        return jsonResponse({ items: [], hasMore: false, limit: 50 });
+      }
+      if (String(url).endsWith("/api/coding-agents/notification-preferences")) {
+        return jsonResponse({
+          preferences: {
+            attentionPush: {
+              approval: true,
+              input: true,
+              failed: true,
+              completed: true,
+            },
+          },
+        });
+      }
+      throw new Error(`unexpected URL ${String(url)}`);
+    });
+
+    await expect(
+      runRuntimeSmoke({
+        runtimeUrl: new URL("https://runtime.test/"),
+        token: "secret-token",
+        fetchImpl,
+        requiredCapabilities: ["codingAgentsRuntimeSummary"],
+        requireReadyProvider: true,
+      }),
+    ).rejects.toMatchObject({
+      name: "SmokeFailure",
+      safeMessage: "runtime requirements unavailable. Refresh runtime state and try again.",
+    });
+  });
+
+  it("fails safely when a required thread snapshot is malformed", async () => {
+    const fetchImpl = vi.fn(async (url: URL | string) => {
+      if (String(url).endsWith("/api/coding-agents/summary")) return jsonResponse(runtimeSummary);
+      if (String(url).endsWith("/api/coding-agents/threads")) {
+        return jsonResponse({ items: runtimeSummary.activeThreads.items, hasMore: false, limit: 50 });
+      }
+      if (String(url).endsWith("/api/coding-agents/reviews")) {
+        return jsonResponse({ items: [], hasMore: false, limit: 50 });
+      }
+      if (String(url).endsWith("/api/coding-agents/threads/thread_live_smoke")) {
+        return jsonResponse({ thread: { id: "../unsafe" }, events: { items: [], hasMore: false, limit: 200 } });
+      }
+      if (String(url).endsWith("/api/coding-agents/notification-preferences")) {
+        return jsonResponse({
+          preferences: {
+            attentionPush: {
+              approval: true,
+              input: true,
+              failed: true,
+              completed: true,
+            },
+          },
+        });
+      }
+      throw new Error(`unexpected URL ${String(url)}`);
+    });
+
+    await expect(
+      runRuntimeSmoke({
+        runtimeUrl: new URL("https://runtime.test/"),
+        token: "secret-token",
+        fetchImpl,
+        requireThreadSnapshot: true,
+      }),
+    ).rejects.toMatchObject({
+      name: "SmokeFailure",
+      safeMessage: "Thread snapshot response did not match the Matrix coding-agent contract.",
+    });
+  });
+
+  it("keeps thread snapshot request descriptions aligned with the client contract", async () => {
+    const snapshotWithOverlongApproval = {
+      ...threadSnapshot,
+      events: {
+        items: [
+          {
+            eventId: "evt_live_smoke_2",
+            threadId: "thread_live_smoke",
+            type: "approval.requested",
+            occurredAt: "2026-07-09T10:01:00.000Z",
+            approval: {
+              approvalId: "appr_live_smoke",
+              threadId: "thread_live_smoke",
+              title: "Approve",
+              safeDescription: "a".repeat(601),
+              risk: "low",
+              actionKind: "command",
+              allowedDecisions: ["approve", "decline"],
+              correlationId: "corr_live_smoke",
+            },
+          },
+        ],
+        hasMore: false,
+        limit: 200,
+      },
+    };
+    const fetchImpl = vi.fn(async (url: URL | string) => {
+      if (String(url).endsWith("/api/coding-agents/summary")) return jsonResponse(runtimeSummary);
+      if (String(url).endsWith("/api/coding-agents/threads")) {
+        return jsonResponse({ items: runtimeSummary.activeThreads.items, hasMore: false, limit: 50 });
+      }
+      if (String(url).endsWith("/api/coding-agents/reviews")) {
+        return jsonResponse({ items: [], hasMore: false, limit: 50 });
+      }
+      if (String(url).endsWith("/api/coding-agents/threads/thread_live_smoke")) {
+        return jsonResponse(snapshotWithOverlongApproval);
+      }
+      if (String(url).endsWith("/api/coding-agents/notification-preferences")) {
+        return jsonResponse({
+          preferences: {
+            attentionPush: {
+              approval: true,
+              input: true,
+              failed: true,
+              completed: true,
+            },
+          },
+        });
+      }
+      throw new Error(`unexpected URL ${String(url)}`);
+    });
+
+    await expect(
+      runRuntimeSmoke({
+        runtimeUrl: new URL("https://runtime.test/"),
+        token: "secret-token",
+        fetchImpl,
+        requireThreadSnapshot: true,
+      }),
+    ).rejects.toMatchObject({
+      name: "SmokeFailure",
+      safeMessage: "Thread snapshot response did not match the Matrix coding-agent contract.",
+    });
+  });
+
+  it("rejects uppercase safe error codes in thread snapshot events", async () => {
+    const snapshotWithSafeError = {
+      ...threadSnapshot,
+      events: {
+        items: [
+          {
+            eventId: "evt_live_smoke_3",
+            threadId: "thread_live_smoke",
+            type: "thread.error",
+            occurredAt: "2026-07-09T10:01:00.000Z",
+            error: {
+              code: "NOT_FOUND",
+              safeMessage: "Thread state unavailable",
+              retryable: true,
+              recoveryActions: ["retry"],
+            },
+          },
+        ],
+        hasMore: false,
+        limit: 200,
+      },
+    };
+    const fetchImpl = vi.fn(async (url: URL | string) => {
+      if (String(url).endsWith("/api/coding-agents/summary")) return jsonResponse(runtimeSummary);
+      if (String(url).endsWith("/api/coding-agents/threads")) {
+        return jsonResponse({ items: runtimeSummary.activeThreads.items, hasMore: false, limit: 50 });
+      }
+      if (String(url).endsWith("/api/coding-agents/reviews")) {
+        return jsonResponse({ items: [], hasMore: false, limit: 50 });
+      }
+      if (String(url).endsWith("/api/coding-agents/threads/thread_live_smoke")) return jsonResponse(snapshotWithSafeError);
+      if (String(url).endsWith("/api/coding-agents/notification-preferences")) {
+        return jsonResponse({
+          preferences: {
+            attentionPush: {
+              approval: true,
+              input: true,
+              failed: true,
+              completed: true,
+            },
+          },
+        });
+      }
+      throw new Error(`unexpected URL ${String(url)}`);
+    });
+
+    await expect(
+      runRuntimeSmoke({
+        runtimeUrl: new URL("https://runtime.test/"),
+        token: "secret-token",
+        fetchImpl,
+        requireThreadSnapshot: true,
+      }),
+    ).rejects.toMatchObject({
+      name: "SmokeFailure",
+      safeMessage: "Thread snapshot response did not match the Matrix coding-agent contract.",
+    });
+  });
+
+  it("explains when a required snapshot has no active or attention thread", async () => {
+    const summaryWithoutThreads = {
+      ...runtimeSummary,
+      activeThreads: { items: [], hasMore: false, limit: 50 },
+      attentionThreads: { items: [], hasMore: false, limit: 50 },
+    };
+    const fetchImpl = vi.fn(async (url: URL | string) => {
+      if (String(url).endsWith("/api/coding-agents/summary")) return jsonResponse(summaryWithoutThreads);
+      if (String(url).endsWith("/api/coding-agents/threads")) {
+        return jsonResponse({ items: [], hasMore: false, limit: 50 });
+      }
+      if (String(url).endsWith("/api/coding-agents/reviews")) {
+        return jsonResponse({ items: [], hasMore: false, limit: 50 });
+      }
+      if (String(url).endsWith("/api/coding-agents/notification-preferences")) {
+        return jsonResponse({
+          preferences: {
+            attentionPush: {
+              approval: true,
+              input: true,
+              failed: true,
+              completed: true,
+            },
+          },
+        });
+      }
+      throw new Error(`unexpected URL ${String(url)}`);
+    });
+
+    await expect(
+      runRuntimeSmoke({
+        runtimeUrl: new URL("https://runtime.test/"),
+        token: "secret-token",
+        fetchImpl,
+        requireThreadSnapshot: true,
+      }),
+    ).rejects.toMatchObject({
+      name: "SmokeFailure",
+      safeMessage: "thread snapshot unavailable because no active or attention thread is available. Start or select a thread and try again.",
+    });
   });
 
   it("checks coding-agent routes under an explicit runtime base path", async () => {


### PR DESCRIPTION
Summary
- Extends the real-runtime smoke helper with optional read-only assertions for runtime capabilities, ready providers, summary counts, review pagination, and thread snapshot validation.
- Keeps the helper self-contained for direct Node execution and updates operator/spec validation notes.

Tests
- pnpm exec vitest run tests/scripts/coding-agent-real-runtime-smoke.test.ts
- git diff --check
- bun run check:patterns
- bun run typecheck
- forbidden-reference scan over touched helper, tests, docs, and specs

Review/Monitoring
- Stacked above #881 and based on branch 105-coding-agent-real-runtime-smoke-docs.
- Do not add ready-for-ci until Greptile reaches 5/5 on this PR head.