### PR TITLE
feat(gateway): add kernel conversation history

### DIFF
--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -237,6 +237,42 @@ export type MatrixComputerCapabilityId = z.infer<typeof MatrixComputerCapability
 export type MatrixComputer = z.infer<typeof MatrixComputerSchema>;
 export type MatrixComputerList = z.infer<typeof MatrixComputerListSchema>;
 
+export const KernelConversationIdSchema = z.string()
+  .min(1)
+  .max(256)
+  .regex(/^[A-Za-z0-9][A-Za-z0-9_.:-]{0,255}$/, "Invalid conversation id")
+  .refine((value) => !value.includes(".."), { message: "Invalid conversation id" });
+
+export const KernelConversationHistoryQuerySchema = z.object({
+  cursor: z.coerce.number().int().min(1).max(1_000_000).optional(),
+  limit: z.coerce.number().int().min(1).max(50).default(50),
+}).strict();
+
+export const KernelConversationHistoryMessageSchema = z.object({
+  index: z.number().int().min(0).max(1_000_000),
+  role: z.enum(["user", "assistant", "system"]),
+  content: z.string().max(32_000),
+  contentTruncated: z.boolean(),
+  timestamp: z.number().int().min(0).max(Number.MAX_SAFE_INTEGER),
+  tool: z.string().min(1).max(128).optional(),
+}).strict();
+
+export const KernelConversationHistoryResponseSchema = z.object({
+  id: KernelConversationIdSchema,
+  createdAt: z.number().int().min(0).max(Number.MAX_SAFE_INTEGER),
+  updatedAt: z.number().int().min(0).max(Number.MAX_SAFE_INTEGER),
+  totalCount: z.number().int().min(0).max(1_000_000),
+  messages: z.array(KernelConversationHistoryMessageSchema).max(50),
+  hasMore: z.boolean(),
+  nextCursor: z.string().regex(/^[1-9][0-9]{0,6}$/).optional(),
+  limit: z.number().int().min(1).max(50),
+}).strict();
+
+export type KernelConversationId = z.infer<typeof KernelConversationIdSchema>;
+export type KernelConversationHistoryQuery = z.infer<typeof KernelConversationHistoryQuerySchema>;
+export type KernelConversationHistoryMessage = z.infer<typeof KernelConversationHistoryMessageSchema>;
+export type KernelConversationHistoryResponse = z.infer<typeof KernelConversationHistoryResponseSchema>;
+
 export const RuntimeSelectionRequestSchema = z.object({
   slot: MatrixComputerRuntimeSlotSchema,
 }).strict();

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -244,12 +244,12 @@ export const KernelConversationIdSchema = z.string()
   .refine((value) => !value.includes(".."), { message: "Invalid conversation id" });
 
 export const KernelConversationHistoryQuerySchema = z.object({
-  cursor: z.coerce.number().int().min(1).max(1_000_000).optional(),
+  cursor: z.coerce.number().int().min(1).max(Number.MAX_SAFE_INTEGER).optional(),
   limit: z.coerce.number().int().min(1).max(50).default(50),
 }).strict();
 
 export const KernelConversationHistoryMessageSchema = z.object({
-  index: z.number().int().min(0).max(1_000_000),
+  index: z.number().int().min(0).max(Number.MAX_SAFE_INTEGER),
   role: z.enum(["user", "assistant", "system"]),
   content: z.string().max(32_000),
   contentTruncated: z.boolean(),
@@ -261,10 +261,15 @@ export const KernelConversationHistoryResponseSchema = z.object({
   id: KernelConversationIdSchema,
   createdAt: z.number().int().min(0).max(Number.MAX_SAFE_INTEGER),
   updatedAt: z.number().int().min(0).max(Number.MAX_SAFE_INTEGER),
-  totalCount: z.number().int().min(0).max(1_000_000),
+  totalCount: z.number().int().min(0).max(Number.MAX_SAFE_INTEGER),
   messages: z.array(KernelConversationHistoryMessageSchema).max(50),
   hasMore: z.boolean(),
-  nextCursor: z.string().regex(/^[1-9][0-9]{0,6}$/).optional(),
+  nextCursor: z.string()
+    .min(1)
+    .max(16)
+    .regex(/^[1-9][0-9]*$/)
+    .refine((value) => Number.isSafeInteger(Number(value)), { message: "Invalid history cursor" })
+    .optional(),
   limit: z.number().int().min(1).max(50),
 }).strict();
 

--- a/packages/gateway/src/server.ts
+++ b/packages/gateway/src/server.ts
@@ -224,6 +224,7 @@ import {
 } from "./server/symphony-origin.js";
 import { registerAppRuntimeRoutes } from "./server/app-runtime-routes.js";
 import { registerFileRoutes } from "./server/file-routes.js";
+import { registerConversationHistoryRoutes } from "./server/conversation-history-routes.js";
 import {
   metricsRegistry,
   httpRequestsTotal,
@@ -3336,6 +3337,8 @@ export async function createGateway(config: GatewayConfig) {
       return c.json({ error: "Integration call failed" }, 502);
     }
   });
+
+  registerConversationHistoryRoutes(app, { conversations });
 
   app.get("/api/conversations", (c) => {
     return c.json(conversations.list());

--- a/packages/gateway/src/server/conversation-history-routes.ts
+++ b/packages/gateway/src/server/conversation-history-routes.ts
@@ -1,0 +1,62 @@
+import {
+  KernelConversationHistoryQuerySchema,
+  KernelConversationHistoryResponseSchema,
+  KernelConversationIdSchema,
+} from "@matrix-os/contracts";
+import type { Hono } from "hono";
+import type { ConversationStore } from "../conversations.js";
+
+const MAX_HISTORY_CONTENT_CHARS = 32_000;
+
+export interface ConversationHistoryRouteDeps {
+  conversations: ConversationStore;
+}
+
+export function registerConversationHistoryRoutes(
+  app: Hono,
+  deps: ConversationHistoryRouteDeps,
+): void {
+  app.get("/api/conversations/:id", (c) => {
+    const id = KernelConversationIdSchema.safeParse(c.req.param("id"));
+    const query = KernelConversationHistoryQuerySchema.safeParse(c.req.query());
+    if (!id.success || !query.success) {
+      return c.json({ error: "Invalid conversation history request." }, 400);
+    }
+
+    try {
+      const conversation = deps.conversations.get(id.data);
+      if (!conversation) {
+        return c.json({ error: "Conversation unavailable. Refresh and try again." }, 404);
+      }
+
+      const totalCount = conversation.messages.length;
+      const end = Math.min(query.data.cursor ?? totalCount, totalCount);
+      const start = Math.max(0, end - query.data.limit);
+      const messages = conversation.messages.slice(start, end).map((message, offset) => ({
+        index: start + offset,
+        role: message.role,
+        content: message.content.slice(0, MAX_HISTORY_CONTENT_CHARS),
+        contentTruncated: message.content.length > MAX_HISTORY_CONTENT_CHARS,
+        timestamp: message.timestamp,
+        ...(message.tool ? { tool: message.tool.slice(0, 128) } : {}),
+      }));
+
+      const response = KernelConversationHistoryResponseSchema.parse({
+        id: conversation.id,
+        createdAt: conversation.createdAt,
+        updatedAt: conversation.updatedAt,
+        totalCount,
+        messages,
+        hasMore: start > 0,
+        ...(start > 0 ? { nextCursor: String(start) } : {}),
+        limit: query.data.limit,
+      });
+      return c.json(response, 200, { "Cache-Control": "no-store" });
+    } catch (error: unknown) {
+      console.error("[gateway] Failed to load conversation history:", error);
+      return c.json({
+        error: "Conversation history is temporarily unavailable. Try again.",
+      }, 503);
+    }
+  });
+}

--- a/specs/105-coding-agent-shells/current-state.md
+++ b/specs/105-coding-agent-shells/current-state.md
@@ -1,7 +1,7 @@
 # Current State: Coding Agent Shells
 
 **Branch stack**: implementation checkpoint merged to `main` through PR #869 (`056b3da668ed6d1753712120316d2d5accfafdcf`)
-**Updated**: 2026-07-12
+**Updated**: 2026-07-13
 **Scope**: Inventory for the coding-agent desktop/mobile shell work. This file records the current Matrix-native route, contract, client, and regression-test state so later slices keep gateway/runtime as source of truth and keep desktop/mobile as thin shells.
 
 For the evidence-based checkpoint audit, see [completion-audit.md](./completion-audit.md).
@@ -53,6 +53,30 @@ checkpoints. The backend expansion remains based on `main` and will deploy to a
 separate disposable preview computer. Both clients will test against that same
 backend preview after Gate B2; no shell branch becomes the backend source of
 truth.
+
+### Kernel Chat History Contract Decision
+
+The mobile Chat tab uses the Matrix kernel conversation store, which is separate
+from coding-agent threads. WebSocket replay remains the source for live buffered
+run events, but it cannot hydrate a completed persisted conversation. The
+canonical persisted-history read contract is therefore an authenticated
+`GET /api/conversations/:id` route with shared Zod schemas:
+
+- `KernelConversationIdSchema` validates the bounded path identifier before any
+  owner-file read.
+- `KernelConversationHistoryQuerySchema` accepts a latest/older cursor and a
+  maximum page size of 50.
+- `KernelConversationHistoryResponseSchema` returns the newest page in
+  chronological order, stable message indexes, a cursor for older messages,
+  and at most 32,000 characters per message with an explicit truncation flag.
+- Raw tool inputs are never projected. Missing or unreadable history returns a
+  generic recovery-oriented error, and successful responses are `no-store`.
+
+Mobile must hydrate this route when switching to a completed conversation and
+may keep only bounded drafts and selected conversation references on device.
+Live WebSocket frames must remain bound to their originating conversation so a
+late frame cannot be appended after the user switches. This kernel-chat route
+does not replace or complete the coding-agent transcript work in Phase 26.
 
 ### Computer And Preview Contract Conflict
 

--- a/tests/contracts/kernel-conversations.test.ts
+++ b/tests/contracts/kernel-conversations.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import {
+  KernelConversationHistoryQuerySchema,
+  KernelConversationHistoryResponseSchema,
+  KernelConversationIdSchema,
+} from "../../packages/contracts/src/index.js";
+
+describe("kernel conversation contracts", () => {
+  it("accepts bounded Matrix conversation identifiers", () => {
+    expect(KernelConversationIdSchema.parse("mobile:123e4567-e89b-12d3-a456-426614174000"))
+      .toBe("mobile:123e4567-e89b-12d3-a456-426614174000");
+    expect(KernelConversationIdSchema.safeParse("../system/config").success).toBe(false);
+    expect(KernelConversationIdSchema.safeParse("chat/other").success).toBe(false);
+  });
+
+  it("coerces and bounds history pagination", () => {
+    expect(KernelConversationHistoryQuerySchema.parse({ limit: "25", cursor: "40" }))
+      .toEqual({ limit: 25, cursor: 40 });
+    expect(KernelConversationHistoryQuerySchema.parse({})).toEqual({ limit: 50 });
+    expect(KernelConversationHistoryQuerySchema.safeParse({ limit: "51" }).success).toBe(false);
+    expect(KernelConversationHistoryQuerySchema.safeParse({ cursor: "0" }).success).toBe(false);
+    expect(KernelConversationHistoryQuerySchema.safeParse({ extra: "value" }).success).toBe(false);
+  });
+
+  it("rejects unbounded or secret-bearing history payload fields", () => {
+    const valid = {
+      id: "conversation-1",
+      createdAt: 1,
+      updatedAt: 2,
+      totalCount: 1,
+      messages: [{
+        index: 0,
+        role: "assistant",
+        content: "Done",
+        contentTruncated: false,
+        timestamp: 2,
+        tool: "Read",
+      }],
+      hasMore: false,
+      limit: 50,
+    };
+
+    expect(KernelConversationHistoryResponseSchema.parse(valid)).toEqual(valid);
+    expect(KernelConversationHistoryResponseSchema.safeParse({
+      ...valid,
+      messages: [{ ...valid.messages[0], toolInput: { token: "secret" } }],
+    }).success).toBe(false);
+    expect(KernelConversationHistoryResponseSchema.safeParse({
+      ...valid,
+      messages: [{ ...valid.messages[0], content: "x".repeat(32_001) }],
+    }).success).toBe(false);
+  });
+});

--- a/tests/contracts/kernel-conversations.test.ts
+++ b/tests/contracts/kernel-conversations.test.ts
@@ -16,6 +16,8 @@ describe("kernel conversation contracts", () => {
   it("coerces and bounds history pagination", () => {
     expect(KernelConversationHistoryQuerySchema.parse({ limit: "25", cursor: "40" }))
       .toEqual({ limit: 25, cursor: 40 });
+    expect(KernelConversationHistoryQuerySchema.parse({ cursor: "1000001" }))
+      .toEqual({ limit: 50, cursor: 1_000_001 });
     expect(KernelConversationHistoryQuerySchema.parse({})).toEqual({ limit: 50 });
     expect(KernelConversationHistoryQuerySchema.safeParse({ limit: "51" }).success).toBe(false);
     expect(KernelConversationHistoryQuerySchema.safeParse({ cursor: "0" }).success).toBe(false);
@@ -41,6 +43,13 @@ describe("kernel conversation contracts", () => {
     };
 
     expect(KernelConversationHistoryResponseSchema.parse(valid)).toEqual(valid);
+    expect(KernelConversationHistoryResponseSchema.parse({
+      ...valid,
+      totalCount: 1_000_001,
+      messages: [{ ...valid.messages[0], index: 1_000_001 }],
+      hasMore: true,
+      nextCursor: "1000001",
+    })).toMatchObject({ totalCount: 1_000_001, nextCursor: "1000001" });
     expect(KernelConversationHistoryResponseSchema.safeParse({
       ...valid,
       messages: [{ ...valid.messages[0], toolInput: { token: "secret" } }],

--- a/tests/gateway/conversation-history-routes.test.ts
+++ b/tests/gateway/conversation-history-routes.test.ts
@@ -1,0 +1,156 @@
+import { Hono } from "hono";
+import { describe, expect, it, vi } from "vitest";
+import { KernelConversationHistoryResponseSchema } from "../../packages/contracts/src/index.js";
+import { authMiddleware } from "../../packages/gateway/src/auth.js";
+import type { ConversationStore } from "../../packages/gateway/src/conversations.js";
+import { registerConversationHistoryRoutes } from "../../packages/gateway/src/server/conversation-history-routes.js";
+
+const TOKEN = "conversation-history-test-token";
+
+function createStore(overrides: Partial<ConversationStore> = {}): ConversationStore {
+  return {
+    begin: vi.fn(),
+    addUserMessage: vi.fn(),
+    appendAssistantText: vi.fn(),
+    addToolStart: vi.fn(),
+    addToolEnd: vi.fn(),
+    finalize: vi.fn(),
+    list: vi.fn(() => []),
+    get: vi.fn(() => null),
+    create: vi.fn(() => "conversation-1"),
+    delete: vi.fn(() => false),
+    search: vi.fn(() => []),
+    ...overrides,
+  };
+}
+
+function createApp(store: ConversationStore) {
+  const app = new Hono();
+  app.use("*", authMiddleware(TOKEN));
+  registerConversationHistoryRoutes(app, { conversations: store });
+  return app;
+}
+
+function authenticated(path: string) {
+  return new Request(`http://localhost${path}`, {
+    headers: { Authorization: `Bearer ${TOKEN}` },
+  });
+}
+
+describe("kernel conversation history route", () => {
+  it("requires gateway authentication", async () => {
+    const get = vi.fn(() => null);
+    const response = await createApp(createStore({ get })).request("/api/conversations/conversation-1");
+
+    expect(response.status).toBe(401);
+    expect(get).not.toHaveBeenCalled();
+  });
+
+  it("returns the newest bounded page in chronological order", async () => {
+    const messages = Array.from({ length: 5 }, (_, index) => ({
+      role: index % 2 === 0 ? "user" as const : "assistant" as const,
+      content: `message-${index}`,
+      timestamp: index + 1,
+    }));
+    const app = createApp(createStore({
+      get: vi.fn(() => ({
+        id: "conversation-1",
+        createdAt: 1,
+        updatedAt: 5,
+        messages,
+      })),
+    }));
+
+    const response = await app.request(authenticated("/api/conversations/conversation-1?limit=2"));
+    const body = KernelConversationHistoryResponseSchema.parse(await response.json());
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("cache-control")).toBe("no-store");
+    expect(body.messages.map((message) => message.index)).toEqual([3, 4]);
+    expect(body.messages.map((message) => message.content)).toEqual(["message-3", "message-4"]);
+    expect(body).toMatchObject({ totalCount: 5, hasMore: true, nextCursor: "3", limit: 2 });
+  });
+
+  it("uses the cursor to load the preceding page", async () => {
+    const app = createApp(createStore({
+      get: vi.fn(() => ({
+        id: "conversation-1",
+        createdAt: 1,
+        updatedAt: 5,
+        messages: Array.from({ length: 5 }, (_, index) => ({
+          role: "user" as const,
+          content: `message-${index}`,
+          timestamp: index + 1,
+        })),
+      })),
+    }));
+
+    const response = await app.request(authenticated(
+      "/api/conversations/conversation-1?limit=2&cursor=3",
+    ));
+    const body = KernelConversationHistoryResponseSchema.parse(await response.json());
+
+    expect(body.messages.map((message) => message.index)).toEqual([1, 2]);
+    expect(body.nextCursor).toBe("1");
+    expect(body.hasMore).toBe(true);
+  });
+
+  it("truncates large content and never returns raw tool inputs", async () => {
+    const app = createApp(createStore({
+      get: vi.fn(() => ({
+        id: "conversation-1",
+        createdAt: 1,
+        updatedAt: 2,
+        messages: [{
+          role: "system",
+          content: "x".repeat(40_000),
+          timestamp: 2,
+          tool: "Read",
+          toolInput: { path: "/home/private", token: "secret" },
+        }],
+      })),
+    }));
+
+    const response = await app.request(authenticated("/api/conversations/conversation-1"));
+    const body = KernelConversationHistoryResponseSchema.parse(await response.json());
+
+    expect(body.messages[0]?.content).toHaveLength(32_000);
+    expect(body.messages[0]?.contentTruncated).toBe(true);
+    expect(body.messages[0]).not.toHaveProperty("toolInput");
+  });
+
+  it("rejects invalid identifiers and pagination before reading storage", async () => {
+    const get = vi.fn(() => null);
+    const app = createApp(createStore({ get }));
+
+    const invalidId = await app.request(authenticated("/api/conversations/..%2Fsystem"));
+    const invalidLimit = await app.request(authenticated(
+      "/api/conversations/conversation-1?limit=500",
+    ));
+
+    expect(invalidId.status).toBe(400);
+    expect(invalidLimit.status).toBe(400);
+    expect(get).not.toHaveBeenCalled();
+  });
+
+  it("maps missing and failed storage reads to safe errors", async () => {
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const missing = await createApp(createStore()).request(authenticated(
+      "/api/conversations/conversation-1",
+    ));
+    const failed = await createApp(createStore({
+      get: vi.fn(() => { throw new Error("/home/private invalid JSON token"); }),
+    })).request(authenticated("/api/conversations/conversation-1"));
+
+    expect(missing.status).toBe(404);
+    expect(await missing.json()).toEqual({
+      error: "Conversation unavailable. Refresh and try again.",
+    });
+    expect(failed.status).toBe(503);
+    expect(await failed.json()).toEqual({
+      error: "Conversation history is temporarily unavailable. Try again.",
+    });
+    expect(consoleError).toHaveBeenCalledOnce();
+    consoleError.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary

- add shared Zod 4 contracts for bounded kernel conversation history
- expose authenticated `GET /api/conversations/:id` with newest-page pagination returned in chronological order
- omit raw tool inputs, cap message content, validate IDs and queries before storage reads, and map failures to generic no-store responses
- record the kernel-chat history decision in spec 105 without conflating it with coding-agent transcript persistence

## Tests

- `pnpm exec vitest run tests/contracts/kernel-conversations.test.ts tests/gateway/conversation-history-routes.test.ts tests/gateway/main-ws-schema.test.ts tests/gateway/conversations.test.ts` - 44 passed
- `pnpm --filter @matrix-os/contracts run typecheck` - passed
- `pnpm --filter @matrix-os/gateway run build` - passed
- `bun run typecheck` - passed
- `bun run check:patterns` - 0 violations, 5 existing full-scan warnings
- `git diff --check` - passed

## Invariants

### Source of truth

The existing owner-local kernel conversation store remains authoritative. This route is a bounded read projection; desktop and mobile must not persist transcripts.

### Lock/transaction scope

No writes, locks, transactions, or persistence changes are introduced. Each response reads one existing conversation snapshot and returns a bounded page.

### Acceptable orphan states

None. The route creates no durable records. Missing or unreadable history returns a generic recovery-oriented response.

### Auth source of truth

Existing gateway authentication remains authoritative and runs before the route. Path IDs and query values are validated with shared schemas before the owner-file store is accessed.

### Deferred scope

Mobile consumption, stale WebSocket-frame isolation, and public mobile workflow documentation remain in the mobile stack. Coding-agent transcript persistence and pagination remain Phase 26 work and are not replaced by this kernel-chat route.
