### PR TITLE
feat(agents): orchestrate problem PR workflows

### DIFF
--- a/.agents/skills/orchestrate-problem-prs/SKILL.md
+++ b/.agents/skills/orchestrate-problem-prs/SKILL.md
@@ -131,9 +131,9 @@ require React Doctor and current screenshot evidence. Record every skipped gate
 with its exact reason.
 
 After implementation and local validation, tell the owner to mark its draft PR
-ready for review and verify that it is no longer a draft. Then tell the owner
-to invoke `$worktree-pr-monitor` for its single assigned PR. The leaf owner
-must:
+ready for review and verify that it is no longer a draft. The same problem
+owner is personally responsible for invoking and completing
+`$worktree-pr-monitor` for its single assigned PR. The owner must:
 
 1. resolve current-head review feedback until Greptile reports `5/5`;
 2. add `ready-for-ci` only at the point required by that skill;

--- a/.agents/skills/orchestrate-problem-prs/SKILL.md
+++ b/.agents/skills/orchestrate-problem-prs/SKILL.md
@@ -1,0 +1,143 @@
+---
+name: orchestrate-problem-prs
+description: Decompose a structured or unstructured problem report into independently scoped workstreams, assign one subagent per accepted problem for read-only root-cause analysis, gate isolated draft PR implementation on evidence and a written plan, and shepherd every PR through worktree-pr-monitor. Use when a requester asks Codex to investigate and fix multiple reported problems in coordinated separate PRs without merging them.
+---
+
+# Orchestrate Problem PRs
+
+Coordinate an evidence-first, multi-PR workflow. Determine the number of
+workstreams from the report; never encode or assume a fixed worker count.
+
+Read [references/worker-contracts.md](references/worker-contracts.md) before
+assigning workers. Use its contracts verbatim enough that every worker returns
+comparable evidence and PR comments.
+
+## Preconditions
+
+- Re-read the repository instructions and constitution.
+- Confirm the requester authorized a multi-agent, manual-worktree PR workflow.
+- Confirm the repository, base branch, source change or incident context, and
+  completion gate.
+- Fetch the remote base once and record its exact commit SHA. Use that pinned
+  SHA for every initial investigation and worktree unless the requester says
+  otherwise.
+- Inspect the primary checkout and preserve unrelated work. Never implement in
+  the primary checkout.
+- Confirm GitHub CLI authentication, the `ready-for-ci` label, and available
+  agent capacity before starting mutations.
+
+## Coordinator Invariants
+
+- Keep one coordinator active until every workstream is complete or blocked.
+- Let `N` equal the number of independently scoped problems supported by the
+  supplied report. Spawn one distinct problem owner for each accepted problem.
+- Run only as many workers concurrently as available slots permit, reserving
+  the coordinator slot. Queue remaining workers without reusing an owner for a
+  different problem.
+- Do not use Agent-tool worktree isolation. Use persistent manual Git
+  worktrees only.
+- Give each worker exactly one problem, the raw relevant evidence, the pinned
+  base SHA, and repository instructions. Do not leak another worker's proposed
+  root cause or intended fix into the investigation prompt.
+- Keep investigation read-only. No edits, branches, worktrees, commits, pushes,
+  PRs, labels, or comments are permitted during that phase.
+- Do not merge. The terminal state is a set of review-ready PRs for the
+  requester.
+
+## Phase 1: Decompose the Report
+
+1. Read the entire report before assigning work.
+2. Extract candidate problems from headings, symptoms, reproduction details,
+   logs, screenshots, and narrative context.
+3. Separate independently diagnosable failures from multiple symptoms of one
+   failure. Record dependencies and suspected overlap without treating those
+   suspicions as conclusions.
+4. Give each accepted problem a stable ID, concise title, observed behavior,
+   expected behavior, evidence pointers, and explicit exclusions.
+5. Ask the requester only when ambiguous boundaries would materially change
+   the number or ownership of PRs. Otherwise proceed with the best supported
+   decomposition.
+
+## Phase 2: Investigate Read-Only
+
+Spawn problem owners in capacity-bounded batches using the investigation
+contract. A worker must return:
+
+- reproduction or a deterministic execution-path trace;
+- exact relevant files, symbols, and line references;
+- the first incorrect state transition, assumption, or boundary violation;
+- how the source change introduced or exposed the behavior;
+- alternatives considered and evidence that rules them out;
+- affected scope, remaining unknowns, and a confidence rating; and
+- a focused regression-test design that fails before the fix.
+
+Reject symptom restatements as root causes. If confidence is not supported by
+evidence, keep that workstream read-only and report it as blocked.
+
+## Phase 3: Reconcile PR Boundaries
+
+Compare completed dossiers before allowing any mutation.
+
+- Preserve one PR per independent root cause by default.
+- If multiple reports resolve to the same root cause, or fixes substantially
+  overlap, pause and propose a consolidated ownership boundary to the
+  requester.
+- If fixes depend on one another, record their order. Use stacked PRs only when
+  repository instructions require them and the required stack tooling is
+  available.
+- Reserve unique semantic branch names, worktree paths, and PR titles.
+- Create or register manual worktrees sequentially to avoid contention in
+  shared Git metadata, then hand each exact path to its owner.
+
+## Phase 4: Bootstrap Draft PRs
+
+Authorize only the bootstrap phase for each accepted dossier.
+
+1. Add the focused failing regression test first and demonstrate the expected
+   failure. Do not change production code yet.
+2. Commit the test as a scoped Conventional Commit and push the assigned
+   branch.
+3. Open a draft PR with the repository-required body sections.
+4. Post two separate comments using the reference templates:
+   `Root-cause analysis` followed by `Resolution plan`.
+5. Return the PR URL, commit SHA, failing-test command and output summary, and
+   comment URLs to the coordinator.
+
+If a meaningful regression test cannot bootstrap the PR, stop and obtain the
+coordinator's explicit approval for another in-scope approach. Never add junk
+files solely to manufacture a diff.
+
+## Phase 5: Unlock Implementation
+
+Verify the draft PR, failing test, root-cause comment, and plan comment. Check
+the plan against repository security, concurrency, resource-management,
+failure-mode, frontend, and documentation requirements.
+
+Only then send a new, explicit implementation task to the same problem owner.
+The worker must follow Red -> Green -> Refactor, commit working increments, and
+remain within its assigned worktree and PR.
+
+## Phase 6: Validate and Monitor
+
+Require focused tests and all applicable repository gates. React changes also
+require React Doctor and current screenshot evidence. Record every skipped gate
+with its exact reason.
+
+After implementation and local validation, tell the owner to invoke
+`$worktree-pr-monitor` for its single assigned PR. The leaf owner must:
+
+1. mark the completed draft PR ready for review;
+2. resolve current-head review feedback until Greptile reports `5/5`;
+3. add `ready-for-ci` only at the point required by that skill;
+4. wait for the label-triggered current-head CI to pass; and
+5. return the PR URL, worktree, branch, SHA, checks, Greptile rating, and risks.
+
+Do not accept stale reviews or checks from an earlier commit.
+
+## Final Handoff
+
+Return one aggregate table containing problem ID, owner, root cause, PR URL,
+branch, current SHA, CI result, Greptile rating, dependency order, and residual
+risk. Present PRs for requester review only when every non-blocked workstream is
+ready. List blocked workstreams separately with the exact evidence or authority
+needed to continue.

--- a/.agents/skills/orchestrate-problem-prs/SKILL.md
+++ b/.agents/skills/orchestrate-problem-prs/SKILL.md
@@ -130,14 +130,15 @@ Require focused tests and all applicable repository gates. React changes also
 require React Doctor and current screenshot evidence. Record every skipped gate
 with its exact reason.
 
-After implementation and local validation, tell the owner to invoke
-`$worktree-pr-monitor` for its single assigned PR. The leaf owner must:
+After implementation and local validation, tell the owner to mark its draft PR
+ready for review and verify that it is no longer a draft. Then tell the owner
+to invoke `$worktree-pr-monitor` for its single assigned PR. The leaf owner
+must:
 
-1. mark the completed draft PR ready for review;
-2. resolve current-head review feedback until Greptile reports `5/5`;
-3. add `ready-for-ci` only at the point required by that skill;
-4. wait for the label-triggered current-head CI to pass; and
-5. return the PR URL, worktree, branch, SHA, checks, Greptile rating, and risks.
+1. resolve current-head review feedback until Greptile reports `5/5`;
+2. add `ready-for-ci` only at the point required by that skill;
+3. wait for the label-triggered current-head CI to pass; and
+4. return the PR URL, worktree, branch, SHA, checks, Greptile rating, and risks.
 
 Do not accept stale reviews or checks from an earlier commit.
 

--- a/.agents/skills/orchestrate-problem-prs/SKILL.md
+++ b/.agents/skills/orchestrate-problem-prs/SKILL.md
@@ -31,9 +31,16 @@ comparable evidence and PR comments.
 - Keep one coordinator active until every workstream is complete or blocked.
 - Let `N` equal the number of independently scoped problems supported by the
   supplied report. Spawn one distinct problem owner for each accepted problem.
-- Run only as many workers concurrently as available slots permit, reserving
-  the coordinator slot. Queue remaining workers without reusing an owner for a
-  different problem.
+- Determine capacity before every batch. Read the platform's declared
+  concurrency limit and use its agent-status/list operation to count every
+  active agent, including the coordinator. Compute available platform slots as
+  `total slots - active agents`. If the requester supplied a lower maximum
+  worker concurrency, compute its remaining allowance as `worker cap - active
+  problem workers`; otherwise use the queued-problem count as that allowance.
+  Spawn at most the smallest of the available slots, remaining allowance, and
+  queued problems, then recompute after workers finish. If the platform exposes
+  no limit, ask the requester instead of guessing.
+- Queue remaining workers without reusing an owner for a different problem.
 - Do not use Agent-tool worktree isolation. Use persistent manual Git
   worktrees only.
 - Give each worker exactly one problem, the raw relevant evidence, the pinned

--- a/.agents/skills/orchestrate-problem-prs/agents/openai.yaml
+++ b/.agents/skills/orchestrate-problem-prs/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Orchestrate Problem PRs"
+  short_description: "Diagnose and shepherd independent problems to PRs"
+  default_prompt: "Use $orchestrate-problem-prs to decompose this report, diagnose each independent problem, and shepherd the resulting PRs to review readiness."

--- a/.agents/skills/orchestrate-problem-prs/references/worker-contracts.md
+++ b/.agents/skills/orchestrate-problem-prs/references/worker-contracts.md
@@ -137,8 +137,9 @@ the comments; implementation remains locked.
 Implementation is authorized for <problem ID> in <worktree and PR>. Follow the
 approved plan and Red -> Green -> Refactor. Do not expand scope without
 returning to the coordinator. Commit working increments. After local validation,
-mark the draft PR ready for review, verify it is no longer a draft, then invoke
-$worktree-pr-monitor for this single assigned PR. Do not merge.
+mark the draft PR ready for review and verify it is no longer a draft. You are
+personally responsible for invoking and completing $worktree-pr-monitor for
+this single assigned PR, including its Greptile and CI gates. Do not merge.
 ```
 
 ## Completion Report

--- a/.agents/skills/orchestrate-problem-prs/references/worker-contracts.md
+++ b/.agents/skills/orchestrate-problem-prs/references/worker-contracts.md
@@ -17,6 +17,8 @@ You own exactly one problem: <problem ID and title>.
 
 Source context: <PR, commit, incident, or preview context>
 Pinned base SHA: <SHA>
+Repository instructions: Re-read <applicable AGENTS.md or CLAUDE.md paths> and
+<constitution path> before investigating; those rules remain authoritative.
 Raw problem evidence: <relevant unedited report excerpt and artifact links>
 Expected behavior: <expected behavior>
 Explicit exclusions: <out-of-scope symptoms or workstreams>

--- a/.agents/skills/orchestrate-problem-prs/references/worker-contracts.md
+++ b/.agents/skills/orchestrate-problem-prs/references/worker-contracts.md
@@ -137,7 +137,8 @@ the comments; implementation remains locked.
 Implementation is authorized for <problem ID> in <worktree and PR>. Follow the
 approved plan and Red -> Green -> Refactor. Do not expand scope without
 returning to the coordinator. Commit working increments. After local validation,
-invoke $worktree-pr-monitor for this single assigned PR. Do not merge.
+mark the draft PR ready for review, verify it is no longer a draft, then invoke
+$worktree-pr-monitor for this single assigned PR. Do not merge.
 ```
 
 ## Completion Report

--- a/.agents/skills/orchestrate-problem-prs/references/worker-contracts.md
+++ b/.agents/skills/orchestrate-problem-prs/references/worker-contracts.md
@@ -1,0 +1,158 @@
+# Worker Contracts
+
+## Contents
+
+1. Investigation assignment
+2. Root-cause dossier
+3. Draft PR bootstrap assignment
+4. Root-cause comment
+5. Resolution-plan comment
+6. Implementation unlock
+7. Completion report
+
+## Investigation Assignment
+
+```text
+You own exactly one problem: <problem ID and title>.
+
+Source context: <PR, commit, incident, or preview context>
+Pinned base SHA: <SHA>
+Raw problem evidence: <relevant unedited report excerpt and artifact links>
+Expected behavior: <expected behavior>
+Explicit exclusions: <out-of-scope symptoms or workstreams>
+
+Investigate in strict read-only mode. Do not edit files, create a branch or
+worktree, commit, push, open a PR, apply labels, or write comments. Trace the
+behavior to its first incorrect state transition, assumption, or trust
+boundary. Return the root-cause dossier below. Do not propose implementation
+as a substitute for proving the cause.
+```
+
+## Root-Cause Dossier
+
+```markdown
+## <problem ID>: <title>
+
+### Observed and expected behavior
+<precise comparison>
+
+### Reproduction or execution trace
+<steps or deterministic control/data-flow trace>
+
+### Evidence
+- `<file:line>` — <what the code proves>
+- <log, screenshot, test, PR-diff, or history evidence>
+
+### Root cause
+<first incorrect state transition, assumption, or boundary violation>
+
+### Relationship to the source change
+<how it was introduced or exposed>
+
+### Alternatives ruled out
+- <alternative> — <contradicting evidence>
+
+### Affected scope and risks
+<users, surfaces, data, concurrency, security, or compatibility>
+
+### Regression-test design
+<focused test and why it fails before the fix>
+
+### Confidence and unknowns
+Confidence: <high, medium, or low>
+Unknowns: <remaining uncertainty or `none`>
+```
+
+High confidence requires direct code evidence plus either reproduction or a
+deterministic trace. Medium or low confidence does not pass the mutation gate.
+
+## Draft PR Bootstrap Assignment
+
+```text
+Your read-only diagnosis for <problem ID> is accepted. Use only the assigned
+manual worktree, branch, and PR title below:
+
+Worktree: <absolute path>
+Branch: <semantic branch>
+PR title: <Conventional Commit title>
+Base SHA: <pinned SHA>
+
+Add the focused failing regression test without changing production code. Run
+it and capture the expected failure. Commit and push that test, open a draft
+PR, then post the root-cause and resolution-plan comments as separate comments.
+Return the PR, commit, command/output summary, and both comment URLs. Stop after
+the comments; implementation remains locked.
+```
+
+## Root-Cause Comment
+
+```markdown
+## Root-cause analysis
+
+**Problem:** <observed versus expected behavior>
+
+**Reproduction/trace:** <concise steps or execution path>
+
+**Root cause:** <first incorrect transition, assumption, or boundary>
+
+**Evidence:**
+- `<file:line>` — <explanation>
+- <other direct evidence>
+
+**Source-change relationship:** <introduced or exposed>
+
+**Affected scope:** <scope and risks>
+
+**Alternatives ruled out:** <alternatives and evidence>
+
+**Confidence:** High — <why>
+
+**Remaining unknowns:** <unknowns or `None`>
+```
+
+## Resolution-Plan Comment
+
+```markdown
+## Resolution plan
+
+1. **Red:** <failing regression test and asserted behavior>
+2. **Green:** <smallest production change that addresses the proven cause>
+3. **Refactor:** <cleanup that preserves the behavior>
+4. **Failure and security review:** <validation, concurrency, cleanup, error,
+   resource, and trust-boundary considerations>
+5. **Validation:** <focused tests, typecheck, pattern scan, unit tests, and any
+   integration or end-to-end checks>
+6. **Frontend evidence:** <React Doctor and screenshot plan, or `Not applicable`>
+7. **Documentation:** <public/internal documentation impact>
+8. **Dependencies:** <other PRs and merge order, or `None`>
+
+**Deferred scope:** <explicit exclusions>
+```
+
+## Implementation Unlock
+
+```text
+Implementation is authorized for <problem ID> in <worktree and PR>. Follow the
+approved plan and Red -> Green -> Refactor. Do not expand scope without
+returning to the coordinator. Commit working increments. After local validation,
+invoke $worktree-pr-monitor for this single assigned PR. Do not merge.
+```
+
+## Completion Report
+
+```markdown
+## <problem ID> completion
+
+- PR: <URL>
+- Worktree: `<absolute path>`
+- Branch: `<branch>`
+- Current SHA: `<SHA>`
+- Root cause: <one-sentence cause>
+- Focused checks: <commands and results>
+- Broad checks: <commands and results>
+- Greptile: `5/5` for <current SHA or review timestamp evidence>
+- `ready-for-ci`: <applied/verified>
+- Label-triggered CI: <passing checks>
+- Dependencies: <order or `None`>
+- Skipped checks/residual risk: <details or `None`>
+```

--- a/.agents/skills/worktree-pr-monitor/SKILL.md
+++ b/.agents/skills/worktree-pr-monitor/SKILL.md
@@ -32,8 +32,11 @@ coordinator-assigned worktree, branch, and PR. The repo-level ban on Agent-tool
 - If neither the requester nor a coordinator explicitly assigned a worktree,
   follow the current branch workflow instead.
 - Keep the primary checkout on its existing branch and preserve unrelated work.
-- Resolve the manual-worktree location from repository instructions; do not
-  assume a fixed home directory or reuse another agent's path.
+- Resolve the primary checkout's absolute path and, unless repository
+  instructions specify another location, use the canonical sibling path
+  `<primary-checkout-parent>/<repo-name>.worktrees/<slug>`. For example, a
+  primary checkout at `/home/deploy/matrix-os` uses
+  `/home/deploy/matrix-os.worktrees/<slug>`. Never reuse another agent's path.
 - Use a semantic branch and PR title. Do not prefix titles with agent/tool tags.
 - Stage only files in scope.
 - Do not merge unless explicitly asked.
@@ -62,10 +65,11 @@ coordinator-assigned worktree, branch, and PR. The repo-level ban on Agent-tool
 2. Create or enter the worktree.
    - Slug: concise task slug, e.g. `fix-canvas-terminal-clicks`.
    - Branch: `codex/<slug>` unless the requester named a branch.
-   - Path: an exact, validated path allowed by repository instructions. Use the
-     coordinator-assigned path when operating as a leaf agent.
+   - Path: the coordinator-assigned path for a leaf agent. Otherwise use the
+     canonical absolute sibling path above unless repository instructions
+     explicitly require another location.
    - Command shape:
-     `git worktree add -b codex/<slug> /absolute/path/to/worktree origin/main`
+     `git worktree add -b codex/<slug> /absolute/path/to/matrix-os.worktrees/<slug> origin/main`
 
 3. Implement.
    - Follow TDD where practical: add a failing focused regression before the
@@ -140,7 +144,7 @@ coordinator-assigned worktree, branch, and PR. The repo-level ban on Agent-tool
 ```sh
 git status --short --branch
 git worktree list
-git worktree add -b codex/<slug> /absolute/path/to/worktree origin/main
+git worktree add -b codex/<slug> /absolute/path/to/matrix-os.worktrees/<slug> origin/main
 bun run typecheck
 bun run check:patterns
 bun run test

--- a/.agents/skills/worktree-pr-monitor/SKILL.md
+++ b/.agents/skills/worktree-pr-monitor/SKILL.md
@@ -1,19 +1,17 @@
 ---
 name: worktree-pr-monitor
-description: Create or continue an isolated Matrix OS worktree PR, validate it, push it, monitor CI and GitHub review feedback, iterate until the latest trusted Greptile result is 5/5, then add ready-for-ci and wait for triggered CI to pass before pinging completion. Use when asked to run a worktree to PR to monitor workflow, get a PR to Greptile 5/5 plus CI pass, publish changes while keeping main clean, or monitor one worktree, branch, and PR exclusively assigned to a leaf agent.
+description: Create or continue an isolated Matrix OS worktree PR, validate it, push it, monitor CI and GitHub review feedback, iterate until the latest trusted Greptile result is 5/5, then add ready-for-ci and wait for triggered CI to pass before pinging completion. Use when asked to run a worktree to PR to monitor workflow, get a PR to Greptile 5/5 plus CI pass, or publish changes while keeping main clean.
 ---
 
 # Worktree PR Monitor
 
 Use this skill only when the requester explicitly asks for the manual git
-worktree -> PR -> monitor workflow or a coordinator assigns that workflow to a
-leaf agent. It keeps `/home/deploy/matrix-os` on `main` while implementation
-happens in `/home/deploy/matrix-os.worktrees/<slug>`.
+worktree -> PR -> monitor workflow. It keeps `/home/deploy/matrix-os` on `main`
+while implementation happens in `/home/deploy/matrix-os.worktrees/<slug>`.
 
-Do not use this skill to coordinate Swarm or multi-agent runs. A leaf agent may
-use it only when a coordinator gives it exclusive ownership of one worktree,
-branch, and PR. The repo-level Swarm ban on `isolation: "worktree"` still
-applies; this workflow uses a persistent manual git worktree.
+This skill does not coordinate Swarm or multi-agent runs. The repo-level Swarm
+ban on `isolation: "worktree"` still applies; this workflow is a user-requested
+manual git worktree flow for isolated PR publication.
 
 ## Preconditions
 
@@ -21,18 +19,15 @@ applies; this workflow uses a persistent manual git worktree.
 - The current repository is `HamedMP/matrix-os`.
 - The repository has a label exactly named `ready-for-ci`; if it is missing,
   stop and report the blocker instead of creating the label silently.
-- The requester or coordinating workflow wants a PR in a worktree, not only a
-  local patch.
-- The requester explicitly asked for a worktree or a coordinator explicitly
-  assigned this leaf workflow.
+- The requester wants a PR in a worktree, not only a local patch.
+- The requester explicitly asked for a worktree or invoked this workflow.
 
 ## Rules
 
-- If neither the requester nor a coordinator explicitly assigned a worktree,
-  follow the current branch workflow instead.
+- If the requester did not explicitly ask for a worktree, follow the current
+  branch workflow instead.
 - Keep `/home/deploy/matrix-os` on `main`.
-- Put feature work in `/home/deploy/matrix-os.worktrees/<slug>`. A leaf agent
-  must use its coordinator-assigned worktree path instead.
+- Put feature work in `/home/deploy/matrix-os.worktrees/<slug>`.
 - Use a semantic branch and PR title. Do not prefix titles with agent/tool tags.
 - Stage only files in scope.
 - Do not merge unless explicitly asked.
@@ -61,8 +56,7 @@ applies; this workflow uses a persistent manual git worktree.
 2. Create or enter the worktree.
    - Slug: concise task slug, e.g. `fix-canvas-terminal-clicks`.
    - Branch: `codex/<slug>` unless the requester named a branch.
-   - Path: `/home/deploy/matrix-os.worktrees/<slug>`, or the exact path assigned
-     by the coordinator for a leaf agent.
+   - Path: `/home/deploy/matrix-os.worktrees/<slug>`.
    - Command shape:
      `git worktree add -b codex/<slug> /home/deploy/matrix-os.worktrees/<slug> origin/main`
 

--- a/.agents/skills/worktree-pr-monitor/SKILL.md
+++ b/.agents/skills/worktree-pr-monitor/SKILL.md
@@ -1,17 +1,20 @@
 ---
 name: worktree-pr-monitor
-description: Create or continue an isolated Matrix OS worktree PR, validate it, push it, monitor CI and GitHub review feedback, iterate until the latest trusted Greptile result is 5/5, then add ready-for-ci and wait for triggered CI to pass before pinging completion. Use when asked to run a worktree to PR to monitor workflow, get a PR to Greptile 5/5 plus CI pass, or publish changes while keeping main clean.
+description: Create or continue one isolated Matrix OS manual-worktree PR, validate it, mark a completed draft ready, resolve current-head review feedback through Greptile 5/5, then add ready-for-ci and wait for triggered CI. Use when asked for the worktree-to-PR monitoring workflow, including when a coordinator assigns a leaf agent exclusive ownership of one worktree, branch, and PR.
 ---
 
 # Worktree PR Monitor
 
-Use this skill only when the requester explicitly asks for the manual git
-worktree -> PR -> monitor workflow. It keeps `/home/deploy/matrix-os` on `main`
-while implementation happens in `/home/deploy/matrix-os.worktrees/<slug>`.
+Use this skill only when the requester explicitly asks for the manual Git
+worktree -> PR -> monitor workflow or when a coordinator explicitly assigns
+that workflow to a leaf agent. Keep the primary checkout unchanged while
+implementation happens in a persistent manual worktree at the path required by
+the repository instructions.
 
-Do not use this skill for Swarm or multi-agent runs. The repo-level Swarm ban on
-`isolation: "worktree"` still applies; this workflow is a user-requested manual
-git worktree flow for isolated PR publication.
+Do not use this skill to coordinate a Swarm or share a worktree between agents.
+A leaf agent in a multi-agent run may use it only when it exclusively owns one
+coordinator-assigned worktree, branch, and PR. The repo-level ban on Agent-tool
+`isolation: "worktree"` still applies; use a persistent manual Git worktree.
 
 ## Preconditions
 
@@ -19,20 +22,23 @@ git worktree flow for isolated PR publication.
 - The current repository is `HamedMP/matrix-os`.
 - The repository has a label exactly named `ready-for-ci`; if it is missing,
   stop and report the blocker instead of creating the label silently.
-- The requester wants a PR in a worktree, not only a local patch.
-- The requester explicitly asked for a worktree or invoked this workflow.
+- The requester or coordinating workflow wants a PR in a worktree, not only a
+  local patch.
+- The requester explicitly asked for a worktree or a coordinator explicitly
+  assigned this leaf workflow.
 
 ## Rules
 
-- If the requester did not explicitly ask for a worktree, follow the current
-  branch workflow instead.
-- Keep `/home/deploy/matrix-os` on `main`.
-- Put feature work in `/home/deploy/matrix-os.worktrees/<slug>`.
+- If neither the requester nor a coordinator explicitly assigned a worktree,
+  follow the current branch workflow instead.
+- Keep the primary checkout on its existing branch and preserve unrelated work.
+- Resolve the manual-worktree location from repository instructions; do not
+  assume a fixed home directory or reuse another agent's path.
 - Use a semantic branch and PR title. Do not prefix titles with agent/tool tags.
 - Stage only files in scope.
 - Do not merge unless explicitly asked.
 - If Greptile has reviewed the PR, the loop is complete only when the latest
-  trusted Greptile result is `5/5`.
+  trusted Greptile result is `5/5` for the current PR head.
 - Add the `ready-for-ci` label only after the latest trusted Greptile result is
   `5/5`; this label triggers the broader PR CI workflows.
 - If the repository label `ready-for-ci` is missing, report the blocker instead
@@ -56,9 +62,10 @@ git worktree flow for isolated PR publication.
 2. Create or enter the worktree.
    - Slug: concise task slug, e.g. `fix-canvas-terminal-clicks`.
    - Branch: `codex/<slug>` unless the requester named a branch.
-   - Path: `/home/deploy/matrix-os.worktrees/<slug>`.
+   - Path: an exact, validated path allowed by repository instructions. Use the
+     coordinator-assigned path when operating as a leaf agent.
    - Command shape:
-     `git worktree add -b codex/<slug> /home/deploy/matrix-os.worktrees/<slug> origin/main`
+     `git worktree add -b codex/<slug> /absolute/path/to/worktree origin/main`
 
 3. Implement.
    - Follow TDD where practical: add a failing focused regression before the
@@ -86,16 +93,23 @@ git worktree flow for isolated PR publication.
      - `Review/Monitoring`
      - `Invariants` when backend code changed
 
-7. Monitor review feedback until Greptile is complete.
+7. Mark completed drafts ready for review.
+   - Keep an incomplete PR in draft state.
+   - After implementation and applicable local validation finish, inspect the
+     PR state and run `gh pr ready` if it is still a draft.
+   - Marking the PR ready may trigger baseline CI. Monitor those checks, but do
+     not treat them as a substitute for the later `ready-for-ci` gate.
+
+8. Monitor review feedback until Greptile is complete.
    - Use `gh pr checks --watch` or equivalent GitHub API status reads for
      already-running checks.
    - Use thread-aware review inspection for unresolved GitHub review threads.
    - Inspect issue comments for Codex reviews.
-   - Inspect Greptile feedback and rating. If the latest trusted Greptile
-     result is below `5/5`, implement fixes, rerun relevant checks, commit,
-     push, and continue monitoring.
+   - Inspect Greptile feedback and rating for the current PR head. If the latest
+     trusted result is stale or below `5/5`, implement fixes, rerun relevant
+     checks, commit, push, and continue monitoring.
 
-8. Trigger and monitor label-gated CI.
+9. Trigger and monitor label-gated CI.
    - Before labeling, verify that the repository label exists:
      `gh label list --search ready-for-ci --json name`. If the exact
      `ready-for-ci` label is missing, stop and report the blocker.
@@ -110,7 +124,7 @@ git worktree flow for isolated PR publication.
      Do not re-add `ready-for-ci` until Greptile is again `5/5` on the latest
      commit.
 
-9. Ping completion.
+10. Ping completion.
    - Reply with:
      - PR URL
      - branch and worktree path
@@ -126,12 +140,13 @@ git worktree flow for isolated PR publication.
 ```sh
 git status --short --branch
 git worktree list
-git worktree add -b codex/<slug> /home/deploy/matrix-os.worktrees/<slug> origin/main
+git worktree add -b codex/<slug> /absolute/path/to/worktree origin/main
 bun run typecheck
 bun run check:patterns
 bun run test
 git push -u origin HEAD
 gh pr view --json number,url,title,state,headRefName,baseRefName
+gh pr ready
 gh label list --search ready-for-ci --json name
 gh pr edit --add-label ready-for-ci
 gh pr edit --remove-label ready-for-ci

--- a/.agents/skills/worktree-pr-monitor/SKILL.md
+++ b/.agents/skills/worktree-pr-monitor/SKILL.md
@@ -1,20 +1,19 @@
 ---
 name: worktree-pr-monitor
-description: Create or continue one isolated Matrix OS manual-worktree PR, validate it, mark a completed draft ready, resolve current-head review feedback through Greptile 5/5, then add ready-for-ci and wait for triggered CI. Use when asked for the worktree-to-PR monitoring workflow, including when a coordinator assigns a leaf agent exclusive ownership of one worktree, branch, and PR.
+description: Create or continue an isolated Matrix OS worktree PR, validate it, push it, monitor CI and GitHub review feedback, iterate until the latest trusted Greptile result is 5/5, then add ready-for-ci and wait for triggered CI to pass before pinging completion. Use when asked to run a worktree to PR to monitor workflow, get a PR to Greptile 5/5 plus CI pass, publish changes while keeping main clean, or monitor one worktree, branch, and PR exclusively assigned to a leaf agent.
 ---
 
 # Worktree PR Monitor
 
-Use this skill only when the requester explicitly asks for the manual Git
-worktree -> PR -> monitor workflow or when a coordinator explicitly assigns
-that workflow to a leaf agent. Keep the primary checkout unchanged while
-implementation happens in a persistent manual worktree at the path required by
-the repository instructions.
+Use this skill only when the requester explicitly asks for the manual git
+worktree -> PR -> monitor workflow or a coordinator assigns that workflow to a
+leaf agent. It keeps `/home/deploy/matrix-os` on `main` while implementation
+happens in `/home/deploy/matrix-os.worktrees/<slug>`.
 
-Do not use this skill to coordinate a Swarm or share a worktree between agents.
-A leaf agent in a multi-agent run may use it only when it exclusively owns one
-coordinator-assigned worktree, branch, and PR. The repo-level ban on Agent-tool
-`isolation: "worktree"` still applies; use a persistent manual Git worktree.
+Do not use this skill to coordinate Swarm or multi-agent runs. A leaf agent may
+use it only when a coordinator gives it exclusive ownership of one worktree,
+branch, and PR. The repo-level Swarm ban on `isolation: "worktree"` still
+applies; this workflow uses a persistent manual git worktree.
 
 ## Preconditions
 
@@ -31,17 +30,14 @@ coordinator-assigned worktree, branch, and PR. The repo-level ban on Agent-tool
 
 - If neither the requester nor a coordinator explicitly assigned a worktree,
   follow the current branch workflow instead.
-- Keep the primary checkout on its existing branch and preserve unrelated work.
-- Resolve the primary checkout's absolute path and, unless repository
-  instructions specify another location, use the canonical sibling path
-  `<primary-checkout-parent>/<repo-name>.worktrees/<slug>`. For example, a
-  primary checkout at `/home/deploy/matrix-os` uses
-  `/home/deploy/matrix-os.worktrees/<slug>`. Never reuse another agent's path.
+- Keep `/home/deploy/matrix-os` on `main`.
+- Put feature work in `/home/deploy/matrix-os.worktrees/<slug>`. A leaf agent
+  must use its coordinator-assigned worktree path instead.
 - Use a semantic branch and PR title. Do not prefix titles with agent/tool tags.
 - Stage only files in scope.
 - Do not merge unless explicitly asked.
 - If Greptile has reviewed the PR, the loop is complete only when the latest
-  trusted Greptile result is `5/5` for the current PR head.
+  trusted Greptile result is `5/5`.
 - Add the `ready-for-ci` label only after the latest trusted Greptile result is
   `5/5`; this label triggers the broader PR CI workflows.
 - If the repository label `ready-for-ci` is missing, report the blocker instead
@@ -65,11 +61,10 @@ coordinator-assigned worktree, branch, and PR. The repo-level ban on Agent-tool
 2. Create or enter the worktree.
    - Slug: concise task slug, e.g. `fix-canvas-terminal-clicks`.
    - Branch: `codex/<slug>` unless the requester named a branch.
-   - Path: the coordinator-assigned path for a leaf agent. Otherwise use the
-     canonical absolute sibling path above unless repository instructions
-     explicitly require another location.
+   - Path: `/home/deploy/matrix-os.worktrees/<slug>`, or the exact path assigned
+     by the coordinator for a leaf agent.
    - Command shape:
-     `git worktree add -b codex/<slug> /absolute/path/to/matrix-os.worktrees/<slug> origin/main`
+     `git worktree add -b codex/<slug> /home/deploy/matrix-os.worktrees/<slug> origin/main`
 
 3. Implement.
    - Follow TDD where practical: add a failing focused regression before the
@@ -97,23 +92,16 @@ coordinator-assigned worktree, branch, and PR. The repo-level ban on Agent-tool
      - `Review/Monitoring`
      - `Invariants` when backend code changed
 
-7. Mark completed drafts ready for review.
-   - Keep an incomplete PR in draft state.
-   - After implementation and applicable local validation finish, inspect the
-     PR state and run `gh pr ready` if it is still a draft.
-   - Marking the PR ready may trigger baseline CI. Monitor those checks, but do
-     not treat them as a substitute for the later `ready-for-ci` gate.
-
-8. Monitor review feedback until Greptile is complete.
+7. Monitor review feedback until Greptile is complete.
    - Use `gh pr checks --watch` or equivalent GitHub API status reads for
      already-running checks.
    - Use thread-aware review inspection for unresolved GitHub review threads.
    - Inspect issue comments for Codex reviews.
-   - Inspect Greptile feedback and rating for the current PR head. If the latest
-     trusted result is stale or below `5/5`, implement fixes, rerun relevant
-     checks, commit, push, and continue monitoring.
+   - Inspect Greptile feedback and rating. If the latest trusted Greptile
+     result is below `5/5`, implement fixes, rerun relevant checks, commit,
+     push, and continue monitoring.
 
-9. Trigger and monitor label-gated CI.
+8. Trigger and monitor label-gated CI.
    - Before labeling, verify that the repository label exists:
      `gh label list --search ready-for-ci --json name`. If the exact
      `ready-for-ci` label is missing, stop and report the blocker.
@@ -128,7 +116,7 @@ coordinator-assigned worktree, branch, and PR. The repo-level ban on Agent-tool
      Do not re-add `ready-for-ci` until Greptile is again `5/5` on the latest
      commit.
 
-10. Ping completion.
+9. Ping completion.
    - Reply with:
      - PR URL
      - branch and worktree path
@@ -144,13 +132,12 @@ coordinator-assigned worktree, branch, and PR. The repo-level ban on Agent-tool
 ```sh
 git status --short --branch
 git worktree list
-git worktree add -b codex/<slug> /absolute/path/to/matrix-os.worktrees/<slug> origin/main
+git worktree add -b codex/<slug> /home/deploy/matrix-os.worktrees/<slug> origin/main
 bun run typecheck
 bun run check:patterns
 bun run test
 git push -u origin HEAD
 gh pr view --json number,url,title,state,headRefName,baseRefName
-gh pr ready
 gh label list --search ready-for-ci --json name
 gh pr edit --add-label ready-for-ci
 gh pr edit --remove-label ready-for-ci


### PR DESCRIPTION
## Summary

- add a generic `orchestrate-problem-prs` skill that derives a dynamic number of independent workstreams from structured or unstructured reports
- enforce read-only root-cause investigation, cross-workstream reconciliation, draft-PR evidence and plan comments, and explicit implementation unlocks
- add reusable worker assignment, diagnosis, PR comment, and completion contracts
- allow `worktree-pr-monitor` to serve an exclusively assigned leaf agent while preserving the manual-worktree and `ready-for-ci` gates

## Tests

- `quick_validate.py .agents/skills/orchestrate-problem-prs` — passed
- `quick_validate.py .agents/skills/worktree-pr-monitor` — passed
- `./scripts/review/check-patterns.sh` — 0 violations; 5 existing repository-wide warning groups
- `git diff --check` — passed
- `bun run typecheck` — not run locally because Bun is unavailable in this environment
- `bun run test` — not run locally because Bun and this worktree's dependency install are unavailable; label-triggered CI is required before completion

## Review/Monitoring

- do not merge; this PR is for requester review
- Greptile must report 5/5 for the current head before applying `ready-for-ci`
- all label-triggered required CI must pass on the current head

## Invariants

- **Source of truth:** the supplied report and a coordinator-pinned base SHA define each investigation; worker conclusions cannot silently redefine the report
- **Worktree/critical-section scope:** every mutation is confined to one coordinator-assigned persistent manual worktree; worktrees are registered sequentially and never shared
- **Acceptable orphan states:** uncertain investigations remain read-only; incomplete fixes remain draft or blocked; the workflow never merges PRs
- **Auth source of truth:** authenticated GitHub CLI access is required for branches, PRs, comments, labels, checks, and review state
- **Deferred scope:** this adds agent workflow instructions only; it does not add runtime orchestration code or automatically consolidate overlapping PRs without requester approval
