### PR TITLE
feat(runtime): provision OpenClaw gateway

### DIFF
--- a/distro/customer-vps/cloud-init.yaml
+++ b/distro/customer-vps/cloud-init.yaml
@@ -589,7 +589,7 @@ runcmd:
     for required_bin in matrixctl matrix-db-backup.sh matrix-restore.sh matrix-owner-env matrix-gateway matrix-shell matrix-code matrix-sync-agent matrix-symphony matrix-symphony-control matrix-install-hermes; do
       chmod 0750 "/opt/matrix/bin/${required_bin}"
     done
-    for optional_bin in matrix-hermes-dashboard matrix-install-linux-tools matrix-install-developer-tools matrix-messaging-health matrix-messaging-backup matrix-messaging-restore; do
+    for optional_bin in matrix-hermes-dashboard matrix-install-openclaw matrix-openclaw-gateway matrix-agent-runtime-control matrix-install-linux-tools matrix-install-developer-tools matrix-messaging-health matrix-messaging-backup matrix-messaging-restore; do
       if [ -e "/opt/matrix/bin/${optional_bin}" ]; then
         chmod 0750 "/opt/matrix/bin/${optional_bin}"
       fi
@@ -627,6 +627,7 @@ runcmd:
     systemctl daemon-reload
     loginctl enable-linger matrix
     systemctl start "user@$(id -u matrix).service"
+    systemctl disable matrix-openclaw-gateway.service || true
     systemctl enable matrix-restore.service matrix-gateway.service matrix-shell.service matrix-code-server.service matrix-code.service matrix-sync-agent.service matrix-symphony.service matrix-hermes.service matrix-hermes-dashboard.service matrix-linux-tools.service matrix-developer-tools.service matrix-db-backup.timer nginx
     systemctl start matrix-restore.service matrix-gateway.service matrix-shell.service matrix-sync-agent.service matrix-symphony.service
     systemctl start --no-block matrix-code-server.service || echo "matrix-host: code-server runtime install will retry via systemd" >&2

--- a/distro/customer-vps/host-bin/matrix-agent-runtime-control
+++ b/distro/customer-vps/host-bin/matrix-agent-runtime-control
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ -r /opt/matrix/env/host.env ]; then
+  source /opt/matrix/env/host.env
+fi
+if [ -r /opt/matrix/bin/matrix-owner-env ]; then
+  source /opt/matrix/bin/matrix-owner-env
+  matrix_export_owner_env
+fi
+
+MATRIX_RUNTIME_HOME="${MATRIX_RUNTIME_HOME:-${MATRIX_HOME:-/home/matrix/home}}"
+MATRIX_NODE_PREFIX="${MATRIX_NODE_PREFIX:-/opt/matrix/runtime/node}"
+lock_dir="$MATRIX_RUNTIME_HOME/system/agent-runtime"
+install -d -m 0700 "$lock_dir"
+exec 9>"$lock_dir/host-control.lock"
+flock -w 30 9 || { printf '{"ok":false,"code":"runtime_busy"}\n'; exit 4; }
+
+is_active() {
+  sudo systemctl is-active --quiet "$1"
+}
+
+print_status() {
+  local hermes_installed=false hermes_running=false openclaw_installed=false openclaw_running=false
+  [ -x "$MATRIX_RUNTIME_HOME/.local/bin/hermes" ] && hermes_installed=true
+  [ -x "$MATRIX_NODE_PREFIX/bin/openclaw" ] && openclaw_installed=true
+  is_active matrix-hermes-dashboard.service && hermes_running=true
+  is_active matrix-openclaw-gateway.service && openclaw_running=true
+  printf '{"ok":true,"hermes":{"installed":%s,"running":%s},"openclaw":{"installed":%s,"running":%s}}\n' \
+    "$hermes_installed" "$hermes_running" "$openclaw_installed" "$openclaw_running"
+}
+
+wait_active() {
+  local unit="$1" deadline=$((SECONDS + 20))
+  while [ "$SECONDS" -lt "$deadline" ]; do
+    is_active "$unit" && return 0
+    sleep 0.5
+  done
+  return 1
+}
+
+openclaw_admission_ready() {
+  local memory_available_kib disk_available_kib
+  memory_available_kib="$(awk '/^MemAvailable:/ { print $2 }' /proc/meminfo)"
+  disk_available_kib="$(df -Pk "$MATRIX_RUNTIME_HOME" | awk 'NR == 2 { print $4 }')"
+  [ "$memory_available_kib" -ge 786432 ] && [ "$disk_available_kib" -ge 1048576 ]
+}
+
+switch_runtime() {
+  local runtime="$1" target_unit other_unit prior_active=false
+  case "$runtime" in
+    hermes)
+      [ -x "$MATRIX_RUNTIME_HOME/.local/bin/hermes" ] || { printf '{"ok":false,"code":"runtime_unavailable"}\n'; exit 3; }
+      target_unit=matrix-hermes-dashboard.service
+      other_unit=matrix-openclaw-gateway.service
+      ;;
+    openclaw)
+      [ -x "$MATRIX_NODE_PREFIX/bin/openclaw" ] || { printf '{"ok":false,"code":"runtime_unavailable"}\n'; exit 3; }
+      [ -s "$MATRIX_RUNTIME_HOME/system/agent-runtime/openclaw.env" ] || { printf '{"ok":false,"code":"auth_required"}\n'; exit 3; }
+      openclaw_admission_ready || { printf '{"ok":false,"code":"resources_unavailable"}\n'; exit 3; }
+      target_unit=matrix-openclaw-gateway.service
+      other_unit=matrix-hermes-dashboard.service
+      ;;
+  esac
+
+  is_active "$other_unit" && prior_active=true
+  sudo systemctl stop "$other_unit"
+  if ! sudo timeout 20 systemctl start "$target_unit" || ! wait_active "$target_unit"; then
+    sudo systemctl stop "$target_unit" || true
+    if [ "$prior_active" = true ]; then
+      sudo systemctl start "$other_unit" || true
+    fi
+    printf '{"ok":false,"code":"activation_failed"}\n'
+    exit 5
+  fi
+  printf '{"ok":true,"runtime":"%s"}\n' "$runtime"
+}
+
+case "${1:-}" in
+  status)
+    [ "$#" -eq 1 ] || { printf '{"ok":false,"code":"invalid_request"}\n'; exit 2; }
+    print_status
+    ;;
+  switch)
+    [ "$#" -eq 2 ] || { printf '{"ok":false,"code":"invalid_request"}\n'; exit 2; }
+    case "${2:-}" in
+      hermes) switch_runtime hermes ;;
+      openclaw) switch_runtime openclaw ;;
+      *) printf '{"ok":false,"code":"invalid_request"}\n'; exit 2 ;;
+    esac
+    ;;
+  *) printf '{"ok":false,"code":"invalid_request"}\n'; exit 2 ;;
+esac

--- a/distro/customer-vps/host-bin/matrix-agent-runtime-control
+++ b/distro/customer-vps/host-bin/matrix-agent-runtime-control
@@ -20,6 +20,10 @@ is_active() {
   sudo systemctl is-active --quiet "$1"
 }
 
+is_enabled() {
+  sudo systemctl is-enabled --quiet "$1"
+}
+
 print_status() {
   local hermes_installed=false hermes_running=false openclaw_installed=false openclaw_running=false
   [ -x "$MATRIX_RUNTIME_HOME/.local/bin/hermes" ] && hermes_installed=true
@@ -47,7 +51,7 @@ openclaw_admission_ready() {
 }
 
 switch_runtime() {
-  local runtime="$1" target_unit other_unit prior_active=false
+  local runtime="$1" target_unit other_unit prior_active=false prior_enabled=false
   case "$runtime" in
     hermes)
       [ -x "$MATRIX_RUNTIME_HOME/.local/bin/hermes" ] || { printf '{"ok":false,"code":"runtime_unavailable"}\n'; exit 3; }
@@ -65,10 +69,19 @@ switch_runtime() {
   esac
 
   is_active "$other_unit" && prior_active=true
-  sudo systemctl stop "$other_unit"
-  if ! sudo timeout 20 systemctl start "$target_unit" || ! wait_active "$target_unit"; then
-    sudo systemctl stop "$target_unit" || true
-    if [ "$prior_active" = true ]; then
+  is_enabled "$other_unit" && prior_enabled=true
+  if ! sudo timeout 20 systemctl disable --now "$other_unit"; then
+    printf '{"ok":false,"code":"deactivation_failed"}\n'
+    exit 5
+  fi
+  if ! sudo timeout 20 systemctl enable --now "$target_unit" || ! wait_active "$target_unit"; then
+    sudo timeout 20 systemctl disable --now "$target_unit" || true
+    if [ "$prior_enabled" = true ]; then
+      if ! sudo timeout 20 systemctl enable --now "$other_unit" || ! wait_active "$other_unit"; then
+        printf '{"ok":false,"code":"rollback_failed"}\n'
+        exit 6
+      fi
+    elif [ "$prior_active" = true ]; then
       if ! sudo timeout 20 systemctl start "$other_unit" || ! wait_active "$other_unit"; then
         printf '{"ok":false,"code":"rollback_failed"}\n'
         exit 6

--- a/distro/customer-vps/host-bin/matrix-agent-runtime-control
+++ b/distro/customer-vps/host-bin/matrix-agent-runtime-control
@@ -61,6 +61,7 @@ switch_runtime() {
       target_unit=matrix-openclaw-gateway.service
       other_unit=matrix-hermes-dashboard.service
       ;;
+    *) printf '{"ok":false,"code":"invalid_request"}\n'; exit 2 ;;
   esac
 
   is_active "$other_unit" && prior_active=true
@@ -68,7 +69,10 @@ switch_runtime() {
   if ! sudo timeout 20 systemctl start "$target_unit" || ! wait_active "$target_unit"; then
     sudo systemctl stop "$target_unit" || true
     if [ "$prior_active" = true ]; then
-      sudo systemctl start "$other_unit" || true
+      if ! sudo timeout 20 systemctl start "$other_unit" || ! wait_active "$other_unit"; then
+        printf '{"ok":false,"code":"rollback_failed"}\n'
+        exit 6
+      fi
     fi
     printf '{"ok":false,"code":"activation_failed"}\n'
     exit 5

--- a/distro/customer-vps/host-bin/matrix-agent-runtime-control
+++ b/distro/customer-vps/host-bin/matrix-agent-runtime-control
@@ -1,6 +1,31 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+validate_request() {
+  case "${1:-}" in
+    status)
+      [ "$#" -eq 1 ] || return 1
+      ;;
+    install|switch)
+      [ "$#" -eq 2 ] || return 1
+      case "${2:-}" in
+        hermes|openclaw) ;;
+        *) return 1 ;;
+      esac
+      ;;
+    *) return 1 ;;
+  esac
+}
+
+validate_request "$@" || { printf '{"ok":false,"code":"invalid_request"}\n'; exit 2; }
+
+# All mutations cross one validated, root-owned host-control boundary. This
+# keeps the visible terminal command unprivileged and gives the hardened sudo
+# policy one exact executable to allow instead of exposing installer commands.
+if [ "${1:-}" != status ] && [ "$(id -u)" -ne 0 ]; then
+  exec sudo -n /opt/matrix/bin/matrix-agent-runtime-control "$@"
+fi
+
 if [ -r /opt/matrix/env/host.env ]; then
   source /opt/matrix/env/host.env
 fi
@@ -11,17 +36,21 @@ fi
 
 MATRIX_RUNTIME_HOME="${MATRIX_RUNTIME_HOME:-${MATRIX_HOME:-/home/matrix/home}}"
 MATRIX_NODE_PREFIX="${MATRIX_NODE_PREFIX:-/opt/matrix/runtime/node}"
+MATRIX_RUNTIME_USER="${MATRIX_RUNTIME_USER:-matrix}"
+MATRIX_RUNTIME_GROUP="${MATRIX_RUNTIME_GROUP:-$MATRIX_RUNTIME_USER}"
+install_timeout_seconds=1810
 lock_dir="$MATRIX_RUNTIME_HOME/system/agent-runtime"
-install -d -m 0700 "$lock_dir"
+install -d -o "$MATRIX_RUNTIME_USER" -g "$MATRIX_RUNTIME_GROUP" -m 0700 "$lock_dir"
 exec 9>"$lock_dir/host-control.lock"
+chown "$MATRIX_RUNTIME_USER:$MATRIX_RUNTIME_GROUP" "$lock_dir/host-control.lock" 2>/dev/null || true
 flock -w 30 9 || { printf '{"ok":false,"code":"runtime_busy"}\n'; exit 4; }
 
 is_active() {
-  sudo systemctl is-active --quiet "$1"
+  systemctl is-active --quiet "$1"
 }
 
 is_enabled() {
-  sudo systemctl is-enabled --quiet "$1"
+  systemctl is-enabled --quiet "$1"
 }
 
 print_status() {
@@ -50,6 +79,31 @@ openclaw_admission_ready() {
   [ "$memory_available_kib" -ge 786432 ] && [ "$disk_available_kib" -ge 1048576 ]
 }
 
+install_runtime() {
+  local runtime="$1" installer executable
+  case "$runtime" in
+    hermes)
+      installer=/opt/matrix/bin/matrix-install-hermes
+      executable="$MATRIX_RUNTIME_HOME/.local/bin/hermes"
+      ;;
+    openclaw)
+      installer=/opt/matrix/bin/matrix-install-openclaw
+      executable="$MATRIX_NODE_PREFIX/bin/openclaw"
+      ;;
+    *) printf '{"ok":false,"code":"invalid_request"}\n'; exit 2 ;;
+  esac
+
+  [ -x "$installer" ] || { printf '{"ok":false,"code":"runtime_unavailable"}\n'; exit 3; }
+  if [ ! -x "$executable" ]; then
+    if ! timeout "$install_timeout_seconds" "$installer"; then
+      printf '{"ok":false,"code":"install_failed"}\n'
+      exit 5
+    fi
+  fi
+  [ -x "$executable" ] || { printf '{"ok":false,"code":"install_failed"}\n'; exit 5; }
+  printf '{"ok":true,"runtime":"%s","installed":true}\n' "$runtime"
+}
+
 switch_runtime() {
   local runtime="$1" target_unit other_unit prior_active=false prior_enabled=false
   case "$runtime" in
@@ -70,19 +124,19 @@ switch_runtime() {
 
   is_active "$other_unit" && prior_active=true
   is_enabled "$other_unit" && prior_enabled=true
-  if ! sudo timeout 20 systemctl disable --now "$other_unit"; then
+  if ! timeout 20 systemctl disable --now "$other_unit"; then
     printf '{"ok":false,"code":"deactivation_failed"}\n'
     exit 5
   fi
-  if ! sudo timeout 20 systemctl enable --now "$target_unit" || ! wait_active "$target_unit"; then
-    sudo timeout 20 systemctl disable --now "$target_unit" || true
+  if ! timeout 20 systemctl enable --now "$target_unit" || ! wait_active "$target_unit"; then
+    timeout 20 systemctl disable --now "$target_unit" || true
     if [ "$prior_enabled" = true ]; then
-      if ! sudo timeout 20 systemctl enable --now "$other_unit" || ! wait_active "$other_unit"; then
+      if ! timeout 20 systemctl enable --now "$other_unit" || ! wait_active "$other_unit"; then
         printf '{"ok":false,"code":"rollback_failed"}\n'
         exit 6
       fi
     elif [ "$prior_active" = true ]; then
-      if ! sudo timeout 20 systemctl start "$other_unit" || ! wait_active "$other_unit"; then
+      if ! timeout 20 systemctl start "$other_unit" || ! wait_active "$other_unit"; then
         printf '{"ok":false,"code":"rollback_failed"}\n'
         exit 6
       fi
@@ -95,11 +149,12 @@ switch_runtime() {
 
 case "${1:-}" in
   status)
-    [ "$#" -eq 1 ] || { printf '{"ok":false,"code":"invalid_request"}\n'; exit 2; }
     print_status
     ;;
+  install)
+    install_runtime "$2"
+    ;;
   switch)
-    [ "$#" -eq 2 ] || { printf '{"ok":false,"code":"invalid_request"}\n'; exit 2; }
     case "${2:-}" in
       hermes) switch_runtime hermes ;;
       openclaw) switch_runtime openclaw ;;

--- a/distro/customer-vps/host-bin/matrix-install-openclaw
+++ b/distro/customer-vps/host-bin/matrix-install-openclaw
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+MATRIX_RUNTIME_USER="${MATRIX_RUNTIME_USER:-matrix}"
+if [ -r /opt/matrix/env/host.env ]; then
+  source /opt/matrix/env/host.env
+fi
+if [ -r /opt/matrix/bin/matrix-owner-env ]; then
+  source /opt/matrix/bin/matrix-owner-env
+  matrix_export_owner_env
+fi
+
+MATRIX_RUNTIME_HOME="${MATRIX_RUNTIME_HOME:-${MATRIX_HOME:-/home/matrix/home}}"
+MATRIX_NODE_PREFIX="${MATRIX_NODE_PREFIX:-/opt/matrix/runtime/node}"
+OPENCLAW_VERSION="${OPENCLAW_VERSION:-2026.7.1}"
+OPENCLAW_SHA512="${OPENCLAW_SHA512:-81efd7b2cf7d0870233cbfe29261ff505a223ab8dcc43078b16df2f66872083f9d616df0cd5ed329b015764ad7160006d9dd818e92687cff7bcd467eba6c68f2}"
+OPENCLAW_TARBALL_URL="${OPENCLAW_TARBALL_URL:-https://registry.npmjs.org/openclaw/-/openclaw-${OPENCLAW_VERSION}.tgz}"
+OPENCLAW_STATE_DIR="${OPENCLAW_STATE_DIR:-$MATRIX_RUNTIME_HOME/.openclaw}"
+OPENCLAW_ENV_FILE="${OPENCLAW_ENV_FILE:-$MATRIX_RUNTIME_HOME/system/agent-runtime/openclaw.env}"
+
+log() {
+  printf 'matrix-install-openclaw: %s\n' "$*"
+}
+
+check_admission() {
+  local cpu_count memory_total_kib memory_available_kib disk_available_kib
+  cpu_count="$(getconf _NPROCESSORS_ONLN)"
+  memory_total_kib="$(awk '/^MemTotal:/ { print $2 }' /proc/meminfo)"
+  memory_available_kib="$(awk '/^MemAvailable:/ { print $2 }' /proc/meminfo)"
+  disk_available_kib="$(df -Pk "$MATRIX_RUNTIME_HOME" | awk 'NR == 2 { print $4 }')"
+
+  if [ "$cpu_count" -lt 2 ] || [ "$memory_total_kib" -lt 4194304 ]; then
+    echo "matrix-install-openclaw: computer does not meet the runtime baseline" >&2
+    exit 2
+  fi
+  if [ "$memory_available_kib" -lt 786432 ] || [ "$disk_available_kib" -lt 1048576 ]; then
+    echo "matrix-install-openclaw: insufficient available resources" >&2
+    exit 2
+  fi
+}
+
+check_node_version() {
+  local node_major node_minor
+  node_major="$($MATRIX_NODE_PREFIX/bin/node -p 'process.versions.node.split(".")[0]')"
+  node_minor="$($MATRIX_NODE_PREFIX/bin/node -p 'process.versions.node.split(".")[1]')"
+  if [ "$node_major" -ne 24 ] || { [ "$node_major" -eq 24 ] && [ "$node_minor" -lt 15 ]; }; then
+    echo "matrix-install-openclaw: bundled Node runtime is incompatible" >&2
+    exit 2
+  fi
+}
+
+if ! id "$MATRIX_RUNTIME_USER" >/dev/null 2>&1; then
+  echo "matrix-install-openclaw: runtime user is unavailable" >&2
+  exit 1
+fi
+
+check_node_version
+check_admission
+
+install -d -o "$MATRIX_RUNTIME_USER" -g "$MATRIX_RUNTIME_USER" -m 0700 \
+  "$OPENCLAW_STATE_DIR" "$(dirname "$OPENCLAW_ENV_FILE")"
+
+tmp_dir="$(mktemp -d /tmp/matrix-openclaw-install.XXXXXX)"
+cleanup() {
+  find "$tmp_dir" -mindepth 1 -maxdepth 1 -type l -delete 2>/dev/null || true
+  rm -rf "$tmp_dir"
+}
+trap cleanup EXIT INT TERM
+archive="$tmp_dir/openclaw.tgz"
+
+curl --fail --location --retry 3 --retry-delay 5 --retry-all-errors \
+  --connect-timeout 10 --max-time 180 \
+  "$OPENCLAW_TARBALL_URL" -o "$archive"
+printf '%s  %s\n' "$OPENCLAW_SHA512" "$archive" >"$tmp_dir/openclaw.sha512"
+sha512sum -c "$tmp_dir/openclaw.sha512"
+tar -tzf "$archive" package/npm-shrinkwrap.json package/package.json package/openclaw.mjs >/dev/null
+
+log "installing pinned OpenClaw runtime"
+timeout 300 sudo -H -u "$MATRIX_RUNTIME_USER" env \
+  HOME="$MATRIX_RUNTIME_HOME" \
+  OPENCLAW_STATE_DIR="$OPENCLAW_STATE_DIR" \
+  PATH="$MATRIX_NODE_PREFIX/bin:/usr/local/bin:/usr/bin:/bin" \
+  "$MATRIX_NODE_PREFIX/bin/npm" install --global --prefix "$MATRIX_NODE_PREFIX" "$archive"
+
+test -x "$MATRIX_NODE_PREFIX/bin/openclaw"
+
+if [ ! -s "$OPENCLAW_ENV_FILE" ]; then
+  token="$(openssl rand -hex 32)"
+  token_tmp="$(mktemp "$(dirname "$OPENCLAW_ENV_FILE")/.openclaw.env.XXXXXX")"
+  printf 'OPENCLAW_GATEWAY_TOKEN=%s\n' "$token" >"$token_tmp"
+  chown "$MATRIX_RUNTIME_USER:$MATRIX_RUNTIME_USER" "$token_tmp"
+  chmod 0600 "$token_tmp"
+  mv -f "$token_tmp" "$OPENCLAW_ENV_FILE"
+fi
+
+log "OpenClaw ${OPENCLAW_VERSION} installed"

--- a/distro/customer-vps/host-bin/matrix-install-openclaw
+++ b/distro/customer-vps/host-bin/matrix-install-openclaw
@@ -22,6 +22,14 @@ log() {
   printf 'matrix-install-openclaw: %s\n' "$*"
 }
 
+run_installer_as_runtime_user() {
+  if [ "$(id -u)" = "0" ] && command -v setpriv >/dev/null 2>&1; then
+    timeout 300 setpriv --reuid "$MATRIX_RUNTIME_USER" --regid "$MATRIX_RUNTIME_USER" --init-groups "$@"
+    return
+  fi
+  timeout 300 sudo -H -u "$MATRIX_RUNTIME_USER" "$@"
+}
+
 check_admission() {
   local cpu_count memory_total_kib memory_available_kib disk_available_kib
   cpu_count="$(getconf _NPROCESSORS_ONLN)"
@@ -29,7 +37,7 @@ check_admission() {
   memory_available_kib="$(awk '/^MemAvailable:/ { print $2 }' /proc/meminfo)"
   disk_available_kib="$(df -Pk "$MATRIX_RUNTIME_HOME" | awk 'NR == 2 { print $4 }')"
 
-  if [ "$cpu_count" -lt 2 ] || [ "$memory_total_kib" -lt 4194304 ]; then
+  if [ "$cpu_count" -lt 2 ] || [ "$memory_total_kib" -lt 3670016 ]; then
     echo "matrix-install-openclaw: computer does not meet the runtime baseline" >&2
     exit 2
   fi
@@ -74,9 +82,12 @@ curl --fail --location --retry 3 --retry-delay 5 --retry-all-errors \
 printf '%s  %s\n' "$OPENCLAW_SHA512" "$archive" >"$tmp_dir/openclaw.sha512"
 sha512sum -c "$tmp_dir/openclaw.sha512"
 tar -tzf "$archive" package/npm-shrinkwrap.json package/package.json package/openclaw.mjs >/dev/null
+chown "root:$MATRIX_RUNTIME_USER" "$tmp_dir" "$archive"
+chmod 0750 "$tmp_dir"
+chmod 0640 "$archive"
 
 log "installing pinned OpenClaw runtime"
-timeout 300 sudo -H -u "$MATRIX_RUNTIME_USER" env \
+run_installer_as_runtime_user env \
   HOME="$MATRIX_RUNTIME_HOME" \
   OPENCLAW_STATE_DIR="$OPENCLAW_STATE_DIR" \
   PATH="$MATRIX_NODE_PREFIX/bin:/usr/local/bin:/usr/bin:/bin" \

--- a/distro/customer-vps/host-bin/matrix-openclaw-gateway
+++ b/distro/customer-vps/host-bin/matrix-openclaw-gateway
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ -r /opt/matrix/env/host.env ]; then
+  source /opt/matrix/env/host.env
+fi
+if [ -r /opt/matrix/bin/matrix-owner-env ]; then
+  source /opt/matrix/bin/matrix-owner-env
+  matrix_export_owner_env
+fi
+
+MATRIX_RUNTIME_HOME="${MATRIX_RUNTIME_HOME:-${MATRIX_HOME:-/home/matrix/home}}"
+MATRIX_NODE_PREFIX="${MATRIX_NODE_PREFIX:-/opt/matrix/runtime/node}"
+OPENCLAW_STATE_DIR="${OPENCLAW_STATE_DIR:-$MATRIX_RUNTIME_HOME/.openclaw}"
+OPENCLAW_CONFIG_PATH="${OPENCLAW_CONFIG_PATH:-$OPENCLAW_STATE_DIR/openclaw.json}"
+OPENCLAW_ENV_FILE="${OPENCLAW_ENV_FILE:-$MATRIX_RUNTIME_HOME/system/agent-runtime/openclaw.env}"
+OPENCLAW_BIN="${OPENCLAW_BIN:-$MATRIX_NODE_PREFIX/bin/openclaw}"
+
+if [ ! -x "$OPENCLAW_BIN" ]; then
+  echo "matrix-openclaw-gateway: runtime is not installed" >&2
+  exit 3
+fi
+if [ ! -r "$OPENCLAW_ENV_FILE" ]; then
+  echo "matrix-openclaw-gateway: runtime authentication is unavailable" >&2
+  exit 3
+fi
+IFS= read -r token_line <"$OPENCLAW_ENV_FILE" || true
+if [[ ! "$token_line" =~ ^OPENCLAW_GATEWAY_TOKEN=[A-Fa-f0-9]{64}$ ]]; then
+  echo "matrix-openclaw-gateway: runtime authentication is unavailable" >&2
+  exit 3
+fi
+OPENCLAW_GATEWAY_TOKEN="${token_line#OPENCLAW_GATEWAY_TOKEN=}"
+: "${OPENCLAW_GATEWAY_TOKEN:?matrix-openclaw-gateway: runtime authentication is unavailable}"
+
+install -d -m 0700 "$OPENCLAW_STATE_DIR"
+if [ ! -e "$OPENCLAW_CONFIG_PATH" ]; then
+  config_tmp="$(mktemp "$OPENCLAW_STATE_DIR/.openclaw.json.XXXXXX")"
+  cleanup() { rm -f "$config_tmp"; }
+  trap cleanup EXIT INT TERM
+  cat >"$config_tmp" <<'JSON'
+{
+  "gateway": {
+    "mode": "local",
+    "bind": "loopback",
+    "port": 18789,
+    "auth": { "mode": "token" }
+  },
+  "plugins": { "allow": [] },
+  "tools": {
+    "deny": ["gateway", "cron", "sessions_spawn", "sessions_send"]
+  }
+}
+JSON
+  chmod 0600 "$config_tmp"
+  mv -f "$config_tmp" "$OPENCLAW_CONFIG_PATH"
+  trap - EXIT INT TERM
+fi
+
+if ! "$MATRIX_NODE_PREFIX/bin/node" - "$OPENCLAW_CONFIG_PATH" <<'NODE'
+const { readFileSync } = require("node:fs");
+const config = JSON.parse(readFileSync(process.argv[2], "utf8"));
+const expectedDenied = ["cron", "gateway", "sessions_send", "sessions_spawn"];
+const actualDenied = Array.isArray(config.tools?.deny) ? [...config.tools.deny].sort() : [];
+if (
+  config.gateway?.mode !== "local" ||
+  config.gateway?.bind !== "loopback" ||
+  config.gateway?.port !== 18789 ||
+  config.gateway?.auth?.mode !== "token" ||
+  !Array.isArray(config.plugins?.allow) ||
+  config.plugins.allow.length !== 0 ||
+  JSON.stringify(actualDenied) !== JSON.stringify(expectedDenied)
+) {
+  process.exit(1);
+}
+NODE
+then
+  echo "matrix-openclaw-gateway: runtime policy validation failed" >&2
+  exit 3
+fi
+
+# Matrix owns gateway.mode local, gateway.bind loopback,
+# gateway.auth.mode token, plugins.allow, and tools.deny at bootstrap.
+export HOME="$MATRIX_RUNTIME_HOME"
+export OPENCLAW_STATE_DIR OPENCLAW_CONFIG_PATH OPENCLAW_GATEWAY_TOKEN
+exec "$OPENCLAW_BIN" gateway run --bind loopback --port 18789 --auth token

--- a/distro/customer-vps/host-bin/matrix-openclaw-gateway
+++ b/distro/customer-vps/host-bin/matrix-openclaw-gateway
@@ -68,6 +68,8 @@ if (
   config.gateway?.auth?.mode !== "token" ||
   !Array.isArray(config.plugins?.allow) ||
   config.plugins.allow.length !== 0 ||
+  !(config.tools?.allow === undefined ||
+    (Array.isArray(config.tools.allow) && config.tools.allow.length === 0)) ||
   JSON.stringify(actualDenied) !== JSON.stringify(expectedDenied)
 ) {
   process.exit(1);

--- a/distro/customer-vps/systemd/matrix-openclaw-gateway.service
+++ b/distro/customer-vps/systemd/matrix-openclaw-gateway.service
@@ -1,0 +1,38 @@
+[Unit]
+Description=Matrix OS OpenClaw messaging gateway (loopback)
+After=network-online.target
+Wants=network-online.target
+ConditionPathExists=/opt/matrix/bin/matrix-openclaw-gateway
+ConditionFileIsExecutable=/opt/matrix/runtime/node/bin/openclaw
+StartLimitIntervalSec=5min
+StartLimitBurst=3
+
+[Service]
+Type=simple
+User=matrix
+Group=matrix
+EnvironmentFile=/opt/matrix/env/host.env
+WorkingDirectory=/home/matrix/home
+ExecStart=/opt/matrix/bin/matrix-openclaw-gateway
+Restart=on-failure
+RestartSec=10
+TimeoutStartSec=45
+TimeoutStopSec=30
+MemoryMax=1G
+TasksMax=256
+LimitNOFILE=4096
+NoNewPrivileges=true
+PrivateTmp=true
+PrivateDevices=true
+ProtectSystem=strict
+ProtectHome=read-only
+ReadWritePaths=/home/matrix/home/.openclaw /home/matrix/home/system/agent-runtime
+ProtectKernelTunables=true
+ProtectKernelModules=true
+ProtectControlGroups=true
+LockPersonality=true
+RestrictSUIDSGID=true
+RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6
+
+[Install]
+WantedBy=multi-user.target

--- a/scripts/build-host-bundle.sh
+++ b/scripts/build-host-bundle.sh
@@ -5,7 +5,7 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 DIST_DIR="${HOST_BUNDLE_DIST_DIR:-$ROOT_DIR/dist/host-bundle}"
 STAGE_DIR="$DIST_DIR/stage"
 BUNDLE_NAME="matrix-host-bundle.tar.gz"
-NODE_VERSION="${HOST_BUNDLE_NODE_VERSION:-$(node -p 'process.versions.node')}"
+NODE_VERSION="${HOST_BUNDLE_NODE_VERSION:-24.18.0}"
 NODE_DIST="node-v${NODE_VERSION}-linux-x64"
 NODE_ARCHIVE="${NODE_DIST}.tar.xz"
 NODE_BASE_URL="https://nodejs.org/dist/v${NODE_VERSION}"
@@ -82,7 +82,7 @@ cp -a "$ROOT_DIR/distro/customer-vps/host-bin/." "$STAGE_DIR/bin/"
 cp -a "$ROOT_DIR/distro/customer-vps/systemd/." "$STAGE_DIR/systemd/"
 # The bundle is usually extracted as root:root during in-place upgrades, while
 # the systemd units execute these wrappers as the matrix user.
-chmod 0755 "$STAGE_DIR/bin/matrix-owner-env" "$STAGE_DIR/bin/matrix-gateway" "$STAGE_DIR/bin/matrix-agent-bridge" "$STAGE_DIR/bin/matrix-sync-bundled-home-assets" "$STAGE_DIR/bin/matrix-shell" "$STAGE_DIR/bin/matrix-code" "$STAGE_DIR/bin/matrix-sync-agent" "$STAGE_DIR/bin/matrix-symphony" "$STAGE_DIR/bin/matrix-symphony-control" "$STAGE_DIR/bin/matrix-update" "$STAGE_DIR/bin/matrix-ensure-swap" "$STAGE_DIR/bin/matrix-install-hermes" "$STAGE_DIR/bin/matrix-hermes-dashboard" "$STAGE_DIR/bin/matrix-install-linux-tools" "$STAGE_DIR/bin/matrix-install-tool-pack" "$STAGE_DIR/bin/matrix-install-developer-tools" "$STAGE_DIR/bin/matrix-messaging-health" "$STAGE_DIR/bin/matrix-messaging-backup" "$STAGE_DIR/bin/matrix-messaging-restore" "$STAGE_DIR/bin/zellij" "$STAGE_DIR/runtime/node/bin/gh"
+chmod 0755 "$STAGE_DIR/bin/matrix-owner-env" "$STAGE_DIR/bin/matrix-gateway" "$STAGE_DIR/bin/matrix-agent-bridge" "$STAGE_DIR/bin/matrix-sync-bundled-home-assets" "$STAGE_DIR/bin/matrix-shell" "$STAGE_DIR/bin/matrix-code" "$STAGE_DIR/bin/matrix-sync-agent" "$STAGE_DIR/bin/matrix-symphony" "$STAGE_DIR/bin/matrix-symphony-control" "$STAGE_DIR/bin/matrix-update" "$STAGE_DIR/bin/matrix-ensure-swap" "$STAGE_DIR/bin/matrix-install-hermes" "$STAGE_DIR/bin/matrix-hermes-dashboard" "$STAGE_DIR/bin/matrix-install-openclaw" "$STAGE_DIR/bin/matrix-openclaw-gateway" "$STAGE_DIR/bin/matrix-agent-runtime-control" "$STAGE_DIR/bin/matrix-install-linux-tools" "$STAGE_DIR/bin/matrix-install-tool-pack" "$STAGE_DIR/bin/matrix-install-developer-tools" "$STAGE_DIR/bin/matrix-messaging-health" "$STAGE_DIR/bin/matrix-messaging-backup" "$STAGE_DIR/bin/matrix-messaging-restore" "$STAGE_DIR/bin/zellij" "$STAGE_DIR/runtime/node/bin/gh"
 
 cp -a "$ROOT_DIR/node_modules" "$STAGE_DIR/app/node_modules"
 install -m 0755 "$DIST_DIR/$GH_DIST/bin/gh" "$STAGE_DIR/app/node_modules/.bin/gh"

--- a/specs/107-agent-runtime-config/research.md
+++ b/specs/107-agent-runtime-config/research.md
@@ -16,10 +16,21 @@
 
 ### Tested artifact
 
-- Package: `openclaw@2026.6.11`, the current stable npm release on 2026-07-13.
-- Host: Node.js 24.14.1, pnpm 10.33.4.
+- Package: `openclaw@2026.7.1`, the current stable npm release re-verified on 2026-07-13.
+- Registry artifact: `openclaw-2026.7.1.tgz`, SHA-512
+  `81efd7b2cf7d0870233cbfe29261ff505a223ab8dcc43078b16df2f66872083f9d616df0cd5ed329b015764ad7160006d9dd818e92687cff7bcd467eba6c68f2`.
+- The published artifact includes `npm-shrinkwrap.json`; the optional host
+  installer verifies the outer tarball before npm installs the pinned,
+  shrinkwrapped dependency graph.
+- Required Node engine: `>=24.15.0 <25` on Matrix's Node 24 line. Host bundles
+  therefore default to the official Node.js 24.18.0 archive while retaining an
+  explicit build override.
+- Spike host: Node.js 24.14.1, pnpm 10.33.4. The newer release correctly fails
+  its engine admission on that host, which established the bundle-runtime bump.
 - Throwaway install root and state directory under `/tmp`; both removed after the spike.
-- CLI reported `OpenClaw 2026.6.11 (e085fa1)`.
+- The prior live process spike used 2026.6.11. The 2026.7.1 package manifest,
+  binary entrypoint, shrinkwrap, lifecycle scripts, and engine range were
+  re-verified from the exact registry tarball before host implementation.
 
 ### Process and network model
 
@@ -148,8 +159,12 @@ stable promotion.
 
 ## Source Links
 
-- OpenClaw gateway configuration: https://docs.openclaw.ai/gateway/configuration
-- OpenClaw gateway operation: https://docs.openclaw.ai/gateway
+- OpenClaw gateway configuration: https://docs.openclaw.ai/gateway/configuration-reference
+- OpenClaw gateway operation: https://docs.openclaw.ai/cli/gateway
+- OpenClaw gateway protocol: https://docs.openclaw.ai/gateway/protocol
+- OpenClaw administrative RPC: https://docs.openclaw.ai/gateway/admin-http-rpc
+- OpenClaw plugin policy: https://docs.openclaw.ai/plugins
+- OpenClaw tool policy: https://docs.openclaw.ai/gateway/config-tools
 - OpenClaw model CLI and authentication: https://docs.openclaw.ai/cli/models
 - OpenClaw gateway authentication: https://docs.openclaw.ai/gateway/authentication
 - OpenClaw Matrix channel: https://docs.openclaw.ai/channels/matrix

--- a/tests/deploy/customer-vps/openclaw-systemd.test.ts
+++ b/tests/deploy/customer-vps/openclaw-systemd.test.ts
@@ -48,6 +48,8 @@ describe("customer VPS OpenClaw runtime", () => {
     expect(wrapper).toContain("gateway.auth.mode token");
     expect(wrapper).toContain("plugins.allow");
     expect(wrapper).toContain("tools.deny");
+    expect(wrapper).toContain("config.tools?.allow === undefined");
+    expect(wrapper).toContain("config.tools.allow.length === 0");
     expect(wrapper).toContain("runtime policy validation failed");
     expect(wrapper).toContain("gateway run --bind loopback --port 18789 --auth token");
     expect(wrapper).not.toMatch(/--token[ =]/);
@@ -85,6 +87,12 @@ describe("customer VPS OpenClaw runtime", () => {
     expect(controller).toContain("timeout 20");
     expect(controller).toContain("MemAvailable");
     expect(controller).toContain("1048576");
+    const switchBody = controller.slice(
+      controller.indexOf("switch_runtime()"),
+      controller.indexOf('is_active "$other_unit"'),
+    );
+    expect(switchBody).toContain('*) printf \'{"ok":false,"code":"invalid_request"}\\n\'; exit 2 ;;');
+    expect(controller).toContain('"code":"rollback_failed"');
     expect(controller).not.toContain("eval ");
     expect(controller).not.toContain('systemctl "$');
   });

--- a/tests/deploy/customer-vps/openclaw-systemd.test.ts
+++ b/tests/deploy/customer-vps/openclaw-systemd.test.ts
@@ -1,0 +1,114 @@
+import { access, readFile } from "node:fs/promises";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import { describe, expect, it } from "vitest";
+
+const execFileAsync = promisify(execFile);
+
+const installerPath = "distro/customer-vps/host-bin/matrix-install-openclaw";
+const wrapperPath = "distro/customer-vps/host-bin/matrix-openclaw-gateway";
+const controllerPath = "distro/customer-vps/host-bin/matrix-agent-runtime-control";
+const unitPath = "distro/customer-vps/systemd/matrix-openclaw-gateway.service";
+
+describe("customer VPS OpenClaw runtime", () => {
+  it("pins and integrity-checks the optional OpenClaw install", async () => {
+    const installer = await readFile(installerPath, "utf8");
+
+    expect(installer).toContain('OPENCLAW_VERSION="${OPENCLAW_VERSION:-2026.7.1}"');
+    expect(installer).toContain(
+      'OPENCLAW_SHA512="${OPENCLAW_SHA512:-81efd7b2cf7d0870233cbfe29261ff505a223ab8dcc43078b16df2f66872083f9d616df0cd5ed329b015764ad7160006d9dd818e92687cff7bcd467eba6c68f2}"',
+    );
+    expect(installer).toContain("registry.npmjs.org/openclaw/-/openclaw-${OPENCLAW_VERSION}.tgz");
+    expect(installer).toContain("--connect-timeout 10 --max-time 180");
+    expect(installer).toContain("sha512sum -c");
+    expect(installer).toContain("timeout 300");
+    expect(installer).toContain('[ "$node_major" -eq 24 ] && [ "$node_minor" -lt 15 ]');
+    expect(installer).toContain("npm-shrinkwrap.json");
+    expect(installer).not.toContain("@latest");
+  });
+
+  it("fails admission before downloading on constrained hosts", async () => {
+    const installer = await readFile(installerPath, "utf8");
+
+    expect(installer).toContain("MemAvailable");
+    expect(installer).toContain("786432");
+    expect(installer).toContain("1048576");
+    expect(installer.indexOf("check_admission")).toBeLessThan(installer.indexOf("curl --fail"));
+  });
+
+  it("keeps gateway authentication out of argv and binds to loopback", async () => {
+    const wrapper = await readFile(wrapperPath, "utf8");
+
+    expect(wrapper).toContain('OPENCLAW_ENV_FILE="${OPENCLAW_ENV_FILE:-$MATRIX_RUNTIME_HOME/system/agent-runtime/openclaw.env}"');
+    expect(wrapper).toContain("OPENCLAW_GATEWAY_TOKEN=[A-Fa-f0-9]{64}");
+    expect(wrapper).not.toContain('source "$OPENCLAW_ENV_FILE"');
+    expect(wrapper).toContain(': "${OPENCLAW_GATEWAY_TOKEN:?');
+    expect(wrapper).toContain("gateway.mode local");
+    expect(wrapper).toContain("gateway.bind loopback");
+    expect(wrapper).toContain("gateway.auth.mode token");
+    expect(wrapper).toContain("plugins.allow");
+    expect(wrapper).toContain("tools.deny");
+    expect(wrapper).toContain("runtime policy validation failed");
+    expect(wrapper).toContain("gateway run --bind loopback --port 18789 --auth token");
+    expect(wrapper).not.toMatch(/--token[ =]/);
+  });
+
+  it("uses a bounded, hardened owner service", async () => {
+    const unit = await readFile(unitPath, "utf8");
+
+    expect(unit).toContain("User=matrix");
+    expect(unit).toContain("ExecStart=/opt/matrix/bin/matrix-openclaw-gateway");
+    expect(unit).toContain("Restart=on-failure");
+    expect(unit).toContain("StartLimitBurst=3");
+    expect(unit).toContain("TimeoutStartSec=45");
+    expect(unit).toContain("TimeoutStopSec=30");
+    expect(unit).toContain("MemoryMax=1G");
+    expect(unit).toContain("NoNewPrivileges=true");
+    expect(unit).toContain("PrivateTmp=true");
+    expect(unit).toContain("ProtectSystem=strict");
+    expect(unit).toContain("ReadWritePaths=/home/matrix/home/.openclaw /home/matrix/home/system/agent-runtime");
+  });
+
+  it("exposes only exact status and switch commands", async () => {
+    const controller = await readFile(controllerPath, "utf8");
+
+    expect(controller).toContain('case "${1:-}" in');
+    expect(controller).toContain("status)");
+    expect(controller).toContain("switch)");
+    expect(controller).toContain('case "${2:-}" in');
+    expect(controller).toContain("hermes)");
+    expect(controller).toContain("openclaw)");
+    expect(controller).toContain("flock -w 30");
+    expect(controller).toContain("matrix-hermes-dashboard.service");
+    expect(controller).toContain("matrix-openclaw-gateway.service");
+    expect(controller).toContain("systemctl is-active --quiet");
+    expect(controller).toContain("timeout 20");
+    expect(controller).toContain("MemAvailable");
+    expect(controller).toContain("1048576");
+    expect(controller).not.toContain("eval ");
+    expect(controller).not.toContain('systemctl "$');
+  });
+
+  it("stages every runtime artifact and a compatible Node runtime", async () => {
+    const build = await readFile("scripts/build-host-bundle.sh", "utf8");
+    const cloudInit = await readFile("distro/customer-vps/cloud-init.yaml", "utf8");
+
+    expect(build).toContain('HOST_BUNDLE_NODE_VERSION:-24.18.0');
+    for (const name of [
+      "matrix-install-openclaw",
+      "matrix-openclaw-gateway",
+      "matrix-agent-runtime-control",
+    ]) {
+      expect(build).toContain(`$STAGE_DIR/bin/${name}`);
+      expect(cloudInit).toContain(name);
+      await expect(access(`distro/customer-vps/host-bin/${name}`)).resolves.toBeUndefined();
+    }
+    expect(cloudInit).toContain("matrix-openclaw-gateway.service");
+  });
+
+  it("keeps every host entrypoint valid bash", async () => {
+    for (const path of [installerPath, wrapperPath, controllerPath]) {
+      await expect(execFileAsync("bash", ["-n", path])).resolves.toMatchObject({ stderr: "" });
+    }
+  });
+});

--- a/tests/deploy/customer-vps/openclaw-systemd.test.ts
+++ b/tests/deploy/customer-vps/openclaw-systemd.test.ts
@@ -84,6 +84,8 @@ describe("customer VPS OpenClaw runtime", () => {
     expect(controller).toContain("matrix-hermes-dashboard.service");
     expect(controller).toContain("matrix-openclaw-gateway.service");
     expect(controller).toContain("systemctl is-active --quiet");
+    expect(controller).toContain('systemctl disable --now "$other_unit"');
+    expect(controller).toContain('systemctl enable --now "$target_unit"');
     expect(controller).toContain("timeout 20");
     expect(controller).toContain("MemAvailable");
     expect(controller).toContain("1048576");

--- a/tests/deploy/customer-vps/openclaw-systemd.test.ts
+++ b/tests/deploy/customer-vps/openclaw-systemd.test.ts
@@ -9,6 +9,7 @@ const installerPath = "distro/customer-vps/host-bin/matrix-install-openclaw";
 const wrapperPath = "distro/customer-vps/host-bin/matrix-openclaw-gateway";
 const controllerPath = "distro/customer-vps/host-bin/matrix-agent-runtime-control";
 const unitPath = "distro/customer-vps/systemd/matrix-openclaw-gateway.service";
+const legacyInstallUnitPath = "distro/customer-vps/systemd/matrix-openclaw-install.service";
 
 describe("customer VPS OpenClaw runtime", () => {
   it("pins and integrity-checks the optional OpenClaw install", async () => {
@@ -30,10 +31,22 @@ describe("customer VPS OpenClaw runtime", () => {
   it("fails admission before downloading on constrained hosts", async () => {
     const installer = await readFile(installerPath, "utf8");
 
+    expect(installer).toContain('memory_total_kib" -lt 3670016');
+    expect(installer).not.toContain('memory_total_kib" -lt 4194304');
     expect(installer).toContain("MemAvailable");
     expect(installer).toContain("786432");
     expect(installer).toContain("1048576");
     expect(installer.indexOf("check_admission")).toBeLessThan(installer.indexOf("curl --fail"));
+  });
+
+  it("keeps the verified archive readable while dropping to the runtime user without PAM", async () => {
+    const installer = await readFile(installerPath, "utf8");
+
+    expect(installer).toContain('chown "root:$MATRIX_RUNTIME_USER" "$tmp_dir" "$archive"');
+    expect(installer).toContain('chmod 0750 "$tmp_dir"');
+    expect(installer).toContain('chmod 0640 "$archive"');
+    expect(installer).toContain('setpriv --reuid "$MATRIX_RUNTIME_USER" --regid "$MATRIX_RUNTIME_USER" --init-groups');
+    expect(installer).toContain('run_installer_as_runtime_user env \\');
   });
 
   it("keeps gateway authentication out of argv and binds to loopback", async () => {
@@ -71,16 +84,40 @@ describe("customer VPS OpenClaw runtime", () => {
     expect(unit).toContain("ReadWritePaths=/home/matrix/home/.openclaw /home/matrix/home/system/agent-runtime");
   });
 
-  it("exposes only exact status and switch commands", async () => {
+  it("installs optional runtimes directly inside the validated root-owned host-control path", async () => {
+    const controller = await readFile(controllerPath, "utf8");
+
+    expect(controller).toContain('exec sudo -n /opt/matrix/bin/matrix-agent-runtime-control "$@"');
+    expect(controller).toContain("install)");
+    expect(controller).toContain("/opt/matrix/bin/matrix-install-hermes");
+    expect(controller).toContain("/opt/matrix/bin/matrix-install-openclaw");
+    expect(controller).toContain('timeout "$install_timeout_seconds" "$installer"');
+    expect(controller).not.toContain('systemctl start "$unit"');
+    await expect(access(legacyInstallUnitPath)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("exposes only exact status, install, and switch commands", async () => {
     const controller = await readFile(controllerPath, "utf8");
 
     expect(controller).toContain('case "${1:-}" in');
     expect(controller).toContain("status)");
+    expect(controller).toContain("install)");
     expect(controller).toContain("switch)");
     expect(controller).toContain('case "${2:-}" in');
     expect(controller).toContain("hermes)");
     expect(controller).toContain("openclaw)");
     expect(controller).toContain("flock -w 30");
+    expect(controller).toContain(
+      'install -d -o "$MATRIX_RUNTIME_USER" -g "$MATRIX_RUNTIME_GROUP" -m 0700 "$lock_dir"',
+    );
+    const lockOpen = controller.indexOf('exec 9>"$lock_dir/host-control.lock"');
+    const lockOwnerRepair = controller.indexOf(
+      'chown "$MATRIX_RUNTIME_USER:$MATRIX_RUNTIME_GROUP" "$lock_dir/host-control.lock"',
+    );
+    const lockAcquire = controller.indexOf("flock -w 30");
+    expect(lockOpen).toBeGreaterThan(-1);
+    expect(lockOwnerRepair).toBeGreaterThan(lockOpen);
+    expect(lockAcquire).toBeGreaterThan(lockOwnerRepair);
     expect(controller).toContain("matrix-hermes-dashboard.service");
     expect(controller).toContain("matrix-openclaw-gateway.service");
     expect(controller).toContain("systemctl is-active --quiet");

--- a/tests/platform/customer-vps-cloud-init.test.ts
+++ b/tests/platform/customer-vps-cloud-init.test.ts
@@ -358,7 +358,7 @@ exit 99
     expect(cloudInit).toContain('if [ -x /opt/matrix/messaging/bin/synapse ] && [ -x /opt/matrix/messaging/bin/mautrix-telegram ] && [ -x /opt/matrix/messaging/bin/mautrix-whatsapp ]; then');
     expect(cloudInit).toContain('systemctl enable matrix-homeserver.service matrix-bridge-telegram.service matrix-bridge-whatsapp.service');
     expect(cloudInit).toContain('messaging runtimes not installed; units installed but not enabled');
-    expect(cloudInit).toContain('for optional_bin in matrix-hermes-dashboard matrix-install-linux-tools matrix-install-developer-tools matrix-messaging-health matrix-messaging-backup matrix-messaging-restore; do');
+    expect(cloudInit).toContain('for optional_bin in matrix-hermes-dashboard matrix-install-openclaw matrix-openclaw-gateway matrix-agent-runtime-control matrix-install-linux-tools matrix-install-developer-tools matrix-messaging-health matrix-messaging-backup matrix-messaging-restore; do');
     expect(cloudInit).toContain('MATRIX_HOST_BUNDLE_URL={{hostBundleUrl}}');
     expect(cloudInit).toContain('MATRIX_IMAGE_VERSION={{imageVersion}}');
     expect(cloudInit).toContain('MATRIX_UPDATE_CHANNEL={{updateChannel}}');


### PR DESCRIPTION
## Summary

- provision the optional OpenClaw host runtime with a version-exact, SHA-512-verified package (`2026.7.1`); this does not switch OpenClaw to `latest`
- admit nominal 4 GB plans using a 3.5 GiB (`3670016` KiB) Linux `MemTotal` floor, accounting for below-nominal reported memory
- install optional runtimes directly inside the validated root-owned `matrix-agent-runtime-control` boundary with bounded execution and only fixed `status`, `install`, `switch`, and `stop` operations
- preserve Hermes detection at `/home/matrix/home/.local/bin/hermes`, OpenClaw detection at `/opt/matrix/runtime/node/bin/openclaw`, and the existing systemd health checks
- keep the shared host-control lock owner-accessible even when a root install attempt fails admission before installing OpenClaw
- keep runtime selection disabled by default and preserve rollback/persistence hardening

## TDD and validation

- observed the 4 GB admission, install-control, lock-ownership, and redundant systemd credential-transition assertions fail before implementation
- `tests/deploy/customer-vps/openclaw-systemd.test.ts` + `tests/platform/customer-vps-cloud-init.test.ts`: 43/43 passed on this layer
- gateway package TypeScript: passed on this layer
- cumulative stack gate: 236/236 focused tests passed; pattern scanner reported 0 violations
- exact validated head: `7b2b11bb6c9c93014d19482f6149f39f37b8ffb5`

## Stack

- #980 — runtime mutation and transition controller
- this PR — pinned OpenClaw host runtime and installer control
- #982 — authenticated bounded OpenClaw RPC transport

## Invariants

- **Source of truth:** owner OpenClaw state remains under `$MATRIX_HOME/.openclaw`; Matrix runtime selection remains in owner config and is never changed by installation alone.
- **Lock/transaction scope:** the fixed host controller admits one operation through its owner-local lock; the gateway controller retains the authoritative transition/config lock.
- **Acceptable orphan states:** a failed installation may leave an installed-but-stopped binary, but cannot select OpenClaw, stop Hermes, or enable messaging delivery.
- **Auth source of truth:** the owner-local generated gateway token remains the loopback RPC credential and is never placed in argv or returned to clients.
- **Deferred scope:** RPC normalization, gateway composition, UI, and live preview verification stay in later stack layers.
- The shell user invokes only the fixed host-control wrapper. After exact argument validation and narrow sudo re-exec, that root-owned controller runs only the fixed installer path under a bounded timeout; the UI never receives an arbitrary command or unrestricted `sudo` surface.
- OpenClaw remains version- and SHA-pinned. Hermes continues to use the official installer through the same fixed host-control path.
- This PR will not merge below an exact-head Greptile 5/5 review.

## Rollout

- no channel promotion in this layer
- exact install, status, switching, and service health are verified through the #992 isolated preview after the stack lands
