### PR TITLE
chore(cli): prepare 0.3.14 release

### DIFF
--- a/docs/dev/cli-release.md
+++ b/docs/dev/cli-release.md
@@ -4,7 +4,7 @@ The installable Matrix CLI is the `@finnaai/matrix` package in `packages/sync-cl
 
 ## Current Prepared Release
 
-`0.3.11` is the prepared CLI patch release after `0.3.10`, including the explicit attached-session clipboard image paste command and path-only clipboard fallback fixes.
+`0.3.14` is the prepared CLI patch release after `0.3.13`. It improves upload destination handling and errors, adds Matrix filesystem completion, and makes attached shell viewers recover from local terminal backpressure without ending the named zellij session.
 
 ## Versioning
 
@@ -34,7 +34,7 @@ git tag -l 'cli-v*'
 
 ## Release
 
-Use the manual GitHub Actions workflow named `CLI Release` with `version=0.3.11` and `update_homebrew=true`. This follows the existing `cli-v0.3.11` workflow/tag release path after the PR merges. The workflow:
+Use the manual GitHub Actions workflow named `CLI Release` with `version=0.3.14` and `update_homebrew=true`. This follows the existing `cli-v0.3.14` workflow/tag release path after the PR merges. The workflow:
 
 1. Validates the requested semver, local package version, npm availability, and `cli-v<version>` tag availability.
 2. Installs the workspace and runs the sync-client build, tests, and publish-shape check.
@@ -51,7 +51,7 @@ npm view @finnaai/matrix dist.tarball
 npx --yes @finnaai/matrix --version
 pnpm dlx @finnaai/matrix --version
 brew update && brew info finnaai/tap/matrix
-MATRIX_VERSION=0.3.11 sh scripts/install.sh
+MATRIX_VERSION=0.3.14 sh scripts/install.sh
 matrix --version
 matrix login --help
 matrix run --help
@@ -69,17 +69,17 @@ matrix forward 5173
 
 For standalone binaries, also verify the GitHub release contains:
 
-- `matrix-0.3.11-linux-x64`
-- `matrix-0.3.11-linux-arm64`
-- `matrix-0.3.11-darwin-x64`
-- `matrix-0.3.11-darwin-arm64`
+- `matrix-0.3.14-linux-x64`
+- `matrix-0.3.14-linux-arm64`
+- `matrix-0.3.14-darwin-x64`
+- `matrix-0.3.14-darwin-arm64`
 
-For macOS app packaging, also verify the GitHub release contains `MatrixSync-0.3.11.pkg` when the macOS job was enabled.
+For macOS app packaging, also verify the GitHub release contains `MatrixSync-0.3.14.pkg` when the macOS job was enabled.
 
 ## Rollback
 
-npm package versions are immutable. If a bad CLI release is published, ship a patch release such as `0.3.12` and update Homebrew through the release workflow. Only deprecate the bad npm version when the replacement is available:
+npm package versions are immutable. If a bad CLI release is published, ship a patch release such as `0.3.15` and update Homebrew through the release workflow. Only deprecate the bad npm version when the replacement is available:
 
 ```bash
-npm deprecate @finnaai/matrix@0.3.11 "Use @finnaai/matrix@0.3.12"
+npm deprecate @finnaai/matrix@0.3.14 "Use @finnaai/matrix@0.3.15"
 ```

--- a/packages/sync-client/package.json
+++ b/packages/sync-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@finnaai/matrix",
-  "version": "0.3.13",
+  "version": "0.3.14",
   "description": "Matrix OS command-line client — login, sync, and peer management for matrix-os.com",
   "type": "module",
   "license": "AGPL-3.0-or-later",


### PR DESCRIPTION
## Summary

- bump `@finnaai/matrix` from `0.3.13` to `0.3.14`
- refresh the CLI release runbook for the upload, completion, and shell-resilience release

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm --filter @finnaai/matrix build`
- `pnpm --filter @finnaai/matrix test` (367 passed)
- `pnpm --filter @finnaai/matrix exec node ./scripts/check-publish.mjs`
- `pnpm --filter @finnaai/matrix exec node ./scripts/validate-package-runners.mjs`
- `bun run check:patterns` (0 violations)
- `git diff --check`

## Invariants

- Source of truth: `packages/sync-client/package.json` is the CLI release version consumed by `.github/workflows/cli-release.yml`.
- Lock or transaction scope: no runtime state or database writes are involved.
- Acceptable orphan states: none; release publication is a separate workflow dispatched only after this PR merges.
- Auth source of truth: npm trusted publishing and the existing GitHub Actions secrets remain unchanged.
- Deferred scope: host-bundle publication and hamedmp rollout are tracked separately from this CLI package release.
