### PR TITLE
fix(platform): preserve selected preview runtime

### DIFF
--- a/packages/platform/src/session-routing-identity.ts
+++ b/packages/platform/src/session-routing-identity.ts
@@ -284,7 +284,7 @@ export async function resolveAppDomainIdentity(opts: {
         ? claims.runtime_slot
         : undefined;
       // Browser app sessions establish the owner; shell cookies select that owner's active computer.
-      if (bearerToken === appSessionToken && opts.requestedHandle) {
+      if (bearerToken === appSessionToken && opts.requestedHandle && !opts.clerkPrincipalOnly) {
         let requestedMachine = await getActiveUserMachineByHandle(
           opts.db,
           opts.requestedHandle,

--- a/packages/platform/src/session-routing-identity.ts
+++ b/packages/platform/src/session-routing-identity.ts
@@ -283,6 +283,25 @@ export async function resolveAppDomainIdentity(opts: {
       const runtimeSlot = RuntimeSlotSchema.safeParse(claims.runtime_slot).success
         ? claims.runtime_slot
         : undefined;
+      // Browser app sessions establish the owner; shell cookies select that owner's active computer.
+      if (bearerToken === appSessionToken && opts.requestedHandle) {
+        let requestedMachine = await getActiveUserMachineByHandle(
+          opts.db,
+          opts.requestedHandle,
+          opts.runtimeSlot,
+        );
+        if (!requestedMachine && opts.runtimeSlot === 'primary') {
+          requestedMachine = await getActiveUserMachineByHandle(opts.db, opts.requestedHandle);
+        }
+        if (requestedMachine?.clerkUserId === claims.sub) {
+          return {
+            handle: requestedMachine.handle,
+            userId: requestedMachine.clerkUserId,
+            runtimeSlot: requestedMachine.runtimeSlot,
+            source: 'auth',
+          };
+        }
+      }
       if (opts.clerkPrincipalOnly) {
         return {
           handle: claims.handle,

--- a/tests/platform/app-session-runtime-routing.test.ts
+++ b/tests/platform/app-session-runtime-routing.test.ts
@@ -4,6 +4,7 @@ import { createClerkAuth } from "../../packages/platform/src/clerk-auth.js";
 import { type PlatformDB, insertUserMachine } from "../../packages/platform/src/db.js";
 import { createApp } from "../../packages/platform/src/main.js";
 import { APP_SESSION_COOKIE } from "../../packages/platform/src/session-cookies.js";
+import { resolveAppDomainIdentity } from "../../packages/platform/src/session-routing-identity.js";
 import { issueSyncJwt } from "../../packages/platform/src/sync-jwt.js";
 import {
   JWT_SECRET,
@@ -129,5 +130,66 @@ describe("browser app-session runtime routing", () => {
 
     expect(response.status).toBe(200);
     expect(fetchMock.mock.calls[0]?.[0]).toBe("https://203.0.113.20:443/api/projects");
+  });
+
+  it("falls back to the signed app-session machine when the selected machine is missing", async () => {
+    await insertMachine(db, {
+      handle: "alice-primary",
+      runtimeSlot: "primary",
+      publicIPv4: "203.0.113.20",
+    });
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response("primary", { status: 200 }),
+    );
+    const app = createApp({
+      db,
+      orchestrator: stubOrchestrator(),
+      clerkAuth: createClerkAuth({ verifyToken: vi.fn().mockResolvedValue(null) }),
+      platformSecret: "platform-secret-123",
+    });
+
+    const response = await app.request("/api/projects", {
+      headers: {
+        host: "app.matrix-os.com",
+        cookie: [
+          await primarySessionCookie(),
+          "matrix_shell_route=missing-review",
+          "matrix_shell_runtime_slot=review",
+        ].join("; "),
+      },
+    });
+
+    expect(response.status).toBe(200);
+    expect(fetchMock.mock.calls[0]?.[0]).toBe("https://203.0.113.20:443/api/projects");
+  });
+
+  it("keeps principal-only resolution independent from selected machine cookies", async () => {
+    await insertMachine(db, {
+      handle: "alice-review",
+      runtimeSlot: "review",
+      publicIPv4: "203.0.113.21",
+    });
+    const cookieHeader = [
+      await primarySessionCookie(),
+      "matrix_shell_route=alice-review",
+      "matrix_shell_runtime_slot=review",
+    ].join("; ");
+
+    const identity = await resolveAppDomainIdentity({
+      authHeader: undefined,
+      cookieHeader,
+      db,
+      platformJwtSecret: JWT_SECRET,
+      clerkPrincipalOnly: true,
+      requestedHandle: "alice-review",
+      runtimeSlot: "review",
+    });
+
+    expect(identity).toMatchObject({
+      handle: "alice-primary",
+      userId: "user_alice",
+      runtimeSlot: "primary",
+      source: "auth",
+    });
   });
 });

--- a/tests/platform/app-session-runtime-routing.test.ts
+++ b/tests/platform/app-session-runtime-routing.test.ts
@@ -1,0 +1,133 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { createClerkAuth } from "../../packages/platform/src/clerk-auth.js";
+import { type PlatformDB, insertUserMachine } from "../../packages/platform/src/db.js";
+import { createApp } from "../../packages/platform/src/main.js";
+import { APP_SESSION_COOKIE } from "../../packages/platform/src/session-cookies.js";
+import { issueSyncJwt } from "../../packages/platform/src/sync-jwt.js";
+import {
+  JWT_SECRET,
+  cleanupProxyRoutingTest,
+  setupProxyRoutingTest,
+  stubOrchestrator,
+} from "./proxy-routing-test-utils.js";
+
+async function insertMachine(
+  db: PlatformDB,
+  input: {
+    clerkUserId?: string;
+    handle: string;
+    runtimeSlot: string;
+    publicIPv4: string;
+  },
+): Promise<void> {
+  await insertUserMachine(db, {
+    machineId: `machine-${input.handle}`,
+    clerkUserId: input.clerkUserId ?? "user_alice",
+    handle: input.handle,
+    runtimeSlot: input.runtimeSlot,
+    status: "running",
+    hetznerServerId: 100,
+    publicIPv4: input.publicIPv4,
+    imageVersion: "dev",
+    serverType: "cpx22",
+    provisionedAt: "2026-07-16T00:00:00.000Z",
+  });
+}
+
+describe("browser app-session runtime routing", () => {
+  let db: PlatformDB;
+
+  beforeEach(async () => {
+    process.env.PLATFORM_JWT_SECRET = JWT_SECRET;
+    db = await setupProxyRoutingTest();
+  });
+
+  afterEach(async () => {
+    await cleanupProxyRoutingTest(db);
+  });
+
+  async function primarySessionCookie(): Promise<string> {
+    const issued = await issueSyncJwt({
+      secret: JWT_SECRET,
+      clerkUserId: "user_alice",
+      handle: "alice-primary",
+      gatewayUrl: "https://app.matrix-os.com/vm/alice-primary",
+      runtimeSlot: "primary",
+    });
+    return `${APP_SESSION_COOKIE}=${encodeURIComponent(issued.token)}`;
+  }
+
+  it("keeps a selected same-owner computer when the app session names primary", async () => {
+    await insertMachine(db, {
+      handle: "alice-primary",
+      runtimeSlot: "primary",
+      publicIPv4: "203.0.113.20",
+    });
+    await insertMachine(db, {
+      handle: "alice-review",
+      runtimeSlot: "review",
+      publicIPv4: "203.0.113.21",
+    });
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response("review", { status: 200 }),
+    );
+    const app = createApp({
+      db,
+      orchestrator: stubOrchestrator(),
+      clerkAuth: createClerkAuth({ verifyToken: vi.fn().mockResolvedValue(null) }),
+      platformSecret: "platform-secret-123",
+    });
+
+    const response = await app.request("/api/projects", {
+      headers: {
+        host: "app.matrix-os.com",
+        cookie: [
+          await primarySessionCookie(),
+          "matrix_shell_route=alice-review",
+          "matrix_shell_runtime_slot=review",
+        ].join("; "),
+      },
+    });
+
+    expect(response.status).toBe(200);
+    expect(fetchMock.mock.calls[0]?.[0]).toBe("https://203.0.113.21:443/api/projects");
+  });
+
+  it("does not let a route cookie move an app session to another owner", async () => {
+    await insertMachine(db, {
+      handle: "alice-primary",
+      runtimeSlot: "primary",
+      publicIPv4: "203.0.113.20",
+    });
+    await insertMachine(db, {
+      clerkUserId: "user_bob",
+      handle: "bob-review",
+      runtimeSlot: "review",
+      publicIPv4: "203.0.113.22",
+    });
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response("primary", { status: 200 }),
+    );
+    const app = createApp({
+      db,
+      orchestrator: stubOrchestrator(),
+      clerkAuth: createClerkAuth({ verifyToken: vi.fn().mockResolvedValue(null) }),
+      platformSecret: "platform-secret-123",
+    });
+
+    const response = await app.request("/api/projects", {
+      headers: {
+        host: "app.matrix-os.com",
+        cookie: [
+          await primarySessionCookie(),
+          "matrix_shell_route=bob-review",
+          "matrix_shell_runtime_slot=review",
+        ].join("; "),
+      },
+    });
+
+    expect(response.status).toBe(200);
+    expect(fetchMock.mock.calls[0]?.[0]).toBe("https://203.0.113.20:443/api/projects");
+  });
+});


### PR DESCRIPTION
## Summary
- preserve an explicitly selected Matrix computer when a browser app-session JWT still names the primary runtime
- require the selected active machine to belong to the signed app-session subject before changing routing
- add focused regression coverage for same-owner selection and cross-owner denial

## Tests
- `vitest run tests/platform/app-session-runtime-routing.test.ts tests/platform/computer-inventory-routes.test.ts tests/platform/runtime-selection-routes.test.ts tests/platform/proxy-routing-billing.test.ts`
- `vitest run tests/platform/proxy-routing.test.ts`
- `tsc --noEmit -p packages/platform/tsconfig.typecheck.json`
- `./scripts/review/check-patterns.sh --diff origin/main`
- `bun run test` attempted, but the shared host terminated the unconstrained Vitest worker pool before a summary; focused and routing suites above pass

## Review/Monitoring
- production reproduction: `matrix_app_session=<primary>` plus `matrix_shell_route=<preview>` incorrectly resolved primary before this change
- no production deployment or machine mutation is included in this PR

## Invariants
- **Source of truth:** the signed app-session subject establishes ownership; `user_machines` establishes active machine ownership; shell route cookies only select within that owner
- **Lock/transaction scope:** read-only identity resolution; no writes or transaction changes
- **Acceptable orphan states:** missing, deleted, invalid-slot, or cross-owner selected machines fall back to the machine named by the signed app session
- **Auth source of truth:** a route cookie never grants identity and cannot cross the JWT subject's Clerk ownership boundary
- **Deferred scope:** reprovisioning missing preview machines and restoring PR-specific bundles are separate operational recovery work
