### PR TITLE
fix(platform): keep fleet deploys off previews

### DIFF
--- a/packages/platform/src/customer-vps-deploy-selection.ts
+++ b/packages/platform/src/customer-vps-deploy-selection.ts
@@ -1,14 +1,11 @@
 import type { UserMachineRecord } from './db.js';
-
-interface DeploySelectionTarget {
-  handle?: string;
-}
+import type { DeployTarget } from './customer-vps.js';
 
 export function selectCustomerVpsDeployMachines<
   T extends Pick<UserMachineRecord, 'handle' | 'provisioningClass'>,
 >(
   runningMachines: readonly T[],
-  target?: DeploySelectionTarget,
+  target?: DeployTarget,
 ): T[] {
   if (target?.handle) {
     return runningMachines.filter((machine) => machine.handle === target.handle);

--- a/packages/platform/src/customer-vps-deploy-selection.ts
+++ b/packages/platform/src/customer-vps-deploy-selection.ts
@@ -1,0 +1,17 @@
+import type { UserMachineRecord } from './db.js';
+
+interface DeploySelectionTarget {
+  handle?: string;
+}
+
+export function selectCustomerVpsDeployMachines<
+  T extends Pick<UserMachineRecord, 'handle' | 'provisioningClass'>,
+>(
+  runningMachines: readonly T[],
+  target?: DeploySelectionTarget,
+): T[] {
+  if (target?.handle) {
+    return runningMachines.filter((machine) => machine.handle === target.handle);
+  }
+  return runningMachines.filter((machine) => machine.provisioningClass !== 'preview');
+}

--- a/packages/platform/src/customer-vps.ts
+++ b/packages/platform/src/customer-vps.ts
@@ -1196,7 +1196,13 @@ export function createCustomerVpsService(deps: CustomerVpsServiceDeps): Customer
     },
 
     async deploy(target?: DeployTarget): Promise<DeployResult> {
-      const runningMachines = await listRunningUserMachines(deps.db, 500);
+      const runningMachines = await listRunningUserMachines(
+        deps.db,
+        500,
+        target?.handle
+          ? { handle: target.handle }
+          : { provisioningClass: 'customer' },
+      );
       const machines = selectCustomerVpsDeployMachines(runningMachines, target);
       const results: DeployResult['results'] = [];
       let triggered = 0;

--- a/packages/platform/src/customer-vps.ts
+++ b/packages/platform/src/customer-vps.ts
@@ -57,6 +57,7 @@ import type {
   ResizeMachineRequest,
 } from './customer-vps-schema.js';
 import { assertPreviewProvisioningCapacity, isPreviewMachine } from './customer-vps-preview.js';
+import { selectCustomerVpsDeployMachines } from './customer-vps-deploy-selection.js';
 import {
   getRuntimeAccessDecision,
   type BillingEntitlement,
@@ -1196,9 +1197,7 @@ export function createCustomerVpsService(deps: CustomerVpsServiceDeps): Customer
 
     async deploy(target?: DeployTarget): Promise<DeployResult> {
       const runningMachines = await listRunningUserMachines(deps.db, 500);
-      const machines = target?.handle
-        ? runningMachines.filter((machine) => machine.handle === target.handle)
-        : runningMachines;
+      const machines = selectCustomerVpsDeployMachines(runningMachines, target);
       const results: DeployResult['results'] = [];
       let triggered = 0;
       let failed = 0;

--- a/packages/platform/src/db.ts
+++ b/packages/platform/src/db.ts
@@ -2166,13 +2166,24 @@ export async function listPendingProviderDeletions(
 export async function listRunningUserMachines(
   db: PlatformDB,
   limit: number,
+  filters: {
+    handle?: string;
+    provisioningClass?: UserMachineProvisioningClass;
+  } = {},
 ): Promise<UserMachineRecord[]> {
   await db.ready;
-  const rows = await db.executor
+  let query = db.executor
     .selectFrom('user_machines')
     .selectAll()
     .where('status', '=', 'running')
-    .where('deleted_at', 'is', null)
+    .where('deleted_at', 'is', null);
+  if (filters.handle !== undefined) {
+    query = query.where('handle', '=', filters.handle);
+  }
+  if (filters.provisioningClass !== undefined) {
+    query = query.where('provisioning_class', '=', filters.provisioningClass);
+  }
+  const rows = await query
     .orderBy('last_seen_at', 'desc')
     .limit(limit)
     .execute();

--- a/tests/platform/customer-vps-deploy-selection.test.ts
+++ b/tests/platform/customer-vps-deploy-selection.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+
+import { selectCustomerVpsDeployMachines } from '../../packages/platform/src/customer-vps-deploy-selection.js';
+
+const customer = {
+  handle: 'alice',
+  provisioningClass: 'customer' as const,
+};
+
+const preview = {
+  handle: 'pr-992',
+  provisioningClass: 'preview' as const,
+};
+
+describe('customer VPS deploy selection', () => {
+  it('excludes preview machines from untargeted fleet deploys', () => {
+    expect(selectCustomerVpsDeployMachines([customer, preview], { version: 'v2026.07.16-765' }))
+      .toEqual([customer]);
+  });
+
+  it('allows an explicitly targeted preview deploy', () => {
+    expect(selectCustomerVpsDeployMachines([customer, preview], {
+      version: 'v2026.07.14-pr992-db1ca31',
+      handle: 'pr-992',
+    })).toEqual([preview]);
+  });
+
+  it('returns no machines for an unknown explicit handle', () => {
+    expect(selectCustomerVpsDeployMachines([customer, preview], {
+      version: 'v2026.07.16-765',
+      handle: 'missing',
+    })).toEqual([]);
+  });
+});

--- a/tests/platform/customer-vps.test.ts
+++ b/tests/platform/customer-vps.test.ts
@@ -9,6 +9,8 @@ import {
   getActiveUserMachineByHandle,
   getRunningUserMachineByHandle,
   getUserMachine,
+  insertUserMachine,
+  listRunningUserMachines,
   listPendingProviderDeletions,
   promoteHostBundleChannel,
   updateUserMachine,
@@ -1828,6 +1830,34 @@ describe('platform/customer-vps', () => {
     } finally {
       vi.unstubAllGlobals();
     }
+  });
+
+  it('filters deploy candidates before applying the running-machine limit', async () => {
+    await insertUserMachine(db, {
+      machineId: '9f05824c-8d0a-4d83-9cb4-b312d43ff120',
+      clerkUserId: 'preview_owner',
+      handle: 'pr-992',
+      runtimeSlot: 'pr-992',
+      provisioningClass: 'preview',
+      status: 'running',
+      provisionedAt: '2026-04-26T12:01:00.000Z',
+      lastSeenAt: '2026-04-26T12:01:00.000Z',
+    });
+    await insertUserMachine(db, {
+      machineId: '9f05824c-8d0a-4d83-9cb4-b312d43ff121',
+      clerkUserId: 'customer_owner',
+      handle: 'alice',
+      provisioningClass: 'customer',
+      status: 'running',
+      provisionedAt: '2026-04-26T12:00:00.000Z',
+      lastSeenAt: '2026-04-26T12:00:00.000Z',
+    });
+
+    const candidates = await listRunningUserMachines(db, 1, {
+      provisioningClass: 'customer',
+    });
+
+    expect(candidates.map((machine) => machine.handle)).toEqual(['alice']);
   });
 
   it('only deploys to the requested VPS handle when provided', async () => {


### PR DESCRIPTION
## Summary

- exclude preview-class machines from untargeted customer fleet releases
- preserve explicit handle deploys used by the Preview VPS workflow
- cover untargeted, explicitly targeted, and unknown-handle selection

## Verification

- `vitest run tests/platform/customer-vps-deploy-selection.test.ts`
- `vitest run tests/platform/customer-vps.test.ts -t "sends channel deploy targets|only deploys to the requested VPS handle"`
- `vitest run tests/platform/customer-vps-routes.test.ts -t "deploys by channel|deploys to a named VPS"`
- `pnpm --filter @matrix-os/platform exec tsc --noEmit -p tsconfig.typecheck.json`
- `./scripts/review/check-patterns.sh --diff origin/main` (0 violations)

## Invariants

- **Source of truth:** `user_machines.provisioning_class` distinguishes preview machines from the customer fleet.
- **Lock/transaction scope:** selection is read-only; existing machine listing and updater request behavior are unchanged.
- **Acceptable orphan states:** an explicit unknown handle selects no machines and triggers no update.
- **Auth source of truth:** platform deploy-route bearer authentication is unchanged.
- **Deferred scope:** preview TTL/reaping and recreation policy remain unchanged.