### PR TITLE
feat(desktop): complete project chat creation

### DIFF
--- a/desktop/src/renderer/src/features/board/CreateProjectDialog.tsx
+++ b/desktop/src/renderer/src/features/board/CreateProjectDialog.tsx
@@ -79,12 +79,18 @@ function CreateProjectForm({ onClose }: { onClose: () => void }) {
       if (destination === "agents") {
         await refreshAgentWorkspace();
         if (dialogClosedRef.current || dialogGenerationRef.current !== submitGeneration) return;
+        // The workspace store catches refresh failures internally and clears
+        // the summary. The project already exists at this point, so keep the
+        // dialog open with a recoverable message instead of closing silently
+        // with nothing selected.
+        const agentSummary = useCodingAgentWorkspace.getState().summary;
+        if (!agentSummary) {
+          setError("The project was created, but the workspace didn't refresh. Close this dialog and open it from Agents.");
+          return;
+        }
         // Land the navigator on the new project; a failed workspace load surfaces
         // through the project-workspace store's own error state.
-        const agentSummary = useCodingAgentWorkspace.getState().summary;
-        if (agentSummary) {
-          await openCreatedProject(agentSummary, project.slug, runtimeScope);
-        }
+        await openCreatedProject(agentSummary, project.slug, runtimeScope);
       } else {
         await selectProject(api, project.slug);
       }

--- a/desktop/src/renderer/src/features/board/CreateProjectDialog.tsx
+++ b/desktop/src/renderer/src/features/board/CreateProjectDialog.tsx
@@ -7,6 +7,8 @@ import { useConnection } from "../../stores/connection";
 import { useTabs } from "../../stores/tabs";
 import { useUi } from "../../stores/ui";
 import { useCodingAgentWorkspace } from "../../stores/coding-agent-workspace";
+import { useCodingAgentProjectWorkspace } from "../../stores/coding-agent-project-workspace";
+import { codingAgentRuntimeScope } from "../../../../shared/coding-agent-project-workspace";
 
 type Mode = "scratch" | "folder" | "github";
 
@@ -19,6 +21,8 @@ function CreateProjectForm({ onClose }: { onClose: () => void }) {
   const openTab = useTabs((s) => s.openTab);
   const destination = useUi((s) => s.createProjectDestination);
   const refreshAgentWorkspace = useCodingAgentWorkspace((s) => s.refresh);
+  const openCreatedProject = useCodingAgentProjectWorkspace((s) => s.openCreatedProject);
+  const runtimeScope = useConnection(codingAgentRuntimeScope);
   const [name, setName] = useState("");
   const [mode, setMode] = useState<Mode>("scratch");
   const [url, setUrl] = useState("");
@@ -74,6 +78,13 @@ function CreateProjectForm({ onClose }: { onClose: () => void }) {
       }
       if (destination === "agents") {
         await refreshAgentWorkspace();
+        if (dialogClosedRef.current || dialogGenerationRef.current !== submitGeneration) return;
+        // Land the navigator on the new project; a failed workspace load surfaces
+        // through the project-workspace store's own error state.
+        const agentSummary = useCodingAgentWorkspace.getState().summary;
+        if (agentSummary) {
+          await openCreatedProject(agentSummary, project.slug, runtimeScope);
+        }
       } else {
         await selectProject(api, project.slug);
       }

--- a/desktop/src/renderer/src/features/board/CreateProjectDialog.tsx
+++ b/desktop/src/renderer/src/features/board/CreateProjectDialog.tsx
@@ -79,11 +79,15 @@ function CreateProjectForm({ onClose }: { onClose: () => void }) {
       if (destination === "agents") {
         await refreshAgentWorkspace();
         if (dialogClosedRef.current || dialogGenerationRef.current !== submitGeneration) return;
-        // The workspace store catches refresh failures internally and clears
-        // the summary. The project already exists at this point, so keep the
-        // dialog open with a recoverable message instead of closing silently
-        // with nothing selected.
-        const agentSummary = useCodingAgentWorkspace.getState().summary;
+        // The workspace store catches refresh failures internally: it clears
+        // the summary when nothing was loaded yet, but keeps a previously
+        // loaded summary with status "error". Both are failed refreshes, and
+        // selecting against the stale summary would miss the new project. The
+        // project already exists at this point, so keep the dialog open with a
+        // recoverable message instead of closing silently with nothing
+        // selected.
+        const agentWorkspace = useCodingAgentWorkspace.getState();
+        const agentSummary = agentWorkspace.status === "error" ? null : agentWorkspace.summary;
         if (!agentSummary) {
           setError("The project was created, but the workspace didn't refresh. Close this dialog and open it from Agents.");
           return;

--- a/desktop/src/renderer/src/features/board/CreateProjectDialog.tsx
+++ b/desktop/src/renderer/src/features/board/CreateProjectDialog.tsx
@@ -5,6 +5,8 @@ import { toUserMessage } from "../../lib/errors";
 import { useBoard } from "../../stores/board";
 import { useConnection } from "../../stores/connection";
 import { useTabs } from "../../stores/tabs";
+import { useUi } from "../../stores/ui";
+import { useCodingAgentWorkspace } from "../../stores/coding-agent-workspace";
 
 type Mode = "scratch" | "folder" | "github";
 
@@ -15,6 +17,8 @@ function CreateProjectForm({ onClose }: { onClose: () => void }) {
   const createProject = useBoard((s) => s.createProject);
   const selectProject = useBoard((s) => s.selectProject);
   const openTab = useTabs((s) => s.openTab);
+  const destination = useUi((s) => s.createProjectDestination);
+  const refreshAgentWorkspace = useCodingAgentWorkspace((s) => s.refresh);
   const [name, setName] = useState("");
   const [mode, setMode] = useState<Mode>("scratch");
   const [url, setUrl] = useState("");
@@ -68,10 +72,16 @@ function CreateProjectForm({ onClose }: { onClose: () => void }) {
         );
         return;
       }
-      await selectProject(api, project.slug);
+      if (destination === "agents") {
+        await refreshAgentWorkspace();
+      } else {
+        await selectProject(api, project.slug);
+      }
       if (dialogClosedRef.current || dialogGenerationRef.current !== submitGeneration) return;
       closeFromUser();
-      openTab({ kind: "board", projectSlug: project.slug, title: project.name || project.slug });
+      if (destination === "board") {
+        openTab({ kind: "board", projectSlug: project.slug, title: project.name || project.slug });
+      }
     } catch (err: unknown) {
       if (!dialogClosedRef.current && dialogGenerationRef.current === submitGeneration) {
         setError(toUserMessage(err));

--- a/desktop/src/renderer/src/features/coding-agents/AgentProjectNavigator.tsx
+++ b/desktop/src/renderer/src/features/coding-agents/AgentProjectNavigator.tsx
@@ -28,6 +28,7 @@ export interface AgentProjectNavigatorProps {
   onSelectThread: (threadId: string) => void;
   onNewChat: (projectId: string, taskId?: string) => void;
   onNewProject?: () => void;
+  onOpenSettings?: () => void;
 }
 
 function CountBadge({ children }: { children: number }) {
@@ -112,6 +113,7 @@ export function AgentProjectNavigator({
   onSelectThread,
   onNewChat,
   onNewProject,
+  onOpenSettings,
 }: AgentProjectNavigatorProps) {
   const grouped = workspace ? groupProjectWorkspaceThreads(workspace) : null;
   const projects = workspace
@@ -320,6 +322,35 @@ export function AgentProjectNavigator({
             <p className="mt-1 text-[11px]" style={{ color: "var(--text-tertiary)" }}>
               Create a project to start a coding conversation.
             </p>
+            {onNewProject ? (
+              <button
+                type="button"
+                onClick={onNewProject}
+                className="mt-3 rounded-md px-3 py-1.5 text-xs font-medium outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)]"
+                style={{ background: "var(--accent)", color: "var(--text-on-accent)" }}
+              >
+                Create project
+              </button>
+            ) : null}
+          </div>
+        ) : null}
+        {summary.providers.length === 0 ? (
+          <div className="mx-2 mt-3 rounded-lg border px-3 py-3" style={{ borderColor: "var(--border-subtle)", background: "var(--bg-surface)" }}>
+            <p className="text-xs font-medium" style={{ color: "var(--text-secondary)" }}>No coding agent connected</p>
+            <p className="mt-1 text-[11px]" style={{ color: "var(--text-tertiary)" }}>
+              Install or authenticate a provider for this computer, then refresh.
+            </p>
+            {onOpenSettings ? (
+              <button
+                type="button"
+                aria-label="Open agent settings"
+                onClick={onOpenSettings}
+                className="mt-2 text-xs font-medium outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)]"
+                style={{ color: "var(--accent)" }}
+              >
+                Open Settings
+              </button>
+            ) : null}
           </div>
         ) : null}
       </div>

--- a/desktop/src/renderer/src/features/coding-agents/AgentProjectWorkspaceShell.tsx
+++ b/desktop/src/renderer/src/features/coding-agents/AgentProjectWorkspaceShell.tsx
@@ -9,6 +9,7 @@ import { useCodingAgentProjectWorkspace } from "../../stores/coding-agent-projec
 import { useConnection } from "../../stores/connection";
 import { useUi } from "../../stores/ui";
 import { AgentProjectNavigator } from "./AgentProjectNavigator";
+import { useTabs } from "../../stores/tabs";
 
 function capabilityEnabled(summary: RuntimeSummary, id: string): boolean {
   return summary.capabilities.some(
@@ -46,7 +47,8 @@ export function AgentProjectWorkspaceShell({
     (state) => state.focusExternalThread,
   );
   const runtimeScope = useConnection(codingAgentRuntimeScope);
-  const setCreateProjectOpen = useUi((state) => state.setCreateProjectOpen);
+  const openCreateProject = useUi((state) => state.openCreateProject);
+  const openTab = useTabs((state) => state.openTab);
   const activeThreadId = useCodingAgentWorkspace((state) => state.activeThreadId);
   const activeThread = useCodingAgentWorkspace((state) =>
     state.threadSnapshot?.thread.id === state.activeThreadId
@@ -192,7 +194,8 @@ export function AgentProjectWorkspaceShell({
             }
           }}
           onNewChat={onNewChat}
-          onNewProject={() => setCreateProjectOpen(true)}
+          onNewProject={() => openCreateProject("agents")}
+          onOpenSettings={() => openTab({ kind: "settings", title: "Settings", slug: "settings" })}
         />
       ) : (
         <nav

--- a/desktop/src/renderer/src/features/coding-agents/AgentProjectWorkspaceShell.tsx
+++ b/desktop/src/renderer/src/features/coding-agents/AgentProjectWorkspaceShell.tsx
@@ -195,7 +195,13 @@ export function AgentProjectWorkspaceShell({
           }}
           onNewChat={onNewChat}
           onNewProject={() => openCreateProject("agents")}
-          onOpenSettings={() => openTab({ kind: "settings", title: "Settings", slug: "settings" })}
+          onOpenSettings={() => {
+            // Land on the Agent section and share the canonical Settings tab
+            // identity so an already-open Settings tab is focused, not
+            // duplicated.
+            useUi.getState().requestSettingsSection("agent");
+            openTab({ kind: "settings", title: "Settings" });
+          }}
         />
       ) : (
         <nav

--- a/desktop/src/renderer/src/features/coding-agents/AgentWorkspace.tsx
+++ b/desktop/src/renderer/src/features/coding-agents/AgentWorkspace.tsx
@@ -32,6 +32,7 @@ import { AgentWorkspaceViewSwitch } from "./AgentKanbanBoard";
 import { AgentKanbanWorkspace } from "./AgentKanbanWorkspace";
 import { AgentConversationInspector } from "./AgentConversationInspector";
 import { AgentWorkspaceSection as Section } from "./AgentWorkspaceSection";
+import { resolveNewChatRelation } from "./project-workspace-model";
 
 const STATUS_COLOR: Record<string, string> = {
   available: "var(--success)",
@@ -1508,12 +1509,13 @@ export default function AgentWorkspace() {
   const projectWorkspaceEnabled = capabilityEnabled(summary, "codingAgentsProjectWorkspace");
 
   function openNewChat(projectId: string, taskId?: string) {
+    const relation = resolveNewChatRelation(projectWorkspace, projectId, taskId);
+    if (!relation) return;
     setComposerSeed({
       seedId: Date.now(),
       draft: {
         ...defaultAgentThreadComposerDraft(summary!),
-        projectId,
-        ...(taskId ? { taskId } : {}),
+        ...relation,
       },
     });
     setComposerOpen(true);

--- a/desktop/src/renderer/src/features/coding-agents/AgentWorkspace.tsx
+++ b/desktop/src/renderer/src/features/coding-agents/AgentWorkspace.tsx
@@ -32,7 +32,7 @@ import { AgentWorkspaceViewSwitch } from "./AgentKanbanBoard";
 import { AgentKanbanWorkspace } from "./AgentKanbanWorkspace";
 import { AgentConversationInspector } from "./AgentConversationInspector";
 import { AgentWorkspaceSection as Section } from "./AgentWorkspaceSection";
-import { resolveNewChatRelation } from "./project-workspace-model";
+import { toast } from "sonner";
 
 const STATUS_COLOR: Record<string, string> = {
   available: "var(--success)",
@@ -1412,6 +1412,7 @@ export default function AgentWorkspace() {
   const loadThreadSnapshot = useCodingAgentWorkspace((s) => s.loadThreadSnapshot);
   const loadNotificationPreferences = useCodingAgentWorkspace((s) => s.loadNotificationPreferences);
   const refreshProjectWorkspace = useCodingAgentProjectWorkspace((s) => s.refresh);
+  const resolveNewChatTarget = useCodingAgentProjectWorkspace((s) => s.resolveNewChatTarget);
   const projectWorkspace = useCodingAgentProjectWorkspace((s) => s.workspace);
   const viewMode = useCodingAgentProjectWorkspace((s) => s.viewMode);
   const setViewMode = useCodingAgentProjectWorkspace((s) => s.setViewMode);
@@ -1508,9 +1509,12 @@ export default function AgentWorkspace() {
   const canCreateFollowUp = capabilityEnabled(summary, "codingAgentsThreadCreate");
   const projectWorkspaceEnabled = capabilityEnabled(summary, "codingAgentsProjectWorkspace");
 
-  function openNewChat(projectId: string, taskId?: string) {
-    const relation = resolveNewChatRelation(projectWorkspace, projectId, taskId);
-    if (!relation) return;
+  async function openNewChat(projectId: string, taskId?: string) {
+    const relation = await resolveNewChatTarget(projectId, taskId);
+    if (!relation) {
+      toast.error("Couldn't start a new chat here. Refresh the workspace and try again.");
+      return;
+    }
     setComposerSeed({
       seedId: Date.now(),
       draft: {
@@ -1595,7 +1599,7 @@ export default function AgentWorkspace() {
                               setComposerSeed(null);
                               return;
                             }
-                            if (selectedProjectId) openNewChat(selectedProjectId, selectedTaskId ?? undefined);
+                            if (selectedProjectId) void openNewChat(selectedProjectId, selectedTaskId ?? undefined);
                           }}
                         >
                           {composerOpen ? "Cancel" : "New chat"}

--- a/desktop/src/renderer/src/features/coding-agents/project-workspace-model.ts
+++ b/desktop/src/renderer/src/features/coding-agents/project-workspace-model.ts
@@ -11,7 +11,13 @@ export function resolveNewChatRelation(
 ): { projectId: string; taskId?: string } | null {
   if (!workspace || workspace.project.id !== projectId) return null;
   if (!taskId) return { projectId: workspace.project.id };
-  if (!workspace.tasks.items.some((task) => task.id === taskId)) return null;
+  const taskInPage = workspace.tasks.items.some((task) => task.id === taskId);
+  // A selected chat can belong to a paged task outside the bounded tasks page;
+  // taskThreads.items backs both grouped and unlisted task conversations.
+  const taskCarriedByThread = workspace.taskThreads.items.some(
+    (thread) => thread.taskId === taskId,
+  );
+  if (!taskInPage && !taskCarriedByThread) return null;
   return { projectId: workspace.project.id, taskId };
 }
 import type {

--- a/desktop/src/renderer/src/features/coding-agents/project-workspace-model.ts
+++ b/desktop/src/renderer/src/features/coding-agents/project-workspace-model.ts
@@ -3,6 +3,17 @@ import type {
   ProjectAgentWorkspace,
   RuntimeSummary,
 } from "@matrix-os/contracts";
+
+export function resolveNewChatRelation(
+  workspace: ProjectAgentWorkspace | null,
+  projectId: string,
+  taskId?: string,
+): { projectId: string; taskId?: string } | null {
+  if (!workspace || workspace.project.id !== projectId) return null;
+  if (!taskId) return { projectId: workspace.project.id };
+  if (!workspace.tasks.items.some((task) => task.id === taskId)) return null;
+  return { projectId: workspace.project.id, taskId };
+}
 import type {
   CodingAgentWorkspaceResumeState,
   CodingAgentWorkspaceViewMode,

--- a/desktop/src/renderer/src/features/settings/SettingsView.tsx
+++ b/desktop/src/renderer/src/features/settings/SettingsView.tsx
@@ -20,6 +20,7 @@ import IntegrationsSection from "./sections/IntegrationsSection";
 import CronSection from "./sections/CronSection";
 import SystemSection from "./sections/SystemSection";
 import { invoke } from "../../lib/operator";
+import { useUi } from "../../stores/ui";
 
 type SectionId =
   | "account"
@@ -54,8 +55,21 @@ function applyDocumentTheme(next: "dark" | "light" | "system") {
   document.documentElement.setAttribute("data-theme", resolved);
 }
 
+function isSectionId(value: string): value is SectionId {
+  return SECTIONS.some((candidate) => candidate.id === value);
+}
+
 export default function SettingsView() {
   const [section, setSection] = useState<SectionId>("account");
+  const requestedSection = useUi((s) => s.requestedSettingsSection);
+
+  // Deep links (for example the provider recovery CTA) request a section
+  // before opening or focusing the Settings tab; consume it once.
+  useEffect(() => {
+    if (!requestedSection) return;
+    if (isSectionId(requestedSection)) setSection(requestedSection);
+    useUi.getState().clearRequestedSettingsSection();
+  }, [requestedSection]);
 
   useEffect(() => {
     void invoke("state:get", { key: "appearance" })

--- a/desktop/src/renderer/src/stores/coding-agent-project-workspace.ts
+++ b/desktop/src/renderer/src/stores/coding-agent-project-workspace.ts
@@ -257,20 +257,30 @@ export const useCodingAgentProjectWorkspace = create<CodingAgentProjectWorkspace
       projectId,
       taskId,
     ): Promise<{ projectId: string; taskId?: string } | null> => {
-      const immediate = resolveNewChatRelation(
-        useCodingAgentProjectWorkspace.getState().workspace,
-        projectId,
-        taskId,
-      );
+      const attempt = (): { projectId: string; taskId?: string } | null => {
+        const state = useCodingAgentProjectWorkspace.getState();
+        const relation = resolveNewChatRelation(state.workspace, projectId, taskId);
+        if (relation) return relation;
+        // Selection reconciliation can preserve a task outside the bounded
+        // tasks/taskThreads pages (an externally focused conversation). That
+        // selection was already validated against the runtime, so a new chat
+        // for it must resolve even though no page lists the task.
+        if (
+          taskId
+          && state.workspace?.project.id === projectId
+          && state.selectedTaskId === taskId
+          && state.selectedThreadId
+        ) {
+          return { projectId, taskId };
+        }
+        return null;
+      };
+      const immediate = attempt();
       if (immediate) return immediate;
       // The snapshot may not be loaded yet or its task page may be stale; refresh
       // once and retry, but never loop.
       await useCodingAgentProjectWorkspace.getState().refresh();
-      return resolveNewChatRelation(
-        useCodingAgentProjectWorkspace.getState().workspace,
-        projectId,
-        taskId,
-      );
+      return attempt();
     },
 
     selectProject: async (projectId) => {

--- a/desktop/src/renderer/src/stores/coding-agent-project-workspace.ts
+++ b/desktop/src/renderer/src/stores/coding-agent-project-workspace.ts
@@ -7,6 +7,7 @@ import {
 } from "../../../shared/coding-agent-project-workspace";
 import {
   reconcileProjectWorkspaceSelection,
+  resolveNewChatRelation,
   resolveSelectedProjectId,
   type ProjectWorkspaceSelection,
 } from "../features/coding-agents/project-workspace-model";
@@ -23,6 +24,15 @@ interface CodingAgentProjectWorkspaceState extends ProjectWorkspaceSelection {
   error: string | null;
   hydrate: (summary: RuntimeSummary, runtimeScope?: string) => Promise<void>;
   refresh: () => Promise<void>;
+  openCreatedProject: (
+    summary: RuntimeSummary,
+    projectId: string,
+    runtimeScope?: string,
+  ) => Promise<void>;
+  resolveNewChatTarget: (
+    projectId: string,
+    taskId?: string,
+  ) => Promise<{ projectId: string; taskId?: string } | null>;
   selectProject: (projectId: string) => Promise<void>;
   selectTask: (taskId: string) => void;
   selectThread: (threadId: string) => void;
@@ -216,6 +226,50 @@ export const useCodingAgentProjectWorkspace = create<CodingAgentProjectWorkspace
             state.selectedProjectId && state.summary.projects.hasMore,
           ),
         },
+      );
+    },
+
+    openCreatedProject: async (summary, projectId, runtimeScope = summary.runtime.id) => {
+      const generation = ++hydrationGeneration;
+      const state = useCodingAgentProjectWorkspace.getState();
+      const preferred = {
+        selectedProjectId: projectId,
+        selectedTaskId: null,
+        selectedThreadId: null,
+        viewMode: state.viewMode,
+      } satisfies ProjectWorkspaceSelection;
+      set({
+        status: "loading",
+        runtimeId: summary.runtime.id,
+        runtimeScope,
+        summary,
+        workspace: null,
+        error: null,
+        ...preferred,
+      });
+      await loadProjectWorkspace(summary, preferred, generation, {
+        preserveSelectionOnError: true,
+        preserveMissingPreferredProject: true,
+      });
+    },
+
+    resolveNewChatTarget: async (
+      projectId,
+      taskId,
+    ): Promise<{ projectId: string; taskId?: string } | null> => {
+      const immediate = resolveNewChatRelation(
+        useCodingAgentProjectWorkspace.getState().workspace,
+        projectId,
+        taskId,
+      );
+      if (immediate) return immediate;
+      // The snapshot may not be loaded yet or its task page may be stale; refresh
+      // once and retry, but never loop.
+      await useCodingAgentProjectWorkspace.getState().refresh();
+      return resolveNewChatRelation(
+        useCodingAgentProjectWorkspace.getState().workspace,
+        projectId,
+        taskId,
       );
     },
 

--- a/desktop/src/renderer/src/stores/ui.ts
+++ b/desktop/src/renderer/src/stores/ui.ts
@@ -13,6 +13,9 @@ interface UiState {
   paletteOpen: boolean;
   quickOpenOpen: boolean;
   sidebarCollapsed: boolean;
+  // One-shot request for which Settings section the next Settings render
+  // should select (consumed and cleared by SettingsView).
+  requestedSettingsSection: string | null;
   setCreateProjectOpen: (open: boolean) => void;
   openCreateProject: (destination?: "board" | "agents") => void;
   setCreateTaskOpen: (open: boolean) => void;
@@ -22,6 +25,8 @@ interface UiState {
   setQuickOpenOpen: (open: boolean) => void;
   toggleSidebar: () => void;
   setSidebarCollapsed: (collapsed: boolean) => void;
+  requestSettingsSection: (section: string) => void;
+  clearRequestedSettingsSection: () => void;
 }
 
 export const useUi = create<UiState>()((set) => ({
@@ -33,6 +38,7 @@ export const useUi = create<UiState>()((set) => ({
   paletteOpen: false,
   quickOpenOpen: false,
   sidebarCollapsed: false,
+  requestedSettingsSection: null,
   setCreateProjectOpen: (open) => set({
     createProjectOpen: open,
     ...(open ? { createProjectDestination: "board" as const } : {}),
@@ -48,4 +54,6 @@ export const useUi = create<UiState>()((set) => ({
   setQuickOpenOpen: (open) => set({ quickOpenOpen: open }),
   toggleSidebar: () => set((s) => ({ sidebarCollapsed: !s.sidebarCollapsed })),
   setSidebarCollapsed: (collapsed) => set({ sidebarCollapsed: collapsed }),
+  requestSettingsSection: (section) => set({ requestedSettingsSection: section }),
+  clearRequestedSettingsSection: () => set({ requestedSettingsSection: null }),
 }));

--- a/desktop/src/renderer/src/stores/ui.ts
+++ b/desktop/src/renderer/src/stores/ui.ts
@@ -4,6 +4,7 @@ import { create } from "zustand";
 
 interface UiState {
   createProjectOpen: boolean;
+  createProjectDestination: "board" | "agents";
   createTaskOpen: boolean;
   // The board column a new task should default to (set when opening the create
   // dialog from a specific column's "+"). null → default ("todo").
@@ -13,6 +14,7 @@ interface UiState {
   quickOpenOpen: boolean;
   sidebarCollapsed: boolean;
   setCreateProjectOpen: (open: boolean) => void;
+  openCreateProject: (destination?: "board" | "agents") => void;
   setCreateTaskOpen: (open: boolean) => void;
   openCreateTask: (status?: string) => void;
   setComposerOpen: (open: boolean) => void;
@@ -24,13 +26,21 @@ interface UiState {
 
 export const useUi = create<UiState>()((set) => ({
   createProjectOpen: false,
+  createProjectDestination: "board",
   createTaskOpen: false,
   createTaskStatus: null,
   composerOpen: false,
   paletteOpen: false,
   quickOpenOpen: false,
   sidebarCollapsed: false,
-  setCreateProjectOpen: (open) => set({ createProjectOpen: open }),
+  setCreateProjectOpen: (open) => set({
+    createProjectOpen: open,
+    ...(open ? { createProjectDestination: "board" as const } : {}),
+  }),
+  openCreateProject: (destination = "board") => set({
+    createProjectOpen: true,
+    createProjectDestination: destination,
+  }),
   setCreateTaskOpen: (open) => set({ createTaskOpen: open, createTaskStatus: null }),
   openCreateTask: (status) => set({ createTaskOpen: true, createTaskStatus: status ?? null }),
   setComposerOpen: (open) => set({ composerOpen: open }),

--- a/tests/desktop/coding-agent-project-navigator.test.tsx
+++ b/tests/desktop/coding-agent-project-navigator.test.tsx
@@ -77,6 +77,52 @@ function workspaceFixture(): ProjectAgentWorkspace {
 afterEach(cleanup);
 
 describe("AgentProjectNavigator", () => {
+  it("offers recovery by creating a project when the selected computer is empty", () => {
+    const onNewProject = vi.fn();
+    const emptySummary = summaryFixture();
+    emptySummary.projects.items = [];
+    render(
+      <AgentProjectNavigator
+        summary={emptySummary}
+        workspace={null}
+        status="ready"
+        selectedProjectId={null}
+        selectedTaskId={null}
+        selectedThreadId={null}
+        onSelectProject={vi.fn()}
+        onSelectTask={vi.fn()}
+        onSelectThread={vi.fn()}
+        onNewChat={vi.fn()}
+        onNewProject={onNewProject}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Create project" }));
+    expect(onNewProject).toHaveBeenCalledOnce();
+  });
+
+  it("offers provider recovery through Settings", () => {
+    const onOpenSettings = vi.fn();
+    render(
+      <AgentProjectNavigator
+        summary={summaryFixture()}
+        workspace={workspaceFixture()}
+        status="ready"
+        selectedProjectId="matrix-os"
+        selectedTaskId={null}
+        selectedThreadId={null}
+        onSelectProject={vi.fn()}
+        onSelectTask={vi.fn()}
+        onSelectThread={vi.fn()}
+        onNewChat={vi.fn()}
+        onOpenSettings={onOpenSettings}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Open agent settings" }));
+    expect(onOpenSettings).toHaveBeenCalledOnce();
+  });
+
   it("creates Matrix projects from the Agents navigator", () => {
     const onNewProject = vi.fn();
     render(

--- a/tests/desktop/coding-agent-project-workspace-store.test.ts
+++ b/tests/desktop/coding-agent-project-workspace-store.test.ts
@@ -526,6 +526,37 @@ describe("coding-agent project workspace store", () => {
     });
   });
 
+  it("resolves a new chat target for a preserved out-of-page task selection", async () => {
+    const invoke = vi.fn(async () => {
+      throw new Error("workspace refresh should not be requested");
+    });
+    Object.defineProperty(window, "operator", {
+      configurable: true,
+      value: { invoke, on: vi.fn(() => () => undefined) },
+    });
+    // An externally focused conversation can select a task outside the bounded
+    // tasks and taskThreads pages; selection reconciliation preserved it, so a
+    // new chat for that selection must still resolve.
+    useCodingAgentProjectWorkspace.setState({
+      status: "ready",
+      runtimeId: "rt_primary",
+      runtimeScope: "rt_primary",
+      summary: summary("rt_primary", "matrix-os", "Matrix OS"),
+      workspace: workspace("matrix-os", "task_auth", "thread_plan"),
+      selectedProjectId: "matrix-os",
+      selectedTaskId: "task_external",
+      selectedThreadId: "thread_external",
+    });
+
+    const relation = await useCodingAgentProjectWorkspace.getState().resolveNewChatTarget(
+      "matrix-os",
+      "task_external",
+    );
+
+    expect(relation).toEqual({ projectId: "matrix-os", taskId: "task_external" });
+    expect(invoke).not.toHaveBeenCalledWith("runtime:get-project-workspace", expect.anything());
+  });
+
   it("resolves a new chat target immediately when the current workspace already lists it", async () => {
     const invoke = vi.fn(async () => {
       throw new Error("workspace refresh should not be requested");

--- a/tests/desktop/coding-agent-project-workspace-store.test.ts
+++ b/tests/desktop/coding-agent-project-workspace-store.test.ts
@@ -526,6 +526,185 @@ describe("coding-agent project workspace store", () => {
     });
   });
 
+  it("resolves a new chat target immediately when the current workspace already lists it", async () => {
+    const invoke = vi.fn(async () => {
+      throw new Error("workspace refresh should not be requested");
+    });
+    Object.defineProperty(window, "operator", {
+      configurable: true,
+      value: { invoke, on: vi.fn(() => () => undefined) },
+    });
+    useCodingAgentProjectWorkspace.setState({
+      status: "ready",
+      runtimeId: "rt_primary",
+      runtimeScope: "rt_primary",
+      summary: summary("rt_primary", "matrix-os", "Matrix OS"),
+      workspace: workspace("matrix-os", "task_auth", "thread_plan"),
+      selectedProjectId: "matrix-os",
+      selectedTaskId: "task_auth",
+      selectedThreadId: "thread_plan",
+    });
+
+    const relation = await useCodingAgentProjectWorkspace.getState().resolveNewChatTarget(
+      "matrix-os",
+      "task_auth",
+    );
+
+    expect(relation).toEqual({ projectId: "matrix-os", taskId: "task_auth" });
+    expect(invoke).not.toHaveBeenCalledWith("runtime:get-project-workspace", expect.anything());
+  });
+
+  it("refreshes the workspace once and resolves a stale new chat target", async () => {
+    const staleWorkspace = workspace("matrix-os", "task_auth", "thread_plan");
+    const refreshedWorkspace = workspace("matrix-os", "task_auth", "thread_plan");
+    refreshedWorkspace.tasks.items.push({
+      ...refreshedWorkspace.tasks.items[0]!,
+      id: "task_paged",
+      title: "Paged task",
+    });
+    let workspaceRequests = 0;
+    const invoke = vi.fn(async (channel: string) => {
+      if (channel === "state:get") return { value: null };
+      if (channel === "state:set") return { ok: true };
+      if (channel === "runtime:get-project-workspace") {
+        workspaceRequests += 1;
+        return refreshedWorkspace;
+      }
+      throw new Error(`unexpected channel ${channel}`);
+    });
+    Object.defineProperty(window, "operator", {
+      configurable: true,
+      value: { invoke, on: vi.fn(() => () => undefined) },
+    });
+    useCodingAgentProjectWorkspace.setState({
+      status: "ready",
+      runtimeId: "rt_primary",
+      runtimeScope: "rt_primary",
+      summary: summary("rt_primary", "matrix-os", "Matrix OS"),
+      workspace: staleWorkspace,
+      selectedProjectId: "matrix-os",
+      selectedTaskId: "task_paged",
+      selectedThreadId: null,
+    });
+
+    const relation = await useCodingAgentProjectWorkspace.getState().resolveNewChatTarget(
+      "matrix-os",
+      "task_paged",
+    );
+
+    expect(workspaceRequests).toBe(1);
+    expect(relation).toEqual({ projectId: "matrix-os", taskId: "task_paged" });
+  });
+
+  it("returns null after a single bounded refresh when the target stays unresolved", async () => {
+    const projectWorkspace = workspace("matrix-os", "task_auth", "thread_plan");
+    let workspaceRequests = 0;
+    const invoke = vi.fn(async (channel: string) => {
+      if (channel === "state:get") return { value: null };
+      if (channel === "state:set") return { ok: true };
+      if (channel === "runtime:get-project-workspace") {
+        workspaceRequests += 1;
+        return projectWorkspace;
+      }
+      throw new Error(`unexpected channel ${channel}`);
+    });
+    Object.defineProperty(window, "operator", {
+      configurable: true,
+      value: { invoke, on: vi.fn(() => () => undefined) },
+    });
+    useCodingAgentProjectWorkspace.setState({
+      status: "ready",
+      runtimeId: "rt_primary",
+      runtimeScope: "rt_primary",
+      summary: summary("rt_primary", "matrix-os", "Matrix OS"),
+      workspace: projectWorkspace,
+      selectedProjectId: "matrix-os",
+      selectedTaskId: "task_missing",
+      selectedThreadId: null,
+    });
+
+    const relation = await useCodingAgentProjectWorkspace.getState().resolveNewChatTarget(
+      "matrix-os",
+      "task_missing",
+    );
+
+    expect(relation).toBeNull();
+    expect(workspaceRequests).toBe(1);
+  });
+
+  it("opens a freshly created project and lands the navigator on it", async () => {
+    const createdSummary = summary("rt_primary", "matrix-os", "Matrix OS");
+    createdSummary.projects.items.push({
+      id: "desktop",
+      label: "Desktop",
+      status: "available",
+      taskCount: 0,
+      threadCount: 0,
+      attentionCount: 0,
+    });
+    const desktopWorkspace = workspace("desktop", "task_start", "thread_start");
+    const invoke = vi.fn(async (channel: string, payload: unknown) => {
+      if (channel === "state:get") return { value: null };
+      if (channel === "state:set") return { ok: true };
+      if (channel === "runtime:get-project-workspace") {
+        expect(payload).toEqual({ projectId: "desktop" });
+        return desktopWorkspace;
+      }
+      throw new Error(`unexpected channel ${channel}`);
+    });
+    Object.defineProperty(window, "operator", {
+      configurable: true,
+      value: { invoke, on: vi.fn(() => () => undefined) },
+    });
+
+    await useCodingAgentProjectWorkspace.getState().openCreatedProject(
+      createdSummary,
+      "desktop",
+      "operator|https://app.matrix-os.com|primary",
+    );
+
+    expect(useCodingAgentProjectWorkspace.getState()).toMatchObject({
+      status: "ready",
+      runtimeScope: "operator|https://app.matrix-os.com|primary",
+      selectedProjectId: "desktop",
+    });
+    expect(useCodingAgentProjectWorkspace.getState().workspace?.project.id).toBe("desktop");
+  });
+
+  it("surfaces a workspace error state when opening a created project fails to load", async () => {
+    const createdSummary = summary("rt_primary", "matrix-os", "Matrix OS");
+    createdSummary.projects.items.push({
+      id: "desktop",
+      label: "Desktop",
+      status: "available",
+      taskCount: 0,
+      threadCount: 0,
+      attentionCount: 0,
+    });
+    const invoke = vi.fn(async (channel: string) => {
+      if (channel === "state:get") return { value: null };
+      if (channel === "state:set") return { ok: true };
+      if (channel === "runtime:get-project-workspace") throw new Error("temporary outage");
+      throw new Error(`unexpected channel ${channel}`);
+    });
+    Object.defineProperty(window, "operator", {
+      configurable: true,
+      value: { invoke, on: vi.fn(() => () => undefined) },
+    });
+
+    await useCodingAgentProjectWorkspace.getState().openCreatedProject(
+      createdSummary,
+      "desktop",
+      "operator|https://app.matrix-os.com|primary",
+    );
+
+    expect(useCodingAgentProjectWorkspace.getState()).toMatchObject({
+      status: "error",
+      selectedProjectId: "desktop",
+      error: "Project workspace unavailable",
+    });
+  });
+
   it("DT-008 switches view mode without changing project, task, or chat identity", () => {
     const invoke = vi.fn().mockResolvedValue({ ok: true });
     Object.defineProperty(window, "operator", {

--- a/tests/desktop/coding-agent-project-workspace.test.ts
+++ b/tests/desktop/coding-agent-project-workspace.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import type { ProjectAgentWorkspace, RuntimeSummary } from "@matrix-os/contracts";
 import {
+  resolveNewChatRelation,
   groupProjectWorkspaceThreads,
   reconcileProjectWorkspaceSelection,
   resolveSelectedProjectId,
@@ -123,5 +124,14 @@ describe("coding-agent project workspace model", () => {
       "thread_plan",
       "thread_fix",
     ]);
+  });
+
+  it("accepts only the canonical workspace project slug and one of its tasks", () => {
+    expect(resolveNewChatRelation(workspace(), "matrix-os", "task_auth")).toEqual({
+      projectId: "matrix-os",
+      taskId: "task_auth",
+    });
+    expect(resolveNewChatRelation(workspace(), "proj_legacy", "task_auth")).toBeNull();
+    expect(resolveNewChatRelation(workspace(), "matrix-os", "task_other")).toBeNull();
   });
 });

--- a/tests/desktop/coding-agent-project-workspace.test.ts
+++ b/tests/desktop/coding-agent-project-workspace.test.ts
@@ -134,4 +134,23 @@ describe("coding-agent project workspace model", () => {
     expect(resolveNewChatRelation(workspace(), "proj_legacy", "task_auth")).toBeNull();
     expect(resolveNewChatRelation(workspace(), "matrix-os", "task_other")).toBeNull();
   });
+
+  it("accepts a selected paged task carried by an unlisted task thread", () => {
+    const paged = workspace();
+    paged.taskThreads = {
+      ...paged.taskThreads,
+      items: [
+        ...paged.taskThreads.items,
+        thread("thread_paged", "Paged task chat", "task_paged"),
+      ],
+      hasMore: true,
+    };
+    // task_paged is outside the bounded tasks page but a visible thread carries it.
+    expect(resolveNewChatRelation(paged, "matrix-os", "task_paged")).toEqual({
+      projectId: "matrix-os",
+      taskId: "task_paged",
+    });
+    // A task neither in the page nor carried by any thread is still rejected.
+    expect(resolveNewChatRelation(paged, "matrix-os", "task_missing")).toBeNull();
+  });
 });

--- a/tests/desktop/coding-agent-workspace.test.tsx
+++ b/tests/desktop/coding-agent-workspace.test.tsx
@@ -14,6 +14,12 @@ import type { ApiClient } from "../../desktop/src/renderer/src/lib/api";
 import { useBoard } from "../../desktop/src/renderer/src/stores/board";
 import { useConnection } from "../../desktop/src/renderer/src/stores/connection";
 import { useTabs } from "../../desktop/src/renderer/src/stores/tabs";
+import { toast } from "sonner";
+
+vi.mock("sonner", () => ({
+  toast: { error: vi.fn(), success: vi.fn(), message: vi.fn() },
+  Toaster: () => null,
+}));
 
 async function selectInspectorTab(name: "Changes" | "Terminal" | "Preview" | "Activity") {
   fireEvent.click(await screen.findByRole("tab", { name: new RegExp(`^${name}\\b`) }));
@@ -3901,5 +3907,120 @@ describe("AgentWorkspace", () => {
     fireEvent.click(screen.getByRole("button", { name: "Retry" }));
     await selectInspectorTab("Activity");
     await screen.findByText("Fix settings route");
+  });
+
+  function projectWorkspaceReadySummary() {
+    return {
+      runtime: { id: "rt_primary", label: "Primary", status: "available" },
+      capabilities: [
+        { id: "codingAgentsRuntimeSummary", enabled: true },
+        { id: "codingAgentsProjectWorkspace", enabled: true },
+        { id: "codingAgentsConversationView", enabled: true },
+        { id: "codingAgentsThreadCreate", enabled: true },
+        { id: "codingAgentsSameThreadTurns", enabled: true },
+        { id: "codingAgentsReview", enabled: true },
+      ],
+      providers: [
+        {
+          id: "codex",
+          kind: "codex",
+          displayName: "Codex",
+          availability: "available",
+          installStatus: "installed",
+          authStatus: "authenticated",
+          supportedModes: ["default"],
+          defaultMode: "default",
+          setupActions: [],
+        },
+      ],
+      projects: {
+        items: [{ id: "matrix-os", label: "Matrix OS", status: "available", taskCount: 1, threadCount: 0, attentionCount: 0 }],
+        hasMore: false,
+        limit: 20,
+      },
+      activeThreads: { items: [], hasMore: false, limit: 20 },
+      attentionThreads: { items: [], hasMore: false, limit: 20 },
+      terminalSessions: { items: [], hasMore: false, limit: 20 },
+      previewSessions: { items: [], hasMore: false, limit: 50 },
+      recentActivity: { items: [], hasMore: false, limit: 20 },
+      limits: { maxPromptBytes: 16384, maxAttachmentCount: 8, maxTerminalInputBytes: 8192, maxListItems: 20 },
+      serverTime: "2026-07-06T00:03:00.000Z",
+    };
+  }
+
+  function projectWorkspaceReadyFixture() {
+    return {
+      project: { id: "matrix-os", label: "Matrix OS", status: "available", taskCount: 1, threadCount: 0, attentionCount: 0 },
+      tasks: {
+        items: [{
+          id: "task_auth",
+          projectId: "matrix-os",
+          title: "Harden authentication",
+          status: "running",
+          priority: "high",
+          order: 0,
+          threadCount: 0,
+          activeThreadCount: 0,
+          attentionCount: 0,
+        }],
+        hasMore: false,
+        limit: 100,
+      },
+      projectThreads: { items: [], hasMore: false, limit: 100 },
+      taskThreads: { items: [], hasMore: false, limit: 100 },
+      updatedAt: "2026-07-10T12:00:00.000Z",
+    };
+  }
+
+  function wireProjectWorkspaceReadyIpc() {
+    window.operator.invoke = vi.fn((channel: string) => {
+      if (channel === "runtime:get-summary") return Promise.resolve(projectWorkspaceReadySummary());
+      if (channel === "runtime:get-project-workspace") return Promise.resolve(projectWorkspaceReadyFixture());
+      if (channel === "runtime:get-reviews") return Promise.resolve(reviewsFixture());
+      if (channel === "runtime:get-notification-preferences") {
+        return Promise.resolve({ attentionPush: { approval: true, input: true, failed: true, completed: true } });
+      }
+      if (channel === "state:get") return Promise.resolve({ value: null });
+      if (channel === "state:set") return Promise.resolve({ ok: true });
+      return Promise.reject(new Error(`unexpected channel ${channel}`));
+    });
+  }
+
+  it("opens the composer after a stale toolbar new chat resolves against a refreshed workspace", async () => {
+    vi.mocked(toast.error).mockClear();
+    wireProjectWorkspaceReadyIpc();
+
+    render(<AgentWorkspace />);
+
+    const newChat = await screen.findByRole("button", { name: "New chat in selected project" });
+    const resolveNewChatTarget = vi.fn(async () => ({ projectId: "matrix-os", taskId: "task_auth" }));
+    act(() => {
+      useCodingAgentProjectWorkspace.setState({ resolveNewChatTarget });
+    });
+
+    fireEvent.click(newChat);
+
+    expect(await screen.findByLabelText("Agent run prompt")).toBeTruthy();
+    expect(resolveNewChatTarget).toHaveBeenCalledWith("matrix-os", undefined);
+    expect(toast.error).not.toHaveBeenCalled();
+  });
+
+  it("surfaces a visible error when a toolbar new chat cannot be resolved after refreshing", async () => {
+    vi.mocked(toast.error).mockClear();
+    wireProjectWorkspaceReadyIpc();
+
+    render(<AgentWorkspace />);
+
+    const newChat = await screen.findByRole("button", { name: "New chat in selected project" });
+    const resolveNewChatTarget = vi.fn(async () => null);
+    act(() => {
+      useCodingAgentProjectWorkspace.setState({ resolveNewChatTarget });
+    });
+
+    fireEvent.click(newChat);
+
+    await waitFor(() => expect(toast.error).toHaveBeenCalled());
+    expect(screen.queryByLabelText("Agent run prompt")).toBeNull();
+    expect(screen.getByRole("button", { name: "New chat in selected project" })).toBeTruthy();
   });
 });

--- a/tests/desktop/coding-agent-workspace.test.tsx
+++ b/tests/desktop/coding-agent-workspace.test.tsx
@@ -3989,6 +3989,10 @@ describe("AgentWorkspace", () => {
   it("opens the composer after a stale toolbar new chat resolves against a refreshed workspace", async () => {
     vi.mocked(toast.error).mockClear();
     wireProjectWorkspaceReadyIpc();
+    // Seed the resolver before render so the component never observes the
+    // store's real implementation.
+    const resolveNewChatTarget = vi.fn(async () => ({ projectId: "matrix-os", taskId: "task_auth" }));
+    useCodingAgentProjectWorkspace.setState({ resolveNewChatTarget });
 
     render(<AgentWorkspace />);
 
@@ -3996,10 +4000,6 @@ describe("AgentWorkspace", () => {
     // The button is disabled until the async project-workspace hydration
     // populates selectedProjectId; clicking earlier is silently ignored.
     await waitFor(() => expect(newChat.hasAttribute("disabled")).toBe(false));
-    const resolveNewChatTarget = vi.fn(async () => ({ projectId: "matrix-os", taskId: "task_auth" }));
-    act(() => {
-      useCodingAgentProjectWorkspace.setState({ resolveNewChatTarget });
-    });
 
     fireEvent.click(newChat);
 
@@ -4011,6 +4011,10 @@ describe("AgentWorkspace", () => {
   it("surfaces a visible error when a toolbar new chat cannot be resolved after refreshing", async () => {
     vi.mocked(toast.error).mockClear();
     wireProjectWorkspaceReadyIpc();
+    // Seed the resolver before render so the component never observes the
+    // store's real implementation.
+    const resolveNewChatTarget = vi.fn(async () => null);
+    useCodingAgentProjectWorkspace.setState({ resolveNewChatTarget });
 
     render(<AgentWorkspace />);
 
@@ -4018,10 +4022,6 @@ describe("AgentWorkspace", () => {
     // The button is disabled until the async project-workspace hydration
     // populates selectedProjectId; clicking earlier is silently ignored.
     await waitFor(() => expect(newChat.hasAttribute("disabled")).toBe(false));
-    const resolveNewChatTarget = vi.fn(async () => null);
-    act(() => {
-      useCodingAgentProjectWorkspace.setState({ resolveNewChatTarget });
-    });
 
     fireEvent.click(newChat);
 

--- a/tests/desktop/coding-agent-workspace.test.tsx
+++ b/tests/desktop/coding-agent-workspace.test.tsx
@@ -3993,6 +3993,9 @@ describe("AgentWorkspace", () => {
     render(<AgentWorkspace />);
 
     const newChat = await screen.findByRole("button", { name: "New chat in selected project" });
+    // The button is disabled until the async project-workspace hydration
+    // populates selectedProjectId; clicking earlier is silently ignored.
+    await waitFor(() => expect(newChat.hasAttribute("disabled")).toBe(false));
     const resolveNewChatTarget = vi.fn(async () => ({ projectId: "matrix-os", taskId: "task_auth" }));
     act(() => {
       useCodingAgentProjectWorkspace.setState({ resolveNewChatTarget });
@@ -4012,6 +4015,9 @@ describe("AgentWorkspace", () => {
     render(<AgentWorkspace />);
 
     const newChat = await screen.findByRole("button", { name: "New chat in selected project" });
+    // The button is disabled until the async project-workspace hydration
+    // populates selectedProjectId; clicking earlier is silently ignored.
+    await waitFor(() => expect(newChat.hasAttribute("disabled")).toBe(false));
     const resolveNewChatTarget = vi.fn(async () => null);
     act(() => {
       useCodingAgentProjectWorkspace.setState({ resolveNewChatTarget });

--- a/tests/desktop/create-project-dialog.test.tsx
+++ b/tests/desktop/create-project-dialog.test.tsx
@@ -8,6 +8,8 @@ import type { Project } from "../../desktop/src/renderer/src/stores/board";
 import { useBoard } from "../../desktop/src/renderer/src/stores/board";
 import { useConnection } from "../../desktop/src/renderer/src/stores/connection";
 import { useTabs } from "../../desktop/src/renderer/src/stores/tabs";
+import { useUi } from "../../desktop/src/renderer/src/stores/ui";
+import { useCodingAgentWorkspace } from "../../desktop/src/renderer/src/stores/coding-agent-workspace";
 
 describe("CreateProjectDialog", () => {
   beforeEach(() => {
@@ -27,6 +29,7 @@ describe("CreateProjectDialog", () => {
       error: null,
     });
     useTabs.setState({ tabs: [], activeTabId: null });
+    useUi.setState({ createProjectDestination: "board" });
   });
 
   afterEach(() => {
@@ -96,5 +99,25 @@ describe("CreateProjectDialog", () => {
       mode: "folder",
       path: "workspaces/customer-app",
     }));
+  });
+
+  it("returns an Agents-created project to chats without opening a board tab", async () => {
+    const project = { slug: "desktop", name: "Desktop" };
+    const createProject = vi.fn(async () => project);
+    const selectProject = vi.fn(async () => undefined);
+    const refresh = vi.fn(async () => undefined);
+    const openTab = vi.fn();
+    useUi.setState({ createProjectDestination: "agents" });
+    useBoard.setState({ createProject, selectProject });
+    useCodingAgentWorkspace.setState({ refresh });
+    useTabs.setState({ openTab });
+
+    render(<CreateProjectDialog open onClose={vi.fn()} />);
+    fireEvent.change(screen.getByPlaceholderText("Project name"), { target: { value: "Desktop" } });
+    fireEvent.click(screen.getByRole("button", { name: "Create" }));
+
+    await waitFor(() => expect(refresh).toHaveBeenCalledOnce());
+    expect(selectProject).not.toHaveBeenCalled();
+    expect(openTab).not.toHaveBeenCalled();
   });
 });

--- a/tests/desktop/create-project-dialog.test.tsx
+++ b/tests/desktop/create-project-dialog.test.tsx
@@ -123,6 +123,35 @@ describe("CreateProjectDialog", () => {
     expect(openTab).not.toHaveBeenCalled();
   });
 
+  it("keeps the dialog open with an error when the Agents workspace refresh fails after create", async () => {
+    const project = { slug: "desktop", name: "Desktop" };
+    const createProject = vi.fn(async () => project);
+    // The workspace store catches refresh failures internally and clears the
+    // summary, so the dialog observes a resolved refresh with a null summary.
+    const refresh = vi.fn(async () => {
+      useCodingAgentWorkspace.setState({ summary: null });
+    });
+    const openCreatedProject = vi.fn(async () => undefined);
+    const openTab = vi.fn();
+    const onClose = vi.fn();
+    useUi.setState({ createProjectDestination: "agents" });
+    useBoard.setState({ createProject, selectProject: vi.fn(async () => undefined) });
+    useCodingAgentWorkspace.setState({ refresh });
+    useCodingAgentProjectWorkspace.setState({ openCreatedProject });
+    useTabs.setState({ openTab });
+
+    render(<CreateProjectDialog open onClose={onClose} />);
+    fireEvent.change(screen.getByPlaceholderText("Project name"), { target: { value: "Desktop" } });
+    fireEvent.click(screen.getByRole("button", { name: "Create" }));
+
+    await waitFor(() => expect(refresh).toHaveBeenCalledOnce());
+    await waitFor(() => expect(screen.getByText(/project was created/i)).toBeTruthy());
+    expect(openCreatedProject).not.toHaveBeenCalled();
+    expect(openTab).not.toHaveBeenCalled();
+    expect(onClose).not.toHaveBeenCalled();
+    expect(screen.getByRole("dialog")).toBeTruthy();
+  });
+
   it("lands the coding-agent navigator on the project created from the Agents empty state", async () => {
     const project = { slug: "desktop", name: "Desktop" };
     const summary = { runtime: { id: "rt_primary" } } as never;

--- a/tests/desktop/create-project-dialog.test.tsx
+++ b/tests/desktop/create-project-dialog.test.tsx
@@ -31,7 +31,7 @@ describe("CreateProjectDialog", () => {
     });
     useTabs.setState({ tabs: [], activeTabId: null });
     useUi.setState({ createProjectDestination: "board" });
-    useCodingAgentWorkspace.setState({ summary: null });
+    useCodingAgentWorkspace.setState({ summary: null, status: "idle" });
   });
 
   afterEach(() => {
@@ -150,6 +150,32 @@ describe("CreateProjectDialog", () => {
     expect(openTab).not.toHaveBeenCalled();
     expect(onClose).not.toHaveBeenCalled();
     expect(screen.getByRole("dialog")).toBeTruthy();
+  });
+
+  it("treats a failed refresh with a stale summary like a missing one", async () => {
+    const project = { slug: "desktop", name: "Desktop" };
+    const staleSummary = { runtime: { id: "rt_primary" } } as never;
+    const createProject = vi.fn(async () => project);
+    // A failed refresh records status "error" but keeps the previous summary;
+    // the dialog must not treat that as success and select against stale data.
+    const refresh = vi.fn(async () => {
+      useCodingAgentWorkspace.setState({ status: "error", summary: staleSummary });
+    });
+    const openCreatedProject = vi.fn(async () => undefined);
+    const onClose = vi.fn();
+    useUi.setState({ createProjectDestination: "agents" });
+    useBoard.setState({ createProject, selectProject: vi.fn(async () => undefined) });
+    useCodingAgentWorkspace.setState({ refresh, summary: staleSummary, status: "ready" });
+    useCodingAgentProjectWorkspace.setState({ openCreatedProject });
+
+    render(<CreateProjectDialog open onClose={onClose} />);
+    fireEvent.change(screen.getByPlaceholderText("Project name"), { target: { value: "Desktop" } });
+    fireEvent.click(screen.getByRole("button", { name: "Create" }));
+
+    await waitFor(() => expect(refresh).toHaveBeenCalledOnce());
+    await waitFor(() => expect(screen.getByText(/project was created/i)).toBeTruthy());
+    expect(openCreatedProject).not.toHaveBeenCalled();
+    expect(onClose).not.toHaveBeenCalled();
   });
 
   it("lands the coding-agent navigator on the project created from the Agents empty state", async () => {

--- a/tests/desktop/create-project-dialog.test.tsx
+++ b/tests/desktop/create-project-dialog.test.tsx
@@ -10,6 +10,7 @@ import { useConnection } from "../../desktop/src/renderer/src/stores/connection"
 import { useTabs } from "../../desktop/src/renderer/src/stores/tabs";
 import { useUi } from "../../desktop/src/renderer/src/stores/ui";
 import { useCodingAgentWorkspace } from "../../desktop/src/renderer/src/stores/coding-agent-workspace";
+import { useCodingAgentProjectWorkspace } from "../../desktop/src/renderer/src/stores/coding-agent-project-workspace";
 
 describe("CreateProjectDialog", () => {
   beforeEach(() => {
@@ -30,6 +31,7 @@ describe("CreateProjectDialog", () => {
     });
     useTabs.setState({ tabs: [], activeTabId: null });
     useUi.setState({ createProjectDestination: "board" });
+    useCodingAgentWorkspace.setState({ summary: null });
   });
 
   afterEach(() => {
@@ -118,6 +120,32 @@ describe("CreateProjectDialog", () => {
 
     await waitFor(() => expect(refresh).toHaveBeenCalledOnce());
     expect(selectProject).not.toHaveBeenCalled();
+    expect(openTab).not.toHaveBeenCalled();
+  });
+
+  it("lands the coding-agent navigator on the project created from the Agents empty state", async () => {
+    const project = { slug: "desktop", name: "Desktop" };
+    const summary = { runtime: { id: "rt_primary" } } as never;
+    const createProject = vi.fn(async () => project);
+    const refresh = vi.fn(async () => undefined);
+    const openCreatedProject = vi.fn(async () => undefined);
+    const openTab = vi.fn();
+    useUi.setState({ createProjectDestination: "agents" });
+    useBoard.setState({ createProject, selectProject: vi.fn(async () => undefined) });
+    useCodingAgentWorkspace.setState({ refresh, summary });
+    useCodingAgentProjectWorkspace.setState({ openCreatedProject });
+    useTabs.setState({ openTab });
+
+    render(<CreateProjectDialog open onClose={vi.fn()} />);
+    fireEvent.change(screen.getByPlaceholderText("Project name"), { target: { value: "Desktop" } });
+    fireEvent.click(screen.getByRole("button", { name: "Create" }));
+
+    await waitFor(() => expect(refresh).toHaveBeenCalledOnce());
+    await waitFor(() => expect(openCreatedProject).toHaveBeenCalledWith(
+      summary,
+      "desktop",
+      "operator|https://platform.test|primary",
+    ));
     expect(openTab).not.toHaveBeenCalled();
   });
 });

--- a/tests/desktop/project-task-chat-flow.test.ts
+++ b/tests/desktop/project-task-chat-flow.test.ts
@@ -1,0 +1,114 @@
+// @vitest-environment jsdom
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { defaultAgentThreadComposerDraft, type AgentThreadSnapshot, type RuntimeSummary } from "@matrix-os/contracts";
+import { useBoard } from "../../desktop/src/renderer/src/stores/board";
+import { useCodingAgentProjectWorkspace } from "../../desktop/src/renderer/src/stores/coding-agent-project-workspace";
+import { useCodingAgentWorkspace } from "../../desktop/src/renderer/src/stores/coding-agent-workspace";
+
+const NOW = "2026-07-12T12:00:00.000Z";
+
+function summary(): RuntimeSummary {
+  return {
+    runtime: { id: "rt_preview", label: "Preview", status: "available" },
+    capabilities: [{ id: "codingAgentsThreadCreate", enabled: true }],
+    providers: [{
+      id: "codex",
+      kind: "codex",
+      displayName: "Codex",
+      availability: "available",
+      installStatus: "installed",
+      authStatus: "authenticated",
+      supportedModes: ["default"],
+      defaultMode: "default",
+      setupActions: [],
+    }],
+    projects: { items: [{ id: "desktop", label: "Desktop", status: "available", taskCount: 1, threadCount: 0, attentionCount: 0 }], hasMore: false, limit: 20 },
+    activeThreads: { items: [], hasMore: false, limit: 20 },
+    attentionThreads: { items: [], hasMore: false, limit: 20 },
+    terminalSessions: { items: [], hasMore: false, limit: 20 },
+    previewSessions: { items: [], hasMore: false, limit: 50 },
+    recentActivity: { items: [], hasMore: false, limit: 20 },
+    limits: { maxPromptBytes: 24_000, maxAttachmentCount: 8, maxTerminalInputBytes: 8_192, maxListItems: 20 },
+    serverTime: NOW,
+  };
+}
+
+function snapshot(id: string, prompt: string): AgentThreadSnapshot {
+  return {
+    thread: {
+      id,
+      providerId: "codex",
+      title: prompt,
+      status: "queued",
+      attention: "none",
+      projectId: "desktop",
+      taskId: "task_build",
+      createdAt: NOW,
+      updatedAt: NOW,
+    },
+    events: { items: [], hasMore: false, limit: 200 },
+  };
+}
+
+describe("project to task to chat flow", () => {
+  beforeEach(() => {
+    useBoard.setState(useBoard.getInitialState(), true);
+    useCodingAgentProjectWorkspace.setState(useCodingAgentProjectWorkspace.getInitialState(), true);
+    useCodingAgentWorkspace.setState(useCodingAgentWorkspace.getInitialState(), true);
+  });
+
+  it("creates canonical project/task routes, opens multiple task chats, and reopens either chat", async () => {
+    const api = {
+      get: vi.fn(async (path: string) => path === "/api/workspace/projects"
+        ? { projects: [{ slug: "desktop", name: "Desktop", localPath: "/home/matrix/home/projects/desktop" }] }
+        : { tasks: [], nextCursor: null }),
+      post: vi.fn(async (path: string) => path === "/api/projects"
+        ? { project: { slug: "desktop", name: "Desktop", localPath: "/home/matrix/home/projects/desktop" } }
+        : { task: { id: "task_build", projectSlug: "desktop", title: "Build chat", status: "todo", priority: "normal", order: 0, previewIds: [], tags: [] } }),
+    } as never;
+
+    const project = await useBoard.getState().createProject(api, { name: "Desktop", mode: "scratch" });
+    const task = await useBoard.getState().createTask(api, project!.slug, { title: "Build chat" });
+    expect(api.post).toHaveBeenCalledWith("/api/projects", { name: "Desktop", mode: "scratch" });
+    expect(api.post).toHaveBeenCalledWith("/api/projects/desktop/tasks", { title: "Build chat" });
+
+    const runtimeSummary = summary();
+    useCodingAgentWorkspace.setState({ summary: runtimeSummary, status: "ready" });
+    useCodingAgentProjectWorkspace.setState({
+      status: "ready",
+      summary: runtimeSummary,
+      selectedProjectId: "desktop",
+      selectedTaskId: task!.id,
+      workspace: {
+        project: runtimeSummary.projects.items[0]!,
+        tasks: { items: [{ id: task!.id, projectId: "desktop", title: task!.title, status: "todo", priority: "normal", order: 0, threadCount: 0, activeThreadCount: 0, attentionCount: 0 }], hasMore: false, limit: 100 },
+        projectThreads: { items: [], hasMore: false, limit: 100 },
+        taskThreads: { items: [], hasMore: false, limit: 100 },
+        updatedAt: NOW,
+      },
+    });
+
+    const created = [snapshot("thread_one", "First chat"), snapshot("thread_two", "Second chat")];
+    window.operator = {
+      invoke: vi.fn(async (channel: string, request: unknown) => {
+        if (channel === "runtime:create-thread") return created.shift()!;
+        if (channel === "runtime:get-thread-snapshot") {
+          return snapshot((request as { threadId: string }).threadId, "Reopened chat");
+        }
+        if (channel === "runtime:subscribe-thread-events" || channel === "runtime:unsubscribe-thread-events") return { ok: true };
+        throw new Error(`unexpected ${channel}`);
+      }),
+      on: vi.fn(() => () => undefined),
+    };
+
+    const base = defaultAgentThreadComposerDraft(runtimeSummary);
+    const firstId = await useCodingAgentWorkspace.getState().createThread({ ...base, prompt: "First chat", projectId: "desktop", taskId: task!.id });
+    const secondId = await useCodingAgentWorkspace.getState().createThread({ ...base, prompt: "Second chat", projectId: "desktop", taskId: task!.id });
+    expect([firstId, secondId]).toEqual(["thread_one", "thread_two"]);
+    expect(window.operator.invoke).toHaveBeenCalledWith("runtime:create-thread", expect.objectContaining({ projectId: "desktop", taskId: "task_build" }));
+
+    await useCodingAgentWorkspace.getState().loadThreadSnapshot(firstId!);
+    expect(useCodingAgentWorkspace.getState()).toMatchObject({ activeThreadId: "thread_one", threadSnapshot: { thread: { id: "thread_one" } } });
+  });
+});

--- a/tests/desktop/settings-view.test.tsx
+++ b/tests/desktop/settings-view.test.tsx
@@ -5,6 +5,7 @@ import { cleanup, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import SettingsView from "../../desktop/src/renderer/src/features/settings/SettingsView";
 import { useConnection } from "../../desktop/src/renderer/src/stores/connection";
+import { useUi } from "../../desktop/src/renderer/src/stores/ui";
 
 describe("SettingsView", () => {
   beforeEach(() => {
@@ -40,5 +41,24 @@ describe("SettingsView", () => {
     await waitFor(() => expect(document.documentElement.getAttribute("data-theme")).toBe("light"));
     expect(window.operator.invoke).toHaveBeenCalledWith("state:get", { key: "appearance" });
     expect(screen.getByRole("button", { name: "Computers" })).not.toBeNull();
+  });
+
+  it("opens the requested section and consumes the deep-link request", async () => {
+    useUi.getState().requestSettingsSection("agent");
+
+    render(<SettingsView />);
+
+    // The Agent (Hermes) section renders instead of the default Account.
+    await waitFor(() => expect(screen.getByRole("heading", { name: "Agent (Hermes)" })).not.toBeNull());
+    expect(useUi.getState().requestedSettingsSection).toBeNull();
+  });
+
+  it("ignores unknown requested sections", async () => {
+    useUi.getState().requestSettingsSection("not-a-section");
+
+    render(<SettingsView />);
+
+    await waitFor(() => expect(useUi.getState().requestedSettingsSection).toBeNull());
+    expect(screen.getByRole("heading", { name: "Account" })).not.toBeNull();
   });
 });

--- a/tests/desktop/ui-store.test.ts
+++ b/tests/desktop/ui-store.test.ts
@@ -6,6 +6,13 @@ beforeEach(() => {
 });
 
 describe("ui store create task dialog state", () => {
+  it("records whether project creation should return to Agents", () => {
+    useUi.getState().openCreateProject("agents");
+
+    expect(useUi.getState().createProjectOpen).toBe(true);
+    expect(useUi.getState().createProjectDestination).toBe("agents");
+  });
+
   it("keeps explicit column preselection only for openCreateTask", () => {
     useUi.getState().openCreateTask("done");
     expect(useUi.getState().createTaskOpen).toBe(true);


### PR DESCRIPTION
## Summary

- keep project creation in the initiating Agents workspace while using canonical POST /api/projects
- validate new project and task chat relations against the current projected project slug
- preserve multiple independent conversations per task and allow either conversation to reopen
- add recovery actions for computers with no projects or no configured coding-agent providers

## Contracts and invariants

- project routes use the canonical project slug; no persisted proj_* identifier is introduced
- task creation remains POST /api/projects/:slug/tasks
- agent chat creation remains trusted IPC to POST /api/coding-agents/threads with the validated project slug and optional task ID
- gateway projections remain the source of truth
- no auth, credential, persistence, or backend schema changes

## Validation

- 100 desktop test files / 937 tests passed
- desktop typecheck
- repository typecheck
- changed-pattern scan: 0 violations
- production desktop build

## Stack

- Base: #919 at 80d4aa77b
- Ready for review. Do not merge or deploy.