### PR TITLE
feat(auth): choose computer during device approval

### DIFF
--- a/desktop/src/main/auth/auth-service.ts
+++ b/desktop/src/main/auth/auth-service.ts
@@ -207,8 +207,8 @@ export class AuthService {
           userId: token.userId,
           handle: token.handle,
         };
-        let runtimeSlot = this.profile?.runtimeSlot ?? "primary";
-        if (runtimeSlot !== "primary") {
+        let runtimeSlot = token.runtimeSlot ?? this.profile?.runtimeSlot ?? "primary";
+        if (!token.runtimeSlot && runtimeSlot !== "primary") {
           try {
             credential = await this.exchangeRuntimeCredential(credential, runtimeSlot);
           } catch (err: unknown) {

--- a/desktop/src/main/auth/device-auth.ts
+++ b/desktop/src/main/auth/device-auth.ts
@@ -21,6 +21,7 @@ export interface DeviceTokenResponse {
   expiresAt: number;
   userId: string;
   handle: string;
+  runtimeSlot?: string;
   // Optional, non-secret display profile (sidebar avatar/name). The platform
   // fills these from Clerk; absent for older gateways or when the profile
   // lookup degraded, so every consumer must treat them as optional.
@@ -125,6 +126,7 @@ export async function pollForToken(options: {
         expiresAt,
         userId,
         handle,
+        ...(optionalString(data.runtimeSlot) ? { runtimeSlot: optionalString(data.runtimeSlot) } : {}),
         ...(optionalString(data.displayName) ? { displayName: optionalString(data.displayName) } : {}),
         ...(optionalString(data.imageUrl) ? { imageUrl: optionalString(data.imageUrl) } : {}),
         ...(optionalString(data.email) ? { email: optionalString(data.email) } : {}),

--- a/packages/platform/src/auth-routes.ts
+++ b/packages/platform/src/auth-routes.ts
@@ -4,6 +4,7 @@ import { bodyLimit } from 'hono/body-limit';
 import { MatrixComputerRuntimeSlotSchema } from '@matrix-os/contracts';
 import {
   createDeviceFlow,
+  DeviceApprovalError,
   type DeviceFlow,
   type DeviceProfile,
   normalizeUserCode,
@@ -18,7 +19,7 @@ import type { PlatformDB } from './db.js';
 import {
   getActiveUserMachineByClerkId,
   getActiveUserMachineByHandle,
-  getRunningUserMachineByClerkId,
+  getRunningUserMachineByClerkIdForUpdate,
   getContainer,
   getContainerByClerkId,
 } from './db.js';
@@ -223,16 +224,22 @@ export function createAuthRoutes(config: AuthRoutesConfig): Hono {
     verificationBase: config.platformUrl,
     expiresInSec: DEVICE_EXPIRES_IN_SEC,
     now: config.now,
-    issueToken: async ({ clerkUserId, runtimeSlot }) => {
+    resolveApprovalTarget: async (transactionDb, { clerkUserId, runtimeSlot }) => {
+      const machine = await getRunningUserMachineByClerkIdForUpdate(
+        transactionDb,
+        clerkUserId,
+        runtimeSlot,
+      );
+      return machine ? { handle: machine.handle, runtimeSlot: machine.runtimeSlot } : null;
+    },
+    issueToken: async ({ clerkUserId, runtimeSlot, handle: approvedHandle }) => {
       const container = config.ignoreLegacyContainers || runtimeSlot
         ? undefined
         : await getContainerByClerkId(config.db, clerkUserId);
-      const machine = container
+      const machine = container || approvedHandle
         ? undefined
-        : runtimeSlot
-          ? await getRunningUserMachineByClerkId(config.db, clerkUserId, runtimeSlot)
-          : await getActiveUserMachineByClerkId(config.db, clerkUserId);
-      const handle = container?.handle ?? machine?.handle;
+        : await getActiveUserMachineByClerkId(config.db, clerkUserId);
+      const handle = approvedHandle ?? container?.handle ?? machine?.handle;
       if (!handle) {
         throw new Error('No runtime provisioned for this Clerk user');
       }
@@ -242,7 +249,7 @@ export function createAuthRoutes(config: AuthRoutesConfig): Hono {
         clerkUserId,
         handle,
         gatewayUrl,
-        runtimeSlot: machine?.runtimeSlot,
+        runtimeSlot: runtimeSlot ?? machine?.runtimeSlot,
       });
       // Best-effort display profile; never let it break sign-in.
       let profile: DeviceProfile | null = null;
@@ -477,21 +484,14 @@ export function createAuthRoutes(config: AuthRoutesConfig): Hono {
       }
 
       try {
-        if (parsedRuntimeSlot.data) {
-          const selectedMachine = await getRunningUserMachineByClerkId(
-            config.db,
-            verifyResult.userId,
-            parsedRuntimeSlot.data,
-          );
-          if (!selectedMachine) {
-            return c.json({ error: 'computer_unavailable' }, 404);
-          }
-        }
         await flow.approveDeviceCode(userCode, verifyResult.userId, parsedRuntimeSlot.data);
         captureAuthEvent("cli_device_approved");
       } catch (err) {
         const msg = err instanceof Error ? err.message : 'approval failed';
         console.error('[device/approve] failed:', msg);
+        if (err instanceof DeviceApprovalError) {
+          return c.json({ error: 'computer_unavailable' }, 404);
+        }
         if (/expired/i.test(msg)) return c.json({ error: 'expired_token' }, 410);
         if (/unknown/i.test(msg)) return c.json({ error: 'invalid_user_code' }, 404);
         return c.json({ error: 'server_error' }, 500);

--- a/packages/platform/src/auth-routes.ts
+++ b/packages/platform/src/auth-routes.ts
@@ -1,6 +1,7 @@
 import { createHmac, randomBytes } from 'node:crypto';
 import { Hono } from 'hono';
 import { bodyLimit } from 'hono/body-limit';
+import { MatrixComputerRuntimeSlotSchema } from '@matrix-os/contracts';
 import {
   createDeviceFlow,
   type DeviceFlow,
@@ -17,10 +18,19 @@ import type { PlatformDB } from './db.js';
 import {
   getActiveUserMachineByClerkId,
   getActiveUserMachineByHandle,
+  getRunningUserMachineByClerkId,
   getContainer,
   getContainerByClerkId,
 } from './db.js';
 import type { ClerkAuth } from './clerk-auth.js';
+import { approvalPage, approvalSuccessPage } from './device-approval-page.js';
+
+function isSyncJwtConfigError(err: unknown): boolean {
+  return err instanceof Error && (
+    err.message === 'verifySyncJwt requires either secret or publicKey' ||
+    err.message.includes('PLATFORM_JWT_SECRET must be at least 32 characters')
+  );
+}
 
 const DEVICE_BODY_LIMIT = 4096;
 const DEVICE_EXPIRES_IN_SEC = 2700;
@@ -137,515 +147,6 @@ function isTrustedNativeDesktopClient(clientId: unknown): boolean {
   return clientId === 'matrix-os-macos' || clientId === 'matrix-os-desktop';
 }
 
-function escapeHtmlAttr(value: string): string {
-  return value
-    .replaceAll("&", "&amp;")
-    .replaceAll('"', "&quot;")
-    .replaceAll("<", "&lt;")
-    .replaceAll(">", "&gt;")
-    .replaceAll("'", "&#39;");
-}
-
-function isSyncJwtConfigError(err: unknown): boolean {
-  return err instanceof Error && (
-    err.message === 'verifySyncJwt requires either secret or publicKey' ||
-    err.message.includes('PLATFORM_JWT_SECRET must be at least 32 characters')
-  );
-}
-
-function approvalPage(
-  userCode: string,
-  csrf: string,
-  publishableKey: string | null,
-  scriptNonce: string,
-  nativeRedirectUri: string | null,
-  nativeRedirectSig: string | null,
-): string {
-  // Renders an HTML page that lets a Clerk-authenticated user confirm the
-  // device pairing. The Clerk widget is loaded for sign-in if needed; once a
-  // session exists, JS sends an explicit bearer token to /auth/device/approve.
-  // The CSRF value is also written as a cookie via Set-Cookie on this response
-  // so POST /auth/device/approve can verify the double-submit.
-  const escapedCode = userCode.replace(/[^A-Z0-9-]/gi, '');
-  const escapedCsrf = csrf.replace(/[^a-f0-9]/gi, '');
-  const escapedPublishableKey = publishableKey
-    ? escapeHtmlAttr(publishableKey)
-    : null;
-  const escapedNativeRedirectUri = nativeRedirectUri ? escapeHtmlAttr(nativeRedirectUri) : '';
-  const escapedNativeRedirectSig = nativeRedirectSig ? escapeHtmlAttr(nativeRedirectSig) : '';
-  const isNativeApp = Boolean(nativeRedirectUri);
-  const productLabel = isNativeApp ? 'Matrix OS app' : 'Matrix CLI';
-  const setupTitle = isNativeApp ? 'Checking Matrix OS' : 'Setting up Matrix CLI';
-  const recoveryDetail = isNativeApp
-    ? 'Matrix could not finish connecting the desktop app. Try again after a moment.'
-    : 'Matrix could not finish connecting this terminal. Try again after a moment.';
-  const clerkScript = publishableKey
-    ? `
-  <script nonce="${scriptNonce}">
-    var userCode = "${escapedCode}";
-    var csrf = "${escapedCsrf}";
-    var approvalUrl = window.location.href;
-    var authMode = new URL(window.location.href).searchParams.get('mode') === 'sign-in' ? 'sign-in' : 'sign-up';
-    var nativeApp = ${isNativeApp ? 'true' : 'false'};
-    var runtimeReady = false;
-
-    function deviceReturnPath() {
-      var url = new URL(window.location.href);
-      url.searchParams.delete('billing');
-      url.searchParams.delete('checkout');
-      return url.pathname + url.search;
-    }
-
-    function billingSetupPath() {
-      var url = new URL('/', window.location.origin);
-      url.searchParams.set('device_return', deviceReturnPath());
-      return url.pathname + url.search;
-    }
-
-    function redirectToBillingSetup() {
-      window.location.assign(billingSetupPath());
-    }
-
-    function deviceAuthUrl(mode) {
-      var url = new URL(approvalUrl);
-      url.searchParams.delete('billing');
-      url.searchParams.delete('checkout');
-      url.searchParams.set('mode', mode);
-      return url.toString();
-    }
-
-    function fetchWithTimeout(url, options) {
-      var controller = new AbortController();
-      var timeoutId = window.setTimeout(function() { controller.abort(); }, 10000);
-      return fetch(url, Object.assign({}, options, { signal: controller.signal })).finally(function() {
-        window.clearTimeout(timeoutId);
-      });
-    }
-
-    function setStatus(message) {
-      var status = document.getElementById('status');
-      if (status) status.textContent = message;
-    }
-
-    function setBusy(isBusy) {
-      var button = document.getElementById('confirm-button');
-      if (button) {
-        button.disabled = isBusy || !runtimeReady;
-        button.textContent = isBusy ? 'authorizing...' : 'approve login';
-      }
-    }
-
-    function setConfirmReady(isReady) {
-      var form = document.getElementById('confirm-area');
-      var confirm = document.getElementById('confirm-button');
-      if (form) form.style.display = isReady ? 'block' : 'none';
-      if (confirm) {
-        confirm.disabled = true;
-        if (isReady) confirm.disabled = false;
-      }
-    }
-
-    function updateSignedInInstance() {
-      var instance = document.getElementById('instance-line');
-      if (!instance || !window.Clerk || !window.Clerk.user) return;
-      var user = window.Clerk.user;
-      var handle = user.username || user.primaryEmailAddress?.emailAddress || user.id;
-      instance.textContent = 'signed in: @' + handle + ' on app.matrix-os.com';
-    }
-
-    function renderActionState(title, detail, primaryLabel, primaryHandler) {
-      var signin = document.getElementById('signin-area');
-      if (!signin) return;
-      signin.style.display = 'block';
-      signin.innerHTML = '';
-      delete signin.dataset.mounted;
-      var state = document.createElement('div');
-      state.className = 'device-state';
-      var heading = document.createElement('h2');
-      heading.textContent = title;
-      state.appendChild(heading);
-      var copy = document.createElement('p');
-      copy.textContent = detail;
-      state.appendChild(copy);
-      var button = document.createElement('button');
-      button.type = 'button';
-      button.textContent = primaryLabel;
-      button.addEventListener('click', primaryHandler);
-      state.appendChild(button);
-      signin.appendChild(state);
-    }
-
-    function showLoadingState(message) {
-      setConfirmReady(false);
-      renderActionState('${setupTitle}', message, 'Working...', function() {});
-      var button = document.querySelector('#signin-area button');
-      if (button) button.disabled = true;
-    }
-
-    function showRuntimeSetupState() {
-      runtimeReady = false;
-      setConfirmReady(false);
-      renderActionState(
-        'Set up your Matrix computer',
-        'Create or activate your Matrix computer first, then return here to approve the desktop app.',
-        'Open setup',
-        redirectToBillingSetup
-      );
-    }
-
-    function showSignedInRecoveryState() {
-      runtimeReady = false;
-      setConfirmReady(false);
-      renderActionState(
-        'Session needs a refresh',
-        '${recoveryDetail}',
-        'Try again',
-        continueDeviceOnboarding
-      );
-    }
-
-    function showConfirm() {
-      runtimeReady = true;
-      var signin = document.getElementById('signin-area');
-      if (signin) {
-        signin.style.display = 'none';
-        signin.innerHTML = '';
-      }
-      setStatus('');
-      setConfirmReady(true);
-    }
-
-    function showSignUp() {
-      runtimeReady = false;
-      setConfirmReady(false);
-      var signin = document.getElementById('signin-area');
-      if (signin) signin.style.display = 'block';
-      if (signin && !signin.dataset.mounted) {
-        signin.dataset.mounted = 'true';
-        window.Clerk.mountSignUp(signin, {
-          signInUrl: deviceAuthUrl('sign-in'),
-          forceRedirectUrl: approvalUrl,
-          fallbackRedirectUrl: approvalUrl,
-          signInForceRedirectUrl: approvalUrl,
-          signInFallbackRedirectUrl: approvalUrl,
-          oauthFlow: 'redirect',
-        });
-      }
-    }
-
-    function showSignIn() {
-      runtimeReady = false;
-      setConfirmReady(false);
-      var signin = document.getElementById('signin-area');
-      if (signin) signin.style.display = 'block';
-      if (signin && !signin.dataset.mounted) {
-        signin.dataset.mounted = 'true';
-        window.Clerk.mountSignIn(signin, {
-          signUpUrl: deviceAuthUrl('sign-up'),
-          forceRedirectUrl: approvalUrl,
-          fallbackRedirectUrl: approvalUrl,
-          signUpForceRedirectUrl: approvalUrl,
-          signUpFallbackRedirectUrl: approvalUrl,
-          oauthFlow: 'redirect',
-        });
-      }
-    }
-
-    function showAuth() {
-      if (authMode === 'sign-in') {
-        showSignIn();
-        return;
-      }
-      showSignUp();
-    }
-
-    async function clerkTokenOrNull() {
-      if (!window.Clerk || !window.Clerk.session) return null;
-      return await window.Clerk.session.getToken();
-    }
-
-    async function continueDeviceOnboarding() {
-      try {
-        var token = await clerkTokenOrNull();
-        if (!token) {
-          showAuth();
-          return;
-        }
-        showLoadingState('Checking your Matrix computer...');
-        var res = await fetchWithTimeout('/api/auth/app-session', {
-          method: 'POST',
-          headers: {
-            Authorization: \`Bearer \${token}\`,
-            'Content-Type': 'application/json',
-          },
-          body: JSON.stringify({ redirectTo: deviceReturnPath() }),
-          credentials: 'same-origin',
-        });
-        if (res.ok) {
-          showConfirm();
-          return;
-        }
-        if (res.status === 402 || res.status === 404) {
-          // Billing-required clients enter browser billing; only native no-runtime 404s keep dedicated setup copy.
-          if (nativeApp && res.status === 404) {
-            showRuntimeSetupState();
-            return;
-          }
-          redirectToBillingSetup();
-          return;
-        }
-        showSignedInRecoveryState();
-      } catch (err) {
-        console.error('[matrix] Device session exchange failed', err instanceof Error ? err.message : String(err));
-        showSignedInRecoveryState();
-      }
-    }
-
-    async function submitApproval(event) {
-      if (!window.Clerk) return;
-      event.preventDefault();
-      setStatus('');
-      setBusy(true);
-
-      try {
-        if (!runtimeReady) {
-          await continueDeviceOnboarding();
-          return;
-        }
-
-        var token = await clerkTokenOrNull();
-        if (!token) {
-          showAuth();
-          return;
-        }
-
-        var body = new URLSearchParams({ userCode: userCode, csrf: csrf });
-        var nativeRedirectUri = document.getElementById('native-redirect-uri')?.value || '';
-        var nativeRedirectSig = document.getElementById('native-redirect-sig')?.value || '';
-        if (nativeRedirectUri) body.set('redirectUri', nativeRedirectUri);
-        if (nativeRedirectSig) body.set('redirectSig', nativeRedirectSig);
-        var res = await fetchWithTimeout('/auth/device/approve', {
-          method: 'POST',
-          headers: {
-            'Content-Type': 'application/x-www-form-urlencoded',
-            Authorization: \`Bearer \${token}\`,
-          },
-          body: body,
-          credentials: 'same-origin',
-        });
-
-        if (res.ok) {
-          var html = await res.text();
-          document.open();
-          document.write(html);
-          document.close();
-          return;
-        }
-
-        setStatus('Could not authorize this device. Refresh and try again.');
-      } catch (err) {
-        console.error('[matrix] Device approval failed', err instanceof Error ? err.message : String(err));
-        setStatus('Could not authorize this device. Refresh and try again.');
-      } finally {
-        setBusy(false);
-      }
-    }
-
-    function initClerk() {
-      window.Clerk.load().then(function() {
-        updateSignedInInstance();
-        if (window.Clerk.user && window.Clerk.session) {
-          continueDeviceOnboarding();
-        } else {
-          showAuth();
-        }
-      }).catch(function() {
-        setStatus('Could not load signup. Refresh and try again.');
-      });
-    }
-
-    document.addEventListener('DOMContentLoaded', function() {
-      var form = document.getElementById('confirm-area');
-      var clerkScript = document.getElementById('clerk-script');
-      if (form) form.addEventListener('submit', submitApproval);
-      if (window.Clerk) {
-        initClerk();
-      } else if (clerkScript) {
-        clerkScript.addEventListener('load', initClerk);
-        clerkScript.addEventListener('error', function() {
-          setStatus('Could not load sign-in. Refresh and try again.');
-        });
-      }
-    });
-  </script>`
-    : '';
-  const clerkLoader = publishableKey
-    ? `
-  <script
-    id="clerk-script"
-    nonce="${scriptNonce}"
-    async crossorigin="anonymous"
-    data-clerk-publishable-key="${escapedPublishableKey}"
-    src="https://clerk.matrix-os.com/npm/@clerk/clerk-js@5/dist/clerk.browser.js"></script>`
-    : '';
-  return `<!DOCTYPE html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Authorize device -- Matrix OS</title>
-  <style>
-    * { box-sizing: border-box; }
-    body {
-      margin: 0;
-      min-height: 100vh;
-      display: grid;
-      place-items: center;
-      background: #101312;
-      color: #e8efe7;
-      font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
-      padding: 24px;
-    }
-    main {
-      width: min(1120px, 100%);
-      display: grid;
-      grid-template-columns: minmax(0, 1fr) minmax(360px, 440px);
-      gap: 24px;
-      align-items: stretch;
-    }
-    .terminal {
-      min-height: 480px;
-      background: #070908;
-      border: 1px solid #2b3a34;
-      border-radius: 8px;
-      overflow: hidden;
-      box-shadow: 0 24px 80px rgba(0,0,0,0.38);
-    }
-    .bar {
-      height: 38px;
-      display: flex;
-      align-items: center;
-      gap: 8px;
-      padding: 0 14px;
-      background: #151a18;
-      border-bottom: 1px solid #2b3a34;
-      color: #9aa8a1;
-      font-size: 13px;
-    }
-    .dot { width: 10px; height: 10px; border-radius: 999px; background: #5f6b65; }
-    .dot.ok { background: #66d19e; }
-    .screen {
-      padding: 28px;
-      font-family: "SFMono-Regular", Consolas, "Liberation Mono", monospace;
-      font-size: 14px;
-      line-height: 1.7;
-    }
-    .prompt { color: #8fbfa3; }
-    .muted { color: #8a968f; }
-    .code {
-      display: inline-block;
-      margin: 12px 0 18px;
-      padding: 10px 14px;
-      border: 1px solid #385247;
-      border-radius: 6px;
-      background: #101714;
-      color: #f4f7f1;
-      font-size: 24px;
-      letter-spacing: 0.08em;
-    }
-    .panel {
-      background: #f6f2e8;
-      color: #25332d;
-      border: 1px solid #ddd4c3;
-      border-radius: 8px;
-      padding: 24px;
-      display: flex;
-      flex-direction: column;
-      gap: 16px;
-    }
-    h1 { margin: 0; font-size: 20px; line-height: 1.2; }
-    h2 { margin: 0; font-size: 18px; line-height: 1.2; }
-    p { margin: 0; color: #516158; line-height: 1.5; }
-    button {
-      width: 100%;
-      background: #25332d;
-      color: #fffdf6;
-      border: 0;
-      padding: 0.75rem 1rem;
-      font-size: 0.95rem;
-      border-radius: 6px;
-      cursor: pointer;
-    }
-    button:disabled { opacity: 0.65; cursor: wait; }
-    .status { min-height: 1.25rem; color: #9f2d2d; }
-    #signin-area { min-width: 0; }
-    .device-state {
-      display: flex;
-      flex-direction: column;
-      gap: 12px;
-      border-top: 1px solid #ded7c9;
-      padding-top: 16px;
-    }
-    @media (max-width: 760px) {
-      main { grid-template-columns: 1fr; }
-      .terminal { min-height: 360px; }
-      .screen { padding: 20px; }
-    }
-  </style>
-</head>
-<body>
-  <main>
-    <section class="terminal" aria-label="${productLabel} login preview">
-      <div class="bar"><span class="dot ok"></span><span class="dot"></span><span class="dot"></span><span>${isNativeApp ? 'matrix app sign in' : 'matrix login'}</span></div>
-      <div class="screen">
-        <div><span class="prompt">matrix</span> login</div>
-        <div class="muted">open app.matrix-os.com/auth/device</div>
-        <div>verification code</div>
-        <div class="code">${escapedCode}</div>
-        <div id="instance-line" class="muted">waiting for signed-in Matrix instance...</div>
-        <br>
-        <div><span class="prompt">matrix</span> whoami</div>
-        <div class="muted">@handle on app.matrix-os.com</div>
-        <div><span class="prompt">matrix</span> shell attach -c main</div>
-        <div><span class="prompt">matrix</span> run -it -- claude</div>
-        <div><span class="prompt">matrix</span> doctor</div>
-      </div>
-    </section>
-    <section class="panel">
-      <div>
-        <h1>Approve ${productLabel}</h1>
-        <p>Authorize ${isNativeApp ? 'the desktop app' : 'this terminal'} to connect to your Matrix OS cloud computer.</p>
-      </div>
-      <div id="signin-area" style="display:none"></div>
-      <form id="confirm-area" method="POST" action="/auth/device/approve" style="display:none">
-        <input type="hidden" name="userCode" value="${escapedCode}">
-        <input type="hidden" name="csrf" value="${escapedCsrf}">
-        <input id="native-redirect-uri" type="hidden" name="redirectUri" value="${escapedNativeRedirectUri}">
-        <input id="native-redirect-sig" type="hidden" name="redirectSig" value="${escapedNativeRedirectSig}">
-        <button id="confirm-button" type="submit" disabled>approve login</button>
-      </form>
-      <p id="status" class="status" role="status" aria-live="polite">${publishableKey ? '' : 'Sign-in is unavailable. Refresh and try again.'}</p>
-    </section>
-  </main>
-  ${clerkLoader}
-  ${clerkScript}
-</body>
-</html>`;
-}
-
-function approvalSuccessPage(nativeRedirectUri: string | null = null): string {
-  const redirectMeta = nativeRedirectUri
-    ? `<meta http-equiv="refresh" content="0; url=${escapeHtmlAttr(nativeRedirectUri)}">`
-    : '';
-  const redirectLink = nativeRedirectUri
-    ? `<p><a href="${escapeHtmlAttr(nativeRedirectUri)}">Return to Matrix OS</a></p>`
-    : '';
-  return `<!DOCTYPE html>
-<html lang="en"><head><meta charset="utf-8">${redirectMeta}<title>Authorized</title>
-<style>body{font-family:-apple-system,sans-serif;background:#0a0a0a;color:#eee;min-height:100vh;display:flex;align-items:center;justify-content:center}.card{max-width:380px;padding:2rem;background:#141414;border:1px solid #222;border-radius:8px;text-align:center}</style></head>
-<body><div class="card"><h1>Login successful</h1><p>You can close this tab and return to Matrix OS.</p>${redirectLink}</div></body></html>`;
-}
-
 function normalizeNativeRedirectUri(value: unknown): string | null {
   if (typeof value !== 'string' || value.length > 512) return null;
   try {
@@ -722,11 +223,15 @@ export function createAuthRoutes(config: AuthRoutesConfig): Hono {
     verificationBase: config.platformUrl,
     expiresInSec: DEVICE_EXPIRES_IN_SEC,
     now: config.now,
-    issueToken: async ({ clerkUserId }) => {
-      const container = config.ignoreLegacyContainers
+    issueToken: async ({ clerkUserId, runtimeSlot }) => {
+      const container = config.ignoreLegacyContainers || runtimeSlot
         ? undefined
         : await getContainerByClerkId(config.db, clerkUserId);
-      const machine = container ? undefined : await getActiveUserMachineByClerkId(config.db, clerkUserId);
+      const machine = container
+        ? undefined
+        : runtimeSlot
+          ? await getRunningUserMachineByClerkId(config.db, clerkUserId, runtimeSlot)
+          : await getActiveUserMachineByClerkId(config.db, clerkUserId);
       const handle = container?.handle ?? machine?.handle;
       if (!handle) {
         throw new Error('No runtime provisioned for this Clerk user');
@@ -737,6 +242,7 @@ export function createAuthRoutes(config: AuthRoutesConfig): Hono {
         clerkUserId,
         handle,
         gatewayUrl,
+        runtimeSlot: machine?.runtimeSlot,
       });
       // Best-effort display profile; never let it break sign-in.
       let profile: DeviceProfile | null = null;
@@ -851,6 +357,7 @@ export function createAuthRoutes(config: AuthRoutesConfig): Hono {
               expiresAt: result.expiresAt,
               userId: result.clerkUserId,
               handle: result.handle,
+              ...(result.runtimeSlot ? { runtimeSlot: result.runtimeSlot } : {}),
               ...(result.profile?.displayName ? { displayName: result.profile.displayName } : {}),
               ...(result.profile?.imageUrl ? { imageUrl: result.profile.imageUrl } : {}),
               ...(result.profile?.email ? { email: result.profile.email } : {}),
@@ -929,6 +436,7 @@ export function createAuthRoutes(config: AuthRoutesConfig): Hono {
       let userCode: string | undefined;
       let formRedirectUri: unknown;
       let formRedirectSig: unknown;
+      let formRuntimeSlot: unknown;
       let nativeRedirectUri: string | null = null;
       try {
         const form = await c.req.parseBody();
@@ -936,6 +444,7 @@ export function createAuthRoutes(config: AuthRoutesConfig): Hono {
         userCode = typeof form.userCode === 'string' ? form.userCode : undefined;
         formRedirectUri = form.redirectUri;
         formRedirectSig = form.redirectSig;
+        formRuntimeSlot = form.runtimeSlot;
       } catch (err: unknown) {
         console.error(
           '[device-flow] Form parse failed:',
@@ -960,9 +469,25 @@ export function createAuthRoutes(config: AuthRoutesConfig): Hono {
         formRedirectUri,
         formRedirectSig,
       );
+      const parsedRuntimeSlot = formRuntimeSlot === undefined || formRuntimeSlot === ''
+        ? { success: true as const, data: undefined }
+        : MatrixComputerRuntimeSlotSchema.safeParse(formRuntimeSlot);
+      if (!parsedRuntimeSlot.success) {
+        return c.json({ error: 'invalid_request' }, 400);
+      }
 
       try {
-        await flow.approveDeviceCode(userCode, verifyResult.userId);
+        if (parsedRuntimeSlot.data) {
+          const selectedMachine = await getRunningUserMachineByClerkId(
+            config.db,
+            verifyResult.userId,
+            parsedRuntimeSlot.data,
+          );
+          if (!selectedMachine) {
+            return c.json({ error: 'computer_unavailable' }, 404);
+          }
+        }
+        await flow.approveDeviceCode(userCode, verifyResult.userId, parsedRuntimeSlot.data);
         captureAuthEvent("cli_device_approved");
       } catch (err) {
         const msg = err instanceof Error ? err.message : 'approval failed';
@@ -999,8 +524,12 @@ export function createAuthRoutes(config: AuthRoutesConfig): Hono {
     if (!claims.sub || !claims.handle) {
       return c.json({ error: 'unauthorized' }, 401);
     }
-    const container = await getContainer(config.db, claims.handle);
-    const machine = container ? undefined : await getActiveUserMachineByHandle(config.db, claims.handle);
+    const container = claims.runtime_slot
+      ? undefined
+      : await getContainer(config.db, claims.handle);
+    const machine = container
+      ? undefined
+      : await getActiveUserMachineByHandle(config.db, claims.handle, claims.runtime_slot);
     const ownerClerkUserId = container?.clerkUserId ?? machine?.clerkUserId;
     const handle = container?.handle ?? machine?.handle;
     if (!ownerClerkUserId || !handle) {
@@ -1015,6 +544,7 @@ export function createAuthRoutes(config: AuthRoutesConfig): Hono {
     return c.json({
       userId: claims.sub,
       handle,
+      ...(machine?.runtimeSlot ? { runtimeSlot: machine.runtimeSlot } : {}),
       gatewayUrl: config.gatewayUrlForHandle(handle),
     });
   });

--- a/packages/platform/src/db.ts
+++ b/packages/platform/src/db.ts
@@ -174,6 +174,7 @@ interface DeviceCodesTable {
   device_code: string;
   user_code: string;
   clerk_user_id: string | null;
+  runtime_slot: string | null;
   expires_at: number;
   last_polled_at: number | null;
   created_at: number;
@@ -903,11 +904,13 @@ async function migrate(db: Kysely<PlatformDatabase>): Promise<void> {
       device_code TEXT PRIMARY KEY,
       user_code TEXT NOT NULL UNIQUE,
       clerk_user_id TEXT,
+      runtime_slot TEXT,
       expires_at BIGINT NOT NULL,
       last_polled_at BIGINT,
       created_at BIGINT NOT NULL
     )
   `.execute(db);
+  await sql`ALTER TABLE device_codes ADD COLUMN IF NOT EXISTS runtime_slot TEXT`.execute(db);
   await sql`CREATE INDEX IF NOT EXISTS idx_device_codes_user_code ON device_codes(user_code)`.execute(db);
   await sql`CREATE INDEX IF NOT EXISTS idx_device_codes_expires_at ON device_codes(expires_at)`.execute(db);
 

--- a/packages/platform/src/db.ts
+++ b/packages/platform/src/db.ts
@@ -175,6 +175,7 @@ interface DeviceCodesTable {
   user_code: string;
   clerk_user_id: string | null;
   runtime_slot: string | null;
+  runtime_handle: string | null;
   expires_at: number;
   last_polled_at: number | null;
   created_at: number;
@@ -905,12 +906,14 @@ async function migrate(db: Kysely<PlatformDatabase>): Promise<void> {
       user_code TEXT NOT NULL UNIQUE,
       clerk_user_id TEXT,
       runtime_slot TEXT,
+      runtime_handle TEXT,
       expires_at BIGINT NOT NULL,
       last_polled_at BIGINT,
       created_at BIGINT NOT NULL
     )
   `.execute(db);
   await sql`ALTER TABLE device_codes ADD COLUMN IF NOT EXISTS runtime_slot TEXT`.execute(db);
+  await sql`ALTER TABLE device_codes ADD COLUMN IF NOT EXISTS runtime_handle TEXT`.execute(db);
   await sql`CREATE INDEX IF NOT EXISTS idx_device_codes_user_code ON device_codes(user_code)`.execute(db);
   await sql`CREATE INDEX IF NOT EXISTS idx_device_codes_expires_at ON device_codes(expires_at)`.execute(db);
 
@@ -1915,6 +1918,24 @@ export async function getRunningUserMachineByClerkId(
     .where('runtime_slot', '=', runtimeSlot)
     .where('status', '=', 'running')
     .where('deleted_at', 'is', null)
+    .executeTakeFirst();
+  return row ? mapUserMachine(row) : undefined;
+}
+
+export async function getRunningUserMachineByClerkIdForUpdate(
+  db: PlatformDB,
+  clerkUserId: string,
+  runtimeSlot: string,
+): Promise<UserMachineRecord | undefined> {
+  await db.ready;
+  const row = await db.executor
+    .selectFrom('user_machines')
+    .selectAll()
+    .where('clerk_user_id', '=', clerkUserId)
+    .where('runtime_slot', '=', runtimeSlot)
+    .where('status', '=', 'running')
+    .where('deleted_at', 'is', null)
+    .forUpdate()
     .executeTakeFirst();
   return row ? mapUserMachine(row) : undefined;
 }

--- a/packages/platform/src/device-approval-page.ts
+++ b/packages/platform/src/device-approval-page.ts
@@ -1,0 +1,652 @@
+function escapeHtmlAttr(value: string): string {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll("'", "&#39;");
+}
+
+export function approvalPage(
+  userCode: string,
+  csrf: string,
+  publishableKey: string | null,
+  scriptNonce: string,
+  nativeRedirectUri: string | null,
+  nativeRedirectSig: string | null,
+): string {
+  // Renders an HTML page that lets a Clerk-authenticated user confirm the
+  // device pairing. The Clerk widget is loaded for sign-in if needed; once a
+  // session exists, JS sends an explicit bearer token to /auth/device/approve.
+  // The CSRF value is also written as a cookie via Set-Cookie on this response
+  // so POST /auth/device/approve can verify the double-submit.
+  const escapedCode = userCode.replace(/[^A-Z0-9-]/gi, '');
+  const escapedCsrf = csrf.replace(/[^a-f0-9]/gi, '');
+  const escapedPublishableKey = publishableKey
+    ? escapeHtmlAttr(publishableKey)
+    : null;
+  const escapedNativeRedirectUri = nativeRedirectUri ? escapeHtmlAttr(nativeRedirectUri) : '';
+  const escapedNativeRedirectSig = nativeRedirectSig ? escapeHtmlAttr(nativeRedirectSig) : '';
+  const isNativeApp = Boolean(nativeRedirectUri);
+  const productLabel = isNativeApp ? 'Matrix OS app' : 'Matrix CLI';
+  const setupTitle = isNativeApp ? 'Checking Matrix OS' : 'Setting up Matrix CLI';
+  const recoveryDetail = isNativeApp
+    ? 'Matrix could not finish connecting the desktop app. Try again after a moment.'
+    : 'Matrix could not finish connecting this terminal. Try again after a moment.';
+  const clerkScript = publishableKey
+    ? `
+  <script nonce="${scriptNonce}">
+    var userCode = "${escapedCode}";
+    var csrf = "${escapedCsrf}";
+    var approvalUrl = window.location.href;
+    var authMode = new URL(window.location.href).searchParams.get('mode') === 'sign-in' ? 'sign-in' : 'sign-up';
+    var nativeApp = ${isNativeApp ? 'true' : 'false'};
+    var runtimeReady = false;
+    var selectedRuntimeSlot = '';
+
+    function deviceReturnPath() {
+      var url = new URL(window.location.href);
+      url.searchParams.delete('billing');
+      url.searchParams.delete('checkout');
+      return url.pathname + url.search;
+    }
+
+    function billingSetupPath() {
+      var url = new URL('/', window.location.origin);
+      url.searchParams.set('device_return', deviceReturnPath());
+      return url.pathname + url.search;
+    }
+
+    function redirectToBillingSetup() {
+      window.location.assign(billingSetupPath());
+    }
+
+    function deviceAuthUrl(mode) {
+      var url = new URL(approvalUrl);
+      url.searchParams.delete('billing');
+      url.searchParams.delete('checkout');
+      url.searchParams.set('mode', mode);
+      return url.toString();
+    }
+
+    function fetchWithTimeout(url, options) {
+      var controller = new AbortController();
+      var timeoutId = window.setTimeout(function() { controller.abort(); }, 10000);
+      return fetch(url, Object.assign({}, options, { signal: controller.signal })).finally(function() {
+        window.clearTimeout(timeoutId);
+      });
+    }
+
+    function setStatus(message) {
+      var status = document.getElementById('status');
+      if (status) status.textContent = message;
+    }
+
+    function setBusy(isBusy) {
+      var button = document.getElementById('confirm-button');
+      if (button) {
+        button.disabled = isBusy || !runtimeReady;
+        button.textContent = isBusy ? 'authorizing...' : 'approve login';
+      }
+    }
+
+    function setConfirmReady(isReady) {
+      var form = document.getElementById('confirm-area');
+      var confirm = document.getElementById('confirm-button');
+      if (form) form.style.display = isReady ? 'block' : 'none';
+      if (confirm) {
+        confirm.disabled = true;
+        if (isReady) confirm.disabled = false;
+      }
+    }
+
+    function updateSignedInIdentity() {
+      var instance = document.getElementById('instance-line');
+      var card = document.getElementById('identity-card');
+      if (!window.Clerk || !window.Clerk.user) return;
+      var user = window.Clerk.user;
+      var handle = user.username || user.primaryEmailAddress?.emailAddress || user.id;
+      var email = user.primaryEmailAddress?.emailAddress || '';
+      var displayName = user.fullName || [user.firstName, user.lastName].filter(Boolean).join(' ') || handle;
+      var avatar = document.getElementById('identity-avatar');
+      var fallback = document.getElementById('identity-avatar-fallback');
+      var name = document.getElementById('identity-name');
+      var username = document.getElementById('identity-username');
+      var emailLine = document.getElementById('identity-email');
+      if (name) name.textContent = displayName;
+      if (username) {
+        username.textContent = user.username ? '@' + user.username : '';
+        username.hidden = !user.username;
+      }
+      if (emailLine) {
+        emailLine.textContent = email;
+        emailLine.hidden = !email;
+      }
+      if (avatar && user.imageUrl) {
+        avatar.addEventListener('error', function() {
+          avatar.hidden = true;
+          if (fallback) {
+            fallback.textContent = displayName.slice(0, 1).toUpperCase();
+            fallback.hidden = false;
+          }
+        }, { once: true });
+        avatar.src = user.imageUrl;
+        avatar.alt = displayName;
+        avatar.hidden = false;
+        if (fallback) fallback.hidden = true;
+      } else if (fallback) {
+        fallback.textContent = displayName.slice(0, 1).toUpperCase();
+        fallback.hidden = false;
+      }
+      if (card) card.hidden = false;
+      if (instance) instance.textContent = 'signed in: @' + handle + ' on app.matrix-os.com';
+    }
+
+    function updateSelectedComputer() {
+      var select = document.getElementById('computer-select');
+      var instance = document.getElementById('instance-line');
+      selectedRuntimeSlot = select?.value || '';
+      runtimeReady = Boolean(selectedRuntimeSlot);
+      if (instance && select?.selectedOptions[0]) {
+        instance.textContent = 'computer: ' + select.selectedOptions[0].textContent;
+      }
+      setBusy(false);
+    }
+
+    function renderComputers(payload) {
+      var section = document.getElementById('computer-field');
+      var select = document.getElementById('computer-select');
+      if (!section || !select || !payload || !Array.isArray(payload.items)) return false;
+      var available = payload.items.filter(function(computer) {
+        return computer && computer.availability === 'available' &&
+          typeof computer.runtimeSlot === 'string' && typeof computer.handle === 'string';
+      });
+      if (available.length === 0) return false;
+      select.innerHTML = '';
+      available.forEach(function(computer) {
+        var option = document.createElement('option');
+        option.value = computer.runtimeSlot;
+        option.textContent = computer.label + ' - ' + computer.handle;
+        select.appendChild(option);
+      });
+      var preferredSlot = typeof payload.selectedSlot === 'string'
+        ? payload.selectedSlot
+        : available.some(function(computer) { return computer.runtimeSlot === 'primary'; })
+          ? 'primary'
+          : available[0].runtimeSlot;
+      select.value = preferredSlot;
+      if (!select.value) select.selectedIndex = 0;
+      select.onchange = updateSelectedComputer;
+      section.hidden = false;
+      updateSelectedComputer();
+      return true;
+    }
+
+    async function loadComputers(token) {
+      var response = await fetchWithTimeout('/api/auth/computers', {
+        headers: { Authorization: \`Bearer \${token}\` },
+        credentials: 'same-origin',
+      });
+      if (!response.ok) return false;
+      return renderComputers(await response.json());
+    }
+
+    function renderActionState(title, detail, primaryLabel, primaryHandler) {
+      var signin = document.getElementById('signin-area');
+      if (!signin) return;
+      signin.style.display = 'block';
+      signin.innerHTML = '';
+      delete signin.dataset.mounted;
+      var state = document.createElement('div');
+      state.className = 'device-state';
+      var heading = document.createElement('h2');
+      heading.textContent = title;
+      state.appendChild(heading);
+      var copy = document.createElement('p');
+      copy.textContent = detail;
+      state.appendChild(copy);
+      var button = document.createElement('button');
+      button.type = 'button';
+      button.textContent = primaryLabel;
+      button.addEventListener('click', primaryHandler);
+      state.appendChild(button);
+      signin.appendChild(state);
+    }
+
+    function showLoadingState(message) {
+      setConfirmReady(false);
+      renderActionState('${setupTitle}', message, 'Working...', function() {});
+      var button = document.querySelector('#signin-area button');
+      if (button) button.disabled = true;
+    }
+
+    function showRuntimeSetupState() {
+      runtimeReady = false;
+      setConfirmReady(false);
+      renderActionState(
+        'Set up your Matrix computer',
+        'Create or activate your Matrix computer first, then return here to approve the desktop app.',
+        'Open setup',
+        redirectToBillingSetup
+      );
+    }
+
+    function showSignedInRecoveryState() {
+      runtimeReady = false;
+      setConfirmReady(false);
+      renderActionState(
+        'Session needs a refresh',
+        '${recoveryDetail}',
+        'Try again',
+        continueDeviceOnboarding
+      );
+    }
+
+    function showConfirm() {
+      var signin = document.getElementById('signin-area');
+      if (signin) {
+        signin.style.display = 'none';
+        signin.innerHTML = '';
+      }
+      setStatus('');
+      setConfirmReady(true);
+    }
+
+    function showSignUp() {
+      runtimeReady = false;
+      setConfirmReady(false);
+      var signin = document.getElementById('signin-area');
+      if (signin) signin.style.display = 'block';
+      if (signin && !signin.dataset.mounted) {
+        signin.dataset.mounted = 'true';
+        window.Clerk.mountSignUp(signin, {
+          signInUrl: deviceAuthUrl('sign-in'),
+          forceRedirectUrl: approvalUrl,
+          fallbackRedirectUrl: approvalUrl,
+          signInForceRedirectUrl: approvalUrl,
+          signInFallbackRedirectUrl: approvalUrl,
+          oauthFlow: 'redirect',
+        });
+      }
+    }
+
+    function showSignIn() {
+      runtimeReady = false;
+      setConfirmReady(false);
+      var signin = document.getElementById('signin-area');
+      if (signin) signin.style.display = 'block';
+      if (signin && !signin.dataset.mounted) {
+        signin.dataset.mounted = 'true';
+        window.Clerk.mountSignIn(signin, {
+          signUpUrl: deviceAuthUrl('sign-up'),
+          forceRedirectUrl: approvalUrl,
+          fallbackRedirectUrl: approvalUrl,
+          signUpForceRedirectUrl: approvalUrl,
+          signUpFallbackRedirectUrl: approvalUrl,
+          oauthFlow: 'redirect',
+        });
+      }
+    }
+
+    function showAuth() {
+      if (authMode === 'sign-in') {
+        showSignIn();
+        return;
+      }
+      showSignUp();
+    }
+
+    async function clerkTokenOrNull() {
+      if (!window.Clerk || !window.Clerk.session) return null;
+      return await window.Clerk.session.getToken();
+    }
+
+    async function continueDeviceOnboarding() {
+      try {
+        var token = await clerkTokenOrNull();
+        if (!token) {
+          showAuth();
+          return;
+        }
+        showLoadingState('Checking your Matrix computer...');
+        var res = await fetchWithTimeout('/api/auth/app-session', {
+          method: 'POST',
+          headers: {
+            Authorization: \`Bearer \${token}\`,
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({ redirectTo: deviceReturnPath() }),
+          credentials: 'same-origin',
+        });
+        if (res.ok) {
+          if (!await loadComputers(token)) {
+            showRuntimeSetupState();
+            return;
+          }
+          showConfirm();
+          return;
+        }
+        if (res.status === 402 || res.status === 404) {
+          // Billing-required clients enter browser billing; only native no-runtime 404s keep dedicated setup copy.
+          if (nativeApp && res.status === 404) {
+            showRuntimeSetupState();
+            return;
+          }
+          redirectToBillingSetup();
+          return;
+        }
+        showSignedInRecoveryState();
+      } catch (err) {
+        console.error('[matrix] Device session exchange failed', err instanceof Error ? err.message : String(err));
+        showSignedInRecoveryState();
+      }
+    }
+
+    async function submitApproval(event) {
+      if (!window.Clerk) return;
+      event.preventDefault();
+      setStatus('');
+      setBusy(true);
+
+      try {
+        if (!runtimeReady) {
+          await continueDeviceOnboarding();
+          return;
+        }
+
+        var token = await clerkTokenOrNull();
+        if (!token) {
+          showAuth();
+          return;
+        }
+
+        var body = new URLSearchParams({ userCode: userCode, csrf: csrf });
+        if (!selectedRuntimeSlot) {
+          setStatus('Choose a computer to continue.');
+          return;
+        }
+        body.set('runtimeSlot', selectedRuntimeSlot);
+        var nativeRedirectUri = document.getElementById('native-redirect-uri')?.value || '';
+        var nativeRedirectSig = document.getElementById('native-redirect-sig')?.value || '';
+        if (nativeRedirectUri) body.set('redirectUri', nativeRedirectUri);
+        if (nativeRedirectSig) body.set('redirectSig', nativeRedirectSig);
+        var res = await fetchWithTimeout('/auth/device/approve', {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/x-www-form-urlencoded',
+            Authorization: \`Bearer \${token}\`,
+          },
+          body: body,
+          credentials: 'same-origin',
+        });
+
+        if (res.ok) {
+          var html = await res.text();
+          document.open();
+          document.write(html);
+          document.close();
+          return;
+        }
+
+        setStatus('Could not authorize this device. Refresh and try again.');
+      } catch (err) {
+        console.error('[matrix] Device approval failed', err instanceof Error ? err.message : String(err));
+        setStatus('Could not authorize this device. Refresh and try again.');
+      } finally {
+        setBusy(false);
+      }
+    }
+
+    function initClerk() {
+      window.Clerk.load().then(function() {
+        updateSignedInIdentity();
+        if (window.Clerk.user && window.Clerk.session) {
+          continueDeviceOnboarding();
+        } else {
+          showAuth();
+        }
+      }).catch(function() {
+        setStatus('Could not load signup. Refresh and try again.');
+      });
+    }
+
+    document.addEventListener('DOMContentLoaded', function() {
+      var form = document.getElementById('confirm-area');
+      var clerkScript = document.getElementById('clerk-script');
+      if (form) form.addEventListener('submit', submitApproval);
+      if (window.Clerk) {
+        initClerk();
+      } else if (clerkScript) {
+        clerkScript.addEventListener('load', initClerk);
+        clerkScript.addEventListener('error', function() {
+          setStatus('Could not load sign-in. Refresh and try again.');
+        });
+      }
+    });
+  </script>`
+    : '';
+  const clerkLoader = publishableKey
+    ? `
+  <script
+    id="clerk-script"
+    nonce="${scriptNonce}"
+    async crossorigin="anonymous"
+    data-clerk-publishable-key="${escapedPublishableKey}"
+    src="https://clerk.matrix-os.com/npm/@clerk/clerk-js@5/dist/clerk.browser.js"></script>`
+    : '';
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Authorize device -- Matrix OS</title>
+  <style>
+    * { box-sizing: border-box; }
+    [hidden] { display: none !important; }
+    body {
+      margin: 0;
+      min-height: 100vh;
+      display: grid;
+      place-items: center;
+      background: #101312;
+      color: #e8efe7;
+      font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      padding: 24px;
+    }
+    main {
+      width: min(1120px, 100%);
+      display: grid;
+      grid-template-columns: minmax(0, 1fr) minmax(360px, 440px);
+      gap: 24px;
+      align-items: stretch;
+    }
+    .terminal {
+      min-height: 480px;
+      background: #070908;
+      border: 1px solid #2b3a34;
+      border-radius: 8px;
+      overflow: hidden;
+      box-shadow: 0 24px 80px rgba(0,0,0,0.38);
+    }
+    .bar {
+      height: 38px;
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      padding: 0 14px;
+      background: #151a18;
+      border-bottom: 1px solid #2b3a34;
+      color: #9aa8a1;
+      font-size: 13px;
+    }
+    .dot { width: 10px; height: 10px; border-radius: 999px; background: #5f6b65; }
+    .dot.ok { background: #66d19e; }
+    .screen {
+      padding: 28px;
+      font-family: "SFMono-Regular", Consolas, "Liberation Mono", monospace;
+      font-size: 14px;
+      line-height: 1.7;
+    }
+    .prompt { color: #8fbfa3; }
+    .muted { color: #8a968f; }
+    .code {
+      display: inline-block;
+      margin: 12px 0 18px;
+      padding: 10px 14px;
+      border: 1px solid #385247;
+      border-radius: 6px;
+      background: #101714;
+      color: #f4f7f1;
+      font-size: 24px;
+      letter-spacing: 0.08em;
+    }
+    .panel {
+      background: #f6f2e8;
+      color: #25332d;
+      border: 1px solid #ddd4c3;
+      border-radius: 8px;
+      padding: 24px;
+      display: flex;
+      flex-direction: column;
+      gap: 16px;
+    }
+    h1 { margin: 0; font-size: 20px; line-height: 1.2; }
+    h2 { margin: 0; font-size: 18px; line-height: 1.2; }
+    p { margin: 0; color: #516158; line-height: 1.5; }
+    button {
+      width: 100%;
+      background: #25332d;
+      color: #fffdf6;
+      border: 0;
+      padding: 0.75rem 1rem;
+      font-size: 0.95rem;
+      border-radius: 6px;
+      cursor: pointer;
+    }
+    button:disabled { opacity: 0.65; cursor: wait; }
+    .status { min-height: 1.25rem; color: #9f2d2d; }
+    .identity {
+      display: grid;
+      grid-template-columns: 44px minmax(0, 1fr);
+      gap: 12px;
+      align-items: center;
+      padding: 12px;
+      border: 1px solid #d7d0c2;
+      border-radius: 6px;
+      background: #fffdf8;
+    }
+    .identity-avatar {
+      width: 44px;
+      height: 44px;
+      border-radius: 50%;
+      object-fit: cover;
+      background: #25332d;
+    }
+    .identity-avatar-fallback {
+      display: grid;
+      place-items: center;
+      color: #fffdf8;
+      font-weight: 700;
+    }
+    .identity-copy { min-width: 0; }
+    .identity-name { color: #25332d; font-weight: 700; }
+    .identity-meta {
+      overflow: hidden;
+      color: #66736c;
+      font-size: 0.82rem;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+    .computer-field { display: grid; gap: 7px; margin: 14px 0; }
+    .computer-field label { color: #35453e; font-size: 0.82rem; font-weight: 700; }
+    .computer-field select {
+      width: 100%;
+      min-height: 42px;
+      border: 1px solid #b9c2bc;
+      border-radius: 6px;
+      background: #fff;
+      color: #25332d;
+      padding: 0 36px 0 12px;
+      font: inherit;
+    }
+    .computer-field select:focus-visible { outline: 2px solid #2c7254; outline-offset: 2px; }
+    #signin-area { min-width: 0; }
+    .device-state {
+      display: flex;
+      flex-direction: column;
+      gap: 12px;
+      border-top: 1px solid #ded7c9;
+      padding-top: 16px;
+    }
+    @media (max-width: 760px) {
+      main { grid-template-columns: 1fr; }
+      .terminal { min-height: 360px; }
+      .screen { padding: 20px; }
+    }
+  </style>
+</head>
+<body>
+  <main>
+    <section class="terminal" aria-label="${productLabel} login preview">
+      <div class="bar"><span class="dot ok"></span><span class="dot"></span><span class="dot"></span><span>${isNativeApp ? 'matrix app sign in' : 'matrix login'}</span></div>
+      <div class="screen">
+        <div><span class="prompt">matrix</span> login</div>
+        <div class="muted">open app.matrix-os.com/auth/device</div>
+        <div>verification code</div>
+        <div class="code">${escapedCode}</div>
+        <div id="instance-line" class="muted">waiting for signed-in Matrix instance...</div>
+        <br>
+        <div><span class="prompt">matrix</span> whoami</div>
+        <div class="muted">@handle on app.matrix-os.com</div>
+        <div><span class="prompt">matrix</span> shell attach -c main</div>
+        <div><span class="prompt">matrix</span> run -it -- claude</div>
+        <div><span class="prompt">matrix</span> doctor</div>
+      </div>
+    </section>
+    <section class="panel">
+      <div>
+        <h1>Approve ${productLabel}</h1>
+        <p>Authorize ${isNativeApp ? 'the desktop app' : 'this terminal'} to connect to your Matrix OS cloud computer.</p>
+      </div>
+      <div id="signin-area" style="display:none"></div>
+      <form id="confirm-area" method="POST" action="/auth/device/approve" style="display:none">
+        <input type="hidden" name="userCode" value="${escapedCode}">
+        <input type="hidden" name="csrf" value="${escapedCsrf}">
+        <input id="native-redirect-uri" type="hidden" name="redirectUri" value="${escapedNativeRedirectUri}">
+        <input id="native-redirect-sig" type="hidden" name="redirectSig" value="${escapedNativeRedirectSig}">
+        <div id="identity-card" class="identity" hidden>
+          <img id="identity-avatar" class="identity-avatar" alt="" referrerpolicy="no-referrer" hidden>
+          <span id="identity-avatar-fallback" class="identity-avatar identity-avatar-fallback" aria-hidden="true" hidden></span>
+          <div class="identity-copy">
+            <div id="identity-name" class="identity-name"></div>
+            <div id="identity-username" class="identity-meta"></div>
+            <div id="identity-email" class="identity-meta"></div>
+          </div>
+        </div>
+        <div id="computer-field" class="computer-field" hidden>
+          <label for="computer-select">Computer</label>
+          <select id="computer-select" name="runtimeSlot" aria-label="Computer"></select>
+        </div>
+        <button id="confirm-button" type="submit" disabled>approve login</button>
+      </form>
+      <p id="status" class="status" role="status" aria-live="polite">${publishableKey ? '' : 'Sign-in is unavailable. Refresh and try again.'}</p>
+    </section>
+  </main>
+  ${clerkLoader}
+  ${clerkScript}
+</body>
+</html>`;
+}
+
+export function approvalSuccessPage(nativeRedirectUri: string | null = null): string {
+  const redirectMeta = nativeRedirectUri
+    ? `<meta http-equiv="refresh" content="0; url=${escapeHtmlAttr(nativeRedirectUri)}">`
+    : '';
+  const redirectLink = nativeRedirectUri
+    ? `<p><a href="${escapeHtmlAttr(nativeRedirectUri)}">Return to Matrix OS</a></p>`
+    : '';
+  return `<!DOCTYPE html>
+<html lang="en"><head><meta charset="utf-8">${redirectMeta}<title>Authorized</title>
+<style>body{font-family:-apple-system,sans-serif;background:#0a0a0a;color:#eee;min-height:100vh;display:flex;align-items:center;justify-content:center}.card{max-width:380px;padding:2rem;background:#141414;border:1px solid #222;border-radius:8px;text-align:center}</style></head>
+<body><div class="card"><h1>Login successful</h1><p>You can close this tab and return to Matrix OS.</p>${redirectLink}</div></body></html>`;
+}

--- a/packages/platform/src/device-approval-page.ts
+++ b/packages/platform/src/device-approval-page.ts
@@ -183,12 +183,18 @@ export function approvalPage(
     }
 
     async function loadComputers(token) {
-      var response = await fetchWithTimeout('/api/auth/computers', {
-        headers: { Authorization: \`Bearer \${token}\` },
-        credentials: 'same-origin',
-      });
-      if (!response.ok) return false;
-      return renderComputers(await response.json());
+      try {
+        var response = await fetchWithTimeout('/api/auth/computers', {
+          headers: { Authorization: \`Bearer \${token}\` },
+          credentials: 'same-origin',
+        });
+        if (response.status === 401 || response.status === 403) return 'auth';
+        if (!response.ok) return 'error';
+        return renderComputers(await response.json()) ? 'ok' : 'empty';
+      } catch (err) {
+        console.error('[matrix] Computer inventory failed', err instanceof Error ? err.message : String(err));
+        return 'error';
+      }
     }
 
     function renderActionState(title, detail, primaryLabel, primaryHandler) {
@@ -319,8 +325,17 @@ export function approvalPage(
           credentials: 'same-origin',
         });
         if (res.ok) {
-          if (!await loadComputers(token)) {
+          var computerState = await loadComputers(token);
+          if (computerState === 'auth') {
+            showAuth();
+            return;
+          }
+          if (computerState === 'empty') {
             showRuntimeSetupState();
+            return;
+          }
+          if (computerState === 'error') {
+            showSignedInRecoveryState();
             return;
           }
           showConfirm();

--- a/packages/platform/src/device-approval-page.ts
+++ b/packages/platform/src/device-approval-page.ts
@@ -43,6 +43,7 @@ export function approvalPage(
     var nativeApp = ${isNativeApp ? 'true' : 'false'};
     var runtimeReady = false;
     var selectedRuntimeSlot = '';
+    var computerSelectionRequired = true;
 
     function deviceReturnPath() {
       var url = new URL(window.location.href);
@@ -162,6 +163,7 @@ export function approvalPage(
           typeof computer.runtimeSlot === 'string' && typeof computer.handle === 'string';
       });
       if (available.length === 0) return false;
+      computerSelectionRequired = true;
       select.innerHTML = '';
       available.forEach(function(computer) {
         var option = document.createElement('option');
@@ -315,6 +317,19 @@ export function approvalPage(
           return;
         }
         showLoadingState('Checking your Matrix computer...');
+        var computerState = await loadComputers(token);
+        if (computerState === 'auth') {
+          showAuth();
+          return;
+        }
+        if (computerState === 'ok') {
+          showConfirm();
+          return;
+        }
+        if (computerState === 'error') {
+          showSignedInRecoveryState();
+          return;
+        }
         var res = await fetchWithTimeout('/api/auth/app-session', {
           method: 'POST',
           headers: {
@@ -325,19 +340,8 @@ export function approvalPage(
           credentials: 'same-origin',
         });
         if (res.ok) {
-          var computerState = await loadComputers(token);
-          if (computerState === 'auth') {
-            showAuth();
-            return;
-          }
-          if (computerState === 'empty') {
-            showRuntimeSetupState();
-            return;
-          }
-          if (computerState === 'error') {
-            showSignedInRecoveryState();
-            return;
-          }
+          computerSelectionRequired = false;
+          runtimeReady = true;
           showConfirm();
           return;
         }
@@ -376,11 +380,11 @@ export function approvalPage(
         }
 
         var body = new URLSearchParams({ userCode: userCode, csrf: csrf });
-        if (!selectedRuntimeSlot) {
+        if (computerSelectionRequired && !selectedRuntimeSlot) {
           setStatus('Choose a computer to continue.');
           return;
         }
-        body.set('runtimeSlot', selectedRuntimeSlot);
+        if (selectedRuntimeSlot) body.set('runtimeSlot', selectedRuntimeSlot);
         var nativeRedirectUri = document.getElementById('native-redirect-uri')?.value || '';
         var nativeRedirectSig = document.getElementById('native-redirect-sig')?.value || '';
         if (nativeRedirectUri) body.set('redirectUri', nativeRedirectUri);

--- a/packages/platform/src/device-flow.ts
+++ b/packages/platform/src/device-flow.ts
@@ -366,7 +366,11 @@ export function createDeviceFlow(config: DeviceFlowConfig): DeviceFlow {
             .execute();
           throw new Error('Expired user_code');
         }
-        if (row.clerk_user_id && row.clerk_user_id !== clerkUserId) {
+        if (row.clerk_user_id) {
+          const sameBinding = row.clerk_user_id === clerkUserId
+            && row.runtime_slot === (runtimeSlot ?? null)
+            && (runtimeSlot === undefined || row.runtime_handle !== null);
+          if (sameBinding) return;
           throw new Error('Device code already approved');
         }
 
@@ -380,7 +384,7 @@ export function createDeviceFlow(config: DeviceFlowConfig): DeviceFlow {
           }
         }
 
-        await trx.executor
+        const updated = await trx.executor
           .updateTable('device_codes')
           .set({
             clerk_user_id: clerkUserId,
@@ -388,7 +392,22 @@ export function createDeviceFlow(config: DeviceFlowConfig): DeviceFlow {
             runtime_handle: selectedTarget?.handle ?? null,
           })
           .where('user_code', '=', normalized)
-          .execute();
+          .where('clerk_user_id', 'is', null)
+          .returning(['clerk_user_id', 'runtime_slot', 'runtime_handle'])
+          .executeTakeFirst();
+        if (updated) return;
+
+        const committed = await trx.executor
+          .selectFrom('device_codes')
+          .select(['clerk_user_id', 'runtime_slot', 'runtime_handle'])
+          .where('user_code', '=', normalized)
+          .executeTakeFirst();
+        const sameCommittedBinding = committed?.clerk_user_id === clerkUserId
+          && committed.runtime_slot === (runtimeSlot ?? null)
+          && committed.runtime_handle === (selectedTarget?.handle ?? null);
+        if (!sameCommittedBinding) {
+          throw new Error('Device code already approved');
+        }
       });
     },
   };

--- a/packages/platform/src/device-flow.ts
+++ b/packages/platform/src/device-flow.ts
@@ -36,6 +36,21 @@ export interface IssuedToken {
 export interface IssueTokenInput {
   clerkUserId: string;
   runtimeSlot?: string;
+  handle?: string;
+}
+
+export interface DeviceApprovalTarget {
+  handle: string;
+  runtimeSlot: string;
+}
+
+export class DeviceApprovalError extends Error {
+  readonly code = 'computer_unavailable';
+
+  constructor() {
+    super('Selected computer unavailable');
+    this.name = 'DeviceApprovalError';
+  }
 }
 
 export type DevicePollResult =
@@ -59,6 +74,10 @@ export interface DeviceFlowConfig {
   intervalSec?: number; // default 5
   maxInFlightPolls?: number; // default 1024
   issueTokenTimeoutMs?: number; // default 30000
+  resolveApprovalTarget?: (
+    db: PlatformDB,
+    input: { clerkUserId: string; runtimeSlot: string },
+  ) => Promise<DeviceApprovalTarget | null>;
   now?: () => number;
   random?: (bytes: number) => Buffer;
   issueToken?: (input: IssueTokenInput) => Promise<IssuedToken>;
@@ -142,6 +161,7 @@ export function createDeviceFlow(config: DeviceFlowConfig): DeviceFlow {
               user_code: userCodeRaw,
               clerk_user_id: null,
               runtime_slot: null,
+              runtime_handle: null,
               expires_at: ts + expiresInSec * 1000,
               last_polled_at: null,
               created_at: ts,
@@ -198,11 +218,11 @@ export function createDeviceFlow(config: DeviceFlowConfig): DeviceFlow {
               .where('device_code', '=', deviceCode)
               .execute();
           }
-          return { status: 'expired' } as DevicePollResult;
+          return { status: 'expired' } as const;
         }
 
         if (row.last_polled_at && ts - row.last_polled_at < intervalSec * 1000) {
-          return { status: 'slow_down' } as DevicePollResult;
+          return { status: 'slow_down' } as const;
         }
 
         if (!row.clerk_user_id) {
@@ -211,13 +231,14 @@ export function createDeviceFlow(config: DeviceFlowConfig): DeviceFlow {
             .set({ last_polled_at: ts })
             .where('device_code', '=', deviceCode)
             .execute();
-          return { status: 'pending' } as DevicePollResult;
+          return { status: 'pending' } as const;
         }
 
         return {
           status: 'approved',
           clerkUserId: row.clerk_user_id,
           runtimeSlot: row.runtime_slot,
+          runtimeHandle: row.runtime_handle,
         } as const;
       });
 
@@ -262,7 +283,8 @@ export function createDeviceFlow(config: DeviceFlowConfig): DeviceFlow {
 
             if (
               row.clerk_user_id !== claimed.clerkUserId ||
-              row.runtime_slot !== claimed.runtimeSlot
+              row.runtime_slot !== claimed.runtimeSlot ||
+              row.runtime_handle !== claimed.runtimeHandle
             ) {
               return { status: 'expired' } as DevicePollResult;
             }
@@ -287,6 +309,7 @@ export function createDeviceFlow(config: DeviceFlowConfig): DeviceFlow {
             void issueToken({
               clerkUserId: claimed.clerkUserId,
               ...(claimed.runtimeSlot ? { runtimeSlot: claimed.runtimeSlot } : {}),
+              ...(claimed.runtimeHandle ? { handle: claimed.runtimeHandle } : {}),
             }).then(
               (value) => {
                 clearTimeout(timer);
@@ -347,11 +370,22 @@ export function createDeviceFlow(config: DeviceFlowConfig): DeviceFlow {
           throw new Error('Device code already approved');
         }
 
+        let selectedTarget: DeviceApprovalTarget | null = null;
+        if (runtimeSlot) {
+          selectedTarget = config.resolveApprovalTarget
+            ? await config.resolveApprovalTarget(trx, { clerkUserId, runtimeSlot })
+            : null;
+          if (!selectedTarget || selectedTarget.runtimeSlot !== runtimeSlot) {
+            throw new DeviceApprovalError();
+          }
+        }
+
         await trx.executor
           .updateTable('device_codes')
           .set({
             clerk_user_id: clerkUserId,
             runtime_slot: runtimeSlot ?? null,
+            runtime_handle: selectedTarget?.handle ?? null,
           })
           .where('user_code', '=', normalized)
           .execute();

--- a/packages/platform/src/device-flow.ts
+++ b/packages/platform/src/device-flow.ts
@@ -35,6 +35,7 @@ export interface IssuedToken {
 
 export interface IssueTokenInput {
   clerkUserId: string;
+  runtimeSlot?: string;
 }
 
 export type DevicePollResult =
@@ -47,6 +48,7 @@ export type DevicePollResult =
       expiresAt: number;
       handle: string;
       clerkUserId: string;
+      runtimeSlot?: string;
       profile?: DeviceProfile;
     };
 
@@ -65,7 +67,7 @@ export interface DeviceFlowConfig {
 export interface DeviceFlow {
   createDeviceCode(): Promise<DeviceCodeIssue>;
   pollDeviceCode(deviceCode: string): Promise<DevicePollResult>;
-  approveDeviceCode(userCode: string, clerkUserId: string): Promise<void>;
+  approveDeviceCode(userCode: string, clerkUserId: string, runtimeSlot?: string): Promise<void>;
 }
 
 export function formatUserCode(raw: string): string {
@@ -139,6 +141,7 @@ export function createDeviceFlow(config: DeviceFlowConfig): DeviceFlow {
               device_code: deviceCode,
               user_code: userCodeRaw,
               clerk_user_id: null,
+              runtime_slot: null,
               expires_at: ts + expiresInSec * 1000,
               last_polled_at: null,
               created_at: ts,
@@ -214,6 +217,7 @@ export function createDeviceFlow(config: DeviceFlowConfig): DeviceFlow {
         return {
           status: 'approved',
           clerkUserId: row.clerk_user_id,
+          runtimeSlot: row.runtime_slot,
         } as const;
       });
 
@@ -256,7 +260,10 @@ export function createDeviceFlow(config: DeviceFlowConfig): DeviceFlow {
               return { status: 'expired' } as DevicePollResult;
             }
 
-            if (row.clerk_user_id !== claimed.clerkUserId) {
+            if (
+              row.clerk_user_id !== claimed.clerkUserId ||
+              row.runtime_slot !== claimed.runtimeSlot
+            ) {
               return { status: 'expired' } as DevicePollResult;
             }
 
@@ -277,7 +284,10 @@ export function createDeviceFlow(config: DeviceFlowConfig): DeviceFlow {
             const timer = setTimeout(() => {
               reject(new Error('issueToken timeout'));
             }, issueTokenTimeoutMs);
-            void issueToken({ clerkUserId: claimed.clerkUserId }).then(
+            void issueToken({
+              clerkUserId: claimed.clerkUserId,
+              ...(claimed.runtimeSlot ? { runtimeSlot: claimed.runtimeSlot } : {}),
+            }).then(
               (value) => {
                 clearTimeout(timer);
                 resolve(value);
@@ -295,6 +305,7 @@ export function createDeviceFlow(config: DeviceFlowConfig): DeviceFlow {
             expiresAt: issued.expiresAt,
             handle: issued.handle,
             clerkUserId: claimed.clerkUserId,
+            ...(claimed.runtimeSlot ? { runtimeSlot: claimed.runtimeSlot } : {}),
             ...(issued.profile ? { profile: issued.profile } : {}),
           });
         } catch (err: unknown) {
@@ -308,7 +319,11 @@ export function createDeviceFlow(config: DeviceFlowConfig): DeviceFlow {
       return issuePromise;
     },
 
-    async approveDeviceCode(userCode: string, clerkUserId: string): Promise<void> {
+    async approveDeviceCode(
+      userCode: string,
+      clerkUserId: string,
+      runtimeSlot?: string,
+    ): Promise<void> {
       const ts = now();
       const normalized = normalizeUserCode(userCode);
       await config.db.transaction(async (trx) => {
@@ -334,7 +349,10 @@ export function createDeviceFlow(config: DeviceFlowConfig): DeviceFlow {
 
         await trx.executor
           .updateTable('device_codes')
-          .set({ clerk_user_id: clerkUserId })
+          .set({
+            clerk_user_id: clerkUserId,
+            runtime_slot: runtimeSlot ?? null,
+          })
           .where('user_code', '=', normalized)
           .execute();
       });

--- a/packages/sync-client/src/auth/token-store.ts
+++ b/packages/sync-client/src/auth/token-store.ts
@@ -11,6 +11,7 @@ export const AuthDataSchema = z.object({
   expiresAt: z.number().nonnegative(),
   userId: z.string().min(1),
   handle: z.string().min(1),
+  runtimeSlot: z.string().min(1).max(32).optional(),
 });
 
 export type AuthData = z.infer<typeof AuthDataSchema>;

--- a/specs/066-file-sync/contracts/auth-api.md
+++ b/specs/066-file-sync/contracts/auth-api.md
@@ -64,7 +64,8 @@ until it gets 200 (approved), 410 (expired), or a hard error.
   accessToken: string,    // signed sync JWT (HS256/RS256)
   expiresAt: number,      // epoch ms
   userId: string,         // Clerk userId, e.g. "user_2abcDEF"
-  handle: string          // "alice"
+  handle: string,         // selected Matrix computer handle, e.g. "alice" or "pr-992"
+  runtimeSlot?: string    // selected runtime slot; omitted by older platform versions
 }
 ```
 
@@ -85,6 +86,7 @@ The JWT carries:
   sub: string,          // Clerk userId
   handle: string,       // matches the gateway's MATRIX_HANDLE
   gateway_url: string,  // hint -- /api/me is authoritative
+  runtime_slot?: string,// selected Matrix computer runtime slot
   iat: number,          // epoch seconds
   exp: number,          // epoch seconds (default iat + 24 hours)
   iss: "matrix-os-platform"
@@ -108,8 +110,10 @@ Set-Cookie: device_csrf=<32-hex>; Path=/auth/device; Max-Age=900;
 
 The page embeds:
 - The Clerk SignIn widget if no session exists, OR
-- A `<form method="POST" action="/auth/device/approve">` with hidden
-  `userCode` and `csrf` inputs once a session is present.
+- The signed-in user's display name, username, email, and profile picture.
+- The user's available Matrix computers from `/api/auth/computers`.
+- A `<form method="POST" action="/auth/device/approve">` with `userCode`,
+  `csrf`, and the selected `runtimeSlot` once a session is present.
 
 **Response 400**: `user_code` query param missing.
 
@@ -124,7 +128,7 @@ Marks the device pairing as approved. Intended for the form on
 
 **Request**: `application/x-www-form-urlencoded`
 ```
-userCode=BCDF-GHJK&csrf=<value>
+userCode=BCDF-GHJK&csrf=<value>&runtimeSlot=primary
 ```
 
 **CSRF check**: the `csrf` form value MUST equal the `device_csrf` cookie
@@ -132,6 +136,8 @@ set by `GET /auth/device`. Constant-time compared.
 
 **Response 200**: `text/html` with "Login successful, return to your terminal".
 The CLI's next poll on `/api/auth/device/token` will return 200 with a JWT.
+The selected computer is validated against the approving Clerk user and bound
+to the one-time device code before the JWT is issued.
 
 **Response 401** `{error: "unauthorized"}`: no Clerk session present or invalid.
 **Response 403** `{error: "csrf_mismatch"}`: CSRF cookie/form mismatch.
@@ -153,7 +159,8 @@ this after successful login to discover where its daemon should connect.
 ```typescript
 {
   userId: string,    // Clerk userId
-  handle: string,    // "alice"
+  handle: string,    // selected computer handle
+  runtimeSlot?: string, // selected VPS runtime slot
   gatewayUrl: string // "https://app.matrix-os.com" or per GATEWAY_URL_TEMPLATE in dev
 }
 ```

--- a/tests/desktop/auth-service.test.ts
+++ b/tests/desktop/auth-service.test.ts
@@ -615,6 +615,7 @@ describe("AuthService device flow", () => {
         expiresAt: 10_000 + HOUR_MS,
         userId: "user-1",
         handle: "neo",
+        runtimeSlot: "review",
         displayName: "Thomas Anderson",
       });
     });
@@ -629,7 +630,7 @@ describe("AuthService device flow", () => {
         signedIn: true,
         handle: "neo",
         displayName: "Thomas Anderson",
-        runtimeSlot: "primary",
+        runtimeSlot: "review",
         platformHost: "https://app.matrix-os.com",
         authGeneration: 1,
       });

--- a/tests/desktop/device-auth.test.ts
+++ b/tests/desktop/device-auth.test.ts
@@ -82,6 +82,7 @@ describe("pollForToken", () => {
         expiresAt: 1,
         userId: "u1",
         handle: "neo",
+        runtimeSlot: "review",
         displayName: "Thomas Anderson",
         imageUrl: "https://img.clerk.com/neo.png",
         email: "neo@matrix-os.com",
@@ -91,6 +92,7 @@ describe("pollForToken", () => {
     expect(result.displayName).toBe("Thomas Anderson");
     expect(result.imageUrl).toBe("https://img.clerk.com/neo.png");
     expect(result.email).toBe("neo@matrix-os.com");
+    expect(result.runtimeSlot).toBe("review");
   });
 
   it("ignores a non-string display profile and still returns the token", async () => {

--- a/tests/platform/device-flow.test.ts
+++ b/tests/platform/device-flow.test.ts
@@ -124,11 +124,17 @@ describe("device flow: polling", () => {
   });
 
   it("binds the approved runtime slot to token issuance", async () => {
-    let issuedFor: { clerkUserId: string; runtimeSlot?: string } | undefined;
+    let issuedFor: { clerkUserId: string; runtimeSlot?: string; handle?: string } | undefined;
+    let approvalDb: PlatformDB | undefined;
     flow = createDeviceFlow({
       db,
       now: () => now,
       verificationBase: VERIFY_BASE,
+      resolveApprovalTarget: async (transactionDb, input) => {
+        approvalDb = transactionDb;
+        expect(input).toEqual({ clerkUserId: "user_alice", runtimeSlot: "pr-992" });
+        return { handle: "pr-992", runtimeSlot: "pr-992" };
+      },
       issueToken: async (input) => {
         issuedFor = input;
         return {
@@ -144,12 +150,41 @@ describe("device flow: polling", () => {
     now += 5_000;
     const result = await flow.pollDeviceCode(issued.deviceCode);
 
-    expect(issuedFor).toEqual({ clerkUserId: "user_alice", runtimeSlot: "pr-992" });
+    expect(approvalDb).toBeDefined();
+    expect(issuedFor).toEqual({
+      clerkUserId: "user_alice",
+      runtimeSlot: "pr-992",
+      handle: "pr-992",
+    });
     expect(result).toMatchObject({
       status: "approved",
       handle: "pr-992",
       runtimeSlot: "pr-992",
     });
+  });
+
+  it("leaves the device code pending when the selected computer is unavailable", async () => {
+    flow = createDeviceFlow({
+      db,
+      now: () => now,
+      verificationBase: VERIFY_BASE,
+      resolveApprovalTarget: async () => null,
+      issueToken: async () => {
+        throw new Error("must not issue");
+      },
+    });
+    const issued = await flow.createDeviceCode();
+
+    await expect(
+      flow.approveDeviceCode(issued.userCode, "user_alice", "missing"),
+    ).rejects.toMatchObject({ code: "computer_unavailable" });
+
+    const row = await db.executor
+      .selectFrom("device_codes")
+      .select(["clerk_user_id", "runtime_slot", "runtime_handle"])
+      .where("device_code", "=", issued.deviceCode)
+      .executeTakeFirstOrThrow();
+    expect(row).toEqual({ clerk_user_id: null, runtime_slot: null, runtime_handle: null });
   });
 
   it("passes through an optional display profile from issueToken", async () => {

--- a/tests/platform/device-flow.test.ts
+++ b/tests/platform/device-flow.test.ts
@@ -123,6 +123,35 @@ describe("device flow: polling", () => {
     expect(result.token).toBe("jwt-for-user_alice");
   });
 
+  it("binds the approved runtime slot to token issuance", async () => {
+    let issuedFor: { clerkUserId: string; runtimeSlot?: string } | undefined;
+    flow = createDeviceFlow({
+      db,
+      now: () => now,
+      verificationBase: VERIFY_BASE,
+      issueToken: async (input) => {
+        issuedFor = input;
+        return {
+          token: `jwt-for-${input.clerkUserId}-${input.runtimeSlot}`,
+          expiresAt: now + 24 * 3_600_000,
+          handle: "pr-992",
+        };
+      },
+    });
+    const issued = await flow.createDeviceCode();
+
+    await flow.approveDeviceCode(issued.userCode, "user_alice", "pr-992");
+    now += 5_000;
+    const result = await flow.pollDeviceCode(issued.deviceCode);
+
+    expect(issuedFor).toEqual({ clerkUserId: "user_alice", runtimeSlot: "pr-992" });
+    expect(result).toMatchObject({
+      status: "approved",
+      handle: "pr-992",
+      runtimeSlot: "pr-992",
+    });
+  });
+
   it("passes through an optional display profile from issueToken", async () => {
     flow = createDeviceFlow({
       db,

--- a/tests/platform/device-flow.test.ts
+++ b/tests/platform/device-flow.test.ts
@@ -163,6 +163,60 @@ describe("device flow: polling", () => {
     });
   });
 
+  it("preserves the first runtime binding across concurrent approvals", async () => {
+    let targetCalls = 0;
+    let signalSecondReached: (() => void) | undefined;
+    let releaseSecond: (() => void) | undefined;
+    const secondReached = new Promise<void>((resolve) => {
+      signalSecondReached = resolve;
+    });
+    const secondMayFinish = new Promise<void>((resolve) => {
+      releaseSecond = resolve;
+    });
+    flow = createDeviceFlow({
+      db,
+      now: () => now,
+      verificationBase: VERIFY_BASE,
+      resolveApprovalTarget: async (_transactionDb, { runtimeSlot }) => {
+        targetCalls++;
+        if (runtimeSlot === "pr-first") {
+          await secondReached;
+          return { handle: "pr-first", runtimeSlot };
+        }
+        signalSecondReached?.();
+        await secondMayFinish;
+        return { handle: "pr-second", runtimeSlot };
+      },
+      issueToken: async () => {
+        throw new Error("must not issue");
+      },
+    });
+    const issued = await flow.createDeviceCode();
+
+    const firstApproval = flow.approveDeviceCode(issued.userCode, "user_alice", "pr-first");
+    await vi.waitFor(() => expect(targetCalls).toBe(1));
+    const secondApproval = flow.approveDeviceCode(issued.userCode, "user_alice", "pr-second");
+    await secondReached;
+
+    await expect(firstApproval).resolves.toBeUndefined();
+    releaseSecond?.();
+    await expect(secondApproval).rejects.toThrow("Device code already approved");
+    await expect(
+      flow.approveDeviceCode(issued.userCode, "user_alice", "pr-first"),
+    ).resolves.toBeUndefined();
+
+    const row = await db.executor
+      .selectFrom("device_codes")
+      .select(["clerk_user_id", "runtime_slot", "runtime_handle"])
+      .where("device_code", "=", issued.deviceCode)
+      .executeTakeFirstOrThrow();
+    expect(row).toEqual({
+      clerk_user_id: "user_alice",
+      runtime_slot: "pr-first",
+      runtime_handle: "pr-first",
+    });
+  });
+
   it("leaves the device code pending when the selected computer is unavailable", async () => {
     flow = createDeviceFlow({
       db,

--- a/tests/platform/device-routes.test.ts
+++ b/tests/platform/device-routes.test.ts
@@ -471,6 +471,118 @@ describe("device routes", () => {
       expect(claims.handle).toBe("bob");
     });
 
+    it("issues a runtime-scoped token for the computer selected during approval", async () => {
+      await insertUserMachine(db, {
+        machineId: "machine_bob_primary",
+        clerkUserId: "user_bob",
+        handle: "bob",
+        runtimeSlot: "primary",
+        status: "running",
+        provisionedAt: new Date().toISOString(),
+      });
+      await insertUserMachine(db, {
+        machineId: "machine_bob_preview",
+        clerkUserId: "user_bob",
+        handle: "pr-992",
+        runtimeSlot: "pr-992",
+        provisioningClass: "preview",
+        status: "running",
+        provisionedAt: new Date().toISOString(),
+      });
+      const authApp = createAuthRoutes({
+        db,
+        clerkAuth: createClerkAuth({
+          verifyToken: vi.fn().mockResolvedValue({ sub: "user_bob" }),
+        }),
+        jwtSecret: JWT_SECRET,
+        platformUrl: "https://app.matrix-os.com",
+        gatewayUrlForHandle: (handle) => `https://app.matrix-os.com/vm/${handle}`,
+        ignoreLegacyContainers: true,
+      });
+      const code = await authApp.request("/api/auth/device/code", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ clientId: "matrixos-cli" }),
+      }).then((response) => response.json());
+      const approvalPage = await authApp.request(`/auth/device?user_code=${code.userCode}`);
+      const csrf = (approvalPage.headers.get("set-cookie") ?? "").match(/device_csrf=([^;]+)/)?.[1];
+
+      const approval = await authApp.request("/auth/device/approve", {
+        method: "POST",
+        headers: {
+          "content-type": "application/x-www-form-urlencoded",
+          authorization: "Bearer clerk-bob",
+          cookie: `device_csrf=${csrf}`,
+        },
+        body: new URLSearchParams({
+          userCode: code.userCode,
+          csrf: csrf ?? "",
+          runtimeSlot: "pr-992",
+        }).toString(),
+      });
+      expect(approval.status).toBe(200);
+
+      const tokenResponse = await authApp.request("/api/auth/device/token", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ deviceCode: code.deviceCode, clientId: "matrixos-cli" }),
+      });
+      expect(tokenResponse.status).toBe(200);
+      const tokenBody = await tokenResponse.json();
+      expect(tokenBody).toMatchObject({ handle: "pr-992", runtimeSlot: "pr-992" });
+      await expect(verifySyncJwt(tokenBody.accessToken, { secret: JWT_SECRET })).resolves.toMatchObject({
+        sub: "user_bob",
+        handle: "pr-992",
+        runtime_slot: "pr-992",
+      });
+
+      const meResponse = await authApp.request("/api/me", {
+        headers: { authorization: `Bearer ${tokenBody.accessToken}` },
+      });
+      expect(meResponse.status).toBe(200);
+      await expect(meResponse.json()).resolves.toMatchObject({
+        handle: "pr-992",
+        runtimeSlot: "pr-992",
+        gatewayUrl: "https://app.matrix-os.com/vm/pr-992",
+      });
+    });
+
+    it("rejects a selected computer that is not owned by the approving user", async () => {
+      await insertUserMachine(db, {
+        machineId: "machine_bob_preview",
+        clerkUserId: "user_bob",
+        handle: "pr-992",
+        runtimeSlot: "pr-992",
+        provisioningClass: "preview",
+        status: "running",
+        provisionedAt: new Date().toISOString(),
+      });
+      const code = await app.request("/api/auth/device/code", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ clientId: "matrixos-cli" }),
+      }).then((response) => response.json());
+      const approvalPage = await app.request(`/auth/device?user_code=${code.userCode}`);
+      const csrf = (approvalPage.headers.get("set-cookie") ?? "").match(/device_csrf=([^;]+)/)?.[1];
+
+      const approval = await app.request("/auth/device/approve", {
+        method: "POST",
+        headers: {
+          "content-type": "application/x-www-form-urlencoded",
+          authorization: "Bearer clerk-alice",
+          cookie: `device_csrf=${csrf}`,
+        },
+        body: new URLSearchParams({
+          userCode: code.userCode,
+          csrf: csrf ?? "",
+          runtimeSlot: "pr-992",
+        }).toString(),
+      });
+
+      expect(approval.status).toBe(404);
+      await expect(approval.json()).resolves.toEqual({ error: "computer_unavailable" });
+    });
+
     it("ignores stale legacy containers when issuing VPS-native device tokens", async () => {
       await insertContainer(db, {
         handle: "stale-bob",
@@ -789,6 +901,14 @@ describe("device routes", () => {
       expect(html).toContain("run -it -- claude");
       expect(html).toContain('<span class="prompt">matrix</span> doctor');
       expect(html).toContain('id="instance-line"');
+      expect(html).toContain('id="identity-card"');
+      expect(html).toContain('id="identity-avatar"');
+      expect(html).toContain('id="identity-name"');
+      expect(html).toContain('id="identity-username"');
+      expect(html).toContain('id="identity-email"');
+      expect(html).toContain('id="computer-select"');
+      expect(html).toContain("fetchWithTimeout('/api/auth/computers'");
+      expect(html).toContain("body.set('runtimeSlot', selectedRuntimeSlot)");
     });
 
     it("starts signed-out CLI approval on signup and sends runtime setup to the shell billing tab", async () => {

--- a/tests/platform/device-routes.test.ts
+++ b/tests/platform/device-routes.test.ts
@@ -913,6 +913,12 @@ describe("device routes", () => {
       expect(html).toContain("return renderComputers(await response.json()) ? 'ok' : 'empty';");
       expect(html).toContain("if (computerState === 'error') {");
       expect(html).toContain("showSignedInRecoveryState();");
+      const continueStart = html.indexOf("async function continueDeviceOnboarding");
+      const inventoryRequest = html.indexOf("var computerState = await loadComputers(token);", continueStart);
+      const appSessionRequest = html.indexOf("fetchWithTimeout('/api/auth/app-session'", continueStart);
+      expect(inventoryRequest).toBeGreaterThan(continueStart);
+      expect(appSessionRequest).toBeGreaterThan(inventoryRequest);
+      expect(html.indexOf("if (computerState === 'ok') {", continueStart)).toBeLessThan(appSessionRequest);
     });
 
     it("starts signed-out CLI approval on signup and sends runtime setup to the shell billing tab", async () => {

--- a/tests/platform/device-routes.test.ts
+++ b/tests/platform/device-routes.test.ts
@@ -909,6 +909,10 @@ describe("device routes", () => {
       expect(html).toContain('id="computer-select"');
       expect(html).toContain("fetchWithTimeout('/api/auth/computers'");
       expect(html).toContain("body.set('runtimeSlot', selectedRuntimeSlot)");
+      expect(html).toContain("return 'auth';");
+      expect(html).toContain("return renderComputers(await response.json()) ? 'ok' : 'empty';");
+      expect(html).toContain("if (computerState === 'error') {");
+      expect(html).toContain("showSignedInRecoveryState();");
     });
 
     it("starts signed-out CLI approval on signup and sends runtime setup to the shell billing tab", async () => {

--- a/www/content/docs/cli.mdx
+++ b/www/content/docs/cli.mdx
@@ -48,7 +48,7 @@ You can also run without installing using `npx --yes @finnaai/matrix <command>` 
 matrix login
 ```
 
-This opens a browser for the device authentication flow. If you do not have a Matrix account yet, `matrix login` waits while the browser walks you through signup, checkout, and provisioning. Approve the CLI in that same browser tab once provisioning finishes.
+This opens a browser for the device authentication flow. The confirmation page shows the signed-in account and lets you choose which available Matrix computer the CLI may access. If you do not have a Matrix account yet, `matrix login` waits while the browser walks you through signup, checkout, and provisioning. Approve the CLI in that same browser tab once provisioning finishes.
 
 **Flags**
 


### PR DESCRIPTION
## Summary

- show the signed-in Clerk name, username, email, and avatar on the shared CLI/desktop approval page
- list available Matrix computers and bind the selected runtime slot and handle to the one-time device code
- issue runtime-scoped JWTs and persist the selected slot in desktop and CLI auth data
- extract the approval renderer from the large auth route module and update auth/CLI documentation

## Verification

- `vitest run tests/platform/device-flow.test.ts tests/platform/device-routes.test.ts` (66 passed)
- `vitest run tests/desktop/device-auth.test.ts tests/desktop/auth-service.test.ts` (37 passed)
- `vitest run packages/sync-client/tests/unit/oauth.test.ts packages/sync-client/tests/unit/token-store.test.ts` from `packages/sync-client` (16 passed)
- `pnpm --filter @matrix-os/platform exec tsc --noEmit -p tsconfig.typecheck.json`
- `pnpm --filter @finnaai/matrix build`
- `./scripts/review/check-patterns.sh --diff origin/main` (0 violations)
- Playwright at 1440x900 and 390x844: one avatar, no body/panel overflow, both computers visible, and selecting preview submitted `runtimeSlot=pr-992`
- Playwright state matrix: success shows confirmation; 401/403 reopens Clerk auth; empty inventory shows setup; 5xx shows recovery

## Known baseline

- Full desktop typecheck remains blocked on current `main` by unrelated `AgentConversationView.tsx` event-union errors and the existing Vite 6/7 plugin mismatch in `electron.vite.config.ts`. Focused desktop auth tests pass.

## Invariants

- **Source of truth:** the selected runtime slot and server-resolved handle are stored on the one-time `device_codes` row; `user_machines` remains authoritative for ownership and running availability at approval.
- **Lock/transaction scope:** the selected machine row is locked while its owner, slot, and handle are bound atomically in the approval transaction; polling atomically consumes the same binding before token issuance.
- **Acceptable orphan states:** missing, stopped, deleted, malformed, or cross-owner selected computers fail approval and leave the device code pending; omitted slots preserve the legacy default-computer flow. A computer going offline after approval does not invalidate the already authorized identity binding.
- **Auth source of truth:** Clerk verification identifies the approver; the server resolves and locks the selected machine by Clerk user ID before binding it.
- **Deferred scope:** custom user-defined computer names are not introduced; this uses the canonical inventory labels and handles. Deployment of the platform-owned app shell remains a separate release action.