### PR TITLE
fix(sync-client): sanitize rich paste upload filenames

### DIFF
--- a/packages/sync-client/package.json
+++ b/packages/sync-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@finnaai/matrix",
-  "version": "0.3.12",
+  "version": "0.3.13",
   "description": "Matrix OS command-line client — login, sync, and peer management for matrix-os.com",
   "type": "module",
   "license": "AGPL-3.0-or-later",

--- a/packages/sync-client/src/cli/rich-paste.ts
+++ b/packages/sync-client/src/cli/rich-paste.ts
@@ -287,8 +287,8 @@ function safeUploadFilename(asset: RichPasteUploadAsset): string {
     .replace(/[\u0300-\u036f]/g, "")
     .replace(/[^A-Za-z0-9._-]+/g, "-")
     .replace(/-+/g, "-")
-    .replace(/^[._-]+|[._-]+$/g, "")
-    .slice(0, maxStemLength);
+    .slice(0, maxStemLength)
+    .replace(/^[._-]+|[._-]+$/g, "");
   return `${stem || "paste"}${extension}`;
 }
 

--- a/packages/sync-client/src/cli/rich-paste.ts
+++ b/packages/sync-client/src/cli/rich-paste.ts
@@ -235,7 +235,7 @@ export function createRichPasteUploadClient(options: RichPasteUploadClientOption
       for (const [index, asset] of input.assets.entries()) {
         const headers: Record<string, string> = {
           "Content-Type": asset.mimeType,
-          "X-Matrix-Filename": asset.name,
+          "X-Matrix-Filename": safeUploadFilename(asset),
         };
         if (options.token) {
           headers.Authorization = `Bearer ${options.token}`;
@@ -274,6 +274,35 @@ export function createRichPasteUploadClient(options: RichPasteUploadClientOption
       return uploaded;
     },
   };
+}
+
+function safeUploadFilename(asset: RichPasteUploadAsset): string {
+  const extension = uploadExtensionForMimeType(asset.mimeType);
+  const rawName = basename(asset.name).split(/[\\/]/).pop() ?? "";
+  const rawExtension = extname(rawName);
+  const rawStem = rawExtension ? rawName.slice(0, -rawExtension.length) : rawName;
+  const maxStemLength = 255 - extension.length;
+  const stem = rawStem
+    .normalize("NFKD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .replace(/[^A-Za-z0-9._-]+/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^[._-]+|[._-]+$/g, "")
+    .slice(0, maxStemLength);
+  return `${stem || "paste"}${extension}`;
+}
+
+function uploadExtensionForMimeType(mimeType: RichPasteImageMimeType): ".png" | ".jpg" | ".gif" | ".webp" {
+  switch (mimeType) {
+    case "image/jpeg":
+      return ".jpg";
+    case "image/gif":
+      return ".gif";
+    case "image/webp":
+      return ".webp";
+    case "image/png":
+      return ".png";
+  }
 }
 
 export function createRichPasteRewriter(input: {

--- a/packages/sync-client/src/cli/shell-client.ts
+++ b/packages/sync-client/src/cli/shell-client.ts
@@ -89,6 +89,7 @@ export interface ShellAttachOptions {
     rewriter?: RichPasteRewriter;
     uploadClient?: RichPasteUploadClient;
     clipboardReader?: ClipboardImageReader;
+    statusMinVisibleMs?: number;
   };
   noRichPaste?: boolean;
   cwd?: string;
@@ -134,6 +135,7 @@ const RICH_PASTE_UPLOAD_FAILED_MESSAGE = "Image paste failed: upload did not com
 const INCOMPLETE_BRACKETED_PASTE_MESSAGE = "Image paste failed: paste did not complete.";
 const RICH_PASTE_PROGRESS_MESSAGE = "Image paste: reading/uploading...";
 const RICH_PASTE_INSERTED_MESSAGE = "Image paste: inserted.";
+const RICH_PASTE_STATUS_MIN_VISIBLE_MS = 1_200;
 
 type MaybeTtyStream = NodeJS.ReadStream & {
   isTTY?: boolean;
@@ -730,6 +732,11 @@ export function createShellClient(options: ShellClientOptions): ShellClient {
           clipboardReader: attachOptions.richPaste?.clipboardReader ?? createMacOsClipboardImageReader(),
         })
         : undefined;
+      const configuredRichPasteStatusMinVisibleMs = attachOptions.richPaste?.statusMinVisibleMs;
+      const richPasteStatusMinVisibleMs = typeof configuredRichPasteStatusMinVisibleMs === "number" &&
+        Number.isFinite(configuredRichPasteStatusMinVisibleMs)
+        ? Math.max(0, configuredRichPasteStatusMinVisibleMs)
+        : RICH_PASTE_STATUS_MIN_VISIBLE_MS;
       const heartbeatIntervalMs = attachOptions.heartbeatIntervalMs ?? SHELL_ATTACH_HEARTBEAT_INTERVAL_MS;
       const heartbeatTimeoutMs = attachOptions.heartbeatTimeoutMs ?? SHELL_ATTACH_HEARTBEAT_TIMEOUT_MS;
       const heartbeatMissesBeforeReconnect =
@@ -1018,6 +1025,16 @@ export function createShellClient(options: ShellClientOptions): ShellClient {
             code: err instanceof Error && "code" in err ? (err as { code?: string }).code ?? "attach_failed" : "attach_failed",
           })));
         };
+        const waitForRichPasteStatusVisibility = (shownAt: number): Promise<void> => {
+          const remainingMs = richPasteStatusMinVisibleMs - (Date.now() - shownAt);
+          if (remainingMs <= 0) {
+            return Promise.resolve();
+          }
+          return new Promise((resolveDelay) => {
+            const timer = setTimeout(resolveDelay, remainingMs);
+            timer.unref?.();
+          });
+        };
         const sendInputFrame = (
           data: string,
           observablePaste: boolean,
@@ -1030,12 +1047,14 @@ export function createShellClient(options: ShellClientOptions): ShellClient {
             sendInputData(data);
             return;
           }
+          const progressShownAt = Date.now();
           writeError(`\r\n${RICH_PASTE_PROGRESS_MESSAGE}\r\n`);
           return richPasteRewriter.rewrite({
             sessionName: name,
             text: options.manualClipboardPaste ? "" : data,
             observablePaste: options.manualClipboardPaste ? true : observablePaste,
-          }).then((result) => {
+          }).then(async (result) => {
+            await waitForRichPasteStatusVisibility(progressShownAt);
             if (settled) {
               return;
             }
@@ -1047,7 +1066,8 @@ export function createShellClient(options: ShellClientOptions): ShellClient {
               writeError(`\r\n${RICH_PASTE_INSERTED_MESSAGE}\r\n`);
             }
             sendInputData(result.outgoingText);
-          }).catch((err: unknown) => {
+          }).catch(async (err: unknown) => {
+            await waitForRichPasteStatusVisibility(progressShownAt);
             if (!settled) {
               writeError(`\r\n${RICH_PASTE_UPLOAD_FAILED_MESSAGE}\r\n`);
               writeError(`[debug] rich paste rewrite failed: ${err instanceof Error ? err.name : typeof err}\r\n`);

--- a/packages/sync-client/tests/unit/rich-paste.test.ts
+++ b/packages/sync-client/tests/unit/rich-paste.test.ts
@@ -98,6 +98,35 @@ describe("cli/rich-paste", () => {
     expect(headers["X-Matrix-Filename"]).toBe("paste.webp");
   });
 
+  it("trims separators after truncating long upload filenames", async () => {
+    const fetchMock = vi.fn(async () => new Response(JSON.stringify({
+      terminalPath: "/home/matrix/home/projects/.matrix-terminal-pastes/2026-07-10/paste.png",
+      path: "projects/.matrix-terminal-pastes/2026-07-10/paste.png",
+      mimeType: "image/png",
+      size: pngBytes.byteLength,
+    }), {
+      status: 201,
+      headers: { "Content-Type": "application/json" },
+    }));
+    const client = createRichPasteUploadClient({
+      gatewayUrl: "https://matrix.example",
+      fetch: fetchMock as typeof fetch,
+    });
+
+    await client.uploadPasteAssets({
+      sessionName: "codex-c",
+      transactionId: "tx-1",
+      assets: [{
+        name: `${"a".repeat(250)} ${"b".repeat(10)}.png`,
+        mimeType: "image/png",
+        bytes: pngBytes,
+      }],
+    });
+
+    const headers = fetchMock.mock.calls[0]?.[1]?.headers as Record<string, string>;
+    expect(headers["X-Matrix-Filename"]).toBe(`${"a".repeat(250)}.png`);
+  });
+
   it("rewrites quoted image paths with spaces while preserving surrounding prompt text", async () => {
     const localPath = join(tempDir, "Screenshot 2026-07-08 at 10.31.00.png");
     await writeFile(localPath, pngBytes);

--- a/packages/sync-client/tests/unit/rich-paste.test.ts
+++ b/packages/sync-client/tests/unit/rich-paste.test.ts
@@ -5,6 +5,7 @@ import { pathToFileURL } from "node:url";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   RICH_PASTE_MAX_IMAGE_BYTES,
+  createRichPasteUploadClient,
   processRichPasteTransaction,
   type RichPasteUploadClient,
 } from "../../src/cli/rich-paste.js";
@@ -37,6 +38,65 @@ describe("cli/rich-paste", () => {
       }))),
     };
   }
+
+  it("sanitizes non-ASCII upload filenames before sending headers", async () => {
+    const fetchMock = vi.fn(async () => new Response(JSON.stringify({
+      terminalPath: "/home/matrix/home/projects/.matrix-terminal-pastes/2026-07-10/paste.png",
+      path: "projects/.matrix-terminal-pastes/2026-07-10/paste.png",
+      mimeType: "image/png",
+      size: pngBytes.byteLength,
+    }), {
+      status: 201,
+      headers: { "Content-Type": "application/json" },
+    }));
+    const client = createRichPasteUploadClient({
+      gatewayUrl: "https://matrix.example",
+      fetch: fetchMock as typeof fetch,
+    });
+
+    await expect(client.uploadPasteAssets({
+      sessionName: "codex-c",
+      transactionId: "tx-1",
+      assets: [{
+        name: "Screenshot 2026-07-09 at 5.13.48\u202fPM.png",
+        mimeType: "image/png",
+        bytes: pngBytes,
+      }],
+    })).resolves.toHaveLength(1);
+
+    const headers = fetchMock.mock.calls[0]?.[1]?.headers as Record<string, string>;
+    expect(headers["X-Matrix-Filename"]).toBe("Screenshot-2026-07-09-at-5.13.48-PM.png");
+    expect(() => new Headers({ "X-Matrix-Filename": headers["X-Matrix-Filename"] })).not.toThrow();
+  });
+
+  it("uses MIME-specific fallback upload filenames when sanitizing removes the basename", async () => {
+    const fetchMock = vi.fn(async () => new Response(JSON.stringify({
+      terminalPath: "/home/matrix/home/projects/.matrix-terminal-pastes/2026-07-10/paste.webp",
+      path: "projects/.matrix-terminal-pastes/2026-07-10/paste.webp",
+      mimeType: "image/webp",
+      size: 12,
+    }), {
+      status: 201,
+      headers: { "Content-Type": "application/json" },
+    }));
+    const client = createRichPasteUploadClient({
+      gatewayUrl: "https://matrix.example",
+      fetch: fetchMock as typeof fetch,
+    });
+
+    await client.uploadPasteAssets({
+      sessionName: "codex-c",
+      transactionId: "tx-1",
+      assets: [{
+        name: "\u202f.webp",
+        mimeType: "image/webp",
+        bytes: Buffer.from([0x52, 0x49, 0x46, 0x46, 0, 0, 0, 0, 0x57, 0x45, 0x42, 0x50]),
+      }],
+    });
+
+    const headers = fetchMock.mock.calls[0]?.[1]?.headers as Record<string, string>;
+    expect(headers["X-Matrix-Filename"]).toBe("paste.webp");
+  });
 
   it("rewrites quoted image paths with spaces while preserving surrounding prompt text", async () => {
     const localPath = join(tempDir, "Screenshot 2026-07-08 at 10.31.00.png");

--- a/packages/sync-client/tests/unit/shell-client.test.ts
+++ b/packages/sync-client/tests/unit/shell-client.test.ts
@@ -1,6 +1,6 @@
 import { EventEmitter } from "node:events";
 import { PassThrough } from "node:stream";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   createShellClient,
   SHELL_ATTACH_LIVE_TAIL_FROM_SEQ,
@@ -53,6 +53,10 @@ describe("createShellClient attachSession", () => {
   beforeEach(() => {
     FakeWebSocket.last = null;
     FakeWebSocket.instances = [];
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
   it("detaches on raw Ctrl-C before the websocket has attached", async () => {
@@ -166,7 +170,7 @@ describe("createShellClient attachSession", () => {
       input,
       output,
       WebSocketImpl: FakeWebSocket as never,
-      richPaste: { rewriter },
+      richPaste: { rewriter, statusMinVisibleMs: 0 },
     });
 
     FakeWebSocket.last?.emit("message", JSON.stringify({ type: "attached" }));
@@ -192,6 +196,65 @@ describe("createShellClient attachSession", () => {
       data: '"/home/matrix/home/projects/.matrix-terminal-pastes/main/2026-07-08/upload.png" what about this?',
     }));
     expect(FakeWebSocket.last?.sent.join("\n")).not.toContain("/var/folders/t5");
+
+    FakeWebSocket.last?.emit("message", JSON.stringify({ type: "exit" }));
+    await expect(attach).resolves.toEqual({ detached: false });
+  });
+
+  it("keeps rich paste progress visible before printing completion and sending rewritten input", async () => {
+    vi.useFakeTimers();
+    const input = new PassThrough() as PassThrough & {
+      isTTY: true;
+      rows: number;
+      columns: number;
+      setRawMode: ReturnType<typeof vi.fn>;
+      pause: ReturnType<typeof vi.fn>;
+    };
+    input.isTTY = true;
+    input.rows = 24;
+    input.columns = 80;
+    input.setRawMode = vi.fn();
+    input.pause = vi.fn();
+    const errorOutput = new PassThrough();
+    const errors: string[] = [];
+    errorOutput.on("data", (chunk) => errors.push(String(chunk)));
+    const rewriter = {
+      rewrite: vi.fn(async () => ({
+        status: "rewritten" as const,
+        outgoingText: "/home/matrix/home/projects/.matrix-terminal-pastes/2026-07-10/upload.png",
+        assets: [],
+      })),
+    };
+    const client = createShellClient({
+      gatewayUrl: "https://matrix.example",
+      token: "token-123",
+      timeoutMs: 10_000,
+    });
+    const attach = client.attachSession("main", {
+      input,
+      output: new PassThrough(),
+      errorOutput: errorOutput as NodeJS.WriteStream,
+      WebSocketImpl: FakeWebSocket as never,
+      richPaste: { rewriter },
+    });
+
+    FakeWebSocket.last?.emit("message", JSON.stringify({ type: "attached" }));
+    input.write("/var/folders/t5/screen.png");
+    await Promise.resolve();
+
+    expect(errors.join("")).toContain("Image paste: reading/uploading...");
+    expect(errors.join("")).not.toContain("Image paste: inserted.");
+    expect(sentInputData()).toEqual([]);
+
+    await vi.advanceTimersByTimeAsync(1_199);
+    expect(errors.join("")).not.toContain("Image paste: inserted.");
+    expect(sentInputData()).toEqual([]);
+
+    await vi.advanceTimersByTimeAsync(1);
+    expect(errors.join("")).toContain("Image paste: inserted.");
+    expect(sentInputData()).toEqual([
+      "/home/matrix/home/projects/.matrix-terminal-pastes/2026-07-10/upload.png",
+    ]);
 
     FakeWebSocket.last?.emit("message", JSON.stringify({ type: "exit" }));
     await expect(attach).resolves.toEqual({ detached: false });
@@ -227,7 +290,7 @@ describe("createShellClient attachSession", () => {
       input,
       output: new PassThrough(),
       WebSocketImpl: FakeWebSocket as never,
-      richPaste: { rewriter },
+      richPaste: { rewriter, statusMinVisibleMs: 0 },
     });
 
     FakeWebSocket.last?.emit("message", JSON.stringify({ type: "attached" }));
@@ -293,7 +356,7 @@ describe("createShellClient attachSession", () => {
       input,
       output: new PassThrough(),
       WebSocketImpl: FakeWebSocket as never,
-      richPaste: { rewriter },
+      richPaste: { rewriter, statusMinVisibleMs: 0 },
     });
 
     FakeWebSocket.last?.emit("message", JSON.stringify({ type: "attached" }));
@@ -357,7 +420,7 @@ describe("createShellClient attachSession", () => {
       input,
       output: new PassThrough(),
       WebSocketImpl: FakeWebSocket as never,
-      richPaste: { rewriter },
+      richPaste: { rewriter, statusMinVisibleMs: 0 },
     });
 
     FakeWebSocket.last?.emit("message", JSON.stringify({ type: "attached" }));
@@ -422,7 +485,7 @@ describe("createShellClient attachSession", () => {
         output: new PassThrough(),
         errorOutput: errorOutput as NodeJS.WriteStream,
         WebSocketImpl: FakeWebSocket as never,
-        richPaste: { rewriter },
+        richPaste: { rewriter, statusMinVisibleMs: 0 },
       });
 
       FakeWebSocket.last?.emit("message", JSON.stringify({ type: "attached" }));
@@ -473,7 +536,7 @@ describe("createShellClient attachSession", () => {
       input,
       output: new PassThrough(),
       WebSocketImpl: FakeWebSocket as never,
-      richPaste: { rewriter },
+      richPaste: { rewriter, statusMinVisibleMs: 0 },
     });
 
     FakeWebSocket.last?.emit("message", JSON.stringify({ type: "attached" }));
@@ -531,7 +594,7 @@ describe("createShellClient attachSession", () => {
       input,
       output: new PassThrough(),
       WebSocketImpl: FakeWebSocket as never,
-      richPaste: { rewriter },
+      richPaste: { rewriter, statusMinVisibleMs: 0 },
     });
 
     FakeWebSocket.last?.emit("message", JSON.stringify({ type: "attached" }));
@@ -593,7 +656,7 @@ describe("createShellClient attachSession", () => {
       output: new PassThrough(),
       errorOutput: errorOutput as NodeJS.WriteStream,
       WebSocketImpl: FakeWebSocket as never,
-      richPaste: { rewriter },
+      richPaste: { rewriter, statusMinVisibleMs: 0 },
     });
 
     FakeWebSocket.last?.emit("message", JSON.stringify({ type: "attached" }));
@@ -649,7 +712,7 @@ describe("createShellClient attachSession", () => {
       input,
       output: new PassThrough(),
       WebSocketImpl: FakeWebSocket as never,
-      richPaste: { rewriter },
+      richPaste: { rewriter, statusMinVisibleMs: 0 },
     });
 
     FakeWebSocket.last?.emit("message", JSON.stringify({ type: "attached" }));
@@ -700,7 +763,7 @@ describe("createShellClient attachSession", () => {
       input,
       output: new PassThrough(),
       WebSocketImpl: FakeWebSocket as never,
-      richPaste: { rewriter },
+      richPaste: { rewriter, statusMinVisibleMs: 0 },
     });
 
     FakeWebSocket.last?.emit("message", JSON.stringify({ type: "attached" }));
@@ -767,7 +830,7 @@ describe("createShellClient attachSession", () => {
       output: new PassThrough(),
       errorOutput: errorOutput as NodeJS.WriteStream,
       WebSocketImpl: FakeWebSocket as never,
-      richPaste: { rewriter },
+      richPaste: { rewriter, statusMinVisibleMs: 0 },
     });
 
     FakeWebSocket.last?.emit("message", JSON.stringify({ type: "attached" }));
@@ -822,7 +885,7 @@ describe("createShellClient attachSession", () => {
       output: new PassThrough(),
       errorOutput: errorOutput as NodeJS.WriteStream,
       WebSocketImpl: FakeWebSocket as never,
-      richPaste: { rewriter },
+      richPaste: { rewriter, statusMinVisibleMs: 0 },
     });
 
     FakeWebSocket.last?.emit("message", JSON.stringify({ type: "attached" }));

--- a/tests/cli/shell-client.test.ts
+++ b/tests/cli/shell-client.test.ts
@@ -720,7 +720,7 @@ describe("shell REST client", () => {
         expect(init?.headers).toEqual(expect.objectContaining({
           Authorization: "Bearer tok",
           "Content-Type": "image/png",
-          "X-Matrix-Filename": "Screenshot 2026-07-07 at 6.50.39 PM.png",
+          "X-Matrix-Filename": "Screenshot-2026-07-07-at-6.50.39-PM.png",
         }));
         expect(Buffer.from(init?.body as BodyInit as ArrayBuffer)).toEqual(PNG_BYTES);
         return new Response(JSON.stringify({
@@ -748,6 +748,7 @@ describe("shell REST client", () => {
       output,
       errorOutput,
       cwd: "projects/app",
+      richPaste: { statusMinVisibleMs: 0 },
     });
     ControlledWebSocket.last?.emit("open");
     ControlledWebSocket.last?.emit("message", JSON.stringify({ type: "attached" }));


### PR DESCRIPTION
## Summary

- Sanitize rich-paste upload filenames before sending them in `X-Matrix-Filename`, preventing Node fetch from rejecting macOS screenshot names containing Unicode such as U+202F.
- Keep the CLI image-paste progress message visible for at least 1.2s so quick uploads do not flash past unreadably.
- Bump `@finnaai/matrix` to `0.3.13` for the next CLI release.

## Tests

- `pnpm --filter @finnaai/matrix exec vitest run tests/unit/rich-paste.test.ts tests/unit/shell-client.test.ts`
- `pnpm exec vitest run tests/cli/shell-client.test.ts`
- `pnpm --filter @finnaai/matrix exec tsc --noEmit`
- `pnpm run check:patterns` (passes; existing scanner warnings only)
- `pnpm run test` was run before the final root fixture update and failed only `tests/cli/shell-client.test.ts`; the failing file was fixed and rerun successfully.

## Review/Monitoring

- CI and Greptile will be monitored through the worktree PR workflow.
- No React files changed; `react-doctor` is not applicable.

## Invariants

- Source of truth: image bytes remain the validated local file/clipboard bytes; the sanitized header is metadata only.
- Lock/transaction scope: no database writes or server-side transactions are introduced.
- Acceptable orphan states: if upload fails after local read, the CLI still withholds the local path and prints the existing generic failure.
- Auth source of truth: upload requests continue to use the existing Matrix CLI bearer token path.
- Deferred scope: this does not make image-only Cmd-V observable in terminals that emit no stdin bytes; it fixes the drag/drop/upload path and status visibility.
