### PR TITLE
feat(gateway): compose OpenClaw runtime services

### DIFF
--- a/distro/customer-vps/host-bin/matrix-agent-runtime-control
+++ b/distro/customer-vps/host-bin/matrix-agent-runtime-control
@@ -6,7 +6,7 @@ validate_request() {
     status)
       [ "$#" -eq 1 ] || return 1
       ;;
-    install|switch)
+    install|switch|stop)
       [ "$#" -eq 2 ] || return 1
       case "${2:-}" in
         hermes|openclaw) ;;
@@ -147,6 +147,20 @@ switch_runtime() {
   printf '{"ok":true,"runtime":"%s"}\n' "$runtime"
 }
 
+stop_runtime() {
+  local runtime="$1" unit
+  case "$runtime" in
+    hermes) unit=matrix-hermes-dashboard.service ;;
+    openclaw) unit=matrix-openclaw-gateway.service ;;
+    *) printf '{"ok":false,"code":"invalid_request"}\n'; exit 2 ;;
+  esac
+  if ! timeout 20 systemctl disable --now "$unit"; then
+    printf '{"ok":false,"code":"deactivation_failed"}\n'
+    exit 5
+  fi
+  printf '{"ok":true,"runtime":"%s"}\n' "$runtime"
+}
+
 case "${1:-}" in
   status)
     print_status
@@ -158,6 +172,13 @@ case "${1:-}" in
     case "${2:-}" in
       hermes) switch_runtime hermes ;;
       openclaw) switch_runtime openclaw ;;
+      *) printf '{"ok":false,"code":"invalid_request"}\n'; exit 2 ;;
+    esac
+    ;;
+  stop)
+    case "${2:-}" in
+      hermes) stop_runtime hermes ;;
+      openclaw) stop_runtime openclaw ;;
       *) printf '{"ok":false,"code":"invalid_request"}\n'; exit 2 ;;
     esac
     ;;

--- a/distro/customer-vps/host-bin/matrix-agent-runtime-control
+++ b/distro/customer-vps/host-bin/matrix-agent-runtime-control
@@ -39,8 +39,8 @@ MATRIX_NODE_PREFIX="${MATRIX_NODE_PREFIX:-/opt/matrix/runtime/node}"
 MATRIX_RUNTIME_USER="${MATRIX_RUNTIME_USER:-matrix}"
 MATRIX_RUNTIME_GROUP="${MATRIX_RUNTIME_GROUP:-$MATRIX_RUNTIME_USER}"
 install_timeout_seconds=1810
-action_timeout_seconds=10
-active_wait_seconds=10
+action_timeout_seconds=50
+active_wait_seconds=45
 lock_dir="$MATRIX_RUNTIME_HOME/system/agent-runtime"
 install -d -o "$MATRIX_RUNTIME_USER" -g "$MATRIX_RUNTIME_GROUP" -m 0700 "$lock_dir"
 exec 9>"$lock_dir/host-control.lock"

--- a/distro/customer-vps/host-bin/matrix-agent-runtime-control
+++ b/distro/customer-vps/host-bin/matrix-agent-runtime-control
@@ -39,6 +39,8 @@ MATRIX_NODE_PREFIX="${MATRIX_NODE_PREFIX:-/opt/matrix/runtime/node}"
 MATRIX_RUNTIME_USER="${MATRIX_RUNTIME_USER:-matrix}"
 MATRIX_RUNTIME_GROUP="${MATRIX_RUNTIME_GROUP:-$MATRIX_RUNTIME_USER}"
 install_timeout_seconds=1810
+action_timeout_seconds=10
+active_wait_seconds=10
 lock_dir="$MATRIX_RUNTIME_HOME/system/agent-runtime"
 install -d -o "$MATRIX_RUNTIME_USER" -g "$MATRIX_RUNTIME_GROUP" -m 0700 "$lock_dir"
 exec 9>"$lock_dir/host-control.lock"
@@ -64,7 +66,7 @@ print_status() {
 }
 
 wait_active() {
-  local unit="$1" deadline=$((SECONDS + 20))
+  local unit="$1" deadline=$((SECONDS + active_wait_seconds))
   while [ "$SECONDS" -lt "$deadline" ]; do
     is_active "$unit" && return 0
     sleep 0.5
@@ -124,19 +126,19 @@ switch_runtime() {
 
   is_active "$other_unit" && prior_active=true
   is_enabled "$other_unit" && prior_enabled=true
-  if ! timeout 20 systemctl disable --now "$other_unit"; then
+  if ! timeout "$action_timeout_seconds" systemctl disable --now "$other_unit"; then
     printf '{"ok":false,"code":"deactivation_failed"}\n'
     exit 5
   fi
-  if ! timeout 20 systemctl enable --now "$target_unit" || ! wait_active "$target_unit"; then
-    timeout 20 systemctl disable --now "$target_unit" || true
+  if ! timeout "$action_timeout_seconds" systemctl enable --now "$target_unit" || ! wait_active "$target_unit"; then
+    timeout "$action_timeout_seconds" systemctl disable --now "$target_unit" || true
     if [ "$prior_enabled" = true ]; then
-      if ! timeout 20 systemctl enable --now "$other_unit" || ! wait_active "$other_unit"; then
+      if ! timeout "$action_timeout_seconds" systemctl enable --now "$other_unit" || ! wait_active "$other_unit"; then
         printf '{"ok":false,"code":"rollback_failed"}\n'
         exit 6
       fi
     elif [ "$prior_active" = true ]; then
-      if ! timeout 20 systemctl start "$other_unit" || ! wait_active "$other_unit"; then
+      if ! timeout "$action_timeout_seconds" systemctl start "$other_unit" || ! wait_active "$other_unit"; then
         printf '{"ok":false,"code":"rollback_failed"}\n'
         exit 6
       fi
@@ -154,7 +156,7 @@ stop_runtime() {
     openclaw) unit=matrix-openclaw-gateway.service ;;
     *) printf '{"ok":false,"code":"invalid_request"}\n'; exit 2 ;;
   esac
-  if ! timeout 20 systemctl disable --now "$unit"; then
+  if ! timeout "$action_timeout_seconds" systemctl disable --now "$unit"; then
     printf '{"ok":false,"code":"deactivation_failed"}\n'
     exit 5
   fi

--- a/packages/gateway/src/agent-config/hermes-adapter.ts
+++ b/packages/gateway/src/agent-config/hermes-adapter.ts
@@ -26,6 +26,7 @@ export function createHermesRuntimeAdapter(options: {
   requestJson: HermesJsonRequester;
   activate?: (signal: AbortSignal) => Promise<void>;
   deactivate?: (signal: AbortSignal) => Promise<void>;
+  prepare?: (signal: AbortSignal) => Promise<void>;
   validateBaseUrl?: (value: string) => Promise<void>;
 }): MessagingRuntimeAdapter {
   async function snapshot(signal: AbortSignal) {
@@ -121,12 +122,13 @@ export function createHermesRuntimeAdapter(options: {
       return AgentMessagingSelectionSchema.parse((await snapshot(signal)).messaging);
     },
     configure,
-    async prepare(signal) {
-      const descriptor = await this.probe(signal);
-      if (descriptor.installState !== "installed") {
+    prepare: options.prepare ?? (async (signal) => {
+      const descriptor = (await snapshot(signal)).runtime.options
+        .find((entry) => entry.id === "hermes");
+      if (descriptor?.installState !== "installed") {
         throw new AgentConfigError("runtime_unavailable");
       }
-    },
+    }),
     activate: options.activate ?? (async () => {}),
     deactivate: options.deactivate ?? (async () => {}),
     async dashboard() {

--- a/packages/gateway/src/agent-config/hermes-source.ts
+++ b/packages/gateway/src/agent-config/hermes-source.ts
@@ -255,12 +255,24 @@ export function createHermesRuntimeSource(
     if (cached !== null && cached.expiresAt > now()) return cached.value;
     if (inFlight === null || inFlight.generation !== generation) {
       const requestGeneration = generation;
-      const promise = Promise.all([
+      const promise = Promise.allSettled([
         readJson("/api/status", signal),
         readJson("/api/model/options", signal),
-      ]).then(([status, modelOptions]) => {
+      ]).then(([statusResult, modelOptionsResult]) => {
+        signal.throwIfAborted();
+        if (statusResult.status === "rejected") throw statusResult.reason;
+        let modelOptions: unknown = { providers: [] };
+        if (modelOptionsResult.status === "fulfilled") {
+          modelOptions = modelOptionsResult.value;
+        } else {
+          logWarning(
+            modelOptionsResult.reason instanceof Error
+              ? modelOptionsResult.reason.name
+              : "UnknownError",
+          );
+        }
         return normalizeHermesRuntimeSnapshot({
-          status,
+          status: statusResult.value,
           options: modelOptions,
         });
       }).catch((err: unknown) => {

--- a/packages/gateway/src/agent-config/host-runtime-control.ts
+++ b/packages/gateway/src/agent-config/host-runtime-control.ts
@@ -113,7 +113,7 @@ export function createHostRuntimeControl(options: {
   async function execute(args: readonly string[], signal: AbortSignal) {
     try {
       return await run(HOST_CONTROL_PATH, args, {
-        timeout: 25_000,
+        timeout: 70_000,
         maxBuffer: MAX_CONTROL_OUTPUT_BYTES,
         signal,
         windowsHide: true,

--- a/packages/gateway/src/agent-config/host-runtime-control.ts
+++ b/packages/gateway/src/agent-config/host-runtime-control.ts
@@ -1,0 +1,190 @@
+import { execFile } from "node:child_process";
+import { constants } from "node:fs";
+import { open } from "node:fs/promises";
+import { join } from "node:path";
+import { promisify } from "node:util";
+import { z } from "zod/v4";
+import { AgentConfigError } from "./errors.js";
+
+const HOST_CONTROL_PATH = "/opt/matrix/bin/matrix-agent-runtime-control";
+const MAX_CONTROL_OUTPUT_BYTES = 4_096;
+const MAX_TOKEN_FILE_BYTES = 256;
+
+const RuntimeIdSchema = z.enum(["hermes", "openclaw"]);
+const RuntimeStatusSchema = z.object({
+  installed: z.boolean(),
+  running: z.boolean(),
+}).strict();
+const StatusResponseSchema = z.object({
+  ok: z.literal(true),
+  hermes: RuntimeStatusSchema,
+  openclaw: RuntimeStatusSchema,
+}).strict();
+const MutationResponseSchema = z.object({
+  ok: z.literal(true),
+  runtime: RuntimeIdSchema,
+}).strict();
+const FailureResponseSchema = z.object({
+  ok: z.literal(false),
+  code: z.enum([
+    "invalid_request",
+    "runtime_unavailable",
+    "auth_required",
+    "resources_unavailable",
+    "runtime_busy",
+    "deactivation_failed",
+    "activation_failed",
+    "rollback_failed",
+  ]),
+}).strict();
+
+interface ExecOptions {
+  timeout: number;
+  maxBuffer: number;
+  signal: AbortSignal;
+  windowsHide: boolean;
+  encoding: "utf8";
+}
+
+type HostControlExecutor = (
+  file: string,
+  args: readonly string[],
+  options: ExecOptions,
+) => Promise<{ stdout: string; stderr: string }>;
+
+export interface HostRuntimeStatus {
+  hermes: { installed: boolean; running: boolean };
+  openclaw: { installed: boolean; running: boolean };
+}
+
+export interface HostRuntimeControl {
+  status(signal: AbortSignal): Promise<HostRuntimeStatus>;
+  switch(runtime: z.infer<typeof RuntimeIdSchema>, signal: AbortSignal): Promise<void>;
+  stop(runtime: z.infer<typeof RuntimeIdSchema>, signal: AbortSignal): Promise<void>;
+}
+
+function boundedText(value: unknown): string | null {
+  if (typeof value === "string") {
+    return Buffer.byteLength(value) <= MAX_CONTROL_OUTPUT_BYTES ? value : null;
+  }
+  if (Buffer.isBuffer(value) && value.byteLength <= MAX_CONTROL_OUTPUT_BYTES) {
+    return value.toString("utf8");
+  }
+  return null;
+}
+
+function mapFailure(value: unknown): AgentConfigError {
+  const error = value as { stdout?: unknown };
+  const stdout = boundedText(error?.stdout);
+  if (stdout !== null) {
+    try {
+      const parsed = FailureResponseSchema.safeParse(JSON.parse(stdout));
+      if (parsed.success) {
+        if (parsed.data.code === "runtime_busy") {
+          return new AgentConfigError("agent_config_conflict");
+        }
+        if (["runtime_unavailable", "auth_required", "resources_unavailable"]
+          .includes(parsed.data.code)) {
+          return new AgentConfigError("runtime_unavailable");
+        }
+        if (parsed.data.code === "invalid_request") {
+          return new AgentConfigError("agent_config_invalid");
+        }
+      }
+    } catch (error) {
+      if (!(error instanceof SyntaxError)) {
+        console.warn(
+          "[agent-config] Host failure response validation failed:",
+          error instanceof Error ? error.name : "UnknownError",
+        );
+      }
+      // Invalid host JSON is deliberately mapped without logging its content.
+    }
+  }
+  return new AgentConfigError("runtime_switch_failed");
+}
+
+export function createHostRuntimeControl(options: {
+  exec?: HostControlExecutor;
+} = {}): HostRuntimeControl {
+  const run = options.exec
+    ?? promisify(execFile) as unknown as HostControlExecutor;
+
+  async function execute(args: readonly string[], signal: AbortSignal) {
+    try {
+      return await run(HOST_CONTROL_PATH, args, {
+        timeout: 25_000,
+        maxBuffer: MAX_CONTROL_OUTPUT_BYTES,
+        signal,
+        windowsHide: true,
+        encoding: "utf8",
+      });
+    } catch (error) {
+      throw mapFailure(error);
+    }
+  }
+
+  async function mutate(
+    operation: "switch" | "stop",
+    runtime: z.infer<typeof RuntimeIdSchema>,
+    signal: AbortSignal,
+  ): Promise<void> {
+    const id = RuntimeIdSchema.parse(runtime);
+    const result = await execute([operation, id], signal);
+    const stdout = boundedText(result.stdout);
+    if (stdout === null) throw new AgentConfigError("invalid_response");
+    try {
+      const parsed = MutationResponseSchema.parse(JSON.parse(stdout));
+      if (parsed.runtime !== id) throw new AgentConfigError("invalid_response");
+    } catch (error) {
+      if (error instanceof AgentConfigError) throw error;
+      throw new AgentConfigError("invalid_response", error);
+    }
+  }
+
+  return {
+    async status(signal) {
+      const result = await execute(["status"], signal);
+      const stdout = boundedText(result.stdout);
+      if (stdout === null) throw new AgentConfigError("invalid_response");
+      try {
+        const parsed = StatusResponseSchema.parse(JSON.parse(stdout));
+        return { hermes: parsed.hermes, openclaw: parsed.openclaw };
+      } catch (error) {
+        throw new AgentConfigError("invalid_response", error);
+      }
+    },
+    switch(runtime, signal) {
+      return mutate("switch", runtime, signal);
+    },
+    stop(runtime, signal) {
+      return mutate("stop", runtime, signal);
+    },
+  };
+}
+
+export async function readOpenClawGatewayToken(homePath: string): Promise<string> {
+  const tokenPath = join(homePath, "system/agent-runtime/openclaw.env");
+  let handle;
+  try {
+    handle = await open(tokenPath, constants.O_RDONLY | constants.O_NOFOLLOW);
+    const stat = await handle.stat();
+    if (!stat.isFile() || stat.size > MAX_TOKEN_FILE_BYTES || (stat.mode & 0o077) !== 0) {
+      throw new AgentConfigError("agent_config_invalid");
+    }
+    const raw = await handle.readFile("utf8");
+    const match = /^OPENCLAW_GATEWAY_TOKEN=([A-Fa-f0-9]{64})\n?$/.exec(raw);
+    if (!match?.[1]) throw new AgentConfigError("agent_config_invalid");
+    return match[1];
+  } catch (error) {
+    if (error instanceof AgentConfigError) throw error;
+    throw new AgentConfigError("runtime_unavailable", error);
+  } finally {
+    await handle?.close().catch((error: unknown) => {
+      console.warn(
+        "[agent-config] OpenClaw token handle close failed:",
+        error instanceof Error ? error.name : "UnknownError",
+      );
+    });
+  }
+}

--- a/packages/gateway/src/agent-config/host-runtime-control.ts
+++ b/packages/gateway/src/agent-config/host-runtime-control.ts
@@ -120,6 +120,7 @@ export function createHostRuntimeControl(options: {
         encoding: "utf8",
       });
     } catch (error) {
+      if (signal.aborted) throw error;
       throw mapFailure(error);
     }
   }

--- a/packages/gateway/src/agent-config/host-runtime-control.ts
+++ b/packages/gateway/src/agent-config/host-runtime-control.ts
@@ -9,6 +9,13 @@ import { AgentConfigError } from "./errors.js";
 const HOST_CONTROL_PATH = "/opt/matrix/bin/matrix-agent-runtime-control";
 const MAX_CONTROL_OUTPUT_BYTES = 4_096;
 const MAX_TOKEN_FILE_BYTES = 256;
+// Includes the 30s host lock plus bounded systemd/readiness work; switch also
+// leaves enough time for the script's complete rollback path (320s maximum).
+const HOST_CONTROL_TIMEOUT_MS = {
+  status: 10_000,
+  stop: 90_000,
+  switch: 330_000,
+} as const;
 
 const RuntimeIdSchema = z.enum(["hermes", "openclaw"]);
 const RuntimeStatusSchema = z.object({
@@ -110,10 +117,15 @@ export function createHostRuntimeControl(options: {
   const run = options.exec
     ?? promisify(execFile) as unknown as HostControlExecutor;
 
-  async function execute(args: readonly string[], signal: AbortSignal) {
+  async function execute(
+    operation: keyof typeof HOST_CONTROL_TIMEOUT_MS,
+    runtime: z.infer<typeof RuntimeIdSchema> | undefined,
+    signal: AbortSignal,
+  ) {
+    const args = runtime === undefined ? [operation] : [operation, runtime];
     try {
       return await run(HOST_CONTROL_PATH, args, {
-        timeout: 70_000,
+        timeout: HOST_CONTROL_TIMEOUT_MS[operation],
         maxBuffer: MAX_CONTROL_OUTPUT_BYTES,
         signal,
         windowsHide: true,
@@ -131,7 +143,7 @@ export function createHostRuntimeControl(options: {
     signal: AbortSignal,
   ): Promise<void> {
     const id = RuntimeIdSchema.parse(runtime);
-    const result = await execute([operation, id], signal);
+    const result = await execute(operation, id, signal);
     const stdout = boundedText(result.stdout);
     if (stdout === null) throw new AgentConfigError("invalid_response");
     try {
@@ -145,7 +157,7 @@ export function createHostRuntimeControl(options: {
 
   return {
     async status(signal) {
-      const result = await execute(["status"], signal);
+      const result = await execute("status", undefined, signal);
       const stdout = boundedText(result.stdout);
       if (stdout === null) throw new AgentConfigError("invalid_response");
       try {

--- a/packages/gateway/src/agent-config/runtime-controller.ts
+++ b/packages/gateway/src/agent-config/runtime-controller.ts
@@ -420,7 +420,9 @@ export function createAgentRuntimeController(
             });
           }
         }
-        await selectedAdapter.activate(probeDeadline.signal);
+        // A healthy probe already proves the selected runtime is active. Do
+        // not send a host lifecycle switch through the deliberately short
+        // startup-reconciliation deadline.
         await resumeDelivery(selected, probeDeadline.signal);
       } else {
         for (const adapter of Object.values(options.adapters)) {

--- a/packages/gateway/src/agent-config/runtime-controller.ts
+++ b/packages/gateway/src/agent-config/runtime-controller.ts
@@ -219,7 +219,7 @@ export function createAgentRuntimeController(
         const descriptor = AgentRuntimeDescriptorSchema.parse(
           await targetAdapter.probe(deadline.signal),
         );
-        if (descriptor.health !== "healthy") {
+        if (descriptor.health !== "healthy" && descriptor.health !== "degraded") {
           throw new AgentConfigError("runtime_switch_failed");
         }
         previousTargetSelection = await targetAdapter.selection(deadline.signal);

--- a/packages/gateway/src/agent-config/runtime-services.ts
+++ b/packages/gateway/src/agent-config/runtime-services.ts
@@ -7,6 +7,7 @@ import {
   type AgentRuntimeSelection,
 } from "@matrix-os/contracts";
 import { join } from "node:path";
+import { setTimeout as delay } from "node:timers/promises";
 import { AgentConfigError } from "./errors.js";
 import { createHermesRuntimeAdapter } from "./hermes-adapter.js";
 import { createHermesRuntimeSource, type HermesJsonReader } from "./hermes-source.js";
@@ -53,56 +54,128 @@ interface LazyOpenClawRpcOptions {
   createClient?: typeof createOpenClawRpcClient;
 }
 
+interface ResettableOpenClawRpc extends OpenClawRpcClient {
+  reset(): Promise<void>;
+}
+
 export function createLazyOpenClawRpc(
   homePath: string,
   options: LazyOpenClawRpcOptions = {},
-): OpenClawRpcClient {
+): ResettableOpenClawRpc {
   let client: OpenClawRpcClient | null = null;
   let pending: Promise<OpenClawRpcClient> | null = null;
+  let resetting: Promise<void> | null = null;
   let closed = false;
+  let epoch = 0;
   const readToken = options.readToken ?? readOpenClawGatewayToken;
   const createClient = options.createClient ?? createOpenClawRpcClient;
 
   async function getClient(): Promise<OpenClawRpcClient> {
     if (closed) throw new AgentConfigError("runtime_unavailable");
+    await resetting;
+    if (closed) throw new AgentConfigError("runtime_unavailable");
     if (client !== null) return client;
     if (pending === null) {
-      pending = readToken(homePath).then((token) => {
+      const creationEpoch = epoch;
+      const creation = readToken(homePath).then((token) => {
         const created = createClient({
           url: "ws://127.0.0.1:18789",
           token,
         });
-        client = created;
+        if (!closed && epoch === creationEpoch) client = created;
         return created;
       }).finally(() => {
-        pending = null;
+        if (pending === creation) pending = null;
       });
+      pending = creation;
     }
+    const requestEpoch = epoch;
     const active = await pending;
     // close() marks the wrapper closed before awaiting an in-flight creation.
     // Recheck after that shared promise settles so no caller can start an RPC
     // on the client that the shutdown path is about to close.
     if (closed) throw new AgentConfigError("runtime_unavailable");
+    if (epoch !== requestEpoch) return getClient();
     return active;
+  }
+
+  async function reset(): Promise<void> {
+    if (closed) throw new AgentConfigError("runtime_unavailable");
+    if (resetting !== null) return resetting;
+    epoch += 1;
+    const active = client;
+    const creating = pending;
+    client = null;
+    const operation = (async () => {
+      const created = active ?? await creating?.catch((error: unknown) => {
+        console.warn(
+          "[agent-config] OpenClaw RPC creation stopped during reset:",
+          error instanceof Error ? error.name : "UnknownError",
+        );
+        return null;
+      }) ?? null;
+      await created?.close();
+    })();
+    resetting = operation;
+    try {
+      await operation;
+    } finally {
+      if (resetting === operation) resetting = null;
+    }
   }
 
   return {
     async call(method, params, signal) {
       return (await getClient()).call(method, params, signal);
     },
+    reset,
     async close() {
+      const resetInFlight = resetting;
+      const activeClient = client;
+      const creatingClient = pending;
       closed = true;
-      const active = client ?? await pending?.catch((error: unknown) => {
-        console.warn(
-          "[agent-config] OpenClaw RPC creation stopped during shutdown:",
-          error instanceof Error ? error.name : "UnknownError",
-        );
-        return null;
-      }) ?? null;
+      epoch += 1;
+      await resetInFlight;
+      const active = resetInFlight === null
+        ? activeClient ?? await creatingClient?.catch((error: unknown) => {
+          console.warn(
+            "[agent-config] OpenClaw RPC creation stopped during shutdown:",
+            error instanceof Error ? error.name : "UnknownError",
+          );
+          return null;
+        }) ?? null
+        : null;
       await active?.close();
       client = null;
     },
   };
+}
+
+async function resetOpenClawRpc(rpc: OpenClawRpcClient): Promise<void> {
+  const reset = (rpc as Partial<ResettableOpenClawRpc>).reset;
+  if (typeof reset === "function") await reset.call(rpc);
+}
+
+async function waitForOpenClawReady(
+  rpc: OpenClawRpcClient,
+  signal: AbortSignal,
+): Promise<void> {
+  const readinessSignal = AbortSignal.any([
+    signal,
+    AbortSignal.timeout(10_000),
+  ]);
+  while (true) {
+    try {
+      await rpc.call("health", {}, readinessSignal);
+      return;
+    } catch (error) {
+      if (signal.aborted) throw error;
+      if (readinessSignal.aborted) {
+        throw new AgentConfigError("runtime_switch_failed", error);
+      }
+      await delay(250, undefined, { signal: readinessSignal });
+    }
+  }
 }
 
 function capabilities(runtime: AgentRuntimeId) {
@@ -198,7 +271,15 @@ function createUnifiedRuntimeSource(options: {
           .filter((provider) => provider.runtime === selected);
       }
       if (selectionResult.status === "fulfilled") {
-        messaging = AgentMessagingSelectionSchema.parse(selectionResult.value);
+        const selection = AgentMessagingSelectionSchema.parse(selectionResult.value);
+        const selectedModelIsCataloged = !selection.configured || providers.some((provider) =>
+          provider.runtime === selected
+          && provider.id === selection.provider
+          && provider.models.some((model) =>
+            model.id === selection.model && model.available
+          )
+        );
+        if (selectedModelIsCataloged) messaging = selection;
       }
       if ([probeResult, catalogResult, selectionResult]
         .some((result) => result.status === "rejected")) {
@@ -239,6 +320,7 @@ export function createAgentRuntimeServices(options: {
 }): AgentRuntimeServices {
   const hostControl = options.hostControl ?? createHostRuntimeControl();
   const hermesSource = createHermesRuntimeSource(options.client.readJson);
+  const openClawRpc = options.openClawRpc ?? createLazyOpenClawRpc(options.homePath);
   const hermes = createHermesRuntimeAdapter({
     source: hermesSource,
     requestJson: options.client.requestJson,
@@ -246,14 +328,14 @@ export function createAgentRuntimeServices(options: {
       const status = await hostControl.status(signal);
       if (!status.hermes.installed) throw new AgentConfigError("runtime_unavailable");
     },
-    activate(signal) {
-      return hostControl.switch("hermes", signal);
+    async activate(signal) {
+      hermesSource.invalidate?.();
+      await hostControl.switch("hermes", signal);
+      hermesSource.invalidate?.();
+      await resetOpenClawRpc(openClawRpc);
     },
-    deactivate(signal) {
-      return hostControl.stop("hermes", signal);
-    },
+    deactivate: async () => {},
   });
-  const openClawRpc = options.openClawRpc ?? createLazyOpenClawRpc(options.homePath);
   const openclaw = createOpenClawRuntimeAdapter({
     rpc: openClawRpc,
     lifecycle: {
@@ -264,12 +346,12 @@ export function createAgentRuntimeServices(options: {
           active: status.openclaw.running,
         };
       },
-      activate(signal) {
-        return hostControl.switch("openclaw", signal);
+      async activate(signal) {
+        await resetOpenClawRpc(openClawRpc);
+        await hostControl.switch("openclaw", signal);
+        await waitForOpenClawReady(openClawRpc, signal);
       },
-      deactivate(signal) {
-        return hostControl.stop("openclaw", signal);
-      },
+      deactivate: async () => {},
     },
   });
   const adapters = { hermes, openclaw };
@@ -281,6 +363,7 @@ export function createAgentRuntimeServices(options: {
   const controller = createAgentRuntimeController({
     homePath: options.homePath,
     adapters,
+    timeoutMs: 75_000,
   });
   return { source, controller };
 }

--- a/packages/gateway/src/agent-config/runtime-services.ts
+++ b/packages/gateway/src/agent-config/runtime-services.ts
@@ -48,17 +48,27 @@ export interface HermesAgentRuntimeServices {
 
 export interface AgentRuntimeServices extends HermesAgentRuntimeServices {}
 
-function createLazyOpenClawRpc(homePath: string): OpenClawRpcClient {
+interface LazyOpenClawRpcOptions {
+  readToken?: (homePath: string) => Promise<string>;
+  createClient?: typeof createOpenClawRpcClient;
+}
+
+export function createLazyOpenClawRpc(
+  homePath: string,
+  options: LazyOpenClawRpcOptions = {},
+): OpenClawRpcClient {
   let client: OpenClawRpcClient | null = null;
   let pending: Promise<OpenClawRpcClient> | null = null;
   let closed = false;
+  const readToken = options.readToken ?? readOpenClawGatewayToken;
+  const createClient = options.createClient ?? createOpenClawRpcClient;
 
   async function getClient(): Promise<OpenClawRpcClient> {
     if (closed) throw new AgentConfigError("runtime_unavailable");
     if (client !== null) return client;
     if (pending === null) {
-      pending = readOpenClawGatewayToken(homePath).then((token) => {
-        const created = createOpenClawRpcClient({
+      pending = readToken(homePath).then((token) => {
+        const created = createClient({
           url: "ws://127.0.0.1:18789",
           token,
         });
@@ -68,7 +78,12 @@ function createLazyOpenClawRpc(homePath: string): OpenClawRpcClient {
         pending = null;
       });
     }
-    return pending;
+    const active = await pending;
+    // close() marks the wrapper closed before awaiting an in-flight creation.
+    // Recheck after that shared promise settles so no caller can start an RPC
+    // on the client that the shutdown path is about to close.
+    if (closed) throw new AgentConfigError("runtime_unavailable");
+    return active;
   }
 
   return {

--- a/packages/gateway/src/agent-config/runtime-services.ts
+++ b/packages/gateway/src/agent-config/runtime-services.ts
@@ -1,10 +1,36 @@
+import {
+  AgentMessagingSelectionSchema,
+  AgentProviderCatalogSchema,
+  AgentRuntimeDescriptorSchema,
+  AgentRuntimeSelectionSchema,
+  type AgentRuntimeId,
+  type AgentRuntimeSelection,
+} from "@matrix-os/contracts";
+import { join } from "node:path";
+import { AgentConfigError } from "./errors.js";
 import { createHermesRuntimeAdapter } from "./hermes-adapter.js";
 import { createHermesRuntimeSource, type HermesJsonReader } from "./hermes-source.js";
+import {
+  createHostRuntimeControl,
+  readOpenClawGatewayToken,
+  type HostRuntimeControl,
+  type HostRuntimeStatus,
+} from "./host-runtime-control.js";
+import { createOpenClawRuntimeAdapter } from "./openclaw-adapter.js";
+import {
+  createOpenClawRpcClient,
+  type OpenClawRpcClient,
+} from "./openclaw-rpc.js";
 import {
   createAgentRuntimeController,
   type AgentRuntimeController,
 } from "./runtime-controller.js";
-import type { AgentRuntimeSource } from "./service.js";
+import { readAgentConfig, readConfig } from "./runtime-files.js";
+import type { MessagingRuntimeAdapter } from "./runtime-types.js";
+import type {
+  AgentRuntimeSettingsSnapshot,
+  AgentRuntimeSource,
+} from "./service.js";
 
 interface HermesRuntimeClient {
   readJson: HermesJsonReader;
@@ -20,6 +46,160 @@ export interface HermesAgentRuntimeServices {
   controller: AgentRuntimeController;
 }
 
+export interface AgentRuntimeServices extends HermesAgentRuntimeServices {}
+
+function createLazyOpenClawRpc(homePath: string): OpenClawRpcClient {
+  let client: OpenClawRpcClient | null = null;
+  let pending: Promise<OpenClawRpcClient> | null = null;
+  let closed = false;
+
+  async function getClient(): Promise<OpenClawRpcClient> {
+    if (closed) throw new AgentConfigError("runtime_unavailable");
+    if (client !== null) return client;
+    if (pending === null) {
+      pending = readOpenClawGatewayToken(homePath).then((token) => {
+        const created = createOpenClawRpcClient({
+          url: "ws://127.0.0.1:18789",
+          token,
+        });
+        client = created;
+        return created;
+      }).finally(() => {
+        pending = null;
+      });
+    }
+    return pending;
+  }
+
+  return {
+    async call(method, params, signal) {
+      return (await getClient()).call(method, params, signal);
+    },
+    async close() {
+      closed = true;
+      const active = client ?? await pending?.catch((error: unknown) => {
+        console.warn(
+          "[agent-config] OpenClaw RPC creation stopped during shutdown:",
+          error instanceof Error ? error.name : "UnknownError",
+        );
+        return null;
+      }) ?? null;
+      await active?.close();
+      client = null;
+    },
+  };
+}
+
+function capabilities(runtime: AgentRuntimeId) {
+  return runtime === "hermes"
+    ? [
+        "provider_catalog" as const,
+        "model_selection" as const,
+        "authentication" as const,
+        "messaging_dashboard" as const,
+      ]
+    : [
+        "provider_catalog" as const,
+        "model_selection" as const,
+        "authentication" as const,
+      ];
+}
+
+function baseDescriptor(
+  runtime: AgentRuntimeId,
+  selected: AgentRuntimeId,
+  status: HostRuntimeStatus[AgentRuntimeId] | undefined,
+) {
+  const isSelected = runtime === selected;
+  const installed = status?.installed;
+  return AgentRuntimeDescriptorSchema.parse({
+    id: runtime,
+    displayName: runtime === "hermes" ? "Hermes" : "OpenClaw",
+    installState: installed === undefined ? "unknown" : installed ? "installed" : "missing",
+    health: status?.running ? "degraded" : status === undefined ? "unknown" : "stopped",
+    selectionState: isSelected
+      ? "active"
+      : installed === true
+        ? "available"
+        : installed === false
+          ? "unavailable"
+          : "action_required",
+    configured: false,
+    capabilities: installed === false ? ["install"] : capabilities(runtime),
+    ...(installed === false ? { setupAction: "install" as const } : {}),
+  });
+}
+
+function createUnifiedRuntimeSource(options: {
+  homePath: string;
+  adapters: Record<AgentRuntimeId, MessagingRuntimeAdapter>;
+  hostControl: HostRuntimeControl;
+}): AgentRuntimeSource {
+  const configPath = join(options.homePath, "system/config.json");
+  return async (signal): Promise<AgentRuntimeSettingsSnapshot> => {
+    signal.throwIfAborted();
+    const config = await readConfig(configPath);
+    const selected = readAgentConfig(config).value.messagingRuntime ?? "hermes";
+    let hostStatus: HostRuntimeStatus | undefined;
+    try {
+      hostStatus = await options.hostControl.status(signal);
+    } catch (error) {
+      if (signal.aborted) throw error;
+      console.warn(
+        "[agent-config] Host runtime status failed:",
+        error instanceof Error ? error.name : "UnknownError",
+      );
+    }
+
+    const descriptors = new Map<AgentRuntimeId, ReturnType<typeof baseDescriptor>>([
+      ["hermes", baseDescriptor("hermes", selected, hostStatus?.hermes)],
+      ["openclaw", baseDescriptor("openclaw", selected, hostStatus?.openclaw)],
+    ]);
+    let providers: AgentRuntimeSettingsSnapshot["providers"] = [];
+    let messaging = AgentMessagingSelectionSchema.parse({
+      runtime: selected,
+      provider: null,
+      model: null,
+      configured: false,
+    });
+    const adapter = options.adapters[selected];
+    if (hostStatus?.[selected].running === true
+      || (hostStatus === undefined && selected === "hermes")) {
+      const [probeResult, catalogResult, selectionResult] = await Promise.allSettled([
+        adapter.probe(signal),
+        adapter.catalog(signal),
+        adapter.selection(signal),
+      ]);
+      signal.throwIfAborted();
+      if (probeResult.status === "fulfilled") {
+        const probed = AgentRuntimeDescriptorSchema.parse(probeResult.value);
+        descriptors.set(selected, AgentRuntimeDescriptorSchema.parse({
+          ...probed,
+          selectionState: "active",
+        }));
+      }
+      if (catalogResult.status === "fulfilled") {
+        providers = AgentProviderCatalogSchema.parse(catalogResult.value)
+          .filter((provider) => provider.runtime === selected);
+      }
+      if (selectionResult.status === "fulfilled") {
+        messaging = AgentMessagingSelectionSchema.parse(selectionResult.value);
+      }
+      if ([probeResult, catalogResult, selectionResult]
+        .some((result) => result.status === "rejected")) {
+        console.warn("[agent-config] Active runtime inventory is degraded");
+      }
+    }
+
+    const runtime: AgentRuntimeSelection = AgentRuntimeSelectionSchema.parse({
+      selected,
+      options: [descriptors.get("hermes"), descriptors.get("openclaw")],
+      transition: null,
+    });
+    return { runtime, providers, messaging };
+  };
+}
+
 export function createHermesAgentRuntimeServices(options: {
   homePath: string;
   client: HermesRuntimeClient;
@@ -32,6 +212,60 @@ export function createHermesAgentRuntimeServices(options: {
   const controller = createAgentRuntimeController({
     homePath: options.homePath,
     adapters: { hermes: adapter },
+  });
+  return { source, controller };
+}
+
+export function createAgentRuntimeServices(options: {
+  homePath: string;
+  client: HermesRuntimeClient;
+  hostControl?: HostRuntimeControl;
+  openClawRpc?: OpenClawRpcClient;
+}): AgentRuntimeServices {
+  const hostControl = options.hostControl ?? createHostRuntimeControl();
+  const hermesSource = createHermesRuntimeSource(options.client.readJson);
+  const hermes = createHermesRuntimeAdapter({
+    source: hermesSource,
+    requestJson: options.client.requestJson,
+    async prepare(signal) {
+      const status = await hostControl.status(signal);
+      if (!status.hermes.installed) throw new AgentConfigError("runtime_unavailable");
+    },
+    activate(signal) {
+      return hostControl.switch("hermes", signal);
+    },
+    deactivate(signal) {
+      return hostControl.stop("hermes", signal);
+    },
+  });
+  const openClawRpc = options.openClawRpc ?? createLazyOpenClawRpc(options.homePath);
+  const openclaw = createOpenClawRuntimeAdapter({
+    rpc: openClawRpc,
+    lifecycle: {
+      async status(signal) {
+        const status = await hostControl.status(signal);
+        return {
+          installed: status.openclaw.installed,
+          active: status.openclaw.running,
+        };
+      },
+      activate(signal) {
+        return hostControl.switch("openclaw", signal);
+      },
+      deactivate(signal) {
+        return hostControl.stop("openclaw", signal);
+      },
+    },
+  });
+  const adapters = { hermes, openclaw };
+  const source = createUnifiedRuntimeSource({
+    homePath: options.homePath,
+    adapters,
+    hostControl,
+  });
+  const controller = createAgentRuntimeController({
+    homePath: options.homePath,
+    adapters,
   });
   return { source, controller };
 }

--- a/packages/gateway/src/agent-config/runtime-services.ts
+++ b/packages/gateway/src/agent-config/runtime-services.ts
@@ -157,6 +157,36 @@ async function resetOpenClawRpc(rpc: OpenClawRpcClient): Promise<void> {
 }
 
 export const OPENCLAW_READINESS_TIMEOUT_MS = 45_000;
+export const HERMES_READINESS_TIMEOUT_MS = 20_000;
+
+async function waitForHermesReady(
+  source: AgentRuntimeSource,
+  signal: AbortSignal,
+  timeoutMs = HERMES_READINESS_TIMEOUT_MS,
+): Promise<void> {
+  const readinessSignal = AbortSignal.any([
+    signal,
+    AbortSignal.timeout(timeoutMs),
+  ]);
+  while (true) {
+    source.invalidate?.();
+    const snapshot = await source(readinessSignal);
+    const descriptor = snapshot.runtime.options.find((runtime) => runtime.id === "hermes");
+    if (descriptor !== undefined
+      && descriptor.health !== "unknown"
+      && descriptor.health !== "unreachable") {
+      return;
+    }
+    if (signal.aborted) throw signal.reason ?? new AgentConfigError("runtime_switch_failed");
+    if (readinessSignal.aborted) throw new AgentConfigError("runtime_switch_failed");
+    try {
+      await delay(250, undefined, { signal: readinessSignal });
+    } catch (error) {
+      if (signal.aborted) throw signal.reason ?? error;
+      throw new AgentConfigError("runtime_switch_failed", error);
+    }
+  }
+}
 
 export async function waitForOpenClawReady(
   rpc: OpenClawRpcClient,
@@ -288,7 +318,7 @@ function createUnifiedRuntimeSource(options: {
           provider.runtime === selected
           && provider.id === selection.provider
           && provider.models.some((model) =>
-            model.id === selection.model && model.available
+            model.id === selection.model
           )
         );
         if (selectedModelIsCataloged) messaging = selection;
@@ -343,6 +373,7 @@ export function createAgentRuntimeServices(options: {
     async activate(signal) {
       hermesSource.invalidate?.();
       await hostControl.switch("hermes", signal);
+      await waitForHermesReady(hermesSource, signal);
       hermesSource.invalidate?.();
     },
     deactivate: async () => {},

--- a/packages/gateway/src/agent-config/runtime-services.ts
+++ b/packages/gateway/src/agent-config/runtime-services.ts
@@ -156,24 +156,32 @@ async function resetOpenClawRpc(rpc: OpenClawRpcClient): Promise<void> {
   if (typeof reset === "function") await reset.call(rpc);
 }
 
-async function waitForOpenClawReady(
+export const OPENCLAW_READINESS_TIMEOUT_MS = 45_000;
+
+export async function waitForOpenClawReady(
   rpc: OpenClawRpcClient,
   signal: AbortSignal,
+  timeoutMs = OPENCLAW_READINESS_TIMEOUT_MS,
 ): Promise<void> {
   const readinessSignal = AbortSignal.any([
     signal,
-    AbortSignal.timeout(10_000),
+    AbortSignal.timeout(timeoutMs),
   ]);
   while (true) {
     try {
       await rpc.call("health", {}, readinessSignal);
       return;
     } catch (error) {
-      if (signal.aborted) throw error;
+      if (signal.aborted) throw signal.reason ?? error;
       if (readinessSignal.aborted) {
         throw new AgentConfigError("runtime_switch_failed", error);
       }
-      await delay(250, undefined, { signal: readinessSignal });
+      try {
+        await delay(250, undefined, { signal: readinessSignal });
+      } catch (delayError) {
+        if (signal.aborted) throw signal.reason ?? delayError;
+        throw new AgentConfigError("runtime_switch_failed", delayError);
+      }
     }
   }
 }
@@ -261,8 +269,12 @@ function createUnifiedRuntimeSource(options: {
       signal.throwIfAborted();
       if (probeResult.status === "fulfilled") {
         const probed = AgentRuntimeDescriptorSchema.parse(probeResult.value);
+        const hostInstallState = descriptors.get(selected)?.installState;
         descriptors.set(selected, AgentRuntimeDescriptorSchema.parse({
           ...probed,
+          ...(hostStatus !== undefined && hostInstallState !== undefined
+            ? { installState: hostInstallState }
+            : {}),
           selectionState: "active",
         }));
       }
@@ -332,7 +344,6 @@ export function createAgentRuntimeServices(options: {
       hermesSource.invalidate?.();
       await hostControl.switch("hermes", signal);
       hermesSource.invalidate?.();
-      await resetOpenClawRpc(openClawRpc);
     },
     deactivate: async () => {},
   });
@@ -351,7 +362,9 @@ export function createAgentRuntimeServices(options: {
         await hostControl.switch("openclaw", signal);
         await waitForOpenClawReady(openClawRpc, signal);
       },
-      deactivate: async () => {},
+      async deactivate() {
+        await resetOpenClawRpc(openClawRpc);
+      },
     },
   });
   const adapters = { hermes, openclaw };

--- a/packages/gateway/src/agent-config/runtime-services.ts
+++ b/packages/gateway/src/agent-config/runtime-services.ts
@@ -159,7 +159,7 @@ async function resetOpenClawRpc(rpc: OpenClawRpcClient): Promise<void> {
 export const OPENCLAW_READINESS_TIMEOUT_MS = 45_000;
 export const HERMES_READINESS_TIMEOUT_MS = 20_000;
 
-async function waitForHermesReady(
+export async function waitForHermesReady(
   source: AgentRuntimeSource,
   signal: AbortSignal,
   timeoutMs = HERMES_READINESS_TIMEOUT_MS,
@@ -169,13 +169,20 @@ async function waitForHermesReady(
     AbortSignal.timeout(timeoutMs),
   ]);
   while (true) {
-    source.invalidate?.();
-    const snapshot = await source(readinessSignal);
-    const descriptor = snapshot.runtime.options.find((runtime) => runtime.id === "hermes");
-    if (descriptor !== undefined
-      && descriptor.health !== "unknown"
-      && descriptor.health !== "unreachable") {
-      return;
+    try {
+      source.invalidate?.();
+      const snapshot = await source(readinessSignal);
+      const descriptor = snapshot.runtime.options.find((runtime) => runtime.id === "hermes");
+      if (descriptor !== undefined
+        && descriptor.health !== "unknown"
+        && descriptor.health !== "unreachable") {
+        return;
+      }
+    } catch (error) {
+      if (signal.aborted) throw signal.reason ?? error;
+      if (readinessSignal.aborted) {
+        throw new AgentConfigError("runtime_switch_failed", error);
+      }
     }
     if (signal.aborted) throw signal.reason ?? new AgentConfigError("runtime_switch_failed");
     if (readinessSignal.aborted) throw new AgentConfigError("runtime_switch_failed");

--- a/packages/gateway/src/server.ts
+++ b/packages/gateway/src/server.ts
@@ -188,7 +188,7 @@ import {
   createHermesDashboardClient,
   validateHermesDashboardUrl,
 } from "./agent-config/hermes-client.js";
-import { createHermesAgentRuntimeServices } from "./agent-config/runtime-services.js";
+import { createAgentRuntimeServices } from "./agent-config/runtime-services.js";
 import { syncApp, createSyncRoutes, type SyncRouteDeps } from "./sync/routes.js";
 import { createR2Client, type R2Client, type R2ClientConfig } from "./sync/r2-client.js";
 import { createPlatformR2Client } from "./sync/platform-r2-client.js";
@@ -3952,7 +3952,7 @@ export async function createGateway(config: GatewayConfig) {
     throw err;
   }
   const hermesClient = createHermesDashboardClient({ baseUrl: hermesDashboardUrl });
-  const agentRuntimeServices = createHermesAgentRuntimeServices({
+  const agentRuntimeServices = createAgentRuntimeServices({
     homePath,
     client: hermesClient,
   });

--- a/tests/deploy/customer-vps/openclaw-systemd.test.ts
+++ b/tests/deploy/customer-vps/openclaw-systemd.test.ts
@@ -124,8 +124,8 @@ describe("customer VPS OpenClaw runtime", () => {
     expect(controller).toContain("systemctl is-active --quiet");
     expect(controller).toContain('systemctl disable --now "$other_unit"');
     expect(controller).toContain('systemctl enable --now "$target_unit"');
-    expect(controller).toContain("action_timeout_seconds=10");
-    expect(controller).toContain("active_wait_seconds=10");
+    expect(controller).toContain("action_timeout_seconds=50");
+    expect(controller).toContain("active_wait_seconds=45");
     expect(controller).toContain('timeout "$action_timeout_seconds"');
     expect(controller).toContain("MemAvailable");
     expect(controller).toContain("1048576");

--- a/tests/deploy/customer-vps/openclaw-systemd.test.ts
+++ b/tests/deploy/customer-vps/openclaw-systemd.test.ts
@@ -96,13 +96,14 @@ describe("customer VPS OpenClaw runtime", () => {
     await expect(access(legacyInstallUnitPath)).rejects.toMatchObject({ code: "ENOENT" });
   });
 
-  it("exposes only exact status, install, and switch commands", async () => {
+  it("exposes only exact status, install, switch, and stop commands", async () => {
     const controller = await readFile(controllerPath, "utf8");
 
     expect(controller).toContain('case "${1:-}" in');
     expect(controller).toContain("status)");
     expect(controller).toContain("install)");
     expect(controller).toContain("switch)");
+    expect(controller).toContain("stop)");
     expect(controller).toContain('case "${2:-}" in');
     expect(controller).toContain("hermes)");
     expect(controller).toContain("openclaw)");

--- a/tests/deploy/customer-vps/openclaw-systemd.test.ts
+++ b/tests/deploy/customer-vps/openclaw-systemd.test.ts
@@ -124,7 +124,9 @@ describe("customer VPS OpenClaw runtime", () => {
     expect(controller).toContain("systemctl is-active --quiet");
     expect(controller).toContain('systemctl disable --now "$other_unit"');
     expect(controller).toContain('systemctl enable --now "$target_unit"');
-    expect(controller).toContain("timeout 20");
+    expect(controller).toContain("action_timeout_seconds=10");
+    expect(controller).toContain("active_wait_seconds=10");
+    expect(controller).toContain('timeout "$action_timeout_seconds"');
     expect(controller).toContain("MemAvailable");
     expect(controller).toContain("1048576");
     const switchBody = controller.slice(

--- a/tests/gateway/agent-config-hermes-source.test.ts
+++ b/tests/gateway/agent-config-hermes-source.test.ts
@@ -82,6 +82,36 @@ describe("Hermes agent settings source", () => {
     expect(readJson).toHaveBeenNthCalledWith(2, "/api/model/options", signal);
   });
 
+  it("keeps dashboard reachability when provider inventory requires authentication", async () => {
+    const readJson = vi.fn(async (path: string) => {
+      if (path === "/api/status") {
+        return { gateway_running: false, version: "0.19.1" };
+      }
+      throw new Error("provider inventory unauthorized");
+    });
+    const logWarning = vi.fn();
+    const source = createHermesRuntimeSource(readJson, { logWarning });
+
+    const snapshot = await source(new AbortController().signal);
+
+    expect(snapshot.runtime.options[0]).toMatchObject({
+      id: "hermes",
+      installState: "installed",
+      health: "degraded",
+      configured: false,
+      version: "0.19.1",
+    });
+    expect(snapshot.providers).toEqual([]);
+    expect(snapshot.messaging).toEqual({
+      runtime: "hermes",
+      provider: null,
+      model: null,
+      configured: false,
+    });
+    expect(logWarning).toHaveBeenCalledOnce();
+    expect(logWarning).toHaveBeenCalledWith("Error");
+  });
+
   it("orders selected and ready catalog entries deterministically", () => {
     const snapshot = normalizeHermesRuntimeSnapshot({
       status: { gateway_running: true },

--- a/tests/gateway/agent-runtime-controller.test.ts
+++ b/tests/gateway/agent-runtime-controller.test.ts
@@ -560,7 +560,6 @@ describe("agent runtime controller", () => {
     expect(calls).toEqual([
       "delivery:pause",
       "openclaw:deactivate",
-      "hermes:activate",
       "delivery:resume:hermes",
     ]);
     await expect(lstat(join(runtimeDir, "transition.lock")))

--- a/tests/gateway/agent-runtime-controller.test.ts
+++ b/tests/gateway/agent-runtime-controller.test.ts
@@ -238,6 +238,41 @@ describe("agent runtime controller", () => {
     expect(resumeDelivery).toHaveBeenCalledWith("openclaw", expect.any(AbortSignal));
   });
 
+  it("persists a reachable degraded runtime before provider setup", async () => {
+    const homePath = await createHome({
+      agent: { messagingRuntime: "openclaw", revision: 0 },
+    });
+    const hermes = fakeAdapter("hermes", {
+      probe: vi.fn(async () => ({
+        id: "hermes" as const,
+        displayName: "Hermes",
+        installState: "installed" as const,
+        health: "degraded" as const,
+        selectionState: "active" as const,
+        configured: false,
+        capabilities: ["provider_catalog" as const, "model_selection" as const],
+      })),
+      selection: vi.fn(async () => ({
+        runtime: "hermes" as const,
+        provider: null,
+        model: null,
+        configured: false,
+      })),
+    });
+    const controller = createAgentRuntimeController({
+      homePath,
+      adapters: { hermes, openclaw: fakeAdapter("openclaw") },
+    });
+
+    await expect(controller.update({ runtime: "hermes", revision: 0 }))
+      .resolves.toMatchObject({ revision: 1, runtime: "hermes" });
+    const config = JSON.parse(await readFile(
+      join(homePath, "system/config.json"),
+      "utf8",
+    ));
+    expect(config.agent).toMatchObject({ messagingRuntime: "hermes", revision: 1 });
+  });
+
   it("atomically preserves and patches Chat settings in a combined update", async () => {
     const homePath = await createHome({
       kernel: {

--- a/tests/gateway/agent-runtime-services.test.ts
+++ b/tests/gateway/agent-runtime-services.test.ts
@@ -27,12 +27,14 @@ describe("Hermes agent runtime services", () => {
       call: vi.fn(async () => ({ ok: true })),
       close: vi.fn(async () => {}),
     };
+    const readToken = vi.fn(async () => token);
     const rpc = createLazyOpenClawRpc("/owner/home", {
-      readToken: async () => token,
+      readToken,
       createClient: () => client,
     });
 
     const call = rpc.call("health", {}, new AbortController().signal);
+    await vi.waitFor(() => expect(readToken).toHaveBeenCalledOnce());
     const close = rpc.close();
     resolveToken?.("a".repeat(64));
 
@@ -40,6 +42,39 @@ describe("Hermes agent runtime services", () => {
     await close;
     expect(client.call).not.toHaveBeenCalled();
     expect(client.close).toHaveBeenCalledOnce();
+  });
+
+  it("recreates the lazy OpenClaw client after a lifecycle reset", async () => {
+    const clients = [
+      {
+        call: vi.fn(async () => ({ generation: 1 })),
+        close: vi.fn(async () => {}),
+      },
+      {
+        call: vi.fn(async () => ({ generation: 2 })),
+        close: vi.fn(async () => {}),
+      },
+    ];
+    const createClient = vi.fn(() => {
+      const client = clients[createClient.mock.calls.length - 1];
+      if (!client) throw new Error("Unexpected OpenClaw client creation");
+      return client;
+    });
+    const rpc = createLazyOpenClawRpc("/owner/home", {
+      readToken: vi.fn(async () => "a".repeat(64)),
+      createClient,
+    });
+
+    await expect(rpc.call("health", {}, new AbortController().signal))
+      .resolves.toEqual({ generation: 1 });
+    await rpc.reset();
+    await expect(rpc.call("health", {}, new AbortController().signal))
+      .resolves.toEqual({ generation: 2 });
+
+    expect(createClient).toHaveBeenCalledTimes(2);
+    expect(clients[0]?.close).toHaveBeenCalledOnce();
+    await rpc.close();
+    expect(clients[1]?.close).toHaveBeenCalledOnce();
   });
 
   it("wires the unified runtime services into gateway startup and shutdown", async () => {
@@ -197,9 +232,271 @@ describe("Hermes agent runtime services", () => {
 
     await expect(services.controller.update({ runtime: "hermes", revision: 0 }))
       .resolves.toMatchObject({ runtime: "hermes" });
-    expect(lifecycleCalls).toEqual(["stop:openclaw", "switch:hermes"]);
+    expect(lifecycleCalls).toEqual(["switch:hermes"]);
     await services.controller.close();
     expect(openClawRpc.close).toHaveBeenCalledOnce();
+  });
+
+  it("does not disable runtimes when startup inventory is temporarily unhealthy", async () => {
+    const homePath = await mkdtemp(join(tmpdir(), "agent-runtime-services-"));
+    cleanupPaths.push(homePath);
+    await mkdir(join(homePath, "system"), { recursive: true });
+    await writeFile(join(homePath, "system/config.json"), JSON.stringify({
+      agent: { messagingRuntime: "hermes", revision: 0 },
+    }));
+    const hostControl = {
+      status: vi.fn(async () => ({
+        hermes: { installed: true, running: true },
+        openclaw: { installed: true, running: false },
+      })),
+      switch: vi.fn(async () => {}),
+      stop: vi.fn(async () => {}),
+    };
+    const services = createAgentRuntimeServices({
+      homePath,
+      client: {
+        readJson: vi.fn(async () => { throw new Error("dashboard starting"); }),
+        requestJson: vi.fn(async () => ({ ok: true })),
+      },
+      hostControl,
+      openClawRpc: {
+        call: vi.fn(async () => { throw new Error("not selected"); }),
+        close: vi.fn(async () => {}),
+      },
+    });
+
+    await expect(services.controller.reconcile()).resolves.toBeUndefined();
+    expect(hostControl.stop).not.toHaveBeenCalled();
+    await services.controller.close();
+  });
+
+  it("clears configured messaging selection when its catalog is unavailable", async () => {
+    const homePath = await mkdtemp(join(tmpdir(), "agent-runtime-services-"));
+    cleanupPaths.push(homePath);
+    await mkdir(join(homePath, "system"), { recursive: true });
+    await writeFile(join(homePath, "system/config.json"), JSON.stringify({
+      agent: { messagingRuntime: "openclaw", revision: 0 },
+    }));
+    const services = createAgentRuntimeServices({
+      homePath,
+      client: {
+        readJson: vi.fn(async () => ({ gateway_running: false })),
+        requestJson: vi.fn(async () => ({ ok: true })),
+      },
+      hostControl: {
+        status: vi.fn(async () => ({
+          hermes: { installed: true, running: false },
+          openclaw: { installed: true, running: true },
+        })),
+        switch: vi.fn(async () => {}),
+        stop: vi.fn(async () => {}),
+      },
+      openClawRpc: {
+        call: vi.fn(async (method: string) => {
+          if (method === "health") return { ts: 1_789_000_000_000 };
+          if (method === "models.list") throw new Error("catalog unavailable");
+          if (method === "models.authStatus") {
+            return { ts: 1_789_000_000_000, providers: [] };
+          }
+          if (method === "config.get") {
+            return {
+              valid: true,
+              hash: "config-hash",
+              config: { agents: { defaults: { model: {
+                primary: "anthropic/claude-opus-4-6",
+              } } } },
+            };
+          }
+          throw new Error("Unexpected OpenClaw method");
+        }),
+        close: vi.fn(async () => {}),
+      },
+    });
+
+    await expect(services.source(new AbortController().signal)).resolves.toMatchObject({
+      providers: [],
+      messaging: {
+        runtime: "openclaw",
+        provider: null,
+        model: null,
+        configured: false,
+      },
+    });
+    await services.controller.close();
+  });
+
+  it("waits for fresh OpenClaw RPC readiness before committing a switch", async () => {
+    const homePath = await mkdtemp(join(tmpdir(), "agent-runtime-services-"));
+    cleanupPaths.push(homePath);
+    await mkdir(join(homePath, "system"), { recursive: true });
+    await writeFile(join(homePath, "system/config.json"), JSON.stringify({
+      agent: { messagingRuntime: "hermes", revision: 0 },
+    }));
+    let active: "hermes" | "openclaw" = "hermes";
+    let healthCalls = 0;
+    const reset = vi.fn(async () => {});
+    const hostControl = {
+      status: vi.fn(async () => ({
+        hermes: { installed: true, running: active === "hermes" },
+        openclaw: { installed: true, running: active === "openclaw" },
+      })),
+      switch: vi.fn(async (runtime: "hermes" | "openclaw") => {
+        active = runtime;
+      }),
+      stop: vi.fn(async () => {}),
+    };
+    const openClawRpc = {
+      call: vi.fn(async (method: string) => {
+        if (method === "health") {
+          healthCalls += 1;
+          if (healthCalls < 3) throw new Error("gateway binding");
+          return { ts: 1_789_000_000_000 };
+        }
+        if (method === "models.list") {
+          return { models: [{
+            id: "claude-opus-4-6",
+            name: "Claude Opus 4.6",
+            provider: "anthropic",
+            available: true,
+          }] };
+        }
+        if (method === "models.authStatus") {
+          return {
+            ts: 1_789_000_000_000,
+            providers: [{
+              provider: "anthropic",
+              displayName: "Anthropic",
+              status: "ok",
+              profiles: [{ profileId: "default", type: "oauth", status: "ok" }],
+            }],
+          };
+        }
+        if (method === "config.get") {
+          return {
+            valid: true,
+            hash: "config-hash",
+            config: { agents: { defaults: { model: {
+              primary: "anthropic/claude-opus-4-6",
+            } } } },
+          };
+        }
+        throw new Error("Unexpected OpenClaw method");
+      }),
+      close: vi.fn(async () => {}),
+      reset,
+    };
+    const services = createAgentRuntimeServices({
+      homePath,
+      client: {
+        readJson: vi.fn(async (path: string) => path === "/api/status"
+          ? { gateway_running: active === "hermes" }
+          : {
+              provider: "nous",
+              model: "hermes-4-405b",
+              providers: [{
+                slug: "nous",
+                name: "Nous",
+                authenticated: true,
+                auth_type: "oauth",
+                models: ["hermes-4-405b"],
+              }],
+            }),
+        requestJson: vi.fn(async () => ({ ok: true })),
+      },
+      hostControl,
+      openClawRpc,
+    });
+
+    await expect(services.controller.update({ runtime: "openclaw", revision: 0 }))
+      .resolves.toMatchObject({ runtime: "openclaw", revision: 1 });
+    expect(reset).toHaveBeenCalled();
+    expect(healthCalls).toBeGreaterThanOrEqual(3);
+    expect(hostControl.stop).not.toHaveBeenCalled();
+    await services.controller.close();
+  });
+
+  it("invalidates Hermes inventory across an away-and-back lifecycle switch", async () => {
+    const homePath = await mkdtemp(join(tmpdir(), "agent-runtime-services-"));
+    cleanupPaths.push(homePath);
+    await mkdir(join(homePath, "system"), { recursive: true });
+    await writeFile(join(homePath, "system/config.json"), JSON.stringify({
+      agent: { messagingRuntime: "hermes", revision: 0 },
+    }));
+    let active: "hermes" | "openclaw" = "hermes";
+    const hostControl = {
+      status: vi.fn(async () => ({
+        hermes: { installed: true, running: active === "hermes" },
+        openclaw: { installed: true, running: active === "openclaw" },
+      })),
+      switch: vi.fn(async (runtime: "hermes" | "openclaw") => {
+        active = runtime;
+      }),
+      stop: vi.fn(async () => {}),
+    };
+    const readJson = vi.fn(async (path: string) => path === "/api/status"
+      ? { gateway_running: active === "hermes" }
+      : {
+          provider: "nous",
+          model: "hermes-4-405b",
+          providers: [{
+            slug: "nous",
+            name: "Nous",
+            authenticated: true,
+            auth_type: "oauth",
+            models: ["hermes-4-405b"],
+          }],
+        });
+    const openClawRpc = {
+      call: vi.fn(async (method: string) => {
+        if (method === "health") return { ts: 1_789_000_000_000 };
+        if (method === "models.list") {
+          return { models: [{
+            id: "claude-opus-4-6",
+            name: "Claude Opus 4.6",
+            provider: "anthropic",
+            available: true,
+          }] };
+        }
+        if (method === "models.authStatus") {
+          return {
+            ts: 1_789_000_000_000,
+            providers: [{
+              provider: "anthropic",
+              displayName: "Anthropic",
+              status: "ok",
+              profiles: [{ profileId: "default", type: "oauth", status: "ok" }],
+            }],
+          };
+        }
+        if (method === "config.get") {
+          return {
+            valid: true,
+            hash: "config-hash",
+            config: { agents: { defaults: { model: {
+              primary: "anthropic/claude-opus-4-6",
+            } } } },
+          };
+        }
+        throw new Error("Unexpected OpenClaw method");
+      }),
+      close: vi.fn(async () => {}),
+      reset: vi.fn(async () => {}),
+    };
+    const services = createAgentRuntimeServices({
+      homePath,
+      client: { readJson, requestJson: vi.fn(async () => ({ ok: true })) },
+      hostControl,
+      openClawRpc,
+    });
+
+    await services.source(new AbortController().signal);
+    expect(readJson).toHaveBeenCalledTimes(2);
+    await services.controller.update({ runtime: "openclaw", revision: 0 });
+    await services.controller.update({ runtime: "hermes", revision: 1 });
+
+    expect(readJson).toHaveBeenCalledTimes(4);
+    expect(hostControl.stop).not.toHaveBeenCalled();
+    await services.controller.close();
   });
 
   it("propagates cancellation while active runtime inventory is settling", async () => {

--- a/tests/gateway/agent-runtime-services.test.ts
+++ b/tests/gateway/agent-runtime-services.test.ts
@@ -3,6 +3,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
+  createAgentRuntimeServices,
   createHermesAgentRuntimeServices,
 } from "../../packages/gateway/src/agent-config/runtime-services.js";
 
@@ -16,6 +17,16 @@ afterEach(async () => {
 });
 
 describe("Hermes agent runtime services", () => {
+  it("wires the unified runtime services into gateway startup and shutdown", async () => {
+    const server = await readFile("packages/gateway/src/server.ts", "utf8");
+
+    expect(server).toContain('import { createAgentRuntimeServices } from "./agent-config/runtime-services.js";');
+    expect(server).toContain("const agentRuntimeServices = createAgentRuntimeServices({");
+    expect(server).toContain("await agentRuntimeServices.controller.reconcile();");
+    expect(server).toContain("await agentRuntimeServices.controller.close();");
+    expect(server).not.toContain("createHermesAgentRuntimeServices");
+  });
+
   it("wires a catalog-backed model mutation through to owner config", async () => {
     const homePath = await mkdtemp(join(tmpdir(), "agent-runtime-services-"));
     cleanupPaths.push(homePath);
@@ -61,6 +72,143 @@ describe("Hermes agent runtime services", () => {
     );
     await expect(readFile(join(homePath, "system/config.json"), "utf8"))
       .resolves.toContain('"revision": 1');
+    await services.controller.close();
+  });
+
+  it("composes OpenClaw inventory and fixed lifecycle switching without requiring it at startup", async () => {
+    const homePath = await mkdtemp(join(tmpdir(), "agent-runtime-services-"));
+    cleanupPaths.push(homePath);
+    await mkdir(join(homePath, "system"), { recursive: true });
+    await writeFile(join(homePath, "system/config.json"), JSON.stringify({
+      agent: { messagingRuntime: "openclaw", revision: 0 },
+    }));
+    let active: "hermes" | "openclaw" = "openclaw";
+    const lifecycleCalls: string[] = [];
+    const hostControl = {
+      status: vi.fn(async () => ({
+        hermes: { installed: true, running: active === "hermes" },
+        openclaw: { installed: true, running: active === "openclaw" },
+      })),
+      switch: vi.fn(async (runtime: "hermes" | "openclaw") => {
+        lifecycleCalls.push(`switch:${runtime}`);
+        active = runtime;
+      }),
+      stop: vi.fn(async (runtime: "hermes" | "openclaw") => {
+        lifecycleCalls.push(`stop:${runtime}`);
+      }),
+    };
+    const readJson = vi.fn(async (path: string) => path === "/api/status"
+      ? { gateway_running: active === "hermes" }
+      : {
+          provider: "nous",
+          model: "hermes-4-405b",
+          providers: [{
+            slug: "nous",
+            name: "Nous",
+            authenticated: true,
+            auth_type: "oauth",
+            models: ["hermes-4-405b"],
+          }],
+        });
+    const openClawRpc = {
+      call: vi.fn(async (method: string) => {
+        if (method === "health") return { ts: 1_789_000_000_000 };
+        if (method === "models.list") {
+          return {
+            models: [{
+              id: "claude-opus-4-6",
+              name: "Claude Opus 4.6",
+              provider: "anthropic",
+              available: true,
+            }],
+          };
+        }
+        if (method === "models.authStatus") {
+          return {
+            ts: 1_789_000_000_000,
+            providers: [{
+              provider: "anthropic",
+              displayName: "Anthropic",
+              status: "ok",
+              profiles: [{ profileId: "default", type: "oauth", status: "ok" }],
+            }],
+          };
+        }
+        if (method === "config.get") {
+          return {
+            valid: true,
+            hash: "config-hash",
+            config: { agents: { defaults: { model: {
+              primary: "anthropic/claude-opus-4-6",
+            } } } },
+          };
+        }
+        throw new Error("Unexpected OpenClaw method");
+      }),
+      close: vi.fn(async () => {}),
+    };
+    const services = createAgentRuntimeServices({
+      homePath,
+      client: { readJson, requestJson: vi.fn(async () => ({ ok: true })) },
+      hostControl,
+      openClawRpc,
+    });
+
+    await expect(services.source(new AbortController().signal)).resolves.toMatchObject({
+      runtime: {
+        selected: "openclaw",
+        options: [
+          { id: "hermes", installState: "installed", selectionState: "available" },
+          { id: "openclaw", health: "healthy", selectionState: "active" },
+        ],
+      },
+      providers: [{ id: "anthropic", runtime: "openclaw" }],
+      messaging: {
+        runtime: "openclaw",
+        provider: "anthropic",
+        model: "claude-opus-4-6",
+      },
+    });
+
+    await expect(services.controller.update({ runtime: "hermes", revision: 0 }))
+      .resolves.toMatchObject({ runtime: "hermes" });
+    expect(lifecycleCalls).toEqual(["stop:openclaw", "switch:hermes"]);
+    await services.controller.close();
+    expect(openClawRpc.close).toHaveBeenCalledOnce();
+  });
+
+  it("propagates cancellation while active runtime inventory is settling", async () => {
+    const homePath = await mkdtemp(join(tmpdir(), "agent-runtime-services-"));
+    cleanupPaths.push(homePath);
+    await mkdir(join(homePath, "system"), { recursive: true });
+    await writeFile(join(homePath, "system/config.json"), JSON.stringify({
+      agent: { messagingRuntime: "openclaw", revision: 0 },
+    }));
+    const controller = new AbortController();
+    const services = createAgentRuntimeServices({
+      homePath,
+      client: {
+        readJson: vi.fn(async () => ({ gateway_running: false })),
+        requestJson: vi.fn(async () => ({ ok: true })),
+      },
+      hostControl: {
+        status: vi.fn(async () => ({
+          hermes: { installed: true, running: false },
+          openclaw: { installed: true, running: true },
+        })),
+        switch: vi.fn(async () => {}),
+        stop: vi.fn(async () => {}),
+      },
+      openClawRpc: {
+        call: vi.fn(async () => {
+          controller.abort(new Error("request cancelled"));
+          throw controller.signal.reason;
+        }),
+        close: vi.fn(async () => {}),
+      },
+    });
+
+    await expect(services.source(controller.signal)).rejects.toThrow("request cancelled");
     await services.controller.close();
   });
 });

--- a/tests/gateway/agent-runtime-services.test.ts
+++ b/tests/gateway/agent-runtime-services.test.ts
@@ -5,6 +5,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   createAgentRuntimeServices,
   createHermesAgentRuntimeServices,
+  createLazyOpenClawRpc,
 } from "../../packages/gateway/src/agent-config/runtime-services.js";
 
 const cleanupPaths: string[] = [];
@@ -17,6 +18,30 @@ afterEach(async () => {
 });
 
 describe("Hermes agent runtime services", () => {
+  it("does not release a newly created OpenClaw client to callers after shutdown starts", async () => {
+    let resolveToken: ((token: string) => void) | undefined;
+    const token = new Promise<string>((resolve) => {
+      resolveToken = resolve;
+    });
+    const client = {
+      call: vi.fn(async () => ({ ok: true })),
+      close: vi.fn(async () => {}),
+    };
+    const rpc = createLazyOpenClawRpc("/owner/home", {
+      readToken: async () => token,
+      createClient: () => client,
+    });
+
+    const call = rpc.call("health", {}, new AbortController().signal);
+    const close = rpc.close();
+    resolveToken?.("a".repeat(64));
+
+    await expect(call).rejects.toMatchObject({ kind: "runtime_unavailable" });
+    await close;
+    expect(client.call).not.toHaveBeenCalled();
+    expect(client.close).toHaveBeenCalledOnce();
+  });
+
   it("wires the unified runtime services into gateway startup and shutdown", async () => {
     const server = await readFile("packages/gateway/src/server.ts", "utf8");
 

--- a/tests/gateway/agent-runtime-services.test.ts
+++ b/tests/gateway/agent-runtime-services.test.ts
@@ -194,7 +194,7 @@ describe("Hermes agent runtime services", () => {
         });
     const openClawRpc = {
       call: vi.fn(async (method: string) => {
-        if (method === "health") return { ts: 1_789_000_000_000 };
+        if (method === "health") return { ok: true, ts: 1_789_000_000_000 };
         if (method === "models.list") {
           return {
             models: [{
@@ -356,7 +356,7 @@ describe("Hermes agent runtime services", () => {
       },
       openClawRpc: {
         call: vi.fn(async (method: string) => {
-          if (method === "health") return { ts: 1_789_000_000_000 };
+          if (method === "health") return { ok: true, ts: 1_789_000_000_000 };
           if (method === "models.list") throw new Error("catalog unavailable");
           if (method === "models.authStatus") {
             return { ts: 1_789_000_000_000, providers: [] };
@@ -388,6 +388,119 @@ describe("Hermes agent runtime services", () => {
     await services.controller.close();
   });
 
+  it("preserves a configured selection when its catalog model is temporarily unavailable", async () => {
+    const homePath = await mkdtemp(join(tmpdir(), "agent-runtime-services-"));
+    cleanupPaths.push(homePath);
+    await mkdir(join(homePath, "system"), { recursive: true });
+    await writeFile(join(homePath, "system/config.json"), JSON.stringify({
+      agent: { messagingRuntime: "openclaw", revision: 0 },
+    }));
+    const services = createAgentRuntimeServices({
+      homePath,
+      client: {
+        readJson: vi.fn(async () => ({ gateway_running: false })),
+        requestJson: vi.fn(async () => ({ ok: true })),
+      },
+      hostControl: {
+        status: vi.fn(async () => ({
+          hermes: { installed: true, running: false },
+          openclaw: { installed: true, running: true },
+        })),
+        switch: vi.fn(async () => {}),
+        stop: vi.fn(async () => {}),
+      },
+      openClawRpc: {
+        call: vi.fn(async (method: string) => {
+          if (method === "health") return { ok: true, ts: 1_789_000_000_000 };
+          if (method === "models.list") {
+            return { models: [{
+              id: "claude-opus-4-6",
+              name: "Claude Opus 4.6",
+              provider: "anthropic",
+              available: false,
+            }] };
+          }
+          if (method === "models.authStatus") {
+            return { ts: 1_789_000_000_000, providers: [] };
+          }
+          if (method === "config.get") {
+            return {
+              valid: true,
+              hash: "config-hash",
+              config: { agents: { defaults: { model: {
+                primary: "anthropic/claude-opus-4-6",
+              } } } },
+            };
+          }
+          throw new Error("Unexpected OpenClaw method");
+        }),
+        close: vi.fn(async () => {}),
+      },
+    });
+
+    await expect(services.source(new AbortController().signal)).resolves.toMatchObject({
+      messaging: {
+        runtime: "openclaw",
+        provider: "anthropic",
+        model: "claude-opus-4-6",
+        configured: true,
+      },
+    });
+    await services.controller.close();
+  });
+
+  it("waits for the Hermes dashboard before verifying a cold switch", async () => {
+    const homePath = await mkdtemp(join(tmpdir(), "agent-runtime-services-"));
+    cleanupPaths.push(homePath);
+    await mkdir(join(homePath, "system"), { recursive: true });
+    await writeFile(join(homePath, "system/config.json"), JSON.stringify({
+      agent: { messagingRuntime: "openclaw", revision: 0 },
+    }));
+    let active: "hermes" | "openclaw" = "openclaw";
+    let statusCalls = 0;
+    const readJson = vi.fn(async (path: string) => {
+      if (path === "/api/status") {
+        statusCalls += 1;
+        if (statusCalls < 3) throw new Error("dashboard binding");
+        return { gateway_running: true };
+      }
+      return {
+        provider: "nous",
+        model: "hermes-4-405b",
+        providers: [{
+          slug: "nous",
+          name: "Nous",
+          authenticated: true,
+          models: ["hermes-4-405b"],
+        }],
+      };
+    });
+    const services = createAgentRuntimeServices({
+      homePath,
+      client: { readJson, requestJson: vi.fn(async () => ({ ok: true })) },
+      hostControl: {
+        status: vi.fn(async () => ({
+          hermes: { installed: true, running: active === "hermes" },
+          openclaw: { installed: true, running: active === "openclaw" },
+        })),
+        switch: vi.fn(async (runtime: "hermes" | "openclaw") => {
+          active = runtime;
+        }),
+        stop: vi.fn(async () => {}),
+      },
+      openClawRpc: {
+        call: vi.fn(async () => { throw new Error("OpenClaw stopped"); }),
+        close: vi.fn(async () => {}),
+        reset: vi.fn(async () => {}),
+      },
+    });
+
+    await expect(services.controller.update({ runtime: "hermes", revision: 0 }))
+      .resolves.toMatchObject({ runtime: "hermes" });
+    expect(statusCalls).toBeGreaterThanOrEqual(3);
+    await services.controller.close();
+  });
+
   it("waits for fresh OpenClaw RPC readiness before committing a switch", async () => {
     const homePath = await mkdtemp(join(tmpdir(), "agent-runtime-services-"));
     cleanupPaths.push(homePath);
@@ -413,7 +526,7 @@ describe("Hermes agent runtime services", () => {
         if (method === "health") {
           healthCalls += 1;
           if (healthCalls < 3) throw new Error("gateway binding");
-          return { ts: 1_789_000_000_000 };
+          return { ok: true, ts: 1_789_000_000_000 };
         }
         if (method === "models.list") {
           return { models: [{
@@ -511,7 +624,7 @@ describe("Hermes agent runtime services", () => {
         });
     const openClawRpc = {
       call: vi.fn(async (method: string) => {
-        if (method === "health") return { ts: 1_789_000_000_000 };
+        if (method === "health") return { ok: true, ts: 1_789_000_000_000 };
         if (method === "models.list") {
           return { models: [{
             id: "claude-opus-4-6",
@@ -557,7 +670,7 @@ describe("Hermes agent runtime services", () => {
     await services.controller.update({ runtime: "openclaw", revision: 0 });
     await services.controller.update({ runtime: "hermes", revision: 1 });
 
-    expect(readJson).toHaveBeenCalledTimes(4);
+    expect(readJson).toHaveBeenCalledTimes(6);
     expect(hostControl.stop).not.toHaveBeenCalled();
     await services.controller.close();
   });

--- a/tests/gateway/agent-runtime-services.test.ts
+++ b/tests/gateway/agent-runtime-services.test.ts
@@ -2,11 +2,13 @@ import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import type { AgentRuntimeSource } from "../../packages/gateway/src/agent-config/service.js";
 import {
   createAgentRuntimeServices,
   createHermesAgentRuntimeServices,
   createLazyOpenClawRpc,
   OPENCLAW_READINESS_TIMEOUT_MS,
+  waitForHermesReady,
   waitForOpenClawReady,
 } from "../../packages/gateway/src/agent-config/runtime-services.js";
 
@@ -32,6 +34,23 @@ describe("Hermes agent runtime services", () => {
 
     await expect(waitForOpenClawReady(
       rpc,
+      new AbortController().signal,
+      1,
+    )).rejects.toMatchObject({
+      name: "AgentConfigError",
+      kind: "runtime_switch_failed",
+    });
+  });
+
+  it("maps a Hermes source abort during readiness polling to a runtime error", async () => {
+    const source: AgentRuntimeSource = vi.fn((signal: AbortSignal) => (
+      new Promise<never>((_resolve, reject) => {
+        signal.addEventListener("abort", () => reject(signal.reason), { once: true });
+      })
+    ));
+
+    await expect(waitForHermesReady(
+      source,
       new AbortController().signal,
       1,
     )).rejects.toMatchObject({

--- a/tests/gateway/agent-runtime-services.test.ts
+++ b/tests/gateway/agent-runtime-services.test.ts
@@ -6,6 +6,8 @@ import {
   createAgentRuntimeServices,
   createHermesAgentRuntimeServices,
   createLazyOpenClawRpc,
+  OPENCLAW_READINESS_TIMEOUT_MS,
+  waitForOpenClawReady,
 } from "../../packages/gateway/src/agent-config/runtime-services.js";
 
 const cleanupPaths: string[] = [];
@@ -18,6 +20,26 @@ afterEach(async () => {
 });
 
 describe("Hermes agent runtime services", () => {
+  it("budgets first-start OpenClaw readiness for bounded migrations", () => {
+    expect(OPENCLAW_READINESS_TIMEOUT_MS).toBe(45_000);
+  });
+
+  it("maps an OpenClaw readiness timeout during retry backoff to a runtime error", async () => {
+    const rpc = {
+      call: vi.fn(async () => { throw new Error("gateway binding"); }),
+      close: vi.fn(async () => {}),
+    };
+
+    await expect(waitForOpenClawReady(
+      rpc,
+      new AbortController().signal,
+      1,
+    )).rejects.toMatchObject({
+      name: "AgentConfigError",
+      kind: "runtime_switch_failed",
+    });
+  });
+
   it("does not release a newly created OpenClaw client to callers after shutdown starts", async () => {
     let resolveToken: ((token: string) => void) | undefined;
     const token = new Promise<string>((resolve) => {
@@ -206,6 +228,7 @@ describe("Hermes agent runtime services", () => {
         throw new Error("Unexpected OpenClaw method");
       }),
       close: vi.fn(async () => {}),
+      reset: vi.fn(async () => { lifecycleCalls.push("reset:openclaw"); }),
     };
     const services = createAgentRuntimeServices({
       homePath,
@@ -232,7 +255,7 @@ describe("Hermes agent runtime services", () => {
 
     await expect(services.controller.update({ runtime: "hermes", revision: 0 }))
       .resolves.toMatchObject({ runtime: "hermes" });
-    expect(lifecycleCalls).toEqual(["switch:hermes"]);
+    expect(lifecycleCalls).toEqual(["reset:openclaw", "switch:hermes"]);
     await services.controller.close();
     expect(openClawRpc.close).toHaveBeenCalledOnce();
   });
@@ -267,6 +290,46 @@ describe("Hermes agent runtime services", () => {
 
     await expect(services.controller.reconcile()).resolves.toBeUndefined();
     expect(hostControl.stop).not.toHaveBeenCalled();
+    await services.controller.close();
+  });
+
+  it("keeps authoritative host install state when the active Hermes probe is unavailable", async () => {
+    const homePath = await mkdtemp(join(tmpdir(), "agent-runtime-services-"));
+    cleanupPaths.push(homePath);
+    await mkdir(join(homePath, "system"), { recursive: true });
+    await writeFile(join(homePath, "system/config.json"), JSON.stringify({
+      agent: { messagingRuntime: "hermes", revision: 0 },
+    }));
+    const services = createAgentRuntimeServices({
+      homePath,
+      client: {
+        readJson: vi.fn(async () => { throw new Error("dashboard starting"); }),
+        requestJson: vi.fn(async () => ({ ok: true })),
+      },
+      hostControl: {
+        status: vi.fn(async () => ({
+          hermes: { installed: true, running: true },
+          openclaw: { installed: false, running: false },
+        })),
+        switch: vi.fn(async () => {}),
+        stop: vi.fn(async () => {}),
+      },
+      openClawRpc: {
+        call: vi.fn(async () => { throw new Error("not selected"); }),
+        close: vi.fn(async () => {}),
+      },
+    });
+
+    await expect(services.source(new AbortController().signal)).resolves.toMatchObject({
+      runtime: {
+        selected: "hermes",
+        options: [
+          { id: "hermes", installState: "installed", selectionState: "active" },
+          { id: "openclaw", installState: "missing", selectionState: "unavailable" },
+        ],
+      },
+    });
+
     await services.controller.close();
   });
 

--- a/tests/gateway/host-runtime-control.test.ts
+++ b/tests/gateway/host-runtime-control.test.ts
@@ -75,6 +75,17 @@ describe("fixed host runtime control", () => {
     await expect(failed.switch("openclaw", new AbortController().signal))
       .rejects.toMatchObject({ kind: "runtime_switch_failed" });
   });
+
+  it("preserves caller cancellation instead of mapping it to a switch failure", async () => {
+    const controller = new AbortController();
+    controller.abort(new DOMException("shutdown", "AbortError"));
+    const exec = vi.fn(async () => {
+      throw controller.signal.reason;
+    });
+    const control = createHostRuntimeControl({ exec });
+
+    await expect(control.status(controller.signal)).rejects.toBe(controller.signal.reason);
+  });
 });
 
 describe("OpenClaw gateway token loading", () => {

--- a/tests/gateway/host-runtime-control.test.ts
+++ b/tests/gateway/host-runtime-control.test.ts
@@ -42,7 +42,7 @@ describe("fixed host runtime control", () => {
       1,
       "/opt/matrix/bin/matrix-agent-runtime-control",
       ["status"],
-      expect.objectContaining({ timeout: 25_000, maxBuffer: 4_096, signal }),
+      expect.objectContaining({ timeout: 70_000, maxBuffer: 4_096, signal }),
     );
     expect(exec).toHaveBeenNthCalledWith(
       2,

--- a/tests/gateway/host-runtime-control.test.ts
+++ b/tests/gateway/host-runtime-control.test.ts
@@ -1,0 +1,115 @@
+import { mkdir, mkdtemp, rm, symlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  createHostRuntimeControl,
+  readOpenClawGatewayToken,
+} from "../../packages/gateway/src/agent-config/host-runtime-control.js";
+
+const cleanupPaths: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(cleanupPaths.splice(0).map((path) => rm(path, {
+    recursive: true,
+    force: true,
+  })));
+});
+
+describe("fixed host runtime control", () => {
+  it("executes only fixed status, switch, and stop arguments with hard limits", async () => {
+    const exec = vi.fn(async (_command: string, args: readonly string[]) => ({
+      stdout: args[0] === "status"
+        ? JSON.stringify({
+            ok: true,
+            hermes: { installed: true, running: true },
+            openclaw: { installed: true, running: false },
+          })
+        : JSON.stringify({ ok: true, runtime: args[1] }),
+      stderr: "",
+    }));
+    const control = createHostRuntimeControl({ exec });
+    const signal = new AbortController().signal;
+
+    await expect(control.status(signal)).resolves.toEqual({
+      hermes: { installed: true, running: true },
+      openclaw: { installed: true, running: false },
+    });
+    await control.switch("openclaw", signal);
+    await control.stop("hermes", signal);
+
+    expect(exec).toHaveBeenNthCalledWith(
+      1,
+      "/opt/matrix/bin/matrix-agent-runtime-control",
+      ["status"],
+      expect.objectContaining({ timeout: 25_000, maxBuffer: 4_096, signal }),
+    );
+    expect(exec).toHaveBeenNthCalledWith(
+      2,
+      "/opt/matrix/bin/matrix-agent-runtime-control",
+      ["switch", "openclaw"],
+      expect.any(Object),
+    );
+    expect(exec).toHaveBeenNthCalledWith(
+      3,
+      "/opt/matrix/bin/matrix-agent-runtime-control",
+      ["stop", "hermes"],
+      expect.any(Object),
+    );
+  });
+
+  it("maps malformed and failed host responses to provider-neutral errors", async () => {
+    const malformed = createHostRuntimeControl({
+      exec: vi.fn(async () => ({ stdout: "provider secret detail", stderr: "" })),
+    });
+    await expect(malformed.status(new AbortController().signal))
+      .rejects.toMatchObject({ kind: "invalid_response" });
+
+    const failed = createHostRuntimeControl({
+      exec: vi.fn(async () => {
+        throw Object.assign(new Error("systemd private path"), {
+          stdout: '{"ok":false,"code":"rollback_failed"}',
+        });
+      }),
+    });
+    await expect(failed.switch("openclaw", new AbortController().signal))
+      .rejects.toMatchObject({ kind: "runtime_switch_failed" });
+  });
+});
+
+describe("OpenClaw gateway token loading", () => {
+  it("reads only one owner-local 64-hex token assignment", async () => {
+    const homePath = await mkdtemp(join(tmpdir(), "openclaw-token-"));
+    cleanupPaths.push(homePath);
+    await mkdir(join(homePath, "system/agent-runtime"), { recursive: true });
+    await writeFile(
+      join(homePath, "system/agent-runtime/openclaw.env"),
+      `OPENCLAW_GATEWAY_TOKEN=${"a".repeat(64)}\n`,
+      { mode: 0o600 },
+    );
+
+    await expect(readOpenClawGatewayToken(homePath)).resolves.toBe("a".repeat(64));
+  });
+
+  it("rejects symlinks, extra lines, and oversized token files", async () => {
+    const homePath = await mkdtemp(join(tmpdir(), "openclaw-token-"));
+    cleanupPaths.push(homePath);
+    const runtimeDir = join(homePath, "system/agent-runtime");
+    await mkdir(runtimeDir, { recursive: true });
+    const target = join(homePath, "target.env");
+    await writeFile(target, `OPENCLAW_GATEWAY_TOKEN=${"b".repeat(64)}\n`);
+    const tokenPath = join(runtimeDir, "openclaw.env");
+    await symlink(target, tokenPath);
+    await expect(readOpenClawGatewayToken(homePath))
+      .rejects.toMatchObject({ kind: "runtime_unavailable" });
+
+    await rm(tokenPath);
+    await writeFile(tokenPath, `OPENCLAW_GATEWAY_TOKEN=${"b".repeat(64)}\nEXTRA=1\n`);
+    await expect(readOpenClawGatewayToken(homePath))
+      .rejects.toMatchObject({ kind: "agent_config_invalid" });
+
+    await writeFile(tokenPath, "x".repeat(257));
+    await expect(readOpenClawGatewayToken(homePath))
+      .rejects.toMatchObject({ kind: "agent_config_invalid" });
+  });
+});

--- a/tests/gateway/host-runtime-control.test.ts
+++ b/tests/gateway/host-runtime-control.test.ts
@@ -42,19 +42,19 @@ describe("fixed host runtime control", () => {
       1,
       "/opt/matrix/bin/matrix-agent-runtime-control",
       ["status"],
-      expect.objectContaining({ timeout: 70_000, maxBuffer: 4_096, signal }),
+      expect.objectContaining({ timeout: 10_000, maxBuffer: 4_096, signal }),
     );
     expect(exec).toHaveBeenNthCalledWith(
       2,
       "/opt/matrix/bin/matrix-agent-runtime-control",
       ["switch", "openclaw"],
-      expect.any(Object),
+      expect.objectContaining({ timeout: 330_000, maxBuffer: 4_096, signal }),
     );
     expect(exec).toHaveBeenNthCalledWith(
       3,
       "/opt/matrix/bin/matrix-agent-runtime-control",
       ["stop", "hermes"],
-      expect.any(Object),
+      expect.objectContaining({ timeout: 90_000, maxBuffer: 4_096, signal }),
     );
   });
 


### PR DESCRIPTION
## Summary

- compose Hermes and OpenClaw behind one gateway runtime-service factory while retaining the focused Hermes compatibility factory
- combine owner-selected runtime, fixed host status, active catalog, and model selection into one additive settings snapshot
- preserve authoritative host install state and configured selections during transient catalog/auth outages
- invoke only the fixed host controller for bounded lifecycle operations and provider-neutral failures
- avoid host switches under the short startup-reconciliation probe deadline
- wait explicitly for cold Hermes dashboard readiness and give systemd lifecycle actions deadlines compatible with their unit budgets
- lazily load the owner-only OpenClaw gateway token and give first-start migrations a bounded 45-second readiness window inside the 75-second transition deadline

## TDD and validation

- added failing regressions for startup host switching, Hermes cold-start readiness, systemd lifecycle budgets, and temporarily unavailable configured models
- owning runtime-service/controller/host surface: 44/44 passed across 3 focused suites
- cumulative changed-surface matrix: 330/330 tests passed across 29 files
- contracts, gateway, shell, and desktop TypeScript strict checks: passed
- pattern scanner: 0 violations
- shell production build and desktop build: passed
- `git diff --check`: passed
- exact validated head: `cd11dc05903359156142a77e8421a58bc59d5916`

## Stack

- #983 — normalized OpenClaw runtime adapter
- this PR — gateway lifecycle and settings composition
- #985 — web Settings runtime/install flow

## Invariants

- **Source of truth:** owner config remains authoritative for runtime selection/revision; Hermes/OpenClaw own their catalogs and selection; systemd status owns installed/running state.
- **Lock/transaction scope:** the runtime controller is the sole owner-config serializer; host operations use the fixed host lock and OpenClaw mutations retain their upstream hash guard.
- **Acceptable orphan states:** missing/malformed tokens degrade OpenClaw without blocking Chat or startup; failed switches roll back inside the fixed host operation; shutdown rejects pending client creation before RPC use.
- **Auth source of truth:** the 0600 owner-local OpenClaw token authenticates loopback RPC and is never logged, returned, or persisted client-side.
- **Deferred scope:** UI and live preview proof remain in later stack layers.
- Only `/opt/matrix/bin/matrix-agent-runtime-control` with exact bounded arguments crosses the gateway-to-host boundary.
- A target must remain reachable (`healthy` or `degraded`) after activation; `stopped`, `unreachable`, and `unknown` still fail closed and roll back.
- This PR will not merge below exact-head Greptile 5/5 with zero unresolved review threads.

## Rollout

- no channel promotion in this layer
- exact live installation, selection, switching, and health verification is performed through #992
