### PR TITLE
fix(docker): disable global virtual store inside image builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,10 @@ COPY scripts/build-default-apps.mjs scripts/build-default-apps.mjs
 COPY scripts/install-hermes-matrix-skills.sh scripts/install-hermes-matrix-skills.sh
 COPY scripts/sync-matrix-agent-skills.sh scripts/sync-matrix-agent-skills.sh
 
-RUN pnpm install --frozen-lockfile
+# Keep the repo-wide global virtual store (pnpm-workspace.yaml
+# enableGlobalVirtualStore) off inside image builds so node_modules stays
+# self-contained and survives COPY into later stages.
+RUN pnpm install --frozen-lockfile --config.enableGlobalVirtualStore=false
 
 # Copy source
 COPY packages/ packages/

--- a/Dockerfile.platform
+++ b/Dockerfile.platform
@@ -20,7 +20,11 @@ COPY scripts/fix-node-pty-perms.mjs scripts/fix-node-pty-perms.mjs
 
 FROM base AS deps
 
-RUN pnpm install --frozen-lockfile --ignore-scripts --filter '@matrix-os/platform...' --filter '@matrix-os/gateway...' --filter './shell...'
+# The repo-wide global virtual store (pnpm-workspace.yaml enableGlobalVirtualStore)
+# must stay off inside image builds: node_modules would symlink into the build
+# stage's home directory, which breaks webpack module resolution and does not
+# survive COPY into later stages.
+RUN pnpm install --frozen-lockfile --ignore-scripts --config.enableGlobalVirtualStore=false --filter '@matrix-os/platform...' --filter '@matrix-os/gateway...' --filter './shell...'
 
 FROM deps AS builder
 
@@ -52,7 +56,7 @@ RUN pnpm --dir shell exec next build --webpack
 
 FROM base AS prod-deps
 
-RUN pnpm install --frozen-lockfile --ignore-scripts --prod --filter '@matrix-os/platform...' --filter '@matrix-os/gateway...' --filter './shell...'
+RUN pnpm install --frozen-lockfile --ignore-scripts --prod --config.enableGlobalVirtualStore=false --filter '@matrix-os/platform...' --filter '@matrix-os/gateway...' --filter './shell...'
 
 FROM node:24-alpine AS runtime
 


### PR DESCRIPTION
## Summary

Platform Cloud Run has been red on main since this morning: the platform image build fails in `pnpm --dir shell exec next build --webpack` with import errors such as "'Emitter' is not exported from '../utils/event.js'" (langium via mermaid/streamdown).

Root cause: #1008 enabled `enableGlobalVirtualStore` in `pnpm-workspace.yaml`. Inside Docker image builds, node_modules then symlinks into the build stage's home directory (`/root/.local/share/pnpm/store/v10/links/...`), which breaks webpack's module resolution for package-internal relative imports and would also leave dangling symlinks when node_modules is copied into later image stages.

Fix: pass `--config.enableGlobalVirtualStore=false` to every `pnpm install` in `Dockerfile` and `Dockerfile.platform`, keeping the global store benefit for local worktrees while image builds stay self-contained.

## Validation

- Reproduced the failure from a clean `git archive` of main: `docker build -f Dockerfile.platform` fails at the shell webpack build with the same errors as Cloud Build.
- Rebuilt the same clean tree with this patch: build passes the previously failing step (full-build evidence in the PR checks and local log).

## Invariants

- Source of truth: `pnpm-workspace.yaml` remains the repo-wide pnpm configuration; image builds override only the virtual-store location at install time.
- Lock/transaction scope: none; no lockfile or dependency version changes.
- Acceptable orphan states: none; the flag only changes where installed packages physically live inside build stages.
- Auth source of truth: unchanged.
- Deferred scope: host-bundle and CI-runner installs keep the global store (they build on the runner filesystem and are unaffected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)