### PR TITLE
fix(platform): persist provisioning jobs durably

### DIFF
--- a/packages/platform/src/customer-vps-provisioning-jobs.ts
+++ b/packages/platform/src/customer-vps-provisioning-jobs.ts
@@ -5,6 +5,7 @@ import type { PlatformDB } from './db.js';
 const MAX_PROVISIONING_JOBS = 100;
 const MAX_ENCRYPTED_PAYLOAD_LENGTH = 8_192;
 const PAYLOAD_VERSION = 1;
+export const MAX_PROVISIONING_JOB_ATTEMPTS = 100;
 
 const ProvisioningJobStatusSchema = z.enum(['queued', 'running', 'completed', 'failed']);
 const ProvisioningPayloadSchema = z.object({
@@ -16,7 +17,7 @@ const ProvisioningJobRowSchema = z.object({
   job_id: z.uuid(),
   machine_id: z.uuid(),
   status: ProvisioningJobStatusSchema,
-  attempts: z.number().int().min(0).max(100),
+  attempts: z.number().int().min(0).max(MAX_PROVISIONING_JOB_ATTEMPTS),
   available_at: z.string().min(1).max(64),
   claimed_at: z.string().min(1).max(64).nullable(),
   lease_expires_at: z.string().min(1).max(64).nullable(),
@@ -155,6 +156,19 @@ export async function getProvisioningJobByMachineId(
   return row ? mapProvisioningJob(row) : undefined;
 }
 
+export async function getProvisioningJob(
+  db: PlatformDB,
+  jobId: string,
+): Promise<ProvisioningJobRecord | undefined> {
+  await db.ready;
+  const row = await db.executor
+    .selectFrom('provisioning_jobs')
+    .selectAll()
+    .where('job_id', '=', jobId)
+    .executeTakeFirst();
+  return row ? mapProvisioningJob(row) : undefined;
+}
+
 export async function listProvisioningJobs(db: PlatformDB, limit: number): Promise<ProvisioningJobRecord[]> {
   await db.ready;
   const boundedLimit = Math.max(1, Math.min(MAX_PROVISIONING_JOBS, Math.trunc(limit)));
@@ -204,6 +218,7 @@ export async function claimProvisioningJob(
       updated_at: now,
     }))
     .where('job_id', '=', jobId)
+    .where('attempts', '<', MAX_PROVISIONING_JOB_ATTEMPTS)
     .where((eb) => eb.or([
       eb.and([eb('status', '=', 'queued'), eb('available_at', '<=', now)]),
       eb.and([eb('status', '=', 'running'), eb('lease_expires_at', '<=', now)]),

--- a/packages/platform/src/customer-vps-provisioning-jobs.ts
+++ b/packages/platform/src/customer-vps-provisioning-jobs.ts
@@ -1,0 +1,257 @@
+import { createCipheriv, createDecipheriv, createHash, randomBytes } from 'node:crypto';
+import { z } from 'zod/v4';
+import type { PlatformDB } from './db.js';
+
+const MAX_PROVISIONING_JOBS = 100;
+const MAX_ENCRYPTED_PAYLOAD_LENGTH = 8_192;
+const PAYLOAD_VERSION = 1;
+
+const ProvisioningJobStatusSchema = z.enum(['queued', 'running', 'completed', 'failed']);
+const ProvisioningPayloadSchema = z.object({
+  registrationToken: z.string().min(8).max(512),
+  postgresPassword: z.string().min(8).max(512),
+}).strict();
+
+const ProvisioningJobRowSchema = z.object({
+  job_id: z.uuid(),
+  machine_id: z.uuid(),
+  status: ProvisioningJobStatusSchema,
+  attempts: z.number().int().min(0).max(100),
+  available_at: z.string().min(1).max(64),
+  claimed_at: z.string().min(1).max(64).nullable(),
+  lease_expires_at: z.string().min(1).max(64).nullable(),
+  encrypted_payload: z.string().max(MAX_ENCRYPTED_PAYLOAD_LENGTH).nullable(),
+  last_error_code: z.string().min(1).max(64).nullable(),
+  created_at: z.string().min(1).max(64),
+  updated_at: z.string().min(1).max(64),
+  completed_at: z.string().min(1).max(64).nullable(),
+});
+
+export interface ProvisioningJobRecord {
+  jobId: string;
+  machineId: string;
+  status: z.infer<typeof ProvisioningJobStatusSchema>;
+  attempts: number;
+  availableAt: string;
+  claimedAt: string | null;
+  leaseExpiresAt: string | null;
+  encryptedPayload: string | null;
+  lastErrorCode: string | null;
+  createdAt: string;
+  updatedAt: string;
+  completedAt: string | null;
+}
+
+export interface NewProvisioningJob {
+  jobId: string;
+  machineId: string;
+  encryptedPayload: string;
+  availableAt: string;
+  createdAt: string;
+}
+
+export interface ProvisioningPayload {
+  registrationToken: string;
+  postgresPassword: string;
+}
+
+function mapProvisioningJob(value: unknown): ProvisioningJobRecord {
+  const row = ProvisioningJobRowSchema.parse(value);
+  return {
+    jobId: row.job_id,
+    machineId: row.machine_id,
+    status: row.status,
+    attempts: row.attempts,
+    availableAt: row.available_at,
+    claimedAt: row.claimed_at,
+    leaseExpiresAt: row.lease_expires_at,
+    encryptedPayload: row.encrypted_payload,
+    lastErrorCode: row.last_error_code,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+    completedAt: row.completed_at,
+  };
+}
+
+function encryptionKey(secret: string): Buffer {
+  if (secret.length < 8) {
+    throw new Error('Provisioning payload encryption is not configured');
+  }
+  return createHash('sha256').update(`matrix-provisioning-job:${secret}`).digest();
+}
+
+export function sealProvisioningPayload(payload: ProvisioningPayload, secret: string): string {
+  const parsed = ProvisioningPayloadSchema.parse(payload);
+  const iv = randomBytes(12);
+  const cipher = createCipheriv('aes-256-gcm', encryptionKey(secret), iv);
+  const ciphertext = Buffer.concat([
+    cipher.update(JSON.stringify(parsed), 'utf8'),
+    cipher.final(),
+  ]);
+  const sealed = [
+    String(PAYLOAD_VERSION),
+    iv.toString('base64url'),
+    cipher.getAuthTag().toString('base64url'),
+    ciphertext.toString('base64url'),
+  ].join('.');
+  if (sealed.length > MAX_ENCRYPTED_PAYLOAD_LENGTH) {
+    throw new Error('Provisioning payload exceeds persistence limit');
+  }
+  return sealed;
+}
+
+export function openProvisioningPayload(sealed: string, secret: string): ProvisioningPayload {
+  if (sealed.length > MAX_ENCRYPTED_PAYLOAD_LENGTH) {
+    throw new Error('Provisioning payload is invalid');
+  }
+  const [version, ivValue, tagValue, ciphertextValue, ...rest] = sealed.split('.');
+  if (version !== String(PAYLOAD_VERSION) || !ivValue || !tagValue || !ciphertextValue || rest.length > 0) {
+    throw new Error('Provisioning payload is invalid');
+  }
+  try {
+    const decipher = createDecipheriv('aes-256-gcm', encryptionKey(secret), Buffer.from(ivValue, 'base64url'));
+    decipher.setAuthTag(Buffer.from(tagValue, 'base64url'));
+    const plaintext = Buffer.concat([
+      decipher.update(Buffer.from(ciphertextValue, 'base64url')),
+      decipher.final(),
+    ]).toString('utf8');
+    return ProvisioningPayloadSchema.parse(JSON.parse(plaintext));
+  } catch (err: unknown) {
+    if (err instanceof Error && err.message === 'Provisioning payload encryption is not configured') {
+      throw err;
+    }
+    throw new Error('Provisioning payload is invalid');
+  }
+}
+
+export async function insertProvisioningJob(db: PlatformDB, job: NewProvisioningJob): Promise<void> {
+  await db.ready;
+  await db.executor.insertInto('provisioning_jobs').values({
+    job_id: job.jobId,
+    machine_id: job.machineId,
+    status: 'queued',
+    attempts: 0,
+    available_at: job.availableAt,
+    claimed_at: null,
+    lease_expires_at: null,
+    encrypted_payload: job.encryptedPayload,
+    last_error_code: null,
+    created_at: job.createdAt,
+    updated_at: job.createdAt,
+    completed_at: null,
+  }).execute();
+}
+
+export async function getProvisioningJobByMachineId(
+  db: PlatformDB,
+  machineId: string,
+): Promise<ProvisioningJobRecord | undefined> {
+  await db.ready;
+  const row = await db.executor
+    .selectFrom('provisioning_jobs')
+    .selectAll()
+    .where('machine_id', '=', machineId)
+    .executeTakeFirst();
+  return row ? mapProvisioningJob(row) : undefined;
+}
+
+export async function listProvisioningJobs(db: PlatformDB, limit: number): Promise<ProvisioningJobRecord[]> {
+  await db.ready;
+  const boundedLimit = Math.max(1, Math.min(MAX_PROVISIONING_JOBS, Math.trunc(limit)));
+  const rows = await db.executor
+    .selectFrom('provisioning_jobs')
+    .selectAll()
+    .orderBy('created_at', 'asc')
+    .limit(boundedLimit)
+    .execute();
+  return rows.map(mapProvisioningJob);
+}
+
+export async function listDispatchableProvisioningJobs(
+  db: PlatformDB,
+  now: string,
+  limit: number,
+): Promise<ProvisioningJobRecord[]> {
+  await db.ready;
+  const boundedLimit = Math.max(1, Math.min(MAX_PROVISIONING_JOBS, Math.trunc(limit)));
+  const rows = await db.executor
+    .selectFrom('provisioning_jobs')
+    .selectAll()
+    .where((eb) => eb.or([
+      eb.and([eb('status', '=', 'queued'), eb('available_at', '<=', now)]),
+      eb.and([eb('status', '=', 'running'), eb('lease_expires_at', '<=', now)]),
+    ]))
+    .orderBy('available_at', 'asc')
+    .limit(boundedLimit)
+    .execute();
+  return rows.map(mapProvisioningJob);
+}
+
+export async function claimProvisioningJob(
+  db: PlatformDB,
+  jobId: string,
+  now: string,
+  leaseExpiresAt: string,
+): Promise<ProvisioningJobRecord | undefined> {
+  await db.ready;
+  const row = await db.executor
+    .updateTable('provisioning_jobs')
+    .set((eb) => ({
+      status: 'running',
+      attempts: eb('attempts', '+', 1),
+      claimed_at: now,
+      lease_expires_at: leaseExpiresAt,
+      updated_at: now,
+    }))
+    .where('job_id', '=', jobId)
+    .where((eb) => eb.or([
+      eb.and([eb('status', '=', 'queued'), eb('available_at', '<=', now)]),
+      eb.and([eb('status', '=', 'running'), eb('lease_expires_at', '<=', now)]),
+    ]))
+    .returningAll()
+    .executeTakeFirst();
+  return row ? mapProvisioningJob(row) : undefined;
+}
+
+export async function completeProvisioningJob(db: PlatformDB, jobId: string, now: string): Promise<boolean> {
+  await db.ready;
+  const row = await db.executor
+    .updateTable('provisioning_jobs')
+    .set({
+      status: 'completed',
+      encrypted_payload: null,
+      lease_expires_at: null,
+      updated_at: now,
+      completed_at: now,
+      last_error_code: null,
+    })
+    .where('job_id', '=', jobId)
+    .where('status', '=', 'running')
+    .returning('job_id')
+    .executeTakeFirst();
+  return Boolean(row);
+}
+
+export async function failProvisioningJob(
+  db: PlatformDB,
+  jobId: string,
+  now: string,
+  errorCode: string,
+): Promise<boolean> {
+  await db.ready;
+  const row = await db.executor
+    .updateTable('provisioning_jobs')
+    .set({
+      status: 'failed',
+      encrypted_payload: null,
+      lease_expires_at: null,
+      updated_at: now,
+      completed_at: now,
+      last_error_code: errorCode.slice(0, 64),
+    })
+    .where('job_id', '=', jobId)
+    .where('status', '=', 'running')
+    .returning('job_id')
+    .executeTakeFirst();
+  return Boolean(row);
+}

--- a/packages/platform/src/customer-vps-provisioning-jobs.ts
+++ b/packages/platform/src/customer-vps-provisioning-jobs.ts
@@ -8,6 +8,7 @@ const PAYLOAD_VERSION = 1;
 export const MAX_PROVISIONING_JOB_ATTEMPTS = 100;
 
 const ProvisioningJobStatusSchema = z.enum(['queued', 'running', 'completed', 'failed']);
+const MachineIdSchema = z.string().min(1).max(128).regex(/^[A-Za-z0-9_-]+$/);
 const ProvisioningPayloadSchema = z.object({
   registrationToken: z.string().min(8).max(512),
   postgresPassword: z.string().min(8).max(512),
@@ -15,7 +16,7 @@ const ProvisioningPayloadSchema = z.object({
 
 const ProvisioningJobRowSchema = z.object({
   job_id: z.uuid(),
-  machine_id: z.uuid(),
+  machine_id: MachineIdSchema,
   status: ProvisioningJobStatusSchema,
   attempts: z.number().int().min(0).max(MAX_PROVISIONING_JOB_ATTEMPTS),
   available_at: z.string().min(1).max(64),

--- a/packages/platform/src/customer-vps.ts
+++ b/packages/platform/src/customer-vps.ts
@@ -640,6 +640,7 @@ export function createCustomerVpsService(deps: CustomerVpsServiceDeps): Customer
     }
 
     let serverIdForCompensation: number | null = null;
+    let adoptedExistingServer = false;
     try {
       const payload = openProvisioningPayload(job.encryptedPayload, deps.config.platformSecret);
       const imageVersion = row.imageVersion ?? deps.config.imageVersion;
@@ -663,18 +664,38 @@ export function createCustomerVpsService(deps: CustomerVpsServiceDeps): Customer
         deps.cloudInitTemplate ?? DEFAULT_CLOUD_INIT_TEMPLATE,
         hostConfig,
       );
-      const server = await deps.hetzner.createServer({
-        name: buildServerName(row.handle),
-        serverType: row.serverType ?? deps.config.serverType,
-        userData,
-        labels: {
-          app: 'matrix-os',
-          clerk_user_id: row.clerkUserId,
-          runtime_slot: row.runtimeSlot,
-          machine_id: row.machineId,
-        },
-      });
-      serverIdForCompensation = server.id;
+      const existingServers = deps.hetzner.listServersByLabel
+        ? (await deps.hetzner.listServersByLabel(`machine_id=${row.machineId}`))
+          .toSorted((left, right) => left.id - right.id)
+        : [];
+      const existingServer = existingServers[0];
+      const server = existingServer ?? await deps.hetzner.createServer({
+          name: buildServerName(row.handle),
+          serverType: row.serverType ?? deps.config.serverType,
+          userData,
+          labels: {
+            app: 'matrix-os',
+            clerk_user_id: row.clerkUserId,
+            runtime_slot: row.runtimeSlot,
+            machine_id: row.machineId,
+          },
+        });
+      adoptedExistingServer = Boolean(existingServer);
+      if (!adoptedExistingServer) serverIdForCompensation = server.id;
+      for (const duplicate of existingServers.slice(1)) {
+        try {
+          await deps.hetzner.deleteServer(duplicate.id);
+        } catch (cleanupErr: unknown) {
+          logCustomerVpsError('duplicate provisioning server cleanup failed', cleanupErr);
+          await queueProviderDeletion({
+            providerServerId: duplicate.id,
+            reason: 'duplicate_provisioning_server',
+            machineId: row.machineId,
+            handle: row.handle,
+            err: cleanupErr,
+          });
+        }
+      }
       const completedAt = now().toISOString();
       await runInPlatformTransaction(deps.db, async (trx) => {
         await updateUserMachine(trx, row.machineId, {
@@ -703,6 +724,11 @@ export function createCustomerVpsService(deps: CustomerVpsServiceDeps): Customer
             err: cleanupErr,
           });
         }
+      }
+      if (adoptedExistingServer) {
+        logCustomerVpsError(`adopted provisioning server persistence failed machineId=${row.machineId}`, err);
+        if (propagateFailure) throw mapped;
+        return 'skipped';
       }
       const failedAt = now().toISOString();
       try {

--- a/packages/platform/src/customer-vps.ts
+++ b/packages/platform/src/customer-vps.ts
@@ -66,6 +66,17 @@ import {
   canonicalizeDeveloperTools,
   developerToolsShellList,
 } from './developer-tools.js';
+import {
+  claimProvisioningJob,
+  completeProvisioningJob,
+  failProvisioningJob,
+  getProvisioningJobByMachineId,
+  insertProvisioningJob,
+  listDispatchableProvisioningJobs,
+  openProvisioningPayload,
+  sealProvisioningPayload,
+  type NewProvisioningJob,
+} from './customer-vps-provisioning-jobs.js';
 
 export interface ProvisionResponse {
   machineId: string;
@@ -137,6 +148,7 @@ export interface CustomerVpsService {
   delete(machineId: string): Promise<DeleteResponse>;
   deploy(target?: DeployTarget): Promise<DeployResult>;
   listAllMachines(): Promise<StatusResponse[]>;
+  dispatchProvisioningJobs(): Promise<{ checked: number; completed: number; failed: number }>;
   reconcileProvisioning(): Promise<{ checked: number; failed: number; running: number }>;
 }
 
@@ -150,6 +162,8 @@ export interface CustomerVpsServiceDeps {
   tokenFactory?: (now: Date, ttlMs: number) => RegistrationToken;
   postgresPasswordFactory?: () => string;
   now?: () => Date;
+  provisioningJobIdFactory?: () => string;
+  enqueueProvisioningJob?: (db: PlatformDB, job: NewProvisioningJob) => Promise<void>;
   fetchDispatcher?: import('undici').Dispatcher;
   resolveBillingEntitlement?: (clerkUserId: string) => Promise<BillingEntitlement | null | undefined>;
 }
@@ -205,6 +219,7 @@ const PROVIDER_DELETION_RETRY_BASE_MS = 60_000;
 const PROVIDER_DELETION_RETRY_MAX_MS = 60 * 60_000;
 const RESIZE_STATUS_POLL_INTERVAL_MS = 1_000;
 const RESIZE_STATUS_POLL_TIMEOUT_MS = 90_000;
+const PROVISIONING_JOB_LEASE_MS = 5 * 60_000;
 
 function activeProvisionResponse(row: UserMachineRecord, etaSeconds: number): ProvisionResponse {
   if (row.status !== 'provisioning' && row.status !== 'running') {
@@ -425,6 +440,8 @@ function sleep(ms: number): Promise<void> {
 
 export function createCustomerVpsService(deps: CustomerVpsServiceDeps): CustomerVpsService {
   const machineIdFactory = deps.machineIdFactory ?? randomUUID;
+  const provisioningJobIdFactory = deps.provisioningJobIdFactory ?? randomUUID;
+  const enqueueProvisioningJob = deps.enqueueProvisioningJob ?? insertProvisioningJob;
   const tokenFactory = deps.tokenFactory ?? createRegistrationToken;
   const postgresPasswordFactory = deps.postgresPasswordFactory ?? (() => randomBytes(24).toString('base64url'));
   const now = deps.now ?? (() => new Date());
@@ -592,6 +609,139 @@ export function createCustomerVpsService(deps: CustomerVpsServiceDeps): Customer
     }
   }
 
+  async function dispatchProvisioningJob(
+    jobId: string,
+    propagateFailure: boolean,
+  ): Promise<'completed' | 'failed' | 'skipped'> {
+    const claimedAt = now();
+    const job = await claimProvisioningJob(
+      deps.db,
+      jobId,
+      claimedAt.toISOString(),
+      new Date(claimedAt.getTime() + PROVISIONING_JOB_LEASE_MS).toISOString(),
+    );
+    if (!job) return 'skipped';
+
+    const row = await getUserMachine(deps.db, job.machineId);
+    if (!row || row.deletedAt || row.status !== 'provisioning' || !job.encryptedPayload) {
+      const failedAt = now().toISOString();
+      await failProvisioningJob(deps.db, job.jobId, failedAt, 'invalid_state');
+      if (row && !row.deletedAt && row.status === 'provisioning') {
+        await updateUserMachine(deps.db, row.machineId, {
+          status: 'failed',
+          failureCode: 'invalid_state',
+          failureAt: failedAt,
+        });
+      }
+      if (propagateFailure) {
+        throw new CustomerVpsError(500, 'invalid_state', 'Provisioning failed');
+      }
+      return 'failed';
+    }
+
+    let serverIdForCompensation: number | null = null;
+    try {
+      const payload = openProvisioningPayload(job.encryptedPayload, deps.config.platformSecret);
+      const imageVersion = row.imageVersion ?? deps.config.imageVersion;
+      const hostConfig = buildHostConfig(
+        deps.config,
+        {
+          clerkUserId: row.clerkUserId,
+          handle: row.handle,
+          runtimeSlot: row.runtimeSlot,
+          developerTools: row.developerTools,
+        },
+        row.machineId,
+        payload.registrationToken,
+        payload.postgresPassword,
+        {
+          imageVersion,
+          hostBundleUrl: hostBundleUrlForImageVersion(deps.config, imageVersion),
+        },
+      );
+      const userData = renderCloudInitTemplate(
+        deps.cloudInitTemplate ?? DEFAULT_CLOUD_INIT_TEMPLATE,
+        hostConfig,
+      );
+      const server = await deps.hetzner.createServer({
+        name: buildServerName(row.handle),
+        serverType: row.serverType ?? deps.config.serverType,
+        userData,
+        labels: {
+          app: 'matrix-os',
+          clerk_user_id: row.clerkUserId,
+          runtime_slot: row.runtimeSlot,
+          machine_id: row.machineId,
+        },
+      });
+      serverIdForCompensation = server.id;
+      const completedAt = now().toISOString();
+      await runInPlatformTransaction(deps.db, async (trx) => {
+        await updateUserMachine(trx, row.machineId, {
+          hetznerServerId: server.id,
+          publicIPv4: server.publicIPv4,
+          publicIPv6: server.publicIPv6,
+        });
+        const completed = await completeProvisioningJob(trx, job.jobId, completedAt);
+        if (!completed) {
+          throw new Error('Provisioning job completion lost its lease');
+        }
+      });
+      return 'completed';
+    } catch (err: unknown) {
+      const mapped = genericProviderError(err);
+      if (serverIdForCompensation !== null) {
+        try {
+          await deps.hetzner.deleteServer(serverIdForCompensation);
+        } catch (cleanupErr: unknown) {
+          logCustomerVpsError('provision compensation delete failed', cleanupErr);
+          await queueProviderDeletion({
+            providerServerId: serverIdForCompensation,
+            reason: 'provision_compensation',
+            machineId: row.machineId,
+            handle: row.handle,
+            err: cleanupErr,
+          });
+        }
+      }
+      const failedAt = now().toISOString();
+      try {
+        await runInPlatformTransaction(deps.db, async (trx) => {
+          await updateUserMachine(trx, row.machineId, {
+            status: 'failed',
+            failureCode: toFailureCode(err),
+            failureAt: failedAt,
+          });
+          await failProvisioningJob(trx, job.jobId, failedAt, toFailureCode(err));
+        });
+      } catch (statusErr: unknown) {
+        logCustomerVpsError('provision failure status update failed', statusErr);
+      }
+      if (propagateFailure) {
+        logCustomerVpsError(`provisioning job failed machineId=${row.machineId}`, err);
+        throw mapped;
+      }
+      logCustomerVpsError(`provisioning job failed machineId=${row.machineId}`, err);
+      return 'failed';
+    }
+  }
+
+  async function dispatchProvisioningJobs(): Promise<{ checked: number; completed: number; failed: number }> {
+    const jobs = await listDispatchableProvisioningJobs(
+      deps.db,
+      now().toISOString(),
+      deps.config.reconciliationBatchSize,
+    );
+    let completed = 0;
+    let failed = 0;
+    for (const job of jobs) {
+      const result = await dispatchProvisioningJob(job.jobId, false);
+      if (result === 'completed') completed += 1;
+      if (result === 'failed') failed += 1;
+    }
+    return { checked: jobs.length, completed, failed };
+  }
+
   async function provision(
     input: ProvisionRequest,
     provisioningClass: UserMachineProvisioningClass,
@@ -603,8 +753,13 @@ export function createCustomerVpsService(deps: CustomerVpsServiceDeps): Customer
     };
     const currentTime = now();
     const machineId = machineIdFactory();
+    const jobId = provisioningJobIdFactory();
     const registration = tokenFactory(currentTime, deps.config.registrationTokenTtlMs);
     const postgresPassword = postgresPasswordFactory();
+    const encryptedPayload = sealProvisioningPayload({
+      registrationToken: registration.token,
+      postgresPassword,
+    }, deps.config.platformSecret);
     const billingContext = provisioningClass === 'preview'
       ? null
       : await resolveBillingProvisionContext(deps, request, currentTime);
@@ -623,18 +778,14 @@ export function createCustomerVpsService(deps: CustomerVpsServiceDeps): Customer
       && !(provisioningClass === 'preview' && existingBeforeBundleResolve.runtimeSlot !== request.runtimeSlot)
       && (provisioningClass === 'customer' || existingBeforeBundleResolve.provisioningClass === 'preview')
     ) {
+      const existingJob = await getProvisioningJobByMachineId(deps.db, existingBeforeBundleResolve.machineId);
+      if (existingJob && (existingJob.status === 'queued' || existingJob.status === 'running')) {
+        await dispatchProvisioningJob(existingJob.jobId, true);
+      }
       return activeProvisionResponse(existingBeforeBundleResolve, deps.config.provisionEtaSeconds);
     }
 
     const bundleRef = await resolveHostBundleRef(deps.db, deps.config);
-    const hostConfig = buildHostConfig(
-      deps.config,
-      request,
-      machineId,
-      registration.token,
-      postgresPassword,
-      bundleRef,
-    );
 
     const provisionRow = await runInPlatformTransaction(deps.db, async (trx) => {
       // Preview capacity and customer entitlement checks share the owner lock
@@ -726,63 +877,24 @@ export function createCustomerVpsService(deps: CustomerVpsServiceDeps): Customer
         provisionedAt: currentTime.toISOString(),
         attempt,
       });
+      await enqueueProvisioningJob(trx, {
+        jobId,
+        machineId,
+        encryptedPayload,
+        availableAt: currentTime.toISOString(),
+        createdAt: currentTime.toISOString(),
+      });
       return { existing: null };
     });
     if (provisionRow.existing) {
+      const existingJob = await getProvisioningJobByMachineId(deps.db, provisionRow.existing.machineId);
+      if (existingJob && (existingJob.status === 'queued' || existingJob.status === 'running')) {
+        await dispatchProvisioningJob(existingJob.jobId, true);
+      }
       return activeProvisionResponse(provisionRow.existing, deps.config.provisionEtaSeconds);
     }
 
-    const userData = renderCloudInitTemplate(
-      deps.cloudInitTemplate ?? DEFAULT_CLOUD_INIT_TEMPLATE,
-      hostConfig,
-    );
-
-    let serverIdForCompensation: number | null = null;
-    try {
-      const server = await deps.hetzner.createServer({
-        name: buildServerName(request.handle),
-        serverType: billingContext?.serverType ?? deps.config.serverType,
-        userData,
-        labels: {
-          app: 'matrix-os',
-          clerk_user_id: request.clerkUserId,
-          runtime_slot: request.runtimeSlot,
-          machine_id: machineId,
-        },
-      });
-      serverIdForCompensation = server.id;
-      await updateUserMachine(deps.db, machineId, {
-        hetznerServerId: server.id,
-        publicIPv4: server.publicIPv4,
-        publicIPv6: server.publicIPv6,
-      });
-    } catch (err: unknown) {
-      const mapped = genericProviderError(err);
-      if (serverIdForCompensation !== null) {
-        try {
-          await deps.hetzner.deleteServer(serverIdForCompensation);
-        } catch (cleanupErr: unknown) {
-          logCustomerVpsError('provision compensation delete failed', cleanupErr);
-          await queueProviderDeletion({
-            providerServerId: serverIdForCompensation,
-            reason: 'provision_compensation',
-            machineId,
-            handle: request.handle,
-            err: cleanupErr,
-          });
-        }
-      }
-      try {
-        await updateUserMachine(deps.db, machineId, {
-          status: 'failed',
-          failureCode: toFailureCode(err),
-          failureAt: now().toISOString(),
-        });
-      } catch (statusErr: unknown) {
-        logCustomerVpsError('provision failure status update failed', statusErr);
-      }
-      throw mapped;
-    }
+    await dispatchProvisioningJob(jobId, true);
 
     return {
       machineId,
@@ -1194,6 +1306,8 @@ export function createCustomerVpsService(deps: CustomerVpsServiceDeps): Customer
       return machines.map(statusResponse);
     },
 
+    dispatchProvisioningJobs,
+
     async deploy(target?: DeployTarget): Promise<DeployResult> {
       const runningMachines = await listRunningUserMachines(deps.db, 500);
       const machines = target?.handle
@@ -1243,6 +1357,7 @@ export function createCustomerVpsService(deps: CustomerVpsServiceDeps): Customer
     },
 
     async reconcileProvisioning() {
+      await dispatchProvisioningJobs();
       const staleBefore = new Date(now().getTime() - deps.config.reconciliationStaleAfterMs).toISOString();
       const rows = await listStaleUserMachines(
         deps.db,

--- a/packages/platform/src/customer-vps.ts
+++ b/packages/platform/src/customer-vps.ts
@@ -313,6 +313,8 @@ function buildHostConfig(
 }
 
 const HOST_BUNDLE_CHANNELS = new Set(['stable', 'canary', 'beta', 'dev']);
+const MAX_LOCAL_PROVISION_LOCKS = 1_024;
+const MAX_LOCAL_PROVISION_QUEUE_DEPTH = 20;
 
 interface HostBundleRef {
   imageVersion: string;
@@ -443,6 +445,39 @@ function sleep(ms: number): Promise<void> {
 export function createCustomerVpsService(deps: CustomerVpsServiceDeps): CustomerVpsService {
   const machineIdFactory = deps.machineIdFactory ?? randomUUID;
   const provisioningJobIdFactory = deps.provisioningJobIdFactory ?? randomUUID;
+  const localProvisionLocks = new Map<string, { tail: Promise<void>; depth: number }>();
+
+  async function withLocalProvisionLock<T>(key: string, fn: () => Promise<T>): Promise<T> {
+    let lock = localProvisionLocks.get(key);
+    if (!lock) {
+      if (localProvisionLocks.size >= MAX_LOCAL_PROVISION_LOCKS) {
+        throw new CustomerVpsError(503, 'provider_unavailable', 'Provisioning unavailable');
+      }
+      lock = { tail: Promise.resolve(), depth: 0 };
+      localProvisionLocks.set(key, lock);
+    }
+    if (lock.depth >= MAX_LOCAL_PROVISION_QUEUE_DEPTH) {
+      throw new CustomerVpsError(429, 'provider_unavailable', 'Try again later');
+    }
+
+    const predecessor = lock.tail;
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    lock.tail = predecessor.then(() => gate);
+    lock.depth += 1;
+    await predecessor;
+    try {
+      return await fn();
+    } finally {
+      release();
+      lock.depth -= 1;
+      if (lock.depth === 0 && localProvisionLocks.get(key) === lock) {
+        localProvisionLocks.delete(key);
+      }
+    }
+  }
   const enqueueProvisioningJob = deps.enqueueProvisioningJob ?? insertProvisioningJob;
   const tokenFactory = deps.tokenFactory ?? createRegistrationToken;
   const postgresPasswordFactory = deps.postgresPasswordFactory ?? (() => randomBytes(24).toString('base64url'));
@@ -795,6 +830,14 @@ export function createCustomerVpsService(deps: CustomerVpsServiceDeps): Customer
     return { checked: jobs.length, completed, failed };
   }
 
+  async function dispatchProvisioningJobBestEffort(jobId: string): Promise<void> {
+    try {
+      await dispatchProvisioningJob(jobId, true);
+    } catch (err: unknown) {
+      logCustomerVpsError('durable provisioning job immediate dispatch unavailable', err);
+    }
+  }
+
   async function provision(
     input: ProvisionRequest,
     provisioningClass: UserMachineProvisioningClass,
@@ -833,14 +876,16 @@ export function createCustomerVpsService(deps: CustomerVpsServiceDeps): Customer
     ) {
       const existingJob = await getProvisioningJobByMachineId(deps.db, existingBeforeBundleResolve.machineId);
       if (existingJob && (existingJob.status === 'queued' || existingJob.status === 'running')) {
-        await dispatchProvisioningJob(existingJob.jobId, true);
+        await dispatchProvisioningJobBestEffort(existingJob.jobId);
       }
       return activeProvisionResponse(existingBeforeBundleResolve, deps.config.provisionEtaSeconds);
     }
 
     const bundleRef = await resolveHostBundleRef(deps.db, deps.config);
 
-    const provisionRow = await runInPlatformTransaction(deps.db, async (trx) => {
+    let provisionRow: { existing: UserMachineRecord | null };
+    try {
+      provisionRow = await runInPlatformTransaction(deps.db, async (trx) => {
       // Preview capacity and customer entitlement checks share the owner lock
       // with insertion so concurrent platform instances cannot over-allocate.
       if (billingContext || provisioningClass === 'preview') {
@@ -937,17 +982,54 @@ export function createCustomerVpsService(deps: CustomerVpsServiceDeps): Customer
         availableAt: currentTime.toISOString(),
         createdAt: currentTime.toISOString(),
       });
-      return { existing: null };
-    });
+        return { existing: null };
+      });
+    } catch (err: unknown) {
+      const errorCode = err instanceof Error
+        ? (err as Error & { code?: unknown }).code
+        : undefined;
+      const errorMessage = err instanceof Error ? err.message : '';
+      const raceLookupAttempts = errorCode === '23505'
+        || errorMessage.includes('idx_user_machines_clerk_slot_active')
+        || errorMessage.includes('current transaction is aborted')
+        ? 3
+        : 1;
+      let concurrent: UserMachineRecord | undefined;
+      for (let attempt = 0; attempt < raceLookupAttempts; attempt += 1) {
+        try {
+          concurrent = await findExistingProvisioningMachine(deps.db, request, provisioningClass);
+        } catch (lookupErr: unknown) {
+          logCustomerVpsError('provisioning convergence lookup unavailable', lookupErr);
+          throw err;
+        }
+        if (concurrent?.status !== 'failed') break;
+        if (attempt + 1 < raceLookupAttempts) {
+          await new Promise((resolve) => setTimeout(resolve, 10));
+        }
+      }
+      if (
+        concurrent
+        && concurrent.status !== 'failed'
+        && !(provisioningClass === 'preview' && concurrent.runtimeSlot !== request.runtimeSlot)
+        && (provisioningClass === 'customer' || concurrent.provisioningClass === 'preview')
+      ) {
+        const concurrentJob = await getProvisioningJobByMachineId(deps.db, concurrent.machineId);
+        if (concurrentJob && (concurrentJob.status === 'queued' || concurrentJob.status === 'running')) {
+          await dispatchProvisioningJobBestEffort(concurrentJob.jobId);
+        }
+        return activeProvisionResponse(concurrent, deps.config.provisionEtaSeconds);
+      }
+      throw err;
+    }
     if (provisionRow.existing) {
       const existingJob = await getProvisioningJobByMachineId(deps.db, provisionRow.existing.machineId);
       if (existingJob && (existingJob.status === 'queued' || existingJob.status === 'running')) {
-        await dispatchProvisioningJob(existingJob.jobId, true);
+        await dispatchProvisioningJobBestEffort(existingJob.jobId);
       }
       return activeProvisionResponse(provisionRow.existing, deps.config.provisionEtaSeconds);
     }
 
-    await dispatchProvisioningJob(jobId, true);
+    await dispatchProvisioningJobBestEffort(jobId);
 
     return {
       machineId,
@@ -958,11 +1040,17 @@ export function createCustomerVpsService(deps: CustomerVpsServiceDeps): Customer
 
   return {
     async provision(input) {
-      return provision(input, 'customer');
+      return withLocalProvisionLock(
+        `${input.clerkUserId}:${input.runtimeSlot ?? 'primary'}`,
+        () => provision(input, 'customer'),
+      );
     },
 
     async provisionPreview(input) {
-      return provision(input, 'preview');
+      return withLocalProvisionLock(
+        `${input.clerkUserId}:${input.runtimeSlot ?? 'primary'}`,
+        () => provision(input, 'preview'),
+      );
     },
 
     async register(token, input) {

--- a/packages/platform/src/customer-vps.ts
+++ b/packages/platform/src/customer-vps.ts
@@ -70,9 +70,11 @@ import {
   claimProvisioningJob,
   completeProvisioningJob,
   failProvisioningJob,
+  getProvisioningJob,
   getProvisioningJobByMachineId,
   insertProvisioningJob,
   listDispatchableProvisioningJobs,
+  MAX_PROVISIONING_JOB_ATTEMPTS,
   openProvisioningPayload,
   sealProvisioningPayload,
   type NewProvisioningJob,
@@ -614,6 +616,31 @@ export function createCustomerVpsService(deps: CustomerVpsServiceDeps): Customer
     propagateFailure: boolean,
   ): Promise<'completed' | 'failed' | 'skipped'> {
     const claimedAt = now();
+    const pendingJob = await getProvisioningJob(deps.db, jobId);
+    if (
+      pendingJob?.status === 'running'
+      && pendingJob.attempts >= MAX_PROVISIONING_JOB_ATTEMPTS
+      && pendingJob.leaseExpiresAt
+      && pendingJob.leaseExpiresAt <= claimedAt.toISOString()
+    ) {
+      await runInPlatformTransaction(deps.db, async (trx) => {
+        await updateUserMachine(trx, pendingJob.machineId, {
+          status: 'failed',
+          failureCode: 'retry_exhausted',
+          failureAt: claimedAt.toISOString(),
+        });
+        await failProvisioningJob(
+          trx,
+          pendingJob.jobId,
+          claimedAt.toISOString(),
+          'retry_exhausted',
+        );
+      });
+      if (propagateFailure) {
+        throw new CustomerVpsError(500, 'retry_exhausted', 'Provisioning failed');
+      }
+      return 'failed';
+    }
     const job = await claimProvisioningJob(
       deps.db,
       jobId,

--- a/packages/platform/src/customer-vps.ts
+++ b/packages/platform/src/customer-vps.ts
@@ -832,6 +832,11 @@ export function createCustomerVpsService(deps: CustomerVpsServiceDeps): Customer
     try {
       await dispatchProvisioningJob(jobId, true);
     } catch (err: unknown) {
+      const code = err instanceof Error ? (err as Error & { code?: unknown }).code : undefined;
+      const message = err instanceof Error ? err.message : '';
+      if (code !== '25P02' && !message.includes('current transaction is aborted')) {
+        throw err;
+      }
       logCustomerVpsError('durable provisioning job immediate dispatch unavailable', err);
     }
   }

--- a/packages/platform/src/customer-vps.ts
+++ b/packages/platform/src/customer-vps.ts
@@ -789,8 +789,6 @@ export function createCustomerVpsService(deps: CustomerVpsServiceDeps): Customer
       }
       if (adoptedExistingServer) {
         logCustomerVpsError(`adopted provisioning server persistence failed machineId=${row.machineId}`, err);
-        if (propagateFailure) throw mapped;
-        return 'skipped';
       }
       const failedAt = now().toISOString();
       try {

--- a/packages/platform/src/db.ts
+++ b/packages/platform/src/db.ts
@@ -71,6 +71,21 @@ interface UserMachinesTable {
   attempt: number;
 }
 
+export interface ProvisioningJobsTable {
+  job_id: string;
+  machine_id: string;
+  status: string;
+  attempts: number;
+  available_at: string;
+  claimed_at: string | null;
+  lease_expires_at: string | null;
+  encrypted_payload: string | null;
+  last_error_code: string | null;
+  created_at: string;
+  updated_at: string;
+  completed_at: string | null;
+}
+
 interface HostBundleReleasesTable {
   version: string;
   channel: string | null;
@@ -287,6 +302,7 @@ export interface PlatformDatabase {
   users: UsersTable;
   containers: ContainersTable;
   user_machines: UserMachinesTable;
+  provisioning_jobs: ProvisioningJobsTable;
   billing_checkout_attempts: BillingCheckoutAttemptsTable;
   onboarding_first_run: OnboardingFirstRunTable;
   onboarding_journey_events: OnboardingJourneyEventsTable;
@@ -713,6 +729,27 @@ async function migrate(db: Kysely<PlatformDatabase>): Promise<void> {
   `.execute(db);
   await sql`CREATE INDEX IF NOT EXISTS idx_user_machines_clerk_slot_status ON user_machines(clerk_user_id, runtime_slot, status)`.execute(db);
   await sql`CREATE INDEX IF NOT EXISTS idx_user_machines_hetzner ON user_machines(hetzner_server_id)`.execute(db);
+
+  await sql`
+    CREATE TABLE IF NOT EXISTS provisioning_jobs (
+      job_id TEXT PRIMARY KEY,
+      machine_id TEXT NOT NULL UNIQUE REFERENCES user_machines(machine_id) ON UPDATE CASCADE,
+      status TEXT NOT NULL DEFAULT 'queued',
+      attempts INTEGER NOT NULL DEFAULT 0,
+      available_at TEXT NOT NULL,
+      claimed_at TEXT,
+      lease_expires_at TEXT,
+      encrypted_payload TEXT,
+      last_error_code TEXT,
+      created_at TEXT NOT NULL,
+      updated_at TEXT NOT NULL,
+      completed_at TEXT
+    )
+  `.execute(db);
+  await sql`
+    CREATE INDEX IF NOT EXISTS idx_provisioning_jobs_dispatch
+    ON provisioning_jobs(status, available_at, lease_expires_at)
+  `.execute(db);
 
   // Onboarding journey (spec 092): server-owned signup-to-ready state. Schema is
   // uniformly TEXT/uuid/ISO-string to match the rest of this file (no jsonb/serial).

--- a/tests/platform/customer-vps-provisioning-durability.test.ts
+++ b/tests/platform/customer-vps-provisioning-durability.test.ts
@@ -210,4 +210,46 @@ describe('platform/customer-vps provisioning durability', () => {
       publicIPv4: '203.0.113.20',
     });
   });
+
+  it('fails an expired job at the bounded worker-attempt limit without corrupting its row', async () => {
+    const enqueueProvisioningJob = vi.fn(async (transaction: PlatformDB, job: NewProvisioningJob) => {
+      await insertProvisioningJob(transaction, {
+        ...job,
+        availableAt: '2026-07-12T01:01:00.000Z',
+      });
+    });
+    let currentTime = new Date('2026-07-12T01:00:00.000Z');
+    const { app, hetzner, service } = createHarness({
+      enqueueProvisioningJob,
+      now: () => currentTime,
+    });
+    expect((await previewProvision(app)).status).toBe(202);
+    await db.executor.updateTable('provisioning_jobs').set({
+      status: 'running',
+      attempts: 100,
+      claimed_at: '2026-07-12T00:50:00.000Z',
+      lease_expires_at: '2026-07-12T00:55:00.000Z',
+    }).execute();
+
+    currentTime = new Date('2026-07-12T01:02:00.000Z');
+    await expect(service.dispatchProvisioningJobs()).resolves.toEqual({
+      checked: 1,
+      completed: 0,
+      failed: 1,
+    });
+
+    expect(hetzner.createServer).not.toHaveBeenCalled();
+    await expect(listProvisioningJobs(db, 10)).resolves.toEqual([
+      expect.objectContaining({
+        status: 'failed',
+        attempts: 100,
+        encryptedPayload: null,
+        lastErrorCode: 'retry_exhausted',
+      }),
+    ]);
+    await expect(getActiveUserMachineByHandle(db, 'pr-919', 'pr-919')).resolves.toMatchObject({
+      status: 'failed',
+      failureCode: 'retry_exhausted',
+    });
+  });
 });

--- a/tests/platform/customer-vps-provisioning-durability.test.ts
+++ b/tests/platform/customer-vps-provisioning-durability.test.ts
@@ -211,6 +211,44 @@ describe('platform/customer-vps provisioning durability', () => {
     });
   });
 
+  it('fails and clears a claimed job when adopted-server persistence fails', async () => {
+    let currentTime = new Date('2026-07-12T01:00:00.000Z');
+    const enqueueProvisioningJob = vi.fn(async (transaction: PlatformDB, job: NewProvisioningJob) => {
+      await insertProvisioningJob(transaction, {
+        ...job,
+        availableAt: '2026-07-12T01:01:00.000Z',
+      });
+    });
+    const hetzner = createMockHetznerClient({
+      listServersByLabel: vi.fn().mockResolvedValue([{
+        id: 654321,
+        status: 'running',
+        serverType: 'cpx22',
+        publicIPv4: '203.0.113.20',
+        publicIPv6: '2001:db8::20',
+      }]),
+    });
+    const { app, service } = createHarness({ enqueueProvisioningJob, hetzner, now: () => currentTime });
+    expect((await previewProvision(app)).status).toBe(202);
+
+    const transaction = vi.spyOn(db, 'transaction');
+    transaction.mockRejectedValueOnce(new Error('persistence unavailable'));
+    currentTime = new Date('2026-07-12T01:02:00.000Z');
+
+    await expect(service.dispatchProvisioningJobs()).resolves.toEqual({
+      checked: 1,
+      completed: 0,
+      failed: 1,
+    });
+    expect(hetzner.createServer).not.toHaveBeenCalled();
+    await expect(listProvisioningJobs(db, 10)).resolves.toEqual([
+      expect.objectContaining({ status: 'failed', encryptedPayload: null }),
+    ]);
+    await expect(getActiveUserMachineByHandle(db, 'pr-919', 'pr-919')).resolves.toMatchObject({
+      status: 'failed',
+    });
+  });
+
   it('fails an expired job at the bounded worker-attempt limit without corrupting its row', async () => {
     const enqueueProvisioningJob = vi.fn(async (transaction: PlatformDB, job: NewProvisioningJob) => {
       await insertProvisioningJob(transaction, {

--- a/tests/platform/customer-vps-provisioning-durability.test.ts
+++ b/tests/platform/customer-vps-provisioning-durability.test.ts
@@ -176,4 +176,38 @@ describe('platform/customer-vps provisioning durability', () => {
       expect.objectContaining({ status: 'completed', attempts: 1, encryptedPayload: null }),
     ]);
   });
+
+  it('adopts a provider server created before an expired worker lease instead of duplicating it', async () => {
+    let currentTime = new Date('2026-07-12T01:00:00.000Z');
+    const enqueueProvisioningJob = vi.fn(async (transaction: PlatformDB, job: NewProvisioningJob) => {
+      await insertProvisioningJob(transaction, {
+        ...job,
+        availableAt: '2026-07-12T01:01:00.000Z',
+      });
+    });
+    const hetzner = createMockHetznerClient({
+      listServersByLabel: vi.fn().mockResolvedValue([{
+        id: 654321,
+        status: 'running',
+        serverType: 'cpx22',
+        publicIPv4: '203.0.113.20',
+        publicIPv6: '2001:db8::20',
+      }]),
+    });
+    const { app, service } = createHarness({
+      enqueueProvisioningJob,
+      hetzner,
+      now: () => currentTime,
+    });
+
+    expect((await previewProvision(app)).status).toBe(202);
+    currentTime = new Date('2026-07-12T01:02:00.000Z');
+    await expect(service.dispatchProvisioningJobs()).resolves.toMatchObject({ completed: 1 });
+
+    expect(hetzner.createServer).not.toHaveBeenCalled();
+    await expect(getActiveUserMachineByHandle(db, 'pr-919', 'pr-919')).resolves.toMatchObject({
+      hetznerServerId: 654321,
+      publicIPv4: '203.0.113.20',
+    });
+  });
 });

--- a/tests/platform/customer-vps-provisioning-durability.test.ts
+++ b/tests/platform/customer-vps-provisioning-durability.test.ts
@@ -1,0 +1,179 @@
+import { Hono } from 'hono';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  getActiveUserMachineByHandle,
+  type PlatformDB,
+} from '../../packages/platform/src/db.js';
+import {
+  insertProvisioningJob,
+  listProvisioningJobs,
+  type NewProvisioningJob,
+} from '../../packages/platform/src/customer-vps-provisioning-jobs.js';
+import { createCustomerVpsRoutes } from '../../packages/platform/src/customer-vps-routes.js';
+import { createCustomerVpsService } from '../../packages/platform/src/customer-vps.js';
+import { loadCustomerVpsConfig } from '../../packages/platform/src/customer-vps-config.js';
+import { hashRegistrationToken } from '../../packages/platform/src/customer-vps-auth.js';
+import { createMockCustomerVpsSystemStore, createMockHetznerClient } from './customer-vps-fixtures.js';
+import { createTestPlatformDb, destroyTestPlatformDb } from './platform-db-test-helper.js';
+
+const PLATFORM_SECRET = 'platform-secret';
+const ADMIN_HEADERS = {
+  authorization: `Bearer ${PLATFORM_SECRET}`,
+  'content-type': 'application/json',
+};
+
+describe('platform/customer-vps provisioning durability', () => {
+  let db: PlatformDB;
+
+  beforeEach(async () => {
+    ({ db } = await createTestPlatformDb());
+  });
+
+  afterEach(async () => {
+    await destroyTestPlatformDb(db);
+  });
+
+  function createHarness(overrides: Parameters<typeof createCustomerVpsService>[0] = {} as never) {
+    const hetzner = createMockHetznerClient(overrides.hetzner);
+    const service = createCustomerVpsService({
+      db,
+      config: loadCustomerVpsConfig({
+        PLATFORM_SECRET,
+        HETZNER_API_TOKEN: 'provider-token',
+        PLATFORM_PUBLIC_URL: 'https://api.matrix-os.com',
+        CUSTOMER_VPS_IMAGE_VERSION: 'dev',
+        S3_ACCESS_KEY_ID: 'r2-access-key',
+        S3_SECRET_ACCESS_KEY: 'r2-secret-key',
+        S3_ENDPOINT: 'https://r2.example',
+        R2_BUCKET: 'matrixos-sync',
+      }),
+      hetzner,
+      systemStore: createMockCustomerVpsSystemStore(),
+      machineIdFactory: () => '9f05824c-8d0a-4d83-9cb4-b312d43ff112',
+      provisioningJobIdFactory: () => '721c3ef8-23f6-47e4-a890-6f6dc14759d1',
+      tokenFactory: () => ({
+        token: 'registration-token',
+        hash: hashRegistrationToken('registration-token'),
+        expiresAt: '2099-01-01T00:00:00.000Z',
+      }),
+      postgresPasswordFactory: () => 'postgres-secret',
+      now: () => new Date('2026-07-12T01:00:00.000Z'),
+      ...overrides,
+    });
+    const app = new Hono();
+    app.route('/vps', createCustomerVpsRoutes({ service, platformSecret: PLATFORM_SECRET }));
+    return { app, hetzner, service };
+  }
+
+  async function previewProvision(app: Hono): Promise<Response> {
+    return app.request('/vps/preview/provision', {
+      method: 'POST',
+      headers: ADMIN_HEADERS,
+      body: JSON.stringify({
+        clerkUserId: 'user_preview',
+        handle: 'pr-919',
+        runtimeSlot: 'pr-919',
+      }),
+    });
+  }
+
+  it('moves an absent preview through durably visible provisioning to running', async () => {
+    const { app, service } = createHarness();
+
+    const accepted = await previewProvision(app);
+
+    expect(accepted.status).toBe(202);
+    const machine = await getActiveUserMachineByHandle(db, 'pr-919', 'pr-919');
+    expect(machine).toMatchObject({ status: 'provisioning', provisioningClass: 'preview' });
+    const jobs = await listProvisioningJobs(db, 10);
+    expect(jobs).toHaveLength(1);
+    expect(jobs[0]).toMatchObject({ machineId: machine?.machineId, status: 'completed' });
+
+    await service.register('registration-token', {
+      machineId: machine!.machineId,
+      hetznerServerId: 123456,
+      publicIPv4: '203.0.113.10',
+      publicIPv6: '2001:db8::1',
+      imageVersion: 'dev',
+    });
+
+    await expect(getActiveUserMachineByHandle(db, 'pr-919', 'pr-919')).resolves.toMatchObject({
+      status: 'running',
+    });
+  });
+
+  it('keeps repeated preview provisioning idempotent across the machine and job', async () => {
+    const { app, hetzner } = createHarness();
+
+    const first = await previewProvision(app);
+    const second = await previewProvision(app);
+
+    expect(first.status).toBe(202);
+    expect(second.status).toBe(202);
+    expect(await second.json()).toEqual(await first.json());
+    expect(hetzner.createServer).toHaveBeenCalledTimes(1);
+    await expect(listProvisioningJobs(db, 10)).resolves.toHaveLength(1);
+  });
+
+  it('rolls back the machine and returns non-success when durable enqueue fails', async () => {
+    const enqueueProvisioningJob = vi.fn<(
+      db: PlatformDB,
+      job: NewProvisioningJob,
+    ) => Promise<void>>().mockRejectedValue(new Error('persistence unavailable'));
+    const { app, hetzner } = createHarness({ enqueueProvisioningJob });
+
+    const response = await previewProvision(app);
+
+    expect(response.status).toBe(500);
+    expect(await response.json()).toEqual({ error: 'Provisioning failed' });
+    expect(hetzner.createServer).not.toHaveBeenCalled();
+    await expect(getActiveUserMachineByHandle(db, 'pr-919', 'pr-919')).resolves.toBeUndefined();
+  });
+
+  it('shows the accepted machine in fleet immediately', async () => {
+    const { app } = createHarness();
+
+    expect((await previewProvision(app)).status).toBe(202);
+    const fleet = await app.request('/vps/fleet', { headers: ADMIN_HEADERS });
+
+    expect(fleet.status).toBe(200);
+    expect(await fleet.json()).toMatchObject({
+      machines: [expect.objectContaining({
+        handle: 'pr-919',
+        runtimeSlot: 'pr-919',
+        status: 'provisioning',
+      })],
+    });
+  });
+
+  it('dispatches a durably queued job from the reconciliation worker', async () => {
+    let currentTime = new Date('2026-07-12T01:00:00.000Z');
+    const enqueueProvisioningJob = vi.fn(async (transaction: PlatformDB, job: NewProvisioningJob) => {
+      await insertProvisioningJob(transaction, {
+        ...job,
+        availableAt: '2026-07-12T01:01:00.000Z',
+      });
+    });
+    const { app, hetzner, service } = createHarness({
+      enqueueProvisioningJob,
+      now: () => currentTime,
+    });
+
+    expect((await previewProvision(app)).status).toBe(202);
+    expect(hetzner.createServer).not.toHaveBeenCalled();
+    await expect(listProvisioningJobs(db, 10)).resolves.toEqual([
+      expect.objectContaining({ status: 'queued', attempts: 0 }),
+    ]);
+
+    currentTime = new Date('2026-07-12T01:02:00.000Z');
+    await expect(service.dispatchProvisioningJobs()).resolves.toEqual({
+      checked: 1,
+      completed: 1,
+      failed: 0,
+    });
+    expect(hetzner.createServer).toHaveBeenCalledOnce();
+    await expect(listProvisioningJobs(db, 10)).resolves.toEqual([
+      expect.objectContaining({ status: 'completed', attempts: 1, encryptedPayload: null }),
+    ]);
+  });
+});

--- a/tests/platform/customer-vps-reliability.test.ts
+++ b/tests/platform/customer-vps-reliability.test.ts
@@ -181,7 +181,8 @@ describe('platform/customer-vps reliability', () => {
       service.provision({ clerkUserId: 'user_123', handle: 'alice' }),
     ]);
 
-    expect(results.some((r) => r.status === 'fulfilled')).toBe(true);
+    const failures = results.flatMap((result) => result.status === 'rejected' ? [String(result.reason)] : []);
+    expect(results.some((r) => r.status === 'fulfilled'), failures.join('\n')).toBe(true);
     const live = (await listUserMachines(db)).filter(
       (m) => m.clerkUserId === 'user_123' && m.deletedAt === null,
     );
@@ -202,7 +203,8 @@ describe('platform/customer-vps reliability', () => {
       service.provision({ clerkUserId: 'user_123', handle: 'alice' }),
     ]);
 
-    expect(results.some((r) => r.status === 'fulfilled')).toBe(true);
+    const failures = results.flatMap((result) => result.status === 'rejected' ? [String(result.reason)] : []);
+    expect(results.some((r) => r.status === 'fulfilled'), failures.join('\n')).toBe(true);
     for (const r of results) {
       if (r.status === 'rejected') {
         expect(r.reason).toBeInstanceOf(Error);


### PR DESCRIPTION
## Summary

- persist each new VPS machine and its provisioning job in one Postgres transaction
- encrypt and bound bootstrap payloads at rest, then clear them on completion or failure
- claim jobs with leases so reconciliation can resume committed work after interruption
- preserve synchronous dispatch compatibility while guaranteeing fleet visibility after acceptance
- cover absent to provisioning to running, idempotency, enqueue rollback, immediate fleet reads, and worker dispatch

## Validation

- `pnpm exec vitest run tests/platform/customer-vps.test.ts --silent` (71 passed)
- focused platform provisioning/routes/workflow suites (96 passed)
- `bun run typecheck` (passed)
- `bun run check:patterns` (0 violations; existing warnings only)
- `bun run check:patterns:diff` (0 violations)
- `git diff --check` (passed)

## Invariants

- **Source of truth:** Platform Postgres remains authoritative for machine and provisioning-job state.
- **Lock/transaction scope:** New machine and job inserts commit atomically inside the existing owner provisioning transaction and advisory lock. Job claims use one conditional update with a bounded lease.
- **Acceptable orphan states:** Provider creation remains outside the database transaction. A post-create persistence failure triggers provider compensation; failed compensation enters the existing durable deletion queue.
- **Auth source of truth:** Existing platform bearer auth, route body limits, and Zod request validation remain unchanged. Bootstrap payloads never enter route responses or fleet projections.
- **Error boundary:** Enqueue or persistence failure returns a generic non-success response and rolls back the machine row.
- **Deferred scope:** Preview workflow adoption and retry validation are isolated in the directly stacked follow-up PR. No production deployment, release promotion, or merge is included.
