### PR TITLE
chore(sync-client): bump cli to 0.3.12

### DIFF
--- a/packages/sync-client/package.json
+++ b/packages/sync-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@finnaai/matrix",
-  "version": "0.3.11",
+  "version": "0.3.12",
   "description": "Matrix OS command-line client — login, sync, and peer management for matrix-os.com",
   "type": "module",
   "license": "AGPL-3.0-or-later",


### PR DESCRIPTION
Summary
- Bump the published Matrix CLI package version from 0.3.11 to 0.3.12.
- Enables the CLI Release workflow to publish the merged dropped-screenshot fix from PR #887.

Tests
- pnpm install --frozen-lockfile
- pnpm --filter @finnaai/matrix build
- pnpm --filter @finnaai/matrix test
- pnpm --filter @finnaai/matrix exec node ./scripts/check-publish.mjs
- pnpm --filter @finnaai/matrix exec node ./scripts/validate-package-runners.mjs
- ./scripts/review/check-patterns.sh (0 violations; existing repo warnings only)
- git diff --check

Review/Monitoring
- `@finnaai/matrix@0.3.11` already exists on npm and `cli-v0.3.11` already exists.
- `@finnaai/matrix@0.3.12` does not exist yet.
- Greptile Confidence Score: 5/5 on b91a2585868b1c16365a7ed6eb9931cec56a5733.
- After this PR merges with Greptile 5/5, dispatch `.github/workflows/cli-release.yml` with `version=0.3.12`.

Invariants
- Source of truth: `packages/sync-client/package.json` version must match the CLI release workflow input.
- Lock/transaction scope: no runtime state, database, or network behavior changes are included.
- Acceptable orphan states: if the release workflow fails after merge, npm remains at 0.3.11 and this version bump can be retried with the same workflow input.
- Auth source of truth: no auth surfaces change.
- Deferred scope: publishing npm, GitHub release, and Homebrew updates happen in the follow-up CLI Release workflow dispatch, not in this PR.
