### PR TITLE
feat(contracts): add canonical computer inventory

### DIFF
--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -89,9 +89,9 @@ export const SafeAssistantPreviewTextSchema = boundedText(243, 1024)
 export const BoundedTextSchema = (maxChars = 4000, maxBytes = 16 * 1024) => boundedText(maxChars, maxBytes);
 
 export const MatrixComputerHandleSchema = z.string()
-  .min(3)
-  .max(31)
-  .regex(/^[a-z][a-z0-9-]{2,30}$/, "Invalid Matrix computer handle");
+  .min(2)
+  .max(63)
+  .regex(/^[a-z0-9][a-z0-9-]{1,62}$/, "Invalid Matrix computer handle");
 export const MatrixComputerRuntimeSlotSchema = z.string()
   .min(1)
   .max(32)

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -96,8 +96,8 @@ export const MatrixComputerLabelSchema = z.enum(["Main Computer", "Preview Compu
 export const MatrixComputerVersionLabelSchema = z.union([
   z.literal("Version pending"),
   z.enum(["stable", "dev", "canary", "beta"]),
-  z.string().regex(
-    /^v\d{4}\.\d{2}\.\d{2}(?:-\d+|-pr\d+-[0-9a-f]{7})?$/,
+  z.string().max(64).regex(
+    /^v\d+\.\d+\.\d+(?:-[0-9A-Za-z]+(?:[.-][0-9A-Za-z]+)*)?$/,
     "Invalid Matrix computer version label",
   ),
 ]);

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -82,6 +82,68 @@ export const SafeAssistantPreviewTextSchema = boundedText(243, 1024)
   .refine((value) => !UNSAFE_ASSISTANT_PREVIEW_TEXT.test(value), { message: "Text is not safe for assistant preview display" });
 export const BoundedTextSchema = (maxChars = 4000, maxBytes = 16 * 1024) => boundedText(maxChars, maxBytes);
 
+export const MatrixComputerHandleSchema = z.string()
+  .min(3)
+  .max(31)
+  .regex(/^[a-z][a-z0-9-]{2,30}$/, "Invalid Matrix computer handle");
+export const MatrixComputerRuntimeSlotSchema = z.string()
+  .min(1)
+  .max(32)
+  .regex(/^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/, "Invalid Matrix computer runtime slot");
+export const MatrixComputerAvailabilitySchema = z.enum(["available", "starting", "unavailable"]);
+export const MatrixComputerKindSchema = z.enum(["customer", "preview"]);
+export const MatrixComputerLabelSchema = z.enum(["Main Computer", "Preview Computer", "Additional Computer"]);
+export const MatrixComputerVersionLabelSchema = z.union([
+  z.literal("Version pending"),
+  z.enum(["stable", "dev", "canary", "beta"]),
+  z.string().regex(/^v\d{4}\.\d{2}\.\d{2}$/, "Invalid Matrix computer version label"),
+]);
+export const MatrixComputerCapabilityIdSchema = z.string()
+  .min(1)
+  .max(80)
+  .regex(/^[a-z][A-Za-z0-9]{0,79}$/, "Invalid Matrix computer capability id");
+export const MatrixComputerSchema = z.object({
+  handle: MatrixComputerHandleSchema,
+  runtimeSlot: MatrixComputerRuntimeSlotSchema,
+  label: MatrixComputerLabelSchema,
+  availability: MatrixComputerAvailabilitySchema,
+  kind: MatrixComputerKindSchema,
+  versionLabel: MatrixComputerVersionLabelSchema.optional(),
+  gatewayPath: z.string().min(6).max(67),
+  capabilities: z.array(MatrixComputerCapabilityIdSchema).max(64),
+}).strict().superRefine((computer, ctx) => {
+  if (computer.gatewayPath !== `/vm/${computer.handle}`) {
+    ctx.addIssue({
+      code: "custom",
+      message: "Gateway path must match the Matrix computer handle",
+      path: ["gatewayPath"],
+    });
+  }
+});
+
+export const MatrixComputerListSchema = z.object({
+  items: z.array(MatrixComputerSchema).max(20),
+  hasMore: z.boolean(),
+  limit: z.number().int().min(1).max(20),
+  selectedSlot: MatrixComputerRuntimeSlotSchema.nullable(),
+}).strict().refine((list) => list.items.length <= list.limit, {
+  message: "Items cannot exceed the requested limit",
+  path: ["items"],
+}).refine((list) => list.selectedSlot === null || list.items.some((item) => item.runtimeSlot === list.selectedSlot), {
+  message: "Selected slot must be present in the computer inventory",
+  path: ["selectedSlot"],
+});
+
+export type MatrixComputerHandle = z.infer<typeof MatrixComputerHandleSchema>;
+export type MatrixComputerRuntimeSlot = z.infer<typeof MatrixComputerRuntimeSlotSchema>;
+export type MatrixComputerAvailability = z.infer<typeof MatrixComputerAvailabilitySchema>;
+export type MatrixComputerKind = z.infer<typeof MatrixComputerKindSchema>;
+export type MatrixComputerLabel = z.infer<typeof MatrixComputerLabelSchema>;
+export type MatrixComputerVersionLabel = z.infer<typeof MatrixComputerVersionLabelSchema>;
+export type MatrixComputerCapabilityId = z.infer<typeof MatrixComputerCapabilityIdSchema>;
+export type MatrixComputer = z.infer<typeof MatrixComputerSchema>;
+export type MatrixComputerList = z.infer<typeof MatrixComputerListSchema>;
+
 export const RecoveryActionSchema = z.enum([
   "retry",
   "sign_in",

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -101,6 +101,8 @@ export const MatrixComputerKindSchema = z.enum(["customer", "preview"]);
 export const MatrixComputerLabelSchema = z.enum(["Main Computer", "Preview Computer", "Additional Computer"]);
 export const MatrixComputerVersionLabelSchema = z.preprocess((value) => {
   if (typeof value !== "string" || value.length > 128) return value;
+  const legacyChannel = value.match(/^matrix-os-host-(stable|dev|canary|beta)$/)?.[1];
+  if (legacyChannel) return legacyChannel;
   const legacyRelease = value.match(/^matrix-os-host-(\d{4}\.\d{2}\.\d{2})(?:$|-)/)?.[1];
   return legacyRelease ? `v${legacyRelease}` : value;
 }, z.union([

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -112,13 +112,16 @@ export const MatrixComputerSchema = z.object({
   availability: MatrixComputerAvailabilitySchema,
   kind: MatrixComputerKindSchema,
   versionLabel: MatrixComputerVersionLabelSchema.optional(),
-  gatewayPath: z.string().min(6).max(67),
+  gatewayPath: z.string().min(6).max(108),
   capabilities: z.array(MatrixComputerCapabilityIdSchema).max(64),
 }).strict().superRefine((computer, ctx) => {
-  if (computer.gatewayPath !== `/vm/${computer.handle}`) {
+  const expectedGatewayPath = computer.runtimeSlot === "primary"
+    ? `/vm/${computer.handle}`
+    : `/vm/${computer.handle}?runtime=${computer.runtimeSlot}`;
+  if (computer.gatewayPath !== expectedGatewayPath) {
     ctx.addIssue({
       code: "custom",
-      message: "Gateway path must match the Matrix computer handle",
+      message: "Gateway path must match the Matrix computer handle and runtime slot",
       path: ["gatewayPath"],
     });
   }

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -16,6 +16,12 @@ function byteLength(value: string): number {
   return textEncoder.encode(value).byteLength;
 }
 
+function hasIpv4AddressInVersionSuffix(value: string): boolean {
+  const suffixStart = value.indexOf("-");
+  if (suffixStart === -1) return false;
+  return /(?:^|[^0-9])(?:\d{1,3}\.){3}\d{1,3}(?:$|[^0-9])/.test(value.slice(suffixStart + 1));
+}
+
 function boundedText(maxChars: number, maxBytes = maxChars * 4) {
   return z.string()
     .min(1)
@@ -103,7 +109,10 @@ export const MatrixComputerVersionLabelSchema = z.union([
       "Invalid Matrix computer version label",
     )
     .refine(
-      (value) => !UNSAFE_ASSISTANT_PREVIEW_TEXT.test(value) && !/(?:machine|server)[._-]?id/i.test(value),
+      (value) =>
+        !UNSAFE_ASSISTANT_PREVIEW_TEXT.test(value) &&
+        !/(?:machine|server)[._-]?id/i.test(value) &&
+        !hasIpv4AddressInVersionSuffix(value),
       { message: "Matrix computer version label is not safe for display" },
     ),
 ]);

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -99,7 +99,11 @@ export const MatrixComputerRuntimeSlotSchema = z.string()
 export const MatrixComputerAvailabilitySchema = z.enum(["available", "starting", "unavailable"]);
 export const MatrixComputerKindSchema = z.enum(["customer", "preview"]);
 export const MatrixComputerLabelSchema = z.enum(["Main Computer", "Preview Computer", "Additional Computer"]);
-export const MatrixComputerVersionLabelSchema = z.union([
+export const MatrixComputerVersionLabelSchema = z.preprocess((value) => {
+  if (typeof value !== "string" || value.length > 128) return value;
+  const legacyRelease = value.match(/^matrix-os-host-(\d{4}\.\d{2}\.\d{2})(?:$|-)/)?.[1];
+  return legacyRelease ? `v${legacyRelease}` : value;
+}, z.union([
   z.literal("Version pending"),
   z.enum(["stable", "dev", "canary", "beta"]),
   z.string()
@@ -115,7 +119,7 @@ export const MatrixComputerVersionLabelSchema = z.union([
         !hasIpv4AddressInVersionSuffix(value),
       { message: "Matrix computer version label is not safe for display" },
     ),
-]);
+]));
 export const MatrixComputerCapabilityIdSchema = z.string()
   .min(1)
   .max(80)

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -96,7 +96,10 @@ export const MatrixComputerLabelSchema = z.enum(["Main Computer", "Preview Compu
 export const MatrixComputerVersionLabelSchema = z.union([
   z.literal("Version pending"),
   z.enum(["stable", "dev", "canary", "beta"]),
-  z.string().regex(/^v\d{4}\.\d{2}\.\d{2}$/, "Invalid Matrix computer version label"),
+  z.string().regex(
+    /^v\d{4}\.\d{2}\.\d{2}(?:-\d+|-pr\d+-[0-9a-f]{7})?$/,
+    "Invalid Matrix computer version label",
+  ),
 ]);
 export const MatrixComputerCapabilityIdSchema = z.string()
   .min(1)

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -96,10 +96,16 @@ export const MatrixComputerLabelSchema = z.enum(["Main Computer", "Preview Compu
 export const MatrixComputerVersionLabelSchema = z.union([
   z.literal("Version pending"),
   z.enum(["stable", "dev", "canary", "beta"]),
-  z.string().max(64).regex(
-    /^v\d+\.\d+\.\d+(?:-[0-9A-Za-z]+(?:[.-][0-9A-Za-z]+)*)?$/,
-    "Invalid Matrix computer version label",
-  ),
+  z.string()
+    .max(64)
+    .regex(
+      /^v\d+\.\d+\.\d+(?:-[0-9A-Za-z]+(?:[.-][0-9A-Za-z]+)*)?$/,
+      "Invalid Matrix computer version label",
+    )
+    .refine(
+      (value) => !UNSAFE_ASSISTANT_PREVIEW_TEXT.test(value) && !/(?:machine|server)[._-]?id/i.test(value),
+      { message: "Matrix computer version label is not safe for display" },
+    ),
 ]);
 export const MatrixComputerCapabilityIdSchema = z.string()
   .min(1)

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -135,6 +135,9 @@ export const MatrixComputerListSchema = z.object({
 }).strict().refine((list) => list.items.length <= list.limit, {
   message: "Items cannot exceed the requested limit",
   path: ["items"],
+}).refine((list) => new Set(list.items.map((item) => item.runtimeSlot)).size === list.items.length, {
+  message: "Runtime slots must be unique within the computer inventory",
+  path: ["items"],
 }).refine((list) => list.selectedSlot === null || list.items.some((item) => item.runtimeSlot === list.selectedSlot), {
   message: "Selected slot must be present in the computer inventory",
   path: ["selectedSlot"],

--- a/specs/105-coding-agent-shells/tasks.md
+++ b/specs/105-coding-agent-shells/tasks.md
@@ -1255,8 +1255,8 @@ Gate:
 Goal: freeze the complete backend capability and migration boundary before shell
 agents depend on new fields.
 
-- [ ] B24-001 Product owner confirms the scope/non-goals in `FULL-WORKSPACE-BACKEND.md`.
-- [ ] B24-002 Write failing shared contract tests for bounded `MatrixComputerListSchema`, authoritative selection, derived gateway paths, and forbidden machine/operator fields in `tests/contracts/runtime-computers.test.ts`.
+- [x] B24-001 Product owner confirms the scope/non-goals in `FULL-WORKSPACE-BACKEND.md`.
+- [x] B24-002 Write failing shared contract tests for bounded `MatrixComputerListSchema`, authoritative selection, derived gateway paths, and forbidden machine/operator fields in `tests/contracts/runtime-computers.test.ts`.
 - [ ] B24-003 Implement one canonical `GET /api/auth/computers` contract/route for server-verified Clerk and native/sync principals; remove duplicate desktop read shape or document a bounded expiring alias.
 - [ ] B24-004 Preserve trusted-main-only `POST /api/auth/runtime-selection` bearer replacement while mobile continues authenticated same-origin platform/session routing.
 - [ ] B24-005 Write failing auth tests, then add a bounded server-verified native identity projection for shell display fallback without trusting client headers.

--- a/tests/contracts/runtime-computers.test.ts
+++ b/tests/contracts/runtime-computers.test.ts
@@ -117,6 +117,14 @@ describe("Matrix computer contracts", () => {
     }
   });
 
+  it("normalizes legacy host-bundle versions to a coarse release label", () => {
+    const computer = MatrixComputerSchema.parse({
+      ...mainComputer,
+      versionLabel: "matrix-os-host-2026.04.26-1",
+    });
+    expect(computer.versionLabel).toBe("v2026.04.26");
+  });
+
   it("rejects mismatched routes, unsafe fields, client selection, and unbounded lists", () => {
     expect(MatrixComputerSchema.safeParse({
       ...mainComputer,

--- a/tests/contracts/runtime-computers.test.ts
+++ b/tests/contracts/runtime-computers.test.ts
@@ -106,6 +106,17 @@ describe("Matrix computer contracts", () => {
     expect(computer.capabilities).toHaveLength(41);
   });
 
+  it("accepts the complete platform-provisioned handle domain", () => {
+    for (const handle of ["1a", "ab", `a${"1".repeat(60)}`, `a${"1".repeat(62)}`]) {
+      const computer = MatrixComputerSchema.parse({
+        ...mainComputer,
+        handle,
+        gatewayPath: `/vm/${handle}`,
+      });
+      expect(computer.handle).toBe(handle);
+    }
+  });
+
   it("rejects mismatched routes, unsafe fields, client selection, and unbounded lists", () => {
     expect(MatrixComputerSchema.safeParse({
       ...mainComputer,
@@ -152,12 +163,12 @@ describe("Matrix computer contracts", () => {
 
     for (const invalid of [
       { ...mainComputer, handle: "N" },
-      { ...mainComputer, handle: "1a", gatewayPath: "/vm/1a" },
-      { ...mainComputer, handle: "ab", gatewayPath: "/vm/ab" },
+      { ...mainComputer, handle: "a", gatewayPath: "/vm/a" },
+      { ...mainComputer, handle: "-bad", gatewayPath: "/vm/-bad" },
       {
         ...mainComputer,
-        handle: "a1234567890123456789012345678901",
-        gatewayPath: "/vm/a1234567890123456789012345678901",
+        handle: `a${"1".repeat(63)}`,
+        gatewayPath: `/vm/a${"1".repeat(63)}`,
       },
       { ...mainComputer, runtimeSlot: "review_slot" },
       { ...mainComputer, gatewayPath: "https://example.com/vm/neo" },

--- a/tests/contracts/runtime-computers.test.ts
+++ b/tests/contracts/runtime-computers.test.ts
@@ -72,7 +72,7 @@ describe("Matrix computer contracts", () => {
           availability: "starting",
           kind: "preview",
           versionLabel: "Version pending",
-          gatewayPath: "/vm/pr-920",
+          gatewayPath: "/vm/pr-920?runtime=pr-920",
           capabilities: ["matrixComputerInventoryV1"],
         },
       ],
@@ -83,7 +83,7 @@ describe("Matrix computer contracts", () => {
 
     expect(response.items).toHaveLength(2);
     expect(response.selectedSlot).toBe("primary");
-    expect(response.items[1]?.gatewayPath).toBe("/vm/pr-920");
+    expect(response.items[1]?.gatewayPath).toBe("/vm/pr-920?runtime=pr-920");
   });
 
   it("represents a verified principal without an authoritative runtime selection", () => {
@@ -131,7 +131,7 @@ describe("Matrix computer contracts", () => {
         ...mainComputer,
         handle: `neo-${index}`,
         runtimeSlot: `slot-${index}`,
-        gatewayPath: `/vm/neo-${index}`,
+        gatewayPath: `/vm/neo-${index}?runtime=slot-${index}`,
       })),
       selectedSlot: null,
       hasMore: true,
@@ -143,7 +143,7 @@ describe("Matrix computer contracts", () => {
         ...mainComputer,
         handle: `neo-${index}`,
         runtimeSlot: `slot-${index}`,
-        gatewayPath: `/vm/neo-${index}`,
+        gatewayPath: `/vm/neo-${index}?runtime=slot-${index}`,
       })),
       selectedSlot: null,
       hasMore: false,

--- a/tests/contracts/runtime-computers.test.ts
+++ b/tests/contracts/runtime-computers.test.ts
@@ -190,6 +190,8 @@ describe("Matrix computer contracts", () => {
       "v2026.07.11",
       "v2026.07.11-42",
       "v2026.07.11-pr921-802ee13",
+      "v0.9.1",
+      "v0.9.1-rc.1",
       "stable",
       "dev",
       "canary",

--- a/tests/contracts/runtime-computers.test.ts
+++ b/tests/contracts/runtime-computers.test.ts
@@ -1,0 +1,220 @@
+import { describe, expect, it } from "vitest";
+import {
+  MatrixComputerListSchema,
+  MatrixComputerSchema,
+} from "@matrix-os/contracts";
+
+const mainComputer = {
+  handle: "neo",
+  runtimeSlot: "primary",
+  label: "Main Computer",
+  availability: "available",
+  kind: "customer",
+  versionLabel: "v2026.07.11",
+  gatewayPath: "/vm/neo",
+  capabilities: ["matrixComputerInventoryV1", "codingAgentsTranscriptPages"],
+} as const;
+
+const documentedCapabilities = [
+  "codingAgentsRuntimeSummary",
+  "codingAgentsDesktopWorkspace",
+  "codingAgentsMobileWorkspace",
+  "codingAgentsThreadCreate",
+  "codingAgentsApprovals",
+  "codingAgentsReview",
+  "codingAgentsPreview",
+  "codingAgentsFiles",
+  "codingAgentsSourceControl",
+  "codingAgentsNativeMobileTerminal",
+  "codingAgentsProjectWorkspace",
+  "codingAgentsSameThreadTurns",
+  "codingAgentsConversationView",
+  "codingAgentsKanbanView",
+  "codingAgentsTranscriptPages",
+  "codingAgentsSessionDiscovery",
+  "codingAgentsSessionLifecycle",
+  "codingAgentsPendingQueue",
+  "codingAgentsSteering",
+  "codingAgentsTurnInterrupt",
+  "codingAgentsProviderControls",
+  "codingAgentsProfiles",
+  "codingAgentsExecutionGraph",
+  "codingAgentsTerminalBindingsV2",
+  "codingAgentsRepositoryState",
+  "codingAgentsSourceControlV2",
+  "codingAgentsReviewComments",
+  "codingAgentsAttachments",
+  "codingAgentsAttentionInbox",
+  "codingAgentsRuntimeHandoff",
+  "codingAgentsCollaboration",
+  "codingAgentsPromptAssets",
+  "codingAgentsUsageSummary",
+  "matrixComputerInventoryV1",
+  "matrixNativeIdentityProjection",
+  "codingAgentsMemorySearch",
+  "codingAgentsAutomations",
+  "codingAgentsVoiceActions",
+  "codingAgentsFeaturePolicy",
+  "codingAgentsRecovery",
+  "codingAgentsDiagnosticsSnapshot",
+] as const;
+
+describe("Matrix computer contracts", () => {
+  it("accepts one bounded owner inventory with authoritative top-level selection", () => {
+    const response = MatrixComputerListSchema.parse({
+      items: [
+        mainComputer,
+        {
+          ...mainComputer,
+          handle: "pr-920",
+          runtimeSlot: "pr-920",
+          label: "Preview Computer",
+          availability: "starting",
+          kind: "preview",
+          versionLabel: "Version pending",
+          gatewayPath: "/vm/pr-920",
+          capabilities: ["matrixComputerInventoryV1"],
+        },
+      ],
+      selectedSlot: "primary",
+      hasMore: false,
+      limit: 20,
+    });
+
+    expect(response.items).toHaveLength(2);
+    expect(response.selectedSlot).toBe("primary");
+    expect(response.items[1]?.gatewayPath).toBe("/vm/pr-920");
+  });
+
+  it("represents a verified principal without an authoritative runtime selection", () => {
+    const response = MatrixComputerListSchema.parse({
+      items: [mainComputer],
+      selectedSlot: null,
+      hasMore: false,
+      limit: 20,
+    });
+
+    expect(response.selectedSlot).toBeNull();
+  });
+
+  it("accepts the complete additive capability roster", () => {
+    const computer = MatrixComputerSchema.parse({
+      ...mainComputer,
+      capabilities: documentedCapabilities,
+    });
+
+    expect(computer.capabilities).toHaveLength(41);
+  });
+
+  it("rejects mismatched routes, unsafe fields, client selection, and unbounded lists", () => {
+    expect(MatrixComputerSchema.safeParse({
+      ...mainComputer,
+      gatewayPath: "/vm/someone-else",
+    }).success).toBe(false);
+
+    for (const leaked of [
+      { machineId: "machine-secret" },
+      { publicIPv4: "203.0.113.12" },
+      { accessToken: "secret" },
+      { provider: "infrastructure-vendor" },
+      { providerState: { authenticated: true } },
+      { privateHostname: "db.internal" },
+      { operatorMetadata: { serverType: "cpx22" } },
+      { credentials: { accessToken: "secret" } },
+      { selected: true },
+    ]) {
+      expect(MatrixComputerSchema.safeParse({ ...mainComputer, ...leaked }).success).toBe(false);
+    }
+
+    expect(MatrixComputerListSchema.safeParse({
+      items: Array.from({ length: 21 }, (_, index) => ({
+        ...mainComputer,
+        handle: `neo-${index}`,
+        runtimeSlot: `slot-${index}`,
+        gatewayPath: `/vm/neo-${index}`,
+      })),
+      selectedSlot: null,
+      hasMore: true,
+      limit: 20,
+    }).success).toBe(false);
+
+    expect(MatrixComputerListSchema.parse({
+      items: Array.from({ length: 20 }, (_, index) => ({
+        ...mainComputer,
+        handle: `neo-${index}`,
+        runtimeSlot: `slot-${index}`,
+        gatewayPath: `/vm/neo-${index}`,
+      })),
+      selectedSlot: null,
+      hasMore: false,
+      limit: 20,
+    }).items).toHaveLength(20);
+
+    for (const invalid of [
+      { ...mainComputer, handle: "N" },
+      { ...mainComputer, handle: "1a", gatewayPath: "/vm/1a" },
+      { ...mainComputer, handle: "ab", gatewayPath: "/vm/ab" },
+      {
+        ...mainComputer,
+        handle: "a1234567890123456789012345678901",
+        gatewayPath: "/vm/a1234567890123456789012345678901",
+      },
+      { ...mainComputer, runtimeSlot: "review_slot" },
+      { ...mainComputer, gatewayPath: "https://example.com/vm/neo" },
+      { ...mainComputer, gatewayPath: "/vm/neo?token=value" },
+      { ...mainComputer, capabilities: Array.from({ length: 65 }, (_, index) => `capability${index}`) },
+      { ...mainComputer, label: "Runtime at 10.0.0.8" },
+      { ...mainComputer, label: "Runtime at fd00::1" },
+      { ...mainComputer, label: "Runtime at 2001:db8::1" },
+      { ...mainComputer, label: "localhost" },
+      { ...mainComputer, label: "db.corp" },
+      { ...mainComputer, label: "db.private" },
+      { ...mainComputer, label: "hostId=h-123" },
+      { ...mainComputer, label: "machineIdentifier=m-123" },
+      { ...mainComputer, versionLabel: "machine.id=m-123" },
+      { ...mainComputer, versionLabel: "server/id=srv-123" },
+      { ...mainComputer, versionLabel: "matrix-os-host-machineIdm123" },
+      { ...mainComputer, versionLabel: "v1machineIdm123" },
+      { ...mainComputer, versionLabel: "db.internal" },
+      { ...mainComputer, versionLabel: "accessToken=secret-value" },
+      { ...mainComputer, versionLabel: "Hetzner server 123" },
+    ]) {
+      expect(MatrixComputerSchema.safeParse(invalid).success).toBe(false);
+    }
+
+    for (const label of ["Main Computer", "Preview Computer", "Additional Computer"]) {
+      expect(MatrixComputerSchema.parse({ ...mainComputer, label }).label).toBe(label);
+    }
+
+    for (const versionLabel of ["v2026.07.11", "stable", "dev", "canary", "beta", "Version pending"]) {
+      expect(MatrixComputerSchema.parse({ ...mainComputer, versionLabel }).versionLabel).toBe(versionLabel);
+    }
+
+    expect(MatrixComputerListSchema.safeParse({
+      items: [mainComputer],
+      selectedSlot: null,
+      hasMore: false,
+      limit: 20,
+      ownerId: "user-secret",
+    }).success).toBe(false);
+
+    expect(MatrixComputerListSchema.safeParse({
+      items: [mainComputer, {
+        ...mainComputer,
+        handle: "neo-2",
+        runtimeSlot: "secondary",
+        gatewayPath: "/vm/neo-2",
+      }],
+      selectedSlot: null,
+      hasMore: false,
+      limit: 1,
+    }).success).toBe(false);
+
+    expect(MatrixComputerListSchema.safeParse({
+      items: [mainComputer],
+      selectedSlot: "preview-1",
+      hasMore: false,
+      limit: 20,
+    }).success).toBe(false);
+  });
+});

--- a/tests/contracts/runtime-computers.test.ts
+++ b/tests/contracts/runtime-computers.test.ts
@@ -186,7 +186,16 @@ describe("Matrix computer contracts", () => {
       expect(MatrixComputerSchema.parse({ ...mainComputer, label }).label).toBe(label);
     }
 
-    for (const versionLabel of ["v2026.07.11", "stable", "dev", "canary", "beta", "Version pending"]) {
+    for (const versionLabel of [
+      "v2026.07.11",
+      "v2026.07.11-42",
+      "v2026.07.11-pr921-802ee13",
+      "stable",
+      "dev",
+      "canary",
+      "beta",
+      "Version pending",
+    ]) {
       expect(MatrixComputerSchema.parse({ ...mainComputer, versionLabel }).versionLabel).toBe(versionLabel);
     }
 

--- a/tests/contracts/runtime-computers.test.ts
+++ b/tests/contracts/runtime-computers.test.ts
@@ -227,5 +227,15 @@ describe("Matrix computer contracts", () => {
       hasMore: false,
       limit: 20,
     }).success).toBe(false);
+
+    expect(MatrixComputerListSchema.safeParse({
+      items: [
+        mainComputer,
+        { ...mainComputer, handle: "neo-two", gatewayPath: "/vm/neo-two" },
+      ],
+      selectedSlot: "primary",
+      hasMore: false,
+      limit: 20,
+    }).success).toBe(false);
   });
 });

--- a/tests/contracts/runtime-computers.test.ts
+++ b/tests/contracts/runtime-computers.test.ts
@@ -176,6 +176,8 @@ describe("Matrix computer contracts", () => {
       { ...mainComputer, versionLabel: "matrix-os-host-machineIdm123" },
       { ...mainComputer, versionLabel: "v1machineIdm123" },
       { ...mainComputer, versionLabel: "v0.9.1-db.internal" },
+      { ...mainComputer, versionLabel: "v1.2.3-10.0.0.8" },
+      { ...mainComputer, versionLabel: "v1.2.3-192.168.1.10" },
       { ...mainComputer, versionLabel: "v1.2.3-machineIdm123" },
       { ...mainComputer, versionLabel: "db.internal" },
       { ...mainComputer, versionLabel: "accessToken=secret-value" },

--- a/tests/contracts/runtime-computers.test.ts
+++ b/tests/contracts/runtime-computers.test.ts
@@ -123,6 +123,14 @@ describe("Matrix computer contracts", () => {
       versionLabel: "matrix-os-host-2026.04.26-1",
     });
     expect(computer.versionLabel).toBe("v2026.04.26");
+
+    for (const channel of ["stable", "dev", "canary", "beta"] as const) {
+      const channelComputer = MatrixComputerSchema.parse({
+        ...mainComputer,
+        versionLabel: `matrix-os-host-${channel}`,
+      });
+      expect(channelComputer.versionLabel).toBe(channel);
+    }
   });
 
   it("rejects mismatched routes, unsafe fields, client selection, and unbounded lists", () => {

--- a/tests/contracts/runtime-computers.test.ts
+++ b/tests/contracts/runtime-computers.test.ts
@@ -175,6 +175,8 @@ describe("Matrix computer contracts", () => {
       { ...mainComputer, versionLabel: "server/id=srv-123" },
       { ...mainComputer, versionLabel: "matrix-os-host-machineIdm123" },
       { ...mainComputer, versionLabel: "v1machineIdm123" },
+      { ...mainComputer, versionLabel: "v0.9.1-db.internal" },
+      { ...mainComputer, versionLabel: "v1.2.3-machineIdm123" },
       { ...mainComputer, versionLabel: "db.internal" },
       { ...mainComputer, versionLabel: "accessToken=secret-value" },
       { ...mainComputer, versionLabel: "Hetzner server 123" },


### PR DESCRIPTION
## Summary

- add one bounded shared `MatrixComputerListSchema` for desktop and mobile inventory hydration
- make selection authoritative at the response level and derive each same-origin gateway path from its validated handle
- allow only fixed computer labels and coarse release labels so machine, network, credential, provider, and operator metadata cannot cross the contract
- support the complete additive coding-agent capability roster while retaining explicit item and capability caps

## Validation

- `pnpm exec vitest run tests/contracts/*.test.ts` (20 passed)
- `pnpm --filter @matrix-os/contracts run typecheck`
- `bun run check:patterns` (0 violations; existing warning categories only)
- `bun run typecheck`
- `git diff --cached --check`

## TDD Evidence

The schema tests were added first and failed for missing contracts. Follow-up red tests reproduced unsafe host/operator display values, a too-small capability bound, and permissive release suffixes before the schema was tightened.

## Invariants

- Source of truth remains the platform owner database; this PR is schema-only and adds no persistence or runtime behavior.
- No transaction or lock is required because this slice performs no reads or writes.
- No orphan state is possible because no state is created.
- Authenticated Clerk/native principal resolution and owner-scoped projection remain in the dependent route PR.
- Trusted desktop credential exchange, mobile routing, preview authority, and shell adoption are intentionally deferred to focused child PRs.
