### PR TITLE
feat(coding-agents): pin Codex app-server contract

### DIFF
--- a/.github/workflows/codex-exec-contract.yml
+++ b/.github/workflows/codex-exec-contract.yml
@@ -1,4 +1,4 @@
-name: Codex Exec Contract
+name: Codex Provider Contracts
 
 on:
   workflow_dispatch:
@@ -9,6 +9,9 @@ on:
     paths:
       - ".github/workflows/codex-exec-contract.yml"
       - "packages/gateway/src/coding-agents/codex-exec-contract.json"
+      - "packages/gateway/src/coding-agents/codex-app-server-contract.json"
+      - "packages/gateway/src/coding-agents/codex-app-server-version.ts"
+      - "packages/gateway/src/coding-agents/codex-contract-version.ts"
       - "packages/gateway/src/coding-agents/codex-events.ts"
       - "packages/gateway/src/coding-agents/codex-version.ts"
       - "scripts/check-codex-exec-contract.mjs"
@@ -16,6 +19,9 @@ on:
     paths:
       - ".github/workflows/codex-exec-contract.yml"
       - "packages/gateway/src/coding-agents/codex-exec-contract.json"
+      - "packages/gateway/src/coding-agents/codex-app-server-contract.json"
+      - "packages/gateway/src/coding-agents/codex-app-server-version.ts"
+      - "packages/gateway/src/coding-agents/codex-contract-version.ts"
       - "packages/gateway/src/coding-agents/codex-events.ts"
       - "packages/gateway/src/coding-agents/codex-version.ts"
       - "scripts/check-codex-exec-contract.mjs"
@@ -29,7 +35,7 @@ concurrency:
 
 jobs:
   verify:
-    name: Verify latest Codex JSONL contract
+    name: Verify latest Codex provider contracts
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -59,7 +65,21 @@ jobs:
             --output /tmp/codex-exec-events.rs
           test -s /tmp/codex-exec-events.rs
 
-      - name: Verify published version and schema digest
+      - name: Generate published app-server schema
         env:
           CODEX_VERSION: ${{ steps.latest.outputs.version }}
-        run: node scripts/check-codex-exec-contract.mjs "$CODEX_VERSION" /tmp/codex-exec-events.rs
+        run: |
+          set -euo pipefail
+          pnpm dlx "@openai/codex@${CODEX_VERSION}" app-server generate-json-schema \
+            --experimental \
+            --out /tmp/codex-app-server-schema
+          test -s /tmp/codex-app-server-schema/codex_app_server_protocol.schemas.json
+
+      - name: Verify published version and protocol digests
+        env:
+          CODEX_VERSION: ${{ steps.latest.outputs.version }}
+        run: |
+          node scripts/check-codex-exec-contract.mjs \
+            "$CODEX_VERSION" \
+            /tmp/codex-exec-events.rs \
+            /tmp/codex-app-server-schema/codex_app_server_protocol.schemas.json

--- a/docs/dev/coding-agent-shells.md
+++ b/docs/dev/coding-agent-shells.md
@@ -92,6 +92,14 @@ Provider-specific behavior belongs behind the gateway provider adapter interface
 - Use foreground terminal setup actions when user interaction is required.
 - Avoid provider-specific branches in shell components unless the shared contract explicitly exposes safe metadata.
 
+Provider executable discovery does not imply protocol compatibility. Codex
+support uses checked-in exec JSONL and app-server manifests with one bounded
+installed-version range. The daily `Codex Provider Contracts` workflow resolves
+the latest published package, verifies both protocol digests, and fails on
+version or schema drift. Runtime capabilities must remain disabled for any
+installed version outside the verified range; do not silently fall back to raw
+terminal parsing for approvals or structured input.
+
 The gateway provider registry owns shell-facing provider projections. It validates the bounded configured adapter set at startup, validates and bounds owner-scoped credential responses, combines adapter metadata with that credential state, and keeps credential-known non-system providers visible even before an execution adapter is registered. Credential-only projections preserve coarse install/auth state but remain unavailable for runs until an adapter exists. Credential-source failures fail closed to unavailable/unknown adapter projections without running setup or health reads. Adapter reads receive timeout signals, and only coarse health booleans enter a capped owner/provider TTL cache with LRU eviction. Invalid summaries or setup actions degrade to generic safe state; raw health output and credentials never enter the runtime summary.
 
 Workspace provider projections are configured with the bounded, comma-separated `MATRIX_CODING_AGENTS_WORKSPACE_PROVIDERS` setting. The supported rollout values are `claude` and `codex`; duplicates, unknown values, empty entries, and more than two entries fail startup with a generic configuration error. Every explicitly configured Claude/Codex adapter enters both the registry and executable provider sets. Customer host bundles enable the executable Codex adapter through the legacy `MATRIX_CODING_AGENTS_WORKSPACE_PROVIDER=1` setting so thread routes are present on a fresh runtime; provider readiness still fails closed until the provider CLI is installed and connected. The legacy setting remains a Codex-only compatibility path when the explicit list is unset, and an explicitly empty provider list disables workspace providers even when the legacy setting is present.

--- a/packages/gateway/src/coding-agents/codex-app-server-contract.json
+++ b/packages/gateway/src/coding-agents/codex-app-server-contract.json
@@ -1,7 +1,7 @@
 {
   "packageName": "@openai/codex",
   "minimumVersion": "0.144.0",
-  "latestVerifiedVersion": "0.144.3",
+  "latestVerifiedVersion": "0.144.6",
   "experimental": true,
   "schemaSha256": "85ea836927d6cfdd3c68a9bda17dba48d2573bbc282ab2d5775a5005e40bc9c3",
   "requiredServerMethods": [

--- a/packages/gateway/src/coding-agents/codex-app-server-contract.json
+++ b/packages/gateway/src/coding-agents/codex-app-server-contract.json
@@ -1,0 +1,13 @@
+{
+  "packageName": "@openai/codex",
+  "minimumVersion": "0.144.0",
+  "latestVerifiedVersion": "0.144.3",
+  "experimental": true,
+  "schemaSha256": "85ea836927d6cfdd3c68a9bda17dba48d2573bbc282ab2d5775a5005e40bc9c3",
+  "requiredServerMethods": [
+    "item/commandExecution/requestApproval",
+    "item/fileChange/requestApproval",
+    "item/tool/requestUserInput",
+    "item/permissions/requestApproval"
+  ]
+}

--- a/packages/gateway/src/coding-agents/codex-app-server-version.ts
+++ b/packages/gateway/src/coding-agents/codex-app-server-version.ts
@@ -1,0 +1,20 @@
+import { z } from "zod/v4";
+import contract from "./codex-app-server-contract.json" with { type: "json" };
+import { codexContractStatus, type CodexContractStatus } from "./codex-contract-version.js";
+
+const CodexVersionSchema = z.string().regex(/^\d+\.\d+\.\d+$/);
+
+const CodexAppServerContractSchema = z.object({
+  packageName: z.literal("@openai/codex"),
+  minimumVersion: CodexVersionSchema,
+  latestVerifiedVersion: CodexVersionSchema,
+  experimental: z.literal(true),
+  schemaSha256: z.string().regex(/^[a-f0-9]{64}$/),
+  requiredServerMethods: z.array(z.string().min(1).max(100)).min(1).max(16),
+}).strict();
+
+export const CODEX_APP_SERVER_CONTRACT = CodexAppServerContractSchema.parse(contract);
+
+export function codexAppServerContractStatus(versionOutput: string): CodexContractStatus {
+  return codexContractStatus(versionOutput, CODEX_APP_SERVER_CONTRACT);
+}

--- a/packages/gateway/src/coding-agents/codex-contract-version.ts
+++ b/packages/gateway/src/coding-agents/codex-contract-version.ts
@@ -1,0 +1,41 @@
+import { z } from "zod/v4";
+
+const CodexVersionSchema = z.string().regex(/^\d+\.\d+\.\d+$/);
+
+export type CodexContractStatus =
+  | { status: "verified"; version: string }
+  | { status: "unverified_older"; version: string }
+  | { status: "unverified_newer"; version: string }
+  | { status: "invalid" };
+
+function versionTuple(version: string): readonly [number, number, number] {
+  const [major, minor, patch] = version.split(".").map(Number);
+  return [major!, minor!, patch!];
+}
+
+function compareVersions(left: string, right: string): number {
+  const leftParts = versionTuple(left);
+  const rightParts = versionTuple(right);
+  for (let index = 0; index < leftParts.length; index += 1) {
+    const difference = leftParts[index]! - rightParts[index]!;
+    if (difference !== 0) return difference;
+  }
+  return 0;
+}
+
+export function codexContractStatus(
+  versionOutput: string,
+  contract: { minimumVersion: string; latestVerifiedVersion: string },
+): CodexContractStatus {
+  const match = versionOutput.trim().match(/(?:^|\s)(\d+\.\d+\.\d+)(?:\s|$)/);
+  const parsed = CodexVersionSchema.safeParse(match?.[1]);
+  if (!parsed.success) return { status: "invalid" };
+  const version = parsed.data;
+  if (compareVersions(version, contract.minimumVersion) < 0) {
+    return { status: "unverified_older", version };
+  }
+  if (compareVersions(version, contract.latestVerifiedVersion) > 0) {
+    return { status: "unverified_newer", version };
+  }
+  return { status: "verified", version };
+}

--- a/packages/gateway/src/coding-agents/codex-version.ts
+++ b/packages/gateway/src/coding-agents/codex-version.ts
@@ -1,5 +1,6 @@
 import { z } from "zod/v4";
 import contract from "./codex-exec-contract.json" with { type: "json" };
+import { codexContractStatus, type CodexContractStatus } from "./codex-contract-version.js";
 
 const CodexVersionSchema = z.string().regex(/^\d+\.\d+\.\d+$/);
 
@@ -13,37 +14,6 @@ const CodexExecContractSchema = z.object({
 
 export const CODEX_EXEC_CONTRACT = CodexExecContractSchema.parse(contract);
 
-type ContractStatus =
-  | { status: "verified"; version: string }
-  | { status: "unverified_older"; version: string }
-  | { status: "unverified_newer"; version: string }
-  | { status: "invalid" };
-
-function versionTuple(version: string): readonly [number, number, number] {
-  const [major, minor, patch] = version.split(".").map(Number);
-  return [major!, minor!, patch!];
-}
-
-function compareVersions(left: string, right: string): number {
-  const leftParts = versionTuple(left);
-  const rightParts = versionTuple(right);
-  for (let index = 0; index < leftParts.length; index += 1) {
-    const difference = leftParts[index]! - rightParts[index]!;
-    if (difference !== 0) return difference;
-  }
-  return 0;
-}
-
-export function codexExecContractStatus(versionOutput: string): ContractStatus {
-  const match = versionOutput.trim().match(/(?:^|\s)(\d+\.\d+\.\d+)(?:\s|$)/);
-  const parsed = CodexVersionSchema.safeParse(match?.[1]);
-  if (!parsed.success) return { status: "invalid" };
-  const version = parsed.data;
-  if (compareVersions(version, CODEX_EXEC_CONTRACT.minimumVersion) < 0) {
-    return { status: "unverified_older", version };
-  }
-  if (compareVersions(version, CODEX_EXEC_CONTRACT.latestVerifiedVersion) > 0) {
-    return { status: "unverified_newer", version };
-  }
-  return { status: "verified", version };
+export function codexExecContractStatus(versionOutput: string): CodexContractStatus {
+  return codexContractStatus(versionOutput, CODEX_EXEC_CONTRACT);
 }

--- a/scripts/check-codex-exec-contract.mjs
+++ b/scripts/check-codex-exec-contract.mjs
@@ -5,9 +5,15 @@ const configUrl = new URL(
   "../packages/gateway/src/coding-agents/codex-exec-contract.json",
   import.meta.url,
 );
+const appServerConfigUrl = new URL(
+  "../packages/gateway/src/coding-agents/codex-app-server-contract.json",
+  import.meta.url,
+);
 const config = JSON.parse(await readFile(configUrl, "utf-8"));
+const appServerConfig = JSON.parse(await readFile(appServerConfigUrl, "utf-8"));
 const latestVersion = process.argv[2]?.trim();
 const schemaPath = process.argv[3];
+const appServerSchemaPath = process.argv[4];
 
 if (!/^\d+\.\d+\.\d+$/.test(latestVersion ?? "")) {
   throw new Error("Codex package version is invalid");
@@ -17,6 +23,14 @@ if (latestVersion !== config.latestVerifiedVersion) {
     `Codex ${latestVersion} is not verified; review its exec JSONL schema and update the compatibility contract`,
   );
 }
+if (latestVersion !== appServerConfig.latestVerifiedVersion) {
+  throw new Error(
+    `Codex ${latestVersion} is not verified; review its app-server schema and update the compatibility contract`,
+  );
+}
+if (config.minimumVersion !== appServerConfig.minimumVersion) {
+  throw new Error("Codex exec and app-server minimum versions must evolve together");
+}
 if (schemaPath) {
   const schemaBytes = await readFile(schemaPath);
   const digest = createHash("sha256").update(schemaBytes).digest("hex");
@@ -24,5 +38,19 @@ if (schemaPath) {
     throw new Error("Codex exec JSONL schema digest changed; update parser fixtures before accepting it");
   }
 }
+if (appServerSchemaPath) {
+  const schemaBytes = await readFile(appServerSchemaPath);
+  const digest = createHash("sha256").update(schemaBytes).digest("hex");
+  if (digest !== appServerConfig.schemaSha256) {
+    throw new Error("Codex app-server schema digest changed; update protocol fixtures before accepting it");
+  }
+  const schema = JSON.parse(schemaBytes.toString("utf-8"));
+  const serialized = JSON.stringify(schema);
+  for (const method of appServerConfig.requiredServerMethods) {
+    if (!serialized.includes(JSON.stringify(method))) {
+      throw new Error(`Codex app-server method is unavailable: ${method}`);
+    }
+  }
+}
 
-console.log(`Codex ${latestVersion} matches the verified exec JSONL contract.`);
+console.log(`Codex ${latestVersion} matches the verified JSONL and app-server contracts.`);

--- a/scripts/check-codex-exec-contract.mjs
+++ b/scripts/check-codex-exec-contract.mjs
@@ -18,6 +18,9 @@ const appServerSchemaPath = process.argv[4];
 if (!/^\d+\.\d+\.\d+$/.test(latestVersion ?? "")) {
   throw new Error("Codex package version is invalid");
 }
+if (!schemaPath || !appServerSchemaPath) {
+  throw new Error("Both Codex schema paths are required");
+}
 if (latestVersion !== config.latestVerifiedVersion) {
   throw new Error(
     `Codex ${latestVersion} is not verified; review its exec JSONL schema and update the compatibility contract`,
@@ -31,25 +34,22 @@ if (latestVersion !== appServerConfig.latestVerifiedVersion) {
 if (config.minimumVersion !== appServerConfig.minimumVersion) {
   throw new Error("Codex exec and app-server minimum versions must evolve together");
 }
-if (schemaPath) {
-  const schemaBytes = await readFile(schemaPath);
-  const digest = createHash("sha256").update(schemaBytes).digest("hex");
-  if (digest !== config.schemaSha256) {
-    throw new Error("Codex exec JSONL schema digest changed; update parser fixtures before accepting it");
-  }
+const schemaBytes = await readFile(schemaPath);
+const digest = createHash("sha256").update(schemaBytes).digest("hex");
+if (digest !== config.schemaSha256) {
+  throw new Error("Codex exec JSONL schema digest changed; update parser fixtures before accepting it");
 }
-if (appServerSchemaPath) {
-  const schemaBytes = await readFile(appServerSchemaPath);
-  const digest = createHash("sha256").update(schemaBytes).digest("hex");
-  if (digest !== appServerConfig.schemaSha256) {
-    throw new Error("Codex app-server schema digest changed; update protocol fixtures before accepting it");
-  }
-  const schema = JSON.parse(schemaBytes.toString("utf-8"));
-  const serialized = JSON.stringify(schema);
-  for (const method of appServerConfig.requiredServerMethods) {
-    if (!serialized.includes(JSON.stringify(method))) {
-      throw new Error(`Codex app-server method is unavailable: ${method}`);
-    }
+
+const appServerSchemaBytes = await readFile(appServerSchemaPath);
+const appServerDigest = createHash("sha256").update(appServerSchemaBytes).digest("hex");
+if (appServerDigest !== appServerConfig.schemaSha256) {
+  throw new Error("Codex app-server schema digest changed; update protocol fixtures before accepting it");
+}
+const appServerSchema = JSON.parse(appServerSchemaBytes.toString("utf-8"));
+const serializedAppServerSchema = JSON.stringify(appServerSchema);
+for (const method of appServerConfig.requiredServerMethods) {
+  if (!serializedAppServerSchema.includes(JSON.stringify(method))) {
+    throw new Error(`Codex app-server method is unavailable: ${method}`);
   }
 }
 

--- a/specs/105-coding-agent-shells/ARCHITECTURE.md
+++ b/specs/105-coding-agent-shells/ARCHITECTURE.md
@@ -390,6 +390,11 @@ Guidance:
   provider identity or capabilities.
 - `setupActions` should contain safe action IDs and labels, not raw arbitrary commands unless explicitly marked as foreground terminal actions.
 - Health checks must be timeout-bound.
+- Provider protocol support is version-gated independently from executable
+  discovery. For Codex, Matrix pins both the exec JSONL schema and the
+  experimental app-server schema to one verified package range, checks the
+  latest published package daily, and fails closed for installed versions
+  outside that range or whenever either schema digest changes.
 
 ### Thread Create
 
@@ -414,6 +419,9 @@ Rules:
 - `clientRequestId` makes create idempotent.
 - Prompt and attachments are bounded.
 - Provider/mode/sandbox/approval combinations are validated server-side.
+- Approval and structured-input capabilities stay disabled until the installed
+  provider's interactive protocol contract is verified; exec JSONL support by
+  itself is not evidence that interactive decisions are supported.
 - Create should return accepted thread snapshot quickly; streaming happens separately.
 - New shell requests require `projectId`; compatibility parsing may accept legacy unassigned records on reads only.
 - If `taskId` is present, the gateway resolves the task and enforces project ownership/match before inserting the thread and first event.

--- a/specs/105-coding-agent-shells/tasks.md
+++ b/specs/105-coding-agent-shells/tasks.md
@@ -1415,6 +1415,7 @@ composer turns, and lifecycle actions.
 - [ ] B28-010 Add safe setup/switch/recovery tests and publish provider-control capabilities to the shell handoff.
 - [ ] B28-011 Write a table-driven provider conformance harness covering install/auth health, create, normalized stream, abort, restart, safe errors, capability truthfulness, timeout, and cleanup for every first-release adapter.
 - [x] B28-011a Add a strict, forward-compatible Codex exec JSONL normalizer, durable idempotent provider-event ingestion, exact verified-version/schema metadata, and a scheduled published-version drift check.
+- [x] B28-011b Pin the Codex experimental app-server schema and required approval/input request methods to the same installed-version range as exec JSONL, and make the scheduled latest-version check fail on either protocol drift.
 - [ ] B28-012 Implement and real-process test first-class adapters for Claude Code, Codex, Pi, and OpenCode plus a validated custom ACP-compatible adapter family; keep credentials and native resume identities server-side.
 - [x] B28-012a Wire the Codex workspace runner to the normalized provider-event ingestion contract and prove assistant/tool/file events through deterministic replay, event-sink publication, and a real child-process test. Disposable-runtime smoke remains in B34-001.
 - [ ] B28-013 Implement capability-gated compatibility adapters for Kiro, GitHub Copilot CLI, Qwen Code, Kimi CLI, Kilo Code, and Auggie without generic shell-command escape hatches.

--- a/tests/gateway/coding-agents-codex-app-server-contract.test.ts
+++ b/tests/gateway/coding-agents-codex-app-server-contract.test.ts
@@ -9,7 +9,7 @@ describe("Codex app-server contract", () => {
     expect(CODEX_APP_SERVER_CONTRACT).toMatchObject({
       packageName: "@openai/codex",
       minimumVersion: "0.144.0",
-      latestVerifiedVersion: "0.144.3",
+      latestVerifiedVersion: "0.144.6",
       experimental: true,
       requiredServerMethods: [
         "item/commandExecution/requestApproval",
@@ -30,8 +30,16 @@ describe("Codex app-server contract", () => {
       version: "0.144.3",
     });
     expect(codexAppServerContractStatus("codex-cli 0.144.4")).toEqual({
-      status: "unverified_newer",
+      status: "verified",
       version: "0.144.4",
+    });
+    expect(codexAppServerContractStatus("codex-cli 0.144.6")).toEqual({
+      status: "verified",
+      version: "0.144.6",
+    });
+    expect(codexAppServerContractStatus("codex-cli 0.144.7")).toEqual({
+      status: "unverified_newer",
+      version: "0.144.7",
     });
     expect(codexAppServerContractStatus("codex-cli 0.143.9")).toEqual({
       status: "unverified_older",

--- a/tests/gateway/coding-agents-codex-app-server-contract.test.ts
+++ b/tests/gateway/coding-agents-codex-app-server-contract.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import {
+  CODEX_APP_SERVER_CONTRACT,
+  codexAppServerContractStatus,
+} from "../../packages/gateway/src/coding-agents/codex-app-server-version.js";
+
+describe("Codex app-server contract", () => {
+  it("pins the bounded server requests used by Matrix", () => {
+    expect(CODEX_APP_SERVER_CONTRACT).toMatchObject({
+      packageName: "@openai/codex",
+      minimumVersion: "0.144.0",
+      latestVerifiedVersion: "0.144.3",
+      experimental: true,
+      requiredServerMethods: [
+        "item/commandExecution/requestApproval",
+        "item/fileChange/requestApproval",
+        "item/tool/requestUserInput",
+        "item/permissions/requestApproval",
+      ],
+    });
+  });
+
+  it("accepts only installed versions covered by the app-server schema", () => {
+    expect(codexAppServerContractStatus("codex-cli 0.144.1")).toEqual({
+      status: "verified",
+      version: "0.144.1",
+    });
+    expect(codexAppServerContractStatus("0.144.3")).toEqual({
+      status: "verified",
+      version: "0.144.3",
+    });
+    expect(codexAppServerContractStatus("codex-cli 0.144.4")).toEqual({
+      status: "unverified_newer",
+      version: "0.144.4",
+    });
+    expect(codexAppServerContractStatus("codex-cli 0.143.9")).toEqual({
+      status: "unverified_older",
+      version: "0.143.9",
+    });
+    expect(codexAppServerContractStatus("unknown")).toEqual({ status: "invalid" });
+  });
+});

--- a/tests/scripts/check-codex-provider-contracts.test.ts
+++ b/tests/scripts/check-codex-provider-contracts.test.ts
@@ -1,0 +1,20 @@
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import contract from "../../packages/gateway/src/coding-agents/codex-exec-contract.json" with { type: "json" };
+
+const scriptPath = fileURLToPath(
+  new URL("../../scripts/check-codex-exec-contract.mjs", import.meta.url),
+);
+
+describe("Codex provider contract checker", () => {
+  it("fails closed when either provider schema is omitted", () => {
+    const result = spawnSync(process.execPath, [scriptPath, contract.latestVerifiedVersion], {
+      encoding: "utf8",
+    });
+
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain("Both Codex schema paths are required");
+    expect(result.stdout).not.toContain("matches the verified JSONL and app-server contracts");
+  });
+});


### PR DESCRIPTION
## Summary

- pin the experimental Codex app-server schema and required approval/input methods
- share installed-version range handling across the JSONL and app-server contracts
- verify the latest published package against both protocol digests in one scheduled workflow
- document fail-closed capability behavior and update spec 105 tasks/current state

## Tests

- `pnpm exec vitest run tests/gateway/coding-agents-codex-app-server-contract.test.ts tests/gateway/coding-agents-codex-events.test.ts tests/gateway/coding-agents-codex-runtime.test.ts` (18 passed)
- `pnpm --filter @matrix-os/gateway exec tsc --noEmit`
- `bun run typecheck`
- `bun run check:patterns` (0 violations; existing scan warnings only)
- `node scripts/check-codex-exec-contract.mjs 0.144.3 /tmp/codex-exec-events.rs /tmp/matrix-codex-app-server-schema-0.144.3/codex_app_server_protocol.schemas.json`
- `git diff --check`

## Invariants

### Source of truth

The gateway remains authoritative. This PR adds compatibility metadata only and does not move provider state or credentials into a shell.

### Capability safety

Executable discovery does not imply protocol support. Installed versions outside the verified range fail closed. Approval and structured-input capabilities remain disabled until the control runtime and end-to-end decision tests land.

### Version evolution

The scheduled workflow resolves one published Codex version and verifies both JSONL and app-server contracts against it. Either version drift or schema drift fails the job.

### Persistence and auth

No persistence, route, auth, IPC, or client-state behavior changes are introduced.

### Deployment

No release, preview, merge, or traffic promotion is included.
