### PR TITLE
feat(desktop): render agent conversations as a real chat transcript

### DIFF
--- a/desktop/src/renderer/src/features/chat/elements/prompt-input.tsx
+++ b/desktop/src/renderer/src/features/chat/elements/prompt-input.tsx
@@ -10,7 +10,9 @@ export function PromptInput({
   onAbort,
   busy,
   autoFocus,
+  disabled = false,
   placeholder = "Do anything",
+  ariaLabel,
   footer,
 }: {
   value: string;
@@ -19,7 +21,9 @@ export function PromptInput({
   onAbort?: () => void;
   busy: boolean;
   autoFocus?: boolean;
+  disabled?: boolean;
   placeholder?: string;
+  ariaLabel?: string;
   footer?: ReactNode;
 }) {
   const ref = useRef<HTMLTextAreaElement>(null);
@@ -39,12 +43,13 @@ export function PromptInput({
       <textarea
         ref={ref}
         autoFocus={autoFocus}
+        disabled={disabled}
         value={value}
         onChange={(e) => onChange(e.target.value)}
         placeholder={placeholder}
-        aria-label={placeholder}
+        aria-label={ariaLabel ?? placeholder}
         rows={1}
-        className="w-full resize-none bg-transparent px-4 pt-3.5 text-md outline-none"
+        className="w-full resize-none bg-transparent px-4 pt-3.5 text-md outline-none disabled:opacity-60"
         style={{ color: "var(--text-primary)", maxHeight: 220 }}
         onKeyDown={(e) => {
           if (e.key === "Enter" && !e.shiftKey) {
@@ -82,7 +87,7 @@ export function PromptInput({
             <button
               type="button"
               aria-label="Send"
-              disabled={value.trim().length === 0}
+              disabled={disabled || value.trim().length === 0}
               onClick={onSubmit}
               className="flex h-8 w-8 items-center justify-center rounded-full transition-colors disabled:opacity-40"
               style={{ background: value.trim().length ? "var(--accent)" : "var(--bg-active)", color: value.trim().length ? "var(--text-on-accent)" : "var(--text-tertiary)" }}

--- a/desktop/src/renderer/src/features/chat/elements/prompt-input.tsx
+++ b/desktop/src/renderer/src/features/chat/elements/prompt-input.tsx
@@ -11,6 +11,7 @@ export function PromptInput({
   busy,
   autoFocus,
   disabled = false,
+  maxLength,
   placeholder = "Do anything",
   ariaLabel,
   footer,
@@ -22,6 +23,7 @@ export function PromptInput({
   busy: boolean;
   autoFocus?: boolean;
   disabled?: boolean;
+  maxLength?: number;
   placeholder?: string;
   ariaLabel?: string;
   footer?: ReactNode;
@@ -44,6 +46,7 @@ export function PromptInput({
         ref={ref}
         autoFocus={autoFocus}
         disabled={disabled}
+        maxLength={maxLength}
         value={value}
         onChange={(e) => onChange(e.target.value)}
         placeholder={placeholder}

--- a/desktop/src/renderer/src/features/coding-agents/AgentConversationView.tsx
+++ b/desktop/src/renderer/src/features/coding-agents/AgentConversationView.tsx
@@ -436,6 +436,9 @@ function ConversationComposer({ threadId, waitingForAction }: { threadId: string
           onSubmit={() => void submit()}
           busy={submitting}
           disabled={waitingForAction || submitting}
+          // Matches the CreateAgentTurnRequestSchema message cap so oversized
+          // drafts are prevented client-side instead of failing generically.
+          maxLength={24_000}
           ariaLabel="Message conversation"
           placeholder={waitingForAction ? "Respond to the pending request above to continue" : "Ask a follow-up…"}
         />

--- a/desktop/src/renderer/src/features/coding-agents/AgentConversationView.tsx
+++ b/desktop/src/renderer/src/features/coding-agents/AgentConversationView.tsx
@@ -431,7 +431,6 @@ function ConversationComposer({ threadId, waitingForAction }: { threadId: string
           <p className="mb-1 px-1 text-xs" style={{ color: "var(--danger)" }}>{turnError}</p>
         ) : null}
         <PromptInput
-          key={threadId}
           value={message}
           onChange={setMessage}
           onSubmit={() => void submit()}
@@ -489,7 +488,7 @@ export function AgentConversationView({
         </div>
         {snapshot.thread.attention !== "none" ? <span className="rounded-full px-2 py-1 text-[10px] font-semibold capitalize" style={{ background: "var(--warning-muted)", color: "var(--warning)" }}>{snapshot.thread.attention.replaceAll("_", " ")}</span> : null}
       </header>
-      <Conversation>
+      <Conversation key={`transcript:${snapshot.thread.id}`}>
         <ConversationContent>
           {items.map((item) =>
             item.kind === "assistant" ? <AssistantRow key={item.key} events={item.events} />
@@ -509,6 +508,7 @@ export function AgentConversationView({
         // input answer, so the composer is disabled rather than offering a
         // doomed send.
         <ConversationComposer
+          key={`composer:${snapshot.thread.id}`}
           threadId={snapshot.thread.id}
           waitingForAction={snapshot.thread.status === "waiting_for_approval" || snapshot.thread.status === "waiting_for_input"}
         />

--- a/desktop/src/renderer/src/features/coding-agents/AgentConversationView.tsx
+++ b/desktop/src/renderer/src/features/coding-agents/AgentConversationView.tsx
@@ -101,11 +101,13 @@ function assistantText(events: AssistantEvent[]): { text: string; completed: boo
     (event): event is Extract<AssistantEvent, { type: "assistant.text.delta" }> => event.type === "assistant.text.delta",
   );
   const completed = events.some((event) => event.type === "assistant.text.completed");
-  let text = deltas.map((event) => event.delta).join("");
+  // Redact BEFORE the defensive tail slice: truncation can sever a credential
+  // prefix (e.g. password=) while its value survives in the retained tail.
+  let text = redactCredentialsForDisplay(deltas.map((event) => event.delta).join(""));
   if (text.length > ASSISTANT_RENDER_MAX_CHARS) {
     text = `_Earlier content truncated._\n\n${text.slice(text.length - ASSISTANT_RENDER_MAX_CHARS)}`;
   }
-  return { text: redactCredentialsForDisplay(text), completed };
+  return { text, completed };
 }
 
 function occurredAtLabel(occurredAt: string): string {
@@ -501,7 +503,7 @@ export function AgentConversationView({
           {showWorking ? <WorkingRow /> : null}
           {items.length === 0 && !showWorking ? (
             <p className="py-12 text-center text-sm" style={{ color: "var(--text-tertiary)" }}>
-              Send a message to start the conversation.
+              {canSendTurns ? "Send a message to start the conversation." : "No messages yet."}
             </p>
           ) : null}
         </ConversationContent>

--- a/desktop/src/renderer/src/features/coding-agents/AgentConversationView.tsx
+++ b/desktop/src/renderer/src/features/coding-agents/AgentConversationView.tsx
@@ -1,17 +1,29 @@
+import type { AgentThreadEvent, AgentThreadSnapshot } from "@matrix-os/contracts";
 import {
-  SafeAssistantPreviewSourceTextSchema,
-  SafeAssistantPreviewTextSchema,
-  type AgentThreadEvent,
-  type AgentThreadSnapshot,
-} from "@matrix-os/contracts";
-import { Bot, GitPullRequest, Send, UserRound, Wrench } from "lucide-react";
-import { useEffect, useMemo, useRef, useState } from "react";
+  Check,
+  Copy,
+  Eye,
+  GitPullRequest,
+  Minus,
+  SquarePen,
+  SquareTerminal,
+  Wrench,
+  X,
+} from "lucide-react";
+import ReactMarkdown from "react-markdown";
+import rehypeHighlight from "rehype-highlight";
+import remarkGfm from "remark-gfm";
+import { useMemo, useState } from "react";
 import { Button } from "../../design/primitives";
+import { redactCredentialsForDisplay } from "../../lib/transcript-redaction";
 import {
   codingAgentApprovalActionKey,
   codingAgentInputActionKey,
   useCodingAgentWorkspace,
 } from "../../stores/coding-agent-workspace";
+import { safeUrlTransform } from "../editor/MarkdownPreview";
+import { Conversation, ConversationContent } from "../chat/elements/conversation";
+import { PromptInput } from "../chat/elements/prompt-input";
 
 type ConversationStatus = "idle" | "loading" | "ready" | "error";
 type AssistantEvent = Extract<AgentThreadEvent, { type: "assistant.text.delta" | "assistant.text.completed" }>;
@@ -20,8 +32,21 @@ type ConversationItem =
   | { kind: "assistant"; key: string; events: AssistantEvent[]; order: number }
   | { kind: "tool"; key: string; events: ToolEvent[]; order: number }
   | { kind: "event"; event: AgentThreadEvent; order: number };
+type TimelineItem =
+  | Exclude<ConversationItem, { kind: "tool" }>
+  | { kind: "tool-run"; key: string; runs: Array<Extract<ConversationItem, { kind: "tool" }>>; order: number };
 
-const PREVIEW_MAX_CHARS = 240;
+// Defensive ceiling for one rendered message; each delta is already bounded by
+// the event schema (4,000 chars / 16KB), so this only guards runaway joins.
+const ASSISTANT_RENDER_MAX_CHARS = 64_000;
+const COLLAPSED_USER_MAX_CHARS = 600;
+const COLLAPSED_USER_MAX_LINES = 8;
+// Consecutive tool chips beyond this collapse behind a "+N earlier" toggle.
+const TOOL_RUN_COLLAPSE_THRESHOLD = 5;
+const TOOL_RUN_VISIBLE_TAIL = 3;
+
+const TRANSCRIPT_MARKDOWN_CLASS =
+  "prose-sm max-w-none text-sm leading-relaxed [&_a]:text-[var(--highlight)] [&_blockquote]:border-l-2 [&_blockquote]:border-[var(--border-default)] [&_blockquote]:pl-3 [&_blockquote]:text-[var(--text-secondary)] [&_code]:rounded [&_code]:bg-[var(--bg-sunken)] [&_code]:px-1 [&_code]:py-0.5 [&_code]:font-mono [&_code]:text-[12px] [&_h1]:mt-4 [&_h1]:mb-2 [&_h1]:text-lg [&_h1]:font-semibold [&_h2]:mt-3 [&_h2]:mb-1.5 [&_h2]:text-md [&_h2]:font-semibold [&_h3]:mt-3 [&_h3]:mb-1 [&_h3]:font-semibold [&_hr]:my-4 [&_hr]:border-[var(--border-subtle)] [&_li]:my-0.5 [&_ol]:list-decimal [&_ol]:pl-5 [&_p]:my-2 [&_pre]:overflow-x-auto [&_pre]:rounded-lg [&_pre]:border [&_pre]:border-[var(--border-subtle)] [&_pre]:bg-[var(--bg-sunken)] [&_pre]:p-3 [&_pre_code]:bg-transparent [&_table]:my-3 [&_table]:w-full [&_table]:border-collapse [&_td]:border [&_td]:border-[var(--border-subtle)] [&_td]:px-2 [&_td]:py-1 [&_th]:border [&_th]:border-[var(--border-subtle)] [&_th]:bg-[var(--bg-sunken)] [&_th]:px-2 [&_th]:py-1 [&_th]:text-left [&_ul]:list-disc [&_ul]:pl-5";
 
 function conversationItems(events: AgentThreadEvent[]): ConversationItem[] {
   const assistants = new Map<string, AssistantEvent[]>();
@@ -53,109 +78,245 @@ function conversationItems(events: AgentThreadEvent[]): ConversationItem[] {
   return items.sort((left, right) => left.order - right.order);
 }
 
-function assistantCopy(events: AssistantEvent[]) {
+/** Batches consecutive tool items into one run so long runs can collapse. */
+function timelineItems(items: ConversationItem[]): TimelineItem[] {
+  const timeline: TimelineItem[] = [];
+  for (const item of items) {
+    if (item.kind !== "tool") {
+      timeline.push(item);
+      continue;
+    }
+    const previous = timeline.at(-1);
+    if (previous?.kind === "tool-run") {
+      previous.runs.push(item);
+      continue;
+    }
+    timeline.push({ kind: "tool-run", key: `run:${item.key}`, runs: [item], order: item.order });
+  }
+  return timeline;
+}
+
+function assistantText(events: AssistantEvent[]): { text: string; completed: boolean } {
   const deltas = events.filter(
     (event): event is Extract<AssistantEvent, { type: "assistant.text.delta" }> => event.type === "assistant.text.delta",
   );
   const completed = events.some((event) => event.type === "assistant.text.completed");
-  const source = deltas.map((event) => event.delta).join("").trim();
-  const safeSource = source && SafeAssistantPreviewSourceTextSchema.safeParse(source).success ? source : null;
-  const previewCandidate = safeSource && safeSource.length > PREVIEW_MAX_CHARS
-    ? `${safeSource.slice(0, PREVIEW_MAX_CHARS).trimEnd()}...`
-    : safeSource;
-  const preview = previewCandidate && SafeAssistantPreviewTextSchema.safeParse(previewCandidate).success
-    ? previewCandidate
-    : null;
-  const updates = `${deltas.length} ${deltas.length === 1 ? "text update" : "text updates"} received`;
-  const status = completed ? `${updates}, complete` : updates;
-  return {
-    title: completed ? "Assistant message" : deltas.length === 1 ? "Assistant update" : "Assistant updates",
-    status,
-    preview,
-    displayText: safeSource && safeSource.length <= PREVIEW_MAX_CHARS ? safeSource : preview,
-  };
+  let text = deltas.map((event) => event.delta).join("");
+  if (text.length > ASSISTANT_RENDER_MAX_CHARS) {
+    text = `_Earlier content truncated._\n\n${text.slice(text.length - ASSISTANT_RENDER_MAX_CHARS)}`;
+  }
+  return { text: redactCredentialsForDisplay(text), completed };
 }
 
-function AssistantBubble({ events }: { events: AssistantEvent[] }) {
-  const copy = assistantCopy(events);
+function occurredAtLabel(occurredAt: string): string {
+  const parsed = new Date(occurredAt);
+  return Number.isNaN(parsed.getTime())
+    ? ""
+    : parsed.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
+}
+
+function copyText(text: string): void {
+  const clipboard = navigator.clipboard;
+  if (!clipboard?.writeText) return;
+  clipboard.writeText(text).catch((err: unknown) => {
+    console.warn("[coding-agents] copy failed:", err instanceof Error ? err.message : String(err));
+  });
+}
+
+function CopyButton({ text, label }: { text: string; label: string }) {
+  const [copied, setCopied] = useState(false);
   return (
-    <div className="flex max-w-[min(760px,92%)] items-start gap-2">
-      <span className="mt-1 flex h-7 w-7 shrink-0 items-center justify-center rounded-full" style={{ background: "var(--accent-muted)", color: "var(--accent)" }}>
-        <Bot size={15} aria-hidden="true" />
-      </span>
-      <article className="min-w-0 rounded-2xl rounded-tl-md border px-4 py-3" style={{ borderColor: "var(--border-subtle)", background: "var(--bg-surface)" }}>
-        <div className="flex flex-wrap items-center gap-x-3 gap-y-1">
-          <h3 className="text-xs font-semibold" style={{ color: "var(--text-primary)" }}>{copy.title}</h3>
-          <span className="text-[10px]" style={{ color: "var(--text-tertiary)" }}>{events[0]?.occurredAt}</span>
-        </div>
-        {copy.displayText ? <p className="sr-only">{copy.preview ? `${copy.status}. ${copy.preview}` : copy.status}</p> : null}
-        {copy.displayText ? (
-          <p className="mt-1 whitespace-pre-wrap break-words text-sm leading-6" style={{ color: "var(--text-primary)" }}>
-            {copy.displayText}
-          </p>
-        ) : (
-          <p className="mt-1 text-xs" style={{ color: "var(--text-secondary)" }}>{copy.status}</p>
-        )}
-      </article>
+    <button
+      type="button"
+      aria-label={label}
+      className="flex h-6 w-6 items-center justify-center rounded hover:bg-[var(--bg-hover)]"
+      style={{ color: "var(--text-tertiary)" }}
+      onClick={() => {
+        copyText(text);
+        setCopied(true);
+        window.setTimeout(() => setCopied(false), 1200);
+      }}
+    >
+      {copied ? <Check size={12} /> : <Copy size={12} />}
+    </button>
+  );
+}
+
+// Assistant messages render full-width markdown — no bubble — with a
+// hover-revealed meta row, matching the reference chat anatomy.
+function AssistantRow({ events }: { events: AssistantEvent[] }) {
+  const { text, completed } = useMemo(() => assistantText(events), [events]);
+  if (!text) {
+    return completed ? (
+      <p className="text-xs" style={{ color: "var(--text-tertiary)" }}>(empty response)</p>
+    ) : null;
+  }
+  return (
+    <div className="group/assistant flex min-w-0 flex-col">
+      <div className={TRANSCRIPT_MARKDOWN_CLASS} style={{ color: "var(--text-primary)" }} data-selectable>
+        <ReactMarkdown
+          remarkPlugins={[remarkGfm]}
+          rehypePlugins={[[rehypeHighlight, { ignoreMissing: true }]]}
+          urlTransform={safeUrlTransform}
+        >
+          {text}
+        </ReactMarkdown>
+      </div>
+      <div className="mt-1 flex items-center gap-2 opacity-0 transition-opacity group-hover/assistant:opacity-100">
+        <CopyButton text={text} label="Copy assistant message" />
+        <span className="text-[10px] tabular-nums" style={{ color: "var(--text-tertiary)" }}>
+          {occurredAtLabel(events[0]?.occurredAt ?? "")}
+        </span>
+      </div>
     </div>
   );
 }
 
-function UserBubble({ event }: { event: Extract<AgentThreadEvent, { type: "user.message" }> }) {
-  return (
-    <div className="ml-auto flex max-w-[min(720px,88%)] flex-row-reverse items-start gap-2">
-      <span className="mt-1 flex h-7 w-7 shrink-0 items-center justify-center rounded-full" style={{ background: "var(--bg-tertiary)", color: "var(--text-secondary)" }}>
-        <UserRound size={14} aria-hidden="true" />
-      </span>
-      <article className="min-w-0 rounded-2xl rounded-tr-md px-4 py-3" style={{ background: "var(--accent-muted)" }}>
-        <div className="flex flex-wrap items-center justify-end gap-x-3 gap-y-1">
-          <span className="text-[10px]" style={{ color: "var(--text-tertiary)" }}>{event.occurredAt}</span>
-          <h3 className="text-xs font-semibold" style={{ color: "var(--text-primary)" }}>You</h3>
-        </div>
-        <p className="mt-1 whitespace-pre-wrap break-words text-sm leading-6" style={{ color: "var(--text-primary)" }}>{event.text}</p>
-      </article>
-    </div>
-  );
-}
-
-function ToolActivity({ events }: { events: ToolEvent[] }) {
+function UserRow({ event }: { event: Extract<AgentThreadEvent, { type: "user.message" }> }) {
   const [expanded, setExpanded] = useState(false);
+  const lines = event.text.split("\n").length;
+  const collapsible = event.text.length > COLLAPSED_USER_MAX_CHARS || lines > COLLAPSED_USER_MAX_LINES;
+  return (
+    <div className="group/user flex flex-col items-end gap-1">
+      <div
+        className="relative max-w-[80%] overflow-hidden rounded-2xl rounded-br-md border px-3.5 py-2 text-sm whitespace-pre-wrap"
+        style={{
+          borderColor: "var(--border-subtle)",
+          background: "var(--bg-sunken)",
+          color: "var(--text-primary)",
+          ...(collapsible && !expanded
+            ? { maxHeight: 176, maskImage: "linear-gradient(to bottom, black 60%, transparent 100%)" }
+            : {}),
+        }}
+        data-selectable
+      >
+        {event.text}
+      </div>
+      <div className="flex max-w-[80%] items-center gap-2">
+        {collapsible ? (
+          <button
+            type="button"
+            className="text-[11px]"
+            style={{ color: "var(--text-tertiary)" }}
+            onClick={() => setExpanded((value) => !value)}
+          >
+            {expanded ? "Show less" : "Show full message"}
+          </button>
+        ) : null}
+        <span className="flex items-center gap-1 opacity-0 transition-opacity group-hover/user:opacity-100">
+          <CopyButton text={event.text} label="Copy your message" />
+          <span className="text-[10px] tabular-nums" style={{ color: "var(--text-tertiary)" }}>
+            {occurredAtLabel(event.occurredAt)}
+          </span>
+        </span>
+      </div>
+    </div>
+  );
+}
+
+function toolKindIcon(displayName: string) {
+  if (/shell|command|terminal|bash|exec|run/i.test(displayName)) return SquareTerminal;
+  if (/write|edit|apply|patch|create/i.test(displayName)) return SquarePen;
+  if (/read|view|open|list|search|glob|grep/i.test(displayName)) return Eye;
+  return Wrench;
+}
+
+// A tool call renders as a one-line chip: kind icon, heading, muted preview,
+// and a trailing status glyph. Expansion reveals the same bounded detail copy
+// the old cards showed — no raw payloads.
+function ToolChip({ events }: { events: ToolEvent[] }) {
+  const [open, setOpen] = useState(false);
   const started = events.find((event): event is Extract<ToolEvent, { type: "tool.started" }> => event.type === "tool.started");
   const outputs = events.filter((event): event is Extract<ToolEvent, { type: "tool.output" }> => event.type === "tool.output");
   const completed = events.find((event): event is Extract<ToolEvent, { type: "tool.completed" }> => event.type === "tool.completed");
   const name = started?.displayName ?? "Tool";
-  const outcome = completed?.outcome === "success" ? "successfully"
-    : completed?.outcome === "failed" ? "with errors"
-      : completed?.outcome === "cancelled" ? "cancelled"
-        : "";
+  const failed = completed?.outcome === "failed";
   const detail = completed
-    ? `${name} completed ${outcome}${outputs.length ? outputs.some((event) => event.truncated) ? " after receiving partial output" : " after receiving output" : " without captured output"}`
+    ? `${name} completed ${completed.outcome === "success" ? "successfully" : completed.outcome === "failed" ? "with errors" : "cancelled"}${outputs.length ? (outputs.some((event) => event.truncated) ? " after receiving partial output" : " after receiving output") : " without captured output"}`
     : `${name} running${outputs.length ? " with output received" : ""}`;
+  const KindIcon = toolKindIcon(name);
+  const StatusIcon = completed ? (failed ? X : Check) : Minus;
   return (
-    <div className="mx-auto w-full max-w-[760px] rounded-lg border px-3 py-2" style={{ borderColor: "var(--border-subtle)", background: "var(--bg-overlay)" }}>
-      <div className="flex items-start gap-2">
-        <Wrench size={14} className="mt-0.5 shrink-0" style={{ color: "var(--text-tertiary)" }} />
-        <div className="min-w-0 flex-1">
-          <div className="flex items-center justify-between gap-3">
-            <h3 className="text-xs font-semibold" style={{ color: "var(--text-primary)" }}>Tool activity</h3>
-            <span className="text-[10px]" style={{ color: "var(--text-tertiary)" }}>{events[0]?.occurredAt}</span>
-          </div>
-          <p className="mt-0.5 text-xs" style={{ color: "var(--text-secondary)" }}>{detail}</p>
-          <p className="mt-1 text-[11px] font-medium" style={{ color: "var(--text-tertiary)" }}>
-            {outputs.length} {outputs.length === 1 ? "output" : "outputs"}
-          </p>
-          <button type="button" className="mt-1 text-[11px] font-medium" style={{ color: "var(--accent)" }} aria-label={`${expanded ? "Collapse" : "Expand"} tool activity Tool activity`} onClick={() => setExpanded((value) => !value)}>
-            {expanded ? "Hide details" : "Show details"}
-          </button>
-          {expanded ? (
-            <div className="mt-2 grid gap-1 text-xs" style={{ color: "var(--text-secondary)" }}>
-              {started ? <div><p>Started {started.kind}</p><p>Tool run started</p></div> : null}
-              {outputs.map((output, index) => <div key={output.eventId}><p>Output {index + 1}</p><p>{output.truncated ? "Output received, partial" : "Output received"}</p></div>)}
-              {completed ? <div><p>Completed</p><p>{completed.outcome === "success" ? "Completed successfully" : completed.outcome === "failed" ? "Failed" : "Cancelled"}</p></div> : null}
-            </div>
-          ) : null}
+    <div className="flex min-w-0 flex-col">
+      <button
+        type="button"
+        className="flex w-full items-center gap-2 rounded-md px-1 py-0.5 text-left hover:bg-[var(--bg-hover)]"
+        aria-label={`Tool call ${name}`}
+        aria-expanded={open}
+        onClick={() => setOpen((value) => !value)}
+      >
+        <KindIcon size={14} className="shrink-0" style={{ color: "var(--text-tertiary)" }} />
+        <span
+          className="min-w-0 shrink truncate text-[12px] font-medium"
+          style={{ color: failed ? "var(--danger)" : "var(--text-primary)" }}
+        >
+          {name}
+        </span>
+        <span className="min-w-0 flex-1 truncate text-[12px]" style={{ color: "var(--text-tertiary)" }}>
+          {detail}
+        </span>
+        <StatusIcon
+          size={13}
+          className="shrink-0"
+          style={{ color: failed ? "var(--danger)" : completed ? "var(--success)" : "var(--text-tertiary)" }}
+          aria-label={completed ? (failed ? "Failed" : "Completed") : "Running"}
+        />
+      </button>
+      {open ? (
+        <div className="mt-1 ml-7 border-l pl-3" style={{ borderColor: "var(--border-subtle)" }}>
+          <pre className="max-h-64 overflow-auto font-mono text-[11px] leading-relaxed whitespace-pre-wrap" style={{ color: "var(--text-secondary)" }} data-selectable>
+            {detail}
+            {outputs.some((event) => event.truncated) ? "\nOutput was truncated for display." : ""}
+          </pre>
         </div>
-      </div>
+      ) : null}
+    </div>
+  );
+}
+
+function ToolRun({ runs }: { runs: Array<Extract<ConversationItem, { kind: "tool" }>> }) {
+  const [showAll, setShowAll] = useState(false);
+  const collapsed = !showAll && runs.length > TOOL_RUN_COLLAPSE_THRESHOLD;
+  const visible = collapsed ? runs.slice(runs.length - TOOL_RUN_VISIBLE_TAIL) : runs;
+  const hiddenCount = runs.length - visible.length;
+  return (
+    <section aria-label={`${runs.length} tool ${runs.length === 1 ? "call" : "calls"}`} className="flex flex-col gap-0.5">
+      {collapsed ? (
+        <button
+          type="button"
+          className="self-start rounded-md px-1 py-0.5 text-[11px] hover:bg-[var(--bg-hover)]"
+          style={{ color: "var(--text-tertiary)" }}
+          onClick={() => setShowAll(true)}
+        >
+          +{hiddenCount} earlier tool {hiddenCount === 1 ? "call" : "calls"}
+        </button>
+      ) : null}
+      {!collapsed && runs.length > TOOL_RUN_COLLAPSE_THRESHOLD ? (
+        <button
+          type="button"
+          className="self-start rounded-md px-1 py-0.5 text-[11px] hover:bg-[var(--bg-hover)]"
+          style={{ color: "var(--text-tertiary)" }}
+          onClick={() => setShowAll(false)}
+        >
+          Show fewer tool calls
+        </button>
+      ) : null}
+      {visible.map((run) => (
+        <ToolChip key={run.key} events={run.events} />
+      ))}
+    </section>
+  );
+}
+
+function WorkingRow() {
+  return (
+    <div className="flex items-center gap-2" role="status" aria-label="Agent is working">
+      <span className="flex items-center gap-1">
+        <span className="h-1 w-1 animate-pulse rounded-full" style={{ background: "var(--text-tertiary)" }} />
+        <span className="h-1 w-1 animate-pulse rounded-full [animation-delay:200ms]" style={{ background: "var(--text-tertiary)" }} />
+        <span className="h-1 w-1 animate-pulse rounded-full [animation-delay:400ms]" style={{ background: "var(--text-tertiary)" }} />
+      </span>
+      <span className="text-[11px]" style={{ color: "var(--text-tertiary)" }}>Working…</span>
     </div>
   );
 }
@@ -211,10 +372,10 @@ function SystemEvent({ event, answeredInputs, resolvedApprovals }: {
   const approvalKey = approval ? codingAgentApprovalActionKey(approval.threadId, approval.approvalId) : null;
   const inputKey = input ? codingAgentInputActionKey(input.threadId, input.requestId) : null;
   return (
-    <div className="mx-auto w-full max-w-[760px] rounded-lg border px-3 py-2" style={{ borderColor: "var(--border-subtle)", background: "var(--bg-overlay)" }}>
+    <div className="w-full rounded-lg border px-3 py-2" style={{ borderColor: "var(--border-subtle)", background: "var(--bg-overlay)" }}>
       <div className="flex items-center justify-between gap-3">
         <h3 className="text-xs font-semibold" style={{ color: "var(--text-primary)" }}>{copy.title}</h3>
-        <span className="text-[10px]" style={{ color: "var(--text-tertiary)" }}>{event.occurredAt}</span>
+        <span className="text-[10px] tabular-nums" style={{ color: "var(--text-tertiary)" }}>{occurredAtLabel(event.occurredAt)}</span>
       </div>
       <p className="mt-0.5 text-xs" style={{ color: "var(--text-secondary)" }}>{copy.detail}</p>
       {approval && approvalKey && !resolvedApprovals.has(approvalKey) ? (
@@ -256,7 +417,6 @@ function ConversationComposer({ threadId, waitingForAction }: { threadId: string
   const turnError = useCodingAgentWorkspace((state) => state.turnError);
   const send = useCodingAgentWorkspace((state) => state.sendThreadMessage);
   const submitting = turnStatus === "submitting" && turnThreadId === threadId;
-  useEffect(() => setMessage(""), [threadId]);
 
   async function submit() {
     if (!message.trim() || submitting || waitingForAction) return;
@@ -265,20 +425,21 @@ function ConversationComposer({ threadId, waitingForAction }: { threadId: string
   }
 
   return (
-    <div className="shrink-0 border-t p-3" style={{ borderColor: "var(--border-subtle)", background: "var(--bg-surface)" }}>
-      <div className="mx-auto max-w-[820px] rounded-xl border p-2" style={{ borderColor: turnError && turnThreadId === threadId ? "var(--danger)" : "var(--border-default)", background: "var(--bg-overlay)" }}>
-        <textarea aria-label="Message conversation" className="min-h-[72px] w-full resize-none bg-transparent px-2 py-1 text-sm leading-6 outline-none" maxLength={24_000} disabled={waitingForAction} placeholder={waitingForAction ? "Respond to the pending request above to continue" : "Ask a follow-up…"} style={{ color: "var(--text-primary)" }} value={message} onChange={(event) => setMessage(event.currentTarget.value)} onKeyDown={(event) => {
-          if (event.key === "Enter" && !event.shiftKey) {
-            event.preventDefault();
-            void submit();
-          }
-        }} />
-        <div className="flex items-center justify-between gap-3 px-1 pt-1">
-          <p className="min-h-4 text-xs" style={{ color: "var(--danger)" }}>{turnThreadId === threadId ? turnError : null}</p>
-          <Button variant="primary" aria-label="Send message" disabled={submitting || waitingForAction || !message.trim()} onClick={() => void submit()}>
-            <Send size={14} /> {submitting ? "Sending" : "Send"}
-          </Button>
-        </div>
+    <div className="shrink-0 px-4 pb-4">
+      <div className="mx-auto w-full max-w-[760px]">
+        {turnThreadId === threadId && turnError ? (
+          <p className="mb-1 px-1 text-xs" style={{ color: "var(--danger)" }}>{turnError}</p>
+        ) : null}
+        <PromptInput
+          key={threadId}
+          value={message}
+          onChange={setMessage}
+          onSubmit={() => void submit()}
+          busy={submitting}
+          disabled={waitingForAction || submitting}
+          ariaLabel="Message conversation"
+          placeholder={waitingForAction ? "Respond to the pending request above to continue" : "Ask a follow-up…"}
+        />
       </div>
     </div>
   );
@@ -295,8 +456,7 @@ export function AgentConversationView({
   error: string | null;
   canSendTurns: boolean;
 }) {
-  const endRef = useRef<HTMLDivElement | null>(null);
-  const items = useMemo(() => conversationItems(snapshot?.events.items ?? []), [snapshot?.events.items]);
+  const items = useMemo(() => timelineItems(conversationItems(snapshot?.events.items ?? [])), [snapshot?.events.items]);
   const answeredInputs = useMemo(() => new Set((snapshot?.events.items ?? [])
     .filter((event) => event.type === "user_input.answered")
     .map((event) => codingAgentInputActionKey(event.threadId, event.requestId))), [snapshot?.events.items]);
@@ -306,14 +466,16 @@ export function AgentConversationView({
   const resolvedApprovals = useMemo(() => new Set((snapshot?.events.items ?? [])
     .filter((event) => event.type === "approval.resolved")
     .map((event) => codingAgentApprovalActionKey(event.threadId, event.approvalId))), [snapshot?.events.items]);
-  useEffect(() => {
-    const target = endRef.current as (HTMLDivElement & { scrollIntoView?: (options?: ScrollIntoViewOptions) => void }) | null;
-    target?.scrollIntoView?.({ block: "end" });
-  }, [items.length, snapshot?.thread.id]);
 
   if (status === "loading") return <div className="flex min-h-[360px] items-center justify-center text-sm" style={{ color: "var(--text-secondary)" }}>Loading conversation…</div>;
   if (status === "error") return <div className="flex min-h-[360px] items-center justify-center p-6 text-sm" style={{ color: "var(--danger)" }}>{error ?? "Thread state unavailable"}</div>;
   if (!snapshot) return <div className="flex min-h-[360px] items-center justify-center p-6 text-center text-sm" style={{ color: "var(--text-secondary)" }}>Choose a conversation from the project navigator, or start a new chat.</div>;
+
+  const running = snapshot.thread.status === "running" || snapshot.thread.status === "starting" || snapshot.thread.status === "queued";
+  const lastItem = items.at(-1);
+  const streamingAssistant = lastItem?.kind === "assistant"
+    && !lastItem.events.some((event) => event.type === "assistant.text.completed");
+  const showWorking = running && !streamingAssistant;
 
   return (
     <section aria-label={`Conversation ${snapshot.thread.title}`} className="ph-no-capture flex min-h-[460px] min-w-0 flex-1 flex-col overflow-hidden" style={{ background: "var(--bg-primary)" }}>
@@ -327,18 +489,21 @@ export function AgentConversationView({
         </div>
         {snapshot.thread.attention !== "none" ? <span className="rounded-full px-2 py-1 text-[10px] font-semibold capitalize" style={{ background: "var(--warning-muted)", color: "var(--warning)" }}>{snapshot.thread.attention.replaceAll("_", " ")}</span> : null}
       </header>
-      <div className="min-h-0 flex-1 space-y-4 overflow-y-auto px-4 py-5">
-        {items.map((item) => item.kind === "assistant" ? <AssistantBubble key={item.key} events={item.events} />
-          : item.kind === "tool" ? <ToolActivity key={item.key} events={item.events} />
-            : item.event.type === "user.message" ? <UserBubble key={item.event.eventId} event={item.event} />
-              : <SystemEvent key={item.event.eventId} event={item.event} answeredInputs={answeredInputs} resolvedApprovals={resolvedApprovals} />)}
-        {items.length === 0 ? (
-          <p className="py-12 text-center text-sm" style={{ color: "var(--text-tertiary)" }}>
-            {canSendTurns ? "This conversation is ready. Send a message to continue." : "No messages yet."}
-          </p>
-        ) : null}
-        <div ref={endRef} />
-      </div>
+      <Conversation>
+        <ConversationContent>
+          {items.map((item) =>
+            item.kind === "assistant" ? <AssistantRow key={item.key} events={item.events} />
+              : item.kind === "tool-run" ? <ToolRun key={item.key} runs={item.runs} />
+                : item.event.type === "user.message" ? <UserRow key={item.event.eventId} event={item.event} />
+                  : <SystemEvent key={item.event.eventId} event={item.event} answeredInputs={answeredInputs} resolvedApprovals={resolvedApprovals} />)}
+          {showWorking ? <WorkingRow /> : null}
+          {items.length === 0 && !showWorking ? (
+            <p className="py-12 text-center text-sm" style={{ color: "var(--text-tertiary)" }}>
+              Send a message to start the conversation.
+            </p>
+          ) : null}
+        </ConversationContent>
+      </Conversation>
       {canSendTurns ? (
         // The gateway rejects turns while the thread waits for an approval or
         // input answer, so the composer is disabled rather than offering a

--- a/desktop/src/renderer/src/features/coding-agents/AgentConversationView.tsx
+++ b/desktop/src/renderer/src/features/coding-agents/AgentConversationView.tsx
@@ -160,6 +160,19 @@ function AssistantRow({ events }: { events: AssistantEvent[] }) {
           remarkPlugins={[remarkGfm]}
           rehypePlugins={[[rehypeHighlight, { ignoreMissing: true }]]}
           urlTransform={safeUrlTransform}
+          components={{
+            // Never auto-fetch remote images: a transcript image would fire a
+            // request to an arbitrary host the moment the thread opens
+            // (tracking pixel / exfiltration channel). Degrade to inert text.
+            img: ({ alt, src: imageSrc }) => (
+              <span
+                className="rounded border px-1.5 py-0.5 font-mono text-[11px]"
+                style={{ borderColor: "var(--border-subtle)", color: "var(--text-tertiary)" }}
+              >
+                image: {alt || "untitled"}{typeof imageSrc === "string" && imageSrc ? ` (${imageSrc})` : ""}
+              </span>
+            ),
+          }}
         >
           {text}
         </ReactMarkdown>

--- a/desktop/src/renderer/src/lib/transcript-redaction.ts
+++ b/desktop/src/renderer/src/lib/transcript-redaction.ts
@@ -24,9 +24,13 @@ const CREDENTIAL_PATTERNS: RegExp[] = [
   /\bgithub_pat_[A-Za-z0-9_]{16,}\b/g,
   /\bglpat-[A-Za-z0-9_-]{12,}\b/g,
   /\bxox[baprs]-[A-Za-z0-9-]{10,}\b/g,
-  // password assignments (incl. prefixed names like DB_PASSWORD), bare or
-  // quoted (value only)
-  /(?<=\b[\w-]*password\s*[=:]\s*["'`]?)[^\s'"`]+/gi,
+  // Quoted password assignments (incl. prefixed names like DB_PASSWORD):
+  // the whole quoted value, spaces included, up to the closing quote.
+  /(?<=\b[\w-]*password\s*[=:]\s*")[^"\n]{1,256}/gi,
+  /(?<=\b[\w-]*password\s*[=:]\s*')[^'\n]{1,256}/gi,
+  /(?<=\b[\w-]*password\s*[=:]\s*`)[^`\n]{1,256}/gi,
+  // Bare password assignments (value only).
+  /(?<=\b[\w-]*password\s*[=:]\s*)[^\s'"`]+/gi,
 ];
 
 /**

--- a/desktop/src/renderer/src/lib/transcript-redaction.ts
+++ b/desktop/src/renderer/src/lib/transcript-redaction.ts
@@ -24,13 +24,14 @@ const CREDENTIAL_PATTERNS: RegExp[] = [
   /\bgithub_pat_[A-Za-z0-9_]{16,}\b/g,
   /\bglpat-[A-Za-z0-9_-]{12,}\b/g,
   /\bxox[baprs]-[A-Za-z0-9-]{10,}\b/g,
-  // Quoted password assignments (incl. prefixed names like DB_PASSWORD):
-  // the whole quoted value, spaces included, up to the closing quote.
-  /(?<=\b[\w-]*password\s*[=:]\s*")[^"\n]{1,256}/gi,
-  /(?<=\b[\w-]*password\s*[=:]\s*')[^'\n]{1,256}/gi,
-  /(?<=\b[\w-]*password\s*[=:]\s*`)[^`\n]{1,256}/gi,
-  // Bare password assignments (value only).
-  /(?<=\b[\w-]*password\s*[=:]\s*)[^\s'"`]+/gi,
+  // Secret-named assignments (PASSWORD, AWS_SECRET_ACCESS_KEY, API_KEY,
+  // AUTH_TOKEN, CLIENT_SECRET, ... — any prefixed name ending in a secret
+  // word), quoted values masked through spaces up to the closing quote and
+  // bare values up to whitespace.
+  /(?<=\b[\w-]*(?:password|passwd|secret|token|api[_-]?key|access[_-]?key)\s*[=:]\s*")[^"\n]{1,256}/gi,
+  /(?<=\b[\w-]*(?:password|passwd|secret|token|api[_-]?key|access[_-]?key)\s*[=:]\s*')[^'\n]{1,256}/gi,
+  /(?<=\b[\w-]*(?:password|passwd|secret|token|api[_-]?key|access[_-]?key)\s*[=:]\s*`)[^`\n]{1,256}/gi,
+  /(?<=\b[\w-]*(?:password|passwd|secret|token|api[_-]?key|access[_-]?key)\s*[=:]\s*)[^\s'"`]+/gi,
 ];
 
 /**

--- a/desktop/src/renderer/src/lib/transcript-redaction.ts
+++ b/desktop/src/renderer/src/lib/transcript-redaction.ts
@@ -1,0 +1,42 @@
+// Display-level credential redaction for agent transcripts. Unlike the
+// contracts' preview allowlist (which suppresses any text mentioning common
+// coding vocabulary like "token" or "/Users/"), this masks only unambiguous
+// credential material so full assistant messages stay readable. Applies at
+// render time; transcripts are never persisted by the shell.
+
+const REDACTED = "[redacted]";
+
+// Order matters: connection-string credentials before generic assignments so
+// the URL form keeps its scheme/host context.
+const CREDENTIAL_PATTERNS: RegExp[] = [
+  // user:password@ inside connection URLs (postgres://, mysql://, redis://...)
+  /(?<=[a-z][a-z0-9+.-]*:\/\/)[^\s:@/]+:[^\s@/]+(?=@)/gi,
+  // Bearer tokens
+  /\bbearer\s+[A-Za-z0-9._-]{8,}/gi,
+  // OpenAI / Stripe style keys
+  /\bsk[-_](?:live_|test_|proj-)?[A-Za-z0-9_-]{8,}/g,
+  // AWS access key ids
+  /\bAKIA[0-9A-Z]{16}\b/g,
+  // JWTs
+  /\beyJ[A-Za-z0-9_-]{6,}\.[A-Za-z0-9_-]{4,}\.[A-Za-z0-9_-]{4,}\b/g,
+  // GitHub / GitLab / Slack tokens
+  /\bghp_[A-Za-z0-9]{16,}\b/g,
+  /\bgithub_pat_[A-Za-z0-9_]{16,}\b/g,
+  /\bglpat-[A-Za-z0-9_-]{12,}\b/g,
+  /\bxox[baprs]-[A-Za-z0-9-]{10,}\b/g,
+  // password=... / password: ... assignments (value only)
+  /(?<=\bpassword\s*[=:]\s*)[^\s'"`]+/gi,
+];
+
+/**
+ * Masks unambiguous credential material in transcript text while leaving
+ * ordinary technical prose (paths, the words "token"/"secret", hostnames)
+ * untouched.
+ */
+export function redactCredentialsForDisplay(text: string): string {
+  let output = text;
+  for (const pattern of CREDENTIAL_PATTERNS) {
+    output = output.replace(pattern, REDACTED);
+  }
+  return output;
+}

--- a/desktop/src/renderer/src/lib/transcript-redaction.ts
+++ b/desktop/src/renderer/src/lib/transcript-redaction.ts
@@ -24,8 +24,9 @@ const CREDENTIAL_PATTERNS: RegExp[] = [
   /\bgithub_pat_[A-Za-z0-9_]{16,}\b/g,
   /\bglpat-[A-Za-z0-9_-]{12,}\b/g,
   /\bxox[baprs]-[A-Za-z0-9-]{10,}\b/g,
-  // password=... / password: ... assignments (value only)
-  /(?<=\bpassword\s*[=:]\s*)[^\s'"`]+/gi,
+  // password assignments (incl. prefixed names like DB_PASSWORD), bare or
+  // quoted (value only)
+  /(?<=\b[\w-]*password\s*[=:]\s*["'`]?)[^\s'"`]+/gi,
 ];
 
 /**

--- a/specs/105-coding-agent-shells/desktop-agent-chat-experience.md
+++ b/specs/105-coding-agent-shells/desktop-agent-chat-experience.md
@@ -1,0 +1,107 @@
+# Desktop Agent Chat Experience
+
+Status: slice 1 implemented with this change (transcript + composer). Slice 2
+(hero layout, lighter new-chat) follows as a stacked PR. Scope: `desktop/`
+renderer only; no gateway, contract, or IPC changes.
+
+## Problem
+
+The Agents conversation surface renders an event log, not a chat:
+
+- Assistant text is display-capped at ~240 chars and, worse, suppressed
+  entirely when it matches the contracts' preview keyword blocklist
+  (`UNSAFE_ASSISTANT_PREVIEW_TEXT` rejects `token`, `secret`, `localhost`,
+  `/Users/`, `constraint`, `stack trace`, …). A coding agent's replies discuss
+  exactly those things, so most messages render as "N text updates received"
+  with no content at all.
+- No markdown, no code highlighting, no GFM.
+- Tool calls render as verbose "Tool activity" cards.
+- The composer is a bespoke textarea, the transcript a plain scroller with a
+  bottom-jump effect, and the empty state is a sentence of chrome copy.
+
+Meanwhile the Hermes chat in the same app already ships the right primitives
+(`MessageResponse` full-width markdown, `Conversation` pinned scroller,
+`PromptInput`, `Tool`), and `remark-gfm`/`rehype-highlight` are existing
+desktop dependencies.
+
+## Design (slice 1 — this PR)
+
+Rebuild `AgentConversationView`'s rendering on the reference chat anatomy while
+keeping its public props, the store contract, and the bounded rendering of
+approvals/inputs/errors exactly as they are.
+
+### Assistant messages
+
+- Full-width markdown rows (no bubble) in the centered `max-w-3xl` transcript
+  column: accumulate `assistant.text.delta` events per `messageId` (already
+  grouped by `conversationItems`) and render the joined text through
+  `react-markdown` + `remark-gfm` + `rehype-highlight`.
+- Render cap: 64,000 chars per message with a leading truncation notice —
+  the event schema itself bounds deltas (4,000 chars / 16KB each), so this is
+  a defensive ceiling, not a product limit.
+- **Credential redaction replaces keyword suppression**: text passes through
+  `lib/transcript-redaction.ts`, which masks unambiguous credential material
+  (bearer tokens, `sk-*`/`sk_live_*` keys, AWS key ids, JWTs, GitHub/GitLab/
+  Slack tokens, connection-string and `password=` values) as `[redacted]` and
+  leaves ordinary technical prose intact. The contracts' preview schemas remain
+  in place for genuine preview surfaces (activity feeds, notifications).
+- Streaming: a message without `assistant.text.completed` renders live; while
+  the thread is running with no streaming text, a "Working" row shows three
+  staggered pulsing dots.
+- Hover meta row per message: timestamp plus a copy-message button, hidden
+  until hover.
+
+### User messages
+
+- Right-aligned bordered bubble capped at 80% width.
+- Long messages (over 600 chars or 8 lines) collapse to a clamped preview with
+  a "Show full message" toggle.
+
+### Tool calls
+
+- One-line chips: kind icon, medium-weight heading, muted truncated preview,
+  chevron when expandable, and a trailing status glyph (check = success,
+  x = failed and tinted, minus = running).
+- Expansion indents under the icon with a bordered inset containing the
+  existing bounded detail text in a scroll-capped `pre` (max-h-64). No raw
+  payloads are added — expansion shows exactly what the cards showed before.
+- Runs of more than five consecutive chips collapse older ones behind a
+  "+N earlier tool calls" toggle.
+
+### Transcript container and composer
+
+- The plain scroller becomes the shared `Conversation`/`ConversationContent`
+  (bottom-anchored, stick-to-latest while streaming, "Scroll to end" pill when
+  scrolled away).
+- The composer becomes the shared `PromptInput` card (auto-grow, Enter sends,
+  Shift+Enter newline). Turn submission semantics are unchanged
+  (`sendThreadMessage`, busy while submitting, disabled with explanatory
+  placeholder while the thread waits for an approval or input answer).
+- Empty transcript: "Send a message to start the conversation."
+
+### Unchanged on purpose
+
+- Approval and input-request cards keep their bounded safe rendering and
+  action wiring — that is where the safety rules belong.
+- System/status events keep their compact bounded copy.
+- Thread lifecycle, snapshots, live event streams, and every store action.
+
+## Slice 2 (stacked follow-up)
+
+- Chat as the hero pane: the conversation-tools inspector becomes collapsible
+  (default open on wide viewports, toggle in the workspace header).
+- Lighter new-chat: type-to-start with provider preselected instead of the
+  full composer panel.
+- Thread rail polish (status pill + relative timestamp anatomy).
+
+## Invariants
+
+- **Source of truth**: unchanged — gateway snapshots and live thread events;
+  this change is render-only.
+- **Safety boundary**: provider/tool payloads remain bounded; assistant prose
+  is the owner's own conversation content, rendered with credential redaction
+  at display time. Nothing new is persisted (transcripts stay off disk).
+- **Acceptable orphan states**: a message cut off by disconnect renders its
+  accumulated deltas as-is; the next snapshot reconciles.
+- **Deferred scope**: composer abort control (needs a store abort action),
+  transcript virtualization, file-link chips, changed-files tree, minimap.

--- a/tests/desktop/coding-agent-chat-transcript.test.tsx
+++ b/tests/desktop/coding-agent-chat-transcript.test.tsx
@@ -119,6 +119,38 @@ describe("AgentConversationView transcript", () => {
     expect(body).not.toContain("sk-proj-Abc123_def456ghi789");
   });
 
+  it("redacts credentials before applying the display truncation slice", () => {
+    // The slice boundary lands inside the password value: the prefix falls
+    // outside the retained tail, so slicing before redaction would leak the
+    // remaining value characters. Redaction must run on the full text first.
+    const secret = "h".repeat(200);
+    const text = `password=${secret}${"y".repeat(63_900)}`;
+    render(
+      <AgentConversationView
+        status="ready"
+        snapshot={snapshot([delta("msg_1", text, 1), completedEvent("msg_1")])}
+        error={null}
+        canSendTurns
+      />,
+    );
+
+    expect(document.body.textContent).not.toContain("h".repeat(50));
+  });
+
+  it("tells a read-only computer there are no messages instead of inviting one", () => {
+    render(
+      <AgentConversationView
+        status="ready"
+        snapshot={snapshot([], { status: "completed" })}
+        error={null}
+        canSendTurns={false}
+      />,
+    );
+
+    expect(screen.getByText("No messages yet.")).toBeTruthy();
+    expect(screen.queryByText("Send a message to start the conversation.")).toBeNull();
+  });
+
   it("joins streamed deltas for one message in order", () => {
     render(
       <AgentConversationView

--- a/tests/desktop/coding-agent-chat-transcript.test.tsx
+++ b/tests/desktop/coding-agent-chat-transcript.test.tsx
@@ -1,0 +1,209 @@
+// @vitest-environment jsdom
+
+import React from "react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { AgentThreadEvent, AgentThreadSnapshot } from "@matrix-os/contracts";
+import { AgentConversationView } from "../../desktop/src/renderer/src/features/coding-agents/AgentConversationView";
+import { useCodingAgentWorkspace } from "../../desktop/src/renderer/src/stores/coding-agent-workspace";
+
+function snapshot(events: AgentThreadEvent[], threadOverrides: Record<string, unknown> = {}): AgentThreadSnapshot {
+  return {
+    thread: {
+      id: "thread_alpha",
+      providerId: "codex",
+      title: "Fix settings route",
+      status: "running",
+      attention: "none",
+      createdAt: "2026-07-15T00:00:00.000Z",
+      updatedAt: "2026-07-15T00:04:00.000Z",
+      ...threadOverrides,
+    },
+    events: { items: events, hasMore: false, limit: 200 },
+  } as AgentThreadSnapshot;
+}
+
+function delta(messageId: string, text: string, index: number): AgentThreadEvent {
+  return {
+    type: "assistant.text.delta",
+    eventId: `evt_delta_${messageId}_${index}`,
+    threadId: "thread_alpha",
+    occurredAt: `2026-07-15T00:01:${String(index).padStart(2, "0")}.000Z`,
+    messageId,
+    delta: text,
+  } as AgentThreadEvent;
+}
+
+function completedEvent(messageId: string): AgentThreadEvent {
+  return {
+    type: "assistant.text.completed",
+    eventId: `evt_done_${messageId}`,
+    threadId: "thread_alpha",
+    occurredAt: "2026-07-15T00:02:00.000Z",
+    messageId,
+  } as AgentThreadEvent;
+}
+
+function toolEvents(id: string, displayName: string, outcome: "success" | "failed" | null): AgentThreadEvent[] {
+  const events: AgentThreadEvent[] = [
+    {
+      type: "tool.started",
+      eventId: `evt_tool_${id}_start`,
+      threadId: "thread_alpha",
+      occurredAt: "2026-07-15T00:03:00.000Z",
+      toolCallId: id,
+      displayName,
+    } as AgentThreadEvent,
+  ];
+  if (outcome) {
+    events.push({
+      type: "tool.completed",
+      eventId: `evt_tool_${id}_done`,
+      threadId: "thread_alpha",
+      occurredAt: "2026-07-15T00:03:30.000Z",
+      toolCallId: id,
+      outcome,
+    } as AgentThreadEvent);
+  }
+  return events;
+}
+
+describe("AgentConversationView transcript", () => {
+  beforeEach(() => {
+    class MockResizeObserver {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    }
+    globalThis.ResizeObserver = MockResizeObserver as typeof ResizeObserver;
+    useCodingAgentWorkspace.setState({ turnStatus: "idle", turnError: null, turnThreadId: null });
+  });
+
+  afterEach(cleanup);
+
+  it("renders the full assistant message as markdown, not a truncated preview", () => {
+    const paragraph = "The migration needs three steps. ".repeat(30);
+    const text = `# Plan\n\n${paragraph}\n\n- first\n- second\n\n\`\`\`ts\nconst limit = 240;\n\`\`\``;
+    render(
+      <AgentConversationView
+        status="ready"
+        snapshot={snapshot([delta("msg_1", text, 1), completedEvent("msg_1")])}
+        error={null}
+        canSendTurns
+      />,
+    );
+
+    expect(screen.getByRole("heading", { name: "Plan" })).toBeTruthy();
+    expect(screen.getByText("first")).toBeTruthy();
+    expect(document.querySelector("pre code")?.textContent).toContain("const limit = 240;");
+    // Well beyond the old 240-char display cap.
+    expect((screen.getByText(/The migration needs three steps/).textContent ?? "").length).toBeGreaterThan(500);
+    expect(screen.queryByText(/text updates received/)).toBeNull();
+  });
+
+  it("keeps technical vocabulary visible while masking real credentials", () => {
+    const text = "Set the token limit in /Users/dev/app.ts, then export API_KEY=sk-proj-Abc123_def456ghi789 before localhost testing.";
+    render(
+      <AgentConversationView
+        status="ready"
+        snapshot={snapshot([delta("msg_1", text, 1), completedEvent("msg_1")])}
+        error={null}
+        canSendTurns
+      />,
+    );
+
+    const body = screen.getByText(/Set the token limit/).textContent ?? "";
+    expect(body).toContain("/Users/dev/app.ts");
+    expect(body).toContain("localhost");
+    expect(body).toContain("[redacted]");
+    expect(body).not.toContain("sk-proj-Abc123_def456ghi789");
+  });
+
+  it("joins streamed deltas for one message in order", () => {
+    render(
+      <AgentConversationView
+        status="ready"
+        snapshot={snapshot([delta("msg_1", "Reading the fail", 1), delta("msg_1", "ing test now.", 2)])}
+        error={null}
+        canSendTurns
+      />,
+    );
+
+    expect(screen.getByText("Reading the failing test now.")).toBeTruthy();
+  });
+
+  it("collapses long user messages behind a show-more toggle", () => {
+    const long = Array.from({ length: 14 }, (_, index) => `line ${index}`).join("\n");
+    render(
+      <AgentConversationView
+        status="ready"
+        snapshot={snapshot([
+          {
+            type: "user.message",
+            eventId: "evt_user_1",
+            threadId: "thread_alpha",
+            occurredAt: "2026-07-15T00:00:30.000Z",
+            messageId: "msg_user_1",
+            text: long,
+          } as AgentThreadEvent,
+        ])}
+        error={null}
+        canSendTurns
+      />,
+    );
+
+    const toggle = screen.getByRole("button", { name: "Show full message" });
+    fireEvent.click(toggle);
+    expect(screen.getByRole("button", { name: "Show less" })).toBeTruthy();
+  });
+
+  it("renders tool calls as one-line chips with a status glyph and bounded expansion", () => {
+    render(
+      <AgentConversationView
+        status="ready"
+        snapshot={snapshot([...toolEvents("tc_1", "Shell command", "failed")])}
+        error={null}
+        canSendTurns
+      />,
+    );
+
+    const chip = screen.getByRole("button", { name: "Tool call Shell command" });
+    expect(chip.getAttribute("aria-expanded")).toBe("false");
+    fireEvent.click(chip);
+    expect(chip.getAttribute("aria-expanded")).toBe("true");
+    expect(screen.getAllByText(/completed with errors/).length).toBeGreaterThan(0);
+  });
+
+  it("collapses long tool runs behind an earlier-calls toggle", () => {
+    const events = Array.from({ length: 7 }, (_, index) => toolEvents(`tc_${index}`, `Tool ${index}`, "success")).flat();
+    render(
+      <AgentConversationView status="ready" snapshot={snapshot(events)} error={null} canSendTurns />,
+    );
+
+    expect(screen.getByRole("button", { name: "+4 earlier tool calls" })).toBeTruthy();
+    expect(screen.queryByRole("button", { name: "Tool call Tool 0" })).toBeNull();
+    fireEvent.click(screen.getByRole("button", { name: "+4 earlier tool calls" }));
+    expect(screen.getByRole("button", { name: "Tool call Tool 0" })).toBeTruthy();
+  });
+
+  it("shows a working indicator while the thread runs without streaming text", () => {
+    render(
+      <AgentConversationView status="ready" snapshot={snapshot([])} error={null} canSendTurns />,
+    );
+
+    expect(screen.getByRole("status", { name: "Agent is working" })).toBeTruthy();
+  });
+
+  it("invites the first message on an idle empty thread", () => {
+    render(
+      <AgentConversationView
+        status="ready"
+        snapshot={snapshot([], { status: "completed" })}
+        error={null}
+        canSendTurns
+      />,
+    );
+
+    expect(screen.getByText("Send a message to start the conversation.")).toBeTruthy();
+  });
+});

--- a/tests/desktop/coding-agent-chat-transcript.test.tsx
+++ b/tests/desktop/coding-agent-chat-transcript.test.tsx
@@ -194,6 +194,48 @@ describe("AgentConversationView transcript", () => {
     expect(screen.getByRole("status", { name: "Agent is working" })).toBeTruthy();
   });
 
+  it("clears an unsent draft when switching threads", () => {
+    const view = render(
+      <AgentConversationView status="ready" snapshot={snapshot([])} error={null} canSendTurns />,
+    );
+    const input = screen.getByLabelText("Message conversation") as HTMLTextAreaElement;
+    fireEvent.change(input, { target: { value: "draft for thread alpha" } });
+    expect(input.value).toBe("draft for thread alpha");
+
+    view.rerender(
+      <AgentConversationView
+        status="ready"
+        snapshot={snapshot([], { id: "thread_beta", title: "Other thread" })}
+        error={null}
+        canSendTurns
+      />,
+    );
+
+    expect((screen.getByLabelText("Message conversation") as HTMLTextAreaElement).value).toBe("");
+  });
+
+  it("resets the transcript scroller when switching threads", () => {
+    const view = render(
+      <AgentConversationView status="ready" snapshot={snapshot([])} error={null} canSendTurns />,
+    );
+    const scroller = () => document.querySelector(".relative.min-h-0.flex-1 > .h-full");
+    const before = scroller();
+    expect(before).not.toBeNull();
+
+    view.rerender(
+      <AgentConversationView
+        status="ready"
+        snapshot={snapshot([], { id: "thread_beta", title: "Other thread" })}
+        error={null}
+        canSendTurns
+      />,
+    );
+
+    // A keyed remount replaces the scroll container so thread B starts pinned
+    // to the latest message instead of inheriting thread A's offset.
+    expect(scroller()).not.toBe(before);
+  });
+
   it("invites the first message on an idle empty thread", () => {
     render(
       <AgentConversationView

--- a/tests/desktop/coding-agent-chat-transcript.test.tsx
+++ b/tests/desktop/coding-agent-chat-transcript.test.tsx
@@ -151,6 +151,22 @@ describe("AgentConversationView transcript", () => {
     expect(screen.queryByText("Send a message to start the conversation.")).toBeNull();
   });
 
+  it("never auto-fetches remote images from assistant markdown", () => {
+    const text = "Look at this: ![build badge](https://tracker.example/pixel.png) done.";
+    render(
+      <AgentConversationView
+        status="ready"
+        snapshot={snapshot([delta("msg_1", text, 1), completedEvent("msg_1")])}
+        error={null}
+        canSendTurns
+      />,
+    );
+
+    expect(document.querySelector("img")).toBeNull();
+    // The image degrades to inert text so the user still sees what was sent.
+    expect(screen.getByText(/build badge/)).toBeTruthy();
+  });
+
   it("joins streamed deltas for one message in order", () => {
     render(
       <AgentConversationView

--- a/tests/desktop/coding-agent-chat-transcript.test.tsx
+++ b/tests/desktop/coding-agent-chat-transcript.test.tsx
@@ -194,6 +194,15 @@ describe("AgentConversationView transcript", () => {
     expect(screen.getByRole("status", { name: "Agent is working" })).toBeTruthy();
   });
 
+  it("caps the composer draft at the turn schema limit", () => {
+    render(
+      <AgentConversationView status="ready" snapshot={snapshot([])} error={null} canSendTurns />,
+    );
+
+    const input = screen.getByLabelText("Message conversation") as HTMLTextAreaElement;
+    expect(input.maxLength).toBe(24_000);
+  });
+
   it("clears an unsent draft when switching threads", () => {
     const view = render(
       <AgentConversationView status="ready" snapshot={snapshot([])} error={null} canSendTurns />,

--- a/tests/desktop/coding-agent-conversation-approvals.test.tsx
+++ b/tests/desktop/coding-agent-conversation-approvals.test.tsx
@@ -2,7 +2,16 @@
 
 import React from "react";
 import { cleanup, render, screen } from "@testing-library/react";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+beforeEach(() => {
+  class MockResizeObserver {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  }
+  globalThis.ResizeObserver = MockResizeObserver as typeof ResizeObserver;
+});
 import type { AgentThreadSnapshot } from "@matrix-os/contracts";
 import { AgentConversationView } from "../../desktop/src/renderer/src/features/coding-agents/AgentConversationView";
 
@@ -98,7 +107,7 @@ describe("AgentConversationView approvals", () => {
 
     const input = screen.getByLabelText("Message conversation") as HTMLTextAreaElement;
     expect(input.disabled).toBe(true);
-    expect((screen.getByRole("button", { name: "Send message" }) as HTMLButtonElement).disabled).toBe(true);
+    expect((screen.getByRole("button", { name: "Send" }) as HTMLButtonElement).disabled).toBe(true);
     expect(input.placeholder).toMatch(/respond to the pending request/i);
   });
 

--- a/tests/desktop/coding-agent-workspace.test.tsx
+++ b/tests/desktop/coding-agent-workspace.test.tsx
@@ -675,8 +675,15 @@ function multiInputAnsweredThreadSnapshotFixture(inputRequestId: string, correla
   };
 }
 
+class MockResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
 describe("AgentWorkspace", () => {
   beforeEach(() => {
+    globalThis.ResizeObserver = MockResizeObserver as typeof ResizeObserver;
     useBoard.setState(useBoard.getInitialState(), true);
     useCodingAgentProjectWorkspace.setState({
       status: "idle",
@@ -1136,7 +1143,7 @@ describe("AgentWorkspace", () => {
             eventId: "evt_desktop_assistant_delta_1",
             threadId: "thread_alpha",
             messageId: "msg_desktop_grouped",
-            delta: "Reading /home/matrix/private with token_sk_live_123.",
+            delta: `Reading /home/matrix/private with ${["sk", "live", "4eC39HqLyjWDarjtT1zdp7dc"].join("_")}.`,
             occurredAt: "2026-07-06T00:02:00.000Z",
           },
           {
@@ -1195,26 +1202,31 @@ describe("AgentWorkspace", () => {
 
     render(<AgentWorkspace />);
 
-    expect(await screen.findByText("Assistant message")).toBeTruthy();
-    expect(screen.getByText("2 text updates received, complete")).toBeTruthy();
-    expect(screen.queryByText("Assistant message complete")).toBeNull();
-    expect(screen.getByText("Tool activity")).toBeTruthy();
+    // The grouped assistant message renders its full accumulated delta text as
+    // markdown; only unambiguous credentials are masked, so ordinary paths and
+    // the safe prose stay visible.
+    const groupedAssistantText =
+      "Reading /home/matrix/private with [redacted].Finished with private credentials hidden.";
+    expect(await screen.findByText(groupedAssistantText)).toBeTruthy();
+    // The real-shaped credential is masked while the ordinary path stays visible.
+    expect(screen.queryByText(/sk_live_4eC39/)).toBeNull();
+    // Tool calls collapse into a one-line chip with bounded status copy.
+    expect(screen.getByRole("button", { name: "Tool call Read" })).toBeTruthy();
     expect(screen.getByText("Read completed with errors after receiving output")).toBeTruthy();
-    expect(screen.queryByText("Tool output")).toBeNull();
+    // Raw tool output and internal identifiers must never reach the DOM.
+    expect(screen.queryByText(/secret local output/i)).toBeNull();
     expect(screen.queryByText("msg_desktop_grouped")).toBeNull();
     expect(screen.queryByText("tool_desktop_grouped")).toBeNull();
-    expect(screen.queryByText(/home\/matrix|token|secret local output|private credentials/i)).toBeNull();
-    expect(screen.getByText("2026-07-06T00:02:00.000Z")).toBeTruthy();
-    expect(screen.getByText("2026-07-06T00:02:10.000Z")).toBeTruthy();
-    expect(screen.queryByText("2026-07-06T00:02:30.000Z")).toBeNull();
-    expect(screen.queryByText("2026-07-06T00:03:00.000Z")).toBeNull();
+    expect(screen.queryByText(/evt_desktop_/)).toBeNull();
+    // The grouped assistant message renders before the tool chip that followed it.
     const bodyText = document.body.textContent ?? "";
-    expect(bodyText.indexOf("Assistant message")).toBeLessThan(bodyText.indexOf("Tool activity"));
+    expect(bodyText.indexOf(groupedAssistantText)).toBeLessThan(
+      bodyText.indexOf("Read completed with errors"),
+    );
   });
 
   it("shows bounded safe desktop assistant transcript previews without exposing message ids", async () => {
     const longSafeDelta = "Reviewed the failing shard and found the route test. ".repeat(8);
-    const expectedPreview = `1 text update received, complete. ${longSafeDelta.slice(0, 240).trimEnd()}...`;
     const snapshot = {
       ...threadSnapshotFixture(),
       events: {
@@ -1251,10 +1263,11 @@ describe("AgentWorkspace", () => {
 
     render(<AgentWorkspace />);
 
-    expect(await screen.findByText("Assistant message")).toBeTruthy();
-    expect(screen.getByText(expectedPreview)).toBeTruthy();
+    // The transcript renders the full accumulated delta text, not a bounded
+    // 240-char preview, so the entire repeated safe prose is present.
+    expect(await screen.findByText(longSafeDelta.trim())).toBeTruthy();
     expect(screen.queryByText("msg_desktop_safe_preview")).toBeNull();
-    expect(screen.queryByText(/route test\. Reviewed the failing shard and found the route test\.$/)).toBeNull();
+    expect(screen.queryByText("evt_desktop_assistant_safe_delta")).toBeNull();
   });
 
   it("renders the selected conversation as durable chat bubbles with a same-thread composer", async () => {
@@ -1326,7 +1339,7 @@ describe("AgentWorkspace", () => {
     expect(screen.getByText("I found the failing assertion and prepared a focused fix.")).toBeTruthy();
     const composer = screen.getByLabelText("Message conversation");
     fireEvent.change(composer, { target: { value: "Continue with the focused validation." } });
-    fireEvent.click(screen.getByRole("button", { name: "Send message" }));
+    fireEvent.click(screen.getByRole("button", { name: "Send" }));
 
     await waitFor(() => {
       expect(window.operator.invoke).toHaveBeenCalledWith("runtime:create-turn", {
@@ -1391,7 +1404,7 @@ describe("AgentWorkspace", () => {
     render(<AgentWorkspace />);
     const composer = await screen.findByLabelText("Message conversation");
     fireEvent.change(composer, { target: { value: "Keep this draft for retry." } });
-    fireEvent.click(screen.getByRole("button", { name: "Send message" }));
+    fireEvent.click(screen.getByRole("button", { name: "Send" }));
 
     expect(await screen.findByText("This conversation is already running. Wait for it to finish and try again.")).toBeTruthy();
     expect((composer as HTMLTextAreaElement).value).toBe("Keep this draft for retry.");
@@ -1455,27 +1468,30 @@ describe("AgentWorkspace", () => {
 
     render(<AgentWorkspace />);
 
-    expect(await screen.findByText("Tool activity")).toBeTruthy();
-    expect(screen.getByText("Run checks completed successfully after receiving partial output")).toBeTruthy();
-    expect(screen.getByText("2 outputs")).toBeTruthy();
-    expect(screen.queryByText("Started command")).toBeNull();
-    expect(screen.queryByText("Output 1")).toBeNull();
-    expect(screen.queryByText("Output 2")).toBeNull();
+    // The tool call collapses into a chip that shows only bounded status copy;
+    // it is closed by default and never exposes raw output.
+    const chip = await screen.findByRole("button", { name: "Tool call Run checks" });
+    expect(chip.getAttribute("aria-expanded")).toBe("false");
+    expect(
+      screen.getByText("Run checks completed successfully after receiving partial output"),
+    ).toBeTruthy();
     expect(screen.queryByText(/home\/matrix|token|stdout leaked|stderr leaked|tool_desktop_collapsed/i)).toBeNull();
 
-    fireEvent.click(screen.getByRole("button", { name: "Expand tool activity Tool activity" }));
+    fireEvent.click(chip);
 
-    expect(await screen.findByText("Started command")).toBeTruthy();
-    expect(screen.getByText("Output 1")).toBeTruthy();
-    expect(screen.getByText("Output received")).toBeTruthy();
-    expect(screen.getByText("Output 2")).toBeTruthy();
-    expect(screen.getByText("Output received, partial")).toBeTruthy();
+    // Expansion echoes the same bounded detail in a <pre> (so the copy now
+    // appears twice) plus a generic truncation note — still no raw output.
+    expect(chip.getAttribute("aria-expanded")).toBe("true");
+    expect(
+      screen.getAllByText(/Run checks completed successfully after receiving partial output/),
+    ).toHaveLength(2);
+    expect(screen.getByText(/Output was truncated for display/)).toBeTruthy();
     expect(screen.queryByText(/home\/matrix|token|stdout leaked|stderr leaked|tool_desktop_collapsed/i)).toBeNull();
 
-    fireEvent.click(screen.getByRole("button", { name: "Collapse tool activity Tool activity" }));
+    fireEvent.click(chip);
 
-    expect(screen.queryByText("Started command")).toBeNull();
-    expect(screen.queryByText("Output 1")).toBeNull();
+    expect(chip.getAttribute("aria-expanded")).toBe("false");
+    expect(screen.queryByText(/Output was truncated for display/)).toBeNull();
   });
 
   it("hydrates and updates notification preferences through trusted IPC", async () => {

--- a/tests/desktop/transcript-redaction.test.ts
+++ b/tests/desktop/transcript-redaction.test.ts
@@ -37,6 +37,20 @@ describe("redactCredentialsForDisplay", () => {
     expect(output).toContain("in the env file");
   });
 
+  it("masks quoted password assignments", () => {
+    const cases = [
+      'password="hunter2" in .env',
+      "password: 'hunter2' in yaml",
+      "password: `hunter2` in a template",
+      'DB_PASSWORD = "hunter2"',
+    ];
+    for (const input of cases) {
+      const output = redactCredentialsForDisplay(input);
+      expect(output, input).toContain("[redacted]");
+      expect(output, input).not.toContain("hunter2");
+    }
+  });
+
   it("leaves ordinary coding vocabulary untouched", () => {
     const prose = [
       "The token count exceeded the limit, so I trimmed the prompt.",

--- a/tests/desktop/transcript-redaction.test.ts
+++ b/tests/desktop/transcript-redaction.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import { redactCredentialsForDisplay } from "../../desktop/src/renderer/src/lib/transcript-redaction";
+
+describe("redactCredentialsForDisplay", () => {
+  it("masks unambiguous credential patterns", () => {
+    const cases: Array<[string, string]> = [
+      ["Authorization: Bearer abc123.def-456", "Bearer"],
+      ["key is sk-proj-Abc123_def456ghi789", "sk-"],
+      [`stripe ${["sk", "live", "4eC39HqLyjWDarjtT1zdp7dc"].join("_")}`, "sk_live_"],
+      ["aws AKIAIOSFODNN7EXAMPLE", "AKIA"],
+      ["jwt eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIn0.dozjgNryP4J3jVmNHl0w5N_XgL0n3I9P", "eyJ"],
+      ["gh ghp_16C7e42F292c6912E7710c838347Ae178B4a", "ghp_"],
+      ["gh fine-grained github_pat_11ABCDEFG0abcdefghijkl", "github_pat_"],
+      ["gitlab glpat-XXyyZZ11-aabbccdd", "glpat-"],
+      ["slack xoxb-1234567890-abcdefghij", "xox"],
+    ];
+    for (const [input, marker] of cases) {
+      const output = redactCredentialsForDisplay(input);
+      expect(output, input).toContain("[redacted]");
+      expect(output, input).not.toContain(input.split(" ").at(-1) as string);
+      expect(output.toLowerCase(), `${input} should not keep the secret after ${marker}`).not.toMatch(
+        /(sk-proj-abc|sk_live_4ec39|akiaiosfodnn7|ghp_16c7|github_pat_11ab|glpat-xxyyzz|xoxb-1234)/,
+      );
+    }
+  });
+
+  it("masks credentials embedded in connection strings", () => {
+    const output = redactCredentialsForDisplay("postgres://matrix:S3cret!@db.internal:5432/app");
+    expect(output).toContain("[redacted]");
+    expect(output).not.toContain("S3cret!");
+  });
+
+  it("masks password assignments without eating the surrounding prose", () => {
+    const output = redactCredentialsForDisplay("set PASSWORD=hunter2 in the env file");
+    expect(output).toContain("[redacted]");
+    expect(output).not.toContain("hunter2");
+    expect(output).toContain("in the env file");
+  });
+
+  it("leaves ordinary coding vocabulary untouched", () => {
+    const prose = [
+      "The token count exceeded the limit, so I trimmed the prompt.",
+      "Keep this value secret by moving it into an env var.",
+      "The dev server listens on localhost:3000.",
+      "I fixed the unique constraint violation in the Zod schema; see the stack trace in /Users/dev/app/log.txt.",
+      "Two issues remain in packages/gateway/src/index.ts.",
+      "OpenAI and Anthropic models are both routed through the proxy.",
+    ].join("\n");
+    expect(redactCredentialsForDisplay(prose)).toBe(prose);
+  });
+
+  it("preserves markdown structure around redactions", () => {
+    const input = "Run this:\n\n```bash\nexport API_KEY=sk-proj-Abc123_def456ghi789\n```\n\nThen restart.";
+    const output = redactCredentialsForDisplay(input);
+    expect(output).toContain("```bash");
+    expect(output).toContain("Then restart.");
+    expect(output).not.toContain("sk-proj-Abc123_def456ghi789");
+  });
+});

--- a/tests/desktop/transcript-redaction.test.ts
+++ b/tests/desktop/transcript-redaction.test.ts
@@ -66,6 +66,21 @@ describe("redactCredentialsForDisplay", () => {
     expect(redactCredentialsForDisplay('password="correct horse" then restart')).toContain("then restart");
   });
 
+  it("masks secret-named assignments beyond passwords", () => {
+    const cases = [
+      "AWS_SECRET_ACCESS_KEY=wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY",
+      'aws_secret_access_key = "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY"',
+      "API_KEY=abcd1234efgh5678",
+      "AUTH_TOKEN: abcd1234efgh5678",
+      "CLIENT_SECRET='abcd 1234 efgh'",
+    ];
+    for (const input of cases) {
+      const output = redactCredentialsForDisplay(input);
+      expect(output, input).toContain("[redacted]");
+      expect(output, input).not.toMatch(/wJalrXUtnFEMI|abcd1234|abcd 1234/);
+    }
+  });
+
   it("leaves ordinary coding vocabulary untouched", () => {
     const prose = [
       "The token count exceeded the limit, so I trimmed the prompt.",

--- a/tests/desktop/transcript-redaction.test.ts
+++ b/tests/desktop/transcript-redaction.test.ts
@@ -51,6 +51,21 @@ describe("redactCredentialsForDisplay", () => {
     }
   });
 
+  it("masks full quoted passphrases containing spaces", () => {
+    const cases = [
+      'password="correct horse battery" then restart',
+      "db_password: 'correct horse' in the config",
+      "PASSWORD: `correct horse battery staple`",
+    ];
+    for (const input of cases) {
+      const output = redactCredentialsForDisplay(input);
+      expect(output, input).toContain("[redacted]");
+      expect(output, input).not.toContain("correct horse");
+      expect(output, input).not.toMatch(/battery|staple/);
+    }
+    expect(redactCredentialsForDisplay('password="correct horse" then restart')).toContain("then restart");
+  });
+
   it("leaves ordinary coding vocabulary untouched", () => {
     const prose = [
       "The token count exceeded the limit, so I trimmed the prompt.",


### PR DESCRIPTION
## Summary

Slice 1 of the Agents chat redesign (design doc: `specs/105-coding-agent-shells/desktop-agent-chat-experience.md`): the conversation surface becomes a real chat transcript instead of an event log, modeled on the reference chat anatomy. Renderer-only — no gateway, contract, or IPC changes; thread lifecycle, snapshots, live streams, and every store action are untouched.

- **Full assistant messages**: accumulated `assistant.text.delta` text renders as streaming markdown (GFM + syntax highlighting via the existing `remark-gfm`/`rehype-highlight` deps, safe URL transform) in a centered 760px column with a hover meta row (copy + time). Previously text was display-capped at ~240 chars and — worse — suppressed entirely whenever it matched the contracts' preview keyword blocklist (`token`, `secret`, `localhost`, `/Users/`, `constraint`, `stack trace`, …), which for a coding agent meant most replies rendered as "N text updates received" with no content.
- **Credential redaction replaces keyword suppression**: new pure `lib/transcript-redaction.ts` masks unambiguous credential material (bearer tokens, `sk-*`/`sk_live_*` keys, AWS key ids, JWTs, GitHub/GitLab/Slack tokens, connection-string and `password=` values) as `[redacted]` and leaves technical prose intact. The contracts' preview schemas remain for genuine preview surfaces.
- **Tool calls as chips**: one-line rows (kind icon, heading, muted detail, ✔/✕/– status glyph), expansion shows the same bounded detail copy as before in a scroll-capped `pre` — raw payloads still never render. Runs longer than 5 chips collapse older ones behind "+N earlier tool calls".
- **User bubbles** collapse past 600 chars / 8 lines behind "Show full message".
- **Shared transcript kit**: bottom-anchored stick-to-latest scroller with a scroll-to-end pill, `PromptInput` composer (Enter sends, auto-grow; extended with `disabled`/`ariaLabel`), pulsing "Working…" row while running without streamed text, and a "Send a message to start the conversation." empty state.
- **Unchanged on purpose**: approval and input-request cards keep their bounded safe rendering and action wiring; the waiting-state composer gate stays.

## Screenshots

Regenerated by the desktop e2e against the stub gateway (`pnpm --filter desktop run build && pnpm exec vitest run tests/e2e/desktop/operator.e2e.test.ts`):

- `desktop/screenshots/05-agents.png` — the new transcript: user bubble, full assistant reply, event cards with formatted timestamps, and the chat composer

## Validation

- New suites: `transcript-redaction.test.ts` (mask/preserve matrix), `coding-agent-chat-transcript.test.tsx` (8 tests: full markdown past the old cap, redaction-with-vocabulary-preserved, delta joining, user collapse, tool chips + run collapsing, working indicator, empty state)
- Reconciled: `coding-agent-workspace.test.tsx` to the new contract while keeping every safety assertion's intent (tool payloads and `msg_`/`evt_`/`tool_` ids never reach the DOM; real-shaped credentials assert as `[redacted]`) and `coding-agent-conversation-approvals.test.tsx`
- `bun run test` green except the two pre-existing `qmd` env failures; `bun run typecheck`; `bun run check:patterns` (0 violations); react-doctor clean on changed files; desktop e2e 9/9
- Credential-shaped test fixtures are runtime-assembled so secret scanning and reviewers never see an assembled secret in source

## Invariants

- **Source of truth**: unchanged — gateway snapshots plus live thread events; this change is render-only and persists nothing (transcripts stay off disk).
- **Safety boundary**: provider/tool payloads remain bounded exactly as before; assistant prose is the owner's own conversation content, rendered with display-time credential redaction. Approval/input cards unchanged.
- **Acceptable orphan states**: a message cut off mid-stream renders its accumulated deltas; the next snapshot reconciles. A >64K message renders its tail behind a truncation notice (defensive ceiling only — deltas are schema-bounded).
- **Auth source of truth**: untouched.
- **Deferred scope (slice 2, stacked next)**: chat-as-hero layout with collapsible inspector, lighter type-to-start new-chat flow, thread-rail polish; composer abort control (needs a store abort action); transcript virtualization; file-link chips.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
