### PR TITLE
docs(agents): add stacked-PR merge safety rules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -356,6 +356,27 @@ Every backend PR must include an "Invariants" section:
 
 Do not request review while still pushing commits. Either declare a review commit range or mark the PR as ready and stop pushing.
 
+### Stacked-PR Merge Safety (NON-NEGOTIABLE)
+
+Learned from the 2026-07-13 merge cascade (PRs #932/#934/#935/#926/#933/#941/#945/#948:
+children merged into parent branches instead of `main`, and four PRs became
+unrecoverable-closed, requiring reland PRs). When landing a stack:
+
+- **Merge a PR only when its base branch is `main`.** Verify first:
+  `gh pr view <n> --json baseRefName`. Merging a stacked PR whose base is another
+  PR's branch lands the child INTO that branch, not into `main`, while GitHub still
+  reports it "merged".
+- **Never pass `--delete-branch` while any later PR in the stack is open.** Branch
+  deletion races GitHub's automatic retargeting; the next merge in a loop can land in
+  the wrong base. Delete branches only after the entire stack has landed.
+- **Never loop `gh pr merge` over a stack.** Land strictly one at a time: merge the
+  bottom PR, wait until the next PR's base shows `main`, then merge it.
+- A closed PR whose base branch was deleted **cannot be reopened or retargeted**
+  (GitHub rejects both). Recovery requires fresh consolidation PRs from the surviving
+  branch tips and a full re-review — far more expensive than merging slowly.
+- Prefer Graphite for the whole lifecycle (`docs/dev/stacked-prs.md`): `gt`-tracked
+  stacks own retarget/restack sequencing and make this class of failure impossible.
+
 ### Hard Rules (never violate)
 
 - **All changes ship via PR from a manual `git worktree`** -- no direct commits to `main`, no exceptions. Create the worktree with `git worktree add -b <kebab-branch> ../<dir-name> origin/main` and do all work there. Applies to code AND docs.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -358,9 +358,16 @@ Do not request review while still pushing commits. Either declare a review commi
 
 ### Stacked-PR Merge Safety (NON-NEGOTIABLE)
 
+**Stacked PRs are managed with Graphite (`gt`) end to end — create, restack, submit,
+AND merge (`gt merge` / Graphite web queue). Raw `gh`/`git` is NOT the tool for stack
+operations.** If a stack was not created with `gt`, track it (`gt track`) before
+landing it. Full workflow: `docs/dev/stacked-prs.md`.
+
 Learned from the 2026-07-13 merge cascade (PRs #932/#934/#935/#926/#933/#941/#945/#948:
-children merged into parent branches instead of `main`, and four PRs became
-unrecoverable-closed, requiring reland PRs). When landing a stack:
+a raw `gh pr merge` loop merged children into parent branches instead of `main`, and
+four PRs became unrecoverable-closed, requiring reland PRs). If you must land a stack
+without Graphite (last resort, e.g. `gt` unauthenticated — normally an environment
+blocker, not a green light):
 
 - **Merge a PR only when its base branch is `main`.** Verify first:
   `gh pr view <n> --json baseRefName`. Merging a stacked PR whose base is another
@@ -374,8 +381,6 @@ unrecoverable-closed, requiring reland PRs). When landing a stack:
 - A closed PR whose base branch was deleted **cannot be reopened or retargeted**
   (GitHub rejects both). Recovery requires fresh consolidation PRs from the surviving
   branch tips and a full re-review — far more expensive than merging slowly.
-- Prefer Graphite for the whole lifecycle (`docs/dev/stacked-prs.md`): `gt`-tracked
-  stacks own retarget/restack sequencing and make this class of failure impossible.
 
 ### Hard Rules (never violate)
 


### PR DESCRIPTION
Codifies the stacked-merge sequencing rules learned from today's merge cascade (#932–#948): merge only base=main, no --delete-branch while the stack is open, never loop gh pr merge, closed-PR-with-deleted-base is unrecoverable, prefer gt. Docs-only.