### PR TITLE
feat(mobile): restore computer switcher and chat tab

### DIFF
--- a/apps/mobile/__tests__/computer-picker-screen.test.tsx
+++ b/apps/mobile/__tests__/computer-picker-screen.test.tsx
@@ -1,0 +1,243 @@
+const mockRouterBack = jest.fn();
+const mockRouterReplace = jest.fn();
+const mockGetToken = jest.fn();
+const mockUseAuth = jest.fn(() => ({ getToken: mockGetToken }));
+
+jest.mock("@clerk/clerk-expo", () => ({
+  useAuth: () => mockUseAuth(),
+}));
+
+jest.mock("@/app/_layout", () => ({
+  useGateway: jest.fn(),
+}));
+
+jest.mock("expo-router", () => ({
+  useRouter: () => ({ back: mockRouterBack, replace: mockRouterReplace }),
+}));
+
+jest.mock("@/lib/mobile-computers", () => ({
+  fetchMatrixComputers: jest.fn(),
+}));
+
+jest.mock("@/lib/storage", () => ({
+  HOSTED_GATEWAY_URL: "https://app.matrix-os.com",
+  getSelectedGatewayConnection: jest.fn(),
+  saveSelectedHostedComputer: jest.fn(),
+}));
+
+import React from "react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react-native";
+import ComputerPickerScreen from "../app/computers";
+import { useGateway } from "@/app/_layout";
+import { fetchMatrixComputers } from "@/lib/mobile-computers";
+import { getSelectedGatewayConnection, saveSelectedHostedComputer } from "@/lib/storage";
+
+describe("ComputerPickerScreen", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseAuth.mockImplementation(() => ({ getToken: mockGetToken }));
+    mockGetToken.mockResolvedValue("clerk-token");
+    jest.mocked(fetchMatrixComputers).mockResolvedValue({
+      ok: true,
+      selectedSlot: null,
+      computers: [
+        {
+          handle: "alice",
+          runtimeSlot: "primary",
+          label: "Main Computer",
+          availability: "available",
+          kind: "customer",
+          versionLabel: "stable",
+          gatewayPath: "/vm/alice",
+          capabilities: ["matrixComputerInventoryV1"],
+        },
+        {
+          handle: "pr-919",
+          runtimeSlot: "pr-919",
+          label: "Preview Computer",
+          availability: "available",
+          kind: "preview",
+          versionLabel: "v2026.07.12",
+          gatewayPath: "/vm/pr-919?runtime=pr-919",
+          capabilities: ["matrixComputerInventoryV1"],
+        },
+      ],
+    });
+    jest.mocked(getSelectedGatewayConnection).mockResolvedValue({
+      id: "matrix-os-hosted",
+      url: "https://app.matrix-os.com",
+      name: "Matrix OS Cloud",
+      addedAt: 0,
+      runtimeSlot: "primary",
+    });
+  });
+
+  it("switches to a server-projected preview computer without signing out", async () => {
+    const setGateway = jest.fn();
+    jest.mocked(useGateway).mockReturnValue({
+      client: null,
+      connectionState: "connected",
+      gateway: null,
+      setGateway,
+      unreadCount: 0,
+      incrementUnread: jest.fn(),
+      clearUnread: jest.fn(),
+    });
+    const selected = {
+      id: "matrix-os-hosted:pr-919:pr-919",
+      url: "https://app.matrix-os.com/vm/pr-919?runtime=pr-919",
+      name: "Preview Computer",
+      addedAt: 1,
+      runtimeSlot: "pr-919",
+    };
+    jest.mocked(saveSelectedHostedComputer).mockResolvedValue(selected);
+
+    render(<ComputerPickerScreen />);
+
+    fireEvent.press(await screen.findByLabelText("Switch to Preview Computer"));
+
+    await waitFor(() => expect(saveSelectedHostedComputer).toHaveBeenCalledWith(
+      expect.objectContaining({ handle: "pr-919", gatewayPath: "/vm/pr-919?runtime=pr-919" }),
+    ));
+    expect(setGateway).toHaveBeenCalledWith(selected);
+    expect(mockRouterBack).toHaveBeenCalledTimes(1);
+  });
+
+  it("uses the canonical selected slot instead of an unrelated persisted URL", async () => {
+    jest.mocked(fetchMatrixComputers).mockResolvedValue({
+      ok: true,
+      selectedSlot: "pr-919",
+      computers: [
+        {
+          handle: "alice",
+          runtimeSlot: "primary",
+          label: "Main Computer",
+          availability: "available",
+          kind: "customer",
+          versionLabel: "stable",
+          gatewayPath: "/vm/alice",
+          capabilities: ["matrixComputerInventoryV1"],
+        },
+        {
+          handle: "pr-919",
+          runtimeSlot: "pr-919",
+          label: "Preview Computer",
+          availability: "available",
+          kind: "preview",
+          versionLabel: "v2026.07.12",
+          gatewayPath: "/vm/pr-919?runtime=pr-919",
+          capabilities: ["matrixComputerInventoryV1"],
+        },
+      ],
+    });
+    jest.mocked(useGateway).mockReturnValue({
+      client: null,
+      connectionState: "connected",
+      gateway: null,
+      setGateway: jest.fn(),
+      unreadCount: 0,
+      incrementUnread: jest.fn(),
+      clearUnread: jest.fn(),
+    });
+
+    render(<ComputerPickerScreen />);
+
+    expect((await screen.findByLabelText("Switch to Preview Computer")).props.accessibilityState)
+      .toMatchObject({ selected: true });
+  });
+
+  it("offers the Cloud sign-in route when no Clerk session is available", async () => {
+    mockGetToken.mockResolvedValue(null);
+    jest.mocked(useGateway).mockReturnValue({
+      client: null,
+      connectionState: "connected",
+      gateway: null,
+      setGateway: jest.fn(),
+      unreadCount: 0,
+      incrementUnread: jest.fn(),
+      clearUnread: jest.fn(),
+    });
+
+    render(<ComputerPickerScreen />);
+
+    fireEvent.press(await screen.findByLabelText("Sign in to choose a computer"));
+
+    expect(mockRouterReplace).toHaveBeenCalledWith("/sign-in");
+  });
+
+  it("shows a retryable error when Clerk token loading rejects", async () => {
+    mockGetToken.mockRejectedValueOnce(new Error("keychain unavailable"));
+    jest.mocked(useGateway).mockReturnValue({
+      client: null,
+      connectionState: "connected",
+      gateway: null,
+      setGateway: jest.fn(),
+      unreadCount: 0,
+      incrementUnread: jest.fn(),
+      clearUnread: jest.fn(),
+    });
+
+    render(<ComputerPickerScreen />);
+
+    expect(await screen.findByText("Computers unavailable. Try again.")).toBeTruthy();
+    expect(screen.getByLabelText("Retry computer list")).toBeTruthy();
+  });
+
+  it("lets the user select another computer after a switch persistence failure", async () => {
+    const setGateway = jest.fn();
+    jest.mocked(useGateway).mockReturnValue({
+      client: null,
+      connectionState: "connected",
+      gateway: null,
+      setGateway,
+      unreadCount: 0,
+      incrementUnread: jest.fn(),
+      clearUnread: jest.fn(),
+    });
+    const selected = {
+      id: "matrix-os-hosted:alice",
+      url: "https://app.matrix-os.com/vm/alice",
+      name: "Main Computer",
+      addedAt: 2,
+    };
+    jest.mocked(saveSelectedHostedComputer)
+      .mockRejectedValueOnce(new Error("secure store unavailable"))
+      .mockResolvedValueOnce(selected);
+
+    render(<ComputerPickerScreen />);
+
+    fireEvent.press(await screen.findByLabelText("Switch to Preview Computer"));
+    await screen.findByText("Computer could not be selected. Try again.");
+    fireEvent.press(screen.getByLabelText("Switch to Main Computer"));
+
+    await waitFor(() => expect(saveSelectedHostedComputer).toHaveBeenCalledTimes(2));
+    expect(setGateway).toHaveBeenCalledWith(selected);
+    expect(mockRouterBack).toHaveBeenCalledTimes(1);
+  });
+
+  it("loads once when Clerk changes the getToken function identity after rendering", async () => {
+    const firstGetToken = jest.fn().mockResolvedValue("clerk-token");
+    const nextGetToken = jest.fn().mockResolvedValue("clerk-token");
+    let authRenderCount = 0;
+    mockUseAuth.mockImplementation(() => ({
+      getToken: authRenderCount++ === 0 ? firstGetToken : nextGetToken,
+    }));
+    jest.mocked(useGateway).mockReturnValue({
+      client: null,
+      connectionState: "connected",
+      gateway: null,
+      setGateway: jest.fn(),
+      unreadCount: 0,
+      incrementUnread: jest.fn(),
+      clearUnread: jest.fn(),
+    });
+
+    render(<ComputerPickerScreen />);
+
+    await screen.findByLabelText("Switch to Main Computer");
+    await new Promise((resolve) => setTimeout(resolve, 25));
+
+    expect(firstGetToken.mock.calls.length + nextGetToken.mock.calls.length).toBe(1);
+    expect(fetchMatrixComputers).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/mobile/__tests__/gateway-client.test.ts
+++ b/apps/mobile/__tests__/gateway-client.test.ts
@@ -175,6 +175,38 @@ describe("GatewayClient", () => {
     expect(client.httpUrl).toBe("http://localhost:4000");
   });
 
+  it("keeps path joins valid for a routed computer URL with a runtime query", async () => {
+    const fetchMock = jest.spyOn(global, "fetch").mockResolvedValue(jsonResponse({ ok: true }));
+    const client = new GatewayClient("https://app.matrix-os.com/vm/pr-919?runtime=pr-919");
+
+    expect(client.httpUrl).toBe("https://app.matrix-os.com/vm/pr-919");
+    expect(client.wsUrl).toBe("wss://app.matrix-os.com/vm/pr-919/ws?runtime=pr-919");
+
+    await client.healthCheck();
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://app.matrix-os.com/vm/pr-919/health?runtime=pr-919",
+      expect.anything(),
+    );
+
+    fetchMock.mockRestore();
+  });
+
+  it("keeps primary computer URLs without a runtime query untouched", async () => {
+    const fetchMock = jest.spyOn(global, "fetch").mockResolvedValue(jsonResponse({ ok: true }));
+    const client = new GatewayClient("https://app.matrix-os.com/vm/neo");
+
+    expect(client.httpUrl).toBe("https://app.matrix-os.com/vm/neo");
+    expect(client.wsUrl).toBe("wss://app.matrix-os.com/vm/neo/ws");
+
+    await client.healthCheck();
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://app.matrix-os.com/vm/neo/health",
+      expect.anything(),
+    );
+
+    fetchMock.mockRestore();
+  });
+
   it("allows only local self-hosted token transport over HTTP and keeps Matrix OS Cloud HTTPS-only", () => {
     expect(() => new GatewayClient("https://app.matrix-os.com", "token")).not.toThrow();
     expect(() => new GatewayClient("http://localhost:4000", "token")).not.toThrow();

--- a/apps/mobile/__tests__/mobile-computers.test.ts
+++ b/apps/mobile/__tests__/mobile-computers.test.ts
@@ -1,0 +1,78 @@
+import { fetchMatrixComputers } from "../lib/mobile-computers";
+
+describe("fetchMatrixComputers", () => {
+  beforeEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("loads and validates the authenticated platform projection", async () => {
+    const fetchMock = jest.spyOn(global, "fetch").mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: jest.fn().mockResolvedValue({
+        items: [{
+          handle: "pr-919",
+          runtimeSlot: "pr-919",
+          label: "Preview Computer",
+          availability: "available",
+          kind: "preview",
+          versionLabel: "v2026.07.12",
+          gatewayPath: "/vm/pr-919?runtime=pr-919",
+          capabilities: ["matrixComputerInventoryV1"],
+        }],
+        selectedSlot: "pr-919",
+        hasMore: false,
+        limit: 20,
+      }),
+    } as unknown as Response);
+
+    await expect(fetchMatrixComputers("clerk-token")).resolves.toEqual({
+      ok: true,
+      selectedSlot: "pr-919",
+      computers: [{
+        handle: "pr-919",
+        runtimeSlot: "pr-919",
+        label: "Preview Computer",
+        availability: "available",
+        kind: "preview",
+        versionLabel: "v2026.07.12",
+        gatewayPath: "/vm/pr-919?runtime=pr-919",
+        capabilities: ["matrixComputerInventoryV1"],
+      }],
+    });
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://app.matrix-os.com/api/auth/computers",
+      expect.objectContaining({
+        headers: { Authorization: "Bearer clerk-token" },
+        signal: expect.any(AbortSignal),
+      }),
+    );
+  });
+
+  it("fails closed for malformed paths or responses", async () => {
+    jest.spyOn(global, "fetch").mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: jest.fn().mockResolvedValue({
+        items: [{
+          handle: "pr-913",
+          runtimeSlot: "pr-913",
+          label: "Preview Computer",
+          availability: "available",
+          kind: "preview",
+          versionLabel: "dev",
+          gatewayPath: "https://attacker.example.com",
+          capabilities: ["matrixComputerInventoryV1"],
+        }],
+        selectedSlot: null,
+        hasMore: false,
+        limit: 20,
+      }),
+    } as unknown as Response);
+
+    await expect(fetchMatrixComputers("clerk-token")).resolves.toEqual({
+      ok: false,
+      error: "Computers unavailable. Try again.",
+    });
+  });
+});

--- a/apps/mobile/__tests__/storage.test.ts
+++ b/apps/mobile/__tests__/storage.test.ts
@@ -1,4 +1,13 @@
-import { generateId } from "../lib/storage";
+import * as SecureStore from "expo-secure-store";
+import {
+  generateId,
+  getMobileJourneyGatewayUrl,
+  getSelectedGatewayConnection,
+  isHostedGatewayUrl,
+  resolveMobileAppSessionLaunchUrl,
+  saveSelectedGatewayBasicAuth,
+  saveSelectedHostedComputer,
+} from "../lib/storage";
 
 describe("storage", () => {
   describe("generateId", () => {
@@ -12,6 +21,88 @@ describe("storage", () => {
       const id = generateId();
       expect(typeof id).toBe("string");
       expect(id.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe("hosted computer selection", () => {
+    beforeEach(() => {
+      jest.mocked(SecureStore.getItemAsync).mockReset();
+      jest.mocked(SecureStore.setItemAsync).mockReset();
+    });
+
+    it("recognizes only bounded same-origin Matrix computer routes as hosted", () => {
+      expect(isHostedGatewayUrl("https://app.matrix-os.com/vm/pr-913")).toBe(true);
+      expect(isHostedGatewayUrl("https://app.matrix-os.com/vm/pr-919?runtime=pr-919")).toBe(true);
+      expect(isHostedGatewayUrl("https://app.matrix-os.com/vm/pr-919?runtime=pr-919&token=secret")).toBe(false);
+      expect(isHostedGatewayUrl("https://app.matrix-os.com/vm/../admin")).toBe(false);
+      expect(isHostedGatewayUrl("https://preview.example.com/vm/pr-913")).toBe(false);
+    });
+
+    it("keeps platform journey requests on the canonical hosted origin after a computer switch", () => {
+      expect(getMobileJourneyGatewayUrl("https://app.matrix-os.com/vm/pr-914"))
+        .toBe("https://app.matrix-os.com");
+      expect(getMobileJourneyGatewayUrl("https://matrix.example.test"))
+        .toBe("https://matrix.example.test");
+    });
+
+    it("routes hosted app sessions through the canonical platform origin", () => {
+      expect(resolveMobileAppSessionLaunchUrl(
+        "https://app.matrix-os.com/vm/pr-914",
+        "/apps/notes/?session=pr-914.token",
+      )).toBe("https://app.matrix-os.com/apps/notes/?session=pr-914.token");
+    });
+
+    it("keeps self-hosted app sessions on the selected gateway", () => {
+      expect(resolveMobileAppSessionLaunchUrl(
+        "https://matrix.example.test",
+        "/apps/notes/?session=token",
+      )).toBe("https://matrix.example.test/apps/notes/?session=token");
+    });
+
+    it("persists a selected computer without credentials and restores its label", async () => {
+      jest.mocked(SecureStore.setItemAsync).mockResolvedValue(undefined);
+
+      const selected = await saveSelectedHostedComputer({
+        handle: "pr-919",
+        runtimeSlot: "pr-919",
+        label: "Preview Computer",
+        availability: "available",
+        kind: "preview",
+        versionLabel: "v2026.07.12",
+        gatewayPath: "/vm/pr-919?runtime=pr-919",
+        capabilities: ["matrixComputerInventoryV1"],
+      });
+
+      expect(selected).toMatchObject({
+        id: "matrix-os-hosted:pr-919:pr-919",
+        url: "https://app.matrix-os.com/vm/pr-919?runtime=pr-919",
+        name: "Preview Computer",
+        runtimeSlot: "pr-919",
+      });
+      expect(selected.token).toBeUndefined();
+      const saved = jest.mocked(SecureStore.setItemAsync).mock.calls[0]?.[1];
+      expect(saved).not.toContain("token");
+
+      jest.mocked(SecureStore.getItemAsync).mockResolvedValue(saved ?? null);
+      await expect(getSelectedGatewayConnection()).resolves.toEqual(selected);
+    });
+
+    it("does not persist a self-hosted Basic Auth credential", async () => {
+      jest.mocked(SecureStore.setItemAsync).mockResolvedValue(undefined);
+
+      const selected = await saveSelectedGatewayBasicAuth(
+        "https://matrix.example.com",
+        "owner",
+        "password",
+      );
+
+      expect(selected.token).toMatch(/^Basic /);
+      expect(SecureStore.setItemAsync).toHaveBeenCalledWith(
+        "matrix_os_gateway_connection",
+        expect.not.stringContaining("Basic"),
+      );
+      const persisted = jest.mocked(SecureStore.setItemAsync).mock.calls[0]?.[1];
+      expect(persisted).not.toContain("token");
     });
   });
 });

--- a/apps/mobile/__tests__/tabs-layout.test.tsx
+++ b/apps/mobile/__tests__/tabs-layout.test.tsx
@@ -1,0 +1,51 @@
+jest.mock("@/app/_layout", () => ({
+  useGateway: () => ({ connectionState: "connected" }),
+}));
+
+jest.mock("expo-blur", () => ({
+  BlurView: () => null,
+}));
+
+const registeredScreens: Array<{ name: string; options?: Record<string, unknown> }> = [];
+
+jest.mock("expo-router", () => {
+  const React = require("react");
+  function Tabs({ children }: { children: React.ReactNode }) {
+    return React.createElement(React.Fragment, null, children);
+  }
+  Tabs.Screen = ({ name, options }: { name: string; options?: Record<string, unknown> }) => {
+    registeredScreens.push({ name, options });
+    return null;
+  };
+  return { Tabs };
+});
+
+import React from "react";
+import { render } from "@testing-library/react-native";
+import TabsLayout from "../app/(tabs)/_layout";
+
+describe("tabs layout", () => {
+  beforeEach(() => {
+    registeredScreens.length = 0;
+  });
+
+  it("shows Chat as a visible bottom tab", () => {
+    render(<TabsLayout />);
+
+    const chat = registeredScreens.find((screen) => screen.name === "chat");
+    expect(chat).toBeDefined();
+    expect(chat?.options?.href).not.toBeNull();
+    expect(chat?.options?.title).toBe("Chat");
+    expect(chat?.options?.tabBarIcon).toBeDefined();
+  });
+
+  it("keeps Apps as the landing tab and hides retired routes", () => {
+    render(<TabsLayout />);
+
+    const names = registeredScreens.map((screen) => screen.name);
+    expect(names).toEqual(expect.arrayContaining(["apps", "chat", "terminal", "settings"]));
+
+    const missionControl = registeredScreens.find((screen) => screen.name === "mission-control");
+    expect(missionControl?.options?.href).toBeNull();
+  });
+});

--- a/apps/mobile/app/(tabs)/_layout.tsx
+++ b/apps/mobile/app/(tabs)/_layout.tsx
@@ -5,7 +5,8 @@ import { BlurView } from "expo-blur";
 import { Ionicons } from "@expo/vector-icons";
 import { useGateway } from "../_layout";
 
-// Chat is hidden from the tab bar, so land on Apps by default.
+// Apps is the launcher home; Chat sits beside it as the always-available
+// Hermes assistant surface.
 export const unstable_settings = {
   initialRouteName: "apps",
 };
@@ -64,14 +65,19 @@ export default function TabsLayout() {
         headerRight: () => <ConnectionDot connected={isConnected} />,
       }}
     >
-      {/* Chat is intentionally hidden from the tab bar; route kept for deep links. */}
-      <Tabs.Screen name="chat" options={{ href: null }} />
       <Tabs.Screen
         name="apps"
         options={{
           title: "Apps",
           headerShown: false,
           tabBarIcon: ({ focused }) => <TabIcon name="apps" focused={focused} />,
+        }}
+      />
+      <Tabs.Screen
+        name="chat"
+        options={{
+          title: "Chat",
+          tabBarIcon: ({ focused }) => <TabIcon name="chat" focused={focused} />,
         }}
       />
       <Tabs.Screen

--- a/apps/mobile/app/(tabs)/chat.tsx
+++ b/apps/mobile/app/(tabs)/chat.tsx
@@ -57,11 +57,15 @@ function TypingIndicator() {
 
   const style = useAnimatedStyle(() => ({ opacity: opacity.value }));
 
+  // Keep the Unistyles style on a plain View: mixing Unistyles and animated
+  // styles on one Animated.View trips Reanimated's CSS prop filtering.
   return (
-    <Animated.View style={[typingStyles.container, style]}>
-      <View style={typingStyles.dot} />
-      <View style={typingStyles.dot} />
-      <View style={typingStyles.dot} />
+    <Animated.View style={style}>
+      <View style={typingStyles.container}>
+        <View style={typingStyles.dot} />
+        <View style={typingStyles.dot} />
+        <View style={typingStyles.dot} />
+      </View>
     </Animated.View>
   );
 }

--- a/apps/mobile/app/(tabs)/settings.tsx
+++ b/apps/mobile/app/(tabs)/settings.tsx
@@ -203,6 +203,10 @@ export default function SettingsScreen() {
     ]);
   }, [router, signOut]);
 
+  const handleSwitchComputer = useCallback(() => {
+    router.push("/computers" as never);
+  }, [router]);
+
   if (!settings) return null;
 
   return (
@@ -219,6 +223,7 @@ export default function SettingsScreen() {
       gatewayUrl={gateway?.url ?? null}
       onRefresh={handleRefresh}
       updateSetting={updateSetting}
+      onSwitchComputer={handleSwitchComputer}
       onSignOut={handleSignOut}
     />
   );
@@ -237,10 +242,11 @@ interface SettingsContentProps {
   gatewayUrl: string | null;
   onRefresh: () => void;
   updateSetting: (key: keyof AppSettings, value: boolean | string) => void;
+  onSwitchComputer: () => void;
   onSignOut: () => void;
 }
 
-function SettingsContent({
+export function SettingsContent({
   settings,
   channels,
   systemInfo,
@@ -253,6 +259,7 @@ function SettingsContent({
   gatewayUrl,
   onRefresh,
   updateSetting,
+  onSwitchComputer,
   onSignOut,
 }: SettingsContentProps) {
   const { theme: uniTheme } = useUnistyles();
@@ -275,6 +282,11 @@ function SettingsContent({
           label={gatewayName ?? "Not connected"}
           icon="server-outline"
           value={gatewayUrl ?? connectionState}
+        />
+        <SettingsRow
+          label="Switch computer"
+          icon="swap-horizontal-outline"
+          onPress={onSwitchComputer}
         />
       </SettingsSection>
 

--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -320,6 +320,14 @@ function GatewayShell() {
           <Stack.Screen name="agents" options={{ headerShown: false }} />
           <Stack.Screen name="sessions" options={{ headerShown: false, presentation: "modal" }} />
           <Stack.Screen
+            name="computers"
+            options={{
+              title: "Computers",
+              headerBackButtonDisplayMode: "minimal",
+              headerStyle: { backgroundColor: theme.colors.background },
+            }}
+          />
+          <Stack.Screen
             name="connect"
             options={{
               title: "Gateway",

--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -192,12 +192,23 @@ function GatewayShell() {
     if (connectionKeyRef.current === nextKey) return;
     connectionKeyRef.current = nextKey;
     clientRef.current?.disconnect();
-    const newClient = new GatewayClient(gw.url, gw.token);
+    // Hosted computers carry no stored credential: authenticate with the live
+    // Clerk token provider and a fresh WS upgrade token, mirroring the mount
+    // path. Self-hosted gateways keep their session credential.
+    const newClient = gw.token
+      ? new GatewayClient(gw.url, gw.token)
+      : new GatewayClient(gw.url, () => getTokenRef.current());
     newClient.onStateChange(setConnectionState);
-    newClient.connect();
     clientRef.current = newClient;
     setClient(newClient);
     setGatewayState(gw);
+    setConnectionState("connecting");
+    void (async () => {
+      const wsToken = await newClient.getWsToken();
+      if (clientRef.current !== newClient) return;
+      if (wsToken) newClient.setWebSocketToken(wsToken);
+      newClient.connect();
+    })();
   }, []);
 
   useEffect(() => {

--- a/apps/mobile/app/computers.tsx
+++ b/apps/mobile/app/computers.tsx
@@ -1,0 +1,208 @@
+import { useCallback, useEffect, useReducer, useRef } from "react";
+import { ActivityIndicator, Pressable, ScrollView, Text, View } from "react-native";
+import { Ionicons } from "@expo/vector-icons";
+import { useAuth } from "@clerk/clerk-expo";
+import { useRouter } from "expo-router";
+import { StyleSheet, useUnistyles } from "react-native-unistyles";
+import type { MatrixComputer } from "@matrix-os/contracts";
+import { useGateway } from "@/app/_layout";
+import { fetchMatrixComputers } from "@/lib/mobile-computers";
+import { getSelectedGatewayConnection, saveSelectedHostedComputer } from "@/lib/storage";
+
+const CLOUD_SIGN_IN_ERROR = "Sign in to Matrix OS Cloud to choose a computer.";
+const COMPUTERS_UNAVAILABLE_ERROR = "Computers unavailable. Try again.";
+
+type ComputerPickerState =
+  | { status: "loading"; computers: MatrixComputer[]; selectedSlot: string | null; error: null }
+  | { status: "ready"; computers: MatrixComputer[]; selectedSlot: string | null; error: string | null; switchingSlot?: string }
+  | { status: "error"; computers: MatrixComputer[]; selectedSlot: string | null; error: string };
+
+type ComputerPickerAction =
+  | { type: "loading" }
+  | { type: "loaded"; computers: MatrixComputer[]; selectedSlot: string | null }
+  | { type: "failed"; error: string }
+  | { type: "switching"; runtimeSlot: string }
+  | { type: "switchFailed"; error: string };
+
+const INITIAL_STATE: ComputerPickerState = {
+  status: "loading",
+  computers: [],
+  selectedSlot: null,
+  error: null,
+};
+
+function reducer(state: ComputerPickerState, action: ComputerPickerAction): ComputerPickerState {
+  switch (action.type) {
+    case "loading":
+      return { ...state, status: "loading", error: null };
+    case "loaded":
+      return { status: "ready", computers: action.computers, selectedSlot: action.selectedSlot, error: null };
+    case "failed":
+      return { ...state, status: "error", error: action.error };
+    case "switching":
+      return state.status === "ready" ? { ...state, error: null, switchingSlot: action.runtimeSlot } : state;
+    case "switchFailed":
+      return state.status === "ready"
+        ? { ...state, error: action.error, switchingSlot: undefined }
+        : state;
+    default:
+      return state;
+  }
+}
+
+export default function ComputerPickerScreen() {
+  const { theme } = useUnistyles();
+  const { getToken } = useAuth();
+  const { setGateway } = useGateway();
+  const router = useRouter();
+  const [state, dispatch] = useReducer(reducer, INITIAL_STATE);
+  const getTokenRef = useRef(getToken);
+
+  useEffect(() => {
+    getTokenRef.current = getToken;
+  }, [getToken]);
+
+  const load = useCallback(async () => {
+    dispatch({ type: "loading" });
+    try {
+      const token = await getTokenRef.current();
+      if (!token) {
+        dispatch({ type: "failed", error: CLOUD_SIGN_IN_ERROR });
+        return;
+      }
+      const [result, selected] = await Promise.all([
+        fetchMatrixComputers(token),
+        getSelectedGatewayConnection(),
+      ]);
+      if (!result.ok) {
+        dispatch({ type: "failed", error: result.error });
+        return;
+      }
+      dispatch({
+        type: "loaded",
+        computers: result.computers,
+        selectedSlot: result.selectedSlot ?? selected.runtimeSlot ?? null,
+      });
+    } catch (error) {
+      console.warn(
+        "[mobile] computer list load failed",
+        error instanceof Error ? error.name : typeof error,
+      );
+      dispatch({ type: "failed", error: COMPUTERS_UNAVAILABLE_ERROR });
+    }
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+    const timer = setTimeout(() => {
+      if (!cancelled) void load();
+    }, 0);
+    return () => {
+      cancelled = true;
+      clearTimeout(timer);
+    };
+  }, [load]);
+
+  const selectComputer = useCallback(async (computer: MatrixComputer) => {
+    if (computer.availability !== "available" || state.status !== "ready" || state.switchingSlot) return;
+    dispatch({ type: "switching", runtimeSlot: computer.runtimeSlot });
+    try {
+      const gateway = await saveSelectedHostedComputer(computer);
+      setGateway(gateway);
+      router.back();
+    } catch {
+      dispatch({ type: "switchFailed", error: "Computer could not be selected. Try again." });
+    }
+  }, [router, setGateway, state]);
+
+  return (
+    <ScrollView style={styles.container} contentContainerStyle={styles.content} contentInsetAdjustmentBehavior="automatic">
+      <View style={styles.header}>
+        <View style={styles.headerIcon}>
+          <Ionicons name="server-outline" size={24} color={theme.colors.primary} />
+        </View>
+        <View style={styles.headerText}>
+          <Text style={styles.title}>Choose computer</Text>
+          <Text style={styles.subtitle}>Switch runtimes without signing out. Your data stays on the selected computer.</Text>
+        </View>
+      </View>
+
+      {state.status === "loading" ? (
+        <View style={styles.centered}>
+          <ActivityIndicator color={theme.colors.primary} />
+          <Text style={styles.statusText}>Loading computers...</Text>
+        </View>
+      ) : null}
+
+      {state.error ? (
+        <View style={styles.errorPanel}>
+          <Text style={styles.errorText}>{state.error}</Text>
+          <Pressable
+            accessibilityRole="button"
+            accessibilityLabel={state.error === CLOUD_SIGN_IN_ERROR ? "Sign in to choose a computer" : "Retry computer list"}
+            onPress={state.error === CLOUD_SIGN_IN_ERROR
+              ? () => router.replace("/sign-in" as never)
+              : () => void load()}
+            style={styles.retryButton}
+          >
+            <Text style={styles.retryText}>{state.error === CLOUD_SIGN_IN_ERROR ? "Sign in" : "Retry"}</Text>
+          </Pressable>
+        </View>
+      ) : null}
+
+      {state.computers.map((computer) => {
+        const selected = state.selectedSlot === computer.runtimeSlot;
+        const disabled = computer.availability !== "available" || state.status !== "ready" || Boolean(state.switchingSlot);
+        return (
+          <Pressable
+            accessibilityRole="button"
+            accessibilityLabel={`Switch to ${computer.label}`}
+            accessibilityState={{ disabled, selected }}
+            disabled={disabled}
+            key={`${computer.handle}:${computer.runtimeSlot}`}
+            onPress={() => void selectComputer(computer)}
+            style={({ pressed }) => [styles.computerCard, selected && styles.computerCardSelected, pressed && !disabled && styles.computerCardPressed, disabled && styles.computerCardDisabled]}
+          >
+            <View style={styles.computerTopline}>
+              <View style={styles.computerTitleRow}>
+                <Ionicons name={selected ? "checkmark-circle" : "desktop-outline"} size={20} color={theme.colors.primary} />
+                <View>
+                  <Text style={styles.computerTitle}>{computer.label}</Text>
+                  <Text style={styles.computerHandle}>{computer.handle}</Text>
+                </View>
+              </View>
+              <Text style={styles.computerStatus}>{state.status === "ready" && state.switchingSlot === computer.runtimeSlot ? "switching" : computer.availability}</Text>
+            </View>
+            <Text style={styles.versionLabel}>{computer.versionLabel ?? "Version pending"}</Text>
+          </Pressable>
+        );
+      })}
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create((theme) => ({
+  container: { flex: 1, backgroundColor: theme.colors.background },
+  content: { padding: theme.spacing.lg, paddingBottom: theme.spacing["2xl"], gap: theme.spacing.md },
+  header: { flexDirection: "row", gap: theme.spacing.md, alignItems: "center", marginBottom: theme.spacing.sm },
+  headerIcon: { width: 48, height: 48, borderRadius: theme.radius.lg, alignItems: "center", justifyContent: "center", backgroundColor: theme.colors.secondary },
+  headerText: { flex: 1 },
+  title: { fontFamily: theme.fonts.sansBold, fontSize: 24, color: theme.colors.foreground },
+  subtitle: { marginTop: 4, fontFamily: theme.fonts.sans, fontSize: 13, lineHeight: 18, color: theme.colors.mutedForeground },
+  centered: { minHeight: 180, alignItems: "center", justifyContent: "center", gap: theme.spacing.sm },
+  statusText: { fontFamily: theme.fonts.sansMedium, color: theme.colors.mutedForeground },
+  errorPanel: { padding: theme.spacing.lg, gap: theme.spacing.md, borderWidth: 1, borderColor: theme.colors.border, borderRadius: theme.radius.lg, backgroundColor: theme.colors.card },
+  errorText: { fontFamily: theme.fonts.sansMedium, color: theme.colors.destructive },
+  retryButton: { alignSelf: "flex-start", minHeight: 40, justifyContent: "center", paddingHorizontal: theme.spacing.lg, borderRadius: theme.radius.full, backgroundColor: theme.colors.primary },
+  retryText: { fontFamily: theme.fonts.sansSemiBold, color: theme.colors.primaryForeground },
+  computerCard: { padding: theme.spacing.lg, borderWidth: 1, borderColor: theme.colors.border, borderRadius: theme.radius.lg, backgroundColor: theme.colors.card, gap: theme.spacing.sm },
+  computerCardSelected: { borderColor: theme.colors.primary, backgroundColor: theme.colors.secondary },
+  computerCardPressed: { opacity: 0.82, transform: [{ scale: 0.99 }] },
+  computerCardDisabled: { opacity: 0.55 },
+  computerTopline: { flexDirection: "row", justifyContent: "space-between", alignItems: "center", gap: theme.spacing.md },
+  computerTitleRow: { flexDirection: "row", alignItems: "center", gap: theme.spacing.sm, flex: 1 },
+  computerTitle: { fontFamily: theme.fonts.sansSemiBold, fontSize: 16, color: theme.colors.foreground },
+  computerHandle: { marginTop: 2, fontFamily: theme.fonts.mono, fontSize: 11, color: theme.colors.mutedForeground },
+  computerStatus: { overflow: "hidden", paddingHorizontal: theme.spacing.sm, paddingVertical: 4, borderRadius: theme.radius.full, fontFamily: theme.fonts.sansMedium, fontSize: 11, color: theme.colors.primary, backgroundColor: theme.colors.background, textTransform: "capitalize" },
+  versionLabel: { fontFamily: theme.fonts.mono, fontSize: 11, color: theme.colors.mutedForeground },
+}));

--- a/apps/mobile/app/index.tsx
+++ b/apps/mobile/app/index.tsx
@@ -6,7 +6,7 @@ import { Ionicons } from "@expo/vector-icons";
 import { Image } from "expo-image";
 import { useAuth } from "@clerk/clerk-expo";
 import { useEffect, useState } from "react";
-import { HOSTED_GATEWAY_URL, getSelectedGatewayConnection, isHostedGatewayUrl } from "@/lib/storage";
+import { HOSTED_GATEWAY_URL, getMobileJourneyGatewayUrl, getSelectedGatewayConnection, isHostedGatewayUrl } from "@/lib/storage";
 import { JourneyGate } from "@/components/JourneyGate";
 import { fetchMobileJourney, isConnectablePhase, type JourneyFetchResult } from "@/lib/journey";
 
@@ -35,7 +35,7 @@ function SignedInJourneyGate() {
           return;
         }
         const token = await getToken();
-        const next = await fetchMobileJourney(gateway.url, token);
+        const next = await fetchMobileJourney(getMobileJourneyGatewayUrl(gateway.url), token);
         if (!active) return;
         if (next.status === "ok" && isConnectablePhase(next.journey.phase)) {
           router.replace("/(tabs)/apps" as any);

--- a/apps/mobile/app/runtime/[...slug].tsx
+++ b/apps/mobile/app/runtime/[...slug].tsx
@@ -8,6 +8,7 @@ import AppRuntimeFrame from "@/components/AppRuntimeFrame";
 import { WindowHeader, WindowHeaderAction } from "@/components/WindowHeader";
 import { useGateway } from "../_layout";
 import { getAppSlug, getRuntimeSlug, slugFromParam, type MatrixAppEntry } from "@/lib/apps";
+import { resolveMobileAppSessionLaunchUrl } from "@/lib/storage";
 
 const SESSION_REFRESH_SKEW_MS = 60_000;
 const SESSION_REFRESH_MIN_INTERVAL_MS = 30_000;
@@ -84,10 +85,7 @@ export default function RuntimeScreen() {
       if (nextApp) {
         const session = await client.createAppSessionToken(getRuntimeSlug(nextApp));
         if (session) {
-          const base = client.httpUrl.replace(/\/+$/, "");
-          const resolvedUrl = session.launchUrl.startsWith("http")
-            ? session.launchUrl
-            : `${base}${session.launchUrl.startsWith("/") ? "" : "/"}${session.launchUrl}`;
+          const resolvedUrl = resolveMobileAppSessionLaunchUrl(client.httpUrl, session.launchUrl);
           dispatch({ type: "sessionReady", launchUrl: resolvedUrl, sessionExpiresAt: session.expiresAt });
         }
       }

--- a/apps/mobile/components/ChatMessage.tsx
+++ b/apps/mobile/components/ChatMessage.tsx
@@ -5,36 +5,36 @@ import { StyleSheet, useUnistyles } from "react-native-unistyles";
 import Animated, { FadeInLeft, FadeInRight } from "react-native-reanimated";
 import * as Clipboard from "expo-clipboard";
 import { Ionicons } from "@expo/vector-icons";
-import { colors, fonts } from "@/lib/theme";
+import { fonts } from "@/lib/theme";
 import type { Message } from "@/app/(tabs)/chat";
 
-const roleContainerStyles: Record<Message["role"], object> = {
-  user: {
-    backgroundColor: colors.light.primary,
-    alignSelf: "flex-end" as const,
-  },
-  assistant: {
-    backgroundColor: colors.light.card,
-    borderWidth: 1,
-    borderColor: colors.light.border,
-    alignSelf: "flex-start" as const,
-  },
-  system: {
-    backgroundColor: "rgba(239, 68, 68, 0.1)",
-    alignSelf: "center" as const,
-  },
-  tool: {
-    backgroundColor: colors.light.secondary,
-    alignSelf: "flex-start" as const,
-  },
-};
+// Role styling lives in the Unistyles sheet below so bubbles follow the active
+// color scheme instead of pinning the light palette.
+function roleBubbleStyle(role: Message["role"]) {
+  switch (role) {
+    case "user":
+      return styles.bubbleUser;
+    case "assistant":
+      return styles.bubbleAssistant;
+    case "system":
+      return styles.bubbleSystem;
+    case "tool":
+      return styles.bubbleTool;
+  }
+}
 
-const roleTextStyles: Record<Message["role"], object> = {
-  user: { color: colors.light.primaryForeground },
-  assistant: { color: colors.light.cardForeground },
-  system: { color: colors.light.destructive, fontSize: 12 },
-  tool: { color: colors.light.mutedForeground, fontSize: 12, fontFamily: fonts.mono },
-};
+function roleTextStyle(role: Message["role"]) {
+  switch (role) {
+    case "user":
+      return styles.textUser;
+    case "assistant":
+      return styles.textAssistant;
+    case "system":
+      return styles.textSystem;
+    case "tool":
+      return styles.textTool;
+  }
+}
 
 const timestampAlignStyles: Record<Message["role"], object> = {
   user: { alignSelf: "flex-end" as const },
@@ -48,7 +48,7 @@ const ENTERING_OTHER = FadeInLeft.duration(200);
 
 const IMAGE_EXTENSIONS = /\.(png|jpg|jpeg|gif|webp|svg)$/i;
 
-function markdownToNodes(text: string, baseStyle: object): React.ReactNode[] {
+function markdownToNodes(text: string, baseStyle: object, linkColor: string): React.ReactNode[] {
   const elements: React.ReactNode[] = [];
   const lines = text.split("\n");
 
@@ -67,13 +67,13 @@ function markdownToNodes(text: string, baseStyle: object): React.ReactNode[] {
       elements.push(
         <Text key={`bullet-${li}`} style={baseStyle}>
           <Text>{"  ".repeat(indent) + "  \u2022  "}</Text>
-          {inlineMarkdownToNodes(bulletContent, baseStyle, `b-${li}`)}
+          {inlineMarkdownToNodes(bulletContent, baseStyle, `b-${li}`, linkColor)}
         </Text>,
       );
       continue;
     }
 
-    elements.push(...inlineMarkdownToNodes(line, baseStyle, `l-${li}`));
+    elements.push(...inlineMarkdownToNodes(line, baseStyle, `l-${li}`, linkColor));
   }
 
   return elements;
@@ -83,6 +83,7 @@ function inlineMarkdownToNodes(
   text: string,
   baseStyle: object,
   keyPrefix: string,
+  linkColor: string,
 ): React.ReactNode[] {
   const elements: React.ReactNode[] = [];
   // Match: **bold**, *italic*, `inline code`, [text](url)
@@ -139,7 +140,7 @@ function inlineMarkdownToNodes(
       elements.push(
         <Text
           key={`${keyPrefix}-tok${match.index}`}
-          style={[baseStyle, { color: colors.light.primary, textDecorationLine: "underline" }]}
+          style={[baseStyle, { color: linkColor, textDecorationLine: "underline" }]}
           onPress={() => Linking.openURL(url)}
         >
           {match[5]}
@@ -163,6 +164,7 @@ function inlineMarkdownToNodes(
 }
 
 export const ChatMessage = memo(function ChatMessage({ message, gatewayUrl }: { message: Message; gatewayUrl?: string }) {
+  const { theme } = useUnistyles();
   const isCode = message.content.includes("```");
   const imageMatches = extractImageLinks(message.content);
   const fileMatches = extractFileLinks(message.content);
@@ -173,7 +175,7 @@ export const ChatMessage = memo(function ChatMessage({ message, gatewayUrl }: { 
 
   return (
     <Animated.View entering={entering}>
-      <View style={[styles.bubble, roleContainerStyles[message.role]]}>
+      <View style={[styles.bubble, roleBubbleStyle(message.role)]}>
         {message.tool && (
           <Text style={styles.toolLabel}>{message.tool}</Text>
         )}
@@ -183,8 +185,8 @@ export const ChatMessage = memo(function ChatMessage({ message, gatewayUrl }: { 
         {isCode ? (
           <CodeContent content={message.content} role={message.role} />
         ) : (
-          <Text style={[styles.text, roleTextStyles[message.role]]}>
-            {markdownToNodes(message.content, { ...styles.text, ...roleTextStyles[message.role] })}
+          <Text style={[styles.text, roleTextStyle(message.role)]}>
+            {markdownToNodes(message.content, { ...styles.text, ...roleTextStyle(message.role) }, theme.colors.primary)}
           </Text>
         )}
         {fileMatches.length > 0 && gatewayUrl && (
@@ -294,6 +296,7 @@ function CodeBlock({ code, lang }: { code: string; lang?: string }) {
 }
 
 function CodeContent({ content, role }: { content: string; role: Message["role"] }) {
+  const { theme } = useUnistyles();
   // Pair each split segment with its source character offset so keys are stable
   // across renders (the segments concatenate back to the immutable content).
   const parts = content.split(/(```[\s\S]*?```)/g);
@@ -313,8 +316,8 @@ function CodeContent({ content, role }: { content: string; role: Message["role"]
         }
         if (part.trim()) {
           return (
-            <Text key={`seg-${start}`} style={[styles.text, roleTextStyles[role]]}>
-              {markdownToNodes(part, { ...styles.text, ...roleTextStyles[role] })}
+            <Text key={`seg-${start}`} style={[styles.text, roleTextStyle(role)]}>
+              {markdownToNodes(part, { ...styles.text, ...roleTextStyle(role) }, theme.colors.primary)}
             </Text>
           );
         }
@@ -332,6 +335,28 @@ const styles = StyleSheet.create((theme) => ({
     paddingHorizontal: theme.spacing.lg,
     paddingVertical: 10,
   },
+  bubbleUser: {
+    backgroundColor: theme.colors.primary,
+    alignSelf: "flex-end" as const,
+  },
+  bubbleAssistant: {
+    backgroundColor: theme.colors.card,
+    borderWidth: 1,
+    borderColor: theme.colors.border,
+    alignSelf: "flex-start" as const,
+  },
+  bubbleSystem: {
+    backgroundColor: "rgba(239, 68, 68, 0.1)",
+    alignSelf: "center" as const,
+  },
+  bubbleTool: {
+    backgroundColor: theme.colors.secondary,
+    alignSelf: "flex-start" as const,
+  },
+  textUser: { color: theme.colors.primaryForeground },
+  textAssistant: { color: theme.colors.cardForeground },
+  textSystem: { color: theme.colors.destructive, fontSize: 12 },
+  textTool: { color: theme.colors.mutedForeground, fontSize: 12, fontFamily: theme.fonts.mono },
   toolLabel: {
     fontFamily: theme.fonts.mono,
     fontSize: 10,

--- a/apps/mobile/lib/gateway-client.ts
+++ b/apps/mobile/lib/gateway-client.ts
@@ -741,7 +741,11 @@ export class GatewayClient {
     params.set("limit", String(limit));
     const res = await this.fetchGateway(`/api/messages?${params}`);
     if (!res.ok) return [];
-    return res.json();
+    // `/api/messages` is owned by the messaging bridge on newer gateways and
+    // no longer returns a chat-history array; treat any non-array body as
+    // "no older history" instead of crashing history pagination.
+    const body: unknown = await res.json();
+    return Array.isArray(body) ? body : [];
   }
 
   async getConversations(): Promise<unknown[]> {

--- a/apps/mobile/lib/gateway-client.ts
+++ b/apps/mobile/lib/gateway-client.ts
@@ -1346,7 +1346,7 @@ export class GatewayClient {
   }
 }
 
-function createTimeoutSignal(timeoutMs: number): AbortSignal | undefined {
+export function createTimeoutSignal(timeoutMs: number): AbortSignal | undefined {
   const timeout = (AbortSignal as { timeout?: (milliseconds: number) => AbortSignal }).timeout;
   if (typeof timeout === "function") {
     return timeout(timeoutMs);

--- a/apps/mobile/lib/gateway-client.ts
+++ b/apps/mobile/lib/gateway-client.ts
@@ -283,6 +283,8 @@ function logGatewayWarning(scope: string, detail: unknown): void {
 export class GatewayClient {
   private ws: WebSocket | null = null;
   private baseUrl: string;
+  /** Routing query (without `?`) carried by the base URL, e.g. `runtime=<slot>`. */
+  private baseQuery: string;
   private token: string | undefined;
   private tokenProvider: TokenProvider | undefined;
   private wsToken: string | undefined;
@@ -295,7 +297,12 @@ export class GatewayClient {
   private shouldReconnect = false;
 
   constructor(baseUrl: string, token?: TokenSource, wsToken?: string) {
-    this.baseUrl = baseUrl.replace(/\/+$/, "");
+    // A routed computer URL may carry a routing query (e.g. `/vm/<handle>?runtime=<slot>`).
+    // Split it off so path joins stay valid, and re-apply it to every request URL.
+    const trimmed = baseUrl.replace(/\/+$/, "");
+    const queryIndex = trimmed.indexOf("?");
+    this.baseUrl = queryIndex === -1 ? trimmed : trimmed.slice(0, queryIndex).replace(/\/+$/, "");
+    this.baseQuery = queryIndex === -1 ? "" : trimmed.slice(queryIndex + 1);
     if (token || wsToken) {
       assertSecureTokenTransport(this.baseUrl);
     }
@@ -329,15 +336,21 @@ export class GatewayClient {
     return formatAuthorizationHeader(token);
   }
 
+  /** Re-applies the base routing query (e.g. `runtime=<slot>`) to a joined URL. */
+  private withBaseQuery(url: string): string {
+    if (!this.baseQuery) return url;
+    return `${url}${url.includes("?") ? "&" : "?"}${this.baseQuery}`;
+  }
+
   get wsUrl(): string {
     const url = this.baseUrl.replace(/^http/, "ws");
-    return `${url}/ws`;
+    return this.withBaseQuery(`${url}/ws`);
   }
 
   get terminalWsUrl(): string {
     const url = this.baseUrl.replace(/^http/, "ws");
     // Shell-sessions endpoint: attach by session name passed in the query.
-    return `${url}/ws/terminal/session`;
+    return this.withBaseQuery(`${url}/ws/terminal/session`);
   }
 
   setWebSocketToken(token: string | null, expiresAt?: number): void {
@@ -386,7 +399,7 @@ export class GatewayClient {
     const upgradeToken = this.wsToken;
     const authorization = formatAuthorizationHeader(this.token);
     const wsUrl = upgradeToken
-      ? `${this.wsUrl}?token=${encodeURIComponent(upgradeToken)}`
+      ? appendQuery(this.wsUrl, `token=${encodeURIComponent(upgradeToken)}`)
       : this.wsUrl;
 
     const WebSocketWithOptions = WebSocket as unknown as ReactNativeWebSocketConstructor;
@@ -507,7 +520,7 @@ export class GatewayClient {
   }
 
   private async fetchGateway(path: string, init: RequestInit = {}): Promise<Response> {
-    return fetch(`${this.httpUrl}${path}`, {
+    return fetch(this.withBaseQuery(`${this.httpUrl}${path}`), {
       ...init,
       headers: {
         ...(await this.authHeaders()),
@@ -535,7 +548,7 @@ export class GatewayClient {
     if (typeof fromSeq === "number" && Number.isFinite(fromSeq)) params.set("fromSeq", String(fromSeq));
     if (token) params.set("token", token);
     const query = params.toString();
-    const wsUrl = query ? `${this.terminalWsUrl}?${query}` : this.terminalWsUrl;
+    const wsUrl = query ? appendQuery(this.terminalWsUrl, query) : this.terminalWsUrl;
     const WebSocketWithOptions = WebSocket as unknown as ReactNativeWebSocketConstructor;
     const authorization = formatAuthorizationHeader(this.token);
     return new WebSocketWithOptions(
@@ -562,7 +575,9 @@ export class GatewayClient {
     if (token) params.set("token", token);
     if (parsedCursor?.success) params.set("cursor", parsedCursor.data);
     const query = params.toString();
-    const wsUrl = `${this.baseUrl.replace(/^http/, "ws")}/ws/coding-agents/thread/${encodeURIComponent(parsedThreadId.data)}${query ? `?${query}` : ""}`;
+    const wsUrl = this.withBaseQuery(
+      `${this.baseUrl.replace(/^http/, "ws")}/ws/coding-agents/thread/${encodeURIComponent(parsedThreadId.data)}${query ? `?${query}` : ""}`,
+    );
     const WebSocketWithOptions = WebSocket as unknown as ReactNativeWebSocketConstructor;
     const authorization = formatAuthorizationHeader(this.token);
     const ws = new WebSocketWithOptions(
@@ -1344,6 +1359,10 @@ export class GatewayClient {
       body: JSON.stringify({ token, platform }),
     });
   }
+}
+
+function appendQuery(url: string, query: string): string {
+  return `${url}${url.includes("?") ? "&" : "?"}${query}`;
 }
 
 export function createTimeoutSignal(timeoutMs: number): AbortSignal | undefined {

--- a/apps/mobile/lib/mobile-computers.ts
+++ b/apps/mobile/lib/mobile-computers.ts
@@ -1,0 +1,33 @@
+import {
+  MatrixComputerListSchema,
+  type MatrixComputer,
+} from "@matrix-os/contracts";
+import { createTimeoutSignal } from "@/lib/gateway-client";
+import { HOSTED_GATEWAY_URL } from "@/lib/storage";
+
+const COMPUTER_LIST_TIMEOUT_MS = 10_000;
+const COMPUTER_LIST_ERROR = "Computers unavailable. Try again.";
+
+export type MatrixComputerListResult =
+  | { ok: true; computers: MatrixComputer[]; selectedSlot: string | null }
+  | { ok: false; error: typeof COMPUTER_LIST_ERROR };
+
+export async function fetchMatrixComputers(clerkToken: string): Promise<MatrixComputerListResult> {
+  if (!clerkToken.trim()) return { ok: false, error: COMPUTER_LIST_ERROR };
+  try {
+    const response = await fetch(`${HOSTED_GATEWAY_URL}/api/auth/computers`, {
+      headers: { Authorization: `Bearer ${clerkToken}` },
+      signal: createTimeoutSignal(COMPUTER_LIST_TIMEOUT_MS),
+    });
+    if (!response.ok) return { ok: false, error: COMPUTER_LIST_ERROR };
+    const parsed = MatrixComputerListSchema.safeParse(await response.json());
+    if (!parsed.success) return { ok: false, error: COMPUTER_LIST_ERROR };
+    return {
+      ok: true,
+      computers: parsed.data.items,
+      selectedSlot: parsed.data.selectedSlot,
+    };
+  } catch {
+    return { ok: false, error: COMPUTER_LIST_ERROR };
+  }
+}

--- a/apps/mobile/lib/storage.ts
+++ b/apps/mobile/lib/storage.ts
@@ -1,4 +1,10 @@
 import * as SecureStore from "expo-secure-store";
+import {
+  MatrixComputerHandleSchema,
+  MatrixComputerRuntimeSlotSchema,
+  MatrixComputerSchema,
+  type MatrixComputer,
+} from "@matrix-os/contracts";
 
 const SETTINGS_KEY = "matrix_os_settings";
 const GATEWAY_CONNECTION_KEY = "matrix_os_gateway_connection";
@@ -9,6 +15,8 @@ const CUSTOM_GATEWAY_ID = "matrix-os-custom";
 export interface GatewayConnection {
   id: string;
   url: string;
+  /** Safe server-projected routing reference; never an authentication credential. */
+  runtimeSlot?: string;
   /** Full Authorization header value for non-Clerk gateways, e.g. "Basic ...". */
   token?: string;
   name: string;
@@ -32,10 +40,65 @@ export const HOSTED_GATEWAY: GatewayConnection = {
   url: HOSTED_GATEWAY_URL,
   name: "Matrix OS Cloud",
   addedAt: 0,
+  runtimeSlot: "primary",
 };
 
 export function isHostedGatewayUrl(url: string): boolean {
-  return normalizeGatewayUrl(url) === HOSTED_GATEWAY_URL;
+  return parseHostedGatewayUrl(url) !== null;
+}
+
+interface HostedGatewayRoute {
+  url: string;
+  handle: string | null;
+  runtimeSlot: string;
+}
+
+function parseHostedGatewayUrl(input: string): HostedGatewayRoute | null {
+  let parsed: URL;
+  try {
+    parsed = new URL(input.trim());
+  } catch {
+    return null;
+  }
+  if (parsed.origin !== HOSTED_GATEWAY_URL || parsed.hash) return null;
+  if ((parsed.pathname === "/" || parsed.pathname === "") && !parsed.search) {
+    return { url: HOSTED_GATEWAY_URL, handle: null, runtimeSlot: "primary" };
+  }
+
+  const match = parsed.pathname.match(/^\/vm\/([^/]+)$/);
+  const handle = MatrixComputerHandleSchema.safeParse(match?.[1]);
+  if (!handle.success) return null;
+
+  const queryKeys = [...parsed.searchParams.keys()];
+  if (queryKeys.length === 0) {
+    return {
+      url: `${HOSTED_GATEWAY_URL}/vm/${handle.data}`,
+      handle: handle.data,
+      runtimeSlot: "primary",
+    };
+  }
+  if (queryKeys.length !== 1 || queryKeys[0] !== "runtime") return null;
+  const runtimeValues = parsed.searchParams.getAll("runtime");
+  const runtimeSlot = MatrixComputerRuntimeSlotSchema.safeParse(runtimeValues[0]);
+  if (runtimeValues.length !== 1 || !runtimeSlot.success || runtimeSlot.data === "primary") return null;
+  return {
+    url: `${HOSTED_GATEWAY_URL}/vm/${handle.data}?runtime=${runtimeSlot.data}`,
+    handle: handle.data,
+    runtimeSlot: runtimeSlot.data,
+  };
+}
+
+/** Platform-owned journey state is not scoped to a selected `/vm/:handle`. */
+export function getMobileJourneyGatewayUrl(selectedGatewayUrl: string): string {
+  return isHostedGatewayUrl(selectedGatewayUrl) ? HOSTED_GATEWAY_URL : selectedGatewayUrl;
+}
+
+/** Hosted app-session tokens route the request to their computer from the canonical app path. */
+export function resolveMobileAppSessionLaunchUrl(selectedGatewayUrl: string, launchUrl: string): string {
+  if (launchUrl.startsWith("http")) return launchUrl;
+  const base = (isHostedGatewayUrl(selectedGatewayUrl) ? HOSTED_GATEWAY_URL : selectedGatewayUrl)
+    .replace(/\/+$/, "");
+  return `${base}${launchUrl.startsWith("/") ? "" : "/"}${launchUrl}`;
 }
 
 export function normalizeGatewayUrl(input: string): string {
@@ -72,8 +135,20 @@ export async function getSelectedGatewayConnection(): Promise<GatewayConnection>
   try {
     const parsed = JSON.parse(raw) as Partial<GatewayConnection>;
     if (typeof parsed.url !== "string") return HOSTED_GATEWAY;
+    const hosted = parseHostedGatewayUrl(parsed.url);
+    if (hosted?.handle === null) return HOSTED_GATEWAY;
+    if (hosted) {
+      const persistedSlot = MatrixComputerRuntimeSlotSchema.safeParse(parsed.runtimeSlot);
+      if (persistedSlot.success && persistedSlot.data !== hosted.runtimeSlot) return HOSTED_GATEWAY;
+      return {
+        id: `${HOSTED_GATEWAY_ID}:${hosted.runtimeSlot}:${hosted.handle}`,
+        url: hosted.url,
+        runtimeSlot: hosted.runtimeSlot,
+        name: typeof parsed.name === "string" && parsed.name.trim() ? parsed.name : "Matrix OS Computer",
+        addedAt: typeof parsed.addedAt === "number" ? parsed.addedAt : Date.now(),
+      };
+    }
     const url = normalizeGatewayUrl(parsed.url);
-    if (url === HOSTED_GATEWAY_URL) return HOSTED_GATEWAY;
     return {
       id: typeof parsed.id === "string" ? parsed.id : CUSTOM_GATEWAY_ID,
       url,
@@ -87,15 +162,44 @@ export async function getSelectedGatewayConnection(): Promise<GatewayConnection>
 }
 
 export async function saveSelectedGatewayUrl(input: string): Promise<GatewayConnection> {
-  const url = normalizeGatewayUrl(input);
-  if (url === HOSTED_GATEWAY_URL) {
+  const hosted = parseHostedGatewayUrl(input);
+  if (hosted?.handle === null) {
     await SecureStore.deleteItemAsync(GATEWAY_CONNECTION_KEY);
     return HOSTED_GATEWAY;
   }
+  if (hosted) {
+    const gateway: GatewayConnection = {
+      id: `${HOSTED_GATEWAY_ID}:${hosted.runtimeSlot}:${hosted.handle}`,
+      url: hosted.url,
+      runtimeSlot: hosted.runtimeSlot,
+      name: "Matrix OS Computer",
+      addedAt: Date.now(),
+    };
+    await SecureStore.setItemAsync(GATEWAY_CONNECTION_KEY, JSON.stringify(gateway));
+    return gateway;
+  }
+  const url = normalizeGatewayUrl(input);
   const gateway: GatewayConnection = {
     id: CUSTOM_GATEWAY_ID,
     url,
     name: "Self-hosted Matrix OS",
+    addedAt: Date.now(),
+  };
+  await SecureStore.setItemAsync(GATEWAY_CONNECTION_KEY, JSON.stringify(gateway));
+  return gateway;
+}
+
+export async function saveSelectedHostedComputer(input: MatrixComputer): Promise<GatewayConnection> {
+  const computer = MatrixComputerSchema.parse(input);
+  const hosted = parseHostedGatewayUrl(`${HOSTED_GATEWAY_URL}${computer.gatewayPath}`);
+  if (!hosted || hosted.handle !== computer.handle || hosted.runtimeSlot !== computer.runtimeSlot) {
+    throw new Error("Invalid Matrix computer route.");
+  }
+  const gateway: GatewayConnection = {
+    id: `${HOSTED_GATEWAY_ID}:${computer.runtimeSlot}:${computer.handle}`,
+    url: hosted.url,
+    runtimeSlot: computer.runtimeSlot,
+    name: computer.label,
     addedAt: Date.now(),
   };
   await SecureStore.setItemAsync(GATEWAY_CONNECTION_KEY, JSON.stringify(gateway));
@@ -117,7 +221,10 @@ export async function saveSelectedGatewayBasicAuth(input: string, username: stri
     name: "Self-hosted Matrix OS",
     addedAt: Date.now(),
   };
-  await SecureStore.setItemAsync(GATEWAY_CONNECTION_KEY, JSON.stringify(gateway));
+  // Keep the credential in memory for this session only; the persisted record
+  // must never contain an Authorization value.
+  const persistedGateway: GatewayConnection = { ...gateway, token: undefined };
+  await SecureStore.setItemAsync(GATEWAY_CONNECTION_KEY, JSON.stringify(persistedGateway));
   return gateway;
 }
 


### PR DESCRIPTION
Stacked on #933 (`feat/mobile-agent-project-creation`).

## What

Six commits restoring two lost/hidden mobile surfaces and fixing the integration defects found during physical-device validation against preview computer pr-919:

- `feat(mobile): restore Matrix computer switcher` — ports the computer picker from the diverged `105-mobile-computer-switcher` branch (dropped in the restack): Settings gains a Switch computer row; picker lists `GET /api/auth/computers`, persists the selected `/vm/<handle>?runtime=<slot>` route credential-free, and routes journey polling + hosted app-session launches through the canonical platform origin.
- `fix(mobile): route requests for runtime-slot computer URLs` — splits the routing query off the client base URL and re-applies it to every HTTP/WS request so path joins stay valid (previously any selected runtime-slot computer stuck at "connecting").
- `feat(mobile): show Chat as a bottom tab` — Hermes kernel chat becomes a first-class tab (Apps · Chat · Terminal · Settings); ChatMessage role bubbles/link colors converted from static light palette to Unistyles theme tokens.
- `fix(mobile): authenticate gateway client on computer switch` — in-app switches now build the client with the live Clerk token provider + WS upgrade token, mirroring the mount path (previously every in-app switch produced an unauthenticated client).
- `fix(mobile): tolerate repurposed messages endpoint in chat history` — `/api/messages` is messaging-bridge-owned on newer gateways; non-array bodies now mean end-of-history instead of crashing pagination.

## Invariants

- **Source of truth**: platform `GET /api/auth/computers` for the computer list; the selected connection persists in SecureStore as a `/vm/<handle>[?runtime=<slot>]` route with **no credential material** (hosted auth is always the live Clerk token; self-hosted Basic Auth is session-only and never persisted).
- **URL routing**: platform explicit-VM routing (`/vm/<handle>/<upstreamPath>` + `?runtime=<slot>` query) is the sanctioned path; the client splits the routing query once at construction and re-applies it on every request/WS URL.
- **Auth source of truth**: Clerk token provider for hosted computers (mount and switch paths now share the same recipe); stored `token` only for self-hosted gateways.
- **Deferred scope**: kernel-chat history pagination has no REST source after the `/api/messages` repurpose — tolerated client-side; canonical history contract is a gateway follow-up. Consolidating the duplicated client-construction recipe into one helper is deferred to the agents-page redesign branch.

## Tests

- 36 suites / 399 tests passing (`pnpm exec jest --runInBand`), `tsc --noEmit`, `expo lint`, `bun run check:patterns` (0 violations)
- New: `computer-picker-screen.test.tsx` (243 lines), `mobile-computers.test.ts`, `tabs-layout.test.tsx`, gateway-client routed-URL tests, storage hosted-computer-selection security tests (rejects `?token=` smuggling, `/vm/../admin` traversal)
- react-doctor: `index.tsx` effect-cleanup finding is a false positive (cleanup returned); remaining findings pre-existing in untouched files

## Validation

Physical-device validation on iPhone against preview computer pr-919: computer list load, pr-919 ↔ Main switching without app restart, chat send/receive, journey polling no longer spams HTML-parse warnings. Screenshots to be attached by owner (validation was live on-device).