### PR TITLE
feat(mobile): chat conversation management

### DIFF
--- a/apps/mobile/__tests__/InputBar.test.tsx
+++ b/apps/mobile/__tests__/InputBar.test.tsx
@@ -15,23 +15,23 @@ describe("InputBar", () => {
 
   it("renders input field", () => {
     render(<InputBar {...defaultProps} />);
-    expect(screen.getByPlaceholderText("Ask Matrix OS...")).toBeTruthy();
+    expect(screen.getByPlaceholderText("Message your Matrix…")).toBeTruthy();
   });
 
-  it("shows 'Thinking...' placeholder when busy", () => {
+  it("shows 'Matrix is thinking…' placeholder when busy", () => {
     render(<InputBar {...defaultProps} busy={true} />);
-    expect(screen.getByPlaceholderText("Thinking...")).toBeTruthy();
+    expect(screen.getByPlaceholderText("Matrix is thinking…")).toBeTruthy();
   });
 
-  it("shows 'Connecting...' placeholder when not connected", () => {
+  it("shows 'Connecting…' placeholder when not connected", () => {
     render(<InputBar {...defaultProps} connected={false} />);
-    expect(screen.getByPlaceholderText("Connecting...")).toBeTruthy();
+    expect(screen.getByPlaceholderText("Connecting…")).toBeTruthy();
   });
 
   it("calls onSend with trimmed text when send pressed", () => {
     const onSend = jest.fn();
     render(<InputBar {...defaultProps} onSend={onSend} />);
-    const input = screen.getByPlaceholderText("Ask Matrix OS...");
+    const input = screen.getByPlaceholderText("Message your Matrix…");
     fireEvent.changeText(input, "  hello world  ");
     fireEvent.press(screen.getByTestId("icon-arrow-up"));
     expect(onSend).toHaveBeenCalledWith("hello world");
@@ -47,7 +47,7 @@ describe("InputBar", () => {
   it("does not call onSend when disconnected", () => {
     const onSend = jest.fn();
     render(<InputBar {...defaultProps} onSend={onSend} connected={false} />);
-    const input = screen.getByPlaceholderText("Connecting...");
+    const input = screen.getByPlaceholderText("Connecting…");
     fireEvent.changeText(input, "hello");
     fireEvent.press(screen.getByTestId("icon-arrow-up"));
     expect(onSend).not.toHaveBeenCalled();
@@ -55,7 +55,7 @@ describe("InputBar", () => {
 
   it("clears input after sending", () => {
     render(<InputBar {...defaultProps} />);
-    const input = screen.getByPlaceholderText("Ask Matrix OS...");
+    const input = screen.getByPlaceholderText("Message your Matrix…");
     fireEvent.changeText(input, "hello");
     fireEvent.press(screen.getByTestId("icon-arrow-up"));
     expect(input.props.value).toBe("");
@@ -64,7 +64,7 @@ describe("InputBar", () => {
   it("triggers haptic on send", () => {
     const Haptics = require("expo-haptics");
     render(<InputBar {...defaultProps} />);
-    const input = screen.getByPlaceholderText("Ask Matrix OS...");
+    const input = screen.getByPlaceholderText("Message your Matrix…");
     fireEvent.changeText(input, "hello");
     fireEvent.press(screen.getByTestId("icon-arrow-up"));
     expect(Haptics.impactAsync).toHaveBeenCalledWith("light");

--- a/apps/mobile/__tests__/apps-screen.test.tsx
+++ b/apps/mobile/__tests__/apps-screen.test.tsx
@@ -13,6 +13,11 @@ jest.mock("../app/_layout", () => ({
 
 jest.mock("expo-router", () => ({
   Link: ({ children }: { children: React.ReactNode }) => children,
+  useRouter: () => ({ push: jest.fn(), replace: jest.fn() }),
+}));
+
+jest.mock("@clerk/clerk-expo", () => ({
+  useUser: () => ({ user: null }),
 }));
 
 jest.mock("expo-image", () => {

--- a/apps/mobile/__tests__/gateway-client.test.ts
+++ b/apps/mobile/__tests__/gateway-client.test.ts
@@ -217,6 +217,41 @@ describe("GatewayClient", () => {
     expect(selfHosted.wsUrl).toBe("wss://matrix.example.test/ws");
   });
 
+  it("parses conversation lists and tolerates invalid payloads", async () => {
+    const fetchMock = jest.spyOn(global, "fetch").mockResolvedValueOnce(jsonResponse([
+      { id: "conv-1", preview: "Fix the tests", messageCount: 4, createdAt: 1, updatedAt: 2 },
+    ]));
+    const client = new GatewayClient("http://localhost:4000");
+
+    await expect(client.getConversations()).resolves.toEqual([
+      expect.objectContaining({ id: "conv-1", preview: "Fix the tests", messageCount: 4 }),
+    ]);
+
+    fetchMock.mockResolvedValueOnce(jsonResponse({ error: { code: "misconfigured" } }));
+    await expect(client.getConversations()).resolves.toEqual([]);
+
+    fetchMock.mockRejectedValueOnce(new Error("ECONNREFUSED /var/secret"));
+    await expect(client.getConversations()).resolves.toEqual([]);
+
+    fetchMock.mockRestore();
+  });
+
+  it("creates a conversation and returns its id", async () => {
+    const fetchMock = jest.spyOn(global, "fetch").mockResolvedValueOnce(jsonResponse({ id: "conv-new" }));
+    const client = new GatewayClient("http://localhost:4000");
+
+    await expect(client.createConversation()).resolves.toBe("conv-new");
+    expect(fetchMock).toHaveBeenCalledWith(
+      "http://localhost:4000/api/conversations",
+      expect.objectContaining({ method: "POST" }),
+    );
+
+    fetchMock.mockResolvedValueOnce(jsonResponse({ nope: true }));
+    await expect(client.createConversation()).resolves.toBeNull();
+
+    fetchMock.mockRestore();
+  });
+
   it("fetches the websocket token from the platform origin for hosted computers", async () => {
     const fetchMock = jest.spyOn(global, "fetch").mockResolvedValue(
       jsonResponse({ token: "jwt-token", expiresAt: Date.now() + 60_000 }),

--- a/apps/mobile/__tests__/gateway-client.test.ts
+++ b/apps/mobile/__tests__/gateway-client.test.ts
@@ -236,6 +236,42 @@ describe("GatewayClient", () => {
     fetchMock.mockRestore();
   });
 
+  it("truncates oversized conversation lists to the first 50 entries", async () => {
+    const many = Array.from({ length: 60 }, (_, i) => ({
+      id: `conv-${i}`,
+      preview: `Conversation ${i}`,
+      messageCount: i,
+      createdAt: i,
+      updatedAt: i,
+    }));
+    const fetchMock = jest.spyOn(global, "fetch").mockResolvedValueOnce(jsonResponse(many));
+    const client = new GatewayClient("http://localhost:4000");
+
+    const result = await client.getConversations();
+    expect(result).toHaveLength(50);
+    expect(result[0]).toEqual(expect.objectContaining({ id: "conv-0" }));
+    expect(result[49]).toEqual(expect.objectContaining({ id: "conv-49" }));
+
+    fetchMock.mockRestore();
+  });
+
+  it("drops malformed conversation entries but keeps the valid ones", async () => {
+    const fetchMock = jest.spyOn(global, "fetch").mockResolvedValueOnce(jsonResponse([
+      { id: "conv-1", preview: "ok", messageCount: 1, createdAt: 1, updatedAt: 2 },
+      { id: "", preview: "empty id", messageCount: 1, createdAt: 1, updatedAt: 2 },
+      { preview: "missing id", messageCount: 1, createdAt: 1, updatedAt: 2 },
+      { id: "conv-2", preview: "ok too", messageCount: 2, createdAt: 3, updatedAt: 4 },
+    ]));
+    const client = new GatewayClient("http://localhost:4000");
+
+    await expect(client.getConversations()).resolves.toEqual([
+      expect.objectContaining({ id: "conv-1" }),
+      expect.objectContaining({ id: "conv-2" }),
+    ]);
+
+    fetchMock.mockRestore();
+  });
+
   it("creates a conversation and returns its id", async () => {
     const fetchMock = jest.spyOn(global, "fetch").mockResolvedValueOnce(jsonResponse({ id: "conv-new" }));
     const client = new GatewayClient("http://localhost:4000");

--- a/apps/mobile/app/(tabs)/apps.tsx
+++ b/apps/mobile/app/(tabs)/apps.tsx
@@ -12,9 +12,10 @@ import {
 } from "react-native";
 import { StyleSheet, useUnistyles } from "react-native-unistyles";
 import { Image } from "expo-image";
-import { Link } from "expo-router";
+import { Link, useRouter } from "expo-router";
 import { Ionicons } from "@expo/vector-icons";
 import * as Haptics from "expo-haptics";
+import { useUser } from "@clerk/clerk-expo";
 import { useGateway } from "../_layout";
 import {
   appRuntimeHref,
@@ -478,7 +479,9 @@ function appsReducer(state: AppsState, action: AppsAction): AppsState {
 export default function AppsScreen() {
   const { width } = useWindowDimensions();
   const { theme } = useUnistyles();
-  const { client, connectionState } = useGateway();
+  const router = useRouter();
+  const { user } = useUser();
+  const { client, connectionState, gateway } = useGateway();
   const [state, dispatch] = useReducer(appsReducer, initialAppsState);
   const { apps, refreshing, loading, query, lastActiveAppSlug } = state;
   const connected = connectionState === "connected";
@@ -622,13 +625,40 @@ export default function AppsScreen() {
     <View style={styles.screen}>
       <View style={styles.header}>
         <View style={styles.headerTitleGroup}>
-          <Text style={styles.headerTitle}>Apps</Text>
-          <Text style={styles.headerSubtitle}>
-            {orderedApps.length} installed{connected ? "" : " · connecting…"}
-          </Text>
+          <View style={styles.brandRow}>
+            <Image
+              source={require("../../assets/icon.png")}
+              style={styles.brandLogo}
+              contentFit="contain"
+              accessibilityLabel="Matrix OS"
+            />
+            <Text style={styles.headerTitle}>Matrix OS</Text>
+          </View>
+          <Pressable
+            accessibilityRole="button"
+            accessibilityLabel={`Switch computer, currently ${gateway?.name ?? "not connected"}`}
+            onPress={() => router.push("/computers" as never)}
+            style={({ pressed }) => [styles.computerChip, pressed ? { opacity: 0.75 } : null]}
+          >
+            <View style={[styles.computerDot, connected ? styles.computerDotOn : styles.computerDotOff]} />
+            <Text numberOfLines={1} style={styles.computerChipText}>
+              {gateway?.name ?? "Not connected"}
+              {connected ? "" : " · connecting…"}
+            </Text>
+            <Ionicons name="chevron-expand-outline" size={12} color={theme.colors.inkMuted} />
+          </Pressable>
         </View>
-        <Pressable accessibilityRole="button" accessibilityLabel="Account" style={styles.avatar}>
-          <Ionicons name="person" size={16} color="#DCE6D2" />
+        <Pressable
+          accessibilityRole="button"
+          accessibilityLabel="Account settings"
+          onPress={() => router.push("/(tabs)/settings" as never)}
+          style={({ pressed }) => [styles.avatar, pressed ? { opacity: 0.8 } : null]}
+        >
+          {user?.imageUrl ? (
+            <Image source={{ uri: user.imageUrl }} style={styles.avatarImage} contentFit="cover" />
+          ) : (
+            <Ionicons name="person" size={16} color="#DCE6D2" />
+          )}
         </Pressable>
       </View>
 
@@ -691,15 +721,46 @@ const styles = StyleSheet.create((theme, rt) => ({
     paddingTop: rt.insets.top + 10,
     paddingBottom: 14,
   },
-  headerTitleGroup: { flex: 1, minWidth: 0, gap: 3 },
+  headerTitleGroup: { flex: 1, minWidth: 0, gap: 6 },
+  brandRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 10,
+  },
+  brandLogo: {
+    width: 32,
+    height: 32,
+    borderRadius: 9,
+  },
   headerTitle: {
     fontFamily: theme.fonts.display,
-    fontSize: 34,
-    letterSpacing: -0.8,
-    lineHeight: 38,
+    fontSize: 28,
+    letterSpacing: -0.6,
+    lineHeight: 34,
     color: theme.colors.ink,
   },
-  headerSubtitle: { fontFamily: theme.fonts.mono, fontSize: 12, color: theme.colors.inkMuted },
+  computerChip: {
+    alignSelf: "flex-start",
+    maxWidth: "100%",
+    minHeight: 26,
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 6,
+    paddingHorizontal: 10,
+    borderRadius: theme.radius.full,
+    borderWidth: 1,
+    borderColor: theme.glass.border,
+    backgroundColor: theme.colors.field,
+  },
+  computerChipText: {
+    flexShrink: 1,
+    fontFamily: theme.fonts.mono,
+    fontSize: 11,
+    color: theme.colors.inkMuted,
+  },
+  computerDot: { width: 7, height: 7, borderRadius: 4 },
+  computerDotOn: { backgroundColor: theme.colors.statusRunning },
+  computerDotOff: { backgroundColor: theme.colors.statusWaiting },
   avatar: {
     width: 38,
     height: 38,
@@ -710,6 +771,12 @@ const styles = StyleSheet.create((theme, rt) => ({
     alignItems: "center",
     justifyContent: "center",
     boxShadow: theme.shadows.sm,
+    overflow: "hidden",
+  },
+  avatarImage: {
+    width: "100%",
+    height: "100%",
+    borderRadius: theme.radius.full,
   },
   searchWrap: { paddingHorizontal: 20, paddingBottom: 4 },
   searchBar: {

--- a/apps/mobile/app/(tabs)/apps.tsx
+++ b/apps/mobile/app/(tabs)/apps.tsx
@@ -627,6 +627,7 @@ export default function AppsScreen() {
         <View style={styles.headerTitleGroup}>
           <View style={styles.brandRow}>
             <Image
+              testID="apps-brand-logo"
               source={require("../../assets/icon.png")}
               style={styles.brandLogo}
               contentFit="contain"

--- a/apps/mobile/app/(tabs)/chat.tsx
+++ b/apps/mobile/app/(tabs)/chat.tsx
@@ -21,9 +21,10 @@ import Animated, {
 } from "react-native-reanimated";
 import { useGateway } from "../_layout";
 import { ChatMessage } from "@/components/ChatMessage";
+import { ChatConversationsSheet } from "@/components/ChatConversationsSheet";
 import { InputBar } from "@/components/InputBar";
 import { ConnectionBanner } from "@/components/ConnectionBanner";
-import type { ServerMessage } from "@/lib/gateway-client";
+import type { ConversationMeta, ServerMessage } from "@/lib/gateway-client";
 import {
   getCachedMessages,
   setCachedMessages,
@@ -104,6 +105,10 @@ export default function ChatScreen() {
   const [busy, setBusy] = useState(false);
   const sessionIdRef = useRef<string | undefined>(undefined);
   const [queueCount, setQueueCount] = useState(0);
+  const [activeSessionId, setActiveSessionId] = useState<string | null>(null);
+  const [conversationsVisible, setConversationsVisible] = useState(false);
+  const [conversationsLoading, setConversationsLoading] = useState(false);
+  const [conversations, setConversations] = useState<ConversationMeta[]>([]);
   const flatListRef = useRef<FlatList<Message>>(null);
   const prevConnectionState = useRef(connectionState);
   const isFocusedRef = useRef(true);
@@ -191,7 +196,12 @@ export default function ChatScreen() {
       switch (msg.type) {
         case "kernel:init":
           sessionIdRef.current = msg.sessionId;
+          setActiveSessionId(msg.sessionId);
           setBusy(true);
+          break;
+        case "session:switched":
+          sessionIdRef.current = msg.sessionId;
+          setActiveSessionId(msg.sessionId);
           break;
         case "kernel:text": {
           // Decide synchronously (the updater below runs deferred, so a flag set
@@ -291,6 +301,51 @@ export default function ChatScreen() {
     [client],
   );
 
+  const resetTranscript = useCallback(() => {
+    headIsStreamingAssistantRef.current = false;
+    setBusy(false);
+    setMessages([]);
+    void setCachedMessages([]);
+  }, []);
+
+  const conversationsOpenedAtRef = useRef(0);
+  const openConversations = useCallback(() => {
+    conversationsOpenedAtRef.current = Date.now();
+    setConversationsVisible(true);
+    if (!client) return;
+    setConversationsLoading(true);
+    void client.getConversations().then((items) => {
+      setConversations(items);
+      setConversationsLoading(false);
+    });
+  }, [client]);
+
+  const selectConversation = useCallback((id: string) => {
+    setConversationsVisible(false);
+    if (!client || id === sessionIdRef.current) return;
+    resetTranscript();
+    sessionIdRef.current = id;
+    setActiveSessionId(id);
+    client.switchSession(id);
+  }, [client, resetTranscript]);
+
+  const startNewConversation = useCallback(async () => {
+    setConversationsVisible(false);
+    if (!client) return;
+    const id = await client.createConversation();
+    if (!id) {
+      setMessages((prev) => [
+        { id: nextId(), role: "system", content: "New conversation could not be started. Try again.", timestamp: Date.now() },
+        ...prev,
+      ]);
+      return;
+    }
+    resetTranscript();
+    sessionIdRef.current = id;
+    setActiveSessionId(id);
+    client.switchSession(id);
+  }, [client, resetTranscript]);
+
   const [loadingOlder, setLoadingOlder] = useState(false);
   const hasMoreRef = useRef(true);
 
@@ -336,6 +391,26 @@ export default function ChatScreen() {
         queueCount={queueCount}
         onRetry={() => client?.connect()}
       />
+      <View style={styles.conversationBar}>
+        <Pressable
+          accessibilityRole="button"
+          accessibilityLabel="Show conversations"
+          onPress={openConversations}
+          style={({ pressed }) => [styles.conversationButton, pressed && { opacity: 0.7 }]}
+        >
+          <Ionicons name="time-outline" size={16} color={theme.colors.mutedForeground} />
+          <Text style={styles.conversationButtonText}>Conversations</Text>
+        </Pressable>
+        <Pressable
+          accessibilityRole="button"
+          accessibilityLabel="Start a new conversation"
+          onPress={() => void startNewConversation()}
+          style={({ pressed }) => [styles.conversationButton, pressed && { opacity: 0.7 }]}
+        >
+          <Ionicons name="add" size={16} color={theme.colors.mutedForeground} />
+          <Text style={styles.conversationButtonText}>New</Text>
+        </Pressable>
+      </View>
       <FlatList
         ref={flatListRef}
         data={messages}
@@ -402,6 +477,16 @@ export default function ChatScreen() {
         busy={busy}
         connected={isConnected}
       />
+      <ChatConversationsSheet
+        visible={conversationsVisible}
+        loading={conversationsLoading}
+        conversations={conversations}
+        activeSessionId={activeSessionId}
+        nowMs={conversationsOpenedAtRef.current}
+        onSelect={selectConversation}
+        onNew={() => void startNewConversation()}
+        onClose={() => setConversationsVisible(false)}
+      />
     </KeyboardAvoidingView>
   );
 }
@@ -410,6 +495,29 @@ const styles = StyleSheet.create((theme) => ({
   container: {
     flex: 1,
     backgroundColor: theme.colors.background,
+  },
+  conversationBar: {
+    flexDirection: "row",
+    justifyContent: "flex-end",
+    gap: theme.spacing.sm,
+    paddingHorizontal: theme.spacing.lg,
+    paddingTop: theme.spacing.sm,
+  },
+  conversationButton: {
+    minHeight: 32,
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 5,
+    paddingHorizontal: theme.spacing.md,
+    borderRadius: theme.radius.full,
+    borderWidth: 1,
+    borderColor: theme.colors.border,
+    backgroundColor: theme.colors.card,
+  },
+  conversationButtonText: {
+    fontFamily: theme.fonts.sansMedium,
+    fontSize: 12,
+    color: theme.colors.mutedForeground,
   },
   listContent: {
     paddingHorizontal: theme.spacing.lg,

--- a/apps/mobile/app/(tabs)/chat.tsx
+++ b/apps/mobile/app/(tabs)/chat.tsx
@@ -4,10 +4,13 @@ import {
   View,
   Text,
   FlatList,
+  Keyboard,
   KeyboardAvoidingView,
   Pressable,
   type ListRenderItemInfo,
 } from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { bottomTabBarHeight } from "@/lib/tab-bar";
 import { StyleSheet, useUnistyles } from "react-native-unistyles";
 import { useRouter, useFocusEffect } from "expo-router";
 import { useAuth } from "@clerk/clerk-expo";
@@ -308,6 +311,25 @@ export default function ChatScreen() {
     void setCachedMessages([]);
   }, []);
 
+  // The floating tab bar overlays the screen bottom; keep the input above it
+  // when the keyboard is closed (the bar hides itself on keyboard open).
+  const insets = useSafeAreaInsets();
+  const [keyboardVisible, setKeyboardVisible] = useState(false);
+  useEffect(() => {
+    const show = Keyboard.addListener(
+      process.env.EXPO_OS === "ios" ? "keyboardWillShow" : "keyboardDidShow",
+      () => setKeyboardVisible(true),
+    );
+    const hide = Keyboard.addListener(
+      process.env.EXPO_OS === "ios" ? "keyboardWillHide" : "keyboardDidHide",
+      () => setKeyboardVisible(false),
+    );
+    return () => {
+      show.remove();
+      hide.remove();
+    };
+  }, []);
+
   const conversationsOpenedAtRef = useRef(0);
   const openConversations = useCallback(() => {
     conversationsOpenedAtRef.current = Date.now();
@@ -472,11 +494,13 @@ export default function ChatScreen() {
           </View>
         }
       />
-      <InputBar
-        onSend={handleSend}
-        busy={busy}
-        connected={isConnected}
-      />
+      <View style={{ paddingBottom: keyboardVisible ? 0 : bottomTabBarHeight(insets.bottom) }}>
+        <InputBar
+          onSend={handleSend}
+          busy={busy}
+          connected={isConnected}
+        />
+      </View>
       <ChatConversationsSheet
         visible={conversationsVisible}
         loading={conversationsLoading}

--- a/apps/mobile/components/ChatConversationsSheet.tsx
+++ b/apps/mobile/components/ChatConversationsSheet.tsx
@@ -1,0 +1,213 @@
+import { ActivityIndicator, FlatList, Modal, Pressable, Text, View } from "react-native";
+import { Ionicons } from "@expo/vector-icons";
+import { StyleSheet, useUnistyles } from "react-native-unistyles";
+import type { ConversationMeta } from "@/lib/gateway-client";
+import { formatRelativeAge } from "@/lib/agent-cockpit";
+
+interface ChatConversationsSheetProps {
+  visible: boolean;
+  loading: boolean;
+  conversations: ConversationMeta[];
+  activeSessionId: string | null;
+  nowMs: number;
+  onSelect: (id: string) => void;
+  onNew: () => void;
+  onClose: () => void;
+}
+
+export function ChatConversationsSheet({
+  visible,
+  loading,
+  conversations,
+  activeSessionId,
+  nowMs,
+  onSelect,
+  onNew,
+  onClose,
+}: ChatConversationsSheetProps) {
+  const { theme } = useUnistyles();
+
+  return (
+    <Modal visible={visible} animationType="slide" presentationStyle="pageSheet" onRequestClose={onClose}>
+      <View style={styles.container}>
+        <View style={styles.header}>
+          <Text style={styles.title}>Conversations</Text>
+          <Pressable
+            accessibilityRole="button"
+            accessibilityLabel="Close conversations"
+            onPress={onClose}
+            style={({ pressed }) => [styles.closeButton, pressed ? styles.pressed : null]}
+          >
+            <Ionicons name="close" size={20} color={theme.colors.foreground} />
+          </Pressable>
+        </View>
+
+        <Pressable
+          accessibilityRole="button"
+          accessibilityLabel="Start a new conversation"
+          onPress={onNew}
+          style={({ pressed }) => [styles.newRow, pressed ? styles.pressed : null]}
+        >
+          <View style={styles.newIcon}>
+            <Ionicons name="add" size={18} color={theme.colors.primaryForeground} />
+          </View>
+          <Text style={styles.newLabel}>New conversation</Text>
+        </Pressable>
+
+        {loading ? (
+          <View style={styles.centered}>
+            <ActivityIndicator color={theme.colors.primary} />
+          </View>
+        ) : conversations.length === 0 ? (
+          <View style={styles.centered}>
+            <Ionicons name="chatbubbles-outline" size={22} color={theme.colors.mutedForeground} />
+            <Text style={styles.emptyTitle}>No recent conversations.</Text>
+            <Text style={styles.emptyBody}>Recent chats with your Matrix appear here.</Text>
+          </View>
+        ) : (
+          <FlatList
+            data={conversations}
+            keyExtractor={(item) => item.id}
+            contentContainerStyle={styles.listContent}
+            renderItem={({ item }) => {
+              const selected = item.id === activeSessionId;
+              const age = formatRelativeAge(new Date(item.updatedAt).toISOString(), nowMs);
+              return (
+                <Pressable
+                  accessibilityRole="button"
+                  accessibilityLabel={`Open conversation ${item.preview || item.id}`}
+                  accessibilityState={{ selected }}
+                  onPress={() => onSelect(item.id)}
+                  style={({ pressed }) => [styles.row, selected ? styles.rowSelected : null, pressed ? styles.pressed : null]}
+                >
+                  <View style={styles.rowIcon}>
+                    <Ionicons
+                      name={selected ? "chatbubble" : "chatbubble-outline"}
+                      size={17}
+                      color={selected ? theme.colors.primary : theme.colors.mutedForeground}
+                    />
+                  </View>
+                  <View style={styles.rowText}>
+                    <Text numberOfLines={2} style={styles.rowPreview}>
+                      {item.preview.trim() || "New conversation"}
+                    </Text>
+                    <Text numberOfLines={1} style={styles.rowMeta}>
+                      {age ? `${item.messageCount} messages · ${age}` : `${item.messageCount} messages`}
+                    </Text>
+                  </View>
+                  {selected ? <Ionicons name="checkmark" size={17} color={theme.colors.primary} /> : null}
+                </Pressable>
+              );
+            }}
+          />
+        )}
+      </View>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create((theme) => ({
+  container: { flex: 1, backgroundColor: theme.colors.background },
+  header: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    paddingHorizontal: theme.spacing.lg,
+    paddingTop: theme.spacing.lg,
+    paddingBottom: theme.spacing.md,
+  },
+  title: {
+    fontFamily: theme.fonts.displaySemiBold,
+    fontSize: 22,
+    color: theme.colors.foreground,
+  },
+  closeButton: {
+    width: 32,
+    height: 32,
+    borderRadius: 16,
+    alignItems: "center",
+    justifyContent: "center",
+    backgroundColor: theme.colors.secondary,
+  },
+  newRow: {
+    marginHorizontal: theme.spacing.lg,
+    marginBottom: theme.spacing.md,
+    minHeight: 52,
+    borderRadius: theme.radius.lg,
+    borderCurve: "continuous" as const,
+    flexDirection: "row",
+    alignItems: "center",
+    gap: theme.spacing.md,
+    paddingHorizontal: theme.spacing.md,
+    backgroundColor: theme.colors.card,
+    borderWidth: 1,
+    borderColor: theme.colors.border,
+  },
+  newIcon: {
+    width: 28,
+    height: 28,
+    borderRadius: 14,
+    alignItems: "center",
+    justifyContent: "center",
+    backgroundColor: theme.colors.primary,
+  },
+  newLabel: {
+    fontFamily: theme.fonts.sansSemiBold,
+    fontSize: 15,
+    color: theme.colors.foreground,
+  },
+  listContent: {
+    paddingHorizontal: theme.spacing.lg,
+    paddingBottom: theme.spacing["2xl"],
+    gap: theme.spacing.xs,
+  },
+  row: {
+    minHeight: 60,
+    borderRadius: theme.radius.lg,
+    borderCurve: "continuous" as const,
+    flexDirection: "row",
+    alignItems: "center",
+    gap: theme.spacing.md,
+    paddingHorizontal: theme.spacing.md,
+    paddingVertical: theme.spacing.sm,
+    backgroundColor: theme.colors.card,
+    borderWidth: 1,
+    borderColor: theme.colors.border,
+  },
+  rowSelected: {
+    borderColor: theme.colors.primary,
+    backgroundColor: theme.colors.secondary,
+  },
+  rowIcon: { width: 24, alignItems: "center" },
+  rowText: { flex: 1, minWidth: 0, gap: 2 },
+  rowPreview: {
+    fontFamily: theme.fonts.sansMedium,
+    fontSize: 14,
+    lineHeight: 19,
+    color: theme.colors.foreground,
+  },
+  rowMeta: {
+    fontFamily: theme.fonts.sans,
+    fontSize: 12,
+    color: theme.colors.mutedForeground,
+  },
+  centered: {
+    flex: 1,
+    alignItems: "center",
+    justifyContent: "center",
+    gap: theme.spacing.sm,
+    paddingHorizontal: theme.spacing.xl,
+  },
+  emptyTitle: {
+    fontFamily: theme.fonts.sansSemiBold,
+    fontSize: 15,
+    color: theme.colors.foreground,
+  },
+  emptyBody: {
+    fontFamily: theme.fonts.sans,
+    fontSize: 13,
+    textAlign: "center",
+    color: theme.colors.mutedForeground,
+  },
+  pressed: { opacity: 0.82 },
+}));

--- a/apps/mobile/components/ChatMessage.tsx
+++ b/apps/mobile/components/ChatMessage.tsx
@@ -186,7 +186,7 @@ export const ChatMessage = memo(function ChatMessage({ message, gatewayUrl, clie
         {isCode ? (
           <CodeContent content={message.content} role={message.role} />
         ) : (
-          <Text style={[styles.text, roleTextStyle(message.role)]}>
+          <Text selectable style={[styles.text, roleTextStyle(message.role)]}>
             {markdownToNodes(message.content, { ...styles.text, ...roleTextStyle(message.role) }, theme.colors.primary)}
           </Text>
         )}
@@ -364,31 +364,40 @@ function CodeContent({ content, role }: { content: string; role: Message["role"]
 const styles = StyleSheet.create((theme) => ({
   bubble: {
     maxWidth: "85%",
-    borderRadius: 16,
+    borderRadius: 20,
     borderCurve: "continuous" as const,
     paddingHorizontal: theme.spacing.lg,
     paddingVertical: 10,
   },
+  // User messages are rich forest bubbles with a "tail" corner; assistant
+  // prose sits directly on the canvas (Cursor-style) so replies read as the
+  // computer talking, not a card stack.
   bubbleUser: {
-    backgroundColor: theme.colors.primary,
+    backgroundColor: theme.colors.forest,
     alignSelf: "flex-end" as const,
+    borderBottomRightRadius: 7,
+    boxShadow: "0 2px 10px rgba(50, 61, 46, 0.16)",
   },
   bubbleAssistant: {
-    backgroundColor: theme.colors.card,
-    borderWidth: 1,
-    borderColor: theme.colors.border,
-    alignSelf: "flex-start" as const,
+    maxWidth: "100%",
+    alignSelf: "stretch" as const,
+    paddingHorizontal: theme.spacing.xs,
+    paddingVertical: 2,
   },
   bubbleSystem: {
-    backgroundColor: "rgba(239, 68, 68, 0.1)",
+    backgroundColor: "rgba(239, 68, 68, 0.08)",
+    borderWidth: 1,
+    borderColor: "rgba(239, 68, 68, 0.14)",
     alignSelf: "center" as const,
   },
   bubbleTool: {
     backgroundColor: theme.colors.secondary,
     alignSelf: "flex-start" as const,
+    borderBottomLeftRadius: 7,
+    paddingVertical: 7,
   },
-  textUser: { color: theme.colors.primaryForeground },
-  textAssistant: { color: theme.colors.cardForeground },
+  textUser: { color: theme.colors.background, fontSize: 15.5, lineHeight: 22 },
+  textAssistant: { color: theme.colors.foreground, fontSize: 15.5, lineHeight: 23 },
   textSystem: { color: theme.colors.destructive, fontSize: 12 },
   textTool: { color: theme.colors.mutedForeground, fontSize: 12, fontFamily: theme.fonts.mono },
   toolLabel: {
@@ -401,15 +410,16 @@ const styles = StyleSheet.create((theme) => ({
   },
   text: {
     fontFamily: theme.fonts.sans,
-    fontSize: 14,
-    lineHeight: 20,
+    fontSize: 15.5,
+    lineHeight: 22,
   },
   timestamp: {
     fontFamily: theme.fonts.sans,
     fontSize: 10,
-    color: theme.colors.mutedForeground,
-    marginTop: 2,
-    marginHorizontal: 4,
+    color: theme.colors.inkDim,
+    marginTop: 3,
+    marginHorizontal: 6,
+    opacity: 0.8,
   },
   codeContainer: {
     gap: 6,

--- a/apps/mobile/components/InputBar.tsx
+++ b/apps/mobile/components/InputBar.tsx
@@ -6,6 +6,7 @@ import {
   ActivityIndicator,
 } from "react-native";
 import { StyleSheet, useUnistyles } from "react-native-unistyles";
+import Animated, { useAnimatedStyle, useSharedValue, withSpring } from "react-native-reanimated";
 import { BlurView } from "expo-blur";
 import * as Haptics from "expo-haptics";
 import { Ionicons } from "@expo/vector-icons";
@@ -19,6 +20,8 @@ interface InputBarProps {
 export function InputBar({ onSend, busy, connected }: InputBarProps) {
   const { theme } = useUnistyles();
   const [text, setText] = useState("");
+  const sendScale = useSharedValue(1);
+  const sendAnimatedStyle = useAnimatedStyle(() => ({ transform: [{ scale: sendScale.value }] }));
 
   const handleSend = useCallback(() => {
     const trimmed = text.trim();
@@ -26,15 +29,18 @@ export function InputBar({ onSend, busy, connected }: InputBarProps) {
     if (process.env.EXPO_OS === "ios") {
       Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
     }
+    sendScale.value = 0.7;
+    sendScale.value = withSpring(1, { damping: 12, stiffness: 320 });
     onSend(trimmed);
     setText("");
-  }, [text, connected, onSend]);
+  }, [text, connected, onSend, sendScale]);
 
-  const canSend = text.trim().length > 0 && connected && !busy;
+  const hasText = text.trim().length > 0;
+  const canSend = hasText && connected && !busy;
 
   return (
-    <BlurView tint="systemChromeMaterial" intensity={80} style={styles.container}>
-      <View style={styles.inputRow}>
+    <BlurView tint="extraLight" intensity={40} style={styles.container}>
+      <View style={styles.inputCard}>
         <TextInput
           style={styles.input}
           value={text}
@@ -42,9 +48,9 @@ export function InputBar({ onSend, busy, connected }: InputBarProps) {
           placeholder={
             connected
               ? busy
-                ? "Thinking..."
-                : "Ask Matrix OS..."
-              : "Connecting..."
+                ? "Matrix is thinking…"
+                : "Message your Matrix…"
+              : "Connecting…"
           }
           placeholderTextColor={theme.colors.mutedForeground}
           multiline
@@ -53,25 +59,29 @@ export function InputBar({ onSend, busy, connected }: InputBarProps) {
           blurOnSubmit={false}
           returnKeyType="default"
         />
-        <Pressable
-          onPress={handleSend}
-          disabled={!canSend}
-          style={({ pressed }) => [
-            styles.sendButton,
-            canSend ? styles.sendButtonActive : styles.sendButtonDisabled,
-            pressed && canSend && styles.sendButtonPressed,
-          ]}
-        >
-          {busy ? (
-            <ActivityIndicator size="small" color={theme.colors.primaryForeground} />
-          ) : (
-            <Ionicons
-              name="arrow-up"
-              size={18}
-              color={canSend ? theme.colors.primaryForeground : theme.colors.mutedForeground}
-            />
-          )}
-        </Pressable>
+        <Animated.View style={sendAnimatedStyle}>
+          <Pressable
+            accessibilityRole="button"
+            accessibilityLabel={busy ? "Matrix is responding" : "Send message"}
+            onPress={handleSend}
+            disabled={!canSend}
+            style={({ pressed }) => [
+              styles.sendButton,
+              canSend || busy ? styles.sendButtonActive : styles.sendButtonIdle,
+              pressed && canSend && styles.sendButtonPressed,
+            ]}
+          >
+            {busy ? (
+              <ActivityIndicator size="small" color={theme.colors.primaryForeground} />
+            ) : (
+              <Ionicons
+                name="arrow-up"
+                size={17}
+                color={canSend ? theme.colors.primaryForeground : theme.colors.mutedForeground}
+              />
+            )}
+          </Pressable>
+        </Animated.View>
       </View>
     </BlurView>
   );
@@ -79,50 +89,52 @@ export function InputBar({ onSend, busy, connected }: InputBarProps) {
 
 const styles = StyleSheet.create((theme) => ({
   container: {
-    borderTopWidth: StyleSheet.hairlineWidth,
-    borderTopColor: theme.colors.border,
     overflow: "hidden" as const,
     paddingHorizontal: theme.spacing.md,
-    paddingTop: theme.spacing.sm,
-    paddingBottom: process.env.EXPO_OS === "ios" ? theme.spacing["2xl"] : theme.spacing.md,
+    paddingTop: theme.spacing.xs,
+    paddingBottom: process.env.EXPO_OS === "ios" ? theme.spacing.lg : theme.spacing.md,
   },
-  inputRow: {
+  // Floating pill: the input reads as a single object hovering over the canvas
+  // rather than a full-width toolbar strip.
+  inputCard: {
     flexDirection: "row",
     alignItems: "flex-end",
     gap: theme.spacing.sm,
-    borderRadius: theme.radius.xl,
+    borderRadius: 26,
     borderCurve: "continuous" as const,
     borderWidth: 1,
     borderColor: theme.colors.border,
-    backgroundColor: "rgba(255, 255, 255, 0.6)",
-    paddingHorizontal: theme.spacing.md,
-    paddingVertical: process.env.EXPO_OS === "ios" ? 8 : 4,
+    backgroundColor: theme.colors.card,
+    paddingLeft: theme.spacing.lg,
+    paddingRight: 6,
+    paddingVertical: 6,
+    boxShadow: "0 6px 24px rgba(50, 61, 46, 0.10), 0 1px 3px rgba(50, 61, 46, 0.06)",
   },
   input: {
     flex: 1,
     fontFamily: theme.fonts.sans,
-    fontSize: 15,
+    fontSize: 16,
+    lineHeight: 21,
     color: theme.colors.foreground,
-    minHeight: 36,
-    maxHeight: 100,
-    paddingVertical: process.env.EXPO_OS === "ios" ? 8 : 6,
+    minHeight: 38,
+    maxHeight: 120,
+    paddingVertical: process.env.EXPO_OS === "ios" ? 9 : 7,
   },
   sendButton: {
-    width: 34,
-    height: 34,
-    borderRadius: 17,
+    width: 38,
+    height: 38,
+    borderRadius: 19,
     alignItems: "center",
     justifyContent: "center",
-    marginBottom: 2,
   },
   sendButtonActive: {
-    backgroundColor: theme.colors.primary,
+    backgroundColor: theme.colors.forest,
+    boxShadow: "0 2px 8px rgba(50, 61, 46, 0.28)",
   },
-  sendButtonDisabled: {
-    backgroundColor: theme.colors.muted,
+  sendButtonIdle: {
+    backgroundColor: theme.colors.secondary,
   },
   sendButtonPressed: {
-    opacity: 0.85,
-    transform: [{ scale: 0.95 }],
+    opacity: 0.9,
   },
 }));

--- a/apps/mobile/lib/gateway-client.ts
+++ b/apps/mobile/lib/gateway-client.ts
@@ -71,6 +71,19 @@ export type ConnectionState = "disconnected" | "connecting" | "connected" | "err
 /** Canonical hosted platform origin; `/vm/<handle>` computer routes share it. */
 const HOSTED_PLATFORM_ORIGIN = "https://app.matrix-os.com";
 
+const ConversationMetaSchema = z.object({
+  id: z.string().min(1).max(128),
+  preview: z.string().max(2_000),
+  messageCount: z.number().int().min(0),
+  createdAt: z.number(),
+  updatedAt: z.number(),
+}).loose();
+
+const ConversationListSchema = z.array(ConversationMetaSchema).max(50);
+const ConversationCreateResponseSchema = z.object({ id: z.string().min(1).max(128) }).loose();
+
+export type ConversationMeta = z.infer<typeof ConversationMetaSchema>;
+
 export type ServerMessage =
   | { type: "kernel:init"; sessionId: string }
   | { type: "kernel:text"; text: string }
@@ -773,9 +786,46 @@ export class GatewayClient {
     return Array.isArray(body) ? body : [];
   }
 
-  async getConversations(): Promise<unknown[]> {
-    const res = await this.fetchGateway("/api/conversations");
-    return res.json();
+  async getConversations(): Promise<ConversationMeta[]> {
+    try {
+      const res = await this.fetchGateway("/api/conversations");
+      if (!res.ok) {
+        logGatewayStatusWarning("/api/conversations unavailable", res.status);
+        return [];
+      }
+      const parsed = ConversationListSchema.safeParse(await res.json());
+      if (!parsed.success) {
+        logGatewayWarning("/api/conversations returned invalid payload", "invalid payload");
+        return [];
+      }
+      return parsed.data;
+    } catch (err: unknown) {
+      logGatewayCatchWarning("/api/conversations unavailable", err);
+      return [];
+    }
+  }
+
+  async createConversation(): Promise<string | null> {
+    try {
+      const res = await this.fetchGateway("/api/conversations", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: "{}",
+      });
+      if (!res.ok) {
+        logGatewayStatusWarning("/api/conversations create unavailable", res.status);
+        return null;
+      }
+      const parsed = ConversationCreateResponseSchema.safeParse(await res.json());
+      if (!parsed.success) {
+        logGatewayWarning("/api/conversations create returned invalid payload", "invalid payload");
+        return null;
+      }
+      return parsed.data.id;
+    } catch (err: unknown) {
+      logGatewayCatchWarning("/api/conversations create unavailable", err);
+      return null;
+    }
   }
 
   async getApps(): Promise<MatrixAppEntry[]> {

--- a/apps/mobile/lib/gateway-client.ts
+++ b/apps/mobile/lib/gateway-client.ts
@@ -79,7 +79,11 @@ const ConversationMetaSchema = z.object({
   updatedAt: z.number(),
 }).loose();
 
-const ConversationListSchema = z.array(ConversationMetaSchema).max(50);
+// Accept any array shape here; oversized or partially-malformed lists are
+// truncated and validated per-entry in getConversations rather than rejected
+// wholesale, so a single bad entry (or >50 entries) does not blank the list.
+const CONVERSATION_LIST_LIMIT = 50;
+const ConversationListSchema = z.array(z.unknown()).catch([]);
 const ConversationCreateResponseSchema = z.object({ id: z.string().min(1).max(128) }).loose();
 
 export type ConversationMeta = z.infer<typeof ConversationMetaSchema>;
@@ -793,12 +797,13 @@ export class GatewayClient {
         logGatewayStatusWarning("/api/conversations unavailable", res.status);
         return [];
       }
-      const parsed = ConversationListSchema.safeParse(await res.json());
-      if (!parsed.success) {
-        logGatewayWarning("/api/conversations returned invalid payload", "invalid payload");
-        return [];
+      const raw = ConversationListSchema.parse(await res.json());
+      const conversations: ConversationMeta[] = [];
+      for (const item of raw.slice(0, CONVERSATION_LIST_LIMIT)) {
+        const parsed = ConversationMetaSchema.safeParse(item);
+        if (parsed.success) conversations.push(parsed.data);
       }
-      return parsed.data;
+      return conversations;
     } catch (err: unknown) {
       logGatewayCatchWarning("/api/conversations unavailable", err);
       return [];

--- a/apps/mobile/lib/tab-bar.ts
+++ b/apps/mobile/lib/tab-bar.ts
@@ -1,0 +1,8 @@
+/**
+ * The bottom tab bar is an absolute overlay (frosted, anchored to the screen
+ * edge), so tab screens with their own bottom-anchored UI must pad by its
+ * height. Single source of truth shared by the tabs layout and screens.
+ */
+export function bottomTabBarHeight(insetsBottom: number): number {
+  return (process.env.EXPO_OS === "ios" ? 56 : 60) + insetsBottom;
+}

--- a/specs/105-coding-agent-shells/mobile-design-review.md
+++ b/specs/105-coding-agent-shells/mobile-design-review.md
@@ -1,0 +1,212 @@
+# Matrix OS Mobile — Design & UX Review
+
+**Reviewer:** principal product designer (review-only)
+**Scope:** `apps/mobile` (Expo, iOS-first) — every screen read in full
+**Bar:** Cursor's iPhone app (calm near-white surfaces, one focal action, agent status as first-class UI)
+**Brand anchor:** `packages/brand/` + `www/` landing (matrix-os.com) — "a computer in the cloud for your AI agents"
+**Date:** 2026-07-13
+
+---
+
+## 1. Executive summary — the 5 highest style-per-effort changes
+
+The app is not a hackathon demo. It has a genuinely mature token layer (`lib/theme.ts`), a legitimately excellent terminal surface, real haptics, well-written empty states, and one screen — the Apps launcher (`app/(tabs)/apps.tsx`) — that is already at the target quality bar. The problem is **inconsistency**: the newest screen uses the polished "botanical" token set (`paper/panel/ink/glow/display/shadows`), while the older screens (agents, files, computers, chat, settings) use a legacy shadcn-ish set (`background/card/foreground/primary`) and let color do almost no work. The result reads as two apps stitched together, and neither one is quite as warm as matrix-os.com.
+
+The five changes with the best return:
+
+1. **Warm the surface palette to match the website (S, `theme.ts` only).** The site is warm oat + cream (`pageBg #EEEEE2`, `card #FCFCF8`, `border #DCD9CC`); the app is cool near-white (`paper #FAFAF9`, `panel #FFFFFF`, `line #E7E9E3`). Retuning ~6 hex values instantly makes the whole app feel like the same product as the landing page. Single highest leverage move in the review.
+
+2. **Ship one `StatusPill` primitive and wire it everywhere (M).** Cursor's signature is agent status as first-class UI (Working / Finished / N Active). Matrix already defines the exact tokens for this (`statusWaiting/Running/Idle/Done`, plus `success/warning/destructive/add/del`) — and **barely uses them**. Today a failed run, a running run, and a done run look identical (flat sage or raw enum text) on the thread, provider, terminal, and computer screens. Making color mean something is the single change that most closes the gap to Cursor while staying botanical.
+
+3. **Fix the primary-button system (S/M).** The website's primary CTA is a deep near-black-forest pill (`deep #32352E`) with cream text. The app's primary is pale sage `primary #9AA48C` with a **mismatched ember drop-shadow** (`rgba(194,112,58,0.2)`) — low contrast and muddy (`app/index.tsx:269`, `sign-in.tsx:406`, `mission-control` FAB `:764`). Move primary → deep forest, demote sage to secondary/selected, reserve ember `#D06F25` as the single accent.
+
+4. **Extract `Button` / `Card` / `StatusPill` primitives and adopt `paper/panel/ink` + the `type` scale app-wide (L, foundational).** There is a token kit but **no component kit** — buttons, cards, and pills are re-styled per screen and `STATUS_COLORS` is copy-pasted three times (`TaskCard.tsx:20`, `TaskDetail.tsx:15`, `ChannelBadge.tsx:10`). Extracting three primitives lets every legacy screen inherit apps.tsx quality and unblocks dark mode. Stage it screen-by-screen behind items 1–3.
+
+5. **Redeem the launch / connect moment (M, signature).** Provisioning your own cloud computer — the emotional peak of onboarding — is currently a bare centered `ActivityIndicator` + one line of body text (`JourneyGate.tsx:122-129`), even though staged progress data (`journey.progress.stage`) is available. Turn it into a branded, staged reveal. This is the moment worth showing a friend.
+
+Two near-free cleanups riding along: **wire or hide the Appearance theme toggle** (it saves `settings.theme` but nothing applies it — `settings.tsx:372`, `unistyles.ts:84` — so "Dark"/"System" do nothing today), and **humanize the machine strings** (raw ISO timestamps, `thread.id`, provider ids, `available - installed / authenticated`, `@@ -a,b +c,d @@`, byte counts) that leak across the agents surface.
+
+---
+
+## 2. Visual direction — fusing Cursor's calm with Matrix botanical
+
+The target is not "make Matrix look like Cursor." It's: **take Cursor's discipline (calm surfaces, one focal action, status-as-UI, restrained motion) and express it in Matrix's warm botanical, owner-controlled voice.** Cursor is cool graphite-on-white; Matrix is warm forest-on-paper. Keep the warmth.
+
+### 2.1 Color — warm the surfaces, let status carry the color
+
+The one token both systems already share is **ember `#D06F25`** — keep it as the singular accent. Everything else should migrate toward the website's warmth.
+
+| Role | Mobile today (`theme.ts`) | Website (`packages/brand/tokens.ts`) | Recommendation |
+|---|---|---|---|
+| App background | `paper #FAFAF9` (cool) | `pageBg #EEEEE2` (warm oat) | Warm to ~`#F4F2EA` (a middle ground; full `#EEEEE2` if you want to fully commit) |
+| Card / panel | `panel #FFFFFF` (pure white) | `card #FCFCF8` (cream) | `#FCFCF8` — pure white is the #1 "generic SaaS" tell |
+| Hairline border | `line #E7E9E3` (cool grey-green) | `border #DCD9CC` (warm taupe) | Warm to ~`#DCD9CC` |
+| Muted text | `inkMuted #6B756B` | `mutedFg #5C5A4F` / `subtle #7A7768` | Warm slightly toward `#5C5A4F` |
+| Ink / foreground | `ink #1A1D18` | `deep #32352E` | Keep `ink` for body; use `deep #32352E` for the primary button fill |
+| Primary CTA | `primary #9AA48C` (pale sage) | `deep #32352E` w/ cream text | **Change:** deep forest pill, cream text |
+| Accent | `glow #D06F25` (under-used) | `ember #D06F25` | Keep — make it the *only* accent (focus, attention dot, key highlight) |
+
+**Sage `#9AA48C` demotes from "primary" to "secondary / selected."** It's a lovely calm tone but it's low-contrast as a button on near-white and it's doing the job the deep forest should. Selected chips, active filters, and toggles can stay sage; primary actions go deep.
+
+### 2.2 Status-pill system (the load-bearing decision)
+
+Define one tone set, back it with the existing tokens, and route **every** status through it. Model the shape on the website's `StatusPill` (radius `full`, tinted bg + solid fg — `packages/brand/src/primitives.tsx:60`):
+
+| State | Fg token | Bg (tint of fg) | Where |
+|---|---|---|---|
+| Working / Running | `forest #323D2E` | `field`/forest 8% | agent running, terminal attached |
+| Waiting / Needs you | `glow #D06F25` (ember) | ember 10% | approval pending, `payment_settling`, attention |
+| Queued / Starting | `accentInk #4E6A4A` | forest 6% | run queued |
+| Done / Ready | `#3B6D11` (website's green fg) or `add #3F7D4E` | green 8% | run complete, connected |
+| Idle | `inkDim #9AA098` | line | dormant session |
+| Error / Failed | `destructive #ef4444` | red 8% | failed run, offline |
+
+Leading affordance: a **dot** for steady states, a **small spinner** for in-flight (`running`, `provisioning`, `connecting`). "N Active" counts (cockpit) use the ember tint. This one component, consistently applied, is what will make people say "it feels like Cursor."
+
+### 2.3 Typography
+
+The biggest brand-coherence gap after color: **the website's display face is Instrument Serif** (`brand/tokens.ts` → `fonts.display`), an elegant serif, while the app's display face is **Bricolage Grotesque** (`theme.ts:102`), a chunky grotesque. The two hero moments don't feel like the same brand.
+
+- **Bring Instrument Serif into the app for hero moments only** — the landing/sign-in headline, the JourneyGate provisioning headline, and large empty-state headlines. Serifs are gorgeous at 28–40px and unmistakably Matrix; they're bad at 12–15px, so **do not** use it for UI. (If shipping another font weight is unwelcome, the fallback is to at least stop scaling Bricolage past 30px and accept the mismatch — but the serif is the right call and it's a small asset.)
+- **Keep Inter for all UI** and JetBrains Mono for metadata/paths/section labels (the mono uppercase section label at `apps.tsx:734` and `settings.tsx:461` is a genuine brand signature — protect it).
+- **Adopt the `type` scale (`theme.ts:125-135`) everywhere.** Right now every screen re-declares font sizes inline and the de-facto title size (24px Bricolage) matches no token (`h1` is 22, `display` is 30). Route titles through `type.display`/`type.h1` so hierarchy stops drifting per screen.
+
+### 2.4 Card / radius / shadow / motion language
+
+- **Radius:** standardize on `lg 12` (rows/inputs), `xl 16`–`xl2 20` (cards/sheets), `full` (pills). The app is already close; just make `borderCurve: "continuous"` (iOS squircle) **universal** — it's applied in apps.tsx/WindowHeader but missing on the Files and Computers cards, so corners visibly disagree.
+- **Shadow:** use the forest-tinted `shadows.*` (`theme.ts:139-144`) — never plain black. Today only apps.tsx uses them; `GatewayCard.tsx:62` and `TaskCard.tsx:70` hardcode `rgba(0,0,0,0.04)`. For the calm look, prefer the website's very diffuse, no-offset shadow feel (`cardShadow = 0 0 7.5rem rgba(50,53,46,0.09)`) over tight drop-shadows.
+- **Motion principles:** entrance fades that respect direction (ChatMessage's `FadeInLeft/Right` at `ChatMessage.tsx:47` is exactly right); press = `scale 0.97 + opacity` (apps.tsx grid cell at `:763` is the reference); status changes cross-fade rather than pop; **no bouncy springs** except the one place it earns delight (the connect moment). Add skeletons for the surfaces that currently flash a bare spinner. Keep motion quiet — calm is the brand.
+
+---
+
+## 3. Screen-by-screen findings (ranked, with fixes)
+
+### Entry / auth
+
+**`app/index.tsx` (landing)** — the first impression undersells the product.
+- **Copy is generic dev-tool, not the brand voice.** "Your AI operating system / Native access to your shell, apps, channels, and agent kernel" (`:168-171`) vs the website's "A computer in the cloud for your AI agents." **Fix:** adopt the website's noun ("your cloud computer") and warmth.
+- **Only a "Sign In" button** (`:176`), no "Get started." The website leads with "Get started." **Fix:** primary "Get started" (deep forest) + text "Sign in" secondary.
+- **Primary button is pale sage with an ember shadow** (`:260-270`) — low contrast, muddy. **Fix:** deep-forest pill, cream text, drop the orange glow.
+- Hero uses Bricolage at 36px (`:235`). **Fix:** Instrument Serif here.
+
+**`app/sign-in.tsx`** — structurally the strongest auth screen; keep it.
+- Good: "Computer URL" panel, `field`-filled inputs, cloud/self-hosted split, sensible keyboard handling. This already frames a *computer*, not a server.
+- Google as a full sage-primary button with ember shadow (`:394-406`) inverts platform convention and repeats the muddy-shadow problem. **Fix:** neutral/white provider buttons; reserve the deep-forest primary for the single most-likely action.
+
+**`components/JourneyGate.tsx`** — **the biggest missed moment in the app** (see §4).
+- Every phase is a centered spinner + title + one line of body (`:122-129`). Provisioning your own computer deserves staged progress, brand, and delight.
+- `title` uses `forest` and `body` uses `forest @ 0.8 opacity` (`:159-160`) — fine, but flat. **Fix:** see §4A.
+
+### Tabs
+
+**`app/(tabs)/apps.tsx` — the internal north star. Protect it; don't churn it.**
+- Uses `paper/panel/field/ink/inkMuted/glow`, `display` at 34px, `shadows.card`, `glass.border`, squircle tiles, monogram fallbacks with gloss, "Jump back in" recent card, mono uppercase section labels. This is the quality bar the rest of the app should meet.
+- Only nits: the top-right **avatar button has no `onPress`** (`:630`) — dead control; wire it to account/settings. Section label + grid spacing is the pattern to copy elsewhere.
+
+**`app/(tabs)/chat.tsx`** — good bones, legacy tokens.
+- Strong: animated typing indicator (reanimated, `:51`), "Try asking" suggestion chips as onboarding (`:449`), offline queue banner. Empty state follows the UX-guide pattern.
+- Uses `background/card/border/primary` not `paper/panel/ink` — reads cooler/flatter than apps.tsx. Conversation bar buttons are 32px tall (`:507`, under 44). **Fix:** adopt the warm tokens; bump the pills.
+
+**`app/(tabs)/terminal.tsx` + `WindowHeader` + `TerminalControlBar` — a genuine strength. Protect.**
+- Full-bleed dark console, terminal-tone `WindowHeader` with double-tap maximize and compacting chrome, cursor-aware keyboard lift, detected-URL banner, session handoff/resume, expandable 6-row accessory keyboard with a variant/size system and a danger-styled Ctrl-C. This is the most polished, most "product" part of the app and shows real terminal-domain craft. **Do not refactor for consistency's sake** — instead, harvest its ideas (the `key()` variant factory, the tone system) into the shared primitives.
+- One gap: the control-bar keys and the maximize gesture fire **no haptic** despite being the app's most tactile surface. **Fix:** add selection/impact haptics to keys and the maximize toggle.
+
+**`app/(tabs)/settings.tsx`** — clean iOS grouped list; two problems.
+- **The Appearance theme toggle is decorative** — `settings.theme` is saved (`:384`) but nothing calls `UnistylesRuntime.setTheme`/`setAdaptiveThemes` (`unistyles.ts:84` keeps `initialTheme:"light"`, adaptive commented out). Selecting Dark/System does nothing. **Fix:** wire it (dark mode is close — see §5) or hide it until dark ships. A control that lies is a trust tell.
+- Section labels are sage mono on near-white — low contrast. Raw `systemInfo.version`/`model` strings (`:416-421`). Mobile also surfaces **Agent / Channels / Security** sections that the web shell hides for paid-beta (per repo `HIDDEN_SECTION_IDS`) — confirm that's intended on mobile.
+
+### Agents (the surface most in need of love — see the detailed sub-report basis below)
+
+**`app/agents/_layout.tsx`** — uses **default iOS `Stack` headers** with plain titles ("Agents", "New Run", "Agent Thread"), unlike the custom `WindowHeader` chrome everywhere else. Inconsistent nav identity. **Fix:** align to the app's header language.
+
+**`components/agent-cockpit.tsx`** — second-best screen in the app after apps.tsx; the model for "agent status as UI."
+- Strong focal quick-start CTA (forest bg, radius 20, `shadows.raised`, human copy "What do you want Matrix to build?", `:216`), `statusLabel` mapping running→"Working" (`:30`), "N working" / attention-count chips, hairline-divided thread rows (`:412`), relative-age formatting, selection haptics. **This is where the StatusPill and "N Active" system should crystallize, then propagate.**
+- Nit: the per-project "+" is 28×28 (`:156`), under 44.
+
+**`app/agents/[threadId].tsx`** — the "unfinished" concentration.
+- **Status is bare `forest` text, not color-coded** (`:1086`) — running/failed/done look identical.
+- **Inline error renders in `moss` green** (`:1153`) — an error styled as the calm brand green. Wrong; use `destructive`.
+- Leaks raw machine data: ISO `updatedAt` (`:257`), raw `thread.id`, `terminalSessionId`, provider shown as **mono id** not display name, and timeline strings expose `event.outcome/requestId/status/decision` enums.
+- No haptic on approve/decline/send (highest-stakes actions). **Fixes:** StatusPill on the header; `destructive` for errors; `formatRelativeAge` for timestamps (the cockpit already has it); friendly provider names; haptics on approve/decline.
+
+**`app/agents/new.tsx` / `AgentComposerScreen.tsx`** — the composer is solid: proper segmented mode control (`:745`), 48px bottom-anchored Start CTA (the one primary that clears 44pt), real disabled states, good keyboard handling. **Add** a haptic on Start-run. Provider availability shows as capitalized subtitle text — convert to StatusPill.
+
+**`app/agents/providers.tsx`** — clean notifications block, but auth status renders as **capitalized moss text** and setup rows show a raw `available - installed / authenticated` machine string (`:369`). **Fix:** StatusPill for auth state; human phrasing.
+
+**`app/agents/reviews.tsx`** — the most dev-tool screen. Titles are raw `projectId` (`:652`), literal `@@ -a,b +c,d @@` hunk ranges (`:1181`), byte counts/etags, canned commit copy, text-only loading states (no spinner), 30px Save/Open buttons. **Fix:** friendly project names, hide/soften diff internals, StatusPill for review state, spinners on load, 44pt controls. Good bit to keep: high-severity finding counts already turn red (`:657`).
+
+**`app/agents/terminals.tsx`** — session status is raw moss text; **unavailable sessions look identical to active ones** (`disabled` set but no visual state, `:99`). **Fix:** StatusPill + a real disabled treatment.
+
+### Files & Computers
+
+**`app/files.tsx` + `components/files/*`** — competent, legacy tokens, no page identity.
+- No "Files" title/header — just breadcrumbs + search (`:365`). Friendly empty/unpreviewable copy (protect). Retry pill 40px (under 44). FileRow git-status pill uses `primary`/`secondary` with **no add/del color coding** despite `add`/`del` tokens existing. FileBreadcrumbs tap rows ~23px tall (`:59`). **Fixes:** add a page title in the warm/`display` style; color the git badges; warm the tokens.
+
+**`app/computers.tsx` + `components/GatewayCard.tsx`** — **reads as a generic server inventory, not "your owned cloud computer."**
+- Infrastructure language ("Choose computer / Switch **runtimes**", `server-outline`/`desktop-outline` icons, `@handle`, raw `versionLabel`, `gateway.url` IP:port in mono). Status pill renders the **raw availability enum, always colored sage** regardless of building/available (`:174,206`). Remove is a hidden long-press → `Alert`. Left-in `console.warn` (`:87`). Badge bg is hardcoded ember-ish with sage text (`GatewayCard.tsx:106`) — a mismatched warm-bg/cool-fg combo.
+- **This is a signature surface** (choosing *your* computer) rendered as the blandest list in the app. **Fixes:** personal framing ("Your computers"), a hero card for the active machine (region/specs/uptime, not just handle/version), StatusPill with a **building spinner/pulse**, a haptic on selection, and warm tokens. Make it feel owned and alive.
+
+**`components/ConnectionBanner.tsx`** — too quiet, and jargony.
+- Offline is styled as calmly as connecting (`secondary` bg, `forest` text, `:28`) with **no red/amber escalation**; the "Connecting" icon is static (no spin); copy says "Chat **socket** offline" (`:16`) — developer jargon. **Fixes:** escalate offline to a `destructive`/`warning` tint, spin the connecting icon, and say "Reconnecting to your computer…".
+
+---
+
+## 4. Signature moments to invest in
+
+Three-to-four interactions that make people show the app to a friend. Protect the two that already work; build the two that don't.
+
+**A. The launch / connect moment (build — highest emotional payoff).**
+Onboarding provisions *your own computer*. Today: a spinner (`JourneyGate.tsx`). Turn it into a staged reveal: a warm full-screen scene, Instrument-Serif headline in the brand voice ("Building your computer in the cloud"), a **stepped progress checklist** driven by the existing `journey.progress.stage` (allocating → installing → booting services → ready) with each step animating to a green check, ember as the active-step accent, and a satisfying "Your computer is ready" hand-off into the launcher. This is the "your agents in your pocket" story made physical.
+
+**B. Agent status pills + "N Active" (build — the Cursor hallmark).**
+The cockpit already coins "Working"/"N working." Promote it into the shared `StatusPill` and put it on the thread header, the agents list, notifications, and the tab-bar/app-icon badge. When someone opens the app to a botanical **"3 Active · 1 needs you"** and taps into a live "Working" run, that's the Cursor-parity beat — in Matrix's warm palette.
+
+**C. Lock-screen / notification presence (build on existing wiring).**
+`lib/push.ts` already routes `agent`/`task`/`cron`/`message`/`security` notifications (agent → `/agents/[threadId]`) and sets badges/banners. The design work is **rich, branded content**: "✅ Claude finished on `web-refactor`" / "⏸ Codex needs your approval," with actionable buttons (Approve / View) so work unblocks from the lock screen. This is the literal product promise ("stay in the loop, unblock from your phone") and it's mostly a content/notification-category design task, not new infra.
+
+**D. The springboard + terminal attach (protect — already signature).**
+The Apps launcher (warm squircles, "Jump back in," monogram fallbacks) and the terminal attach/resume (full-bleed console, cursor-aware lift, control bar) are already show-a-friend good. Don't refactor them into blandness in the name of consistency — instead, pull *their* warmth and craft into the shared kit.
+
+---
+
+## 5. Phased implementation plan
+
+### Phase 1 — Polish (days). Warmth + color doing work. No structural change.
+- **[S]** Retune surface tokens to the website's warmth (`lib/theme.ts`): `paper`→~`#F4F2EA`, `panel`→`#FCFCF8`, `line`→`#DCD9CC`, warm `inkMuted`. Ship dark values in the same pass so item below can flip.
+- **[S]** Primary-button fix: deep-forest fill + cream text; drop ember shadows (`app/index.tsx:260`, `sign-in.tsx:394`, `mission-control.tsx:754` FAB).
+- **[S]** Landing copy + Instrument-Serif hero (`app/index.tsx:168`); add "Get started."
+- **[S]** Wire **or** hide the Appearance toggle (`settings.tsx:372` ↔ `unistyles.ts:79`).
+- **[S]** Fix green error text → `destructive` (`app/agents/[threadId].tsx:1153`); escalate `ConnectionBanner` offline color + spin icon + de-jargon copy.
+- **[S]** Humanize the worst machine strings: relative timestamps (reuse cockpit's `formatRelativeAge`), provider display names, drop raw `available - installed / authenticated` (`providers.tsx:369`), remove left-in `console.warn` (`computers.tsx:87`).
+- **[S]** `borderCurve:"continuous"` on Files/Computers cards; forest-tinted `shadows.*` in place of hardcoded black (`GatewayCard.tsx:62`, `TaskCard.tsx:70`).
+
+### Phase 2 — Structure (≈week). One kit, applied.
+- **[M]** Extract `StatusPill` (tone set from §2.2) and delete the three duplicated `STATUS_COLORS` maps (`TaskCard.tsx:20`, `TaskDetail.tsx:15`, `ChannelBadge.tsx:10`).
+- **[M]** Extract `Button` (primary/secondary/danger) and `Card` primitives; route apps.tsx's recipe through them.
+- **[M]** Wire StatusPill through agents (`[threadId]` header, list, providers auth, terminals sessions), computers availability (with building spinner), tasks, cron, review state.
+- **[M]** Migrate agents/files/computers/chat/settings from legacy tokens to `paper/panel/ink` + the `type` scale; add page titles in the warm `display` style where missing (Files, Computers).
+- **[S]** Align `app/agents/_layout.tsx` nav chrome to the app's header language.
+- **[S]** Bump sub-44pt controls (cockpit "+" `:156`, review Save/Open `:30`, breadcrumbs, chat conversation pills); add missing haptics (composer Start, approve/decline, terminal keys, computer select).
+- **[M]** Complete dark mode: finish `colors.dark` botanical tokens, replace hardcoded white/black fills (`InputBar.tsx:97`, `ChatMessage` code bgs), then enable the settings toggle.
+
+### Phase 3 — Signature (later). The show-a-friend beats.
+- **[M]** JourneyGate staged provisioning reveal (§4A) — serif headline, stepped checklist off `journey.progress.stage`, ember active accent, ready hand-off.
+- **[M]** Cockpit "N Active · N needs you" summary + tab-bar/app-icon badge (§4B).
+- **[M]** Rich, actionable agent notifications (Approve/View from lock screen) on top of `lib/push.ts` (§4C).
+- **[M]** Computers screen as an owned-computer hero (active machine card w/ region/specs/uptime, alive status) (§4D basis).
+- **[S/M]** Quiet motion pass: cross-fade status changes, skeletons replacing bare spinners (files, reviews, thread), the one earned spring at connect.
+
+---
+
+## 6. Explicitly OUT — what NOT to copy from Cursor
+
+- **Don't go cool/graphite.** Cursor is cool-neutral on white; copying that palette would erase Matrix's warm botanical identity. Keep forest/moss/ember/paper — warm, not clinical.
+- **Don't frame it as a code editor / dev tool.** Cursor's story is "AI code editor." Matrix's is "your owned cloud computer" (OS + agents + apps + terminal, owner-controlled data). Keep computer/owner language ("your computer," "runs after your laptop closes"), not "workspace/IDE." This also means: don't strip the Apps launcher, Chat, or the non-coding surfaces to look like a pure coding-agent client — the breadth *is* the product.
+- **Don't over-minimize to a single-purpose feed.** Cursor can be one focal action per screen because it does one thing. Matrix is an OS; preserve the launcher/tabs breadth. Apply Cursor's *focus discipline within* each screen, not Cursor's *scope*.
+- **Don't chase heavy/animated marketing motion.** Keep motion calm and functional (status, entrance, connect). The brand is warm and quiet; flashy motion would fight it.
+- **Don't adopt pure-white cards or a mono-accent graphite system** — that's the exact "generic SaaS" look the warm cream surfaces are meant to avoid.
+- **Don't hide ownership behind "server/runtime" abstraction** even though it's technically accurate — that's the opposite of the "your computer" promise the whole review is trying to strengthen.
+
+---
+
+*Grounding: every claim cites a file/line read during this review. Strengths intentionally called out to protect (Apps launcher, terminal/WindowHeader/TerminalControlBar, cockpit quick-start, ChatMessage code blocks + haptics, empty-state copy) — the plan builds on them, it does not churn them.*


### PR DESCRIPTION
Stacked on #953 (`105-mobile-terminal-ux`).

## What

The Chat tab was a single implicit session — no way to see past conversations or start a fresh one.

- **Conversations sheet**: pill button above the transcript opens a page sheet listing conversations from `GET /api/conversations` (preview, message count, relative age; bounded Zod parsing; active row marked). Tap to switch — transcript resets and the existing WS `switch_session` flow re-attaches with replay.
- **New conversation**: `POST /api/conversations` → switch to the returned id; failure surfaces a generic system message.
- Session identity now tracked in state (`kernel:init` + `session:switched`) so the sheet marks the active conversation.

## Invariants

- **Source of truth**: gateway conversation store (`~/system/conversations`); the client never persists conversation metadata — the sheet loads fresh on open.
- **Switching**: local transcript + cache reset before `switch_session`; replayed frames flow through the existing reducer unchanged.
- **Bounded parsing**: list capped at 50, preview at 2k chars; invalid payloads degrade to an empty list with a logged generic warning.
- **Deferred scope**: full transcript hydration on switch requires a `GET /api/conversations/:id` gateway route (does not exist yet — flagged as a backend ask); until then history appears only as the agent streams. Conversation delete/rename not included.

## Tests

42 suites / 465 tests passing; `tsc --noEmit`; `expo lint` clean. New: conversation list parsing/tolerance, create-conversation id/error paths.

## Validation

Needs on-device smoke (open sheet, switch conversations, new conversation while connected to pr-919). Screenshots to be attached by owner.