### PR TITLE
feat(coding-agents): add codex control runtime

### DIFF
--- a/packages/gateway/package.json
+++ b/packages/gateway/package.json
@@ -12,7 +12,7 @@
   },
   "scripts": {
     "dev": "tsx watch src/main.ts",
-    "build": "pnpm --dir ../.. --filter '@matrix-os/observability' build && tsc && cp src/coding-agents/codex-runner.mjs dist/coding-agents/codex-runner.mjs"
+    "build": "pnpm --dir ../.. --filter '@matrix-os/observability' build && tsc && cp src/coding-agents/codex-runner.mjs dist/coding-agents/codex-runner.mjs && cp src/coding-agents/codex-app-server-runner.mjs dist/coding-agents/codex-app-server-runner.mjs"
   },
   "devDependencies": {
     "@electric-sql/pglite": "^0.4.0",

--- a/packages/gateway/src/agent-launcher.ts
+++ b/packages/gateway/src/agent-launcher.ts
@@ -317,7 +317,7 @@ export function buildAgentLaunch(input: AgentLaunchInput): AgentLaunchSpec {
         ).toString("base64");
         return {
           command: process.execPath,
-          args: [CODEX_APP_SERVER_RUNNER_PATH, providerEventPath, command, "app-server", appServerConfig],
+          args: [CODEX_APP_SERVER_RUNNER_PATH, providerEventPath, command, appServerConfig],
           cwd: input.cwd,
           env,
         };

--- a/packages/gateway/src/agent-launcher.ts
+++ b/packages/gateway/src/agent-launcher.ts
@@ -59,9 +59,15 @@ const ProviderEventPathSchema = z.string()
   .max(4096)
   .refine(isAbsolute)
   .regex(/^[^\u0000\r\n]+\.jsonl$/);
-const CODEX_RUNNER_PATH = fileURLToPath(
-  new URL("./coding-agents/codex-runner.mjs", import.meta.url),
+const CODEX_APP_SERVER_RUNNER_PATH = fileURLToPath(
+  new URL("./coding-agents/codex-app-server-runner.mjs", import.meta.url),
 );
+const CodexAppServerConfigSchema = z.object({
+  prompt: z.string().trim().min(1).max(64 * 1024),
+  approvalPolicy: z.enum(["untrusted", "on-request", "never"]),
+  sandbox: z.enum(["read-only", "workspace-write", "danger-full-access"]),
+  writableRoots: z.array(z.string().min(1).max(4096).refine(isAbsolute)).max(20),
+}).strict();
 
 const AGENTS: Record<SupportedAgent, { command: string; displayName: string }> = {
   claude: { command: "claude", displayName: "Claude" },
@@ -269,6 +275,22 @@ function codexPrompt(prompt: string | undefined, mode?: AgentLaunchInput["mode"]
   return prompt ? `${planPrefix}\n\n${prompt}` : planPrefix;
 }
 
+function codexAppServerConfig(input: AgentLaunchInput): z.infer<typeof CodexAppServerConfigSchema> {
+  codexSandboxArgs(input.sandbox);
+  const sandbox = input.sandbox;
+  const mode = sandbox?.enabled === false
+    ? "danger-full-access"
+    : sandbox?.mode ?? "workspace-write";
+  return CodexAppServerConfigSchema.parse({
+    prompt: codexPrompt(input.prompt, input.mode),
+    approvalPolicy: input.approvalPolicy === "on-failure"
+      ? "on-request"
+      : input.approvalPolicy ?? "never",
+    sandbox: mode,
+    writableRoots: mode === "workspace-write" ? sandbox?.writableRoots ?? [] : [],
+  });
+}
+
 export function buildAgentLaunch(input: AgentLaunchInput): AgentLaunchSpec {
   const parsed = SupportedAgentSchema.parse(input.agent);
   const command = AGENTS[parsed].command;
@@ -289,11 +311,13 @@ export function buildAgentLaunch(input: AgentLaunchInput): AgentLaunchSpec {
         ];
         if (!input.providerEventPath) return { command, args, cwd: input.cwd, env };
         const providerEventPath = ProviderEventPathSchema.parse(input.providerEventPath);
-        const execIndex = args.indexOf("exec");
-        const structuredArgs = [...args.slice(0, execIndex + 1), "--json", ...args.slice(execIndex + 1)];
+        const appServerConfig = Buffer.from(
+          JSON.stringify(codexAppServerConfig(input)),
+          "utf8",
+        ).toString("base64");
         return {
           command: process.execPath,
-          args: [CODEX_RUNNER_PATH, providerEventPath, command, ...structuredArgs],
+          args: [CODEX_APP_SERVER_RUNNER_PATH, providerEventPath, command, "app-server", appServerConfig],
           cwd: input.cwd,
           env,
         };

--- a/packages/gateway/src/coding-agents/codex-app-server-runner.mjs
+++ b/packages/gateway/src/coding-agents/codex-app-server-runner.mjs
@@ -52,6 +52,11 @@ const NativeApprovalDecisionSchema = z.union([
     }).strict(),
   }).strict(),
 ]);
+const NativeApprovalDecisionListSchema = z.array(z.unknown()).max(16).transform((decisions) =>
+  decisions.flatMap((decision) => {
+    const parsed = NativeApprovalDecisionSchema.safeParse(decision);
+    return parsed.success ? [parsed.data] : [];
+  }));
 const RunnerConfigSchema = z.object({
   prompt: z.string().trim().min(1).max(64 * 1024),
   approvalPolicy: z.enum(["untrusted", "on-request", "never"]),
@@ -65,7 +70,7 @@ const ApprovalRequestSchema = z.object({
     threadId: NativeReferenceSchema,
     turnId: NativeReferenceSchema,
     itemId: NativeReferenceSchema,
-    availableDecisions: z.array(NativeApprovalDecisionSchema).max(16).nullable().optional(),
+    availableDecisions: NativeApprovalDecisionListSchema.nullable().optional(),
   }).passthrough(),
 }).passthrough();
 const DisplayTextSchema = z.string()
@@ -343,7 +348,10 @@ async function handleInput(raw) {
   const parsed = InputRequestSchema.safeParse(raw);
   if (!parsed.success) return false;
   const nativeQuestionIds = parsed.data.params.questions.map((question) => question.id);
-  if (new Set(nativeQuestionIds).size !== nativeQuestionIds.length) return true;
+  if (new Set(nativeQuestionIds).size !== nativeQuestionIds.length) {
+    sendProvider({ id: parsed.data.id, result: { answers: {} } });
+    return true;
+  }
   if (pendingInputs.size >= MAX_PENDING_REQUESTS) {
     sendProvider({ id: parsed.data.id, result: { answers: {} } });
     return true;

--- a/packages/gateway/src/coding-agents/codex-app-server-runner.mjs
+++ b/packages/gateway/src/coding-agents/codex-app-server-runner.mjs
@@ -1,0 +1,584 @@
+import { spawn } from "node:child_process";
+import { createHash } from "node:crypto";
+import { constants } from "node:fs";
+import { chmod, lstat, mkdir, open, rm } from "node:fs/promises";
+import { createServer } from "node:net";
+import { dirname, isAbsolute } from "node:path";
+import { StringDecoder } from "node:string_decoder";
+import { z } from "zod/v4";
+
+process.on("uncaughtException", () => {
+  process.stderr.write("Codex app-server runner stopped unexpectedly.\n");
+  process.exit(1);
+});
+process.on("unhandledRejection", () => {
+  process.stderr.write("Codex app-server runner stopped unexpectedly.\n");
+  process.exit(1);
+});
+
+const MAX_LINE_BYTES = 64 * 1024;
+const MAX_PROVIDER_LINE_BYTES = 1024 * 1024;
+const MAX_TRANSCRIPT_BYTES = 16 * 1024 * 1024;
+const MAX_PENDING_REQUESTS = 20;
+const MAX_COMPLETED_REQUESTS = 100;
+const REQUEST_TIMEOUT_MS = 5 * 60 * 1000;
+const RPC_TIMEOUT_MS = 30 * 1000;
+const SHUTDOWN_REPLAY_GRACE_MS = 250;
+const NativeRequestIdSchema = z.union([z.string().min(1).max(128), z.number().int().safe()]);
+const NativeReferenceSchema = z.string().min(1).max(512);
+const ApprovalMethodSchema = z.enum([
+  "item/commandExecution/requestApproval",
+  "item/fileChange/requestApproval",
+  "item/permissions/requestApproval",
+]);
+const ApprovalDecisionSchema = z.enum(["approve", "approve_for_session", "decline", "cancel"]);
+const NativeApprovalDecisionSchema = z.union([
+  z.enum(["accept", "acceptForSession", "decline", "cancel"]),
+  z.object({
+    acceptWithExecpolicyAmendment: z.object({
+      execpolicy_amendment: z.array(z.string().max(4000)).max(128),
+    }).strict(),
+  }).strict(),
+  z.object({
+    applyNetworkPolicyAmendment: z.object({
+      network_policy_amendment: z.object({
+        action: z.enum(["allow", "deny"]),
+        host: z.string().min(1).max(255),
+      }).strict(),
+    }).strict(),
+  }).strict(),
+]);
+const RunnerConfigSchema = z.object({
+  prompt: z.string().trim().min(1).max(64 * 1024),
+  approvalPolicy: z.enum(["untrusted", "on-request", "never"]),
+  sandbox: z.enum(["read-only", "workspace-write", "danger-full-access"]),
+  writableRoots: z.array(z.string().min(1).max(4096).refine(isAbsolute)).max(20),
+}).strict();
+const ApprovalRequestSchema = z.object({
+  id: NativeRequestIdSchema,
+  method: ApprovalMethodSchema,
+  params: z.object({
+    threadId: NativeReferenceSchema,
+    turnId: NativeReferenceSchema,
+    itemId: NativeReferenceSchema,
+    availableDecisions: z.array(NativeApprovalDecisionSchema).max(16).nullable().optional(),
+  }).passthrough(),
+}).passthrough();
+const DisplayTextSchema = z.string()
+  .refine((value) => !/[\u0000-\u0008\u000B\u000C\u000E-\u001F\u007F]/.test(value));
+const NativeQuestionSchema = z.object({
+  id: z.string().min(1).max(128),
+  header: DisplayTextSchema.min(1).max(160),
+  question: DisplayTextSchema.min(1).max(2400),
+  options: z.array(z.object({
+    label: DisplayTextSchema.min(1).max(160),
+    description: DisplayTextSchema.min(1).max(1200),
+  }).passthrough()).min(1).max(10).nullable().optional(),
+  isOther: z.boolean().default(false),
+  isSecret: z.boolean().default(false),
+}).passthrough();
+const InputRequestSchema = z.object({
+  id: NativeRequestIdSchema,
+  method: z.literal("item/tool/requestUserInput"),
+  params: z.object({
+    threadId: NativeReferenceSchema,
+    turnId: NativeReferenceSchema,
+    itemId: NativeReferenceSchema,
+    autoResolutionMs: z.number().int().min(0).max(240_000).nullable().optional(),
+    questions: z.array(NativeQuestionSchema).min(1).max(8),
+  }).passthrough(),
+}).passthrough();
+const AgentDeltaSchema = z.object({
+  method: z.literal("item/agentMessage/delta"),
+  params: z.object({ delta: z.string().max(MAX_LINE_BYTES) }).passthrough(),
+}).passthrough();
+const TurnCompletedSchema = z.object({
+  method: z.literal("turn/completed"),
+  params: z.object({
+    turn: z.object({ status: z.string().max(80).optional() }).passthrough(),
+  }).passthrough(),
+}).passthrough();
+const RpcResponseSchema = z.object({
+  id: NativeRequestIdSchema,
+  result: z.unknown().optional(),
+  error: z.unknown().optional(),
+}).passthrough();
+const ApprovalControlSchema = z.object({
+  type: z.literal("approval"),
+  approvalId: z.string().regex(/^appr_codex_[a-f0-9]{32}$/),
+  decision: ApprovalDecisionSchema,
+  clientRequestId: z.string().min(1).max(128).regex(/^[A-Za-z0-9][A-Za-z0-9_.:-]{0,127}$/),
+}).strict();
+const MatrixQuestionIdSchema = z.string().regex(/^question_codex_[a-f0-9]{24}$/);
+const InputControlSchema = z.object({
+  type: z.literal("input"),
+  requestId: z.string().regex(/^req_codex_[a-f0-9]{32}$/),
+  structuredAnswers: z.record(
+    MatrixQuestionIdSchema,
+    z.array(z.string().min(1).max(400).refine((value) => Buffer.byteLength(value, "utf8") <= 700))
+      .min(1).max(4),
+  ).superRefine((answers, context) => {
+    const count = Object.keys(answers).length;
+    if (count < 1 || count > 8) context.addIssue({ code: "custom", message: "Invalid answer count" });
+  }),
+  clientRequestId: ApprovalControlSchema.shape.clientRequestId,
+}).strict();
+const ControlSchema = z.discriminatedUnion("type", [ApprovalControlSchema, InputControlSchema]);
+
+function fail(message) {
+  process.stderr.write(`${message}\n`);
+  process.exit(1);
+}
+
+const eventPath = process.argv[2];
+const command = process.argv[3];
+const encodedConfig = process.argv.at(-1);
+const commandArgs = process.argv.slice(4, -1);
+if (!eventPath || !isAbsolute(eventPath) || !/^[^\u0000\r\n]+\.jsonl$/.test(eventPath) || !command) {
+  fail("Codex app-server runner configuration is invalid.");
+}
+let config;
+try {
+  const bytes = Buffer.from(encodedConfig ?? "", "base64");
+  if (bytes.toString("base64") !== encodedConfig) throw new Error("invalid_base64");
+  config = RunnerConfigSchema.parse(JSON.parse(new TextDecoder("utf-8", { fatal: true }).decode(bytes)));
+} catch (_error) {
+  fail("Codex app-server runner configuration is invalid.");
+}
+
+const controlPath = eventPath.replace(/\.jsonl$/, ".sock");
+await mkdir(dirname(eventPath), { recursive: true });
+for (const path of [eventPath, controlPath]) {
+  try {
+    const existing = await lstat(path);
+    if (path === controlPath && existing.isSocket()) {
+      await rm(path, { force: true });
+      continue;
+    }
+    if (existing.isSymbolicLink() || (path === eventPath && !existing.isFile())) {
+      throw new Error("unsafe_provider_path");
+    }
+  } catch (error) {
+    if (!(error instanceof Error && "code" in error && error.code === "ENOENT")) throw error;
+  }
+}
+
+const eventFile = await open(
+  eventPath,
+  constants.O_CREAT | constants.O_APPEND | constants.O_WRONLY | (constants.O_NOFOLLOW ?? 0),
+  0o600,
+);
+let transcriptBytes = (await eventFile.stat()).size;
+let stopping = false;
+let activeTurn = false;
+let completedTurn = false;
+let nextRpcId = 1;
+const pendingRpc = new Map();
+const pendingApprovals = new Map();
+const pendingInputs = new Map();
+const completedControls = new Map();
+
+function digest(parts) {
+  return createHash("sha256").update(JSON.stringify(parts)).digest("hex").slice(0, 32);
+}
+
+function approvalIdentity(request) {
+  const parts = [
+    request.method,
+    request.id,
+    request.params.threadId,
+    request.params.turnId,
+    request.params.itemId,
+  ];
+  return {
+    approvalId: `appr_codex_${digest([...parts, "approval"])}`,
+    correlationId: `corr_codex_${digest(parts)}`,
+  };
+}
+
+function inputIdentity(request) {
+  const parts = [
+    request.method,
+    request.id,
+    request.params.threadId,
+    request.params.turnId,
+    request.params.itemId,
+  ];
+  return {
+    requestId: `req_codex_${digest([...parts, "input"])}`,
+    correlationId: `corr_codex_${digest(parts)}`,
+  };
+}
+
+function boundedExternalText(value, maxChars, maxBytes) {
+  let result = "";
+  for (const character of value) {
+    const candidate = `${result}${character}`;
+    if (candidate.length > maxChars || Buffer.byteLength(candidate, "utf8") > maxBytes) break;
+    result = candidate;
+  }
+  return result;
+}
+
+async function persist(value) {
+  const line = JSON.stringify(value);
+  const bytes = Buffer.byteLength(`${line}\n`, "utf8");
+  if (bytes > MAX_LINE_BYTES || transcriptBytes + bytes > MAX_TRANSCRIPT_BYTES) {
+    throw new Error("provider_transcript_limit");
+  }
+  await eventFile.write(`${line}\n`);
+  transcriptBytes += bytes;
+}
+
+function sendProvider(value) {
+  if (!child.stdin.writable) throw new Error("provider_transport_closed");
+  child.stdin.write(`${JSON.stringify(value)}\n`);
+}
+
+function request(method, params) {
+  if (pendingRpc.size >= MAX_PENDING_REQUESTS) {
+    return Promise.reject(new Error("provider_request_limit"));
+  }
+  const id = nextRpcId++;
+  return new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      pendingRpc.delete(id);
+      reject(new Error("provider_request_timeout"));
+    }, RPC_TIMEOUT_MS);
+    timeout.unref();
+    pendingRpc.set(id, { resolve, reject, timeout });
+    sendProvider({ id, method, params });
+  });
+}
+
+function approvalCopy(method) {
+  if (method === "item/commandExecution/requestApproval") {
+    return { title: "Run command", safeDescription: "The coding agent wants to run a command.", actionKind: "command", risk: "medium" };
+  }
+  if (method === "item/fileChange/requestApproval") {
+    return { title: "Change files", safeDescription: "The coding agent wants to change project files.", actionKind: "file_change", risk: "medium" };
+  }
+  return { title: "Change permissions", safeDescription: "The coding agent wants additional permissions.", actionKind: "provider", risk: "high" };
+}
+
+function decisionMapping(request) {
+  const source = request.params.availableDecisions ?? ["accept", "acceptForSession", "decline", "cancel"];
+  const nativeDecisionByMatrixDecision = {};
+  const mapped = source.map((decision) => {
+    const matrixDecision = decision === "accept"
+      ? "approve"
+      : decision === "acceptForSession" || typeof decision === "object"
+        ? "approve_for_session"
+        : decision;
+    nativeDecisionByMatrixDecision[matrixDecision] ??= decision;
+    return matrixDecision;
+  });
+  return {
+    allowedDecisions: mapped.filter((decision, index) => mapped.indexOf(decision) === index),
+    nativeDecisionByMatrixDecision,
+  };
+}
+
+async function handleApproval(raw) {
+  const parsed = ApprovalRequestSchema.safeParse(raw);
+  if (!parsed.success) return false;
+  if (parsed.data.method === "item/permissions/requestApproval") {
+    sendProvider({
+      id: parsed.data.id,
+      error: { code: -32601, message: "Permission request is unavailable." },
+    });
+    return true;
+  }
+  const identity = approvalIdentity(parsed.data);
+  const decisions = decisionMapping(parsed.data);
+  if (pendingApprovals.size >= MAX_PENDING_REQUESTS || pendingApprovals.has(identity.approvalId)) {
+    sendProvider({ id: parsed.data.id, result: { decision: "cancel" } });
+    return true;
+  }
+  await persist({
+    type: "matrix.codex.approval.requested",
+    approvalId: identity.approvalId,
+    correlationId: identity.correlationId,
+    ...approvalCopy(parsed.data.method),
+    allowedDecisions: decisions.allowedDecisions,
+  });
+  pendingApprovals.set(identity.approvalId, {
+    nativeRequestId: parsed.data.id,
+    allowedDecisions: decisions.allowedDecisions,
+    nativeDecisionByMatrixDecision: decisions.nativeDecisionByMatrixDecision,
+    expiresAt: Date.now() + REQUEST_TIMEOUT_MS,
+  });
+  return true;
+}
+
+async function handleInput(raw) {
+  const parsed = InputRequestSchema.safeParse(raw);
+  if (!parsed.success) return false;
+  const nativeQuestionIds = parsed.data.params.questions.map((question) => question.id);
+  if (new Set(nativeQuestionIds).size !== nativeQuestionIds.length) return true;
+  if (pendingInputs.size >= MAX_PENDING_REQUESTS) {
+    sendProvider({ id: parsed.data.id, result: { answers: {} } });
+    return true;
+  }
+  const identity = inputIdentity(parsed.data);
+  if (pendingInputs.has(identity.requestId)) {
+    sendProvider({ id: parsed.data.id, result: { answers: {} } });
+    return true;
+  }
+  const questions = parsed.data.params.questions.map((question, index) => ({
+    questionId: `question_codex_${digest([identity.requestId, question.id, index]).slice(0, 24)}`,
+    header: question.header,
+    question: boundedExternalText(question.question, 600, 2400),
+    ...(question.options ? { options: question.options.map((option) => ({
+      label: boundedExternalText(option.label, 160, 640),
+      description: boundedExternalText(option.description, 300, 1200),
+    })) } : {}),
+    allowOther: question.isOther,
+    secret: question.isSecret,
+  }));
+  await persist({
+    type: "matrix.codex.user_input.requested",
+    requestId: identity.requestId,
+    correlationId: identity.correlationId,
+    title: questions[0]?.header ?? "Question",
+    safeDescription: "The coding agent needs more information.",
+    questions,
+    ...(typeof parsed.data.params.autoResolutionMs === "number" && parsed.data.params.autoResolutionMs >= 60_000
+      ? { autoResolutionMs: parsed.data.params.autoResolutionMs }
+      : {}),
+  });
+  pendingInputs.set(identity.requestId, {
+    nativeRequestId: parsed.data.id,
+    questions: questions.map((question, index) => ({
+      questionId: question.questionId,
+      nativeQuestionId: parsed.data.params.questions[index].id,
+    })),
+    expiresAt: Date.now() + REQUEST_TIMEOUT_MS,
+  });
+  return true;
+}
+
+async function handleProviderMessage(raw) {
+  const response = RpcResponseSchema.safeParse(raw);
+  if (response.success && pendingRpc.has(response.data.id)) {
+    const pending = pendingRpc.get(response.data.id);
+    pendingRpc.delete(response.data.id);
+    clearTimeout(pending.timeout);
+    if (response.data.error !== undefined) pending.reject(new Error("provider_request_failed"));
+    else pending.resolve(response.data.result);
+    return;
+  }
+  if (await handleApproval(raw)) return;
+  if (await handleInput(raw)) return;
+  const delta = AgentDeltaSchema.safeParse(raw);
+  if (delta.success) {
+    await persist({ type: "matrix.codex.assistant.delta", delta: delta.data.params.delta });
+    return;
+  }
+  const completed = TurnCompletedSchema.safeParse(raw);
+  if (completed.success) {
+    activeTurn = false;
+    completedTurn = true;
+    await persist({ type: "turn.completed" });
+  }
+}
+
+async function consumeProviderOutput(stream) {
+  const decoder = new StringDecoder("utf8");
+  let pending = "";
+  let discarding = false;
+  for await (const chunk of stream) {
+    let text = decoder.write(chunk);
+    if (discarding) {
+      const newline = text.indexOf("\n");
+      if (newline < 0) continue;
+      text = text.slice(newline + 1);
+      discarding = false;
+    }
+    pending += text;
+    let newline = pending.indexOf("\n");
+    while (newline >= 0) {
+      const line = pending.slice(0, newline).replace(/\r$/, "");
+      pending = pending.slice(newline + 1);
+      if (line && Buffer.byteLength(line, "utf8") <= MAX_PROVIDER_LINE_BYTES) {
+        try {
+          await handleProviderMessage(JSON.parse(line));
+        } catch (error) {
+          if (!(error instanceof SyntaxError)) throw error;
+        }
+      }
+      newline = pending.indexOf("\n");
+    }
+    if (Buffer.byteLength(pending, "utf8") > MAX_PROVIDER_LINE_BYTES) {
+      pending = "";
+      discarding = true;
+    }
+  }
+}
+
+async function discardProviderErrors(stream) {
+  for await (const _chunk of stream) {
+    // Provider stderr can include credentials, paths, or raw failures.
+  }
+}
+
+function controlResponse(socket, value) {
+  socket.end(`${JSON.stringify(value)}\n`);
+}
+
+async function applyControl(control) {
+  const replay = completedControls.get(control.clientRequestId);
+  if (replay) {
+    const same = replay.fingerprint === digest([control]);
+    return same ? { ok: true, replayed: true } : { ok: false };
+  }
+  if (control.type === "approval") {
+    const pending = pendingApprovals.get(control.approvalId);
+    if (!pending || !pending.allowedDecisions.includes(control.decision)) return { ok: false };
+    sendProvider({
+      id: pending.nativeRequestId,
+      result: { decision: pending.nativeDecisionByMatrixDecision[control.decision] },
+    });
+    pendingApprovals.delete(control.approvalId);
+  } else {
+    const pending = pendingInputs.get(control.requestId);
+    if (!pending) return { ok: false };
+    const expected = new Set(pending.questions.map((question) => question.questionId));
+    const provided = Object.keys(control.structuredAnswers);
+    if (provided.length !== expected.size || provided.some((questionId) => !expected.has(questionId))) {
+      return { ok: false };
+    }
+    const answers = Object.fromEntries(pending.questions.map((question) => [
+      question.nativeQuestionId,
+      { answers: control.structuredAnswers[question.questionId] },
+    ]));
+    sendProvider({ id: pending.nativeRequestId, result: { answers } });
+    pendingInputs.delete(control.requestId);
+  }
+  if (completedControls.size >= MAX_COMPLETED_REQUESTS) {
+    const oldest = completedControls.keys().next().value;
+    if (oldest) completedControls.delete(oldest);
+  }
+  completedControls.set(control.clientRequestId, {
+    fingerprint: digest([control]),
+    expiresAt: Date.now() + REQUEST_TIMEOUT_MS,
+  });
+  return { ok: true };
+}
+
+const controlServer = createServer({ allowHalfOpen: true }, (socket) => {
+  let input = "";
+  socket.setEncoding("utf8");
+  socket.on("error", () => socket.destroy());
+  socket.on("data", (chunk) => {
+    input += chunk;
+    if (Buffer.byteLength(input, "utf8") > MAX_LINE_BYTES) socket.destroy();
+  });
+  socket.on("end", async () => {
+    const line = input.trim();
+    const parsed = ControlSchema.safeParse((() => {
+      try { return JSON.parse(line); } catch (_error) { return undefined; }
+    })());
+    if (!parsed.success) {
+      controlResponse(socket, { ok: false });
+      return;
+    }
+    try {
+      controlResponse(socket, await applyControl(parsed.data));
+    } catch (_error) {
+      controlResponse(socket, { ok: false });
+    }
+  });
+});
+await new Promise((resolve, reject) => {
+  controlServer.once("error", reject);
+  controlServer.listen(controlPath, resolve);
+});
+await chmod(controlPath, 0o600);
+
+const cleanupTimer = setInterval(() => {
+  const now = Date.now();
+  for (const [approvalId, pending] of pendingApprovals) {
+    if (pending.expiresAt > now) continue;
+    pendingApprovals.delete(approvalId);
+    try { sendProvider({ id: pending.nativeRequestId, result: { decision: "cancel" } }); } catch (_error) { stopping = true; }
+  }
+  for (const [requestId, pending] of pendingInputs) {
+    if (pending.expiresAt > now) continue;
+    pendingInputs.delete(requestId);
+    try { sendProvider({ id: pending.nativeRequestId, result: { answers: {} } }); } catch (_error) { stopping = true; }
+  }
+  for (const [requestId, completed] of completedControls) {
+    if (completed.expiresAt <= now) completedControls.delete(requestId);
+  }
+}, 30_000);
+cleanupTimer.unref();
+
+const child = spawn(command, [...commandArgs, "app-server"], {
+  cwd: process.cwd(),
+  env: process.env,
+  stdio: ["pipe", "pipe", "pipe"],
+});
+const childExit = new Promise((resolve, reject) => {
+  child.once("error", reject);
+  child.once("close", (code, signal) => {
+    for (const pending of pendingRpc.values()) {
+      clearTimeout(pending.timeout);
+      pending.reject(new Error("provider_stopped"));
+    }
+    pendingRpc.clear();
+    resolve({ code, signal });
+  });
+});
+const providerOutput = consumeProviderOutput(child.stdout);
+const providerErrors = discardProviderErrors(child.stderr);
+
+function stop() {
+  if (stopping) return;
+  stopping = true;
+  child.kill("SIGTERM");
+}
+process.once("SIGTERM", stop);
+process.once("SIGINT", stop);
+
+let exitCode = 1;
+try {
+  await request("initialize", {
+    clientInfo: { name: "matrix-os", title: "Matrix OS", version: "1" },
+    capabilities: { experimentalApi: true },
+  });
+  sendProvider({ method: "initialized", params: {} });
+  const started = await request("thread/start", {
+    cwd: process.cwd(),
+    approvalPolicy: config.approvalPolicy,
+    sandbox: config.sandbox,
+    runtimeWorkspaceRoots: config.writableRoots,
+    experimentalRawEvents: false,
+  });
+  const threadId = z.object({ thread: z.object({ id: NativeReferenceSchema }).passthrough() })
+    .passthrough().parse(started).thread.id;
+  activeTurn = true;
+  await request("turn/start", {
+    threadId,
+    input: [{ type: "text", text: config.prompt, text_elements: [] }],
+  });
+  const exit = await childExit;
+  await Promise.all([providerOutput, providerErrors]);
+  await new Promise((resolve) => setTimeout(resolve, SHUTDOWN_REPLAY_GRACE_MS));
+  exitCode = exit.code === 0 && completedTurn && !activeTurn ? 0 : 1;
+} catch (_error) {
+  await persist({ type: "turn.failed" }).catch(() => undefined);
+  stop();
+  await Promise.allSettled([childExit, providerOutput, providerErrors]);
+} finally {
+  clearInterval(cleanupTimer);
+  for (const pending of pendingRpc.values()) {
+    clearTimeout(pending.timeout);
+    pending.reject(new Error("provider_stopped"));
+  }
+  pendingRpc.clear();
+  await new Promise((resolve) => controlServer.close(resolve));
+  await rm(controlPath, { force: true });
+  await eventFile.close();
+}
+process.exitCode = exitCode;

--- a/packages/gateway/src/coding-agents/codex-app-server-runner.mjs
+++ b/packages/gateway/src/coding-agents/codex-app-server-runner.mjs
@@ -21,9 +21,13 @@ const MAX_PROVIDER_LINE_BYTES = 1024 * 1024;
 const MAX_TRANSCRIPT_BYTES = 16 * 1024 * 1024;
 const MAX_PENDING_REQUESTS = 20;
 const MAX_COMPLETED_REQUESTS = 100;
+const MAX_CONTROL_SOCKETS = 20;
 const REQUEST_TIMEOUT_MS = 5 * 60 * 1000;
 const RPC_TIMEOUT_MS = 30 * 1000;
+const CONTROL_SOCKET_TIMEOUT_MS = 2_000;
+const PROVIDER_STOP_TIMEOUT_MS = 5_000;
 const SHUTDOWN_REPLAY_GRACE_MS = 250;
+const UNSAFE_DISPLAY_TEXT = /(stack trace|\/home\/|\/tmp\/|\/var\/|\.ssh\/|id_rsa|bearer\s+[A-Za-z0-9._-]+|sk-[A-Za-z0-9_-]+)/i;
 const NativeRequestIdSchema = z.union([z.string().min(1).max(128), z.number().int().safe()]);
 const NativeReferenceSchema = z.string().min(1).max(512);
 const ApprovalMethodSchema = z.enum([
@@ -96,6 +100,12 @@ const TurnCompletedSchema = z.object({
   method: z.literal("turn/completed"),
   params: z.object({
     turn: z.object({ status: z.string().max(80).optional() }).passthrough(),
+  }).passthrough(),
+}).passthrough();
+const TurnFailedSchema = z.object({
+  method: z.enum(["turn/failed", "turn/cancelled"]),
+  params: z.object({
+    turn: z.object({ status: z.string().max(80).optional() }).passthrough().optional(),
   }).passthrough(),
 }).passthrough();
 const RpcResponseSchema = z.object({
@@ -171,7 +181,8 @@ const eventFile = await open(
 let transcriptBytes = (await eventFile.stat()).size;
 let stopping = false;
 let activeTurn = false;
-let completedTurn = false;
+let terminalOutcome;
+let stopTimer;
 let nextRpcId = 1;
 const pendingRpc = new Map();
 const pendingApprovals = new Map();
@@ -220,6 +231,11 @@ function boundedExternalText(value, maxChars, maxBytes) {
   return result;
 }
 
+function safeExternalText(value, fallback, maxChars, maxBytes) {
+  const bounded = boundedExternalText(value, maxChars, maxBytes);
+  return bounded.trim() && !UNSAFE_DISPLAY_TEXT.test(bounded) ? bounded : fallback;
+}
+
 async function persist(value) {
   const line = JSON.stringify(value);
   const bytes = Buffer.byteLength(`${line}\n`, "utf8");
@@ -264,17 +280,25 @@ function approvalCopy(method) {
 function decisionMapping(request) {
   const source = request.params.availableDecisions ?? ["accept", "acceptForSession", "decline", "cancel"];
   const nativeDecisionByMatrixDecision = {};
-  const mapped = source.map((decision) => {
+  const choicesByMatrixDecision = new Map();
+  for (const decision of source) {
     const matrixDecision = decision === "accept"
       ? "approve"
       : decision === "acceptForSession" || typeof decision === "object"
         ? "approve_for_session"
         : decision;
-    nativeDecisionByMatrixDecision[matrixDecision] ??= decision;
-    return matrixDecision;
-  });
+    const choices = choicesByMatrixDecision.get(matrixDecision) ?? [];
+    if (!choices.some((choice) => digest([choice]) === digest([decision]))) choices.push(decision);
+    choicesByMatrixDecision.set(matrixDecision, choices);
+  }
+  const allowedDecisions = [];
+  for (const [matrixDecision, choices] of choicesByMatrixDecision) {
+    if (matrixDecision === "approve_for_session" && choices.length !== 1) continue;
+    allowedDecisions.push(matrixDecision);
+    nativeDecisionByMatrixDecision[matrixDecision] = choices[0];
+  }
   return {
-    allowedDecisions: mapped.filter((decision, index) => mapped.indexOf(decision) === index),
+    allowedDecisions,
     nativeDecisionByMatrixDecision,
   };
 }
@@ -291,6 +315,10 @@ async function handleApproval(raw) {
   }
   const identity = approvalIdentity(parsed.data);
   const decisions = decisionMapping(parsed.data);
+  if (decisions.allowedDecisions.length === 0) {
+    sendProvider({ id: parsed.data.id, result: { decision: "cancel" } });
+    return true;
+  }
   if (pendingApprovals.size >= MAX_PENDING_REQUESTS || pendingApprovals.has(identity.approvalId)) {
     sendProvider({ id: parsed.data.id, result: { decision: "cancel" } });
     return true;
@@ -327,11 +355,16 @@ async function handleInput(raw) {
   }
   const questions = parsed.data.params.questions.map((question, index) => ({
     questionId: `question_codex_${digest([identity.requestId, question.id, index]).slice(0, 24)}`,
-    header: question.header,
-    question: boundedExternalText(question.question, 600, 2400),
-    ...(question.options ? { options: question.options.map((option) => ({
-      label: boundedExternalText(option.label, 160, 640),
-      description: boundedExternalText(option.description, 300, 1200),
+    header: safeExternalText(question.header, "Question", 120, 512),
+    question: safeExternalText(
+      question.question,
+      "The coding agent needs an answer.",
+      600,
+      2400,
+    ),
+    ...(question.options ? { options: question.options.map((option, optionIndex) => ({
+      label: safeExternalText(option.label, `Option ${optionIndex + 1}`, 120, 512),
+      description: safeExternalText(option.description, "Choose this option.", 300, 1200),
     })) } : {}),
     allowOther: question.isOther,
     secret: question.isSecret,
@@ -377,9 +410,21 @@ async function handleProviderMessage(raw) {
   }
   const completed = TurnCompletedSchema.safeParse(raw);
   if (completed.success) {
-    activeTurn = false;
-    completedTurn = true;
-    await persist({ type: "turn.completed" });
+    await finishTurn("completed");
+    return;
+  }
+  const failed = TurnFailedSchema.safeParse(raw);
+  if (failed.success) {
+    await finishTurn("failed");
+  }
+}
+
+async function processProviderLine(line) {
+  if (!line || Buffer.byteLength(line, "utf8") > MAX_PROVIDER_LINE_BYTES) return;
+  try {
+    await handleProviderMessage(JSON.parse(line));
+  } catch (error) {
+    if (!(error instanceof SyntaxError)) throw error;
   }
 }
 
@@ -400,13 +445,7 @@ async function consumeProviderOutput(stream) {
     while (newline >= 0) {
       const line = pending.slice(0, newline).replace(/\r$/, "");
       pending = pending.slice(newline + 1);
-      if (line && Buffer.byteLength(line, "utf8") <= MAX_PROVIDER_LINE_BYTES) {
-        try {
-          await handleProviderMessage(JSON.parse(line));
-        } catch (error) {
-          if (!(error instanceof SyntaxError)) throw error;
-        }
-      }
+      await processProviderLine(line);
       newline = pending.indexOf("\n");
     }
     if (Buffer.byteLength(pending, "utf8") > MAX_PROVIDER_LINE_BYTES) {
@@ -414,6 +453,8 @@ async function consumeProviderOutput(stream) {
       discarding = true;
     }
   }
+  pending += decoder.end();
+  if (!discarding) await processProviderLine(pending.replace(/\r$/, ""));
 }
 
 async function discardProviderErrors(stream) {
@@ -466,9 +507,17 @@ async function applyControl(control) {
   return { ok: true };
 }
 
+const controlSockets = new Set();
 const controlServer = createServer({ allowHalfOpen: true }, (socket) => {
+  if (controlSockets.size >= MAX_CONTROL_SOCKETS) {
+    socket.destroy();
+    return;
+  }
+  controlSockets.add(socket);
   let input = "";
   socket.setEncoding("utf8");
+  socket.setTimeout(CONTROL_SOCKET_TIMEOUT_MS, () => socket.destroy());
+  socket.once("close", () => controlSockets.delete(socket));
   socket.on("error", () => socket.destroy());
   socket.on("data", (chunk) => {
     input += chunk;
@@ -519,9 +568,10 @@ const child = spawn(command, [...commandArgs, "app-server"], {
   env: process.env,
   stdio: ["pipe", "pipe", "pipe"],
 });
-const childExit = new Promise((resolve, reject) => {
-  child.once("error", reject);
+const childExit = new Promise((resolve) => {
+  child.once("error", (error) => resolve({ code: null, signal: null, error }));
   child.once("close", (code, signal) => {
+    if (stopTimer) clearTimeout(stopTimer);
     for (const pending of pendingRpc.values()) {
       clearTimeout(pending.timeout);
       pending.reject(new Error("provider_stopped"));
@@ -530,14 +580,40 @@ const childExit = new Promise((resolve, reject) => {
     resolve({ code, signal });
   });
 });
-const providerOutput = consumeProviderOutput(child.stdout);
-const providerErrors = discardProviderErrors(child.stderr);
 
 function stop() {
   if (stopping) return;
   stopping = true;
   child.kill("SIGTERM");
+  stopTimer = setTimeout(() => child.kill("SIGKILL"), PROVIDER_STOP_TIMEOUT_MS);
+  stopTimer.unref();
 }
+
+async function finishTurn(outcome) {
+  if (terminalOutcome) return;
+  terminalOutcome = outcome;
+  activeTurn = false;
+  try {
+    await persist({ type: outcome === "completed" ? "turn.completed" : "turn.failed" });
+  } finally {
+    stop();
+  }
+}
+
+const providerOutput = consumeProviderOutput(child.stdout).then(
+  () => ({ ok: true }),
+  (error) => {
+    stop();
+    return { ok: false, error };
+  },
+);
+const providerErrors = discardProviderErrors(child.stderr).then(
+  () => ({ ok: true }),
+  (error) => {
+    stop();
+    return { ok: false, error };
+  },
+);
 process.once("SIGTERM", stop);
 process.once("SIGINT", stop);
 
@@ -562,21 +638,32 @@ try {
     threadId,
     input: [{ type: "text", text: config.prompt, text_elements: [] }],
   });
-  const exit = await childExit;
-  await Promise.all([providerOutput, providerErrors]);
+  const first = await Promise.race([
+    childExit.then((exit) => ({ type: "exit", exit })),
+    providerOutput.then((result) => ({ type: "output", result })),
+  ]);
+  if (first.type === "output" && !first.result.ok) throw first.result.error;
+  const exit = first.type === "exit" ? first.exit : await childExit;
+  const [outputResult, errorResult] = await Promise.all([providerOutput, providerErrors]);
+  if (!outputResult.ok) throw outputResult.error;
+  if (!errorResult.ok) throw errorResult.error;
+  if (!terminalOutcome) await finishTurn("failed");
   await new Promise((resolve) => setTimeout(resolve, SHUTDOWN_REPLAY_GRACE_MS));
-  exitCode = exit.code === 0 && completedTurn && !activeTurn ? 0 : 1;
+  exitCode = terminalOutcome === "completed" && !activeTurn && !exit.error ? 0 : 1;
 } catch (_error) {
-  await persist({ type: "turn.failed" }).catch(() => undefined);
+  await finishTurn("failed").catch(() => undefined);
   stop();
   await Promise.allSettled([childExit, providerOutput, providerErrors]);
 } finally {
   clearInterval(cleanupTimer);
+  if (stopTimer) clearTimeout(stopTimer);
   for (const pending of pendingRpc.values()) {
     clearTimeout(pending.timeout);
     pending.reject(new Error("provider_stopped"));
   }
   pendingRpc.clear();
+  for (const socket of controlSockets) socket.destroy();
+  controlSockets.clear();
   await new Promise((resolve) => controlServer.close(resolve));
   await rm(controlPath, { force: true });
   await eventFile.close();

--- a/packages/gateway/src/coding-agents/codex-events.ts
+++ b/packages/gateway/src/coding-agents/codex-events.ts
@@ -1,6 +1,11 @@
 import { z } from "zod/v4";
 import {
   AgentThreadEventSchema,
+  ApprovalIdSchema,
+  CorrelationIdSchema,
+  RequestIdSchema,
+  SafeDisplayStringSchema,
+  UserInputQuestionSchema,
   type AgentThreadEvent,
 } from "@matrix-os/contracts";
 
@@ -88,6 +93,32 @@ const CodexExecEventSchema = z.discriminatedUnion("type", [
   z.object({ type: z.literal("item.completed"), item: CodexItemSchema }).passthrough(),
   z.object({ type: z.literal("error") }).passthrough(),
 ]);
+const MatrixCodexRecordSchema = z.discriminatedUnion("type", [
+  z.object({
+    type: z.literal("matrix.codex.approval.requested"),
+    approvalId: ApprovalIdSchema,
+    correlationId: CorrelationIdSchema,
+    title: SafeDisplayStringSchema,
+    safeDescription: SafeDisplayStringSchema,
+    actionKind: z.enum(["command", "file_change", "provider"]),
+    risk: z.enum(["medium", "high"]),
+    allowedDecisions: z.array(z.enum(["approve", "approve_for_session", "decline", "cancel"]))
+      .min(1).max(4),
+  }).strict(),
+  z.object({
+    type: z.literal("matrix.codex.user_input.requested"),
+    requestId: RequestIdSchema,
+    correlationId: CorrelationIdSchema,
+    title: SafeDisplayStringSchema,
+    safeDescription: SafeDisplayStringSchema,
+    questions: z.array(UserInputQuestionSchema).min(1).max(8),
+    autoResolutionMs: z.number().int().min(60_000).max(240_000).optional(),
+  }).strict(),
+  z.object({
+    type: z.literal("matrix.codex.assistant.delta"),
+    delta: CodexTextSchema,
+  }).strict(),
+]);
 
 export interface CodexEventContext {
   threadId: string;
@@ -125,6 +156,52 @@ function assistantEvents(
     }));
   }
   events.push(event(context, { type: "assistant.text.completed", messageId: item.id }));
+  return events;
+}
+
+function appServerRecordEvents(
+  context: CodexEventContext,
+  record: z.infer<typeof MatrixCodexRecordSchema>,
+): AgentThreadEvent[] {
+  if (record.type === "matrix.codex.approval.requested") {
+    return [event(context, {
+      type: "approval.requested",
+      approval: {
+        approvalId: record.approvalId,
+        threadId: context.threadId,
+        title: record.title,
+        safeDescription: record.safeDescription,
+        actionKind: record.actionKind,
+        risk: record.risk,
+        allowedDecisions: record.allowedDecisions,
+        correlationId: record.correlationId,
+      },
+    })];
+  }
+  if (record.type === "matrix.codex.user_input.requested") {
+    return [event(context, {
+      type: "user_input.requested",
+      request: {
+        requestId: record.requestId,
+        threadId: context.threadId,
+        title: record.title,
+        safeDescription: record.safeDescription,
+        required: true,
+        questions: record.questions,
+        ...(record.autoResolutionMs ? { autoResolutionMs: record.autoResolutionMs } : {}),
+        correlationId: record.correlationId,
+      },
+    })];
+  }
+  const codePoints = Array.from(record.delta);
+  const events: AgentThreadEvent[] = [];
+  for (let offset = 0; offset < codePoints.length; offset += MAX_ASSISTANT_DELTA_CHARS) {
+    events.push(event(context, {
+      type: "assistant.text.delta",
+      messageId: "codex_app_server",
+      delta: codePoints.slice(offset, offset + MAX_ASSISTANT_DELTA_CHARS).join(""),
+    }));
+  }
   return events;
 }
 
@@ -250,6 +327,10 @@ export function parseCodexExecJsonLine(
       console.warn("[coding-agents] Codex event JSON parsing failed");
     }
     return { events: [] };
+  }
+  const appServerRecord = MatrixCodexRecordSchema.safeParse(raw);
+  if (appServerRecord.success) {
+    return { events: appServerRecordEvents(context, appServerRecord.data) };
   }
   const parsed = CodexExecEventSchema.safeParse(raw);
   if (!parsed.success) return { events: [] };

--- a/packages/gateway/src/coding-agents/workspace-provider.ts
+++ b/packages/gateway/src/coding-agents/workspace-provider.ts
@@ -233,7 +233,7 @@ export function createWorkspaceCodingAgentProvider(
             taskId: request.taskId,
             worktreeId: request.worktreeId,
             mode: request.mode,
-            approvalPolicy: request.approvalPolicy,
+            approvalPolicy: agent === "codex" ? "never" : request.approvalPolicy,
             sandboxMode: request.sandboxMode,
             runtimePreference: "zellij",
           },

--- a/specs/105-coding-agent-shells/tasks.md
+++ b/specs/105-coding-agent-shells/tasks.md
@@ -1420,6 +1420,7 @@ composer turns, and lifecycle actions.
 - [x] B28-011d Normalize verified Codex app-server command, file, permission, and structured-input requests into safe Matrix events while keeping native request, thread, turn, item, command, path, host, and permission payloads server-private.
 - [ ] B28-012 Implement and real-process test first-class adapters for Claude Code, Codex, Pi, and OpenCode plus a validated custom ACP-compatible adapter family; keep credentials and native resume identities server-side.
 - [x] B28-012a Wire the Codex workspace runner to the normalized provider-event ingestion contract and prove assistant/tool/file events through deterministic replay, event-sink publication, and a real child-process test. Disposable-runtime smoke remains in B34-001.
+- [x] B28-012b Route coding-thread Codex launches through the bounded app-server control runner, respond fail-closed to malformed provider requests, and retain the exec JSONL runner as a directly tested compatibility path.
 - [ ] B28-013 Implement capability-gated compatibility adapters for Kiro, GitHub Copilot CLI, Qwen Code, Kimi CLI, Kilo Code, and Auggie without generic shell-command escape hatches.
 - [ ] B28-014 Prove each provider/runtime combination advertises only verified resume, discovery/import, fork, rollback, steering, approval, image, model/mode, and handoff capabilities; reject Gemini CLI as unsupported for this release.
 

--- a/tests/gateway/coding-agents-codex-app-server-reliability.test.ts
+++ b/tests/gateway/coding-agents-codex-app-server-reliability.test.ts
@@ -111,6 +111,56 @@ const initialize = "if (message.method === 'initialize') console.log(JSON.string
 const startThread = "else if (message.method === 'thread/start') console.log(JSON.stringify({ id: message.id, result: { thread: { id: 'native-thread' }, model: 'codex', modelProvider: 'openai', cwd: '/private/project', approvalPolicy: 'on-request', approvalsReviewer: 'user', sandbox: {} } }));";
 
 describe("Codex app-server runner reliability", () => {
+  it("answers duplicate input questions with a fail-closed empty result", async () => {
+    const runtime = await startFakeRuntime("duplicate_questions", [
+      initialize,
+      startThread,
+      "else if (message.method === 'turn/start') {",
+      "  console.log(JSON.stringify({ id: message.id, result: { turn: { id: 'native-turn' } } }));",
+      "  console.log(JSON.stringify({ id: 42, method: 'item/tool/requestUserInput', params: { threadId: 'native-thread', turnId: 'native-turn', itemId: 'native-item', questions: [{ id: 'duplicate', header: 'First', question: 'First question' }, { id: 'duplicate', header: 'Second', question: 'Second question' }] } }));",
+      "} else if (message.id === 42 && JSON.stringify(message.result) === JSON.stringify({ answers: {} })) {",
+      "  console.log(JSON.stringify({ method: 'turn/completed', params: { turn: { status: 'completed' } } }));",
+      "  process.exit(0);",
+      "}",
+    ]);
+
+    try {
+      await expect(waitForExit(runtime.child)).resolves.toBe(0);
+      expect(await readFile(runtime.eventPath, "utf8")).not.toContain("user_input.requested");
+    } finally {
+      await cleanup(runtime);
+    }
+  });
+
+  it("ignores unknown approval variants while preserving one safe known decision", async () => {
+    const runtime = await startFakeRuntime("unknown_decision", [
+      initialize,
+      startThread,
+      "else if (message.method === 'turn/start') {",
+      "  console.log(JSON.stringify({ id: message.id, result: { turn: { id: 'native-turn' } } }));",
+      "  console.log(JSON.stringify({ id: 42, method: 'item/commandExecution/requestApproval', params: { threadId: 'native-thread', turnId: 'native-turn', itemId: 'native-item', availableDecisions: [{ futureGrant: { private: true } }, 'decline'] } }));",
+      "} else if (message.id === 42 && message.result?.decision === 'decline') {",
+      "  console.log(JSON.stringify({ method: 'turn/completed', params: { turn: { status: 'completed' } } }));",
+      "  process.exit(0);",
+      "}",
+    ]);
+
+    try {
+      const transcript = await waitForTranscript(runtime.eventPath, /approval\.requested/);
+      const approval = transcript.trim().split("\n").map((line) => JSON.parse(line))[0];
+      expect(approval.allowedDecisions).toEqual(["decline"]);
+      await expect(sendControl(runtime.controlPath, {
+        type: "approval",
+        approvalId: approval.approvalId,
+        decision: "decline",
+        clientRequestId: "req_unknown_variant_decline",
+      })).resolves.toEqual({ ok: true });
+      await expect(waitForExit(runtime.child)).resolves.toBe(0);
+    } finally {
+      await cleanup(runtime);
+    }
+  });
+
   it("fails ambiguous native session grants closed", async () => {
     const runtime = await startFakeRuntime("ambiguous_grants", [
       initialize,

--- a/tests/gateway/coding-agents-codex-app-server-reliability.test.ts
+++ b/tests/gateway/coding-agents-codex-app-server-reliability.test.ts
@@ -1,0 +1,257 @@
+import { spawn, type ChildProcess } from "node:child_process";
+import { chmod, lstat, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { createConnection, type Socket } from "node:net";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { codexProviderEventPath } from "../../packages/gateway/src/coding-agents/codex-event-bridge.js";
+
+interface FakeRuntime {
+  child: ChildProcess;
+  controlPath: string;
+  eventPath: string;
+  homePath: string;
+}
+
+async function waitForFile(path: string): Promise<void> {
+  const deadline = Date.now() + 3_000;
+  while (Date.now() < deadline) {
+    if (await lstat(path).then(() => true).catch(() => false)) return;
+    await new Promise((resolve) => setTimeout(resolve, 20));
+  }
+  throw new Error("Timed out waiting for runtime file");
+}
+
+async function waitForTranscript(path: string, pattern: RegExp): Promise<string> {
+  const deadline = Date.now() + 3_000;
+  while (Date.now() < deadline) {
+    const transcript = await readFile(path, "utf8").catch(() => "");
+    if (pattern.test(transcript)) return transcript;
+    await new Promise((resolve) => setTimeout(resolve, 20));
+  }
+  throw new Error("Timed out waiting for provider transcript");
+}
+
+async function waitForExit(child: ChildProcess, timeoutMs = 3_000): Promise<number | null> {
+  if (child.exitCode !== null || child.signalCode !== null) return child.exitCode;
+  return Promise.race([
+    new Promise<number | null>((resolve, reject) => {
+      child.once("error", reject);
+      child.once("close", resolve);
+    }),
+    new Promise<never>((_resolve, reject) => {
+      const timer = setTimeout(() => reject(new Error("Runner did not exit")), timeoutMs);
+      timer.unref();
+    }),
+  ]);
+}
+
+async function sendControl(path: string, payload: unknown): Promise<unknown> {
+  return new Promise((resolve, reject) => {
+    const socket = createConnection(path);
+    let response = "";
+    socket.setEncoding("utf8");
+    socket.once("connect", () => socket.end(`${JSON.stringify(payload)}\n`));
+    socket.on("data", (chunk) => {
+      response += chunk;
+    });
+    socket.once("error", reject);
+    socket.once("close", () => resolve(JSON.parse(response)));
+  });
+}
+
+async function startFakeRuntime(
+  name: string,
+  handlerLines: string[],
+  options: { initialTranscriptBytes?: number } = {},
+): Promise<FakeRuntime> {
+  const shortName = name.slice(0, 8);
+  const homePath = await mkdtemp(join(tmpdir(), `mx-${shortName}-`));
+  const fakePath = join(homePath, "fake-codex.mjs");
+  const eventPath = codexProviderEventPath(homePath, `sess_${shortName}`);
+  const controlPath = eventPath.replace(/\.jsonl$/, ".sock");
+  if (options.initialTranscriptBytes) {
+    await mkdir(dirname(eventPath), { recursive: true });
+    await writeFile(eventPath, "x".repeat(options.initialTranscriptBytes), "utf8");
+  }
+  await writeFile(fakePath, [
+    "#!/usr/bin/env node",
+    "import { createInterface } from 'node:readline';",
+    "const input = createInterface({ input: process.stdin, crlfDelay: Infinity });",
+    "for await (const line of input) {",
+    "  const message = JSON.parse(line);",
+    ...handlerLines.map((line) => `  ${line}`),
+    "}",
+  ].join("\n"), "utf8");
+  await chmod(fakePath, 0o700);
+  const config = Buffer.from(JSON.stringify({
+    prompt: "Fix the route.",
+    approvalPolicy: "on-request",
+    sandbox: "workspace-write",
+    writableRoots: [homePath],
+  }), "utf8").toString("base64");
+  const runnerPath = join(
+    process.cwd(),
+    "packages/gateway/src/coding-agents/codex-app-server-runner.mjs",
+  );
+  const child = spawn(process.execPath, [runnerPath, eventPath, process.execPath, fakePath, config], {
+    cwd: homePath,
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  return { child, controlPath, eventPath, homePath };
+}
+
+async function cleanup(runtime: FakeRuntime, socket?: Socket): Promise<void> {
+  socket?.destroy();
+  runtime.child.kill("SIGKILL");
+  await rm(runtime.homePath, { recursive: true, force: true });
+}
+
+const initialize = "if (message.method === 'initialize') console.log(JSON.stringify({ id: message.id, result: { userAgent: 'fake', platformFamily: 'unix', platformOs: 'linux', codexHome: '/private/codex' } }));";
+const startThread = "else if (message.method === 'thread/start') console.log(JSON.stringify({ id: message.id, result: { thread: { id: 'native-thread' }, model: 'codex', modelProvider: 'openai', cwd: '/private/project', approvalPolicy: 'on-request', approvalsReviewer: 'user', sandbox: {} } }));";
+
+describe("Codex app-server runner reliability", () => {
+  it("fails ambiguous native session grants closed", async () => {
+    const runtime = await startFakeRuntime("ambiguous_grants", [
+      initialize,
+      startThread,
+      "else if (message.method === 'turn/start') {",
+      "  console.log(JSON.stringify({ id: message.id, result: { turn: { id: 'native-turn' } } }));",
+      "  console.log(JSON.stringify({ id: 42, method: 'item/commandExecution/requestApproval', params: { threadId: 'native-thread', turnId: 'native-turn', itemId: 'native-item', availableDecisions: [{ acceptWithExecpolicyAmendment: { execpolicy_amendment: ['git status'] } }, { applyNetworkPolicyAmendment: { network_policy_amendment: { action: 'allow', host: 'example.com' } } }, 'decline', 'cancel'] } }));",
+      "} else if (message.id === 42) {",
+      "  console.log(JSON.stringify({ method: 'turn/completed', params: { turn: { status: 'completed' } } }));",
+      "  process.exit(0);",
+      "}",
+    ]);
+
+    try {
+      const transcript = await waitForTranscript(runtime.eventPath, /approval\.requested/);
+      const approval = transcript.trim().split("\n").map((line) => JSON.parse(line))[0];
+      expect(approval.allowedDecisions).toEqual(["decline", "cancel"]);
+      await expect(sendControl(runtime.controlPath, {
+        type: "approval",
+        approvalId: approval.approvalId,
+        decision: "approve_for_session",
+        clientRequestId: "req_ambiguous_grant",
+      })).resolves.toEqual({ ok: false });
+      await expect(sendControl(runtime.controlPath, {
+        type: "approval",
+        approvalId: approval.approvalId,
+        decision: "decline",
+        clientRequestId: "req_decline_ambiguous_grant",
+      })).resolves.toEqual({ ok: true });
+      await expect(waitForExit(runtime.child)).resolves.toBe(0);
+    } finally {
+      await cleanup(runtime);
+    }
+  });
+
+  it("flushes a final frame without a newline before provider exit", async () => {
+    const runtime = await startFakeRuntime("final_frame", [
+      initialize,
+      startThread,
+      "else if (message.method === 'turn/start') {",
+      "  console.log(JSON.stringify({ id: message.id, result: { turn: { id: 'native-turn' } } }));",
+      "  process.stdout.write(JSON.stringify({ method: 'turn/completed', params: { turn: { status: 'completed' } } }));",
+      "  process.stdout.end();",
+      "  setTimeout(() => process.exit(0), 50);",
+      "}",
+    ]);
+
+    try {
+      await expect(waitForExit(runtime.child)).resolves.toBe(0);
+      expect(await readFile(runtime.eventPath, "utf8")).toContain('"type":"turn.completed"');
+    } finally {
+      await cleanup(runtime);
+    }
+  });
+
+  it("stops the long-lived provider on completed and failed turns", async () => {
+    for (const terminalMethod of ["turn/completed", "turn/failed"] as const) {
+      const runtime = await startFakeRuntime(`terminal_${terminalMethod.split("/")[1]}`, [
+        initialize,
+        startThread,
+        "else if (message.method === 'turn/start') {",
+        "  console.log(JSON.stringify({ id: message.id, result: { turn: { id: 'native-turn' } } }));",
+        `  console.log(JSON.stringify({ method: '${terminalMethod}', params: { turn: { status: 'failed' } } }));`,
+        "  setInterval(() => {}, 1000);",
+        "}",
+      ]);
+
+      try {
+        const code = await waitForExit(runtime.child);
+        const transcript = await readFile(runtime.eventPath, "utf8");
+        expect(code).toBe(terminalMethod === "turn/completed" ? 0 : 1);
+        expect(transcript).toContain(terminalMethod === "turn/completed"
+          ? '"type":"turn.completed"'
+          : '"type":"turn.failed"');
+      } finally {
+        await cleanup(runtime);
+      }
+    }
+  });
+
+  it("persists a failure when the provider exits after accepting a turn", async () => {
+    const runtime = await startFakeRuntime("mid_turn_exit", [
+      initialize,
+      startThread,
+      "else if (message.method === 'turn/start') {",
+      "  console.log(JSON.stringify({ id: message.id, result: { turn: { id: 'native-turn' } } }));",
+      "  setTimeout(() => process.exit(7), 20);",
+      "}",
+    ]);
+
+    try {
+      await expect(waitForExit(runtime.child)).resolves.toBe(1);
+      expect(await readFile(runtime.eventPath, "utf8")).toContain('"type":"turn.failed"');
+    } finally {
+      await cleanup(runtime);
+    }
+  });
+
+  it("drains stalled control clients during terminal cleanup", async () => {
+    const runtime = await startFakeRuntime("stalled_control", [
+      initialize,
+      startThread,
+      "else if (message.method === 'turn/start') {",
+      "  console.log(JSON.stringify({ id: message.id, result: { turn: { id: 'native-turn' } } }));",
+      "  setTimeout(() => console.log(JSON.stringify({ method: 'turn/completed', params: { turn: { status: 'completed' } } })), 200);",
+      "  setInterval(() => {}, 1000);",
+      "}",
+    ]);
+    let socket: Socket | undefined;
+
+    try {
+      await waitForFile(runtime.controlPath);
+      socket = createConnection(runtime.controlPath);
+      await new Promise<void>((resolve, reject) => {
+        socket?.once("connect", resolve);
+        socket?.once("error", reject);
+      });
+      await expect(waitForExit(runtime.child, 4_000)).resolves.toBe(0);
+      await expect(lstat(runtime.controlPath)).rejects.toMatchObject({ code: "ENOENT" });
+    } finally {
+      await cleanup(runtime, socket);
+    }
+  });
+
+  it("handles provider output failures through terminal cleanup", async () => {
+    const runtime = await startFakeRuntime("output_failure", [
+      initialize,
+      startThread,
+      "else if (message.method === 'turn/start') {",
+      "  console.log(JSON.stringify({ id: message.id, result: { turn: { id: 'native-turn' } } }));",
+      "  console.log(JSON.stringify({ method: 'item/agentMessage/delta', params: { delta: 'a'.repeat(1000) } }));",
+      "  setInterval(() => {}, 1000);",
+      "}",
+    ], { initialTranscriptBytes: 16 * 1024 * 1024 - 100 });
+
+    try {
+      await expect(waitForExit(runtime.child)).resolves.toBe(1);
+      expect(await readFile(runtime.eventPath, "utf8")).toContain('"type":"turn.failed"');
+      await expect(lstat(runtime.controlPath)).rejects.toMatchObject({ code: "ENOENT" });
+    } finally {
+      await cleanup(runtime);
+    }
+  });
+});

--- a/tests/gateway/coding-agents-codex-app-server-runtime.test.ts
+++ b/tests/gateway/coding-agents-codex-app-server-runtime.test.ts
@@ -155,7 +155,7 @@ describe("Codex app-server control runtime", () => {
       "  else if (message.method === 'thread/start') console.log(JSON.stringify({ id: message.id, result: { thread: { id: 'native-thread-input' }, model: 'codex', modelProvider: 'openai', cwd: '/private/project', approvalPolicy: 'on-request', approvalsReviewer: 'user', sandbox: {} } }));",
       "  else if (message.method === 'turn/start') {",
       "    console.log(JSON.stringify({ id: message.id, result: { turn: { id: 'native-turn-input' } } }));",
-      "    console.log(JSON.stringify({ id: 'rpc-input-secret', method: 'item/tool/requestUserInput', params: { threadId: 'native-thread-input', turnId: 'native-turn-input', itemId: 'native-item-input', questions: [{ id: 'native-approach', header: 'Approach', question: 'Which approach?', options: [{ label: 'Minimal', description: 'Make the smallest change.' }], isOther: true, isSecret: false }, { id: 'native-secret', header: 'Secret', question: 'Enter the temporary value.', options: null, isOther: false, isSecret: true }] } }));",
+      "    console.log(JSON.stringify({ id: 'rpc-input-secret', method: 'item/tool/requestUserInput', params: { threadId: 'native-thread-input', turnId: 'native-turn-input', itemId: 'native-item-input', questions: [{ id: 'native-approach', header: 'Approach', question: 'Which approach for /home/matrix/private-question?', options: [{ label: 'Minimal', description: 'Use /home/matrix/private-question.' }], isOther: true, isSecret: false }, { id: 'native-secret', header: 'Secret', question: 'Enter the temporary value.', options: null, isOther: false, isSecret: true }] } }));",
       "  } else if (message.id === 'rpc-input-secret') {",
       "    await appendFile(responsesPath, JSON.stringify(message) + '\\n');",
       "    console.log(JSON.stringify({ method: 'turn/completed', params: { threadId: 'native-thread-input', turn: { id: 'native-turn-input', status: 'completed', items: [] } } }));",
@@ -183,7 +183,11 @@ describe("Codex app-server control runtime", () => {
         .find((event) => event.type === "matrix.codex.user_input.requested");
       expect(request.requestId).toMatch(/^req_codex_[a-f0-9]{32}$/);
       expect(request.questions).toHaveLength(2);
-      expect(beforeAnswer).not.toMatch(/native-|rpc-input-secret|private\/project/);
+      expect(request.questions[0]).toMatchObject({
+        question: "The coding agent needs an answer.",
+        options: [{ label: "Minimal", description: "Choose this option." }],
+      });
+      expect(beforeAnswer).not.toMatch(/native-|rpc-input-secret|private\/project|private-question/);
 
       const [approach, secret] = request.questions;
       await expect(sendControl(controlPath, {

--- a/tests/gateway/coding-agents-codex-app-server-runtime.test.ts
+++ b/tests/gateway/coding-agents-codex-app-server-runtime.test.ts
@@ -1,0 +1,318 @@
+import { spawn, type ChildProcess } from "node:child_process";
+import { chmod, lstat, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { createConnection } from "node:net";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { codexProviderEventPath } from "../../packages/gateway/src/coding-agents/codex-event-bridge.js";
+
+async function waitForTranscript(path: string, pattern: RegExp): Promise<string> {
+  const deadline = Date.now() + 5_000;
+  while (Date.now() < deadline) {
+    const value = await readFile(path, "utf8").catch(() => "");
+    if (pattern.test(value)) return value;
+    await new Promise((resolve) => setTimeout(resolve, 20));
+  }
+  throw new Error("Timed out waiting for Codex transcript");
+}
+
+function waitForExit(child: ChildProcess): Promise<number | null> {
+  return new Promise((resolve, reject) => {
+    child.once("error", reject);
+    child.once("close", resolve);
+  });
+}
+
+async function sendControl(path: string, payload: unknown): Promise<unknown> {
+  return new Promise((resolve, reject) => {
+    const socket = createConnection(path);
+    let response = "";
+    const timeout = setTimeout(() => {
+      socket.destroy();
+      reject(new Error("Control response timed out"));
+    }, 2_000);
+    socket.setEncoding("utf8");
+    socket.once("connect", () => socket.end(`${JSON.stringify(payload)}\n`));
+    socket.on("data", (chunk) => {
+      response += chunk;
+    });
+    socket.once("error", reject);
+    socket.once("close", () => {
+      clearTimeout(timeout);
+      resolve(JSON.parse(response));
+    });
+  });
+}
+
+describe("Codex app-server control runtime", () => {
+  it("durably publishes a safe approval before accepting one idempotent decision", async () => {
+    const homePath = await mkdtemp(join(tmpdir(), "matrix-codex-app-server-"));
+    const fakeCodexPath = join(homePath, "fake-codex-app-server.mjs");
+    const responsesPath = join(homePath, "responses.jsonl");
+    const eventPath = codexProviderEventPath(homePath, "sess_app_server_1");
+    const controlPath = eventPath.replace(/\.jsonl$/, ".sock");
+    await writeFile(fakeCodexPath, [
+      "#!/usr/bin/env node",
+      "import { appendFile } from 'node:fs/promises';",
+      "import { createInterface } from 'node:readline';",
+      `const responsesPath = ${JSON.stringify(responsesPath)};`,
+      "const input = createInterface({ input: process.stdin, crlfDelay: Infinity });",
+      "for await (const line of input) {",
+      "  const message = JSON.parse(line);",
+      "  if (message.method === 'initialize') {",
+      "    console.log(JSON.stringify({ id: message.id, result: { userAgent: 'fake', platformFamily: 'unix', platformOs: 'linux', codexHome: '/private/codex' } }));",
+      "  } else if (message.method === 'thread/start') {",
+      "    console.log(JSON.stringify({ id: message.id, result: { thread: { id: 'native-thread-secret' }, model: 'codex', modelProvider: 'openai', cwd: '/private/project', approvalPolicy: 'on-request', approvalsReviewer: 'user', sandbox: {} } }));",
+      "  } else if (message.method === 'turn/start') {",
+      "    console.log(JSON.stringify({ id: message.id, result: { turn: { id: 'native-turn-secret' } } }));",
+      "    console.log(JSON.stringify({ id: 42, method: 'item/commandExecution/requestApproval', params: { threadId: 'native-thread-secret', turnId: 'native-turn-secret', itemId: 'native-item-secret', command: 'cat /home/matrix/.codex/auth.json', cwd: '/private/project', availableDecisions: [{ applyNetworkPolicyAmendment: { network_policy_amendment: { action: 'allow', host: 'private.internal' } } }, 'decline', 'cancel'] } }));",
+      "  } else if (message.id === 42) {",
+      "    await appendFile(responsesPath, JSON.stringify(message) + '\\n');",
+      "    console.log(JSON.stringify({ method: 'item/agentMessage/delta', params: { threadId: 'native-thread-secret', turnId: 'native-turn-secret', itemId: 'message-1', delta: 'Approved and continuing.' } }));",
+      "    console.log(JSON.stringify({ method: 'turn/completed', params: { threadId: 'native-thread-secret', turn: { id: 'native-turn-secret', status: 'completed', items: [] } } }));",
+      "    process.exit(0);",
+      "  }",
+      "}",
+    ].join("\n"), "utf8");
+    await chmod(fakeCodexPath, 0o700);
+
+    const runnerPath = join(
+      process.cwd(),
+      "packages/gateway/src/coding-agents/codex-app-server-runner.mjs",
+    );
+    const config = Buffer.from(JSON.stringify({
+      prompt: "Fix the route.",
+      approvalPolicy: "on-request",
+      sandbox: "workspace-write",
+      writableRoots: [homePath],
+    }), "utf8").toString("base64");
+    const child = spawn(process.execPath, [runnerPath, eventPath, process.execPath, fakeCodexPath, config], {
+      cwd: homePath,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+
+    try {
+      const beforeDecision = await waitForTranscript(eventPath, /matrix\.codex\.approval\.requested/);
+      const approval = beforeDecision.trim().split("\n").map((line) => JSON.parse(line))
+        .find((event) => event.type === "matrix.codex.approval.requested");
+      expect(approval.approvalId).toMatch(/^appr_codex_[a-f0-9]{32}$/);
+      expect(beforeDecision).not.toMatch(/auth\.json|private\/project|private\.internal|native-|"42"|:42/);
+
+      const control = {
+        type: "approval",
+        approvalId: approval.approvalId,
+        decision: "approve_for_session",
+        clientRequestId: "req_control_1",
+      };
+      await expect(sendControl(controlPath, {
+        ...control,
+        approvalId: "appr_codex_00000000000000000000000000000000",
+        clientRequestId: "req_control_unknown",
+      })).resolves.toEqual({ ok: false });
+      await expect(sendControl(controlPath, control)).resolves.toEqual({ ok: true });
+      await expect(sendControl(controlPath, control)).resolves.toEqual({ ok: true, replayed: true });
+      await expect(sendControl(controlPath, { ...control, decision: "decline" })).resolves.toEqual({ ok: false });
+      await expect(waitForExit(child)).resolves.toBe(0);
+
+      const responses = (await readFile(responsesPath, "utf8")).trim().split("\n");
+      expect(responses).toHaveLength(1);
+      expect(JSON.parse(responses[0]!)).toEqual({
+        id: 42,
+        result: {
+          decision: {
+            applyNetworkPolicyAmendment: {
+              network_policy_amendment: { action: "allow", host: "private.internal" },
+            },
+          },
+        },
+      });
+      await expect(lstat(controlPath)).rejects.toMatchObject({ code: "ENOENT" });
+      const transcript = await readFile(eventPath, "utf8");
+      expect(transcript).toContain('"type":"matrix.codex.assistant.delta"');
+      expect(transcript).toContain('"type":"turn.completed"');
+      expect(transcript).not.toMatch(/auth\.json|private\/project|native-/);
+    } finally {
+      child.kill("SIGTERM");
+      await rm(homePath, { recursive: true, force: true });
+    }
+  });
+
+  it("maps structured answers to native questions without persisting secret input", async () => {
+    const homePath = await mkdtemp(join(tmpdir(), "matrix-codex-app-server-input-"));
+    const fakeCodexPath = join(homePath, "fake-codex-input.mjs");
+    const responsesPath = join(homePath, "responses.jsonl");
+    const eventPath = codexProviderEventPath(homePath, "sess_app_server_input_1");
+    const controlPath = eventPath.replace(/\.jsonl$/, ".sock");
+    await writeFile(fakeCodexPath, [
+      "#!/usr/bin/env node",
+      "import { appendFile } from 'node:fs/promises';",
+      "import { createInterface } from 'node:readline';",
+      `const responsesPath = ${JSON.stringify(responsesPath)};`,
+      "const input = createInterface({ input: process.stdin, crlfDelay: Infinity });",
+      "for await (const line of input) {",
+      "  const message = JSON.parse(line);",
+      "  if (message.method === 'initialize') console.log(JSON.stringify({ id: message.id, result: { userAgent: 'fake', platformFamily: 'unix', platformOs: 'linux', codexHome: '/private/codex' } }));",
+      "  else if (message.method === 'thread/start') console.log(JSON.stringify({ id: message.id, result: { thread: { id: 'native-thread-input' }, model: 'codex', modelProvider: 'openai', cwd: '/private/project', approvalPolicy: 'on-request', approvalsReviewer: 'user', sandbox: {} } }));",
+      "  else if (message.method === 'turn/start') {",
+      "    console.log(JSON.stringify({ id: message.id, result: { turn: { id: 'native-turn-input' } } }));",
+      "    console.log(JSON.stringify({ id: 'rpc-input-secret', method: 'item/tool/requestUserInput', params: { threadId: 'native-thread-input', turnId: 'native-turn-input', itemId: 'native-item-input', questions: [{ id: 'native-approach', header: 'Approach', question: 'Which approach?', options: [{ label: 'Minimal', description: 'Make the smallest change.' }], isOther: true, isSecret: false }, { id: 'native-secret', header: 'Secret', question: 'Enter the temporary value.', options: null, isOther: false, isSecret: true }] } }));",
+      "  } else if (message.id === 'rpc-input-secret') {",
+      "    await appendFile(responsesPath, JSON.stringify(message) + '\\n');",
+      "    console.log(JSON.stringify({ method: 'turn/completed', params: { threadId: 'native-thread-input', turn: { id: 'native-turn-input', status: 'completed', items: [] } } }));",
+      "    process.exit(0);",
+      "  }",
+      "}",
+    ].join("\n"), "utf8");
+    await chmod(fakeCodexPath, 0o700);
+
+    const runnerPath = join(process.cwd(), "packages/gateway/src/coding-agents/codex-app-server-runner.mjs");
+    const config = Buffer.from(JSON.stringify({
+      prompt: "Ask before continuing.",
+      approvalPolicy: "on-request",
+      sandbox: "workspace-write",
+      writableRoots: [homePath],
+    }), "utf8").toString("base64");
+    const child = spawn(process.execPath, [runnerPath, eventPath, process.execPath, fakeCodexPath, config], {
+      cwd: homePath,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+
+    try {
+      const beforeAnswer = await waitForTranscript(eventPath, /matrix\.codex\.user_input\.requested/);
+      const request = beforeAnswer.trim().split("\n").map((line) => JSON.parse(line))
+        .find((event) => event.type === "matrix.codex.user_input.requested");
+      expect(request.requestId).toMatch(/^req_codex_[a-f0-9]{32}$/);
+      expect(request.questions).toHaveLength(2);
+      expect(beforeAnswer).not.toMatch(/native-|rpc-input-secret|private\/project/);
+
+      const [approach, secret] = request.questions;
+      await expect(sendControl(controlPath, {
+        type: "input",
+        requestId: request.requestId,
+        structuredAnswers: {
+          [approach.questionId]: ["Minimal"],
+          [secret.questionId]: ["temporary-secret-value"],
+        },
+        clientRequestId: "req_control_input_1",
+      })).resolves.toEqual({ ok: true });
+      await expect(waitForExit(child)).resolves.toBe(0);
+
+      const providerResponse = JSON.parse((await readFile(responsesPath, "utf8")).trim());
+      expect(providerResponse).toEqual({
+        id: "rpc-input-secret",
+        result: {
+          answers: {
+            "native-approach": { answers: ["Minimal"] },
+            "native-secret": { answers: ["temporary-secret-value"] },
+          },
+        },
+      });
+      const transcript = await readFile(eventPath, "utf8");
+      expect(transcript).not.toContain("temporary-secret-value");
+      expect(transcript).not.toMatch(/native-|rpc-input-secret|private\/project/);
+    } finally {
+      child.kill("SIGTERM");
+      await rm(homePath, { recursive: true, force: true });
+    }
+  });
+
+  it("caps pending requests and fails the excess request closed", async () => {
+    const homePath = await mkdtemp(join(tmpdir(), "matrix-codex-app-server-cap-"));
+    const fakeCodexPath = join(homePath, "fake-codex-cap.mjs");
+    const responsesPath = join(homePath, "responses.jsonl");
+    const eventPath = codexProviderEventPath(homePath, "sess_app_server_cap_1");
+    await writeFile(fakeCodexPath, [
+      "#!/usr/bin/env node",
+      "import { appendFile } from 'node:fs/promises';",
+      "import { createInterface } from 'node:readline';",
+      `const responsesPath = ${JSON.stringify(responsesPath)};`,
+      "const input = createInterface({ input: process.stdin, crlfDelay: Infinity });",
+      "for await (const line of input) {",
+      "  const message = JSON.parse(line);",
+      "  if (message.method === 'initialize') console.log(JSON.stringify({ id: message.id, result: { userAgent: 'fake', platformFamily: 'unix', platformOs: 'linux', codexHome: '/private/codex' } }));",
+      "  else if (message.method === 'thread/start') console.log(JSON.stringify({ id: message.id, result: { thread: { id: 'native-thread-cap' }, model: 'codex', modelProvider: 'openai', cwd: '/private/project', approvalPolicy: 'on-request', approvalsReviewer: 'user', sandbox: {} } }));",
+      "  else if (message.method === 'turn/start') {",
+      "    console.log(JSON.stringify({ id: message.id, result: { turn: { id: 'native-turn-cap' } } }));",
+      "    for (let index = 0; index < 21; index += 1) console.log(JSON.stringify({ id: 100 + index, method: 'item/commandExecution/requestApproval', params: { threadId: 'native-thread-cap', turnId: 'native-turn-cap', itemId: `native-item-${index}`, availableDecisions: ['accept', 'cancel'] } }));",
+      "  } else if (message.id >= 100) {",
+      "    await appendFile(responsesPath, JSON.stringify(message) + '\\n');",
+      "    console.log(JSON.stringify({ method: 'turn/completed', params: { threadId: 'native-thread-cap', turn: { id: 'native-turn-cap', status: 'completed', items: [] } } }));",
+      "    process.exit(0);",
+      "  }",
+      "}",
+    ].join("\n"), "utf8");
+    await chmod(fakeCodexPath, 0o700);
+    const runnerPath = join(process.cwd(), "packages/gateway/src/coding-agents/codex-app-server-runner.mjs");
+    const config = Buffer.from(JSON.stringify({
+      prompt: "Exercise the request cap.",
+      approvalPolicy: "on-request",
+      sandbox: "workspace-write",
+      writableRoots: [homePath],
+    }), "utf8").toString("base64");
+    const child = spawn(process.execPath, [runnerPath, eventPath, process.execPath, fakeCodexPath, config], {
+      cwd: homePath,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+
+    try {
+      await expect(waitForExit(child)).resolves.toBe(0);
+      const responses = (await readFile(responsesPath, "utf8")).trim().split("\n");
+      expect(responses.map((line) => JSON.parse(line))).toEqual([
+        { id: 120, result: { decision: "cancel" } },
+      ]);
+      const transcript = (await readFile(eventPath, "utf8")).trim().split("\n");
+      expect(transcript.filter((line) => JSON.parse(line).type === "matrix.codex.approval.requested"))
+        .toHaveLength(20);
+      expect(transcript.join("\n")).not.toContain("native-");
+    } finally {
+      child.kill("SIGTERM");
+      await rm(homePath, { recursive: true, force: true });
+    }
+  });
+
+  it("persists a generic failure and removes the control socket when the provider exits", async () => {
+    const homePath = await mkdtemp(join(tmpdir(), "matrix-codex-app-server-exit-"));
+    const fakeCodexPath = join(homePath, "fake-codex-exit.mjs");
+    const eventPath = codexProviderEventPath(homePath, "sess_app_server_exit_1");
+    const controlPath = eventPath.replace(/\.jsonl$/, ".sock");
+    await writeFile(fakeCodexPath, [
+      "#!/usr/bin/env node",
+      "import { createInterface } from 'node:readline';",
+      "const input = createInterface({ input: process.stdin, crlfDelay: Infinity });",
+      "for await (const line of input) {",
+      "  const message = JSON.parse(line);",
+      "  if (message.method === 'initialize') {",
+      "    console.log(JSON.stringify({ id: message.id, result: { userAgent: 'fake', platformFamily: 'unix', platformOs: 'linux', codexHome: '/private/codex' } }));",
+      "    process.stderr.write('token-secret at /private/project\\n');",
+      "  } else if (message.method === 'thread/start') process.exit(7);",
+      "}",
+    ].join("\n"), "utf8");
+    await chmod(fakeCodexPath, 0o700);
+    const runnerPath = join(process.cwd(), "packages/gateway/src/coding-agents/codex-app-server-runner.mjs");
+    const config = Buffer.from(JSON.stringify({
+      prompt: "Start a turn.",
+      approvalPolicy: "on-request",
+      sandbox: "workspace-write",
+      writableRoots: [homePath],
+    }), "utf8").toString("base64");
+    const child = spawn(process.execPath, [runnerPath, eventPath, process.execPath, fakeCodexPath, config], {
+      cwd: homePath,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    let stderr = "";
+    child.stderr?.setEncoding("utf8");
+    child.stderr?.on("data", (chunk) => {
+      stderr += chunk;
+    });
+
+    try {
+      await expect(waitForExit(child)).resolves.toBe(1);
+      expect(await readFile(eventPath, "utf8")).toBe('{"type":"turn.failed"}\n');
+      expect(stderr).not.toMatch(/token-secret|private\/project/);
+      await expect(lstat(controlPath)).rejects.toMatchObject({ code: "ENOENT" });
+    } finally {
+      child.kill("SIGTERM");
+      await rm(homePath, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/gateway/coding-agents-codex-events.test.ts
+++ b/tests/gateway/coding-agents-codex-events.test.ts
@@ -181,4 +181,56 @@ describe("Codex structured event normalization", () => {
       item: { id: "../bad", type: "agent_message", text: "unsafe id" },
     }), context)).toEqual({ events: [] });
   });
+
+  it("normalizes app-server control records into canonical thread events", () => {
+    const approval = parseCodexExecJsonLine(JSON.stringify({
+      type: "matrix.codex.approval.requested",
+      approvalId: "appr_codex_11111111111111111111111111111111",
+      correlationId: "corr_codex_22222222222222222222222222222222",
+      title: "Run command",
+      safeDescription: "The coding agent wants to run a command.",
+      actionKind: "command",
+      risk: "medium",
+      allowedDecisions: ["approve", "decline", "cancel"],
+    }), context);
+    expect(approval.events[0]).toMatchObject({
+      type: "approval.requested",
+      approval: {
+        approvalId: "appr_codex_11111111111111111111111111111111",
+        allowedDecisions: ["approve", "decline", "cancel"],
+      },
+    });
+
+    const input = parseCodexExecJsonLine(JSON.stringify({
+      type: "matrix.codex.user_input.requested",
+      requestId: "req_codex_33333333333333333333333333333333",
+      correlationId: "corr_codex_44444444444444444444444444444444",
+      title: "Approach",
+      safeDescription: "The coding agent needs more information.",
+      questions: [{
+        questionId: "question_codex_555555555555555555555555",
+        header: "Approach",
+        question: "Which approach should be used?",
+        options: [{ label: "Minimal", description: "Make the smallest change." }],
+        allowOther: true,
+        secret: false,
+      }],
+    }), context);
+    expect(input.events[0]).toMatchObject({
+      type: "user_input.requested",
+      request: {
+        requestId: "req_codex_33333333333333333333333333333333",
+        questions: [expect.objectContaining({ header: "Approach" })],
+      },
+    });
+
+    const delta = parseCodexExecJsonLine(JSON.stringify({
+      type: "matrix.codex.assistant.delta",
+      delta: "Working on it.",
+    }), context);
+    expect(delta.events[0]).toMatchObject({
+      type: "assistant.text.delta",
+      delta: "Working on it.",
+    });
+  });
 });

--- a/tests/gateway/coding-agents-codex-runtime.test.ts
+++ b/tests/gateway/coding-agents-codex-runtime.test.ts
@@ -39,7 +39,7 @@ function runProcess(command: string, args: string[], cwd: string, input = ""): P
 }
 
 describe("Codex structured event runtime", () => {
-  it("wraps Codex exec with the Matrix event runner and forces JSONL output", () => {
+  it("launches coding threads through the Matrix control-capable app-server runner", () => {
     const launch = buildAgentLaunch({
       agent: "codex",
       cwd: "/home/matrix/home/projects/repo",
@@ -54,14 +54,19 @@ describe("Codex structured event runtime", () => {
     });
 
     expect(launch.command).toBe(process.execPath);
-    expect(launch.args[0]).toMatch(/coding-agents\/codex-runner\.mjs$/);
-    expect(launch.args.slice(1, 3)).toEqual([
+    expect(launch.args[0]).toMatch(/coding-agents\/codex-app-server-runner\.mjs$/);
+    expect(launch.args.slice(1, 4)).toEqual([
       "/home/matrix/home/system/coding-agents/provider-events/sess_test.jsonl",
       "codex",
+      "app-server",
     ]);
-    expect(launch.args).toContain("--json");
-    expect(launch.args.indexOf("--sandbox")).toBeLessThan(launch.args.indexOf("exec"));
-    expect(launch.args.indexOf("--add-dir")).toBeLessThan(launch.args.indexOf("exec"));
+    const config = JSON.parse(Buffer.from(launch.args[4]!, "base64").toString("utf8"));
+    expect(config).toEqual({
+      prompt: "Fix the failing route.",
+      approvalPolicy: "never",
+      sandbox: "workspace-write",
+      writableRoots: ["/home/matrix/home/projects/repo"],
+    });
     expect(launch.args).not.toContain("sh");
     expect(launch.args).not.toContain("-c");
   });

--- a/tests/gateway/coding-agents-codex-runtime.test.ts
+++ b/tests/gateway/coding-agents-codex-runtime.test.ts
@@ -55,12 +55,11 @@ describe("Codex structured event runtime", () => {
 
     expect(launch.command).toBe(process.execPath);
     expect(launch.args[0]).toMatch(/coding-agents\/codex-app-server-runner\.mjs$/);
-    expect(launch.args.slice(1, 4)).toEqual([
+    expect(launch.args.slice(1, 3)).toEqual([
       "/home/matrix/home/system/coding-agents/provider-events/sess_test.jsonl",
       "codex",
-      "app-server",
     ]);
-    const config = JSON.parse(Buffer.from(launch.args[4]!, "base64").toString("utf8"));
+    const config = JSON.parse(Buffer.from(launch.args[3]!, "base64").toString("utf8"));
     expect(config).toEqual({
       prompt: "Fix the failing route.",
       approvalPolicy: "never",
@@ -69,6 +68,7 @@ describe("Codex structured event runtime", () => {
     });
     expect(launch.args).not.toContain("sh");
     expect(launch.args).not.toContain("-c");
+    expect(launch.args).not.toContain("app-server");
   });
 
   it("runs a real child process, persists raw complete JSONL, and prints only safe terminal output", async () => {

--- a/tests/gateway/coding-agents-workspace-provider.test.ts
+++ b/tests/gateway/coding-agents-workspace-provider.test.ts
@@ -264,7 +264,7 @@ describe("coding agent workspace provider", () => {
         runtimePreference: "zellij",
         sessionId: expect.stringMatching(/^sess_[A-Za-z0-9_-]+$/),
         mode: "default",
-        approvalPolicy: "on_request",
+        approvalPolicy: "never",
         sandboxMode: "workspace_write",
       }),
     });


### PR DESCRIPTION
## Summary

- add a Matrix-owned Codex app-server JSON-RPC runner for durable approval and structured-input control
- persist only bounded Matrix-safe request envelopes while retaining native correlation in capped process memory
- route decisions and secret answers through an owner-only Unix socket instead of terminal input
- fail permission-profile requests closed until their grant semantics are supported
- package the runner in the gateway build

## Tests

- `pnpm exec vitest run tests/gateway/coding-agents-codex-app-server-runtime.test.ts tests/gateway/coding-agents-codex-app-server-events.test.ts tests/gateway/coding-agents-codex-runtime.test.ts tests/gateway/coding-agents-workspace-provider.test.ts tests/gateway/coding-agents-threads.test.ts tests/contracts/coding-agents.test.ts` (64 passed)
- `pnpm --filter '@matrix-os/gateway' build` (passed; packaged runner verified)
- `bun run typecheck` (passed)
- `bun run check:patterns` (0 violations; existing warnings only)
- `git diff --check` (passed)

## Review/Monitoring

- opened ready for review as the next PR above #949
- capability exposure and gateway submission are intentionally deferred to the next slice
- no deployment, merge, or release promotion is included

## Invariants

### Source of truth

- the gateway thread store remains authoritative; this runner only transports provider protocol messages and writes bounded event envelopes
- native provider request, thread, turn, item, command, path, policy, and secret-answer data never enter the durable provider transcript

### Resource and shutdown scope

- pending RPC, approval, input, and completed-idempotency registries are capped with timeout cleanup
- provider lines, control frames, transcript bytes, questions, options, roots, and answers are bounded
- provider exit rejects pending RPC immediately, drains streams, closes the control server, removes the socket, and closes the transcript

### Auth and control boundary

- the control socket is created beside the owner-local transcript with mode 0600
- control frames use Matrix request ids; native JSON-RPC ids remain process-private
- secret answers are sent only over the local socket and are never persisted or printed

### Acceptable orphan states

- a stale socket from an exited runner is removed before binding and again during shutdown
- excess or expired provider requests fail closed; no accepted control is reported before the provider response is written

### Deferred scope

- safe envelope ingestion, provider adapter submission, and capability enablement are the next stacked PR
- permission-profile grants remain unsupported and fail closed
