### PR TITLE
feat(platform): add recruiting ATS backend

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -42,6 +42,14 @@ PIPEDREAM_WEBHOOK_SECRET=
 # Platform DB (can reuse DATABASE_URL or separate)
 PLATFORM_DATABASE_URL=
 
+# Recruiting ATS (platform PostgreSQL + matrix-os-site server routes)
+# Use distinct high-entropy values; never expose these as NEXT_PUBLIC_*.
+ATS_INGEST_SECRET=
+ATS_ADMIN_SECRET=
+# External scheduling page, for example https://cal.com/matrix-os/interview
+ATS_BOOKING_BASE_URL=
+MATRIX_PUBLIC_SITE_URL=https://matrix-os.com
+
 # Gateway auth token (auto-generated in production)
 MATRIX_AUTH_TOKEN=
 

--- a/.env.example
+++ b/.env.example
@@ -44,6 +44,8 @@ PLATFORM_DATABASE_URL=
 
 # Recruiting ATS (platform PostgreSQL + matrix-os-site server routes)
 # Use distinct high-entropy values; never expose these as NEXT_PUBLIC_*.
+# Dedicated Neon/PostgreSQL database. Do not point this at PLATFORM_DATABASE_URL.
+ATS_DATABASE_URL=
 ATS_INGEST_SECRET=
 ATS_ADMIN_SECRET=
 # External scheduling page, for example https://cal.com/matrix-os/interview

--- a/packages/platform/src/ats-db.ts
+++ b/packages/platform/src/ats-db.ts
@@ -1,0 +1,68 @@
+import { Kysely, PostgresDialect, type Transaction } from 'kysely';
+import pg from 'pg';
+import { migrateAts, type AtsDatabaseTables } from './ats-schema.js';
+
+type AtsExecutor = Kysely<AtsDatabaseTables> | Transaction<AtsDatabaseTables>;
+
+export interface AtsDB {
+  kysely: Kysely<AtsDatabaseTables>;
+  executor: AtsExecutor;
+  ready: Promise<void>;
+  transaction<T>(fn: (trx: AtsDB) => Promise<T>): Promise<T>;
+  destroy(): Promise<void>;
+}
+
+export class AtsDatabaseConfigError extends Error {
+  constructor() {
+    super('ATS_DATABASE_URL is required when recruiting ATS secrets are configured');
+    this.name = 'AtsDatabaseConfigError';
+  }
+}
+
+export function resolveAtsDatabaseUrl(env: NodeJS.ProcessEnv): string | undefined {
+  const databaseUrl = env.ATS_DATABASE_URL?.trim() || undefined;
+  const enabled = Boolean(env.ATS_INGEST_SECRET?.trim() || env.ATS_ADMIN_SECRET?.trim());
+  if (enabled && !databaseUrl) throw new AtsDatabaseConfigError();
+  return databaseUrl;
+}
+
+function wrapAtsDb(
+  kysely: Kysely<AtsDatabaseTables>,
+  executor: AtsExecutor,
+  ready: Promise<void>,
+  destroyFn: () => Promise<void>,
+): AtsDB {
+  return {
+    kysely,
+    executor,
+    ready,
+    async transaction(fn) {
+      await ready;
+      return kysely.transaction().execute((trx) =>
+        fn(wrapAtsDb(kysely, trx, Promise.resolve(), destroyFn)),
+      );
+    },
+    destroy: destroyFn,
+  };
+}
+
+export function createAtsDb(opts: string | { dialect: unknown }): AtsDB {
+  if (typeof opts === 'string' && !opts.trim()) throw new AtsDatabaseConfigError();
+  let pool: pg.Pool | null = null;
+  const kysely = typeof opts === 'string'
+    ? (() => {
+        pool = new pg.Pool({ connectionString: opts, max: 5 });
+        pool.on('error', (err) => console.error('[ats-db] Idle pool client error:', err.message));
+        return new Kysely<AtsDatabaseTables>({ dialect: new PostgresDialect({ pool }) });
+      })()
+    : new Kysely<AtsDatabaseTables>({ dialect: opts.dialect as never });
+  const ready = migrateAts(kysely);
+  return wrapAtsDb(kysely, kysely, ready, async () => {
+    await kysely.destroy();
+    try {
+      await pool?.end();
+    } catch (err: unknown) {
+      if (!(err instanceof Error && err.message === 'Called end on pool more than once')) throw err;
+    }
+  });
+}

--- a/packages/platform/src/ats-mappers.ts
+++ b/packages/platform/src/ats-mappers.ts
@@ -1,0 +1,80 @@
+import type { Selectable } from 'kysely';
+import type {
+  AtsApplicationEventsTable,
+  AtsApplicationsTable,
+  AtsInterviewsTable,
+  AtsNotesTable,
+  AtsScorecardsTable,
+  AtsTasksTable,
+} from './ats-schema.js';
+import type {
+  AtsApplicationSummary,
+  AtsDisposition,
+  AtsEvent,
+  AtsInterview,
+  AtsNote,
+  AtsScorecard,
+  AtsStage,
+  AtsTask,
+} from './ats-types.js';
+
+export const applicationColumns = [
+  'id', 'submission_key', 'role_slug', 'candidate_name', 'candidate_email',
+  'phone', 'location', 'availability', 'links', 'answers', 'source', 'stage',
+  'disposition', 'revision', 'owner_id', 'tags', 'next_action_at',
+  'disposition_reason', 'consent_at', 'retention_until', 'resume_filename',
+  'resume_content_type', 'created_at', 'updated_at',
+] as const;
+
+function parseJson<T>(raw: string): T {
+  return JSON.parse(raw) as T;
+}
+
+export function mapApplication(row: Omit<Selectable<AtsApplicationsTable>, 'resume_bytes' | 'deleted_at'>): AtsApplicationSummary {
+  return {
+    id: row.id,
+    submissionKey: row.submission_key,
+    roleSlug: row.role_slug,
+    candidateName: row.candidate_name,
+    candidateEmail: row.candidate_email,
+    phone: row.phone,
+    location: row.location,
+    availability: row.availability,
+    links: parseJson<Record<string, string>>(row.links),
+    answers: parseJson<Array<{ prompt: string; answer: string }>>(row.answers),
+    source: row.source,
+    stage: row.stage as AtsStage,
+    disposition: row.disposition as AtsDisposition,
+    revision: row.revision,
+    ownerId: row.owner_id,
+    tags: parseJson<string[]>(row.tags),
+    nextActionAt: row.next_action_at,
+    dispositionReason: row.disposition_reason,
+    consentAt: row.consent_at,
+    retentionUntil: row.retention_until,
+    resumeFilename: row.resume_filename,
+    resumeContentType: row.resume_content_type,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  };
+}
+
+export function mapEvent(row: Selectable<AtsApplicationEventsTable>): AtsEvent {
+  return { id: row.id, applicationId: row.application_id, eventType: row.event_type, actorId: row.actor_id, fromStage: row.from_stage, toStage: row.to_stage, detail: parseJson<Record<string, unknown>>(row.detail), createdAt: row.created_at };
+}
+
+export function mapNote(row: Selectable<AtsNotesTable>): AtsNote {
+  return { id: row.id, applicationId: row.application_id, authorId: row.author_id, body: row.body, createdAt: row.created_at, updatedAt: row.updated_at };
+}
+
+export function mapScorecard(row: Selectable<AtsScorecardsTable>): AtsScorecard {
+  return { id: row.id, applicationId: row.application_id, interviewerId: row.interviewer_id, interviewType: row.interview_type, recommendation: row.recommendation, ratings: parseJson<Record<string, number>>(row.ratings), strengths: row.strengths, concerns: row.concerns, createdAt: row.created_at, updatedAt: row.updated_at };
+}
+
+export function mapInterview(row: Selectable<AtsInterviewsTable>): AtsInterview {
+  return { id: row.id, applicationId: row.application_id, interviewType: row.interview_type, status: row.status, interviewerIds: parseJson<string[]>(row.interviewer_ids), bookingUrl: row.booking_url, scheduledStart: row.scheduled_start, scheduledEnd: row.scheduled_end, timezone: row.timezone, meetingLocation: row.meeting_location, createdAt: row.created_at, updatedAt: row.updated_at };
+}
+
+export function mapTask(row: Selectable<AtsTasksTable>): AtsTask {
+  return { id: row.id, applicationId: row.application_id, title: row.title, assigneeId: row.assignee_id, dueAt: row.due_at, status: row.status, completedAt: row.completed_at, createdAt: row.created_at, updatedAt: row.updated_at };
+}

--- a/packages/platform/src/ats-repository.ts
+++ b/packages/platform/src/ats-repository.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from 'node:crypto';
-import type { PlatformDB } from './db.js';
+import type { AtsDB } from './ats-db.js';
 import {
   applicationColumns,
   mapApplication,
@@ -36,7 +36,7 @@ export class AtsApplicationNotFoundError extends Error {
 }
 
 async function insertEvent(
-  db: PlatformDB,
+  db: AtsDB,
   input: {
     applicationId: string;
     eventType: string;
@@ -60,7 +60,7 @@ async function insertEvent(
 }
 
 export async function createAtsApplication(
-  db: PlatformDB,
+  db: AtsDB,
   input: {
     submissionKey: string;
     roleSlug: string;
@@ -132,7 +132,7 @@ export async function createAtsApplication(
 }
 
 export async function listAtsApplications(
-  db: PlatformDB,
+  db: AtsDB,
   filters: { roleSlug?: string; stage?: AtsStage; disposition?: AtsDisposition; search?: string },
 ): Promise<AtsApplicationSummary[]> {
   await db.ready;
@@ -152,7 +152,7 @@ export async function listAtsApplications(
   return (await query.orderBy('updated_at', 'desc').limit(200).execute()).map(mapApplication);
 }
 
-export async function getAtsApplication(db: PlatformDB, id: string): Promise<AtsApplicationDetail | undefined> {
+export async function getAtsApplication(db: AtsDB, id: string): Promise<AtsApplicationDetail | undefined> {
   await db.ready;
   const application = await db.executor.selectFrom('ats_applications')
     .select(applicationColumns)
@@ -178,7 +178,7 @@ export async function getAtsApplication(db: PlatformDB, id: string): Promise<Ats
 }
 
 export async function getAtsApplicationResume(
-  db: PlatformDB,
+  db: AtsDB,
   id: string,
 ): Promise<{ filename: string; contentType: string; bytes: Uint8Array } | undefined> {
   await db.ready;
@@ -195,7 +195,7 @@ export async function getAtsApplicationResume(
 }
 
 export async function transitionAtsApplication(
-  db: PlatformDB,
+  db: AtsDB,
   input: {
     applicationId: string;
     baseRevision: number;
@@ -240,7 +240,7 @@ export async function transitionAtsApplication(
 }
 
 export async function updateAtsApplicationMetadata(
-  db: PlatformDB,
+  db: AtsDB,
   input: {
     applicationId: string;
     baseRevision: number;
@@ -276,7 +276,7 @@ export async function updateAtsApplicationMetadata(
   });
 }
 
-export async function addAtsNote(db: PlatformDB, input: {
+export async function addAtsNote(db: AtsDB, input: {
   applicationId: string; authorId: string; body: string; at: string;
 }): Promise<AtsNote> {
   await db.ready;
@@ -290,7 +290,7 @@ export async function addAtsNote(db: PlatformDB, input: {
   });
 }
 
-export async function upsertAtsScorecard(db: PlatformDB, input: {
+export async function upsertAtsScorecard(db: AtsDB, input: {
   applicationId: string; interviewerId: string; interviewType: string;
   recommendation: string; ratings: Record<string, number>; strengths: string;
   concerns: string | null; at: string;
@@ -315,7 +315,7 @@ export async function upsertAtsScorecard(db: PlatformDB, input: {
   });
 }
 
-export async function createAtsInterview(db: PlatformDB, input: {
+export async function createAtsInterview(db: AtsDB, input: {
   applicationId: string; interviewType: string; interviewerIds: string[];
   bookingTokenHash: string; bookingUrl: string; actorId: string; at: string;
 }): Promise<AtsInterview> {
@@ -335,7 +335,7 @@ export async function createAtsInterview(db: PlatformDB, input: {
 }
 
 export async function resolveAtsBooking(
-  db: PlatformDB,
+  db: AtsDB,
   bookingTokenHash: string,
   at: string,
 ): Promise<string | undefined> {
@@ -367,7 +367,7 @@ export async function resolveAtsBooking(
   });
 }
 
-export async function createAtsTask(db: PlatformDB, input: {
+export async function createAtsTask(db: AtsDB, input: {
   applicationId: string; title: string; assigneeId: string | null;
   dueAt: string | null; actorId: string; at: string;
 }): Promise<AtsTask> {
@@ -383,7 +383,7 @@ export async function createAtsTask(db: PlatformDB, input: {
   });
 }
 
-export async function completeAtsTask(db: PlatformDB, input: {
+export async function completeAtsTask(db: AtsDB, input: {
   applicationId: string; taskId: string; actorId: string; at: string;
 }): Promise<AtsTask> {
   await db.ready;

--- a/packages/platform/src/ats-repository.ts
+++ b/packages/platform/src/ats-repository.ts
@@ -1,0 +1,401 @@
+import { randomUUID } from 'node:crypto';
+import type { PlatformDB } from './db.js';
+import {
+  applicationColumns,
+  mapApplication,
+  mapEvent,
+  mapInterview,
+  mapNote,
+  mapScorecard,
+  mapTask,
+} from './ats-mappers.js';
+import type {
+  AtsApplicationDetail,
+  AtsApplicationSummary,
+  AtsDisposition,
+  AtsEvent,
+  AtsInterview,
+  AtsNote,
+  AtsScorecard,
+  AtsStage,
+  AtsTask,
+} from './ats-types.js';
+
+export class AtsRevisionConflictError extends Error {
+  constructor() {
+    super('Application was updated by another reviewer');
+    this.name = 'AtsRevisionConflictError';
+  }
+}
+
+export class AtsApplicationNotFoundError extends Error {
+  constructor() {
+    super('Application not found');
+    this.name = 'AtsApplicationNotFoundError';
+  }
+}
+
+async function insertEvent(
+  db: PlatformDB,
+  input: {
+    applicationId: string;
+    eventType: string;
+    actorId?: string | null;
+    fromStage?: string | null;
+    toStage?: string | null;
+    detail?: Record<string, unknown>;
+    at: string;
+  },
+): Promise<void> {
+  await db.executor.insertInto('ats_application_events').values({
+    id: randomUUID(),
+    application_id: input.applicationId,
+    event_type: input.eventType,
+    actor_id: input.actorId ?? null,
+    from_stage: input.fromStage ?? null,
+    to_stage: input.toStage ?? null,
+    detail: JSON.stringify(input.detail ?? {}),
+    created_at: input.at,
+  }).execute();
+}
+
+export async function createAtsApplication(
+  db: PlatformDB,
+  input: {
+    submissionKey: string;
+    roleSlug: string;
+    candidateName: string;
+    candidateEmail: string;
+    phone: string | null;
+    location: string;
+    availability: string;
+    links: Record<string, string>;
+    answers: Array<{ prompt: string; answer: string }>;
+    source: string;
+    consentAt: string;
+    retentionUntil: string;
+    resume: { filename: string; contentType: string; bytes: Uint8Array };
+  },
+  now: string,
+): Promise<{ application: AtsApplicationSummary; created: boolean }> {
+  await db.ready;
+  return db.transaction(async (trx) => {
+    const id = randomUUID();
+    const inserted = await trx.executor.insertInto('ats_applications').values({
+      id,
+      submission_key: input.submissionKey,
+      role_slug: input.roleSlug,
+      candidate_name: input.candidateName.trim(),
+      candidate_email: input.candidateEmail.trim().toLowerCase(),
+      phone: input.phone,
+      location: input.location.trim(),
+      availability: input.availability.trim(),
+      links: JSON.stringify(input.links),
+      answers: JSON.stringify(input.answers),
+      source: input.source,
+      stage: 'applied',
+      disposition: 'active',
+      revision: 1,
+      owner_id: null,
+      tags: '[]',
+      next_action_at: null,
+      disposition_reason: null,
+      consent_at: input.consentAt,
+      retention_until: input.retentionUntil,
+      resume_filename: input.resume.filename,
+      resume_content_type: input.resume.contentType,
+      resume_bytes: input.resume.bytes,
+      created_at: now,
+      updated_at: now,
+      deleted_at: null,
+    }).onConflict((oc) => oc.column('submission_key').doNothing())
+      .returning(applicationColumns)
+      .executeTakeFirst();
+
+    if (!inserted) {
+      const existing = await trx.executor.selectFrom('ats_applications')
+        .select(applicationColumns)
+        .where('submission_key', '=', input.submissionKey)
+        .where('deleted_at', 'is', null)
+        .executeTakeFirstOrThrow();
+      return { application: mapApplication(existing), created: false };
+    }
+
+    await insertEvent(trx, {
+      applicationId: id,
+      eventType: 'application_submitted',
+      detail: { roleSlug: input.roleSlug, source: input.source },
+      at: now,
+    });
+    return { application: mapApplication(inserted), created: true };
+  });
+}
+
+export async function listAtsApplications(
+  db: PlatformDB,
+  filters: { roleSlug?: string; stage?: AtsStage; disposition?: AtsDisposition; search?: string },
+): Promise<AtsApplicationSummary[]> {
+  await db.ready;
+  let query = db.executor.selectFrom('ats_applications')
+    .select(applicationColumns)
+    .where('deleted_at', 'is', null);
+  if (filters.roleSlug) query = query.where('role_slug', '=', filters.roleSlug);
+  if (filters.stage) query = query.where('stage', '=', filters.stage);
+  if (filters.disposition) query = query.where('disposition', '=', filters.disposition);
+  if (filters.search) {
+    const search = `%${filters.search.trim().toLowerCase()}%`;
+    query = query.where((eb) => eb.or([
+      eb('candidate_email', 'like', search),
+      eb('candidate_name', 'like', search),
+    ]));
+  }
+  return (await query.orderBy('updated_at', 'desc').limit(200).execute()).map(mapApplication);
+}
+
+export async function getAtsApplication(db: PlatformDB, id: string): Promise<AtsApplicationDetail | undefined> {
+  await db.ready;
+  const application = await db.executor.selectFrom('ats_applications')
+    .select(applicationColumns)
+    .where('id', '=', id)
+    .where('deleted_at', 'is', null)
+    .executeTakeFirst();
+  if (!application) return undefined;
+  const [events, notes, scorecards, interviews, tasks] = await Promise.all([
+    db.executor.selectFrom('ats_application_events').selectAll().where('application_id', '=', id).orderBy('created_at', 'desc').execute(),
+    db.executor.selectFrom('ats_notes').selectAll().where('application_id', '=', id).orderBy('created_at', 'desc').execute(),
+    db.executor.selectFrom('ats_scorecards').selectAll().where('application_id', '=', id).orderBy('updated_at', 'desc').execute(),
+    db.executor.selectFrom('ats_interviews').selectAll().where('application_id', '=', id).orderBy('created_at', 'desc').execute(),
+    db.executor.selectFrom('ats_tasks').selectAll().where('application_id', '=', id).orderBy('created_at', 'desc').execute(),
+  ]);
+  return {
+    ...mapApplication(application),
+    events: events.map(mapEvent),
+    notes: notes.map(mapNote),
+    scorecards: scorecards.map(mapScorecard),
+    interviews: interviews.map(mapInterview),
+    tasks: tasks.map(mapTask),
+  };
+}
+
+export async function getAtsApplicationResume(
+  db: PlatformDB,
+  id: string,
+): Promise<{ filename: string; contentType: string; bytes: Uint8Array } | undefined> {
+  await db.ready;
+  const row = await db.executor.selectFrom('ats_applications')
+    .select(['resume_filename', 'resume_content_type', 'resume_bytes'])
+    .where('id', '=', id)
+    .where('deleted_at', 'is', null)
+    .executeTakeFirst();
+  return row ? {
+    filename: row.resume_filename,
+    contentType: row.resume_content_type,
+    bytes: new Uint8Array(row.resume_bytes),
+  } : undefined;
+}
+
+export async function transitionAtsApplication(
+  db: PlatformDB,
+  input: {
+    applicationId: string;
+    baseRevision: number;
+    stage: AtsStage;
+    disposition: AtsDisposition;
+    actorId: string;
+    reason: string | null;
+    at: string;
+  },
+): Promise<AtsApplicationSummary> {
+  await db.ready;
+  return db.transaction(async (trx) => {
+    const before = await trx.executor.selectFrom('ats_applications')
+      .select(['stage'])
+      .where('id', '=', input.applicationId)
+      .where('deleted_at', 'is', null)
+      .executeTakeFirst();
+    if (!before) throw new AtsApplicationNotFoundError();
+    const updated = await trx.executor.updateTable('ats_applications').set({
+      stage: input.stage,
+      disposition: input.disposition,
+      disposition_reason: input.reason,
+      revision: input.baseRevision + 1,
+      updated_at: input.at,
+    }).where('id', '=', input.applicationId)
+      .where('revision', '=', input.baseRevision)
+      .where('deleted_at', 'is', null)
+      .returning(applicationColumns)
+      .executeTakeFirst();
+    if (!updated) throw new AtsRevisionConflictError();
+    await insertEvent(trx, {
+      applicationId: input.applicationId,
+      eventType: input.disposition === 'active' ? 'stage_changed' : 'disposition_changed',
+      actorId: input.actorId,
+      fromStage: before.stage,
+      toStage: input.stage,
+      detail: { disposition: input.disposition, reason: input.reason },
+      at: input.at,
+    });
+    return mapApplication(updated);
+  });
+}
+
+export async function updateAtsApplicationMetadata(
+  db: PlatformDB,
+  input: {
+    applicationId: string;
+    baseRevision: number;
+    ownerId: string | null;
+    tags: string[];
+    nextActionAt: string | null;
+    actorId: string;
+    at: string;
+  },
+): Promise<AtsApplicationSummary> {
+  await db.ready;
+  return db.transaction(async (trx) => {
+    const updated = await trx.executor.updateTable('ats_applications').set({
+      owner_id: input.ownerId,
+      tags: JSON.stringify(input.tags),
+      next_action_at: input.nextActionAt,
+      revision: input.baseRevision + 1,
+      updated_at: input.at,
+    }).where('id', '=', input.applicationId)
+      .where('revision', '=', input.baseRevision)
+      .where('deleted_at', 'is', null)
+      .returning(applicationColumns)
+      .executeTakeFirst();
+    if (!updated) throw new AtsRevisionConflictError();
+    await insertEvent(trx, {
+      applicationId: input.applicationId,
+      eventType: 'application_metadata_updated',
+      actorId: input.actorId,
+      detail: { ownerId: input.ownerId, tags: input.tags, nextActionAt: input.nextActionAt },
+      at: input.at,
+    });
+    return mapApplication(updated);
+  });
+}
+
+export async function addAtsNote(db: PlatformDB, input: {
+  applicationId: string; authorId: string; body: string; at: string;
+}): Promise<AtsNote> {
+  await db.ready;
+  return db.transaction(async (trx) => {
+    const row = await trx.executor.insertInto('ats_notes').values({
+      id: randomUUID(), application_id: input.applicationId, author_id: input.authorId,
+      body: input.body, created_at: input.at, updated_at: input.at,
+    }).returningAll().executeTakeFirstOrThrow();
+    await insertEvent(trx, { applicationId: input.applicationId, eventType: 'note_added', actorId: input.authorId, at: input.at });
+    return mapNote(row);
+  });
+}
+
+export async function upsertAtsScorecard(db: PlatformDB, input: {
+  applicationId: string; interviewerId: string; interviewType: string;
+  recommendation: string; ratings: Record<string, number>; strengths: string;
+  concerns: string | null; at: string;
+}): Promise<AtsScorecard> {
+  await db.ready;
+  return db.transaction(async (trx) => {
+    const id = randomUUID();
+    const row = await trx.executor.insertInto('ats_scorecards').values({
+      id, application_id: input.applicationId, interviewer_id: input.interviewerId,
+      interview_type: input.interviewType, recommendation: input.recommendation,
+      ratings: JSON.stringify(input.ratings), strengths: input.strengths,
+      concerns: input.concerns, created_at: input.at, updated_at: input.at,
+    }).onConflict((oc) => oc.columns(['application_id', 'interviewer_id', 'interview_type']).doUpdateSet({
+      recommendation: input.recommendation,
+      ratings: JSON.stringify(input.ratings),
+      strengths: input.strengths,
+      concerns: input.concerns,
+      updated_at: input.at,
+    })).returningAll().executeTakeFirstOrThrow();
+    await insertEvent(trx, { applicationId: input.applicationId, eventType: 'scorecard_submitted', actorId: input.interviewerId, detail: { interviewType: input.interviewType }, at: input.at });
+    return mapScorecard(row);
+  });
+}
+
+export async function createAtsInterview(db: PlatformDB, input: {
+  applicationId: string; interviewType: string; interviewerIds: string[];
+  bookingTokenHash: string; bookingUrl: string; actorId: string; at: string;
+}): Promise<AtsInterview> {
+  await db.ready;
+  return db.transaction(async (trx) => {
+    const row = await trx.executor.insertInto('ats_interviews').values({
+      id: randomUUID(), application_id: input.applicationId,
+      interview_type: input.interviewType, status: 'awaiting_booking',
+      interviewer_ids: JSON.stringify(input.interviewerIds),
+      booking_token_hash: input.bookingTokenHash, booking_url: input.bookingUrl,
+      scheduled_start: null, scheduled_end: null, timezone: null,
+      meeting_location: null, created_at: input.at, updated_at: input.at,
+    }).returningAll().executeTakeFirstOrThrow();
+    await insertEvent(trx, { applicationId: input.applicationId, eventType: 'interview_created', actorId: input.actorId, detail: { interviewType: input.interviewType }, at: input.at });
+    return mapInterview(row);
+  });
+}
+
+export async function resolveAtsBooking(
+  db: PlatformDB,
+  bookingTokenHash: string,
+  at: string,
+): Promise<string | undefined> {
+  await db.ready;
+  return db.transaction(async (trx) => {
+    const interview = await trx.executor.selectFrom('ats_interviews')
+      .select(['id', 'application_id', 'status', 'booking_url'])
+      .where('booking_token_hash', '=', bookingTokenHash)
+      .executeTakeFirst();
+    if (!interview) return undefined;
+    if (interview.status === 'awaiting_booking') {
+      const updated = await trx.executor.updateTable('ats_interviews').set({
+        status: 'booking_opened',
+        updated_at: at,
+      }).where('id', '=', interview.id)
+        .where('status', '=', 'awaiting_booking')
+        .returning('id')
+        .executeTakeFirst();
+      if (updated) {
+        await insertEvent(trx, {
+          applicationId: interview.application_id,
+          eventType: 'booking_link_opened',
+          detail: { interviewId: interview.id },
+          at,
+        });
+      }
+    }
+    return interview.booking_url;
+  });
+}
+
+export async function createAtsTask(db: PlatformDB, input: {
+  applicationId: string; title: string; assigneeId: string | null;
+  dueAt: string | null; actorId: string; at: string;
+}): Promise<AtsTask> {
+  await db.ready;
+  return db.transaction(async (trx) => {
+    const row = await trx.executor.insertInto('ats_tasks').values({
+      id: randomUUID(), application_id: input.applicationId, title: input.title,
+      assignee_id: input.assigneeId, due_at: input.dueAt, status: 'open',
+      completed_at: null, created_at: input.at, updated_at: input.at,
+    }).returningAll().executeTakeFirstOrThrow();
+    await insertEvent(trx, { applicationId: input.applicationId, eventType: 'task_created', actorId: input.actorId, detail: { taskId: row.id }, at: input.at });
+    return mapTask(row);
+  });
+}
+
+export async function completeAtsTask(db: PlatformDB, input: {
+  applicationId: string; taskId: string; actorId: string; at: string;
+}): Promise<AtsTask> {
+  await db.ready;
+  return db.transaction(async (trx) => {
+    const row = await trx.executor.updateTable('ats_tasks').set({
+      status: 'completed', completed_at: input.at, updated_at: input.at,
+    }).where('id', '=', input.taskId)
+      .where('application_id', '=', input.applicationId)
+      .where('status', '=', 'open')
+      .returningAll().executeTakeFirst();
+    if (!row) throw new AtsApplicationNotFoundError();
+    await insertEvent(trx, { applicationId: input.applicationId, eventType: 'task_completed', actorId: input.actorId, detail: { taskId: input.taskId }, at: input.at });
+    return mapTask(row);
+  });
+}

--- a/packages/platform/src/ats-repository.ts
+++ b/packages/platform/src/ats-repository.ts
@@ -59,6 +59,15 @@ async function insertEvent(
   }).execute();
 }
 
+async function requireAtsApplication(db: AtsDB, applicationId: string): Promise<void> {
+  const application = await db.executor.selectFrom('ats_applications')
+    .select('id')
+    .where('id', '=', applicationId)
+    .where('deleted_at', 'is', null)
+    .executeTakeFirst();
+  if (!application) throw new AtsApplicationNotFoundError();
+}
+
 export async function createAtsApplication(
   db: AtsDB,
   input: {
@@ -146,7 +155,7 @@ export async function listAtsApplications(
     const search = `%${filters.search.trim().toLowerCase()}%`;
     query = query.where((eb) => eb.or([
       eb('candidate_email', 'like', search),
-      eb('candidate_name', 'like', search),
+      eb(eb.fn<string>('lower', ['candidate_name']), 'like', search),
     ]));
   }
   return (await query.orderBy('updated_at', 'desc').limit(200).execute()).map(mapApplication);
@@ -253,6 +262,7 @@ export async function updateAtsApplicationMetadata(
 ): Promise<AtsApplicationSummary> {
   await db.ready;
   return db.transaction(async (trx) => {
+    await requireAtsApplication(trx, input.applicationId);
     const updated = await trx.executor.updateTable('ats_applications').set({
       owner_id: input.ownerId,
       tags: JSON.stringify(input.tags),
@@ -281,6 +291,7 @@ export async function addAtsNote(db: AtsDB, input: {
 }): Promise<AtsNote> {
   await db.ready;
   return db.transaction(async (trx) => {
+    await requireAtsApplication(trx, input.applicationId);
     const row = await trx.executor.insertInto('ats_notes').values({
       id: randomUUID(), application_id: input.applicationId, author_id: input.authorId,
       body: input.body, created_at: input.at, updated_at: input.at,
@@ -297,6 +308,7 @@ export async function upsertAtsScorecard(db: AtsDB, input: {
 }): Promise<AtsScorecard> {
   await db.ready;
   return db.transaction(async (trx) => {
+    await requireAtsApplication(trx, input.applicationId);
     const id = randomUUID();
     const row = await trx.executor.insertInto('ats_scorecards').values({
       id, application_id: input.applicationId, interviewer_id: input.interviewerId,
@@ -321,6 +333,7 @@ export async function createAtsInterview(db: AtsDB, input: {
 }): Promise<AtsInterview> {
   await db.ready;
   return db.transaction(async (trx) => {
+    await requireAtsApplication(trx, input.applicationId);
     const row = await trx.executor.insertInto('ats_interviews').values({
       id: randomUUID(), application_id: input.applicationId,
       interview_type: input.interviewType, status: 'awaiting_booking',
@@ -373,6 +386,7 @@ export async function createAtsTask(db: AtsDB, input: {
 }): Promise<AtsTask> {
   await db.ready;
   return db.transaction(async (trx) => {
+    await requireAtsApplication(trx, input.applicationId);
     const row = await trx.executor.insertInto('ats_tasks').values({
       id: randomUUID(), application_id: input.applicationId, title: input.title,
       assignee_id: input.assigneeId, due_at: input.dueAt, status: 'open',

--- a/packages/platform/src/ats-routes.ts
+++ b/packages/platform/src/ats-routes.ts
@@ -19,7 +19,7 @@ import {
   upsertAtsScorecard,
 } from './ats-repository.js';
 import { ATS_DISPOSITIONS, ATS_STAGES } from './ats-types.js';
-import type { PlatformDB } from './db.js';
+import type { AtsDB } from './ats-db.js';
 import { timingSafeTokenEquals } from './platform-token.js';
 
 const APPLICATION_BODY_LIMIT = 6 * 1024 * 1024;
@@ -111,7 +111,7 @@ function getActorId(headers: { get(name: string): string | null }): string {
 }
 
 export function createAtsRoutes(options: {
-  db: PlatformDB;
+  db: AtsDB;
   ingestSecret: string;
   adminSecret: string;
   allowedRoleSlugs: readonly string[];

--- a/packages/platform/src/ats-routes.ts
+++ b/packages/platform/src/ats-routes.ts
@@ -1,5 +1,5 @@
 import { createHash, randomBytes } from 'node:crypto';
-import { Hono } from 'hono';
+import { Hono, type Context } from 'hono';
 import { bodyLimit } from 'hono/body-limit';
 import { z } from 'zod/v4';
 import {
@@ -108,6 +108,14 @@ async function readJson<T>(c: { req: { json(): Promise<unknown> } }, schema: z.Z
 function getActorId(headers: { get(name: string): string | null }): string {
   const raw = headers.get('x-ats-actor-id')?.trim();
   return raw && raw.length <= 200 ? raw : 'site-admin';
+}
+
+function adminRouteError(c: Context, operation: string, err: unknown) {
+  if (err instanceof AtsApplicationNotFoundError) {
+    return c.json({ error: 'Not found' }, 404);
+  }
+  console.error(`[ats] ${operation} failed:`, err instanceof Error ? err.message : String(err));
+  return c.json({ error: 'ATS operation failed' }, 503);
 }
 
 export function createAtsRoutes(options: {
@@ -244,23 +252,31 @@ export function createAtsRoutes(options: {
   app.get('/api/ats/admin/applications/:id', async (c) => {
     const id = z.uuid().safeParse(c.req.param('id'));
     if (!id.success) return c.json({ error: 'Invalid application' }, 422);
-    const detail = await getAtsApplication(options.db, id.data);
-    return detail ? c.json({ application: detail }) : c.json({ error: 'Not found' }, 404);
+    try {
+      const detail = await getAtsApplication(options.db, id.data);
+      return detail ? c.json({ application: detail }) : c.json({ error: 'Not found' }, 404);
+    } catch (err: unknown) {
+      return adminRouteError(c, 'Candidate detail read', err);
+    }
   });
 
   app.get('/api/ats/admin/applications/:id/resume', async (c) => {
     const id = z.uuid().safeParse(c.req.param('id'));
     if (!id.success) return c.json({ error: 'Invalid application' }, 422);
-    const resume = await getAtsApplicationResume(options.db, id.data);
-    if (!resume) return c.json({ error: 'Not found' }, 404);
-    return new Response(resume.bytes as BodyInit, {
-      headers: {
-        'cache-control': 'no-store, private',
-        'content-type': resume.contentType,
-        'content-disposition': `attachment; filename="${safeFilename(resume.filename)}"`,
-        'x-content-type-options': 'nosniff',
-      },
-    });
+    try {
+      const resume = await getAtsApplicationResume(options.db, id.data);
+      if (!resume) return c.json({ error: 'Not found' }, 404);
+      return new Response(resume.bytes as BodyInit, {
+        headers: {
+          'cache-control': 'no-store, private',
+          'content-type': resume.contentType,
+          'content-disposition': `attachment; filename="${safeFilename(resume.filename)}"`,
+          'x-content-type-options': 'nosniff',
+        },
+      });
+    } catch (err: unknown) {
+      return adminRouteError(c, 'Candidate resume read', err);
+    }
   });
 
   app.patch('/api/ats/admin/applications/:id', bodyLimit({ maxSize: ADMIN_BODY_LIMIT }), async (c) => {
@@ -277,8 +293,7 @@ export function createAtsRoutes(options: {
       return c.json({ application });
     } catch (err: unknown) {
       if (err instanceof AtsRevisionConflictError) return c.json({ error: 'Revision conflict' }, 409);
-      console.error('[ats] Candidate metadata update failed:', err instanceof Error ? err.message : String(err));
-      return c.json({ error: 'Candidate update failed' }, 503);
+      return adminRouteError(c, 'Candidate metadata update', err);
     }
   });
 
@@ -306,26 +321,34 @@ export function createAtsRoutes(options: {
     const id = z.uuid().safeParse(c.req.param('id'));
     const body = await readJson(c, NoteSchema);
     if (!id.success || !body) return c.json({ error: 'Invalid note' }, 422);
-    const note = await addAtsNote(options.db, {
-      applicationId: id.data,
-      authorId: getActorId(c.req.raw.headers),
-      body: body.body,
-      at: now().toISOString(),
-    });
-    return c.json({ note }, 201);
+    try {
+      const note = await addAtsNote(options.db, {
+        applicationId: id.data,
+        authorId: getActorId(c.req.raw.headers),
+        body: body.body,
+        at: now().toISOString(),
+      });
+      return c.json({ note }, 201);
+    } catch (err: unknown) {
+      return adminRouteError(c, 'Candidate note create', err);
+    }
   });
 
   app.put('/api/ats/admin/applications/:id/scorecards', bodyLimit({ maxSize: ADMIN_BODY_LIMIT }), async (c) => {
     const id = z.uuid().safeParse(c.req.param('id'));
     const body = await readJson(c, ScorecardSchema);
     if (!id.success || !body) return c.json({ error: 'Invalid scorecard' }, 422);
-    const scorecard = await upsertAtsScorecard(options.db, {
-      applicationId: id.data,
-      interviewerId: getActorId(c.req.raw.headers),
-      ...body,
-      at: now().toISOString(),
-    });
-    return c.json({ scorecard });
+    try {
+      const scorecard = await upsertAtsScorecard(options.db, {
+        applicationId: id.data,
+        interviewerId: getActorId(c.req.raw.headers),
+        ...body,
+        at: now().toISOString(),
+      });
+      return c.json({ scorecard });
+    } catch (err: unknown) {
+      return adminRouteError(c, 'Candidate scorecard update', err);
+    }
   });
 
   app.post('/api/ats/admin/applications/:id/interviews', bodyLimit({ maxSize: ADMIN_BODY_LIMIT }), async (c) => {
@@ -334,36 +357,44 @@ export function createAtsRoutes(options: {
     if (!id.success || !body || !options.bookingBaseUrl) {
       return c.json({ error: options.bookingBaseUrl ? 'Invalid interview' : 'Booking not configured' }, options.bookingBaseUrl ? 422 : 503);
     }
-    const token = randomBytes(32).toString('base64url');
-    const bookingTokenHash = createHash('sha256').update(token).digest('hex');
-    const providerUrl = new URL(options.bookingBaseUrl);
-    providerUrl.searchParams.set('ats_interview', bookingTokenHash.slice(0, 16));
-    const interview = await createAtsInterview(options.db, {
-      applicationId: id.data,
-      ...body,
-      bookingTokenHash,
-      bookingUrl: providerUrl.toString(),
-      actorId: getActorId(c.req.raw.headers),
-      at: now().toISOString(),
-    });
-    const siteUrl = options.publicSiteUrl ?? 'https://matrix-os.com';
-    return c.json({
-      interview,
-      candidateBookingUrl: new URL(`/careers/schedule/${token}`, siteUrl).toString(),
-    }, 201);
+    try {
+      const token = randomBytes(32).toString('base64url');
+      const bookingTokenHash = createHash('sha256').update(token).digest('hex');
+      const providerUrl = new URL(options.bookingBaseUrl);
+      providerUrl.searchParams.set('ats_interview', bookingTokenHash.slice(0, 16));
+      const interview = await createAtsInterview(options.db, {
+        applicationId: id.data,
+        ...body,
+        bookingTokenHash,
+        bookingUrl: providerUrl.toString(),
+        actorId: getActorId(c.req.raw.headers),
+        at: now().toISOString(),
+      });
+      const siteUrl = options.publicSiteUrl ?? 'https://matrix-os.com';
+      return c.json({
+        interview,
+        candidateBookingUrl: new URL(`/careers/schedule/${token}`, siteUrl).toString(),
+      }, 201);
+    } catch (err: unknown) {
+      return adminRouteError(c, 'Candidate interview create', err);
+    }
   });
 
   app.post('/api/ats/admin/applications/:id/tasks', bodyLimit({ maxSize: ADMIN_BODY_LIMIT }), async (c) => {
     const id = z.uuid().safeParse(c.req.param('id'));
     const body = await readJson(c, TaskSchema);
     if (!id.success || !body) return c.json({ error: 'Invalid task' }, 422);
-    const task = await createAtsTask(options.db, {
-      applicationId: id.data,
-      ...body,
-      actorId: getActorId(c.req.raw.headers),
-      at: now().toISOString(),
-    });
-    return c.json({ task }, 201);
+    try {
+      const task = await createAtsTask(options.db, {
+        applicationId: id.data,
+        ...body,
+        actorId: getActorId(c.req.raw.headers),
+        at: now().toISOString(),
+      });
+      return c.json({ task }, 201);
+    } catch (err: unknown) {
+      return adminRouteError(c, 'Candidate task create', err);
+    }
   });
 
   app.post('/api/ats/admin/applications/:id/tasks/:taskId/complete', bodyLimit({ maxSize: ADMIN_BODY_LIMIT }), async (c) => {
@@ -372,12 +403,16 @@ export function createAtsRoutes(options: {
       taskId: c.req.param('taskId'),
     });
     if (!ids.success) return c.json({ error: 'Invalid task' }, 422);
-    const task = await completeAtsTask(options.db, {
-      ...ids.data,
-      actorId: getActorId(c.req.raw.headers),
-      at: now().toISOString(),
-    });
-    return c.json({ task });
+    try {
+      const task = await completeAtsTask(options.db, {
+        ...ids.data,
+        actorId: getActorId(c.req.raw.headers),
+        at: now().toISOString(),
+      });
+      return c.json({ task });
+    } catch (err: unknown) {
+      return adminRouteError(c, 'Candidate task complete', err);
+    }
   });
 
   return app;

--- a/packages/platform/src/ats-routes.ts
+++ b/packages/platform/src/ats-routes.ts
@@ -105,6 +105,15 @@ async function readJson<T>(c: { req: { json(): Promise<unknown> } }, schema: z.Z
   return parsed.success ? parsed.data : null;
 }
 
+function parseJsonFormField(value: FormDataEntryValue | null, fallback: string): unknown {
+  try {
+    return JSON.parse(String(value ?? fallback));
+  } catch (err: unknown) {
+    if (err instanceof SyntaxError) return undefined;
+    throw err;
+  }
+}
+
 function getActorId(headers: { get(name: string): string | null }): string {
   const raw = headers.get('x-ats-actor-id')?.trim();
   return raw && raw.length <= 200 ? raw : 'site-admin';
@@ -144,8 +153,8 @@ export function createAtsRoutes(options: {
     try {
       const form = await c.req.formData();
       const roleSlug = String(form.get('roleSlug') ?? '');
-      const linksParsed = LinksSchema.safeParse(JSON.parse(String(form.get('links') ?? '{}')));
-      const answersParsed = AnswersSchema.safeParse(JSON.parse(String(form.get('answers') ?? '[]')));
+      const linksParsed = LinksSchema.safeParse(parseJsonFormField(form.get('links'), '{}'));
+      const answersParsed = AnswersSchema.safeParse(parseJsonFormField(form.get('answers'), '[]'));
       const fields = z.object({
         submissionKey: z.uuid(),
         candidateName: z.string().trim().min(1).max(200),

--- a/packages/platform/src/ats-routes.ts
+++ b/packages/platform/src/ats-routes.ts
@@ -1,0 +1,384 @@
+import { createHash, randomBytes } from 'node:crypto';
+import { Hono } from 'hono';
+import { bodyLimit } from 'hono/body-limit';
+import { z } from 'zod/v4';
+import {
+  AtsApplicationNotFoundError,
+  AtsRevisionConflictError,
+  addAtsNote,
+  completeAtsTask,
+  createAtsApplication,
+  createAtsInterview,
+  createAtsTask,
+  getAtsApplication,
+  getAtsApplicationResume,
+  listAtsApplications,
+  resolveAtsBooking,
+  transitionAtsApplication,
+  updateAtsApplicationMetadata,
+  upsertAtsScorecard,
+} from './ats-repository.js';
+import { ATS_DISPOSITIONS, ATS_STAGES } from './ats-types.js';
+import type { PlatformDB } from './db.js';
+import { timingSafeTokenEquals } from './platform-token.js';
+
+const APPLICATION_BODY_LIMIT = 6 * 1024 * 1024;
+const RESUME_SIZE_LIMIT = 5 * 1024 * 1024;
+const ADMIN_BODY_LIMIT = 64 * 1024;
+
+const HttpUrlSchema = z.string().max(2_048).url().refine((value) => {
+  const protocol = new URL(value).protocol;
+  return protocol === 'https:' || protocol === 'http:';
+});
+
+const LinksSchema = z.record(z.string().min(1).max(50), HttpUrlSchema).refine(
+  (links) => Object.keys(links).length <= 10,
+);
+const AnswersSchema = z.array(z.object({
+  prompt: z.string().trim().min(1).max(500),
+  answer: z.string().trim().min(1).max(5_000),
+})).min(1).max(10);
+
+const TransitionSchema = z.object({
+  baseRevision: z.number().int().positive(),
+  stage: z.enum(ATS_STAGES),
+  disposition: z.enum(ATS_DISPOSITIONS),
+  reason: z.string().trim().max(2_000).nullable().default(null),
+});
+
+const NoteSchema = z.object({ body: z.string().trim().min(1).max(10_000) });
+const ScorecardSchema = z.object({
+  interviewType: z.string().trim().min(1).max(100),
+  recommendation: z.enum(['strong_no', 'no', 'mixed', 'yes', 'strong_yes']),
+  ratings: z.record(z.string().min(1).max(50), z.number().int().min(1).max(5)).refine(
+    (ratings) => Object.keys(ratings).length <= 20,
+  ),
+  strengths: z.string().trim().min(1).max(10_000),
+  concerns: z.string().trim().max(10_000).nullable().default(null),
+});
+const InterviewSchema = z.object({
+  interviewType: z.string().trim().min(1).max(100),
+  interviewerIds: z.array(z.string().trim().min(1).max(200)).min(1).max(20),
+});
+const TaskSchema = z.object({
+  title: z.string().trim().min(1).max(500),
+  assigneeId: z.string().trim().min(1).max(200).nullable().default(null),
+  dueAt: z.iso.datetime().nullable().default(null),
+});
+const MetadataSchema = z.object({
+  baseRevision: z.number().int().positive(),
+  ownerId: z.string().trim().min(1).max(200).nullable(),
+  tags: z.array(z.string().trim().min(1).max(50)).max(20).transform((tags) => [...new Set(tags)]),
+  nextActionAt: z.iso.datetime().nullable(),
+});
+const BookingTokenSchema = z.string().regex(/^[A-Za-z0-9_-]{43}$/);
+
+function bearerToken(header: string | undefined): string | undefined {
+  return header?.startsWith('Bearer ') ? header.slice('Bearer '.length) : undefined;
+}
+
+function safeFilename(value: string): string {
+  const sanitized = value.replace(/[^a-zA-Z0-9._ -]/g, '_').replace(/\s+/g, ' ').trim();
+  return sanitized.slice(0, 180) || 'resume';
+}
+
+function isAllowedResumeSignature(contentType: string, bytes: Uint8Array): boolean {
+  if (contentType === 'application/pdf') {
+    return bytes.length >= 4 && new TextDecoder().decode(bytes.slice(0, 4)) === '%PDF';
+  }
+  if (contentType === 'application/vnd.openxmlformats-officedocument.wordprocessingml.document') {
+    return bytes.length >= 4 && bytes[0] === 0x50 && bytes[1] === 0x4b && bytes[2] === 0x03 && bytes[3] === 0x04;
+  }
+  if (contentType === 'application/msword') {
+    const signature = [0xd0, 0xcf, 0x11, 0xe0];
+    return bytes.length >= 4 && signature.every((byte, index) => bytes[index] === byte);
+  }
+  return false;
+}
+
+async function readJson<T>(c: { req: { json(): Promise<unknown> } }, schema: z.ZodType<T>): Promise<T | null> {
+  const raw = await c.req.json().catch((err: unknown) => {
+    console.warn('[ats] Invalid JSON request:', err instanceof Error ? err.name : typeof err);
+    return undefined;
+  });
+  const parsed = schema.safeParse(raw);
+  return parsed.success ? parsed.data : null;
+}
+
+function getActorId(headers: { get(name: string): string | null }): string {
+  const raw = headers.get('x-ats-actor-id')?.trim();
+  return raw && raw.length <= 200 ? raw : 'site-admin';
+}
+
+export function createAtsRoutes(options: {
+  db: PlatformDB;
+  ingestSecret: string;
+  adminSecret: string;
+  allowedRoleSlugs: readonly string[];
+  bookingBaseUrl?: string;
+  publicSiteUrl?: string;
+  now?: () => Date;
+}): Hono {
+  const app = new Hono();
+  const now = options.now ?? (() => new Date());
+
+  function requireSecret(c: Parameters<Parameters<typeof app.use>[1]>[0], secret: string, kind: string) {
+    if (!secret) return c.json({ error: `${kind} not configured` }, 503);
+    if (!timingSafeTokenEquals(bearerToken(c.req.header('authorization')), secret)) {
+      return c.json({ error: 'Unauthorized' }, 401);
+    }
+    return null;
+  }
+
+  app.post('/api/ats/applications', bodyLimit({ maxSize: APPLICATION_BODY_LIMIT }), async (c) => {
+    const authError = requireSecret(c, options.ingestSecret, 'Application intake');
+    if (authError) return authError;
+    try {
+      const form = await c.req.formData();
+      const roleSlug = String(form.get('roleSlug') ?? '');
+      const linksParsed = LinksSchema.safeParse(JSON.parse(String(form.get('links') ?? '{}')));
+      const answersParsed = AnswersSchema.safeParse(JSON.parse(String(form.get('answers') ?? '[]')));
+      const fields = z.object({
+        submissionKey: z.uuid(),
+        candidateName: z.string().trim().min(1).max(200),
+        candidateEmail: z.email().max(320),
+        phone: z.string().trim().max(100).nullable(),
+        location: z.string().trim().min(1).max(300),
+        availability: z.string().trim().min(1).max(1_000),
+        source: z.string().trim().min(1).max(100),
+        consent: z.literal('true'),
+      }).safeParse({
+        submissionKey: String(form.get('submissionKey') ?? ''),
+        candidateName: String(form.get('candidateName') ?? ''),
+        candidateEmail: String(form.get('candidateEmail') ?? ''),
+        phone: form.get('phone') ? String(form.get('phone')) : null,
+        location: String(form.get('location') ?? ''),
+        availability: String(form.get('availability') ?? ''),
+        source: String(form.get('source') ?? 'careers_page'),
+        consent: String(form.get('consent') ?? ''),
+      });
+      const resume = form.get('resume');
+      if (
+        !options.allowedRoleSlugs.includes(roleSlug) ||
+        !fields.success ||
+        !linksParsed.success ||
+        !answersParsed.success ||
+        !(resume instanceof File) ||
+        resume.size === 0 ||
+        resume.size > RESUME_SIZE_LIMIT
+      ) {
+        return c.json({ error: 'Invalid application' }, 422);
+      }
+      const resumeBytes = new Uint8Array(await resume.arrayBuffer());
+      if (!isAllowedResumeSignature(resume.type, resumeBytes)) {
+        return c.json({ error: 'Invalid application' }, 422);
+      }
+      const submittedAt = now();
+      const retentionUntil = new Date(submittedAt);
+      retentionUntil.setUTCFullYear(retentionUntil.getUTCFullYear() + 1);
+      const result = await createAtsApplication(options.db, {
+        submissionKey: fields.data.submissionKey,
+        roleSlug,
+        candidateName: fields.data.candidateName,
+        candidateEmail: fields.data.candidateEmail,
+        phone: fields.data.phone,
+        location: fields.data.location,
+        availability: fields.data.availability,
+        links: linksParsed.data,
+        answers: answersParsed.data,
+        source: fields.data.source,
+        consentAt: submittedAt.toISOString(),
+        retentionUntil: retentionUntil.toISOString(),
+        resume: {
+          filename: safeFilename(resume.name),
+          contentType: resume.type,
+          bytes: resumeBytes,
+        },
+      }, submittedAt.toISOString());
+      c.header('Cache-Control', 'no-store');
+      return c.json({ receiptId: result.application.id }, result.created ? 201 : 200);
+    } catch (err: unknown) {
+      console.error('[ats] Application submission failed:', err instanceof Error ? err.message : String(err));
+      return c.json({ error: 'Application could not be submitted' }, 503);
+    }
+  });
+
+  app.get('/api/ats/booking/:token', async (c) => {
+    const token = BookingTokenSchema.safeParse(c.req.param('token'));
+    if (!token.success) return c.json({ error: 'Not found' }, 404);
+    try {
+      const tokenHash = createHash('sha256').update(token.data).digest('hex');
+      const providerUrl = await resolveAtsBooking(options.db, tokenHash, now().toISOString());
+      if (!providerUrl) return c.json({ error: 'Not found' }, 404);
+      c.header('Cache-Control', 'no-store, private');
+      return c.redirect(providerUrl, 302);
+    } catch (err: unknown) {
+      console.error('[ats] Booking link resolution failed:', err instanceof Error ? err.message : String(err));
+      return c.json({ error: 'Booking unavailable' }, 503);
+    }
+  });
+
+  app.use('/api/ats/admin/*', async (c, next) => {
+    const authError = requireSecret(c, options.adminSecret, 'ATS administration');
+    if (authError) return authError;
+    c.header('Cache-Control', 'no-store, private');
+    return next();
+  });
+
+  app.get('/api/ats/admin/applications', async (c) => {
+    const query = z.object({
+      roleSlug: z.string().trim().min(1).max(200).optional(),
+      stage: z.enum(ATS_STAGES).optional(),
+      disposition: z.enum(ATS_DISPOSITIONS).optional(),
+      search: z.string().trim().min(1).max(200).optional(),
+    }).safeParse(c.req.query());
+    if (!query.success) return c.json({ error: 'Invalid filters' }, 422);
+    try {
+      return c.json({ applications: await listAtsApplications(options.db, query.data) });
+    } catch (err: unknown) {
+      console.error('[ats] Candidate list failed:', err instanceof Error ? err.message : String(err));
+      return c.json({ error: 'Candidates unavailable' }, 503);
+    }
+  });
+
+  app.get('/api/ats/admin/applications/:id', async (c) => {
+    const id = z.uuid().safeParse(c.req.param('id'));
+    if (!id.success) return c.json({ error: 'Invalid application' }, 422);
+    const detail = await getAtsApplication(options.db, id.data);
+    return detail ? c.json({ application: detail }) : c.json({ error: 'Not found' }, 404);
+  });
+
+  app.get('/api/ats/admin/applications/:id/resume', async (c) => {
+    const id = z.uuid().safeParse(c.req.param('id'));
+    if (!id.success) return c.json({ error: 'Invalid application' }, 422);
+    const resume = await getAtsApplicationResume(options.db, id.data);
+    if (!resume) return c.json({ error: 'Not found' }, 404);
+    return new Response(resume.bytes as BodyInit, {
+      headers: {
+        'cache-control': 'no-store, private',
+        'content-type': resume.contentType,
+        'content-disposition': `attachment; filename="${safeFilename(resume.filename)}"`,
+        'x-content-type-options': 'nosniff',
+      },
+    });
+  });
+
+  app.patch('/api/ats/admin/applications/:id', bodyLimit({ maxSize: ADMIN_BODY_LIMIT }), async (c) => {
+    const id = z.uuid().safeParse(c.req.param('id'));
+    const body = await readJson(c, MetadataSchema);
+    if (!id.success || !body) return c.json({ error: 'Invalid candidate update' }, 422);
+    try {
+      const application = await updateAtsApplicationMetadata(options.db, {
+        applicationId: id.data,
+        ...body,
+        actorId: getActorId(c.req.raw.headers),
+        at: now().toISOString(),
+      });
+      return c.json({ application });
+    } catch (err: unknown) {
+      if (err instanceof AtsRevisionConflictError) return c.json({ error: 'Revision conflict' }, 409);
+      console.error('[ats] Candidate metadata update failed:', err instanceof Error ? err.message : String(err));
+      return c.json({ error: 'Candidate update failed' }, 503);
+    }
+  });
+
+  app.post('/api/ats/admin/applications/:id/transition', bodyLimit({ maxSize: ADMIN_BODY_LIMIT }), async (c) => {
+    const id = z.uuid().safeParse(c.req.param('id'));
+    const body = await readJson(c, TransitionSchema);
+    if (!id.success || !body) return c.json({ error: 'Invalid transition' }, 422);
+    try {
+      const application = await transitionAtsApplication(options.db, {
+        applicationId: id.data,
+        ...body,
+        actorId: getActorId(c.req.raw.headers),
+        at: now().toISOString(),
+      });
+      return c.json({ application });
+    } catch (err: unknown) {
+      if (err instanceof AtsRevisionConflictError) return c.json({ error: 'Revision conflict' }, 409);
+      if (err instanceof AtsApplicationNotFoundError) return c.json({ error: 'Not found' }, 404);
+      console.error('[ats] Candidate transition failed:', err instanceof Error ? err.message : String(err));
+      return c.json({ error: 'Transition failed' }, 503);
+    }
+  });
+
+  app.post('/api/ats/admin/applications/:id/notes', bodyLimit({ maxSize: ADMIN_BODY_LIMIT }), async (c) => {
+    const id = z.uuid().safeParse(c.req.param('id'));
+    const body = await readJson(c, NoteSchema);
+    if (!id.success || !body) return c.json({ error: 'Invalid note' }, 422);
+    const note = await addAtsNote(options.db, {
+      applicationId: id.data,
+      authorId: getActorId(c.req.raw.headers),
+      body: body.body,
+      at: now().toISOString(),
+    });
+    return c.json({ note }, 201);
+  });
+
+  app.put('/api/ats/admin/applications/:id/scorecards', bodyLimit({ maxSize: ADMIN_BODY_LIMIT }), async (c) => {
+    const id = z.uuid().safeParse(c.req.param('id'));
+    const body = await readJson(c, ScorecardSchema);
+    if (!id.success || !body) return c.json({ error: 'Invalid scorecard' }, 422);
+    const scorecard = await upsertAtsScorecard(options.db, {
+      applicationId: id.data,
+      interviewerId: getActorId(c.req.raw.headers),
+      ...body,
+      at: now().toISOString(),
+    });
+    return c.json({ scorecard });
+  });
+
+  app.post('/api/ats/admin/applications/:id/interviews', bodyLimit({ maxSize: ADMIN_BODY_LIMIT }), async (c) => {
+    const id = z.uuid().safeParse(c.req.param('id'));
+    const body = await readJson(c, InterviewSchema);
+    if (!id.success || !body || !options.bookingBaseUrl) {
+      return c.json({ error: options.bookingBaseUrl ? 'Invalid interview' : 'Booking not configured' }, options.bookingBaseUrl ? 422 : 503);
+    }
+    const token = randomBytes(32).toString('base64url');
+    const bookingTokenHash = createHash('sha256').update(token).digest('hex');
+    const providerUrl = new URL(options.bookingBaseUrl);
+    providerUrl.searchParams.set('ats_interview', bookingTokenHash.slice(0, 16));
+    const interview = await createAtsInterview(options.db, {
+      applicationId: id.data,
+      ...body,
+      bookingTokenHash,
+      bookingUrl: providerUrl.toString(),
+      actorId: getActorId(c.req.raw.headers),
+      at: now().toISOString(),
+    });
+    const siteUrl = options.publicSiteUrl ?? 'https://matrix-os.com';
+    return c.json({
+      interview,
+      candidateBookingUrl: new URL(`/careers/schedule/${token}`, siteUrl).toString(),
+    }, 201);
+  });
+
+  app.post('/api/ats/admin/applications/:id/tasks', bodyLimit({ maxSize: ADMIN_BODY_LIMIT }), async (c) => {
+    const id = z.uuid().safeParse(c.req.param('id'));
+    const body = await readJson(c, TaskSchema);
+    if (!id.success || !body) return c.json({ error: 'Invalid task' }, 422);
+    const task = await createAtsTask(options.db, {
+      applicationId: id.data,
+      ...body,
+      actorId: getActorId(c.req.raw.headers),
+      at: now().toISOString(),
+    });
+    return c.json({ task }, 201);
+  });
+
+  app.post('/api/ats/admin/applications/:id/tasks/:taskId/complete', bodyLimit({ maxSize: ADMIN_BODY_LIMIT }), async (c) => {
+    const ids = z.object({ applicationId: z.uuid(), taskId: z.uuid() }).safeParse({
+      applicationId: c.req.param('id'),
+      taskId: c.req.param('taskId'),
+    });
+    if (!ids.success) return c.json({ error: 'Invalid task' }, 422);
+    const task = await completeAtsTask(options.db, {
+      ...ids.data,
+      actorId: getActorId(c.req.raw.headers),
+      at: now().toISOString(),
+    });
+    return c.json({ task });
+  });
+
+  return app;
+}

--- a/packages/platform/src/ats-schema.ts
+++ b/packages/platform/src/ats-schema.ts
@@ -1,0 +1,214 @@
+import { sql, type Kysely } from 'kysely';
+
+export interface AtsApplicationsTable {
+  id: string;
+  submission_key: string;
+  role_slug: string;
+  candidate_name: string;
+  candidate_email: string;
+  phone: string | null;
+  location: string;
+  availability: string;
+  links: string;
+  answers: string;
+  source: string;
+  stage: string;
+  disposition: string;
+  revision: number;
+  owner_id: string | null;
+  tags: string;
+  next_action_at: string | null;
+  disposition_reason: string | null;
+  consent_at: string;
+  retention_until: string;
+  resume_filename: string;
+  resume_content_type: string;
+  resume_bytes: Uint8Array;
+  created_at: string;
+  updated_at: string;
+  deleted_at: string | null;
+}
+
+export interface AtsApplicationEventsTable {
+  id: string;
+  application_id: string;
+  event_type: string;
+  actor_id: string | null;
+  from_stage: string | null;
+  to_stage: string | null;
+  detail: string;
+  created_at: string;
+}
+
+export interface AtsNotesTable {
+  id: string;
+  application_id: string;
+  author_id: string;
+  body: string;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface AtsScorecardsTable {
+  id: string;
+  application_id: string;
+  interviewer_id: string;
+  interview_type: string;
+  recommendation: string;
+  ratings: string;
+  strengths: string;
+  concerns: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface AtsInterviewsTable {
+  id: string;
+  application_id: string;
+  interview_type: string;
+  status: string;
+  interviewer_ids: string;
+  booking_token_hash: string;
+  booking_url: string;
+  scheduled_start: string | null;
+  scheduled_end: string | null;
+  timezone: string | null;
+  meeting_location: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface AtsTasksTable {
+  id: string;
+  application_id: string;
+  title: string;
+  assignee_id: string | null;
+  due_at: string | null;
+  status: string;
+  completed_at: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface AtsDatabaseTables {
+  ats_applications: AtsApplicationsTable;
+  ats_application_events: AtsApplicationEventsTable;
+  ats_notes: AtsNotesTable;
+  ats_scorecards: AtsScorecardsTable;
+  ats_interviews: AtsInterviewsTable;
+  ats_tasks: AtsTasksTable;
+}
+
+export async function migrateAts<T extends AtsDatabaseTables>(db: Kysely<T>): Promise<void> {
+  await sql`
+    CREATE TABLE IF NOT EXISTS ats_applications (
+      id TEXT PRIMARY KEY,
+      submission_key TEXT NOT NULL UNIQUE,
+      role_slug TEXT NOT NULL,
+      candidate_name TEXT NOT NULL,
+      candidate_email TEXT NOT NULL,
+      phone TEXT,
+      location TEXT NOT NULL,
+      availability TEXT NOT NULL,
+      links TEXT NOT NULL DEFAULT '{}',
+      answers TEXT NOT NULL DEFAULT '[]',
+      source TEXT NOT NULL DEFAULT 'careers_page',
+      stage TEXT NOT NULL DEFAULT 'applied',
+      disposition TEXT NOT NULL DEFAULT 'active',
+      revision INTEGER NOT NULL DEFAULT 1,
+      owner_id TEXT,
+      tags TEXT NOT NULL DEFAULT '[]',
+      next_action_at TEXT,
+      disposition_reason TEXT,
+      consent_at TEXT NOT NULL,
+      retention_until TEXT NOT NULL,
+      resume_filename TEXT NOT NULL,
+      resume_content_type TEXT NOT NULL,
+      resume_bytes BYTEA NOT NULL,
+      created_at TEXT NOT NULL,
+      updated_at TEXT NOT NULL,
+      deleted_at TEXT
+    )
+  `.execute(db);
+  await sql`CREATE INDEX IF NOT EXISTS idx_ats_applications_pipeline ON ats_applications(disposition, stage, updated_at DESC)`.execute(db);
+  await sql`CREATE INDEX IF NOT EXISTS idx_ats_applications_role ON ats_applications(role_slug, updated_at DESC)`.execute(db);
+  await sql`CREATE INDEX IF NOT EXISTS idx_ats_applications_email ON ats_applications(candidate_email)`.execute(db);
+  await sql`CREATE INDEX IF NOT EXISTS idx_ats_applications_retention ON ats_applications(retention_until) WHERE deleted_at IS NULL`.execute(db);
+
+  await sql`
+    CREATE TABLE IF NOT EXISTS ats_application_events (
+      id TEXT PRIMARY KEY,
+      application_id TEXT NOT NULL REFERENCES ats_applications(id) ON DELETE CASCADE,
+      event_type TEXT NOT NULL,
+      actor_id TEXT,
+      from_stage TEXT,
+      to_stage TEXT,
+      detail TEXT NOT NULL DEFAULT '{}',
+      created_at TEXT NOT NULL
+    )
+  `.execute(db);
+  await sql`CREATE INDEX IF NOT EXISTS idx_ats_events_application ON ats_application_events(application_id, created_at DESC)`.execute(db);
+
+  await sql`
+    CREATE TABLE IF NOT EXISTS ats_notes (
+      id TEXT PRIMARY KEY,
+      application_id TEXT NOT NULL REFERENCES ats_applications(id) ON DELETE CASCADE,
+      author_id TEXT NOT NULL,
+      body TEXT NOT NULL,
+      created_at TEXT NOT NULL,
+      updated_at TEXT NOT NULL
+    )
+  `.execute(db);
+  await sql`CREATE INDEX IF NOT EXISTS idx_ats_notes_application ON ats_notes(application_id, created_at DESC)`.execute(db);
+
+  await sql`
+    CREATE TABLE IF NOT EXISTS ats_scorecards (
+      id TEXT PRIMARY KEY,
+      application_id TEXT NOT NULL REFERENCES ats_applications(id) ON DELETE CASCADE,
+      interviewer_id TEXT NOT NULL,
+      interview_type TEXT NOT NULL,
+      recommendation TEXT NOT NULL,
+      ratings TEXT NOT NULL DEFAULT '{}',
+      strengths TEXT NOT NULL,
+      concerns TEXT,
+      created_at TEXT NOT NULL,
+      updated_at TEXT NOT NULL,
+      UNIQUE(application_id, interviewer_id, interview_type)
+    )
+  `.execute(db);
+  await sql`CREATE INDEX IF NOT EXISTS idx_ats_scorecards_application ON ats_scorecards(application_id, updated_at DESC)`.execute(db);
+
+  await sql`
+    CREATE TABLE IF NOT EXISTS ats_interviews (
+      id TEXT PRIMARY KEY,
+      application_id TEXT NOT NULL REFERENCES ats_applications(id) ON DELETE CASCADE,
+      interview_type TEXT NOT NULL,
+      status TEXT NOT NULL DEFAULT 'awaiting_booking',
+      interviewer_ids TEXT NOT NULL DEFAULT '[]',
+      booking_token_hash TEXT NOT NULL UNIQUE,
+      booking_url TEXT NOT NULL,
+      scheduled_start TEXT,
+      scheduled_end TEXT,
+      timezone TEXT,
+      meeting_location TEXT,
+      created_at TEXT NOT NULL,
+      updated_at TEXT NOT NULL
+    )
+  `.execute(db);
+  await sql`CREATE INDEX IF NOT EXISTS idx_ats_interviews_application ON ats_interviews(application_id, created_at DESC)`.execute(db);
+
+  await sql`
+    CREATE TABLE IF NOT EXISTS ats_tasks (
+      id TEXT PRIMARY KEY,
+      application_id TEXT NOT NULL REFERENCES ats_applications(id) ON DELETE CASCADE,
+      title TEXT NOT NULL,
+      assignee_id TEXT,
+      due_at TEXT,
+      status TEXT NOT NULL DEFAULT 'open',
+      completed_at TEXT,
+      created_at TEXT NOT NULL,
+      updated_at TEXT NOT NULL
+    )
+  `.execute(db);
+  await sql`CREATE INDEX IF NOT EXISTS idx_ats_tasks_application ON ats_tasks(application_id, status, due_at)`.execute(db);
+}

--- a/packages/platform/src/ats-types.ts
+++ b/packages/platform/src/ats-types.ts
@@ -1,0 +1,116 @@
+export const ATS_STAGES = [
+  'applied',
+  'screening',
+  'intro_call',
+  'technical_interview',
+  'founder_interview',
+  'reference_check',
+  'offer',
+  'hired',
+] as const;
+
+export const ATS_DISPOSITIONS = [
+  'active',
+  'rejected',
+  'withdrawn',
+  'archived',
+] as const;
+
+export type AtsStage = (typeof ATS_STAGES)[number];
+export type AtsDisposition = (typeof ATS_DISPOSITIONS)[number];
+
+export interface AtsApplicationSummary {
+  id: string;
+  submissionKey: string;
+  roleSlug: string;
+  candidateName: string;
+  candidateEmail: string;
+  phone: string | null;
+  location: string;
+  availability: string;
+  links: Record<string, string>;
+  answers: Array<{ prompt: string; answer: string }>;
+  source: string;
+  stage: AtsStage;
+  disposition: AtsDisposition;
+  revision: number;
+  ownerId: string | null;
+  tags: string[];
+  nextActionAt: string | null;
+  dispositionReason: string | null;
+  consentAt: string;
+  retentionUntil: string;
+  resumeFilename: string;
+  resumeContentType: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface AtsEvent {
+  id: string;
+  applicationId: string;
+  eventType: string;
+  actorId: string | null;
+  fromStage: string | null;
+  toStage: string | null;
+  detail: Record<string, unknown>;
+  createdAt: string;
+}
+
+export interface AtsNote {
+  id: string;
+  applicationId: string;
+  authorId: string;
+  body: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface AtsScorecard {
+  id: string;
+  applicationId: string;
+  interviewerId: string;
+  interviewType: string;
+  recommendation: string;
+  ratings: Record<string, number>;
+  strengths: string;
+  concerns: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface AtsInterview {
+  id: string;
+  applicationId: string;
+  interviewType: string;
+  status: string;
+  interviewerIds: string[];
+  bookingUrl: string;
+  scheduledStart: string | null;
+  scheduledEnd: string | null;
+  timezone: string | null;
+  meetingLocation: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface AtsTask {
+  id: string;
+  applicationId: string;
+  title: string;
+  assigneeId: string | null;
+  dueAt: string | null;
+  status: string;
+  completedAt: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface AtsApplicationDetail extends AtsApplicationSummary {
+  events: AtsEvent[];
+  notes: AtsNote[];
+  scorecards: AtsScorecard[];
+  interviews: AtsInterview[];
+  tasks: AtsTask[];
+}
+

--- a/packages/platform/src/db.ts
+++ b/packages/platform/src/db.ts
@@ -13,10 +13,6 @@ import {
   serializeDeveloperTools,
   type DeveloperToolId,
 } from './developer-tools.js';
-import {
-  migrateAts,
-  type AtsDatabaseTables,
-} from './ats-schema.js';
 
 const DEFAULT_PLATFORM_DB_URL =
   process.env.PLATFORM_DATABASE_URL ??
@@ -304,7 +300,7 @@ interface OnboardingJourneyEventsTable {
   at: string;
 }
 
-export interface PlatformDatabase extends AtsDatabaseTables {
+export interface PlatformDatabase {
   users: UsersTable;
   containers: ContainersTable;
   user_machines: UserMachinesTable;
@@ -1067,7 +1063,6 @@ async function migrate(db: Kysely<PlatformDatabase>): Promise<void> {
   `.execute(db);
   await sql`CREATE INDEX IF NOT EXISTS idx_follows_follower ON social_follows(follower_id)`.execute(db);
   await sql`CREATE INDEX IF NOT EXISTS idx_follows_following ON social_follows(following_id)`.execute(db);
-  await migrateAts(db);
 }
 
 export function createPlatformDb(opts: string | { dialect: unknown } = DEFAULT_PLATFORM_DB_URL ?? ''): PlatformDB {

--- a/packages/platform/src/db.ts
+++ b/packages/platform/src/db.ts
@@ -13,6 +13,10 @@ import {
   serializeDeveloperTools,
   type DeveloperToolId,
 } from './developer-tools.js';
+import {
+  migrateAts,
+  type AtsDatabaseTables,
+} from './ats-schema.js';
 
 const DEFAULT_PLATFORM_DB_URL =
   process.env.PLATFORM_DATABASE_URL ??
@@ -300,7 +304,7 @@ interface OnboardingJourneyEventsTable {
   at: string;
 }
 
-export interface PlatformDatabase {
+export interface PlatformDatabase extends AtsDatabaseTables {
   users: UsersTable;
   containers: ContainersTable;
   user_machines: UserMachinesTable;
@@ -1063,6 +1067,7 @@ async function migrate(db: Kysely<PlatformDatabase>): Promise<void> {
   `.execute(db);
   await sql`CREATE INDEX IF NOT EXISTS idx_follows_follower ON social_follows(follower_id)`.execute(db);
   await sql`CREATE INDEX IF NOT EXISTS idx_follows_following ON social_follows(following_id)`.execute(db);
+  await migrateAts(db);
 }
 
 export function createPlatformDb(opts: string | { dialect: unknown } = DEFAULT_PLATFORM_DB_URL ?? ''): PlatformDB {

--- a/packages/platform/src/main.ts
+++ b/packages/platform/src/main.ts
@@ -97,6 +97,7 @@ import {
   releaseVersionFromProbe,
 } from './runtime-probes.js';
 import { createPlatformMetricsRoutes } from './platform-metrics-routes.js';
+import { createAtsRoutes } from './ats-routes.js';
 import { shouldVerifyCustomerVpsTls } from './customer-vps-tls.js';
 import {
   APP_SESSION_COOKIE,
@@ -574,6 +575,18 @@ export function createApp(deps: {
     appOrigin: journeyAppOrigin,
     maxProvisionAttempts: Number(appEnv.CUSTOMER_VPS_MAX_PROVISION_ATTEMPTS) || 3,
     settlingWindowMs: Number(appEnv.BILLING_SETTLING_WINDOW_MS) || undefined,
+  }));
+
+  app.route('/', createAtsRoutes({
+    db,
+    ingestSecret: appEnv.ATS_INGEST_SECRET ?? '',
+    adminSecret: appEnv.ATS_ADMIN_SECRET ?? platformSecret,
+    allowedRoleSlugs: [
+      'founders-associate-gtm-operations',
+      'founding-engineer',
+    ],
+    bookingBaseUrl: appEnv.ATS_BOOKING_BASE_URL,
+    publicSiteUrl: appEnv.MATRIX_PUBLIC_SITE_URL ?? 'https://matrix-os.com',
   }));
 
   // Session-based routing:

--- a/packages/platform/src/main.ts
+++ b/packages/platform/src/main.ts
@@ -98,6 +98,7 @@ import {
 } from './runtime-probes.js';
 import { createPlatformMetricsRoutes } from './platform-metrics-routes.js';
 import { createAtsRoutes } from './ats-routes.js';
+import type { AtsDB } from './ats-db.js';
 import { shouldVerifyCustomerVpsTls } from './customer-vps-tls.js';
 import {
   APP_SESSION_COOKIE,
@@ -300,6 +301,7 @@ function getGatewayUrlForHandle(handle: string): string {
 
 export function createApp(deps: {
   db: PlatformDB;
+  atsDb?: AtsDB;
   docker?: Dockerode;
   orchestrator: Orchestrator;
   clerkAuth?: ClerkAuth;
@@ -577,17 +579,19 @@ export function createApp(deps: {
     settlingWindowMs: Number(appEnv.BILLING_SETTLING_WINDOW_MS) || undefined,
   }));
 
-  app.route('/', createAtsRoutes({
-    db,
-    ingestSecret: appEnv.ATS_INGEST_SECRET ?? '',
-    adminSecret: appEnv.ATS_ADMIN_SECRET ?? platformSecret,
-    allowedRoleSlugs: [
-      'founders-associate-gtm-operations',
-      'founding-engineer',
-    ],
-    bookingBaseUrl: appEnv.ATS_BOOKING_BASE_URL,
-    publicSiteUrl: appEnv.MATRIX_PUBLIC_SITE_URL ?? 'https://matrix-os.com',
-  }));
+  if (deps.atsDb) {
+    app.route('/', createAtsRoutes({
+      db: deps.atsDb,
+      ingestSecret: appEnv.ATS_INGEST_SECRET ?? '',
+      adminSecret: appEnv.ATS_ADMIN_SECRET ?? '',
+      allowedRoleSlugs: [
+        'founders-associate-gtm-operations',
+        'founding-engineer',
+      ],
+      bookingBaseUrl: appEnv.ATS_BOOKING_BASE_URL,
+      publicSiteUrl: appEnv.MATRIX_PUBLIC_SITE_URL ?? 'https://matrix-os.com',
+    }));
+  }
 
   // Session-based routing:
   // - app.matrix-os.com -> Clerk session -> Matrix OS shell/gateway

--- a/packages/platform/src/platform-startup.ts
+++ b/packages/platform/src/platform-startup.ts
@@ -16,6 +16,7 @@ import {
   updateContainerStatus,
   type PlatformDB,
 } from './db.js';
+import { createAtsDb, resolveAtsDatabaseUrl, type AtsDB } from './ats-db.js';
 import type { Orchestrator } from './orchestrator.js';
 import type { ClerkAuth } from './clerk-auth.js';
 import { createClerkAuth, createClerkSessionRevoker } from './clerk-auth.js';
@@ -125,6 +126,7 @@ interface GatewayR2ClientModule {
 
 type CreatePlatformApp = (deps: {
   db: PlatformDB;
+  atsDb?: AtsDB;
   docker?: Dockerode;
   orchestrator: Orchestrator;
   clerkAuth?: ClerkAuth;
@@ -205,8 +207,11 @@ export async function startPlatformServer(opts: StartPlatformServerOptions): Pro
     process.exit(1);
   }
 
+  const atsDatabaseUrl = resolveAtsDatabaseUrl(process.env);
   const db = createPlatformDb(runtimeConfig.platformDatabaseUrl);
   await db.ready;
+  const atsDb = atsDatabaseUrl ? createAtsDb(atsDatabaseUrl) : undefined;
+  await atsDb?.ready;
 
   let docker: Dockerode | undefined;
   let orchestrator: Orchestrator;
@@ -509,6 +514,7 @@ export async function startPlatformServer(opts: StartPlatformServerOptions): Pro
     appEnv.MATRIX_LEGACY_CONTAINER_ROUTING_ENABLED === 'true' && !customerVpsService;
   const app = createPlatformApp({
     db,
+    atsDb,
     docker,
     orchestrator,
     clerkAuth,
@@ -564,7 +570,7 @@ export async function startPlatformServer(opts: StartPlatformServerOptions): Pro
         posthogProcessErrors.dispose();
         await app.shutdownPostHog();
         await processPosthogErrorTracker.shutdown();
-        await db.destroy();
+        await Promise.all([db.destroy(), atsDb?.destroy()]);
       })()
         .catch((destroyErr: unknown) => {
           exitCode = 1;

--- a/specs/108-recruiting-ats/spec.md
+++ b/specs/108-recruiting-ats/spec.md
@@ -1,0 +1,143 @@
+# Spec 108: Recruiting ATS
+
+## Status
+
+Draft for implementation.
+
+## Problem
+
+Matrix needs a first-party applicant tracking system tied to the careers pages. Applicants should apply without creating a Matrix account, while the founding team needs a secure CRM-like workflow for screening, reviewing CVs, coordinating interviews, recording decisions, and preserving an auditable hiring history.
+
+Email-only applications lose structured answers, duplicate follow-ups, stage history, review context, and retention controls. A generic third-party ATS would also fragment candidate data from Matrix's existing PostgreSQL platform.
+
+## Goals
+
+- Replace `mailto:` application links with a structured, accessible application flow.
+- Store recruiting records in the existing platform PostgreSQL database.
+- Keep CV files private, bounded, and available only to authorized hiring administrators.
+- Provide a hiring pipeline with explicit stages, optimistic concurrency, search, filters, assignments, tags, next actions, notes, tasks, scorecards, and activity history.
+- Support interview planning and candidate-specific booking links without coupling the data model to one calendar provider.
+- Give applicants clear consent, submission confirmation, and safe duplicate behavior.
+- Support retention, withdrawal, rejection, archival, export, and deletion workflows.
+
+## Non-goals for the first release
+
+- Payroll, offer-letter signature, background checks, or HRIS onboarding.
+- Automated employment decisions or opaque AI ranking.
+- Scraping candidates from external networks.
+- Storing CVs in a public bucket or exposing platform administration credentials to browsers.
+
+## Architecture
+
+```text
+Applicant browser
+  -> matrix-os-site /api/careers/apply
+  -> platform /api/ats/applications (ATS_INGEST_SECRET)
+  -> PostgreSQL ATS tables
+
+Hiring admin browser
+  -> Clerk-protected matrix-os-site /admin/ats
+  -> site server actions (ATS_ADMIN_SECRET / PLATFORM_SECRET)
+  -> platform /api/ats/admin/*
+  -> PostgreSQL ATS tables
+```
+
+The public browser never receives either platform secret. The site validates and forwards multipart applications server-side. Platform routes independently validate every field and file.
+
+## Roles and authorization
+
+- **Applicant:** anonymous; can submit an application and later use a high-entropy candidate link for explicitly exposed actions such as booking or withdrawal.
+- **Hiring admin:** authenticated through Clerk and allowlisted by the site (`publicMetadata.role === "admin"` for the first release). All admin platform requests are server-to-server.
+- **Platform service:** validates a scoped ingest secret for submissions and a separate admin secret for recruiting operations.
+
+## Pipeline
+
+Canonical stages:
+
+1. `applied`
+2. `screening`
+3. `intro_call`
+4. `technical_interview`
+5. `founder_interview`
+6. `reference_check`
+7. `offer`
+8. `hired`
+
+Terminal/disposition states are represented separately: `active`, `rejected`, `withdrawn`, `archived`, and `deleted`. Stage changes require `baseRevision`; the `UPDATE` enforces the revision in its `WHERE` clause and increments it atomically. Every successful transition writes an activity event in the same transaction.
+
+## Data model
+
+- `ats_applications`: candidate identity, role, structured answers, links, source, stage, disposition, owner, tags, next action, consent, retention date, revision, timestamps, and bounded CV bytes/metadata.
+- `ats_application_events`: immutable audit log for submission, stage/disposition changes, assignment, interview, scorecard, task, and retention actions.
+- `ats_notes`: internal notes with author and timestamps.
+- `ats_scorecards`: structured interview recommendation, ratings, strengths, concerns, and interviewer.
+- `ats_interviews`: interview type, status, interviewer IDs, candidate booking token hash, provider URL, schedule, timezone, and meeting location.
+- `ats_tasks`: assignee, due date, status, and completion time.
+
+Normal list/detail reads exclude CV bytes. The CV download endpoint returns the file only after admin authorization. Soft-deleted records stay out of normal reads.
+
+## Application contract
+
+Required:
+
+- submission key (UUID; idempotency)
+- role slug matching an open role
+- full name
+- normalized email
+- location and availability
+- role-specific answers
+- consent to recruitment processing and retention policy
+- CV in PDF, DOC, or DOCX format
+
+Optional:
+
+- phone
+- LinkedIn, GitHub, portfolio, and other work links
+- referral/source
+
+Limits:
+
+- Multipart body: 6 MiB.
+- CV: 5 MiB.
+- Text fields and answer counts have explicit Zod bounds.
+- File names are sanitized and never used as storage paths.
+- Submission keys are unique and inserted with `ON CONFLICT DO NOTHING`; a retry returns the original receipt.
+
+## Admin capabilities
+
+- Dashboard counts and pipeline grouped by stage.
+- Search by candidate name/email and filter by role, stage, disposition, owner, or tag.
+- Candidate detail with structured answers, links, CV preview/download, notes, scorecards, interviews, tasks, and chronological activity.
+- Atomic stage/disposition transitions with conflict feedback.
+- Assignment, tags, next action, and due date.
+- Interview creation and candidate-specific booking URL.
+- Scorecard submission with an explicit recommendation; no automated decision score.
+- Candidate data export, withdrawal, archival, anonymization/deletion, and retention visibility.
+
+## Interview booking
+
+`ATS_BOOKING_BASE_URL` configures the calendar/provider booking page (for example Cal.com). Creating an interview generates a random token, stores only its SHA-256 hash, and returns a Matrix candidate URL. The public booking route resolves the token, records the access event, and redirects to the configured provider URL with only a non-sensitive interview identifier. Provider webhooks or an admin action can later record the scheduled start/end and meeting location.
+
+## Privacy and security
+
+- Candidate data is company recruiting data in platform PostgreSQL, not Matrix customer runtime data.
+- CVs and answers are never logged, sent to analytics, or returned in list endpoints.
+- Responses expose generic errors; server logs retain bounded operational context only.
+- Mutating Hono endpoints use `bodyLimit`; multipart parsing happens only after the limit middleware.
+- All admin operations authenticate before reading candidate existence.
+- No automated ranking or model-generated hiring decision is part of the launch scope.
+- Retention defaults to 365 days and remains visible/editable per candidate.
+- Delete/anonymize is transactional and preserves only a minimal non-identifying audit tombstone when legally needed.
+
+## Acceptance criteria
+
+- A candidate can submit each careers role with a CV and receives a non-enumerable receipt ID.
+- Retrying the same submission key creates exactly one application and one submission event.
+- Invalid roles, oversized bodies/files, unsafe MIME types, malformed URLs, missing consent, and unauthenticated calls fail closed.
+- Hiring admins can list/filter candidates and open a detail view without loading CV bytes.
+- Stage changes reject stale revisions and never write an event for a failed transition.
+- Notes, scorecards, interviews, tasks, tags, owners, and next actions persist and appear in activity history.
+- CV download requires admin authorization and returns safe content disposition headers.
+- The careers pages use the structured application flow instead of email.
+- Repository tests cover migrations, idempotency, transactions, authorization, validation, redaction, and core UI contracts.
+

--- a/specs/108-recruiting-ats/spec.md
+++ b/specs/108-recruiting-ats/spec.md
@@ -33,16 +33,16 @@ Email-only applications lose structured answers, duplicate follow-ups, stage his
 Applicant browser
   -> matrix-os-site /api/careers/apply
   -> platform /api/ats/applications (ATS_INGEST_SECRET)
-  -> PostgreSQL ATS tables
+  -> dedicated recruiting PostgreSQL (`ATS_DATABASE_URL`)
 
 Hiring admin browser
   -> Clerk-protected matrix-os-site /admin/ats
-  -> site server actions (ATS_ADMIN_SECRET / PLATFORM_SECRET)
+  -> site server actions (ATS_ADMIN_SECRET)
   -> platform /api/ats/admin/*
-  -> PostgreSQL ATS tables
+  -> dedicated recruiting PostgreSQL (`ATS_DATABASE_URL`)
 ```
 
-The public browser never receives either platform secret. The site validates and forwards multipart applications server-side. Platform routes independently validate every field and file.
+The public browser never receives either platform secret. The site validates and forwards multipart applications server-side. Platform routes independently validate every field and file. Recruiting uses a dedicated PostgreSQL/Neon database and never migrates ATS tables into `PLATFORM_DATABASE_URL`.
 
 ## Roles and authorization
 
@@ -120,7 +120,7 @@ Limits:
 
 ## Privacy and security
 
-- Candidate data is company recruiting data in platform PostgreSQL, not Matrix customer runtime data.
+- Candidate data is company recruiting data in the dedicated ATS PostgreSQL database, not the Matrix platform or customer runtime databases.
 - CVs and answers are never logged, sent to analytics, or returned in list endpoints.
 - Responses expose generic errors; server logs retain bounded operational context only.
 - Mutating Hono endpoints use `bodyLimit`; multipart parsing happens only after the limit middleware.
@@ -140,4 +140,3 @@ Limits:
 - CV download requires admin authorization and returns safe content disposition headers.
 - The careers pages use the structured application flow instead of email.
 - Repository tests cover migrations, idempotency, transactions, authorization, validation, redaction, and core UI contracts.
-

--- a/tests/platform/ats-database-isolation.test.ts
+++ b/tests/platform/ats-database-isolation.test.ts
@@ -1,0 +1,42 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { sql } from 'kysely';
+import {
+  AtsDatabaseConfigError,
+  resolveAtsDatabaseUrl,
+  type AtsDB,
+} from '../../packages/platform/src/ats-db.js';
+import type { PlatformDB } from '../../packages/platform/src/db.js';
+import { createTestAtsDb, destroyTestAtsDb } from './ats-db-test-helper.js';
+import { createTestPlatformDb, destroyTestPlatformDb } from './platform-db-test-helper.js';
+
+describe('ATS database isolation', () => {
+  let atsDb: AtsDB | undefined;
+  let platformDb: PlatformDB | undefined;
+
+  afterEach(async () => {
+    await Promise.all([destroyTestAtsDb(atsDb), destroyTestPlatformDb(platformDb)]);
+    atsDb = undefined;
+    platformDb = undefined;
+  });
+
+  it('migrates recruiting tables only in the dedicated ATS database', async () => {
+    ({ db: atsDb } = await createTestAtsDb());
+    ({ db: platformDb } = await createTestPlatformDb());
+
+    const atsTable = await sql<{ name: string | null }>`SELECT to_regclass('ats_applications')::text AS name`.execute(atsDb.kysely);
+    const platformTable = await sql<{ name: string | null }>`SELECT to_regclass('ats_applications')::text AS name`.execute(platformDb.kysely);
+
+    expect(atsTable.rows[0]?.name).toBe('ats_applications');
+    expect(platformTable.rows[0]?.name).toBeNull();
+  });
+
+  it('requires a dedicated database URL whenever ATS secrets enable recruiting', () => {
+    expect(() => resolveAtsDatabaseUrl({ ATS_INGEST_SECRET: 'configured' })).toThrow(AtsDatabaseConfigError);
+    expect(() => resolveAtsDatabaseUrl({ ATS_ADMIN_SECRET: 'configured' })).toThrow(AtsDatabaseConfigError);
+    expect(resolveAtsDatabaseUrl({})).toBeUndefined();
+    expect(resolveAtsDatabaseUrl({
+      ATS_INGEST_SECRET: 'configured',
+      ATS_DATABASE_URL: 'postgresql://ats.example/recruiting',
+    })).toBe('postgresql://ats.example/recruiting');
+  });
+});

--- a/tests/platform/ats-db-test-helper.ts
+++ b/tests/platform/ats-db-test-helper.ts
@@ -1,0 +1,13 @@
+import { KyselyPGlite } from 'kysely-pglite';
+import { createAtsDb, type AtsDB } from '../../packages/platform/src/ats-db.js';
+
+export async function createTestAtsDb(): Promise<{ db: AtsDB; instance: InstanceType<typeof KyselyPGlite> }> {
+  const instance = await KyselyPGlite.create();
+  const db = createAtsDb({ dialect: instance.dialect });
+  await db.ready;
+  return { db, instance };
+}
+
+export async function destroyTestAtsDb(db: AtsDB | undefined): Promise<void> {
+  await db?.destroy();
+}

--- a/tests/platform/ats-repository.test.ts
+++ b/tests/platform/ats-repository.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import {
+  AtsApplicationNotFoundError,
   AtsRevisionConflictError,
   addAtsNote,
   completeAtsTask,
@@ -100,6 +101,13 @@ describe('platform ATS repository', () => {
     expect([...resume!.bytes]).toEqual([0x25, 0x50, 0x44, 0x46]);
   });
 
+  it('searches candidate names case-insensitively', async () => {
+    await createAtsApplication(db, applicationInput(), NOW);
+
+    expect(await listAtsApplications(db, { search: 'ada' })).toHaveLength(1);
+    expect(await listAtsApplications(db, { search: 'LOVELACE' })).toHaveLength(1);
+  });
+
   it('enforces optimistic concurrency in the stage update and records one event', async () => {
     const { application } = await createAtsApplication(db, applicationInput(), NOW);
 
@@ -160,6 +168,18 @@ describe('platform ATS repository', () => {
       at: NOW,
     })).rejects.toBeInstanceOf(AtsRevisionConflictError);
     expect((await getAtsApplication(db, application.id))?.events[0]?.eventType).toBe('application_metadata_updated');
+  });
+
+  it('distinguishes a missing metadata target from a stale revision', async () => {
+    await expect(updateAtsApplicationMetadata(db, {
+      applicationId: '550e8400-e29b-41d4-a716-446655440099',
+      baseRevision: 1,
+      ownerId: null,
+      tags: [],
+      nextActionAt: null,
+      actorId: 'user_founder',
+      at: NOW,
+    })).rejects.toBeInstanceOf(AtsApplicationNotFoundError);
   });
 
   it('resolves a candidate booking token and records its first use once', async () => {

--- a/tests/platform/ats-repository.test.ts
+++ b/tests/platform/ats-repository.test.ts
@@ -1,0 +1,243 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  AtsRevisionConflictError,
+  addAtsNote,
+  completeAtsTask,
+  createAtsApplication,
+  createAtsInterview,
+  createAtsTask,
+  getAtsApplication,
+  getAtsApplicationResume,
+  listAtsApplications,
+  resolveAtsBooking,
+  transitionAtsApplication,
+  updateAtsApplicationMetadata,
+  upsertAtsScorecard,
+} from '../../packages/platform/src/ats-repository.js';
+import type { PlatformDB } from '../../packages/platform/src/db.js';
+import { createTestPlatformDb, destroyTestPlatformDb } from './platform-db-test-helper.js';
+
+const NOW = '2026-07-19T12:00:00.000Z';
+
+function applicationInput(overrides: Record<string, unknown> = {}) {
+  return {
+    submissionKey: '550e8400-e29b-41d4-a716-446655440000',
+    roleSlug: 'founding-engineer',
+    candidateName: 'Ada Lovelace',
+    candidateEmail: 'ADA@example.com',
+    phone: null,
+    location: 'London, UK',
+    availability: 'One month',
+    links: {
+      linkedin: 'https://www.linkedin.com/in/ada',
+      github: 'https://github.com/ada',
+    },
+    answers: [
+      { prompt: 'Why Matrix?', answer: 'Persistent computers for agents are inevitable.' },
+      { prompt: 'Hardest system?', answer: 'A distributed analytical engine.' },
+    ],
+    source: 'careers_page',
+    consentAt: NOW,
+    retentionUntil: '2027-07-19T12:00:00.000Z',
+    resume: {
+      filename: 'ada-resume.pdf',
+      contentType: 'application/pdf',
+      bytes: new Uint8Array([0x25, 0x50, 0x44, 0x46]),
+    },
+    ...overrides,
+  };
+}
+
+describe('platform ATS repository', () => {
+  let db: PlatformDB;
+
+  beforeEach(async () => {
+    ({ db } = await createTestPlatformDb());
+  });
+
+  afterEach(async () => {
+    await destroyTestPlatformDb(db);
+  });
+
+  it('creates an application and submission event atomically', async () => {
+    const result = await createAtsApplication(db, applicationInput(), NOW);
+
+    expect(result.created).toBe(true);
+    expect(result.application).toMatchObject({
+      candidateName: 'Ada Lovelace',
+      candidateEmail: 'ada@example.com',
+      roleSlug: 'founding-engineer',
+      stage: 'applied',
+      disposition: 'active',
+      revision: 1,
+    });
+
+    const detail = await getAtsApplication(db, result.application.id);
+    expect(detail?.events).toHaveLength(1);
+    expect(detail?.events[0]?.eventType).toBe('application_submitted');
+  });
+
+  it('is idempotent by submission key without duplicating events', async () => {
+    const first = await createAtsApplication(db, applicationInput(), NOW);
+    const second = await createAtsApplication(db, applicationInput(), NOW);
+
+    expect(first.created).toBe(true);
+    expect(second.created).toBe(false);
+    expect(second.application.id).toBe(first.application.id);
+    expect((await getAtsApplication(db, first.application.id))?.events).toHaveLength(1);
+  });
+
+  it('keeps resume bytes out of list and detail reads', async () => {
+    const { application } = await createAtsApplication(db, applicationInput(), NOW);
+
+    const [summary] = await listAtsApplications(db, {});
+    const detail = await getAtsApplication(db, application.id);
+    expect(summary).not.toHaveProperty('resumeBytes');
+    expect(detail).not.toHaveProperty('resumeBytes');
+
+    const resume = await getAtsApplicationResume(db, application.id);
+    expect(resume?.filename).toBe('ada-resume.pdf');
+    expect([...resume!.bytes]).toEqual([0x25, 0x50, 0x44, 0x46]);
+  });
+
+  it('enforces optimistic concurrency in the stage update and records one event', async () => {
+    const { application } = await createAtsApplication(db, applicationInput(), NOW);
+
+    const updated = await transitionAtsApplication(db, {
+      applicationId: application.id,
+      baseRevision: 1,
+      stage: 'screening',
+      disposition: 'active',
+      actorId: 'user_founder',
+      reason: null,
+      at: '2026-07-19T13:00:00.000Z',
+    });
+    expect(updated).toMatchObject({ stage: 'screening', revision: 2 });
+
+    await expect(transitionAtsApplication(db, {
+      applicationId: application.id,
+      baseRevision: 1,
+      stage: 'intro_call',
+      disposition: 'active',
+      actorId: 'user_founder',
+      reason: null,
+      at: '2026-07-19T14:00:00.000Z',
+    })).rejects.toBeInstanceOf(AtsRevisionConflictError);
+
+    const detail = await getAtsApplication(db, application.id);
+    expect(detail?.events.map((event) => event.eventType)).toEqual([
+      'stage_changed',
+      'application_submitted',
+    ]);
+  });
+
+  it('updates CRM ownership, tags, and next action with optimistic concurrency', async () => {
+    const { application } = await createAtsApplication(db, applicationInput(), NOW);
+
+    const updated = await updateAtsApplicationMetadata(db, {
+      applicationId: application.id,
+      baseRevision: 1,
+      ownerId: 'user_founder',
+      tags: ['systems', 'high-priority'],
+      nextActionAt: '2026-07-21T09:00:00.000Z',
+      actorId: 'user_founder',
+      at: '2026-07-19T13:00:00.000Z',
+    });
+
+    expect(updated).toMatchObject({
+      ownerId: 'user_founder',
+      tags: ['systems', 'high-priority'],
+      nextActionAt: '2026-07-21T09:00:00.000Z',
+      revision: 2,
+    });
+    await expect(updateAtsApplicationMetadata(db, {
+      applicationId: application.id,
+      baseRevision: 1,
+      ownerId: null,
+      tags: [],
+      nextActionAt: null,
+      actorId: 'user_founder',
+      at: NOW,
+    })).rejects.toBeInstanceOf(AtsRevisionConflictError);
+    expect((await getAtsApplication(db, application.id))?.events[0]?.eventType).toBe('application_metadata_updated');
+  });
+
+  it('resolves a candidate booking token and records its first use once', async () => {
+    const { application } = await createAtsApplication(db, applicationInput(), NOW);
+    await createAtsInterview(db, {
+      applicationId: application.id,
+      interviewType: 'intro_call',
+      interviewerIds: ['user_founder'],
+      bookingTokenHash: 'b'.repeat(64),
+      bookingUrl: 'https://cal.com/matrix/intro',
+      actorId: 'user_founder',
+      at: NOW,
+    });
+
+    expect(await resolveAtsBooking(db, 'b'.repeat(64), '2026-07-19T13:00:00.000Z')).toBe('https://cal.com/matrix/intro');
+    expect(await resolveAtsBooking(db, 'b'.repeat(64), '2026-07-19T14:00:00.000Z')).toBe('https://cal.com/matrix/intro');
+    expect(await resolveAtsBooking(db, 'c'.repeat(64), NOW)).toBeUndefined();
+
+    const detail = await getAtsApplication(db, application.id);
+    expect(detail?.interviews[0]?.status).toBe('booking_opened');
+    expect(detail?.events.filter((event) => event.eventType === 'booking_link_opened')).toHaveLength(1);
+  });
+
+  it('persists notes, scorecards, interviews, and tasks in candidate detail', async () => {
+    const { application } = await createAtsApplication(db, applicationInput(), NOW);
+    await addAtsNote(db, {
+      applicationId: application.id,
+      authorId: 'user_founder',
+      body: 'Strong systems judgment.',
+      at: NOW,
+    });
+    await upsertAtsScorecard(db, {
+      applicationId: application.id,
+      interviewerId: 'user_founder',
+      interviewType: 'technical_interview',
+      recommendation: 'strong_yes',
+      ratings: { systems: 5, product: 4, collaboration: 5 },
+      strengths: 'Excellent architecture and debugging depth.',
+      concerns: null,
+      at: NOW,
+    });
+    const interview = await createAtsInterview(db, {
+      applicationId: application.id,
+      interviewType: 'intro_call',
+      interviewerIds: ['user_founder'],
+      bookingTokenHash: 'a'.repeat(64),
+      bookingUrl: 'https://cal.com/matrix/intro',
+      actorId: 'user_founder',
+      at: NOW,
+    });
+    expect(interview.status).toBe('awaiting_booking');
+    const task = await createAtsTask(db, {
+      applicationId: application.id,
+      title: 'Review GitHub projects',
+      assigneeId: 'user_founder',
+      dueAt: '2026-07-20T12:00:00.000Z',
+      actorId: 'user_founder',
+      at: NOW,
+    });
+    await completeAtsTask(db, {
+      applicationId: application.id,
+      taskId: task.id,
+      actorId: 'user_founder',
+      at: '2026-07-20T10:00:00.000Z',
+    });
+
+    const detail = await getAtsApplication(db, application.id);
+    expect(detail?.notes[0]?.body).toBe('Strong systems judgment.');
+    expect(detail?.scorecards[0]?.recommendation).toBe('strong_yes');
+    expect(detail?.interviews[0]?.bookingUrl).toBe('https://cal.com/matrix/intro');
+    expect(detail?.tasks[0]?.status).toBe('completed');
+    expect(detail?.events.map((event) => event.eventType)).toEqual(expect.arrayContaining([
+      'task_completed',
+      'task_created',
+      'interview_created',
+      'scorecard_submitted',
+      'note_added',
+      'application_submitted',
+    ]));
+  });
+});

--- a/tests/platform/ats-repository.test.ts
+++ b/tests/platform/ats-repository.test.ts
@@ -14,8 +14,8 @@ import {
   updateAtsApplicationMetadata,
   upsertAtsScorecard,
 } from '../../packages/platform/src/ats-repository.js';
-import type { PlatformDB } from '../../packages/platform/src/db.js';
-import { createTestPlatformDb, destroyTestPlatformDb } from './platform-db-test-helper.js';
+import type { AtsDB } from '../../packages/platform/src/ats-db.js';
+import { createTestAtsDb, destroyTestAtsDb } from './ats-db-test-helper.js';
 
 const NOW = '2026-07-19T12:00:00.000Z';
 
@@ -49,14 +49,14 @@ function applicationInput(overrides: Record<string, unknown> = {}) {
 }
 
 describe('platform ATS repository', () => {
-  let db: PlatformDB;
+  let db: AtsDB;
 
   beforeEach(async () => {
-    ({ db } = await createTestPlatformDb());
+    ({ db } = await createTestAtsDb());
   });
 
   afterEach(async () => {
-    await destroyTestPlatformDb(db);
+    await destroyTestAtsDb(db);
   });
 
   it('creates an application and submission event atomically', async () => {

--- a/tests/platform/ats-routes.test.ts
+++ b/tests/platform/ats-routes.test.ts
@@ -1,0 +1,154 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { createAtsRoutes } from '../../packages/platform/src/ats-routes.js';
+import type { PlatformDB } from '../../packages/platform/src/db.js';
+import { createTestPlatformDb, destroyTestPlatformDb } from './platform-db-test-helper.js';
+
+const INGEST_SECRET = 'test-ingest-secret';
+const ADMIN_SECRET = 'test-admin-secret';
+
+function validApplicationForm() {
+  const form = new FormData();
+  form.set('submissionKey', '550e8400-e29b-41d4-a716-446655440000');
+  form.set('roleSlug', 'founding-engineer');
+  form.set('candidateName', 'Ada Lovelace');
+  form.set('candidateEmail', 'ada@example.com');
+  form.set('location', 'London, UK');
+  form.set('availability', 'One month');
+  form.set('links', JSON.stringify({ github: 'https://github.com/ada' }));
+  form.set('answers', JSON.stringify([{ prompt: 'Why Matrix?', answer: 'Agents need computers.' }]));
+  form.set('source', 'careers_page');
+  form.set('consent', 'true');
+  form.set('resume', new File(['%PDF'], 'ada.pdf', { type: 'application/pdf' }));
+  return form;
+}
+
+describe('platform ATS routes', () => {
+  let db: PlatformDB;
+
+  beforeEach(async () => {
+    ({ db } = await createTestPlatformDb());
+  });
+
+  afterEach(async () => {
+    await destroyTestPlatformDb(db);
+  });
+
+  function routes(overrides: Partial<Parameters<typeof createAtsRoutes>[0]> = {}) {
+    return createAtsRoutes({
+      db,
+      ingestSecret: INGEST_SECRET,
+      adminSecret: ADMIN_SECRET,
+      allowedRoleSlugs: ['founders-associate-gtm-operations', 'founding-engineer'],
+      bookingBaseUrl: 'https://cal.com/matrix',
+      now: () => new Date('2026-07-19T12:00:00.000Z'),
+      ...overrides,
+    });
+  }
+
+  it('fails closed when application ingest is not configured', async () => {
+    const res = await routes({ ingestSecret: '' }).request('/api/ats/applications', {
+      method: 'POST',
+      body: validApplicationForm(),
+    });
+    expect(res.status).toBe(503);
+  });
+
+  it('rejects an unauthenticated application submission', async () => {
+    const res = await routes().request('/api/ats/applications', {
+      method: 'POST',
+      body: validApplicationForm(),
+    });
+    expect(res.status).toBe(401);
+  });
+
+  it('accepts a valid application and returns an opaque receipt', async () => {
+    const res = await routes().request('/api/ats/applications', {
+      method: 'POST',
+      headers: { authorization: `Bearer ${INGEST_SECRET}` },
+      body: validApplicationForm(),
+    });
+    expect(res.status).toBe(201);
+    const body = await res.json() as { receiptId: string };
+    expect(body.receiptId).toMatch(/^[0-9a-f-]{36}$/);
+  });
+
+  it('rejects invalid roles, missing consent, and unsafe resume types', async () => {
+    const invalid = validApplicationForm();
+    invalid.set('roleSlug', 'chief-vibes-officer');
+    invalid.set('consent', 'false');
+    invalid.set('resume', new File(['hello'], 'resume.html', { type: 'text/html' }));
+    const res = await routes().request('/api/ats/applications', {
+      method: 'POST',
+      headers: { authorization: `Bearer ${INGEST_SECRET}` },
+      body: invalid,
+    });
+    expect(res.status).toBe(422);
+    expect(await res.json()).toEqual({ error: 'Invalid application' });
+  });
+
+  it('keeps candidate lists and CV downloads behind the admin secret', async () => {
+    const submitted = await routes().request('/api/ats/applications', {
+      method: 'POST',
+      headers: { authorization: `Bearer ${INGEST_SECRET}` },
+      body: validApplicationForm(),
+    });
+    const { receiptId } = await submitted.json() as { receiptId: string };
+
+    expect((await routes().request('/api/ats/admin/applications')).status).toBe(401);
+    const list = await routes().request('/api/ats/admin/applications', {
+      headers: { authorization: `Bearer ${ADMIN_SECRET}` },
+    });
+    expect(list.status).toBe(200);
+    const listBody = await list.json() as { applications: Array<Record<string, unknown>> };
+    expect(listBody.applications).toHaveLength(1);
+    expect(listBody.applications[0]).not.toHaveProperty('resumeBytes');
+
+    const cv = await routes().request(`/api/ats/admin/applications/${receiptId}/resume`, {
+      headers: { authorization: `Bearer ${ADMIN_SECRET}` },
+    });
+    expect(cv.status).toBe(200);
+    expect(cv.headers.get('content-type')).toBe('application/pdf');
+    expect(cv.headers.get('content-disposition')).toContain('attachment;');
+    expect(await cv.text()).toBe('%PDF');
+  });
+
+  it('updates candidate CRM metadata behind admin auth', async () => {
+    const submitted = await routes().request('/api/ats/applications', {
+      method: 'POST', headers: { authorization: `Bearer ${INGEST_SECRET}` }, body: validApplicationForm(),
+    });
+    const { receiptId } = await submitted.json() as { receiptId: string };
+    const response = await routes().request(`/api/ats/admin/applications/${receiptId}`, {
+      method: 'PATCH',
+      headers: { authorization: `Bearer ${ADMIN_SECRET}`, 'content-type': 'application/json', 'x-ats-actor-id': 'user_founder' },
+      body: JSON.stringify({
+        baseRevision: 1,
+        ownerId: 'user_founder',
+        tags: ['systems', 'high-priority'],
+        nextActionAt: '2026-07-21T09:00:00.000Z',
+      }),
+    });
+    expect(response.status).toBe(200);
+    expect((await response.json() as { application: Record<string, unknown> }).application).toMatchObject({
+      ownerId: 'user_founder', tags: ['systems', 'high-priority'], revision: 2,
+    });
+  });
+
+  it('redirects a valid candidate booking token without exposing the provider URL in ATS records', async () => {
+    const submitted = await routes().request('/api/ats/applications', {
+      method: 'POST', headers: { authorization: `Bearer ${INGEST_SECRET}` }, body: validApplicationForm(),
+    });
+    const { receiptId } = await submitted.json() as { receiptId: string };
+    const created = await routes({ publicSiteUrl: 'https://matrix-os.com' }).request(`/api/ats/admin/applications/${receiptId}/interviews`, {
+      method: 'POST',
+      headers: { authorization: `Bearer ${ADMIN_SECRET}`, 'content-type': 'application/json' },
+      body: JSON.stringify({ interviewType: 'intro_call', interviewerIds: ['user_founder'] }),
+    });
+    const body = await created.json() as { candidateBookingUrl: string };
+    const token = new URL(body.candidateBookingUrl).pathname.split('/').at(-1)!;
+
+    const booking = await routes().request(`/api/ats/booking/${token}`);
+    expect(booking.status).toBe(302);
+    expect(booking.headers.get('location')).toMatch(/^https:\/\/cal\.com\/matrix/);
+    expect((await routes().request('/api/ats/booking/not-a-token')).status).toBe(404);
+  });
+});

--- a/tests/platform/ats-routes.test.ts
+++ b/tests/platform/ats-routes.test.ts
@@ -86,6 +86,19 @@ describe('platform ATS routes', () => {
     expect(await res.json()).toEqual({ error: 'Invalid application' });
   });
 
+  it('returns a validation error for malformed application JSON fields', async () => {
+    const invalid = validApplicationForm();
+    invalid.set('links', '{not-json');
+    const res = await routes().request('/api/ats/applications', {
+      method: 'POST',
+      headers: { authorization: `Bearer ${INGEST_SECRET}` },
+      body: invalid,
+    });
+
+    expect(res.status).toBe(422);
+    expect(await res.json()).toEqual({ error: 'Invalid application' });
+  });
+
   it('keeps candidate lists and CV downloads behind the admin secret', async () => {
     const submitted = await routes().request('/api/ats/applications', {
       method: 'POST',

--- a/tests/platform/ats-routes.test.ts
+++ b/tests/platform/ats-routes.test.ts
@@ -133,6 +133,42 @@ describe('platform ATS routes', () => {
     });
   });
 
+  it('returns controlled not-found responses for missing admin mutation targets', async () => {
+    const missingApplicationId = '550e8400-e29b-41d4-a716-446655440099';
+    const missingTaskId = '550e8400-e29b-41d4-a716-446655440098';
+    const headers = {
+      authorization: `Bearer ${ADMIN_SECRET}`,
+      'content-type': 'application/json',
+    };
+    const requests = [
+      routes().request(`/api/ats/admin/applications/${missingApplicationId}`, {
+        method: 'PATCH', headers, body: JSON.stringify({ baseRevision: 1, ownerId: null, tags: [], nextActionAt: null }),
+      }),
+      routes().request(`/api/ats/admin/applications/${missingApplicationId}/notes`, {
+        method: 'POST', headers, body: JSON.stringify({ body: 'Review note' }),
+      }),
+      routes().request(`/api/ats/admin/applications/${missingApplicationId}/scorecards`, {
+        method: 'PUT', headers, body: JSON.stringify({
+          interviewType: 'technical', recommendation: 'yes', ratings: { systems: 5 }, strengths: 'Strong', concerns: null,
+        }),
+      }),
+      routes().request(`/api/ats/admin/applications/${missingApplicationId}/interviews`, {
+        method: 'POST', headers, body: JSON.stringify({ interviewType: 'intro', interviewerIds: ['user_founder'] }),
+      }),
+      routes().request(`/api/ats/admin/applications/${missingApplicationId}/tasks`, {
+        method: 'POST', headers, body: JSON.stringify({ title: 'Review', assigneeId: null, dueAt: null }),
+      }),
+      routes().request(`/api/ats/admin/applications/${missingApplicationId}/tasks/${missingTaskId}/complete`, {
+        method: 'POST', headers,
+      }),
+    ];
+
+    for (const response of await Promise.all(requests)) {
+      expect(response.status).toBe(404);
+      expect(await response.json()).toEqual({ error: 'Not found' });
+    }
+  });
+
   it('redirects a valid candidate booking token without exposing the provider URL in ATS records', async () => {
     const submitted = await routes().request('/api/ats/applications', {
       method: 'POST', headers: { authorization: `Bearer ${INGEST_SECRET}` }, body: validApplicationForm(),

--- a/tests/platform/ats-routes.test.ts
+++ b/tests/platform/ats-routes.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { createAtsRoutes } from '../../packages/platform/src/ats-routes.js';
-import type { PlatformDB } from '../../packages/platform/src/db.js';
-import { createTestPlatformDb, destroyTestPlatformDb } from './platform-db-test-helper.js';
+import type { AtsDB } from '../../packages/platform/src/ats-db.js';
+import { createTestAtsDb, destroyTestAtsDb } from './ats-db-test-helper.js';
 
 const INGEST_SECRET = 'test-ingest-secret';
 const ADMIN_SECRET = 'test-admin-secret';
@@ -23,14 +23,14 @@ function validApplicationForm() {
 }
 
 describe('platform ATS routes', () => {
-  let db: PlatformDB;
+  let db: AtsDB;
 
   beforeEach(async () => {
-    ({ db } = await createTestPlatformDb());
+    ({ db } = await createTestAtsDb());
   });
 
   afterEach(async () => {
-    await destroyTestPlatformDb(db);
+    await destroyTestAtsDb(db);
   });
 
   function routes(overrides: Partial<Parameters<typeof createAtsRoutes>[0]> = {}) {


### PR DESCRIPTION
## Summary

Adds a first-party recruiting ATS with idempotent applications, bounded private CV storage, pipeline/dispositions, optimistic revisions, ownership/tags/next actions, notes, scorecards, tasks, secure interview booking tokens, CV downloads, and immutable activity events.

Recruiting data is isolated in a dedicated PostgreSQL database. `ATS_DATABASE_URL` is required whenever ATS secrets enable the service; no ATS tables are migrated into `PLATFORM_DATABASE_URL`. Ingest and administration use separate scoped secrets, with no fallback to the platform-wide secret.

## Verification

- 19 focused ATS route, repository, and database-isolation tests
- Platform TypeScript check
- Full repository pattern scan: 0 violations (existing warnings only)
- `git diff --check`

## Invariants

### Source of truth
- The dedicated database at `ATS_DATABASE_URL` is the sole source of truth for applications, CV bytes, pipeline state, notes, scorecards, interviews, tasks, and audit events.
- The careers site and browser never connect to Postgres directly; they use the platform ATS API.

### Lock/transaction scope
- Application creation plus its audit event, pipeline/metadata updates plus their audit events, and all related ATS entity writes plus their audit events execute in one database transaction.
- Optimistic application updates enforce `revision = baseRevision` in the write statement.
- No external network call is held inside an ATS transaction.

### Acceptable orphan states
- Application submission is idempotent on `submission_key`; retries do not duplicate applications or events.
- Interview records contain a booking URL but no external provider object is created by this change, so there is no provider/DB split-brain state.
- If the dedicated database is unavailable or misconfigured, routes fail closed with generic errors and the platform does not fall back to the production Matrix database.

### Auth source of truth
- Application intake requires `ATS_INGEST_SECRET`.
- ATS administration requires the separate `ATS_ADMIN_SECRET`.
- Both are server-to-server bearer checks using constant-time comparison; empty secrets fail closed.
- Browser admin authorization remains the careers site's Clerk `publicMetadata.role === "admin"` gate.

### Deferred scope
- Automated retention deletion, calendar-provider webhooks, email delivery, and fine-grained recruiter roles are not included in this first ATS release.
