### PR TITLE
feat(gateway): normalize OpenClaw runtime config

### DIFF
--- a/packages/gateway/src/agent-config/openclaw-adapter.ts
+++ b/packages/gateway/src/agent-config/openclaw-adapter.ts
@@ -1,0 +1,341 @@
+import {
+  AgentMessagingSelectionSchema,
+  AgentProviderCatalogSchema,
+  AgentRuntimeDescriptorSchema,
+  type AgentAuthKind,
+  type AgentMessagingSelection,
+  type AgentProviderDescriptor,
+} from "@matrix-os/contracts";
+import { z } from "zod/v4";
+import { AgentConfigError } from "./errors.js";
+import type { OpenClawRpcClient } from "./openclaw-rpc.js";
+import type {
+  MessagingRuntimeAdapter,
+  RuntimeConfigureInput,
+} from "./runtime-types.js";
+
+const MAX_OPENCLAW_PROVIDERS = 31;
+const MAX_OPENCLAW_MODELS = 253;
+const MAX_MODELS_PER_PROVIDER = 128;
+
+const ProviderIdSchema = z.string()
+  .trim()
+  .min(1)
+  .max(80)
+  .regex(/^[a-z0-9][a-z0-9_-]{0,79}$/);
+const ModelIdSchema = z.string().trim().min(1).max(160);
+const DisplayNameSchema = z.string().trim().min(1).max(120);
+
+const HostStatusSchema = z.object({
+  installed: z.boolean(),
+  active: z.boolean(),
+  version: z.string().trim().min(1).max(64).optional(),
+}).strict();
+
+const ModelChoiceSchema = z.object({
+  id: ModelIdSchema,
+  name: DisplayNameSchema,
+  provider: ProviderIdSchema,
+  alias: z.string().trim().min(1).max(160).optional(),
+  available: z.boolean().optional(),
+  contextWindow: z.number().int().positive().max(10_000_000).optional(),
+  reasoning: z.boolean().optional(),
+}).strict();
+const ModelsListSchema = z.object({
+  models: z.array(ModelChoiceSchema).max(2_048),
+}).strict();
+
+const AuthProfileSchema = z.object({
+  profileId: z.string().min(1).max(256),
+  type: z.string().min(1).max(32),
+  status: z.string().min(1).max(32),
+}).passthrough();
+const AuthProviderSchema = z.object({
+  provider: ProviderIdSchema,
+  displayName: DisplayNameSchema.optional(),
+  status: z.string().min(1).max(32),
+  profiles: z.array(AuthProfileSchema).max(128),
+}).passthrough();
+const AuthStatusSchema = z.object({
+  ts: z.number().finite(),
+  providers: z.array(AuthProviderSchema).max(256),
+}).strict();
+
+const ConfigSnapshotSchema = z.object({
+  valid: z.literal(true),
+  hash: z.string().min(1).max(256),
+  config: z.object({
+    agents: z.object({
+      defaults: z.object({
+        model: z.object({
+          primary: z.string().trim().min(1).max(241).optional(),
+        }).passthrough().optional(),
+      }).passthrough().optional(),
+    }).passthrough().optional(),
+  }).passthrough(),
+}).passthrough();
+const MutationResponseSchema = z.object({ ok: z.literal(true) }).passthrough();
+const HealthResponseSchema = z.object({
+  ts: z.number().finite().optional(),
+}).passthrough();
+
+export interface OpenClawLifecycle {
+  status(signal: AbortSignal): Promise<unknown>;
+  activate(signal: AbortSignal): Promise<void>;
+  deactivate(signal: AbortSignal): Promise<void>;
+}
+
+interface ConfigSelection {
+  hash: string;
+  primary: string | null;
+  selection: AgentMessagingSelection;
+}
+
+function parsePrimary(primary: string | undefined): AgentMessagingSelection {
+  if (primary === undefined) {
+    return { runtime: "openclaw", provider: null, model: null, configured: false };
+  }
+  const separator = primary.indexOf("/");
+  if (separator <= 0 || separator === primary.length - 1) {
+    throw new AgentConfigError("invalid_response");
+  }
+  const provider = ProviderIdSchema.safeParse(primary.slice(0, separator));
+  const model = ModelIdSchema.safeParse(primary.slice(separator + 1));
+  if (!provider.success || !model.success) {
+    throw new AgentConfigError("invalid_response");
+  }
+  return AgentMessagingSelectionSchema.parse({
+    runtime: "openclaw",
+    provider: provider.data,
+    model: model.data,
+    configured: true,
+  });
+}
+
+function authKindForProvider(profiles: z.infer<typeof AuthProfileSchema>[]): AgentAuthKind {
+  if (profiles.some((profile) => profile.type === "oauth")) return "oauth_login";
+  return "api_key";
+}
+
+function actionForAuth(authKind: AgentAuthKind) {
+  return authKind === "oauth_login"
+    ? "open_login_terminal" as const
+    : "enter_api_key" as const;
+}
+
+function authReady(status: string): boolean {
+  return status === "ok" || status === "static";
+}
+
+function normalizeCatalog(
+  modelResponse: unknown,
+  authResponse: unknown,
+): AgentProviderDescriptor[] {
+  const models = ModelsListSchema.parse(modelResponse).models;
+  const authProviders = AuthStatusSchema.parse(authResponse).providers;
+  const authByProvider = new Map(authProviders.map((provider) => [provider.provider, provider]));
+  const grouped = new Map<string, z.infer<typeof ModelChoiceSchema>[]>();
+  for (const model of models) {
+    const entries = grouped.get(model.provider) ?? [];
+    const duplicateIndex = entries.findIndex((entry) => entry.id === model.id);
+    if (duplicateIndex === -1 && entries.length < MAX_MODELS_PER_PROVIDER) {
+      entries.push(model);
+    } else if (duplicateIndex !== -1
+      && entries[duplicateIndex]?.available !== true
+      && model.available === true) {
+      entries[duplicateIndex] = model;
+    }
+    grouped.set(model.provider, entries);
+  }
+
+  const providers: AgentProviderDescriptor[] = [];
+  let modelCount = 0;
+  for (const [id, entries] of [...grouped].sort(([left], [right]) => left.localeCompare(right))) {
+    if (providers.length === MAX_OPENCLAW_PROVIDERS || modelCount === MAX_OPENCLAW_MODELS) break;
+    const auth = authByProvider.get(id);
+    const authKind = authKindForProvider(auth?.profiles ?? []);
+    const ready = auth === undefined
+      ? entries.some((model) => model.available === true)
+      : authReady(auth.status);
+    const remaining = MAX_OPENCLAW_MODELS - modelCount;
+    const normalizedModels = entries.slice(0, remaining).map((model) => ({
+      id: model.id,
+      displayName: model.name,
+      capabilities: [
+        "tools" as const,
+        ...(model.reasoning === true ? ["reasoning" as const] : []),
+        ...(model.contextWindow !== undefined && model.contextWindow >= 100_000
+          ? ["long_context" as const]
+          : []),
+      ],
+      efforts: [],
+      available: model.available === true,
+    }));
+    const displayName = DisplayNameSchema.safeParse(auth?.displayName);
+    providers.push({
+      id,
+      displayName: displayName.success ? displayName.data : id,
+      runtime: "openclaw",
+      scopes: ["messaging"],
+      authKind,
+      supportedAuthKinds: [authKind],
+      models: normalizedModels,
+      authStatus: ready
+        ? { state: "ready", authenticated: true, action: "none" }
+        : {
+            state: "action_required",
+            authenticated: false,
+            action: actionForAuth(authKind),
+          },
+    });
+    modelCount += normalizedModels.length;
+  }
+  return AgentProviderCatalogSchema.parse(providers);
+}
+
+function primaryPatch(primary: string | null) {
+  return {
+    raw: JSON.stringify({ agents: { defaults: { model: { primary } } } }),
+  };
+}
+
+export function createOpenClawRuntimeAdapter(options: {
+  rpc: OpenClawRpcClient;
+  lifecycle: OpenClawLifecycle;
+}): MessagingRuntimeAdapter {
+  async function readConfig(signal: AbortSignal): Promise<ConfigSelection> {
+    const snapshot = ConfigSnapshotSchema.parse(
+      await options.rpc.call("config.get", {}, signal),
+    );
+    const primary = snapshot.config.agents?.defaults?.model?.primary ?? null;
+    return {
+      hash: snapshot.hash,
+      primary,
+      selection: parsePrimary(primary ?? undefined),
+    };
+  }
+
+  async function patchPrimary(
+    primary: string | null,
+    baseHash: string,
+    signal: AbortSignal,
+  ): Promise<void> {
+    MutationResponseSchema.parse(await options.rpc.call("config.patch", {
+      ...primaryPatch(primary),
+      baseHash,
+    }, signal));
+  }
+
+  async function restorePrimary(previous: string | null): Promise<void> {
+    const signal = AbortSignal.timeout(2_000);
+    try {
+      const current = await readConfig(signal);
+      await patchPrimary(previous, current.hash, signal);
+    } catch (error) {
+      console.warn(
+        "[agent-config] OpenClaw selection restore failed:",
+        error instanceof Error ? error.name : "UnknownError",
+      );
+    }
+  }
+
+  async function catalog(signal: AbortSignal) {
+    const modelResponse = await options.rpc.call("models.list", { view: "all" }, signal);
+    const authResponse = await options.rpc.call(
+      "models.authStatus",
+      { refresh: false },
+      signal,
+    );
+    return normalizeCatalog(modelResponse, authResponse);
+  }
+
+  async function configure(
+    input: RuntimeConfigureInput,
+    signal: AbortSignal,
+  ): Promise<AgentMessagingSelection> {
+    if (input.baseUrl !== undefined) throw new AgentConfigError("not_configured");
+    const providers = await catalog(signal);
+    const provider = providers.find((entry) => entry.id === input.provider);
+    if (provider?.models.some((model) =>
+      model.id === input.model && model.available
+    ) !== true) {
+      throw new AgentConfigError("not_configured");
+    }
+    const previous = await readConfig(signal);
+    const primary = `${input.provider}/${input.model}`;
+    await patchPrimary(primary, previous.hash, signal);
+    try {
+      const verified = await readConfig(signal);
+      if (verified.primary !== primary) throw new AgentConfigError("invalid_response");
+      return verified.selection;
+    } catch (error) {
+      await restorePrimary(previous.primary);
+      if (error instanceof AgentConfigError) throw error;
+      throw new AgentConfigError("invalid_response", error);
+    }
+  }
+
+  return {
+    id: "openclaw",
+    async probe(signal) {
+      const host = HostStatusSchema.parse(await options.lifecycle.status(signal));
+      if (!host.installed) {
+        return AgentRuntimeDescriptorSchema.parse({
+          id: "openclaw",
+          displayName: "OpenClaw",
+          installState: "missing",
+          health: "stopped",
+          selectionState: "unavailable",
+          configured: false,
+          capabilities: ["install"],
+          setupAction: "install",
+        });
+      }
+      if (!host.active) {
+        return AgentRuntimeDescriptorSchema.parse({
+          id: "openclaw",
+          displayName: "OpenClaw",
+          installState: "installed",
+          health: "stopped",
+          selectionState: "available",
+          configured: false,
+          ...(host.version === undefined ? {} : { version: host.version }),
+          capabilities: ["provider_catalog", "model_selection", "authentication"],
+        });
+      }
+      HealthResponseSchema.parse(await options.rpc.call("health", {}, signal));
+      const current = await readConfig(signal);
+      return AgentRuntimeDescriptorSchema.parse({
+        id: "openclaw",
+        displayName: "OpenClaw",
+        installState: "installed",
+        health: "healthy",
+        selectionState: "active",
+        configured: current.selection.configured,
+        ...(host.version === undefined ? {} : { version: host.version }),
+        capabilities: ["provider_catalog", "model_selection", "authentication"],
+      });
+    },
+    catalog,
+    async selection(signal) {
+      return (await readConfig(signal)).selection;
+    },
+    configure,
+    async prepare(signal) {
+      const host = HostStatusSchema.parse(await options.lifecycle.status(signal));
+      if (!host.installed) throw new AgentConfigError("runtime_unavailable");
+    },
+    async activate(signal) {
+      await options.lifecycle.activate(signal);
+    },
+    async deactivate(signal) {
+      await options.lifecycle.deactivate(signal);
+    },
+    async dashboard() {
+      return null;
+    },
+    async close() {
+      await options.rpc.close();
+    },
+  };
+}

--- a/packages/gateway/src/agent-config/openclaw-adapter.ts
+++ b/packages/gateway/src/agent-config/openclaw-adapter.ts
@@ -263,8 +263,11 @@ export function createOpenClawRuntimeAdapter(options: {
     }
     const previous = await readConfig(signal);
     const primary = `${input.provider}/${input.model}`;
-    await patchPrimary(primary, previous.hash, signal);
     try {
+      // A transport failure can occur after OpenClaw accepted the patch but
+      // before Matrix received the response. Keep the write inside the
+      // restore boundary so an unknown outcome is treated like a mismatch.
+      await patchPrimary(primary, previous.hash, signal);
       const verified = await readConfig(signal);
       if (verified.primary !== primary) throw new AgentConfigError("invalid_response");
       return verified.selection;

--- a/packages/gateway/src/agent-config/openclaw-adapter.ts
+++ b/packages/gateway/src/agent-config/openclaw-adapter.ts
@@ -39,8 +39,9 @@ const ModelChoiceSchema = z.object({
   alias: z.string().trim().min(1).max(160).optional(),
   available: z.boolean().optional(),
   contextWindow: z.number().int().positive().max(10_000_000).optional(),
+  contextTokens: z.number().int().positive().max(10_000_000).optional(),
   reasoning: z.boolean().optional(),
-}).strict();
+}).passthrough();
 const ModelsListSchema = z.object({
   models: z.array(ModelChoiceSchema).max(2_048),
 }).strict();
@@ -67,15 +68,19 @@ const ConfigSnapshotSchema = z.object({
   config: z.object({
     agents: z.object({
       defaults: z.object({
-        model: z.object({
-          primary: z.string().trim().min(1).max(241).nullish(),
-        }).passthrough().optional(),
+        model: z.union([
+          z.string().trim().min(1).max(241),
+          z.object({
+            primary: z.string().trim().min(1).max(241).nullish(),
+          }).passthrough(),
+        ]).optional(),
       }).passthrough().optional(),
     }).passthrough().optional(),
   }).passthrough(),
 }).passthrough();
 const MutationResponseSchema = z.object({ ok: z.literal(true) }).passthrough();
 const HealthResponseSchema = z.object({
+  ok: z.literal(true),
   ts: z.number().finite().optional(),
 }).passthrough();
 
@@ -124,7 +129,7 @@ function actionForAuth(authKind: AgentAuthKind) {
 }
 
 function authReady(status: string): boolean {
-  return status === "ok" || status === "static";
+  return status === "ok" || status === "static" || status === "expiring";
 }
 
 function normalizeCatalog(
@@ -142,12 +147,15 @@ function normalizeCatalog(
       grouped.set(model.provider, entries);
     }
     const duplicateIndex = entries.findIndex((entry) => entry.id === model.id);
-    if (duplicateIndex === -1 && entries.length < MAX_MODELS_PER_PROVIDER) {
-      entries.push(model);
-    } else if (duplicateIndex !== -1
+    if (duplicateIndex !== -1
       && entries[duplicateIndex]?.available !== true
       && model.available === true) {
       entries[duplicateIndex] = model;
+    } else if (duplicateIndex === -1 && entries.length < MAX_MODELS_PER_PROVIDER) {
+      entries.push(model);
+    } else if (duplicateIndex === -1 && model.available === true) {
+      const unavailableIndex = entries.findIndex((entry) => entry.available !== true);
+      if (unavailableIndex !== -1) entries[unavailableIndex] = model;
     }
   }
 
@@ -167,7 +175,7 @@ function normalizeCatalog(
       capabilities: [
         "tools" as const,
         ...(model.reasoning === true ? ["reasoning" as const] : []),
-        ...(model.contextWindow !== undefined && model.contextWindow >= 100_000
+        ...((model.contextWindow ?? model.contextTokens ?? 0) >= 100_000
           ? ["long_context" as const]
           : []),
       ],
@@ -213,7 +221,10 @@ export function createOpenClawRuntimeAdapter(options: {
     const snapshot = ConfigSnapshotSchema.parse(
       await options.rpc.call("config.get", {}, signal),
     );
-    const primary = snapshot.config.agents?.defaults?.model?.primary ?? null;
+    const modelConfig = snapshot.config.agents?.defaults?.model;
+    const primary = typeof modelConfig === "string"
+      ? modelConfig
+      : modelConfig?.primary ?? null;
     let selection: AgentMessagingSelection;
     try {
       selection = parsePrimary(primary ?? undefined);
@@ -258,12 +269,10 @@ export function createOpenClawRuntimeAdapter(options: {
   }
 
   async function catalog(signal: AbortSignal) {
-    const modelResponse = await options.rpc.call("models.list", { view: "all" }, signal);
-    const authResponse = await options.rpc.call(
-      "models.authStatus",
-      { refresh: false },
-      signal,
-    );
+    const [modelResponse, authResponse] = await Promise.all([
+      options.rpc.call("models.list", { view: "configured" }, signal),
+      options.rpc.call("models.authStatus", { refresh: false }, signal),
+    ]);
     return normalizeCatalog(modelResponse, authResponse);
   }
 
@@ -279,18 +288,24 @@ export function createOpenClawRuntimeAdapter(options: {
     ) !== true) {
       throw new AgentConfigError("not_configured");
     }
-    const previous = await readConfig(signal);
+    const previous = await readConfig(signal, true);
     const primary = `${input.provider}/${input.model}`;
+    let patchMayHaveApplied = false;
     try {
       // A transport failure can occur after OpenClaw accepted the patch but
       // before Matrix received the response. Keep the write inside the
       // restore boundary so an unknown outcome is treated like a mismatch.
       await patchPrimary(primary, previous.hash, signal);
+      patchMayHaveApplied = true;
       const verified = await readConfig(signal);
       if (verified.primary !== primary) throw new AgentConfigError("invalid_response");
       return verified.selection;
     } catch (error) {
-      await restorePrimary(previous.primary);
+      const outcomeIsAmbiguous = !(error instanceof AgentConfigError)
+        || error.kind === "runtime_unavailable";
+      if (patchMayHaveApplied || outcomeIsAmbiguous) {
+        await restorePrimary(previous.primary);
+      }
       if (error instanceof AgentConfigError) throw error;
       throw new AgentConfigError("invalid_response", error);
     }
@@ -339,7 +354,7 @@ export function createOpenClawRuntimeAdapter(options: {
     },
     catalog,
     async selection(signal) {
-      return (await readConfig(signal)).selection;
+      return (await readConfig(signal, true)).selection;
     },
     configure,
     async prepare(signal) {

--- a/packages/gateway/src/agent-config/openclaw-adapter.ts
+++ b/packages/gateway/src/agent-config/openclaw-adapter.ts
@@ -68,7 +68,7 @@ const ConfigSnapshotSchema = z.object({
     agents: z.object({
       defaults: z.object({
         model: z.object({
-          primary: z.string().trim().min(1).max(241).optional(),
+          primary: z.string().trim().min(1).max(241).nullish(),
         }).passthrough().optional(),
       }).passthrough().optional(),
     }).passthrough().optional(),
@@ -133,10 +133,14 @@ function normalizeCatalog(
 ): AgentProviderDescriptor[] {
   const models = ModelsListSchema.parse(modelResponse).models;
   const authProviders = AuthStatusSchema.parse(authResponse).providers;
-  const authByProvider = new Map(authProviders.map((provider) => [provider.provider, provider]));
   const grouped = new Map<string, z.infer<typeof ModelChoiceSchema>[]>();
   for (const model of models) {
-    const entries = grouped.get(model.provider) ?? [];
+    let entries = grouped.get(model.provider);
+    if (entries === undefined) {
+      if (grouped.size >= MAX_OPENCLAW_PROVIDERS) continue;
+      entries = [];
+      grouped.set(model.provider, entries);
+    }
     const duplicateIndex = entries.findIndex((entry) => entry.id === model.id);
     if (duplicateIndex === -1 && entries.length < MAX_MODELS_PER_PROVIDER) {
       entries.push(model);
@@ -145,14 +149,13 @@ function normalizeCatalog(
       && model.available === true) {
       entries[duplicateIndex] = model;
     }
-    grouped.set(model.provider, entries);
   }
 
   const providers: AgentProviderDescriptor[] = [];
   let modelCount = 0;
   for (const [id, entries] of [...grouped].sort(([left], [right]) => left.localeCompare(right))) {
     if (providers.length === MAX_OPENCLAW_PROVIDERS || modelCount === MAX_OPENCLAW_MODELS) break;
-    const auth = authByProvider.get(id);
+    const auth = authProviders.find((candidate) => candidate.provider === id);
     const authKind = authKindForProvider(auth?.profiles ?? []);
     const ready = auth === undefined
       ? entries.some((model) => model.available === true)
@@ -203,15 +206,30 @@ export function createOpenClawRuntimeAdapter(options: {
   rpc: OpenClawRpcClient;
   lifecycle: OpenClawLifecycle;
 }): MessagingRuntimeAdapter {
-  async function readConfig(signal: AbortSignal): Promise<ConfigSelection> {
+  async function readConfig(
+    signal: AbortSignal,
+    tolerateMalformedPrimary = false,
+  ): Promise<ConfigSelection> {
     const snapshot = ConfigSnapshotSchema.parse(
       await options.rpc.call("config.get", {}, signal),
     );
     const primary = snapshot.config.agents?.defaults?.model?.primary ?? null;
+    let selection: AgentMessagingSelection;
+    try {
+      selection = parsePrimary(primary ?? undefined);
+    } catch (error) {
+      if (!tolerateMalformedPrimary || !(error instanceof AgentConfigError)) throw error;
+      selection = {
+        runtime: "openclaw",
+        provider: null,
+        model: null,
+        configured: false,
+      };
+    }
     return {
       hash: snapshot.hash,
       primary,
-      selection: parsePrimary(primary ?? undefined),
+      selection,
     };
   }
 
@@ -307,7 +325,7 @@ export function createOpenClawRuntimeAdapter(options: {
         });
       }
       HealthResponseSchema.parse(await options.rpc.call("health", {}, signal));
-      const current = await readConfig(signal);
+      const current = await readConfig(signal, true);
       return AgentRuntimeDescriptorSchema.parse({
         id: "openclaw",
         displayName: "OpenClaw",

--- a/tests/gateway/openclaw-runtime-adapter.test.ts
+++ b/tests/gateway/openclaw-runtime-adapter.test.ts
@@ -1,0 +1,244 @@
+import { describe, expect, it, vi } from "vitest";
+import { createOpenClawRuntimeAdapter } from "../../packages/gateway/src/agent-config/openclaw-adapter.js";
+
+function createRpc(responses: Record<string, unknown[]>) {
+  return {
+    call: vi.fn(async (method: string) => {
+      const queue = responses[method];
+      if (!queue?.length) throw new Error(`Unexpected RPC method: ${method}`);
+      return queue.shift();
+    }),
+    close: vi.fn(async () => {}),
+  };
+}
+
+function config(primary: string | null, hash = "config-hash") {
+  return {
+    valid: true,
+    hash,
+    config: primary === null
+      ? { agents: { defaults: { model: {} } } }
+      : { agents: { defaults: { model: { primary } } } },
+  };
+}
+
+const models = {
+  models: [{
+    id: "claude-opus-4-6",
+    name: "Claude Opus 4.6",
+    provider: "anthropic",
+    available: true,
+    contextWindow: 200_000,
+    reasoning: true,
+  }, {
+    id: "claude-sonnet-4-5",
+    name: "Claude Sonnet 4.5",
+    provider: "anthropic",
+    available: false,
+  }, {
+    id: "claude-sonnet-4-5",
+    name: "Claude Sonnet 4.5",
+    provider: "anthropic",
+    available: false,
+  }, {
+    id: "gpt-5.4",
+    name: "GPT-5.4",
+    provider: "openai",
+    available: true,
+  }],
+};
+
+const auth = {
+  ts: 1_789_000_000_000,
+  providers: [{
+    provider: "anthropic",
+    displayName: "Anthropic",
+    status: "ok",
+    profiles: [{ profileId: "anthropic:default", type: "oauth", status: "ok" }],
+  }, {
+    provider: "openai",
+    displayName: "OpenAI",
+    status: "static",
+    profiles: [{ profileId: "openai:default", type: "api_key", status: "static" }],
+  }],
+};
+
+function lifecycle(overrides: { installed?: boolean; active?: boolean } = {}) {
+  return {
+    status: vi.fn(async () => ({
+      installed: overrides.installed ?? true,
+      active: overrides.active ?? true,
+      version: "2026.7.1",
+    })),
+    activate: vi.fn(async () => {}),
+    deactivate: vi.fn(async () => {}),
+  };
+}
+
+describe("OpenClaw messaging runtime adapter", () => {
+  it("normalizes the bounded model and authentication catalogs", async () => {
+    const rpc = createRpc({
+      "models.list": [models],
+      "models.authStatus": [auth],
+    });
+    const adapter = createOpenClawRuntimeAdapter({ rpc, lifecycle: lifecycle() });
+
+    await expect(adapter.catalog(new AbortController().signal)).resolves.toEqual([
+      expect.objectContaining({
+        id: "anthropic",
+        displayName: "Anthropic",
+        runtime: "openclaw",
+        authKind: "oauth_login",
+        authStatus: { state: "ready", authenticated: true, action: "none" },
+        models: [expect.objectContaining({
+          id: "claude-opus-4-6",
+          displayName: "Claude Opus 4.6",
+          capabilities: ["tools", "reasoning", "long_context"],
+          available: true,
+        }), expect.objectContaining({ id: "claude-sonnet-4-5", available: false })],
+      }),
+      expect.objectContaining({
+        id: "openai",
+        authKind: "api_key",
+        authStatus: { state: "ready", authenticated: true, action: "none" },
+      }),
+    ]);
+    expect(rpc.call).toHaveBeenNthCalledWith(
+      1,
+      "models.list",
+      { view: "all" },
+      expect.any(AbortSignal),
+    );
+    expect(rpc.call).toHaveBeenNthCalledWith(
+      2,
+      "models.authStatus",
+      { refresh: false },
+      expect.any(AbortSignal),
+    );
+  });
+
+  it("reads the selected provider/model only from the redacted config snapshot", async () => {
+    const rpc = createRpc({ "config.get": [config("anthropic/claude-opus-4-6")] });
+    const adapter = createOpenClawRuntimeAdapter({ rpc, lifecycle: lifecycle() });
+
+    await expect(adapter.selection(new AbortController().signal)).resolves.toEqual({
+      runtime: "openclaw",
+      provider: "anthropic",
+      model: "claude-opus-4-6",
+      configured: true,
+    });
+  });
+
+  it("patches a catalog-backed selection with OpenClaw optimistic concurrency", async () => {
+    const rpc = createRpc({
+      "models.list": [models],
+      "models.authStatus": [auth],
+      "config.get": [
+        config("openai/gpt-5.4", "before-hash"),
+        config("anthropic/claude-opus-4-6", "after-hash"),
+      ],
+      "config.patch": [{ ok: true }],
+    });
+    const adapter = createOpenClawRuntimeAdapter({ rpc, lifecycle: lifecycle() });
+
+    await expect(adapter.configure({
+      provider: "anthropic",
+      model: "claude-opus-4-6",
+    }, new AbortController().signal)).resolves.toMatchObject({
+      provider: "anthropic",
+      model: "claude-opus-4-6",
+    });
+    expect(rpc.call).toHaveBeenCalledWith(
+      "config.patch",
+      {
+        raw: JSON.stringify({
+          agents: { defaults: { model: { primary: "anthropic/claude-opus-4-6" } } },
+        }),
+        baseHash: "before-hash",
+      },
+      expect.any(AbortSignal),
+    );
+  });
+
+  it("rejects unavailable selections and custom base URLs before mutation", async () => {
+    const rpc = createRpc({
+      "models.list": [models, models],
+      "models.authStatus": [auth, auth],
+    });
+    const adapter = createOpenClawRuntimeAdapter({ rpc, lifecycle: lifecycle() });
+    const signal = new AbortController().signal;
+
+    await expect(adapter.configure({
+      provider: "anthropic",
+      model: "claude-sonnet-4-5",
+    }, signal)).rejects.toMatchObject({ kind: "not_configured" });
+    await expect(adapter.configure({
+      provider: "anthropic",
+      model: "claude-opus-4-6",
+      baseUrl: "https://models.example.com/v1",
+    }, signal)).rejects.toMatchObject({ kind: "not_configured" });
+    expect(rpc.call).not.toHaveBeenCalledWith(
+      "config.patch",
+      expect.anything(),
+      expect.anything(),
+    );
+  });
+
+  it("restores the prior primary when post-patch verification mismatches", async () => {
+    const rpc = createRpc({
+      "models.list": [models],
+      "models.authStatus": [auth],
+      "config.get": [
+        config("openai/gpt-5.4", "before-hash"),
+        config("openai/gpt-5.4", "mutated-hash"),
+        config("anthropic/claude-opus-4-6", "rollback-read-hash"),
+      ],
+      "config.patch": [{ ok: true }, { ok: true }],
+    });
+    const adapter = createOpenClawRuntimeAdapter({ rpc, lifecycle: lifecycle() });
+
+    await expect(adapter.configure({
+      provider: "anthropic",
+      model: "claude-opus-4-6",
+    }, new AbortController().signal)).rejects.toMatchObject({
+      kind: "invalid_response",
+    });
+    const patchCalls = rpc.call.mock.calls.filter(([method]) => method === "config.patch");
+    expect(patchCalls).toHaveLength(2);
+    expect(patchCalls[1]?.[1]).toEqual({
+      raw: JSON.stringify({
+        agents: { defaults: { model: { primary: "openai/gpt-5.4" } } },
+      }),
+      baseHash: "rollback-read-hash",
+    });
+  });
+
+  it("fails closed when OpenClaw is absent and health-checks active installs", async () => {
+    const missingRpc = createRpc({});
+    const missing = createOpenClawRuntimeAdapter({
+      rpc: missingRpc,
+      lifecycle: lifecycle({ installed: false, active: false }),
+    });
+    await expect(missing.probe(new AbortController().signal)).resolves.toMatchObject({
+      id: "openclaw",
+      installState: "missing",
+      health: "stopped",
+      selectionState: "unavailable",
+      setupAction: "install",
+    });
+    expect(missingRpc.call).not.toHaveBeenCalled();
+
+    const activeRpc = createRpc({
+      health: [{ ts: 1_789_000_000_000 }],
+      "config.get": [config("anthropic/claude-opus-4-6")],
+    });
+    const active = createOpenClawRuntimeAdapter({ rpc: activeRpc, lifecycle: lifecycle() });
+    await expect(active.probe(new AbortController().signal)).resolves.toMatchObject({
+      installState: "installed",
+      health: "healthy",
+      selectionState: "active",
+      configured: true,
+      version: "2026.7.1",
+    });
+  });
+});

--- a/tests/gateway/openclaw-runtime-adapter.test.ts
+++ b/tests/gateway/openclaw-runtime-adapter.test.ts
@@ -6,7 +6,9 @@ function createRpc(responses: Record<string, unknown[]>) {
     call: vi.fn(async (method: string) => {
       const queue = responses[method];
       if (!queue?.length) throw new Error(`Unexpected RPC method: ${method}`);
-      return queue.shift();
+      const response = queue.shift();
+      if (response instanceof Error) throw response;
+      return response;
     }),
     close: vi.fn(async () => {}),
   };
@@ -213,6 +215,58 @@ describe("OpenClaw messaging runtime adapter", () => {
     });
   });
 
+  it("restores the prior primary when the initial patch outcome is unknown", async () => {
+    const rpc = createRpc({
+      "models.list": [models],
+      "models.authStatus": [auth],
+      "config.get": [
+        config("openai/gpt-5.4", "before-hash"),
+        config("anthropic/claude-opus-4-6", "rollback-read-hash"),
+      ],
+      "config.patch": [new Error("connection closed after write"), { ok: true }],
+    });
+    const adapter = createOpenClawRuntimeAdapter({ rpc, lifecycle: lifecycle() });
+
+    await expect(adapter.configure({
+      provider: "anthropic",
+      model: "claude-opus-4-6",
+    }, new AbortController().signal)).rejects.toMatchObject({ kind: "invalid_response" });
+
+    const patchCalls = rpc.call.mock.calls.filter(([method]) => method === "config.patch");
+    expect(patchCalls).toHaveLength(2);
+    expect(patchCalls[1]?.[1]).toEqual({
+      raw: JSON.stringify({
+        agents: { defaults: { model: { primary: "openai/gpt-5.4" } } },
+      }),
+      baseHash: "rollback-read-hash",
+    });
+  });
+
+  it("can restore an initially unset primary after a verification mismatch", async () => {
+    const rpc = createRpc({
+      "models.list": [models],
+      "models.authStatus": [auth],
+      "config.get": [
+        config(null, "before-hash"),
+        config("openai/gpt-5.4", "mutated-hash"),
+        config("anthropic/claude-opus-4-6", "rollback-read-hash"),
+      ],
+      "config.patch": [{ ok: true }, { ok: true }],
+    });
+    const adapter = createOpenClawRuntimeAdapter({ rpc, lifecycle: lifecycle() });
+
+    await expect(adapter.configure({
+      provider: "anthropic",
+      model: "claude-opus-4-6",
+    }, new AbortController().signal)).rejects.toMatchObject({ kind: "invalid_response" });
+
+    const patchCalls = rpc.call.mock.calls.filter(([method]) => method === "config.patch");
+    expect(patchCalls[1]?.[1]).toEqual({
+      raw: JSON.stringify({ agents: { defaults: { model: { primary: null } } } }),
+      baseHash: "rollback-read-hash",
+    });
+  });
+
   it("fails closed when OpenClaw is absent and health-checks active installs", async () => {
     const missingRpc = createRpc({});
     const missing = createOpenClawRuntimeAdapter({
@@ -227,6 +281,19 @@ describe("OpenClaw messaging runtime adapter", () => {
       setupAction: "install",
     });
     expect(missingRpc.call).not.toHaveBeenCalled();
+
+    const stoppedRpc = createRpc({});
+    const stopped = createOpenClawRuntimeAdapter({
+      rpc: stoppedRpc,
+      lifecycle: lifecycle({ installed: true, active: false }),
+    });
+    await expect(stopped.probe(new AbortController().signal)).resolves.toMatchObject({
+      installState: "installed",
+      health: "stopped",
+      selectionState: "available",
+      configured: false,
+    });
+    expect(stoppedRpc.call).not.toHaveBeenCalled();
 
     const activeRpc = createRpc({
       health: [{ ts: 1_789_000_000_000 }],

--- a/tests/gateway/openclaw-runtime-adapter.test.ts
+++ b/tests/gateway/openclaw-runtime-adapter.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import { createOpenClawRuntimeAdapter } from "../../packages/gateway/src/agent-config/openclaw-adapter.js";
+import { AgentConfigError } from "../../packages/gateway/src/agent-config/errors.js";
 
 function createRpc(responses: Record<string, unknown[]>) {
   return {
@@ -108,7 +109,7 @@ describe("OpenClaw messaging runtime adapter", () => {
     expect(rpc.call).toHaveBeenNthCalledWith(
       1,
       "models.list",
-      { view: "all" },
+      { view: "configured" },
       expect.any(AbortSignal),
     );
     expect(rpc.call).toHaveBeenNthCalledWith(
@@ -117,6 +118,68 @@ describe("OpenClaw messaging runtime adapter", () => {
       { refresh: false },
       expect.any(AbortSignal),
     );
+  });
+
+  it("accepts OpenClaw catalog metadata and expiring credentials", async () => {
+    const rpc = createRpc({
+      "models.list": [{
+        models: [{
+          id: "claude-opus-4-6",
+          name: "Claude Opus 4.6",
+          provider: "anthropic",
+          available: true,
+          contextTokens: 200_000,
+          releaseDate: "2026-04-01",
+        }],
+      }],
+      "models.authStatus": [{
+        ts: 1_789_000_000_000,
+        providers: [{
+          provider: "anthropic",
+          status: "expiring",
+          profiles: [{ profileId: "anthropic:default", type: "oauth", status: "expiring" }],
+        }],
+      }],
+    });
+    const adapter = createOpenClawRuntimeAdapter({ rpc, lifecycle: lifecycle() });
+
+    await expect(adapter.catalog(new AbortController().signal)).resolves.toEqual([
+      expect.objectContaining({
+        id: "anthropic",
+        authStatus: { state: "ready", authenticated: true, action: "none" },
+        models: [expect.objectContaining({
+          id: "claude-opus-4-6",
+          capabilities: ["tools", "long_context"],
+        })],
+      }),
+    ]);
+  });
+
+  it("retains an available model when a provider catalog exceeds its cap", async () => {
+    const providerModels = [
+      ...Array.from({ length: 128 }, (_, index) => ({
+        id: `unavailable-${index}`,
+        name: `Unavailable ${index}`,
+        provider: "anthropic",
+        available: false,
+      })),
+      {
+        id: "available-model",
+        name: "Available Model",
+        provider: "anthropic",
+        available: true,
+      },
+    ];
+    const rpc = createRpc({
+      "models.list": [{ models: providerModels }],
+      "models.authStatus": [{ ts: 1_789_000_000_000, providers: [] }],
+    });
+    const adapter = createOpenClawRuntimeAdapter({ rpc, lifecycle: lifecycle() });
+
+    const catalog = await adapter.catalog(new AbortController().signal);
+
+    expect(catalog[0]?.models).toHaveLength(128);
+    expect(catalog[0]?.models.some((model) => model.id === "available-model")).toBe(true);
   });
 
   it("caps provider grouping during catalog ingestion", async () => {
@@ -141,6 +204,24 @@ describe("OpenClaw messaging runtime adapter", () => {
 
   it("reads the selected provider/model only from the redacted config snapshot", async () => {
     const rpc = createRpc({ "config.get": [config("anthropic/claude-opus-4-6")] });
+    const adapter = createOpenClawRuntimeAdapter({ rpc, lifecycle: lifecycle() });
+
+    await expect(adapter.selection(new AbortController().signal)).resolves.toEqual({
+      runtime: "openclaw",
+      provider: "anthropic",
+      model: "claude-opus-4-6",
+      configured: true,
+    });
+  });
+
+  it("accepts OpenClaw's shorthand string model configuration", async () => {
+    const rpc = createRpc({
+      "config.get": [{
+        valid: true,
+        hash: "config-hash",
+        config: { agents: { defaults: { model: "anthropic/claude-opus-4-6" } } },
+      }],
+    });
     const adapter = createOpenClawRuntimeAdapter({ rpc, lifecycle: lifecycle() });
 
     await expect(adapter.selection(new AbortController().signal)).resolves.toEqual({
@@ -280,6 +361,48 @@ describe("OpenClaw messaging runtime adapter", () => {
     });
   });
 
+  it("does not overwrite a concurrent selection after a rejected patch", async () => {
+    const rpc = createRpc({
+      "models.list": [models],
+      "models.authStatus": [auth],
+      "config.get": [config("openai/gpt-5.4", "before-hash")],
+      "config.patch": [new AgentConfigError("agent_config_conflict")],
+    });
+    const adapter = createOpenClawRuntimeAdapter({ rpc, lifecycle: lifecycle() });
+
+    await expect(adapter.configure({
+      provider: "anthropic",
+      model: "claude-opus-4-6",
+    }, new AbortController().signal)).rejects.toMatchObject({
+      kind: "agent_config_conflict",
+    });
+
+    expect(rpc.call.mock.calls.filter(([method]) => method === "config.patch")).toHaveLength(1);
+    expect(rpc.call.mock.calls.filter(([method]) => method === "config.get")).toHaveLength(1);
+  });
+
+  it("recovers from a malformed existing primary when configuring a valid model", async () => {
+    const rpc = createRpc({
+      "models.list": [models],
+      "models.authStatus": [auth],
+      "config.get": [
+        config("INVALID PRIMARY", "before-hash"),
+        config("anthropic/claude-opus-4-6", "after-hash"),
+      ],
+      "config.patch": [{ ok: true }],
+    });
+    const adapter = createOpenClawRuntimeAdapter({ rpc, lifecycle: lifecycle() });
+
+    await expect(adapter.configure({
+      provider: "anthropic",
+      model: "claude-opus-4-6",
+    }, new AbortController().signal)).resolves.toMatchObject({
+      provider: "anthropic",
+      model: "claude-opus-4-6",
+      configured: true,
+    });
+  });
+
   it("can restore an initially unset primary after a verification mismatch", async () => {
     const rpc = createRpc({
       "models.list": [models],
@@ -334,7 +457,7 @@ describe("OpenClaw messaging runtime adapter", () => {
     expect(stoppedRpc.call).not.toHaveBeenCalled();
 
     const activeRpc = createRpc({
-      health: [{ ts: 1_789_000_000_000 }],
+      health: [{ ok: true, ts: 1_789_000_000_000 }],
       "config.get": [config("anthropic/claude-opus-4-6")],
     });
     const active = createOpenClawRuntimeAdapter({ rpc: activeRpc, lifecycle: lifecycle() });
@@ -347,7 +470,7 @@ describe("OpenClaw messaging runtime adapter", () => {
     });
 
     const malformedRpc = createRpc({
-      health: [{ ts: 1_789_000_000_001 }],
+      health: [{ ok: true, ts: 1_789_000_000_001 }],
       "config.get": [config("INVALID PRIMARY")],
     });
     const malformed = createOpenClawRuntimeAdapter({ rpc: malformedRpc, lifecycle: lifecycle() });
@@ -357,5 +480,19 @@ describe("OpenClaw messaging runtime adapter", () => {
       selectionState: "active",
       configured: false,
     });
+
+    const unhealthyRpc = createRpc({
+      health: [{ ok: false, ts: 1_789_000_000_002 }],
+    });
+    const unhealthy = createOpenClawRuntimeAdapter({
+      rpc: unhealthyRpc,
+      lifecycle: lifecycle(),
+    });
+    await expect(unhealthy.probe(new AbortController().signal)).rejects.toBeDefined();
+    expect(unhealthyRpc.call).not.toHaveBeenCalledWith(
+      "config.get",
+      expect.anything(),
+      expect.anything(),
+    );
   });
 });

--- a/tests/gateway/openclaw-runtime-adapter.test.ts
+++ b/tests/gateway/openclaw-runtime-adapter.test.ts
@@ -119,6 +119,26 @@ describe("OpenClaw messaging runtime adapter", () => {
     );
   });
 
+  it("caps provider grouping during catalog ingestion", async () => {
+    const providerModels = Array.from({ length: 32 }, (_, index) => ({
+      id: `model-${index}`,
+      name: `Model ${index}`,
+      provider: `p${String(index).padStart(2, "0")}`,
+      available: true,
+    })).reverse();
+    const rpc = createRpc({
+      "models.list": [{ models: providerModels }],
+      "models.authStatus": [{ ts: 1_789_000_000_000, providers: [] }],
+    });
+    const adapter = createOpenClawRuntimeAdapter({ rpc, lifecycle: lifecycle() });
+
+    const catalog = await adapter.catalog(new AbortController().signal);
+
+    expect(catalog).toHaveLength(31);
+    expect(catalog.some((provider) => provider.id === "p31")).toBe(true);
+    expect(catalog.some((provider) => provider.id === "p00")).toBe(false);
+  });
+
   it("reads the selected provider/model only from the redacted config snapshot", async () => {
     const rpc = createRpc({ "config.get": [config("anthropic/claude-opus-4-6")] });
     const adapter = createOpenClawRuntimeAdapter({ rpc, lifecycle: lifecycle() });
@@ -128,6 +148,24 @@ describe("OpenClaw messaging runtime adapter", () => {
       provider: "anthropic",
       model: "claude-opus-4-6",
       configured: true,
+    });
+  });
+
+  it("accepts an explicit null primary as an unconfigured selection", async () => {
+    const rpc = createRpc({
+      "config.get": [{
+        valid: true,
+        hash: "config-hash",
+        config: { agents: { defaults: { model: { primary: null } } } },
+      }],
+    });
+    const adapter = createOpenClawRuntimeAdapter({ rpc, lifecycle: lifecycle() });
+
+    await expect(adapter.selection(new AbortController().signal)).resolves.toEqual({
+      runtime: "openclaw",
+      provider: null,
+      model: null,
+      configured: false,
     });
   });
 
@@ -306,6 +344,18 @@ describe("OpenClaw messaging runtime adapter", () => {
       selectionState: "active",
       configured: true,
       version: "2026.7.1",
+    });
+
+    const malformedRpc = createRpc({
+      health: [{ ts: 1_789_000_000_001 }],
+      "config.get": [config("INVALID PRIMARY")],
+    });
+    const malformed = createOpenClawRuntimeAdapter({ rpc: malformedRpc, lifecycle: lifecycle() });
+    await expect(malformed.probe(new AbortController().signal)).resolves.toMatchObject({
+      installState: "installed",
+      health: "healthy",
+      selectionState: "active",
+      configured: false,
     });
   });
 });


### PR DESCRIPTION
## Summary

- normalize bounded OpenClaw 2026.7.1 model and authentication responses into the shared provider contract
- accept both documented shorthand and object model configuration while tolerating bounded upstream metadata
- read and update `agents.defaults.model.primary` through redacted `config.get` and hash-guarded `config.patch`
- restore after ambiguous write outcomes, but never overwrite a concurrent selection after a definite rejected patch
- use the configured model view, preserve usable expiring credentials, prioritize available rows under caps, and require an explicitly healthy gateway response
- fail closed when OpenClaw is absent or inactive and expose no raw config, credentials, provider errors, or health details

## TDD and validation

- added failing regressions for shorthand config, upstream metadata, configured catalogs, expiring credentials, model caps, unhealthy snapshots, rejected-patch concurrency, and malformed-primary recovery
- OpenClaw adapter suite: 15/15 passed on this layer
- cumulative changed-surface matrix: 330/330 tests passed across 29 files
- contracts, gateway, shell, and desktop TypeScript strict checks: passed
- pattern scanner: 0 violations
- shell production build and desktop build: passed
- `git diff --check`: passed
- exact validated head: `fd211e128215e6241d9b37ba266e20bbd9b7ef80`

## Stack

- #982 — authenticated bounded OpenClaw RPC transport
- this PR — normalized OpenClaw runtime adapter
- #984 — gateway lifecycle and settings composition

## Invariants

- **Source of truth:** OpenClaw remains authoritative for its catalog, authentication health, and `agents.defaults.model.primary`; Matrix stores only selected runtime and its optimistic revision.
- **Lock/transaction scope:** OpenClaw `config.get.hash` guards every `config.patch`; the Matrix runtime controller remains the sole serializer for cross-runtime switches.
- **Acceptable orphan states:** ambiguous patch outcomes enter a bounded best-effort restore using a fresh hash; definite rejected patches never write the old primary over a concurrent owner change.
- **Auth source of truth:** OpenClaw owns provider credentials; this adapter consumes only bounded auth state and never reads, logs, returns, or persists provider secrets.
- **Deferred scope:** fixed host lifecycle/token composition, UI, and preview verification remain in later stack layers.
- Only configured, catalog-backed models with `available: true` may be newly selected. Existing configured selections remain recoverable.
- This PR will not merge below exact-head Greptile 5/5 with zero unresolved review threads.

## Rollout

- no channel promotion in this layer
- exact live installation, selection, switching, and health verification is performed through #992
