### PR TITLE
fix(desktop): stabilize task workspace rendering

### DIFF
--- a/desktop/src/renderer/src/features/editor/EditorPanel.tsx
+++ b/desktop/src/renderer/src/features/editor/EditorPanel.tsx
@@ -10,6 +10,7 @@ const MarkdownPreview = lazy(() => import("./MarkdownPreview"));
 // Stable empty reference: a selector returning a fresh [] every render would
 // fail the Object.is check and loop forever (React #185, CLAUDE.md rule).
 const EMPTY_TABS: string[] = [];
+const EMPTY_DIRTY_PATHS: string[] = [];
 
 const isMarkdown = (path: string): boolean => /\.mdx?$/i.test(path);
 
@@ -19,7 +20,7 @@ export default function EditorPanel({ taskId }: { taskId: string }) {
   const activePath = useEditorTabs((s) => s.activePathByTask[taskId] ?? null);
   const setActive = useEditorTabs((s) => s.setActive);
   const closeTab = useEditorTabs((s) => s.closeTab);
-  const dirtyPaths = useEditorTabs((s) => s.dirtyPathsByTask[taskId] ?? []);
+  const dirtyPaths = useEditorTabs((s) => s.dirtyPathsByTask[taskId] ?? EMPTY_DIRTY_PATHS);
   // Per-path "edit this markdown as code" overrides; markdown previews by default.
   const [editPaths, setEditPaths] = useState<Record<string, boolean>>({});
 

--- a/desktop/src/renderer/src/lib/kernel-socket.ts
+++ b/desktop/src/renderer/src/lib/kernel-socket.ts
@@ -129,8 +129,11 @@ export class KernelSocket {
     this.createWebSocket =
       options.createWebSocket ??
       ((url) => new WebSocket(url) as unknown as WebSocketLike);
-    this.setTimeoutFn = options.setTimeoutFn ?? setTimeout;
-    this.clearTimeoutFn = options.clearTimeoutFn ?? clearTimeout;
+    // Browser timers perform a receiver check. Keeping the bare functions on
+    // the socket and later calling `this.setTimeoutFn(...)` binds `this` to the
+    // KernelSocket and throws "Illegal invocation" in Electron.
+    this.setTimeoutFn = options.setTimeoutFn ?? globalThis.setTimeout.bind(globalThis);
+    this.clearTimeoutFn = options.clearTimeoutFn ?? globalThis.clearTimeout.bind(globalThis);
     this.random = options.random ?? Math.random;
   }
 

--- a/tests/desktop/editor-panel.test.tsx
+++ b/tests/desktop/editor-panel.test.tsx
@@ -1,0 +1,25 @@
+// @vitest-environment jsdom
+
+import React from "react";
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import EditorPanel from "../../desktop/src/renderer/src/features/editor/EditorPanel";
+import { useEditorTabs } from "../../desktop/src/renderer/src/features/editor/editor-tabs-store";
+
+describe("EditorPanel", () => {
+  beforeEach(() => {
+    useEditorTabs.setState({ tabsByTask: {}, activePathByTask: {}, dirtyPathsByTask: {} });
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it("uses stable empty selector values when a task has no editor state", () => {
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+    render(<EditorPanel taskId="task_new" />);
+    expect(screen.getByRole("heading", { name: "No file open" })).not.toBeNull();
+    expect(error).not.toHaveBeenCalledWith(expect.stringContaining("getSnapshot"));
+  });
+});

--- a/tests/desktop/kernel-socket.test.ts
+++ b/tests/desktop/kernel-socket.test.ts
@@ -127,6 +127,29 @@ describe("buildKernelWsUrl", () => {
 });
 
 describe("KernelSocket: connection and routing", () => {
+  it("does not invoke browser timers with the socket as their receiver", () => {
+    const sockets: FakeWebSocket[] = [];
+    const strictTimer = vi.fn(function (this: unknown, fn: () => void) {
+      if (this !== globalThis) throw new TypeError("Illegal invocation");
+      return 1 as unknown as ReturnType<typeof setTimeout>;
+    });
+    vi.stubGlobal("setTimeout", strictTimer);
+    const socket = new KernelSocket({
+      baseUrl: "https://app.matrix-os.com",
+      runtimeSlot: "primary",
+      createWebSocket: () => {
+        const next = new FakeWebSocket();
+        sockets.push(next);
+        return next;
+      },
+    });
+
+    socket.connect();
+    expect(() => sockets[0]!.fail()).not.toThrow();
+    expect(strictTimer).toHaveBeenCalledOnce();
+    socket.dispose();
+  });
+
   it("connects to the built URL", () => {
     const h = createHarness({ runtimeSlot: "vm-2" });
     h.socket.connect();

--- a/tests/desktop/kernel-socket.test.ts
+++ b/tests/desktop/kernel-socket.test.ts
@@ -103,6 +103,9 @@ beforeEach(() => {
 
 afterEach(() => {
   vi.restoreAllMocks();
+  // restoreAllMocks does not undo vi.stubGlobal; a leaked setTimeout stub
+  // never schedules callbacks and can hang later tests in the same worker.
+  vi.unstubAllGlobals();
 });
 
 describe("buildKernelWsUrl", () => {


### PR DESCRIPTION
## Summary

- bind Electron browser timer functions before storing them on `KernelSocket`
- keep the editor's empty dirty-path selector referentially stable
- remove the duplicate gateway `/api/sessions` routing change; backend PR #929 owns that contract
- retain focused regressions for the Electron timer and editor render loop

Review head: `3bc50932978b3cb4e8d8a84dc898882c1679cab0`.
Stacked on PR #927.

## Tests

- `bun run test tests/desktop/editor-panel.test.tsx tests/desktop/kernel-socket.test.ts` (24 passed)
- `pnpm --dir desktop typecheck`
- `git diff --check`

The full desktop stack previously passed 105 files and 988 tests; current-head CI and review are required after this rewrite.

## Invariants

### Source of truth

- gateway route ownership remains in backend PR #929
- desktop stores remain renderer projections and do not become runtime authority

### Lock and transaction scope

- no database, lock, transaction, route, or persistence changes remain in this PR

### Acceptable orphan states

- none introduced; timer cleanup and editor selection retain existing lifecycle behavior

### Auth source of truth

- existing trusted desktop main-process auth remains unchanged
- no bearer or provider credentials cross into renderer state

### Deferred scope

- project/task/chat creation remains in PR #930
- files browsing remains in PR #927
- no merge, deployment, or promotion is requested
