### PR TITLE
fix(preview): validate provision acceptance

### DIFF
--- a/.github/workflows/preview-vps.yml
+++ b/.github/workflows/preview-vps.yml
@@ -405,7 +405,6 @@ jobs:
       CLERK_SECRET_KEY: ${{ secrets.CLERK_SECRET_KEY }}
       PREVIEW_CLERK_USER_ID: ${{ secrets.PREVIEW_CLERK_USER_ID }}
       PLATFORM_PUBLIC_URL: ${{ vars.PLATFORM_PUBLIC_URL || 'https://api.matrix-os.com' }}
-      APP_PUBLIC_URL: https://app.matrix-os.com
       HANDLE: ${{ needs.gate.outputs.handle }}
     steps:
       - name: Verify authenticated inventory projection
@@ -428,45 +427,30 @@ jobs:
             exit 1
           fi
 
-          task_id=""
-          cleanup() {
-            if [ -n "$task_id" ]; then
-              curl -fsS --max-time 30 -o /dev/null \
-                -X POST "https://api.clerk.com/v1/agents/tasks/${task_id}/revoke" \
-                -H "authorization: Bearer ${CLERK_SECRET_KEY}" \
-                -H "Clerk-API-Version: 2025-11-10" || true
-            fi
-          }
-          trap cleanup EXIT
-
-          redirect_url="${APP_PUBLIC_URL}/runtime"
-          task_body="$(jq -cn \
-            --arg user_id "$PREVIEW_CLERK_USER_ID" \
-            --arg redirect_url "$redirect_url" \
-            '{on_behalf_of: {user_id: $user_id}, permissions: "*", agent_name: "matrix-preview-verifier", task_description: "Verify preview computer inventory", redirect_url: $redirect_url, session_max_duration_in_seconds: 300}')"
-          task_code="$(curl -sS --max-time 30 -o /tmp/clerk-task.json -w '%{http_code}' \
-            -X POST "https://api.clerk.com/v1/agents/tasks" \
+          sessions_code="$(curl -sS --max-time 30 -o /tmp/clerk-sessions.json -w '%{http_code}' \
+            "https://api.clerk.com/v1/sessions?user_id=${PREVIEW_CLERK_USER_ID}&status=active&limit=10" \
+            -H "authorization: Bearer ${CLERK_SECRET_KEY}" \
+            -H "Clerk-API-Version: 2025-11-10")"
+          if [ "$sessions_code" != "200" ]; then
+            echo "Active preview verification sessions are unavailable (HTTP ${sessions_code})." >&2
+            exit 1
+          fi
+          session_id="$(jq -er 'sort_by(.last_active_at // 0) | reverse | .[0].id | select(type == "string" and test("^sess_[A-Za-z0-9]+$"))' /tmp/clerk-sessions.json)"
+          token_code="$(curl -sS --max-time 30 -o /tmp/clerk-token.json -w '%{http_code}' \
+            -X POST "https://api.clerk.com/v1/sessions/${session_id}/tokens" \
             -H "authorization: Bearer ${CLERK_SECRET_KEY}" \
             -H "Clerk-API-Version: 2025-11-10" \
             -H "content-type: application/json" \
-            --data-binary "$task_body")"
-          case "$task_code" in
-            200|201) ;;
-            *)
-              task_error="$(jq -r '.errors[0].code // "unknown" | select(type == "string" and test("^[a-z0-9_]{1,80}$"))' /tmp/clerk-task.json 2>/dev/null || true)"
-              task_field="$(jq -r '.errors[0].meta.name // "unknown" | select(type == "string" and test("^[a-z0-9_]{1,80}$"))' /tmp/clerk-task.json 2>/dev/null || true)"
-              echo "Temporary preview verification task failed with HTTP ${task_code} (${task_error:-unknown}, field ${task_field:-unknown})." >&2
-              exit 1
-              ;;
-          esac
-          task_id="$(jq -er '.id | select(type == "string" and test("^[A-Za-z0-9_-]{1,128}$"))' /tmp/clerk-task.json)"
-          task_url="$(jq -er '.url | select(type == "string" and length <= 4096 and startswith("https://"))' /tmp/clerk-task.json)"
-          curl -fsS --max-time 30 --max-redirs 10 -c /tmp/clerk-cookies.txt -b /tmp/clerk-cookies.txt \
-            -o /dev/null -L "$task_url"
+            --data-binary '{"expires_in_seconds":60}')"
+          if [ "$token_code" != "200" ]; then
+            echo "Preview verification token is unavailable (HTTP ${token_code})." >&2
+            exit 1
+          fi
+          session_token="$(jq -er '.jwt | select(type == "string" and length <= 8192)' /tmp/clerk-token.json)"
 
           inventory_code="$(curl -sS --max-time 30 -o /tmp/computers.json -w '%{http_code}' \
             "${PLATFORM_PUBLIC_URL}/api/auth/computers" \
-            -b /tmp/clerk-cookies.txt)"
+            -H "authorization: Bearer ${session_token}")"
           if [ "$inventory_code" != "200" ]; then
             echo "Authenticated computer inventory is unavailable." >&2
             exit 1

--- a/.github/workflows/preview-vps.yml
+++ b/.github/workflows/preview-vps.yml
@@ -415,6 +415,18 @@ jobs:
             echo "Preview inventory verification is not configured." >&2
             exit 1
           fi
+          if ! printf '%s' "$PREVIEW_CLERK_USER_ID" | grep -Eq '^user_[A-Za-z0-9]+$'; then
+            echo "Preview inventory verification user is invalid." >&2
+            exit 1
+          fi
+          user_code="$(curl -sS --max-time 30 -o /dev/null -w '%{http_code}' \
+            "https://api.clerk.com/v1/users/${PREVIEW_CLERK_USER_ID}" \
+            -H "authorization: Bearer ${CLERK_SECRET_KEY}" \
+            -H "Clerk-API-Version: 2025-11-10")"
+          if [ "$user_code" != "200" ]; then
+            echo "Configured preview verification user is unavailable (HTTP ${user_code})." >&2
+            exit 1
+          fi
 
           task_id=""
           cleanup() {

--- a/.github/workflows/preview-vps.yml
+++ b/.github/workflows/preview-vps.yml
@@ -28,6 +28,10 @@ on:
         description: "PR number to deploy a preview VPS for"
         required: true
         type: string
+      version:
+        description: "Optional existing version pinned to this PR head"
+        required: false
+        type: string
 
 permissions:
   contents: read
@@ -49,6 +53,9 @@ jobs:
       action: ${{ steps.decide.outputs.action }}
       pr: ${{ steps.decide.outputs.pr }}
       handle: ${{ steps.decide.outputs.handle }}
+      head_sha: ${{ steps.decide.outputs.head_sha }}
+      head_ref: ${{ steps.decide.outputs.head_ref }}
+      requested_version: ${{ steps.decide.outputs.requested_version }}
     steps:
       - name: Decide action
         id: decide
@@ -58,11 +65,29 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number || inputs.pr }}
           LABELED_NAME: ${{ github.event.label.name }}
           HAS_LABEL: ${{ contains(github.event.pull_request.labels.*.name, 'preview-vps') }}
-          SAME_REPO: ${{ github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository }}
+          EVENT_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          EVENT_HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          EVENT_HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+          REQUESTED_VERSION: ${{ inputs.version }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
           action="skip"
-          if [ "$SAME_REPO" != "true" ]; then
+          if ! printf '%s' "$PR_NUMBER" | grep -Eq '^[0-9]+$'; then
+            echo "Invalid PR number" >&2
+            exit 1
+          fi
+
+          head_sha="$EVENT_HEAD_SHA"
+          head_ref="$EVENT_HEAD_REF"
+          head_repo="$EVENT_HEAD_REPO"
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            pr_json="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}")"
+            head_sha="$(jq -r .head.sha <<< "$pr_json")"
+            head_ref="$(jq -r .head.ref <<< "$pr_json")"
+            head_repo="$(jq -r .head.repo.full_name <<< "$pr_json")"
+          fi
+          if [ "$head_repo" != "$GITHUB_REPOSITORY" ]; then
             echo "Fork PRs never get preview VPSes (secrets are not exposed to them anyway)."
           elif [ "$EVENT_NAME" = "workflow_dispatch" ]; then
             action="deploy"
@@ -73,14 +98,25 @@ jobs:
           elif [ "$HAS_LABEL" = "true" ]; then
             action="deploy"
           fi
-          if ! printf '%s' "$PR_NUMBER" | grep -Eq '^[0-9]+$'; then
-            echo "Invalid PR number" >&2
+          if [ "$action" = "deploy" ] && ! printf '%s' "$head_sha" | grep -Eq '^[0-9a-f]{40}$'; then
+            echo "Invalid PR head SHA" >&2
             exit 1
+          fi
+          if [ -n "$REQUESTED_VERSION" ]; then
+            if ! printf '%s' "$REQUESTED_VERSION" |
+              grep -Eq "^v[0-9]{4}\\.[0-9]{2}\\.[0-9]{2}-pr${PR_NUMBER}-[0-9a-f]{7}$" ||
+              [ "${REQUESTED_VERSION##*-}" != "${head_sha:0:7}" ]; then
+              echo "Invalid pinned preview version" >&2
+              exit 1
+            fi
           fi
           {
             echo "action=$action"
             echo "pr=$PR_NUMBER"
             echo "handle=pr-$PR_NUMBER"
+            echo "head_sha=$head_sha"
+            echo "head_ref=$head_ref"
+            echo "requested_version=$REQUESTED_VERSION"
           } >> "$GITHUB_OUTPUT"
           echo "action=$action pr=$PR_NUMBER"
 
@@ -101,7 +137,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          ref: ${{ needs.gate.outputs.head_sha }}
 
       - uses: pnpm/action-setup@v6
 
@@ -133,10 +169,11 @@ jobs:
         id: version
         env:
           PR_NUMBER: ${{ needs.gate.outputs.pr }}
-          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+          HEAD_SHA: ${{ needs.gate.outputs.head_sha }}
+          REQUESTED_VERSION: ${{ needs.gate.outputs.requested_version }}
         run: |
           set -euo pipefail
-          VERSION="v$(date -u +%Y.%m.%d)-pr${PR_NUMBER}-${HEAD_SHA:0:7}"
+          VERSION="${REQUESTED_VERSION:-v$(date -u +%Y.%m.%d)-pr${PR_NUMBER}-${HEAD_SHA:0:7}}"
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "Preview version: $VERSION"
 
@@ -144,8 +181,8 @@ jobs:
         env:
           HOST_BUNDLE_VERSION: ${{ steps.version.outputs.version }}
           HOST_BUNDLE_CHANNEL: none
-          MATRIX_BUILD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
-          MATRIX_BUILD_REF: ${{ github.event.pull_request.head.ref || github.ref_name }}
+          MATRIX_BUILD_SHA: ${{ needs.gate.outputs.head_sha }}
+          MATRIX_BUILD_REF: ${{ needs.gate.outputs.head_ref }}
         run: |
           set -euo pipefail
           ./scripts/build-host-bundle.sh
@@ -184,7 +221,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          ref: ${{ needs.gate.outputs.head_sha }}
 
       - name: Download bundle artifact
         uses: actions/download-artifact@v8

--- a/.github/workflows/preview-vps.yml
+++ b/.github/workflows/preview-vps.yml
@@ -441,7 +441,8 @@ jobs:
           case "$task_code" in
             200|201) ;;
             *)
-              echo "Temporary preview verification task failed with HTTP ${task_code}." >&2
+              task_error="$(jq -r '.errors[0].code // "unknown" | select(type == "string" and test("^[a-z0-9_]{1,80}$"))' /tmp/clerk-task.json 2>/dev/null || true)"
+              echo "Temporary preview verification task failed with HTTP ${task_code} (${task_error:-unknown})." >&2
               exit 1
               ;;
           esac

--- a/.github/workflows/preview-vps.yml
+++ b/.github/workflows/preview-vps.yml
@@ -420,7 +420,8 @@ jobs:
             if [ -n "$session_id" ]; then
               curl -fsS --max-time 30 -o /dev/null \
                 -X POST "https://api.clerk.com/v1/sessions/${session_id}/revoke" \
-                -H "authorization: Bearer ${CLERK_SECRET_KEY}" || true
+                -H "authorization: Bearer ${CLERK_SECRET_KEY}" \
+                -H "Clerk-API-Version: 2025-11-10" || true
             fi
           }
           trap cleanup EXIT
@@ -429,6 +430,7 @@ jobs:
           session_code="$(curl -sS --max-time 30 -o /tmp/clerk-session.json -w '%{http_code}' \
             -X POST "https://api.clerk.com/v1/sessions" \
             -H "authorization: Bearer ${CLERK_SECRET_KEY}" \
+            -H "Clerk-API-Version: 2025-11-10" \
             -H "content-type: application/json" \
             --data-binary "$session_body")"
           case "$session_code" in
@@ -442,7 +444,8 @@ jobs:
 
           token_code="$(curl -sS --max-time 30 -o /tmp/clerk-token.json -w '%{http_code}' \
             -X POST "https://api.clerk.com/v1/sessions/${session_id}/tokens" \
-            -H "authorization: Bearer ${CLERK_SECRET_KEY}")"
+            -H "authorization: Bearer ${CLERK_SECRET_KEY}" \
+            -H "Clerk-API-Version: 2025-11-10")"
           if [ "$token_code" != "200" ]; then
             echo "Could not create the temporary preview verification token." >&2
             exit 1

--- a/.github/workflows/preview-vps.yml
+++ b/.github/workflows/preview-vps.yml
@@ -96,7 +96,13 @@ jobs:
           if [ "$head_repo" != "$GITHUB_REPOSITORY" ]; then
             echo "Fork PRs never get preview VPSes (secrets are not exposed to them anyway)."
           elif [ "$EVENT_NAME" = "workflow_dispatch" ]; then
-            if [ "$VERIFY_INVENTORY" = "true" ]; then action="verify"; else action="deploy"; fi
+            if [ "$VERIFY_INVENTORY" = "true" ]; then
+              action="verify"
+            elif [ -n "$REQUESTED_VERSION" ]; then
+              action="deploy_existing"
+            else
+              action="deploy"
+            fi
           elif [ "$EVENT_ACTION" = "closed" ]; then
             if [ "$HAS_LABEL" = "true" ]; then action="teardown"; fi
           elif [ "$EVENT_ACTION" = "labeled" ]; then
@@ -108,7 +114,7 @@ jobs:
             echo "Invalid PR head SHA" >&2
             exit 1
           fi
-          if [ "$action" = "deploy" ] && [ -n "$REQUESTED_VERSION" ]; then
+          if [ "$action" = "deploy_existing" ]; then
             if ! printf '%s' "$REQUESTED_VERSION" |
               grep -Eq "^v[0-9]{4}\\.[0-9]{2}\\.[0-9]{2}-pr${PR_NUMBER}-[0-9a-f]{7}$" ||
               [ "${REQUESTED_VERSION##*-}" != "${head_sha:0:7}" ]; then
@@ -210,7 +216,7 @@ jobs:
   deploy:
     name: Publish and deploy preview VPS
     needs: [gate, build]
-    if: needs.gate.outputs.action == 'deploy'
+    if: always() && ((needs.gate.outputs.action == 'deploy' && needs.build.result == 'success') || needs.gate.outputs.action == 'deploy_existing')
     runs-on: ubuntu-latest
     timeout-minutes: 20
     env:
@@ -223,19 +229,22 @@ jobs:
       PLATFORM_SECRET: ${{ secrets.PLATFORM_SECRET }}
       PREVIEW_CLERK_USER_ID: ${{ secrets.PREVIEW_CLERK_USER_ID }}
       HANDLE: ${{ needs.gate.outputs.handle }}
-      VERSION: ${{ needs.build.outputs.version }}
+      VERSION: ${{ needs.gate.outputs.action == 'deploy_existing' && needs.gate.outputs.requested_version || needs.build.outputs.version }}
     steps:
       - uses: actions/checkout@v6
+        if: needs.gate.outputs.action == 'deploy'
         with:
           ref: ${{ needs.gate.outputs.head_sha }}
 
       - name: Download bundle artifact
+        if: needs.gate.outputs.action == 'deploy'
         uses: actions/download-artifact@v8
         with:
           name: preview-bundle-${{ needs.gate.outputs.pr }}
           path: dist/host-bundle
 
       - name: Publish release (register-only, no channel)
+        if: needs.gate.outputs.action == 'deploy'
         run: |
           set -euo pipefail
           ./scripts/publish-release.sh "$VERSION" --channel none \

--- a/.github/workflows/preview-vps.yml
+++ b/.github/workflows/preview-vps.yml
@@ -274,6 +274,8 @@ jobs:
                | del(._preview_rank)')"
           status="$(jq -r '.status' <<< "$fleet_machine")"
           accepted_machine_id="$(jq -r '.machineId // ""' <<< "$fleet_machine")"
+          runtime_slot="$(jq -r '.runtimeSlot // ""' <<< "$fleet_machine")"
+          needs_provision=false
           echo "Fleet status for ${HANDLE}: ${status}"
 
           case "$status" in
@@ -282,9 +284,23 @@ jobs:
                 echo "Fleet returned an active preview without a machine ID." >&2
                 exit 1
               fi
-              echo "Reusing existing ${HANDLE} machine ${accepted_machine_id} (${status})"
+              if [ "$runtime_slot" = "$HANDLE" ]; then
+                echo "Reusing existing ${HANDLE} machine ${accepted_machine_id} (${status})"
+              else
+                echo "Active ${HANDLE} requires exact-slot adoption from ${runtime_slot:-unset}"
+                needs_provision=true
+              fi
               ;;
             absent|failed)
+              needs_provision=true
+              ;;
+            *)
+              echo "Preview ${HANDLE} is in an unsupported state (${status})." >&2
+              exit 1
+              ;;
+          esac
+
+          if [ "$needs_provision" = true ]; then
               provision_body="$(jq -cn \
                 --arg owner "$PREVIEW_CLERK_USER_ID" \
                 --arg handle "$HANDLE" \
@@ -309,12 +325,7 @@ jobs:
                 echo "Preview provision returned an invalid response." >&2
                 exit 1
               fi
-              ;;
-            *)
-              echo "Preview ${HANDLE} is in an unsupported state (${status})." >&2
-              exit 1
-              ;;
-          esac
+          fi
 
           status="$(curl -fsS --max-time 30 \
             -H "authorization: Bearer ${PLATFORM_SECRET}" \

--- a/.github/workflows/preview-vps.yml
+++ b/.github/workflows/preview-vps.yml
@@ -431,10 +431,13 @@ jobs:
             -H "authorization: Bearer ${CLERK_SECRET_KEY}" \
             -H "content-type: application/json" \
             --data-binary "$session_body")"
-          if [ "$session_code" != "200" ]; then
-            echo "Could not create the temporary preview verification session." >&2
-            exit 1
-          fi
+          case "$session_code" in
+            200|201) ;;
+            *)
+              echo "Temporary preview verification session failed with HTTP ${session_code}." >&2
+              exit 1
+              ;;
+          esac
           session_id="$(jq -er '.id | select(type == "string" and test("^sess_[A-Za-z0-9]+$"))' /tmp/clerk-session.json)"
 
           token_code="$(curl -sS --max-time 30 -o /tmp/clerk-token.json -w '%{http_code}' \

--- a/.github/workflows/preview-vps.yml
+++ b/.github/workflows/preview-vps.yml
@@ -32,6 +32,11 @@ on:
         description: "Optional existing version pinned to this PR head"
         required: false
         type: string
+      verify_inventory:
+        description: "Only verify the deployed preview in the authenticated computer inventory"
+        required: false
+        default: false
+        type: boolean
 
 permissions:
   contents: read
@@ -69,6 +74,7 @@ jobs:
           EVENT_HEAD_REF: ${{ github.event.pull_request.head.ref }}
           EVENT_HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
           REQUESTED_VERSION: ${{ inputs.version }}
+          VERIFY_INVENTORY: ${{ inputs.verify_inventory }}
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
@@ -90,7 +96,7 @@ jobs:
           if [ "$head_repo" != "$GITHUB_REPOSITORY" ]; then
             echo "Fork PRs never get preview VPSes (secrets are not exposed to them anyway)."
           elif [ "$EVENT_NAME" = "workflow_dispatch" ]; then
-            action="deploy"
+            if [ "$VERIFY_INVENTORY" = "true" ]; then action="verify"; else action="deploy"; fi
           elif [ "$EVENT_ACTION" = "closed" ]; then
             if [ "$HAS_LABEL" = "true" ]; then action="teardown"; fi
           elif [ "$EVENT_ACTION" = "labeled" ]; then
@@ -98,11 +104,11 @@ jobs:
           elif [ "$HAS_LABEL" = "true" ]; then
             action="deploy"
           fi
-          if [ "$action" = "deploy" ] && ! printf '%s' "$head_sha" | grep -Eq '^[0-9a-f]{40}$'; then
+          if [ "$action" != "skip" ] && ! printf '%s' "$head_sha" | grep -Eq '^[0-9a-f]{40}$'; then
             echo "Invalid PR head SHA" >&2
             exit 1
           fi
-          if [ -n "$REQUESTED_VERSION" ]; then
+          if [ "$action" = "deploy" ] && [ -n "$REQUESTED_VERSION" ]; then
             if ! printf '%s' "$REQUESTED_VERSION" |
               grep -Eq "^v[0-9]{4}\\.[0-9]{2}\\.[0-9]{2}-pr${PR_NUMBER}-[0-9a-f]{7}$" ||
               [ "${REQUESTED_VERSION##*-}" != "${head_sha:0:7}" ]; then
@@ -377,8 +383,74 @@ jobs:
           if [ -n "$existing" ]; then
             gh api -X PATCH "repos/${GITHUB_REPOSITORY}/issues/comments/${existing}" -f body="$body" > /dev/null
           else
-            gh api "repos/${GITHUB_REPOSITORY}/issues/${PR}/comments" -f body="$body" > /dev/null
+             gh api "repos/${GITHUB_REPOSITORY}/issues/${PR}/comments" -f body="$body" > /dev/null
+           fi
+
+  verify_inventory:
+    name: Verify preview computer inventory
+    needs: gate
+    if: needs.gate.outputs.action == 'verify'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    env:
+      CLERK_SECRET_KEY: ${{ secrets.CLERK_SECRET_KEY }}
+      PREVIEW_CLERK_USER_ID: ${{ secrets.PREVIEW_CLERK_USER_ID }}
+      PLATFORM_PUBLIC_URL: ${{ vars.PLATFORM_PUBLIC_URL || 'https://api.matrix-os.com' }}
+      HANDLE: ${{ needs.gate.outputs.handle }}
+    steps:
+      - name: Verify authenticated inventory projection
+        run: |
+          set -euo pipefail
+          if [ -z "${CLERK_SECRET_KEY:-}" ] || [ -z "${PREVIEW_CLERK_USER_ID:-}" ]; then
+            echo "Preview inventory verification is not configured." >&2
+            exit 1
           fi
+
+          session_id=""
+          cleanup() {
+            if [ -n "$session_id" ]; then
+              curl -fsS --max-time 30 -o /dev/null \
+                -X POST "https://api.clerk.com/v1/sessions/${session_id}/revoke" \
+                -H "authorization: Bearer ${CLERK_SECRET_KEY}" || true
+            fi
+          }
+          trap cleanup EXIT
+
+          session_body="$(jq -cn --arg user_id "$PREVIEW_CLERK_USER_ID" '{user_id: $user_id}')"
+          session_code="$(curl -sS --max-time 30 -o /tmp/clerk-session.json -w '%{http_code}' \
+            -X POST "https://api.clerk.com/v1/sessions" \
+            -H "authorization: Bearer ${CLERK_SECRET_KEY}" \
+            -H "content-type: application/json" \
+            --data-binary "$session_body")"
+          if [ "$session_code" != "200" ]; then
+            echo "Could not create the temporary preview verification session." >&2
+            exit 1
+          fi
+          session_id="$(jq -er '.id | select(type == "string" and test("^sess_[A-Za-z0-9]+$"))' /tmp/clerk-session.json)"
+
+          token_code="$(curl -sS --max-time 30 -o /tmp/clerk-token.json -w '%{http_code}' \
+            -X POST "https://api.clerk.com/v1/sessions/${session_id}/tokens" \
+            -H "authorization: Bearer ${CLERK_SECRET_KEY}")"
+          if [ "$token_code" != "200" ]; then
+            echo "Could not create the temporary preview verification token." >&2
+            exit 1
+          fi
+          session_token="$(jq -er '.jwt | select(type == "string" and length <= 8192)' /tmp/clerk-token.json)"
+
+          inventory_code="$(curl -sS --max-time 30 -o /tmp/computers.json -w '%{http_code}' \
+            "${PLATFORM_PUBLIC_URL}/api/auth/computers" \
+            -H "authorization: Bearer ${session_token}")"
+          if [ "$inventory_code" != "200" ]; then
+            echo "Authenticated computer inventory is unavailable." >&2
+            exit 1
+          fi
+          if ! jq -e --arg h "$HANDLE" \
+            '[.items[] | select(.handle == $h and .runtimeSlot == $h and .kind == "preview")] | length == 1' \
+            /tmp/computers.json > /dev/null; then
+            echo "Preview computer is not selectable in the authenticated inventory." >&2
+            exit 1
+          fi
+          echo "Verified ${HANDLE} in the authenticated computer inventory."
 
   teardown:
     name: Teardown preview VPS

--- a/.github/workflows/preview-vps.yml
+++ b/.github/workflows/preview-vps.yml
@@ -442,7 +442,8 @@ jobs:
             200|201) ;;
             *)
               task_error="$(jq -r '.errors[0].code // "unknown" | select(type == "string" and test("^[a-z0-9_]{1,80}$"))' /tmp/clerk-task.json 2>/dev/null || true)"
-              echo "Temporary preview verification task failed with HTTP ${task_code} (${task_error:-unknown})." >&2
+              task_field="$(jq -r '.errors[0].meta.name // "unknown" | select(type == "string" and test("^[a-z0-9_]{1,80}$"))' /tmp/clerk-task.json 2>/dev/null || true)"
+              echo "Temporary preview verification task failed with HTTP ${task_code} (${task_error:-unknown}, field ${task_field:-unknown})." >&2
               exit 1
               ;;
           esac

--- a/.github/workflows/preview-vps.yml
+++ b/.github/workflows/preview-vps.yml
@@ -331,7 +331,7 @@ jobs:
             -H "authorization: Bearer ${PLATFORM_SECRET}" \
             "${PLATFORM_PUBLIC_URL}/vps/fleet" |
             jq -r --arg h "$HANDLE" --arg id "$accepted_machine_id" \
-              '[.machines[] | select(.handle == $h and .machineId == $id)] | .[0].status // "absent"')"
+              '[.machines[] | select(.handle == $h and .machineId == $id and .runtimeSlot == $h)] | .[0].status // "absent"')"
           echo "Immediate fleet visibility for ${HANDLE}: ${status}"
           if [ "$status" != "provisioning" ] && [ "$status" != "running" ]; then
             echo "Accepted preview machine is not durably visible in the fleet." >&2

--- a/.github/workflows/preview-vps.yml
+++ b/.github/workflows/preview-vps.yml
@@ -210,7 +210,16 @@ jobs:
             -H "authorization: Bearer ${PLATFORM_SECRET}" \
             "${PLATFORM_PUBLIC_URL}/vps/fleet" |
             jq -c --arg h "$HANDLE" \
-              '[.machines[] | select(.handle == $h and .status != "deleted")] | .[0] // {status: "absent", machineId: ""}')"
+              '[.machines[]
+                | select(.handle == $h and .status != "deleted")
+                | . + { _preview_rank:
+                    (if .status == "running" then 0
+                     elif .status == "provisioning" then 1
+                     elif .status == "failed" then 2
+                     else 3 end) }]
+               | sort_by(._preview_rank, (if .runtimeSlot == $h then 0 else 1 end), .provisionedAt)
+               | (.[0] // {status: "absent", machineId: ""})
+               | del(._preview_rank)')"
           status="$(jq -r '.status' <<< "$fleet_machine")"
           accepted_machine_id="$(jq -r '.machineId // ""' <<< "$fleet_machine")"
           echo "Fleet status for ${HANDLE}: ${status}"

--- a/.github/workflows/preview-vps.yml
+++ b/.github/workflows/preview-vps.yml
@@ -405,6 +405,7 @@ jobs:
       CLERK_SECRET_KEY: ${{ secrets.CLERK_SECRET_KEY }}
       PREVIEW_CLERK_USER_ID: ${{ secrets.PREVIEW_CLERK_USER_ID }}
       PLATFORM_PUBLIC_URL: ${{ vars.PLATFORM_PUBLIC_URL || 'https://api.matrix-os.com' }}
+      APP_PUBLIC_URL: https://app.matrix-os.com
       HANDLE: ${{ needs.gate.outputs.handle }}
     steps:
       - name: Verify authenticated inventory projection
@@ -415,46 +416,43 @@ jobs:
             exit 1
           fi
 
-          session_id=""
+          task_id=""
           cleanup() {
-            if [ -n "$session_id" ]; then
+            if [ -n "$task_id" ]; then
               curl -fsS --max-time 30 -o /dev/null \
-                -X POST "https://api.clerk.com/v1/sessions/${session_id}/revoke" \
+                -X POST "https://api.clerk.com/v1/agents/tasks/${task_id}/revoke" \
                 -H "authorization: Bearer ${CLERK_SECRET_KEY}" \
                 -H "Clerk-API-Version: 2025-11-10" || true
             fi
           }
           trap cleanup EXIT
 
-          session_body="$(jq -cn --arg user_id "$PREVIEW_CLERK_USER_ID" '{user_id: $user_id}')"
-          session_code="$(curl -sS --max-time 30 -o /tmp/clerk-session.json -w '%{http_code}' \
-            -X POST "https://api.clerk.com/v1/sessions" \
+          redirect_url="${APP_PUBLIC_URL}/runtime"
+          task_body="$(jq -cn \
+            --arg user_id "$PREVIEW_CLERK_USER_ID" \
+            --arg redirect_url "$redirect_url" \
+            '{on_behalf_of: {user_id: $user_id}, permissions: "*", agent_name: "matrix-preview-verifier", task_description: "Verify preview computer inventory", redirect_url: $redirect_url, session_max_duration_in_seconds: 300}')"
+          task_code="$(curl -sS --max-time 30 -o /tmp/clerk-task.json -w '%{http_code}' \
+            -X POST "https://api.clerk.com/v1/agents/tasks" \
             -H "authorization: Bearer ${CLERK_SECRET_KEY}" \
             -H "Clerk-API-Version: 2025-11-10" \
             -H "content-type: application/json" \
-            --data-binary "$session_body")"
-          case "$session_code" in
+            --data-binary "$task_body")"
+          case "$task_code" in
             200|201) ;;
             *)
-              echo "Temporary preview verification session failed with HTTP ${session_code}." >&2
+              echo "Temporary preview verification task failed with HTTP ${task_code}." >&2
               exit 1
               ;;
           esac
-          session_id="$(jq -er '.id | select(type == "string" and test("^sess_[A-Za-z0-9]+$"))' /tmp/clerk-session.json)"
-
-          token_code="$(curl -sS --max-time 30 -o /tmp/clerk-token.json -w '%{http_code}' \
-            -X POST "https://api.clerk.com/v1/sessions/${session_id}/tokens" \
-            -H "authorization: Bearer ${CLERK_SECRET_KEY}" \
-            -H "Clerk-API-Version: 2025-11-10")"
-          if [ "$token_code" != "200" ]; then
-            echo "Could not create the temporary preview verification token." >&2
-            exit 1
-          fi
-          session_token="$(jq -er '.jwt | select(type == "string" and length <= 8192)' /tmp/clerk-token.json)"
+          task_id="$(jq -er '.id | select(type == "string" and test("^[A-Za-z0-9_-]{1,128}$"))' /tmp/clerk-task.json)"
+          task_url="$(jq -er '.url | select(type == "string" and length <= 4096 and startswith("https://"))' /tmp/clerk-task.json)"
+          curl -fsS --max-time 30 --max-redirs 10 -c /tmp/clerk-cookies.txt -b /tmp/clerk-cookies.txt \
+            -o /dev/null -L "$task_url"
 
           inventory_code="$(curl -sS --max-time 30 -o /tmp/computers.json -w '%{http_code}' \
             "${PLATFORM_PUBLIC_URL}/api/auth/computers" \
-            -H "authorization: Bearer ${session_token}")"
+            -b /tmp/clerk-cookies.txt)"
           if [ "$inventory_code" != "200" ]; then
             echo "Authenticated computer inventory is unavailable." >&2
             exit 1

--- a/.github/workflows/preview-vps.yml
+++ b/.github/workflows/preview-vps.yml
@@ -198,41 +198,84 @@ jobs:
           ./scripts/publish-release.sh "$VERSION" --channel none \
             --changelog "Preview bundle for PR #${{ needs.gate.outputs.pr }}"
 
-      - name: Provision preview VPS if absent
+      - name: Provision or resume preview VPS
         run: |
           set -euo pipefail
           if [ -z "${PREVIEW_CLERK_USER_ID:-}" ]; then
             echo "PREVIEW_CLERK_USER_ID secret is not configured." >&2
             exit 1
           fi
+
+          fleet_machine="$(curl -fsS --max-time 30 \
+            -H "authorization: Bearer ${PLATFORM_SECRET}" \
+            "${PLATFORM_PUBLIC_URL}/vps/fleet" |
+            jq -c --arg h "$HANDLE" \
+              '[.machines[] | select(.handle == $h and .status != "deleted")] | .[0] // {status: "absent", machineId: ""}')"
+          status="$(jq -r '.status' <<< "$fleet_machine")"
+          accepted_machine_id="$(jq -r '.machineId // ""' <<< "$fleet_machine")"
+          echo "Fleet status for ${HANDLE}: ${status}"
+
+          case "$status" in
+            provisioning|running)
+              if [ -z "$accepted_machine_id" ]; then
+                echo "Fleet returned an active preview without a machine ID." >&2
+                exit 1
+              fi
+              echo "Reusing existing ${HANDLE} machine ${accepted_machine_id} (${status})"
+              ;;
+            absent|failed)
+              provision_body="$(jq -cn \
+                --arg owner "$PREVIEW_CLERK_USER_ID" \
+                --arg handle "$HANDLE" \
+                '{clerkUserId: $owner, handle: $handle, runtimeSlot: $handle}')"
+              code="$(curl -sS --max-time 60 -o /tmp/provision.json -w '%{http_code}' \
+                -X POST "${PLATFORM_PUBLIC_URL}/vps/preview/provision" \
+                -H "authorization: Bearer ${PLATFORM_SECRET}" \
+                -H "content-type: application/json" \
+                --data-binary "$provision_body")"
+              if [ "$code" != "202" ]; then
+                echo "Preview provision failed with HTTP ${code}." >&2
+                exit 1
+              fi
+              if ! accepted_machine_id="$(jq -er '
+                if (
+                  type == "object"
+                  and (.machineId | type == "string" and test("^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"))
+                  and (.status == "provisioning" or .status == "running")
+                  and (.etaSeconds | type == "number" and . >= 0)
+                ) then .machineId else error("invalid response") end
+              ' /tmp/provision.json)"; then
+                echo "Preview provision returned an invalid response." >&2
+                exit 1
+              fi
+              ;;
+            *)
+              echo "Preview ${HANDLE} is in an unsupported state (${status})." >&2
+              exit 1
+              ;;
+          esac
+
           status="$(curl -fsS --max-time 30 \
             -H "authorization: Bearer ${PLATFORM_SECRET}" \
             "${PLATFORM_PUBLIC_URL}/vps/fleet" |
-            jq -r --arg h "$HANDLE" \
-              '[.machines[] | select(.handle == $h and .status != "deleted")] | .[0].status // "absent"')"
-          echo "Fleet status for ${HANDLE}: ${status}"
-          if [ "$status" = "absent" ]; then
-            code="$(curl -sS --max-time 60 -o /tmp/provision.json -w '%{http_code}' \
-              -X POST "${PLATFORM_PUBLIC_URL}/vps/provision" \
-              -H "authorization: Bearer ${PLATFORM_SECRET}" \
-              -H "content-type: application/json" \
-              -d "{\"clerkUserId\":\"${PREVIEW_CLERK_USER_ID}\",\"handle\":\"${HANDLE}\",\"runtimeSlot\":\"preview\"}")"
-            if [ "$code" != "202" ] && [ "$code" != "200" ]; then
-              echo "Provision failed with HTTP ${code} (body in workflow log)" >&2
-              cat /tmp/provision.json >&2
-              exit 1
-            fi
-            echo "Provision accepted; waiting for the VPS to come up..."
+            jq -r --arg h "$HANDLE" --arg id "$accepted_machine_id" \
+              '[.machines[] | select(.handle == $h and .machineId == $id)] | .[0].status // "absent"')"
+          echo "Immediate fleet visibility for ${HANDLE}: ${status}"
+          if [ "$status" != "provisioning" ] && [ "$status" != "running" ]; then
+            echo "Accepted preview machine is not durably visible in the fleet." >&2
+            exit 1
+          fi
+
+          if [ "$status" = "provisioning" ]; then
+            echo "Waiting for the VPS to come up..."
             deadline=$((SECONDS + 600))
             while true; do
-              # Let the record settle before reading; a fresh provision can
-              # transiently read as absent.
               sleep 15
               status="$(curl -fsS --max-time 30 \
                 -H "authorization: Bearer ${PLATFORM_SECRET}" \
                 "${PLATFORM_PUBLIC_URL}/vps/fleet" |
-                jq -r --arg h "$HANDLE" \
-                  '[.machines[] | select(.handle == $h)] | .[0].status // "absent"')"
+                jq -r --arg h "$HANDLE" --arg id "$accepted_machine_id" \
+                  '[.machines[] | select(.handle == $h and .machineId == $id)] | .[0].status // "absent"')"
               [ "$status" = "running" ] && break
               if [ "$status" = "failed" ]; then
                 echo "Provisioning failed for ${HANDLE}" >&2

--- a/docs/dev/preview-environments.md
+++ b/docs/dev/preview-environments.md
@@ -66,6 +66,13 @@ is skipped, and the job fails so the skip is visible. Manual deploy: `gh workflo
 Required repo secrets (beyond the existing release secrets):
 `PREVIEW_CLERK_USER_ID` — the Clerk user that owns preview VPSes.
 
+Preview provisioning uses the operator-only `/vps/preview/provision` route with the
+same `pr-<N>` value for the handle and runtime slot. A `202` is valid only when its
+machine ID is immediately visible as `provisioning` or `running` in `/vps/fleet`.
+Rerunning the workflow resumes that exact machine; an absent or failed preview is
+retried through the same idempotent route. The platform persists the machine and a
+durable provisioning job atomically before provider dispatch.
+
 To walk the full onboarding/billing flow against branch platform code — a
 four-slice split (staging slot for the shell, an IAM-proxied `preview-platform`
 revision for the journey/reliability API, a local `dev:platform` + Stripe CLI

--- a/packages/platform/src/customer-vps-provisioning-jobs.ts
+++ b/packages/platform/src/customer-vps-provisioning-jobs.ts
@@ -5,6 +5,7 @@ import type { PlatformDB } from './db.js';
 const MAX_PROVISIONING_JOBS = 100;
 const MAX_ENCRYPTED_PAYLOAD_LENGTH = 8_192;
 const PAYLOAD_VERSION = 1;
+export const MAX_PROVISIONING_JOB_ATTEMPTS = 100;
 
 const ProvisioningJobStatusSchema = z.enum(['queued', 'running', 'completed', 'failed']);
 const ProvisioningPayloadSchema = z.object({
@@ -16,7 +17,7 @@ const ProvisioningJobRowSchema = z.object({
   job_id: z.uuid(),
   machine_id: z.uuid(),
   status: ProvisioningJobStatusSchema,
-  attempts: z.number().int().min(0).max(100),
+  attempts: z.number().int().min(0).max(MAX_PROVISIONING_JOB_ATTEMPTS),
   available_at: z.string().min(1).max(64),
   claimed_at: z.string().min(1).max(64).nullable(),
   lease_expires_at: z.string().min(1).max(64).nullable(),
@@ -155,6 +156,19 @@ export async function getProvisioningJobByMachineId(
   return row ? mapProvisioningJob(row) : undefined;
 }
 
+export async function getProvisioningJob(
+  db: PlatformDB,
+  jobId: string,
+): Promise<ProvisioningJobRecord | undefined> {
+  await db.ready;
+  const row = await db.executor
+    .selectFrom('provisioning_jobs')
+    .selectAll()
+    .where('job_id', '=', jobId)
+    .executeTakeFirst();
+  return row ? mapProvisioningJob(row) : undefined;
+}
+
 export async function listProvisioningJobs(db: PlatformDB, limit: number): Promise<ProvisioningJobRecord[]> {
   await db.ready;
   const boundedLimit = Math.max(1, Math.min(MAX_PROVISIONING_JOBS, Math.trunc(limit)));
@@ -204,6 +218,7 @@ export async function claimProvisioningJob(
       updated_at: now,
     }))
     .where('job_id', '=', jobId)
+    .where('attempts', '<', MAX_PROVISIONING_JOB_ATTEMPTS)
     .where((eb) => eb.or([
       eb.and([eb('status', '=', 'queued'), eb('available_at', '<=', now)]),
       eb.and([eb('status', '=', 'running'), eb('lease_expires_at', '<=', now)]),

--- a/packages/platform/src/customer-vps-provisioning-jobs.ts
+++ b/packages/platform/src/customer-vps-provisioning-jobs.ts
@@ -1,0 +1,257 @@
+import { createCipheriv, createDecipheriv, createHash, randomBytes } from 'node:crypto';
+import { z } from 'zod/v4';
+import type { PlatformDB } from './db.js';
+
+const MAX_PROVISIONING_JOBS = 100;
+const MAX_ENCRYPTED_PAYLOAD_LENGTH = 8_192;
+const PAYLOAD_VERSION = 1;
+
+const ProvisioningJobStatusSchema = z.enum(['queued', 'running', 'completed', 'failed']);
+const ProvisioningPayloadSchema = z.object({
+  registrationToken: z.string().min(8).max(512),
+  postgresPassword: z.string().min(8).max(512),
+}).strict();
+
+const ProvisioningJobRowSchema = z.object({
+  job_id: z.uuid(),
+  machine_id: z.uuid(),
+  status: ProvisioningJobStatusSchema,
+  attempts: z.number().int().min(0).max(100),
+  available_at: z.string().min(1).max(64),
+  claimed_at: z.string().min(1).max(64).nullable(),
+  lease_expires_at: z.string().min(1).max(64).nullable(),
+  encrypted_payload: z.string().max(MAX_ENCRYPTED_PAYLOAD_LENGTH).nullable(),
+  last_error_code: z.string().min(1).max(64).nullable(),
+  created_at: z.string().min(1).max(64),
+  updated_at: z.string().min(1).max(64),
+  completed_at: z.string().min(1).max(64).nullable(),
+});
+
+export interface ProvisioningJobRecord {
+  jobId: string;
+  machineId: string;
+  status: z.infer<typeof ProvisioningJobStatusSchema>;
+  attempts: number;
+  availableAt: string;
+  claimedAt: string | null;
+  leaseExpiresAt: string | null;
+  encryptedPayload: string | null;
+  lastErrorCode: string | null;
+  createdAt: string;
+  updatedAt: string;
+  completedAt: string | null;
+}
+
+export interface NewProvisioningJob {
+  jobId: string;
+  machineId: string;
+  encryptedPayload: string;
+  availableAt: string;
+  createdAt: string;
+}
+
+export interface ProvisioningPayload {
+  registrationToken: string;
+  postgresPassword: string;
+}
+
+function mapProvisioningJob(value: unknown): ProvisioningJobRecord {
+  const row = ProvisioningJobRowSchema.parse(value);
+  return {
+    jobId: row.job_id,
+    machineId: row.machine_id,
+    status: row.status,
+    attempts: row.attempts,
+    availableAt: row.available_at,
+    claimedAt: row.claimed_at,
+    leaseExpiresAt: row.lease_expires_at,
+    encryptedPayload: row.encrypted_payload,
+    lastErrorCode: row.last_error_code,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+    completedAt: row.completed_at,
+  };
+}
+
+function encryptionKey(secret: string): Buffer {
+  if (secret.length < 8) {
+    throw new Error('Provisioning payload encryption is not configured');
+  }
+  return createHash('sha256').update(`matrix-provisioning-job:${secret}`).digest();
+}
+
+export function sealProvisioningPayload(payload: ProvisioningPayload, secret: string): string {
+  const parsed = ProvisioningPayloadSchema.parse(payload);
+  const iv = randomBytes(12);
+  const cipher = createCipheriv('aes-256-gcm', encryptionKey(secret), iv);
+  const ciphertext = Buffer.concat([
+    cipher.update(JSON.stringify(parsed), 'utf8'),
+    cipher.final(),
+  ]);
+  const sealed = [
+    String(PAYLOAD_VERSION),
+    iv.toString('base64url'),
+    cipher.getAuthTag().toString('base64url'),
+    ciphertext.toString('base64url'),
+  ].join('.');
+  if (sealed.length > MAX_ENCRYPTED_PAYLOAD_LENGTH) {
+    throw new Error('Provisioning payload exceeds persistence limit');
+  }
+  return sealed;
+}
+
+export function openProvisioningPayload(sealed: string, secret: string): ProvisioningPayload {
+  if (sealed.length > MAX_ENCRYPTED_PAYLOAD_LENGTH) {
+    throw new Error('Provisioning payload is invalid');
+  }
+  const [version, ivValue, tagValue, ciphertextValue, ...rest] = sealed.split('.');
+  if (version !== String(PAYLOAD_VERSION) || !ivValue || !tagValue || !ciphertextValue || rest.length > 0) {
+    throw new Error('Provisioning payload is invalid');
+  }
+  try {
+    const decipher = createDecipheriv('aes-256-gcm', encryptionKey(secret), Buffer.from(ivValue, 'base64url'));
+    decipher.setAuthTag(Buffer.from(tagValue, 'base64url'));
+    const plaintext = Buffer.concat([
+      decipher.update(Buffer.from(ciphertextValue, 'base64url')),
+      decipher.final(),
+    ]).toString('utf8');
+    return ProvisioningPayloadSchema.parse(JSON.parse(plaintext));
+  } catch (err: unknown) {
+    if (err instanceof Error && err.message === 'Provisioning payload encryption is not configured') {
+      throw err;
+    }
+    throw new Error('Provisioning payload is invalid');
+  }
+}
+
+export async function insertProvisioningJob(db: PlatformDB, job: NewProvisioningJob): Promise<void> {
+  await db.ready;
+  await db.executor.insertInto('provisioning_jobs').values({
+    job_id: job.jobId,
+    machine_id: job.machineId,
+    status: 'queued',
+    attempts: 0,
+    available_at: job.availableAt,
+    claimed_at: null,
+    lease_expires_at: null,
+    encrypted_payload: job.encryptedPayload,
+    last_error_code: null,
+    created_at: job.createdAt,
+    updated_at: job.createdAt,
+    completed_at: null,
+  }).execute();
+}
+
+export async function getProvisioningJobByMachineId(
+  db: PlatformDB,
+  machineId: string,
+): Promise<ProvisioningJobRecord | undefined> {
+  await db.ready;
+  const row = await db.executor
+    .selectFrom('provisioning_jobs')
+    .selectAll()
+    .where('machine_id', '=', machineId)
+    .executeTakeFirst();
+  return row ? mapProvisioningJob(row) : undefined;
+}
+
+export async function listProvisioningJobs(db: PlatformDB, limit: number): Promise<ProvisioningJobRecord[]> {
+  await db.ready;
+  const boundedLimit = Math.max(1, Math.min(MAX_PROVISIONING_JOBS, Math.trunc(limit)));
+  const rows = await db.executor
+    .selectFrom('provisioning_jobs')
+    .selectAll()
+    .orderBy('created_at', 'asc')
+    .limit(boundedLimit)
+    .execute();
+  return rows.map(mapProvisioningJob);
+}
+
+export async function listDispatchableProvisioningJobs(
+  db: PlatformDB,
+  now: string,
+  limit: number,
+): Promise<ProvisioningJobRecord[]> {
+  await db.ready;
+  const boundedLimit = Math.max(1, Math.min(MAX_PROVISIONING_JOBS, Math.trunc(limit)));
+  const rows = await db.executor
+    .selectFrom('provisioning_jobs')
+    .selectAll()
+    .where((eb) => eb.or([
+      eb.and([eb('status', '=', 'queued'), eb('available_at', '<=', now)]),
+      eb.and([eb('status', '=', 'running'), eb('lease_expires_at', '<=', now)]),
+    ]))
+    .orderBy('available_at', 'asc')
+    .limit(boundedLimit)
+    .execute();
+  return rows.map(mapProvisioningJob);
+}
+
+export async function claimProvisioningJob(
+  db: PlatformDB,
+  jobId: string,
+  now: string,
+  leaseExpiresAt: string,
+): Promise<ProvisioningJobRecord | undefined> {
+  await db.ready;
+  const row = await db.executor
+    .updateTable('provisioning_jobs')
+    .set((eb) => ({
+      status: 'running',
+      attempts: eb('attempts', '+', 1),
+      claimed_at: now,
+      lease_expires_at: leaseExpiresAt,
+      updated_at: now,
+    }))
+    .where('job_id', '=', jobId)
+    .where((eb) => eb.or([
+      eb.and([eb('status', '=', 'queued'), eb('available_at', '<=', now)]),
+      eb.and([eb('status', '=', 'running'), eb('lease_expires_at', '<=', now)]),
+    ]))
+    .returningAll()
+    .executeTakeFirst();
+  return row ? mapProvisioningJob(row) : undefined;
+}
+
+export async function completeProvisioningJob(db: PlatformDB, jobId: string, now: string): Promise<boolean> {
+  await db.ready;
+  const row = await db.executor
+    .updateTable('provisioning_jobs')
+    .set({
+      status: 'completed',
+      encrypted_payload: null,
+      lease_expires_at: null,
+      updated_at: now,
+      completed_at: now,
+      last_error_code: null,
+    })
+    .where('job_id', '=', jobId)
+    .where('status', '=', 'running')
+    .returning('job_id')
+    .executeTakeFirst();
+  return Boolean(row);
+}
+
+export async function failProvisioningJob(
+  db: PlatformDB,
+  jobId: string,
+  now: string,
+  errorCode: string,
+): Promise<boolean> {
+  await db.ready;
+  const row = await db.executor
+    .updateTable('provisioning_jobs')
+    .set({
+      status: 'failed',
+      encrypted_payload: null,
+      lease_expires_at: null,
+      updated_at: now,
+      completed_at: now,
+      last_error_code: errorCode.slice(0, 64),
+    })
+    .where('job_id', '=', jobId)
+    .where('status', '=', 'running')
+    .returning('job_id')
+    .executeTakeFirst();
+  return Boolean(row);
+}

--- a/packages/platform/src/customer-vps-provisioning-jobs.ts
+++ b/packages/platform/src/customer-vps-provisioning-jobs.ts
@@ -8,6 +8,7 @@ const PAYLOAD_VERSION = 1;
 export const MAX_PROVISIONING_JOB_ATTEMPTS = 100;
 
 const ProvisioningJobStatusSchema = z.enum(['queued', 'running', 'completed', 'failed']);
+const MachineIdSchema = z.string().min(1).max(128).regex(/^[A-Za-z0-9_-]+$/);
 const ProvisioningPayloadSchema = z.object({
   registrationToken: z.string().min(8).max(512),
   postgresPassword: z.string().min(8).max(512),
@@ -15,7 +16,7 @@ const ProvisioningPayloadSchema = z.object({
 
 const ProvisioningJobRowSchema = z.object({
   job_id: z.uuid(),
-  machine_id: z.uuid(),
+  machine_id: MachineIdSchema,
   status: ProvisioningJobStatusSchema,
   attempts: z.number().int().min(0).max(MAX_PROVISIONING_JOB_ATTEMPTS),
   available_at: z.string().min(1).max(64),

--- a/packages/platform/src/customer-vps.ts
+++ b/packages/platform/src/customer-vps.ts
@@ -640,6 +640,7 @@ export function createCustomerVpsService(deps: CustomerVpsServiceDeps): Customer
     }
 
     let serverIdForCompensation: number | null = null;
+    let adoptedExistingServer = false;
     try {
       const payload = openProvisioningPayload(job.encryptedPayload, deps.config.platformSecret);
       const imageVersion = row.imageVersion ?? deps.config.imageVersion;
@@ -663,18 +664,38 @@ export function createCustomerVpsService(deps: CustomerVpsServiceDeps): Customer
         deps.cloudInitTemplate ?? DEFAULT_CLOUD_INIT_TEMPLATE,
         hostConfig,
       );
-      const server = await deps.hetzner.createServer({
-        name: buildServerName(row.handle),
-        serverType: row.serverType ?? deps.config.serverType,
-        userData,
-        labels: {
-          app: 'matrix-os',
-          clerk_user_id: row.clerkUserId,
-          runtime_slot: row.runtimeSlot,
-          machine_id: row.machineId,
-        },
-      });
-      serverIdForCompensation = server.id;
+      const existingServers = deps.hetzner.listServersByLabel
+        ? (await deps.hetzner.listServersByLabel(`machine_id=${row.machineId}`))
+          .toSorted((left, right) => left.id - right.id)
+        : [];
+      const existingServer = existingServers[0];
+      const server = existingServer ?? await deps.hetzner.createServer({
+          name: buildServerName(row.handle),
+          serverType: row.serverType ?? deps.config.serverType,
+          userData,
+          labels: {
+            app: 'matrix-os',
+            clerk_user_id: row.clerkUserId,
+            runtime_slot: row.runtimeSlot,
+            machine_id: row.machineId,
+          },
+        });
+      adoptedExistingServer = Boolean(existingServer);
+      if (!adoptedExistingServer) serverIdForCompensation = server.id;
+      for (const duplicate of existingServers.slice(1)) {
+        try {
+          await deps.hetzner.deleteServer(duplicate.id);
+        } catch (cleanupErr: unknown) {
+          logCustomerVpsError('duplicate provisioning server cleanup failed', cleanupErr);
+          await queueProviderDeletion({
+            providerServerId: duplicate.id,
+            reason: 'duplicate_provisioning_server',
+            machineId: row.machineId,
+            handle: row.handle,
+            err: cleanupErr,
+          });
+        }
+      }
       const completedAt = now().toISOString();
       await runInPlatformTransaction(deps.db, async (trx) => {
         await updateUserMachine(trx, row.machineId, {
@@ -703,6 +724,11 @@ export function createCustomerVpsService(deps: CustomerVpsServiceDeps): Customer
             err: cleanupErr,
           });
         }
+      }
+      if (adoptedExistingServer) {
+        logCustomerVpsError(`adopted provisioning server persistence failed machineId=${row.machineId}`, err);
+        if (propagateFailure) throw mapped;
+        return 'skipped';
       }
       const failedAt = now().toISOString();
       try {

--- a/packages/platform/src/customer-vps.ts
+++ b/packages/platform/src/customer-vps.ts
@@ -66,6 +66,17 @@ import {
   canonicalizeDeveloperTools,
   developerToolsShellList,
 } from './developer-tools.js';
+import {
+  claimProvisioningJob,
+  completeProvisioningJob,
+  failProvisioningJob,
+  getProvisioningJobByMachineId,
+  insertProvisioningJob,
+  listDispatchableProvisioningJobs,
+  openProvisioningPayload,
+  sealProvisioningPayload,
+  type NewProvisioningJob,
+} from './customer-vps-provisioning-jobs.js';
 
 export interface ProvisionResponse {
   machineId: string;
@@ -137,6 +148,7 @@ export interface CustomerVpsService {
   delete(machineId: string): Promise<DeleteResponse>;
   deploy(target?: DeployTarget): Promise<DeployResult>;
   listAllMachines(): Promise<StatusResponse[]>;
+  dispatchProvisioningJobs(): Promise<{ checked: number; completed: number; failed: number }>;
   reconcileProvisioning(): Promise<{ checked: number; failed: number; running: number }>;
 }
 
@@ -150,6 +162,8 @@ export interface CustomerVpsServiceDeps {
   tokenFactory?: (now: Date, ttlMs: number) => RegistrationToken;
   postgresPasswordFactory?: () => string;
   now?: () => Date;
+  provisioningJobIdFactory?: () => string;
+  enqueueProvisioningJob?: (db: PlatformDB, job: NewProvisioningJob) => Promise<void>;
   fetchDispatcher?: import('undici').Dispatcher;
   resolveBillingEntitlement?: (clerkUserId: string) => Promise<BillingEntitlement | null | undefined>;
 }
@@ -205,6 +219,7 @@ const PROVIDER_DELETION_RETRY_BASE_MS = 60_000;
 const PROVIDER_DELETION_RETRY_MAX_MS = 60 * 60_000;
 const RESIZE_STATUS_POLL_INTERVAL_MS = 1_000;
 const RESIZE_STATUS_POLL_TIMEOUT_MS = 90_000;
+const PROVISIONING_JOB_LEASE_MS = 5 * 60_000;
 
 function activeProvisionResponse(row: UserMachineRecord, etaSeconds: number): ProvisionResponse {
   if (row.status !== 'provisioning' && row.status !== 'running') {
@@ -425,6 +440,8 @@ function sleep(ms: number): Promise<void> {
 
 export function createCustomerVpsService(deps: CustomerVpsServiceDeps): CustomerVpsService {
   const machineIdFactory = deps.machineIdFactory ?? randomUUID;
+  const provisioningJobIdFactory = deps.provisioningJobIdFactory ?? randomUUID;
+  const enqueueProvisioningJob = deps.enqueueProvisioningJob ?? insertProvisioningJob;
   const tokenFactory = deps.tokenFactory ?? createRegistrationToken;
   const postgresPasswordFactory = deps.postgresPasswordFactory ?? (() => randomBytes(24).toString('base64url'));
   const now = deps.now ?? (() => new Date());
@@ -592,6 +609,139 @@ export function createCustomerVpsService(deps: CustomerVpsServiceDeps): Customer
     }
   }
 
+  async function dispatchProvisioningJob(
+    jobId: string,
+    propagateFailure: boolean,
+  ): Promise<'completed' | 'failed' | 'skipped'> {
+    const claimedAt = now();
+    const job = await claimProvisioningJob(
+      deps.db,
+      jobId,
+      claimedAt.toISOString(),
+      new Date(claimedAt.getTime() + PROVISIONING_JOB_LEASE_MS).toISOString(),
+    );
+    if (!job) return 'skipped';
+
+    const row = await getUserMachine(deps.db, job.machineId);
+    if (!row || row.deletedAt || row.status !== 'provisioning' || !job.encryptedPayload) {
+      const failedAt = now().toISOString();
+      await failProvisioningJob(deps.db, job.jobId, failedAt, 'invalid_state');
+      if (row && !row.deletedAt && row.status === 'provisioning') {
+        await updateUserMachine(deps.db, row.machineId, {
+          status: 'failed',
+          failureCode: 'invalid_state',
+          failureAt: failedAt,
+        });
+      }
+      if (propagateFailure) {
+        throw new CustomerVpsError(500, 'invalid_state', 'Provisioning failed');
+      }
+      return 'failed';
+    }
+
+    let serverIdForCompensation: number | null = null;
+    try {
+      const payload = openProvisioningPayload(job.encryptedPayload, deps.config.platformSecret);
+      const imageVersion = row.imageVersion ?? deps.config.imageVersion;
+      const hostConfig = buildHostConfig(
+        deps.config,
+        {
+          clerkUserId: row.clerkUserId,
+          handle: row.handle,
+          runtimeSlot: row.runtimeSlot,
+          developerTools: row.developerTools,
+        },
+        row.machineId,
+        payload.registrationToken,
+        payload.postgresPassword,
+        {
+          imageVersion,
+          hostBundleUrl: hostBundleUrlForImageVersion(deps.config, imageVersion),
+        },
+      );
+      const userData = renderCloudInitTemplate(
+        deps.cloudInitTemplate ?? DEFAULT_CLOUD_INIT_TEMPLATE,
+        hostConfig,
+      );
+      const server = await deps.hetzner.createServer({
+        name: buildServerName(row.handle),
+        serverType: row.serverType ?? deps.config.serverType,
+        userData,
+        labels: {
+          app: 'matrix-os',
+          clerk_user_id: row.clerkUserId,
+          runtime_slot: row.runtimeSlot,
+          machine_id: row.machineId,
+        },
+      });
+      serverIdForCompensation = server.id;
+      const completedAt = now().toISOString();
+      await runInPlatformTransaction(deps.db, async (trx) => {
+        await updateUserMachine(trx, row.machineId, {
+          hetznerServerId: server.id,
+          publicIPv4: server.publicIPv4,
+          publicIPv6: server.publicIPv6,
+        });
+        const completed = await completeProvisioningJob(trx, job.jobId, completedAt);
+        if (!completed) {
+          throw new Error('Provisioning job completion lost its lease');
+        }
+      });
+      return 'completed';
+    } catch (err: unknown) {
+      const mapped = genericProviderError(err);
+      if (serverIdForCompensation !== null) {
+        try {
+          await deps.hetzner.deleteServer(serverIdForCompensation);
+        } catch (cleanupErr: unknown) {
+          logCustomerVpsError('provision compensation delete failed', cleanupErr);
+          await queueProviderDeletion({
+            providerServerId: serverIdForCompensation,
+            reason: 'provision_compensation',
+            machineId: row.machineId,
+            handle: row.handle,
+            err: cleanupErr,
+          });
+        }
+      }
+      const failedAt = now().toISOString();
+      try {
+        await runInPlatformTransaction(deps.db, async (trx) => {
+          await updateUserMachine(trx, row.machineId, {
+            status: 'failed',
+            failureCode: toFailureCode(err),
+            failureAt: failedAt,
+          });
+          await failProvisioningJob(trx, job.jobId, failedAt, toFailureCode(err));
+        });
+      } catch (statusErr: unknown) {
+        logCustomerVpsError('provision failure status update failed', statusErr);
+      }
+      if (propagateFailure) {
+        logCustomerVpsError(`provisioning job failed machineId=${row.machineId}`, err);
+        throw mapped;
+      }
+      logCustomerVpsError(`provisioning job failed machineId=${row.machineId}`, err);
+      return 'failed';
+    }
+  }
+
+  async function dispatchProvisioningJobs(): Promise<{ checked: number; completed: number; failed: number }> {
+    const jobs = await listDispatchableProvisioningJobs(
+      deps.db,
+      now().toISOString(),
+      deps.config.reconciliationBatchSize,
+    );
+    let completed = 0;
+    let failed = 0;
+    for (const job of jobs) {
+      const result = await dispatchProvisioningJob(job.jobId, false);
+      if (result === 'completed') completed += 1;
+      if (result === 'failed') failed += 1;
+    }
+    return { checked: jobs.length, completed, failed };
+  }
+
   async function provision(
     input: ProvisionRequest,
     provisioningClass: UserMachineProvisioningClass,
@@ -603,8 +753,13 @@ export function createCustomerVpsService(deps: CustomerVpsServiceDeps): Customer
     };
     const currentTime = now();
     const machineId = machineIdFactory();
+    const jobId = provisioningJobIdFactory();
     const registration = tokenFactory(currentTime, deps.config.registrationTokenTtlMs);
     const postgresPassword = postgresPasswordFactory();
+    const encryptedPayload = sealProvisioningPayload({
+      registrationToken: registration.token,
+      postgresPassword,
+    }, deps.config.platformSecret);
     const billingContext = provisioningClass === 'preview'
       ? null
       : await resolveBillingProvisionContext(deps, request, currentTime);
@@ -623,18 +778,14 @@ export function createCustomerVpsService(deps: CustomerVpsServiceDeps): Customer
       && !(provisioningClass === 'preview' && existingBeforeBundleResolve.runtimeSlot !== request.runtimeSlot)
       && (provisioningClass === 'customer' || existingBeforeBundleResolve.provisioningClass === 'preview')
     ) {
+      const existingJob = await getProvisioningJobByMachineId(deps.db, existingBeforeBundleResolve.machineId);
+      if (existingJob && (existingJob.status === 'queued' || existingJob.status === 'running')) {
+        await dispatchProvisioningJob(existingJob.jobId, true);
+      }
       return activeProvisionResponse(existingBeforeBundleResolve, deps.config.provisionEtaSeconds);
     }
 
     const bundleRef = await resolveHostBundleRef(deps.db, deps.config);
-    const hostConfig = buildHostConfig(
-      deps.config,
-      request,
-      machineId,
-      registration.token,
-      postgresPassword,
-      bundleRef,
-    );
 
     const provisionRow = await runInPlatformTransaction(deps.db, async (trx) => {
       // Preview capacity and customer entitlement checks share the owner lock
@@ -726,63 +877,24 @@ export function createCustomerVpsService(deps: CustomerVpsServiceDeps): Customer
         provisionedAt: currentTime.toISOString(),
         attempt,
       });
+      await enqueueProvisioningJob(trx, {
+        jobId,
+        machineId,
+        encryptedPayload,
+        availableAt: currentTime.toISOString(),
+        createdAt: currentTime.toISOString(),
+      });
       return { existing: null };
     });
     if (provisionRow.existing) {
+      const existingJob = await getProvisioningJobByMachineId(deps.db, provisionRow.existing.machineId);
+      if (existingJob && (existingJob.status === 'queued' || existingJob.status === 'running')) {
+        await dispatchProvisioningJob(existingJob.jobId, true);
+      }
       return activeProvisionResponse(provisionRow.existing, deps.config.provisionEtaSeconds);
     }
 
-    const userData = renderCloudInitTemplate(
-      deps.cloudInitTemplate ?? DEFAULT_CLOUD_INIT_TEMPLATE,
-      hostConfig,
-    );
-
-    let serverIdForCompensation: number | null = null;
-    try {
-      const server = await deps.hetzner.createServer({
-        name: buildServerName(request.handle),
-        serverType: billingContext?.serverType ?? deps.config.serverType,
-        userData,
-        labels: {
-          app: 'matrix-os',
-          clerk_user_id: request.clerkUserId,
-          runtime_slot: request.runtimeSlot,
-          machine_id: machineId,
-        },
-      });
-      serverIdForCompensation = server.id;
-      await updateUserMachine(deps.db, machineId, {
-        hetznerServerId: server.id,
-        publicIPv4: server.publicIPv4,
-        publicIPv6: server.publicIPv6,
-      });
-    } catch (err: unknown) {
-      const mapped = genericProviderError(err);
-      if (serverIdForCompensation !== null) {
-        try {
-          await deps.hetzner.deleteServer(serverIdForCompensation);
-        } catch (cleanupErr: unknown) {
-          logCustomerVpsError('provision compensation delete failed', cleanupErr);
-          await queueProviderDeletion({
-            providerServerId: serverIdForCompensation,
-            reason: 'provision_compensation',
-            machineId,
-            handle: request.handle,
-            err: cleanupErr,
-          });
-        }
-      }
-      try {
-        await updateUserMachine(deps.db, machineId, {
-          status: 'failed',
-          failureCode: toFailureCode(err),
-          failureAt: now().toISOString(),
-        });
-      } catch (statusErr: unknown) {
-        logCustomerVpsError('provision failure status update failed', statusErr);
-      }
-      throw mapped;
-    }
+    await dispatchProvisioningJob(jobId, true);
 
     return {
       machineId,
@@ -1194,6 +1306,8 @@ export function createCustomerVpsService(deps: CustomerVpsServiceDeps): Customer
       return machines.map(statusResponse);
     },
 
+    dispatchProvisioningJobs,
+
     async deploy(target?: DeployTarget): Promise<DeployResult> {
       const runningMachines = await listRunningUserMachines(deps.db, 500);
       const machines = target?.handle
@@ -1243,6 +1357,7 @@ export function createCustomerVpsService(deps: CustomerVpsServiceDeps): Customer
     },
 
     async reconcileProvisioning() {
+      await dispatchProvisioningJobs();
       const staleBefore = new Date(now().getTime() - deps.config.reconciliationStaleAfterMs).toISOString();
       const rows = await listStaleUserMachines(
         deps.db,

--- a/packages/platform/src/customer-vps.ts
+++ b/packages/platform/src/customer-vps.ts
@@ -313,6 +313,8 @@ function buildHostConfig(
 }
 
 const HOST_BUNDLE_CHANNELS = new Set(['stable', 'canary', 'beta', 'dev']);
+const MAX_LOCAL_PROVISION_LOCKS = 1_024;
+const MAX_LOCAL_PROVISION_QUEUE_DEPTH = 20;
 
 interface HostBundleRef {
   imageVersion: string;
@@ -443,6 +445,39 @@ function sleep(ms: number): Promise<void> {
 export function createCustomerVpsService(deps: CustomerVpsServiceDeps): CustomerVpsService {
   const machineIdFactory = deps.machineIdFactory ?? randomUUID;
   const provisioningJobIdFactory = deps.provisioningJobIdFactory ?? randomUUID;
+  const localProvisionLocks = new Map<string, { tail: Promise<void>; depth: number }>();
+
+  async function withLocalProvisionLock<T>(key: string, fn: () => Promise<T>): Promise<T> {
+    let lock = localProvisionLocks.get(key);
+    if (!lock) {
+      if (localProvisionLocks.size >= MAX_LOCAL_PROVISION_LOCKS) {
+        throw new CustomerVpsError(503, 'provider_unavailable', 'Provisioning unavailable');
+      }
+      lock = { tail: Promise.resolve(), depth: 0 };
+      localProvisionLocks.set(key, lock);
+    }
+    if (lock.depth >= MAX_LOCAL_PROVISION_QUEUE_DEPTH) {
+      throw new CustomerVpsError(429, 'provider_unavailable', 'Try again later');
+    }
+
+    const predecessor = lock.tail;
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    lock.tail = predecessor.then(() => gate);
+    lock.depth += 1;
+    await predecessor;
+    try {
+      return await fn();
+    } finally {
+      release();
+      lock.depth -= 1;
+      if (lock.depth === 0 && localProvisionLocks.get(key) === lock) {
+        localProvisionLocks.delete(key);
+      }
+    }
+  }
   const enqueueProvisioningJob = deps.enqueueProvisioningJob ?? insertProvisioningJob;
   const tokenFactory = deps.tokenFactory ?? createRegistrationToken;
   const postgresPasswordFactory = deps.postgresPasswordFactory ?? (() => randomBytes(24).toString('base64url'));
@@ -795,6 +830,14 @@ export function createCustomerVpsService(deps: CustomerVpsServiceDeps): Customer
     return { checked: jobs.length, completed, failed };
   }
 
+  async function dispatchProvisioningJobBestEffort(jobId: string): Promise<void> {
+    try {
+      await dispatchProvisioningJob(jobId, true);
+    } catch (err: unknown) {
+      logCustomerVpsError('durable provisioning job immediate dispatch unavailable', err);
+    }
+  }
+
   async function provision(
     input: ProvisionRequest,
     provisioningClass: UserMachineProvisioningClass,
@@ -833,14 +876,16 @@ export function createCustomerVpsService(deps: CustomerVpsServiceDeps): Customer
     ) {
       const existingJob = await getProvisioningJobByMachineId(deps.db, existingBeforeBundleResolve.machineId);
       if (existingJob && (existingJob.status === 'queued' || existingJob.status === 'running')) {
-        await dispatchProvisioningJob(existingJob.jobId, true);
+        await dispatchProvisioningJobBestEffort(existingJob.jobId);
       }
       return activeProvisionResponse(existingBeforeBundleResolve, deps.config.provisionEtaSeconds);
     }
 
     const bundleRef = await resolveHostBundleRef(deps.db, deps.config);
 
-    const provisionRow = await runInPlatformTransaction(deps.db, async (trx) => {
+    let provisionRow: { existing: UserMachineRecord | null };
+    try {
+      provisionRow = await runInPlatformTransaction(deps.db, async (trx) => {
       // Preview capacity and customer entitlement checks share the owner lock
       // with insertion so concurrent platform instances cannot over-allocate.
       if (billingContext || provisioningClass === 'preview') {
@@ -937,17 +982,54 @@ export function createCustomerVpsService(deps: CustomerVpsServiceDeps): Customer
         availableAt: currentTime.toISOString(),
         createdAt: currentTime.toISOString(),
       });
-      return { existing: null };
-    });
+        return { existing: null };
+      });
+    } catch (err: unknown) {
+      const errorCode = err instanceof Error
+        ? (err as Error & { code?: unknown }).code
+        : undefined;
+      const errorMessage = err instanceof Error ? err.message : '';
+      const raceLookupAttempts = errorCode === '23505'
+        || errorMessage.includes('idx_user_machines_clerk_slot_active')
+        || errorMessage.includes('current transaction is aborted')
+        ? 3
+        : 1;
+      let concurrent: UserMachineRecord | undefined;
+      for (let attempt = 0; attempt < raceLookupAttempts; attempt += 1) {
+        try {
+          concurrent = await findExistingProvisioningMachine(deps.db, request, provisioningClass);
+        } catch (lookupErr: unknown) {
+          logCustomerVpsError('provisioning convergence lookup unavailable', lookupErr);
+          throw err;
+        }
+        if (concurrent?.status !== 'failed') break;
+        if (attempt + 1 < raceLookupAttempts) {
+          await new Promise((resolve) => setTimeout(resolve, 10));
+        }
+      }
+      if (
+        concurrent
+        && concurrent.status !== 'failed'
+        && !(provisioningClass === 'preview' && concurrent.runtimeSlot !== request.runtimeSlot)
+        && (provisioningClass === 'customer' || concurrent.provisioningClass === 'preview')
+      ) {
+        const concurrentJob = await getProvisioningJobByMachineId(deps.db, concurrent.machineId);
+        if (concurrentJob && (concurrentJob.status === 'queued' || concurrentJob.status === 'running')) {
+          await dispatchProvisioningJobBestEffort(concurrentJob.jobId);
+        }
+        return activeProvisionResponse(concurrent, deps.config.provisionEtaSeconds);
+      }
+      throw err;
+    }
     if (provisionRow.existing) {
       const existingJob = await getProvisioningJobByMachineId(deps.db, provisionRow.existing.machineId);
       if (existingJob && (existingJob.status === 'queued' || existingJob.status === 'running')) {
-        await dispatchProvisioningJob(existingJob.jobId, true);
+        await dispatchProvisioningJobBestEffort(existingJob.jobId);
       }
       return activeProvisionResponse(provisionRow.existing, deps.config.provisionEtaSeconds);
     }
 
-    await dispatchProvisioningJob(jobId, true);
+    await dispatchProvisioningJobBestEffort(jobId);
 
     return {
       machineId,
@@ -958,11 +1040,17 @@ export function createCustomerVpsService(deps: CustomerVpsServiceDeps): Customer
 
   return {
     async provision(input) {
-      return provision(input, 'customer');
+      return withLocalProvisionLock(
+        `${input.clerkUserId}:${input.runtimeSlot ?? 'primary'}`,
+        () => provision(input, 'customer'),
+      );
     },
 
     async provisionPreview(input) {
-      return provision(input, 'preview');
+      return withLocalProvisionLock(
+        `${input.clerkUserId}:${input.runtimeSlot ?? 'primary'}`,
+        () => provision(input, 'preview'),
+      );
     },
 
     async register(token, input) {

--- a/packages/platform/src/customer-vps.ts
+++ b/packages/platform/src/customer-vps.ts
@@ -70,9 +70,11 @@ import {
   claimProvisioningJob,
   completeProvisioningJob,
   failProvisioningJob,
+  getProvisioningJob,
   getProvisioningJobByMachineId,
   insertProvisioningJob,
   listDispatchableProvisioningJobs,
+  MAX_PROVISIONING_JOB_ATTEMPTS,
   openProvisioningPayload,
   sealProvisioningPayload,
   type NewProvisioningJob,
@@ -614,6 +616,31 @@ export function createCustomerVpsService(deps: CustomerVpsServiceDeps): Customer
     propagateFailure: boolean,
   ): Promise<'completed' | 'failed' | 'skipped'> {
     const claimedAt = now();
+    const pendingJob = await getProvisioningJob(deps.db, jobId);
+    if (
+      pendingJob?.status === 'running'
+      && pendingJob.attempts >= MAX_PROVISIONING_JOB_ATTEMPTS
+      && pendingJob.leaseExpiresAt
+      && pendingJob.leaseExpiresAt <= claimedAt.toISOString()
+    ) {
+      await runInPlatformTransaction(deps.db, async (trx) => {
+        await updateUserMachine(trx, pendingJob.machineId, {
+          status: 'failed',
+          failureCode: 'retry_exhausted',
+          failureAt: claimedAt.toISOString(),
+        });
+        await failProvisioningJob(
+          trx,
+          pendingJob.jobId,
+          claimedAt.toISOString(),
+          'retry_exhausted',
+        );
+      });
+      if (propagateFailure) {
+        throw new CustomerVpsError(500, 'retry_exhausted', 'Provisioning failed');
+      }
+      return 'failed';
+    }
     const job = await claimProvisioningJob(
       deps.db,
       jobId,

--- a/packages/platform/src/customer-vps.ts
+++ b/packages/platform/src/customer-vps.ts
@@ -832,6 +832,11 @@ export function createCustomerVpsService(deps: CustomerVpsServiceDeps): Customer
     try {
       await dispatchProvisioningJob(jobId, true);
     } catch (err: unknown) {
+      const code = err instanceof Error ? (err as Error & { code?: unknown }).code : undefined;
+      const message = err instanceof Error ? err.message : '';
+      if (code !== '25P02' && !message.includes('current transaction is aborted')) {
+        throw err;
+      }
       logCustomerVpsError('durable provisioning job immediate dispatch unavailable', err);
     }
   }

--- a/packages/platform/src/customer-vps.ts
+++ b/packages/platform/src/customer-vps.ts
@@ -789,8 +789,6 @@ export function createCustomerVpsService(deps: CustomerVpsServiceDeps): Customer
       }
       if (adoptedExistingServer) {
         logCustomerVpsError(`adopted provisioning server persistence failed machineId=${row.machineId}`, err);
-        if (propagateFailure) throw mapped;
-        return 'skipped';
       }
       const failedAt = now().toISOString();
       try {

--- a/packages/platform/src/db.ts
+++ b/packages/platform/src/db.ts
@@ -71,6 +71,21 @@ interface UserMachinesTable {
   attempt: number;
 }
 
+export interface ProvisioningJobsTable {
+  job_id: string;
+  machine_id: string;
+  status: string;
+  attempts: number;
+  available_at: string;
+  claimed_at: string | null;
+  lease_expires_at: string | null;
+  encrypted_payload: string | null;
+  last_error_code: string | null;
+  created_at: string;
+  updated_at: string;
+  completed_at: string | null;
+}
+
 interface HostBundleReleasesTable {
   version: string;
   channel: string | null;
@@ -287,6 +302,7 @@ export interface PlatformDatabase {
   users: UsersTable;
   containers: ContainersTable;
   user_machines: UserMachinesTable;
+  provisioning_jobs: ProvisioningJobsTable;
   billing_checkout_attempts: BillingCheckoutAttemptsTable;
   onboarding_first_run: OnboardingFirstRunTable;
   onboarding_journey_events: OnboardingJourneyEventsTable;
@@ -713,6 +729,27 @@ async function migrate(db: Kysely<PlatformDatabase>): Promise<void> {
   `.execute(db);
   await sql`CREATE INDEX IF NOT EXISTS idx_user_machines_clerk_slot_status ON user_machines(clerk_user_id, runtime_slot, status)`.execute(db);
   await sql`CREATE INDEX IF NOT EXISTS idx_user_machines_hetzner ON user_machines(hetzner_server_id)`.execute(db);
+
+  await sql`
+    CREATE TABLE IF NOT EXISTS provisioning_jobs (
+      job_id TEXT PRIMARY KEY,
+      machine_id TEXT NOT NULL UNIQUE REFERENCES user_machines(machine_id) ON UPDATE CASCADE,
+      status TEXT NOT NULL DEFAULT 'queued',
+      attempts INTEGER NOT NULL DEFAULT 0,
+      available_at TEXT NOT NULL,
+      claimed_at TEXT,
+      lease_expires_at TEXT,
+      encrypted_payload TEXT,
+      last_error_code TEXT,
+      created_at TEXT NOT NULL,
+      updated_at TEXT NOT NULL,
+      completed_at TEXT
+    )
+  `.execute(db);
+  await sql`
+    CREATE INDEX IF NOT EXISTS idx_provisioning_jobs_dispatch
+    ON provisioning_jobs(status, available_at, lease_expires_at)
+  `.execute(db);
 
   // Onboarding journey (spec 092): server-owned signup-to-ready state. Schema is
   // uniformly TEXT/uuid/ISO-string to match the rest of this file (no jsonb/serial).

--- a/specs/093-preview-environments/spec.md
+++ b/specs/093-preview-environments/spec.md
@@ -65,9 +65,11 @@ connect to, CLI betas need a paired shell), and today each is assembled by hand.
   release validation (`/^[A-Za-z0-9._-]{1,128}$/`).
 - Publish: `scripts/publish-release.sh` **without** `--channel` — the release is
   registered but never promoted; no channel pointer can ever select a PR bundle.
-- Provision: `POST /vps/provision` with `handle: pr-<N>`, a dedicated
-  `PREVIEW_CLERK_USER_ID` secret, `runtimeSlot: preview`. Idempotent: if the handle
-  already exists in `/vps/fleet`, skip provision and deploy only.
+- Provision: `POST /vps/preview/provision` with a dedicated
+  `PREVIEW_CLERK_USER_ID` secret and identical `handle` / `runtimeSlot` values of
+  `pr-<N>`. The platform commits the machine and its durable provisioning job in one
+  transaction before returning `202`; the workflow rejects an accepted response unless
+  that exact machine is immediately visible in `/vps/fleet`.
 - Deploy: `POST /vps/deploy {"version": "...", "handle": "pr-<N>"}` — version-pinned,
   single-handle. Never channel-wide.
 - Report: PR comment with the VM URL, bundle version, and log-query one-liner.
@@ -132,10 +134,13 @@ connect to, CLI betas need a paired shell), and today each is assembled by hand.
   billing slot enforcement. The authenticated operator path may adopt an existing
   matching row before excluding it from customer billing. Exact per-PR lookup falls
   back to the same owner's matching legacy `runtimeSlot: preview` row under the
-  owner lock, so migration cannot create a duplicate provider server. Exact slots
+  owner provisioning lock, so migration cannot create a duplicate provider server. Exact slots
   must match the requested handle or fail with a generic conflict, and a live
   matching legacy row wins over a failed exact row during migration. The failed
   duplicate is retired and queued for provider cleanup before capacity is checked.
+- Provisioning jobs use bounded Postgres rows with encrypted, size-limited bootstrap
+  payloads. A leased worker claim dispatches provider creation; completed and failed
+  jobs clear the payload. Expired claims are eligible for bounded reconciliation.
 - `matrix-install-logship`: URL must be `https://`, handle must match
   `^[a-z0-9][a-z0-9-]{1,62}$`, env must be one of `preview|prod|staging`; the Alloy
   binary download is pinned to an exact version and verified against a recorded
@@ -156,6 +161,9 @@ connect to, CLI betas need a paired shell), and today each is assembled by hand.
   deploy step retries once; on persistent failure the job fails loudly and the PR
   comment is replaced by a failure note with the handle so teardown still works.
   Orphan state is acceptable: the reaper deletes it within 72h regardless.
+- **Provision enqueue fails**: the machine insert rolls back with the job insert and
+  the route returns a generic non-success response. A successful response is never
+  allowed for a machine that is absent from the authoritative fleet read.
 - **Teardown fails on PR close**: the scheduled reaper is the backstop (same deletion
   code path). Reaper failures alert via workflow failure notifications.
 - **Two PRs race for a staging slot**: slot claim uses `O_EXCL` lock-file creation;

--- a/tests/platform/customer-vps-host-bundle.test.ts
+++ b/tests/platform/customer-vps-host-bundle.test.ts
@@ -677,6 +677,7 @@ test "$(readlink "$MATRIX_LEGACY_HOME/.hermes")" = "$MATRIX_HOME/.hermes"
     expect(workflow).toContain('https://api.clerk.com/v1/sessions');
     expect(workflow).toContain('https://api.clerk.com/v1/sessions/${session_id}/tokens');
     expect(workflow).toContain('https://api.clerk.com/v1/sessions/${session_id}/revoke');
+    expect(workflow.match(/Clerk-API-Version: 2025-11-10/g)).toHaveLength(3);
     expect(workflow).toContain('Temporary preview verification session failed with HTTP ${session_code}.');
     expect(workflow).toContain('case "$session_code" in');
     expect(workflow).toContain('200|201) ;;');

--- a/tests/platform/customer-vps-host-bundle.test.ts
+++ b/tests/platform/customer-vps-host-bundle.test.ts
@@ -682,6 +682,17 @@ test "$(readlink "$MATRIX_LEGACY_HOME/.hermes")" = "$MATRIX_HOME/.hermes"
     expect(workflow).not.toContain('echo "$session_token"');
   });
 
+  it('pinned preview redeploys skip bundle build and immutable publication', () => {
+    const root = process.cwd();
+    const workflow = readFileSync(join(root, '.github/workflows/preview-vps.yml'), 'utf8');
+
+    expect(workflow).toContain('action="deploy_existing"');
+    expect(workflow).toContain("if: needs.gate.outputs.action == 'deploy'");
+    expect(workflow).toContain("if: always() && ((needs.gate.outputs.action == 'deploy' && needs.build.result == 'success') || needs.gate.outputs.action == 'deploy_existing')");
+    expect(workflow).toContain("if: needs.gate.outputs.action == 'deploy'");
+    expect(workflow).toContain("VERSION: ${{ needs.gate.outputs.action == 'deploy_existing' && needs.gate.outputs.requested_version || needs.build.outputs.version }}");
+  });
+
   it('host bundle release workflow can skip dev bundles only through explicit manual input', () => {
     const root = process.cwd();
     const workflow = readFileSync(join(root, '.github/workflows/host-bundle-release.yml'), 'utf8');

--- a/tests/platform/customer-vps-host-bundle.test.ts
+++ b/tests/platform/customer-vps-host-bundle.test.ts
@@ -643,6 +643,16 @@ test "$(readlink "$MATRIX_LEGACY_HOME/.hermes")" = "$MATRIX_HOME/.hermes"
     expect(workflow.match(/\/vps\/preview\/provision/g)).toHaveLength(1);
   });
 
+  it('preview VPS workflow prefers active same-handle rows over failed history', () => {
+    const root = process.cwd();
+    const workflow = readFileSync(join(root, '.github/workflows/preview-vps.yml'), 'utf8');
+
+    expect(workflow).toContain('if .status == "running" then 0');
+    expect(workflow).toContain('elif .status == "provisioning" then 1');
+    expect(workflow).toContain('elif .status == "failed" then 2');
+    expect(workflow).toContain('sort_by(._preview_rank, (if .runtimeSlot == $h then 0 else 1 end), .provisionedAt)');
+  });
+
   it('host bundle release workflow can skip dev bundles only through explicit manual input', () => {
     const root = process.cwd();
     const workflow = readFileSync(join(root, '.github/workflows/host-bundle-release.yml'), 'utf8');

--- a/tests/platform/customer-vps-host-bundle.test.ts
+++ b/tests/platform/customer-vps-host-bundle.test.ts
@@ -595,7 +595,7 @@ test "$(readlink "$MATRIX_LEGACY_HOME/.hermes")" = "$MATRIX_HOME/.hermes"
     const root = process.cwd();
     const workflow = readFileSync(join(root, '.github/workflows/preview-vps.yml'), 'utf8');
 
-    expect(workflow).toContain('VERSION="v$(date -u +%Y.%m.%d)-pr${PR_NUMBER}-${HEAD_SHA:0:7}"');
+    expect(workflow).toContain('VERSION="${REQUESTED_VERSION:-v$(date -u +%Y.%m.%d)-pr${PR_NUMBER}-${HEAD_SHA:0:7}}"');
     expect(workflow).toContain('dist/host-bundle/incremental-manifest.json');
     expect(workflow).toContain('dist/host-bundle/objects/**');
     expect(workflow).toContain('./scripts/publish-release.sh "$VERSION" --channel none');
@@ -651,6 +651,21 @@ test "$(readlink "$MATRIX_LEGACY_HOME/.hermes")" = "$MATRIX_HOME/.hermes"
     expect(workflow).toContain('elif .status == "provisioning" then 1');
     expect(workflow).toContain('elif .status == "failed" then 2');
     expect(workflow).toContain('sort_by(._preview_rank, (if .runtimeSlot == $h then 0 else 1 end), .provisionedAt)');
+  });
+
+  it('manual preview dispatch resolves the target PR head and validates a pinned version', () => {
+    const root = process.cwd();
+    const workflow = readFileSync(join(root, '.github/workflows/preview-vps.yml'), 'utf8');
+
+    expect(workflow).toContain('gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}"');
+    expect(workflow).toContain('head_sha="$(jq -r .head.sha <<< "$pr_json")"');
+    expect(workflow).toContain('head_repo="$(jq -r .head.repo.full_name <<< "$pr_json")"');
+    expect(workflow).toContain('if [ "$head_repo" != "$GITHUB_REPOSITORY" ]; then');
+    expect(workflow).toContain('ref: ${{ needs.gate.outputs.head_sha }}');
+    expect(workflow).toContain('REQUESTED_VERSION: ${{ needs.gate.outputs.requested_version }}');
+    expect(workflow).toContain('VERSION="${REQUESTED_VERSION:-v$(date -u +%Y.%m.%d)-pr${PR_NUMBER}-${HEAD_SHA:0:7}}"');
+    expect(workflow).toContain('Invalid pinned preview version');
+    expect(workflow).toContain('[ "${REQUESTED_VERSION##*-}" != "${head_sha:0:7}" ]');
   });
 
   it('host bundle release workflow can skip dev bundles only through explicit manual input', () => {

--- a/tests/platform/customer-vps-host-bundle.test.ts
+++ b/tests/platform/customer-vps-host-bundle.test.ts
@@ -638,7 +638,10 @@ test "$(readlink "$MATRIX_LEGACY_HOME/.hermes")" = "$MATRIX_HOME/.hermes"
     const workflow = readFileSync(join(root, '.github/workflows/preview-vps.yml'), 'utf8');
 
     expect(workflow).toContain('provisioning|running)');
+    expect(workflow).toContain('if [ "$runtime_slot" = "$HANDLE" ]; then');
     expect(workflow).toContain('Reusing existing ${HANDLE} machine ${accepted_machine_id} (${status})');
+    expect(workflow).toContain('requires exact-slot adoption from ${runtime_slot:-unset}');
+    expect(workflow).toContain('needs_provision=true');
     expect(workflow).toContain('absent|failed)');
     expect(workflow.match(/\/vps\/preview\/provision/g)).toHaveLength(1);
   });

--- a/tests/platform/customer-vps-host-bundle.test.ts
+++ b/tests/platform/customer-vps-host-bundle.test.ts
@@ -677,6 +677,9 @@ test "$(readlink "$MATRIX_LEGACY_HOME/.hermes")" = "$MATRIX_HOME/.hermes"
     expect(workflow).toContain('https://api.clerk.com/v1/sessions');
     expect(workflow).toContain('https://api.clerk.com/v1/sessions/${session_id}/tokens');
     expect(workflow).toContain('https://api.clerk.com/v1/sessions/${session_id}/revoke');
+    expect(workflow).toContain('Temporary preview verification session failed with HTTP ${session_code}.');
+    expect(workflow).toContain('case "$session_code" in');
+    expect(workflow).toContain('200|201) ;;');
     expect(workflow).toContain('"${PLATFORM_PUBLIC_URL}/api/auth/computers"');
     expect(workflow).toContain('select(.handle == $h and .runtimeSlot == $h and .kind == "preview")');
     expect(workflow).not.toContain('echo "$session_token"');

--- a/tests/platform/customer-vps-host-bundle.test.ts
+++ b/tests/platform/customer-vps-host-bundle.test.ts
@@ -679,6 +679,7 @@ test "$(readlink "$MATRIX_LEGACY_HOME/.hermes")" = "$MATRIX_HOME/.hermes"
     expect(workflow.match(/Clerk-API-Version: 2025-11-10/g)).toHaveLength(2);
     expect(workflow).toContain("redirect_url: $redirect_url");
     expect(workflow).toContain('task_error="$(jq -r');
+    expect(workflow).toContain('task_field="$(jq -r');
     expect(workflow).toContain('test("^[a-z0-9_]{1,80}$")');
     expect(workflow).toContain('--max-redirs 10 -c /tmp/clerk-cookies.txt -b /tmp/clerk-cookies.txt');
     expect(workflow).toContain('-b /tmp/clerk-cookies.txt');

--- a/tests/platform/customer-vps-host-bundle.test.ts
+++ b/tests/platform/customer-vps-host-bundle.test.ts
@@ -668,26 +668,22 @@ test "$(readlink "$MATRIX_LEGACY_HOME/.hermes")" = "$MATRIX_HOME/.hermes"
     expect(workflow).toContain('[ "${REQUESTED_VERSION##*-}" != "${head_sha:0:7}" ]');
   });
 
-  it('manual preview verification uses a temporary QA agent task and revokes it', () => {
+  it('manual preview verification uses a short-lived token from an active QA session', () => {
     const root = process.cwd();
     const workflow = readFileSync(join(root, '.github/workflows/preview-vps.yml'), 'utf8');
 
     expect(workflow).toContain('verify_inventory:');
     expect(workflow).toContain('action="verify"');
-    expect(workflow).toContain('https://api.clerk.com/v1/agents/tasks');
     expect(workflow).toContain('https://api.clerk.com/v1/users/${PREVIEW_CLERK_USER_ID}');
     expect(workflow).toContain('Configured preview verification user is unavailable (HTTP ${user_code}).');
-    expect(workflow).toContain('https://api.clerk.com/v1/agents/tasks/${task_id}/revoke');
+    expect(workflow).toContain('https://api.clerk.com/v1/sessions?user_id=${PREVIEW_CLERK_USER_ID}&status=active&limit=10');
+    expect(workflow).toContain('https://api.clerk.com/v1/sessions/${session_id}/tokens');
+    expect(workflow).toContain("--data-binary '{\"expires_in_seconds\":60}'");
     expect(workflow.match(/Clerk-API-Version: 2025-11-10/g)).toHaveLength(3);
-    expect(workflow).toContain("redirect_url: $redirect_url");
-    expect(workflow).toContain('task_error="$(jq -r');
-    expect(workflow).toContain('task_field="$(jq -r');
-    expect(workflow).toContain('test("^[a-z0-9_]{1,80}$")');
-    expect(workflow).toContain('--max-redirs 10 -c /tmp/clerk-cookies.txt -b /tmp/clerk-cookies.txt');
-    expect(workflow).toContain('-b /tmp/clerk-cookies.txt');
     expect(workflow).toContain('"${PLATFORM_PUBLIC_URL}/api/auth/computers"');
     expect(workflow).toContain('select(.handle == $h and .runtimeSlot == $h and .kind == "preview")');
-    expect(workflow).not.toContain('echo "$task_url"');
+    expect(workflow).not.toContain('echo "$session_token"');
+    expect(workflow).not.toContain('/sessions/${session_id}/revoke');
   });
 
   it('pinned preview redeploys skip bundle build and immutable publication', () => {

--- a/tests/platform/customer-vps-host-bundle.test.ts
+++ b/tests/platform/customer-vps-host-bundle.test.ts
@@ -602,6 +602,47 @@ test "$(readlink "$MATRIX_LEGACY_HOME/.hermes")" = "$MATRIX_HOME/.hermes"
     expect(workflow).toContain('-X POST "${PLATFORM_PUBLIC_URL}/vps/deploy"');
   });
 
+  it('preview VPS workflow uses the durable preview provision contract', () => {
+    const root = process.cwd();
+    const workflow = readFileSync(join(root, '.github/workflows/preview-vps.yml'), 'utf8');
+
+    expect(workflow).toContain('-X POST "${PLATFORM_PUBLIC_URL}/vps/preview/provision"');
+    expect(workflow).toContain('{clerkUserId: $owner, handle: $handle, runtimeSlot: $handle}');
+    expect(workflow).not.toContain('-X POST "${PLATFORM_PUBLIC_URL}/vps/provision"');
+    expect(workflow).not.toContain('"runtimeSlot":"preview"');
+  });
+
+  it('preview VPS workflow accepts only a valid 202 provision response', () => {
+    const root = process.cwd();
+    const workflow = readFileSync(join(root, '.github/workflows/preview-vps.yml'), 'utf8');
+
+    expect(workflow).toContain('if [ "$code" != "202" ]; then');
+    expect(workflow).toContain('accepted_machine_id="$(jq -er');
+    expect(workflow).toContain('.status == "provisioning" or .status == "running"');
+    expect(workflow).toContain('.etaSeconds | type == "number" and . >= 0');
+  });
+
+  it('preview VPS workflow requires immediate fleet visibility after acceptance', () => {
+    const root = process.cwd();
+    const workflow = readFileSync(join(root, '.github/workflows/preview-vps.yml'), 'utf8');
+
+    expect(workflow).toContain('Immediate fleet visibility for ${HANDLE}: ${status}');
+    expect(workflow).toContain('select(.handle == $h and .machineId == $id)');
+    expect(workflow).toContain('if [ "$status" != "provisioning" ] && [ "$status" != "running" ]; then');
+    expect(workflow.indexOf('Immediate fleet visibility for ${HANDLE}: ${status}'))
+      .toBeLessThan(workflow.indexOf('deadline=$((SECONDS + 600))'));
+  });
+
+  it('preview VPS workflow safely resumes an existing active preview', () => {
+    const root = process.cwd();
+    const workflow = readFileSync(join(root, '.github/workflows/preview-vps.yml'), 'utf8');
+
+    expect(workflow).toContain('provisioning|running)');
+    expect(workflow).toContain('Reusing existing ${HANDLE} machine ${accepted_machine_id} (${status})');
+    expect(workflow).toContain('absent|failed)');
+    expect(workflow.match(/\/vps\/preview\/provision/g)).toHaveLength(1);
+  });
+
   it('host bundle release workflow can skip dev bundles only through explicit manual input', () => {
     const root = process.cwd();
     const workflow = readFileSync(join(root, '.github/workflows/host-bundle-release.yml'), 'utf8');

--- a/tests/platform/customer-vps-host-bundle.test.ts
+++ b/tests/platform/customer-vps-host-bundle.test.ts
@@ -668,6 +668,20 @@ test "$(readlink "$MATRIX_LEGACY_HOME/.hermes")" = "$MATRIX_HOME/.hermes"
     expect(workflow).toContain('[ "${REQUESTED_VERSION##*-}" != "${head_sha:0:7}" ]');
   });
 
+  it('manual preview verification uses a temporary QA session and revokes it', () => {
+    const root = process.cwd();
+    const workflow = readFileSync(join(root, '.github/workflows/preview-vps.yml'), 'utf8');
+
+    expect(workflow).toContain('verify_inventory:');
+    expect(workflow).toContain('action="verify"');
+    expect(workflow).toContain('https://api.clerk.com/v1/sessions');
+    expect(workflow).toContain('https://api.clerk.com/v1/sessions/${session_id}/tokens');
+    expect(workflow).toContain('https://api.clerk.com/v1/sessions/${session_id}/revoke');
+    expect(workflow).toContain('"${PLATFORM_PUBLIC_URL}/api/auth/computers"');
+    expect(workflow).toContain('select(.handle == $h and .runtimeSlot == $h and .kind == "preview")');
+    expect(workflow).not.toContain('echo "$session_token"');
+  });
+
   it('host bundle release workflow can skip dev bundles only through explicit manual input', () => {
     const root = process.cwd();
     const workflow = readFileSync(join(root, '.github/workflows/host-bundle-release.yml'), 'utf8');

--- a/tests/platform/customer-vps-host-bundle.test.ts
+++ b/tests/platform/customer-vps-host-bundle.test.ts
@@ -675,8 +675,10 @@ test "$(readlink "$MATRIX_LEGACY_HOME/.hermes")" = "$MATRIX_HOME/.hermes"
     expect(workflow).toContain('verify_inventory:');
     expect(workflow).toContain('action="verify"');
     expect(workflow).toContain('https://api.clerk.com/v1/agents/tasks');
+    expect(workflow).toContain('https://api.clerk.com/v1/users/${PREVIEW_CLERK_USER_ID}');
+    expect(workflow).toContain('Configured preview verification user is unavailable (HTTP ${user_code}).');
     expect(workflow).toContain('https://api.clerk.com/v1/agents/tasks/${task_id}/revoke');
-    expect(workflow.match(/Clerk-API-Version: 2025-11-10/g)).toHaveLength(2);
+    expect(workflow.match(/Clerk-API-Version: 2025-11-10/g)).toHaveLength(3);
     expect(workflow).toContain("redirect_url: $redirect_url");
     expect(workflow).toContain('task_error="$(jq -r');
     expect(workflow).toContain('task_field="$(jq -r');

--- a/tests/platform/customer-vps-host-bundle.test.ts
+++ b/tests/platform/customer-vps-host-bundle.test.ts
@@ -627,7 +627,7 @@ test "$(readlink "$MATRIX_LEGACY_HOME/.hermes")" = "$MATRIX_HOME/.hermes"
     const workflow = readFileSync(join(root, '.github/workflows/preview-vps.yml'), 'utf8');
 
     expect(workflow).toContain('Immediate fleet visibility for ${HANDLE}: ${status}');
-    expect(workflow).toContain('select(.handle == $h and .machineId == $id)');
+    expect(workflow).toContain('select(.handle == $h and .machineId == $id and .runtimeSlot == $h)');
     expect(workflow).toContain('if [ "$status" != "provisioning" ] && [ "$status" != "running" ]; then');
     expect(workflow.indexOf('Immediate fleet visibility for ${HANDLE}: ${status}'))
       .toBeLessThan(workflow.indexOf('deadline=$((SECONDS + 600))'));

--- a/tests/platform/customer-vps-host-bundle.test.ts
+++ b/tests/platform/customer-vps-host-bundle.test.ts
@@ -678,6 +678,8 @@ test "$(readlink "$MATRIX_LEGACY_HOME/.hermes")" = "$MATRIX_HOME/.hermes"
     expect(workflow).toContain('https://api.clerk.com/v1/agents/tasks/${task_id}/revoke');
     expect(workflow.match(/Clerk-API-Version: 2025-11-10/g)).toHaveLength(2);
     expect(workflow).toContain("redirect_url: $redirect_url");
+    expect(workflow).toContain('task_error="$(jq -r');
+    expect(workflow).toContain('test("^[a-z0-9_]{1,80}$")');
     expect(workflow).toContain('--max-redirs 10 -c /tmp/clerk-cookies.txt -b /tmp/clerk-cookies.txt');
     expect(workflow).toContain('-b /tmp/clerk-cookies.txt');
     expect(workflow).toContain('"${PLATFORM_PUBLIC_URL}/api/auth/computers"');

--- a/tests/platform/customer-vps-host-bundle.test.ts
+++ b/tests/platform/customer-vps-host-bundle.test.ts
@@ -668,22 +668,21 @@ test "$(readlink "$MATRIX_LEGACY_HOME/.hermes")" = "$MATRIX_HOME/.hermes"
     expect(workflow).toContain('[ "${REQUESTED_VERSION##*-}" != "${head_sha:0:7}" ]');
   });
 
-  it('manual preview verification uses a temporary QA session and revokes it', () => {
+  it('manual preview verification uses a temporary QA agent task and revokes it', () => {
     const root = process.cwd();
     const workflow = readFileSync(join(root, '.github/workflows/preview-vps.yml'), 'utf8');
 
     expect(workflow).toContain('verify_inventory:');
     expect(workflow).toContain('action="verify"');
-    expect(workflow).toContain('https://api.clerk.com/v1/sessions');
-    expect(workflow).toContain('https://api.clerk.com/v1/sessions/${session_id}/tokens');
-    expect(workflow).toContain('https://api.clerk.com/v1/sessions/${session_id}/revoke');
-    expect(workflow.match(/Clerk-API-Version: 2025-11-10/g)).toHaveLength(3);
-    expect(workflow).toContain('Temporary preview verification session failed with HTTP ${session_code}.');
-    expect(workflow).toContain('case "$session_code" in');
-    expect(workflow).toContain('200|201) ;;');
+    expect(workflow).toContain('https://api.clerk.com/v1/agents/tasks');
+    expect(workflow).toContain('https://api.clerk.com/v1/agents/tasks/${task_id}/revoke');
+    expect(workflow.match(/Clerk-API-Version: 2025-11-10/g)).toHaveLength(2);
+    expect(workflow).toContain("redirect_url: $redirect_url");
+    expect(workflow).toContain('--max-redirs 10 -c /tmp/clerk-cookies.txt -b /tmp/clerk-cookies.txt');
+    expect(workflow).toContain('-b /tmp/clerk-cookies.txt');
     expect(workflow).toContain('"${PLATFORM_PUBLIC_URL}/api/auth/computers"');
     expect(workflow).toContain('select(.handle == $h and .runtimeSlot == $h and .kind == "preview")');
-    expect(workflow).not.toContain('echo "$session_token"');
+    expect(workflow).not.toContain('echo "$task_url"');
   });
 
   it('pinned preview redeploys skip bundle build and immutable publication', () => {

--- a/tests/platform/customer-vps-provisioning-durability.test.ts
+++ b/tests/platform/customer-vps-provisioning-durability.test.ts
@@ -210,4 +210,46 @@ describe('platform/customer-vps provisioning durability', () => {
       publicIPv4: '203.0.113.20',
     });
   });
+
+  it('fails an expired job at the bounded worker-attempt limit without corrupting its row', async () => {
+    const enqueueProvisioningJob = vi.fn(async (transaction: PlatformDB, job: NewProvisioningJob) => {
+      await insertProvisioningJob(transaction, {
+        ...job,
+        availableAt: '2026-07-12T01:01:00.000Z',
+      });
+    });
+    let currentTime = new Date('2026-07-12T01:00:00.000Z');
+    const { app, hetzner, service } = createHarness({
+      enqueueProvisioningJob,
+      now: () => currentTime,
+    });
+    expect((await previewProvision(app)).status).toBe(202);
+    await db.executor.updateTable('provisioning_jobs').set({
+      status: 'running',
+      attempts: 100,
+      claimed_at: '2026-07-12T00:50:00.000Z',
+      lease_expires_at: '2026-07-12T00:55:00.000Z',
+    }).execute();
+
+    currentTime = new Date('2026-07-12T01:02:00.000Z');
+    await expect(service.dispatchProvisioningJobs()).resolves.toEqual({
+      checked: 1,
+      completed: 0,
+      failed: 1,
+    });
+
+    expect(hetzner.createServer).not.toHaveBeenCalled();
+    await expect(listProvisioningJobs(db, 10)).resolves.toEqual([
+      expect.objectContaining({
+        status: 'failed',
+        attempts: 100,
+        encryptedPayload: null,
+        lastErrorCode: 'retry_exhausted',
+      }),
+    ]);
+    await expect(getActiveUserMachineByHandle(db, 'pr-919', 'pr-919')).resolves.toMatchObject({
+      status: 'failed',
+      failureCode: 'retry_exhausted',
+    });
+  });
 });

--- a/tests/platform/customer-vps-provisioning-durability.test.ts
+++ b/tests/platform/customer-vps-provisioning-durability.test.ts
@@ -211,6 +211,44 @@ describe('platform/customer-vps provisioning durability', () => {
     });
   });
 
+  it('fails and clears a claimed job when adopted-server persistence fails', async () => {
+    let currentTime = new Date('2026-07-12T01:00:00.000Z');
+    const enqueueProvisioningJob = vi.fn(async (transaction: PlatformDB, job: NewProvisioningJob) => {
+      await insertProvisioningJob(transaction, {
+        ...job,
+        availableAt: '2026-07-12T01:01:00.000Z',
+      });
+    });
+    const hetzner = createMockHetznerClient({
+      listServersByLabel: vi.fn().mockResolvedValue([{
+        id: 654321,
+        status: 'running',
+        serverType: 'cpx22',
+        publicIPv4: '203.0.113.20',
+        publicIPv6: '2001:db8::20',
+      }]),
+    });
+    const { app, service } = createHarness({ enqueueProvisioningJob, hetzner, now: () => currentTime });
+    expect((await previewProvision(app)).status).toBe(202);
+
+    const transaction = vi.spyOn(db, 'transaction');
+    transaction.mockRejectedValueOnce(new Error('persistence unavailable'));
+    currentTime = new Date('2026-07-12T01:02:00.000Z');
+
+    await expect(service.dispatchProvisioningJobs()).resolves.toEqual({
+      checked: 1,
+      completed: 0,
+      failed: 1,
+    });
+    expect(hetzner.createServer).not.toHaveBeenCalled();
+    await expect(listProvisioningJobs(db, 10)).resolves.toEqual([
+      expect.objectContaining({ status: 'failed', encryptedPayload: null }),
+    ]);
+    await expect(getActiveUserMachineByHandle(db, 'pr-919', 'pr-919')).resolves.toMatchObject({
+      status: 'failed',
+    });
+  });
+
   it('fails an expired job at the bounded worker-attempt limit without corrupting its row', async () => {
     const enqueueProvisioningJob = vi.fn(async (transaction: PlatformDB, job: NewProvisioningJob) => {
       await insertProvisioningJob(transaction, {

--- a/tests/platform/customer-vps-provisioning-durability.test.ts
+++ b/tests/platform/customer-vps-provisioning-durability.test.ts
@@ -176,4 +176,38 @@ describe('platform/customer-vps provisioning durability', () => {
       expect.objectContaining({ status: 'completed', attempts: 1, encryptedPayload: null }),
     ]);
   });
+
+  it('adopts a provider server created before an expired worker lease instead of duplicating it', async () => {
+    let currentTime = new Date('2026-07-12T01:00:00.000Z');
+    const enqueueProvisioningJob = vi.fn(async (transaction: PlatformDB, job: NewProvisioningJob) => {
+      await insertProvisioningJob(transaction, {
+        ...job,
+        availableAt: '2026-07-12T01:01:00.000Z',
+      });
+    });
+    const hetzner = createMockHetznerClient({
+      listServersByLabel: vi.fn().mockResolvedValue([{
+        id: 654321,
+        status: 'running',
+        serverType: 'cpx22',
+        publicIPv4: '203.0.113.20',
+        publicIPv6: '2001:db8::20',
+      }]),
+    });
+    const { app, service } = createHarness({
+      enqueueProvisioningJob,
+      hetzner,
+      now: () => currentTime,
+    });
+
+    expect((await previewProvision(app)).status).toBe(202);
+    currentTime = new Date('2026-07-12T01:02:00.000Z');
+    await expect(service.dispatchProvisioningJobs()).resolves.toMatchObject({ completed: 1 });
+
+    expect(hetzner.createServer).not.toHaveBeenCalled();
+    await expect(getActiveUserMachineByHandle(db, 'pr-919', 'pr-919')).resolves.toMatchObject({
+      hetznerServerId: 654321,
+      publicIPv4: '203.0.113.20',
+    });
+  });
 });

--- a/tests/platform/customer-vps-provisioning-durability.test.ts
+++ b/tests/platform/customer-vps-provisioning-durability.test.ts
@@ -1,0 +1,179 @@
+import { Hono } from 'hono';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  getActiveUserMachineByHandle,
+  type PlatformDB,
+} from '../../packages/platform/src/db.js';
+import {
+  insertProvisioningJob,
+  listProvisioningJobs,
+  type NewProvisioningJob,
+} from '../../packages/platform/src/customer-vps-provisioning-jobs.js';
+import { createCustomerVpsRoutes } from '../../packages/platform/src/customer-vps-routes.js';
+import { createCustomerVpsService } from '../../packages/platform/src/customer-vps.js';
+import { loadCustomerVpsConfig } from '../../packages/platform/src/customer-vps-config.js';
+import { hashRegistrationToken } from '../../packages/platform/src/customer-vps-auth.js';
+import { createMockCustomerVpsSystemStore, createMockHetznerClient } from './customer-vps-fixtures.js';
+import { createTestPlatformDb, destroyTestPlatformDb } from './platform-db-test-helper.js';
+
+const PLATFORM_SECRET = 'platform-secret';
+const ADMIN_HEADERS = {
+  authorization: `Bearer ${PLATFORM_SECRET}`,
+  'content-type': 'application/json',
+};
+
+describe('platform/customer-vps provisioning durability', () => {
+  let db: PlatformDB;
+
+  beforeEach(async () => {
+    ({ db } = await createTestPlatformDb());
+  });
+
+  afterEach(async () => {
+    await destroyTestPlatformDb(db);
+  });
+
+  function createHarness(overrides: Parameters<typeof createCustomerVpsService>[0] = {} as never) {
+    const hetzner = createMockHetznerClient(overrides.hetzner);
+    const service = createCustomerVpsService({
+      db,
+      config: loadCustomerVpsConfig({
+        PLATFORM_SECRET,
+        HETZNER_API_TOKEN: 'provider-token',
+        PLATFORM_PUBLIC_URL: 'https://api.matrix-os.com',
+        CUSTOMER_VPS_IMAGE_VERSION: 'dev',
+        S3_ACCESS_KEY_ID: 'r2-access-key',
+        S3_SECRET_ACCESS_KEY: 'r2-secret-key',
+        S3_ENDPOINT: 'https://r2.example',
+        R2_BUCKET: 'matrixos-sync',
+      }),
+      hetzner,
+      systemStore: createMockCustomerVpsSystemStore(),
+      machineIdFactory: () => '9f05824c-8d0a-4d83-9cb4-b312d43ff112',
+      provisioningJobIdFactory: () => '721c3ef8-23f6-47e4-a890-6f6dc14759d1',
+      tokenFactory: () => ({
+        token: 'registration-token',
+        hash: hashRegistrationToken('registration-token'),
+        expiresAt: '2099-01-01T00:00:00.000Z',
+      }),
+      postgresPasswordFactory: () => 'postgres-secret',
+      now: () => new Date('2026-07-12T01:00:00.000Z'),
+      ...overrides,
+    });
+    const app = new Hono();
+    app.route('/vps', createCustomerVpsRoutes({ service, platformSecret: PLATFORM_SECRET }));
+    return { app, hetzner, service };
+  }
+
+  async function previewProvision(app: Hono): Promise<Response> {
+    return app.request('/vps/preview/provision', {
+      method: 'POST',
+      headers: ADMIN_HEADERS,
+      body: JSON.stringify({
+        clerkUserId: 'user_preview',
+        handle: 'pr-919',
+        runtimeSlot: 'pr-919',
+      }),
+    });
+  }
+
+  it('moves an absent preview through durably visible provisioning to running', async () => {
+    const { app, service } = createHarness();
+
+    const accepted = await previewProvision(app);
+
+    expect(accepted.status).toBe(202);
+    const machine = await getActiveUserMachineByHandle(db, 'pr-919', 'pr-919');
+    expect(machine).toMatchObject({ status: 'provisioning', provisioningClass: 'preview' });
+    const jobs = await listProvisioningJobs(db, 10);
+    expect(jobs).toHaveLength(1);
+    expect(jobs[0]).toMatchObject({ machineId: machine?.machineId, status: 'completed' });
+
+    await service.register('registration-token', {
+      machineId: machine!.machineId,
+      hetznerServerId: 123456,
+      publicIPv4: '203.0.113.10',
+      publicIPv6: '2001:db8::1',
+      imageVersion: 'dev',
+    });
+
+    await expect(getActiveUserMachineByHandle(db, 'pr-919', 'pr-919')).resolves.toMatchObject({
+      status: 'running',
+    });
+  });
+
+  it('keeps repeated preview provisioning idempotent across the machine and job', async () => {
+    const { app, hetzner } = createHarness();
+
+    const first = await previewProvision(app);
+    const second = await previewProvision(app);
+
+    expect(first.status).toBe(202);
+    expect(second.status).toBe(202);
+    expect(await second.json()).toEqual(await first.json());
+    expect(hetzner.createServer).toHaveBeenCalledTimes(1);
+    await expect(listProvisioningJobs(db, 10)).resolves.toHaveLength(1);
+  });
+
+  it('rolls back the machine and returns non-success when durable enqueue fails', async () => {
+    const enqueueProvisioningJob = vi.fn<(
+      db: PlatformDB,
+      job: NewProvisioningJob,
+    ) => Promise<void>>().mockRejectedValue(new Error('persistence unavailable'));
+    const { app, hetzner } = createHarness({ enqueueProvisioningJob });
+
+    const response = await previewProvision(app);
+
+    expect(response.status).toBe(500);
+    expect(await response.json()).toEqual({ error: 'Provisioning failed' });
+    expect(hetzner.createServer).not.toHaveBeenCalled();
+    await expect(getActiveUserMachineByHandle(db, 'pr-919', 'pr-919')).resolves.toBeUndefined();
+  });
+
+  it('shows the accepted machine in fleet immediately', async () => {
+    const { app } = createHarness();
+
+    expect((await previewProvision(app)).status).toBe(202);
+    const fleet = await app.request('/vps/fleet', { headers: ADMIN_HEADERS });
+
+    expect(fleet.status).toBe(200);
+    expect(await fleet.json()).toMatchObject({
+      machines: [expect.objectContaining({
+        handle: 'pr-919',
+        runtimeSlot: 'pr-919',
+        status: 'provisioning',
+      })],
+    });
+  });
+
+  it('dispatches a durably queued job from the reconciliation worker', async () => {
+    let currentTime = new Date('2026-07-12T01:00:00.000Z');
+    const enqueueProvisioningJob = vi.fn(async (transaction: PlatformDB, job: NewProvisioningJob) => {
+      await insertProvisioningJob(transaction, {
+        ...job,
+        availableAt: '2026-07-12T01:01:00.000Z',
+      });
+    });
+    const { app, hetzner, service } = createHarness({
+      enqueueProvisioningJob,
+      now: () => currentTime,
+    });
+
+    expect((await previewProvision(app)).status).toBe(202);
+    expect(hetzner.createServer).not.toHaveBeenCalled();
+    await expect(listProvisioningJobs(db, 10)).resolves.toEqual([
+      expect.objectContaining({ status: 'queued', attempts: 0 }),
+    ]);
+
+    currentTime = new Date('2026-07-12T01:02:00.000Z');
+    await expect(service.dispatchProvisioningJobs()).resolves.toEqual({
+      checked: 1,
+      completed: 1,
+      failed: 0,
+    });
+    expect(hetzner.createServer).toHaveBeenCalledOnce();
+    await expect(listProvisioningJobs(db, 10)).resolves.toEqual([
+      expect.objectContaining({ status: 'completed', attempts: 1, encryptedPayload: null }),
+    ]);
+  });
+});

--- a/tests/platform/customer-vps-reliability.test.ts
+++ b/tests/platform/customer-vps-reliability.test.ts
@@ -181,7 +181,8 @@ describe('platform/customer-vps reliability', () => {
       service.provision({ clerkUserId: 'user_123', handle: 'alice' }),
     ]);
 
-    expect(results.some((r) => r.status === 'fulfilled')).toBe(true);
+    const failures = results.flatMap((result) => result.status === 'rejected' ? [String(result.reason)] : []);
+    expect(results.some((r) => r.status === 'fulfilled'), failures.join('\n')).toBe(true);
     const live = (await listUserMachines(db)).filter(
       (m) => m.clerkUserId === 'user_123' && m.deletedAt === null,
     );
@@ -202,7 +203,8 @@ describe('platform/customer-vps reliability', () => {
       service.provision({ clerkUserId: 'user_123', handle: 'alice' }),
     ]);
 
-    expect(results.some((r) => r.status === 'fulfilled')).toBe(true);
+    const failures = results.flatMap((result) => result.status === 'rejected' ? [String(result.reason)] : []);
+    expect(results.some((r) => r.status === 'fulfilled'), failures.join('\n')).toBe(true);
     for (const r of results) {
       if (r.status === 'rejected') {
         expect(r.reason).toBeInstanceOf(Error);


### PR DESCRIPTION
## Summary

- provision PR previews through the dedicated operator route with identical `pr-N` handle and runtime slot
- validate the exact `202` response shape before treating provisioning as accepted
- require the accepted machine ID to be immediately visible in the authoritative fleet read
- resume an existing provisioning or running preview without a duplicate provision request
- document durable acceptance and safe workflow retries

Stacked on #924.

## Validation

- `pnpm exec vitest run tests/platform/customer-vps-host-bundle.test.ts tests/platform/ci-workflows.test.ts --silent` (64 passed)
- combined focused platform suite (96 passed)
- `bun run typecheck` (passed on the combined stack)
- `bun run check:patterns` (0 violations; existing warnings only)
- `git diff --check` (passed)

## Invariants

- **Source of truth:** Platform Postgres and `/vps/fleet` remain authoritative. The workflow stores no machine state.
- **Lock/transaction scope:** This PR adds no database writes or locks; it consumes the atomic machine/job contract from #924.
- **Acceptable orphan states:** A register-only bundle can remain after a failed workflow, but no release channel is promoted. PR-close teardown and the bounded reaper remain the cleanup backstops.
- **Auth source of truth:** Existing `PLATFORM_SECRET` bearer auth remains authoritative. Same-repository workflow gating continues to protect secret-bearing jobs.
- **Error boundary:** Invalid success bodies and accepted-but-absent machines fail closed without echoing platform response bodies.
- **Deferred scope:** No Preview Platform deployment, production traffic promotion, release-channel promotion, or merge is included.
