### PR TITLE
docs(coding-agents): add desktop runtime smoke runbook

### DIFF
--- a/docs/dev/coding-agent-shells.md
+++ b/docs/dev/coding-agent-shells.md
@@ -298,6 +298,86 @@ Checks:
 4. Runtime or project switches should clear stale preview rows before new data loads.
 5. If a preview is stale, refresh the runtime summary rather than trusting a persisted client reference.
 
+### Desktop Validation
+
+Before enabling a desktop coding-agent shell change broadly:
+
+1. Run the touched desktop unit or renderer tests and `pnpm --filter desktop run typecheck`.
+2. When the slice touches shared shell, gateway, or contract behavior, also run the matching gateway Vitest tests, shell typecheck, and desktop operator smoke listed below.
+3. Confirm desktop renderer state and IPC payloads contain only validated summaries, snapshots, and bounded UI references. Bearer credentials, provider credentials, raw provider errors, terminal output, file contents beyond transient editor state, and unbounded transcripts must stay out of renderer persistence.
+4. Run the Manual Desktop Real-Runtime Smoke checklist below when the slice touches runtime switching, native menu or command-palette entry points, Agents workspace routing, provider setup actions, thread detail, approval/input controls, review/file/preview routes, notification click-through, desktop badge counts, or terminal binding.
+5. Confirm Terminal Shells, Apps, Settings, Chat, hosted shell embeds, updater entry points, deep links, and window/menu behavior still work after the Agents pass.
+
+#### Automated Desktop Preflight
+
+Use the smallest focused set for the touched surface first. These are the current desktop coding-agent gates:
+
+```bash
+pnpm exec vitest run tests/desktop/coding-agent-runtime-client.test.ts tests/desktop/coding-agent-thread-stream.test.ts tests/desktop/coding-agent-workspace.test.tsx tests/desktop/ipc-contract.test.ts
+pnpm exec vitest run tests/desktop/menu-template.test.ts tests/desktop/shortcuts.test.ts tests/desktop/command-palette.test.tsx
+pnpm --filter desktop run typecheck
+```
+
+If the slice changes the desktop end-to-end shell path, also run:
+
+```bash
+xvfb-run -a bun run test:e2e tests/e2e/desktop/operator.e2e.test.ts
+```
+
+For release-parity packaging or trusted main-process changes, add:
+
+```bash
+bun run build:desktop
+```
+
+### Manual Desktop Real-Runtime Smoke
+
+Use this checklist against a real Matrix computer before broad rollout of
+desktop coding-agent shell changes. Keep evidence public-safe: do not paste
+bearer tokens, provider credentials, private hostnames, VPS IPs, raw provider
+output, terminal output, transcripts, file contents, diffs, approval payloads,
+launch tokens, or customer identifiers.
+
+1. Launch the desktop app from the branch or packaged artifact under test, sign
+   in, and select the intended Matrix computer. If multiple runtimes are
+   available, switch runtimes once and confirm Agents rehydrates from the newly
+   selected runtime.
+2. Open Agents from the sidebar, command palette, and native menu or shortcut.
+   Confirm each entry point focuses the same gateway-backed workspace instead
+   of a legacy local composer.
+3. Confirm the workspace hydrates provider status, active threads, attention
+   threads, terminal summaries, review summaries, and preview summaries from
+   the gateway without raw errors.
+4. If a provider requires setup, use the foreground setup action. Confirm it
+   opens a canonical terminal session and does not expose setup commands,
+   credentials, or provider raw errors in renderer state or screenshots.
+5. Open an existing thread, or create a disposable test thread only when a
+   provider is ready. Confirm the detail snapshot loads, event grouping is
+   bounded, stream updates do not duplicate replayed events, and unresolved
+   approval/input controls stay idempotent while a request is in flight.
+6. Use a bound terminal action from Agents or thread detail. Confirm it opens
+   the existing Terminal tab/model for the canonical Matrix terminal session;
+   detaching or leaving the tab must not terminate the underlying process.
+7. Open review, file, and preview surfaces. Confirm review/file content loads
+   through trusted IPC, file edits remain transient until saved through the
+   gateway, large/partial data shows recoverable UI, HTTPS previews open through
+   safe desktop open paths, and failures remain generic.
+8. Trigger or simulate a coding-agent attention notification with a bounded
+   thread reference. Confirm clicking the native notification focuses the
+   Agents workspace and visibly selects the matching thread. Confirm the badge
+   count reflects bounded gateway-owned attention state and uses overflow
+   behavior when the list is truncated.
+9. Put the runtime in an unavailable or offline state, or switch away from it,
+   then return. Confirm stale thread, terminal, review, and preview references
+   are dropped or shown as recoverable, and the UI rehydrates from the gateway
+   instead of trusting local renderer state.
+10. Recheck Terminal Shells, Apps, Settings, Chat, hosted shell embeds, updater
+    entry points, deep links, native menus, shortcuts, and window restore after
+    the Agents pass.
+11. Record branch, commit, desktop app build type, selected validation commands,
+    pass/fail notes, and any deferred manual step with the automated or manual
+    coverage that still applies.
+
 ### Mobile Validation
 
 Before enabling a mobile coding-agent shell change broadly:

--- a/docs/dev/mobile-shell.md
+++ b/docs/dev/mobile-shell.md
@@ -256,7 +256,8 @@ summary behavior, run the matching gateway or contract tests listed in
     such as selected thread, review, preview, or terminal IDs. Thread snapshots,
     transcripts, terminal output, file contents, diffs, approval payloads,
     credentials, and launch tokens must reload from the gateway or remain absent.
-11. Recheck Chat, Apps, Terminal, and Settings after the Agents pass.
+11. Recheck Chat, Mission Control, Terminal, Apps, and Settings after the Agents
+    pass.
 
 ### Evidence To Record
 

--- a/specs/105-coding-agent-shells/completion-audit.md
+++ b/specs/105-coding-agent-shells/completion-audit.md
@@ -111,7 +111,7 @@ That automated desktop smoke now also covers opening the Agents workspace from t
 
 ## Remaining Validation
 
-- Run manual desktop smoke against a real Matrix computer for runtime switch, native menu entry points, review/file/preview paths, notification click-through, non-stub provider setup, and cross-shell terminal binding. The automated desktop operator smoke now covers sign-in, project board, terminal attach, current Agents workspace create, command-palette Agents entry, Terminal, Apps, Settings, Chat, and hosted-shell detach through the stub gateway.
+- Run the Manual Desktop Real-Runtime Smoke checklist in `docs/dev/coding-agent-shells.md` against a real Matrix computer for runtime switch, native menu entry points, review/file/preview paths, notification click-through, non-stub provider setup, and cross-shell terminal binding. The automated desktop operator smoke now covers sign-in, project board, terminal attach, current Agents workspace create, command-palette Agents entry, Terminal, Apps, Settings, Chat, and hosted-shell detach through the stub gateway.
 - Run the manual mobile SDK 57 device smoke checklist in `docs/dev/mobile-shell.md` for chat, mission control, terminal, apps, agents workspace, thread detail, terminal handoff, review/file/preview paths, approvals/input, notification tap routing, offline/reconnect state, and persisted safe references.
 - Keep `docs/dev/coding-agent-shells.md`, `www/content/docs/coding-agents.mdx`, and this audit synchronized when provider/runtime behavior changes.
 

--- a/specs/105-coding-agent-shells/tasks.md
+++ b/specs/105-coding-agent-shells/tasks.md
@@ -21,7 +21,8 @@ As of the `056b3da668ed6d1753712120316d2d5accfafdcf` main checkpoint:
 - PR #868 mobile validation now confirms thread detail terminal handoff persists the bounded canonical terminal session reference needed by the mobile Terminal route without persisting terminal output or transcript data.
 - PR #869 desktop validation now confirms the command-palette Agents entry still opens after terminal interaction, and menu-template tests cover the native Agents accelerator used to focus the same workspace.
 - The mobile SDK 57 coding-agent device smoke runbook now lives in `docs/dev/mobile-shell.md`.
-- Remaining work is validation and rollout hardening: real-runtime desktop smoke, manual mobile SDK 57 device smoke, mobile workspace reference persistence wired into the new Agents cockpit, and continued docs sync as later provider/runtime behavior changes.
+- The desktop coding-agent real-runtime smoke runbook now lives in `docs/dev/coding-agent-shells.md`.
+- Remaining work is validation and rollout hardening: manual real-runtime desktop smoke, manual mobile SDK 57 device smoke, mobile workspace reference persistence wired into the new Agents cockpit, and continued docs sync as later provider/runtime behavior changes.
 
 That checkpoint is not the clarified final product. The active backlog now requires a project-first hierarchy, same-thread conversation turns, tasks with multiple threads, and Conversation/Kanban views. `acceptance-tests.md` is the authoritative test matrix for this follow-up work.
 


### PR DESCRIPTION
## Summary
- add a desktop coding-agent validation section and Manual Desktop Real-Runtime Smoke checklist
- cross-link the 105 completion audit/tasks to the new desktop checklist
- carry forward the mobile SDK 57 runbook tab-list consistency cleanup above #884

## Tests
- git diff --check
- rg -n "t3code|reference repo|private reference" docs/dev/coding-agent-shells.md docs/dev/mobile-shell.md specs/105-coding-agent-shells/completion-audit.md specs/105-coding-agent-shells/tasks.md (no matches)
- bun run check:patterns (passed with existing warnings, 0 violations)

Skipped desktop/mobile runtime tests because this PR changes only documentation and spec notes.

## Review/Monitoring
- Stacked above #884 (`105-mobile-coding-agent-device-smoke`).
- Will wait for Greptile 5/5 before adding `ready-for-ci`.