### PR TITLE
feat(gateway): unify agent settings inventory

### DIFF
--- a/packages/gateway/src/agent-config/hermes-client.ts
+++ b/packages/gateway/src/agent-config/hermes-client.ts
@@ -9,8 +9,8 @@ type FetchLike = (
 ) => Promise<Response>;
 
 export class HermesUnavailableError extends Error {
-  constructor(cause?: unknown) {
-    super("Hermes upstream is unavailable");
+  constructor(cause?: unknown, diagnostic?: string) {
+    super(diagnostic ?? "Hermes upstream is unavailable");
     this.name = "HermesUnavailableError";
     if (cause !== undefined) this.cause = cause;
   }
@@ -43,7 +43,13 @@ export function validateHermesDashboardUrl(rawUrl: string): void {
   try {
     parsed = new URL(rawUrl);
   } catch (err) {
-    throw new HermesUnavailableError(err);
+    throw new HermesUnavailableError(err, "Hermes dashboard URL is invalid");
+  }
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    throw new HermesUnavailableError(
+      undefined,
+      `Hermes dashboard URL rejected protocol: ${parsed.protocol}`,
+    );
   }
   const hostname = parsed.hostname.replace(/^\[|\]$/g, "");
   if (hostname === "::1" || hostname === "localhost") return;
@@ -51,7 +57,10 @@ export function validateHermesDashboardUrl(rawUrl: string): void {
     && hostname.startsWith("127.")) {
     return;
   }
-  throw new HermesUnavailableError();
+  throw new HermesUnavailableError(
+    undefined,
+    `Hermes dashboard URL rejected non-loopback host: ${hostname}`,
+  );
 }
 
 function validatePath(path: string): void {

--- a/packages/gateway/src/agent-config/hermes-client.ts
+++ b/packages/gateway/src/agent-config/hermes-client.ts
@@ -1,0 +1,142 @@
+const DEFAULT_HERMES_BASE_URL = "http://127.0.0.1:9119";
+const DEFAULT_HERMES_TIMEOUT_MS = 10_000;
+const MAX_HERMES_JSON_BYTES = 1024 * 1024;
+const HERMES_PATH = /^\/api\/[a-z0-9_/-]+$/;
+
+type FetchLike = (
+  input: string | URL | Request,
+  init?: RequestInit,
+) => Promise<Response>;
+
+export class HermesUnavailableError extends Error {
+  constructor(cause?: unknown) {
+    super("Hermes upstream is unavailable");
+    this.name = "HermesUnavailableError";
+    if (cause !== undefined) this.cause = cause;
+  }
+}
+
+export class HermesResponseTooLargeError extends Error {
+  constructor() {
+    super("Hermes response exceeded its size limit");
+    this.name = "HermesResponseTooLargeError";
+  }
+}
+
+export class HermesUpstreamResponseError extends Error {
+  constructor() {
+    super("Hermes upstream returned an unsuccessful response");
+    this.name = "HermesUpstreamResponseError";
+  }
+}
+
+export class HermesInvalidResponseError extends Error {
+  constructor(cause?: unknown) {
+    super("Hermes upstream returned an invalid response");
+    this.name = "HermesInvalidResponseError";
+    if (cause !== undefined) this.cause = cause;
+  }
+}
+
+export function validateHermesDashboardUrl(rawUrl: string): void {
+  let parsed: URL;
+  try {
+    parsed = new URL(rawUrl);
+  } catch (err) {
+    throw new HermesUnavailableError(err);
+  }
+  const hostname = parsed.hostname.replace(/^\[|\]$/g, "");
+  if (hostname === "::1" || hostname === "localhost") return;
+  if (/^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$/.test(hostname)
+    && hostname.startsWith("127.")) {
+    return;
+  }
+  throw new HermesUnavailableError();
+}
+
+function validatePath(path: string): void {
+  if (!HERMES_PATH.test(path) || path.includes("..") || path.includes("//")) {
+    throw new TypeError("Invalid Hermes API path");
+  }
+}
+
+async function readBoundedBody(response: Response): Promise<Uint8Array> {
+  const contentLength = response.headers.get("content-length");
+  if (contentLength !== null) {
+    const parsedLength = Number(contentLength);
+    if (Number.isFinite(parsedLength) && parsedLength > MAX_HERMES_JSON_BYTES) {
+      await response.body?.cancel();
+      throw new HermesResponseTooLargeError();
+    }
+  }
+  if (response.body === null) return new Uint8Array();
+
+  const reader = response.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let totalBytes = 0;
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      totalBytes += value.byteLength;
+      if (totalBytes > MAX_HERMES_JSON_BYTES) {
+        await reader.cancel();
+        throw new HermesResponseTooLargeError();
+      }
+      chunks.push(value);
+    }
+  } finally {
+    reader.releaseLock();
+  }
+
+  const body = new Uint8Array(totalBytes);
+  let offset = 0;
+  for (const chunk of chunks) {
+    body.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return body;
+}
+
+export function createHermesDashboardClient(options: {
+  baseUrl?: string;
+  fetchImpl?: FetchLike;
+} = {}) {
+  const baseUrl = options.baseUrl
+    ?? process.env.HERMES_DASHBOARD_URL
+    ?? DEFAULT_HERMES_BASE_URL;
+  validateHermesDashboardUrl(baseUrl);
+  const normalizedBaseUrl = baseUrl.replace(/\/$/, "");
+  const fetchImpl = options.fetchImpl ?? globalThis.fetch;
+
+  async function fetchPath(
+    path: string,
+    init: Omit<RequestInit, "redirect"> = {},
+  ): Promise<Response> {
+    validatePath(path);
+    try {
+      return await fetchImpl(`${normalizedBaseUrl}${path}`, {
+        ...init,
+        signal: init.signal ?? AbortSignal.timeout(DEFAULT_HERMES_TIMEOUT_MS),
+        redirect: "error",
+      });
+    } catch (err) {
+      throw new HermesUnavailableError(err);
+    }
+  }
+
+  async function readJson(path: string, signal: AbortSignal): Promise<unknown> {
+    const response = await fetchPath(path, { signal });
+    if (!response.ok) throw new HermesUpstreamResponseError();
+    const body = await readBoundedBody(response);
+    try {
+      return JSON.parse(new TextDecoder().decode(body)) as unknown;
+    } catch (err) {
+      throw new HermesInvalidResponseError(err);
+    }
+  }
+
+  return { fetch: fetchPath, readJson };
+}
+
+export type HermesDashboardClient = ReturnType<typeof createHermesDashboardClient>;

--- a/packages/gateway/src/agent-config/hermes-source.ts
+++ b/packages/gateway/src/agent-config/hermes-source.ts
@@ -1,0 +1,312 @@
+import {
+  AgentProviderDescriptorSchema,
+  type AgentAuthKind,
+  type AgentProviderDescriptor,
+} from "@matrix-os/contracts";
+import { z } from "zod/v4";
+import type { AgentRuntimeSettingsSnapshot } from "./service.js";
+
+export type HermesJsonReader = (
+  path: string,
+  signal: AbortSignal,
+) => Promise<unknown>;
+
+const MAX_HERMES_PROVIDERS = 31;
+const MAX_HERMES_MODELS = 253;
+const MAX_MODELS_PER_PROVIDER = 128;
+
+const ProviderIdSchema = z.string()
+  .trim()
+  .min(1)
+  .max(80)
+  .regex(/^[a-z0-9][a-z0-9_-]{0,79}$/);
+const ModelIdSchema = z.string().trim().min(1).max(160);
+const DisplayNameSchema = z.string().trim().min(1).max(120);
+const VersionSchema = z.string().trim().min(1).max(64);
+
+const HermesStatusSchema = z.object({
+  gateway_running: z.boolean().optional(),
+  version: z.unknown().optional(),
+}).passthrough();
+
+const HermesOptionsSchema = z.object({
+  provider: z.unknown().optional(),
+  model: z.unknown().optional(),
+  providers: z.array(z.unknown()).max(128),
+}).passthrough();
+
+const HermesProviderSchema = z.object({
+  slug: z.unknown(),
+  name: z.unknown().optional(),
+  authenticated: z.boolean().optional(),
+  auth_type: z.string().max(64).optional(),
+  is_user_defined: z.boolean().optional(),
+  models: z.array(z.unknown()).max(512).optional(),
+}).passthrough();
+
+function authKindForProvider(
+  authType: string | undefined,
+  isUserDefined: boolean,
+): AgentAuthKind {
+  if (isUserDefined || authType === "base_url" || authType === "custom") {
+    return "base_url";
+  }
+  if (authType === "api_key") return "api_key";
+  return "oauth_login";
+}
+
+function authAction(authKind: AgentAuthKind) {
+  if (authKind === "api_key") return "enter_api_key" as const;
+  if (authKind === "base_url") return "configure_base_url" as const;
+  if (authKind === "oauth_login") return "open_login_terminal" as const;
+  return "contact_owner" as const;
+}
+
+function parseModelIds(rawModels: unknown[] | undefined, currentModel: string | null) {
+  const models: string[] = [];
+  const seen = new Set<string>();
+  for (const candidate of rawModels ?? []) {
+    const parsed = ModelIdSchema.safeParse(candidate);
+    if (!parsed.success || seen.has(parsed.data)) continue;
+    seen.add(parsed.data);
+    models.push(parsed.data);
+    if (models.length === MAX_MODELS_PER_PROVIDER) break;
+  }
+  models.sort((left, right) => left.localeCompare(right));
+  if (currentModel === null) return models;
+  const selectedIndex = models.indexOf(currentModel);
+  if (selectedIndex !== -1) models.splice(selectedIndex, 1);
+  return [currentModel, ...models].slice(0, MAX_MODELS_PER_PROVIDER);
+}
+
+function normalizeProvider(
+  raw: unknown,
+  currentProvider: string | null,
+  currentModel: string | null,
+): AgentProviderDescriptor | null {
+  const parsed = HermesProviderSchema.safeParse(raw);
+  if (!parsed.success) return null;
+  const id = ProviderIdSchema.safeParse(parsed.data.slug);
+  if (!id.success) return null;
+  const name = DisplayNameSchema.safeParse(parsed.data.name);
+  const authenticated = parsed.data.authenticated === true;
+  const authKind = authKindForProvider(
+    parsed.data.auth_type,
+    parsed.data.is_user_defined === true,
+  );
+  const models = parseModelIds(
+    parsed.data.models,
+    id.data === currentProvider ? currentModel : null,
+  ).map((model) => ({
+    id: model,
+    displayName: model,
+    capabilities: ["tools" as const],
+    efforts: [],
+    available: true,
+  }));
+  const provider = {
+    id: id.data,
+    displayName: name.success ? name.data : id.data,
+    runtime: "hermes" as const,
+    scopes: ["messaging" as const],
+    authKind,
+    supportedAuthKinds: [authKind],
+    models,
+    authStatus: authenticated
+      ? { state: "ready" as const, authenticated: true, action: "none" as const }
+      : {
+          state: "action_required" as const,
+          authenticated: false,
+          action: authAction(authKind),
+        },
+  };
+  const validated = AgentProviderDescriptorSchema.safeParse(provider);
+  return validated.success ? validated.data : null;
+}
+
+export function normalizeHermesRuntimeSnapshot(input: {
+  status: unknown;
+  options: unknown;
+}): AgentRuntimeSettingsSnapshot {
+  const status = HermesStatusSchema.parse(input.status);
+  const options = HermesOptionsSchema.parse(input.options);
+  const currentProviderResult = ProviderIdSchema.safeParse(options.provider);
+  const currentModelResult = ModelIdSchema.safeParse(options.model);
+  const currentProvider = currentProviderResult.success
+    ? currentProviderResult.data
+    : null;
+  const currentModel = currentModelResult.success ? currentModelResult.data : null;
+  const normalizedProviders: AgentProviderDescriptor[] = [];
+  for (const rawProvider of options.providers) {
+    const provider = normalizeProvider(rawProvider, currentProvider, currentModel);
+    if (!provider) continue;
+    const duplicateIndex = normalizedProviders.findIndex(
+      (entry) => entry.id === provider.id,
+    );
+    if (duplicateIndex === -1) {
+      normalizedProviders.push(provider);
+    } else if (normalizedProviders[duplicateIndex]?.authStatus.state !== "ready"
+      && provider.authStatus.state === "ready") {
+      normalizedProviders[duplicateIndex] = provider;
+    }
+  }
+  normalizedProviders.sort((left, right) => {
+    const selectedDifference = Number(right.id === currentProvider)
+      - Number(left.id === currentProvider);
+    if (selectedDifference !== 0) return selectedDifference;
+    const readyDifference = Number(right.authStatus.state === "ready")
+      - Number(left.authStatus.state === "ready");
+    return readyDifference !== 0
+      ? readyDifference
+      : left.id.localeCompare(right.id);
+  });
+
+  const providers: AgentProviderDescriptor[] = [];
+  let modelCount = 0;
+  for (const provider of normalizedProviders) {
+    const remainingModels = MAX_HERMES_MODELS - modelCount;
+    if (remainingModels <= 0) break;
+    const boundedProvider = provider.models.length <= remainingModels
+      ? provider
+      : { ...provider, models: provider.models.slice(0, remainingModels) };
+    providers.push(boundedProvider);
+    modelCount += boundedProvider.models.length;
+    if (providers.length === MAX_HERMES_PROVIDERS) break;
+  }
+
+  const selectedProvider = currentProvider === null
+    ? undefined
+    : providers.find((provider) => provider.id === currentProvider);
+  const hasSelection = currentModel !== null
+    && selectedProvider?.models.some((model) => model.id === currentModel) === true;
+  const configured = currentProvider !== null && currentModel !== null && hasSelection;
+  const version = VersionSchema.safeParse(status.version);
+
+  return {
+    runtime: {
+      selected: "hermes",
+      options: [
+        {
+          id: "hermes",
+          displayName: "Hermes",
+          installState: "installed",
+          health: status.gateway_running === true ? "healthy" : "degraded",
+          selectionState: "active",
+          configured,
+          ...(version.success ? { version: version.data } : {}),
+          capabilities: [
+            "provider_catalog",
+            "model_selection",
+            "authentication",
+            "messaging_dashboard",
+          ],
+        },
+        {
+          id: "openclaw",
+          displayName: "OpenClaw",
+          installState: "missing",
+          health: "stopped",
+          selectionState: "unavailable",
+          configured: false,
+          capabilities: ["install"],
+          setupAction: "install",
+        },
+      ],
+      transition: null,
+    },
+    providers,
+    messaging: {
+      runtime: "hermes",
+      provider: configured ? currentProvider : null,
+      model: configured ? currentModel : null,
+      configured,
+    },
+  };
+}
+
+export function createHermesRuntimeSource(
+  readJson: HermesJsonReader,
+  options: {
+    cacheTtlMs?: number;
+    now?: () => number;
+    logWarning?: (errorName: string) => void;
+  } = {},
+) {
+  const cacheTtlMs = options.cacheTtlMs ?? 5_000;
+  if (!Number.isFinite(cacheTtlMs) || cacheTtlMs < 0 || cacheTtlMs > 60_000) {
+    throw new RangeError("Invalid Hermes settings cache TTL");
+  }
+  const now = options.now ?? Date.now;
+  const logWarning = options.logWarning ?? ((errorName: string) => {
+    console.warn("[agent-config] Hermes settings probe failed:", errorName);
+  });
+  let cached: { value: AgentRuntimeSettingsSnapshot; expiresAt: number } | null = null;
+  let inFlight: Promise<AgentRuntimeSettingsSnapshot> | null = null;
+
+  return async (signal: AbortSignal): Promise<AgentRuntimeSettingsSnapshot> => {
+    signal.throwIfAborted();
+    if (cached !== null && cached.expiresAt > now()) return cached.value;
+    if (inFlight === null) {
+      inFlight = Promise.all([
+        readJson("/api/status", signal),
+        readJson("/api/model/options", signal),
+      ]).then(([status, modelOptions]) => {
+        return normalizeHermesRuntimeSnapshot({
+          status,
+          options: modelOptions,
+        });
+      }).catch((err: unknown) => {
+        logWarning(err instanceof Error ? err.name : "UnknownError");
+        return unavailableHermesRuntimeSnapshot();
+      }).then((value) => {
+        cached = { value, expiresAt: now() + cacheTtlMs };
+        return value;
+      }).finally(() => {
+        inFlight = null;
+      });
+    }
+    return inFlight;
+  };
+}
+
+function unavailableHermesRuntimeSnapshot(): AgentRuntimeSettingsSnapshot {
+  return {
+    runtime: {
+      selected: "hermes",
+      options: [
+        {
+          id: "hermes",
+          displayName: "Hermes",
+          installState: "unknown",
+          health: "unreachable",
+          selectionState: "active",
+          configured: false,
+          capabilities: [
+            "provider_catalog",
+            "model_selection",
+            "authentication",
+            "messaging_dashboard",
+          ],
+        },
+        {
+          id: "openclaw",
+          displayName: "OpenClaw",
+          installState: "missing",
+          health: "stopped",
+          selectionState: "unavailable",
+          configured: false,
+          capabilities: ["install"],
+          setupAction: "install",
+        },
+      ],
+      transition: null,
+    },
+    providers: [],
+    messaging: {
+      runtime: "hermes",
+      provider: null,
+      model: null,
+      configured: false,
+    },
+  };
+}

--- a/packages/gateway/src/agent-config/service.ts
+++ b/packages/gateway/src/agent-config/service.ts
@@ -1,0 +1,191 @@
+import {
+  AgentSettingsViewSchema,
+  type AgentMessagingSelection,
+  type AgentProviderDescriptor,
+  type AgentRuntimeSelection,
+  type AgentSettingsView,
+} from "@matrix-os/contracts";
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { z } from "zod/v4";
+import {
+  KERNEL_DEFAULTS,
+  KERNEL_EFFORTS,
+  KERNEL_MODELS,
+  normalizeKernelEffort,
+  normalizeKernelModel,
+} from "../kernel-settings.js";
+
+interface BuildAgentSettingsViewInput {
+  identity: Record<string, unknown>;
+  config: Record<string, unknown>;
+  claudeLoginAvailable: boolean;
+  platformCredentialAvailable: boolean;
+  runtimeSnapshot?: AgentRuntimeSettingsSnapshot;
+}
+
+export interface AgentRuntimeSettingsSnapshot {
+  runtime: AgentRuntimeSelection;
+  providers: AgentProviderDescriptor[];
+  messaging: AgentMessagingSelection;
+}
+
+export type AgentRuntimeSource = (
+  signal: AbortSignal,
+) => Promise<AgentRuntimeSettingsSnapshot>;
+
+export async function readRuntimeSnapshot(
+  source: AgentRuntimeSource,
+  timeoutMs = 2_000,
+): Promise<AgentRuntimeSettingsSnapshot> {
+  const controller = new AbortController();
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  const timeoutPromise = new Promise<never>((_resolve, reject) => {
+    timeout = setTimeout(() => {
+      controller.abort();
+      reject(new Error("Runtime settings probe timed out"));
+    }, timeoutMs);
+  });
+
+  try {
+    return await Promise.race([source(controller.signal), timeoutPromise]);
+  } finally {
+    if (timeout !== undefined) clearTimeout(timeout);
+  }
+}
+
+const ClaudeLoginSchema = z.object({
+  oauthAccount: z.object({
+    accountUuid: z.string().min(1).max(256),
+  }).passthrough(),
+}).passthrough();
+
+export async function hasClaudeLogin(homePath: string): Promise<boolean> {
+  try {
+    const raw = await readFile(join(homePath, ".claude.json"), "utf-8");
+    return ClaudeLoginSchema.safeParse(JSON.parse(raw)).success;
+  } catch (err) {
+    if (!(err instanceof Error)
+      || (err as NodeJS.ErrnoException).code !== "ENOENT") {
+      console.warn(
+        "[agent-config] Failed to read owner login status:",
+        err instanceof Error ? err.name : "UnknownError",
+      );
+    }
+    return false;
+  }
+}
+
+export function buildAgentSettingsView(
+  input: BuildAgentSettingsViewInput,
+): AgentSettingsView {
+  const kernelConfig = typeof input.config.kernel === "object"
+    && input.config.kernel !== null
+    && !Array.isArray(input.config.kernel)
+    ? input.config.kernel as Record<string, unknown>
+    : {};
+  const savedModel = normalizeKernelModel(kernelConfig.model);
+  const savedEffort = normalizeKernelEffort(kernelConfig.effort);
+  const hasByokCredential = typeof kernelConfig.anthropicApiKey === "string"
+    && kernelConfig.anthropicApiKey.trim().length > 0;
+  const authKind = hasByokCredential
+    ? "api_key" as const
+    : input.claudeLoginAvailable
+      ? "oauth_login" as const
+      : "platform" as const;
+  const model = savedModel ?? KERNEL_DEFAULTS.model;
+  const effort = savedEffort ?? KERNEL_DEFAULTS.effort;
+  const chat = {
+    provider: "anthropic",
+    model,
+    effort,
+    source: savedModel === null ? "default" as const : "saved" as const,
+    authKind,
+  };
+  const authStatus = hasByokCredential
+    || input.claudeLoginAvailable
+    || input.platformCredentialAvailable
+    ? { state: "ready" as const, authenticated: true, action: "none" as const }
+    : {
+        state: "action_required" as const,
+        authenticated: false,
+        action: "contact_owner" as const,
+      };
+  const agentConfig = typeof input.config.agent === "object"
+    && input.config.agent !== null
+    && !Array.isArray(input.config.agent)
+    ? input.config.agent as Record<string, unknown>
+    : {};
+  const revision = typeof agentConfig.revision === "number"
+    && Number.isSafeInteger(agentConfig.revision)
+    && agentConfig.revision >= 0
+    ? agentConfig.revision
+    : 0;
+
+  return AgentSettingsViewSchema.parse({
+    identity: input.identity,
+    kernel: { model: savedModel, effort: savedEffort },
+    availableModels: KERNEL_MODELS,
+    availableEfforts: KERNEL_EFFORTS,
+    defaults: KERNEL_DEFAULTS,
+    contractVersion: 2,
+    revision,
+    chat,
+    runtime: input.runtimeSnapshot?.runtime ?? {
+      selected: "hermes",
+      options: [
+        {
+          id: "hermes",
+          displayName: "Hermes",
+          installState: "unknown",
+          health: "unknown",
+          selectionState: "active",
+          configured: false,
+          capabilities: [
+            "provider_catalog",
+            "model_selection",
+            "authentication",
+            "messaging_dashboard",
+          ],
+        },
+        {
+          id: "openclaw",
+          displayName: "OpenClaw",
+          installState: "missing",
+          health: "stopped",
+          selectionState: "unavailable",
+          configured: false,
+          capabilities: ["install"],
+          setupAction: "install",
+        },
+      ],
+      transition: null,
+    },
+    providers: [{
+      id: "anthropic",
+      displayName: "Anthropic",
+      runtime: null,
+      scopes: ["chat"],
+      authKind,
+      supportedAuthKinds: ["platform", "api_key", "oauth_login"],
+      models: KERNEL_MODELS.map((entry) => ({
+        id: entry.id,
+        displayName: entry.label,
+        description: entry.tier,
+        capabilities: ["tools", "vision", "reasoning"],
+        efforts: [...KERNEL_EFFORTS],
+        available: true,
+      })),
+      authStatus,
+    }, ...(input.runtimeSnapshot?.providers ?? [])],
+    currentSelection: {
+      chat,
+      messaging: input.runtimeSnapshot?.messaging ?? {
+        runtime: "hermes",
+        provider: null,
+        model: null,
+        configured: false,
+      },
+    },
+  });
+}

--- a/packages/gateway/src/routes/hermes.ts
+++ b/packages/gateway/src/routes/hermes.ts
@@ -22,6 +22,13 @@ import {
   isRequestPrincipalError,
   mapRequestPrincipalError,
 } from "../request-principal.js";
+import {
+  createHermesDashboardClient,
+  HermesUnavailableError,
+  type HermesDashboardClient,
+} from "../agent-config/hermes-client.js";
+
+export { validateHermesDashboardUrl } from "../agent-config/hermes-client.js";
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -35,88 +42,6 @@ const SAFE_SLUG = /^[a-z][a-z0-9_-]{0,62}$/;
 
 // PairingId: UUID v4 format or simple alphanumeric token up to 128 chars.
 const PAIRING_ID_PATTERN = /^[a-zA-Z0-9_-]{1,128}$/;
-
-// ---------------------------------------------------------------------------
-// URL validation (exported for tests)
-// ---------------------------------------------------------------------------
-
-/**
- * Validate that the given URL resolves to loopback (127.x, ::1, localhost).
- * Throws if the URL is non-loopback to prevent SSRF.
- */
-export function validateHermesDashboardUrl(rawUrl: string): void {
-  let parsed: URL;
-  try {
-    parsed = new URL(rawUrl);
-  } catch (err) {
-    console.error("[hermes-proxy] invalid HERMES_DASHBOARD_URL:", err instanceof Error ? err.message : typeof err);
-    throw new Error(`HERMES_DASHBOARD_URL is not a valid URL: ${rawUrl}`);
-  }
-
-  const hostname = parsed.hostname.replace(/^\[|\]$/g, ""); // strip IPv6 brackets
-
-  // IPv6 loopback
-  if (hostname === "::1") return;
-
-  // Hostname "localhost" acceptable (resolves to 127.x or ::1 on
-  // well-configured hosts).  Residual DNS-rebinding risk documented in §4.
-  if (hostname === "localhost") return;
-
-  // IPv4: must start with 127.
-  if (/^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$/.test(hostname)) {
-    if (hostname.startsWith("127.")) return;
-    throw new Error(
-      `HERMES_DASHBOARD_URL must resolve to loopback; got ${hostname}`,
-    );
-  }
-
-  throw new Error(
-    `HERMES_DASHBOARD_URL must be a loopback address (127.x, ::1, localhost); got ${hostname}`,
-  );
-}
-
-// ---------------------------------------------------------------------------
-// Upstream fetch helper
-// ---------------------------------------------------------------------------
-
-const DEFAULT_HERMES_BASE_URL = "http://127.0.0.1:9119";
-
-function getBaseUrl(): string {
-  return process.env.HERMES_DASHBOARD_URL ?? DEFAULT_HERMES_BASE_URL;
-}
-
-class HermesUnavailableError extends Error {
-  constructor(cause?: unknown) {
-    super("Hermes upstream is unavailable");
-    this.name = "HermesUnavailableError";
-    if (cause !== undefined) this.cause = cause;
-  }
-}
-
-type FetchInit = Omit<RequestInit, "signal" | "redirect">;
-
-/**
- * Fetch from Hermes dashboard.
- * - Hard timeout of 10 s.
- * - redirect: "error" (no redirect following).
- * - Maps connection/abort errors → HermesUnavailableError.
- */
-async function hermesFetch(path: string, init: FetchInit = {}): Promise<Response> {
-  const url = `${getBaseUrl()}${path}`;
-  try {
-    return await fetch(url, {
-      ...init,
-      signal: AbortSignal.timeout(10_000),
-      redirect: "error",
-    });
-  } catch (err) {
-    console.error(
-      "[hermes-proxy] upstream fetch failed:",
-      err instanceof Error ? err.message : String(err),
-    );
-    throw new HermesUnavailableError(err);
-  }
-}
 
 // ---------------------------------------------------------------------------
 // Response helpers (use `any` for c — consistent with canvas/routes.ts pattern)
@@ -192,7 +117,7 @@ const TelegramOnboardingApplySchema = z.object({
 // ---------------------------------------------------------------------------
 
 export interface HermesRouteDeps {
-  // Reserved — upstream base URL comes from process.env.HERMES_DASHBOARD_URL.
+  client?: HermesDashboardClient;
 }
 
 // ---------------------------------------------------------------------------
@@ -201,6 +126,7 @@ export interface HermesRouteDeps {
 
 export function createHermesRoutes(_deps: HermesRouteDeps = {}): Hono {
   const app = new Hono();
+  const hermesFetch = (_deps.client ?? createHermesDashboardClient()).fetch;
 
   // ------------------------------------------------------------------
   // GET /status  (aggregates /api/status + /api/model/info into coarse shape)

--- a/packages/gateway/src/routes/settings.ts
+++ b/packages/gateway/src/routes/settings.ts
@@ -12,19 +12,23 @@ import {
 } from "node:fs/promises";
 import { dirname, extname, relative, join } from "node:path";
 import { DEFAULT_ICON_STYLE, loadSkills } from "@matrix-os/kernel";
+import { AgentSettingsUpdateSchema } from "@matrix-os/contracts";
 import type { ChannelManager } from "../channels/manager.js";
 import type { ChannelConfig, ChannelId } from "../channels/types.js";
 import { validateApiKeyFormat, validateApiKeyLive, storeApiKey, hasApiKey } from "../onboarding/api-key.js";
 import { buildAgentProfileSummary } from "../agent-profile-summary.js";
 import {
-  KERNEL_DEFAULTS,
-  KERNEL_EFFORTS,
-  KERNEL_MODELS,
   KernelEffortSchema,
   KernelModelSchema,
   normalizeKernelEffort,
   normalizeKernelModel,
 } from "../kernel-settings.js";
+import {
+  buildAgentSettingsView,
+  hasClaudeLogin,
+  readRuntimeSnapshot,
+  type AgentRuntimeSource,
+} from "../agent-config/service.js";
 
 const DESKTOP_DEFAULTS = {
   background: { type: "wallpaper", name: "moraine-lake.jpg" },
@@ -35,6 +39,7 @@ const DESKTOP_DEFAULTS = {
 
 const THEME_DEFAULTS = {};
 const SETTINGS_BODY_LIMIT = 256 * 1024;
+const AGENT_SETTINGS_BODY_LIMIT = 16 * 1024;
 
 const KernelPatchSchema = z
   .object({
@@ -158,6 +163,10 @@ function isNotFoundError(err: unknown): boolean {
   return err instanceof Error && (err as NodeJS.ErrnoException).code === "ENOENT";
 }
 
+function isBodyLimitError(err: unknown): boolean {
+  return err instanceof Error && err.name === "BodyLimitError";
+}
+
 async function fileExists(path: string): Promise<boolean> {
   try {
     await access(path);
@@ -200,8 +209,9 @@ function mergeDesktopDefaults(config: Record<string, unknown>): Record<string, u
 export function createSettingsRoutes(opts: {
   homePath: string;
   channelManager: ChannelManager;
+  agentRuntimeSource?: AgentRuntimeSource;
 }) {
-  const { homePath, channelManager } = opts;
+  const { homePath, channelManager, agentRuntimeSource } = opts;
   const app = new Hono();
   const configPath = join(homePath, "system/config.json");
 
@@ -263,18 +273,26 @@ export function createSettingsRoutes(opts: {
   app.get("/agent", async (c) => {
     const cfg = await readConfig();
     const handlePath = join(homePath, "system/handle.json");
-    const handle = await readJson(handlePath, {}, "handle");
-    const kernel = (cfg.kernel ?? {}) as Record<string, unknown>;
-    return c.json({
+    const handle = await readJson<Record<string, unknown>>(handlePath, {}, "handle");
+    let runtimeSnapshot;
+    if (agentRuntimeSource) {
+      try {
+        runtimeSnapshot = await readRuntimeSnapshot(agentRuntimeSource);
+      } catch (err) {
+        console.warn(
+          "[settings] Failed to read agent runtime settings:",
+          err instanceof Error ? err.name : "UnknownError",
+        );
+      }
+    }
+    return c.json(buildAgentSettingsView({
       identity: handle,
-      kernel: {
-        model: normalizeKernelModel(kernel.model),
-        effort: normalizeKernelEffort(kernel.effort),
-      },
-      availableModels: KERNEL_MODELS,
-      availableEfforts: KERNEL_EFFORTS,
-      defaults: KERNEL_DEFAULTS,
-    });
+      config: cfg,
+      claudeLoginAvailable: await hasClaudeLogin(homePath),
+      platformCredentialAvailable: typeof process.env.ANTHROPIC_API_KEY === "string"
+        && process.env.ANTHROPIC_API_KEY.length > 0,
+      runtimeSnapshot,
+    }));
   });
 
   app.get("/agent/summary", async (c) => {
@@ -286,24 +304,41 @@ export function createSettingsRoutes(opts: {
     }
   });
 
-  app.put("/agent", bodyLimit({ maxSize: SETTINGS_BODY_LIMIT }), async (c) => {
+  app.put("/agent", bodyLimit({ maxSize: AGENT_SETTINGS_BODY_LIMIT }), async (c) => {
     let raw: unknown;
     try {
       raw = await c.req.json();
     } catch (err) {
+      if (isBodyLimitError(err)) {
+        return c.json({ error: "agent_config_invalid" }, 413);
+      }
       if (!(err instanceof SyntaxError)) {
         console.warn("[settings] Failed to parse agent config request:", err);
       }
       return c.json({ error: "Invalid JSON" }, 400);
     }
-    const parsed = KernelPatchSchema.safeParse(raw);
+    const parsed = AgentSettingsUpdateSchema.safeParse(raw);
     if (!parsed.success) {
-      return c.json({ error: "Invalid kernel settings" }, 400);
+      return c.json({ error: "agent_config_invalid" }, 400);
+    }
+    const hasExtendedMutation = parsed.data.runtime !== undefined
+      || parsed.data.provider !== undefined
+      || parsed.data.messagingModel !== undefined
+      || parsed.data.baseUrl !== undefined;
+    if (hasExtendedMutation) {
+      return c.json({ error: "runtime_unavailable" }, 503);
+    }
+    const kernelPatch = KernelPatchSchema.safeParse({
+      model: parsed.data.model,
+      effort: parsed.data.effort,
+    });
+    if (!kernelPatch.success) {
+      return c.json({ error: "agent_config_invalid" }, 400);
     }
     const cfg = await readConfig();
     const kernel = { ...((cfg.kernel ?? {}) as Record<string, unknown>) };
-    if (parsed.data.model !== undefined) kernel.model = parsed.data.model;
-    if (parsed.data.effort !== undefined) kernel.effort = parsed.data.effort;
+    if (kernelPatch.data.model !== undefined) kernel.model = kernelPatch.data.model;
+    if (kernelPatch.data.effort !== undefined) kernel.effort = kernelPatch.data.effort;
     cfg.kernel = kernel;
     await writeJsonAtomic(configPath, cfg);
     return c.json({

--- a/packages/gateway/src/server.ts
+++ b/packages/gateway/src/server.ts
@@ -183,7 +183,12 @@ import {
   type LoadedPlugin,
 } from "./plugins/index.js";
 import { createSettingsRoutes } from "./routes/settings.js";
-import { createHermesRoutes, validateHermesDashboardUrl } from "./routes/hermes.js";
+import { createHermesRoutes } from "./routes/hermes.js";
+import {
+  createHermesDashboardClient,
+  validateHermesDashboardUrl,
+} from "./agent-config/hermes-client.js";
+import { createHermesRuntimeSource } from "./agent-config/hermes-source.js";
 import { syncApp, createSyncRoutes, type SyncRouteDeps } from "./sync/routes.js";
 import { createR2Client, type R2Client, type R2ClientConfig } from "./sync/r2-client.js";
 import { createPlatformR2Client } from "./sync/platform-r2-client.js";
@@ -3934,18 +3939,28 @@ export async function createGateway(config: GatewayConfig) {
     }
   });
 
-  // T978-T979: Settings API routes
-  const settingsRoutes = createSettingsRoutes({ homePath, channelManager });
-  app.route("/api/settings", settingsRoutes);
-
   // Spec 101: Hermes dashboard proxy (loopback only, auth-gated)
+  const hermesDashboardUrl = process.env.HERMES_DASHBOARD_URL
+    ?? "http://127.0.0.1:9119";
   try {
-    validateHermesDashboardUrl(process.env.HERMES_DASHBOARD_URL ?? "http://127.0.0.1:9119");
+    validateHermesDashboardUrl(hermesDashboardUrl);
   } catch (err) {
-    console.error("[hermes-proxy] startup validation failed:", err instanceof Error ? err.message : String(err));
+    console.error(
+      "[hermes-proxy] startup validation failed:",
+      err instanceof Error ? err.name : "UnknownError",
+    );
     throw err;
   }
-  app.route("/api/hermes", createHermesRoutes());
+  const hermesClient = createHermesDashboardClient({ baseUrl: hermesDashboardUrl });
+
+  // T978-T979: Settings API routes
+  const settingsRoutes = createSettingsRoutes({
+    homePath,
+    channelManager,
+    agentRuntimeSource: createHermesRuntimeSource(hermesClient.readJson),
+  });
+  app.route("/api/settings", settingsRoutes);
+  app.route("/api/hermes", createHermesRoutes({ client: hermesClient }));
 
   if (messagingRepository) {
     app.route("/api/messages", createMessagingRoutes({

--- a/packages/gateway/src/server.ts
+++ b/packages/gateway/src/server.ts
@@ -3947,7 +3947,7 @@ export async function createGateway(config: GatewayConfig) {
   } catch (err) {
     console.error(
       "[hermes-proxy] startup validation failed:",
-      err instanceof Error ? err.name : "UnknownError",
+      err instanceof Error ? err.message : "UnknownError",
     );
     throw err;
   }

--- a/tests/gateway/agent-config-hermes-source.test.ts
+++ b/tests/gateway/agent-config-hermes-source.test.ts
@@ -1,0 +1,172 @@
+import { describe, expect, it, vi } from "vitest";
+import { AgentProviderDescriptorSchema } from "@matrix-os/contracts";
+import {
+  createHermesRuntimeSource,
+  normalizeHermesRuntimeSnapshot,
+} from "../../packages/gateway/src/agent-config/hermes-source.js";
+
+describe("Hermes agent settings source", () => {
+  it("normalizes the dashboard inventory into the shared provider contract", () => {
+    const snapshot = normalizeHermesRuntimeSnapshot({
+      status: {
+        version: "1.0.0",
+        gateway_running: true,
+      },
+      options: {
+        provider: "nous",
+        model: "hermes-4-405b",
+        providers: [{
+          slug: "nous",
+          name: "Nous Portal",
+          authenticated: true,
+          auth_type: "oauth",
+          models: ["hermes-4-405b", "hermes-3-llama-3.1-405b"],
+        }],
+      },
+    });
+
+    expect(snapshot.runtime.options[0]).toMatchObject({
+      id: "hermes",
+      installState: "installed",
+      health: "healthy",
+      selectionState: "active",
+      configured: true,
+      version: "1.0.0",
+    });
+    expect(snapshot.providers).toHaveLength(1);
+    expect(AgentProviderDescriptorSchema.safeParse(snapshot.providers[0]).success)
+      .toBe(true);
+    expect(snapshot.providers[0]).toMatchObject({
+      id: "nous",
+      displayName: "Nous Portal",
+      runtime: "hermes",
+      scopes: ["messaging"],
+      authKind: "oauth_login",
+      authStatus: { state: "ready", authenticated: true, action: "none" },
+    });
+    expect(snapshot.providers[0]?.models.map((model) => model.id)).toEqual([
+      "hermes-4-405b",
+      "hermes-3-llama-3.1-405b",
+    ]);
+    expect(snapshot.messaging).toEqual({
+      runtime: "hermes",
+      provider: "nous",
+      model: "hermes-4-405b",
+      configured: true,
+    });
+  });
+
+  it("loads status and curated model options with the caller's abort signal", async () => {
+    const readJson = vi.fn(async (path: string, _signal: AbortSignal) => {
+      if (path === "/api/status") {
+        return { gateway_running: true };
+      }
+      return {
+        provider: "nous",
+        model: "hermes-4-405b",
+        providers: [{
+          slug: "nous",
+          authenticated: true,
+          auth_type: "oauth",
+          models: ["hermes-4-405b"],
+        }],
+      };
+    });
+    const source = createHermesRuntimeSource(readJson);
+    const signal = new AbortController().signal;
+
+    const snapshot = await source(signal);
+
+    expect(snapshot.messaging.configured).toBe(true);
+    expect(readJson).toHaveBeenNthCalledWith(1, "/api/status", signal);
+    expect(readJson).toHaveBeenNthCalledWith(2, "/api/model/options", signal);
+  });
+
+  it("orders selected and ready catalog entries deterministically", () => {
+    const snapshot = normalizeHermesRuntimeSnapshot({
+      status: { gateway_running: true },
+      options: {
+        provider: "nous",
+        model: "selected-model",
+        providers: [
+          {
+            slug: "zulu",
+            authenticated: false,
+            auth_type: "api_key",
+            models: ["z-model"],
+          },
+          {
+            slug: "nous",
+            authenticated: true,
+            auth_type: "oauth",
+            models: ["z-model", "selected-model", "a-model"],
+          },
+          {
+            slug: "alpha",
+            authenticated: true,
+            auth_type: "api_key",
+            models: ["model"],
+          },
+        ],
+      },
+    });
+
+    expect(snapshot.providers.map((provider) => provider.id)).toEqual([
+      "nous",
+      "alpha",
+      "zulu",
+    ]);
+    expect(snapshot.providers[0]?.models.map((model) => model.id)).toEqual([
+      "selected-model",
+      "a-model",
+      "z-model",
+    ]);
+  });
+
+  it("coalesces concurrent reads and reuses a five-second snapshot", async () => {
+    let now = 1_000;
+    const readJson = vi.fn(async (path: string) => {
+      await Promise.resolve();
+      return path === "/api/status"
+        ? { gateway_running: true }
+        : { provider: "", model: "", providers: [] };
+    });
+    const source = createHermesRuntimeSource(readJson, {
+      cacheTtlMs: 5_000,
+      now: () => now,
+    });
+    const signal = new AbortController().signal;
+
+    await Promise.all([source(signal), source(signal), source(signal)]);
+    await source(signal);
+    expect(readJson).toHaveBeenCalledTimes(2);
+
+    now += 5_001;
+    await source(signal);
+    expect(readJson).toHaveBeenCalledTimes(4);
+  });
+
+  it("negative-caches an unreachable runtime without logging raw errors", async () => {
+    const canary = "sk-secret-upstream-canary";
+    const readJson = vi.fn(async () => {
+      throw new Error(canary);
+    });
+    const logWarning = vi.fn();
+    const source = createHermesRuntimeSource(readJson, { logWarning });
+    const signal = new AbortController().signal;
+
+    const snapshots = await Promise.all([
+      source(signal),
+      source(signal),
+      source(signal),
+    ]);
+    await source(signal);
+
+    expect(snapshots.map((snapshot) => snapshot.runtime.options[0]?.health))
+      .toEqual(["unreachable", "unreachable", "unreachable"]);
+    expect(readJson).toHaveBeenCalledTimes(2);
+    expect(logWarning).toHaveBeenCalledOnce();
+    expect(logWarning).toHaveBeenCalledWith("Error");
+    expect(JSON.stringify(logWarning.mock.calls)).not.toContain(canary);
+  });
+});

--- a/tests/gateway/agent-config-service.test.ts
+++ b/tests/gateway/agent-config-service.test.ts
@@ -1,0 +1,43 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it, vi } from "vitest";
+import {
+  hasClaudeLogin,
+  readRuntimeSnapshot,
+} from "../../packages/gateway/src/agent-config/service.js";
+
+describe("agent runtime settings probe", () => {
+  it("aborts a runtime source that exceeds its deadline", async () => {
+    let observedSignal: AbortSignal | undefined;
+    const result = readRuntimeSnapshot(async (signal) => {
+      observedSignal = signal;
+      await new Promise((resolve) => setTimeout(resolve, 25));
+      throw new Error("source completed after its deadline");
+    }, 5);
+
+    await expect(result).rejects.toThrow("Runtime settings probe timed out");
+    expect(observedSignal?.aborted).toBe(true);
+  });
+
+  it("does not log raw owner login parse failures", async () => {
+    const homePath = await mkdtemp(join(tmpdir(), "agent-login-status-"));
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      await writeFile(
+        join(homePath, ".claude.json"),
+        '{"oauthAccount":"owner-secret-canary"',
+      );
+
+      await expect(hasClaudeLogin(homePath)).resolves.toBe(false);
+      expect(warn).toHaveBeenCalledWith(
+        "[agent-config] Failed to read owner login status:",
+        "SyntaxError",
+      );
+      expect(JSON.stringify(warn.mock.calls)).not.toContain("owner-secret-canary");
+    } finally {
+      warn.mockRestore();
+      await rm(homePath, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/gateway/agent-settings-hermes-integration.test.ts
+++ b/tests/gateway/agent-settings-hermes-integration.test.ts
@@ -1,0 +1,78 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { AgentSettingsViewSchema } from "@matrix-os/contracts";
+import { Hono } from "hono";
+import {
+  createHermesDashboardClient,
+} from "../../packages/gateway/src/agent-config/hermes-client.js";
+import {
+  createHermesRuntimeSource,
+} from "../../packages/gateway/src/agent-config/hermes-source.js";
+import { createSettingsRoutes } from "../../packages/gateway/src/routes/settings.js";
+
+describe("unified agent settings Hermes integration", () => {
+  const cleanupPaths: string[] = [];
+
+  afterEach(() => {
+    for (const path of cleanupPaths.splice(0)) {
+      rmSync(path, { recursive: true, force: true });
+    }
+  });
+
+  it("renders the live loopback inventory through the public settings route", async () => {
+    const homePath = mkdtempSync(join(tmpdir(), "agent-settings-hermes-"));
+    cleanupPaths.push(homePath);
+    mkdirSync(join(homePath, "system"), { recursive: true });
+    writeFileSync(join(homePath, "system/config.json"), "{}");
+    const fetchImpl = vi.fn(async (url: string | URL | Request) => {
+      const path = new URL(String(url)).pathname;
+      if (path === "/api/status") {
+        return Response.json({ version: "1.0.0", gateway_running: true });
+      }
+      return Response.json({
+        provider: "nous",
+        model: "hermes-4-405b",
+        providers: [{
+          slug: "nous",
+          name: "Nous Portal",
+          authenticated: true,
+          auth_type: "oauth",
+          models: ["hermes-4-405b"],
+        }],
+      });
+    });
+    const hermesClient = createHermesDashboardClient({
+      baseUrl: "http://127.0.0.1:9119",
+      fetchImpl,
+    });
+    const routes = createSettingsRoutes({
+      homePath,
+      channelManager: {
+        status: () => ({}),
+        start: async () => {},
+        stop: async () => {},
+        send: () => {},
+        replay: async () => {},
+        restartChannel: async () => {},
+      } as never,
+      agentRuntimeSource: createHermesRuntimeSource(hermesClient.readJson),
+    });
+    const app = new Hono();
+    app.route("/api/settings", routes);
+
+    const response = await app.request("/api/settings/agent");
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(AgentSettingsViewSchema.safeParse(body).success).toBe(true);
+    expect(body.currentSelection.messaging).toEqual({
+      runtime: "hermes",
+      provider: "nous",
+      model: "hermes-4-405b",
+      configured: true,
+    });
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+  });
+});

--- a/tests/gateway/hermes-client.test.ts
+++ b/tests/gateway/hermes-client.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  createHermesDashboardClient,
+} from "../../packages/gateway/src/agent-config/hermes-client.js";
+
+describe("Hermes dashboard client", () => {
+  it("forwards the caller signal and rejects oversized JSON responses", async () => {
+    const fetchImpl = vi.fn(async () => new Response(
+      JSON.stringify({ payload: "x".repeat(1024 * 1024) }),
+      { headers: { "content-type": "application/json" } },
+    ));
+    const client = createHermesDashboardClient({
+      baseUrl: "http://127.0.0.1:9119",
+      fetchImpl,
+    });
+    const signal = new AbortController().signal;
+
+    await expect(client.readJson("/api/status", signal)).rejects.toMatchObject({
+      name: "HermesResponseTooLargeError",
+    });
+    expect(fetchImpl).toHaveBeenCalledWith(
+      "http://127.0.0.1:9119/api/status",
+      expect.objectContaining({ signal, redirect: "error" }),
+    );
+  });
+});

--- a/tests/gateway/hermes-proxy.test.ts
+++ b/tests/gateway/hermes-proxy.test.ts
@@ -599,8 +599,20 @@ describe("SSRF guard: HERMES_DASHBOARD_URL validation", () => {
     );
     // External host — should throw
     expect(() => validateHermesDashboardUrl("http://example.com:9119")).toThrow();
-    expect(() => validateHermesDashboardUrl("http://192.168.1.100:9119")).toThrow();
+    expect(() => validateHermesDashboardUrl("http://192.168.1.100:9119"))
+      .toThrow(/192\.168\.1\.100/);
     expect(() => validateHermesDashboardUrl("http://0.0.0.0:9119")).toThrow();
+  });
+
+  it("rejects non-HTTP loopback URL schemes", async () => {
+    const { validateHermesDashboardUrl } = await import(
+      "../../packages/gateway/src/routes/hermes.js"
+    );
+
+    expect(() => validateHermesDashboardUrl("file://127.0.0.1/etc/passwd"))
+      .toThrow(/file:/);
+    expect(() => validateHermesDashboardUrl("ws://127.0.0.1:9119"))
+      .toThrow(/ws:/);
   });
 
   it("accepts loopback addresses", async () => {

--- a/tests/gateway/settings-desktop.test.ts
+++ b/tests/gateway/settings-desktop.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import {
   mkdtempSync,
   mkdirSync,
@@ -10,6 +10,7 @@ import {
 import { join, resolve } from "node:path";
 import { tmpdir } from "node:os";
 import { Hono } from "hono";
+import { AgentSettingsViewSchema } from "@matrix-os/contracts";
 import { createSettingsRoutes } from "../../packages/gateway/src/routes/settings.js";
 
 function stubChannelManager() {
@@ -478,6 +479,161 @@ describe("Settings: desktop + theme + wallpapers", () => {
   });
 
   describe("GET /agent (kernel config)", () => {
+    it("returns one additive v2 view without changing legacy fields", async () => {
+      const res = await app.request("/api/settings/agent");
+      expect(res.status).toBe(200);
+      const data = await res.json();
+
+      expect(data.kernel).toEqual({ model: null, effort: null });
+      expect(data.availableModels.map((model: { id: string }) => model.id))
+        .toEqual([
+          "claude-opus-4-6",
+          "claude-sonnet-4-5",
+          "claude-haiku-4-5",
+        ]);
+      expect(AgentSettingsViewSchema.safeParse(data).success).toBe(true);
+      expect(data.runtime.selected).toBe("hermes");
+      expect(data.runtime.options).toEqual(expect.arrayContaining([
+        expect.objectContaining({ id: "hermes", selectionState: "active" }),
+        expect.objectContaining({ id: "openclaw", installState: "missing" }),
+      ]));
+    });
+
+    it("reports persisted BYOK readiness without returning the key", async () => {
+      const canary = "sk-ant-secret-canary";
+      writeFileSync(
+        join(homePath, "system/config.json"),
+        JSON.stringify({ kernel: { anthropicApiKey: canary } }),
+      );
+
+      const res = await app.request("/api/settings/agent");
+      const data = await res.json();
+
+      expect(data.chat.authKind).toBe("api_key");
+      expect(data.providers[0].authKind).toBe("api_key");
+      expect(data.providers[0].authStatus).toMatchObject({
+        state: "ready",
+        authenticated: true,
+      });
+      expect(JSON.stringify(data)).not.toContain(canary);
+    });
+
+    it("reports an owner-local subscription login when BYOK is absent", async () => {
+      writeFileSync(
+        join(homePath, ".claude.json"),
+        JSON.stringify({ oauthAccount: { accountUuid: "account-123" } }),
+      );
+
+      const res = await app.request("/api/settings/agent");
+      const data = await res.json();
+
+      expect(data.chat.authKind).toBe("oauth_login");
+      expect(data.providers[0]).toMatchObject({
+        authKind: "oauth_login",
+        authStatus: { state: "ready", authenticated: true },
+      });
+    });
+
+    it("merges a normalized messaging runtime snapshot into the same view", async () => {
+      const routes = createSettingsRoutes({
+        homePath,
+        channelManager: stubChannelManager() as any,
+        agentRuntimeSource: async () => ({
+          runtime: {
+            selected: "hermes",
+            options: [
+              {
+                id: "hermes",
+                displayName: "Hermes",
+                installState: "installed",
+                health: "healthy",
+                selectionState: "active",
+                configured: true,
+                capabilities: ["provider_catalog", "model_selection", "authentication"],
+              },
+              {
+                id: "openclaw",
+                displayName: "OpenClaw",
+                installState: "missing",
+                health: "stopped",
+                selectionState: "unavailable",
+                configured: false,
+                capabilities: ["install"],
+                setupAction: "install",
+              },
+            ],
+            transition: null,
+          },
+          providers: [{
+            id: "nous",
+            displayName: "Nous Portal",
+            runtime: "hermes",
+            scopes: ["messaging"],
+            authKind: "oauth_login",
+            supportedAuthKinds: ["oauth_login"],
+            models: [{
+              id: "hermes-4-405b",
+              displayName: "Hermes 4 405B",
+              capabilities: ["tools"],
+              efforts: [],
+              available: true,
+            }],
+            authStatus: { state: "ready", authenticated: true, action: "none" },
+          }],
+          messaging: {
+            runtime: "hermes",
+            provider: "nous",
+            model: "hermes-4-405b",
+            configured: true,
+          },
+        }),
+      });
+      const runtimeApp = new Hono();
+      runtimeApp.route("/api/settings", routes);
+
+      const res = await runtimeApp.request("/api/settings/agent");
+      const data = await res.json();
+
+      expect(AgentSettingsViewSchema.safeParse(data).success).toBe(true);
+      expect(data.providers.map((provider: { id: string }) => provider.id))
+        .toEqual(["anthropic", "nous"]);
+      expect(data.currentSelection.messaging).toEqual({
+        runtime: "hermes",
+        provider: "nous",
+        model: "hermes-4-405b",
+        configured: true,
+      });
+    });
+
+    it("degrades safely without logging a runtime probe's raw error", async () => {
+      const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+      const canary = "sk-secret-runtime-canary";
+      try {
+        const routes = createSettingsRoutes({
+          homePath,
+          channelManager: stubChannelManager() as any,
+          agentRuntimeSource: async () => {
+            throw new Error(`upstream rejected ${canary}`);
+          },
+        });
+        const runtimeApp = new Hono();
+        runtimeApp.route("/api/settings", routes);
+
+        const res = await runtimeApp.request("/api/settings/agent");
+        const body = await res.json();
+
+        expect(res.status).toBe(200);
+        expect(body.runtime.options[0]).toMatchObject({
+          id: "hermes",
+          health: "unknown",
+        });
+        expect(JSON.stringify(body)).not.toContain(canary);
+        expect(JSON.stringify(warn.mock.calls)).not.toContain(canary);
+      } finally {
+        warn.mockRestore();
+      }
+    });
+
     it("returns null model/effort, the model allowlist, and defaults when unset", async () => {
       const res = await app.request("/api/settings/agent");
       expect(res.status).toBe(200);
@@ -572,6 +728,32 @@ describe("Settings: desktop + theme + wallpapers", () => {
         body: JSON.stringify({ model: "claude-opus-4-6", systemPrompt: "pwn" }),
       });
       expect(res.status).toBe(400);
+    });
+
+    it("fails closed when an extended update has no runtime controller", async () => {
+      const res = await app.request("/api/settings/agent", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ runtime: "openclaw", revision: 0 }),
+      });
+
+      expect(res.status).toBe(503);
+      expect(await res.json()).toEqual({ error: "runtime_unavailable" });
+      expect(JSON.parse(readFileSync(join(homePath, "system/config.json"), "utf-8")))
+        .toEqual({});
+    });
+
+    it("rejects agent updates larger than 16 KiB before parsing", async () => {
+      const res = await app.request("/api/settings/agent", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          model: "claude-opus-4-6",
+          padding: "x".repeat(17 * 1024),
+        }),
+      });
+
+      expect(res.status).toBe(413);
     });
   });
 });


### PR DESCRIPTION
## Summary

- grow `GET /api/settings/agent` additively with the shared runtime, provider,
  authentication, and current-selection contract while preserving all legacy
  fields
- normalize the live Hermes dashboard status and curated provider/model
  inventory into that contract
- share one loopback-only HTTP(S) Hermes client with bounded JSON reads,
  redirect rejection, deadlines, fixed path validation, and coarse errors
- coalesce live inventory reads behind a five-second bounded cache and degrade
  unavailable runtimes without breaking Chat
- preserve legacy model/effort updates; fail closed on extended mutations until
  the runtime controller lands in the next stack slice

The inventory shape was verified against the latest official Hermes source and
documentation:

- https://raw.githubusercontent.com/NousResearch/hermes-agent/main/hermes_cli/inventory.py
- https://hermes-agent.nousresearch.com/docs/user-guide/features/web-dashboard

## TDD and validation

- Red/green coverage includes the additive response, credential precedence,
  runtime timeout/fallback, strict request validation, 16 KiB mutation limit,
  Hermes normalization/order/caps, concurrent and negative caching, bounded
  upstream responses, integration wiring, and raw-error/secret suppression.
- Greptile follow-up red/green coverage rejects non-HTTP(S) loopback URLs and
  preserves sanitized protocol/hostname diagnostics for operators.
- Focused agent settings suites: 72/72 passed across 6 files on the feature
  implementation; the review-fix subset passes 70/70 across 4 files.
- `bun run typecheck`: passed after the review fix.
- `bun run check:patterns`: 0 violations, 5 pre-existing warning groups.
- Exact current-main stack-tip repository gate: 785 files passed, 3 skipped;
  8,478 tests passed, 20 skipped.
- `git diff --check`: passed.
- React Doctor: not applicable; this PR has no React changes.

## Stack

- #960 — spec and OpenClaw spike
- #968 — stored conversation transcript
- #972 — per-message kernel selection
- #973 — truthful system-config diagnostics for the active-model resolver
- #974 — shared additive contracts
- this PR — unified gateway inventory

## Invariants

- **Source of truth:** Owner-local `$MATRIX_HOME/system/config.json` remains
  authoritative for Chat model, effort, and BYOK state. The live Hermes
  dashboard remains authoritative for messaging provider/model inventory and
  health. The gateway only normalizes those sources.
- **Lock/transaction scope:** Inventory reads are read-only. The five-second
  cache has one entry and coalesces one in-flight read. Legacy model/effort
  writes retain the existing atomic temp-file rename. Extended mutations do
  not write anything in this slice.
- **Acceptable orphan states:** Hermes may be absent, stopped, malformed, or
  unreachable; the response reports a bounded unavailable state and Chat keeps
  working. OpenClaw remains explicitly missing/unavailable until its adapter
  lands.
- **Auth source of truth:** Existing gateway request authentication remains the
  route boundary. BYOK presence, owner-local Claude login, and inherited
  platform credential availability are projected only as coarse state; no key,
  login payload, provider response, or raw error is returned.
- **Deferred scope:** Runtime switching and rollback, OpenClaw lifecycle,
  provider/model mutations, authentication mutations, web shell, desktop, and
  public docs are subsequent stacked PRs. Until then extended PUT fields return
  `runtime_unavailable` without changing owner configuration.
- `GET/PUT /api/settings/agent` remains backward compatible for shipped desktop
  and mobile clients.
- The mutating route has a 16 KiB Hono body limit and strict shared Zod schema.
- The Hermes probe permits only HTTP(S) loopback URLs, rejects redirects, has a
  two-second inventory deadline and ten-second client fallback, and caps
  response bytes, providers, and models.
- Server startup logs only sanitized parsed protocol/hostname diagnostics for
  invalid Hermes URLs; clients still receive coarse errors only.
- This PR remains below 3,000 additions and 50 files and will not merge below an
  exact-head Greptile 5/5 review.

## Rollout

- no merge or promotion requested
- live preview verification occurs at the backend-stack tip after the runtime
  controller is wired
