### PR TITLE
feat(coding-agents): stream codex runtime events

### DIFF
--- a/packages/gateway/package.json
+++ b/packages/gateway/package.json
@@ -12,7 +12,7 @@
   },
   "scripts": {
     "dev": "tsx watch src/main.ts",
-    "build": "pnpm --dir ../.. --filter '@matrix-os/observability' build && tsc"
+    "build": "pnpm --dir ../.. --filter '@matrix-os/observability' build && tsc && cp src/coding-agents/codex-runner.mjs dist/coding-agents/codex-runner.mjs"
   },
   "devDependencies": {
     "@electric-sql/pglite": "^0.4.0",

--- a/packages/gateway/src/agent-launcher.ts
+++ b/packages/gateway/src/agent-launcher.ts
@@ -1,4 +1,6 @@
 import { execFile } from "node:child_process";
+import { isAbsolute } from "node:path";
+import { fileURLToPath } from "node:url";
 import { promisify } from "node:util";
 import { z } from "zod/v4";
 
@@ -33,6 +35,7 @@ export interface AgentLaunchInput {
   sandbox?: AgentLaunchSandbox;
   approvalPolicy?: "untrusted" | "on-request" | "on-failure" | "never";
   runtimeHome?: string;
+  providerEventPath?: string;
 }
 
 export interface AgentLaunchSpec {
@@ -50,6 +53,15 @@ type CommandRunner = (
 
 const execFileAsync = promisify(execFile);
 const DETECT_TIMEOUT_MS = 5_000;
+const ProviderEventPathSchema = z.string()
+  .trim()
+  .min(1)
+  .max(4096)
+  .refine(isAbsolute)
+  .regex(/^[^\u0000\r\n]+\.jsonl$/);
+const CODEX_RUNNER_PATH = fileURLToPath(
+  new URL("./coding-agents/codex-runner.mjs", import.meta.url),
+);
 
 const AGENTS: Record<SupportedAgent, { command: string; displayName: string }> = {
   claude: { command: "claude", displayName: "Claude" },
@@ -265,9 +277,8 @@ export function buildAgentLaunch(input: AgentLaunchInput): AgentLaunchSpec {
     case "claude":
       return { command, args: claudeLaunchArgs(input), cwd: input.cwd, env };
     case "codex":
-      return {
-        command,
-        args: [
+      {
+        const args = [
           "--ask-for-approval",
           input.approvalPolicy ?? "never",
           "exec",
@@ -275,10 +286,17 @@ export function buildAgentLaunch(input: AgentLaunchInput): AgentLaunchSpec {
           ...codexSandboxArgs(input.sandbox),
           ...codexModeArgs(input.mode),
           ...promptArgs(codexPrompt(input.prompt, input.mode)),
-        ],
-        cwd: input.cwd,
-        env,
-      };
+        ];
+        if (!input.providerEventPath) return { command, args, cwd: input.cwd, env };
+        const providerEventPath = ProviderEventPathSchema.parse(input.providerEventPath);
+        const structuredArgs = [...args.slice(0, 4), "--json", ...args.slice(4)];
+        return {
+          command: process.execPath,
+          args: [CODEX_RUNNER_PATH, providerEventPath, command, ...structuredArgs],
+          cwd: input.cwd,
+          env,
+        };
+      }
     case "opencode":
       return { command, args: ["run", ...promptArgs(input.prompt)], cwd: input.cwd, env };
     case "pi":

--- a/packages/gateway/src/agent-launcher.ts
+++ b/packages/gateway/src/agent-launcher.ts
@@ -281,15 +281,16 @@ export function buildAgentLaunch(input: AgentLaunchInput): AgentLaunchSpec {
         const args = [
           "--ask-for-approval",
           input.approvalPolicy ?? "never",
+          ...codexSandboxArgs(input.sandbox),
           "exec",
           "--skip-git-repo-check",
-          ...codexSandboxArgs(input.sandbox),
           ...codexModeArgs(input.mode),
           ...promptArgs(codexPrompt(input.prompt, input.mode)),
         ];
         if (!input.providerEventPath) return { command, args, cwd: input.cwd, env };
         const providerEventPath = ProviderEventPathSchema.parse(input.providerEventPath);
-        const structuredArgs = [...args.slice(0, 4), "--json", ...args.slice(4)];
+        const execIndex = args.indexOf("exec");
+        const structuredArgs = [...args.slice(0, execIndex + 1), "--json", ...args.slice(execIndex + 1)];
         return {
           command: process.execPath,
           args: [CODEX_RUNNER_PATH, providerEventPath, command, ...structuredArgs],

--- a/packages/gateway/src/agent-session-manager.ts
+++ b/packages/gateway/src/agent-session-manager.ts
@@ -18,6 +18,7 @@ import { atomicWriteJson, readJsonFile } from "./state-ops.js";
 import type { createAgentLauncher } from "./agent-launcher.js";
 import type { createWorktreeManager, WorktreeRecord } from "./worktree-manager.js";
 import type { createZellijRuntime } from "./zellij-runtime.js";
+import { codexProviderEventPath } from "./coding-agents/codex-event-bridge.js";
 
 export type SessionKind = "shell" | "agent";
 export type RuntimeStatus = "starting" | "running" | "idle" | "waiting" | "exited" | "failed" | "degraded";
@@ -338,6 +339,9 @@ export function createAgentSessionManager(options: {
             mode: request.mode,
             sandbox: request.sandbox,
             approvalPolicy: toAgentApprovalPolicy(request.approvalPolicy),
+            ...(request.agent === "codex"
+              ? { providerEventPath: codexProviderEventPath(homePath, sessionId) }
+              : {}),
           })
           : { command: "bash", args: [], cwd, env: {} };
       } catch (err: unknown) {

--- a/packages/gateway/src/coding-agents/codex-event-bridge.ts
+++ b/packages/gateway/src/coding-agents/codex-event-bridge.ts
@@ -278,7 +278,7 @@ export function createCodexEventBridge(options: {
       entry.offset += consumedBytes;
       entry.lastTouchedAt = nowMs();
       entry.pendingOccurredAt = undefined;
-      if (terminal) watchers.delete(entry.sessionId);
+      if (terminal && entry.stopRequestedAt !== undefined) watchers.delete(entry.sessionId);
     } catch (error: unknown) {
       if (error instanceof Error && "code" in error && (error as NodeJS.ErrnoException).code === "ENOENT") {
         if (stoppedDrainExpired()) watchers.delete(entry.sessionId);

--- a/packages/gateway/src/coding-agents/codex-event-bridge.ts
+++ b/packages/gateway/src/coding-agents/codex-event-bridge.ts
@@ -357,9 +357,12 @@ export function createCodexEventBridge(options: {
       await queue;
     },
     async shutdown(): Promise<void> {
-      closed = true;
+      if (closed) return;
       clearInterval(timer);
       await queue;
+      queue = queue.then(drainAll, drainAll);
+      await queue;
+      closed = true;
       watchers.clear();
       store = undefined;
       versionCache = undefined;

--- a/packages/gateway/src/coding-agents/codex-event-bridge.ts
+++ b/packages/gateway/src/coding-agents/codex-event-bridge.ts
@@ -133,12 +133,12 @@ export function createCodexEventBridge(options: {
 
   async function versionIsVerified(parentSignal?: AbortSignal): Promise<boolean> {
     if (versionCache && versionCache.expiresAt > nowMs()) return versionCache.ok;
+    const timeoutSignal = AbortSignal.timeout(VERSION_TIMEOUT_MS);
+    const signal = parentSignal
+      ? AbortSignal.any([parentSignal, timeoutSignal])
+      : timeoutSignal;
     let ok = false;
     try {
-      const timeoutSignal = AbortSignal.timeout(VERSION_TIMEOUT_MS);
-      const signal = parentSignal
-        ? AbortSignal.any([parentSignal, timeoutSignal])
-        : timeoutSignal;
       const result = await runVersionCommand("codex", ["--version"], {
         cwd: homePath,
         timeout: VERSION_TIMEOUT_MS,
@@ -146,6 +146,12 @@ export function createCodexEventBridge(options: {
       });
       ok = codexExecContractStatus(result.stdout || result.stderr).status === "verified";
     } catch (error: unknown) {
+      if (
+        signal.aborted ||
+        (error instanceof Error && (error.name === "AbortError" || error.name === "TimeoutError"))
+      ) {
+        return false;
+      }
       console.warn("[coding-agents] Codex version check failed");
     }
     versionCache = { ok, expiresAt: nowMs() + VERSION_CACHE_TTL_MS };

--- a/packages/gateway/src/coding-agents/codex-event-bridge.ts
+++ b/packages/gateway/src/coding-agents/codex-event-bridge.ts
@@ -27,6 +27,7 @@ const MAX_DRAIN_BYTES = 1024 * 1024;
 const DEFAULT_POLL_INTERVAL_MS = 250;
 const VERSION_TIMEOUT_MS = 5_000;
 const VERSION_CACHE_TTL_MS = 30_000;
+const STOP_DRAIN_GRACE_MS = 5_000;
 const ORPHAN_RETENTION_MS = 7 * 24 * 60 * 60 * 1000;
 const MAX_ORPHAN_FILES = 200;
 const CLEANUP_INTERVAL_MS = 60 * 60 * 1000;
@@ -51,6 +52,7 @@ type WatchEntry = {
   offset: number;
   lastTouchedAt: number;
   pendingOccurredAt?: string;
+  stopRequestedAt?: number;
 };
 
 const execFileAsync = promisify(execFile);
@@ -196,10 +198,11 @@ export function createCodexEventBridge(options: {
     }
   }
 
-  async function ingest(entry: WatchEntry, bytes: Buffer, consumedBytes: number): Promise<void> {
+  async function ingest(entry: WatchEntry, bytes: Buffer, consumedBytes: number): Promise<boolean> {
     if (!store) throw new Error("Codex event store is unavailable");
     const events: AgentThreadEvent[] = [];
     let providerThreadId: string | undefined;
+    let terminal = false;
     let lineStart = 0;
     let absoluteOffset = entry.offset;
     const occurredAt = entry.pendingOccurredAt ?? now().toISOString();
@@ -222,6 +225,7 @@ export function createCodexEventBridge(options: {
         providerThreadId = parsed.providerThreadId;
       }
       if (parsed.outcome) {
+        terminal = true;
         events.push(...completionEvents({
           threadId: entry.threadId,
           outcome: parsed.outcome,
@@ -242,9 +246,12 @@ export function createCodexEventBridge(options: {
         ...(index === 0 && providerThreadId ? { providerThreadId } : {}),
       });
     }
+    return terminal;
   }
 
   async function drainEntry(entry: WatchEntry): Promise<void> {
+    const stoppedDrainExpired = () =>
+      entry.stopRequestedAt !== undefined && nowMs() - entry.stopRequestedAt >= STOP_DRAIN_GRACE_MS;
     let handle;
     try {
       const info = await lstat(entry.path);
@@ -252,21 +259,31 @@ export function createCodexEventBridge(options: {
         watchers.delete(entry.sessionId);
         return;
       }
-      if (info.size <= entry.offset) return;
+      if (info.size <= entry.offset) {
+        if (stoppedDrainExpired()) watchers.delete(entry.sessionId);
+        return;
+      }
       const length = Math.min(info.size - entry.offset, MAX_DRAIN_BYTES);
       const bytes = Buffer.alloc(length);
       handle = await open(entry.path, constants.O_RDONLY | (constants.O_NOFOLLOW ?? 0));
       const read = await handle.read(bytes, 0, length, entry.offset);
       const data = bytes.subarray(0, read.bytesRead);
       const lastNewline = data.lastIndexOf(0x0a);
-      if (lastNewline < 0) return;
+      if (lastNewline < 0) {
+        if (stoppedDrainExpired()) watchers.delete(entry.sessionId);
+        return;
+      }
       const consumedBytes = lastNewline + 1;
-      await ingest(entry, data, consumedBytes);
+      const terminal = await ingest(entry, data, consumedBytes);
       entry.offset += consumedBytes;
       entry.lastTouchedAt = nowMs();
       entry.pendingOccurredAt = undefined;
+      if (terminal) watchers.delete(entry.sessionId);
     } catch (error: unknown) {
-      if (error instanceof Error && "code" in error && (error as NodeJS.ErrnoException).code === "ENOENT") return;
+      if (error instanceof Error && "code" in error && (error as NodeJS.ErrnoException).code === "ENOENT") {
+        if (stoppedDrainExpired()) watchers.delete(entry.sessionId);
+        return;
+      }
       console.warn("[coding-agents] Codex event ingestion will retry");
     } finally {
       await handle?.close();
@@ -323,6 +340,14 @@ export function createCodexEventBridge(options: {
     },
     unwatch(sessionId: string): void {
       if (SessionIdSchema.safeParse(sessionId).success) watchers.delete(sessionId);
+    },
+    markStopped(sessionId: string): void {
+      if (!SessionIdSchema.safeParse(sessionId).success) return;
+      const entry = watchers.get(sessionId);
+      if (!entry) return;
+      entry.stopRequestedAt = nowMs();
+      entry.lastTouchedAt = nowMs();
+      queue = queue.then(drainAll, drainAll);
     },
     watcherCount(): number {
       return watchers.size;

--- a/packages/gateway/src/coding-agents/codex-event-bridge.ts
+++ b/packages/gateway/src/coding-agents/codex-event-bridge.ts
@@ -1,0 +1,345 @@
+import { execFile } from "node:child_process";
+import { createHash } from "node:crypto";
+import { constants } from "node:fs";
+import { lstat, mkdir, open, readdir, realpath, rm } from "node:fs/promises";
+import { dirname, join, resolve } from "node:path";
+import { promisify } from "node:util";
+import { z } from "zod/v4";
+import {
+  AgentThreadEventSchema,
+  AgentThreadSummarySchema,
+  SafeClientErrorSchema,
+  type AgentThreadEvent,
+} from "@matrix-os/contracts";
+import type { RequestPrincipal } from "../request-principal.js";
+import { parseCodexExecJsonLine } from "./codex-events.js";
+import { codexExecContractStatus } from "./codex-version.js";
+import type { CodingAgentProviderEventBatch } from "./provider-adapter.js";
+
+const SessionIdSchema = z.string().regex(/^sess_[A-Za-z0-9_-]{1,128}$/);
+const WatchInputSchema = z.object({
+  threadId: AgentThreadSummarySchema.shape.id,
+  sessionId: SessionIdSchema,
+}).strict();
+const MAX_WATCHERS = 100;
+const MAX_TRANSCRIPT_BYTES = 16 * 1024 * 1024;
+const MAX_DRAIN_BYTES = 1024 * 1024;
+const DEFAULT_POLL_INTERVAL_MS = 250;
+const VERSION_TIMEOUT_MS = 5_000;
+const VERSION_CACHE_TTL_MS = 30_000;
+const ORPHAN_RETENTION_MS = 7 * 24 * 60 * 60 * 1000;
+const MAX_ORPHAN_FILES = 200;
+const CLEANUP_INTERVAL_MS = 60 * 60 * 1000;
+
+type VersionCommand = (
+  command: string,
+  args: string[],
+  options: { cwd: string; timeout: number; signal: AbortSignal },
+) => Promise<{ stdout: string; stderr: string }>;
+type ProviderEventStore = {
+  ingestProviderEvents(
+    principal: RequestPrincipal,
+    threadId: string,
+    batch: CodingAgentProviderEventBatch,
+  ): Promise<unknown>;
+};
+type WatchEntry = {
+  principal: RequestPrincipal;
+  threadId: string;
+  sessionId: string;
+  path: string;
+  offset: number;
+  lastTouchedAt: number;
+  pendingOccurredAt?: string;
+};
+
+const execFileAsync = promisify(execFile);
+const defaultVersionCommand: VersionCommand = async (command, args, options) => {
+  const result = await execFileAsync(command, args, {
+    cwd: options.cwd,
+    timeout: options.timeout,
+    signal: options.signal,
+    encoding: "utf-8",
+    maxBuffer: 64 * 1024,
+  });
+  return { stdout: result.stdout, stderr: result.stderr };
+};
+
+export function codexProviderEventPath(homePath: string, sessionId: string): string {
+  const parsed = SessionIdSchema.parse(sessionId);
+  return join(resolve(homePath), "system", "coding-agents", "provider-events", `${parsed}.jsonl`);
+}
+
+function eventId(sessionId: string, byteOffset: number, index: number): string {
+  const digest = createHash("sha256")
+    .update(`${sessionId}:${byteOffset}:${index}`)
+    .digest("hex")
+    .slice(0, 32);
+  return `evt_codex_${digest}`;
+}
+
+function completionEvents(input: {
+  threadId: string;
+  outcome: "completed" | "failed";
+  occurredAt: string;
+  nextEventId: () => string;
+}): AgentThreadEvent[] {
+  const events: AgentThreadEvent[] = [];
+  if (input.outcome === "failed") {
+    events.push(AgentThreadEventSchema.parse({
+      type: "thread.error",
+      eventId: input.nextEventId(),
+      threadId: input.threadId,
+      occurredAt: input.occurredAt,
+      error: SafeClientErrorSchema.parse({
+        code: "provider_failed",
+        safeMessage: "The coding agent stopped. Review the thread and try again.",
+        retryable: true,
+        recoveryActions: ["retry"],
+      }),
+    }));
+  }
+  events.push(AgentThreadEventSchema.parse({
+    type: "thread.completed",
+    eventId: input.nextEventId(),
+    threadId: input.threadId,
+    occurredAt: input.occurredAt,
+    outcome: input.outcome,
+  }));
+  return events;
+}
+
+export function createCodexEventBridge(options: {
+  homePath: string;
+  runVersionCommand?: VersionCommand;
+  pollIntervalMs?: number;
+  now?: () => Date;
+  nowMs?: () => number;
+}) {
+  const homePath = resolve(options.homePath);
+  const eventDir = join(homePath, "system", "coding-agents", "provider-events");
+  const runVersionCommand = options.runVersionCommand ?? defaultVersionCommand;
+  const pollIntervalMs = Math.max(50, options.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS);
+  const now = options.now ?? (() => new Date());
+  const nowMs = options.nowMs ?? Date.now;
+  const watchers = new Map<string, WatchEntry>();
+  let store: ProviderEventStore | undefined;
+  let closed = false;
+  let queue: Promise<void> = Promise.resolve();
+  let lastCleanupAt = 0;
+  let versionCache: { ok: boolean; expiresAt: number } | undefined;
+
+  async function versionIsVerified(parentSignal?: AbortSignal): Promise<boolean> {
+    if (versionCache && versionCache.expiresAt > nowMs()) return versionCache.ok;
+    let ok = false;
+    try {
+      const timeoutSignal = AbortSignal.timeout(VERSION_TIMEOUT_MS);
+      const signal = parentSignal
+        ? AbortSignal.any([parentSignal, timeoutSignal])
+        : timeoutSignal;
+      const result = await runVersionCommand("codex", ["--version"], {
+        cwd: homePath,
+        timeout: VERSION_TIMEOUT_MS,
+        signal,
+      });
+      ok = codexExecContractStatus(result.stdout || result.stderr).status === "verified";
+    } catch (error: unknown) {
+      console.warn("[coding-agents] Codex version check failed");
+    }
+    versionCache = { ok, expiresAt: nowMs() + VERSION_CACHE_TTL_MS };
+    return ok;
+  }
+
+  async function ensureEventDirectory(): Promise<void> {
+    await mkdir(eventDir, { recursive: true });
+    const canonicalHome = await realpath(homePath);
+    const canonicalEventDir = await realpath(eventDir);
+    if (canonicalEventDir !== join(canonicalHome, "system", "coding-agents", "provider-events")) {
+      throw new Error("Codex event directory is unavailable");
+    }
+  }
+
+  function evictIfNeeded(): void {
+    if (watchers.size < MAX_WATCHERS) return;
+    let oldest: WatchEntry | undefined;
+    for (const entry of watchers.values()) {
+      if (!oldest || entry.lastTouchedAt < oldest.lastTouchedAt) oldest = entry;
+    }
+    if (oldest) watchers.delete(oldest.sessionId);
+  }
+
+  async function cleanupOrphans(): Promise<void> {
+    const currentTime = nowMs();
+    if (currentTime - lastCleanupAt < CLEANUP_INTERVAL_MS) return;
+    lastCleanupAt = currentTime;
+    let entries;
+    try {
+      entries = await readdir(eventDir, { withFileTypes: true });
+    } catch (error: unknown) {
+      if (error instanceof Error && "code" in error && (error as NodeJS.ErrnoException).code === "ENOENT") return;
+      throw error;
+    }
+    const files: Array<{ path: string; mtimeMs: number }> = [];
+    for (const entry of entries) {
+      if (!entry.isFile() || !entry.name.endsWith(".jsonl")) continue;
+      const sessionId = entry.name.slice(0, -".jsonl".length);
+      if (!SessionIdSchema.safeParse(sessionId).success || watchers.has(sessionId)) continue;
+      const path = join(eventDir, entry.name);
+      const info = await lstat(path);
+      if (info.isSymbolicLink() || !info.isFile()) continue;
+      files.push({ path, mtimeMs: info.mtimeMs });
+    }
+    files.sort((left, right) => left.mtimeMs - right.mtimeMs);
+    for (const [index, file] of files.entries()) {
+      if (file.mtimeMs > currentTime - ORPHAN_RETENTION_MS && index >= files.length - MAX_ORPHAN_FILES) continue;
+      await rm(file.path, { force: true });
+    }
+  }
+
+  async function ingest(entry: WatchEntry, bytes: Buffer, consumedBytes: number): Promise<void> {
+    if (!store) throw new Error("Codex event store is unavailable");
+    const events: AgentThreadEvent[] = [];
+    let providerThreadId: string | undefined;
+    let lineStart = 0;
+    let absoluteOffset = entry.offset;
+    const occurredAt = entry.pendingOccurredAt ?? now().toISOString();
+    entry.pendingOccurredAt = occurredAt;
+    while (lineStart < consumedBytes) {
+      const newline = bytes.indexOf(0x0a, lineStart);
+      if (newline < 0 || newline >= consumedBytes) break;
+      const line = bytes.subarray(lineStart, newline).toString("utf-8").replace(/\r$/, "");
+      let index = 0;
+      const parsed = parseCodexExecJsonLine(line, {
+        threadId: entry.threadId,
+        now: () => new Date(occurredAt),
+        nextEventId: () => eventId(entry.sessionId, absoluteOffset, index++),
+      });
+      events.push(...parsed.events);
+      if (parsed.providerThreadId) {
+        if (providerThreadId && providerThreadId !== parsed.providerThreadId) {
+          throw new Error("Codex provider conversation changed");
+        }
+        providerThreadId = parsed.providerThreadId;
+      }
+      if (parsed.outcome) {
+        events.push(...completionEvents({
+          threadId: entry.threadId,
+          outcome: parsed.outcome,
+          occurredAt,
+          nextEventId: () => eventId(entry.sessionId, absoluteOffset, index++),
+        }));
+      }
+      absoluteOffset += newline - lineStart + 1;
+      lineStart = newline + 1;
+    }
+
+    const chunks: AgentThreadEvent[][] = [];
+    for (let index = 0; index < events.length; index += 100) chunks.push(events.slice(index, index + 100));
+    if (chunks.length === 0 && providerThreadId) chunks.push([]);
+    for (const [index, chunk] of chunks.entries()) {
+      await store.ingestProviderEvents(entry.principal, entry.threadId, {
+        events: chunk,
+        ...(index === 0 && providerThreadId ? { providerThreadId } : {}),
+      });
+    }
+  }
+
+  async function drainEntry(entry: WatchEntry): Promise<void> {
+    let handle;
+    try {
+      const info = await lstat(entry.path);
+      if (info.isSymbolicLink() || !info.isFile() || info.size > MAX_TRANSCRIPT_BYTES) {
+        watchers.delete(entry.sessionId);
+        return;
+      }
+      if (info.size <= entry.offset) return;
+      const length = Math.min(info.size - entry.offset, MAX_DRAIN_BYTES);
+      const bytes = Buffer.alloc(length);
+      handle = await open(entry.path, constants.O_RDONLY | (constants.O_NOFOLLOW ?? 0));
+      const read = await handle.read(bytes, 0, length, entry.offset);
+      const data = bytes.subarray(0, read.bytesRead);
+      const lastNewline = data.lastIndexOf(0x0a);
+      if (lastNewline < 0) return;
+      const consumedBytes = lastNewline + 1;
+      await ingest(entry, data, consumedBytes);
+      entry.offset += consumedBytes;
+      entry.lastTouchedAt = nowMs();
+      entry.pendingOccurredAt = undefined;
+    } catch (error: unknown) {
+      if (error instanceof Error && "code" in error && (error as NodeJS.ErrnoException).code === "ENOENT") return;
+      console.warn("[coding-agents] Codex event ingestion will retry");
+    } finally {
+      await handle?.close();
+    }
+  }
+
+  async function drainAll(): Promise<void> {
+    if (closed) return;
+    await cleanupOrphans();
+    for (const entry of watchers.values()) await drainEntry(entry);
+  }
+
+  const timer = setInterval(() => {
+    queue = queue.then(drainAll, drainAll);
+  }, pollIntervalMs);
+  timer.unref();
+
+  return {
+    attachThreadStore(nextStore: ProviderEventStore): void {
+      store = nextStore;
+    },
+    async healthCheck(signal?: AbortSignal): Promise<{ ok: boolean }> {
+      return { ok: await versionIsVerified(signal) };
+    },
+    async watch(input: {
+      principal: RequestPrincipal;
+      threadId: string;
+      sessionId: string;
+    }): Promise<{ path: string }> {
+      if (closed || !await versionIsVerified()) {
+        throw new Error("Codex structured events are unavailable");
+      }
+      const parsed = WatchInputSchema.parse({ threadId: input.threadId, sessionId: input.sessionId });
+      await ensureEventDirectory();
+      const path = codexProviderEventPath(homePath, parsed.sessionId);
+      const existing = watchers.get(parsed.sessionId);
+      if (existing) {
+        if (existing.threadId !== parsed.threadId || existing.principal.userId !== input.principal.userId) {
+          throw new Error("Codex event watcher identity mismatch");
+        }
+        existing.lastTouchedAt = nowMs();
+        return { path };
+      }
+      evictIfNeeded();
+      watchers.set(parsed.sessionId, {
+        principal: input.principal,
+        threadId: parsed.threadId,
+        sessionId: parsed.sessionId,
+        path,
+        offset: 0,
+        lastTouchedAt: nowMs(),
+      });
+      return { path };
+    },
+    unwatch(sessionId: string): void {
+      if (SessionIdSchema.safeParse(sessionId).success) watchers.delete(sessionId);
+    },
+    watcherCount(): number {
+      return watchers.size;
+    },
+    async drain(): Promise<void> {
+      queue = queue.then(drainAll, drainAll);
+      await queue;
+    },
+    async shutdown(): Promise<void> {
+      closed = true;
+      clearInterval(timer);
+      await queue;
+      watchers.clear();
+      store = undefined;
+      versionCache = undefined;
+    },
+  };
+}
+
+export type CodexEventBridge = ReturnType<typeof createCodexEventBridge>;

--- a/packages/gateway/src/coding-agents/codex-events.ts
+++ b/packages/gateway/src/coding-agents/codex-events.ts
@@ -258,6 +258,9 @@ export function parseCodexExecJsonLine(
   if (codexEvent.type === "thread.started") {
     return { events: [], providerThreadId: codexEvent.thread_id };
   }
+  if (codexEvent.type === "turn.started") {
+    return { events: [event(context, { type: "thread.status", status: "running" })] };
+  }
   if (codexEvent.type === "turn.completed") return { events: [], outcome: "completed" };
   if (codexEvent.type === "turn.failed") return { events: [], outcome: "failed" };
   if (codexEvent.type === "item.started") {

--- a/packages/gateway/src/coding-agents/codex-runner.mjs
+++ b/packages/gateway/src/coding-agents/codex-runner.mjs
@@ -1,0 +1,270 @@
+import { spawn } from "node:child_process";
+import { constants } from "node:fs";
+import { lstat, mkdir, open } from "node:fs/promises";
+import { dirname, isAbsolute } from "node:path";
+import { createInterface } from "node:readline";
+import { StringDecoder } from "node:string_decoder";
+import { z } from "zod/v4";
+
+process.on("uncaughtException", () => {
+  process.stderr.write("Codex event runner stopped unexpectedly.\n");
+  process.exit(1);
+});
+process.on("unhandledRejection", () => {
+  process.stderr.write("Codex event runner stopped unexpectedly.\n");
+  process.exit(1);
+});
+
+const MAX_JSON_LINE_BYTES = 64 * 1024;
+const MAX_TRANSCRIPT_BYTES = 16 * 1024 * 1024;
+const MAX_PENDING_PROMPTS = 20;
+const MAX_PROMPT_BYTES = 64 * 1024;
+const TURN_TIMEOUT_MS = 10 * 60 * 1000;
+const PROVIDER_THREAD_ID = /^[A-Za-z0-9][A-Za-z0-9_-]{0,511}$/;
+const RunnerInputSchema = z.object({
+  eventPath: z.string().min(1).max(4096).refine(isAbsolute).regex(/^[^\u0000\r\n]+\.jsonl$/),
+  command: z.string().min(1).max(4096).regex(/^[^\u0000\r\n]+$/),
+  initialArgs: z.array(z.string().max(100_000)).min(1).max(128),
+}).strict().superRefine((value, context) => {
+  if (!value.initialArgs.includes("exec") || !value.initialArgs.includes("--json")) {
+    context.addIssue({ code: "custom", message: "Structured output flags are required" });
+  }
+});
+const RunnerEventSchema = z.object({
+  type: z.string().min(1).max(80),
+  thread_id: z.string().max(512).optional(),
+  item: z.object({
+    type: z.string().min(1).max(80),
+    text: z.string().max(MAX_JSON_LINE_BYTES).optional(),
+  }).passthrough().optional(),
+}).passthrough();
+const PendingPromptSchema = z.string().trim().min(1).max(MAX_PROMPT_BYTES);
+
+const parsedInput = RunnerInputSchema.safeParse({
+  eventPath: process.argv[2],
+  command: process.argv[3],
+  initialArgs: process.argv.slice(4),
+});
+if (!parsedInput.success) {
+  process.stderr.write("Codex event runner configuration is invalid.\n");
+  process.exit(1);
+}
+const { eventPath, command, initialArgs } = parsedInput.data;
+
+await mkdir(dirname(eventPath), { recursive: true });
+try {
+  const existing = await lstat(eventPath);
+  if (existing.isSymbolicLink() || !existing.isFile()) {
+    throw new Error("unsafe_event_file");
+  }
+} catch (error) {
+  if (!(error instanceof Error && "code" in error && error.code === "ENOENT")) throw error;
+}
+
+const noFollow = constants.O_NOFOLLOW ?? 0;
+const eventFile = await open(
+  eventPath,
+  constants.O_CREAT | constants.O_APPEND | constants.O_WRONLY | noFollow,
+  0o600,
+);
+let transcriptBytes = (await eventFile.stat()).size;
+let providerThreadId;
+let activeChild;
+let stopping = false;
+let fatalTransportFailure = false;
+let stdinClosed = false;
+const pendingPrompts = [];
+let wakePrompt;
+
+function safeTerminalLine(raw) {
+  let value;
+  try {
+    const parsed = RunnerEventSchema.safeParse(JSON.parse(raw));
+    if (!parsed.success) return;
+    value = parsed.data;
+  } catch (error) {
+    if (!(error instanceof SyntaxError)) {
+      process.stdout.write("Codex: Activity could not be displayed.\n");
+    }
+    return;
+  }
+  if (!value || typeof value !== "object") return;
+  if (value.type === "thread.started" && PROVIDER_THREAD_ID.test(value.thread_id ?? "")) {
+    providerThreadId = value.thread_id;
+    return;
+  }
+  if (value.type === "item.started" && value.item?.type === "command_execution") {
+    process.stdout.write("Codex: Running command.\n");
+    return;
+  }
+  if (value.type === "item.started" && value.item?.type === "file_change") {
+    process.stdout.write("Codex: Updating files.\n");
+    return;
+  }
+  if (value.type === "item.completed" && value.item?.type === "agent_message") {
+    const text = typeof value.item.text === "string" ? value.item.text : "";
+    if (text.trim()) {
+      process.stdout.write(`${Array.from(text).slice(0, 8_000).join("")}\n`);
+    }
+    return;
+  }
+  if (value.type === "turn.completed") {
+    process.stdout.write("Codex: Turn complete.\n");
+    return;
+  }
+  if (value.type === "turn.failed" || value.type === "error") {
+    process.stdout.write("Codex: Turn needs attention.\n");
+  }
+}
+
+async function persistLine(line) {
+  const bytes = Buffer.byteLength(`${line}\n`, "utf-8");
+  if (bytes > MAX_JSON_LINE_BYTES || transcriptBytes + bytes > MAX_TRANSCRIPT_BYTES) {
+    fatalTransportFailure = true;
+    throw new Error("event_transcript_limit");
+  }
+  await eventFile.write(`${line}\n`);
+  transcriptBytes += bytes;
+  safeTerminalLine(line);
+  try {
+    const parsed = RunnerEventSchema.safeParse(JSON.parse(line));
+    return parsed.success ? parsed.data.type : undefined;
+  } catch (error) {
+    if (error instanceof SyntaxError) return undefined;
+    throw error;
+  }
+}
+
+async function consumeStdout(stream) {
+  const decoder = new StringDecoder("utf-8");
+  let pending = "";
+  const eventTypes = [];
+  for await (const chunk of stream) {
+    pending += decoder.write(chunk);
+    if (Buffer.byteLength(pending, "utf-8") > MAX_JSON_LINE_BYTES * 2) {
+      fatalTransportFailure = true;
+      throw new Error("event_line_limit");
+    }
+    let newline = pending.indexOf("\n");
+    while (newline >= 0) {
+      const line = pending.slice(0, newline).replace(/\r$/, "");
+      pending = pending.slice(newline + 1);
+      if (line.length > 0) eventTypes.push(await persistLine(line));
+      newline = pending.indexOf("\n");
+    }
+  }
+  pending += decoder.end();
+  if (pending.length > 0) eventTypes.push(await persistLine(pending.replace(/\r$/, "")));
+  return eventTypes;
+}
+
+async function discardStderr(stream) {
+  for await (const _chunk of stream) {
+    // Provider stderr can contain credentials, private paths, or raw failures.
+  }
+}
+
+function childExit(child) {
+  return new Promise((resolve, reject) => {
+    child.once("error", reject);
+    child.once("close", (code, signal) => resolve({ code, signal }));
+  });
+}
+
+async function runCodex(args) {
+  const child = spawn(command, args, {
+    cwd: process.cwd(),
+    env: process.env,
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  activeChild = child;
+  const timeout = setTimeout(() => child.kill("SIGTERM"), TURN_TIMEOUT_MS);
+  timeout.unref();
+  try {
+    const [exit, eventTypes] = await Promise.all([
+      childExit(child),
+      consumeStdout(child.stdout),
+      discardStderr(child.stderr),
+    ]);
+    if (exit.code !== 0 && !eventTypes.includes("turn.failed")) {
+      await persistLine(JSON.stringify({ type: "turn.failed" }));
+    }
+    return exit.code === 0;
+  } catch (error) {
+    child.kill("SIGTERM");
+    await persistLine(JSON.stringify({ type: "turn.failed" })).catch(() => undefined);
+    if (fatalTransportFailure) stopping = true;
+    return false;
+  } finally {
+    clearTimeout(timeout);
+    activeChild = undefined;
+  }
+}
+
+function enqueuePrompt(line) {
+  const parsed = PendingPromptSchema.safeParse(line);
+  if (!parsed.success || Buffer.byteLength(parsed.data, "utf-8") > MAX_PROMPT_BYTES) return;
+  const prompt = parsed.data;
+  if (pendingPrompts.length >= MAX_PENDING_PROMPTS) {
+    process.stdout.write("Codex: Too many pending messages. Try again shortly.\n");
+    return;
+  }
+  pendingPrompts.push(prompt);
+  wakePrompt?.();
+  wakePrompt = undefined;
+}
+
+function nextPrompt() {
+  if (pendingPrompts.length > 0) return Promise.resolve(pendingPrompts.shift());
+  if (stdinClosed || stopping) return Promise.resolve(undefined);
+  return new Promise((resolve) => {
+    wakePrompt = () => resolve(pendingPrompts.shift());
+  });
+}
+
+const input = createInterface({ input: process.stdin, crlfDelay: Infinity });
+input.on("line", enqueuePrompt);
+input.on("close", () => {
+  stdinClosed = true;
+  wakePrompt?.();
+  wakePrompt = undefined;
+});
+
+function stop() {
+  stopping = true;
+  activeChild?.kill("SIGTERM");
+  input.close();
+}
+process.once("SIGTERM", stop);
+process.once("SIGINT", stop);
+
+let exitCode = 0;
+try {
+  if (!await runCodex(initialArgs)) exitCode = 1;
+  const execIndex = initialArgs.indexOf("exec");
+  const globalArgs = execIndex >= 0 ? initialArgs.slice(0, execIndex) : [];
+  while (!stopping && !fatalTransportFailure) {
+    const prompt = await nextPrompt();
+    if (!prompt) break;
+    if (!providerThreadId) {
+      process.stdout.write("Codex: This conversation cannot be resumed. Start a new chat.\n");
+      exitCode = 1;
+      continue;
+    }
+    const resumed = await runCodex([
+      ...globalArgs,
+      "exec",
+      "resume",
+      "--json",
+      "--skip-git-repo-check",
+      providerThreadId,
+      "--",
+      prompt,
+    ]);
+    if (!resumed) exitCode = 1;
+  }
+} finally {
+  input.close();
+  await eventFile.close();
+}
+process.exitCode = exitCode;

--- a/packages/gateway/src/coding-agents/codex-runner.mjs
+++ b/packages/gateway/src/coding-agents/codex-runner.mjs
@@ -16,6 +16,7 @@ process.on("unhandledRejection", () => {
 });
 
 const MAX_JSON_LINE_BYTES = 64 * 1024;
+const MAX_PROVIDER_LINE_BYTES = 1024 * 1024;
 const MAX_TRANSCRIPT_BYTES = 16 * 1024 * 1024;
 const MAX_PENDING_PROMPTS = 20;
 const MAX_PROMPT_BYTES = 64 * 1024;
@@ -39,6 +40,15 @@ const RunnerEventSchema = z.object({
     type: z.string().min(1).max(80),
     text: z.string().max(MAX_JSON_LINE_BYTES).optional(),
   }).passthrough().optional(),
+}).passthrough();
+const OversizedCommandEventSchema = z.object({
+  type: z.enum(["item.started", "item.updated", "item.completed"]),
+  item: z.object({
+    id: z.string().min(1).max(128).regex(/^[A-Za-z0-9][A-Za-z0-9_.:-]{0,127}$/),
+    type: z.literal("command_execution"),
+    exit_code: z.number().int().nullable(),
+    status: z.enum(["in_progress", "completed", "failed", "declined"]),
+  }).passthrough(),
 }).passthrough();
 const PendingPromptSchema = z.string().trim().min(1).max(MAX_PROMPT_BYTES);
 const FramedPromptSchema = z.string()
@@ -123,17 +133,41 @@ function safeTerminalLine(raw) {
   }
 }
 
+function sanitizeOversizedLine(line) {
+  try {
+    const parsed = OversizedCommandEventSchema.safeParse(JSON.parse(line));
+    if (!parsed.success) return undefined;
+    return JSON.stringify({
+      type: parsed.data.type,
+      item: {
+        id: parsed.data.item.id,
+        type: "command_execution",
+        command: "",
+        aggregated_output: "Output omitted.",
+        exit_code: parsed.data.item.exit_code,
+        status: parsed.data.item.status,
+      },
+    });
+  } catch (_error) {
+    return undefined;
+  }
+}
+
 async function persistLine(line) {
-  const bytes = Buffer.byteLength(`${line}\n`, "utf-8");
-  if (bytes > MAX_JSON_LINE_BYTES || transcriptBytes + bytes > MAX_TRANSCRIPT_BYTES) {
+  const persistedLine = Buffer.byteLength(line, "utf-8") > MAX_JSON_LINE_BYTES
+    ? sanitizeOversizedLine(line)
+    : line;
+  if (!persistedLine) return undefined;
+  const bytes = Buffer.byteLength(`${persistedLine}\n`, "utf-8");
+  if (transcriptBytes + bytes > MAX_TRANSCRIPT_BYTES) {
     fatalTransportFailure = true;
     throw new Error("event_transcript_limit");
   }
-  await eventFile.write(`${line}\n`);
+  await eventFile.write(`${persistedLine}\n`);
   transcriptBytes += bytes;
-  safeTerminalLine(line);
+  safeTerminalLine(persistedLine);
   try {
-    const parsed = RunnerEventSchema.safeParse(JSON.parse(line));
+    const parsed = RunnerEventSchema.safeParse(JSON.parse(persistedLine));
     return parsed.success ? parsed.data.type : undefined;
   } catch (error) {
     if (error instanceof SyntaxError) return undefined;
@@ -144,23 +178,39 @@ async function persistLine(line) {
 async function consumeStdout(stream) {
   const decoder = new StringDecoder("utf-8");
   let pending = "";
+  let discardingOversizedLine = false;
   const eventTypes = [];
   for await (const chunk of stream) {
-    pending += decoder.write(chunk);
-    if (Buffer.byteLength(pending, "utf-8") > MAX_JSON_LINE_BYTES * 2) {
-      fatalTransportFailure = true;
-      throw new Error("event_line_limit");
+    let text = decoder.write(chunk);
+    if (discardingOversizedLine) {
+      const newline = text.indexOf("\n");
+      if (newline < 0) continue;
+      text = text.slice(newline + 1);
+      discardingOversizedLine = false;
     }
+    pending += text;
     let newline = pending.indexOf("\n");
     while (newline >= 0) {
       const line = pending.slice(0, newline).replace(/\r$/, "");
       pending = pending.slice(newline + 1);
-      if (line.length > 0) eventTypes.push(await persistLine(line));
+      if (line.length > 0 && Buffer.byteLength(line, "utf-8") <= MAX_PROVIDER_LINE_BYTES) {
+        eventTypes.push(await persistLine(line));
+      }
       newline = pending.indexOf("\n");
+    }
+    if (Buffer.byteLength(pending, "utf-8") > MAX_PROVIDER_LINE_BYTES) {
+      pending = "";
+      discardingOversizedLine = true;
     }
   }
   pending += decoder.end();
-  if (pending.length > 0) eventTypes.push(await persistLine(pending.replace(/\r$/, "")));
+  if (
+    !discardingOversizedLine &&
+    pending.length > 0 &&
+    Buffer.byteLength(pending, "utf-8") <= MAX_PROVIDER_LINE_BYTES
+  ) {
+    eventTypes.push(await persistLine(pending.replace(/\r$/, "")));
+  }
   return eventTypes;
 }
 

--- a/packages/gateway/src/coding-agents/codex-runner.mjs
+++ b/packages/gateway/src/coding-agents/codex-runner.mjs
@@ -19,7 +19,9 @@ const MAX_JSON_LINE_BYTES = 64 * 1024;
 const MAX_TRANSCRIPT_BYTES = 16 * 1024 * 1024;
 const MAX_PENDING_PROMPTS = 20;
 const MAX_PROMPT_BYTES = 64 * 1024;
+const MAX_FRAMED_PROMPT_BYTES = Math.ceil(MAX_PROMPT_BYTES * 4 / 3) + 4;
 const TURN_TIMEOUT_MS = 10 * 60 * 1000;
+const TURN_FRAME_PREFIX = "matrix-turn-v1:";
 const PROVIDER_THREAD_ID = /^[A-Za-z0-9][A-Za-z0-9_-]{0,511}$/;
 const RunnerInputSchema = z.object({
   eventPath: z.string().min(1).max(4096).refine(isAbsolute).regex(/^[^\u0000\r\n]+\.jsonl$/),
@@ -39,6 +41,10 @@ const RunnerEventSchema = z.object({
   }).passthrough().optional(),
 }).passthrough();
 const PendingPromptSchema = z.string().trim().min(1).max(MAX_PROMPT_BYTES);
+const FramedPromptSchema = z.string()
+  .min(4)
+  .max(MAX_FRAMED_PROMPT_BYTES)
+  .regex(/^[A-Za-z0-9+/]+={0,2}$/);
 
 const parsedInput = RunnerInputSchema.safeParse({
   eventPath: process.argv[2],
@@ -202,7 +208,20 @@ async function runCodex(args) {
 }
 
 function enqueuePrompt(line) {
-  const parsed = PendingPromptSchema.safeParse(line);
+  let candidate = line;
+  if (line.startsWith(TURN_FRAME_PREFIX)) {
+    const encoded = FramedPromptSchema.safeParse(line.slice(TURN_FRAME_PREFIX.length));
+    if (!encoded.success) return;
+    try {
+      const bytes = Buffer.from(encoded.data, "base64");
+      const canonical = bytes.toString("base64");
+      if (canonical !== encoded.data) return;
+      candidate = new TextDecoder("utf-8", { fatal: true }).decode(bytes);
+    } catch (_error) {
+      return;
+    }
+  }
+  const parsed = PendingPromptSchema.safeParse(candidate);
   if (!parsed.success || Buffer.byteLength(parsed.data, "utf-8") > MAX_PROMPT_BYTES) return;
   const prompt = parsed.data;
   if (pendingPrompts.length >= MAX_PENDING_PROMPTS) {

--- a/packages/gateway/src/coding-agents/workspace-provider.ts
+++ b/packages/gateway/src/coding-agents/workspace-provider.ts
@@ -11,6 +11,7 @@ import {
 import { SupportedAgentSchema, type SupportedAgent } from "../agent-launcher.js";
 import type { WorkspaceSessionOrchestrator } from "../workspace-session-orchestrator.js";
 import type { CodingAgentProviderAdapter } from "./thread-store.js";
+import type { CodexEventBridge } from "./codex-event-bridge.js";
 
 type WorkspaceRuntime = Pick<WorkspaceSessionOrchestrator, "startSession" | "stopSession"> &
   Partial<Pick<WorkspaceSessionOrchestrator, "sendInput">>;
@@ -32,11 +33,13 @@ export interface WorkspaceCodingAgentProviderOptions {
   agent: SupportedAgent;
   runtime: WorkspaceRuntime;
   runnable?: boolean;
+  codexEvents?: Pick<CodexEventBridge, "healthCheck" | "watch" | "unwatch">;
 }
 
 export interface WorkspaceCodingAgentProviderSetOptions {
   agents: readonly SupportedAgent[];
   runtime: WorkspaceRuntime;
+  codexEvents: Pick<CodexEventBridge, "healthCheck" | "watch" | "unwatch">;
 }
 
 export interface WorkspaceCodingAgentProviderSet {
@@ -180,12 +183,15 @@ export function createWorkspaceCodingAgentProvider(
 
   return {
     providerId,
-    getSummary({ now }) {
+    async getSummary({ now, signal }) {
+      const executable = runnable && (
+        agent !== "codex" || !options.codexEvents || (await options.codexEvents.healthCheck(signal)).ok
+      );
       return {
         id: providerId,
         displayName: providerDisplayName(agent),
         kind: providerKind(agent),
-        availability: runnable ? "available" : "unavailable",
+        availability: executable ? "available" : "unavailable",
         installStatus: "installed",
         authStatus: "authenticated",
         supportedModes: ["default", "review"],
@@ -194,8 +200,10 @@ export function createWorkspaceCodingAgentProvider(
         lastCheckedAt: now().toISOString(),
       };
     },
-    healthCheck() {
-      return { ok: runnable };
+    async healthCheck({ signal }) {
+      if (!runnable) return { ok: false };
+      if (agent === "codex" && options.codexEvents) return options.codexEvents.healthCheck(signal);
+      return { ok: true };
     },
     buildSetupAction(): SafeSetupAction[] {
       return providerSetupActions(agent);
@@ -205,24 +213,38 @@ export function createWorkspaceCodingAgentProvider(
         throw new Error("Workspace provider execution unavailable");
       }
       const sessionId = sessionIdForThread(thread.id);
-      const result = await options.runtime.startSession({
-        ownerScope: { type: "user", id: principal.userId },
-        request: {
+      if (agent === "codex" && options.codexEvents) {
+        await options.codexEvents.watch({
+          principal,
+          threadId: thread.id,
           sessionId,
-          kind: "agent",
-          agent,
-          prompt: request.prompt,
-          attachments: request.attachments,
-          projectSlug: request.projectId,
-          taskId: request.taskId,
-          worktreeId: request.worktreeId,
-          mode: request.mode,
-          approvalPolicy: request.approvalPolicy,
-          sandboxMode: request.sandboxMode,
-          runtimePreference: "zellij",
-        },
-      });
+        });
+      }
+      let result;
+      try {
+        result = await options.runtime.startSession({
+          ownerScope: { type: "user", id: principal.userId },
+          request: {
+            sessionId,
+            kind: "agent",
+            agent,
+            prompt: request.prompt,
+            attachments: request.attachments,
+            projectSlug: request.projectId,
+            taskId: request.taskId,
+            worktreeId: request.worktreeId,
+            mode: request.mode,
+            approvalPolicy: request.approvalPolicy,
+            sandboxMode: request.sandboxMode,
+            runtimePreference: "zellij",
+          },
+        });
+      } catch (error: unknown) {
+        options.codexEvents?.unwatch(sessionId);
+        throw error;
+      }
       if (!result.ok) {
+        options.codexEvents?.unwatch(sessionId);
         throw new Error("Workspace provider start failed");
       }
 
@@ -240,14 +262,6 @@ export function createWorkspaceCodingAgentProvider(
           threadId: thread.id,
           occurredAt: now().toISOString(),
           terminalSessionId,
-        }),
-        AgentThreadEventSchema.parse({
-          type: "assistant.text.delta",
-          eventId: nextEventId(),
-          threadId: thread.id,
-          occurredAt: now().toISOString(),
-          messageId: `msg_${thread.id}`,
-          delta: "Agent session started.",
         })],
         resumeState: { conversationId: sessionId },
       };
@@ -274,6 +288,7 @@ export function createWorkspaceCodingAgentProvider(
       if (!result.ok) {
         throw new Error("Workspace provider abort failed");
       }
+      options.codexEvents?.unwatch(sessionIdForThread(thread.id));
       return [
         statusEvent({
           threadId: thread.id,
@@ -307,6 +322,7 @@ export function createWorkspaceCodingAgentProviderSet(
     agent,
     runtime: options.runtime,
     runnable: agent === "codex" || agent === "claude",
+    codexEvents: agent === "codex" ? options.codexEvents : undefined,
   }));
   return {
     registryProviders,

--- a/packages/gateway/src/coding-agents/workspace-provider.ts
+++ b/packages/gateway/src/coding-agents/workspace-provider.ts
@@ -33,13 +33,13 @@ export interface WorkspaceCodingAgentProviderOptions {
   agent: SupportedAgent;
   runtime: WorkspaceRuntime;
   runnable?: boolean;
-  codexEvents?: Pick<CodexEventBridge, "healthCheck" | "watch" | "unwatch">;
+  codexEvents?: Pick<CodexEventBridge, "healthCheck" | "watch" | "unwatch" | "markStopped">;
 }
 
 export interface WorkspaceCodingAgentProviderSetOptions {
   agents: readonly SupportedAgent[];
   runtime: WorkspaceRuntime;
-  codexEvents: Pick<CodexEventBridge, "healthCheck" | "watch" | "unwatch">;
+  codexEvents: Pick<CodexEventBridge, "healthCheck" | "watch" | "unwatch" | "markStopped">;
 }
 
 export interface WorkspaceCodingAgentProviderSet {
@@ -288,7 +288,7 @@ export function createWorkspaceCodingAgentProvider(
       if (!result.ok) {
         throw new Error("Workspace provider abort failed");
       }
-      options.codexEvents?.unwatch(sessionIdForThread(thread.id));
+      options.codexEvents?.markStopped(sessionIdForThread(thread.id));
       return [
         statusEvent({
           threadId: thread.id,

--- a/packages/gateway/src/coding-agents/workspace-provider.ts
+++ b/packages/gateway/src/coding-agents/workspace-provider.ts
@@ -137,11 +137,10 @@ function workspaceTurnInput(
   const body = references.length > 0
     ? `${message}\n\nContext references:\n${references.join("\n")}`
     : message;
-  const input = `${body}\r`;
-  if (Buffer.byteLength(input, "utf-8") > 64 * 1024) {
+  if (Buffer.byteLength(body, "utf-8") > 64 * 1024) {
     throw new Error("Workspace provider input is too large");
   }
-  return input;
+  return `matrix-turn-v1:${Buffer.from(body, "utf-8").toString("base64")}\r`;
 }
 
 function statusEvent(input: {

--- a/packages/gateway/src/server.ts
+++ b/packages/gateway/src/server.ts
@@ -118,6 +118,7 @@ import { createCodingAgentSourceControlStore } from "./coding-agents/source-cont
 import { registerCodingAgentAttentionNotifications } from "./coding-agents/attention-notifications.js";
 import { createCodingAgentNotificationPreferenceStore } from "./coding-agents/notification-preferences.js";
 import { createCodingAgentProjectMutationService } from "./coding-agents/project-mutations.js";
+import { createCodexEventBridge, type CodexEventBridge } from "./coding-agents/codex-event-bridge.js";
 import { createAgentActionAuditService } from "./onboarding/agent-action-audit.js";
 import { capabilityIdsForConnectedServices, createIntegrationCapabilityService } from "./onboarding/integration-capabilities.js";
 import { createIntegrationCapabilityRoutes } from "./onboarding/integration-capability-routes.js";
@@ -508,6 +509,7 @@ export async function createGateway(config: GatewayConfig) {
     },
   });
   let codingAgentThreadStore: (CodingAgentThreadStore & CodingAgentTurnStore) | undefined;
+  let codexEventBridge: CodexEventBridge | undefined;
   const codingAgentSessionStopReconciler = createCodingAgentSessionStopReconciler();
   const workspaceEventStore = createWorkspaceEventStore({ homePath });
   const reviewStore = createReviewStore({ homePath });
@@ -545,6 +547,7 @@ export async function createGateway(config: GatewayConfig) {
   const codingAgentWorkspaceAgents = configuredWorkspaceProviderAgents(process.env);
   if (codingAgentWorkspaceAgents.length > 0) {
     const codingAgentProjectManager = createProjectManager({ homePath });
+    codexEventBridge = createCodexEventBridge({ homePath });
     const codingAgentWorktreeManager = createWorktreeManager({ homePath });
     const codingAgentLauncher = createAgentLauncher({ cwd: homePath, runtimeHome: homePath });
     const codingAgentSessionManager = createAgentSessionManager({
@@ -566,6 +569,7 @@ export async function createGateway(config: GatewayConfig) {
     const providerSet = createWorkspaceCodingAgentProviderSet({
       agents: codingAgentWorkspaceAgents,
       runtime: codingAgentWorkspaceRuntime,
+      codexEvents: codexEventBridge,
     });
     codingAgentProviders.push(...providerSet.executionProviders);
     codingAgentRegistryProviders.push(...providerSet.registryProviders);
@@ -587,6 +591,7 @@ export async function createGateway(config: GatewayConfig) {
         workspaceEventPublisher.publishCodingAgentThreadProjection(change),
     })
     : undefined;
+  if (codingAgentThreadStore) codexEventBridge?.attachThreadStore(codingAgentThreadStore);
   const codingAgentProviderRegistry = createCodingAgentProviderRegistry({
     providers: codingAgentRegistryProviders,
     agentCredentials: agentCredentialService,
@@ -4257,6 +4262,7 @@ export async function createGateway(config: GatewayConfig) {
       proactiveHeartbeat.stop();
       cronService.stop();
       await codingAgentTurnLifecycle.shutdown();
+      await codexEventBridge?.shutdown();
       codingAgentThreadStream?.shutdown();
       codingAgentAttentionNotifications?.dispose();
       codingAgentSessionStopReconciler.dispose();

--- a/specs/105-coding-agent-shells/current-state.md
+++ b/specs/105-coding-agent-shells/current-state.md
@@ -278,6 +278,8 @@ Workspace provider behavior:
 - Passes through prompt, project, task, worktree, mode, approval policy, sandbox mode, and zellij runtime preference.
 - Passes bounded `structured_ref` attachments into the runtime launch prompt as safe reference metadata so review follow-up runs can inspect the selected file/hunk without client-side diff contents.
 - Binds coding-agent threads to canonical `terminalSessionId` from the workspace session.
+- Runs Codex through a Matrix-owned, shell-free subprocess wrapper that forces JSONL output, preserves the attachable Zellij terminal, queues bounded same-thread prompts, resumes the exact server-side provider thread id, suppresses raw provider stderr, and applies a ten-minute turn timeout.
+- Watches a dedicated bounded owner-local provider-event transcript through a capped registry with deterministic replay ids, symlink-safe reads, stale-file cleanup, shutdown drain, and durable-before-publish thread-store ingestion. Unverified installed Codex versions fail closed before the session starts.
 - Aborts through the deterministic workspace session id.
 - Keeps provider startup failures safe in the returned thread snapshot.
 

--- a/specs/105-coding-agent-shells/tasks.md
+++ b/specs/105-coding-agent-shells/tasks.md
@@ -1416,7 +1416,7 @@ composer turns, and lifecycle actions.
 - [ ] B28-011 Write a table-driven provider conformance harness covering install/auth health, create, normalized stream, abort, restart, safe errors, capability truthfulness, timeout, and cleanup for every first-release adapter.
 - [x] B28-011a Add a strict, forward-compatible Codex exec JSONL normalizer, durable idempotent provider-event ingestion, exact verified-version/schema metadata, and a scheduled published-version drift check.
 - [ ] B28-012 Implement and real-process test first-class adapters for Claude Code, Codex, Pi, and OpenCode plus a validated custom ACP-compatible adapter family; keep credentials and native resume identities server-side.
-- [ ] B28-012a Wire the Codex workspace runner to the normalized provider-event ingestion contract and prove assistant/tool/file events stream through replay plus WebSocket publication on a disposable runtime.
+- [x] B28-012a Wire the Codex workspace runner to the normalized provider-event ingestion contract and prove assistant/tool/file events through deterministic replay, event-sink publication, and a real child-process test. Disposable-runtime smoke remains in B34-001.
 - [ ] B28-013 Implement capability-gated compatibility adapters for Kiro, GitHub Copilot CLI, Qwen Code, Kimi CLI, Kilo Code, and Auggie without generic shell-command escape hatches.
 - [ ] B28-014 Prove each provider/runtime combination advertises only verified resume, discovery/import, fork, rollback, steering, approval, image, model/mode, and handoff capabilities; reject Gemini CLI as unsupported for this release.
 

--- a/tests/gateway/agent-launcher.test.ts
+++ b/tests/gateway/agent-launcher.test.ts
@@ -112,12 +112,12 @@ describe("agent-launcher", () => {
       args: [
         "--ask-for-approval",
         "never",
-        "exec",
-        "--skip-git-repo-check",
         "--sandbox",
         "workspace-write",
         "--add-dir",
         "/tmp/matrixos-codex",
+        "exec",
+        "--skip-git-repo-check",
         "--",
         "fix tests; rm -rf /",
       ],
@@ -157,12 +157,12 @@ describe("agent-launcher", () => {
         expect(launch.args).toEqual([
           "--ask-for-approval",
           "never",
-          "exec",
-          "--skip-git-repo-check",
           "--sandbox",
           "workspace-write",
           "--add-dir",
           "/tmp/sandbox",
+          "exec",
+          "--skip-git-repo-check",
           "--",
           "--dangerously-bypass-sandbox",
         ]);
@@ -191,20 +191,21 @@ describe("agent-launcher", () => {
     expect(launchEmpty.args).not.toContain("--");
   });
 
-  it("places Codex exec controls before sandbox flags and the prompt last", () => {
+  it("places Codex security controls before exec and the prompt last", () => {
     const launch = buildAgentLaunch({
       agent: "codex",
       cwd: "/home/matrixos/home/projects/repo",
       prompt: "--help",
       sandbox: { enabled: true, writableRoots: ["/tmp/sandbox"] },
     });
-    expect(launch.args.slice(0, 4)).toEqual(["--ask-for-approval", "never", "exec", "--skip-git-repo-check"]);
     const sandboxIndex = launch.args.indexOf("--sandbox");
     const writableRootIndex = launch.args.indexOf("--add-dir");
+    const execIndex = launch.args.indexOf("exec");
     const dashDashIndex = launch.args.indexOf("--");
-    expect(sandboxIndex).toBeGreaterThan(3);
+    expect(sandboxIndex).toBeGreaterThan(1);
     expect(writableRootIndex).toBeGreaterThan(sandboxIndex);
-    expect(dashDashIndex).toBeGreaterThan(writableRootIndex);
+    expect(execIndex).toBeGreaterThan(writableRootIndex);
+    expect(dashDashIndex).toBeGreaterThan(execIndex);
     expect(launch.args.at(-1)).toBe("--help");
   });
 
@@ -220,10 +221,10 @@ describe("agent-launcher", () => {
     expect(launch.args).toEqual([
       "--ask-for-approval",
       "on-request",
-      "exec",
-      "--skip-git-repo-check",
       "--sandbox",
       "read-only",
+      "exec",
+      "--skip-git-repo-check",
       "--",
       "review only",
     ]);
@@ -241,10 +242,10 @@ describe("agent-launcher", () => {
     expect(reviewLaunch.args).toEqual([
       "--ask-for-approval",
       "never",
-      "exec",
-      "--skip-git-repo-check",
       "--sandbox",
       "read-only",
+      "exec",
+      "--skip-git-repo-check",
       "review",
       "--",
       "check this PR",
@@ -274,7 +275,7 @@ describe("agent-launcher", () => {
       cwd: "/home/matrixos/home/projects/repo",
       prompt: "work",
       sandbox: { enabled: false, adminOverride: true },
-    }).args).toEqual(["--ask-for-approval", "never", "exec", "--skip-git-repo-check", "--dangerously-bypass-approvals-and-sandbox", "--", "work"]);
+    }).args).toEqual(["--ask-for-approval", "never", "--dangerously-bypass-approvals-and-sandbox", "exec", "--skip-git-repo-check", "--", "work"]);
   });
 
   it("constructs a strict workspace-scoped Claude launch policy", () => {

--- a/tests/gateway/coding-agents-codex-runtime.test.ts
+++ b/tests/gateway/coding-agents-codex-runtime.test.ts
@@ -1,5 +1,5 @@
 import { spawn } from "node:child_process";
-import { chmod, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { appendFile, chmod, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it, vi } from "vitest";
@@ -109,6 +109,41 @@ describe("Codex structured event runtime", () => {
         "item.completed",
         "turn.completed",
       ]);
+    } finally {
+      await rm(homePath, { recursive: true, force: true });
+    }
+  });
+
+  it("sanitizes oversized command output without failing the Codex turn", async () => {
+    const homePath = await mkdtemp(join(tmpdir(), "matrix-codex-runner-large-event-"));
+    const fakeCodexPath = join(homePath, "fake-codex-large-event.mjs");
+    const eventPath = codexProviderEventPath(homePath, "sess_runner_large_1");
+    await writeFile(fakeCodexPath, [
+      "#!/usr/bin/env node",
+      "console.log(JSON.stringify({type:'thread.started',thread_id:'019f-large-thread'}));",
+      "console.log(JSON.stringify({type:'item.completed',item:{id:'item_large',type:'command_execution',command:'run tests',aggregated_output:'secret-output-'.repeat(7000),exit_code:0,status:'completed'}}));",
+      "console.log(JSON.stringify({type:'turn.completed'}));",
+    ].join("\n"), "utf-8");
+    await chmod(fakeCodexPath, 0o700);
+
+    try {
+      const runnerPath = join(process.cwd(), "packages/gateway/src/coding-agents/codex-runner.mjs");
+      const result = await runProcess(process.execPath, [
+        runnerPath,
+        eventPath,
+        process.execPath,
+        fakeCodexPath,
+        "exec",
+        "--json",
+        "--",
+        "Run the tests.",
+      ], homePath);
+
+      expect(result.code).toBe(0);
+      const persisted = await readFile(eventPath, "utf-8");
+      expect(persisted).not.toContain("secret-output");
+      expect(persisted).toContain('"type":"command_execution"');
+      expect(persisted).toContain('"type":"turn.completed"');
     } finally {
       await rm(homePath, { recursive: true, force: true });
     }
@@ -417,6 +452,18 @@ describe("Codex structured event runtime", () => {
 
       await bridge.drain();
 
+      expect(bridge.watcherCount()).toBe(1);
+      await appendFile(codexProviderEventPath(homePath, sessionId), [
+        JSON.stringify({ type: "turn.started" }),
+        JSON.stringify({
+          type: "item.completed",
+          item: { id: "item_message_2", type: "agent_message", text: "The follow-up is complete." },
+        }),
+        JSON.stringify({ type: "turn.completed" }),
+        "",
+      ].join("\n"), "utf-8");
+      await bridge.drain();
+
       const replay = await store.getThread(principal, created.snapshot.thread.id);
       expect(replay.thread.status).toBe("completed");
       expect(replay.events.items.map((event) => event.type)).toEqual(expect.arrayContaining([
@@ -425,6 +472,9 @@ describe("Codex structured event runtime", () => {
         "assistant.text.delta",
         "assistant.text.completed",
         "thread.completed",
+      ]));
+      expect(replay.events.items).toEqual(expect.arrayContaining([
+        expect.objectContaining({ type: "assistant.text.delta", delta: "The follow-up is complete." }),
       ]));
       expect(sink).toHaveBeenCalledWith(expect.objectContaining({
         ownerId: principal.userId,

--- a/tests/gateway/coding-agents-codex-runtime.test.ts
+++ b/tests/gateway/coding-agents-codex-runtime.test.ts
@@ -248,6 +248,49 @@ describe("Codex structured event runtime", () => {
     }
   });
 
+  it("durably drains final provider records before removing an aborted session watcher", async () => {
+    const homePath = await mkdtemp(join(tmpdir(), "matrix-codex-runtime-abort-"));
+    const batches: CodingAgentProviderEventBatch[] = [];
+    const bridge = createCodexEventBridge({
+      homePath,
+      pollIntervalMs: 60_000,
+      runVersionCommand: vi.fn(async () => ({ stdout: "codex-cli 0.144.1\n", stderr: "" })),
+    });
+    bridge.attachThreadStore({
+      async ingestProviderEvents(_principal, _threadId, batch) {
+        batches.push(batch);
+      },
+    });
+    try {
+      const sessionId = "sess_abort_final_1";
+      await bridge.watch({ principal, threadId: "thread_abort_final_1", sessionId });
+      await writeFile(codexProviderEventPath(homePath, sessionId), [
+        JSON.stringify({ type: "thread.started", thread_id: "019f-abort-final" }),
+        JSON.stringify({ type: "turn.failed", error: { message: "provider secret" } }),
+        "",
+      ].join("\n"), "utf-8");
+
+      bridge.markStopped(sessionId);
+      expect(bridge.watcherCount()).toBe(1);
+      await bridge.drain();
+
+      expect(bridge.watcherCount()).toBe(0);
+      expect(batches).toEqual(expect.arrayContaining([
+        expect.objectContaining({ providerThreadId: "019f-abort-final" }),
+        expect.objectContaining({
+          events: expect.arrayContaining([
+            expect.objectContaining({ type: "thread.error" }),
+            expect.objectContaining({ type: "thread.completed", outcome: "failed" }),
+          ]),
+        }),
+      ]));
+      expect(JSON.stringify(batches)).not.toContain("provider secret");
+    } finally {
+      await bridge.shutdown();
+      await rm(homePath, { recursive: true, force: true });
+    }
+  });
+
   it("streams a real provider transcript through durable replay and event publication", async () => {
     const homePath = await mkdtemp(join(tmpdir(), "matrix-codex-runtime-integration-"));
     const bridge = createCodexEventBridge({

--- a/tests/gateway/coding-agents-codex-runtime.test.ts
+++ b/tests/gateway/coding-agents-codex-runtime.test.ts
@@ -458,6 +458,7 @@ describe("Codex structured event runtime", () => {
       });
       expect(created.snapshot.events.items.map((event) => event.type)).toEqual([
         "thread.created",
+        "user.message",
         "thread.status",
         "terminal.bound",
       ]);

--- a/tests/gateway/coding-agents-codex-runtime.test.ts
+++ b/tests/gateway/coding-agents-codex-runtime.test.ts
@@ -60,6 +60,8 @@ describe("Codex structured event runtime", () => {
       "codex",
     ]);
     expect(launch.args).toContain("--json");
+    expect(launch.args.indexOf("--sandbox")).toBeLessThan(launch.args.indexOf("exec"));
+    expect(launch.args.indexOf("--add-dir")).toBeLessThan(launch.args.indexOf("exec"));
     expect(launch.args).not.toContain("sh");
     expect(launch.args).not.toContain("-c");
   });
@@ -130,6 +132,8 @@ describe("Codex structured event runtime", () => {
 
     try {
       const runnerPath = join(process.cwd(), "packages/gateway/src/coding-agents/codex-runner.mjs");
+      const followUp = "Continue the fix.\n\nContext references:\n- route: src/route.ts";
+      const framedFollowUp = `matrix-turn-v1:${Buffer.from(followUp, "utf-8").toString("base64")}\r`;
       const result = await runProcess(process.execPath, [
         runnerPath,
         eventPath,
@@ -137,11 +141,15 @@ describe("Codex structured event runtime", () => {
         fakeCodexPath,
         "--ask-for-approval",
         "never",
+        "--sandbox",
+        "workspace-write",
+        "--add-dir",
+        "/tmp/matrix-write-root",
         "exec",
         "--json",
         "--",
         "Start.",
-      ], homePath, "Continue.\r");
+      ], homePath, framedFollowUp);
 
       expect(result.code).toBe(0);
       expect(result.stdout).toContain("Continued.");
@@ -150,13 +158,17 @@ describe("Codex structured event runtime", () => {
       expect(calls[1]).toEqual([
         "--ask-for-approval",
         "never",
+        "--sandbox",
+        "workspace-write",
+        "--add-dir",
+        "/tmp/matrix-write-root",
         "exec",
         "resume",
         "--json",
         "--skip-git-repo-check",
         "019f-resume-thread",
         "--",
-        "Continue.",
+        followUp,
       ]);
     } finally {
       await rm(homePath, { recursive: true, force: true });
@@ -285,6 +297,48 @@ describe("Codex structured event runtime", () => {
         }),
       ]));
       expect(JSON.stringify(batches)).not.toContain("provider secret");
+    } finally {
+      await bridge.shutdown();
+      await rm(homePath, { recursive: true, force: true });
+    }
+  });
+
+  it("drains provider records written immediately before bridge shutdown", async () => {
+    const homePath = await mkdtemp(join(tmpdir(), "matrix-codex-runtime-shutdown-"));
+    const batches: CodingAgentProviderEventBatch[] = [];
+    const bridge = createCodexEventBridge({
+      homePath,
+      pollIntervalMs: 60_000,
+      runVersionCommand: vi.fn(async () => ({ stdout: "codex-cli 0.144.1\n", stderr: "" })),
+    });
+    bridge.attachThreadStore({
+      async ingestProviderEvents(_principal, _threadId, batch) {
+        batches.push(batch);
+      },
+    });
+    try {
+      const sessionId = "sess_shutdown_final_1";
+      await bridge.watch({ principal, threadId: "thread_shutdown_final_1", sessionId });
+      await writeFile(codexProviderEventPath(homePath, sessionId), [
+        JSON.stringify({ type: "thread.started", thread_id: "019f-shutdown-final" }),
+        JSON.stringify({
+          type: "item.completed",
+          item: { id: "item_shutdown", type: "agent_message", text: "Final response." },
+        }),
+        JSON.stringify({ type: "turn.completed" }),
+        "",
+      ].join("\n"), "utf-8");
+
+      await bridge.shutdown();
+
+      expect(batches).toEqual(expect.arrayContaining([
+        expect.objectContaining({
+          events: expect.arrayContaining([
+            expect.objectContaining({ type: "assistant.text.delta", delta: "Final response." }),
+            expect.objectContaining({ type: "thread.completed", outcome: "completed" }),
+          ]),
+        }),
+      ]));
     } finally {
       await bridge.shutdown();
       await rm(homePath, { recursive: true, force: true });

--- a/tests/gateway/coding-agents-codex-runtime.test.ts
+++ b/tests/gateway/coding-agents-codex-runtime.test.ts
@@ -230,6 +230,41 @@ describe("Codex structured event runtime", () => {
     }
   });
 
+  it("does not cache an aborted Codex version probe", async () => {
+    const homePath = await mkdtemp(join(tmpdir(), "matrix-codex-bridge-"));
+    const runVersionCommand = vi.fn(async (
+      _command: string,
+      _args: string[],
+      options: { signal: AbortSignal },
+    ) => {
+      if (options.signal.aborted) {
+        throw Object.assign(new Error("aborted"), { name: "AbortError" });
+      }
+      return { stdout: "codex-cli 0.144.1\n", stderr: "" };
+    });
+    const bridge = createCodexEventBridge({
+      homePath,
+      pollIntervalMs: 60_000,
+      runVersionCommand,
+    });
+    const controller = new AbortController();
+    controller.abort();
+    try {
+      await expect(bridge.healthCheck(controller.signal)).resolves.toEqual({ ok: false });
+      await expect(bridge.watch({
+        principal,
+        threadId: "thread_version_retry_1",
+        sessionId: "sess_version_retry_1",
+      })).resolves.toEqual({
+        path: codexProviderEventPath(homePath, "sess_version_retry_1"),
+      });
+      expect(runVersionCommand).toHaveBeenCalledTimes(2);
+    } finally {
+      await bridge.shutdown();
+      await rm(homePath, { recursive: true, force: true });
+    }
+  });
+
   it("retries failed ingestion with stable event ids then advances the transcript cursor", async () => {
     const homePath = await mkdtemp(join(tmpdir(), "matrix-codex-bridge-"));
     const eventPath = codexProviderEventPath(homePath, "sess_bridge_1");

--- a/tests/gateway/coding-agents-codex-runtime.test.ts
+++ b/tests/gateway/coding-agents-codex-runtime.test.ts
@@ -1,0 +1,345 @@
+import { spawn } from "node:child_process";
+import { chmod, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it, vi } from "vitest";
+import { buildAgentLaunch } from "../../packages/gateway/src/agent-launcher.js";
+import {
+  codexProviderEventPath,
+  createCodexEventBridge,
+} from "../../packages/gateway/src/coding-agents/codex-event-bridge.js";
+import { createCodingAgentThreadStore } from "../../packages/gateway/src/coding-agents/thread-store.js";
+import { createWorkspaceCodingAgentProvider } from "../../packages/gateway/src/coding-agents/workspace-provider.js";
+import type { RequestPrincipal } from "../../packages/gateway/src/request-principal.js";
+
+const principal: RequestPrincipal = { userId: "owner_user", source: "jwt" };
+
+function runProcess(command: string, args: string[], cwd: string, input = ""): Promise<{
+  code: number | null;
+  stdout: string;
+  stderr: string;
+}> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, {
+      cwd,
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", (chunk: Buffer) => {
+      stdout += chunk.toString("utf-8");
+    });
+    child.stderr.on("data", (chunk: Buffer) => {
+      stderr += chunk.toString("utf-8");
+    });
+    child.once("error", reject);
+    child.once("close", (code) => resolve({ code, stdout, stderr }));
+    child.stdin.end(input);
+  });
+}
+
+describe("Codex structured event runtime", () => {
+  it("wraps Codex exec with the Matrix event runner and forces JSONL output", () => {
+    const launch = buildAgentLaunch({
+      agent: "codex",
+      cwd: "/home/matrix/home/projects/repo",
+      prompt: "Fix the failing route.",
+      approvalPolicy: "never",
+      sandbox: {
+        enabled: true,
+        mode: "workspace-write",
+        writableRoots: ["/home/matrix/home/projects/repo"],
+      },
+      providerEventPath: "/home/matrix/home/system/coding-agents/provider-events/sess_test.jsonl",
+    });
+
+    expect(launch.command).toBe(process.execPath);
+    expect(launch.args[0]).toMatch(/coding-agents\/codex-runner\.mjs$/);
+    expect(launch.args.slice(1, 3)).toEqual([
+      "/home/matrix/home/system/coding-agents/provider-events/sess_test.jsonl",
+      "codex",
+    ]);
+    expect(launch.args).toContain("--json");
+    expect(launch.args).not.toContain("sh");
+    expect(launch.args).not.toContain("-c");
+  });
+
+  it("runs a real child process, persists raw complete JSONL, and prints only safe terminal output", async () => {
+    const homePath = await mkdtemp(join(tmpdir(), "matrix-codex-runner-"));
+    const fakeCodexPath = join(homePath, "fake-codex.mjs");
+    const eventPath = codexProviderEventPath(homePath, "sess_runner_1");
+    await writeFile(fakeCodexPath, [
+      "#!/usr/bin/env node",
+      "process.stderr.write('token sk-private at /home/matrix/private\\n');",
+      "console.log(JSON.stringify({type:'thread.started',thread_id:'019f-runner-thread'}));",
+      "console.log(JSON.stringify({type:'item.started',item:{id:'item_cmd',type:'command_execution',command:'cat /home/matrix/private',aggregated_output:'',exit_code:null,status:'in_progress'}}));",
+      "console.log(JSON.stringify({type:'item.completed',item:{id:'item_msg',type:'agent_message',text:'The route is fixed.'}}));",
+      "console.log(JSON.stringify({type:'turn.completed'}));",
+    ].join("\n"), "utf-8");
+    await chmod(fakeCodexPath, 0o700);
+
+    try {
+      const runnerPath = join(
+        process.cwd(),
+        "packages/gateway/src/coding-agents/codex-runner.mjs",
+      );
+      const result = await runProcess(process.execPath, [
+        runnerPath,
+        eventPath,
+        process.execPath,
+        fakeCodexPath,
+        "exec",
+        "--json",
+        "--",
+        "Fix the route.",
+      ], homePath);
+
+      expect(result.code).toBe(0);
+      expect(result.stdout).toContain("The route is fixed.");
+      expect(result.stdout).toContain("Running command");
+      expect(result.stdout).not.toMatch(/sk-private|\/home\/matrix\/private|cat \/home/);
+      expect(result.stderr).not.toMatch(/sk-private|\/home\/matrix\/private/);
+      const persisted = (await readFile(eventPath, "utf-8")).trim().split("\n");
+      expect(persisted).toHaveLength(4);
+      expect(persisted.map((line) => JSON.parse(line).type)).toEqual([
+        "thread.started",
+        "item.started",
+        "item.completed",
+        "turn.completed",
+      ]);
+    } finally {
+      await rm(homePath, { recursive: true, force: true });
+    }
+  });
+
+  it("queues a follow-up and resumes the exact provider thread", async () => {
+    const homePath = await mkdtemp(join(tmpdir(), "matrix-codex-runner-resume-"));
+    const fakeCodexPath = join(homePath, "fake-codex-resume.mjs");
+    const callsPath = join(homePath, "calls.jsonl");
+    const eventPath = codexProviderEventPath(homePath, "sess_runner_resume_1");
+    await writeFile(fakeCodexPath, [
+      "#!/usr/bin/env node",
+      "import { appendFile } from 'node:fs/promises';",
+      `await appendFile(${JSON.stringify(callsPath)}, JSON.stringify(process.argv.slice(2)) + '\\n');`,
+      "const resumed = process.argv.includes('resume');",
+      "if (!resumed) console.log(JSON.stringify({type:'thread.started',thread_id:'019f-resume-thread'}));",
+      "if (resumed) console.log(JSON.stringify({type:'item.completed',item:{id:'item_resume',type:'agent_message',text:'Continued.'}}));",
+      "console.log(JSON.stringify({type:'turn.completed'}));",
+    ].join("\n"), "utf-8");
+    await chmod(fakeCodexPath, 0o700);
+
+    try {
+      const runnerPath = join(process.cwd(), "packages/gateway/src/coding-agents/codex-runner.mjs");
+      const result = await runProcess(process.execPath, [
+        runnerPath,
+        eventPath,
+        process.execPath,
+        fakeCodexPath,
+        "--ask-for-approval",
+        "never",
+        "exec",
+        "--json",
+        "--",
+        "Start.",
+      ], homePath, "Continue.\r");
+
+      expect(result.code).toBe(0);
+      expect(result.stdout).toContain("Continued.");
+      const calls = (await readFile(callsPath, "utf-8")).trim().split("\n").map((line) => JSON.parse(line));
+      expect(calls).toHaveLength(2);
+      expect(calls[1]).toEqual([
+        "--ask-for-approval",
+        "never",
+        "exec",
+        "resume",
+        "--json",
+        "--skip-git-repo-check",
+        "019f-resume-thread",
+        "--",
+        "Continue.",
+      ]);
+    } finally {
+      await rm(homePath, { recursive: true, force: true });
+    }
+  });
+
+  it("refuses unverified installed versions before creating a watcher", async () => {
+    const homePath = await mkdtemp(join(tmpdir(), "matrix-codex-bridge-"));
+    const bridge = createCodexEventBridge({
+      homePath,
+      pollIntervalMs: 60_000,
+      runVersionCommand: vi.fn(async () => ({ stdout: "codex-cli 0.145.0\n", stderr: "" })),
+    });
+    try {
+      await expect(bridge.watch({
+        principal,
+        threadId: "thread_version_1",
+        sessionId: "sess_version_1",
+      })).rejects.toThrow("Codex structured events are unavailable");
+      expect(bridge.watcherCount()).toBe(0);
+    } finally {
+      await bridge.shutdown();
+      await rm(homePath, { recursive: true, force: true });
+    }
+  });
+
+  it("retries failed ingestion with stable event ids then advances the transcript cursor", async () => {
+    const homePath = await mkdtemp(join(tmpdir(), "matrix-codex-bridge-"));
+    const eventPath = codexProviderEventPath(homePath, "sess_bridge_1");
+    const batches: Array<{ events: Array<{ eventId: string; type: string }>; providerThreadId?: string }> = [];
+    let shouldFail = true;
+    const ingestProviderEvents = vi.fn(async (
+      _principal: RequestPrincipal,
+      _threadId: string,
+      batch: { events: Array<{ eventId: string; type: string }>; providerThreadId?: string },
+    ) => {
+      batches.push(batch);
+      if (shouldFail) throw new Error("temporary store failure");
+      return {};
+    });
+    const bridge = createCodexEventBridge({
+      homePath,
+      pollIntervalMs: 60_000,
+      runVersionCommand: vi.fn(async () => ({ stdout: "codex-cli 0.144.1\n", stderr: "" })),
+    });
+    bridge.attachThreadStore({ ingestProviderEvents });
+    try {
+      await bridge.watch({
+        principal,
+        threadId: "thread_bridge_1",
+        sessionId: "sess_bridge_1",
+      });
+      await writeFile(eventPath, [
+        JSON.stringify({ type: "thread.started", thread_id: "019f-bridge-thread" }),
+        JSON.stringify({
+          type: "item.completed",
+          item: { id: "item_1", type: "agent_message", text: "A real response." },
+        }),
+        JSON.stringify({ type: "turn.completed" }),
+        "",
+      ].join("\n"), "utf-8");
+
+      await bridge.drain();
+      const firstAttemptIds = batches.flatMap((batch) => batch.events.map((event) => event.eventId));
+      expect(firstAttemptIds.length).toBeGreaterThan(0);
+
+      shouldFail = false;
+      batches.length = 0;
+      await bridge.drain();
+      const retryIds = batches.flatMap((batch) => batch.events.map((event) => event.eventId));
+      expect(retryIds).toEqual(firstAttemptIds);
+      expect(batches).toEqual(expect.arrayContaining([
+        expect.objectContaining({ providerThreadId: "019f-bridge-thread" }),
+        expect.objectContaining({
+          events: expect.arrayContaining([
+            expect.objectContaining({ type: "assistant.text.delta" }),
+            expect.objectContaining({ type: "assistant.text.completed" }),
+            expect.objectContaining({ type: "thread.completed", outcome: "completed" }),
+          ]),
+        }),
+      ]));
+
+      batches.length = 0;
+      await bridge.drain();
+      expect(batches).toEqual([]);
+    } finally {
+      await bridge.shutdown();
+      await rm(homePath, { recursive: true, force: true });
+    }
+  });
+
+  it("streams a real provider transcript through durable replay and event publication", async () => {
+    const homePath = await mkdtemp(join(tmpdir(), "matrix-codex-runtime-integration-"));
+    const bridge = createCodexEventBridge({
+      homePath,
+      pollIntervalMs: 60_000,
+      runVersionCommand: vi.fn(async () => ({ stdout: "codex-cli 0.144.1\n", stderr: "" })),
+    });
+    const runtime = {
+      startSession: vi.fn(async () => ({
+        ok: true as const,
+        status: 201,
+        session: {
+          id: "sess_runtime_integration_1",
+          runtime: { status: "running", zellijSession: "matrix-agent-runtime-integration" },
+        },
+      })),
+      sendInput: vi.fn(async () => ({ ok: true as const, session: {} })),
+      stopSession: vi.fn(async () => ({ ok: true as const, session: {} })),
+    };
+    const store = createCodingAgentThreadStore({
+      homePath,
+      providers: [createWorkspaceCodingAgentProvider({
+        providerId: "codex",
+        agent: "codex",
+        runtime,
+        codexEvents: bridge,
+      })],
+      now: () => new Date("2026-07-13T12:00:00.000Z"),
+    });
+    bridge.attachThreadStore(store);
+    const sink = vi.fn();
+    store.registerEventSink(sink);
+    try {
+      const created = await store.createThread(principal, {
+        providerId: "codex",
+        prompt: "Fix the route.",
+        mode: "default",
+        approvalPolicy: "never",
+        sandboxMode: "workspace_write",
+        clientRequestId: "req_runtime_integration_1",
+      });
+      expect(created.snapshot.events.items.map((event) => event.type)).toEqual([
+        "thread.created",
+        "thread.status",
+        "terminal.bound",
+      ]);
+      sink.mockClear();
+      const sessionId = `sess_${created.snapshot.thread.id.slice("thread_".length)}`;
+      await writeFile(codexProviderEventPath(homePath, sessionId), [
+        JSON.stringify({ type: "thread.started", thread_id: "019f-runtime-integration" }),
+        JSON.stringify({ type: "turn.started" }),
+        JSON.stringify({
+          type: "item.started",
+          item: {
+            id: "item_command_1",
+            type: "command_execution",
+            command: "pnpm test",
+            aggregated_output: "",
+            exit_code: null,
+            status: "in_progress",
+          },
+        }),
+        JSON.stringify({
+          type: "item.completed",
+          item: { id: "item_message_1", type: "agent_message", text: "The route is fixed." },
+        }),
+        JSON.stringify({ type: "turn.completed" }),
+        "",
+      ].join("\n"), "utf-8");
+
+      await bridge.drain();
+
+      const replay = await store.getThread(principal, created.snapshot.thread.id);
+      expect(replay.thread.status).toBe("completed");
+      expect(replay.events.items.map((event) => event.type)).toEqual(expect.arrayContaining([
+        "thread.status",
+        "tool.started",
+        "assistant.text.delta",
+        "assistant.text.completed",
+        "thread.completed",
+      ]));
+      expect(sink).toHaveBeenCalledWith(expect.objectContaining({
+        ownerId: principal.userId,
+        threadId: created.snapshot.thread.id,
+        events: expect.arrayContaining([
+          expect.objectContaining({ type: "assistant.text.delta", delta: "The route is fixed." }),
+        ]),
+      }));
+    } finally {
+      await store.shutdownTurns();
+      await bridge.shutdown();
+      await rm(homePath, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/gateway/coding-agents-workspace-provider.test.ts
+++ b/tests/gateway/coding-agents-workspace-provider.test.ts
@@ -281,7 +281,6 @@ describe("coding agent workspace provider", () => {
       "user.message",
       "thread.status",
       "terminal.bound",
-      "assistant.text.delta",
     ]);
   });
 

--- a/tests/gateway/coding-agents-workspace-provider.test.ts
+++ b/tests/gateway/coding-agents-workspace-provider.test.ts
@@ -460,7 +460,7 @@ describe("coding agent workspace provider", () => {
     expect(resumeState).toEqual({ conversationId: "sess_workspace_1" });
     expect(sendInput).toHaveBeenCalledWith(
       "sess_workspace_1",
-      "Continue with the tests.\r",
+      `matrix-turn-v1:${Buffer.from("Continue with the tests.", "utf-8").toString("base64")}\r`,
       signal,
     );
     expect(resumed).toMatchObject({

--- a/tests/gateway/coding-agents-workspace-provider.test.ts
+++ b/tests/gateway/coding-agents-workspace-provider.test.ts
@@ -364,6 +364,7 @@ describe("coding agent workspace provider", () => {
   });
 
   it("aborts the deterministic workspace session for a thread", async () => {
+    const markStopped = vi.fn();
     const runtime = {
       startSession: vi.fn(async () => ({ ok: true, status: 201, session: workspaceSession() })),
       stopSession: vi.fn(async () => ({ ok: true, session: workspaceSession({ runtime: { type: "zellij", status: "exited" } }) })),
@@ -372,6 +373,12 @@ describe("coding agent workspace provider", () => {
       providerId: "codex",
       agent: "codex",
       runtime,
+      codexEvents: {
+        healthCheck: vi.fn(async () => ({ ok: true })),
+        watch: vi.fn(async () => ({ path: "/tmp/provider-events.jsonl" })),
+        unwatch: vi.fn(),
+        markStopped,
+      },
     });
     const thread = AgentThreadSummarySchema.parse({
       id: "thread_workspace_1",
@@ -393,6 +400,8 @@ describe("coding agent workspace provider", () => {
     });
 
     expect(runtime.stopSession).toHaveBeenCalledWith("sess_workspace_1");
+    expect(markStopped).toHaveBeenCalledWith("sess_workspace_1");
+    expect(runtime.stopSession.mock.invocationCallOrder[0]).toBeLessThan(markStopped.mock.invocationCallOrder[0]!);
     expect((events ?? []).map((event: AgentThreadEvent) => AgentThreadEventSchema.parse(event).type)).toEqual([
       "thread.status",
       "thread.completed",

--- a/www/content/docs/coding-agents.mdx
+++ b/www/content/docs/coding-agents.mdx
@@ -147,6 +147,8 @@ Matrix OS syncs a curated skill pack into each agent's skill discovery path at i
 
 Agent work is organized into threads. A thread records the selected provider, project or worktree context, lifecycle status, and safe event timeline. Desktop and mobile can keep an open thread updated from gateway state and can reopen a thread to see progress without replaying terminal output into local storage.
 
+Codex threads use the installed CLI's structured event stream when its version matches Matrix's verified compatibility range. Matrix turns assistant messages, tool activity, file changes, and completion state into bounded thread events while keeping raw commands, command output, provider errors, and credentials out of shell timelines. Follow-up messages resume the same provider thread. If the installed CLI is newer or older than the verified range, Matrix marks structured execution unavailable until the compatibility contract is updated.
+
 Threads may need attention when an agent:
 
 - requests approval for an action;


### PR DESCRIPTION
## Summary

- run Matrix-managed Codex threads through a bounded JSONL runner instead of terminal-only passthrough
- durably ingest verified Codex events into the authoritative thread store before publishing them to shell subscribers
- resume follow-up turns with the provider thread identity while keeping raw commands, tool output, stderr, and internal paths out of client events
- fail closed when the installed Codex version is outside the verified contract range
- add owner-local transcript cleanup, watcher caps, timeouts, retry-safe event identities, and shutdown drain
- update spec 105 and public coding-agent documentation

## Tests

- `pnpm exec vitest run tests/contracts/coding-agents.test.ts tests/gateway/coding-agents-*.test.ts tests/gateway/agent-launcher.test.ts tests/gateway/agent-session-manager.test.ts` - 27 files, 275 tests passed
- `bun run typecheck` - passed
- `bun run check:patterns` - 0 violations; 5 existing full-scan warnings
- `pnpm --filter '@matrix-os/gateway' build` - passed; runner artifact verified in `dist`
- `node --check packages/gateway/src/coding-agents/codex-runner.mjs` - passed
- `git diff --check origin/feat/codex-structured-event-contract...HEAD` - passed

## Review / Monitoring

- ready for review
- add `ready-for-ci` only after current-head Greptile reaches 5/5
- no merge, preview deployment, or release promotion is requested by this PR

## Invariants

### Source of truth

The gateway thread store remains authoritative. The owner-local JSONL file is a bounded provider transport log; desktop and mobile receive only normalized thread events after durable ingestion.

### Lock / transaction scope

No database schema or transaction changes are introduced. Transcript offsets advance only after the complete batch is accepted by the thread store, and failed ingestion retries with stable event identities.

### Acceptable orphan states

A stopped gateway can leave a bounded owner-local transcript file. Files are capped, symlinks are rejected, stale files are reaped after seven days with a maximum orphan count of 200, and watcher state is capped at 100 with oldest-entry eviction. Gateway-restart watcher recovery remains tracked separately in #936.

### Auth source of truth

No new public route or authentication path is added. The existing authenticated, owner-scoped thread creation path supplies the principal used for provider execution and durable thread ingestion. Provider credentials and raw output never enter renderer or mobile state.

### Deferred scope

- approval and user-input event handling is the next stacked slice
- live disposable-computer verification is deferred until this stack is explicitly authorized for preview deployment
- gateway-restart watcher recovery remains in #936
