### PR TITLE
feat(gateway): add structured agent profile summary

### DIFF
--- a/packages/contracts/src/agent-profile.ts
+++ b/packages/contracts/src/agent-profile.ts
@@ -1,0 +1,38 @@
+import { z } from "zod/v4";
+
+const SAFE_REFERENCE = /^[A-Za-z0-9][A-Za-z0-9_.:-]{0,127}$/;
+const UNSAFE_AGENT_PROFILE_TEXT =
+  /(postgres(?:ql)?:\/\/|mysql:\/\/|sqlite:|\/home\/|\/tmp\/|\/var\/|\/opt\/|\/etc\/|\/root\/|\/Users\/|[A-Za-z]:[\\/]|\.ssh\/|id_rsa|bearer\s+[A-Za-z0-9._-]+|sk-[A-Za-z0-9_-]+|password\s*[=:]|eyJ[A-Za-z0-9_-]{6,}\.[A-Za-z0-9_-]{4,}\.[A-Za-z0-9_-]{4,}|ghp_[A-Za-z0-9_]{20,}|github_pat_[A-Za-z0-9_]{20,}|glpat-[A-Za-z0-9_-]{12,}|xox[baprs]-[A-Za-z0-9-]{10,}|sk_(?:live|test)_[A-Za-z0-9]{12,}|AKIA[0-9A-Z]{16})/i;
+
+const textEncoder = new TextEncoder();
+
+function agentProfileDisplayText(maxChars: number, maxBytes: number) {
+  return z.string()
+    .min(1)
+    .max(maxChars)
+    .refine((value) => value.trim().length > 0, { message: "Text cannot be blank" })
+    .refine((value) => textEncoder.encode(value).byteLength <= maxBytes, {
+      message: "Text exceeds byte limit",
+    })
+    .refine((value) => !UNSAFE_AGENT_PROFILE_TEXT.test(value), {
+      message: "Text is not safe for agent profile display",
+    });
+}
+
+export const AgentProfileSummarySchema = z.object({
+  identity: z.object({
+    name: agentProfileDisplayText(80, 320).optional(),
+    tagline: agentProfileDisplayText(180, 720).optional(),
+  }).strict(),
+  kernel: z.object({
+    model: z.string().min(1).max(80).regex(SAFE_REFERENCE, "Invalid kernel model"),
+    modelLabel: agentProfileDisplayText(120, 512),
+    effort: z.enum(["low", "medium", "high", "max"]),
+  }).strict(),
+  credentials: z.object({
+    mode: z.enum(["platform", "api_key", "claude_login"]),
+  }).strict(),
+  soulPreview: agentProfileDisplayText(280, 1_120),
+}).strict();
+
+export type AgentProfileSummary = z.infer<typeof AgentProfileSummarySchema>;

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -87,6 +87,7 @@ export const SafeAssistantPreviewSourceTextSchema = boundedText(16_000, 64 * 102
 export const SafeAssistantPreviewTextSchema = boundedText(243, 1024)
   .refine((value) => !UNSAFE_ASSISTANT_PREVIEW_TEXT.test(value), { message: "Text is not safe for assistant preview display" });
 export const BoundedTextSchema = (maxChars = 4000, maxBytes = 16 * 1024) => boundedText(maxChars, maxBytes);
+export { AgentProfileSummarySchema, type AgentProfileSummary } from "./agent-profile.js";
 
 export const MatrixComputerHandleSchema = z.string()
   .min(2)

--- a/packages/gateway/src/agent-profile-summary.ts
+++ b/packages/gateway/src/agent-profile-summary.ts
@@ -1,0 +1,95 @@
+import { open } from "node:fs/promises";
+import { join } from "node:path";
+import { parseFrontmatter, resolveKernelConfigFileAsync } from "@matrix-os/kernel";
+import {
+  AgentProfileSummarySchema,
+  type AgentProfileSummary,
+} from "@matrix-os/contracts";
+import { resolveKernelCredentialMode } from "./kernel-credentials.js";
+import { resolveKernelModelOption } from "./kernel-settings.js";
+
+const SOUL_SUMMARY_FILE_LIMIT = 16 * 1024;
+
+function isNotFoundError(err: unknown): boolean {
+  return err instanceof Error && (err as NodeJS.ErrnoException).code === "ENOENT";
+}
+
+function sanitizeProfileText(value: string, maxChars: number): string {
+  return value
+    .replace(/\b(?:sk|ghp|glpat|github_pat)[-_][A-Za-z0-9_-]+\b/gi, "[redacted]")
+    .replace(/\bBearer\s+[A-Za-z0-9._-]+\b/gi, "[redacted]")
+    .replace(/\/(?:home|tmp|var|opt|etc|root|Users)\/[^\s)>\]]+/g, "[redacted]")
+    .replace(/<[^>]*>/g, " ")
+    .replace(/!\[[^\]]*\]\([^)]*\)/g, " ")
+    .replace(/\[([^\]]+)\]\([^)]*\)/g, "$1")
+    .replace(/^\s{0,3}(?:#{1,6}|[-*+])\s+/gm, "")
+    .replace(/[*_`~]/g, "")
+    .replace(/[\u0000-\u001F\u007F]/g, " ")
+    .replace(/\s+/g, " ")
+    .trim()
+    .slice(0, maxChars);
+}
+
+async function readBoundedSoul(path: string): Promise<string> {
+  let file;
+  try {
+    file = await open(path, "r");
+  } catch (err) {
+    if (isNotFoundError(err)) return "";
+    throw err;
+  }
+  try {
+    const buffer = Buffer.alloc(SOUL_SUMMARY_FILE_LIMIT + 1);
+    const { bytesRead } = await file.read(buffer, 0, buffer.length, 0);
+    return buffer.subarray(0, Math.min(bytesRead, SOUL_SUMMARY_FILE_LIMIT)).toString("utf-8");
+  } finally {
+    await file.close();
+  }
+}
+
+function summarizeSoul(content: string): {
+  identity: { name?: string; tagline?: string };
+  soulPreview: string;
+} {
+  const { frontmatter, body } = parseFrontmatter(content);
+  const heading = body.match(/^\s*#{1,6}\s+(.+)$/m)?.[1];
+  const nameSource = typeof frontmatter.name === "string" ? frontmatter.name : heading;
+  const firstParagraph = body
+    .split(/\r?\n\s*\r?\n/)
+    .map((paragraph) => paragraph.trim())
+    .find((paragraph) => paragraph.length > 0 && !/^#{1,6}\s/.test(paragraph));
+  const taglineSource = typeof frontmatter.tagline === "string"
+    ? frontmatter.tagline
+    : firstParagraph;
+
+  const name = nameSource ? sanitizeProfileText(nameSource, 80) : "";
+  const tagline = taglineSource ? sanitizeProfileText(taglineSource, 180) : "";
+  const soulPreview = firstParagraph
+    ? sanitizeProfileText(firstParagraph, 280)
+    : "No soul profile configured.";
+
+  return {
+    identity: {
+      ...(name ? { name } : {}),
+      ...(tagline ? { tagline } : {}),
+    },
+    soulPreview: soulPreview || "No soul profile configured.",
+  };
+}
+
+export async function buildAgentProfileSummary(homePath: string): Promise<AgentProfileSummary> {
+  const soul = summarizeSoul(await readBoundedSoul(join(homePath, "system/soul.md")));
+  const kernel = await resolveKernelConfigFileAsync(homePath);
+  const model = resolveKernelModelOption(kernel.model);
+  const credentialMode = await resolveKernelCredentialMode(homePath);
+  return AgentProfileSummarySchema.parse({
+    identity: soul.identity,
+    kernel: {
+      model: model.id,
+      modelLabel: model.label,
+      effort: kernel.effort,
+    },
+    credentials: { mode: credentialMode },
+    soulPreview: soul.soulPreview,
+  });
+}

--- a/packages/gateway/src/dispatcher.ts
+++ b/packages/gateway/src/dispatcher.ts
@@ -12,7 +12,7 @@ import {
   type MatrixDB,
 } from "@matrix-os/kernel";
 import { wrapExternalContent, detectSuspiciousPatterns } from "@matrix-os/kernel/security/external-content";
-import { appendFile, readFile } from "node:fs/promises";
+import { appendFile } from "node:fs/promises";
 import { join } from "node:path";
 import type { ChannelId } from "./channels/types.js";
 import type { AiGenerationInput } from "./ai-analytics.js";
@@ -24,6 +24,7 @@ import {
   aiCostTotal,
   aiTokensTotal,
 } from "./metrics.js";
+import { buildKernelEnv } from "./kernel-credentials.js";
 
 export type SpawnFn = typeof spawnKernel;
 
@@ -75,13 +76,6 @@ export interface Dispatcher {
   homePath: string;
 }
 
-function hasClaudeOauthConfig(value: unknown): boolean {
-  if (!value || typeof value !== "object") return false;
-  const account = (value as { oauthAccount?: unknown }).oauthAccount;
-  if (!account || typeof account !== "object") return false;
-  return typeof (account as { accountUuid?: unknown }).accountUuid === "string";
-}
-
 type InternalEntry =
   | {
       kind: "serial";
@@ -126,39 +120,6 @@ export function createDispatcher(opts: DispatchOptions): Dispatcher {
     } catch (err: unknown) {
       logNonFatal("[dispatcher] ai generation capture failed:", err);
     }
-  }
-
-  async function buildKernelEnv(): Promise<Record<string, string | undefined> | undefined> {
-    const env = { ...process.env };
-    try {
-      const raw = await readFile(join(homePath, "system/config.json"), "utf-8");
-      const userConfig = JSON.parse(raw);
-      const byokKey = userConfig?.kernel?.anthropicApiKey;
-      if (byokKey && typeof byokKey === "string") {
-        env.ANTHROPIC_API_KEY = byokKey;
-        return env;
-      }
-    } catch (err: unknown) {
-      if (!(err instanceof Error) || (err as NodeJS.ErrnoException).code !== "ENOENT") {
-        logNonFatal("[dispatcher] failed to read user API key config:", err);
-      }
-    }
-
-    try {
-      const raw = await readFile(join(homePath, ".claude.json"), "utf-8");
-      if (hasClaudeOauthConfig(JSON.parse(raw))) {
-        env.HOME = homePath;
-        delete env.ANTHROPIC_API_KEY;
-        delete env.ANTHROPIC_BASE_URL;
-        return env;
-      }
-    } catch (err: unknown) {
-      if (!(err instanceof Error) || (err as NodeJS.ErrnoException).code !== "ENOENT") {
-        logNonFatal("[dispatcher] failed to read Claude OAuth config:", err);
-      }
-    }
-
-    return undefined;
   }
 
   function processQueue() {
@@ -215,7 +176,7 @@ export function createDispatcher(opts: DispatchOptions): Dispatcher {
         sessionId: entry.sessionId,
         model: opts.model,
         maxTurns: opts.maxTurns,
-        env: await buildKernelEnv(),
+        env: await buildKernelEnv(homePath),
       };
 
       for await (const event of spawnFn(message, config, entry.abortController)) {
@@ -349,7 +310,7 @@ export function createDispatcher(opts: DispatchOptions): Dispatcher {
             homePath,
             model: opts.model,
             maxTurns: opts.maxTurns,
-            env: await buildKernelEnv(),
+            env: await buildKernelEnv(homePath),
           };
 
           try {

--- a/packages/gateway/src/kernel-credentials.ts
+++ b/packages/gateway/src/kernel-credentials.ts
@@ -1,0 +1,67 @@
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+
+export type KernelCredentialMode = "platform" | "api_key" | "claude_login";
+
+interface KernelCredentialResolution {
+  mode: KernelCredentialMode;
+  env?: Record<string, string | undefined>;
+}
+
+function hasClaudeOauthConfig(value: unknown): boolean {
+  if (!value || typeof value !== "object") return false;
+  const account = (value as { oauthAccount?: unknown }).oauthAccount;
+  if (!account || typeof account !== "object") return false;
+  return typeof (account as { accountUuid?: unknown }).accountUuid === "string";
+}
+
+function logCredentialReadFailure(label: string, err: unknown): void {
+  console.warn(label, err instanceof Error ? err.message : String(err));
+}
+
+async function resolveKernelCredentials(
+  homePath: string,
+  baseEnv: NodeJS.ProcessEnv = process.env,
+): Promise<KernelCredentialResolution> {
+  const env = { ...baseEnv };
+  try {
+    const raw = await readFile(join(homePath, "system/config.json"), "utf-8");
+    const userConfig = JSON.parse(raw);
+    const byokKey = userConfig?.kernel?.anthropicApiKey;
+    if (byokKey && typeof byokKey === "string") {
+      env.ANTHROPIC_API_KEY = byokKey;
+      return { mode: "api_key", env };
+    }
+  } catch (err) {
+    if (!(err instanceof Error) || (err as NodeJS.ErrnoException).code !== "ENOENT") {
+      logCredentialReadFailure("[kernel-credentials] failed to read user API key config:", err);
+    }
+  }
+
+  try {
+    const raw = await readFile(join(homePath, ".claude.json"), "utf-8");
+    if (hasClaudeOauthConfig(JSON.parse(raw))) {
+      env.HOME = homePath;
+      delete env.ANTHROPIC_API_KEY;
+      delete env.ANTHROPIC_BASE_URL;
+      return { mode: "claude_login", env };
+    }
+  } catch (err) {
+    if (!(err instanceof Error) || (err as NodeJS.ErrnoException).code !== "ENOENT") {
+      logCredentialReadFailure("[kernel-credentials] failed to read Claude OAuth config:", err);
+    }
+  }
+
+  return { mode: "platform" };
+}
+
+export async function buildKernelEnv(
+  homePath: string,
+  baseEnv: NodeJS.ProcessEnv = process.env,
+): Promise<Record<string, string | undefined> | undefined> {
+  return (await resolveKernelCredentials(homePath, baseEnv)).env;
+}
+
+export async function resolveKernelCredentialMode(homePath: string): Promise<KernelCredentialMode> {
+  return (await resolveKernelCredentials(homePath)).mode;
+}

--- a/packages/gateway/src/kernel-settings.ts
+++ b/packages/gateway/src/kernel-settings.ts
@@ -1,0 +1,32 @@
+import {
+  DEFAULT_KERNEL_EFFORT,
+  DEFAULT_KERNEL_MODEL,
+  type KernelEffort,
+} from "@matrix-os/kernel";
+
+export const KERNEL_MODELS = [
+  { id: "claude-opus-4-6", label: "Claude Opus 4.6", tier: "Most capable" },
+  { id: "claude-sonnet-4-5", label: "Claude Sonnet 4.5", tier: "Balanced" },
+  { id: "claude-haiku-4-5", label: "Claude Haiku 4.5", tier: "Fastest" },
+] as const;
+
+export const KERNEL_MODEL_IDS = KERNEL_MODELS.map((model) => model.id) as [string, ...string[]];
+export const KERNEL_EFFORTS = ["low", "medium", "high", "max"] as const;
+export const KERNEL_DEFAULTS = {
+  model: DEFAULT_KERNEL_MODEL,
+  effort: DEFAULT_KERNEL_EFFORT,
+} as const;
+
+export function normalizeKernelModel(value: unknown): string | null {
+  return typeof value === "string" && KERNEL_MODEL_IDS.includes(value) ? value : null;
+}
+
+export function normalizeKernelEffort(value: unknown): KernelEffort | null {
+  return typeof value === "string" && (KERNEL_EFFORTS as readonly string[]).includes(value)
+    ? value as KernelEffort
+    : null;
+}
+
+export function resolveKernelModelOption(model: string): (typeof KERNEL_MODELS)[number] {
+  return KERNEL_MODELS.find((option) => option.id === model) ?? KERNEL_MODELS[0];
+}

--- a/packages/gateway/src/routes/settings.ts
+++ b/packages/gateway/src/routes/settings.ts
@@ -15,6 +15,15 @@ import { DEFAULT_ICON_STYLE, loadSkills } from "@matrix-os/kernel";
 import type { ChannelManager } from "../channels/manager.js";
 import type { ChannelConfig, ChannelId } from "../channels/types.js";
 import { validateApiKeyFormat, validateApiKeyLive, storeApiKey, hasApiKey } from "../onboarding/api-key.js";
+import { buildAgentProfileSummary } from "../agent-profile-summary.js";
+import {
+  KERNEL_DEFAULTS,
+  KERNEL_EFFORTS,
+  KERNEL_MODELS,
+  KERNEL_MODEL_IDS,
+  normalizeKernelEffort,
+  normalizeKernelModel,
+} from "../kernel-settings.js";
 
 const DESKTOP_DEFAULTS = {
   background: { type: "wallpaper", name: "moraine-lake.jpg" },
@@ -26,33 +35,12 @@ const DESKTOP_DEFAULTS = {
 const THEME_DEFAULTS = {};
 const SETTINGS_BODY_LIMIT = 256 * 1024;
 
-// Curated kernel model allowlist surfaced to the agent-config UI. Keep in sync
-// with the kernel runtime; users may only persist a model from this list.
-const KERNEL_MODELS = [
-  { id: "claude-opus-4-6", label: "Claude Opus 4.6", tier: "Most capable" },
-  { id: "claude-sonnet-4-5", label: "Claude Sonnet 4.5", tier: "Balanced" },
-  { id: "claude-haiku-4-5", label: "Claude Haiku 4.5", tier: "Fastest" },
-] as const;
-const KERNEL_MODEL_IDS = KERNEL_MODELS.map((m) => m.id) as [string, ...string[]];
-const KERNEL_EFFORTS = ["low", "medium", "high", "max"] as const;
-const KERNEL_DEFAULTS = { model: "claude-opus-4-6", effort: "high" } as const;
-
 const KernelPatchSchema = z
   .object({
     model: z.enum(KERNEL_MODEL_IDS).optional(),
     effort: z.enum(KERNEL_EFFORTS).optional(),
   })
   .strict();
-
-function normalizeKernelModel(value: unknown): string | null {
-  return typeof value === "string" && KERNEL_MODEL_IDS.includes(value) ? value : null;
-}
-
-function normalizeKernelEffort(value: unknown): string | null {
-  return typeof value === "string" && (KERNEL_EFFORTS as readonly string[]).includes(value)
-    ? value
-    : null;
-}
 
 const WALLPAPER_FILE_EXTENSIONS = new Set([
   ".avif",
@@ -251,6 +239,15 @@ export function createSettingsRoutes(opts: {
       availableEfforts: KERNEL_EFFORTS,
       defaults: KERNEL_DEFAULTS,
     });
+  });
+
+  app.get("/agent/summary", async (c) => {
+    try {
+      return c.json(await buildAgentProfileSummary(homePath));
+    } catch (err) {
+      console.warn("[settings] Failed to build agent summary:", err);
+      return c.json({ error: "Agent summary unavailable" }, 500);
+    }
   });
 
   app.put("/agent", bodyLimit({ maxSize: SETTINGS_BODY_LIMIT }), async (c) => {

--- a/packages/kernel/src/index.ts
+++ b/packages/kernel/src/index.ts
@@ -1,11 +1,14 @@
 export { spawnKernel } from "./kernel.js";
 export type { KernelEvent, KernelResult } from "./kernel.js";
+export { parseFrontmatter } from "./agents.js";
 export {
   DEFAULT_KERNEL_EFFORT,
   DEFAULT_KERNEL_MODEL,
   kernelOptions,
   loadKernelConfigFile,
+  loadKernelConfigFileAsync,
   resolveKernelConfigFile,
+  resolveKernelConfigFileAsync,
 } from "./options.js";
 export type { KernelConfig, KernelEffort } from "./options.js";
 export { createDB } from "./db.js";

--- a/packages/kernel/src/options.ts
+++ b/packages/kernel/src/options.ts
@@ -1,4 +1,12 @@
-import { readFileSync, existsSync } from "node:fs";
+import {
+  closeSync,
+  existsSync,
+  fstatSync,
+  openSync,
+  readFileSync,
+  readSync,
+} from "node:fs";
+import { open } from "node:fs/promises";
 import { join } from "node:path";
 import type { MatrixDB } from "./db.js";
 import { createIpcServer } from "./ipc-server.js";
@@ -71,9 +79,51 @@ function loadBrowserConfig(homePath: string): {
 
 const KERNEL_EFFORT_VALUES = ["low", "medium", "high", "max"] as const;
 const SAFE_KERNEL_MODEL = /^[A-Za-z0-9][A-Za-z0-9_.:-]{0,79}$/;
+const KERNEL_CONFIG_MAX_BYTES = 256 * 1024;
 export type KernelEffort = (typeof KERNEL_EFFORT_VALUES)[number];
 export const DEFAULT_KERNEL_MODEL = "claude-opus-4-6";
 export const DEFAULT_KERNEL_EFFORT: KernelEffort = "high";
+
+function parseKernelConfigFile(raw: string): { model?: string; effort?: KernelEffort } {
+  const config = JSON.parse(raw);
+  const kernel = config.kernel;
+  if (!kernel || typeof kernel !== "object") return {};
+  const model = typeof kernel.model === "string" && SAFE_KERNEL_MODEL.test(kernel.model)
+    ? kernel.model
+    : undefined;
+  const effort = KERNEL_EFFORT_VALUES.includes(kernel.effort) ? (kernel.effort as KernelEffort) : undefined;
+  return { ...(model ? { model } : {}), ...(effort ? { effort } : {}) };
+}
+
+function isMissingKernelConfig(err: unknown): boolean {
+  return err instanceof Error && (err as NodeJS.ErrnoException).code === "ENOENT";
+}
+
+function readKernelConfigBoundedSync(path: string): string | undefined {
+  const fd = openSync(path, "r");
+  try {
+    const stat = fstatSync(fd);
+    if (!stat.isFile() || stat.size > KERNEL_CONFIG_MAX_BYTES) return undefined;
+    const buffer = Buffer.alloc(stat.size);
+    const bytesRead = readSync(fd, buffer, 0, buffer.length, 0);
+    return buffer.subarray(0, bytesRead).toString("utf-8");
+  } finally {
+    closeSync(fd);
+  }
+}
+
+async function readKernelConfigBounded(path: string): Promise<string | undefined> {
+  const file = await open(path, "r");
+  try {
+    const stat = await file.stat();
+    if (!stat.isFile() || stat.size > KERNEL_CONFIG_MAX_BYTES) return undefined;
+    const buffer = Buffer.alloc(stat.size);
+    const { bytesRead } = await file.read(buffer, 0, buffer.length, 0);
+    return buffer.subarray(0, bytesRead).toString("utf-8");
+  } finally {
+    await file.close();
+  }
+}
 
 // User-tunable kernel settings persisted by the gateway settings UI under the
 // `kernel` key of ~/system/config.json (Everything Is a File). Read at spawn so
@@ -81,23 +131,42 @@ export const DEFAULT_KERNEL_EFFORT: KernelEffort = "high";
 export function loadKernelConfigFile(homePath: string): { model?: string; effort?: KernelEffort } {
   try {
     const configPath = join(homePath, "system", "config.json");
-    if (!existsSync(configPath)) return {};
-    const config = JSON.parse(readFileSync(configPath, "utf-8"));
-    const kernel = config.kernel;
-    if (!kernel || typeof kernel !== "object") return {};
-    const model = typeof kernel.model === "string" && SAFE_KERNEL_MODEL.test(kernel.model)
-      ? kernel.model
-      : undefined;
-    const effort = KERNEL_EFFORT_VALUES.includes(kernel.effort) ? (kernel.effort as KernelEffort) : undefined;
-    return { ...(model ? { model } : {}), ...(effort ? { effort } : {}) };
+    const raw = readKernelConfigBoundedSync(configPath);
+    return raw === undefined ? {} : parseKernelConfigFile(raw);
   } catch (err: unknown) {
-    console.warn("[kernel-options] Could not load kernel config:", err instanceof Error ? err.message : String(err));
+    if (!isMissingKernelConfig(err)) {
+      console.warn("[kernel-options] Could not load kernel config:", err instanceof Error ? err.message : String(err));
+    }
+    return {};
+  }
+}
+
+export async function loadKernelConfigFileAsync(
+  homePath: string,
+): Promise<{ model?: string; effort?: KernelEffort }> {
+  try {
+    const raw = await readKernelConfigBounded(join(homePath, "system", "config.json"));
+    return raw === undefined ? {} : parseKernelConfigFile(raw);
+  } catch (err: unknown) {
+    if (!isMissingKernelConfig(err)) {
+      console.warn("[kernel-options] Could not load kernel config:", err instanceof Error ? err.message : String(err));
+    }
     return {};
   }
 }
 
 export function resolveKernelConfigFile(homePath: string): { model: string; effort: KernelEffort } {
   const fileKernel = loadKernelConfigFile(homePath);
+  return {
+    model: fileKernel.model ?? DEFAULT_KERNEL_MODEL,
+    effort: fileKernel.effort ?? DEFAULT_KERNEL_EFFORT,
+  };
+}
+
+export async function resolveKernelConfigFileAsync(
+  homePath: string,
+): Promise<{ model: string; effort: KernelEffort }> {
+  const fileKernel = await loadKernelConfigFileAsync(homePath);
   return {
     model: fileKernel.model ?? DEFAULT_KERNEL_MODEL,
     effort: fileKernel.effort ?? DEFAULT_KERNEL_EFFORT,

--- a/tests/contracts/agent-profile-summary.test.ts
+++ b/tests/contracts/agent-profile-summary.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import { AgentProfileSummarySchema } from "../../packages/contracts/src/index.js";
+
+describe("AgentProfileSummarySchema", () => {
+  it("accepts a bounded structured profile without credential material", () => {
+    expect(AgentProfileSummarySchema.parse({
+      identity: { name: "Hermes", tagline: "A thoughtful operating-system companion." },
+      kernel: {
+        model: "claude-opus-4-6",
+        modelLabel: "Claude Opus 4.6",
+        effort: "high",
+      },
+      credentials: { mode: "platform" },
+      soulPreview: "Be genuinely helpful, resourceful, and careful with private information.",
+    })).toEqual({
+      identity: { name: "Hermes", tagline: "A thoughtful operating-system companion." },
+      kernel: {
+        model: "claude-opus-4-6",
+        modelLabel: "Claude Opus 4.6",
+        effort: "high",
+      },
+      credentials: { mode: "platform" },
+      soulPreview: "Be genuinely helpful, resourceful, and careful with private information.",
+    });
+  });
+
+  it("rejects oversized, unsafe, or secret-bearing response fields", () => {
+    const valid = {
+      identity: { name: "Hermes" },
+      kernel: {
+        model: "claude-opus-4-6",
+        modelLabel: "Claude Opus 4.6",
+        effort: "high" as const,
+      },
+      credentials: { mode: "platform" as const },
+      soulPreview: "A safe preview.",
+    };
+
+    expect(AgentProfileSummarySchema.safeParse({
+      ...valid,
+      soulPreview: "x".repeat(281),
+    }).success).toBe(false);
+    expect(AgentProfileSummarySchema.safeParse({
+      ...valid,
+      soulPreview: "Read /opt/matrix/private before replying.",
+    }).success).toBe(false);
+    expect(AgentProfileSummarySchema.safeParse({
+      ...valid,
+      credentials: { mode: "sk-ant-secret-material" },
+    }).success).toBe(false);
+  });
+});

--- a/tests/gateway/kernel-credentials.test.ts
+++ b/tests/gateway/kernel-credentials.test.ts
@@ -1,0 +1,58 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  buildKernelEnv,
+  resolveKernelCredentialMode,
+} from "../../packages/gateway/src/kernel-credentials.js";
+
+describe("kernel credential resolution", () => {
+  let homePath: string;
+
+  beforeEach(() => {
+    homePath = mkdtempSync(join(tmpdir(), "kernel-credentials-"));
+    mkdirSync(join(homePath, "system"), { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(homePath, { recursive: true, force: true });
+  });
+
+  it("prefers an owner API key over a Claude login", async () => {
+    writeFileSync(
+      join(homePath, "system/config.json"),
+      JSON.stringify({ kernel: { anthropicApiKey: "sk-ant-owner-key" } }),
+    );
+    writeFileSync(
+      join(homePath, ".claude.json"),
+      JSON.stringify({ oauthAccount: { accountUuid: "oauth-account" } }),
+    );
+
+    expect(await resolveKernelCredentialMode(homePath)).toBe("api_key");
+    await expect(buildKernelEnv(homePath, { ANTHROPIC_API_KEY: "platform-key" })).resolves.toMatchObject({
+      ANTHROPIC_API_KEY: "sk-ant-owner-key",
+    });
+  });
+
+  it("uses a Claude login before the platform environment", async () => {
+    writeFileSync(
+      join(homePath, ".claude.json"),
+      JSON.stringify({ oauthAccount: { accountUuid: "oauth-account" } }),
+    );
+
+    expect(await resolveKernelCredentialMode(homePath)).toBe("claude_login");
+    const env = await buildKernelEnv(homePath, {
+      ANTHROPIC_API_KEY: "platform-key",
+      ANTHROPIC_BASE_URL: "https://proxy.example.com",
+    });
+    expect(env?.HOME).toBe(homePath);
+    expect(env?.ANTHROPIC_API_KEY).toBeUndefined();
+    expect(env?.ANTHROPIC_BASE_URL).toBeUndefined();
+  });
+
+  it("uses platform mode when owner credentials are absent", async () => {
+    expect(await resolveKernelCredentialMode(homePath)).toBe("platform");
+    await expect(buildKernelEnv(homePath, { ANTHROPIC_API_KEY: "platform-key" })).resolves.toBeUndefined();
+  });
+});

--- a/tests/gateway/settings-agent-summary.test.ts
+++ b/tests/gateway/settings-agent-summary.test.ts
@@ -1,0 +1,171 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { Hono } from "hono";
+import { createSettingsRoutes } from "../../packages/gateway/src/routes/settings.js";
+
+function stubChannelManager() {
+  return {
+    status: () => ({}),
+    start: async () => {},
+    stop: async () => {},
+    send: () => {},
+    replay: async () => {},
+    restartChannel: async () => {},
+  };
+}
+
+describe("GET /api/settings/agent/summary", () => {
+  let homePath: string;
+  let app: Hono;
+
+  beforeEach(() => {
+    homePath = resolve(mkdtempSync(join(tmpdir(), "settings-agent-summary-")));
+    mkdirSync(join(homePath, "system"), { recursive: true });
+    writeFileSync(join(homePath, "system/config.json"), "{}");
+    app = new Hono();
+    app.route("/api/settings", createSettingsRoutes({
+      homePath,
+      channelManager: stubChannelManager() as never,
+    }));
+  });
+
+  afterEach(() => {
+    rmSync(homePath, { recursive: true, force: true });
+  });
+
+  it("returns bounded identity, kernel, credential, and soul summary fields", async () => {
+    writeFileSync(
+      join(homePath, "system/config.json"),
+      JSON.stringify({ kernel: { model: "claude-sonnet-4-5", effort: "low" } }),
+    );
+    writeFileSync(
+      join(homePath, "system/soul.md"),
+      [
+        "---",
+        "name: Nova",
+        "tagline: A clear-thinking companion.",
+        "---",
+        "# Nova",
+        "",
+        "I help my owner reason carefully and act with confidence.",
+      ].join("\n"),
+    );
+
+    const res = await app.request("/api/settings/agent/summary");
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      identity: { name: "Nova", tagline: "A clear-thinking companion." },
+      kernel: {
+        model: "claude-sonnet-4-5",
+        modelLabel: "Claude Sonnet 4.5",
+        effort: "low",
+      },
+      credentials: { mode: "platform" },
+      soulPreview: "I help my owner reason carefully and act with confidence.",
+    });
+  });
+
+  it("reports API-key mode by precedence without returning credential material", async () => {
+    writeFileSync(
+      join(homePath, "system/config.json"),
+      JSON.stringify({
+        kernel: {
+          model: "claude-opus-4-6",
+          effort: "high",
+          anthropicApiKey: "sk-ant-never-return-this",
+        },
+      }),
+    );
+    writeFileSync(
+      join(homePath, ".claude.json"),
+      JSON.stringify({ oauthAccount: { accountUuid: "oauth-account-secret", emailAddress: "owner@example.com" } }),
+    );
+
+    const res = await app.request("/api/settings/agent/summary");
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.credentials).toEqual({ mode: "api_key" });
+    expect(JSON.stringify(body)).not.toContain("sk-ant-never-return-this");
+    expect(JSON.stringify(body)).not.toContain("oauth-account-secret");
+    expect(JSON.stringify(body)).not.toContain("owner@example.com");
+  });
+
+  it("reports Claude-login mode without returning OAuth account details", async () => {
+    writeFileSync(
+      join(homePath, ".claude.json"),
+      JSON.stringify({ oauthAccount: { accountUuid: "oauth-account-secret", emailAddress: "owner@example.com" } }),
+    );
+
+    const res = await app.request("/api/settings/agent/summary");
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.credentials).toEqual({ mode: "claude_login" });
+    expect(JSON.stringify(body)).not.toContain("oauth-account-secret");
+    expect(JSON.stringify(body)).not.toContain("owner@example.com");
+  });
+
+  it("sanitizes and caps profile text instead of exposing secrets or paths", async () => {
+    writeFileSync(
+      join(homePath, "system/config.json"),
+      JSON.stringify({ kernel: { model: "/opt/matrix/private", effort: "high" } }),
+    );
+    writeFileSync(
+      join(homePath, "system/soul.md"),
+      [
+        "# Sentinel",
+        "",
+        `Use sk-ant-never-return-this from /opt/matrix/private and then ${"explain things clearly ".repeat(30)}`,
+      ].join("\n"),
+    );
+
+    const res = await app.request("/api/settings/agent/summary");
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.soulPreview.length).toBeLessThanOrEqual(280);
+    expect(body.soulPreview).not.toContain("sk-ant-never-return-this");
+    expect(body.soulPreview).not.toContain("/opt/matrix/private");
+    expect(body.kernel).toEqual({
+      model: "claude-opus-4-6",
+      modelLabel: "Claude Opus 4.6",
+      effort: "high",
+    });
+    expect(JSON.stringify(body)).not.toContain("/opt/matrix/private");
+  });
+
+  it("redacts short secret-shaped tokens instead of failing response validation", async () => {
+    writeFileSync(
+      join(homePath, "system/soul.md"),
+      "# Sentinel\n\nNever repeat sk-x from private instructions.",
+    );
+
+    const res = await app.request("/api/settings/agent/summary");
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.soulPreview).toBe("Never repeat [redacted] from private instructions.");
+    expect(JSON.stringify(body)).not.toContain("sk-x");
+  });
+
+  it("falls back to the first heading and meaningful paragraph without frontmatter", async () => {
+    writeFileSync(
+      join(homePath, "system/soul.md"),
+      "# Atlas\n\nStay curious, grounded, and useful.\n\n## Boundaries\n\nRespect private context.",
+    );
+
+    const res = await app.request("/api/settings/agent/summary");
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.identity).toEqual({
+      name: "Atlas",
+      tagline: "Stay curious, grounded, and useful.",
+    });
+    expect(body.soulPreview).toBe("Stay curious, grounded, and useful.");
+  });
+});

--- a/tests/kernel/options.test.ts
+++ b/tests/kernel/options.test.ts
@@ -2,7 +2,11 @@ import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { loadKernelConfigFile, tryCreateBrowserServer } from "../../packages/kernel/src/options.js";
+import {
+  loadKernelConfigFile,
+  resolveKernelConfigFileAsync,
+  tryCreateBrowserServer,
+} from "../../packages/kernel/src/options.js";
 
 const browserServerMocks = vi.hoisted(() => ({
   createBrowserMcpServer: vi.fn((config: unknown) => ({
@@ -89,5 +93,32 @@ describe("loadKernelConfigFile", () => {
   it("does not throw on malformed JSON", () => {
     writeFileSync(join(homePath, "system", "config.json"), "{not json");
     expect(loadKernelConfigFile(homePath)).toEqual({});
+  });
+
+  it("resolves kernel config asynchronously with the runtime defaults", async () => {
+    writeConfig({ kernel: { model: "claude-sonnet-4-5", effort: "medium" } });
+    await expect(resolveKernelConfigFileAsync(homePath)).resolves.toEqual({
+      model: "claude-sonnet-4-5",
+      effort: "medium",
+    });
+
+    writeFileSync(join(homePath, "system", "config.json"), "{not json");
+    await expect(resolveKernelConfigFileAsync(homePath)).resolves.toEqual({
+      model: "claude-opus-4-6",
+      effort: "high",
+    });
+  });
+
+  it("bounds kernel config reads consistently across sync and async loaders", async () => {
+    writeConfig({
+      kernel: { model: "claude-sonnet-4-5", effort: "medium" },
+      padding: "x".repeat(300 * 1024),
+    });
+
+    expect(loadKernelConfigFile(homePath)).toEqual({});
+    await expect(resolveKernelConfigFileAsync(homePath)).resolves.toEqual({
+      model: "claude-opus-4-6",
+      effort: "high",
+    });
   });
 });


### PR DESCRIPTION
## Summary

- Add `GET /api/settings/agent/summary` with a Zod-validated identity, kernel, credential-mode, and soul-preview response.
- Reuse the kernel frontmatter parser, kernel config resolver, and Settings model catalog.
- Extract credential precedence from the dispatcher so dispatch and diagnostics cannot drift.
- Bound soul reads to 16 KiB and sanitize/cap every display string.

## Tests

- `pnpm exec vitest run tests/contracts/agent-profile-summary.test.ts tests/gateway/kernel-credentials.test.ts tests/gateway/settings-agent-summary.test.ts tests/gateway/settings-desktop.test.ts tests/gateway/dispatcher-logging.test.ts`
- Relevant combined stack: 80/80 tests pass.
- Contracts, kernel, and gateway TypeScript checks pass.
- `bun run check:patterns`

## Review / Monitoring

- Greptile 5/5 required before merge.
- CI must be green on the current head before the `ready-for-ci` label is applied.

## Invariants

- Sources of truth: `~/system/soul.md` for identity/preview, `~/system/config.json` plus the existing Settings catalog for model/effort/label, and the dispatcher's credential precedence for billing mode.
- Fallback order: frontmatter name/tagline, then first heading/meaningful paragraph; valid configured model/effort, then Opus 4.6/high; owner API key, then Claude login, then platform credentials.
- Lock / transaction scope: bounded read-only file access; no database writes, locks, or transactions.
- Acceptable orphan states: missing soul/config/login files produce a bounded default profile; malformed sensitive config never becomes response data.
- Auth source of truth: the existing authenticated `/api/settings` router boundary is unchanged.
- Secrecy: credential output is enum-only; no key, OAuth account, raw error, or filesystem path is returned. Profile strings are bounded and sanitized.
- Back compatibility: `GET /api/ai-profile` and `GET /api/settings/agent` remain unchanged; the summary route is additive.
- Deferred scope: desktop/mobile profile rendering is intentionally separate.

