### PR TITLE
fix(docker): keep dev container installs on the local virtual store

### DIFF
--- a/distro/docker-dev-entrypoint.sh
+++ b/distro/docker-dev-entrypoint.sh
@@ -16,7 +16,10 @@ ensure_deps() {
     return 0
   fi
   echo "[matrix-os-dev] Installing dependencies (lockfile changed)..."
-  pnpm install --frozen-lockfile
+  # Installs run as root but services run as matrixos; the repo-wide global
+  # virtual store would symlink node_modules into /root and break tool
+  # resolution (e.g. typescript/bin/tsc) for the service user.
+  pnpm install --frozen-lockfile --config.enableGlobalVirtualStore=false
   md5sum pnpm-lock.yaml > node_modules/.pnpm-lock-hash 2>/dev/null || true
 }
 ensure_deps
@@ -185,7 +188,7 @@ if [ "${MATRIX_DEV_DEP_WATCH:-1}" != "0" ]; then
       sleep 5
       md5sum --status -c node_modules/.pnpm-lock-hash 2>/dev/null && continue
       echo "[matrix-os-dev] Lockfile changed -- reinstalling dependencies..."
-      if pnpm install --frozen-lockfile; then
+      if pnpm install --frozen-lockfile --config.enableGlobalVirtualStore=false; then
         md5sum pnpm-lock.yaml > node_modules/.pnpm-lock-hash 2>/dev/null || true
         echo "[matrix-os-dev] Dependencies synced; HMR will pick up changes."
       else


### PR DESCRIPTION
## Summary

Follow-up to #1024. Docker scenario tests on main fail with `Cannot find module '/app/packages/kernel/node_modules/typescript/bin/tsc'`: the dev container entrypoint installs dependencies as root, but services and package builds run as the `matrixos` user. With the repo-wide `enableGlobalVirtualStore` (#1008), node_modules symlinks into /root's pnpm store, which the service user cannot resolve.

Fix: pass `--config.enableGlobalVirtualStore=false` to both `pnpm install` calls in `distro/docker-dev-entrypoint.sh` (initial install and the lockfile-watcher reinstall), keeping the dev container's virtual store inside the repo.

## Validation

- `bash -n` on the entrypoint.
- Same flag already proven in #1024 for the platform and user image builds (Platform Cloud Run green on main after merge).

## Invariants

- Source of truth: `pnpm-workspace.yaml` remains the repo-wide pnpm config; only containerized installs override the store location.
- Lock/transaction scope: none; no dependency changes.
- Acceptable orphan states: none.
- Auth source of truth: unchanged.
- Deferred scope: `scripts/setup-server.sh` installs and runs as the same user, so it keeps the global store.

🤖 Generated with [Claude Code](https://claude.com/claude-code)