### PR TITLE
feat(desktop): add project Kanban workspace

### DIFF
--- a/desktop/src/renderer/src/features/coding-agents/AgentKanbanBoard.tsx
+++ b/desktop/src/renderer/src/features/coding-agents/AgentKanbanBoard.tsx
@@ -1,0 +1,284 @@
+import type {
+  AgentThreadSummary,
+  ProjectAgentWorkspace,
+  RuntimeSummary,
+  TaskAgentSummary,
+} from "@matrix-os/contracts";
+import { AlertTriangle, CircleDot, MessageSquare } from "lucide-react";
+import type { CodingAgentWorkspaceViewMode } from "../../../../shared/coding-agent-project-workspace";
+import {
+  BOARD_COLUMNS,
+  type CardStatus,
+} from "../../stores/board";
+import { groupProjectWorkspaceThreads } from "./project-workspace-model";
+
+const COLUMN_LABEL: Record<(typeof BOARD_COLUMNS)[number], string> = {
+  todo: "Todo",
+  running: "Running",
+  waiting: "Waiting",
+  blocked: "Blocked",
+  complete: "Complete",
+  archived: "Archived",
+};
+
+const COLUMN_COLOR: Record<(typeof BOARD_COLUMNS)[number], string> = {
+  todo: "var(--status-todo)",
+  running: "var(--status-running)",
+  waiting: "var(--status-waiting)",
+  blocked: "var(--status-blocked)",
+  complete: "var(--status-complete)",
+  archived: "var(--status-todo)",
+};
+
+function aggregateLabel(count: number, singular: string, plural: string): string {
+  return `${count} ${count === 1 ? singular : plural}`;
+}
+
+function providerLabel(
+  providers: RuntimeSummary["providers"],
+  thread: AgentThreadSummary,
+): string {
+  return providers.find((provider) => provider.id === thread.providerId)?.displayName
+    ?? "Agent";
+}
+
+function statusLabel(thread: AgentThreadSummary): string {
+  if (thread.attention === "approval_required") return "Approval";
+  if (thread.attention === "input_required") return "Input";
+  if (thread.attention === "failed") return "Failed";
+  if (thread.status === "running") return "Working";
+  return thread.status.replaceAll("_", " ");
+}
+
+function ChatRow({
+  thread,
+  providers,
+  selected,
+  onOpen,
+}: {
+  thread: AgentThreadSummary;
+  providers: RuntimeSummary["providers"];
+  selected: boolean;
+  onOpen: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      aria-label={`Open chat ${thread.title}`}
+      aria-current={selected ? "page" : undefined}
+      onClick={onOpen}
+      className="flex w-full min-w-0 items-center gap-2 rounded-md px-2 py-1.5 text-left outline-none transition-colors hover:bg-[var(--bg-hover)] focus-visible:ring-2 focus-visible:ring-[var(--accent)]"
+      style={{
+        background: selected ? "var(--accent-muted)" : "transparent",
+        color: selected ? "var(--text-primary)" : "var(--text-secondary)",
+      }}
+    >
+      <MessageSquare size={12} className="shrink-0" aria-hidden="true" />
+      <span className="min-w-0 flex-1">
+        <span className="block truncate text-[11px] font-medium">{thread.title}</span>
+        <span className="block truncate text-[10px] capitalize" style={{ color: "var(--text-tertiary)" }}>
+          {providerLabel(providers, thread)} · {statusLabel(thread)}
+        </span>
+      </span>
+    </button>
+  );
+}
+
+function TaskCard({
+  task,
+  threads,
+  providers,
+  selectedTaskId,
+  selectedThreadId,
+  canMoveTasks,
+  movingTaskId,
+  onSelectTask,
+  onOpenThread,
+  onMoveTask,
+}: {
+  task: TaskAgentSummary;
+  threads: AgentThreadSummary[];
+  providers: RuntimeSummary["providers"];
+  selectedTaskId: string | null;
+  selectedThreadId: string | null;
+  canMoveTasks: boolean;
+  movingTaskId: string | null;
+  onSelectTask: (taskId: string) => void;
+  onOpenThread: (threadId: string) => void;
+  onMoveTask: (taskId: string, status: CardStatus, order: number) => void;
+}) {
+  const moving = movingTaskId === task.id;
+  return (
+    <article
+      className="rounded-xl border p-2.5 shadow-sm"
+      style={{
+        borderColor: selectedTaskId === task.id ? "var(--accent)" : "var(--border-subtle)",
+        background: "var(--bg-surface)",
+      }}
+    >
+      <button
+        type="button"
+        onClick={() => onSelectTask(task.id)}
+        className="block w-full rounded-md px-1 py-0.5 text-left outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)]"
+      >
+        <span className="block truncate text-sm font-semibold" style={{ color: "var(--text-primary)" }}>
+          {task.title}
+        </span>
+        <span className="mt-1 flex flex-wrap items-center gap-1.5 text-[10px]" style={{ color: "var(--text-tertiary)" }}>
+          <span>{aggregateLabel(task.threadCount, "chat", "chats")}</span>
+          <span aria-hidden="true">·</span>
+          <span>{aggregateLabel(task.activeThreadCount, "active", "active")}</span>
+          {task.attentionCount > 0 ? (
+            <>
+              <span aria-hidden="true">·</span>
+              <span className="inline-flex items-center gap-1" style={{ color: "var(--warning)" }}>
+                <AlertTriangle size={10} aria-hidden="true" />
+                {aggregateLabel(task.attentionCount, "needs attention", "need attention")}
+              </span>
+            </>
+          ) : null}
+        </span>
+      </button>
+
+      {threads.length > 0 ? (
+        <div className="mt-2 space-y-0.5 border-t pt-2" style={{ borderColor: "var(--border-subtle)" }}>
+          {threads.map((thread) => (
+            <ChatRow
+              key={thread.id}
+              thread={thread}
+              providers={providers}
+              selected={thread.id === selectedThreadId}
+              onOpen={() => onOpenThread(thread.id)}
+            />
+          ))}
+        </div>
+      ) : (
+        <p className="mt-2 border-t px-2 pt-2 text-[11px]" style={{ borderColor: "var(--border-subtle)", color: "var(--text-tertiary)" }}>
+          No chats yet
+        </p>
+      )}
+
+      <div className="mt-2 flex items-center justify-between gap-2 border-t pt-2" style={{ borderColor: "var(--border-subtle)" }}>
+        <span className="inline-flex items-center gap-1 text-[10px] capitalize" style={{ color: "var(--text-tertiary)" }}>
+          <CircleDot size={10} aria-hidden="true" /> {task.priority}
+        </span>
+        <select
+          aria-label={`Move ${task.title}`}
+          value={task.status}
+          disabled={!canMoveTasks || moving}
+          onChange={(event) => {
+            const status = event.currentTarget.value as CardStatus;
+            if (status !== task.status) onMoveTask(task.id, status, task.order);
+          }}
+          className="no-drag h-7 rounded-md border bg-transparent px-2 text-[11px] capitalize outline-none disabled:opacity-50"
+          style={{ borderColor: "var(--border-default)", color: "var(--text-secondary)" }}
+        >
+          {BOARD_COLUMNS.map((status) => (
+            <option key={status} value={status}>{COLUMN_LABEL[status]}</option>
+          ))}
+        </select>
+      </div>
+    </article>
+  );
+}
+
+export function AgentKanbanBoard({
+  workspace,
+  providers,
+  selectedTaskId,
+  selectedThreadId,
+  canMoveTasks,
+  movingTaskId,
+  mutationError,
+  onSelectTask,
+  onOpenThread,
+  onMoveTask,
+}: {
+  workspace: ProjectAgentWorkspace;
+  providers: RuntimeSummary["providers"];
+  selectedTaskId: string | null;
+  selectedThreadId: string | null;
+  canMoveTasks: boolean;
+  movingTaskId: string | null;
+  mutationError: string | null;
+  onSelectTask: (taskId: string) => void;
+  onOpenThread: (threadId: string) => void;
+  onMoveTask: (taskId: string, status: CardStatus, order: number) => void;
+}) {
+  const groupedThreads = groupProjectWorkspaceThreads(workspace);
+  const visibleTasks = workspace.tasks.items.filter((task) => task.status !== "archived");
+  return (
+    <section aria-label={`${workspace.project.label} Kanban`} className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden">
+      {mutationError ? (
+        <p className="border-b px-4 py-2 text-xs" style={{ borderColor: "var(--border-subtle)", color: "var(--danger)" }}>
+          {mutationError}
+        </p>
+      ) : null}
+      <div className="flex min-h-0 flex-1 gap-4 overflow-x-auto p-4">
+        {BOARD_COLUMNS.map((status) => {
+          const tasks = visibleTasks
+            .filter((task) => task.status === status)
+            .sort((left, right) => left.order - right.order || left.id.localeCompare(right.id));
+          return (
+            <div key={status} className="flex w-[280px] shrink-0 flex-col">
+              <div className="mb-2 flex items-center gap-2 px-1">
+                <span className="h-2 w-2 rounded-full" style={{ background: COLUMN_COLOR[status] }} aria-hidden="true" />
+                <h2 className="text-sm font-semibold" style={{ color: "var(--text-primary)" }}>{COLUMN_LABEL[status]}</h2>
+                <span className="text-xs tabular-nums" style={{ color: "var(--text-tertiary)" }}>{tasks.length}</span>
+              </div>
+              <div className="space-y-2 rounded-xl bg-[var(--bg-secondary)] p-1.5">
+                {tasks.map((task) => (
+                  <TaskCard
+                    key={task.id}
+                    task={task}
+                    threads={groupedThreads.taskThreads[task.id] ?? []}
+                    providers={providers}
+                    selectedTaskId={selectedTaskId}
+                    selectedThreadId={selectedThreadId}
+                    canMoveTasks={canMoveTasks}
+                    movingTaskId={movingTaskId}
+                    onSelectTask={onSelectTask}
+                    onOpenThread={onOpenThread}
+                    onMoveTask={onMoveTask}
+                  />
+                ))}
+                {tasks.length === 0 ? (
+                  <p className="px-3 py-8 text-center text-xs" style={{ color: "var(--text-tertiary)" }}>No tasks</p>
+                ) : null}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </section>
+  );
+}
+
+export function AgentWorkspaceViewSwitch({
+  viewMode,
+  onChange,
+}: {
+  viewMode: CodingAgentWorkspaceViewMode;
+  onChange: (viewMode: CodingAgentWorkspaceViewMode) => void;
+}) {
+  return (
+    <div role="group" aria-label="Workspace view" className="inline-flex rounded-lg border p-0.5" style={{ borderColor: "var(--border-subtle)", background: "var(--bg-overlay)" }}>
+      {(["conversation", "kanban"] as const).map((mode) => (
+        <button
+          key={mode}
+          type="button"
+          aria-label={mode === "conversation" ? "Conversation" : "Kanban"}
+          aria-pressed={viewMode === mode}
+          onClick={() => onChange(mode)}
+          className="rounded-md px-3 py-1.5 text-xs font-medium capitalize outline-none transition-colors focus-visible:ring-2 focus-visible:ring-[var(--accent)]"
+          style={{
+            background: viewMode === mode ? "var(--bg-selected)" : "transparent",
+            color: viewMode === mode ? "var(--text-primary)" : "var(--text-tertiary)",
+          }}
+        >
+          {mode}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/desktop/src/renderer/src/features/coding-agents/AgentKanbanBoard.tsx
+++ b/desktop/src/renderer/src/features/coding-agents/AgentKanbanBoard.tsx
@@ -148,7 +148,10 @@ function TaskCard({
               thread={thread}
               providers={providers}
               selected={thread.id === selectedThreadId}
-              onOpen={() => onOpenThread(thread.id)}
+              onOpen={() => {
+                onSelectTask(task.id);
+                onOpenThread(thread.id);
+              }}
             />
           ))}
         </div>

--- a/desktop/src/renderer/src/features/coding-agents/AgentKanbanWorkspace.tsx
+++ b/desktop/src/renderer/src/features/coding-agents/AgentKanbanWorkspace.tsx
@@ -53,7 +53,14 @@ export function AgentKanbanWorkspace({
     try {
       await moveBoardTask(api, projectId, taskId, nextStatus, order);
       if (useCodingAgentProjectWorkspace.getState().selectedProjectId === projectId) {
-        await refreshWorkspace();
+        try {
+          await refreshWorkspace();
+        } catch (err: unknown) {
+          const failureKind = err instanceof Error ? err.name : typeof err;
+          console.warn(
+            `[coding-agents] project workspace refresh failed after task move (${failureKind})`,
+          );
+        }
       }
     } finally {
       setMovingTaskId((current) => (current === taskId ? null : current));

--- a/desktop/src/renderer/src/features/coding-agents/AgentKanbanWorkspace.tsx
+++ b/desktop/src/renderer/src/features/coding-agents/AgentKanbanWorkspace.tsx
@@ -1,0 +1,87 @@
+import { useEffect, useState } from "react";
+import type { RuntimeSummary } from "@matrix-os/contracts";
+import { AppError, toUserMessage } from "../../lib/errors";
+import { useBoard, type CardStatus } from "../../stores/board";
+import { useCodingAgentProjectWorkspace } from "../../stores/coding-agent-project-workspace";
+import { useCodingAgentWorkspace } from "../../stores/coding-agent-workspace";
+import { useConnection } from "../../stores/connection";
+import { AgentKanbanBoard } from "./AgentKanbanBoard";
+
+export function AgentKanbanWorkspace({
+  providers,
+}: {
+  providers: RuntimeSummary["providers"];
+}) {
+  const api = useConnection((state) => state.api);
+  const workspace = useCodingAgentProjectWorkspace((state) => state.workspace);
+  const selectedProjectId = useCodingAgentProjectWorkspace((state) => state.selectedProjectId);
+  const selectedTaskId = useCodingAgentProjectWorkspace((state) => state.selectedTaskId);
+  const selectedThreadId = useCodingAgentProjectWorkspace((state) => state.selectedThreadId);
+  const selectTask = useCodingAgentProjectWorkspace((state) => state.selectTask);
+  const selectThread = useCodingAgentProjectWorkspace((state) => state.selectThread);
+  const setViewMode = useCodingAgentProjectWorkspace((state) => state.setViewMode);
+  const refreshWorkspace = useCodingAgentProjectWorkspace((state) => state.refresh);
+  const loadThreadSnapshot = useCodingAgentWorkspace((state) => state.loadThreadSnapshot);
+  const cardsByProject = useBoard((state) => state.cardsByProject);
+  const boardError = useBoard((state) => state.error);
+  const selectBoardProject = useBoard((state) => state.selectProject);
+  const moveBoardTask = useBoard((state) => state.moveTask);
+  const [movingTaskId, setMovingTaskId] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!api || !workspace) return;
+    void selectBoardProject(api, workspace.project.id);
+  }, [api, selectBoardProject, workspace?.project.id]);
+
+  if (!workspace) return null;
+
+  const projectId = workspace.project.id;
+  const boardCards = selectedProjectId
+    ? cardsByProject[selectedProjectId]
+    : undefined;
+  const canMoveTasks = Boolean(
+    api
+    && boardCards
+    && workspace.tasks.items
+      .filter((task) => task.status !== "archived")
+      .every((task) => boardCards.some((card) => card.id === task.id)),
+  );
+
+  async function moveTask(taskId: string, nextStatus: CardStatus, order: number) {
+    if (!api || movingTaskId) return;
+    setMovingTaskId(taskId);
+    try {
+      await moveBoardTask(api, projectId, taskId, nextStatus, order);
+      if (useCodingAgentProjectWorkspace.getState().selectedProjectId === projectId) {
+        await refreshWorkspace();
+      }
+    } finally {
+      setMovingTaskId((current) => (current === taskId ? null : current));
+    }
+  }
+
+  function openThread(threadId: string) {
+    setViewMode("conversation");
+    selectThread(threadId);
+    if (useCodingAgentWorkspace.getState().activeThreadId !== threadId) {
+      void loadThreadSnapshot(threadId);
+    }
+  }
+
+  return (
+    <AgentKanbanBoard
+      workspace={workspace}
+      providers={providers}
+      selectedTaskId={selectedTaskId}
+      selectedThreadId={selectedThreadId}
+      canMoveTasks={canMoveTasks}
+      movingTaskId={movingTaskId}
+      mutationError={boardError ? toUserMessage(new AppError(boardError)) : null}
+      onSelectTask={selectTask}
+      onOpenThread={openThread}
+      onMoveTask={(taskId, nextStatus, order) => {
+        void moveTask(taskId, nextStatus, order);
+      }}
+    />
+  );
+}

--- a/desktop/src/renderer/src/features/coding-agents/AgentWorkspace.tsx
+++ b/desktop/src/renderer/src/features/coding-agents/AgentWorkspace.tsx
@@ -28,6 +28,8 @@ import { AgentPreviewList, AgentTerminalList } from "./AgentWorkspaceContext";
 import { AgentRuntimeHeader } from "./AgentRuntimeHeader";
 import { AgentProjectWorkspaceShell } from "./AgentProjectWorkspaceShell";
 import { AgentConversationView } from "./AgentConversationView";
+import { AgentWorkspaceViewSwitch } from "./AgentKanbanBoard";
+import { AgentKanbanWorkspace } from "./AgentKanbanWorkspace";
 import {
   AgentWorkspaceSection as Section,
   AgentWorkspaceStack,
@@ -1398,6 +1400,9 @@ export default function AgentWorkspace() {
   const loadThreadSnapshot = useCodingAgentWorkspace((s) => s.loadThreadSnapshot);
   const loadNotificationPreferences = useCodingAgentWorkspace((s) => s.loadNotificationPreferences);
   const refreshProjectWorkspace = useCodingAgentProjectWorkspace((s) => s.refresh);
+  const projectWorkspace = useCodingAgentProjectWorkspace((s) => s.workspace);
+  const viewMode = useCodingAgentProjectWorkspace((s) => s.viewMode);
+  const setViewMode = useCodingAgentProjectWorkspace((s) => s.setViewMode);
   const requestComposerFocus = useCodingAgentWorkspace((s) => s.requestComposerFocus);
   const composerFocusRequestId = useCodingAgentWorkspace((s) => s.composerFocusRequestId);
   const selectedProjectId = useCodingAgentProjectWorkspace((s) => s.selectedProjectId);
@@ -1441,6 +1446,9 @@ export default function AgentWorkspace() {
   }, [activeThreadId, loadThreadSnapshot, runtimeScope, threadSnapshot?.thread.id, threadSnapshotStatus]);
 
   const summaryScopeReady = summaryRuntimeScope === runtimeScope;
+  const kanbanEnabled = summary
+    ? capabilityEnabled(summary, "codingAgentsKanbanView")
+    : false;
 
   if (!summaryScopeReady) {
     if (status === "error") {
@@ -1501,6 +1509,8 @@ export default function AgentWorkspace() {
     requestComposerFocus();
   }
 
+  const showKanban = kanbanEnabled && viewMode === "kanban" && projectWorkspace;
+
   return (
     <div className="flex min-h-0 flex-1 flex-col">
       <AgentRuntimeHeader
@@ -1516,17 +1526,30 @@ export default function AgentWorkspace() {
         summary={summary}
         onNewChat={openNewChat}
       >
-        <div className="grid min-h-0 min-w-0 flex-1 grid-cols-1 overflow-y-auto lg:grid-cols-[minmax(360px,1fr)_minmax(340px,clamp(340px,34vw,520px))] lg:overflow-hidden">
-          <div className="flex min-h-[460px] min-w-0 flex-col overflow-hidden border-b lg:min-h-0 lg:border-b-0 lg:border-r" style={{ borderColor: "var(--border-subtle)" }}>
-            <AgentConversationView
-              status={threadSnapshotStatus}
-              snapshot={threadSnapshot}
-              error={threadSnapshotError}
-              canSendTurns={capabilityEnabled(summary, "codingAgentsSameThreadTurns")}
-            />
-          </div>
-          <aside aria-label="Conversation tools" className="min-h-0 min-w-0 overflow-y-auto" style={{ background: "var(--bg-secondary)" }}>
-            <AgentWorkspaceStack>
+        <div className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden">
+          {projectWorkspace ? (
+            <header className="flex shrink-0 items-center justify-between gap-3 border-b px-4 py-2.5" style={{ borderColor: "var(--border-subtle)", background: "var(--bg-surface)" }}>
+              <div className="min-w-0">
+                <p className="truncate text-xs font-semibold" style={{ color: "var(--text-primary)" }}>{projectWorkspace.project.label}</p>
+                <p className="text-[10px]" style={{ color: "var(--text-tertiary)" }}>{showKanban ? "Project tasks" : "Project conversations"}</p>
+              </div>
+              {kanbanEnabled ? <AgentWorkspaceViewSwitch viewMode={viewMode} onChange={setViewMode} /> : null}
+            </header>
+          ) : null}
+          {showKanban ? (
+            <AgentKanbanWorkspace providers={summary.providers} />
+          ) : (
+            <div className="grid min-h-0 min-w-0 flex-1 grid-cols-1 overflow-y-auto lg:grid-cols-[minmax(360px,1fr)_minmax(340px,clamp(340px,34vw,520px))] lg:overflow-hidden">
+              <div className="flex min-h-[460px] min-w-0 flex-col overflow-hidden border-b lg:min-h-0 lg:border-b-0 lg:border-r" style={{ borderColor: "var(--border-subtle)" }}>
+                <AgentConversationView
+                  status={threadSnapshotStatus}
+                  snapshot={threadSnapshot}
+                  error={threadSnapshotError}
+                  canSendTurns={capabilityEnabled(summary, "codingAgentsSameThreadTurns")}
+                />
+              </div>
+              <aside aria-label="Conversation tools" className="min-h-0 min-w-0 overflow-y-auto" style={{ background: "var(--bg-secondary)" }}>
+                <AgentWorkspaceStack>
               {projectWorkspaceEnabled ? (
                 <div className="flex items-center justify-between gap-3">
                   <div>
@@ -1585,8 +1608,10 @@ export default function AgentWorkspace() {
               <CreatedThreadHandleList summary={summary} />
               <ProviderList summary={summary} />
               <NotificationPreferencesPanel />
-            </AgentWorkspaceStack>
-          </aside>
+                </AgentWorkspaceStack>
+              </aside>
+            </div>
+          )}
         </div>
       </AgentProjectWorkspaceShell>
     </div>

--- a/packages/gateway/src/coding-agents/runtime-summary.ts
+++ b/packages/gateway/src/coding-agents/runtime-summary.ts
@@ -79,6 +79,8 @@ export interface CodingAgentRuntimeSummaryOptions {
   projects?: CodingAgentProjectSummaryStore;
   capabilities?: {
     projectWorkspace?: boolean;
+    conversationView?: boolean;
+    kanbanView?: boolean;
     workspace?: boolean;
     sameThreadTurns?: boolean;
     approvals?: boolean;
@@ -381,6 +383,11 @@ export function createCodingAgentRuntimeSummaryService(
       const sourceControlEnabled = options.capabilities?.sourceControl === true;
       const terminalEnabled = Boolean(options.terminalRegistry) &&
         canReadTerminalSessions(principal, options.terminalOwnerId);
+      const projectWorkspaceConfigured = options.capabilities?.projectWorkspace === true;
+      const projectWorkspaceEnabled = projectWorkspaceConfigured && projectRead.available;
+      const projectWorkspaceReason = !projectRead.available
+        ? "Project workspace is temporarily unavailable"
+        : undefined;
 
       return RuntimeSummarySchema.parse({
         runtime: {
@@ -405,14 +412,26 @@ export function createCodingAgentRuntimeSummaryService(
           capability({ id: "codingAgentsFiles", enabled: filesEnabled }),
           capability({ id: "codingAgentsSourceControl", enabled: sourceControlEnabled }),
           capability({ id: "codingAgentsNativeMobileTerminal", enabled: terminalEnabled }),
-          ...(options.capabilities?.projectWorkspace === true
-            ? [capability({
-              id: "codingAgentsProjectWorkspace",
-              enabled: projectRead.available,
-              reason: !projectRead.available
-                ? "Project workspace is temporarily unavailable"
-                : undefined,
-            })]
+          ...(projectWorkspaceConfigured
+            ? [
+                capability({
+                  id: "codingAgentsProjectWorkspace",
+                  enabled: projectWorkspaceEnabled,
+                  reason: projectWorkspaceReason,
+                }),
+                capability({
+                  id: "codingAgentsConversationView",
+                  enabled: projectWorkspaceEnabled
+                    && options.capabilities?.conversationView === true,
+                  reason: projectWorkspaceReason,
+                }),
+                capability({
+                  id: "codingAgentsKanbanView",
+                  enabled: projectWorkspaceEnabled
+                    && options.capabilities?.kanbanView === true,
+                  reason: projectWorkspaceReason,
+                }),
+              ]
             : []),
         ],
         providers,

--- a/packages/gateway/src/server.ts
+++ b/packages/gateway/src/server.ts
@@ -624,6 +624,8 @@ export async function createGateway(config: GatewayConfig) {
     previews: codingAgentPreviewSummaryStore,
     capabilities: {
       projectWorkspace: true,
+      conversationView: true,
+      kanbanView: true,
       workspace: codingAgentWorkspaceEnabled,
       sameThreadTurns: codingAgentTurnsEnabled,
       approvals: false,

--- a/specs/105-coding-agent-shells/acceptance-tests.md
+++ b/specs/105-coding-agent-shells/acceptance-tests.md
@@ -1,6 +1,6 @@
 # Acceptance Tests: Project Conversations And Kanban
 
-**Status**: Phase 18-20 backend evidence and Phase 21.1-21.2 desktop navigator/conversation evidence added; Kanban, mobile, and cross-shell evidence remains planned
+**Status**: Phase 18-20 backend evidence and Phase 21.1-21.3 desktop navigator/conversation/Kanban evidence added; mobile and cross-shell evidence remains planned
 **Updated**: 2026-07-10
 
 This matrix is the executable acceptance contract for the clarified coding-agent shell model. A task checkbox in `tasks.md` is complete only when its named test IDs have current evidence on the exact implementation head. Existing checkpoint tests remain required regressions but do not prove these new cases.
@@ -80,10 +80,10 @@ Every clarified functional requirement and buildable success criterion has at le
 | DT-005 | Selected-thread composer invokes turn IPC, not create-thread IPC. | Exact trusted-client, IPC handler, store, and conversation-component invocation tests with thread ID and bounded idempotency key. |
 | DT-006 | Busy/offline/duplicate turn outcomes keep draft/selection safely recoverable. | Store/component tests prove allowlisted copy, identical retry-key reuse, edited-message key rotation, retained draft, and stale-selection protection. |
 | DT-007 | Explicit new-chat action remains separate and can target project plus optional task. | Navigator/composer routing tests plus gateway workspace-provider coverage for server-owned worktree provisioning when the optional worktree reference is absent. |
-| DT-008 | Conversation/Kanban segmented control preserves selected project. | Component/store mode-switch test. |
-| DT-009 | Kanban uses canonical task columns/order and task mutation path. | Board integration test; no duplicate agent-only task store. |
-| DT-010 | Task card shows bounded count/active/attention aggregates and opens either attached thread. | Card/detail component tests. |
-| DT-011 | Thread status updates badges but never dispatch task movement. | Reducer/effect regression with mixed thread states. |
+| DT-008 | Conversation/Kanban segmented control preserves selected project. | `tests/desktop/coding-agent-kanban.test.tsx`, `tests/desktop/coding-agent-project-workspace-store.test.ts`, and the integrated workspace mode-switch assertion preserve project/task/thread identity. |
+| DT-009 | Kanban uses canonical task columns/order and task mutation path. | The integrated `AgentWorkspace` test joins the project projection to the existing board store and asserts the canonical `/api/projects/:slug/tasks/:taskId` PATCH; `tests/desktop/board-store.test.ts` remains the mutation source-of-truth coverage. |
+| DT-010 | Task card shows bounded count/active/attention aggregates and opens either attached thread. | `tests/desktop/coding-agent-kanban.test.tsx` renders both task chats and all three bounded aggregate types. |
+| DT-011 | Thread status updates badges but never dispatch task movement. | `tests/desktop/coding-agent-kanban.test.tsx` rerenders mixed thread state and proves no task movement callback occurs. |
 
 ## Mobile Tests
 
@@ -199,6 +199,8 @@ Current Phase 21.1 evidence on the desktop navigator slice:
 - `bun run check:patterns`
 - `bun run build:desktop`
 - `pnpm exec vitest run tests/e2e/desktop/operator.e2e.test.ts`
+- Built-app screenshots: `desktop/screenshots/04b-agents-kanban.png` and
+  `desktop/screenshots/04c-agents-kanban-narrow.png`
 
 These checks prove `DT-001` through `DT-004` and the desktop portion of
 `SEC-003`. The integrated desktop tests additionally preserve external thread
@@ -219,7 +221,22 @@ These checks prove `DT-005` through `DT-007`: selected conversations replay
 gateway-owned user/assistant activity, the same-thread composer crosses strict
 trusted IPC, busy/offline retry state stays recoverable without exposing raw
 errors, and new-chat worktree creation remains a server-owned lifecycle. The
-Kanban and cross-shell cases remain open.
+cross-shell cases remain open.
+
+Current Phase 21.3 evidence on the desktop Kanban slice:
+
+- `pnpm exec vitest run tests/desktop/coding-agent-kanban.test.tsx tests/desktop/coding-agent-project-workspace-store.test.ts tests/desktop/coding-agent-workspace.test.tsx tests/desktop/board-store.test.ts`
+- `pnpm --filter desktop run typecheck`
+- `bun run typecheck`
+- `bun run check:patterns`
+- `bun run build:desktop`
+- `pnpm exec vitest run tests/e2e/desktop/operator.e2e.test.ts`
+
+These checks prove `DT-008` through `DT-011`: the view switch preserves the
+selected project/task/chat references, the board renders canonical columns and
+bounded multi-chat aggregates, task moves reuse the existing canonical task
+store and route, opening a card chat returns to the same conversation, and
+thread state alone cannot mutate task status.
 
 Gateway/contract PRs additionally run the exact focused Vitest files named in their PR body. Desktop UI PRs run the operator E2E and screenshot checks. Mobile UI PRs run the SDK 57 dev-client device smoke before their rollout gate. `vp` commands may be reported unavailable, but they are not silently substituted for repository commands.
 

--- a/specs/105-coding-agent-shells/tasks.md
+++ b/specs/105-coding-agent-shells/tasks.md
@@ -1,6 +1,6 @@
 # Tasks: Coding Agent Shells
 
-**Status**: Backend Phases 18-20 and desktop Phase 21.1-21.2 implemented; Phase 21.3-21.5 shell implementation next; real-process Gate 3 smoke pending
+**Status**: Backend Phases 18-20 and desktop Phase 21 implemented; mobile Phase 22, cross-shell Phase 23, and real-process Gate 3 smoke remain pending
 **Lineage**: foundation merged through the recorded implementation checkpoint; clarified follow-up is specified against current `main`
 **Rule**: Preserve all existing desktop and mobile functionality. Add coding-agent capabilities incrementally behind contracts, tests, and feature flags.
 
@@ -1201,21 +1201,28 @@ Evidence: strict turn IPC/client/handler tests, server-authoritative
 `user.message` replay coverage, retry/idempotency and selection-race store tests,
 durable chat-bubble/component tests, workspace-provider auto-provisioning tests,
 the full focused desktop workspace regression, and desktop typecheck are recorded
-in `acceptance-tests.md`. Kanban remains open in 21.3.
+in `acceptance-tests.md`. Kanban evidence is recorded separately in 21.3.
 
 ### 21.3 Kanban View
 
-- [ ] Add segmented Conversation/Kanban control.
-- [ ] Reuse canonical task columns/order/mutations.
-- [ ] Show bounded thread count, active count, and attention count on task cards.
-- [ ] Open all task threads from a card and preserve selected identity when switching modes.
-- [ ] Never auto-move task status from thread reducer/effects.
+- [x] Add segmented Conversation/Kanban control.
+- [x] Reuse canonical task columns/order/mutations.
+- [x] Show bounded thread count, active count, and attention count on task cards.
+- [x] Open all task threads from a card and preserve selected identity when switching modes.
+- [x] Never auto-move task status from thread reducer/effects.
 
 Tests: `DT-008`, `DT-009`, `DT-010`, `DT-011`.
 
+Evidence: focused Kanban component, project-workspace store, integrated desktop
+workspace, and canonical board-store coverage prove the five visible task
+columns, hidden archived tasks, bounded thread aggregates, explicit task PATCH
+path, multi-chat selection, cross-view identity continuity, and the absence of
+thread-driven task movement. Surface validation is recorded in
+`acceptance-tests.md`.
+
 Gate:
 
-- [ ] Desktop typecheck, focused Vitest, operator E2E, Canvas/Desktop regression, pattern scan, and screenshot checks pass.
+- [x] Desktop typecheck, focused Vitest, operator E2E, Canvas/Desktop regression, pattern scan, and screenshot checks pass.
 
 ## Phase 22 - Mobile Project Conversation And Kanban
 

--- a/tests/desktop/coding-agent-kanban.test.tsx
+++ b/tests/desktop/coding-agent-kanban.test.tsx
@@ -1,0 +1,210 @@
+// @vitest-environment jsdom
+
+import React from "react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { ProjectAgentWorkspace, RuntimeSummary } from "@matrix-os/contracts";
+import {
+  AgentKanbanBoard,
+  AgentWorkspaceViewSwitch,
+} from "../../desktop/src/renderer/src/features/coding-agents/AgentKanbanBoard";
+
+const NOW = "2026-07-10T12:00:00.000Z";
+
+function thread(id: string, taskId: string, overrides: Record<string, unknown> = {}) {
+  return {
+    id,
+    providerId: "codex",
+    title: id === "thread_one" ? "Implement the route" : "Add regression coverage",
+    status: "completed" as const,
+    attention: "completed" as const,
+    projectId: "matrix-os",
+    taskId,
+    createdAt: NOW,
+    updatedAt: NOW,
+    ...overrides,
+  };
+}
+
+function workspace(): ProjectAgentWorkspace {
+  return {
+    project: {
+      id: "matrix-os",
+      label: "Matrix OS",
+      status: "available",
+      taskCount: 3,
+      threadCount: 2,
+      attentionCount: 1,
+    },
+    tasks: {
+      items: [
+        {
+          id: "task_auth",
+          projectId: "matrix-os",
+          title: "Desktop auth",
+          status: "todo",
+          priority: "high",
+          order: 2,
+          threadCount: 2,
+          activeThreadCount: 1,
+          attentionCount: 1,
+          latestThreadAt: NOW,
+        },
+        {
+          id: "task_release",
+          projectId: "matrix-os",
+          title: "Release checks",
+          status: "complete",
+          priority: "normal",
+          order: 1,
+          threadCount: 0,
+          activeThreadCount: 0,
+          attentionCount: 0,
+        },
+        {
+          id: "task_archived",
+          projectId: "matrix-os",
+          title: "Archived task",
+          status: "archived",
+          priority: "low",
+          order: 0,
+          threadCount: 0,
+          activeThreadCount: 0,
+          attentionCount: 0,
+        },
+      ],
+      hasMore: false,
+      limit: 100,
+    },
+    projectThreads: { items: [], hasMore: false, limit: 100 },
+    taskThreads: {
+      items: [thread("thread_one", "task_auth"), thread("thread_two", "task_auth")],
+      hasMore: false,
+      limit: 100,
+    },
+    updatedAt: NOW,
+  };
+}
+
+const providers: RuntimeSummary["providers"] = [{
+  id: "codex",
+  kind: "codex",
+  displayName: "Codex",
+  availability: "available",
+  installStatus: "installed",
+  authStatus: "authenticated",
+  supportedModes: ["default"],
+  defaultMode: "default",
+  setupActions: [],
+}];
+
+describe("AgentKanbanBoard", () => {
+  afterEach(cleanup);
+
+  it("renders canonical columns, hides archived tasks, and exposes bounded aggregates", () => {
+    render(
+      <AgentKanbanBoard
+        workspace={workspace()}
+        providers={providers}
+        selectedTaskId="task_auth"
+        selectedThreadId="thread_one"
+        canMoveTasks
+        movingTaskId={null}
+        mutationError={null}
+        onSelectTask={vi.fn()}
+        onOpenThread={vi.fn()}
+        onMoveTask={vi.fn()}
+      />,
+    );
+
+    for (const label of ["Todo", "Running", "Waiting", "Blocked", "Complete"]) {
+      expect(screen.getByRole("heading", { name: label })).toBeTruthy();
+    }
+    expect(screen.queryByText("Archived task")).toBeNull();
+    expect(screen.getByText("2 chats")).toBeTruthy();
+    expect(screen.getByText("1 active")).toBeTruthy();
+    expect(screen.getByText("1 needs attention")).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Open chat Implement the route" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Open chat Add regression coverage" })).toBeTruthy();
+  });
+
+  it("opens either attached chat and moves only through the explicit canonical task action", () => {
+    const onOpenThread = vi.fn();
+    const onMoveTask = vi.fn();
+    render(
+      <AgentKanbanBoard
+        workspace={workspace()}
+        providers={providers}
+        selectedTaskId="task_auth"
+        selectedThreadId="thread_one"
+        canMoveTasks
+        movingTaskId={null}
+        mutationError={null}
+        onSelectTask={vi.fn()}
+        onOpenThread={onOpenThread}
+        onMoveTask={onMoveTask}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Open chat Add regression coverage" }));
+    expect(onOpenThread).toHaveBeenCalledWith("thread_two");
+
+    fireEvent.change(screen.getByLabelText("Move Desktop auth"), {
+      target: { value: "blocked" },
+    });
+    expect(onMoveTask).toHaveBeenCalledWith("task_auth", "blocked", 2);
+  });
+
+  it("does not move a task when only an attached thread status changes", () => {
+    const onMoveTask = vi.fn();
+    const view = render(
+      <AgentKanbanBoard
+        workspace={workspace()}
+        providers={providers}
+        selectedTaskId="task_auth"
+        selectedThreadId="thread_one"
+        canMoveTasks
+        movingTaskId={null}
+        mutationError={null}
+        onSelectTask={vi.fn()}
+        onOpenThread={vi.fn()}
+        onMoveTask={onMoveTask}
+      />,
+    );
+    const updated = workspace();
+    updated.taskThreads.items[0] = thread("thread_one", "task_auth", {
+      status: "running",
+      attention: "approval_required",
+    });
+
+    view.rerender(
+      <AgentKanbanBoard
+        workspace={updated}
+        providers={providers}
+        selectedTaskId="task_auth"
+        selectedThreadId="thread_one"
+        canMoveTasks
+        movingTaskId={null}
+        mutationError={null}
+        onSelectTask={vi.fn()}
+        onOpenThread={vi.fn()}
+        onMoveTask={onMoveTask}
+      />,
+    );
+
+    expect(onMoveTask).not.toHaveBeenCalled();
+  });
+});
+
+describe("AgentWorkspaceViewSwitch", () => {
+  afterEach(cleanup);
+
+  it("switches modes without owning or rewriting project, task, or thread identity", () => {
+    const onChange = vi.fn();
+    render(<AgentWorkspaceViewSwitch viewMode="conversation" onChange={onChange} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Kanban" }));
+
+    expect(onChange).toHaveBeenCalledWith("kanban");
+  });
+});

--- a/tests/desktop/coding-agent-kanban.test.tsx
+++ b/tests/desktop/coding-agent-kanban.test.tsx
@@ -1,13 +1,18 @@
 // @vitest-environment jsdom
 
 import React from "react";
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { ProjectAgentWorkspace, RuntimeSummary } from "@matrix-os/contracts";
 import {
   AgentKanbanBoard,
   AgentWorkspaceViewSwitch,
 } from "../../desktop/src/renderer/src/features/coding-agents/AgentKanbanBoard";
+import { AgentKanbanWorkspace } from "../../desktop/src/renderer/src/features/coding-agents/AgentKanbanWorkspace";
+import type { ApiClient } from "../../desktop/src/renderer/src/lib/api";
+import { useBoard } from "../../desktop/src/renderer/src/stores/board";
+import { useCodingAgentProjectWorkspace } from "../../desktop/src/renderer/src/stores/coding-agent-project-workspace";
+import { useConnection } from "../../desktop/src/renderer/src/stores/connection";
 
 const NOW = "2026-07-10T12:00:00.000Z";
 
@@ -129,24 +134,26 @@ describe("AgentKanbanBoard", () => {
   });
 
   it("opens either attached chat and moves only through the explicit canonical task action", () => {
+    const onSelectTask = vi.fn();
     const onOpenThread = vi.fn();
     const onMoveTask = vi.fn();
     render(
       <AgentKanbanBoard
         workspace={workspace()}
         providers={providers}
-        selectedTaskId="task_auth"
+        selectedTaskId="task_release"
         selectedThreadId="thread_one"
         canMoveTasks
         movingTaskId={null}
         mutationError={null}
-        onSelectTask={vi.fn()}
+        onSelectTask={onSelectTask}
         onOpenThread={onOpenThread}
         onMoveTask={onMoveTask}
       />,
     );
 
     fireEvent.click(screen.getByRole("button", { name: "Open chat Add regression coverage" }));
+    expect(onSelectTask).toHaveBeenCalledWith("task_auth");
     expect(onOpenThread).toHaveBeenCalledWith("thread_two");
 
     fireEvent.change(screen.getByLabelText("Move Desktop auth"), {
@@ -193,6 +200,67 @@ describe("AgentKanbanBoard", () => {
     );
 
     expect(onMoveTask).not.toHaveBeenCalled();
+  });
+});
+
+describe("AgentKanbanWorkspace", () => {
+  afterEach(() => {
+    cleanup();
+    useBoard.setState(useBoard.getInitialState(), true);
+    useCodingAgentProjectWorkspace.setState(
+      useCodingAgentProjectWorkspace.getInitialState(),
+      true,
+    );
+    useConnection.setState(useConnection.getInitialState(), true);
+    vi.restoreAllMocks();
+  });
+
+  it("contains projection refresh failures after a successful canonical task move", async () => {
+    const refresh = vi.fn().mockRejectedValue(new Error("private upstream detail"));
+    const moveTask = vi.fn().mockResolvedValue(undefined);
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    useConnection.setState({ api: {} as ApiClient });
+    useCodingAgentProjectWorkspace.setState({
+      workspace: workspace(),
+      selectedProjectId: "matrix-os",
+      selectedTaskId: "task_auth",
+      selectedThreadId: "thread_one",
+      refresh,
+    });
+    useBoard.setState({
+      cardsByProject: {
+        "matrix-os": workspace().tasks.items.map((task) => ({
+          id: task.id,
+          projectSlug: task.projectId,
+          title: task.title,
+          description: "",
+          status: task.status,
+          priority: task.priority,
+          order: task.order,
+          parentTaskId: null,
+          linkedSessionId: null,
+          linkedWorktreeId: null,
+          previewIds: [],
+          tags: [],
+          updatedAt: null,
+          revision: null,
+        })),
+      },
+      selectProject: vi.fn().mockResolvedValue(undefined),
+      moveTask,
+      error: null,
+    });
+
+    render(<AgentKanbanWorkspace providers={providers} />);
+    fireEvent.change(screen.getByLabelText("Move Desktop auth"), {
+      target: { value: "blocked" },
+    });
+
+    await waitFor(() => expect(moveTask).toHaveBeenCalled());
+    await waitFor(() => expect(refresh).toHaveBeenCalled());
+    await waitFor(() => expect(warn).toHaveBeenCalledWith(
+      "[coding-agents] project workspace refresh failed after task move (Error)",
+    ));
   });
 });
 

--- a/tests/desktop/coding-agent-project-workspace-store.test.ts
+++ b/tests/desktop/coding-agent-project-workspace-store.test.ts
@@ -525,4 +525,42 @@ describe("coding-agent project workspace store", () => {
       selectedThreadId: "thread_outside_page",
     });
   });
+
+  it("DT-008 switches view mode without changing project, task, or chat identity", () => {
+    const invoke = vi.fn().mockResolvedValue({ ok: true });
+    Object.defineProperty(window, "operator", {
+      configurable: true,
+      value: { invoke, on: vi.fn(() => () => undefined) },
+    });
+    useCodingAgentProjectWorkspace.setState({
+      status: "ready",
+      runtimeId: "rt_primary",
+      runtimeScope: "operator|https://app.matrix-os.com|primary",
+      summary: summary("rt_primary", "matrix-os", "Matrix OS"),
+      workspace: workspace("matrix-os", "task_auth", "thread_plan"),
+      selectedProjectId: "matrix-os",
+      selectedTaskId: "task_auth",
+      selectedThreadId: "thread_plan",
+      viewMode: "conversation",
+    });
+
+    useCodingAgentProjectWorkspace.getState().setViewMode("kanban");
+
+    expect(useCodingAgentProjectWorkspace.getState()).toMatchObject({
+      selectedProjectId: "matrix-os",
+      selectedTaskId: "task_auth",
+      selectedThreadId: "thread_plan",
+      viewMode: "kanban",
+    });
+    expect(invoke).toHaveBeenCalledWith("state:set", {
+      key: "codingAgentWorkspace",
+      value: expect.objectContaining({
+        runtimeScope: "operator|https://app.matrix-os.com|primary",
+        selectedProjectId: "matrix-os",
+        selectedTaskId: "task_auth",
+        selectedThreadId: "thread_plan",
+        viewMode: "kanban",
+      }),
+    });
+  });
 });

--- a/tests/desktop/coding-agent-workspace.test.tsx
+++ b/tests/desktop/coding-agent-workspace.test.tsx
@@ -9,6 +9,8 @@ import AgentWorkspace, {
 } from "../../desktop/src/renderer/src/features/coding-agents/AgentWorkspace";
 import { useCodingAgentWorkspace } from "../../desktop/src/renderer/src/stores/coding-agent-workspace";
 import { useCodingAgentProjectWorkspace } from "../../desktop/src/renderer/src/stores/coding-agent-project-workspace";
+import type { ApiClient } from "../../desktop/src/renderer/src/lib/api";
+import { useBoard } from "../../desktop/src/renderer/src/stores/board";
 import { useConnection } from "../../desktop/src/renderer/src/stores/connection";
 import { useTabs } from "../../desktop/src/renderer/src/stores/tabs";
 
@@ -664,6 +666,7 @@ function multiInputAnsweredThreadSnapshotFixture(inputRequestId: string, correla
 
 describe("AgentWorkspace", () => {
   beforeEach(() => {
+    useBoard.setState(useBoard.getInitialState(), true);
     useCodingAgentProjectWorkspace.setState({
       status: "idle",
       runtimeId: null,
@@ -884,6 +887,7 @@ describe("AgentWorkspace", () => {
         ...baseSummary.capabilities,
         { id: "codingAgentsProjectWorkspace", enabled: true },
         { id: "codingAgentsConversationView", enabled: true },
+        { id: "codingAgentsKanbanView", enabled: true },
       ],
       projects: {
         items: [
@@ -955,6 +959,38 @@ describe("AgentWorkspace", () => {
       resolveManualSummary = resolve;
     });
     let summaryRequestCount = 0;
+    const taskWire = {
+      id: "task_auth",
+      projectSlug: "matrix-os",
+      title: "Harden authentication",
+      description: "",
+      status: "running",
+      priority: "high",
+      order: 0,
+      parentTaskId: null,
+      linkedSessionId: null,
+      linkedWorktreeId: null,
+      previewIds: [],
+      tags: [],
+      updatedAt: "2026-07-10T12:00:00.000Z",
+      revision: 1,
+    };
+    const taskGet = vi.fn().mockResolvedValue({ tasks: [taskWire], nextCursor: null });
+    const taskPatch = vi.fn().mockResolvedValue({
+      task: { ...taskWire, status: "blocked", revision: 2 },
+    });
+    useConnection.setState({
+      api: {
+        baseUrl: "https://platform.test",
+        get: taskGet,
+        getText: vi.fn(),
+        post: vi.fn(),
+        patch: taskPatch,
+        put: vi.fn(),
+        delete: vi.fn(),
+        putText: vi.fn(),
+      } as unknown as ApiClient,
+    });
     window.operator.invoke = vi.fn((channel: string, payload?: unknown) => {
       if (channel === "runtime:get-summary") {
         summaryRequestCount += 1;
@@ -998,6 +1034,27 @@ describe("AgentWorkspace", () => {
       { name: "Chat Audit architecture" },
     )).toBeTruthy();
 
+    const identityBeforeKanban = {
+      selectedProjectId: useCodingAgentProjectWorkspace.getState().selectedProjectId,
+      selectedTaskId: useCodingAgentProjectWorkspace.getState().selectedTaskId,
+      selectedThreadId: useCodingAgentProjectWorkspace.getState().selectedThreadId,
+    };
+    fireEvent.click(screen.getByRole("button", { name: "Kanban" }));
+    expect(await screen.findByRole("region", { name: "Matrix OS Kanban" })).toBeTruthy();
+    expect(useCodingAgentProjectWorkspace.getState()).toMatchObject(identityBeforeKanban);
+    await waitFor(() => expect(taskGet).toHaveBeenCalledWith(
+      "/api/projects/matrix-os/tasks?limit=100",
+    ));
+    const move = screen.getByLabelText("Move Harden authentication") as HTMLSelectElement;
+    await waitFor(() => expect(move.disabled).toBe(false));
+    fireEvent.change(move, { target: { value: "blocked" } });
+    await waitFor(() => expect(taskPatch).toHaveBeenCalledWith(
+      "/api/projects/matrix-os/tasks/task_auth",
+      { status: "blocked", order: 0 },
+    ));
+    fireEvent.click(screen.getByRole("button", { name: "Conversation" }));
+    expect(useCodingAgentProjectWorkspace.getState()).toMatchObject(identityBeforeKanban);
+
     await act(async () => {
       await useCodingAgentWorkspace.getState().refresh();
     });
@@ -1009,7 +1066,7 @@ describe("AgentWorkspace", () => {
     });
     expect(vi.mocked(window.operator.invoke).mock.calls.filter(
       ([channel]) => channel === "runtime:get-project-workspace",
-    )).toHaveLength(1);
+    )).toHaveLength(2);
 
     fireEvent.click(screen.getByRole("button", { name: "Refresh agent workspace" }));
     await waitFor(() => {
@@ -1020,14 +1077,14 @@ describe("AgentWorkspace", () => {
     });
     expect(vi.mocked(window.operator.invoke).mock.calls.filter(
       ([channel]) => channel === "runtime:get-project-workspace",
-    )).toHaveLength(1);
+    )).toHaveLength(2);
 
     resolveManualSummary(summary);
     await waitFor(() => {
       const workspaceRequests = vi.mocked(window.operator.invoke).mock.calls.filter(
         ([channel]) => channel === "runtime:get-project-workspace",
       );
-      expect(workspaceRequests).toHaveLength(2);
+      expect(workspaceRequests).toHaveLength(3);
     });
     await waitFor(() => {
       expect(useCodingAgentWorkspace.getState().activeThreadId).toBe("thread_audit");

--- a/tests/e2e/desktop/fixtures/stub-gateway.ts
+++ b/tests/e2e/desktop/fixtures/stub-gateway.ts
@@ -23,6 +23,7 @@ export interface StubGateway {
     terminalInputs: string[];
     kernelMessages: Array<Record<string, unknown>>;
     codingAgentCreates: Array<Record<string, unknown>>;
+    taskUpdates: Array<Record<string, unknown>>;
   };
 }
 
@@ -54,7 +55,7 @@ async function readBody(req: IncomingMessage): Promise<Record<string, unknown>> 
 
 const TASKS = [
   {
-    id: "task-1",
+    id: "task_auth",
     projectSlug: "matrix-os",
     title: "Fix the failing auth tests",
     description: "",
@@ -70,7 +71,7 @@ const TASKS = [
     revision: 1,
   },
   {
-    id: "task-2",
+    id: "task_polish",
     projectSlug: "matrix-os",
     title: "Polish the board design",
     description: "",
@@ -120,7 +121,9 @@ function codingAgentTaskThread(
   };
 }
 
-export function codingAgentProjectWorkspace(): ProjectAgentWorkspace {
+export function codingAgentProjectWorkspace(tasks = TASKS): ProjectAgentWorkspace {
+  const authTask = tasks.find((task) => task.id === "task_auth") ?? TASKS[0];
+  const polishTask = tasks.find((task) => task.id === "task_polish") ?? TASKS[1];
   return ProjectAgentWorkspaceSchema.parse({
     project: {
       id: "matrix-os",
@@ -137,26 +140,26 @@ export function codingAgentProjectWorkspace(): ProjectAgentWorkspace {
           id: "task_auth",
           projectId: "matrix-os",
           title: "Fix the failing auth tests",
-          status: "todo",
+          status: authTask.status,
           priority: "high",
           order: 0,
           threadCount: 2,
           activeThreadCount: 1,
           attentionCount: 0,
           latestThreadAt: NOW,
-          revision: 1,
+          revision: authTask.revision,
         },
         {
           id: "task_polish",
           projectId: "matrix-os",
           title: "Polish the board design",
-          status: "running",
+          status: polishTask.status,
           priority: "normal",
           order: 1,
           threadCount: 0,
           activeThreadCount: 0,
           attentionCount: 0,
-          revision: 1,
+          revision: polishTask.revision,
         },
       ],
       hasMore: false,
@@ -260,6 +263,9 @@ export function codingAgentSummary(): RuntimeSummary {
       { id: "codingAgentsRuntimeSummary", enabled: true },
       { id: "codingAgentsDesktopWorkspace", enabled: true },
       { id: "codingAgentsProjectWorkspace", enabled: true },
+      { id: "codingAgentsConversationView", enabled: true },
+      { id: "codingAgentsKanbanView", enabled: true },
+      { id: "codingAgentsSameThreadTurns", enabled: true },
       { id: "codingAgentsThreadCreate", enabled: true },
       { id: "codingAgentsNativeMobileTerminal", enabled: true },
     ],
@@ -336,12 +342,14 @@ export function codingAgentSummary(): RuntimeSummary {
 }
 
 export async function startStubGateway(): Promise<StubGateway> {
+  const tasks = TASKS.map((task) => ({ ...task, tags: [...task.tags] }));
   const state: StubGateway["state"] = {
     deviceCodeRequests: 0,
     tokenRequests: 0,
     terminalInputs: [],
     kernelMessages: [],
     codingAgentCreates: [],
+    taskUpdates: [],
   };
 
   const server: Server = createServer((req, res) => {
@@ -419,21 +427,29 @@ export async function startStubGateway(): Promise<StubGateway> {
       return;
     }
     if (path === "/api/projects/matrix-os/tasks" && req.method === "GET") {
-      json(res, 200, { tasks: TASKS, nextCursor: null });
+      json(res, 200, { tasks, nextCursor: null });
       return;
     }
     if (path.startsWith("/api/projects/matrix-os/tasks/") && req.method === "PATCH") {
       const id = path.split("/").pop();
       const body = await readBody(req);
-      const task = TASKS.find((t) => t.id === id);
-      json(res, 200, { task: { ...(task ?? TASKS[0]), ...body } });
+      const task = tasks.find((candidate) => candidate.id === id);
+      if (!task) {
+        json(res, 404, { error: "not found" });
+        return;
+      }
+      const status = typeof body.status === "string" ? body.status : task.status;
+      const order = typeof body.order === "number" ? body.order : task.order;
+      Object.assign(task, { status, order, revision: task.revision + 1 });
+      state.taskUpdates.push({ taskId: task.id, ...body });
+      json(res, 200, { task });
       return;
     }
     if (path === "/api/projects/matrix-os/tasks" && req.method === "POST") {
       const body = await readBody(req);
       json(res, 201, {
         task: {
-          ...TASKS[0],
+          ...tasks[0],
           id: `task-${Date.now()}`,
           title: typeof body.title === "string" ? body.title : "New task",
           status: typeof body.status === "string" ? body.status : "todo",
@@ -462,7 +478,7 @@ export async function startStubGateway(): Promise<StubGateway> {
       req.method === "GET"
       && path === "/api/coding-agents/projects/matrix-os/workspace"
     ) {
-      json(res, 200, codingAgentProjectWorkspace());
+      json(res, 200, codingAgentProjectWorkspace(tasks));
       return;
     }
     if (req.method === "GET" && path === "/api/coding-agents/notification-preferences") {

--- a/tests/e2e/desktop/operator.e2e.test.ts
+++ b/tests/e2e/desktop/operator.e2e.test.ts
@@ -98,6 +98,25 @@ suite("operator desktop e2e", () => {
     await page.getByRole("button", { name: "Chat Investigate auth callback" }).waitFor();
     await page.getByRole("button", { name: "Chat Verify token refresh" }).waitFor();
     await page.screenshot({ path: join(SCREENSHOT_DIR, "04-agents-project-navigator.png") });
+
+    await page.getByRole("button", { name: "Kanban" }).click();
+    await page.getByRole("region", { name: "Matrix OS Kanban" }).waitFor();
+    await page.getByRole("button", { name: "Open chat Investigate auth callback" }).waitFor();
+    await page.getByRole("button", { name: "Open chat Verify token refresh" }).waitFor();
+    await page.screenshot({ path: join(SCREENSHOT_DIR, "04b-agents-kanban.png") });
+
+    await page.setViewportSize({ width: 820, height: 720 });
+    await page.getByRole("region", { name: "Matrix OS Kanban" }).waitFor();
+    await page.getByRole("button", { name: "Open chat Investigate auth callback" }).waitFor();
+    await page.screenshot({ path: join(SCREENSHOT_DIR, "04c-agents-kanban-narrow.png") });
+    await page.setViewportSize({ width: 1280, height: 720 });
+
+    await page.getByLabel("Move Fix the failing auth tests").selectOption("blocked");
+    await expect.poll(() => gateway.state.taskUpdates.length).toBe(1);
+    expect(gateway.state.taskUpdates[0]).toMatchObject({ taskId: "task_auth", status: "blocked" });
+
+    await page.getByRole("button", { name: "Conversation" }).click();
+    await page.getByRole("region", { name: "Conversation Fix the failing auth tests" }).waitFor();
   }, 30_000);
 
   it("starts an agent thread from the Agents workspace composer", async () => {

--- a/tests/gateway/coding-agents-summary.test.ts
+++ b/tests/gateway/coding-agents-summary.test.ts
@@ -317,7 +317,13 @@ describe("coding agent runtime summary", () => {
       threads: {
         listThreads: async () => ({ items: [], hasMore: false, limit: 50 }),
       },
+      projects: {
+        listProjectSummaries: async () => ({ items: [], hasMore: false, limit: 50 }),
+      },
       capabilities: {
+        projectWorkspace: true,
+        conversationView: true,
+        kanbanView: true,
         workspace: true,
         approvals: true,
         sameThreadTurns: true,
@@ -334,6 +340,9 @@ describe("coding agent runtime summary", () => {
       expect.objectContaining({ id: "codingAgentsMobileWorkspace", enabled: true }),
       expect.objectContaining({ id: "codingAgentsThreadCreate", enabled: true }),
       expect.objectContaining({ id: "codingAgentsSameThreadTurns", enabled: true }),
+      expect.objectContaining({ id: "codingAgentsProjectWorkspace", enabled: true }),
+      expect.objectContaining({ id: "codingAgentsConversationView", enabled: true }),
+      expect.objectContaining({ id: "codingAgentsKanbanView", enabled: true }),
       expect.objectContaining({ id: "codingAgentsApprovals", enabled: true }),
       expect.objectContaining({ id: "codingAgentsNativeMobileTerminal", enabled: true }),
     ]));

--- a/www/content/docs/coding-agents.mdx
+++ b/www/content/docs/coding-agents.mdx
@@ -42,6 +42,15 @@ conversation. Matrix records accepted user messages on the gateway, so a
 refresh or another desktop session replays the same conversation instead of
 reconstructing it from local UI state.
 
+Switch the selected project between **Conversation** and **Kanban** without
+changing the selected task or chat. Kanban uses the same Matrix task records as
+the rest of the desktop app: Todo, Running, Waiting, Blocked, and Complete.
+Archived tasks stay out of the normal board. Each card shows bounded chat,
+active-run, and attention counts and lists every attached chat in the current
+project projection. Opening one of those chats returns to its exact
+conversation. Moving a task updates its canonical task status; agent thread
+status never moves a card automatically.
+
 ## Supported agents
 
 Four coding agents are supported:


### PR DESCRIPTION
## Summary

- add a segmented Conversation/Kanban view over the same selected project
- render canonical Matrix task columns with bounded chat, active, and attention counts
- expose every task chat as an independently reopenable row without deriving task status from thread state
- move tasks through the existing canonical board store and refresh the gateway-owned project projection after success
- preserve selected project, task, thread, and view mode across switching and hydration
- emit the authoritative Conversation/Kanban capability flags from the production gateway when project projection is available
- add desktop and 820px packaged-app coverage plus Phase 21 docs and acceptance evidence

This is stack layer 3 of 3 and targets `105-coding-agent-desktop-conversation-view`.

## Tests

- `pnpm exec vitest run tests/desktop/coding-agent-kanban.test.tsx tests/desktop/coding-agent-project-workspace-store.test.ts tests/desktop/coding-agent-workspace.test.tsx tests/desktop/board-store.test.ts` (122 passed)
- `pnpm exec vitest run tests/gateway/coding-agents-summary.test.ts tests/gateway/coding-agents-project-summary.test.ts tests/contracts/coding-agent-project-conversations.test.ts` (67 passed)
- `pnpm exec vitest run tests/gateway/coding-agents-project-workspace.test.ts tests/contracts/coding-agent-project-conversations.test.ts tests/desktop/coding-agent-project-workspace.test.ts tests/desktop/coding-agent-runtime-client.test.ts` (46 passed)
- `pnpm --filter desktop run typecheck`
- `bun run typecheck`
- `bun run check:patterns` (zero violations; repository baseline warnings only)
- `bun run build:desktop`
- `pnpm exec vitest run tests/e2e/desktop/operator.e2e.test.ts` (7 passed; desktop and narrow screenshots inspected)
- `bun run test` was attempted and stopped after unrelated suites cascaded on the local Node 26 vs Node 24 native-module ABI mismatch and unavailable global `localStorage`; exact-head Linux CI remains the broad-suite gate

## Review / Monitoring

- exact-head review feedback for rejected projection refreshes, cross-card task identity, and production capability wiring is fixed with regressions
- Greptile must reach 5/5 on the latest exact head before `ready-for-ci` is added
- unresolved review threads and exact-head CI failures will be fixed on this branch

## Invariants

- **Source of truth:** task status/order remain owned by the canonical gateway task route and existing board store; the project workspace response and runtime capabilities remain authoritative for project/task/thread projection and view availability
- **Lock/transaction scope:** this PR adds no database writes; task mutations retain the existing per-task serialized client request path and gateway write semantics
- **Acceptable orphan states:** a successful task mutation followed by a failed projection refresh may leave the displayed projection stale until the next refresh, but is contained and does not create or duplicate task/thread records
- **Auth source of truth:** renderer requests continue through the existing authenticated desktop network layer; no bearer or provider credentials enter renderer state or persistence
- **Deferred scope:** native computer selection, contextual inspector polish, mobile views, cross-shell acceptance, and real-provider smoke are outside this stack layer



## Review notes

- Greptile round on the restacked head flagged that a failed post-move workspace refresh clears the Kanban projection at this point in the stack. That behavior is fixed at the top of this same train (#1000): stale-while-revalidate refresh, same-project retention on failure, live-selection application at settle, and a stale-board retry strip. The train merges together via the Graphite queue, so the merged main includes the fix.
