### PR TITLE
fix(coding-agents): redact gateway diagnostics

### DIFF
--- a/docs/dev/coding-agent-shells.md
+++ b/docs/dev/coding-agent-shells.md
@@ -56,6 +56,10 @@ Provider-specific behavior belongs behind the gateway provider adapter interface
 - Normalize start, abort, status, tool activity, approvals, input requests, and completion into shared thread events.
 - Enforce timeouts or `AbortSignal` on external calls.
 - Return generic client errors while logging provider details server-side only.
+- Log coding-agent gateway failures through `logCodingAgentWarning()` from
+  `packages/gateway/src/coding-agents/diagnostics.ts` so server diagnostics keep
+  coarse scope and error type while redacting tokens, owner paths, URLs, private
+  hosts, and database details.
 - Use foreground terminal setup actions when user interaction is required.
 - Avoid provider-specific branches in shell components unless the shared contract explicitly exposes safe metadata.
 
@@ -141,6 +145,9 @@ Use this checklist for every coding-agent shell PR:
 - WebSocket auth completes before success frames, frame size is capped, subscribers are capped, stale subscribers are swept, and shutdown drains subscribers.
 - Lists are bounded before response.
 - Errors sent to clients are generic and safe.
+- Server diagnostics for coding-agent routes, summary adapters, streams,
+  provider lifecycle, and notification bridges use the bounded redacted
+  diagnostic helper instead of raw `err.message` logging.
 - Desktop renderer never receives bearer credentials or provider credentials.
 - Mobile AsyncStorage contains only bounded safe references.
 - Terminal/session behavior reuses canonical Matrix terminal primitives.

--- a/packages/gateway/src/coding-agents/attention-notifications.ts
+++ b/packages/gateway/src/coding-agents/attention-notifications.ts
@@ -5,6 +5,7 @@ import {
   type CodingAgentAttentionNotificationKind,
 } from "@matrix-os/contracts";
 import type { ChannelReply } from "../channels/types.js";
+import { logCodingAgentWarning } from "./diagnostics.js";
 import type { CodingAgentThreadStore } from "./thread-store.js";
 
 const PUSH_CHAT_ID = "coding-agents";
@@ -117,7 +118,7 @@ export function registerCodingAgentAttentionNotifications(options: CodingAgentAt
     function sendIfEligible(): void {
       if (!remember(dedupeKey, now())) return;
       void options.send(safeNotification).catch((err: unknown) => {
-        console.warn("[coding-agents] attention notification failed:", err instanceof Error ? err.message : String(err));
+        logCodingAgentWarning("attention notification failed", err);
       });
     }
 
@@ -128,7 +129,7 @@ export function registerCodingAgentAttentionNotifications(options: CodingAgentAt
           sendIfEligible();
         })
         .catch((err: unknown) => {
-          console.warn("[coding-agents] attention notification preference check failed:", err instanceof Error ? err.message : String(err));
+          logCodingAgentWarning("attention notification preference check failed", err);
         });
       return;
     }

--- a/packages/gateway/src/coding-agents/diagnostics.ts
+++ b/packages/gateway/src/coding-agents/diagnostics.ts
@@ -12,11 +12,12 @@ export interface CodingAgentDiagnostic {
 
 const URL_PATTERN = /\b[a-z][a-z0-9+.-]*:\/\/[^\s"'<>]+/gi;
 const BEARER_PATTERN = /\bBearer\s+[A-Za-z0-9._~+/=-]+/gi;
-const SECRET_ASSIGNMENT_PATTERN = /\b(?:authorization|api[_-]?key|access[_-]?token|refresh[_-]?token|token|password|passwd|secret)\s*[:=]\s*[^\s"'<>]+/gi;
+const SECRET_ASSIGNMENT_PATTERN = /\b(authorization|api[_-]?key|access[_-]?token|refresh[_-]?token|token|password|passwd|secret)(\s*[:=]\s*)(?:"(?:\\.|[^"\\\r\n])*"|'(?:\\.|[^'\\\r\n])*'|[^\s"'<>]+)/gi;
 const KNOWN_SECRET_PREFIX_PATTERN = /\b(?:sk|sk_live|sk_test|ghp|github_pat|xoxb|xoxp|xoxa|xoxr|glpat|hf)[_-][A-Za-z0-9._-]{4,}\b/gi;
 const OWNER_PATH_PATTERN = /(?:^|[\s"'(:])(?:\/(?:home|Users|private|tmp|var|opt|etc|root|run)\/[^\s"'<>)]*)/g;
 const WINDOWS_PATH_PATTERN = /\b[A-Za-z]:\\[^\s"'<>)]*/g;
-const PRIVATE_IPV4_PATTERN = /\b(?:(?:10|127)\.\d{1,3}\.\d{1,3}\.\d{1,3}|172\.(?:1[6-9]|2\d|3[0-1])\.\d{1,3}\.\d{1,3}|192\.168\.\d{1,3}\.\d{1,3})\b/g;
+const PRIVATE_IPV4_PATTERN = /\b(?:(?:10|127)\.\d{1,3}\.\d{1,3}\.\d{1,3}|169\.254\.\d{1,3}\.\d{1,3}|172\.(?:1[6-9]|2\d|3[0-1])\.\d{1,3}\.\d{1,3}|192\.168\.\d{1,3}\.\d{1,3})\b/g;
+const PRIVATE_IPV6_PATTERN = /(?<![A-Fa-f0-9:])(?:::1|(?:f[cd][A-Fa-f0-9]{2}|fe[89ab][A-Fa-f0-9])(?::[A-Fa-f0-9]{0,4}){1,7})(?:%[A-Za-z0-9_.-]+)?(?![A-Fa-f0-9:])/gi;
 const HOST_VALUE_PATTERN = /\b(?:host|hostname)\s*[:=]?\s*[A-Za-z0-9.-]*(?:\.local|\.internal|\.lan|\.home|runtime|matrix|vps)[A-Za-z0-9.-]*/gi;
 const DATABASE_PATTERN = /\b(?:postgres(?:ql)?|kysely|database|db)\b/gi;
 
@@ -35,15 +36,14 @@ export function redactCodingAgentDiagnosticText(value: unknown): string {
   const redacted = raw
     .replace(URL_PATTERN, "[url]")
     .replace(BEARER_PATTERN, "Bearer [token]")
-    .replace(SECRET_ASSIGNMENT_PATTERN, (match) => {
-      const separator = match.includes(":") ? ":" : "=";
-      const key = match.split(separator)[0]?.trim() || "token";
-      return `${key}${separator} [token]`;
+    .replace(SECRET_ASSIGNMENT_PATTERN, (_match, key: string, separator: string) => {
+      return `${key}${separator.trim()} [token]`;
     })
     .replace(KNOWN_SECRET_PREFIX_PATTERN, "[token]")
     .replace(OWNER_PATH_PATTERN, (match) => `${match[0] === "/" ? "" : match[0]}[path]`)
     .replace(WINDOWS_PATH_PATTERN, "[path]")
     .replace(PRIVATE_IPV4_PATTERN, "[host]")
+    .replace(PRIVATE_IPV6_PATTERN, "[host]")
     .replace(HOST_VALUE_PATTERN, (match) => {
       const prefix = match.match(/^(host|hostname)\s*[:=]?/i)?.[0] ?? "host ";
       return `${prefix}[host]`;

--- a/packages/gateway/src/coding-agents/diagnostics.ts
+++ b/packages/gateway/src/coding-agents/diagnostics.ts
@@ -12,7 +12,7 @@ export interface CodingAgentDiagnostic {
 
 const URL_PATTERN = /\b[a-z][a-z0-9+.-]*:\/\/[^\s"'<>]+/gi;
 const BEARER_PATTERN = /\bBearer\s+[A-Za-z0-9._~+/=-]+/gi;
-const SECRET_ASSIGNMENT_PATTERN = /\b(authorization|api[_-]?key|access[_-]?token|refresh[_-]?token|token|password|passwd|secret)(\s*[:=]\s*)(?:"(?:\\.|[^"\\\r\n])*"|'(?:\\.|[^'\\\r\n])*'|[^\s"'<>]+)/gi;
+const SECRET_ASSIGNMENT_PATTERN = /\b((?:[A-Za-z][A-Za-z0-9]*[_-])*(?:authorization|api[_-]?key|access[_-]?token|refresh[_-]?token|auth[_-]?token|token|password|passwd|secret))(\s*[:=]\s*)(?:(?:Basic|Bearer|Digest)\s+[^\s"'<>]+|"(?:\\.|[^"\\\r\n])*"|'(?:\\.|[^'\\\r\n])*'|[^\s"'<>]+)/gi;
 const KNOWN_SECRET_PREFIX_PATTERN = /\b(?:sk|sk_live|sk_test|ghp|github_pat|xoxb|xoxp|xoxa|xoxr|glpat|hf)[_-][A-Za-z0-9._-]{4,}\b/gi;
 const OWNER_PATH_PATTERN = /(?:^|[\s"'(:])(?:\/(?:home|Users|private|tmp|var|opt|etc|root|run)\/[^\s"'<>)]*)/g;
 const WINDOWS_PATH_PATTERN = /\b[A-Za-z]:\\[^\s"'<>)]*/g;

--- a/packages/gateway/src/coding-agents/diagnostics.ts
+++ b/packages/gateway/src/coding-agents/diagnostics.ts
@@ -12,7 +12,7 @@ export interface CodingAgentDiagnostic {
 
 const URL_PATTERN = /\b[a-z][a-z0-9+.-]*:\/\/[^\s"'<>]+/gi;
 const BEARER_PATTERN = /\bBearer\s+[A-Za-z0-9._~+/=-]+/gi;
-const SECRET_ASSIGNMENT_PATTERN = /\b((?:[A-Za-z][A-Za-z0-9]*[_-])*(?:authorization|api[_-]?key|access[_-]?token|refresh[_-]?token|auth[_-]?token|token|password|passwd|secret))(\s*[:=]\s*)(?:(?:Basic|Bearer|Digest)\s+[^\s"'<>]+|"(?:\\.|[^"\\\r\n])*"|'(?:\\.|[^'\\\r\n])*'|[^\s"'<>]+)/gi;
+const ASSIGNMENT_PATTERN = /\b([A-Za-z][A-Za-z0-9_-]{0,127})(\s*[:=]\s*)(?:(?:Basic|Bearer|Digest)\s+[^\s"'<>]+|"(?:\\.|[^"\\\r\n])*"|'(?:\\.|[^'\\\r\n])*'|[^\s"'<>]+)/gi;
 const KNOWN_SECRET_PREFIX_PATTERN = /\b(?:sk|sk_live|sk_test|ghp|github_pat|xoxb|xoxp|xoxa|xoxr|glpat|hf)[_-][A-Za-z0-9._-]{4,}\b/gi;
 const OWNER_PATH_PATTERN = /(?:^|[\s"'(:])(?:\/(?:home|Users|private|tmp|var|opt|etc|root|run)\/[^\s"'<>)]*)/g;
 const WINDOWS_PATH_PATTERN = /\b[A-Za-z]:\\[^\s"'<>)]*/g;
@@ -30,13 +30,30 @@ function normalizeDiagnosticText(value: string): string {
   return value.replace(/\s+/g, " ").trim();
 }
 
+function isSecretAssignmentKey(key: string): boolean {
+  const segments = key.toLowerCase().split(/[_-]+/);
+  if (segments.some((segment) => ["authorization", "credential", "credentials", "passwd", "password", "secret", "token"].includes(segment))) {
+    return true;
+  }
+
+  const flattened = segments.join("");
+  if (["apikey", "accesstoken", "authtoken", "pgpassword", "refreshtoken"].includes(flattened)) {
+    return true;
+  }
+
+  return segments.some(
+    (segment, index) => ["access", "api", "private"].includes(segment) && segments[index + 1] === "key",
+  );
+}
+
 export function redactCodingAgentDiagnosticText(value: unknown): string {
   const raw = normalizeDiagnosticText(typeof value === "string" ? value : String(value));
   if (!raw) return "unavailable";
   const redacted = raw
     .replace(URL_PATTERN, "[url]")
     .replace(BEARER_PATTERN, "Bearer [token]")
-    .replace(SECRET_ASSIGNMENT_PATTERN, (_match, key: string, separator: string) => {
+    .replace(ASSIGNMENT_PATTERN, (match, key: string, separator: string) => {
+      if (!isSecretAssignmentKey(key)) return match;
       return `${key}${separator.trim()} [token]`;
     })
     .replace(KNOWN_SECRET_PREFIX_PATTERN, "[token]")

--- a/packages/gateway/src/coding-agents/diagnostics.ts
+++ b/packages/gateway/src/coding-agents/diagnostics.ts
@@ -1,3 +1,4 @@
+const MAX_DIAGNOSTIC_INPUT_LENGTH = 4_096;
 const MAX_DIAGNOSTIC_MESSAGE_LENGTH = 180;
 const MAX_DIAGNOSTIC_NAME_LENGTH = 48;
 
@@ -12,7 +13,7 @@ export interface CodingAgentDiagnostic {
 
 const URL_PATTERN = /\b[a-z][a-z0-9+.-]*:\/\/[^\s"'<>]+/gi;
 const BEARER_PATTERN = /\bBearer\s+[A-Za-z0-9._~+/=-]+/gi;
-const AUTHORIZATION_ASSIGNMENT_PATTERN = /\b(authorization)(\s*[:=]\s*)(?:"(?:\\.|[^"\\\r\n])*"|'(?:\\.|[^'\\\r\n])*'|[A-Za-z][A-Za-z0-9._-]{0,31}\s+[^\s"'<>]+|[^\s"'<>]+)/gi;
+const AUTHORIZATION_ASSIGNMENT_PATTERN = /\b(authorization)(\s*[:=]\s*)[^\r\n]+/gi;
 const ASSIGNMENT_PATTERN = /\b([A-Za-z][A-Za-z0-9_-]{0,127})(\s*[:=]\s*)(?:(?:Basic|Bearer|Digest)\s+[^\s"'<>]+|"(?:\\.|[^"\\\r\n])*"|'(?:\\.|[^'\\\r\n])*'|[^\s"'<>]+)/gi;
 const KNOWN_SECRET_PREFIX_PATTERN = /\b(?:sk|sk_live|sk_test|ghp|github_pat|xoxb|xoxp|xoxa|xoxr|glpat|hf)[_-][A-Za-z0-9._-]{4,}\b/gi;
 const OWNER_PATH_PATTERN = /(?:^|[\s"'(:])(?:\/(?:home|Users|private|tmp|var|opt|etc|root|run)\/[^\s"'<>)]*)/g;
@@ -33,7 +34,11 @@ function normalizeDiagnosticText(value: string): string {
 }
 
 function isSecretAssignmentKey(key: string): boolean {
-  const segments = key.toLowerCase().split(/[_-]+/);
+  const segments = key
+    .replace(/([a-z0-9])([A-Z])/g, "$1_$2")
+    .replace(/([A-Z]+)([A-Z][a-z])/g, "$1_$2")
+    .toLowerCase()
+    .split(/[_-]+/);
   if (segments.some((segment) => ["authorization", "credential", "credentials", "passwd", "password", "secret", "token"].includes(segment))) {
     return true;
   }
@@ -49,9 +54,9 @@ function isSecretAssignmentKey(key: string): boolean {
 }
 
 export function redactCodingAgentDiagnosticText(value: unknown): string {
-  const raw = normalizeDiagnosticText(typeof value === "string" ? value : String(value));
-  if (!raw) return "unavailable";
-  const redacted = raw
+  const input = (typeof value === "string" ? value : String(value)).slice(0, MAX_DIAGNOSTIC_INPUT_LENGTH);
+  if (!normalizeDiagnosticText(input)) return "unavailable";
+  const redacted = input
     .replace(URL_PATTERN, "[url]")
     .replace(BEARER_PATTERN, "Bearer [token]")
     .replace(AUTHORIZATION_ASSIGNMENT_PATTERN, (_match, key: string, separator: string) => {

--- a/packages/gateway/src/coding-agents/diagnostics.ts
+++ b/packages/gateway/src/coding-agents/diagnostics.ts
@@ -1,0 +1,79 @@
+const MAX_DIAGNOSTIC_MESSAGE_LENGTH = 180;
+const MAX_DIAGNOSTIC_NAME_LENGTH = 48;
+
+export interface CodingAgentDiagnosticLogger {
+  warn(message: string, diagnostic?: CodingAgentDiagnostic): void;
+}
+
+export interface CodingAgentDiagnostic {
+  name: string;
+  message: string;
+}
+
+const URL_PATTERN = /\b[a-z][a-z0-9+.-]*:\/\/[^\s"'<>]+/gi;
+const BEARER_PATTERN = /\bBearer\s+[A-Za-z0-9._~+/=-]+/gi;
+const SECRET_ASSIGNMENT_PATTERN = /\b(?:authorization|api[_-]?key|access[_-]?token|refresh[_-]?token|token|password|passwd|secret)\s*[:=]\s*[^\s"'<>]+/gi;
+const KNOWN_SECRET_PREFIX_PATTERN = /\b(?:sk|sk_live|sk_test|ghp|github_pat|xoxb|xoxp|xoxa|xoxr|glpat|hf)[_-][A-Za-z0-9._-]{4,}\b/gi;
+const OWNER_PATH_PATTERN = /(?:^|[\s"'(:])(?:\/(?:home|Users|private|tmp|var|opt|etc|root)\/[^\s"'<>)]*)/g;
+const WINDOWS_PATH_PATTERN = /\b[A-Za-z]:\\[^\s"'<>)]*/g;
+const PRIVATE_IPV4_PATTERN = /\b(?:(?:10|127)\.\d{1,3}\.\d{1,3}\.\d{1,3}|172\.(?:1[6-9]|2\d|3[0-1])\.\d{1,3}\.\d{1,3}|192\.168\.\d{1,3}\.\d{1,3})\b/g;
+const HOST_VALUE_PATTERN = /\b(?:host|hostname)\s*[:=]?\s*[A-Za-z0-9.-]*(?:\.local|\.internal|\.lan|\.home|runtime|matrix|vps)[A-Za-z0-9.-]*/gi;
+const DATABASE_PATTERN = /\b(?:postgres(?:ql)?|kysely|database|db)\b/gi;
+
+function capDiagnosticText(value: string): string {
+  if (value.length <= MAX_DIAGNOSTIC_MESSAGE_LENGTH) return value;
+  return `${value.slice(0, MAX_DIAGNOSTIC_MESSAGE_LENGTH - 3)}...`;
+}
+
+function normalizeDiagnosticText(value: string): string {
+  return value.replace(/\s+/g, " ").trim();
+}
+
+export function redactCodingAgentDiagnosticText(value: unknown): string {
+  const raw = normalizeDiagnosticText(typeof value === "string" ? value : String(value));
+  if (!raw) return "unavailable";
+  const redacted = raw
+    .replace(URL_PATTERN, "[url]")
+    .replace(BEARER_PATTERN, "Bearer [token]")
+    .replace(SECRET_ASSIGNMENT_PATTERN, (match) => {
+      const separator = match.includes(":") ? ":" : "=";
+      const key = match.split(separator)[0]?.trim() || "token";
+      return `${key}${separator} [token]`;
+    })
+    .replace(KNOWN_SECRET_PREFIX_PATTERN, "[token]")
+    .replace(OWNER_PATH_PATTERN, (match) => `${match[0] === "/" ? "" : match[0]}[path]`)
+    .replace(WINDOWS_PATH_PATTERN, "[path]")
+    .replace(PRIVATE_IPV4_PATTERN, "[host]")
+    .replace(HOST_VALUE_PATTERN, (match) => {
+      const prefix = match.match(/^(host|hostname)\s*[:=]?/i)?.[0] ?? "host ";
+      return `${prefix}[host]`;
+    })
+    .replace(DATABASE_PATTERN, "[database]");
+  return capDiagnosticText(normalizeDiagnosticText(redacted) || "unavailable");
+}
+
+function safeDiagnosticName(name: string): string {
+  const normalized = name.replace(/[^A-Za-z0-9_.-]/g, "").slice(0, MAX_DIAGNOSTIC_NAME_LENGTH);
+  return normalized || "Error";
+}
+
+export function formatCodingAgentDiagnostic(err: unknown): CodingAgentDiagnostic {
+  if (err instanceof Error) {
+    return {
+      name: safeDiagnosticName(err.name || "Error"),
+      message: redactCodingAgentDiagnosticText(err.message),
+    };
+  }
+  return {
+    name: "Unknown",
+    message: redactCodingAgentDiagnosticText(err),
+  };
+}
+
+export function logCodingAgentWarning(
+  scope: string,
+  err: unknown,
+  logger: CodingAgentDiagnosticLogger = console,
+): void {
+  logger.warn(`[coding-agents] ${redactCodingAgentDiagnosticText(scope)}`, formatCodingAgentDiagnostic(err));
+}

--- a/packages/gateway/src/coding-agents/diagnostics.ts
+++ b/packages/gateway/src/coding-agents/diagnostics.ts
@@ -12,12 +12,14 @@ export interface CodingAgentDiagnostic {
 
 const URL_PATTERN = /\b[a-z][a-z0-9+.-]*:\/\/[^\s"'<>]+/gi;
 const BEARER_PATTERN = /\bBearer\s+[A-Za-z0-9._~+/=-]+/gi;
+const AUTHORIZATION_ASSIGNMENT_PATTERN = /\b(authorization)(\s*[:=]\s*)(?:"(?:\\.|[^"\\\r\n])*"|'(?:\\.|[^'\\\r\n])*'|[A-Za-z][A-Za-z0-9._-]{0,31}\s+[^\s"'<>]+|[^\s"'<>]+)/gi;
 const ASSIGNMENT_PATTERN = /\b([A-Za-z][A-Za-z0-9_-]{0,127})(\s*[:=]\s*)(?:(?:Basic|Bearer|Digest)\s+[^\s"'<>]+|"(?:\\.|[^"\\\r\n])*"|'(?:\\.|[^'\\\r\n])*'|[^\s"'<>]+)/gi;
 const KNOWN_SECRET_PREFIX_PATTERN = /\b(?:sk|sk_live|sk_test|ghp|github_pat|xoxb|xoxp|xoxa|xoxr|glpat|hf)[_-][A-Za-z0-9._-]{4,}\b/gi;
 const OWNER_PATH_PATTERN = /(?:^|[\s"'(:])(?:\/(?:home|Users|private|tmp|var|opt|etc|root|run)\/[^\s"'<>)]*)/g;
 const WINDOWS_PATH_PATTERN = /\b[A-Za-z]:\\[^\s"'<>)]*/g;
 const PRIVATE_IPV4_PATTERN = /\b(?:(?:10|127)\.\d{1,3}\.\d{1,3}\.\d{1,3}|169\.254\.\d{1,3}\.\d{1,3}|172\.(?:1[6-9]|2\d|3[0-1])\.\d{1,3}\.\d{1,3}|192\.168\.\d{1,3}\.\d{1,3})\b/g;
 const PRIVATE_IPV6_PATTERN = /(?<![A-Fa-f0-9:])(?:::1|(?:f[cd][A-Fa-f0-9]{2}|fe[89ab][A-Fa-f0-9])(?::[A-Fa-f0-9]{0,4}){1,7})(?:%[A-Za-z0-9_.-]+)?(?![A-Fa-f0-9:])/gi;
+const PRIVATE_HOSTNAME_PATTERN = /\b(?:(?=[A-Za-z0-9.-]{1,253}\b)(?:[A-Za-z0-9](?:[A-Za-z0-9-]{0,62})?\.)+(?:local|internal|lan|home|localhost)|localhost)\b/gi;
 const HOST_VALUE_PATTERN = /\b(?:host|hostname)\s*[:=]?\s*[A-Za-z0-9.-]*(?:\.local|\.internal|\.lan|\.home|runtime|matrix|vps)[A-Za-z0-9.-]*/gi;
 const DATABASE_PATTERN = /\b(?:postgres(?:ql)?|kysely|database|db)\b/gi;
 
@@ -52,6 +54,9 @@ export function redactCodingAgentDiagnosticText(value: unknown): string {
   const redacted = raw
     .replace(URL_PATTERN, "[url]")
     .replace(BEARER_PATTERN, "Bearer [token]")
+    .replace(AUTHORIZATION_ASSIGNMENT_PATTERN, (_match, key: string, separator: string) => {
+      return `${key}${separator.trim()} [token]`;
+    })
     .replace(ASSIGNMENT_PATTERN, (match, key: string, separator: string) => {
       if (!isSecretAssignmentKey(key)) return match;
       return `${key}${separator.trim()} [token]`;
@@ -61,6 +66,7 @@ export function redactCodingAgentDiagnosticText(value: unknown): string {
     .replace(WINDOWS_PATH_PATTERN, "[path]")
     .replace(PRIVATE_IPV4_PATTERN, "[host]")
     .replace(PRIVATE_IPV6_PATTERN, "[host]")
+    .replace(PRIVATE_HOSTNAME_PATTERN, "[host]")
     .replace(HOST_VALUE_PATTERN, (match) => {
       const prefix = match.match(/^(host|hostname)\s*[:=]?/i)?.[0] ?? "host ";
       return `${prefix}[host]`;

--- a/packages/gateway/src/coding-agents/diagnostics.ts
+++ b/packages/gateway/src/coding-agents/diagnostics.ts
@@ -14,7 +14,7 @@ const URL_PATTERN = /\b[a-z][a-z0-9+.-]*:\/\/[^\s"'<>]+/gi;
 const BEARER_PATTERN = /\bBearer\s+[A-Za-z0-9._~+/=-]+/gi;
 const SECRET_ASSIGNMENT_PATTERN = /\b(?:authorization|api[_-]?key|access[_-]?token|refresh[_-]?token|token|password|passwd|secret)\s*[:=]\s*[^\s"'<>]+/gi;
 const KNOWN_SECRET_PREFIX_PATTERN = /\b(?:sk|sk_live|sk_test|ghp|github_pat|xoxb|xoxp|xoxa|xoxr|glpat|hf)[_-][A-Za-z0-9._-]{4,}\b/gi;
-const OWNER_PATH_PATTERN = /(?:^|[\s"'(:])(?:\/(?:home|Users|private|tmp|var|opt|etc|root)\/[^\s"'<>)]*)/g;
+const OWNER_PATH_PATTERN = /(?:^|[\s"'(:])(?:\/(?:home|Users|private|tmp|var|opt|etc|root|run)\/[^\s"'<>)]*)/g;
 const WINDOWS_PATH_PATTERN = /\b[A-Za-z]:\\[^\s"'<>)]*/g;
 const PRIVATE_IPV4_PATTERN = /\b(?:(?:10|127)\.\d{1,3}\.\d{1,3}\.\d{1,3}|172\.(?:1[6-9]|2\d|3[0-1])\.\d{1,3}\.\d{1,3}|192\.168\.\d{1,3}\.\d{1,3})\b/g;
 const HOST_VALUE_PATTERN = /\b(?:host|hostname)\s*[:=]?\s*[A-Za-z0-9.-]*(?:\.local|\.internal|\.lan|\.home|runtime|matrix|vps)[A-Za-z0-9.-]*/gi;
@@ -57,6 +57,10 @@ function safeDiagnosticName(name: string): string {
   return normalized || "Error";
 }
 
+function safeDiagnosticScope(scope: string): string {
+  return capDiagnosticText(normalizeDiagnosticText(scope) || "warning");
+}
+
 export function formatCodingAgentDiagnostic(err: unknown): CodingAgentDiagnostic {
   if (err instanceof Error) {
     return {
@@ -75,5 +79,5 @@ export function logCodingAgentWarning(
   err: unknown,
   logger: CodingAgentDiagnosticLogger = console,
 ): void {
-  logger.warn(`[coding-agents] ${redactCodingAgentDiagnosticText(scope)}`, formatCodingAgentDiagnostic(err));
+  logger.warn(`[coding-agents] ${safeDiagnosticScope(scope)}`, formatCodingAgentDiagnostic(err));
 }

--- a/packages/gateway/src/coding-agents/preview-summary.ts
+++ b/packages/gateway/src/coding-agents/preview-summary.ts
@@ -12,6 +12,7 @@ import type {
   CodingAgentPreviewSummaryStore,
   CodingAgentRuntimeSummaryRequestOptions,
 } from "./runtime-summary.js";
+import { logCodingAgentWarning } from "./diagnostics.js";
 
 type PreviewListResult =
   | { ok: true; previews: PreviewRecord[]; nextCursor: string | null }
@@ -75,7 +76,7 @@ function localPreviewOrigin(rawUrl: string): string | undefined {
     return local ? url.origin : undefined;
   } catch (err: unknown) {
     if (err instanceof TypeError) return undefined;
-    console.warn("[coding-agents] preview origin parse failed:", err instanceof Error ? err.message : String(err));
+    logCodingAgentWarning("preview origin parse failed", err);
     return undefined;
   }
 }

--- a/packages/gateway/src/coding-agents/routes.ts
+++ b/packages/gateway/src/coding-agents/routes.ts
@@ -58,6 +58,7 @@ import {
   type CodingAgentSourceControlStore,
 } from "./source-control.js";
 import type { CodingAgentNotificationPreferenceStore } from "./notification-preferences.js";
+import { logCodingAgentWarning } from "./diagnostics.js";
 
 export interface CodingAgentRouteDeps {
   service: CodingAgentRuntimeSummaryService;
@@ -216,7 +217,7 @@ function mapThreadRouteError(c: Context, err: unknown) {
   if (err instanceof z.ZodError) {
     return c.json({ error: validationFailed() }, 400);
   }
-  console.warn("[coding-agents] thread route failed:", err instanceof Error ? err.message : String(err));
+  logCodingAgentWarning("thread route failed", err);
   return c.json({ error: threadsUnavailable() }, 503);
 }
 
@@ -253,7 +254,7 @@ export function createCodingAgentRoutes(deps: CodingAgentRouteDeps): Hono {
       if (err instanceof z.ZodError) {
         return c.json({ error: validationFailed() }, 400);
       }
-      console.warn("[coding-agents] summary route failed:", err instanceof Error ? err.message : String(err));
+      logCodingAgentWarning("summary route failed", err);
       return c.json({ error: summaryUnavailable() }, 503);
     }
   });
@@ -352,7 +353,7 @@ export function createCodingAgentRoutes(deps: CodingAgentRouteDeps): Hono {
         if (err instanceof z.ZodError) {
           return c.json({ error: validationFailed() }, 400);
         }
-        console.warn("[coding-agents] review route failed:", err instanceof Error ? err.message : String(err));
+        logCodingAgentWarning("review route failed", err);
         return c.json({ error: reviewsUnavailable() }, 503);
       }
     });
@@ -377,7 +378,7 @@ export function createCodingAgentRoutes(deps: CodingAgentRouteDeps): Hono {
           const status = err.code === "review_not_found" ? 404 : 503;
           return c.json({ error: err.code === "review_not_found" ? reviewNotFound() : reviewsUnavailable() }, status);
         }
-        console.warn("[coding-agents] review snapshot route failed:", err instanceof Error ? err.message : String(err));
+        logCodingAgentWarning("review snapshot route failed", err);
         return c.json({ error: reviewsUnavailable() }, 503);
       }
     });
@@ -407,7 +408,7 @@ export function createCodingAgentRoutes(deps: CodingAgentRouteDeps): Hono {
           if (err.code === "not_file") return c.json({ error: validationFailed() }, 400);
           return c.json({ error: filesUnavailable() }, 503);
         }
-        console.warn("[coding-agents] file browse route failed:", err instanceof Error ? err.message : String(err));
+        logCodingAgentWarning("file browse route failed", err);
         return c.json({ error: filesUnavailable() }, 503);
       }
     });
@@ -434,7 +435,7 @@ export function createCodingAgentRoutes(deps: CodingAgentRouteDeps): Hono {
           if (err.code === "not_file") return c.json({ error: validationFailed() }, 400);
           return c.json({ error: filesUnavailable() }, 503);
         }
-        console.warn("[coding-agents] file read route failed:", err instanceof Error ? err.message : String(err));
+        logCodingAgentWarning("file read route failed", err);
         return c.json({ error: filesUnavailable() }, 503);
       }
     });
@@ -463,7 +464,7 @@ export function createCodingAgentRoutes(deps: CodingAgentRouteDeps): Hono {
           if (err.code === "not_file") return c.json({ error: validationFailed() }, 400);
           return c.json({ error: filesUnavailable() }, 503);
         }
-        console.warn("[coding-agents] file search route failed:", err instanceof Error ? err.message : String(err));
+        logCodingAgentWarning("file search route failed", err);
         return c.json({ error: filesUnavailable() }, 503);
       }
     });
@@ -491,7 +492,7 @@ export function createCodingAgentRoutes(deps: CodingAgentRouteDeps): Hono {
           if (err.code === "not_file" || err.code === "invalid_request") return c.json({ error: validationFailed() }, 400);
           return c.json({ error: filesUnavailable() }, 503);
         }
-        console.warn("[coding-agents] file write route failed:", err instanceof Error ? err.message : String(err));
+        logCodingAgentWarning("file write route failed", err);
         return c.json({ error: filesUnavailable() }, 503);
       }
     });
@@ -523,7 +524,7 @@ export function createCodingAgentRoutes(deps: CodingAgentRouteDeps): Hono {
           if (err.code === "invalid_request") return c.json({ error: validationFailed() }, 400);
           return c.json({ error: sourceControlUnavailable() }, 503);
         }
-        console.warn("[coding-agents] source-control route failed:", err instanceof Error ? err.message : String(err));
+        logCodingAgentWarning("source-control route failed", err);
         return c.json({ error: sourceControlUnavailable() }, 503);
       }
     });
@@ -553,7 +554,7 @@ export function createCodingAgentRoutes(deps: CodingAgentRouteDeps): Hono {
           if (err.code === "invalid_request") return c.json({ error: validationFailed() }, 400);
           return c.json({ error: sourceControlUnavailable() }, 503);
         }
-        console.warn("[coding-agents] source-control pull request route failed:", err instanceof Error ? err.message : String(err));
+        logCodingAgentWarning("source-control pull request route failed", err);
         return c.json({ error: sourceControlUnavailable() }, 503);
       }
     });
@@ -572,7 +573,7 @@ export function createCodingAgentRoutes(deps: CodingAgentRouteDeps): Hono {
           const mapped = mapRequestPrincipalError(err);
           return c.json(mapped.body, mapped.status as ContentfulStatusCode);
         }
-        console.warn("[coding-agents] notification preferences route failed:", err instanceof Error ? err.message : String(err));
+        logCodingAgentWarning("notification preferences route failed", err);
         return c.json({ error: notificationPreferencesUnavailable() }, 503);
       }
     });
@@ -596,7 +597,7 @@ export function createCodingAgentRoutes(deps: CodingAgentRouteDeps): Hono {
         if (err instanceof z.ZodError || err instanceof SyntaxError) {
           return c.json({ error: validationFailed() }, 400);
         }
-        console.warn("[coding-agents] notification preferences update failed:", err instanceof Error ? err.message : String(err));
+        logCodingAgentWarning("notification preferences update failed", err);
         return c.json({ error: notificationPreferencesUnavailable() }, 503);
       }
     });

--- a/packages/gateway/src/coding-agents/runtime-summary.ts
+++ b/packages/gateway/src/coding-agents/runtime-summary.ts
@@ -16,6 +16,7 @@ import type {
   AgentId,
 } from "../onboarding/activation-contracts.js";
 import type { AgentCredentialStatusService } from "../onboarding/agent-credential-status.js";
+import { logCodingAgentWarning } from "./diagnostics.js";
 
 const TERMINAL_SUMMARY_LIMIT = 20;
 const PREVIEW_SUMMARY_LIMIT = 50;
@@ -193,7 +194,7 @@ async function readProviders(
       .filter((agent) => !registeredProviderIds || registeredProviderIds.has(agent.agent))
       .map(statusToProviderSummary);
   } catch (err: unknown) {
-    console.warn("[coding-agents] provider summary unavailable:", err instanceof Error ? err.message : String(err));
+    logCodingAgentWarning("provider summary unavailable", err);
     return [];
   }
 }
@@ -206,7 +207,7 @@ async function readActiveThreads(
   try {
     return await store.listThreads(principal);
   } catch (err: unknown) {
-    console.warn("[coding-agents] thread summary unavailable:", err instanceof Error ? err.message : String(err));
+    logCodingAgentWarning("thread summary unavailable", err);
     return { items: [], hasMore: false, limit: 20 };
   }
 }
@@ -219,7 +220,7 @@ async function readAttentionThreads(
   try {
     return await store.listAttentionThreads(principal);
   } catch (err: unknown) {
-    console.warn("[coding-agents] attention summary unavailable:", err instanceof Error ? err.message : String(err));
+    logCodingAgentWarning("attention summary unavailable", err);
     return { items: [], hasMore: false, limit: 20 };
   }
 }
@@ -243,7 +244,7 @@ async function readPreviewSessions(
       limit: PREVIEW_SUMMARY_LIMIT,
     };
   } catch (err: unknown) {
-    console.warn("[coding-agents] preview summary unavailable:", err instanceof Error ? err.message : String(err));
+    logCodingAgentWarning("preview summary unavailable", err);
     return { items: [], hasMore: false, limit: PREVIEW_SUMMARY_LIMIT };
   }
 }
@@ -271,7 +272,7 @@ async function readTerminalSessions(
       limit: TERMINAL_SUMMARY_LIMIT,
     };
   } catch (err: unknown) {
-    console.warn("[coding-agents] terminal summary unavailable:", err instanceof Error ? err.message : String(err));
+    logCodingAgentWarning("terminal summary unavailable", err);
     return { items: [], hasMore: false, limit: TERMINAL_SUMMARY_LIMIT };
   }
 }

--- a/packages/gateway/src/coding-agents/session-stop-reconciler.ts
+++ b/packages/gateway/src/coding-agents/session-stop-reconciler.ts
@@ -1,5 +1,6 @@
 import { z } from "zod/v4";
 import { TerminalSessionIdSchema } from "@matrix-os/contracts";
+import { logCodingAgentWarning } from "./diagnostics.js";
 import type { CodingAgentThreadStore } from "./thread-store.js";
 
 const DEFAULT_MAX_PENDING_STOPS = 100;
@@ -63,10 +64,7 @@ export function createCodingAgentSessionStopReconciler(options: {
     retryTimer = setTimeout(() => {
       retryTimer = undefined;
       void drainPendingStops().catch((err: unknown) => {
-        console.warn(
-          "[coding-agents] Retained session stop retry failed:",
-          err instanceof Error ? err.message : String(err),
-        );
+        logCodingAgentWarning("retained session stop retry failed", err);
         scheduleRetry();
       });
     }, retryDelayMs);

--- a/packages/gateway/src/coding-agents/thread-store.ts
+++ b/packages/gateway/src/coding-agents/thread-store.ts
@@ -22,6 +22,7 @@ import {
 } from "@matrix-os/contracts";
 import { atomicWriteJson } from "../state-ops.js";
 import type { RequestPrincipal } from "../request-principal.js";
+import { logCodingAgentWarning } from "./diagnostics.js";
 
 const THREAD_STORE_RELATIVE_PATH = ["system", "coding-agents", "threads.json"] as const;
 const THREAD_LIST_LIMIT = 50;
@@ -612,7 +613,7 @@ export function createCodingAgentThreadStore(options: CodingAgentThreadStoreOpti
       try {
         sink({ ownerId, threadId, events });
       } catch (err: unknown) {
-        console.warn("[coding-agents] thread event sink failed:", err instanceof Error ? err.message : String(err));
+        logCodingAgentWarning("thread event sink failed", err);
       }
     }
   }
@@ -668,7 +669,7 @@ export function createCodingAgentThreadStore(options: CodingAgentThreadStoreOpti
             nextEventId,
           }), thread.id);
         } catch (err: unknown) {
-          console.warn("[coding-agents] provider start failed:", err instanceof Error ? err.message : String(err));
+          logCodingAgentWarning("provider start failed", err);
           providerEvents = safeProviderRunFailureEvents(thread.id, now, nextEventId);
         }
         const events = [createdEvent, ...providerEvents];
@@ -751,7 +752,7 @@ export function createCodingAgentThreadStore(options: CodingAgentThreadStoreOpti
               abortEvents = defaultAbortEvents(threadId, now, nextEventId);
             }
           } catch (err: unknown) {
-            console.warn("[coding-agents] provider abort failed:", err instanceof Error ? err.message : String(err));
+            logCodingAgentWarning("provider abort failed", err);
             abortEvents = defaultAbortEvents(threadId, now, nextEventId);
           }
         } else {
@@ -807,7 +808,7 @@ export function createCodingAgentThreadStore(options: CodingAgentThreadStoreOpti
               nextEventId,
             }), threadId);
           } catch (err: unknown) {
-            console.warn("[coding-agents] provider approval submit failed:", err instanceof Error ? err.message : String(err));
+            logCodingAgentWarning("provider approval submit failed", err);
             throw new CodingAgentThreadError("thread_store_unavailable", "Provider approval submit failed");
           }
         } else {
@@ -862,7 +863,7 @@ export function createCodingAgentThreadStore(options: CodingAgentThreadStoreOpti
               nextEventId,
             }), threadId);
           } catch (err: unknown) {
-            console.warn("[coding-agents] provider input submit failed:", err instanceof Error ? err.message : String(err));
+            logCodingAgentWarning("provider input submit failed", err);
             throw new CodingAgentThreadError("thread_store_unavailable", "Provider input submit failed");
           }
         } else {

--- a/packages/gateway/src/coding-agents/thread-stream.ts
+++ b/packages/gateway/src/coding-agents/thread-stream.ts
@@ -11,6 +11,7 @@ import {
   safeThreadError,
   type CodingAgentThreadStore,
 } from "./thread-store.js";
+import { logCodingAgentWarning } from "./diagnostics.js";
 
 const MAX_INBOUND_FRAME_BYTES = 4096;
 const DEFAULT_MAX_SUBSCRIBERS = 64;
@@ -71,7 +72,7 @@ function sendJson(ws: CodingAgentThreadStreamSocket, frame: unknown): boolean {
     ws.send(JSON.stringify(frame));
     return true;
   } catch (err: unknown) {
-    console.warn("[coding-agents] thread stream send failed:", err instanceof Error ? err.message : String(err));
+    logCodingAgentWarning("thread stream send failed", err);
     return false;
   }
 }
@@ -80,7 +81,7 @@ function closeSocket(ws: CodingAgentThreadStreamSocket): void {
   try {
     ws.close?.();
   } catch (err: unknown) {
-    console.warn("[coding-agents] thread stream close failed:", err instanceof Error ? err.message : String(err));
+    logCodingAgentWarning("thread stream close failed", err);
   }
 }
 
@@ -225,7 +226,7 @@ export function createCodingAgentThreadStream(options: CodingAgentThreadStreamOp
             parsed = JSON.parse(raw);
           } catch (err: unknown) {
             if (!(err instanceof SyntaxError)) {
-              console.warn("[coding-agents] thread stream JSON parse failed:", err instanceof Error ? err.message : String(err));
+              logCodingAgentWarning("thread stream JSON parse failed", err);
             }
             sendJson(input.ws, { type: "thread.stream.error", error: invalidFrameError() });
             return;
@@ -258,7 +259,7 @@ export function createCodingAgentThreadStream(options: CodingAgentThreadStreamOp
           recoveryActions: ["retry"],
         });
       if (!(err instanceof CodingAgentThreadError)) {
-        console.warn("[coding-agents] thread stream open failed:", err instanceof Error ? err.message : String(err));
+        logCodingAgentWarning("thread stream open failed", err);
       }
       sendJson(input.ws, { type: "thread.stream.error", error: safeError });
       closeSocket(input.ws);

--- a/specs/105-coding-agent-shells/completion-audit.md
+++ b/specs/105-coding-agent-shells/completion-audit.md
@@ -20,6 +20,7 @@ This audit records current evidence through the desktop operator palette smoke a
 | Browser shell remains Canvas-first and read-only for coding-agent state | `shell/src/components/workspace/WorkspaceApp.tsx`; `tests/shell/workspace-app.test.tsx`; browser section in `current-state.md` | Implemented |
 | File, review, diff, preview, and source-control surfaces remain gateway-owned with bounded shell clients | Gateway route inventory plus desktop/mobile review tests listed in `current-state.md` | Implemented |
 | Notifications and attention routing use safe owner-scoped payloads and preferences | `packages/gateway/src/coding-agents/attention-notifications.ts`; `packages/gateway/src/coding-agents/notification-preferences.ts`; related gateway, desktop, and mobile tests listed in `current-state.md` | Implemented |
+| Redacted diagnostics for coding-agent gateway/runtime failure paths | `packages/gateway/src/coding-agents/diagnostics.ts`; `tests/gateway/coding-agents-diagnostics.test.ts`; route/summary/thread-stream/thread-store/attention-notification callers | Implemented |
 | Desktop renderer does not receive raw bearer/provider credentials | Trusted IPC and main-process client inventory in `current-state.md`; desktop runtime client tests | Implemented by architecture and tests |
 | Mobile persistent state stores only bounded UI references | `apps/mobile/lib/agent-workspace-state.ts`; `apps/mobile/lib/mobile-shell-state.ts`; mobile state tests listed in `current-state.md` | Implemented |
 | Public and internal docs | `docs/dev/coding-agent-shells.md`; `www/content/docs/coding-agents.mdx`; `current-state.md` | Implemented and must stay synchronized |
@@ -87,5 +88,6 @@ That automated desktop smoke now also covers opening the Agents workspace from t
 - New shell routes and clients use shared Zod 4 contracts at the boundary.
 - Mutating gateway routes use body limits, validation, ownership checks, and safe error mapping.
 - WebSocket thread streams authenticate before success, validate frames, cap subscribers, and clean up stale streams.
+- Gateway coding-agent diagnostics are bounded and redacted before logging paths, tokens, URLs, private hosts, database details, or provider/runtime failure text.
 - No new embedded database persistence was added.
 - Gateway/runtime remains the source of truth; desktop, mobile, and browser shells are resumable clients.

--- a/specs/105-coding-agent-shells/current-state.md
+++ b/specs/105-coding-agent-shells/current-state.md
@@ -79,6 +79,7 @@ Security and ownership:
 - Path params and query cursors are Zod-validated at the route boundary.
 - Mutating routes use Hono `bodyLimit`.
 - Route errors are mapped to safe client errors and log details server-side only.
+- Gateway coding-agent route, summary, stream, provider lifecycle, and attention-notification failure diagnostics use the bounded redacted helper in `packages/gateway/src/coding-agents/diagnostics.ts` instead of raw `err.message` logging.
 - Thread store state is owner-scoped in the existing owner file convention at `system/coding-agents/threads.json`; no new embedded DB was added.
 
 Related workspace routes in `packages/gateway/src/workspace-routes.ts`:
@@ -412,6 +413,12 @@ Focused gateway/contracts:
 
 ```bash
 pnpm exec vitest run tests/gateway/coding-agents-workspace-provider.test.ts tests/gateway/coding-agents-threads.test.ts tests/gateway/coding-agents-thread-stream.test.ts tests/gateway/coding-agents-summary.test.ts tests/gateway/coding-agents-file-read.test.ts tests/contracts/coding-agents.test.ts tests/gateway/agent-launcher.test.ts tests/gateway/agent-session-manager.test.ts tests/gateway/workspace-session-orchestrator.test.ts tests/observability/process-error-entrypoints.test.ts
+```
+
+Gateway diagnostics:
+
+```bash
+pnpm exec vitest run tests/gateway/coding-agents-diagnostics.test.ts
 ```
 
 Gateway typecheck:

--- a/tests/gateway/coding-agents-diagnostics.test.ts
+++ b/tests/gateway/coding-agents-diagnostics.test.ts
@@ -36,6 +36,24 @@ describe("coding agent diagnostics", () => {
     expect(redacted.endsWith("...")).toBe(true);
   });
 
+  it("fully redacts colon-containing and quoted secret assignments", () => {
+    const redacted = redactCodingAgentDiagnosticText(
+      `token=abc:def apiKey="abcd" password: 'hunter2'`,
+    );
+
+    expect(redacted).toBe("token= [token] apiKey= [token] password: [token]");
+    expect(redacted).not.toMatch(/abc|def|abcd|hunter2/i);
+  });
+
+  it("redacts link-local and private IPv6 hosts", () => {
+    const redacted = redactCodingAgentDiagnosticText(
+      "metadata 169.254.169.254 loopback ::1 link-local fe80::1 private fd12:3456::1",
+    );
+
+    expect(redacted).toBe("metadata [host] loopback [host] link-local [host] private [host]");
+    expect(redacted).not.toMatch(/169\.254|::1|fe80|fd12/i);
+  });
+
   it("formats non-error diagnostics and unsafe names safely", () => {
     const unknown = formatCodingAgentDiagnostic("token=sk_live_private /tmp/private-file");
     const unsafeNameError = new Error("failed");

--- a/tests/gateway/coding-agents-diagnostics.test.ts
+++ b/tests/gateway/coding-agents-diagnostics.test.ts
@@ -17,7 +17,7 @@ describe("coding agent diagnostics", () => {
       "host internal-runtime.local",
       "probe 10.0.0.5",
       "ENOENT",
-    ].join(" ");
+    ].join("\n");
 
     const redacted = redactCodingAgentDiagnosticText(raw);
 
@@ -38,13 +38,19 @@ describe("coding agent diagnostics", () => {
 
   it("fully redacts colon-containing and quoted secret assignments", () => {
     const redacted = redactCodingAgentDiagnosticText(
-      `token=abc:def apiKey="abcd" password: 'hunter2' Authorization: Basic dXNlcjpwYXNz Authorization: Token tokenpayload TWILIO_AUTH_TOKEN=abc123`,
+      [
+        `token=abc:def apiKey="abcd" password: 'hunter2'`,
+        "Authorization: Basic dXNlcjpwYXNz",
+        "Authorization: Token tokenpayload",
+        `Authorization: Digest username="bob", response="digestsecret"`,
+        "TWILIO_AUTH_TOKEN=abc123",
+      ].join("\n"),
     );
 
     expect(redacted).toBe(
-      "token= [token] apiKey= [token] password: [token] Authorization: [token] Authorization: [token] TWILIO_AUTH_TOKEN= [token]",
+      "token= [token] apiKey= [token] password: [token] Authorization: [token] Authorization: [token] Authorization: [token] TWILIO_AUTH_TOKEN= [token]",
     );
-    expect(redacted).not.toMatch(/abc|def|abcd|hunter2|dXNlcjpwYXNz|tokenpayload|abc123/i);
+    expect(redacted).not.toMatch(/abc|def|abcd|hunter2|dXNlcjpwYXNz|tokenpayload|bob|digestsecret|abc123/i);
   });
 
   it("redacts compound credential environment assignments", () => {
@@ -56,6 +62,17 @@ describe("coding agent diagnostics", () => {
       "AWS_SECRET_ACCESS_KEY= [token] S3_ACCESS_KEY_ID= [token] R2_SECRET_ACCESS_KEY= [token] PGPASSWORD= [token] MONKEY=banana STATUS=healthy",
     );
     expect(redacted).not.toMatch(/awsvalue|s3value|r2value|pgvalue/i);
+  });
+
+  it("redacts camel-case credential assignment keys", () => {
+    const redacted = redactCodingAgentDiagnosticText(
+      "clientSecret=clientvalue privateKey=privatevalue idToken=idvalue awsSecretAccessKey=camelvalue MONKEY=banana",
+    );
+
+    expect(redacted).toBe(
+      "clientSecret= [token] privateKey= [token] idToken= [token] awsSecretAccessKey= [token] MONKEY=banana",
+    );
+    expect(redacted).not.toMatch(/clientvalue|privatevalue|idvalue|camelvalue/i);
   });
 
   it("redacts link-local and private IPv6 hosts", () => {

--- a/tests/gateway/coding-agents-diagnostics.test.ts
+++ b/tests/gateway/coding-agents-diagnostics.test.ts
@@ -38,11 +38,13 @@ describe("coding agent diagnostics", () => {
 
   it("fully redacts colon-containing and quoted secret assignments", () => {
     const redacted = redactCodingAgentDiagnosticText(
-      `token=abc:def apiKey="abcd" password: 'hunter2'`,
+      `token=abc:def apiKey="abcd" password: 'hunter2' Authorization: Basic dXNlcjpwYXNz TWILIO_AUTH_TOKEN=abc123`,
     );
 
-    expect(redacted).toBe("token= [token] apiKey= [token] password: [token]");
-    expect(redacted).not.toMatch(/abc|def|abcd|hunter2/i);
+    expect(redacted).toBe(
+      "token= [token] apiKey= [token] password: [token] Authorization: [token] TWILIO_AUTH_TOKEN= [token]",
+    );
+    expect(redacted).not.toMatch(/abc|def|abcd|hunter2|dXNlcjpwYXNz|abc123/i);
   });
 
   it("redacts link-local and private IPv6 hosts", () => {

--- a/tests/gateway/coding-agents-diagnostics.test.ts
+++ b/tests/gateway/coding-agents-diagnostics.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  formatCodingAgentDiagnostic,
+  logCodingAgentWarning,
+  redactCodingAgentDiagnosticText,
+} from "../../packages/gateway/src/coding-agents/diagnostics.js";
+
+describe("coding agent diagnostics", () => {
+  it("redacts sensitive paths, hosts, tokens, urls, and database details", () => {
+    const raw = [
+      "failed to open /home/matrix/home/projects/private-app/src/index.ts",
+      "token=sk_live_51_private_secret",
+      "Authorization: Bearer ghp_privatevalue1234567890",
+      "postgres://matrix:password@10.0.0.5:5432/runtime",
+      "host internal-runtime.local",
+      "ENOENT",
+    ].join(" ");
+
+    const redacted = redactCodingAgentDiagnosticText(raw);
+
+    expect(redacted).toContain("[path]");
+    expect(redacted).toContain("[token]");
+    expect(redacted).toContain("[url]");
+    expect(redacted).toContain("[host]");
+    expect(redacted.length).toBeLessThanOrEqual(180);
+    expect(redacted).not.toMatch(/\/home\/matrix|private-app|sk_live|ghp_|postgres|10\.0\.0\.5|internal-runtime/i);
+  });
+
+  it("formats bounded error diagnostics without leaking raw values", () => {
+    const diagnostic = formatCodingAgentDiagnostic(
+      new Error("Provider said /Users/alice/.ssh/id_rsa failed with xoxb-secret and db timeout"),
+    );
+
+    expect(diagnostic.name).toBe("Error");
+    expect(diagnostic.message).toContain("[path]");
+    expect(diagnostic.message).toContain("[token]");
+    expect(diagnostic.message).toContain("[database]");
+    expect(JSON.stringify(diagnostic)).not.toMatch(/alice|id_rsa|xoxb-secret|db timeout/i);
+  });
+
+  it("logs only coarse scope and redacted diagnostics", () => {
+    const warn = vi.fn();
+
+    logCodingAgentWarning(
+      "summary route failed",
+      new Error("raw path /opt/matrix/release.json leaked token=secret-value"),
+      { warn },
+    );
+
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn).toHaveBeenCalledWith(
+      "[coding-agents] summary route failed",
+      expect.objectContaining({
+        name: "Error",
+        message: expect.stringContaining("[path]"),
+      }),
+    );
+    expect(JSON.stringify(warn.mock.calls)).not.toMatch(/\/opt\/matrix|secret-value/i);
+  });
+});

--- a/tests/gateway/coding-agents-diagnostics.test.ts
+++ b/tests/gateway/coding-agents-diagnostics.test.ts
@@ -47,6 +47,17 @@ describe("coding agent diagnostics", () => {
     expect(redacted).not.toMatch(/abc|def|abcd|hunter2|dXNlcjpwYXNz|abc123/i);
   });
 
+  it("redacts compound credential environment assignments", () => {
+    const redacted = redactCodingAgentDiagnosticText(
+      `AWS_SECRET_ACCESS_KEY=awsvalue S3_ACCESS_KEY_ID=s3value R2_SECRET_ACCESS_KEY="r2value" PGPASSWORD=pgvalue MONKEY=banana STATUS=healthy`,
+    );
+
+    expect(redacted).toBe(
+      "AWS_SECRET_ACCESS_KEY= [token] S3_ACCESS_KEY_ID= [token] R2_SECRET_ACCESS_KEY= [token] PGPASSWORD= [token] MONKEY=banana STATUS=healthy",
+    );
+    expect(redacted).not.toMatch(/awsvalue|s3value|r2value|pgvalue/i);
+  });
+
   it("redacts link-local and private IPv6 hosts", () => {
     const redacted = redactCodingAgentDiagnosticText(
       "metadata 169.254.169.254 loopback ::1 link-local fe80::1 private fd12:3456::1",

--- a/tests/gateway/coding-agents-diagnostics.test.ts
+++ b/tests/gateway/coding-agents-diagnostics.test.ts
@@ -12,7 +12,10 @@ describe("coding agent diagnostics", () => {
       "token=sk_live_51_private_secret",
       "Authorization: Bearer ghp_privatevalue1234567890",
       "postgres://matrix:password@10.0.0.5:5432/runtime",
+      "socket /run/matrix/gateway.sock",
+      "windows C:\\Users\\alice\\matrix\\token.txt",
       "host internal-runtime.local",
+      "probe 10.0.0.5",
       "ENOENT",
     ].join(" ");
 
@@ -23,7 +26,29 @@ describe("coding agent diagnostics", () => {
     expect(redacted).toContain("[url]");
     expect(redacted).toContain("[host]");
     expect(redacted.length).toBeLessThanOrEqual(180);
-    expect(redacted).not.toMatch(/\/home\/matrix|private-app|sk_live|ghp_|postgres|10\.0\.0\.5|internal-runtime/i);
+    expect(redacted).not.toMatch(/\/home\/matrix|\/run\/matrix|C:\\Users|alice|private-app|sk_live|ghp_|postgres|10\.0\.0\.5|internal-runtime/i);
+  });
+
+  it("bounds long diagnostic text", () => {
+    const redacted = redactCodingAgentDiagnosticText(`status ${"x".repeat(220)}`);
+
+    expect(redacted).toHaveLength(180);
+    expect(redacted.endsWith("...")).toBe(true);
+  });
+
+  it("formats non-error diagnostics and unsafe names safely", () => {
+    const unknown = formatCodingAgentDiagnostic("token=sk_live_private /tmp/private-file");
+    const unsafeNameError = new Error("failed");
+    unsafeNameError.name = "!!!";
+
+    expect(unknown).toEqual({
+      name: "Unknown",
+      message: "token= [token] [path]",
+    });
+    expect(formatCodingAgentDiagnostic(unsafeNameError)).toEqual({
+      name: "Error",
+      message: "failed",
+    });
   });
 
   it("formats bounded error diagnostics without leaking raw values", () => {
@@ -42,14 +67,14 @@ describe("coding agent diagnostics", () => {
     const warn = vi.fn();
 
     logCodingAgentWarning(
-      "summary route failed",
+      "database summary route failed",
       new Error("raw path /opt/matrix/release.json leaked token=secret-value"),
       { warn },
     );
 
     expect(warn).toHaveBeenCalledTimes(1);
     expect(warn).toHaveBeenCalledWith(
-      "[coding-agents] summary route failed",
+      "[coding-agents] database summary route failed",
       expect.objectContaining({
         name: "Error",
         message: expect.stringContaining("[path]"),

--- a/tests/gateway/coding-agents-diagnostics.test.ts
+++ b/tests/gateway/coding-agents-diagnostics.test.ts
@@ -38,13 +38,13 @@ describe("coding agent diagnostics", () => {
 
   it("fully redacts colon-containing and quoted secret assignments", () => {
     const redacted = redactCodingAgentDiagnosticText(
-      `token=abc:def apiKey="abcd" password: 'hunter2' Authorization: Basic dXNlcjpwYXNz TWILIO_AUTH_TOKEN=abc123`,
+      `token=abc:def apiKey="abcd" password: 'hunter2' Authorization: Basic dXNlcjpwYXNz Authorization: Token tokenpayload TWILIO_AUTH_TOKEN=abc123`,
     );
 
     expect(redacted).toBe(
-      "token= [token] apiKey= [token] password: [token] Authorization: [token] TWILIO_AUTH_TOKEN= [token]",
+      "token= [token] apiKey= [token] password: [token] Authorization: [token] Authorization: [token] TWILIO_AUTH_TOKEN= [token]",
     );
-    expect(redacted).not.toMatch(/abc|def|abcd|hunter2|dXNlcjpwYXNz|abc123/i);
+    expect(redacted).not.toMatch(/abc|def|abcd|hunter2|dXNlcjpwYXNz|tokenpayload|abc123/i);
   });
 
   it("redacts compound credential environment assignments", () => {
@@ -60,11 +60,13 @@ describe("coding agent diagnostics", () => {
 
   it("redacts link-local and private IPv6 hosts", () => {
     const redacted = redactCodingAgentDiagnosticText(
-      "metadata 169.254.169.254 loopback ::1 link-local fe80::1 private fd12:3456::1",
+      "metadata 169.254.169.254 loopback ::1 link-local fe80::1 private fd12:3456::1 getaddrinfo ENOTFOUND internal-runtime.local connect ECONNREFUSED matrix-vps.internal localhost",
     );
 
-    expect(redacted).toBe("metadata [host] loopback [host] link-local [host] private [host]");
-    expect(redacted).not.toMatch(/169\.254|::1|fe80|fd12/i);
+    expect(redacted).toBe(
+      "metadata [host] loopback [host] link-local [host] private [host] getaddrinfo ENOTFOUND [host] connect ECONNREFUSED [host] [host]",
+    );
+    expect(redacted).not.toMatch(/169\.254|::1|fe80|fd12|internal-runtime|matrix-vps|localhost/i);
   });
 
   it("formats non-error diagnostics and unsafe names safely", () => {


### PR DESCRIPTION
Summary
- Add a bounded coding-agent diagnostics helper that redacts owner paths, tokens, URLs, private hosts, and database details before logging.
- Route coding-agent summary, route, stream, provider lifecycle, session-stop retry, and attention-notification failure warnings through the helper.
- Fully redact colon-containing, quoted, prefixed, compound, and camelCase credential assignments without redacting ordinary assignments.
- Cap diagnostic input at 4 KiB and redact complete Authorization header lines, including parameterized schemes, before final whitespace normalization.
- Redact link-local IPv4, local/private IPv6, localhost, and standalone private DNS suffixes.
- Document the diagnostics boundary in the internal coding-agent guide and spec audit/state notes.

Tests
- `pnpm exec vitest run tests/gateway/coding-agents-diagnostics.test.ts`
- Focused coding-agent gateway suite: 98 tests passed.
- `bun run check:patterns` (0 violations)
- `bun run typecheck`
- `bun run test`: 8,223 passed, 27 skipped on the final head.
- `git diff --check`
- Forbidden-reference scan over touched coding-agent docs/spec/source/test files.

Review/Monitoring
- Review findings for assignment parsing, Authorization schemes and parameters, environment and camelCase keys, path coverage, labeled and standalone host coverage, stable scope labels, and branch coverage are addressed on the latest head.
- `ready-for-ci` will be applied only after current-head Greptile returns 5/5 and current-head review threads are clear.

Invariants
- Source of truth: gateway/runtime remains source of truth for coding-agent state; this PR changes diagnostics only.
- Lock/transaction scope: no persistence, DB, or transaction behavior changes.
- Acceptable orphan states: diagnostic logging failure remains non-blocking; no user workflow depends on logs being emitted.
- Auth source of truth: unchanged; existing route auth and principal resolution remain authoritative.
- Deferred scope: this PR does not add a client-facing diagnostics UI or replace real-runtime/mobile device smoke.
