### PR TITLE
fix(gateway): report installed release in system info

### DIFF
--- a/packages/gateway/src/system-info.ts
+++ b/packages/gateway/src/system-info.ts
@@ -1,4 +1,12 @@
-import { readFileSync, existsSync, statfsSync } from "node:fs";
+import {
+  closeSync,
+  existsSync,
+  fstatSync,
+  openSync,
+  readFileSync,
+  readSync,
+  statfsSync,
+} from "node:fs";
 import { join, resolve } from "node:path";
 import { cpus, freemem, loadavg, totalmem } from "node:os";
 import { loadSkills } from "@matrix-os/kernel";
@@ -6,6 +14,51 @@ import type { HostBundleRelease } from "./system-update.js";
 
 const startTime = Date.now();
 const startedAt = new Date(startTime).toISOString();
+const SYSTEM_INFO_FILE_MAX_BYTES = 64 * 1024;
+const SYSTEM_INFO_CACHE_TTL_MS = 5_000;
+const SYSTEM_INFO_CACHE_MAX_ENTRIES = 8;
+
+interface CachedSystemInfoFile<T> {
+  expiresAt: number;
+  value: T;
+}
+
+const systemInfoFileCache = new Map<string, CachedSystemInfoFile<unknown>>();
+
+function readCachedSystemInfoFile<T>(cacheKey: string, read: () => T): T {
+  const cached = systemInfoFileCache.get(cacheKey) as CachedSystemInfoFile<T> | undefined;
+  if (cached && cached.expiresAt > Date.now()) {
+    systemInfoFileCache.delete(cacheKey);
+    systemInfoFileCache.set(cacheKey, cached);
+    return cached.value;
+  }
+
+  const value = read();
+  systemInfoFileCache.delete(cacheKey);
+  systemInfoFileCache.set(cacheKey, {
+    expiresAt: Date.now() + SYSTEM_INFO_CACHE_TTL_MS,
+    value,
+  });
+  while (systemInfoFileCache.size > SYSTEM_INFO_CACHE_MAX_ENTRIES) {
+    const oldestKey = systemInfoFileCache.keys().next().value;
+    if (oldestKey === undefined) break;
+    systemInfoFileCache.delete(oldestKey);
+  }
+  return value;
+}
+
+function readBoundedTextFile(file: string): string {
+  const fd = openSync(file, "r");
+  try {
+    const stat = fstatSync(fd);
+    if (!stat.isFile() || stat.size > SYSTEM_INFO_FILE_MAX_BYTES) return "";
+    const buffer = Buffer.alloc(stat.size);
+    const bytesRead = readSync(fd, buffer, 0, stat.size, 0);
+    return buffer.subarray(0, bytesRead).toString("utf-8");
+  } finally {
+    closeSync(fd);
+  }
+}
 
 function logSystemInfoReadFailure(context: string, err: unknown): void {
   console.warn(
@@ -18,9 +71,35 @@ function isMissingFileError(err: unknown): boolean {
   return typeof err === "object" && err !== null && "code" in err && err.code === "ENOENT";
 }
 
-export function getVersion(): string {
+function parseSafeSystemVersion(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  return /^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/.test(trimmed) ? trimmed : undefined;
+}
+
+function parseReleaseChannel(value: unknown): string | undefined {
+  return typeof value === "string" && ["stable", "canary", "beta", "dev"].includes(value)
+    ? value
+    : undefined;
+}
+
+export function getVersion(release?: HostBundleRelease): string {
+  const releaseVersion = parseSafeSystemVersion(release?.version);
+  if (releaseVersion) return releaseVersion;
+  const bundleVersionFile = process.env.MATRIX_BUNDLE_VERSION_FILE ?? "/opt/matrix/app/BUNDLE_VERSION";
   try {
-    return readFileSync("/app/VERSION", "utf-8").trim();
+    const bundleVersion = readCachedSystemInfoFile(`bundle:${bundleVersionFile}`, () => (
+      parseSafeSystemVersion(readBoundedTextFile(bundleVersionFile))
+    ));
+    if (bundleVersion) return bundleVersion;
+  } catch (err) {
+    if (!isMissingFileError(err)) {
+      logSystemInfoReadFailure("Failed to read installed bundle version", err);
+    }
+  }
+  try {
+    const legacyVersion = parseSafeSystemVersion(readFileSync("/app/VERSION", "utf-8"));
+    if (legacyVersion) return legacyVersion;
   } catch (err) {
     if (!isMissingFileError(err)) {
       logSystemInfoReadFailure("Failed to read /app/VERSION", err);
@@ -33,7 +112,7 @@ export function getVersion(): string {
         "utf-8",
       ),
     );
-    return pkg.version ?? "0.0.0";
+    return parseSafeSystemVersion(pkg.version) ?? "0.0.0";
   } catch (err) {
     logSystemInfoReadFailure("Failed to read package.json version", err);
   }
@@ -42,6 +121,7 @@ export function getVersion(): string {
 
 export interface SystemInfo {
   version: string;
+  channel?: string;
   image: string;
   runtime: {
     handle: string | null;
@@ -73,18 +153,25 @@ export interface SystemInfo {
   release?: HostBundleRelease;
 }
 
-function readReleaseInfo(homePath: string): HostBundleRelease | undefined {
-  const candidates = [
-    process.env.MATRIX_RELEASE_FILE,
-    "/opt/matrix/release.json",
-    join(homePath, "release.json"),
-  ].filter((value): value is string => Boolean(value));
+function readReleaseInfo(): HostBundleRelease | undefined {
+  const candidates = [process.env.MATRIX_RELEASE_FILE ?? "/opt/matrix/release.json"];
 
   for (const file of candidates) {
     try {
-      if (!existsSync(file)) continue;
-      const parsed = JSON.parse(readFileSync(file, "utf-8")) as HostBundleRelease;
-      if (parsed && typeof parsed === "object") return parsed;
+      const release = readCachedSystemInfoFile<HostBundleRelease | undefined>(`release:${file}`, () => {
+        try {
+          const raw = readBoundedTextFile(file);
+          if (!raw) return undefined;
+          const parsed = JSON.parse(raw) as HostBundleRelease;
+          return parsed && typeof parsed === "object" && !Array.isArray(parsed)
+            ? parsed
+            : undefined;
+        } catch (err) {
+          if (isMissingFileError(err)) return undefined;
+          throw err;
+        }
+      });
+      if (release) return release;
     } catch (err) {
       logSystemInfoReadFailure("Failed to read release metadata", err);
     }
@@ -164,9 +251,12 @@ export function getSystemInfo(homePath: string): SystemInfo {
   const rootDisk = readDiskUsage("/");
   const homeDisk = readDiskUsage(homePath);
   const [load1 = 0, load5 = 0, load15 = 0] = loadavg();
+  const release = readReleaseInfo();
+  const channel = parseReleaseChannel(release?.channel);
 
   return {
-    version: getVersion(),
+    version: getVersion(release),
+    ...(channel ? { channel } : {}),
     image: process.env.MATRIX_IMAGE ?? "unknown",
     runtime: {
       handle: process.env.MATRIX_HANDLE ?? null,
@@ -195,6 +285,6 @@ export function getSystemInfo(homePath: string): SystemInfo {
       homeDiskTotalBytes: homeDisk?.totalBytes ?? null,
       homeDiskFreeBytes: homeDisk?.freeBytes ?? null,
     },
-    release: readReleaseInfo(homePath),
+    release,
   };
 }

--- a/tests/gateway/system-info.test.ts
+++ b/tests/gateway/system-info.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
 import { join, resolve } from "node:path";
 import { tmpdir } from "node:os";
@@ -99,10 +99,140 @@ describe("T135: System info", () => {
         buildTime: "2026-05-06T20:15:00.000Z",
         installedAt: "2026-05-06T20:20:00.000Z",
       });
+      expect(info.version).toBe("v2026.05.06-1");
+      expect(info.channel).toBe("stable");
       expect(info.startedAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
     } finally {
       if (previousReleasePath === undefined) delete process.env.MATRIX_RELEASE_FILE;
       else process.env.MATRIX_RELEASE_FILE = previousReleasePath;
+      rmSync(homePath, { recursive: true, force: true });
+    }
+  });
+
+  it("falls back to the installed bundle version when release metadata has no version", () => {
+    const homePath = tmpHome();
+    const releasePath = join(homePath, "release.json");
+    const bundleVersionPath = join(homePath, "BUNDLE_VERSION");
+    const previousReleasePath = process.env.MATRIX_RELEASE_FILE;
+    const previousBundleVersionPath = process.env.MATRIX_BUNDLE_VERSION_FILE;
+    process.env.MATRIX_RELEASE_FILE = releasePath;
+    process.env.MATRIX_BUNDLE_VERSION_FILE = bundleVersionPath;
+    writeFileSync(releasePath, "{}");
+    writeFileSync(bundleVersionPath, "main-ea2f91510b\n");
+
+    try {
+      expect(getSystemInfo(homePath).version).toBe("main-ea2f91510b");
+    } finally {
+      if (previousReleasePath === undefined) delete process.env.MATRIX_RELEASE_FILE;
+      else process.env.MATRIX_RELEASE_FILE = previousReleasePath;
+      if (previousBundleVersionPath === undefined) delete process.env.MATRIX_BUNDLE_VERSION_FILE;
+      else process.env.MATRIX_BUNDLE_VERSION_FILE = previousBundleVersionPath;
+      rmSync(homePath, { recursive: true, force: true });
+    }
+  });
+
+  it("ignores oversized release metadata and uses the bounded bundle-version fallback", () => {
+    const homePath = tmpHome();
+    const releasePath = join(homePath, "release.json");
+    const bundleVersionPath = join(homePath, "BUNDLE_VERSION");
+    const previousReleasePath = process.env.MATRIX_RELEASE_FILE;
+    const previousBundleVersionPath = process.env.MATRIX_BUNDLE_VERSION_FILE;
+    process.env.MATRIX_RELEASE_FILE = releasePath;
+    process.env.MATRIX_BUNDLE_VERSION_FILE = bundleVersionPath;
+    writeFileSync(
+      releasePath,
+      JSON.stringify({ version: "v999.0.0", padding: "x".repeat(70 * 1024) }),
+    );
+    writeFileSync(bundleVersionPath, "v2026.07.13-1\n");
+
+    try {
+      expect(getSystemInfo(homePath).version).toBe("v2026.07.13-1");
+    } finally {
+      if (previousReleasePath === undefined) delete process.env.MATRIX_RELEASE_FILE;
+      else process.env.MATRIX_RELEASE_FILE = previousReleasePath;
+      if (previousBundleVersionPath === undefined) delete process.env.MATRIX_BUNDLE_VERSION_FILE;
+      else process.env.MATRIX_BUNDLE_VERSION_FILE = previousBundleVersionPath;
+      rmSync(homePath, { recursive: true, force: true });
+    }
+  });
+
+  it("caches installed release metadata between nearby system-info requests", () => {
+    const homePath = tmpHome();
+    const releasePath = join(homePath, "release.json");
+    const previousReleasePath = process.env.MATRIX_RELEASE_FILE;
+    process.env.MATRIX_RELEASE_FILE = releasePath;
+    writeFileSync(releasePath, JSON.stringify({ version: "v2026.07.13-1", channel: "dev" }));
+
+    try {
+      expect(getSystemInfo(homePath).version).toBe("v2026.07.13-1");
+      writeFileSync(releasePath, JSON.stringify({ version: "v2026.07.13-2", channel: "canary" }));
+      const cached = getSystemInfo(homePath);
+      expect(cached.version).toBe("v2026.07.13-1");
+      expect(cached.channel).toBe("dev");
+    } finally {
+      if (previousReleasePath === undefined) delete process.env.MATRIX_RELEASE_FILE;
+      else process.env.MATRIX_RELEASE_FILE = previousReleasePath;
+      rmSync(homePath, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps a refreshed release entry at the newest end of the LRU cache", () => {
+    const homePath = tmpHome();
+    const releasePaths = Array.from(
+      { length: 9 },
+      (_, index) => join(homePath, `release-${index}.json`),
+    );
+    const previousReleasePath = process.env.MATRIX_RELEASE_FILE;
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-13T18:00:00.000Z"));
+
+    try {
+      for (const [index, releasePath] of releasePaths.slice(0, 8).entries()) {
+        writeFileSync(releasePath, JSON.stringify({ version: `v2026.07.13-${index}` }));
+        process.env.MATRIX_RELEASE_FILE = releasePath;
+        expect(getSystemInfo(homePath).version).toBe(`v2026.07.13-${index}`);
+      }
+
+      vi.advanceTimersByTime(5_001);
+      writeFileSync(releasePaths[0], JSON.stringify({ version: "v2026.07.13-refreshed" }));
+      process.env.MATRIX_RELEASE_FILE = releasePaths[0];
+      expect(getSystemInfo(homePath).version).toBe("v2026.07.13-refreshed");
+
+      writeFileSync(releasePaths[8], JSON.stringify({ version: "v2026.07.13-newest" }));
+      process.env.MATRIX_RELEASE_FILE = releasePaths[8];
+      expect(getSystemInfo(homePath).version).toBe("v2026.07.13-newest");
+
+      writeFileSync(releasePaths[0], JSON.stringify({ version: "v2026.07.13-after-eviction" }));
+      process.env.MATRIX_RELEASE_FILE = releasePaths[0];
+      expect(getSystemInfo(homePath).version).toBe("v2026.07.13-refreshed");
+    } finally {
+      vi.useRealTimers();
+      if (previousReleasePath === undefined) delete process.env.MATRIX_RELEASE_FILE;
+      else process.env.MATRIX_RELEASE_FILE = previousReleasePath;
+      rmSync(homePath, { recursive: true, force: true });
+    }
+  });
+
+  it("does not surface unsafe release version or channel strings", () => {
+    const homePath = tmpHome();
+    const releasePath = join(homePath, "release.json");
+    const bundleVersionPath = join(homePath, "BUNDLE_VERSION");
+    const previousReleasePath = process.env.MATRIX_RELEASE_FILE;
+    const previousBundleVersionPath = process.env.MATRIX_BUNDLE_VERSION_FILE;
+    process.env.MATRIX_RELEASE_FILE = releasePath;
+    process.env.MATRIX_BUNDLE_VERSION_FILE = bundleVersionPath;
+    writeFileSync(releasePath, JSON.stringify({ version: "/opt/matrix/private", channel: "../../stable" }));
+    writeFileSync(bundleVersionPath, "v2026.07.13-3\n");
+
+    try {
+      const info = getSystemInfo(homePath);
+      expect(info.version).toBe("v2026.07.13-3");
+      expect(info.channel).toBeUndefined();
+    } finally {
+      if (previousReleasePath === undefined) delete process.env.MATRIX_RELEASE_FILE;
+      else process.env.MATRIX_RELEASE_FILE = previousReleasePath;
+      if (previousBundleVersionPath === undefined) delete process.env.MATRIX_BUNDLE_VERSION_FILE;
+      else process.env.MATRIX_BUNDLE_VERSION_FILE = previousBundleVersionPath;
       rmSync(homePath, { recursive: true, force: true });
     }
   });


### PR DESCRIPTION
## Summary

- Report the installed host-bundle release as `GET /api/system/info.version`.
- Include the recognized release `channel` when present.
- Bound release metadata reads to 64 KiB and cache results for 5 seconds in a capped eight-entry cache.

## Tests

- `pnpm exec vitest run tests/gateway/system-info.test.ts`
- `pnpm exec tsc -p packages/gateway/tsconfig.json --noEmit`
- `bun run check:patterns`

## Review / Monitoring

- Greptile 5/5 required before merge.
- CI must be green on the current head before the `ready-for-ci` label is applied.

## Invariants

- Source of truth: `/opt/matrix/release.json`.
- Fallback order: canonical release metadata, then `/opt/matrix/app/BUNDLE_VERSION`, then the legacy `/app/VERSION`, then the gateway package version for local development, finally `0.0.0`.
- Lock / transaction scope: no database writes, locks, or transactions are introduced; reads are bounded and cached.
- Acceptable orphan states: missing, malformed, oversized, or unsafe release metadata falls through without persisting state.
- Auth source of truth: the existing authenticated system-info route boundary is unchanged.
- Secrecy: responses include only validated release version/channel values; filesystem paths and raw read errors are never returned.
- Back compatibility: the existing `version` field and nested `release` data remain; `channel` is additive and optional.
- Deferred scope: no client rendering changes or release promotion/deployment behavior.

