### PR TITLE
feat(mobile): provider setup from the providers screen

### DIFF
--- a/apps/mobile/__tests__/ChatMessage.test.tsx
+++ b/apps/mobile/__tests__/ChatMessage.test.tsx
@@ -14,10 +14,11 @@ import { ChatMessage } from "../components/ChatMessage";
 import type { Message } from "../app/(tabs)/chat";
 import type { GatewayClient } from "../lib/gateway-client";
 
-function imageClient(overrides: Partial<Record<"homeFileUrl" | "getAuthorizationHeader", unknown>> = {}) {
+function imageClient(overrides: Partial<Record<"homeFileUrl" | "getAuthorizationHeader" | "onStateChange", unknown>> = {}) {
   return {
     homeFileUrl: jest.fn((rel: string) => `http://gw.test/files/${rel}`),
     getAuthorizationHeader: jest.fn().mockResolvedValue("Bearer test-token"),
+    onStateChange: jest.fn(() => () => {}),
     ...overrides,
   };
 }

--- a/apps/mobile/__tests__/ChatMessage.test.tsx
+++ b/apps/mobile/__tests__/ChatMessage.test.tsx
@@ -9,7 +9,7 @@ jest.mock("expo-image", () => {
 });
 
 import React from "react";
-import { render, screen } from "@testing-library/react-native";
+import { act, render, screen, waitFor } from "@testing-library/react-native";
 import { ChatMessage } from "../components/ChatMessage";
 import type { Message } from "../app/(tabs)/chat";
 import type { GatewayClient } from "../lib/gateway-client";
@@ -97,6 +97,46 @@ describe("ChatMessage", () => {
     expect(client.homeFileUrl).toHaveBeenCalledWith("system/shot.png");
     expect(image.props.source.uri).toBe("http://gw.test/files/system/shot.png");
     expect(image.props.source.headers).toEqual({ Authorization: "Bearer test-token" });
+  });
+
+  it("does not render inline images when the auth header fails to resolve", async () => {
+    const warn = jest.spyOn(console, "warn").mockImplementation(() => {});
+    const client = imageClient({
+      getAuthorizationHeader: jest.fn().mockRejectedValue(new Error("no session")),
+    });
+    const content = "Look: ![screenshot](/files/system/shot.png)";
+    render(
+      <ChatMessage
+        message={msg({ role: "assistant", content })}
+        client={client as unknown as GatewayClient}
+      />,
+    );
+
+    await waitFor(() => expect(client.getAuthorizationHeader).toHaveBeenCalled());
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(screen.queryAllByLabelText("screenshot")).toHaveLength(0);
+    warn.mockRestore();
+  });
+
+  it("does not render inline images when the auth header is empty", async () => {
+    const client = imageClient({
+      getAuthorizationHeader: jest.fn().mockResolvedValue(undefined),
+    });
+    const content = "Look: ![screenshot](/files/system/shot.png)";
+    render(
+      <ChatMessage
+        message={msg({ role: "assistant", content })}
+        client={client as unknown as GatewayClient}
+      />,
+    );
+
+    await waitFor(() => expect(client.getAuthorizationHeader).toHaveBeenCalled());
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(screen.queryAllByLabelText("screenshot")).toHaveLength(0);
   });
 
   it("does not render inline images without a gateway client", () => {

--- a/apps/mobile/components/ChatMessage.tsx
+++ b/apps/mobile/components/ChatMessage.tsx
@@ -280,6 +280,19 @@ function ImageAttachments({ images, client }: { images: { alt: string; path: str
     };
   }, [client, attempt]);
 
+  // Bounded retries can settle hidden while the gateway is unreachable; a
+  // reconnect restarts resolution so images recover without a remount.
+  useEffect(() => {
+    return client.onStateChange((state) => {
+      if (state !== "connected") return;
+      setHeader((current) => {
+        if (current) return current;
+        setAttempt(0);
+        return undefined;
+      });
+    });
+  }, [client]);
+
   // Render nothing until a non-empty Authorization header is available.
   if (!header) return null;
 

--- a/apps/mobile/components/ChatMessage.tsx
+++ b/apps/mobile/components/ChatMessage.tsx
@@ -235,28 +235,31 @@ function filesUrlToRelPath(path: string): string {
 
 // Owner `/files/*` images require the gateway Authorization header and the
 // base routing query (`/vm/<handle>?runtime=`), so build the URL through
-// `client.homeFileUrl` and attach the auth header once it resolves. Rendering
-// waits for the header so the <Image> mounts a single time with the credential,
-// mirroring the authenticated file preview path.
+// `client.homeFileUrl` and attach the auth header once it resolves. The header
+// is tracked as three states: `undefined` while pending, `null` when resolution
+// failed or produced an empty credential, and a non-empty string when ready.
+// The <Image> mounts only in the ready state, so it never renders without the
+// credential and 401s on an authed gateway, mirroring the file preview path.
 function ImageAttachments({ images, client }: { images: { alt: string; path: string }[]; client: GatewayClient }) {
-  const [auth, setAuth] = useState<{ ready: boolean; header?: string }>({ ready: false });
+  const [header, setHeader] = useState<string | null | undefined>(undefined);
 
   useEffect(() => {
     let cancelled = false;
     client.getAuthorizationHeader()
-      .then((header) => {
-        if (!cancelled) setAuth({ ready: true, header });
+      .then((resolved) => {
+        if (!cancelled) setHeader(resolved ? resolved : null);
       })
       .catch((err: unknown) => {
         console.warn("[mobile] chat image auth header unavailable", err instanceof Error ? err.name : "unknown");
-        if (!cancelled) setAuth({ ready: true });
+        if (!cancelled) setHeader(null);
       });
     return () => {
       cancelled = true;
     };
   }, [client]);
 
-  if (!auth.ready) return null;
+  // Render nothing until a non-empty Authorization header is available.
+  if (!header) return null;
 
   return (
     <View style={styles.imageContainer}>
@@ -266,7 +269,7 @@ function ImageAttachments({ images, client }: { images: { alt: string; path: str
           accessibilityLabel={img.alt || "Image"}
           source={{
             uri: client.homeFileUrl(filesUrlToRelPath(img.path)),
-            headers: auth.header ? { Authorization: auth.header } : undefined,
+            headers: { Authorization: header },
           }}
           style={styles.inlineImage}
           contentFit="contain"

--- a/apps/mobile/components/ChatMessage.tsx
+++ b/apps/mobile/components/ChatMessage.tsx
@@ -240,23 +240,45 @@ function filesUrlToRelPath(path: string): string {
 // failed or produced an empty credential, and a non-empty string when ready.
 // The <Image> mounts only in the ready state, so it never renders without the
 // credential and 401s on an authed gateway, mirroring the file preview path.
+const IMAGE_AUTH_RETRY_DELAY_MS = 1_500;
+const IMAGE_AUTH_MAX_ATTEMPTS = 3;
+
 function ImageAttachments({ images, client }: { images: { alt: string; path: string }[]; client: GatewayClient }) {
   const [header, setHeader] = useState<string | null | undefined>(undefined);
+  const [attempt, setAttempt] = useState(0);
 
   useEffect(() => {
     let cancelled = false;
+    let retryTimer: ReturnType<typeof setTimeout> | undefined;
+    // A transient token failure must not permanently hide the images for this
+    // message: retry a bounded number of times before settling on hidden.
+    const scheduleRetry = () => {
+      if (cancelled || attempt >= IMAGE_AUTH_MAX_ATTEMPTS - 1) {
+        if (!cancelled) setHeader(null);
+        return;
+      }
+      retryTimer = setTimeout(() => {
+        if (!cancelled) setAttempt((current) => current + 1);
+      }, IMAGE_AUTH_RETRY_DELAY_MS);
+    };
     client.getAuthorizationHeader()
       .then((resolved) => {
-        if (!cancelled) setHeader(resolved ? resolved : null);
+        if (cancelled) return;
+        if (resolved) {
+          setHeader(resolved);
+          return;
+        }
+        scheduleRetry();
       })
       .catch((err: unknown) => {
         console.warn("[mobile] chat image auth header unavailable", err instanceof Error ? err.name : "unknown");
-        if (!cancelled) setHeader(null);
+        scheduleRetry();
       });
     return () => {
       cancelled = true;
+      if (retryTimer) clearTimeout(retryTimer);
     };
-  }, [client]);
+  }, [client, attempt]);
 
   // Render nothing until a non-empty Authorization header is available.
   if (!header) return null;

--- a/apps/mobile/components/ChatMessage.tsx
+++ b/apps/mobile/components/ChatMessage.tsx
@@ -241,7 +241,8 @@ function filesUrlToRelPath(path: string): string {
 // The <Image> mounts only in the ready state, so it never renders without the
 // credential and 401s on an authed gateway, mirroring the file preview path.
 const IMAGE_AUTH_RETRY_DELAY_MS = 1_500;
-const IMAGE_AUTH_MAX_ATTEMPTS = 3;
+const IMAGE_AUTH_SLOW_RETRY_DELAY_MS = 30_000;
+const IMAGE_AUTH_FAST_ATTEMPTS = 2;
 
 function ImageAttachments({ images, client }: { images: { alt: string; path: string }[]; client: GatewayClient }) {
   const [header, setHeader] = useState<string | null | undefined>(undefined);
@@ -250,16 +251,18 @@ function ImageAttachments({ images, client }: { images: { alt: string; path: str
   useEffect(() => {
     let cancelled = false;
     let retryTimer: ReturnType<typeof setTimeout> | undefined;
-    // A transient token failure must not permanently hide the images for this
-    // message: retry a bounded number of times before settling on hidden.
+    // A failed token resolution must not permanently hide the images: retry
+    // quickly at first, then keep trying at a slow cadence while mounted, so
+    // an already-connected client that hydrates its session later (no state
+    // transition fires) still recovers.
     const scheduleRetry = () => {
-      if (cancelled || attempt >= IMAGE_AUTH_MAX_ATTEMPTS - 1) {
-        if (!cancelled) setHeader(null);
-        return;
-      }
+      if (cancelled) return;
+      const delay = attempt < IMAGE_AUTH_FAST_ATTEMPTS
+        ? IMAGE_AUTH_RETRY_DELAY_MS
+        : IMAGE_AUTH_SLOW_RETRY_DELAY_MS;
       retryTimer = setTimeout(() => {
         if (!cancelled) setAttempt((current) => current + 1);
-      }, IMAGE_AUTH_RETRY_DELAY_MS);
+      }, delay);
     };
     client.getAuthorizationHeader()
       .then((resolved) => {


### PR DESCRIPTION
Stacked on #948 (`105-mobile-files-app`).

## What

- `feat(mobile): run provider setup in a terminal session` — providers needing install/auth now render their `setupActions` as buttons on the Providers screen. `foreground_terminal` actions POST the registry-supplied command to the canonical `POST /api/terminal/sessions` (`{name, cwd: "projects", cmd}` — the same mechanism desktop uses, `desktop/src/renderer/src/features/coding-agents/provider-setup-terminal.ts`), then hand off to the Terminal tab by session name via the existing `terminalHandoffSessionId` state. `open_settings` routes to Settings. Per-action running/error states with generic copy.
- `fix(mobile): authenticate chat image attachments` — ChatMessage `/files/*` images now load through `client.homeFileUrl()` (base routing query for hosted `/vm/<handle>?runtime=` computers) with a resolved Authorization header, rendering after the header resolves; previously they 401'd on authed gateways and mis-routed on routed computers. Switched to expo-image.

## Invariants

- **Command-hidden setup (CLAUDE.md rule)**: the setup command is read from the gateway registry payload and sent only back to the gateway session-create route; it is never rendered into UI, logged, or persisted in shell state — only the returned session *name* is stored for handoff.
- **Canonical terminal flow**: no new backend contract; session create + name-based attach are the same primitives the Terminal tab and desktop already use.
- **Auth source of truth**: image loads use the live client credential (Clerk token provider / session Basic), resolved per render, never cached to disk.
- **Deferred scope**: setup progress/completion is not tracked in-app — the user watches the terminal; provider status refreshes with the runtime summary on focus.

## Tests

42 suites / 438 tests passing; `tsc --noEmit`; `expo lint`; react-doctor: zero findings in changed files. New tests: handoff-by-name + command-never-rendered/persisted, open_settings routing, setup error path, authenticated image URL + header, no-client no-render.

## Validation

Needs on-device smoke on iPhone against pr-919 (Providers → install codex → terminal opens running setup; chat image attachment renders). Screenshots to be attached by owner.