### PR TITLE
feat(desktop): unify kernel and coding-agent threads behind one UI thread model

### DIFF
--- a/desktop/src/renderer/src/features/chat/ChatTab.tsx
+++ b/desktop/src/renderer/src/features/chat/ChatTab.tsx
@@ -145,12 +145,14 @@ export default function ChatTab() {
   const threads = useThreads((s) => s.threads);
   const activeThreadId = useThreads((s) => s.activeThreadId);
   const setActiveThread = useThreads((s) => s.setActiveThread);
-  const summary = useCodingAgentWorkspace((s) => s.summary);
+  // Short-circuit inside the selector so a disabled workspace never re-renders
+  // the rail on coding-agent store updates.
+  const summary = useCodingAgentWorkspace((s) => (CODING_AGENTS_DESKTOP_WORKSPACE ? s.summary : null));
   const loadThreadSnapshot = useCodingAgentWorkspace((s) => s.loadThreadSnapshot);
   const openTab = useTabs((s) => s.openTab);
 
   const railThreads = useMemo(
-    () => listUnifiedThreads(threads, CODING_AGENTS_DESKTOP_WORKSPACE ? summary : null),
+    () => listUnifiedThreads(threads, summary),
     [threads, summary],
   );
 
@@ -159,7 +161,12 @@ export default function ChatTab() {
       setActiveThread(item.id);
       return;
     }
-    void loadThreadSnapshot(item.id);
+    loadThreadSnapshot(item.id).catch((err: unknown) => {
+      console.warn(
+        "[chat] coding-agent thread open failed:",
+        err instanceof Error ? err.message : String(err),
+      );
+    });
     openTab(AGENTS_WORKSPACE_TAB_SPEC);
   };
 

--- a/desktop/src/renderer/src/features/chat/ChatTab.tsx
+++ b/desktop/src/renderer/src/features/chat/ChatTab.tsx
@@ -1,24 +1,24 @@
 import { GitBranch, Laptop, MessageSquarePlus, Sparkles, SquareTerminal } from "lucide-react";
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { StatusDot } from "../../design/primitives";
 import { groupMessages } from "../../lib/chat";
+import { CODING_AGENTS_DESKTOP_WORKSPACE } from "../../lib/feature-flags";
 import { useBoard } from "../../stores/board";
+import { useCodingAgentWorkspace } from "../../stores/coding-agent-workspace";
 import { useHermesChat, type HermesStatus } from "../../stores/hermes-chat";
-import { useThreads, type ThreadStatus } from "../../stores/threads";
+import { AGENTS_WORKSPACE_TAB_SPEC, useTabs } from "../../stores/tabs";
+import { useThreads } from "../../stores/threads";
+import {
+  listUnifiedThreads,
+  UNIFIED_THREAD_STATUS_META,
+  type UnifiedThreadItem,
+} from "../../stores/unified-threads";
 import ThreadView from "../threads/ThreadView";
 import { Conversation, ConversationContent } from "./elements/conversation";
 import { Message, MessageContent, MessageResponse } from "./elements/message";
 import { PromptInput } from "./elements/prompt-input";
 import { Reasoning } from "./elements/reasoning";
 import { Tool } from "./elements/tool";
-
-const STATUS_COLOR: Record<ThreadStatus, string> = {
-  running: "var(--status-running)",
-  "needs-attention": "var(--status-attention)",
-  done: "var(--status-complete)",
-  failed: "var(--status-failed)",
-  aborted: "var(--status-todo)",
-};
 
 function Pill({ icon, label }: { icon: React.ReactNode; label: string }) {
   return (
@@ -139,12 +139,29 @@ function HermesPane() {
 }
 
 // Unified chat: a Codex-style rail listing Hermes + every agent thread on the
-// left, the selected conversation on the right. (The old standalone "Agents"
-// tab folds in here.)
+// left, the selected conversation on the right. Kernel runs open in-pane;
+// coding-agent threads route to their canonical Agents workspace surface.
 export default function ChatTab() {
   const threads = useThreads((s) => s.threads);
   const activeThreadId = useThreads((s) => s.activeThreadId);
   const setActiveThread = useThreads((s) => s.setActiveThread);
+  const summary = useCodingAgentWorkspace((s) => s.summary);
+  const loadThreadSnapshot = useCodingAgentWorkspace((s) => s.loadThreadSnapshot);
+  const openTab = useTabs((s) => s.openTab);
+
+  const railThreads = useMemo(
+    () => listUnifiedThreads(threads, CODING_AGENTS_DESKTOP_WORKSPACE ? summary : null),
+    [threads, summary],
+  );
+
+  const selectRailThread = (item: UnifiedThreadItem) => {
+    if (item.source === "kernel") {
+      setActiveThread(item.id);
+      return;
+    }
+    void loadThreadSnapshot(item.id);
+    openTab(AGENTS_WORKSPACE_TAB_SPEC);
+  };
 
   // activeThreadId is the single source of truth: null → Hermes, otherwise the
   // selected agent run (the composer and sidebar Chat both drive it).
@@ -190,19 +207,19 @@ export default function ChatTab() {
             <Sparkles size={14} style={{ color: showHermes ? "var(--accent)" : "var(--text-tertiary)" }} />,
             "Hermes",
           )}
-          {threads.length > 0 ? (
+          {railThreads.length > 0 ? (
             <span className="px-2.5 pt-2 pb-0.5 text-xs font-semibold tracking-wide uppercase" style={{ color: "var(--text-tertiary)" }}>
               Agent runs
             </span>
           ) : null}
-          {threads.map((thread) =>
+          {railThreads.map((item) =>
             railButton(
-              thread.id,
-              thread.id === activeThreadId,
-              () => setActiveThread(thread.id),
-              <StatusDot color={STATUS_COLOR[thread.status]} pulse={thread.status === "running"} />,
-              thread.title,
-              thread.unread,
+              `${item.source}:${item.id}`,
+              item.source === "kernel" && item.id === activeThreadId,
+              () => selectRailThread(item),
+              <StatusDot color={UNIFIED_THREAD_STATUS_META[item.status].color} pulse={item.status === "running"} />,
+              item.title,
+              item.unread,
             ),
           )}
         </div>

--- a/desktop/src/renderer/src/features/mission-control/Sidebar.tsx
+++ b/desktop/src/renderer/src/features/mission-control/Sidebar.tsx
@@ -18,9 +18,11 @@ import { IconButton } from "../../design/primitives";
 import { CODING_AGENTS_DESKTOP_WORKSPACE } from "../../lib/feature-flags";
 import { invoke } from "../../lib/operator";
 import { useBoard } from "../../stores/board";
+import { useCodingAgentWorkspace } from "../../stores/coding-agent-workspace";
 import { useConnection } from "../../stores/connection";
 import { AGENTS_WORKSPACE_TAB_SPEC, FILES_WORKSPACE_TAB_SPEC, useTabs } from "../../stores/tabs";
 import { useThreads } from "../../stores/threads";
+import { codingAgentAttentionCount, kernelThreadAttentionCount } from "../../stores/unified-threads";
 import { useUi } from "../../stores/ui";
 import RuntimeComputerMenu from "../runtime/RuntimeComputerMenu";
 
@@ -98,7 +100,8 @@ export default function Sidebar() {
   const profileName = useConnection((s) => s.displayName);
   const imageUrl = useConnection((s) => s.imageUrl);
   const platformHost = useConnection((s) => s.platformHost);
-  const unread = useThreads((s) => s.threads.filter((t) => t.unread || t.status === "needs-attention").length);
+  const chatAttention = useThreads((s) => kernelThreadAttentionCount(s.threads));
+  const agentsAttention = useCodingAgentWorkspace((s) => codingAgentAttentionCount(s.summary));
   const collapsed = useUi((s) => s.sidebarCollapsed);
   const toggleSidebar = useUi((s) => s.toggleSidebar);
   const setCreateProjectOpen = useUi((s) => s.setCreateProjectOpen);
@@ -147,9 +150,9 @@ export default function Sidebar() {
       <div className="flex min-h-0 flex-1 flex-col overflow-y-auto px-2 pb-2">
         <nav className="flex flex-col gap-0.5">
           <NavRow icon={<Home size={15} />} label="Home" collapsed={collapsed} active={activeTab?.kind === "home"} onClick={() => openTab({ kind: "home", title: "Home", closable: false })} />
-          <NavRow icon={<Sparkles size={15} />} label="Chat" collapsed={collapsed} active={activeTab?.kind === "chat"} onClick={() => { useThreads.getState().setActiveThread(null); openTab({ kind: "chat", title: "Hermes", closable: false }); }} />
+          <NavRow icon={<Sparkles size={15} />} label="Chat" collapsed={collapsed} active={activeTab?.kind === "chat"} badge={chatAttention} onClick={() => { useThreads.getState().setActiveThread(null); openTab({ kind: "chat", title: "Hermes", closable: false }); }} />
           {CODING_AGENTS_DESKTOP_WORKSPACE ? (
-            <NavRow icon={<Bot size={15} />} label="Agents" collapsed={collapsed} active={activeTab?.kind === "agents"} onClick={() => openTab(AGENTS_WORKSPACE_TAB_SPEC)} />
+            <NavRow icon={<Bot size={15} />} label="Agents" collapsed={collapsed} active={activeTab?.kind === "agents"} badge={agentsAttention} onClick={() => openTab(AGENTS_WORKSPACE_TAB_SPEC)} />
           ) : null}
           <NavRow icon={<SquareTerminal size={15} />} label="Terminal" collapsed={collapsed} active={activeTab?.kind === "terminals"} onClick={() => openTab({ kind: "terminals", title: "Terminal" })} />
           <NavRow icon={<FolderTree size={15} />} label="Files" collapsed={collapsed} active={activeTab?.kind === "files"} onClick={() => openTab(FILES_WORKSPACE_TAB_SPEC)} />

--- a/desktop/src/renderer/src/features/threads/ThreadView.tsx
+++ b/desktop/src/renderer/src/features/threads/ThreadView.tsx
@@ -4,15 +4,8 @@ import ReactMarkdown from "react-markdown";
 import { Button, StatusDot } from "../../design/primitives";
 import { groupMessages, type ChatMessage } from "../../lib/chat";
 import { abortKernelRequest } from "../../lib/kernel-wiring";
-import { useThreads, type ThreadStatus } from "../../stores/threads";
-
-const STATUS_META: Record<ThreadStatus, { label: string; color: string }> = {
-  running: { label: "Running", color: "var(--status-running)" },
-  "needs-attention": { label: "Needs attention", color: "var(--status-attention)" },
-  done: { label: "Done", color: "var(--status-complete)" },
-  failed: { label: "Failed", color: "var(--status-failed)" },
-  aborted: { label: "Aborted", color: "var(--status-todo)" },
-};
+import { useThreads } from "../../stores/threads";
+import { UNIFIED_THREAD_STATUS_META } from "../../stores/unified-threads";
 
 function ToolRow({ message }: { message: ChatMessage }) {
   return (
@@ -80,7 +73,7 @@ export default function ThreadView({ threadId, embedded = false }: { threadId: s
     );
   }
 
-  const status = STATUS_META[thread.status];
+  const status = UNIFIED_THREAD_STATUS_META[thread.status];
 
   return (
     <div className="flex min-h-0 flex-1 flex-col">

--- a/desktop/src/renderer/src/lib/kernel-wiring.ts
+++ b/desktop/src/renderer/src/lib/kernel-wiring.ts
@@ -152,7 +152,12 @@ export function wireKernel(): () => void {
       useTabs.getState().openTab({ kind: "chat", title: "Hermes", closable: false });
       return;
     }
-    void useCodingAgentWorkspace.getState().loadThreadSnapshot(route.select);
+    useCodingAgentWorkspace.getState().loadThreadSnapshot(route.select).catch((err: unknown) => {
+      console.warn(
+        "[kernel-wiring] notification thread open failed:",
+        err instanceof Error ? err.message : String(err),
+      );
+    });
     useTabs.getState().openTab(AGENTS_WORKSPACE_TAB_SPEC);
   });
 

--- a/desktop/src/renderer/src/lib/kernel-wiring.ts
+++ b/desktop/src/renderer/src/lib/kernel-wiring.ts
@@ -13,6 +13,7 @@ import { useHermesChat } from "../stores/hermes-chat";
 import { useCodingAgentWorkspace } from "../stores/coding-agent-workspace";
 import { AGENTS_WORKSPACE_TAB_SPEC, useTabs } from "../stores/tabs";
 import { useThreads } from "../stores/threads";
+import { routeThreadNotification, unifiedAttentionCount } from "../stores/unified-threads";
 
 const KERNEL_CHAT_EVENT_TYPES = new Set([
   "kernel:init",
@@ -36,20 +37,6 @@ function isTaskEvent(msg: KernelServerMessage): msg is BoardTaskEvent {
     typeof msg.taskId === "string" &&
     typeof msg.status === "string"
   );
-}
-
-function legacyThreadAttentionCount(): number {
-  return useThreads.getState().threads.reduce(
-    (sum, thread) => sum + (thread.unread || thread.status === "needs-attention" ? 1 : 0),
-    0,
-  );
-}
-
-function codingAgentAttentionCount(): number {
-  const attentionThreads = useCodingAgentWorkspace.getState().summary?.attentionThreads;
-  return attentionThreads
-    ? attentionThreads.hasMore ? 999 : attentionThreads.items.length
-    : 0;
 }
 
 export function getKernelSocket(): KernelSocket | null {
@@ -101,11 +88,12 @@ export function wireKernel(): () => void {
   const activeSocket = socket;
 
   const unsubscribeMessages = activeSocket.subscribe((msg) => {
-    // A thread is "focused" only when the Agents tab is active and it's the
-    // selected thread; otherwise completions raise a notification.
+    // A kernel thread is "focused" only when the Chat tab (where ThreadView
+    // renders) is active and it's the selected thread; otherwise completions
+    // raise a notification.
     const tabsState = useTabs.getState();
-    const agentsActive = tabsState.tabs.find((t) => t.id === tabsState.activeTabId)?.kind === "agents";
-    const focusedThreadId = agentsActive ? useThreads.getState().activeThreadId : null;
+    const chatActive = tabsState.tabs.find((t) => t.id === tabsState.activeTabId)?.kind === "chat";
+    const focusedThreadId = chatActive ? useThreads.getState().activeThreadId : null;
     const { notification } = useThreads
       .getState()
       .handleKernelMessage(msg, { focusedThreadId });
@@ -133,7 +121,10 @@ export function wireKernel(): () => void {
 
   let lastBadge = -1;
   const updateBadge = () => {
-    const count = legacyThreadAttentionCount() + codingAgentAttentionCount();
+    const count = unifiedAttentionCount(
+      useThreads.getState().threads,
+      useCodingAgentWorkspace.getState().summary,
+    );
     if (count !== lastBadge) {
       lastBadge = count;
       void invoke("badge:set", { count: Math.min(count, 999) }).catch((err: unknown) => {
@@ -148,10 +139,20 @@ export function wireKernel(): () => void {
   const unsubscribeCodingAgentBadge = useCodingAgentWorkspace.subscribe(updateBadge);
   updateBadge();
 
-  // Clicking a native notification focuses the thread in the Agents tab.
+  // Clicking a native notification focuses the thread on its own surface:
+  // kernel threads render in the Chat tab, coding-agent threads in the Agents
+  // workspace. Never select across store namespaces.
   const offNotificationClick = onEvent("notification:clicked", ({ threadId }) => {
-    useThreads.getState().setActiveThread(threadId);
-    useCodingAgentWorkspace.setState({ activeThreadId: threadId });
+    const route = routeThreadNotification(
+      threadId,
+      useThreads.getState().threads.map((thread) => thread.id),
+    );
+    if (route.target === "chat") {
+      useThreads.getState().setActiveThread(route.select);
+      useTabs.getState().openTab({ kind: "chat", title: "Hermes", closable: false });
+      return;
+    }
+    void useCodingAgentWorkspace.getState().loadThreadSnapshot(route.select);
     useTabs.getState().openTab(AGENTS_WORKSPACE_TAB_SPEC);
   });
 

--- a/desktop/src/renderer/src/stores/coding-agent/thread-model.ts
+++ b/desktop/src/renderer/src/stores/coding-agent/thread-model.ts
@@ -69,8 +69,10 @@ export function summaryIncludesThread(summary: RuntimeSummary, threadId: string)
 // Reconciles one live-updated thread into the bounded summary lists: updates
 // in place, drops it from attentionThreads when attention clears, and promotes
 // it to the head of attentionThreads when a live event raises attention from
-// "none" (#998). Promotion enforces the server limit and marks truncation; the
-// next full summary refresh restores canonical ordering.
+// "none" (#998). Promotion mirrors the gateway's attentionThread predicate
+// (attention !== "none" && status !== "archived" in coding-agents/
+// thread-store.ts) so the local list anticipates exactly what the next
+// summary refresh returns; the refresh restores canonical ordering.
 export function reconcileSummaryThread(
   summary: RuntimeSummary,
   thread: RuntimeSummary["activeThreads"]["items"][number],
@@ -86,6 +88,8 @@ export function reconcileSummaryThread(
     attentionItems = summary.attentionThreads.items.map((candidate) =>
       candidate.id === thread.id ? thread : candidate,
     );
+  } else if (thread.status === "archived") {
+    attentionItems = summary.attentionThreads.items;
   } else {
     attentionItems = [thread, ...summary.attentionThreads.items];
     const limit = summary.attentionThreads.limit;

--- a/desktop/src/renderer/src/stores/coding-agent/thread-model.ts
+++ b/desktop/src/renderer/src/stores/coding-agent/thread-model.ts
@@ -66,10 +66,11 @@ export function summaryIncludesThread(summary: RuntimeSummary, threadId: string)
     || summary.attentionThreads.items.some((thread) => thread.id === threadId);
 }
 
-// Known limitation (#998): this updates threads already present in
-// attentionThreads but cannot PROMOTE a thread into the list when a live
-// event raises its attention from "none"; the next full summary refresh
-// reconciles. Behavior moved verbatim from the pre-split store.
+// Reconciles one live-updated thread into the bounded summary lists: updates
+// in place, drops it from attentionThreads when attention clears, and promotes
+// it to the head of attentionThreads when a live event raises attention from
+// "none" (#998). Promotion enforces the server limit and marks truncation; the
+// next full summary refresh restores canonical ordering.
 export function reconcileSummaryThread(
   summary: RuntimeSummary,
   thread: RuntimeSummary["activeThreads"]["items"][number],
@@ -77,11 +78,22 @@ export function reconcileSummaryThread(
   const activeItems = summary.activeThreads.items.map((candidate) =>
     candidate.id === thread.id ? thread : candidate,
   );
-  const attentionItems = thread.attention === "none"
-    ? summary.attentionThreads.items.filter((candidate) => candidate.id !== thread.id)
-    : summary.attentionThreads.items.map((candidate) =>
-        candidate.id === thread.id ? thread : candidate,
-      );
+  let attentionItems: typeof summary.attentionThreads.items;
+  let attentionHasMore = summary.attentionThreads.hasMore;
+  if (thread.attention === "none") {
+    attentionItems = summary.attentionThreads.items.filter((candidate) => candidate.id !== thread.id);
+  } else if (summary.attentionThreads.items.some((candidate) => candidate.id === thread.id)) {
+    attentionItems = summary.attentionThreads.items.map((candidate) =>
+      candidate.id === thread.id ? thread : candidate,
+    );
+  } else {
+    attentionItems = [thread, ...summary.attentionThreads.items];
+    const limit = summary.attentionThreads.limit;
+    if (attentionItems.length > limit) {
+      attentionItems = attentionItems.slice(0, limit);
+      attentionHasMore = true;
+    }
+  }
   return {
     ...summary,
     activeThreads: {
@@ -91,6 +103,7 @@ export function reconcileSummaryThread(
     attentionThreads: {
       ...summary.attentionThreads,
       items: attentionItems,
+      hasMore: attentionHasMore,
     },
   };
 }

--- a/desktop/src/renderer/src/stores/unified-threads.ts
+++ b/desktop/src/renderer/src/stores/unified-threads.ts
@@ -105,7 +105,12 @@ export function kernelThreadAttentionCount(threads: AgentThread[]): number {
 export function codingAgentAttentionCount(summary: RuntimeSummary | null): number {
   const attentionThreads = summary?.attentionThreads;
   if (!attentionThreads) return 0;
-  return attentionThreads.hasMore ? 999 : attentionThreads.items.length;
+  // The truncation sentinel only applies to a non-empty page: the server never
+  // returns hasMore with zero items, but client-side promotion eviction can
+  // leave hasMore set after every listed thread demotes.
+  return attentionThreads.hasMore && attentionThreads.items.length > 0
+    ? 999
+    : attentionThreads.items.length;
 }
 
 export function unifiedAttentionCount(

--- a/desktop/src/renderer/src/stores/unified-threads.ts
+++ b/desktop/src/renderer/src/stores/unified-threads.ts
@@ -1,0 +1,137 @@
+// One UI thread model over two distinct backends: local kernel-WS agent runs
+// (stores/threads.ts) and server-backed coding-agent threads (RuntimeSummary
+// projections). Pure derivation only — this module owns no state, so the two
+// systems cannot diverge through it. See
+// specs/105-coding-agent-shells/desktop-thread-unification.md.
+import type { AgentThreadSummary, RuntimeSummary } from "@matrix-os/contracts";
+import type { AgentThread, ThreadStatus } from "./threads";
+
+export type UnifiedThreadSource = "kernel" | "coding-agent";
+export type UnifiedThreadStatus = ThreadStatus;
+
+export interface UnifiedThreadItem {
+  source: UnifiedThreadSource;
+  id: string;
+  title: string;
+  status: UnifiedThreadStatus;
+  unread: boolean;
+  updatedAt: number;
+}
+
+export const UNIFIED_THREAD_STATUS_META: Record<UnifiedThreadStatus, { label: string; color: string }> = {
+  running: { label: "Running", color: "var(--status-running)" },
+  "needs-attention": { label: "Needs attention", color: "var(--status-attention)" },
+  done: { label: "Done", color: "var(--status-complete)" },
+  failed: { label: "Failed", color: "var(--status-failed)" },
+  aborted: { label: "Aborted", color: "var(--status-todo)" },
+};
+
+// Server thread ids come from ThreadIdSchema (`thread_` prefix); local kernel
+// thread ids are `thread-<epoch>-<seq>`. The namespaces cannot collide.
+const SERVER_THREAD_ID_PREFIX = "thread_";
+
+export function kernelThreadToUnified(thread: AgentThread): UnifiedThreadItem {
+  return {
+    source: "kernel",
+    id: thread.id,
+    title: thread.title,
+    status: thread.status,
+    unread: thread.unread,
+    updatedAt: thread.updatedAt,
+  };
+}
+
+function codingAgentUnifiedStatus(thread: AgentThreadSummary): UnifiedThreadStatus {
+  if (thread.attention === "approval_required" || thread.attention === "input_required") {
+    return "needs-attention";
+  }
+  switch (thread.status) {
+    case "queued":
+    case "starting":
+    case "running":
+      return "running";
+    case "waiting_for_approval":
+    case "waiting_for_input":
+      return "needs-attention";
+    case "completed":
+      return "done";
+    case "failed":
+      return "failed";
+    default:
+      // aborted, stale, archived: no longer executing and needs no action.
+      return "aborted";
+  }
+}
+
+export function codingAgentThreadToUnified(thread: AgentThreadSummary): UnifiedThreadItem {
+  const parsed = Date.parse(thread.updatedAt);
+  return {
+    source: "coding-agent",
+    id: thread.id,
+    title: thread.title,
+    status: codingAgentUnifiedStatus(thread),
+    unread: thread.attention === "approval_required" || thread.attention === "input_required",
+    updatedAt: Number.isNaN(parsed) ? 0 : parsed,
+  };
+}
+
+/**
+ * Merges kernel threads with the summary's active and attention lists into one
+ * recency-sorted rail model. Attention entries win the dedupe because they
+ * carry the actionable state. Inputs are already bounded (kernel store caps at
+ * 100, summary lists are server-limited), so the result is bounded too.
+ */
+export function listUnifiedThreads(
+  kernelThreads: AgentThread[],
+  summary: RuntimeSummary | null,
+): UnifiedThreadItem[] {
+  const items = kernelThreads.map(kernelThreadToUnified);
+  if (summary) {
+    const byId = new Map<string, AgentThreadSummary>();
+    for (const thread of summary.activeThreads.items) byId.set(thread.id, thread);
+    for (const thread of summary.attentionThreads.items) byId.set(thread.id, thread);
+    for (const thread of byId.values()) items.push(codingAgentThreadToUnified(thread));
+  }
+  return items.sort((a, b) => b.updatedAt - a.updatedAt);
+}
+
+export function kernelThreadAttentionCount(threads: AgentThread[]): number {
+  return threads.reduce(
+    (sum, thread) => sum + (thread.unread || thread.status === "needs-attention" ? 1 : 0),
+    0,
+  );
+}
+
+export function codingAgentAttentionCount(summary: RuntimeSummary | null): number {
+  const attentionThreads = summary?.attentionThreads;
+  if (!attentionThreads) return 0;
+  return attentionThreads.hasMore ? 999 : attentionThreads.items.length;
+}
+
+export function unifiedAttentionCount(
+  kernelThreads: AgentThread[],
+  summary: RuntimeSummary | null,
+): number {
+  return kernelThreadAttentionCount(kernelThreads) + codingAgentAttentionCount(summary);
+}
+
+export type ThreadNotificationRoute =
+  | { target: "chat"; select: string | null }
+  | { target: "coding-agent"; select: string };
+
+/**
+ * Decides which surface a thread notification belongs to. Kernel threads are
+ * matched by presence (their store is the only authority for local ids);
+ * otherwise the server id namespace routes to the coding-agent workspace. A
+ * kernel-format id that is no longer in the store (runtime switch cleared it)
+ * opens chat with no selection rather than feeding a foreign-namespace id to
+ * the coding-agent snapshot loader.
+ */
+export function routeThreadNotification(
+  threadId: string,
+  kernelThreadIds: readonly string[],
+): ThreadNotificationRoute {
+  if (kernelThreadIds.includes(threadId)) return { target: "chat", select: threadId };
+  if (threadId.startsWith(SERVER_THREAD_ID_PREFIX)) return { target: "coding-agent", select: threadId };
+  return { target: "chat", select: null };
+}

--- a/specs/105-coding-agent-shells/desktop-thread-unification.md
+++ b/specs/105-coding-agent-shells/desktop-thread-unification.md
@@ -1,0 +1,144 @@
+# Desktop Thread Unification (Phase 1c)
+
+Status: implemented with this change. Scope: `desktop/` renderer only; no gateway,
+contract, or IPC changes.
+
+## Problem
+
+The desktop renderer has two thread systems that grew independently:
+
+1. **Kernel threads** (`stores/threads.ts`): local, ephemeral agent runs
+   multiplexed over the kernel WebSocket by `requestId`. Rendered by
+   `features/chat/ChatTab.tsx` (rail) and `features/threads/ThreadView.tsx`.
+   Local ids look like `thread-<epoch>-<seq>`.
+2. **Coding-agent threads** (`stores/coding-agent-workspace.ts`): server-backed
+   threads from the `runtime:*` IPC bridge (`RuntimeSummary.activeThreads` /
+   `attentionThreads`, snapshots, live event streams). Rendered by the Agents
+   workspace. Server ids are `thread_`-prefixed (`ThreadIdSchema`).
+
+They stay **distinct backends** — the kernel WS request/reduce path and the
+bounded coding-agent projection are different contracts with different
+lifecycles — but the UI currently exposes two disconnected thread models, and
+the seams have real bugs:
+
+- **Stale focus gate** (`lib/kernel-wiring.ts`): a kernel thread counts as
+  "focused" only when the active tab kind is `"agents"`. The old standalone
+  Agents tab folded into Chat long ago; kernel `ThreadView` renders inside the
+  `"chat"` tab. Watching a running thread in Chat still marks it unread and
+  raises a native notification for the transcript the user is looking at.
+- **Wrong notification routing**: `notification:clicked` sets
+  `useThreads.activeThreadId` *and* `useCodingAgentWorkspace.activeThreadId`
+  to the same id, then always opens the Agents workspace tab. Kernel threads do
+  not render there, and the coding-agent store receives an id from the wrong
+  namespace. Clicking "Run completed" for a kernel thread lands on the wrong
+  surface with a phantom selection.
+- **Duplicated derived logic**: attention/badge math exists twice in
+  `kernel-wiring.ts` (`legacyThreadAttentionCount`, `codingAgentAttentionCount`)
+  and a third variant sits unused in `mission-control/Sidebar.tsx` (`unread`
+  selector computed and never rendered). Status→color/label maps are duplicated
+  between `ChatTab` and `ThreadView`.
+- **#998**: `reconcileSummaryThread` in `stores/coding-agent/thread-model.ts`
+  updates a thread already present in `attentionThreads` but cannot *promote*
+  a thread into the list when a live event raises attention from `"none"`,
+  so the attention rail and badge lag until the next full summary refresh.
+
+## Design
+
+One **UI thread model** over both backends: a pure derivation module, no new
+store, no new persistence, no transcript/token/diff storage (per
+`backend-shell-handoff.md` shells persist only safe selection references —
+this change persists nothing).
+
+### New module: `stores/unified-threads.ts` (pure functions + types)
+
+```ts
+type UnifiedThreadSource = "kernel" | "coding-agent";
+type UnifiedThreadStatus = "running" | "needs-attention" | "done" | "failed" | "aborted";
+
+interface UnifiedThreadItem {
+  source: UnifiedThreadSource;
+  id: string;
+  title: string;
+  status: UnifiedThreadStatus;
+  unread: boolean;      // kernel: unread flag; coding-agent: actionable attention
+  updatedAt: number;    // epoch ms (ISO timestamps parsed once here)
+}
+```
+
+- `kernelThreadToUnified(thread)` — identity mapping; kernel statuses already
+  use the UI vocabulary.
+- `codingAgentThreadToUnified(summary)` — status mapping:
+  `approval_required`/`input_required` attention → `needs-attention`; else
+  `queued`/`starting`/`running` → `running`, `completed` → `done`, `failed` →
+  `failed`, `aborted`/`stale`/`archived` → `aborted`.
+- `listUnifiedThreads(kernelThreads, runtimeSummary | null)` — merges kernel
+  threads with `activeThreads ∪ attentionThreads` (deduped by id), sorted by
+  `updatedAt` descending. Bounded by construction: kernel store caps at 100,
+  summary lists are server-bounded.
+- `kernelThreadAttentionCount(threads)` / `codingAgentAttentionCount(summary)`
+  / `unifiedAttentionCount(...)` — single home for badge math, preserving
+  current semantics exactly (kernel: `unread || needs-attention`; coding-agent:
+  `hasMore ? 999 : items.length`).
+- `UNIFIED_THREAD_STATUS_META` — one status → `{ label, colorVar }` map shared
+  by `ChatTab` and `ThreadView`.
+- `routeThreadNotification(threadId, kernelThreadIds)` — pure routing decision:
+  - id present in the kernel store → `{ target: "chat", select: id }`;
+  - else id matches the server namespace (`thread_` prefix) →
+    `{ target: "coding-agent", select: id }`;
+  - else (stale kernel id after a runtime switch reset) →
+    `{ target: "chat", select: null }` — never feeds a foreign-namespace id to
+    the coding-agent snapshot loader.
+
+### Wiring changes
+
+- **`lib/kernel-wiring.ts`**
+  - Focus gate keys on active tab kind `"chat"` (where kernel `ThreadView`
+    renders), not `"agents"`.
+  - Badge uses `unifiedAttentionCount`.
+  - `notification:clicked` applies `routeThreadNotification`: kernel → select
+    in `useThreads` + open the chat tab; coding-agent →
+    `loadThreadSnapshot(threadId)` + open the Agents workspace tab. No more
+    cross-store writes.
+- **`features/chat/ChatTab.tsx`** — the rail renders `listUnifiedThreads(...)`
+  under "Agent runs": kernel items keep the in-pane `ThreadView` behavior;
+  selecting a coding-agent item opens the Agents workspace tab and loads that
+  thread's snapshot (transcript/approvals stay on their canonical surface —
+  ChatTab does not re-render coding-agent events). Coding-agent items appear
+  only when `CODING_AGENTS_DESKTOP_WORKSPACE` is enabled.
+- **`features/threads/ThreadView.tsx`** — consumes the shared status meta.
+- **`features/mission-control/Sidebar.tsx`** — the dead `unread` selector
+  becomes a rendered badge: Chat row shows the kernel attention count, Agents
+  row shows the coding-agent attention count, via the shared helpers.
+- **`stores/coding-agent/thread-model.ts`** — `reconcileSummaryThread` promotes
+  a thread into `attentionThreads` when its attention rises from `"none"`
+  (insert at head, enforce `limit`, set `hasMore` when the insert evicts),
+  keeping the existing demote-on-`"none"` and update-in-place behavior. Fixes
+  #998.
+
+## Invariants
+
+- **Source of truth**: kernel threads — `useThreads` (renderer-local, reset on
+  runtime switch); coding-agent threads — gateway projections via `runtime:*`
+  IPC, reconciled by summary refresh. `unified-threads.ts` is derivation only;
+  it owns no state and cannot diverge.
+- **Backends stay distinct**: no kernel event ever mutates coding-agent state
+  or vice versa; the only join point is read-side list/count derivation and
+  notification routing.
+- **Bounded UI state**: no new caches; unified lists are recomputed from
+  already-bounded inputs. Nothing new is persisted.
+- **Attention semantics preserved**: badge totals for existing states are
+  byte-identical to the previous two-helper sum; #998 promotion only *adds*
+  the missing rise-from-none case.
+- **Orphan states**: a notification for a thread that no longer exists in
+  either system opens the chat surface with no selection (kernel-format id) or
+  surfaces the safe "Thread state unavailable" error (server-format id) — no
+  crash, no cross-namespace selection.
+
+## Out of scope (deferred)
+
+- Rendering coding-agent transcripts/approvals inside ChatTab (canonical
+  surface remains the Agents workspace).
+- Merging `hermes-chat.ts` into the thread stores (Hermes is a single
+  continuous conversation, not a thread list).
+- Any gateway/contract change; `attentionThreads` ordering remains
+  server-defined between refreshes.

--- a/tests/desktop/chat-tab-render.test.tsx
+++ b/tests/desktop/chat-tab-render.test.tsx
@@ -5,7 +5,9 @@ import { act, cleanup, fireEvent, render, screen } from "@testing-library/react"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import ChatTab from "../../desktop/src/renderer/src/features/chat/ChatTab";
 import { useBoard } from "../../desktop/src/renderer/src/stores/board";
+import { useCodingAgentWorkspace } from "../../desktop/src/renderer/src/stores/coding-agent-workspace";
 import { useHermesChat } from "../../desktop/src/renderer/src/stores/hermes-chat";
+import { useTabs } from "../../desktop/src/renderer/src/stores/tabs";
 import { useThreads, type AgentThread } from "../../desktop/src/renderer/src/stores/threads";
 
 vi.mock("../../desktop/src/renderer/src/features/threads/ThreadView", () => ({
@@ -29,6 +31,40 @@ function thread(id: string, title: string): AgentThread {
   };
 }
 
+function codingAgentSummaryFixture() {
+  return {
+    runtime: { id: "rt_primary", label: "Primary", status: "available" },
+    capabilities: [],
+    providers: [],
+    projects: { items: [], hasMore: false, limit: 20 },
+    activeThreads: {
+      items: [
+        {
+          id: "thread_server",
+          providerId: "codex",
+          title: "Server-backed run",
+          status: "running",
+          attention: "none",
+          createdAt: "2026-07-06T00:00:00.000Z",
+          updatedAt: "2026-07-06T00:01:00.000Z",
+        },
+      ],
+      hasMore: false,
+      limit: 20,
+    },
+    attentionThreads: { items: [], hasMore: false, limit: 20 },
+    terminalSessions: { items: [], hasMore: false, limit: 20 },
+    recentActivity: { items: [], hasMore: false, limit: 20 },
+    limits: {
+      maxPromptBytes: 16384,
+      maxAttachmentCount: 8,
+      maxTerminalInputBytes: 8192,
+      maxListItems: 20,
+    },
+    serverTime: "2026-07-06T00:03:00.000Z",
+  };
+}
+
 describe("ChatTab", () => {
   beforeEach(() => {
     class MockResizeObserver {
@@ -47,6 +83,8 @@ describe("ChatTab", () => {
       abort: vi.fn(),
     });
     useThreads.setState({ threads: [], activeThreadId: null });
+    useCodingAgentWorkspace.setState({ summary: null, activeThreadId: null });
+    useTabs.setState({ tabs: [], activeTabId: null });
   });
 
   afterEach(() => {
@@ -74,6 +112,31 @@ describe("ChatTab", () => {
 
     expect(useThreads.getState().activeThreadId).toBe("t1");
     expect(screen.getByTestId("thread-view").textContent).toBe("thread:t1");
+  });
+
+  it("lists coding-agent workspace threads in the rail", () => {
+    useCodingAgentWorkspace.setState({ summary: codingAgentSummaryFixture() });
+
+    render(<ChatTab />);
+
+    expect(screen.getByRole("button", { name: "Server-backed run" })).toBeTruthy();
+  });
+
+  it("routes a coding-agent rail selection to the Agents workspace", () => {
+    const loadThreadSnapshot = vi.fn().mockResolvedValue(undefined);
+    useCodingAgentWorkspace.setState({
+      summary: codingAgentSummaryFixture(),
+      loadThreadSnapshot,
+    });
+
+    render(<ChatTab />);
+    fireEvent.click(screen.getByRole("button", { name: "Server-backed run" }));
+
+    expect(loadThreadSnapshot).toHaveBeenCalledWith("thread_server");
+    const tabs = useTabs.getState();
+    expect(tabs.tabs.find((tab) => tab.id === tabs.activeTabId)?.kind).toBe("agents");
+    // The chat pane itself stays on Hermes; the transcript renders in the workspace.
+    expect(screen.queryByTestId("thread-view")).toBeNull();
   });
 
   it("falls back to Hermes when the active agent thread is removed", () => {

--- a/tests/desktop/coding-agent-thread-model.test.ts
+++ b/tests/desktop/coding-agent-thread-model.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from "vitest";
+import type { AgentThreadSummary, RuntimeSummary } from "@matrix-os/contracts";
+import { reconcileSummaryThread } from "../../desktop/src/renderer/src/stores/coding-agent/thread-model";
+
+function thread(overrides: Partial<AgentThreadSummary> = {}): AgentThreadSummary {
+  return {
+    id: "thread_alpha",
+    providerId: "codex",
+    title: "Run",
+    status: "running",
+    attention: "none",
+    createdAt: "2026-07-06T00:00:00.000Z",
+    updatedAt: "2026-07-06T00:01:00.000Z",
+    ...overrides,
+  };
+}
+
+function summary(overrides: {
+  active?: AgentThreadSummary[];
+  attention?: AgentThreadSummary[];
+  attentionLimit?: number;
+  attentionHasMore?: boolean;
+} = {}): RuntimeSummary {
+  return {
+    runtime: { id: "rt_primary", label: "Primary", status: "available" },
+    capabilities: [],
+    providers: [],
+    projects: { items: [], hasMore: false, limit: 20 },
+    activeThreads: { items: overrides.active ?? [], hasMore: false, limit: 20 },
+    attentionThreads: {
+      items: overrides.attention ?? [],
+      hasMore: overrides.attentionHasMore ?? false,
+      limit: overrides.attentionLimit ?? 20,
+    },
+    terminalSessions: { items: [], hasMore: false, limit: 20 },
+    recentActivity: { items: [], hasMore: false, limit: 20 },
+    limits: {
+      maxPromptBytes: 16384,
+      maxAttachmentCount: 8,
+      maxTerminalInputBytes: 8192,
+      maxListItems: 20,
+    },
+    serverTime: "2026-07-06T00:03:00.000Z",
+  } as RuntimeSummary;
+}
+
+describe("reconcileSummaryThread", () => {
+  it("updates a thread in place in both lists", () => {
+    const stale = thread({ status: "waiting_for_approval", attention: "approval_required" });
+    const next = thread({ status: "running", attention: "approval_required", updatedAt: "2026-07-06T00:02:00.000Z" });
+    const result = reconcileSummaryThread(summary({ active: [stale], attention: [stale] }), next);
+
+    expect(result.activeThreads.items).toEqual([next]);
+    expect(result.attentionThreads.items).toEqual([next]);
+  });
+
+  it("removes a thread from the attention list when attention drops to none", () => {
+    const attending = thread({ status: "waiting_for_approval", attention: "approval_required" });
+    const resolved = thread({ status: "running", attention: "none", updatedAt: "2026-07-06T00:02:00.000Z" });
+    const result = reconcileSummaryThread(summary({ active: [attending], attention: [attending] }), resolved);
+
+    expect(result.attentionThreads.items).toEqual([]);
+    expect(result.activeThreads.items).toEqual([resolved]);
+  });
+
+  it("promotes a thread into the attention list when a live event raises attention", () => {
+    const calm = thread({ status: "running", attention: "none" });
+    const raised = thread({ status: "waiting_for_approval", attention: "approval_required", updatedAt: "2026-07-06T00:02:00.000Z" });
+    const result = reconcileSummaryThread(summary({ active: [calm], attention: [] }), raised);
+
+    expect(result.attentionThreads.items).toEqual([raised]);
+    expect(result.attentionThreads.hasMore).toBe(false);
+    expect(result.activeThreads.items).toEqual([raised]);
+  });
+
+  it("does not duplicate an already-listed attention thread on promotion", () => {
+    const raised = thread({ status: "waiting_for_input", attention: "input_required" });
+    const result = reconcileSummaryThread(summary({ active: [raised], attention: [raised] }), raised);
+
+    expect(result.attentionThreads.items).toHaveLength(1);
+  });
+
+  it("enforces the attention list limit on promotion and marks truncation", () => {
+    const existing = [
+      thread({ id: "thread_one", status: "waiting_for_approval", attention: "approval_required" }),
+      thread({ id: "thread_two", status: "waiting_for_input", attention: "input_required" }),
+    ];
+    const raised = thread({ id: "thread_new", status: "waiting_for_approval", attention: "approval_required", updatedAt: "2026-07-06T00:05:00.000Z" });
+    const result = reconcileSummaryThread(summary({ attention: existing, attentionLimit: 2 }), raised);
+
+    expect(result.attentionThreads.items).toHaveLength(2);
+    expect(result.attentionThreads.items[0]).toEqual(raised);
+    expect(result.attentionThreads.hasMore).toBe(true);
+  });
+
+  it("preserves an existing truncation marker on unrelated updates", () => {
+    const listed = thread({ id: "thread_listed", status: "waiting_for_approval", attention: "approval_required" });
+    const updated = { ...listed, updatedAt: "2026-07-06T00:06:00.000Z" };
+    const result = reconcileSummaryThread(summary({ attention: [listed], attentionHasMore: true }), updated);
+
+    expect(result.attentionThreads.hasMore).toBe(true);
+    expect(result.attentionThreads.items).toEqual([updated]);
+  });
+});

--- a/tests/desktop/coding-agent-thread-model.test.ts
+++ b/tests/desktop/coding-agent-thread-model.test.ts
@@ -73,6 +73,18 @@ describe("reconcileSummaryThread", () => {
     expect(result.activeThreads.items).toEqual([raised]);
   });
 
+  it("does not promote archived threads even when their attention is set", () => {
+    const archived = thread({
+      id: "thread_archived",
+      status: "archived",
+      attention: "completed",
+      updatedAt: "2026-07-06T00:02:00.000Z",
+    });
+    const result = reconcileSummaryThread(summary({ attention: [] }), archived);
+
+    expect(result.attentionThreads.items).toEqual([]);
+  });
+
   it("does not duplicate an already-listed attention thread on promotion", () => {
     const raised = thread({ status: "waiting_for_input", attention: "input_required" });
     const result = reconcileSummaryThread(summary({ active: [raised], attention: [raised] }), raised);

--- a/tests/desktop/kernel-wiring.test.ts
+++ b/tests/desktop/kernel-wiring.test.ts
@@ -60,17 +60,21 @@ const kernelSocketMocks = vi.hoisted(() => ({
   instances: [] as MockKernelSocket[],
 }));
 
-vi.mock("../../desktop/src/renderer/src/lib/kernel-socket", () => ({
-  KernelSocket: vi.fn().mockImplementation(function MockKernelSocketConstructor() {
-    const instance: MockKernelSocket = {
-      subscribe: vi.fn(() => () => undefined),
-      connect: vi.fn(),
-      dispose: vi.fn(),
-    };
-    kernelSocketMocks.instances.push(instance);
-    return instance;
-  }),
-}));
+vi.mock("../../desktop/src/renderer/src/lib/kernel-socket", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../desktop/src/renderer/src/lib/kernel-socket")>();
+  return {
+    ...actual,
+    KernelSocket: vi.fn().mockImplementation(function MockKernelSocketConstructor() {
+      const instance: MockKernelSocket = {
+        subscribe: vi.fn(() => () => undefined),
+        connect: vi.fn(),
+        dispose: vi.fn(),
+      };
+      kernelSocketMocks.instances.push(instance);
+      return instance;
+    }),
+  };
+});
 
 describe("kernel wiring", () => {
   let notificationClick: ((payload: { threadId: string }) => void) | null = null;
@@ -118,14 +122,136 @@ describe("kernel wiring", () => {
   });
 
   it("focuses the coding-agent workspace thread when a native notification is clicked", () => {
+    const loadThreadSnapshot = vi.fn().mockResolvedValue(undefined);
+    useCodingAgentWorkspace.setState({ loadThreadSnapshot });
     const cleanup = wireKernel();
 
     expect(notificationClick).not.toBeNull();
     notificationClick?.({ threadId: "thread_alpha" });
 
-    expect(useCodingAgentWorkspace.getState().activeThreadId).toBe("thread_alpha");
+    expect(loadThreadSnapshot).toHaveBeenCalledWith("thread_alpha");
     const tabs = useTabs.getState();
     expect(tabs.tabs.find((tab) => tab.id === tabs.activeTabId)?.kind).toBe("agents");
+
+    cleanup();
+  });
+
+  it("routes a kernel-thread notification to the chat tab without touching the coding-agent store", () => {
+    const loadThreadSnapshot = vi.fn().mockResolvedValue(undefined);
+    useCodingAgentWorkspace.setState({ loadThreadSnapshot });
+    useThreads.setState({
+      threads: [
+        {
+          id: "thread-1000-1",
+          requestId: "request-1",
+          sessionId: null,
+          taskId: null,
+          title: "Kernel run",
+          status: "done",
+          transcript: [],
+          unread: true,
+          createdAt: 1_000,
+          updatedAt: 1_000,
+        },
+      ],
+      activeThreadId: null,
+    });
+    const cleanup = wireKernel();
+
+    notificationClick?.({ threadId: "thread-1000-1" });
+
+    expect(useThreads.getState().activeThreadId).toBe("thread-1000-1");
+    expect(loadThreadSnapshot).not.toHaveBeenCalled();
+    expect(useCodingAgentWorkspace.getState().activeThreadId).toBeNull();
+    const tabs = useTabs.getState();
+    expect(tabs.tabs.find((tab) => tab.id === tabs.activeTabId)?.kind).toBe("chat");
+
+    cleanup();
+  });
+
+  it("routes a stale kernel-format notification to the chat tab with no selection", () => {
+    const loadThreadSnapshot = vi.fn().mockResolvedValue(undefined);
+    useCodingAgentWorkspace.setState({ loadThreadSnapshot });
+    const cleanup = wireKernel();
+
+    notificationClick?.({ threadId: "thread-999-9" });
+
+    expect(useThreads.getState().activeThreadId).toBeNull();
+    expect(loadThreadSnapshot).not.toHaveBeenCalled();
+    const tabs = useTabs.getState();
+    expect(tabs.tabs.find((tab) => tab.id === tabs.activeTabId)?.kind).toBe("chat");
+
+    cleanup();
+  });
+
+  it("treats the selected kernel thread as focused while the chat tab is active", () => {
+    useThreads.setState({
+      threads: [
+        {
+          id: "thread-1000-1",
+          requestId: "request-1",
+          sessionId: null,
+          taskId: null,
+          title: "Kernel run",
+          status: "running",
+          transcript: [],
+          unread: false,
+          createdAt: 1_000,
+          updatedAt: 1_000,
+        },
+      ],
+      activeThreadId: "thread-1000-1",
+    });
+    useTabs.getState().openTab({ kind: "chat", title: "Hermes", closable: false });
+    const cleanup = wireKernel();
+    const invoke = window.operator.invoke as ReturnType<typeof vi.fn>;
+    invoke.mockClear();
+    const handleMessage = kernelSocketMocks.instances[0]?.subscribe.mock.calls[0]?.[0] as (
+      msg: unknown,
+    ) => void;
+
+    handleMessage({ type: "kernel:result", data: {}, requestId: "request-1" });
+
+    const updated = useThreads.getState().threads[0];
+    expect(updated?.status).toBe("done");
+    expect(updated?.unread).toBe(false);
+    expect(invoke).not.toHaveBeenCalledWith("notify", expect.anything());
+
+    cleanup();
+  });
+
+  it("marks the selected kernel thread unread and notifies when another tab is active", () => {
+    useThreads.setState({
+      threads: [
+        {
+          id: "thread-1000-1",
+          requestId: "request-1",
+          sessionId: null,
+          taskId: null,
+          title: "Kernel run",
+          status: "running",
+          transcript: [],
+          unread: false,
+          createdAt: 1_000,
+          updatedAt: 1_000,
+        },
+      ],
+      activeThreadId: "thread-1000-1",
+    });
+    useTabs.getState().openTab({ kind: "home", title: "Home", closable: false });
+    const cleanup = wireKernel();
+    const invoke = window.operator.invoke as ReturnType<typeof vi.fn>;
+    invoke.mockClear();
+    const handleMessage = kernelSocketMocks.instances[0]?.subscribe.mock.calls[0]?.[0] as (
+      msg: unknown,
+    ) => void;
+
+    handleMessage({ type: "kernel:result", data: {}, requestId: "request-1" });
+
+    const updated = useThreads.getState().threads[0];
+    expect(updated?.status).toBe("done");
+    expect(updated?.unread).toBe(true);
+    expect(invoke).toHaveBeenCalledWith("notify", expect.objectContaining({ threadId: "thread-1000-1", kind: "done" }));
 
     cleanup();
   });

--- a/tests/desktop/sidebar-attention-badges.test.tsx
+++ b/tests/desktop/sidebar-attention-badges.test.tsx
@@ -1,0 +1,124 @@
+// @vitest-environment jsdom
+
+import React from "react";
+import * as Tooltip from "@radix-ui/react-tooltip";
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import Sidebar from "../../desktop/src/renderer/src/features/mission-control/Sidebar";
+import { useBoard } from "../../desktop/src/renderer/src/stores/board";
+import { useCodingAgentWorkspace } from "../../desktop/src/renderer/src/stores/coding-agent-workspace";
+import { useConnection } from "../../desktop/src/renderer/src/stores/connection";
+import { useTabs } from "../../desktop/src/renderer/src/stores/tabs";
+import { useThreads, type AgentThread } from "../../desktop/src/renderer/src/stores/threads";
+import { useUi } from "../../desktop/src/renderer/src/stores/ui";
+
+function kernelThread(id: string, overrides: Partial<AgentThread> = {}): AgentThread {
+  return {
+    id,
+    requestId: `request-${id}`,
+    sessionId: null,
+    taskId: null,
+    title: `Run ${id}`,
+    status: "running",
+    transcript: [],
+    unread: false,
+    createdAt: 1,
+    updatedAt: 1,
+    ...overrides,
+  };
+}
+
+function summaryWithAttention(count: number) {
+  return {
+    runtime: { id: "rt_primary", label: "Primary", status: "available" },
+    capabilities: [],
+    providers: [],
+    projects: { items: [], hasMore: false, limit: 20 },
+    activeThreads: { items: [], hasMore: false, limit: 20 },
+    attentionThreads: {
+      items: Array.from({ length: count }, (_, index) => ({
+        id: `thread_attention_${index}`,
+        providerId: "codex",
+        title: `Attention ${index}`,
+        status: "waiting_for_approval",
+        attention: "approval_required",
+        createdAt: "2026-07-06T00:00:00.000Z",
+        updatedAt: "2026-07-06T00:01:00.000Z",
+      })),
+      hasMore: false,
+      limit: 20,
+    },
+    terminalSessions: { items: [], hasMore: false, limit: 20 },
+    recentActivity: { items: [], hasMore: false, limit: 20 },
+    limits: {
+      maxPromptBytes: 16384,
+      maxAttachmentCount: 8,
+      maxTerminalInputBytes: 8192,
+      maxListItems: 20,
+    },
+    serverTime: "2026-07-06T00:03:00.000Z",
+  };
+}
+
+describe("Sidebar attention badges", () => {
+  beforeEach(() => {
+    useConnection.setState({
+      status: "signed-in",
+      handle: "operator",
+      displayName: null,
+      imageUrl: null,
+      platformHost: "https://platform.test",
+    });
+    useBoard.setState({ projects: [] });
+    useTabs.setState({ tabs: [], activeTabId: null });
+    useThreads.setState({ threads: [], activeThreadId: null });
+    useCodingAgentWorkspace.setState({ summary: null, activeThreadId: null });
+    useUi.setState({ sidebarCollapsed: false });
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("shows the kernel attention count on the Chat row", () => {
+    useThreads.setState({
+      threads: [
+        kernelThread("thread-1-1", { unread: true }),
+        kernelThread("thread-1-2", { status: "needs-attention" }),
+        kernelThread("thread-1-3"),
+      ],
+      activeThreadId: null,
+    });
+
+    render(
+      <Tooltip.Provider>
+        <Sidebar />
+      </Tooltip.Provider>,
+    );
+
+    expect(screen.getByRole("button", { name: /^Chat\s*2$/ })).toBeTruthy();
+  });
+
+  it("shows the coding-agent attention count on the Agents row", () => {
+    useCodingAgentWorkspace.setState({ summary: summaryWithAttention(3) });
+
+    render(
+      <Tooltip.Provider>
+        <Sidebar />
+      </Tooltip.Provider>,
+    );
+
+    expect(screen.getByRole("button", { name: /^Agents\s*3$/ })).toBeTruthy();
+  });
+
+  it("shows no badges when nothing needs attention", () => {
+    render(
+      <Tooltip.Provider>
+        <Sidebar />
+      </Tooltip.Provider>,
+    );
+
+    expect(screen.getByRole("button", { name: "Chat" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Agents" })).toBeTruthy();
+  });
+});

--- a/tests/desktop/unified-threads.test.ts
+++ b/tests/desktop/unified-threads.test.ts
@@ -1,0 +1,186 @@
+import { describe, expect, it } from "vitest";
+import type { AgentThreadSummary, RuntimeSummary } from "@matrix-os/contracts";
+import type { AgentThread } from "../../desktop/src/renderer/src/stores/threads";
+import {
+  codingAgentAttentionCount,
+  codingAgentThreadToUnified,
+  kernelThreadAttentionCount,
+  kernelThreadToUnified,
+  listUnifiedThreads,
+  routeThreadNotification,
+  UNIFIED_THREAD_STATUS_META,
+  unifiedAttentionCount,
+} from "../../desktop/src/renderer/src/stores/unified-threads";
+
+function kernelThread(overrides: Partial<AgentThread> = {}): AgentThread {
+  return {
+    id: "thread-1000-1",
+    requestId: "request-1",
+    sessionId: null,
+    taskId: null,
+    title: "Kernel run",
+    status: "running",
+    transcript: [],
+    unread: false,
+    createdAt: 1_000,
+    updatedAt: 1_000,
+    ...overrides,
+  };
+}
+
+function codingAgentThread(overrides: Partial<AgentThreadSummary> = {}): AgentThreadSummary {
+  return {
+    id: "thread_alpha",
+    providerId: "codex",
+    title: "Server run",
+    status: "running",
+    attention: "none",
+    createdAt: "2026-07-06T00:00:00.000Z",
+    updatedAt: "2026-07-06T00:01:00.000Z",
+    ...overrides,
+  };
+}
+
+function runtimeSummary(overrides: Partial<RuntimeSummary> = {}): RuntimeSummary {
+  return {
+    runtime: { id: "rt_primary", label: "Primary", status: "available" },
+    capabilities: [],
+    providers: [],
+    projects: { items: [], hasMore: false, limit: 20 },
+    activeThreads: { items: [], hasMore: false, limit: 20 },
+    attentionThreads: { items: [], hasMore: false, limit: 20 },
+    terminalSessions: { items: [], hasMore: false, limit: 20 },
+    recentActivity: { items: [], hasMore: false, limit: 20 },
+    limits: {
+      maxPromptBytes: 16384,
+      maxAttachmentCount: 8,
+      maxTerminalInputBytes: 8192,
+      maxListItems: 20,
+    },
+    serverTime: "2026-07-06T00:03:00.000Z",
+  } as RuntimeSummary;
+}
+
+describe("kernelThreadToUnified", () => {
+  it("keeps the kernel status vocabulary and epoch timestamps", () => {
+    const item = kernelThreadToUnified(kernelThread({ status: "needs-attention", unread: true, updatedAt: 42 }));
+    expect(item).toEqual({
+      source: "kernel",
+      id: "thread-1000-1",
+      title: "Kernel run",
+      status: "needs-attention",
+      unread: true,
+      updatedAt: 42,
+    });
+  });
+});
+
+describe("codingAgentThreadToUnified", () => {
+  it("maps actionable attention to needs-attention regardless of status", () => {
+    expect(codingAgentThreadToUnified(codingAgentThread({ status: "waiting_for_approval", attention: "approval_required" })).status).toBe("needs-attention");
+    expect(codingAgentThreadToUnified(codingAgentThread({ status: "waiting_for_input", attention: "input_required" })).status).toBe("needs-attention");
+  });
+
+  it("maps lifecycle statuses onto the unified vocabulary", () => {
+    expect(codingAgentThreadToUnified(codingAgentThread({ status: "queued" })).status).toBe("running");
+    expect(codingAgentThreadToUnified(codingAgentThread({ status: "starting" })).status).toBe("running");
+    expect(codingAgentThreadToUnified(codingAgentThread({ status: "running" })).status).toBe("running");
+    expect(codingAgentThreadToUnified(codingAgentThread({ status: "completed", attention: "completed" })).status).toBe("done");
+    expect(codingAgentThreadToUnified(codingAgentThread({ status: "failed", attention: "failed" })).status).toBe("failed");
+    expect(codingAgentThreadToUnified(codingAgentThread({ status: "aborted" })).status).toBe("aborted");
+    expect(codingAgentThreadToUnified(codingAgentThread({ status: "stale" })).status).toBe("aborted");
+    expect(codingAgentThreadToUnified(codingAgentThread({ status: "archived" })).status).toBe("aborted");
+  });
+
+  it("marks only actionable attention as unread and parses ISO timestamps", () => {
+    const actionable = codingAgentThreadToUnified(codingAgentThread({ attention: "approval_required", status: "waiting_for_approval" }));
+    expect(actionable.unread).toBe(true);
+    const finished = codingAgentThreadToUnified(codingAgentThread({ attention: "completed", status: "completed" }));
+    expect(finished.unread).toBe(false);
+    expect(actionable.updatedAt).toBe(Date.parse("2026-07-06T00:01:00.000Z"));
+  });
+});
+
+describe("listUnifiedThreads", () => {
+  it("merges kernel threads with active and attention coding-agent threads sorted by recency", () => {
+    const summary = runtimeSummary();
+    summary.activeThreads.items = [codingAgentThread({ id: "thread_old", updatedAt: "2026-07-06T00:00:30.000Z" })];
+    summary.attentionThreads.items = [
+      codingAgentThread({ id: "thread_hot", status: "waiting_for_approval", attention: "approval_required", updatedAt: "2026-07-06T00:02:00.000Z" }),
+    ];
+    const kernel = kernelThread({ id: "thread-1-1", updatedAt: Date.parse("2026-07-06T00:01:00.000Z") });
+
+    const items = listUnifiedThreads([kernel], summary);
+
+    expect(items.map((item) => item.id)).toEqual(["thread_hot", "thread-1-1", "thread_old"]);
+    expect(items.map((item) => item.source)).toEqual(["coding-agent", "kernel", "coding-agent"]);
+  });
+
+  it("dedupes threads present in both active and attention lists preferring the attention entry", () => {
+    const summary = runtimeSummary();
+    summary.activeThreads.items = [codingAgentThread({ id: "thread_dup", status: "running", attention: "none" })];
+    summary.attentionThreads.items = [
+      codingAgentThread({ id: "thread_dup", status: "waiting_for_input", attention: "input_required" }),
+    ];
+
+    const items = listUnifiedThreads([], summary);
+
+    expect(items).toHaveLength(1);
+    expect(items[0]?.status).toBe("needs-attention");
+  });
+
+  it("returns only kernel threads when there is no runtime summary", () => {
+    const items = listUnifiedThreads([kernelThread()], null);
+    expect(items).toHaveLength(1);
+    expect(items[0]?.source).toBe("kernel");
+  });
+});
+
+describe("attention counts", () => {
+  it("counts kernel unread and needs-attention threads", () => {
+    const threads = [
+      kernelThread({ id: "a", unread: true }),
+      kernelThread({ id: "b", status: "needs-attention" }),
+      kernelThread({ id: "c" }),
+    ];
+    expect(kernelThreadAttentionCount(threads)).toBe(2);
+  });
+
+  it("counts coding-agent attention threads with the truncation cap", () => {
+    const summary = runtimeSummary();
+    summary.attentionThreads.items = [codingAgentThread({ id: "thread_a" }), codingAgentThread({ id: "thread_b" })];
+    expect(codingAgentAttentionCount(summary)).toBe(2);
+    summary.attentionThreads.hasMore = true;
+    expect(codingAgentAttentionCount(summary)).toBe(999);
+    expect(codingAgentAttentionCount(null)).toBe(0);
+  });
+
+  it("sums both systems in the unified count", () => {
+    const summary = runtimeSummary();
+    summary.attentionThreads.items = [codingAgentThread({ id: "thread_a" })];
+    expect(unifiedAttentionCount([kernelThread({ unread: true })], summary)).toBe(2);
+  });
+});
+
+describe("routeThreadNotification", () => {
+  it("routes ids present in the kernel store to the chat surface", () => {
+    expect(routeThreadNotification("thread-1000-1", ["thread-1000-1"])).toEqual({ target: "chat", select: "thread-1000-1" });
+  });
+
+  it("routes server-namespace ids to the coding-agent surface", () => {
+    expect(routeThreadNotification("thread_alpha", [])).toEqual({ target: "coding-agent", select: "thread_alpha" });
+  });
+
+  it("routes stale kernel-format ids to chat without a selection", () => {
+    expect(routeThreadNotification("thread-999-9", [])).toEqual({ target: "chat", select: null });
+  });
+});
+
+describe("UNIFIED_THREAD_STATUS_META", () => {
+  it("defines a label and color for every unified status", () => {
+    for (const status of ["running", "needs-attention", "done", "failed", "aborted"] as const) {
+      expect(UNIFIED_THREAD_STATUS_META[status].label.length).toBeGreaterThan(0);
+      expect(UNIFIED_THREAD_STATUS_META[status].color).toMatch(/^var\(--/);
+    }
+  });
+});

--- a/tests/desktop/unified-threads.test.ts
+++ b/tests/desktop/unified-threads.test.ts
@@ -155,6 +155,16 @@ describe("attention counts", () => {
     expect(codingAgentAttentionCount(null)).toBe(0);
   });
 
+  it("ignores the truncation sentinel when the attention list is empty", () => {
+    // Client-side promotion eviction can leave hasMore set after every listed
+    // thread demotes; the server never returns hasMore with an empty page, so
+    // an empty list always counts as zero.
+    const summary = runtimeSummary();
+    summary.attentionThreads.items = [];
+    summary.attentionThreads.hasMore = true;
+    expect(codingAgentAttentionCount(summary)).toBe(0);
+  });
+
   it("sums both systems in the unified count", () => {
     const summary = runtimeSummary();
     summary.attentionThreads.items = [codingAgentThread({ id: "thread_a" })];

--- a/tests/e2e/desktop/operator.e2e.test.ts
+++ b/tests/e2e/desktop/operator.e2e.test.ts
@@ -247,4 +247,22 @@ suite("operator desktop e2e", () => {
     await page.waitForFunction(() => document.documentElement.getAttribute("data-theme-id") === "operator");
     await page.screenshot({ path: join(SCREENSHOT_DIR, "16-theme-operator-default.png") });
   }, 40_000);
+
+  it("lists coding-agent threads in the unified chat rail and routes selection to Agents", async () => {
+    // The earlier computer switch cleared the workspace summary; opening the
+    // Agents workspace refreshes it before the rail is inspected.
+    await page.locator("aside button", { hasText: "Agents" }).first().click();
+    await page.getByRole("button", { name: "New chat in Matrix OS" }).waitFor({ timeout: 10_000 });
+    await page.locator("aside button", { hasText: "Chat" }).first().click();
+    // The rail lists the server-backed run alongside Hermes under "Agent runs".
+    await page.getByText("Agent runs").waitFor({ timeout: 10_000 });
+    const railItem = page.getByRole("button", { name: "fix the failing auth tests" }).first();
+    await railItem.waitFor({ timeout: 10_000 });
+    await page.screenshot({ path: join(SCREENSHOT_DIR, "17-chat-unified-rail.png") });
+
+    // Selecting a coding-agent thread routes to its canonical workspace surface.
+    await railItem.click();
+    await page.getByRole("button", { name: "New chat in Matrix OS" }).waitFor({ timeout: 10_000 });
+    await page.screenshot({ path: join(SCREENSHOT_DIR, "18-chat-rail-routes-to-agents.png") });
+  }, 30_000);
 });


### PR DESCRIPTION
## Summary

Phase 1c of the desktop agent-workspace track: one **UI thread model** over the two thread backends (local kernel-WS agent runs in `stores/threads.ts`, server-backed coding-agent threads from the `runtime:*` bridge), which stay distinct backends. Design doc: `specs/105-coding-agent-shells/desktop-thread-unification.md`.

- **New `stores/unified-threads.ts`** (pure derivation, no state): unified rail item type, status mapping (`waiting_for_approval`/`waiting_for_input` → `needs-attention`, `queued`/`starting` → `running`, etc.), one recency-sorted `listUnifiedThreads`, the single home for attention/badge counts, shared status→label/color meta, and a pure `routeThreadNotification` decision.
- **ChatTab rail lists both systems** under "Agent runs": kernel runs keep the in-pane `ThreadView`; selecting a coding-agent thread loads its snapshot and opens the Agents workspace (transcripts/approvals stay on their canonical surface).
- **Three cross-wiring bug fixes** in `kernel-wiring.ts`:
  - The kernel-thread focus gate keyed on the removed standalone `"agents"` tab; watching a running thread in Chat still marked it unread and raised a native notification. It now keys on the `"chat"` tab where `ThreadView` actually renders.
  - `notification:clicked` wrote the same id into **both** stores and always opened the Agents workspace — kernel-thread notifications landed on the wrong surface with a foreign id in the coding-agent store. Now routed per source; stale kernel-format ids open Chat with no selection instead of feeding the snapshot loader.
  - Badge math deduplicated into the shared helpers (byte-identical totals).
- **#998 fixed**: `reconcileSummaryThread` now promotes a thread into `attentionThreads` when a live event raises attention from `"none"` (head insert, limit enforced, `hasMore` set on eviction). Closes #998.
- **Sidebar badges**: the dead `unread` selector becomes rendered NavRow badges — Chat shows the kernel attention count, Agents the coding-agent attention count.

## Screenshots

Captured by the extended desktop e2e (`operator.e2e.test.ts`, "lists coding-agent threads in the unified chat rail and routes selection to Agents") against the stub gateway — regenerate with `pnpm --filter desktop run build && pnpm exec vitest run tests/e2e/desktop/operator.e2e.test.ts`:

- `desktop/screenshots/17-chat-unified-rail.png` — Chat rail listing Hermes plus a server-backed run under "Agent runs" with its status dot
- `desktop/screenshots/18-chat-rail-routes-to-agents.png` — selecting that run lands in the Agents workspace with the thread active

## Validation

- `pnpm exec vitest run` on the 9 touched/related desktop suites — green (new: `unified-threads`, `coding-agent-thread-model`, `sidebar-attention-badges`; extended: `kernel-wiring`, `chat-tab-render`)
- `bun run test` — green except the two pre-existing `qmd` env failures (global `qmd` CLI native module vs local Node ABI; fails identically on the parent branch)
- `bun run typecheck`, `bun run check:patterns` (0 violations; warnings are pre-existing gateway/platform paths) — green
- `npx react-doctor@latest desktop` — no findings in any changed file
- Desktop e2e `operator.e2e.test.ts` — 9/9 including the new rail step

## Invariants

- **Source of truth**: kernel threads — `useThreads` (renderer-local, reset on runtime switch); coding-agent threads — gateway projections via `runtime:*` IPC reconciled by summary refresh. `unified-threads.ts` derives and never stores, so it cannot diverge.
- **Lock/transaction scope**: no network calls added; the only async path touched (`loadThreadSnapshot` on notification/rail selection) is the store's existing sequenced loader.
- **Acceptable orphan states**: a notification for a vanished thread opens Chat with no selection (kernel-format id) or the workspace's safe "Thread state unavailable" error (server-format id); an attention promotion that evicts under the server limit marks `hasMore` and is restored by the next full summary refresh.
- **Auth source of truth**: unchanged — all coding-agent traffic stays on the existing authenticated `runtime:*` IPC bridge.
- **Deferred scope**: rendering coding-agent transcripts/approvals inside ChatTab (canonical surface remains the Agents workspace); merging `hermes-chat.ts` (a single continuous conversation, not a thread list); any gateway/contract change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



## Review notes

- Round-2 Greptile suggested restricting the reconcileSummaryThread promotion to approval_required/input_required. The gateway's own inclusion rule (`attentionThread` in `packages/gateway/src/coding-agents/thread-store.ts`: `attention !== "none" && status !== "archived"`) includes completed and failed attention, so the client promotion mirrors that predicate exactly — restricting it would make the local list diverge from the next summary refresh. The real gap (archived threads) is fixed with a regression test.
