### PR TITLE
feat(shell): use adjective-noun UI session names

### DIFF
--- a/apps/mobile/__tests__/mobile-shell-test-utils.ts
+++ b/apps/mobile/__tests__/mobile-shell-test-utils.ts
@@ -51,6 +51,7 @@ export function jsonResponse(body: unknown, init: { ok?: boolean; status?: numbe
     status,
     json: jest.fn().mockResolvedValue(body),
     text: jest.fn().mockResolvedValue(text),
+    clone: jest.fn(() => jsonResponse(body, { ok, status })),
   } as unknown as Response;
 }
 

--- a/apps/mobile/__tests__/terminal-client.test.ts
+++ b/apps/mobile/__tests__/terminal-client.test.ts
@@ -10,6 +10,8 @@ import { jsonResponse } from "./mobile-shell-test-utils";
 
 const SESSION_ID = "c4319d6a-a24c-4820-a0f8-f6f8a6ce76b9";
 const SHELL_NAME = "matrix-7af3c2e";
+const TWO_WORD_SESSION_NAME_PATTERN = /^[a-z]+-[a-z]+$/;
+const TWO_WORD_FALLBACK_SESSION_NAME_PATTERN = /^[a-z]+-[a-z]+-[a-z0-9]{5}$/;
 
 class MockWebSocket {
   static OPEN = 1;
@@ -78,6 +80,33 @@ describe("mobile terminal client", () => {
       `https://app.matrix-os.test/api/terminal/sessions/${SHELL_NAME}?force=1`,
       expect.objectContaining({ method: "DELETE" }),
     );
+  });
+
+  it("creates shell sessions with two-word names before a suffixed collision fallback", async () => {
+    const postedNames: string[] = [];
+    const fetchMock = jest.spyOn(global, "fetch").mockImplementation(async (input, init) => {
+      if (String(input).endsWith("/api/terminal/sessions") && init?.method === "POST") {
+        const body = JSON.parse(String(init.body ?? "{}")) as { name?: string };
+        if (typeof body.name === "string") postedNames.push(body.name);
+        if (postedNames.length <= 3) {
+          return jsonResponse({ error: { code: "session_exists", message: "Request failed" } }, { status: 409 });
+        }
+        return jsonResponse({ name: body.name }, { status: 201 });
+      }
+      return jsonResponse({});
+    });
+
+    const gateway = new GatewayClient("https://app.matrix-os.test", "clerk-token");
+    const created = await gateway.createTerminalSession();
+
+    expect(fetchMock).toHaveBeenCalledTimes(4);
+    expect(created).toBe(postedNames[3]);
+    expect(postedNames.slice(0, 3)).toEqual([
+      expect.stringMatching(TWO_WORD_SESSION_NAME_PATTERN),
+      expect.stringMatching(TWO_WORD_SESSION_NAME_PATTERN),
+      expect.stringMatching(TWO_WORD_SESSION_NAME_PATTERN),
+    ]);
+    expect(postedNames[3]).toMatch(TWO_WORD_FALLBACK_SESSION_NAME_PATTERN);
   });
 
   it("builds token-authenticated terminal websocket URLs", () => {

--- a/apps/mobile/lib/gateway-client.ts
+++ b/apps/mobile/lib/gateway-client.ts
@@ -5,6 +5,7 @@ import {
   type MobileTerminalSession,
 } from "@/lib/terminal-state";
 import { logMobileCodingAgentWarning } from "@/lib/coding-agent-diagnostics";
+import { twoWordShellSessionName } from "@/lib/shell-session-names";
 import {
   AgentThreadEventSchema,
   AgentThreadSnapshotSchema,
@@ -242,6 +243,8 @@ type ReactNativeWebSocketConstructor = new (
 const RECONNECT_BASE_MS = 1000;
 const RECONNECT_MAX_MS = 30000;
 export const DEFAULT_GATEWAY_FETCH_TIMEOUT_MS = 10_000;
+const TWO_WORD_COLLISION_RETRIES = 3;
+const TERMINAL_CREATE_ATTEMPTS = TWO_WORD_COLLISION_RETRIES + 1;
 const SAFE_REVIEW_REFERENCE = /^[A-Za-z0-9][A-Za-z0-9_.:-]{0,127}$/;
 const SECURE_TOKEN_TRANSPORT_ERROR =
   "Matrix OS Cloud requires HTTPS/WSS.";
@@ -298,6 +301,20 @@ function logGatewayCatchWarning(scope: string, err: unknown): void {
 
 function logGatewayWarning(scope: string, detail: unknown): void {
   logMobileCodingAgentWarning(scope, detail);
+}
+
+async function readGatewayErrorCode(res: Response): Promise<string | null> {
+  try {
+    const data = await res.clone().json() as { error?: { code?: unknown } };
+    return typeof data.error?.code === "string" ? data.error.code : null;
+  } catch (err: unknown) {
+    logGatewayCatchWarning("failed to read gateway error code", err);
+    return null;
+  }
+}
+
+async function isSessionExistsResponse(res: Response): Promise<boolean> {
+  return res.status === 409 && await readGatewayErrorCode(res) === "session_exists";
 }
 
 export class GatewayClient {
@@ -1343,28 +1360,37 @@ export class GatewayClient {
 
   /** Create a new shell session and return its zellij name, or null on failure. */
   async createTerminalSession(): Promise<string | null> {
-    const name = `matrix-${randomShellSuffix()}`;
-    try {
-      const res = await this.fetchGateway("/api/terminal/sessions", {
-        method: "POST",
-        body: JSON.stringify({ name }),
-        headers: { "Content-Type": "application/json" },
+    for (let attempt = 0; attempt < TERMINAL_CREATE_ATTEMPTS; attempt += 1) {
+      const name = twoWordShellSessionName({
+        collisionFallback: attempt >= TWO_WORD_COLLISION_RETRIES,
       });
-      if (!res.ok) {
-        await res.text().catch((err: unknown) => {
-          logGatewayCatchWarning("failed to read terminal session create error body", err);
-          return "";
+      try {
+        const res = await this.fetchGateway("/api/terminal/sessions", {
+          method: "POST",
+          body: JSON.stringify({ name }),
+          headers: { "Content-Type": "application/json" },
         });
-        logGatewayStatusWarning("terminal session create failed", res.status);
+        if (await isSessionExistsResponse(res) && attempt < TERMINAL_CREATE_ATTEMPTS - 1) {
+          continue;
+        }
+        if (!res.ok) {
+          await res.text().catch((err: unknown) => {
+            logGatewayCatchWarning("failed to read terminal session create error body", err);
+            return "";
+          });
+          logGatewayStatusWarning("terminal session create failed", res.status);
+          return null;
+        }
+        const body = (await res.json().catch(() => null)) as { name?: unknown } | null;
+        const created = typeof body?.name === "string" ? body.name : name;
+        return isSafeShellSessionName(created) ? created : null;
+      } catch (err: unknown) {
+        logGatewayCatchWarning("terminal session create unavailable", err);
         return null;
       }
-      const body = (await res.json().catch(() => null)) as { name?: unknown } | null;
-      const created = typeof body?.name === "string" ? body.name : name;
-      return isSafeShellSessionName(created) ? created : null;
-    } catch {
-      logGatewayWarning("terminal session create unavailable", "unavailable");
-      return null;
     }
+    logGatewayWarning("terminal session create failed", "collision_exhausted");
+    return null;
   }
 
   /**

--- a/apps/mobile/lib/shell-session-names.ts
+++ b/apps/mobile/lib/shell-session-names.ts
@@ -1,0 +1,30 @@
+const SHELL_SESSION_ADJECTIVES = [
+  "swift", "calm", "bright", "bold", "brave", "clever", "cosmic", "crisp",
+  "amber", "azure", "lunar", "solar", "misty", "quiet", "rapid", "shiny",
+  "still", "vivid", "warm", "wild", "noble", "lucid", "fresh", "keen",
+  "neat", "prime", "spry", "deft", "mellow", "nimble", "sleek", "stark",
+] as const;
+
+const SHELL_SESSION_NOUNS = [
+  "falcon", "otter", "cedar", "river", "comet", "harbor", "meadow", "summit",
+  "willow", "pine", "lynx", "heron", "maple", "delta", "ember", "quartz",
+  "raven", "sparrow", "tide", "vale", "wren", "birch", "cobalt", "drift",
+  "fern", "grove", "isle", "moss", "reef", "dune", "fjord", "atlas",
+] as const;
+
+export interface ShellSessionNameOptions {
+  collisionFallback?: boolean;
+}
+
+function pick<T>(list: readonly T[]): T {
+  return list[Math.floor(Math.random() * list.length)]!;
+}
+
+function entropySuffix(): string {
+  return Math.floor(Math.random() * 36 ** 5).toString(36).padStart(5, "0");
+}
+
+export function twoWordShellSessionName(options: ShellSessionNameOptions = {}): string {
+  const base = `${pick(SHELL_SESSION_ADJECTIVES)}-${pick(SHELL_SESSION_NOUNS)}`;
+  return options.collisionFallback ? `${base}-${entropySuffix()}` : base;
+}

--- a/apps/mobile/lib/shell-session-names.ts
+++ b/apps/mobile/lib/shell-session-names.ts
@@ -1,30 +1,4 @@
-const SHELL_SESSION_ADJECTIVES = [
-  "swift", "calm", "bright", "bold", "brave", "clever", "cosmic", "crisp",
-  "amber", "azure", "lunar", "solar", "misty", "quiet", "rapid", "shiny",
-  "still", "vivid", "warm", "wild", "noble", "lucid", "fresh", "keen",
-  "neat", "prime", "spry", "deft", "mellow", "nimble", "sleek", "stark",
-] as const;
-
-const SHELL_SESSION_NOUNS = [
-  "falcon", "otter", "cedar", "river", "comet", "harbor", "meadow", "summit",
-  "willow", "pine", "lynx", "heron", "maple", "delta", "ember", "quartz",
-  "raven", "sparrow", "tide", "vale", "wren", "birch", "cobalt", "drift",
-  "fern", "grove", "isle", "moss", "reef", "dune", "fjord", "atlas",
-] as const;
-
-export interface ShellSessionNameOptions {
-  collisionFallback?: boolean;
-}
-
-function pick<T>(list: readonly T[]): T {
-  return list[Math.floor(Math.random() * list.length)]!;
-}
-
-function entropySuffix(): string {
-  return Math.floor(Math.random() * 36 ** 5).toString(36).padStart(5, "0");
-}
-
-export function twoWordShellSessionName(options: ShellSessionNameOptions = {}): string {
-  const base = `${pick(SHELL_SESSION_ADJECTIVES)}-${pick(SHELL_SESSION_NOUNS)}`;
-  return options.collisionFallback ? `${base}-${entropySuffix()}` : base;
-}
+export {
+  createShellSessionName as twoWordShellSessionName,
+  type ShellSessionNameOptions,
+} from "@matrix-os/contracts";

--- a/desktop/src/renderer/src/lib/shell-session-names.ts
+++ b/desktop/src/renderer/src/lib/shell-session-names.ts
@@ -1,0 +1,30 @@
+const SHELL_SESSION_ADJECTIVES = [
+  "swift", "calm", "bright", "bold", "brave", "clever", "cosmic", "crisp",
+  "amber", "azure", "lunar", "solar", "misty", "quiet", "rapid", "shiny",
+  "still", "vivid", "warm", "wild", "noble", "lucid", "fresh", "keen",
+  "neat", "prime", "spry", "deft", "mellow", "nimble", "sleek", "stark",
+] as const;
+
+const SHELL_SESSION_NOUNS = [
+  "falcon", "otter", "cedar", "river", "comet", "harbor", "meadow", "summit",
+  "willow", "pine", "lynx", "heron", "maple", "delta", "ember", "quartz",
+  "raven", "sparrow", "tide", "vale", "wren", "birch", "cobalt", "drift",
+  "fern", "grove", "isle", "moss", "reef", "dune", "fjord", "atlas",
+] as const;
+
+export interface ShellSessionNameOptions {
+  collisionFallback?: boolean;
+}
+
+function pick<T>(list: readonly T[]): T {
+  return list[Math.floor(Math.random() * list.length)]!;
+}
+
+function entropySuffix(): string {
+  return Math.floor(Math.random() * 36 ** 5).toString(36).padStart(5, "0");
+}
+
+export function twoWordShellSessionName(options: ShellSessionNameOptions = {}): string {
+  const base = `${pick(SHELL_SESSION_ADJECTIVES)}-${pick(SHELL_SESSION_NOUNS)}`;
+  return options.collisionFallback ? `${base}-${entropySuffix()}` : base;
+}

--- a/desktop/src/renderer/src/lib/shell-session-names.ts
+++ b/desktop/src/renderer/src/lib/shell-session-names.ts
@@ -1,30 +1,4 @@
-const SHELL_SESSION_ADJECTIVES = [
-  "swift", "calm", "bright", "bold", "brave", "clever", "cosmic", "crisp",
-  "amber", "azure", "lunar", "solar", "misty", "quiet", "rapid", "shiny",
-  "still", "vivid", "warm", "wild", "noble", "lucid", "fresh", "keen",
-  "neat", "prime", "spry", "deft", "mellow", "nimble", "sleek", "stark",
-] as const;
-
-const SHELL_SESSION_NOUNS = [
-  "falcon", "otter", "cedar", "river", "comet", "harbor", "meadow", "summit",
-  "willow", "pine", "lynx", "heron", "maple", "delta", "ember", "quartz",
-  "raven", "sparrow", "tide", "vale", "wren", "birch", "cobalt", "drift",
-  "fern", "grove", "isle", "moss", "reef", "dune", "fjord", "atlas",
-] as const;
-
-export interface ShellSessionNameOptions {
-  collisionFallback?: boolean;
-}
-
-function pick<T>(list: readonly T[]): T {
-  return list[Math.floor(Math.random() * list.length)]!;
-}
-
-function entropySuffix(): string {
-  return Math.floor(Math.random() * 36 ** 5).toString(36).padStart(5, "0");
-}
-
-export function twoWordShellSessionName(options: ShellSessionNameOptions = {}): string {
-  const base = `${pick(SHELL_SESSION_ADJECTIVES)}-${pick(SHELL_SESSION_NOUNS)}`;
-  return options.collisionFallback ? `${base}-${entropySuffix()}` : base;
-}
+export {
+  createShellSessionName as twoWordShellSessionName,
+  type ShellSessionNameOptions,
+} from "@matrix-os/contracts";

--- a/desktop/src/renderer/src/stores/sessions.ts
+++ b/desktop/src/renderer/src/stores/sessions.ts
@@ -90,6 +90,19 @@ function isSessionExistsError(err: unknown): boolean {
   return err instanceof AppError && err.detail === "session_exists";
 }
 
+async function createTerminalSessionWithRetries(api: ApiClient): Promise<{ name: string; response: { name?: unknown } }> {
+  for (let attempt = 0; ; attempt += 1) {
+    const name = nextSessionName(attempt);
+    try {
+      const response = await api.post<{ name?: unknown }>("/api/terminal/sessions", { name });
+      return { name, response };
+    } catch (err: unknown) {
+      if (isSessionExistsError(err) && attempt < CREATE_ATTEMPTS - 1) continue;
+      throw err;
+    }
+  }
+}
+
 async function deleteAttachableSession(api: ApiClient, attachName: string): Promise<void> {
   await api.delete(`/api/terminal/sessions/${encodeURIComponent(attachName)}?force=1`);
 }
@@ -174,19 +187,7 @@ export const useSessions = create<SessionsState>()((set, get) => ({
     set({ creating: true, error: null, createError: null });
     try {
       if (!input) {
-        let name = "";
-        let response: { name?: unknown } | null = null;
-        for (let attempt = 0; attempt < CREATE_ATTEMPTS; attempt += 1) {
-          name = nextSessionName(attempt);
-          try {
-            response = await api.post<{ name?: unknown }>("/api/terminal/sessions", { name });
-            break;
-          } catch (err: unknown) {
-            if (isSessionExistsError(err) && attempt < CREATE_ATTEMPTS - 1) continue;
-            throw err;
-          }
-        }
-        if (response === null) throw new AppError("server");
+        const { name, response } = await createTerminalSessionWithRetries(api);
         if (!isCurrentRuntimeGeneration(runtimeGeneration)) return null;
         const attachName = typeof response.name === "string" && response.name.trim() ? response.name.trim() : name;
         const refreshSequence = loadSequence + 1;

--- a/desktop/src/renderer/src/stores/sessions.ts
+++ b/desktop/src/renderer/src/stores/sessions.ts
@@ -5,6 +5,7 @@
 import { create } from "zustand";
 import { AppError, type AppErrorCategory } from "../../../shared/app-error";
 import type { ApiClient } from "../lib/api";
+import { twoWordShellSessionName } from "../lib/shell-session-names";
 import {
   mergeAttachableSessions,
   type AttachableSession,
@@ -78,10 +79,15 @@ function asArray<T>(value: unknown): T[] {
 }
 
 let loadSequence = 0;
+const TWO_WORD_COLLISION_RETRIES = 3;
+const CREATE_ATTEMPTS = TWO_WORD_COLLISION_RETRIES + 1;
 
-function nextSessionName(): string {
-  const suffix = crypto.randomUUID().replace(/-/g, "").slice(0, 8);
-  return `operator-${Date.now().toString(36)}-${suffix}`;
+function nextSessionName(attempt: number): string {
+  return twoWordShellSessionName({ collisionFallback: attempt >= TWO_WORD_COLLISION_RETRIES });
+}
+
+function isSessionExistsError(err: unknown): boolean {
+  return err instanceof AppError && err.detail === "session_exists";
 }
 
 async function deleteAttachableSession(api: ApiClient, attachName: string): Promise<void> {
@@ -168,8 +174,19 @@ export const useSessions = create<SessionsState>()((set, get) => ({
     set({ creating: true, error: null, createError: null });
     try {
       if (!input) {
-        const name = nextSessionName();
-        const response = await api.post<{ name?: unknown }>("/api/terminal/sessions", { name });
+        let name = "";
+        let response: { name?: unknown } | null = null;
+        for (let attempt = 0; attempt < CREATE_ATTEMPTS; attempt += 1) {
+          name = nextSessionName(attempt);
+          try {
+            response = await api.post<{ name?: unknown }>("/api/terminal/sessions", { name });
+            break;
+          } catch (err: unknown) {
+            if (isSessionExistsError(err) && attempt < CREATE_ATTEMPTS - 1) continue;
+            throw err;
+          }
+        }
+        if (response === null) throw new AppError("server");
         if (!isCurrentRuntimeGeneration(runtimeGeneration)) return null;
         const attachName = typeof response.name === "string" && response.name.trim() ? response.name.trim() : name;
         const refreshSequence = loadSequence + 1;

--- a/desktop/src/renderer/src/stores/shell-sessions.ts
+++ b/desktop/src/renderer/src/stores/shell-sessions.ts
@@ -1,6 +1,7 @@
 import { create } from "zustand";
 import { AppError, type AppErrorCategory } from "../../../shared/app-error";
 import type { ApiClient } from "../lib/api";
+import { twoWordShellSessionName } from "../lib/shell-session-names";
 import { captureRuntimeGeneration, isCurrentRuntimeGeneration } from "./runtime-generation";
 
 export type ShellSessionPlacement = "active" | "background";
@@ -38,7 +39,8 @@ interface ShellSessionsState {
 
 const SHELL_SESSION_NAME_PATTERN = /^[a-z0-9]([a-z0-9-]{0,29}[a-z0-9])?$/;
 const DEFAULT_CWD = "projects";
-const CREATE_ATTEMPTS = 3;
+const TWO_WORD_COLLISION_RETRIES = 3;
+const CREATE_ATTEMPTS = TWO_WORD_COLLISION_RETRIES + 1;
 
 export function isValidShellSessionName(name: string): boolean {
   return SHELL_SESSION_NAME_PATTERN.test(name);
@@ -48,15 +50,8 @@ function shellConnectCommand(name: string): string {
   return `matrix shell connect ${name}`;
 }
 
-function randomShellSuffix(): string {
-  if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
-    return crypto.randomUUID().replace(/-/g, "").slice(0, 7);
-  }
-  return Math.random().toString(36).slice(2, 9).padEnd(7, "0").slice(0, 7);
-}
-
-function nextShellName(): string {
-  return `matrix-${randomShellSuffix()}`;
+function nextShellName(attempt: number): string {
+  return twoWordShellSessionName({ collisionFallback: attempt >= TWO_WORD_COLLISION_RETRIES });
 }
 
 function isSessionExistsError(err: unknown): boolean {
@@ -228,7 +223,7 @@ export const useShellSessions = create<ShellSessionsState>()((set, get) => ({
     const generation = captureRuntimeGeneration();
     set({ creating: true, error: null });
     for (let attempt = 0; attempt < CREATE_ATTEMPTS; attempt += 1) {
-      const name = nextShellName();
+      const name = nextShellName(attempt);
       try {
         const response = await api.post<{ name?: unknown }>("/api/terminal/sessions", { name, cwd: DEFAULT_CWD });
         if (!isCurrentRuntimeGeneration(generation)) return null;

--- a/macos/Sources/App/AppModel.swift
+++ b/macos/Sources/App/AppModel.swift
@@ -1970,7 +1970,6 @@ public final class AppModel: ObservableObject {
         openError = nil
         isCreatingWorkItem = true
         let existingSessionNames = Set(sessions.map(\.name))
-        let name = generatedShellSessionName()
         Task { [weak self] in
             defer { Task { @MainActor in self?.isCreatingWorkItem = false } }
             struct CreateSessionRequest: Encodable {
@@ -1980,27 +1979,32 @@ public final class AppModel: ObservableObject {
             struct CreateSessionResponse: Decodable {
                 let name: String?
             }
-            do {
-                let response: CreateSessionResponse = try await client.post(
-                    "/api/terminal/sessions",
-                    body: CreateSessionRequest(name: name, cwd: nil)
-                )
-                await self?.loadSessions()
-                let requestedName = response.name ?? name
-                if self?.sessions.contains(where: { $0.name == requestedName }) == true {
-                    await MainActor.run { self?.openSession(named: requestedName) }
-                } else if let created = self?.sessions.first(where: { !existingSessionNames.contains($0.name) }) {
-                    await MainActor.run { self?.openSession(named: created.name) }
+            let twoWordCollisionRetries = 3
+            let createAttempts = twoWordCollisionRetries + 1
+            for attempt in 0..<createAttempts {
+                let name = generatedShellSessionName(collisionFallback: attempt >= twoWordCollisionRetries)
+                do {
+                    let response: CreateSessionResponse = try await client.post(
+                        "/api/terminal/sessions",
+                        body: CreateSessionRequest(name: name, cwd: nil)
+                    )
+                    await self?.loadSessions()
+                    let requestedName = response.name ?? name
+                    if self?.sessions.contains(where: { $0.name == requestedName }) == true {
+                        await MainActor.run { self?.openSession(named: requestedName) }
+                    } else if let created = self?.sessions.first(where: { !existingSessionNames.contains($0.name) }) {
+                        await MainActor.run { self?.openSession(named: created.name) }
+                    }
+                    return
+                } catch GatewayError.conflict(let code) where code == "session_exists" && attempt < createAttempts - 1 {
+                    continue
+                } catch {
+                    await MainActor.run { self?.openError = .createSessionFailed }
+                    return
                 }
-            } catch {
-                await MainActor.run { self?.openError = .createSessionFailed }
             }
+            await MainActor.run { self?.openError = .createSessionFailed }
         }
-    }
-
-    private func generatedShellSessionName() -> String {
-        let suffix = UUID().uuidString.prefix(8).lowercased()
-        return "shell-\(suffix)"
     }
 
     private func displayName(for card: Card) -> String {

--- a/macos/Sources/App/ShellSessionNames.swift
+++ b/macos/Sources/App/ShellSessionNames.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+private let shellSessionAdjectives = [
+    "swift", "calm", "bright", "bold", "brave", "clever", "cosmic", "crisp",
+    "amber", "azure", "lunar", "solar", "misty", "quiet", "rapid", "shiny",
+    "still", "vivid", "warm", "wild", "noble", "lucid", "fresh", "keen",
+    "neat", "prime", "spry", "deft", "mellow", "nimble", "sleek", "stark",
+]
+
+private let shellSessionNouns = [
+    "falcon", "otter", "cedar", "river", "comet", "harbor", "meadow", "summit",
+    "willow", "pine", "lynx", "heron", "maple", "delta", "ember", "quartz",
+    "raven", "sparrow", "tide", "vale", "wren", "birch", "cobalt", "drift",
+    "fern", "grove", "isle", "moss", "reef", "dune", "fjord", "atlas",
+]
+
+func generatedShellSessionName(collisionFallback: Bool = false) -> String {
+    let adjective = shellSessionAdjectives.randomElement() ?? "swift"
+    let noun = shellSessionNouns.randomElement() ?? "falcon"
+    let base = "\(adjective)-\(noun)"
+    guard collisionFallback else { return base }
+    let suffix = UUID().uuidString
+        .lowercased()
+        .replacingOccurrences(of: "-", with: "")
+        .prefix(5)
+    return "\(base)-\(suffix)"
+}

--- a/macos/Sources/Board/BoardStore.swift
+++ b/macos/Sources/Board/BoardStore.swift
@@ -49,7 +49,7 @@ public enum BoardError: Error, Equatable, Sendable {
         case .network: return .offline
         case .timeout: return .timeout
         case .misconfigured: return .misconfigured
-        case .notFound, .server, .decoding: return .generic
+        case .notFound, .conflict, .server, .decoding: return .generic
         }
     }
 }

--- a/macos/Sources/Net/GatewayError.swift
+++ b/macos/Sources/Net/GatewayError.swift
@@ -23,6 +23,9 @@ public enum GatewayError: Error, Equatable, Sendable {
     /// Local misconfiguration (e.g. no VPS resolved / empty host) — distinct from
     /// not-found and from transient connectivity.
     case misconfigured
+    /// 409 — request conflicted with current state. Safe code is allowlisted and
+    /// only used for control flow; UI copy remains generic.
+    case conflict(code: String?)
 
     /// Safe, generic, user-facing copy. Contains no server/provider/path detail.
     public var userMessage: String {
@@ -34,15 +37,22 @@ public enum GatewayError: Error, Equatable, Sendable {
         case .timeout: return "The request timed out. Please try again."
         case .decoding: return "Received an unexpected response. Please try again."
         case .misconfigured: return "No computer is connected. Select a runtime to continue."
+        case .conflict: return "Something went wrong. Please try again."
         }
     }
 
+    public var safeCode: String? {
+        if case .conflict(let code) = self { return code }
+        return nil
+    }
+
     /// Maps an HTTP status code to a generic error. 2xx returns nil (success).
-    static func from(statusCode: Int) -> GatewayError? {
+    static func from(statusCode: Int, data: Data? = nil) -> GatewayError? {
         switch statusCode {
         case 200..<300: return nil
         case 401: return .unauthorized
         case 404: return .notFound
+        case 409: return .conflict(code: safeErrorCode(from: data))
         default: return .server
         }
     }
@@ -56,5 +66,25 @@ public enum GatewayError: Error, Equatable, Sendable {
             }
         }
         return .network
+    }
+
+    private struct ErrorEnvelope: Decodable {
+        struct ErrorBody: Decodable {
+            let code: String?
+        }
+
+        let error: ErrorBody?
+    }
+
+    private static func safeErrorCode(from data: Data?) -> String? {
+        guard let data else { return nil }
+        guard let envelope = try? JSONDecoder().decode(ErrorEnvelope.self, from: data) else { return nil }
+        guard let code = envelope.error?.code, (1...64).contains(code.count) else { return nil }
+        let allowed = code.unicodeScalars.allSatisfy { scalar in
+            (scalar.value >= 97 && scalar.value <= 122) ||
+                (scalar.value >= 48 && scalar.value <= 57) ||
+                scalar.value == 95
+        }
+        return allowed ? code : nil
     }
 }

--- a/macos/Sources/Net/GatewayHTTPClient.swift
+++ b/macos/Sources/Net/GatewayHTTPClient.swift
@@ -128,7 +128,7 @@ public struct GatewayHTTPClient: Sendable {
         guard let http = response as? HTTPURLResponse else {
             throw GatewayError.server
         }
-        if let mapped = GatewayError.from(statusCode: http.statusCode) {
+        if let mapped = GatewayError.from(statusCode: http.statusCode, data: data) {
             throw mapped
         }
         return data

--- a/macos/Tests/AppTests/AppModelAuthTests.swift
+++ b/macos/Tests/AppTests/AppModelAuthTests.swift
@@ -795,6 +795,63 @@ final class AppModelAuthTests: XCTestCase {
         XCTAssertEqual(model.selectedCard?.id, "matrix_session_alpha")
     }
 
+    func testCreateSessionRetriesTwoWordCollisionsBeforeSuffixedFallback() async throws {
+        let principal = PrincipalProvider(store: MemoryTokenStore())
+        try await principal.setToken("token")
+        let postedNames = LockedStringArray()
+        AppTestURLProtocol.setHandler { req in
+            if req.url?.path == "/api/terminal/sessions", req.httpMethod == "POST" {
+                let name = appTestRequestName(req) ?? ""
+                postedNames.append(name)
+                if postedNames.values.count <= 3 {
+                    return (
+                        appTestHTTPResponse(req.url!, 409),
+                        Data(#"{"error":{"code":"session_exists","message":"Request failed"}}"#.utf8)
+                    )
+                }
+                return (
+                    appTestHTTPResponse(req.url!, 201),
+                    Data(#"{"name":"\#(name)"}"#.utf8)
+                )
+            }
+            if req.url?.path == "/api/terminal/sessions" {
+                let name = postedNames.last ?? "swift-falcon"
+                return (
+                    appTestHTTPResponse(req.url!, 200),
+                    Data(#"{"sessions":[{"name":"\#(name)","status":"active"}]}"#.utf8)
+                )
+            }
+            return (appTestHTTPResponse(req.url!, 200), Data("{}".utf8))
+        }
+        let model = AppModel(
+            principal: principal,
+            projectSlug: "main",
+            profile: ConnectionProfile(handle: "alice", gatewayHost: "app.matrix-os.com"),
+            makeClient: { url, provider in
+                GatewayHTTPClient(baseURL: url, tokenProvider: provider, sessionConfiguration: .appTestMocked())
+            },
+            makeLoader: { _ in EmptyBoardLoader() },
+            deviceAuth: MockDeviceAuthorizer(),
+            openExternalURL: { _ in }
+        )
+
+        let loaded = expectation(description: "created session loads")
+        var cancellables = Set<AnyCancellable>()
+        model.$sessions
+            .filter { !$0.isEmpty }
+            .sink { _ in loaded.fulfill() }
+            .store(in: &cancellables)
+
+        model.createSession()
+        await fulfillment(of: [loaded], timeout: 5)
+
+        let names = postedNames.values
+        XCTAssertEqual(names.count, 4)
+        XCTAssertTrue(names.prefix(3).allSatisfy(isTwoWordShellSessionName))
+        XCTAssertTrue(isFallbackShellSessionName(names[3]))
+        XCTAssertTrue(model.sessions.map(\.name).contains(names[3]))
+    }
+
     func testApprovedSignInOpensHomeWhenNoProjectIsSelected() async throws {
         let principal = PrincipalProvider(store: MemoryTokenStore())
         let openedURL = OpenedURLRecorder()
@@ -1153,6 +1210,29 @@ private final class LockedCounter: @unchecked Sendable {
     }
 }
 
+private final class LockedStringArray: @unchecked Sendable {
+    private let lock = NSLock()
+    private var storage: [String] = []
+
+    var values: [String] {
+        lock.lock()
+        defer { lock.unlock() }
+        return storage
+    }
+
+    var last: String? {
+        lock.lock()
+        defer { lock.unlock() }
+        return storage.last
+    }
+
+    func append(_ value: String) {
+        lock.lock()
+        storage.append(value)
+        lock.unlock()
+    }
+}
+
 private extension URLSessionConfiguration {
     static func appTestMocked() -> URLSessionConfiguration {
         let config = URLSessionConfiguration.ephemeral
@@ -1163,5 +1243,55 @@ private extension URLSessionConfiguration {
 
 private func appTestHTTPResponse(_ url: URL, _ status: Int) -> HTTPURLResponse {
     HTTPURLResponse(url: url, statusCode: status, httpVersion: "HTTP/1.1", headerFields: nil)!
+}
+
+private func appTestRequestName(_ request: URLRequest) -> String? {
+    guard let data = appTestRequestBodyData(request),
+          let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+        return nil
+    }
+    return json["name"] as? String
+}
+
+private func appTestRequestBodyData(_ request: URLRequest) -> Data? {
+    if let body = request.httpBody {
+        return body
+    }
+    guard let stream = request.httpBodyStream else { return nil }
+    stream.open()
+    defer { stream.close() }
+    var data = Data()
+    var buffer = [UInt8](repeating: 0, count: 1024)
+    while stream.hasBytesAvailable {
+        let count = stream.read(&buffer, maxLength: buffer.count)
+        if count > 0 {
+            data.append(buffer, count: count)
+        } else {
+            break
+        }
+    }
+    return data
+}
+
+private func isTwoWordShellSessionName(_ name: String) -> Bool {
+    let parts = name.split(separator: "-")
+    return parts.count == 2 && parts.allSatisfy(isLowercaseWord)
+}
+
+private func isFallbackShellSessionName(_ name: String) -> Bool {
+    let parts = name.split(separator: "-")
+    guard parts.count == 3 else { return false }
+    return isLowercaseWord(parts[0]) &&
+        isLowercaseWord(parts[1]) &&
+        parts[2].count == 5 &&
+        parts[2].unicodeScalars.allSatisfy { scalar in
+            (scalar.value >= 97 && scalar.value <= 122) || (scalar.value >= 48 && scalar.value <= 57)
+        }
+}
+
+private func isLowercaseWord(_ value: Substring) -> Bool {
+    !value.isEmpty && value.unicodeScalars.allSatisfy { scalar in
+        scalar.value >= 97 && scalar.value <= 122
+    }
 }
 #endif

--- a/macos/Tests/NetTests/GatewayHTTPClientTests.swift
+++ b/macos/Tests/NetTests/GatewayHTTPClientTests.swift
@@ -207,6 +207,22 @@ final class GatewayHTTPClientTests: XCTestCase {
         }
     }
 
+    func testConflictPreservesAllowlistedSafeErrorCode() async {
+        MockURLProtocol.setHandler { req in
+            (
+                httpResponse(req.url!, 409),
+                Data(#"{"error":{"code":"session_exists","message":"Postgres path /secret leaked"}}"#.utf8)
+            )
+        }
+        let client = makeClient()
+        await assertThrows(client) { _ = try await $0.get("/x", as: Sample.self) } expecting: { error in
+            XCTAssertEqual(error, .conflict(code: "session_exists"))
+            XCTAssertEqual(error.safeCode, "session_exists")
+            XCTAssertFalse(error.userMessage.lowercased().contains("postgres"))
+            XCTAssertFalse(error.userMessage.contains("/secret"))
+        }
+    }
+
     func testMalformedJSONMapsToDecoding() async {
         MockURLProtocol.setHandler { req in
             (httpResponse(req.url!, 200), Data("not json at all".utf8))

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -81,6 +81,38 @@ export const ReviewIdSchema = referenceId(128);
 export const WorktreeIdSchema = z.string().regex(/^wt_[a-z0-9]{12,40}$/, "Invalid worktree id");
 export const CursorSchema = referenceId(160);
 export const IsoTimestampSchema = z.string().regex(ISO_DATETIME, "Invalid ISO timestamp");
+
+export const SHELL_SESSION_ADJECTIVES = [
+  "swift", "calm", "bright", "bold", "brave", "clever", "cosmic", "crisp",
+  "amber", "azure", "lunar", "solar", "misty", "quiet", "rapid", "shiny",
+  "still", "vivid", "warm", "wild", "noble", "lucid", "fresh", "keen",
+  "neat", "prime", "spry", "deft", "mellow", "nimble", "sleek", "stark",
+] as const;
+
+export const SHELL_SESSION_NOUNS = [
+  "falcon", "otter", "cedar", "river", "comet", "harbor", "meadow", "summit",
+  "willow", "pine", "lynx", "heron", "maple", "delta", "ember", "quartz",
+  "raven", "sparrow", "tide", "vale", "wren", "birch", "cobalt", "drift",
+  "fern", "grove", "isle", "moss", "reef", "dune", "fjord", "atlas",
+] as const;
+
+export interface ShellSessionNameOptions {
+  collisionFallback?: boolean;
+}
+
+function pickShellSessionWord<T>(list: readonly T[]): T {
+  return list[Math.floor(Math.random() * list.length)]!;
+}
+
+function shellSessionEntropySuffix(): string {
+  return Math.floor(Math.random() * 36 ** 5).toString(36).padStart(5, "0");
+}
+
+export function createShellSessionName(options: ShellSessionNameOptions = {}): string {
+  const base = `${pickShellSessionWord(SHELL_SESSION_ADJECTIVES)}-${pickShellSessionWord(SHELL_SESSION_NOUNS)}`;
+  return options.collisionFallback ? `${base}-${shellSessionEntropySuffix()}` : base;
+}
+
 export const SafeDisplayStringSchema = boundedDisplayText(120, 512);
 export const SafeAssistantPreviewSourceTextSchema = boundedText(16_000, 64 * 1024)
   .refine((value) => !UNSAFE_ASSISTANT_PREVIEW_TEXT.test(value), { message: "Text is not safe for assistant preview display" });

--- a/shell/src/components/terminal/TerminalApp.tsx
+++ b/shell/src/components/terminal/TerminalApp.tsx
@@ -69,6 +69,10 @@ async function readShellErrorCode(res: Response): Promise<string | null> {
   }
 }
 
+async function isShellSessionExistsResponse(res: Response): Promise<boolean> {
+  return res.status === 409 && await readShellErrorCode(res) === "session_exists";
+}
+
 async function ensureShellSessions(sessionNames: string[]): Promise<boolean> {
   const requestedNames = Array.from(new Set(
     sessionNames.filter((name) => isCanonicalShellSessionId(name)),
@@ -397,8 +401,12 @@ export function TerminalApp({ initialCommand, initialLabel, initialClaudeMode = 
   ) => {
     let requestedCwd = cwd || "~";
     let retriedHomeCwd = false;
-    for (let attempt = 0; attempt < 3; attempt += 1) {
-      const name = terminalSessionName(options.namePrefix);
+    const twoWordCollisionRetries = 3;
+    const maxAttempts = options.namePrefix ? 3 : twoWordCollisionRetries + 1;
+    for (let attempt = 0; attempt < maxAttempts; attempt += 1) {
+      const name = terminalSessionName(options.namePrefix, {
+        collisionFallback: !options.namePrefix && attempt >= twoWordCollisionRetries,
+      });
       try {
         // react-doctor-disable-next-line react-doctor/async-await-in-loop -- sequential-by-design retry loop: each attempt only runs if the prior one failed with a 409 name collision or abort; parallelizing would create multiple sessions
         const res = await fetch(`${getGatewayUrl()}/api/terminal/sessions`, {
@@ -407,7 +415,7 @@ export function TerminalApp({ initialCommand, initialLabel, initialClaudeMode = 
           body: JSON.stringify({ name, cwd: requestedCwd, ...(options.cmd ? { cmd: options.cmd } : {}) }),
           signal: AbortSignal.timeout(10_000),
         });
-        if (res.status === 409) {
+        if (await isShellSessionExistsResponse(res)) {
           continue;
         }
         if (!res.ok) {

--- a/shell/src/components/terminal/terminal-layout.ts
+++ b/shell/src/components/terminal/terminal-layout.ts
@@ -21,7 +21,7 @@ export function genId() {
   return Math.random().toString(36).slice(2, 9);
 }
 
-export function terminalSessionName(prefix = "matrix") {
+export function terminalSessionName(prefix = "matrix", options: { collisionFallback?: boolean } = {}) {
   const normalized = prefix.toLowerCase();
   // A meaningful prefix (e.g. a project name) keeps the prefixed form; the
   // default produces a friendly two-word handle instead of matrix-<random>.
@@ -32,7 +32,7 @@ export function terminalSessionName(prefix = "matrix") {
       .slice(0, 22) || "matrix";
     return `${safePrefix}-${genId()}`.slice(0, 31);
   }
-  return twoWordSessionName();
+  return twoWordSessionName(options);
 }
 
 export function splitPaneInTree(node: PaneNode, paneId: string, dir: "horizontal" | "vertical"): PaneNode {

--- a/shell/src/components/terminal/terminal-session-names.ts
+++ b/shell/src/components/terminal/terminal-session-names.ts
@@ -1,20 +1,24 @@
-// Friendly session names (e.g. "swift-falcon-3k9qm") instead of
+// Friendly session names (e.g. "swift-falcon") instead of
 // "matrix-<random>". Both word lists are lowercase, slug-safe single words so
 // the result always matches SHELL_SESSION_NAME_PATTERN.
 
-const ADJECTIVES = [
+export const SHELL_SESSION_ADJECTIVES = [
   "swift", "calm", "bright", "bold", "brave", "clever", "cosmic", "crisp",
   "amber", "azure", "lunar", "solar", "misty", "quiet", "rapid", "shiny",
   "still", "vivid", "warm", "wild", "noble", "lucid", "fresh", "keen",
   "neat", "prime", "spry", "deft", "mellow", "nimble", "sleek", "stark",
 ] as const;
 
-const NOUNS = [
+export const SHELL_SESSION_NOUNS = [
   "falcon", "otter", "cedar", "river", "comet", "harbor", "meadow", "summit",
   "willow", "pine", "lynx", "heron", "maple", "delta", "ember", "quartz",
   "raven", "sparrow", "tide", "vale", "wren", "birch", "cobalt", "drift",
   "fern", "grove", "isle", "moss", "reef", "dune", "fjord", "atlas",
 ] as const;
+
+export interface TwoWordSessionNameOptions {
+  collisionFallback?: boolean;
+}
 
 function pick<T>(list: readonly T[]): T {
   return list[Math.floor(Math.random() * list.length)]!;
@@ -24,9 +28,10 @@ function entropySuffix(): string {
   return Math.floor(Math.random() * 36 ** 5).toString(36).padStart(5, "0");
 }
 
-/** Returns a friendly session handle like "swift-falcon-3k9qm". */
-export function twoWordSessionName(): string {
-  return `${pick(ADJECTIVES)}-${pick(NOUNS)}-${entropySuffix()}`;
+/** Returns a friendly session handle like "swift-falcon". */
+export function twoWordSessionName(options: TwoWordSessionNameOptions = {}): string {
+  const base = `${pick(SHELL_SESSION_ADJECTIVES)}-${pick(SHELL_SESSION_NOUNS)}`;
+  return options.collisionFallback ? `${base}-${entropySuffix()}` : base;
 }
 
 /**

--- a/shell/src/components/terminal/terminal-session-names.ts
+++ b/shell/src/components/terminal/terminal-session-names.ts
@@ -1,37 +1,17 @@
-// Friendly session names (e.g. "swift-falcon") instead of
-// "matrix-<random>". Both word lists are lowercase, slug-safe single words so
-// the result always matches SHELL_SESSION_NAME_PATTERN.
+import {
+  createShellSessionName,
+  SHELL_SESSION_ADJECTIVES,
+  SHELL_SESSION_NOUNS,
+  type ShellSessionNameOptions,
+} from "@matrix-os/contracts";
 
-export const SHELL_SESSION_ADJECTIVES = [
-  "swift", "calm", "bright", "bold", "brave", "clever", "cosmic", "crisp",
-  "amber", "azure", "lunar", "solar", "misty", "quiet", "rapid", "shiny",
-  "still", "vivid", "warm", "wild", "noble", "lucid", "fresh", "keen",
-  "neat", "prime", "spry", "deft", "mellow", "nimble", "sleek", "stark",
-] as const;
+export { SHELL_SESSION_ADJECTIVES, SHELL_SESSION_NOUNS };
 
-export const SHELL_SESSION_NOUNS = [
-  "falcon", "otter", "cedar", "river", "comet", "harbor", "meadow", "summit",
-  "willow", "pine", "lynx", "heron", "maple", "delta", "ember", "quartz",
-  "raven", "sparrow", "tide", "vale", "wren", "birch", "cobalt", "drift",
-  "fern", "grove", "isle", "moss", "reef", "dune", "fjord", "atlas",
-] as const;
-
-export interface TwoWordSessionNameOptions {
-  collisionFallback?: boolean;
-}
-
-function pick<T>(list: readonly T[]): T {
-  return list[Math.floor(Math.random() * list.length)]!;
-}
-
-function entropySuffix(): string {
-  return Math.floor(Math.random() * 36 ** 5).toString(36).padStart(5, "0");
-}
+export type TwoWordSessionNameOptions = ShellSessionNameOptions;
 
 /** Returns a friendly session handle like "swift-falcon". */
 export function twoWordSessionName(options: TwoWordSessionNameOptions = {}): string {
-  const base = `${pick(SHELL_SESSION_ADJECTIVES)}-${pick(SHELL_SESSION_NOUNS)}`;
-  return options.collisionFallback ? `${base}-${entropySuffix()}` : base;
+  return createShellSessionName(options);
 }
 
 /**

--- a/tests/contracts/shell-session-names.test.ts
+++ b/tests/contracts/shell-session-names.test.ts
@@ -1,0 +1,34 @@
+import { readFile } from "node:fs/promises";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  SHELL_SESSION_ADJECTIVES,
+  SHELL_SESSION_NOUNS,
+  createShellSessionName,
+} from "@matrix-os/contracts";
+
+function readSwiftList(source: string, name: string): string[] {
+  const match = new RegExp(`let ${name} = \\[([\\s\\S]*?)\\]`).exec(source);
+  if (!match) throw new Error(`Missing Swift list: ${name}`);
+  return [...match[1].matchAll(/"([^"]+)"/g)].map((entry) => entry[1]);
+}
+
+describe("shell session names contract", () => {
+  it("creates plain two-word names until collision fallback is requested", () => {
+    const originalRandom = Math.random;
+    try {
+      Math.random = () => 0;
+      expect(createShellSessionName()).toBe("swift-falcon");
+      expect(createShellSessionName({ collisionFallback: true })).toBe("swift-falcon-00000");
+    } finally {
+      Math.random = originalRandom;
+    }
+  });
+
+  it("keeps the macOS word lists in sync with the shared TypeScript source", async () => {
+    const swiftSource = await readFile(resolve(process.cwd(), "macos/Sources/App/ShellSessionNames.swift"), "utf8");
+
+    expect(readSwiftList(swiftSource, "shellSessionAdjectives")).toEqual([...SHELL_SESSION_ADJECTIVES]);
+    expect(readSwiftList(swiftSource, "shellSessionNouns")).toEqual([...SHELL_SESSION_NOUNS]);
+  });
+});

--- a/tests/desktop/session-merge.test.ts
+++ b/tests/desktop/session-merge.test.ts
@@ -307,7 +307,7 @@ describe("useSessions store", () => {
     const created = await useSessions.getState().create(makeApi(get, post));
 
     expect(post).toHaveBeenCalledWith("/api/terminal/sessions", {
-      name: expect.stringMatching(/^operator-[a-z0-9]+-[a-f0-9]{8}$/),
+      name: expect.stringMatching(/^[a-z]+-[a-z]+$/),
     });
     expect(created?.attachName).toBe("operator-new");
     expect(useSessions.getState().sessions.map((s) => s.attachName)).toEqual(["operator-new"]);

--- a/tests/desktop/sessions-store.test.ts
+++ b/tests/desktop/sessions-store.test.ts
@@ -4,6 +4,9 @@ import type { ApiClient } from "@desktop/renderer/src/lib/api";
 import { useBoard, type Card } from "@desktop/renderer/src/stores/board";
 import { useSessions } from "@desktop/renderer/src/stores/sessions";
 
+const TWO_WORD_SESSION_NAME_PATTERN = /^[a-z]+-[a-z]+$/;
+const TWO_WORD_FALLBACK_SESSION_NAME_PATTERN = /^[a-z]+-[a-z]+-[a-z0-9]{5}$/;
+
 function makeApi(overrides: Partial<ApiClient> = {}): ApiClient {
   return {
     baseUrl: "https://x.test",
@@ -77,6 +80,34 @@ describe("useSessions.load", () => {
 });
 
 describe("useSessions.create", () => {
+  it("creates normal terminal sessions with two-word names and a suffixed collision fallback", async () => {
+    const post = vi
+      .fn()
+      .mockRejectedValueOnce(new AppError("server", { detail: "session_exists" }))
+      .mockRejectedValueOnce(new AppError("server", { detail: "session_exists" }))
+      .mockRejectedValueOnce(new AppError("server", { detail: "session_exists" }))
+      .mockResolvedValueOnce({ name: "fallback-created" });
+    const get = vi.fn(async (path: string) => {
+      if (path === "/api/terminal/sessions") {
+        return { sessions: [{ name: "fallback-created", status: "active" }] };
+      }
+      return { sessions: [], nextCursor: null };
+    });
+    const api = makeApi({ post, get });
+
+    const created = await useSessions.getState().create(api);
+
+    expect(created).toEqual({ sessionId: "fallback-created", attachName: "fallback-created" });
+    expect(post).toHaveBeenCalledTimes(4);
+    const names = post.mock.calls.map(([, body]) => (body as { name: string }).name);
+    expect(names.slice(0, 3)).toEqual([
+      expect.stringMatching(TWO_WORD_SESSION_NAME_PATTERN),
+      expect.stringMatching(TWO_WORD_SESSION_NAME_PATTERN),
+      expect.stringMatching(TWO_WORD_SESSION_NAME_PATTERN),
+    ]);
+    expect(names[3]).toMatch(TWO_WORD_FALLBACK_SESSION_NAME_PATTERN);
+  });
+
   it("POSTs the session, reloads, and resolves the new attach name", async () => {
     const post = vi.fn().mockResolvedValue({ session: { id: "sess_new" } });
     // After creation, the reload returns the workspace session carrying its

--- a/tests/desktop/shell-sessions-store.test.ts
+++ b/tests/desktop/shell-sessions-store.test.ts
@@ -4,6 +4,9 @@ import type { ApiClient } from "@desktop/renderer/src/lib/api";
 import { advanceRuntimeGeneration } from "@desktop/renderer/src/stores/runtime-generation";
 import { isValidShellSessionName, useShellSessions } from "@desktop/renderer/src/stores/shell-sessions";
 
+const TWO_WORD_SESSION_NAME_PATTERN = /^[a-z]+-[a-z]+$/;
+const TWO_WORD_FALLBACK_SESSION_NAME_PATTERN = /^[a-z]+-[a-z]+-[a-z0-9]{5}$/;
+
 function makeApi(overrides: Partial<ApiClient> = {}): ApiClient {
   return {
     baseUrl: "https://x.test",
@@ -106,7 +109,7 @@ describe("useShellSessions", () => {
     expect(useShellSessions.getState().sessions.map((session) => session.name)).toEqual(["matrix-reset"]);
   });
 
-  it("creates shell sessions with matrix names, projects cwd, and retries one 409 conflict", async () => {
+  it("creates shell sessions with two-word names, projects cwd, and retries one 409 conflict", async () => {
     const post = vi
       .fn()
       .mockRejectedValueOnce(new AppError("server", { detail: "session_exists" }))
@@ -118,14 +121,36 @@ describe("useShellSessions", () => {
     expect(created?.name).toBe("matrix-created");
     expect(post).toHaveBeenCalledTimes(2);
     expect(post).toHaveBeenNthCalledWith(1, "/api/terminal/sessions", {
-      name: expect.stringMatching(/^matrix-[a-z0-9]{7}$/),
+      name: expect.stringMatching(TWO_WORD_SESSION_NAME_PATTERN),
       cwd: "projects",
     });
     expect(post).toHaveBeenNthCalledWith(2, "/api/terminal/sessions", {
-      name: expect.stringMatching(/^matrix-[a-z0-9]{7}$/),
+      name: expect.stringMatching(TWO_WORD_SESSION_NAME_PATTERN),
       cwd: "projects",
     });
     expect(useShellSessions.getState().sessions.map((session) => session.name)).toEqual(["matrix-created"]);
+  });
+
+  it("uses a suffixed shell name only after repeated two-word collisions", async () => {
+    const post = vi
+      .fn()
+      .mockRejectedValueOnce(new AppError("server", { detail: "session_exists" }))
+      .mockRejectedValueOnce(new AppError("server", { detail: "session_exists" }))
+      .mockRejectedValueOnce(new AppError("server", { detail: "session_exists" }))
+      .mockResolvedValueOnce({ name: "fallback-created" });
+    const get = vi.fn().mockResolvedValue({ sessions: [{ name: "fallback-created", status: "active" }] });
+
+    const created = await useShellSessions.getState().create(makeApi({ post, get }));
+
+    expect(created?.name).toBe("fallback-created");
+    expect(post).toHaveBeenCalledTimes(4);
+    const bodies = post.mock.calls.map(([, body]) => body as { name: string; cwd: string });
+    expect(bodies.slice(0, 3).map((body) => body.name)).toEqual([
+      expect.stringMatching(TWO_WORD_SESSION_NAME_PATTERN),
+      expect.stringMatching(TWO_WORD_SESSION_NAME_PATTERN),
+      expect.stringMatching(TWO_WORD_SESSION_NAME_PATTERN),
+    ]);
+    expect(bodies[3]?.name).toMatch(TWO_WORD_FALLBACK_SESSION_NAME_PATTERN);
   });
 
   it("keeps a created shell when an older load resolves after create refresh", async () => {

--- a/tests/shell/terminal-app-component.test.tsx
+++ b/tests/shell/terminal-app-component.test.tsx
@@ -5,6 +5,8 @@ import { act, fireEvent, render, screen, within } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi, afterEach } from "vitest";
 
 const CANONICAL_SESSION_NAME_PATTERN = /^[a-z0-9][a-z0-9-]{0,30}$/;
+const TWO_WORD_SESSION_NAME_PATTERN = /^[a-z]+-[a-z]+$/;
+const TWO_WORD_FALLBACK_SESSION_NAME_PATTERN = /^[a-z]+-[a-z]+-[a-z0-9]{5}$/;
 
 const paneGridSpy = vi.fn();
 const { saveThemeSpy, terminalSettingsState } = vi.hoisted(() => ({
@@ -113,6 +115,16 @@ function terminalSessionPostBodies(): string[] {
   return vi.mocked(fetch).mock.calls
     .filter(([input, init]) => String(input).includes("/api/terminal/sessions") && init?.method === "POST")
     .map(([, init]) => String(init?.body ?? ""));
+}
+
+function mockJsonResponse(body: unknown, status = 200): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+    text: async () => JSON.stringify(body),
+    clone: () => mockJsonResponse(body, status),
+  } as Response;
 }
 
 function createDragDataTransfer(): DataTransfer {
@@ -1941,7 +1953,7 @@ describe("TerminalApp", () => {
     expect(menu.style.top).toBe("0px");
   });
 
-  it("opens Matrix-named shell sessions from the new-session menu", async () => {
+  it("opens two-word shell sessions from the new-session menu", async () => {
     render(<TerminalApp />);
 
     await act(async () => {
@@ -1965,11 +1977,69 @@ describe("TerminalApp", () => {
       ))
       .map(([, init]: [RequestInfo | URL, RequestInit]) => JSON.parse(String(init.body)) as { name: string });
 
-    const createdShell = createCalls.find((body) => CANONICAL_SESSION_NAME_PATTERN.test(body.name));
+    const createdShell = createCalls.find((body) => TWO_WORD_SESSION_NAME_PATTERN.test(body.name));
     expect(createdShell).toBeTruthy();
     expect(paneGridSpy.mock.lastCall?.[0]).toMatchObject({
       paneTree: {
         sessionId: createdShell?.name,
+      },
+    });
+  });
+
+  it("retries two-word shell name collisions before using a suffixed fallback", async () => {
+    const postedNames: string[] = [];
+    vi.mocked(fetch).mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.includes("/api/files/tree")) {
+        return Promise.resolve(mockJsonResponse([]));
+      }
+      if (url.includes("/api/terminal/layout") && init?.method === "PUT") {
+        return Promise.resolve(mockJsonResponse({ ok: true }));
+      }
+      if (url.includes("/api/terminal/layout")) {
+        return Promise.resolve(mockJsonResponse({}));
+      }
+      if (url.endsWith("/api/terminal/sessions") && init?.method === "POST") {
+        const body = JSON.parse(String(init.body ?? "{}")) as { name?: string };
+        if (body.name === "main") {
+          return Promise.resolve(mockJsonResponse({ name: "main", created: true }, 201));
+        }
+        if (typeof body.name === "string") postedNames.push(body.name);
+        if (postedNames.length <= 3) {
+          return Promise.resolve(mockJsonResponse({ error: { code: "session_exists", message: "Request failed" } }, 409));
+        }
+        return Promise.resolve(mockJsonResponse({ name: body.name, created: true }, 201));
+      }
+      if (url.endsWith("/api/terminal/sessions")) {
+        return Promise.resolve(mockJsonResponse({
+          sessions: postedNames.length >= 4 ? [{ name: postedNames[3], status: "active" }] : [],
+        }));
+      }
+      return Promise.resolve(mockJsonResponse({}));
+    });
+
+    render(<TerminalApp />);
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    await act(async () => {
+      await chooseNewSessionMenuItem(/Shell/);
+    });
+
+    await vi.waitFor(() => expect(postedNames).toHaveLength(4));
+    expect(postedNames.slice(0, 3)).toEqual([
+      expect.stringMatching(TWO_WORD_SESSION_NAME_PATTERN),
+      expect.stringMatching(TWO_WORD_SESSION_NAME_PATTERN),
+      expect.stringMatching(TWO_WORD_SESSION_NAME_PATTERN),
+    ]);
+    expect(postedNames[3]).toMatch(TWO_WORD_FALLBACK_SESSION_NAME_PATTERN);
+    expect(paneGridSpy.mock.lastCall?.[0]).toMatchObject({
+      paneTree: {
+        sessionId: postedNames[3],
       },
     });
   });
@@ -2814,7 +2884,7 @@ describe("TerminalApp", () => {
     });
   });
 
-  it("creates toolbar shell launches as Matrix-named canonical shell sessions", async () => {
+  it("creates toolbar shell launches as two-word canonical shell sessions", async () => {
     render(<TerminalApp />);
 
     await act(async () => {
@@ -2834,12 +2904,12 @@ describe("TerminalApp", () => {
       String(input).includes("/api/terminal/sessions") &&
       init?.method === "POST" &&
       typeof init.body === "string" &&
-      CANONICAL_SESSION_NAME_PATTERN.test(JSON.parse(init.body).name)
+      TWO_WORD_SESSION_NAME_PATTERN.test(JSON.parse(init.body).name)
     ));
     expect(createCall).toBeTruthy();
     const body = JSON.parse(createCall?.[1]?.body as string) as { name: string; cwd: string };
     expect(body).toMatchObject({ cwd: "projects" });
-    expect(body.name).toMatch(CANONICAL_SESSION_NAME_PATTERN);
+    expect(body.name).toMatch(TWO_WORD_SESSION_NAME_PATTERN);
 
     const props = paneGridSpy.mock.lastCall?.[0] as {
       paneTree: { type: "pane"; sessionId?: string; startupCommand?: string };

--- a/tests/shell/terminal.test.ts
+++ b/tests/shell/terminal.test.ts
@@ -100,12 +100,20 @@ describe("Terminal WebSocket protocol", () => {
     expect(terminalWebSocketPathForSession(null)).toBe("/ws/terminal");
   });
 
-  it("adds an entropy suffix to friendly terminal session names", () => {
+  it("uses two-word friendly terminal session names by default", () => {
+    vi.spyOn(Math, "random")
+      .mockReturnValueOnce(0)
+      .mockReturnValueOnce(0);
+
+    expect(twoWordSessionName()).toBe("swift-falcon");
+  });
+
+  it("adds an entropy suffix only for collision fallback names", () => {
     vi.spyOn(Math, "random")
       .mockReturnValueOnce(0)
       .mockReturnValueOnce(0)
       .mockReturnValueOnce(0);
 
-    expect(twoWordSessionName()).toBe("swift-falcon-00000");
+    expect(twoWordSessionName({ collisionFallback: true })).toBe("swift-falcon-00000");
   });
 });


### PR DESCRIPTION
## Summary

- Change normal UI-created Shell session names to default to `adjective-noun` across web shell, desktop renderer, mobile, and macOS.
- Add bounded collision handling: retry fresh two-word names on `409/session_exists`, then use an explicit suffixed fallback only after repeated collisions.
- Preserve CLI/agent-prefixed session names such as `codex-*`, `claude-*`, and setup/session intent prefixes.

## Tests

- `pnpm exec vitest run tests/desktop/session-merge.test.ts tests/desktop/sessions-store.test.ts tests/desktop/shell-sessions-store.test.ts`
- `pnpm exec vitest run tests/shell/terminal.test.ts tests/shell/terminal-app-component.test.tsx tests/desktop/shell-sessions-store.test.ts tests/desktop/sessions-store.test.ts`
- `pnpm --filter matrix-os-mobile test -- terminal-client.test.ts --runInBand`
- `pnpm --dir shell exec tsc --noEmit -p tsconfig.json`
- `pnpm --filter desktop run typecheck`
- `pnpm run typecheck:build-kernel && pnpm --filter '@matrix-os/observability' exec tsc --noEmit && pnpm --filter '@matrix-os/gateway' exec tsc --noEmit && pnpm --filter '@matrix-os/platform' exec tsc --noEmit -p tsconfig.typecheck.json && pnpm --filter '@matrix-os/proxy' exec tsc --noEmit && pnpm --filter '@matrix-os/edge-router' exec tsc --noEmit && pnpm --filter desktop run typecheck`
- `pnpm run check:patterns`
- `npx react-doctor@latest --verbose --scope changed --base origin/main shell`
- `pnpm run test` (790 files passed, 8603 tests passed, 20 skipped)

Skipped/known environment limits:

- macOS Swift tests not run because `swift` is not installed in this shell.
- `pnpm --filter matrix-os-mobile exec tsc --noEmit -p tsconfig.json` still fails on an unrelated existing issue in `apps/mobile/app/agents/[threadId].tsx`.

## Review/Monitoring

- Published from manual worktree `/home/nima/matrix-os.worktrees/ui-shell-session-adjective-noun`.
- Branch: `codex/ui-shell-session-adjective-noun`.
- Waiting for CI and Greptile review after PR creation; latest trusted Greptile result must be 5/5 before merge.

## Invariants

- Source of truth: the gateway remains authoritative for session creation and collision detection; clients only propose safe names.
- Lock/transaction scope: no database or backend write scope changes; UI clients issue one create request at a time and retry only on safe `session_exists` conflicts.
- Acceptable orphan states: if a UI create succeeds but a refresh/open step fails, existing client cleanup/error behavior is preserved; existing sessions are never renamed.
- Auth source of truth: unchanged; all create calls continue through existing gateway/native client authentication.
- Deferred scope: CLI-generated names and agent-prefixed sessions are intentionally unchanged.
