### PR TITLE
chore(pnpm): enable global virtual store

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -7,6 +7,9 @@ packages:
   - "marketing"
   - "marketing/web"
 
+# Share the dependency-graph-addressed virtual store across Git worktrees.
+enableGlobalVirtualStore: true
+
 # Delay newly published package versions by 7 days (10,080 minutes) to reduce
 # exposure to short-lived compromised npm releases.
 minimumReleaseAge: 10080


### PR DESCRIPTION
## Summary

- enable pnpm's dependency-graph-addressed global virtual store for all workspace installs
- reduce per-worktree node_modules overhead while preserving the shared content-addressable store

## Validation

- pnpm config get enableGlobalVirtualStore returns true
- pnpm install --frozen-lockfile passed in a fresh detached disposable worktree
- 3,019 packages reused with zero downloads
- disposable worktree node_modules used 13 MB locally and linked into the central pnpm store

## Invariants

- Source of truth: pnpm-workspace.yaml
- Lock/transaction scope: no database or runtime lock scope; pnpm-lock.yaml is unchanged
- Acceptable orphan states: existing worktrees keep their current node_modules until reinstalled; new installs use the global virtual store
- Auth source of truth: unchanged; this configuration does not affect authentication
- Deferred scope: bulk reinstalling active or dirty worktrees is intentionally excluded to avoid disrupting in-progress work