### PR TITLE
fix(preview): isolate VPS runtime slots per PR

### DIFF
--- a/.github/workflows/preview-vps.yml
+++ b/.github/workflows/preview-vps.yml
@@ -6,7 +6,8 @@
 # Flow:
 #   deploy   — on label / push while labeled: build bundle v<date>-pr<N>-<sha7>,
 #              publish register-only (--channel none, never promoted),
-#              provision pr-<N> if absent, deploy the exact version, comment.
+#              provision pr-<N> in runtime slot pr-<N> if absent, deploy the
+#              exact version, comment.
 #   teardown — on PR close: delete the pr-<N> VPS.
 #   reaper   — daily: delete any pr-* VPS whose PR is closed or older than 72h,
 #              so orphans cannot accumulate Hetzner cost.
@@ -180,6 +181,7 @@ jobs:
       PLATFORM_SECRET: ${{ secrets.PLATFORM_SECRET }}
       PREVIEW_CLERK_USER_ID: ${{ secrets.PREVIEW_CLERK_USER_ID }}
       HANDLE: ${{ needs.gate.outputs.handle }}
+      RUNTIME_SLOT: ${{ needs.gate.outputs.handle }}
       VERSION: ${{ needs.build.outputs.version }}
     steps:
       - uses: actions/checkout@v6
@@ -212,11 +214,16 @@ jobs:
               '[.machines[] | select(.handle == $h and .status != "deleted")] | .[0].status // "absent"')"
           echo "Fleet status for ${HANDLE}: ${status}"
           if [ "$status" = "absent" ]; then
+            payload="$(jq -cn \
+              --arg clerkUserId "$PREVIEW_CLERK_USER_ID" \
+              --arg handle "$HANDLE" \
+              --arg runtimeSlot "$RUNTIME_SLOT" \
+              '{clerkUserId: $clerkUserId, handle: $handle, runtimeSlot: $runtimeSlot}')"
             code="$(curl -sS --max-time 60 -o /tmp/provision.json -w '%{http_code}' \
               -X POST "${PLATFORM_PUBLIC_URL}/vps/provision" \
               -H "authorization: Bearer ${PLATFORM_SECRET}" \
               -H "content-type: application/json" \
-              -d "{\"clerkUserId\":\"${PREVIEW_CLERK_USER_ID}\",\"handle\":\"${HANDLE}\",\"runtimeSlot\":\"preview\"}")"
+              --data-binary "$payload")"
             if [ "$code" != "202" ] && [ "$code" != "200" ]; then
               echo "Provision failed with HTTP ${code} (body in workflow log)" >&2
               cat /tmp/provision.json >&2

--- a/docs/dev/preview-environments.md
+++ b/docs/dev/preview-environments.md
@@ -53,9 +53,11 @@ Add the **`preview-vps`** label to a same-repo PR. The `Preview VPS` workflow:
 2. Publishes it **register-only** (`publish-release.sh --channel none`): the
    release exists in R2 + platform DB but no channel pointer can ever select
    it, so it cannot reach real users.
-3. Provisions VPS `pr-<N>` (runtime slot `preview`, bound to the
-   `PREVIEW_CLERK_USER_ID` Clerk user) if absent, then deploys exactly that
-   version to exactly that handle.
+3. Provisions VPS `pr-<N>` in the matching `pr-<N>` runtime slot, bound to the
+   `PREVIEW_CLERK_USER_ID` Clerk user, if absent, then deploys exactly that
+   version to exactly that handle. The per-PR slot keeps provisioning
+   idempotent without making concurrent previews for the shared QA owner
+   collide.
 4. Comments the URL on the PR: `https://app.matrix-os.com/vm/pr-<N>`.
 
 Teardown is automatic on PR close. A daily reaper deletes any `pr-*` VPS whose

--- a/specs/093-preview-environments/spec.md
+++ b/specs/093-preview-environments/spec.md
@@ -65,9 +65,11 @@ connect to, CLI betas need a paired shell), and today each is assembled by hand.
   release validation (`/^[A-Za-z0-9._-]{1,128}$/`).
 - Publish: `scripts/publish-release.sh` **without** `--channel` — the release is
   registered but never promoted; no channel pointer can ever select a PR bundle.
-- Provision: `POST /vps/provision` with `handle: pr-<N>`, a dedicated
-  `PREVIEW_CLERK_USER_ID` secret, `runtimeSlot: preview`. Idempotent: if the handle
-  already exists in `/vps/fleet`, skip provision and deploy only.
+- Provision: `POST /vps/provision` with matching `handle: pr-<N>` and
+  `runtimeSlot: pr-<N>`, plus a dedicated `PREVIEW_CLERK_USER_ID` secret. The
+  per-PR slot preserves owner/slot idempotency while allowing concurrent preview
+  VPSes for the shared QA owner. If the handle already exists in `/vps/fleet`,
+  skip provision and deploy only.
 - Deploy: `POST /vps/deploy {"version": "...", "handle": "pr-<N>"}` — version-pinned,
   single-handle. Never channel-wide.
 - Report: PR comment with the VM URL, bundle version, and log-query one-liner.

--- a/tests/platform/customer-vps-host-bundle.test.ts
+++ b/tests/platform/customer-vps-host-bundle.test.ts
@@ -596,6 +596,10 @@ test "$(readlink "$MATRIX_LEGACY_HOME/.hermes")" = "$MATRIX_HOME/.hermes"
     const workflow = readFileSync(join(root, '.github/workflows/preview-vps.yml'), 'utf8');
 
     expect(workflow).toContain('VERSION="v$(date -u +%Y.%m.%d)-pr${PR_NUMBER}-${HEAD_SHA:0:7}"');
+    expect(workflow).toContain('RUNTIME_SLOT: ${{ needs.gate.outputs.handle }}');
+    expect(workflow).toContain('--arg runtimeSlot "$RUNTIME_SLOT"');
+    expect(workflow).toContain("'{clerkUserId: $clerkUserId, handle: $handle, runtimeSlot: $runtimeSlot}'");
+    expect(workflow).not.toContain('\\"runtimeSlot\\":\\"preview\\"');
     expect(workflow).toContain('dist/host-bundle/incremental-manifest.json');
     expect(workflow).toContain('dist/host-bundle/objects/**');
     expect(workflow).toContain('./scripts/publish-release.sh "$VERSION" --channel none');


### PR DESCRIPTION
## Summary

- derive each preview VPS runtime slot from its validated `pr-<N>` handle
- build the provision payload with `jq` instead of handwritten JSON interpolation
- document and test concurrent preview provisioning for the shared QA owner

This removes the owner/runtime-slot collision that caused PR #896's exact preview deployment to resolve to another open PR's machine.

## Tests

- `pnpm exec vitest run tests/platform/customer-vps-host-bundle.test.ts tests/platform/ci-workflows.test.ts` (60 passed)
- `bun run test` (760 files passed, 8,274 tests passed, 4 files/27 tests intentionally skipped)
- `bun run typecheck`
- `bun run check:patterns` (0 violations, 5 existing warning categories)
- `git diff --check`
- `vp check` unavailable on this host

## Review/Monitoring

- ready for review immediately
- add `ready-for-ci` only after exact-head Greptile 5/5
- after merge, rebase PR #896 on the new main and rerun its `preview-vps` workflow

## Invariants

### Source of truth
- Platform Postgres remains authoritative for machines, owners, handles, and runtime slots.
- The workflow derives both preview handle and slot from the validated PR number; it stores no runtime state.

### Lock/transaction scope
- No database transaction or lock behavior changes.
- Provisioning remains behind the platform service's existing owner/slot idempotency boundary; external release and provisioning calls remain outside any workflow-local critical section.

### Acceptable orphan states
- A register-only preview release may remain if provisioning or deployment fails; no channel points to it.
- Preview machines remain bounded by PR-close teardown and the fail-safe TTL reaper.

### Auth source of truth
- GitHub same-repository event checks gate secret-bearing jobs.
- Existing platform bearer authentication remains authoritative for fleet, provision, deploy, and delete operations; failures remain closed.

### Deferred scope
- No platform persistence, customer runtime, provider rollout, or preview retention-policy changes.
- PR #896 remains separate and will be rebased after this infrastructure fix lands.