### PR TITLE
feat(platform): add canonical computer inventory route

### DIFF
--- a/Dockerfile.platform
+++ b/Dockerfile.platform
@@ -7,6 +7,7 @@ WORKDIR /app
 
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml tsconfig.json ./
 COPY packages/clerk-sync/package.json packages/clerk-sync/package.json
+COPY packages/contracts/package.json packages/contracts/package.json
 COPY packages/gateway/package.json packages/gateway/package.json
 COPY packages/kernel/package.json packages/kernel/package.json
 COPY packages/mcp-browser/package.json packages/mcp-browser/package.json
@@ -64,6 +65,7 @@ RUN adduser -D -u 1001 -h /home/matrix-platform -s /sbin/nologin matrix-platform
 
 COPY --from=prod-deps --chown=matrix-platform:matrix-platform /app/node_modules ./node_modules
 COPY --from=prod-deps --chown=matrix-platform:matrix-platform /app/packages/clerk-sync/package.json ./packages/clerk-sync/package.json
+COPY --from=prod-deps --chown=matrix-platform:matrix-platform /app/packages/contracts/package.json ./packages/contracts/package.json
 COPY --from=prod-deps --chown=matrix-platform:matrix-platform /app/packages/gateway/package.json ./packages/gateway/package.json
 COPY --from=prod-deps --chown=matrix-platform:matrix-platform /app/packages/kernel/package.json ./packages/kernel/package.json
 COPY --from=prod-deps --chown=matrix-platform:matrix-platform /app/packages/mcp-browser/package.json ./packages/mcp-browser/package.json
@@ -73,6 +75,7 @@ COPY --from=prod-deps --chown=matrix-platform:matrix-platform /app/packages/plat
 COPY --from=prod-deps --chown=matrix-platform:matrix-platform /app/packages/sync-client/package.json ./packages/sync-client/package.json
 COPY --from=prod-deps --chown=matrix-platform:matrix-platform /app/shell/package.json ./shell/package.json
 COPY --from=builder --chown=matrix-platform:matrix-platform /app/packages/clerk-sync/src ./packages/clerk-sync/src
+COPY --from=builder --chown=matrix-platform:matrix-platform /app/packages/contracts/src ./packages/contracts/src
 COPY --from=builder --chown=matrix-platform:matrix-platform /app/packages/gateway/dist ./packages/gateway/dist
 COPY --from=builder --chown=matrix-platform:matrix-platform /app/packages/kernel/dist ./packages/kernel/dist
 COPY --from=builder --chown=matrix-platform:matrix-platform /app/packages/observability/dist ./packages/observability/dist

--- a/packages/platform/package.json
+++ b/packages/platform/package.json
@@ -24,6 +24,7 @@
     "@clerk/backend": "2.33.0",
     "@hono/node-server": "^1.19.9",
     "@matrix-os/clerk-sync": "workspace:*",
+    "@matrix-os/contracts": "workspace:*",
     "@matrix-os/observability": "workspace:*",
     "dockerode": "^4.0.7",
     "hono": "^4.11.9",

--- a/packages/platform/src/computer-repository.ts
+++ b/packages/platform/src/computer-repository.ts
@@ -1,0 +1,49 @@
+import { sql } from 'kysely';
+
+import type {
+  PlatformDB,
+  UserMachineProvisioningClass,
+} from './db.js';
+
+export interface UserRuntimeComputerRecord {
+  handle: string;
+  runtimeSlot: string;
+  provisioningClass: UserMachineProvisioningClass;
+  status: string;
+  imageVersion: string | null;
+}
+
+export async function listUserRuntimeComputersByClerkId(
+  db: PlatformDB,
+  clerkUserId: string,
+  limit: number,
+  selectedRuntimeSlot?: string,
+): Promise<UserRuntimeComputerRecord[]> {
+  await db.ready;
+  const boundedLimit = Math.max(1, Math.min(limit, 21));
+  let query = db.executor
+    .selectFrom('user_machines')
+    .select(['handle', 'runtime_slot', 'provisioning_class', 'status', 'image_version'])
+    .where('clerk_user_id', '=', clerkUserId)
+    .where('deleted_at', 'is', null)
+    .where('provisioning_class', 'in', ['customer', 'preview'])
+    .where(sql<boolean>`${sql.ref('handle')} ~ ${'^[a-z][a-z0-9-]{2,30}$'}`)
+    .where(sql<boolean>`${sql.ref('runtime_slot')} ~ ${'^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$'}`)
+    .where(sql<boolean>`char_length(${sql.ref('runtime_slot')}) <= 32`);
+  if (selectedRuntimeSlot) {
+    query = query.orderBy(sql`CASE WHEN runtime_slot = ${selectedRuntimeSlot} THEN 0 WHEN runtime_slot = 'primary' THEN 1 ELSE 2 END`);
+  } else {
+    query = query.orderBy(sql`CASE WHEN runtime_slot = 'primary' THEN 0 ELSE 1 END`);
+  }
+  const rows = await query
+    .orderBy('provisioned_at', 'desc')
+    .limit(boundedLimit)
+    .execute();
+  return rows.map((row) => ({
+    handle: row.handle,
+    runtimeSlot: row.runtime_slot,
+    provisioningClass: row.provisioning_class === 'preview' ? 'preview' : 'customer',
+    status: row.status,
+    imageVersion: row.image_version,
+  }));
+}

--- a/packages/platform/src/computer-repository.ts
+++ b/packages/platform/src/computer-repository.ts
@@ -4,6 +4,7 @@ import type {
   PlatformDB,
   UserMachineProvisioningClass,
 } from './db.js';
+import { HANDLE_PATTERN_SOURCE } from './platform-route-utils.js';
 
 export interface UserRuntimeComputerRecord {
   handle: string;
@@ -27,7 +28,7 @@ export async function listUserRuntimeComputersByClerkId(
     .where('clerk_user_id', '=', clerkUserId)
     .where('deleted_at', 'is', null)
     .where('provisioning_class', 'in', ['customer', 'preview'])
-    .where(sql<boolean>`${sql.ref('handle')} ~ ${'^[a-z][a-z0-9-]{2,30}$'}`)
+    .where(sql<boolean>`${sql.ref('handle')} ~ ${HANDLE_PATTERN_SOURCE}`)
     .where(sql<boolean>`${sql.ref('runtime_slot')} ~ ${'^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$'}`)
     .where(sql<boolean>`char_length(${sql.ref('runtime_slot')}) <= 32`);
   if (selectedRuntimeSlot) {

--- a/packages/platform/src/computer-routes.ts
+++ b/packages/platform/src/computer-routes.ts
@@ -101,18 +101,23 @@ export function createComputerRoutes(opts: {
     }
 
     try {
-      const selectedSlot = identity.source === 'auth' ? identity.runtimeSlot ?? null : null;
+      const requestedSelectedSlot = identity.source === 'auth' ? identity.runtimeSlot ?? null : null;
       const records = await listUserRuntimeComputersByClerkId(
         opts.db,
         identity.userId,
         COMPUTER_QUERY_LIMIT,
-        selectedSlot ?? undefined,
+        requestedSelectedSlot ?? undefined,
       );
       const projected = records.flatMap((record) => {
         const computer = projectComputer(record);
         return computer ? [computer] : [];
       });
       const items = projected.slice(0, COMPUTER_LIST_LIMIT);
+      const selectedSlot = requestedSelectedSlot !== null && items.some(
+        (item) => item.runtimeSlot === requestedSelectedSlot,
+      )
+        ? requestedSelectedSlot
+        : null;
       const payload = MatrixComputerListSchema.parse({
         items,
         selectedSlot,

--- a/packages/platform/src/computer-routes.ts
+++ b/packages/platform/src/computer-routes.ts
@@ -1,0 +1,129 @@
+import {
+  MatrixComputerListSchema,
+  MatrixComputerSchema,
+  type MatrixComputer,
+  type MatrixComputerAvailability,
+  type MatrixComputerVersionLabel,
+} from '@matrix-os/contracts';
+import { Hono, type Context } from 'hono';
+
+import type { ClerkAuth } from './clerk-auth.js';
+import type { PlatformDB } from './db.js';
+import {
+  listUserRuntimeComputersByClerkId,
+  type UserRuntimeComputerRecord,
+} from './computer-repository.js';
+import { isPreviewMachine } from './customer-vps-preview.js';
+import {
+  resolveAppDomainIdentity,
+  type AppDomainIdentity,
+} from './session-routing-identity.js';
+
+const COMPUTER_LIST_LIMIT = 20;
+const COMPUTER_QUERY_LIMIT = COMPUTER_LIST_LIMIT + 1;
+const COMPUTER_CAPABILITIES = ['matrixComputerInventoryV1'] as const;
+const RELEASE_DATE_PATTERN = /^(?:v|matrix-os-host-)(\d{4}\.\d{2}\.\d{2})(?:$|-)/;
+
+function computerAvailability(status: string): MatrixComputerAvailability {
+  if (status === 'running') return 'available';
+  if (status === 'provisioning' || status === 'recovering' || status === 'resizing') return 'starting';
+  return 'unavailable';
+}
+
+function computerVersionLabel(imageVersion: string | null): MatrixComputerVersionLabel {
+  if (imageVersion === 'stable' || imageVersion === 'dev' || imageVersion === 'canary' || imageVersion === 'beta') {
+    return imageVersion;
+  }
+  const releaseDate = imageVersion?.match(RELEASE_DATE_PATTERN)?.[1];
+  return releaseDate ? `v${releaseDate}` as MatrixComputerVersionLabel : 'Version pending';
+}
+
+function projectComputer(machine: UserRuntimeComputerRecord): MatrixComputer | null {
+  const preview = isPreviewMachine(machine);
+  const parsed = MatrixComputerSchema.safeParse({
+    handle: machine.handle,
+    runtimeSlot: machine.runtimeSlot,
+    label: machine.runtimeSlot === 'primary'
+      ? 'Main Computer'
+      : preview
+        ? 'Preview Computer'
+        : 'Additional Computer',
+    availability: computerAvailability(machine.status),
+    kind: preview ? 'preview' : 'customer',
+    versionLabel: computerVersionLabel(machine.imageVersion),
+    gatewayPath: `/vm/${machine.handle}`,
+    capabilities: COMPUTER_CAPABILITIES,
+  });
+  return parsed.success ? parsed.data : null;
+}
+
+export function createComputerRoutes(opts: {
+  db: PlatformDB;
+  clerkAuth?: ClerkAuth;
+  platformJwtSecret: string;
+  legacyContainerRoutingEnabled: boolean;
+  resolveIdentity?: typeof resolveAppDomainIdentity;
+  applyNoStoreHeaders: (c: Context) => void;
+  logRouteError: (route: string, err: unknown) => void;
+}) {
+  const routes = new Hono();
+  const resolveIdentity = opts.resolveIdentity ?? resolveAppDomainIdentity;
+
+  routes.get('/api/auth/computers', async (c) => {
+    if (!opts.platformJwtSecret && !opts.clerkAuth) {
+      opts.applyNoStoreHeaders(c);
+      return c.json({ error: 'Computers unavailable' }, 503);
+    }
+
+    let identity: AppDomainIdentity | null;
+    try {
+      identity = await resolveIdentity({
+        authHeader: c.req.header('authorization'),
+        cookieHeader: c.req.header('cookie'),
+        clerkAuth: opts.clerkAuth,
+        db: opts.db,
+        platformJwtSecret: opts.platformJwtSecret,
+        allowUnroutedClerkIdentity: true,
+        legacyContainerRoutingEnabled: opts.legacyContainerRoutingEnabled,
+        runtimeSlot: 'primary',
+      });
+    } catch (err: unknown) {
+      opts.logRouteError('/api/auth/computers auth', err);
+      opts.applyNoStoreHeaders(c);
+      return c.json({ error: 'Computers unavailable' }, 503);
+    }
+    if (!identity) {
+      opts.applyNoStoreHeaders(c);
+      return c.json({ error: 'Unauthorized' }, 401);
+    }
+
+    try {
+      const selectedSlot = identity.source === 'auth' ? identity.runtimeSlot ?? null : null;
+      const records = await listUserRuntimeComputersByClerkId(
+        opts.db,
+        identity.userId,
+        COMPUTER_QUERY_LIMIT,
+        selectedSlot ?? undefined,
+      );
+      const projected = records.flatMap((record) => {
+        const computer = projectComputer(record);
+        return computer ? [computer] : [];
+      });
+      const items = projected.slice(0, COMPUTER_LIST_LIMIT);
+      const payload = MatrixComputerListSchema.parse({
+        items,
+        selectedSlot,
+        hasMore: projected.length > items.length,
+        limit: COMPUTER_LIST_LIMIT,
+      });
+      opts.applyNoStoreHeaders(c);
+      return c.json(payload);
+    } catch (err: unknown) {
+      opts.logRouteError('/api/auth/computers', err);
+      opts.applyNoStoreHeaders(c);
+      return c.json({ error: 'Computers unavailable' }, 503);
+    }
+  });
+
+  return routes;
+}

--- a/packages/platform/src/computer-routes.ts
+++ b/packages/platform/src/computer-routes.ts
@@ -51,7 +51,9 @@ function projectComputer(machine: UserRuntimeComputerRecord): MatrixComputer | n
     availability: computerAvailability(machine.status),
     kind: preview ? 'preview' : 'customer',
     versionLabel: computerVersionLabel(machine.imageVersion),
-    gatewayPath: `/vm/${machine.handle}`,
+    gatewayPath: machine.runtimeSlot === 'primary'
+      ? `/vm/${machine.handle}`
+      : `/vm/${machine.handle}?runtime=${machine.runtimeSlot}`,
     capabilities: COMPUTER_CAPABILITIES,
   });
   return parsed.success ? parsed.data : null;

--- a/packages/platform/src/computer-routes.ts
+++ b/packages/platform/src/computer-routes.ts
@@ -84,6 +84,7 @@ export function createComputerRoutes(opts: {
         db: opts.db,
         platformJwtSecret: opts.platformJwtSecret,
         allowUnroutedClerkIdentity: true,
+        clerkPrincipalOnly: true,
         legacyContainerRoutingEnabled: opts.legacyContainerRoutingEnabled,
         runtimeSlot: 'primary',
       });

--- a/packages/platform/src/main.ts
+++ b/packages/platform/src/main.ts
@@ -78,6 +78,7 @@ import { createLaunchReadinessRoutes } from './launch-readiness-routes.js';
 import { createHostBundleRoutes } from './host-bundle-routes.js';
 import { createLegacyContainerRoutes } from './legacy-container-routes.js';
 import { createAppSessionRoutes } from './app-session-routes.js';
+import { createComputerRoutes } from './computer-routes.js';
 import {
   HANDLE_PATTERN,
   describeError,
@@ -470,6 +471,15 @@ export function createApp(deps: {
       }),
     );
   }
+
+  app.route('/', createComputerRoutes({
+    db,
+    clerkAuth,
+    platformJwtSecret,
+    legacyContainerRoutingEnabled,
+    applyNoStoreHeaders,
+    logRouteError: logPlatformRouteError,
+  }));
 
   app.route('/', createAppSessionRoutes({
     db,

--- a/packages/platform/src/platform-route-utils.ts
+++ b/packages/platform/src/platform-route-utils.ts
@@ -3,7 +3,8 @@ import {
   type PlatformDB,
 } from './db.js';
 
-export const HANDLE_PATTERN = /^[a-z0-9][a-z0-9-]{1,62}$/;
+export const HANDLE_PATTERN_SOURCE = '^[a-z0-9][a-z0-9-]{1,62}$';
+export const HANDLE_PATTERN = new RegExp(HANDLE_PATTERN_SOURCE);
 
 export function logPlatformRouteError(route: string, err: unknown): void {
   console.error(

--- a/packages/platform/src/platform-route-utils.ts
+++ b/packages/platform/src/platform-route-utils.ts
@@ -3,7 +3,7 @@ import {
   type PlatformDB,
 } from './db.js';
 
-export const HANDLE_PATTERN = /^[a-z][a-z0-9-]{2,30}$/;
+export const HANDLE_PATTERN = /^[a-z0-9][a-z0-9-]{1,62}$/;
 
 export function logPlatformRouteError(route: string, err: unknown): void {
   console.error(

--- a/packages/platform/src/session-cookies.ts
+++ b/packages/platform/src/session-cookies.ts
@@ -8,6 +8,7 @@ export const CLERK_SESSION_COOKIE = '__session';
 export const CLERK_CLIENT_UAT_COOKIE = '__client_uat';
 export const APP_ROUTE_COOKIE = 'matrix_app_route';
 export const SHELL_ROUTE_COOKIE = 'matrix_shell_route';
+export const SHELL_RUNTIME_SLOT_COOKIE = 'matrix_shell_runtime_slot';
 export const CODE_SESSION_EXPIRES_IN_SEC = 12 * 60 * 60;
 export const NATIVE_APP_SESSION_PROXY_HEADER = 'x-matrix-native-app-session';
 export const PLATFORM_SESSION_PROXY_HEADER = 'x-matrix-platform-session';
@@ -115,6 +116,17 @@ export function buildClearShellRouteCookie(): string {
   ].join('; ');
 }
 
+export function buildClearShellRuntimeSlotCookie(): string {
+  return [
+    `${SHELL_RUNTIME_SLOT_COOKIE}=`,
+    'Path=/',
+    'HttpOnly',
+    'Secure',
+    'SameSite=Lax',
+    'Max-Age=0',
+  ].join('; ');
+}
+
 export function buildClearBrowserCookie(name: string, domain?: string): string {
   return [
     `${name}=`,
@@ -154,6 +166,7 @@ export function appendSignOutClearCookies(c: Context): void {
   c.header('Set-Cookie', buildClearAppSessionCookie(), { append: true });
   c.header('Set-Cookie', buildClearNativeAppSessionCookie(), { append: true });
   c.header('Set-Cookie', buildClearShellRouteCookie(), { append: true });
+  c.header('Set-Cookie', buildClearShellRuntimeSlotCookie(), { append: true });
   for (const name of clerkCookieClearNames(cookieHeader)) {
     c.header('Set-Cookie', buildClearBrowserCookie(name), { append: true });
     if (domain) {

--- a/packages/platform/src/session-routing-identity.ts
+++ b/packages/platform/src/session-routing-identity.ts
@@ -145,6 +145,7 @@ export async function resolveAppDomainIdentity(opts: {
   db: PlatformDB;
   platformJwtSecret: string;
   allowUnroutedClerkIdentity?: boolean;
+  clerkPrincipalOnly?: boolean;
   legacyContainerRoutingEnabled?: boolean;
   requestedHandle?: string | null;
   runtimeSlot: string;
@@ -221,6 +222,13 @@ export async function resolveAppDomainIdentity(opts: {
   const result = await opts.clerkAuth.verify(token);
   if (!result.authenticated || !result.userId) {
     return null;
+  }
+
+  if (opts.clerkPrincipalOnly) {
+    return {
+      handle: '',
+      userId: result.userId,
+    };
   }
 
   if (opts.requestedHandle) {

--- a/packages/platform/src/session-routing-identity.ts
+++ b/packages/platform/src/session-routing-identity.ts
@@ -124,8 +124,8 @@ export function readShellRuntimeSlotCookie(path: string, cookieHeader: string | 
 }
 
 export function readExplicitVmRoute(path: string): ExplicitVmRoute | null {
-  const match = path.match(/^\/vm\/([a-z][a-z0-9-]{2,30})(?:\/(.*))?$/);
-  if (!match?.[1]) return null;
+  const match = path.match(/^\/vm\/([^/]+)(?:\/(.*))?$/);
+  if (!match?.[1] || !HANDLE_PATTERN.test(match[1])) return null;
   const rest = match[2];
   return {
     handle: match[1],

--- a/packages/platform/src/session-routing-identity.ts
+++ b/packages/platform/src/session-routing-identity.ts
@@ -16,6 +16,7 @@ import {
   CODE_SESSION_COOKIE,
   NATIVE_APP_SESSION_COOKIE,
   SHELL_ROUTE_COOKIE,
+  SHELL_RUNTIME_SLOT_COOKIE,
   isValidNativeAppSessionProof,
   readCookie,
 } from './session-cookies.js';
@@ -100,6 +101,26 @@ export function buildShellRouteCookie(handle: string): string {
     'SameSite=Lax',
     'Max-Age=600',
   ].join('; ');
+}
+
+export function buildShellRuntimeSlotCookie(runtimeSlot: string): string {
+  return [
+    `${SHELL_RUNTIME_SLOT_COOKIE}=${encodeURIComponent(runtimeSlot)}`,
+    'Path=/',
+    'HttpOnly',
+    'Secure',
+    'SameSite=Lax',
+    'Max-Age=600',
+  ].join('; ');
+}
+
+export function readShellRuntimeSlotCookie(path: string, cookieHeader: string | undefined): string | null {
+  if (!isAppDomainGatewayPath(path) && !isAppDomainStaticAssetPath(path)) {
+    return null;
+  }
+  const runtimeSlot = readCookie(cookieHeader, SHELL_RUNTIME_SLOT_COOKIE);
+  const parsed = RuntimeSlotSchema.safeParse(runtimeSlot);
+  return parsed.success ? parsed.data : null;
 }
 
 export function readExplicitVmRoute(path: string): ExplicitVmRoute | null {
@@ -232,7 +253,14 @@ export async function resolveAppDomainIdentity(opts: {
   }
 
   if (opts.requestedHandle) {
-    const requestedMachine = await getActiveUserMachineByHandle(opts.db, opts.requestedHandle);
+    let requestedMachine = await getActiveUserMachineByHandle(
+      opts.db,
+      opts.requestedHandle,
+      opts.runtimeSlot,
+    );
+    if (!requestedMachine && opts.runtimeSlot === 'primary') {
+      requestedMachine = await getActiveUserMachineByHandle(opts.db, opts.requestedHandle);
+    }
     if (requestedMachine && requestedMachine.clerkUserId === result.userId) {
       return {
         handle: requestedMachine.handle,

--- a/packages/platform/src/session-routing-identity.ts
+++ b/packages/platform/src/session-routing-identity.ts
@@ -191,6 +191,17 @@ export async function resolveAppDomainIdentity(opts: {
           }
         }
       }
+      const runtimeSlot = RuntimeSlotSchema.safeParse(claims.runtime_slot).success
+        ? claims.runtime_slot
+        : undefined;
+      if (opts.clerkPrincipalOnly) {
+        return {
+          handle: claims.handle,
+          userId: claims.sub,
+          runtimeSlot,
+          source: 'auth',
+        };
+      }
       const record = opts.legacyContainerRoutingEnabled === false
         ? undefined
         : await getContainer(opts.db, claims.handle);
@@ -201,9 +212,6 @@ export async function resolveAppDomainIdentity(opts: {
           source: 'auth',
         };
       }
-      const runtimeSlot = RuntimeSlotSchema.safeParse(claims.runtime_slot).success
-        ? claims.runtime_slot
-        : undefined;
       const machine = await getRunningUserMachineByHandle(opts.db, claims.handle, runtimeSlot);
       if (machine?.clerkUserId === claims.sub) {
         return {

--- a/packages/platform/src/session-routing-middleware.ts
+++ b/packages/platform/src/session-routing-middleware.ts
@@ -249,6 +249,7 @@ export function createSessionRoutingMiddleware(opts: CreateSessionRoutingMiddlew
       reqPath.startsWith('/auth/device/') ||
       reqPath.startsWith('/api/auth/device/') ||
       reqPath === '/api/auth/app-session' ||
+      reqPath === '/api/auth/computers' ||
       reqPath === '/api/auth/provision-runtime' ||
       reqPath === '/api/journey' ||
       reqPath === '/api/journey/retry-provision'

--- a/packages/platform/src/session-routing-middleware.ts
+++ b/packages/platform/src/session-routing-middleware.ts
@@ -449,7 +449,11 @@ export function createSessionRoutingMiddleware(opts: CreateSessionRoutingMiddlew
         applyNoStoreHeaders(c);
         return c.text('Unauthorized', 401);
       }
-      const machine = await getActiveUserMachineByHandle(db, explicitVmRoute.handle);
+      const machine = await getActiveUserMachineByHandle(
+        db,
+        explicitVmRoute.handle,
+        runtimeSelection.source === 'query' ? requestRuntimeSlot : undefined,
+      );
       if (!machine || (identity.userId && machine.clerkUserId !== identity.userId)) {
         applyNoStoreHeaders(c);
         return c.text('Matrix OS computer unavailable', 404);

--- a/packages/platform/src/session-routing-middleware.ts
+++ b/packages/platform/src/session-routing-middleware.ts
@@ -544,6 +544,7 @@ export function createSessionRoutingMiddleware(opts: CreateSessionRoutingMiddlew
           responseHeaders,
           path: explicitVmRoute.upstreamPath,
           handle: machine.handle,
+          runtimeSlot: machine.runtimeSlot,
           platformSecret,
           assetRouteToken: readAppAssetRouteToken(c.req.url),
         });
@@ -734,6 +735,7 @@ export function createSessionRoutingMiddleware(opts: CreateSessionRoutingMiddlew
             responseHeaders,
             path,
             handle: runningMachine.handle,
+            runtimeSlot: runningMachine.runtimeSlot,
             platformSecret,
             assetRouteToken: readAppAssetRouteToken(c.req.url),
           });
@@ -914,6 +916,7 @@ export function createSessionRoutingMiddleware(opts: CreateSessionRoutingMiddlew
             responseHeaders,
             path,
             handle: record.handle,
+            runtimeSlot: 'primary',
             platformSecret,
             assetRouteToken: readAppAssetRouteToken(c.req.url),
           });

--- a/packages/platform/src/session-routing-middleware.ts
+++ b/packages/platform/src/session-routing-middleware.ts
@@ -77,11 +77,13 @@ import {
 import {
   buildAppRouteCookie,
   buildShellRouteCookie,
+  buildShellRuntimeSlotCookie,
   readAppDomainRouteCookie,
   readExplicitVmRoute,
   readMobileAppRouteCookie,
   readMobileAppSessionRoutingHandle,
   readShellRouteCookie,
+  readShellRuntimeSlotCookie,
   resolveAppDomainIdentity,
   shouldMarkNativeAppSession,
 } from './session-routing-identity.js';
@@ -337,7 +339,12 @@ export function createSessionRoutingMiddleware(opts: CreateSessionRoutingMiddlew
       }),
     );
     const runtimeSelection = readRuntimeSlotSelection(c.req.url);
-    const requestRuntimeSlot = runtimeSelection.slot;
+    const cookieRuntimeSlot = isAppDomain
+      ? readShellRuntimeSlotCookie(path, cookieHeader)
+      : null;
+    const requestRuntimeSlot = runtimeSelection.source === 'query'
+      ? runtimeSelection.slot
+      : cookieRuntimeSlot ?? runtimeSelection.slot;
     let singleMachineRuntimeSlot: string | null = null;
 
     const isGatewayPath = isAppDomain && isAppDomainGatewayPath(path);
@@ -531,6 +538,7 @@ export function createSessionRoutingMiddleware(opts: CreateSessionRoutingMiddlew
         applySandboxedAppAssetCorsHeaders(responseHeaders, explicitVmRoute.upstreamPath, c.req.header('origin'));
         applyAppDomainRuntimeAssetCacheHeaders(responseHeaders, explicitVmRoute.upstreamPath, c.req.url);
         responseHeaders.append('set-cookie', buildShellRouteCookie(machine.handle));
+        responseHeaders.append('set-cookie', buildShellRuntimeSlotCookie(machine.runtimeSlot));
         return await buildAppDomainProxyResponse({
           upstream,
           responseHeaders,
@@ -706,6 +714,7 @@ export function createSessionRoutingMiddleware(opts: CreateSessionRoutingMiddlew
         }
         if (isAppDomain && identity.source !== 'static-route') {
           responseHeaders.append('set-cookie', buildShellRouteCookie(runningMachine.handle));
+          responseHeaders.append('set-cookie', buildShellRuntimeSlotCookie(runningMachine.runtimeSlot));
         }
         if (isCodeDomain && platformJwtSecret) {
           const issued = await issueSyncJwt({
@@ -886,6 +895,7 @@ export function createSessionRoutingMiddleware(opts: CreateSessionRoutingMiddlew
         }
         if (isAppDomain && identity.source !== 'static-route') {
           responseHeaders.append('set-cookie', buildShellRouteCookie(record.handle));
+          responseHeaders.append('set-cookie', buildShellRuntimeSlotCookie('primary'));
         }
         if (isCodeDomain && platformJwtSecret) {
           const issued = await issueSyncJwt({

--- a/packages/platform/src/session-routing-proxy.ts
+++ b/packages/platform/src/session-routing-proxy.ts
@@ -1,8 +1,10 @@
 import { createHmac } from 'node:crypto';
+import { z } from 'zod/v4';
 import {
   NATIVE_APP_SESSION_PROXY_HEADER,
   PLATFORM_SESSION_PROXY_HEADER,
 } from './session-cookies.js';
+import { RuntimeSlotSchema } from './customer-vps-schema.js';
 import { timingSafeTokenEquals } from './platform-token.js';
 
 export const EDGE_SECRET_HEADER = 'x-matrix-edge-secret';
@@ -115,10 +117,15 @@ export function hasValidExplicitVmAppAssetToken(input: {
   if (!slug) return false;
   try {
     const url = new URL(input.rawUrl, 'https://app.matrix-os.com');
+    const runtimeParam = url.searchParams.get('runtime');
+    if (runtimeParam !== null && !RuntimeSlotSchema.safeParse(runtimeParam).success) {
+      return false;
+    }
     return verifyAppAssetRouteToken({
       token: url.searchParams.get(APP_ASSET_ROUTE_TOKEN_PARAM),
       expectedHandle: input.route.handle,
       expectedSlug: slug,
+      expectedRuntimeSlot: runtimeParam ?? 'primary',
       platformSecret: input.platformSecret,
     });
   } catch (err: unknown) {
@@ -132,11 +139,14 @@ function getViteAppHtmlSlug(path: string): string | null {
   return match?.[1] ?? null;
 }
 
-interface AppAssetRouteTokenPayload {
-  v: 1;
-  handle: string;
-  slug: string;
-}
+const AppAssetRouteTokenPayloadSchema = z.object({
+  v: z.literal(1),
+  handle: z.string().min(1).max(64),
+  slug: z.string().regex(/^[a-z0-9][a-z0-9-]{0,63}$/),
+  runtimeSlot: RuntimeSlotSchema.optional(),
+}).strict();
+
+type AppAssetRouteTokenPayload = z.infer<typeof AppAssetRouteTokenPayloadSchema>;
 
 function signAppAssetRouteToken(
   payload: AppAssetRouteTokenPayload,
@@ -152,6 +162,7 @@ function signAppAssetRouteToken(
 function buildAppAssetRouteToken(
   handle: string,
   slug: string,
+  runtimeSlot: string,
   platformSecret: string,
 ): string {
   // Vite can lazy-load chunks long after initial HTML render, and browser
@@ -161,6 +172,7 @@ function buildAppAssetRouteToken(
     v: 1,
     handle,
     slug,
+    runtimeSlot,
   }, platformSecret);
 }
 
@@ -168,6 +180,7 @@ export function verifyAppAssetRouteToken(input: {
   token: string | null;
   expectedHandle: string;
   expectedSlug: string;
+  expectedRuntimeSlot: string;
   platformSecret: string;
 }): boolean {
   if (!input.token || !input.platformSecret) return false;
@@ -179,11 +192,17 @@ export function verifyAppAssetRouteToken(input: {
   if (!timingSafeTokenEquals(signature, expectedSignature)) return false;
 
   try {
-    const parsed = JSON.parse(Buffer.from(encodedPayload, 'base64url').toString('utf8')) as Partial<AppAssetRouteTokenPayload>;
+    const parsed = AppAssetRouteTokenPayloadSchema.safeParse(
+      JSON.parse(Buffer.from(encodedPayload, 'base64url').toString('utf8')),
+    );
+    if (!parsed.success) return false;
     return (
-      parsed.v === 1 &&
-      parsed.handle === input.expectedHandle &&
-      parsed.slug === input.expectedSlug
+      parsed.data.handle === input.expectedHandle &&
+      parsed.data.slug === input.expectedSlug &&
+      (
+        parsed.data.runtimeSlot === input.expectedRuntimeSlot ||
+        (parsed.data.runtimeSlot === undefined && input.expectedRuntimeSlot === 'primary')
+      )
     );
   } catch (err: unknown) {
     console.warn('[platform] Failed to parse app asset route token:', err instanceof Error ? err.message : String(err));
@@ -209,15 +228,31 @@ export function readAppAssetRouteToken(rawUrl: string): string | null {
   }
 }
 
+function addAppAssetRouteParams(path: string, runtimeSlot: string, assetToken: string): string {
+  const hashStart = path.indexOf('#');
+  const pathAndQuery = hashStart === -1 ? path : path.slice(0, hashStart);
+  const hash = hashStart === -1 ? '' : path.slice(hashStart);
+  const queryStart = pathAndQuery.indexOf('?');
+  const pathname = queryStart === -1 ? pathAndQuery : pathAndQuery.slice(0, queryStart);
+  const params = new URLSearchParams(queryStart === -1 ? '' : pathAndQuery.slice(queryStart + 1));
+  params.delete('runtime');
+  if (runtimeSlot !== 'primary') {
+    params.set('runtime', runtimeSlot);
+  }
+  params.set(APP_ASSET_ROUTE_TOKEN_PARAM, assetToken);
+  return `${pathname}?${params.toString()}${hash}`;
+}
+
 function rewriteSandboxedViteAppAssetUrls(
   html: string,
   handle: string,
   path: string,
+  runtimeSlot: string,
   platformSecret: string,
 ): string {
   const slug = getViteAppHtmlSlug(path);
   if (!slug || !platformSecret) return html;
-  const assetToken = buildAppAssetRouteToken(handle, slug, platformSecret);
+  const assetToken = buildAppAssetRouteToken(handle, slug, runtimeSlot, platformSecret);
   const appAssetPrefix = `/apps/${slug}/assets/`;
   const rewriteTag = (tag: string): string => tag.replace(
     /\b(src|href)=(["'])([^"']+)\2/g,
@@ -228,9 +263,9 @@ function rewriteSandboxedViteAppAssetUrls(
           ? value.slice(appAssetPrefix.length)
           : null;
       if (!assetRemainder) return match;
-      const explicitAssetPath = appendQueryParamToPath(
+      const explicitAssetPath = addAppAssetRouteParams(
         `/vm/${handle}/apps/${slug}/assets/${assetRemainder}`,
-        APP_ASSET_ROUTE_TOKEN_PARAM,
+        runtimeSlot,
         assetToken,
       );
       return `${attr}=${quote}${explicitAssetPath}${quote}`;
@@ -269,13 +304,16 @@ function rewriteSandboxedViteAppAssetUrls(
   return rewritten;
 }
 
-function rewriteSandboxedViteJsAssetImports(js: string, assetToken: string | null): string {
+function rewriteSandboxedViteJsAssetImports(
+  js: string,
+  runtimeSlot: string,
+  assetToken: string | null,
+): string {
   if (!assetToken) return js;
   return js.replace(
     /((?:\bimport\s*\(\s*)|(?:\bimport\s*)|(?:\b(?:import|export)[^"']*?\bfrom\s*))(["'])(\.\/[^"']+\.(?:js|css)(?:\?[^"'#]*)?(?:#[^"']*)?)\2/g,
-    (match: string, prefix: string, quote: string, value: string) => {
-      if (value.includes(`${APP_ASSET_ROUTE_TOKEN_PARAM}=`)) return match;
-      return `${prefix}${quote}${appendQueryParamToPath(value, APP_ASSET_ROUTE_TOKEN_PARAM, assetToken)}${quote}`;
+    (_match: string, prefix: string, quote: string, value: string) => {
+      return `${prefix}${quote}${addAppAssetRouteParams(value, runtimeSlot, assetToken)}${quote}`;
     },
   );
 }
@@ -285,13 +323,20 @@ export async function buildAppDomainProxyResponse(input: {
   responseHeaders: Headers;
   path: string;
   handle: string;
+  runtimeSlot: string;
   platformSecret: string;
   assetRouteToken?: string | null;
 }): Promise<Response> {
   if (getViteAppHtmlSlug(input.path) && input.responseHeaders.get('content-type')?.includes('text/html')) {
     const html = await input.upstream.text();
     input.responseHeaders.delete('content-length');
-    return new Response(rewriteSandboxedViteAppAssetUrls(html, input.handle, input.path, input.platformSecret), {
+    return new Response(rewriteSandboxedViteAppAssetUrls(
+      html,
+      input.handle,
+      input.path,
+      input.runtimeSlot,
+      input.platformSecret,
+    ), {
       status: input.upstream.status,
       headers: input.responseHeaders,
     });
@@ -303,7 +348,7 @@ export async function buildAppDomainProxyResponse(input: {
   ) {
     const js = await input.upstream.text();
     input.responseHeaders.delete('content-length');
-    return new Response(rewriteSandboxedViteJsAssetImports(js, input.assetRouteToken), {
+    return new Response(rewriteSandboxedViteJsAssetImports(js, input.runtimeSlot, input.assetRouteToken), {
       status: input.upstream.status,
       headers: input.responseHeaders,
     });

--- a/packages/platform/src/session-routing-proxy.ts
+++ b/packages/platform/src/session-routing-proxy.ts
@@ -318,6 +318,29 @@ function rewriteSandboxedViteJsAssetImports(
   );
 }
 
+function rewriteSandboxedViteCssAssetUrls(
+  css: string,
+  runtimeSlot: string,
+  assetToken: string | null,
+): string {
+  if (!assetToken) return css;
+  const withImports = css.replace(
+    /(@import\s+)(["'])(\.\/[^"']+)\2/gi,
+    (_match: string, prefix: string, quote: string, value: string) => {
+      return `${prefix}${quote}${addAppAssetRouteParams(value, runtimeSlot, assetToken)}${quote}`;
+    },
+  );
+  return withImports.replace(
+    /\burl\(\s*(?:(["'])(\.\/[^"']+)\1|(\.\/[^)\s]+))\s*\)/gi,
+    (_match: string, quote: string | undefined, quotedValue: string | undefined, unquotedValue: string | undefined) => {
+      const value = quotedValue ?? unquotedValue;
+      if (!value) return _match;
+      const rewritten = addAppAssetRouteParams(value, runtimeSlot, assetToken);
+      return `url(${quote ?? ''}${rewritten}${quote ?? ''})`;
+    },
+  );
+}
+
 export async function buildAppDomainProxyResponse(input: {
   upstream: Response;
   responseHeaders: Headers;
@@ -349,6 +372,18 @@ export async function buildAppDomainProxyResponse(input: {
     const js = await input.upstream.text();
     input.responseHeaders.delete('content-length');
     return new Response(rewriteSandboxedViteJsAssetImports(js, input.runtimeSlot, input.assetRouteToken), {
+      status: input.upstream.status,
+      headers: input.responseHeaders,
+    });
+  }
+  if (
+    getViteAppAssetSlug(input.path) &&
+    input.assetRouteToken &&
+    input.responseHeaders.get('content-type')?.includes('text/css')
+  ) {
+    const css = await input.upstream.text();
+    input.responseHeaders.delete('content-length');
+    return new Response(rewriteSandboxedViteCssAssetUrls(css, input.runtimeSlot, input.assetRouteToken), {
       status: input.upstream.status,
       headers: input.responseHeaders,
     });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -695,6 +695,9 @@ importers:
       '@matrix-os/clerk-sync':
         specifier: workspace:*
         version: link:../clerk-sync
+      '@matrix-os/contracts':
+        specifier: workspace:*
+        version: link:../contracts
       '@matrix-os/observability':
         specifier: workspace:*
         version: link:../observability

--- a/specs/105-coding-agent-shells/current-state.md
+++ b/specs/105-coding-agent-shells/current-state.md
@@ -64,6 +64,13 @@ native/sync principals use the same owner-scoped projection. Desktop runtime
 credential exchange remains native/sync-authenticated and main-process-only;
 mobile uses validated same-origin routing and does not persist runtime bearers.
 
+The backend stack now implements that read route with a SQL-bounded owner query,
+strict shared response validation, fixed safe labels, coarse release labels,
+and no-store generic failures. Plain Clerk sessions do not imply a selected
+runtime; only a verified native/sync principal bound back to its current owner
+machine can publish `selectedSlot`. The paused desktop and mobile branches still
+need to adopt this shared route after the trusted selection slice lands.
+
 The existing Platform Preview and Preview VPS workflows do not yet form one
 isolated authority. The target preview environment owns a dedicated preview
 database/JWT/edge/provisioning/provider boundary, exact PR/head/bundle,

--- a/specs/105-coding-agent-shells/tasks.md
+++ b/specs/105-coding-agent-shells/tasks.md
@@ -1257,7 +1257,7 @@ agents depend on new fields.
 
 - [x] B24-001 Product owner confirms the scope/non-goals in `FULL-WORKSPACE-BACKEND.md`.
 - [x] B24-002 Write failing shared contract tests for bounded `MatrixComputerListSchema`, authoritative selection, derived gateway paths, and forbidden machine/operator fields in `tests/contracts/runtime-computers.test.ts`.
-- [ ] B24-003 Implement one canonical `GET /api/auth/computers` contract/route for server-verified Clerk and native/sync principals; remove duplicate desktop read shape or document a bounded expiring alias.
+- [x] B24-003 Implement one canonical `GET /api/auth/computers` contract/route for server-verified Clerk and native/sync principals; remove duplicate desktop read shape or document a bounded expiring alias.
 - [ ] B24-004 Preserve trusted-main-only `POST /api/auth/runtime-selection` bearer replacement while mobile continues authenticated same-origin platform/session routing.
 - [ ] B24-005 Write failing auth tests, then add a bounded server-verified native identity projection for shell display fallback without trusting client headers.
 - [ ] B24-006 Rebase/preserve current native Linux app streaming and capability routing when composing the canonical platform candidate.

--- a/tests/platform/computer-inventory-routes.test.ts
+++ b/tests/platform/computer-inventory-routes.test.ts
@@ -273,6 +273,16 @@ describe("canonical computer inventory route", () => {
       platformSecret: "platform-secret-123",
     });
 
+    const inventoryResponse = await app.request("/api/auth/computers", {
+      headers: {
+        host: "app.matrix-os.com",
+        authorization: "Bearer clerk-session",
+      },
+    });
+    expect(inventoryResponse.status).toBe(200);
+    const inventory = MatrixComputerListSchema.parse(await inventoryResponse.json());
+    expect(inventory.items.map((item) => item.handle)).toContain(handle);
+
     const response = await app.request(`/vm/${handle}/projects`, {
       headers: {
         host: "app.matrix-os.com",

--- a/tests/platform/computer-inventory-routes.test.ts
+++ b/tests/platform/computer-inventory-routes.test.ts
@@ -199,15 +199,17 @@ describe("canonical computer inventory route", () => {
   });
 
   it("quarantines a malformed persisted provisioning class without hiding valid computers", async () => {
+    process.env.MATRIX_LEGACY_CONTAINER_ROUTING_ENABLED = "false";
     await insertMachine(db, {
-      handle: "alice-primary",
-      runtimeSlot: "primary",
+      handle: "alice-review",
+      runtimeSlot: "review",
       imageVersion: "stable",
     });
     await insertMachine(db, {
       handle: "alice-corrupt",
-      runtimeSlot: "corrupt",
+      runtimeSlot: "primary",
       imageVersion: "stable",
+      provisionedAt: "2026-07-11T01:00:00.000Z",
     });
     await sql`UPDATE user_machines SET provisioning_class = 'operator-data' WHERE handle = 'alice-corrupt'`
       .execute(db.executor);
@@ -229,7 +231,7 @@ describe("canonical computer inventory route", () => {
 
     expect(response.status).toBe(200);
     const body = MatrixComputerListSchema.parse(await response.json());
-    expect(body.items.map((item) => item.handle)).toEqual(["alice-primary"]);
+    expect(body.items.map((item) => item.handle)).toEqual(["alice-review"]);
     expect(JSON.stringify(body)).not.toContain("operator-data");
   });
 

--- a/tests/platform/computer-inventory-routes.test.ts
+++ b/tests/platform/computer-inventory-routes.test.ts
@@ -19,6 +19,7 @@ import {
 async function insertMachine(
   db: PlatformDB,
   input: {
+    machineId?: string;
     clerkUserId?: string;
     handle: string;
     runtimeSlot: string;
@@ -26,17 +27,18 @@ async function insertMachine(
     imageVersion?: string | null;
     provisioningClass?: "customer" | "preview";
     provisionedAt?: string;
+    publicIPv4?: string;
   },
 ): Promise<void> {
   await insertUserMachine(db, {
-    machineId: `machine-${input.handle}`,
+    machineId: input.machineId ?? `machine-${input.handle}`,
     clerkUserId: input.clerkUserId ?? "user_alice",
     handle: input.handle,
     runtimeSlot: input.runtimeSlot,
     status: input.status ?? "running",
     provisioningClass: input.provisioningClass,
     hetznerServerId: 100,
-    publicIPv4: "203.0.113.10",
+    publicIPv4: input.publicIPv4 ?? "203.0.113.10",
     imageVersion: input.imageVersion,
     serverType: "cpx22",
     provisionedAt: input.provisionedAt ?? "2026-07-11T00:00:00.000Z",
@@ -138,7 +140,7 @@ describe("canonical computer inventory route", () => {
           availability: "unavailable",
           kind: "customer",
           versionLabel: "Version pending",
-          gatewayPath: "/vm/alice-review",
+          gatewayPath: "/vm/alice-review?runtime=review",
           capabilities: ["matrixComputerInventoryV1"],
         },
         {
@@ -148,7 +150,7 @@ describe("canonical computer inventory route", () => {
           availability: "starting",
           kind: "preview",
           versionLabel: "v2026.07.10",
-          gatewayPath: "/vm/pr-921",
+          gatewayPath: "/vm/pr-921?runtime=pr-921",
           capabilities: ["matrixComputerInventoryV1"],
         },
       ],
@@ -196,6 +198,42 @@ describe("canonical computer inventory route", () => {
     expect(body.selectedSlot).toBe("review");
     expect(body.items.map((item) => item.handle)).toContain("alice-review");
     expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("routes a slot-qualified computer path to the matching shared-handle runtime", async () => {
+    await insertMachine(db, {
+      machineId: "machine-shared-primary",
+      handle: "alice-shared",
+      runtimeSlot: "primary",
+      publicIPv4: "203.0.113.20",
+    });
+    await insertMachine(db, {
+      machineId: "machine-shared-review",
+      handle: "alice-shared",
+      runtimeSlot: "review",
+      publicIPv4: "203.0.113.21",
+    });
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response("review", { status: 200 }),
+    );
+    const app = createApp({
+      db,
+      orchestrator: stubOrchestrator(),
+      clerkAuth: createClerkAuth({
+        verifyToken: vi.fn().mockResolvedValue({ sub: "user_alice" }),
+      }),
+      platformSecret: "platform-secret-123",
+    });
+
+    const response = await app.request("/vm/alice-shared/projects?runtime=review", {
+      headers: {
+        host: "app.matrix-os.com",
+        authorization: "Bearer clerk-session",
+      },
+    });
+
+    expect(response.status).toBe(200);
+    expect(fetchMock.mock.calls[0]?.[0]).toBe("https://203.0.113.21:443/projects");
   });
 
   it("quarantines a malformed persisted provisioning class without hiding valid computers", async () => {

--- a/tests/platform/computer-inventory-routes.test.ts
+++ b/tests/platform/computer-inventory-routes.test.ts
@@ -290,6 +290,50 @@ describe("canonical computer inventory route", () => {
     expect(JSON.stringify(body)).not.toContain("operator-data");
   });
 
+  it("quarantines a malformed selected machine for a verified native principal", async () => {
+    process.env.PLATFORM_JWT_SECRET = JWT_SECRET;
+    process.env.MATRIX_LEGACY_CONTAINER_ROUTING_ENABLED = "false";
+    await insertMachine(db, {
+      handle: "alice-review",
+      runtimeSlot: "review",
+      imageVersion: "stable",
+    });
+    await insertMachine(db, {
+      handle: "alice-corrupt",
+      runtimeSlot: "primary",
+      imageVersion: "stable",
+      provisionedAt: "2026-07-11T01:00:00.000Z",
+    });
+    await sql`UPDATE user_machines SET provisioning_class = 'operator-data' WHERE handle = 'alice-corrupt'`
+      .execute(db.executor);
+    const issued = await issueSyncJwt({
+      secret: JWT_SECRET,
+      clerkUserId: "user_alice",
+      handle: "alice-corrupt",
+      gatewayUrl: "https://app.matrix-os.com/vm/alice-corrupt",
+      runtimeSlot: "primary",
+    });
+    const app = createApp({
+      db,
+      orchestrator: stubOrchestrator(),
+      clerkAuth: createClerkAuth({ verifyToken: vi.fn().mockResolvedValue(null) }),
+      platformSecret: "platform-secret-123",
+    });
+
+    const response = await app.request("/api/auth/computers", {
+      headers: {
+        host: "app.matrix-os.com",
+        authorization: `Bearer ${issued.token}`,
+      },
+    });
+
+    expect(response.status).toBe(200);
+    const body = MatrixComputerListSchema.parse(await response.json());
+    expect(body.selectedSlot).toBeNull();
+    expect(body.items.map((item) => item.handle)).toEqual(["alice-review"]);
+    expect(JSON.stringify(body)).not.toContain("operator-data");
+  });
+
   it("caps inventory at twenty records and reports remaining rows", async () => {
     for (let index = 0; index < 21; index += 1) {
       await insertMachine(db, {

--- a/tests/platform/computer-inventory-routes.test.ts
+++ b/tests/platform/computer-inventory-routes.test.ts
@@ -253,6 +253,37 @@ describe("canonical computer inventory route", () => {
     expect(fetchMock.mock.calls[0]?.[0]).toBe("https://203.0.113.21:443/api/projects");
   });
 
+  it("routes an existing long platform-provisioned computer handle", async () => {
+    const handle = `a${"1".repeat(60)}`;
+    await insertMachine(db, {
+      machineId: "machine-long-handle",
+      handle,
+      runtimeSlot: "primary",
+      publicIPv4: "203.0.113.22",
+    });
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response("long handle", { status: 200 }),
+    );
+    const app = createApp({
+      db,
+      orchestrator: stubOrchestrator(),
+      clerkAuth: createClerkAuth({
+        verifyToken: vi.fn().mockResolvedValue({ sub: "user_alice" }),
+      }),
+      platformSecret: "platform-secret-123",
+    });
+
+    const response = await app.request(`/vm/${handle}/projects`, {
+      headers: {
+        host: "app.matrix-os.com",
+        authorization: "Bearer clerk-session",
+      },
+    });
+
+    expect(response.status).toBe(200);
+    expect(fetchMock.mock.calls[0]?.[0]).toBe("https://203.0.113.22:443/projects");
+  });
+
   it("quarantines a malformed persisted provisioning class without hiding valid computers", async () => {
     process.env.MATRIX_LEGACY_CONTAINER_ROUTING_ENABLED = "false";
     await insertMachine(db, {

--- a/tests/platform/computer-inventory-routes.test.ts
+++ b/tests/platform/computer-inventory-routes.test.ts
@@ -234,6 +234,23 @@ describe("canonical computer inventory route", () => {
 
     expect(response.status).toBe(200);
     expect(fetchMock.mock.calls[0]?.[0]).toBe("https://203.0.113.21:443/projects");
+    const setCookie = response.headers.get("set-cookie") ?? "";
+    const handleCookie = setCookie.match(/matrix_shell_route=([^;,]+)/)?.[1];
+    const slotCookie = setCookie.match(/matrix_shell_runtime_slot=([^;,]+)/)?.[1];
+    expect(handleCookie).toBe("alice-shared");
+    expect(slotCookie).toBe("review");
+
+    fetchMock.mockClear();
+    const followUp = await app.request("/api/projects", {
+      headers: {
+        host: "app.matrix-os.com",
+        authorization: "Bearer clerk-session",
+        cookie: `matrix_shell_route=${handleCookie}; matrix_shell_runtime_slot=${slotCookie}`,
+      },
+    });
+
+    expect(followUp.status).toBe(200);
+    expect(fetchMock.mock.calls[0]?.[0]).toBe("https://203.0.113.21:443/api/projects");
   });
 
   it("quarantines a malformed persisted provisioning class without hiding valid computers", async () => {

--- a/tests/platform/computer-inventory-routes.test.ts
+++ b/tests/platform/computer-inventory-routes.test.ts
@@ -1,0 +1,324 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { sql } from "kysely";
+
+import { MatrixComputerListSchema } from "@matrix-os/contracts";
+import { createClerkAuth } from "../../packages/platform/src/clerk-auth.js";
+import {
+  type PlatformDB,
+  insertUserMachine,
+} from "../../packages/platform/src/db.js";
+import { createApp } from "../../packages/platform/src/main.js";
+import { issueSyncJwt } from "../../packages/platform/src/sync-jwt.js";
+import {
+  JWT_SECRET,
+  cleanupProxyRoutingTest,
+  setupProxyRoutingTest,
+  stubOrchestrator,
+} from "./proxy-routing-test-utils.js";
+
+async function insertMachine(
+  db: PlatformDB,
+  input: {
+    clerkUserId?: string;
+    handle: string;
+    runtimeSlot: string;
+    status?: string;
+    imageVersion?: string | null;
+    provisioningClass?: "customer" | "preview";
+    provisionedAt?: string;
+  },
+): Promise<void> {
+  await insertUserMachine(db, {
+    machineId: `machine-${input.handle}`,
+    clerkUserId: input.clerkUserId ?? "user_alice",
+    handle: input.handle,
+    runtimeSlot: input.runtimeSlot,
+    status: input.status ?? "running",
+    provisioningClass: input.provisioningClass,
+    hetznerServerId: 100,
+    publicIPv4: "203.0.113.10",
+    imageVersion: input.imageVersion,
+    serverType: "cpx22",
+    provisionedAt: input.provisionedAt ?? "2026-07-11T00:00:00.000Z",
+  });
+}
+
+describe("canonical computer inventory route", () => {
+  let db: PlatformDB;
+
+  beforeEach(async () => {
+    db = await setupProxyRoutingTest();
+  });
+
+  afterEach(async () => {
+    await cleanupProxyRoutingTest(db);
+  });
+
+  it("authenticates before listing any computer", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response("wrong target", { status: 200 }),
+    );
+    const app = createApp({
+      db,
+      orchestrator: stubOrchestrator(),
+      clerkAuth: createClerkAuth({ verifyToken: vi.fn().mockResolvedValue(null) }),
+      platformSecret: "platform-secret-123",
+    });
+
+    const response = await app.request("/api/auth/computers", {
+      headers: { host: "app.matrix-os.com" },
+    });
+
+    expect(response.status).toBe(401);
+    await expect(response.json()).resolves.toEqual({ error: "Unauthorized" });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("returns a bounded safe owner projection for a verified Clerk principal", async () => {
+    await insertMachine(db, {
+      handle: "alice-primary",
+      runtimeSlot: "primary",
+      imageVersion: "v2026.07.11-private-build-data",
+    });
+    await insertMachine(db, {
+      handle: "pr-921",
+      runtimeSlot: "pr-921",
+      status: "provisioning",
+      imageVersion: "matrix-os-host-2026.07.10-1",
+      provisioningClass: "preview",
+      provisionedAt: "2026-07-11T01:00:00.000Z",
+    });
+    await insertMachine(db, {
+      handle: "alice-review",
+      runtimeSlot: "review",
+      status: "stopped",
+      imageVersion: "operator.internal",
+      provisionedAt: "2026-07-11T02:00:00.000Z",
+    });
+    await insertMachine(db, {
+      clerkUserId: "user_bob",
+      handle: "bob-private",
+      runtimeSlot: "primary",
+      imageVersion: "v2026.07.11",
+    });
+    const app = createApp({
+      db,
+      orchestrator: stubOrchestrator(),
+      clerkAuth: createClerkAuth({
+        verifyToken: vi.fn().mockResolvedValue({ sub: "user_alice" }),
+      }),
+      platformSecret: "platform-secret-123",
+    });
+
+    const response = await app.request("/api/auth/computers", {
+      headers: {
+        host: "app.matrix-os.com",
+        authorization: "Bearer clerk-session",
+      },
+    });
+
+    expect(response.status).toBe(200);
+    const body = MatrixComputerListSchema.parse(await response.json());
+    expect(body).toEqual({
+      items: [
+        {
+          handle: "alice-primary",
+          runtimeSlot: "primary",
+          label: "Main Computer",
+          availability: "available",
+          kind: "customer",
+          versionLabel: "v2026.07.11",
+          gatewayPath: "/vm/alice-primary",
+          capabilities: ["matrixComputerInventoryV1"],
+        },
+        {
+          handle: "alice-review",
+          runtimeSlot: "review",
+          label: "Additional Computer",
+          availability: "unavailable",
+          kind: "customer",
+          versionLabel: "Version pending",
+          gatewayPath: "/vm/alice-review",
+          capabilities: ["matrixComputerInventoryV1"],
+        },
+        {
+          handle: "pr-921",
+          runtimeSlot: "pr-921",
+          label: "Preview Computer",
+          availability: "starting",
+          kind: "preview",
+          versionLabel: "v2026.07.10",
+          gatewayPath: "/vm/pr-921",
+          capabilities: ["matrixComputerInventoryV1"],
+        },
+      ],
+      selectedSlot: null,
+      hasMore: false,
+      limit: 20,
+    });
+    expect(JSON.stringify(body)).not.toMatch(/bob|machineId|publicIPv|serverType|operator|private-build/i);
+    expect(response.headers.get("cache-control")).toContain("no-store");
+  });
+
+  it("projects the signed runtime selection for a verified native principal", async () => {
+    process.env.PLATFORM_JWT_SECRET = JWT_SECRET;
+    await insertMachine(db, {
+      handle: "alice-review",
+      runtimeSlot: "review",
+      imageVersion: "stable",
+    });
+    const issued = await issueSyncJwt({
+      secret: JWT_SECRET,
+      clerkUserId: "user_alice",
+      handle: "alice-review",
+      gatewayUrl: "https://app.matrix-os.com/vm/alice-review",
+      runtimeSlot: "review",
+    });
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response("wrong target", { status: 200 }),
+    );
+    const app = createApp({
+      db,
+      orchestrator: stubOrchestrator(),
+      clerkAuth: createClerkAuth({ verifyToken: vi.fn().mockResolvedValue(null) }),
+      platformSecret: "platform-secret-123",
+    });
+
+    const response = await app.request("/api/auth/computers", {
+      headers: {
+        host: "app.matrix-os.com",
+        authorization: `Bearer ${issued.token}`,
+      },
+    });
+
+    expect(response.status).toBe(200);
+    const body = MatrixComputerListSchema.parse(await response.json());
+    expect(body.selectedSlot).toBe("review");
+    expect(body.items.map((item) => item.handle)).toContain("alice-review");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("quarantines a malformed persisted provisioning class without hiding valid computers", async () => {
+    await insertMachine(db, {
+      handle: "alice-primary",
+      runtimeSlot: "primary",
+      imageVersion: "stable",
+    });
+    await insertMachine(db, {
+      handle: "alice-corrupt",
+      runtimeSlot: "corrupt",
+      imageVersion: "stable",
+    });
+    await sql`UPDATE user_machines SET provisioning_class = 'operator-data' WHERE handle = 'alice-corrupt'`
+      .execute(db.executor);
+    const app = createApp({
+      db,
+      orchestrator: stubOrchestrator(),
+      clerkAuth: createClerkAuth({
+        verifyToken: vi.fn().mockResolvedValue({ sub: "user_alice" }),
+      }),
+      platformSecret: "platform-secret-123",
+    });
+
+    const response = await app.request("/api/auth/computers", {
+      headers: {
+        host: "app.matrix-os.com",
+        authorization: "Bearer clerk-session",
+      },
+    });
+
+    expect(response.status).toBe(200);
+    const body = MatrixComputerListSchema.parse(await response.json());
+    expect(body.items.map((item) => item.handle)).toEqual(["alice-primary"]);
+    expect(JSON.stringify(body)).not.toContain("operator-data");
+  });
+
+  it("caps inventory at twenty records and reports remaining rows", async () => {
+    for (let index = 0; index < 21; index += 1) {
+      await insertMachine(db, {
+        handle: `alice-${index}`,
+        runtimeSlot: index === 0 ? "primary" : `slot-${index}`,
+        imageVersion: "dev",
+        provisionedAt: `2026-07-11T00:${String(index).padStart(2, "0")}:00.000Z`,
+      });
+    }
+    await insertMachine(db, {
+      handle: "1a",
+      runtimeSlot: "invalid",
+      imageVersion: "dev",
+      provisionedAt: "2026-07-11T00:59:00.000Z",
+    });
+    await insertMachine(db, {
+      handle: "alice-invalid-slot",
+      runtimeSlot: "a".repeat(33),
+      imageVersion: "dev",
+      provisionedAt: "2026-07-11T00:58:00.000Z",
+    });
+    const app = createApp({
+      db,
+      orchestrator: stubOrchestrator(),
+      clerkAuth: createClerkAuth({
+        verifyToken: vi.fn().mockResolvedValue({ sub: "user_alice" }),
+      }),
+      platformSecret: "platform-secret-123",
+    });
+
+    const response = await app.request("/api/auth/computers", {
+      headers: {
+        host: "app.matrix-os.com",
+        authorization: "Bearer clerk-session",
+      },
+    });
+
+    expect(response.status).toBe(200);
+    const body = MatrixComputerListSchema.parse(await response.json());
+    expect(body.items).toHaveLength(20);
+    expect(body.hasMore).toBe(true);
+    expect(body.limit).toBe(20);
+  });
+
+  it("keeps the verified native selection inside a capped inventory page", async () => {
+    process.env.PLATFORM_JWT_SECRET = JWT_SECRET;
+    await insertMachine(db, {
+      handle: "alice-selected",
+      runtimeSlot: "review",
+      imageVersion: "stable",
+      provisionedAt: "2026-07-10T00:00:00.000Z",
+    });
+    for (let index = 0; index < 20; index += 1) {
+      await insertMachine(db, {
+        handle: `alice-${index}`,
+        runtimeSlot: index === 0 ? "primary" : `slot-${index}`,
+        imageVersion: "dev",
+        provisionedAt: `2026-07-11T00:${String(index).padStart(2, "0")}:00.000Z`,
+      });
+    }
+    const issued = await issueSyncJwt({
+      secret: JWT_SECRET,
+      clerkUserId: "user_alice",
+      handle: "alice-selected",
+      gatewayUrl: "https://app.matrix-os.com/vm/alice-selected",
+      runtimeSlot: "review",
+    });
+    const app = createApp({
+      db,
+      orchestrator: stubOrchestrator(),
+      clerkAuth: createClerkAuth({ verifyToken: vi.fn().mockResolvedValue(null) }),
+      platformSecret: "platform-secret-123",
+    });
+
+    const response = await app.request("/api/auth/computers", {
+      headers: {
+        host: "app.matrix-os.com",
+        authorization: `Bearer ${issued.token}`,
+      },
+    });
+
+    expect(response.status).toBe(200);
+    const body = MatrixComputerListSchema.parse(await response.json());
+    expect(body.selectedSlot).toBe("review");
+    expect(body.items.map((item) => item.runtimeSlot)).toContain("review");
+    expect(body.items).toHaveLength(20);
+    expect(body.hasMore).toBe(true);
+  });
+});

--- a/tests/platform/proxy-routing.test.ts
+++ b/tests/platform/proxy-routing.test.ts
@@ -3014,7 +3014,7 @@ describe("platform proxy routing", () => {
     const fetchMock = vi.spyOn(globalThis, "fetch")
       .mockResolvedValueOnce(
         new Response(
-          '<!doctype html><script type="module" src="./assets/index.js"></script>',
+          '<!doctype html><script type="module" src="./assets/index.js"></script><link rel="stylesheet" href="./assets/index.css">',
           {
             status: 200,
             headers: {
@@ -3030,6 +3030,18 @@ describe("platform proxy routing", () => {
             "content-type": "application/javascript",
             vary: "Accept-Encoding",
           },
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response('@import "./theme.css";@font-face{src:url("./font.woff2")}main{background:url(./image.png)}', {
+          status: 200,
+          headers: { "content-type": "text/css; charset=utf-8" },
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response("font-data", {
+          status: 200,
+          headers: { "content-type": "font/woff2" },
         }),
       );
     const app = createApp({
@@ -3050,7 +3062,9 @@ describe("platform proxy routing", () => {
     expect(htmlRes.status).toBe(200);
     const html = await htmlRes.text();
     const assetPath = html.match(/src="([^"]+)"/)?.[1];
+    const stylesheetPath = html.match(/href="([^"]+)"/)?.[1];
     expect(assetPath).toMatch(/^\/vm\/alice\/apps\/chess\/assets\/index\.js\?matrix_asset_token=/);
+    expect(stylesheetPath).toMatch(/^\/vm\/alice\/apps\/chess\/assets\/index\.css\?matrix_asset_token=/);
 
     const res = await app.request(assetPath ?? "/invalid", {
       headers: {
@@ -3075,6 +3089,23 @@ describe("platform proxy routing", () => {
     expect(js).toMatch(/from"\.\/react\.js\?matrix_asset_token=[^"]+"/);
     expect(js).toMatch(/import\("\.\/editor\.js\?matrix_asset_token=[^"]+"\)/);
     expect(js).toContain('Array.from("./plain.js")');
+
+    const cssRes = await app.request(stylesheetPath ?? "/invalid", {
+      headers: { host: "app.matrix-os.com", origin: "null" },
+    });
+    expect(cssRes.status).toBe(200);
+    const css = await cssRes.text();
+    expect(css).toMatch(/@import "\.\/theme\.css\?matrix_asset_token=[^"]+"/);
+    expect(css).toMatch(/url\("\.\/font\.woff2\?matrix_asset_token=[^"]+"\)/);
+    expect(css).toMatch(/url\(\.\/image\.png\?matrix_asset_token=[^)]+\)/);
+
+    const fontPath = css.match(/url\("([^"]+font\.woff2[^"]*)"\)/)?.[1];
+    const fontUrl = new URL(fontPath ?? "/invalid", `https://app.matrix-os.com${stylesheetPath}`);
+    const fontRes = await app.request(`${fontUrl.pathname}${fontUrl.search}`, {
+      headers: { host: "app.matrix-os.com", origin: "null" },
+    });
+    expect(fontRes.status).toBe(200);
+    expect(fetchMock.mock.calls[3]?.[0]).toBe("https://203.0.113.34:443/apps/chess/assets/font.woff2");
   });
 
   it("binds cookie-free Vite assets and lazy chunks to the selected same-handle runtime", async () => {

--- a/tests/platform/proxy-routing.test.ts
+++ b/tests/platform/proxy-routing.test.ts
@@ -3077,6 +3077,97 @@ describe("platform proxy routing", () => {
     expect(js).toContain('Array.from("./plain.js")');
   });
 
+  it("binds cookie-free Vite assets and lazy chunks to the selected same-handle runtime", async () => {
+    await deleteContainer(db, "alice");
+    await insertUserMachine(db, {
+      machineId: "9f05824c-8d0a-4d83-9cb4-b312d43ff150",
+      clerkUserId: "user_alice",
+      handle: "alice",
+      runtimeSlot: "primary",
+      status: "running",
+      hetznerServerId: 123500,
+      publicIPv4: "203.0.113.50",
+      imageVersion: "matrix-os-host-2026.04.26-1",
+      provisionedAt: "2026-04-26T12:00:00.000Z",
+    });
+    await insertUserMachine(db, {
+      machineId: "9f05824c-8d0a-4d83-9cb4-b312d43ff151",
+      clerkUserId: "user_alice",
+      handle: "alice",
+      runtimeSlot: "review",
+      status: "running",
+      hetznerServerId: 123501,
+      publicIPv4: "203.0.113.51",
+      imageVersion: "matrix-os-host-2026.04.26-1",
+      provisionedAt: "2026-04-26T12:01:00.000Z",
+    });
+    const fetchMock = vi.spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(
+        new Response('<!doctype html><script type="module" src="./assets/index.js"></script>', {
+          status: 200,
+          headers: { "content-type": "text/html; charset=utf-8" },
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response('import("./editor.js")', {
+          status: 200,
+          headers: { "content-type": "application/javascript" },
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response("export const editor = true", {
+          status: 200,
+          headers: { "content-type": "application/javascript" },
+        }),
+      );
+    const app = createApp({
+      db,
+      orchestrator: stubOrchestrator(),
+      clerkAuth: createClerkAuth({
+        verifyToken: vi.fn().mockResolvedValue({ sub: "user_alice" }),
+      }),
+      platformSecret: "platform-secret-123",
+    });
+
+    const htmlRes = await app.request("/vm/alice/apps/chess/?runtime=review", {
+      headers: {
+        host: "app.matrix-os.com",
+        authorization: "Bearer clerk-session",
+      },
+    });
+
+    expect(htmlRes.status).toBe(200);
+    expect(fetchMock.mock.calls[0]?.[0]).toBe("https://203.0.113.51:443/apps/chess/");
+    const html = await htmlRes.text();
+    const entryAssetPath = html.match(/src="([^"]+)"/)?.[1];
+    expect(entryAssetPath).toMatch(
+      /^\/vm\/alice\/apps\/chess\/assets\/index\.js\?runtime=review&matrix_asset_token=/,
+    );
+
+    const entryRes = await app.request(entryAssetPath ?? "/invalid", {
+      headers: { host: "app.matrix-os.com", origin: "null" },
+    });
+    expect(entryRes.status).toBe(200);
+    expect(fetchMock.mock.calls[1]?.[0]).toBe("https://203.0.113.51:443/apps/chess/assets/index.js");
+    const entryJs = await entryRes.text();
+    const lazyImportPath = entryJs.match(/import\("([^"]+)"\)/)?.[1];
+    expect(lazyImportPath).toMatch(/^\.\/editor\.js\?runtime=review&matrix_asset_token=/);
+
+    const tamperedAssetPath = entryAssetPath?.replace("runtime=review", "runtime=primary");
+    const tamperedRes = await app.request(tamperedAssetPath ?? "/invalid", {
+      headers: { host: "app.matrix-os.com", origin: "null" },
+    });
+    expect(tamperedRes.status).toBe(401);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+
+    const lazyAssetUrl = new URL(lazyImportPath ?? "/invalid", `https://app.matrix-os.com${entryAssetPath}`);
+    const lazyRes = await app.request(`${lazyAssetUrl.pathname}${lazyAssetUrl.search}`, {
+      headers: { host: "app.matrix-os.com", origin: "null" },
+    });
+    expect(lazyRes.status).toBe(200);
+    expect(fetchMock.mock.calls[2]?.[0]).toBe("https://203.0.113.51:443/apps/chess/assets/editor.js");
+  });
+
   it("rejects unsigned explicit VM Vite app assets before probing a handle", async () => {
     await deleteContainer(db, "alice");
     await insertUserMachine(db, {

--- a/tests/scripts/start-platform-cloud-run.test.ts
+++ b/tests/scripts/start-platform-cloud-run.test.ts
@@ -51,6 +51,17 @@ describe('start-platform-cloud-run.sh', () => {
     expect(dockerfile).toContain("/app/packages/sync-client/package.json ./packages/sync-client/package.json");
   });
 
+  it('packages shared contracts imported by the compiled platform server', () => {
+    const root = process.cwd();
+    const dockerfile = readFileSync(join(root, 'Dockerfile.platform'), 'utf8');
+    const platformPackage = readFileSync(join(root, 'packages/platform/package.json'), 'utf8');
+
+    expect(platformPackage).toContain('"@matrix-os/contracts": "workspace:*"');
+    expect(dockerfile).toContain('COPY packages/contracts/package.json packages/contracts/package.json');
+    expect(dockerfile).toContain('/app/packages/contracts/package.json ./packages/contracts/package.json');
+    expect(dockerfile).toContain('/app/packages/contracts/src ./packages/contracts/src');
+  });
+
   it('exits nonzero when the auth shell never becomes ready', () => {
     const root = process.cwd();
     const script = readFileSync(join(root, 'scripts/start-platform-cloud-run.sh'), 'utf8');


### PR DESCRIPTION
## Summary

- add canonical platform-owned `GET /api/auth/computers` for verified Clerk and native/sync principals
- query only bounded safe owner projection columns, filtering malformed persisted rows before SQL pagination
- derive fixed labels, coarse availability/version state, same-origin gateway paths, and truthful inventory capability data
- publish a selected slot only from a verified native/sync identity and prioritize that machine inside the bounded page
- keep the exact route on the platform while leaving existing runtime HTTP and WebSocket forwarding unchanged

## Validation

- `pnpm exec vitest run tests/platform/computer-inventory-routes.test.ts tests/contracts/runtime-computers.test.ts` (10 passed)
- `pnpm exec vitest run tests/platform/computer-inventory-routes.test.ts tests/platform/proxy-routing.test.ts tests/contracts/runtime-computers.test.ts` (119 passed)
- `pnpm --filter @matrix-os/platform exec tsc --noEmit -p tsconfig.typecheck.json`
- `bun run typecheck`
- `bun run check:patterns` (0 violations; existing warning categories only)
- `git diff --cached --check`

## TDD Evidence

Tests failed first for the absent route, malformed persisted provisioning state, invalid rows counted before pagination, a selected native machine falling outside the page, and overlong slots occupying the query window. Each case now passes through SQL pre-validation plus strict shared response parsing.

## Invariants

- Source of truth remains the platform owner database; shells receive only a bounded projection.
- This route is read-only, so it performs no mutation, transaction, lock, or credential exchange.
- Ownership comes only from the shared verified Clerk/native identity resolver; client owner identifiers and query-selected slots are ignored.
- The query reads at most 21 valid rows and returns at most 20; no in-memory registry or cache is introduced.
- Raw machine IDs, IPs, credentials, provider/operator metadata, failure data, and exact build suffixes never enter the response.
- Trusted desktop runtime credential replacement remains deferred to the next focused child PR.
