### PR TITLE
feat(desktop): add Matrix computer file browser

### DIFF
--- a/desktop/src/main/auth/header-injection.ts
+++ b/desktop/src/main/auth/header-injection.ts
@@ -107,7 +107,9 @@ export function buildRendererCsp(gatewayOrigin: string | null, rendererOrigin: s
     `connect-src ${connectSources}`,
     "worker-src 'self' blob:",
     "font-src 'self' data:",
-    "img-src 'self' data: https:",
+    // blob: renders same-renderer object URLs (authenticated file previews);
+    // it cannot reference external content.
+    "img-src 'self' data: blob: https:",
   ].join("; ");
 }
 

--- a/desktop/src/renderer/src/features/board/CreateProjectDialog.tsx
+++ b/desktop/src/renderer/src/features/board/CreateProjectDialog.tsx
@@ -9,6 +9,7 @@ import { useUi } from "../../stores/ui";
 import { useCodingAgentWorkspace } from "../../stores/coding-agent-workspace";
 import { useCodingAgentProjectWorkspace } from "../../stores/coding-agent-project-workspace";
 import { codingAgentRuntimeScope } from "../../../../shared/coding-agent-project-workspace";
+import ComputerFileBrowser from "../files/ComputerFileBrowser";
 
 type Mode = "scratch" | "folder" | "github";
 
@@ -171,13 +172,13 @@ function CreateProjectForm({ onClose }: { onClose: () => void }) {
           <input value={url} onChange={(e) => setUrl(e.target.value)} placeholder="https://github.com/owner/repo" style={field} />
         </label>
       ) : mode === "folder" ? (
-        <label className="flex flex-col gap-1">
-          <span className="text-xs font-medium" style={{ color: "var(--text-secondary)" }}>Folder on this computer</span>
-          <input value={path} onChange={(e) => setPath(e.target.value)} placeholder="workspaces/customer-app" style={field} />
+        <div className="flex flex-col gap-1.5">
+          <span className="text-xs font-medium" style={{ color: "var(--text-secondary)" }}>Choose a folder on this computer</span>
+          <ComputerFileBrowser compact onChooseFolder={setPath} />
           <span className="text-xs" style={{ color: "var(--text-tertiary)" }}>
-            Enter a folder relative to your Matrix home. The folder stays in place and remains yours.
+            {path ? `Selected: ${path}` : "Select a folder. It stays in place and remains yours."}
           </span>
-        </label>
+        </div>
       ) : (
         <p className="text-xs" style={{ color: "var(--text-tertiary)" }}>
           A new project folder is created on your Matrix computer. Git and GitHub are optional.
@@ -198,7 +199,7 @@ function CreateProjectForm({ onClose }: { onClose: () => void }) {
 
 export default function CreateProjectDialog({ open, onClose }: { open: boolean; onClose: () => void }) {
   return (
-    <Dialog open={open} onClose={onClose} width={520}>
+    <Dialog open={open} onClose={onClose} width={620}>
       <CreateProjectForm onClose={onClose} />
     </Dialog>
   );

--- a/desktop/src/renderer/src/features/board/CreateProjectDialog.tsx
+++ b/desktop/src/renderer/src/features/board/CreateProjectDialog.tsx
@@ -24,14 +24,36 @@ function CreateProjectForm({ onClose }: { onClose: () => void }) {
   const refreshAgentWorkspace = useCodingAgentWorkspace((s) => s.refresh);
   const openCreatedProject = useCodingAgentProjectWorkspace((s) => s.openCreatedProject);
   const runtimeScope = useConnection(codingAgentRuntimeScope);
+  const runtimeSlot = useConnection((s) => s.runtimeSlot);
+  const authGeneration = useConnection((s) => s.authGeneration);
   const [name, setName] = useState("");
   const [mode, setMode] = useState<Mode>("scratch");
   const [url, setUrl] = useState("");
-  const [path, setPath] = useState("");
+  // A folder chosen under one computer/session must not stay submittable under
+  // another, so the selection carries its scope and resolves to "" as soon as
+  // the slot or credential generation changes (synchronously, like the Files
+  // workspace selection).
+  const [folderSelection, setFolderSelection] = useState<{ slot: string; authGeneration: number; path: string } | null>(null);
+  const path = folderSelection && folderSelection.slot === runtimeSlot && folderSelection.authGeneration === authGeneration
+    ? folderSelection.path
+    : "";
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const dialogClosedRef = useRef(false);
   const dialogGenerationRef = useRef(0);
+
+  useEffect(() => {
+    setFolderSelection((current) =>
+      current && (current.slot !== runtimeSlot || current.authGeneration !== authGeneration)
+        ? null
+        : current,
+    );
+  }, [authGeneration, runtimeSlot]);
+
+  const chooseFolder = useCallback(
+    (chosen: string) => setFolderSelection({ slot: runtimeSlot, authGeneration, path: chosen }),
+    [authGeneration, runtimeSlot],
+  );
 
   const canSubmit = name.trim().length > 0 && (
     mode === "scratch" ||
@@ -174,7 +196,7 @@ function CreateProjectForm({ onClose }: { onClose: () => void }) {
       ) : mode === "folder" ? (
         <div className="flex flex-col gap-1.5">
           <span className="text-xs font-medium" style={{ color: "var(--text-secondary)" }}>Choose a folder on this computer</span>
-          <ComputerFileBrowser compact onChooseFolder={setPath} />
+          <ComputerFileBrowser compact onChooseFolder={chooseFolder} />
           <span className="text-xs" style={{ color: "var(--text-tertiary)" }}>
             {path ? `Selected: ${path}` : "Select a folder. It stays in place and remains yours."}
           </span>

--- a/desktop/src/renderer/src/features/editor/MarkdownPreview.tsx
+++ b/desktop/src/renderer/src/features/editor/MarkdownPreview.tsx
@@ -26,6 +26,22 @@ export function safeUrlTransform(url: string): string {
 export const MARKDOWN_PREVIEW_CLASS_NAME =
   "prose-sm mx-auto max-w-[760px] text-sm leading-relaxed [&_a]:text-[var(--highlight)] [&_blockquote]:border-l-2 [&_blockquote]:border-[var(--border-default)] [&_blockquote]:pl-3 [&_blockquote]:text-[var(--text-secondary)] [&_code]:rounded [&_code]:bg-[var(--bg-sunken)] [&_code]:px-1 [&_code]:py-0.5 [&_code]:font-mono [&_code]:text-[12px] [&_h1]:mt-4 [&_h1]:mb-2 [&_h1]:text-xl [&_h1]:font-semibold [&_h2]:mt-4 [&_h2]:mb-2 [&_h2]:text-lg [&_h2]:font-semibold [&_h3]:mt-3 [&_h3]:mb-1.5 [&_h3]:font-semibold [&_hr]:my-4 [&_hr]:border-[var(--border-subtle)] [&_li]:my-0.5 [&_ol]:list-decimal [&_ol]:pl-5 [&_p]:my-2 [&_pre]:overflow-x-auto [&_pre]:rounded-lg [&_pre]:border [&_pre]:border-[var(--border-subtle)] [&_pre]:bg-[var(--bg-sunken)] [&_pre]:p-3 [&_pre_code]:bg-transparent [&_table]:my-3 [&_table]:w-full [&_table]:border-collapse [&_td]:border [&_td]:border-[var(--border-subtle)] [&_td]:px-2 [&_td]:py-1 [&_th]:border [&_th]:border-[var(--border-subtle)] [&_th]:bg-[var(--bg-sunken)] [&_th]:px-2 [&_th]:py-1 [&_th]:text-left [&_ul]:list-disc [&_ul]:pl-5 [&_ul.contains-task-list]:!list-none [&_li.task-list-item]:!list-none [&_input]:mr-1.5";
 
+export function MarkdownContent({ content }: { content: string }) {
+  return (
+    <div className="min-h-0 flex-1 overflow-y-auto px-6 py-5">
+      <div className={MARKDOWN_PREVIEW_CLASS_NAME} style={{ color: "var(--text-primary)" }} data-selectable>
+        <ReactMarkdown
+          remarkPlugins={[remarkGfm]}
+          rehypePlugins={[[rehypeHighlight, { ignoreMissing: true }]]}
+          urlTransform={safeUrlTransform}
+        >
+          {content}
+        </ReactMarkdown>
+      </div>
+    </div>
+  );
+}
+
 // Read-only rendered markdown for .md/.mdx files. Reuses the chat response prose
 // styling so docs read like docs instead of raw CodeMirror text. Toggle to Code
 // in the editor header to edit.
@@ -58,21 +74,5 @@ export default function MarkdownPreview({ path }: { path: string }) {
     return <div className="flex flex-1 items-center justify-center text-sm" style={{ color: "var(--text-tertiary)" }}>Loading…</div>;
   }
 
-  return (
-    <div className="min-h-0 flex-1 overflow-y-auto px-6 py-5">
-      <div
-        className={MARKDOWN_PREVIEW_CLASS_NAME}
-        style={{ color: "var(--text-primary)" }}
-        data-selectable
-      >
-        <ReactMarkdown
-          remarkPlugins={[remarkGfm]}
-          rehypePlugins={[[rehypeHighlight, { ignoreMissing: true }]]}
-          urlTransform={safeUrlTransform}
-        >
-          {preview.content}
-        </ReactMarkdown>
-      </div>
-    </div>
-  );
+  return <MarkdownContent content={preview.content} />;
 }

--- a/desktop/src/renderer/src/features/files/ComputerFileBrowser.tsx
+++ b/desktop/src/renderer/src/features/files/ComputerFileBrowser.tsx
@@ -167,6 +167,15 @@ export default function ComputerFileBrowser({
                   onDoubleClick={() => {
                     if (entry.type === "directory") navigate(path);
                   }}
+                  onKeyDown={(event) => {
+                    // Double-click is mouse-only; Enter must let keyboard and
+                    // screen-reader users enter the directory (Space still
+                    // selects it as the folder candidate via the click event).
+                    if (entry.type === "directory" && event.key === "Enter") {
+                      event.preventDefault();
+                      navigate(path);
+                    }
+                  }}
                 >
                   <span style={{ color: entry.type === "directory" ? "var(--accent)" : "var(--text-tertiary)" }}>
                     {entry.type === "directory" ? (selected ? <FolderOpen size={17} /> : <Folder size={17} />) : fileIcon(entry.name)}

--- a/desktop/src/renderer/src/features/files/ComputerFileBrowser.tsx
+++ b/desktop/src/renderer/src/features/files/ComputerFileBrowser.tsx
@@ -37,12 +37,25 @@ export default function ComputerFileBrowser({
 }) {
   const api = useConnection((state) => state.api);
   const runtimeSlot = useConnection((state) => state.runtimeSlot);
+  const authGeneration = useConnection((state) => state.authGeneration);
   const [currentPath, setCurrentPath] = useState("");
   const [candidatePath, setCandidatePath] = useState("");
   const [entries, setEntries] = useState<FileEntry[]>([]);
   const [status, setStatus] = useState<BrowserStatus>("loading");
   const [error, setError] = useState<string | null>(null);
   const requestGeneration = useRef(0);
+  // Listings belong to one computer/session. Derive the rendered view
+  // synchronously from the scope they were loaded under, so a runtime switch
+  // or replacement session never shows the previous owner's directory names or
+  // lets stale rows fire onOpenFile/onChooseFolder against the new API.
+  const browserScope = `${runtimeSlot}|${authGeneration}`;
+  const [loadedScope, setLoadedScope] = useState(browserScope);
+  const scoped = loadedScope === browserScope;
+  const viewCurrentPath = scoped ? currentPath : "";
+  const viewCandidatePath = scoped ? candidatePath : "";
+  const viewEntries = scoped ? entries : [];
+  const viewStatus: BrowserStatus = scoped ? status : "loading";
+  const viewError = scoped ? error : null;
 
   const load = useCallback(async (path: string) => {
     if (!api) return;
@@ -63,13 +76,14 @@ export default function ComputerFileBrowser({
   }, [api]);
 
   useEffect(() => {
+    setLoadedScope(browserScope);
     setCurrentPath("");
     setCandidatePath("");
     void load("");
     return () => {
       requestGeneration.current += 1;
     };
-  }, [load, runtimeSlot]);
+  }, [browserScope, load]);
 
   const navigate = useCallback((path: string) => {
     setCurrentPath(path);
@@ -78,11 +92,11 @@ export default function ComputerFileBrowser({
   }, [load]);
 
   const crumbs = useMemo(() => {
-    const segments = currentPath ? currentPath.split("/") : [];
+    const segments = viewCurrentPath ? viewCurrentPath.split("/") : [];
     return segments.map((label, index) => ({ label, path: segments.slice(0, index + 1).join("/") }));
-  }, [currentPath]);
+  }, [viewCurrentPath]);
 
-  const chosenName = (candidatePath.split("/").pop() || "Matrix home");
+  const chosenName = (viewCandidatePath.split("/").pop() || "Matrix home");
 
   return (
     <div
@@ -94,7 +108,7 @@ export default function ComputerFileBrowser({
           type="button"
           aria-label="Matrix home"
           className="flex items-center gap-1.5 rounded-md px-2 py-1 text-xs font-medium hover:bg-[var(--bg-hover)]"
-          style={{ color: currentPath ? "var(--text-secondary)" : "var(--text-primary)" }}
+          style={{ color: viewCurrentPath ? "var(--text-secondary)" : "var(--text-primary)" }}
           onClick={() => navigate("")}
         >
           <Home size={13} />
@@ -106,7 +120,7 @@ export default function ComputerFileBrowser({
             <button
               type="button"
               className="max-w-[150px] truncate rounded px-1.5 py-1 text-xs hover:bg-[var(--bg-hover)]"
-              style={{ color: crumb.path === currentPath ? "var(--text-primary)" : "var(--text-secondary)" }}
+              style={{ color: crumb.path === viewCurrentPath ? "var(--text-primary)" : "var(--text-secondary)" }}
               onClick={() => navigate(crumb.path)}
             >
               {crumb.label}
@@ -114,27 +128,27 @@ export default function ComputerFileBrowser({
           </span>
         ))}
         <span className="ml-auto">
-          <IconButton label="Refresh folder" onClick={() => void load(currentPath)}>
+          <IconButton label="Refresh folder" onClick={() => void load(viewCurrentPath)}>
             <RefreshCw size={13} />
           </IconButton>
         </span>
       </div>
 
       <div className={`${compact ? "h-52" : "min-h-0 flex-1"} overflow-y-auto p-1.5`}>
-        {status === "loading" ? (
+        {viewStatus === "loading" ? (
           <div className="flex h-full items-center justify-center text-xs" style={{ color: "var(--text-tertiary)" }}>Loading folder…</div>
-        ) : status === "error" ? (
+        ) : viewStatus === "error" ? (
           <div className="flex h-full flex-col items-center justify-center gap-2 px-4 text-center">
-            <span className="text-sm" style={{ color: "var(--danger)" }}>{error}</span>
-            <Button variant="subtle" onClick={() => void load(currentPath)}>Try again</Button>
+            <span className="text-sm" style={{ color: "var(--danger)" }}>{viewError}</span>
+            <Button variant="subtle" onClick={() => void load(viewCurrentPath)}>Try again</Button>
           </div>
-        ) : entries.length === 0 ? (
+        ) : viewEntries.length === 0 ? (
           <div className="flex h-full items-center justify-center text-sm" style={{ color: "var(--text-tertiary)" }}>This folder is empty.</div>
         ) : (
           <div className="grid grid-cols-1 gap-0.5">
-            {entries.map((entry) => {
-              const path = joinPath(currentPath, entry.name);
-              const selected = entry.type === "directory" && candidatePath === path;
+            {viewEntries.map((entry) => {
+              const path = joinPath(viewCurrentPath, entry.name);
+              const selected = entry.type === "directory" && viewCandidatePath === path;
               return (
                 <button
                   key={`${entry.type}:${path}`}
@@ -168,10 +182,10 @@ export default function ComputerFileBrowser({
 
       {onChooseFolder ? (
         <div className="flex shrink-0 items-center justify-between gap-3 border-t px-3 py-2" style={{ borderColor: "var(--border-subtle)", background: "var(--bg-raised)" }}>
-          <span className="min-w-0 truncate text-xs" style={{ color: "var(--text-secondary)" }} title={candidatePath || "Matrix home"}>
-            {candidatePath || "Matrix home"}
+          <span className="min-w-0 truncate text-xs" style={{ color: "var(--text-secondary)" }} title={viewCandidatePath || "Matrix home"}>
+            {viewCandidatePath || "Matrix home"}
           </span>
-          <Button variant="primary" disabled={!candidatePath} onClick={() => onChooseFolder(candidatePath)}>
+          <Button variant="primary" disabled={!viewCandidatePath} onClick={() => onChooseFolder(viewCandidatePath)}>
             Choose {chosenName}
           </Button>
         </div>

--- a/desktop/src/renderer/src/features/files/ComputerFileBrowser.tsx
+++ b/desktop/src/renderer/src/features/files/ComputerFileBrowser.tsx
@@ -1,0 +1,181 @@
+import {
+  ChevronRight,
+  File,
+  FileCode2,
+  Folder,
+  FolderOpen,
+  Home,
+  Image as ImageIcon,
+  RefreshCw,
+} from "lucide-react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { Button, IconButton } from "../../design/primitives";
+import { toUserMessage } from "../../lib/errors";
+import { useConnection } from "../../stores/connection";
+import { parseEntries, type FileEntry } from "../../stores/file-tree";
+
+type BrowserStatus = "loading" | "ready" | "error";
+
+function joinPath(parent: string, name: string): string {
+  return parent ? `${parent}/${name}` : name;
+}
+
+function fileIcon(name: string) {
+  if (/\.(png|jpe?g|gif|webp|svg)$/i.test(name)) return <ImageIcon size={16} />;
+  if (/\.(tsx?|jsx?|json|css|html|py|rs|go|mdx?)$/i.test(name)) return <FileCode2 size={16} />;
+  return <File size={16} />;
+}
+
+export default function ComputerFileBrowser({
+  compact = false,
+  onOpenFile,
+  onChooseFolder,
+}: {
+  compact?: boolean;
+  onOpenFile?: (path: string) => void;
+  onChooseFolder?: (path: string) => void;
+}) {
+  const api = useConnection((state) => state.api);
+  const runtimeSlot = useConnection((state) => state.runtimeSlot);
+  const [currentPath, setCurrentPath] = useState("");
+  const [candidatePath, setCandidatePath] = useState("");
+  const [entries, setEntries] = useState<FileEntry[]>([]);
+  const [status, setStatus] = useState<BrowserStatus>("loading");
+  const [error, setError] = useState<string | null>(null);
+  const requestGeneration = useRef(0);
+
+  const load = useCallback(async (path: string) => {
+    if (!api) return;
+    const generation = ++requestGeneration.current;
+    setStatus("loading");
+    setError(null);
+    try {
+      const response = await api.get<{ entries: unknown }>(`/api/files/list?path=${encodeURIComponent(path)}`);
+      if (generation !== requestGeneration.current) return;
+      setEntries(parseEntries(response.entries));
+      setStatus("ready");
+    } catch (err: unknown) {
+      if (generation !== requestGeneration.current) return;
+      setEntries([]);
+      setStatus("error");
+      setError(toUserMessage(err));
+    }
+  }, [api]);
+
+  useEffect(() => {
+    setCurrentPath("");
+    setCandidatePath("");
+    void load("");
+    return () => {
+      requestGeneration.current += 1;
+    };
+  }, [load, runtimeSlot]);
+
+  const navigate = useCallback((path: string) => {
+    setCurrentPath(path);
+    setCandidatePath(path);
+    void load(path);
+  }, [load]);
+
+  const crumbs = useMemo(() => {
+    const segments = currentPath ? currentPath.split("/") : [];
+    return segments.map((label, index) => ({ label, path: segments.slice(0, index + 1).join("/") }));
+  }, [currentPath]);
+
+  const chosenName = (candidatePath.split("/").pop() || "Matrix home");
+
+  return (
+    <div
+      className="flex min-h-0 flex-1 flex-col overflow-hidden rounded-lg border"
+      style={{ background: "var(--bg-surface)", borderColor: "var(--border-subtle)" }}
+    >
+      <div className="flex h-10 shrink-0 items-center gap-1 border-b px-2" style={{ borderColor: "var(--border-subtle)" }}>
+        <button
+          type="button"
+          aria-label="Matrix home"
+          className="flex items-center gap-1.5 rounded-md px-2 py-1 text-xs font-medium hover:bg-[var(--bg-hover)]"
+          style={{ color: currentPath ? "var(--text-secondary)" : "var(--text-primary)" }}
+          onClick={() => navigate("")}
+        >
+          <Home size={13} />
+          {!compact ? "Matrix home" : "Home"}
+        </button>
+        {crumbs.map((crumb) => (
+          <span key={crumb.path} className="flex min-w-0 items-center gap-1">
+            <ChevronRight size={11} style={{ color: "var(--text-tertiary)" }} />
+            <button
+              type="button"
+              className="max-w-[150px] truncate rounded px-1.5 py-1 text-xs hover:bg-[var(--bg-hover)]"
+              style={{ color: crumb.path === currentPath ? "var(--text-primary)" : "var(--text-secondary)" }}
+              onClick={() => navigate(crumb.path)}
+            >
+              {crumb.label}
+            </button>
+          </span>
+        ))}
+        <span className="ml-auto">
+          <IconButton label="Refresh folder" onClick={() => void load(currentPath)}>
+            <RefreshCw size={13} />
+          </IconButton>
+        </span>
+      </div>
+
+      <div className={`${compact ? "h-52" : "min-h-0 flex-1"} overflow-y-auto p-1.5`}>
+        {status === "loading" ? (
+          <div className="flex h-full items-center justify-center text-xs" style={{ color: "var(--text-tertiary)" }}>Loading folder…</div>
+        ) : status === "error" ? (
+          <div className="flex h-full flex-col items-center justify-center gap-2 px-4 text-center">
+            <span className="text-sm" style={{ color: "var(--danger)" }}>{error}</span>
+            <Button variant="subtle" onClick={() => void load(currentPath)}>Try again</Button>
+          </div>
+        ) : entries.length === 0 ? (
+          <div className="flex h-full items-center justify-center text-sm" style={{ color: "var(--text-tertiary)" }}>This folder is empty.</div>
+        ) : (
+          <div className="grid grid-cols-1 gap-0.5">
+            {entries.map((entry) => {
+              const path = joinPath(currentPath, entry.name);
+              const selected = entry.type === "directory" && candidatePath === path;
+              return (
+                <button
+                  key={`${entry.type}:${path}`}
+                  type="button"
+                  aria-label={`Open ${entry.name}`}
+                  aria-pressed={entry.type === "directory" ? selected : undefined}
+                  className="group flex h-9 w-full items-center gap-2 rounded-md px-2 text-left text-sm"
+                  style={{
+                    background: selected ? "var(--bg-selected)" : "transparent",
+                    color: "var(--text-primary)",
+                  }}
+                  onClick={() => {
+                    if (entry.type === "directory") setCandidatePath(path);
+                    else onOpenFile?.(path);
+                  }}
+                  onDoubleClick={() => {
+                    if (entry.type === "directory") navigate(path);
+                  }}
+                >
+                  <span style={{ color: entry.type === "directory" ? "var(--accent)" : "var(--text-tertiary)" }}>
+                    {entry.type === "directory" ? (selected ? <FolderOpen size={17} /> : <Folder size={17} />) : fileIcon(entry.name)}
+                  </span>
+                  <span className="min-w-0 flex-1 truncate">{entry.name}</span>
+                  {entry.type === "directory" ? <ChevronRight size={13} className="opacity-0 group-hover:opacity-100" style={{ color: "var(--text-tertiary)" }} /> : null}
+                </button>
+              );
+            })}
+          </div>
+        )}
+      </div>
+
+      {onChooseFolder ? (
+        <div className="flex shrink-0 items-center justify-between gap-3 border-t px-3 py-2" style={{ borderColor: "var(--border-subtle)", background: "var(--bg-raised)" }}>
+          <span className="min-w-0 truncate text-xs" style={{ color: "var(--text-secondary)" }} title={candidatePath || "Matrix home"}>
+            {candidatePath || "Matrix home"}
+          </span>
+          <Button variant="primary" disabled={!candidatePath} onClick={() => onChooseFolder(candidatePath)}>
+            Choose {chosenName}
+          </Button>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/desktop/src/renderer/src/features/files/FilesWorkspace.tsx
+++ b/desktop/src/renderer/src/features/files/FilesWorkspace.tsx
@@ -40,6 +40,15 @@ function isFiniteSizeWithin(size: unknown, max: number): boolean {
   return typeof size === "number" && Number.isFinite(size) && size <= max;
 }
 
+// The api client resolves the CURRENT runtime slot per request, so a preview
+// that started under one computer/session must re-check the scope immediately
+// before any follow-up fetch instead of relying only on the effect-cleanup
+// flag, which runs on React's schedule.
+function captureConnectionScope(): string {
+  const { runtimeSlot, authGeneration } = useConnection.getState();
+  return `${runtimeSlot}|${authGeneration}`;
+}
+
 function isImage(path: string): boolean {
   return /\.(png|jpe?g|gif|webp|svg)$/i.test(path);
 }
@@ -61,15 +70,16 @@ function TextPreview({ path, markdown = false }: { path: string; markdown?: bool
   useEffect(() => {
     if (!api) return;
     let cancelled = false;
+    const scope = captureConnectionScope();
     setState({ status: "loading" });
     void api.get<{ size?: number }>(`/api/files/stat?path=${encodeURIComponent(path)}`)
       .then(async (stat) => {
         // Fail closed: a missing or non-finite size must not bypass the bound.
         if (!isFiniteSizeWithin(stat.size, MAX_TEXT_PREVIEW_BYTES)) throw new Error("file_too_large");
-        // The selected computer may have changed while stat was in flight; the
-        // api client resolves the CURRENT runtime slot per request, so fetching
-        // now would read this path from the newly selected computer. Bail first.
-        if (cancelled) return null;
+        // The selected computer/session may have changed while stat was in
+        // flight; check the pinned scope (not only the effect-cleanup flag)
+        // before fetching this path against the newly selected computer.
+        if (cancelled || captureConnectionScope() !== scope) return null;
         // The stat can be stale by the time the blob is read (the file may
         // have grown), so the transfer itself is capped too.
         return api.getText(`/api/files/blob?path=${encodeURIComponent(path)}`, { maxBytes: MAX_TEXT_PREVIEW_BYTES });
@@ -101,15 +111,16 @@ function ImagePreview({ path, name }: { path: string; name: string }) {
     if (!api) return;
     let cancelled = false;
     let objectUrl: string | null = null;
+    const scope = captureConnectionScope();
     setState({ status: "loading" });
     void api.get<{ size?: number }>(`/api/files/stat?path=${encodeURIComponent(path)}`)
       .then(async (stat) => {
         // Fail closed like text previews: bound the bytes read into renderer memory.
         if (!isFiniteSizeWithin(stat.size, MAX_IMAGE_PREVIEW_BYTES)) throw new Error("file_too_large");
-        // The selected computer may have changed while stat was in flight; the
-        // api client resolves the CURRENT runtime slot per request, so fetching
-        // now would read this path from the newly selected computer. Bail first.
-        if (cancelled) return null;
+        // The selected computer/session may have changed while stat was in
+        // flight; check the pinned scope (not only the effect-cleanup flag)
+        // before fetching this path against the newly selected computer.
+        if (cancelled || captureConnectionScope() !== scope) return null;
         // Load bytes through the authenticated client so credentials injected at
         // the network layer apply. A bare <img src> to the blob route cannot
         // carry them and would expose the selected computer's file by URL. The

--- a/desktop/src/renderer/src/features/files/FilesWorkspace.tsx
+++ b/desktop/src/renderer/src/features/files/FilesWorkspace.tsx
@@ -1,7 +1,6 @@
 import { FileCode2, FolderOpen, HardDrive } from "lucide-react";
-import { lazy, Suspense, useEffect, useState } from "react";
+import { lazy, Suspense, useCallback, useEffect, useState } from "react";
 import { EmptyState } from "../../design/primitives";
-import { buildGatewayUrl } from "../../lib/api";
 import { toUserMessage } from "../../lib/errors";
 import { useConnection } from "../../stores/connection";
 import ComputerFileBrowser from "./ComputerFileBrowser";
@@ -12,6 +11,26 @@ const MarkdownContent = lazy(async () => {
 });
 
 const MAX_TEXT_PREVIEW_BYTES = 1024 * 1024;
+// Images stream through the authenticated client into renderer memory, so the
+// bound matches the gateway blob body limit rather than the smaller text cap.
+const MAX_IMAGE_PREVIEW_BYTES = 10 * 1024 * 1024;
+
+export interface FileSelection {
+  slot: string;
+  path: string;
+}
+
+// A selection captured under one computer must never resolve to a preview under
+// another. Derived synchronously so a runtime switch clears the path in the same
+// render, before any stat/blob request can target the new computer.
+export function resolveActivePath(selection: FileSelection | null, runtimeSlot: string): string | null {
+  if (!selection || selection.slot !== runtimeSlot) return null;
+  return selection.path;
+}
+
+function isFiniteSizeWithin(size: unknown, max: number): boolean {
+  return typeof size === "number" && Number.isFinite(size) && size <= max;
+}
 
 function isImage(path: string): boolean {
   return /\.(png|jpe?g|gif|webp|svg)$/i.test(path);
@@ -19,6 +38,12 @@ function isImage(path: string): boolean {
 
 function isMarkdown(path: string): boolean {
   return /\.mdx?$/i.test(path);
+}
+
+function previewErrorMessage(err: unknown): string {
+  return err instanceof Error && err.message === "file_too_large"
+    ? "This file is too large to preview."
+    : toUserMessage(err);
 }
 
 function TextPreview({ path, markdown = false }: { path: string; markdown?: boolean }) {
@@ -31,14 +56,15 @@ function TextPreview({ path, markdown = false }: { path: string; markdown?: bool
     setState({ status: "loading" });
     void api.get<{ size?: number }>(`/api/files/stat?path=${encodeURIComponent(path)}`)
       .then(async (stat) => {
-        if ((stat.size ?? 0) > MAX_TEXT_PREVIEW_BYTES) throw new Error("file_too_large");
+        // Fail closed: a missing or non-finite size must not bypass the bound.
+        if (!isFiniteSizeWithin(stat.size, MAX_TEXT_PREVIEW_BYTES)) throw new Error("file_too_large");
         return api.getText(`/api/files/blob?path=${encodeURIComponent(path)}`);
       })
       .then((content) => {
         if (!cancelled) setState({ status: "ready", content });
       })
       .catch((err: unknown) => {
-        if (!cancelled) setState({ status: "error", error: err instanceof Error && err.message === "file_too_large" ? "This file is too large to preview." : toUserMessage(err) });
+        if (!cancelled) setState({ status: "error", error: previewErrorMessage(err) });
       });
     return () => { cancelled = true; };
   }, [api, path]);
@@ -53,21 +79,55 @@ function TextPreview({ path, markdown = false }: { path: string; markdown?: bool
   );
 }
 
+function ImagePreview({ path, name }: { path: string; name: string }) {
+  const api = useConnection((state) => state.api);
+  const [state, setState] = useState<{ status: "loading" | "ready" | "error"; url?: string; error?: string }>({ status: "loading" });
+
+  useEffect(() => {
+    if (!api) return;
+    let cancelled = false;
+    let objectUrl: string | null = null;
+    setState({ status: "loading" });
+    void api.get<{ size?: number }>(`/api/files/stat?path=${encodeURIComponent(path)}`)
+      .then(async (stat) => {
+        // Fail closed like text previews: bound the bytes read into renderer memory.
+        if (!isFiniteSizeWithin(stat.size, MAX_IMAGE_PREVIEW_BYTES)) throw new Error("file_too_large");
+        // Load bytes through the authenticated client so credentials injected at
+        // the network layer apply. A bare <img src> to the blob route cannot
+        // carry them and would expose the selected computer's file by URL.
+        return api.getBlob(`/api/files/blob?path=${encodeURIComponent(path)}`);
+      })
+      .then((blob) => {
+        if (cancelled) return;
+        objectUrl = URL.createObjectURL(blob);
+        setState({ status: "ready", url: objectUrl });
+      })
+      .catch((err: unknown) => {
+        if (!cancelled) setState({ status: "error", error: previewErrorMessage(err) });
+      });
+    return () => {
+      cancelled = true;
+      // Revoke on path change/unmount so object URLs never leak.
+      if (objectUrl) URL.revokeObjectURL(objectUrl);
+    };
+  }, [api, path]);
+
+  if (state.status === "loading") return <div className="flex flex-1 items-center justify-center text-sm" style={{ color: "var(--text-tertiary)" }}>Loading preview…</div>;
+  if (state.status === "error") return <div className="flex flex-1 items-center justify-center text-sm" style={{ color: "var(--danger)" }}>{state.error}</div>;
+  return (
+    <div className="flex min-h-0 flex-1 items-center justify-center overflow-auto p-6" style={{ background: "var(--bg-sunken)" }}>
+      <img src={state.url} alt={name} className="max-h-full max-w-full rounded-lg object-contain" style={{ boxShadow: "var(--shadow-2)" }} />
+    </div>
+  );
+}
+
 function FilePreview({ path }: { path: string | null }) {
   const api = useConnection((state) => state.api);
-  const runtimeSlot = useConnection((state) => state.runtimeSlot);
   if (!path || !api) {
     return <EmptyState icon={<FileCode2 size={26} />} headline="Choose a file" description="Preview images, Markdown, and code from this computer." />;
   }
   const name = path.split("/").pop() ?? path;
-  if (isImage(path)) {
-    const src = buildGatewayUrl(api.baseUrl, `/api/files/blob?path=${encodeURIComponent(path)}`, runtimeSlot);
-    return (
-      <div className="flex min-h-0 flex-1 items-center justify-center overflow-auto p-6" style={{ background: "var(--bg-sunken)" }}>
-        <img src={src} alt={name} className="max-h-full max-w-full rounded-lg object-contain" style={{ boxShadow: "var(--shadow-2)" }} />
-      </div>
-    );
-  }
+  if (isImage(path)) return <ImagePreview path={path} name={name} />;
   if (isMarkdown(path)) return <TextPreview path={path} markdown />;
   return <TextPreview path={path} />;
 }
@@ -75,9 +135,21 @@ function FilePreview({ path }: { path: string | null }) {
 export default function FilesWorkspace() {
   const handle = useConnection((state) => state.handle);
   const runtimeSlot = useConnection((state) => state.runtimeSlot);
-  const [activePath, setActivePath] = useState<string | null>(null);
+  const [selection, setSelection] = useState<FileSelection | null>(null);
 
-  useEffect(() => setActivePath(null), [runtimeSlot]);
+  // Correctness comes from this synchronous derivation, not the effect below:
+  // a selection made under another computer resolves to null on the first render
+  // with the new slot, so FilePreview never sees a stale path.
+  const activePath = resolveActivePath(selection, runtimeSlot);
+
+  useEffect(() => {
+    setSelection((current) => (current && current.slot !== runtimeSlot ? null : current));
+  }, [runtimeSlot]);
+
+  const handleOpenFile = useCallback(
+    (path: string) => setSelection({ slot: runtimeSlot, path }),
+    [runtimeSlot],
+  );
 
   return (
     <div className="flex min-h-0 flex-1 flex-col" style={{ background: "var(--bg-app)" }}>
@@ -96,7 +168,7 @@ export default function FilesWorkspace() {
         </div>
       </header>
       <div className="grid min-h-0 flex-1 grid-cols-1 grid-rows-[minmax(220px,40%)_minmax(0,1fr)] gap-3 p-3 md:grid-cols-[minmax(260px,360px)_minmax(0,1fr)] md:grid-rows-1">
-        <ComputerFileBrowser onOpenFile={setActivePath} />
+        <ComputerFileBrowser onOpenFile={handleOpenFile} />
         <section className="flex min-h-0 min-w-0 flex-col overflow-hidden rounded-lg border" style={{ background: "var(--bg-surface)", borderColor: "var(--border-subtle)" }}>
           <div className="flex h-10 shrink-0 items-center border-b px-3 text-xs" style={{ borderColor: "var(--border-subtle)", color: "var(--text-secondary)" }}>
             <span className="truncate" title={activePath ?? undefined}>{activePath ?? "Preview"}</span>

--- a/desktop/src/renderer/src/features/files/FilesWorkspace.tsx
+++ b/desktop/src/renderer/src/features/files/FilesWorkspace.tsx
@@ -17,14 +17,22 @@ const MAX_IMAGE_PREVIEW_BYTES = 10 * 1024 * 1024;
 
 export interface FileSelection {
   slot: string;
+  authGeneration: number;
   path: string;
 }
 
-// A selection captured under one computer must never resolve to a preview under
-// another. Derived synchronously so a runtime switch clears the path in the same
-// render, before any stat/blob request can target the new computer.
-export function resolveActivePath(selection: FileSelection | null, runtimeSlot: string): string | null {
-  if (!selection || selection.slot !== runtimeSlot) return null;
+// A selection captured under one computer/session must never resolve to a
+// preview under another. Scoped to both the runtime slot and the credential
+// generation (a replacement session can keep the same slot). Derived
+// synchronously so a switch clears the path in the same render, before any
+// stat/blob request can target the new computer or owner.
+export function resolveActivePath(
+  selection: FileSelection | null,
+  runtimeSlot: string,
+  authGeneration: number,
+): string | null {
+  if (!selection) return null;
+  if (selection.slot !== runtimeSlot || selection.authGeneration !== authGeneration) return null;
   return selection.path;
 }
 
@@ -58,10 +66,14 @@ function TextPreview({ path, markdown = false }: { path: string; markdown?: bool
       .then(async (stat) => {
         // Fail closed: a missing or non-finite size must not bypass the bound.
         if (!isFiniteSizeWithin(stat.size, MAX_TEXT_PREVIEW_BYTES)) throw new Error("file_too_large");
+        // The selected computer may have changed while stat was in flight; the
+        // api client resolves the CURRENT runtime slot per request, so fetching
+        // now would read this path from the newly selected computer. Bail first.
+        if (cancelled) return null;
         return api.getText(`/api/files/blob?path=${encodeURIComponent(path)}`);
       })
       .then((content) => {
-        if (!cancelled) setState({ status: "ready", content });
+        if (!cancelled && content !== null) setState({ status: "ready", content });
       })
       .catch((err: unknown) => {
         if (!cancelled) setState({ status: "error", error: previewErrorMessage(err) });
@@ -92,13 +104,17 @@ function ImagePreview({ path, name }: { path: string; name: string }) {
       .then(async (stat) => {
         // Fail closed like text previews: bound the bytes read into renderer memory.
         if (!isFiniteSizeWithin(stat.size, MAX_IMAGE_PREVIEW_BYTES)) throw new Error("file_too_large");
+        // The selected computer may have changed while stat was in flight; the
+        // api client resolves the CURRENT runtime slot per request, so fetching
+        // now would read this path from the newly selected computer. Bail first.
+        if (cancelled) return null;
         // Load bytes through the authenticated client so credentials injected at
         // the network layer apply. A bare <img src> to the blob route cannot
         // carry them and would expose the selected computer's file by URL.
         return api.getBlob(`/api/files/blob?path=${encodeURIComponent(path)}`);
       })
       .then((blob) => {
-        if (cancelled) return;
+        if (cancelled || blob === null) return;
         objectUrl = URL.createObjectURL(blob);
         setState({ status: "ready", url: objectUrl });
       })
@@ -127,28 +143,37 @@ function FilePreview({ path }: { path: string | null }) {
     return <EmptyState icon={<FileCode2 size={26} />} headline="Choose a file" description="Preview images, Markdown, and code from this computer." />;
   }
   const name = path.split("/").pop() ?? path;
-  if (isImage(path)) return <ImagePreview path={path} name={name} />;
-  if (isMarkdown(path)) return <TextPreview path={path} markdown />;
-  return <TextPreview path={path} />;
+  // key={path} remounts the preview when the file changes so its loading state
+  // resets synchronously, instead of showing the previous file until the effect
+  // runs after paint.
+  if (isImage(path)) return <ImagePreview key={path} path={path} name={name} />;
+  if (isMarkdown(path)) return <TextPreview key={path} path={path} markdown />;
+  return <TextPreview key={path} path={path} />;
 }
 
 export default function FilesWorkspace() {
   const handle = useConnection((state) => state.handle);
   const runtimeSlot = useConnection((state) => state.runtimeSlot);
+  const authGeneration = useConnection((state) => state.authGeneration);
   const [selection, setSelection] = useState<FileSelection | null>(null);
 
   // Correctness comes from this synchronous derivation, not the effect below:
-  // a selection made under another computer resolves to null on the first render
-  // with the new slot, so FilePreview never sees a stale path.
-  const activePath = resolveActivePath(selection, runtimeSlot);
+  // a selection made under another computer/session resolves to null on the
+  // first render with the new slot or generation, so FilePreview never sees a
+  // stale path.
+  const activePath = resolveActivePath(selection, runtimeSlot, authGeneration);
 
   useEffect(() => {
-    setSelection((current) => (current && current.slot !== runtimeSlot ? null : current));
-  }, [runtimeSlot]);
+    setSelection((current) =>
+      current && (current.slot !== runtimeSlot || current.authGeneration !== authGeneration)
+        ? null
+        : current,
+    );
+  }, [runtimeSlot, authGeneration]);
 
   const handleOpenFile = useCallback(
-    (path: string) => setSelection({ slot: runtimeSlot, path }),
-    [runtimeSlot],
+    (path: string) => setSelection({ slot: runtimeSlot, authGeneration, path }),
+    [runtimeSlot, authGeneration],
   );
 
   return (

--- a/desktop/src/renderer/src/features/files/FilesWorkspace.tsx
+++ b/desktop/src/renderer/src/features/files/FilesWorkspace.tsx
@@ -1,0 +1,111 @@
+import { FileCode2, FolderOpen, HardDrive } from "lucide-react";
+import { lazy, Suspense, useEffect, useState } from "react";
+import { EmptyState } from "../../design/primitives";
+import { buildGatewayUrl } from "../../lib/api";
+import { toUserMessage } from "../../lib/errors";
+import { useConnection } from "../../stores/connection";
+import ComputerFileBrowser from "./ComputerFileBrowser";
+
+const MarkdownContent = lazy(async () => {
+  const module = await import("../editor/MarkdownPreview");
+  return { default: module.MarkdownContent };
+});
+
+const MAX_TEXT_PREVIEW_BYTES = 1024 * 1024;
+
+function isImage(path: string): boolean {
+  return /\.(png|jpe?g|gif|webp|svg)$/i.test(path);
+}
+
+function isMarkdown(path: string): boolean {
+  return /\.mdx?$/i.test(path);
+}
+
+function TextPreview({ path, markdown = false }: { path: string; markdown?: boolean }) {
+  const api = useConnection((state) => state.api);
+  const [state, setState] = useState<{ status: "loading" | "ready" | "error"; content?: string; error?: string }>({ status: "loading" });
+
+  useEffect(() => {
+    if (!api) return;
+    let cancelled = false;
+    setState({ status: "loading" });
+    void api.get<{ size?: number }>(`/api/files/stat?path=${encodeURIComponent(path)}`)
+      .then(async (stat) => {
+        if ((stat.size ?? 0) > MAX_TEXT_PREVIEW_BYTES) throw new Error("file_too_large");
+        return api.getText(`/api/files/blob?path=${encodeURIComponent(path)}`);
+      })
+      .then((content) => {
+        if (!cancelled) setState({ status: "ready", content });
+      })
+      .catch((err: unknown) => {
+        if (!cancelled) setState({ status: "error", error: err instanceof Error && err.message === "file_too_large" ? "This file is too large to preview." : toUserMessage(err) });
+      });
+    return () => { cancelled = true; };
+  }, [api, path]);
+
+  if (state.status === "loading") return <div className="flex flex-1 items-center justify-center text-sm" style={{ color: "var(--text-tertiary)" }}>Loading preview…</div>;
+  if (state.status === "error") return <div className="flex flex-1 items-center justify-center text-sm" style={{ color: "var(--danger)" }}>{state.error}</div>;
+  if (markdown) return <MarkdownContent content={state.content ?? ""} />;
+  return (
+    <pre className="min-h-0 flex-1 overflow-auto p-5 font-mono text-[13px] leading-6" style={{ color: "var(--text-primary)", background: "var(--bg-sunken)" }} data-selectable>
+      <code>{state.content}</code>
+    </pre>
+  );
+}
+
+function FilePreview({ path }: { path: string | null }) {
+  const api = useConnection((state) => state.api);
+  const runtimeSlot = useConnection((state) => state.runtimeSlot);
+  if (!path || !api) {
+    return <EmptyState icon={<FileCode2 size={26} />} headline="Choose a file" description="Preview images, Markdown, and code from this computer." />;
+  }
+  const name = path.split("/").pop() ?? path;
+  if (isImage(path)) {
+    const src = buildGatewayUrl(api.baseUrl, `/api/files/blob?path=${encodeURIComponent(path)}`, runtimeSlot);
+    return (
+      <div className="flex min-h-0 flex-1 items-center justify-center overflow-auto p-6" style={{ background: "var(--bg-sunken)" }}>
+        <img src={src} alt={name} className="max-h-full max-w-full rounded-lg object-contain" style={{ boxShadow: "var(--shadow-2)" }} />
+      </div>
+    );
+  }
+  if (isMarkdown(path)) return <TextPreview path={path} markdown />;
+  return <TextPreview path={path} />;
+}
+
+export default function FilesWorkspace() {
+  const handle = useConnection((state) => state.handle);
+  const runtimeSlot = useConnection((state) => state.runtimeSlot);
+  const [activePath, setActivePath] = useState<string | null>(null);
+
+  useEffect(() => setActivePath(null), [runtimeSlot]);
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col" style={{ background: "var(--bg-app)" }}>
+      <header className="flex h-14 shrink-0 items-center justify-between border-b px-5" style={{ borderColor: "var(--border-subtle)" }}>
+        <div className="flex items-center gap-3">
+          <span className="flex h-8 w-8 items-center justify-center rounded-lg" style={{ background: "var(--accent-muted)", color: "var(--accent)" }}><FolderOpen size={17} /></span>
+          <div>
+            <h1 className="text-sm font-semibold" style={{ color: "var(--text-primary)" }}>Files</h1>
+            <p className="text-xs" style={{ color: "var(--text-tertiary)" }}>Browse and preview your Matrix computer</p>
+          </div>
+        </div>
+        <div className="flex items-center gap-1.5 text-xs" style={{ color: "var(--text-tertiary)" }}>
+          <HardDrive size={13} />
+          <span>{handle ?? "Matrix computer"}</span>
+          {runtimeSlot !== "primary" ? <span>· {runtimeSlot}</span> : null}
+        </div>
+      </header>
+      <div className="grid min-h-0 flex-1 grid-cols-1 grid-rows-[minmax(220px,40%)_minmax(0,1fr)] gap-3 p-3 md:grid-cols-[minmax(260px,360px)_minmax(0,1fr)] md:grid-rows-1">
+        <ComputerFileBrowser onOpenFile={setActivePath} />
+        <section className="flex min-h-0 min-w-0 flex-col overflow-hidden rounded-lg border" style={{ background: "var(--bg-surface)", borderColor: "var(--border-subtle)" }}>
+          <div className="flex h-10 shrink-0 items-center border-b px-3 text-xs" style={{ borderColor: "var(--border-subtle)", color: "var(--text-secondary)" }}>
+            <span className="truncate" title={activePath ?? undefined}>{activePath ?? "Preview"}</span>
+          </div>
+          <Suspense fallback={<div className="flex flex-1 items-center justify-center text-xs" style={{ color: "var(--text-tertiary)" }}>Loading preview…</div>}>
+            <FilePreview path={activePath} />
+          </Suspense>
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/desktop/src/renderer/src/features/files/FilesWorkspace.tsx
+++ b/desktop/src/renderer/src/features/files/FilesWorkspace.tsx
@@ -70,7 +70,9 @@ function TextPreview({ path, markdown = false }: { path: string; markdown?: bool
         // api client resolves the CURRENT runtime slot per request, so fetching
         // now would read this path from the newly selected computer. Bail first.
         if (cancelled) return null;
-        return api.getText(`/api/files/blob?path=${encodeURIComponent(path)}`);
+        // The stat can be stale by the time the blob is read (the file may
+        // have grown), so the transfer itself is capped too.
+        return api.getText(`/api/files/blob?path=${encodeURIComponent(path)}`, { maxBytes: MAX_TEXT_PREVIEW_BYTES });
       })
       .then((content) => {
         if (!cancelled && content !== null) setState({ status: "ready", content });
@@ -110,8 +112,9 @@ function ImagePreview({ path, name }: { path: string; name: string }) {
         if (cancelled) return null;
         // Load bytes through the authenticated client so credentials injected at
         // the network layer apply. A bare <img src> to the blob route cannot
-        // carry them and would expose the selected computer's file by URL.
-        return api.getBlob(`/api/files/blob?path=${encodeURIComponent(path)}`);
+        // carry them and would expose the selected computer's file by URL. The
+        // transfer is capped as well: the stat may be stale by read time.
+        return api.getBlob(`/api/files/blob?path=${encodeURIComponent(path)}`, { maxBytes: MAX_IMAGE_PREVIEW_BYTES });
       })
       .then((blob) => {
         if (cancelled || blob === null) return;

--- a/desktop/src/renderer/src/features/mission-control/Sidebar.tsx
+++ b/desktop/src/renderer/src/features/mission-control/Sidebar.tsx
@@ -2,6 +2,7 @@ import {
   Bot,
   ChevronRight,
   Home,
+  FolderTree,
   LayoutGrid,
   LogOut,
   PanelLeftClose,
@@ -18,7 +19,7 @@ import { CODING_AGENTS_DESKTOP_WORKSPACE } from "../../lib/feature-flags";
 import { invoke } from "../../lib/operator";
 import { useBoard } from "../../stores/board";
 import { useConnection } from "../../stores/connection";
-import { AGENTS_WORKSPACE_TAB_SPEC, useTabs } from "../../stores/tabs";
+import { AGENTS_WORKSPACE_TAB_SPEC, FILES_WORKSPACE_TAB_SPEC, useTabs } from "../../stores/tabs";
 import { useThreads } from "../../stores/threads";
 import { useUi } from "../../stores/ui";
 import RuntimeComputerMenu from "../runtime/RuntimeComputerMenu";
@@ -151,6 +152,7 @@ export default function Sidebar() {
             <NavRow icon={<Bot size={15} />} label="Agents" collapsed={collapsed} active={activeTab?.kind === "agents"} onClick={() => openTab(AGENTS_WORKSPACE_TAB_SPEC)} />
           ) : null}
           <NavRow icon={<SquareTerminal size={15} />} label="Terminal" collapsed={collapsed} active={activeTab?.kind === "terminals"} onClick={() => openTab({ kind: "terminals", title: "Terminal" })} />
+          <NavRow icon={<FolderTree size={15} />} label="Files" collapsed={collapsed} active={activeTab?.kind === "files"} onClick={() => openTab(FILES_WORKSPACE_TAB_SPEC)} />
           <NavRow icon={<LayoutGrid size={15} />} label="Apps" collapsed={collapsed} active={activeTab?.kind === "apps" || activeTab?.kind === "app"} onClick={() => openTab({ kind: "apps", title: "Apps" })} />
         </nav>
 

--- a/desktop/src/renderer/src/features/mission-control/TabBar.tsx
+++ b/desktop/src/renderer/src/features/mission-control/TabBar.tsx
@@ -1,5 +1,6 @@
 import {
   FileCode2,
+  FolderTree,
   Home,
   Kanban,
   LayoutGrid,
@@ -21,6 +22,7 @@ const TAB_ICON: Record<TabKind, LucideIcon> = {
   terminal: SquareTerminal,
   terminals: SquareTerminal,
   agents: MessageSquare,
+  files: FolderTree,
   thread: MessageSquare,
   apps: LayoutGrid,
   app: LayoutGrid,

--- a/desktop/src/renderer/src/features/mission-control/TabContent.tsx
+++ b/desktop/src/renderer/src/features/mission-control/TabContent.tsx
@@ -15,6 +15,7 @@ import { AppLauncher } from "../embeds";
 import TerminalsTab from "../terminal/TerminalsTab";
 import EmbedHost from "../embeds/EmbedHost";
 import { CODING_AGENTS_DESKTOP_WORKSPACE } from "../../lib/feature-flags";
+import FilesWorkspace from "../files/FilesWorkspace";
 
 export class TabErrorBoundary extends Component<{
   children: ReactNode;
@@ -54,6 +55,8 @@ function TabPane({ tab, active }: { tab: Tab; active: boolean }) {
       return <ChatTab />;
     case "terminals":
       return <TerminalsTab />;
+    case "files":
+      return <FilesWorkspace />;
     case "apps":
       return <AppLauncher />;
     case "app":

--- a/desktop/src/renderer/src/lib/api.ts
+++ b/desktop/src/renderer/src/lib/api.ts
@@ -23,10 +23,17 @@ export interface ApiClientOptions {
   onUnauthorized?: () => void;
 }
 
+export interface BoundedReadOptions {
+  // Hard cap on the bytes read from the response body. The stat that sized a
+  // file can be stale by the time the body is fetched, so the cap must apply
+  // to the transfer itself; exceeding it rejects with "file_too_large".
+  maxBytes?: number;
+}
+
 export interface ApiClient {
   get<T>(path: string): Promise<T>;
-  getText(path: string): Promise<string>;
-  getBlob(path: string): Promise<Blob>;
+  getText(path: string, options?: BoundedReadOptions): Promise<string>;
+  getBlob(path: string, options?: BoundedReadOptions): Promise<Blob>;
   post<T>(path: string, body: unknown): Promise<T>;
   patch<T>(path: string, body: unknown): Promise<T>;
   put<T>(path: string, body: unknown): Promise<T>;
@@ -75,20 +82,60 @@ export function createApiClient(options: ApiClientOptions): ApiClient {
     }
   }
 
-  async function requestText(path: string, init: RequestInit): Promise<string> {
+  async function readBoundedBytes(response: Response, maxBytes: number): Promise<Uint8Array[]> {
+    const reader = response.body?.getReader();
+    if (!reader) {
+      // Test doubles and legacy responses may not expose a stream; the cap
+      // still applies to the buffered body.
+      const buffered = new Uint8Array(await response.arrayBuffer());
+      if (buffered.byteLength > maxBytes) throw new Error("file_too_large");
+      return [buffered];
+    }
+    const chunks: Uint8Array[] = [];
+    let total = 0;
+    try {
+      while (true) {
+        const chunk = await reader.read();
+        if (chunk.done) break;
+        total += chunk.value.byteLength;
+        if (total > maxBytes) {
+          await reader.cancel();
+          throw new Error("file_too_large");
+        }
+        chunks.push(chunk.value);
+      }
+    } finally {
+      reader.releaseLock();
+    }
+    return chunks;
+  }
+
+  async function requestText(path: string, init: RequestInit, bounds?: BoundedReadOptions): Promise<string> {
     const response = await send(path, init);
     try {
+      if (bounds?.maxBytes !== undefined) {
+        const chunks = await readBoundedBytes(response, bounds.maxBytes);
+        const decoder = new TextDecoder();
+        return chunks.map((chunk) => decoder.decode(chunk, { stream: true })).join("") + decoder.decode();
+      }
       return await response.text();
     } catch (err: unknown) {
+      if (err instanceof Error && err.message === "file_too_large") throw err;
       throw new AppError("server", { cause: err });
     }
   }
 
-  async function requestBlob(path: string, init: RequestInit): Promise<Blob> {
+  async function requestBlob(path: string, init: RequestInit, bounds?: BoundedReadOptions): Promise<Blob> {
     const response = await send(path, init);
     try {
+      if (bounds?.maxBytes !== undefined) {
+        const chunks = await readBoundedBytes(response, bounds.maxBytes);
+        const type = response.headers.get("content-type") ?? "";
+        return new Blob(chunks as BlobPart[], type ? { type } : undefined);
+      }
       return await response.blob();
     } catch (err: unknown) {
+      if (err instanceof Error && err.message === "file_too_large") throw err;
       throw new AppError("server", { cause: err });
     }
   }
@@ -96,8 +143,8 @@ export function createApiClient(options: ApiClientOptions): ApiClient {
   return {
     baseUrl: options.baseUrl,
     get: (path) => request(path, { method: "GET" }),
-    getText: (path) => requestText(path, { method: "GET" }),
-    getBlob: (path) => requestBlob(path, { method: "GET" }),
+    getText: (path, boundedOptions) => requestText(path, { method: "GET" }, boundedOptions),
+    getBlob: (path, boundedOptions) => requestBlob(path, { method: "GET" }, boundedOptions),
     post: (path, body) =>
       request(path, {
         method: "POST",

--- a/desktop/src/renderer/src/lib/api.ts
+++ b/desktop/src/renderer/src/lib/api.ts
@@ -26,6 +26,7 @@ export interface ApiClientOptions {
 export interface ApiClient {
   get<T>(path: string): Promise<T>;
   getText(path: string): Promise<string>;
+  getBlob(path: string): Promise<Blob>;
   post<T>(path: string, body: unknown): Promise<T>;
   patch<T>(path: string, body: unknown): Promise<T>;
   put<T>(path: string, body: unknown): Promise<T>;
@@ -83,10 +84,20 @@ export function createApiClient(options: ApiClientOptions): ApiClient {
     }
   }
 
+  async function requestBlob(path: string, init: RequestInit): Promise<Blob> {
+    const response = await send(path, init);
+    try {
+      return await response.blob();
+    } catch (err: unknown) {
+      throw new AppError("server", { cause: err });
+    }
+  }
+
   return {
     baseUrl: options.baseUrl,
     get: (path) => request(path, { method: "GET" }),
     getText: (path) => requestText(path, { method: "GET" }),
+    getBlob: (path) => requestBlob(path, { method: "GET" }),
     post: (path, body) =>
       request(path, {
         method: "POST",

--- a/desktop/src/renderer/src/stores/tabs.ts
+++ b/desktop/src/renderer/src/stores/tabs.ts
@@ -12,6 +12,7 @@ export type TabKind =
   | "terminal"
   | "terminals"
   | "agents"
+  | "files"
   | "thread"
   | "apps"
   | "app"
@@ -35,6 +36,13 @@ export const AGENTS_WORKSPACE_TAB_SPEC = {
   kind: "agents" as const,
   title: "Agents",
   slug: "agents",
+};
+
+export const FILES_WORKSPACE_TAB_SPEC = {
+  kind: "files" as const,
+  title: "Files",
+  slug: "files",
+  closable: false,
 };
 
 const MAX_TABS = 24;

--- a/specs/105-coding-agent-shells/acceptance-tests.md
+++ b/specs/105-coding-agent-shells/acceptance-tests.md
@@ -273,6 +273,20 @@ preserve the existing trusted file/review/source-control/terminal/preview paths.
 External review actions reveal Changes, while hidden panes retain bounded
 unsaved editor state.
 
+Current Matrix computer Files evidence:
+
+- `bunx vitest run tests/desktop/create-project-dialog.test.tsx tests/desktop/files-workspace.test.tsx tests/desktop/files-panel.test.tsx tests/desktop/markdown-preview.test.ts`
+- `bunx vitest run tests/desktop` (99 files, 930 tests)
+- `pnpm --filter desktop typecheck`
+- `bun run typecheck`
+- `bun run check:patterns:diff` (zero violations; existing stack warnings only)
+- `bun run build:desktop`
+
+These checks prove the selected computer remains the source of folder listings,
+the project chooser submits a selected relative folder path, Files opens as a
+stable desktop destination, bounded text/code and Markdown previews use the
+gateway file routes, and image URLs contain runtime routing but no credentials.
+
 Gateway/contract PRs additionally run the exact focused Vitest files named in their PR body. Desktop UI PRs run the operator E2E and screenshot checks. Mobile UI PRs run the SDK 57 dev-client device smoke before their rollout gate. `vp` commands may be reported unavailable, but they are not silently substituted for repository commands.
 
 ## Confirmation Boundary

--- a/specs/105-coding-agent-shells/tasks.md
+++ b/specs/105-coding-agent-shells/tasks.md
@@ -1262,6 +1262,18 @@ integrated workspace suite proves existing trusted IPC actions continue through
 their original gateway-owned contracts. Surface validation is recorded in
 `acceptance-tests.md`.
 
+### 21.6 Matrix Computer Files
+
+- [x] Add a first-class Files destination to the desktop navigator.
+- [x] Browse the selected computer's Matrix home with gateway-owned directory listings and breadcrumbs.
+- [x] Preview bounded text/code, rendered Markdown, and images without exposing credentials.
+- [x] Reuse the same browser as the existing-folder chooser when creating a project.
+- [x] Clear the active file and reload folder state when the selected computer changes.
+
+Tests: `tests/desktop/files-workspace.test.tsx`,
+`tests/desktop/create-project-dialog.test.tsx`, and the existing file-panel and
+Markdown-preview regressions.
+
 ## Phase 22 - Mobile Project Conversation And Kanban
 
 Goal: expose the same hierarchy and conversations with SDK 57 phone/tablet ergonomics.

--- a/tests/desktop/api-client.test.ts
+++ b/tests/desktop/api-client.test.ts
@@ -126,4 +126,33 @@ describe("createApiClient", () => {
     });
     await expect(client.get("/api/apps")).rejects.toMatchObject({ category: "server" });
   });
+
+  it("fetches binary blobs through the authenticated client with a timeout signal", async () => {
+    const fetchFn = vi
+      .fn()
+      .mockResolvedValue(new Response(new Uint8Array([1, 2, 3]), { status: 200, headers: { "content-type": "image/png" } }));
+    const client = createApiClient({
+      baseUrl: "https://app.matrix-os.com",
+      getRuntimeSlot: () => "vm-2",
+      fetchFn,
+    });
+    const blob = await client.getBlob("/api/files/blob?path=hero.png");
+    expect(blob).toBeInstanceOf(Blob);
+    expect(blob.size).toBe(3);
+    const [url, init] = fetchFn.mock.calls[0]!;
+    expect(url).toBe("https://app.matrix-os.com/api/files/blob?path=hero.png&runtime=vm-2");
+    expect((init as RequestInit).signal).toBeInstanceOf(AbortSignal);
+  });
+
+  it("maps blob 401s to unauthorized without leaking bytes", async () => {
+    const fetchFn = vi.fn().mockResolvedValue(jsonResponse(401, {}));
+    const client = createApiClient({
+      baseUrl: "https://x.test",
+      getRuntimeSlot: () => "primary",
+      fetchFn,
+    });
+    await expect(client.getBlob("/api/files/blob?path=hero.png")).rejects.toMatchObject({
+      category: "unauthorized",
+    });
+  });
 });

--- a/tests/desktop/api-client.test.ts
+++ b/tests/desktop/api-client.test.ts
@@ -155,4 +155,35 @@ describe("createApiClient", () => {
       category: "unauthorized",
     });
   });
+
+  it("fails closed when a bounded blob response exceeds the byte cap", async () => {
+    // The stat that sized the file can be stale by the time the blob is read;
+    // the cap must apply to the bytes actually fetched.
+    const fetchFn = vi.fn().mockResolvedValue(new Response(new Uint8Array(64), { status: 200 }));
+    const client = createApiClient({
+      baseUrl: "https://x.test",
+      getRuntimeSlot: () => "primary",
+      fetchFn,
+    });
+    await expect(
+      client.getBlob("/api/files/blob?path=hero.png", { maxBytes: 16 }),
+    ).rejects.toMatchObject({ message: "file_too_large" });
+  });
+
+  it("returns bounded text within the byte cap and rejects beyond it", async () => {
+    const fetchFn = vi.fn()
+      .mockResolvedValueOnce(new Response("small body", { status: 200 }))
+      .mockResolvedValueOnce(new Response("x".repeat(64), { status: 200 }));
+    const client = createApiClient({
+      baseUrl: "https://x.test",
+      getRuntimeSlot: () => "primary",
+      fetchFn,
+    });
+    await expect(
+      client.getText("/api/files/blob?path=notes.md", { maxBytes: 1024 }),
+    ).resolves.toBe("small body");
+    await expect(
+      client.getText("/api/files/blob?path=notes.md", { maxBytes: 16 }),
+    ).rejects.toMatchObject({ message: "file_too_large" });
+  });
 });

--- a/tests/desktop/create-project-dialog.test.tsx
+++ b/tests/desktop/create-project-dialog.test.tsx
@@ -136,6 +136,46 @@ describe("CreateProjectDialog", () => {
     expect(openTab).not.toHaveBeenCalled();
   });
 
+  it("clears the chosen folder when the signed-in session is replaced", async () => {
+    const createProject = vi.fn(async () => ({
+      slug: "customer-app",
+      name: "Customer app",
+      localPath: "/home/matrix/home/workspaces/customer-app",
+      githubBacked: false,
+    }));
+    const get = vi.fn(async (requestPath: string) => {
+      if (requestPath === "/api/files/list?path=") {
+        return { entries: [{ name: "workspaces", type: "directory" }] };
+      }
+      if (requestPath === "/api/files/list?path=workspaces") {
+        return { entries: [{ name: "customer-app", type: "directory" }] };
+      }
+      return { entries: [] };
+    });
+    useConnection.setState({ api: { post: vi.fn(), get } as never, authGeneration: 1 });
+    useBoard.setState({ createProject, selectProject: vi.fn(async () => undefined) });
+    render(<Tooltip.Provider><CreateProjectDialog open onClose={vi.fn()} /></Tooltip.Provider>);
+
+    fireEvent.change(screen.getByPlaceholderText("Project name"), { target: { value: "Customer app" } });
+    fireEvent.click(screen.getByRole("button", { name: "Use existing folder" }));
+    await waitFor(() => expect(screen.getByRole("button", { name: "Open workspaces" })).not.toBeNull());
+    fireEvent.doubleClick(screen.getByRole("button", { name: "Open workspaces" }));
+    await waitFor(() => expect(screen.getByRole("button", { name: "Open customer-app" })).not.toBeNull());
+    fireEvent.click(screen.getByRole("button", { name: "Open customer-app" }));
+    fireEvent.click(screen.getByRole("button", { name: "Choose customer-app" }));
+    expect(screen.getByText(/^Selected:/)).toBeTruthy();
+
+    // A replacement signed-in session (same slot, new credential) must drop the
+    // folder picked under the previous owner.
+    act(() => {
+      useConnection.setState({ authGeneration: 2 });
+    });
+
+    expect(screen.queryByText(/^Selected:/)).toBeNull();
+    fireEvent.click(screen.getByRole("button", { name: "Create" }));
+    expect(createProject).not.toHaveBeenCalled();
+  });
+
   it("keeps the dialog open with an error when the Agents workspace refresh fails after create", async () => {
     const project = { slug: "desktop", name: "Desktop" };
     const createProject = vi.fn(async () => project);

--- a/tests/desktop/create-project-dialog.test.tsx
+++ b/tests/desktop/create-project-dialog.test.tsx
@@ -1,6 +1,7 @@
 // @vitest-environment jsdom
 
 import React, { useState } from "react";
+import * as Tooltip from "@radix-ui/react-tooltip";
 import { act, cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import CreateProjectDialog from "../../desktop/src/renderer/src/features/board/CreateProjectDialog";
@@ -86,14 +87,26 @@ describe("CreateProjectDialog", () => {
       localPath: "/home/matrix/home/workspaces/customer-app",
       githubBacked: false,
     }));
+    const get = vi.fn(async (requestPath: string) => {
+      if (requestPath === "/api/files/list?path=") {
+        return { entries: [{ name: "workspaces", type: "directory" }] };
+      }
+      if (requestPath === "/api/files/list?path=workspaces") {
+        return { entries: [{ name: "customer-app", type: "directory" }] };
+      }
+      return { entries: [] };
+    });
+    useConnection.setState({ api: { post: vi.fn(), get } as never });
     useBoard.setState({ createProject, selectProject: vi.fn(async () => undefined) });
-    render(<CreateProjectDialog open onClose={vi.fn()} />);
+    render(<Tooltip.Provider><CreateProjectDialog open onClose={vi.fn()} /></Tooltip.Provider>);
 
     fireEvent.change(screen.getByPlaceholderText("Project name"), { target: { value: "Customer app" } });
     fireEvent.click(screen.getByRole("button", { name: "Use existing folder" }));
-    fireEvent.change(screen.getByPlaceholderText("workspaces/customer-app"), {
-      target: { value: "workspaces/customer-app" },
-    });
+    await waitFor(() => expect(screen.getByRole("button", { name: "Open workspaces" })).not.toBeNull());
+    fireEvent.doubleClick(screen.getByRole("button", { name: "Open workspaces" }));
+    await waitFor(() => expect(screen.getByRole("button", { name: "Open customer-app" })).not.toBeNull());
+    fireEvent.click(screen.getByRole("button", { name: "Open customer-app" }));
+    fireEvent.click(screen.getByRole("button", { name: "Choose customer-app" }));
     fireEvent.click(screen.getByRole("button", { name: "Create" }));
 
     await waitFor(() => expect(createProject).toHaveBeenCalledWith(expect.anything(), {

--- a/tests/desktop/files-workspace.test.tsx
+++ b/tests/desktop/files-workspace.test.tsx
@@ -22,21 +22,38 @@ const LIST: Record<string, { entries: Array<{ name: string; type: string }> }> =
     entries: [
       { name: "hero.png", type: "file" },
       { name: "app.ts", type: "file" },
+      { name: "util.ts", type: "file" },
     ],
   },
 };
 
-function makeApi(overrides?: { statFor?: (path: string) => { size?: number } }) {
+interface ApiOverrides {
+  statFor?: (path: string) => { size?: number };
+  statImpl?: (path: string) => Promise<{ size?: number }>;
+  textFor?: (path: string) => string;
+}
+
+function makeApi(overrides?: ApiOverrides) {
   const get = vi.fn(async (path: string) => {
     if (path.startsWith("/api/files/list?path=")) return LIST[path] ?? { entries: [] };
     if (path.startsWith("/api/files/stat?path=")) {
+      if (overrides?.statImpl) return overrides.statImpl(path);
       return overrides?.statFor ? overrides.statFor(path) : { size: 128 };
     }
     return { entries: [] };
   });
-  const getText = vi.fn(async () => "# Matrix files\n\nA remote home you can inspect.");
+  const getText = vi.fn(async (path: string) =>
+    overrides?.textFor ? overrides.textFor(path) : "# Matrix files\n\nA remote home you can inspect.",
+  );
   const getBlob = vi.fn(async () => new Blob([new Uint8Array([1, 2, 3, 4])], { type: "image/png" }));
   return { get, getText, getBlob, baseUrl: "https://app.matrix-os.com" };
+}
+
+async function flushMicrotasks(): Promise<void> {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  });
 }
 
 describe("Files workspace", () => {
@@ -59,6 +76,7 @@ describe("Files workspace", () => {
       handle: "operator",
       platformHost: "https://app.matrix-os.com",
       runtimeSlot: "pr-919",
+      authGeneration: 3,
       api: api as never,
     });
     useTabs.setState({ tabs: [], activeTabId: null });
@@ -155,20 +173,127 @@ describe("Files workspace", () => {
     );
     expect(staleStat).toBeUndefined();
   });
+
+  it("does not fetch a text blob against the new computer when the slot changes mid-stat", async () => {
+    let resolveStat!: (value: { size: number }) => void;
+    const statPromise = new Promise<{ size: number }>((resolve) => {
+      resolveStat = resolve;
+    });
+    const custom = makeApi({ statImpl: () => statPromise });
+    useConnection.setState({ api: custom as never });
+    render(<Tooltip.Provider><FilesWorkspace /></Tooltip.Provider>);
+    fireEvent.doubleClick(await screen.findByRole("button", { name: "Open workspaces" }));
+    fireEvent.click(await screen.findByRole("button", { name: "Open app.ts" }));
+
+    // Switch the selected computer while the stat request is still pending.
+    act(() => {
+      useConnection.setState({ runtimeSlot: "pr-920" });
+    });
+    await act(async () => {
+      resolveStat({ size: 128 });
+      await Promise.resolve();
+    });
+
+    expect(custom.getText).not.toHaveBeenCalled();
+  });
+
+  it("does not fetch an image blob against the new computer when the slot changes mid-stat", async () => {
+    let resolveStat!: (value: { size: number }) => void;
+    const statPromise = new Promise<{ size: number }>((resolve) => {
+      resolveStat = resolve;
+    });
+    const custom = makeApi({ statImpl: () => statPromise });
+    useConnection.setState({ api: custom as never });
+    render(<Tooltip.Provider><FilesWorkspace /></Tooltip.Provider>);
+    fireEvent.doubleClick(await screen.findByRole("button", { name: "Open workspaces" }));
+    fireEvent.click(await screen.findByRole("button", { name: "Open hero.png" }));
+
+    act(() => {
+      useConnection.setState({ runtimeSlot: "pr-920" });
+    });
+    await act(async () => {
+      resolveStat({ size: 128 });
+      await Promise.resolve();
+    });
+
+    expect(custom.getBlob).not.toHaveBeenCalled();
+  });
+
+  it("clears the preview when the session identity changes on the same computer", async () => {
+    render(<Tooltip.Provider><FilesWorkspace /></Tooltip.Provider>);
+    fireEvent.doubleClick(await screen.findByRole("button", { name: "Open workspaces" }));
+    fireEvent.click(await screen.findByRole("button", { name: "Open app.ts" }));
+    expect(await screen.findByText(/A remote home you can inspect/)).not.toBeNull();
+
+    api.getText.mockClear();
+    api.get.mockClear();
+    // Same runtime slot, but a replacement signed-in session (new credential).
+    act(() => {
+      useConnection.setState({ authGeneration: 4 });
+    });
+
+    expect(await screen.findByText("Choose a file")).not.toBeNull();
+    expect(api.getText).not.toHaveBeenCalled();
+    const staleStat = api.get.mock.calls.find(
+      ([p]) => String(p).includes("/api/files/stat") && String(p).includes("app.ts"),
+    );
+    expect(staleStat).toBeUndefined();
+  });
+
+  it("shows loading for a newly selected file rather than the previous file's content", async () => {
+    let resolveSecondStat!: (value: { size: number }) => void;
+    const secondStat = new Promise<{ size: number }>((resolve) => {
+      resolveSecondStat = resolve;
+    });
+    const custom = makeApi({
+      textFor: (path) => `content of ${path}`,
+      statImpl: (path) => (path.includes("util.ts") ? secondStat : Promise.resolve({ size: 128 })),
+    });
+    useConnection.setState({ api: custom as never });
+    render(<Tooltip.Provider><FilesWorkspace /></Tooltip.Provider>);
+    fireEvent.doubleClick(await screen.findByRole("button", { name: "Open workspaces" }));
+    fireEvent.click(await screen.findByRole("button", { name: "Open app.ts" }));
+    expect(
+      await screen.findByText("content of /api/files/blob?path=workspaces%2Fapp.ts"),
+    ).not.toBeNull();
+
+    // Switch to another text file whose stat has not resolved yet.
+    fireEvent.click(screen.getByRole("button", { name: "Open util.ts" }));
+    expect(
+      screen.queryByText("content of /api/files/blob?path=workspaces%2Fapp.ts"),
+    ).toBeNull();
+    expect(screen.getByText("Loading preview…")).not.toBeNull();
+
+    await act(async () => {
+      resolveSecondStat({ size: 128 });
+      await Promise.resolve();
+    });
+    expect(
+      await screen.findByText("content of /api/files/blob?path=workspaces%2Futil.ts"),
+    ).not.toBeNull();
+  });
 });
 
 describe("resolveActivePath", () => {
-  it("returns the stored path only when the runtime slot matches", () => {
-    expect(resolveActivePath({ slot: "pr-919", path: "workspaces/app.ts" }, "pr-919")).toBe(
-      "workspaces/app.ts",
-    );
+  it("returns the stored path when slot and auth generation match", () => {
+    expect(
+      resolveActivePath({ slot: "pr-919", authGeneration: 3, path: "workspaces/app.ts" }, "pr-919", 3),
+    ).toBe("workspaces/app.ts");
   });
 
-  it("returns null when the stored slot differs from the current slot", () => {
-    expect(resolveActivePath({ slot: "pr-919", path: "workspaces/app.ts" }, "pr-920")).toBeNull();
+  it("returns null when the stored slot differs", () => {
+    expect(
+      resolveActivePath({ slot: "pr-919", authGeneration: 3, path: "workspaces/app.ts" }, "pr-920", 3),
+    ).toBeNull();
+  });
+
+  it("returns null when the auth generation differs", () => {
+    expect(
+      resolveActivePath({ slot: "pr-919", authGeneration: 3, path: "workspaces/app.ts" }, "pr-919", 4),
+    ).toBeNull();
   });
 
   it("returns null when nothing is selected", () => {
-    expect(resolveActivePath(null, "pr-919")).toBeNull();
+    expect(resolveActivePath(null, "pr-919", 3)).toBeNull();
   });
 });

--- a/tests/desktop/files-workspace.test.tsx
+++ b/tests/desktop/files-workspace.test.tsx
@@ -272,6 +272,20 @@ describe("Files workspace", () => {
       await screen.findByText("content of /api/files/blob?path=workspaces%2Futil.ts"),
     ).not.toBeNull();
   });
+
+  it("hides browser entries loaded under a previous session scope", async () => {
+    render(<Tooltip.Provider><FilesWorkspace /></Tooltip.Provider>);
+    await waitFor(() => expect(screen.getByRole("button", { name: "Open workspaces" })).toBeTruthy());
+
+    // A replacement session can keep the same runtime slot; the previous
+    // owner's directory listing must not stay visible or clickable.
+    act(() => {
+      useConnection.setState({ authGeneration: 4 });
+    });
+
+    expect(screen.queryByRole("button", { name: "Open workspaces" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Open README.md" })).toBeNull();
+  });
 });
 
 describe("resolveActivePath", () => {

--- a/tests/desktop/files-workspace.test.tsx
+++ b/tests/desktop/files-workspace.test.tsx
@@ -174,6 +174,30 @@ describe("Files workspace", () => {
     expect(staleStat).toBeUndefined();
   });
 
+  it("pins the session scope at fetch time even before React commits the switch", async () => {
+    let resolveStat!: (value: { size: number }) => void;
+    const statPromise = new Promise<{ size: number }>((resolve) => {
+      resolveStat = resolve;
+    });
+    const custom = makeApi({ statImpl: () => statPromise });
+    useConnection.setState({ api: custom as never });
+    render(<Tooltip.Provider><FilesWorkspace /></Tooltip.Provider>);
+    fireEvent.doubleClick(await screen.findByRole("button", { name: "Open workspaces" }));
+    fireEvent.click(await screen.findByRole("button", { name: "Open app.ts" }));
+
+    // The store commits the replacement session before React re-renders and
+    // runs the effect cleanup; the stat can settle inside that gap, so the
+    // cancelled flag alone cannot stop the follow-up blob fetch.
+    useConnection.setState({ authGeneration: 4 });
+    resolveStat({ size: 128 });
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(custom.getText).not.toHaveBeenCalled();
+  });
+
   it("does not fetch a text blob against the new computer when the slot changes mid-stat", async () => {
     let resolveStat!: (value: { size: number }) => void;
     const statPromise = new Promise<{ size: number }>((resolve) => {

--- a/tests/desktop/files-workspace.test.tsx
+++ b/tests/desktop/files-workspace.test.tsx
@@ -1,0 +1,80 @@
+// @vitest-environment jsdom
+
+import React from "react";
+import * as Tooltip from "@radix-ui/react-tooltip";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import FilesWorkspace from "../../desktop/src/renderer/src/features/files/FilesWorkspace";
+import Sidebar from "../../desktop/src/renderer/src/features/mission-control/Sidebar";
+import { useConnection } from "../../desktop/src/renderer/src/stores/connection";
+import { useTabs } from "../../desktop/src/renderer/src/stores/tabs";
+
+describe("Files workspace", () => {
+  const get = vi.fn(async (path: string) => {
+    if (path === "/api/files/list?path=") {
+      return { entries: [{ name: "workspaces", type: "directory" }, { name: "README.md", type: "file" }] };
+    }
+    if (path === "/api/files/list?path=workspaces") {
+      return { entries: [{ name: "hero.png", type: "file" }, { name: "app.ts", type: "file" }] };
+    }
+    if (path.startsWith("/api/files/stat?path=")) return { size: 128 };
+    return { entries: [] };
+  });
+  const getText = vi.fn(async () => "# Matrix files\n\nA remote home you can inspect.");
+
+  beforeEach(() => {
+    get.mockClear();
+    getText.mockClear();
+    useConnection.setState({
+      status: "signed-in",
+      handle: "operator",
+      platformHost: "https://app.matrix-os.com",
+      runtimeSlot: "pr-919",
+      api: { get, getText, baseUrl: "https://app.matrix-os.com" } as never,
+    });
+    useTabs.setState({ tabs: [], activeTabId: null });
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it("opens from the main navigation as a stable Files tab", () => {
+    render(<Tooltip.Provider><Sidebar /></Tooltip.Provider>);
+    fireEvent.click(screen.getByRole("button", { name: "Files" }));
+    expect(useTabs.getState().tabs).toEqual([
+      expect.objectContaining({ kind: "files", title: "Files", closable: false }),
+    ]);
+  });
+
+  it("browses folders with breadcrumbs and previews markdown", async () => {
+    render(<Tooltip.Provider><FilesWorkspace /></Tooltip.Provider>);
+    fireEvent.click(await screen.findByRole("button", { name: "Open README.md" }));
+    expect(await screen.findByRole("heading", { name: "Matrix files" })).not.toBeNull();
+
+    fireEvent.doubleClick(screen.getByRole("button", { name: "Open workspaces" }));
+    await waitFor(() => expect(get).toHaveBeenCalledWith("/api/files/list?path=workspaces"));
+    expect(screen.getByRole("button", { name: "Matrix home" })).not.toBeNull();
+    expect(screen.getByRole("button", { name: "workspaces" })).not.toBeNull();
+  });
+
+  it("previews images from the selected computer without exposing credentials", async () => {
+    render(<Tooltip.Provider><FilesWorkspace /></Tooltip.Provider>);
+    fireEvent.doubleClick(await screen.findByRole("button", { name: "Open workspaces" }));
+    fireEvent.click(await screen.findByRole("button", { name: "Open hero.png" }));
+    const image = await screen.findByRole("img", { name: "hero.png" });
+    expect(image.getAttribute("src")).toBe(
+      "https://app.matrix-os.com/api/files/blob?path=workspaces%2Fhero.png&runtime=pr-919",
+    );
+    expect(image.getAttribute("src")).not.toMatch(/token|bearer/i);
+  });
+
+  it("previews bounded code as selectable text", async () => {
+    render(<Tooltip.Provider><FilesWorkspace /></Tooltip.Provider>);
+    fireEvent.doubleClick(await screen.findByRole("button", { name: "Open workspaces" }));
+    fireEvent.click(await screen.findByRole("button", { name: "Open app.ts" }));
+    await waitFor(() => expect(getText).toHaveBeenCalledWith("/api/files/blob?path=workspaces%2Fapp.ts"));
+    expect(screen.getByText(/A remote home you can inspect/).closest("pre")).not.toBeNull();
+  });
+});

--- a/tests/desktop/files-workspace.test.tsx
+++ b/tests/desktop/files-workspace.test.tsx
@@ -112,7 +112,7 @@ describe("Files workspace", () => {
     render(<Tooltip.Provider><FilesWorkspace /></Tooltip.Provider>);
     fireEvent.doubleClick(await screen.findByRole("button", { name: "Open workspaces" }));
     fireEvent.click(await screen.findByRole("button", { name: "Open app.ts" }));
-    await waitFor(() => expect(api.getText).toHaveBeenCalledWith("/api/files/blob?path=workspaces%2Fapp.ts"));
+    await waitFor(() => expect(api.getText).toHaveBeenCalledWith("/api/files/blob?path=workspaces%2Fapp.ts", { maxBytes: 1024 * 1024 }));
     expect(screen.getByText(/A remote home you can inspect/).closest("pre")).not.toBeNull();
   });
 
@@ -132,7 +132,7 @@ describe("Files workspace", () => {
     fireEvent.click(await screen.findByRole("button", { name: "Open hero.png" }));
     const image = await screen.findByRole("img", { name: "hero.png" });
     await waitFor(() =>
-      expect(api.getBlob).toHaveBeenCalledWith("/api/files/blob?path=workspaces%2Fhero.png"),
+      expect(api.getBlob).toHaveBeenCalledWith("/api/files/blob?path=workspaces%2Fhero.png", { maxBytes: 10 * 1024 * 1024 }),
     );
     const src = image.getAttribute("src") ?? "";
     expect(src).toMatch(/^blob:mock\//);

--- a/tests/desktop/files-workspace.test.tsx
+++ b/tests/desktop/files-workspace.test.tsx
@@ -297,6 +297,17 @@ describe("Files workspace", () => {
     ).not.toBeNull();
   });
 
+  it("enters directories with the keyboard", async () => {
+    render(<Tooltip.Provider><FilesWorkspace /></Tooltip.Provider>);
+    const workspaces = await screen.findByRole("button", { name: "Open workspaces" });
+
+    // Keyboard and screen-reader users cannot double-click; Enter on a
+    // directory row must navigate into it.
+    fireEvent.keyDown(workspaces, { key: "Enter" });
+
+    expect(await screen.findByRole("button", { name: "Open app.ts" })).not.toBeNull();
+  });
+
   it("hides browser entries loaded under a previous session scope", async () => {
     render(<Tooltip.Provider><FilesWorkspace /></Tooltip.Provider>);
     await waitFor(() => expect(screen.getByRole("button", { name: "Open workspaces" })).toBeTruthy());

--- a/tests/desktop/files-workspace.test.tsx
+++ b/tests/desktop/files-workspace.test.tsx
@@ -2,35 +2,64 @@
 
 import React from "react";
 import * as Tooltip from "@radix-ui/react-tooltip";
-import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { act, cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import FilesWorkspace from "../../desktop/src/renderer/src/features/files/FilesWorkspace";
+import FilesWorkspace, {
+  resolveActivePath,
+} from "../../desktop/src/renderer/src/features/files/FilesWorkspace";
 import Sidebar from "../../desktop/src/renderer/src/features/mission-control/Sidebar";
 import { useConnection } from "../../desktop/src/renderer/src/stores/connection";
 import { useTabs } from "../../desktop/src/renderer/src/stores/tabs";
 
-describe("Files workspace", () => {
+const LIST: Record<string, { entries: Array<{ name: string; type: string }> }> = {
+  "/api/files/list?path=": {
+    entries: [
+      { name: "workspaces", type: "directory" },
+      { name: "README.md", type: "file" },
+    ],
+  },
+  "/api/files/list?path=workspaces": {
+    entries: [
+      { name: "hero.png", type: "file" },
+      { name: "app.ts", type: "file" },
+    ],
+  },
+};
+
+function makeApi(overrides?: { statFor?: (path: string) => { size?: number } }) {
   const get = vi.fn(async (path: string) => {
-    if (path === "/api/files/list?path=") {
-      return { entries: [{ name: "workspaces", type: "directory" }, { name: "README.md", type: "file" }] };
+    if (path.startsWith("/api/files/list?path=")) return LIST[path] ?? { entries: [] };
+    if (path.startsWith("/api/files/stat?path=")) {
+      return overrides?.statFor ? overrides.statFor(path) : { size: 128 };
     }
-    if (path === "/api/files/list?path=workspaces") {
-      return { entries: [{ name: "hero.png", type: "file" }, { name: "app.ts", type: "file" }] };
-    }
-    if (path.startsWith("/api/files/stat?path=")) return { size: 128 };
     return { entries: [] };
   });
   const getText = vi.fn(async () => "# Matrix files\n\nA remote home you can inspect.");
+  const getBlob = vi.fn(async () => new Blob([new Uint8Array([1, 2, 3, 4])], { type: "image/png" }));
+  return { get, getText, getBlob, baseUrl: "https://app.matrix-os.com" };
+}
+
+describe("Files workspace", () => {
+  const originalCreate = URL.createObjectURL;
+  const originalRevoke = URL.revokeObjectURL;
+  let objectUrlCounter = 0;
+  const createObjectURL = vi.fn(() => `blob:mock/${objectUrlCounter++}`);
+  const revokeObjectURL = vi.fn();
+  let api: ReturnType<typeof makeApi>;
 
   beforeEach(() => {
-    get.mockClear();
-    getText.mockClear();
+    objectUrlCounter = 0;
+    createObjectURL.mockClear();
+    revokeObjectURL.mockClear();
+    URL.createObjectURL = createObjectURL as typeof URL.createObjectURL;
+    URL.revokeObjectURL = revokeObjectURL as typeof URL.revokeObjectURL;
+    api = makeApi();
     useConnection.setState({
       status: "signed-in",
       handle: "operator",
       platformHost: "https://app.matrix-os.com",
       runtimeSlot: "pr-919",
-      api: { get, getText, baseUrl: "https://app.matrix-os.com" } as never,
+      api: api as never,
     });
     useTabs.setState({ tabs: [], activeTabId: null });
   });
@@ -38,6 +67,8 @@ describe("Files workspace", () => {
   afterEach(() => {
     cleanup();
     vi.restoreAllMocks();
+    URL.createObjectURL = originalCreate;
+    URL.revokeObjectURL = originalRevoke;
   });
 
   it("opens from the main navigation as a stable Files tab", () => {
@@ -54,27 +85,90 @@ describe("Files workspace", () => {
     expect(await screen.findByRole("heading", { name: "Matrix files" })).not.toBeNull();
 
     fireEvent.doubleClick(screen.getByRole("button", { name: "Open workspaces" }));
-    await waitFor(() => expect(get).toHaveBeenCalledWith("/api/files/list?path=workspaces"));
+    await waitFor(() => expect(api.get).toHaveBeenCalledWith("/api/files/list?path=workspaces"));
     expect(screen.getByRole("button", { name: "Matrix home" })).not.toBeNull();
     expect(screen.getByRole("button", { name: "workspaces" })).not.toBeNull();
-  });
-
-  it("previews images from the selected computer without exposing credentials", async () => {
-    render(<Tooltip.Provider><FilesWorkspace /></Tooltip.Provider>);
-    fireEvent.doubleClick(await screen.findByRole("button", { name: "Open workspaces" }));
-    fireEvent.click(await screen.findByRole("button", { name: "Open hero.png" }));
-    const image = await screen.findByRole("img", { name: "hero.png" });
-    expect(image.getAttribute("src")).toBe(
-      "https://app.matrix-os.com/api/files/blob?path=workspaces%2Fhero.png&runtime=pr-919",
-    );
-    expect(image.getAttribute("src")).not.toMatch(/token|bearer/i);
   });
 
   it("previews bounded code as selectable text", async () => {
     render(<Tooltip.Provider><FilesWorkspace /></Tooltip.Provider>);
     fireEvent.doubleClick(await screen.findByRole("button", { name: "Open workspaces" }));
     fireEvent.click(await screen.findByRole("button", { name: "Open app.ts" }));
-    await waitFor(() => expect(getText).toHaveBeenCalledWith("/api/files/blob?path=workspaces%2Fapp.ts"));
+    await waitFor(() => expect(api.getText).toHaveBeenCalledWith("/api/files/blob?path=workspaces%2Fapp.ts"));
     expect(screen.getByText(/A remote home you can inspect/).closest("pre")).not.toBeNull();
+  });
+
+  it("fails closed when a text stat omits a size instead of fetching the full blob", async () => {
+    const custom = makeApi({ statFor: () => ({}) });
+    useConnection.setState({ api: custom as never });
+    render(<Tooltip.Provider><FilesWorkspace /></Tooltip.Provider>);
+    fireEvent.doubleClick(await screen.findByRole("button", { name: "Open workspaces" }));
+    fireEvent.click(await screen.findByRole("button", { name: "Open app.ts" }));
+    expect(await screen.findByText(/too large to preview/i)).not.toBeNull();
+    expect(custom.getText).not.toHaveBeenCalled();
+  });
+
+  it("previews images through the authenticated api client and revokes the object URL on unmount", async () => {
+    render(<Tooltip.Provider><FilesWorkspace /></Tooltip.Provider>);
+    fireEvent.doubleClick(await screen.findByRole("button", { name: "Open workspaces" }));
+    fireEvent.click(await screen.findByRole("button", { name: "Open hero.png" }));
+    const image = await screen.findByRole("img", { name: "hero.png" });
+    await waitFor(() =>
+      expect(api.getBlob).toHaveBeenCalledWith("/api/files/blob?path=workspaces%2Fhero.png"),
+    );
+    const src = image.getAttribute("src") ?? "";
+    expect(src).toMatch(/^blob:mock\//);
+    expect(src).not.toMatch(/token|bearer/i);
+    const created = createObjectURL.mock.results.at(-1)!.value as string;
+    cleanup();
+    expect(revokeObjectURL).toHaveBeenCalledWith(created);
+  });
+
+  it("fails closed when an image stat omits a size instead of fetching the blob", async () => {
+    const custom = makeApi({ statFor: () => ({}) });
+    useConnection.setState({ api: custom as never });
+    render(<Tooltip.Provider><FilesWorkspace /></Tooltip.Provider>);
+    fireEvent.doubleClick(await screen.findByRole("button", { name: "Open workspaces" }));
+    fireEvent.click(await screen.findByRole("button", { name: "Open hero.png" }));
+    expect(await screen.findByText(/too large to preview/i)).not.toBeNull();
+    expect(custom.getBlob).not.toHaveBeenCalled();
+  });
+
+  it("clears the file preview and issues no stale request when the selected computer changes", async () => {
+    render(<Tooltip.Provider><FilesWorkspace /></Tooltip.Provider>);
+    fireEvent.doubleClick(await screen.findByRole("button", { name: "Open workspaces" }));
+    fireEvent.click(await screen.findByRole("button", { name: "Open app.ts" }));
+    expect(await screen.findByText(/A remote home you can inspect/)).not.toBeNull();
+
+    api.getText.mockClear();
+    api.getBlob.mockClear();
+    api.get.mockClear();
+    act(() => {
+      useConnection.setState({ runtimeSlot: "pr-920" });
+    });
+
+    expect(await screen.findByText("Choose a file")).not.toBeNull();
+    expect(api.getText).not.toHaveBeenCalled();
+    expect(api.getBlob).not.toHaveBeenCalled();
+    const staleStat = api.get.mock.calls.find(
+      ([p]) => String(p).includes("/api/files/stat") && String(p).includes("app.ts"),
+    );
+    expect(staleStat).toBeUndefined();
+  });
+});
+
+describe("resolveActivePath", () => {
+  it("returns the stored path only when the runtime slot matches", () => {
+    expect(resolveActivePath({ slot: "pr-919", path: "workspaces/app.ts" }, "pr-919")).toBe(
+      "workspaces/app.ts",
+    );
+  });
+
+  it("returns null when the stored slot differs from the current slot", () => {
+    expect(resolveActivePath({ slot: "pr-919", path: "workspaces/app.ts" }, "pr-920")).toBeNull();
+  });
+
+  it("returns null when nothing is selected", () => {
+    expect(resolveActivePath(null, "pr-919")).toBeNull();
   });
 });

--- a/tests/desktop/header-injection.test.ts
+++ b/tests/desktop/header-injection.test.ts
@@ -146,6 +146,12 @@ describe("installGatewayCors", () => {
     expect(scriptDirective(csp)).toBe("script-src 'self'");
   });
 
+  it("allows blob: images so object-URL previews render in the packaged app", () => {
+    const csp = buildRendererCsp(GATEWAY, "null");
+    const imgDirective = csp.split(";").map((part) => part.trim()).find((part) => part.startsWith("img-src "));
+    expect(imgDirective).toBe("img-src 'self' data: blob: https:");
+  });
+
   it("allows Vite React Refresh inline preamble for localhost development renderers with explicit ports", () => {
     const localhostCsp = buildRendererCsp(GATEWAY, "http://localhost:3000");
     const loopbackCsp = buildRendererCsp(GATEWAY, "http://127.0.0.1:5173");

--- a/www/content/docs/guide/cloud-coding.mdx
+++ b/www/content/docs/guide/cloud-coding.mdx
@@ -11,6 +11,8 @@ A Matrix project is a Kanban workspace connected to a folder on the selected Mat
 
 Removing a project that connects an existing folder removes the Matrix project metadata, not the files in the owner folder.
 
+The desktop app's **Files** page browses the selected Matrix computer directly. Use breadcrumbs to move through the Matrix home and select images, Markdown, or code files for an inline preview. The same browser appears under **New project → Use existing folder**, so you can choose a project folder without typing a remote path. Switching computers reloads the browser for that computer; credentials never enter the renderer or appear in file URLs.
+
 ## GitHub authentication
 
 Connect GitHub inside your Matrix workspace with the GitHub CLI. SSH keys and GitHub credentials are stored under your Matrix home, so terminal panes, agents, and the browser IDE see the same authenticated identity.


### PR DESCRIPTION
## Summary

- add a first-class Files destination to the desktop sidebar
- browse the selected Matrix computer with breadcrumbs and runtime-safe refreshes
- preview bounded code/text, rendered Markdown, and images without renderer credentials
- reuse the same browser for New project → Use existing folder
- document the folder-first workflow and Phase 21 acceptance evidence

## Tests

- `bunx vitest run tests/desktop` — 99 files, 930 tests passed
- `pnpm --filter desktop typecheck`
- `bun run typecheck`
- `bun run check:patterns:diff` — zero violations, existing stack warnings only
- `bun run build:desktop`
- full `bun run test` attempted; the existing default-app `localStorage` environment failure reproduced before relevant suites, so the run was stopped after 72 unrelated failures
- launched with `bun run dev:desktop` and visually checked Files against `pr-919`

## Invariants

### Source of truth

- the selected Matrix computer and its authenticated gateway file routes remain authoritative
- the renderer stores only transient folder/file selections and never invents filesystem state

### Lock/transaction scope

- no persistence, lock, or transaction behavior changes
- directory and preview reads remain independent bounded gateway requests

### Acceptable orphan states

- failed or superseded reads leave no persisted state; stale responses are generation-guarded

### Auth source of truth

- Electron main remains the credential authority and injects auth outside renderer state
- image URLs contain only the gateway path and selected runtime slot

### Deferred scope

- file mutation, upload, rename, trash, and native-local Mac folder selection are not part of this read/choose slice
- no backend contract changes
