### PR TITLE
fix(terminal): stabilize coding agent availability

### DIFF
--- a/packages/gateway/src/agent-launcher.ts
+++ b/packages/gateway/src/agent-launcher.ts
@@ -78,11 +78,28 @@ function promptArgs(prompt?: string): string[] {
   return ["--", prompt];
 }
 
+function matrixNodePrefix(): string {
+  const configured = process.env.MATRIX_NODE_PREFIX?.trim();
+  return configured && configured.length > 0 ? configured : "/opt/matrix/runtime/node";
+}
+
+function pathWithMatrixAgentBins(runtimeHome: string, nodePrefix = matrixNodePrefix()): string {
+  const preferred = [`${runtimeHome}/.local/bin`, `${nodePrefix}/bin`];
+  const current = (process.env.PATH ?? "").split(":").filter(Boolean);
+  return [
+    ...preferred,
+    ...current.filter((entry) => !preferred.includes(entry)),
+  ].join(":");
+}
+
 function agentRuntimeEnv(runtimeHome?: string): Record<string, string> {
   if (!runtimeHome) return {};
+  const nodePrefix = matrixNodePrefix();
   return {
     HOME: runtimeHome,
     MATRIX_HOME: runtimeHome,
+    MATRIX_NODE_PREFIX: nodePrefix,
+    PATH: pathWithMatrixAgentBins(runtimeHome, nodePrefix),
   };
 }
 

--- a/packages/gateway/src/shell/zellij-config.ts
+++ b/packages/gateway/src/shell/zellij-config.ts
@@ -33,7 +33,9 @@ const MATRIX_TERMINAL_PATH_BOOTSTRAP = `matrix_prepend_terminal_path() {
 
 matrix_prepend_terminal_path "/opt/matrix/bin"
 matrix_prepend_terminal_path "\${MATRIX_NODE_PREFIX:-/opt/matrix/runtime/node}/bin"
-matrix_prepend_terminal_path "$MATRIX_HOME/.local/bin"
+if [ -n "\${MATRIX_HOME:-}" ]; then
+  matrix_prepend_terminal_path "$MATRIX_HOME/.local/bin"
+fi
 `;
 
 export const MATRIX_TERMINAL_BASHRC = `# Matrix OS generated terminal rcfile.

--- a/packages/gateway/src/shell/zellij-config.ts
+++ b/packages/gateway/src/shell/zellij-config.ts
@@ -21,10 +21,27 @@ layout {
 }
 `;
 
+const MATRIX_TERMINAL_PATH_BOOTSTRAP = `matrix_prepend_terminal_path() {
+  local entry="$1"
+  [ -n "$entry" ] || return 0
+  case ":\${PATH:-}:" in
+    *":$entry:"*) ;;
+    *) PATH="$entry\${PATH:+:$PATH}" ;;
+  esac
+  export PATH
+}
+
+matrix_prepend_terminal_path "/opt/matrix/bin"
+matrix_prepend_terminal_path "\${MATRIX_NODE_PREFIX:-/opt/matrix/runtime/node}/bin"
+matrix_prepend_terminal_path "$MATRIX_HOME/.local/bin"
+`;
+
 export const MATRIX_TERMINAL_BASHRC = `# Matrix OS generated terminal rcfile.
 if [ -r "$HOME/.bashrc" ]; then
   . "$HOME/.bashrc"
 fi
+
+${MATRIX_TERMINAL_PATH_BOOTSTRAP}
 
 if [ -n "\${MATRIX_TERMINAL_PROMPT:-}" ]; then
   PS1="\${MATRIX_TERMINAL_PROMPT}"
@@ -122,6 +139,8 @@ set -euo pipefail
 
 export MATRIX_HOME="\${MATRIX_HOME:-\${HOME:-/home/matrix/home}}"
 export HOME="\${HOME:-$MATRIX_HOME}"
+${MATRIX_TERMINAL_PATH_BOOTSTRAP}
+
 if [ -z "\${MATRIX_TERMINAL_PROMPT:-}" ]; then
   matrix_prompt_label=""
   if command -v node >/dev/null 2>&1; then

--- a/shell/src/components/terminal/MobileTerminalControls.tsx
+++ b/shell/src/components/terminal/MobileTerminalControls.tsx
@@ -62,7 +62,10 @@ export function MobileTerminalActions({
   const toggleNewSessionMenu = () => {
     const shouldOpen = !newSessionMenuOpen;
     setNewSessionMenuOpen(shouldOpen);
-    if (shouldOpen) void fetchAgentStatuses();
+    if (shouldOpen) {
+      setAgentStatuses(null);
+      void fetchAgentStatuses();
+    }
   };
 
   const closeNewSessionMenu = () => {

--- a/shell/src/components/terminal/NewSessionMenu.tsx
+++ b/shell/src/components/terminal/NewSessionMenu.tsx
@@ -128,7 +128,7 @@ export function NewSessionMenu({
         onClick={onCreateShell}
       />
       {TERMINAL_AGENT_OPTIONS.map((option) => {
-        const installed = agentStatuses?.[option.id] ?? option.fallbackInstalled;
+        const installed = agentStatuses?.[option.id] === true;
         return (
           <NewSessionMenuItem
             key={option.id}

--- a/shell/src/components/terminal/TerminalSidebar.tsx
+++ b/shell/src/components/terminal/TerminalSidebar.tsx
@@ -776,6 +776,7 @@ export function LocalTerminalSidebar() {
   const openNewSessionMenu = (anchor: NewSessionMenuAnchor) => {
     if (creatingShell) return;
     if (newSessionMenuAnchor !== anchor) {
+      setAgentStatuses(null);
       void fetchAgentStatuses();
     }
     setNewSessionMenuAnchor((current) => current === anchor ? null : anchor);

--- a/shell/src/components/terminal/terminal-agent-options.ts
+++ b/shell/src/components/terminal/terminal-agent-options.ts
@@ -10,7 +10,6 @@ export interface TerminalAgentOption {
   installPackage: string;
   installFlags?: string[];
   claudeMode?: boolean;
-  fallbackInstalled: boolean;
 }
 
 export interface TerminalAgentStatus {
@@ -27,7 +26,6 @@ export const TERMINAL_AGENT_OPTIONS: TerminalAgentOption[] = [
     shortcut: "⌘⇧C",
     installPackage: "@anthropic-ai/claude-code@latest",
     claudeMode: true,
-    fallbackInstalled: true,
   },
   {
     id: "codex",
@@ -37,7 +35,6 @@ export const TERMINAL_AGENT_OPTIONS: TerminalAgentOption[] = [
     shortcut: "⌘⇧X",
     launchCommand: "codex",
     installPackage: "@openai/codex@latest",
-    fallbackInstalled: true,
   },
   {
     id: "opencode",
@@ -46,7 +43,6 @@ export const TERMINAL_AGENT_OPTIONS: TerminalAgentOption[] = [
     logoSrc: "/agent-logos/opencode-white.png",
     launchCommand: "opencode",
     installPackage: "opencode-ai@latest",
-    fallbackInstalled: false,
   },
   {
     id: "pi",
@@ -56,7 +52,6 @@ export const TERMINAL_AGENT_OPTIONS: TerminalAgentOption[] = [
     launchCommand: "pi",
     installPackage: "@earendil-works/pi-coding-agent@latest",
     installFlags: ["--ignore-scripts"],
-    fallbackInstalled: false,
   },
 ];
 
@@ -83,6 +78,7 @@ export function terminalAgentInstallCommand(option: TerminalAgentOption): string
   const extraFlags = flags ? `${flags} ` : "";
   return [
     'export MATRIX_NODE_PREFIX="${MATRIX_NODE_PREFIX:-/opt/matrix/runtime/node}"',
+    'export PATH="$MATRIX_NODE_PREFIX/bin:$PATH"',
     `npm install -g ${extraFlags}--prefix "$MATRIX_NODE_PREFIX" ${option.installPackage}`,
   ].join("; ");
 }

--- a/tests/gateway/agent-launcher.test.ts
+++ b/tests/gateway/agent-launcher.test.ts
@@ -59,6 +59,40 @@ describe("agent-launcher", () => {
     }));
   });
 
+  it("detects agents with the Matrix node prefix on PATH", async () => {
+    const originalPath = process.env.PATH;
+    const originalNodePrefix = process.env.MATRIX_NODE_PREFIX;
+    process.env.PATH = "/usr/local/bin:/usr/bin:/bin";
+    process.env.MATRIX_NODE_PREFIX = "/opt/matrix/runtime/node";
+    const runCommand = vi.fn(async () => ({ stdout: "ok\n", stderr: "" }));
+    const launcher = createAgentLauncher({
+      runCommand,
+      cwd: "/home/matrix/home",
+      runtimeHome: "/home/matrix/home",
+    });
+
+    try {
+      await launcher.detectAgents();
+    } finally {
+      if (originalPath === undefined) {
+        delete process.env.PATH;
+      } else {
+        process.env.PATH = originalPath;
+      }
+      if (originalNodePrefix === undefined) {
+        delete process.env.MATRIX_NODE_PREFIX;
+      } else {
+        process.env.MATRIX_NODE_PREFIX = originalNodePrefix;
+      }
+    }
+
+    expect(runCommand).toHaveBeenCalledWith("claude", ["--version"], expect.objectContaining({
+      env: expect.objectContaining({
+        PATH: "/home/matrix/home/.local/bin:/opt/matrix/runtime/node/bin:/usr/local/bin:/usr/bin:/bin",
+      }),
+    }));
+  });
+
   it("constructs non-interactive Codex exec argv without shell interpolation", () => {
     const launch = buildAgentLaunch({
       agent: "codex",

--- a/tests/gateway/shell-zellij.test.ts
+++ b/tests/gateway/shell-zellij.test.ts
@@ -362,6 +362,8 @@ describe("zellij adapter", () => {
       expect(shell).not.toContain("/bin/bash");
       expect(shellMode & 0o700).toBe(0o700);
       expect(bashrc).toContain('matrix_prepend_terminal_path "${MATRIX_NODE_PREFIX:-/opt/matrix/runtime/node}/bin"');
+      expect(bashrc).toContain('if [ -n "${MATRIX_HOME:-}" ]; then');
+      expect(bashrc).toContain('matrix_prepend_terminal_path "$MATRIX_HOME/.local/bin"');
       expect(bashrc).toContain('PS1="${MATRIX_TERMINAL_PROMPT}"');
       expect(bashrc).toContain("\\u:\\w\\$ ");
       expect(promptLabel).toContain("JSON.parse");

--- a/tests/gateway/shell-zellij.test.ts
+++ b/tests/gateway/shell-zellij.test.ts
@@ -354,11 +354,14 @@ describe("zellij adapter", () => {
       expect(config).toContain('default_layout "matrix"');
       expect(config).toContain(`default_shell ${JSON.stringify(shellPath)}`);
       expect(shell).toContain(`exec bash --noprofile --rcfile '${bashrcPath}' -i`);
+      expect(shell).toContain('matrix_prepend_terminal_path "$MATRIX_HOME/.local/bin"');
+      expect(shell).toContain('matrix_prepend_terminal_path "${MATRIX_NODE_PREFIX:-/opt/matrix/runtime/node}/bin"');
       expect(shell).toContain('if [ "$#" -gt 0 ]; then');
       expect(shell).toContain('  set +e\n  ( "$@" )\n  set -e');
       expect(shell).toContain(`node '${promptLabelPath}'`);
       expect(shell).not.toContain("/bin/bash");
       expect(shellMode & 0o700).toBe(0o700);
+      expect(bashrc).toContain('matrix_prepend_terminal_path "${MATRIX_NODE_PREFIX:-/opt/matrix/runtime/node}/bin"');
       expect(bashrc).toContain('PS1="${MATRIX_TERMINAL_PROMPT}"');
       expect(bashrc).toContain("\\u:\\w\\$ ");
       expect(promptLabel).toContain("JSON.parse");

--- a/tests/shell/terminal-agent-options.test.ts
+++ b/tests/shell/terminal-agent-options.test.ts
@@ -27,7 +27,7 @@ describe("terminal agent options", () => {
     expect(codex).toBeDefined();
 
     expect(terminalAgentInstallCommand(codex!)).toBe(
-      'export MATRIX_NODE_PREFIX="${MATRIX_NODE_PREFIX:-/opt/matrix/runtime/node}"; npm install -g --prefix "$MATRIX_NODE_PREFIX" @openai/codex@latest',
+      'export MATRIX_NODE_PREFIX="${MATRIX_NODE_PREFIX:-/opt/matrix/runtime/node}"; export PATH="$MATRIX_NODE_PREFIX/bin:$PATH"; npm install -g --prefix "$MATRIX_NODE_PREFIX" @openai/codex@latest',
     );
   });
 

--- a/tests/shell/terminal-app-component.test.tsx
+++ b/tests/shell/terminal-app-component.test.tsx
@@ -93,9 +93,13 @@ async function chooseNewSessionMenuItem(name: RegExp | string) {
 
 async function chooseNewSessionMenuItemAfterStatus(name: RegExp | string) {
   await openNewSessionMenu();
-  const menu = screen.getByRole("menu", { name: "New session menu" });
-  const item = await vi.waitFor(() => within(menu).getByRole("menuitem", { name }));
-  fireEvent.click(item);
+  const item = await vi.waitFor(() => (
+    within(screen.getByRole("menu", { name: "New session menu" })).getByRole("menuitem", { name })
+  ));
+  await act(async () => {
+    fireEvent.click(item);
+    await Promise.resolve();
+  });
   await vi.waitFor(() => {
     expect(screen.queryByRole("menu", { name: "New session menu" })).toBeNull();
   });
@@ -1881,8 +1885,8 @@ describe("TerminalApp", () => {
     const menu = screen.getByRole("menu", { name: "New session menu" });
     expect(within(menu).getByText("NEW TAB")).toBeTruthy();
     expect(within(menu).getByRole("menuitem", { name: /^Shell(?:\s+⌘T)?$/i })).toBeTruthy();
-    expect(within(menu).getByRole("menuitem", { name: /^Claude Code(?:\s+⌘⇧C)?$/i })).toBeTruthy();
-    expect(within(menu).getByRole("menuitem", { name: /^Codex(?:\s+⌘⇧X)?$/i })).toBeTruthy();
+    expect(within(menu).getByRole("menuitem", { name: /Claude Code.*Install/i })).toBeTruthy();
+    expect(within(menu).getByRole("menuitem", { name: /Codex.*Install/i })).toBeTruthy();
     expect(fetchMock.mock.calls.some(([input, init]) => (
       String(input).endsWith("/api/terminal/sessions") &&
       init?.method === "POST"
@@ -3420,6 +3424,44 @@ describe("TerminalApp", () => {
     expectOptimizedImageSrc(within(menu).getByTestId("terminal-agent-logo-image-pi"), "/agent-logos/pi-coding-agent.png");
   });
 
+  it("shows install actions while agent install status is unknown", async () => {
+    vi.stubGlobal("fetch", vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.includes("/api/agents")) {
+        return Promise.resolve({ ok: true, json: async () => ({ agents: [] }) });
+      }
+      if (url.includes("/api/files/tree")) {
+        return Promise.resolve({ ok: true, json: async () => [] });
+      }
+      if (url.includes("/api/terminal/layout") && init?.method === "PUT") {
+        return Promise.resolve({ ok: true, json: async () => ({ ok: true }) });
+      }
+      if (url.includes("/api/terminal/layout")) {
+        return Promise.resolve({ ok: true, json: async () => ({}) });
+      }
+      return Promise.resolve({ ok: true, json: async () => ({}) });
+    }));
+
+    render(<TerminalApp />);
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    await act(async () => {
+      await openNewSessionMenu();
+    });
+
+    const menu = screen.getByRole("menu", { name: "New session menu" });
+    expect(within(menu).getByRole("menuitem", { name: /Claude Code.*Install/ })).toBeTruthy();
+    expect(within(menu).getByRole("menuitem", { name: /Codex.*Install/ })).toBeTruthy();
+    expect(within(menu).getByRole("menuitem", { name: /OpenCode.*Install/ })).toBeTruthy();
+    expect(within(menu).getByRole("menuitem", { name: /Pi.*Install/ })).toBeTruthy();
+    expect(within(menu).getAllByTestId("terminal-agent-install-pill")).toHaveLength(4);
+  });
+
   it("refreshes agent install state when opening the new-session menu", async () => {
     let agentStatusCalls = 0;
     vi.stubGlobal("fetch", vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
@@ -3515,49 +3557,49 @@ describe("TerminalApp", () => {
       await Promise.resolve();
     });
 
-    await act(async () => {
-      await chooseNewSessionMenuItem(/Claude Code/);
-    });
+    await chooseNewSessionMenuItemAfterStatus(/^Claude Code$/);
 
     expect(terminalSessionPostBodies().some((body) => /"name":"claude-[a-z0-9-]+".*"cmd":"claude"/.test(body))).toBe(true);
-    expect(paneGridSpy.mock.lastCall?.[0]).toMatchObject({
-      paneTree: {
-        sessionId: expect.stringMatching(/^claude-[a-z0-9-]+$/),
-      },
+    await vi.waitFor(() => {
+      expect(paneGridSpy.mock.lastCall?.[0]).toMatchObject({
+        paneTree: {
+          sessionId: expect.stringMatching(/^claude-[a-z0-9-]+$/),
+        },
+      });
     });
 
-    await act(async () => {
-      await chooseNewSessionMenuItem(/Codex/);
-    });
+    await chooseNewSessionMenuItemAfterStatus(/^Codex$/);
 
     expect(terminalSessionPostBodies().some((body) => /"name":"codex-[a-z0-9-]+".*"cmd":"codex"/.test(body))).toBe(true);
-    expect(paneGridSpy.mock.lastCall?.[0]).toMatchObject({
-      paneTree: {
-        sessionId: expect.stringMatching(/^codex-[a-z0-9-]+$/),
-        compatMode: "codex-tui",
-      },
+    await vi.waitFor(() => {
+      expect(paneGridSpy.mock.lastCall?.[0]).toMatchObject({
+        paneTree: {
+          sessionId: expect.stringMatching(/^codex-[a-z0-9-]+$/),
+          compatMode: "codex-tui",
+        },
+      });
     });
 
-    await act(async () => {
-      await chooseNewSessionMenuItemAfterStatus(/^OpenCode$/);
-    });
+    await chooseNewSessionMenuItemAfterStatus(/^OpenCode$/);
 
     expect(terminalSessionPostBodies().some((body) => /"name":"opencode-[a-z0-9-]+".*"cmd":"opencode"/.test(body))).toBe(true);
-    expect(paneGridSpy.mock.lastCall?.[0]).toMatchObject({
-      paneTree: {
-        sessionId: expect.stringMatching(/^opencode-[a-z0-9-]+$/),
-      },
+    await vi.waitFor(() => {
+      expect(paneGridSpy.mock.lastCall?.[0]).toMatchObject({
+        paneTree: {
+          sessionId: expect.stringMatching(/^opencode-[a-z0-9-]+$/),
+        },
+      });
     });
 
-    await act(async () => {
-      await chooseNewSessionMenuItemAfterStatus(/^Pi$/);
-    });
+    await chooseNewSessionMenuItemAfterStatus(/^Pi$/);
 
     expect(terminalSessionPostBodies().some((body) => /"name":"pi-[a-z0-9-]+".*"cmd":"pi"/.test(body))).toBe(true);
-    expect(paneGridSpy.mock.lastCall?.[0]).toMatchObject({
-      paneTree: {
-        sessionId: expect.stringMatching(/^pi-[a-z0-9-]+$/),
-      },
+    await vi.waitFor(() => {
+      expect(paneGridSpy.mock.lastCall?.[0]).toMatchObject({
+        paneTree: {
+          sessionId: expect.stringMatching(/^pi-[a-z0-9-]+$/),
+        },
+      });
     });
   });
 
@@ -3614,21 +3656,20 @@ describe("TerminalApp", () => {
       await Promise.resolve();
     });
 
-    await act(async () => {
-      await chooseNewSessionMenuItem(/Claude Code/);
-    });
+    await chooseNewSessionMenuItemAfterStatus(/^Claude Code$/);
 
-    const claudeBodies = terminalSessionPostBodies()
-      .map((body) => JSON.parse(body) as { name: string; cwd: string; cmd?: string })
-      .filter((body) => body.name.startsWith("claude-"));
-
-    expect(claudeBodies.map((body) => body.cwd)).toEqual(["projects", "~"]);
-    expect(claudeBodies.every((body) => body.cmd === "claude")).toBe(true);
-    expect(paneGridSpy.mock.lastCall?.[0]).toMatchObject({
-      paneTree: {
-        cwd: "~",
-        sessionId: expect.stringMatching(/^claude-[a-z0-9-]+$/),
-      },
+    await vi.waitFor(() => {
+      const bodies = terminalSessionPostBodies()
+        .map((body) => JSON.parse(body) as { name: string; cwd: string; cmd?: string })
+        .filter((body) => body.name.startsWith("claude-"));
+      expect(bodies.map((body) => body.cwd)).toEqual(["projects", "~"]);
+      expect(bodies.every((body) => body.cmd === "claude")).toBe(true);
+      expect(paneGridSpy.mock.lastCall?.[0]).toMatchObject({
+        paneTree: {
+          cwd: "~",
+          sessionId: expect.stringMatching(/^claude-[a-z0-9-]+$/),
+        },
+      });
     });
   });
 


### PR DESCRIPTION
## Summary
- Make `/api/agents` resolve coding-agent CLIs with the same Matrix runtime PATH used by terminal installs: `$MATRIX_HOME/.local/bin` plus `$MATRIX_NODE_PREFIX/bin`.
- Bootstrap that PATH into generated zellij shells and the fallback interactive bashrc so `claude`, `codex`, `opencode`, and `pi` remain available after Ctrl+C returns to an interactive shell.
- Remove stale optimistic UI fallbacks for Claude/Codex and clear cached agent status when the new-session menu opens, so unknown status shows Install until a fresh `/api/agents` true result arrives.
- Addressed Greptile follow-up by guarding the bashrc `$MATRIX_HOME/.local/bin` bootstrap when `MATRIX_HOME` is unset and adding the symmetric bashrc assertion.

## Visual Evidence
Local shell screenshot captured with `E2E_TEST_BYPASS=1 NEXT_PUBLIC_E2E_TEST_BYPASS=1`, mocked `/api/agents` returning no installed agents, and the terminal new-session menu open:

![Terminal new-session menu showing all four agents as Install](https://gist.githubusercontent.com/Nima-Naderi/93bf8817d5aeaa9cfc334758574ae128/raw/94508712ecd40327249686d4eb1b93efc3fa7693/matrix-terminal-menu-pr1003.svg)

## Tests
- `bun run test -- tests/gateway/agent-launcher.test.ts tests/gateway/shell-zellij.test.ts tests/shell/terminal-agent-options.test.ts tests/shell/terminal-app-component.test.tsx`
- `pnpm --filter @matrix-os/gateway exec tsc --noEmit`
- `bun run check:patterns` (0 violations; 5 existing warning groups)
- `pnpm --filter ./shell exec tsc --noEmit` (passed before the Greptile follow-up; no shell source changed afterward)
- `bun run typecheck` (passed before the Greptile follow-up; follow-up was gateway shell-template/test-only)
- `pnpm --filter @matrix-os/brand build` before local screenshot capture
- `bun run test` attempted locally, but the broad suite produced many unrelated failures/timeouts and then hung with no output after the final tail; interrupted with code 130. Observed categories included missing localStorage/fetch in broad jsdom app tests, loopback/CLI daemon timeouts, app-runtime Vite build timeouts, sandboxed git/GPG commit failures, and E2E gateway tests failing without a live gateway harness.

## Review/Monitoring
- Greptile initial review was 4/5 on commit `9b31e881`; code/test comments have been addressed in `c6baa42c` and visual evidence has been added.
- `ready-for-ci` has not been added yet. It will only be added after the latest trusted Greptile result is 5/5.

## Invariants
- Source of truth: installed agent availability now comes from executable discovery under the Matrix runtime PATH; the shell menu no longer treats Claude/Codex as installed without a true backend status.
- Lock/transaction scope: no database writes, locks, or transactions are introduced.
- Acceptable orphan states: while status is loading or the binary is genuinely missing/corrupt, the menu shows Install. Existing already-open shell panes may need a new shell to inherit the corrected PATH after deployment.
- Auth source of truth: unchanged; existing terminal session and `/api/agents` auth/proxy boundaries remain in force.
- Deferred scope: live VPS host-bundle publish/deploy and any one-off repair of already-corrupt tool installs are outside this PR.
