### PR TITLE
fix(shell): resolve nodenext .js specifiers from workspace TS sources in webpack builds

### DIFF
--- a/shell/next.config.ts
+++ b/shell/next.config.ts
@@ -25,6 +25,19 @@ const nextConfig: NextConfig = {
   turbopack: {
     root: resolve(__dirname, ".."),
   },
+  // Workspace packages (e.g. @matrix-os/contracts) are consumed as TS source
+  // and use nodenext module resolution, so their relative imports carry .js
+  // extensions ("./agent-profile.js" -> agent-profile.ts). Turbopack maps
+  // that natively; webpack needs extensionAlias or the production build
+  // fails with "Module not found: Can't resolve './agent-profile.js'".
+  webpack: (config) => {
+    config.resolve.extensionAlias = {
+      ".js": [".ts", ".tsx", ".js"],
+      ".jsx": [".tsx", ".jsx"],
+      ...config.resolve.extensionAlias,
+    };
+    return config;
+  },
   async rewrites() {
     return [
       // Same-origin PostHog proxy. Ad blockers blocklist *.posthog.com and

--- a/shell/next.config.ts
+++ b/shell/next.config.ts
@@ -32,9 +32,9 @@ const nextConfig: NextConfig = {
   // fails with "Module not found: Can't resolve './agent-profile.js'".
   webpack: (config) => {
     config.resolve.extensionAlias = {
+      ...config.resolve.extensionAlias,
       ".js": [".ts", ".tsx", ".js"],
       ".jsx": [".tsx", ".jsx"],
-      ...config.resolve.extensionAlias,
     };
     return config;
   },


### PR DESCRIPTION
## Summary

Host-bundle releases on main are currently broken: `next build --webpack` fails with `Module not found: Can't resolve './agent-profile.js'` from `packages/contracts/src/index.ts` (first release run after today's merges; Publish/Deploy skipped).

Root cause is a resolver mismatch, not the contracts export: the contracts package uses `nodenext` module resolution, whose relative imports must carry `.js` extensions mapping to `.ts` sources (tsc errors if the extension is dropped — verified). Turbopack, which dev servers and per-PR builds used, resolves `.js -> .ts` natively, so this only surfaces in the webpack production build the release pipeline runs. The `agent-profile` re-export from #963 was simply the first nodenext-style relative re-export to hit that path.

Fix: add the standard `resolve.extensionAlias` mapping (`.js -> [.ts, .tsx, .js]`) in the shell webpack config, preserving any future upstream aliases.

## Tests

- `bun run build:shell:production` (the canonical release-parity build, same `next build --webpack` invocation the bundle workflow runs): fails on main with the exact release error; compiles successfully (81s) with this change.
- `bun run typecheck` clean — the alternative fix (dropping the `.js` extension in contracts) breaks tsc under nodenext and was rejected.
- Config-only; no React component changes (react-doctor not applicable).

## Review/Monitoring

Will monitor Greptile to 5/5; this unblocks the pending fleet deploy, so it will be merged once review-clean per the standing deploy instruction.

## Invariants

- **Source of truth**: webpack resolution now honors the workspace-wide nodenext convention; contracts keeps its required `.js` specifiers.
- **Deferred scope**: making the PR `Shell Production Build` CI gate mandatory for packages/* changes that shell imports (this regression merged with green PR CI because only the release workflow runs the webpack build).

🤖 Generated with [Claude Code](https://claude.com/claude-code)