### PR TITLE
feat(desktop): add resumable project conversations

### DIFF
--- a/desktop/src/main/coding-agents/runtime-summary-client.ts
+++ b/desktop/src/main/coding-agents/runtime-summary-client.ts
@@ -2,6 +2,9 @@ import {
   AgentThreadSnapshotSchema,
   CodingAgentNotificationPreferencesSchema,
   CodingAgentNotificationPreferencesUpdateSchema,
+  CreateAgentTurnErrorSchema,
+  CreateAgentTurnRequestSchema,
+  CreateAgentTurnResponseSchema,
   FileBrowseRequestSchema,
   FileBrowseResponseSchema,
   FileReadRequestSchema,
@@ -22,6 +25,9 @@ import {
   type CodingAgentNotificationPreferences,
   type CodingAgentNotificationPreferencesUpdate,
   type CreateAgentThreadRequest,
+  type CreateAgentTurnError,
+  type CreateAgentTurnRequest,
+  type CreateAgentTurnResponse,
   type FileBrowseRequest,
   type FileBrowseResponse,
   type FileReadRequest,
@@ -39,6 +45,7 @@ import {
   type SourceControlPrepareCommitRequest,
   type SourceControlPrepareCommitResponse,
   type UserInputAnswerRequest,
+  ThreadIdSchema,
   boundedListSchema,
 } from "@matrix-os/contracts";
 import { z } from "zod/v4";
@@ -59,6 +66,7 @@ const FILE_READ_TIMEOUT_MS = 10_000;
 const FILE_WRITE_TIMEOUT_MS = 10_000;
 const SOURCE_CONTROL_TIMEOUT_MS = 10_000;
 const THREAD_CREATE_TIMEOUT_MS = 15_000;
+const THREAD_TURN_TIMEOUT_MS = 15_000;
 const THREAD_SNAPSHOT_TIMEOUT_MS = 10_000;
 const APPROVAL_DECISION_TIMEOUT_MS = 10_000;
 const INPUT_ANSWER_TIMEOUT_MS = 10_000;
@@ -70,6 +78,38 @@ type ReviewSummaryList = z.infer<typeof ReviewSummaryListSchema>;
 const NotificationPreferencesResponseSchema = z.object({
   preferences: CodingAgentNotificationPreferencesSchema,
 }).strict();
+const CreateAgentTurnErrorEnvelopeSchema = z.object({
+  error: CreateAgentTurnErrorSchema,
+}).strict();
+
+export type CodingAgentCreateTurnResult =
+  | { ok: true; response: CreateAgentTurnResponse }
+  | { ok: false; error: CreateAgentTurnError };
+
+function localTurnError(code: CreateAgentTurnError["code"]): CreateAgentTurnError {
+  if (code === "thread_busy") {
+    return CreateAgentTurnErrorSchema.parse({
+      code,
+      safeMessage: "This conversation is already running. Wait for it to finish and try again.",
+      retryable: true,
+      recoveryActions: ["retry"],
+    });
+  }
+  if (code === "thread_not_found") {
+    return CreateAgentTurnErrorSchema.parse({
+      code,
+      safeMessage: "Conversation is unavailable. Refresh and try again.",
+      retryable: true,
+      recoveryActions: ["retry"],
+    });
+  }
+  return CreateAgentTurnErrorSchema.parse({
+    code,
+    safeMessage: "This conversation cannot accept a message right now. Refresh and try again.",
+    retryable: true,
+    recoveryActions: ["retry"],
+  });
+}
 
 function buildSummaryUrl(origin: string, runtimeSlot: string): string {
   const url = new URL("/api/coding-agents/summary", origin);
@@ -257,6 +297,49 @@ export async function createCodingAgentThread(
     throw new Error("agent thread unavailable");
   }
   return parsed.data;
+}
+
+export async function createCodingAgentTurn(
+  auth: AuthService,
+  request: CreateAgentTurnRequest & { threadId: string },
+  fetchFn: FetchFn = fetch,
+): Promise<CodingAgentCreateTurnResult> {
+  const token = auth.getToken();
+  const { threadId, ...turnRequest } = request;
+  const parsedThreadId = ThreadIdSchema.safeParse(threadId);
+  const parsedRequest = CreateAgentTurnRequestSchema.safeParse(turnRequest);
+  if (!token || !parsedThreadId.success || !parsedRequest.success) {
+    throw new Error("conversation turn unavailable");
+  }
+
+  const url = buildRuntimeUrl(
+    auth,
+    `/api/coding-agents/threads/${encodeURIComponent(parsedThreadId.data)}/turns`,
+  );
+  const res = await fetchFn(url.toString(), {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${token}`,
+      Accept: "application/json",
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(parsedRequest.data),
+    signal: AbortSignal.timeout(THREAD_TURN_TIMEOUT_MS),
+  });
+  const body = await res.json();
+  if (res.status === 200 || res.status === 202) {
+    const parsed = CreateAgentTurnResponseSchema.safeParse(body);
+    if (!parsed.success || parsed.data.threadId !== parsedThreadId.data) {
+      throw new Error("conversation turn unavailable");
+    }
+    return { ok: true, response: parsed.data };
+  }
+  if (res.status === 404 || res.status === 409) {
+    const parsed = CreateAgentTurnErrorEnvelopeSchema.safeParse(body);
+    if (!parsed.success) throw new Error("conversation turn unavailable");
+    return { ok: false, error: localTurnError(parsed.data.error.code) };
+  }
+  throw new Error("conversation turn unavailable");
 }
 
 export async function fetchCodingAgentThreadSnapshot(

--- a/desktop/src/main/index.ts
+++ b/desktop/src/main/index.ts
@@ -7,6 +7,7 @@ import { EmbedService } from "./embeds/embed-service";
 import {
   createCodingAgentSourcePullRequest,
   createCodingAgentThread,
+  createCodingAgentTurn,
   fetchCodingAgentFileBrowse,
   fetchCodingAgentFileContent,
   fetchCodingAgentFileSearch,
@@ -281,8 +282,9 @@ if (!gotLock) {
             threadId,
             inputRequestId,
             request: { answer, clientRequestId, correlationId },
-          }),
+        }),
         createAgentThread: (request) => createCodingAgentThread(auth, request),
+        createAgentTurn: (request) => createCodingAgentTurn(auth, request),
       });
 
       let boundsSaveTimer: ReturnType<typeof setTimeout> | null = null;

--- a/desktop/src/main/ipc/handlers.ts
+++ b/desktop/src/main/ipc/handlers.ts
@@ -61,6 +61,9 @@ export interface HandlerContext {
   createAgentThread: (
     request: CreateAgentThreadRequest,
   ) => Promise<z.infer<typeof AgentThreadSnapshotSchema>>;
+  createAgentTurn: (
+    request: InvokeRequest<"runtime:create-turn">,
+  ) => Promise<InvokeResponse<"runtime:create-turn">>;
   subscribeThreadEvents: (
     request: InvokeRequest<"runtime:subscribe-thread-events">,
   ) => Promise<void>;
@@ -146,6 +149,7 @@ export function registerIpcHandlers(ipcMain: IpcMainLike, ctx: HandlerContext): 
   handle("runtime:submit-approval-decision", (request) => ctx.submitApprovalDecision(request));
   handle("runtime:submit-input-answer", (request) => ctx.submitInputAnswer(request));
   handle("runtime:create-thread", (request) => ctx.createAgentThread(request));
+  handle("runtime:create-turn", (request) => ctx.createAgentTurn(request));
 
   handle("state:get", async ({ key }) => ({
     value: await ctx.store.get(key as LocalStoreKey),

--- a/desktop/src/renderer/src/features/coding-agents/AgentConversationView.tsx
+++ b/desktop/src/renderer/src/features/coding-agents/AgentConversationView.tsx
@@ -1,0 +1,321 @@
+import {
+  SafeAssistantPreviewSourceTextSchema,
+  SafeAssistantPreviewTextSchema,
+  type AgentThreadEvent,
+  type AgentThreadSnapshot,
+} from "@matrix-os/contracts";
+import { Bot, GitPullRequest, Send, UserRound, Wrench } from "lucide-react";
+import { useEffect, useMemo, useRef, useState } from "react";
+import { Button } from "../../design/primitives";
+import {
+  codingAgentApprovalActionKey,
+  codingAgentInputActionKey,
+  useCodingAgentWorkspace,
+} from "../../stores/coding-agent-workspace";
+
+type ConversationStatus = "idle" | "loading" | "ready" | "error";
+type AssistantEvent = Extract<AgentThreadEvent, { type: "assistant.text.delta" | "assistant.text.completed" }>;
+type ToolEvent = Extract<AgentThreadEvent, { type: "tool.started" | "tool.output" | "tool.completed" }>;
+type ConversationItem =
+  | { kind: "assistant"; key: string; events: AssistantEvent[]; order: number }
+  | { kind: "tool"; key: string; events: ToolEvent[]; order: number }
+  | { kind: "event"; event: AgentThreadEvent; order: number };
+
+const PREVIEW_MAX_CHARS = 240;
+
+function conversationItems(events: AgentThreadEvent[]): ConversationItem[] {
+  const assistants = new Map<string, AssistantEvent[]>();
+  const tools = new Map<string, ToolEvent[]>();
+  const items: ConversationItem[] = [];
+  for (const [order, event] of events.entries()) {
+    if (event.type === "assistant.text.delta" || event.type === "assistant.text.completed") {
+      const group = assistants.get(event.messageId);
+      if (group) group.push(event);
+      else {
+        const next = [event];
+        assistants.set(event.messageId, next);
+        items.push({ kind: "assistant", key: `assistant:${event.messageId}`, events: next, order });
+      }
+      continue;
+    }
+    if (event.type === "tool.started" || event.type === "tool.output" || event.type === "tool.completed") {
+      const group = tools.get(event.toolCallId);
+      if (group) group.push(event);
+      else {
+        const next = [event];
+        tools.set(event.toolCallId, next);
+        items.push({ kind: "tool", key: `tool:${event.toolCallId}`, events: next, order });
+      }
+      continue;
+    }
+    items.push({ kind: "event", event, order });
+  }
+  return items.sort((left, right) => left.order - right.order);
+}
+
+function assistantCopy(events: AssistantEvent[]) {
+  const deltas = events.filter(
+    (event): event is Extract<AssistantEvent, { type: "assistant.text.delta" }> => event.type === "assistant.text.delta",
+  );
+  const completed = events.some((event) => event.type === "assistant.text.completed");
+  const source = deltas.map((event) => event.delta).join("").trim();
+  const safeSource = source && SafeAssistantPreviewSourceTextSchema.safeParse(source).success ? source : null;
+  const previewCandidate = safeSource && safeSource.length > PREVIEW_MAX_CHARS
+    ? `${safeSource.slice(0, PREVIEW_MAX_CHARS).trimEnd()}...`
+    : safeSource;
+  const preview = previewCandidate && SafeAssistantPreviewTextSchema.safeParse(previewCandidate).success
+    ? previewCandidate
+    : null;
+  const updates = `${deltas.length} ${deltas.length === 1 ? "text update" : "text updates"} received`;
+  const status = completed ? `${updates}, complete` : updates;
+  return {
+    title: completed ? "Assistant message" : deltas.length === 1 ? "Assistant update" : "Assistant updates",
+    status,
+    preview,
+    displayText: safeSource && safeSource.length <= PREVIEW_MAX_CHARS ? safeSource : preview,
+  };
+}
+
+function AssistantBubble({ events }: { events: AssistantEvent[] }) {
+  const copy = assistantCopy(events);
+  return (
+    <div className="flex max-w-[min(760px,92%)] items-start gap-2">
+      <span className="mt-1 flex h-7 w-7 shrink-0 items-center justify-center rounded-full" style={{ background: "var(--accent-muted)", color: "var(--accent)" }}>
+        <Bot size={15} aria-hidden="true" />
+      </span>
+      <article className="min-w-0 rounded-2xl rounded-tl-md border px-4 py-3" style={{ borderColor: "var(--border-subtle)", background: "var(--bg-surface)" }}>
+        <div className="flex flex-wrap items-center gap-x-3 gap-y-1">
+          <h3 className="text-xs font-semibold" style={{ color: "var(--text-primary)" }}>{copy.title}</h3>
+          <span className="text-[10px]" style={{ color: "var(--text-tertiary)" }}>{events[0]?.occurredAt}</span>
+        </div>
+        {copy.displayText ? <p className="sr-only">{copy.preview ? `${copy.status}. ${copy.preview}` : copy.status}</p> : null}
+        {copy.displayText ? (
+          <p className="mt-1 whitespace-pre-wrap break-words text-sm leading-6" style={{ color: "var(--text-primary)" }}>
+            {copy.displayText}
+          </p>
+        ) : (
+          <p className="mt-1 text-xs" style={{ color: "var(--text-secondary)" }}>{copy.status}</p>
+        )}
+      </article>
+    </div>
+  );
+}
+
+function UserBubble({ event }: { event: Extract<AgentThreadEvent, { type: "user.message" }> }) {
+  return (
+    <div className="ml-auto flex max-w-[min(720px,88%)] flex-row-reverse items-start gap-2">
+      <span className="mt-1 flex h-7 w-7 shrink-0 items-center justify-center rounded-full" style={{ background: "var(--bg-tertiary)", color: "var(--text-secondary)" }}>
+        <UserRound size={14} aria-hidden="true" />
+      </span>
+      <article className="min-w-0 rounded-2xl rounded-tr-md px-4 py-3" style={{ background: "var(--accent-muted)" }}>
+        <div className="flex flex-wrap items-center justify-end gap-x-3 gap-y-1">
+          <span className="text-[10px]" style={{ color: "var(--text-tertiary)" }}>{event.occurredAt}</span>
+          <h3 className="text-xs font-semibold" style={{ color: "var(--text-primary)" }}>You</h3>
+        </div>
+        <p className="mt-1 whitespace-pre-wrap break-words text-sm leading-6" style={{ color: "var(--text-primary)" }}>{event.text}</p>
+      </article>
+    </div>
+  );
+}
+
+function ToolActivity({ events }: { events: ToolEvent[] }) {
+  const [expanded, setExpanded] = useState(false);
+  const started = events.find((event): event is Extract<ToolEvent, { type: "tool.started" }> => event.type === "tool.started");
+  const outputs = events.filter((event): event is Extract<ToolEvent, { type: "tool.output" }> => event.type === "tool.output");
+  const completed = events.find((event): event is Extract<ToolEvent, { type: "tool.completed" }> => event.type === "tool.completed");
+  const name = started?.displayName ?? "Tool";
+  const outcome = completed?.outcome === "success" ? "successfully"
+    : completed?.outcome === "failed" ? "with errors"
+      : completed?.outcome === "cancelled" ? "cancelled"
+        : "";
+  const detail = completed
+    ? `${name} completed ${outcome}${outputs.length ? outputs.some((event) => event.truncated) ? " after receiving partial output" : " after receiving output" : " without captured output"}`
+    : `${name} running${outputs.length ? " with output received" : ""}`;
+  return (
+    <div className="mx-auto w-full max-w-[760px] rounded-lg border px-3 py-2" style={{ borderColor: "var(--border-subtle)", background: "var(--bg-overlay)" }}>
+      <div className="flex items-start gap-2">
+        <Wrench size={14} className="mt-0.5 shrink-0" style={{ color: "var(--text-tertiary)" }} />
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center justify-between gap-3">
+            <h3 className="text-xs font-semibold" style={{ color: "var(--text-primary)" }}>Tool activity</h3>
+            <span className="text-[10px]" style={{ color: "var(--text-tertiary)" }}>{events[0]?.occurredAt}</span>
+          </div>
+          <p className="mt-0.5 text-xs" style={{ color: "var(--text-secondary)" }}>{detail}</p>
+          <p className="mt-1 text-[11px] font-medium" style={{ color: "var(--text-tertiary)" }}>
+            {outputs.length} {outputs.length === 1 ? "output" : "outputs"}
+          </p>
+          <button type="button" className="mt-1 text-[11px] font-medium" style={{ color: "var(--accent)" }} aria-label={`${expanded ? "Collapse" : "Expand"} tool activity Tool activity`} onClick={() => setExpanded((value) => !value)}>
+            {expanded ? "Hide details" : "Show details"}
+          </button>
+          {expanded ? (
+            <div className="mt-2 grid gap-1 text-xs" style={{ color: "var(--text-secondary)" }}>
+              {started ? <div><p>Started {started.kind}</p><p>Tool run started</p></div> : null}
+              {outputs.map((output, index) => <div key={output.eventId}><p>Output {index + 1}</p><p>{output.truncated ? "Output received, partial" : "Output received"}</p></div>)}
+              {completed ? <div><p>Completed</p><p>{completed.outcome === "success" ? "Completed successfully" : completed.outcome === "failed" ? "Failed" : "Cancelled"}</p></div> : null}
+            </div>
+          ) : null}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function eventCopy(event: AgentThreadEvent): { title: string; detail: string } {
+  switch (event.type) {
+    case "turn.accepted": return { title: "Message accepted", detail: "Waiting for the agent run" };
+    case "turn.status": return { title: "Message status", detail: event.status };
+    case "thread.created": return { title: "Thread created", detail: event.thread.title };
+    case "thread.status": return { title: "Status changed", detail: event.status.replaceAll("_", " ") };
+    case "approval.requested": return { title: "Approval needed", detail: event.approval.safeDescription };
+    case "approval.resolved": return { title: "Approval resolved", detail: event.decision };
+    case "user_input.requested": return { title: "Input needed", detail: event.request.safeDescription };
+    case "user_input.answered": return { title: "Input answered", detail: "Input answer received" };
+    case "file.changed": return { title: `File ${event.changeKind}`, detail: `${event.changeKind} file` };
+    case "review.ready": return { title: "Review ready", detail: `${event.summary.changedFileCount} ${event.summary.changedFileCount === 1 ? "file" : "files"} changed, +${event.summary.additions} -${event.summary.deletions}${event.summary.partial ? ", partial" : ""}` };
+    case "terminal.bound": return { title: "Terminal bound", detail: event.terminalSessionId };
+    case "thread.error": return { title: "Thread needs attention", detail: event.error.retryable ? "Refresh the thread or check the runtime." : "Open the workspace again." };
+    case "thread.completed": return { title: "Thread completed", detail: event.outcome };
+    case "user.message": return { title: "You", detail: event.text };
+    case "assistant.text.delta":
+    case "assistant.text.completed": return { title: "Assistant update", detail: "Text update received" };
+    case "tool.started":
+    case "tool.output":
+    case "tool.completed": return { title: "Tool activity", detail: "Tool state updated" };
+  }
+}
+
+function approvalLabel(decision: string) {
+  if (decision === "approve") return "Approve";
+  if (decision === "approve_for_session") return "Approve for session";
+  if (decision === "decline") return "Decline";
+  if (decision === "cancel") return "Cancel";
+  return "Decide";
+}
+
+function SystemEvent({ event, answeredInputs }: { event: AgentThreadEvent; answeredInputs: ReadonlySet<string> }) {
+  const copy = eventCopy(event);
+  const pendingApprovalKeys = useCodingAgentWorkspace((state) => state.pendingApprovalKeys);
+  const approvalErrors = useCodingAgentWorkspace((state) => state.approvalActionErrors);
+  const submitApproval = useCodingAgentWorkspace((state) => state.submitApprovalDecision);
+  const pendingInputKeys = useCodingAgentWorkspace((state) => state.pendingInputRequestKeys);
+  const inputErrors = useCodingAgentWorkspace((state) => state.inputActionErrors);
+  const submitInput = useCodingAgentWorkspace((state) => state.submitInputAnswer);
+  const selectReview = useCodingAgentWorkspace((state) => state.selectReview);
+  const [answer, setAnswer] = useState("");
+  const approval = event.type === "approval.requested" ? event.approval : null;
+  const input = event.type === "user_input.requested" ? event.request : null;
+  const approvalKey = approval ? codingAgentApprovalActionKey(approval.threadId, approval.approvalId) : null;
+  const inputKey = input ? codingAgentInputActionKey(input.threadId, input.requestId) : null;
+  return (
+    <div className="mx-auto w-full max-w-[760px] rounded-lg border px-3 py-2" style={{ borderColor: "var(--border-subtle)", background: "var(--bg-overlay)" }}>
+      <div className="flex items-center justify-between gap-3">
+        <h3 className="text-xs font-semibold" style={{ color: "var(--text-primary)" }}>{copy.title}</h3>
+        <span className="text-[10px]" style={{ color: "var(--text-tertiary)" }}>{event.occurredAt}</span>
+      </div>
+      <p className="mt-0.5 text-xs" style={{ color: "var(--text-secondary)" }}>{copy.detail}</p>
+      {approval ? (
+        <div className="mt-2 flex flex-wrap items-center gap-2">
+          {approval.allowedDecisions.map((decision) => (
+            <Button key={decision} variant={decision.startsWith("approve") ? "primary" : "danger"} aria-label={`${approvalLabel(decision)} ${approval.title}`} disabled={Boolean(approvalKey && pendingApprovalKeys.includes(approvalKey))} onClick={() => void submitApproval({ threadId: approval.threadId, approvalId: approval.approvalId, decision, correlationId: approval.correlationId })}>
+              {approvalKey && pendingApprovalKeys.includes(approvalKey) ? "Sending..." : approvalLabel(decision)}
+            </Button>
+          ))}
+          {approvalKey && approvalErrors[approvalKey] ? <span className="text-xs" style={{ color: "var(--danger)" }}>{approvalErrors[approvalKey]}</span> : null}
+        </div>
+      ) : null}
+      {input && inputKey && !answeredInputs.has(inputKey) ? (
+        <div className="mt-2 grid gap-2">
+          <textarea aria-label={`Answer ${input.title}`} className="min-h-20 resize-y rounded-md border px-3 py-2 text-sm outline-none" maxLength={8000} placeholder={input.placeholder ?? "Answer"} style={{ borderColor: "var(--border-subtle)", background: "var(--bg-surface)", color: "var(--text-primary)" }} value={answer} onChange={(event) => setAnswer(event.currentTarget.value)} />
+          <div className="flex items-center gap-2">
+            <Button variant="primary" aria-label={`Send ${input.title}`} disabled={pendingInputKeys.includes(inputKey) || (input.required && !answer.trim())} onClick={() => void submitInput({ threadId: input.threadId, inputRequestId: input.requestId, answer, correlationId: input.correlationId })}>
+              {pendingInputKeys.includes(inputKey) ? "Sending..." : "Send"}
+            </Button>
+            {inputErrors[inputKey] ? <span className="text-xs" style={{ color: "var(--danger)" }}>{inputErrors[inputKey]}</span> : null}
+          </div>
+        </div>
+      ) : null}
+      {event.type === "review.ready" ? (
+        <div className="mt-2">
+          <Button variant="subtle" aria-label="Open review from thread" onClick={() => void selectReview(event.reviewId)}>
+            <GitPullRequest size={14} /> Open review
+          </Button>
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function ConversationComposer({ threadId }: { threadId: string }) {
+  const [message, setMessage] = useState("");
+  const turnStatus = useCodingAgentWorkspace((state) => state.turnStatus);
+  const turnThreadId = useCodingAgentWorkspace((state) => state.turnThreadId);
+  const turnError = useCodingAgentWorkspace((state) => state.turnError);
+  const send = useCodingAgentWorkspace((state) => state.sendThreadMessage);
+  const submitting = turnStatus === "submitting" && turnThreadId === threadId;
+  useEffect(() => setMessage(""), [threadId]);
+
+  async function submit() {
+    if (!message.trim() || submitting) return;
+    const sent = await send({ threadId, message });
+    if (sent) setMessage("");
+  }
+
+  return (
+    <div className="shrink-0 border-t p-3" style={{ borderColor: "var(--border-subtle)", background: "var(--bg-surface)" }}>
+      <div className="mx-auto max-w-[820px] rounded-xl border p-2" style={{ borderColor: turnError && turnThreadId === threadId ? "var(--danger)" : "var(--border-default)", background: "var(--bg-overlay)" }}>
+        <textarea aria-label="Message conversation" className="min-h-[72px] w-full resize-none bg-transparent px-2 py-1 text-sm leading-6 outline-none" maxLength={24_000} placeholder="Ask a follow-up…" style={{ color: "var(--text-primary)" }} value={message} onChange={(event) => setMessage(event.currentTarget.value)} onKeyDown={(event) => {
+          if (event.key === "Enter" && !event.shiftKey) {
+            event.preventDefault();
+            void submit();
+          }
+        }} />
+        <div className="flex items-center justify-between gap-3 px-1 pt-1">
+          <p className="min-h-4 text-xs" style={{ color: "var(--danger)" }}>{turnThreadId === threadId ? turnError : null}</p>
+          <Button variant="primary" aria-label="Send message" disabled={submitting || !message.trim()} onClick={() => void submit()}>
+            <Send size={14} /> {submitting ? "Sending" : "Send"}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function AgentConversationView({ status, snapshot, error }: { status: ConversationStatus; snapshot: AgentThreadSnapshot | null; error: string | null }) {
+  const endRef = useRef<HTMLDivElement | null>(null);
+  const items = useMemo(() => conversationItems(snapshot?.events.items ?? []), [snapshot?.events.items]);
+  const answeredInputs = useMemo(() => new Set((snapshot?.events.items ?? [])
+    .filter((event) => event.type === "user_input.answered")
+    .map((event) => codingAgentInputActionKey(event.threadId, event.requestId))), [snapshot?.events.items]);
+  useEffect(() => {
+    const target = endRef.current as (HTMLDivElement & { scrollIntoView?: (options?: ScrollIntoViewOptions) => void }) | null;
+    target?.scrollIntoView?.({ block: "end" });
+  }, [items.length, snapshot?.thread.id]);
+
+  if (status === "loading") return <div className="flex min-h-[360px] items-center justify-center text-sm" style={{ color: "var(--text-secondary)" }}>Loading conversation…</div>;
+  if (status === "error") return <div className="flex min-h-[360px] items-center justify-center p-6 text-sm" style={{ color: "var(--danger)" }}>{error ?? "Thread state unavailable"}</div>;
+  if (!snapshot) return <div className="flex min-h-[360px] items-center justify-center p-6 text-center text-sm" style={{ color: "var(--text-secondary)" }}>Choose a conversation from the project navigator, or start a new chat.</div>;
+
+  return (
+    <section aria-label={`Conversation ${snapshot.thread.title}`} className="ph-no-capture flex min-h-[460px] min-w-0 flex-1 flex-col overflow-hidden" style={{ background: "var(--bg-primary)" }}>
+      <header className="flex shrink-0 items-center justify-between gap-3 border-b px-4 py-3" style={{ borderColor: "var(--border-subtle)", background: "var(--bg-surface)" }}>
+        <div className="min-w-0">
+          <span className="sr-only">Thread details</span>
+          <h2 className="truncate text-sm font-semibold" style={{ color: "var(--text-primary)" }}>{snapshot.thread.title}</h2>
+          <p className="flex min-w-0 items-center gap-1 truncate text-xs capitalize" style={{ color: "var(--text-tertiary)" }}>
+            <span>{snapshot.thread.providerId}</span><span aria-hidden="true">·</span><span>{snapshot.thread.status.replaceAll("_", " ")}</span>
+          </p>
+        </div>
+        {snapshot.thread.attention !== "none" ? <span className="rounded-full px-2 py-1 text-[10px] font-semibold capitalize" style={{ background: "var(--warning-muted)", color: "var(--warning)" }}>{snapshot.thread.attention.replaceAll("_", " ")}</span> : null}
+      </header>
+      <div className="min-h-0 flex-1 space-y-4 overflow-y-auto px-4 py-5">
+        {items.map((item) => item.kind === "assistant" ? <AssistantBubble key={item.key} events={item.events} />
+          : item.kind === "tool" ? <ToolActivity key={item.key} events={item.events} />
+            : item.event.type === "user.message" ? <UserBubble key={item.event.eventId} event={item.event} />
+              : <SystemEvent key={item.event.eventId} event={item.event} answeredInputs={answeredInputs} />)}
+        {items.length === 0 ? <p className="py-12 text-center text-sm" style={{ color: "var(--text-tertiary)" }}>This conversation is ready. Send a message to continue.</p> : null}
+        <div ref={endRef} />
+      </div>
+      <ConversationComposer threadId={snapshot.thread.id} />
+    </section>
+  );
+}

--- a/desktop/src/renderer/src/features/coding-agents/AgentConversationView.tsx
+++ b/desktop/src/renderer/src/features/coding-agents/AgentConversationView.tsx
@@ -280,7 +280,17 @@ function ConversationComposer({ threadId }: { threadId: string }) {
   );
 }
 
-export function AgentConversationView({ status, snapshot, error }: { status: ConversationStatus; snapshot: AgentThreadSnapshot | null; error: string | null }) {
+export function AgentConversationView({
+  status,
+  snapshot,
+  error,
+  canSendTurns,
+}: {
+  status: ConversationStatus;
+  snapshot: AgentThreadSnapshot | null;
+  error: string | null;
+  canSendTurns: boolean;
+}) {
   const endRef = useRef<HTMLDivElement | null>(null);
   const items = useMemo(() => conversationItems(snapshot?.events.items ?? []), [snapshot?.events.items]);
   const answeredInputs = useMemo(() => new Set((snapshot?.events.items ?? [])
@@ -312,10 +322,23 @@ export function AgentConversationView({ status, snapshot, error }: { status: Con
           : item.kind === "tool" ? <ToolActivity key={item.key} events={item.events} />
             : item.event.type === "user.message" ? <UserBubble key={item.event.eventId} event={item.event} />
               : <SystemEvent key={item.event.eventId} event={item.event} answeredInputs={answeredInputs} />)}
-        {items.length === 0 ? <p className="py-12 text-center text-sm" style={{ color: "var(--text-tertiary)" }}>This conversation is ready. Send a message to continue.</p> : null}
+        {items.length === 0 ? (
+          <p className="py-12 text-center text-sm" style={{ color: "var(--text-tertiary)" }}>
+            {canSendTurns ? "This conversation is ready. Send a message to continue." : "No messages yet."}
+          </p>
+        ) : null}
         <div ref={endRef} />
       </div>
-      <ConversationComposer threadId={snapshot.thread.id} />
+      {canSendTurns ? (
+        <ConversationComposer threadId={snapshot.thread.id} />
+      ) : (
+        <p
+          className="shrink-0 border-t px-4 py-3 text-center text-xs"
+          style={{ borderColor: "var(--border-subtle)", color: "var(--text-tertiary)", background: "var(--bg-surface)" }}
+        >
+          Follow-ups are unavailable on this computer.
+        </p>
+      )}
     </section>
   );
 }

--- a/desktop/src/renderer/src/features/coding-agents/AgentWorkspace.tsx
+++ b/desktop/src/renderer/src/features/coding-agents/AgentWorkspace.tsx
@@ -1,12 +1,7 @@
-import { Bell, Bot, ChevronDown, ChevronRight, ChevronUp, ClipboardCheck, ExternalLink, FileText, FolderOpen, GitBranch, GitCommitHorizontal, GitPullRequest, Play, Save, Search, Server, SquareTerminal } from "lucide-react";
+import { Bell, Bot, ChevronRight, ClipboardCheck, ExternalLink, FileText, FolderOpen, GitBranch, GitCommitHorizontal, GitPullRequest, Play, Save, Search, Server, SquareTerminal } from "lucide-react";
 import { useEffect, useMemo, useRef, useState } from "react";
 import {
-  ReviewIdSchema,
-  SafeAssistantPreviewSourceTextSchema,
-  SafeAssistantPreviewTextSchema,
   defaultAgentThreadComposerDraft,
-  type AgentThreadEvent,
-  type AgentThreadSnapshot,
   type AgentThreadComposerDraft,
   type FileBrowseResponse,
   type FileReadRequest,
@@ -25,8 +20,6 @@ import { invoke } from "../../lib/operator";
 import { useConnection } from "../../stores/connection";
 import {
   clearCodingAgentRuntimeSelection,
-  codingAgentApprovalActionKey,
-  codingAgentInputActionKey,
   useCodingAgentWorkspace,
 } from "../../stores/coding-agent-workspace";
 import { useCodingAgentProjectWorkspace } from "../../stores/coding-agent-project-workspace";
@@ -34,6 +27,7 @@ import { useTabs } from "../../stores/tabs";
 import { AgentPreviewList, AgentTerminalList } from "./AgentWorkspaceContext";
 import { AgentRuntimeHeader } from "./AgentRuntimeHeader";
 import { AgentProjectWorkspaceShell } from "./AgentProjectWorkspaceShell";
+import { AgentConversationView } from "./AgentConversationView";
 import {
   AgentWorkspaceSection as Section,
   AgentWorkspaceStack,
@@ -55,7 +49,6 @@ const STATUS_COLOR: Record<string, string> = {
 };
 const DEFAULT_STATUS_COLOR = "var(--text-tertiary)";
 type ReviewDetailStatus = "idle" | "loading" | "ready" | "error";
-type ThreadDetailStatus = "idle" | "loading" | "ready" | "error";
 type ReviewSnapshotFile = ReviewSnapshot["files"]["items"][number];
 type ReviewSnapshotHunk = ReviewSnapshotFile["hunks"][number];
 type ReviewSnapshotLine = NonNullable<ReviewSnapshotHunk["lines"]>[number];
@@ -67,20 +60,12 @@ type ComposerSeed = {
   draft: AgentThreadComposerDraft;
 };
 type NotificationPreferenceKey = "approval" | "input" | "failed" | "completed";
-type AssistantTimelineEvent = Extract<AgentThreadEvent, { type: "assistant.text.delta" | "assistant.text.completed" }>;
-type ToolTimelineEvent = Extract<AgentThreadEvent, { type: "tool.started" | "tool.output" | "tool.completed" }>;
-type ThreadTimelineItem =
-  | { kind: "assistant"; key: string; events: AssistantTimelineEvent[]; order: number }
-  | { kind: "event"; event: AgentThreadEvent; order: number }
-  | { kind: "tool"; key: string; events: ToolTimelineEvent[]; order: number };
 type SelectedReviewHunk = {
   key: string;
   file: ReviewSnapshotFile;
   hunk: ReviewSnapshotHunk;
   hunkIndex: number;
 };
-
-const ASSISTANT_PREVIEW_MAX_CHARS = 240;
 
 function capabilityEnabled(summary: RuntimeSummary, id: string): boolean {
   return summary.capabilities.some((capability) => capability.id === id && capability.enabled);
@@ -321,7 +306,7 @@ function hasComposerContent(current: AgentThreadComposerDraft): boolean {
     || Boolean(current.attachments?.length);
 }
 
-function AgentComposer({ summary, seed, focusRequestId }: { summary: RuntimeSummary; seed: ComposerSeed | null; focusRequestId: number }) {
+function AgentComposer({ summary, seed, focusRequestId, onCreated }: { summary: RuntimeSummary; seed: ComposerSeed | null; focusRequestId: number; onCreated?: () => void }) {
   const initialDraft = useMemo(() => defaultAgentThreadComposerDraft(summary), [summary]);
   const [draft, setDraft] = useState<AgentThreadComposerDraft>(initialDraft);
   const promptRef = useRef<HTMLTextAreaElement | null>(null);
@@ -369,6 +354,7 @@ function AgentComposer({ summary, seed, focusRequestId }: { summary: RuntimeSumm
       return;
     }
     setDraft(initialDraft);
+    onCreated?.();
   }
 
   return (
@@ -584,496 +570,6 @@ function CreatedThreadHandleList({ summary }: { summary: RuntimeSummary }) {
   );
 }
 
-function ThreadSnapshotPanel({
-  status,
-  snapshot,
-  error,
-}: {
-  status: ThreadDetailStatus;
-  snapshot: AgentThreadSnapshot | null;
-  error: string | null;
-}) {
-  if (status === "idle") return null;
-  if (status === "loading") {
-    return (
-      <p className="rounded-md border p-3 text-sm" style={{ borderColor: "var(--border-subtle)", color: "var(--text-secondary)" }}>
-        Loading thread details...
-      </p>
-    );
-  }
-  if (status === "error") {
-    return (
-      <p className="rounded-md border p-3 text-sm" style={{ borderColor: "var(--border-subtle)", color: "var(--danger)" }}>
-        {error ?? "Thread state unavailable"}
-      </p>
-    );
-  }
-  if (!snapshot) return null;
-  const answeredInputRequestKeys = new Set(snapshot.events.items
-    .filter((event) => event.type === "user_input.answered")
-    .map((event) => codingAgentInputActionKey(event.threadId, event.requestId)));
-  const timelineItems = createThreadTimelineItems(snapshot.events.items);
-
-  return (
-    <article
-      className="ph-no-capture grid gap-3 rounded-md border p-3"
-      style={{ borderColor: "var(--border-subtle)", background: "var(--bg-surface)" }}
-    >
-      <div className="flex items-center justify-between gap-3">
-        <div className="min-w-0">
-          <h2 className="truncate text-sm font-semibold" style={{ color: "var(--text-primary)" }}>
-            Thread details
-          </h2>
-          <p className="truncate text-xs" style={{ color: "var(--text-tertiary)" }}>
-            {snapshot.thread.title}
-          </p>
-        </div>
-        <span className="shrink-0 text-xs capitalize" style={{ color: "var(--text-secondary)" }}>
-          {snapshot.thread.status.replace(/_/g, " ")}
-        </span>
-      </div>
-      <dl className="grid grid-cols-2 gap-2 text-xs md:grid-cols-4">
-        <div>
-          <dt style={{ color: "var(--text-tertiary)" }}>Provider</dt>
-          <dd className="truncate" style={{ color: "var(--text-secondary)" }}>{snapshot.thread.providerId}</dd>
-        </div>
-        <div>
-          <dt style={{ color: "var(--text-tertiary)" }}>Terminal</dt>
-          <dd className="truncate" style={{ color: "var(--text-secondary)" }}>
-            {snapshot.thread.terminalSessionId ?? "Not bound"}
-          </dd>
-        </div>
-        <div>
-          <dt style={{ color: "var(--text-tertiary)" }}>Updated</dt>
-          <dd className="truncate" style={{ color: "var(--text-secondary)" }}>{snapshot.thread.updatedAt}</dd>
-        </div>
-        <div>
-          <dt style={{ color: "var(--text-tertiary)" }}>Events</dt>
-          <dd className="truncate" style={{ color: "var(--text-secondary)" }}>{snapshot.events.items.length}</dd>
-        </div>
-      </dl>
-      <div className="grid gap-2">
-        {timelineItems.map((item) => item.kind === "assistant" ? (
-          <ThreadTimelineSummaryRow
-            key={item.key}
-            occurredAt={item.events[0]?.occurredAt ?? snapshot.thread.updatedAt}
-            {...describeAssistantTimeline(item.events)}
-          />
-        ) : item.kind === "tool" ? (
-          <ThreadToolTimelineRow
-            key={item.key}
-            occurredAt={item.events[0]?.occurredAt ?? snapshot.thread.updatedAt}
-            events={item.events}
-          />
-        ) : (
-          <ThreadEventRow key={item.event.eventId} event={item.event} answeredInputRequestKeys={answeredInputRequestKeys} />
-        ))}
-        {snapshot.events.items.length === 0 ? (
-          <p className="rounded-md border p-3 text-sm" style={{ borderColor: "var(--border-subtle)", color: "var(--text-secondary)" }}>
-            No thread events yet.
-          </p>
-        ) : null}
-      </div>
-    </article>
-  );
-}
-
-function ThreadTimelineSummaryRow({ title, detail, occurredAt }: { title: string; detail: string; occurredAt: string }) {
-  return (
-    <div
-      className="grid gap-1 rounded-md border px-3 py-2"
-      style={{ borderColor: "var(--border-subtle)", background: "var(--bg-overlay)" }}
-    >
-      <div className="flex items-center justify-between gap-3">
-        <p className="text-sm font-medium" style={{ color: "var(--text-primary)" }}>
-          {title}
-        </p>
-        <span className="shrink-0 text-xs" style={{ color: "var(--text-tertiary)" }}>
-          {occurredAt}
-        </span>
-      </div>
-      <p className="text-xs" style={{ color: "var(--text-secondary)" }}>
-        {detail}
-      </p>
-    </div>
-  );
-}
-
-function ThreadToolTimelineRow({ events, occurredAt }: { events: ToolTimelineEvent[]; occurredAt: string }) {
-  const [expanded, setExpanded] = useState(false);
-  const copy = describeToolTimeline(events);
-  const details = describeToolTimelineDetails(events);
-  const outputCount = `${details.outputs.length} ${details.outputs.length === 1 ? "output" : "outputs"}`;
-
-  return (
-    <div
-      className="grid gap-2 rounded-md border px-3 py-2"
-      style={{ borderColor: "var(--border-subtle)", background: "var(--bg-overlay)" }}
-    >
-      <div className="flex items-center justify-between gap-3">
-        <p className="text-sm font-medium" style={{ color: "var(--text-primary)" }}>
-          {copy.title}
-        </p>
-        <span className="shrink-0 text-xs" style={{ color: "var(--text-tertiary)" }}>
-          {occurredAt}
-        </span>
-      </div>
-      <p className="text-xs" style={{ color: "var(--text-secondary)" }}>
-        {copy.detail}
-      </p>
-      <div className="flex flex-wrap items-center justify-between gap-2">
-        <span className="text-xs font-medium" style={{ color: "var(--text-tertiary)" }}>
-          {outputCount}
-        </span>
-        <Button
-          variant="ghost"
-          aria-label={`${expanded ? "Collapse" : "Expand"} tool activity ${copy.title}`}
-          onClick={() => setExpanded((value) => !value)}
-        >
-          {expanded ? <ChevronUp size={14} /> : <ChevronDown size={14} />}
-          {expanded ? "Hide details" : "Show details"}
-        </Button>
-      </div>
-      {expanded ? (
-        <div className="grid gap-1">
-          {details.started ? (
-            <ThreadToolDetailRow title={`Started ${details.started.kind}`} detail="Tool run started" />
-          ) : null}
-          {details.outputs.map((output, index) => (
-            <ThreadToolDetailRow
-              key={output.eventId}
-              title={`Output ${index + 1}`}
-              detail={output.truncated ? "Output received, partial" : "Output received"}
-            />
-          ))}
-          {details.completed ? (
-            <ThreadToolDetailRow title="Completed" detail={formatToolCompletion(details.completed.outcome)} />
-          ) : null}
-        </div>
-      ) : null}
-    </div>
-  );
-}
-
-function ThreadToolDetailRow({ title, detail }: { title: string; detail: string }) {
-  return (
-    <div
-      className="grid gap-1 rounded-md border px-3 py-2"
-      style={{ borderColor: "var(--border-subtle)", background: "var(--bg-surface)" }}
-    >
-      <p className="text-xs font-medium" style={{ color: "var(--text-primary)" }}>
-        {title}
-      </p>
-      <p className="text-xs" style={{ color: "var(--text-secondary)" }}>
-        {detail}
-      </p>
-    </div>
-  );
-}
-
-function ThreadEventRow({ event, answeredInputRequestKeys }: { event: AgentThreadEvent; answeredInputRequestKeys: ReadonlySet<string> }) {
-  const copy = describeThreadEvent(event);
-  const pendingApprovalKeys = useCodingAgentWorkspace((s) => s.pendingApprovalKeys);
-  const approvalActionErrors = useCodingAgentWorkspace((s) => s.approvalActionErrors);
-  const submitApprovalDecision = useCodingAgentWorkspace((s) => s.submitApprovalDecision);
-  const pendingInputRequestKeys = useCodingAgentWorkspace((s) => s.pendingInputRequestKeys);
-  const inputActionErrors = useCodingAgentWorkspace((s) => s.inputActionErrors);
-  const submitInputAnswer = useCodingAgentWorkspace((s) => s.submitInputAnswer);
-  const selectReview = useCodingAgentWorkspace((s) => s.selectReview);
-  const [inputAnswer, setInputAnswer] = useState("");
-  const approval = event.type === "approval.requested" ? event.approval : null;
-  const inputRequest = event.type === "user_input.requested" ? event.request : null;
-  const approvalKey = approval ? codingAgentApprovalActionKey(approval.threadId, approval.approvalId) : null;
-  const approvalPending = approvalKey ? pendingApprovalKeys.includes(approvalKey) : false;
-  const approvalActionError = approvalKey ? approvalActionErrors[approvalKey] : undefined;
-  const inputKey = inputRequest ? codingAgentInputActionKey(inputRequest.threadId, inputRequest.requestId) : null;
-  const inputPending = inputKey ? pendingInputRequestKeys.includes(inputKey) : false;
-  const inputActionError = inputKey ? inputActionErrors[inputKey] : undefined;
-  const inputAnswered = inputKey ? answeredInputRequestKeys.has(inputKey) : false;
-  const trimmedInputAnswer = inputAnswer.trim();
-  const reviewReadyId = event.type === "review.ready" ? ReviewIdSchema.safeParse(event.reviewId) : null;
-  return (
-    <div
-      className="grid gap-1 rounded-md border px-3 py-2"
-      style={{ borderColor: "var(--border-subtle)", background: "var(--bg-overlay)" }}
-    >
-      <div className="flex items-center justify-between gap-3">
-        <p className="text-sm font-medium" style={{ color: "var(--text-primary)" }}>
-          {copy.title}
-        </p>
-        <span className="shrink-0 text-xs" style={{ color: "var(--text-tertiary)" }}>
-          {event.occurredAt}
-        </span>
-      </div>
-      <p className="text-xs" style={{ color: "var(--text-secondary)" }}>
-        {copy.detail}
-      </p>
-      {reviewReadyId?.success ? (
-        <div className="flex flex-wrap items-center gap-2 pt-1">
-          <Button
-            aria-label="Open review from thread"
-            variant="subtle"
-            onClick={() => void selectReview(reviewReadyId.data)}
-          >
-            <GitPullRequest size={14} />
-            Open review
-          </Button>
-        </div>
-      ) : null}
-      {approval ? (
-        <div className="flex flex-wrap items-center gap-2 pt-1">
-          {approval.allowedDecisions.map((decision) => (
-            <Button
-              key={decision}
-              aria-label={`${approvalDecisionLabel(decision)} ${approval.title}`}
-              variant={approvalDecisionVariant(decision)}
-              disabled={approvalPending}
-              onClick={() => void submitApprovalDecision({
-                threadId: approval.threadId,
-                approvalId: approval.approvalId,
-                decision,
-                correlationId: approval.correlationId,
-              })}
-            >
-              {approvalPending ? "Sending..." : approvalDecisionLabel(decision)}
-            </Button>
-          ))}
-          {approvalActionError ? (
-            <span className="text-xs" style={{ color: "var(--danger)" }}>
-              {approvalActionError}
-            </span>
-          ) : null}
-        </div>
-      ) : null}
-      {inputRequest && !inputAnswered ? (
-        <div className="grid gap-2 pt-1">
-          <textarea
-            aria-label={`Answer ${inputRequest.title}`}
-            className="min-h-20 resize-y rounded-md border px-3 py-2 text-sm outline-none"
-            maxLength={8000}
-            placeholder={inputRequest.placeholder ?? "Answer"}
-            style={{
-              borderColor: "var(--border-subtle)",
-              background: "var(--bg-surface)",
-              color: "var(--text-primary)",
-            }}
-            value={inputAnswer}
-            onChange={(e) => setInputAnswer(e.currentTarget.value)}
-          />
-          <div className="flex flex-wrap items-center gap-2">
-            <Button
-              aria-label={`Send ${inputRequest.title}`}
-              variant="primary"
-              disabled={inputPending || (inputRequest.required && trimmedInputAnswer.length === 0)}
-              onClick={() => void submitInputAnswer({
-                threadId: inputRequest.threadId,
-                inputRequestId: inputRequest.requestId,
-                answer: inputAnswer,
-                correlationId: inputRequest.correlationId,
-              })}
-            >
-              {inputPending ? "Sending..." : "Send"}
-            </Button>
-            {inputActionError ? (
-              <span className="text-xs" style={{ color: "var(--danger)" }}>
-                {inputActionError}
-              </span>
-            ) : null}
-          </div>
-        </div>
-      ) : null}
-    </div>
-  );
-}
-
-function createThreadTimelineItems(events: AgentThreadEvent[]): ThreadTimelineItem[] {
-  const assistantGroups = new Map<string, AssistantTimelineEvent[]>();
-  const toolGroups = new Map<string, ToolTimelineEvent[]>();
-  const items: ThreadTimelineItem[] = [];
-  for (const [order, event] of events.entries()) {
-    if (isAssistantTimelineEvent(event)) {
-      const group = assistantGroups.get(event.messageId);
-      if (group) {
-        group.push(event);
-        continue;
-      }
-      const eventsForMessage = [event];
-      assistantGroups.set(event.messageId, eventsForMessage);
-      items.push({ kind: "assistant", key: `assistant:${event.messageId}`, events: eventsForMessage, order });
-      continue;
-    }
-    if (isToolTimelineEvent(event)) {
-      const group = toolGroups.get(event.toolCallId);
-      if (group) {
-        group.push(event);
-        continue;
-      }
-      const eventsForTool = [event];
-      toolGroups.set(event.toolCallId, eventsForTool);
-      items.push({ kind: "tool", key: `tool:${event.toolCallId}`, events: eventsForTool, order });
-      continue;
-    }
-    items.push({ kind: "event", event, order });
-  }
-  return items.sort((a, b) => a.order - b.order);
-}
-
-function isAssistantTimelineEvent(event: AgentThreadEvent): event is AssistantTimelineEvent {
-  return event.type === "assistant.text.delta" || event.type === "assistant.text.completed";
-}
-
-function isToolTimelineEvent(event: AgentThreadEvent): event is ToolTimelineEvent {
-  return event.type === "tool.started" || event.type === "tool.output" || event.type === "tool.completed";
-}
-
-function describeAssistantTimeline(events: AssistantTimelineEvent[]): { title: string; detail: string } {
-  const deltas = events.filter((event): event is Extract<AssistantTimelineEvent, { type: "assistant.text.delta" }> => event.type === "assistant.text.delta");
-  const completed = events.some((event) => event.type === "assistant.text.completed");
-  const preview = formatAssistantPreview(deltas);
-  if (deltas.length === 1 && !completed) {
-    return { title: "Assistant update", detail: preview ?? "Text update received" };
-  }
-  const updates = `${deltas.length} ${deltas.length === 1 ? "text update" : "text updates"} received`;
-  const statusDetail = completed ? `${updates}, complete` : updates;
-  return {
-    title: completed ? "Assistant message" : "Assistant updates",
-    detail: preview ? completed ? `${statusDetail}. ${preview}` : preview : statusDetail,
-  };
-}
-
-function formatAssistantPreview(deltas: Extract<AssistantTimelineEvent, { type: "assistant.text.delta" }>[]): string | null {
-  const preview = deltas
-    .map((event) => event.delta)
-    .join("")
-    .replace(/\s+/g, " ")
-    .trim();
-  if (!preview) {
-    return null;
-  }
-  if (!SafeAssistantPreviewSourceTextSchema.safeParse(preview).success) {
-    return null;
-  }
-  const cappedPreview = preview.length <= ASSISTANT_PREVIEW_MAX_CHARS
-    ? preview
-    : `${preview.slice(0, ASSISTANT_PREVIEW_MAX_CHARS).trimEnd()}...`;
-  return SafeAssistantPreviewTextSchema.safeParse(cappedPreview).success ? cappedPreview : null;
-}
-
-function describeToolTimeline(events: ToolTimelineEvent[]): { title: string; detail: string } {
-  const started = events.find((event): event is Extract<ToolTimelineEvent, { type: "tool.started" }> => event.type === "tool.started");
-  const outputs = events.filter((event): event is Extract<ToolTimelineEvent, { type: "tool.output" }> => event.type === "tool.output");
-  const completed = events.find((event): event is Extract<ToolTimelineEvent, { type: "tool.completed" }> => event.type === "tool.completed");
-  const displayName = started?.displayName ?? "Tool";
-  if (!completed) {
-    return {
-      title: "Tool activity",
-      detail: outputs.length > 0 ? `${displayName} running with output received` : `${displayName} running`,
-    };
-  }
-  const outputState = outputs.length > 0
-    ? outputs.some((event) => event.truncated) ? " after receiving partial output" : " after receiving output"
-    : " without captured output";
-  return {
-    title: "Tool activity",
-    detail: `${displayName} completed ${describeToolOutcome(completed.outcome)}${outputState}`,
-  };
-}
-
-function describeToolTimelineDetails(events: ToolTimelineEvent[]): {
-  started: Extract<ToolTimelineEvent, { type: "tool.started" }> | null;
-  outputs: Array<Extract<ToolTimelineEvent, { type: "tool.output" }>>;
-  completed: Extract<ToolTimelineEvent, { type: "tool.completed" }> | null;
-} {
-  return {
-    started: events.find((event): event is Extract<ToolTimelineEvent, { type: "tool.started" }> => event.type === "tool.started") ?? null,
-    outputs: events.filter((event): event is Extract<ToolTimelineEvent, { type: "tool.output" }> => event.type === "tool.output"),
-    completed: events.find((event): event is Extract<ToolTimelineEvent, { type: "tool.completed" }> => event.type === "tool.completed") ?? null,
-  };
-}
-
-function describeToolOutcome(outcome: string): string {
-  if (outcome === "success") return "successfully";
-  if (outcome === "failed") return "with errors";
-  if (outcome === "cancelled") return "cancelled";
-  return outcome.replace(/_/g, " ");
-}
-
-function formatToolCompletion(outcome: string): string {
-  if (outcome === "success") return "Completed successfully";
-  if (outcome === "failed") return "Failed";
-  if (outcome === "cancelled") return "Cancelled";
-  return outcome.replace(/_/g, " ");
-}
-
-function approvalDecisionLabel(decision: string): string {
-  switch (decision) {
-    case "approve":
-      return "Approve";
-    case "approve_for_session":
-      return "Approve for session";
-    case "decline":
-      return "Decline";
-    case "cancel":
-      return "Cancel";
-    default:
-      return "Decide";
-  }
-}
-
-function approvalDecisionVariant(decision: string): "primary" | "danger" | "subtle" {
-  return decision === "approve" || decision === "approve_for_session" ? "primary" : "danger";
-}
-
-function describeThreadEvent(event: AgentThreadEvent): { title: string; detail: string } {
-  switch (event.type) {
-    case "turn.accepted":
-      return { title: "Message accepted", detail: "Waiting for the agent run" };
-    case "turn.status":
-      return { title: "Message status", detail: event.status };
-    case "thread.created":
-      return { title: "Thread created", detail: event.thread.title };
-    case "thread.status":
-      return { title: "Status changed", detail: event.status.replace(/_/g, " ") };
-    case "assistant.text.delta":
-      return { title: "Assistant update", detail: "Text update received" };
-    case "assistant.text.completed":
-      return { title: "Assistant message complete", detail: "Message complete" };
-    case "tool.started":
-      return { title: "Tool started", detail: event.displayName };
-    case "tool.output":
-      return { title: "Tool output", detail: event.truncated ? "Output received, partial" : "Output received" };
-    case "tool.completed":
-      return { title: "Tool completed", detail: event.outcome };
-    case "approval.requested":
-      return { title: "Approval needed", detail: event.approval.safeDescription };
-    case "approval.resolved":
-      return { title: "Approval resolved", detail: event.decision };
-    case "user_input.requested":
-      return { title: "Input needed", detail: event.request.safeDescription };
-    case "user_input.answered":
-      return { title: "Input answered", detail: "Input answer received" };
-    case "file.changed":
-      return { title: `File ${event.changeKind}`, detail: `${capitalize(event.changeKind)} file` };
-    case "review.ready": {
-      const files = `${event.summary.changedFileCount} ${event.summary.changedFileCount === 1 ? "file" : "files"} changed`;
-      const partial = event.summary.partial ? ", partial" : "";
-      return { title: "Review ready", detail: `${files}, +${event.summary.additions} -${event.summary.deletions}${partial}` };
-    }
-    case "terminal.bound":
-      return { title: "Terminal bound", detail: event.terminalSessionId };
-    case "thread.error":
-      return {
-        title: "Thread needs attention",
-        detail: event.error.retryable ? "Refresh the thread or check the runtime." : "Open the workspace again.",
-      };
-    case "thread.completed":
-      return { title: "Thread completed", detail: event.outcome };
-  }
-}
-
-function capitalize(value: string): string {
-  return `${value.slice(0, 1).toUpperCase()}${value.slice(1)}`;
-}
 
 function canOpenPreviewExternally(origin: string | undefined): origin is string {
   if (!origin) return false;
@@ -1904,7 +1400,10 @@ export default function AgentWorkspace() {
   const refreshProjectWorkspace = useCodingAgentProjectWorkspace((s) => s.refresh);
   const requestComposerFocus = useCodingAgentWorkspace((s) => s.requestComposerFocus);
   const composerFocusRequestId = useCodingAgentWorkspace((s) => s.composerFocusRequestId);
+  const selectedProjectId = useCodingAgentProjectWorkspace((s) => s.selectedProjectId);
+  const selectedTaskId = useCodingAgentProjectWorkspace((s) => s.selectedTaskId);
   const [composerSeed, setComposerSeed] = useState<ComposerSeed | null>(null);
+  const [composerOpen, setComposerOpen] = useState(false);
   const [summaryRuntimeScope, setSummaryRuntimeScope] = useState<string | null>(null);
   const previousRuntimeScope = useRef(runtimeScope);
 
@@ -1987,6 +1486,20 @@ export default function AgentWorkspace() {
   if (!summary) return null;
 
   const canCreateFollowUp = capabilityEnabled(summary, "codingAgentsThreadCreate");
+  const projectWorkspaceEnabled = capabilityEnabled(summary, "codingAgentsProjectWorkspace");
+
+  function openNewChat(projectId: string, taskId?: string) {
+    setComposerSeed({
+      seedId: Date.now(),
+      draft: {
+        ...defaultAgentThreadComposerDraft(summary!),
+        projectId,
+        ...(taskId ? { taskId } : {}),
+      },
+    });
+    setComposerOpen(true);
+    requestComposerFocus();
+  }
 
   return (
     <div className="flex min-h-0 flex-1 flex-col">
@@ -2001,54 +1514,79 @@ export default function AgentWorkspace() {
       />
       <AgentProjectWorkspaceShell
         summary={summary}
-        onNewChat={(projectId, taskId) => {
-          setComposerSeed({
-            seedId: Date.now(),
-            draft: {
-              ...defaultAgentThreadComposerDraft(summary),
-              projectId,
-              ...(taskId ? { taskId } : {}),
-            },
-          });
-          requestComposerFocus();
-        }}
+        onNewChat={openNewChat}
       >
-        <AgentWorkspaceStack>
-          <AgentComposer summary={summary} seed={composerSeed} focusRequestId={composerFocusRequestId} />
-          <NotificationPreferencesPanel />
-          <ProviderList summary={summary} />
-          <AttentionThreadList summary={summary} />
-          <div className="grid gap-4 xl:grid-cols-2">
-            <div className="grid gap-4">
-              <ThreadList summary={summary} />
-              <CreatedThreadHandleList summary={summary} />
-            </div>
-            <div className="grid gap-4">
-              <ThreadSnapshotPanel
-                status={threadSnapshotStatus}
-                snapshot={threadSnapshot}
-                error={threadSnapshotError}
-              />
+        <div className="grid min-h-0 min-w-0 flex-1 grid-cols-1 overflow-y-auto lg:grid-cols-[minmax(360px,1fr)_minmax(340px,clamp(340px,34vw,520px))] lg:overflow-hidden">
+          <div className="flex min-h-[460px] min-w-0 flex-col overflow-hidden border-b lg:min-h-0 lg:border-b-0 lg:border-r" style={{ borderColor: "var(--border-subtle)" }}>
+            <AgentConversationView
+              status={threadSnapshotStatus}
+              snapshot={threadSnapshot}
+              error={threadSnapshotError}
+            />
+          </div>
+          <aside aria-label="Conversation tools" className="min-h-0 min-w-0 overflow-y-auto" style={{ background: "var(--bg-secondary)" }}>
+            <AgentWorkspaceStack>
+              {projectWorkspaceEnabled ? (
+                <div className="flex items-center justify-between gap-3">
+                  <div>
+                    <h2 className="text-sm font-semibold" style={{ color: "var(--text-primary)" }}>Conversation tools</h2>
+                    <p className="text-xs" style={{ color: "var(--text-tertiary)" }}>Terminal, review, files, diff, and preview</p>
+                  </div>
+                  <Button
+                    variant={composerOpen ? "subtle" : "primary"}
+                    disabled={!selectedProjectId}
+                    aria-label={composerOpen ? "Close new chat composer" : "New chat in selected project"}
+                    onClick={() => {
+                      if (composerOpen) {
+                        setComposerOpen(false);
+                        setComposerSeed(null);
+                        return;
+                      }
+                      if (selectedProjectId) openNewChat(selectedProjectId, selectedTaskId ?? undefined);
+                    }}
+                  >
+                    {composerOpen ? "Cancel" : "New chat"}
+                  </Button>
+                </div>
+              ) : null}
+              {!projectWorkspaceEnabled || composerOpen ? (
+                <AgentComposer
+                  summary={summary}
+                  seed={composerSeed}
+                  focusRequestId={composerFocusRequestId}
+                  onCreated={() => {
+                    if (!projectWorkspaceEnabled) return;
+                    setComposerOpen(false);
+                    setComposerSeed(null);
+                  }}
+                />
+              ) : null}
+              {capabilityEnabled(summary, "codingAgentsReview") ? (
+                <ReviewList
+                  canReadFiles={capabilityEnabled(summary, "codingAgentsFiles")}
+                  canPrepareCommit={capabilityEnabled(summary, "codingAgentsSourceControl")}
+                  canCreateFollowUp={canCreateFollowUp}
+                  onAskHunkFollowUp={(snapshot, selected) => {
+                    setComposerSeed({
+                      seedId: Date.now(),
+                      draft: reviewHunkFollowUpDraft(summary, snapshot, selected),
+                    });
+                    setComposerOpen(true);
+                  }}
+                />
+              ) : null}
               {capabilityEnabled(summary, "codingAgentsPreview") ? (
                 <AgentPreviewList summary={summary} />
               ) : null}
               <AgentTerminalList summary={summary} />
-            </div>
-          </div>
-          {capabilityEnabled(summary, "codingAgentsReview") ? (
-            <ReviewList
-              canReadFiles={capabilityEnabled(summary, "codingAgentsFiles")}
-              canPrepareCommit={capabilityEnabled(summary, "codingAgentsSourceControl")}
-              canCreateFollowUp={canCreateFollowUp}
-              onAskHunkFollowUp={(snapshot, selected) => {
-                setComposerSeed({
-                  seedId: Date.now(),
-                  draft: reviewHunkFollowUpDraft(summary, snapshot, selected),
-                });
-              }}
-            />
-          ) : null}
-        </AgentWorkspaceStack>
+              <AttentionThreadList summary={summary} />
+              <ThreadList summary={summary} />
+              <CreatedThreadHandleList summary={summary} />
+              <ProviderList summary={summary} />
+              <NotificationPreferencesPanel />
+            </AgentWorkspaceStack>
+          </aside>
+        </div>
       </AgentProjectWorkspaceShell>
     </div>
   );

--- a/desktop/src/renderer/src/features/coding-agents/AgentWorkspace.tsx
+++ b/desktop/src/renderer/src/features/coding-agents/AgentWorkspace.tsx
@@ -1522,6 +1522,7 @@ export default function AgentWorkspace() {
               status={threadSnapshotStatus}
               snapshot={threadSnapshot}
               error={threadSnapshotError}
+              canSendTurns={capabilityEnabled(summary, "codingAgentsSameThreadTurns")}
             />
           </div>
           <aside aria-label="Conversation tools" className="min-h-0 min-w-0 overflow-y-auto" style={{ background: "var(--bg-secondary)" }}>

--- a/desktop/src/renderer/src/stores/coding-agent-workspace.ts
+++ b/desktop/src/renderer/src/stores/coding-agent-workspace.ts
@@ -7,6 +7,7 @@ import {
   type AgentThreadComposerDraft,
   type CodingAgentNotificationPreferences,
   type CodingAgentNotificationPreferencesUpdate,
+  type CreateAgentTurnError,
   type FileReadRequest,
   type FileReadResponse,
   type FileWriteRequest,
@@ -30,10 +31,12 @@ type SourceCommitStatus = "idle" | "preparing" | "prepared" | "error";
 type SourcePullRequestStatus = "idle" | "creating" | "ready" | "error";
 type NotificationPreferencesStatus = "idle" | "loading" | "ready" | "saving" | "error";
 type CreateStatus = "idle" | "submitting";
+type TurnStatus = "idle" | "submitting" | "error";
 type ActionStatus = "idle" | "submitting";
 type AgentThreadSnapshotEvent = AgentThreadSnapshot["events"]["items"][number];
 type FileReference = Pick<FileReadRequest, "projectId" | "worktreeId" | "path">;
 type AttentionPushPreferences = CodingAgentNotificationPreferences["attentionPush"];
+type TurnRetry = { threadId: string; message: string; clientRequestId: string };
 type ReviewSummaryList = {
   items: ReviewSummary[];
   hasMore: boolean;
@@ -76,6 +79,10 @@ interface CodingAgentWorkspaceState {
   threadSnapshotError: string | null;
   createStatus: CreateStatus;
   createError: string | null;
+  turnStatus: TurnStatus;
+  turnError: string | null;
+  turnRetry: TurnRetry | null;
+  turnThreadId: string | null;
   composerFocusRequestId: number;
   approvalActionStatus: ActionStatus;
   pendingApprovalId: string | null;
@@ -112,6 +119,7 @@ interface CodingAgentWorkspaceState {
   }) => Promise<void>;
   requestComposerFocus: () => void;
   createThread: (draft: AgentThreadComposerDraft) => Promise<string | null>;
+  sendThreadMessage: (input: { threadId: string; message: string }) => Promise<boolean>;
 }
 
 let refreshSeq = 0;
@@ -163,6 +171,10 @@ function clearThreadSnapshotState() {
     threadSnapshotStatus: "idle" as const,
     threadSnapshot: null,
     threadSnapshotError: null,
+    turnStatus: "idle" as const,
+    turnError: null,
+    turnRetry: null,
+    turnThreadId: null,
   };
 }
 
@@ -174,6 +186,16 @@ function nextCreateRequestId(): string {
 function nextActionRequestId(): string {
   actionRequestSeq += 1;
   return `req_desktop_${Date.now().toString(36)}_${actionRequestSeq}`;
+}
+
+function safeTurnError(code: CreateAgentTurnError["code"]): string {
+  if (code === "thread_busy") {
+    return "This conversation is already running. Wait for it to finish and try again.";
+  }
+  if (code === "thread_not_found") {
+    return "Conversation is unavailable. Refresh and try again.";
+  }
+  return "This conversation cannot accept a message right now. Refresh and try again.";
 }
 
 function withoutRecordKey<T>(record: Record<string, T>, key: string): Record<string, T> {
@@ -475,6 +497,10 @@ export const useCodingAgentWorkspace = create<CodingAgentWorkspaceState>()((set)
   threadSnapshotError: null,
   createStatus: "idle",
   createError: null,
+  turnStatus: "idle",
+  turnError: null,
+  turnRetry: null,
+  turnThreadId: null,
   composerFocusRequestId: 0,
   approvalActionStatus: "idle",
   pendingApprovalId: null,
@@ -850,6 +876,9 @@ export const useCodingAgentWorkspace = create<CodingAgentWorkspaceState>()((set)
       threadSnapshotStatus: state.threadSnapshot?.thread.id === threadId ? "ready" : "loading",
       threadSnapshot: state.threadSnapshot?.thread.id === threadId ? state.threadSnapshot : null,
       threadSnapshotError: null,
+      ...(state.activeThreadId === threadId
+        ? {}
+        : { turnStatus: "idle" as const, turnError: null, turnRetry: null, turnThreadId: null }),
     }));
     try {
       const snapshot = await invoke("runtime:get-thread-snapshot", { threadId });
@@ -1068,6 +1097,87 @@ export const useCodingAgentWorkspace = create<CodingAgentWorkspaceState>()((set)
       console.warn("[coding-agents] thread create failed");
       set({ createStatus: "idle", createError: "Agent run could not be started. Try again." });
       return null;
+    }
+  },
+
+  sendThreadMessage: async ({ threadId, message }) => {
+    const initial = useCodingAgentWorkspace.getState();
+    if (
+      initial.turnStatus === "submitting"
+      || initial.activeThreadId !== threadId
+      || initial.threadSnapshot?.thread.id !== threadId
+    ) {
+      return false;
+    }
+    const retry = initial.turnRetry?.threadId === threadId && initial.turnRetry.message === message
+      ? initial.turnRetry
+      : { threadId, message, clientRequestId: nextActionRequestId() };
+    const selectionSeq = threadSnapshotSeq;
+    set({
+      turnStatus: "submitting",
+      turnError: null,
+      turnRetry: retry,
+      turnThreadId: threadId,
+    });
+
+    try {
+      const result = await invoke("runtime:create-turn", retry);
+      const stillSelected = () => {
+        const state = useCodingAgentWorkspace.getState();
+        return threadSnapshotSeq === selectionSeq
+          && state.activeThreadId === threadId
+          && state.threadSnapshot?.thread.id === threadId;
+      };
+      if (!result.ok) {
+        set((state) => state.turnThreadId === threadId
+          ? {
+              turnStatus: stillSelected() ? "error" : "idle",
+              turnError: stillSelected() ? safeTurnError(result.error.code) : null,
+              turnRetry: stillSelected() ? retry : null,
+              turnThreadId: stillSelected() ? threadId : null,
+            }
+          : {});
+        return false;
+      }
+
+      set((state) => state.turnThreadId === threadId
+        ? { turnStatus: "idle", turnError: null, turnRetry: null, turnThreadId: null }
+        : {});
+      if (!stillSelected()) return true;
+
+      try {
+        const snapshot = await invoke("runtime:get-thread-snapshot", { threadId });
+        if (!stillSelected()) return true;
+        set((state) => {
+          if (state.activeThreadId !== threadId || state.threadSnapshot?.thread.id !== threadId) return {};
+          const merged = mergeSelectedThreadSnapshot(state.threadSnapshot, snapshot);
+          return {
+            threadSnapshotStatus: "ready",
+            threadSnapshot: merged,
+            threadSnapshotError: null,
+            summary: state.summary ? reconcileSummaryThread(state.summary, merged.thread) : state.summary,
+          };
+        });
+        attachActiveThreadEventStream(snapshot);
+      } catch {
+        console.warn("[coding-agents] accepted turn refresh failed");
+      }
+      return true;
+    } catch {
+      console.warn("[coding-agents] thread turn failed");
+      set((state) => {
+        const selected = threadSnapshotSeq === selectionSeq
+          && state.activeThreadId === threadId
+          && state.threadSnapshot?.thread.id === threadId;
+        if (state.turnThreadId !== threadId) return {};
+        return {
+          turnStatus: selected ? "error" : "idle",
+          turnError: selected ? "Message could not be sent. Try again." : null,
+          turnRetry: selected ? retry : null,
+          turnThreadId: selected ? threadId : null,
+        };
+      });
+      return false;
     }
   },
 }));

--- a/desktop/src/shared/ipc-contract.ts
+++ b/desktop/src/shared/ipc-contract.ts
@@ -11,6 +11,9 @@ import {
   CodingAgentNotificationPreferencesSchema,
   CodingAgentNotificationPreferencesUpdateSchema,
   CreateAgentThreadRequestSchema,
+  CreateAgentTurnErrorSchema,
+  CreateAgentTurnRequestSchema,
+  CreateAgentTurnResponseSchema,
   CursorSchema,
   FileBrowseRequestSchema,
   FileBrowseResponseSchema,
@@ -39,6 +42,13 @@ import { CodingAgentProjectWorkspaceRequestSchema } from "./coding-agent-project
 const Empty = z.object({}).strict();
 
 const Ok = z.object({ ok: z.boolean() }).strict();
+const CodingAgentCreateTurnRequestSchema = CreateAgentTurnRequestSchema.extend({
+  threadId: ThreadIdSchema,
+}).strict();
+const CodingAgentCreateTurnResultSchema = z.discriminatedUnion("ok", [
+  z.object({ ok: z.literal(true), response: CreateAgentTurnResponseSchema }).strict(),
+  z.object({ ok: z.literal(false), error: CreateAgentTurnErrorSchema }).strict(),
+]);
 const EmbedStateSchema = z.enum(["loading", "ready", "auth-required", "failed"]);
 const ReviewIdSchema = z.string().regex(/^rev_[A-Za-z0-9_-]{1,128}$/);
 
@@ -211,6 +221,10 @@ export const INVOKE_CHANNELS = {
   "runtime:create-thread": {
     request: CreateAgentThreadRequestSchema,
     response: AgentThreadSnapshotSchema,
+  },
+  "runtime:create-turn": {
+    request: CodingAgentCreateTurnRequestSchema,
+    response: CodingAgentCreateTurnResultSchema,
   },
   "state:get": {
     request: z.object({ key: z.enum(STATE_KEYS) }).strict(),

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -586,6 +586,14 @@ const CoreAgentThreadEventSchema = z.discriminatedUnion("type", [
     status: AgentThreadStatusSchema,
   }).strict(),
   BaseThreadEventSchema.extend({
+    type: z.literal("user.message"),
+    messageId: referenceId(128),
+    text: boundedText(24_000, 96 * 1024),
+    clientRequestId: RequestIdSchema,
+    turnId: AgentTurnIdSchema.optional(),
+    attachments: z.array(AgentAttachmentSchema).max(8).optional(),
+  }).strict(),
+  BaseThreadEventSchema.extend({
     type: z.literal("assistant.text.delta"),
     messageId: referenceId(128),
     delta: boundedText(4000, 16 * 1024),

--- a/packages/gateway/src/coding-agents/provider-adapter.ts
+++ b/packages/gateway/src/coding-agents/provider-adapter.ts
@@ -97,6 +97,9 @@ export function parseCodingAgentProviderEvents(
   if (parsed.some((event) => event.threadId !== threadId)) {
     throw new Error("Provider emitted event for another thread");
   }
+  if (parsed.some((event) => event.type === "user.message")) {
+    throw new Error("Provider cannot emit user messages");
+  }
   return parsed;
 }
 

--- a/packages/gateway/src/coding-agents/thread-store.ts
+++ b/packages/gateway/src/coding-agents/thread-store.ts
@@ -1006,6 +1006,16 @@ export function createCodingAgentThreadStore(
         occurredAt: createdAt,
         thread: stripOwner(thread),
       });
+      const userMessageEvent = AgentThreadEventSchema.parse({
+        type: "user.message",
+        eventId: nextEventId(),
+        threadId: thread.id,
+        occurredAt: createdAt,
+        messageId: `msg_${randomUUID()}`,
+        text: request.prompt,
+        clientRequestId: request.clientRequestId,
+        ...(request.attachments ? { attachments: request.attachments } : {}),
+      });
       let providerEvents: AgentThreadEvent[];
       let providerResumeState: CodingAgentProviderResumeState | undefined;
       try {
@@ -1022,7 +1032,7 @@ export function createCodingAgentThreadStore(
         logCodingAgentWarning("provider start failed", err);
         providerEvents = safeProviderRunFailureEvents(thread.id, now, nextEventId);
       }
-      const events = [createdEvent, ...providerEvents];
+      const events = [createdEvent, userMessageEvent, ...providerEvents];
       for (const event of events.slice(1)) {
         thread = applyEvent(thread, event);
       }
@@ -1160,7 +1170,7 @@ export function createCodingAgentThreadStore(
           }
           const acceptedAt = now().toISOString();
           const turnId = AgentTurnIdSchema.parse(`turn_${randomUUID()}`);
-          const event = AgentThreadEventSchema.parse({
+          const acceptedEvent = AgentThreadEventSchema.parse({
             type: "turn.accepted",
             eventId: nextEventId(),
             threadId,
@@ -1169,6 +1179,18 @@ export function createCodingAgentThreadStore(
             clientRequestId: request.clientRequestId,
             acceptedAt,
           });
+          const userMessageEvent = AgentThreadEventSchema.parse({
+            type: "user.message",
+            eventId: nextEventId(),
+            threadId,
+            occurredAt: acceptedAt,
+            messageId: `msg_${randomUUID()}`,
+            text: request.message,
+            clientRequestId: request.clientRequestId,
+            turnId,
+            ...(request.attachments ? { attachments: request.attachments } : {}),
+          });
+          const acceptedEvents = [acceptedEvent, userMessageEvent];
           const nextThread: StoredThread = {
             ...thread,
             activeTurnId: turnId,
@@ -1189,7 +1211,7 @@ export function createCodingAgentThreadStore(
             state: {
               ...state,
               threads: state.threads.map((candidate) => candidate === thread ? nextThread : candidate),
-              events: [...state.events, event],
+              events: [...state.events, ...acceptedEvents],
               turns: [...state.turns, turn],
             },
             result: {
@@ -1199,7 +1221,7 @@ export function createCodingAgentThreadStore(
                 status: "accepted",
                 acceptedAt,
               }),
-              eventsToPublish: [event],
+              eventsToPublish: acceptedEvents,
               dispatch: { thread: nextThread, turn },
             },
           };

--- a/specs/105-coding-agent-shells/acceptance-tests.md
+++ b/specs/105-coding-agent-shells/acceptance-tests.md
@@ -1,6 +1,6 @@
 # Acceptance Tests: Project Conversations And Kanban
 
-**Status**: Phase 18-20 backend evidence and Phase 21.1 desktop navigator evidence added; Conversation, Kanban, mobile, and cross-shell evidence remains planned
+**Status**: Phase 18-20 backend evidence and Phase 21.1-21.2 desktop navigator/conversation evidence added; Kanban, mobile, and cross-shell evidence remains planned
 **Updated**: 2026-07-10
 
 This matrix is the executable acceptance contract for the clarified coding-agent shell model. A task checkbox in `tasks.md` is complete only when its named test IDs have current evidence on the exact implementation head. Existing checkpoint tests remain required regressions but do not prove these new cases.
@@ -77,9 +77,9 @@ Every clarified functional requirement and buildable success criterion has at le
 | DT-002 | One task expands to two independently selectable thread rows. | Accessible independent-row assertions in `tests/desktop/coding-agent-project-navigator.test.tsx` plus grouping-model coverage. |
 | DT-003 | Project-level thread is not rendered as task-bound. | `tests/desktop/coding-agent-project-workspace.test.ts` and the project-chat/task-group component assertions. |
 | DT-004 | Stale persisted project/task/thread references reconcile to a valid fallback. | `tests/desktop/coding-agent-project-workspace-store.test.ts` covers initial hydration and runtime switching; model tests cover stale task/thread fallback. |
-| DT-005 | Selected-thread composer invokes turn IPC, not create-thread IPC. | Exact invocation test with thread ID/idempotency key. |
-| DT-006 | Busy/offline/duplicate turn outcomes keep draft/selection safely recoverable. | Store/component failure tests with generic copy. |
-| DT-007 | Explicit new-chat action remains separate and can target project plus optional task. | Composer routing and contract tests. |
+| DT-005 | Selected-thread composer invokes turn IPC, not create-thread IPC. | Exact trusted-client, IPC handler, store, and conversation-component invocation tests with thread ID and bounded idempotency key. |
+| DT-006 | Busy/offline/duplicate turn outcomes keep draft/selection safely recoverable. | Store/component tests prove allowlisted copy, identical retry-key reuse, edited-message key rotation, retained draft, and stale-selection protection. |
+| DT-007 | Explicit new-chat action remains separate and can target project plus optional task. | Navigator/composer routing tests plus gateway workspace-provider coverage for server-owned worktree provisioning when the optional worktree reference is absent. |
 | DT-008 | Conversation/Kanban segmented control preserves selected project. | Component/store mode-switch test. |
 | DT-009 | Kanban uses canonical task columns/order and task mutation path. | Board integration test; no duplicate agent-only task store. |
 | DT-010 | Task card shows bounded count/active/attention aggregates and opens either attached thread. | Card/detail component tests. |
@@ -203,7 +203,23 @@ Current Phase 21.1 evidence on the desktop navigator slice:
 These checks prove `DT-001` through `DT-004` and the desktop portion of
 `SEC-003`. The integrated desktop tests additionally preserve external thread
 focus and explicit projection refresh behavior from `E2E-006`; they do not
-prove the still-open Conversation/Kanban or cross-shell acceptance cases.
+by themselves prove the later Conversation, Kanban, or cross-shell acceptance
+cases.
+
+Current Phase 21.2 evidence on the desktop Conversation slice:
+
+- `pnpm exec vitest run tests/desktop/ipc-contract.test.ts tests/desktop/ipc-handlers.test.ts tests/desktop/coding-agent-runtime-client.test.ts tests/desktop/coding-agent-workspace.test.tsx tests/desktop/coding-agent-project-workspace-shell.test.tsx tests/desktop/coding-agent-project-workspace-store.test.ts tests/desktop/coding-agent-project-workspace.test.ts tests/gateway/coding-agents-provider-adapter.test.ts tests/gateway/coding-agents-threads.test.ts tests/gateway/coding-agents-turns.test.ts tests/gateway/coding-agents-workspace-provider.test.ts tests/gateway/workspace-session-orchestrator.test.ts tests/contracts/coding-agent-project-conversations.test.ts`
+- `pnpm --filter desktop run typecheck`
+- `bun run typecheck`
+- `bun run check:patterns` (zero violations; repository baseline warnings only)
+- `bun run build:desktop`
+- `pnpm exec vitest run tests/e2e/desktop/operator.e2e.test.ts`
+
+These checks prove `DT-005` through `DT-007`: selected conversations replay
+gateway-owned user/assistant activity, the same-thread composer crosses strict
+trusted IPC, busy/offline retry state stays recoverable without exposing raw
+errors, and new-chat worktree creation remains a server-owned lifecycle. The
+Kanban and cross-shell cases remain open.
 
 Gateway/contract PRs additionally run the exact focused Vitest files named in their PR body. Desktop UI PRs run the operator E2E and screenshot checks. Mobile UI PRs run the SDK 57 dev-client device smoke before their rollout gate. `vp` commands may be reported unavailable, but they are not silently substituted for repository commands.
 

--- a/specs/105-coding-agent-shells/backend-shell-handoff.md
+++ b/specs/105-coding-agent-shells/backend-shell-handoff.md
@@ -21,7 +21,7 @@ This note is the stable integration boundary for desktop and mobile Conversation
 
 ## Mutations
 
-- Create a new project chat or task chat with `POST /api/coding-agents/threads` and `CreateAgentThreadRequestSchema`. New shell-created threads require `projectId`; `taskId` is optional but must belong to that project.
+- Create a new project chat or task chat with `POST /api/coding-agents/threads` and `CreateAgentThreadRequestSchema`. New shell-created threads require `projectId`; `taskId` is optional but must belong to that project. `worktreeId` remains optional at this boundary: workspace-backed providers provision the deterministic server-owned worktree when it is omitted.
 - Send later messages to the selected conversation with `POST /api/coding-agents/threads/:threadId/turns` and `CreateAgentTurnRequestSchema`. A 202 response is newly accepted, a 200 response is an idempotent retry, and a safe 409 means the shell should keep the current thread selected and offer retry after refresh.
 - Adopt an old unassigned conversation with `POST /api/coding-agents/threads/:threadId/adopt` and `AdoptAgentThreadRequestSchema`. This compatibility route cannot move an already assigned thread.
 - Keep task create/update/delete on the canonical `/api/projects/:projectId/tasks` routes. Thread state never moves a Kanban card automatically.
@@ -34,6 +34,7 @@ Every persisted public thread change emits a bounded `coding-agent.thread.create
 - Fetch `GET /api/coding-agents/threads/:threadId` for the latest bounded `AgentThreadSnapshotSchema` window.
 - Fetch `GET /api/coding-agents/threads/:threadId/events?cursor=...` for bounded continuation.
 - Subscribe to `/ws/coding-agents/thread/:threadId` through the existing authenticated shell client and validate every frame before reducing it.
+- Render user turns only from gateway-authored `user.message` events. Provider adapters cannot emit this event type, and shells must not synthesize user transcript rows after a mutation.
 - Keep the server-provided `threadId`, event cursor, and event IDs. Never store transcripts, terminal output, provider resume identity, approvals, file contents, or diffs in shell persistence.
 
 Workspace input delivery completes the accepted turn but does not complete a still-running thread. The canonical workspace session-stop path owns terminal thread completion/failure. Shell reducers should therefore render turn and thread lifecycle independently.

--- a/specs/105-coding-agent-shells/tasks.md
+++ b/specs/105-coding-agent-shells/tasks.md
@@ -1,6 +1,6 @@
 # Tasks: Coding Agent Shells
 
-**Status**: Backend Phases 18-20 and desktop Phase 21.1 implemented; Phase 21.2-21.5 shell implementation next; real-process Gate 3 smoke pending
+**Status**: Backend Phases 18-20 and desktop Phase 21.1-21.2 implemented; Phase 21.3-21.5 shell implementation next; real-process Gate 3 smoke pending
 **Lineage**: foundation merged through the recorded implementation checkpoint; clarified follow-up is specified against current `main`
 **Rule**: Preserve all existing desktop and mobile functionality. Add coding-agent capabilities incrementally behind contracts, tests, and feature flags.
 
@@ -1190,12 +1190,18 @@ typecheck/build, and the built-app operator flow are recorded in
 
 ### 21.2 Conversation View
 
-- [ ] Render selected same-thread transcript, attention, approvals, terminal, files, review, and preview context.
-- [ ] Send follow-up through the turn IPC, not thread create.
-- [ ] Keep explicit "new chat from context" separate from same-thread send.
-- [ ] Handle busy/idempotent/offline states with generic recovery copy.
+- [x] Render selected same-thread transcript, attention, approvals, terminal, files, review, and preview context.
+- [x] Send follow-up through the turn IPC, not thread create.
+- [x] Keep explicit "new chat from context" separate from same-thread send.
+- [x] Handle busy/idempotent/offline states with generic recovery copy.
 
 Tests: `DT-005`, `DT-006`, `DT-007`.
+
+Evidence: strict turn IPC/client/handler tests, server-authoritative
+`user.message` replay coverage, retry/idempotency and selection-race store tests,
+durable chat-bubble/component tests, workspace-provider auto-provisioning tests,
+the full focused desktop workspace regression, and desktop typecheck are recorded
+in `acceptance-tests.md`. Kanban remains open in 21.3.
 
 ### 21.3 Kanban View
 

--- a/tests/contracts/coding-agent-project-conversations.test.ts
+++ b/tests/contracts/coding-agent-project-conversations.test.ts
@@ -274,6 +274,20 @@ describe("coding agent project conversation contracts", () => {
       clientRequestId: "req_turn_fix_2",
       acceptedAt: now,
     }).type).toBe("turn.accepted");
+    expect(AgentThreadEventSchema.parse({
+      type: "user.message",
+      eventId: "evt_user_message",
+      threadId: "thread_fix",
+      occurredAt: now,
+      messageId: "msg_user_turn_2",
+      text: "Continue with the gateway fix.",
+      clientRequestId: "req_turn_fix_2",
+      turnId: "turn_fix_2",
+    })).toMatchObject({
+      type: "user.message",
+      text: "Continue with the gateway fix.",
+      turnId: "turn_fix_2",
+    });
 
     const unsafeValues = [
       {

--- a/tests/desktop/coding-agent-runtime-client.test.ts
+++ b/tests/desktop/coding-agent-runtime-client.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import {
   createCodingAgentThread,
+  createCodingAgentTurn,
   createCodingAgentSourcePullRequest,
   fetchCodingAgentProjectWorkspace,
   fetchCodingAgentFileBrowse,
@@ -279,6 +280,85 @@ describe("coding agent desktop runtime client", () => {
       "https://runtime.test/api/coding-agents/threads?runtime=secondary",
       expect.objectContaining({ method: "POST" }),
     );
+  });
+
+  it("creates same-thread turns against the selected runtime without exposing credentials", async () => {
+    const fetchFn = vi.fn().mockResolvedValue(new Response(JSON.stringify({
+      threadId: "thread_desktop_1",
+      turnId: "turn_desktop_1",
+      status: "accepted",
+      acceptedAt: "2026-07-06T00:01:00.000Z",
+    }), { status: 202 }));
+
+    await expect(createCodingAgentTurn(auth("secondary"), {
+      threadId: "thread_desktop_1",
+      message: "Continue with the focused tests.",
+      clientRequestId: "req_desktop_turn_1",
+    }, fetchFn)).resolves.toEqual({
+      ok: true,
+      response: expect.objectContaining({
+        threadId: "thread_desktop_1",
+        turnId: "turn_desktop_1",
+        status: "accepted",
+      }),
+    });
+    expect(fetchFn).toHaveBeenCalledWith(
+      "https://runtime.test/api/coding-agents/threads/thread_desktop_1/turns?runtime=secondary",
+      expect.objectContaining({
+        method: "POST",
+        headers: expect.objectContaining({ Authorization: "Bearer desktop-token" }),
+        body: JSON.stringify({
+          message: "Continue with the focused tests.",
+          clientRequestId: "req_desktop_turn_1",
+        }),
+        signal: expect.any(AbortSignal),
+      }),
+    );
+  });
+
+  it("maps expected turn conflicts to bounded local recovery copy", async () => {
+    const fetchFn = vi.fn().mockResolvedValue(new Response(JSON.stringify({
+      error: {
+        code: "thread_busy",
+        safeMessage: "Please retry this provider operation.",
+        retryable: true,
+        recoveryActions: ["retry"],
+      },
+    }), { status: 409 }));
+
+    const result = await createCodingAgentTurn(auth(), {
+      threadId: "thread_desktop_1",
+      message: "Continue with the focused tests.",
+      clientRequestId: "req_desktop_turn_1",
+    }, fetchFn);
+
+    expect(result).toEqual({
+      ok: false,
+      error: {
+        code: "thread_busy",
+        safeMessage: "This conversation is already running. Wait for it to finish and try again.",
+        retryable: true,
+        recoveryActions: ["retry"],
+      },
+    });
+    expect(JSON.stringify(result)).not.toMatch(/home\/matrix|provider/i);
+  });
+
+  it("rejects unsafe turn conflict envelopes with generic local copy", async () => {
+    const fetchFn = vi.fn().mockResolvedValue(new Response(JSON.stringify({
+      error: {
+        code: "thread_busy",
+        safeMessage: "Provider failed in /home/matrix/private.",
+        retryable: true,
+        recoveryActions: ["retry"],
+      },
+    }), { status: 409 }));
+
+    await expect(createCodingAgentTurn(auth(), {
+      threadId: "thread_desktop_1",
+      message: "Continue with the focused tests.",
+      clientRequestId: "req_desktop_turn_1",
+    }, fetchFn)).rejects.toThrow("conversation turn unavailable");
   });
 
   it("rejects unsafe or malformed thread snapshot responses with a generic error", async () => {

--- a/tests/desktop/coding-agent-workspace.test.tsx
+++ b/tests/desktop/coding-agent-workspace.test.tsx
@@ -692,6 +692,10 @@ describe("AgentWorkspace", () => {
       threadSnapshotError: null,
       createStatus: "idle",
       createError: null,
+      turnStatus: "idle",
+      turnError: null,
+      turnRetry: null,
+      turnThreadId: null,
       composerFocusRequestId: 0,
       approvalActionStatus: "idle",
       pendingApprovalId: null,
@@ -1172,6 +1176,113 @@ describe("AgentWorkspace", () => {
     expect(screen.getByText(expectedPreview)).toBeTruthy();
     expect(screen.queryByText("msg_desktop_safe_preview")).toBeNull();
     expect(screen.queryByText(/route test\. Reviewed the failing shard and found the route test\.$/)).toBeNull();
+  });
+
+  it("renders the selected conversation as durable chat bubbles with a same-thread composer", async () => {
+    const conversationSnapshot = {
+      ...threadSnapshotFixture(),
+      events: {
+        ...threadSnapshotFixture().events,
+        items: [
+          {
+            type: "user.message" as const,
+            eventId: "evt_desktop_user_message",
+            threadId: "thread_alpha",
+            occurredAt: "2026-07-06T00:01:00.000Z",
+            messageId: "msg_desktop_user",
+            text: "Please inspect the failing desktop test.",
+            clientRequestId: "req_desktop_user",
+            attachments: [],
+          },
+          {
+            type: "assistant.text.delta" as const,
+            eventId: "evt_desktop_agent_message",
+            threadId: "thread_alpha",
+            occurredAt: "2026-07-06T00:02:00.000Z",
+            messageId: "msg_desktop_agent",
+            delta: "I found the failing assertion and prepared a focused fix.",
+          },
+          {
+            type: "assistant.text.completed" as const,
+            eventId: "evt_desktop_agent_complete",
+            threadId: "thread_alpha",
+            occurredAt: "2026-07-06T00:02:01.000Z",
+            messageId: "msg_desktop_agent",
+          },
+        ],
+      },
+    };
+    useCodingAgentWorkspace.setState({ activeThreadId: "thread_alpha" });
+    window.operator.invoke = vi.fn((channel: string) => {
+      if (channel === "runtime:get-summary") return Promise.resolve(summaryFixture());
+      if (channel === "runtime:get-reviews") return Promise.resolve(reviewsFixture());
+      if (channel === "runtime:get-notification-preferences") {
+        return Promise.resolve({ attentionPush: { approval: true, input: true, failed: true, completed: true } });
+      }
+      if (channel === "runtime:get-thread-snapshot") return Promise.resolve(conversationSnapshot);
+      if (channel === "runtime:create-turn") {
+        return Promise.resolve({
+          ok: true,
+          response: {
+            threadId: "thread_alpha",
+            turnId: "turn_desktop_chat",
+            status: "accepted",
+            acceptedAt: "2026-07-06T00:03:00.000Z",
+          },
+        });
+      }
+      return Promise.reject(new Error(`unexpected channel ${channel}`));
+    });
+
+    render(<AgentWorkspace />);
+
+    expect(await screen.findByText("Please inspect the failing desktop test.")).toBeTruthy();
+    expect(screen.getByText("I found the failing assertion and prepared a focused fix.")).toBeTruthy();
+    const composer = screen.getByLabelText("Message conversation");
+    fireEvent.change(composer, { target: { value: "Continue with the focused validation." } });
+    fireEvent.click(screen.getByRole("button", { name: "Send message" }));
+
+    await waitFor(() => {
+      expect(window.operator.invoke).toHaveBeenCalledWith("runtime:create-turn", {
+        threadId: "thread_alpha",
+        message: "Continue with the focused validation.",
+        clientRequestId: expect.stringMatching(/^req_desktop_/),
+      });
+    });
+    await waitFor(() => expect((composer as HTMLTextAreaElement).value).toBe(""));
+  });
+
+  it("keeps the conversation draft and shows allowlisted recovery copy after a send conflict", async () => {
+    useCodingAgentWorkspace.setState({ activeThreadId: "thread_alpha" });
+    window.operator.invoke = vi.fn((channel: string) => {
+      if (channel === "runtime:get-summary") return Promise.resolve(summaryFixture());
+      if (channel === "runtime:get-reviews") return Promise.resolve(reviewsFixture());
+      if (channel === "runtime:get-notification-preferences") {
+        return Promise.resolve({ attentionPush: { approval: true, input: true, failed: true, completed: true } });
+      }
+      if (channel === "runtime:get-thread-snapshot") return Promise.resolve(threadSnapshotFixture());
+      if (channel === "runtime:create-turn") {
+        return Promise.resolve({
+          ok: false,
+          error: {
+            code: "thread_busy",
+            safeMessage: "Unexpected provider copy",
+            retryable: true,
+            recoveryActions: ["retry"],
+          },
+        });
+      }
+      return Promise.reject(new Error(`unexpected channel ${channel}`));
+    });
+
+    render(<AgentWorkspace />);
+    const composer = await screen.findByLabelText("Message conversation");
+    fireEvent.change(composer, { target: { value: "Keep this draft for retry." } });
+    fireEvent.click(screen.getByRole("button", { name: "Send message" }));
+
+    expect(await screen.findByText("This conversation is already running. Wait for it to finish and try again.")).toBeTruthy();
+    expect((composer as HTMLTextAreaElement).value).toBe("Keep this draft for retry.");
+    expect(screen.queryByText(/provider copy/i)).toBeNull();
   });
 
   it("collapses desktop tool activity details until expanded", async () => {
@@ -3461,6 +3572,146 @@ describe("AgentWorkspace", () => {
       },
     });
     await expect(first).resolves.toBe("thread_duplicate_1");
+  });
+
+  it("sends a same-thread message and refreshes only the selected conversation", async () => {
+    const refreshedSnapshot = {
+      ...threadSnapshotFixture(),
+      events: {
+        ...threadSnapshotFixture().events,
+        items: [
+          ...threadSnapshotFixture().events.items,
+          {
+            type: "user.message" as const,
+            eventId: "evt_user_message_1",
+            threadId: "thread_alpha",
+            occurredAt: "2026-07-06T00:05:00.000Z",
+            messageId: "msg_desktop_1",
+            text: "Continue with the focused tests.",
+            clientRequestId: "req_desktop_turn_1",
+            turnId: "turn_desktop_1",
+            attachments: [],
+          },
+        ],
+      },
+    };
+    window.operator.invoke = vi.fn((channel: string) => {
+      if (channel === "runtime:create-turn") {
+        return Promise.resolve({
+          ok: true,
+          response: {
+            threadId: "thread_alpha",
+            turnId: "turn_desktop_1",
+            status: "accepted",
+            acceptedAt: "2026-07-06T00:05:00.000Z",
+          },
+        });
+      }
+      if (channel === "runtime:get-thread-snapshot") return Promise.resolve(refreshedSnapshot);
+      return Promise.reject(new Error("unexpected channel"));
+    });
+    useCodingAgentWorkspace.setState({
+      activeThreadId: "thread_alpha",
+      threadSnapshotStatus: "ready",
+      threadSnapshot: threadSnapshotFixture(),
+    });
+
+    await expect(useCodingAgentWorkspace.getState().sendThreadMessage({
+      threadId: "thread_alpha",
+      message: "Continue with the focused tests.",
+    })).resolves.toBe(true);
+
+    expect(window.operator.invoke).toHaveBeenCalledWith("runtime:create-turn", {
+      threadId: "thread_alpha",
+      message: "Continue with the focused tests.",
+      clientRequestId: expect.stringMatching(/^req_desktop_/),
+    });
+    expect(useCodingAgentWorkspace.getState().threadSnapshot?.events.items)
+      .toEqual(expect.arrayContaining([expect.objectContaining({ type: "user.message" })]));
+    expect(useCodingAgentWorkspace.getState().turnRetry).toBeNull();
+  });
+
+  it("reuses a turn request id for an identical retry and rotates it after editing", async () => {
+    window.operator.invoke = vi.fn((channel: string) => {
+      if (channel === "runtime:create-turn") {
+        return Promise.resolve({
+          ok: false,
+          error: {
+            code: "thread_busy",
+            safeMessage: "Unexpected upstream copy",
+            retryable: true,
+            recoveryActions: ["retry"],
+          },
+        });
+      }
+      return Promise.reject(new Error("unexpected channel"));
+    });
+    useCodingAgentWorkspace.setState({
+      activeThreadId: "thread_alpha",
+      threadSnapshotStatus: "ready",
+      threadSnapshot: threadSnapshotFixture(),
+    });
+
+    const send = (message: string) => useCodingAgentWorkspace.getState().sendThreadMessage({
+      threadId: "thread_alpha",
+      message,
+    });
+    await send("Continue with the focused tests.");
+    await send("Continue with the focused tests.");
+    await send("Continue with the focused tests, then report back.");
+
+    const requests = vi.mocked(window.operator.invoke).mock.calls
+      .filter(([channel]) => channel === "runtime:create-turn")
+      .map(([, request]) => request as { clientRequestId: string });
+    expect(requests[0]?.clientRequestId).toBe(requests[1]?.clientRequestId);
+    expect(requests[2]?.clientRequestId).not.toBe(requests[1]?.clientRequestId);
+    expect(useCodingAgentWorkspace.getState().turnError)
+      .toBe("This conversation is already running. Wait for it to finish and try again.");
+    expect(useCodingAgentWorkspace.getState().turnError).not.toContain("upstream");
+  });
+
+  it("does not refresh or reopen a conversation after selection changes during send", async () => {
+    let resolveTurn: ((value: unknown) => void) | null = null;
+    window.operator.invoke = vi.fn((channel: string) => {
+      if (channel === "runtime:create-turn") {
+        return new Promise((resolve) => {
+          resolveTurn = resolve;
+        });
+      }
+      return Promise.reject(new Error("unexpected channel"));
+    });
+    useCodingAgentWorkspace.setState({
+      activeThreadId: "thread_alpha",
+      threadSnapshotStatus: "ready",
+      threadSnapshot: threadSnapshotFixture(),
+    });
+
+    const pending = useCodingAgentWorkspace.getState().sendThreadMessage({
+      threadId: "thread_alpha",
+      message: "Continue with the focused tests.",
+    });
+    useCodingAgentWorkspace.setState({
+      activeThreadId: "thread_beta",
+      threadSnapshotStatus: "ready",
+      threadSnapshot: betaThreadSnapshotFixture(),
+    });
+    resolveTurn?.({
+      ok: true,
+      response: {
+        threadId: "thread_alpha",
+        turnId: "turn_desktop_1",
+        status: "accepted",
+        acceptedAt: "2026-07-06T00:05:00.000Z",
+      },
+    });
+    await pending;
+
+    expect(useCodingAgentWorkspace.getState().activeThreadId).toBe("thread_beta");
+    expect(useCodingAgentWorkspace.getState().threadSnapshot?.thread.id).toBe("thread_beta");
+    expect(window.operator.invoke).not.toHaveBeenCalledWith(
+      "runtime:get-thread-snapshot",
+      expect.anything(),
+    );
   });
 
   it("shows a generic safe error when summary refresh fails", async () => {

--- a/tests/desktop/coding-agent-workspace.test.tsx
+++ b/tests/desktop/coding-agent-workspace.test.tsx
@@ -14,11 +14,12 @@ import { useTabs } from "../../desktop/src/renderer/src/stores/tabs";
 
 function summaryFixture({
   threadCreate = false,
+  sameThreadTurns = true,
   files = false,
   sourceControl = false,
   threadTerminalSessionId,
   terminalSessionName = "matrix-abc1234",
-}: { threadCreate?: boolean; files?: boolean; sourceControl?: boolean; threadTerminalSessionId?: string; terminalSessionName?: string } = {}) {
+}: { threadCreate?: boolean; sameThreadTurns?: boolean; files?: boolean; sourceControl?: boolean; threadTerminalSessionId?: string; terminalSessionName?: string } = {}) {
   return {
     runtime: {
       id: "rt_primary",
@@ -34,6 +35,11 @@ function summaryFixture({
         id: "codingAgentsThreadCreate",
         enabled: threadCreate,
         ...(threadCreate ? {} : { reason: "Not enabled yet" }),
+      },
+      {
+        id: "codingAgentsSameThreadTurns",
+        enabled: sameThreadTurns,
+        ...(sameThreadTurns ? {} : { reason: "Not enabled yet" }),
       },
       {
         id: "codingAgentsReview",
@@ -1250,6 +1256,28 @@ describe("AgentWorkspace", () => {
       });
     });
     await waitFor(() => expect((composer as HTMLTextAreaElement).value).toBe(""));
+  });
+
+  it("withholds the same-thread composer when the runtime does not support turns", async () => {
+    useCodingAgentWorkspace.setState({ activeThreadId: "thread_alpha" });
+    window.operator.invoke = vi.fn((channel: string) => {
+      if (channel === "runtime:get-summary") {
+        return Promise.resolve(summaryFixture({ sameThreadTurns: false }));
+      }
+      if (channel === "runtime:get-reviews") return Promise.resolve(reviewsFixture());
+      if (channel === "runtime:get-notification-preferences") {
+        return Promise.resolve({ attentionPush: { approval: true, input: true, failed: true, completed: true } });
+      }
+      if (channel === "runtime:get-thread-snapshot") return Promise.resolve(threadSnapshotFixture());
+      return Promise.reject(new Error(`unexpected channel ${channel}`));
+    });
+
+    render(<AgentWorkspace />);
+
+    expect(await screen.findByRole("region", { name: "Conversation Fix settings route" })).toBeTruthy();
+    expect(screen.queryByLabelText("Message conversation")).toBeNull();
+    expect(screen.getByText("Follow-ups are unavailable on this computer.")).toBeTruthy();
+    expect(screen.queryByText(/send a message to continue/i)).toBeNull();
   });
 
   it("keeps the conversation draft and shows allowlisted recovery copy after a send conflict", async () => {

--- a/tests/desktop/ipc-contract.test.ts
+++ b/tests/desktop/ipc-contract.test.ts
@@ -14,6 +14,7 @@ describe("IPC contract", () => {
       "auth:status",
       "auth:sign-out",
       "runtime:create-thread",
+      "runtime:create-turn",
       "runtime:subscribe-thread-events",
       "runtime:unsubscribe-thread-events",
       "runtime:get-notification-preferences",
@@ -125,6 +126,44 @@ describe("IPC contract", () => {
         },
       }).success,
     ).toBe(true);
+  });
+
+  it("validates runtime:create-turn success and safe conflict results", () => {
+    const request = {
+      threadId: "thread_desktop_1",
+      message: "Continue with the focused tests.",
+      clientRequestId: "req_desktop_turn_1",
+    };
+    const channel = INVOKE_CHANNELS["runtime:create-turn"];
+
+    expect(channel.request.safeParse(request).success).toBe(true);
+    expect(channel.request.safeParse({ ...request, bearerToken: "secret" }).success).toBe(false);
+    expect(channel.response.safeParse({
+      ok: true,
+      response: {
+        threadId: "thread_desktop_1",
+        turnId: "turn_desktop_1",
+        status: "accepted",
+        acceptedAt: "2026-07-06T00:01:00.000Z",
+      },
+    }).success).toBe(true);
+    expect(channel.response.safeParse({
+      ok: false,
+      error: {
+        code: "thread_busy",
+        safeMessage: "This conversation is already running.",
+        retryable: true,
+        recoveryActions: ["retry"],
+      },
+    }).success).toBe(true);
+    expect(channel.response.safeParse({
+      ok: false,
+      error: {
+        code: "provider_error",
+        safeMessage: "/home/matrix/secret",
+        retryable: true,
+      },
+    }).success).toBe(false);
   });
 
   it("validates runtime:get-thread-snapshot requests and rejects credential leakage shapes", () => {

--- a/tests/desktop/ipc-handlers.test.ts
+++ b/tests/desktop/ipc-handlers.test.ts
@@ -52,6 +52,7 @@ function makeHarness(overrides: Partial<HandlerContext> = {}) {
     submitApprovalDecision: vi.fn(),
     submitInputAnswer: vi.fn(),
     createAgentThread: vi.fn(),
+    createAgentTurn: vi.fn(),
     ...overrides,
   } as unknown as HandlerContext;
 
@@ -891,5 +892,31 @@ describe("registerIpcHandlers", () => {
         clientRequestId: "req_desktop_1",
       }),
     ).rejects.not.toThrow("/home/matrix");
+  });
+
+  it("creates same-thread turns through trusted-core IPC without exposing credentials", async () => {
+    const result = {
+      ok: false as const,
+      error: {
+        code: "thread_busy" as const,
+        safeMessage: "This conversation is already running. Wait for it to finish and try again.",
+        retryable: true,
+        recoveryActions: ["retry" as const],
+      },
+    };
+    const createAgentTurn = vi.fn().mockResolvedValue(result);
+    const harness = makeHarness({ createAgentTurn } as Partial<HandlerContext>);
+    const request = {
+      threadId: "thread_desktop_1",
+      message: "Continue with the focused tests.",
+      clientRequestId: "req_desktop_turn_1",
+    };
+
+    await expect(harness.invoke("runtime:create-turn", request)).resolves.toEqual(result);
+    expect(createAgentTurn).toHaveBeenCalledWith(request);
+    await expect(harness.invoke("runtime:create-turn", {
+      ...request,
+      providerToken: "secret",
+    })).rejects.toThrow("invalid request");
   });
 });

--- a/tests/e2e/desktop/fixtures/stub-gateway.ts
+++ b/tests/e2e/desktop/fixtures/stub-gateway.ts
@@ -203,6 +203,15 @@ export function codingAgentSnapshot(prompt = "Fix the failing auth tests"): Agen
           thread,
         },
         {
+          type: "user.message",
+          eventId: "evt_operator_user_message",
+          threadId: thread.id,
+          occurredAt: NOW,
+          messageId: "msg_operator_user_1",
+          text: prompt,
+          clientRequestId: "req_operator_user_1",
+        },
+        {
           type: "assistant.text.delta",
           eventId: "evt_operator_text",
           threadId: thread.id,

--- a/tests/e2e/desktop/operator.e2e.test.ts
+++ b/tests/e2e/desktop/operator.e2e.test.ts
@@ -91,7 +91,7 @@ suite("operator desktop e2e", () => {
     await page.keyboard.press("Control+K");
     await page.getByLabel("Command palette").waitFor({ timeout: 10_000 });
     await page.getByText("Open Agents").click();
-    await page.getByRole("button", { name: "Start run" }).waitFor({ timeout: 10_000 });
+    await page.getByRole("button", { name: "New chat in selected project" }).waitFor({ timeout: 10_000 });
     await page.getByRole("navigation", { name: "Projects and conversations" }).waitFor();
     await page.getByRole("group", { name: "Project chats" }).waitFor();
     await page.getByRole("group", { name: "Task Fix the failing auth tests" }).waitFor();
@@ -102,10 +102,12 @@ suite("operator desktop e2e", () => {
 
   it("starts an agent thread from the Agents workspace composer", async () => {
     await page.locator("aside button", { hasText: "Agents" }).first().click({ timeout: 5_000 });
-    await page.locator("textarea:visible").first().fill("fix the failing auth tests", { timeout: 5_000 });
+    await page.getByRole("button", { name: "New chat in Matrix OS" }).click();
+    await page.getByLabel("Agent run prompt").fill("fix the failing auth tests", { timeout: 5_000 });
     await page.getByRole("button", { name: "Start run" }).focus();
     await page.keyboard.press("Enter");
     await expect.poll(() => gateway.state.codingAgentCreates.length, { timeout: 5_000 }).toBe(1);
+    expect(gateway.state.codingAgentCreates[0]).toMatchObject({ projectId: "matrix-os" });
     await page.getByText("fix the failing auth tests").first().waitFor({ timeout: 10_000 });
     await page.getByText("Completed").first().waitFor({ timeout: 10_000 });
     await page.screenshot({ path: join(SCREENSHOT_DIR, "05-agents.png") });

--- a/tests/gateway/coding-agents-provider-adapter.test.ts
+++ b/tests/gateway/coding-agents-provider-adapter.test.ts
@@ -42,4 +42,19 @@ describe("coding agent provider adapter boundary", () => {
       outcome: "completed",
     } as never, "thread_provider_1")).toThrow();
   });
+
+  it("rejects provider-authored user messages so the gateway remains authoritative", () => {
+    expect(() => parseCodingAgentProviderRunResult({
+      events: [{
+        type: "user.message",
+        eventId: "evt_provider_user_message",
+        threadId: "thread_provider_1",
+        occurredAt: now,
+        messageId: "msg_provider_user_message",
+        text: "Provider-invented user content",
+        clientRequestId: "req_provider_user_message",
+      }],
+      outcome: "completed",
+    }, "thread_provider_1")).toThrow("Provider cannot emit user messages");
+  });
 });

--- a/tests/gateway/coding-agents-thread-stream.test.ts
+++ b/tests/gateway/coding-agents-thread-stream.test.ts
@@ -79,6 +79,7 @@ describe("coding agent thread stream", () => {
       "thread.event",
       "thread.event",
       "thread.event",
+      "thread.event",
       "thread.replay.end",
       "thread.event",
       "thread.event",
@@ -179,6 +180,7 @@ describe("coding agent thread stream", () => {
     await stream.open({ ws: stale, principal: testPrincipal, threadId, cursor: "evt_missing" });
 
     expect(afterCursor.sent.map((frame) => (frame as { event?: { type?: string } }).event?.type).filter(Boolean)).toEqual([
+      "user.message",
       "thread.status",
       "assistant.text.delta",
     ]);

--- a/tests/gateway/coding-agents-threads.test.ts
+++ b/tests/gateway/coding-agents-threads.test.ts
@@ -104,13 +104,19 @@ describe("coding agent thread lifecycle", () => {
     });
     expect(firstSnapshot.events.items.map((event) => event.type)).toEqual([
       "thread.created",
+      "user.message",
       "thread.status",
       "assistant.text.delta",
     ]);
+    expect(firstSnapshot.events.items[1]).toMatchObject({
+      type: "user.message",
+      text: createBody.prompt,
+      clientRequestId: createBody.clientRequestId,
+    });
 
     const replay = await app.request(`/api/coding-agents/threads/${firstSnapshot.thread.id}/events`);
     expect(replay.status).toBe(200);
-    expect(AgentThreadSnapshotSchema.parse(await replay.json()).events.items).toHaveLength(3);
+    expect(AgentThreadSnapshotSchema.parse(await replay.json()).events.items).toHaveLength(4);
   });
 
   it("aggregates every bounded owner project thread beyond the list page", async () => {
@@ -150,6 +156,7 @@ describe("coding agent thread lifecycle", () => {
     expect(replay.status).toBe(200);
     const replayBody = AgentThreadSnapshotSchema.parse(await replay.json());
     expect(replayBody.events.items.map((event) => event.type)).toEqual([
+      "user.message",
       "thread.status",
       "assistant.text.delta",
     ]);
@@ -656,6 +663,7 @@ describe("coding agent thread lifecycle", () => {
     expect(decided.thread).toMatchObject({ status: "running", attention: "none" });
     expect(decided.events.items.map((event) => event.type)).toEqual([
       "thread.created",
+      "user.message",
       "approval.requested",
       "approval.resolved",
       "thread.status",
@@ -751,6 +759,7 @@ describe("coding agent thread lifecycle", () => {
     expect(answered.thread).toMatchObject({ status: "running", attention: "none" });
     expect(answered.events.items.map((event) => event.type)).toEqual([
       "thread.created",
+      "user.message",
       "user_input.requested",
       "user_input.answered",
       "thread.status",
@@ -783,10 +792,11 @@ describe("coding agent thread lifecycle", () => {
     });
     expect(created.snapshot.events.items.map((event) => event.type)).toEqual([
       "thread.created",
+      "user.message",
       "thread.error",
       "thread.completed",
     ]);
-    expect(created.snapshot.events.items[1]).toMatchObject({
+    expect(created.snapshot.events.items[2]).toMatchObject({
       type: "thread.error",
       error: {
         code: "provider_run_failed",
@@ -856,6 +866,7 @@ describe("coding agent thread lifecycle", () => {
     expect(aborted.thread.status).toBe("aborted");
     expect(aborted.events.items.map((event) => event.type)).toEqual([
       "thread.created",
+      "user.message",
       "thread.status",
       "thread.status",
       "assistant.text.completed",
@@ -1056,6 +1067,6 @@ describe("coding agent thread lifecycle", () => {
 
     expect(raw).toContain(snapshot.thread.id);
     expect(raw).toContain("owner_user");
-    expect(raw).not.toMatch(/Inspect the failing tests/);
+    expect(raw).toContain(createBody.prompt);
   });
 });

--- a/tests/gateway/coding-agents-turn-dispatch.test.ts
+++ b/tests/gateway/coding-agents-turn-dispatch.test.ts
@@ -142,8 +142,17 @@ describe("coding agent turn dispatch", () => {
         join(harness.homePath, "system", "coding-agents", "threads.json"),
         "utf-8",
       );
-      expect(persisted).not.toContain("Implement the route.");
-      expect(persisted).not.toContain("Now add the regression test.");
+      const persistedDocument = JSON.parse(persisted) as {
+        threads: unknown[];
+        events: Array<{ type?: string; text?: string }>;
+      };
+      expect(persistedDocument.events.filter((event) => event.type === "user.message"))
+        .toEqual(expect.arrayContaining([
+          expect.objectContaining({ text: "Implement the route." }),
+          expect.objectContaining({ text: "Now add the regression test." }),
+        ]));
+      expect(JSON.stringify(persistedDocument.threads)).not.toContain("Implement the route.");
+      expect(JSON.stringify(persistedDocument.threads)).not.toContain("Now add the regression test.");
       expect(JSON.stringify(
         await harness.threads.getThread(ownerPrincipal, harness.threadId),
       )).not.toContain("provider_conversation_stable");

--- a/tests/gateway/coding-agents-turns.test.ts
+++ b/tests/gateway/coding-agents-turns.test.ts
@@ -36,6 +36,12 @@ describe("coding agent same-thread turns", () => {
         turnId: accepted.turnId,
         clientRequestId: turnBody.clientRequestId,
       }));
+      expect(snapshot.events.items).toContainEqual(expect.objectContaining({
+        type: "user.message",
+        turnId: accepted.turnId,
+        text: turnBody.message,
+        clientRequestId: turnBody.clientRequestId,
+      }));
       expect(harness.validateThread).toHaveBeenCalledWith(ownerPrincipal, {
         projectId: "matrix-os",
         taskId: "task_auth",

--- a/tests/gateway/coding-agents-workspace-provider.test.ts
+++ b/tests/gateway/coding-agents-workspace-provider.test.ts
@@ -260,6 +260,7 @@ describe("coding agent workspace provider", () => {
     });
     expect(snapshot.events.items.map((event) => event.type)).toEqual([
       "thread.created",
+      "user.message",
       "thread.status",
       "terminal.bound",
       "assistant.text.delta",
@@ -338,6 +339,7 @@ describe("coding agent workspace provider", () => {
     expect(created.snapshot.thread).toMatchObject({ status: "failed", attention: "failed" });
     expect(created.snapshot.events.items.map((event) => event.type)).toEqual([
       "thread.created",
+      "user.message",
       "thread.error",
       "thread.completed",
     ]);

--- a/www/content/docs/coding-agents.mdx
+++ b/www/content/docs/coding-agents.mdx
@@ -29,6 +29,19 @@ In the browser shell, Canvas remains the primary workspace. The built-in Workspa
   Desktop, mobile, browser shell, and CLI sessions all reconnect to the same Matrix computer. If an agent keeps running after you close one shell, another shell can reopen the same thread, terminal, review, or preview from the gateway state.
 </Callout>
 
+### Project conversations on desktop
+
+The desktop workspace groups coding chats by project. A project can have its
+own chats, and each task can contain several independent chats. Selecting a
+chat opens its durable gateway timeline in the center while terminal, review,
+files, diff, and preview tools stay available beside it.
+
+Use the composer at the bottom of an open conversation to continue that same
+thread. Use a project's or task's **New chat** action when you want a separate
+conversation. Matrix records accepted user messages on the gateway, so a
+refresh or another desktop session replays the same conversation instead of
+reconstructing it from local UI state.
+
 ## Supported agents
 
 Four coding agents are supported:


### PR DESCRIPTION
## Summary

- replace the desktop thread-detail card with a project-first conversation canvas that replays durable user/assistant messages, approvals, input requests, and bounded tool activity
- add strict trusted-main IPC for same-thread turns with safe local error copy, stable retry idempotency keys, stale-selection protection, and capability gating
- keep explicit new-chat creation separate and let workspace-backed providers provision a deterministic server-owned worktree when the optional worktree reference is absent
- make gateway-authored `user.message` events the transcript source of truth and reject provider-authored user messages
- align stream and persistence coverage with durable user transcript events while keeping prompt text out of thread metadata
- update Phase 21.2 acceptance evidence and the public coding-agent guide

## Tests

- `pnpm exec vitest run tests/desktop/ipc-contract.test.ts tests/desktop/ipc-handlers.test.ts tests/desktop/coding-agent-runtime-client.test.ts tests/desktop/coding-agent-workspace.test.tsx tests/desktop/coding-agent-project-workspace-shell.test.tsx tests/desktop/coding-agent-project-workspace-store.test.ts tests/desktop/coding-agent-project-workspace.test.ts tests/gateway/coding-agents-provider-adapter.test.ts tests/gateway/coding-agents-threads.test.ts tests/gateway/coding-agents-turns.test.ts tests/gateway/coding-agents-workspace-provider.test.ts tests/gateway/workspace-session-orchestrator.test.ts tests/contracts/coding-agent-project-conversations.test.ts` (250 passed)
- `pnpm exec vitest run tests/desktop/coding-agent-workspace.test.tsx tests/gateway/coding-agents-thread-stream.test.ts tests/gateway/coding-agents-turn-dispatch.test.ts` (90 passed after CI/review fixes)
- `pnpm --filter desktop run typecheck`
- `bun run typecheck`
- `bun run check:patterns` (0 violations; 5 baseline warning groups)
- `bun run build:desktop`
- `pnpm exec vitest run tests/e2e/desktop/operator.e2e.test.ts` (7 passed; built Electron app)
- [Exact-head Linux CI and E2E](https://github.com/HamedMP/matrix-os/actions/runs/29132840489) (passed)
- [Exact-head Docker image, smoke, fresh-install, upgrade, customized-files, channels, and recovery](https://github.com/HamedMP/matrix-os/actions/runs/29132841169) (passed)
- `bun run test` was also attempted locally and stopped after unrelated host failures cascaded across existing suites: the shell is running Node 26 while a globally installed native module targets another ABI, and the local Vitest environment has no usable `localStorage`. The exact-head Linux CI all-suite run is green.

## Review/Monitoring

- Review range is frozen at `2e68fb698..3b807530d`.
- Exact-head Greptile review is 5/5 on `3b807530d`.
- All review threads are resolved and `ready-for-ci` is applied.
- The first manual CI run found three stale transcript expectations; they were corrected and the exact-head rerun passed.
- The stack base remains PR #910. Workflow branch filters do not include this fixed objective branch name, so CI and Docker Tests were manually dispatched on the exact head.

## Invariants

### Source of truth

- The gateway thread store owns thread summaries, accepted turns, and replayable events. Providers may emit agent/tool lifecycle events but cannot author `user.message`.
- Canonical project/task relations remain gateway/canonical-project projections. The desktop persists only bounded project/task/thread/view references and re-fetches authoritative snapshots.

### Lock/transaction scope

- Turn acceptance uses the existing serialized thread-store mutation to claim active-turn ownership and append the accepted turn plus gateway-authored user message before publication.
- Provider dispatch and Electron network calls remain outside renderer state. Worktree provisioning completes before sandbox preflight and process launch.

### Acceptable orphan states

- If sandbox preflight or session launch fails after automatic worktree creation, the deterministic server-owned worktree may remain for safe retry/recovery; no user project data is deleted.
- If a turn is accepted but the desktop refresh fails, the persisted event remains authoritative and the existing stream/refresh path reconciles it.

### Auth source of truth

- Existing owner-scoped gateway bearer/JWT authentication remains primary. Electron main holds the bearer token; renderer IPC schemas contain no bearer or provider credentials.
- Authentication, malformed response, and unknown runtime failures fail closed with generic local copy.

### Deferred scope

- Canonical Kanban projection/mutations and Conversation/Kanban identity switching are the next stacked PR.
- Native desktop computer selection, mobile parity, real-VPS smoke, and broad file/git inspector polish remain later goal slices.