### PR TITLE
feat(desktop): add native computer picker

### DIFF
--- a/desktop/src/renderer/src/features/embeds/EmbedHost.tsx
+++ b/desktop/src/renderer/src/features/embeds/EmbedHost.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from "react";
 import { Button } from "../../design/primitives";
 import { invoke, onEvent } from "../../lib/operator";
+import { useConnection } from "../../stores/connection";
 
 // Hosts a main-process WebContentsView positioned over this element's rect.
 // The remote content renders in an isolated partition with no IPC access.
@@ -16,6 +17,7 @@ export default function EmbedHost({
   slug?: string;
   active?: boolean;
 }) {
+  const runtimeSlot = useConnection((connection) => connection.runtimeSlot);
   const hostRef = useRef<HTMLDivElement>(null);
   const embedIdRef = useRef<string | null>(null);
   const activeRef = useRef(active);
@@ -41,6 +43,7 @@ export default function EmbedHost({
   useEffect(() => {
     const host = hostRef.current;
     if (!host) return;
+    setState("loading");
     let disposed = false;
     let offState: (() => void) | null = null;
     const pendingStates = new Map<string, typeof state>();
@@ -95,7 +98,7 @@ export default function EmbedHost({
       if (id) void invoke("embed:close", { embedId: id });
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [kind, slug]);
+  }, [kind, slug, runtimeSlot]);
 
   // Attach/detach the native view as the hosting tab activates/deactivates.
   useEffect(() => {

--- a/desktop/src/renderer/src/features/settings/SettingsView.tsx
+++ b/desktop/src/renderer/src/features/settings/SettingsView.tsx
@@ -37,7 +37,7 @@ const SECTIONS: { id: SectionId; label: string; icon: React.ReactNode; group: st
   { id: "billing", label: "Billing", icon: <CreditCard size={15} />, group: "You" },
   { id: "appearance", label: "Appearance", icon: <Palette size={15} />, group: "You" },
   { id: "agent", label: "Agent (Hermes)", icon: <Sparkles size={15} />, group: "Machine" },
-  { id: "runtime", label: "Runtime", icon: <Server size={15} />, group: "Machine" },
+  { id: "runtime", label: "Computers", icon: <Server size={15} />, group: "Machine" },
   { id: "channels", label: "Channels", icon: <MonitorCog size={15} />, group: "Machine" },
   { id: "integrations", label: "Integrations", icon: <Blocks size={15} />, group: "Machine" },
   { id: "cron", label: "Schedules", icon: <Clock size={15} />, group: "Machine" },

--- a/desktop/src/renderer/src/features/settings/sections/RuntimeSection.tsx
+++ b/desktop/src/renderer/src/features/settings/sections/RuntimeSection.tsx
@@ -1,46 +1,194 @@
+import { Check, LoaderCircle, Monitor, RefreshCw } from "lucide-react";
 import { useEffect, useState } from "react";
+import {
+  MatrixComputerListSchema,
+  type MatrixComputer,
+} from "@matrix-os/contracts";
 import { Button } from "../../../design/primitives";
 import { useConnection } from "../../../stores/connection";
-import { Card, Row, SectionHeader } from "./section-kit";
+import { Card, Empty, SectionHeader } from "./section-kit";
+
+type LoadState = "loading" | "ready" | "error";
+
+const STATUS_LABEL: Record<MatrixComputer["availability"], string> = {
+  available: "Available",
+  starting: "Starting",
+  unavailable: "Unavailable",
+};
+
+function ComputerCard({
+  computer,
+  selected,
+  switching,
+  onSelect,
+}: {
+  computer: MatrixComputer;
+  selected: boolean;
+  switching: boolean;
+  onSelect: (computer: MatrixComputer) => void;
+}) {
+  const unavailable = computer.availability !== "available";
+  const buttonLabel = selected
+    ? "Current computer"
+    : unavailable
+      ? `${computer.label} is ${computer.availability}`
+      : `Use ${computer.label}`;
+
+  return (
+    <div
+      className="flex flex-col gap-3 rounded-lg border p-3 sm:flex-row sm:items-center sm:justify-between"
+      style={{
+        background: selected ? "var(--accent-muted)" : "var(--bg-elevated)",
+        borderColor: selected ? "var(--accent)" : "var(--border-subtle)",
+      }}
+    >
+      <div className="flex min-w-0 items-center gap-3">
+        <div
+          className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg"
+          style={{
+            background: selected ? "var(--accent)" : "var(--bg-hover)",
+            color: selected ? "var(--text-on-accent)" : "var(--text-secondary)",
+          }}
+        >
+          <Monitor size={17} aria-hidden="true" />
+        </div>
+        <div className="min-w-0">
+          <div className="flex items-center gap-2">
+            <span className="truncate text-sm font-medium" style={{ color: "var(--text-primary)" }}>
+              {computer.label}
+            </span>
+            {selected ? <Check size={14} style={{ color: "var(--accent)" }} aria-hidden="true" /> : null}
+          </div>
+          <div className="flex items-center gap-2 text-xs" style={{ color: "var(--text-tertiary)" }}>
+            <span className="truncate">{computer.handle}</span>
+            <span aria-hidden="true">·</span>
+            <span>{STATUS_LABEL[computer.availability]}</span>
+          </div>
+        </div>
+      </div>
+      <Button
+        variant={selected ? "ghost" : "subtle"}
+        className="shrink-0 justify-center"
+        disabled={selected || unavailable || switching}
+        aria-label={buttonLabel}
+        onClick={() => onSelect(computer)}
+      >
+        {switching ? <LoaderCircle size={14} className="animate-spin" aria-hidden="true" /> : null}
+        {switching ? "Switching…" : selected ? "Current" : "Use"}
+      </Button>
+    </div>
+  );
+}
 
 export default function RuntimeSection() {
-  const runtimeSlot = useConnection((s) => s.runtimeSlot);
-  const selectRuntime = useConnection((s) => s.selectRuntime);
-  const [slot, setSlot] = useState(runtimeSlot);
+  const api = useConnection((state) => state.api);
+  const runtimeSlot = useConnection((state) => state.runtimeSlot);
+  const selectRuntime = useConnection((state) => state.selectRuntime);
+  const [loadState, setLoadState] = useState<LoadState>("loading");
+  const [computers, setComputers] = useState<MatrixComputer[]>([]);
+  const [selectedSlot, setSelectedSlot] = useState<string | null>(runtimeSlot);
+  const [switchingSlot, setSwitchingSlot] = useState<string | null>(null);
+  const [switchError, setSwitchError] = useState(false);
+  const [reloadKey, setReloadKey] = useState(0);
 
   useEffect(() => {
-    setSlot(runtimeSlot);
-  }, [runtimeSlot]);
+    let active = true;
+    if (!api) {
+      setComputers([]);
+      setLoadState("error");
+      return () => {
+        active = false;
+      };
+    }
+    setLoadState("loading");
+    setSwitchError(false);
+    void api.get("/api/auth/computers")
+      .then((response) => MatrixComputerListSchema.parse(response))
+      .then((response) => {
+        if (!active) return;
+        setComputers(response.items);
+        setSelectedSlot(response.selectedSlot);
+        setLoadState("ready");
+      })
+      .catch(() => {
+        if (!active) return;
+        setComputers([]);
+        setLoadState("error");
+      });
+    return () => {
+      active = false;
+    };
+  }, [api, reloadKey, runtimeSlot]);
+
+  async function switchComputer(computer: MatrixComputer): Promise<void> {
+    if (computer.runtimeSlot === selectedSlot || computer.availability !== "available" || switchingSlot) return;
+    setSwitchError(false);
+    setSwitchingSlot(computer.runtimeSlot);
+    try {
+      await selectRuntime(computer.runtimeSlot);
+    } catch {
+      setSwitchError(true);
+    } finally {
+      setSwitchingSlot(null);
+    }
+  }
 
   return (
     <>
-      <SectionHeader title="Runtime" description="Choose which of your computers this app targets." />
+      <SectionHeader
+        title="Computers"
+        description="Choose the Matrix computer this desktop app connects to."
+      />
       <Card>
-        <Row label="Active runtime" value={runtimeSlot} />
-        <div className="flex items-center gap-2 border-t pt-3" style={{ borderColor: "var(--border-subtle)" }}>
-          <input
-            value={slot}
-            onChange={(e) => setSlot(e.target.value)}
-            maxLength={64}
-            placeholder="primary"
-            className="h-8 flex-1 rounded-md border bg-transparent px-2.5 text-sm outline-none"
-            style={{ borderColor: "var(--border-default)", color: "var(--text-primary)" }}
-          />
+        <div className="flex items-center justify-between gap-3">
+          <div>
+            <p className="text-sm font-medium" style={{ color: "var(--text-primary)" }}>Your computers</p>
+            <p className="text-xs" style={{ color: "var(--text-tertiary)" }}>
+              Chats, tasks, files, and terminals follow the selected computer.
+            </p>
+          </div>
           <Button
-            variant="primary"
-            disabled={slot.trim().length === 0 || slot === runtimeSlot}
-            onClick={() => {
-              void selectRuntime(slot.trim()).catch((err: unknown) => {
-                console.warn(
-                  "[settings] runtime switch failed:",
-                  err instanceof Error ? err.message : String(err),
-                );
-              });
-            }}
+            variant="ghost"
+            aria-label="Refresh computers"
+            disabled={loadState === "loading"}
+            onClick={() => setReloadKey((value) => value + 1)}
           >
-            Switch
+            <RefreshCw size={14} className={loadState === "loading" ? "animate-spin" : ""} aria-hidden="true" />
+            Refresh
           </Button>
         </div>
+
+        {loadState === "loading" ? (
+          <div className="flex items-center gap-2 py-3 text-sm" style={{ color: "var(--text-tertiary)" }}>
+            <LoaderCircle size={15} className="animate-spin" aria-hidden="true" />
+            Loading computers…
+          </div>
+        ) : null}
+
+        {loadState === "error" ? <Empty text="Computers are unavailable right now." /> : null}
+        {loadState === "ready" && computers.length === 0 ? <Empty text="No computers are available yet." /> : null}
+
+        {loadState === "ready" ? (
+          <div className="flex flex-col gap-2">
+            {computers.map((computer) => (
+              <ComputerCard
+                key={computer.runtimeSlot}
+                computer={computer}
+                selected={computer.runtimeSlot === selectedSlot}
+                switching={switchingSlot === computer.runtimeSlot}
+                onSelect={(next) => {
+                  void switchComputer(next);
+                }}
+              />
+            ))}
+          </div>
+        ) : null}
+
+        {switchError ? (
+          <p role="alert" className="text-xs" style={{ color: "var(--danger)" }}>
+            Couldn&apos;t switch computers. Try again.
+          </p>
+        ) : null}
       </Card>
     </>
   );

--- a/desktop/src/shared/ipc-contract.ts
+++ b/desktop/src/shared/ipc-contract.ts
@@ -26,6 +26,7 @@ import {
   ProjectAgentWorkspaceSchema,
   ReviewSnapshotSchema,
   ReviewSummarySchema,
+  RuntimeSelectionRequestSchema,
   RuntimeSummarySchema,
   SafeClientErrorSchema,
   SourceControlCreatePullRequestRequestSchema,
@@ -135,7 +136,7 @@ export const INVOKE_CHANNELS = {
   "auth:sign-out": { request: Empty, response: Ok },
   "auth:session-expired": { request: Empty, response: Ok },
   "runtime:select": {
-    request: z.object({ slot: z.string().min(1).max(64) }).strict(),
+    request: RuntimeSelectionRequestSchema,
     response: Ok,
   },
   "runtime:get-summary": {

--- a/specs/105-coding-agent-shells/acceptance-tests.md
+++ b/specs/105-coding-agent-shells/acceptance-tests.md
@@ -238,6 +238,21 @@ bounded multi-chat aggregates, task moves reuse the existing canonical task
 store and route, opening a card chat returns to the same conversation, and
 thread state alone cannot mutate task status.
 
+Current native computer-selection evidence:
+
+- `pnpm exec vitest run tests/contracts/runtime-computers.test.ts tests/platform/proxy-routing.test.ts tests/desktop/auth-service.test.ts tests/desktop/credential-store.test.ts tests/desktop/ipc-contract.test.ts tests/desktop/ipc-handlers.test.ts tests/desktop/runtime-section.test.tsx tests/desktop/settings-view.test.tsx tests/desktop/embed-host.test.tsx`
+- `pnpm --filter desktop run typecheck`
+- `bun run typecheck`
+- `bun run check:patterns`
+- `bun run build:desktop`
+- `pnpm exec vitest run tests/e2e/desktop/operator.e2e.test.ts`
+
+These checks prove the desktop discovers only capped owner-scoped computer
+summaries, rotates the selected runtime credential inside Electron main,
+persists a bounded slot, rejects invalid or cross-owner selection, rehydrates
+after `runtime:changed`, and contains raw platform or filesystem failures behind
+generic desktop copy.
+
 Gateway/contract PRs additionally run the exact focused Vitest files named in their PR body. Desktop UI PRs run the operator E2E and screenshot checks. Mobile UI PRs run the SDK 57 dev-client device smoke before their rollout gate. `vp` commands may be reported unavailable, but they are not silently substituted for repository commands.
 
 ## Confirmation Boundary

--- a/specs/105-coding-agent-shells/tasks.md
+++ b/specs/105-coding-agent-shells/tasks.md
@@ -1220,6 +1220,23 @@ path, multi-chat selection, cross-view identity continuity, and the absence of
 thread-driven task movement. Surface validation is recorded in
 `acceptance-tests.md`.
 
+### 21.4 Native Computer Selection
+
+- [x] Replace free-text runtime entry with an owner-scoped computer list.
+- [x] Exchange and persist a runtime-scoped credential only in Electron main.
+- [x] Rehydrate project/task/thread state after the selected computer changes.
+- [x] Keep machine identifiers, network details, credentials, and raw failures out of the renderer.
+
+Tests: runtime computer contracts, platform owner/auth route coverage, trusted
+auth and credential-store tests, IPC boundary tests, renderer switching/error
+tests, and desktop settings coverage.
+
+Evidence: the platform returns a capped safe projection and rejects invalid,
+unauthenticated, or cross-owner selection; the trusted core rotates the bearer
+before broadcasting `runtime:changed`; the desktop renders only available,
+starting, and unavailable states with generic failure copy. Surface validation
+is recorded in `acceptance-tests.md`.
+
 Gate:
 
 - [x] Desktop typecheck, focused Vitest, operator E2E, Canvas/Desktop regression, pattern scan, and screenshot checks pass.

--- a/tests/desktop/embed-host.test.tsx
+++ b/tests/desktop/embed-host.test.tsx
@@ -5,6 +5,7 @@ import { act, cleanup, fireEvent, render, screen, waitFor } from "@testing-libra
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import EmbedHost from "../../desktop/src/renderer/src/features/embeds/EmbedHost";
 import { invoke } from "../../desktop/src/renderer/src/lib/operator";
+import { useConnection } from "../../desktop/src/renderer/src/stores/connection";
 
 vi.mock("../../desktop/src/renderer/src/lib/operator", () => ({
   invoke: vi.fn(),
@@ -16,6 +17,8 @@ describe("EmbedHost", () => {
   let rect = { left: 10, top: 20, width: 300, height: 200 };
 
   beforeEach(() => {
+    useConnection.setState(useConnection.getInitialState(), true);
+    useConnection.setState({ runtimeSlot: "primary" });
     openResolve = null;
     rect = { left: 10, top: 20, width: 300, height: 200 };
     vi.mocked(invoke).mockImplementation((channel: string) => {
@@ -118,6 +121,35 @@ describe("EmbedHost", () => {
         embedId: "embed-1",
         bounds: { x: 90, y: 100, width: 700, height: 500 },
       });
+    });
+  });
+
+  it("reopens the hosted surface after the trusted runtime changes", async () => {
+    let nextEmbedId = 0;
+    vi.mocked(invoke).mockImplementation((channel: string) => {
+      if (channel === "embed:open") {
+        nextEmbedId += 1;
+        return Promise.resolve({ embedId: `embed-${nextEmbedId}`, state: "ready" }) as ReturnType<typeof invoke>;
+      }
+      return Promise.resolve({ ok: true }) as ReturnType<typeof invoke>;
+    });
+
+    render(<EmbedHost kind="hosted-shell" />);
+    await waitFor(() => expect(invoke).toHaveBeenCalledWith(
+      "embed:set-active",
+      { embedId: "embed-1", active: true },
+    ));
+
+    act(() => {
+      useConnection.setState({ runtimeSlot: "review" });
+    });
+
+    await waitFor(() => {
+      expect(invoke).toHaveBeenCalledWith("embed:close", { embedId: "embed-1" });
+      expect(invoke).toHaveBeenCalledWith(
+        "embed:set-active",
+        { embedId: "embed-2", active: true },
+      );
     });
   });
 });

--- a/tests/desktop/ipc-contract.test.ts
+++ b/tests/desktop/ipc-contract.test.ts
@@ -704,6 +704,8 @@ describe("IPC contract", () => {
     expect(schema.safeParse({ slot: "primary" }).success).toBe(true);
     expect(schema.safeParse({ slot: "" }).success).toBe(false);
     expect(schema.safeParse({ slot: "x".repeat(65) }).success).toBe(false);
+    expect(schema.safeParse({ slot: "../private" }).success).toBe(false);
+    expect(schema.safeParse({ slot: "review computer" }).success).toBe(false);
     expect(schema.safeParse({}).success).toBe(false);
   });
 

--- a/tests/desktop/runtime-section.test.tsx
+++ b/tests/desktop/runtime-section.test.tsx
@@ -1,0 +1,120 @@
+// @vitest-environment jsdom
+
+import React from "react";
+import { act, cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import RuntimeSection from "../../desktop/src/renderer/src/features/settings/sections/RuntimeSection";
+import { useConnection } from "../../desktop/src/renderer/src/stores/connection";
+
+function makeApi(response: unknown) {
+  return {
+    baseUrl: "https://app.matrix-os.com",
+    get: vi.fn(async () => response),
+    getText: vi.fn(),
+    post: vi.fn(),
+    patch: vi.fn(),
+    put: vi.fn(),
+    delete: vi.fn(),
+    putText: vi.fn(),
+  };
+}
+
+const computers = {
+  items: [
+    {
+      handle: "operator",
+      runtimeSlot: "primary",
+      label: "Main Computer",
+      availability: "available",
+      kind: "customer",
+      gatewayPath: "/vm/operator",
+      capabilities: [],
+    },
+    {
+      handle: "operator-review",
+      runtimeSlot: "review",
+      label: "Additional Computer",
+      availability: "available",
+      kind: "preview",
+      gatewayPath: "/vm/operator-review?runtime=review",
+      capabilities: [],
+    },
+    {
+      handle: "operator-preview",
+      runtimeSlot: "preview",
+      label: "Preview Computer",
+      availability: "starting",
+      kind: "preview",
+      gatewayPath: "/vm/operator-preview?runtime=preview",
+      capabilities: [],
+    },
+  ],
+  selectedSlot: "primary",
+  hasMore: false,
+  limit: 20,
+};
+
+describe("desktop runtime settings", () => {
+  beforeEach(() => {
+    useConnection.setState(useConnection.getInitialState(), true);
+    useConnection.setState({
+      status: "signed-in",
+      handle: "operator",
+      platformHost: "https://app.matrix-os.com",
+      runtimeSlot: "primary",
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it("shows the owner's bounded computers instead of a free-text runtime field", async () => {
+    const api = makeApi(computers);
+    useConnection.setState({ api: api as never });
+
+    render(<RuntimeSection />);
+
+    await waitFor(() => expect(screen.getByText("Main Computer")).not.toBeNull());
+    expect(api.get).toHaveBeenCalledWith("/api/auth/computers");
+    expect(screen.getByText("operator-review")).not.toBeNull();
+    expect(screen.getByText("Starting")).not.toBeNull();
+    expect(screen.queryByRole("textbox")).toBeNull();
+    expect(screen.getByRole("button", { name: "Current computer" }).hasAttribute("disabled")).toBe(true);
+    expect(screen.getByRole("button", { name: "Preview Computer is starting" }).hasAttribute("disabled")).toBe(true);
+  });
+
+  it("switches only to an available owner computer", async () => {
+    const api = makeApi(computers);
+    const selectRuntime = vi.fn(async () => undefined);
+    useConnection.setState({ api: api as never, selectRuntime });
+
+    render(<RuntimeSection />);
+    await waitFor(() => expect(screen.getByText("Additional Computer")).not.toBeNull());
+    fireEvent.click(screen.getByRole("button", { name: "Use Additional Computer" }));
+
+    await waitFor(() => expect(selectRuntime).toHaveBeenCalledWith("review"));
+  });
+
+  it("contains malformed responses and switching failures behind safe messages", async () => {
+    const api = makeApi({ items: [{ runtimeSlot: "../secret", token: "raw-secret" }] });
+    const selectRuntime = vi.fn(async () => {
+      throw new Error("/home/matrix/private token=raw-secret");
+    });
+    useConnection.setState({ api: api as never, selectRuntime });
+
+    const { rerender } = render(<RuntimeSection />);
+    await waitFor(() => expect(screen.getByText("Computers are unavailable right now.")).not.toBeNull());
+    expect(screen.queryByText(/raw-secret|\/home\/matrix/i)).toBeNull();
+
+    act(() => {
+      useConnection.setState({ api: makeApi(computers) as never });
+    });
+    rerender(<RuntimeSection />);
+    await waitFor(() => expect(screen.getByText("Additional Computer")).not.toBeNull());
+    fireEvent.click(screen.getByRole("button", { name: "Use Additional Computer" }));
+    await waitFor(() => expect(screen.getByText("Couldn't switch computers. Try again.")).not.toBeNull());
+    expect(screen.queryByText(/raw-secret|\/home\/matrix/i)).toBeNull();
+  });
+});

--- a/tests/desktop/settings-view.test.tsx
+++ b/tests/desktop/settings-view.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 
 import React from "react";
-import { cleanup, render, waitFor } from "@testing-library/react";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import SettingsView from "../../desktop/src/renderer/src/features/settings/SettingsView";
 import { useConnection } from "../../desktop/src/renderer/src/stores/connection";
@@ -39,5 +39,6 @@ describe("SettingsView", () => {
 
     await waitFor(() => expect(document.documentElement.getAttribute("data-theme")).toBe("light"));
     expect(window.operator.invoke).toHaveBeenCalledWith("state:get", { key: "appearance" });
+    expect(screen.getByRole("button", { name: "Computers" })).not.toBeNull();
   });
 });

--- a/tests/e2e/desktop/fixtures/stub-gateway.ts
+++ b/tests/e2e/desktop/fixtures/stub-gateway.ts
@@ -24,10 +24,12 @@ export interface StubGateway {
     kernelMessages: Array<Record<string, unknown>>;
     codingAgentCreates: Array<Record<string, unknown>>;
     taskUpdates: Array<Record<string, unknown>>;
+    runtimeSelections: string[];
   };
 }
 
 const TOKEN = "stub-token-1";
+const REVIEW_TOKEN = "stub-review-token-with-enough-entropy-1";
 const NOW = "2026-07-08T00:00:00.000Z";
 
 function json(res: ServerResponse, status: number, body: unknown): void {
@@ -350,7 +352,9 @@ export async function startStubGateway(): Promise<StubGateway> {
     kernelMessages: [],
     codingAgentCreates: [],
     taskUpdates: [],
+    runtimeSelections: [],
   };
+  let currentToken = TOKEN;
 
   const server: Server = createServer((req, res) => {
     void handle(req, res);
@@ -404,8 +408,54 @@ export async function startStubGateway(): Promise<StubGateway> {
     }
 
     // Everything below requires the bearer header (verifies header injection).
-    if (req.headers.authorization !== `Bearer ${TOKEN}`) {
+    if (req.headers.authorization !== `Bearer ${currentToken}`) {
       json(res, 401, { error: "unauthorized" });
+      return;
+    }
+
+    if (req.method === "GET" && path === "/api/auth/computers") {
+      json(res, 200, {
+        items: [
+          {
+            handle: "neo",
+            runtimeSlot: "primary",
+            label: "Main Computer",
+            availability: "available",
+            kind: "customer",
+            gatewayPath: "/vm/neo",
+            capabilities: [],
+          },
+          {
+            handle: "neo-review",
+            runtimeSlot: "review",
+            label: "Additional Computer",
+            availability: "available",
+            kind: "preview",
+            gatewayPath: "/vm/neo-review?runtime=review",
+            capabilities: [],
+          },
+        ],
+        selectedSlot: currentToken === REVIEW_TOKEN ? "review" : "primary",
+        hasMore: false,
+        limit: 20,
+      });
+      return;
+    }
+
+    if (req.method === "POST" && path === "/api/auth/runtime-selection") {
+      const body = await readBody(req);
+      if (body.slot !== "review") {
+        json(res, 404, { error: "Computer unavailable" });
+        return;
+      }
+      state.runtimeSelections.push("review");
+      currentToken = REVIEW_TOKEN;
+      json(res, 200, {
+        accessToken: REVIEW_TOKEN,
+        expiresAt: Date.now() + 3_600_000,
+        handle: "neo-review",
+        slot: "review",
+      });
       return;
     }
 
@@ -545,7 +595,7 @@ export async function startStubGateway(): Promise<StubGateway> {
   server.on("upgrade", (req, socket, head) => {
     const url = new URL(req.url ?? "/", "http://localhost");
     // WS upgrades carry the bearer header via the app's header injection.
-    if (req.headers.authorization !== `Bearer ${TOKEN}`) {
+    if (req.headers.authorization !== `Bearer ${currentToken}`) {
       socket.write("HTTP/1.1 401 Unauthorized\r\n\r\n");
       socket.destroy();
       return;

--- a/tests/e2e/desktop/operator.e2e.test.ts
+++ b/tests/e2e/desktop/operator.e2e.test.ts
@@ -159,6 +159,11 @@ suite("operator desktop e2e", () => {
     await page.locator("aside button", { hasText: "Settings" }).first().click();
     await page.getByRole("heading", { name: "Settings" }).waitFor({ timeout: 10_000 });
     await expect.poll(attachedNativeViewCount).toBe(0);
+    await page.getByRole("button", { name: "Computers" }).click();
+    await page.getByText("Additional Computer").waitFor({ timeout: 10_000 });
+    await page.getByRole("button", { name: "Use Additional Computer" }).click();
+    await expect.poll(() => gateway.state.runtimeSelections).toEqual(["review"]);
+    await page.getByRole("button", { name: "Current computer" }).waitFor({ timeout: 10_000 });
     await page.screenshot({ path: join(SCREENSHOT_DIR, "09-settings-no-shell-overlay.png") });
 
     await page.locator("aside button", { hasText: "Chat" }).first().click();

--- a/www/content/docs/desktop.mdx
+++ b/www/content/docs/desktop.mdx
@@ -113,9 +113,12 @@ Standard macOS menus, full-screen, and window controls work as expected.
 ## Settings
 
 Native settings cover **Account**, **Billing**, **Appearance** (dark/light/system),
-**Agent** (Hermes configuration), **Runtime** (switch Matrix computer target), **Channels**,
-**Integrations**, **Schedules**, and **System info**. Switching runtime re-targets every
-surface — board, terminals, chat, and apps.
+**Agent** (Hermes configuration), **Computers**, **Channels**, **Integrations**,
+**Schedules**, and **System info**. The Computers section lists the Matrix computers
+available to your account, shows which one is current or still starting, and lets you
+switch to another available computer. Switching securely re-targets every surface —
+projects, tasks, chats, terminals, files, Git, and apps — without exposing the connection
+credential to the desktop interface.
 
 ## Privacy and updates
 


### PR DESCRIPTION
## Summary
- add a capped owner-scoped computer projection and runtime credential exchange on the platform
- retain failed/stopped owner computers as disabled Unavailable cards without changing active-machine provisioning semantics
- replace the desktop free-text runtime field with polished current, available, starting, and unavailable computer cards
- rotate and persist the selected runtime credential only in Electron main, then rehydrate the renderer through the existing runtime event
- require a main-only exchange proof, strip it from renderer-session requests, and keep it outside renderer CORS
- reopen hosted shell and app embeds after a computer switch
- document the contract, public workflow, and Phase 21 acceptance evidence

## Tests
- focused contract, platform routing, desktop auth, credential, header injection, IPC, settings, connection, and embed Vitest suites: pass
- full platform proxy-routing file: 118/118 pass
- pnpm --filter desktop run typecheck: pass
- pnpm --filter @matrix-os/platform exec tsc --noEmit -p tsconfig.typecheck.json: pass
- bun run typecheck: pass
- bun run check:patterns: 0 violations, baseline warnings only
- bun run build:desktop: pass
- desktop operator E2E: 7/7 pass, including protected computer switch and embed restoration
- bun run test: attempted; local Node 26 loads Node 24 native modules and lacks the configured localStorage test environment, causing unrelated baseline failures. Exact-head Node 24 CI is the authoritative broad gate.

## Review/Monitoring
- ready for review
- review range: 542228218303987ff19c6a85af251f4f9c54ca18..fa39a3e59
- addressed the unavailable-computer review with a dedicated capped non-deleted projection
- addressed the renderer token-exchange review with a stripped main-only proof header and renderer-shaped request regression
- ready-for-ci will be added only after the latest trusted review is 5/5

## Invariants

### Source of truth
- Platform Postgres user_machines remains authoritative for runtime ownership, status, slot, and handle.
- The desktop stores only the current OS-encrypted bearer and a bounded non-secret connection profile. On startup the credential slot and handle reconcile a stale profile.

### Lock/transaction scope
- Runtime discovery is a capped owner-scoped read. Selection reads one running owner machine and issues a stateless signed replacement token; it performs no related database writes.
- Desktop credential/profile persistence is compensated locally. No external network call occurs inside a database transaction or lock.

### Acceptable orphan states
- A process crash between credential and profile persistence can leave a new credential beside an old profile; startup reconciliation repairs the profile from the credential.
- If profile persistence fails synchronously, the trusted core attempts to restore both prior values and keeps its in-memory identity unchanged. No server-side orphan is created.

### Auth source of truth
- Verified platform identity from a sync JWT or Clerk session establishes the owner. Selection additionally requires the platform signing secret, a main-only exchange proof, and a running user_machines row for that same owner and slot.
- Renderer network hooks strip the proof header and renderer CORS does not allow it. Missing, invalid, cross-owner, oversized, or unavailable selections fail closed with generic responses.

### Deferred scope
- Computer provisioning, deletion, renaming, resizing, and billing changes remain in their existing platform flows.
- Mobile/browser picker changes and the separate desktop files/Git contextual-inspector polish are not part of this slice.