### PR TITLE
fix(terminal): align privacy test xterm mock

### DIFF
--- a/tests/shell/terminal-pane-privacy.test.tsx
+++ b/tests/shell/terminal-pane-privacy.test.tsx
@@ -7,6 +7,7 @@ const stubTerminal = vi.hoisted(() => ({
   element: null as HTMLElement | null,
   focus: vi.fn(),
   write: vi.fn(),
+  refresh: vi.fn(),
   dispose: vi.fn(),
   cols: 80,
   rows: 24,


### PR DESCRIPTION
## Summary

- Add xterm's public `refresh()` method to the cached terminal stub in the privacy suite.
- Prevent cached terminal restore from emitting unhandled `term.refresh is not a function` rejections in CI.
- Keep production terminal caching and renderer behavior unchanged.

## Tests

- `pnpm exec vitest run tests/shell/terminal-pane-privacy.test.tsx` (5 passed)
- `pnpm exec vitest run tests/shell/terminal-pane-privacy.test.tsx tests/shell/terminal-pane-scrolling.test.tsx tests/shell/terminal-cache.test.ts tests/shell/terminal-pane.test.tsx` (33 passed)
- `pnpm run check:patterns` (0 violations; existing warnings only)
- Typecheck aggregate commands run individually through pnpm because `bun` is unavailable (passed)
- `pnpm dlx react-doctor@latest shell` (completed; only unrelated existing shell findings)
- `pnpm run test` (attempted; sandbox blocks child-process spawning and local socket listeners, causing unrelated `EPERM` failures; CI is the unrestricted full-suite gate)

## Review/Monitoring

- Worktree PR monitor active.
- Do not merge until CI is green, review threads are clear, and the latest trusted Greptile result is 5/5.

## Invariants

- **Source of truth:** Unchanged. The production terminal instance and cache remain authoritative; this PR only aligns a Vitest stub with xterm's public `refresh()` API.
- **Lock/transaction scope:** Not applicable. No database, filesystem, or concurrency behavior changes.
- **Acceptable orphan states:** None introduced. The change creates no persistent or external state.
- **Auth source of truth:** Unchanged. No authentication or authorization path is touched.
- **Deferred scope:** Production terminal lifecycle behavior and broader test-mock refactoring are intentionally out of scope.
