### PR TITLE
fix(terminal): transfer cached pane ownership on restore

### DIFF
--- a/shell/src/components/terminal/TerminalPane.tsx
+++ b/shell/src/components/terminal/TerminalPane.tsx
@@ -16,7 +16,7 @@ import type { TerminalFontFamily, TerminalThemeId } from "@/stores/terminal-sett
 import { buildXtermTheme } from "./terminal-themes";
 import { TerminalSearchBar } from "./TerminalSearchBar";
 import { WebLinkProvider } from "./web-link-provider";
-import { cacheTerminal, getCached, removeCached, type CachedTerminal } from "./terminal-cache";
+import { cacheTerminal, removeCached, takeCached, type CachedTerminal } from "./terminal-cache";
 import { discardStaleCachedTerminal, getCachedTerminalRestorePlan } from "./terminal-restore";
 import { TERMINAL_INPUT_EVENT, type TerminalInputEventDetail } from "./terminal-input-event";
 import { applyTerminalAppearance } from "./terminal-appearance";
@@ -856,7 +856,7 @@ export function TerminalPane({
       }
 
       // Check cache first — instant tab switch
-      const cachedRestore = getCachedTerminalRestorePlan(getCached(paneId));
+      const cachedRestore = getCachedTerminalRestorePlan(takeCached(paneId));
       const cached = cachedRestore.cached;
       const canReuseCachedTerminal = cachedRestore.reuseTerminal;
       const canReuseCachedSocket = cachedRestore.reuseSocket;

--- a/shell/src/components/terminal/terminal-cache.ts
+++ b/shell/src/components/terminal/terminal-cache.ts
@@ -87,17 +87,16 @@ export function cacheTerminal(paneId: string, entry: CachedTerminal, options: Ca
   cache.set(paneId, entry);
 }
 
-export function getCached(paneId: string): CachedTerminal | null {
+/** Transfers ownership of a cached terminal to the caller. */
+export function takeCached(paneId: string): CachedTerminal | null {
   const entry = cache.get(paneId);
-  terminalCacheDebug("cache-get", {
+  cache.delete(paneId);
+  terminalCacheDebug("cache-take", {
     paneId,
     hit: !!entry,
     sessionId: entry?.sessionId ?? null,
+    cacheSizeAfter: cache.size,
   });
-  if (entry) {
-    cache.delete(paneId);
-    cache.set(paneId, entry);
-  }
   return entry ?? null;
 }
 

--- a/tests/shell/terminal-cache.test.ts
+++ b/tests/shell/terminal-cache.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import {
   cacheTerminal,
-  getCached,
+  takeCached,
   removeCached,
   hasCached,
   type CachedTerminal,
@@ -27,13 +27,15 @@ describe("Terminal Cache", () => {
     }
   });
 
-  it("cacheTerminal stores an entry and getCached retrieves it", () => {
+  it("cacheTerminal stores an entry and takeCached transfers ownership", () => {
     const entry = createMockCachedTerminal({ sessionId: "session-abc" });
     cacheTerminal("pane-1", entry);
 
-    const cached = getCached("pane-1");
+    const cached = takeCached("pane-1");
     expect(cached).not.toBeNull();
     expect(cached!.sessionId).toBe("session-abc");
+    expect(hasCached("pane-1")).toBe(false);
+    expect(takeCached("pane-1")).toBeNull();
   });
 
   it("detaches and closes the socket before caching when socket retention is disabled", () => {
@@ -43,7 +45,7 @@ describe("Terminal Cache", () => {
 
     expect((entry.ws as unknown as { send: ReturnType<typeof vi.fn> }).send).toHaveBeenCalledWith(JSON.stringify({ type: "detach" }));
     expect((entry.ws as unknown as { close: ReturnType<typeof vi.fn> }).close).toHaveBeenCalledOnce();
-    expect(getCached("pane-1")).toMatchObject({
+    expect(takeCached("pane-1")).toMatchObject({
       sessionId: "main",
       lastSeq: 42,
     });
@@ -65,8 +67,8 @@ describe("Terminal Cache", () => {
     expect((entry.ws as unknown as { close: ReturnType<typeof vi.fn> }).close).toHaveBeenCalledOnce();
   });
 
-  it("getCached returns null for cache miss", () => {
-    expect(getCached("nonexistent")).toBeNull();
+  it("takeCached returns null for cache miss", () => {
+    expect(takeCached("nonexistent")).toBeNull();
   });
 
   it("hasCached returns true for cached pane", () => {
@@ -84,7 +86,7 @@ describe("Terminal Cache", () => {
 
     removeCached("pane-1");
     expect(hasCached("pane-1")).toBe(false);
-    expect(getCached("pane-1")).toBeNull();
+    expect(takeCached("pane-1")).toBeNull();
   });
 
   it("removeCached is a no-op for nonexistent key", () => {
@@ -99,11 +101,25 @@ describe("Terminal Cache", () => {
     cacheTerminal("pane-1", entry1);
     cacheTerminal("pane-1", entry2);
 
-    const cached = getCached("pane-1");
+    const cached = takeCached("pane-1");
     expect(cached!.sessionId).toBe("session-2");
     expect((entry1.ws as unknown as { send: ReturnType<typeof vi.fn> }).send).toHaveBeenCalledWith(JSON.stringify({ type: "detach" }));
     expect((entry1.ws as unknown as { close: ReturnType<typeof vi.fn> }).close).toHaveBeenCalledOnce();
     expect((entry1.terminal as unknown as { dispose: ReturnType<typeof vi.fn> }).dispose).toHaveBeenCalledOnce();
+  });
+
+  it("does not dispose a restored terminal when it is cached again", () => {
+    const entry = createMockCachedTerminal({ sessionId: "session-restored" });
+    cacheTerminal("pane-1", entry);
+
+    const restored = takeCached("pane-1");
+    expect(restored).toBe(entry);
+
+    cacheTerminal("pane-1", { ...restored! });
+
+    expect((entry.ws as unknown as { send: ReturnType<typeof vi.fn> }).send).not.toHaveBeenCalled();
+    expect((entry.ws as unknown as { close: ReturnType<typeof vi.fn> }).close).not.toHaveBeenCalled();
+    expect((entry.terminal as unknown as { dispose: ReturnType<typeof vi.fn> }).dispose).not.toHaveBeenCalled();
   });
 
   it("supports multiple panes cached simultaneously", () => {
@@ -111,14 +127,14 @@ describe("Terminal Cache", () => {
     cacheTerminal("pane-2", createMockCachedTerminal({ sessionId: "s2" }));
     cacheTerminal("pane-3", createMockCachedTerminal({ sessionId: "s3" }));
 
-    expect(getCached("pane-1")!.sessionId).toBe("s1");
-    expect(getCached("pane-2")!.sessionId).toBe("s2");
-    expect(getCached("pane-3")!.sessionId).toBe("s3");
+    expect(takeCached("pane-1")!.sessionId).toBe("s1");
+    expect(takeCached("pane-2")!.sessionId).toBe("s2");
+    expect(takeCached("pane-3")!.sessionId).toBe("s3");
   });
 
   it("preserves lastSeq value", () => {
     cacheTerminal("pane-1", createMockCachedTerminal({ lastSeq: 42 }));
-    expect(getCached("pane-1")!.lastSeq).toBe(42);
+    expect(takeCached("pane-1")!.lastSeq).toBe(42);
   });
 
   it("evicts the oldest entry before exceeding the hard cap", () => {

--- a/tests/shell/terminal-pane-privacy.test.tsx
+++ b/tests/shell/terminal-pane-privacy.test.tsx
@@ -38,7 +38,7 @@ const MAX_TERMINAL_INPUT = 65_536;
 
 vi.mock("../../shell/src/components/terminal/terminal-cache.js", () => ({
   cacheTerminal: vi.fn(),
-  getCached: vi.fn(() => null),
+  takeCached: vi.fn(() => null),
   removeCached: vi.fn(),
   hasCached: vi.fn(() => false),
 }));

--- a/tests/shell/terminal-pane-scrolling.test.tsx
+++ b/tests/shell/terminal-pane-scrolling.test.tsx
@@ -153,7 +153,7 @@ vi.mock("@xterm/addon-image", () => ({
 
 vi.mock("../../shell/src/components/terminal/terminal-cache.js", () => ({
   cacheTerminal: vi.fn(),
-  getCached: vi.fn(() => null),
+  takeCached: vi.fn(() => null),
   removeCached: vi.fn(),
   hasCached: vi.fn(() => false),
 }));


### PR DESCRIPTION
## Summary

- transfer cached terminal ownership to the active pane when a cache entry is restored
- prevent a restored xterm instance and WebSocket from being disposed when the pane is cached again
- add regression coverage for the restore -> recache lifecycle and update focused TerminalPane cache mocks

## Root Cause

`getCached()` retained the restored entry in the cache map. On a later session switch, `cacheTerminal()` treated the same live terminal as an old dormant entry, disposed its terminal and socket, and then cached the disposed wrapper. The next xterm fit could read renderer `dimensions` from an already disposed terminal and trigger the shell error boundary.

## Invariants

- **Source of truth:** the terminal cache map owns dormant terminal resources only; `takeCached()` transfers ownership atomically to the active pane.
- **Lock/transaction scope:** cache take and write operations remain synchronous in-memory map mutations; no network calls occur inside them.
- **Acceptable orphan states:** genuine replacement, explicit removal, and LRU eviction continue to dispose their dormant terminal and socket resources.
- **Auth source of truth:** unchanged; terminal WebSocket authentication and session identity are outside this lifecycle fix.
- **Deferred scope:** WebGL policy, gateway/zellij replay, and terminal public APIs are unchanged.

## Tests

- `pnpm exec vitest run tests/shell/terminal-pane-scrolling.test.tsx tests/shell/terminal-cache.test.ts tests/shell/terminal-pane.test.tsx tests/shell/terminal-pane-privacy.test.tsx tests/shell/terminal-app-component.test.tsx` (114 passed)
- `pnpm exec vitest run` (793 files, 8,623 passed; 3 files/20 tests skipped)
- package TypeScript matrix for observability, gateway, platform, proxy, edge-router, and shell
- `./scripts/review/check-patterns.sh` (0 violations)
- `npx react-doctor@latest --verbose --scope changed --base origin/main shell` (no changed-code issues)
- `git diff --check`

## Review/Monitoring

- local validation is complete and the review commit range is frozen at `8c6e0a6c9`
- `ready-for-ci` is applied
- merge is gated on all required checks, resolved review threads, and the latest trusted Greptile 5/5 result

## Visual Evidence

Not applicable: this changes terminal resource ownership during session switching without changing rendered UI, layout, styling, or copy.
