### PR TITLE
fix(gateway): include active kernel model in system info

### DIFF
--- a/packages/gateway/src/system-info.ts
+++ b/packages/gateway/src/system-info.ts
@@ -9,7 +9,7 @@ import {
 } from "node:fs";
 import { join, resolve } from "node:path";
 import { cpus, freemem, loadavg, totalmem } from "node:os";
-import { loadSkills } from "@matrix-os/kernel";
+import { loadSkills, resolveKernelConfigFile } from "@matrix-os/kernel";
 import type { HostBundleRelease } from "./system-update.js";
 
 const startTime = Date.now();
@@ -122,6 +122,8 @@ export function getVersion(release?: HostBundleRelease): string {
 export interface SystemInfo {
   version: string;
   channel?: string;
+  model: string;
+  effort: string;
   image: string;
   runtime: {
     handle: string | null;
@@ -193,6 +195,7 @@ function readDiskUsage(path: string): { totalBytes: number; freeBytes: number } 
 }
 
 export function getSystemInfo(homePath: string): SystemInfo {
+  const kernel = resolveKernelConfigFile(homePath);
   let modules = 0;
   const modulesPath = join(homePath, "system", "modules.json");
   if (existsSync(modulesPath)) {
@@ -257,6 +260,8 @@ export function getSystemInfo(homePath: string): SystemInfo {
   return {
     version: getVersion(release),
     ...(channel ? { channel } : {}),
+    model: kernel.model,
+    effort: kernel.effort,
     image: process.env.MATRIX_IMAGE ?? "unknown",
     runtime: {
       handle: process.env.MATRIX_HANDLE ?? null,

--- a/packages/kernel/src/index.ts
+++ b/packages/kernel/src/index.ts
@@ -1,7 +1,13 @@
 export { spawnKernel } from "./kernel.js";
 export type { KernelEvent, KernelResult } from "./kernel.js";
-export { kernelOptions } from "./options.js";
-export type { KernelConfig } from "./options.js";
+export {
+  DEFAULT_KERNEL_EFFORT,
+  DEFAULT_KERNEL_MODEL,
+  kernelOptions,
+  loadKernelConfigFile,
+  resolveKernelConfigFile,
+} from "./options.js";
+export type { KernelConfig, KernelEffort } from "./options.js";
 export { createDB } from "./db.js";
 export type { MatrixDB } from "./db.js";
 export { ensureHome, generateTemplateManifest, smartSyncTemplate } from "./boot.js";

--- a/packages/kernel/src/options.ts
+++ b/packages/kernel/src/options.ts
@@ -70,7 +70,10 @@ function loadBrowserConfig(homePath: string): {
 }
 
 const KERNEL_EFFORT_VALUES = ["low", "medium", "high", "max"] as const;
-type KernelEffort = (typeof KERNEL_EFFORT_VALUES)[number];
+const SAFE_KERNEL_MODEL = /^[A-Za-z0-9][A-Za-z0-9_.:-]{0,79}$/;
+export type KernelEffort = (typeof KERNEL_EFFORT_VALUES)[number];
+export const DEFAULT_KERNEL_MODEL = "claude-opus-4-6";
+export const DEFAULT_KERNEL_EFFORT: KernelEffort = "high";
 
 // User-tunable kernel settings persisted by the gateway settings UI under the
 // `kernel` key of ~/system/config.json (Everything Is a File). Read at spawn so
@@ -82,13 +85,23 @@ export function loadKernelConfigFile(homePath: string): { model?: string; effort
     const config = JSON.parse(readFileSync(configPath, "utf-8"));
     const kernel = config.kernel;
     if (!kernel || typeof kernel !== "object") return {};
-    const model = typeof kernel.model === "string" && kernel.model.length > 0 ? kernel.model : undefined;
+    const model = typeof kernel.model === "string" && SAFE_KERNEL_MODEL.test(kernel.model)
+      ? kernel.model
+      : undefined;
     const effort = KERNEL_EFFORT_VALUES.includes(kernel.effort) ? (kernel.effort as KernelEffort) : undefined;
     return { ...(model ? { model } : {}), ...(effort ? { effort } : {}) };
   } catch (err: unknown) {
     console.warn("[kernel-options] Could not load kernel config:", err instanceof Error ? err.message : String(err));
     return {};
   }
+}
+
+export function resolveKernelConfigFile(homePath: string): { model: string; effort: KernelEffort } {
+  const fileKernel = loadKernelConfigFile(homePath);
+  return {
+    model: fileKernel.model ?? DEFAULT_KERNEL_MODEL,
+    effort: fileKernel.effort ?? DEFAULT_KERNEL_EFFORT,
+  };
 }
 
 export async function tryCreateBrowserServer(
@@ -124,9 +137,9 @@ export async function kernelOptions(config: KernelConfig) {
 
   // Explicit per-call config wins; otherwise fall back to the persisted
   // ~/system/config.json kernel settings, then hardcoded defaults.
-  const fileKernel = loadKernelConfigFile(homePath);
-  const effort = (config.effort ?? fileKernel.effort) as KernelEffort | undefined;
-  const resolvedEffort = effort && KERNEL_EFFORT_VALUES.includes(effort) ? effort : undefined;
+  const fileKernel = resolveKernelConfigFile(homePath);
+  const effort = (config.effort ?? fileKernel.effort) as KernelEffort;
+  const resolvedEffort = KERNEL_EFFORT_VALUES.includes(effort) ? effort : DEFAULT_KERNEL_EFFORT;
 
   const ipcServer = await createIpcServer(db, homePath);
   const coreAgents = getCoreAgents(homePath);
@@ -151,8 +164,8 @@ export async function kernelOptions(config: KernelConfig) {
   }
 
   return {
-    model: config.model ?? fileKernel.model ?? "claude-opus-4-6",
-    ...(resolvedEffort ? { effort: resolvedEffort } : {}),
+    model: config.model ?? fileKernel.model,
+    effort: resolvedEffort,
     systemPrompt,
     cwd: homePath,
     ...(config.env ? { env: config.env } : {}),

--- a/tests/gateway/system-info.test.ts
+++ b/tests/gateway/system-info.test.ts
@@ -291,6 +291,41 @@ describe("T135: System info", () => {
     rmSync(homePath, { recursive: true, force: true });
   });
 
+  it("reports the active kernel model and effort from owner config", () => {
+    const homePath = tmpHome();
+    writeFileSync(
+      join(homePath, "system", "config.json"),
+      JSON.stringify({ kernel: { model: "claude-sonnet-4-5", effort: "max" } }),
+    );
+
+    const info = getSystemInfo(homePath);
+
+    expect(info.model).toBe("claude-sonnet-4-5");
+    expect(info.effort).toBe("max");
+    rmSync(homePath, { recursive: true, force: true });
+  });
+
+  it("reports the kernel defaults when owner config is absent", () => {
+    const homePath = tmpHome();
+
+    const info = getSystemInfo(homePath);
+
+    expect(info.model).toBe("claude-opus-4-6");
+    expect(info.effort).toBe("high");
+    rmSync(homePath, { recursive: true, force: true });
+  });
+
+  it("reports the kernel defaults when owner config is malformed", () => {
+    const homePath = tmpHome();
+    writeFileSync(join(homePath, "system", "config.json"), "{not json");
+
+    const info = getSystemInfo(homePath);
+
+    expect(info.model).toBe("claude-opus-4-6");
+    expect(info.effort).toBe("high");
+    rmSync(homePath, { recursive: true, force: true });
+  });
+
   it("counts skills", () => {
     const homePath = tmpHome();
     mkdirSync(join(homePath, ".agents", "skills", "summarize"), { recursive: true });

--- a/tests/kernel/options.test.ts
+++ b/tests/kernel/options.test.ts
@@ -73,6 +73,14 @@ describe("loadKernelConfigFile", () => {
     expect(loadKernelConfigFile(homePath)).toEqual({ effort: "max" });
   });
 
+  it("ignores path-like and oversized model values", () => {
+    writeConfig({ kernel: { model: "/opt/matrix/private", effort: "high" } });
+    expect(loadKernelConfigFile(homePath)).toEqual({ effort: "high" });
+
+    writeConfig({ kernel: { model: `claude-${"x".repeat(80)}`, effort: "low" } });
+    expect(loadKernelConfigFile(homePath)).toEqual({ effort: "low" });
+  });
+
   it("returns empty when there is no kernel section", () => {
     writeConfig({ channels: { telegram: { enabled: true } } });
     expect(loadKernelConfigFile(homePath)).toEqual({});


### PR DESCRIPTION
## Summary

- Add active kernel `model` and `effort` to `GET /api/system/info`.
- Reuse the kernel's exported config resolver so runtime behavior and diagnostics share one source.
- Reject path-like or oversized hand-edited model identifiers before they can reach the kernel or clients.

## Tests

- `pnpm exec vitest run tests/kernel/options.test.ts tests/gateway/system-info.test.ts`
- `pnpm exec tsc -p packages/kernel/tsconfig.json --noEmit`
- `pnpm exec tsc -p packages/gateway/tsconfig.json --noEmit`
- `bun run check:patterns`

## Review / Monitoring

- Greptile 5/5 required before merge.
- CI must be green on the current head before the `ready-for-ci` label is applied.

## Invariants

- Source of truth: owner-controlled `~/system/config.json` at `kernel.model` and `kernel.effort`.
- Fallback order: valid persisted values, then `claude-opus-4-6` and `high`, exactly matching kernel runtime defaults.
- Lock / transaction scope: read-only file configuration; no database writes, locks, or transactions.
- Acceptable orphan states: absent, malformed, unsafe, or unsupported values resolve to defaults without mutating owner data.
- Auth source of truth: the existing authenticated system-info route boundary is unchanged.
- Secrecy: only bounded model and effort identifiers are returned; raw parse errors and paths are not returned.
- Back compatibility: existing system-info fields are unchanged; `model` and `effort` are additive.
- Deferred scope: no Settings UI changes and no model-catalog expansion.

