### PR TITLE
feat(gateway): expose stored conversation transcripts

### DIFF
--- a/packages/gateway/src/conversations.ts
+++ b/packages/gateway/src/conversations.ts
@@ -46,7 +46,7 @@ export interface ConversationStore {
   get(id: string): ConversationFile | null;
   create(channel?: string): string;
   delete(id: string): boolean;
-  search(query: string, opts?: { limit?: number }): SearchResult[];
+  search(query: string, opts?: { limit?: number; sessionId?: string }): SearchResult[];
 }
 
 const CONVERSATION_IDLE_TTL_MS = 30 * 60 * 1000; // 30 minutes
@@ -266,7 +266,10 @@ export function createConversationStore(homePath: string): ConversationStore {
       const lowerQuery = query.toLowerCase();
       const results: SearchResult[] = [];
 
-      const files = readdirSync(dir).filter((f) => f.endsWith(".json"));
+      const files = readdirSync(dir).filter((fileName) =>
+        fileName.endsWith(".json")
+        && (!opts?.sessionId || fileName === `${opts.sessionId}.json`)
+      );
       for (const f of files) {
         const id = f.replace(".json", "");
         const conv = readFromDisk(id);

--- a/packages/gateway/src/routes/conversations.ts
+++ b/packages/gateway/src/routes/conversations.ts
@@ -28,14 +28,14 @@ export function createConversationRoutes(conversations: ConversationStore): Hono
   app.get("/", (c) => c.json(conversations.list()));
 
   app.post("/", routeBodyLimit, async (c) => {
-    let raw: unknown;
+    let raw: unknown = {};
     try {
       raw = await c.req.json();
     } catch (error: unknown) {
       if (!(error instanceof SyntaxError)) {
         console.error("[conversations] Failed to read create request body", error);
+        return c.json({ error: "Invalid request" }, 400);
       }
-      return c.json({ error: "Invalid request" }, 400);
     }
 
     const parsed = CreateConversationSchema.safeParse(raw);
@@ -78,7 +78,10 @@ export function createConversationRoutes(conversations: ConversationStore): Hono
     });
     if (!parsed.success) return c.json({ error: "Invalid search query" }, 400);
 
-    return c.json(conversations.search(parsed.data.q, { limit: parsed.data.limit }));
+    return c.json(conversations.search(parsed.data.q, {
+      limit: parsed.data.limit,
+      sessionId: id,
+    }));
   });
 
   return app;

--- a/packages/gateway/src/routes/conversations.ts
+++ b/packages/gateway/src/routes/conversations.ts
@@ -1,0 +1,85 @@
+import { Hono } from "hono";
+import { bodyLimit } from "hono/body-limit";
+import { z } from "zod/v4";
+import type { ConversationStore } from "../conversations.js";
+
+const CONVERSATION_BODY_LIMIT_BYTES = 4 * 1024;
+const ConversationIdSchema = z.string()
+  .min(1)
+  .max(256)
+  .regex(/^[A-Za-z0-9][A-Za-z0-9_.:-]*$/);
+const CreateConversationSchema = z.object({
+  channel: z.string().trim().min(1).max(32).regex(/^[a-z][a-z0-9_-]*$/).optional(),
+}).strict();
+const SearchConversationSchema = z.object({
+  q: z.string().trim().min(1).max(512),
+  limit: z.coerce.number().int().min(1).max(100).optional(),
+}).strict();
+
+function parseConversationId(value: string): string | null {
+  const parsed = ConversationIdSchema.safeParse(value);
+  return parsed.success ? parsed.data : null;
+}
+
+export function createConversationRoutes(conversations: ConversationStore): Hono {
+  const app = new Hono();
+  const routeBodyLimit = bodyLimit({ maxSize: CONVERSATION_BODY_LIMIT_BYTES });
+
+  app.get("/", (c) => c.json(conversations.list()));
+
+  app.post("/", routeBodyLimit, async (c) => {
+    let raw: unknown;
+    try {
+      raw = await c.req.json();
+    } catch (error: unknown) {
+      if (!(error instanceof SyntaxError)) {
+        console.error("[conversations] Failed to read create request body", error);
+      }
+      return c.json({ error: "Invalid request" }, 400);
+    }
+
+    const parsed = CreateConversationSchema.safeParse(raw);
+    if (!parsed.success) return c.json({ error: "Invalid request" }, 400);
+
+    const id = conversations.create(parsed.data.channel);
+    return c.json({ id }, 201);
+  });
+
+  app.get("/:id", (c) => {
+    const id = parseConversationId(c.req.param("id"));
+    if (!id) return c.json({ error: "Invalid conversation id" }, 400);
+
+    try {
+      const conversation = conversations.get(id);
+      if (!conversation) return c.json({ error: "conversation_not_found" }, 404);
+      return c.json(conversation);
+    } catch (error: unknown) {
+      console.error("[conversations] Failed to load stored conversation", error);
+      return c.json({ error: "Unable to load conversation" }, 500);
+    }
+  });
+
+  app.delete("/:id", routeBodyLimit, (c) => {
+    const id = parseConversationId(c.req.param("id"));
+    if (!id) return c.json({ error: "Invalid conversation id" }, 400);
+
+    const deleted = conversations.delete(id);
+    if (!deleted) return c.json({ error: "Not found" }, 404);
+    return c.json({ ok: true });
+  });
+
+  app.get("/:id/search", (c) => {
+    const id = parseConversationId(c.req.param("id"));
+    if (!id) return c.json({ error: "Invalid conversation id" }, 400);
+
+    const parsed = SearchConversationSchema.safeParse({
+      q: c.req.query("q"),
+      limit: c.req.query("limit"),
+    });
+    if (!parsed.success) return c.json({ error: "Invalid search query" }, 400);
+
+    return c.json(conversations.search(parsed.data.q, { limit: parsed.data.limit }));
+  });
+
+  return app;
+}

--- a/packages/gateway/src/server.ts
+++ b/packages/gateway/src/server.ts
@@ -180,6 +180,7 @@ import {
 } from "./plugins/index.js";
 import { createSettingsRoutes } from "./routes/settings.js";
 import { createHermesRoutes, validateHermesDashboardUrl } from "./routes/hermes.js";
+import { createConversationRoutes } from "./routes/conversations.js";
 import { syncApp, createSyncRoutes, type SyncRouteDeps } from "./sync/routes.js";
 import { createR2Client, type R2Client, type R2ClientConfig } from "./sync/r2-client.js";
 import { createPlatformR2Client } from "./sync/platform-r2-client.js";
@@ -2786,7 +2787,6 @@ export async function createGateway(config: GatewayConfig) {
   const apiMessageBodyLimit = bodyLimit({ maxSize: 64 * 1024 });
   const bridgeQueryBodyLimit = bodyLimit({ maxSize: 1_000_000 });
   const bridgeDataBodyLimit = bodyLimit({ maxSize: 1_000_000 });
-  const conversationBodyLimit = bodyLimit({ maxSize: 4096 });
   const layoutBodyLimit = bodyLimit({ maxSize: 100_000 });
   const canvasBodyLimit = bodyLimit({ maxSize: 100_000 });
   const taskBodyLimit = bodyLimit({ maxSize: 64 * 1024 });
@@ -3334,37 +3334,7 @@ export async function createGateway(config: GatewayConfig) {
     }
   });
 
-  app.get("/api/conversations", (c) => {
-    return c.json(conversations.list());
-  });
-
-  app.post("/api/conversations", conversationBodyLimit, async (c) => {
-    let body: { channel?: string } = {};
-    try {
-      body = await c.req.json<{ channel?: string }>();
-    } catch (err: unknown) {
-      if (!(err instanceof SyntaxError)) {
-        console.error("[gateway] Failed to read conversation create body:", err);
-      }
-    }
-    const id = conversations.create(body.channel);
-    return c.json({ id }, 201);
-  });
-
-  app.delete("/api/conversations/:id", (c) => {
-    const id = c.req.param("id");
-    const deleted = conversations.delete(id);
-    if (!deleted) return c.json({ error: "Not found" }, 404);
-    return c.json({ ok: true });
-  });
-
-  app.get("/api/conversations/:id/search", (c) => {
-    const query = c.req.query("q");
-    if (!query) return c.json({ error: "q parameter required" }, 400);
-    const limit = c.req.query("limit") ? Number(c.req.query("limit")) : undefined;
-    const results = conversations.search(query, { limit });
-    return c.json(results);
-  });
+  app.route("/api/conversations", createConversationRoutes(conversations));
 
   app.get("/api/layout", (c) => {
     const layoutPath = join(homePath, "system/layout.json");

--- a/tests/e2e/api/conversations.e2e.test.ts
+++ b/tests/e2e/api/conversations.e2e.test.ts
@@ -1,3 +1,5 @@
+import { writeFile } from "node:fs/promises";
+import { join } from "node:path";
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import { startTestGateway, type TestGateway } from "../fixtures/gateway.js";
 
@@ -56,6 +58,41 @@ describe("E2E: Conversation Management", () => {
       expect(conv).toHaveProperty("createdAt");
       expect(conv).toHaveProperty("updatedAt");
     }
+  });
+
+  it("GET /api/conversations/:id returns the stored transcript in order", async () => {
+    const conversation = {
+      id: "mobile-session-1",
+      createdAt: 1_700_000_000_000,
+      updatedAt: 1_700_000_000_200,
+      messages: [
+        { role: "user", content: "first", timestamp: 1_700_000_000_100 },
+        { role: "assistant", content: "second", timestamp: 1_700_000_000_200 },
+      ],
+    };
+    await writeFile(
+      join(gw.homePath, "system", "conversations", `${conversation.id}.json`),
+      JSON.stringify(conversation),
+    );
+
+    const res = await fetch(`${gw.url}/api/conversations/${conversation.id}`);
+
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual(conversation);
+  });
+
+  it("GET /api/conversations/:id returns 404 for an unknown transcript", async () => {
+    const res = await fetch(`${gw.url}/api/conversations/missing-session`);
+
+    expect(res.status).toBe(404);
+    await expect(res.json()).resolves.toEqual({ error: "conversation_not_found" });
+  });
+
+  it("GET /api/conversations/:id rejects unsafe identifiers", async () => {
+    const res = await fetch(`${gw.url}/api/conversations/unsafe%24id`);
+
+    expect(res.status).toBe(400);
+    await expect(res.json()).resolves.toEqual({ error: "Invalid conversation id" });
   });
 
   it("DELETE /api/conversations/:id removes a conversation", async () => {

--- a/tests/e2e/api/conversations.e2e.test.ts
+++ b/tests/e2e/api/conversations.e2e.test.ts
@@ -60,6 +60,24 @@ describe("E2E: Conversation Management", () => {
     }
   });
 
+  it("POST /api/conversations preserves bodyless create compatibility", async () => {
+    const res = await fetch(`${gw.url}/api/conversations`, { method: "POST" });
+
+    expect(res.status).toBe(201);
+    await expect(res.json()).resolves.toMatchObject({ id: expect.any(String) });
+  });
+
+  it("POST /api/conversations preserves non-JSON create compatibility", async () => {
+    const res = await fetch(`${gw.url}/api/conversations`, {
+      method: "POST",
+      headers: { "Content-Type": "text/plain" },
+      body: "legacy-client-body",
+    });
+
+    expect(res.status).toBe(201);
+    await expect(res.json()).resolves.toMatchObject({ id: expect.any(String) });
+  });
+
   it("GET /api/conversations/:id returns the stored transcript in order", async () => {
     const conversation = {
       id: "mobile-session-1",
@@ -93,6 +111,37 @@ describe("E2E: Conversation Management", () => {
 
     expect(res.status).toBe(400);
     await expect(res.json()).resolves.toEqual({ error: "Invalid conversation id" });
+  });
+
+  it("GET /api/conversations/:id/search stays within the selected transcript", async () => {
+    const selected = {
+      id: "selected-search-session",
+      createdAt: 1_700_000_000_000,
+      updatedAt: 1_700_000_000_100,
+      messages: [
+        { role: "user", content: "shared route search phrase", timestamp: 1_700_000_000_100 },
+      ],
+    };
+    const other = {
+      ...selected,
+      id: "other-search-session",
+      messages: [
+        { role: "user", content: "shared route search phrase", timestamp: 1_700_000_000_200 },
+      ],
+    };
+    await Promise.all([selected, other].map((conversation) => writeFile(
+      join(gw.homePath, "system", "conversations", `${conversation.id}.json`),
+      JSON.stringify(conversation),
+    )));
+
+    const res = await fetch(
+      `${gw.url}/api/conversations/${selected.id}/search?q=shared%20route%20search%20phrase`,
+    );
+
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual([
+      expect.objectContaining({ sessionId: selected.id }),
+    ]);
   });
 
   it("DELETE /api/conversations/:id removes a conversation", async () => {

--- a/tests/gateway/conversations.test.ts
+++ b/tests/gateway/conversations.test.ts
@@ -360,6 +360,22 @@ describe("ConversationStore", () => {
       expect(results.every((r) => r.content.includes("world"))).toBe(true);
     });
 
+    it("limits results to one session when a sessionId is provided", () => {
+      const store = createConversationStore(homePath);
+      const selectedId = store.create();
+      store.addUserMessage(selectedId, "shared search phrase in selected session");
+      store.finalize(selectedId);
+
+      const otherId = store.create();
+      store.addUserMessage(otherId, "shared search phrase in another session");
+      store.finalize(otherId);
+
+      const results = store.search("shared search phrase", { sessionId: selectedId });
+
+      expect(results).toHaveLength(1);
+      expect(results[0].sessionId).toBe(selectedId);
+    });
+
     it("returns empty array when nothing matches", () => {
       const store = createConversationStore(homePath);
       const id = store.create();


### PR DESCRIPTION
## Summary

- add `GET /api/conversations/:id` so mobile and other shells can restore the owner's stored transcript when switching sessions
- return messages in stored order with a bounded `conversation_not_found` error
- extract conversation endpoints from the gateway composition file into a focused route module
- validate path/query/body values with Zod, apply `bodyLimit` to mutations, scope search to the selected transcript, and preserve bodyless create compatibility

## TDD and validation

- Ordered transcript, missing transcript, and unsafe-id E2E cases were observed red before implementation.
- Review cases were observed red for cross-transcript search leakage and create compatibility.
- Focused conversation scope: 47/47 passed.
- Exact current-main stack-tip gate: typecheck passed; pattern scan reported 0 violations; 785 files passed, 3 skipped; 8,478 tests passed, 20 skipped.
- Exact head: `a29072ae35350e9904bc013d590266959a7cb62c`.

## Stack

- #960 — spec and spike
- this PR — stored conversation transcript

## Invariants

- **Source of truth:** Owner transcript files under `$MATRIX_HOME/system/conversations/` remain authoritative; this route exposes `ConversationStore.get(id)` and creates no parallel persistence.
- **Lock/transaction scope:** Transcript reads and search are read-only. Existing mutations remain scoped to `ConversationStore`; no new lock, transaction, or multi-write sequence is introduced.
- **Acceptable orphan states:** Missing transcripts return `conversation_not_found`; malformed stored files return a generic server error and remain owner-local for recovery.
- **Auth source of truth:** Existing gateway auth protects `/api/conversations/*`; the store remains scoped to the current computer owner's home.
- **Deferred scope:** Transcript pagination, migration to async/capped storage, and mobile UI adoption remain separate work.
- Search validates the requested id before reading and does not scan another transcript. Identifiers are bounded before filesystem-backed operations.
- Client errors expose no path, parse error, credential, provider, or upstream detail. Mutations use a 4 KiB body limit, including DELETE.
- This PR has 197 additions across 5 files, below the 3,000-addition/50-file limits, and will not merge below exact-head Greptile 5/5.

## Rollout

- no merge or promotion requested
- verify create/read/search/missing/unsafe-id behavior through the exact preview gateway
