### PR TITLE
fix(sync-client): handle dropped screenshot paths

### DIFF
--- a/packages/sync-client/src/cli/rich-paste.ts
+++ b/packages/sync-client/src/cli/rich-paste.ts
@@ -588,10 +588,7 @@ function normalizeTerminalLocalPath(rawPath: string): string {
       return decodedPath;
     }
     const url = new URL(decodedPath);
-    if (url.protocol === "file:") {
-      return safeFileUrlToPath(url) ?? decodedPath;
-    }
-    return decodedPath;
+    return safeFileUrlToPath(url) ?? decodedPath;
   }
   return expandLocalPath(decodedPath);
 }

--- a/packages/sync-client/src/cli/rich-paste.ts
+++ b/packages/sync-client/src/cli/rich-paste.ts
@@ -2,11 +2,13 @@ import { randomUUID } from "node:crypto";
 import { lstat, readFile, realpath, stat } from "node:fs/promises";
 import { homedir } from "node:os";
 import { basename, extname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 import type { ClipboardImageReader } from "./clipboard-image.js";
 
 export const RICH_PASTE_MAX_ASSETS = 5;
 export const RICH_PASTE_MAX_IMAGE_BYTES = 10 * 1024 * 1024;
 export const RICH_PASTE_UPLOAD_TIMEOUT_MS = 30_000;
+const DEFAULT_LOCAL_IMAGE_READ_RETRY_DELAYS_MS = [50, 100, 200, 300, 400, 450] as const;
 
 export const RICH_PASTE_LOCAL_FAILURE_MESSAGES = {
   local_read_failed: "Image paste failed: local image could not be read.",
@@ -138,6 +140,7 @@ export interface RichPasteRewriter {
 export interface ProcessRichPasteTransactionInput extends RichPasteRewriteInput {
   uploadClient: RichPasteUploadClient;
   clipboardReader?: ClipboardImageReader;
+  localReadRetryDelaysMs?: readonly number[];
 }
 
 export interface RichPasteUploadClientOptions {
@@ -157,6 +160,23 @@ type InternalCandidate = LocalImageCandidate & {
   quote?: "\"" | "'";
   uploadIndex?: number;
 };
+
+type LocalReadFailureReason =
+  | "not_found"
+  | "permission_denied"
+  | "symlink"
+  | "not_file"
+  | "magic_mismatch"
+  | "unknown";
+
+type LocalValidationResult =
+  | { status: "ok"; candidate: InternalCandidate }
+  | { status: "skip" }
+  | {
+      status: "failed";
+      failureCode: RichPasteFailureCode;
+      allowClipboardFallback: boolean;
+    };
 
 const IMAGE_EXTENSIONS = Object.values(RICH_PASTE_IMAGE_TYPES)
   .flatMap((type) => type.extensions);
@@ -275,9 +295,11 @@ export async function processRichPasteTransaction(
     return { status: "passthrough", outgoingText: input.text, assets: [] };
   }
 
-  const validation = await collectLocalImageCandidates(input.text);
+  const validation = await collectLocalImageCandidates(input.text, {
+    retryDelaysMs: input.localReadRetryDelaysMs ?? DEFAULT_LOCAL_IMAGE_READ_RETRY_DELAYS_MS,
+  });
   if (validation.status === "failed") {
-    if (input.observablePaste && validation.clipboardFallbackCandidate) {
+    if (validation.clipboardFallbackCandidate) {
       const fallback = await processClipboardPaste(input, {
         candidateToReplace: validation.clipboardFallbackCandidate,
         unsupportedFailureCode: validation.failureCode,
@@ -379,7 +401,10 @@ async function processClipboardPaste(
   };
 }
 
-async function collectLocalImageCandidates(text: string): Promise<
+async function collectLocalImageCandidates(
+  text: string,
+  options: { retryDelaysMs: readonly number[] },
+): Promise<
   | { status: "ok"; candidates: InternalCandidate[] }
   | {
       status: "failed";
@@ -392,7 +417,9 @@ async function collectLocalImageCandidates(text: string): Promise<
   const clipboardFallbackCandidate = singlePathOnlyCandidate(text, rawCandidates);
 
   for (const raw of rawCandidates) {
-    const result = await validateLocalCandidate(raw);
+    const result = await validateLocalCandidate(raw, {
+      retryDelaysMs: raw === clipboardFallbackCandidate ? options.retryDelaysMs : [],
+    });
     if (result.status === "skip") {
       continue;
     }
@@ -400,7 +427,7 @@ async function collectLocalImageCandidates(text: string): Promise<
       return {
         status: "failed",
         failureCode: result.failureCode,
-        clipboardFallbackCandidate: result.failureCode === "local_read_failed"
+        clipboardFallbackCandidate: result.allowClipboardFallback && raw === clipboardFallbackCandidate
           ? clipboardFallbackCandidate
           : undefined,
       };
@@ -414,6 +441,7 @@ async function collectLocalImageCandidates(text: string): Promise<
 function findRawCandidates(text: string): InternalCandidate[] {
   const candidates: InternalCandidate[] = [];
   const occupiedRanges: PasteTextRange[] = [];
+  const wholeInputCandidate = createWholeInputCandidate(text);
 
   for (const match of text.matchAll(QUOTED_PATH_PATTERN)) {
     const fullMatch = match[0];
@@ -455,6 +483,16 @@ function findRawCandidates(text: string): InternalCandidate[] {
     }));
   }
 
+  if (
+    wholeInputCandidate &&
+    !candidates.some((candidate) => rangesOverlap(
+      wholeInputCandidate.sourceTextRange,
+      candidate.sourceTextRange,
+    ))
+  ) {
+    candidates.push(wholeInputCandidate);
+  }
+
   return candidates.sort((left, right) => left.sourceTextRange.start - right.sourceTextRange.start);
 }
 
@@ -469,6 +507,58 @@ function singlePathOnlyCandidate(text: string, candidates: InternalCandidate[]):
   return candidate;
 }
 
+function createWholeInputCandidate(text: string): InternalCandidate | undefined {
+  const leadingWhitespace = text.match(/^\s*/u)?.[0].length ?? 0;
+  const trailingWhitespace = text.match(/\s*$/u)?.[0].length ?? 0;
+  const start = leadingWhitespace;
+  const end = text.length - trailingWhitespace;
+  if (start >= end) {
+    return undefined;
+  }
+
+  const displayText = text.slice(start, end);
+  const quotedPath = unwrapQuotedPath(displayText);
+  const rawPath = quotedPath?.rawPath ?? displayText;
+  if (!isPotentialLocalPathText(rawPath)) {
+    return undefined;
+  }
+
+  const localPath = normalizeTerminalLocalPath(rawPath);
+  if (!mimeTypeFromExtension(localPath)) {
+    return undefined;
+  }
+
+  return createRawCandidate({
+    text,
+    start,
+    end,
+    displayText,
+    rawPath,
+    quote: quotedPath?.quote,
+  });
+}
+
+function unwrapQuotedPath(value: string): { quote: "\"" | "'"; rawPath: string } | undefined {
+  if (value.length < 2) {
+    return undefined;
+  }
+  const quote = value[0];
+  if ((quote !== "\"" && quote !== "'") || value[value.length - 1] !== quote) {
+    return undefined;
+  }
+  return {
+    quote,
+    rawPath: value.slice(1, -1),
+  };
+}
+
+function isPotentialLocalPathText(rawPath: string): boolean {
+  return rawPath.startsWith("/") ||
+    rawPath.startsWith("~/") ||
+    rawPath.startsWith("file://") ||
+    decodeTerminalPathEscapes(rawPath).startsWith("/");
+}
+
 function createRawCandidate(input: {
   text: string;
   start: number;
@@ -477,7 +567,7 @@ function createRawCandidate(input: {
   rawPath: string;
   quote?: "\"" | "'";
 }): InternalCandidate {
-  const localPath = expandLocalPath(input.rawPath);
+  const localPath = normalizeTerminalLocalPath(input.rawPath);
   return {
     kind: "local-path",
     sourceTextRange: { start: input.start, end: input.end },
@@ -485,28 +575,114 @@ function createRawCandidate(input: {
     localPath,
     dedupeKey: localPath,
     sizeBytes: 0,
-    mimeType: mimeTypeFromExtension(input.rawPath) ?? "image/png",
+    mimeType: mimeTypeFromExtension(localPath) ?? "image/png",
     quote: input.quote,
   };
 }
 
-async function validateLocalCandidate(candidate: InternalCandidate): Promise<
-  | { status: "ok"; candidate: InternalCandidate }
-  | { status: "skip" }
-  | { status: "failed"; failureCode: RichPasteFailureCode }
-> {
+function normalizeTerminalLocalPath(rawPath: string): string {
+  const decodedPath = decodeTerminalPathEscapes(rawPath);
+  if (decodedPath.startsWith("file://")) {
+    try {
+      const url = new URL(decodedPath);
+      if (url.protocol === "file:") {
+        return fileURLToPath(url);
+      }
+    } catch (err: unknown) {
+      if (err instanceof Error) {
+        return decodedPath;
+      }
+      return decodedPath;
+    }
+  }
+  return expandLocalPath(decodedPath);
+}
+
+function decodeTerminalPathEscapes(value: string): string {
+  return value.replace(
+    /\\u([0-9a-fA-F]{4})|\\(.)/gu,
+    (match, hex: string | undefined, escaped: string | undefined) => {
+      if (hex) {
+        return String.fromCharCode(Number.parseInt(hex, 16));
+      }
+      if (escaped && TERMINAL_PATH_ESCAPED_CHARS.has(escaped)) {
+        return escaped;
+      }
+      return match;
+    },
+  );
+}
+
+const TERMINAL_PATH_ESCAPED_CHARS = new Set([
+  " ",
+  "\\",
+  "\"",
+  "'",
+  "(",
+  ")",
+  "[",
+  "]",
+  "{",
+  "}",
+  "&",
+  ";",
+  "#",
+  "$",
+  "!",
+  "?",
+  "*",
+  "|",
+  "<",
+  ">",
+]);
+
+async function validateLocalCandidate(
+  candidate: InternalCandidate,
+  options: { retryDelaysMs: readonly number[] },
+): Promise<LocalValidationResult> {
   const extensionMimeType = mimeTypeFromExtension(candidate.localPath);
   if (!extensionMimeType) {
     return { status: "skip" };
   }
 
+  let nextRetry = 0;
+  while (true) {
+    const result = await validateLocalCandidateOnce(candidate, extensionMimeType);
+    if (
+      result.status !== "failed" ||
+      result.failureCode !== "local_read_failed" ||
+      !result.allowClipboardFallback ||
+      nextRetry >= options.retryDelaysMs.length
+    ) {
+      return result;
+    }
+
+    const delayMs = options.retryDelaysMs[nextRetry] ?? 0;
+    nextRetry += 1;
+    if (delayMs > 0) {
+      await delay(delayMs);
+    }
+  }
+}
+
+async function validateLocalCandidateOnce(
+  candidate: InternalCandidate,
+  extensionMimeType: RichPasteImageMimeType,
+): Promise<LocalValidationResult> {
   try {
     const linkStats = await lstat(candidate.localPath);
-    if (linkStats.isSymbolicLink() || !linkStats.isFile()) {
-      return { status: "failed", failureCode: "local_read_failed" };
+    if (linkStats.isSymbolicLink()) {
+      return localReadFailed("symlink");
+    }
+    if (!linkStats.isFile()) {
+      return localReadFailed("not_file");
     }
     if (linkStats.size > RICH_PASTE_MAX_IMAGE_BYTES) {
-      return { status: "failed", failureCode: "image_too_large" };
+      return {
+        status: "failed",
+        failureCode: "image_too_large",
+        allowClipboardFallback: false,
+      };
     }
     const [stats, bytes, resolvedRealPath] = await Promise.all([
       stat(candidate.localPath),
@@ -514,14 +690,18 @@ async function validateLocalCandidate(candidate: InternalCandidate): Promise<
       realpath(candidate.localPath),
     ]);
     if (!stats.isFile()) {
-      return { status: "failed", failureCode: "local_read_failed" };
+      return localReadFailed("not_file");
     }
     if (bytes.byteLength > RICH_PASTE_MAX_IMAGE_BYTES) {
-      return { status: "failed", failureCode: "image_too_large" };
+      return {
+        status: "failed",
+        failureCode: "image_too_large",
+        allowClipboardFallback: false,
+      };
     }
     const sniffedMimeType = sniffImageMimeType(bytes);
     if (!sniffedMimeType || sniffedMimeType !== extensionMimeType) {
-      return { status: "failed", failureCode: "local_read_failed" };
+      return localReadFailed("magic_mismatch");
     }
     return {
       status: "ok",
@@ -535,11 +715,36 @@ async function validateLocalCandidate(candidate: InternalCandidate): Promise<
       },
     };
   } catch (err: unknown) {
-    if (err instanceof Error) {
-      return { status: "failed", failureCode: "local_read_failed" };
-    }
-    return { status: "failed", failureCode: "local_read_failed" };
+    return localReadFailed(localReadFailureReasonFromError(err));
   }
+}
+
+function localReadFailed(reason: LocalReadFailureReason): LocalValidationResult {
+  return {
+    status: "failed",
+    failureCode: "local_read_failed",
+    allowClipboardFallback: reason === "not_found" || reason === "permission_denied",
+  };
+}
+
+function localReadFailureReasonFromError(err: unknown): LocalReadFailureReason {
+  if (!(err instanceof Error) || !("code" in err)) {
+    return "unknown";
+  }
+  const code = (err as { code?: unknown }).code;
+  if (code === "ENOENT" || code === "ENOTDIR") {
+    return "not_found";
+  }
+  if (code === "EACCES" || code === "EPERM") {
+    return "permission_denied";
+  }
+  return "unknown";
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolveDelay) => {
+    setTimeout(resolveDelay, ms);
+  });
 }
 
 function dedupeCandidates(candidates: InternalCandidate[]): InternalCandidate[] {

--- a/packages/sync-client/src/cli/rich-paste.ts
+++ b/packages/sync-client/src/cli/rich-paste.ts
@@ -176,6 +176,7 @@ type LocalValidationResult =
       status: "failed";
       failureCode: RichPasteFailureCode;
       allowClipboardFallback: boolean;
+      retryable: boolean;
     };
 
 const IMAGE_EXTENSIONS = Object.values(RICH_PASTE_IMAGE_TYPES)
@@ -583,19 +584,27 @@ function createRawCandidate(input: {
 function normalizeTerminalLocalPath(rawPath: string): string {
   const decodedPath = decodeTerminalPathEscapes(rawPath);
   if (decodedPath.startsWith("file://")) {
-    try {
-      const url = new URL(decodedPath);
-      if (url.protocol === "file:") {
-        return fileURLToPath(url);
-      }
-    } catch (err: unknown) {
-      if (err instanceof Error) {
-        return decodedPath;
-      }
+    if (!URL.canParse(decodedPath)) {
       return decodedPath;
     }
+    const url = new URL(decodedPath);
+    if (url.protocol === "file:") {
+      return safeFileUrlToPath(url) ?? decodedPath;
+    }
+    return decodedPath;
   }
   return expandLocalPath(decodedPath);
+}
+
+function safeFileUrlToPath(url: URL): string | undefined {
+  try {
+    return fileURLToPath(url);
+  } catch (err: unknown) {
+    if (err instanceof Error) {
+      return undefined;
+    }
+    throw err;
+  }
 }
 
 function decodeTerminalPathEscapes(value: string): string {
@@ -651,7 +660,7 @@ async function validateLocalCandidate(
     if (
       result.status !== "failed" ||
       result.failureCode !== "local_read_failed" ||
-      !result.allowClipboardFallback ||
+      !result.retryable ||
       nextRetry >= options.retryDelaysMs.length
     ) {
       return result;
@@ -682,6 +691,7 @@ async function validateLocalCandidateOnce(
         status: "failed",
         failureCode: "image_too_large",
         allowClipboardFallback: false,
+        retryable: false,
       };
     }
     const [stats, bytes, resolvedRealPath] = await Promise.all([
@@ -697,6 +707,7 @@ async function validateLocalCandidateOnce(
         status: "failed",
         failureCode: "image_too_large",
         allowClipboardFallback: false,
+        retryable: false,
       };
     }
     const sniffedMimeType = sniffImageMimeType(bytes);
@@ -724,6 +735,7 @@ function localReadFailed(reason: LocalReadFailureReason): LocalValidationResult 
     status: "failed",
     failureCode: "local_read_failed",
     allowClipboardFallback: reason === "not_found" || reason === "permission_denied",
+    retryable: reason === "not_found",
   };
 }
 

--- a/packages/sync-client/src/cli/shell-client.ts
+++ b/packages/sync-client/src/cli/shell-client.ts
@@ -1043,7 +1043,9 @@ export function createShellClient(options: ShellClientOptions): ShellClient {
               writeError(`\r\n${result.localMessage}\r\n`);
               return;
             }
-            writeError(`\r\n${RICH_PASTE_INSERTED_MESSAGE}\r\n`);
+            if (result.status === "rewritten") {
+              writeError(`\r\n${RICH_PASTE_INSERTED_MESSAGE}\r\n`);
+            }
             sendInputData(result.outgoingText);
           }).catch((err: unknown) => {
             if (!settled) {

--- a/packages/sync-client/src/cli/shell-client.ts
+++ b/packages/sync-client/src/cli/shell-client.ts
@@ -132,6 +132,8 @@ const SAFE_SHELL_SERVER_ERROR_CODES = new Set([
 ]);
 const RICH_PASTE_UPLOAD_FAILED_MESSAGE = "Image paste failed: upload did not complete.";
 const INCOMPLETE_BRACKETED_PASTE_MESSAGE = "Image paste failed: paste did not complete.";
+const RICH_PASTE_PROGRESS_MESSAGE = "Image paste: reading/uploading...";
+const RICH_PASTE_INSERTED_MESSAGE = "Image paste: inserted.";
 
 type MaybeTtyStream = NodeJS.ReadStream & {
   isTTY?: boolean;
@@ -1028,6 +1030,7 @@ export function createShellClient(options: ShellClientOptions): ShellClient {
             sendInputData(data);
             return;
           }
+          writeError(`\r\n${RICH_PASTE_PROGRESS_MESSAGE}\r\n`);
           return richPasteRewriter.rewrite({
             sessionName: name,
             text: options.manualClipboardPaste ? "" : data,
@@ -1040,6 +1043,7 @@ export function createShellClient(options: ShellClientOptions): ShellClient {
               writeError(`\r\n${result.localMessage}\r\n`);
               return;
             }
+            writeError(`\r\n${RICH_PASTE_INSERTED_MESSAGE}\r\n`);
             sendInputData(result.outgoingText);
           }).catch((err: unknown) => {
             if (!settled) {

--- a/packages/sync-client/tests/unit/rich-paste.test.ts
+++ b/packages/sync-client/tests/unit/rich-paste.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, mkdtemp, rm, symlink, writeFile } from "node:fs/promises";
+import { chmod, mkdir, mkdtemp, rm, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { pathToFileURL } from "node:url";
@@ -344,6 +344,46 @@ describe("cli/rich-paste", () => {
     expect(result.failureCode).toBe("local_read_failed");
     expect(clipboardReader.readImage).not.toHaveBeenCalled();
     expect(client.uploadPasteAssets).not.toHaveBeenCalled();
+  });
+
+  it("falls back to the clipboard without retry delay for a single permission-denied image path", async () => {
+    const lockedDir = join(tempDir, "locked");
+    await mkdir(lockedDir);
+    const localPath = join(lockedDir, "screen.png");
+    await writeFile(localPath, pngBytes);
+    await chmod(lockedDir, 0o000);
+    const client = uploadClient(["/home/matrix/home/projects/.matrix-terminal-pastes/main/2026-07-08/clipboard.png"]);
+    const clipboardReader = {
+      readImage: vi.fn(async () => ({
+        status: "available" as const,
+        candidate: {
+          kind: "clipboard" as const,
+          capturedAt: new Date("2026-07-08T10:31:00Z"),
+          sizeBytes: pngBytes.byteLength,
+          mimeType: "image/png" as const,
+          bytes: new Uint8Array(pngBytes),
+        },
+      })),
+    };
+
+    try {
+      const startedAt = Date.now();
+      const result = await processRichPasteTransaction({
+        sessionName: "main",
+        text: localPath,
+        observablePaste: false,
+        uploadClient: client,
+        clipboardReader,
+        localReadRetryDelaysMs: [1_000],
+      });
+
+      expect(result.status).toBe("rewritten");
+      expect(result.outgoingText).toBe("/home/matrix/home/projects/.matrix-terminal-pastes/main/2026-07-08/clipboard.png");
+      expect(clipboardReader.readImage).toHaveBeenCalledTimes(1);
+      expect(Date.now() - startedAt).toBeLessThan(500);
+    } finally {
+      await chmod(lockedDir, 0o700);
+    }
   });
 
   it("fails locally for unreadable non-file image paths", async () => {

--- a/packages/sync-client/tests/unit/rich-paste.test.ts
+++ b/packages/sync-client/tests/unit/rich-paste.test.ts
@@ -1,6 +1,7 @@
 import { mkdir, mkdtemp, rm, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { pathToFileURL } from "node:url";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   RICH_PASTE_MAX_IMAGE_BYTES,
@@ -181,6 +182,7 @@ describe("cli/rich-paste", () => {
       observablePaste: true,
       uploadClient: client,
       clipboardReader,
+      localReadRetryDelaysMs: [],
     });
 
     expect(result.status).toBe("rewritten");
@@ -192,6 +194,126 @@ describe("cli/rich-paste", () => {
       mimeType: "image/png",
       bytes: new Uint8Array(pngBytes),
     }]);
+  });
+
+  it("falls back to the clipboard image for a single unreadable non-bracketed dropped image path", async () => {
+    const localPath = join(tempDir, "missing.png");
+    const client = uploadClient(["/home/matrix/home/projects/.matrix-terminal-pastes/main/2026-07-08/clipboard.png"]);
+    const clipboardReader = {
+      readImage: vi.fn(async () => ({
+        status: "available" as const,
+        candidate: {
+          kind: "clipboard" as const,
+          capturedAt: new Date("2026-07-08T10:31:00Z"),
+          sizeBytes: pngBytes.byteLength,
+          mimeType: "image/png" as const,
+          bytes: new Uint8Array(pngBytes),
+        },
+      })),
+    };
+
+    const result = await processRichPasteTransaction({
+      sessionName: "main",
+      text: `"${localPath}" `,
+      observablePaste: false,
+      uploadClient: client,
+      clipboardReader,
+      localReadRetryDelaysMs: [],
+    });
+
+    expect(result.status).toBe("rewritten");
+    expect(result.outgoingText).toBe('"/home/matrix/home/projects/.matrix-terminal-pastes/main/2026-07-08/clipboard.png" ');
+    expect(clipboardReader.readImage).toHaveBeenCalledTimes(1);
+  });
+
+  it("decodes terminal-emitted unicode escapes in quoted dropped image paths", async () => {
+    const actualPath = join(tempDir, "Screenshot 2026-07-09 at 5.13.48\u202fPM.png");
+    await writeFile(actualPath, pngBytes);
+    const client = uploadClient(["/home/matrix/home/projects/.matrix-terminal-pastes/main/2026-07-08/screenshot.png"]);
+    const terminalPath = actualPath.replace("\u202f", "\\u202f");
+
+    const result = await processRichPasteTransaction({
+      sessionName: "main",
+      text: `"${terminalPath}" `,
+      observablePaste: false,
+      uploadClient: client,
+    });
+
+    expect(result.status).toBe("rewritten");
+    expect(result.outgoingText).toBe('"/home/matrix/home/projects/.matrix-terminal-pastes/main/2026-07-08/screenshot.png" ');
+    expect(client.uploadPasteAssets).toHaveBeenCalledTimes(1);
+  });
+
+  it("rewrites single whole-input unquoted image paths with spaces", async () => {
+    const localPath = join(tempDir, "Screenshot with spaces.png");
+    await writeFile(localPath, pngBytes);
+    const client = uploadClient(["/home/matrix/home/projects/.matrix-terminal-pastes/main/2026-07-08/spaces.png"]);
+
+    const result = await processRichPasteTransaction({
+      sessionName: "main",
+      text: `${localPath} `,
+      observablePaste: false,
+      uploadClient: client,
+    });
+
+    expect(result.status).toBe("rewritten");
+    expect(result.outgoingText).toBe("/home/matrix/home/projects/.matrix-terminal-pastes/main/2026-07-08/spaces.png ");
+  });
+
+  it("decodes backslash-escaped spaces in dropped image paths", async () => {
+    const localPath = join(tempDir, "Screenshot escaped spaces.png");
+    await writeFile(localPath, pngBytes);
+    const client = uploadClient(["/home/matrix/home/projects/.matrix-terminal-pastes/main/2026-07-08/escaped.png"]);
+    const escapedPath = localPath.replaceAll(" ", "\\ ");
+
+    const result = await processRichPasteTransaction({
+      sessionName: "main",
+      text: escapedPath,
+      observablePaste: false,
+      uploadClient: client,
+    });
+
+    expect(result.status).toBe("rewritten");
+    expect(result.outgoingText).toBe("/home/matrix/home/projects/.matrix-terminal-pastes/main/2026-07-08/escaped.png");
+  });
+
+  it("rewrites file url image paths with percent encoding", async () => {
+    const localPath = join(tempDir, "Screenshot file url.png");
+    await writeFile(localPath, pngBytes);
+    const client = uploadClient(["/home/matrix/home/projects/.matrix-terminal-pastes/main/2026-07-08/file-url.png"]);
+
+    const result = await processRichPasteTransaction({
+      sessionName: "main",
+      text: pathToFileURL(localPath).href,
+      observablePaste: false,
+      uploadClient: client,
+    });
+
+    expect(result.status).toBe("rewritten");
+    expect(result.outgoingText).toBe("/home/matrix/home/projects/.matrix-terminal-pastes/main/2026-07-08/file-url.png");
+  });
+
+  it("retries transient single-path dropped images until the file becomes readable", async () => {
+    const localPath = join(tempDir, "transient.png");
+    const client = uploadClient(["/home/matrix/home/projects/.matrix-terminal-pastes/main/2026-07-08/transient.png"]);
+    const writeLater = setTimeout(() => {
+      void writeFile(localPath, pngBytes);
+    }, 10);
+
+    try {
+      const result = await processRichPasteTransaction({
+        sessionName: "main",
+        text: localPath,
+        observablePaste: false,
+        uploadClient: client,
+        localReadRetryDelaysMs: [25, 25],
+      });
+
+      expect(result.status).toBe("rewritten");
+      expect(result.outgoingText).toBe("/home/matrix/home/projects/.matrix-terminal-pastes/main/2026-07-08/transient.png");
+    } finally {
+      clearTimeout(writeLater);
+    }
   });
 
   it("does not use clipboard fallback for prose with an unreadable image path", async () => {
@@ -278,22 +400,36 @@ describe("cli/rich-paste", () => {
     expect(client.uploadPasteAssets).not.toHaveBeenCalled();
   });
 
-  it("rejects symlinked image paths", async () => {
+  it("rejects symlinked image paths without clipboard fallback", async () => {
     const target = join(tempDir, "target.png");
     const link = join(tempDir, "link.png");
     await writeFile(target, pngBytes);
     await symlink(target, link);
     const client = uploadClient([]);
+    const clipboardReader = {
+      readImage: vi.fn(async () => ({
+        status: "available" as const,
+        candidate: {
+          kind: "clipboard" as const,
+          capturedAt: new Date("2026-07-08T10:31:00Z"),
+          sizeBytes: pngBytes.byteLength,
+          mimeType: "image/png" as const,
+          bytes: new Uint8Array(pngBytes),
+        },
+      })),
+    };
 
     const result = await processRichPasteTransaction({
       sessionName: "main",
-      text: `inspect ${link}`,
+      text: link,
       observablePaste: true,
       uploadClient: client,
+      clipboardReader,
     });
 
     expect(result.status).toBe("failed");
     expect(result.localMessage).toBe("Image paste failed: local image could not be read.");
+    expect(clipboardReader.readImage).not.toHaveBeenCalled();
     expect(client.uploadPasteAssets).not.toHaveBeenCalled();
   });
 

--- a/packages/sync-client/tests/unit/shell-client.test.ts
+++ b/packages/sync-client/tests/unit/shell-client.test.ts
@@ -789,6 +789,61 @@ describe("createShellClient attachSession", () => {
     await expect(attach).resolves.toEqual({ detached: false });
   });
 
+  it("does not print inserted feedback when rich paste passes text through", async () => {
+    const input = new PassThrough() as PassThrough & {
+      isTTY: true;
+      rows: number;
+      columns: number;
+      setRawMode: ReturnType<typeof vi.fn>;
+      pause: ReturnType<typeof vi.fn>;
+    };
+    input.isTTY = true;
+    input.rows = 24;
+    input.columns = 80;
+    input.setRawMode = vi.fn();
+    input.pause = vi.fn();
+    const errorOutput = new PassThrough();
+    const errors: string[] = [];
+    errorOutput.on("data", (chunk) => errors.push(String(chunk)));
+    const rewriter = {
+      rewrite: vi.fn(async () => ({
+        status: "passthrough" as const,
+        outgoingText: "/tmp/not-uploaded.png",
+        assets: [],
+      })),
+    };
+    const client = createShellClient({
+      gatewayUrl: "https://matrix.example",
+      token: "token-123",
+      timeoutMs: 100,
+    });
+    const attach = client.attachSession("main", {
+      input,
+      output: new PassThrough(),
+      errorOutput: errorOutput as NodeJS.WriteStream,
+      WebSocketImpl: FakeWebSocket as never,
+      richPaste: { rewriter },
+    });
+
+    FakeWebSocket.last?.emit("message", JSON.stringify({ type: "attached" }));
+    input.write("/tmp/not-uploaded.png");
+
+    const deadline = Date.now() + 250;
+    while (sentInputData().length < 1) {
+      if (Date.now() > deadline) break;
+      await new Promise((resolve) => {
+        setTimeout(resolve, 1);
+      });
+    }
+
+    expect(errors.join("")).toContain("Image paste: reading/uploading...");
+    expect(errors.join("")).not.toContain("Image paste: inserted.");
+    expect(sentInputData()).toEqual(["/tmp/not-uploaded.png"]);
+
+    FakeWebSocket.last?.emit("message", JSON.stringify({ type: "exit" }));
+    await expect(attach).resolves.toEqual({ detached: false });
+  });
+
   it("uses live tail by default so attach does not replay stale full-screen frames", async () => {
     const client = createShellClient({
       gatewayUrl: "https://matrix.example",

--- a/packages/sync-client/tests/unit/shell-client.test.ts
+++ b/packages/sync-client/tests/unit/shell-client.test.ts
@@ -600,7 +600,7 @@ describe("createShellClient attachSession", () => {
     input.write("\u001cv");
 
     const deadline = Date.now() + 250;
-    while (!errors.join("").includes("Image paste")) {
+    while (!errors.join("").includes("Image paste is not supported")) {
       if (Date.now() > deadline) break;
       await new Promise((resolve) => {
         setTimeout(resolve, 1);
@@ -781,6 +781,7 @@ describe("createShellClient attachSession", () => {
       });
     }
 
+    expect(errors.join("")).toContain("Image paste: reading/uploading...");
     expect(errors.join("")).toContain("Image paste failed: upload did not complete.");
     expect(FakeWebSocket.last?.sent.join("\n")).not.toContain("/var/folders/t5");
 


### PR DESCRIPTION
Summary
- Normalize terminal-emitted image paths before local validation, including literal \uXXXX escapes, backslash-escaped path characters, file:// URLs, and whole-input dropped paths with spaces.
- Retry strict single-path local image reads briefly, then fall back to the clipboard image for retryable dropped temp-file failures.
- Add local shell attach progress feedback while image paste rewriting/uploading is in flight.

Tests
- pnpm --filter @finnaai/matrix exec vitest run tests/unit/rich-paste.test.ts tests/unit/shell-client.test.ts
- pnpm --filter @finnaai/matrix build
- pnpm --filter @finnaai/matrix test
- ./scripts/review/check-patterns.sh (0 violations; existing repo warnings only)
- Root typecheck equivalent via pnpm because bun is unavailable in this environment: observability build, kernel build, observability/gateway/platform/proxy/edge-router tsc --noEmit, desktop typecheck
- pnpm exec vitest run (757 files passed, 8214 tests passed, 27 skipped)

Review/Monitoring
- This PR intentionally does not claim image-only Cmd-V can work when the terminal emits no stdin bytes.
- GitHub PR checks passed on 72c3449fc2b42b30574119603ff633282439cf63.
- Greptile Confidence Score: 5/5 on 72c3449fc2b42b30574119603ff633282439cf63.
- Earlier Greptile inline comments were fixed and acknowledged before merge.

Invariants
- Source of truth: local image bytes come only from a readable local file or the macOS clipboard reader; remote terminal text receives only uploaded asset paths.
- Lock/transaction scope: no DB transaction is involved; local read, clipboard fallback, and upload remain sequential in the CLI paste transaction.
- Acceptable orphan states: if upload fails after local read succeeds, no local path is sent to the remote shell and the user gets a generic paste failure.
- Auth source of truth: upload auth continues to use the existing sync-client gateway token path; this change does not add auth surfaces.
- Deferred scope: image-only Cmd-V remains terminal-dependent and is not changed here.
