### PR TITLE
feat(gateway): add bounded OpenClaw RPC

### DIFF
--- a/packages/gateway/src/agent-config/openclaw-rpc.ts
+++ b/packages/gateway/src/agent-config/openclaw-rpc.ts
@@ -4,6 +4,9 @@ import { z } from "zod/v4";
 import { AgentConfigError } from "./errors.js";
 
 const MAX_FRAME_BYTES = 1024 * 1024;
+const MAX_REQUEST_BYTES = 16 * 1024;
+const CONFIG_PATCH_LIMIT = 3;
+const CONFIG_PATCH_WINDOW_MS = 60_000;
 const ALLOWED_METHODS = new Set([
   "health",
   "channels.status",
@@ -24,10 +27,10 @@ const EventSchema = z.object({
   event: z.string().min(1).max(128),
   payload: z.unknown().optional(),
   seq: z.number().int().nonnegative().optional(),
-  stateVersion: z.object({
-    presence: z.number().int().nonnegative(),
-    health: z.number().int().nonnegative(),
-  }).strict().optional(),
+  stateVersion: z.record(
+    z.string().min(1).max(128),
+    z.number().int().nonnegative(),
+  ).refine((value) => Object.keys(value).length <= 64).optional(),
 }).strict();
 
 const ResponseSchema = z.object({
@@ -37,6 +40,29 @@ const ResponseSchema = z.object({
   payload: z.unknown().optional(),
   error: z.unknown().optional(),
 }).strict();
+
+const RetryableConnectErrorSchema = z.object({
+  code: z.literal("UNAVAILABLE"),
+  details: z.object({
+    reason: z.literal("startup-sidecars"),
+    retryAfterMs: z.number().int().nonnegative().max(10_000).optional(),
+  }).passthrough(),
+  retryAfterMs: z.number().int().nonnegative().max(10_000).optional(),
+}).passthrough();
+
+const EmptyParamsSchema = z.object({}).strict();
+const ConfigPatchParamsSchema = z.object({
+  raw: z.string().min(2).max(MAX_REQUEST_BYTES),
+  baseHash: z.string().min(1).max(256),
+}).strict();
+const MethodParamsSchemas: Record<string, z.ZodType> = {
+  health: EmptyParamsSchema,
+  "channels.status": EmptyParamsSchema,
+  "models.list": EmptyParamsSchema,
+  "models.authStatus": EmptyParamsSchema,
+  "config.get": EmptyParamsSchema,
+  "config.patch": ConfigPatchParamsSchema,
+};
 
 const HelloSchema = z.object({
   type: z.literal("hello-ok"),
@@ -59,7 +85,7 @@ const HelloSchema = z.object({
     maxBufferedBytes: z.number().int().positive(),
     tickIntervalMs: z.number().int().positive(),
   }).passthrough(),
-}).strict();
+}).passthrough();
 
 interface SocketLike {
   readyState: number;
@@ -128,6 +154,24 @@ function frameText(data: unknown): string {
   return buffer.toString("utf8");
 }
 
+function serializeRequest(id: string, method: string, params: unknown): string {
+  const schema = MethodParamsSchemas[method];
+  const parsed = schema?.safeParse(params);
+  if (parsed?.success !== true) {
+    throw new AgentConfigError("agent_config_invalid", parsed?.error);
+  }
+  let serialized: string;
+  try {
+    serialized = JSON.stringify({ type: "req", id, method, params: parsed.data });
+  } catch (error) {
+    throw new AgentConfigError("agent_config_invalid", error);
+  }
+  if (Buffer.byteLength(serialized) > MAX_REQUEST_BYTES) {
+    throw new AgentConfigError("agent_config_invalid");
+  }
+  return serialized;
+}
+
 export function createOpenClawRpcClient(
   options: OpenClawRpcClientOptions,
 ): OpenClawRpcClient {
@@ -135,10 +179,10 @@ export function createOpenClawRpcClient(
   if (!/^[A-Fa-f0-9]{64}$/.test(options.token)) {
     throw new AgentConfigError("agent_config_invalid");
   }
-  const maxPending = options.maxPending ?? 32;
+  const maxPending = options.maxPending ?? 8;
   const timeoutMs = options.timeoutMs ?? 2_000;
   const now = options.now ?? Date.now;
-  if (!Number.isInteger(maxPending) || maxPending < 1 || maxPending > 64) {
+  if (!Number.isInteger(maxPending) || maxPending < 1 || maxPending > 8) {
     throw new RangeError("Invalid OpenClaw pending-call cap");
   }
   if (!Number.isFinite(timeoutMs) || timeoutMs < 100 || timeoutMs > 10_000) {
@@ -158,7 +202,11 @@ export function createOpenClawRpcClient(
   let connectResolve: (() => void) | null = null;
   let connectReject: ((error: unknown) => void) | null = null;
   let connectTimer: ReturnType<typeof setTimeout> | null = null;
+  let connectRetryTimer: ReturnType<typeof setTimeout> | null = null;
+  let connectDeadline = 0;
   let reconnectAfter = 0;
+  let configPatchInFlight = false;
+  const configPatchWrites: number[] = [];
 
   function rejectPending(error: AgentConfigError): void {
     for (const [id, entry] of pending) {
@@ -172,7 +220,10 @@ export function createOpenClawRpcClient(
   function failConnection(error: AgentConfigError): void {
     reconnectAfter = Math.max(reconnectAfter, now() + timeoutMs);
     if (connectTimer !== null) clearTimeout(connectTimer);
+    if (connectRetryTimer !== null) clearTimeout(connectRetryTimer);
     connectTimer = null;
+    connectRetryTimer = null;
+    connectDeadline = 0;
     connectReject?.(error);
     connectResolve = null;
     connectReject = null;
@@ -184,9 +235,39 @@ export function createOpenClawRpcClient(
     if (failedSocket?.readyState !== WebSocket.CLOSED) failedSocket?.close();
   }
 
+  function retryDelay(error: unknown): number | null {
+    const parsed = RetryableConnectErrorSchema.safeParse(error);
+    if (!parsed.success) return null;
+    return parsed.data.retryAfterMs ?? parsed.data.details.retryAfterMs ?? null;
+  }
+
+  function scheduleConnectRetry(delayMs: number): void {
+    if (connectPromise === null || now() + delayMs >= connectDeadline) {
+      failConnection(new AgentConfigError("runtime_unavailable"));
+      return;
+    }
+    const retrySocket = socket;
+    socket = null;
+    connectId = null;
+    if (retrySocket?.readyState !== WebSocket.CLOSED) retrySocket?.close();
+    connectRetryTimer = setTimeout(() => {
+      connectRetryTimer = null;
+      if (closed || connectPromise === null || now() >= connectDeadline) {
+        failConnection(new AgentConfigError("runtime_unavailable"));
+        return;
+      }
+      openSocket();
+    }, delayMs);
+  }
+
   function handleResponse(frame: z.infer<typeof ResponseSchema>): void {
     if (frame.id === connectId) {
       if (!frame.ok) {
+        const delayMs = retryDelay(frame.error);
+        if (delayMs !== null) {
+          scheduleConnectRetry(delayMs);
+          return;
+        }
         failConnection(new AgentConfigError("runtime_unavailable"));
         return;
       }
@@ -200,6 +281,9 @@ export function createOpenClawRpcClient(
       }
       if (connectTimer !== null) clearTimeout(connectTimer);
       connectTimer = null;
+      if (connectRetryTimer !== null) clearTimeout(connectRetryTimer);
+      connectRetryTimer = null;
+      connectDeadline = 0;
       connectId = null;
       reconnectAfter = 0;
       connectResolve?.();
@@ -266,6 +350,27 @@ export function createOpenClawRpcClient(
     }
   }
 
+  function openSocket(): void {
+    try {
+      const created = socketFactory(url);
+      socket = created;
+      created.on("message", (data) => {
+        if (socket !== created) return;
+        handleMessage(data);
+      });
+      created.on("close", () => {
+        if (socket !== created) return;
+        failConnection(new AgentConfigError("runtime_unavailable"));
+      });
+      created.on("error", () => {
+        if (socket !== created) return;
+        failConnection(new AgentConfigError("runtime_unavailable"));
+      });
+    } catch (error) {
+      failConnection(new AgentConfigError("runtime_unavailable", error));
+    }
+  }
+
   function ensureConnected(): Promise<void> {
     if (closed) return Promise.reject(new AgentConfigError("runtime_unavailable"));
     if (connectPromise !== null) return connectPromise;
@@ -277,18 +382,89 @@ export function createOpenClawRpcClient(
     connectPromise = connecting;
     connectResolve = deferred.resolve;
     connectReject = deferred.reject;
-    try {
-      socket = socketFactory(url);
-      socket.on("message", handleMessage);
-      socket.on("close", () => failConnection(new AgentConfigError("runtime_unavailable")));
-      socket.on("error", () => failConnection(new AgentConfigError("runtime_unavailable")));
-      connectTimer = setTimeout(() => {
-        failConnection(new AgentConfigError("runtime_unavailable"));
-      }, timeoutMs);
-    } catch (error) {
-      failConnection(new AgentConfigError("runtime_unavailable", error));
-    }
+    connectDeadline = now() + timeoutMs;
+    connectTimer = setTimeout(() => {
+      failConnection(new AgentConfigError("runtime_unavailable"));
+    }, timeoutMs);
+    openSocket();
     return connecting;
+  }
+
+  async function waitForConnection(signal: AbortSignal): Promise<void> {
+    if (signal.aborted) throw new AgentConfigError("runtime_unavailable");
+    const connecting = ensureConnected();
+    await new Promise<void>((resolve, reject) => {
+      const onAbort = () => {
+        signal.removeEventListener("abort", onAbort);
+        reject(new AgentConfigError("runtime_unavailable"));
+      };
+      signal.addEventListener("abort", onAbort, { once: true });
+      connecting.then(
+        () => {
+          signal.removeEventListener("abort", onAbort);
+          resolve();
+        },
+        (error: unknown) => {
+          signal.removeEventListener("abort", onAbort);
+          reject(error);
+        },
+      );
+      // Close the check-then-listen race when the caller aborts between the
+      // initial guard and listener registration.
+      if (signal.aborted) onAbort();
+    });
+  }
+
+  function pruneConfigPatchWrites(): void {
+    const cutoff = now() - CONFIG_PATCH_WINDOW_MS;
+    while (configPatchWrites[0] !== undefined && configPatchWrites[0] <= cutoff) {
+      configPatchWrites.shift();
+    }
+  }
+
+  async function performCall(
+    method: string,
+    serialized: string,
+    id: string,
+    signal: AbortSignal,
+  ): Promise<unknown> {
+    await waitForConnection(signal);
+    if (closed || socket === null || socket.readyState !== WebSocket.OPEN) {
+      throw new AgentConfigError("runtime_unavailable");
+    }
+    if (pending.size >= maxPending) {
+      throw new AgentConfigError("agent_config_conflict");
+    }
+    if (signal.aborted) throw new AgentConfigError("runtime_unavailable");
+    const deferred = Promise.withResolvers<unknown>();
+    const onAbort = () => {
+      if (!pending.has(id)) return;
+      failConnection(new AgentConfigError("runtime_unavailable"));
+    };
+    const timer = setTimeout(() => {
+      if (!pending.has(id)) return;
+      failConnection(new AgentConfigError("runtime_unavailable"));
+    }, timeoutMs);
+    pending.set(id, {
+      resolve: deferred.resolve,
+      reject: deferred.reject,
+      timer,
+      signal,
+      onAbort,
+    });
+    signal.addEventListener("abort", onAbort, { once: true });
+    if (method === "config.patch") configPatchWrites.push(now());
+    try {
+      socket.send(serialized);
+    } catch (error) {
+      pending.delete(id);
+      clearTimeout(timer);
+      signal.removeEventListener("abort", onAbort);
+      const failure = new AgentConfigError("runtime_unavailable", error);
+      failConnection(failure);
+      throw failure;
+    }
+    return deferred.promise;
   }
 
   return {
@@ -296,47 +472,21 @@ export function createOpenClawRpcClient(
       if (!ALLOWED_METHODS.has(method)) {
         throw new AgentConfigError("agent_config_invalid");
       }
-      await ensureConnected();
-      if (closed || socket === null || socket.readyState !== WebSocket.OPEN) {
-        throw new AgentConfigError("runtime_unavailable");
+      const id = randomUUID();
+      const serialized = serializeRequest(id, method, params);
+      if (method !== "config.patch") {
+        return performCall(method, serialized, id, signal);
       }
-      if (pending.size >= maxPending) {
+      pruneConfigPatchWrites();
+      if (configPatchInFlight || configPatchWrites.length >= CONFIG_PATCH_LIMIT) {
         throw new AgentConfigError("agent_config_conflict");
       }
-      if (signal.aborted) throw new AgentConfigError("runtime_unavailable");
-      const id = randomUUID();
-      const deferred = Promise.withResolvers<unknown>();
-      const onAbort = () => {
-        const entry = pending.get(id);
-        if (!entry) return;
-        pending.delete(id);
-        clearTimeout(entry.timer);
-        entry.reject(new AgentConfigError("runtime_unavailable"));
-      };
-      const timer = setTimeout(() => {
-        const entry = pending.get(id);
-        if (!entry) return;
-        pending.delete(id);
-        signal.removeEventListener("abort", onAbort);
-        entry.reject(new AgentConfigError("runtime_unavailable"));
-      }, timeoutMs);
-      pending.set(id, {
-        resolve: deferred.resolve,
-        reject: deferred.reject,
-        timer,
-        signal,
-        onAbort,
-      });
-      signal.addEventListener("abort", onAbort, { once: true });
+      configPatchInFlight = true;
       try {
-        socket.send(JSON.stringify({ type: "req", id, method, params }));
-      } catch (error) {
-        pending.delete(id);
-        clearTimeout(timer);
-        signal.removeEventListener("abort", onAbort);
-        throw new AgentConfigError("runtime_unavailable", error);
+        return await performCall(method, serialized, id, signal);
+      } finally {
+        configPatchInFlight = false;
       }
-      return deferred.promise;
     },
     async close() {
       if (closed) return;
@@ -346,11 +496,15 @@ export function createOpenClawRpcClient(
       connectResolve = null;
       connectReject = null;
       if (connectTimer !== null) clearTimeout(connectTimer);
+      if (connectRetryTimer !== null) clearTimeout(connectRetryTimer);
       connectTimer = null;
+      connectRetryTimer = null;
+      connectDeadline = 0;
       socket?.close();
       socket = null;
       connectPromise = null;
       connectId = null;
+      configPatchWrites.length = 0;
     },
   };
 }

--- a/packages/gateway/src/agent-config/openclaw-rpc.ts
+++ b/packages/gateway/src/agent-config/openclaw-rpc.ts
@@ -1,0 +1,327 @@
+import { randomUUID } from "node:crypto";
+import { WebSocket } from "ws";
+import { z } from "zod/v4";
+import { AgentConfigError } from "./errors.js";
+
+const MAX_FRAME_BYTES = 1024 * 1024;
+const ALLOWED_METHODS = new Set([
+  "health",
+  "channels.status",
+  "models.list",
+  "models.authStatus",
+  "config.get",
+  "config.patch",
+]);
+
+const ChallengeSchema = z.object({
+  type: z.literal("event"),
+  event: z.literal("connect.challenge"),
+  payload: z.object({ nonce: z.string().min(1).max(512), ts: z.number() }).strict(),
+}).strict();
+
+const ResponseSchema = z.object({
+  type: z.literal("res"),
+  id: z.string().uuid(),
+  ok: z.boolean(),
+  payload: z.unknown().optional(),
+  error: z.unknown().optional(),
+}).strict();
+
+const HelloSchema = z.object({
+  type: z.literal("hello-ok"),
+  protocol: z.literal(4),
+  server: z.object({
+    version: z.string().min(1).max(128),
+    connId: z.string().min(1).max(256),
+  }).passthrough(),
+  features: z.object({
+    methods: z.array(z.string().min(1).max(128)).max(512),
+    events: z.array(z.string().min(1).max(128)).max(512),
+  }).passthrough(),
+  snapshot: z.record(z.string(), z.unknown()),
+  auth: z.object({
+    role: z.literal("operator"),
+    scopes: z.array(z.string().min(1).max(128)).max(32),
+  }).passthrough(),
+  policy: z.object({
+    maxPayload: z.number().int().positive(),
+    maxBufferedBytes: z.number().int().positive(),
+    tickIntervalMs: z.number().int().positive(),
+  }).passthrough(),
+}).strict();
+
+interface SocketLike {
+  readyState: number;
+  send(data: string): void;
+  close(): void;
+  on(event: "message", listener: (data: unknown) => void): unknown;
+  on(event: "close", listener: () => void): unknown;
+  on(event: "error", listener: (error: unknown) => void): unknown;
+}
+
+interface PendingCall {
+  resolve(value: unknown): void;
+  reject(error: unknown): void;
+  timer: ReturnType<typeof setTimeout>;
+  signal: AbortSignal;
+  onAbort: () => void;
+}
+
+export interface OpenClawRpcClient {
+  call(method: string, params: unknown, signal: AbortSignal): Promise<unknown>;
+  close(): Promise<void>;
+}
+
+interface OpenClawRpcClientOptions {
+  url: string;
+  token: string;
+  socketFactory?: (url: string) => SocketLike;
+  maxPending?: number;
+  timeoutMs?: number;
+}
+
+function validateUrl(value: string): string {
+  let url: URL;
+  try {
+    url = new URL(value);
+  } catch (error) {
+    throw new AgentConfigError("agent_config_invalid", error);
+  }
+  if (url.protocol !== "ws:"
+    || !["127.0.0.1", "[::1]"].includes(url.hostname)
+    || url.port !== "18789"
+    || url.username !== ""
+    || url.password !== ""
+    || url.pathname !== "/"
+    || url.search !== ""
+    || url.hash !== "") {
+    throw new AgentConfigError("agent_config_invalid");
+  }
+  return url.href;
+}
+
+function frameText(data: unknown): string {
+  const buffer = Buffer.isBuffer(data)
+    ? data
+    : data instanceof ArrayBuffer
+      ? Buffer.from(data)
+      : ArrayBuffer.isView(data)
+        ? Buffer.from(data.buffer, data.byteOffset, data.byteLength)
+        : typeof data === "string"
+          ? Buffer.from(data)
+          : null;
+  if (buffer === null || buffer.byteLength > MAX_FRAME_BYTES) {
+    throw new AgentConfigError("invalid_response");
+  }
+  return buffer.toString("utf8");
+}
+
+export function createOpenClawRpcClient(
+  options: OpenClawRpcClientOptions,
+): OpenClawRpcClient {
+  const url = validateUrl(options.url);
+  if (!/^[A-Fa-f0-9]{64}$/.test(options.token)) {
+    throw new AgentConfigError("agent_config_invalid");
+  }
+  const maxPending = options.maxPending ?? 32;
+  const timeoutMs = options.timeoutMs ?? 2_000;
+  if (!Number.isInteger(maxPending) || maxPending < 1 || maxPending > 64) {
+    throw new RangeError("Invalid OpenClaw pending-call cap");
+  }
+  if (!Number.isFinite(timeoutMs) || timeoutMs < 100 || timeoutMs > 10_000) {
+    throw new RangeError("Invalid OpenClaw RPC timeout");
+  }
+  const socketFactory = options.socketFactory ?? ((target: string) => new WebSocket(target, {
+    handshakeTimeout: timeoutMs,
+    maxPayload: MAX_FRAME_BYTES,
+    perMessageDeflate: false,
+  }));
+
+  const pending = new Map<string, PendingCall>();
+  let socket: SocketLike | null = null;
+  let closed = false;
+  let connectId: string | null = null;
+  let connectPromise: Promise<void> | null = null;
+  let connectResolve: (() => void) | null = null;
+  let connectReject: ((error: unknown) => void) | null = null;
+  let connectTimer: ReturnType<typeof setTimeout> | null = null;
+
+  function rejectPending(error: AgentConfigError): void {
+    for (const [id, entry] of pending) {
+      pending.delete(id);
+      clearTimeout(entry.timer);
+      entry.signal.removeEventListener("abort", entry.onAbort);
+      entry.reject(error);
+    }
+  }
+
+  function failConnection(error: AgentConfigError): void {
+    if (connectTimer !== null) clearTimeout(connectTimer);
+    connectTimer = null;
+    connectReject?.(error);
+    connectResolve = null;
+    connectReject = null;
+    rejectPending(error);
+    if (socket?.readyState !== WebSocket.CLOSED) socket?.close();
+    socket = null;
+    connectPromise = null;
+    connectId = null;
+  }
+
+  function handleResponse(frame: z.infer<typeof ResponseSchema>): void {
+    if (frame.id === connectId) {
+      if (!frame.ok) {
+        failConnection(new AgentConfigError("runtime_unavailable"));
+        return;
+      }
+      const hello = HelloSchema.safeParse(frame.payload);
+      if (!hello.success
+        || !hello.data.auth.scopes.includes("operator.read")
+        || !hello.data.auth.scopes.includes("operator.write")
+        || !hello.data.auth.scopes.includes("operator.admin")) {
+        failConnection(new AgentConfigError("invalid_response", hello.error));
+        return;
+      }
+      if (connectTimer !== null) clearTimeout(connectTimer);
+      connectTimer = null;
+      connectId = null;
+      connectResolve?.();
+      connectResolve = null;
+      connectReject = null;
+      return;
+    }
+
+    const entry = pending.get(frame.id);
+    if (!entry) return;
+    pending.delete(frame.id);
+    clearTimeout(entry.timer);
+    entry.signal.removeEventListener("abort", entry.onAbort);
+    if (frame.ok) entry.resolve(frame.payload);
+    else entry.reject(new AgentConfigError("invalid_response"));
+  }
+
+  function handleMessage(data: unknown): void {
+    try {
+      const raw = JSON.parse(frameText(data));
+      const challenge = ChallengeSchema.safeParse(raw);
+      if (challenge.success && connectId === null) {
+        connectId = randomUUID();
+        socket?.send(JSON.stringify({
+          type: "req",
+          id: connectId,
+          method: "connect",
+          params: {
+            minProtocol: 4,
+            maxProtocol: 4,
+            client: {
+              id: "gateway-client",
+              version: "matrix-os",
+              platform: "linux",
+              mode: "backend",
+            },
+            role: "operator",
+            scopes: ["operator.read", "operator.write", "operator.admin"],
+            caps: [],
+            commands: [],
+            permissions: {},
+            auth: { token: options.token },
+            locale: "en-US",
+            userAgent: "matrix-os-gateway",
+          },
+        }));
+        return;
+      }
+      const response = ResponseSchema.safeParse(raw);
+      if (!response.success) throw new AgentConfigError("invalid_response", response.error);
+      handleResponse(response.data);
+    } catch (error) {
+      console.warn(
+        "[agent-config] OpenClaw RPC protocol failure:",
+        error instanceof Error ? error.name : "UnknownError",
+      );
+      failConnection(error instanceof AgentConfigError
+        ? error
+        : new AgentConfigError("invalid_response", error));
+    }
+  }
+
+  function ensureConnected(): Promise<void> {
+    if (closed) return Promise.reject(new AgentConfigError("runtime_unavailable"));
+    if (connectPromise !== null) return connectPromise;
+    const deferred = Promise.withResolvers<void>();
+    connectPromise = deferred.promise;
+    connectResolve = deferred.resolve;
+    connectReject = deferred.reject;
+    socket = socketFactory(url);
+    socket.on("message", handleMessage);
+    socket.on("close", () => failConnection(new AgentConfigError("runtime_unavailable")));
+    socket.on("error", () => failConnection(new AgentConfigError("runtime_unavailable")));
+    connectTimer = setTimeout(() => {
+      failConnection(new AgentConfigError("runtime_unavailable"));
+    }, timeoutMs);
+    return connectPromise;
+  }
+
+  return {
+    async call(method, params, signal) {
+      if (!ALLOWED_METHODS.has(method)) {
+        throw new AgentConfigError("agent_config_invalid");
+      }
+      await ensureConnected();
+      if (closed || socket === null || socket.readyState !== WebSocket.OPEN) {
+        throw new AgentConfigError("runtime_unavailable");
+      }
+      if (pending.size >= maxPending) {
+        throw new AgentConfigError("agent_config_conflict");
+      }
+      if (signal.aborted) throw new AgentConfigError("runtime_unavailable");
+      const id = randomUUID();
+      const deferred = Promise.withResolvers<unknown>();
+      const onAbort = () => {
+        const entry = pending.get(id);
+        if (!entry) return;
+        pending.delete(id);
+        clearTimeout(entry.timer);
+        entry.reject(new AgentConfigError("runtime_unavailable"));
+      };
+      const timer = setTimeout(() => {
+        const entry = pending.get(id);
+        if (!entry) return;
+        pending.delete(id);
+        signal.removeEventListener("abort", onAbort);
+        entry.reject(new AgentConfigError("runtime_unavailable"));
+      }, timeoutMs);
+      pending.set(id, {
+        resolve: deferred.resolve,
+        reject: deferred.reject,
+        timer,
+        signal,
+        onAbort,
+      });
+      signal.addEventListener("abort", onAbort, { once: true });
+      try {
+        socket.send(JSON.stringify({ type: "req", id, method, params }));
+      } catch (error) {
+        pending.delete(id);
+        clearTimeout(timer);
+        signal.removeEventListener("abort", onAbort);
+        throw new AgentConfigError("runtime_unavailable", error);
+      }
+      return deferred.promise;
+    },
+    async close() {
+      if (closed) return;
+      closed = true;
+      rejectPending(new AgentConfigError("runtime_unavailable"));
+      connectReject?.(new AgentConfigError("runtime_unavailable"));
+      connectResolve = null;
+      connectReject = null;
+      if (connectTimer !== null) clearTimeout(connectTimer);
+      connectTimer = null;
+      socket?.close();
+      socket = null;
+      connectPromise = null;
+      connectId = null;
+    },
+  };
+}

--- a/packages/gateway/src/agent-config/openclaw-rpc.ts
+++ b/packages/gateway/src/agent-config/openclaw-rpc.ts
@@ -51,6 +51,13 @@ const RetryableConnectErrorSchema = z.object({
 }).passthrough();
 
 const EmptyParamsSchema = z.object({}).strict();
+const ModelsListParamsSchema = z.object({
+  includeProviderCapabilities: z.boolean().optional(),
+  view: z.enum(["default", "configured", "provider-config", "all"]).optional(),
+}).strict();
+const ModelsAuthStatusParamsSchema = z.object({
+  refresh: z.boolean().optional(),
+}).strict();
 const ConfigPatchParamsSchema = z.object({
   raw: z.string().min(2).max(MAX_REQUEST_BYTES),
   baseHash: z.string().min(1).max(256),
@@ -58,8 +65,8 @@ const ConfigPatchParamsSchema = z.object({
 const MethodParamsSchemas: Record<string, z.ZodType> = {
   health: EmptyParamsSchema,
   "channels.status": EmptyParamsSchema,
-  "models.list": EmptyParamsSchema,
-  "models.authStatus": EmptyParamsSchema,
+  "models.list": ModelsListParamsSchema,
+  "models.authStatus": ModelsAuthStatusParamsSchema,
   "config.get": EmptyParamsSchema,
   "config.patch": ConfigPatchParamsSchema,
 };

--- a/packages/gateway/src/agent-config/openclaw-rpc.ts
+++ b/packages/gateway/src/agent-config/openclaw-rpc.ts
@@ -19,6 +19,17 @@ const ChallengeSchema = z.object({
   payload: z.object({ nonce: z.string().min(1).max(512), ts: z.number() }).strict(),
 }).strict();
 
+const EventSchema = z.object({
+  type: z.literal("event"),
+  event: z.string().min(1).max(128),
+  payload: z.unknown().optional(),
+  seq: z.number().int().nonnegative().optional(),
+  stateVersion: z.object({
+    presence: z.number().int().nonnegative(),
+    health: z.number().int().nonnegative(),
+  }).strict().optional(),
+}).strict();
+
 const ResponseSchema = z.object({
   type: z.literal("res"),
   id: z.string().uuid(),
@@ -78,6 +89,7 @@ interface OpenClawRpcClientOptions {
   socketFactory?: (url: string) => SocketLike;
   maxPending?: number;
   timeoutMs?: number;
+  now?: () => number;
 }
 
 function validateUrl(value: string): string {
@@ -125,6 +137,7 @@ export function createOpenClawRpcClient(
   }
   const maxPending = options.maxPending ?? 32;
   const timeoutMs = options.timeoutMs ?? 2_000;
+  const now = options.now ?? Date.now;
   if (!Number.isInteger(maxPending) || maxPending < 1 || maxPending > 64) {
     throw new RangeError("Invalid OpenClaw pending-call cap");
   }
@@ -145,6 +158,7 @@ export function createOpenClawRpcClient(
   let connectResolve: (() => void) | null = null;
   let connectReject: ((error: unknown) => void) | null = null;
   let connectTimer: ReturnType<typeof setTimeout> | null = null;
+  let reconnectAfter = 0;
 
   function rejectPending(error: AgentConfigError): void {
     for (const [id, entry] of pending) {
@@ -156,16 +170,18 @@ export function createOpenClawRpcClient(
   }
 
   function failConnection(error: AgentConfigError): void {
+    reconnectAfter = Math.max(reconnectAfter, now() + timeoutMs);
     if (connectTimer !== null) clearTimeout(connectTimer);
     connectTimer = null;
     connectReject?.(error);
     connectResolve = null;
     connectReject = null;
     rejectPending(error);
-    if (socket?.readyState !== WebSocket.CLOSED) socket?.close();
+    const failedSocket = socket;
     socket = null;
     connectPromise = null;
     connectId = null;
+    if (failedSocket?.readyState !== WebSocket.CLOSED) failedSocket?.close();
   }
 
   function handleResponse(frame: z.infer<typeof ResponseSchema>): void {
@@ -185,6 +201,7 @@ export function createOpenClawRpcClient(
       if (connectTimer !== null) clearTimeout(connectTimer);
       connectTimer = null;
       connectId = null;
+      reconnectAfter = 0;
       connectResolve?.();
       connectResolve = null;
       connectReject = null;
@@ -204,7 +221,7 @@ export function createOpenClawRpcClient(
     try {
       const raw = JSON.parse(frameText(data));
       const challenge = ChallengeSchema.safeParse(raw);
-      if (challenge.success && connectId === null) {
+      if (challenge.success && connectResolve !== null && connectId === null) {
         connectId = randomUUID();
         socket?.send(JSON.stringify({
           type: "req",
@@ -232,8 +249,12 @@ export function createOpenClawRpcClient(
         return;
       }
       const response = ResponseSchema.safeParse(raw);
-      if (!response.success) throw new AgentConfigError("invalid_response", response.error);
-      handleResponse(response.data);
+      if (response.success) {
+        handleResponse(response.data);
+        return;
+      }
+      if (EventSchema.safeParse(raw).success) return;
+      throw new AgentConfigError("invalid_response", response.error);
     } catch (error) {
       console.warn(
         "[agent-config] OpenClaw RPC protocol failure:",
@@ -248,18 +269,26 @@ export function createOpenClawRpcClient(
   function ensureConnected(): Promise<void> {
     if (closed) return Promise.reject(new AgentConfigError("runtime_unavailable"));
     if (connectPromise !== null) return connectPromise;
+    if (now() < reconnectAfter) {
+      return Promise.reject(new AgentConfigError("runtime_unavailable"));
+    }
     const deferred = Promise.withResolvers<void>();
-    connectPromise = deferred.promise;
+    const connecting = deferred.promise;
+    connectPromise = connecting;
     connectResolve = deferred.resolve;
     connectReject = deferred.reject;
-    socket = socketFactory(url);
-    socket.on("message", handleMessage);
-    socket.on("close", () => failConnection(new AgentConfigError("runtime_unavailable")));
-    socket.on("error", () => failConnection(new AgentConfigError("runtime_unavailable")));
-    connectTimer = setTimeout(() => {
-      failConnection(new AgentConfigError("runtime_unavailable"));
-    }, timeoutMs);
-    return connectPromise;
+    try {
+      socket = socketFactory(url);
+      socket.on("message", handleMessage);
+      socket.on("close", () => failConnection(new AgentConfigError("runtime_unavailable")));
+      socket.on("error", () => failConnection(new AgentConfigError("runtime_unavailable")));
+      connectTimer = setTimeout(() => {
+        failConnection(new AgentConfigError("runtime_unavailable"));
+      }, timeoutMs);
+    } catch (error) {
+      failConnection(new AgentConfigError("runtime_unavailable", error));
+    }
+    return connecting;
   }
 
   return {

--- a/tests/gateway/openclaw-rpc.test.ts
+++ b/tests/gateway/openclaw-rpc.test.ts
@@ -154,4 +154,77 @@ describe("OpenClaw gateway RPC", () => {
     await active.client.close();
     await healthClosed;
   });
+
+  it("ignores bounded server events and duplicate challenges after handshake", async () => {
+    const active = await beginCall();
+
+    active.socket.receive({
+      type: "event",
+      event: "health",
+      payload: { ts: 1_789_000_000_000 },
+      seq: 4,
+      stateVersion: { presence: 2, health: 3 },
+    });
+    active.socket.receive({
+      type: "event",
+      event: "connect.challenge",
+      payload: { nonce: "duplicate", ts: 1_789_000_000_001 },
+    });
+
+    expect(active.socket.sent).toHaveLength(2);
+    active.socket.receive({
+      type: "res",
+      id: active.request.id,
+      ok: true,
+      payload: { ok: true },
+    });
+    await expect(active.call).resolves.toEqual({ ok: true });
+    await active.client.close();
+  });
+
+  it("backs off sequential reconnects and maps synchronous socket failures", async () => {
+    let now = 1_000;
+    const sockets: FakeSocket[] = [];
+    const socketFactory = vi.fn(() => {
+      const socket = new FakeSocket();
+      sockets.push(socket);
+      return socket;
+    });
+    const client = createOpenClawRpcClient({
+      url: "ws://127.0.0.1:18789",
+      token: "c".repeat(64),
+      socketFactory,
+      timeoutMs: 100,
+      now: () => now,
+    });
+    const first = client.call("health", {}, new AbortController().signal);
+    sockets[0]!.emit("close");
+    await expect(first).rejects.toMatchObject({ kind: "runtime_unavailable" });
+
+    await expect(client.call("health", {}, new AbortController().signal))
+      .rejects.toMatchObject({ kind: "runtime_unavailable" });
+    expect(socketFactory).toHaveBeenCalledOnce();
+
+    now += 101;
+    const retry = client.call("health", {}, new AbortController().signal);
+    expect(socketFactory).toHaveBeenCalledTimes(2);
+    const retryClosed = expect(retry).rejects.toMatchObject({
+      kind: "runtime_unavailable",
+    });
+    await client.close();
+    await retryClosed;
+
+    const throwingFactory = vi.fn(() => {
+      throw new Error("provider socket detail");
+    });
+    const throwing = createOpenClawRpcClient({
+      url: "ws://127.0.0.1:18789",
+      token: "d".repeat(64),
+      socketFactory: throwingFactory,
+      timeoutMs: 100,
+    });
+    await expect(throwing.call("health", {}, new AbortController().signal))
+      .rejects.toMatchObject({ kind: "runtime_unavailable" });
+    await throwing.close();
+  });
 });

--- a/tests/gateway/openclaw-rpc.test.ts
+++ b/tests/gateway/openclaw-rpc.test.ts
@@ -22,13 +22,19 @@ class FakeSocket extends EventEmitter {
   }
 }
 
-async function beginCall(options: { maxPending?: number; timeoutMs?: number } = {}) {
+async function beginCall(options: {
+  maxPending?: number;
+  timeoutMs?: number;
+  now?: () => number;
+  helloExtensions?: Record<string, unknown>;
+} = {}) {
   const socket = new FakeSocket();
+  const { helloExtensions, ...clientOptions } = options;
   const client = createOpenClawRpcClient({
     url: "ws://127.0.0.1:18789",
     token: "a".repeat(64),
     socketFactory: () => socket,
-    ...options,
+    ...clientOptions,
   });
   const call = client.call("health", {}, new AbortController().signal);
   socket.receive({
@@ -50,6 +56,7 @@ async function beginCall(options: { maxPending?: number; timeoutMs?: number } = 
       snapshot: {},
       auth: { role: "operator", scopes: ["operator.read", "operator.write", "operator.admin"] },
       policy: { maxPayload: 1024 * 1024, maxBufferedBytes: 2 * 1024 * 1024, tickIntervalMs: 15_000 },
+      ...helloExtensions,
     },
   });
   await vi.waitFor(() => expect(socket.sent).toHaveLength(2));
@@ -92,6 +99,38 @@ describe("OpenClaw gateway RPC", () => {
     expect(socketFactory).not.toHaveBeenCalled();
   });
 
+  it("rejects oversized and malformed method requests before connecting", async () => {
+    const socketFactory = vi.fn(() => new FakeSocket());
+    const client = createOpenClawRpcClient({
+      url: "ws://127.0.0.1:18789",
+      token: "f".repeat(64),
+      socketFactory,
+      timeoutMs: 100,
+    });
+
+    await expect(client.call("config.patch", {
+      raw: "x".repeat(16 * 1024),
+      baseHash: "hash-1",
+    }, new AbortController().signal)).rejects.toMatchObject({
+      kind: "agent_config_invalid",
+    });
+    await expect(client.call("config.patch", {
+      arbitrary: true,
+    }, new AbortController().signal)).rejects.toMatchObject({
+      kind: "agent_config_invalid",
+    });
+    expect(socketFactory).not.toHaveBeenCalled();
+    await client.close();
+  });
+
+  it("enforces the published eight-correlation ceiling", () => {
+    expect(() => createOpenClawRpcClient({
+      url: "ws://127.0.0.1:18789",
+      token: "0".repeat(64),
+      maxPending: 9,
+    })).toThrowError("Invalid OpenClaw pending-call cap");
+  });
+
   it("caps pending correlations and rejects all work on close", async () => {
     const { client, call } = await beginCall({ maxPending: 1 });
     const second = client.call("models.list", {}, new AbortController().signal);
@@ -119,13 +158,16 @@ describe("OpenClaw gateway RPC", () => {
   it("bounds calls with a timeout and honors caller abort", async () => {
     const timed = await beginCall({ timeoutMs: 100 });
     await expect(timed.call).rejects.toMatchObject({ kind: "runtime_unavailable" });
+    expect(timed.socket.readyState).toBe(3);
     await timed.client.close();
 
     const active = await beginCall();
     const controller = new AbortController();
     const aborted = active.client.call("models.list", {}, controller.signal);
+    await vi.waitFor(() => expect(active.socket.sent).toHaveLength(3));
     controller.abort();
     await expect(aborted).rejects.toMatchObject({ kind: "runtime_unavailable" });
+    expect(active.socket.readyState).toBe(3);
     const healthClosed = expect(active.call).rejects.toMatchObject({
       kind: "runtime_unavailable",
     });
@@ -133,26 +175,54 @@ describe("OpenClaw gateway RPC", () => {
     await healthClosed;
   });
 
-  it("cleans up correlation state when a socket send throws", async () => {
+  it("honors caller abort while the initial handshake is pending", async () => {
+    vi.useFakeTimers();
+    const socket = new FakeSocket();
+    const client = createOpenClawRpcClient({
+      url: "ws://127.0.0.1:18789",
+      token: "e".repeat(64),
+      socketFactory: () => socket,
+      timeoutMs: 2_000,
+    });
+    const controller = new AbortController();
+    const rejection = vi.fn();
+    const observed = client.call("health", {}, controller.signal).catch(rejection);
+
+    try {
+      await vi.advanceTimersByTimeAsync(0);
+      controller.abort();
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(rejection).toHaveBeenCalledWith(expect.objectContaining({
+        kind: "runtime_unavailable",
+      }));
+      expect(socket.readyState).toBe(1);
+    } finally {
+      await client.close();
+      await observed;
+      vi.useRealTimers();
+    }
+  });
+
+  it("invalidates the connection when a socket send throws", async () => {
     const active = await beginCall({ maxPending: 2 });
+    const healthOutcome = active.call.catch((error: unknown) => error);
     active.socket.throwOnSend = true;
     await expect(active.client.call(
       "models.list",
       {},
       new AbortController().signal,
     )).rejects.toMatchObject({ kind: "runtime_unavailable" });
-
-    active.socket.throwOnSend = false;
-    const retry = active.client.call("models.list", {}, new AbortController().signal);
-    await vi.waitFor(() => expect(active.socket.sent).toHaveLength(3));
-    const frame = JSON.parse(active.socket.sent[2]!);
-    active.socket.receive({ type: "res", id: frame.id, ok: true, payload: [] });
-    await expect(retry).resolves.toEqual([]);
-    const healthClosed = expect(active.call).rejects.toMatchObject({
+    expect(active.socket.readyState).toBe(3);
+    await expect(active.client.call(
+      "models.list",
+      {},
+      new AbortController().signal,
+    )).rejects.toMatchObject({ kind: "runtime_unavailable" });
+    await expect(healthOutcome).resolves.toMatchObject({
       kind: "runtime_unavailable",
     });
     await active.client.close();
-    await healthClosed;
   });
 
   it("ignores bounded server events and duplicate challenges after handshake", async () => {
@@ -172,6 +242,46 @@ describe("OpenClaw gateway RPC", () => {
     });
 
     expect(active.socket.sent).toHaveLength(2);
+    active.socket.receive({
+      type: "res",
+      id: active.request.id,
+      ok: true,
+      payload: { ok: true },
+    });
+    await expect(active.call).resolves.toEqual({ ok: true });
+    await active.client.close();
+  });
+
+  it("ignores bounded events with additive state-version counters", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const active = await beginCall();
+    try {
+      active.socket.receive({
+        type: "event",
+        event: "catalog.changed",
+        payload: { providerCount: 2 },
+        stateVersion: { catalog: 7 },
+      });
+      active.socket.receive({
+        type: "res",
+        id: active.request.id,
+        ok: true,
+        payload: { ok: true },
+      });
+      await expect(active.call).resolves.toEqual({ ok: true });
+      expect(warn).not.toHaveBeenCalled();
+    } finally {
+      warn.mockRestore();
+      await active.client.close();
+    }
+  });
+
+  it("accepts documented additive hello metadata", async () => {
+    const active = await beginCall({
+      helloExtensions: {
+        pluginSurfaceUrls: { canvas: "http://127.0.0.1:18789/plugins/canvas" },
+      },
+    });
     active.socket.receive({
       type: "res",
       id: active.request.id,
@@ -226,5 +336,175 @@ describe("OpenClaw gateway RPC", () => {
     await expect(throwing.call("health", {}, new AbortController().signal))
       .rejects.toMatchObject({ kind: "runtime_unavailable" });
     await throwing.close();
+  });
+
+  it("ignores delayed callbacks from a replaced socket", async () => {
+    let now = 1_000;
+    const sockets: FakeSocket[] = [];
+    const client = createOpenClawRpcClient({
+      url: "ws://127.0.0.1:18789",
+      token: "1".repeat(64),
+      socketFactory: () => {
+        const socket = new FakeSocket();
+        sockets.push(socket);
+        return socket;
+      },
+      timeoutMs: 100,
+      now: () => now,
+    });
+    const first = client.call("health", {}, new AbortController().signal);
+    sockets[0]!.emit("close");
+    await expect(first).rejects.toMatchObject({ kind: "runtime_unavailable" });
+
+    now += 101;
+    const retry = client.call("health", {}, new AbortController().signal);
+    const replacement = sockets[1]!;
+    replacement.receive({
+      type: "event",
+      event: "connect.challenge",
+      payload: { nonce: "retry", ts: 1_789_000_000_000 },
+    });
+    await vi.waitFor(() => expect(replacement.sent).toHaveLength(1));
+    const connect = JSON.parse(replacement.sent[0]!);
+    replacement.receive({
+      type: "res",
+      id: connect.id,
+      ok: true,
+      payload: {
+        type: "hello-ok",
+        protocol: 4,
+        server: { version: "2026.7.1", connId: "conn-2" },
+        features: { methods: ["health"], events: [] },
+        snapshot: {},
+        auth: { role: "operator", scopes: ["operator.read", "operator.write", "operator.admin"] },
+        policy: { maxPayload: 1024, maxBufferedBytes: 2048, tickIntervalMs: 15_000 },
+      },
+    });
+    await vi.waitFor(() => expect(replacement.sent).toHaveLength(2));
+    sockets[0]!.emit("close");
+    const request = JSON.parse(replacement.sent[1]!);
+    replacement.receive({ type: "res", id: request.id, ok: true, payload: { ok: true } });
+
+    await expect(retry).resolves.toEqual({ ok: true });
+    await client.close();
+  });
+
+  it("retries startup-sidecar handshakes within the connection budget", async () => {
+    vi.useFakeTimers();
+    const sockets: FakeSocket[] = [];
+    const client = createOpenClawRpcClient({
+      url: "ws://127.0.0.1:18789",
+      token: "2".repeat(64),
+      socketFactory: () => {
+        const socket = new FakeSocket();
+        sockets.push(socket);
+        return socket;
+      },
+      timeoutMs: 500,
+    });
+    const call = client.call("health", {}, new AbortController().signal);
+    const observed = call.catch(() => undefined);
+    try {
+      sockets[0]!.receive({
+        type: "event",
+        event: "connect.challenge",
+        payload: { nonce: "first", ts: 1_789_000_000_000 },
+      });
+      await vi.advanceTimersByTimeAsync(0);
+      const firstConnect = JSON.parse(sockets[0]!.sent[0]!);
+      sockets[0]!.receive({
+        type: "res",
+        id: firstConnect.id,
+        ok: false,
+        error: {
+          code: "UNAVAILABLE",
+          details: { reason: "startup-sidecars" },
+          retryAfterMs: 50,
+        },
+      });
+
+      await vi.advanceTimersByTimeAsync(50);
+      expect(sockets).toHaveLength(2);
+      sockets[1]!.receive({
+        type: "event",
+        event: "connect.challenge",
+        payload: { nonce: "second", ts: 1_789_000_000_050 },
+      });
+      await vi.advanceTimersByTimeAsync(0);
+      const secondConnect = JSON.parse(sockets[1]!.sent[0]!);
+      sockets[1]!.receive({
+        type: "res",
+        id: secondConnect.id,
+        ok: true,
+        payload: {
+          type: "hello-ok",
+          protocol: 4,
+          server: { version: "2026.7.1", connId: "conn-retry" },
+          features: { methods: ["health"], events: [] },
+          snapshot: {},
+          auth: { role: "operator", scopes: ["operator.read", "operator.write", "operator.admin"] },
+          policy: { maxPayload: 1024, maxBufferedBytes: 2048, tickIntervalMs: 15_000 },
+        },
+      });
+      await vi.advanceTimersByTimeAsync(0);
+      const request = JSON.parse(sockets[1]!.sent[1]!);
+      sockets[1]!.receive({ type: "res", id: request.id, ok: true, payload: { ok: true } });
+      await expect(call).resolves.toEqual({ ok: true });
+    } finally {
+      await client.close();
+      await observed;
+      vi.useRealTimers();
+    }
+  });
+
+  it("serializes and rate-limits config patches", async () => {
+    let now = 10_000;
+    const active = await beginCall({ now: () => now });
+    const initialOutcome = active.call.catch((error: unknown) => error);
+    const patch = active.client.call("config.patch", {
+      raw: JSON.stringify({ agents: { defaults: { model: { primary: "a/b" } } } }),
+      baseHash: "hash-1",
+    }, new AbortController().signal);
+    await vi.waitFor(() => expect(active.socket.sent).toHaveLength(3));
+    await expect(active.client.call("config.patch", {
+      raw: JSON.stringify({ agents: { defaults: { model: { primary: "a/c" } } } }),
+      baseHash: "hash-1",
+    }, new AbortController().signal)).rejects.toMatchObject({
+      kind: "agent_config_conflict",
+    });
+    const firstPatch = JSON.parse(active.socket.sent[2]!);
+    active.socket.receive({ type: "res", id: firstPatch.id, ok: true, payload: { ok: true } });
+    await expect(patch).resolves.toEqual({ ok: true });
+
+    for (let index = 2; index <= 3; index += 1) {
+      const next = active.client.call("config.patch", {
+        raw: JSON.stringify({ agents: { defaults: { model: { primary: `a/${index}` } } } }),
+        baseHash: `hash-${index}`,
+      }, new AbortController().signal);
+      await vi.waitFor(() => expect(active.socket.sent).toHaveLength(index + 2));
+      const request = JSON.parse(active.socket.sent[index + 1]!);
+      active.socket.receive({ type: "res", id: request.id, ok: true, payload: { ok: true } });
+      await expect(next).resolves.toEqual({ ok: true });
+    }
+    await expect(active.client.call("config.patch", {
+      raw: JSON.stringify({ agents: { defaults: { model: { primary: "a/4" } } } }),
+      baseHash: "hash-4",
+    }, new AbortController().signal)).rejects.toMatchObject({
+      kind: "agent_config_conflict",
+    });
+
+    now += 60_001;
+    const afterWindow = active.client.call("config.patch", {
+      raw: JSON.stringify({ agents: { defaults: { model: { primary: "a/5" } } } }),
+      baseHash: "hash-5",
+    }, new AbortController().signal);
+    await vi.waitFor(() => expect(active.socket.sent).toHaveLength(6));
+    const finalRequest = JSON.parse(active.socket.sent[5]!);
+    active.socket.receive({ type: "res", id: finalRequest.id, ok: true, payload: { ok: true } });
+    await expect(afterWindow).resolves.toEqual({ ok: true });
+    await active.client.close();
+    await expect(initialOutcome).resolves.toMatchObject({
+      kind: "runtime_unavailable",
+    });
   });
 });

--- a/tests/gateway/openclaw-rpc.test.ts
+++ b/tests/gateway/openclaw-rpc.test.ts
@@ -123,6 +123,41 @@ describe("OpenClaw gateway RPC", () => {
     await client.close();
   });
 
+  it("accepts the bounded OpenClaw catalog parameter surface", async () => {
+    const socketFactory = vi.fn(() => new FakeSocket());
+    const client = createOpenClawRpcClient({
+      url: "ws://127.0.0.1:18789",
+      token: "f".repeat(64),
+      socketFactory,
+      timeoutMs: 100,
+    });
+
+    await expect(client.call("models.list", {
+      view: "all",
+      includeProviderCapabilities: true,
+    }, new AbortController().signal)).rejects.toMatchObject({
+      kind: "runtime_unavailable",
+    });
+    await expect(client.call("models.authStatus", {
+      refresh: false,
+    }, new AbortController().signal)).rejects.toMatchObject({
+      kind: "runtime_unavailable",
+    });
+    expect(socketFactory).toHaveBeenCalled();
+
+    await expect(client.call("models.list", {
+      view: "private",
+    }, new AbortController().signal)).rejects.toMatchObject({
+      kind: "agent_config_invalid",
+    });
+    await expect(client.call("models.authStatus", {
+      refresh: "yes",
+    }, new AbortController().signal)).rejects.toMatchObject({
+      kind: "agent_config_invalid",
+    });
+    await client.close();
+  });
+
   it("enforces the published eight-correlation ceiling", () => {
     expect(() => createOpenClawRpcClient({
       url: "ws://127.0.0.1:18789",

--- a/tests/gateway/openclaw-rpc.test.ts
+++ b/tests/gateway/openclaw-rpc.test.ts
@@ -1,0 +1,157 @@
+import { EventEmitter } from "node:events";
+import { describe, expect, it, vi } from "vitest";
+import { createOpenClawRpcClient } from "../../packages/gateway/src/agent-config/openclaw-rpc.js";
+
+class FakeSocket extends EventEmitter {
+  readonly sent: string[] = [];
+  readyState = 1;
+  throwOnSend = false;
+
+  send(data: string) {
+    if (this.throwOnSend) throw new Error("send failed");
+    this.sent.push(data);
+  }
+
+  close() {
+    this.readyState = 3;
+    this.emit("close");
+  }
+
+  receive(value: unknown) {
+    this.emit("message", Buffer.from(JSON.stringify(value)));
+  }
+}
+
+async function beginCall(options: { maxPending?: number; timeoutMs?: number } = {}) {
+  const socket = new FakeSocket();
+  const client = createOpenClawRpcClient({
+    url: "ws://127.0.0.1:18789",
+    token: "a".repeat(64),
+    socketFactory: () => socket,
+    ...options,
+  });
+  const call = client.call("health", {}, new AbortController().signal);
+  socket.receive({
+    type: "event",
+    event: "connect.challenge",
+    payload: { nonce: "nonce-1", ts: 1_736_000_000_000 },
+  });
+  await vi.waitFor(() => expect(socket.sent).toHaveLength(1));
+  const connect = JSON.parse(socket.sent[0]!);
+  socket.receive({
+    type: "res",
+    id: connect.id,
+    ok: true,
+    payload: {
+      type: "hello-ok",
+      protocol: 4,
+      server: { version: "2026.7.1", connId: "conn-1" },
+      features: { methods: ["health", "models.list"], events: [] },
+      snapshot: {},
+      auth: { role: "operator", scopes: ["operator.read", "operator.write", "operator.admin"] },
+      policy: { maxPayload: 1024 * 1024, maxBufferedBytes: 2 * 1024 * 1024, tickIntervalMs: 15_000 },
+    },
+  });
+  await vi.waitFor(() => expect(socket.sent).toHaveLength(2));
+  return { client, socket, call, connect, request: JSON.parse(socket.sent[1]!) };
+}
+
+describe("OpenClaw gateway RPC", () => {
+  it("performs the protocol-v4 backend handshake without device pairing", async () => {
+    const { client, socket, call, connect, request } = await beginCall();
+
+    expect(connect).toMatchObject({
+      type: "req",
+      method: "connect",
+      params: {
+        minProtocol: 4,
+        maxProtocol: 4,
+        client: { id: "gateway-client", mode: "backend" },
+        role: "operator",
+        scopes: ["operator.read", "operator.write", "operator.admin"],
+        auth: { token: "a".repeat(64) },
+      },
+    });
+    expect(connect.params).not.toHaveProperty("device");
+    expect(request).toMatchObject({ type: "req", method: "health", params: {} });
+    socket.receive({ type: "res", id: request.id, ok: true, payload: { ok: true } });
+    await expect(call).resolves.toEqual({ ok: true });
+    await client.close();
+  });
+
+  it("rejects methods outside the Matrix allowlist before connecting", async () => {
+    const socketFactory = vi.fn(() => new FakeSocket());
+    const client = createOpenClawRpcClient({
+      url: "ws://127.0.0.1:18789",
+      token: "b".repeat(64),
+      socketFactory,
+    });
+
+    await expect(client.call("plugins.install", {}, new AbortController().signal))
+      .rejects.toMatchObject({ kind: "agent_config_invalid" });
+    expect(socketFactory).not.toHaveBeenCalled();
+  });
+
+  it("caps pending correlations and rejects all work on close", async () => {
+    const { client, call } = await beginCall({ maxPending: 1 });
+    const second = client.call("models.list", {}, new AbortController().signal);
+
+    await expect(second).rejects.toMatchObject({ kind: "agent_config_conflict" });
+    await client.close();
+    await expect(call).rejects.toMatchObject({ kind: "runtime_unavailable" });
+  });
+
+  it("rejects oversized frames without logging frame or token content", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const { client, socket, call } = await beginCall();
+    const canary = `sk-secret-${"x".repeat(1024 * 1024)}`;
+
+    try {
+      socket.emit("message", Buffer.from(canary));
+      await expect(call).rejects.toMatchObject({ kind: "invalid_response" });
+      expect(JSON.stringify(warn.mock.calls)).not.toContain("sk-secret");
+    } finally {
+      warn.mockRestore();
+      await client.close();
+    }
+  });
+
+  it("bounds calls with a timeout and honors caller abort", async () => {
+    const timed = await beginCall({ timeoutMs: 100 });
+    await expect(timed.call).rejects.toMatchObject({ kind: "runtime_unavailable" });
+    await timed.client.close();
+
+    const active = await beginCall();
+    const controller = new AbortController();
+    const aborted = active.client.call("models.list", {}, controller.signal);
+    controller.abort();
+    await expect(aborted).rejects.toMatchObject({ kind: "runtime_unavailable" });
+    const healthClosed = expect(active.call).rejects.toMatchObject({
+      kind: "runtime_unavailable",
+    });
+    await active.client.close();
+    await healthClosed;
+  });
+
+  it("cleans up correlation state when a socket send throws", async () => {
+    const active = await beginCall({ maxPending: 2 });
+    active.socket.throwOnSend = true;
+    await expect(active.client.call(
+      "models.list",
+      {},
+      new AbortController().signal,
+    )).rejects.toMatchObject({ kind: "runtime_unavailable" });
+
+    active.socket.throwOnSend = false;
+    const retry = active.client.call("models.list", {}, new AbortController().signal);
+    await vi.waitFor(() => expect(active.socket.sent).toHaveLength(3));
+    const frame = JSON.parse(active.socket.sent[2]!);
+    active.socket.receive({ type: "res", id: frame.id, ok: true, payload: [] });
+    await expect(retry).resolves.toEqual([]);
+    const healthClosed = expect(active.call).rejects.toMatchObject({
+      kind: "runtime_unavailable",
+    });
+    await active.client.close();
+    await healthClosed;
+  });
+});


### PR DESCRIPTION
## Summary

- add an authenticated OpenClaw protocol-v4 WebSocket client for trusted direct
  loopback backend use
- require the server challenge, negotiate operator read/write/admin scopes, and
  keep device pairing out of the fixed local control-plane path
- expose only the six RPC methods needed for health, channels, model catalog,
  auth status, and revisioned config reads/patches
- cap frames at 1 MiB, serialized requests at 16 KiB, correlations at 8,
  method discovery arrays, call time, connect time, and all shutdown work
- retry bounded startup-sidecar unavailability, accept additive protocol-v4
  hello/event metadata, and ignore callbacks from replaced sockets
- serialize `config.patch` and enforce OpenClaw's three-writes-per-rolling-minute
  limit before transport use
- reject malformed/oversized/provider-error frames with provider-neutral typed
  errors and never log frame, response, or token content

## TDD and validation

- The suite was observed failing because the RPC module did not exist.
- A socket-send cleanup regression was then observed red before correlation
  cleanup and typed error mapping were added.
- Review reds proved request-size, correlation-ceiling, uncertain-call socket
  invalidation, generic-event, additive-hello, stale-callback, startup-retry,
  config-write serialization/rate, handshake-abort, and catalog-parameter schema gaps before each fix.
- OpenClaw RPC suite: 17/17 passed on the exact restacked stack head.
- Full repository gate on the direct pre-review ancestor: 785 files passed, 3 skipped;
  8,497 tests passed, 20 skipped in 1,706.05 seconds. Final exact-tip CI is running.
- Exact validated head: `7dd0b53e1d4930de601b9c6c7cfc2b7aa877f63d`.
- Gateway TypeScript strict check: passed on exact head.
- `bun run check:patterns`: 0 violations, 5 existing warning groups.
- `git diff --check`: passed.
- React Doctor: not applicable; this PR has no React changes.

## Stack

- #980 — runtime mutation and transition controller
- #981 — pinned OpenClaw host runtime
- this PR — authenticated bounded OpenClaw RPC transport

## Invariants

- **Source of truth:** OpenClaw remains authoritative for its runtime config and
  model state. This transport persists nothing and exposes no generic config or
  plugin surface.
- **Lock/transaction scope:** The client admits at most 8 correlated calls per
  connection and serializes `config.patch` behind one bounded owner queue; the
  higher runtime controller remains the sole serializer for cross-runtime
  config mutations and switches.
- **Acceptable orphan states:** Connection loss may leave a runtime-owned RPC
  mutation outcome unknown. The adapter/controller layer above this transport
  must verify and rollback selection before Matrix config commit. No Matrix
  owner file is written by this slice.
- **Auth source of truth:** The owner-local gateway token is supplied only in
  the protocol `connect` frame to a validated `ws://127.0.0.1:18789/` or IPv6
  loopback peer. It is never logged, returned, persisted, placed in the URL, or
  accepted from a browser request.
- **Deferred scope:** Token-file loading, provider/model normalization,
  revisioned config patch/rollback, fixed lifecycle control, delivery wiring,
  settings composition, UI, docs, and preview verification remain subsequent
  stack slices.
- Protocol schemas are strict and bounded. Valid bounded server events are
  discarded after handshake; duplicate challenges cannot resend credentials.
  Malformed frames, missing negotiated scopes, oversized frames, socket errors,
  caller aborts, timeouts, and close all fail closed.
- The method allowlist excludes plugin install, arbitrary config paths, terminal,
  send, sessions, tools, logs, secrets, update, wizard, and pairing RPC.
- Every pending entry has timeout/abort cleanup; once a request may have reached
  OpenClaw, send failure, timeout, or caller abort invalidates that socket and
  rejects all correlated work so an uncertain connection is never reused.
- Failed connections suppress sequential reconnects for one bounded timeout
  interval, concurrent callers share one connect promise, startup-sidecar
  retries remain inside the original connection budget, stale socket callbacks
  cannot affect a replacement, and synchronous socket construction failures
  map to provider-neutral errors.
- Config patches are serialized and limited to 3 starts per rolling 60 seconds;
  excess work fails before opening or reusing a transport.
- This PR has 1,062 additions across 2 files, below the 3,000-addition/50-file
  limits, and will not merge below an exact-head Greptile 5/5 review.

## Rollout

- no merge or promotion requested
- live authenticated handshake and malformed/timeout injection will run on the
  exact preview bundle after the normalized adapter is wired
