### PR TITLE
fix(terminal): dispose webgl before caching panes

### DIFF
--- a/shell/src/components/terminal/TerminalPane.tsx
+++ b/shell/src/components/terminal/TerminalPane.tsx
@@ -337,12 +337,11 @@ function applyXtermScrollOptions(term: Terminal): void {
   term.options.scrollOnUserInput = true;
 }
 
-function refreshTerminalRenderer(term: Terminal | null): void {
-  const maybeRefresh = (term as { refresh?: unknown } | null)?.refresh;
-  if (typeof maybeRefresh !== "function" || !term || term.rows <= 0) {
+function refreshTerminalRenderer(term: Terminal): void {
+  if (term.rows <= 0) {
     return;
   }
-  maybeRefresh.call(term, 0, term.rows - 1);
+  term.refresh(0, term.rows - 1);
 }
 
 type DisposableWebglAddon = { dispose: () => void };
@@ -971,11 +970,9 @@ export function TerminalPane({
         fitAddon = cached.fitAddon;
         searchAddon = cached.searchAddon;
         webglAddon = null;
-        webglAddonRef.current = toDisposableWebglAddon(cached.webglAddon);
-        if (webglAddonRef.current) {
-          log("webgl-disposed-from-cache-restore", { webglDisabled });
-          disposeWebgl();
-        }
+        // Cached terminals intentionally never retain WebGL. Restore starts on
+        // the DOM renderer, then re-enables WebGL after attach + fit.
+        webglAddonRef.current = null;
         termRef.current = cached.terminal;
         fitAddonRef.current = cached.fitAddon;
         searchAddonRef.current = cached.searchAddon;

--- a/shell/src/components/terminal/TerminalPane.tsx
+++ b/shell/src/components/terminal/TerminalPane.tsx
@@ -337,6 +337,24 @@ function applyXtermScrollOptions(term: Terminal): void {
   term.options.scrollOnUserInput = true;
 }
 
+function refreshTerminalRenderer(term: Terminal | null): void {
+  const maybeRefresh = (term as { refresh?: unknown } | null)?.refresh;
+  if (typeof maybeRefresh !== "function" || !term || term.rows <= 0) {
+    return;
+  }
+  maybeRefresh.call(term, 0, term.rows - 1);
+}
+
+type DisposableWebglAddon = { dispose: () => void };
+
+function toDisposableWebglAddon(addon: unknown): DisposableWebglAddon | null {
+  if (!addon || typeof addon !== "object") {
+    return null;
+  }
+  const dispose = (addon as { dispose?: unknown }).dispose;
+  return typeof dispose === "function" ? (addon as DisposableWebglAddon) : null;
+}
+
 function terminalTelemetry(event: string, properties: Record<string, string | number | boolean | undefined>): void {
   const payload = {
     source: "terminal-pane",
@@ -438,7 +456,7 @@ export function TerminalPane({
   const onSessionAttachedRef = useRef(onSessionAttached);
   const shouldCacheOnUnmountRef = useRef(shouldCacheOnUnmount);
   const shouldDestroyOnUnmountRef = useRef(shouldDestroyOnUnmount);
-  const webglAddonRef = useRef<{ dispose: () => void } | null>(null);
+  const webglAddonRef = useRef<DisposableWebglAddon | null>(null);
   const webglContextLossDisposableRef = useRef<{ dispose: () => void } | null>(null);
   const webglRecreateAttemptedRef = useRef(false);
   const onDataDisposableRef = useRef<{ dispose: () => void } | null>(null);
@@ -811,9 +829,8 @@ export function TerminalPane({
       };
 
       // Tears down only the context-loss subscription (the closure that drives
-      // DOM-renderer fallback). Safe to call on every cleanup path: on a cache
-      // for tab-switch the WebGL addon itself stays loaded on the retained
-      // terminal, while on a destroy path term.dispose() disposes the addon.
+      // DOM-renderer fallback). Cache paths dispose WebGL before detaching the
+      // xterm element; destroy paths let term.dispose() dispose loaded addons.
       const teardownWebglSubscription = () => {
         webglContextLossDisposableRef.current?.dispose();
         webglContextLossDisposableRef.current = null;
@@ -953,27 +970,12 @@ export function TerminalPane({
         applyXtermScrollOptions(term);
         fitAddon = cached.fitAddon;
         searchAddon = cached.searchAddon;
-        webglAddon = cached.webglAddon;
-        // The cached terminal kept its WebGL addon loaded, but the old
-        // context-loss subscription was torn down on cache. Re-wire it (or
-        // re-create the renderer if a prior context loss left it on the DOM
-        // renderer).
-        webglAddonRef.current = (cached.webglAddon as { dispose: () => void } | null) ?? null;
-        if (webglDisabled && webglAddonRef.current) {
+        webglAddon = null;
+        webglAddonRef.current = toDisposableWebglAddon(cached.webglAddon);
+        if (webglAddonRef.current) {
+          log("webgl-disposed-from-cache-restore", { webglDisabled });
           disposeWebgl();
-          webglAddon = null;
-        } else if (webglAddonRef.current) {
-          wireWebglContextLoss(
-            webglAddonRef.current as unknown as {
-              onContextLoss: (cb: () => void) => { dispose: () => void };
-            },
-          );
-        } else if (!webglDisabled) {
-          void enableWebgl().then((addon) => {
-            webglAddon = addon;
-          });
         }
-        fitAddon.fit();
         termRef.current = cached.terminal;
         fitAddonRef.current = cached.fitAddon;
         searchAddonRef.current = cached.searchAddon;
@@ -981,7 +983,21 @@ export function TerminalPane({
         sessionIdRef.current = cachedRestore.sessionId;
         lastSeqRef.current = cachedRestore.lastSeq;
         hasReplayCursorRef.current = cachedRestore.hasReplayCursor;
+        let restoredFitSucceeded = false;
+        try {
+          fitAddon.fit();
+          sendTerminalResize(wsRef.current, term, allowRemoteResizeRef.current);
+          restoredFitSucceeded = true;
+        } catch (err: unknown) {
+          log("fit-failed", { message: err instanceof Error ? err.message : String(err) });
+        }
+        refreshTerminalRenderer(term);
         scheduleStableFit();
+        if (!webglDisabled && restoredFitSucceeded) {
+          void enableWebgl().then((addon) => {
+            webglAddon = addon;
+          });
+        }
       } else {
         // Cache miss — create fresh terminal
         // react-doctor-disable-next-line react-hooks-js/todo -- React Compiler cannot lower dynamic import() expressions; lazy-loading xterm this way is intentional code-splitting, not a defect.
@@ -1627,10 +1643,9 @@ export function TerminalPane({
         clearReconnectTimer();
         clearPendingReconnectBanner();
         heartbeatRef.current?.stop();
-        // Drop the context-loss subscription on every path. On a cache (tab
-        // switch) the WebGL addon stays loaded on the retained terminal and is
-        // re-wired on reattach; on a destroy path term.dispose() below disposes
-        // the addon along with the terminal.
+        // Drop the context-loss subscription on every path. Cache paths dispose
+        // the live WebGL renderer before detaching the retained xterm element;
+        // destroy paths let term.dispose() dispose loaded addons.
         teardownWebglSubscription();
         onDataDisposableRef.current?.dispose();
         onDataDisposableRef.current = null;
@@ -1666,6 +1681,13 @@ export function TerminalPane({
         } else if (wsRef.current) {
           // Tab switch — cache the terminal for instant restore
           log("cleanup-cache-terminal");
+          const retainedWebglAddon = webglAddonRef.current ?? toDisposableWebglAddon(webglAddon);
+          if (retainedWebglAddon && !webglAddonRef.current) {
+            webglAddonRef.current = retainedWebglAddon;
+          }
+          log("webgl-disposed-before-cache", { hadWebgl: Boolean(retainedWebglAddon) });
+          disposeWebgl();
+          webglAddon = null;
           const termElement = (term as { element?: HTMLElement }).element;
           if (termElement?.parentNode) {
             termElement.parentNode.removeChild(termElement);
@@ -1676,10 +1698,7 @@ export function TerminalPane({
           cacheTerminal(paneId, {
             terminal: term,
             fitAddon,
-            // The live addon ref is authoritative: it tracks the renderer
-            // through any context-loss re-create that may have replaced the
-            // addon captured in the local `webglAddon` binding.
-            webglAddon: webglAddonRef.current ?? webglAddon,
+            webglAddon: null,
             searchAddon,
             ws: wsRef.current,
             lastSeq: lastSeqRef.current,

--- a/tests/shell/terminal-pane-scrolling.test.tsx
+++ b/tests/shell/terminal-pane-scrolling.test.tsx
@@ -51,6 +51,8 @@ const restorePlan = vi.hoisted(() => ({
         cols: number;
         rows: number;
         focus: ReturnType<typeof vi.fn>;
+        loadAddon: ReturnType<typeof vi.fn>;
+        refresh: ReturnType<typeof vi.fn>;
         write: ReturnType<typeof vi.fn>;
         dispose: ReturnType<typeof vi.fn>;
         onData: ReturnType<typeof vi.fn>;
@@ -92,6 +94,7 @@ vi.mock("@xterm/xterm", () => ({
 
     loadAddon = vi.fn();
     focus = vi.fn();
+    refresh = vi.fn();
     write = vi.fn();
     dispose = vi.fn();
     onData = vi.fn(() => ({ dispose: vi.fn() }));
@@ -199,6 +202,9 @@ vi.mock("@/stores/terminal-settings", () => {
 });
 
 import { TerminalPane } from "../../shell/src/components/terminal/TerminalPane.js";
+import { cacheTerminal } from "../../shell/src/components/terminal/terminal-cache.js";
+
+const mockedCacheTerminal = vi.mocked(cacheTerminal);
 
 const theme = {
   mode: "dark",
@@ -273,6 +279,8 @@ function createCachedTerminal() {
       cols: 80,
       rows: 24,
       focus: vi.fn(),
+      loadAddon: vi.fn(),
+      refresh: vi.fn(),
       write: vi.fn(),
       dispose: vi.fn(),
       onData: vi.fn(() => ({ dispose: vi.fn() })),
@@ -305,6 +313,7 @@ describe("TerminalPane scrolling", () => {
       setTimeout(() => cb(0), 0)) as typeof requestAnimationFrame;
     stubWs.send.mockReset();
     stubWs.close.mockReset();
+    mockedCacheTerminal.mockClear();
     WebSocketMock.instances.length = 0;
     buildAuthenticatedWebSocketUrl.mockClear();
     Reflect.deleteProperty(window, "visualViewport");
@@ -398,6 +407,92 @@ describe("TerminalPane scrolling", () => {
     expect(cached.viewport.style.getPropertyValue("scrollbar-gutter")).toBe("stable");
     expect(cached.viewport.style.overscrollBehavior).toBe("contain");
     expect(cached.viewport.style.touchAction).toBe("pan-y");
+  });
+
+  it("disposes WebGL before caching an unmounted desktop pane", async () => {
+    const { unmount } = render(
+      <TerminalPane
+        paneId="pane-cache-webgl-dispose-test"
+        cwd=""
+        theme={theme}
+        isFocused={false}
+        isClosing={false}
+        shouldCacheOnUnmount={() => true}
+        shouldDestroyOnUnmount={() => false}
+        onFocus={() => {}}
+      />,
+    );
+
+    await waitFor(() => expect(createdWebglAddons).toHaveLength(1));
+    await waitFor(() => expect(WebSocketMock.instances).toHaveLength(1));
+
+    await act(async () => {
+      unmount();
+      await Promise.resolve();
+    });
+
+    await waitFor(() => expect(mockedCacheTerminal).toHaveBeenCalledOnce());
+
+    const webglAddon = createdWebglAddons[0];
+    expect(webglAddon.dispose).toHaveBeenCalledOnce();
+    expect(webglAddon.dispose.mock.invocationCallOrder[0]).toBeLessThan(
+      mockedCacheTerminal.mock.invocationCallOrder[0],
+    );
+    expect(mockedCacheTerminal.mock.calls[0]?.[1]).toEqual(expect.objectContaining({
+      terminal: createdTerminals[0],
+      fitAddon: createdFitAddons[0],
+      webglAddon: null,
+      ws: WebSocketMock.instances[0],
+    }));
+  });
+
+  it("reattaches and refreshes a DOM cached terminal before re-enabling WebGL", async () => {
+    const cached = createCachedTerminal();
+    const fitAddon = { fit: vi.fn() };
+    restorePlan.current = {
+      cached: {
+        terminal: cached.terminal,
+        fitAddon,
+        webglAddon: null,
+        searchAddon: null,
+        ws: stubWs,
+        lastSeq: 14,
+        hasReplayCursor: true,
+        sessionId: "cached-terminal-with-dom-renderer",
+      },
+      reuseTerminal: true,
+      reuseSocket: true,
+      sessionId: "cached-terminal-with-dom-renderer",
+      lastSeq: 14,
+      hasReplayCursor: true,
+    };
+
+    const { container } = render(
+      <TerminalPane
+        paneId="pane-cached-webgl-restore-test"
+        cwd=""
+        theme={theme}
+        isFocused={false}
+        isClosing={false}
+        shouldCacheOnUnmount={() => false}
+        shouldDestroyOnUnmount={() => false}
+        onFocus={() => {}}
+      />,
+    );
+
+    await waitFor(() => expect(container.querySelector(".xterm")).toBe(cached.terminal.element));
+    await waitFor(() => expect(cached.terminal.refresh).toHaveBeenCalledWith(0, 23));
+    await waitFor(() => expect(createdWebglAddons).toHaveLength(1));
+
+    expect(createdTerminals).toHaveLength(0);
+    expect(fitAddon.fit).toHaveBeenCalled();
+    expect(cached.terminal.loadAddon).toHaveBeenCalledWith(createdWebglAddons[0]);
+    expect(fitAddon.fit.mock.invocationCallOrder[0]).toBeLessThan(
+      cached.terminal.loadAddon.mock.invocationCallOrder[0],
+    );
+    expect(cached.terminal.refresh.mock.invocationCallOrder[0]).toBeLessThan(
+      cached.terminal.loadAddon.mock.invocationCallOrder[0],
+    );
   });
 
   it("does not refocus xterm on mobile visual viewport resize when native keyboard is suppressed", async () => {
@@ -509,7 +604,7 @@ describe("TerminalPane scrolling", () => {
     }));
   });
 
-  it("keeps attempting WebGL on desktop panes", async () => {
+  it("loads WebGL on fresh desktop panes", async () => {
     render(
       <TerminalPane
         paneId="pane-desktop-webgl-test"


### PR DESCRIPTION
## Summary
- Dispose any live terminal WebGL renderer before detaching and caching an xterm instance.
- Restore cached terminals as DOM-rendered xterm instances, refresh the renderer, then create a new WebGL addon after fit.
- Add regression coverage for cache disposal, null cached WebGL entries, restore ordering, fresh desktop WebGL, and mobile DOM rendering.

## Tests
- `pnpm exec vitest run tests/shell/terminal-pane-scrolling.test.tsx tests/shell/terminal-cache.test.ts tests/shell/terminal-pane.test.tsx`
- `pnpm --filter ./shell exec tsc --noEmit`
- `./scripts/review/check-patterns.sh --diff origin/main`
- `npx react-doctor@latest --verbose --scope changed --base origin/main --project shell .`
- Attempted requested `bun run test ...`, but `bun` is not installed in this environment; used the direct Vitest equivalent.
- Screenshot/recording not captured: this is an xterm renderer lifecycle regression with no reliable static visual state, and the local shell/gateway dev stack cannot be started here because `bun` is unavailable.

## Review/Monitoring
- Initial Greptile review was 4/5; code findings were fixed in follow-up commit and the file-size concern is explicitly deferred to #1015.
- Latest Greptile review is 5/5 on commit `9d4a62b7ddb07f5f13e782a05216bfdc647282b2`.
- GitHub PR title and preview gate checks are passing; preview deploy jobs are skipped by workflow conditions.

## Extraction Follow-up
- `TerminalPane.tsx` is already near the repo's extraction threshold. The broader WebGL lifecycle extraction is intentionally out of scope for this bug fix and is tracked in #1015.

## Invariants
- Source of truth: terminal session/socket state stays in the existing client terminal cache and gateway WebSocket session; this change only changes renderer cache policy.
- Lock/transaction scope: no database or backend writes.
- Acceptable orphan states: if cached restore fit fails, the pane remains on the DOM renderer instead of re-enabling WebGL prematurely.
- Auth source of truth: unchanged existing terminal WebSocket auth.
- Deferred scope: no global WebGL disable, no backend/zellij replay changes, no public API changes.
