### PR TITLE
fix(platform): restore native stream capability routing

### DIFF
--- a/packages/platform/src/platform-websocket-upgrade.ts
+++ b/packages/platform/src/platform-websocket-upgrade.ts
@@ -18,6 +18,7 @@ import {
 import type { EntitlementAccessDecision } from './profile-routing.js';
 import {
   getWebSocketUpgradeToken,
+  isAppDomainHost,
   isCodeDomainHost,
   isSafeWebSocketUpgradePath,
   isSessionRoutedHost,
@@ -26,6 +27,9 @@ import {
 import { readRuntimeSlot } from './request-routing.js';
 import { EDGE_SECRET_HEADER } from './session-routing-proxy.js';
 import {
+  buildExplicitVmWebSocketUpstreamPath,
+  hasExplicitVmNativeAppStreamCapability,
+  readExplicitVmWebSocketRoute,
   resolveAppDomainIdentity,
   type AppDomainIdentity,
 } from './session-routing-identity.js';
@@ -109,7 +113,6 @@ export function registerPlatformWebSocketUpgradeHandler(
     }
 
     const path = req.url ?? '/';
-    const pathClass = classifyWebSocketPath(path);
     const host = getTrustedSessionRoutedWebSocketHost(
       req.headers.host,
       req.headers['x-forwarded-host'],
@@ -122,10 +125,20 @@ export function registerPlatformWebSocketUpgradeHandler(
       return;
     }
     const isCodeDomain = isCodeDomainHost(host);
+    const isAppDomain = isAppDomainHost(host);
     const hostClass = classifySessionRoutedHost(host);
+    const explicitVmRoute = isAppDomain ? readExplicitVmWebSocketRoute(path) : null;
+    const webSocketProxyPath = explicitVmRoute
+      ? buildExplicitVmWebSocketUpstreamPath(path)
+      : path;
+    const pathClass = classifyWebSocketPath(webSocketProxyPath);
+    if (isAppDomain && path.startsWith('/vm/') && !explicitVmRoute) {
+      socket.destroy();
+      return;
+    }
 
-    const requestRuntimeSlot = readRuntimeSlot(path);
-    const wsToken = getWebSocketUpgradeToken(path);
+    const requestRuntimeSlot = readRuntimeSlot(webSocketProxyPath);
+    const wsToken = getWebSocketUpgradeToken(webSocketProxyPath);
     let identity: AppDomainIdentity | null;
     try {
       identity = await resolveAppDomainIdentity({
@@ -135,9 +148,22 @@ export function registerPlatformWebSocketUpgradeHandler(
         db,
         platformJwtSecret,
         legacyContainerRoutingEnabled,
+        allowUnroutedClerkIdentity: Boolean(explicitVmRoute),
+        requestedHandle: explicitVmRoute?.handle,
         runtimeSlot: requestRuntimeSlot,
         wsToken,
       });
+      if (
+        !identity
+        && explicitVmRoute
+        && hasExplicitVmNativeAppStreamCapability(req.method ?? '', explicitVmRoute)
+      ) {
+        identity = {
+          handle: explicitVmRoute.handle,
+          userId: '',
+          source: 'static-route',
+        };
+      }
     } catch (err: unknown) {
       console.warn(
         `[platform] websocket auth failed host=${host} pathClass=${pathClass} error=${describeError(err)}`,
@@ -168,9 +194,19 @@ export function registerPlatformWebSocketUpgradeHandler(
 
     let runtimeSlot = identity.runtimeSlot ?? requestRuntimeSlot;
     let requestedActiveMachine: UserMachineRecord | undefined;
-    let runningMachine = identity.userId
-      ? await getRunningUserMachineByClerkId(db, identity.userId, runtimeSlot)
-      : await getRunningUserMachineByHandle(db, identity.handle);
+    let runningMachine: UserMachineRecord | undefined;
+    if (explicitVmRoute) {
+      const explicitMachine = await getRunningUserMachineByHandle(db, explicitVmRoute.handle);
+      if (!explicitMachine || (identity.userId && explicitMachine.clerkUserId !== identity.userId)) {
+        socket.destroy();
+        return;
+      }
+      runningMachine = explicitMachine;
+    } else {
+      runningMachine = identity.userId
+        ? await getRunningUserMachineByClerkId(db, identity.userId, runtimeSlot)
+        : await getRunningUserMachineByHandle(db, identity.handle);
+    }
     if (!runningMachine && identity.userId) {
       requestedActiveMachine = await getActiveUserMachineByClerkId(db, identity.userId, runtimeSlot);
       if (!requestedActiveMachine) {
@@ -213,12 +249,12 @@ export function registerPlatformWebSocketUpgradeHandler(
       upstreamHostHeader: string,
       headers: string,
     ): void => {
-      if (!isSafeWebSocketUpgradePath(path)) {
+      if (!isSafeWebSocketUpgradePath(webSocketProxyPath)) {
         socket.destroy();
         upstream.destroy();
         return;
       }
-      const upstreamPath = stripWebSocketUpgradeToken(path);
+      const upstreamPath = stripWebSocketUpgradeToken(webSocketProxyPath);
       upstream.write(
         `${req.method} ${upstreamPath} HTTP/1.1\r\nHost: ${upstreamHostHeader}\r\n${headers}\r\n\r\n`,
       );

--- a/packages/platform/src/platform-websocket-upgrade.ts
+++ b/packages/platform/src/platform-websocket-upgrade.ts
@@ -29,6 +29,7 @@ import { EDGE_SECRET_HEADER } from './session-routing-proxy.js';
 import {
   buildExplicitVmWebSocketUpstreamPath,
   hasExplicitVmNativeAppStreamCapability,
+  isNativeAppStreamPath,
   readExplicitVmWebSocketRoute,
   resolveAppDomainIdentity,
   type AppDomainIdentity,
@@ -133,6 +134,14 @@ export function registerPlatformWebSocketUpgradeHandler(
       : path;
     const pathClass = classifyWebSocketPath(webSocketProxyPath);
     if (isAppDomain && path.startsWith('/vm/') && !explicitVmRoute) {
+      socket.destroy();
+      return;
+    }
+    if (
+      explicitVmRoute
+      && isNativeAppStreamPath(explicitVmRoute.upstreamPath)
+      && !hasExplicitVmNativeAppStreamCapability(req.method ?? '', explicitVmRoute)
+    ) {
       socket.destroy();
       return;
     }

--- a/packages/platform/src/platform-websocket-upgrade.ts
+++ b/packages/platform/src/platform-websocket-upgrade.ts
@@ -239,7 +239,7 @@ export function registerPlatformWebSocketUpgradeHandler(
         handle,
         userId: identity.userId,
         platformSecret,
-        includePlatformProof,
+        includePlatformProof: includePlatformProof && identity.source !== 'static-route',
         isCodeDomain,
       })
     );

--- a/packages/platform/src/session-routing-identity.ts
+++ b/packages/platform/src/session-routing-identity.ts
@@ -173,6 +173,8 @@ export function hasExplicitVmNativeAppStreamCapability(
   method: string,
   route: ExplicitVmRoute,
 ): boolean {
+  // The route only selects the gateway capability endpoint. The gateway still
+  // timing-safely validates the full random stream token against a live session.
   return (method === 'GET' || method === 'HEAD')
     && NATIVE_APP_STREAM_CAPABILITY_PATH.test(route.upstreamPath);
 }

--- a/packages/platform/src/session-routing-identity.ts
+++ b/packages/platform/src/session-routing-identity.ts
@@ -30,6 +30,9 @@ export interface ExplicitVmRoute {
   upstreamPath: string;
 }
 
+const NATIVE_APP_STREAM_PATH = /^\/api\/native-apps\/sessions\/session_[A-Za-z0-9_-]{24,96}\/stream(?:\/|$)/;
+const NATIVE_APP_STREAM_CAPABILITY_PATH = /^\/api\/native-apps\/sessions\/session_[A-Za-z0-9_-]{24,96}\/stream\/stream_[A-Za-z0-9_-]{24,96}(?:\/|$)/;
+
 export interface AppDomainIdentity {
   handle: string;
   userId: string;
@@ -138,6 +141,40 @@ export function readExplicitVmRoute(path: string): ExplicitVmRoute | null {
     handle: match[1],
     upstreamPath: rest ? `/${rest}` : '/',
   };
+}
+
+export function readExplicitVmWebSocketRoute(path: string): ExplicitVmRoute | null {
+  try {
+    const url = new URL(path, 'https://app.matrix-os.com');
+    return readExplicitVmRoute(url.pathname);
+  } catch (err: unknown) {
+    if (err instanceof TypeError) return null;
+    throw err;
+  }
+}
+
+export function buildExplicitVmWebSocketUpstreamPath(path: string): string {
+  try {
+    const url = new URL(path, 'https://app.matrix-os.com');
+    const route = readExplicitVmRoute(url.pathname);
+    if (!route) return path;
+    return `${route.upstreamPath}${url.search}`;
+  } catch (err: unknown) {
+    if (err instanceof TypeError) return path;
+    throw err;
+  }
+}
+
+export function isNativeAppStreamPath(path: string): boolean {
+  return NATIVE_APP_STREAM_PATH.test(path);
+}
+
+export function hasExplicitVmNativeAppStreamCapability(
+  method: string,
+  route: ExplicitVmRoute,
+): boolean {
+  return (method === 'GET' || method === 'HEAD')
+    && NATIVE_APP_STREAM_CAPABILITY_PATH.test(route.upstreamPath);
 }
 
 function readGatewayRouteCookie(path: string, cookieHeader: string | undefined): string | null {

--- a/packages/platform/src/session-routing-middleware.ts
+++ b/packages/platform/src/session-routing-middleware.ts
@@ -425,6 +425,15 @@ export function createSessionRoutingMiddleware(opts: CreateSessionRoutingMiddlew
       isAppDomain &&
       isAppDomainStaticAssetPath(path),
     );
+    const shouldPersistShellRoute = Boolean(
+      isAppDomain &&
+      identity &&
+      identity.source !== 'static-route' &&
+      (
+        requestedRouteHandle ||
+        (!isGatewayPath && !isAppDomainStaticAssetPath(path))
+      ),
+    );
 
     // No session/JWT -- serve Clerk auth directly from the platform.
     if (!identity) {
@@ -731,7 +740,7 @@ export function createSessionRoutingMiddleware(opts: CreateSessionRoutingMiddlew
           const routeCookie = buildAppRouteCookie(runningMachine.handle, path);
           if (routeCookie) responseHeaders.append('set-cookie', routeCookie);
         }
-        if (isAppDomain && identity.source !== 'static-route') {
+        if (shouldPersistShellRoute) {
           responseHeaders.append('set-cookie', buildShellRouteCookie(runningMachine.handle));
           responseHeaders.append('set-cookie', buildShellRuntimeSlotCookie(runningMachine.runtimeSlot));
         }
@@ -913,7 +922,7 @@ export function createSessionRoutingMiddleware(opts: CreateSessionRoutingMiddlew
           const routeCookie = buildAppRouteCookie(record.handle, path);
           if (routeCookie) responseHeaders.append('set-cookie', routeCookie);
         }
-        if (isAppDomain && identity.source !== 'static-route') {
+        if (shouldPersistShellRoute) {
           responseHeaders.append('set-cookie', buildShellRouteCookie(record.handle));
           responseHeaders.append('set-cookie', buildShellRuntimeSlotCookie('primary'));
         }

--- a/packages/platform/src/session-routing-middleware.ts
+++ b/packages/platform/src/session-routing-middleware.ts
@@ -345,6 +345,14 @@ export function createSessionRoutingMiddleware(opts: CreateSessionRoutingMiddlew
     );
     const explicitVmRouteHasCredentiallessCapability =
       explicitVmRouteHasValidAppAssetToken || explicitVmRouteHasNativeAppStreamCapability;
+    if (
+      explicitVmRoute
+      && isNativeAppStreamPath(explicitVmRoute.upstreamPath)
+      && !explicitVmRouteHasNativeAppStreamCapability
+    ) {
+      applyNoStoreHeaders(c);
+      return c.text('Unauthorized', 401);
+    }
     const runtimeSelection = readRuntimeSlotSelection(c.req.url);
     const cookieRuntimeSlot = isAppDomain
       ? readShellRuntimeSlotCookie(path, cookieHeader)
@@ -429,10 +437,6 @@ export function createSessionRoutingMiddleware(opts: CreateSessionRoutingMiddlew
         return c.text('Unauthorized', 401);
       }
       if (isAppDomain && explicitVmRoute && isViteAppAssetPath(explicitVmRoute.upstreamPath)) {
-        applyNoStoreHeaders(c);
-        return c.text('Unauthorized', 401);
-      }
-      if (isAppDomain && explicitVmRoute && isNativeAppStreamPath(explicitVmRoute.upstreamPath)) {
         applyNoStoreHeaders(c);
         return c.text('Unauthorized', 401);
       }

--- a/packages/platform/src/session-routing-middleware.ts
+++ b/packages/platform/src/session-routing-middleware.ts
@@ -524,7 +524,10 @@ export function createSessionRoutingMiddleware(opts: CreateSessionRoutingMiddlew
       headers.set('x-forwarded-proto', 'https');
       headers.set('accept-encoding', 'identity');
       headers.set('connection', 'close');
-      if (platformSecret) {
+      // Capability-only requests must not inherit the platform's internal
+      // runtime credential. The gateway authorizes this exact stream path by
+      // validating its opaque token against the live native-app session.
+      if (platformSecret && !explicitVmRouteHasNativeAppStreamCapability) {
         headers.set('authorization', `Bearer ${buildPlatformVerificationToken(machine.handle, platformSecret)}`);
         if (identity.userId) {
           headers.set('x-platform-user-id', identity.userId);

--- a/packages/platform/src/session-routing-middleware.ts
+++ b/packages/platform/src/session-routing-middleware.ts
@@ -78,6 +78,8 @@ import {
   buildAppRouteCookie,
   buildShellRouteCookie,
   buildShellRuntimeSlotCookie,
+  hasExplicitVmNativeAppStreamCapability,
+  isNativeAppStreamPath,
   readAppDomainRouteCookie,
   readExplicitVmRoute,
   readMobileAppRouteCookie,
@@ -338,6 +340,11 @@ export function createSessionRoutingMiddleware(opts: CreateSessionRoutingMiddlew
         platformSecret,
       }),
     );
+    const explicitVmRouteHasNativeAppStreamCapability = Boolean(
+      explicitVmRoute && hasExplicitVmNativeAppStreamCapability(c.req.method, explicitVmRoute),
+    );
+    const explicitVmRouteHasCredentiallessCapability =
+      explicitVmRouteHasValidAppAssetToken || explicitVmRouteHasNativeAppStreamCapability;
     const runtimeSelection = readRuntimeSlotSelection(c.req.url);
     const cookieRuntimeSlot = isAppDomain
       ? readShellRuntimeSlotCookie(path, cookieHeader)
@@ -385,7 +392,7 @@ export function createSessionRoutingMiddleware(opts: CreateSessionRoutingMiddlew
     if (
       !identity &&
       explicitVmRoute &&
-      explicitVmRouteHasValidAppAssetToken
+      explicitVmRouteHasCredentiallessCapability
     ) {
       identity = {
         handle: explicitVmRoute.handle,
@@ -425,6 +432,10 @@ export function createSessionRoutingMiddleware(opts: CreateSessionRoutingMiddlew
         applyNoStoreHeaders(c);
         return c.text('Unauthorized', 401);
       }
+      if (isAppDomain && explicitVmRoute && isNativeAppStreamPath(explicitVmRoute.upstreamPath)) {
+        applyNoStoreHeaders(c);
+        return c.text('Unauthorized', 401);
+      }
       if (isAppDomain && isAppDomainStaticAssetPath(path)) {
         applyNoStoreHeaders(c);
         return c.text('Unauthorized', 401);
@@ -452,7 +463,7 @@ export function createSessionRoutingMiddleware(opts: CreateSessionRoutingMiddlew
       return c.text('Invalid Matrix OS computer', 400);
     }
     if (isAppDomain && explicitVmRoute) {
-      if ((!identity.userId || identity.source === 'mobile-session' || identity.source === 'static-route') && !explicitVmRouteHasValidAppAssetToken) {
+      if ((!identity.userId || identity.source === 'mobile-session' || identity.source === 'static-route') && !explicitVmRouteHasCredentiallessCapability) {
         applyNoStoreHeaders(c);
         return c.text('Unauthorized', 401);
       }

--- a/tests/platform/native-app-capability-routing.test.ts
+++ b/tests/platform/native-app-capability-routing.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildExplicitVmWebSocketUpstreamPath,
+  hasExplicitVmNativeAppStreamCapability,
+  readExplicitVmWebSocketRoute,
+} from "../../packages/platform/src/session-routing-identity.js";
+
+describe("native app capability routing", () => {
+  it("maps explicit VM native app WebSocket paths to the selected runtime", () => {
+    const path = "/vm/alice-staging/api/native-apps/sessions/session_aaaaaaaaaaaaaaaaaaaaaaaa/stream/stream_bbbbbbbbbbbbbbbbbbbbbbbb/";
+
+    const route = readExplicitVmWebSocketRoute(path);
+    expect(route).toEqual({
+      handle: "alice-staging",
+      upstreamPath: "/api/native-apps/sessions/session_aaaaaaaaaaaaaaaaaaaaaaaa/stream/stream_bbbbbbbbbbbbbbbbbbbbbbbb/",
+    });
+    expect(hasExplicitVmNativeAppStreamCapability("GET", route!)).toBe(true);
+    expect(buildExplicitVmWebSocketUpstreamPath(path)).toBe(
+      "/api/native-apps/sessions/session_aaaaaaaaaaaaaaaaaaaaaaaa/stream/stream_bbbbbbbbbbbbbbbbbbbbbbbb/",
+    );
+  });
+
+  it("rejects malformed and tokenless native app capability paths", () => {
+    expect(hasExplicitVmNativeAppStreamCapability("POST", {
+      handle: "alice-staging",
+      upstreamPath: "/api/native-apps/sessions/session_aaaaaaaaaaaaaaaaaaaaaaaa/stream/stream_bbbbbbbbbbbbbbbbbbbbbbbb/",
+    })).toBe(false);
+    expect(hasExplicitVmNativeAppStreamCapability("GET", {
+      handle: "alice-staging",
+      upstreamPath: "/api/native-apps/sessions/session_aaaaaaaaaaaaaaaaaaaaaaaa/stream/js/Utilities.js",
+    })).toBe(false);
+    expect(readExplicitVmWebSocketRoute("/vm/invalid%2Fhandle/api/native-apps/sessions/session_aaaaaaaaaaaaaaaaaaaaaaaa/stream/stream_bbbbbbbbbbbbbbbbbbbbbbbb/")).toBeNull();
+  });
+});

--- a/tests/platform/native-app-capability-routing.test.ts
+++ b/tests/platform/native-app-capability-routing.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   buildExplicitVmWebSocketUpstreamPath,
   hasExplicitVmNativeAppStreamCapability,
+  isNativeAppStreamPath,
   readExplicitVmWebSocketRoute,
 } from "../../packages/platform/src/session-routing-identity.js";
 
@@ -25,10 +26,12 @@ describe("native app capability routing", () => {
       handle: "alice-staging",
       upstreamPath: "/api/native-apps/sessions/session_aaaaaaaaaaaaaaaaaaaaaaaa/stream/stream_bbbbbbbbbbbbbbbbbbbbbbbb/",
     })).toBe(false);
-    expect(hasExplicitVmNativeAppStreamCapability("GET", {
+    const tokenlessRoute = {
       handle: "alice-staging",
       upstreamPath: "/api/native-apps/sessions/session_aaaaaaaaaaaaaaaaaaaaaaaa/stream/js/Utilities.js",
-    })).toBe(false);
+    };
+    expect(isNativeAppStreamPath(tokenlessRoute.upstreamPath)).toBe(true);
+    expect(hasExplicitVmNativeAppStreamCapability("GET", tokenlessRoute)).toBe(false);
     expect(readExplicitVmWebSocketRoute("/vm/invalid%2Fhandle/api/native-apps/sessions/session_aaaaaaaaaaaaaaaaaaaaaaaa/stream/stream_bbbbbbbbbbbbbbbbbbbbbbbb/")).toBeNull();
   });
 });

--- a/tests/platform/proxy-routing.test.ts
+++ b/tests/platform/proxy-routing.test.ts
@@ -73,9 +73,6 @@ describe("platform proxy routing", () => {
     const app = createApp({
       db,
       orchestrator: stubOrchestrator(),
-      clerkAuth: createClerkAuth({
-        verifyToken: vi.fn().mockResolvedValue({ sub: "user_alice" }),
-      }),
       platformSecret: "platform-secret-123",
     });
 
@@ -238,6 +235,9 @@ describe("platform proxy routing", () => {
     const app = createApp({
       db,
       orchestrator: stubOrchestrator(),
+      clerkAuth: createClerkAuth({
+        verifyToken: vi.fn().mockResolvedValue({ sub: "user_alice" }),
+      }),
       platformSecret: "platform-secret-123",
     });
     const issued = await issueSyncJwt({
@@ -3047,6 +3047,9 @@ describe("platform proxy routing", () => {
     const app = createApp({
       db,
       orchestrator: stubOrchestrator(),
+      clerkAuth: createClerkAuth({
+        verifyToken: vi.fn().mockResolvedValue({ sub: "user_alice" }),
+      }),
       platformSecret: "platform-secret-123",
     });
 
@@ -3056,6 +3059,20 @@ describe("platform proxy routing", () => {
     );
 
     expect(res.status).toBe(401);
+    expect(fetchMock).not.toHaveBeenCalled();
+
+    const authenticatedRes = await app.request(
+      "/vm/alice-staging/api/native-apps/sessions/session_aaaaaaaaaaaaaaaaaaaaaaaa/stream/js/Utilities.js",
+      {
+        headers: {
+          host: "app.matrix-os.com",
+          origin: "null",
+          authorization: "Bearer clerk-session",
+        },
+      },
+    );
+
+    expect(authenticatedRes.status).toBe(401);
     expect(fetchMock).not.toHaveBeenCalled();
   });
 

--- a/tests/platform/proxy-routing.test.ts
+++ b/tests/platform/proxy-routing.test.ts
@@ -2998,6 +2998,66 @@ describe("platform proxy routing", () => {
     expect(claims.runtime_slot).toBe("staging");
   });
 
+  it("routes explicit VM native app capability assets without browser cookies", async () => {
+    await deleteContainer(db, "alice");
+    await insertUserMachine(db, {
+      machineId: "9f05824c-8d0a-4d83-9cb4-b312d43ff141",
+      clerkUserId: "user_alice",
+      handle: "alice-staging",
+      runtimeSlot: "staging",
+      status: "running",
+      hetznerServerId: 123485,
+      publicIPv4: "203.0.113.35",
+      imageVersion: "v082-login-shell-8935a7cd",
+      provisionedAt: "2026-05-25T11:23:51.076Z",
+    });
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response("window.Utilities = {};", {
+        status: 200,
+        headers: { "content-type": "application/javascript" },
+      }),
+    );
+    const app = createApp({
+      db,
+      orchestrator: stubOrchestrator(),
+      platformSecret: "platform-secret-123",
+    });
+
+    const res = await app.request(
+      "/vm/alice-staging/api/native-apps/sessions/session_aaaaaaaaaaaaaaaaaaaaaaaa/stream/stream_bbbbbbbbbbbbbbbbbbbbbbbb/js/Utilities.js",
+      { headers: { host: "app.matrix-os.com", origin: "null" } },
+    );
+
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe("window.Utilities = {};");
+    const [url, init] = fetchMock.mock.calls[0]!;
+    expect(url).toBe(
+      "https://203.0.113.35:443/api/native-apps/sessions/session_aaaaaaaaaaaaaaaaaaaaaaaa/stream/stream_bbbbbbbbbbbbbbbbbbbbbbbb/js/Utilities.js",
+    );
+    const headers = init?.headers as Headers;
+    expect(headers.get("cookie")).toBeNull();
+    expect(headers.get("x-platform-user-id")).toBeNull();
+  });
+
+  it("rejects explicit VM native app stream assets without a capability token", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response("unexpected", { status: 200 }),
+    );
+    const app = createApp({
+      db,
+      orchestrator: stubOrchestrator(),
+      platformSecret: "platform-secret-123",
+    });
+
+    const res = await app.request(
+      "/vm/alice-staging/api/native-apps/sessions/session_aaaaaaaaaaaaaaaaaaaaaaaa/stream/js/Utilities.js",
+      { headers: { host: "app.matrix-os.com", origin: "null" } },
+    );
+
+    expect(res.status).toBe(401);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
   it("routes signed explicit VM Vite app assets with null-origin CORS without browser cookies", async () => {
     await deleteContainer(db, "alice");
     await insertUserMachine(db, {

--- a/tests/platform/proxy-routing.test.ts
+++ b/tests/platform/proxy-routing.test.ts
@@ -3035,6 +3035,7 @@ describe("platform proxy routing", () => {
       "https://203.0.113.35:443/api/native-apps/sessions/session_aaaaaaaaaaaaaaaaaaaaaaaa/stream/stream_bbbbbbbbbbbbbbbbbbbbbbbb/js/Utilities.js",
     );
     const headers = init?.headers as Headers;
+    expect(headers.get("authorization")).toBeNull();
     expect(headers.get("cookie")).toBeNull();
     expect(headers.get("x-platform-user-id")).toBeNull();
   });

--- a/tests/platform/proxy-routing.test.ts
+++ b/tests/platform/proxy-routing.test.ts
@@ -73,6 +73,9 @@ describe("platform proxy routing", () => {
     const app = createApp({
       db,
       orchestrator: stubOrchestrator(),
+      clerkAuth: createClerkAuth({
+        verifyToken: vi.fn().mockResolvedValue({ sub: "user_alice" }),
+      }),
       platformSecret: "platform-secret-123",
     });
 
@@ -98,6 +101,7 @@ describe("platform proxy routing", () => {
     expect(headers.get("x-platform-user-id")).toBe("user_alice");
     expect(headers.get("x-matrix-native-app-session")).toBeNull();
     expect(headers.get("x-matrix-platform-session")).toBeNull();
+    expect(res.headers.get("set-cookie") ?? "").not.toContain("matrix_shell_route=");
     expect(headers.get("cookie")).toBeNull();
   });
 


### PR DESCRIPTION
## Summary
- restore cookie-free explicit-VM routing for native app stream capability assets on the refactored platform
- map explicit-VM native app WebSocket upgrades to the selected VPS and strip the `/vm/{handle}` prefix upstream
- reject malformed or tokenless native stream paths before probing a runtime
- prevent unselected API/static responses from overwriting an explicit computer route during shell hydration

## Tests
- `pnpm exec vitest run tests/platform/proxy-routing.test.ts tests/platform/native-app-capability-routing.test.ts` (115 passed)
- `pnpm --filter @matrix-os/platform exec tsc --noEmit`
- `git diff --check`

## Review/Monitoring
- Implements spec 105 Phase 24 task B24-006 and acceptance boundary PV-103: preserve native Linux app HTTP/WebSocket capability routing while composing the canonical computer/session routing from PRs #921-#923.
- This is the platform half of the composed candidate. PR #703 owns the gateway native-app routes, route-scoped stream auth bypass, and stream-token validation.
- Canonical non-primary acceptance target: `https://app.matrix-os.com/vm/pr-703?runtime=preview`.
- The wider isolated preview authority in B24-007 through B24-010 remains separate and incomplete; this PR does not claim Gate B0.5 completion.

## Invariants
- Source of truth: the opaque session and stream capability IDs generated and validated by the customer gateway.
- Computer selection: canonical server-derived handle/runtime-slot routing from PRs #921-#923; no new client-owned inventory or bearer flow.
- Route persistence: document/explicit navigation may establish selection; API/static responses only refresh an existing valid selection and cannot race it back to primary.
- Lock/transaction scope: no persistence or multi-write behavior changes.
- Acceptable orphan states: none introduced; routing is request-scoped.
- Auth source of truth: ordinary routes still use Clerk/sync identity; only strict GET/HEAD native stream capability paths may route without browser credentials, and PR #703's gateway validates the opaque stream token.
- Deferred scope: resolving PR #703's broader merge conflicts and implementing the isolated preview authority remain separate.
