### PR TITLE
chore(mobile): prepare Android store release

### DIFF
--- a/apps/mobile/__tests__/mobile-app-config.test.ts
+++ b/apps/mobile/__tests__/mobile-app-config.test.ts
@@ -1,17 +1,82 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
 type MobileAppConfig = {
   expo?: {
     orientation?: string;
+    android?: {
+      package?: string;
+    };
     ios?: {
       supportsTablet?: boolean;
     };
   };
 };
 
+type MobilePackageConfig = {
+  devDependencies?: Record<string, string>;
+};
+
+type MobileEasConfig = {
+  cli?: {
+    version?: string;
+    appVersionSource?: string;
+  };
+  build?: {
+    base?: {
+      node?: string;
+      pnpm?: string;
+    };
+    production?: {
+      autoIncrement?: boolean;
+      android?: {
+        buildType?: string;
+      };
+    };
+  };
+  submit?: {
+    production?: {
+      android?: {
+        track?: string;
+      };
+    };
+  };
+};
+
 const appConfig = require("../app.json") as MobileAppConfig;
+const packageConfig = require("../package.json") as MobilePackageConfig;
+const easConfig = JSON.parse(
+  readFileSync(join(__dirname, "../eas.json"), "utf8")
+    .split("\n")
+    .filter((line) => !line.trimStart().startsWith("//"))
+    .join("\n"),
+) as MobileEasConfig;
 
 describe("mobile native orientation configuration", () => {
   it("allows portrait and landscape on phones and tablets", () => {
     expect(appConfig.expo?.orientation).toBe("default");
     expect(appConfig.expo?.ios?.supportsTablet).toBe(true);
+  });
+});
+
+describe("mobile Android release configuration", () => {
+  it("declares the Expo config plugin dependency used by native plugins", () => {
+    expect(packageConfig.devDependencies?.["@expo/config-plugins"]).toBe("57.0.2");
+  });
+
+  it("builds a versioned Android App Bundle with the supported toolchain", () => {
+    expect(appConfig.expo?.android?.package).toBe("com.matrixos.mobile");
+    expect(easConfig.cli?.version).toBe(">= 20.1.0");
+    expect(easConfig.cli?.appVersionSource).toBe("remote");
+    expect(easConfig.build?.base).toEqual({
+      node: "24.14.0",
+      pnpm: "10.33.4",
+    });
+    expect(easConfig.build?.production?.autoIncrement).toBe(true);
+    expect(easConfig.build?.production?.android?.buildType).toBe("app-bundle");
+  });
+
+  it("defaults Android submissions to the internal Play track", () => {
+    expect(easConfig.submit?.production?.android?.track).toBe("internal");
   });
 });

--- a/apps/mobile/__tests__/mobile-app-config.test.ts
+++ b/apps/mobile/__tests__/mobile-app-config.test.ts
@@ -1,5 +1,6 @@
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
+import { parseConfigFileTextToJson } from "typescript";
 
 type MobileAppConfig = {
   expo?: {
@@ -45,12 +46,17 @@ type MobileEasConfig = {
 
 const appConfig = require("../app.json") as MobileAppConfig;
 const packageConfig = require("../package.json") as MobilePackageConfig;
-const easConfig = JSON.parse(
-  readFileSync(join(__dirname, "../eas.json"), "utf8")
-    .split("\n")
-    .filter((line) => !line.trimStart().startsWith("//"))
-    .join("\n"),
-) as MobileEasConfig;
+const easConfigPath = join(__dirname, "../eas.json");
+const parsedEasConfig = parseConfigFileTextToJson(
+  easConfigPath,
+  readFileSync(easConfigPath, "utf8"),
+);
+
+if (parsedEasConfig.error) {
+  throw parsedEasConfig.error;
+}
+
+const easConfig = parsedEasConfig.config as MobileEasConfig;
 
 describe("mobile native orientation configuration", () => {
   it("allows portrait and landscape on phones and tablets", () => {
@@ -61,6 +67,8 @@ describe("mobile native orientation configuration", () => {
 
 describe("mobile Android release configuration", () => {
   it("declares the Expo config plugin dependency used by native plugins", () => {
+    // Expo config plugins must stay aligned with SDK 57; upgrades should update
+    // this pin deliberately instead of accepting an arbitrary transitive version.
     expect(packageConfig.devDependencies?.["@expo/config-plugins"]).toBe("57.0.2");
   });
 

--- a/apps/mobile/app/agents/[threadId].tsx
+++ b/apps/mobile/app/agents/[threadId].tsx
@@ -964,6 +964,8 @@ function describeThreadEvent(event: AgentThreadEvent): { icon: keyof typeof Ioni
       return { icon: "sparkles-outline", title: "Thread created", detail: event.thread.title };
     case "thread.status":
       return { icon: "pulse-outline", title: "Status changed", detail: event.status.replace(/_/g, " ") };
+    case "user.message":
+      return { icon: "chatbubble-outline", title: "User message", detail: "Message sent" };
     case "assistant.text.delta":
       return { icon: "chatbubble-ellipses-outline", title: "Assistant update", detail: "Text update received" };
     case "assistant.text.completed":

--- a/apps/mobile/components/InputBar.tsx
+++ b/apps/mobile/components/InputBar.tsx
@@ -6,7 +6,7 @@ import {
   ActivityIndicator,
 } from "react-native";
 import { StyleSheet, useUnistyles } from "react-native-unistyles";
-import Animated, { useAnimatedStyle, useSharedValue, withSpring } from "react-native-reanimated";
+import Animated, { type SharedValue, useAnimatedStyle, useSharedValue, withSpring } from "react-native-reanimated";
 import { BlurView } from "expo-blur";
 import * as Haptics from "expo-haptics";
 import { Ionicons } from "@expo/vector-icons";
@@ -15,6 +15,11 @@ interface InputBarProps {
   onSend: (text: string) => void;
   busy: boolean;
   connected: boolean;
+}
+
+function animateSend(scale: SharedValue<number>): void {
+  scale.value = 0.7;
+  scale.value = withSpring(1, { damping: 12, stiffness: 320 });
 }
 
 export function InputBar({ onSend, busy, connected }: InputBarProps) {
@@ -29,8 +34,7 @@ export function InputBar({ onSend, busy, connected }: InputBarProps) {
     if (process.env.EXPO_OS === "ios") {
       Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
     }
-    sendScale.value = 0.7;
-    sendScale.value = withSpring(1, { damping: 12, stiffness: 320 });
+    animateSend(sendScale);
     onSend(trimmed);
     setText("");
   }, [text, connected, onSend, sendScale]);

--- a/apps/mobile/eas.json
+++ b/apps/mobile/eas.json
@@ -1,12 +1,12 @@
 {
   "cli": {
-    "version": ">= 13.0.0",
+    "version": ">= 20.1.0",
     "appVersionSource": "remote"
   },
   "build": {
     "base": {
-      "node": "20.19.4",
-      "pnpm": "10.6.2"
+      "node": "24.14.0",
+      "pnpm": "10.33.4"
     },
     "development": {
       "extends": "base",
@@ -34,6 +34,9 @@
     "production": {
       "extends": "base",
       "autoIncrement": true,
+      "android": {
+        "buildType": "app-bundle"
+      },
       // EXPO_PUBLIC_POSTHOG_API_KEY is intentionally NOT set here — provide it as
       // an EAS secret/env var so the key is never committed. When it is absent the
       // app runs analytics-free (see apps/mobile/lib/analytics.ts).
@@ -45,6 +48,9 @@
   },
   "submit": {
     "production": {
+      "android": {
+        "track": "internal"
+      },
       "ios": {
         // Apple ID auth. ascAppId + appleTeamId are intentionally omitted so EAS
         // auto-resolves them (finds/creates the ASC app by bundleIdentifier and

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -73,6 +73,7 @@
   },
   "devDependencies": {
     "@babel/core": "^7.25.0",
+    "@expo/config-plugins": "57.0.2",
     "@expo/ngrok": "^4.1.3",
     "@xterm/addon-fit": "^0.11.0",
     "@xterm/xterm": "^6.0.0",

--- a/docs/dev/mobile-shell.md
+++ b/docs/dev/mobile-shell.md
@@ -84,6 +84,40 @@ terminals the QR may not render; use the URL above, or generate a QR for the
 deep link and scan it from the dev-client launcher. If the phone cannot reach
 the Mac on LAN, retry Metro with `--host tunnel`.
 
+## Android Store Release
+
+Use a clean manual worktree based on the latest `origin/main`. From the mobile
+app directory, validate the production config and create the Play Store bundle:
+
+```bash
+cd apps/mobile
+eas project:info
+eas build --platform android --profile production
+```
+
+The production profile emits an Android App Bundle (`.aab`), increments the
+remote Android version code, and uses package name `com.matrixos.mobile`.
+Download the finished artifact from the EAS build page.
+
+Google Play requires the first bundle for a new app to be uploaded manually in
+Play Console. Create the app with the exact package name, enable Play App
+Signing, and upload the `.aab` to Internal testing before configuring API-based
+submissions. Add testers and complete the store listing, privacy policy, data
+safety, content rating, target audience, ads, and distribution declarations in
+Play Console.
+
+After the first manual upload, create a least-privilege Google Play service
+account with permission to release to testing tracks and attach its JSON key to
+the EAS project through `eas credentials`. Never commit the key. Subsequent
+internal-track submissions use:
+
+```bash
+eas submit --platform android --profile production --latest
+```
+
+Promote a verified internal release through Play Console rather than changing
+the default automated submission track directly to production.
+
 ### Clerk Redirects
 
 Google SSO depends on Clerk allowing the mobile redirect URI used by

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -225,6 +225,9 @@ importers:
       '@babel/core':
         specifier: ^7.25.0
         version: 7.29.0
+      '@expo/config-plugins':
+        specifier: 57.0.2
+        version: 57.0.2(typescript@6.0.3)
       '@expo/ngrok':
         specifier: ^4.1.3
         version: 4.1.3

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -28,6 +28,14 @@ minimumReleaseAgeExclude:
 
 shamefullyHoist: true
 
+# Expo config plugins are loaded from the plugin package's own module scope.
+# Declare the package's implicit dependency so local global-store worktrees can
+# evaluate app.json before EAS uploads the project.
+packageExtensions:
+  "react-native-edge-to-edge@1.8.1":
+    dependencies:
+      "@expo/config-plugins": 57.0.2
+
 # Tests at the workspace root (tests/integrations/*) import packages that
 # are direct dependencies of workspace sub-packages (e.g. hono, @pipedream/sdk,
 # kysely-pglite from packages/gateway). pnpm doesn't hoist workspace-package


### PR DESCRIPTION
## Summary

- Configure EAS production Android builds as signed Android App Bundles with remote versioning and automatic version-code increments.
- Prepare later Google Play internal-track submissions while preserving the required manual first upload.
- Align the mobile EAS environment with the repository's Node and pnpm versions and make the Expo config-plugin dependency explicit.
- Fix two existing mobile release gates found by TypeScript and React Compiler lint, and document the Android release runbook.

## Tests

- `pnpm install --frozen-lockfile --config.enableGlobalVirtualStore=false`
- `pnpm --dir apps/mobile exec jest --runInBand` (54 suites, 557 tests)
- `pnpm --dir apps/mobile exec tsc --noEmit`
- `pnpm --dir apps/mobile run lint`
- `bun run typecheck`
- `bun run check:patterns` (0 violations; 5 pre-existing warnings)
- `git diff --check`
- `bun run test`: 8,794 passed, 14 failed, 1 skipped. The 14 failures are isolated to three Codex control-socket suites and report macOS UNIX-socket path-length `listen EINVAL` errors from this long worktree/temp path; no mobile test failed.
- Previously failing native-database cases were rerun after rebuilding the fresh worktree's `better-sqlite3` binding: 9 files, 138 tests passed.

## Invariants

### Source of truth

- `apps/mobile/app.json` owns the Android package and public application metadata; `apps/mobile/eas.json` owns EAS build and submission profiles.
- EAS remote app-version state owns Android `versionCode`; production builds auto-increment it.

### Lock/transaction scope

- No database, lock, or transaction behavior changes in this PR.
- EAS and Google Play network operations occur only in explicit release commands, outside application runtime requests.

### Acceptable orphan states

- A failed EAS build may leave an unpublished build record or bundle artifact, but creates no customer runtime or Google Play release.
- The first AAB remains unpublished until an operator manually uploads it to Google Play internal testing. Later submissions also stay on the internal track until deliberately promoted.

### Auth source of truth

- Expo account membership and EAS-managed Android credentials authorize builds.
- Google Play Console access authorizes the first manual upload; later EAS Submit runs require a Google service-account key configured in EAS credentials. No credential is committed to Git.

### Deferred scope

- Creating/completing the Google Play Console listing, declarations, first manual AAB upload, service-account setup, review submission, and production-track promotion remain operator actions.
- Real-device validation happens from Google Play internal testing before any production rollout.

## Review range

Review `origin/main...1253f538a0a751e7a8ff86fa290aecb601d42242`.
