### PR TITLE
feat(platform): expose golden snapshot build controls

### DIFF
--- a/packages/platform/src/golden-snapshot-routes.ts
+++ b/packages/platform/src/golden-snapshot-routes.ts
@@ -1,0 +1,149 @@
+import { randomUUID } from 'node:crypto';
+import { Hono } from 'hono';
+import { bodyLimit } from 'hono/body-limit';
+import { z } from 'zod/v4';
+import type { PlatformDB } from './db.js';
+import { bearerTokenMatches } from './customer-vps-auth.js';
+import {
+  enqueueGoldenSnapshotBuild,
+  GoldenSnapshotBuildRequiresRetryError,
+  getGoldenSnapshot,
+  getGoldenSnapshotBuild,
+} from './golden-snapshot-repository.js';
+import type { GoldenSnapshotRuntimeConfig } from './golden-snapshot-schema.js';
+import { GoldenSnapshotBundleVersionSchema } from './golden-snapshot-schema.js';
+import {
+  GoldenSnapshotCallbackSchema,
+  GoldenSnapshotCallbackError,
+  type GoldenSnapshotService,
+} from './golden-snapshot-service.js';
+
+const SNAPSHOT_ENQUEUE_BODY_LIMIT = 8 * 1024;
+const SNAPSHOT_CALLBACK_BODY_LIMIT = 64 * 1024;
+const BuildIdSchema = z.string().uuid();
+const EnqueueSchema = z.object({
+  bundleVersion: GoldenSnapshotBundleVersionSchema,
+  testMode: z.boolean().optional().default(false),
+}).strict();
+
+export interface GoldenSnapshotRoutesDeps {
+  db: PlatformDB;
+  service: GoldenSnapshotService;
+  config: GoldenSnapshotRuntimeConfig;
+  platformSecret: string;
+  operatorSecret: string;
+  now?: () => string;
+  idFactory?: () => string;
+}
+
+async function readJson(c: import('hono').Context): Promise<unknown> {
+  try {
+    return await c.req.json();
+  } catch (err: unknown) {
+    if (err instanceof SyntaxError) return undefined;
+    throw err;
+  }
+}
+
+export function createGoldenSnapshotRoutes(deps: GoldenSnapshotRoutesDeps): Hono {
+  if (!deps.db || !deps.service) throw new Error('Golden snapshot routes require dependencies');
+  const routes = new Hono();
+  const now = deps.now ?? (() => new Date().toISOString());
+  const idFactory = deps.idFactory ?? randomUUID;
+
+  function requireBearerAuth(c: import('hono').Context, secret: string): Response | null {
+    if (!secret) return c.json({ error: 'Snapshot automation not configured' }, 503);
+    if (!bearerTokenMatches(c.req.header('authorization'), secret)) {
+      return c.json({ error: 'Unauthorized' }, 401);
+    }
+    return null;
+  }
+
+  routes.post('/snapshot-builds', bodyLimit({ maxSize: SNAPSHOT_ENQUEUE_BODY_LIMIT }), async (c) => {
+    const authorization = c.req.header('authorization');
+    if (!bearerTokenMatches(authorization, deps.platformSecret)
+      && !bearerTokenMatches(authorization, deps.operatorSecret)) {
+      return c.json({ error: 'Unauthorized' }, 401);
+    }
+    const parsed = EnqueueSchema.safeParse(await readJson(c));
+    if (!parsed.success) return c.json({ error: 'Invalid request' }, 400);
+    const authError = requireBearerAuth(
+      c,
+      parsed.data.testMode ? deps.operatorSecret : deps.platformSecret,
+    );
+    if (authError) return authError;
+    if (!deps.config.buildsEnabled) return c.json({ error: 'Snapshot builds disabled' }, 503);
+    try {
+      const result = await enqueueGoldenSnapshotBuild(deps.db, {
+        bundleVersion: parsed.data.bundleVersion,
+        compatibility: deps.config.compatibility,
+        snapshotId: idFactory(),
+        buildId: idFactory(),
+        testMode: parsed.data.testMode,
+        now: now(),
+      });
+      if (result.reused && result.build.status === 'failed') {
+        return c.json({ error: 'Snapshot build requires retry' }, 409);
+      }
+      return c.json({
+        snapshotId: result.snapshot.snapshotId,
+        buildId: result.build.buildId,
+        status: result.build.status,
+        reused: result.reused,
+      }, 202);
+    } catch (err: unknown) {
+      if (err instanceof GoldenSnapshotBuildRequiresRetryError) {
+        return c.json({ error: 'Snapshot build requires retry' }, 409);
+      }
+      console.error(`[golden-snapshot] enqueue failed: ${err instanceof Error ? err.name : typeof err}`);
+      return c.json({ error: 'Snapshot build request failed' }, 500);
+    }
+  });
+
+  routes.get('/snapshot-builds/:buildId', async (c) => {
+    const authError = requireBearerAuth(c, deps.operatorSecret);
+    if (authError) return authError;
+    const parsedId = BuildIdSchema.safeParse(c.req.param('buildId'));
+    if (!parsedId.success) return c.json({ error: 'Invalid request' }, 400);
+    const build = await getGoldenSnapshotBuild(deps.db, parsedId.data);
+    if (!build) return c.json({ error: 'Snapshot build not found' }, 404);
+    const snapshot = await getGoldenSnapshot(deps.db, build.snapshotId);
+    if (!snapshot) return c.json({ error: 'Snapshot build unavailable' }, 503);
+    return c.json({
+      buildId: build.buildId,
+      snapshotId: snapshot.snapshotId,
+      phase: build.phase,
+      status: build.status,
+      attempts: build.attempts,
+      state: snapshot.state,
+      failureCode: build.lastErrorCode ?? snapshot.failureCode,
+    });
+  });
+
+  routes.post('/snapshot-builds/:buildId/callback', bodyLimit({ maxSize: SNAPSHOT_CALLBACK_BODY_LIMIT }), async (c) => {
+    const buildId = BuildIdSchema.safeParse(c.req.param('buildId'));
+    if (!buildId.success) return c.json({ error: 'Invalid request' }, 400);
+    const auth = c.req.header('authorization');
+    const token = auth?.startsWith('Bearer ') ? auth.slice(7) : '';
+    if (token.length < 16 || token.length > 512) {
+      return c.json({ error: 'Snapshot callback rejected' }, 401);
+    }
+    const parsed = GoldenSnapshotCallbackSchema.safeParse(await readJson(c));
+    if (!parsed.success) return c.json({ error: 'Invalid request' }, 400);
+    try {
+      await deps.service.consumeCallback(buildId.data, token, parsed.data);
+      return c.json({ accepted: true });
+    } catch (err: unknown) {
+      if (err instanceof GoldenSnapshotCallbackError) {
+        return c.json(
+          { error: 'Snapshot callback rejected' },
+          err.code === 'unauthorized' ? 401 : 409,
+        );
+      }
+      console.error(`[golden-snapshot] callback failed: ${err instanceof Error ? err.name : typeof err}`);
+      return c.json({ error: 'Snapshot callback failed' }, 500);
+    }
+  });
+
+  return routes;
+}

--- a/packages/platform/src/main.ts
+++ b/packages/platform/src/main.ts
@@ -73,6 +73,9 @@ import {
 } from './launch-readiness.js';
 import { createLaunchReadinessRoutes } from './launch-readiness-routes.js';
 import { createHostBundleRoutes } from './host-bundle-routes.js';
+import { createGoldenSnapshotRoutes } from './golden-snapshot-routes.js';
+import type { GoldenSnapshotService } from './golden-snapshot-service.js';
+import type { GoldenSnapshotRuntimeConfig } from './golden-snapshot-schema.js';
 import { createLegacyContainerRoutes } from './legacy-container-routes.js';
 import { createAppSessionRoutes } from './app-session-routes.js';
 import { createComputerRoutes } from './computer-routes.js';
@@ -316,6 +319,8 @@ export function createApp(deps: {
   internalIntegrationRoutes?: Hono<any>;
   internalSyncRoutes?: Hono<any>;
   customerVpsService?: CustomerVpsService;
+  goldenSnapshotService?: GoldenSnapshotService;
+  goldenSnapshotConfig?: GoldenSnapshotRuntimeConfig;
   customerVpsObjectStore?: CustomerVpsObjectStore;
   hostBundleObjectStore?: CustomerVpsObjectStore;
   env?: NodeJS.ProcessEnv;
@@ -442,6 +447,15 @@ export function createApp(deps: {
 
   app.route('/', platformMetricsRoutes.routes);
 
+  if (deps.goldenSnapshotService && deps.goldenSnapshotConfig) {
+    app.route('/system-bundles', createGoldenSnapshotRoutes({
+      db,
+      service: deps.goldenSnapshotService,
+      config: deps.goldenSnapshotConfig,
+      platformSecret,
+      operatorSecret: appEnv.GOLDEN_SNAPSHOT_OPERATOR_SECRET ?? '',
+    }));
+  }
   app.route('/system-bundles', createHostBundleRoutes({
     db,
     platformSecret,

--- a/packages/platform/src/platform-startup.ts
+++ b/packages/platform/src/platform-startup.ts
@@ -7,6 +7,8 @@ import type { Hono, Context } from 'hono';
 import type { Server } from 'node:http';
 import type Dockerode from 'dockerode';
 import type { Agent } from 'undici';
+import { randomBytes } from 'node:crypto';
+import { readFile } from 'node:fs/promises';
 import {
   createPlatformDb,
   getContainer,
@@ -22,6 +24,8 @@ import type { ClerkAuth } from './clerk-auth.js';
 import { createClerkAuth, createClerkSessionRevoker } from './clerk-auth.js';
 import type { MatrixProvisioner } from './matrix-provisioning.js';
 import type { CustomerVpsService } from './customer-vps.js';
+import type { GoldenSnapshotService } from './golden-snapshot-service.js';
+import type { GoldenSnapshotRuntimeConfig } from './golden-snapshot-schema.js';
 import type { CustomerVpsObjectStore } from './customer-vps-r2.js';
 import type { EntitlementAccessDecision } from './profile-routing.js';
 import type { BillingEntitlement } from './billing.js';
@@ -44,6 +48,12 @@ interface GatewayPlatformUser {
   email: string;
   containerId: string;
   pipedreamExternalId?: string;
+}
+
+export function parseGoldenSnapshotReconciliationInterval(raw: string | undefined): number | undefined {
+  const value = Number(raw ?? 15_000);
+  if (!Number.isSafeInteger(value) || value < 1_000 || value > 3_600_000) return undefined;
+  return value;
 }
 
 interface GatewayPlatformDb {
@@ -135,6 +145,8 @@ type CreatePlatformApp = (deps: {
   internalIntegrationRoutes?: Hono<any>;
   internalSyncRoutes?: Hono<any>;
   customerVpsService?: CustomerVpsService;
+  goldenSnapshotService?: GoldenSnapshotService;
+  goldenSnapshotConfig?: GoldenSnapshotRuntimeConfig;
   customerVpsObjectStore?: CustomerVpsObjectStore;
   hostBundleObjectStore?: CustomerVpsObjectStore;
   env?: NodeJS.ProcessEnv;
@@ -414,8 +426,12 @@ export async function startPlatformServer(opts: StartPlatformServerOptions): Pro
   }
 
   let customerVpsService: CustomerVpsService | undefined;
+  let goldenSnapshotService: GoldenSnapshotService | undefined;
+  let goldenSnapshotConfig: GoldenSnapshotRuntimeConfig | undefined;
   let customerVpsReconciliationInterval: ReturnType<typeof setInterval> | undefined;
   let customerVpsReconciliationPromise: Promise<void> | undefined;
+  let goldenSnapshotInterval: ReturnType<typeof setInterval> | undefined;
+  let goldenSnapshotPromise: Promise<void> | undefined;
   if (runtimeConfig.customerVpsEnabled) {
     const [
       { createCustomerVpsService },
@@ -432,10 +448,11 @@ export async function startPlatformServer(opts: StartPlatformServerOptions): Pro
     ]);
     const customerVpsConfig = loadCustomerVpsConfig();
     const cloudInitTemplate = await loadCustomerVpsCloudInitTemplate();
+    const hetzner = createHetznerClient(customerVpsConfig);
     customerVpsService = createCustomerVpsService({
       db,
       config: customerVpsConfig,
-      hetzner: createHetznerClient(customerVpsConfig),
+      hetzner,
       systemStore: customerVpsObjectStore
         ? createCustomerVpsSystemStore({
             r2: customerVpsObjectStore,
@@ -454,6 +471,107 @@ export async function startPlatformServer(opts: StartPlatformServerOptions): Pro
           )
         : undefined,
     });
+    goldenSnapshotConfig = customerVpsConfig.goldenSnapshots;
+    {
+      const [
+        { createGoldenSnapshotService },
+        {
+          claimGoldenSnapshotBuildBatch,
+          listCallbackWaitGoldenSnapshotBuildIds,
+          listPendingGoldenSnapshotCleanup,
+          listRunnableGoldenSnapshotBuildIds,
+          listUnresolvedGoldenSnapshotBuildIds,
+        },
+      ] = await Promise.all([
+        import('./golden-snapshot-service.js'),
+        import('./golden-snapshot-repository.js'),
+      ]);
+      const builderTemplate = await readFile(
+        process.env.GOLDEN_SNAPSHOT_BUILDER_CLOUD_INIT_PATH
+          ?? 'distro/customer-vps/golden-snapshot-builder-cloud-init.yaml',
+        'utf8',
+      );
+      goldenSnapshotService = createGoldenSnapshotService({
+        db,
+        config: goldenSnapshotConfig,
+        hetzner,
+        builderCloudInitTemplate: builderTemplate,
+        bundleBaseUrl: process.env.MATRIX_HOST_BUNDLE_BASE_URL ?? process.env.PLATFORM_PUBLIC_URL ?? `http://localhost:${port}`,
+        callbackBaseUrl: process.env.PLATFORM_PUBLIC_URL ?? `http://localhost:${port}`,
+        tokenFactory: () => randomBytes(32).toString('base64url'),
+      });
+      const runGoldenSnapshotWorker = async () => {
+        if (goldenSnapshotPromise || !goldenSnapshotService || !goldenSnapshotConfig) return;
+        goldenSnapshotPromise = (async () => {
+          try {
+            const workerNow = new Date().toISOString();
+            if (goldenSnapshotConfig.buildsEnabled) {
+              await claimGoldenSnapshotBuildBatch(
+                db,
+                workerNow,
+                new Date(new Date(workerNow).getTime() + goldenSnapshotConfig.buildLeaseMs).toISOString(),
+                goldenSnapshotConfig.maxBuildAttempts,
+                goldenSnapshotConfig.reconciliationBatchSize,
+                goldenSnapshotConfig.maxConcurrentBuilds,
+              );
+              const runnable = await listRunnableGoldenSnapshotBuildIds(
+                db, new Date().toISOString(), goldenSnapshotConfig.reconciliationBatchSize,
+              );
+              for (const buildId of runnable) {
+                try {
+                  await goldenSnapshotService!.runBuildStep(buildId);
+                } catch (err: unknown) {
+                  console.error(`[golden-snapshot] worker step failed: ${err instanceof Error ? err.name : typeof err}`);
+                }
+              }
+              const callbackWaits = await listCallbackWaitGoldenSnapshotBuildIds(
+                db, goldenSnapshotConfig.reconciliationBatchSize,
+              );
+              for (const buildId of callbackWaits) {
+                try {
+                  await goldenSnapshotService!.runBuildStep(buildId);
+                } catch (err: unknown) {
+                  console.error(`[golden-snapshot] callback wait failed: ${err instanceof Error ? err.name : typeof err}`);
+                }
+              }
+            }
+            const unresolvedBuilds = await listUnresolvedGoldenSnapshotBuildIds(
+              db, goldenSnapshotConfig.reconciliationBatchSize,
+            );
+            for (const buildId of unresolvedBuilds) {
+              try {
+                await goldenSnapshotService!.runOrphanReconciliationStep(buildId);
+              } catch (err: unknown) {
+                console.error(`[golden-snapshot] orphan reconciliation failed: ${err instanceof Error ? err.name : typeof err}`);
+              }
+            }
+            const cleanup = await listPendingGoldenSnapshotCleanup(
+              db, new Date().toISOString(), goldenSnapshotConfig.reconciliationBatchSize,
+            );
+            for (const item of cleanup) {
+              try {
+                await goldenSnapshotService!.runCleanupStep(item.cleanupId);
+              } catch (err: unknown) {
+                console.error(`[golden-snapshot] cleanup step failed: ${err instanceof Error ? err.name : typeof err}`);
+              }
+            }
+          } catch (err: unknown) {
+            logPlatformRouteError('golden snapshot reconciliation', err);
+          }
+        })().finally(() => {
+          goldenSnapshotPromise = undefined;
+        });
+        await goldenSnapshotPromise;
+      };
+      const intervalMs = parseGoldenSnapshotReconciliationInterval(
+        process.env.GOLDEN_SNAPSHOT_RECONCILIATION_INTERVAL_MS,
+      );
+      if (intervalMs !== undefined) {
+        void runGoldenSnapshotWorker();
+        goldenSnapshotInterval = setInterval(runGoldenSnapshotWorker, intervalMs);
+        goldenSnapshotInterval.unref();
+      }
+    }
     const reconciliationIntervalMs = Number(process.env.CUSTOMER_VPS_RECONCILIATION_INTERVAL_MS ?? 60_000);
     if (reconciliationIntervalMs > 0) {
       let reconciliationRunning = false;
@@ -539,6 +657,8 @@ export async function startPlatformServer(opts: StartPlatformServerOptions): Pro
     internalIntegrationRoutes,
     internalSyncRoutes,
     customerVpsService,
+    goldenSnapshotService,
+    goldenSnapshotConfig,
     customerVpsObjectStore,
     hostBundleObjectStore,
     env: appEnv,
@@ -563,6 +683,7 @@ export async function startPlatformServer(opts: StartPlatformServerOptions): Pro
     if (customerVpsReconciliationInterval) {
       clearInterval(customerVpsReconciliationInterval);
     }
+    if (goldenSnapshotInterval) clearInterval(goldenSnapshotInterval);
     const shutdownTimer = setTimeout(() => {
       console.error('[platform] Graceful shutdown timed out');
       process.exit(1);
@@ -579,6 +700,7 @@ export async function startPlatformServer(opts: StartPlatformServerOptions): Pro
         if (customerVpsReconciliationPromise) {
           await customerVpsReconciliationPromise;
         }
+        if (goldenSnapshotPromise) await goldenSnapshotPromise;
         await Promise.allSettled([
           containerProxyDispatcher.close(),
           customerVpsProxyDispatcher.close(),

--- a/tests/platform/golden-snapshot-routes.test.ts
+++ b/tests/platform/golden-snapshot-routes.test.ts
@@ -1,0 +1,233 @@
+import { randomUUID } from 'node:crypto';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { upsertHostBundleRelease, type PlatformDB } from '../../packages/platform/src/db.js';
+import { createGoldenSnapshotRoutes } from '../../packages/platform/src/golden-snapshot-routes.js';
+import { GoldenSnapshotCallbackError } from '../../packages/platform/src/golden-snapshot-service.js';
+import { createApp as createPlatformApp } from '../../packages/platform/src/main.js';
+import type { GoldenSnapshotRuntimeConfig } from '../../packages/platform/src/golden-snapshot-schema.js';
+import { createTestPlatformDb, destroyTestPlatformDb } from './platform-db-test-helper.js';
+
+const config: GoldenSnapshotRuntimeConfig = {
+  enabled: false,
+  buildsEnabled: true,
+  rolloutPercent: 0,
+  compatibility: {
+    provider: 'hetzner', architecture: 'x86', region: 'eu-central', baseImage: 'ubuntu-24.04',
+    baseGeneration: 'ubuntu-24.04-v1', bootMode: 'bios', activationAbi: 'host-v1', minimumDiskGb: 40,
+  },
+  maxBuildAttempts: 5, maxConcurrentBuilds: 2, buildLeaseMs: 300_000, provisioningLeaseMs: 600_000,
+  callbackDeadlineMs: 30 * 60 * 1000,
+  retentionLimit: 20, freshnessMaxAgeMs: 7 * 24 * 60 * 60 * 1000, reconciliationBatchSize: 25,
+  testModeTtlMs: 24 * 60 * 60 * 1000, auditRetentionMs: 90 * 24 * 60 * 60 * 1000,
+};
+
+describe('golden snapshot control-plane routes', () => {
+  let db: PlatformDB;
+  let ids: string[];
+  const service = {
+    runBuildStep: vi.fn(), runOrphanReconciliationStep: vi.fn(),
+    runCleanupStep: vi.fn(), consumeCallback: vi.fn(),
+  };
+
+  beforeEach(async () => {
+    ({ db } = await createTestPlatformDb());
+    ids = [
+      '10000000-0000-4000-8000-000000000001', '20000000-0000-4000-8000-000000000001',
+      '10000000-0000-4000-8000-000000000002', '20000000-0000-4000-8000-000000000002',
+      '10000000-0000-4000-8000-000000000003', '20000000-0000-4000-8000-000000000003',
+    ];
+    service.consumeCallback.mockReset();
+    await upsertHostBundleRelease(db, {
+      version: 'v1', gitCommit: '1111111', buildTime: '2026-07-01T00:00:00.000Z',
+      bundleKey: 'system-bundles/v1/matrix-host-bundle.tar.gz', checksumKey: null,
+      sha256: '1'.repeat(64), size: 100, createdAt: '2026-07-01T00:00:00.000Z',
+    });
+  });
+  afterEach(async () => destroyTestPlatformDb(db));
+
+  function app() {
+    return createGoldenSnapshotRoutes({
+      db, service, config, platformSecret: 'platform-secret', operatorSecret: 'operator-secret',
+      now: () => '2026-07-03T00:00:00.000Z', idFactory: () => ids.shift()!,
+    });
+  }
+
+  it('requires platform auth and enqueues duplicate immutable requests idempotently', async () => {
+    expect((await app().request('/snapshot-builds', { method: 'POST', body: '{}' })).status).toBe(401);
+    const request = () => app().request('/snapshot-builds', {
+      method: 'POST', headers: { authorization: 'Bearer platform-secret', 'content-type': 'application/json' },
+      body: JSON.stringify({ bundleVersion: 'v1' }),
+    });
+    const first = await request();
+    const second = await request();
+    expect(first.status).toBe(202);
+    expect(second.status).toBe(202);
+    expect(await first.json()).toMatchObject({ reused: false, status: 'queued' });
+    expect(await second.json()).toMatchObject({ reused: true, status: 'queued' });
+    const rejectedTestBuild = await app().request('/snapshot-builds', {
+      method: 'POST', headers: { authorization: 'Bearer platform-secret', 'content-type': 'application/json' },
+      body: JSON.stringify({ bundleVersion: 'v1', testMode: true }),
+    });
+    expect(rejectedTestBuild.status).toBe(401);
+    const testBuild = await app().request('/snapshot-builds', {
+      method: 'POST', headers: { authorization: 'Bearer operator-secret', 'content-type': 'application/json' },
+      body: JSON.stringify({ bundleVersion: 'v1', testMode: true }),
+    });
+    expect(await testBuild.json()).toMatchObject({ reused: false, status: 'queued' });
+    expect(await db.executor.selectFrom('golden_snapshots').select(['test_mode']).where('test_mode', '=', true)
+      .executeTakeFirst()).toEqual({ test_mode: true });
+  });
+
+  it('rejects terminal build reuse until an explicit retry resets it', async () => {
+    const request = () => app().request('/snapshot-builds', {
+      method: 'POST', headers: { authorization: 'Bearer platform-secret', 'content-type': 'application/json' },
+      body: JSON.stringify({ bundleVersion: 'v1' }),
+    });
+    expect((await request()).status).toBe(202);
+    await db.executor.updateTable('golden_snapshot_builds').set({
+      phase: 'failed', status: 'failed', last_error_code: 'validation_failed',
+    }).execute();
+
+    const response = await request();
+    expect(response.status).toBe(409);
+    expect(await response.json()).toEqual({ error: 'Snapshot build requires retry' });
+  });
+
+  it('applies a body limit and strict schema before enqueue', async () => {
+    const response = await app().request('/snapshot-builds', {
+      method: 'POST', headers: { authorization: 'Bearer platform-secret', 'content-type': 'application/json' },
+      body: JSON.stringify({ bundleVersion: 'v1', padding: 'x'.repeat(9_000) }),
+    });
+    expect(response.status).toBe(413);
+    const unsafeVersion = await app().request('/snapshot-builds', {
+      method: 'POST', headers: { authorization: 'Bearer platform-secret', 'content-type': 'application/json' },
+      body: JSON.stringify({ bundleVersion: "v1'; touch /tmp/injected #" }),
+    });
+    expect(unsafeVersion.status).toBe(400);
+  });
+
+  it('requires the scoped operator credential for build status', async () => {
+    await app().request('/snapshot-builds', {
+      method: 'POST', headers: { authorization: 'Bearer platform-secret', 'content-type': 'application/json' },
+      body: JSON.stringify({ bundleVersion: 'v1' }),
+    });
+    const path = '/snapshot-builds/20000000-0000-4000-8000-000000000001';
+    expect((await app().request(path, {
+      headers: { authorization: 'Bearer platform-secret' },
+    })).status).toBe(401);
+    expect((await app().request(path, {
+      headers: { authorization: 'Bearer operator-secret' },
+    })).status).toBe(200);
+  });
+
+  it('reads the snapshot operator credential from the injected app environment', async () => {
+    const platformApp = createPlatformApp({
+      db,
+      orchestrator: {} as never,
+      platformSecret: 'platform-secret',
+      goldenSnapshotService: service as never,
+      goldenSnapshotConfig: config,
+      env: { GOLDEN_SNAPSHOT_OPERATOR_SECRET: 'injected-operator-secret' },
+    });
+
+    const response = await platformApp.request('/system-bundles/snapshot-builds', {
+      method: 'POST',
+      headers: {
+        authorization: 'Bearer injected-operator-secret',
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({ bundleVersion: 'v1', testMode: true }),
+    });
+    expect(response.status).toBe(202);
+  });
+
+  it('passes phase tokens to the service and returns only generic callback errors', async () => {
+    service.consumeCallback.mockRejectedValueOnce(new GoldenSnapshotCallbackError('unauthorized'));
+    const response = await app().request('/snapshot-builds/20000000-0000-4000-8000-000000000001/callback', {
+      method: 'POST',
+      headers: { authorization: 'Bearer wrong-token-long-enough', 'content-type': 'application/json' },
+      body: JSON.stringify({
+        eventId: randomUUID(),
+        phase: 'sanitized', bundleVersion: 'v1', bundleSha256: '1'.repeat(64),
+        builderMachineIdSha256: '2'.repeat(64), builderSshHostKeySha256: '3'.repeat(64),
+      }),
+    });
+    expect(response.status).toBe(401);
+    expect(await response.json()).toEqual({ error: 'Snapshot callback rejected' });
+
+    service.consumeCallback.mockClear();
+    const missingToken = await app().request('/snapshot-builds/20000000-0000-4000-8000-000000000001/callback', {
+      method: 'POST', headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        eventId: randomUUID(),
+        phase: 'sanitized', bundleVersion: 'v1', bundleSha256: '1'.repeat(64),
+        builderMachineIdSha256: '2'.repeat(64), builderSshHostKeySha256: '3'.repeat(64),
+      }),
+    });
+    expect(missingToken.status).toBe(401);
+    expect(await missingToken.json()).toEqual({ error: 'Snapshot callback rejected' });
+    expect(service.consumeCallback).not.toHaveBeenCalled();
+  });
+
+  it('accepts bounded validation identity evidence at the callback boundary', async () => {
+    service.consumeCallback.mockResolvedValueOnce(undefined);
+    const response = await app().request(
+      '/snapshot-builds/20000000-0000-4000-8000-000000000001/callback',
+      {
+        method: 'POST',
+        headers: { authorization: 'Bearer callback-token-long-enough', 'content-type': 'application/json' },
+        body: JSON.stringify({
+          eventId: randomUUID(),
+          phase: 'validated', bundleVersion: 'v1', bundleSha256: '1'.repeat(64),
+          validationMachineIdSha256: '2'.repeat(64), validationSshHostKeySha256: '3'.repeat(64),
+          evidence: {
+            exactBundle: true, healthy: true, freshActivation: true,
+            uniqueMachineId: true, uniqueSshHostKey: true, forbiddenStateAbsent: true,
+          },
+        }),
+      },
+    );
+    expect(response.status).toBe(200);
+    expect(service.consumeCallback).toHaveBeenCalledWith(
+      '20000000-0000-4000-8000-000000000001',
+      'callback-token-long-enough',
+      expect.objectContaining({ validationMachineIdSha256: '2'.repeat(64) }),
+    );
+  });
+
+  it('accepts the strict builder-booted callback variant', async () => {
+    service.consumeCallback.mockResolvedValueOnce(undefined);
+    const response = await app().request(
+      '/snapshot-builds/20000000-0000-4000-8000-000000000001/callback',
+      {
+        method: 'POST',
+        headers: { authorization: 'Bearer callback-token-long-enough', 'content-type': 'application/json' },
+        body: JSON.stringify({
+          eventId: randomUUID(), phase: 'builder_booted',
+          bundleVersion: 'v1', bundleSha256: '1'.repeat(64),
+          builderMachineIdSha256: '2'.repeat(64),
+          builderSshHostKeySha256: '3'.repeat(64), healthy: true,
+        }),
+      },
+    );
+    expect(response.status).toBe(200);
+    expect(service.consumeCallback).toHaveBeenCalledWith(
+      '20000000-0000-4000-8000-000000000001',
+      'callback-token-long-enough',
+      expect.objectContaining({ phase: 'builder_booted', healthy: true }),
+    );
+  });
+
+  it('uses the route-specific body limits from the approved contract', async () => {
+    const callback = await app().request(
+      '/snapshot-builds/20000000-0000-4000-8000-000000000001/callback',
+      {
+        method: 'POST',
+        headers: { authorization: 'Bearer callback-token-long-enough', 'content-type': 'application/json' },
+        body: JSON.stringify({ padding: 'x'.repeat(9_000) }),
+      },
+    );
+    expect(callback.status).toBe(400);
+
+  });
+});

--- a/tests/platform/golden-snapshot-worker-wiring.test.ts
+++ b/tests/platform/golden-snapshot-worker-wiring.test.ts
@@ -1,0 +1,52 @@
+import { readFile } from 'node:fs/promises';
+import { describe, expect, it } from 'vitest';
+import { parseGoldenSnapshotReconciliationInterval } from '../../packages/platform/src/platform-startup.js';
+
+describe('golden snapshot worker wiring', () => {
+  it('bounds the reconciliation timer to a safe interval', () => {
+    expect(parseGoldenSnapshotReconciliationInterval(undefined)).toBe(15_000);
+    expect(parseGoldenSnapshotReconciliationInterval('1000')).toBe(1_000);
+    expect(parseGoldenSnapshotReconciliationInterval('3600000')).toBe(3_600_000);
+    expect(parseGoldenSnapshotReconciliationInterval('999')).toBeUndefined();
+    expect(parseGoldenSnapshotReconciliationInterval('2147483648')).toBeUndefined();
+    expect(parseGoldenSnapshotReconciliationInterval('not-a-number')).toBeUndefined();
+  });
+
+  it('contains worker query failures inside the scheduled tick', async () => {
+    const source = await readFile('packages/platform/src/platform-startup.ts', 'utf8');
+    const worker = source.slice(
+      source.indexOf('const runGoldenSnapshotWorker = async () => {'),
+      source.indexOf('const reconciliationIntervalMs = Number'),
+    );
+    expect(worker).toContain("logPlatformRouteError('golden snapshot reconciliation', err)");
+    expect(worker.indexOf('try {')).toBeLessThan(worker.indexOf('claimGoldenSnapshotBuildBatch'));
+  });
+
+  it('pauses build claims while keeping cleanup enabled when builds are disabled', async () => {
+    const source = await readFile('packages/platform/src/platform-startup.ts', 'utf8');
+    const worker = source.slice(
+      source.indexOf('const runGoldenSnapshotWorker = async () => {'),
+      source.indexOf('const reconciliationIntervalMs = Number'),
+    );
+    expect(worker).toMatch(
+      /if \(goldenSnapshotConfig\.buildsEnabled\) \{[\s\S]*claimGoldenSnapshotBuildBatch[\s\S]*listRunnableGoldenSnapshotBuildIds[\s\S]*\}\n\s*const cleanup/,
+    );
+    expect(worker).toContain('goldenSnapshotConfig.maxConcurrentBuilds');
+    expect(worker).not.toContain('listClaimableGoldenSnapshotBuildIds');
+    expect(source).not.toContain(
+      'if (goldenSnapshotConfig.buildsEnabled || goldenSnapshotConfig.enabled) {',
+    );
+    expect(worker.indexOf('listUnresolvedGoldenSnapshotBuildIds'))
+      .toBeGreaterThan(worker.indexOf('if (goldenSnapshotConfig.buildsEnabled)'));
+    expect(worker.indexOf('listCallbackWaitGoldenSnapshotBuildIds'))
+      .toBeGreaterThan(worker.indexOf('listRunnableGoldenSnapshotBuildIds'));
+    expect(worker.indexOf('listCallbackWaitGoldenSnapshotBuildIds'))
+      .toBeLessThan(worker.indexOf('listUnresolvedGoldenSnapshotBuildIds'));
+  });
+
+  it('mounts snapshot status routes before the generic bundle catch-all', async () => {
+    const source = await readFile('packages/platform/src/main.ts', 'utf8');
+    expect(source.indexOf('createGoldenSnapshotRoutes({'))
+      .toBeLessThan(source.indexOf('createHostBundleRoutes({'));
+  });
+});


### PR DESCRIPTION
## Summary

- expose bounded authenticated enqueue/status/callback controls
- wire the build/cleanup worker into startup and shutdown without blocking existing fleet deployment
- keep production selection disabled by configuration

## Tests

- [x] Route and worker-wiring suites: 13 passed
- [x] Platform TypeScript project check
- [x] PR size: 5 files, 571 additions

## Invariants

### Source of truth

Platform Postgres remains authoritative for builds, callbacks, cleanup, status, and rollout state.

### Lock/transaction scope

Routes delegate transactional writes to repositories/services; worker/provider calls remain outside DB transaction and lock scope.

### Acceptable orphan states

Only durable bounded build/cleanup/reconciliation states are accepted; unsafe or ambiguous resources are never selectable.

### Authorization source

Release enqueue uses `PLATFORM_SECRET`; test/operator status and mutation paths use the separate operator secret; callback tokens remain phase-bound and hashed.

### Deferred scope

Customer snapshot selection/cloning, recovery, release workflow automation, rollout enablement, and production deployment remain deferred upstack.