### PR TITLE
fix(gateway): wire workspace session input

### DIFF
--- a/packages/gateway/src/workspace-routes.ts
+++ b/packages/gateway/src/workspace-routes.ts
@@ -208,6 +208,7 @@ export function createWorkspaceRoutes(options: {
     worktreeManager,
     agentLauncher,
     zellijRuntime,
+    inputWriter: (sessionId, input, signal) => zellijRuntime.sendInput(sessionId, input, signal),
   });
   const agentSandbox = options.agentSandbox ?? createAgentSandbox({ homePath: options.homePath });
   // Defense in depth: when the caller forgets to inject sessionRuntimeBridge,

--- a/tests/gateway/workspace-routes.test.ts
+++ b/tests/gateway/workspace-routes.test.ts
@@ -5,6 +5,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { createWorkspaceRoutes } from "../../packages/gateway/src/workspace-routes.js";
 import { MissingRequestPrincipalError } from "../../packages/gateway/src/request-principal.js";
+import { createZellijRuntime } from "../../packages/gateway/src/zellij-runtime.js";
 
 function jsonRequest(path: string, body: unknown): Request {
   return new Request(`http://localhost${path}`, {
@@ -387,6 +388,50 @@ describe("workspace API routes", () => {
       available: true,
       enforced: true,
     });
+  });
+
+  it("wires default workspace session input to the injected Zellij runtime", async () => {
+    const sendInput = vi.fn(async () => undefined);
+    const zellijRuntime: ReturnType<typeof createZellijRuntime> = {
+      generateLayout: vi.fn(async ({ sessionId }) => ({
+        sessionName: `matrix-${sessionId}`,
+        layoutPath: join(homePath, "layouts", `${sessionId}.kdl`),
+      })),
+      start: vi.fn(async ({ sessionId }) => ({
+        ok: true,
+        status: "running",
+        sessionName: `matrix-${sessionId}`,
+        layoutPath: join(homePath, "layouts", `${sessionId}.kdl`),
+      })),
+      attachCommand: vi.fn((sessionId) => ["zellij", "attach", `matrix-${sessionId}`]),
+      observeCommand: vi.fn((sessionId) => ["zellij", "attach", `matrix-${sessionId}`, "--index", "0"]),
+      sendInput,
+      kill: vi.fn(async () => ({ ok: true })),
+      health: vi.fn(async () => ({
+        available: true,
+        status: "ok",
+        fallbackReason: null,
+        version: "zellij test",
+      })),
+    };
+    const app = createWorkspaceRoutes({
+      homePath,
+      zellijRuntime,
+      getOwnerScope: () => ({ type: "user", id: "user_workspace" }),
+    });
+
+    const created = await app.request(jsonRequest("/api/sessions", {
+      sessionId: "sess_route_input",
+      kind: "shell",
+    }));
+    expect(created.status).toBe(201);
+
+    const sent = await app.request(jsonRequest("/api/sessions/sess_route_input/send", {
+      input: "pwd\n",
+    }));
+
+    expect(sent.status).toBe(200);
+    expect(sendInput).toHaveBeenCalledWith("sess_route_input", "pwd\n", undefined);
   });
 
   it("checks default agent auth with the Matrix home", async () => {


### PR DESCRIPTION
## Summary
- connect default workspace session input to the injected canonical Zellij runtime
- preserve the existing workspace session and terminal identity
- add route-level regression coverage for create then send

## Tests
- `pnpm exec vitest run tests/gateway/workspace-routes.test.ts` - 17 passed
- related gateway suites - 39 passed
- `pnpm --filter @matrix-os/gateway exec tsc --noEmit` - passed
- `bun run check:patterns` - 0 violations, existing warnings only
- `git diff --check` - passed

Root `bun run typecheck` reached desktop typecheck, then hit a local shared-node_modules Vite 6/7 type identity mismatch; the affected gateway package typecheck passed.

## Invariants
- Source of truth remains the gateway workspace session store plus canonical Zellij runtime.
- No persistence, auth, route schema, credential, or client-state changes.
- Input remains bounded and validated by the existing route and session manager schemas.
- Runtime failures retain existing generic client-safe error mapping.
- This PR is stacked on #934 and must be reviewed and merged after the lower backend stack.