### PR TITLE
feat(desktop): add agent runtime settings

### DIFF
--- a/desktop/electron.vite.config.ts
+++ b/desktop/electron.vite.config.ts
@@ -10,7 +10,10 @@ const codingAgentsDesktopWorkspace =
 
 export default defineConfig({
   main: {
-    plugins: [externalizeDepsPlugin()],
+    // Workspace contracts export TypeScript source for package consumers.
+    // Bundle the schemas and Zod so the built Electron main process never
+    // depends on source-only `.js` specifiers at runtime.
+    plugins: [externalizeDepsPlugin({ exclude: ["zod", "@matrix-os/contracts"] })],
     define: {
       __MATRIX_DESKTOP_UPDATE_CHANNEL__: JSON.stringify(desktopUpdateChannel),
       __CODING_AGENTS_DESKTOP_WORKSPACE__: JSON.stringify(codingAgentsDesktopWorkspace),

--- a/desktop/src/renderer/src/features/settings/sections/AgentRuntimeSettingsCard.tsx
+++ b/desktop/src/renderer/src/features/settings/sections/AgentRuntimeSettingsCard.tsx
@@ -1,0 +1,408 @@
+import type {
+  AgentProviderDescriptor,
+  AgentRuntimeId,
+  AgentSettingsView,
+} from "@matrix-os/contracts";
+import { KeyRound, Radio, SquareTerminal } from "lucide-react";
+import { useEffect, useMemo, useState } from "react";
+import { Button, StatusDot } from "../../../design/primitives";
+import { normalizeAgentConfig } from "../../../lib/agent-config";
+import { toUserMessage } from "../../../lib/errors";
+import { useConnection } from "../../../stores/connection";
+import { useTabs } from "../../../stores/tabs";
+import {
+  openProviderSetupTerminal,
+  type ProviderSetupCommand,
+} from "../../coding-agents/provider-setup-terminal";
+import { Card, Empty } from "./section-kit";
+
+const AGENT_PATH = "/api/settings/agent";
+const API_KEY_PATH = "/api/settings/api-key";
+const LOAD_ERROR = "Agent runtime settings are unavailable.";
+const UPDATE_ERROR = "Agent settings could not be updated.";
+const SETUP_ERROR = "Could not open setup terminal. Try again from Terminal.";
+
+const RUNTIME_SETUP: Record<AgentRuntimeId, ProviderSetupCommand> = {
+  hermes: {
+    key: "hermes:model",
+    label: "Hermes provider setup",
+    command: "hermes model",
+    sessionName: "matrix-setup-hermes-model",
+  },
+  openclaw: {
+    key: "openclaw:model-auth",
+    label: "OpenClaw provider setup",
+    command: "openclaw models auth add",
+    sessionName: "matrix-setup-openclaw-auth",
+  },
+};
+
+const CLAUDE_SETUP: ProviderSetupCommand = {
+  key: "claude:login",
+  label: "Claude login",
+  command: "claude",
+  sessionName: "matrix-setup-claude-login",
+};
+
+function statusLabel(value: string): string {
+  return value
+    .split("_")
+    .map((part) => part.length > 0 ? `${part[0]?.toUpperCase()}${part.slice(1)}` : part)
+    .join(" ");
+}
+
+function statusColor(value: string): string {
+  if (value === "healthy" || value === "ready" || value === "active") return "var(--success)";
+  if (value === "installing" || value === "validating" || value === "activating") return "var(--accent)";
+  if (value === "degraded" || value === "action_required" || value === "stopped") return "var(--warning)";
+  if (value === "unavailable" || value === "unreachable" || value === "failed") return "var(--danger)";
+  return "var(--text-tertiary)";
+}
+
+function availableModels(provider: AgentProviderDescriptor | undefined) {
+  return provider?.models.filter((model) => model.available) ?? [];
+}
+
+function AuthStatus({ provider }: { provider: AgentProviderDescriptor }) {
+  return (
+    <span className="flex items-center gap-1.5 text-xs" style={{ color: "var(--text-tertiary)" }}>
+      <StatusDot color={statusColor(provider.authStatus.state)} />
+      {statusLabel(provider.authStatus.state)} · {statusLabel(provider.authKind)}
+    </span>
+  );
+}
+
+function RuntimeOptions({
+  view,
+  busy,
+  onSwitch,
+}: {
+  view: AgentSettingsView;
+  busy: boolean;
+  onSwitch: (runtime: AgentRuntimeId) => void;
+}) {
+  return (
+    <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
+      {view.runtime.options.map((runtime) => {
+        const selected = runtime.id === view.runtime.selected;
+        const usable = runtime.installState === "installed"
+          && runtime.selectionState !== "unavailable";
+        return (
+          <article
+            key={runtime.id}
+            className="rounded-lg border p-3"
+            style={{
+              borderColor: selected ? "var(--accent)" : "var(--border-subtle)",
+              background: selected ? "var(--accent-subtle)" : "var(--bg-sunken)",
+            }}
+          >
+            <div className="flex items-start justify-between gap-2">
+              <div className="min-w-0">
+                <span className="block truncate text-sm font-medium" style={{ color: "var(--text-primary)" }}>
+                  {runtime.displayName}
+                </span>
+                <span className="text-xs" style={{ color: "var(--text-tertiary)" }}>
+                  {runtime.version ? `Version ${runtime.version}` : statusLabel(runtime.installState)}
+                </span>
+              </div>
+              <span className="flex items-center gap-1.5 text-xs" style={{ color: "var(--text-secondary)" }}>
+                <StatusDot color={statusColor(runtime.health)} />
+                {statusLabel(runtime.health)}
+              </span>
+            </div>
+            <div className="mt-3">
+              {selected ? (
+                <span className="text-xs font-medium" style={{ color: "var(--success)" }}>
+                  {runtime.displayName} is active
+                </span>
+              ) : (
+                <Button
+                  variant="subtle"
+                  disabled={busy || !usable}
+                  aria-label={`Use ${runtime.displayName}`}
+                  onClick={() => onSwitch(runtime.id)}
+                >
+                  {usable ? `Use ${runtime.displayName}` : "Runtime update needed"}
+                </Button>
+              )}
+            </div>
+          </article>
+        );
+      })}
+    </div>
+  );
+}
+
+function ChatAuthentication({
+  view,
+  busy,
+  onSaveKey,
+  onOpenSetup,
+}: {
+  view: AgentSettingsView;
+  busy: boolean;
+  onSaveKey: (key: string) => Promise<void>;
+  onOpenSetup: (setup: ProviderSetupCommand) => Promise<void>;
+}) {
+  const provider = view.providers.find((candidate) =>
+    candidate.runtime === null && candidate.scopes.includes("chat"));
+  const [showKey, setShowKey] = useState(false);
+  const [apiKey, setApiKey] = useState("");
+
+  if (!provider) return null;
+
+  const saveKey = async () => {
+    const key = apiKey;
+    setApiKey("");
+    await onSaveKey(key);
+  };
+
+  return (
+    <div className="rounded-lg border p-3" style={{ borderColor: "var(--border-subtle)", background: "var(--bg-sunken)" }}>
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <div>
+          <span className="block text-sm font-medium" style={{ color: "var(--text-primary)" }}>{provider.displayName}</span>
+          <AuthStatus provider={provider} />
+        </div>
+        <div className="flex flex-wrap gap-2">
+          {provider.supportedAuthKinds.includes("api_key") ? (
+            <Button variant="subtle" onClick={() => setShowKey((value) => !value)}>
+              <KeyRound size={13} />Use my API key
+            </Button>
+          ) : null}
+          {provider.supportedAuthKinds.includes("oauth_login") ? (
+            <Button variant="subtle" onClick={() => void onOpenSetup(CLAUDE_SETUP)}>
+              <SquareTerminal size={13} />Sign in with Claude
+            </Button>
+          ) : null}
+        </div>
+      </div>
+      {showKey ? (
+        <div className="mt-3 flex flex-wrap items-end gap-2">
+          <label className="min-w-48 flex-1 text-xs" style={{ color: "var(--text-secondary)" }}>
+            Anthropic API key
+            <input
+              className="mt-1 h-8 w-full rounded-md border bg-transparent px-2 text-sm outline-none"
+              style={{ borderColor: "var(--border-default)", color: "var(--text-primary)" }}
+              type="password"
+              autoComplete="off"
+              value={apiKey}
+              onChange={(event) => setApiKey(event.target.value)}
+            />
+          </label>
+          <Button variant="primary" disabled={busy || apiKey.length < 8} onClick={() => void saveKey()}>
+            Save API key
+          </Button>
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function MessagingProvider({
+  view,
+  busy,
+  onSave,
+  onOpenSetup,
+}: {
+  view: AgentSettingsView;
+  busy: boolean;
+  onSave: (provider: string, model: string) => void;
+  onOpenSetup: (setup: ProviderSetupCommand) => Promise<void>;
+}) {
+  const providers = useMemo(() => view.providers.filter((candidate) =>
+    candidate.runtime === view.runtime.selected && candidate.scopes.includes("messaging")), [view]);
+  const current = view.currentSelection.messaging;
+  const [providerId, setProviderId] = useState(current.provider ?? providers[0]?.id ?? "");
+  const provider = providers.find((candidate) => candidate.id === providerId);
+  const [model, setModel] = useState(current.model ?? availableModels(provider)[0]?.id ?? "");
+
+  if (providers.length === 0) {
+    return <Empty text="No providers are available for the selected messaging runtime." />;
+  }
+
+  return (
+    <div className="flex flex-col gap-3 rounded-lg border p-3" style={{ borderColor: "var(--border-subtle)", background: "var(--bg-sunken)" }}>
+      <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
+        {providers.map((candidate) => (
+          <button
+            key={candidate.id}
+            type="button"
+            className="rounded-md border p-2 text-left"
+            style={{
+              borderColor: candidate.id === providerId ? "var(--accent)" : "var(--border-default)",
+              background: candidate.id === providerId ? "var(--accent-subtle)" : "transparent",
+            }}
+            aria-label={`Choose ${candidate.displayName}`}
+            aria-pressed={candidate.id === providerId}
+            onClick={() => {
+              setProviderId(candidate.id);
+              setModel(availableModels(candidate)[0]?.id ?? "");
+            }}
+          >
+            <span className="block text-sm font-medium" style={{ color: "var(--text-primary)" }}>{candidate.displayName}</span>
+            <AuthStatus provider={candidate} />
+          </button>
+        ))}
+      </div>
+      <label className="text-xs" style={{ color: "var(--text-secondary)" }}>
+        Messaging model
+        <select
+          className="mt-1 h-8 w-full rounded-md border bg-transparent px-2 text-sm outline-none"
+          style={{ borderColor: "var(--border-default)", color: "var(--text-primary)" }}
+          aria-label="Messaging model"
+          value={model}
+          onChange={(event) => setModel(event.target.value)}
+        >
+          {availableModels(provider).map((candidate) => (
+            <option key={candidate.id} value={candidate.id}>{candidate.displayName}</option>
+          ))}
+        </select>
+      </label>
+      <div className="flex flex-wrap justify-end gap-2">
+        <Button
+          variant="subtle"
+          aria-label={`Configure ${statusLabel(view.runtime.selected)} provider`}
+          onClick={() => void onOpenSetup(RUNTIME_SETUP[view.runtime.selected])}
+        >
+          <SquareTerminal size={13} />Configure
+        </Button>
+        <Button variant="primary" disabled={busy || !providerId || !model} onClick={() => onSave(providerId, model)}>
+          Save messaging model
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+export default function AgentRuntimeSettingsCard() {
+  const api = useConnection((state) => state.api);
+  const openTab = useTabs((state) => state.openTab);
+  const [view, setView] = useState<AgentSettingsView | null>(null);
+  const [legacy, setLegacy] = useState(false);
+  const [loading, setLoading] = useState(true);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = async () => {
+    if (!api) return;
+    const config = normalizeAgentConfig(await api.get<unknown>(AGENT_PATH));
+    setView(config.extended);
+    setLegacy(config.runtimeUpdateRequired);
+  };
+
+  useEffect(() => {
+    let cancelled = false;
+    if (!api) {
+      setLoading(false);
+      setError(LOAD_ERROR);
+      return;
+    }
+    api.get<unknown>(AGENT_PATH)
+      .then((raw) => {
+        if (cancelled) return;
+        const config = normalizeAgentConfig(raw);
+        setView(config.extended);
+        setLegacy(config.runtimeUpdateRequired);
+        setError(null);
+      })
+      .catch((loadError: unknown) => {
+        if (!cancelled) setError(toUserMessage(loadError));
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [api]);
+
+  const mutate = async (body: Record<string, unknown>) => {
+    if (!api) return;
+    setBusy(true);
+    setError(null);
+    try {
+      const raw = await api.put<unknown>(AGENT_PATH, body);
+      const config = normalizeAgentConfig(raw);
+      if (config.extended) setView(config.extended);
+      else await load();
+    } catch (mutationError: unknown) {
+      setError(toUserMessage(mutationError) || UPDATE_ERROR);
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const openSetup = async (setup: ProviderSetupCommand) => {
+    if (!api) return;
+    setError(null);
+    if (!await openProviderSetupTerminal(api, setup, openTab, "agent-settings")) {
+      setError(SETUP_ERROR);
+    }
+  };
+
+  const saveKey = async (key: string) => {
+    if (!api) return;
+    setBusy(true);
+    setError(null);
+    try {
+      await api.post(API_KEY_PATH, { apiKey: key });
+      await load();
+    } catch (keyError: unknown) {
+      setError(toUserMessage(keyError));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  if (loading) return <Card><Empty text="Loading agent runtime settings…" /></Card>;
+  if (legacy) {
+    return (
+      <Card>
+        <span className="text-sm font-medium" style={{ color: "var(--warning)" }}>Runtime update needed</span>
+        <p className="text-xs" style={{ color: "var(--text-secondary)" }}>
+          This computer keeps Chat model and effort controls, but needs a newer gateway for runtime and provider controls.
+        </p>
+      </Card>
+    );
+  }
+  if (!view) return <Card><Empty text={error ?? LOAD_ERROR} /></Card>;
+
+  return (
+    <Card>
+      <div className="flex items-start gap-2">
+        <Radio size={15} style={{ color: "var(--accent)" }} />
+        <div>
+          <span className="block text-sm font-medium" style={{ color: "var(--text-primary)" }}>Messaging runtime</span>
+          <p className="text-xs" style={{ color: "var(--text-secondary)" }}>
+            Controls optional messaging channels. Matrix Chat continues through the kernel above.
+          </p>
+        </div>
+      </div>
+      {error ? <span role="alert" className="text-xs" style={{ color: "var(--danger)" }}>{error}</span> : null}
+      <RuntimeOptions
+        view={view}
+        busy={busy}
+        onSwitch={(runtime) => void mutate({ runtime, revision: view.revision })}
+      />
+      <div className="flex flex-col gap-2">
+        <span className="text-xs font-medium" style={{ color: "var(--text-secondary)" }}>Chat provider authentication</span>
+        <ChatAuthentication view={view} busy={busy} onSaveKey={saveKey} onOpenSetup={openSetup} />
+      </div>
+      <div className="flex flex-col gap-2">
+        <span className="text-xs font-medium" style={{ color: "var(--text-secondary)" }}>Messaging provider</span>
+        <MessagingProvider
+          key={`${view.revision}:${view.runtime.selected}`}
+          view={view}
+          busy={busy}
+          onOpenSetup={openSetup}
+          onSave={(provider, messagingModel) => void mutate({
+            provider,
+            messagingModel,
+            revision: view.revision,
+          })}
+        />
+      </div>
+    </Card>
+  );
+}

--- a/desktop/src/renderer/src/features/settings/sections/AgentRuntimeSettingsCard.tsx
+++ b/desktop/src/renderer/src/features/settings/sections/AgentRuntimeSettingsCard.tsx
@@ -307,7 +307,10 @@ export default function AgentRuntimeSettingsCard() {
         setError(null);
       })
       .catch((loadError: unknown) => {
-        if (!cancelled) setError(toUserMessage(loadError));
+        if (!cancelled) {
+          setLegacy(false);
+          setError(toUserMessage(loadError));
+        }
       })
       .finally(() => {
         if (!cancelled) setLoading(false);
@@ -327,6 +330,7 @@ export default function AgentRuntimeSettingsCard() {
       if (config.extended) setView(config.extended);
       else await load();
     } catch (mutationError: unknown) {
+      setLegacy(false);
       setError(toUserMessage(mutationError) || UPDATE_ERROR);
     } finally {
       setBusy(false);

--- a/desktop/src/renderer/src/features/settings/sections/AgentRuntimeSettingsCard.tsx
+++ b/desktop/src/renderer/src/features/settings/sections/AgentRuntimeSettingsCard.tsx
@@ -37,6 +37,21 @@ const RUNTIME_SETUP: Record<AgentRuntimeId, ProviderSetupCommand> = {
   },
 };
 
+const RUNTIME_INSTALL: Record<AgentRuntimeId, ProviderSetupCommand> = {
+  hermes: {
+    key: "hermes:install",
+    label: "Install Hermes",
+    command: "/opt/matrix/bin/matrix-agent-runtime-control install hermes",
+    sessionName: "matrix-install-hermes",
+  },
+  openclaw: {
+    key: "openclaw:install",
+    label: "Install OpenClaw",
+    command: "/opt/matrix/bin/matrix-agent-runtime-control install openclaw",
+    sessionName: "matrix-install-openclaw",
+  },
+};
+
 const CLAUDE_SETUP: ProviderSetupCommand = {
   key: "claude:login",
   label: "Claude login",
@@ -75,10 +90,12 @@ function AuthStatus({ provider }: { provider: AgentProviderDescriptor }) {
 function RuntimeOptions({
   view,
   busy,
+  onOpenSetup,
   onSwitch,
 }: {
   view: AgentSettingsView;
   busy: boolean;
+  onOpenSetup: (setup: ProviderSetupCommand) => Promise<void>;
   onSwitch: (runtime: AgentRuntimeId) => void;
 }) {
   return (
@@ -87,6 +104,8 @@ function RuntimeOptions({
         const selected = runtime.id === view.runtime.selected;
         const usable = runtime.installState === "installed"
           && runtime.selectionState !== "unavailable";
+        const canInstall = runtime.installState !== "installed"
+          && runtime.setupAction === "install";
         return (
           <article
             key={runtime.id}
@@ -115,6 +134,15 @@ function RuntimeOptions({
                 <span className="text-xs font-medium" style={{ color: "var(--success)" }}>
                   {runtime.displayName} is active
                 </span>
+              ) : canInstall ? (
+                <Button
+                  variant="subtle"
+                  disabled={busy}
+                  aria-label={`Install ${runtime.displayName}`}
+                  onClick={() => void onOpenSetup(RUNTIME_INSTALL[runtime.id])}
+                >
+                  <SquareTerminal size={13} />Install {runtime.displayName}
+                </Button>
               ) : (
                 <Button
                   variant="subtle"
@@ -141,7 +169,7 @@ function ChatAuthentication({
 }: {
   view: AgentSettingsView;
   busy: boolean;
-  onSaveKey: (key: string) => Promise<void>;
+  onSaveKey: (key: string, onAccepted: () => void) => Promise<void>;
   onOpenSetup: (setup: ProviderSetupCommand) => Promise<void>;
 }) {
   const provider = view.providers.find((candidate) =>
@@ -152,9 +180,7 @@ function ChatAuthentication({
   if (!provider) return null;
 
   const saveKey = async () => {
-    const key = apiKey;
-    setApiKey("");
-    await onSaveKey(key);
+    await onSaveKey(apiKey, () => setApiKey(""));
   };
 
   return (
@@ -214,8 +240,15 @@ function MessagingProvider({
     candidate.runtime === view.runtime.selected && candidate.scopes.includes("messaging")), [view]);
   const current = view.currentSelection.messaging;
   const [providerId, setProviderId] = useState(current.provider ?? providers[0]?.id ?? "");
-  const provider = providers.find((candidate) => candidate.id === providerId);
+  const selectedProviderId = providers.some((candidate) => candidate.id === providerId)
+    ? providerId
+    : providers[0]?.id ?? "";
+  const provider = providers.find((candidate) => candidate.id === selectedProviderId);
   const [model, setModel] = useState(current.model ?? availableModels(provider)[0]?.id ?? "");
+  const providerModels = availableModels(provider);
+  const selectedModel = providerModels.some((candidate) => candidate.id === model)
+    ? model
+    : providerModels[0]?.id ?? "";
 
   if (providers.length === 0) {
     return <Empty text="No providers are available for the selected messaging runtime." />;
@@ -230,11 +263,11 @@ function MessagingProvider({
             type="button"
             className="rounded-md border p-2 text-left"
             style={{
-              borderColor: candidate.id === providerId ? "var(--accent)" : "var(--border-default)",
-              background: candidate.id === providerId ? "var(--accent-subtle)" : "transparent",
+              borderColor: candidate.id === selectedProviderId ? "var(--accent)" : "var(--border-default)",
+              background: candidate.id === selectedProviderId ? "var(--accent-subtle)" : "transparent",
             }}
             aria-label={`Choose ${candidate.displayName}`}
-            aria-pressed={candidate.id === providerId}
+            aria-pressed={candidate.id === selectedProviderId}
             onClick={() => {
               setProviderId(candidate.id);
               setModel(availableModels(candidate)[0]?.id ?? "");
@@ -251,10 +284,10 @@ function MessagingProvider({
           className="mt-1 h-8 w-full rounded-md border bg-transparent px-2 text-sm outline-none"
           style={{ borderColor: "var(--border-default)", color: "var(--text-primary)" }}
           aria-label="Messaging model"
-          value={model}
+          value={selectedModel}
           onChange={(event) => setModel(event.target.value)}
         >
-          {availableModels(provider).map((candidate) => (
+          {providerModels.map((candidate) => (
             <option key={candidate.id} value={candidate.id}>{candidate.displayName}</option>
           ))}
         </select>
@@ -267,7 +300,11 @@ function MessagingProvider({
         >
           <SquareTerminal size={13} />Configure
         </Button>
-        <Button variant="primary" disabled={busy || !providerId || !model} onClick={() => onSave(providerId, model)}>
+        <Button
+          variant="primary"
+          disabled={busy || !selectedProviderId || !selectedModel}
+          onClick={() => onSave(selectedProviderId, selectedModel)}
+        >
           Save messaging model
         </Button>
       </div>
@@ -308,6 +345,7 @@ export default function AgentRuntimeSettingsCard() {
       })
       .catch((loadError: unknown) => {
         if (!cancelled) {
+          setView(null);
           setLegacy(false);
           setError(toUserMessage(loadError));
         }
@@ -325,13 +363,22 @@ export default function AgentRuntimeSettingsCard() {
     setBusy(true);
     setError(null);
     try {
-      const raw = await api.put<unknown>(AGENT_PATH, body);
-      const config = normalizeAgentConfig(raw);
-      if (config.extended) setView(config.extended);
-      else await load();
-    } catch (mutationError: unknown) {
-      setLegacy(false);
-      setError(toUserMessage(mutationError) || UPDATE_ERROR);
+      let raw: unknown;
+      try {
+        raw = await api.put<unknown>(AGENT_PATH, body);
+      } catch (mutationError: unknown) {
+        setError(toUserMessage(mutationError) || UPDATE_ERROR);
+        return;
+      }
+      try {
+        const config = normalizeAgentConfig(raw);
+        if (config.extended) setView(config.extended);
+        else await load();
+      } catch (mutationError: unknown) {
+        setView(null);
+        setLegacy(false);
+        setError(toUserMessage(mutationError) || UPDATE_ERROR);
+      }
     } finally {
       setBusy(false);
     }
@@ -345,15 +392,25 @@ export default function AgentRuntimeSettingsCard() {
     }
   };
 
-  const saveKey = async (key: string) => {
+  const saveKey = async (key: string, onAccepted: () => void): Promise<void> => {
     if (!api) return;
     setBusy(true);
     setError(null);
     try {
-      await api.post(API_KEY_PATH, { apiKey: key });
-      await load();
-    } catch (keyError: unknown) {
-      setError(toUserMessage(keyError));
+      try {
+        await api.post(API_KEY_PATH, { apiKey: key });
+      } catch (keyError: unknown) {
+        setError(toUserMessage(keyError));
+        return;
+      }
+      onAccepted();
+      try {
+        await load();
+      } catch (loadError: unknown) {
+        setView(null);
+        setLegacy(false);
+        setError(toUserMessage(loadError));
+      }
     } finally {
       setBusy(false);
     }
@@ -387,6 +444,7 @@ export default function AgentRuntimeSettingsCard() {
       <RuntimeOptions
         view={view}
         busy={busy}
+        onOpenSetup={openSetup}
         onSwitch={(runtime) => void mutate({ runtime, revision: view.revision })}
       />
       <div className="flex flex-col gap-2">

--- a/desktop/src/renderer/src/features/settings/sections/AgentSection.tsx
+++ b/desktop/src/renderer/src/features/settings/sections/AgentSection.tsx
@@ -9,6 +9,7 @@ import { useConnection } from "../../../stores/connection";
 import { useTabs } from "../../../stores/tabs";
 import { openProviderSetupTerminal, providerSetupCommands, type ProviderSetupCommand } from "../../coding-agents/provider-setup-terminal";
 import { Card, Empty, SectionHeader } from "./section-kit";
+import AgentRuntimeSettingsCard from "./AgentRuntimeSettingsCard";
 
 const SOUL_PATH = "/files/system/soul.md";
 const AGENT_PATH = "/api/settings/agent";
@@ -466,10 +467,11 @@ export default function AgentSection() {
   return (
     <>
       <SectionHeader
-        title="Agent (Hermes)"
-        description="Hermes is your OS agent. Tune its model and reasoning, edit its standing instructions (SOUL), and check which coding agents are connected."
+        title="Agent"
+        description="Tune Matrix Chat, choose the runtime for messaging channels, authenticate providers, edit SOUL, and check which coding agents are connected."
       />
       <ModelEffortCard />
+      <AgentRuntimeSettingsCard />
       <RuntimeProvidersCard />
       <ProvidersCard />
       <SoulEditor />

--- a/desktop/src/renderer/src/features/settings/sections/AgentSection.tsx
+++ b/desktop/src/renderer/src/features/settings/sections/AgentSection.tsx
@@ -464,6 +464,7 @@ function RuntimeProvidersCard() {
 }
 
 export default function AgentSection() {
+  const runtimeScope = useConnection((state) => `${state.runtimeSlot}:${state.authGeneration}`);
   return (
     <>
       <SectionHeader
@@ -471,7 +472,7 @@ export default function AgentSection() {
         description="Tune Matrix Chat, choose the runtime for messaging channels, authenticate providers, edit SOUL, and check which coding agents are connected."
       />
       <ModelEffortCard />
-      <AgentRuntimeSettingsCard />
+      <AgentRuntimeSettingsCard key={runtimeScope} />
       <RuntimeProvidersCard />
       <ProvidersCard />
       <SoulEditor />

--- a/desktop/src/renderer/src/lib/agent-config.ts
+++ b/desktop/src/renderer/src/lib/agent-config.ts
@@ -43,6 +43,9 @@ export function normalizeAgentConfig(raw: unknown): AgentConfigView {
   const kernel = asRecord(root.kernel);
   const defaults = asRecord(root.defaults);
   const extended = AgentSettingsViewSchema.safeParse(raw);
+  if (!extended.success && root.contractVersion !== undefined) {
+    throw new Error("Agent settings response is invalid");
+  }
   return {
     kernel: { model: asStringOrNull(kernel.model), effort: asStringOrNull(kernel.effort) },
     availableModels: Array.isArray(root.availableModels)

--- a/desktop/src/renderer/src/lib/agent-config.ts
+++ b/desktop/src/renderer/src/lib/agent-config.ts
@@ -1,3 +1,5 @@
+import { AgentSettingsViewSchema, type AgentSettingsView } from "@matrix-os/contracts";
+
 // Defensive normalizer for GET /api/settings/agent. The model/effort catalog
 // (availableModels/availableEfforts/defaults) was added to the gateway after
 // the desktop UI shipped, so an older deployed gateway answers with only
@@ -16,6 +18,8 @@ export interface AgentConfigView {
   availableModels: ModelOption[];
   availableEfforts: string[];
   defaults: { model: string | null; effort: string | null };
+  extended: AgentSettingsView | null;
+  runtimeUpdateRequired: boolean;
 }
 
 function asRecord(value: unknown): Record<string, unknown> {
@@ -38,6 +42,7 @@ export function normalizeAgentConfig(raw: unknown): AgentConfigView {
   const root = asRecord(raw);
   const kernel = asRecord(root.kernel);
   const defaults = asRecord(root.defaults);
+  const extended = AgentSettingsViewSchema.safeParse(raw);
   return {
     kernel: { model: asStringOrNull(kernel.model), effort: asStringOrNull(kernel.effort) },
     availableModels: Array.isArray(root.availableModels)
@@ -47,6 +52,8 @@ export function normalizeAgentConfig(raw: unknown): AgentConfigView {
       ? root.availableEfforts.filter((e): e is string => typeof e === "string")
       : [],
     defaults: { model: asStringOrNull(defaults.model), effort: asStringOrNull(defaults.effort) },
+    extended: extended.success ? extended.data : null,
+    runtimeUpdateRequired: !extended.success,
   };
 }
 

--- a/tests/desktop/agent-config.test.ts
+++ b/tests/desktop/agent-config.test.ts
@@ -37,6 +37,17 @@ describe("normalizeAgentConfig", () => {
     expect(cfg.defaults).toEqual({ model: "a", effort: "low" });
   });
 
+  it("rejects a malformed current contract instead of labeling it as an older gateway", () => {
+    expect(() => normalizeAgentConfig({
+      contractVersion: 2,
+      identity: {},
+      kernel: { model: "sonnet", effort: "medium" },
+      availableModels: [{ id: "sonnet", label: "Sonnet", tier: "Balanced" }],
+      availableEfforts: ["medium"],
+      defaults: { model: "sonnet", effort: "medium" },
+    })).toThrow("Agent settings response is invalid");
+  });
+
   it("preserves the validated additive runtime and provider contract", () => {
     const cfg = normalizeAgentConfig({
       identity: {},

--- a/tests/desktop/agent-config.test.ts
+++ b/tests/desktop/agent-config.test.ts
@@ -17,6 +17,8 @@ describe("normalizeAgentConfig", () => {
     expect(cfg.availableEfforts).toEqual([]);
     expect(cfg.defaults).toEqual({ model: null, effort: null });
     expect(cfg.kernel).toEqual({ model: "claude-opus-4-6", effort: "high" });
+    expect(cfg.extended).toBeNull();
+    expect(cfg.runtimeUpdateRequired).toBe(true);
   });
 
   it("preserves a full catalog and drops malformed model entries", () => {
@@ -33,6 +35,111 @@ describe("normalizeAgentConfig", () => {
     expect(cfg.availableModels).toEqual([{ id: "a", label: "A", tier: "Fast" }]);
     expect(cfg.availableEfforts).toEqual(["low", "high"]);
     expect(cfg.defaults).toEqual({ model: "a", effort: "low" });
+  });
+
+  it("preserves the validated additive runtime and provider contract", () => {
+    const cfg = normalizeAgentConfig({
+      identity: {},
+      kernel: { model: null, effort: null },
+      availableModels: [{ id: "sonnet", label: "Sonnet", tier: "Balanced" }],
+      availableEfforts: ["medium"],
+      defaults: { model: "sonnet", effort: "medium" },
+      contractVersion: 2,
+      revision: 7,
+      chat: {
+        provider: "anthropic",
+        model: "sonnet",
+        effort: "medium",
+        source: "default",
+        authKind: "platform",
+      },
+      runtime: {
+        selected: "hermes",
+        transition: null,
+        options: [
+          {
+            id: "hermes",
+            displayName: "Hermes",
+            installState: "installed",
+            health: "healthy",
+            selectionState: "active",
+            configured: true,
+            capabilities: ["provider_catalog", "model_selection", "authentication"],
+          },
+          {
+            id: "openclaw",
+            displayName: "OpenClaw",
+            installState: "missing",
+            health: "stopped",
+            selectionState: "action_required",
+            configured: false,
+            capabilities: ["install"],
+            setupAction: "install",
+          },
+        ],
+      },
+      providers: [
+        {
+          id: "anthropic",
+          displayName: "Anthropic",
+          runtime: null,
+          scopes: ["chat"],
+          authKind: "platform",
+          supportedAuthKinds: ["platform", "api_key", "oauth_login"],
+          models: [{
+            id: "sonnet",
+            displayName: "Sonnet",
+            capabilities: ["tools", "reasoning"],
+            efforts: ["medium"],
+            available: true,
+          }],
+          authStatus: { state: "ready", authenticated: true, action: "none" },
+        },
+        {
+          id: "openrouter",
+          displayName: "OpenRouter",
+          runtime: "hermes",
+          scopes: ["messaging"],
+          authKind: "api_key",
+          supportedAuthKinds: ["api_key"],
+          models: [{
+            id: "openrouter/auto",
+            displayName: "Auto",
+            capabilities: ["tools"],
+            efforts: [],
+            available: true,
+          }],
+          authStatus: {
+            state: "action_required",
+            authenticated: false,
+            action: "enter_api_key",
+          },
+        },
+      ],
+      currentSelection: {
+        chat: {
+          provider: "anthropic",
+          model: "sonnet",
+          effort: "medium",
+          source: "default",
+          authKind: "platform",
+        },
+        messaging: {
+          runtime: "hermes",
+          provider: "openrouter",
+          model: "openrouter/auto",
+          configured: true,
+        },
+      },
+    });
+
+    expect(cfg.runtimeUpdateRequired).toBe(false);
+    expect(cfg.extended?.revision).toBe(7);
+    expect(cfg.extended?.runtime.selected).toBe("hermes");
+    expect(cfg.extended?.providers.map((provider) => provider.displayName)).toEqual([
+      "Anthropic",
+      "OpenRouter",
+    ]);
   });
 
   it("never throws on garbage input", () => {
@@ -52,6 +159,8 @@ describe("selectedModelEffort", () => {
     availableModels: [],
     availableEfforts: [],
     defaults: { model: null, effort: null },
+    extended: null,
+    runtimeUpdateRequired: true,
   };
 
   it("prefers the saved kernel value over defaults", () => {

--- a/tests/desktop/agent-section.test.tsx
+++ b/tests/desktop/agent-section.test.tsx
@@ -103,6 +103,145 @@ describe("AgentSection", () => {
     vi.restoreAllMocks();
   });
 
+  it("renders the additive runtime and provider controls and sends revisioned updates", async () => {
+    const current = {
+      identity: {},
+      kernel: { model: null, effort: null },
+      availableModels: [{ id: "sonnet", label: "Sonnet", tier: "Balanced" }],
+      availableEfforts: ["medium"],
+      defaults: { model: "sonnet", effort: "medium" },
+      contractVersion: 2,
+      revision: 7,
+      chat: {
+        provider: "anthropic",
+        model: "sonnet",
+        effort: "medium",
+        source: "default",
+        authKind: "platform",
+      },
+      runtime: {
+        selected: "hermes",
+        transition: null,
+        options: [
+          {
+            id: "hermes",
+            displayName: "Hermes",
+            installState: "installed",
+            health: "healthy",
+            selectionState: "active",
+            configured: true,
+            capabilities: ["provider_catalog", "model_selection", "authentication"],
+          },
+          {
+            id: "openclaw",
+            displayName: "OpenClaw",
+            installState: "installed",
+            health: "stopped",
+            selectionState: "available",
+            configured: false,
+            capabilities: ["provider_catalog", "model_selection", "authentication"],
+          },
+        ],
+      },
+      providers: [
+        {
+          id: "anthropic",
+          displayName: "Anthropic",
+          runtime: null,
+          scopes: ["chat"],
+          authKind: "platform",
+          supportedAuthKinds: ["platform", "api_key", "oauth_login"],
+          models: [{
+            id: "sonnet",
+            displayName: "Sonnet",
+            capabilities: ["tools", "reasoning"],
+            efforts: ["medium"],
+            available: true,
+          }],
+          authStatus: { state: "ready", authenticated: true, action: "none" },
+        },
+        {
+          id: "openrouter",
+          displayName: "OpenRouter",
+          runtime: "hermes",
+          scopes: ["messaging"],
+          authKind: "api_key",
+          supportedAuthKinds: ["api_key"],
+          models: [{
+            id: "openrouter/auto",
+            displayName: "Auto",
+            capabilities: ["tools"],
+            efforts: [],
+            available: true,
+          }],
+          authStatus: {
+            state: "action_required",
+            authenticated: false,
+            action: "enter_api_key",
+          },
+        },
+      ],
+      currentSelection: {
+        chat: {
+          provider: "anthropic",
+          model: "sonnet",
+          effort: "medium",
+          source: "default",
+          authKind: "platform",
+        },
+        messaging: {
+          runtime: "hermes",
+          provider: "openrouter",
+          model: "openrouter/auto",
+          configured: true,
+        },
+      },
+    };
+    api.get.mockImplementation((path: string) => {
+      if (path === "/api/settings/agent") return Promise.resolve(current);
+      if (path === "/api/agents/credentials/status") return Promise.resolve({});
+      return Promise.reject(new Error(`unexpected path ${path}`));
+    });
+    api.put.mockResolvedValue(current);
+    api.post.mockResolvedValue({ valid: true });
+
+    render(<AgentSection />);
+
+    expect(await screen.findByText("Messaging runtime")).toBeTruthy();
+    expect(screen.getByText("Hermes is active")).toBeTruthy();
+    expect(screen.getByText("Anthropic")).toBeTruthy();
+    expect(screen.getByText("OpenRouter")).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("button", { name: "Use OpenClaw" }));
+    await waitFor(() => expect(api.put).toHaveBeenCalledWith(
+      "/api/settings/agent",
+      { runtime: "openclaw", revision: 7 },
+    ));
+
+    fireEvent.click(screen.getByRole("button", { name: "Use my API key" }));
+    const keyInput = screen.getByLabelText("Anthropic API key") as HTMLInputElement;
+    fireEvent.change(keyInput, { target: { value: "sk-ant-desktop-test" } });
+    fireEvent.click(screen.getByRole("button", { name: "Save API key" }));
+    expect(keyInput.value).toBe("");
+    await waitFor(() => expect(api.post).toHaveBeenCalledWith(
+      "/api/settings/api-key",
+      { apiKey: "sk-ant-desktop-test" },
+    ));
+
+    fireEvent.click(screen.getByRole("button", { name: "Configure Hermes provider" }));
+    await waitFor(() => expect(api.post).toHaveBeenCalledWith(
+      "/api/terminal/sessions",
+      expect.objectContaining({ cmd: "hermes model", cwd: "projects" }),
+    ));
+  });
+
+  it("shows a runtime update fallback for older gateways", async () => {
+    render(<AgentSection />);
+
+    expect(await screen.findByText("Runtime update needed")).toBeTruthy();
+    expect(screen.getByText(/needs a newer gateway for runtime and provider controls/i)).toBeTruthy();
+  });
+
   it("does not crash when provider status omits agents", async () => {
     render(<AgentSection />);
 

--- a/tests/desktop/agent-section.test.tsx
+++ b/tests/desktop/agent-section.test.tsx
@@ -242,6 +242,142 @@ describe("AgentSection", () => {
     expect(screen.getByText(/needs a newer gateway for runtime and provider controls/i)).toBeTruthy();
   });
 
+  it("replaces a stale legacy fallback when a current-contract load is malformed", async () => {
+    render(<AgentSection />);
+    expect(await screen.findByText("Runtime update needed")).toBeTruthy();
+
+    const invalidApi = {
+      ...api,
+      get: vi.fn((path: string) => path === "/api/settings/agent"
+        ? Promise.resolve({ contractVersion: 2 })
+        : Promise.resolve({})),
+    };
+    act(() => useConnection.setState({ api: invalidApi as never }));
+
+    await waitFor(() => expect(screen.queryByText("Runtime update needed")).toBeNull());
+    expect(screen.getAllByText("Something went wrong. Please try again.").length).toBeGreaterThan(0);
+  });
+
+  it("replaces a stale legacy fallback when a current-contract mutation is malformed", async () => {
+    const current = {
+      identity: {},
+      kernel: { model: null, effort: null },
+      availableModels: [{ id: "sonnet", label: "Sonnet", tier: "Balanced" }],
+      availableEfforts: ["medium"],
+      defaults: { model: "sonnet", effort: "medium" },
+      contractVersion: 2,
+      revision: 7,
+      chat: {
+        provider: "anthropic",
+        model: "sonnet",
+        effort: "medium",
+        source: "default",
+        authKind: "platform",
+      },
+      runtime: {
+        selected: "hermes",
+        transition: null,
+        options: [
+          {
+            id: "hermes",
+            displayName: "Hermes",
+            installState: "installed",
+            health: "healthy",
+            selectionState: "active",
+            configured: true,
+            capabilities: ["provider_catalog", "model_selection", "authentication"],
+          },
+          {
+            id: "openclaw",
+            displayName: "OpenClaw",
+            installState: "installed",
+            health: "stopped",
+            selectionState: "available",
+            configured: false,
+            capabilities: ["provider_catalog", "model_selection", "authentication"],
+          },
+        ],
+      },
+      providers: [
+        {
+          id: "anthropic",
+          displayName: "Anthropic",
+          runtime: null,
+          scopes: ["chat"],
+          authKind: "platform",
+          supportedAuthKinds: ["platform", "api_key", "oauth_login"],
+          models: [{
+            id: "sonnet",
+            displayName: "Sonnet",
+            capabilities: ["tools", "reasoning"],
+            efforts: ["medium"],
+            available: true,
+          }],
+          authStatus: { state: "ready", authenticated: true, action: "none" },
+        },
+        {
+          id: "openrouter",
+          displayName: "OpenRouter",
+          runtime: "hermes",
+          scopes: ["messaging"],
+          authKind: "api_key",
+          supportedAuthKinds: ["api_key"],
+          models: [{
+            id: "openrouter/auto",
+            displayName: "Auto",
+            capabilities: ["tools"],
+            efforts: [],
+            available: true,
+          }],
+          authStatus: { state: "action_required", authenticated: false, action: "enter_api_key" },
+        },
+      ],
+      currentSelection: {
+        chat: {
+          provider: "anthropic",
+          model: "sonnet",
+          effort: "medium",
+          source: "default",
+          authKind: "platform",
+        },
+        messaging: {
+          runtime: "hermes",
+          provider: "openrouter",
+          model: "openrouter/auto",
+          configured: true,
+        },
+      },
+    };
+    api.get.mockImplementation((path: string) => path === "/api/settings/agent"
+      ? Promise.resolve(current)
+      : Promise.resolve({}));
+    let resolveMutation!: (value: unknown) => void;
+    api.put.mockReturnValue(new Promise((resolve) => {
+      resolveMutation = resolve;
+    }));
+    render(<AgentSection />);
+
+    fireEvent.click(await screen.findByRole("button", { name: "Use OpenClaw" }));
+    const legacyApi = {
+      ...api,
+      get: vi.fn((path: string) => path === "/api/settings/agent"
+        ? Promise.resolve({
+          kernel: { model: null, effort: null },
+          availableModels: [{ id: "sonnet", label: "Sonnet", tier: "Balanced" }],
+          availableEfforts: ["medium"],
+          defaults: { model: "sonnet", effort: "medium" },
+        })
+        : Promise.resolve({})),
+    };
+    act(() => useConnection.setState({ api: legacyApi as never }));
+    expect(await screen.findByText("Runtime update needed")).toBeTruthy();
+
+    await act(async () => resolveMutation({ contractVersion: 2 }));
+
+    await waitFor(() => expect(screen.queryByText("Runtime update needed")).toBeNull());
+    expect(screen.getAllByText("Something went wrong. Please try again.").length).toBeGreaterThan(0);
+  });
+
   it("does not crash when provider status omits agents", async () => {
     render(<AgentSection />);
 

--- a/tests/desktop/agent-section.test.tsx
+++ b/tests/desktop/agent-section.test.tsx
@@ -7,6 +7,98 @@ import AgentSection from "../../desktop/src/renderer/src/features/settings/secti
 import { useConnection } from "../../desktop/src/renderer/src/stores/connection";
 import { useTabs } from "../../desktop/src/renderer/src/stores/tabs";
 
+function currentAgentSettings() {
+  return {
+    identity: {},
+    kernel: { model: "sonnet", effort: "medium" },
+    availableModels: [{ id: "sonnet", label: "Sonnet", tier: "Balanced" }],
+    availableEfforts: ["medium"],
+    defaults: { model: "sonnet", effort: "medium" },
+    contractVersion: 2,
+    revision: 7,
+    chat: {
+      provider: "anthropic",
+      model: "sonnet",
+      effort: "medium",
+      source: "saved",
+      authKind: "platform",
+    },
+    runtime: {
+      selected: "hermes",
+      transition: null,
+      options: [
+        {
+          id: "hermes",
+          displayName: "Hermes",
+          installState: "installed",
+          health: "healthy",
+          selectionState: "active",
+          configured: true,
+          capabilities: ["provider_catalog", "model_selection", "authentication"],
+        },
+        {
+          id: "openclaw",
+          displayName: "OpenClaw",
+          installState: "installed",
+          health: "stopped",
+          selectionState: "available",
+          configured: false,
+          capabilities: ["provider_catalog", "model_selection", "authentication"],
+        },
+      ],
+    },
+    providers: [
+      {
+        id: "anthropic",
+        displayName: "Anthropic",
+        runtime: null,
+        scopes: ["chat"],
+        authKind: "platform",
+        supportedAuthKinds: ["platform", "api_key", "oauth_login"],
+        models: [{
+          id: "sonnet",
+          displayName: "Sonnet",
+          capabilities: ["tools", "reasoning"],
+          efforts: ["medium"],
+          available: true,
+        }],
+        authStatus: { state: "ready", authenticated: true, action: "none" },
+      },
+      {
+        id: "openrouter",
+        displayName: "OpenRouter",
+        runtime: "hermes",
+        scopes: ["messaging"],
+        authKind: "api_key",
+        supportedAuthKinds: ["api_key"],
+        models: [{
+          id: "openrouter/auto",
+          displayName: "Auto",
+          capabilities: ["tools"],
+          efforts: [],
+          available: true,
+        }],
+        authStatus: { state: "action_required", authenticated: false, action: "enter_api_key" },
+      },
+    ],
+    currentSelection: {
+      chat: {
+        provider: "anthropic",
+        model: "sonnet",
+        effort: "medium",
+        source: "saved",
+        authKind: "platform",
+      },
+      messaging: {
+        runtime: "hermes",
+        provider: "openrouter",
+        model: "openrouter/auto",
+        configured: true,
+      },
+    },
+  };
+}
+
 describe("AgentSection", () => {
   let api: {
     get: ReturnType<typeof vi.fn>;
@@ -135,11 +227,12 @@ describe("AgentSection", () => {
           {
             id: "openclaw",
             displayName: "OpenClaw",
-            installState: "installed",
+            installState: "missing",
             health: "stopped",
-            selectionState: "available",
+            selectionState: "unavailable",
             configured: false,
-            capabilities: ["provider_catalog", "model_selection", "authentication"],
+            capabilities: ["install"],
+            setupAction: "install",
           },
         ],
       },
@@ -212,26 +305,103 @@ describe("AgentSection", () => {
     expect(screen.getByText("Anthropic")).toBeTruthy();
     expect(screen.getByText("OpenRouter")).toBeTruthy();
 
-    fireEvent.click(screen.getByRole("button", { name: "Use OpenClaw" }));
+    fireEvent.click(screen.getByRole("button", { name: "Install OpenClaw" }));
+    await waitFor(() => expect(api.post).toHaveBeenCalledWith(
+      "/api/terminal/sessions",
+      expect.objectContaining({
+        cmd: "/opt/matrix/bin/matrix-agent-runtime-control install openclaw",
+        cwd: "projects",
+      }),
+    ));
+
+    current.runtime.options[1] = {
+      id: "openclaw",
+      displayName: "OpenClaw",
+      installState: "installed",
+      health: "stopped",
+      selectionState: "available",
+      configured: false,
+      capabilities: ["provider_catalog", "model_selection", "authentication"],
+    };
+    act(() => useConnection.setState({ api: null }));
+    act(() => useConnection.setState({ api: api as never }));
+    fireEvent.click(await screen.findByRole("button", { name: "Use OpenClaw" }));
     await waitFor(() => expect(api.put).toHaveBeenCalledWith(
       "/api/settings/agent",
       { runtime: "openclaw", revision: 7 },
-    ));
-
-    fireEvent.click(screen.getByRole("button", { name: "Use my API key" }));
-    const keyInput = screen.getByLabelText("Anthropic API key") as HTMLInputElement;
-    fireEvent.change(keyInput, { target: { value: "sk-ant-desktop-test" } });
-    fireEvent.click(screen.getByRole("button", { name: "Save API key" }));
-    expect(keyInput.value).toBe("");
-    await waitFor(() => expect(api.post).toHaveBeenCalledWith(
-      "/api/settings/api-key",
-      { apiKey: "sk-ant-desktop-test" },
     ));
 
     fireEvent.click(screen.getByRole("button", { name: "Configure Hermes provider" }));
     await waitFor(() => expect(api.post).toHaveBeenCalledWith(
       "/api/terminal/sessions",
       expect.objectContaining({ cmd: "hermes model", cwd: "projects" }),
+    ));
+
+    const invalidApi = {
+      ...api,
+      get: vi.fn((path: string) => path === "/api/settings/agent"
+        ? Promise.resolve({ contractVersion: 2 })
+        : Promise.resolve({})),
+    };
+    act(() => useConnection.setState({ api: invalidApi as never }));
+
+    await waitFor(() => expect(screen.queryByText("Messaging runtime")).toBeNull());
+    expect(screen.queryByRole("button", { name: "Use OpenClaw" })).toBeNull();
+    expect(screen.getAllByText("Something went wrong. Please try again.").length).toBeGreaterThan(0);
+
+    act(() => useConnection.setState({ api: api as never }));
+    expect(await screen.findByText("Messaging runtime")).toBeTruthy();
+    api.get.mockImplementation((path: string) => path === "/api/settings/agent"
+      ? Promise.resolve({ contractVersion: 2 })
+      : Promise.resolve({}));
+
+    fireEvent.click(screen.getByRole("button", { name: "Use my API key" }));
+    const keyInput = screen.getByLabelText("Anthropic API key") as HTMLInputElement;
+    fireEvent.change(keyInput, { target: { value: "sk-ant-desktop-test" } });
+    fireEvent.click(screen.getByRole("button", { name: "Save API key" }));
+    await waitFor(() => expect(api.post).toHaveBeenCalledWith(
+      "/api/settings/api-key",
+      { apiKey: "sk-ant-desktop-test" },
+    ));
+    await waitFor(() => expect(screen.queryByText("Messaging runtime")).toBeNull());
+    expect(screen.queryByRole("button", { name: "Use OpenClaw" })).toBeNull();
+  });
+
+  it("submits the visible fallback when the saved messaging model is unavailable", async () => {
+    const current = currentAgentSettings();
+    const messagingProvider = current.providers.find((provider) => provider.id === "openrouter");
+    if (!messagingProvider) throw new Error("missing messaging provider fixture");
+    messagingProvider.models = [
+      {
+        id: "retired-model",
+        displayName: "Retired",
+        capabilities: ["tools"],
+        efforts: [],
+        available: false,
+      },
+      {
+        id: "ready-model",
+        displayName: "Ready",
+        capabilities: ["tools"],
+        efforts: [],
+        available: true,
+      },
+    ];
+    current.currentSelection.messaging.model = "retired-model";
+    api.get.mockImplementation((path: string) => path === "/api/settings/agent"
+      ? Promise.resolve(current)
+      : Promise.resolve({}));
+    api.put.mockResolvedValue(current);
+
+    render(<AgentSection />);
+
+    const model = await screen.findByRole("combobox", { name: "Messaging model" }) as HTMLSelectElement;
+    expect(model.value).toBe("ready-model");
+    fireEvent.click(screen.getByRole("button", { name: "Save messaging model" }));
+
+    await waitFor(() => expect(api.put).toHaveBeenCalledWith(
+      "/api/settings/agent",
+      { provider: "openrouter", messagingModel: "ready-model", revision: 7 },
     ));
   });
 
@@ -258,7 +428,7 @@ describe("AgentSection", () => {
     expect(screen.getAllByText("Something went wrong. Please try again.").length).toBeGreaterThan(0);
   });
 
-  it("replaces a stale legacy fallback when a current-contract mutation is malformed", async () => {
+  it("clears stale current-contract controls when a mutation response is malformed", async () => {
     const current = {
       identity: {},
       kernel: { model: null, effort: null },
@@ -358,24 +528,113 @@ describe("AgentSection", () => {
     render(<AgentSection />);
 
     fireEvent.click(await screen.findByRole("button", { name: "Use OpenClaw" }));
-    const legacyApi = {
-      ...api,
-      get: vi.fn((path: string) => path === "/api/settings/agent"
-        ? Promise.resolve({
-          kernel: { model: null, effort: null },
-          availableModels: [{ id: "sonnet", label: "Sonnet", tier: "Balanced" }],
-          availableEfforts: ["medium"],
-          defaults: { model: "sonnet", effort: "medium" },
-        })
-        : Promise.resolve({})),
-    };
-    act(() => useConnection.setState({ api: legacyApi as never }));
-    expect(await screen.findByText("Runtime update needed")).toBeTruthy();
-
     await act(async () => resolveMutation({ contractVersion: 2 }));
 
-    await waitFor(() => expect(screen.queryByText("Runtime update needed")).toBeNull());
+    await waitFor(() => expect(screen.queryByText("Messaging runtime")).toBeNull());
+    expect(screen.queryByRole("button", { name: "Use OpenClaw" })).toBeNull();
     expect(screen.getAllByText("Something went wrong. Please try again.").length).toBeGreaterThan(0);
+  });
+
+  it("keeps current runtime controls after a rejected mutation", async () => {
+    const current = currentAgentSettings();
+    api.get.mockImplementation((path: string) => path === "/api/settings/agent"
+      ? Promise.resolve(current)
+      : Promise.resolve({}));
+    api.put.mockRejectedValue(new Error("conflict"));
+    render(<AgentSection />);
+
+    fireEvent.click(await screen.findByRole("button", { name: "Use OpenClaw" }));
+
+    await screen.findByText("Something went wrong. Please try again.");
+    expect(screen.getByText("Messaging runtime")).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Use OpenClaw" })).toBeTruthy();
+  });
+
+  it("keeps a typed API key after a rejected validation request", async () => {
+    const current = currentAgentSettings();
+    api.get.mockImplementation((path: string) => path === "/api/settings/agent"
+      ? Promise.resolve(current)
+      : Promise.resolve({}));
+    api.post.mockImplementation((path: string) => path === "/api/settings/api-key"
+      ? Promise.reject(new Error("invalid key"))
+      : Promise.resolve({ name: "setup" }));
+    render(<AgentSection />);
+
+    fireEvent.click(await screen.findByRole("button", { name: "Use my API key" }));
+    const keyInput = screen.getByLabelText("Anthropic API key") as HTMLInputElement;
+    fireEvent.change(keyInput, { target: { value: "sk-ant-retry-value" } });
+    fireEvent.click(screen.getByRole("button", { name: "Save API key" }));
+
+    await screen.findByText("Something went wrong. Please try again.");
+    expect(keyInput.value).toBe("sk-ant-retry-value");
+    expect(screen.getByText("Messaging runtime")).toBeTruthy();
+  });
+
+  it("reloads settings when the selected runtime slot changes even if the API client is reused", async () => {
+    const primary = currentAgentSettings();
+    const secondary = structuredClone(primary);
+    secondary.runtime.selected = "openclaw";
+    secondary.runtime.options[0].selectionState = "available";
+    secondary.runtime.options[1].selectionState = "active";
+    secondary.runtime.options[1].health = "healthy";
+    secondary.currentSelection.messaging = {
+      runtime: "openclaw",
+      provider: null,
+      model: null,
+      configured: false,
+    };
+    let active = primary;
+    api.get.mockImplementation((path: string) => path === "/api/settings/agent"
+      ? Promise.resolve(active)
+      : Promise.resolve({}));
+    render(<AgentSection />);
+    expect(await screen.findByText("Hermes is active")).toBeTruthy();
+
+    active = secondary;
+    act(() => useConnection.setState({ runtimeSlot: "secondary" }));
+
+    expect(await screen.findByText("OpenClaw is active")).toBeTruthy();
+  });
+
+  it("discards a delayed mutation response from the previously selected computer", async () => {
+    const primary = currentAgentSettings();
+    const secondary = structuredClone(primary);
+    secondary.runtime.selected = "openclaw";
+    secondary.runtime.options[0].selectionState = "available";
+    secondary.runtime.options[1].selectionState = "active";
+    secondary.runtime.options[1].health = "healthy";
+    secondary.currentSelection.messaging = {
+      runtime: "openclaw",
+      provider: null,
+      model: null,
+      configured: false,
+    };
+    let resolveOldMutation!: (value: unknown) => void;
+    api.get.mockImplementation((path: string) => path === "/api/settings/agent"
+      ? Promise.resolve(primary)
+      : Promise.resolve({}));
+    api.put.mockReturnValue(new Promise((resolve) => {
+      resolveOldMutation = resolve;
+    }));
+    render(<AgentSection />);
+    fireEvent.click(await screen.findByRole("button", { name: "Use OpenClaw" }));
+
+    const nextApi = {
+      ...api,
+      get: vi.fn((path: string) => path === "/api/settings/agent"
+        ? Promise.resolve(secondary)
+        : Promise.resolve({})),
+    };
+    act(() => useConnection.setState({
+      runtimeSlot: "secondary",
+      authGeneration: 1,
+      api: nextApi as never,
+    }));
+    expect(await screen.findByText("OpenClaw is active")).toBeTruthy();
+
+    await act(async () => resolveOldMutation(primary));
+    expect(screen.getByText("OpenClaw is active")).toBeTruthy();
+    expect(screen.queryByText("Hermes is active")).toBeNull();
   });
 
   it("does not crash when provider status omits agents", async () => {

--- a/tests/desktop/desktop-release-workflows.test.ts
+++ b/tests/desktop/desktop-release-workflows.test.ts
@@ -65,6 +65,15 @@ describe("desktop release workflows", () => {
     expect(config).toContain('externalizeDepsPlugin({ exclude: ["zod", "@matrix-os/contracts"] })');
   });
 
+  it("bundles runtime schema dependencies into the Electron main process", () => {
+    const config = readFileSync(join(root, "desktop/electron.vite.config.ts"), "utf8");
+    const bundledContracts = config.match(
+      /externalizeDepsPlugin\(\{ exclude: \["zod", "@matrix-os\/contracts"\] \}\)/g,
+    );
+
+    expect(bundledContracts).toHaveLength(2);
+  });
+
   it("records the full canary app version in the release manifest", () => {
     const workflow = readFileSync(join(root, ".github/workflows/desktop-release-canary.yml"), "utf8");
 

--- a/tests/desktop/settings-view.test.tsx
+++ b/tests/desktop/settings-view.test.tsx
@@ -49,8 +49,8 @@ describe("SettingsView", () => {
 
     render(<SettingsView />);
 
-    // The Agent (Hermes) section renders instead of the default Account.
-    await waitFor(() => expect(screen.getByRole("heading", { name: "Agent (Hermes)" })).not.toBeNull());
+    // The unified Agent section renders instead of the default Account.
+    await waitFor(() => expect(screen.getByRole("heading", { name: "Agent" })).not.toBeNull());
     expect(useUi.getState().requestedSettingsSection).toBeNull();
   });
 


### PR DESCRIPTION
## Summary

- extend native desktop Agent settings with the same Hermes/OpenClaw inventory and revisioned switching contract as the web shell
- show **Install Hermes** or **Install OpenClaw** when the selected descriptor is missing and installable
- open a foreground native Terminal tab running the fixed `matrix-agent-runtime-control install <runtime>` command
- preserve legacy-gateway fallback, fail-closed schema normalization, provider setup, safe errors, and trusted-core boundaries
- reload on computer/runtime-scope changes, discard delayed responses from the previous computer, preserve valid controls after transport failures, and retain rejected API keys for retry

## TDD and validation

- observed the missing install-action test fail before implementation
- focused desktop matrix: 22/22 passed, including visible terminal creation, runtime-scope reload, stale-response rejection, retry-safe failures, and unavailable-model clamping
- desktop package TypeScript: passed
- Electron production build (main, preload, renderer): passed
- React Doctor changed-scope scan: 100/100, no issues
- cumulative changed-surface matrix: 323/323 tests passed across 29 files; pattern scanner reported 0 violations
- exact validated head: `92c49adf33ee20899f336db0b97011afbfb50b9c`

## Stack

- #985 — web shell Agent settings and visible install flow
- this PR — native desktop Agent runtime settings
- #992 — isolated preview verification gate

## Invariants

- **Source of truth:** gateway settings and owner config remain authoritative; the renderer holds transient request/form state only.
- **Lock/transaction scope:** the renderer sends the last loaded revision and allows one mutation at a time; gateway and host controllers remain the only serializers.
- **Acceptable orphan states:** closing or failing an install leaves a visible terminal session and does not clear or change the confirmed runtime selection.
- **Auth source of truth:** gateway routes own credentials; the renderer never receives a privileged installer API or stores secrets.
- **Deferred scope:** host/runtime proof is performed on #992.
- Installation commands are fixed and routed through foreground terminal sessions; no arbitrary command or unrestricted sudo surface is exposed.
- This PR will not merge below an exact-head Greptile 5/5 review.

## Rollout

- no channel promotion in this layer
- exact runtime installation and switching are verified through the #992 preview flow

