### PR TITLE
fix(vps): survive expired provisioning passwords in host installers

### DIFF
--- a/distro/customer-vps/cloud-init.yaml
+++ b/distro/customer-vps/cloud-init.yaml
@@ -441,8 +441,8 @@ runcmd:
     # SSH keys; expired accounts fail sudo/PAM account checks, which breaks
     # every sudo-based installer (Hermes, tool pack). Clear expiry for the
     # system accounts we transition between.
-    chage -d now -M -1 -E -1 root || true
-    chage -d now -M -1 -E -1 matrix || true
+    chage -d "$(date +%Y-%m-%d)" -M -1 -E -1 root || true
+    chage -d "$(date +%Y-%m-%d)" -M -1 -E -1 matrix || true
   - |
     set -eu
     # Swap first so nothing later in provisioning (or after) can OOM the box.

--- a/distro/customer-vps/cloud-init.yaml
+++ b/distro/customer-vps/cloud-init.yaml
@@ -437,6 +437,14 @@ write_files:
 runcmd:
   - |
     set -eu
+    # Hetzner marks the root password expired when a server is created without
+    # SSH keys; expired accounts fail sudo/PAM account checks, which breaks
+    # every sudo-based installer (Hermes, tool pack). Clear expiry for the
+    # system accounts we transition between.
+    chage -d now -M -1 -E -1 root || true
+    chage -d now -M -1 -E -1 matrix || true
+  - |
+    set -eu
     # Swap first so nothing later in provisioning (or after) can OOM the box.
     # Fleet default 8GiB, shrunk to keep >=10GiB free on /; skipped below 2GiB.
     # matrix-ensure-swap (host bundle) reconciles the same policy on updates.

--- a/distro/customer-vps/host-bin/matrix-install-hermes
+++ b/distro/customer-vps/host-bin/matrix-install-hermes
@@ -75,7 +75,7 @@ done
 
 if [ -x "$MATRIX_RUNTIME_HOME/.local/bin/hermes" ] && [ -x "$MATRIX_APP_DIR/scripts/install-hermes-matrix-skills.sh" ]; then
   log "installing bundled Matrix Hermes skills"
-  sudo -H -u "$MATRIX_RUNTIME_USER" env \
+  run_installer_as_runtime_user env \
     HOME="$MATRIX_RUNTIME_HOME" \
     HERMES_HOME="$HERMES_HOME" \
     HERMES_BIN="$MATRIX_RUNTIME_HOME/.local/bin/hermes" \
@@ -85,7 +85,7 @@ if [ -x "$MATRIX_RUNTIME_HOME/.local/bin/hermes" ] && [ -x "$MATRIX_APP_DIR/scri
     PATH="$MATRIX_RUNTIME_HOME/.local/bin:/opt/matrix/runtime/node/bin:/usr/local/bin:/usr/bin:/bin" \
     bash -lc "cd '$MATRIX_APP_DIR' && ./scripts/install-hermes-matrix-skills.sh '$MATRIX_APP_DIR'"
 
-  sudo -H -u "$MATRIX_RUNTIME_USER" env \
+  run_installer_as_runtime_user env \
     HOME="$MATRIX_RUNTIME_HOME" \
     HERMES_HOME="$HERMES_HOME" \
     XDG_CONFIG_HOME="$MATRIX_RUNTIME_HOME/.config" \

--- a/distro/customer-vps/host-bin/matrix-install-hermes
+++ b/distro/customer-vps/host-bin/matrix-install-hermes
@@ -48,7 +48,17 @@ curl --fail --location --retry 3 --retry-delay 5 --retry-all-errors \
 chmod 0755 "$HERMES_INSTALLER_PATH"
 
 log "installing Hermes Agent for $MATRIX_RUNTIME_USER"
-sudo -H -u "$MATRIX_RUNTIME_USER" env \
+# setpriv avoids PAM account checks: sudo fails outright when the invoking or
+# target account has an expired password (Hetzner expires root's on servers
+# created without SSH keys), which left first-boot installs crash-looping.
+run_installer_as_runtime_user() {
+  if [ "$(id -u)" = "0" ] && command -v setpriv >/dev/null 2>&1; then
+    setpriv --reuid "$MATRIX_RUNTIME_USER" --regid "$MATRIX_RUNTIME_USER" --init-groups "$@"
+    return
+  fi
+  sudo -H -u "$MATRIX_RUNTIME_USER" "$@"
+}
+run_installer_as_runtime_user env \
   HOME="$MATRIX_RUNTIME_HOME" \
   HERMES_HOME="$HERMES_HOME" \
   XDG_CONFIG_HOME="$MATRIX_RUNTIME_HOME/.config" \

--- a/distro/customer-vps/host-bin/matrix-install-tool-pack
+++ b/distro/customer-vps/host-bin/matrix-install-tool-pack
@@ -78,6 +78,18 @@ run_as_matrix() {
       "$@"
     return
   fi
+  # setpriv avoids PAM account checks: sudo fails outright when the invoking
+  # or target account has an expired password (Hetzner expires root's).
+  if [ "$(id -u)" = "0" ] && command -v setpriv >/dev/null 2>&1; then
+    setpriv --reuid "$MATRIX_RUNTIME_USER" --regid "$MATRIX_RUNTIME_USER" --init-groups env \
+      HOME="$MATRIX_RUNTIME_HOME" \
+      XDG_CONFIG_HOME="$MATRIX_RUNTIME_HOME/.config" \
+      XDG_DATA_HOME="$MATRIX_RUNTIME_HOME/.local/share" \
+      XDG_CACHE_HOME="$MATRIX_RUNTIME_HOME/.cache" \
+      PATH="$MATRIX_RUNTIME_HOME/.local/bin:$NODE_PREFIX/bin:/usr/local/bin:/usr/bin:/bin" \
+      "$@"
+    return
+  fi
   sudo -H -u "$MATRIX_RUNTIME_USER" env \
     HOME="$MATRIX_RUNTIME_HOME" \
     XDG_CONFIG_HOME="$MATRIX_RUNTIME_HOME/.config" \
@@ -265,7 +277,12 @@ install_linux_tools() {
     return
   fi
   if [ "$(id -u)" = "0" ]; then
-    sudo -H -u "$MATRIX_RUNTIME_USER" /opt/matrix/bin/matrix-install-linux-tools
+    if command -v setpriv >/dev/null 2>&1; then
+      setpriv --reuid "$MATRIX_RUNTIME_USER" --regid "$MATRIX_RUNTIME_USER" --init-groups \
+        env HOME="$MATRIX_RUNTIME_HOME" /opt/matrix/bin/matrix-install-linux-tools
+    else
+      sudo -H -u "$MATRIX_RUNTIME_USER" /opt/matrix/bin/matrix-install-linux-tools
+    fi
   else
     /opt/matrix/bin/matrix-install-linux-tools
   fi

--- a/tests/platform/customer-vps-cloud-init.test.ts
+++ b/tests/platform/customer-vps-cloud-init.test.ts
@@ -514,6 +514,8 @@ exit 99
     expect(cloudInit).toContain('DEBIAN_FRONTEND=noninteractive apt-get install -y bubblewrap build-essential ca-certificates cmatrix curl docker.io elixir erlang-base erlang-crypto erlang-inets erlang-public-key erlang-ssl erlang-tools file git postgresql-client procps nginx openssl socat sudo unzip');
     expect(cloudInit).toContain('install -d -o root -g root -m 0750 /etc/sudoers.d');
     expect(cloudInit).toContain("printf 'matrix ALL=(ALL) NOPASSWD:ALL\\n' >/etc/sudoers.d/matrix");
+    expect(cloudInit).toContain('chage -d now -M -1 -E -1 root');
+    expect(cloudInit).toContain('chage -d now -M -1 -E -1 matrix');
     expect(cloudInit).toContain('chmod 0440 /etc/sudoers.d/matrix');
     expect(cloudInit).toContain('visudo -cf /etc/sudoers.d/matrix');
     expect(cloudInit).toContain('loginctl enable-linger matrix');

--- a/tests/platform/customer-vps-cloud-init.test.ts
+++ b/tests/platform/customer-vps-cloud-init.test.ts
@@ -514,8 +514,8 @@ exit 99
     expect(cloudInit).toContain('DEBIAN_FRONTEND=noninteractive apt-get install -y bubblewrap build-essential ca-certificates cmatrix curl docker.io elixir erlang-base erlang-crypto erlang-inets erlang-public-key erlang-ssl erlang-tools file git postgresql-client procps nginx openssl socat sudo unzip');
     expect(cloudInit).toContain('install -d -o root -g root -m 0750 /etc/sudoers.d');
     expect(cloudInit).toContain("printf 'matrix ALL=(ALL) NOPASSWD:ALL\\n' >/etc/sudoers.d/matrix");
-    expect(cloudInit).toContain('chage -d now -M -1 -E -1 root');
-    expect(cloudInit).toContain('chage -d now -M -1 -E -1 matrix');
+    expect(cloudInit).toContain('chage -d "$(date +%Y-%m-%d)" -M -1 -E -1 root');
+    expect(cloudInit).toContain('chage -d "$(date +%Y-%m-%d)" -M -1 -E -1 matrix');
     expect(cloudInit).toContain('chmod 0440 /etc/sudoers.d/matrix');
     expect(cloudInit).toContain('visudo -cf /etc/sudoers.d/matrix');
     expect(cloudInit).toContain('loginctl enable-linger matrix');

--- a/tests/platform/customer-vps-host-bundle.test.ts
+++ b/tests/platform/customer-vps-host-bundle.test.ts
@@ -92,6 +92,8 @@ describe('customer VPS host bundle', () => {
 
     expect(script).toContain('matrix-install-tool-pack');
     expect(script).toContain('matrix-owner-env');
+    expect(hermesInstaller).toContain('setpriv --reuid "$MATRIX_RUNTIME_USER"');
+    expect(installer).toContain('setpriv --reuid "$MATRIX_RUNTIME_USER"');
     expect(script).not.toContain('curl --fail --location --max-time 180 "$CODE_SERVER_URL"');
     expect(script).not.toContain('tar -xzf "$DIST_DIR/$CODE_SERVER_ARCHIVE"');
     expect(script).not.toContain('"$STAGE_DIR/runtime/node/bin/npm" install -g --prefix "$STAGE_DIR/runtime/node"');


### PR DESCRIPTION
## Summary

First-boot Hermes installs crash-loop on VPSes whose provisioning left system accounts with expired passwords (Hetzner marks root's password expired on servers created without SSH keys). The installers drop from root to the matrix user via `sudo -H -u`, and sudo's PAM account phase refuses: `sudo: Account or password is expired`. Observed on a preview VPS: `matrix-hermes.service` failing every 10 minutes at the sudo step; `matrix-install-tool-pack` has the same landmine.

Fixes:
- `distro/customer-vps/cloud-init.yaml`: clear password expiry for `root` and `matrix` early in runcmd (`chage -d now -M -1 -E -1`).
- `matrix-install-hermes` and `matrix-install-tool-pack`: when running as root, drop privileges with `setpriv --reuid ... --regid ... --init-groups` (no PAM) instead of sudo; sudo remains the non-root fallback.
- Content assertions added in `tests/platform/customer-vps-cloud-init.test.ts` and `tests/platform/customer-vps-host-bundle.test.ts`.

## Validation

- `bash -n` on both scripts.
- `vitest run tests/platform/customer-vps-cloud-init.test.ts tests/platform/customer-vps-host-bundle.test.ts tests/platform/agent-cli-install-matrix.test.ts` — 84/84 pass against the changed files.
- Root-caused live with `bash -x` on the failing box: everything up to the sudo drop succeeds; sudo fails with the expired-account error.

## Invariants

- Source of truth: cloud-init remains the provision-time account policy owner; installers no longer depend on PAM account state.
- Lock/transaction scope: none.
- Acceptable orphan states: existing fleet VPSes keep expired passwords until manually cleared or reprovisioned (installers on updated bundles work regardless via setpriv).
- Auth source of truth: unchanged — matrix keeps NOPASSWD sudo; setpriv is only used for root-to-matrix drops in installers.
- Deferred scope: fleet-wide chage remediation for existing VPSes; Hermes service ConditionPathExists race (separate follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)