### PR TITLE
feat(gateway): support per-message kernel selection

### DIFF
--- a/packages/gateway/src/dispatcher.ts
+++ b/packages/gateway/src/dispatcher.ts
@@ -25,6 +25,7 @@ import {
   aiTokensTotal,
 } from "./metrics.js";
 import { buildKernelEnv } from "./kernel-credentials.js";
+import type { KernelEffort, KernelModel } from "./kernel-settings.js";
 
 export type SpawnFn = typeof spawnKernel;
 
@@ -45,6 +46,11 @@ export interface DispatchContext {
   senderId?: string;
   senderName?: string;
   chatId?: string;
+}
+
+export interface KernelDispatchOverrides {
+  model?: KernelModel;
+  effort?: KernelEffort;
 }
 
 export interface BatchEntry {
@@ -68,6 +74,9 @@ export interface Dispatcher {
     /** Optional abort controller. Caller (gateway) passes this so it can
         stop the in-flight kernel run on user request. */
     abortController?: AbortController,
+    /** Allowlisted, per-dispatch kernel selection. These values never mutate
+        the persisted defaults or another queued dispatch. */
+    kernelOverrides?: KernelDispatchOverrides,
   ): Promise<void>;
   dispatchBatch(entries: BatchEntry[]): Promise<BatchResult[]>;
   readonly queueLength: number;
@@ -84,6 +93,7 @@ type InternalEntry =
       onEvent: (event: KernelEvent) => void;
       context?: DispatchContext;
       abortController?: AbortController;
+      kernelOverrides?: KernelDispatchOverrides;
       resolve: () => void;
       reject: (error: Error) => void;
     }
@@ -146,6 +156,7 @@ export function createDispatcher(opts: DispatchOptions): Dispatcher {
 
     const startTime = Date.now();
     const source = entry.context?.channel ?? "web";
+    const dispatchModel = entry.kernelOverrides?.model ?? opts.model;
     const toolsUsed: string[] = [];
     let resultSessionId = "";
     let resultData: KernelResult | undefined;
@@ -174,7 +185,8 @@ export function createDispatcher(opts: DispatchOptions): Dispatcher {
         db,
         homePath,
         sessionId: entry.sessionId,
-        model: opts.model,
+        model: dispatchModel,
+        effort: entry.kernelOverrides?.effort,
         maxTurns: opts.maxTurns,
         env: await buildKernelEnv(homePath),
       };
@@ -198,19 +210,19 @@ export function createDispatcher(opts: DispatchOptions): Dispatcher {
       kernelDispatchDuration.observe({ source }, durationSec);
       if (resultData) {
         if (resultData.cost > 0) {
-          aiCostTotal.inc({ model: opts.model ?? "unknown" }, resultData.cost);
+          aiCostTotal.inc({ model: dispatchModel ?? "unknown" }, resultData.cost);
         }
       }
 
       const tokensIn = resultData?.tokensIn ?? 0;
       const tokensOut = resultData?.tokensOut ?? 0;
-      const model = opts.model ?? "unknown";
+      const model = dispatchModel ?? "unknown";
       if (tokensIn > 0) aiTokensTotal.inc({ model, direction: "in" }, tokensIn);
       if (tokensOut > 0) aiTokensTotal.inc({ model, direction: "out" }, tokensOut);
 
       recordAiGeneration({
         traceId: resultSessionId || entry.sessionId,
-        model: opts.model,
+        model: dispatchModel,
         latencyMs: durationMs,
         tokensIn: resultData?.tokensIn,
         tokensOut: resultData?.tokensOut,
@@ -228,7 +240,7 @@ export function createDispatcher(opts: DispatchOptions): Dispatcher {
           durationMs,
           result: "ok",
           senderId: entry.context?.senderId,
-          model: opts.model,
+          model: dispatchModel,
         });
       } catch (err) {
         logNonFatal("[dispatcher] interaction logger failed:", err);
@@ -239,7 +251,7 @@ export function createDispatcher(opts: DispatchOptions): Dispatcher {
         try {
           usageTracker.track("dispatch", costUsd, {
             senderId: entry.context?.senderId,
-            model: opts.model,
+            model: dispatchModel,
             tokensIn,
             tokensOut,
           });
@@ -257,7 +269,7 @@ export function createDispatcher(opts: DispatchOptions): Dispatcher {
 
       recordAiGeneration({
         traceId: resultSessionId || entry.sessionId,
-        model: opts.model,
+        model: dispatchModel,
         latencyMs: durationMs,
         tokensIn: resultData?.tokensIn,
         tokensOut: resultData?.tokensOut,
@@ -277,7 +289,7 @@ export function createDispatcher(opts: DispatchOptions): Dispatcher {
           durationMs,
           result: "error",
           senderId: entry.context?.senderId,
-          model: opts.model,
+          model: dispatchModel,
           error: {
             name: err.name,
             message: err.message,
@@ -432,7 +444,7 @@ export function createDispatcher(opts: DispatchOptions): Dispatcher {
       return active;
     },
 
-    dispatch(message, sessionId, onEvent, context, abortController) {
+    dispatch(message, sessionId, onEvent, context, abortController, kernelOverrides) {
       if (queue.length >= MAX_QUEUE_SIZE) {
         return Promise.reject(new Error("Dispatch queue full — try again later"));
       }
@@ -444,6 +456,7 @@ export function createDispatcher(opts: DispatchOptions): Dispatcher {
           onEvent,
           context,
           abortController,
+          kernelOverrides,
           resolve,
           reject,
         });

--- a/packages/gateway/src/index.ts
+++ b/packages/gateway/src/index.ts
@@ -2,7 +2,15 @@ export { createGateway } from "./server.js";
 export type { GatewayConfig, ServerMessage } from "./server.js";
 export { createProvisioner } from "./provisioner.js";
 export { createDispatcher } from "./dispatcher.js";
-export type { Dispatcher, DispatchOptions, DispatchContext, SpawnFn, BatchEntry, BatchResult } from "./dispatcher.js";
+export type {
+  Dispatcher,
+  DispatchOptions,
+  DispatchContext,
+  KernelDispatchOverrides,
+  SpawnFn,
+  BatchEntry,
+  BatchResult,
+} from "./dispatcher.js";
 export { createWatcher } from "./watcher.js";
 export type { Watcher, FileChangeEvent, FileEvent } from "./watcher.js";
 export { createPtyHandler } from "./pty.js";

--- a/packages/gateway/src/kernel-settings.ts
+++ b/packages/gateway/src/kernel-settings.ts
@@ -1,21 +1,37 @@
 import {
   DEFAULT_KERNEL_EFFORT,
   DEFAULT_KERNEL_MODEL,
-  type KernelEffort,
 } from "@matrix-os/kernel";
+import { z } from "zod/v4";
 
-export const KERNEL_MODELS = [
-  { id: "claude-opus-4-6", label: "Claude Opus 4.6", tier: "Most capable" },
-  { id: "claude-sonnet-4-5", label: "Claude Sonnet 4.5", tier: "Balanced" },
-  { id: "claude-haiku-4-5", label: "Claude Haiku 4.5", tier: "Fastest" },
+export const KERNEL_MODEL_IDS = [
+  "claude-opus-4-6",
+  "claude-sonnet-4-5",
+  "claude-haiku-4-5",
 ] as const;
 
-export const KERNEL_MODEL_IDS = KERNEL_MODELS.map((model) => model.id) as [string, ...string[]];
+export const KernelModelSchema = z.enum(KERNEL_MODEL_IDS);
+export type KernelModel = z.infer<typeof KernelModelSchema>;
+
+const KERNEL_MODEL_DETAILS = {
+  "claude-opus-4-6": { label: "Claude Opus 4.6", tier: "Most capable" },
+  "claude-sonnet-4-5": { label: "Claude Sonnet 4.5", tier: "Balanced" },
+  "claude-haiku-4-5": { label: "Claude Haiku 4.5", tier: "Fastest" },
+} as const satisfies Record<KernelModel, { label: string; tier: string }>;
+
+export const KERNEL_MODELS = KERNEL_MODEL_IDS.map((id) => ({
+  id,
+  ...KERNEL_MODEL_DETAILS[id],
+}));
+
 export const KERNEL_EFFORTS = ["low", "medium", "high", "max"] as const;
+export const KernelEffortSchema = z.enum(KERNEL_EFFORTS);
+export type KernelEffort = z.infer<typeof KernelEffortSchema>;
+
 export const KERNEL_DEFAULTS = {
   model: DEFAULT_KERNEL_MODEL,
   effort: DEFAULT_KERNEL_EFFORT,
-} as const;
+} as const satisfies { model: KernelModel; effort: KernelEffort };
 
 export interface KernelModelOption {
   id: string;
@@ -23,14 +39,14 @@ export interface KernelModelOption {
   tier: string;
 }
 
-export function normalizeKernelModel(value: unknown): string | null {
-  return typeof value === "string" && KERNEL_MODEL_IDS.includes(value) ? value : null;
+export function normalizeKernelModel(value: unknown): KernelModel | null {
+  const parsed = KernelModelSchema.safeParse(value);
+  return parsed.success ? parsed.data : null;
 }
 
 export function normalizeKernelEffort(value: unknown): KernelEffort | null {
-  return typeof value === "string" && (KERNEL_EFFORTS as readonly string[]).includes(value)
-    ? value as KernelEffort
-    : null;
+  const parsed = KernelEffortSchema.safeParse(value);
+  return parsed.success ? parsed.data : null;
 }
 
 export function resolveKernelModelOption(model: string): KernelModelOption {

--- a/packages/gateway/src/routes/settings.ts
+++ b/packages/gateway/src/routes/settings.ts
@@ -20,7 +20,8 @@ import {
   KERNEL_DEFAULTS,
   KERNEL_EFFORTS,
   KERNEL_MODELS,
-  KERNEL_MODEL_IDS,
+  KernelEffortSchema,
+  KernelModelSchema,
   normalizeKernelEffort,
   normalizeKernelModel,
 } from "../kernel-settings.js";
@@ -37,8 +38,8 @@ const SETTINGS_BODY_LIMIT = 256 * 1024;
 
 const KernelPatchSchema = z
   .object({
-    model: z.enum(KERNEL_MODEL_IDS).optional(),
-    effort: z.enum(KERNEL_EFFORTS).optional(),
+    model: KernelModelSchema.optional(),
+    effort: KernelEffortSchema.optional(),
   })
   .strict();
 

--- a/packages/gateway/src/server.ts
+++ b/packages/gateway/src/server.ts
@@ -2131,7 +2131,10 @@ export async function createGateway(config: GatewayConfig) {
                   finalizeWithSummary(activeSessionId);
                   conversationRuns.complete(activeSessionId);
                 }
-              }, undefined, abortController)
+              }, undefined, abortController, {
+                model: parsed.model,
+                effort: parsed.effort,
+              })
               .catch((err: Error) => {
                 console.error("[gateway] Conversation dispatch failed:", err);
                 captureGatewayProductEvent("agent_task_dispatch_failed", {

--- a/packages/gateway/src/ws-message-schema.ts
+++ b/packages/gateway/src/ws-message-schema.ts
@@ -1,4 +1,5 @@
 import { z } from "zod/v4";
+import { KernelEffortSchema, KernelModelSchema } from "./kernel-settings.js";
 
 export const MainWsClientMessageSchema = z.discriminatedUnion("type", [
   z.object({
@@ -7,6 +8,8 @@ export const MainWsClientMessageSchema = z.discriminatedUnion("type", [
     displayText: z.string().trim().min(1).max(100_000).optional(),
     sessionId: z.string().min(1).max(256).optional(),
     requestId: z.string().min(1).max(256).optional(),
+    model: KernelModelSchema.optional(),
+    effort: KernelEffortSchema.optional(),
   }),
   z.object({
     type: z.literal("switch_session"),

--- a/tests/e2e/api/chat-flow.e2e.test.ts
+++ b/tests/e2e/api/chat-flow.e2e.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import type { KernelConfig, KernelEvent } from "@matrix-os/kernel";
 import { startTestGateway, type TestGateway } from "../fixtures/gateway.js";
 import { connectWs } from "../fixtures/ws-client.js";
 
@@ -188,6 +189,50 @@ describe("E2E: Chat message roundtrip", () => {
       expect(msg.sessionId).toBe("second-conn");
     } finally {
       ws2.close();
+    }
+  });
+});
+
+describe("E2E: Per-message kernel selection", () => {
+  let gw: TestGateway;
+  const observedConfigs: KernelConfig[] = [];
+
+  beforeAll(async () => {
+    gw = await startTestGateway({
+      spawnFn: async function* (_message, config) {
+        observedConfigs.push(config);
+        yield { type: "init", sessionId: "override-session" } as KernelEvent;
+        yield {
+          type: "result",
+          data: { sessionId: "override-session", cost: 0, turns: 1 },
+        } as KernelEvent;
+      },
+    });
+  });
+
+  afterAll(async () => {
+    await gw?.close();
+  });
+
+  it("threads an allowlisted WebSocket model and effort through to KernelConfig", async () => {
+    const ws = await connectWs(gw.url.replace("http", "ws") + "/ws");
+    try {
+      ws.send({
+        type: "message",
+        text: "use a fast model",
+        requestId: "override-request",
+        model: "claude-haiku-4-5",
+        effort: "low",
+      });
+
+      await ws.waitFor("kernel:result", 5_000);
+      expect(observedConfigs).toHaveLength(1);
+      expect(observedConfigs[0]).toMatchObject({
+        model: "claude-haiku-4-5",
+        effort: "low",
+      });
+    } finally {
+      ws.close();
     }
   });
 });

--- a/tests/gateway/dispatcher-overrides.test.ts
+++ b/tests/gateway/dispatcher-overrides.test.ts
@@ -1,0 +1,65 @@
+import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { KernelConfig, KernelEvent } from "@matrix-os/kernel";
+import {
+  createDispatcher,
+  type SpawnFn,
+} from "../../packages/gateway/src/dispatcher.js";
+
+const temporaryHomePaths: string[] = [];
+
+function makeHomePath(): string {
+  const dir = resolve(mkdtempSync(join(tmpdir(), "dispatch-overrides-")));
+  mkdirSync(join(dir, "system"), { recursive: true });
+  temporaryHomePaths.push(dir);
+  return dir;
+}
+
+function resultEvent(): KernelEvent {
+  return {
+    type: "result",
+    data: { sessionId: "override-session", cost: 0, turns: 1 },
+  };
+}
+
+describe("dispatcher per-message kernel overrides", () => {
+  afterEach(() => {
+    for (const homePath of temporaryHomePaths.splice(0)) {
+      rmSync(homePath, { recursive: true, force: true });
+    }
+  });
+
+  it("passes model and effort to the kernel for only the selected dispatch", async () => {
+    const configs: KernelConfig[] = [];
+    const spawn = vi.fn<SpawnFn>(async function* (_message, config) {
+      configs.push(config);
+      yield resultEvent();
+    });
+    const dispatcher = createDispatcher({
+      homePath: makeHomePath(),
+      model: "claude-opus-4-6",
+      spawnFn: spawn,
+      maxConcurrency: 1,
+    });
+
+    await dispatcher.dispatch(
+      "override this turn",
+      undefined,
+      () => {},
+      undefined,
+      undefined,
+      { model: "claude-haiku-4-5", effort: "low" },
+    );
+    await dispatcher.dispatch("use the default", undefined, () => {});
+
+    expect(configs).toHaveLength(2);
+    expect(configs[0]).toMatchObject({
+      model: "claude-haiku-4-5",
+      effort: "low",
+    });
+    expect(configs[1]).toMatchObject({ model: "claude-opus-4-6" });
+    expect(configs[1].effort).toBeUndefined();
+  });
+});

--- a/tests/gateway/main-ws-schema.test.ts
+++ b/tests/gateway/main-ws-schema.test.ts
@@ -13,6 +13,34 @@ describe("MainWsClientMessageSchema", () => {
     expect(result.success).toBe(true);
   });
 
+  it("accepts allowlisted per-message model and effort overrides", () => {
+    const result = MainWsClientMessageSchema.safeParse({
+      type: "message",
+      text: "hello",
+      model: "claude-sonnet-4-5",
+      effort: "max",
+    });
+
+    expect(result.success).toBe(true);
+    if (result.success && result.data.type === "message") {
+      expect(result.data.model).toBe("claude-sonnet-4-5");
+      expect(result.data.effort).toBe("max");
+    }
+  });
+
+  it.each([
+    ["model", "not-an-allowlisted-model"],
+    ["effort", "extreme"],
+  ])("rejects an unsupported %s override", (key, value) => {
+    const result = MainWsClientMessageSchema.safeParse({
+      type: "message",
+      text: "hello",
+      [key]: value,
+    });
+
+    expect(result.success).toBe(false);
+  });
+
   it("rejects malformed switch_session payloads", () => {
     const result = MainWsClientMessageSchema.safeParse({
       type: "switch_session",


### PR DESCRIPTION
## Summary

- validate optional allowlisted model and effort values on kernel WebSocket message frames
- thread immutable per-message overrides through the dispatcher queue into `KernelConfig`
- centralize the existing kernel model/effort catalog without changing `GET/PUT /api/settings/agent` compatibility
- cover boundary validation, queue isolation, settings compatibility, and the real `/ws` dispatch path

## TDD and validation

- The schema was observed dropping supported fields and accepting unsupported values before implementation; dispatcher and WebSocket tests observed no override.
- Restacked model/effort boundary and dispatcher tests passed in the 192-test conflict-seam suite.
- Dedicated Chat E2E: 11/11 passed, including real per-message kernel selection.
- Exact current-main stack-tip gate: typecheck passed; pattern scan reported 0 violations; 785 files passed, 3 skipped; 8,478 tests passed, 20 skipped.
- Exact head: `f9642073725af68b8da0242a10cd81565d16083d`.

## Stack

- #960 — spec and spike
- #968 — stored conversation transcript
- this PR — per-message kernel model and effort

## Invariants

- **Source of truth:** The owner file remains authoritative for persisted kernel defaults; the shared allowlist validates only one WebSocket dispatch.
- **Lock/transaction scope:** Each queued dispatch captures an immutable override object. No database write or additional lock is introduced.
- **Acceptable orphan states:** None. Invalid frames reject before dispatch; disconnect and cancellation continue through the existing WebSocket lifecycle.
- **Auth source of truth:** Existing authenticated `/ws` middleware remains the sole access gate.
- **Deferred scope:** Provider/runtime selection, provider authentication, and shell UI remain later stack slices. Per-message selections are not persisted.
- Model and effort are separately optional, strict, and allowlisted. Dispatcher defaults and queued/concurrent requests cannot be mutated by another message.
- This PR has 208 additions across 9 files, below the 3,000-addition/50-file limits, and will not merge below exact-head Greptile 5/5.

## Rollout

- no merge or promotion requested
- verify one-message override isolation and invalid-frame rejection on the exact preview gateway
