### PR TITLE
docs(coding-agents): add mobile device smoke runbook

### DIFF
--- a/docs/dev/coding-agent-shells.md
+++ b/docs/dev/coding-agent-shells.md
@@ -305,7 +305,7 @@ Before enabling a mobile coding-agent shell change broadly:
 1. Run the touched mobile Jest tests and `pnpm --filter matrix-os-mobile exec tsc --noEmit`.
 2. When the slice touches shared shell, gateway, or contract behavior, also run the matching gateway Vitest tests, shell typecheck, and the shell/mobile readiness tests listed in `docs/dev/mobile-shell.md`.
 3. Confirm mobile persisted state contains only bounded UI references.
-4. Open the Agents workspace, thread detail, approval/input controls, review/file detail, preview route, and bound terminal route in a dev client when the slice touches those surfaces.
+4. Run the Coding-Agent SDK 57 Device Smoke checklist in `docs/dev/mobile-shell.md` when the slice touches Agents workspace routing, thread detail, approval/input controls, review/file detail, preview routes, bound terminal routes, notification tap routing, offline/reconnect handling, or mobile persistence.
 5. Confirm Chat, Apps, Terminal, and Settings tabs still open.
 6. Keep the existing terminal fallback. Do not land native terminal replacement behavior without separate device validation.
 

--- a/docs/dev/mobile-shell.md
+++ b/docs/dev/mobile-shell.md
@@ -183,3 +183,89 @@ git diff --check
 - Confirm Continue restores the last app where possible.
 - Confirm unavailable apps show a generic fallback, not raw gateway or filesystem errors.
 - Confirm Terminal path, prompt/cursor, command input, and touch controls are visible in portrait and landscape.
+
+## Coding-Agent SDK 57 Device Smoke
+
+Use this checklist before broad rollout of mobile coding-agent shell changes, and
+whenever a release touches Agents workspace routing, terminal handoff, review
+details, previews, approvals, user input, push routing, or mobile persistence.
+Keep all evidence public-safe: do not paste bearer tokens, provider credentials,
+private hostnames, VPS IPs, raw provider output, terminal output, transcripts,
+file contents, diffs, approval payloads, launch tokens, or customer identifiers.
+
+### Automated Preflight
+
+Run the focused mobile coding-agent checks first:
+
+```bash
+pnpm --dir apps/mobile exec jest --runInBand __tests__/agents-screen.test.tsx __tests__/agent-thread-screen.test.tsx __tests__/agents-preview-screen.test.tsx __tests__/agent-workspace-state.test.ts __tests__/gateway-client.test.ts __tests__/push.test.ts
+pnpm --dir apps/mobile exec tsc --noEmit
+pnpm --dir apps/mobile run lint
+```
+
+If the slice touches terminal routing or terminal persistence, also run:
+
+```bash
+pnpm --dir apps/mobile exec jest --runInBand __tests__/terminal-client.test.ts __tests__/terminal-state.test.ts __tests__/terminal-screen.test.tsx __tests__/TerminalControlBar.test.tsx
+```
+
+If the slice touches shared contracts, gateway read models, or shell runtime
+summary behavior, run the matching gateway or contract tests listed in
+`docs/dev/coding-agent-shells.md` before moving to a phone.
+
+### Runtime Preflight
+
+1. Start a Matrix runtime that has coding-agent shell capabilities enabled.
+2. Validate the authenticated `/api/coding-agents/summary` runtime summary
+   using the runtime smoke command documented by the stack under test. Require
+   the mobile workspace capability and any capability changed by the slice.
+3. If the validation requires a running thread, create it from a disposable test
+   workspace first, then run the helper with the thread-snapshot assertion.
+4. Confirm failures are generic and recovery-oriented. Do not capture provider
+   raw errors, internal paths, private hostnames, or terminal output as evidence.
+
+### Phone Flow
+
+1. Launch the Expo SDK 57 dev client using the instructions above, then sign in
+   and select the intended Matrix computer.
+2. Confirm Chat, Mission Control, Terminal, Apps, and Settings still open from
+   the mobile shell.
+3. Open Apps, then open Agents. Confirm provider status, recent work, attention
+   threads, terminal summaries, and preview summaries hydrate from the gateway
+   without raw errors.
+4. Open a thread detail from Recent Work. Confirm the bounded timeline, newest
+   approval or input request, review links, and terminal references render from
+   the gateway snapshot.
+5. If using a disposable run, submit one approval decision or user-input answer
+   and confirm duplicate taps stay disabled while the request is in flight.
+   Confirm failure copy remains generic.
+6. Use a bound terminal action from Agents or thread detail. Confirm it opens the
+   existing Terminal tab and attaches to the canonical Matrix terminal session;
+   leaving Terminal must not end the underlying process.
+7. Open review, file, and preview routes from the thread or summary. Confirm
+   large or unavailable review data shows partial/recoverable UI, file content
+   reloads from the gateway, and preview failures stay generic.
+8. If push credentials are available on the test device, tap an attention
+   notification and confirm it opens the matching Agents route. If a live push
+   is not practical, rely on the mobile push tests and record that manual push
+   tap routing was deferred.
+9. Toggle the phone offline, keep the Agents workspace visible, and confirm the
+   shell shows a reconnecting or offline state while preserving the last
+   hydrated bounded summary. Reconnect and refresh the thread.
+10. Fully close and reopen the app. Confirm only bounded UI references restore,
+    such as selected thread, review, preview, or terminal IDs. Thread snapshots,
+    transcripts, terminal output, file contents, diffs, approval payloads,
+    credentials, and launch tokens must reload from the gateway or remain absent.
+11. Recheck Chat, Apps, Terminal, and Settings after the Agents pass.
+
+### Evidence To Record
+
+- Branch name, commit, device OS version, and whether the dev client was rebuilt
+  or only Metro was reloaded.
+- Exact automated commands and pass/fail results.
+- Runtime preflight result with sanitized capability names and counts only.
+- Manual phone-flow pass/fail notes with screenshots only when they do not show
+  secrets, raw terminal output, file contents, diffs, or private infrastructure
+  details.
+- Any deferred manual step with the reason and the automated test that still
+  covers the behavior.

--- a/specs/105-coding-agent-shells/completion-audit.md
+++ b/specs/105-coding-agent-shells/completion-audit.md
@@ -112,7 +112,7 @@ That automated desktop smoke now also covers opening the Agents workspace from t
 ## Remaining Validation
 
 - Run manual desktop smoke against a real Matrix computer for runtime switch, native menu entry points, review/file/preview paths, notification click-through, non-stub provider setup, and cross-shell terminal binding. The automated desktop operator smoke now covers sign-in, project board, terminal attach, current Agents workspace create, command-palette Agents entry, Terminal, Apps, Settings, Chat, and hosted-shell detach through the stub gateway.
-- Run manual mobile SDK 57 device smoke for chat, mission control, terminal, apps, agents workspace, thread detail, terminal handoff, review/file/preview paths, approvals/input, notification tap routing, offline/reconnect state, and persisted safe references.
+- Run the manual mobile SDK 57 device smoke checklist in `docs/dev/mobile-shell.md` for chat, mission control, terminal, apps, agents workspace, thread detail, terminal handoff, review/file/preview paths, approvals/input, notification tap routing, offline/reconnect state, and persisted safe references.
 - Keep `docs/dev/coding-agent-shells.md`, `www/content/docs/coding-agents.mdx`, and this audit synchronized when provider/runtime behavior changes.
 
 ## Security Notes

--- a/specs/105-coding-agent-shells/tasks.md
+++ b/specs/105-coding-agent-shells/tasks.md
@@ -20,7 +20,8 @@ As of the `056b3da668ed6d1753712120316d2d5accfafdcf` main checkpoint:
 - PR #866 desktop operator e2e smoke validation now covers the stubbed sign-in/device-auth flow, project board hydration, canonical terminal attach and echo, the current Agents workspace summary/create path, Terminal Shells, Apps, Settings, Chat, and hosted-shell detach behavior.
 - PR #868 mobile validation now confirms thread detail terminal handoff persists the bounded canonical terminal session reference needed by the mobile Terminal route without persisting terminal output or transcript data.
 - PR #869 desktop validation now confirms the command-palette Agents entry still opens after terminal interaction, and menu-template tests cover the native Agents accelerator used to focus the same workspace.
-- Remaining work is validation and rollout hardening: real-runtime desktop smoke, mobile SDK 57 device smoke, and continued docs sync as later provider/runtime behavior changes.
+- The mobile SDK 57 coding-agent device smoke runbook now lives in `docs/dev/mobile-shell.md`.
+- Remaining work is validation and rollout hardening: real-runtime desktop smoke, manual mobile SDK 57 device smoke, mobile workspace reference persistence wired into the new Agents cockpit, and continued docs sync as later provider/runtime behavior changes.
 
 That checkpoint is not the clarified final product. The active backlog now requires a project-first hierarchy, same-thread conversation turns, tasks with multiple threads, and Conversation/Kanban views. `acceptance-tests.md` is the authoritative test matrix for this follow-up work.
 


### PR DESCRIPTION
## Summary
- add a Mobile Shell runbook for SDK 57 coding-agent real-device smoke validation
- cross-link coding-agent mobile validation to the new checklist
- record in the 105 audit/tasks that the runbook exists while manual device smoke remains outstanding

## Tests
- git diff --check
- rg -n "t3code|reference repo|private reference" docs/dev/mobile-shell.md docs/dev/coding-agent-shells.md specs/105-coding-agent-shells/completion-audit.md specs/105-coding-agent-shells/tasks.md (no matches)
- bun run check:patterns (passed with existing warnings, 0 violations)

Skipped mobile Jest/tsc because this PR changes only documentation and specs.

## Review/Monitoring
- Stacked above #878 (`105-mobile-agent-workspace-state-docs`).
- Will wait for Greptile 5/5 before adding `ready-for-ci`.