### PR TITLE
feat(gateway): send-first terminal output pipeline with bounded persistence

### DIFF
--- a/distro/customer-vps/cloud-init.yaml
+++ b/distro/customer-vps/cloud-init.yaml
@@ -93,6 +93,8 @@ write_files:
       ExecStart=/opt/matrix/bin/matrix-gateway
       Restart=on-failure
       RestartSec=5
+      MemoryHigh=1G
+      MemoryMax=1536M
 
       [Install]
       WantedBy=multi-user.target

--- a/distro/customer-vps/systemd/matrix-gateway.service
+++ b/distro/customer-vps/systemd/matrix-gateway.service
@@ -17,6 +17,10 @@ ExecStart=/opt/matrix/bin/matrix-gateway
 TimeoutStartSec=720
 Restart=on-failure
 RestartSec=5
+# Contain gateway memory so a leak throttles and restarts this unit instead
+# of driving the whole host into OOM (spec 107 Phase 1 guardrail).
+MemoryHigh=1G
+MemoryMax=1536M
 
 [Install]
 WantedBy=multi-user.target

--- a/packages/gateway/src/server.ts
+++ b/packages/gateway/src/server.ts
@@ -239,6 +239,7 @@ import {
   ShellPreferencesStore,
   createPendingTerminalInputQueue,
   createShellCommandRunner,
+  createShellSessionReaper,
   createShellWsHandler,
   createZellijAdapter,
   ShellRegistry as ZellijShellRegistry,
@@ -368,6 +369,8 @@ export async function createGateway(config: GatewayConfig) {
     adapter: zellijAdapter,
     scrollbackStore: shellScrollbackStore,
   });
+  const shellSessionReaper = createShellSessionReaper({ registry: zellijShellRegistry });
+  shellSessionReaper.start();
   const forwardTunnelHub = createForwardTunnelHub();
   // One distinct id for every gateway telemetry event so all events on a
   // dev gateway without owner env vars land under the same person.
@@ -4110,6 +4113,10 @@ export async function createGateway(config: GatewayConfig) {
     sandbox: {
       status: typeof process.getuid === "function" && process.getuid() === 0 ? "degraded" : "ok",
     },
+    memory: {
+      rssBytes: process.memoryUsage.rss(),
+      pendingPersistBytes: zellijShellWs.pendingPersistBytes(),
+    },
     browserIde: {
       status: process.env.MATRIX_CODE_SERVER_PORT ? "configured" : "disabled",
     },
@@ -4226,6 +4233,8 @@ export async function createGateway(config: GatewayConfig) {
       await channelManager.stop();
       await processManager.shutdownAll();
       await forwardTunnelHub.close();
+      shellSessionReaper.stop();
+      zellijShellWs.dispose();
       await sessionRegistry.shutdown();
       await watcher.close();
       await homeMirror?.stop();

--- a/packages/gateway/src/server.ts
+++ b/packages/gateway/src/server.ts
@@ -4234,7 +4234,7 @@ export async function createGateway(config: GatewayConfig) {
       await processManager.shutdownAll();
       await forwardTunnelHub.close();
       shellSessionReaper.stop();
-      zellijShellWs.dispose();
+      await zellijShellWs.dispose();
       await sessionRegistry.shutdown();
       await watcher.close();
       await homeMirror?.stop();

--- a/packages/gateway/src/shell/index.ts
+++ b/packages/gateway/src/shell/index.ts
@@ -12,4 +12,6 @@ export * from "./replay-buffer.js";
 export * from "./routes.js";
 export * from "./scrollback-store.js";
 export * from "./ws.js";
+export * from "./reaper.js";
+export * from "./output-pipeline.js";
 export * from "./zellij.js";

--- a/packages/gateway/src/shell/output-pipeline.ts
+++ b/packages/gateway/src/shell/output-pipeline.ts
@@ -1,0 +1,172 @@
+import type { ScrollbackRecord } from "./scrollback-store.js";
+
+interface PendingStore {
+  append(name: string, records: ScrollbackRecord[]): Promise<void>;
+}
+
+export interface PendingPersistQueueOptions {
+  store: PendingStore;
+  sessionName: string;
+  flushIntervalMs?: number;
+  flushBytes?: number;
+  maxPendingBytes?: number;
+  maxBackoffMs?: number;
+}
+
+interface PendingEntry {
+  record: ScrollbackRecord;
+  bytes: number;
+}
+
+function recordBytes(record: ScrollbackRecord): number {
+  return record.type === "output" ? Buffer.byteLength(record.data) + 16 : 32;
+}
+
+/**
+ * Coalesces terminal scrollback appends so live output delivery never waits on
+ * disk. Bounded: when the pending queue exceeds its byte cap, the oldest
+ * records are dropped from persistence only (live delivery already happened)
+ * and the dropped range is exposed via evictedThroughSeq so replay can report
+ * the gap. Store failures retry with capped backoff and never propagate.
+ */
+export class PendingPersistQueue {
+  private readonly store: PendingStore;
+  private readonly sessionName: string;
+  private readonly flushIntervalMs: number;
+  private readonly flushBytes: number;
+  private readonly maxPendingBytes: number;
+  private readonly maxBackoffMs: number;
+
+  private pending: PendingEntry[] = [];
+  private bytes = 0;
+  private timer: NodeJS.Timeout | null = null;
+  private flushing: Promise<void> | null = null;
+  private backoffMs = 0;
+  private lastDropWarnAt = 0;
+  private disposed = false;
+
+  evictedThroughSeq: number | null = null;
+
+  constructor(options: PendingPersistQueueOptions) {
+    this.store = options.store;
+    this.sessionName = options.sessionName;
+    this.flushIntervalMs = options.flushIntervalMs ?? 250;
+    this.flushBytes = options.flushBytes ?? 64 * 1024;
+    this.maxPendingBytes = options.maxPendingBytes ?? 4 * 1024 * 1024;
+    this.maxBackoffMs = options.maxBackoffMs ?? 30_000;
+  }
+
+  get pendingBytes(): number {
+    return this.bytes;
+  }
+
+  enqueue(records: ScrollbackRecord[]): void {
+    if (this.disposed || records.length === 0) {
+      return;
+    }
+    for (const record of records) {
+      const size = recordBytes(record);
+      this.pending.push({ record, bytes: size });
+      this.bytes += size;
+    }
+    this.evictOverCap();
+    if (this.bytes >= this.flushBytes) {
+      queueMicrotask(() => {
+        void this.flushNow();
+      });
+      return;
+    }
+    this.scheduleTimer();
+  }
+
+  /** Final drain for shutdown; safe to call repeatedly. */
+  async dispose(): Promise<void> {
+    this.disposed = true;
+    this.clearTimer();
+    await this.flushing;
+    await this.flushNow();
+  }
+
+  private evictOverCap(): void {
+    let droppedThrough: number | null = null;
+    while (this.bytes > this.maxPendingBytes && this.pending.length > 1) {
+      const dropped = this.pending.shift()!;
+      this.bytes -= dropped.bytes;
+      droppedThrough = dropped.record.seq;
+    }
+    if (droppedThrough === null) {
+      return;
+    }
+    this.evictedThroughSeq = Math.max(this.evictedThroughSeq ?? -1, droppedThrough);
+    const now = Date.now();
+    if (now - this.lastDropWarnAt > 10_000) {
+      this.lastDropWarnAt = now;
+      console.warn("[shell] persistence queue over cap; dropped oldest pending scrollback:", {
+        session: this.sessionName,
+        evictedThroughSeq: this.evictedThroughSeq,
+      });
+    }
+  }
+
+  private scheduleTimer(): void {
+    if (this.timer || this.disposed) {
+      return;
+    }
+    const delay = this.backoffMs > 0 ? this.backoffMs : this.flushIntervalMs;
+    this.timer = setTimeout(() => {
+      this.timer = null;
+      void this.flushNow();
+    }, delay);
+    this.timer.unref?.();
+  }
+
+  private clearTimer(): void {
+    if (this.timer) {
+      clearTimeout(this.timer);
+      this.timer = null;
+    }
+  }
+
+  private async flushNow(): Promise<void> {
+    if (this.flushing) {
+      await this.flushing;
+    }
+    if (this.pending.length === 0) {
+      return;
+    }
+    const batch = this.pending;
+    const batchBytes = this.bytes;
+    this.pending = [];
+    this.bytes = 0;
+    const run = this.store
+      .append(this.sessionName, batch.map((entry) => entry.record))
+      .then(() => {
+        this.backoffMs = 0;
+      })
+      .catch((err: unknown) => {
+        // Requeue in front of anything enqueued during the failed flush, then
+        // retry with capped backoff. The byte cap still applies, so a dead
+        // store degrades to bounded drop-oldest rather than unbounded growth.
+        this.pending = batch.concat(this.pending);
+        this.bytes += batchBytes;
+        this.evictOverCap();
+        this.backoffMs = Math.min(
+          this.maxBackoffMs,
+          this.backoffMs > 0 ? this.backoffMs * 2 : this.flushIntervalMs * 4,
+        );
+        console.warn("[shell] scrollback flush failed; will retry:", {
+          session: this.sessionName,
+          backoffMs: this.backoffMs,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      })
+      .finally(() => {
+        this.flushing = null;
+        if (this.pending.length > 0 && !this.disposed) {
+          this.scheduleTimer();
+        }
+      });
+    this.flushing = run;
+    await run;
+  }
+}

--- a/packages/gateway/src/shell/reaper.ts
+++ b/packages/gateway/src/shell/reaper.ts
@@ -1,0 +1,81 @@
+interface ReapableSession {
+  name: string;
+  status?: "active" | "exited";
+  updatedAt?: string;
+  kind?: string;
+}
+
+interface ReaperRegistry {
+  list(): Promise<ReapableSession[]>;
+  delete(name: string, options?: { force?: boolean }): Promise<void>;
+}
+
+export interface ShellSessionReaperOptions {
+  registry: ReaperRegistry;
+  /** Exited sessions older than this are deleted. Default 7 days. */
+  ttlMs?: number;
+  /** Sweep cadence. Default 1 hour. */
+  intervalMs?: number;
+}
+
+/**
+ * Periodically deletes exited zellij sessions (and their scrollback, via the
+ * registry delete cascade) once they age past the retention TTL.
+ *
+ * Only sessions carrying `kind` metadata are eligible: entries that predate
+ * workspace/kind stamping are pre-upgrade user sessions and must survive
+ * until the spec 107 Phase 3 migration has had a chance to convert them.
+ */
+export function createShellSessionReaper(options: ShellSessionReaperOptions) {
+  const ttlMs = options.ttlMs ?? 7 * 24 * 60 * 60 * 1000;
+  const intervalMs = options.intervalMs ?? 60 * 60 * 1000;
+  let timer: NodeJS.Timeout | null = null;
+
+  async function sweep(): Promise<void> {
+    let sessions: ReapableSession[];
+    try {
+      sessions = await options.registry.list();
+    } catch (err: unknown) {
+      console.warn("[shell] session reaper list failed:", err instanceof Error ? err.message : String(err));
+      return;
+    }
+    const cutoff = Date.now() - ttlMs;
+    for (const session of sessions) {
+      if (!session.kind || session.status !== "exited") {
+        continue;
+      }
+      const updatedAt = session.updatedAt ? Date.parse(session.updatedAt) : Number.NaN;
+      if (!Number.isFinite(updatedAt) || updatedAt > cutoff) {
+        continue;
+      }
+      try {
+        await options.registry.delete(session.name, { force: true });
+        console.log("[shell] reaped exited session:", session.name);
+      } catch (err: unknown) {
+        console.warn("[shell] failed to reap session:", {
+          session: session.name,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+    }
+  }
+
+  function start(): void {
+    if (timer) {
+      return;
+    }
+    timer = setInterval(() => {
+      void sweep();
+    }, intervalMs);
+    timer.unref?.();
+  }
+
+  function stop(): void {
+    if (timer) {
+      clearInterval(timer);
+      timer = null;
+    }
+  }
+
+  return { sweep, start, stop };
+}

--- a/packages/gateway/src/shell/registry.ts
+++ b/packages/gateway/src/shell/registry.ts
@@ -40,6 +40,9 @@ const ShellSessionSchema = z.object({
   lastSeq: z.number().int().nonnegative().optional(),
   placement: ShellPlacementSchema.default("active"),
   lastSeenSeq: z.number().int().nonnegative().nullable().default(null),
+  // "session" for sessions created after reaper support shipped; absent for
+  // pre-upgrade sessions, which are exempt from TTL reaping (spec 107 FR-018).
+  kind: z.string().optional(),
   visualStatus: ShellVisualStatusSchema.optional(),
   visualStatusUpdatedAt: z.string().optional(),
 });
@@ -200,6 +203,7 @@ export class ShellRegistry {
         attachedClients: 0,
         placement: "active",
         lastSeenSeq: null,
+        kind: "session",
       };
       file.sessions[name] = session;
       if (file.order) {

--- a/packages/gateway/src/shell/replay-buffer.ts
+++ b/packages/gateway/src/shell/replay-buffer.ts
@@ -83,12 +83,21 @@ export class ShellReplayBuffer {
       .append(this.sessionName, [{ type: "seq-reserve", seq: target }])
       .then(() => {
         this.reservedThrough = Math.max(this.reservedThrough, target);
+        this.reservationInFlight = false;
       })
       .catch((err: unknown) => {
-        console.warn("[shell] seq reservation write failed:", err instanceof Error ? err.message : String(err));
-      })
-      .finally(() => {
-        this.reservationInFlight = false;
+        console.warn("[shell] seq reservation write failed; retrying:", err instanceof Error ? err.message : String(err));
+        // Retry on a timer rather than waiting for the next write: if output
+        // stops flowing after an overrun, the crash-safety window must still
+        // re-establish itself once the store recovers.
+        const retry = setTimeout(() => {
+          this.reservationInFlight = false;
+          const latest = this.lastSeq;
+          if (latest !== null) {
+            this.maybeReserve(latest);
+          }
+        }, 1_000);
+        retry.unref?.();
       });
   }
 

--- a/packages/gateway/src/shell/replay-buffer.ts
+++ b/packages/gateway/src/shell/replay-buffer.ts
@@ -13,6 +13,12 @@ export interface ShellReplayBufferOptions {
   maxBytes?: number;
   scrollbackStore?: ScrollbackStore;
   sessionName?: string;
+  reserveWindow?: number;
+}
+
+export interface LiveWriteResult {
+  seq: number | null;
+  records: ScrollbackRecord[];
 }
 
 export class ShellReplayBuffer {
@@ -23,11 +29,67 @@ export class ShellReplayBuffer {
   private seqOffset = 0;
   private seedPromise: Promise<void> | null = null;
   private persistentQueue: Promise<void> = Promise.resolve();
+  private readonly reserveWindow: number;
+  private reservedThrough = -1;
+  private reservationInFlight = false;
 
   constructor(options: ShellReplayBufferOptions = {}) {
     this.buffer = new RingBuffer(options.maxBytes);
     this.scrollbackStore = options.scrollbackStore;
     this.sessionName = options.sessionName;
+    this.reserveWindow = options.reserveWindow ?? 10_000;
+  }
+
+  /** Must complete before the first writeLive so seeding stays off the hot path. */
+  async ensureSeeded(): Promise<void> {
+    await this.seedOffsetFromScrollback();
+    if (this.reservedThrough < this.seqOffset - 1) {
+      this.reservedThrough = this.seqOffset - 1;
+    }
+  }
+
+  /**
+   * Send-first write: assigns the sequence number synchronously so the caller
+   * can deliver the frame immediately, and returns the records the caller
+   * queues for asynchronous persistence. A durable seq reservation is
+   * refreshed ahead of assignment so a crashed gateway never reissues a seq a
+   * client already received (see spec 107 FR-001).
+   */
+  writeLive(data: string): LiveWriteResult {
+    const written = this.write(data);
+    if (written.seq === null) {
+      return { seq: null, records: [] };
+    }
+    const seq = written.seq;
+    const parsed = this.osc133.write(data);
+    const records: ScrollbackRecord[] = [
+      { type: "output", seq, data: parsed.data },
+      ...parsed.marks.map((mark): ScrollbackRecord => ({ type: "block-mark", seq, mark })),
+    ];
+    this.maybeReserve(seq);
+    return { seq, records };
+  }
+
+  private maybeReserve(seq: number): void {
+    if (!this.scrollbackStore || !this.sessionName || this.reservationInFlight) {
+      return;
+    }
+    if (seq + this.reserveWindow / 2 < this.reservedThrough) {
+      return;
+    }
+    const target = seq + this.reserveWindow;
+    this.reservationInFlight = true;
+    this.scrollbackStore
+      .append(this.sessionName, [{ type: "seq-reserve", seq: target }])
+      .then(() => {
+        this.reservedThrough = Math.max(this.reservedThrough, target);
+      })
+      .catch((err: unknown) => {
+        console.warn("[shell] seq reservation write failed:", err instanceof Error ? err.message : String(err));
+      })
+      .finally(() => {
+        this.reservationInFlight = false;
+      });
   }
 
   write(data: string): { seq: number | null; stored: boolean } {

--- a/packages/gateway/src/shell/scrollback-store.ts
+++ b/packages/gateway/src/shell/scrollback-store.ts
@@ -110,7 +110,18 @@ export class ScrollbackStore {
     try {
       const raw = await readFile(this.pathForValidatedSession(safeName), "utf-8");
       const parsed = parseScrollbackLines(raw.split("\n"), safeName);
-      return parsed.records.at(-1)?.seq ?? null;
+      // Max across all records, not last-by-file-position: seq-reserve records
+      // are appended immediately while output records flush later via the
+      // coalescing queue, so file order does not track seq order. Seeding from
+      // anything but the max would let a restarted gateway reuse delivered
+      // seqs — the exact failure the reservation exists to prevent.
+      let latest: number | null = null;
+      for (const record of parsed.records) {
+        if (latest === null || record.seq > latest) {
+          latest = record.seq;
+        }
+      }
+      return latest;
     } catch (err: unknown) {
       if (
         err instanceof Error &&

--- a/packages/gateway/src/shell/scrollback-store.ts
+++ b/packages/gateway/src/shell/scrollback-store.ts
@@ -5,7 +5,11 @@ import { z } from "zod/v4";
 import { validateSessionName } from "./names.js";
 import type { ReplayEvent } from "./replay-buffer.js";
 
-export type ScrollbackRecord = Extract<ReplayEvent, { type: "output" | "block-mark" }>;
+export type ReplayableScrollbackRecord = Extract<ReplayEvent, { type: "output" | "block-mark" }>;
+// seq-reserve records make sequence numbering crash-durable: they raise
+// latestSeq so a restarted gateway resumes numbering above anything a client
+// may have seen, but they are never replayed as output.
+export type ScrollbackRecord = ReplayableScrollbackRecord | { type: "seq-reserve"; seq: number };
 type StoredScrollbackRecord = ScrollbackRecord & { at?: string };
 
 export interface ScrollbackActivity {
@@ -36,6 +40,10 @@ const ScrollbackRecordSchema = z.discriminatedUnion("type", [
     type: z.literal("block-mark"),
     seq: z.number().int().nonnegative(),
     mark: Osc133MarkSchema,
+  }),
+  z.object({
+    type: z.literal("seq-reserve"),
+    seq: z.number().int().nonnegative(),
   }),
 ]);
 
@@ -76,12 +84,13 @@ export class ScrollbackStore {
     });
   }
 
-  async readSince(name: string, fromSeq: number): Promise<ScrollbackRecord[]> {
+  async readSince(name: string, fromSeq: number): Promise<ReplayableScrollbackRecord[]> {
     const safeName = validateSessionName(name);
     try {
       const raw = await readFile(this.pathForValidatedSession(safeName), "utf-8");
       const parsed = parseScrollbackLines(raw.split("\n"), safeName);
       return parsed.records
+        .filter((record): record is ReplayableScrollbackRecord => record.type !== "seq-reserve")
         .filter((record) => record.seq >= fromSeq)
         .sort((a, b) => a.seq - b.seq);
     } catch (err: unknown) {
@@ -150,7 +159,7 @@ export class ScrollbackStore {
             }
             continue;
           }
-          if (activity.latestSeq === null) {
+          if (activity.latestSeq === null && record.type !== "seq-reserve") {
             activity.latestSeq = record.seq;
           }
           if (record.type === "output" && activity.latestOutputAt === null) {

--- a/packages/gateway/src/shell/ws.ts
+++ b/packages/gateway/src/shell/ws.ts
@@ -142,7 +142,7 @@ export function createShellWsHandler(options: ShellWsHandlerOptions) {
   const runtimes = new Map<string, SessionRuntime>();
   let drainTimer: NodeJS.Timeout | null = null;
 
-  function runtimeFor(name: string): SessionRuntime {
+  function runtimeFor(name: string): SessionRuntime | null {
     const existing = runtimes.get(name);
     if (existing) {
       runtimes.delete(name);
@@ -150,12 +150,21 @@ export function createShellWsHandler(options: ShellWsHandlerOptions) {
       return existing;
     }
     if (runtimes.size >= maxBuffers) {
+      let evicted = false;
       for (const [candidateName, candidate] of runtimes) {
         if (candidate.conns.size === 0) {
           runtimes.delete(candidateName);
-          void candidate.queue?.dispose();
+          void candidate.queue?.dispose().catch((err: unknown) => {
+            console.warn("[shell] evicted runtime flush failed:", err instanceof Error ? err.message : String(err));
+          });
+          evicted = true;
           break;
         }
+      }
+      if (!evicted) {
+        // Hard cap: every tracked session still has live clients, so nothing
+        // is safely evictable. Reject instead of growing without bound.
+        return null;
       }
     }
     const buffer = new ShellReplayBuffer({
@@ -258,6 +267,12 @@ export function createShellWsHandler(options: ShellWsHandlerOptions) {
       }
     }
     if (stalest) {
+      // Free the slot synchronously so a concurrent open cannot observe the
+      // evicted conn still occupying capacity while its close settles.
+      runtime.conns.delete(stalest);
+      if (runtime.recorder === stalest) {
+        electRecorder(runtime, stalest);
+      }
       stalest.close();
       return true;
     }
@@ -281,6 +296,11 @@ export function createShellWsHandler(options: ShellWsHandlerOptions) {
     }
 
     const runtime = runtimeFor(safeName);
+    if (!runtime) {
+      sendJson(ws, { type: "error", code: "session_capacity", message: "Too many active sessions" });
+      ws.close?.();
+      return { onMessage: () => undefined, onClose: () => undefined };
+    }
     if (!evictStaleOrReject(runtime, ws)) {
       return { onMessage: () => undefined, onClose: () => undefined };
     }

--- a/packages/gateway/src/shell/ws.ts
+++ b/packages/gateway/src/shell/ws.ts
@@ -332,6 +332,13 @@ export function createShellWsHandler(options: ShellWsHandlerOptions) {
       exitDisposable = null;
     };
 
+    // Re-check capacity: awaits since the first check (seeding, registry
+    // list) allow concurrent opens to race the same last slot.
+    if (runtime.conns.size >= maxAttachedClients && !evictStaleOrReject(runtime, ws)) {
+      child.kill();
+      return { onMessage: () => undefined, onClose: () => undefined };
+    }
+
     const conn: ConnState = {
       ws,
       child,
@@ -498,14 +505,22 @@ export function createShellWsHandler(options: ShellWsHandlerOptions) {
     return total;
   }
 
-  function dispose(): void {
+  async function dispose(): Promise<void> {
     if (drainTimer) {
       clearInterval(drainTimer);
       drainTimer = null;
     }
+    const drains: Array<Promise<void>> = [];
     for (const runtime of runtimes.values()) {
-      void runtime.queue?.dispose();
+      if (runtime.queue) {
+        drains.push(
+          runtime.queue.dispose().catch((err: unknown) => {
+            console.warn("[shell] shutdown scrollback flush failed:", err instanceof Error ? err.message : String(err));
+          }),
+        );
+      }
     }
+    await Promise.all(drains);
   }
 
   return { open, dispose, pendingPersistBytes };

--- a/packages/gateway/src/shell/ws.ts
+++ b/packages/gateway/src/shell/ws.ts
@@ -1,6 +1,7 @@
 import { z } from "zod/v4";
 import { SHELL_ATTACH_LIVE_TAIL_FROM_SEQ } from "@finnaai/matrix/shell-protocol";
 import { ShellReplayBuffer } from "./replay-buffer.js";
+import { PendingPersistQueue } from "./output-pipeline.js";
 import type { ScrollbackStore } from "./scrollback-store.js";
 import { validateSessionName } from "./names.js";
 import type { ShellAttachProcess } from "./zellij.js";
@@ -43,6 +44,9 @@ export const SHELL_ATTACH_RECENT_REPLAY_EVENTS = 50;
 export interface ShellWsSocket {
   send(data: string): void;
   close?: () => void;
+  /** Backpressure signal; Hono WSContext exposes it on the raw socket. */
+  bufferedAmount?: number;
+  raw?: { bufferedAmount?: number };
 }
 
 interface ShellWsRegistry {
@@ -53,12 +57,23 @@ interface ShellWsAdapter {
   attachSession(name: string, options?: { signal?: AbortSignal }): ShellAttachProcess;
 }
 
+export interface ShellWsFlowControlOptions {
+  highWaterMark?: number;
+  lowWaterMark?: number;
+  drainIntervalMs?: number;
+}
+
 export interface ShellWsHandlerOptions {
   registry: ShellWsRegistry;
   adapter: ShellWsAdapter;
   scrollbackStore?: ScrollbackStore;
   maxReplayBytes?: number;
   maxBuffers?: number;
+  persistFlushIntervalMs?: number;
+  maxPendingPersistBytes?: number;
+  maxAttachedClients?: number;
+  staleAttachTtlMs?: number;
+  flowControl?: ShellWsFlowControlOptions;
 }
 
 export interface ShellWsOpenOptions {
@@ -88,51 +103,168 @@ export function shellWsMessageDataToString(data: unknown): string | null {
   return null;
 }
 
-class ReplayBufferCache {
-  private readonly buffers = new Map<string, ShellReplayBuffer>();
-  private readonly maxBuffers: number;
-
-  constructor(
-    private readonly options: {
-      scrollbackStore?: ScrollbackStore;
-      maxReplayBytes?: number;
-      maxBuffers?: number;
-    },
-  ) {
-    this.maxBuffers = options.maxBuffers ?? 20;
+function socketBufferedAmount(ws: ShellWsSocket): number {
+  if (typeof ws.bufferedAmount === "number") {
+    return ws.bufferedAmount;
   }
-
-  get(name: string): ShellReplayBuffer {
-    const existing = this.buffers.get(name);
-    if (existing) {
-      this.buffers.delete(name);
-      this.buffers.set(name, existing);
-      return existing;
-    }
-
-    if (this.buffers.size >= this.maxBuffers) {
-      const oldest = this.buffers.keys().next().value as string | undefined;
-      if (oldest) {
-        this.buffers.delete(oldest);
-      }
-    }
-
-    const next = new ShellReplayBuffer({
-      maxBytes: this.options.maxReplayBytes,
-      scrollbackStore: this.options.scrollbackStore,
-      sessionName: name,
-    });
-    this.buffers.set(name, next);
-    return next;
+  const raw = ws.raw;
+  if (raw && typeof raw.bufferedAmount === "number") {
+    return raw.bufferedAmount;
   }
+  return 0;
+}
+
+interface ConnState {
+  ws: ShellWsSocket;
+  child: ShellAttachProcess;
+  openedAt: number;
+  lastActivityAt: number;
+  paused: boolean;
+  closed: boolean;
+  close: () => void;
+}
+
+interface SessionRuntime {
+  buffer: ShellReplayBuffer;
+  queue: PendingPersistQueue | null;
+  conns: Set<ConnState>;
+  recorder: ConnState | null;
 }
 
 export function createShellWsHandler(options: ShellWsHandlerOptions) {
-  const buffers = new ReplayBufferCache({
-    scrollbackStore: options.scrollbackStore,
-    maxReplayBytes: options.maxReplayBytes,
-    maxBuffers: options.maxBuffers,
-  });
+  const maxBuffers = options.maxBuffers ?? 20;
+  const maxAttachedClients = options.maxAttachedClients ?? 8;
+  const staleAttachTtlMs = options.staleAttachTtlMs ?? 60_000;
+  const highWaterMark = options.flowControl?.highWaterMark ?? 1024 * 1024;
+  const lowWaterMark = options.flowControl?.lowWaterMark ?? 256 * 1024;
+  const drainIntervalMs = options.flowControl?.drainIntervalMs ?? 500;
+
+  const runtimes = new Map<string, SessionRuntime>();
+  let drainTimer: NodeJS.Timeout | null = null;
+
+  function runtimeFor(name: string): SessionRuntime {
+    const existing = runtimes.get(name);
+    if (existing) {
+      runtimes.delete(name);
+      runtimes.set(name, existing);
+      return existing;
+    }
+    if (runtimes.size >= maxBuffers) {
+      for (const [candidateName, candidate] of runtimes) {
+        if (candidate.conns.size === 0) {
+          runtimes.delete(candidateName);
+          void candidate.queue?.dispose();
+          break;
+        }
+      }
+    }
+    const buffer = new ShellReplayBuffer({
+      maxBytes: options.maxReplayBytes,
+      scrollbackStore: options.scrollbackStore,
+      sessionName: name,
+    });
+    const queue = options.scrollbackStore
+      ? new PendingPersistQueue({
+          store: options.scrollbackStore,
+          sessionName: name,
+          flushIntervalMs: options.persistFlushIntervalMs,
+          maxPendingBytes: options.maxPendingPersistBytes,
+        })
+      : null;
+    const runtime: SessionRuntime = { buffer, queue, conns: new Set(), recorder: null };
+    runtimes.set(name, runtime);
+    return runtime;
+  }
+
+  function electRecorder(runtime: SessionRuntime, exclude?: ConnState): void {
+    let oldest: ConnState | null = null;
+    for (const conn of runtime.conns) {
+      if (conn === exclude || conn.closed) {
+        continue;
+      }
+      if (!oldest || conn.openedAt < oldest.openedAt) {
+        oldest = conn;
+      }
+    }
+    runtime.recorder = oldest;
+  }
+
+  function ensureDrainTimer(): void {
+    if (drainTimer) {
+      return;
+    }
+    drainTimer = setInterval(() => {
+      let anyPaused = false;
+      for (const runtime of runtimes.values()) {
+        for (const conn of runtime.conns) {
+          if (!conn.paused) {
+            continue;
+          }
+          if (socketBufferedAmount(conn.ws) <= lowWaterMark) {
+            conn.paused = false;
+            conn.child.resume?.();
+          } else {
+            anyPaused = true;
+          }
+        }
+      }
+      if (!anyPaused && drainTimer) {
+        clearInterval(drainTimer);
+        drainTimer = null;
+      }
+    }, drainIntervalMs);
+    drainTimer.unref?.();
+  }
+
+  /**
+   * Deliver a frame with backpressure. Returns false when the frame was
+   * skipped because the socket is over the high-water mark and the connection
+   * cannot be paused (a sole recorder must keep producing for persistence).
+   */
+  function deliver(runtime: SessionRuntime, conn: ConnState, msg: unknown): boolean {
+    if (socketBufferedAmount(conn.ws) > highWaterMark) {
+      if (runtime.recorder === conn && runtime.conns.size > 1) {
+        electRecorder(runtime, conn);
+      }
+      if (runtime.recorder !== conn) {
+        if (!conn.paused) {
+          conn.paused = true;
+          conn.child.pause?.();
+          ensureDrainTimer();
+        }
+        return false;
+      }
+      // Sole recorder: never pause the stream that feeds persistence; skip
+      // delivery to the saturated socket instead. The client recovers via
+      // seq-based replay on drain/reconnect.
+      return false;
+    }
+    sendJson(conn.ws, msg);
+    return true;
+  }
+
+  function evictStaleOrReject(runtime: SessionRuntime, ws: ShellWsSocket): boolean {
+    if (runtime.conns.size < maxAttachedClients) {
+      return true;
+    }
+    const now = Date.now();
+    let stalest: ConnState | null = null;
+    for (const conn of runtime.conns) {
+      if (now - conn.lastActivityAt < staleAttachTtlMs) {
+        continue;
+      }
+      if (!stalest || conn.lastActivityAt < stalest.lastActivityAt) {
+        stalest = conn;
+      }
+    }
+    if (stalest) {
+      stalest.close();
+      return true;
+    }
+    sendJson(ws, { type: "error", code: "attach_limit", message: "Too many clients attached" });
+    ws.close?.();
+    return false;
+  }
 
   async function open({ ws, session, fromSeq = 0 }: ShellWsOpenOptions): Promise<ShellWsSession> {
     const safeName = validateSessionName(session);
@@ -148,8 +280,14 @@ export function createShellWsHandler(options: ShellWsHandlerOptions) {
       return { onMessage: () => undefined, onClose: () => undefined };
     }
 
+    const runtime = runtimeFor(safeName);
+    if (!evictStaleOrReject(runtime, ws)) {
+      return { onMessage: () => undefined, onClose: () => undefined };
+    }
+
     const abortController = new AbortController();
-    const replayBuffer = buffers.get(safeName);
+    const replayBuffer = runtime.buffer;
+    await replayBuffer.ensureSeeded();
     let child: ShellAttachProcess;
     try {
       child = options.adapter.attachSession(safeName, {
@@ -165,7 +303,6 @@ export function createShellWsHandler(options: ShellWsHandlerOptions) {
       ws.close?.();
       return { onMessage: () => undefined, onClose: () => undefined };
     }
-    let closed = false;
     let dataDisposable: { dispose(): void } | null = null;
     let exitDisposable: { dispose(): void } | null = null;
     const cleanupProcessListeners = () => {
@@ -174,6 +311,24 @@ export function createShellWsHandler(options: ShellWsHandlerOptions) {
       dataDisposable = null;
       exitDisposable = null;
     };
+
+    const conn: ConnState = {
+      ws,
+      child,
+      openedAt: Date.now(),
+      lastActivityAt: Date.now(),
+      paused: false,
+      closed: false,
+      close: () => {
+        void closeSession().finally(() => {
+          ws.close?.();
+        });
+      },
+    };
+    runtime.conns.add(conn);
+    if (!runtime.recorder) {
+      runtime.recorder = conn;
+    }
 
     const effectiveFromSeq = fromSeq === SHELL_ATTACH_LIVE_TAIL_FROM_SEQ
       ? Math.max(0, (await replayBuffer.latestSeq() ?? 0) - SHELL_ATTACH_RECENT_REPLAY_EVENTS + 1)
@@ -204,42 +359,69 @@ export function createShellWsHandler(options: ShellWsHandlerOptions) {
       sendJson(ws, event);
     }
 
-    const persistOutput = async (data: string) => {
+    // Send-first live output: the frame is delivered immediately with a
+    // synchronously assigned seq; only the elected recorder's stream feeds the
+    // replay buffer and the coalesced persistence queue (spec 107 FR-001/004).
+    const emitOutput = (data: string) => {
       if (data.length === 0) {
         return;
       }
-      await replayBuffer.writePersistent(data)
-        .then((result) => {
-          if (result.seq !== null) {
-            sendJson(ws, { type: "output", seq: result.seq, data });
-          }
-        })
-        .catch((err: unknown) => {
-          console.warn("[shell] failed to persist terminal output:", err instanceof Error ? err.message : String(err));
-        });
-    };
-    const onData = (data: string) => {
-      void persistOutput(outputCompat.write(data));
-    };
-    const onExit = (event: { exitCode: number }) => {
-      if (closed) {
+      if (runtime.recorder === conn) {
+        const result = replayBuffer.writeLive(data);
+        deliver(runtime, conn, { type: "output", seq: result.seq, data });
+        if (result.records.length > 0) {
+          runtime.queue?.enqueue(result.records);
+        }
         return;
       }
-      closed = true;
+      deliver(runtime, conn, { type: "output", seq: replayBuffer.lastSeq, data });
+    };
+    const onData = (data: string) => {
+      emitOutput(outputCompat.write(data));
+    };
+    const detachConn = () => {
+      runtime.conns.delete(conn);
+      if (runtime.recorder === conn) {
+        electRecorder(runtime, conn);
+      }
+      if (runtime.conns.size === 0 && runtime.queue) {
+        // Nobody attached: persist promptly instead of waiting for the timer.
+        void runtime.queue.dispose().catch((err: unknown) => {
+          console.warn("[shell] final scrollback flush failed:", err instanceof Error ? err.message : String(err));
+        });
+        runtime.queue = options.scrollbackStore
+          ? new PendingPersistQueue({
+              store: options.scrollbackStore,
+              sessionName: safeName,
+              flushIntervalMs: options.persistFlushIntervalMs,
+              maxPendingBytes: options.maxPendingPersistBytes,
+            })
+          : null;
+      }
+    };
+
+    const onExit = (event: { exitCode: number }) => {
+      if (conn.closed) {
+        return;
+      }
+      conn.closed = true;
       cleanupProcessListeners();
-      void persistOutput(outputCompat.flush()).finally(() => {
-        sendJson(ws, { type: "exit", code: event.exitCode });
-      });
+      // Flush while this conn still holds its recorder role so trailing
+      // output is persisted, then hand the role off.
+      emitOutput(outputCompat.flush());
+      sendJson(ws, { type: "exit", code: event.exitCode });
+      detachConn();
     };
     dataDisposable = child.onData(onData);
     exitDisposable = child.onExit(onExit);
 
     const closeSession = async () => {
-      if (closed) {
+      if (conn.closed) {
         return;
       }
-      closed = true;
-      await persistOutput(outputCompat.flush());
+      conn.closed = true;
+      emitOutput(outputCompat.flush());
+      detachConn();
       abortController.abort();
       cleanupProcessListeners();
       child.kill();
@@ -247,6 +429,7 @@ export function createShellWsHandler(options: ShellWsHandlerOptions) {
 
     return {
       onMessage(raw: string) {
+        conn.lastActivityAt = Date.now();
         let parsed: unknown;
         try {
           parsed = JSON.parse(raw);
@@ -287,7 +470,25 @@ export function createShellWsHandler(options: ShellWsHandlerOptions) {
     };
   }
 
-  return { open };
+  function pendingPersistBytes(): number {
+    let total = 0;
+    for (const runtime of runtimes.values()) {
+      total += runtime.queue?.pendingBytes ?? 0;
+    }
+    return total;
+  }
+
+  function dispose(): void {
+    if (drainTimer) {
+      clearInterval(drainTimer);
+      drainTimer = null;
+    }
+    for (const runtime of runtimes.values()) {
+      void runtime.queue?.dispose();
+    }
+  }
+
+  return { open, dispose, pendingPersistBytes };
 }
 
 function sendJson(ws: ShellWsSocket, msg: unknown): void {

--- a/packages/gateway/src/shell/zellij.ts
+++ b/packages/gateway/src/shell/zellij.ts
@@ -28,6 +28,9 @@ export interface ShellAttachProcess {
   kill(): void;
   onData(listener: (data: string) => void): Disposable;
   onExit(listener: (event: PtyExitEvent) => void): Disposable;
+  /** node-pty flow control; used by WS backpressure to pause a slow client. */
+  pause?(): void;
+  resume?(): void;
 }
 type PtySpawn = (
   command: string,

--- a/tests/gateway/shell-output-pipeline.test.ts
+++ b/tests/gateway/shell-output-pipeline.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { PendingPersistQueue } from "../../packages/gateway/src/shell/output-pipeline.js";
+import type { ScrollbackRecord } from "../../packages/gateway/src/shell/scrollback-store.js";
+
+function outputRecord(seq: number, data: string): ScrollbackRecord {
+  return { type: "output", seq, data };
+}
+
+describe("shell/output-pipeline PendingPersistQueue", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  function makeStore() {
+    const batches: ScrollbackRecord[][] = [];
+    return {
+      batches,
+      append: vi.fn(async (_name: string, records: ScrollbackRecord[]) => {
+        batches.push(records);
+      }),
+    };
+  }
+
+  it("coalesces enqueued records into one append per flush interval", async () => {
+    const store = makeStore();
+    const queue = new PendingPersistQueue({
+      store,
+      sessionName: "main",
+      flushIntervalMs: 250,
+      flushBytes: 64 * 1024,
+      maxPendingBytes: 4 * 1024 * 1024,
+    });
+
+    queue.enqueue([outputRecord(0, "a")]);
+    queue.enqueue([outputRecord(1, "b")]);
+    queue.enqueue([outputRecord(2, "c")]);
+    expect(store.append).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(250);
+    expect(store.append).toHaveBeenCalledTimes(1);
+    expect(store.batches[0]).toHaveLength(3);
+    expect(store.batches[0]!.map((r) => r.seq)).toEqual([0, 1, 2]);
+    await queue.dispose();
+  });
+
+  it("flushes early when the byte threshold is crossed", async () => {
+    const store = makeStore();
+    const queue = new PendingPersistQueue({
+      store,
+      sessionName: "main",
+      flushIntervalMs: 60_000,
+      flushBytes: 8,
+      maxPendingBytes: 4 * 1024 * 1024,
+    });
+
+    queue.enqueue([outputRecord(0, "0123456789")]);
+    await vi.advanceTimersByTimeAsync(0);
+    expect(store.append).toHaveBeenCalledTimes(1);
+    await queue.dispose();
+  });
+
+  it("drops oldest pending data at the byte cap and reports the evicted seq range", async () => {
+    const store = makeStore();
+    const queue = new PendingPersistQueue({
+      store,
+      sessionName: "main",
+      flushIntervalMs: 60_000,
+      flushBytes: 1024 * 1024,
+      maxPendingBytes: 30,
+    });
+
+    queue.enqueue([outputRecord(0, "x".repeat(20))]);
+    queue.enqueue([outputRecord(1, "y".repeat(20))]);
+    queue.enqueue([outputRecord(2, "z".repeat(20))]);
+
+    // cap 30 bytes: seq 0 and 1 must have been dropped for persistence
+    expect(queue.evictedThroughSeq).toBe(1);
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(store.batches.flat().map((r) => r.seq)).toEqual([2]);
+    await queue.dispose();
+  });
+
+  it("retries with backoff when the store fails and never throws", async () => {
+    const append = vi.fn()
+      .mockRejectedValueOnce(new Error("disk full"))
+      .mockRejectedValueOnce(new Error("disk full"))
+      .mockResolvedValue(undefined);
+    const queue = new PendingPersistQueue({
+      store: { append },
+      sessionName: "main",
+      flushIntervalMs: 250,
+      flushBytes: 64 * 1024,
+      maxPendingBytes: 4 * 1024 * 1024,
+    });
+
+    queue.enqueue([outputRecord(0, "a")]);
+    await vi.advanceTimersByTimeAsync(250);
+    expect(append).toHaveBeenCalledTimes(1);
+
+    // first retry is delayed by backoff (>= one interval), data retained
+    await vi.advanceTimersByTimeAsync(2_000);
+    expect(append.mock.calls.length).toBeGreaterThanOrEqual(2);
+
+    await vi.advanceTimersByTimeAsync(10_000);
+    const lastBatch = append.mock.calls.at(-1)?.[1] as ScrollbackRecord[];
+    expect(lastBatch.map((r) => r.seq)).toContain(0);
+    expect(queue.pendingBytes).toBe(0);
+    await queue.dispose();
+  });
+
+  it("dispose flushes remaining records", async () => {
+    const store = makeStore();
+    const queue = new PendingPersistQueue({
+      store,
+      sessionName: "main",
+      flushIntervalMs: 60_000,
+      flushBytes: 1024 * 1024,
+      maxPendingBytes: 4 * 1024 * 1024,
+    });
+
+    queue.enqueue([outputRecord(0, "final")]);
+    await queue.dispose();
+    expect(store.append).toHaveBeenCalledTimes(1);
+    expect(store.batches[0]![0]!.seq).toBe(0);
+  });
+
+  it("tracks pendingBytes for telemetry", () => {
+    const store = makeStore();
+    const queue = new PendingPersistQueue({
+      store,
+      sessionName: "main",
+      flushIntervalMs: 60_000,
+      flushBytes: 1024 * 1024,
+      maxPendingBytes: 4 * 1024 * 1024,
+    });
+    queue.enqueue([outputRecord(0, "abcde")]);
+    expect(queue.pendingBytes).toBeGreaterThanOrEqual(5);
+    void queue.dispose();
+  });
+});

--- a/tests/gateway/shell-reaper.test.ts
+++ b/tests/gateway/shell-reaper.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { createShellSessionReaper } from "../../packages/gateway/src/shell/reaper.js";
+
+const DAY = 24 * 60 * 60 * 1000;
+
+function session(input: {
+  name: string;
+  status: "active" | "exited";
+  ageMs: number;
+  kind?: string;
+}) {
+  const stamp = new Date(Date.now() - input.ageMs).toISOString();
+  return {
+    name: input.name,
+    status: input.status,
+    createdAt: stamp,
+    updatedAt: stamp,
+    ...(input.kind ? { kind: input.kind } : {}),
+  };
+}
+
+describe("shell session reaper", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-13T12:00:00.000Z"));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("reaps only kind-tagged exited sessions older than the TTL", async () => {
+    const deleted: string[] = [];
+    const registry = {
+      list: vi.fn(async () => [
+        session({ name: "old-tagged", status: "exited", ageMs: 8 * DAY, kind: "session" }),
+        session({ name: "fresh-tagged", status: "exited", ageMs: 2 * DAY, kind: "session" }),
+        session({ name: "old-legacy", status: "exited", ageMs: 30 * DAY }),
+        session({ name: "old-active", status: "active", ageMs: 30 * DAY, kind: "session" }),
+      ]),
+      delete: vi.fn(async (name: string) => {
+        deleted.push(name);
+      }),
+    };
+    const reaper = createShellSessionReaper({ registry, ttlMs: 7 * DAY });
+
+    await reaper.sweep();
+
+    expect(deleted).toEqual(["old-tagged"]);
+  });
+
+  it("continues past per-session delete failures", async () => {
+    const deleted: string[] = [];
+    const registry = {
+      list: vi.fn(async () => [
+        session({ name: "broken", status: "exited", ageMs: 9 * DAY, kind: "session" }),
+        session({ name: "ok", status: "exited", ageMs: 9 * DAY, kind: "session" }),
+      ]),
+      delete: vi.fn(async (name: string) => {
+        if (name === "broken") {
+          throw new Error("zellij unavailable");
+        }
+        deleted.push(name);
+      }),
+    };
+    const reaper = createShellSessionReaper({ registry, ttlMs: 7 * DAY });
+
+    await expect(reaper.sweep()).resolves.toBeUndefined();
+    expect(deleted).toEqual(["ok"]);
+  });
+
+  it("runs on an interval after start and stops cleanly", async () => {
+    const registry = {
+      list: vi.fn(async () => []),
+      delete: vi.fn(async () => undefined),
+    };
+    const reaper = createShellSessionReaper({ registry, ttlMs: 7 * DAY, intervalMs: 1_000 });
+
+    reaper.start();
+    await vi.advanceTimersByTimeAsync(3_100);
+    expect(registry.list.mock.calls.length).toBeGreaterThanOrEqual(3);
+
+    reaper.stop();
+    const calls = registry.list.mock.calls.length;
+    await vi.advanceTimersByTimeAsync(5_000);
+    expect(registry.list.mock.calls.length).toBe(calls);
+  });
+});

--- a/tests/gateway/shell-replay-buffer.test.ts
+++ b/tests/gateway/shell-replay-buffer.test.ts
@@ -110,6 +110,44 @@ describe("shell replay buffer", () => {
     expect(reservation!.seq).toBeGreaterThanOrEqual(100);
   });
 
+  it("retries a failed seq reservation on a timer even when output stops", async () => {
+    vi.useFakeTimers();
+    try {
+      const reserves: number[] = [];
+      let failFirst = true;
+      const store = {
+        latestSeq: async () => null,
+        append: async (_name: string, records: Array<{ type: string; seq: number }>) => {
+          const reserve = records.find((r) => r.type === "seq-reserve");
+          if (reserve) {
+            if (failFirst) {
+              failFirst = false;
+              throw new Error("disk full");
+            }
+            reserves.push(reserve.seq);
+          }
+        },
+      } as unknown as ScrollbackStore;
+      const replay = new ShellReplayBuffer({
+        maxBytes: 4096,
+        scrollbackStore: store,
+        sessionName: "main",
+        reserveWindow: 100,
+      });
+      await replay.ensureSeeded();
+
+      replay.writeLive("one");
+      await vi.advanceTimersByTimeAsync(0);
+      expect(reserves).toEqual([]); // first attempt failed
+
+      await vi.advanceTimersByTimeAsync(1_100); // retry timer, no new output
+      expect(reserves.length).toBe(1);
+      expect(reserves[0]).toBeGreaterThanOrEqual(100);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("seeds numbering above a persisted reservation so delivered seqs are never reused", async () => {
     const store = {
       // scrollback holds outputs up to seq 5 plus a reservation through 10000

--- a/tests/gateway/shell-replay-buffer.test.ts
+++ b/tests/gateway/shell-replay-buffer.test.ts
@@ -65,6 +65,67 @@ describe("shell replay buffer", () => {
     expect(replay.replayFrom(0)).toContainEqual({ type: "output", seq: 0, data: image });
   });
 
+  it("writeLive assigns the seq synchronously and returns persistable records", async () => {
+    const appended: Array<{ type: string; seq: number }> = [];
+    const store = {
+      latestSeq: async () => null,
+      append: async (_name: string, records: Array<{ type: string; seq: number }>) => {
+        appended.push(...records);
+      },
+    } as unknown as ScrollbackStore;
+    const replay = new ShellReplayBuffer({
+      maxBytes: 4096,
+      scrollbackStore: store,
+      sessionName: "main",
+    });
+    await replay.ensureSeeded();
+
+    const result = replay.writeLive("hello \x1b]133;A\x07world");
+    expect(result.seq).toBe(0);
+    expect(result.records[0]).toMatchObject({ type: "output", seq: 0 });
+    expect(result.records.some((r) => r.type === "block-mark")).toBe(true);
+    expect(replay.lastSeq).toBe(0);
+  });
+
+  it("writeLive persists a durable seq reservation ahead of assignment", async () => {
+    const appended: Array<{ type: string; seq: number }> = [];
+    const store = {
+      latestSeq: async () => null,
+      append: async (_name: string, records: Array<{ type: string; seq: number }>) => {
+        appended.push(...records);
+      },
+    } as unknown as ScrollbackStore;
+    const replay = new ShellReplayBuffer({
+      maxBytes: 4096,
+      scrollbackStore: store,
+      sessionName: "main",
+      reserveWindow: 100,
+    });
+    await replay.ensureSeeded();
+
+    replay.writeLive("one");
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    const reservation = appended.find((r) => r.type === "seq-reserve");
+    expect(reservation).toBeDefined();
+    expect(reservation!.seq).toBeGreaterThanOrEqual(100);
+  });
+
+  it("seeds numbering above a persisted reservation so delivered seqs are never reused", async () => {
+    const store = {
+      // scrollback holds outputs up to seq 5 plus a reservation through 10000
+      latestSeq: async () => 10_000,
+      append: async () => undefined,
+    } as unknown as ScrollbackStore;
+    const replay = new ShellReplayBuffer({
+      maxBytes: 4096,
+      scrollbackStore: store,
+      sessionName: "main",
+    });
+    await replay.ensureSeeded();
+
+    expect(replay.writeLive("after-restart").seq).toBe(10_001);
+  });
+
   it("serializes persistent writes for a session", async () => {
     const events: string[] = [];
     let releaseFirstAppend: (() => void) | null = null;

--- a/tests/gateway/shell-scrollback-store.test.ts
+++ b/tests/gateway/shell-scrollback-store.test.ts
@@ -44,6 +44,11 @@ describe("scrollback store", () => {
     expect(replayed).toEqual([{ type: "output", seq: 3, data: "visible" }]);
     const activity = await store.latestActivity("main");
     expect(activity.latestSeq).toBe(3);
+
+    // Coalesced output flushes AFTER the reservation by file position; the
+    // max seq must still win or a restarted gateway would reuse delivered seqs.
+    await store.append("main", [{ type: "output", seq: 4, data: "flushed late" }]);
+    await expect(store.latestSeq("main")).resolves.toBe(10_000);
   });
 
   it("returns latest activity metadata for Paper status derivation", async () => {

--- a/tests/gateway/shell-scrollback-store.test.ts
+++ b/tests/gateway/shell-scrollback-store.test.ts
@@ -32,6 +32,20 @@ describe("scrollback store", () => {
     ]);
   });
 
+  it("stores seq reservations that raise latestSeq but never replay", async () => {
+    const root = await tempRoot();
+    const store = new ScrollbackStore({ homePath: root, maxBytesPerSession: 4096 });
+
+    await store.append("main", [{ type: "output", seq: 3, data: "visible" }]);
+    await store.append("main", [{ type: "seq-reserve", seq: 10_000 }]);
+
+    await expect(store.latestSeq("main")).resolves.toBe(10_000);
+    const replayed = await store.readSince("main", 0);
+    expect(replayed).toEqual([{ type: "output", seq: 3, data: "visible" }]);
+    const activity = await store.latestActivity("main");
+    expect(activity.latestSeq).toBe(3);
+  });
+
   it("returns latest activity metadata for Paper status derivation", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-06-15T12:00:00.000Z"));

--- a/tests/gateway/terminal-zellij-ws.test.ts
+++ b/tests/gateway/terminal-zellij-ws.test.ts
@@ -12,8 +12,21 @@ class FakePty {
   writes: string[] = [];
   resizes: Array<{ cols: number; rows: number }> = [];
   killed = false;
+  pauseCount = 0;
+  resumeCount = 0;
+  paused = false;
   private dataListeners = new Set<(data: string) => void>();
   private exitListeners = new Set<(event: { exitCode: number; signal?: number }) => void>();
+
+  pause(): void {
+    this.paused = true;
+    this.pauseCount += 1;
+  }
+
+  resume(): void {
+    this.paused = false;
+    this.resumeCount += 1;
+  }
 
   write(data: string): void {
     this.writes.push(data);
@@ -87,6 +100,7 @@ describe("zellij terminal WebSocket", () => {
         pathForSession: vi.fn(() => ""),
       },
       maxReplayBytes: 4096,
+      persistFlushIntervalMs: 0,
     });
     const raw = "OpenAI Codex (v0.142.5)\n\x1b[7mprompt\x1b[27m";
     const readable = "OpenAI Codex (v0.142.5)\n\x1b[38;2;214;216;221;48;2;48;54;61mprompt\x1b[39;49m";
@@ -129,6 +143,7 @@ describe("zellij terminal WebSocket", () => {
         pathForSession: vi.fn(() => ""),
       },
       maxReplayBytes: 4096,
+      persistFlushIntervalMs: 0,
     });
     const raw = "OpenAI Codex (v0.142.5)\n\x1b[39m\x1b[48;2;240;240;239mprompt\x1b[39;49m";
     const readable = "OpenAI Codex (v0.142.5)\n\x1b[39m\x1b[38;2;214;216;221;48;2;48;54;61mprompt\x1b[38;2;214;216;221;49m";
@@ -176,6 +191,7 @@ describe("zellij terminal WebSocket", () => {
         pathForSession: vi.fn(() => ""),
       },
       maxReplayBytes: 4096,
+      persistFlushIntervalMs: 0,
     });
 
     await handler.open({ ws, session: "main", fromSeq: 40 });
@@ -433,6 +449,7 @@ describe("zellij terminal WebSocket", () => {
         pathForSession: vi.fn(() => ""),
       },
       maxReplayBytes: 4096,
+      persistFlushIntervalMs: 0,
     });
 
     const session = await handler.open({
@@ -489,6 +506,234 @@ describe("zellij terminal WebSocket", () => {
       { type: "error", code: "session_not_found", message: "Session not found" },
     ]);
     expect(ws.closed).toBe(true);
+  });
+
+  it("delivers live output before persistence completes (send-first)", async () => {
+    const pty = new FakePty();
+    const ws = socket();
+    let appendStarted = 0;
+    const handler = createShellWsHandler({
+      registry: { list: vi.fn(async () => [{ name: "main", status: "active" }]) },
+      adapter: { attachSession: vi.fn(() => pty) },
+      scrollbackStore: {
+        latestSeq: vi.fn(async () => null),
+        readSince: vi.fn(async () => []),
+        append: vi.fn(async () => {
+          appendStarted += 1;
+          await new Promise(() => undefined); // never resolves: dead disk
+        }),
+        cleanup: vi.fn(async () => undefined),
+        pathForSession: vi.fn(() => ""),
+      },
+      maxReplayBytes: 4096,
+      persistFlushIntervalMs: 0,
+    });
+
+    await handler.open({ ws, session: "main", fromSeq: 0 });
+    pty.emitData("instant echo");
+    // no timer advance needed: the frame must already be on the socket
+    expect(ws.sent).toContainEqual({ type: "output", seq: 0, data: "instant echo" });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(appendStarted).toBeGreaterThanOrEqual(1);
+  });
+
+  it("persists exactly one recorder stream when multiple clients attach", async () => {
+    const recorderPty = new FakePty();
+    const observerPty = new FakePty();
+    const append = vi.fn(async () => undefined);
+    const handler = createShellWsHandler({
+      registry: { list: vi.fn(async () => [{ name: "main", status: "active" }]) },
+      adapter: {
+        attachSession: vi.fn()
+          .mockReturnValueOnce(recorderPty)
+          .mockReturnValueOnce(observerPty),
+      },
+      scrollbackStore: {
+        latestSeq: vi.fn(async () => null),
+        readSince: vi.fn(async () => []),
+        append,
+        cleanup: vi.fn(async () => undefined),
+        pathForSession: vi.fn(() => ""),
+      },
+      maxReplayBytes: 4096,
+      persistFlushIntervalMs: 0,
+    });
+
+    const recorderWs = socket();
+    const observerWs = socket();
+    await handler.open({ ws: recorderWs, session: "main", fromSeq: 0 });
+    await handler.open({ ws: observerWs, session: "main", fromSeq: 0 });
+
+    recorderPty.emitData("from-recorder");
+    observerPty.emitData("from-observer");
+    await new Promise((resolve) => setTimeout(resolve, 5));
+
+    // both clients see their own live stream
+    expect(recorderWs.sent).toContainEqual({ type: "output", seq: 0, data: "from-recorder" });
+    expect(observerWs.sent.some((m) => (m as { data?: string }).data === "from-observer")).toBe(true);
+    // but only the recorder stream is persisted
+    const persisted = append.mock.calls
+      .flatMap((call) => call[1] as Array<{ type: string; data?: string }>)
+      .filter((r) => r.type === "output")
+      .map((r) => r.data);
+    expect(persisted).toContain("from-recorder");
+    expect(persisted).not.toContain("from-observer");
+  });
+
+  it("re-elects the oldest remaining client as recorder when the recorder detaches", async () => {
+    const firstPty = new FakePty();
+    const secondPty = new FakePty();
+    const append = vi.fn(async () => undefined);
+    const handler = createShellWsHandler({
+      registry: { list: vi.fn(async () => [{ name: "main", status: "active" }]) },
+      adapter: {
+        attachSession: vi.fn()
+          .mockReturnValueOnce(firstPty)
+          .mockReturnValueOnce(secondPty),
+      },
+      scrollbackStore: {
+        latestSeq: vi.fn(async () => null),
+        readSince: vi.fn(async () => []),
+        append,
+        cleanup: vi.fn(async () => undefined),
+        pathForSession: vi.fn(() => ""),
+      },
+      maxReplayBytes: 4096,
+      persistFlushIntervalMs: 0,
+    });
+
+    const firstConn = await handler.open({ ws: socket(), session: "main", fromSeq: 0 });
+    const secondWs = socket();
+    await handler.open({ ws: secondWs, session: "main", fromSeq: 0 });
+
+    firstConn.onClose();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    secondPty.emitData("post-handoff");
+    await new Promise((resolve) => setTimeout(resolve, 5));
+
+    const persisted = append.mock.calls
+      .flatMap((call) => call[1] as Array<{ type: string; data?: string }>)
+      .filter((r) => r.type === "output")
+      .map((r) => r.data);
+    expect(persisted).toContain("post-handoff");
+    expect(secondWs.sent).toContainEqual({ type: "output", seq: 0, data: "post-handoff" });
+  });
+
+  it("pauses a slow non-recorder client's pty and resumes it after drain", async () => {
+    const recorderPty = new FakePty();
+    const slowPty = new FakePty();
+    const handler = createShellWsHandler({
+      registry: { list: vi.fn(async () => [{ name: "main", status: "active" }]) },
+      adapter: {
+        attachSession: vi.fn()
+          .mockReturnValueOnce(recorderPty)
+          .mockReturnValueOnce(slowPty),
+      },
+      maxReplayBytes: 4096,
+      flowControl: { highWaterMark: 10, lowWaterMark: 5, drainIntervalMs: 5 },
+    });
+
+    await handler.open({ ws: socket(), session: "main", fromSeq: 0 });
+    const slowWs = Object.assign(socket(), { bufferedAmount: 1_000 });
+    await handler.open({ ws: slowWs, session: "main", fromSeq: 0 });
+
+    slowPty.emitData("burst");
+    expect(slowPty.pauseCount).toBe(1);
+    expect(slowPty.paused).toBe(true);
+
+    slowWs.bufferedAmount = 0;
+    await new Promise((resolve) => setTimeout(resolve, 25));
+    expect(slowPty.resumeCount).toBe(1);
+    expect(slowPty.paused).toBe(false);
+    handler.dispose();
+  });
+
+  it("never pauses a sole recorder; delivery to its slow socket is skipped instead", async () => {
+    const pty = new FakePty();
+    const append = vi.fn(async () => undefined);
+    const handler = createShellWsHandler({
+      registry: { list: vi.fn(async () => [{ name: "main", status: "active" }]) },
+      adapter: { attachSession: vi.fn(() => pty) },
+      scrollbackStore: {
+        latestSeq: vi.fn(async () => null),
+        readSince: vi.fn(async () => []),
+        append,
+        cleanup: vi.fn(async () => undefined),
+        pathForSession: vi.fn(() => ""),
+      },
+      maxReplayBytes: 4096,
+      persistFlushIntervalMs: 0,
+      flowControl: { highWaterMark: 10, lowWaterMark: 5, drainIntervalMs: 5 },
+    });
+
+    const slowWs = Object.assign(socket(), { bufferedAmount: 1_000 });
+    await handler.open({ ws: slowWs, session: "main", fromSeq: 0 });
+    const sentBefore = slowWs.sent.length;
+
+    pty.emitData("still persists");
+    await new Promise((resolve) => setTimeout(resolve, 5));
+
+    expect(pty.pauseCount).toBe(0);
+    expect(slowWs.sent.length).toBe(sentBefore); // frame skipped for the slow socket
+    const persisted = append.mock.calls
+      .flatMap((call) => call[1] as Array<{ type: string; data?: string }>)
+      .filter((r) => r.type === "output")
+      .map((r) => r.data);
+    expect(persisted).toContain("still persists");
+    handler.dispose();
+  });
+
+  it("caps attaches per session and evicts the stalest client first", async () => {
+    const ptys = [new FakePty(), new FakePty(), new FakePty()];
+    let next = 0;
+    const handler = createShellWsHandler({
+      registry: { list: vi.fn(async () => [{ name: "main", status: "active" }]) },
+      adapter: { attachSession: vi.fn(() => ptys[next++]!) },
+      maxReplayBytes: 4096,
+      maxAttachedClients: 2,
+      staleAttachTtlMs: 10,
+    });
+
+    const firstWs = socket();
+    await handler.open({ ws: firstWs, session: "main", fromSeq: 0 });
+    const second = await handler.open({ ws: socket(), session: "main", fromSeq: 0 });
+    // keep the second connection fresh, let the first go stale
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    second.onMessage(JSON.stringify({ type: "ping" }));
+
+    const thirdWs = socket();
+    await handler.open({ ws: thirdWs, session: "main", fromSeq: 0 });
+
+    expect(firstWs.closed).toBe(true); // stalest evicted
+    expect(thirdWs.sent).toContainEqual(
+      expect.objectContaining({ type: "attached", session: "main" }),
+    );
+    handler.dispose();
+  });
+
+  it("rejects attaches over the cap when every client is fresh", async () => {
+    const ptys = [new FakePty(), new FakePty()];
+    let next = 0;
+    const handler = createShellWsHandler({
+      registry: { list: vi.fn(async () => [{ name: "main", status: "active" }]) },
+      adapter: { attachSession: vi.fn(() => ptys[next++] ?? new FakePty()) },
+      maxReplayBytes: 4096,
+      maxAttachedClients: 2,
+      staleAttachTtlMs: 60_000,
+    });
+
+    await handler.open({ ws: socket(), session: "main", fromSeq: 0 });
+    await handler.open({ ws: socket(), session: "main", fromSeq: 0 });
+    const thirdWs = socket();
+    await handler.open({ ws: thirdWs, session: "main", fromSeq: 0 });
+
+    expect(thirdWs.sent).toContainEqual({
+      type: "error",
+      code: "attach_limit",
+      message: "Too many clients attached",
+    });
+    expect(thirdWs.closed).toBe(true);
+    handler.dispose();
   });
 
   it("accepts terminal query token and bearer auth through constant-time auth middleware", async () => {

--- a/tests/gateway/terminal-zellij-ws.test.ts
+++ b/tests/gateway/terminal-zellij-ws.test.ts
@@ -736,6 +736,34 @@ describe("zellij terminal WebSocket", () => {
     handler.dispose();
   });
 
+  it("rejects new sessions at runtime capacity when every tracked session has live clients", async () => {
+    const handler = createShellWsHandler({
+      registry: {
+        list: vi.fn(async () => [
+          { name: "one", status: "active" },
+          { name: "two", status: "active" },
+          { name: "three", status: "active" },
+        ]),
+      },
+      adapter: { attachSession: vi.fn(() => new FakePty()) },
+      maxReplayBytes: 4096,
+      maxBuffers: 2,
+    });
+
+    await handler.open({ ws: socket(), session: "one", fromSeq: 0 });
+    await handler.open({ ws: socket(), session: "two", fromSeq: 0 });
+    const thirdWs = socket();
+    await handler.open({ ws: thirdWs, session: "three", fromSeq: 0 });
+
+    expect(thirdWs.sent).toContainEqual({
+      type: "error",
+      code: "session_capacity",
+      message: "Too many active sessions",
+    });
+    expect(thirdWs.closed).toBe(true);
+    handler.dispose();
+  });
+
   it("accepts terminal query token and bearer auth through constant-time auth middleware", async () => {
     const next = vi.fn();
     const makeContext = (url: string, authorization?: string) => ({


### PR DESCRIPTION
## Summary

Implements `specs/107-terminal-multi-device/` **Phase 1** — the gateway-only fixes for the two unbounded terminal-output buffers behind the recurring gateway OOM kills (observed at 1.4GB anon RSS / 69GB VM on a 4GB host) and the 20-30s TUI echo latency:

- **Send-first delivery (FR-001)**: output frames are sent with a synchronously assigned `seq` before persistence. Echo no longer waits on disk. A durable seq reservation (`seq-reserve` scrollback records, 10k window, refreshed at half-window) guarantees a restarted gateway never reissues a seq a client already received; restart gaps surface through the existing replay path.
- **Bounded coalesced persistence (FR-002/003)**: `PendingPersistQueue` batches appends (250ms / 64KiB) with a 4MiB per-session cap, drop-oldest with `evictedThroughSeq` tracking, and capped-backoff retry on store failure. A dead disk now degrades to bounded persistence loss instead of unbounded memory growth.
- **Single recorder per session (FR-004/005)**: exactly one elected stream (oldest live attach) feeds the replay buffer and scrollback; re-election on recorder loss keeps seq monotonic. Kills the N-attached-devices → N× duplicate scrollback writes and interleaved replay corruption.
- **WS flow control (FR-017)**: a slow client's own attach pty is paused at 1MiB `bufferedAmount` and resumed below 256KiB via a drain poll; recorder re-election runs before pausing a recorder, and a sole recorder is never paused — delivery to its saturated socket is skipped so persistence cannot stall.
- **Attach caps (FR-019)**: 8 live attaches per session, stale-first eviction (60s activity TTL), generic `attach_limit` error otherwise.
- **Session reaper (FR-018)**: exited sessions older than 7 days are deleted (zellij session + registry entry + scrollback via the existing delete cascade) — but only sessions stamped with new `kind` metadata; pre-upgrade sessions are exempt until the Phase 3 migration ships.
- **Memory guardrails**: `MemoryHigh=1G` / `MemoryMax=1536M` on `matrix-gateway.service` in both the bundle unit and cloud-init, so a future leak throttles and restarts the gateway alone instead of taking the host down. `/health` now reports `memory.rssBytes` and `memory.pendingPersistBytes`.

Protocol compatibility: all three clients (CLI, web, native mobile) render output frames unconditionally and use `seq` only as a reconnect cursor (verified against `shell-client.ts`, `TerminalPane.tsx`, `terminal-client.ts`), so non-recorder frames carrying the buffer's monotonic `lastSeq` and occasional `null` seqs are safe. No client changes required.

## Tests

- 42 new/updated tests across `shell-output-pipeline` (coalescing, byte-cap eviction, backoff retry, dispose-drain), `shell-replay-buffer` (sync seq, reservation write, restart-above-reservation), `shell-scrollback-store` (reserve records raise latestSeq, never replay), `shell-reaper` (kind/TTL gating, per-session failure isolation, interval lifecycle), and `terminal-zellij-ws` (send-first ordering against a dead store, recorder election/re-election, flow-control pause/resume, sole-recorder skip, attach cap + stale eviction). All 16 pre-existing zellij-ws behavior tests pass unchanged apart from an added `persistFlushIntervalMs: 0` test option.
- `bun run typecheck` clean; `bun run check:patterns` 0 violations; full `tests/gateway/` suite 3059 passed.
- Full `bun run test`: 8407 passed with 2 failures in `tests/integrations/routes.test.ts` and `tests/platform/billing-routes.test.ts` — both pass in isolation in this worktree AND on clean main, and touch surfaces this diff does not; a baseline full-suite run on clean main is in progress to confirm they are pre-existing parallelism flakes, tracked for a separate fix.
- Spike caveat (spec S3): node-pty 1.1.0 `pause()/resume()` is exercised via fakes here; behavior against a live `zellij attach` child should be verified on a preview VPS before enabling aggressive flow-control tuning. Defaults chosen are conservative.

## Review/Monitoring

Will monitor Greptile to 5/5 and CI on this PR; fixes land on this branch.

## Invariants

- **Source of truth**: the in-memory ring buffer assigns seqs; the scrollback file is a bounded, possibly-gapped persistence of the recorder stream. Divergence is reconciled at attach via the existing cold+hot replay merge; gaps are reported through replay-evicted semantics.
- **Lock/transaction scope**: per-session persistence is serialized by the queue's single-flight flush plus the store's existing write lock; seq assignment is synchronous on the event loop. No network calls inside any critical section.
- **Acceptable orphan states**: crash loses at most the pending queue (≤4MiB/session) of unpersisted scrollback — live delivery already happened and seq reuse is prevented by the durable reservation; a reservation written without subsequent output only advances future numbering. Persistence drops under cap pressure lose scrollback history, never live output.
- **Auth source of truth**: unchanged — existing WS token auth on both routes; no new endpoints.
- **Deferred scope**: canonical sizing (Phase 2), workspaces/tabs + migration (Phase 3), per-tab persisted scrollback, live-zellij pause/resume verification (S3), and the two pre-existing full-suite flakes (separate fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)