### PR TITLE
docs(agent): distinguish chat and messaging runtimes

### DIFF
--- a/specs/107-agent-runtime-config/data-model.md
+++ b/specs/107-agent-runtime-config/data-model.md
@@ -164,7 +164,7 @@ Transient owner-local JSON under `system/agent-runtime/transition.json`, mode 06
 | `to` | AgentRuntimeId | Required and different. |
 | `state` | enum | `validating`, `pausing`, `draining`, `activating`, `verifying`, `committing`, `rolling_back`. |
 | `startedAt` | ISO timestamp | Required. |
-| `deadlineAt` | ISO timestamp | At most 10 seconds after start. |
+| `deadlineAt` | ISO timestamp | At most 75 seconds after start. |
 
 State transitions:
 

--- a/specs/107-agent-runtime-config/plan.md
+++ b/specs/107-agent-runtime-config/plan.md
@@ -17,7 +17,7 @@ The work lands as a Graphite stack of small, independently testable PRs. Three c
 **Testing**: Vitest unit/route/component tests, systemd/host-bundle tests, current mobile compatibility tests, React Doctor, production shell build, preview VPS live probes
 **Target Platform**: VPS-native Linux gateway and systemd services; web Canvas/desktop shell; Electron desktop renderer with trusted main/preload boundary; mobile contract consumers
 **Project Type**: Monorepo backend contracts + gateway + host runtime + web shell + Electron desktop
-**Performance Goals**: Agent settings visible within 2 seconds; runtime status probes bounded to 2 seconds each and performed concurrently; runtime switch completes or safely fails within 10 seconds; no effect on Chat request latency when messaging runtimes are absent
+**Performance Goals**: Agent settings visible within 2 seconds; runtime status probes bounded to 2 seconds each and performed concurrently; runtime switch completes or safely fails within 75 seconds, including a host-control action bounded to 70 seconds; no effect on Chat request latency when messaging runtimes are absent
 **Constraints**: Additive wire compatibility; no browser-side secrets; no provider-specific raw errors; loopback-only external dashboards with auth; bounded catalogs and queues; no direct OpenClaw Matrix room membership; kernel prompt remains under 7K tokens
 **Scale/Scope**: One owner per customer VPS; two selectable messaging runtimes; maximum 32 provider descriptors, 256 models total, 128 models per provider; one serialized runtime transition; existing Chat queue limits unchanged
 

--- a/specs/107-agent-runtime-config/resource-management.md
+++ b/specs/107-agent-runtime-config/resource-management.md
@@ -15,10 +15,10 @@
 | Model capabilities | 12 | Schema |
 | Runtime capabilities | 16 | Schema |
 | Concurrent runtime transitions | 1 | Exclusive `wx` lock |
-| Runtime transition duration | 10 seconds hard deadline | Controller timeout |
+| Runtime transition duration | 75 seconds hard deadline | Controller timeout |
 | Active-work drain | 5 seconds | Controller deadline + abort |
 | Runtime status cache | 2 runtimes, TTL 5 seconds | Fixed keys, replace in place |
-| In-flight adapter RPC | 8 total, 4 per runtime | Semaphore; excess returns busy/retry |
+| In-flight OpenClaw RPC | 8 total | Correlation ceiling; excess returns busy/retry |
 | OpenClaw config writes | At most 3 per rolling 60 seconds per device/IP | One serialized owner queue; debounce/coalesce compatible pending patches and reject excess work with a bounded retry state |
 | Setup/login sessions | 4 owner-local, TTL 10 minutes | Bounded registry + recurring sweep |
 | Diagnostic events | 500 entries or 30 days | Owner-local capped rotation |
@@ -27,10 +27,11 @@
 
 - Agent settings aggregate read: 3 seconds hard budget.
 - Individual runtime health/config/catalog probe: 2 seconds.
-- Runtime config mutation: 10 seconds.
+- Kernel/provider config mutation without a runtime switch: 10 seconds.
 - Provider credential validation: 10 seconds.
 - Custom endpoint validation/probe if enabled after DNS-pinning decision: 10 seconds, redirect error.
-- Service start/stop state wait: 2 seconds each, within the 10-second transition budget.
+- Host runtime control action: 70 seconds, within the 75-second transition budget.
+- OpenClaw post-activation readiness probe: 10 seconds, within the same transition budget.
 - WebSocket connect and authenticated handshake: 2 seconds.
 - Terminal setup session creation: existing terminal API timeout, no hidden background wait.
 

--- a/specs/107-agent-runtime-config/spec.md
+++ b/specs/107-agent-runtime-config/spec.md
@@ -177,7 +177,7 @@ As a Matrix OS owner using mobile Chat, I want session history and effective mod
 - **SC-003**: A saved model or effort change appears consistently in web, desktop, and legacy-compatible mobile reads within 2 seconds on the same computer.
 - **SC-004**: In validation, 100% of unsupported per-message choices are rejected before agent work begins, and 100% of accepted overrides leave the saved default unchanged.
 - **SC-005**: In failure tests where OpenClaw is absent, unhealthy, or loses authentication, 100% preserve Chat availability and the last healthy messaging-runtime selection.
-- **SC-006**: In runtime-switch tests, no source event is delivered to both runtimes and new messaging work resumes within 10 seconds or returns a clear retryable state.
+- **SC-006**: In runtime-switch tests, no source event is delivered to both runtimes and new messaging work resumes within the 75-second hard deadline or returns a clear retryable state.
 - **SC-007**: In security tests, no settings, status, error, diagnostic, or conversation response contains provider credentials, login tokens, raw upstream errors, or filesystem paths.
 - **SC-008**: Existing desktop and mobile contract tests for model/effort continue to pass unchanged while current clients can consume the extended fields.
 - **SC-009**: An owner can switch mobile Chat sessions and load the stored transcript and effective model on every validated session change.

--- a/tests/www/agent-runtime-docs.test.ts
+++ b/tests/www/agent-runtime-docs.test.ts
@@ -20,6 +20,7 @@ describe("agent runtime public docs", () => {
     expect(agentRuntime).toContain("Platform-provided");
     expect(agentRuntime).toContain("API key");
     expect(agentRuntime).toContain("subscription login");
+    expect(agentRuntime).toContain("custom base URL when that runtime and provider support it");
     expect(agentRuntime).toContain("never stored in the browser");
     expect(agentRuntime).toContain("keeps Chat available");
     expect(agentRuntime).toMatch(/keeps the\s+current healthy messaging runtime selected/);

--- a/tests/www/agent-runtime-docs.test.ts
+++ b/tests/www/agent-runtime-docs.test.ts
@@ -1,0 +1,42 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const root = process.cwd();
+const readDoc = (name: string) =>
+  readFileSync(join(root, `www/content/docs/${name}.mdx`), "utf8");
+
+describe("agent runtime public docs", () => {
+  it("distinguishes Chat from optional messaging runtimes", () => {
+    const agentRuntime = readDoc("hermes");
+
+    expect(agentRuntime).toContain("Chat kernel");
+    expect(agentRuntime).toContain("Claude Agent SDK V1");
+    expect(agentRuntime).toContain("Messaging runtime");
+    expect(agentRuntime).toContain("Hermes");
+    expect(agentRuntime).toContain("OpenClaw");
+    expect(agentRuntime).toContain("Settings");
+    expect(agentRuntime).toContain("Agent");
+    expect(agentRuntime).toContain("Platform-provided");
+    expect(agentRuntime).toContain("API key");
+    expect(agentRuntime).toContain("subscription login");
+    expect(agentRuntime).toContain("never stored in the browser");
+    expect(agentRuntime).toContain("keeps Chat available");
+    expect(agentRuntime).toMatch(/keeps the\s+current healthy messaging runtime selected/);
+  });
+
+  it("uses the same runtime language on overview, glossary, and Messages pages", () => {
+    const overview = readDoc("index");
+    const glossary = readDoc("glossary");
+    const messages = readDoc("messages");
+
+    expect(overview).not.toContain("Hermes is always on");
+    expect(overview).toContain("Chat kernel");
+    expect(overview).toContain("Hermes or OpenClaw");
+    expect(glossary).toContain("**Chat kernel**");
+    expect(glossary).toContain("**Messaging runtime**");
+    expect(glossary).not.toContain("**Hermes** — Matrix's always-on chat agent");
+    expect(messages).toContain("selected messaging runtime");
+    expect(messages).not.toContain("does not let Hermes read or reply");
+  });
+});

--- a/www/content/docs/coding-agents.mdx
+++ b/www/content/docs/coding-agents.mdx
@@ -40,8 +40,8 @@ Four coding agents are supported:
   <Card title="Pi" description="Earendil's Pi coding agent. Launched with the pi command." />
 </Cards>
 
-<Callout type="info" title="Hermes is separate">
-  Hermes is the always-on Matrix chat agent, not a coding agent you install from the Terminal menu. See [Hermes](/docs/hermes) for details.
+<Callout type="info" title="Background runtimes are separate">
+  The Matrix Chat kernel and optional Hermes or OpenClaw Messaging runtime are not coding agents you install from the Terminal menu. See [Agent runtime](/docs/hermes) for details.
 </Callout>
 
 ## Installing an agent

--- a/www/content/docs/desktop.mdx
+++ b/www/content/docs/desktop.mdx
@@ -46,7 +46,7 @@ on your Matrix computer.
 
 ## Navigation
 
-The collapsible sidebar holds four primary destinations — **Home**, **Chat** (Hermes),
+The collapsible sidebar holds four primary destinations — **Home**, **Chat**,
 **Terminal**, and **Apps** — followed by your **Projects** list. Everything you open becomes a
 **tab** in the main area. Tabs are cached: switching away from a terminal never kills it, and
 coming back is instant. Close a tab with its close button or a middle-click; the Home tab always
@@ -73,12 +73,12 @@ the terminal shows a clear ended state with a one-click recreate action.
   CLI. See the [CLI](/docs/cli) docs for `matrix shell connect` usage.
 </Callout>
 
-## Agent threads (Hermes)
+## Agent threads
 
 Press **⌘J** to open the composer and start an agent run. Each run is a thread with live
 status (running, needs attention, done, failed). Run several at once and switch freely between
 them; the sidebar shows unread markers and needs-attention badges. The **Chat** sidebar item
-opens the full Hermes thread list as a tab.
+opens the full Chat thread list as a tab.
 
 ## Task workspace
 
@@ -113,7 +113,7 @@ Standard macOS menus, full-screen, and window controls work as expected.
 ## Settings
 
 Native settings cover **Account**, **Billing**, **Appearance** (dark/light/system),
-**Agent** (Hermes configuration), **Runtime** (switch Matrix computer target), **Channels**,
+**Agent** (Chat model and optional Messaging runtime), **Runtime** (switch Matrix computer target), **Channels**,
 **Integrations**, **Schedules**, and **System info**. Switching runtime re-targets every
 surface — board, terminals, chat, and apps.
 

--- a/www/content/docs/glossary.mdx
+++ b/www/content/docs/glossary.mdx
@@ -39,6 +39,12 @@ A quick reference for the terms you'll see across these guides.
 
 **Coding agent** — An AI coding tool — Claude, Codex, Pi, or OpenCode — that you install and run on your Matrix computer inside a session. See [Coding Agents](/docs/coding-agents).
 
-**Hermes** — Matrix's always-on chat agent. It runs in the background and replies across web chat, mobile, and messaging channels. Hermes is model-agnostic — [pick a model](/docs/hermes) (Claude, GPT, Gemini, and more) before it can respond.
+**Chat kernel** — The Matrix OS agent behind Chat in the web shell, desktop app, and mobile app. Its provider, model, effort, and authentication are configured in [Agent settings](/docs/hermes).
+
+**Messaging runtime** — An optional owner-local background process that can receive and reply to permitted messaging rooms. Hermes is the default; OpenClaw is an alternative when installed and healthy. It is separate from the Chat kernel.
+
+**Hermes** — The default Messaging runtime. Hermes has its own provider and model configuration and never gains room access merely by being selected.
+
+**OpenClaw** — An optional Messaging runtime. Matrix only activates it after installation, authentication, and a successful health check.
 
 **Skill** — A short instruction file that coding agents discover and use to learn how Matrix works — build conventions, UI patterns, and debug playbooks. See [Matrix Skills](/docs/matrix-skills).

--- a/www/content/docs/hermes.mdx
+++ b/www/content/docs/hermes.mdx
@@ -1,97 +1,95 @@
 ---
-title: Hermes
-description: The always-on Matrix chat agent that responds across web, mobile, and messaging channels.
+title: Agent runtime
+description: Choose the Chat model and the optional messaging runtime on your Matrix computer.
 ---
 
 import { Callout } from 'fumadocs-ui/components/callout';
 import { Card, Cards } from 'fumadocs-ui/components/card';
 import { Step, Steps } from 'fumadocs-ui/components/steps';
 
-Hermes is the Matrix system agent: always running in the background, reachable across
-web chat, mobile, and connected messaging channels. It is distinct from the coding agents
-(Claude Code, Codex, OpenCode, Pi) that you install and launch from the Terminal.
+Matrix OS has two separate agent layers. The names used by earlier releases made them
+easy to confuse:
 
-<Callout type="warn" title="Pick a model before using Hermes">
-  Hermes is model-agnostic — it works with many LLM providers. Choose a model and add that
-  provider's credential before Hermes can respond. Until a model is configured, Hermes shows
-  as active but can't generate replies.
+- The **Chat kernel** powers Chat in the web shell, desktop app, and mobile app. It uses
+  Claude Agent SDK V1 and remains the Matrix OS kernel.
+- A **Messaging runtime** is an optional background process for permitted Telegram and
+  WhatsApp rooms. Hermes is the default option; OpenClaw is an alternative when it is
+  installed and healthy.
+
+Changing the Messaging runtime does not replace the Chat kernel, migrate Chat
+conversations, or change the model used by Chat.
+
+<Callout type="info" title="One settings surface, two independent selections">
+  Open **Settings → Agent** to see the effective Chat model and effort, authentication
+  state, available Messaging runtimes, and the provider and model used by the selected
+  Messaging runtime.
 </Callout>
 
-## What Hermes is
+## Configure Chat
 
-Hermes fills the role of a persistent background agent that is always reachable. Coding
-agents are interactive: you open a terminal, launch the agent, and it runs for that
-session. Hermes is different — it stays alive across sessions and responds to messages
-without you having to start it each time.
+The current Chat catalog uses Anthropic models. Choose a model and effort level in Agent
+settings. The saved choice becomes the computer default; supported shells can also send
+an allowlisted model and effort for one message without changing that default.
 
-## Choose your model
-
-Hermes runs on a **main model** for its core reasoning, plus a set of auxiliary models for
-specialized tasks (each defaults to your main model unless you override it). It is not tied
-to any single provider — it works with:
+Authentication is shown as a coarse state, never as a credential:
 
 <Cards>
-  <Card title="Nous Portal" description="300+ models via OpenRouter through a single Nous Portal subscription. The fastest way to get started." />
-  <Card title="Anthropic" description="Claude models, using your Anthropic API key or login." />
-  <Card title="OpenAI" description="GPT models with your OpenAI key." />
-  <Card title="Google" description="Gemini models with your Google credential." />
-  <Card title="Custom endpoint" description="Point Hermes at any compatible model server with your own base URL." />
+  <Card title="Platform-provided" description="Use the model access included with your Matrix computer. No key entry is required." />
+  <Card title="Your API key" description="Submit a BYOK key through the write-only gateway flow. The key is validated and never returned to a shell." />
+  <Card title="Subscription login" description="Open the visible, named terminal setup flow and complete the provider login on your Matrix computer." />
 </Cards>
 
-Configure which model Hermes uses:
+Provider secrets are never stored in the browser or desktop renderer. Agent settings
+clears key-entry fields after submission and receives only states such as connected,
+action required, or unavailable.
+
+## Choose a Messaging runtime
+
+<Cards>
+  <Card title="Hermes" description="The default messaging-agent runtime, with its own provider and model configuration." />
+  <Card title="OpenClaw" description="An optional owner-local gateway. It must be installed, authenticated, and healthy before it can be selected." />
+</Cards>
+
+The runtime cards show install state, health, selection eligibility, and the active
+provider and model. Provider choices belong to that Messaging runtime; they do not alter
+the Chat model.
+
+To configure a runtime:
 
 <Steps>
-  <Step>Add a provider credential first — only providers you've authenticated are selectable.</Step>
-  <Step>Run `hermes model` in a terminal for interactive setup, or `/model <name>` inside a chat. You can also run `hermes setup --portal` to use Nous Portal in one step.</Step>
-  <Step>Prefer editing config directly? Set your model in `~/.hermes/config.yaml`.</Step>
+  <Step>Open **Settings → Agent** and choose Hermes or OpenClaw under Messaging runtime.</Step>
+  <Step>Select an available provider and model. Unavailable models cannot be saved.</Step>
+  <Step>Use the authentication action shown for that provider: platform access, API key, subscription login, or a supported custom base URL.</Step>
+  <Step>Save the selection. Matrix activates it only after a bounded health check succeeds.</Step>
 </Steps>
 
-For the full provider list and model slots, see the [Hermes model configuration docs](https://hermes-agent.nousresearch.com/docs/user-guide/configuring-models).
+Hermes and OpenClaw keep their own configuration and authentication state in the
+owner-controlled home directory on the Matrix computer. Agent settings exposes a safe,
+normalized view rather than raw runtime configuration.
 
-### Before Hermes can respond
+## Failure and recovery
 
-- A **main model** must be selected.
-- The **provider credential** for that model must be set (API key, OAuth, or a custom endpoint).
+If OpenClaw is missing, stopped, unauthenticated, or unhealthy, Matrix marks it as
+unavailable and rejects activation. A failed switch keeps Chat available and keeps the
+current healthy messaging runtime selected. It never falls back to an unauthenticated
+runtime or sends work to two runtimes.
 
-Until both are in place, Hermes still appears as the system agent, room permissions and
-automation rules are still stored, and pending drafts stay visible — but it can't generate
-chat responses, drafts, or assistant results.
+If provider authentication expires, Agent settings shows **Action required** and offers
+the appropriate setup flow. It does not expose the provider response or raw error.
 
-## Where you talk to Hermes
+<Callout type="warn" title="Messaging access remains default-deny">
+  Selecting or authenticating a Messaging runtime does not grant it access to any room.
+  Read, reply, and automation permissions are still granted and revoked per room in
+  Messages. See [Messages](/docs/messages) for the permission model.
+</Callout>
 
-<Cards>
-  <Card title="Web shell chat" description="The chat surface built into the Matrix OS web shell. Start a conversation from any page." />
-  <Card title="Mobile" description="The Matrix OS mobile app surfaces the same Hermes conversation. Responses arrive even when the web shell is closed." />
-  <Card title="Messages" description="Connect Telegram or WhatsApp accounts and grant Hermes per-room access. See Messages for the privacy model." href="/docs/messages" />
-</Cards>
+## Messaging runtimes versus coding agents
 
-## What Hermes can do
+Hermes and OpenClaw are owner-local background runtimes for permitted message delivery.
+Claude Code, Codex, OpenCode, and Pi are coding tools that you install and launch in named
+terminal sessions. See [Coding Agents](/docs/coding-agents) for that workflow.
 
-Hermes can access shell, files, skills, and integrations — each gated by explicit
-owner permission. The default state is no access to any room or integration.
-
-- **Shell and files**: requires the owner to grant terminal or file-browser access in
-  the room permission settings.
-- **Skills**: Hermes loads the Matrix skill pack at startup. Skills teach it how to build
-  apps, use the design system, and navigate the project layout. See
-  [Matrix Skills](/docs/matrix-skills).
-- **Integrations**: assistant capabilities (calendar, email, summaries) require the
-  owner to approve each capability in the Integrations panel. Hermes starts with no
-  integration access.
-- **Messages**: default-deny. Each room must have read and reply access explicitly
-  granted. See [Messages](/docs/messages) for per-room controls.
-
-## Hermes versus coding agents
-
-| | Hermes | Coding agents |
-|---|---|---|
-| Always running | Yes | No — you start them per session |
-| Reachable via messaging channels | Yes | No |
-| Requires install | No | Yes (from Terminal menu) |
-| Requires its own login | No | Yes (per-agent login) |
-| Needs a model configured | Yes | The agent brings its own |
-
-Coding agents are better for long interactive development sessions where you want a
-persistent terminal context. Hermes is better for background tasks, quick questions,
-and ambient access across web, mobile, and messaging. See
-[Coding Agents](/docs/coding-agents) for how to install and launch them.
+For runtime-specific commands and provider support, see the official
+[Hermes documentation](https://hermes-agent.nousresearch.com/docs) and
+[OpenClaw documentation](https://docs.openclaw.ai/). Matrix keeps those setup actions
+visible in a terminal so you can inspect and resume them.

--- a/www/content/docs/hermes.mdx
+++ b/www/content/docs/hermes.mdx
@@ -59,7 +59,7 @@ To configure a runtime:
 <Steps>
   <Step>Open **Settings → Agent** and choose Hermes or OpenClaw under Messaging runtime.</Step>
   <Step>Select an available provider and model. Unavailable models cannot be saved.</Step>
-  <Step>Use the authentication action shown for that provider: platform access, API key, subscription login, or a supported custom base URL.</Step>
+  <Step>Use the authentication action shown for that provider: platform access, API key, subscription login, or a custom base URL when that runtime and provider support it.</Step>
   <Step>Save the selection. Matrix activates it only after a bounded health check succeeds.</Step>
 </Steps>
 

--- a/www/content/docs/index.mdx
+++ b/www/content/docs/index.mdx
@@ -59,8 +59,8 @@ Matrix OS is a real computer hosted in the cloud. It has a terminal, a file syst
   <Card title="Coding Agents" href="/docs/coding-agents">
     Install Claude, Codex, Pi, or OpenCode on your Matrix computer and run them in persistent sessions.
   </Card>
-  <Card title="Hermes" href="/docs/hermes">
-    The always-on Matrix chat agent. Runs in the background, responds across web, mobile, and messaging channels.
+  <Card title="Agent runtime" href="/docs/hermes">
+    Choose the Chat model and configure Hermes or OpenClaw for permitted messaging rooms.
   </Card>
 </Cards>
 
@@ -70,6 +70,6 @@ Matrix OS is a real computer hosted in the cloud. It has a terminal, a file syst
 
 **One computer, four surfaces.** The web shell (`app.matrix-os.com`), the `matrix` CLI, the mobile app, and the desktop app all connect to the same machine and the same sessions. No re-cloning, no re-authenticating.
 
-**AI at the kernel level.** Hermes is always on. Coding agents — Claude, Codex, Pi, OpenCode — install as tools on your Matrix computer and run in named sessions. The AI kernel has access to the shell, files, apps, and integrations with your permission.
+**AI at the kernel level.** The Chat kernel is available across web, desktop, and mobile. Hermes or OpenClaw can separately handle permitted messaging rooms. Coding agents — Claude, Codex, Pi, OpenCode — install as tools on your Matrix computer and run in named sessions. The AI kernel has access to the shell, files, apps, and integrations with your permission.
 
 **Your files are yours.** Your home directory, repos, and workspace data live on your Matrix computer. The platform handles routing, auth, and recovery.

--- a/www/content/docs/messages.mdx
+++ b/www/content/docs/messages.mdx
@@ -6,7 +6,7 @@ description: Connect Telegram and WhatsApp to Matrix OS with private, room-level
 import { Callout } from 'fumadocs-ui/components/callout';
 import { Card, Cards } from 'fumadocs-ui/components/card';
 
-Messages brings Telegram and WhatsApp into Matrix OS through a private Matrix backbone running on your Matrix computer. Conversations appear in the Messages app, and [Hermes](/docs/hermes) starts with no access to any room until you grant it.
+Messages brings Telegram and WhatsApp into Matrix OS through a private Matrix backbone running on your Matrix computer. Conversations appear in the Messages app, and the [selected messaging runtime](/docs/hermes) starts with no access to any room until you grant it.
 
 ## Supported networks
 
@@ -19,26 +19,26 @@ Text messages sync bidirectionally. Edits, deletes, reactions, receipts, typing 
 
 ## Privacy model
 
-Messages is default-deny. Connecting an account does not let Hermes read or reply to any conversation. Each room has its own access controls:
+Messages is default-deny. Connecting an account does not let the selected messaging runtime read or reply to any conversation. Each room has its own access controls:
 
-- **Read** — Hermes receives new messages in the room. If mention-only is also enabled, Hermes only receives messages that explicitly address Matrix OS.
-- **Reply** — Hermes can send a message into the room, subject to a final permission check at send time.
+- **Read** — the selected runtime receives new messages in the room. If mention-only is also enabled, it only receives messages that explicitly address Matrix OS.
+- **Reply** — the selected runtime can send a message into the room, subject to a final permission check at send time.
 - **Automation** — automation rules can run for this room. Without this flag, matching rules are skipped even if read is enabled.
 
 Revoking any permission cancels queued work and prevents new delivery. Draft replies still waiting for approval remain visible in Messages until you approve or cancel them.
 
-## Hermes and Messages
+## Agent runtimes and Messages
 
-Hermes can do several things with messages from permitted rooms:
+The selected messaging runtime can do several things with messages from permitted rooms:
 
 - Summarize or classify incoming messages (read permission)
 - Generate draft replies (read + reply permission)
 - Run automation rules that create tasks or draft replies (automation permission)
 
-See [Hermes](/docs/hermes) for model setup and how Hermes is enabled.
+See [Agent runtime](/docs/hermes) for provider, model, authentication, and runtime selection.
 
-<Callout type="warn" title="Hermes needs a model configured">
-  Hermes uses its configured model to generate summaries, drafts, and automation responses. Until you pick a model and add its provider credential, Hermes cannot act on any room — even if room-level permissions are enabled. See [Hermes](/docs/hermes) for setup.
+<Callout type="warn" title="The selected runtime needs a model configured">
+  The Messaging runtime uses its configured model to generate summaries, drafts, and automation responses. Until you select a model and complete its provider authentication, it cannot act on any room — even if room-level permissions are enabled. See [Agent runtime](/docs/hermes) for setup.
 </Callout>
 
 ## Automations

--- a/www/content/docs/onboarding-launch-readiness.mdx
+++ b/www/content/docs/onboarding-launch-readiness.mdx
@@ -7,9 +7,9 @@ Matrix launch onboarding is designed to get a founder or developer to a useful w
 
 The first-run flow teaches what Matrix can do, asks which goal matters first, and then guides the user through only the setup needed for that goal. Coding users are guided through GitHub, project selection, Symphony, terminal context, and optional Claude or Codex. Assistant users are guided through approved calendar, email, and integration capabilities.
 
-Hermes remains the Matrix system agent in every setup state. Claude and Codex can add specialized capabilities, but they do not replace Hermes for Matrix-owned app-building, assistant, integration, and operating workflows.
+The Chat kernel remains available in every setup state. Optional coding agents and Messaging runtimes add specialized capabilities without replacing the kernel or reprovisioning the workspace.
 
-Launch readiness also includes an admin/control surface for models, agents, integrations, settings, automations, activity, and remediation. The surface uses operational patterns inspired by Finna Cloud while keeping the Matrix visual system from the website redesign.
+Launch readiness also includes an admin/control surface for models, agents, integrations, settings, automations, activity, and remediation. The surface follows the Matrix visual system and keeps operational state easy to scan.
 
 ## What The User Gets
 
@@ -17,13 +17,14 @@ Matrix onboarding is goal-based. A user can start by coding, building apps, usin
 
 For coding, Matrix can guide the user through GitHub connection, project selection, task source selection, Symphony coding runs, terminal context, and handoff summaries. For assistant work, Matrix can guide calendar, email, messaging, and work-update capabilities through explicit approval. For company-brain work, Matrix can capture and reuse product decisions, customer notes, project records, and support context with source display.
 
-Hermes is always available as the Matrix system agent. Users can bring Claude or Codex later, but those credentials upgrade capability rather than replacing Hermes or reprovisioning the workspace.
+The Chat kernel remains the Matrix system agent. Users can bring Claude or Codex later and choose Hermes or OpenClaw for permitted messaging, but those choices do not replace Chat or reprovision the workspace.
 
 ## Admin And Control Surface
 
 The Matrix admin/control surface gives users and operators one place to inspect:
 
-- model and provider status for Hermes, Claude, Codex, and future providers
+- Chat model, effort, provider, and authentication status
+- Messaging runtime install, health, provider, model, and authentication status
 - integration capability approvals and revoked/missing states
 - setup wizard recovery after reload or interruption
 - settings save/reload state
@@ -40,7 +41,7 @@ Operators use the launch readiness report before enabling paid access:
 GET /api/operator/launch-readiness
 ```
 
-The report must remain blocked unless every release-critical gate passes. It covers beta release promotion, fresh workspace rehearsal, existing workspace rehearsal, shell routing, onboarding education, visual QA, approved integrations, Hermes continuity, agent execution, coding handoff, company brain, support/growth drafts, admin/control surface, and entitlement behavior.
+The report must remain blocked unless every release-critical gate passes. It covers beta release promotion, fresh workspace rehearsal, existing workspace rehearsal, shell routing, onboarding education, visual QA, approved integrations, Chat continuity, agent execution, coding handoff, company brain, support/growth drafts, admin/control surface, and entitlement behavior.
 
 Payment enforcement is now backed by Clerk Billing for the early adopter launch plan. The shell requires an active `early_adopter` subscription before mounting the Matrix desktop, and the settings surface exposes Clerk's billing table so users can start or manage access.
 


### PR DESCRIPTION
## Summary

- replace the ambiguous public Hermes guide with an Agent runtime guide that separates the Claude Agent SDK V1 Chat kernel from optional Hermes/OpenClaw messaging runtimes
- document Chat model/effort selection and platform-provided, BYOK, subscription-login, and custom-endpoint authentication paths without exposing secrets
- document health-gated runtime switching, provider/model scope, default-deny room permissions, and fail-closed recovery
- align overview, glossary, Messages, desktop, coding-agent, and launch-readiness language with the unified contract
- align the published 75-second transition, 70-second host-control, and 10-second
  readiness budgets with the implemented bounded lifecycle

## TDD and validation

- The new public-docs contract suite was observed red against the previous conflated Hermes copy before the documentation was updated.
- Focused docs suites: 5/5 passed across 3 files.
- `pnpm --filter www build`: passed on the exact content, including TypeScript and 184 generated pages; one pre-existing Edge-runtime observability warning remains non-blocking.
- Exact final CI run [29331839337](https://github.com/HamedMP/matrix-os/actions/runs/29331839337) passed.
- Exact changed-surface matrix: 334/334 passed across 27 files. The all-repository run exercised 8,500 passing tests with 20 skipped; one unrelated platform test timed out after 43 minutes of runner saturation, then its complete 39-test file passed in isolation.
- Exact validated head: `66402f30bd50a0600c6ceeaf4fb388252407df0e`.

## Stack

- #984 — gateway lifecycle and settings composition
- #985 — web shell Agent settings
- #987 — desktop Agent settings
- this PR — public Agent runtime documentation

## Invariants

- **Source of truth:** The gateway-owned additive agent settings contract and owner-local runtime state remain authoritative. Public docs describe the normalized product contract and do not introduce configuration or runtime state.
- **Lock/transaction scope:** Documentation performs no writes at runtime and adds no locks, queues, transactions, or competing config writers.
- **Acceptable orphan states:** A missing or unhealthy optional runtime remains visible as unavailable; Chat and the last healthy Messaging runtime remain unchanged. The docs make no promise of implicit installation, migration, or unauthenticated fallback.
- **Auth source of truth:** Gateway and runtime-owned authentication flows remain authoritative. Docs state that shells receive coarse status only and never persist or receive provider secrets.
- **Deferred scope:** Runtime-aware Matrix work-claim pause/drain remains tracked in #986 because the spec 077 production claimant does not exist yet. Native mobile adoption remains compatibility-only in this mission; live preview evidence lands after the exact stack bundle is deployed.
- Matrix OS Chat remains the Claude Agent SDK V1 kernel. `hermes | openclaw` selects only the optional Messaging runtime.
- Per-room read, reply, and automation permissions remain default-deny and independent of runtime selection or authentication.
- This PR has 150 additions and 101 deletions across 12 files, below the 3,000-addition/50-file limits, and will not merge below an exact-head Greptile 5/5 review.

## Rollout

- no merge or promotion requested
- preview workflow [29331824070](https://github.com/HamedMP/matrix-os/actions/runs/29331824070) built and registered immutable release `v2026.07.14-pr988-66402f3` (`787b7bbf620ae77decf73fbf71ad2d44472cbd90e9779a8fd6458de4d694ae6a`) without channel promotion
- platform deploy reported `triggered:1, failed:0` for `pr-919`; `/vps/releases` then proved reachable 200 on exact SHA `66402f30bd50a0600c6ceeaf4fb388252407df0e`, and system info reported `claude-opus-4-6`
- live checks passed for additive v2 settings plus legacy kernel fields, nullable effort clearing, unavailable OpenClaw fail-closed behavior, stored conversation retrieval, terminal session create/forced cleanup, and valid/invalid per-message model boundaries
