### PR TITLE
test(sync-client): await rich paste upload

### DIFF
--- a/tests/cli/shell-client.test.ts
+++ b/tests/cli/shell-client.test.ts
@@ -752,8 +752,13 @@ describe("shell REST client", () => {
     ControlledWebSocket.last?.emit("open");
     ControlledWebSocket.last?.emit("message", JSON.stringify({ type: "attached" }));
     input.emit("data", `"${imagePath}"`);
-    await new Promise((resolve) => setTimeout(resolve, 0));
-    await new Promise((resolve) => setTimeout(resolve, 0));
+    await vi.waitFor(() => {
+      expect(fetchImpl).toHaveBeenCalledTimes(1);
+      expect(ControlledWebSocket.last?.sent.map((frame) => JSON.parse(frame))).toContainEqual({
+        type: "input",
+        data: "\"/home/matrix/home/projects/.matrix-terminal-pastes/2026-07-07/upload.png\"",
+      });
+    });
     ControlledWebSocket.last?.emit("message", JSON.stringify({ type: "exit", code: 0 }));
 
     await expect(attached).resolves.toEqual({ detached: false });


### PR DESCRIPTION
## Summary
- replace two fixed event-loop ticks in the root CLI rich-paste regression with a milestone-based wait
- wait for both the upload request and rewritten terminal input before closing the fake socket
- keep production rich-paste behavior unchanged while removing CI timing dependence

## Tests
- `pnpm exec vitest run tests/cli/shell-client.test.ts -t "uploads a pasted quoted macOS screenshot path and sends the VPS terminal path" --maxWorkers=1`
- `pnpm exec vitest run tests/cli/shell-client.test.ts --maxWorkers=1` (44 tests passed)
- `bun run check:patterns` (0 violations)
- `git diff --check`

The failure was observed in PR #892 unit shard 1/4 and reproduced locally from that exact head before this isolated fix. Public and internal docs are unchanged because this is test synchronization only and does not change product behavior or contracts.

## Review/Monitoring
- Ready for exact-head review.
- Do not add `ready-for-ci` until trusted review is 5/5 and all review feedback is resolved.

## Invariants

### Source of truth
- The test waits for observable upload and terminal-frame milestones instead of assuming a fixed number of event-loop turns.
- Production rich-paste code remains unchanged.

### Lock/transaction scope
- No runtime lock, transaction, persistence, or external-call behavior changes.

### Acceptable orphan states
- None introduced; this PR changes only fake-socket test sequencing.

### Auth source of truth
- Existing bearer-auth upload assertions remain unchanged.

### Deferred scope
- No CLI runtime behavior, gateway route, shell UI, desktop, or mobile changes are included.
