### PR TITLE
fix(mobile): redact coding-agent diagnostics

### DIFF
--- a/apps/mobile/__tests__/coding-agent-diagnostics.test.ts
+++ b/apps/mobile/__tests__/coding-agent-diagnostics.test.ts
@@ -33,6 +33,12 @@ describe("mobile coding-agent diagnostics", () => {
     expect(redacted).toBe("Authorization: [token]");
   });
 
+  it("redacts private ipv6 diagnostic hosts", () => {
+    const redacted = redactMobileCodingAgentDiagnosticText("connect ::1 fe80::1 fd12:3456:789a::1");
+
+    expect(redacted).toBe("connect [host] [host] [host]");
+  });
+
   it("bounds long diagnostic text", () => {
     const redacted = redactMobileCodingAgentDiagnosticText(`status ${"x".repeat(220)}`);
 

--- a/apps/mobile/__tests__/coding-agent-diagnostics.test.ts
+++ b/apps/mobile/__tests__/coding-agent-diagnostics.test.ts
@@ -1,4 +1,5 @@
 import {
+  formatMobileCodingAgentDiagnostic,
   logMobileCodingAgentWarning,
   redactMobileCodingAgentDiagnosticText,
 } from "../lib/coding-agent-diagnostics";
@@ -10,6 +11,8 @@ describe("mobile coding-agent diagnostics", () => {
       "Authorization: Bearer ghp_privatevalue1234567890",
       "url=https://internal-runtime.local/api?token=secret",
       "host=internal-runtime.local probe 10.0.0.8",
+      "socket /run/matrix/gateway.sock",
+      "windows C:\\Users\\alice\\matrix\\token.txt",
       "postgres://matrix:secret@10.0.0.8:5432/runtime",
     ].join(" ");
 
@@ -20,7 +23,29 @@ describe("mobile coding-agent diagnostics", () => {
     expect(redacted).toContain("[url]");
     expect(redacted).toContain("[host]");
     expect(redacted.length).toBeLessThanOrEqual(180);
-    expect(redacted).not.toMatch(/\/home\/matrix|private-app|ghp_|internal-runtime|postgres|10\.0\.0\.8|secret/i);
+    expect(redacted).not.toMatch(/\/home\/matrix|\/run\/matrix|C:\\Users|alice|private-app|ghp_|internal-runtime|postgres|10\.0\.0\.8|secret/i);
+  });
+
+  it("bounds long diagnostic text", () => {
+    const redacted = redactMobileCodingAgentDiagnosticText(`status ${"x".repeat(220)}`);
+
+    expect(redacted).toHaveLength(180);
+    expect(redacted.endsWith("...")).toBe(true);
+  });
+
+  it("formats non-error diagnostics and unsafe names safely", () => {
+    const unknown = formatMobileCodingAgentDiagnostic("token=sk_live_private /tmp/private-file");
+    const unsafeNameError = new Error("failed");
+    unsafeNameError.name = "!!!";
+
+    expect(unknown).toEqual({
+      name: "Unknown",
+      message: "token= [token] [path]",
+    });
+    expect(formatMobileCodingAgentDiagnostic(unsafeNameError)).toEqual({
+      name: "Error",
+      message: "failed",
+    });
   });
 
   it("logs bounded scope and redacted metadata only", () => {
@@ -40,5 +65,17 @@ describe("mobile coding-agent diagnostics", () => {
       }),
     );
     expect(JSON.stringify(warn.mock.calls)).not.toMatch(/alice|id_rsa|sk_live_secret/i);
+  });
+
+  it("redacts exported scope labels defensively", () => {
+    const warn = jest.fn();
+
+    logMobileCodingAgentWarning("database probe /home/matrix/home token=ghp_private123", "status 500", { warn });
+
+    expect(warn).toHaveBeenCalledWith(
+      "[mobile] [database] probe [path] token= [token]",
+      expect.objectContaining({ message: "status 500" }),
+    );
+    expect(JSON.stringify(warn.mock.calls)).not.toMatch(/\/home\/matrix|ghp_private123/i);
   });
 });

--- a/apps/mobile/__tests__/coding-agent-diagnostics.test.ts
+++ b/apps/mobile/__tests__/coding-agent-diagnostics.test.ts
@@ -83,6 +83,24 @@ describe("mobile coding-agent diagnostics", () => {
     expect(redacted).not.toMatch(/\/home\/matrix|private\.ts|internal-runtime|localhost/);
   });
 
+  it("redacts backtick-quoted owner paths", () => {
+    const redacted = redactMobileCodingAgentDiagnosticText(
+      "open `/home/matrix/home/project/file.ts` failed",
+    );
+
+    expect(redacted).toBe("open `[path]` failed");
+    expect(redacted).not.toMatch(/\/home\/matrix|project|file\.ts/);
+  });
+
+  it("redacts single-label hosts in network errors", () => {
+    const redacted = redactMobileCodingAgentDiagnosticText(
+      "getaddrinfo ENOTFOUND internal-runtime connect ECONNREFUSED matrix-vps",
+    );
+
+    expect(redacted).toBe("getaddrinfo ENOTFOUND [host] connect ECONNREFUSED [host]");
+    expect(redacted).not.toMatch(/internal-runtime|matrix-vps/);
+  });
+
   it("bounds long diagnostic text", () => {
     const redacted = redactMobileCodingAgentDiagnosticText(`status ${"x".repeat(220)}`);
 

--- a/apps/mobile/__tests__/coding-agent-diagnostics.test.ts
+++ b/apps/mobile/__tests__/coding-agent-diagnostics.test.ts
@@ -11,6 +11,7 @@ describe("mobile coding-agent diagnostics", () => {
       "Authorization: Bearer ghp_privatevalue1234567890",
       "url=https://internal-runtime.local/api?token=secret",
       "host=internal-runtime.local probe 10.0.0.8",
+      "link-local 169.254.10.20",
       "socket /run/matrix/gateway.sock",
       "windows C:\\Users\\alice\\matrix\\token.txt",
       "postgres://matrix:secret@10.0.0.8:5432/runtime",
@@ -23,7 +24,13 @@ describe("mobile coding-agent diagnostics", () => {
     expect(redacted).toContain("[url]");
     expect(redacted).toContain("[host]");
     expect(redacted.length).toBeLessThanOrEqual(180);
-    expect(redacted).not.toMatch(/\/home\/matrix|\/run\/matrix|C:\\Users|alice|private-app|ghp_|internal-runtime|postgres|10\.0\.0\.8|secret/i);
+    expect(redacted).not.toMatch(/\/home\/matrix|\/run\/matrix|C:\\Users|alice|private-app|ghp_|internal-runtime|postgres|10\.0\.0\.8|169\.254\.10\.20|secret/i);
+  });
+
+  it("avoids duplicate token placeholders for authorization headers", () => {
+    const redacted = redactMobileCodingAgentDiagnosticText("Authorization: Bearer ghp_privatevalue1234567890");
+
+    expect(redacted).toBe("Authorization: [token]");
   });
 
   it("bounds long diagnostic text", () => {
@@ -36,7 +43,9 @@ describe("mobile coding-agent diagnostics", () => {
   it("formats non-error diagnostics and unsafe names safely", () => {
     const unknown = formatMobileCodingAgentDiagnostic("token=sk_live_private /tmp/private-file");
     const unsafeNameError = new Error("failed");
+    const tokenNameError = new Error("failed");
     unsafeNameError.name = "!!!";
+    tokenNameError.name = "sk_live_private_name";
 
     expect(unknown).toEqual({
       name: "Unknown",
@@ -44,6 +53,10 @@ describe("mobile coding-agent diagnostics", () => {
     });
     expect(formatMobileCodingAgentDiagnostic(unsafeNameError)).toEqual({
       name: "Error",
+      message: "failed",
+    });
+    expect(formatMobileCodingAgentDiagnostic(tokenNameError)).toEqual({
+      name: "token",
       message: "failed",
     });
   });

--- a/apps/mobile/__tests__/coding-agent-diagnostics.test.ts
+++ b/apps/mobile/__tests__/coding-agent-diagnostics.test.ts
@@ -1,0 +1,44 @@
+import {
+  logMobileCodingAgentWarning,
+  redactMobileCodingAgentDiagnosticText,
+} from "../lib/coding-agent-diagnostics";
+
+describe("mobile coding-agent diagnostics", () => {
+  it("redacts sensitive diagnostic text before logging", () => {
+    const text = [
+      "failed /home/matrix/home/projects/private-app/src/index.ts",
+      "Authorization: Bearer ghp_privatevalue1234567890",
+      "url=https://internal-runtime.local/api?token=secret",
+      "host=internal-runtime.local probe 10.0.0.8",
+      "postgres://matrix:secret@10.0.0.8:5432/runtime",
+    ].join(" ");
+
+    const redacted = redactMobileCodingAgentDiagnosticText(text);
+
+    expect(redacted).toContain("[path]");
+    expect(redacted).toContain("[token]");
+    expect(redacted).toContain("[url]");
+    expect(redacted).toContain("[host]");
+    expect(redacted.length).toBeLessThanOrEqual(180);
+    expect(redacted).not.toMatch(/\/home\/matrix|private-app|ghp_|internal-runtime|postgres|10\.0\.0\.8|secret/i);
+  });
+
+  it("logs bounded scope and redacted metadata only", () => {
+    const warn = jest.fn();
+
+    logMobileCodingAgentWarning(
+      "/api/coding-agents/files/read unavailable",
+      new Error("raw file /Users/alice/.ssh/id_rsa token=sk_live_secret"),
+      { warn },
+    );
+
+    expect(warn).toHaveBeenCalledWith(
+      "[mobile] /api/coding-agents/files/read unavailable",
+      expect.objectContaining({
+        name: "Error",
+        message: expect.stringContaining("[path]"),
+      }),
+    );
+    expect(JSON.stringify(warn.mock.calls)).not.toMatch(/alice|id_rsa|sk_live_secret/i);
+  });
+});

--- a/apps/mobile/__tests__/coding-agent-diagnostics.test.ts
+++ b/apps/mobile/__tests__/coding-agent-diagnostics.test.ts
@@ -15,7 +15,7 @@ describe("mobile coding-agent diagnostics", () => {
       "socket /run/matrix/gateway.sock",
       "windows C:\\Users\\alice\\matrix\\token.txt",
       "postgres://matrix:secret@10.0.0.8:5432/runtime",
-    ].join(" ");
+    ].join("\n");
 
     const redacted = redactMobileCodingAgentDiagnosticText(text);
 
@@ -33,10 +33,54 @@ describe("mobile coding-agent diagnostics", () => {
     expect(redacted).toBe("Authorization: [token]");
   });
 
-  it("redacts private ipv6 diagnostic hosts", () => {
-    const redacted = redactMobileCodingAgentDiagnosticText("connect ::1 fe80::1 fd12:3456:789a::1");
+  it("redacts complete authorization header values for every auth scheme", () => {
+    const redacted = redactMobileCodingAgentDiagnosticText([
+      "Authorization: Basic dXNlcjpwYXNzd29yZA==",
+      "Authorization: Token private-value",
+      'Authorization: Digest username="alice", response="private-response"',
+    ].join("\n"));
 
-    expect(redacted).toBe("connect [host] [host] [host]");
+    expect(redacted).toBe([
+      "Authorization: [token]",
+      "Authorization: [token]",
+      "Authorization: [token]",
+    ].join(" "));
+    expect(redacted).not.toMatch(/dXNlcj|private-value|alice|private-response/);
+  });
+
+  it("preserves the assignment separator without leaking secret fragments", () => {
+    const redacted = redactMobileCodingAgentDiagnosticText(
+      `token=abc:def apiKey="quoted private value" password: 'hunter2:private'`,
+    );
+
+    expect(redacted).toBe("token= [token] apiKey= [token] password: [token]");
+    expect(redacted).not.toMatch(/abc|def|quoted|private|hunter2/);
+  });
+
+  it("redacts compound secret keys without redacting unrelated assignments", () => {
+    const redacted = redactMobileCodingAgentDiagnosticText(
+      "AWS_SECRET_ACCESS_KEY=aws-private clientSecret=client-private privateKey=key-private idToken=id-private PGPASSWORD=pg-private MONKEY=banana",
+    );
+
+    expect(redacted).toBe(
+      "AWS_SECRET_ACCESS_KEY= [token] clientSecret= [token] privateKey= [token] idToken= [token] PGPASSWORD= [token] MONKEY=banana",
+    );
+    expect(redacted).not.toMatch(/aws-private|client-private|key-private|id-private|pg-private/);
+  });
+
+  it("redacts private ipv6 diagnostic hosts", () => {
+    const redacted = redactMobileCodingAgentDiagnosticText("connect ::1 fe80::1 fe90::2%en0 fd12:3456:789a::1");
+
+    expect(redacted).toBe("connect [host] [host] [host] [host]");
+  });
+
+  it("redacts assignment-prefixed owner paths and unlabeled private hosts", () => {
+    const redacted = redactMobileCodingAgentDiagnosticText(
+      "read path=/home/matrix/private.ts ENOTFOUND internal-runtime.local connect localhost",
+    );
+
+    expect(redacted).toBe("read path=[path] ENOTFOUND [host] connect [host]");
+    expect(redacted).not.toMatch(/\/home\/matrix|private\.ts|internal-runtime|localhost/);
   });
 
   it("bounds long diagnostic text", () => {

--- a/apps/mobile/__tests__/coding-agent-diagnostics.test.ts
+++ b/apps/mobile/__tests__/coding-agent-diagnostics.test.ts
@@ -101,6 +101,15 @@ describe("mobile coding-agent diagnostics", () => {
     expect(redacted).not.toMatch(/internal-runtime|matrix-vps/);
   });
 
+  it("redacts complete scheme-less host and url values", () => {
+    const redacted = redactMobileCodingAgentDiagnosticText(
+      "probe url=internal-runtime.local/api?token=secret host=matrix-vps/private?credential=value",
+    );
+
+    expect(redacted).toBe("probe url=[host] host=[host]");
+    expect(redacted).not.toMatch(/internal-runtime|matrix-vps|\/api|\/private|secret|credential|value/);
+  });
+
   it("bounds long diagnostic text", () => {
     const redacted = redactMobileCodingAgentDiagnosticText(`status ${"x".repeat(220)}`);
 

--- a/apps/mobile/__tests__/gateway-client.test.ts
+++ b/apps/mobile/__tests__/gateway-client.test.ts
@@ -1536,6 +1536,7 @@ describe("GatewayClient", () => {
 
   it("refreshes expired websocket tokens before reconnecting", async () => {
     jest.useFakeTimers();
+    const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => undefined);
     const OriginalWebSocket = global.WebSocket;
     const sockets: Array<{
       readyState: number;
@@ -1573,9 +1574,18 @@ describe("GatewayClient", () => {
     const client = new GatewayClient("https://app.matrix-os.com", "clerk-token");
     client.setWebSocketToken("expired-ws-token", Date.now() - 1000);
     client.connect();
-    sockets[0]?.onclose?.({ code: 1006, reason: "" });
+    sockets[0]?.onclose?.({ code: 1006, reason: "/home/matrix/home token=ghp_privatevalue1234567890" });
 
     await jest.runOnlyPendingTimersAsync();
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      "[mobile] websocket closed",
+      expect.objectContaining({
+        name: "Unknown",
+        message: expect.stringContaining("[path]"),
+      }),
+    );
+    expect(JSON.stringify(warnSpy.mock.calls)).not.toMatch(/\/home\/matrix|ghp_privatevalue/i);
 
     expect(fetchMock).toHaveBeenCalledWith("https://app.matrix-os.com/api/auth/ws-token", expect.objectContaining({
       headers: expect.objectContaining({ Authorization: "Bearer clerk-token" }),
@@ -1587,6 +1597,7 @@ describe("GatewayClient", () => {
     );
 
     fetchMock.mockRestore();
+    warnSpy.mockRestore();
     global.WebSocket = OriginalWebSocket;
     jest.useRealTimers();
   });
@@ -1610,13 +1621,44 @@ describe("GatewayClient", () => {
   it("returns a safe fallback when app inventory fetch fails", async () => {
     const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => undefined);
     const fetchMock = jest.spyOn(global, "fetch").mockRejectedValueOnce(
-      new Error("network unavailable"),
+      new Error("network unavailable /var/run/provider.sock token=sk_live_private"),
     );
 
     const client = new GatewayClient("http://localhost:4000");
     await expect(client.getApps()).resolves.toEqual([]);
 
-    expect(warnSpy).toHaveBeenCalledWith("[mobile] /api/apps unavailable", "network unavailable");
+    expect(warnSpy).toHaveBeenCalledWith(
+      "[mobile] /api/apps unavailable",
+      expect.objectContaining({
+        name: "Error",
+        message: expect.stringContaining("[path]"),
+      }),
+    );
+    expect(JSON.stringify(warnSpy.mock.calls)).not.toMatch(/\/var\/run|sk_live_private/i);
+
+    fetchMock.mockRestore();
+    warnSpy.mockRestore();
+  });
+
+  it("does not log raw app inventory error bodies", async () => {
+    const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => undefined);
+    const fetchMock = jest.spyOn(global, "fetch").mockResolvedValueOnce({
+      ok: false,
+      status: 503,
+      text: jest.fn().mockResolvedValueOnce("raw /home/matrix/home token=ghp_privatevalue1234567890"),
+    } as unknown as Response);
+
+    const client = new GatewayClient("http://localhost:4000");
+    await expect(client.getApps()).resolves.toEqual([]);
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      "[mobile] /api/apps unavailable",
+      expect.objectContaining({
+        name: "Unknown",
+        message: "status 503",
+      }),
+    );
+    expect(JSON.stringify(warnSpy.mock.calls)).not.toMatch(/\/home\/matrix|ghp_privatevalue|raw/i);
 
     fetchMock.mockRestore();
     warnSpy.mockRestore();
@@ -1634,7 +1676,13 @@ describe("GatewayClient", () => {
       error: "Gateway unavailable",
     });
 
-    expect(warnSpy).toHaveBeenCalledWith("[mobile] gateway health check unavailable");
+    expect(warnSpy).toHaveBeenCalledWith(
+      "[mobile] gateway health check unavailable",
+      expect.objectContaining({
+        name: "Unknown",
+        message: "unavailable",
+      }),
+    );
 
     fetchMock.mockRestore();
     warnSpy.mockRestore();

--- a/apps/mobile/lib/coding-agent-diagnostics.ts
+++ b/apps/mobile/lib/coding-agent-diagnostics.ts
@@ -17,6 +17,7 @@ const KNOWN_SECRET_PREFIX_PATTERN = /\b(?:sk|sk_live|sk_test|ghp|github_pat|xoxb
 const OWNER_PATH_PATTERN = /(?:^|[\s"'(:])(?:\/(?:home|Users|private|tmp|var|opt|etc|root|run)\/[^\s"'<>)]*)/g;
 const WINDOWS_PATH_PATTERN = /\b[A-Za-z]:\\[^\s"'<>)]*/g;
 const PRIVATE_IPV4_PATTERN = /\b(?:(?:10|127)\.\d{1,3}\.\d{1,3}\.\d{1,3}|169\.254\.\d{1,3}\.\d{1,3}|172\.(?:1[6-9]|2\d|3[0-1])\.\d{1,3}\.\d{1,3}|192\.168\.\d{1,3}\.\d{1,3})\b/g;
+const PRIVATE_IPV6_PATTERN = /(^|[^A-Fa-f0-9:])(?:(?:::1)|(?:fe80(?::[A-Fa-f0-9]{0,4}){1,7})|(?:f[cd][A-Fa-f0-9]{2}(?::[A-Fa-f0-9]{0,4}){1,7}))(?=$|[^A-Fa-f0-9:])/g;
 const HOST_VALUE_PATTERN = /\b(?:host|hostname|url)\s*[:=]?\s*[A-Za-z0-9.-]*(?:\.local|\.internal|\.lan|\.home|runtime|matrix|vps)[A-Za-z0-9.-]*/gi;
 const DATABASE_PATTERN = /\b(?:postgres(?:ql)?|kysely|database|db)\b/gi;
 
@@ -44,6 +45,7 @@ export function redactMobileCodingAgentDiagnosticText(value: unknown): string {
     .replace(OWNER_PATH_PATTERN, (match) => `${match[0] === "/" ? "" : match[0]}[path]`)
     .replace(WINDOWS_PATH_PATTERN, "[path]")
     .replace(PRIVATE_IPV4_PATTERN, "[host]")
+    .replace(PRIVATE_IPV6_PATTERN, (_match, prefix: string) => `${prefix}[host]`)
     .replace(HOST_VALUE_PATTERN, (match) => {
       const prefix = match.match(/^(host|hostname|url)\s*[:=]?/i)?.[0] ?? "host ";
       return `${prefix}[host]`;

--- a/apps/mobile/lib/coding-agent-diagnostics.ts
+++ b/apps/mobile/lib/coding-agent-diagnostics.ts
@@ -22,7 +22,7 @@ const PRIVATE_IPV4_PATTERN = /\b(?:(?:10|127)\.\d{1,3}\.\d{1,3}\.\d{1,3}|169\.25
 const PRIVATE_IPV6_PATTERN = /(^|[^A-Fa-f0-9:])(?:::1|(?:f[cd][A-Fa-f0-9]{2}|fe[89ab][A-Fa-f0-9])(?::[A-Fa-f0-9]{0,4}){1,7})(?:%[A-Za-z0-9_.-]+)?(?=$|[^A-Fa-f0-9:])/gi;
 const PRIVATE_HOSTNAME_PATTERN = /\b(?:(?=[A-Za-z0-9.-]{1,253}\b)(?:[A-Za-z0-9](?:[A-Za-z0-9-]{0,62})?\.)+(?:local|internal|lan|home|localhost)|localhost)\b/gi;
 const NETWORK_ERROR_SINGLE_LABEL_HOST_PATTERN = /\b((?:ENOTFOUND|EAI_AGAIN|ECONNREFUSED|EHOSTUNREACH|ETIMEDOUT)\s+)(?=[A-Za-z0-9-]{1,63}(?![A-Za-z0-9.-]))(?=[A-Za-z0-9-]*[A-Za-z])[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?(?![A-Za-z0-9.-])/gi;
-const HOST_VALUE_PATTERN = /\b(?:host|hostname|url)\s*[:=]?\s*[A-Za-z0-9.-]*(?:\.local|\.internal|\.lan|\.home|runtime|matrix|vps)[A-Za-z0-9.-]*/gi;
+const HOST_VALUE_PATTERN = /\b(hostname|host|url)(\s*[:=]\s*|\s+)(?:"(?:\\.|[^"\\\r\n])*"|'(?:\\.|[^'\\\r\n])*'|[^\s"'<>]+)/gi;
 const DATABASE_PATTERN = /\b(?:postgres(?:ql)?|kysely|database|db)\b/gi;
 
 function normalize(value: string): string {
@@ -74,9 +74,8 @@ export function redactMobileCodingAgentDiagnosticText(value: unknown): string {
     .replace(PRIVATE_IPV6_PATTERN, (_match, prefix: string) => `${prefix}[host]`)
     .replace(PRIVATE_HOSTNAME_PATTERN, "[host]")
     .replace(NETWORK_ERROR_SINGLE_LABEL_HOST_PATTERN, "$1[host]")
-    .replace(HOST_VALUE_PATTERN, (match) => {
-      const prefix = match.match(/^(host|hostname|url)\s*[:=]?/i)?.[0] ?? "host ";
-      return `${prefix}[host]`;
+    .replace(HOST_VALUE_PATTERN, (_match, key: string, separator: string) => {
+      return `${key}${separator}[host]`;
     })
     .replace(DATABASE_PATTERN, "[database]");
   return cap(normalize(redacted) || "unavailable");

--- a/apps/mobile/lib/coding-agent-diagnostics.ts
+++ b/apps/mobile/lib/coding-agent-diagnostics.ts
@@ -1,0 +1,78 @@
+const MAX_DIAGNOSTIC_MESSAGE_LENGTH = 180;
+const MAX_DIAGNOSTIC_NAME_LENGTH = 48;
+
+export interface MobileCodingAgentDiagnostic {
+  name: string;
+  message: string;
+}
+
+export interface MobileCodingAgentDiagnosticLogger {
+  warn(message: string, diagnostic?: MobileCodingAgentDiagnostic): void;
+}
+
+const URL_PATTERN = /\b[a-z][a-z0-9+.-]*:\/\/[^\s"'<>]+/gi;
+const BEARER_PATTERN = /\bBearer\s+[A-Za-z0-9._~+/=-]+/gi;
+const SECRET_ASSIGNMENT_PATTERN = /\b(?:authorization|api[_-]?key|access[_-]?token|refresh[_-]?token|token|password|passwd|secret)\s*[:=]\s*[^\s"'<>]+/gi;
+const KNOWN_SECRET_PREFIX_PATTERN = /\b(?:sk|sk_live|sk_test|ghp|github_pat|xoxb|xoxp|xoxa|xoxr|glpat|hf)[_-][A-Za-z0-9._-]{4,}\b/gi;
+const OWNER_PATH_PATTERN = /(?:^|[\s"'(:])(?:\/(?:home|Users|private|tmp|var|opt|etc|root)\/[^\s"'<>)]*)/g;
+const WINDOWS_PATH_PATTERN = /\b[A-Za-z]:\\[^\s"'<>)]*/g;
+const PRIVATE_IPV4_PATTERN = /\b(?:(?:10|127)\.\d{1,3}\.\d{1,3}\.\d{1,3}|172\.(?:1[6-9]|2\d|3[0-1])\.\d{1,3}\.\d{1,3}|192\.168\.\d{1,3}\.\d{1,3})\b/g;
+const HOST_VALUE_PATTERN = /\b(?:host|hostname|url)\s*[:=]?\s*[A-Za-z0-9.-]*(?:\.local|\.internal|\.lan|\.home|runtime|matrix|vps)[A-Za-z0-9.-]*/gi;
+const DATABASE_PATTERN = /\b(?:postgres(?:ql)?|kysely|database|db)\b/gi;
+
+function normalize(value: string): string {
+  return value.replace(/\s+/g, " ").trim();
+}
+
+function cap(value: string): string {
+  if (value.length <= MAX_DIAGNOSTIC_MESSAGE_LENGTH) return value;
+  return `${value.slice(0, MAX_DIAGNOSTIC_MESSAGE_LENGTH - 3)}...`;
+}
+
+export function redactMobileCodingAgentDiagnosticText(value: unknown): string {
+  const raw = normalize(typeof value === "string" ? value : String(value));
+  if (!raw) return "unavailable";
+  const redacted = raw
+    .replace(URL_PATTERN, "[url]")
+    .replace(BEARER_PATTERN, "Bearer [token]")
+    .replace(SECRET_ASSIGNMENT_PATTERN, (match) => {
+      const separator = match.includes(":") ? ":" : "=";
+      const key = match.split(separator)[0]?.trim() || "token";
+      return `${key}${separator} [token]`;
+    })
+    .replace(KNOWN_SECRET_PREFIX_PATTERN, "[token]")
+    .replace(OWNER_PATH_PATTERN, (match) => `${match[0] === "/" ? "" : match[0]}[path]`)
+    .replace(WINDOWS_PATH_PATTERN, "[path]")
+    .replace(PRIVATE_IPV4_PATTERN, "[host]")
+    .replace(HOST_VALUE_PATTERN, (match) => {
+      const prefix = match.match(/^(host|hostname|url)\s*[:=]?/i)?.[0] ?? "host ";
+      return `${prefix}[host]`;
+    })
+    .replace(DATABASE_PATTERN, "[database]");
+  return cap(normalize(redacted) || "unavailable");
+}
+
+function safeDiagnosticName(value: string): string {
+  return value.replace(/[^A-Za-z0-9_.-]/g, "").slice(0, MAX_DIAGNOSTIC_NAME_LENGTH) || "Error";
+}
+
+export function formatMobileCodingAgentDiagnostic(err: unknown): MobileCodingAgentDiagnostic {
+  if (err instanceof Error) {
+    return {
+      name: safeDiagnosticName(err.name || "Error"),
+      message: redactMobileCodingAgentDiagnosticText(err.message),
+    };
+  }
+  return {
+    name: "Unknown",
+    message: redactMobileCodingAgentDiagnosticText(err),
+  };
+}
+
+export function logMobileCodingAgentWarning(
+  scope: string,
+  err: unknown,
+  logger: MobileCodingAgentDiagnosticLogger = console,
+): void {
+  logger.warn(`[mobile] ${redactMobileCodingAgentDiagnosticText(scope)}`, formatMobileCodingAgentDiagnostic(err));
+}

--- a/apps/mobile/lib/coding-agent-diagnostics.ts
+++ b/apps/mobile/lib/coding-agent-diagnostics.ts
@@ -14,7 +14,7 @@ const URL_PATTERN = /\b[a-z][a-z0-9+.-]*:\/\/[^\s"'<>]+/gi;
 const BEARER_PATTERN = /\bBearer\s+[A-Za-z0-9._~+/=-]+/gi;
 const SECRET_ASSIGNMENT_PATTERN = /\b(?:authorization|api[_-]?key|access[_-]?token|refresh[_-]?token|token|password|passwd|secret)\s*[:=]\s*[^\s"'<>]+/gi;
 const KNOWN_SECRET_PREFIX_PATTERN = /\b(?:sk|sk_live|sk_test|ghp|github_pat|xoxb|xoxp|xoxa|xoxr|glpat|hf)[_-][A-Za-z0-9._-]{4,}\b/gi;
-const OWNER_PATH_PATTERN = /(?:^|[\s"'(:])(?:\/(?:home|Users|private|tmp|var|opt|etc|root)\/[^\s"'<>)]*)/g;
+const OWNER_PATH_PATTERN = /(?:^|[\s"'(:])(?:\/(?:home|Users|private|tmp|var|opt|etc|root|run)\/[^\s"'<>)]*)/g;
 const WINDOWS_PATH_PATTERN = /\b[A-Za-z]:\\[^\s"'<>)]*/g;
 const PRIVATE_IPV4_PATTERN = /\b(?:(?:10|127)\.\d{1,3}\.\d{1,3}\.\d{1,3}|172\.(?:1[6-9]|2\d|3[0-1])\.\d{1,3}\.\d{1,3}|192\.168\.\d{1,3}\.\d{1,3})\b/g;
 const HOST_VALUE_PATTERN = /\b(?:host|hostname|url)\s*[:=]?\s*[A-Za-z0-9.-]*(?:\.local|\.internal|\.lan|\.home|runtime|matrix|vps)[A-Za-z0-9.-]*/gi;
@@ -74,5 +74,6 @@ export function logMobileCodingAgentWarning(
   err: unknown,
   logger: MobileCodingAgentDiagnosticLogger = console,
 ): void {
+  // The helper is exported for mobile clients, so scope labels are redacted too.
   logger.warn(`[mobile] ${redactMobileCodingAgentDiagnosticText(scope)}`, formatMobileCodingAgentDiagnostic(err));
 }

--- a/apps/mobile/lib/coding-agent-diagnostics.ts
+++ b/apps/mobile/lib/coding-agent-diagnostics.ts
@@ -1,3 +1,4 @@
+const MAX_DIAGNOSTIC_INPUT_LENGTH = 4_096;
 const MAX_DIAGNOSTIC_MESSAGE_LENGTH = 180;
 const MAX_DIAGNOSTIC_NAME_LENGTH = 48;
 
@@ -11,13 +12,15 @@ export interface MobileCodingAgentDiagnosticLogger {
 }
 
 const URL_PATTERN = /\b[a-z][a-z0-9+.-]*:\/\/[^\s"'<>]+/gi;
-const BEARER_PATTERN = /\b(?:Authorization\s*:\s*)?Bearer\s+[A-Za-z0-9._~+/=-]+/gi;
-const SECRET_ASSIGNMENT_PATTERN = /\b(?:authorization|api[_-]?key|access[_-]?token|refresh[_-]?token|token|password|passwd|secret)\s*[:=]\s*[^\s"'<>]+/gi;
+const BEARER_PATTERN = /\bBearer\s+[A-Za-z0-9._~+/=-]+/gi;
+const AUTHORIZATION_ASSIGNMENT_PATTERN = /\b(authorization)(\s*[:=]\s*)[^\r\n]+/gi;
+const ASSIGNMENT_PATTERN = /\b([A-Za-z][A-Za-z0-9_-]{0,127})(\s*[:=]\s*)(?:(?:Basic|Bearer|Digest)\s+[^\s"'<>]+|"(?:\\.|[^"\\\r\n])*"|'(?:\\.|[^'\\\r\n])*'|[^\s"'<>]+)/gi;
 const KNOWN_SECRET_PREFIX_PATTERN = /\b(?:sk|sk_live|sk_test|ghp|github_pat|xoxb|xoxp|xoxa|xoxr|glpat|hf)[_-][A-Za-z0-9._-]{4,}\b/gi;
-const OWNER_PATH_PATTERN = /(?:^|[\s"'(:])(?:\/(?:home|Users|private|tmp|var|opt|etc|root|run)\/[^\s"'<>)]*)/g;
+const OWNER_PATH_PATTERN = /(?:^|[\s"'(:=])(?:\/(?:home|Users|private|tmp|var|opt|etc|root|run)\/[^\s"'<>)]*)/g;
 const WINDOWS_PATH_PATTERN = /\b[A-Za-z]:\\[^\s"'<>)]*/g;
 const PRIVATE_IPV4_PATTERN = /\b(?:(?:10|127)\.\d{1,3}\.\d{1,3}\.\d{1,3}|169\.254\.\d{1,3}\.\d{1,3}|172\.(?:1[6-9]|2\d|3[0-1])\.\d{1,3}\.\d{1,3}|192\.168\.\d{1,3}\.\d{1,3})\b/g;
-const PRIVATE_IPV6_PATTERN = /(^|[^A-Fa-f0-9:])(?:(?:::1)|(?:fe80(?::[A-Fa-f0-9]{0,4}){1,7})|(?:f[cd][A-Fa-f0-9]{2}(?::[A-Fa-f0-9]{0,4}){1,7}))(?=$|[^A-Fa-f0-9:])/g;
+const PRIVATE_IPV6_PATTERN = /(^|[^A-Fa-f0-9:])(?:::1|(?:f[cd][A-Fa-f0-9]{2}|fe[89ab][A-Fa-f0-9])(?::[A-Fa-f0-9]{0,4}){1,7})(?:%[A-Za-z0-9_.-]+)?(?=$|[^A-Fa-f0-9:])/gi;
+const PRIVATE_HOSTNAME_PATTERN = /\b(?:(?=[A-Za-z0-9.-]{1,253}\b)(?:[A-Za-z0-9](?:[A-Za-z0-9-]{0,62})?\.)+(?:local|internal|lan|home|localhost)|localhost)\b/gi;
 const HOST_VALUE_PATTERN = /\b(?:host|hostname|url)\s*[:=]?\s*[A-Za-z0-9.-]*(?:\.local|\.internal|\.lan|\.home|runtime|matrix|vps)[A-Za-z0-9.-]*/gi;
 const DATABASE_PATTERN = /\b(?:postgres(?:ql)?|kysely|database|db)\b/gi;
 
@@ -30,22 +33,45 @@ function cap(value: string): string {
   return `${value.slice(0, MAX_DIAGNOSTIC_MESSAGE_LENGTH - 3)}...`;
 }
 
+function isSecretAssignmentKey(key: string): boolean {
+  const segments = key
+    .replace(/([a-z0-9])([A-Z])/g, "$1_$2")
+    .replace(/([A-Z]+)([A-Z][a-z])/g, "$1_$2")
+    .toLowerCase()
+    .split(/[_-]+/);
+  if (segments.some((segment) => ["authorization", "credential", "credentials", "passwd", "password", "secret", "token"].includes(segment))) {
+    return true;
+  }
+
+  const flattened = segments.join("");
+  if (["apikey", "accesstoken", "authtoken", "pgpassword", "refreshtoken"].includes(flattened)) {
+    return true;
+  }
+
+  return segments.some(
+    (segment, index) => ["access", "api", "private"].includes(segment) && segments[index + 1] === "key",
+  );
+}
+
 export function redactMobileCodingAgentDiagnosticText(value: unknown): string {
-  const raw = normalize(typeof value === "string" ? value : String(value));
-  if (!raw) return "unavailable";
-  const redacted = raw
+  const input = (typeof value === "string" ? value : String(value)).slice(0, MAX_DIAGNOSTIC_INPUT_LENGTH);
+  if (!normalize(input)) return "unavailable";
+  const redacted = input
     .replace(URL_PATTERN, "[url]")
-    .replace(BEARER_PATTERN, (match) => (match.match(/^Authorization\s*:/i) ? "Authorization: [token]" : "Bearer [token]"))
-    .replace(SECRET_ASSIGNMENT_PATTERN, (match) => {
-      const separator = match.includes(":") ? ":" : "=";
-      const key = match.split(separator)[0]?.trim() || "token";
-      return `${key}${separator} [token]`;
+    .replace(BEARER_PATTERN, "Bearer [token]")
+    .replace(AUTHORIZATION_ASSIGNMENT_PATTERN, (_match, key: string, separator: string) => {
+      return `${key}${separator.trim()} [token]`;
+    })
+    .replace(ASSIGNMENT_PATTERN, (match, key: string, separator: string) => {
+      if (!isSecretAssignmentKey(key)) return match;
+      return `${key}${separator.trim()} [token]`;
     })
     .replace(KNOWN_SECRET_PREFIX_PATTERN, "[token]")
     .replace(OWNER_PATH_PATTERN, (match) => `${match[0] === "/" ? "" : match[0]}[path]`)
     .replace(WINDOWS_PATH_PATTERN, "[path]")
     .replace(PRIVATE_IPV4_PATTERN, "[host]")
     .replace(PRIVATE_IPV6_PATTERN, (_match, prefix: string) => `${prefix}[host]`)
+    .replace(PRIVATE_HOSTNAME_PATTERN, "[host]")
     .replace(HOST_VALUE_PATTERN, (match) => {
       const prefix = match.match(/^(host|hostname|url)\s*[:=]?/i)?.[0] ?? "host ";
       return `${prefix}[host]`;

--- a/apps/mobile/lib/coding-agent-diagnostics.ts
+++ b/apps/mobile/lib/coding-agent-diagnostics.ts
@@ -16,11 +16,12 @@ const BEARER_PATTERN = /\bBearer\s+[A-Za-z0-9._~+/=-]+/gi;
 const AUTHORIZATION_ASSIGNMENT_PATTERN = /\b(authorization)(\s*[:=]\s*)[^\r\n]+/gi;
 const ASSIGNMENT_PATTERN = /\b([A-Za-z][A-Za-z0-9_-]{0,127})(\s*[:=]\s*)(?:(?:Basic|Bearer|Digest)\s+[^\s"'<>]+|"(?:\\.|[^"\\\r\n])*"|'(?:\\.|[^'\\\r\n])*'|[^\s"'<>]+)/gi;
 const KNOWN_SECRET_PREFIX_PATTERN = /\b(?:sk|sk_live|sk_test|ghp|github_pat|xoxb|xoxp|xoxa|xoxr|glpat|hf)[_-][A-Za-z0-9._-]{4,}\b/gi;
-const OWNER_PATH_PATTERN = /(?:^|[\s"'(:=])(?:\/(?:home|Users|private|tmp|var|opt|etc|root|run)\/[^\s"'<>)]*)/g;
-const WINDOWS_PATH_PATTERN = /\b[A-Za-z]:\\[^\s"'<>)]*/g;
+const OWNER_PATH_PATTERN = /(?:^|[\s"'`(:=])(?:\/(?:home|Users|private|tmp|var|opt|etc|root|run)\/[^\s"'`<>)]*)/g;
+const WINDOWS_PATH_PATTERN = /\b[A-Za-z]:\\[^\s"'`<>)]*/g;
 const PRIVATE_IPV4_PATTERN = /\b(?:(?:10|127)\.\d{1,3}\.\d{1,3}\.\d{1,3}|169\.254\.\d{1,3}\.\d{1,3}|172\.(?:1[6-9]|2\d|3[0-1])\.\d{1,3}\.\d{1,3}|192\.168\.\d{1,3}\.\d{1,3})\b/g;
 const PRIVATE_IPV6_PATTERN = /(^|[^A-Fa-f0-9:])(?:::1|(?:f[cd][A-Fa-f0-9]{2}|fe[89ab][A-Fa-f0-9])(?::[A-Fa-f0-9]{0,4}){1,7})(?:%[A-Za-z0-9_.-]+)?(?=$|[^A-Fa-f0-9:])/gi;
 const PRIVATE_HOSTNAME_PATTERN = /\b(?:(?=[A-Za-z0-9.-]{1,253}\b)(?:[A-Za-z0-9](?:[A-Za-z0-9-]{0,62})?\.)+(?:local|internal|lan|home|localhost)|localhost)\b/gi;
+const NETWORK_ERROR_SINGLE_LABEL_HOST_PATTERN = /\b((?:ENOTFOUND|EAI_AGAIN|ECONNREFUSED|EHOSTUNREACH|ETIMEDOUT)\s+)(?=[A-Za-z0-9-]{1,63}(?![A-Za-z0-9.-]))(?=[A-Za-z0-9-]*[A-Za-z])[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?(?![A-Za-z0-9.-])/gi;
 const HOST_VALUE_PATTERN = /\b(?:host|hostname|url)\s*[:=]?\s*[A-Za-z0-9.-]*(?:\.local|\.internal|\.lan|\.home|runtime|matrix|vps)[A-Za-z0-9.-]*/gi;
 const DATABASE_PATTERN = /\b(?:postgres(?:ql)?|kysely|database|db)\b/gi;
 
@@ -72,6 +73,7 @@ export function redactMobileCodingAgentDiagnosticText(value: unknown): string {
     .replace(PRIVATE_IPV4_PATTERN, "[host]")
     .replace(PRIVATE_IPV6_PATTERN, (_match, prefix: string) => `${prefix}[host]`)
     .replace(PRIVATE_HOSTNAME_PATTERN, "[host]")
+    .replace(NETWORK_ERROR_SINGLE_LABEL_HOST_PATTERN, "$1[host]")
     .replace(HOST_VALUE_PATTERN, (match) => {
       const prefix = match.match(/^(host|hostname|url)\s*[:=]?/i)?.[0] ?? "host ";
       return `${prefix}[host]`;

--- a/apps/mobile/lib/coding-agent-diagnostics.ts
+++ b/apps/mobile/lib/coding-agent-diagnostics.ts
@@ -11,12 +11,12 @@ export interface MobileCodingAgentDiagnosticLogger {
 }
 
 const URL_PATTERN = /\b[a-z][a-z0-9+.-]*:\/\/[^\s"'<>]+/gi;
-const BEARER_PATTERN = /\bBearer\s+[A-Za-z0-9._~+/=-]+/gi;
+const BEARER_PATTERN = /\b(?:Authorization\s*:\s*)?Bearer\s+[A-Za-z0-9._~+/=-]+/gi;
 const SECRET_ASSIGNMENT_PATTERN = /\b(?:authorization|api[_-]?key|access[_-]?token|refresh[_-]?token|token|password|passwd|secret)\s*[:=]\s*[^\s"'<>]+/gi;
 const KNOWN_SECRET_PREFIX_PATTERN = /\b(?:sk|sk_live|sk_test|ghp|github_pat|xoxb|xoxp|xoxa|xoxr|glpat|hf)[_-][A-Za-z0-9._-]{4,}\b/gi;
 const OWNER_PATH_PATTERN = /(?:^|[\s"'(:])(?:\/(?:home|Users|private|tmp|var|opt|etc|root|run)\/[^\s"'<>)]*)/g;
 const WINDOWS_PATH_PATTERN = /\b[A-Za-z]:\\[^\s"'<>)]*/g;
-const PRIVATE_IPV4_PATTERN = /\b(?:(?:10|127)\.\d{1,3}\.\d{1,3}\.\d{1,3}|172\.(?:1[6-9]|2\d|3[0-1])\.\d{1,3}\.\d{1,3}|192\.168\.\d{1,3}\.\d{1,3})\b/g;
+const PRIVATE_IPV4_PATTERN = /\b(?:(?:10|127)\.\d{1,3}\.\d{1,3}\.\d{1,3}|169\.254\.\d{1,3}\.\d{1,3}|172\.(?:1[6-9]|2\d|3[0-1])\.\d{1,3}\.\d{1,3}|192\.168\.\d{1,3}\.\d{1,3})\b/g;
 const HOST_VALUE_PATTERN = /\b(?:host|hostname|url)\s*[:=]?\s*[A-Za-z0-9.-]*(?:\.local|\.internal|\.lan|\.home|runtime|matrix|vps)[A-Za-z0-9.-]*/gi;
 const DATABASE_PATTERN = /\b(?:postgres(?:ql)?|kysely|database|db)\b/gi;
 
@@ -34,7 +34,7 @@ export function redactMobileCodingAgentDiagnosticText(value: unknown): string {
   if (!raw) return "unavailable";
   const redacted = raw
     .replace(URL_PATTERN, "[url]")
-    .replace(BEARER_PATTERN, "Bearer [token]")
+    .replace(BEARER_PATTERN, (match) => (match.match(/^Authorization\s*:/i) ? "Authorization: [token]" : "Bearer [token]"))
     .replace(SECRET_ASSIGNMENT_PATTERN, (match) => {
       const separator = match.includes(":") ? ":" : "=";
       const key = match.split(separator)[0]?.trim() || "token";
@@ -53,7 +53,9 @@ export function redactMobileCodingAgentDiagnosticText(value: unknown): string {
 }
 
 function safeDiagnosticName(value: string): string {
-  return value.replace(/[^A-Za-z0-9_.-]/g, "").slice(0, MAX_DIAGNOSTIC_NAME_LENGTH) || "Error";
+  return redactMobileCodingAgentDiagnosticText(value)
+    .replace(/[^A-Za-z0-9_.-]/g, "")
+    .slice(0, MAX_DIAGNOSTIC_NAME_LENGTH) || "Error";
 }
 
 export function formatMobileCodingAgentDiagnostic(err: unknown): MobileCodingAgentDiagnostic {

--- a/apps/mobile/lib/gateway-client.ts
+++ b/apps/mobile/lib/gateway-client.ts
@@ -4,6 +4,7 @@ import {
   parseShellSessions,
   type MobileTerminalSession,
 } from "@/lib/terminal-state";
+import { logMobileCodingAgentWarning } from "@/lib/coding-agent-diagnostics";
 import {
   AgentThreadEventSchema,
   AgentThreadSnapshotSchema,
@@ -244,6 +245,19 @@ const ThreadStreamServerFrameSchema = z.discriminatedUnion("type", [
 ]);
 
 const WS_OPEN = 1;
+
+function logCodingAgentStatusWarning(scope: string, status: number): void {
+  logMobileCodingAgentWarning(scope, `status ${status}`);
+}
+
+function logCodingAgentParseWarning(scope: string): void {
+  logMobileCodingAgentWarning(scope, "invalid payload");
+}
+
+function logCodingAgentCatchWarning(scope: string, err: unknown): void {
+  const reason = err instanceof Error && err.name === "AbortError" ? "aborted" : err;
+  logMobileCodingAgentWarning(scope, reason);
+}
 
 export class GatewayClient {
   private ws: WebSocket | null = null;
@@ -550,12 +564,12 @@ export class GatewayClient {
       try {
         parsedJson = JSON.parse(event.data);
       } catch {
-        console.warn("[mobile] coding-agent thread stream sent invalid JSON");
+        logMobileCodingAgentWarning("coding-agent thread stream sent invalid JSON", "invalid json");
         return;
       }
       const frame = ThreadStreamServerFrameSchema.safeParse(parsedJson);
       if (!frame.success) {
-        console.warn("[mobile] coding-agent thread stream sent invalid frame");
+        logCodingAgentParseWarning("coding-agent thread stream sent invalid frame");
         return;
       }
       if (frame.data.type === "thread.event") {
@@ -583,14 +597,14 @@ export class GatewayClient {
         if (ws.readyState === WS_OPEN) {
           try {
             ws.send(JSON.stringify({ type: "detach" }));
-          } catch {
-            console.warn("[mobile] coding-agent thread stream detach failed");
+          } catch (err: unknown) {
+            logCodingAgentCatchWarning("coding-agent thread stream detach failed", err);
           }
         }
         try {
           ws.close();
-        } catch {
-          console.warn("[mobile] coding-agent thread stream close failed");
+        } catch (err: unknown) {
+          logCodingAgentCatchWarning("coding-agent thread stream close failed", err);
         }
       },
     };
@@ -737,18 +751,18 @@ export class GatewayClient {
     try {
       const res = await this.fetchGateway("/api/coding-agents/summary");
       if (!res.ok) {
-        console.warn("[mobile] /api/coding-agents/summary unavailable", res.status);
+        logCodingAgentStatusWarning("/api/coding-agents/summary unavailable", res.status);
         return { ok: false, error: "Runtime summary unavailable" };
       }
       const body = await res.json();
       const parsed = RuntimeSummarySchema.safeParse(body);
       if (!parsed.success) {
-        console.warn("[mobile] /api/coding-agents/summary returned invalid payload");
+        logCodingAgentParseWarning("/api/coding-agents/summary returned invalid payload");
         return { ok: false, error: "Runtime summary unavailable" };
       }
       return { ok: true, summary: parsed.data };
-    } catch {
-      console.warn("[mobile] /api/coding-agents/summary unavailable");
+    } catch (err: unknown) {
+      logCodingAgentCatchWarning("/api/coding-agents/summary unavailable", err);
       return { ok: false, error: "Runtime summary unavailable" };
     }
   }
@@ -757,18 +771,18 @@ export class GatewayClient {
     try {
       const res = await this.fetchGateway("/api/coding-agents/notification-preferences");
       if (!res.ok) {
-        console.warn("[mobile] /api/coding-agents/notification-preferences unavailable", res.status);
+        logCodingAgentStatusWarning("/api/coding-agents/notification-preferences unavailable", res.status);
         return { ok: false, error: "Notification settings unavailable" };
       }
       const body = await res.json();
       const parsed = CodingAgentNotificationPreferencesRouteResponseSchema.safeParse(body);
       if (!parsed.success) {
-        console.warn("[mobile] /api/coding-agents/notification-preferences returned invalid payload");
+        logCodingAgentParseWarning("/api/coding-agents/notification-preferences returned invalid payload");
         return { ok: false, error: "Notification settings unavailable" };
       }
       return { ok: true, preferences: parsed.data.preferences };
-    } catch {
-      console.warn("[mobile] /api/coding-agents/notification-preferences unavailable");
+    } catch (err: unknown) {
+      logCodingAgentCatchWarning("/api/coding-agents/notification-preferences unavailable", err);
       return { ok: false, error: "Notification settings unavailable" };
     }
   }
@@ -786,18 +800,18 @@ export class GatewayClient {
         body: JSON.stringify(parsedRequest.data),
       });
       if (!res.ok) {
-        console.warn("[mobile] /api/coding-agents/notification-preferences update unavailable", res.status);
+        logCodingAgentStatusWarning("/api/coding-agents/notification-preferences update unavailable", res.status);
         return { ok: false, error: "Notification settings could not be saved. Try again." };
       }
       const body = await res.json();
       const parsed = CodingAgentNotificationPreferencesRouteResponseSchema.safeParse(body);
       if (!parsed.success) {
-        console.warn("[mobile] /api/coding-agents/notification-preferences update returned invalid payload");
+        logCodingAgentParseWarning("/api/coding-agents/notification-preferences update returned invalid payload");
         return { ok: false, error: "Notification settings could not be saved. Try again." };
       }
       return { ok: true, preferences: parsed.data.preferences };
-    } catch {
-      console.warn("[mobile] /api/coding-agents/notification-preferences update unavailable");
+    } catch (err: unknown) {
+      logCodingAgentCatchWarning("/api/coding-agents/notification-preferences update unavailable", err);
       return { ok: false, error: "Notification settings could not be saved. Try again." };
     }
   }
@@ -811,18 +825,18 @@ export class GatewayClient {
         body: JSON.stringify(request),
       });
       if (!res.ok) {
-        console.warn("[mobile] /api/coding-agents/threads unavailable", res.status);
+        logCodingAgentStatusWarning("/api/coding-agents/threads unavailable", res.status);
         return { ok: false, error: "Agent run could not be started. Try again." };
       }
       const body = await res.json();
       const parsed = AgentThreadSnapshotSchema.safeParse(body);
       if (!parsed.success) {
-        console.warn("[mobile] /api/coding-agents/threads returned invalid payload");
+        logCodingAgentParseWarning("/api/coding-agents/threads returned invalid payload");
         return { ok: false, error: "Agent run could not be started. Try again." };
       }
       return { ok: true, snapshot: parsed.data };
-    } catch {
-      console.warn("[mobile] /api/coding-agents/threads unavailable");
+    } catch (err: unknown) {
+      logCodingAgentCatchWarning("/api/coding-agents/threads unavailable", err);
       return { ok: false, error: "Agent run could not be started. Try again." };
     }
   }
@@ -837,18 +851,18 @@ export class GatewayClient {
       }
       const res = await this.fetchGateway(`/api/coding-agents/threads/${encodeURIComponent(parsedThreadId.data)}`);
       if (!res.ok) {
-        console.warn("[mobile] /api/coding-agents/threads/:threadId unavailable", res.status);
+        logCodingAgentStatusWarning("/api/coding-agents/threads/:threadId unavailable", res.status);
         return { ok: false, error: "Thread state unavailable" };
       }
       const body = await res.json();
       const parsed = AgentThreadSnapshotSchema.safeParse(body);
       if (!parsed.success) {
-        console.warn("[mobile] /api/coding-agents/threads/:threadId returned invalid payload");
+        logCodingAgentParseWarning("/api/coding-agents/threads/:threadId returned invalid payload");
         return { ok: false, error: "Thread state unavailable" };
       }
       return { ok: true, snapshot: parsed.data };
-    } catch {
-      console.warn("[mobile] /api/coding-agents/threads/:threadId unavailable");
+    } catch (err: unknown) {
+      logCodingAgentCatchWarning("/api/coding-agents/threads/:threadId unavailable", err);
       return { ok: false, error: "Thread state unavailable" };
     }
   }
@@ -879,18 +893,18 @@ export class GatewayClient {
         },
       );
       if (!res.ok) {
-        console.warn("[mobile] /api/coding-agents/threads/:threadId/approvals/:approvalId/decision unavailable", res.status);
+        logCodingAgentStatusWarning("/api/coding-agents/threads/:threadId/approvals/:approvalId/decision unavailable", res.status);
         return { ok: false, error: "Approval could not be sent. Try again." };
       }
       const body = await res.json();
       const parsed = AgentThreadSnapshotSchema.safeParse(body);
       if (!parsed.success) {
-        console.warn("[mobile] /api/coding-agents/threads/:threadId/approvals/:approvalId/decision returned invalid payload");
+        logCodingAgentParseWarning("/api/coding-agents/threads/:threadId/approvals/:approvalId/decision returned invalid payload");
         return { ok: false, error: "Approval could not be sent. Try again." };
       }
       return { ok: true, snapshot: parsed.data };
-    } catch {
-      console.warn("[mobile] /api/coding-agents/threads/:threadId/approvals/:approvalId/decision unavailable");
+    } catch (err: unknown) {
+      logCodingAgentCatchWarning("/api/coding-agents/threads/:threadId/approvals/:approvalId/decision unavailable", err);
       return { ok: false, error: "Approval could not be sent. Try again." };
     }
   }
@@ -921,18 +935,18 @@ export class GatewayClient {
         },
       );
       if (!res.ok) {
-        console.warn("[mobile] /api/coding-agents/threads/:threadId/inputs/:inputRequestId/answer unavailable", res.status);
+        logCodingAgentStatusWarning("/api/coding-agents/threads/:threadId/inputs/:inputRequestId/answer unavailable", res.status);
         return { ok: false, error: "Input could not be sent. Try again." };
       }
       const body = await res.json();
       const parsed = AgentThreadSnapshotSchema.safeParse(body);
       if (!parsed.success) {
-        console.warn("[mobile] /api/coding-agents/threads/:threadId/inputs/:inputRequestId/answer returned invalid payload");
+        logCodingAgentParseWarning("/api/coding-agents/threads/:threadId/inputs/:inputRequestId/answer returned invalid payload");
         return { ok: false, error: "Input could not be sent. Try again." };
       }
       return { ok: true, snapshot: parsed.data };
-    } catch {
-      console.warn("[mobile] /api/coding-agents/threads/:threadId/inputs/:inputRequestId/answer unavailable");
+    } catch (err: unknown) {
+      logCodingAgentCatchWarning("/api/coding-agents/threads/:threadId/inputs/:inputRequestId/answer unavailable", err);
       return { ok: false, error: "Input could not be sent. Try again." };
     }
   }
@@ -949,18 +963,18 @@ export class GatewayClient {
       }
       const res = await this.fetchGateway(path);
       if (!res.ok) {
-        console.warn("[mobile] /api/coding-agents/reviews unavailable", res.status);
+        logCodingAgentStatusWarning("/api/coding-agents/reviews unavailable", res.status);
         return { ok: false, error: "Review state unavailable" };
       }
       const body = await res.json();
       const parsed = CodingAgentReviewListSchema.safeParse(body);
       if (!parsed.success) {
-        console.warn("[mobile] /api/coding-agents/reviews returned invalid payload");
+        logCodingAgentParseWarning("/api/coding-agents/reviews returned invalid payload");
         return { ok: false, error: "Review state unavailable" };
       }
       return { ok: true, reviews: parsed.data };
-    } catch {
-      console.warn("[mobile] /api/coding-agents/reviews unavailable");
+    } catch (err: unknown) {
+      logCodingAgentCatchWarning("/api/coding-agents/reviews unavailable", err);
       return { ok: false, error: "Review state unavailable" };
     }
   }
@@ -974,19 +988,18 @@ export class GatewayClient {
       }
       const res = await this.fetchGateway(`/api/coding-agents/reviews/${encodeURIComponent(options.reviewId)}`);
       if (!res.ok) {
-        console.warn("[mobile] /api/coding-agents/reviews/:reviewId unavailable", res.status);
+        logCodingAgentStatusWarning("/api/coding-agents/reviews/:reviewId unavailable", res.status);
         return { ok: false, error: "Review details unavailable" };
       }
       const body = await res.json();
       const parsed = ReviewSnapshotSchema.safeParse(body);
       if (!parsed.success) {
-        console.warn("[mobile] /api/coding-agents/reviews/:reviewId returned invalid payload");
+        logCodingAgentParseWarning("/api/coding-agents/reviews/:reviewId returned invalid payload");
         return { ok: false, error: "Review details unavailable" };
       }
       return { ok: true, snapshot: parsed.data };
     } catch (err: unknown) {
-      const reason = err instanceof Error && err.name === "AbortError" ? "aborted" : "unavailable";
-      console.warn(`[mobile] /api/coding-agents/reviews/:reviewId ${reason}`);
+      logCodingAgentCatchWarning("/api/coding-agents/reviews/:reviewId unavailable", err);
       return { ok: false, error: "Review details unavailable" };
     }
   }
@@ -1006,19 +1019,18 @@ export class GatewayClient {
       });
       const res = await this.fetchGateway(`/api/coding-agents/files/read?${query.toString()}`);
       if (!res.ok) {
-        console.warn("[mobile] /api/coding-agents/files/read unavailable", res.status);
+        logCodingAgentStatusWarning("/api/coding-agents/files/read unavailable", res.status);
         return { ok: false, error: "File content unavailable" };
       }
       const body = await res.json();
       const parsed = FileReadResponseSchema.safeParse(body);
       if (!parsed.success) {
-        console.warn("[mobile] /api/coding-agents/files/read returned invalid payload");
+        logCodingAgentParseWarning("/api/coding-agents/files/read returned invalid payload");
         return { ok: false, error: "File content unavailable" };
       }
       return { ok: true, file: parsed.data };
     } catch (err: unknown) {
-      const reason = err instanceof Error && err.name === "AbortError" ? "aborted" : "unavailable";
-      console.warn(`[mobile] /api/coding-agents/files/read ${reason}`);
+      logCodingAgentCatchWarning("/api/coding-agents/files/read unavailable", err);
       return { ok: false, error: "File content unavailable" };
     }
   }
@@ -1041,19 +1053,18 @@ export class GatewayClient {
       query.set("limit", String(parsedRequest.data.limit));
       const res = await this.fetchGateway(`/api/coding-agents/files/browse?${query.toString()}`);
       if (!res.ok) {
-        console.warn("[mobile] /api/coding-agents/files/browse unavailable", res.status);
+        logCodingAgentStatusWarning("/api/coding-agents/files/browse unavailable", res.status);
         return { ok: false, error: "File list unavailable" };
       }
       const body = await res.json();
       const parsed = FileBrowseResponseSchema.safeParse(body);
       if (!parsed.success) {
-        console.warn("[mobile] /api/coding-agents/files/browse returned invalid payload");
+        logCodingAgentParseWarning("/api/coding-agents/files/browse returned invalid payload");
         return { ok: false, error: "File list unavailable" };
       }
       return { ok: true, browse: parsed.data };
     } catch (err: unknown) {
-      const reason = err instanceof Error && err.name === "AbortError" ? "aborted" : "unavailable";
-      console.warn(`[mobile] /api/coding-agents/files/browse ${reason}`);
+      logCodingAgentCatchWarning("/api/coding-agents/files/browse unavailable", err);
       return { ok: false, error: "File list unavailable" };
     }
   }
@@ -1077,19 +1088,18 @@ export class GatewayClient {
       query.set("limit", String(parsedRequest.data.limit));
       const res = await this.fetchGateway(`/api/coding-agents/files/search?${query.toString()}`);
       if (!res.ok) {
-        console.warn("[mobile] /api/coding-agents/files/search unavailable", res.status);
+        logCodingAgentStatusWarning("/api/coding-agents/files/search unavailable", res.status);
         return { ok: false, error: "File search unavailable" };
       }
       const body = await res.json();
       const parsed = FileSearchResponseSchema.safeParse(body);
       if (!parsed.success) {
-        console.warn("[mobile] /api/coding-agents/files/search returned invalid payload");
+        logCodingAgentParseWarning("/api/coding-agents/files/search returned invalid payload");
         return { ok: false, error: "File search unavailable" };
       }
       return { ok: true, search: parsed.data };
     } catch (err: unknown) {
-      const reason = err instanceof Error && err.name === "AbortError" ? "aborted" : "unavailable";
-      console.warn(`[mobile] /api/coding-agents/files/search ${reason}`);
+      logCodingAgentCatchWarning("/api/coding-agents/files/search unavailable", err);
       return { ok: false, error: "File search unavailable" };
     }
   }
@@ -1107,19 +1117,18 @@ export class GatewayClient {
         body: JSON.stringify(parsedRequest.data),
       });
       if (!res.ok) {
-        console.warn("[mobile] /api/coding-agents/files/write unavailable");
+        logCodingAgentStatusWarning("/api/coding-agents/files/write unavailable", res.status);
         return { ok: false, error: "File could not be saved. Refresh and try again." };
       }
       const body = await res.json();
       const parsed = FileWriteResponseSchema.safeParse(body);
       if (!parsed.success) {
-        console.warn("[mobile] /api/coding-agents/files/write returned invalid payload");
+        logCodingAgentParseWarning("/api/coding-agents/files/write returned invalid payload");
         return { ok: false, error: "File could not be saved. Refresh and try again." };
       }
       return { ok: true, file: parsed.data };
     } catch (err: unknown) {
-      const reason = err instanceof Error && err.name === "AbortError" ? "aborted" : "unavailable";
-      console.warn(`[mobile] /api/coding-agents/files/write ${reason}`);
+      logCodingAgentCatchWarning("/api/coding-agents/files/write unavailable", err);
       return { ok: false, error: "File could not be saved. Refresh and try again." };
     }
   }
@@ -1137,19 +1146,18 @@ export class GatewayClient {
         body: JSON.stringify(parsedRequest.data),
       });
       if (!res.ok) {
-        console.warn("[mobile] /api/coding-agents/source-control/prepare-commit unavailable");
+        logCodingAgentStatusWarning("/api/coding-agents/source-control/prepare-commit unavailable", res.status);
         return { ok: false, error: "Source commit could not be prepared. Refresh and try again." };
       }
       const body = await res.json();
       const parsed = SourceControlPrepareCommitResponseSchema.safeParse(body);
       if (!parsed.success) {
-        console.warn("[mobile] /api/coding-agents/source-control/prepare-commit returned invalid payload");
+        logCodingAgentParseWarning("/api/coding-agents/source-control/prepare-commit returned invalid payload");
         return { ok: false, error: "Source commit could not be prepared. Refresh and try again." };
       }
       return { ok: true, commit: parsed.data };
     } catch (err: unknown) {
-      const reason = err instanceof Error && err.name === "AbortError" ? "aborted" : "unavailable";
-      console.warn(`[mobile] /api/coding-agents/source-control/prepare-commit ${reason}`);
+      logCodingAgentCatchWarning("/api/coding-agents/source-control/prepare-commit unavailable", err);
       return { ok: false, error: "Source commit could not be prepared. Refresh and try again." };
     }
   }
@@ -1167,19 +1175,18 @@ export class GatewayClient {
         body: JSON.stringify(parsedRequest.data),
       });
       if (!res.ok) {
-        console.warn("[mobile] /api/coding-agents/source-control/pull-requests unavailable");
+        logCodingAgentStatusWarning("/api/coding-agents/source-control/pull-requests unavailable", res.status);
         return { ok: false, error: "Pull request could not be created. Refresh and try again." };
       }
       const body = await res.json();
       const parsed = SourceControlCreatePullRequestResponseSchema.safeParse(body);
       if (!parsed.success) {
-        console.warn("[mobile] /api/coding-agents/source-control/pull-requests returned invalid payload");
+        logCodingAgentParseWarning("/api/coding-agents/source-control/pull-requests returned invalid payload");
         return { ok: false, error: "Pull request could not be created. Refresh and try again." };
       }
       return { ok: true, pullRequest: parsed.data };
     } catch (err: unknown) {
-      const reason = err instanceof Error && err.name === "AbortError" ? "aborted" : "unavailable";
-      console.warn(`[mobile] /api/coding-agents/source-control/pull-requests ${reason}`);
+      logCodingAgentCatchWarning("/api/coding-agents/source-control/pull-requests unavailable", err);
       return { ok: false, error: "Pull request could not be created. Refresh and try again." };
     }
   }

--- a/apps/mobile/lib/gateway-client.ts
+++ b/apps/mobile/lib/gateway-client.ts
@@ -259,6 +259,19 @@ function logCodingAgentCatchWarning(scope: string, err: unknown): void {
   logMobileCodingAgentWarning(scope, reason);
 }
 
+function logGatewayStatusWarning(scope: string, status: number): void {
+  logMobileCodingAgentWarning(scope, `status ${status}`);
+}
+
+function logGatewayCatchWarning(scope: string, err: unknown): void {
+  const reason = err instanceof Error && err.name === "AbortError" ? "aborted" : err;
+  logMobileCodingAgentWarning(scope, reason);
+}
+
+function logGatewayWarning(scope: string, detail: unknown): void {
+  logMobileCodingAgentWarning(scope, detail);
+}
+
 export class GatewayClient {
   private ws: WebSocket | null = null;
   private baseUrl: string;
@@ -395,7 +408,7 @@ export class GatewayClient {
 
     this.ws.onclose = (evt) => {
       const closeEvent = evt as CloseEvent;
-      console.warn("[mobile] websocket closed", closeEvent.code, closeEvent.reason || "");
+      logGatewayWarning("websocket closed", `code ${closeEvent.code}${closeEvent.reason ? ` ${closeEvent.reason}` : ""}`);
       this.ws = null;
       this.setState("disconnected");
       this.scheduleReconnect();
@@ -455,7 +468,7 @@ export class GatewayClient {
       this.reconnectTimer = null;
       this.refreshWebSocketTokenForReconnect()
         .catch((err: unknown) => {
-          console.warn("[mobile] websocket token refresh before reconnect failed", err instanceof Error ? err.message : String(err));
+          logGatewayCatchWarning("websocket token refresh before reconnect failed", err);
         })
         .finally(() => this.connect());
     }, delay);
@@ -467,7 +480,7 @@ export class GatewayClient {
       const nextToken = await this.tokenProvider();
       this.token = nextToken ?? undefined;
     } catch (err: unknown) {
-      console.warn("[mobile] Clerk session token refresh failed", err instanceof Error ? err.message : String(err));
+      logGatewayCatchWarning("Clerk session token refresh failed", err);
       this.token = undefined;
     }
     return this.token;
@@ -617,7 +630,7 @@ export class GatewayClient {
       const data = await res.json();
       return { ok: true, data };
     } catch {
-      console.warn("[mobile] gateway health check unavailable");
+      logGatewayWarning("gateway health check unavailable", "unavailable");
       return { ok: false, error: "Gateway unavailable" };
     }
   }
@@ -626,19 +639,19 @@ export class GatewayClient {
     try {
       const res = await this.fetchGateway("/api/auth/ws-token");
       if (!res.ok) {
-        console.warn("[mobile] /api/auth/ws-token unavailable", res.status);
+        logGatewayStatusWarning("/api/auth/ws-token unavailable", res.status);
         return null;
       }
       const data = (await res.json()) as { token?: unknown; expiresAt?: unknown };
       if (data.token == null) return null;
       if (typeof data.token !== "string") {
-        console.warn("[mobile] /api/auth/ws-token returned invalid token");
+        logGatewayWarning("/api/auth/ws-token returned invalid token", "invalid payload");
         return null;
       }
       this.setWebSocketToken(data.token, typeof data.expiresAt === "number" ? data.expiresAt : undefined);
       return data.token;
     } catch {
-      console.warn("[mobile] /api/auth/ws-token network error");
+      logGatewayWarning("/api/auth/ws-token network error", "unavailable");
       return null;
     }
   }
@@ -717,16 +730,16 @@ export class GatewayClient {
     try {
       const res = await this.fetchGateway("/api/apps");
       if (!res.ok) {
-        const body = await res.text().catch((err: unknown) => {
-          console.warn("[mobile] failed to read /api/apps error body", err instanceof Error ? err.message : String(err));
+        await res.text().catch((err: unknown) => {
+          logGatewayCatchWarning("failed to read /api/apps error body", err);
           return "";
         });
-        console.warn("[mobile] /api/apps unavailable", res.status, body.slice(0, 160));
+        logGatewayStatusWarning("/api/apps unavailable", res.status);
         return [];
       }
       return res.json();
     } catch (err: unknown) {
-      console.warn("[mobile] /api/apps unavailable", err instanceof Error ? err.message : String(err));
+      logGatewayCatchWarning("/api/apps unavailable", err);
       return [];
     }
   }
@@ -735,14 +748,17 @@ export class GatewayClient {
     try {
       const res = await this.fetchGateway("/api/terminal/sessions");
       if (!res.ok) {
-        const body = await res.text().catch(() => "");
-        console.warn("[mobile] /api/terminal/sessions unavailable", res.status, body.slice(0, 160));
+        await res.text().catch((err: unknown) => {
+          logGatewayCatchWarning("failed to read /api/terminal/sessions error body", err);
+          return "";
+        });
+        logGatewayStatusWarning("/api/terminal/sessions unavailable", res.status);
         return [];
       }
       const body = (await res.json()) as { sessions?: unknown };
       return parseShellSessions(body?.sessions ?? body);
     } catch (err: unknown) {
-      console.warn("[mobile] /api/terminal/sessions unavailable", err instanceof Error ? err.message : String(err));
+      logGatewayCatchWarning("/api/terminal/sessions unavailable", err);
       return [];
     }
   }
@@ -1201,15 +1217,18 @@ export class GatewayClient {
         headers: { "Content-Type": "application/json" },
       });
       if (!res.ok) {
-        const body = await res.text().catch(() => "");
-        console.warn("[mobile] terminal session create failed", res.status, body.slice(0, 160));
+        await res.text().catch((err: unknown) => {
+          logGatewayCatchWarning("failed to read terminal session create error body", err);
+          return "";
+        });
+        logGatewayStatusWarning("terminal session create failed", res.status);
         return null;
       }
       const body = (await res.json().catch(() => null)) as { name?: unknown } | null;
       const created = typeof body?.name === "string" ? body.name : name;
       return isSafeShellSessionName(created) ? created : null;
     } catch {
-      console.warn("[mobile] terminal session create unavailable");
+      logGatewayWarning("terminal session create unavailable", "unavailable");
       return null;
     }
   }
@@ -1222,10 +1241,10 @@ export class GatewayClient {
         { method: "DELETE" },
       );
       if (res.ok || res.status === 404) return true;
-      console.warn("[mobile] terminal session delete unavailable", res.status);
+      logGatewayStatusWarning("terminal session delete unavailable", res.status);
       return false;
     } catch {
-      console.warn("[mobile] terminal session delete unavailable");
+      logGatewayWarning("terminal session delete unavailable", "unavailable");
       return false;
     }
   }
@@ -1236,7 +1255,7 @@ export class GatewayClient {
       if (!res.ok) return null;
       return res.json();
     } catch {
-      console.warn("[mobile] /api/apps/:slug/manifest unavailable", slug);
+      logGatewayWarning("/api/apps/:slug/manifest unavailable", `slug ${slug}`);
       return null;
     }
   }
@@ -1248,24 +1267,21 @@ export class GatewayClient {
         body: "{}",
       });
       if (!res.ok) {
-        const body = await res.text().catch((err: unknown) => {
-          console.warn(
-            "[mobile] failed to read /api/apps/:slug/session-token error body",
-            err instanceof Error ? err.message : String(err),
-          );
+        await res.text().catch((err: unknown) => {
+          logGatewayCatchWarning("failed to read /api/apps/:slug/session-token error body", err);
           return "";
         });
-        console.warn("[mobile] /api/apps/:slug/session-token unavailable", slug, res.status, body.slice(0, 160));
+        logGatewayWarning("/api/apps/:slug/session-token unavailable", `slug ${slug} status ${res.status}`);
         return null;
       }
       const data = (await res.json()) as { launchUrl?: unknown; expiresAt?: unknown };
       if (typeof data.launchUrl !== "string" || typeof data.expiresAt !== "number") {
-        console.warn("[mobile] /api/apps/:slug/session-token returned invalid payload", slug);
+        logGatewayWarning("/api/apps/:slug/session-token returned invalid payload", `slug ${slug}`);
         return null;
       }
       return { launchUrl: data.launchUrl, expiresAt: data.expiresAt };
     } catch {
-      console.warn("[mobile] /api/apps/:slug/session-token network error", slug);
+      logGatewayWarning("/api/apps/:slug/session-token network error", `slug ${slug}`);
       return null;
     }
   }

--- a/docs/dev/coding-agent-shells.md
+++ b/docs/dev/coding-agent-shells.md
@@ -148,6 +148,11 @@ Use this checklist for every coding-agent shell PR:
 - Server diagnostics for coding-agent routes, summary adapters, streams,
   provider lifecycle, and notification bridges use the bounded redacted
   diagnostic helper instead of raw `err.message` logging.
+- Mobile coding-agent gateway client diagnostics use
+  `apps/mobile/lib/coding-agent-diagnostics.ts` for bounded warning scope and
+  redacted metadata. Do not log raw gateway response bodies, filesystem paths,
+  private hosts, bearer tokens, provider errors, or database details from mobile
+  coding-agent clients.
 - Desktop renderer never receives bearer credentials or provider credentials.
 - Mobile AsyncStorage contains only bounded safe references.
 - Terminal/session behavior reuses canonical Matrix terminal primitives.

--- a/docs/dev/coding-agent-shells.md
+++ b/docs/dev/coding-agent-shells.md
@@ -152,7 +152,7 @@ Use this checklist for every coding-agent shell PR:
   `apps/mobile/lib/coding-agent-diagnostics.ts` for bounded warning scope and
   redacted metadata. Do not log raw gateway response bodies, filesystem paths,
   private hosts, bearer tokens, provider errors, or database details from mobile
-  coding-agent clients.
+  gateway clients.
 - Desktop renderer never receives bearer credentials or provider credentials.
 - Mobile AsyncStorage contains only bounded safe references.
 - Terminal/session behavior reuses canonical Matrix terminal primitives.

--- a/packages/gateway/src/coding-agents/diagnostics.ts
+++ b/packages/gateway/src/coding-agents/diagnostics.ts
@@ -16,7 +16,7 @@ const BEARER_PATTERN = /\bBearer\s+[A-Za-z0-9._~+/=-]+/gi;
 const AUTHORIZATION_ASSIGNMENT_PATTERN = /\b(authorization)(\s*[:=]\s*)[^\r\n]+/gi;
 const ASSIGNMENT_PATTERN = /\b([A-Za-z][A-Za-z0-9_-]{0,127})(\s*[:=]\s*)(?:(?:Basic|Bearer|Digest)\s+[^\s"'<>]+|"(?:\\.|[^"\\\r\n])*"|'(?:\\.|[^'\\\r\n])*'|[^\s"'<>]+)/gi;
 const KNOWN_SECRET_PREFIX_PATTERN = /\b(?:sk|sk_live|sk_test|ghp|github_pat|xoxb|xoxp|xoxa|xoxr|glpat|hf)[_-][A-Za-z0-9._-]{4,}\b/gi;
-const OWNER_PATH_PATTERN = /(?:^|[\s"'(:])(?:\/(?:home|Users|private|tmp|var|opt|etc|root|run)\/[^\s"'<>)]*)/g;
+const OWNER_PATH_PATTERN = /(?:^|[\s"'(:=])(?:\/(?:home|Users|private|tmp|var|opt|etc|root|run)\/[^\s"'<>)]*)/g;
 const WINDOWS_PATH_PATTERN = /\b[A-Za-z]:\\[^\s"'<>)]*/g;
 const PRIVATE_IPV4_PATTERN = /\b(?:(?:10|127)\.\d{1,3}\.\d{1,3}\.\d{1,3}|169\.254\.\d{1,3}\.\d{1,3}|172\.(?:1[6-9]|2\d|3[0-1])\.\d{1,3}\.\d{1,3}|192\.168\.\d{1,3}\.\d{1,3})\b/g;
 const PRIVATE_IPV6_PATTERN = /(?<![A-Fa-f0-9:])(?:::1|(?:f[cd][A-Fa-f0-9]{2}|fe[89ab][A-Fa-f0-9])(?::[A-Fa-f0-9]{0,4}){1,7})(?:%[A-Za-z0-9_.-]+)?(?![A-Fa-f0-9:])/gi;
@@ -81,7 +81,9 @@ export function redactCodingAgentDiagnosticText(value: unknown): string {
 }
 
 function safeDiagnosticName(name: string): string {
-  const normalized = name.replace(/[^A-Za-z0-9_.-]/g, "").slice(0, MAX_DIAGNOSTIC_NAME_LENGTH);
+  const normalized = redactCodingAgentDiagnosticText(name)
+    .replace(/[^A-Za-z0-9_.-]/g, "")
+    .slice(0, MAX_DIAGNOSTIC_NAME_LENGTH);
   return normalized || "Error";
 }
 

--- a/packages/gateway/src/coding-agents/diagnostics.ts
+++ b/packages/gateway/src/coding-agents/diagnostics.ts
@@ -16,11 +16,12 @@ const BEARER_PATTERN = /\bBearer\s+[A-Za-z0-9._~+/=-]+/gi;
 const AUTHORIZATION_ASSIGNMENT_PATTERN = /\b(authorization)(\s*[:=]\s*)[^\r\n]+/gi;
 const ASSIGNMENT_PATTERN = /\b([A-Za-z][A-Za-z0-9_-]{0,127})(\s*[:=]\s*)(?:(?:Basic|Bearer|Digest)\s+[^\s"'<>]+|"(?:\\.|[^"\\\r\n])*"|'(?:\\.|[^'\\\r\n])*'|[^\s"'<>]+)/gi;
 const KNOWN_SECRET_PREFIX_PATTERN = /\b(?:sk|sk_live|sk_test|ghp|github_pat|xoxb|xoxp|xoxa|xoxr|glpat|hf)[_-][A-Za-z0-9._-]{4,}\b/gi;
-const OWNER_PATH_PATTERN = /(?:^|[\s"'(:=])(?:\/(?:home|Users|private|tmp|var|opt|etc|root|run)\/[^\s"'<>)]*)/g;
-const WINDOWS_PATH_PATTERN = /\b[A-Za-z]:\\[^\s"'<>)]*/g;
+const OWNER_PATH_PATTERN = /(?:^|[\s"'`(:=])(?:\/(?:home|Users|private|tmp|var|opt|etc|root|run)\/[^\s"'`<>)]*)/g;
+const WINDOWS_PATH_PATTERN = /\b[A-Za-z]:\\[^\s"'`<>)]*/g;
 const PRIVATE_IPV4_PATTERN = /\b(?:(?:10|127)\.\d{1,3}\.\d{1,3}\.\d{1,3}|169\.254\.\d{1,3}\.\d{1,3}|172\.(?:1[6-9]|2\d|3[0-1])\.\d{1,3}\.\d{1,3}|192\.168\.\d{1,3}\.\d{1,3})\b/g;
 const PRIVATE_IPV6_PATTERN = /(?<![A-Fa-f0-9:])(?:::1|(?:f[cd][A-Fa-f0-9]{2}|fe[89ab][A-Fa-f0-9])(?::[A-Fa-f0-9]{0,4}){1,7})(?:%[A-Za-z0-9_.-]+)?(?![A-Fa-f0-9:])/gi;
 const PRIVATE_HOSTNAME_PATTERN = /\b(?:(?=[A-Za-z0-9.-]{1,253}\b)(?:[A-Za-z0-9](?:[A-Za-z0-9-]{0,62})?\.)+(?:local|internal|lan|home|localhost)|localhost)\b/gi;
+const NETWORK_ERROR_SINGLE_LABEL_HOST_PATTERN = /\b((?:ENOTFOUND|EAI_AGAIN|ECONNREFUSED|EHOSTUNREACH|ETIMEDOUT)\s+)(?=[A-Za-z0-9-]{1,63}(?![A-Za-z0-9.-]))(?=[A-Za-z0-9-]*[A-Za-z])[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?(?![A-Za-z0-9.-])/gi;
 const HOST_VALUE_PATTERN = /\b(?:host|hostname)\s*[:=]?\s*[A-Za-z0-9.-]*(?:\.local|\.internal|\.lan|\.home|runtime|matrix|vps)[A-Za-z0-9.-]*/gi;
 const DATABASE_PATTERN = /\b(?:postgres(?:ql)?|kysely|database|db)\b/gi;
 
@@ -72,6 +73,7 @@ export function redactCodingAgentDiagnosticText(value: unknown): string {
     .replace(PRIVATE_IPV4_PATTERN, "[host]")
     .replace(PRIVATE_IPV6_PATTERN, "[host]")
     .replace(PRIVATE_HOSTNAME_PATTERN, "[host]")
+    .replace(NETWORK_ERROR_SINGLE_LABEL_HOST_PATTERN, "$1[host]")
     .replace(HOST_VALUE_PATTERN, (match) => {
       const prefix = match.match(/^(host|hostname)\s*[:=]?/i)?.[0] ?? "host ";
       return `${prefix}[host]`;

--- a/packages/gateway/src/coding-agents/diagnostics.ts
+++ b/packages/gateway/src/coding-agents/diagnostics.ts
@@ -22,7 +22,7 @@ const PRIVATE_IPV4_PATTERN = /\b(?:(?:10|127)\.\d{1,3}\.\d{1,3}\.\d{1,3}|169\.25
 const PRIVATE_IPV6_PATTERN = /(?<![A-Fa-f0-9:])(?:::1|(?:f[cd][A-Fa-f0-9]{2}|fe[89ab][A-Fa-f0-9])(?::[A-Fa-f0-9]{0,4}){1,7})(?:%[A-Za-z0-9_.-]+)?(?![A-Fa-f0-9:])/gi;
 const PRIVATE_HOSTNAME_PATTERN = /\b(?:(?=[A-Za-z0-9.-]{1,253}\b)(?:[A-Za-z0-9](?:[A-Za-z0-9-]{0,62})?\.)+(?:local|internal|lan|home|localhost)|localhost)\b/gi;
 const NETWORK_ERROR_SINGLE_LABEL_HOST_PATTERN = /\b((?:ENOTFOUND|EAI_AGAIN|ECONNREFUSED|EHOSTUNREACH|ETIMEDOUT)\s+)(?=[A-Za-z0-9-]{1,63}(?![A-Za-z0-9.-]))(?=[A-Za-z0-9-]*[A-Za-z])[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?(?![A-Za-z0-9.-])/gi;
-const HOST_VALUE_PATTERN = /\b(?:host|hostname)\s*[:=]?\s*[A-Za-z0-9.-]*(?:\.local|\.internal|\.lan|\.home|runtime|matrix|vps)[A-Za-z0-9.-]*/gi;
+const HOST_VALUE_PATTERN = /\b(hostname|host)(\s*[:=]\s*|\s+)(?:"(?:\\.|[^"\\\r\n])*"|'(?:\\.|[^'\\\r\n])*'|[^\s"'<>]+)/gi;
 const DATABASE_PATTERN = /\b(?:postgres(?:ql)?|kysely|database|db)\b/gi;
 
 function capDiagnosticText(value: string): string {
@@ -74,9 +74,8 @@ export function redactCodingAgentDiagnosticText(value: unknown): string {
     .replace(PRIVATE_IPV6_PATTERN, "[host]")
     .replace(PRIVATE_HOSTNAME_PATTERN, "[host]")
     .replace(NETWORK_ERROR_SINGLE_LABEL_HOST_PATTERN, "$1[host]")
-    .replace(HOST_VALUE_PATTERN, (match) => {
-      const prefix = match.match(/^(host|hostname)\s*[:=]?/i)?.[0] ?? "host ";
-      return `${prefix}[host]`;
+    .replace(HOST_VALUE_PATTERN, (_match, key: string, separator: string) => {
+      return `${key}${separator}[host]`;
     })
     .replace(DATABASE_PATTERN, "[database]");
   return capDiagnosticText(normalizeDiagnosticText(redacted) || "unavailable");

--- a/packages/gateway/src/coding-agents/diagnostics.ts
+++ b/packages/gateway/src/coding-agents/diagnostics.ts
@@ -22,7 +22,7 @@ const PRIVATE_IPV4_PATTERN = /\b(?:(?:10|127)\.\d{1,3}\.\d{1,3}\.\d{1,3}|169\.25
 const PRIVATE_IPV6_PATTERN = /(?<![A-Fa-f0-9:])(?:::1|(?:f[cd][A-Fa-f0-9]{2}|fe[89ab][A-Fa-f0-9])(?::[A-Fa-f0-9]{0,4}){1,7})(?:%[A-Za-z0-9_.-]+)?(?![A-Fa-f0-9:])/gi;
 const PRIVATE_HOSTNAME_PATTERN = /\b(?:(?=[A-Za-z0-9.-]{1,253}\b)(?:[A-Za-z0-9](?:[A-Za-z0-9-]{0,62})?\.)+(?:local|internal|lan|home|localhost)|localhost)\b/gi;
 const NETWORK_ERROR_SINGLE_LABEL_HOST_PATTERN = /\b((?:ENOTFOUND|EAI_AGAIN|ECONNREFUSED|EHOSTUNREACH|ETIMEDOUT)\s+)(?=[A-Za-z0-9-]{1,63}(?![A-Za-z0-9.-]))(?=[A-Za-z0-9-]*[A-Za-z])[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?(?![A-Za-z0-9.-])/gi;
-const HOST_VALUE_PATTERN = /\b(hostname|host)(\s*[:=]\s*|\s+)(?:"(?:\\.|[^"\\\r\n])*"|'(?:\\.|[^'\\\r\n])*'|[^\s"'<>]+)/gi;
+const HOST_VALUE_PATTERN = /\b(hostname|host|url)(\s*[:=]\s*|\s+)(?:"(?:\\.|[^"\\\r\n])*"|'(?:\\.|[^'\\\r\n])*'|[^\s"'<>]+)/gi;
 const DATABASE_PATTERN = /\b(?:postgres(?:ql)?|kysely|database|db)\b/gi;
 
 function capDiagnosticText(value: string): string {

--- a/specs/105-coding-agent-shells/completion-audit.md
+++ b/specs/105-coding-agent-shells/completion-audit.md
@@ -89,6 +89,6 @@ That automated desktop smoke now also covers opening the Agents workspace from t
 - Mutating gateway routes use body limits, validation, ownership checks, and safe error mapping.
 - WebSocket thread streams authenticate before success, validate frames, cap subscribers, and clean up stale streams.
 - Gateway coding-agent diagnostics are bounded and redacted before logging paths, tokens, URLs, private hosts, database details, or provider/runtime failure text.
-- Mobile coding-agent client diagnostics are bounded and redacted before logging paths, tokens, URLs, private hosts, database details, or gateway/runtime failure text.
+- Mobile gateway-client diagnostics are bounded and redacted before logging paths, tokens, URLs, private hosts, database details, raw response bodies, or gateway/runtime failure text.
 - No new embedded database persistence was added.
 - Gateway/runtime remains the source of truth; desktop, mobile, and browser shells are resumable clients.

--- a/specs/105-coding-agent-shells/completion-audit.md
+++ b/specs/105-coding-agent-shells/completion-audit.md
@@ -20,7 +20,7 @@ This audit records current evidence through the desktop operator palette smoke a
 | Browser shell remains Canvas-first and read-only for coding-agent state | `shell/src/components/workspace/WorkspaceApp.tsx`; `tests/shell/workspace-app.test.tsx`; browser section in `current-state.md` | Implemented |
 | File, review, diff, preview, and source-control surfaces remain gateway-owned with bounded shell clients | Gateway route inventory plus desktop/mobile review tests listed in `current-state.md` | Implemented |
 | Notifications and attention routing use safe owner-scoped payloads and preferences | `packages/gateway/src/coding-agents/attention-notifications.ts`; `packages/gateway/src/coding-agents/notification-preferences.ts`; related gateway, desktop, and mobile tests listed in `current-state.md` | Implemented |
-| Redacted diagnostics for coding-agent gateway/runtime failure paths | `packages/gateway/src/coding-agents/diagnostics.ts`; `tests/gateway/coding-agents-diagnostics.test.ts`; route/summary/thread-stream/thread-store/attention-notification callers | Implemented |
+| Redacted diagnostics for coding-agent gateway/runtime and mobile client failure paths | `packages/gateway/src/coding-agents/diagnostics.ts`; `apps/mobile/lib/coding-agent-diagnostics.ts`; `tests/gateway/coding-agents-diagnostics.test.ts`; `apps/mobile/__tests__/coding-agent-diagnostics.test.ts`; route/summary/thread-stream/thread-store/attention-notification/mobile gateway-client callers | Implemented |
 | Desktop renderer does not receive raw bearer/provider credentials | Trusted IPC and main-process client inventory in `current-state.md`; desktop runtime client tests | Implemented by architecture and tests |
 | Mobile persistent state stores only bounded UI references | `apps/mobile/lib/agent-workspace-state.ts`; `apps/mobile/lib/mobile-shell-state.ts`; mobile state tests listed in `current-state.md` | Implemented |
 | Public and internal docs | `docs/dev/coding-agent-shells.md`; `www/content/docs/coding-agents.mdx`; `current-state.md` | Implemented and must stay synchronized |
@@ -89,5 +89,6 @@ That automated desktop smoke now also covers opening the Agents workspace from t
 - Mutating gateway routes use body limits, validation, ownership checks, and safe error mapping.
 - WebSocket thread streams authenticate before success, validate frames, cap subscribers, and clean up stale streams.
 - Gateway coding-agent diagnostics are bounded and redacted before logging paths, tokens, URLs, private hosts, database details, or provider/runtime failure text.
+- Mobile coding-agent client diagnostics are bounded and redacted before logging paths, tokens, URLs, private hosts, database details, or gateway/runtime failure text.
 - No new embedded database persistence was added.
 - Gateway/runtime remains the source of truth; desktop, mobile, and browser shells are resumable clients.

--- a/specs/105-coding-agent-shells/current-state.md
+++ b/specs/105-coding-agent-shells/current-state.md
@@ -80,6 +80,7 @@ Security and ownership:
 - Mutating routes use Hono `bodyLimit`.
 - Route errors are mapped to safe client errors and log details server-side only.
 - Gateway coding-agent route, summary, stream, provider lifecycle, and attention-notification failure diagnostics use the bounded redacted helper in `packages/gateway/src/coding-agents/diagnostics.ts` instead of raw `err.message` logging.
+- Mobile coding-agent gateway-client warnings use `apps/mobile/lib/coding-agent-diagnostics.ts` to log only bounded warning scopes and redacted metadata for status, parse, stream detach/close, and catch paths.
 - Thread store state is owner-scoped in the existing owner file convention at `system/coding-agents/threads.json`; no new embedded DB was added.
 
 Related workspace routes in `packages/gateway/src/workspace-routes.ts`:
@@ -294,6 +295,7 @@ Focused tests:
 Gateway client:
 
 - `apps/mobile/lib/gateway-client.ts`
+- `apps/mobile/lib/coding-agent-diagnostics.ts`
 - `getCodingAgentRuntimeSummary()` calls `GET /api/coding-agents/summary`, validates `RuntimeSummarySchema`, and returns the safe `"Runtime summary unavailable"` error on failure.
 - `getCodingAgentNotificationPreferences()` calls `GET /api/coding-agents/notification-preferences`, validates the gateway `{ preferences }` envelope with `CodingAgentNotificationPreferencesSchema`, and returns the safe `"Notification settings unavailable"` error on failure.
 - `updateCodingAgentNotificationPreferences()` sends a full `CodingAgentNotificationPreferencesUpdateSchema` body to `PUT /api/coding-agents/notification-preferences`, validates the gateway `{ preferences }` envelope, and returns the safe `"Notification settings could not be saved. Try again."` error on failure.
@@ -351,6 +353,7 @@ Persisted UI references:
 Focused tests:
 
 - `apps/mobile/__tests__/gateway-client.test.ts`
+- `apps/mobile/__tests__/coding-agent-diagnostics.test.ts`
 - `apps/mobile/__tests__/agents-screen.test.tsx`
 - `apps/mobile/__tests__/agents-preview-screen.test.tsx`
 - `apps/mobile/__tests__/agent-thread-screen.test.tsx`
@@ -431,6 +434,12 @@ Mobile focused Jest:
 
 ```bash
 pnpm --filter matrix-os-mobile exec jest __tests__/gateway-client.test.ts __tests__/apps-screen.test.tsx __tests__/agents-screen.test.tsx __tests__/agent-thread-screen.test.tsx __tests__/agent-workspace-state.test.ts --runInBand
+```
+
+Mobile diagnostics:
+
+```bash
+pnpm --filter matrix-os-mobile exec jest __tests__/coding-agent-diagnostics.test.ts __tests__/gateway-client.test.ts --runInBand
 ```
 
 Desktop typecheck:

--- a/specs/105-coding-agent-shells/current-state.md
+++ b/specs/105-coding-agent-shells/current-state.md
@@ -80,7 +80,7 @@ Security and ownership:
 - Mutating routes use Hono `bodyLimit`.
 - Route errors are mapped to safe client errors and log details server-side only.
 - Gateway coding-agent route, summary, stream, provider lifecycle, and attention-notification failure diagnostics use the bounded redacted helper in `packages/gateway/src/coding-agents/diagnostics.ts` instead of raw `err.message` logging.
-- Mobile coding-agent gateway-client warnings use `apps/mobile/lib/coding-agent-diagnostics.ts` to log only bounded warning scopes and redacted metadata for status, parse, stream detach/close, and catch paths.
+- Mobile gateway-client warnings use `apps/mobile/lib/coding-agent-diagnostics.ts` to log only bounded warning scopes and redacted metadata for status, parse, stream detach/close, and catch paths without raw response bodies, filesystem paths, tokens, private hosts, or database details.
 - Thread store state is owner-scoped in the existing owner file convention at `system/coding-agents/threads.json`; no new embedded DB was added.
 
 Related workspace routes in `packages/gateway/src/workspace-routes.ts`:

--- a/tests/gateway/coding-agents-diagnostics.test.ts
+++ b/tests/gateway/coding-agents-diagnostics.test.ts
@@ -115,11 +115,11 @@ describe("coding agent diagnostics", () => {
 
   it("redacts complete scheme-less host values", () => {
     const redacted = redactCodingAgentDiagnosticText(
-      "probe host=internal-runtime.local/api?token=secret hostname=matrix-vps/private?credential=value",
+      "probe host=internal-runtime.local/api?token=secret hostname=matrix-vps/private?credential=value url=runtime.internal/review?access_key=private",
     );
 
-    expect(redacted).toBe("probe host=[host] hostname=[host]");
-    expect(redacted).not.toMatch(/internal-runtime|matrix-vps|\/api|\/private|secret|credential|value/);
+    expect(redacted).toBe("probe host=[host] hostname=[host] url=[host]");
+    expect(redacted).not.toMatch(/internal-runtime|matrix-vps|runtime\.internal|\/api|\/private|\/review|secret|credential|access_key|value/);
   });
 
   it("formats non-error diagnostics and unsafe names safely", () => {

--- a/tests/gateway/coding-agents-diagnostics.test.ts
+++ b/tests/gateway/coding-agents-diagnostics.test.ts
@@ -95,6 +95,24 @@ describe("coding agent diagnostics", () => {
     expect(redacted).not.toMatch(/\/home\/matrix|\/opt\/matrix|private\.ts|release\.json/);
   });
 
+  it("redacts backtick-quoted owner paths", () => {
+    const redacted = redactCodingAgentDiagnosticText(
+      "open `/home/matrix/home/project/file.ts` failed",
+    );
+
+    expect(redacted).toBe("open `[path]` failed");
+    expect(redacted).not.toMatch(/\/home\/matrix|project|file\.ts/);
+  });
+
+  it("redacts single-label hosts in network errors", () => {
+    const redacted = redactCodingAgentDiagnosticText(
+      "getaddrinfo ENOTFOUND internal-runtime connect ECONNREFUSED matrix-vps",
+    );
+
+    expect(redacted).toBe("getaddrinfo ENOTFOUND [host] connect ECONNREFUSED [host]");
+    expect(redacted).not.toMatch(/internal-runtime|matrix-vps/);
+  });
+
   it("formats non-error diagnostics and unsafe names safely", () => {
     const unknown = formatCodingAgentDiagnostic("token=sk_live_private /tmp/private-file");
     const unsafeNameError = new Error("failed");

--- a/tests/gateway/coding-agents-diagnostics.test.ts
+++ b/tests/gateway/coding-agents-diagnostics.test.ts
@@ -113,6 +113,15 @@ describe("coding agent diagnostics", () => {
     expect(redacted).not.toMatch(/internal-runtime|matrix-vps/);
   });
 
+  it("redacts complete scheme-less host values", () => {
+    const redacted = redactCodingAgentDiagnosticText(
+      "probe host=internal-runtime.local/api?token=secret hostname=matrix-vps/private?credential=value",
+    );
+
+    expect(redacted).toBe("probe host=[host] hostname=[host]");
+    expect(redacted).not.toMatch(/internal-runtime|matrix-vps|\/api|\/private|secret|credential|value/);
+  });
+
   it("formats non-error diagnostics and unsafe names safely", () => {
     const unknown = formatCodingAgentDiagnostic("token=sk_live_private /tmp/private-file");
     const unsafeNameError = new Error("failed");

--- a/tests/gateway/coding-agents-diagnostics.test.ts
+++ b/tests/gateway/coding-agents-diagnostics.test.ts
@@ -86,10 +86,25 @@ describe("coding agent diagnostics", () => {
     expect(redacted).not.toMatch(/169\.254|::1|fe80|fd12|internal-runtime|matrix-vps|localhost/i);
   });
 
+  it("redacts assignment-prefixed owner paths", () => {
+    const redacted = redactCodingAgentDiagnosticText(
+      "read path=/home/matrix/private.ts file=/opt/matrix/release.json",
+    );
+
+    expect(redacted).toBe("read path=[path] file=[path]");
+    expect(redacted).not.toMatch(/\/home\/matrix|\/opt\/matrix|private\.ts|release\.json/);
+  });
+
   it("formats non-error diagnostics and unsafe names safely", () => {
     const unknown = formatCodingAgentDiagnostic("token=sk_live_private /tmp/private-file");
     const unsafeNameError = new Error("failed");
+    const tokenNameError = new Error("failed");
+    const pathNameError = new Error("failed");
+    const hostNameError = new Error("failed");
     unsafeNameError.name = "!!!";
+    tokenNameError.name = "sk_live_private_name";
+    pathNameError.name = "/home/matrix/private-error";
+    hostNameError.name = "internal-runtime.local";
 
     expect(unknown).toEqual({
       name: "Unknown",
@@ -99,6 +114,9 @@ describe("coding agent diagnostics", () => {
       name: "Error",
       message: "failed",
     });
+    expect(formatCodingAgentDiagnostic(tokenNameError).name).toBe("token");
+    expect(formatCodingAgentDiagnostic(pathNameError).name).toBe("path");
+    expect(formatCodingAgentDiagnostic(hostNameError).name).toBe("host");
   });
 
   it("formats bounded error diagnostics without leaking raw values", () => {


### PR DESCRIPTION
## Summary
- add a bounded mobile coding-agent diagnostics helper for warning scopes and redacted metadata
- route mobile coding-agent gateway-client status, parse, stream, and catch warnings through the helper
- redact complete Authorization values, compound secret assignments, quoted owner paths, private IPv4/IPv6 hosts, and private DNS names before logging
- redact single-label private runtime hosts when bounded network failures identify them as host values
- consume complete scheme-less host and URL values so private path/query tails cannot survive redaction
- close inherited gateway redaction gaps for assignment-prefixed owner paths and structured error names
- update internal coding-agent shell docs/spec evidence for mobile client diagnostic redaction

## Tests
- `pnpm --filter matrix-os-mobile exec jest __tests__/coding-agent-diagnostics.test.ts __tests__/gateway-client.test.ts --runInBand` (69 passed)
- `pnpm --filter matrix-os-mobile run test --runInBand` (32 suites, 360 passed)
- `pnpm --filter matrix-os-mobile exec tsc --noEmit`
- `pnpm --filter matrix-os-mobile run lint`
- `bun run check:patterns` (0 violations)
- `bun run typecheck`
- `bun run test -- --maxWorkers=2` (757 files and 8,222 tests passed; one unrelated CLI rich-paste test failed in the full run)
- `pnpm exec vitest run tests/cli/shell-client.test.ts --maxWorkers=1` (44 passed, including the full-run failure)
- `pnpm exec vitest run tests/gateway/coding-agents-diagnostics.test.ts tests/gateway/coding-agents-summary.test.ts tests/gateway/coding-agents-threads.test.ts tests/gateway/coding-agents-thread-stream.test.ts --maxWorkers=2` (96 passed)
- `git diff --check`
- prohibited-reference scan across every changed file (no matches)

`vp` is not installed on the validation host, so the repository-native commands above were used directly.

## Review/Monitoring
- Rebased onto merged `main` at `8d14636810` without a merge commit.
- Mobile and gateway review feedback is addressed through exact head `571cba0710`.
- Do not add `ready-for-ci` until trusted review is 5/5 on the current head and all review threads are resolved.

## Invariants
- Gateway/runtime remains the source of truth; mobile is still a thin authenticated client.
- Mobile AsyncStorage persistence is unchanged and stores no transcripts, terminal output, file contents, diffs, provider credentials, approval payloads, or launch tokens.
- Mobile client logs may include only bounded warning scopes and redacted diagnostic metadata, never raw gateway response bodies, paths, tokens, private hosts, database details, or provider/runtime failure text.
- No new persistence technology, provider credentials, route behavior, or user-visible UI behavior is introduced.
