### PR TITLE
feat(gateway): orchestrate messaging runtime configuration

### DIFF
--- a/packages/gateway/src/agent-config/base-url-policy.ts
+++ b/packages/gateway/src/agent-config/base-url-policy.ts
@@ -1,0 +1,83 @@
+import { lookup } from "node:dns/promises";
+import { isIP } from "node:net";
+import { AgentConfigError } from "./errors.js";
+
+type ResolvedAddress = { address: string; family: number };
+
+function isPrivateIpv4(address: string): boolean {
+  const parts = address.split(".").map(Number);
+  if (parts.length !== 4 || parts.some((part) => !Number.isInteger(part) || part < 0 || part > 255)) return true;
+  const [a = 0, b = 0] = parts;
+  if (a === 0 || a === 10 || a === 127 || a >= 224) return true;
+  if (a === 100 && b >= 64 && b <= 127) return true;
+  if (a === 169 && b === 254) return true;
+  if (a === 172 && b >= 16 && b <= 31) return true;
+  if (a === 192 && (b === 0 || b === 168)) return true;
+  if (a === 198 && (b === 18 || b === 19)) return true;
+  return false;
+}
+
+function isPrivateIpv6(address: string): boolean {
+  const normalized = address.toLowerCase().split("%", 1)[0] ?? "";
+  if (normalized === "::" || normalized === "::1") return true;
+  if (normalized.startsWith("::ffff:")) {
+    return isPrivateIpv4(normalized.slice("::ffff:".length));
+  }
+  return normalized.startsWith("fc")
+    || normalized.startsWith("fd")
+    || /^fe[89ab]/.test(normalized)
+    || normalized.startsWith("ff")
+    || normalized.startsWith("2001:db8");
+}
+
+function isPublicAddress(address: string): boolean {
+  const family = isIP(address);
+  if (family === 4) return !isPrivateIpv4(address);
+  if (family === 6) return !isPrivateIpv6(address);
+  return false;
+}
+
+export async function validateProviderBaseUrl(
+  value: string,
+  resolveHost: (hostname: string) => Promise<ResolvedAddress[]> = (hostname) =>
+    lookup(hostname, { all: true, verbatim: true }),
+): Promise<void> {
+  let url: URL;
+  try {
+    url = new URL(value);
+  } catch (error) {
+    throw new AgentConfigError("agent_config_invalid", error);
+  }
+  const hostname = url.hostname.toLowerCase();
+  if (url.protocol !== "https:"
+    || url.username !== ""
+    || url.password !== ""
+    || hostname === "localhost"
+    || hostname.endsWith(".localhost")
+    || hostname.endsWith(".local")
+    || hostname.endsWith(".internal")) {
+    throw new AgentConfigError("agent_config_invalid");
+  }
+  if (isIP(hostname) !== 0 && !isPublicAddress(hostname)) {
+    throw new AgentConfigError("agent_config_invalid");
+  }
+
+  const timeout = AbortSignal.timeout(2_000);
+  let addresses: ResolvedAddress[];
+  try {
+    addresses = await Promise.race([
+      resolveHost(hostname),
+      new Promise<never>((_resolve, reject) => {
+        timeout.addEventListener("abort", () => reject(timeout.reason), { once: true });
+      }),
+    ]);
+  } catch (error) {
+    throw new AgentConfigError("agent_config_invalid", error);
+  }
+  if (addresses.length === 0 || addresses.some(({ address }) => !isPublicAddress(address))) {
+    throw new AgentConfigError("agent_config_invalid");
+  }
+  // Hermes resolves and follows the configured URL later, so this preflight
+  // cannot pin DNS or validate runtime redirects. The residual rebinding risk
+  // stays documented until Hermes exposes a pinned-dispatcher policy.
+}

--- a/packages/gateway/src/agent-config/errors.ts
+++ b/packages/gateway/src/agent-config/errors.ts
@@ -1,0 +1,22 @@
+export type AgentConfigErrorKind =
+  | "agent_config_invalid"
+  | "agent_config_conflict"
+  | "runtime_unavailable"
+  | "runtime_switch_failed"
+  | "not_configured"
+  | "invalid_response";
+
+export class AgentConfigError extends Error {
+  constructor(
+    readonly kind: AgentConfigErrorKind,
+    cause?: unknown,
+  ) {
+    super(kind);
+    this.name = "AgentConfigError";
+    if (cause !== undefined) this.cause = cause;
+  }
+}
+
+export function isAgentConfigError(error: unknown): error is AgentConfigError {
+  return error instanceof AgentConfigError;
+}

--- a/packages/gateway/src/agent-config/hermes-adapter.ts
+++ b/packages/gateway/src/agent-config/hermes-adapter.ts
@@ -1,0 +1,105 @@
+import {
+  AgentMessagingSelectionSchema,
+  AgentProviderCatalogSchema,
+  AgentRuntimeDescriptorSchema,
+  type AgentMessagingSelection,
+} from "@matrix-os/contracts";
+import { z } from "zod/v4";
+import { AgentConfigError } from "./errors.js";
+import type {
+  MessagingRuntimeAdapter,
+  RuntimeConfigureInput,
+} from "./runtime-controller.js";
+import type { AgentRuntimeSource } from "./service.js";
+
+type HermesJsonRequester = (
+  path: string,
+  init: Omit<RequestInit, "signal" | "redirect">,
+  signal: AbortSignal,
+) => Promise<unknown>;
+
+const HermesMutationResponseSchema = z.record(z.string(), z.unknown());
+
+export function createHermesRuntimeAdapter(options: {
+  source: AgentRuntimeSource;
+  requestJson: HermesJsonRequester;
+  activate?: (signal: AbortSignal) => Promise<void>;
+  deactivate?: (signal: AbortSignal) => Promise<void>;
+}): MessagingRuntimeAdapter {
+  async function snapshot(signal: AbortSignal) {
+    return options.source(signal);
+  }
+
+  async function configure(
+    input: RuntimeConfigureInput,
+    signal: AbortSignal,
+  ): Promise<AgentMessagingSelection> {
+    const current = await snapshot(signal);
+    const providers = AgentProviderCatalogSchema.parse(current.providers);
+    const provider = providers.find((entry) =>
+      entry.runtime === "hermes"
+      && entry.id === input.provider
+      && entry.scopes.includes("messaging")
+    );
+    if (!provider?.models.some((model) =>
+      model.id === input.model && model.available
+    )) {
+      throw new AgentConfigError("not_configured");
+    }
+    if (input.baseUrl !== undefined
+      && !provider.supportedAuthKinds.includes("base_url")) {
+      throw new AgentConfigError("not_configured");
+    }
+    const body = {
+      scope: "main",
+      provider: input.provider,
+      model: input.model,
+      ...(input.baseUrl === undefined ? {} : { base_url: input.baseUrl }),
+    };
+    const response = await options.requestJson("/api/model/set", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(body),
+    }, signal);
+    const parsed = HermesMutationResponseSchema.safeParse(response);
+    if (!parsed.success) throw new AgentConfigError("invalid_response", parsed.error);
+    options.source.invalidate?.();
+    const updated = await snapshot(signal);
+    const selection = AgentMessagingSelectionSchema.parse(updated.messaging);
+    if (!selection.configured
+      || selection.provider !== input.provider
+      || selection.model !== input.model) {
+      throw new AgentConfigError("invalid_response");
+    }
+    return selection;
+  }
+
+  return {
+    id: "hermes",
+    async probe(signal) {
+      const current = await snapshot(signal);
+      const descriptor = current.runtime.options.find((entry) => entry.id === "hermes");
+      if (!descriptor) throw new AgentConfigError("invalid_response");
+      return AgentRuntimeDescriptorSchema.parse(descriptor);
+    },
+    async catalog(signal) {
+      return AgentProviderCatalogSchema.parse((await snapshot(signal)).providers);
+    },
+    async selection(signal) {
+      return AgentMessagingSelectionSchema.parse((await snapshot(signal)).messaging);
+    },
+    configure,
+    async prepare(signal) {
+      const descriptor = await this.probe(signal);
+      if (descriptor.installState !== "installed") {
+        throw new AgentConfigError("runtime_unavailable");
+      }
+    },
+    activate: options.activate ?? (async () => {}),
+    deactivate: options.deactivate ?? (async () => {}),
+    async dashboard() {
+      return null;
+    },
+    async close() {},
+  };
+}

--- a/packages/gateway/src/agent-config/hermes-adapter.ts
+++ b/packages/gateway/src/agent-config/hermes-adapter.ts
@@ -35,6 +35,7 @@ export function createHermesRuntimeAdapter(options: {
     signal: AbortSignal,
   ): Promise<AgentMessagingSelection> {
     const current = await snapshot(signal);
+    const previousSelection = AgentMessagingSelectionSchema.parse(current.messaging);
     const providers = AgentProviderCatalogSchema.parse(current.providers);
     const provider = providers.find((entry) =>
       entry.runtime === "hermes"
@@ -61,17 +62,43 @@ export function createHermesRuntimeAdapter(options: {
       headers: { "content-type": "application/json" },
       body: JSON.stringify(body),
     }, signal);
-    const parsed = HermesMutationResponseSchema.safeParse(response);
-    if (!parsed.success) throw new AgentConfigError("invalid_response", parsed.error);
-    options.source.invalidate?.();
-    const updated = await snapshot(signal);
-    const selection = AgentMessagingSelectionSchema.parse(updated.messaging);
-    if (!selection.configured
-      || selection.provider !== input.provider
-      || selection.model !== input.model) {
-      throw new AgentConfigError("invalid_response");
+    try {
+      const parsed = HermesMutationResponseSchema.safeParse(response);
+      if (!parsed.success) throw new AgentConfigError("invalid_response", parsed.error);
+      options.source.invalidate?.();
+      const updated = await snapshot(signal);
+      const selection = AgentMessagingSelectionSchema.parse(updated.messaging);
+      if (!selection.configured
+        || selection.provider !== input.provider
+        || selection.model !== input.model) {
+        throw new AgentConfigError("invalid_response");
+      }
+      return selection;
+    } catch (error) {
+      if (previousSelection.configured
+        && previousSelection.provider !== null
+        && previousSelection.model !== null) {
+        const rollbackSignal = AbortSignal.timeout(2_000);
+        await options.requestJson("/api/model/set", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({
+            scope: "main",
+            provider: previousSelection.provider,
+            model: previousSelection.model,
+          }),
+        }, rollbackSignal).then(() => {
+          options.source.invalidate?.();
+        }).catch((rollbackError: unknown) => {
+          console.warn(
+            "[agent-config] Hermes selection restore failed:",
+            rollbackError instanceof Error ? rollbackError.name : "UnknownError",
+          );
+        });
+      }
+      if (error instanceof AgentConfigError) throw error;
+      throw new AgentConfigError("invalid_response", error);
     }
-    return selection;
   }
 
   return {

--- a/packages/gateway/src/agent-config/hermes-adapter.ts
+++ b/packages/gateway/src/agent-config/hermes-adapter.ts
@@ -6,6 +6,7 @@ import {
 } from "@matrix-os/contracts";
 import { z } from "zod/v4";
 import { AgentConfigError } from "./errors.js";
+import { validateProviderBaseUrl } from "./base-url-policy.js";
 import type {
   MessagingRuntimeAdapter,
   RuntimeConfigureInput,
@@ -25,6 +26,7 @@ export function createHermesRuntimeAdapter(options: {
   requestJson: HermesJsonRequester;
   activate?: (signal: AbortSignal) => Promise<void>;
   deactivate?: (signal: AbortSignal) => Promise<void>;
+  validateBaseUrl?: (value: string) => Promise<void>;
 }): MessagingRuntimeAdapter {
   async function snapshot(signal: AbortSignal) {
     return options.source(signal);
@@ -50,6 +52,9 @@ export function createHermesRuntimeAdapter(options: {
     if (input.baseUrl !== undefined
       && !provider.supportedAuthKinds.includes("base_url")) {
       throw new AgentConfigError("not_configured");
+    }
+    if (input.baseUrl !== undefined) {
+      await (options.validateBaseUrl ?? validateProviderBaseUrl)(input.baseUrl);
     }
     const body = {
       scope: "main",

--- a/packages/gateway/src/agent-config/hermes-client.ts
+++ b/packages/gateway/src/agent-config/hermes-client.ts
@@ -134,8 +134,12 @@ export function createHermesDashboardClient(options: {
     }
   }
 
-  async function readJson(path: string, signal: AbortSignal): Promise<unknown> {
-    const response = await fetchPath(path, { signal });
+  async function requestJson(
+    path: string,
+    init: Omit<RequestInit, "signal" | "redirect">,
+    signal: AbortSignal,
+  ): Promise<unknown> {
+    const response = await fetchPath(path, { ...init, signal });
     if (!response.ok) throw new HermesUpstreamResponseError();
     const body = await readBoundedBody(response);
     try {
@@ -145,7 +149,11 @@ export function createHermesDashboardClient(options: {
     }
   }
 
-  return { fetch: fetchPath, readJson };
+  async function readJson(path: string, signal: AbortSignal): Promise<unknown> {
+    return requestJson(path, { method: "GET" }, signal);
+  }
+
+  return { fetch: fetchPath, readJson, requestJson };
 }
 
 export type HermesDashboardClient = ReturnType<typeof createHermesDashboardClient>;

--- a/packages/gateway/src/agent-config/hermes-source.ts
+++ b/packages/gateway/src/agent-config/hermes-source.ts
@@ -4,7 +4,10 @@ import {
   type AgentProviderDescriptor,
 } from "@matrix-os/contracts";
 import { z } from "zod/v4";
-import type { AgentRuntimeSettingsSnapshot } from "./service.js";
+import type {
+  AgentRuntimeSettingsSnapshot,
+  AgentRuntimeSource,
+} from "./service.js";
 
 export type HermesJsonReader = (
   path: string,
@@ -241,13 +244,18 @@ export function createHermesRuntimeSource(
     console.warn("[agent-config] Hermes settings probe failed:", errorName);
   });
   let cached: { value: AgentRuntimeSettingsSnapshot; expiresAt: number } | null = null;
-  let inFlight: Promise<AgentRuntimeSettingsSnapshot> | null = null;
+  let generation = 0;
+  let inFlight: {
+    generation: number;
+    promise: Promise<AgentRuntimeSettingsSnapshot>;
+  } | null = null;
 
-  return async (signal: AbortSignal): Promise<AgentRuntimeSettingsSnapshot> => {
+  const source: AgentRuntimeSource = async (signal) => {
     signal.throwIfAborted();
     if (cached !== null && cached.expiresAt > now()) return cached.value;
-    if (inFlight === null) {
-      inFlight = Promise.all([
+    if (inFlight === null || inFlight.generation !== generation) {
+      const requestGeneration = generation;
+      const promise = Promise.all([
         readJson("/api/status", signal),
         readJson("/api/model/options", signal),
       ]).then(([status, modelOptions]) => {
@@ -259,14 +267,22 @@ export function createHermesRuntimeSource(
         logWarning(err instanceof Error ? err.name : "UnknownError");
         return unavailableHermesRuntimeSnapshot();
       }).then((value) => {
-        cached = { value, expiresAt: now() + cacheTtlMs };
+        if (requestGeneration === generation) {
+          cached = { value, expiresAt: now() + cacheTtlMs };
+        }
         return value;
       }).finally(() => {
-        inFlight = null;
+        if (inFlight?.generation === requestGeneration) inFlight = null;
       });
+      inFlight = { generation: requestGeneration, promise };
     }
-    return inFlight;
+    return inFlight.promise;
   };
+  source.invalidate = () => {
+    generation += 1;
+    cached = null;
+  };
+  return source;
 }
 
 function unavailableHermesRuntimeSnapshot(): AgentRuntimeSettingsSnapshot {

--- a/packages/gateway/src/agent-config/runtime-controller.ts
+++ b/packages/gateway/src/agent-config/runtime-controller.ts
@@ -79,7 +79,7 @@ export function createAgentRuntimeController(
   const lockPath = join(runtimeDir, "transition.lock");
   const transitionPath = join(runtimeDir, "transition.json");
   const timeoutMs = options.timeoutMs ?? 10_000;
-  if (!Number.isFinite(timeoutMs) || timeoutMs < 100 || timeoutMs > 30_000) {
+  if (!Number.isFinite(timeoutMs) || timeoutMs < 100 || timeoutMs > 90_000) {
     throw new RangeError("Invalid runtime transition timeout");
   }
   const now = options.now ?? (() => new Date());
@@ -242,7 +242,7 @@ export function createAgentRuntimeController(
         deliveryPaused = false;
         return { revision: nextRevision, runtime: targetRuntime, selection };
       } catch (error) {
-        const rollbackSignal = AbortSignal.timeout(2_000);
+        const rollbackSignal = AbortSignal.timeout(Math.min(timeoutMs, 70_000));
         if (targetConfigured
           && previousTargetSelection?.configured
           && previousTargetSelection.provider !== null

--- a/packages/gateway/src/agent-config/runtime-controller.ts
+++ b/packages/gateway/src/agent-config/runtime-controller.ts
@@ -160,10 +160,11 @@ export function createAgentRuntimeController(
             && previousSelection.model !== null
             && (previousSelection.provider !== selection.provider
               || previousSelection.model !== selection.model)) {
+            const rollbackSignal = AbortSignal.timeout(2_000);
             await targetAdapter.configure({
               provider: previousSelection.provider,
               model: previousSelection.model,
-            }, deadline.signal).catch((error: unknown) => {
+            }, rollbackSignal).catch((error: unknown) => {
               logBestEffortFailure("Provider selection restore failed", error);
             });
           }

--- a/packages/gateway/src/agent-config/runtime-controller.ts
+++ b/packages/gateway/src/agent-config/runtime-controller.ts
@@ -452,10 +452,14 @@ export function createAgentRuntimeController(
       }
       if (transitionStat?.isFile()) {
         await unlink(transitionPath).catch((error: unknown) => {
-          if (!isErrno(error, "ENOENT")) throw error;
+          if (!isErrno(error, "ENOENT")) {
+            logBestEffortFailure("Transition marker cleanup failed", error);
+          }
         });
       }
-      await releaseLock();
+      await releaseLock().catch((error: unknown) => {
+        logBestEffortFailure("Runtime reconciliation lock release failed", error);
+      });
     }
   }
 

--- a/packages/gateway/src/agent-config/runtime-controller.ts
+++ b/packages/gateway/src/agent-config/runtime-controller.ts
@@ -1,48 +1,27 @@
 import {
   AgentRuntimeDescriptorSchema,
   type AgentMessagingSelection,
-  type AgentProviderDescriptor,
-  type AgentRuntimeDescriptor,
   type AgentRuntimeId,
   type AgentSettingsUpdate,
 } from "@matrix-os/contracts";
-import {
-  mkdir,
-  lstat,
-  open,
-  readFile,
-  rename,
-  unlink,
-  type FileHandle,
-} from "node:fs/promises";
-import { constants as fsConstants } from "node:fs";
+import { lstat, mkdir, unlink } from "node:fs/promises";
 import { randomUUID } from "node:crypto";
-import { dirname, join } from "node:path";
-import { z } from "zod/v4";
+import { join } from "node:path";
 import { AgentConfigError, isAgentConfigError } from "./errors.js";
-
-export interface RuntimeConfigureInput {
-  provider: string;
-  model: string;
-  baseUrl?: string;
-  expectedConfigRevision?: string;
-}
-
-export interface MessagingRuntimeAdapter {
-  readonly id: AgentRuntimeId;
-  probe(signal: AbortSignal): Promise<AgentRuntimeDescriptor>;
-  catalog(signal: AbortSignal): Promise<AgentProviderDescriptor[]>;
-  selection(signal: AbortSignal): Promise<AgentMessagingSelection>;
-  configure(
-    input: RuntimeConfigureInput,
-    signal: AbortSignal,
-  ): Promise<AgentMessagingSelection>;
-  prepare(signal: AbortSignal): Promise<void>;
-  activate(signal: AbortSignal): Promise<void>;
-  deactivate(signal: AbortSignal): Promise<void>;
-  dashboard(signal: AbortSignal): Promise<Record<string, unknown> | null>;
-  close(): Promise<void>;
-}
+import {
+  ConfigRecordSchema,
+  TransitionStateSchema,
+  acquireLock,
+  isErrno,
+  logBestEffortFailure,
+  readAgentConfig,
+  readConfig,
+  validateStartupTransitionMarker,
+  writeJsonAtomic,
+  type TransitionState,
+} from "./runtime-files.js";
+import type { MessagingRuntimeAdapter } from "./runtime-types.js";
+export type { MessagingRuntimeAdapter, RuntimeConfigureInput } from "./runtime-types.js";
 
 interface AgentRuntimeControllerOptions {
   homePath: string;
@@ -75,111 +54,6 @@ export interface AgentRuntimeController {
   ): Promise<AgentKernelPatchResult>;
   reconcile(): Promise<void>;
   close(): Promise<void>;
-}
-
-const PersistedAgentSchema = z.object({
-  messagingRuntime: z.enum(["hermes", "openclaw"]).optional(),
-  revision: z.number().int().min(0).optional(),
-  updatedAt: z.iso.datetime().optional(),
-}).passthrough();
-
-const ConfigRecordSchema = z.record(z.string(), z.unknown());
-const MAX_TRANSITION_MARKER_BYTES = 8 * 1024;
-
-const TransitionStateSchema = z.object({
-  id: z.uuid(),
-  from: z.enum(["hermes", "openclaw"]),
-  to: z.enum(["hermes", "openclaw"]),
-  state: z.enum([
-    "validating",
-    "pausing",
-    "draining",
-    "activating",
-    "verifying",
-    "committing",
-    "rolling_back",
-  ]),
-  startedAt: z.iso.datetime(),
-  deadlineAt: z.iso.datetime(),
-}).strict();
-
-type TransitionState = z.infer<typeof TransitionStateSchema>;
-
-function isErrno(error: unknown, code: string): boolean {
-  return error instanceof Error
-    && (error as NodeJS.ErrnoException).code === code;
-}
-
-function logBestEffortFailure(label: string, error: unknown): void {
-  console.warn(
-    `[agent-config] ${label}:`,
-    error instanceof Error ? error.name : "UnknownError",
-  );
-}
-
-async function readConfig(path: string): Promise<Record<string, unknown>> {
-  let raw: string;
-  try {
-    raw = await readFile(path, "utf8");
-  } catch (error) {
-    if (isErrno(error, "ENOENT")) return {};
-    throw new AgentConfigError("agent_config_invalid", error);
-  }
-  try {
-    return ConfigRecordSchema.parse(JSON.parse(raw));
-  } catch (error) {
-    throw new AgentConfigError("agent_config_invalid", error);
-  }
-}
-
-async function writeJsonAtomic(path: string, value: unknown): Promise<void> {
-  await mkdir(dirname(path), { recursive: true, mode: 0o700 });
-  const tempPath = join(dirname(path), `.${randomUUID()}.tmp`);
-  let file: FileHandle | undefined;
-  try {
-    file = await open(tempPath, "wx", 0o600);
-    await file.writeFile(`${JSON.stringify(value, null, 2)}\n`, "utf8");
-    await file.sync();
-    await file.close();
-    file = undefined;
-    await rename(tempPath, path);
-  } finally {
-    await file?.close().catch((error: unknown) => {
-      logBestEffortFailure("Temporary config file close failed", error);
-    });
-    await unlink(tempPath).catch((error: unknown) => {
-      if (!isErrno(error, "ENOENT")) throw error;
-    });
-  }
-}
-
-async function acquireLock(lockPath: string): Promise<() => Promise<void>> {
-  await mkdir(dirname(lockPath), { recursive: true, mode: 0o700 });
-  let file: FileHandle;
-  try {
-    file = await open(lockPath, "wx", 0o600);
-  } catch (error) {
-    if (isErrno(error, "EEXIST")) {
-      throw new AgentConfigError("agent_config_conflict");
-    }
-    throw new AgentConfigError("runtime_switch_failed", error);
-  }
-  return async () => {
-    await file.close();
-    await unlink(lockPath).catch((error: unknown) => {
-      if (!isErrno(error, "ENOENT")) throw error;
-    });
-  };
-}
-
-function readAgentConfig(config: Record<string, unknown>) {
-  if (config.agent === undefined) return { value: {}, stored: {} };
-  const parsed = PersistedAgentSchema.safeParse(config.agent);
-  if (!parsed.success) throw new AgentConfigError("agent_config_invalid", parsed.error);
-  return {
-    value: parsed.data,
-    stored: { ...(config.agent as Record<string, unknown>) },
-  };
 }
 
 function deadlineSignal(timeoutMs: number) {
@@ -480,61 +354,7 @@ export function createAgentRuntimeController(
     return pending;
   }
 
-  async function validateStartupTransitionMarker(): Promise<void> {
-    let markerStat;
-    try {
-      markerStat = await lstat(transitionPath);
-    } catch (error) {
-      if (isErrno(error, "ENOENT")) return;
-      console.warn(
-        "[agent-config] Runtime transition marker check failed:",
-        error instanceof Error ? error.name : "UnknownError",
-      );
-      return;
-    }
-    if (markerStat.isSymbolicLink() || !markerStat.isFile()) {
-      console.warn("[agent-config] Ignoring untrusted runtime transition marker");
-      return;
-    }
-    if (markerStat.size > MAX_TRANSITION_MARKER_BYTES) {
-      console.warn(
-        "[agent-config] Ignoring invalid runtime transition marker:",
-        "ResourceLimitError",
-      );
-      return;
-    }
-
-    let file: FileHandle | undefined;
-    try {
-      file = await open(
-        transitionPath,
-        fsConstants.O_RDONLY | fsConstants.O_NOFOLLOW,
-      );
-      const openedStat = await file.stat();
-      if (!openedStat.isFile() || openedStat.size > MAX_TRANSITION_MARKER_BYTES) {
-        throw new RangeError("Invalid transition marker size");
-      }
-      const buffer = Buffer.alloc(MAX_TRANSITION_MARKER_BYTES + 1);
-      const { bytesRead } = await file.read(buffer, 0, buffer.length, 0);
-      if (bytesRead > MAX_TRANSITION_MARKER_BYTES) {
-        throw new RangeError("Invalid transition marker size");
-      }
-      TransitionStateSchema.parse(JSON.parse(
-        buffer.subarray(0, bytesRead).toString("utf8"),
-      ));
-    } catch (error) {
-      console.warn(
-        "[agent-config] Ignoring invalid runtime transition marker:",
-        error instanceof Error ? error.name : "UnknownError",
-      );
-    } finally {
-      await file?.close().catch((error: unknown) => {
-        logBestEffortFailure("Transition marker close failed", error);
-      });
-    }
-  }
-
-  async function reconcile(): Promise<void> {
+  async function performReconcile(): Promise<void> {
     if (closed) return;
     await mkdir(runtimeDir, { recursive: true, mode: 0o700 });
     let staleLock;
@@ -566,7 +386,7 @@ export function createAgentRuntimeController(
     const releaseLock = await acquireLock(lockPath);
     const probeDeadline = deadlineSignal(Math.min(timeoutMs, 2_000));
     try {
-      await validateStartupTransitionMarker();
+      await validateStartupTransitionMarker(transitionPath);
       const config = await readConfig(configPath);
       const agent = readAgentConfig(config);
       const selected = agent.value.messagingRuntime ?? "hermes";
@@ -635,6 +455,20 @@ export function createAgentRuntimeController(
       }
       await releaseLock();
     }
+  }
+
+  function reconcile(): Promise<void> {
+    if (closed) return Promise.resolve();
+    if (activeOperation !== null) {
+      return Promise.reject(new AgentConfigError("agent_config_conflict"));
+    }
+    const pending = performReconcile();
+    activeOperation = pending;
+    const clearPending = () => {
+      if (activeOperation === pending) activeOperation = null;
+    };
+    void pending.then(clearPending, clearPending);
+    return pending;
   }
 
   return {

--- a/packages/gateway/src/agent-config/runtime-controller.ts
+++ b/packages/gateway/src/agent-config/runtime-controller.ts
@@ -1,0 +1,659 @@
+import {
+  AgentRuntimeDescriptorSchema,
+  type AgentMessagingSelection,
+  type AgentProviderDescriptor,
+  type AgentRuntimeDescriptor,
+  type AgentRuntimeId,
+  type AgentSettingsUpdate,
+} from "@matrix-os/contracts";
+import {
+  mkdir,
+  lstat,
+  open,
+  readFile,
+  rename,
+  unlink,
+  type FileHandle,
+} from "node:fs/promises";
+import { constants as fsConstants } from "node:fs";
+import { randomUUID } from "node:crypto";
+import { dirname, join } from "node:path";
+import { z } from "zod/v4";
+import { AgentConfigError, isAgentConfigError } from "./errors.js";
+
+export interface RuntimeConfigureInput {
+  provider: string;
+  model: string;
+  baseUrl?: string;
+  expectedConfigRevision?: string;
+}
+
+export interface MessagingRuntimeAdapter {
+  readonly id: AgentRuntimeId;
+  probe(signal: AbortSignal): Promise<AgentRuntimeDescriptor>;
+  catalog(signal: AbortSignal): Promise<AgentProviderDescriptor[]>;
+  selection(signal: AbortSignal): Promise<AgentMessagingSelection>;
+  configure(
+    input: RuntimeConfigureInput,
+    signal: AbortSignal,
+  ): Promise<AgentMessagingSelection>;
+  prepare(signal: AbortSignal): Promise<void>;
+  activate(signal: AbortSignal): Promise<void>;
+  deactivate(signal: AbortSignal): Promise<void>;
+  dashboard(signal: AbortSignal): Promise<Record<string, unknown> | null>;
+  close(): Promise<void>;
+}
+
+interface AgentRuntimeControllerOptions {
+  homePath: string;
+  adapters: Partial<Record<AgentRuntimeId, MessagingRuntimeAdapter>>;
+  pauseDelivery?: (signal: AbortSignal) => Promise<void>;
+  drainDelivery?: (signal: AbortSignal) => Promise<void>;
+  resumeDelivery?: (
+    runtime: AgentRuntimeId,
+    signal: AbortSignal,
+  ) => Promise<void>;
+  timeoutMs?: number;
+  now?: () => Date;
+}
+
+export interface AgentRuntimeUpdateResult {
+  revision: number;
+  runtime: AgentRuntimeId;
+  selection: AgentMessagingSelection;
+}
+
+export interface AgentKernelPatchResult {
+  model: unknown;
+  effort: unknown;
+}
+
+export interface AgentRuntimeController {
+  update(update: AgentSettingsUpdate): Promise<AgentRuntimeUpdateResult>;
+  updateKernel(
+    patch: Pick<AgentSettingsUpdate, "model" | "effort">,
+  ): Promise<AgentKernelPatchResult>;
+  reconcile(): Promise<void>;
+  close(): Promise<void>;
+}
+
+const PersistedAgentSchema = z.object({
+  messagingRuntime: z.enum(["hermes", "openclaw"]).optional(),
+  revision: z.number().int().min(0).optional(),
+  updatedAt: z.iso.datetime().optional(),
+}).passthrough();
+
+const ConfigRecordSchema = z.record(z.string(), z.unknown());
+const MAX_TRANSITION_MARKER_BYTES = 8 * 1024;
+
+const TransitionStateSchema = z.object({
+  id: z.uuid(),
+  from: z.enum(["hermes", "openclaw"]),
+  to: z.enum(["hermes", "openclaw"]),
+  state: z.enum([
+    "validating",
+    "pausing",
+    "draining",
+    "activating",
+    "verifying",
+    "committing",
+    "rolling_back",
+  ]),
+  startedAt: z.iso.datetime(),
+  deadlineAt: z.iso.datetime(),
+}).strict();
+
+type TransitionState = z.infer<typeof TransitionStateSchema>;
+
+function isErrno(error: unknown, code: string): boolean {
+  return error instanceof Error
+    && (error as NodeJS.ErrnoException).code === code;
+}
+
+function logBestEffortFailure(label: string, error: unknown): void {
+  console.warn(
+    `[agent-config] ${label}:`,
+    error instanceof Error ? error.name : "UnknownError",
+  );
+}
+
+async function readConfig(path: string): Promise<Record<string, unknown>> {
+  let raw: string;
+  try {
+    raw = await readFile(path, "utf8");
+  } catch (error) {
+    if (isErrno(error, "ENOENT")) return {};
+    throw new AgentConfigError("agent_config_invalid", error);
+  }
+  try {
+    return ConfigRecordSchema.parse(JSON.parse(raw));
+  } catch (error) {
+    throw new AgentConfigError("agent_config_invalid", error);
+  }
+}
+
+async function writeJsonAtomic(path: string, value: unknown): Promise<void> {
+  await mkdir(dirname(path), { recursive: true, mode: 0o700 });
+  const tempPath = join(dirname(path), `.${randomUUID()}.tmp`);
+  let file: FileHandle | undefined;
+  try {
+    file = await open(tempPath, "wx", 0o600);
+    await file.writeFile(`${JSON.stringify(value, null, 2)}\n`, "utf8");
+    await file.sync();
+    await file.close();
+    file = undefined;
+    await rename(tempPath, path);
+  } finally {
+    await file?.close().catch((error: unknown) => {
+      logBestEffortFailure("Temporary config file close failed", error);
+    });
+    await unlink(tempPath).catch((error: unknown) => {
+      if (!isErrno(error, "ENOENT")) throw error;
+    });
+  }
+}
+
+async function acquireLock(lockPath: string): Promise<() => Promise<void>> {
+  await mkdir(dirname(lockPath), { recursive: true, mode: 0o700 });
+  let file: FileHandle;
+  try {
+    file = await open(lockPath, "wx", 0o600);
+  } catch (error) {
+    if (isErrno(error, "EEXIST")) {
+      throw new AgentConfigError("agent_config_conflict");
+    }
+    throw new AgentConfigError("runtime_switch_failed", error);
+  }
+  return async () => {
+    await file.close();
+    await unlink(lockPath).catch((error: unknown) => {
+      if (!isErrno(error, "ENOENT")) throw error;
+    });
+  };
+}
+
+function readAgentConfig(config: Record<string, unknown>) {
+  if (config.agent === undefined) return { value: {}, stored: {} };
+  const parsed = PersistedAgentSchema.safeParse(config.agent);
+  if (!parsed.success) throw new AgentConfigError("agent_config_invalid", parsed.error);
+  return {
+    value: parsed.data,
+    stored: { ...(config.agent as Record<string, unknown>) },
+  };
+}
+
+function deadlineSignal(timeoutMs: number) {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  return {
+    signal: controller.signal,
+    abort: () => controller.abort(),
+    close: () => clearTimeout(timer),
+  };
+}
+
+function mapSwitchError(error: unknown): AgentConfigError {
+  if (isAgentConfigError(error)) return error;
+  return new AgentConfigError("runtime_switch_failed", error);
+}
+
+export function createAgentRuntimeController(
+  options: AgentRuntimeControllerOptions,
+): AgentRuntimeController {
+  const configPath = join(options.homePath, "system/config.json");
+  const runtimeDir = join(options.homePath, "system/agent-runtime");
+  const lockPath = join(runtimeDir, "transition.lock");
+  const transitionPath = join(runtimeDir, "transition.json");
+  const timeoutMs = options.timeoutMs ?? 10_000;
+  if (!Number.isFinite(timeoutMs) || timeoutMs < 100 || timeoutMs > 30_000) {
+    throw new RangeError("Invalid runtime transition timeout");
+  }
+  const now = options.now ?? (() => new Date());
+  const pauseDelivery = options.pauseDelivery ?? (async () => {});
+  const drainDelivery = options.drainDelivery ?? (async () => {});
+  const resumeDelivery = options.resumeDelivery ?? (async () => {});
+  let closed = false;
+  let activeAbort: (() => void) | null = null;
+  let activeOperation: Promise<unknown> | null = null;
+  let closePromise: Promise<void> | null = null;
+
+  async function performUpdate(
+    updateInput: AgentSettingsUpdate,
+  ): Promise<AgentRuntimeUpdateResult> {
+    const releaseLock = await acquireLock(lockPath);
+    const deadline = deadlineSignal(timeoutMs);
+    activeAbort = deadline.abort;
+    let hasTransition = false;
+    try {
+      const config = await readConfig(configPath);
+      const agent = readAgentConfig(config);
+      const revision = agent.value.revision ?? 0;
+      if (updateInput.revision !== revision) {
+        throw new AgentConfigError("agent_config_conflict");
+      }
+      const currentRuntime = agent.value.messagingRuntime ?? "hermes";
+      const targetRuntime = updateInput.runtime ?? currentRuntime;
+      const currentAdapter = options.adapters[currentRuntime];
+      const targetAdapter = options.adapters[targetRuntime];
+      if (!targetAdapter) {
+        throw new AgentConfigError("runtime_unavailable");
+      }
+
+      const nextRevision = revision + 1;
+      const hasKernelPatch = updateInput.model !== undefined
+        || updateInput.effort !== undefined;
+      let nextKernel: Record<string, unknown> | undefined;
+      if (hasKernelPatch) {
+        const parsedKernel = ConfigRecordSchema.safeParse(config.kernel ?? {});
+        if (!parsedKernel.success) {
+          throw new AgentConfigError("agent_config_invalid", parsedKernel.error);
+        }
+        nextKernel = {
+          ...parsedKernel.data,
+          ...(updateInput.model === undefined ? {} : { model: updateInput.model }),
+          ...(updateInput.effort === undefined ? {} : { effort: updateInput.effort }),
+        };
+      }
+      const nextConfig = {
+        ...config,
+        ...(nextKernel === undefined ? {} : { kernel: nextKernel }),
+        agent: {
+          ...agent.stored,
+          messagingRuntime: targetRuntime,
+          revision: nextRevision,
+          updatedAt: now().toISOString(),
+        },
+      };
+
+      if (targetRuntime === currentRuntime) {
+        const previousSelection = await targetAdapter.selection(deadline.signal);
+        let selection = previousSelection;
+        if (updateInput.provider !== undefined
+          && updateInput.messagingModel !== undefined) {
+          selection = await targetAdapter.configure({
+            provider: updateInput.provider,
+            model: updateInput.messagingModel,
+            ...(updateInput.baseUrl === undefined
+              ? {}
+              : { baseUrl: updateInput.baseUrl }),
+          }, deadline.signal);
+        }
+        try {
+          await writeJsonAtomic(configPath, nextConfig);
+        } catch (error) {
+          if (previousSelection.configured
+            && previousSelection.provider !== null
+            && previousSelection.model !== null
+            && (previousSelection.provider !== selection.provider
+              || previousSelection.model !== selection.model)) {
+            await targetAdapter.configure({
+              provider: previousSelection.provider,
+              model: previousSelection.model,
+            }, deadline.signal).catch((error: unknown) => {
+              logBestEffortFailure("Provider selection restore failed", error);
+            });
+          }
+          throw error;
+        }
+        return { revision: nextRevision, runtime: targetRuntime, selection };
+      }
+
+      const startedAt = now();
+      const baseTransition = {
+        id: randomUUID(),
+        from: currentRuntime,
+        to: targetRuntime,
+        startedAt: startedAt.toISOString(),
+        deadlineAt: new Date(startedAt.getTime() + timeoutMs).toISOString(),
+      };
+      const setTransition = async (state: TransitionState["state"]) => {
+        const transition = TransitionStateSchema.parse({
+          ...baseTransition,
+          state,
+        });
+        await writeJsonAtomic(transitionPath, transition);
+        hasTransition = true;
+      };
+
+      let deliveryPaused = false;
+      let currentDeactivated = false;
+      let targetActivationAttempted = false;
+      let committed = false;
+      let previousTargetSelection: AgentMessagingSelection | null = null;
+      let targetConfigured = false;
+      try {
+        await setTransition("validating");
+        await targetAdapter.prepare(deadline.signal);
+        await setTransition("pausing");
+        await pauseDelivery(deadline.signal);
+        deliveryPaused = true;
+        await setTransition("draining");
+        const drainSignal = AbortSignal.any([
+          deadline.signal,
+          AbortSignal.timeout(Math.min(5_000, timeoutMs)),
+        ]);
+        await drainDelivery(drainSignal);
+        if (currentAdapter) {
+          await currentAdapter.deactivate(deadline.signal);
+          currentDeactivated = true;
+        }
+        await setTransition("activating");
+        targetActivationAttempted = true;
+        await targetAdapter.activate(deadline.signal);
+        await setTransition("verifying");
+        const descriptor = AgentRuntimeDescriptorSchema.parse(
+          await targetAdapter.probe(deadline.signal),
+        );
+        if (descriptor.health !== "healthy") {
+          throw new AgentConfigError("runtime_switch_failed");
+        }
+        previousTargetSelection = await targetAdapter.selection(deadline.signal);
+        let selection = previousTargetSelection;
+        if (updateInput.provider !== undefined
+          && updateInput.messagingModel !== undefined) {
+          selection = await targetAdapter.configure({
+            provider: updateInput.provider,
+            model: updateInput.messagingModel,
+            ...(updateInput.baseUrl === undefined
+              ? {}
+              : { baseUrl: updateInput.baseUrl }),
+          }, deadline.signal);
+          targetConfigured = true;
+        }
+        await setTransition("committing");
+        await writeJsonAtomic(configPath, nextConfig);
+        committed = true;
+        await resumeDelivery(targetRuntime, deadline.signal);
+        deliveryPaused = false;
+        return { revision: nextRevision, runtime: targetRuntime, selection };
+      } catch (error) {
+        const rollbackSignal = AbortSignal.timeout(2_000);
+        if (targetActivationAttempted || currentDeactivated) {
+          await setTransition("rolling_back").catch((rollbackError: unknown) => {
+            logBestEffortFailure("Rollback marker write failed", rollbackError);
+          });
+          if (targetActivationAttempted) {
+            await targetAdapter.deactivate(rollbackSignal).catch((rollbackError: unknown) => {
+              logBestEffortFailure("Target runtime rollback failed", rollbackError);
+            });
+          }
+          if (currentDeactivated && currentAdapter) {
+            await currentAdapter.activate(rollbackSignal).catch((rollbackError: unknown) => {
+              logBestEffortFailure("Previous runtime restore failed", rollbackError);
+            });
+          }
+        }
+        if (targetConfigured
+          && previousTargetSelection?.configured
+          && previousTargetSelection.provider !== null
+          && previousTargetSelection.model !== null) {
+          await targetAdapter.configure({
+            provider: previousTargetSelection.provider,
+            model: previousTargetSelection.model,
+          }, rollbackSignal).catch((rollbackError: unknown) => {
+            logBestEffortFailure("Target provider restore failed", rollbackError);
+          });
+        }
+        if (committed) {
+          await writeJsonAtomic(configPath, config).catch((rollbackError: unknown) => {
+            logBestEffortFailure("Owner config rollback failed", rollbackError);
+          });
+        }
+        if (deliveryPaused) {
+          await resumeDelivery(currentRuntime, rollbackSignal).catch((rollbackError: unknown) => {
+            logBestEffortFailure("Previous runtime delivery resume failed", rollbackError);
+          });
+        }
+        throw mapSwitchError(error);
+      }
+    } finally {
+      activeAbort = null;
+      deadline.close();
+      if (hasTransition) {
+        await unlink(transitionPath).catch((error: unknown) => {
+          if (!isErrno(error, "ENOENT")) {
+            console.warn(
+              "[agent-config] Failed to remove transition marker:",
+              error instanceof Error ? error.name : "UnknownError",
+            );
+          }
+        });
+      }
+      await releaseLock();
+    }
+  }
+
+  function update(
+    updateInput: AgentSettingsUpdate,
+  ): Promise<AgentRuntimeUpdateResult> {
+    if (closed) return Promise.reject(new AgentConfigError("runtime_unavailable"));
+    if (activeOperation !== null) {
+      return Promise.reject(new AgentConfigError("agent_config_conflict"));
+    }
+    const pending = performUpdate(updateInput);
+    activeOperation = pending;
+    const clearPending = () => {
+      if (activeOperation === pending) activeOperation = null;
+    };
+    void pending.then(clearPending, clearPending);
+    return pending;
+  }
+
+  async function performKernelUpdate(
+    patch: Pick<AgentSettingsUpdate, "model" | "effort">,
+  ): Promise<AgentKernelPatchResult> {
+    if (patch.model === undefined && patch.effort === undefined) {
+      throw new AgentConfigError("agent_config_invalid");
+    }
+    const releaseLock = await acquireLock(lockPath);
+    try {
+      const config = await readConfig(configPath);
+      const parsedKernel = ConfigRecordSchema.safeParse(config.kernel ?? {});
+      if (!parsedKernel.success) {
+        throw new AgentConfigError("agent_config_invalid", parsedKernel.error);
+      }
+      const kernel = {
+        ...parsedKernel.data,
+        ...(patch.model === undefined ? {} : { model: patch.model }),
+        ...(patch.effort === undefined ? {} : { effort: patch.effort }),
+      };
+      await writeJsonAtomic(configPath, { ...config, kernel });
+      return { model: kernel.model, effort: kernel.effort };
+    } finally {
+      await releaseLock();
+    }
+  }
+
+  function updateKernel(
+    patch: Pick<AgentSettingsUpdate, "model" | "effort">,
+  ): Promise<AgentKernelPatchResult> {
+    if (closed) return Promise.reject(new AgentConfigError("runtime_unavailable"));
+    if (activeOperation !== null) {
+      return Promise.reject(new AgentConfigError("agent_config_conflict"));
+    }
+    const pending = performKernelUpdate(patch);
+    activeOperation = pending;
+    const clearPending = () => {
+      if (activeOperation === pending) activeOperation = null;
+    };
+    void pending.then(clearPending, clearPending);
+    return pending;
+  }
+
+  async function validateStartupTransitionMarker(): Promise<void> {
+    let markerStat;
+    try {
+      markerStat = await lstat(transitionPath);
+    } catch (error) {
+      if (isErrno(error, "ENOENT")) return;
+      console.warn(
+        "[agent-config] Runtime transition marker check failed:",
+        error instanceof Error ? error.name : "UnknownError",
+      );
+      return;
+    }
+    if (markerStat.isSymbolicLink() || !markerStat.isFile()) {
+      console.warn("[agent-config] Ignoring untrusted runtime transition marker");
+      return;
+    }
+    if (markerStat.size > MAX_TRANSITION_MARKER_BYTES) {
+      console.warn(
+        "[agent-config] Ignoring invalid runtime transition marker:",
+        "ResourceLimitError",
+      );
+      return;
+    }
+
+    let file: FileHandle | undefined;
+    try {
+      file = await open(
+        transitionPath,
+        fsConstants.O_RDONLY | fsConstants.O_NOFOLLOW,
+      );
+      const openedStat = await file.stat();
+      if (!openedStat.isFile() || openedStat.size > MAX_TRANSITION_MARKER_BYTES) {
+        throw new RangeError("Invalid transition marker size");
+      }
+      const buffer = Buffer.alloc(MAX_TRANSITION_MARKER_BYTES + 1);
+      const { bytesRead } = await file.read(buffer, 0, buffer.length, 0);
+      if (bytesRead > MAX_TRANSITION_MARKER_BYTES) {
+        throw new RangeError("Invalid transition marker size");
+      }
+      TransitionStateSchema.parse(JSON.parse(
+        buffer.subarray(0, bytesRead).toString("utf8"),
+      ));
+    } catch (error) {
+      console.warn(
+        "[agent-config] Ignoring invalid runtime transition marker:",
+        error instanceof Error ? error.name : "UnknownError",
+      );
+    } finally {
+      await file?.close().catch((error: unknown) => {
+        logBestEffortFailure("Transition marker close failed", error);
+      });
+    }
+  }
+
+  async function reconcile(): Promise<void> {
+    if (closed) return;
+    await mkdir(runtimeDir, { recursive: true, mode: 0o700 });
+    let staleLock;
+    try {
+      staleLock = await lstat(lockPath);
+    } catch (error) {
+      if (!isErrno(error, "ENOENT")) {
+        console.warn(
+          "[agent-config] Runtime reconciliation lock check failed:",
+          error instanceof Error ? error.name : "UnknownError",
+        );
+        return;
+      }
+    }
+    if (staleLock?.isSymbolicLink()) {
+      console.warn("[agent-config] Ignoring untrusted runtime transition lock");
+      return;
+    }
+    if (staleLock !== undefined) {
+      if (!staleLock.isFile()) {
+        console.warn("[agent-config] Ignoring invalid runtime transition lock");
+        return;
+      }
+      await unlink(lockPath).catch((error: unknown) => {
+        if (!isErrno(error, "ENOENT")) throw error;
+      });
+    }
+
+    const releaseLock = await acquireLock(lockPath);
+    const probeDeadline = deadlineSignal(Math.min(timeoutMs, 2_000));
+    try {
+      await validateStartupTransitionMarker();
+      const config = await readConfig(configPath);
+      const agent = readAgentConfig(config);
+      const selected = agent.value.messagingRuntime ?? "hermes";
+      const selectedAdapter = options.adapters[selected];
+      if (!selectedAdapter) {
+        await pauseDelivery(probeDeadline.signal);
+        return;
+      }
+
+      let selectedHealthy = false;
+      try {
+        const descriptor = AgentRuntimeDescriptorSchema.parse(
+          await selectedAdapter.probe(probeDeadline.signal),
+        );
+        selectedHealthy = descriptor.health === "healthy";
+      } catch (error) {
+        console.warn(
+          "[agent-config] Selected runtime reconciliation probe failed:",
+          error instanceof Error ? error.name : "UnknownError",
+        );
+      }
+
+      await pauseDelivery(probeDeadline.signal);
+      if (selectedHealthy) {
+        for (const [id, adapter] of Object.entries(options.adapters)) {
+          if (id !== selected) {
+            await adapter?.deactivate(probeDeadline.signal).catch((error: unknown) => {
+              logBestEffortFailure("Inactive runtime reconciliation failed", error);
+            });
+          }
+        }
+        await selectedAdapter.activate(probeDeadline.signal);
+        await resumeDelivery(selected, probeDeadline.signal);
+      } else {
+        for (const adapter of Object.values(options.adapters)) {
+          await adapter?.deactivate(probeDeadline.signal).catch((error: unknown) => {
+            logBestEffortFailure("Unavailable runtime deactivation failed", error);
+          });
+        }
+      }
+    } catch (error) {
+      console.warn(
+        "[agent-config] Runtime reconciliation failed:",
+        error instanceof Error ? error.name : "UnknownError",
+      );
+      await pauseDelivery(probeDeadline.signal).catch((pauseError: unknown) => {
+        logBestEffortFailure("Delivery reconciliation pause failed", pauseError);
+      });
+    } finally {
+      probeDeadline.close();
+      let transitionStat;
+      try {
+        transitionStat = await lstat(transitionPath);
+      } catch (error) {
+        if (!isErrno(error, "ENOENT")) {
+          console.warn(
+            "[agent-config] Transition marker cleanup failed:",
+            error instanceof Error ? error.name : "UnknownError",
+          );
+        }
+      }
+      if (transitionStat?.isFile()) {
+        await unlink(transitionPath).catch((error: unknown) => {
+          if (!isErrno(error, "ENOENT")) throw error;
+        });
+      }
+      await releaseLock();
+    }
+  }
+
+  return {
+    update,
+    updateKernel,
+    reconcile,
+    close() {
+      if (closePromise !== null) return closePromise;
+      closed = true;
+      activeAbort?.();
+      closePromise = (async () => {
+        await activeOperation?.catch((error: unknown) => {
+          logBestEffortFailure("Active agent config operation stopped", error);
+        });
+        await Promise.all(Object.values(options.adapters).map(async (adapter) => {
+          await adapter?.close();
+        }));
+      })();
+      return closePromise;
+    },
+  };
+}

--- a/packages/gateway/src/agent-config/runtime-controller.ts
+++ b/packages/gateway/src/agent-config/runtime-controller.ts
@@ -356,36 +356,37 @@ export function createAgentRuntimeController(
 
   async function performReconcile(): Promise<void> {
     if (closed) return;
-    await mkdir(runtimeDir, { recursive: true, mode: 0o700 });
-    let staleLock;
-    try {
-      staleLock = await lstat(lockPath);
-    } catch (error) {
-      if (!isErrno(error, "ENOENT")) {
-        console.warn(
-          "[agent-config] Runtime reconciliation lock check failed:",
-          error instanceof Error ? error.name : "UnknownError",
-        );
-        return;
-      }
-    }
-    if (staleLock?.isSymbolicLink()) {
-      console.warn("[agent-config] Ignoring untrusted runtime transition lock");
-      return;
-    }
-    if (staleLock !== undefined) {
-      if (!staleLock.isFile()) {
-        console.warn("[agent-config] Ignoring invalid runtime transition lock");
-        return;
-      }
-      await unlink(lockPath).catch((error: unknown) => {
-        if (!isErrno(error, "ENOENT")) throw error;
-      });
-    }
-
-    const releaseLock = await acquireLock(lockPath);
     const probeDeadline = deadlineSignal(Math.min(timeoutMs, 2_000));
+    let releaseLock: (() => Promise<void>) | null = null;
     try {
+      await mkdir(runtimeDir, { recursive: true, mode: 0o700 });
+      let staleLock;
+      try {
+        staleLock = await lstat(lockPath);
+      } catch (error) {
+        if (!isErrno(error, "ENOENT")) {
+          console.warn(
+            "[agent-config] Runtime reconciliation lock check failed:",
+            error instanceof Error ? error.name : "UnknownError",
+          );
+          return;
+        }
+      }
+      if (staleLock?.isSymbolicLink()) {
+        console.warn("[agent-config] Ignoring untrusted runtime transition lock");
+        return;
+      }
+      if (staleLock !== undefined) {
+        if (!staleLock.isFile()) {
+          console.warn("[agent-config] Ignoring invalid runtime transition lock");
+          return;
+        }
+        await unlink(lockPath).catch((error: unknown) => {
+          if (!isErrno(error, "ENOENT")) throw error;
+        });
+      }
+
+      releaseLock = await acquireLock(lockPath);
       await validateStartupTransitionMarker(transitionPath);
       const config = await readConfig(configPath);
       const agent = readAgentConfig(config);
@@ -437,6 +438,7 @@ export function createAgentRuntimeController(
       });
     } finally {
       probeDeadline.close();
+      if (releaseLock === null) return;
       let transitionStat;
       try {
         transitionStat = await lstat(transitionPath);

--- a/packages/gateway/src/agent-config/runtime-controller.ts
+++ b/packages/gateway/src/agent-config/runtime-controller.ts
@@ -242,6 +242,17 @@ export function createAgentRuntimeController(
         return { revision: nextRevision, runtime: targetRuntime, selection };
       } catch (error) {
         const rollbackSignal = AbortSignal.timeout(2_000);
+        if (targetConfigured
+          && previousTargetSelection?.configured
+          && previousTargetSelection.provider !== null
+          && previousTargetSelection.model !== null) {
+          await targetAdapter.configure({
+            provider: previousTargetSelection.provider,
+            model: previousTargetSelection.model,
+          }, rollbackSignal).catch((rollbackError: unknown) => {
+            logBestEffortFailure("Target provider restore failed", rollbackError);
+          });
+        }
         if (targetActivationAttempted || currentDeactivated) {
           await setTransition("rolling_back").catch((rollbackError: unknown) => {
             logBestEffortFailure("Rollback marker write failed", rollbackError);
@@ -256,17 +267,6 @@ export function createAgentRuntimeController(
               logBestEffortFailure("Previous runtime restore failed", rollbackError);
             });
           }
-        }
-        if (targetConfigured
-          && previousTargetSelection?.configured
-          && previousTargetSelection.provider !== null
-          && previousTargetSelection.model !== null) {
-          await targetAdapter.configure({
-            provider: previousTargetSelection.provider,
-            model: previousTargetSelection.model,
-          }, rollbackSignal).catch((rollbackError: unknown) => {
-            logBestEffortFailure("Target provider restore failed", rollbackError);
-          });
         }
         if (committed) {
           await writeJsonAtomic(configPath, config).catch((rollbackError: unknown) => {

--- a/packages/gateway/src/agent-config/runtime-files.ts
+++ b/packages/gateway/src/agent-config/runtime-files.ts
@@ -1,0 +1,175 @@
+import { randomUUID } from "node:crypto";
+import { constants as fsConstants } from "node:fs";
+import {
+  lstat,
+  mkdir,
+  open,
+  readFile,
+  rename,
+  unlink,
+  type FileHandle,
+} from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { z } from "zod/v4";
+import { AgentConfigError } from "./errors.js";
+
+const PersistedAgentSchema = z.object({
+  messagingRuntime: z.enum(["hermes", "openclaw"]).optional(),
+  revision: z.number().int().min(0).optional(),
+  updatedAt: z.iso.datetime().optional(),
+}).passthrough();
+
+export const ConfigRecordSchema = z.record(z.string(), z.unknown());
+const MAX_TRANSITION_MARKER_BYTES = 8 * 1024;
+
+export const TransitionStateSchema = z.object({
+  id: z.uuid(),
+  from: z.enum(["hermes", "openclaw"]),
+  to: z.enum(["hermes", "openclaw"]),
+  state: z.enum([
+    "validating",
+    "pausing",
+    "draining",
+    "activating",
+    "verifying",
+    "committing",
+    "rolling_back",
+  ]),
+  startedAt: z.iso.datetime(),
+  deadlineAt: z.iso.datetime(),
+}).strict();
+
+export type TransitionState = z.infer<typeof TransitionStateSchema>;
+
+export function isErrno(error: unknown, code: string): boolean {
+  return error instanceof Error
+    && (error as NodeJS.ErrnoException).code === code;
+}
+
+export function logBestEffortFailure(label: string, error: unknown): void {
+  console.warn(
+    `[agent-config] ${label}:`,
+    error instanceof Error ? error.name : "UnknownError",
+  );
+}
+
+export async function readConfig(path: string): Promise<Record<string, unknown>> {
+  let raw: string;
+  try {
+    raw = await readFile(path, "utf8");
+  } catch (error) {
+    if (isErrno(error, "ENOENT")) return {};
+    throw new AgentConfigError("agent_config_invalid", error);
+  }
+  try {
+    return ConfigRecordSchema.parse(JSON.parse(raw));
+  } catch (error) {
+    throw new AgentConfigError("agent_config_invalid", error);
+  }
+}
+
+export async function writeJsonAtomic(path: string, value: unknown): Promise<void> {
+  await mkdir(dirname(path), { recursive: true, mode: 0o700 });
+  const tempPath = join(dirname(path), `.${randomUUID()}.tmp`);
+  let file: FileHandle | undefined;
+  try {
+    file = await open(tempPath, "wx", 0o600);
+    await file.writeFile(`${JSON.stringify(value, null, 2)}\n`, "utf8");
+    await file.sync();
+    await file.close();
+    file = undefined;
+    await rename(tempPath, path);
+  } finally {
+    await file?.close().catch((error: unknown) => {
+      logBestEffortFailure("Temporary config file close failed", error);
+    });
+    await unlink(tempPath).catch((error: unknown) => {
+      if (!isErrno(error, "ENOENT")) throw error;
+    });
+  }
+}
+
+export async function acquireLock(lockPath: string): Promise<() => Promise<void>> {
+  await mkdir(dirname(lockPath), { recursive: true, mode: 0o700 });
+  let file: FileHandle;
+  try {
+    file = await open(lockPath, "wx", 0o600);
+  } catch (error) {
+    if (isErrno(error, "EEXIST")) {
+      throw new AgentConfigError("agent_config_conflict");
+    }
+    throw new AgentConfigError("runtime_switch_failed", error);
+  }
+  return async () => {
+    await file.close();
+    await unlink(lockPath).catch((error: unknown) => {
+      if (!isErrno(error, "ENOENT")) throw error;
+    });
+  };
+}
+
+export function readAgentConfig(config: Record<string, unknown>) {
+  if (config.agent === undefined) return { value: {}, stored: {} };
+  const parsed = PersistedAgentSchema.safeParse(config.agent);
+  if (!parsed.success) throw new AgentConfigError("agent_config_invalid", parsed.error);
+  return {
+    value: parsed.data,
+    stored: { ...(config.agent as Record<string, unknown>) },
+  };
+}
+
+export async function validateStartupTransitionMarker(
+  transitionPath: string,
+): Promise<void> {
+  let markerStat;
+  try {
+    markerStat = await lstat(transitionPath);
+  } catch (error) {
+    if (isErrno(error, "ENOENT")) return;
+    console.warn(
+      "[agent-config] Runtime transition marker check failed:",
+      error instanceof Error ? error.name : "UnknownError",
+    );
+    return;
+  }
+  if (markerStat.isSymbolicLink() || !markerStat.isFile()) {
+    console.warn("[agent-config] Ignoring untrusted runtime transition marker");
+    return;
+  }
+  if (markerStat.size > MAX_TRANSITION_MARKER_BYTES) {
+    console.warn(
+      "[agent-config] Ignoring invalid runtime transition marker:",
+      "ResourceLimitError",
+    );
+    return;
+  }
+
+  let file: FileHandle | undefined;
+  try {
+    file = await open(
+      transitionPath,
+      fsConstants.O_RDONLY | fsConstants.O_NOFOLLOW,
+    );
+    const openedStat = await file.stat();
+    if (!openedStat.isFile() || openedStat.size > MAX_TRANSITION_MARKER_BYTES) {
+      throw new RangeError("Invalid transition marker size");
+    }
+    const buffer = Buffer.alloc(MAX_TRANSITION_MARKER_BYTES + 1);
+    const { bytesRead } = await file.read(buffer, 0, buffer.length, 0);
+    if (bytesRead > MAX_TRANSITION_MARKER_BYTES) {
+      throw new RangeError("Invalid transition marker size");
+    }
+    TransitionStateSchema.parse(JSON.parse(
+      buffer.subarray(0, bytesRead).toString("utf8"),
+    ));
+  } catch (error) {
+    console.warn(
+      "[agent-config] Ignoring invalid runtime transition marker:",
+      error instanceof Error ? error.name : "UnknownError",
+    );
+  } finally {
+    await file?.close().catch((error: unknown) => {
+      logBestEffortFailure("Transition marker close failed", error);
+    });
+  }
+}

--- a/packages/gateway/src/agent-config/runtime-services.ts
+++ b/packages/gateway/src/agent-config/runtime-services.ts
@@ -1,0 +1,37 @@
+import { createHermesRuntimeAdapter } from "./hermes-adapter.js";
+import { createHermesRuntimeSource, type HermesJsonReader } from "./hermes-source.js";
+import {
+  createAgentRuntimeController,
+  type AgentRuntimeController,
+} from "./runtime-controller.js";
+import type { AgentRuntimeSource } from "./service.js";
+
+interface HermesRuntimeClient {
+  readJson: HermesJsonReader;
+  requestJson(
+    path: string,
+    init: Omit<RequestInit, "signal" | "redirect">,
+    signal: AbortSignal,
+  ): Promise<unknown>;
+}
+
+export interface HermesAgentRuntimeServices {
+  source: AgentRuntimeSource;
+  controller: AgentRuntimeController;
+}
+
+export function createHermesAgentRuntimeServices(options: {
+  homePath: string;
+  client: HermesRuntimeClient;
+}): HermesAgentRuntimeServices {
+  const source = createHermesRuntimeSource(options.client.readJson);
+  const adapter = createHermesRuntimeAdapter({
+    source,
+    requestJson: options.client.requestJson,
+  });
+  const controller = createAgentRuntimeController({
+    homePath: options.homePath,
+    adapters: { hermes: adapter },
+  });
+  return { source, controller };
+}

--- a/packages/gateway/src/agent-config/runtime-types.ts
+++ b/packages/gateway/src/agent-config/runtime-types.ts
@@ -1,0 +1,29 @@
+import type {
+  AgentMessagingSelection,
+  AgentProviderDescriptor,
+  AgentRuntimeDescriptor,
+  AgentRuntimeId,
+} from "@matrix-os/contracts";
+
+export interface RuntimeConfigureInput {
+  provider: string;
+  model: string;
+  baseUrl?: string;
+  expectedConfigRevision?: string;
+}
+
+export interface MessagingRuntimeAdapter {
+  readonly id: AgentRuntimeId;
+  probe(signal: AbortSignal): Promise<AgentRuntimeDescriptor>;
+  catalog(signal: AbortSignal): Promise<AgentProviderDescriptor[]>;
+  selection(signal: AbortSignal): Promise<AgentMessagingSelection>;
+  configure(
+    input: RuntimeConfigureInput,
+    signal: AbortSignal,
+  ): Promise<AgentMessagingSelection>;
+  prepare(signal: AbortSignal): Promise<void>;
+  activate(signal: AbortSignal): Promise<void>;
+  deactivate(signal: AbortSignal): Promise<void>;
+  dashboard(signal: AbortSignal): Promise<Record<string, unknown> | null>;
+  close(): Promise<void>;
+}

--- a/packages/gateway/src/agent-config/service.ts
+++ b/packages/gateway/src/agent-config/service.ts
@@ -30,9 +30,10 @@ export interface AgentRuntimeSettingsSnapshot {
   messaging: AgentMessagingSelection;
 }
 
-export type AgentRuntimeSource = (
-  signal: AbortSignal,
-) => Promise<AgentRuntimeSettingsSnapshot>;
+export interface AgentRuntimeSource {
+  (signal: AbortSignal): Promise<AgentRuntimeSettingsSnapshot>;
+  invalidate?: () => void;
+}
 
 export async function readRuntimeSnapshot(
   source: AgentRuntimeSource,

--- a/packages/gateway/src/routes/settings.ts
+++ b/packages/gateway/src/routes/settings.ts
@@ -29,6 +29,11 @@ import {
   readRuntimeSnapshot,
   type AgentRuntimeSource,
 } from "../agent-config/service.js";
+import {
+  isAgentConfigError,
+  type AgentConfigErrorKind,
+} from "../agent-config/errors.js";
+import type { AgentRuntimeController } from "../agent-config/runtime-controller.js";
 
 const DESKTOP_DEFAULTS = {
   background: { type: "wallpaper", name: "moraine-lake.jpg" },
@@ -210,13 +215,61 @@ export function createSettingsRoutes(opts: {
   homePath: string;
   channelManager: ChannelManager;
   agentRuntimeSource?: AgentRuntimeSource;
+  agentRuntimeController?: AgentRuntimeController;
 }) {
-  const { homePath, channelManager, agentRuntimeSource } = opts;
+  const {
+    homePath,
+    channelManager,
+    agentRuntimeSource,
+    agentRuntimeController,
+  } = opts;
   const app = new Hono();
   const configPath = join(homePath, "system/config.json");
 
   async function readConfig(): Promise<Record<string, unknown>> {
     return readJson(configPath, {}, "config");
+  }
+
+  async function readAgentSettingsView() {
+    const cfg = await readConfig();
+    const handlePath = join(homePath, "system/handle.json");
+    const handle = await readJson<Record<string, unknown>>(
+      handlePath,
+      {},
+      "handle",
+    );
+    let runtimeSnapshot;
+    if (agentRuntimeSource) {
+      try {
+        runtimeSnapshot = await readRuntimeSnapshot(agentRuntimeSource);
+      } catch (err) {
+        console.warn(
+          "[settings] Failed to read agent runtime settings:",
+          err instanceof Error ? err.name : "UnknownError",
+        );
+      }
+    }
+    return buildAgentSettingsView({
+      identity: handle,
+      config: cfg,
+      claudeLoginAvailable: await hasClaudeLogin(homePath),
+      platformCredentialAvailable: typeof process.env.ANTHROPIC_API_KEY === "string"
+        && process.env.ANTHROPIC_API_KEY.length > 0,
+      runtimeSnapshot,
+    });
+  }
+
+  function mapAgentConfigError(kind: AgentConfigErrorKind) {
+    if (kind === "agent_config_invalid" || kind === "not_configured") {
+      return { status: 400 as const, error: "agent_config_invalid" as const };
+    }
+    if (kind === "agent_config_conflict") {
+      return { status: 409 as const, error: "agent_config_conflict" as const };
+    }
+    if (kind === "runtime_unavailable" || kind === "invalid_response") {
+      return { status: 503 as const, error: "runtime_unavailable" as const };
+    }
+    return { status: 503 as const, error: "runtime_switch_failed" as const };
   }
 
   app.get("/channels", async (c) => {
@@ -271,28 +324,7 @@ export function createSettingsRoutes(opts: {
   });
 
   app.get("/agent", async (c) => {
-    const cfg = await readConfig();
-    const handlePath = join(homePath, "system/handle.json");
-    const handle = await readJson<Record<string, unknown>>(handlePath, {}, "handle");
-    let runtimeSnapshot;
-    if (agentRuntimeSource) {
-      try {
-        runtimeSnapshot = await readRuntimeSnapshot(agentRuntimeSource);
-      } catch (err) {
-        console.warn(
-          "[settings] Failed to read agent runtime settings:",
-          err instanceof Error ? err.name : "UnknownError",
-        );
-      }
-    }
-    return c.json(buildAgentSettingsView({
-      identity: handle,
-      config: cfg,
-      claudeLoginAvailable: await hasClaudeLogin(homePath),
-      platformCredentialAvailable: typeof process.env.ANTHROPIC_API_KEY === "string"
-        && process.env.ANTHROPIC_API_KEY.length > 0,
-      runtimeSnapshot,
-    }));
+    return c.json(await readAgentSettingsView());
   });
 
   app.get("/agent/summary", async (c) => {
@@ -326,7 +358,22 @@ export function createSettingsRoutes(opts: {
       || parsed.data.messagingModel !== undefined
       || parsed.data.baseUrl !== undefined;
     if (hasExtendedMutation) {
-      return c.json({ error: "runtime_unavailable" }, 503);
+      if (!agentRuntimeController) {
+        return c.json({ error: "runtime_unavailable" }, 503);
+      }
+      try {
+        await agentRuntimeController.update(parsed.data);
+        return c.json(await readAgentSettingsView());
+      } catch (err) {
+        const mapped = mapAgentConfigError(
+          isAgentConfigError(err) ? err.kind : "runtime_switch_failed",
+        );
+        console.warn(
+          "[settings] Agent runtime update failed:",
+          err instanceof Error ? err.name : "UnknownError",
+        );
+        return c.json({ error: mapped.error }, mapped.status);
+      }
     }
     const kernelPatch = KernelPatchSchema.safeParse({
       model: parsed.data.model,
@@ -334,6 +381,27 @@ export function createSettingsRoutes(opts: {
     });
     if (!kernelPatch.success) {
       return c.json({ error: "agent_config_invalid" }, 400);
+    }
+    if (agentRuntimeController) {
+      try {
+        const kernel = await agentRuntimeController.updateKernel(kernelPatch.data);
+        return c.json({
+          ok: true,
+          kernel: {
+            model: normalizeKernelModel(kernel.model),
+            effort: normalizeKernelEffort(kernel.effort),
+          },
+        });
+      } catch (err) {
+        const mapped = mapAgentConfigError(
+          isAgentConfigError(err) ? err.kind : "runtime_switch_failed",
+        );
+        console.warn(
+          "[settings] Agent kernel update failed:",
+          err instanceof Error ? err.name : "UnknownError",
+        );
+        return c.json({ error: mapped.error }, mapped.status);
+      }
     }
     const cfg = await readConfig();
     const kernel = { ...((cfg.kernel ?? {}) as Record<string, unknown>) };

--- a/packages/gateway/src/server.ts
+++ b/packages/gateway/src/server.ts
@@ -188,7 +188,7 @@ import {
   createHermesDashboardClient,
   validateHermesDashboardUrl,
 } from "./agent-config/hermes-client.js";
-import { createHermesRuntimeSource } from "./agent-config/hermes-source.js";
+import { createHermesAgentRuntimeServices } from "./agent-config/runtime-services.js";
 import { syncApp, createSyncRoutes, type SyncRouteDeps } from "./sync/routes.js";
 import { createR2Client, type R2Client, type R2ClientConfig } from "./sync/r2-client.js";
 import { createPlatformR2Client } from "./sync/platform-r2-client.js";
@@ -3952,12 +3952,18 @@ export async function createGateway(config: GatewayConfig) {
     throw err;
   }
   const hermesClient = createHermesDashboardClient({ baseUrl: hermesDashboardUrl });
+  const agentRuntimeServices = createHermesAgentRuntimeServices({
+    homePath,
+    client: hermesClient,
+  });
+  await agentRuntimeServices.controller.reconcile();
 
   // T978-T979: Settings API routes
   const settingsRoutes = createSettingsRoutes({
     homePath,
     channelManager,
-    agentRuntimeSource: createHermesRuntimeSource(hermesClient.readJson),
+    agentRuntimeSource: agentRuntimeServices.source,
+    agentRuntimeController: agentRuntimeServices.controller,
   });
   app.route("/api/settings", settingsRoutes);
   app.route("/api/hermes", createHermesRoutes({ client: hermesClient }));
@@ -4245,6 +4251,7 @@ export async function createGateway(config: GatewayConfig) {
       watchdog.stop();
       proactiveHeartbeat.stop();
       cronService.stop();
+      await agentRuntimeServices.controller.close();
       await codingAgentTurnLifecycle.shutdown();
       await codexEventBridge?.shutdown();
       codingAgentThreadStream?.shutdown();

--- a/tests/gateway/agent-config-hermes-source.test.ts
+++ b/tests/gateway/agent-config-hermes-source.test.ts
@@ -146,6 +146,23 @@ describe("Hermes agent settings source", () => {
     expect(readJson).toHaveBeenCalledTimes(4);
   });
 
+  it("invalidates a cached inventory after a successful configuration mutation", async () => {
+    const readJson = vi.fn(async (path: string) => path === "/api/status"
+      ? { gateway_running: true }
+      : { provider: "", model: "", providers: [] });
+    const source = createHermesRuntimeSource(readJson, { cacheTtlMs: 5_000 });
+    const signal = new AbortController().signal;
+
+    await source(signal);
+    await source(signal);
+    expect(readJson).toHaveBeenCalledTimes(2);
+
+    source.invalidate();
+    await source(signal);
+
+    expect(readJson).toHaveBeenCalledTimes(4);
+  });
+
   it("negative-caches an unreachable runtime without logging raw errors", async () => {
     const canary = "sk-secret-upstream-canary";
     const readJson = vi.fn(async () => {

--- a/tests/gateway/agent-runtime-controller.test.ts
+++ b/tests/gateway/agent-runtime-controller.test.ts
@@ -298,6 +298,33 @@ describe("agent runtime controller", () => {
     )).rejects.toMatchObject({ code: "ENOENT" });
   });
 
+  it("does not let reconciliation remove a live transition lock", async () => {
+    const homePath = await createHome();
+    let releasePrepare: (() => void) | undefined;
+    const prepareGate = new Promise<void>((resolve) => {
+      releasePrepare = resolve;
+    });
+    const openclaw = fakeAdapter("openclaw", {
+      prepare: vi.fn(async () => prepareGate),
+    });
+    const controller = createAgentRuntimeController({
+      homePath,
+      adapters: { hermes: fakeAdapter("hermes"), openclaw },
+    });
+    const update = controller.update({ runtime: "openclaw", revision: 0 });
+    await vi.waitFor(() => expect(openclaw.prepare).toHaveBeenCalledOnce());
+    const lockPath = join(homePath, "system/agent-runtime/transition.lock");
+
+    await expect(controller.reconcile()).rejects.toMatchObject({
+      kind: "agent_config_conflict",
+    });
+    await expect(lstat(lockPath)).resolves.toMatchObject({});
+
+    releasePrepare?.();
+    await expect(update).resolves.toMatchObject({ runtime: "openclaw" });
+    await expect(lstat(lockPath)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
   it("serializes legacy Chat patches with runtime transitions", async () => {
     const homePath = await createHome({
       kernel: { model: "claude-opus-4-6", effort: "high" },

--- a/tests/gateway/agent-runtime-controller.test.ts
+++ b/tests/gateway/agent-runtime-controller.test.ts
@@ -456,6 +456,32 @@ describe("agent runtime controller", () => {
       .rejects.toMatchObject({ code: "ENOENT" });
   });
 
+  it("keeps gateway startup available when reconciliation cannot create its directory", async () => {
+    const homePath = await createHome({
+      kernel: { model: "claude-opus-4-6", effort: "high" },
+    });
+    await writeFile(join(homePath, "system/agent-runtime"), "not-a-directory");
+    const pauseDelivery = vi.fn(async () => {});
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const controller = createAgentRuntimeController({
+      homePath,
+      adapters: { hermes: fakeAdapter("hermes") },
+      pauseDelivery,
+    });
+
+    try {
+      await expect(controller.reconcile()).resolves.toBeUndefined();
+      expect(pauseDelivery).toHaveBeenCalledOnce();
+      expect(warn).toHaveBeenCalledWith(
+        "[agent-config] Runtime reconciliation failed:",
+        expect.any(String),
+      );
+    } finally {
+      warn.mockRestore();
+      await controller.close();
+    }
+  });
+
   it("ignores untrusted startup lock symlinks without following or removing them", async () => {
     const homePath = await createHome();
     const runtimeDir = join(homePath, "system/agent-runtime");

--- a/tests/gateway/agent-runtime-controller.test.ts
+++ b/tests/gateway/agent-runtime-controller.test.ts
@@ -1,0 +1,465 @@
+import {
+  lstat,
+  mkdir,
+  mkdtemp,
+  readFile,
+  rm,
+  symlink,
+  writeFile,
+} from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  createAgentRuntimeController,
+  type MessagingRuntimeAdapter,
+} from "../../packages/gateway/src/agent-config/runtime-controller.js";
+
+const homes: string[] = [];
+
+async function createHome(config: Record<string, unknown> = {}) {
+  const homePath = await mkdtemp(join(tmpdir(), "agent-runtime-controller-"));
+  homes.push(homePath);
+  await mkdir(join(homePath, "system"), { recursive: true });
+  await writeFile(join(homePath, "system/config.json"), JSON.stringify(config));
+  return homePath;
+}
+
+function fakeAdapter(
+  id: "hermes" | "openclaw",
+  overrides: Partial<MessagingRuntimeAdapter> = {},
+): MessagingRuntimeAdapter {
+  return {
+    id,
+    probe: vi.fn(async () => ({
+      id,
+      displayName: id === "hermes" ? "Hermes" : "OpenClaw",
+      installState: "installed",
+      health: "healthy",
+      selectionState: "available",
+      configured: true,
+      capabilities: ["provider_catalog", "model_selection"],
+    })),
+    catalog: vi.fn(async () => []),
+    selection: vi.fn(async () => ({
+      runtime: id,
+      provider: "provider",
+      model: "model",
+      configured: true,
+    })),
+    configure: vi.fn(async () => ({
+      runtime: id,
+      provider: "provider",
+      model: "model",
+      configured: true,
+    })),
+    prepare: vi.fn(async () => {}),
+    activate: vi.fn(async () => {}),
+    deactivate: vi.fn(async () => {}),
+    dashboard: vi.fn(async () => null),
+    close: vi.fn(async () => {}),
+    ...overrides,
+  };
+}
+
+afterEach(async () => {
+  await Promise.all(homes.splice(0).map((path) => rm(path, {
+    recursive: true,
+    force: true,
+  })));
+});
+
+describe("agent runtime controller", () => {
+  it("rejects absent OpenClaw without changing owner config", async () => {
+    const homePath = await createHome({ unrelated: { preserved: true } });
+    const controller = createAgentRuntimeController({
+      homePath,
+      adapters: { hermes: fakeAdapter("hermes") },
+    });
+
+    await expect(controller.update({ runtime: "openclaw", revision: 0 }))
+      .rejects.toMatchObject({ kind: "runtime_unavailable" });
+    await expect(readFile(join(homePath, "system/config.json"), "utf8"))
+      .resolves.toBe(JSON.stringify({ unrelated: { preserved: true } }));
+  });
+
+  it("recovers from a persisted absent runtime by switching to healthy Hermes", async () => {
+    const homePath = await createHome({
+      agent: { messagingRuntime: "openclaw", revision: 2 },
+    });
+    const hermes = fakeAdapter("hermes");
+    const resumeDelivery = vi.fn(async () => {});
+    const controller = createAgentRuntimeController({
+      homePath,
+      adapters: { hermes },
+      resumeDelivery,
+    });
+
+    await expect(controller.update({ runtime: "hermes", revision: 2 }))
+      .resolves.toMatchObject({ runtime: "hermes", revision: 3 });
+    const config = JSON.parse(await readFile(
+      join(homePath, "system/config.json"),
+      "utf8",
+    ));
+    expect(config.agent).toMatchObject({
+      messagingRuntime: "hermes",
+      revision: 3,
+    });
+    expect(hermes.activate).toHaveBeenCalledOnce();
+    expect(resumeDelivery).toHaveBeenCalledWith("hermes", expect.any(AbortSignal));
+  });
+
+  it("rejects a stale revision before touching either adapter", async () => {
+    const homePath = await createHome({
+      agent: { messagingRuntime: "hermes", revision: 3 },
+    });
+    const hermes = fakeAdapter("hermes");
+    const controller = createAgentRuntimeController({
+      homePath,
+      adapters: { hermes },
+    });
+
+    await expect(controller.update({
+      provider: "provider",
+      messagingModel: "model",
+      revision: 2,
+    })).rejects.toMatchObject({ kind: "agent_config_conflict" });
+    expect(hermes.configure).not.toHaveBeenCalled();
+  });
+
+  it("health-gates a switch and rolls service activation back on failure", async () => {
+    const homePath = await createHome({
+      agent: { messagingRuntime: "hermes", revision: 0 },
+    });
+    const calls: string[] = [];
+    const hermes = fakeAdapter("hermes", {
+      deactivate: vi.fn(async () => { calls.push("hermes:deactivate"); }),
+      activate: vi.fn(async () => { calls.push("hermes:activate"); }),
+    });
+    const openclaw = fakeAdapter("openclaw", {
+      prepare: vi.fn(async () => { calls.push("openclaw:prepare"); }),
+      activate: vi.fn(async () => {
+        calls.push("openclaw:activate");
+        throw new Error("activation secret canary");
+      }),
+      deactivate: vi.fn(async () => { calls.push("openclaw:deactivate"); }),
+    });
+    const pauseDelivery = vi.fn(async () => { calls.push("delivery:pause"); });
+    const drainDelivery = vi.fn(async () => { calls.push("delivery:drain"); });
+    const resumeDelivery = vi.fn(async (runtime: string) => {
+      calls.push(`delivery:resume:${runtime}`);
+    });
+    const controller = createAgentRuntimeController({
+      homePath,
+      adapters: { hermes, openclaw },
+      pauseDelivery,
+      drainDelivery,
+      resumeDelivery,
+    });
+
+    await expect(controller.update({ runtime: "openclaw", revision: 0 }))
+      .rejects.toMatchObject({ kind: "runtime_switch_failed" });
+    expect(calls).toEqual([
+      "openclaw:prepare",
+      "delivery:pause",
+      "delivery:drain",
+      "hermes:deactivate",
+      "openclaw:activate",
+      "openclaw:deactivate",
+      "hermes:activate",
+      "delivery:resume:hermes",
+    ]);
+    const config = JSON.parse(await readFile(
+      join(homePath, "system/config.json"),
+      "utf8",
+    ));
+    expect(config.agent).toEqual({ messagingRuntime: "hermes", revision: 0 });
+  });
+
+  it("persists only a healthy switch and preserves unrelated config", async () => {
+    const homePath = await createHome({
+      unrelated: { preserved: true },
+      agent: { messagingRuntime: "hermes", revision: 6 },
+    });
+    const hermes = fakeAdapter("hermes");
+    const openclaw = fakeAdapter("openclaw");
+    const resumeDelivery = vi.fn(async () => {});
+    const controller = createAgentRuntimeController({
+      homePath,
+      adapters: { hermes, openclaw },
+      resumeDelivery,
+    });
+
+    await expect(controller.update({ runtime: "openclaw", revision: 6 }))
+      .resolves.toMatchObject({ revision: 7, runtime: "openclaw" });
+    const config = JSON.parse(await readFile(
+      join(homePath, "system/config.json"),
+      "utf8",
+    ));
+    expect(config.unrelated).toEqual({ preserved: true });
+    expect(config.agent).toMatchObject({
+      messagingRuntime: "openclaw",
+      revision: 7,
+    });
+    expect(resumeDelivery).toHaveBeenCalledWith("openclaw", expect.any(AbortSignal));
+  });
+
+  it("atomically preserves and patches Chat settings in a combined update", async () => {
+    const homePath = await createHome({
+      kernel: {
+        model: "claude-opus-4-6",
+        effort: "high",
+        anthropicApiKey: "owner-secret",
+      },
+      agent: { messagingRuntime: "hermes", revision: 2 },
+    });
+    const controller = createAgentRuntimeController({
+      homePath,
+      adapters: { hermes: fakeAdapter("hermes") },
+    });
+
+    await controller.update({
+      model: "claude-haiku-4-5",
+      effort: "low",
+      provider: "provider",
+      messagingModel: "model",
+      revision: 2,
+    });
+
+    const config = JSON.parse(await readFile(
+      join(homePath, "system/config.json"),
+      "utf8",
+    ));
+    expect(config.kernel).toEqual({
+      model: "claude-haiku-4-5",
+      effort: "low",
+      anthropicApiKey: "owner-secret",
+    });
+    expect(config.agent).toMatchObject({
+      messagingRuntime: "hermes",
+      revision: 3,
+    });
+  });
+
+  it("does not query a stopped target selection before prepare and activation", async () => {
+    const homePath = await createHome();
+    let active = false;
+    const openclaw = fakeAdapter("openclaw", {
+      prepare: vi.fn(async () => {}),
+      activate: vi.fn(async () => { active = true; }),
+      selection: vi.fn(async () => {
+        if (!active) throw new Error("target gateway is stopped");
+        return {
+          runtime: "openclaw",
+          provider: "provider",
+          model: "model",
+          configured: true,
+        };
+      }),
+    });
+    const controller = createAgentRuntimeController({
+      homePath,
+      adapters: { hermes: fakeAdapter("hermes"), openclaw },
+    });
+
+    await expect(controller.update({ runtime: "openclaw", revision: 0 }))
+      .resolves.toMatchObject({ runtime: "openclaw", revision: 1 });
+    expect(openclaw.prepare).toHaveBeenCalledBefore(
+      openclaw.selection as ReturnType<typeof vi.fn>,
+    );
+    expect(openclaw.activate).toHaveBeenCalledBefore(
+      openclaw.selection as ReturnType<typeof vi.fn>,
+    );
+  });
+
+  it("admits only one concurrent transition and leaves no lock file", async () => {
+    const homePath = await createHome();
+    let releasePrepare: (() => void) | undefined;
+    const prepareGate = new Promise<void>((resolve) => {
+      releasePrepare = resolve;
+    });
+    const openclaw = fakeAdapter("openclaw", {
+      prepare: vi.fn(async () => prepareGate),
+    });
+    const controller = createAgentRuntimeController({
+      homePath,
+      adapters: { hermes: fakeAdapter("hermes"), openclaw },
+    });
+
+    const first = controller.update({ runtime: "openclaw", revision: 0 });
+    await vi.waitFor(() => expect(openclaw.prepare).toHaveBeenCalledOnce());
+    await expect(controller.update({ runtime: "openclaw", revision: 0 }))
+      .rejects.toMatchObject({ kind: "agent_config_conflict" });
+    releasePrepare?.();
+    await expect(first).resolves.toMatchObject({ revision: 1 });
+    await expect(readFile(
+      join(homePath, "system/agent-runtime/transition.lock"),
+      "utf8",
+    )).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("serializes legacy Chat patches with runtime transitions", async () => {
+    const homePath = await createHome({
+      kernel: { model: "claude-opus-4-6", effort: "high" },
+      agent: { messagingRuntime: "hermes", revision: 0 },
+    });
+    let releasePrepare: (() => void) | undefined;
+    const prepareGate = new Promise<void>((resolve) => {
+      releasePrepare = resolve;
+    });
+    const openclaw = fakeAdapter("openclaw", {
+      prepare: vi.fn(async () => prepareGate),
+    });
+    const controller = createAgentRuntimeController({
+      homePath,
+      adapters: { hermes: fakeAdapter("hermes"), openclaw },
+    });
+
+    const transition = controller.update({ runtime: "openclaw", revision: 0 });
+    await vi.waitFor(() => expect(openclaw.prepare).toHaveBeenCalledOnce());
+    await expect(controller.updateKernel({ effort: "low" }))
+      .rejects.toMatchObject({ kind: "agent_config_conflict" });
+    releasePrepare?.();
+    await transition;
+    await expect(controller.updateKernel({ effort: "low" })).resolves.toEqual({
+      model: "claude-opus-4-6",
+      effort: "low",
+    });
+
+    const config = JSON.parse(await readFile(
+      join(homePath, "system/config.json"),
+      "utf8",
+    ));
+    expect(config.agent).toMatchObject({
+      messagingRuntime: "openclaw",
+      revision: 1,
+    });
+    expect(config.kernel).toEqual({
+      model: "claude-opus-4-6",
+      effort: "low",
+    });
+  });
+
+  it("reconciles a stale transition to the persisted healthy runtime", async () => {
+    const homePath = await createHome({
+      agent: { messagingRuntime: "hermes", revision: 4 },
+    });
+    const runtimeDir = join(homePath, "system/agent-runtime");
+    await mkdir(runtimeDir, { recursive: true });
+    await writeFile(join(runtimeDir, "transition.lock"), "stale");
+    await writeFile(join(runtimeDir, "transition.json"), JSON.stringify({
+      id: "6f06cf2c-806f-4c44-b92e-97e041ff088b",
+      from: "hermes",
+      to: "openclaw",
+      state: "verifying",
+      startedAt: "2026-07-13T00:00:00.000Z",
+      deadlineAt: "2026-07-13T00:00:10.000Z",
+    }));
+    const calls: string[] = [];
+    const controller = createAgentRuntimeController({
+      homePath,
+      adapters: {
+        hermes: fakeAdapter("hermes", {
+          activate: vi.fn(async () => { calls.push("hermes:activate"); }),
+        }),
+        openclaw: fakeAdapter("openclaw", {
+          deactivate: vi.fn(async () => { calls.push("openclaw:deactivate"); }),
+        }),
+      },
+      pauseDelivery: vi.fn(async () => { calls.push("delivery:pause"); }),
+      resumeDelivery: vi.fn(async (runtime) => {
+        calls.push(`delivery:resume:${runtime}`);
+      }),
+    });
+
+    await controller.reconcile();
+
+    expect(calls).toEqual([
+      "delivery:pause",
+      "openclaw:deactivate",
+      "hermes:activate",
+      "delivery:resume:hermes",
+    ]);
+    await expect(lstat(join(runtimeDir, "transition.lock")))
+      .rejects.toMatchObject({ code: "ENOENT" });
+    await expect(lstat(join(runtimeDir, "transition.json")))
+      .rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("ignores untrusted startup lock symlinks without following or removing them", async () => {
+    const homePath = await createHome();
+    const runtimeDir = join(homePath, "system/agent-runtime");
+    await mkdir(runtimeDir, { recursive: true });
+    const targetPath = join(homePath, "owner-file");
+    await writeFile(targetPath, "preserve-me");
+    const lockPath = join(runtimeDir, "transition.lock");
+    await symlink(targetPath, lockPath);
+    const hermes = fakeAdapter("hermes");
+    const controller = createAgentRuntimeController({
+      homePath,
+      adapters: { hermes },
+    });
+
+    await controller.reconcile();
+
+    expect((await lstat(lockPath)).isSymbolicLink()).toBe(true);
+    await expect(readFile(targetPath, "utf8")).resolves.toBe("preserve-me");
+    expect(hermes.activate).not.toHaveBeenCalled();
+  });
+
+  it("rejects malformed startup transition content without logging it", async () => {
+    const homePath = await createHome();
+    const runtimeDir = join(homePath, "system/agent-runtime");
+    await mkdir(runtimeDir, { recursive: true });
+    const canary = "sk-secret-transition-canary";
+    await writeFile(join(runtimeDir, "transition.json"), canary);
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const controller = createAgentRuntimeController({
+      homePath,
+      adapters: { hermes: fakeAdapter("hermes") },
+    });
+
+    try {
+      await controller.reconcile();
+      expect(warn).toHaveBeenCalledWith(
+        "[agent-config] Ignoring invalid runtime transition marker:",
+        expect.any(String),
+      );
+      expect(JSON.stringify(warn.mock.calls)).not.toContain(canary);
+      await expect(lstat(join(runtimeDir, "transition.json")))
+        .rejects.toMatchObject({ code: "ENOENT" });
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it("aborts and waits for an in-flight transition before closing adapters", async () => {
+    const homePath = await createHome();
+    let prepareSignal: AbortSignal | undefined;
+    const openclaw = fakeAdapter("openclaw", {
+      prepare: vi.fn(async (signal) => new Promise<void>((_resolve, reject) => {
+        prepareSignal = signal;
+        signal.addEventListener("abort", () => reject(signal.reason), {
+          once: true,
+        });
+      })),
+    });
+    const hermes = fakeAdapter("hermes");
+    const controller = createAgentRuntimeController({
+      homePath,
+      adapters: { hermes, openclaw },
+      timeoutMs: 100,
+    });
+    const transition = controller.update({ runtime: "openclaw", revision: 0 });
+    await vi.waitFor(() => expect(openclaw.prepare).toHaveBeenCalledOnce());
+
+    await controller.close();
+
+    expect(prepareSignal?.aborted).toBe(true);
+    await expect(transition).rejects.toMatchObject({
+      kind: "runtime_switch_failed",
+    });
+    expect(hermes.close).toHaveBeenCalledOnce();
+    expect(openclaw.close).toHaveBeenCalledOnce();
+  });
+});

--- a/tests/gateway/agent-runtime-controller.test.ts
+++ b/tests/gateway/agent-runtime-controller.test.ts
@@ -242,6 +242,50 @@ describe("agent runtime controller", () => {
     });
   });
 
+  it("uses a fresh deadline to restore a same-runtime selection after persistence fails", async () => {
+    const homePath = await createHome({
+      agent: { messagingRuntime: "hermes", revision: 0 },
+    });
+    const configPath = join(homePath, "system/config.json");
+    const rollbackSignals: boolean[] = [];
+    const hermes = fakeAdapter("hermes", {
+      selection: vi.fn(async () => ({
+        runtime: "hermes",
+        provider: "old-provider",
+        model: "old-model",
+        configured: true,
+      })),
+      configure: vi.fn(async (input, signal) => {
+        if (input.provider === "new-provider") {
+          await rm(configPath);
+          await mkdir(configPath);
+          await new Promise((resolve) => setTimeout(resolve, 120));
+        } else {
+          rollbackSignals.push(signal.aborted);
+          signal.throwIfAborted();
+        }
+        return {
+          runtime: "hermes",
+          provider: input.provider,
+          model: input.model,
+          configured: true,
+        };
+      }),
+    });
+    const controller = createAgentRuntimeController({
+      homePath,
+      adapters: { hermes },
+      timeoutMs: 100,
+    });
+
+    await expect(controller.update({
+      provider: "new-provider",
+      messagingModel: "new-model",
+      revision: 0,
+    })).rejects.toBeDefined();
+    expect(rollbackSignals).toEqual([false]);
+  });
+
   it("does not query a stopped target selection before prepare and activation", async () => {
     const homePath = await createHome();
     let active = false;

--- a/tests/gateway/agent-runtime-controller.test.ts
+++ b/tests/gateway/agent-runtime-controller.test.ts
@@ -7,6 +7,7 @@ import {
   symlink,
   writeFile,
 } from "node:fs/promises";
+import { chmodSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -454,6 +455,55 @@ describe("agent runtime controller", () => {
       .rejects.toMatchObject({ code: "ENOENT" });
     await expect(lstat(join(runtimeDir, "transition.json")))
       .rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("keeps gateway startup available when transition cleanup fails", async () => {
+    const homePath = await createHome();
+    const runtimeDir = join(homePath, "system/agent-runtime");
+    await mkdir(runtimeDir, { recursive: true });
+    await writeFile(join(runtimeDir, "transition.json"), JSON.stringify({
+      id: "6f06cf2c-806f-4c44-b92e-97e041ff088b",
+      from: "openclaw",
+      to: "hermes",
+      state: "verifying",
+      startedAt: "2026-07-13T00:00:00.000Z",
+      deadlineAt: "2026-07-13T00:00:10.000Z",
+    }));
+    const warn = vi.spyOn(console, "warn").mockImplementation((message) => {
+      if (message === "[agent-config] Transition marker cleanup failed:") {
+        chmodSync(runtimeDir, 0o700);
+      }
+    });
+    const hermes = fakeAdapter("hermes", {
+      probe: vi.fn(async () => {
+        chmodSync(runtimeDir, 0o500);
+        return {
+          id: "hermes",
+          displayName: "Hermes",
+          installState: "installed",
+          health: "healthy",
+          selectionState: "active",
+          configured: true,
+          capabilities: ["provider_catalog", "model_selection"],
+        };
+      }),
+    });
+    const controller = createAgentRuntimeController({
+      homePath,
+      adapters: { hermes },
+    });
+
+    try {
+      await expect(controller.reconcile()).resolves.toBeUndefined();
+      expect(warn).toHaveBeenCalledWith(
+        "[agent-config] Transition marker cleanup failed:",
+        expect.any(String),
+      );
+    } finally {
+      chmodSync(runtimeDir, 0o700);
+      warn.mockRestore();
+      await controller.close();
+    }
   });
 
   it("keeps gateway startup available when reconciliation cannot create its directory", async () => {

--- a/tests/gateway/agent-runtime-controller.test.ts
+++ b/tests/gateway/agent-runtime-controller.test.ts
@@ -272,6 +272,49 @@ describe("agent runtime controller", () => {
     );
   });
 
+  it("restores a changed target selection before deactivating rollback", async () => {
+    const homePath = await createHome();
+    const calls: string[] = [];
+    let active = false;
+    const openclaw = fakeAdapter("openclaw", {
+      activate: vi.fn(async () => { active = true; calls.push("activate"); }),
+      deactivate: vi.fn(async () => { active = false; calls.push("deactivate"); }),
+      selection: vi.fn(async () => ({
+        runtime: "openclaw",
+        provider: "old-provider",
+        model: "old-model",
+        configured: true,
+      })),
+      configure: vi.fn(async (input) => {
+        if (!active) throw new Error("runtime must be active");
+        calls.push(`configure:${input.provider}/${input.model}`);
+        return {
+          runtime: "openclaw",
+          provider: input.provider,
+          model: input.model,
+          configured: true,
+        };
+      }),
+    });
+    const controller = createAgentRuntimeController({
+      homePath,
+      adapters: { hermes: fakeAdapter("hermes"), openclaw },
+      resumeDelivery: vi.fn(async (runtime) => {
+        if (runtime === "openclaw") throw new Error("delivery failed");
+      }),
+    });
+
+    await expect(controller.update({
+      runtime: "openclaw",
+      provider: "new-provider",
+      messagingModel: "new-model",
+      revision: 0,
+    })).rejects.toMatchObject({ kind: "runtime_switch_failed" });
+    expect(calls).toContain("configure:old-provider/old-model");
+    expect(calls.indexOf("configure:old-provider/old-model"))
+      .toBeLessThan(calls.indexOf("deactivate"));
+  });
+
   it("admits only one concurrent transition and leaves no lock file", async () => {
     const homePath = await createHome();
     let releasePrepare: (() => void) | undefined;

--- a/tests/gateway/agent-runtime-controller.test.ts
+++ b/tests/gateway/agent-runtime-controller.test.ts
@@ -177,6 +177,39 @@ describe("agent runtime controller", () => {
     expect(config.agent).toEqual({ messagingRuntime: "hermes", revision: 0 });
   });
 
+  it("gives the previous runtime a bounded host-scale rollback window", async () => {
+    const homePath = await createHome({
+      agent: { messagingRuntime: "hermes", revision: 0 },
+    });
+    let restored = false;
+    const hermes = fakeAdapter("hermes", {
+      activate: vi.fn(async (signal) => {
+        await new Promise<void>((resolve, reject) => {
+          const timer = setTimeout(resolve, 2_100);
+          signal.addEventListener("abort", () => {
+            clearTimeout(timer);
+            reject(signal.reason);
+          }, { once: true });
+        });
+        restored = true;
+      }),
+    });
+    const openclaw = fakeAdapter("openclaw", {
+      activate: vi.fn(async () => {
+        throw new Error("activation failed");
+      }),
+    });
+    const controller = createAgentRuntimeController({
+      homePath,
+      adapters: { hermes, openclaw },
+      timeoutMs: 3_000,
+    });
+
+    await expect(controller.update({ runtime: "openclaw", revision: 0 }))
+      .rejects.toMatchObject({ kind: "runtime_switch_failed" });
+    expect(restored).toBe(true);
+  });
+
   it("persists only a healthy switch and preserves unrelated config", async () => {
     const homePath = await createHome({
       unrelated: { preserved: true },

--- a/tests/gateway/agent-runtime-services.test.ts
+++ b/tests/gateway/agent-runtime-services.test.ts
@@ -1,0 +1,66 @@
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  createHermesAgentRuntimeServices,
+} from "../../packages/gateway/src/agent-config/runtime-services.js";
+
+const cleanupPaths: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(cleanupPaths.splice(0).map((path) => rm(path, {
+    recursive: true,
+    force: true,
+  })));
+});
+
+describe("Hermes agent runtime services", () => {
+  it("wires a catalog-backed model mutation through to owner config", async () => {
+    const homePath = await mkdtemp(join(tmpdir(), "agent-runtime-services-"));
+    cleanupPaths.push(homePath);
+    await mkdir(join(homePath, "system"), { recursive: true });
+    await writeFile(join(homePath, "system/config.json"), "{}");
+    let model = "hermes-3";
+    const readJson = vi.fn(async (path: string) => path === "/api/status"
+      ? { gateway_running: true }
+      : {
+          provider: "nous",
+          model,
+          providers: [{
+            slug: "nous",
+            name: "Nous",
+            authenticated: true,
+            auth_type: "oauth",
+            models: ["hermes-3", "hermes-4-405b"],
+          }],
+        });
+    const requestJson = vi.fn(async () => {
+      model = "hermes-4-405b";
+      return { ok: true };
+    });
+    const services = createHermesAgentRuntimeServices({
+      homePath,
+      client: { readJson, requestJson },
+    });
+
+    await expect(services.controller.update({
+      provider: "nous",
+      messagingModel: "hermes-4-405b",
+      revision: 0,
+    })).resolves.toMatchObject({
+      runtime: "hermes",
+      revision: 1,
+      selection: { provider: "nous", model: "hermes-4-405b" },
+    });
+
+    expect(requestJson).toHaveBeenCalledWith(
+      "/api/model/set",
+      expect.objectContaining({ method: "POST" }),
+      expect.any(AbortSignal),
+    );
+    await expect(readFile(join(homePath, "system/config.json"), "utf8"))
+      .resolves.toContain('"revision": 1');
+    await services.controller.close();
+  });
+});

--- a/tests/gateway/hermes-client.test.ts
+++ b/tests/gateway/hermes-client.test.ts
@@ -23,4 +23,28 @@ describe("Hermes dashboard client", () => {
       expect.objectContaining({ signal, redirect: "error" }),
     );
   });
+
+  it("sends bounded JSON mutations with the caller signal", async () => {
+    const fetchImpl = vi.fn(async () => Response.json({ ok: true }));
+    const client = createHermesDashboardClient({
+      baseUrl: "http://127.0.0.1:9119",
+      fetchImpl,
+    });
+    const signal = new AbortController().signal;
+
+    await expect(client.requestJson("/api/model/set", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ provider: "nous", model: "hermes-4-405b" }),
+    }, signal)).resolves.toEqual({ ok: true });
+
+    expect(fetchImpl).toHaveBeenCalledWith(
+      "http://127.0.0.1:9119/api/model/set",
+      expect.objectContaining({
+        method: "POST",
+        signal,
+        redirect: "error",
+      }),
+    );
+  });
 });

--- a/tests/gateway/hermes-runtime-adapter.test.ts
+++ b/tests/gateway/hermes-runtime-adapter.test.ts
@@ -137,4 +137,26 @@ describe("Hermes messaging runtime adapter", () => {
     );
     expect(source.invalidate).toHaveBeenCalledTimes(2);
   });
+
+  it("blocks private custom-provider base URLs before runtime mutation", async () => {
+    const current = snapshot();
+    const source = Object.assign(vi.fn(async () => snapshot({
+      providers: [{
+        ...current.providers[0]!,
+        authKind: "base_url",
+        supportedAuthKinds: ["base_url"],
+      }],
+    })), { invalidate: vi.fn() });
+    const requestJson = vi.fn(async () => ({ ok: true }));
+    const adapter = createHermesRuntimeAdapter({ source, requestJson });
+
+    await expect(adapter.configure({
+      provider: "nous",
+      model: "hermes-4-405b",
+      baseUrl: "https://127.0.0.1:8443/v1",
+    }, new AbortController().signal)).rejects.toMatchObject({
+      kind: "agent_config_invalid",
+    });
+    expect(requestJson).not.toHaveBeenCalled();
+  });
 });

--- a/tests/gateway/hermes-runtime-adapter.test.ts
+++ b/tests/gateway/hermes-runtime-adapter.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it, vi } from "vitest";
+import type { AgentRuntimeSettingsSnapshot } from "../../packages/gateway/src/agent-config/service.js";
+import { createHermesRuntimeAdapter } from "../../packages/gateway/src/agent-config/hermes-adapter.js";
+
+function snapshot(overrides: Partial<AgentRuntimeSettingsSnapshot> = {}): AgentRuntimeSettingsSnapshot {
+  return {
+    runtime: {
+      selected: "hermes",
+      options: [
+        {
+          id: "hermes",
+          displayName: "Hermes",
+          installState: "installed",
+          health: "healthy",
+          selectionState: "active",
+          configured: true,
+          capabilities: ["provider_catalog", "model_selection", "authentication"],
+        },
+        {
+          id: "openclaw",
+          displayName: "OpenClaw",
+          installState: "missing",
+          health: "stopped",
+          selectionState: "unavailable",
+          configured: false,
+          capabilities: ["install"],
+          setupAction: "install",
+        },
+      ],
+      transition: null,
+    },
+    providers: [{
+      id: "nous",
+      displayName: "Nous",
+      runtime: "hermes",
+      scopes: ["messaging"],
+      authKind: "oauth_login",
+      supportedAuthKinds: ["oauth_login"],
+      models: [{
+        id: "hermes-4-405b",
+        displayName: "Hermes 4 405B",
+        capabilities: ["tools"],
+        efforts: [],
+        available: true,
+      }],
+      authStatus: { state: "ready", authenticated: true, action: "none" },
+    }],
+    messaging: {
+      runtime: "hermes",
+      provider: "nous",
+      model: "hermes-4-405b",
+      configured: true,
+    },
+    ...overrides,
+  };
+}
+
+describe("Hermes messaging runtime adapter", () => {
+  it("configures only a catalog-backed provider/model and invalidates inventory", async () => {
+    const source = vi.fn(async () => snapshot());
+    const invalidate = vi.fn();
+    Object.assign(source, { invalidate });
+    const requestJson = vi.fn(async () => ({ ok: true }));
+    const adapter = createHermesRuntimeAdapter({ source, requestJson });
+
+    await expect(adapter.configure({
+      provider: "nous",
+      model: "hermes-4-405b",
+    }, new AbortController().signal)).resolves.toEqual(snapshot().messaging);
+
+    expect(requestJson).toHaveBeenCalledWith(
+      "/api/model/set",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({
+          scope: "main",
+          provider: "nous",
+          model: "hermes-4-405b",
+        }),
+      }),
+      expect.any(AbortSignal),
+    );
+    expect(invalidate).toHaveBeenCalledOnce();
+  });
+
+  it("rejects unknown selections and disallows base URLs for non-custom providers", async () => {
+    const source = Object.assign(vi.fn(async () => snapshot()), {
+      invalidate: vi.fn(),
+    });
+    const requestJson = vi.fn(async () => ({ ok: true }));
+    const adapter = createHermesRuntimeAdapter({ source, requestJson });
+    const signal = new AbortController().signal;
+
+    await expect(adapter.configure({
+      provider: "nous",
+      model: "missing",
+    }, signal)).rejects.toMatchObject({ kind: "not_configured" });
+    await expect(adapter.configure({
+      provider: "nous",
+      model: "hermes-4-405b",
+      baseUrl: "https://models.example.com/v1",
+    }, signal)).rejects.toMatchObject({ kind: "not_configured" });
+    expect(requestJson).not.toHaveBeenCalled();
+  });
+});

--- a/tests/gateway/hermes-runtime-adapter.test.ts
+++ b/tests/gateway/hermes-runtime-adapter.test.ts
@@ -42,6 +42,12 @@ function snapshot(overrides: Partial<AgentRuntimeSettingsSnapshot> = {}): AgentR
         capabilities: ["tools"],
         efforts: [],
         available: true,
+      }, {
+        id: "hermes-4-70b",
+        displayName: "Hermes 4 70B",
+        capabilities: ["tools"],
+        efforts: [],
+        available: true,
       }],
       authStatus: { state: "ready", authenticated: true, action: "none" },
     }],
@@ -101,5 +107,34 @@ describe("Hermes messaging runtime adapter", () => {
       baseUrl: "https://models.example.com/v1",
     }, signal)).rejects.toMatchObject({ kind: "not_configured" });
     expect(requestJson).not.toHaveBeenCalled();
+  });
+
+  it("restores the prior selection when post-mutation verification fails", async () => {
+    const source = Object.assign(vi.fn(async () => snapshot()), {
+      invalidate: vi.fn(),
+    });
+    const requestJson = vi.fn(async () => ({ ok: true }));
+    const adapter = createHermesRuntimeAdapter({ source, requestJson });
+
+    await expect(adapter.configure({
+      provider: "nous",
+      model: "hermes-4-70b",
+    }, new AbortController().signal)).rejects.toMatchObject({
+      kind: "invalid_response",
+    });
+
+    expect(requestJson).toHaveBeenNthCalledWith(2,
+      "/api/model/set",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({
+          scope: "main",
+          provider: "nous",
+          model: "hermes-4-405b",
+        }),
+      }),
+      expect.any(AbortSignal),
+    );
+    expect(source.invalidate).toHaveBeenCalledTimes(2);
   });
 });

--- a/tests/gateway/settings-desktop.test.ts
+++ b/tests/gateway/settings-desktop.test.ts
@@ -12,6 +12,7 @@ import { tmpdir } from "node:os";
 import { Hono } from "hono";
 import { AgentSettingsViewSchema } from "@matrix-os/contracts";
 import { createSettingsRoutes } from "../../packages/gateway/src/routes/settings.js";
+import { AgentConfigError } from "../../packages/gateway/src/agent-config/errors.js";
 
 function stubChannelManager() {
   return {
@@ -687,6 +688,41 @@ describe("Settings: desktop + theme + wallpapers", () => {
       expect(saved.channels.telegram.enabled).toBe(true);
     });
 
+    it("delegates legacy Chat patches to the runtime controller when available", async () => {
+      const updateKernel = vi.fn(async () => ({
+        model: "claude-haiku-4-5" as const,
+        effort: "max" as const,
+      }));
+      const routes = createSettingsRoutes({
+        homePath,
+        channelManager: stubChannelManager() as any,
+        agentRuntimeController: {
+          update: vi.fn(),
+          updateKernel,
+          reconcile: vi.fn(),
+          close: async () => {},
+        },
+      });
+      const runtimeApp = new Hono();
+      runtimeApp.route("/api/settings", routes);
+
+      const res = await runtimeApp.request("/api/settings/agent", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ model: "claude-haiku-4-5", effort: "max" }),
+      });
+
+      expect(res.status).toBe(200);
+      await expect(res.json()).resolves.toEqual({
+        ok: true,
+        kernel: { model: "claude-haiku-4-5", effort: "max" },
+      });
+      expect(updateKernel).toHaveBeenCalledWith({
+        model: "claude-haiku-4-5",
+        effort: "max",
+      });
+    });
+
     it("normalizes the response after partial updates to hand-edited kernel config", async () => {
       writeFileSync(
         join(homePath, "system/config.json"),
@@ -741,6 +777,142 @@ describe("Settings: desktop + theme + wallpapers", () => {
       expect(await res.json()).toEqual({ error: "runtime_unavailable" });
       expect(JSON.parse(readFileSync(join(homePath, "system/config.json"), "utf-8")))
         .toEqual({});
+    });
+
+    it("applies an extended update and returns the additive settings view", async () => {
+      const source = vi.fn(async () => ({
+        runtime: {
+          selected: "hermes" as const,
+          options: [{
+            id: "hermes" as const,
+            displayName: "Hermes",
+            installState: "installed" as const,
+            health: "healthy" as const,
+            selectionState: "active" as const,
+            configured: true,
+            capabilities: ["provider_catalog" as const, "model_selection" as const],
+          }, {
+            id: "openclaw" as const,
+            displayName: "OpenClaw",
+            installState: "missing" as const,
+            health: "stopped" as const,
+            selectionState: "unavailable" as const,
+            configured: false,
+            capabilities: ["install" as const],
+            setupAction: "install" as const,
+          }],
+          transition: null,
+        },
+        providers: [{
+          id: "nous",
+          displayName: "Nous",
+          runtime: "hermes" as const,
+          scopes: ["messaging" as const],
+          authKind: "oauth_login" as const,
+          supportedAuthKinds: ["oauth_login" as const],
+          models: [{
+            id: "hermes-4-405b",
+            displayName: "Hermes 4 405B",
+            capabilities: ["tools" as const],
+            efforts: [],
+            available: true,
+          }],
+          authStatus: {
+            state: "ready" as const,
+            authenticated: true,
+            action: "none" as const,
+          },
+        }],
+        messaging: {
+          runtime: "hermes" as const,
+          provider: "nous",
+          model: "hermes-4-405b",
+          configured: true,
+        },
+      }));
+      const update = vi.fn(async () => {
+        writeFileSync(join(homePath, "system/config.json"), JSON.stringify({
+          agent: { messagingRuntime: "hermes", revision: 1 },
+        }));
+        return {
+          revision: 1,
+          runtime: "hermes" as const,
+          selection: (await source()).messaging,
+        };
+      });
+      const routes = createSettingsRoutes({
+        homePath,
+        channelManager: stubChannelManager() as any,
+        agentRuntimeSource: source,
+        agentRuntimeController: { update, close: async () => {} },
+      });
+      const runtimeApp = new Hono();
+      runtimeApp.route("/api/settings", routes);
+
+      const res = await runtimeApp.request("/api/settings/agent", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          provider: "nous",
+          messagingModel: "hermes-4-405b",
+          revision: 0,
+        }),
+      });
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(AgentSettingsViewSchema.safeParse(body).success).toBe(true);
+      expect(body.revision).toBe(1);
+      expect(update).toHaveBeenCalledWith({
+        provider: "nous",
+        messagingModel: "hermes-4-405b",
+        revision: 0,
+      });
+    });
+
+    it("maps runtime conflicts and unexpected failures to safe errors", async () => {
+      const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+      const makeApp = (error: Error) => {
+        const routes = createSettingsRoutes({
+          homePath,
+          channelManager: stubChannelManager() as any,
+          agentRuntimeController: {
+            update: vi.fn(async () => { throw error; }),
+            close: async () => {},
+          },
+        });
+        const runtimeApp = new Hono();
+        runtimeApp.route("/api/settings", routes);
+        return runtimeApp;
+      };
+      const request = (runtimeApp: Hono) => runtimeApp.request(
+        "/api/settings/agent",
+        {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ runtime: "openclaw", revision: 0 }),
+        },
+      );
+
+      try {
+        const conflict = await request(makeApp(
+          new AgentConfigError("agent_config_conflict"),
+        ));
+        expect(conflict.status).toBe(409);
+        await expect(conflict.json()).resolves.toEqual({
+          error: "agent_config_conflict",
+        });
+
+        const canary = "sk-secret-runtime-route-canary";
+        const unavailable = await request(makeApp(new Error(canary)));
+        expect(unavailable.status).toBe(503);
+        await expect(unavailable.json()).resolves.toEqual({
+          error: "runtime_switch_failed",
+        });
+        expect(JSON.stringify(warn.mock.calls)).not.toContain(canary);
+      } finally {
+        warn.mockRestore();
+      }
     });
 
     it("rejects agent updates larger than 16 KiB before parsing", async () => {


### PR DESCRIPTION
## Summary

- add a bounded messaging-runtime controller with one exclusive owner-local
  transition lock, optimistic revision checks, health-gated activation, atomic
  config commit, rollback, startup reconciliation, and shutdown drain
- add a catalog-backed Hermes adapter that applies provider/model changes
  through the fixed loopback dashboard API and re-verifies the resulting
  selection after cache invalidation
- make additive `PUT /api/settings/agent` mutations operational while preserving
  the shipped legacy model/effort request and response shape
- serialize legacy Chat patches with runtime transitions so concurrent writes
  fail with a bounded conflict instead of losing either config domain
- fail closed when OpenClaw is absent, while allowing an owner to recover from a
  persisted absent runtime by switching back to healthy Hermes

## TDD and validation

- Initial controller, adapter, mutation-client, cache-invalidation, route, and
  composition tests were observed failing before their implementations existed.
- Review hardening reds covered startup reconciliation, symlink-safe marker
  handling, malformed marker caps, shutdown abort, stopped-target ordering,
  atomic combined Chat/messaging updates, concurrent legacy patches, and
  recovery from a persisted absent runtime.
- Exact-head controller suite: 19/19 passed, including red-to-green startup
  directory and transition-cleanup failures that prove reconciliation resolves
  and contains cleanup errors instead of aborting gateway creation, plus a
  primary-deadline-expiry regression proving rollback receives a fresh bounded
  cleanup signal, plus a host-scale rollback-window regression.
- Isolated shared terminal-registry fixture: 51/51 passed; its earlier parallel
  collision was reproduced as shared `/tmp/test-home` state and does not touch
  this diff.
- `bun run check:patterns`: 0 violations, 5 pre-existing warning groups.
- Gateway TypeScript strict check: passed on the exact review-fix head.
- Exact current-main stack-tip repository gate: 785 files passed, 3 skipped;
  8,497 tests passed, 20 skipped in 1,706.05 seconds.
- Exact validated head: `87e952b850d5b42fefc3a0544f80a97d1d30edea`.
- `git diff --check`: passed.
- React Doctor: not applicable; this PR has no React changes.

## Stack

- #960 — spec and OpenClaw spike
- #968 — stored conversation transcript
- #972 — per-message kernel selection
- #973 — truthful system-config diagnostics for the active-model resolver
- #974 — shared additive contracts
- #978 — unified gateway inventory
- this PR — runtime mutation and transition controller

## Invariants

- **Source of truth:** `$MATRIX_HOME/system/config.json` is authoritative for
  Matrix-selected messaging runtime, revision, and Chat model/effort. The active
  runtime remains authoritative for its provider/model selection; the gateway
  verifies that selection before returning success.
- **Lock/transaction scope:** Every extended mutation and production legacy
  Chat patch shares `system/agent-runtime/transition.lock`. The controller holds
  one bounded in-process operation plus the exclusive file lock, writes config
  through a sibling `wx` temp file and atomic rename, and releases markers/locks
  during success, rollback, timeout, and shutdown.
- **Acceptable orphan states:** If a target runtime had no prior configured
  provider/model and a later Matrix config commit fails, its runtime-owned
  selection may remain configured but inactive. It is never selected in Matrix
  config, never resumes delivery, and is deactivated during rollback. All
  previously configured selections are restored best-effort.
- **Auth source of truth:** Existing authenticated `/api/settings` registration
  remains authoritative. This slice adds no secret write route; Hermes calls are
  fixed loopback paths and clients receive only bounded provider-neutral error
  codes. No key, login payload, raw provider response, or raw error is returned.
- **Deferred scope:** The pinned OpenClaw installer/wrapper/systemd unit,
  authenticated OpenClaw RPC adapter, fixed host lifecycle controller, selected
  messaging-delivery generalization, provider credential mutation routes,
  diagnostics, shell UI, desktop UI, and public docs remain separate stack
  slices.
- OpenClaw cannot be selected until an installed adapter is registered; absent
  or unhealthy selection never changes Matrix config or Chat availability.
- Startup accepts only regular bounded transition markers, ignores symlinks,
  restores only a healthy persisted runtime, and otherwise leaves messaging
  delivery paused without affecting the Claude Agent SDK Chat kernel.
- Directory creation, stale-lock cleanup, lock acquisition, transition cleanup,
  and lock-release failures during startup reconciliation are caught at the
  orchestration boundary; they pause messaging best-effort and never reject
  gateway creation.
- External calls have caller deadlines, redirects are rejected, JSON responses
  are capped at 1 MiB, and mutating settings bodies remain capped at 16 KiB.
- Custom provider base URLs require HTTPS, reject credential/private/local/
  documentation ranges, and resolve only to public IPs under a 2-second budget.
  The residual Hermes-side DNS-rebinding/redirect risk is documented in code
  until that external runtime exposes address pinning.
- Runtime filesystem/marker mechanics and adapter types are extracted into
  focused modules; the transition controller is 499 lines. Future OpenClaw RPC
  and host lifecycle code remain separate modules/PRs.
- This PR has 2,252 additions and 40 deletions across 18 files, below the 3,000-addition/50-file
  limits, and will not merge below an exact-head Greptile 5/5 review.

## Rollout

- no merge or promotion requested
- live preview deployment and runtime switching verification occur only after
  the OpenClaw host and adapter layers join the stack
