### PR TITLE
feat(gateway): canonical session sizing with hard/soft client classes

### DIFF
--- a/packages/gateway/src/server.ts
+++ b/packages/gateway/src/server.ts
@@ -368,6 +368,11 @@ export async function createGateway(config: GatewayConfig) {
     registry: zellijShellRegistry,
     adapter: zellijAdapter,
     scrollbackStore: shellScrollbackStore,
+    persistCanonicalSize: (name, size) => {
+      void zellijShellRegistry.updateCanonicalSize(name, size).catch((err: unknown) => {
+        console.warn("[shell] canonical size persist failed:", err instanceof Error ? err.message : String(err));
+      });
+    },
   });
   const shellSessionReaper = createShellSessionReaper({ registry: zellijShellRegistry });
   shellSessionReaper.start();
@@ -2167,11 +2172,29 @@ export async function createGateway(config: GatewayConfig) {
     upgradeWebSocket(() => forwardTunnelHub.createHandler()),
   );
 
+  const parseTerminalSizingParams = (
+    query: (name: string) => string | undefined,
+  ): { clientClass?: "hard" | "soft"; declaredSize?: { cols: number; rows: number } } => {
+    const clientParam = query("client");
+    const clientClass = clientParam === "hard" || clientParam === "soft" ? clientParam : undefined;
+    const colsParam = query("cols");
+    const rowsParam = query("rows");
+    const cols = colsParam && /^\d{1,3}$/.test(colsParam) ? Number(colsParam) : null;
+    const rows = rowsParam && /^\d{1,3}$/.test(rowsParam) ? Number(rowsParam) : null;
+    const declaredSize =
+      cols && rows && cols >= 1 && cols <= 500 && rows >= 1 && rows <= 200
+        ? { cols, rows }
+        : undefined;
+    return { clientClass, declaredSize };
+  };
+
+
   app.get(
     "/ws/terminal/session",
     upgradeWebSocket((c) => {
       const namedSession = c.req.query("session");
       const fromSeqParam = c.req.query("fromSeq");
+      const sizingParams = parseTerminalSizingParams((name) => c.req.query(name));
       let namedHandle: { onMessage(raw: string): void; onClose(): void } | null = null;
       let namedSocketClosed = false;
       const pendingInput = createPendingTerminalInputQueue();
@@ -2195,6 +2218,8 @@ export async function createGateway(config: GatewayConfig) {
             ws,
             session: namedSession,
             fromSeq,
+            clientClass: sizingParams.clientClass,
+            declaredSize: sizingParams.declaredSize,
           }).then((session) => {
             if (namedSocketClosed) {
               session.onClose();
@@ -2366,6 +2391,7 @@ export async function createGateway(config: GatewayConfig) {
       const cwdParam = c.req.query("cwd");
       const namedSession = c.req.query("session");
       const fromSeqParam = c.req.query("fromSeq");
+      const sizingParams = parseTerminalSizingParams((name) => c.req.query(name));
       let handle: SessionHandle | null = null;
       let namedHandle: { onMessage(raw: string): void; onClose(): void } | null = null;
       let namedSocketClosed = false;
@@ -2418,6 +2444,8 @@ export async function createGateway(config: GatewayConfig) {
               ws,
               session: namedSession,
               fromSeq,
+              clientClass: sizingParams.clientClass,
+              declaredSize: sizingParams.declaredSize,
             }).then((session) => {
               if (namedSocketClosed) {
                 session.onClose();

--- a/packages/gateway/src/shell/registry.ts
+++ b/packages/gateway/src/shell/registry.ts
@@ -43,6 +43,11 @@ const ShellSessionSchema = z.object({
   // "session" for sessions created after reaper support shipped; absent for
   // pre-upgrade sessions, which are exempt from TTL reaping (spec 107 FR-018).
   kind: z.string().optional(),
+  // Canonical terminal size negotiated across hard clients (spec 107 FR-006).
+  canonicalSize: z.object({
+    cols: z.number().int().min(1).max(500),
+    rows: z.number().int().min(1).max(200),
+  }).optional(),
   visualStatus: ShellVisualStatusSchema.optional(),
   visualStatusUpdatedAt: z.string().optional(),
 });
@@ -358,6 +363,20 @@ export class ShellRegistry {
       }
 
       return this.decorateSession(next, file);
+    });
+  }
+
+  async updateCanonicalSize(name: string, size: { cols: number; rows: number }): Promise<void> {
+    return this.withMutationLock(async () => {
+      const safeName = validateSessionName(name);
+      const file = await this.read();
+      const targetName = this.resolveSessionName(file, safeName);
+      const session = file.sessions[targetName];
+      if (!session) {
+        return;
+      }
+      file.sessions[targetName] = { ...session, canonicalSize: size, updatedAt: new Date().toISOString() };
+      await this.write(file);
     });
   }
 

--- a/packages/gateway/src/shell/sizing.ts
+++ b/packages/gateway/src/shell/sizing.ts
@@ -77,14 +77,20 @@ export function createSessionSizing(options: SessionSizingOptions) {
   }
 
   function scheduleApply(): void {
+    // Always cancel first: a timer armed while classified clients existed
+    // must not fire after the last one detached and persist a stale fallback.
+    if (timer) {
+      clearTimeout(timer);
+      timer = null;
+    }
     if (disposed || classifiedCount() === 0) {
       return;
     }
-    if (timer) {
-      clearTimeout(timer);
-    }
     timer = setTimeout(() => {
       timer = null;
+      if (disposed || classifiedCount() === 0) {
+        return;
+      }
       const next = computeCanonical();
       if (applied && applied.cols === next.cols && applied.rows === next.rows) {
         return;

--- a/packages/gateway/src/shell/sizing.ts
+++ b/packages/gateway/src/shell/sizing.ts
@@ -1,0 +1,148 @@
+export type ShellClientClass = "hard" | "soft" | "legacy";
+
+export interface TerminalSize {
+  cols: number;
+  rows: number;
+}
+
+export interface SessionSizingOptions {
+  /** Last persisted canonical size, if any. */
+  initialSize?: TerminalSize | null;
+  /** Fallback when nothing is persisted and no hard client is attached. */
+  defaultSize?: TerminalSize;
+  debounceMs?: number;
+  /** Apply the canonical size to every attached pty. */
+  onApply: (size: TerminalSize) => void;
+  /** Persist the canonical size (registry). */
+  persist?: (size: TerminalSize) => void;
+}
+
+const MIN_COLS = 1;
+const MAX_COLS = 500;
+const MIN_ROWS = 1;
+const MAX_ROWS = 200;
+
+export function clampTerminalSize(size: TerminalSize): TerminalSize {
+  return {
+    cols: Math.min(MAX_COLS, Math.max(MIN_COLS, Math.floor(size.cols) || MIN_COLS)),
+    rows: Math.min(MAX_ROWS, Math.max(MIN_ROWS, Math.floor(size.rows) || MIN_ROWS)),
+  };
+}
+
+/**
+ * Canonical session size arbiter (spec 107 FR-006..009).
+ *
+ * Hard clients (CLI/TTY — cannot scale their render) negotiate the canonical
+ * size as the component-wise minimum of their declared sizes. Soft clients
+ * (web, native mobile — render the canonical grid scaled) never influence it.
+ * Legacy clients (no class declared) keep today's resize-follow behavior, but
+ * only while zero classified clients are attached, so an un-upgraded client
+ * can never shrink a session an upgraded client is using.
+ */
+export function createSessionSizing(options: SessionSizingOptions) {
+  const debounceMs = options.debounceMs ?? 500;
+  const defaultSize = clampTerminalSize(options.defaultSize ?? { cols: 200, rows: 50 });
+  let persistedSize: TerminalSize | null = options.initialSize ? clampTerminalSize(options.initialSize) : null;
+  const clients = new Map<string, { klass: ShellClientClass; declared: TerminalSize | null }>();
+  let applied: TerminalSize | null = null;
+  let timer: NodeJS.Timeout | null = null;
+  let disposed = false;
+
+  function classifiedCount(): number {
+    let count = 0;
+    for (const client of clients.values()) {
+      if (client.klass !== "legacy") {
+        count += 1;
+      }
+    }
+    return count;
+  }
+
+  function computeCanonical(): TerminalSize {
+    let cols = Number.POSITIVE_INFINITY;
+    let rows = Number.POSITIVE_INFINITY;
+    let hardSeen = false;
+    for (const client of clients.values()) {
+      if (client.klass !== "hard" || !client.declared) {
+        continue;
+      }
+      hardSeen = true;
+      cols = Math.min(cols, client.declared.cols);
+      rows = Math.min(rows, client.declared.rows);
+    }
+    if (!hardSeen) {
+      return persistedSize ?? defaultSize;
+    }
+    return clampTerminalSize({ cols, rows });
+  }
+
+  function scheduleApply(): void {
+    if (disposed || classifiedCount() === 0) {
+      return;
+    }
+    if (timer) {
+      clearTimeout(timer);
+    }
+    timer = setTimeout(() => {
+      timer = null;
+      const next = computeCanonical();
+      if (applied && applied.cols === next.cols && applied.rows === next.rows) {
+        return;
+      }
+      applied = next;
+      persistedSize = next;
+      options.onApply(next);
+      options.persist?.(next);
+    }, debounceMs);
+    timer.unref?.();
+  }
+
+  return {
+    attach(id: string, klass: ShellClientClass, declared: TerminalSize | null): void {
+      clients.set(id, { klass, declared: declared ? clampTerminalSize(declared) : null });
+      scheduleApply();
+    },
+    detach(id: string): void {
+      if (clients.delete(id)) {
+        scheduleApply();
+      }
+    },
+    /** A hard client's declared size changed (its terminal was resized). */
+    declared(id: string, size: TerminalSize): void {
+      const client = clients.get(id);
+      if (!client) {
+        return;
+      }
+      client.declared = clampTerminalSize(size);
+      if (client.klass === "hard") {
+        scheduleApply();
+      }
+    },
+    /** True while legacy resize frames may drive the pty (no classified clients). */
+    legacyResizeAllowed(): boolean {
+      return classifiedCount() === 0;
+    },
+    current(): TerminalSize | null {
+      if (classifiedCount() === 0) {
+        return persistedSize ?? null;
+      }
+      return computeCanonical();
+    },
+    /** Size to spawn a new attach pty at. */
+    spawnSize(): TerminalSize {
+      if (classifiedCount() === 0) {
+        return persistedSize ?? defaultSize;
+      }
+      return computeCanonical();
+    },
+    dispose(): void {
+      disposed = true;
+      if (timer) {
+        clearTimeout(timer);
+        timer = null;
+      }
+    },
+  };
+}
+
+export type SessionSizing = ReturnType<typeof createSessionSizing>;

--- a/packages/gateway/src/shell/ws.ts
+++ b/packages/gateway/src/shell/ws.ts
@@ -4,6 +4,7 @@ import { ShellReplayBuffer } from "./replay-buffer.js";
 import { PendingPersistQueue } from "./output-pipeline.js";
 import type { ScrollbackStore } from "./scrollback-store.js";
 import { validateSessionName } from "./names.js";
+import { createSessionSizing, type SessionSizing, type ShellClientClass, type TerminalSize } from "./sizing.js";
 import type { ShellAttachProcess } from "./zellij.js";
 import {
   createTerminalOutputCompatStream,
@@ -53,11 +54,11 @@ export interface ShellWsSocket {
 }
 
 interface ShellWsRegistry {
-  list(): Promise<Array<{ name: string; status?: "active" | "exited" }>>;
+  list(): Promise<Array<{ name: string; status?: "active" | "exited"; canonicalSize?: TerminalSize | null }>>;
 }
 
 interface ShellWsAdapter {
-  attachSession(name: string, options?: { signal?: AbortSignal }): ShellAttachProcess;
+  attachSession(name: string, options?: { signal?: AbortSignal; size?: TerminalSize }): ShellAttachProcess;
 }
 
 export interface ShellWsFlowControlOptions {
@@ -80,12 +81,18 @@ export interface ShellWsHandlerOptions {
   staleAttachTtlMs?: number;
   idleAttachGraceMs?: number;
   flowControl?: ShellWsFlowControlOptions;
+  sizingDebounceMs?: number;
+  defaultCanonicalSize?: TerminalSize;
+  persistCanonicalSize?: (name: string, size: TerminalSize) => void;
 }
 
 export interface ShellWsOpenOptions {
   ws: ShellWsSocket;
   session: string;
   fromSeq?: number;
+  /** Sizing class (spec 107 FR-007): absent = legacy (pre-upgrade client). */
+  clientClass?: Exclude<ShellClientClass, "legacy">;
+  declaredSize?: TerminalSize;
 }
 
 export interface ShellWsSession {
@@ -141,6 +148,7 @@ interface SessionRuntime {
   attachPromise: Promise<boolean> | null;
   idleCloseTimer: NodeJS.Timeout | null;
   disposed: boolean;
+  sizing: SessionSizing | null;
 }
 
 export function createShellWsHandler(options: ShellWsHandlerOptions) {
@@ -151,6 +159,7 @@ export function createShellWsHandler(options: ShellWsHandlerOptions) {
   const highWaterMark = options.flowControl?.highWaterMark ?? 1024 * 1024;
 
   const runtimes = new Map<string, SessionRuntime>();
+  let connCounter = 0;
 
   function createQueue(name: string): PendingPersistQueue | null {
     return options.scrollbackStore
@@ -204,6 +213,7 @@ export function createShellWsHandler(options: ShellWsHandlerOptions) {
       attachPromise: null,
       idleCloseTimer: null,
       disposed: false,
+      sizing: null,
     };
     runtimes.set(name, runtime);
     return runtime;
@@ -369,6 +379,7 @@ export function createShellWsHandler(options: ShellWsHandlerOptions) {
       try {
         child = options.adapter.attachSession(safeName, {
           signal: abortController.signal,
+          size: runtime.sizing?.spawnSize(),
         });
       } catch (err: unknown) {
         if (canUseAttachPromise(runtime, attachPromise)) {
@@ -408,6 +419,8 @@ export function createShellWsHandler(options: ShellWsHandlerOptions) {
   async function disposeRuntime(runtime: SessionRuntime, warnContext: string): Promise<void> {
     runtime.disposed = true;
     cancelIdleClose(runtime);
+    runtime.sizing?.dispose();
+    runtime.sizing = null;
     for (const conn of runtime.conns) {
       conn.closed = true;
       conn.ws.close?.();
@@ -445,7 +458,7 @@ export function createShellWsHandler(options: ShellWsHandlerOptions) {
     return false;
   }
 
-  async function open({ ws, session, fromSeq = 0 }: ShellWsOpenOptions): Promise<ShellWsSession> {
+  async function open({ ws, session, fromSeq = 0, clientClass: openOptionsClass, declaredSize }: ShellWsOpenOptions): Promise<ShellWsSession> {
     const safeName = validateSessionName(session);
     const sessions = await options.registry.list();
     const info = sessions.find((candidate) => candidate.name === safeName);
@@ -470,6 +483,20 @@ export function createShellWsHandler(options: ShellWsHandlerOptions) {
     }
 
     const replayBuffer = runtime.buffer;
+    if (!runtime.sizing) {
+      runtime.sizing = createSessionSizing({
+        initialSize: info.canonicalSize ?? null,
+        defaultSize: options.defaultCanonicalSize,
+        debounceMs: options.sizingDebounceMs,
+        onApply: (size) => {
+          runtime.child?.resize(size.cols, size.rows);
+        },
+        persist: (size) => {
+          options.persistCanonicalSize?.(safeName, size);
+        },
+      });
+    }
+    const sizing = runtime.sizing;
     await replayBuffer.ensureSeeded();
 
     // Re-check capacity: awaits since the first check (seeding, registry
@@ -478,7 +505,19 @@ export function createShellWsHandler(options: ShellWsHandlerOptions) {
       return { onMessage: () => undefined, onClose: () => undefined };
     }
 
+    // A hard declaration without a size cannot participate in negotiation;
+    // treat it as legacy so it does not disable legacy resize-follow while
+    // contributing nothing (review finding on spec 107 FR-007).
+    const clientClass: ShellClientClass =
+      openOptionsClass === "hard" && !declaredSize ? "legacy" : (openOptionsClass ?? "legacy");
+    const connId = `conn-${++connCounter}`;
+    // Register before the shared attach so the first client's pty spawns at
+    // its own declared size instead of the fallback corrected after the
+    // debounce.
+    sizing.attach(connId, clientClass, declaredSize ?? null);
+
     if (!(await ensureSharedAttach(runtime, safeName, replayBuffer))) {
+      sizing.detach(connId);
       sendJson(ws, {
         type: "error",
         code: "attach_failed",
@@ -491,6 +530,7 @@ export function createShellWsHandler(options: ShellWsHandlerOptions) {
     // One or more concurrent opens may have filled the final client slot while
     // this call awaited the shared attach startup.
     if (runtime.conns.size >= maxAttachedClients && !evictStaleOrReject(runtime, ws)) {
+      sizing.detach(connId);
       return { onMessage: () => undefined, onClose: () => undefined };
     }
 
@@ -539,6 +579,7 @@ export function createShellWsHandler(options: ShellWsHandlerOptions) {
 
     const detachConn = () => {
       runtime.conns.delete(conn);
+      sizing.detach(connId);
       if (runtime.conns.size === 0) {
         scheduleIdleClose(runtime);
       }
@@ -558,6 +599,7 @@ export function createShellWsHandler(options: ShellWsHandlerOptions) {
           }
         }
         runtime.conns.delete(conn);
+        sizing.detach(connId);
         await closeSharedAttach(runtime);
         return;
       }
@@ -601,7 +643,24 @@ export function createShellWsHandler(options: ShellWsHandlerOptions) {
           return;
         }
         if (msg.type === "resize") {
-          runtime.child?.resize(msg.cols, msg.rows);
+          const requested = { cols: msg.cols, rows: msg.rows };
+          if (clientClass === "hard") {
+            // A hard client's terminal changed size: update its declaration
+            // and let the arbiter re-pin the shared attach pty (spec 107
+            // FR-008/9).
+            sizing.declared(connId, requested);
+            return;
+          }
+          if (clientClass === "soft") {
+            // Soft viewports render the canonical grid scaled; their resize
+            // frames are hints only and never touch the pty.
+            return;
+          }
+          // Legacy clients keep resize-follow behavior only while no
+          // classified client is attached (spec 107 FR-007).
+          if (sizing.legacyResizeAllowed()) {
+            runtime.child?.resize(msg.cols, msg.rows);
+          }
         }
       },
       onClose() {

--- a/packages/gateway/src/shell/ws.ts
+++ b/packages/gateway/src/shell/ws.ts
@@ -331,6 +331,12 @@ export function createShellWsHandler(options: ShellWsHandlerOptions) {
       sendJson(conn.ws, { type: "exit", code: event.exitCode });
     }
     runtime.conns.clear();
+    // Every connection was just cleared without running its detach path, so
+    // their sizing registrations would linger. Drop the arbiter so a later
+    // reconnect negotiates from fresh declarations instead of stale ones;
+    // the persisted canonical size reloads from the registry on next open.
+    runtime.sizing?.dispose();
+    runtime.sizing = null;
     void flushAndRotateQueue(runtime, "final scrollback flush failed", true);
   }
 

--- a/packages/gateway/src/shell/zellij.ts
+++ b/packages/gateway/src/shell/zellij.ts
@@ -82,6 +82,7 @@ export interface CreateSessionOptions {
 
 export interface AttachOptions {
   signal?: AbortSignal;
+  size?: { cols: number; rows: number };
 }
 
 export interface ZellijAdapter {
@@ -354,8 +355,8 @@ export function createZellijAdapter(deps: ZellijAdapterDeps = {}): ZellijAdapter
   function attachProcess(name: string, options: AttachOptions = {}): ShellAttachProcess {
     const pty = spawnPty("zellij", ["attach", name], {
       name: "xterm-256color",
-      cols: 120,
-      rows: 40,
+      cols: options.size?.cols ?? 120,
+      rows: options.size?.rows ?? 40,
       cwd,
       env: attachEnv(deps.env, zellijConfigPaths),
     });

--- a/packages/sync-client/src/cli/shell-client.ts
+++ b/packages/sync-client/src/cli/shell-client.ts
@@ -45,7 +45,7 @@ export interface ShellClient {
   deleteLayout(name: string): Promise<Record<string, unknown>>;
   applyLayout(session: string, layout: string): Promise<Record<string, unknown>>;
   dumpLayout(session: string): Promise<Record<string, unknown>>;
-  createAttachUrl(name: string, options?: { fromSeq?: number; token?: string }): string;
+  createAttachUrl(name: string, options?: { fromSeq?: number; token?: string; size?: { cols: number; rows: number } | null }): string;
   sendInput(name: string, data: string): Promise<void>;
   attachSession(name: string, options?: ShellAttachOptions): Promise<{ detached: boolean }>;
 }
@@ -483,10 +483,17 @@ export function createShellClient(options: ShellClientOptions): ShellClient {
   const terminalSessionsPath = "/api/terminal/sessions";
   const terminalLayoutsPath = "/api/terminal/layouts";
 
-  function createAttachUrl(name: string, attachOptions: { fromSeq?: number; token?: string } = {}): string {
+  function createAttachUrl(name: string, attachOptions: { fromSeq?: number; token?: string; size?: { cols: number; rows: number } | null } = {}): string {
     const url = new URL(`${base}/ws/terminal/session`);
     url.protocol = url.protocol === "https:" ? "wss:" : "ws:";
     url.searchParams.set("session", name);
+    // Declare as a hard sizing client (spec 107 FR-007): a TTY cannot scale
+    // its render, so its size participates in canonical-size negotiation.
+    url.searchParams.set("client", "hard");
+    if (attachOptions.size) {
+      url.searchParams.set("cols", String(attachOptions.size.cols));
+      url.searchParams.set("rows", String(attachOptions.size.rows));
+    }
     if (typeof attachOptions.fromSeq === "number") {
       url.searchParams.set("fromSeq", String(attachOptions.fromSeq));
     }
@@ -964,6 +971,7 @@ export function createShellClient(options: ShellClientOptions): ShellClient {
           const ws = new WebSocketImpl(createAttachUrl(name, {
             ...attachOptions,
             fromSeq: currentFromSeq(),
+            size: terminalSize(input, output),
           }), { headers });
           currentWs = ws;
           const isCurrentSocket = () => currentWs === ws && socketGeneration === generation && !settled;

--- a/packages/sync-client/src/cli/shell-client.ts
+++ b/packages/sync-client/src/cli/shell-client.ts
@@ -487,10 +487,12 @@ export function createShellClient(options: ShellClientOptions): ShellClient {
     const url = new URL(`${base}/ws/terminal/session`);
     url.protocol = url.protocol === "https:" ? "wss:" : "ws:";
     url.searchParams.set("session", name);
-    // Declare as a hard sizing client (spec 107 FR-007): a TTY cannot scale
-    // its render, so its size participates in canonical-size negotiation.
-    url.searchParams.set("client", "hard");
     if (attachOptions.size) {
+      // Declare as a hard sizing client (spec 107 FR-007): a TTY cannot scale
+      // its render, so its size participates in canonical-size negotiation.
+      // Without a known size the declaration is omitted (legacy behavior) so
+      // an undeclared hard client can never pin the session to a fallback.
+      url.searchParams.set("client", "hard");
       url.searchParams.set("cols", String(attachOptions.size.cols));
       url.searchParams.set("rows", String(attachOptions.size.rows));
     }

--- a/tests/gateway/shell-sizing.test.ts
+++ b/tests/gateway/shell-sizing.test.ts
@@ -106,6 +106,16 @@ describe("shell session sizing arbiter", () => {
     expect(size!.rows).toBeGreaterThanOrEqual(1);
   });
 
+  it("cancels a pending apply when the last classified client detaches", async () => {
+    const { sizing, applied, persisted } = harness();
+    sizing.attach("cli", "hard", { cols: 120, rows: 40 });
+    sizing.detach("cli"); // detach before the debounce fires
+    await vi.advanceTimersByTimeAsync(50);
+
+    expect(applied).toEqual([]);
+    expect(persisted).toEqual([]);
+  });
+
   it("dispose cancels pending applications", async () => {
     const { sizing, applied } = harness();
     sizing.attach("a", "hard", { cols: 200, rows: 50 });

--- a/tests/gateway/shell-sizing.test.ts
+++ b/tests/gateway/shell-sizing.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { createSessionSizing } from "../../packages/gateway/src/shell/sizing.js";
+
+describe("shell session sizing arbiter", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  function harness(options: { initial?: { cols: number; rows: number } | null } = {}) {
+    const applied: Array<{ cols: number; rows: number }> = [];
+    const persisted: Array<{ cols: number; rows: number }> = [];
+    const sizing = createSessionSizing({
+      initialSize: options.initial ?? null,
+      debounceMs: 10,
+      onApply: (size) => {
+        applied.push(size);
+      },
+      persist: (size) => {
+        persisted.push(size);
+      },
+    });
+    return { sizing, applied, persisted };
+  }
+
+  it("uses the component-wise minimum across hard clients", async () => {
+    const { sizing, applied } = harness();
+    sizing.attach("a", "hard", { cols: 200, rows: 50 });
+    sizing.attach("b", "hard", { cols: 190, rows: 60 });
+    await vi.advanceTimersByTimeAsync(20);
+
+    expect(sizing.current()).toEqual({ cols: 190, rows: 50 });
+    expect(applied.at(-1)).toEqual({ cols: 190, rows: 50 });
+  });
+
+  it("soft clients never influence the canonical size", async () => {
+    const { sizing, applied } = harness();
+    sizing.attach("desktop", "hard", { cols: 200, rows: 50 });
+    await vi.advanceTimersByTimeAsync(20);
+    const before = sizing.current();
+
+    sizing.attach("phone", "soft", { cols: 60, rows: 30 });
+    sizing.declared("phone", { cols: 40, rows: 20 });
+    await vi.advanceTimersByTimeAsync(20);
+
+    expect(sizing.current()).toEqual(before);
+    expect(applied.at(-1)).toEqual(before);
+  });
+
+  it("legacy resizes pass through only while no classified client is attached", async () => {
+    const { sizing } = harness();
+    sizing.attach("old-web", "legacy", { cols: 100, rows: 30 });
+    expect(sizing.legacyResizeAllowed()).toBe(true);
+
+    sizing.attach("new-cli", "hard", { cols: 200, rows: 50 });
+    expect(sizing.legacyResizeAllowed()).toBe(false);
+
+    sizing.detach("new-cli");
+    expect(sizing.legacyResizeAllowed()).toBe(true);
+  });
+
+  it("recomputes when a hard client detaches and persists the result", async () => {
+    const { sizing, persisted } = harness();
+    sizing.attach("small", "hard", { cols: 100, rows: 30 });
+    sizing.attach("big", "hard", { cols: 200, rows: 50 });
+    await vi.advanceTimersByTimeAsync(20);
+    expect(sizing.current()).toEqual({ cols: 100, rows: 30 });
+
+    sizing.detach("small");
+    await vi.advanceTimersByTimeAsync(20);
+    expect(sizing.current()).toEqual({ cols: 200, rows: 50 });
+    expect(persisted.at(-1)).toEqual({ cols: 200, rows: 50 });
+  });
+
+  it("pins soft-only sessions to the persisted size, never the soft viewport", async () => {
+    const { sizing, applied } = harness({ initial: { cols: 150, rows: 40 } });
+    sizing.attach("phone", "soft", { cols: 60, rows: 30 });
+    await vi.advanceTimersByTimeAsync(20);
+
+    expect(sizing.current()).toEqual({ cols: 150, rows: 40 });
+    // the soft client's pty is pinned to canonical (FR-009), not its viewport
+    expect(applied).toEqual([{ cols: 150, rows: 40 }]);
+  });
+
+  it("debounces rapid attach/detach churn into one application", async () => {
+    const { sizing, applied } = harness();
+    sizing.attach("a", "hard", { cols: 200, rows: 50 });
+    sizing.attach("b", "hard", { cols: 190, rows: 48 });
+    sizing.detach("b");
+    sizing.attach("c", "hard", { cols: 180, rows: 45 });
+    await vi.advanceTimersByTimeAsync(20);
+
+    expect(applied).toHaveLength(1);
+    expect(applied[0]).toEqual({ cols: 180, rows: 45 });
+  });
+
+  it("clamps declared sizes to protocol bounds", async () => {
+    const { sizing } = harness();
+    sizing.attach("weird", "hard", { cols: 9_999, rows: 0 });
+    await vi.advanceTimersByTimeAsync(20);
+    const size = sizing.current();
+    expect(size!.cols).toBeLessThanOrEqual(500);
+    expect(size!.rows).toBeGreaterThanOrEqual(1);
+  });
+
+  it("dispose cancels pending applications", async () => {
+    const { sizing, applied } = harness();
+    sizing.attach("a", "hard", { cols: 200, rows: 50 });
+    sizing.dispose();
+    await vi.advanceTimersByTimeAsync(50);
+    expect(applied).toEqual([]);
+  });
+});

--- a/tests/gateway/terminal-zellij-ws.test.ts
+++ b/tests/gateway/terminal-zellij-ws.test.ts
@@ -1077,6 +1077,40 @@ describe("zellij terminal WebSocket", () => {
     handler.dispose();
   });
 
+  it("drops stale sizing registrations when the shared attach exits so reconnects negotiate fresh", async () => {
+    const ptyA = new FakePty();
+    const ptyB = new FakePty();
+    const sizes: Array<{ cols: number; rows: number } | undefined> = [];
+    const handler = createShellWsHandler({
+      registry: { list: vi.fn(async () => [{ name: "main", status: "active" }]) },
+      adapter: {
+        attachSession: vi.fn((_name: string, opts?: { size?: { cols: number; rows: number } }) => {
+          sizes.push(opts?.size);
+          return sizes.length === 1 ? ptyA : ptyB;
+        }),
+      },
+      maxReplayBytes: 4096,
+      sizingDebounceMs: 5,
+    });
+
+    await handler.open({ ws: socket(), session: "main", fromSeq: 0, clientClass: "hard", declaredSize: { cols: 80, rows: 20 } });
+    await new Promise((resolve) => setTimeout(resolve, 15));
+    expect(sizes[0]).toEqual({ cols: 80, rows: 20 });
+
+    // The zellij attach process dies unexpectedly, clearing every connection.
+    ptyA.emitExit({ exitCode: 1 });
+
+    const reconnected = await handler.open({ ws: socket(), session: "main", fromSeq: 0, clientClass: "hard", declaredSize: { cols: 200, rows: 50 } });
+    await new Promise((resolve) => setTimeout(resolve, 15));
+
+    // The reconnect spawns and pins at its own declaration; the dead 80x20
+    // hard client must not participate in negotiation anymore.
+    expect(sizes[1]).toEqual({ cols: 200, rows: 50 });
+    expect(ptyB.resizes.at(-1)).toEqual({ cols: 200, rows: 50 });
+    expect(reconnected).toBeDefined();
+    handler.dispose();
+  });
+
   it("accepts terminal query token and bearer auth through constant-time auth middleware", async () => {
     const next = vi.fn();
     const makeContext = (url: string, authorization?: string) => ({

--- a/tests/gateway/terminal-zellij-ws.test.ts
+++ b/tests/gateway/terminal-zellij-ws.test.ts
@@ -982,6 +982,23 @@ describe("zellij terminal WebSocket", () => {
     handler.dispose();
   });
 
+  it("treats a hard declaration without a size as legacy", async () => {
+    const pty = new FakePty();
+    const handler = createShellWsHandler({
+      registry: { list: vi.fn(async () => [{ name: "main", status: "active" }]) },
+      adapter: { attachSession: vi.fn(() => pty) },
+      maxReplayBytes: 4096,
+      sizingDebounceMs: 5,
+    });
+
+    const session = await handler.open({ ws: socket(), session: "main", fromSeq: 0, clientClass: "hard" });
+    session.onMessage(JSON.stringify({ type: "resize", cols: 100, rows: 30 }));
+
+    // no declared size -> legacy semantics: resize-follow still works
+    expect(pty.resizes).toContainEqual({ cols: 100, rows: 30 });
+    handler.dispose();
+  });
+
   it("negotiates canonical size across hard clients and pins the shared attach pty", async () => {
     const pty = new FakePty();
     const sizes: Array<{ cols: number; rows: number } | undefined> = [];
@@ -1006,7 +1023,8 @@ describe("zellij terminal WebSocket", () => {
     await handler.open({ ws: socket(), session: "main", fromSeq: 0, clientClass: "hard", declaredSize: { cols: 190, rows: 60 } });
     await new Promise((resolve) => setTimeout(resolve, 15));
 
-    // the shared attach spawns once, at the first hard client's declared size
+    // the first hard attach spawns the shared pty at its own declared size,
+    // not the fallback
     expect(sizes).toEqual([{ cols: 200, rows: 50 }]);
     // after negotiation the shared pty is pinned to the component-wise minimum
     expect(pty.resizes.at(-1)).toEqual({ cols: 190, rows: 50 });

--- a/tests/gateway/terminal-zellij-ws.test.ts
+++ b/tests/gateway/terminal-zellij-ws.test.ts
@@ -982,6 +982,83 @@ describe("zellij terminal WebSocket", () => {
     handler.dispose();
   });
 
+  it("negotiates canonical size across hard clients and pins the shared attach pty", async () => {
+    const pty = new FakePty();
+    const sizes: Array<{ cols: number; rows: number } | undefined> = [];
+    const persisted: Array<[string, { cols: number; rows: number }]> = [];
+    const handler = createShellWsHandler({
+      registry: { list: vi.fn(async () => [{ name: "main", status: "active" }]) },
+      adapter: {
+        attachSession: vi.fn((_name: string, opts?: { size?: { cols: number; rows: number } }) => {
+          sizes.push(opts?.size);
+          return pty;
+        }),
+      },
+      maxReplayBytes: 4096,
+      sizingDebounceMs: 5,
+      persistCanonicalSize: (name, size) => {
+        persisted.push([name, size]);
+      },
+    });
+
+    await handler.open({ ws: socket(), session: "main", fromSeq: 0, clientClass: "hard", declaredSize: { cols: 200, rows: 50 } });
+    await new Promise((resolve) => setTimeout(resolve, 15));
+    await handler.open({ ws: socket(), session: "main", fromSeq: 0, clientClass: "hard", declaredSize: { cols: 190, rows: 60 } });
+    await new Promise((resolve) => setTimeout(resolve, 15));
+
+    // the shared attach spawns once, at the first hard client's declared size
+    expect(sizes).toEqual([{ cols: 200, rows: 50 }]);
+    // after negotiation the shared pty is pinned to the component-wise minimum
+    expect(pty.resizes.at(-1)).toEqual({ cols: 190, rows: 50 });
+    expect(persisted.at(-1)).toEqual(["main", { cols: 190, rows: 50 }]);
+    handler.dispose();
+  });
+
+  it("ignores soft-client resize frames and keeps the canonical size", async () => {
+    const pty = new FakePty();
+    const handler = createShellWsHandler({
+      registry: { list: vi.fn(async () => [{ name: "main", status: "active" }]) },
+      adapter: { attachSession: vi.fn(() => pty) },
+      maxReplayBytes: 4096,
+      sizingDebounceMs: 5,
+    });
+
+    await handler.open({ ws: socket(), session: "main", fromSeq: 0, clientClass: "hard", declaredSize: { cols: 200, rows: 50 } });
+    const soft = await handler.open({ ws: socket(), session: "main", fromSeq: 0, clientClass: "soft", declaredSize: { cols: 60, rows: 30 } });
+    await new Promise((resolve) => setTimeout(resolve, 15));
+
+    soft.onMessage(JSON.stringify({ type: "resize", cols: 40, rows: 20 }));
+    await new Promise((resolve) => setTimeout(resolve, 15));
+
+    expect(pty.resizes).not.toContainEqual({ cols: 40, rows: 20 });
+    expect(pty.resizes.at(-1)).toEqual({ cols: 200, rows: 50 });
+    handler.dispose();
+  });
+
+  it("keeps legacy resize-follow only until a classified client attaches", async () => {
+    const pty = new FakePty();
+    const handler = createShellWsHandler({
+      registry: { list: vi.fn(async () => [{ name: "main", status: "active" }]) },
+      adapter: { attachSession: vi.fn(() => pty) },
+      maxReplayBytes: 4096,
+      sizingDebounceMs: 5,
+    });
+
+    const legacy = await handler.open({ ws: socket(), session: "main", fromSeq: 0 });
+    legacy.onMessage(JSON.stringify({ type: "resize", cols: 100, rows: 30 }));
+    expect(pty.resizes).toContainEqual({ cols: 100, rows: 30 });
+
+    await handler.open({ ws: socket(), session: "main", fromSeq: 0, clientClass: "hard", declaredSize: { cols: 200, rows: 50 } });
+    await new Promise((resolve) => setTimeout(resolve, 15));
+
+    legacy.onMessage(JSON.stringify({ type: "resize", cols: 44, rows: 11 }));
+    await new Promise((resolve) => setTimeout(resolve, 15));
+    expect(pty.resizes).not.toContainEqual({ cols: 44, rows: 11 });
+    // instead the shared pty is pinned to the hard client's canonical size
+    expect(pty.resizes.at(-1)).toEqual({ cols: 200, rows: 50 });
+    handler.dispose();
+  });
+
   it("accepts terminal query token and bearer auth through constant-time auth middleware", async () => {
     const next = vi.fn();
     const makeContext = (url: string, authorization?: string) => ({


### PR DESCRIPTION
## Summary

Spec 107 **Phase 2** (FR-006..009), gateway + CLI: ends "my phone resized my desktop terminal".

- **`shell/sizing.ts`** — per-session canonical-size arbiter: component-wise minimum across hard clients' declared sizes; soft clients never participate; persisted size (registry `canonicalSize`) or 200x50 default when no hard client is attached; 500ms debounced application; protocol-bounds clamping.
- **Client classes over the WS attach URL** (`client=hard|soft`, `cols`, `rows`, validated at the route boundary): absent class = **legacy**, which keeps today's resize-follow behavior *only while zero classified clients are attached* (FR-007) — so un-upgraded clients behave exactly as before among themselves, but can never shrink a session an upgraded client is using.
- **Every attach pty is pinned to canonical** (FR-009): spawns at `spawnSize()` (replacing the hardcoded 120x40) and is re-pinned when the canonical changes. Hard-client resize frames update declarations; soft-client resize frames are ignored; legacy frames apply only in legacy-only sessions.
- **CLI declares hard** with its TTY size on attach; its existing SIGWINCH resize frames now act as declaration updates.

Explicitly NOT here (follow-ups per spec): web shell scaled-viewport rendering (separate frontend PR with screenshot evidence — until then the web shell stays legacy class, safe by FR-007), mobile equivalents (pending their in-flight PRs), spikes S2/S3 live verification on a preview VPS.

## Tests

- New `tests/gateway/shell-sizing.test.ts` (8): min negotiation, soft exclusion, legacy gating, detach recompute + persistence, soft-only pinning to persisted size, debounce coalescing, bounds clamping, dispose.
- `terminal-zellij-ws.test.ts` +3 integration tests: canonical negotiation pins every pty and persists; soft resize frames ignored while ptys stay pinned; legacy resize-follow flips to hint-mode when a hard client attaches.
- Full `tests/gateway/`: 3108 passed; `tests/sync-client/`: 21 passed; `bun run typecheck` clean; `check:patterns` 0 violations.

## Review/Monitoring

Will monitor Greptile to 5/5 and CI; fixes land on this branch.

## Invariants

- **Source of truth**: the in-memory arbiter computes canonical from live declarations; the registry's `canonicalSize` is a persisted cache used to seed sessions with no live hard client. Divergence resolves on next application (arbiter wins).
- **Lock/transaction scope**: arbiter state is single-threaded per session on the event loop; registry persistence goes through the existing mutation lock; persistence failures log and never block sizing.
- **Acceptable orphan states**: a crash between application and persistence leaves a stale persisted size, corrected on the next hard-client attach; a debounce window (500ms) of mixed pty sizes during negotiation is by design.
- **Auth source of truth**: unchanged; new query params are validated (enum + bounded ints) at the route boundary before reaching the handler.
- **Deferred scope**: web/mobile scaled rendering, viewport-hint surfacing to UIs, S2 (uniform-size pinning on live zellij) and S3 (pause/resume on live zellij) preview-VPS spikes before tightening defaults.

🤖 Generated with [Claude Code](https://claude.com/claude-code)