### PR TITLE
feat(desktop): add computer-aware folder workspaces

### DIFF
--- a/desktop/src/main/auth/auth-service.ts
+++ b/desktop/src/main/auth/auth-service.ts
@@ -1,6 +1,8 @@
 import {
+  MatrixComputerListSchema,
   RuntimeSelectionRequestSchema,
   RuntimeSelectionResponseSchema,
+  type MatrixComputerList,
 } from "@matrix-os/contracts";
 // Trusted-core auth orchestration: owns the device flow, the credential, and
 // the connection profile. The renderer only ever sees status snapshots.
@@ -372,6 +374,35 @@ export class AuthService {
         err instanceof Error ? err.name : typeof err,
       );
       throw new Error(RUNTIME_SELECTION_ERROR);
+    }
+  }
+
+  async listRuntimeComputers(): Promise<MatrixComputerList> {
+    this.expireCredentialIfNeeded();
+    const currentCredential = this.credential;
+    if (!currentCredential) throw new Error("Runtime computers unavailable");
+
+    const endpoint = new URL("/api/auth/computers", this.deps.runtimeSelectionOrigin);
+    const fetchFn = this.deps.fetchFn ?? ((input: string, init?: RequestInit) => fetch(input, init));
+    try {
+      const response = await fetchFn(endpoint.toString(), {
+        method: "GET",
+        headers: { authorization: `Bearer ${currentCredential.accessToken}` },
+        signal: AbortSignal.timeout(RUNTIME_SELECTION_TIMEOUT_MS),
+      });
+      if (!response.ok) throw new Error("computer inventory rejected");
+      const contentLength = Number(response.headers.get("content-length"));
+      if (Number.isFinite(contentLength) && contentLength > RUNTIME_SELECTION_RESPONSE_LIMIT) {
+        throw new Error("computer inventory response too large");
+      }
+      const text = await readBoundedResponseText(response);
+      return MatrixComputerListSchema.parse(JSON.parse(text));
+    } catch (err: unknown) {
+      console.warn(
+        "[auth] computer inventory unavailable:",
+        err instanceof Error ? err.name : typeof err,
+      );
+      throw new Error("Runtime computers unavailable");
     }
   }
 

--- a/desktop/src/main/auth/auth-service.ts
+++ b/desktop/src/main/auth/auth-service.ts
@@ -31,6 +31,10 @@ export interface AuthStatus {
   platformHost: string;
   displayName?: string;
   imageUrl?: string;
+  // Monotonic credential generation. Advances on every credential replacement
+  // or drop so renderer caches keyed on identity cannot survive a session swap
+  // that keeps the same handle/host/slot.
+  authGeneration: number;
 }
 
 export type PollResult = {
@@ -84,6 +88,7 @@ interface AuthServiceDeps {
 
 export class AuthService {
   private credential: StoredCredential | null = null;
+  private authGeneration = 0;
   private profile: ConnectionProfile | null = null;
   private flowState: "idle" | "pending" | "authorized" | "expired" = "idle";
   private flowNonce = 0;
@@ -151,7 +156,13 @@ export class AuthService {
       ...(signedIn && this.profile?.imageUrl ? { imageUrl: this.profile.imageUrl } : {}),
       runtimeSlot: this.profile?.runtimeSlot ?? "primary",
       platformHost: this.getGatewayOrigin(),
+      authGeneration: this.authGeneration,
     };
+  }
+
+  private replaceCredential(credential: StoredCredential | null): void {
+    this.credential = credential;
+    this.authGeneration += 1;
   }
 
   async startDeviceFlow(): Promise<Pick<DeviceCodeResponse, "userCode" | "verificationUri" | "expiresIn">> {
@@ -210,7 +221,7 @@ export class AuthService {
           }
         }
         if (nonce !== this.flowNonce) return;
-        this.credential = credential;
+        this.replaceCredential(credential);
         const profile: ConnectionProfile = {
           handle: credential.handle,
           userId: token.userId,
@@ -365,7 +376,7 @@ export class AuthService {
           });
           throw err;
         }
-        this.credential = nextCredential;
+        this.replaceCredential(nextCredential);
         this.profile = nextProfile;
       });
     } catch (err: unknown) {
@@ -390,6 +401,13 @@ export class AuthService {
         headers: { authorization: `Bearer ${currentCredential.accessToken}` },
         signal: AbortSignal.timeout(RUNTIME_SELECTION_TIMEOUT_MS),
       });
+      // A 401 means the token was revoked or rotated server-side before the
+      // local expiry: drop the session so the renderer returns to sign-in
+      // instead of retrying against a dead credential forever.
+      if (response.status === 401 && this.credential === currentCredential) {
+        await this.expireSession();
+        throw new Error("computer inventory unauthorized");
+      }
       if (!response.ok) throw new Error("computer inventory rejected");
       const contentLength = Number(response.headers.get("content-length"));
       if (Number.isFinite(contentLength) && contentLength > RUNTIME_SELECTION_RESPONSE_LIMIT) {
@@ -412,7 +430,7 @@ export class AuthService {
   async expireSession(): Promise<void> {
     if (!this.credential) return;
     this.flowNonce += 1;
-    this.credential = null;
+    this.replaceCredential(null);
     this.flowState = "idle";
     try {
       await this.runPersistence(() => this.deps.credentialStore.clear());
@@ -429,7 +447,7 @@ export class AuthService {
   async signOut(): Promise<void> {
     this.flowNonce += 1;
     this.pendingDeviceCode = null;
-    this.credential = null;
+    this.replaceCredential(null);
     this.profile = null;
     this.flowState = "idle";
     this.deps.onAuthChanged(this.getStatus());
@@ -481,7 +499,7 @@ export class AuthService {
     if (!this.isExpired()) return;
     this.flowNonce += 1;
     this.pendingDeviceCode = null;
-    this.credential = null;
+    this.replaceCredential(null);
     this.flowState = "idle";
     this.deps.onAuthChanged(this.currentStatus());
     void this.runPersistence(() => this.deps.credentialStore.clear()).catch((err: unknown) => {

--- a/desktop/src/main/ipc/handlers.ts
+++ b/desktop/src/main/ipc/handlers.ts
@@ -120,6 +120,7 @@ export function registerIpcHandlers(ipcMain: IpcMainLike, ctx: HandlerContext): 
     return { ok: true };
   });
 
+  handle("runtime:list-computers", () => ctx.auth.listRuntimeComputers());
   handle("runtime:select", async ({ slot }) => {
     await ctx.auth.selectRuntime(slot);
     ctx.onRuntimeChanged(slot);

--- a/desktop/src/renderer/src/features/board/CreateProjectDialog.tsx
+++ b/desktop/src/renderer/src/features/board/CreateProjectDialog.tsx
@@ -1,4 +1,4 @@
-import { FolderPlus, Github } from "lucide-react";
+import { FolderOpen, FolderPlus, Github } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { Button, Dialog } from "../../design/primitives";
 import { toUserMessage } from "../../lib/errors";
@@ -6,7 +6,7 @@ import { useBoard } from "../../stores/board";
 import { useConnection } from "../../stores/connection";
 import { useTabs } from "../../stores/tabs";
 
-type Mode = "scratch" | "github";
+type Mode = "scratch" | "folder" | "github";
 
 // Inner form mounts only while open, so its state is fresh per open (no
 // reset-on-prop effect). autoFocus replaces a focus setTimeout.
@@ -18,12 +18,17 @@ function CreateProjectForm({ onClose }: { onClose: () => void }) {
   const [name, setName] = useState("");
   const [mode, setMode] = useState<Mode>("scratch");
   const [url, setUrl] = useState("");
+  const [path, setPath] = useState("");
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const dialogClosedRef = useRef(false);
   const dialogGenerationRef = useRef(0);
 
-  const canSubmit = name.trim().length > 0 && (mode === "scratch" || url.trim().length > 0);
+  const canSubmit = name.trim().length > 0 && (
+    mode === "scratch" ||
+    (mode === "folder" && path.trim().length > 0) ||
+    (mode === "github" && url.trim().length > 0)
+  );
 
   useEffect(() => {
     dialogGenerationRef.current += 1;
@@ -50,10 +55,17 @@ function CreateProjectForm({ onClose }: { onClose: () => void }) {
         name: name.trim(),
         mode,
         ...(mode === "github" ? { url: url.trim() } : {}),
+        ...(mode === "folder" ? { path: path.trim() } : {}),
       });
       if (dialogClosedRef.current || dialogGenerationRef.current !== submitGeneration) return;
       if (!project) {
-        setError("Couldn't create the project. Check the name" + (mode === "github" ? " and the GitHub URL." : "."));
+        setError(
+          mode === "github"
+            ? "Couldn't create the project. Check the name and GitHub URL."
+            : mode === "folder"
+              ? "Couldn't connect that folder. Check that it exists on this computer."
+              : "Couldn't create the project. Check the name.",
+        );
         return;
       }
       await selectProject(api, project.slug);
@@ -101,8 +113,9 @@ function CreateProjectForm({ onClose }: { onClose: () => void }) {
         <span className="text-xs font-medium" style={{ color: "var(--text-secondary)" }}>How do you want to start?</span>
         <div className="flex rounded-lg border p-0.5" style={{ borderColor: "var(--border-subtle)", background: "var(--bg-sunken)" }}>
           {([
-            { key: "scratch" as const, label: "Start from scratch", icon: <FolderPlus size={13} /> },
-            { key: "github" as const, label: "Import from GitHub", icon: <Github size={13} /> },
+            { key: "scratch" as const, label: "New folder", icon: <FolderPlus size={13} /> },
+            { key: "folder" as const, label: "Use existing folder", icon: <FolderOpen size={13} /> },
+            { key: "github" as const, label: "Clone GitHub", icon: <Github size={13} /> },
           ]).map((opt) => {
             const activeMode = mode === opt.key;
             return (
@@ -126,9 +139,17 @@ function CreateProjectForm({ onClose }: { onClose: () => void }) {
           <span className="text-xs font-medium" style={{ color: "var(--text-secondary)" }}>GitHub repository URL</span>
           <input value={url} onChange={(e) => setUrl(e.target.value)} placeholder="https://github.com/owner/repo" style={field} />
         </label>
+      ) : mode === "folder" ? (
+        <label className="flex flex-col gap-1">
+          <span className="text-xs font-medium" style={{ color: "var(--text-secondary)" }}>Folder on this computer</span>
+          <input value={path} onChange={(e) => setPath(e.target.value)} placeholder="workspaces/customer-app" style={field} />
+          <span className="text-xs" style={{ color: "var(--text-tertiary)" }}>
+            Enter a folder relative to your Matrix home. The folder stays in place and remains yours.
+          </span>
+        </label>
       ) : (
         <p className="text-xs" style={{ color: "var(--text-tertiary)" }}>
-          A fresh repository is created on your cloud computer. Connect it to GitHub later from the board.
+          A new project folder is created on your Matrix computer. Git and GitHub are optional.
         </p>
       )}
 

--- a/desktop/src/renderer/src/features/coding-agents/AgentProjectNavigator.tsx
+++ b/desktop/src/renderer/src/features/coding-agents/AgentProjectNavigator.tsx
@@ -27,6 +27,7 @@ export interface AgentProjectNavigatorProps {
   onSelectTask: (taskId: string) => void;
   onSelectThread: (threadId: string) => void;
   onNewChat: (projectId: string, taskId?: string) => void;
+  onNewProject?: () => void;
 }
 
 function CountBadge({ children }: { children: number }) {
@@ -110,6 +111,7 @@ export function AgentProjectNavigator({
   onSelectTask,
   onSelectThread,
   onNewChat,
+  onNewProject,
 }: AgentProjectNavigatorProps) {
   const grouped = workspace ? groupProjectWorkspaceThreads(workspace) : null;
   const projects = workspace
@@ -137,7 +139,21 @@ export function AgentProjectNavigator({
         <span className="text-[11px] font-semibold uppercase tracking-[0.12em]" style={{ color: "var(--text-tertiary)" }}>
           Projects
         </span>
-        <CountBadge>{projects.length}</CountBadge>
+        <div className="flex items-center gap-1.5">
+          {onNewProject ? (
+            <button
+              type="button"
+              aria-label="New project"
+              title="New project"
+              onClick={onNewProject}
+              className="rounded p-1 outline-none hover:bg-[var(--bg-tertiary)] focus-visible:ring-2 focus-visible:ring-[var(--accent)]"
+              style={{ color: "var(--text-tertiary)" }}
+            >
+              <Plus size={13} />
+            </button>
+          ) : null}
+          <CountBadge>{projects.length}</CountBadge>
+        </div>
       </div>
 
       <div className="min-h-0 flex-1 overflow-y-auto px-2 pb-3">

--- a/desktop/src/renderer/src/features/coding-agents/AgentProjectWorkspaceShell.tsx
+++ b/desktop/src/renderer/src/features/coding-agents/AgentProjectWorkspaceShell.tsx
@@ -7,6 +7,7 @@ import {
 } from "../../stores/coding-agent-workspace";
 import { useCodingAgentProjectWorkspace } from "../../stores/coding-agent-project-workspace";
 import { useConnection } from "../../stores/connection";
+import { useUi } from "../../stores/ui";
 import { AgentProjectNavigator } from "./AgentProjectNavigator";
 
 function capabilityEnabled(summary: RuntimeSummary, id: string): boolean {
@@ -45,6 +46,7 @@ export function AgentProjectWorkspaceShell({
     (state) => state.focusExternalThread,
   );
   const runtimeScope = useConnection(codingAgentRuntimeScope);
+  const setCreateProjectOpen = useUi((state) => state.setCreateProjectOpen);
   const activeThreadId = useCodingAgentWorkspace((state) => state.activeThreadId);
   const activeThread = useCodingAgentWorkspace((state) =>
     state.threadSnapshot?.thread.id === state.activeThreadId
@@ -190,6 +192,7 @@ export function AgentProjectWorkspaceShell({
             }
           }}
           onNewChat={onNewChat}
+          onNewProject={() => setCreateProjectOpen(true)}
         />
       ) : (
         <nav

--- a/desktop/src/renderer/src/features/mission-control/MissionControl.tsx
+++ b/desktop/src/renderer/src/features/mission-control/MissionControl.tsx
@@ -87,7 +87,7 @@ export default function MissionControl() {
     return () => {
       cancelled = true;
     };
-  }, [api, loadProjects]);
+  }, [api, loadProjects, runtimeSlot]);
 
   useEffect(() => {
     if (!api) return;

--- a/desktop/src/renderer/src/features/mission-control/Sidebar.tsx
+++ b/desktop/src/renderer/src/features/mission-control/Sidebar.tsx
@@ -21,6 +21,7 @@ import { useConnection } from "../../stores/connection";
 import { AGENTS_WORKSPACE_TAB_SPEC, useTabs } from "../../stores/tabs";
 import { useThreads } from "../../stores/threads";
 import { useUi } from "../../stores/ui";
+import RuntimeComputerMenu from "../runtime/RuntimeComputerMenu";
 
 function NavRow({
   icon,
@@ -215,6 +216,7 @@ export default function Sidebar() {
       </div>
 
       <div className="flex flex-col border-t" style={{ borderColor: "var(--border-subtle)" }}>
+        <RuntimeComputerMenu collapsed={collapsed} />
         <div className={`flex items-center ${collapsed ? "justify-center" : "justify-between"} px-2 pt-1`}>
           <NavRow icon={<Settings size={15} />} label="Settings" collapsed={collapsed} active={activeTab?.kind === "settings"} onClick={() => openTab({ kind: "settings", title: "Settings" })} />
         </div>

--- a/desktop/src/renderer/src/features/mission-control/TabContent.tsx
+++ b/desktop/src/renderer/src/features/mission-control/TabContent.tsx
@@ -1,5 +1,6 @@
 import { Sparkles } from "lucide-react";
-import { EmptyState } from "../../design/primitives";
+import { Component, type ErrorInfo, type ReactNode } from "react";
+import { Button, EmptyState } from "../../design/primitives";
 import { useTabs, type Tab } from "../../stores/tabs";
 import { useUi } from "../../stores/ui";
 import Board from "../board/Board";
@@ -14,6 +15,36 @@ import { AppLauncher } from "../embeds";
 import TerminalsTab from "../terminal/TerminalsTab";
 import EmbedHost from "../embeds/EmbedHost";
 import { CODING_AGENTS_DESKTOP_WORKSPACE } from "../../lib/feature-flags";
+
+export class TabErrorBoundary extends Component<{
+  children: ReactNode;
+  tabTitle: string;
+  onClose: () => void;
+}, { failed: boolean }> {
+  override state = { failed: false };
+
+  static getDerivedStateFromError(): { failed: boolean } {
+    return { failed: true };
+  }
+
+  override componentDidCatch(error: Error, info: ErrorInfo): void {
+    console.warn(
+      `[tabs] ${this.props.tabTitle} workspace failed (${error.name}; component stack: ${info.componentStack ? "present" : "missing"})`,
+    );
+  }
+
+  override render(): ReactNode {
+    if (!this.state.failed) return this.props.children;
+    return (
+      <EmptyState
+        icon={<Sparkles size={28} />}
+        headline={`${this.props.tabTitle} couldn't open`}
+        description="Close this tab and try again. Your project and task data are safe."
+        action={<Button variant="primary" onClick={this.props.onClose}>Close tab</Button>}
+      />
+    );
+  }
+}
 
 function TabPane({ tab, active }: { tab: Tab; active: boolean }) {
   switch (tab.kind) {
@@ -47,6 +78,7 @@ function TabPane({ tab, active }: { tab: Tab; active: boolean }) {
 export default function TabContent() {
   const tabs = useTabs((s) => s.tabs);
   const activeTabId = useTabs((s) => s.activeTabId);
+  const closeTab = useTabs((s) => s.closeTab);
   // A native embed paints above the renderer, so while a modal overlay is open
   // we treat embeds as inactive (detached) — otherwise the palette/composer/
   // dialogs would render behind the embed.
@@ -87,7 +119,9 @@ export default function TabContent() {
             // `inert` keeps keyboard focus out of cached-but-hidden panes.
             inert={!active}
           >
-            <TabPane tab={tab} active={paneActive} />
+            <TabErrorBoundary tabTitle={tab.title} onClose={() => closeTab(tab.id)}>
+              <TabPane tab={tab} active={paneActive} />
+            </TabErrorBoundary>
           </div>
         );
       })}

--- a/desktop/src/renderer/src/features/runtime/RuntimeComputerMenu.tsx
+++ b/desktop/src/renderer/src/features/runtime/RuntimeComputerMenu.tsx
@@ -19,18 +19,23 @@ export default function RuntimeComputerMenu({ collapsed }: { collapsed: boolean 
   const platformHost = useConnection((state) => state.platformHost);
   const handle = useConnection((state) => state.handle);
   const runtimeSlot = useConnection((state) => state.runtimeSlot);
+  const authGeneration = useConnection((state) => state.authGeneration);
   const loadStatus = useRuntimeComputers((state) => state.status);
   const computers = useRuntimeComputers((state) => state.computers);
+  const serverSelectedSlot = useRuntimeComputers((state) => state.runtimeSlot);
   const switchingSlot = useRuntimeComputers((state) => state.switchingSlot);
   const switchError = useRuntimeComputers((state) => state.switchError);
   const refresh = useRuntimeComputers((state) => state.refresh);
   const select = useRuntimeComputers((state) => state.select);
   const [open, setOpen] = useState(false);
   const rootRef = useRef<HTMLDivElement | null>(null);
+  // The token can be on a different slot than the persisted profile (stale
+  // profile write); the inventory response's selectedSlot is authoritative.
+  const selectedSlot = serverSelectedSlot ?? runtimeSlot;
 
   useEffect(() => {
     void refresh();
-  }, [connectionStatus, handle, platformHost, refresh, runtimeSlot]);
+  }, [authGeneration, connectionStatus, handle, platformHost, refresh, runtimeSlot]);
 
   useEffect(() => {
     if (!open) return;
@@ -49,11 +54,11 @@ export default function RuntimeComputerMenu({ collapsed }: { collapsed: boolean 
   }, [open]);
 
   const current = useMemo(
-    () => computers.find((computer) => computer.runtimeSlot === runtimeSlot)
+    () => computers.find((computer) => computer.runtimeSlot === selectedSlot)
       ?? null,
-    [computers, runtimeSlot],
+    [computers, selectedSlot],
   );
-  const currentLabel = current?.label ?? fallbackComputerLabel(runtimeSlot);
+  const currentLabel = current?.label ?? fallbackComputerLabel(selectedSlot);
   const buttonLabel = loadStatus === "error"
     ? "Computer list unavailable"
     : `Change computer, currently ${currentLabel}`;
@@ -64,7 +69,7 @@ export default function RuntimeComputerMenu({ collapsed }: { collapsed: boolean 
         <div
           role="listbox"
           aria-label="Choose computer"
-          className="absolute bottom-full left-2 right-2 mb-1 overflow-hidden rounded-xl border p-1 shadow-lg"
+          className={`absolute bottom-full left-2 mb-1 overflow-hidden rounded-xl border p-1 shadow-lg ${collapsed ? "w-64" : "right-2"}`}
           style={{ zIndex: 20, borderColor: "var(--border-default)", background: "var(--bg-elevated)" }}
         >
           <div className="flex items-center justify-between gap-2 px-2 py-1.5">
@@ -90,36 +95,38 @@ export default function RuntimeComputerMenu({ collapsed }: { collapsed: boolean 
               <LoaderCircle size={13} className="animate-spin" aria-hidden="true" /> Loading computers…
             </p>
           ) : null}
-          {computers.map((computer) => {
-            const selected = computer.runtimeSlot === runtimeSlot;
-            const switching = switchingSlot === computer.runtimeSlot;
-            const disabled = selected || computer.availability !== "available" || Boolean(switchingSlot);
-            return (
-              <button
-                key={computer.runtimeSlot}
-                type="button"
-                role="option"
-                aria-selected={selected}
-                disabled={disabled}
-                className="flex w-full items-center gap-2 rounded-lg px-2 py-2 text-left outline-none hover:bg-[var(--bg-hover)] focus-visible:ring-2 focus-visible:ring-[var(--accent)] disabled:opacity-60"
-                onClick={() => {
-                  setOpen(false);
-                  void select(computer.runtimeSlot);
-                }}
-              >
-                <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md" style={{ background: selected ? "var(--accent-muted)" : "var(--bg-hover)", color: selected ? "var(--accent)" : "var(--text-secondary)" }}>
-                  {switching ? <LoaderCircle size={14} className="animate-spin" aria-hidden="true" /> : <Monitor size={14} aria-hidden="true" />}
-                </span>
-                <span className="min-w-0 flex-1">
-                  <span className="block truncate text-xs font-medium" style={{ color: "var(--text-primary)" }}>{computer.label}</span>
-                  <span className="block truncate text-[10px]" style={{ color: "var(--text-tertiary)" }}>
-                    {selected ? "Current" : STATUS_LABEL[computer.availability]} · {computer.handle}
+          <div className="max-h-72 overflow-y-auto">
+            {computers.map((computer) => {
+              const selected = computer.runtimeSlot === selectedSlot;
+              const switching = switchingSlot === computer.runtimeSlot;
+              const disabled = selected || computer.availability !== "available" || Boolean(switchingSlot);
+              return (
+                <button
+                  key={computer.runtimeSlot}
+                  type="button"
+                  role="option"
+                  aria-selected={selected}
+                  disabled={disabled}
+                  className="flex w-full items-center gap-2 rounded-lg px-2 py-2 text-left outline-none hover:bg-[var(--bg-hover)] focus-visible:ring-2 focus-visible:ring-[var(--accent)] disabled:opacity-60"
+                  onClick={() => {
+                    setOpen(false);
+                    void select(computer.runtimeSlot);
+                  }}
+                >
+                  <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md" style={{ background: selected ? "var(--accent-muted)" : "var(--bg-hover)", color: selected ? "var(--accent)" : "var(--text-secondary)" }}>
+                    {switching ? <LoaderCircle size={14} className="animate-spin" aria-hidden="true" /> : <Monitor size={14} aria-hidden="true" />}
                   </span>
-                </span>
-                {selected ? <Check size={13} className="shrink-0" style={{ color: "var(--accent)" }} aria-hidden="true" /> : null}
-              </button>
-            );
-          })}
+                  <span className="min-w-0 flex-1">
+                    <span className="block truncate text-xs font-medium" style={{ color: "var(--text-primary)" }}>{computer.label}</span>
+                    <span className="block truncate text-[10px]" style={{ color: "var(--text-tertiary)" }}>
+                      {selected ? "Current" : STATUS_LABEL[computer.availability]} · {computer.handle}
+                    </span>
+                  </span>
+                  {selected ? <Check size={13} className="shrink-0" style={{ color: "var(--accent)" }} aria-hidden="true" /> : null}
+                </button>
+              );
+            })}
+          </div>
           {switchError ? <p className="px-2 py-2 text-[11px]" style={{ color: "var(--danger)" }}>Couldn&apos;t switch computers. Try again.</p> : null}
         </div>
       ) : null}

--- a/desktop/src/renderer/src/features/runtime/RuntimeComputerMenu.tsx
+++ b/desktop/src/renderer/src/features/runtime/RuntimeComputerMenu.tsx
@@ -1,0 +1,152 @@
+import { Check, ChevronUp, LoaderCircle, Monitor, RefreshCw } from "lucide-react";
+import { useEffect, useMemo, useRef, useState } from "react";
+import { useConnection } from "../../stores/connection";
+import { useRuntimeComputers } from "../../stores/runtime-computers";
+
+const STATUS_LABEL = {
+  available: "Available",
+  starting: "Starting",
+  unavailable: "Unavailable",
+} as const;
+
+function fallbackComputerLabel(slot: string): string {
+  if (slot === "primary") return "Main Computer";
+  return `${slot.split("-").map((part) => `${part.charAt(0).toUpperCase()}${part.slice(1)}`).join(" ")} Computer`;
+}
+
+export default function RuntimeComputerMenu({ collapsed }: { collapsed: boolean }) {
+  const connectionStatus = useConnection((state) => state.status);
+  const platformHost = useConnection((state) => state.platformHost);
+  const handle = useConnection((state) => state.handle);
+  const runtimeSlot = useConnection((state) => state.runtimeSlot);
+  const loadStatus = useRuntimeComputers((state) => state.status);
+  const computers = useRuntimeComputers((state) => state.computers);
+  const switchingSlot = useRuntimeComputers((state) => state.switchingSlot);
+  const switchError = useRuntimeComputers((state) => state.switchError);
+  const refresh = useRuntimeComputers((state) => state.refresh);
+  const select = useRuntimeComputers((state) => state.select);
+  const [open, setOpen] = useState(false);
+  const rootRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    void refresh();
+  }, [connectionStatus, handle, platformHost, refresh, runtimeSlot]);
+
+  useEffect(() => {
+    if (!open) return;
+    const closeOnPointer = (event: PointerEvent) => {
+      if (!rootRef.current?.contains(event.target as Node)) setOpen(false);
+    };
+    const closeOnEscape = (event: KeyboardEvent) => {
+      if (event.key === "Escape") setOpen(false);
+    };
+    document.addEventListener("pointerdown", closeOnPointer);
+    document.addEventListener("keydown", closeOnEscape);
+    return () => {
+      document.removeEventListener("pointerdown", closeOnPointer);
+      document.removeEventListener("keydown", closeOnEscape);
+    };
+  }, [open]);
+
+  const current = useMemo(
+    () => computers.find((computer) => computer.runtimeSlot === runtimeSlot)
+      ?? null,
+    [computers, runtimeSlot],
+  );
+  const currentLabel = current?.label ?? fallbackComputerLabel(runtimeSlot);
+  const buttonLabel = loadStatus === "error"
+    ? "Computer list unavailable"
+    : `Change computer, currently ${currentLabel}`;
+
+  return (
+    <div ref={rootRef} className="relative px-2 py-1">
+      {open ? (
+        <div
+          role="listbox"
+          aria-label="Choose computer"
+          className="absolute bottom-full left-2 right-2 mb-1 overflow-hidden rounded-xl border p-1 shadow-lg"
+          style={{ zIndex: 20, borderColor: "var(--border-default)", background: "var(--bg-elevated)" }}
+        >
+          <div className="flex items-center justify-between gap-2 px-2 py-1.5">
+            <span className="text-[10px] font-semibold uppercase tracking-[0.1em]" style={{ color: "var(--text-tertiary)" }}>
+              Computers
+            </span>
+            <button
+              type="button"
+              aria-label="Retry computers"
+              disabled={loadStatus === "loading"}
+              className="rounded p-1 hover:bg-[var(--bg-hover)] disabled:opacity-40"
+              style={{ color: "var(--text-tertiary)" }}
+              onClick={() => void refresh({ force: true })}
+            >
+              <RefreshCw size={12} className={loadStatus === "loading" ? "animate-spin" : ""} aria-hidden="true" />
+            </button>
+          </div>
+          {loadStatus === "error" ? (
+            <p className="px-2 py-3 text-xs" style={{ color: "var(--text-secondary)" }}>Computers unavailable</p>
+          ) : null}
+          {loadStatus === "loading" && computers.length === 0 ? (
+            <p className="flex items-center gap-2 px-2 py-3 text-xs" style={{ color: "var(--text-secondary)" }}>
+              <LoaderCircle size={13} className="animate-spin" aria-hidden="true" /> Loading computers…
+            </p>
+          ) : null}
+          {computers.map((computer) => {
+            const selected = computer.runtimeSlot === runtimeSlot;
+            const switching = switchingSlot === computer.runtimeSlot;
+            const disabled = selected || computer.availability !== "available" || Boolean(switchingSlot);
+            return (
+              <button
+                key={computer.runtimeSlot}
+                type="button"
+                role="option"
+                aria-selected={selected}
+                disabled={disabled}
+                className="flex w-full items-center gap-2 rounded-lg px-2 py-2 text-left outline-none hover:bg-[var(--bg-hover)] focus-visible:ring-2 focus-visible:ring-[var(--accent)] disabled:opacity-60"
+                onClick={() => {
+                  setOpen(false);
+                  void select(computer.runtimeSlot);
+                }}
+              >
+                <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md" style={{ background: selected ? "var(--accent-muted)" : "var(--bg-hover)", color: selected ? "var(--accent)" : "var(--text-secondary)" }}>
+                  {switching ? <LoaderCircle size={14} className="animate-spin" aria-hidden="true" /> : <Monitor size={14} aria-hidden="true" />}
+                </span>
+                <span className="min-w-0 flex-1">
+                  <span className="block truncate text-xs font-medium" style={{ color: "var(--text-primary)" }}>{computer.label}</span>
+                  <span className="block truncate text-[10px]" style={{ color: "var(--text-tertiary)" }}>
+                    {selected ? "Current" : STATUS_LABEL[computer.availability]} · {computer.handle}
+                  </span>
+                </span>
+                {selected ? <Check size={13} className="shrink-0" style={{ color: "var(--accent)" }} aria-hidden="true" /> : null}
+              </button>
+            );
+          })}
+          {switchError ? <p className="px-2 py-2 text-[11px]" style={{ color: "var(--danger)" }}>Couldn&apos;t switch computers. Try again.</p> : null}
+        </div>
+      ) : null}
+      <button
+        type="button"
+        aria-label={buttonLabel}
+        title={collapsed ? currentLabel : undefined}
+        aria-haspopup="listbox"
+        aria-expanded={open}
+        className={`flex h-9 w-full items-center rounded-md transition-colors hover:bg-[var(--bg-hover)] ${collapsed ? "justify-center" : "gap-2 px-2"}`}
+        style={{ color: "var(--text-secondary)" }}
+        onClick={() => setOpen((value) => !value)}
+      >
+        <span className="relative flex h-6 w-6 shrink-0 items-center justify-center rounded-md" style={{ background: "var(--bg-hover)" }}>
+          <Monitor size={14} aria-hidden="true" />
+          <span className="absolute -bottom-0.5 -right-0.5 h-2 w-2 rounded-full border" style={{ background: current?.availability === "available" ? "var(--success)" : loadStatus === "error" ? "var(--danger)" : "var(--warning)", borderColor: "var(--bg-sunken)" }} />
+        </span>
+        {!collapsed ? (
+          <>
+            <span className="min-w-0 flex-1 text-left">
+              <span className="block truncate text-xs font-medium" style={{ color: "var(--text-primary)" }}>{currentLabel}</span>
+              <span className="block truncate text-[10px]" style={{ color: "var(--text-tertiary)" }}>{current?.handle ?? handle ?? "Select computer"}</span>
+            </span>
+            <ChevronUp size={13} className="shrink-0 transition-transform" style={{ transform: open ? "rotate(180deg)" : undefined }} aria-hidden="true" />
+          </>
+        ) : null}
+      </button>
+    </div>
+  );
+}

--- a/desktop/src/renderer/src/features/settings/sections/RuntimeSection.tsx
+++ b/desktop/src/renderer/src/features/settings/sections/RuntimeSection.tsx
@@ -83,19 +83,24 @@ export default function RuntimeSection() {
   const handle = useConnection((state) => state.handle);
   const platformHost = useConnection((state) => state.platformHost);
   const runtimeSlot = useConnection((state) => state.runtimeSlot);
+  const authGeneration = useConnection((state) => state.authGeneration);
   const loadState = useRuntimeComputers((state) => state.status);
   const computers = useRuntimeComputers((state) => state.computers);
+  const serverSelectedSlot = useRuntimeComputers((state) => state.runtimeSlot);
   const switchingSlot = useRuntimeComputers((state) => state.switchingSlot);
   const switchError = useRuntimeComputers((state) => state.switchError);
   const refresh = useRuntimeComputers((state) => state.refresh);
   const selectComputer = useRuntimeComputers((state) => state.select);
+  // The inventory response's selectedSlot reflects the credential in use; the
+  // persisted profile slot is only a fallback until the first refresh lands.
+  const selectedSlot = serverSelectedSlot ?? runtimeSlot;
 
   useEffect(() => {
     void refresh();
-  }, [connectionStatus, handle, platformHost, refresh, runtimeSlot]);
+  }, [authGeneration, connectionStatus, handle, platformHost, refresh, runtimeSlot]);
 
   async function switchComputer(computer: MatrixComputer): Promise<void> {
-    if (computer.runtimeSlot === runtimeSlot || computer.availability !== "available" || switchingSlot) return;
+    if (computer.runtimeSlot === selectedSlot || computer.availability !== "available" || switchingSlot) return;
     await selectComputer(computer.runtimeSlot);
   }
 
@@ -140,7 +145,7 @@ export default function RuntimeSection() {
               <ComputerCard
                 key={computer.runtimeSlot}
                 computer={computer}
-                selected={computer.runtimeSlot === runtimeSlot}
+                selected={computer.runtimeSlot === selectedSlot}
                 switching={switchingSlot === computer.runtimeSlot}
                 onSelect={(next) => {
                   void switchComputer(next);

--- a/desktop/src/renderer/src/features/settings/sections/RuntimeSection.tsx
+++ b/desktop/src/renderer/src/features/settings/sections/RuntimeSection.tsx
@@ -1,14 +1,12 @@
 import { Check, LoaderCircle, Monitor, RefreshCw } from "lucide-react";
-import { useEffect, useState } from "react";
+import { useEffect } from "react";
 import {
-  MatrixComputerListSchema,
   type MatrixComputer,
 } from "@matrix-os/contracts";
 import { Button } from "../../../design/primitives";
 import { useConnection } from "../../../stores/connection";
+import { useRuntimeComputers } from "../../../stores/runtime-computers";
 import { Card, Empty, SectionHeader } from "./section-kit";
-
-type LoadState = "loading" | "ready" | "error";
 
 const STATUS_LABEL: Record<MatrixComputer["availability"], string> = {
   available: "Available",
@@ -81,56 +79,24 @@ function ComputerCard({
 }
 
 export default function RuntimeSection() {
-  const api = useConnection((state) => state.api);
+  const connectionStatus = useConnection((state) => state.status);
+  const handle = useConnection((state) => state.handle);
+  const platformHost = useConnection((state) => state.platformHost);
   const runtimeSlot = useConnection((state) => state.runtimeSlot);
-  const selectRuntime = useConnection((state) => state.selectRuntime);
-  const [loadState, setLoadState] = useState<LoadState>("loading");
-  const [computers, setComputers] = useState<MatrixComputer[]>([]);
-  const [selectedSlot, setSelectedSlot] = useState<string | null>(runtimeSlot);
-  const [switchingSlot, setSwitchingSlot] = useState<string | null>(null);
-  const [switchError, setSwitchError] = useState(false);
-  const [reloadKey, setReloadKey] = useState(0);
+  const loadState = useRuntimeComputers((state) => state.status);
+  const computers = useRuntimeComputers((state) => state.computers);
+  const switchingSlot = useRuntimeComputers((state) => state.switchingSlot);
+  const switchError = useRuntimeComputers((state) => state.switchError);
+  const refresh = useRuntimeComputers((state) => state.refresh);
+  const selectComputer = useRuntimeComputers((state) => state.select);
 
   useEffect(() => {
-    let active = true;
-    if (!api) {
-      setComputers([]);
-      setLoadState("error");
-      return () => {
-        active = false;
-      };
-    }
-    setLoadState("loading");
-    setSwitchError(false);
-    void api.get("/api/auth/computers")
-      .then((response) => MatrixComputerListSchema.parse(response))
-      .then((response) => {
-        if (!active) return;
-        setComputers(response.items);
-        setSelectedSlot(response.selectedSlot);
-        setLoadState("ready");
-      })
-      .catch(() => {
-        if (!active) return;
-        setComputers([]);
-        setLoadState("error");
-      });
-    return () => {
-      active = false;
-    };
-  }, [api, reloadKey, runtimeSlot]);
+    void refresh();
+  }, [connectionStatus, handle, platformHost, refresh, runtimeSlot]);
 
   async function switchComputer(computer: MatrixComputer): Promise<void> {
-    if (computer.runtimeSlot === selectedSlot || computer.availability !== "available" || switchingSlot) return;
-    setSwitchError(false);
-    setSwitchingSlot(computer.runtimeSlot);
-    try {
-      await selectRuntime(computer.runtimeSlot);
-    } catch {
-      setSwitchError(true);
-    } finally {
-      setSwitchingSlot(null);
-    }
+    if (computer.runtimeSlot === runtimeSlot || computer.availability !== "available" || switchingSlot) return;
+    await selectComputer(computer.runtimeSlot);
   }
 
   return (
@@ -151,7 +117,7 @@ export default function RuntimeSection() {
             variant="ghost"
             aria-label="Refresh computers"
             disabled={loadState === "loading"}
-            onClick={() => setReloadKey((value) => value + 1)}
+            onClick={() => void refresh({ force: true })}
           >
             <RefreshCw size={14} className={loadState === "loading" ? "animate-spin" : ""} aria-hidden="true" />
             Refresh
@@ -174,7 +140,7 @@ export default function RuntimeSection() {
               <ComputerCard
                 key={computer.runtimeSlot}
                 computer={computer}
-                selected={computer.runtimeSlot === selectedSlot}
+                selected={computer.runtimeSlot === runtimeSlot}
                 switching={switchingSlot === computer.runtimeSlot}
                 onSelect={(next) => {
                   void switchComputer(next);

--- a/desktop/src/renderer/src/features/workspace/PanelStrip.tsx
+++ b/desktop/src/renderer/src/features/workspace/PanelStrip.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from "react";
+import { Component, useMemo, type ErrorInfo, type ReactNode } from "react";
 import { Group, Panel, Separator, type Layout as GroupLayout } from "react-resizable-panels";
 import {
   useWorkspace,
@@ -18,6 +18,36 @@ export const PANEL_TITLES: Record<PanelKind, string> = {
   processes: "Processes",
   timeline: "Timeline",
 };
+
+export class PanelErrorBoundary extends Component<{
+  children: ReactNode;
+  panel: PanelKind;
+}, { failed: boolean }> {
+  override state = { failed: false };
+
+  static getDerivedStateFromError(): { failed: boolean } {
+    return { failed: true };
+  }
+
+  override componentDidCatch(error: Error, info: ErrorInfo): void {
+    console.warn(
+      `[task-workspace] ${this.props.panel} panel failed (${error.name}; component stack: ${info.componentStack ? "present" : "missing"})`,
+    );
+  }
+
+  override render(): ReactNode {
+    if (!this.state.failed) return this.props.children;
+    return (
+      <div
+        role="alert"
+        className="flex min-h-0 flex-1 items-center justify-center px-4 text-center text-sm"
+        style={{ color: "var(--text-secondary)" }}
+      >
+        {PANEL_TITLES[this.props.panel]} panel couldn&apos;t open.
+      </div>
+    );
+  }
+}
 
 interface PanelStripProps {
   taskId: string;
@@ -117,7 +147,9 @@ function PanelHost({
         >
           {PANEL_TITLES[panel]}
         </header>
-        <div className="flex min-h-0 min-w-0 flex-1 flex-col">{renderPanel(panel)}</div>
+        <div className="flex min-h-0 min-w-0 flex-1 flex-col">
+          <PanelErrorBoundary panel={panel}>{renderPanel(panel)}</PanelErrorBoundary>
+        </div>
       </Panel>
     </>
   );

--- a/desktop/src/renderer/src/lib/kernel-wiring.ts
+++ b/desktop/src/renderer/src/lib/kernel-wiring.ts
@@ -56,6 +56,16 @@ export function getKernelSocket(): KernelSocket | null {
   return socket;
 }
 
+export function resetKernel(): void {
+  if (cleanupKernel) {
+    cleanupKernel();
+    cleanupKernel = null;
+  } else if (socket) {
+    socket.dispose();
+    socket = null;
+  }
+}
+
 export function sendKernelMessage(msg: {
   text: string;
   sessionId?: string;

--- a/desktop/src/renderer/src/stores/board.ts
+++ b/desktop/src/renderer/src/stores/board.ts
@@ -421,13 +421,16 @@ export const useBoard = create<BoardState>()((set, get) => {
         ...(fields.linkedWorktreeId !== undefined ? { linkedWorktreeId: fields.linkedWorktreeId } : {}),
         ...(fields.status !== undefined ? { status: fields.status } : {}),
       }));
+      const runtimeGeneration = captureRuntimeGeneration();
       return enqueueTaskMutation(taskId, async () => {
         try {
           const response = await api.patch<{ task: unknown }>(taskPath(slug, taskId), fields);
+          if (!isCurrentRuntimeGeneration(runtimeGeneration)) return;
           const card = toCard(response.task);
           if (card) patchCard(slug, taskId, () => card);
           set({ error: null });
         } catch (err: unknown) {
+          if (!isCurrentRuntimeGeneration(runtimeGeneration)) return;
           console.error("[board] Link session failed:", err);
           patchCard(slug, taskId, () => before);
           await refreshInto(api, slug);
@@ -447,15 +450,18 @@ export const useBoard = create<BoardState>()((set, get) => {
         set({ error: "server" });
         return Promise.resolve();
       }
+      const runtimeGeneration = captureRuntimeGeneration();
       return enqueueTaskMutation(taskId, async () => {
         try {
           const response = await api.patch<{ task: unknown }>(taskPath(slug, taskId), {
             status: "archived",
           });
+          if (!isCurrentRuntimeGeneration(runtimeGeneration)) return;
           const card = toCard(response.task);
           if (card) patchCard(slug, taskId, () => card);
           set({ error: null });
         } catch (err: unknown) {
+          if (!isCurrentRuntimeGeneration(runtimeGeneration)) return;
           console.error("[board] Task archive failed:", err);
           set({ error: categoryOf(err) });
         }
@@ -469,9 +475,11 @@ export const useBoard = create<BoardState>()((set, get) => {
         set({ error: "server" });
         return Promise.resolve();
       }
+      const runtimeGeneration = captureRuntimeGeneration();
       return enqueueTaskMutation(taskId, async () => {
         try {
           await api.delete<{ ok: boolean }>(taskPath(slug, taskId));
+          if (!isCurrentRuntimeGeneration(runtimeGeneration)) return;
           set((state) => {
             const current = state.cardsByProject[slug] ?? [];
             return {
@@ -483,6 +491,7 @@ export const useBoard = create<BoardState>()((set, get) => {
             };
           });
         } catch (err: unknown) {
+          if (!isCurrentRuntimeGeneration(runtimeGeneration)) return;
           console.error("[board] Task delete failed:", err);
           set({ error: categoryOf(err) });
         }

--- a/desktop/src/renderer/src/stores/board.ts
+++ b/desktop/src/renderer/src/stores/board.ts
@@ -10,6 +10,7 @@ import { create } from "zustand";
 import { z } from "zod/v4";
 import { AppError, type AppErrorCategory } from "../../../shared/app-error";
 import type { ApiClient } from "../lib/api";
+import { captureRuntimeGeneration, isCurrentRuntimeGeneration } from "./runtime-generation";
 
 export type CardStatus = "todo" | "running" | "waiting" | "blocked" | "complete" | "archived";
 export type CardPriority = "low" | "normal" | "high" | "urgent";
@@ -252,12 +253,15 @@ export const useBoard = create<BoardState>()((set, get) => {
   }
 
   async function refreshInto(api: ApiClient, slug: string): Promise<void> {
+    const runtimeGeneration = captureRuntimeGeneration();
     set({ refreshing: true });
     try {
       const cards = await fetchAllTasks(api, slug);
+      if (!isCurrentRuntimeGeneration(runtimeGeneration)) return;
       replaceProjectCards(slug, cards);
       set({ refreshing: false, error: null });
     } catch (err: unknown) {
+      if (!isCurrentRuntimeGeneration(runtimeGeneration)) return;
       console.error("[board] Failed to load tasks:", err);
       set({ refreshing: false, error: categoryOf(err) });
     }
@@ -303,8 +307,10 @@ export const useBoard = create<BoardState>()((set, get) => {
     error: null,
 
     loadProjects: async (api) => {
+      const runtimeGeneration = captureRuntimeGeneration();
       try {
         const response = await api.get<{ projects: unknown[] }>("/api/workspace/projects");
+        if (!isCurrentRuntimeGeneration(runtimeGeneration)) return false;
         const projects: Project[] = [];
         for (const raw of response.projects ?? []) {
           const project = toProject(raw);
@@ -313,6 +319,7 @@ export const useBoard = create<BoardState>()((set, get) => {
         set({ projects, error: null });
         return true;
       } catch (err: unknown) {
+        if (!isCurrentRuntimeGeneration(runtimeGeneration)) return false;
         console.error("[board] Failed to load projects:", err);
         set({ error: categoryOf(err) });
         return false;

--- a/desktop/src/renderer/src/stores/board.ts
+++ b/desktop/src/renderer/src/stores/board.ts
@@ -34,6 +34,8 @@ export interface Card {
 export interface Project {
   slug: string;
   name: string;
+  localPath?: string;
+  githubBacked?: boolean;
 }
 
 export const BOARD_COLUMNS: readonly CardStatus[] = [
@@ -66,7 +68,21 @@ const WireTaskSchema = z.object({
 const WireProjectSchema = z.object({
   slug: z.string().min(1),
   name: z.string().min(1),
+  localPath: z.string().min(1).optional(),
+  github: z.object({ owner: z.string(), repo: z.string() }).passthrough().optional(),
 });
+
+function toProject(raw: unknown): Project | null {
+  const parsed = WireProjectSchema.safeParse(raw);
+  if (!parsed.success) return null;
+  return {
+    slug: parsed.data.slug,
+    name: parsed.data.name,
+    ...(parsed.data.localPath
+      ? { localPath: parsed.data.localPath, githubBacked: parsed.data.github !== undefined }
+      : {}),
+  };
+}
 
 function toCard(raw: unknown): Card | null {
   const parsed = WireTaskSchema.safeParse(raw);
@@ -195,7 +211,12 @@ interface BoardState {
   refreshing: boolean;
   error: AppErrorCategory | null;
   loadProjects(api: ApiClient): Promise<boolean>;
-  createProject(api: ApiClient, input: { name: string; mode: "scratch" | "github"; url?: string }): Promise<Project | null>;
+  createProject(api: ApiClient, input: {
+    name: string;
+    mode: "scratch" | "github" | "folder";
+    url?: string;
+    path?: string;
+  }): Promise<Project | null>;
   selectProject(api: ApiClient, slug: string): Promise<void>;
   refreshTasks(api: ApiClient, slug: string): Promise<void>;
   createTask(api: ApiClient, slug: string, input: CreateTaskInput): Promise<Card | null>;
@@ -286,8 +307,8 @@ export const useBoard = create<BoardState>()((set, get) => {
         const response = await api.get<{ projects: unknown[] }>("/api/workspace/projects");
         const projects: Project[] = [];
         for (const raw of response.projects ?? []) {
-          const parsed = WireProjectSchema.safeParse(raw);
-          if (parsed.success) projects.push({ slug: parsed.data.slug, name: parsed.data.name });
+          const project = toProject(raw);
+          if (project) projects.push(project);
         }
         set({ projects, error: null });
         return true;
@@ -300,15 +321,18 @@ export const useBoard = create<BoardState>()((set, get) => {
 
     createProject: async (api, input) => {
       try {
-        const body = input.mode === "github" ? { name: input.name, mode: "github", url: input.url } : { name: input.name, mode: "scratch" };
+        const body = input.mode === "github"
+          ? { name: input.name, mode: "github" as const, url: input.url }
+          : input.mode === "folder"
+            ? { name: input.name, mode: "folder" as const, path: input.path }
+            : { name: input.name, mode: "scratch" as const };
         const res = await api.post<{ project: unknown }>("/api/projects", body);
-        const parsed = WireProjectSchema.safeParse(res.project);
-        if (!parsed.success) {
+        const project = toProject(res.project);
+        if (!project) {
           const refreshed = await get().loadProjects(api);
           set({ error: refreshed ? "server" : get().error });
           return null;
         }
-        const project: Project = { slug: parsed.data.slug, name: parsed.data.name };
         // Refresh the list so the sidebar shows it immediately.
         const refreshed = await get().loadProjects(api);
         if (refreshed) set({ error: null });

--- a/desktop/src/renderer/src/stores/board.ts
+++ b/desktop/src/renderer/src/stores/board.ts
@@ -279,14 +279,17 @@ export const useBoard = create<BoardState>()((set, get) => {
       set({ error: "server" });
       return Promise.resolve();
     }
+    const runtimeGeneration = captureRuntimeGeneration();
     patchCard(slug, taskId, (card) => ({ ...card, ...patch }));
     return enqueueTaskMutation(taskId, async () => {
       try {
         const response = await api.patch<{ task: unknown }>(taskPath(slug, taskId), patch);
+        if (!isCurrentRuntimeGeneration(runtimeGeneration)) return;
         const card = toCard(response.task);
         if (card) patchCard(slug, taskId, () => card);
         set({ error: null });
       } catch (err: unknown) {
+        if (!isCurrentRuntimeGeneration(runtimeGeneration)) return;
         console.error("[board] Task update failed:", err);
         patchCard(slug, taskId, () => before);
         // FR-011: a rejected write may mean our base was stale — converge on
@@ -327,6 +330,9 @@ export const useBoard = create<BoardState>()((set, get) => {
     },
 
     createProject: async (api, input) => {
+      // A create that settles after a computer switch must not repopulate the
+      // new computer's board with the previous runtime's projects.
+      const runtimeGeneration = captureRuntimeGeneration();
       try {
         const body = input.mode === "github"
           ? { name: input.name, mode: "github" as const, url: input.url }
@@ -334,6 +340,7 @@ export const useBoard = create<BoardState>()((set, get) => {
             ? { name: input.name, mode: "folder" as const, path: input.path }
             : { name: input.name, mode: "scratch" as const };
         const res = await api.post<{ project: unknown }>("/api/projects", body);
+        if (!isCurrentRuntimeGeneration(runtimeGeneration)) return null;
         const project = toProject(res.project);
         if (!project) {
           const refreshed = await get().loadProjects(api);
@@ -345,6 +352,7 @@ export const useBoard = create<BoardState>()((set, get) => {
         if (refreshed) set({ error: null });
         return project;
       } catch (err: unknown) {
+        if (!isCurrentRuntimeGeneration(runtimeGeneration)) return null;
         console.error("[board] Create project failed:", err);
         set({ error: categoryOf(err) });
         return null;
@@ -371,8 +379,10 @@ export const useBoard = create<BoardState>()((set, get) => {
     },
 
     createTask: async (api, slug, input) => {
+      const runtimeGeneration = captureRuntimeGeneration();
       try {
         const response = await api.post<{ task: unknown }>(taskPath(slug), input);
+        if (!isCurrentRuntimeGeneration(runtimeGeneration)) return null;
         const card = toCard(response.task);
         if (!card) {
           set({ error: "server" });
@@ -389,6 +399,7 @@ export const useBoard = create<BoardState>()((set, get) => {
         }));
         return card;
       } catch (err: unknown) {
+        if (!isCurrentRuntimeGeneration(runtimeGeneration)) return null;
         console.error("[board] Task create failed:", err);
         set({ error: categoryOf(err) });
         return null;

--- a/desktop/src/renderer/src/stores/coding-agent-project-workspace.ts
+++ b/desktop/src/renderer/src/stores/coding-agent-project-workspace.ts
@@ -35,6 +35,21 @@ interface CodingAgentProjectWorkspaceState extends ProjectWorkspaceSelection {
 
 let hydrationGeneration = 0;
 
+export function clearCodingAgentProjectRuntime(): void {
+  hydrationGeneration += 1;
+  useCodingAgentProjectWorkspace.setState({
+    status: "idle",
+    runtimeId: null,
+    runtimeScope: null,
+    summary: null,
+    workspace: null,
+    error: null,
+    selectedProjectId: null,
+    selectedTaskId: null,
+    selectedThreadId: null,
+  });
+}
+
 function currentSelection(
   state: Pick<CodingAgentProjectWorkspaceState, keyof ProjectWorkspaceSelection>,
 ): ProjectWorkspaceSelection {

--- a/desktop/src/renderer/src/stores/coding-agent-workspace.ts
+++ b/desktop/src/renderer/src/stores/coding-agent-workspace.ts
@@ -378,6 +378,10 @@ export function clearCodingAgentRuntimeSelection(): void {
     summary: null,
     error: null,
     createdThreadHandles: [],
+    // A create abandoned mid-flight by the switch must not leave the new
+    // runtime's composer blocked on a phantom "submitting" state.
+    createStatus: "idle",
+    createError: null,
     reviewsStatus: "idle",
     reviews: null,
     reviewsError: null,

--- a/desktop/src/renderer/src/stores/coding-agent-workspace.ts
+++ b/desktop/src/renderer/src/stores/coding-agent-workspace.ts
@@ -364,8 +364,18 @@ export function clearCodingAgentThreadSelection(): void {
 
 export function clearCodingAgentRuntimeSelection(): void {
   clearCodingAgentThreadSelection();
+  refreshSeq += 1;
   reviewsSeq += 1;
+  reviewSnapshotSeq += 1;
+  fileReadSeq += 1;
+  threadSnapshotSeq += 1;
+  notificationPreferencesSeq += 1;
+  createRequestSeq += 1;
+  actionRequestSeq += 1;
   useCodingAgentWorkspace.setState({
+    status: "idle",
+    summary: null,
+    error: null,
     createdThreadHandles: [],
     reviewsStatus: "idle",
     reviews: null,

--- a/desktop/src/renderer/src/stores/coding-agent-workspace.ts
+++ b/desktop/src/renderer/src/stores/coding-agent-workspace.ts
@@ -22,6 +22,7 @@ import {
 } from "@matrix-os/contracts";
 import { create } from "zustand";
 import { invoke, onEvent } from "../lib/operator";
+import { captureRuntimeGeneration, isCurrentRuntimeGeneration } from "./runtime-generation";
 
 type WorkspaceStatus = "idle" | "loading" | "ready" | "error";
 type ReviewStatus = "idle" | "loading" | "ready" | "error";
@@ -1061,9 +1062,14 @@ export const useCodingAgentWorkspace = create<CodingAgentWorkspaceState>()((set)
       return null;
     }
 
+    // A computer switch advances the runtime generation and clears this store;
+    // a create that settles afterwards must not install the old runtime's
+    // thread into the new runtime's state.
+    const runtimeGeneration = captureRuntimeGeneration();
     set({ createStatus: "submitting", createError: null });
     try {
       const snapshot = await invoke("runtime:create-thread", built.request);
+      if (!isCurrentRuntimeGeneration(runtimeGeneration)) return null;
       const thread = snapshot.thread;
       set((state) => {
         const createdThreadHandles = [
@@ -1107,6 +1113,7 @@ export const useCodingAgentWorkspace = create<CodingAgentWorkspaceState>()((set)
       });
       return thread.id;
     } catch {
+      if (!isCurrentRuntimeGeneration(runtimeGeneration)) return null;
       console.warn("[coding-agents] thread create failed");
       set({ createStatus: "idle", createError: "Agent run could not be started. Try again." });
       return null;

--- a/desktop/src/renderer/src/stores/connection.ts
+++ b/desktop/src/renderer/src/stores/connection.ts
@@ -14,6 +14,9 @@ interface ConnectionState {
   imageUrl: string | null;
   platformHost: string;
   runtimeSlot: string;
+  // Trusted-core credential generation; advances on every credential
+  // replacement so caches keyed on visible identity cannot cross sessions.
+  authGeneration: number;
   api: ApiClient | null;
   refresh: () => Promise<void>;
   selectRuntime: (slot: string) => Promise<void>;
@@ -27,6 +30,7 @@ export const useConnection = create<ConnectionState>()((set, get) => ({
   imageUrl: null,
   platformHost: "",
   runtimeSlot: "primary",
+  authGeneration: 0,
   api: null,
 
   refresh: async () => {
@@ -50,6 +54,7 @@ export const useConnection = create<ConnectionState>()((set, get) => ({
         imageUrl: status.imageUrl ?? null,
         platformHost: status.platformHost,
         runtimeSlot: status.runtimeSlot,
+        authGeneration: status.authGeneration,
         api,
       });
     } catch (err: unknown) {
@@ -59,16 +64,18 @@ export const useConnection = create<ConnectionState>()((set, get) => ({
   },
 
   selectRuntime: async (slot) => {
-    reconcileDesktopRuntimeChange();
     try {
       await invoke("runtime:select", { slot });
-      set({ runtimeSlot: slot });
     } catch (err: unknown) {
-      // Recreate the API client so runtime-bound surfaces reload the still
-      // selected computer after a failed switch.
+      // The switch never happened: keep every surface on the still-selected
+      // computer and refresh the auth snapshot so the API client stays valid.
       await get().refresh();
       throw err;
     }
+    // Clear previous-computer state only after the trusted core confirms the
+    // switch, and before the new slot becomes observable to the UI.
+    reconcileDesktopRuntimeChange();
+    set({ runtimeSlot: slot });
   },
 
   signOut: async () => {

--- a/desktop/src/renderer/src/stores/connection.ts
+++ b/desktop/src/renderer/src/stores/connection.ts
@@ -3,6 +3,7 @@
 import { create } from "zustand";
 import { invoke, onEvent } from "../lib/operator";
 import { createApiClient, type ApiClient } from "../lib/api";
+import { reconcileDesktopRuntimeChange } from "./runtime-transition";
 
 export type ConnectionStatus = "loading" | "signed-out" | "signed-in";
 
@@ -58,8 +59,16 @@ export const useConnection = create<ConnectionState>()((set, get) => ({
   },
 
   selectRuntime: async (slot) => {
-    await invoke("runtime:select", { slot });
-    set({ runtimeSlot: slot });
+    reconcileDesktopRuntimeChange();
+    try {
+      await invoke("runtime:select", { slot });
+      set({ runtimeSlot: slot });
+    } catch (err: unknown) {
+      // Recreate the API client so runtime-bound surfaces reload the still
+      // selected computer after a failed switch.
+      await get().refresh();
+      throw err;
+    }
   },
 
   signOut: async () => {

--- a/desktop/src/renderer/src/stores/connection.ts
+++ b/desktop/src/renderer/src/stores/connection.ts
@@ -64,18 +64,28 @@ export const useConnection = create<ConnectionState>()((set, get) => ({
   },
 
   selectRuntime: async (slot) => {
+    // The trusted core emits runtime:changed before the runtime:select invoke
+    // resolves. If the wired listener refreshed immediately, the new slot and
+    // API would become observable before reconciliation, letting surfaces load
+    // the new computer under the old runtime generation only to be wiped.
+    runtimeSwitchesInFlight += 1;
     try {
       await invoke("runtime:select", { slot });
+      // Clear previous-computer state only after the trusted core confirms the
+      // switch, and before the new slot becomes observable to the UI.
+      reconcileDesktopRuntimeChange();
+      set({ runtimeSlot: slot });
     } catch (err: unknown) {
       // The switch never happened: keep every surface on the still-selected
       // computer and refresh the auth snapshot so the API client stays valid.
       await get().refresh();
       throw err;
+    } finally {
+      runtimeSwitchesInFlight -= 1;
     }
-    // Clear previous-computer state only after the trusted core confirms the
-    // switch, and before the new slot becomes observable to the UI.
-    reconcileDesktopRuntimeChange();
-    set({ runtimeSlot: slot });
+    // Publish the post-switch snapshot (handle, authGeneration, API) now that
+    // the previous computer's state is gone.
+    await get().refresh();
   },
 
   signOut: async () => {
@@ -86,6 +96,7 @@ export const useConnection = create<ConnectionState>()((set, get) => ({
 
 let wired = false;
 let connectionEventCleanups: Array<() => void> = [];
+let runtimeSwitchesInFlight = 0;
 
 function refreshFromConnectionEvent(): void {
   void useConnection
@@ -96,12 +107,19 @@ function refreshFromConnectionEvent(): void {
     });
 }
 
+function refreshFromRuntimeChangedEvent(): void {
+  // selectRuntime reconciles and refreshes itself; refreshing here would
+  // publish the new slot before the previous computer's state is cleared.
+  if (runtimeSwitchesInFlight > 0) return;
+  refreshFromConnectionEvent();
+}
+
 export function wireConnectionEvents(): void {
   if (wired) return;
   wired = true;
   connectionEventCleanups = [
     onEvent("auth:changed", refreshFromConnectionEvent),
-    onEvent("runtime:changed", refreshFromConnectionEvent),
+    onEvent("runtime:changed", refreshFromRuntimeChangedEvent),
   ];
 }
 

--- a/desktop/src/renderer/src/stores/git.ts
+++ b/desktop/src/renderer/src/stores/git.ts
@@ -6,6 +6,7 @@ import { create } from "zustand";
 import { z } from "zod/v4";
 import { AppError, type AppErrorCategory } from "../../../shared/app-error";
 import type { ApiClient } from "../lib/api";
+import { captureRuntimeGeneration, isCurrentRuntimeGeneration } from "./runtime-generation";
 
 const BranchSchema = z.object({
   name: z.string().min(1),
@@ -158,6 +159,7 @@ export const useGit = create<GitState>()((set, get) => ({
   previewError: null,
 
   loadAll: async (api, slug) => {
+    const runtimeGeneration = captureRuntimeGeneration();
     const requestSeq = ++loadAllRequestSeq;
     set({ loading: true, error: null });
     const failures: AppErrorCategory[] = [];
@@ -199,7 +201,7 @@ export const useGit = create<GitState>()((set, get) => ({
     ]);
 
     set((state) => {
-      if (requestSeq !== loadAllRequestSeq) {
+      if (requestSeq !== loadAllRequestSeq || !isCurrentRuntimeGeneration(runtimeGeneration)) {
         return {};
       }
       return {
@@ -212,6 +214,7 @@ export const useGit = create<GitState>()((set, get) => ({
   },
 
   loadPreviews: async (api, slug, taskId) => {
+    const runtimeGeneration = captureRuntimeGeneration();
     const scope: PreviewScope = { projectSlug: slug, taskId: taskId ?? null };
     const request = markPreviewRequest(scope);
     const query = taskId ? `?limit=100&taskId=${encodeURIComponent(taskId)}` : "?limit=100";
@@ -220,14 +223,14 @@ export const useGit = create<GitState>()((set, get) => ({
       const res = await api.get<{ previews?: unknown }>(`/api/projects/${slug}/previews${query}`);
       const incoming = parseRows(PreviewSchema, res.previews);
       set((state) => {
-        if (!isLatestPreviewRequest(request.key, request.seq)) {
+        if (!isLatestPreviewRequest(request.key, request.seq) || !isCurrentRuntimeGeneration(runtimeGeneration)) {
           return {};
         }
         return { previews: mergePreviewsForScope(state.previews, incoming, slug, taskId), previewError: null };
       });
     } catch (err: unknown) {
       set((state) => {
-        if (!isLatestPreviewRequest(request.key, request.seq)) {
+        if (!isLatestPreviewRequest(request.key, request.seq) || !isCurrentRuntimeGeneration(runtimeGeneration)) {
           return {};
         }
         return { previewError: categoryOf(err) };

--- a/desktop/src/renderer/src/stores/runtime-computers.ts
+++ b/desktop/src/renderer/src/stores/runtime-computers.ts
@@ -24,8 +24,11 @@ let refreshGeneration = 0;
 function currentScope(): { scope: string; runtimeSlot: string } | null {
   const connection = useConnection.getState();
   if (connection.status !== "signed-in" || !connection.platformHost) return null;
+  // The trusted-core auth generation is part of the cache key: a replacement
+  // credential with the same host/handle/slot must never reuse the previous
+  // owner's ready inventory.
   return {
-    scope: `${connection.platformHost}|${connection.handle ?? "signed-in"}`,
+    scope: `${connection.platformHost}|${connection.handle ?? "signed-in"}|${connection.authGeneration}`,
     runtimeSlot: connection.runtimeSlot,
   };
 }
@@ -83,11 +86,14 @@ export const useRuntimeComputers = create<RuntimeComputerState>()((set, get) => 
     const state = get();
     const computer = state.computers.find((candidate) => candidate.runtimeSlot === slot);
     const connection = useConnection.getState();
+    // The server-reported selected slot (refresh response) is authoritative;
+    // the profile-derived connection slot is only a fallback so a stale
+    // profile cannot block switching back to the slot it still names.
+    const effectiveSlot = state.runtimeSlot ?? connection.runtimeSlot;
     if (
       !computer
       || computer.availability !== "available"
-      || state.runtimeSlot === slot
-      || connection.runtimeSlot === slot
+      || effectiveSlot === slot
       || state.switchingSlot
     ) {
       return false;
@@ -109,7 +115,7 @@ useConnection.subscribe((connection, previous) => {
   const signedOut = previous.status === "signed-in" && connection.status !== "signed-in";
   const signedInSessionReplaced = previous.status === "signed-in"
     && connection.status === "signed-in"
-    && previous.api !== connection.api;
+    && (previous.api !== connection.api || previous.authGeneration !== connection.authGeneration);
   if (!signedOut && !signedInSessionReplaced) return;
   refreshGeneration += 1;
   useRuntimeComputers.setState({

--- a/desktop/src/renderer/src/stores/runtime-computers.ts
+++ b/desktop/src/renderer/src/stores/runtime-computers.ts
@@ -1,0 +1,119 @@
+import {
+  MatrixComputerListSchema,
+  type MatrixComputer,
+} from "@matrix-os/contracts";
+import { create } from "zustand";
+import { invoke } from "../lib/operator";
+import { useConnection } from "./connection";
+
+type RuntimeComputerLoadStatus = "idle" | "loading" | "ready" | "error";
+
+interface RuntimeComputerState {
+  status: RuntimeComputerLoadStatus;
+  scope: string | null;
+  runtimeSlot: string | null;
+  computers: MatrixComputer[];
+  switchingSlot: string | null;
+  switchError: boolean;
+  refresh: (options?: { force?: boolean }) => Promise<void>;
+  select: (slot: string) => Promise<boolean>;
+}
+
+let refreshGeneration = 0;
+
+function currentScope(): { scope: string; runtimeSlot: string } | null {
+  const connection = useConnection.getState();
+  if (connection.status !== "signed-in" || !connection.platformHost) return null;
+  return {
+    scope: `${connection.platformHost}|${connection.handle ?? "signed-in"}`,
+    runtimeSlot: connection.runtimeSlot,
+  };
+}
+
+export const useRuntimeComputers = create<RuntimeComputerState>()((set, get) => ({
+  status: "idle",
+  scope: null,
+  runtimeSlot: null,
+  computers: [],
+  switchingSlot: null,
+  switchError: false,
+
+  refresh: async (options = {}) => {
+    const target = currentScope();
+    if (!target) {
+      refreshGeneration += 1;
+      set({
+        status: "idle",
+        scope: null,
+        runtimeSlot: null,
+        computers: [],
+        switchingSlot: null,
+        switchError: false,
+      });
+      return;
+    }
+    const state = get();
+    const sameTarget = state.scope === target.scope && state.runtimeSlot === target.runtimeSlot;
+    if (!options.force && sameTarget && (state.status === "loading" || state.status === "ready")) return;
+    const generation = ++refreshGeneration;
+    set({
+      status: "loading",
+      scope: target.scope,
+      runtimeSlot: target.runtimeSlot,
+      ...(sameTarget ? {} : { computers: [] }),
+      switchError: false,
+    });
+    try {
+      const response = await invoke("runtime:list-computers", {});
+      const parsed = MatrixComputerListSchema.safeParse(response);
+      if (!parsed.success) throw new Error("invalid computer list");
+      if (generation !== refreshGeneration) return;
+      set({
+        status: "ready",
+        computers: parsed.data.items,
+        runtimeSlot: parsed.data.selectedSlot ?? target.runtimeSlot,
+      });
+    } catch {
+      if (generation !== refreshGeneration) return;
+      set({ status: "error", computers: [] });
+    }
+  },
+
+  select: async (slot) => {
+    const state = get();
+    const computer = state.computers.find((candidate) => candidate.runtimeSlot === slot);
+    const connection = useConnection.getState();
+    if (
+      !computer
+      || computer.availability !== "available"
+      || state.runtimeSlot === slot
+      || connection.runtimeSlot === slot
+      || state.switchingSlot
+    ) {
+      return false;
+    }
+    set({ switchingSlot: slot, switchError: false });
+    try {
+      await connection.selectRuntime(slot);
+      set({ switchingSlot: null });
+      await get().refresh({ force: true });
+      return true;
+    } catch {
+      set({ switchingSlot: null, switchError: true });
+      return false;
+    }
+  },
+}));
+
+useConnection.subscribe((connection, previous) => {
+  if (previous.status !== "signed-in" || connection.status === "signed-in") return;
+  refreshGeneration += 1;
+  useRuntimeComputers.setState({
+    status: "idle",
+    scope: null,
+    runtimeSlot: null,
+    computers: [],
+    switchingSlot: null,
+    switchError: false,
+  });
+});

--- a/desktop/src/renderer/src/stores/runtime-computers.ts
+++ b/desktop/src/renderer/src/stores/runtime-computers.ts
@@ -113,9 +113,12 @@ export const useRuntimeComputers = create<RuntimeComputerState>()((set, get) => 
 
 useConnection.subscribe((connection, previous) => {
   const signedOut = previous.status === "signed-in" && connection.status !== "signed-in";
+  // The credential generation is the replacement signal; the ApiClient object
+  // is recreated on every auth refresh (including after a failed switch) and
+  // must not wipe a still-valid inventory.
   const signedInSessionReplaced = previous.status === "signed-in"
     && connection.status === "signed-in"
-    && (previous.api !== connection.api || previous.authGeneration !== connection.authGeneration);
+    && previous.authGeneration !== connection.authGeneration;
   if (!signedOut && !signedInSessionReplaced) return;
   refreshGeneration += 1;
   useRuntimeComputers.setState({

--- a/desktop/src/renderer/src/stores/runtime-computers.ts
+++ b/desktop/src/renderer/src/stores/runtime-computers.ts
@@ -106,7 +106,11 @@ export const useRuntimeComputers = create<RuntimeComputerState>()((set, get) => 
 }));
 
 useConnection.subscribe((connection, previous) => {
-  if (previous.status !== "signed-in" || connection.status === "signed-in") return;
+  const signedOut = previous.status === "signed-in" && connection.status !== "signed-in";
+  const signedInSessionReplaced = previous.status === "signed-in"
+    && connection.status === "signed-in"
+    && previous.api !== connection.api;
+  if (!signedOut && !signedInSessionReplaced) return;
   refreshGeneration += 1;
   useRuntimeComputers.setState({
     status: "idle",

--- a/desktop/src/renderer/src/stores/runtime-generation.ts
+++ b/desktop/src/renderer/src/stores/runtime-generation.ts
@@ -1,0 +1,14 @@
+let runtimeGeneration = 0;
+
+export function captureRuntimeGeneration(): number {
+  return runtimeGeneration;
+}
+
+export function isCurrentRuntimeGeneration(generation: number): boolean {
+  return generation === runtimeGeneration;
+}
+
+export function advanceRuntimeGeneration(): number {
+  runtimeGeneration += 1;
+  return runtimeGeneration;
+}

--- a/desktop/src/renderer/src/stores/runtime-transition.ts
+++ b/desktop/src/renderer/src/stores/runtime-transition.ts
@@ -2,6 +2,7 @@ import { resetAttachManager } from "../features/terminal/terminal-runtime";
 import { useEditorTabs } from "../features/editor/editor-tabs-store";
 import { resetKernel } from "../lib/kernel-wiring";
 import { useBoard } from "./board";
+import { useHermesChat } from "./hermes-chat";
 import { clearCodingAgentProjectRuntime } from "./coding-agent-project-workspace";
 import { clearCodingAgentRuntimeSelection } from "./coding-agent-workspace";
 import { useFileTree } from "./file-tree";
@@ -35,6 +36,12 @@ export function reconcileDesktopRuntimeChange(options: RuntimeChangeOptions = {}
     error: null,
   });
   useTabs.setState({ tabs: [], activeTabId: null });
+  // MissionControl only opens Home in its mount-only effect, so reopen it here
+  // or a successful switch leaves the already-mounted desktop with no active tab.
+  useTabs.getState().openTab({ kind: "home", title: "Home", closable: false });
+  // The Hermes transcript and kernel session follow the selected computer; the
+  // kernel socket is already reset above, so drop the chat state with it.
+  useHermesChat.setState({ messages: [], sessionId: null, status: "idle", activeRequestId: null });
   useSessions.setState({
     sessions: [],
     aliasMap: {},

--- a/desktop/src/renderer/src/stores/runtime-transition.ts
+++ b/desktop/src/renderer/src/stores/runtime-transition.ts
@@ -1,0 +1,84 @@
+import { resetAttachManager } from "../features/terminal/terminal-runtime";
+import { useEditorTabs } from "../features/editor/editor-tabs-store";
+import { resetKernel } from "../lib/kernel-wiring";
+import { useBoard } from "./board";
+import { clearCodingAgentProjectRuntime } from "./coding-agent-project-workspace";
+import { clearCodingAgentRuntimeSelection } from "./coding-agent-workspace";
+import { useFileTree } from "./file-tree";
+import { useGit } from "./git";
+import { useSessions } from "./sessions";
+import { useShellSessions } from "./shell-sessions";
+import { useTabs } from "./tabs";
+import { useThreads } from "./threads";
+import { useUi } from "./ui";
+import { useWorkspace } from "./workspace";
+import { advanceRuntimeGeneration } from "./runtime-generation";
+
+interface RuntimeChangeOptions {
+  disposeRuntimeAttachments?: () => void;
+}
+
+/**
+ * Synchronously removes every renderer reference owned by the previous
+ * computer before the selected runtime becomes observable to the UI.
+ */
+export function reconcileDesktopRuntimeChange(options: RuntimeChangeOptions = {}): void {
+  advanceRuntimeGeneration();
+  (options.disposeRuntimeAttachments ?? resetAttachManager)();
+  resetKernel();
+  useBoard.setState({
+    projects: [],
+    activeProjectSlug: null,
+    cardsByProject: {},
+    firstLoadByProject: {},
+    refreshing: false,
+    error: null,
+  });
+  useTabs.setState({ tabs: [], activeTabId: null });
+  useSessions.setState({
+    sessions: [],
+    aliasMap: {},
+    loading: false,
+    creating: false,
+    error: null,
+    createError: null,
+  });
+  useShellSessions.setState((state) => ({
+    sessions: [],
+    loading: false,
+    creating: false,
+    error: null,
+    loadSequence: state.loadSequence + 1,
+  }));
+  useGit.setState({
+    branches: [],
+    prs: [],
+    worktrees: [],
+    previews: [],
+    previewScope: null,
+    refreshedAt: null,
+    loading: false,
+    error: null,
+    previewError: null,
+  });
+  useWorkspace.setState({ entries: [] });
+  useEditorTabs.setState({ tabsByTask: {}, activePathByTask: {}, dirtyPathsByTask: {} });
+  useFileTree.setState({
+    roots: null,
+    childrenByPath: {},
+    expanded: {},
+    loadingRoots: false,
+    loadingPaths: {},
+  });
+  useThreads.setState({ threads: [], activeThreadId: null });
+  clearCodingAgentRuntimeSelection();
+  clearCodingAgentProjectRuntime();
+  useUi.setState({
+    createProjectOpen: false,
+    createTaskOpen: false,
+    createTaskStatus: null,
+    composerOpen: false,
+    paletteOpen: false,
+    quickOpenOpen: false,
+  });
+}

--- a/desktop/src/renderer/src/stores/sessions.ts
+++ b/desktop/src/renderer/src/stores/sessions.ts
@@ -12,6 +12,7 @@ import {
   type ZellijSessionDTO,
 } from "../lib/session-merge";
 import { useBoard } from "./board";
+import { captureRuntimeGeneration, isCurrentRuntimeGeneration } from "./runtime-generation";
 
 export interface SessionCreateInput {
   kind: "shell" | "agent";
@@ -137,11 +138,12 @@ export const useSessions = create<SessionsState>()((set, get) => ({
   createError: null,
 
   load: async (api) => {
+    const runtimeGeneration = captureRuntimeGeneration();
     const sequence = ++loadSequence;
     set({ loading: true, error: null });
     try {
       const merged = await fetchMergedSessions(api);
-      if (sequence !== loadSequence) return;
+      if (sequence !== loadSequence || !isCurrentRuntimeGeneration(runtimeGeneration)) return;
       set({
         sessions: merged.sessions,
         aliasMap: merged.aliasMap,
@@ -149,7 +151,7 @@ export const useSessions = create<SessionsState>()((set, get) => ({
         error: null,
       });
     } catch (err: unknown) {
-      if (sequence !== loadSequence) return;
+      if (sequence !== loadSequence || !isCurrentRuntimeGeneration(runtimeGeneration)) return;
       console.error("[sessions] Failed to load sessions:", err);
       set({
         loading: false,

--- a/desktop/src/renderer/src/stores/sessions.ts
+++ b/desktop/src/renderer/src/stores/sessions.ts
@@ -266,18 +266,22 @@ export const useSessions = create<SessionsState>()((set, get) => ({
   },
 
   kill: async (api, attachName) => {
+    const runtimeGeneration = captureRuntimeGeneration();
     try {
       await deleteAttachableSession(api, attachName);
     } catch (err: unknown) {
+      if (!isCurrentRuntimeGeneration(runtimeGeneration)) return false;
       if (!(err instanceof AppError && err.category === "notFound")) {
         console.error("[sessions] Failed to kill session:", err);
         set({ error: err instanceof AppError ? err.category : "server" });
         return false;
       }
     }
+    if (!isCurrentRuntimeGeneration(runtimeGeneration)) return false;
     try {
       await get().load(api);
     } catch (err: unknown) {
+      if (!isCurrentRuntimeGeneration(runtimeGeneration)) return false;
       console.error("[sessions] Failed to reload after kill:", err);
       set({ error: err instanceof AppError ? err.category : "server" });
     }

--- a/desktop/src/renderer/src/stores/sessions.ts
+++ b/desktop/src/renderer/src/stores/sessions.ts
@@ -161,14 +161,20 @@ export const useSessions = create<SessionsState>()((set, get) => ({
   },
 
   create: async (api, input) => {
+    // A computer switch advances the runtime generation; a create that settles
+    // afterwards belongs to the previous computer and must not commit results
+    // (the transition already reset creating/error state).
+    const runtimeGeneration = captureRuntimeGeneration();
     set({ creating: true, error: null, createError: null });
     try {
       if (!input) {
         const name = nextSessionName();
         const response = await api.post<{ name?: unknown }>("/api/terminal/sessions", { name });
+        if (!isCurrentRuntimeGeneration(runtimeGeneration)) return null;
         const attachName = typeof response.name === "string" && response.name.trim() ? response.name.trim() : name;
         const refreshSequence = loadSequence + 1;
         await get().load(api);
+        if (!isCurrentRuntimeGeneration(runtimeGeneration)) return null;
         const refreshError = get().error;
         const created = get().sessions.find((session) => session.attachName === attachName) ?? {
           name: attachName,
@@ -188,6 +194,7 @@ export const useSessions = create<SessionsState>()((set, get) => ({
       const res = await api.post<{
         session?: { id?: unknown; runtime?: { zellijSession?: unknown } | null };
       }>("/api/sessions", input);
+      if (!isCurrentRuntimeGeneration(runtimeGeneration)) return null;
       const sessionId = typeof res.session?.id === "string" ? res.session.id : null;
       const directAttachName =
         typeof res.session?.runtime?.zellijSession === "string"
@@ -201,6 +208,9 @@ export const useSessions = create<SessionsState>()((set, get) => ({
       try {
         merged = await fetchMergedSessions(api);
       } catch (err: unknown) {
+        // The cleanup delete would target the newly selected computer with the
+        // old computer's session id; skip it and the error commit entirely.
+        if (!isCurrentRuntimeGeneration(runtimeGeneration)) return null;
         if (sessionId) {
           await api.delete(`/api/sessions/${encodeURIComponent(sessionId)}`).catch((cleanupErr: unknown) => {
             console.warn(
@@ -213,6 +223,7 @@ export const useSessions = create<SessionsState>()((set, get) => ({
         set({ creating: false, error: err instanceof AppError ? err.category : "server" });
         return null;
       }
+      if (!isCurrentRuntimeGeneration(runtimeGeneration)) return null;
       if (sequence === loadSequence) {
         set({
           sessions: merged.sessions,
@@ -243,6 +254,7 @@ export const useSessions = create<SessionsState>()((set, get) => ({
         attachName: merged.aliasMap[sessionId] ?? directAttachName,
       };
     } catch (err: unknown) {
+      if (!isCurrentRuntimeGeneration(runtimeGeneration)) return null;
       console.error("[sessions] Failed to create session:", err);
       set({
         creating: false,
@@ -273,6 +285,9 @@ export const useSessions = create<SessionsState>()((set, get) => ({
   },
 
   restart: async (api, attachName) => {
+    // Same invariant as create: a restart that settles after a computer switch
+    // must not commit sessions or issue follow-up requests on the new runtime.
+    const runtimeGeneration = captureRuntimeGeneration();
     set({ creating: true });
     try {
       const existing = get().sessions.find((session) => session.attachName === attachName) ?? null;
@@ -281,6 +296,7 @@ export const useSessions = create<SessionsState>()((set, get) => ({
       } catch (err: unknown) {
         if (!(err instanceof AppError && err.category === "notFound")) throw err;
       }
+      if (!isCurrentRuntimeGeneration(runtimeGeneration)) return null;
       if (existing?.source === "workspace" && existing.kind) {
         const input: SessionCreateInput = { kind: existing.kind };
         const agent = existing.kind === "agent" ? sessionAgent(existing.agent) : undefined;
@@ -291,6 +307,7 @@ export const useSessions = create<SessionsState>()((set, get) => ({
         const res = await api.post<{
           session?: { id?: unknown; runtime?: { zellijSession?: unknown } | null };
         }>("/api/sessions", input);
+        if (!isCurrentRuntimeGeneration(runtimeGeneration)) return null;
         const sessionId = typeof res.session?.id === "string" ? res.session.id : null;
         const directAttachName =
           typeof res.session?.runtime?.zellijSession === "string"
@@ -305,6 +322,7 @@ export const useSessions = create<SessionsState>()((set, get) => ({
         try {
           merged = await fetchMergedSessions(api);
         } catch (err: unknown) {
+          if (!isCurrentRuntimeGeneration(runtimeGeneration)) return null;
           await api.delete(`/api/sessions/${encodeURIComponent(sessionId)}`).catch((cleanupErr: unknown) => {
             console.warn(
               "[sessions] Failed to clean up restarted session after refresh failure:",
@@ -315,6 +333,7 @@ export const useSessions = create<SessionsState>()((set, get) => ({
           set({ creating: false, error: err instanceof AppError ? err.category : "server" });
           return null;
         }
+        if (!isCurrentRuntimeGeneration(runtimeGeneration)) return null;
         let nextAttachName = merged.aliasMap[sessionId] ?? directAttachName;
         if (sequence === loadSequence) {
           set({
@@ -345,6 +364,7 @@ export const useSessions = create<SessionsState>()((set, get) => ({
             console.error("[sessions] Failed to relink restarted session:", err);
             linkError = err;
           }
+          if (!isCurrentRuntimeGeneration(runtimeGeneration)) return null;
         }
         if (linkError) {
           if (nextAttachName) {
@@ -369,11 +389,14 @@ export const useSessions = create<SessionsState>()((set, get) => ({
         return { sessionId, attachName: nextAttachName };
       }
       const response = await api.post<{ name?: unknown }>("/api/terminal/sessions", { name: attachName });
+      if (!isCurrentRuntimeGeneration(runtimeGeneration)) return null;
       const restarted = typeof response.name === "string" && response.name.trim() ? response.name.trim() : attachName;
       await get().load(api);
+      if (!isCurrentRuntimeGeneration(runtimeGeneration)) return null;
       set({ creating: false, error: null });
       return { sessionId: restarted, attachName: restarted };
     } catch (err: unknown) {
+      if (!isCurrentRuntimeGeneration(runtimeGeneration)) return null;
       console.error("[sessions] Failed to restart session:", err);
       set({ creating: false, error: err instanceof AppError ? err.category : "server" });
       return null;

--- a/desktop/src/renderer/src/stores/shell-sessions.ts
+++ b/desktop/src/renderer/src/stores/shell-sessions.ts
@@ -1,6 +1,7 @@
 import { create } from "zustand";
 import { AppError, type AppErrorCategory } from "../../../shared/app-error";
 import type { ApiClient } from "../lib/api";
+import { captureRuntimeGeneration, isCurrentRuntimeGeneration } from "./runtime-generation";
 
 export type ShellSessionPlacement = "active" | "background";
 export type ShellVisualStatus = "running" | "waiting" | "finished" | "idle";
@@ -221,11 +222,16 @@ export const useShellSessions = create<ShellSessionsState>()((set, get) => ({
 
   create: async (api) => {
     if (get().creating) return null;
+    // A computer switch advances the runtime generation and clears this store;
+    // a create that settles afterwards belongs to the previous computer and
+    // must not repopulate the new one (the transition already reset `creating`).
+    const generation = captureRuntimeGeneration();
     set({ creating: true, error: null });
     for (let attempt = 0; attempt < CREATE_ATTEMPTS; attempt += 1) {
       const name = nextShellName();
       try {
         const response = await api.post<{ name?: unknown }>("/api/terminal/sessions", { name, cwd: DEFAULT_CWD });
+        if (!isCurrentRuntimeGeneration(generation)) return null;
         const createdName = typeof response.name === "string" && isValidShellSessionName(response.name) ? response.name : name;
         let created: ShellSessionSummary = {
           name: createdName,
@@ -237,6 +243,7 @@ export const useShellSessions = create<ShellSessionsState>()((set, get) => ({
         set({ loadSequence: refreshSequence });
         try {
           const sessions = await fetchShellSessions(api);
+          if (!isCurrentRuntimeGeneration(generation)) return null;
           if (refreshSequence !== get().loadSequence) {
             set({ creating: false, error: null });
             return created;
@@ -249,6 +256,7 @@ export const useShellSessions = create<ShellSessionsState>()((set, get) => ({
             error: null,
           }));
         } catch (refreshErr: unknown) {
+          if (!isCurrentRuntimeGeneration(generation)) return null;
           if (refreshSequence !== get().loadSequence) {
             set({ creating: false, error: null });
             return created;
@@ -263,6 +271,7 @@ export const useShellSessions = create<ShellSessionsState>()((set, get) => ({
         }
         return created;
       } catch (err: unknown) {
+        if (!isCurrentRuntimeGeneration(generation)) return null;
         if (isSessionExistsError(err) && attempt < CREATE_ATTEMPTS - 1) continue;
         console.error("[shell-sessions] Failed to create shell session:", err);
         set({ creating: false, error: errorCategory(err) });

--- a/desktop/src/renderer/src/stores/shell-sessions.ts
+++ b/desktop/src/renderer/src/stores/shell-sessions.ts
@@ -283,6 +283,7 @@ export const useShellSessions = create<ShellSessionsState>()((set, get) => ({
   },
 
   deleteSession: async (api, name) => {
+    const generation = captureRuntimeGeneration();
     const previous = get().sessions;
     const deletedIndex = previous.findIndex((session) => session.name === name);
     const deleted = deletedIndex >= 0 ? previous[deletedIndex] : undefined;
@@ -291,6 +292,9 @@ export const useShellSessions = create<ShellSessionsState>()((set, get) => ({
       await api.delete(`/api/terminal/sessions/${encodeURIComponent(name)}?force=1`);
       return true;
     } catch (err: unknown) {
+      // After a computer switch the cleared list must not get the old
+      // computer's session restored into it.
+      if (!isCurrentRuntimeGeneration(generation)) return false;
       console.error("[shell-sessions] Failed to delete shell session:", err);
       set((state) => ({
         sessions: deleted ? insertSessionAt(state.sessions, deleted, deletedIndex) : state.sessions,
@@ -307,6 +311,7 @@ export const useShellSessions = create<ShellSessionsState>()((set, get) => ({
       set({ error: "server" });
       return false;
     }
+    const generation = captureRuntimeGeneration();
     const previous = get().sessions;
     const originalIndex = previous.findIndex((session) => session.name === name);
     const original = originalIndex >= 0 ? previous[originalIndex] : undefined;
@@ -316,6 +321,7 @@ export const useShellSessions = create<ShellSessionsState>()((set, get) => ({
     });
     try {
       const response = await api.put<{ session?: unknown }>(`/api/terminal/sessions/${encodeURIComponent(name)}/rename`, { name: nextName });
+      if (!isCurrentRuntimeGeneration(generation)) return false;
       const renamed = asShellSession(response.session) ?? null;
       if (renamed) {
         set((state) => ({
@@ -325,6 +331,7 @@ export const useShellSessions = create<ShellSessionsState>()((set, get) => ({
       }
       return true;
     } catch (err: unknown) {
+      if (!isCurrentRuntimeGeneration(generation)) return false;
       console.error("[shell-sessions] Failed to rename shell session:", err);
       set((state) => ({
         sessions: original ? rollbackRename(state.sessions, original, originalIndex, nextName) : state.sessions,

--- a/desktop/src/renderer/src/stores/workspace.ts
+++ b/desktop/src/renderer/src/stores/workspace.ts
@@ -181,10 +181,15 @@ export const useWorkspace = create<WorkspaceState>()((set, get) => {
       }
       try {
         const loaded = await persistence.loadLayouts();
+        const normalizedLoaded = loaded
+          ? Object.fromEntries(
+              Object.entries(loaded).map(([taskId, layout]) => [taskId, normalizeLayout(layout)]),
+            )
+          : null;
         // In-memory layouts win: they were touched during this session.
         set((state) => ({
           hydrated: true,
-          layouts: loaded ? { ...loaded, ...state.layouts } : state.layouts,
+          layouts: normalizedLoaded ? { ...normalizedLoaded, ...state.layouts } : state.layouts,
         }));
       } catch (err: unknown) {
         console.warn("[workspace] Failed to load persisted layouts:", err);

--- a/desktop/src/shared/ipc-contract.ts
+++ b/desktop/src/shared/ipc-contract.ts
@@ -26,6 +26,7 @@ import {
   ProjectAgentWorkspaceSchema,
   ReviewSnapshotSchema,
   ReviewSummarySchema,
+  MatrixComputerListSchema,
   RuntimeSelectionRequestSchema,
   RuntimeSummarySchema,
   SafeClientErrorSchema,
@@ -135,6 +136,10 @@ export const INVOKE_CHANNELS = {
   },
   "auth:sign-out": { request: Empty, response: Ok },
   "auth:session-expired": { request: Empty, response: Ok },
+  "runtime:list-computers": {
+    request: Empty,
+    response: MatrixComputerListSchema,
+  },
   "runtime:select": {
     request: RuntimeSelectionRequestSchema,
     response: Ok,

--- a/desktop/src/shared/ipc-contract.ts
+++ b/desktop/src/shared/ipc-contract.ts
@@ -131,6 +131,7 @@ export const INVOKE_CHANNELS = {
         imageUrl: z.string().url().max(2048).optional(),
         runtimeSlot: z.string().max(64),
         platformHost: z.string().max(256),
+        authGeneration: z.number().int().nonnegative(),
       })
       .strict(),
   },

--- a/packages/gateway/src/agent-sandbox.ts
+++ b/packages/gateway/src/agent-sandbox.ts
@@ -45,7 +45,9 @@ type ClaudeSandboxVerifier = (input: {
   sandbox: AgentLaunchSandbox;
   approvalPolicy?: "untrusted" | "on-request" | "on-failure" | "never";
 }) => Promise<void>;
-type GitCommonDirResolver = (worktreePath: string) => Promise<string>;
+// Resolves the Git common dir for a workspace, or null when the workspace is
+// not inside a Git repository (no Git metadata exists to protect).
+type GitCommonDirResolver = (worktreePath: string) => Promise<string | null>;
 
 const execFileAsync = promisify(execFile);
 const CLAUDE_PREFLIGHT_TIMEOUT_MS = 5_000;
@@ -78,17 +80,26 @@ const defaultClaudeSandboxVerifier: ClaudeSandboxVerifier = async (input) => {
 };
 
 const defaultGitCommonDirResolver: GitCommonDirResolver = async (worktreePath) => {
-  const { stdout } = await execFileAsync(
-    "git",
-    ["-C", worktreePath, "rev-parse", "--path-format=absolute", "--git-common-dir"],
-    {
-      cwd: worktreePath,
-      timeout: GIT_METADATA_TIMEOUT_MS,
-      encoding: "utf-8",
-      maxBuffer: 8 * 1024,
-    },
-  );
-  return z.string().trim().min(1).max(4096).parse(stdout);
+  try {
+    const { stdout } = await execFileAsync(
+      "git",
+      ["-C", worktreePath, "rev-parse", "--path-format=absolute", "--git-common-dir"],
+      {
+        cwd: worktreePath,
+        timeout: GIT_METADATA_TIMEOUT_MS,
+        encoding: "utf-8",
+        maxBuffer: 8 * 1024,
+      },
+    );
+    return z.string().trim().min(1).max(4096).parse(stdout);
+  } catch (err: unknown) {
+    const stderr = err instanceof Error && "stderr" in err && typeof (err as { stderr?: unknown }).stderr === "string"
+      ? (err as { stderr: string }).stderr
+      : "";
+    // Scratch and folder projects are not required to be Git repositories.
+    if (/not a git repository/i.test(stderr)) return null;
+    throw err;
+  }
 };
 
 function failure(status: number, code: string, message: string, sandboxStatus?: AgentSandboxStatus): Failure {
@@ -330,15 +341,20 @@ export function createAgentSandbox(options: {
       let denyWriteRoots: string[] | undefined;
       if (effectiveReadOnly && request.agent === "claude") {
         try {
-          const gitCommonPath = resolve(
-            canonicalWorktree.path,
-            await resolveGitCommonDir(canonicalWorktree.path),
-          );
-          const canonicalGitCommon = await canonicalDirectoryWithinHome(homePath, gitCommonPath);
-          if (canonicalGitCommon.kind !== "ok") {
-            return failure(503, "sandbox_unavailable", "Agent sandbox is unavailable", uidStatus);
+          const commonDirRaw = await resolveGitCommonDir(canonicalWorktree.path);
+          if (commonDirRaw === null) {
+            // Non-Git workspaces (scratch/folder projects) have no Git
+            // metadata to protect; review stays read-only over the workspace
+            // root alone instead of failing closed.
+            denyWriteRoots = [canonicalWorktree.path];
+          } else {
+            const gitCommonPath = resolve(canonicalWorktree.path, commonDirRaw);
+            const canonicalGitCommon = await canonicalDirectoryWithinHome(homePath, gitCommonPath);
+            if (canonicalGitCommon.kind !== "ok") {
+              return failure(503, "sandbox_unavailable", "Agent sandbox is unavailable", uidStatus);
+            }
+            denyWriteRoots = [...new Set([canonicalWorktree.path, canonicalGitCommon.path])];
           }
-          denyWriteRoots = [...new Set([canonicalWorktree.path, canonicalGitCommon.path])];
         } catch (err: unknown) {
           console.warn(
             "[agent-sandbox] Claude read-only Git metadata preflight failed:",

--- a/packages/gateway/src/path-security.ts
+++ b/packages/gateway/src/path-security.ts
@@ -25,6 +25,14 @@ export function isDeniedFileApiPath(homePath: string, requestedPath: string): bo
   return DENIED_FILE_API_PREFIXES.some((prefix) => rel === prefix || rel.startsWith(`${prefix}/`));
 }
 
+// True when the resolved path is an ancestor of (or equal to) a denied
+// subtree: granting it as a workspace root would expose the denied content.
+export function containsDeniedFileApiPath(homePath: string, resolvedPath: string): boolean {
+  const rel = relative(resolve(homePath), resolvedPath).split(sep).join("/");
+  if (rel === "") return true;
+  return DENIED_FILE_API_PREFIXES.some((prefix) => prefix === rel || prefix.startsWith(`${rel}/`));
+}
+
 function isWithinRealPath(baseReal: string, candidateReal: string): boolean {
   return candidateReal === baseReal || candidateReal.startsWith(`${baseReal}${sep}`);
 }

--- a/packages/gateway/src/project-manager.ts
+++ b/packages/gateway/src/project-manager.ts
@@ -116,6 +116,14 @@ function genericError(status: number, code: string, message: string): Failure {
   return { ok: false, status, error: { code, message } };
 }
 
+function isNotAGitRepositoryError(err: unknown): boolean {
+  if (!(err instanceof Error)) return false;
+  const stderr = "stderr" in err && typeof (err as { stderr?: unknown }).stderr === "string"
+    ? (err as { stderr: string }).stderr
+    : "";
+  return /not a git repository/i.test(stderr) || /not a git repository/i.test(err.message);
+}
+
 function nowIso(now?: () => string): string {
   return now ? now() : new Date().toISOString();
 }
@@ -546,10 +554,31 @@ export function createProjectManager(options: {
     async listBranches(slug: string): Promise<Result<{ branches: BranchSummary[]; refreshedAt: string }> | Failure> {
       const projectResult = await this.getProject(slug);
       if (!projectResult.ok) return projectResult;
-      if (!await pathExists(join(projectResult.project.localPath, ".git"))) {
-        return { ok: true, branches: [], refreshedAt: nowIso(options.now) };
+      const refreshedAt = nowIso(options.now);
+      // Probe Git itself instead of checking for a local .git entry: a folder
+      // project can point at a subdirectory of a repository (monorepo
+      // packages) whose .git lives in an ancestor.
+      let repoTopLevel: string;
+      try {
+        const probe = await runCommand("git", ["rev-parse", "--show-toplevel"], {
+          cwd: projectResult.project.localPath,
+          timeout: DEFAULT_TIMEOUT_MS,
+        });
+        repoTopLevel = probe.stdout.trim();
+      } catch (err: unknown) {
+        if (isNotAGitRepositoryError(err)) {
+          return { ok: true, branches: [], refreshedAt };
+        }
+        if (err instanceof Error) console.warn("[project-manager] Failed to probe git worktree:", err.message);
+        return genericError(502, "git_request_failed", "Git request failed");
       }
       try {
+        // The Matrix home itself is a versioned Git repo; a plain folder that
+        // resolves to it as its toplevel has no project branches to show.
+        const [homeReal, repoReal] = await Promise.all([realpath(homePath), realpath(repoTopLevel)]);
+        if (homeReal === repoReal) {
+          return { ok: true, branches: [], refreshedAt };
+        }
         const result = await runCommand("git", ["branch", "--list", "--format=%(refname:short)"], {
           cwd: projectResult.project.localPath,
           timeout: DEFAULT_TIMEOUT_MS,

--- a/packages/gateway/src/project-manager.ts
+++ b/packages/gateway/src/project-manager.ts
@@ -6,6 +6,7 @@ import { join, resolve } from "node:path";
 import { promisify } from "node:util";
 import { z } from "zod/v4";
 import { atomicWriteJson, readJsonFile, withProjectLock, type OwnerScope } from "./state-ops.js";
+import { resolveExistingFileApiPath } from "./path-security.js";
 
 export const PROJECT_SLUG_REGEX = /^[a-z0-9][a-z0-9-]{0,62}$/;
 
@@ -68,7 +69,7 @@ type CommandRunner = (
 
 type Result<T> = { ok: true; status?: number } & T;
 type Failure = { ok: false; status: number; error: WorkspaceError };
-type CreateProjectMode = "scratch" | "github";
+type CreateProjectMode = "scratch" | "github" | "folder";
 
 const DEFAULT_TIMEOUT_MS = 10_000;
 const CLONE_TIMEOUT_MS = 5 * 60_000;
@@ -215,6 +216,7 @@ export function createProjectManager(options: {
       url?: string;
       slug?: string;
       name?: string;
+      path?: string;
       mode?: CreateProjectMode;
       ownerScope?: OwnerScope;
       clientRequestId?: string;
@@ -223,6 +225,37 @@ export function createProjectManager(options: {
         return genericError(400, "invalid_request", "Project request is invalid");
       }
       const mode = input.mode ?? (input.url ? "github" : "scratch");
+      if (mode === "folder") {
+        const name = input.name?.trim() || "";
+        if (!name) return genericError(400, "invalid_project_name", "Project name is required");
+        const slug = input.slug ? input.slug.trim() : slugify(name);
+        if (!SlugSchema.safeParse(slug).success) {
+          return genericError(400, "invalid_slug", "Project slug is invalid");
+        }
+        const localPath = input.path ? resolveExistingFileApiPath(homePath, input.path) : null;
+        const metadataPath = projectPath(homePath, slug);
+        if (!localPath || localPath === metadataPath || localPath.startsWith(`${metadataPath}/`)) {
+          return genericError(400, "invalid_project_path", "Project folder is invalid");
+        }
+        return withProjectLock(slug, async () => {
+          if (await pathExists(metadataPath)) {
+            return genericError(409, "slug_conflict", "Project slug already exists");
+          }
+          await mkdir(metadataPath, { recursive: true });
+          const timestamp = nowIso(options.now);
+          const project: ProjectConfig = {
+            id: `proj_${randomUUID()}`,
+            name,
+            slug,
+            localPath,
+            addedAt: timestamp,
+            updatedAt: timestamp,
+            ownerScope: input.ownerScope ?? { type: "user", id: "local" },
+          };
+          await atomicWriteJson(join(metadataPath, "config.json"), project);
+          return { ok: true, status: 201, project };
+        });
+      }
       if (mode === "scratch") {
         const name = input.name?.trim() || input.slug?.trim() || "";
         if (!name) {
@@ -422,7 +455,7 @@ export function createProjectManager(options: {
       if (!projectResult.ok) return projectResult;
       const project = projectResult.project;
       if (!project.github) {
-        return genericError(400, "not_github_project", "Project is not linked to GitHub");
+        return { ok: true, prs: [], refreshedAt: nowIso(options.now) };
       }
       try {
         const result = await runCommand(
@@ -445,6 +478,9 @@ export function createProjectManager(options: {
     async listBranches(slug: string): Promise<Result<{ branches: BranchSummary[]; refreshedAt: string }> | Failure> {
       const projectResult = await this.getProject(slug);
       if (!projectResult.ok) return projectResult;
+      if (!await pathExists(join(projectResult.project.localPath, ".git"))) {
+        return { ok: true, branches: [], refreshedAt: nowIso(options.now) };
+      }
       try {
         const result = await runCommand("git", ["branch", "--list", "--format=%(refname:short)"], {
           cwd: projectResult.project.localPath,

--- a/packages/gateway/src/project-manager.ts
+++ b/packages/gateway/src/project-manager.ts
@@ -6,7 +6,7 @@ import { join, relative, resolve, sep } from "node:path";
 import { promisify } from "node:util";
 import { z } from "zod/v4";
 import { atomicWriteJson, readJsonFile, withProjectLock, type OwnerScope } from "./state-ops.js";
-import { resolveExistingFileApiPath } from "./path-security.js";
+import { containsDeniedFileApiPath, resolveExistingFileApiPath } from "./path-security.js";
 
 export const PROJECT_SLUG_REGEX = /^[a-z0-9][a-z0-9-]{0,62}$/;
 
@@ -292,6 +292,10 @@ export function createProjectManager(options: {
             || candidate.path.startsWith(`${registryEntry}${sep}`)
             || registryEntry.startsWith(`${candidate.path}${sep}`)
             || isProtectedFolderProjectPath(candidate.base, candidate.path)
+            // An ancestor of a denied subtree (data/browser-profiles holds
+            // persistent browser login state) would expose it as part of the
+            // agent-writable workspace.
+            || containsDeniedFileApiPath(candidate.base, candidate.path)
           ) {
             return genericError(400, "invalid_project_path", "Project folder is invalid");
           }

--- a/packages/gateway/src/project-manager.ts
+++ b/packages/gateway/src/project-manager.ts
@@ -178,13 +178,18 @@ function projectPath(homePath: string, slug: string): string {
 // OS-owned subtrees that must never become an agent-accessible project root.
 // A folder project's localPath is handed to shells and coding-agent sandboxes
 // as a workspace cwd, so granting these would expose kernel/agent state.
-const PROTECTED_FOLDER_PROJECT_PREFIXES = ["system", "agents", ".trash"];
+const PROTECTED_FOLDER_PROJECT_PREFIXES = ["system", "agents"];
 
 function isProtectedFolderProjectPath(homePath: string, resolvedPath: string): boolean {
   const rel = relative(resolve(homePath), resolvedPath);
   if (rel === "") return true;
   const firstSegment = rel.split(sep)[0];
-  return firstSegment !== undefined && PROTECTED_FOLDER_PROJECT_PREFIXES.includes(firstSegment);
+  if (firstSegment === undefined) return false;
+  // Every top-level dot directory under the Matrix home is owner or tool
+  // state (.trash, .hermes, .claude, .codex, .ssh, ...), never a user
+  // workspace; deny the whole class instead of chasing individual names.
+  if (firstSegment.startsWith(".")) return true;
+  return PROTECTED_FOLDER_PROJECT_PREFIXES.includes(firstSegment);
 }
 
 async function readProjectConfig(homePath: string, slug: string): Promise<ProjectConfig | null> {
@@ -303,7 +308,11 @@ export function createProjectManager(options: {
             id: `proj_${randomUUID()}`,
             name,
             slug,
-            localPath,
+            // Persist the fully resolved path: session launches use the stored
+            // localPath as cwd/sandbox root without rerunning these checks, so
+            // a symlink ancestor repointed at a protected subtree later must
+            // not be able to bypass the validation that ran here.
+            localPath: realLocalPath,
             addedAt: timestamp,
             updatedAt: timestamp,
             ownerScope: input.ownerScope ?? { type: "user", id: "local" },

--- a/packages/gateway/src/project-manager.ts
+++ b/packages/gateway/src/project-manager.ts
@@ -1,7 +1,7 @@
 import { execFile } from "node:child_process";
 import { createHash, randomUUID } from "node:crypto";
 import { constants } from "node:fs";
-import { access, lstat, mkdir, readdir, rename, rm } from "node:fs/promises";
+import { access, lstat, mkdir, readdir, realpath, rename, rm } from "node:fs/promises";
 import { join, relative, resolve, sep } from "node:path";
 import { promisify } from "node:util";
 import { z } from "zod/v4";
@@ -245,20 +245,18 @@ export function createProjectManager(options: {
           return genericError(400, "invalid_slug", "Project slug is invalid");
         }
         const localPath = input.path ? resolveExistingFileApiPath(homePath, input.path) : null;
-        const metadataPath = projectPath(homePath, slug);
-        if (
-          !localPath
-          || localPath === metadataPath
-          || localPath.startsWith(`${metadataPath}/`)
-          || isProtectedFolderProjectPath(homePath, localPath)
-        ) {
+        if (!localPath) {
           return genericError(400, "invalid_project_path", "Project folder is invalid");
         }
+        let realLocalPath: string;
+        let realHomePath: string;
         try {
           const stats = await lstat(localPath);
           if (!stats.isDirectory()) {
             return genericError(400, "invalid_project_path", "Project folder is invalid");
           }
+          realLocalPath = await realpath(localPath);
+          realHomePath = await realpath(homePath);
         } catch (err: unknown) {
           console.warn(
             "[projects] folder project path became unreadable:",
@@ -266,6 +264,26 @@ export function createProjectManager(options: {
           );
           return genericError(400, "invalid_project_path", "Project folder is invalid");
         }
+        // Check the lexical path AND the fully resolved path against the same
+        // rules so a symlinked ancestor cannot alias a protected subtree, and
+        // reject any root that would contain the project registry: metadata
+        // (config.json, sibling projects) must never live inside an
+        // agent-writable workspace.
+        for (const candidate of [
+          { base: homePath, path: localPath },
+          { base: realHomePath, path: realLocalPath },
+        ]) {
+          const registryEntry = join(candidate.base, "projects", slug);
+          if (
+            candidate.path === registryEntry
+            || candidate.path.startsWith(`${registryEntry}${sep}`)
+            || registryEntry.startsWith(`${candidate.path}${sep}`)
+            || isProtectedFolderProjectPath(candidate.base, candidate.path)
+          ) {
+            return genericError(400, "invalid_project_path", "Project folder is invalid");
+          }
+        }
+        const metadataPath = projectPath(homePath, slug);
         return withProjectLock(slug, async () => {
           if (await pathExists(metadataPath)) {
             return genericError(409, "slug_conflict", "Project slug already exists");

--- a/packages/gateway/src/project-manager.ts
+++ b/packages/gateway/src/project-manager.ts
@@ -1,8 +1,8 @@
 import { execFile } from "node:child_process";
 import { createHash, randomUUID } from "node:crypto";
 import { constants } from "node:fs";
-import { access, mkdir, readdir, rename, rm } from "node:fs/promises";
-import { join, resolve } from "node:path";
+import { access, lstat, mkdir, readdir, rename, rm } from "node:fs/promises";
+import { join, relative, resolve, sep } from "node:path";
 import { promisify } from "node:util";
 import { z } from "zod/v4";
 import { atomicWriteJson, readJsonFile, withProjectLock, type OwnerScope } from "./state-ops.js";
@@ -175,6 +175,18 @@ function projectPath(homePath: string, slug: string): string {
   return join(homePath, "projects", slug);
 }
 
+// OS-owned subtrees that must never become an agent-accessible project root.
+// A folder project's localPath is handed to shells and coding-agent sandboxes
+// as a workspace cwd, so granting these would expose kernel/agent state.
+const PROTECTED_FOLDER_PROJECT_PREFIXES = ["system", "agents", ".trash"];
+
+function isProtectedFolderProjectPath(homePath: string, resolvedPath: string): boolean {
+  const rel = relative(resolve(homePath), resolvedPath);
+  if (rel === "") return true;
+  const firstSegment = rel.split(sep)[0];
+  return firstSegment !== undefined && PROTECTED_FOLDER_PROJECT_PREFIXES.includes(firstSegment);
+}
+
 async function readProjectConfig(homePath: string, slug: string): Promise<ProjectConfig | null> {
   try {
     return await readJsonFile<ProjectConfig>(join(projectPath(homePath, slug), "config.json"));
@@ -234,7 +246,24 @@ export function createProjectManager(options: {
         }
         const localPath = input.path ? resolveExistingFileApiPath(homePath, input.path) : null;
         const metadataPath = projectPath(homePath, slug);
-        if (!localPath || localPath === metadataPath || localPath.startsWith(`${metadataPath}/`)) {
+        if (
+          !localPath
+          || localPath === metadataPath
+          || localPath.startsWith(`${metadataPath}/`)
+          || isProtectedFolderProjectPath(homePath, localPath)
+        ) {
+          return genericError(400, "invalid_project_path", "Project folder is invalid");
+        }
+        try {
+          const stats = await lstat(localPath);
+          if (!stats.isDirectory()) {
+            return genericError(400, "invalid_project_path", "Project folder is invalid");
+          }
+        } catch (err: unknown) {
+          console.warn(
+            "[projects] folder project path became unreadable:",
+            err instanceof Error ? err.message : String(err),
+          );
           return genericError(400, "invalid_project_path", "Project folder is invalid");
         }
         return withProjectLock(slug, async () => {

--- a/packages/gateway/src/project-manager.ts
+++ b/packages/gateway/src/project-manager.ts
@@ -282,6 +282,15 @@ export function createProjectManager(options: {
           ) {
             return genericError(400, "invalid_project_path", "Project folder is invalid");
           }
+          // Any managed project root (projects/<slug>) holds registry metadata
+          // (config.json, worktrees) that must never sit inside an
+          // agent-writable workspace; deeper paths such as projects/<slug>/repo
+          // contain no metadata and stay connectable.
+          const relFromRegistry = relative(join(candidate.base, "projects"), candidate.path);
+          const insideRegistry = relFromRegistry !== "" && !relFromRegistry.startsWith("..");
+          if (insideRegistry && relFromRegistry.split(sep).length === 1) {
+            return genericError(400, "invalid_project_path", "Project folder is invalid");
+          }
         }
         const metadataPath = projectPath(homePath, slug);
         return withProjectLock(slug, async () => {

--- a/packages/gateway/src/project-manager.ts
+++ b/packages/gateway/src/project-manager.ts
@@ -287,14 +287,17 @@ export function createProjectManager(options: {
           ) {
             return genericError(400, "invalid_project_path", "Project folder is invalid");
           }
-          // Any managed project root (projects/<slug>) holds registry metadata
-          // (config.json, worktrees) that must never sit inside an
-          // agent-writable workspace; deeper paths such as projects/<slug>/repo
-          // contain no metadata and stay connectable.
+          // Inside the registry only the repo checkout (projects/<slug>/repo
+          // and below) is user content. The project root holds config.json,
+          // and worktrees/ holds Matrix-owned leases and .matrix metadata;
+          // none of it may become an agent-writable workspace root.
           const relFromRegistry = relative(join(candidate.base, "projects"), candidate.path);
           const insideRegistry = relFromRegistry !== "" && !relFromRegistry.startsWith("..");
-          if (insideRegistry && relFromRegistry.split(sep).length === 1) {
-            return genericError(400, "invalid_project_path", "Project folder is invalid");
+          if (insideRegistry) {
+            const segments = relFromRegistry.split(sep);
+            if (segments.length === 1 || segments[1] !== "repo") {
+              return genericError(400, "invalid_project_path", "Project folder is invalid");
+            }
           }
         }
         const metadataPath = projectPath(homePath, slug);

--- a/packages/gateway/src/server.ts
+++ b/packages/gateway/src/server.ts
@@ -538,6 +538,7 @@ export async function createGateway(config: GatewayConfig) {
   const codingAgentRegistryProviders: CodingAgentProviderAdapter[] = [];
   const codingAgentWorkspaceAgents = configuredWorkspaceProviderAgents(process.env);
   if (codingAgentWorkspaceAgents.length > 0) {
+    const codingAgentProjectManager = createProjectManager({ homePath });
     const codingAgentWorktreeManager = createWorktreeManager({ homePath });
     const codingAgentLauncher = createAgentLauncher({ cwd: homePath, runtimeHome: homePath });
     const codingAgentSessionManager = createAgentSessionManager({
@@ -549,6 +550,7 @@ export async function createGateway(config: GatewayConfig) {
         workspaceZellijRuntime.sendInput(sessionId, input, signal),
     });
     const codingAgentWorkspaceRuntime = createWorkspaceSessionOrchestrator({
+      projectManager: codingAgentProjectManager,
       worktreeManager: codingAgentWorktreeManager,
       projectManager: codingAgentProjectManager,
       agentSessionManager: codingAgentSessionManager,

--- a/packages/gateway/src/server.ts
+++ b/packages/gateway/src/server.ts
@@ -552,7 +552,6 @@ export async function createGateway(config: GatewayConfig) {
     const codingAgentWorkspaceRuntime = createWorkspaceSessionOrchestrator({
       projectManager: codingAgentProjectManager,
       worktreeManager: codingAgentWorktreeManager,
-      projectManager: codingAgentProjectManager,
       agentSessionManager: codingAgentSessionManager,
       agentSandbox: createAgentSandbox({ homePath }),
       sessionRuntimeBridge: workspaceSessionRuntimeBridge,

--- a/packages/gateway/src/workspace-routes.ts
+++ b/packages/gateway/src/workspace-routes.ts
@@ -41,7 +41,8 @@ const CreateProjectSchema = z.object({
   url: z.string().min(1).max(512).optional(),
   slug: z.string().min(1).max(63).optional(),
   name: z.string().trim().min(1).max(128).optional(),
-  mode: z.enum(["scratch", "github"]).optional(),
+  path: z.string().min(1).max(4096).optional(),
+  mode: z.enum(["scratch", "github", "folder"]).optional(),
   ownerScope: z.object({
     type: z.enum(["user", "org"]),
     id: z.string().min(1).max(128),
@@ -60,6 +61,13 @@ const CreateProjectSchema = z.object({
       code: "custom",
       path: ["name"],
       message: "Project name is required",
+    });
+  }
+  if (mode === "folder" && (!body.name || !body.path)) {
+    ctx.addIssue({
+      code: "custom",
+      path: [body.name ? "path" : "name"],
+      message: "Folder projects require a name and path",
     });
   }
 });
@@ -227,6 +235,7 @@ export function createWorkspaceRoutes(options: {
   const eventStore = options.eventStore ?? createWorkspaceEventStore({ homePath: options.homePath });
   const eventPublisher = options.eventPublisher ?? createWorkspaceEventPublisher({ eventStore });
   const sessionOrchestrator = options.sessionOrchestrator ?? createWorkspaceSessionOrchestrator({
+    projectManager,
     worktreeManager,
     agentSessionManager,
     agentSandbox,
@@ -294,6 +303,7 @@ export function createWorkspaceRoutes(options: {
       url: body.value.url,
       slug: body.value.slug,
       name: body.value.name,
+      path: body.value.path,
       mode: body.value.mode ?? (body.value.url ? "github" : "scratch"),
       ownerScope,
     });

--- a/packages/gateway/src/workspace-session-orchestrator.ts
+++ b/packages/gateway/src/workspace-session-orchestrator.ts
@@ -5,14 +5,18 @@ import type {
   createAgentSessionManager,
 } from "./agent-session-manager.js";
 import type { AgentLaunchSandbox, SupportedAgent } from "./agent-launcher.js";
-import type { createProjectManager, WorkspaceError } from "./project-manager.js";
+import type { WorkspaceError } from "./project-manager.js";
 import type { OwnerScope } from "./state-ops.js";
 import type { createAgentSandbox } from "./agent-sandbox.js";
 import type { createSessionRuntimeBridge } from "./session-runtime-bridge.js";
 import type { createWorktreeManager, WorktreeRecord } from "./worktree-manager.js";
+import type { createProjectManager } from "./project-manager.js";
 import type { WorkspaceEventPublisher } from "./workspace-event-publisher.js";
 
-type WorktreeManager = Pick<ReturnType<typeof createWorktreeManager>, "listWorktrees">;
+type WorktreeManager = Pick<
+  ReturnType<typeof createWorktreeManager>,
+  "listWorktrees"
+>;
 type ProjectManager = Pick<ReturnType<typeof createProjectManager>, "getProject">;
 type AgentSessionManager = Pick<
   ReturnType<typeof createAgentSessionManager>,
@@ -68,25 +72,32 @@ async function resolveRequestedWorktree(
   return worktree ? { ok: true, worktree } : failure(404, "not_found", "Worktree was not found");
 }
 
-async function resolveRequestedProject(
-  projectManager: ProjectManager | undefined,
+async function resolveAgentWorkspaceRoot(
+  projectManager: ProjectManager,
+  worktreeManager: WorktreeManager,
   ownerScope: OwnerScope,
   projectSlug: string,
-): Promise<{ ok: true; path: string } | Failure> {
-  if (!projectManager) {
-    return failure(503, "sandbox_unavailable", "Agent sandbox is unavailable");
+  worktreeId: string | undefined,
+): Promise<{ ok: true; path: string; worktreeId?: string } | Failure> {
+  if (worktreeId) {
+    const resolved = await resolveRequestedWorktree(worktreeManager, projectSlug, worktreeId);
+    return resolved.ok
+      ? { ok: true, path: resolved.worktree.path, worktreeId: resolved.worktree.id }
+      : resolved;
   }
-  const result = await projectManager.getProject(projectSlug);
-  if (!result.ok) {
-    return result.status >= 500
+  const project = await projectManager.getProject(projectSlug);
+  if (!project.ok) {
+    return project.status >= 500
       ? failure(503, "sandbox_unavailable", "Agent sandbox is unavailable")
       : failure(404, "not_found", "Project was not found");
   }
-  const projectOwner = result.project.ownerScope;
+  // A project checkout may only host sessions for its persisted owner; a
+  // mismatched scope reads as not-found so foreign owners learn nothing.
+  const projectOwner = project.project.ownerScope;
   if (projectOwner.type !== ownerScope.type || projectOwner.id !== ownerScope.id) {
     return failure(404, "not_found", "Project was not found");
   }
-  return { ok: true, path: result.project.localPath };
+  return { ok: true, path: project.project.localPath };
 }
 
 function toLaunchApprovalPolicy(
@@ -141,8 +152,8 @@ async function resolveAgentSandbox(options: {
 }
 
 export function createWorkspaceSessionOrchestrator(options: {
+  projectManager: ProjectManager;
   worktreeManager: WorktreeManager;
-  projectManager?: ProjectManager;
   agentSessionManager: AgentSessionManager;
   agentSandbox: AgentSandbox;
   sessionRuntimeBridge: SessionRuntimeBridge;
@@ -194,28 +205,36 @@ export function createWorkspaceSessionOrchestrator(options: {
         : input.request;
       const sessionId = request.sessionId ?? idGenerator();
       let sandbox: AgentLaunchSandbox | undefined;
+      let effectiveRequest = request;
 
       if (request.agent === "codex" || request.agent === "claude") {
         if (!request.projectSlug) {
           return failure(400, "sandbox_unavailable", "Agent sandbox is unavailable");
         }
-        const workspace = request.worktreeId
-          ? await resolveRequestedWorktree(options.worktreeManager, request.projectSlug, request.worktreeId)
-          : await resolveRequestedProject(options.projectManager, input.ownerScope, request.projectSlug);
-        if (!workspace.ok) return workspace;
+        const workspaceRoot = await resolveAgentWorkspaceRoot(
+          options.projectManager,
+          options.worktreeManager,
+          input.ownerScope,
+          request.projectSlug,
+          request.worktreeId,
+        );
+        if (!workspaceRoot.ok) return workspaceRoot;
+        effectiveRequest = workspaceRoot.worktreeId
+          ? { ...request, worktreeId: workspaceRoot.worktreeId }
+          : request;
         const preflight = await resolveAgentSandbox({
           agentSandbox: options.agentSandbox,
           agent: request.agent,
-          request,
+          request: effectiveRequest,
           sessionId,
-          workspacePath: "worktree" in workspace ? workspace.worktree.path : workspace.path,
+          workspacePath: workspaceRoot.path,
         });
         if (!preflight.ok) return preflight;
         sandbox = preflight.sandbox;
       }
 
       const result = await options.agentSessionManager.startSession({
-        ...request,
+        ...effectiveRequest,
         sessionId,
         ownerId: input.ownerScope.id,
         sandbox,

--- a/specs/069-cloud-coding-workspaces/contracts/api.md
+++ b/specs/069-cloud-coding-workspaces/contracts/api.md
@@ -35,7 +35,26 @@ Returns GitHub CLI/auth availability for the current container.
 
 ### `POST /api/projects`
 
-Request:
+Create a managed folder:
+
+```json
+{
+  "mode": "scratch",
+  "name": "Customer app"
+}
+```
+
+Connect an existing folder within the owner's Matrix home without moving it:
+
+```json
+{
+  "mode": "folder",
+  "name": "Customer app",
+  "path": "workspaces/customer-app"
+}
+```
+
+Clone an optional GitHub repository:
 
 ```json
 {
@@ -57,7 +76,9 @@ Response: `201`
 }
 ```
 
-Errors: `github_auth_required`, `invalid_repository_url`, `clone_too_large`, `clone_timeout`, `slug_conflict`.
+Git and GitHub are optional project capabilities. Tasks and shell/agent sessions run in the project folder when no explicit worktree is selected. Removing a folder-linked project removes Matrix metadata only; it does not delete the connected owner folder.
+
+Errors: `github_auth_required`, `invalid_repository_url`, `invalid_project_path`, `clone_too_large`, `clone_timeout`, `slug_conflict`.
 
 ### `GET /api/workspace/projects`
 
@@ -73,6 +94,8 @@ Response:
 ```
 
 ### `GET /api/projects/:slug/prs`
+
+Non-GitHub projects return an empty `prs` array rather than an error.
 
 Response:
 

--- a/specs/105-coding-agent-shells/tasks.md
+++ b/specs/105-coding-agent-shells/tasks.md
@@ -1224,12 +1224,14 @@ thread-driven task movement. Surface validation is recorded in
 
 - [x] Replace free-text runtime entry with an owner-scoped computer list.
 - [x] Exchange and persist a runtime-scoped credential only in Electron main.
+- [x] Reuse the trusted computer list in a persistent sidebar dropdown above Settings.
+- [x] Keep platform-control-plane auth traffic separate from selected-runtime traffic.
 - [x] Rehydrate project/task/thread state after the selected computer changes.
 - [x] Keep machine identifiers, network details, credentials, and raw failures out of the renderer.
 
 Tests: runtime computer contracts, platform owner/auth route coverage, trusted
 auth and credential-store tests, IPC boundary tests, renderer switching/error
-tests, and desktop settings coverage.
+tests, sidebar dropdown coverage, and desktop settings coverage.
 
 Evidence: the platform returns a capped safe projection and rejects invalid,
 unauthenticated, or cross-owner selection; the trusted core rotates the bearer

--- a/tests/desktop/auth-service.test.ts
+++ b/tests/desktop/auth-service.test.ts
@@ -631,6 +631,7 @@ describe("AuthService device flow", () => {
         displayName: "Thomas Anderson",
         runtimeSlot: "primary",
         platformHost: "https://app.matrix-os.com",
+        authGeneration: 1,
       });
       expect(auth.poll()).toEqual({ status: "authorized", profile: { handle: "neo", userId: "user-1" } });
       expect(changes.at(-1)).toMatchObject({
@@ -825,5 +826,113 @@ describe("AuthService expireSession", () => {
     await auth.init();
 
     await expect(auth.listRuntimeComputers()).rejects.toThrow("Runtime computers unavailable");
+  });
+
+  it("expires the session when the computer inventory returns 401", async () => {
+    const fetchFn = vi.fn(async () => new Response("unauthorized", { status: 401 }));
+    const { auth, changes, peekCredential } = makeService({
+      now: 10_000,
+      credential: VALID,
+      profile: PROFILE,
+      fetchFn,
+    });
+    await auth.init();
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    try {
+      await expect(auth.listRuntimeComputers()).rejects.toThrow("Runtime computers unavailable");
+    } finally {
+      warn.mockRestore();
+    }
+
+    expect(auth.getStatus().signedIn).toBe(false);
+    expect(peekCredential()).toBeNull();
+    expect(changes.at(-1)?.signedIn).toBe(false);
+  });
+
+  it("keeps the session when the computer inventory fails without an auth error", async () => {
+    const fetchFn = vi.fn(async () => new Response("upstream down", { status: 503 }));
+    const { auth, peekCredential } = makeService({
+      now: 10_000,
+      credential: VALID,
+      profile: PROFILE,
+      fetchFn,
+    });
+    await auth.init();
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    try {
+      await expect(auth.listRuntimeComputers()).rejects.toThrow("Runtime computers unavailable");
+    } finally {
+      warn.mockRestore();
+    }
+
+    expect(auth.getStatus().signedIn).toBe(true);
+    expect(peekCredential()).not.toBeNull();
+  });
+});
+
+describe("AuthService auth generation", () => {
+  it("advances the auth generation whenever the credential is replaced or dropped", async () => {
+    const fetchFn = vi.fn(async (url: string) => {
+      if (url.endsWith("/api/auth/device/code")) {
+        return jsonResponse({
+          deviceCode: "device-1",
+          userCode: "ABCD",
+          verificationUri: "https://app.matrix-os.com/device",
+          expiresIn: 600,
+          interval: 5,
+        });
+      }
+      return jsonResponse({
+        accessToken: "fresh-device-token",
+        expiresAt: 1_800_000_000_000,
+        userId: "user-1",
+        handle: "neo",
+      });
+    });
+    const { auth } = makeService({ profile: PROFILE, now: 10_000, fetchFn });
+    await auth.init();
+    const initialGeneration = auth.getStatus().authGeneration;
+
+    await auth.startDeviceFlow();
+    await flushAuthFlow();
+    expect(auth.getStatus().signedIn).toBe(true);
+    const firstSessionGeneration = auth.getStatus().authGeneration;
+    expect(firstSessionGeneration).not.toBe(initialGeneration);
+
+    await auth.expireSession();
+    const expiredGeneration = auth.getStatus().authGeneration;
+    expect(expiredGeneration).not.toBe(firstSessionGeneration);
+
+    // A replacement session with an identical handle/host/slot must still get
+    // a distinct generation so renderer caches keyed on it cannot leak.
+    await auth.startDeviceFlow();
+    await flushAuthFlow();
+    expect(auth.getStatus().signedIn).toBe(true);
+    expect(auth.getStatus().authGeneration).not.toBe(firstSessionGeneration);
+    expect(auth.getStatus().authGeneration).not.toBe(expiredGeneration);
+  });
+
+  it("advances the auth generation on runtime credential exchange and sign-out", async () => {
+    const fetchFn = vi.fn(async (url: string) => {
+      if (url === "https://api.matrix-os.com/api/auth/runtime-selection") {
+        return jsonResponse({
+          accessToken: "s".repeat(64),
+          expiresAt: 1_800_000_000_000,
+          handle: "neo-review",
+          slot: "review",
+        });
+      }
+      return jsonResponse({});
+    });
+    const { auth } = makeService({ credential: VALID, profile: PROFILE, now: 10_000, fetchFn });
+    await auth.init();
+    const beforeSwitch = auth.getStatus().authGeneration;
+
+    await auth.selectRuntime("review");
+    const afterSwitch = auth.getStatus().authGeneration;
+    expect(afterSwitch).not.toBe(beforeSwitch);
+
+    await auth.signOut();
+    expect(auth.getStatus().authGeneration).not.toBe(afterSwitch);
   });
 });

--- a/tests/desktop/auth-service.test.ts
+++ b/tests/desktop/auth-service.test.ts
@@ -760,4 +760,70 @@ describe("AuthService expireSession", () => {
     expect(getProfile()).toBeNull();
     expect(store.save).not.toHaveBeenCalled();
   });
+
+  it("lists the canonical bounded computer inventory through trusted main", async () => {
+    const inventory = {
+      items: [{
+        handle: "neo",
+        runtimeSlot: "primary",
+        label: "Main Computer",
+        availability: "available",
+        kind: "customer",
+        gatewayPath: "/vm/neo",
+        capabilities: [],
+      }],
+      selectedSlot: "primary",
+      hasMore: false,
+      limit: 20,
+    };
+    const fetchFn = vi.fn(async () => jsonResponse(inventory));
+    const { auth } = makeService({
+      now: 10_000,
+      credential: {
+        accessToken: "opaque-runtime-token",
+        expiresAt: HOUR_MS,
+        userId: "user-1",
+        handle: "neo",
+      },
+      profile: {
+        handle: "neo",
+        userId: "user-1",
+        platformHost: "https://app.matrix-os.com",
+        runtimeSlot: "primary",
+      },
+      fetchFn,
+    });
+    await auth.init();
+
+    await expect(auth.listRuntimeComputers()).resolves.toEqual(inventory);
+    expect(fetchFn).toHaveBeenCalledWith(
+      "https://api.matrix-os.com/api/auth/computers",
+      expect.objectContaining({
+        method: "GET",
+        headers: { authorization: "Bearer opaque-runtime-token" },
+      }),
+    );
+  });
+
+  it("contains malformed computer inventory responses behind a generic error", async () => {
+    const { auth } = makeService({
+      now: 10_000,
+      credential: {
+        accessToken: "opaque-runtime-token",
+        expiresAt: HOUR_MS,
+        userId: "user-1",
+        handle: "neo",
+      },
+      profile: {
+        handle: "neo",
+        userId: "user-1",
+        platformHost: "https://app.matrix-os.com",
+        runtimeSlot: "primary",
+      },
+      fetchFn: async () => jsonResponse({ accessToken: "leaked", items: [] }),
+    });
+    await auth.init();
+
+    await expect(auth.listRuntimeComputers()).rejects.toThrow("Runtime computers unavailable");
+  });
 });

--- a/tests/desktop/board-store.test.ts
+++ b/tests/desktop/board-store.test.ts
@@ -94,6 +94,24 @@ describe("groupCardsByColumn", () => {
 });
 
 describe("createProject", () => {
+  it("keeps the gateway-owned folder and optional GitHub capability", async () => {
+    const api = makeApi({
+      get: vi.fn().mockResolvedValue({
+        projects: [
+          { slug: "folder", name: "Folder", localPath: "/home/matrix/home/workspaces/folder" },
+          { slug: "repo", name: "Repo", localPath: "/home/matrix/home/projects/repo/repo", github: { owner: "o", repo: "r" } },
+        ],
+      }),
+    });
+
+    await useBoard.getState().loadProjects(api);
+
+    expect(useBoard.getState().projects).toEqual([
+      { slug: "folder", name: "Folder", localPath: "/home/matrix/home/workspaces/folder", githubBacked: false },
+      { slug: "repo", name: "Repo", localPath: "/home/matrix/home/projects/repo/repo", githubBacked: true },
+    ]);
+  });
+
   it("POSTs a scratch project and refreshes the list", async () => {
     const post = vi.fn().mockResolvedValue({ project: { slug: "my-app", name: "My App" } });
     const get = vi.fn().mockResolvedValue({ projects: [{ slug: "my-app", name: "My App" }] });
@@ -110,6 +128,25 @@ describe("createProject", () => {
     const api = makeApi({ post, get: vi.fn().mockResolvedValue({ projects: [] }) });
     await useBoard.getState().createProject(api, { name: "repo", mode: "github", url: "https://github.com/o/repo" });
     expect(post).toHaveBeenCalledWith("/api/projects", { name: "repo", mode: "github", url: "https://github.com/o/repo" });
+  });
+
+  it("connects a project to an existing computer folder", async () => {
+    const post = vi.fn().mockResolvedValue({
+      project: { slug: "app", name: "App", localPath: "/home/matrix/home/workspaces/app" },
+    });
+    const api = makeApi({ post, get: vi.fn().mockResolvedValue({ projects: [] }) });
+
+    await useBoard.getState().createProject(api, {
+      name: "App",
+      mode: "folder",
+      path: "workspaces/app",
+    });
+
+    expect(post).toHaveBeenCalledWith("/api/projects", {
+      name: "App",
+      mode: "folder",
+      path: "workspaces/app",
+    });
   });
 
   it("preserves the refresh error when creation succeeds but the project list reload fails", async () => {
@@ -205,7 +242,12 @@ describe("loadProjects", () => {
     });
     await useBoard.getState().loadProjects(api);
     expect(api.get).toHaveBeenCalledWith("/api/workspace/projects");
-    expect(useBoard.getState().projects).toEqual([{ slug: "proj", name: "Proj" }]);
+    expect(useBoard.getState().projects).toEqual([{
+      slug: "proj",
+      name: "Proj",
+      localPath: "/x",
+      githubBacked: false,
+    }]);
     expect(useBoard.getState().error).toBeNull();
   });
 

--- a/tests/desktop/coding-agent-project-navigator.test.tsx
+++ b/tests/desktop/coding-agent-project-navigator.test.tsx
@@ -77,6 +77,28 @@ function workspaceFixture(): ProjectAgentWorkspace {
 afterEach(cleanup);
 
 describe("AgentProjectNavigator", () => {
+  it("creates Matrix projects from the Agents navigator", () => {
+    const onNewProject = vi.fn();
+    render(
+      <AgentProjectNavigator
+        summary={summaryFixture()}
+        workspace={workspaceFixture()}
+        status="ready"
+        selectedProjectId="matrix-os"
+        selectedTaskId={null}
+        selectedThreadId={null}
+        onSelectProject={vi.fn()}
+        onSelectTask={vi.fn()}
+        onSelectThread={vi.fn()}
+        onNewChat={vi.fn()}
+        onNewProject={onNewProject}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "New project" }));
+    expect(onNewProject).toHaveBeenCalledOnce();
+  });
+
   it("DT-001 renders every bounded project from the trusted projection", () => {
     render(
       <AgentProjectNavigator

--- a/tests/desktop/coding-agent-workspace.test.tsx
+++ b/tests/desktop/coding-agent-workspace.test.tsx
@@ -3736,6 +3736,8 @@ describe("AgentWorkspace", () => {
     expect(useCodingAgentWorkspace.getState().activeThreadId).toBeNull();
     expect(useCodingAgentWorkspace.getState().threadSnapshot).toBeNull();
     expect(useCodingAgentWorkspace.getState().createdThreadHandles).toEqual([]);
+    // The new runtime's composer must not inherit a phantom submitting state.
+    expect(useCodingAgentWorkspace.getState().createStatus).toBe("idle");
   });
 
   it("sends a same-thread message and refreshes only the selected conversation", async () => {

--- a/tests/desktop/coding-agent-workspace.test.tsx
+++ b/tests/desktop/coding-agent-workspace.test.tsx
@@ -9,6 +9,7 @@ import AgentWorkspace, {
 } from "../../desktop/src/renderer/src/features/coding-agents/AgentWorkspace";
 import { useCodingAgentWorkspace } from "../../desktop/src/renderer/src/stores/coding-agent-workspace";
 import { useCodingAgentProjectWorkspace } from "../../desktop/src/renderer/src/stores/coding-agent-project-workspace";
+import { reconcileDesktopRuntimeChange } from "../../desktop/src/renderer/src/stores/runtime-transition";
 import type { ApiClient } from "../../desktop/src/renderer/src/lib/api";
 import { useBoard } from "../../desktop/src/renderer/src/stores/board";
 import { useConnection } from "../../desktop/src/renderer/src/stores/connection";
@@ -3691,6 +3692,50 @@ describe("AgentWorkspace", () => {
       },
     });
     await expect(first).resolves.toBe("thread_duplicate_1");
+  });
+
+  it("discards an in-flight thread create that settles after the computer changes", async () => {
+    let resolveCreate: (value: unknown) => void = () => undefined;
+    window.operator.invoke = vi.fn((channel: string) => {
+      if (channel === "runtime:create-thread") {
+        return new Promise((resolve) => {
+          resolveCreate = resolve;
+        });
+      }
+      return Promise.reject(new Error("unexpected channel"));
+    });
+    useCodingAgentWorkspace.setState({ summary: summaryFixture({ threadCreate: true }) });
+    const draft = {
+      providerId: "codex",
+      prompt: "Stale create after switch",
+      mode: "default",
+      approvalPolicy: "on_request",
+      sandboxMode: "workspace_write",
+    } as const;
+
+    const pending = useCodingAgentWorkspace.getState().createThread(draft);
+    reconcileDesktopRuntimeChange({ disposeRuntimeAttachments: vi.fn() });
+    resolveCreate({
+      thread: {
+        id: "thread_stale_1",
+        providerId: "codex",
+        title: "Stale create after switch",
+        status: "queued",
+        attention: "none",
+        createdAt: "2026-07-06T00:00:00.000Z",
+        updatedAt: "2026-07-06T00:00:00.000Z",
+      },
+      events: {
+        items: [],
+        hasMore: false,
+        limit: 200,
+      },
+    });
+
+    await expect(pending).resolves.toBeNull();
+    expect(useCodingAgentWorkspace.getState().activeThreadId).toBeNull();
+    expect(useCodingAgentWorkspace.getState().threadSnapshot).toBeNull();
+    expect(useCodingAgentWorkspace.getState().createdThreadHandles).toEqual([]);
   });
 
   it("sends a same-thread message and refreshes only the selected conversation", async () => {

--- a/tests/desktop/connection-store.test.ts
+++ b/tests/desktop/connection-store.test.ts
@@ -16,6 +16,7 @@ beforeEach(() => {
     handle: null,
     platformHost: "",
     runtimeSlot: "primary",
+    authGeneration: 0,
     api: null,
   });
 });
@@ -26,11 +27,14 @@ afterEach(() => {
 });
 
 describe("connection event wiring", () => {
-  it("invalidates the previous runtime before the trusted runtime switch", async () => {
+  it("keeps the previous desktop state intact until the trusted runtime switch succeeds", async () => {
     useBoard.setState({ projects: [{ slug: "old", name: "Old" }], activeProjectSlug: "old" });
     const invoke = vi.fn(async (channel: string) => {
       if (channel === "runtime:select") {
-        expect(useBoard.getState()).toMatchObject({ projects: [], activeProjectSlug: null });
+        expect(useBoard.getState()).toMatchObject({
+          projects: [{ slug: "old", name: "Old" }],
+          activeProjectSlug: "old",
+        });
       }
       return {};
     });
@@ -39,7 +43,51 @@ describe("connection event wiring", () => {
     await useConnection.getState().selectRuntime("preview");
 
     expect(invoke).toHaveBeenCalledWith("runtime:select", { slot: "preview" });
+    expect(useBoard.getState()).toMatchObject({ projects: [], activeProjectSlug: null });
     expect(useConnection.getState().runtimeSlot).toBe("preview");
+  });
+
+  it("preserves desktop state and the selected slot when the runtime switch fails", async () => {
+    useBoard.setState({ projects: [{ slug: "old", name: "Old" }], activeProjectSlug: "old" });
+    const invoke = vi.fn(async (channel: string) => {
+      if (channel === "runtime:select") throw new Error("switch failed");
+      if (channel === "auth:status") {
+        return {
+          signedIn: true,
+          handle: "neo",
+          platformHost: "https://app.matrix-os.com",
+          runtimeSlot: "primary",
+          authGeneration: 1,
+        };
+      }
+      return {};
+    });
+    window.operator = { invoke, on: vi.fn() };
+
+    await expect(useConnection.getState().selectRuntime("preview")).rejects.toThrow();
+
+    expect(useBoard.getState()).toMatchObject({
+      projects: [{ slug: "old", name: "Old" }],
+      activeProjectSlug: "old",
+    });
+    expect(useConnection.getState().runtimeSlot).toBe("primary");
+  });
+
+  it("exposes the trusted-core auth generation on refresh", async () => {
+    window.operator = {
+      invoke: vi.fn(async () => ({
+        signedIn: true,
+        handle: "neo",
+        platformHost: "https://app.matrix-os.com",
+        runtimeSlot: "primary",
+        authGeneration: 7,
+      })),
+      on: vi.fn(),
+    };
+
+    await useConnection.getState().refresh();
+
+    expect(useConnection.getState().authGeneration).toBe(7);
   });
 
   it("recovers from an initial auth status failure instead of staying loading", async () => {

--- a/tests/desktop/connection-store.test.ts
+++ b/tests/desktop/connection-store.test.ts
@@ -6,6 +6,7 @@ import {
   useConnection,
   wireConnectionEvents,
 } from "@desktop/renderer/src/stores/connection";
+import { useBoard } from "@desktop/renderer/src/stores/board";
 
 type Listener = (payload: unknown) => void;
 
@@ -25,6 +26,22 @@ afterEach(() => {
 });
 
 describe("connection event wiring", () => {
+  it("invalidates the previous runtime before the trusted runtime switch", async () => {
+    useBoard.setState({ projects: [{ slug: "old", name: "Old" }], activeProjectSlug: "old" });
+    const invoke = vi.fn(async (channel: string) => {
+      if (channel === "runtime:select") {
+        expect(useBoard.getState()).toMatchObject({ projects: [], activeProjectSlug: null });
+      }
+      return {};
+    });
+    window.operator = { invoke, on: vi.fn() };
+
+    await useConnection.getState().selectRuntime("preview");
+
+    expect(invoke).toHaveBeenCalledWith("runtime:select", { slot: "preview" });
+    expect(useConnection.getState().runtimeSlot).toBe("preview");
+  });
+
   it("recovers from an initial auth status failure instead of staying loading", async () => {
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
     window.operator = {

--- a/tests/desktop/connection-store.test.ts
+++ b/tests/desktop/connection-store.test.ts
@@ -36,6 +36,15 @@ describe("connection event wiring", () => {
           activeProjectSlug: "old",
         });
       }
+      if (channel === "auth:status") {
+        return {
+          signedIn: true,
+          handle: "neo-preview",
+          platformHost: "https://app.matrix-os.com",
+          runtimeSlot: "preview",
+          authGeneration: 2,
+        };
+      }
       return {};
     });
     window.operator = { invoke, on: vi.fn() };
@@ -45,6 +54,57 @@ describe("connection event wiring", () => {
     expect(invoke).toHaveBeenCalledWith("runtime:select", { slot: "preview" });
     expect(useBoard.getState()).toMatchObject({ projects: [], activeProjectSlug: null });
     expect(useConnection.getState().runtimeSlot).toBe("preview");
+    // The post-switch refresh publishes the replacement session's snapshot.
+    expect(useConnection.getState().authGeneration).toBe(2);
+  });
+
+  it("suppresses runtime event refreshes until the switch has reconciled", async () => {
+    const listeners = new Map<string, Listener>();
+    let resolveSelect!: (value: unknown) => void;
+    const invoke = vi.fn(async (channel: string) => {
+      if (channel === "runtime:select") {
+        return new Promise((resolve) => {
+          resolveSelect = resolve;
+        });
+      }
+      if (channel === "auth:status") {
+        return {
+          signedIn: true,
+          handle: "neo-review",
+          platformHost: "https://app.matrix-os.com",
+          runtimeSlot: "review",
+          authGeneration: 2,
+        };
+      }
+      return {};
+    });
+    window.operator = {
+      invoke,
+      on: vi.fn((channel: string, callback: Listener) => {
+        listeners.set(channel, callback);
+        return () => {
+          listeners.delete(channel);
+        };
+      }),
+    };
+    wireConnectionEvents();
+    useBoard.setState({ projects: [{ slug: "old", name: "Old" }], activeProjectSlug: "old" });
+
+    const pending = useConnection.getState().selectRuntime("review");
+    // The trusted core emits runtime:changed before the invoke resolves; the
+    // wired listener must not publish the new slot before reconciliation.
+    listeners.get("runtime:changed")?.({ slot: "review" });
+    await Promise.resolve();
+    expect(invoke).not.toHaveBeenCalledWith("auth:status", {});
+    expect(useConnection.getState().runtimeSlot).toBe("primary");
+    expect(useBoard.getState()).toMatchObject({ projects: [{ slug: "old", name: "Old" }] });
+
+    resolveSelect({});
+    await pending;
+
+    expect(useBoard.getState()).toMatchObject({ projects: [], activeProjectSlug: null });
+    expect(useConnection.getState().runtimeSlot).toBe("review");
+    expect(useConnection.getState().authGeneration).toBe(2);
   });
 
   it("preserves desktop state and the selected slot when the runtime switch fails", async () => {

--- a/tests/desktop/create-project-dialog.test.tsx
+++ b/tests/desktop/create-project-dialog.test.tsx
@@ -73,4 +73,28 @@ describe("CreateProjectDialog", () => {
     expect(selectProject).not.toHaveBeenCalled();
     expect(openTab).not.toHaveBeenCalled();
   });
+
+  it("connects an existing computer folder without requiring GitHub", async () => {
+    const createProject = vi.fn(async () => ({
+      slug: "customer-app",
+      name: "Customer app",
+      localPath: "/home/matrix/home/workspaces/customer-app",
+      githubBacked: false,
+    }));
+    useBoard.setState({ createProject, selectProject: vi.fn(async () => undefined) });
+    render(<CreateProjectDialog open onClose={vi.fn()} />);
+
+    fireEvent.change(screen.getByPlaceholderText("Project name"), { target: { value: "Customer app" } });
+    fireEvent.click(screen.getByRole("button", { name: "Use existing folder" }));
+    fireEvent.change(screen.getByPlaceholderText("workspaces/customer-app"), {
+      target: { value: "workspaces/customer-app" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Create" }));
+
+    await waitFor(() => expect(createProject).toHaveBeenCalledWith(expect.anything(), {
+      name: "Customer app",
+      mode: "folder",
+      path: "workspaces/customer-app",
+    }));
+  });
 });

--- a/tests/desktop/ipc-contract.test.ts
+++ b/tests/desktop/ipc-contract.test.ts
@@ -31,6 +31,7 @@ describe("IPC contract", () => {
       "runtime:get-reviews",
       "runtime:get-summary",
       "runtime:get-project-workspace",
+      "runtime:list-computers",
       "runtime:select",
       "state:get",
       "state:set",
@@ -707,6 +708,42 @@ describe("IPC contract", () => {
     expect(schema.safeParse({ slot: "../private" }).success).toBe(false);
     expect(schema.safeParse({ slot: "review computer" }).success).toBe(false);
     expect(schema.safeParse({}).success).toBe(false);
+  });
+
+  it("returns only bounded safe computer summaries", () => {
+    const request = INVOKE_CHANNELS["runtime:list-computers"].request;
+    const response = INVOKE_CHANNELS["runtime:list-computers"].response;
+    expect(request.safeParse({}).success).toBe(true);
+    expect(request.safeParse({ accessToken: "secret" }).success).toBe(false);
+    expect(response.safeParse({
+      items: [{
+        handle: "operator",
+        runtimeSlot: "primary",
+        label: "Main Computer",
+        availability: "available",
+        kind: "customer",
+        gatewayPath: "/vm/operator",
+        capabilities: [],
+      }],
+      selectedSlot: "primary",
+      hasMore: false,
+      limit: 20,
+    }).success).toBe(true);
+    expect(response.safeParse({
+      items: [{
+        handle: "operator",
+        runtimeSlot: "primary",
+        label: "Main Computer",
+        availability: "available",
+        kind: "customer",
+        gatewayPath: "/vm/operator",
+        capabilities: [],
+        accessToken: "secret",
+      }],
+      selectedSlot: "primary",
+      hasMore: false,
+      limit: 20,
+    }).success).toBe(false);
   });
 
   it("bounds notify payloads", () => {

--- a/tests/desktop/mission-control.test.tsx
+++ b/tests/desktop/mission-control.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 
 import React from "react";
-import { cleanup, render, waitFor } from "@testing-library/react";
+import { act, cleanup, render, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import MissionControl from "../../desktop/src/renderer/src/features/mission-control/MissionControl";
 import { useConnection } from "../../desktop/src/renderer/src/stores/connection";
@@ -118,5 +118,43 @@ describe("MissionControl", () => {
       "[mission-control] restore last project failed:",
       "project refresh failed",
     );
+  });
+
+  it("selects a valid project from the new runtime instead of restoring a stale slug", async () => {
+    const api = { get: vi.fn() };
+    const loadProjects = vi.fn(async () => {
+      const runtimeSlot = useConnection.getState().runtimeSlot;
+      useBoard.setState({
+        projects: runtimeSlot === "preview"
+          ? [{ slug: "preview-project", name: "Preview Project" }]
+          : [{ slug: "main-project", name: "Main Project" }],
+      });
+    });
+    const selectProject = vi.fn(async (_api, slug: string) => {
+      useBoard.setState({ activeProjectSlug: slug });
+    });
+    vi.stubGlobal("operator", {
+      invoke: vi.fn(async () => ({ value: "main-project" })),
+      on: vi.fn(),
+    });
+    useConnection.setState({
+      status: "signed-in",
+      handle: "operator",
+      platformHost: "https://platform.test",
+      runtimeSlot: "primary",
+      api: api as never,
+    });
+    useBoard.setState({ loadProjects, selectProject, projects: [], activeProjectSlug: null });
+
+    render(<MissionControl />);
+    await waitFor(() => expect(selectProject).toHaveBeenCalledWith(api, "main-project"));
+
+    act(() => {
+      useBoard.setState({ projects: [], activeProjectSlug: null });
+      useConnection.setState({ runtimeSlot: "preview" });
+    });
+
+    await waitFor(() => expect(selectProject).toHaveBeenCalledWith(api, "preview-project"));
+    expect(useBoard.getState().activeProjectSlug).toBe("preview-project");
   });
 });

--- a/tests/desktop/panel-strip.test.ts
+++ b/tests/desktop/panel-strip.test.ts
@@ -1,6 +1,11 @@
-import { describe, expect, it } from "vitest";
+// @vitest-environment jsdom
+
+import React from "react";
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   groupLayoutForPanels,
+  PanelErrorBoundary,
   panelSizesFromGroupLayout,
 } from "@desktop/renderer/src/features/workspace/PanelStrip";
 import type { PanelKind } from "@desktop/renderer/src/stores/workspace";
@@ -15,6 +20,8 @@ const baseSizes: Record<PanelKind, number> = {
 };
 
 describe("PanelStrip layout adapters", () => {
+  afterEach(cleanup);
+
   it("passes react-resizable-panels a keyed layout", () => {
     expect(groupLayoutForPanels(["terminal", "editor"], baseSizes)).toEqual({
       terminal: 70,
@@ -42,5 +49,28 @@ describe("PanelStrip layout adapters", () => {
       ...baseSizes,
       terminal: 64,
     });
+  });
+
+  it("contains a failing legacy panel without hiding the rest of the task", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    function BrokenPanel(): React.ReactNode {
+      throw new Error("private file path");
+    }
+
+    render(React.createElement(
+      "div",
+      null,
+      React.createElement(
+        PanelErrorBoundary,
+        { panel: "terminal" },
+        React.createElement(BrokenPanel),
+      ),
+      React.createElement("p", null, "Files panel remains available"),
+    ));
+
+    expect(screen.getByText("Terminal panel couldn't open.")).toBeTruthy();
+    expect(screen.getByText("Files panel remains available")).toBeTruthy();
+    expect(screen.queryByText(/private file path/i)).toBeNull();
+    warn.mockRestore();
   });
 });

--- a/tests/desktop/runtime-computer-menu.test.tsx
+++ b/tests/desktop/runtime-computer-menu.test.tsx
@@ -143,4 +143,36 @@ describe("sidebar computer menu", () => {
     expect(firstInvoke).toHaveBeenCalledWith("runtime:list-computers", {});
     expect(window.operator.invoke).toHaveBeenCalledWith("runtime:list-computers", {});
   });
+
+  it("clears owner-scoped inventory when a signed-in session is replaced in place", async () => {
+    useConnection.setState({ api: { get: vi.fn(), post: vi.fn(), delete: vi.fn() } as never });
+    const view = render(<RuntimeComputerMenu collapsed={false} />);
+    await waitFor(() => expect(screen.getByText("operator")).not.toBeNull());
+    view.unmount();
+
+    window.operator.invoke = vi.fn(async (channel: string) => {
+      if (channel === "runtime:list-computers") {
+        return {
+          ...computers,
+          items: [{
+            handle: "operator-new-session",
+            runtimeSlot: "primary",
+            label: "Main Computer",
+            availability: "available",
+            kind: "customer",
+            gatewayPath: "/vm/operator-new-session",
+            capabilities: [],
+          }],
+        };
+      }
+      return { ok: true };
+    });
+    act(() => {
+      useConnection.setState({ api: { get: vi.fn(), post: vi.fn(), delete: vi.fn() } as never });
+    });
+
+    render(<RuntimeComputerMenu collapsed={false} />);
+    await waitFor(() => expect(screen.getByText("operator-new-session")).not.toBeNull());
+    expect(window.operator.invoke).toHaveBeenCalledWith("runtime:list-computers", {});
+  });
 });

--- a/tests/desktop/runtime-computer-menu.test.tsx
+++ b/tests/desktop/runtime-computer-menu.test.tsx
@@ -234,7 +234,7 @@ describe("sidebar computer menu", () => {
   });
 
   it("clears owner-scoped inventory when a signed-in session is replaced in place", async () => {
-    useConnection.setState({ api: { get: vi.fn(), post: vi.fn(), delete: vi.fn() } as never });
+    useConnection.setState({ authGeneration: 1, api: { get: vi.fn(), post: vi.fn(), delete: vi.fn() } as never });
     const view = render(<RuntimeComputerMenu collapsed={false} />);
     await waitFor(() => expect(screen.getByText("operator")).not.toBeNull());
     view.unmount();
@@ -257,11 +257,26 @@ describe("sidebar computer menu", () => {
       return { ok: true };
     });
     act(() => {
-      useConnection.setState({ api: { get: vi.fn(), post: vi.fn(), delete: vi.fn() } as never });
+      useConnection.setState({ authGeneration: 2, api: { get: vi.fn(), post: vi.fn(), delete: vi.fn() } as never });
     });
 
     render(<RuntimeComputerMenu collapsed={false} />);
     await waitFor(() => expect(screen.getByText("operator-new-session")).not.toBeNull());
     expect(window.operator.invoke).toHaveBeenCalledWith("runtime:list-computers", {});
+  });
+
+  it("keeps the ready inventory when a same-session refresh replaces the api client", async () => {
+    render(<RuntimeComputerMenu collapsed={false} />);
+    await waitFor(() => expect(screen.getByText("Main Computer")).not.toBeNull());
+
+    // A failed switch refreshes auth status and constructs a new ApiClient
+    // while the credential (and its generation) is unchanged; the ready
+    // inventory must survive so the picker is not left empty.
+    act(() => {
+      useConnection.setState({ api: { get: vi.fn(), post: vi.fn(), delete: vi.fn() } as never });
+    });
+
+    expect(useRuntimeComputers.getState().status).toBe("ready");
+    expect(screen.getByText("Main Computer")).not.toBeNull();
   });
 });

--- a/tests/desktop/runtime-computer-menu.test.tsx
+++ b/tests/desktop/runtime-computer-menu.test.tsx
@@ -144,6 +144,95 @@ describe("sidebar computer menu", () => {
     expect(window.operator.invoke).toHaveBeenCalledWith("runtime:list-computers", {});
   });
 
+  it("refetches inventory when the credential generation changes behind an identical identity", async () => {
+    act(() => {
+      useConnection.setState({ authGeneration: 1 });
+    });
+    render(<RuntimeComputerMenu collapsed={false} />);
+    await waitFor(() => expect(screen.getByText("Main Computer")).not.toBeNull());
+
+    window.operator.invoke = vi.fn(async (channel: string) => {
+      if (channel === "runtime:list-computers") {
+        return {
+          ...computers,
+          items: [{
+            handle: "operator-replaced",
+            runtimeSlot: "primary",
+            label: "Main Computer",
+            availability: "available",
+            kind: "customer",
+            gatewayPath: "/vm/operator-replaced",
+            capabilities: [],
+          }],
+        };
+      }
+      return { ok: true };
+    });
+    act(() => {
+      useConnection.setState({ authGeneration: 2 });
+    });
+
+    await waitFor(() => expect(screen.getByText("operator-replaced")).not.toBeNull());
+    expect(window.operator.invoke).toHaveBeenCalledWith("runtime:list-computers", {});
+  });
+
+  it("marks the server-reported selected slot as current when the profile slot is stale", async () => {
+    window.operator.invoke = vi.fn(async (channel: string) => {
+      if (channel === "runtime:list-computers") return { ...computers, selectedSlot: "review" };
+      return { ok: true };
+    });
+    const selectRuntime = vi.fn(async () => undefined);
+    useConnection.setState({ selectRuntime });
+
+    render(<RuntimeComputerMenu collapsed={false} />);
+    await waitFor(() => expect(screen.getByRole("button", { name: "Change computer, currently Additional Computer" })).not.toBeNull());
+    fireEvent.click(screen.getByRole("button", { name: /Change computer/i }));
+
+    expect(screen.getByRole("option", { name: /Additional Computer.*Current/i }).hasAttribute("disabled")).toBe(true);
+    const staleProfileOption = screen.getByRole("option", { name: /Main Computer.*Available/i });
+    expect(staleProfileOption.hasAttribute("disabled")).toBe(false);
+    fireEvent.click(staleProfileOption);
+    await waitFor(() => expect(selectRuntime).toHaveBeenCalledWith("primary"));
+  });
+
+  it("caps long computer lists behind a scrollable region", async () => {
+    const manyComputers = {
+      ...computers,
+      items: Array.from({ length: 20 }, (_, index) => ({
+        handle: `operator-${index}`,
+        runtimeSlot: index === 0 ? "primary" : `slot-${index}`,
+        label: index === 0 ? "Main Computer" : "Additional Computer",
+        availability: "available",
+        kind: index === 0 ? "customer" : "preview",
+        gatewayPath: index === 0 ? "/vm/operator-0" : `/vm/operator-${index}?runtime=slot-${index}`,
+        capabilities: [],
+      })),
+    };
+    window.operator.invoke = vi.fn(async (channel: string) => (
+      channel === "runtime:list-computers" ? manyComputers : { ok: true }
+    ));
+
+    render(<RuntimeComputerMenu collapsed={false} />);
+    await waitFor(() => expect(screen.getByText("operator-0")).not.toBeNull());
+    fireEvent.click(screen.getByRole("button", { name: /Change computer/i }));
+
+    const listbox = screen.getByRole("listbox", { name: "Choose computer" });
+    const scrollRegion = listbox.querySelector(".overflow-y-auto");
+    expect(scrollRegion).not.toBeNull();
+    expect(scrollRegion?.className).toMatch(/max-h-/);
+    expect(screen.getAllByRole("option")).toHaveLength(20);
+  });
+
+  it("keeps the collapsed rail menu wide enough to read computer labels", async () => {
+    render(<RuntimeComputerMenu collapsed />);
+    await waitFor(() => expect(window.operator.invoke).toHaveBeenCalledWith("runtime:list-computers", {}));
+    fireEvent.click(screen.getByRole("button", { name: /Change computer/i }));
+
+    const listbox = screen.getByRole("listbox", { name: "Choose computer" });
+    expect(listbox.className).toMatch(/w-64/);
+    expect(listbox.className).not.toMatch(/right-2/);
+  });
+
   it("clears owner-scoped inventory when a signed-in session is replaced in place", async () => {
     useConnection.setState({ api: { get: vi.fn(), post: vi.fn(), delete: vi.fn() } as never });
     const view = render(<RuntimeComputerMenu collapsed={false} />);

--- a/tests/desktop/runtime-computer-menu.test.tsx
+++ b/tests/desktop/runtime-computer-menu.test.tsx
@@ -1,0 +1,146 @@
+// @vitest-environment jsdom
+
+import React from "react";
+import { act, cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import RuntimeComputerMenu from "../../desktop/src/renderer/src/features/runtime/RuntimeComputerMenu";
+import { useConnection } from "../../desktop/src/renderer/src/stores/connection";
+import { useRuntimeComputers } from "../../desktop/src/renderer/src/stores/runtime-computers";
+
+const computers = {
+  items: [
+    {
+      handle: "operator",
+      runtimeSlot: "primary",
+      label: "Main Computer",
+      availability: "available",
+      kind: "customer",
+      gatewayPath: "/vm/operator",
+      capabilities: [],
+    },
+    {
+      handle: "operator-review",
+      runtimeSlot: "review",
+      label: "Additional Computer",
+      availability: "available",
+      kind: "preview",
+      gatewayPath: "/vm/operator-review?runtime=review",
+      capabilities: [],
+    },
+    {
+      handle: "operator-preview",
+      runtimeSlot: "preview",
+      label: "Preview Computer",
+      availability: "starting",
+      kind: "preview",
+      gatewayPath: "/vm/operator-preview?runtime=preview",
+      capabilities: [],
+    },
+  ],
+  selectedSlot: "primary",
+  hasMore: false,
+  limit: 20,
+};
+
+describe("sidebar computer menu", () => {
+  beforeEach(() => {
+    useConnection.setState(useConnection.getInitialState(), true);
+    useRuntimeComputers.setState(useRuntimeComputers.getInitialState(), true);
+    useConnection.setState({
+      status: "signed-in",
+      handle: "operator",
+      platformHost: "https://app.matrix-os.com",
+      runtimeSlot: "primary",
+    });
+    window.operator = {
+      invoke: vi.fn(async (channel: string) => {
+        if (channel === "runtime:list-computers") return computers;
+        return { ok: true };
+      }),
+      on: vi.fn(() => () => undefined),
+    };
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it("shows the active computer and opens an upward list of owner computers", async () => {
+    render(<RuntimeComputerMenu collapsed={false} />);
+
+    await waitFor(() => expect(screen.getByRole("button", { name: "Change computer, currently Main Computer" })).not.toBeNull());
+    fireEvent.click(screen.getByRole("button", { name: "Change computer, currently Main Computer" }));
+
+    expect(screen.getByRole("listbox", { name: "Choose computer" })).not.toBeNull();
+    expect(screen.getByRole("option", { name: /Main Computer.*Current/i })).not.toBeNull();
+    expect(screen.getByRole("option", { name: /Additional Computer.*Available/i })).not.toBeNull();
+    expect(screen.getByRole("option", { name: /Preview Computer.*Starting/i }).hasAttribute("disabled")).toBe(true);
+  });
+
+  it("switches through trusted runtime selection and closes the menu", async () => {
+    const selectRuntime = vi.fn(async () => undefined);
+    useConnection.setState({ selectRuntime });
+    render(<RuntimeComputerMenu collapsed={false} />);
+    await waitFor(() => expect(screen.getByText("Main Computer")).not.toBeNull());
+    fireEvent.click(screen.getByRole("button", { name: /Change computer/i }));
+    fireEvent.click(screen.getByRole("option", { name: /Additional Computer.*Available/i }));
+
+    await waitFor(() => expect(selectRuntime).toHaveBeenCalledWith("review"));
+    expect(screen.queryByRole("listbox", { name: "Choose computer" })).toBeNull();
+  });
+
+  it("keeps failures safe and offers an inline retry", async () => {
+    window.operator.invoke = vi.fn(async () => {
+      throw new Error("/home/matrix/private token=raw-secret");
+    });
+    render(<RuntimeComputerMenu collapsed={false} />);
+    await waitFor(() => expect(screen.getByRole("button", { name: /Computer list unavailable/i })).not.toBeNull());
+    fireEvent.click(screen.getByRole("button", { name: /Computer list unavailable/i }));
+
+    expect(screen.getByText("Computers unavailable")).not.toBeNull();
+    expect(screen.getByRole("button", { name: "Retry computers" })).not.toBeNull();
+    expect(screen.queryByText(/raw-secret|\/home\/matrix/i)).toBeNull();
+  });
+
+  it("clears owner-scoped inventory across sign-out even when the visible identity is reused", async () => {
+    const firstInvoke = window.operator.invoke;
+    const view = render(<RuntimeComputerMenu collapsed={false} />);
+    await waitFor(() => expect(screen.getByText("Main Computer")).not.toBeNull());
+    view.unmount();
+
+    act(() => {
+      useConnection.setState({ status: "signed-out" });
+    });
+    window.operator.invoke = vi.fn(async (channel: string) => {
+      if (channel === "runtime:list-computers") {
+        return {
+          ...computers,
+          items: [{
+            handle: "operator-new",
+            runtimeSlot: "primary",
+            label: "Main Computer",
+            availability: "available",
+            kind: "customer",
+            gatewayPath: "/vm/operator-new",
+            capabilities: [],
+          }],
+        };
+      }
+      return { ok: true };
+    });
+    act(() => {
+      useConnection.setState({
+        status: "signed-in",
+        handle: "operator",
+        platformHost: "https://app.matrix-os.com",
+        runtimeSlot: "primary",
+      });
+    });
+
+    render(<RuntimeComputerMenu collapsed={false} />);
+    await waitFor(() => expect(screen.getByText("operator-new")).not.toBeNull());
+    expect(firstInvoke).toHaveBeenCalledWith("runtime:list-computers", {});
+    expect(window.operator.invoke).toHaveBeenCalledWith("runtime:list-computers", {});
+  });
+});

--- a/tests/desktop/runtime-section.test.tsx
+++ b/tests/desktop/runtime-section.test.tsx
@@ -5,19 +5,7 @@ import { act, cleanup, fireEvent, render, screen, waitFor } from "@testing-libra
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import RuntimeSection from "../../desktop/src/renderer/src/features/settings/sections/RuntimeSection";
 import { useConnection } from "../../desktop/src/renderer/src/stores/connection";
-
-function makeApi(response: unknown) {
-  return {
-    baseUrl: "https://app.matrix-os.com",
-    get: vi.fn(async () => response),
-    getText: vi.fn(),
-    post: vi.fn(),
-    patch: vi.fn(),
-    put: vi.fn(),
-    delete: vi.fn(),
-    putText: vi.fn(),
-  };
-}
+import { useRuntimeComputers } from "../../desktop/src/renderer/src/stores/runtime-computers";
 
 const computers = {
   items: [
@@ -57,12 +45,20 @@ const computers = {
 describe("desktop runtime settings", () => {
   beforeEach(() => {
     useConnection.setState(useConnection.getInitialState(), true);
+    useRuntimeComputers.setState(useRuntimeComputers.getInitialState(), true);
     useConnection.setState({
       status: "signed-in",
       handle: "operator",
       platformHost: "https://app.matrix-os.com",
       runtimeSlot: "primary",
     });
+    window.operator = {
+      invoke: vi.fn(async (channel: string) => {
+        if (channel === "runtime:list-computers") return computers;
+        return { ok: true };
+      }),
+      on: vi.fn(() => () => undefined),
+    };
   });
 
   afterEach(() => {
@@ -71,13 +67,10 @@ describe("desktop runtime settings", () => {
   });
 
   it("shows the owner's bounded computers instead of a free-text runtime field", async () => {
-    const api = makeApi(computers);
-    useConnection.setState({ api: api as never });
-
     render(<RuntimeSection />);
 
     await waitFor(() => expect(screen.getByText("Main Computer")).not.toBeNull());
-    expect(api.get).toHaveBeenCalledWith("/api/auth/computers");
+    expect(window.operator.invoke).toHaveBeenCalledWith("runtime:list-computers", {});
     expect(screen.getByText("operator-review")).not.toBeNull();
     expect(screen.getByText("Starting")).not.toBeNull();
     expect(screen.queryByRole("textbox")).toBeNull();
@@ -86,9 +79,8 @@ describe("desktop runtime settings", () => {
   });
 
   it("switches only to an available owner computer", async () => {
-    const api = makeApi(computers);
     const selectRuntime = vi.fn(async () => undefined);
-    useConnection.setState({ api: api as never, selectRuntime });
+    useConnection.setState({ selectRuntime });
 
     render(<RuntimeSection />);
     await waitFor(() => expect(screen.getByText("Additional Computer")).not.toBeNull());
@@ -98,20 +90,29 @@ describe("desktop runtime settings", () => {
   });
 
   it("contains malformed responses and switching failures behind safe messages", async () => {
-    const api = makeApi({ items: [{ runtimeSlot: "../secret", token: "raw-secret" }] });
+    window.operator.invoke = vi.fn(async (channel: string) => {
+      if (channel === "runtime:list-computers") {
+        return { items: [{ runtimeSlot: "../secret", token: "raw-secret" }] };
+      }
+      return { ok: true };
+    });
     const selectRuntime = vi.fn(async () => {
       throw new Error("/home/matrix/private token=raw-secret");
     });
-    useConnection.setState({ api: api as never, selectRuntime });
+    useConnection.setState({ selectRuntime });
 
-    const { rerender } = render(<RuntimeSection />);
+    render(<RuntimeSection />);
     await waitFor(() => expect(screen.getByText("Computers are unavailable right now.")).not.toBeNull());
     expect(screen.queryByText(/raw-secret|\/home\/matrix/i)).toBeNull();
 
     act(() => {
-      useConnection.setState({ api: makeApi(computers) as never });
+      window.operator.invoke = vi.fn(async (channel: string) => {
+        if (channel === "runtime:list-computers") return computers;
+        return { ok: true };
+      });
+      useRuntimeComputers.setState({ status: "idle" });
     });
-    rerender(<RuntimeSection />);
+    fireEvent.click(screen.getByRole("button", { name: "Refresh computers" }));
     await waitFor(() => expect(screen.getByText("Additional Computer")).not.toBeNull());
     fireEvent.click(screen.getByRole("button", { name: "Use Additional Computer" }));
     await waitFor(() => expect(screen.getByText("Couldn't switch computers. Try again.")).not.toBeNull());

--- a/tests/desktop/runtime-section.test.tsx
+++ b/tests/desktop/runtime-section.test.tsx
@@ -89,6 +89,24 @@ describe("desktop runtime settings", () => {
     await waitFor(() => expect(selectRuntime).toHaveBeenCalledWith("review"));
   });
 
+  it("drives the current badge from the server-reported selected slot when the profile is stale", async () => {
+    window.operator.invoke = vi.fn(async (channel: string) => {
+      if (channel === "runtime:list-computers") return { ...computers, selectedSlot: "review" };
+      return { ok: true };
+    });
+    const selectRuntime = vi.fn(async () => undefined);
+    useConnection.setState({ selectRuntime });
+
+    render(<RuntimeSection />);
+    await waitFor(() => expect(screen.getByText("Additional Computer")).not.toBeNull());
+
+    expect(screen.getByRole("button", { name: "Current computer" }).hasAttribute("disabled")).toBe(true);
+    const staleProfileButton = screen.getByRole("button", { name: "Use Main Computer" });
+    expect(staleProfileButton.hasAttribute("disabled")).toBe(false);
+    fireEvent.click(staleProfileButton);
+    await waitFor(() => expect(selectRuntime).toHaveBeenCalledWith("primary"));
+  });
+
   it("contains malformed responses and switching failures behind safe messages", async () => {
     window.operator.invoke = vi.fn(async (channel: string) => {
       if (channel === "runtime:list-computers") {

--- a/tests/desktop/runtime-transition.test.ts
+++ b/tests/desktop/runtime-transition.test.ts
@@ -195,6 +195,45 @@ describe("desktop runtime transition", () => {
     expect(useBoard.getState().cardsByProject["old-project"]).toBeUndefined();
   });
 
+  it("does not commit stale board mutation results after the computer changes", async () => {
+    const card = {
+      id: "task_old",
+      projectSlug: "old-project",
+      title: "Old task",
+      description: "",
+      status: "todo" as const,
+      priority: "normal" as const,
+      order: 0,
+      parentTaskId: null,
+      linkedSessionId: null,
+      linkedWorktreeId: null,
+      previewIds: [],
+      tags: [],
+      updatedAt: null,
+      revision: null,
+    };
+    useBoard.setState({ cardsByProject: { "old-project": [card] }, error: null });
+    let rejectDelete: ((err: unknown) => void) | undefined;
+    const api = {
+      delete: vi.fn(() => new Promise((_resolve, reject) => {
+        rejectDelete = reject;
+      })),
+      get: vi.fn(async () => ({ tasks: [], nextCursor: null })),
+      patch: vi.fn(async () => ({ task: card })),
+    } as never;
+
+    const pending = useBoard.getState().deleteTask(api, "old-project", "task_old");
+    reconcileDesktopRuntimeChange({ disposeRuntimeAttachments: vi.fn() });
+    // The per-task mutation queue starts the request on a microtask.
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    rejectDelete?.(new Error("old runtime rejected"));
+    await pending;
+
+    // The failure belongs to the previous computer; the new board must not
+    // inherit its error state.
+    expect(useBoard.getState().error).toBeNull();
+  });
+
   it("rejects a project response that settles after the computer changes", async () => {
     let resolveProjects!: (value: { projects: unknown[] }) => void;
     const api = {

--- a/tests/desktop/runtime-transition.test.ts
+++ b/tests/desktop/runtime-transition.test.ts
@@ -105,6 +105,49 @@ describe("desktop runtime transition", () => {
     expect(useShellSessions.getState().creating).toBe(false);
   });
 
+  it("discards an in-flight workspace session create that settles after the computer changes", async () => {
+    let resolveCreate!: (value: unknown) => void;
+    const api = {
+      post: vi.fn(() => new Promise((resolve) => {
+        resolveCreate = resolve;
+      })),
+      get: vi.fn(async () => ({ sessions: [], nextCursor: null })),
+      delete: vi.fn(async () => ({})),
+    } as never;
+    useSessions.setState({ sessions: [], aliasMap: {}, creating: false });
+
+    const pending = useSessions.getState().create(api, { kind: "shell" });
+    reconcileDesktopRuntimeChange({ disposeRuntimeAttachments: vi.fn() });
+    resolveCreate({ session: { id: "session_stale", runtime: { zellijSession: "stale-zellij" } } });
+    const created = await pending;
+
+    expect(created).toBeNull();
+    expect(useSessions.getState().sessions).toEqual([]);
+    expect(useSessions.getState().aliasMap).toEqual({});
+  });
+
+  it("discards an in-flight session restart that settles after the computer changes", async () => {
+    let resolveRestart: ((value: unknown) => void) | undefined;
+    const api = {
+      post: vi.fn(() => new Promise((resolve) => {
+        resolveRestart = resolve;
+      })),
+      get: vi.fn(async () => ({ sessions: [], nextCursor: null })),
+      delete: vi.fn(async () => ({})),
+    } as never;
+
+    const pending = useSessions.getState().restart(api, "old");
+    reconcileDesktopRuntimeChange({ disposeRuntimeAttachments: vi.fn() });
+    // Let the restart flow advance past the delete; with the generation guard
+    // it bails before ever issuing the create POST.
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    resolveRestart?.({ name: "old" });
+    const restarted = await pending;
+
+    expect(restarted).toBeNull();
+    expect(useSessions.getState().sessions).toEqual([]);
+  });
+
   it("rejects a project response that settles after the computer changes", async () => {
     let resolveProjects!: (value: { projects: unknown[] }) => void;
     const api = {

--- a/tests/desktop/runtime-transition.test.ts
+++ b/tests/desktop/runtime-transition.test.ts
@@ -148,6 +148,53 @@ describe("desktop runtime transition", () => {
     expect(useSessions.getState().sessions).toEqual([]);
   });
 
+  it("discards an in-flight board project create that settles after the computer changes", async () => {
+    let resolveCreate!: (value: unknown) => void;
+    const api = {
+      post: vi.fn(() => new Promise((resolve) => {
+        resolveCreate = resolve;
+      })),
+      get: vi.fn(async () => ({ projects: [{ slug: "stale", name: "Stale" }] })),
+    } as never;
+    useBoard.setState({ projects: [], activeProjectSlug: null, error: null });
+
+    const pending = useBoard.getState().createProject(api, { mode: "scratch", name: "Stale" });
+    reconcileDesktopRuntimeChange({ disposeRuntimeAttachments: vi.fn() });
+    resolveCreate({ project: { slug: "stale", name: "Stale" } });
+    const created = await pending;
+
+    expect(created).toBeNull();
+    expect(useBoard.getState().projects).toEqual([]);
+  });
+
+  it("discards an in-flight task create that settles after the computer changes", async () => {
+    let resolveCreate!: (value: unknown) => void;
+    const api = {
+      post: vi.fn(() => new Promise((resolve) => {
+        resolveCreate = resolve;
+      })),
+      get: vi.fn(async () => ({ tasks: [], nextCursor: null })),
+    } as never;
+    useBoard.setState({ cardsByProject: {}, error: null });
+
+    const pending = useBoard.getState().createTask(api, "old-project", { title: "Stale task" });
+    reconcileDesktopRuntimeChange({ disposeRuntimeAttachments: vi.fn() });
+    resolveCreate({
+      task: {
+        id: "task_stale",
+        projectSlug: "old-project",
+        title: "Stale task",
+        status: "todo",
+        priority: "normal",
+        order: 0,
+      },
+    });
+    const created = await pending;
+
+    expect(created).toBeNull();
+    expect(useBoard.getState().cardsByProject["old-project"]).toBeUndefined();
+  });
+
   it("rejects a project response that settles after the computer changes", async () => {
     let resolveProjects!: (value: { projects: unknown[] }) => void;
     const api = {

--- a/tests/desktop/runtime-transition.test.ts
+++ b/tests/desktop/runtime-transition.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { reconcileDesktopRuntimeChange } from "../../desktop/src/renderer/src/stores/runtime-transition";
 import { useBoard } from "../../desktop/src/renderer/src/stores/board";
+import { useHermesChat } from "../../desktop/src/renderer/src/stores/hermes-chat";
 import { useCodingAgentProjectWorkspace } from "../../desktop/src/renderer/src/stores/coding-agent-project-workspace";
 import { useCodingAgentWorkspace } from "../../desktop/src/renderer/src/stores/coding-agent-workspace";
 import { useEditorTabs } from "../../desktop/src/renderer/src/features/editor/editor-tabs-store";
@@ -42,7 +43,7 @@ describe("desktop runtime transition", () => {
 
     expect(disposeRuntimeAttachments).toHaveBeenCalledOnce();
     expect(useBoard.getState()).toMatchObject({ projects: [], activeProjectSlug: null, cardsByProject: {} });
-    expect(useTabs.getState()).toMatchObject({ tabs: [], activeTabId: null });
+    expect(useTabs.getState().tabs.some((tab) => tab.id === "old-task")).toBe(false);
     expect(useSessions.getState()).toMatchObject({ sessions: [], aliasMap: {} });
     expect(useShellSessions.getState().sessions).toEqual([]);
     expect(useGit.getState()).toMatchObject({ branches: [], previews: [], previewScope: null });
@@ -55,6 +56,53 @@ describe("desktop runtime transition", () => {
       selectedTaskId: null,
       selectedThreadId: null,
     });
+  });
+
+  it("reopens the Home tab so the desktop is never left blank after a switch", () => {
+    reconcileDesktopRuntimeChange({ disposeRuntimeAttachments: vi.fn() });
+
+    const { tabs, activeTabId } = useTabs.getState();
+    expect(tabs).toHaveLength(1);
+    expect(tabs[0]).toMatchObject({ kind: "home", closable: false });
+    expect(activeTabId).toBe(tabs[0]?.id);
+  });
+
+  it("clears the Hermes chat transcript and session owned by the previous computer", () => {
+    useHermesChat.setState({
+      messages: [{ id: "m1", role: "user", content: "old transcript", requestId: "r1", timestamp: 1 }],
+      sessionId: "session-old",
+      status: "streaming",
+      activeRequestId: "r1",
+    });
+
+    reconcileDesktopRuntimeChange({ disposeRuntimeAttachments: vi.fn() });
+
+    expect(useHermesChat.getState()).toMatchObject({
+      messages: [],
+      sessionId: null,
+      status: "idle",
+      activeRequestId: null,
+    });
+  });
+
+  it("discards an in-flight shell create that settles after the computer changes", async () => {
+    let resolveCreate!: (value: { name: string }) => void;
+    const api = {
+      post: vi.fn(() => new Promise<{ name: string }>((resolve) => {
+        resolveCreate = resolve;
+      })),
+      get: vi.fn(async () => ({ sessions: [] })),
+    } as never;
+    useShellSessions.setState({ sessions: [], creating: false, error: null });
+
+    const pending = useShellSessions.getState().create(api);
+    reconcileDesktopRuntimeChange({ disposeRuntimeAttachments: vi.fn() });
+    resolveCreate({ name: "matrix-old-1" });
+    const created = await pending;
+
+    expect(created).toBeNull();
+    expect(useShellSessions.getState().sessions).toEqual([]);
+    expect(useShellSessions.getState().creating).toBe(false);
   });
 
   it("rejects a project response that settles after the computer changes", async () => {

--- a/tests/desktop/runtime-transition.test.ts
+++ b/tests/desktop/runtime-transition.test.ts
@@ -1,0 +1,102 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { reconcileDesktopRuntimeChange } from "../../desktop/src/renderer/src/stores/runtime-transition";
+import { useBoard } from "../../desktop/src/renderer/src/stores/board";
+import { useCodingAgentProjectWorkspace } from "../../desktop/src/renderer/src/stores/coding-agent-project-workspace";
+import { useCodingAgentWorkspace } from "../../desktop/src/renderer/src/stores/coding-agent-workspace";
+import { useEditorTabs } from "../../desktop/src/renderer/src/features/editor/editor-tabs-store";
+import { useGit } from "../../desktop/src/renderer/src/stores/git";
+import { useSessions } from "../../desktop/src/renderer/src/stores/sessions";
+import { useShellSessions } from "../../desktop/src/renderer/src/stores/shell-sessions";
+import { useTabs } from "../../desktop/src/renderer/src/stores/tabs";
+import { useThreads } from "../../desktop/src/renderer/src/stores/threads";
+import { useWorkspace } from "../../desktop/src/renderer/src/stores/workspace";
+
+describe("desktop runtime transition", () => {
+  beforeEach(() => {
+    useBoard.setState({
+      projects: [{ slug: "old-project", name: "Old project" }],
+      activeProjectSlug: "old-project",
+      cardsByProject: { "old-project": [] },
+      firstLoadByProject: { "old-project": false },
+      refreshing: false,
+      error: null,
+    });
+    useTabs.setState({
+      tabs: [{ id: "old-task", kind: "task", title: "Old task", projectSlug: "old-project", taskId: "task_old", closable: true }],
+      activeTabId: "old-task",
+    });
+    useSessions.setState({ sessions: [{ name: "old", attachName: "old", status: "active", source: "zellij" }], aliasMap: { session_old: "old" } });
+    useShellSessions.setState({ sessions: [{ name: "old" }] });
+    useGit.setState({ branches: [{ name: "old" }], prs: [], worktrees: [], previews: [{ id: "preview_old" }], previewScope: { projectSlug: "old-project", taskId: "task_old" } });
+    useWorkspace.setState({ entries: [{ taskId: "task_old", lastFocusedAt: 1, live: true }] });
+    useEditorTabs.setState({ tabsByTask: { task_old: ["README.md"] }, activePathByTask: { task_old: "README.md" }, dirtyPathsByTask: {} });
+    useThreads.setState({ threads: [], activeThreadId: "thread_old" });
+    useCodingAgentWorkspace.setState({ activeThreadId: "thread_old", selectedReviewId: "review_old" });
+    useCodingAgentProjectWorkspace.setState({ selectedProjectId: "proj_old", selectedTaskId: "task_old", selectedThreadId: "thread_old" });
+  });
+
+  it("atomically removes identifiers and attachments owned by the previous computer", () => {
+    const disposeRuntimeAttachments = vi.fn();
+
+    reconcileDesktopRuntimeChange({ disposeRuntimeAttachments });
+
+    expect(disposeRuntimeAttachments).toHaveBeenCalledOnce();
+    expect(useBoard.getState()).toMatchObject({ projects: [], activeProjectSlug: null, cardsByProject: {} });
+    expect(useTabs.getState()).toMatchObject({ tabs: [], activeTabId: null });
+    expect(useSessions.getState()).toMatchObject({ sessions: [], aliasMap: {} });
+    expect(useShellSessions.getState().sessions).toEqual([]);
+    expect(useGit.getState()).toMatchObject({ branches: [], previews: [], previewScope: null });
+    expect(useWorkspace.getState().entries).toEqual([]);
+    expect(useEditorTabs.getState().tabsByTask).toEqual({});
+    expect(useThreads.getState()).toMatchObject({ threads: [], activeThreadId: null });
+    expect(useCodingAgentWorkspace.getState()).toMatchObject({ activeThreadId: null, selectedReviewId: null });
+    expect(useCodingAgentProjectWorkspace.getState()).toMatchObject({
+      selectedProjectId: null,
+      selectedTaskId: null,
+      selectedThreadId: null,
+    });
+  });
+
+  it("rejects a project response that settles after the computer changes", async () => {
+    let resolveProjects!: (value: { projects: unknown[] }) => void;
+    const api = {
+      get: vi.fn(() => new Promise<{ projects: unknown[] }>((resolve) => {
+        resolveProjects = resolve;
+      })),
+    } as never;
+
+    const pending = useBoard.getState().loadProjects(api);
+    reconcileDesktopRuntimeChange({ disposeRuntimeAttachments: vi.fn() });
+    resolveProjects({ projects: [{ slug: "old-project", name: "Old project" }] });
+    await pending;
+
+    expect(useBoard.getState()).toMatchObject({ projects: [], activeProjectSlug: null, error: null });
+  });
+
+  it("rejects stale session, terminal, Git, review, and preview loads", async () => {
+    const resolvers = new Map<string, Array<(value: unknown) => void>>();
+    const api = {
+      get: vi.fn((path: string) => new Promise((resolve) => {
+        resolvers.set(path, [...(resolvers.get(path) ?? []), resolve]);
+      })),
+    } as never;
+
+    const sessionLoad = useSessions.getState().load(api);
+    const shellLoad = useShellSessions.getState().load(api);
+    const gitLoad = useGit.getState().loadAll(api, "old-project");
+    const previewLoad = useGit.getState().loadPreviews(api, "old-project", "task_old");
+    reconcileDesktopRuntimeChange({ disposeRuntimeAttachments: vi.fn() });
+
+    for (const resolve of resolvers.get("/api/terminal/sessions") ?? []) resolve({ sessions: [{ name: "old" }] });
+    for (const resolve of resolvers.get("/api/sessions") ?? []) resolve({ sessions: [], nextCursor: null });
+    for (const resolve of resolvers.get("/api/projects/old-project/branches") ?? []) resolve({ branches: [{ name: "old" }] });
+    for (const resolve of resolvers.get("/api/projects/old-project/prs") ?? []) resolve({ prs: [{ number: 1 }] });
+    for (const resolve of resolvers.get("/api/projects/old-project/worktrees") ?? []) resolve({ worktrees: [{ id: "old" }] });
+    for (const resolve of resolvers.get("/api/projects/old-project/previews?limit=100&taskId=task_old") ?? []) resolve({ previews: [{ id: "old" }] });
+    await Promise.all([sessionLoad, shellLoad, gitLoad, previewLoad]);
+
+    expect(useSessions.getState().sessions).toEqual([]);
+    expect(useShellSessions.getState().sessions).toEqual([]);
+    expect(useGit.getState()).toMatchObject({ branches: [], prs: [], worktrees: [], previews: [], previewScope: null });
+  });
+});

--- a/tests/desktop/tab-content.test.tsx
+++ b/tests/desktop/tab-content.test.tsx
@@ -3,7 +3,7 @@
 import React from "react";
 import { cleanup, render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import TabContent from "@desktop/renderer/src/features/mission-control/TabContent";
+import TabContent, { TabErrorBoundary } from "@desktop/renderer/src/features/mission-control/TabContent";
 import { useConnection } from "@desktop/renderer/src/stores/connection";
 import { useTabs } from "@desktop/renderer/src/stores/tabs";
 
@@ -85,5 +85,21 @@ describe("TabContent", () => {
     render(<TabContent />);
 
     expect(screen.getByRole("heading", { name: /^(Apps|Loading apps)$/ })).toBeTruthy();
+  });
+
+  it("contains a task panel exception without blanking the desktop renderer", () => {
+    function BrokenPanel(): React.ReactNode {
+      throw new Error("private terminal failure");
+    }
+
+    render(
+      <TabErrorBoundary tabTitle="Task A" onClose={vi.fn()}>
+        <BrokenPanel />
+      </TabErrorBoundary>,
+    );
+
+    expect(screen.getByRole("heading", { name: "Task A couldn't open" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Close tab" })).toBeTruthy();
+    expect(screen.queryByText(/private terminal failure/i)).toBeNull();
   });
 });

--- a/tests/desktop/workspace-store.test.ts
+++ b/tests/desktop/workspace-store.test.ts
@@ -286,6 +286,23 @@ describe("persistence", () => {
     expect(persistence.loadLayouts).toHaveBeenCalledTimes(1);
   });
 
+  it("normalizes legacy task layouts before exposing them to workspace panels", async () => {
+    const legacy = {
+      order: ["terminal", "editor"],
+      visible: { terminal: true, editor: true },
+      sizes: { terminal: 50, editor: 50 },
+      touchedAt: 10,
+    } as unknown as PanelLayout;
+    useWorkspace.getState().configure(makePersistence({ task_legacy: legacy }));
+
+    await useWorkspace.getState().hydrate();
+
+    const hydrated = useWorkspace.getState().layouts.task_legacy!;
+    expect(hydrated.order).toEqual(PANEL_KINDS);
+    expect(hydrated.visible.timeline).toBe(false);
+    expect(hydrated.sizes.timeline).toBe(0);
+  });
+
   it("hydrate tolerates a load failure and still marks the store hydrated", async () => {
     const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
     try {

--- a/tests/e2e/desktop/operator.e2e.test.ts
+++ b/tests/e2e/desktop/operator.e2e.test.ts
@@ -178,10 +178,36 @@ suite("operator desktop e2e", () => {
     await expect.poll(attachedNativeViewCount).toBe(0);
     await page.getByRole("button", { name: "Computers" }).click();
     await page.getByText("Additional Computer").waitFor({ timeout: 10_000 });
+    await page.screenshot({ path: join(SCREENSHOT_DIR, "09-settings-no-shell-overlay.png") });
     await page.getByRole("button", { name: "Use Additional Computer" }).click();
     await expect.poll(() => gateway.state.runtimeSelections).toEqual(["review"]);
+    // A successful switch tears down the previous computer's desktop (all tabs
+    // close), so the persistent sidebar computer menu is the post-switch
+    // assertion surface: it must report the server-selected computer.
+    await page.getByRole("button", { name: "Change computer, currently Additional Computer" }).waitFor({ timeout: 10_000 });
+    await page.screenshot({ path: join(SCREENSHOT_DIR, "09b-computer-switched.png") });
+
+    // Reopening Settings must mark the server-reported slot as current and
+    // leave the other computer selectable.
+    await page.locator("aside button", { hasText: "Settings" }).first().click();
+    await page.getByRole("heading", { name: "Settings" }).waitFor({ timeout: 10_000 });
+    await page.getByRole("button", { name: "Computers" }).click();
     await page.getByRole("button", { name: "Current computer" }).waitFor({ timeout: 10_000 });
-    await page.screenshot({ path: join(SCREENSHOT_DIR, "09-settings-no-shell-overlay.png") });
+    await page.getByRole("button", { name: "Use Main Computer" }).waitFor({ timeout: 10_000 });
+    await page.screenshot({ path: join(SCREENSHOT_DIR, "09c-settings-current-computer.png") });
+
+    // Sidebar computer menu evidence: expanded rail, then the collapsed rail
+    // popup that must keep a readable fixed width.
+    await page.getByRole("button", { name: /Change computer, currently/ }).click();
+    await page.getByRole("listbox", { name: "Choose computer" }).waitFor({ timeout: 10_000 });
+    await page.screenshot({ path: join(SCREENSHOT_DIR, "09d-computer-menu.png") });
+    await page.keyboard.press("Escape");
+    await page.getByRole("button", { name: "Collapse sidebar (⌘B)" }).click();
+    await page.getByRole("button", { name: /Change computer, currently/ }).click();
+    await page.getByRole("listbox", { name: "Choose computer" }).waitFor({ timeout: 10_000 });
+    await page.screenshot({ path: join(SCREENSHOT_DIR, "09e-computer-menu-collapsed.png") });
+    await page.keyboard.press("Escape");
+    await page.getByRole("button", { name: "Expand sidebar (⌘B)" }).click();
 
     await page.locator("aside button", { hasText: "Chat" }).first().click();
     await page.getByRole("heading", { name: /What should we build/i }).waitFor({ timeout: 10_000 });

--- a/tests/gateway/agent-sandbox.test.ts
+++ b/tests/gateway/agent-sandbox.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
-import { lstat, mkdir, mkdtemp, stat, symlink, utimes, writeFile } from "node:fs/promises";
+import { lstat, mkdir, mkdtemp, realpath, stat, symlink, utimes, writeFile } from "node:fs/promises";
 import { rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -33,7 +33,7 @@ describe("agent-sandbox", () => {
       sandbox: {
         enabled: true,
         writableRoots: [
-          worktreePath,
+          await realpath(worktreePath),
           join(homePath, "system", "agent-scratch", "sess_abc123"),
         ],
       },
@@ -65,7 +65,7 @@ describe("agent-sandbox", () => {
         enabled: true,
         mode: "workspace-write",
         writableRoots: [
-          worktreePath,
+          await realpath(worktreePath),
           join(homePath, "system", "agent-scratch", "sess_abc123"),
         ],
       },
@@ -77,7 +77,7 @@ describe("agent-sandbox", () => {
       },
     });
     expect(verifyClaudeSandbox).toHaveBeenCalledWith(expect.objectContaining({
-      cwd: worktreePath,
+      cwd: await realpath(worktreePath),
       runtimeHome: homePath,
       approvalPolicy: "on-request",
       sandbox: expect.objectContaining({ mode: "workspace-write" }),
@@ -243,7 +243,7 @@ describe("agent-sandbox", () => {
       worktreePath,
     })).resolves.toMatchObject({
       ok: true,
-      sandbox: { writableRoots: [worktreePath, scratchPath] },
+      sandbox: { writableRoots: [await realpath(worktreePath), scratchPath] },
     });
     await expect(stat(scratchPath)).resolves.toMatchObject({ isDirectory: expect.any(Function) });
 
@@ -319,10 +319,41 @@ describe("agent-sandbox", () => {
       sandbox: expect.objectContaining({
         mode: "read-only",
         writableRoots: [],
-        denyWriteRoots: [worktreePath, gitCommonDir],
+        denyWriteRoots: [await realpath(worktreePath), await realpath(gitCommonDir)],
       }),
     }));
-    expect(resolveGitCommonDir).toHaveBeenCalledWith(worktreePath);
+    expect(resolveGitCommonDir).toHaveBeenCalledWith(await realpath(worktreePath));
+  });
+
+  it("lets Claude review non-Git folder projects start with a workspace-only deny root", async () => {
+    const verifyClaudeSandbox = vi.fn(async () => undefined);
+    // A null resolution means the workspace is not inside a Git repository:
+    // there is no Git metadata to protect, so review stays read-only over the
+    // workspace root alone instead of failing sandbox_unavailable.
+    const resolveGitCommonDir = vi.fn(async () => null);
+    const sandbox = createAgentSandbox({
+      homePath,
+      getUid: () => 1000,
+      verifyClaudeSandbox,
+      resolveGitCommonDir,
+    });
+
+    await expect(sandbox.preflight({
+      agent: "claude",
+      sessionId: "sess_review_plain",
+      worktreePath,
+      mode: "review",
+      approvalPolicy: "on-request",
+      sandboxMode: "full_access",
+    })).resolves.toMatchObject({ ok: true });
+    expect(verifyClaudeSandbox).toHaveBeenCalledWith(expect.objectContaining({
+      mode: "review",
+      sandbox: expect.objectContaining({
+        mode: "read-only",
+        // The sandbox canonicalizes paths (macOS tmpdir is a /var symlink).
+        denyWriteRoots: [await realpath(worktreePath)],
+      }),
+    }));
   });
 
   it("fails closed when running as root unless an explicit admin override is configured", async () => {

--- a/tests/gateway/project-manager.test.ts
+++ b/tests/gateway/project-manager.test.ts
@@ -173,6 +173,34 @@ describe("project-manager", () => {
     })).resolves.toMatchObject({ ok: false, status: 400, error: { code: "invalid_project_path" } });
   });
 
+  it("rejects the home root and protected OS subtrees as folder projects", async () => {
+    await mkdir(join(homePath, "system", "wallpapers"), { recursive: true });
+    await mkdir(join(homePath, "agents", "custom"), { recursive: true });
+    await mkdir(join(homePath, ".trash"), { recursive: true });
+    const manager = createProjectManager({ homePath, runCommand: vi.fn() });
+
+    for (const path of [".", "system", "system/wallpapers", "agents", "agents/custom", ".trash"]) {
+      await expect(manager.createProject({
+        mode: "folder",
+        name: "Protected",
+        slug: `protected-${path.replace(/[^a-z0-9]+/g, "-")}`,
+        path,
+      })).resolves.toMatchObject({ ok: false, status: 400, error: { code: "invalid_project_path" } });
+    }
+  });
+
+  it("requires existing folder project paths to be directories", async () => {
+    await writeFile(join(homePath, "notes.txt"), "owner notes");
+    const manager = createProjectManager({ homePath, runCommand: vi.fn() });
+
+    await expect(manager.createProject({
+      mode: "folder",
+      name: "Notes",
+      slug: "notes",
+      path: "notes.txt",
+    })).resolves.toMatchObject({ ok: false, status: 400, error: { code: "invalid_project_path" } });
+  });
+
   it("rejects slug conflicts before cloning", async () => {
     await mkdir(join(homePath, "projects", "repo"), { recursive: true });
     const runCommand = vi.fn();

--- a/tests/gateway/project-manager.test.ts
+++ b/tests/gateway/project-manager.test.ts
@@ -118,7 +118,14 @@ describe("project-manager", () => {
   });
 
   it("treats Git and GitHub as optional capabilities for folder projects", async () => {
-    const runCommand = vi.fn();
+    const runCommand = vi.fn(async (command: string, args: string[]) => {
+      if (command === "git" && args[0] === "rev-parse") {
+        const err = new Error("fatal: not a git repository") as Error & { stderr: string };
+        err.stderr = "fatal: not a git repository (or any of the parent directories): .git";
+        throw err;
+      }
+      return { stdout: "", stderr: "" };
+    });
     const manager = createProjectManager({ homePath, runCommand, now: () => "2026-04-26T00:00:00.000Z" });
     const created = await manager.createProject({
       mode: "scratch",
@@ -138,7 +145,53 @@ describe("project-manager", () => {
       branches: [],
       refreshedAt: "2026-04-26T00:00:00.000Z",
     });
-    expect(runCommand).not.toHaveBeenCalled();
+    expect(runCommand).not.toHaveBeenCalledWith("git", expect.arrayContaining(["branch"]), expect.any(Object));
+  });
+
+  it("lists branches for a folder project nested inside a repository", async () => {
+    const repoRoot = join(homePath, "workspaces", "monorepo");
+    await mkdir(join(repoRoot, "packages", "app"), { recursive: true });
+    const runCommand = vi.fn(async (command: string, args: string[]) => {
+      if (command === "git" && args[0] === "rev-parse") return { stdout: `${repoRoot}\n`, stderr: "" };
+      if (command === "git" && args[0] === "branch") return { stdout: "main\nfeature\n", stderr: "" };
+      return { stdout: "", stderr: "" };
+    });
+    const manager = createProjectManager({ homePath, runCommand, now: () => "2026-04-26T00:00:00.000Z" });
+    await manager.createProject({
+      mode: "folder",
+      name: "Monorepo app",
+      slug: "monorepo-app",
+      path: "workspaces/monorepo/packages/app",
+    });
+
+    await expect(manager.listBranches("monorepo-app")).resolves.toMatchObject({
+      ok: true,
+      branches: [{ name: "main" }, { name: "feature" }],
+    });
+  });
+
+  it("does not show home-versioning branches for plain folders", async () => {
+    await mkdir(join(homePath, "workspaces", "notes"), { recursive: true });
+    // The Matrix home itself is a versioned Git repo: a folder that resolves
+    // to it as its repository toplevel has no project branches to show.
+    const runCommand = vi.fn(async (command: string, args: string[]) => {
+      if (command === "git" && args[0] === "rev-parse") return { stdout: `${homePath}\n`, stderr: "" };
+      return { stdout: "main\n", stderr: "" };
+    });
+    const manager = createProjectManager({ homePath, runCommand, now: () => "2026-04-26T00:00:00.000Z" });
+    await manager.createProject({
+      mode: "folder",
+      name: "Notes",
+      slug: "notes-folder",
+      path: "workspaces/notes",
+    });
+
+    await expect(manager.listBranches("notes-folder")).resolves.toEqual({
+      ok: true,
+      branches: [],
+      refreshedAt: "2026-04-26T00:00:00.000Z",
+    });
+    expect(runCommand).not.toHaveBeenCalledWith("git", expect.arrayContaining(["branch"]), expect.any(Object));
   });
 
   it("connects a project to an existing owner folder without moving or deleting it", async () => {
@@ -323,6 +376,9 @@ describe("project-manager", () => {
     const runCommand = vi.fn(async (command: string, args: string[]) => {
       if (command === "gh" && args[0] === "pr") {
         return { stdout: JSON.stringify([{ number: 7, title: "Fix", author: { login: "octo" }, headRefName: "fix", baseRefName: "main", state: "OPEN" }]), stderr: "" };
+      }
+      if (command === "git" && args[0] === "rev-parse") {
+        return { stdout: `${join(homePath, "projects", "repo", "repo")}\n`, stderr: "" };
       }
       if (command === "git" && args[0] === "branch") {
         return { stdout: "main\nfeature\n", stderr: "" };

--- a/tests/gateway/project-manager.test.ts
+++ b/tests/gateway/project-manager.test.ts
@@ -232,13 +232,33 @@ describe("project-manager", () => {
 
     // A repo checkout nested inside a managed project stays connectable: it
     // contains no registry metadata.
-    await mkdir(join(homePath, "projects", "other", "repo"), { recursive: true });
+    await mkdir(join(homePath, "projects", "other", "repo", "src"), { recursive: true });
     await expect(manager.createProject({
       mode: "folder",
       name: "Other repo",
       slug: "other-repo",
       path: "projects/other/repo",
     })).resolves.toMatchObject({ ok: true, status: 201 });
+    await expect(manager.createProject({
+      mode: "folder",
+      name: "Other repo src",
+      slug: "other-repo-src",
+      path: "projects/other/repo/src",
+    })).resolves.toMatchObject({ ok: true, status: 201 });
+  });
+
+  it("rejects managed worktree and metadata areas as folder project roots", async () => {
+    await mkdir(join(homePath, "projects", "other", "worktrees", "wt-1"), { recursive: true });
+    const manager = createProjectManager({ homePath, runCommand: vi.fn() });
+
+    for (const path of ["projects/other/worktrees", "projects/other/worktrees/wt-1"]) {
+      await expect(manager.createProject({
+        mode: "folder",
+        name: "Worktree",
+        slug: `worktree-${path.split("/").length}`,
+        path,
+      })).resolves.toMatchObject({ ok: false, status: 400, error: { code: "invalid_project_path" } });
+    }
   });
 
   it("requires existing folder project paths to be directories", async () => {

--- a/tests/gateway/project-manager.test.ts
+++ b/tests/gateway/project-manager.test.ts
@@ -214,6 +214,29 @@ describe("project-manager", () => {
     })).resolves.toMatchObject({ ok: false, status: 400, error: { code: "invalid_project_path" } });
   });
 
+  it("rejects other managed project roots as folder projects", async () => {
+    await mkdir(join(homePath, "projects", "other"), { recursive: true });
+    await writeFile(join(homePath, "projects", "other", "config.json"), "{}");
+    const manager = createProjectManager({ homePath, runCommand: vi.fn() });
+
+    await expect(manager.createProject({
+      mode: "folder",
+      name: "Other copy",
+      slug: "other-copy",
+      path: "projects/other",
+    })).resolves.toMatchObject({ ok: false, status: 400, error: { code: "invalid_project_path" } });
+
+    // A repo checkout nested inside a managed project stays connectable: it
+    // contains no registry metadata.
+    await mkdir(join(homePath, "projects", "other", "repo"), { recursive: true });
+    await expect(manager.createProject({
+      mode: "folder",
+      name: "Other repo",
+      slug: "other-repo",
+      path: "projects/other/repo",
+    })).resolves.toMatchObject({ ok: true, status: 201 });
+  });
+
   it("requires existing folder project paths to be directories", async () => {
     await writeFile(join(homePath, "notes.txt"), "owner notes");
     const manager = createProjectManager({ homePath, runCommand: vi.fn() });

--- a/tests/gateway/project-manager.test.ts
+++ b/tests/gateway/project-manager.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
-import { mkdir, mkdtemp, readdir, readFile, stat } from "node:fs/promises";
+import { mkdir, mkdtemp, readdir, readFile, stat, writeFile } from "node:fs/promises";
 import { rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -115,6 +115,62 @@ describe("project-manager", () => {
       project: { slug: "mobile-workspace", createRequestId: "req_mobile_workspace_1" },
     });
     expect(changedPayload).toMatchObject({ ok: false, status: 409 });
+  });
+
+  it("treats Git and GitHub as optional capabilities for folder projects", async () => {
+    const runCommand = vi.fn();
+    const manager = createProjectManager({ homePath, runCommand, now: () => "2026-04-26T00:00:00.000Z" });
+    const created = await manager.createProject({
+      mode: "scratch",
+      name: "Plain folder",
+      slug: "plain-folder",
+      ownerScope: { type: "user", id: "user_123" },
+    });
+    expect(created.ok).toBe(true);
+
+    await expect(manager.listPullRequests("plain-folder")).resolves.toEqual({
+      ok: true,
+      prs: [],
+      refreshedAt: "2026-04-26T00:00:00.000Z",
+    });
+    await expect(manager.listBranches("plain-folder")).resolves.toEqual({
+      ok: true,
+      branches: [],
+      refreshedAt: "2026-04-26T00:00:00.000Z",
+    });
+    expect(runCommand).not.toHaveBeenCalled();
+  });
+
+  it("connects a project to an existing owner folder without moving or deleting it", async () => {
+    const existing = join(homePath, "workspaces", "customer-app");
+    await mkdir(existing, { recursive: true });
+    await writeFile(join(existing, "README.md"), "owner data");
+    const manager = createProjectManager({ homePath, runCommand: vi.fn(), now: () => "2026-04-26T00:00:00.000Z" });
+
+    const created = await manager.createProject({
+      mode: "folder",
+      name: "Customer app",
+      slug: "customer-app",
+      path: "workspaces/customer-app",
+      ownerScope: { type: "user", id: "user_123" },
+    });
+
+    expect(created).toMatchObject({
+      ok: true,
+      project: { localPath: existing },
+    });
+    if (created.ok) expect(created.project.github).toBeUndefined();
+    await expect(manager.deleteProject("customer-app")).resolves.toEqual({ ok: true });
+    await expect(readFile(join(existing, "README.md"), "utf-8")).resolves.toBe("owner data");
+  });
+
+  it("rejects project folders outside the Matrix home", async () => {
+    const manager = createProjectManager({ homePath, runCommand: vi.fn() });
+    await expect(manager.createProject({
+      mode: "folder",
+      name: "Outside",
+      path: "../../outside",
+    })).resolves.toMatchObject({ ok: false, status: 400, error: { code: "invalid_project_path" } });
   });
 
   it("rejects slug conflicts before cloning", async () => {

--- a/tests/gateway/project-manager.test.ts
+++ b/tests/gateway/project-manager.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
-import { mkdir, mkdtemp, readdir, readFile, stat, symlink, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readdir, readFile, realpath, stat, symlink, writeFile } from "node:fs/promises";
 import { rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -155,9 +155,11 @@ describe("project-manager", () => {
       ownerScope: { type: "user", id: "user_123" },
     });
 
+    // The stored localPath is the fully resolved path so later symlink
+    // repoints cannot bypass the create-time validation.
     expect(created).toMatchObject({
       ok: true,
-      project: { localPath: existing },
+      project: { localPath: await realpath(existing) },
     });
     if (created.ok) expect(created.project.github).toBeUndefined();
     await expect(manager.deleteProject("customer-app")).resolves.toEqual({ ok: true });
@@ -177,9 +179,11 @@ describe("project-manager", () => {
     await mkdir(join(homePath, "system", "wallpapers"), { recursive: true });
     await mkdir(join(homePath, "agents", "custom"), { recursive: true });
     await mkdir(join(homePath, ".trash"), { recursive: true });
+    await mkdir(join(homePath, ".hermes"), { recursive: true });
+    await mkdir(join(homePath, ".claude"), { recursive: true });
     const manager = createProjectManager({ homePath, runCommand: vi.fn() });
 
-    for (const path of [".", "system", "system/wallpapers", "agents", "agents/custom", ".trash"]) {
+    for (const path of [".", "system", "system/wallpapers", "agents", "agents/custom", ".trash", ".hermes", ".claude"]) {
       await expect(manager.createProject({
         mode: "folder",
         name: "Protected",

--- a/tests/gateway/project-manager.test.ts
+++ b/tests/gateway/project-manager.test.ts
@@ -300,6 +300,27 @@ describe("project-manager", () => {
     })).resolves.toMatchObject({ ok: true, status: 201 });
   });
 
+  it("rejects ancestors of denied subtrees while allowing sibling folders", async () => {
+    await mkdir(join(homePath, "data", "browser-profiles"), { recursive: true });
+    await mkdir(join(homePath, "data", "exports"), { recursive: true });
+    const manager = createProjectManager({ homePath, runCommand: vi.fn() });
+
+    // data contains data/browser-profiles (persistent browser login state).
+    await expect(manager.createProject({
+      mode: "folder",
+      name: "Data",
+      slug: "data-root",
+      path: "data",
+    })).resolves.toMatchObject({ ok: false, status: 400, error: { code: "invalid_project_path" } });
+
+    await expect(manager.createProject({
+      mode: "folder",
+      name: "Exports",
+      slug: "data-exports",
+      path: "data/exports",
+    })).resolves.toMatchObject({ ok: true, status: 201 });
+  });
+
   it("rejects managed worktree and metadata areas as folder project roots", async () => {
     await mkdir(join(homePath, "projects", "other", "worktrees", "wt-1"), { recursive: true });
     const manager = createProjectManager({ homePath, runCommand: vi.fn() });

--- a/tests/gateway/project-manager.test.ts
+++ b/tests/gateway/project-manager.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
-import { mkdir, mkdtemp, readdir, readFile, stat, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readdir, readFile, stat, symlink, writeFile } from "node:fs/promises";
 import { rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -187,6 +187,31 @@ describe("project-manager", () => {
         path,
       })).resolves.toMatchObject({ ok: false, status: 400, error: { code: "invalid_project_path" } });
     }
+  });
+
+  it("rejects symlinked aliases of protected subtrees as folder projects", async () => {
+    await mkdir(join(homePath, "system", "wallpapers"), { recursive: true });
+    await symlink(join(homePath, "system"), join(homePath, "alias"));
+    const manager = createProjectManager({ homePath, runCommand: vi.fn() });
+
+    await expect(manager.createProject({
+      mode: "folder",
+      name: "Alias",
+      slug: "alias-project",
+      path: "alias/wallpapers",
+    })).resolves.toMatchObject({ ok: false, status: 400, error: { code: "invalid_project_path" } });
+  });
+
+  it("rejects the Matrix project registry as a folder project root", async () => {
+    await mkdir(join(homePath, "projects"), { recursive: true });
+    const manager = createProjectManager({ homePath, runCommand: vi.fn() });
+
+    await expect(manager.createProject({
+      mode: "folder",
+      name: "Registry",
+      slug: "registry",
+      path: "projects",
+    })).resolves.toMatchObject({ ok: false, status: 400, error: { code: "invalid_project_path" } });
   });
 
   it("requires existing folder project paths to be directories", async () => {

--- a/tests/gateway/workspace-session-orchestrator.test.ts
+++ b/tests/gateway/workspace-session-orchestrator.test.ts
@@ -32,6 +32,7 @@ describe("workspace session orchestrator", () => {
       })),
     };
     const worktreeManager = {
+      createWorktree: vi.fn(async () => ({ ok: true, status: 201 as const, worktree })),
       listWorktrees: vi.fn(async () => ({ ok: true, worktrees: [worktree] })),
     };
     const agentSandbox = {
@@ -57,8 +58,8 @@ describe("workspace session orchestrator", () => {
       publishSessionStopped: vi.fn(async () => undefined),
     };
     return {
-      worktreeManager,
       projectManager,
+      worktreeManager,
       agentSandbox,
       agentSessionManager,
       sessionRuntimeBridge,
@@ -107,7 +108,8 @@ describe("workspace session orchestrator", () => {
     expect(d.eventPublisher.publishSessionStarted).toHaveBeenCalledWith(session);
   });
 
-  it("starts an agent in the validated primary project checkout when no worktree is selected", async () => {
+  it("runs an agent in the canonical project folder when no worktree is requested", async () => {
+    const projectRoot = join(homePath, "projects", "repo", "repo");
     const d = deps();
     const orchestrator = createWorkspaceSessionOrchestrator({
       ...d,
@@ -118,18 +120,26 @@ describe("workspace session orchestrator", () => {
       ownerScope: { type: "user", id: "user_workspace" },
       request: {
         projectSlug: "repo",
+        taskId: "task_abc123",
         kind: "agent",
         agent: "codex",
-        prompt: "inspect the project",
+        prompt: "fix tests",
       },
     });
 
     expect(result).toMatchObject({ ok: true, status: 201 });
     expect(d.projectManager.getProject).toHaveBeenCalledWith("repo");
+    expect(d.worktreeManager.createWorktree).not.toHaveBeenCalled();
     expect(d.worktreeManager.listWorktrees).not.toHaveBeenCalled();
     expect(d.agentSandbox.preflight).toHaveBeenCalledWith(expect.objectContaining({
-      worktreePath: join(homePath, "projects", "repo", "repo"),
+      sessionId: "sess_fixed",
+      worktreePath: projectRoot,
     }));
+    expect(d.agentSessionManager.startSession).toHaveBeenCalledWith(expect.objectContaining({
+      projectSlug: "repo",
+      ownerId: "user_workspace",
+    }));
+    expect(d.agentSessionManager.startSession.mock.calls[0]?.[0].worktreeId).toBeUndefined();
   });
 
   it("rejects legacy local primary checkouts when the authenticated owner does not match", async () => {

--- a/www/content/docs/guide/cloud-coding.mdx
+++ b/www/content/docs/guide/cloud-coding.mdx
@@ -5,6 +5,12 @@ description: Project workspaces, GitHub authentication, Browser IDE access, revi
 
 Matrix OS cloud coding workspaces turn each user VPS into a private development machine. Projects, tasks, worktrees, sessions, transcripts, reviews, and editor settings live in the user's Matrix home so the gateway, web desktop, CLI, TUI, and browser IDE all operate on the same records.
 
+## Projects and folders
+
+A Matrix project is a Kanban workspace connected to a folder on the selected Matrix computer. Create a new folder, connect an existing folder within your Matrix home, or optionally clone a GitHub repository. Git and GitHub are not required: every project can create tasks and run multiple durable Shell, Claude, or Codex sessions in its folder. A task uses the project folder by default and uses a git worktree only when you explicitly select one.
+
+Removing a project that connects an existing folder removes the Matrix project metadata, not the files in the owner folder.
+
 ## GitHub authentication
 
 Connect GitHub inside your Matrix workspace with the GitHub CLI. SSH keys and GitHub credentials are stored under your Matrix home, so terminal panes, agents, and the browser IDE see the same authenticated identity.


### PR DESCRIPTION
## Summary

- load the signed-in owner's Matrix computers through trusted main-process IPC and expose one computer picker in the sidebar and Settings
- preserve gateway-owned runtime selection, encrypted credential persistence, re-auth fallback, and cancellation race handling without exposing credentials to the renderer
- contain legacy task/tab/panel failures so opening a Kanban card cannot blank the desktop
- model Matrix projects as Kanban workspaces rooted in owner-controlled computer folders, with separate New folder, Use existing folder, and Clone GitHub flows
- treat Git and GitHub as optional project capabilities instead of prerequisites
- run Shell, Claude, and Codex tasks in the canonical project folder unless the user explicitly selects a worktree
- expose project creation from the Agents project/conversation navigator

## Tests

- `bunx vitest run tests/desktop` — 98 files / 925 tests passed
- focused gateway project, session-orchestrator, and workspace-route suites — 37 tests passed
- `bun run typecheck` — passed
- `bun run check:patterns:diff` — 0 violations; existing scanner warnings only
- `bun run build:desktop` — passed
- `git diff --check` — passed
- repository-wide `bun run test` attempted; unrelated default-app baseline failed because Node exposed `localStorage` as unavailable before this diff's tests ran

## Invariants

- **Source of truth:** gateway project configs own folder identity and optional Git/GitHub capabilities; canonical task, session, and coding-thread routes remain authoritative. The desktop holds bounded display projections only.
- **Lock/transaction scope:** project metadata creation remains serialized by the existing per-project lock. Folder-linked creation writes only Matrix metadata and never moves or mutates the connected owner folder.
- **Acceptable orphan states:** if a connected folder later disappears, project/task metadata remains and runtime actions return a bounded recoverable error. Failed runtime switching retains the previous authenticated computer.
- **Auth source of truth:** the native credential store and trusted main process own the bearer. Gateway request principals own project/session authorization. No credential crosses renderer IPC.
- **Deletion:** deleting a folder-linked project removes Matrix metadata only; it never deletes the external owner folder. Managed scratch/clone projects keep their existing lifecycle.
- **Deferred scope:** a visual remote-folder browser can replace the bounded path field later. Git worktree creation remains an explicit task action rather than an implicit requirement for every agent session.
