### PR TITLE
feat(cli): improve file transfer paths and shell resilience

### DIFF
--- a/packages/gateway/src/file-blob-routes.ts
+++ b/packages/gateway/src/file-blob-routes.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from "node:crypto";
 import { lstat, mkdir, readFile, rename, stat, unlink, writeFile } from "node:fs/promises";
-import { basename, dirname, extname } from "node:path";
+import { basename, dirname, extname, posix } from "node:path";
 import { Hono, type Context } from "hono";
 import { bodyLimit } from "hono/body-limit";
 import { z } from "zod/v4";
@@ -19,6 +19,12 @@ const BoolQuerySchema = z
 
 const BlobQuerySchema = z.object({
   path: z.string().trim().min(1).max(4096),
+  filename: z.string()
+    .min(1)
+    .max(255)
+    .regex(/^[^/\0]+$/)
+    .refine((value) => value !== "." && value !== "..")
+    .optional(),
   force: BoolQuerySchema,
   secret: BoolQuerySchema,
 });
@@ -56,6 +62,7 @@ export function createFileBlobRoutes(deps: FileBlobRouteDeps): Hono {
   function parseQuery(c: Context) {
     const parsed = BlobQuerySchema.safeParse({
       path: c.req.query("path"),
+      filename: c.req.query("filename"),
       force: c.req.query("force"),
       secret: c.req.query("secret"),
     });
@@ -84,11 +91,37 @@ export function createFileBlobRoutes(deps: FileBlobRouteDeps): Hono {
     const parsed = parseQuery(c);
     if (!parsed) return invalidPath(c);
 
-    const resolved = resolveWritableFileApiPath(deps.homePath, parsed.path);
+    let destinationPath = parsed.path;
+    let resolved = resolveWritableFileApiPath(deps.homePath, destinationPath);
     if (!resolved) return invalidPath(c);
 
     try {
       const existing = await lstat(resolved);
+      if (existing.isDirectory()) {
+        if (!parsed.filename) return c.json({ error: "not_file" }, 400);
+        destinationPath = posix.join(destinationPath, parsed.filename);
+        resolved = resolveWritableFileApiPath(deps.homePath, destinationPath);
+        if (!resolved) return invalidPath(c);
+      }
+    } catch (err: unknown) {
+      if (
+        !(err instanceof Error) ||
+        !("code" in err) ||
+        (err as NodeJS.ErrnoException).code !== "ENOENT"
+      ) {
+        throw err;
+      }
+      if (parsed.path.endsWith("/") && parsed.filename) {
+        destinationPath = posix.join(parsed.path, parsed.filename);
+        resolved = resolveWritableFileApiPath(deps.homePath, destinationPath);
+        if (!resolved) return invalidPath(c);
+      }
+    }
+
+    if (!resolved) return invalidPath(c);
+    const uploadPath = resolved;
+    try {
+      const existing = await lstat(uploadPath);
       if (existing.isDirectory()) return c.json({ error: "not_file" }, 400);
       if (!parsed.force) return c.json({ error: "file_exists" }, 409);
     } catch (err: unknown) {
@@ -102,15 +135,15 @@ export function createFileBlobRoutes(deps: FileBlobRouteDeps): Hono {
     }
 
     const body = Buffer.from(await c.req.arrayBuffer());
-    const parent = dirname(resolved);
-    const tmpPath = `${resolved}.matrix-upload-${randomUUID()}.tmp`;
+    const parent = dirname(uploadPath);
+    const tmpPath = `${uploadPath}.matrix-upload-${randomUUID()}.tmp`;
     const mode = parsed.secret ? 0o600 : 0o644;
 
     try {
       await mkdir(parent, { recursive: true, mode: 0o700 });
       await writeFile(tmpPath, body, { flag: "wx", mode });
-      await rename(tmpPath, resolved);
-      return c.json({ ok: true, path: parsed.path, size: body.byteLength });
+      await rename(tmpPath, uploadPath);
+      return c.json({ ok: true, path: destinationPath, size: body.byteLength });
     } catch (err: unknown) {
       await safeUnlink(tmpPath);
       if (

--- a/packages/sync-client/src/cli/commands/completion.ts
+++ b/packages/sync-client/src/cli/commands/completion.ts
@@ -202,6 +202,10 @@ function fishCompletion(): string {
   return `# Matrix CLI completion for fish
 function __matrix_transfer_position
   set -l tokens (commandline -opc)
+  set -l current_token (commandline -ct)
+  if test -n "$current_token"; and test (count $tokens) -gt 2
+    set -e tokens[-1]
+  end
   set -l skip 0
   set -l position 0
   for word in $tokens[3..-1]

--- a/packages/sync-client/src/cli/commands/completion.ts
+++ b/packages/sync-client/src/cli/commands/completion.ts
@@ -1,4 +1,7 @@
 import { defineCommand } from "citty";
+import { requireCliAuthToken } from "../auth-state.js";
+import { completeRemotePaths } from "../file-transfer-client.js";
+import { resolveCliProfile } from "../profiles.js";
 
 const COMMANDS = [
   "login",
@@ -41,8 +44,30 @@ _matrix_shell_sessions() {
     | sed -n 's/.*"name"[[:space:]]*:[[:space:]]*"\\([^"]*\\)".*/\\1/p'
 }
 
+_matrix_remote_paths() {
+  matrix completion paths "$1" 2>/dev/null
+}
+
+_matrix_transfer_position() {
+  local i word skip=0 position=0
+  for ((i = 2; i < COMP_CWORD; i++)); do
+    word="\${COMP_WORDS[i]}"
+    if ((skip)); then
+      skip=0
+      continue
+    fi
+    case "$word" in
+      --profile|--gateway|--token) skip=1 ;;
+      --profile=*|--gateway=*|--token=*|--force|--secret|--dev|--json) ;;
+      --*) ;;
+      *) ((position += 1)) ;;
+    esac
+  done
+  printf '%s' "$position"
+}
+
 _matrix_completion() {
-  local cur command shell_command
+  local cur command shell_command transfer_position
   cur="\${COMP_WORDS[COMP_CWORD]}"
   command="\${COMP_WORDS[1]}"
   shell_command="\${COMP_WORDS[2]}"
@@ -60,6 +85,32 @@ _matrix_completion() {
     COMPREPLY=( $(compgen -W "${SHELL_COMMANDS.join(" ")}" -- "$cur") )
     return 0
   fi
+
+  if [[ "$command" == "upload" ]]; then
+    transfer_position="$(_matrix_transfer_position)"
+    if [[ "$transfer_position" -eq 0 ]]; then
+      COMPREPLY=( $(compgen -f -- "$cur") )
+      return 0
+    fi
+    while IFS= read -r candidate; do
+      [[ "$candidate" == "$cur"* ]] && COMPREPLY+=("$candidate")
+    done < <(_matrix_remote_paths "$cur")
+    compopt -o nospace 2>/dev/null || true
+    return 0
+  fi
+
+  if [[ "$command" == "download" ]]; then
+    transfer_position="$(_matrix_transfer_position)"
+    if [[ "$transfer_position" -eq 0 ]]; then
+      while IFS= read -r candidate; do
+        [[ "$candidate" == "$cur"* ]] && COMPREPLY+=("$candidate")
+      done < <(_matrix_remote_paths "$cur")
+      compopt -o nospace 2>/dev/null || true
+      return 0
+    fi
+    COMPREPLY=( $(compgen -f -- "$cur") )
+    return 0
+  fi
 }
 complete -F _matrix_completion matrix
 `;
@@ -74,8 +125,31 @@ _matrix_shell_sessions() {
     | sed -n 's/.*"name"[[:space:]]*:[[:space:]]*"\\([^"]*\\)".*/\\1/p'
 }
 
+_matrix_remote_paths() {
+  matrix completion paths "$1" 2>/dev/null
+}
+
+_matrix_transfer_position() {
+  local i word skip=0 position=0
+  for ((i = 3; i < CURRENT; i++)); do
+    word="\${words[i]}"
+    if ((skip)); then
+      skip=0
+      continue
+    fi
+    case "$word" in
+      --profile|--gateway|--token) skip=1 ;;
+      --profile=*|--gateway=*|--token=*|--force|--secret|--dev|--json) ;;
+      --*) ;;
+      *) ((position += 1)) ;;
+    esac
+  done
+  REPLY="$position"
+}
+
 _matrix() {
   local -a commands shell_commands shell_sessions
+  local REPLY
   commands=(${COMMANDS.map((command) => `'${command}:${command}'`).join(" ")})
   shell_commands=(${SHELL_COMMANDS.map((command) => `'${command}:${command}'`).join(" ")})
 
@@ -94,6 +168,28 @@ _matrix() {
     return
   fi
 
+  if [[ "\${words[2]}" == "upload" ]]; then
+    _matrix_transfer_position
+    if (( REPLY == 0 )); then
+      _files
+      return
+    fi
+    shell_sessions=("\${(@f)$(_matrix_remote_paths "\${words[CURRENT]}")}")
+    compadd -Q -S '' -- "\${shell_sessions[@]}"
+    return
+  fi
+
+  if [[ "\${words[2]}" == "download" ]]; then
+    _matrix_transfer_position
+    if (( REPLY == 0 )); then
+      shell_sessions=("\${(@f)$(_matrix_remote_paths "\${words[CURRENT]}")}")
+      compadd -Q -S '' -- "\${shell_sessions[@]}"
+      return
+    fi
+    _files
+    return
+  fi
+
   _files
 }
 compdef _matrix matrix
@@ -104,9 +200,33 @@ function fishCompletion(): string {
   const commandList = COMMANDS.join(" ");
   const shellCommandList = SHELL_COMMANDS.join(" ");
   return `# Matrix CLI completion for fish
+function __matrix_transfer_position
+  set -l tokens (commandline -opc)
+  set -l skip 0
+  set -l position 0
+  for word in $tokens[3..-1]
+    if test $skip -eq 1
+      set skip 0
+      continue
+    end
+    switch $word
+      case --profile --gateway --token
+        set skip 1
+      case '--profile=*' '--gateway=*' '--token=*' --force --secret --dev --json '--*'
+      case '*'
+        set position (math $position + 1)
+    end
+  end
+  echo $position
+end
+
 complete -c matrix -f -n '__fish_use_subcommand' -a '${commandList}'
 complete -c matrix -f -n '__fish_seen_subcommand_from shell sh; and not __fish_seen_subcommand_from ${SHELL_COMMANDS.join(" ")}' -a '${shellCommandList}'
 complete -c matrix -f -n '__fish_seen_subcommand_from shell sh; and __fish_seen_subcommand_from connect attach rm' -a '(matrix shell list --json 2>/dev/null | tr "," "\\n" | sed -n "s/.*\\"name\\"[[:space:]]*:[[:space:]]*\\"\\\\([^\\"]*\\\\)\\".*/\\\\1/p")'
+complete -c matrix -F -n '__fish_seen_subcommand_from upload; and test (__matrix_transfer_position) -eq 0'
+complete -c matrix -f -n '__fish_seen_subcommand_from upload; and test (__matrix_transfer_position) -ge 1' -a '(matrix completion paths (commandline -ct) 2>/dev/null)'
+complete -c matrix -f -n '__fish_seen_subcommand_from download; and test (__matrix_transfer_position) -eq 0' -a '(matrix completion paths (commandline -ct) 2>/dev/null)'
+complete -c matrix -F -n '__fish_seen_subcommand_from download; and test (__matrix_transfer_position) -ge 1'
 `;
 }
 
@@ -132,8 +252,28 @@ export const completionCommand = defineCommand({
   meta: { name: "completion", description: "Print shell completion scripts" },
   args: {
     shell: { type: "positional", required: false },
+    prefix: { type: "positional", required: false },
+    profile: { type: "string", required: false },
+    dev: { type: "boolean", required: false, default: false },
+    gateway: { type: "string", required: false },
+    token: { type: "string", required: false },
   },
-  run: ({ args }) => {
-    console.log(completionFor(typeof args.shell === "string" ? args.shell : undefined));
+  run: async ({ args }) => {
+    const shell = typeof args.shell === "string" ? args.shell : undefined;
+    if (shell === "paths") {
+      try {
+        const profile = await resolveCliProfile(args);
+        const token = await requireCliAuthToken(profile);
+        const paths = await completeRemotePaths(
+          { gatewayUrl: profile.gatewayUrl, token },
+          typeof args.prefix === "string" ? args.prefix : "~/",
+        );
+        if (paths.length > 0) process.stdout.write(`${paths.join("\n")}\n`);
+      } catch {
+        // Completion must stay silent when auth or the remote instance is unavailable.
+      }
+      return;
+    }
+    console.log(completionFor(shell));
   },
 });

--- a/packages/sync-client/src/cli/commands/completion.ts
+++ b/packages/sync-client/src/cli/commands/completion.ts
@@ -269,8 +269,12 @@ export const completionCommand = defineCommand({
           typeof args.prefix === "string" ? args.prefix : "~/",
         );
         if (paths.length > 0) process.stdout.write(`${paths.join("\n")}\n`);
-      } catch {
+      } catch (err) {
         // Completion must stay silent when auth or the remote instance is unavailable.
+        if (process.env.MATRIX_CLI_DEBUG === "1") {
+          const kind = err instanceof Error ? err.name : typeof err;
+          console.error(`[debug] remote path completion unavailable: ${kind}`);
+        }
       }
       return;
     }

--- a/packages/sync-client/src/cli/commands/download.ts
+++ b/packages/sync-client/src/cli/commands/download.ts
@@ -19,8 +19,16 @@ export const downloadCommand = defineCommand({
     description: "Download one file from your Matrix computer",
   },
   args: {
-    remote: { type: "positional", required: true },
-    local: { type: "positional", required: true },
+    remote: {
+      type: "positional",
+      required: true,
+      description: "Source file in your Matrix home",
+    },
+    local: {
+      type: "positional",
+      required: true,
+      description: "Local destination path on this computer",
+    },
     force: { type: "boolean", required: false, default: false },
     secret: { type: "boolean", required: false, default: false },
     profile: { type: "string", required: false },

--- a/packages/sync-client/src/cli/commands/upload.ts
+++ b/packages/sync-client/src/cli/commands/upload.ts
@@ -19,8 +19,16 @@ export const uploadCommand = defineCommand({
     description: "Upload one local file to your Matrix computer",
   },
   args: {
-    local: { type: "positional", required: true },
-    remote: { type: "positional", required: true },
+    local: {
+      type: "positional",
+      required: true,
+      description: "Local file path on this computer",
+    },
+    remote: {
+      type: "positional",
+      required: true,
+      description: "Destination file or existing folder in your Matrix home",
+    },
     force: { type: "boolean", required: false, default: false },
     secret: { type: "boolean", required: false, default: false },
     profile: { type: "string", required: false },

--- a/packages/sync-client/src/cli/file-transfer-client.ts
+++ b/packages/sync-client/src/cli/file-transfer-client.ts
@@ -35,11 +35,17 @@ export function expandLocalPath(path: string): string {
 }
 
 export function normalizeMatrixPath(remotePath: string): string {
-  const homeRelative = remotePath === "~"
+  const localHome = homedir();
+  const shellExpandedHomeRelative = remotePath === localHome
     ? "."
-    : remotePath.startsWith("~/")
-      ? remotePath.slice(2) || "."
+    : remotePath.startsWith(`${localHome}/`)
+      ? remotePath.slice(localHome.length + 1)
       : remotePath;
+  const homeRelative = shellExpandedHomeRelative === "~"
+    ? "."
+    : shellExpandedHomeRelative.startsWith("~/")
+      ? shellExpandedHomeRelative.slice(2) || "."
+      : shellExpandedHomeRelative;
   if (!homeRelative || homeRelative.startsWith("/")) {
     throw codedError(
       "Matrix paths must stay within your Matrix home. Use a path such as `~/dev/file.txt`.",

--- a/packages/sync-client/src/cli/file-transfer-client.ts
+++ b/packages/sync-client/src/cli/file-transfer-client.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from "node:crypto";
 import { chmod, lstat, mkdir, readFile, rename, stat, unlink, writeFile } from "node:fs/promises";
-import { dirname, resolve } from "node:path";
+import { basename, dirname, posix, resolve } from "node:path";
 import { homedir } from "node:os";
 
 export interface FileTransferClient {
@@ -28,9 +28,37 @@ export function expandLocalPath(path: string): string {
   return resolve(path);
 }
 
-function blobUrl(client: FileTransferClient, remotePath: string, options: UploadOptions = {}): string {
+export function normalizeMatrixPath(remotePath: string): string {
+  const homeRelative = remotePath === "~"
+    ? "."
+    : remotePath.startsWith("~/")
+      ? remotePath.slice(2) || "."
+      : remotePath;
+  if (!homeRelative || homeRelative.startsWith("/")) {
+    throw codedError(
+      "Matrix paths must stay within your Matrix home. Use a path such as `~/dev/file.txt`.",
+      "invalid_remote_path",
+    );
+  }
+  const normalized = posix.normalize(homeRelative);
+  if (normalized === ".." || normalized.startsWith("../")) {
+    throw codedError(
+      "Matrix paths must stay within your Matrix home. Use a path such as `~/dev/file.txt`.",
+      "invalid_remote_path",
+    );
+  }
+  return normalized;
+}
+
+function blobUrl(
+  client: FileTransferClient,
+  remotePath: string,
+  options: UploadOptions = {},
+  localFilename?: string,
+): string {
   const url = new URL("/api/files/blob", client.gatewayUrl);
-  url.searchParams.set("path", remotePath);
+  url.searchParams.set("path", normalizeMatrixPath(remotePath));
+  if (localFilename) url.searchParams.set("filename", localFilename);
   if (options.force) url.searchParams.set("force", "true");
   if (options.secret) url.searchParams.set("secret", "true");
   return url.toString();
@@ -40,13 +68,98 @@ function authHeaders(client: FileTransferClient): Record<string, string> {
   return { authorization: `Bearer ${client.token}` };
 }
 
-function errorForResponse(res: Response, fallback: string): Error {
+export async function completeRemotePaths(
+  client: FileTransferClient,
+  remotePrefix: string,
+): Promise<string[]> {
+  const homeStyle = remotePrefix === "~" || remotePrefix.startsWith("~/");
+  const relativePrefix = remotePrefix === "~"
+    ? ""
+    : homeStyle
+      ? remotePrefix.slice(2)
+      : remotePrefix;
+  if (relativePrefix.startsWith("/")) return [];
+
+  const separator = relativePrefix.lastIndexOf("/");
+  const parentPrefix = separator >= 0 ? relativePrefix.slice(0, separator) : "";
+  const namePrefix = separator >= 0 ? relativePrefix.slice(separator + 1) : relativePrefix;
+  let parentPath: string;
+  try {
+    parentPath = normalizeMatrixPath(parentPrefix || ".");
+  } catch {
+    return [];
+  }
+
+  const url = new URL("/api/files/list", client.gatewayUrl);
+  url.searchParams.set("path", parentPath);
+  try {
+    const res = await fetch(url, {
+      headers: authHeaders(client),
+      signal: AbortSignal.timeout(10_000),
+    });
+    if (!res.ok) return [];
+    const payload = (await res.json()) as { entries?: unknown };
+    if (!Array.isArray(payload.entries)) return [];
+    const displayParent = parentPrefix ? `${parentPrefix}/` : "";
+    const displayHome = homeStyle ? "~/" : "";
+    return payload.entries
+      .slice(0, 500)
+      .flatMap((entry): string[] => {
+        if (!entry || typeof entry !== "object") return [];
+        const { name, type } = entry as { name?: unknown; type?: unknown };
+        if (
+          typeof name !== "string" ||
+          !name.startsWith(namePrefix) ||
+          /[\r\n]/.test(name) ||
+          (type !== "file" && type !== "directory")
+        ) {
+          return [];
+        }
+        return [`${displayHome}${displayParent}${name}${type === "directory" ? "/" : ""}`];
+      });
+  } catch {
+    return [];
+  }
+}
+
+const SAFE_TRANSFER_ERRORS: Record<string, { code: string; message: string }> = {
+  invalid_path: {
+    code: "invalid_remote_path",
+    message: "Matrix paths must stay within your Matrix home. Use a path such as `~/dev/file.txt`.",
+  },
+  not_file: {
+    code: "remote_path_not_file",
+    message: "Matrix source must be a regular file.",
+  },
+  file_exists: {
+    code: "remote_file_exists",
+    message: "Remote file already exists. Re-run with --force to overwrite.",
+  },
+  payload_too_large: {
+    code: "payload_too_large",
+    message: "File is too large for single-file transfer.",
+  },
+};
+
+async function safeTransferErrorCode(res: Response): Promise<string | null> {
+  try {
+    const payload = (await res.json()) as { error?: unknown };
+    return typeof payload.error === "string" ? payload.error : null;
+  } catch {
+    return null;
+  }
+}
+
+async function errorForResponse(res: Response, fallback: string): Promise<Error> {
   if (res.status === 401 || res.status === 403) {
     return codedError("Auth token rejected or expired. Run `matrix login` again.", "auth_rejected");
   }
-  if (res.status === 404) {
-    return codedError("Remote file not found.", "remote_file_not_found");
+  const serverCode = await safeTransferErrorCode(res);
+  if (serverCode && SAFE_TRANSFER_ERRORS[serverCode]) {
+    const safe = SAFE_TRANSFER_ERRORS[serverCode];
+    return codedError(safe.message, safe.code);
   }
+  if (res.status === 404) return codedError("Remote file not found.", "remote_file_not_found");
   if (res.status === 409) {
     return codedError("Remote file already exists. Re-run with --force to overwrite.", "remote_file_exists");
   }
@@ -81,14 +194,14 @@ export async function uploadLocalFile(
   }
 
   const bytes = await readFile(resolvedLocal);
-  const res = await fetch(blobUrl(client, remotePath, options), {
+  const res = await fetch(blobUrl(client, remotePath, options, basename(resolvedLocal)), {
     method: "PUT",
     headers: authHeaders(client),
     body: new Blob([bytes]),
     signal: AbortSignal.timeout(30_000),
   });
   if (!res.ok) {
-    throw errorForResponse(res, "Upload failed.");
+    throw await errorForResponse(res, "Upload failed.");
   }
   return (await res.json()) as { ok: true; path: string; size: number };
 }
@@ -123,7 +236,7 @@ export async function downloadRemoteFile(
     signal: AbortSignal.timeout(30_000),
   });
   if (!res.ok) {
-    throw errorForResponse(res, "Download failed.");
+    throw await errorForResponse(res, "Download failed.");
   }
 
   const bytes = Buffer.from(await res.arrayBuffer());

--- a/packages/sync-client/src/cli/file-transfer-client.ts
+++ b/packages/sync-client/src/cli/file-transfer-client.ts
@@ -22,6 +22,12 @@ function codedError(message: string, code: string): Error {
   return Object.assign(new Error(message), { code });
 }
 
+function debugTransferFailure(context: string, err: unknown): void {
+  if (process.env.MATRIX_CLI_DEBUG !== "1") return;
+  const kind = err instanceof Error ? err.name : typeof err;
+  console.error(`[debug] ${context}: ${kind}`);
+}
+
 export function expandLocalPath(path: string): string {
   if (path === "~") return homedir();
   if (path.startsWith("~/")) return resolve(homedir(), path.slice(2));
@@ -86,7 +92,8 @@ export async function completeRemotePaths(
   let parentPath: string;
   try {
     parentPath = normalizeMatrixPath(parentPrefix || ".");
-  } catch {
+  } catch (err) {
+    debugTransferFailure("remote completion path rejected", err);
     return [];
   }
 
@@ -117,7 +124,8 @@ export async function completeRemotePaths(
         }
         return [`${displayHome}${displayParent}${name}${type === "directory" ? "/" : ""}`];
       });
-  } catch {
+  } catch (err) {
+    debugTransferFailure("remote completion request failed", err);
     return [];
   }
 }
@@ -145,7 +153,8 @@ async function safeTransferErrorCode(res: Response): Promise<string | null> {
   try {
     const payload = (await res.json()) as { error?: unknown };
     return typeof payload.error === "string" ? payload.error : null;
-  } catch {
+  } catch (err) {
+    debugTransferFailure("transfer error response was not JSON", err);
     return null;
   }
 }

--- a/packages/sync-client/src/cli/shell-client.ts
+++ b/packages/sync-client/src/cli/shell-client.ts
@@ -832,7 +832,7 @@ export function createShellClient(options: ShellClientOptions): ShellClient {
           }
           try {
             const canContinue = output.write(data);
-            if (!canContinue) {
+            if (canContinue === false) {
               localOutputBackpressured = true;
               output.once?.("drain", onLocalOutputDrain);
               currentWs?.close();

--- a/packages/sync-client/src/cli/shell-client.ts
+++ b/packages/sync-client/src/cli/shell-client.ts
@@ -765,6 +765,7 @@ export function createShellClient(options: ShellClientOptions): ShellClient {
         let heartbeatPending = false;
         let missedHeartbeats = 0;
         let reconnectNoticeVisible = false;
+        let localOutputBackpressured = false;
         const detachForClosedLocalPipe = () => {
           if (settled) {
             return;
@@ -818,6 +819,30 @@ export function createShellClient(options: ShellClientOptions): ShellClient {
         const onLocalStreamError = (err: unknown) => {
           handleLocalStreamError(err);
         };
+        const onLocalOutputDrain = () => {
+          if (settled || !localOutputBackpressured) {
+            return;
+          }
+          localOutputBackpressured = false;
+          scheduleReconnect();
+        };
+        const writeRemoteOutput = (data: string): boolean => {
+          if (settled || localOutputBackpressured) {
+            return false;
+          }
+          try {
+            const canContinue = output.write(data);
+            if (!canContinue) {
+              localOutputBackpressured = true;
+              output.once?.("drain", onLocalOutputDrain);
+              currentWs?.close();
+            }
+            return true;
+          } catch (err: unknown) {
+            handleLocalStreamError(err);
+            return false;
+          }
+        };
         const cleanup = () => {
           clearTimeout(attachTimeout);
           clearTimeout(reconnectTimer);
@@ -829,6 +854,7 @@ export function createShellClient(options: ShellClientOptions): ShellClient {
           process.off("SIGTERM", onSignal);
           process.off("exit", onProcessExit);
           output.off?.("error", onLocalStreamError);
+          output.off?.("drain", onLocalOutputDrain);
           errorOutput.off?.("error", onLocalStreamError);
           pendingInput = "";
           inputFilter.reset();
@@ -1255,12 +1281,11 @@ export function createShellClient(options: ShellClientOptions): ShellClient {
             }
             schedulePostAttachResizeFrames();
           } else if (msg.type === "output" && typeof msg.data === "string") {
-            if (Number.isSafeInteger(msg.seq) && (msg.seq as number) >= 0) {
-              lastSeq = msg.seq as number;
-            }
             noteRemoteActivity();
             inputFilter.noteRemoteOutput();
-            writeOutput(msg.data);
+            if (writeRemoteOutput(msg.data) && Number.isSafeInteger(msg.seq) && (msg.seq as number) >= 0) {
+              lastSeq = msg.seq as number;
+            }
           } else if (msg.type === "pong") {
             noteRemoteActivity();
           } else if (msg.type === "error") {
@@ -1281,6 +1306,9 @@ export function createShellClient(options: ShellClientOptions): ShellClient {
           cleanupSocket();
           if (!shouldReconnect) {
             settle(() => reject(Object.assign(new Error("Request failed"), { code: "attach_failed" })));
+            return;
+          }
+          if (localOutputBackpressured) {
             return;
           }
           scheduleReconnect();

--- a/packages/sync-client/tests/unit/file-transfer-client.test.ts
+++ b/packages/sync-client/tests/unit/file-transfer-client.test.ts
@@ -3,6 +3,7 @@ import { mkdtemp, readFile, rm, stat, symlink, writeFile } from "node:fs/promise
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
+  completeRemotePaths,
   downloadRemoteFile,
   uploadLocalFile,
 } from "../../src/cli/file-transfer-client.js";
@@ -38,7 +39,7 @@ describe("cli/file-transfer-client", () => {
 
     expect(fetchMock).toHaveBeenCalledTimes(1);
     const [url, init] = fetchMock.mock.calls[0]!;
-    expect(String(url)).toBe("https://gateway.example/api/files/blob?path=.codex%2Fauth.json&force=true&secret=true");
+    expect(String(url)).toBe("https://gateway.example/api/files/blob?path=.codex%2Fauth.json&filename=auth.json&force=true&secret=true");
     expect(init?.method).toBe("PUT");
     expect((init?.headers as Record<string, string>).authorization).toBe("Bearer token");
     expect(Buffer.from(await (init?.body as Blob).arrayBuffer()).toString("utf8")).toBe('{"token":"secret"}');
@@ -65,6 +66,33 @@ describe("cli/file-transfer-client", () => {
 
     const [, init] = fetchMock.mock.calls[0]!;
     expect(Buffer.from(await (init?.body as Blob).arrayBuffer()).toString("utf8")).toBe('{"token":"from-symlink"}');
+  });
+
+  it("sends the local filename when uploading to a Matrix-home folder", async () => {
+    const local = join(tempDir, "codex-security-findings.csv");
+    await writeFile(local, "finding\n");
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({
+        ok: true,
+        path: "dev/matrix-os/codex-security-findings.csv",
+        size: 8,
+      }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+
+    const result = await uploadLocalFile(
+      { gatewayUrl: "https://gateway.example", token: "token" },
+      local,
+      "~/dev/matrix-os",
+    );
+
+    const [url] = fetchMock.mock.calls[0]!;
+    expect(String(url)).toBe(
+      "https://gateway.example/api/files/blob?path=dev%2Fmatrix-os&filename=codex-security-findings.csv",
+    );
+    expect(result.path).toBe("dev/matrix-os/codex-security-findings.csv");
   });
 
   it("rejects missing local files and local directories before upload", async () => {
@@ -142,5 +170,66 @@ describe("cli/file-transfer-client", () => {
       ),
     ).rejects.toMatchObject({ code: "remote_file_not_found" });
     await expect(stat(join(tempDir, "new-parent"))).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("reports invalid Matrix destinations clearly on upload", async () => {
+    const local = join(tempDir, "report.csv");
+    await writeFile(local, "finding\n");
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ error: "invalid_path" }), {
+        status: 400,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+
+    await expect(
+      uploadLocalFile(
+        { gatewayUrl: "https://gateway.example", token: "token" },
+        local,
+        "../outside/report.csv",
+      ),
+    ).rejects.toMatchObject({
+      code: "invalid_remote_path",
+      message: expect.stringMatching(/Matrix home/i),
+    });
+  });
+
+  it("keeps status-based transfer errors for older gateways", async () => {
+    const local = join(tempDir, "report.csv");
+    await writeFile(local, "finding\n");
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response("conflict", { status: 409 }),
+    );
+
+    await expect(uploadLocalFile(
+      { gatewayUrl: "https://gateway.example", token: "token" },
+      local,
+      "~/report.csv",
+    )).rejects.toMatchObject({ code: "remote_file_exists" });
+  });
+
+  it("completes Matrix directories while preserving the typed home prefix", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({
+        path: ".",
+        entries: [
+          { name: "dev", type: "directory" },
+          { name: "documents", type: "directory" },
+          { name: "README.md", type: "file" },
+        ],
+      }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+
+    await expect(completeRemotePaths(
+      { gatewayUrl: "https://gateway.example", token: "token" },
+      "~/de",
+    )).resolves.toEqual(["~/dev/"]);
+
+    expect(String(fetchMock.mock.calls[0]?.[0])).toBe(
+      "https://gateway.example/api/files/list?path=.",
+    );
   });
 });

--- a/packages/sync-client/tests/unit/file-transfer-client.test.ts
+++ b/packages/sync-client/tests/unit/file-transfer-client.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { mkdtemp, readFile, rm, stat, symlink, writeFile } from "node:fs/promises";
-import { tmpdir } from "node:os";
+import { homedir, tmpdir } from "node:os";
 import { join } from "node:path";
 import {
   completeRemotePaths,
@@ -93,6 +93,27 @@ describe("cli/file-transfer-client", () => {
       "https://gateway.example/api/files/blob?path=dev%2Fmatrix-os&filename=codex-security-findings.csv",
     );
     expect(result.path).toBe("dev/matrix-os/codex-security-findings.csv");
+  });
+
+  it("treats an unquoted shell-expanded home path as a Matrix-home destination", async () => {
+    const local = join(tempDir, "codex-security-findings.csv");
+    await writeFile(local, "finding\n");
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ ok: true, path: "dev/matrix-os/codex-security-findings.csv", size: 8 }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+
+    await uploadLocalFile(
+      { gatewayUrl: "https://gateway.example", token: "token" },
+      local,
+      join(homedir(), "dev", "matrix-os"),
+    );
+
+    expect(String(fetchMock.mock.calls[0]?.[0])).toBe(
+      "https://gateway.example/api/files/blob?path=dev%2Fmatrix-os&filename=codex-security-findings.csv",
+    );
   });
 
   it("rejects missing local files and local directories before upload", async () => {

--- a/packages/sync-client/tests/unit/shell-client.test.ts
+++ b/packages/sync-client/tests/unit/shell-client.test.ts
@@ -967,6 +967,47 @@ describe("createShellClient attachSession", () => {
     await expect(attach).resolves.toEqual({ detached: false });
   });
 
+  it("backs off the remote attach until a backgrounded local terminal drains", async () => {
+    const output = Object.assign(new EventEmitter(), {
+      columns: 80,
+      rows: 24,
+      write: vi.fn(() => false),
+    }) as unknown as NodeJS.WriteStream;
+    const client = createShellClient({
+      gatewayUrl: "https://matrix.example",
+      token: "token-123",
+      timeoutMs: 100,
+    });
+
+    const attach = client.attachSession("main", {
+      input: new PassThrough() as NodeJS.ReadStream,
+      output,
+      errorOutput: new PassThrough() as NodeJS.WriteStream,
+      WebSocketImpl: FakeWebSocket as never,
+      heartbeatIntervalMs: 0,
+      reconnectBaseDelayMs: 1,
+      reconnectMaxDelayMs: 1,
+    });
+
+    const firstSocket = FakeWebSocket.last;
+    firstSocket?.emit("message", JSON.stringify({ type: "attached" }));
+    firstSocket?.emit("message", JSON.stringify({ type: "output", seq: 41, data: "download progress" }));
+
+    expect(firstSocket?.closed).toBe(true);
+    firstSocket?.emit("close");
+    await new Promise((resolve) => setTimeout(resolve, 5));
+    expect(FakeWebSocket.instances).toHaveLength(1);
+
+    output.write = vi.fn(() => true) as never;
+    output.emit("drain");
+    await waitForFakeSocketCount(2);
+    expect(FakeWebSocket.last?.url).toContain("fromSeq=42");
+
+    FakeWebSocket.last?.emit("message", JSON.stringify({ type: "attached" }));
+    FakeWebSocket.last?.emit("message", JSON.stringify({ type: "exit" }));
+    await expect(attach).resolves.toEqual({ detached: false });
+  });
+
   it("forwards SIGINT after attach so terminals that still emit signals can interrupt remote programs", async () => {
     const input = new PassThrough() as PassThrough & {
       isTTY: true;

--- a/tests/cli/unified-command-tree.test.ts
+++ b/tests/cli/unified-command-tree.test.ts
@@ -164,6 +164,26 @@ describe("unified CLI command tree", () => {
     expect(script).toContain('"connect" || "$shell_command" == "attach" || "$shell_command" == "rm"');
   });
 
+  it("prints authenticated Matrix path completion for upload and download", async () => {
+    for (const shell of ["bash", "zsh", "fish"]) {
+      const logs: string[] = [];
+      const originalLog = console.log;
+      console.log = (line?: unknown) => {
+        logs.push(String(line));
+      };
+      try {
+        await completionCommand.run?.({ args: { shell } } as never);
+      } finally {
+        console.log = originalLog;
+      }
+
+      const script = logs.join("\n");
+      expect(script).toContain("matrix completion paths");
+      expect(script).toContain("upload");
+      expect(script).toContain("download");
+    }
+  });
+
   it("prevents fish shell command completions from mixing with session completions", async () => {
     const logs: string[] = [];
     const originalLog = console.log;

--- a/tests/cli/unified-command-tree.test.ts
+++ b/tests/cli/unified-command-tree.test.ts
@@ -184,6 +184,24 @@ describe("unified CLI command tree", () => {
     }
   });
 
+  it("does not count the active fish token as a completed transfer argument", async () => {
+    const logs: string[] = [];
+    const originalLog = console.log;
+    console.log = (line?: unknown) => {
+      logs.push(String(line));
+    };
+    try {
+      await completionCommand.run?.({ args: { shell: "fish" } } as never);
+    } finally {
+      console.log = originalLog;
+    }
+
+    const script = logs.join("\n");
+    expect(script).toContain("set -l current_token (commandline -ct)");
+    expect(script).toContain("if test -n \"$current_token\"; and test (count $tokens) -gt 2");
+    expect(script).toContain("set -e tokens[-1]");
+  });
+
   it("prevents fish shell command completions from mixing with session completions", async () => {
     const logs: string[] = [];
     const originalLog = console.log;

--- a/tests/gateway/file-blob-routes.test.ts
+++ b/tests/gateway/file-blob-routes.test.ts
@@ -38,6 +38,24 @@ describe("file blob routes", () => {
     expect(get.headers.get("content-type")).toContain("text/markdown");
   });
 
+  it("keeps the local filename when the Matrix destination is a directory", async () => {
+    await mkdir(join(homePath, "dev/matrix-os"), { recursive: true });
+
+    const put = await app.request(
+      "/blob?path=dev%2Fmatrix-os&filename=codex-security-findings.csv",
+      { method: "PUT", body: "finding\n" },
+    );
+
+    expect(put.status).toBe(200);
+    await expect(put.json()).resolves.toEqual({
+      ok: true,
+      path: "dev/matrix-os/codex-security-findings.csv",
+      size: 8,
+    });
+    expect(await readFile(join(homePath, "dev/matrix-os/codex-security-findings.csv"), "utf8"))
+      .toBe("finding\n");
+  });
+
   it("writes secret uploads with owner-only file permissions", async () => {
     const res = await app.request("/blob?path=.codex/auth.json&secret=true", {
       method: "PUT",
@@ -79,6 +97,14 @@ describe("file blob routes", () => {
     });
     expect(traversal.status).toBe(400);
     expect(await traversal.json()).toEqual({ error: "invalid_path" });
+
+    const filenameTraversal = await app.request(
+      "/blob?path=safe&filename=..%2Foutside.txt",
+      { method: "PUT", body: "x" },
+    );
+    expect(filenameTraversal.status).toBe(400);
+    expect(await filenameTraversal.json()).toEqual({ error: "invalid_path" });
+    await expect(readFile(join(homePath, "outside.txt"))).rejects.toMatchObject({ code: "ENOENT" });
 
     const symlinkParent = await app.request("/blob?path=safe/link/secret.txt", {
       method: "PUT",

--- a/www/content/docs/cli.mdx
+++ b/www/content/docs/cli.mdx
@@ -181,13 +181,27 @@ matrix sync resume
 
 Use `matrix upload` and `matrix download` for one-off file transfers without starting or touching the sync daemon.
 
-```bash
-matrix upload ./README.md projects/demo/README.md
-matrix upload --force ./config.json system/config.json
-matrix upload --secret ./api-key.txt system/secrets/api-key.txt
+```text
+matrix upload <local-file> <matrix-destination>
+matrix download <matrix-file> <local-destination>
+```
 
-matrix download projects/demo/README.md ./README.remote.md
-matrix download --force projects/demo/README.md ./README.remote.md
+Only the Matrix-side argument uses Matrix-home paths. `~/` means the home directory on your Matrix computer, not the home directory on your local computer.
+
+When an upload destination is an existing Matrix folder, the local filename is preserved. Specify a complete Matrix file path when you want to rename it.
+
+```bash
+# Keep the local filename: ~/dev/matrix-os/report.csv
+matrix upload ./report.csv ~/dev/matrix-os
+
+# Rename while uploading: ~/dev/matrix-os/security-findings.csv
+matrix upload ./report.csv ~/dev/matrix-os/security-findings.csv
+
+matrix upload --force ./config.json ~/system/config.json
+matrix upload --secret ./api-key.txt ~/system/secrets/api-key.txt
+
+matrix download ~/dev/matrix-os/report.csv ./report.csv
+matrix download --force ~/dev/matrix-os/report.csv ./report.csv
 ```
 
 **Flags (both commands)**
@@ -196,6 +210,8 @@ matrix download --force projects/demo/README.md ./README.remote.md
 |------|-------------|
 | `--force` | Overwrite the destination if it already exists |
 | `--secret` | Mark the file as secret on upload (affects storage handling) |
+
+Installed shell completions suggest Matrix files and folders for the upload destination and download source. Regenerate your completion script after upgrading the CLI.
 
 ## Port forwarding
 

--- a/www/content/docs/guide/cli.mdx
+++ b/www/content/docs/guide/cli.mdx
@@ -229,11 +229,19 @@ matrix sync ~/work-projects --folder projects
 
 Use `matrix upload` and `matrix download` for one-off files that should not start the sync daemon or touch R2 sync state.
 
+```text
+matrix upload <local-file> <matrix-destination>
+matrix download <matrix-file> <local-destination>
+```
+
+`~/` in a Matrix-side argument refers to the home directory on your Matrix computer. Uploading to an existing Matrix folder preserves the local filename; provide a complete destination file path to rename it.
+
 ```bash
-matrix upload ./README.md projects/demo/README.md
-matrix upload --force ./config.json system/config.json
-matrix download projects/demo/README.md ./README.remote.md
-matrix download --force projects/demo/README.md ./README.remote.md
+matrix upload ./report.csv ~/dev/matrix-os
+matrix upload ./report.csv ~/dev/matrix-os/security-findings.csv
+matrix upload --force ./config.json ~/system/config.json
+matrix download ~/dev/matrix-os/report.csv ./report.csv
+matrix download --force ~/dev/matrix-os/report.csv ./report.csv
 ```
 
 Regular downloads are written with standard user-readable file permissions.
@@ -314,6 +322,8 @@ matrix completion zsh > ~/.zfunc/_matrix
 matrix completion bash > ~/.local/share/bash-completion/completions/matrix
 matrix completion fish > ~/.config/fish/completions/matrix.fish
 ```
+
+Completions suggest Matrix files and folders for the upload destination and download source. Regenerate the script after upgrading the CLI.
 
 ## Troubleshooting
 


### PR DESCRIPTION
## Summary

- report allowlisted file-transfer errors instead of the generic Upload failed message
- accept Matrix-home paths such as ~/dev/matrix-os, including the safe local-home absolute path produced by unquoted shell expansion
- preserve the local basename when the destination is an existing directory
- add authenticated Matrix filesystem completion for upload and download in bash, zsh, and fish
- detach and replay the CLI shell viewer when a backgrounded local terminal applies output backpressure
- clarify local versus Matrix arguments and folder-versus-rename behavior in both public CLI docs pages

## Root cause

The shell expanded the unquoted Matrix destination `~/dev/matrix-os` to the local macOS path `/Users/hamed/dev/matrix-os` before CLI 0.3.13 received it. The upload request reached hamedmp, but the gateway correctly rejected that absolute destination as `invalid_path`; the CLI then collapsed the safe error code into a generic message. The CLI now maps only its own local home prefix back to Matrix-home-relative syntax, while continuing to reject other absolute paths.

For the shell disconnect, the CLI ignored an explicit `false` return from `stdout.write`. A backgrounded terminal tab could stop draining while a high-volume command such as Homebrew download progress kept arriving. The viewer stayed attached until zellij disconnected the slow client. The CLI now closes only that viewer connection, waits for stdout drain, and reconnects from the next replay sequence while the named zellij session remains alive.

## Validation

- `pnpm --filter @finnaai/matrix test`: 367 passed
- `pnpm exec vitest run tests/cli/shell-client.test.ts tests/cli/unified-command-tree.test.ts tests/gateway/file-blob-routes.test.ts`: 60 passed
- `pnpm --filter @finnaai/matrix build`
- `bun run typecheck`
- `pnpm --filter www build`
- generated bash completion syntax and option-aware positional smoke checks
- `git diff --check`

## Invariants

- Source of truth: gateway path containment remains authoritative for Matrix-home file access; CLI normalization is usability and early feedback only.
- Lock or transaction scope: no database state is involved. Uploads retain exclusive temporary-file creation followed by atomic rename.
- Acceptable orphan states: an interrupted upload may leave no destination file; temporary files remain covered by the existing cleanup path. A slow local terminal may lose its viewer connection, but the named zellij session and replayed output remain available.
- Auth source of truth: existing CLI bearer authentication and gateway middleware remain authoritative; completion uses the same authenticated file-list route.
- Deferred scope: recursive directory upload and completion of hidden Matrix entries are not included.
