### PR TITLE
fix(terminal): restore retained browser scrollback

### DIFF
--- a/shell/src/components/terminal/TerminalPane.tsx
+++ b/shell/src/components/terminal/TerminalPane.tsx
@@ -1451,17 +1451,22 @@ export function TerminalPane({
         }
       }
 
-      function connectWs() {
-        const generation = wsGenerationRef.current + 1;
-        wsGenerationRef.current = generation;
+      function getCanonicalReplayRequest(): CanonicalReplayRequest | undefined {
         const currentSessionId = sessionIdRef.current;
-        const wsPath = terminalWebSocketPathForSession(currentSessionId);
-        const replayRequest: CanonicalReplayRequest | undefined = currentSessionId && isCanonicalShellSessionId(currentSessionId)
+        return currentSessionId && isCanonicalShellSessionId(currentSessionId)
           ? {
               mode: hasReplayCursorRef.current ? "cursor-resume" : "cold-replay",
               requestedSeq: hasReplayCursorRef.current ? lastSeqRef.current : 0,
             }
           : undefined;
+      }
+
+      function connectWs() {
+        const generation = wsGenerationRef.current + 1;
+        wsGenerationRef.current = generation;
+        const currentSessionId = sessionIdRef.current;
+        const wsPath = terminalWebSocketPathForSession(currentSessionId);
+        const replayRequest = getCanonicalReplayRequest();
         const query = currentSessionId && isCanonicalShellSessionId(currentSessionId)
           ? { session: currentSessionId, fromSeq: String(replayRequest?.requestedSeq ?? 0) }
           : currentSessionId || !cwd
@@ -1526,6 +1531,7 @@ export function TerminalPane({
       if (cached && canReuseCachedSocket) {
         bindWs(cached.ws, cached.ws.readyState === WebSocket.CONNECTING, {
           alreadyAttached: cached.ws.readyState === WebSocket.OPEN,
+          replayRequest: getCanonicalReplayRequest(),
         });
       } else {
         if (cached && !canReuseCachedTerminal) {

--- a/shell/src/components/terminal/TerminalPane.tsx
+++ b/shell/src/components/terminal/TerminalPane.tsx
@@ -52,7 +52,6 @@ const TERMINAL_PASTE_MIME_BY_EXTENSION = new Map([
 const TERMINAL_SCROLLBACK_LINES = 10_000;
 const TERMINAL_SCROLL_SENSITIVITY = 1;
 const TERMINAL_FAST_SCROLL_SENSITIVITY = 5;
-const TERMINAL_LIVE_TAIL_FROM_SEQ = Number.MAX_SAFE_INTEGER;
 const IMAGE_ADDON_OPTIONS: IImageAddonOptions = {
   enableSizeReports: false,
   pixelLimit: 4_194_304,
@@ -345,6 +344,10 @@ function refreshTerminalRenderer(term: Terminal): void {
 }
 
 type DisposableWebglAddon = { dispose: () => void };
+type CanonicalReplayRequest = {
+  mode: "cold-replay" | "cursor-resume";
+  requestedSeq: number;
+};
 
 function toDisposableWebglAddon(addon: unknown): DisposableWebglAddon | null {
   if (!addon || typeof addon !== "object") {
@@ -1148,7 +1151,11 @@ export function TerminalPane({
       function bindWs(
         ws: WebSocket,
         attachOnOpen: boolean,
-        options: { alreadyAttached?: boolean; generation?: number } = {},
+        options: {
+          alreadyAttached?: boolean;
+          generation?: number;
+          replayRequest?: CanonicalReplayRequest;
+        } = {},
       ) {
         const generation = options.generation ?? wsGenerationRef.current + 1;
         wsGenerationRef.current = generation;
@@ -1327,11 +1334,16 @@ export function TerminalPane({
                 attachedSessionId: msg.sessionId,
                 state: msg.state,
                 exitCode: msg.exitCode ?? null,
-                fromSeq: msg.fromSeq,
+                replayMode: options.replayRequest?.mode,
+                requestedSeq: options.replayRequest?.requestedSeq,
+                acceptedSeq: msg.fromSeq,
               });
               track("attached", {
                 state: msg.state,
                 hasExitCode: msg.exitCode != null,
+                replayMode: options.replayRequest?.mode,
+                requestedSeq: options.replayRequest?.requestedSeq,
+                acceptedSeq: msg.fromSeq ?? undefined,
               });
               sessionIdRef.current = msg.sessionId;
               if (msg.fromSeq !== null) {
@@ -1444,9 +1456,14 @@ export function TerminalPane({
         wsGenerationRef.current = generation;
         const currentSessionId = sessionIdRef.current;
         const wsPath = terminalWebSocketPathForSession(currentSessionId);
-        const fromSeq = hasReplayCursorRef.current ? lastSeqRef.current : TERMINAL_LIVE_TAIL_FROM_SEQ;
+        const replayRequest: CanonicalReplayRequest | undefined = currentSessionId && isCanonicalShellSessionId(currentSessionId)
+          ? {
+              mode: hasReplayCursorRef.current ? "cursor-resume" : "cold-replay",
+              requestedSeq: hasReplayCursorRef.current ? lastSeqRef.current : 0,
+            }
+          : undefined;
         const query = currentSessionId && isCanonicalShellSessionId(currentSessionId)
-          ? { session: currentSessionId, fromSeq: String(fromSeq) }
+          ? { session: currentSessionId, fromSeq: String(replayRequest?.requestedSeq ?? 0) }
           : currentSessionId || !cwd
             ? undefined
             : { cwd };
@@ -1456,6 +1473,8 @@ export function TerminalPane({
           wsPath,
           queryCwd,
           querySession,
+          replayMode: replayRequest?.mode,
+          requestedSeq: replayRequest?.requestedSeq,
           reconnectAttempt: reconnectAttemptRef.current,
         });
 
@@ -1500,7 +1519,7 @@ export function TerminalPane({
               previousWs.close();
             }
             const ws = new WebSocket(wsUrl);
-            bindWs(ws, true, { generation });
+            bindWs(ws, true, { generation, replayRequest });
           });
       }
 

--- a/tests/gateway/terminal-zellij-ws.test.ts
+++ b/tests/gateway/terminal-zellij-ws.test.ts
@@ -180,13 +180,12 @@ describe("zellij terminal WebSocket", () => {
     const rawLivePrompt = "\x1b[7mlive prompt\x1b[27m";
     const readableReplayPrompt = "\x1b[38;2;214;216;221;48;2;48;54;61mold prompt\x1b[39;49m";
     const readableLivePrompt = "\x1b[38;2;214;216;221;48;2;48;54;61mlive prompt\x1b[39;49m";
+    const attachSession = vi.fn(() => pty);
     const handler = createShellWsHandler({
       registry: {
         list: vi.fn(async () => [{ name: "main", status: "active" }]),
       },
-      adapter: {
-        attachSession: vi.fn(() => pty),
-      },
+      adapter: { attachSession },
       scrollbackStore: {
         latestSeq: vi.fn(async () => 41),
         readSince: vi.fn(async () => [
@@ -210,6 +209,7 @@ describe("zellij terminal WebSocket", () => {
     expect(ws.sent).not.toContainEqual({ type: "output", seq: 41, data: rawReplayPrompt });
     expect(ws.sent).toContainEqual({ type: "output", seq: 42, data: readableLivePrompt });
     expect(append).toHaveBeenCalledWith("main", [{ type: "output", seq: 42, data: readableLivePrompt }]);
+    expect(attachSession).toHaveBeenCalledTimes(1);
   });
 
   it("keeps non-Codex reverse-video output unchanged", async () => {

--- a/tests/shell/terminal-pane-scrolling.test.tsx
+++ b/tests/shell/terminal-pane-scrolling.test.tsx
@@ -315,6 +315,7 @@ describe("TerminalPane scrolling", () => {
       setTimeout(() => cb(0), 0)) as typeof requestAnimationFrame;
     stubWs.send.mockReset();
     stubWs.close.mockReset();
+    stubWs.readyState = WebSocketMock.OPEN;
     mockedCacheTerminal.mockClear();
     mockedCapturePostHogEvent.mockClear();
     WebSocketMock.instances.length = 0;
@@ -739,6 +740,57 @@ describe("TerminalPane scrolling", () => {
 
     const telemetryPayloads = mockedCapturePostHogEvent.mock.calls.map(([, payload]) => payload);
     expect(telemetryPayloads).not.toContainEqual(expect.objectContaining({ data: expect.anything() }));
+  });
+
+  it("records cursor-resume metadata when a cached canonical socket finishes connecting", async () => {
+    const cached = createCachedTerminal();
+    stubWs.readyState = WebSocketMock.CONNECTING;
+    restorePlan.current = {
+      cached: {
+        terminal: cached.terminal,
+        fitAddon: { fit: vi.fn() },
+        webglAddon: null,
+        searchAddon: null,
+        ws: stubWs,
+        lastSeq: 23,
+        hasReplayCursor: true,
+        sessionId: "main",
+      },
+      reuseTerminal: true,
+      reuseSocket: true,
+      sessionId: "main",
+      lastSeq: 23,
+      hasReplayCursor: true,
+    };
+
+    render(
+      <TerminalPane
+        paneId="pane-cached-connecting-telemetry-test"
+        cwd=""
+        theme={theme}
+        isFocused={false}
+        isClosing={false}
+        shouldCacheOnUnmount={() => false}
+        shouldDestroyOnUnmount={() => false}
+        onFocus={() => {}}
+      />,
+    );
+
+    await waitFor(() => expect(stubWs.onmessage).not.toBeNull());
+    await act(async () => {
+      stubWs.readyState = WebSocketMock.OPEN;
+      stubWs.onopen?.();
+      stubWs.onmessage?.({
+        data: JSON.stringify({ type: "attached", session: "main", state: "running", fromSeq: 23 }),
+      });
+    });
+
+    expect(mockedCapturePostHogEvent).toHaveBeenCalledWith("shell_terminal_ws", expect.objectContaining({
+      event: "attached",
+      replayMode: "cursor-resume",
+      requestedSeq: 23,
+      acceptedSeq: 23,
+    }));
   });
 
   it("resumes from the next accepted sequence and renders missed output once", async () => {

--- a/tests/shell/terminal-pane-scrolling.test.tsx
+++ b/tests/shell/terminal-pane-scrolling.test.tsx
@@ -203,8 +203,10 @@ vi.mock("@/stores/terminal-settings", () => {
 
 import { TerminalPane } from "../../shell/src/components/terminal/TerminalPane.js";
 import { cacheTerminal } from "../../shell/src/components/terminal/terminal-cache.js";
+import { capturePostHogEvent } from "../../shell/src/lib/posthog-client.js";
 
 const mockedCacheTerminal = vi.mocked(cacheTerminal);
+const mockedCapturePostHogEvent = vi.mocked(capturePostHogEvent);
 
 const theme = {
   mode: "dark",
@@ -314,6 +316,7 @@ describe("TerminalPane scrolling", () => {
     stubWs.send.mockReset();
     stubWs.close.mockReset();
     mockedCacheTerminal.mockClear();
+    mockedCapturePostHogEvent.mockClear();
     WebSocketMock.instances.length = 0;
     buildAuthenticatedWebSocketUrl.mockClear();
     Reflect.deleteProperty(window, "visualViewport");
@@ -620,6 +623,222 @@ describe("TerminalPane scrolling", () => {
 
     await waitFor(() => expect(createdWebglAddons).toHaveLength(1));
     expect(createdTerminals[0].loadAddon).toHaveBeenCalledWith(createdWebglAddons[0]);
+  });
+
+  it("requests retained scrollback from zero for a fresh canonical browser session", async () => {
+    render(
+      <TerminalPane
+        paneId="pane-cold-replay-test"
+        cwd=""
+        theme={theme}
+        isFocused={false}
+        isClosing={false}
+        sessionId="main"
+        shouldCacheOnUnmount={() => false}
+        shouldDestroyOnUnmount={() => false}
+        onFocus={() => {}}
+      />,
+    );
+
+    await waitFor(() => expect(WebSocketMock.instances).toHaveLength(1));
+    const url = new URL(WebSocketMock.instances[0]!.url);
+
+    expect(url.pathname).toBe("/ws/terminal/session");
+    expect(url.searchParams.get("session")).toBe("main");
+    expect(url.searchParams.get("fromSeq")).toBe("0");
+    expect(url.searchParams.get("fromSeq")).not.toBe(String(Number.MAX_SAFE_INTEGER));
+  });
+
+  it("renders retained output into a new xterm after a full canonical-session remount", async () => {
+    const props = {
+      paneId: "pane-full-remount-test",
+      cwd: "",
+      theme,
+      isFocused: false,
+      isClosing: false,
+      sessionId: "main",
+      shouldCacheOnUnmount: () => false,
+      shouldDestroyOnUnmount: () => false,
+      onFocus: () => {},
+    } satisfies Parameters<typeof TerminalPane>[0];
+    const firstMount = render(<TerminalPane {...props} />);
+
+    await waitFor(() => expect(WebSocketMock.instances).toHaveLength(1));
+    firstMount.unmount();
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    render(<TerminalPane {...props} />);
+    await waitFor(() => expect(WebSocketMock.instances).toHaveLength(2));
+    expect(createdTerminals).toHaveLength(2);
+    const restoredSocket = WebSocketMock.instances[1]!;
+    const restoredTerminal = createdTerminals[1]!;
+    expect(new URL(restoredSocket.url).searchParams.get("fromSeq")).toBe("0");
+
+    await act(async () => {
+      restoredSocket.onmessage?.({
+        data: JSON.stringify({ type: "attached", session: "main", state: "running", fromSeq: 0 }),
+      });
+      restoredSocket.onmessage?.({ data: JSON.stringify({ type: "replay-start", fromSeq: 0 }) });
+      restoredSocket.onmessage?.({
+        data: JSON.stringify({ type: "output", seq: 0, data: "retained-before-refresh\r\n" }),
+      });
+      restoredSocket.onmessage?.({ data: JSON.stringify({ type: "replay-end" }) });
+    });
+
+    expect(restoredTerminal.write).toHaveBeenCalledWith("retained-before-refresh\r\n");
+  });
+
+  it("records cold replay and cursor resume request/accept metadata without terminal content", async () => {
+    render(
+      <TerminalPane
+        paneId="pane-replay-telemetry-test"
+        cwd=""
+        theme={theme}
+        isFocused={false}
+        isClosing={false}
+        sessionId="main"
+        shouldCacheOnUnmount={() => false}
+        shouldDestroyOnUnmount={() => false}
+        onFocus={() => {}}
+      />,
+    );
+
+    await waitFor(() => expect(WebSocketMock.instances).toHaveLength(1));
+    const firstSocket = WebSocketMock.instances[0]!;
+    await act(async () => {
+      firstSocket.onmessage?.({
+        data: JSON.stringify({ type: "attached", session: "main", state: "running", fromSeq: 12 }),
+      });
+    });
+    expect(mockedCapturePostHogEvent).toHaveBeenCalledWith("shell_terminal_ws", expect.objectContaining({
+      event: "attached",
+      replayMode: "cold-replay",
+      requestedSeq: 0,
+      acceptedSeq: 12,
+    }));
+
+    await act(async () => {
+      firstSocket.onclose?.();
+      document.dispatchEvent(new Event("visibilitychange"));
+    });
+    await waitFor(() => expect(WebSocketMock.instances).toHaveLength(2));
+    const reconnectSocket = WebSocketMock.instances[1]!;
+    await act(async () => {
+      reconnectSocket.onmessage?.({
+        data: JSON.stringify({ type: "attached", session: "main", state: "running", fromSeq: 12 }),
+      });
+    });
+    expect(mockedCapturePostHogEvent).toHaveBeenCalledWith("shell_terminal_ws", expect.objectContaining({
+      event: "attached",
+      replayMode: "cursor-resume",
+      requestedSeq: 12,
+      acceptedSeq: 12,
+    }));
+
+    const telemetryPayloads = mockedCapturePostHogEvent.mock.calls.map(([, payload]) => payload);
+    expect(telemetryPayloads).not.toContainEqual(expect.objectContaining({ data: expect.anything() }));
+  });
+
+  it("resumes from the next accepted sequence and renders missed output once", async () => {
+    render(
+      <TerminalPane
+        paneId="pane-missed-output-test"
+        cwd=""
+        theme={theme}
+        isFocused={false}
+        isClosing={false}
+        sessionId="main"
+        shouldCacheOnUnmount={() => false}
+        shouldDestroyOnUnmount={() => false}
+        onFocus={() => {}}
+      />,
+    );
+
+    await waitFor(() => expect(WebSocketMock.instances).toHaveLength(1));
+    const firstSocket = WebSocketMock.instances[0]!;
+    const terminal = createdTerminals[0]!;
+    await act(async () => {
+      firstSocket.onmessage?.({
+        data: JSON.stringify({ type: "attached", session: "main", state: "running", fromSeq: 40 }),
+      });
+      firstSocket.onmessage?.({ data: JSON.stringify({ type: "output", seq: 40, data: "before-drop\r\n" }) });
+      firstSocket.onclose?.();
+      document.dispatchEvent(new Event("visibilitychange"));
+    });
+
+    await waitFor(() => expect(WebSocketMock.instances).toHaveLength(2));
+    const reconnectSocket = WebSocketMock.instances[1]!;
+    expect(new URL(reconnectSocket.url).searchParams.get("fromSeq")).toBe("41");
+    await act(async () => {
+      reconnectSocket.onmessage?.({
+        data: JSON.stringify({ type: "attached", session: "main", state: "running", fromSeq: 41 }),
+      });
+      reconnectSocket.onmessage?.({ data: JSON.stringify({ type: "output", seq: 41, data: "missed-once\r\n" }) });
+    });
+
+    expect(terminal.write.mock.calls.filter(([data]) => data === "before-drop\r\n")).toHaveLength(1);
+    expect(terminal.write.mock.calls.filter(([data]) => data === "missed-once\r\n")).toHaveLength(1);
+  });
+
+  it("preserves the xterm buffer and replay cursor across cached tab switching", async () => {
+    const props = {
+      paneId: "pane-cached-replay-test",
+      cwd: "",
+      theme,
+      isFocused: false,
+      isClosing: false,
+      sessionId: "main",
+      shouldCacheOnUnmount: () => true,
+      shouldDestroyOnUnmount: () => false,
+      onFocus: () => {},
+    } satisfies Parameters<typeof TerminalPane>[0];
+    const firstMount = render(<TerminalPane {...props} />);
+
+    await waitFor(() => expect(WebSocketMock.instances).toHaveLength(1));
+    const firstSocket = WebSocketMock.instances[0]!;
+    const terminal = createdTerminals[0]!;
+    await act(async () => {
+      firstSocket.onmessage?.({
+        data: JSON.stringify({ type: "attached", session: "main", state: "running", fromSeq: 7 }),
+      });
+      firstSocket.onmessage?.({ data: JSON.stringify({ type: "output", seq: 7, data: "cached-output\r\n" }) });
+      firstMount.unmount();
+      await Promise.resolve();
+    });
+
+    await waitFor(() => expect(mockedCacheTerminal).toHaveBeenCalled());
+    const cachedEntry = mockedCacheTerminal.mock.calls.at(-1)![1];
+    expect(cachedEntry.terminal).toBe(terminal);
+    expect(cachedEntry.lastSeq).toBe(8);
+    expect(cachedEntry.hasReplayCursor).toBe(true);
+    expect(mockedCacheTerminal.mock.calls.at(-1)![2]).toEqual({ retainSocket: false });
+
+    restorePlan.current = {
+      cached: {
+        terminal: cachedEntry.terminal,
+        fitAddon: cachedEntry.fitAddon,
+        webglAddon: null,
+        searchAddon: cachedEntry.searchAddon,
+        ws: stubWs,
+        lastSeq: cachedEntry.lastSeq,
+        hasReplayCursor: cachedEntry.hasReplayCursor,
+        sessionId: cachedEntry.sessionId,
+      },
+      reuseTerminal: true,
+      reuseSocket: false,
+      sessionId: "main",
+      lastSeq: 8,
+      hasReplayCursor: true,
+    };
+
+    render(<TerminalPane {...props} />);
+    await waitFor(() => expect(WebSocketMock.instances).toHaveLength(2));
+
+    expect(createdTerminals).toHaveLength(1);
+    expect(terminal.write.mock.calls.filter(([data]) => data === "cached-output\r\n")).toHaveLength(1);
+    expect(new URL(WebSocketMock.instances[1]!.url).searchParams.get("fromSeq")).toBe("8");
   });
 
   it.each([0, 60])("uses attached fromSeq %i as the reconnect cursor before output arrives", async (fromSeq) => {

--- a/www/content/docs/guide/cloud-coding.mdx
+++ b/www/content/docs/guide/cloud-coding.mdx
@@ -87,7 +87,7 @@ Dirty worktrees require explicit cleanup. Matrix OS tracks leases so two writers
 
 Coding sessions are durable workspace objects. You can attach as the active operator, observe without taking control, take over when needed, duplicate panes, or hand a session to a local terminal.
 
-Session transcripts are retained with bounded replay caps, so reconnecting from web, desktop, CLI, or TUI can show recent output without keeping unbounded process output in memory.
+Session transcripts are retained with bounded replay caps, so reconnecting from web, desktop, CLI, or TUI can show recent output without keeping unbounded process output in memory. Reopening a terminal or refreshing the browser restores the output still available within that bounded replay limit; output older than the retained limit is not restored.
 
 ## Review loops
 


### PR DESCRIPTION
## Summary

- restore retained gateway scrollback on fresh canonical browser terminal mounts by requesting `fromSeq=0`
- preserve accepted replay cursors for duplicate-free reconnects and cached tab restores
- add content-free `cold-replay` / `cursor-resume` telemetry and document browser refresh behavior

## Tests

- `pnpm exec vitest run tests/shell/terminal-pane-scrolling.test.tsx tests/shell/terminal-pane.test.tsx tests/shell/terminal-cache.test.ts`
- `pnpm exec vitest run tests/gateway/terminal-zellij-ws.test.ts`
- `pnpm run check:patterns`
- `npx react-doctor@latest --verbose --scope lines --base origin/main --no-score shell`
- `pnpm run build:shell:production`
- package TypeScript builds/checks for observability, kernel, gateway, platform, proxy, and edge-router

## Review / Monitoring

- [x] CI green
- [x] preview VPS `v2026.07.18-pr1031-c3dd4ff` deployed and requester confirmed the authenticated shell was working; disposable VPS removed afterward
- [ ] current screenshot or recording of retained output after refresh/reopen/tab discard attached
- [x] latest trusted Greptile review is 5/5 on `c3dd4ff5c`

## Invariants

- **Source of truth:** the existing bounded gateway scrollback store remains canonical; the browser only retains the accepted replay cursor and existing cached xterm instance.
- **Lock/transaction scope:** no database writes, locks, or transactions are added; replay ordering continues to use gateway sequence numbers.
- **Acceptable orphan states:** output evicted beyond the bounded replay limit remains unavailable; a dropped mounted browser resumes from its accepted next sequence, while a full remount starts at zero.
- **Auth source of truth:** the existing authenticated terminal WebSocket route and query-token policy are unchanged.
- **Deferred scope:** no PTY, zellij lifecycle, protocol, layout, browser-local snapshot, or persistence changes; CLI/native explicit live-tail sentinel behavior remains supported.
