### PR TITLE
feat(contracts): add project conversation schemas

### DIFF
--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -65,6 +65,7 @@ export const ProviderIdSchema = z.string().min(1).max(80).regex(SAFE_SLUG, "Inva
 export const ProjectIdSchema = referenceId(160);
 export const TaskIdSchema = prefixedId("task_");
 export const ThreadIdSchema = prefixedId("thread_");
+export const AgentTurnIdSchema = prefixedId("turn_");
 export const EventIdSchema = prefixedId("evt_");
 export const ApprovalIdSchema = prefixedId("appr_");
 export const RequestIdSchema = prefixedId("req_");
@@ -121,6 +122,10 @@ export const RuntimeCapabilityIdSchema = z.enum([
   "codingAgentsFiles",
   "codingAgentsSourceControl",
   "codingAgentsNativeMobileTerminal",
+  "codingAgentsProjectWorkspace",
+  "codingAgentsSameThreadTurns",
+  "codingAgentsConversationView",
+  "codingAgentsKanbanView",
 ]);
 
 export const RuntimeTargetSchema = z.object({
@@ -257,6 +262,36 @@ export const CreateAgentThreadRequestSchema = z.object({
 
 export type CreateAgentThreadRequest = z.infer<typeof CreateAgentThreadRequestSchema>;
 
+export const CreateAgentTurnRequestSchema = z.object({
+  message: boundedText(24_000, 96 * 1024),
+  attachments: z.array(AgentAttachmentSchema).max(8).optional(),
+  clientRequestId: RequestIdSchema,
+}).strict();
+
+export type CreateAgentTurnRequest = z.infer<typeof CreateAgentTurnRequestSchema>;
+
+export const AgentTurnStatusSchema = z.enum(["accepted", "running", "completed", "failed", "aborted"]);
+
+export const CreateAgentTurnResponseSchema = z.object({
+  threadId: ThreadIdSchema,
+  turnId: AgentTurnIdSchema,
+  status: z.enum(["accepted", "already_accepted"]),
+  acceptedAt: IsoTimestampSchema,
+}).strict();
+
+export const CreateAgentTurnErrorCodeSchema = z.enum([
+  "thread_busy",
+  "thread_not_found",
+  "turn_unavailable",
+]);
+
+export const CreateAgentTurnErrorSchema = SafeClientErrorSchema.extend({
+  code: CreateAgentTurnErrorCodeSchema,
+}).strict();
+
+export type CreateAgentTurnResponse = z.infer<typeof CreateAgentTurnResponseSchema>;
+export type CreateAgentTurnError = z.infer<typeof CreateAgentTurnErrorSchema>;
+
 export const AgentThreadComposerDraftSchema = z.object({
   providerId: ProviderIdSchema.optional(),
   prompt: z.string()
@@ -366,6 +401,22 @@ const BaseThreadEventSchema = z.object({
   threadId: ThreadIdSchema,
   occurredAt: IsoTimestampSchema,
 });
+
+export const AgentTurnLifecycleEventSchema = z.discriminatedUnion("type", [
+  BaseThreadEventSchema.extend({
+    type: z.literal("turn.accepted"),
+    turnId: AgentTurnIdSchema,
+    clientRequestId: RequestIdSchema,
+    acceptedAt: IsoTimestampSchema,
+  }).strict(),
+  BaseThreadEventSchema.extend({
+    type: z.literal("turn.status"),
+    turnId: AgentTurnIdSchema,
+    status: AgentTurnStatusSchema,
+  }).strict(),
+]);
+
+export type AgentTurnLifecycleEvent = z.infer<typeof AgentTurnLifecycleEventSchema>;
 
 export const AgentThreadEventSchema = z.discriminatedUnion("type", [
   BaseThreadEventSchema.extend({
@@ -548,12 +599,91 @@ export const TerminalServerFrameSchema = z.discriminatedUnion("type", [
   }).strict(),
 ]);
 
+export const BoundedAggregateCountSchema = z.number().int().min(0).max(1_000_000);
+
 export const ProjectSummarySchema = z.object({
   id: ProjectIdSchema,
   label: SafeDisplayStringSchema,
   status: z.enum(["available", "missing", "stale", "unknown"]).default("unknown"),
+  taskCount: BoundedAggregateCountSchema,
+  threadCount: BoundedAggregateCountSchema,
+  attentionCount: BoundedAggregateCountSchema,
   updatedAt: IsoTimestampSchema.optional(),
 }).strict();
+
+export const CanonicalTaskStatusSchema = z.enum([
+  "todo",
+  "running",
+  "waiting",
+  "blocked",
+  "complete",
+  "archived",
+]);
+export const CanonicalTaskPrioritySchema = z.enum(["low", "normal", "high", "urgent"]);
+
+export const TaskAgentSummarySchema = z.object({
+  id: TaskIdSchema,
+  projectId: ProjectIdSchema,
+  title: SafeDisplayStringSchema,
+  status: CanonicalTaskStatusSchema,
+  priority: CanonicalTaskPrioritySchema,
+  order: z.number().int().min(0).max(1_000_000),
+  threadCount: BoundedAggregateCountSchema,
+  activeThreadCount: BoundedAggregateCountSchema,
+  attentionCount: BoundedAggregateCountSchema,
+  latestThreadAt: IsoTimestampSchema.optional(),
+  revision: z.number().int().min(0).max(1_000_000_000).optional(),
+}).strict();
+
+export type TaskAgentSummary = z.infer<typeof TaskAgentSummarySchema>;
+
+const ProjectTaskSummaryListSchema = boundedListSchema(TaskAgentSummarySchema, 100);
+const ProjectThreadSummaryListSchema = boundedListSchema(AgentThreadSummarySchema, 100);
+
+export const ProjectAgentWorkspaceSchema = z.object({
+  project: ProjectSummarySchema,
+  tasks: ProjectTaskSummaryListSchema,
+  projectThreads: ProjectThreadSummaryListSchema,
+  taskThreads: ProjectThreadSummaryListSchema,
+  updatedAt: IsoTimestampSchema,
+}).strict().superRefine((workspace, ctx) => {
+  for (const [index, task] of workspace.tasks.items.entries()) {
+    if (task.projectId !== workspace.project.id) {
+      ctx.addIssue({ code: "custom", message: "Task project does not match workspace", path: ["tasks", "items", index, "projectId"] });
+    }
+  }
+  for (const [index, thread] of workspace.projectThreads.items.entries()) {
+    if (thread.projectId !== workspace.project.id || thread.taskId !== undefined) {
+      ctx.addIssue({ code: "custom", message: "Project thread relation is invalid", path: ["projectThreads", "items", index] });
+    }
+  }
+  for (const [index, thread] of workspace.taskThreads.items.entries()) {
+    if (thread.projectId !== workspace.project.id || thread.taskId === undefined) {
+      ctx.addIssue({ code: "custom", message: "Task thread relation is invalid", path: ["taskThreads", "items", index] });
+    }
+  }
+});
+
+export type ProjectAgentWorkspace = z.infer<typeof ProjectAgentWorkspaceSchema>;
+
+const AgentThreadListLimitSchema = z.number().int().min(1).max(100).default(50);
+
+export const AgentThreadListFilterSchema = z.discriminatedUnion("scope", [
+  z.object({
+    scope: z.literal("project"),
+    projectId: ProjectIdSchema,
+    taskId: TaskIdSchema.optional(),
+    cursor: CursorSchema.optional(),
+    limit: AgentThreadListLimitSchema,
+  }).strict(),
+  z.object({
+    scope: z.literal("legacy_unassigned"),
+    cursor: CursorSchema.optional(),
+    limit: AgentThreadListLimitSchema,
+  }).strict(),
+]);
+
+export type AgentThreadListFilter = z.infer<typeof AgentThreadListFilterSchema>;
 
 export const PreviewSessionSummarySchema = z.object({
   id: referenceId(128),

--- a/specs/105-coding-agent-shells/acceptance-tests.md
+++ b/specs/105-coding-agent-shells/acceptance-tests.md
@@ -1,6 +1,6 @@
 # Acceptance Tests: Project Conversations And Kanban
 
-**Status**: Specification checkpoint - no implementation evidence claimed
+**Status**: Phase 18 contract evidence added; gateway, shell, security, and cross-shell evidence remains planned
 **Updated**: 2026-07-10
 
 This matrix is the executable acceptance contract for the clarified coding-agent shell model. A task checkbox in `tasks.md` is complete only when its named test IDs have current evidence on the exact implementation head. Existing checkpoint tests remain required regressions but do not prove these new cases.
@@ -36,7 +36,7 @@ Every clarified functional requirement and buildable success criterion has at le
 
 | ID | Requirement | Expected Evidence |
 | --- | --- | --- |
-| CT-001 | Project summary is bounded and carries safe task/thread/attention counts. | Zod 4 parse/reject tests in `tests/contracts/coding-agents.test.ts`. |
+| CT-001 | Project summary is bounded and carries safe task/thread/attention counts. | Zod 4 parse/reject tests in `tests/contracts/coding-agent-project-conversations.test.ts`. |
 | CT-002 | Task agent summary uses canonical status/priority values and bounded aggregate counts. | Valid fixture plus negative status/count/title/ID cases. |
 | CT-003 | Project workspace has independent bounded task, project-thread, and task-thread lists with truncation/cursors. | Oversized nested/list fixtures reject; boundary-size fixtures pass. |
 | CT-004 | Thread list filters validate required project and optional task IDs independently. | Valid project-only/task filter plus malformed/cross-field rejection fixtures. |

--- a/specs/105-coding-agent-shells/tasks.md
+++ b/specs/105-coding-agent-shells/tasks.md
@@ -1070,26 +1070,29 @@ Goal: make the clarified hierarchy explicit and independently testable before ru
 
 ### 18.1 Shared Project Workspace Contracts
 
-- [ ] Add bounded project summary counts for tasks, threads, and attention.
-- [ ] Add canonical `TaskAgentSummarySchema` using existing Matrix task status/priority values.
-- [ ] Add bounded `ProjectAgentWorkspaceSchema` with independent task/thread caps and truncation metadata.
-- [ ] Add thread list filters for required `projectId` and optional `taskId`.
-- [ ] Keep legacy unassigned thread reads explicit and bounded; do not allow new shell-created unassigned threads.
+- [x] Add bounded project summary counts for tasks, threads, and attention.
+- [x] Add canonical `TaskAgentSummarySchema` using existing Matrix task status/priority values.
+- [x] Add bounded `ProjectAgentWorkspaceSchema` with independent task/thread caps and truncation metadata.
+- [x] Add thread list filters for required `projectId` and optional `taskId`.
+- [x] Keep legacy unassigned thread read filters explicit and bounded.
+- [ ] Enforce no new shell-created unassigned threads in Phase 19 (`GW-009`) after real project hydration exists.
 
 Tests: `CT-001`, `CT-002`, `CT-003`, `CT-004`.
 
 ### 18.2 Same-Thread Turn Contracts
 
-- [ ] Add `AgentTurnIdSchema`, `CreateAgentTurnRequestSchema`, and `CreateAgentTurnResponseSchema`.
-- [ ] Bound message, attachments, idempotency key, and safe errors.
-- [ ] Add turn lifecycle events without exposing provider resume identity.
-- [ ] Add capability IDs for project workspace projection, same-thread turns, and Conversation/Kanban shells.
+- [x] Add `AgentTurnIdSchema`, `CreateAgentTurnRequestSchema`, and `CreateAgentTurnResponseSchema`.
+- [x] Bound message, attachments, idempotency key, and safe errors.
+- [x] Add turn lifecycle event contracts without exposing provider resume identity.
+- [x] Add capability IDs for project workspace projection, same-thread turns, and Conversation/Kanban shells.
 
 Tests: `CT-005`, `CT-006`, `CT-007`.
 
 Gate:
 
-- [ ] Gate 1 rerun passes for the additive contracts.
+- [x] Gate 1 rerun passes for the additive contracts (`CT-001` through `CT-007`).
+
+Maintenance boundary: `packages/contracts/src/index.ts` is now a 1,000+ line schema-only barrel. Before adding another coding-agent contract family, extract the coding-agent schemas into focused domain modules while preserving the package's existing root exports.
 
 ## Phase 19 - Gateway Project Workspace Read Model
 

--- a/tests/contracts/coding-agent-project-conversations.test.ts
+++ b/tests/contracts/coding-agent-project-conversations.test.ts
@@ -1,0 +1,306 @@
+import { describe, expect, it } from "vitest";
+import {
+  AgentThreadEventSchema,
+  AgentThreadListFilterSchema,
+  AgentTurnLifecycleEventSchema,
+  AgentTurnIdSchema,
+  CreateAgentTurnErrorSchema,
+  CreateAgentTurnRequestSchema,
+  CreateAgentTurnResponseSchema,
+  ProjectAgentWorkspaceSchema,
+  ProjectSummarySchema,
+  RuntimeCapabilityIdSchema,
+  RuntimeSummarySchema,
+  TaskAgentSummarySchema,
+} from "../../packages/contracts/src/index.js";
+
+const now = "2026-07-06T12:00:00.000Z";
+
+function task(index: number) {
+  return {
+    id: `task_auth_${index}`,
+    projectId: "matrix-os",
+    title: `Authentication task ${index}`,
+    status: "todo" as const,
+    priority: "normal" as const,
+    order: index,
+    threadCount: 1,
+    activeThreadCount: 0,
+    attentionCount: 0,
+  };
+}
+
+function thread(index: number, taskId?: string) {
+  return {
+    id: `thread_auth_${index}`,
+    providerId: "codex",
+    title: `Authentication chat ${index}`,
+    status: "completed" as const,
+    attention: "none" as const,
+    projectId: "matrix-os",
+    ...(taskId ? { taskId } : {}),
+    createdAt: now,
+    updatedAt: now,
+  };
+}
+
+function workspaceFixture() {
+  return {
+    project: {
+      id: "matrix-os",
+      label: "Matrix OS",
+      status: "available" as const,
+      taskCount: 1,
+      threadCount: 2,
+      attentionCount: 0,
+    },
+    tasks: { items: [task(0)], hasMore: false, limit: 100 },
+    projectThreads: { items: [thread(0)], hasMore: false, limit: 100 },
+    taskThreads: { items: [thread(1, "task_auth_0")], hasMore: false, limit: 100 },
+    updatedAt: now,
+  };
+}
+
+describe("coding agent project conversation contracts", () => {
+  it("CT-001 parses bounded project summary counts", () => {
+    expect(ProjectSummarySchema.parse({
+      id: "matrix-os",
+      label: "Matrix OS",
+      status: "available",
+      taskCount: 12,
+      threadCount: 18,
+      attentionCount: 2,
+      updatedAt: now,
+    })).toMatchObject({ taskCount: 12, threadCount: 18, attentionCount: 2 });
+
+    for (const taskCount of [-1, 1_000_001]) {
+      expect(() => ProjectSummarySchema.parse({
+        id: "matrix-os",
+        label: "Matrix OS",
+        status: "available",
+        taskCount,
+        threadCount: 0,
+        attentionCount: 0,
+      })).toThrow();
+    }
+  });
+
+  it("CT-002 validates canonical task summaries and bounded thread aggregates", () => {
+    expect(TaskAgentSummarySchema.parse({
+      id: "task_auth",
+      projectId: "matrix-os",
+      title: "Harden authentication",
+      status: "running",
+      priority: "urgent",
+      order: 2,
+      threadCount: 3,
+      activeThreadCount: 1,
+      attentionCount: 1,
+      latestThreadAt: now,
+      revision: 7,
+    })).toMatchObject({ status: "running", priority: "urgent", threadCount: 3 });
+
+    for (const invalid of [
+      { status: "in_progress" },
+      { priority: "critical" },
+      { title: "/home/matrix/private" },
+      { threadCount: -1 },
+      { activeThreadCount: 1_000_001 },
+    ]) {
+      expect(() => TaskAgentSummarySchema.parse({ ...task(0), ...invalid })).toThrow();
+    }
+  });
+
+  it("CT-003 validates independently bounded project workspace lists", () => {
+    const workspace = workspaceFixture();
+    expect(ProjectAgentWorkspaceSchema.parse(workspace).taskThreads.items[0]?.taskId).toBe("task_auth_0");
+
+    for (const listName of ["tasks", "projectThreads", "taskThreads"] as const) {
+      const itemFactory = listName === "tasks"
+        ? task
+        : (index: number) => thread(index, listName === "taskThreads" ? "task_auth_0" : undefined);
+      expect(() => ProjectAgentWorkspaceSchema.parse({
+        ...workspace,
+        [listName]: {
+          items: Array.from({ length: 101 }, (_, index) => itemFactory(index)),
+          hasMore: true,
+          limit: 100,
+        },
+      })).toThrow();
+    }
+    expect(() => ProjectAgentWorkspaceSchema.parse({
+      ...workspace,
+      projectThreads: { items: [{ ...thread(0), taskId: "task_auth_0" }], hasMore: false, limit: 100 },
+    })).toThrow();
+    expect(() => ProjectAgentWorkspaceSchema.parse({
+      ...workspace,
+      taskThreads: {
+        items: [{ ...thread(1, "task_auth_0"), transcript: ["private"] }],
+        hasMore: false,
+        limit: 100,
+      },
+    })).toThrow();
+  });
+
+  it("CT-004 requires explicit bounded project or legacy-unassigned thread filters", () => {
+    expect(AgentThreadListFilterSchema.parse({
+      scope: "project",
+      projectId: "matrix-os",
+      limit: 25,
+    })).toMatchObject({ scope: "project", projectId: "matrix-os", limit: 25 });
+    expect(AgentThreadListFilterSchema.parse({
+      scope: "project",
+      projectId: "matrix-os",
+      taskId: "task_auth",
+      cursor: "cursor.next",
+    })).toMatchObject({ projectId: "matrix-os", taskId: "task_auth", limit: 50 });
+    expect(AgentThreadListFilterSchema.parse({ scope: "legacy_unassigned" })).toMatchObject({
+      scope: "legacy_unassigned",
+      limit: 50,
+    });
+
+    for (const invalid of [
+      { scope: "project", taskId: "task_auth" },
+      { scope: "project", projectId: "../matrix-os" },
+      { scope: "legacy_unassigned", projectId: "matrix-os" },
+      { scope: "project", projectId: "matrix-os", limit: 101 },
+    ]) {
+      expect(() => AgentThreadListFilterSchema.parse(invalid)).toThrow();
+    }
+  });
+
+  it("CT-005 bounds same-thread turn messages, attachments, and idempotency keys", () => {
+    expect(AgentTurnIdSchema.parse("turn_auth_fix_1")).toBe("turn_auth_fix_1");
+    expect(CreateAgentTurnRequestSchema.parse({
+      message: "Continue with the gateway fix.",
+      attachments: [{
+        id: "review:auth:12",
+        kind: "structured_ref",
+        label: "Authentication review",
+        path: "packages/gateway/src/auth.ts",
+      }],
+      clientRequestId: "req_turn_auth_1",
+    }).message).toBe("Continue with the gateway fix.");
+
+    for (const invalid of [
+      { message: "", clientRequestId: "req_turn_auth_1" },
+      { message: "a".repeat(24_001), clientRequestId: "req_turn_auth_1" },
+      { message: "Continue.", clientRequestId: "turn_auth_1" },
+      {
+        message: "Continue.",
+        clientRequestId: "req_turn_auth_1",
+        attachments: Array.from({ length: 9 }, (_, index) => ({
+          id: `ref:${index}`,
+          kind: "structured_ref",
+          label: `Reference ${index}`,
+        })),
+      },
+    ]) {
+      expect(() => CreateAgentTurnRequestSchema.parse(invalid)).toThrow();
+    }
+  });
+
+  it("CT-006 keeps turn responses, errors, and lifecycle events safe", () => {
+    expect(CreateAgentTurnResponseSchema.parse({
+      threadId: "thread_fix",
+      turnId: "turn_fix_2",
+      status: "accepted",
+      acceptedAt: now,
+    }).turnId).toBe("turn_fix_2");
+
+    for (const code of ["thread_busy", "thread_not_found", "turn_unavailable"] as const) {
+      expect(CreateAgentTurnErrorSchema.parse({
+        code,
+        safeMessage: "This conversation cannot accept a message right now. Refresh and try again.",
+        retryable: code === "thread_busy",
+        recoveryActions: ["retry"],
+      }).code).toBe(code);
+    }
+
+    expect(AgentTurnLifecycleEventSchema.parse({
+      type: "turn.accepted",
+      eventId: "evt_turn_accepted",
+      threadId: "thread_fix",
+      occurredAt: now,
+      turnId: "turn_fix_2",
+      clientRequestId: "req_turn_fix_2",
+      acceptedAt: now,
+    }).type).toBe("turn.accepted");
+    expect(AgentTurnLifecycleEventSchema.parse({
+      type: "turn.status",
+      eventId: "evt_turn_completed",
+      threadId: "thread_fix",
+      occurredAt: now,
+      turnId: "turn_fix_2",
+      status: "completed",
+    }).type).toBe("turn.status");
+
+    const unsafeValues = [
+      {
+        schema: CreateAgentTurnResponseSchema,
+        value: {
+          threadId: "thread_fix",
+          turnId: "turn_fix_2",
+          status: "accepted",
+          acceptedAt: now,
+          providerResumeIdentity: "resume_secret",
+        },
+      },
+      {
+        schema: CreateAgentTurnErrorSchema,
+        value: { code: "provider_failed", safeMessage: "Provider failed.", retryable: false },
+      },
+      {
+        schema: AgentTurnLifecycleEventSchema,
+        value: {
+          type: "turn.status",
+          eventId: "evt_turn_completed",
+          threadId: "thread_fix",
+          occurredAt: now,
+          turnId: "turn_fix_2",
+          status: "completed",
+          providerResumeIdentity: "resume_secret",
+        },
+      },
+    ];
+    for (const { schema, value } of unsafeValues) {
+      expect(() => schema.parse(value)).toThrow();
+    }
+  });
+
+  it("CT-007 advertises project workspace, same-thread turn, and dual-view capabilities", () => {
+    const capabilityIds = [
+      "codingAgentsProjectWorkspace",
+      "codingAgentsSameThreadTurns",
+      "codingAgentsConversationView",
+      "codingAgentsKanbanView",
+    ] as const;
+    for (const id of capabilityIds) {
+      expect(RuntimeCapabilityIdSchema.parse(id)).toBe(id);
+    }
+    expect(() => RuntimeCapabilityIdSchema.parse("codingAgentsProviderResumeIdentity")).toThrow();
+
+    const summary = RuntimeSummarySchema.parse({
+      runtime: { id: "rt_primary", label: "Primary Matrix computer", status: "available" },
+      capabilities: capabilityIds.map((id, index) => ({ id, enabled: index < 2 })),
+      providers: [],
+      projects: { items: [], hasMore: false, limit: 20 },
+      activeThreads: { items: [], hasMore: false, limit: 20 },
+      terminalSessions: { items: [], hasMore: false, limit: 20 },
+      recentActivity: { items: [], hasMore: false, limit: 20 },
+      limits: {
+        maxPromptBytes: 24_000,
+        maxAttachmentCount: 8,
+        maxTerminalInputBytes: 65_536,
+        maxListItems: 50,
+      },
+      serverTime: now,
+    });
+    expect(summary.capabilities).toEqual([
+      { id: "codingAgentsProjectWorkspace", enabled: true },
+      { id: "codingAgentsSameThreadTurns", enabled: true },
+      { id: "codingAgentsConversationView", enabled: false },
+      { id: "codingAgentsKanbanView", enabled: false },
+    ]);
+  });
+});


### PR DESCRIPTION
## Stack

2 of 2. Depends on #900, which records the confirmed Gate 0 product model.

## Summary

- adds bounded project, canonical task, and project workspace projection schemas
- adds explicit project and legacy-unassigned thread-list filter contracts
- adds same-thread turn request, response, safe-error, identifier, and lifecycle schemas
- adds independent capability flags for project workspace, same-thread turns, Conversation, and Kanban
- adds CT-001 through CT-007 and aligns the Phase 18 checklist and acceptance evidence

## Validation

- bun run test -- tests/contracts/coding-agents.test.ts tests/contracts/coding-agent-project-conversations.test.ts (15 passed)
- pnpm --filter @matrix-os/contracts run typecheck
- bun run typecheck
- bun run check:patterns (0 violations; existing warnings only)
- git diff --check
- prohibited-name scan of changed contract, test, and spec files

## Invariants

- **Source of truth:** These are schema-only projections. Gateway/runtime ownership remains unchanged.
- **Lock/transaction scope:** None in this slice; no persistence or mutation implementation changes.
- **Acceptable orphan states:** Legacy unassigned threads are readable only through an explicit bounded filter scope. New-create enforcement is deferred to GW-009 after real project hydration exists.
- **Auth source of truth:** Existing gateway request-principal and shell trust boundaries remain unchanged.
- **Deferred scope:** Project adapters/routes, task ownership checks, turn persistence/provider execution, desktop/mobile views, and runtime capability enablement remain in later stacked PRs.

## Maintenance Boundary

The contracts root is now over 1,000 lines. Before another coding-agent contract family is added, the coding-agent schemas will be extracted into focused domain modules while preserving existing package-root exports.

## Documentation

Updated Phase 18 tasks and the acceptance-test evidence path. Public product docs are deferred because this slice exposes no user-facing runtime behavior.