### PR TITLE
fix(test): exclude e2e from unit config and give DB hooks timeout margin

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -77,13 +77,22 @@ export default defineConfig({
     // CI runners are sometimes slow under load; tests that rely on async
     // waitFor polling can exceed the 5s vitest default.
     testTimeout: 20_000,
-    hookTimeout: 20_000,
+    // DB-provisioning hooks (createTestPlatformDb and friends) are the
+    // slowest step and the dominant full-suite flake under disk/IO pressure:
+    // rotating "Hook timed out in 20000ms" failures across platform suites on
+    // loaded agent machines while every victim passes in isolation. Hooks are
+    // setup, not assertions — a generous ceiling only delays the report for
+    // genuinely broken hooks (timeouts must cover observed runtime with margin).
+    hookTimeout: 60_000,
     // PGlite-backed suites are memory- and CPU-heavy during database startup.
     // Keep file-level parallelism bounded so full-suite runs do not starve
     // KyselyPGlite.create() hooks under shared CI or agent-machine load.
     maxWorkers: 2,
     include: ["tests/**/*.test.ts", "tests/**/*.test.tsx"],
-    exclude: ["tests/**/*.integration.ts", "node_modules", "dist", ".next"],
+    // tests/e2e is owned by vitest.e2e.config.ts (bun run test:e2e); the
+    // desktop suites there launch Electron, which fails on headless unit
+    // runners when the unit glob accidentally collects them.
+    exclude: ["tests/**/*.integration.ts", "tests/e2e/**", "node_modules", "dist", ".next"],
     coverage: {
       provider: "v8",
       include: [


### PR DESCRIPTION
## Summary

Fixes the two classes of full-suite unit-test flakiness observed across four runs on a loaded agent machine (victims rotated between `tests/integrations/routes.test.ts`, `tests/platform/billing-routes.test.ts`, `tests/platform/{customer-vps,social-api,social-feed}.test.ts`, `tests/kernel/boot.test.ts`, and `tests/e2e/desktop/operator.e2e.test.ts`; every one passes in isolation):

1. **`tests/e2e/**` excluded from the unit config.** The unit include glob (`tests/**/*.test.ts`) also matches `*.e2e.test.ts`, so unit runs collected the desktop Electron suite, which fails with `electron.launch: Process failed to launch!` on headless runners. That directory is owned by `vitest.e2e.config.ts` / `bun run test:e2e`.
2. **`hookTimeout` 20s → 60s** (testTimeout unchanged at 20s). The rotating failures were all `Hook timed out in 20000ms` in DB-provisioning `beforeEach` hooks (`createTestPlatformDb`) under disk/IO pressure — the same failure class the existing `maxWorkers: 2` comment describes. Hooks are setup, not assertions: a generous ceiling only delays reporting genuinely broken hooks, and follows the repo rule that timeouts must cover observed runtime with margin.

## Tests

- `tests/platform/{social-api,social-feed,customer-vps}.test.ts` — 109 passed after prerequisite builds.
- `pnpm exec vitest run tests/e2e/desktop/operator.e2e.test.ts` under the unit config now reports "No test files found" (excluded), and `vitest.e2e.config.ts` still includes it for `bun run test:e2e`.
- Config-only change; no product code touched.

## Review/Monitoring

Will monitor Greptile to 5/5 and CI; fixes land on this branch.

## Invariants

- **Source of truth**: `vitest.config.ts` owns unit collection; `vitest.e2e.config.ts` owns `tests/e2e/**`. This PR makes that boundary real instead of accidental.
- **Deferred scope**: per-suite profiling of slow DB hooks (PGlite startup cost) if 60s ever proves insufficient; CI job timeout budgets are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)