### PR TITLE
feat(platform): recover and retire golden snapshots

### DIFF
--- a/packages/platform/src/golden-snapshot-repository.ts
+++ b/packages/platform/src/golden-snapshot-repository.ts
@@ -1937,6 +1937,8 @@ export async function retireGoldenSnapshot(
     const retirementTarget = await trx.executor.selectFrom('golden_snapshots').selectAll()
       .where('snapshot_id', '=', snapshotId).executeTakeFirst();
     if (!retirementTarget || !['ready', 'failed', 'quarantined'].includes(retirementTarget.state)) return false;
+    await sql`SELECT pg_advisory_xact_lock(hashtext(${retirementTarget.base_generation}))`
+      .execute(trx.executor);
     const compatibilityRows = retirementTarget.state === 'ready'
       ? await trx.executor.selectFrom('golden_snapshots').selectAll()
         .where('compatibility_key', '=', retirementTarget.compatibility_key)
@@ -1947,6 +1949,11 @@ export async function retireGoldenSnapshot(
         .where('snapshot_id', '=', snapshotId).forUpdate().executeTakeFirst()];
     const snapshotRow = compatibilityRows.find((row) => row?.snapshot_id === snapshotId);
     if (!snapshotRow || !['ready', 'failed', 'quarantined'].includes(snapshotRow.state)) return false;
+    const build = await trx.executor.selectFrom('golden_snapshot_builds').selectAll()
+      .where('snapshot_id', '=', snapshotId).forUpdate().executeTakeFirst();
+    // An unresolved provider create must be reconciled before retirement. Its
+    // exact resource may not be represented by any persisted provider ID yet.
+    if (build?.pending_operation !== null && build?.pending_operation !== undefined) return false;
     const freshnessExpired = snapshotRow.state === 'ready'
       && policy.freshnessMaxAgeMs !== undefined
       && snapshotRow.ready_at !== null
@@ -1996,13 +2003,27 @@ export async function retireGoldenSnapshot(
       const otherReady = compatibilityRows.find((row) => row?.snapshot_id !== snapshotId);
       if (!otherReady) return false;
     }
-    if (snapshotRow.provider_image_id !== null) {
-      const build = await trx.executor.selectFrom('golden_snapshot_builds').select('build_id')
-        .where('snapshot_id', '=', snapshotId).executeTakeFirst();
+    const resources = [
+      build?.provider_builder_id === null || build?.provider_builder_id === undefined ? undefined : {
+        type: 'builder_server' as const, id: build.provider_builder_id,
+      },
+      build?.provider_validation_id === null || build?.provider_validation_id === undefined ? undefined : {
+        type: 'validation_server' as const, id: build.provider_validation_id,
+      },
+      snapshotRow.provider_image_id === null ? undefined : {
+        type: 'snapshot_image' as const, id: snapshotRow.provider_image_id,
+      },
+    ].filter((resource): resource is {
+      type: 'builder_server' | 'validation_server' | 'snapshot_image'; id: number;
+    } => resource !== undefined);
+    for (const resource of resources) {
       await trx.executor.insertInto('golden_snapshot_cleanup').values({
         cleanup_id: randomUUID(), snapshot_id: snapshotId, build_id: build?.build_id ?? null,
-        resource_type: 'snapshot_image', provider_resource_id: snapshotRow.provider_image_id,
-        provenance_key: `snapshot:${snapshotId}`, reason, status: 'queued', attempts: 0,
+        resource_type: resource.type, provider_resource_id: resource.id,
+        provenance_key: resource.type === 'snapshot_image'
+          ? `snapshot:${snapshotId}`
+          : `build:${build!.build_id}:${resource.type}`,
+        reason, status: 'queued', attempts: 0,
         next_attempt_at: now, lease_expires_at: null, last_error_code: null,
         created_at: now, completed_at: null,
       }).onConflict((oc) => oc.columns(['resource_type', 'provider_resource_id'])
@@ -2022,6 +2043,44 @@ export async function retireGoldenSnapshot(
   });
 }
 
+async function finalizeRetiringGoldenSnapshotWithoutImage(
+  db: PlatformDB,
+  snapshotId: string,
+  now: string,
+): Promise<boolean> {
+  return db.transaction(async (trx) => {
+    const identity = await trx.executor.selectFrom('golden_snapshots').select('base_generation')
+      .where('snapshot_id', '=', snapshotId).executeTakeFirst();
+    if (!identity) return false;
+    await sql`SELECT pg_advisory_xact_lock(hashtext(${identity.base_generation}))`.execute(trx.executor);
+    const snapshot = await trx.executor.selectFrom('golden_snapshots').selectAll()
+      .where('snapshot_id', '=', snapshotId).forUpdate().executeTakeFirst();
+    if (!snapshot || snapshot.state !== 'retiring' || snapshot.provider_image_id !== null) return false;
+    const build = await trx.executor.selectFrom('golden_snapshot_builds').selectAll()
+      .where('snapshot_id', '=', snapshotId).forUpdate().executeTakeFirst();
+    if (build && (build.pending_operation !== null
+      || build.provider_builder_id !== null
+      || build.provider_validation_id !== null)) return false;
+    const [unreleasedLease, pendingCleanup] = await Promise.all([
+      trx.executor.selectFrom('golden_snapshot_leases').select('lease_id')
+        .where('snapshot_id', '=', snapshotId).where('released_at', 'is', null).executeTakeFirst(),
+      trx.executor.selectFrom('golden_snapshot_cleanup').select('cleanup_id')
+        .where('snapshot_id', '=', snapshotId).where('completed_at', 'is', null).executeTakeFirst(),
+    ]);
+    if (unreleasedLease || pendingCleanup) return false;
+    const deleted = await trx.executor.updateTable('golden_snapshots').set({
+      state: 'deleted', deleted_at: now, updated_at: now, revision: sql<number>`revision + 1`,
+    }).where('snapshot_id', '=', snapshotId).where('state', '=', 'retiring')
+      .where('revision', '=', snapshot.revision).returning('snapshot_id').executeTakeFirst();
+    if (!deleted) return false;
+    await appendGoldenSnapshotAuditEvent(trx, {
+      snapshotId, buildId: build?.build_id, eventType: 'snapshot_deleted', actorType: 'worker',
+      fromState: 'retiring', toState: 'deleted', reason: 'provider_image_absent', now,
+    });
+    return true;
+  });
+}
+
 export async function enforceGoldenSnapshotRetention(
   db: PlatformDB,
   rawInput: z.input<typeof RetentionInputSchema>,
@@ -2033,12 +2092,15 @@ export async function enforceGoldenSnapshotRetention(
   } catch (err: unknown) {
     console.error(`[golden-snapshot] lease reconciliation failed: ${err instanceof Error ? err.name : typeof err}`);
   }
-  const [readyRows, disposableRows, channels] = await Promise.all([
+  const [readyRows, disposableRows, retiringWithoutImageRows, channels] = await Promise.all([
     db.executor.selectFrom('golden_snapshots').select([
       'snapshot_id', 'bundle_version', 'compatibility_key', 'ready_at', 'test_mode',
     ]).where('state', '=', 'ready').orderBy('ready_at', 'desc').limit(100).execute(),
     db.executor.selectFrom('golden_snapshots').select('snapshot_id')
-      .where('state', 'in', ['failed', 'quarantined']).where('provider_image_id', 'is not', null)
+      .where('state', 'in', ['failed', 'quarantined'])
+      .orderBy('updated_at').limit(100).execute(),
+    db.executor.selectFrom('golden_snapshots').select('snapshot_id')
+      .where('state', '=', 'retiring').where('provider_image_id', 'is', null)
       .orderBy('updated_at').limit(100).execute(),
     db.executor.selectFrom('host_bundle_channels').select(['channel', 'version']).limit(20).execute(),
   ]);
@@ -2138,6 +2200,19 @@ export async function enforceGoldenSnapshotRetention(
   for (const candidate of candidates.slice(0, retirementCount)) {
     if (await tryRetire(candidate.snapshot_id, input.quotaPressure ? 'quota_pressure' : 'retention')) {
       retiredSnapshotIds.push(candidate.snapshot_id);
+    }
+  }
+  const imageLessRetiringIds = new Set([
+    ...retiringWithoutImageRows.map((row) => row.snapshot_id),
+    ...retiredSnapshotIds,
+  ]);
+  for (const snapshotId of imageLessRetiringIds) {
+    try {
+      await finalizeRetiringGoldenSnapshotWithoutImage(db, snapshotId, input.now);
+    } catch (err: unknown) {
+      console.error(
+        `[golden-snapshot] image-less retirement finalization failed snapshot=${snapshotId}: ${err instanceof Error ? err.name : typeof err}`,
+      );
     }
   }
   return {

--- a/packages/platform/src/golden-snapshot-routes.ts
+++ b/packages/platform/src/golden-snapshot-routes.ts
@@ -9,6 +9,9 @@ import {
   GoldenSnapshotBuildRequiresRetryError,
   getGoldenSnapshot,
   getGoldenSnapshotBuild,
+  listGoldenSnapshotOperationalStatus,
+  retryGoldenSnapshotBuild,
+  revokeGoldenSnapshot,
 } from './golden-snapshot-repository.js';
 import type { GoldenSnapshotRuntimeConfig } from './golden-snapshot-schema.js';
 import { GoldenSnapshotBundleVersionSchema } from './golden-snapshot-schema.js';
@@ -20,7 +23,12 @@ import {
 
 const SNAPSHOT_ENQUEUE_BODY_LIMIT = 8 * 1024;
 const SNAPSHOT_CALLBACK_BODY_LIMIT = 64 * 1024;
+const SNAPSHOT_RETRY_BODY_LIMIT = 1024;
+const SNAPSHOT_REVOKE_BODY_LIMIT = 4 * 1024;
 const BuildIdSchema = z.string().uuid();
+const SnapshotIdSchema = z.string().uuid();
+const StatusQuerySchema = z.coerce.number().int().min(1).max(100).default(25);
+const RevokeSchema = z.object({ reason: z.string().min(1).max(128).regex(/^[a-z0-9][a-z0-9._-]*$/) }).strict();
 const EnqueueSchema = z.object({
   bundleVersion: GoldenSnapshotBundleVersionSchema,
   testMode: z.boolean().optional().default(false),
@@ -118,6 +126,46 @@ export function createGoldenSnapshotRoutes(deps: GoldenSnapshotRoutesDeps): Hono
       state: snapshot.state,
       failureCode: build.lastErrorCode ?? snapshot.failureCode,
     });
+  });
+
+  routes.get('/snapshots', async (c) => {
+    const authError = requireBearerAuth(c, deps.operatorSecret);
+    if (authError) return authError;
+    const limit = StatusQuerySchema.safeParse(c.req.query('limit'));
+    if (!limit.success) return c.json({ error: 'Invalid request' }, 400);
+    try {
+      return c.json({ snapshots: await listGoldenSnapshotOperationalStatus(deps.db, limit.data) });
+    } catch (err: unknown) {
+      console.error(`[golden-snapshot] status failed: ${err instanceof Error ? err.name : typeof err}`);
+      return c.json({ error: 'Snapshot status unavailable' }, 500);
+    }
+  });
+
+  routes.post('/snapshot-builds/:buildId/retry', bodyLimit({ maxSize: SNAPSHOT_RETRY_BODY_LIMIT }), async (c) => {
+    const authError = requireBearerAuth(c, deps.operatorSecret);
+    if (authError) return authError;
+    const buildId = BuildIdSchema.safeParse(c.req.param('buildId'));
+    if (!buildId.success) return c.json({ error: 'Invalid request' }, 400);
+    try {
+      return c.json({ retried: await retryGoldenSnapshotBuild(deps.db, buildId.data, now()) });
+    } catch (err: unknown) {
+      console.error(`[golden-snapshot] retry failed: ${err instanceof Error ? err.name : typeof err}`);
+      return c.json({ error: 'Snapshot retry unavailable' }, 500);
+    }
+  });
+
+  routes.post('/snapshots/:snapshotId/revoke', bodyLimit({ maxSize: SNAPSHOT_REVOKE_BODY_LIMIT }), async (c) => {
+    const authError = requireBearerAuth(c, deps.operatorSecret);
+    if (authError) return authError;
+    const snapshotId = SnapshotIdSchema.safeParse(c.req.param('snapshotId'));
+    const body = RevokeSchema.safeParse(await readJson(c));
+    if (!snapshotId.success || !body.success) return c.json({ error: 'Invalid request' }, 400);
+    try {
+      return c.json({ revoked: await revokeGoldenSnapshot(deps.db, snapshotId.data, body.data.reason, now()) });
+    } catch (err: unknown) {
+      console.error(`[golden-snapshot] revocation failed: ${err instanceof Error ? err.name : typeof err}`);
+      return c.json({ error: 'Snapshot revocation unavailable' }, 500);
+    }
   });
 
   routes.post('/snapshot-builds/:buildId/callback', bodyLimit({ maxSize: SNAPSHOT_CALLBACK_BODY_LIMIT }), async (c) => {

--- a/packages/platform/src/golden-snapshot-service.ts
+++ b/packages/platform/src/golden-snapshot-service.ts
@@ -3,7 +3,10 @@ import { sql } from 'kysely';
 import { z } from 'zod/v4';
 import type { PlatformDB } from './db.js';
 import type { HetznerClient, HetznerServer } from './customer-vps-hetzner.js';
-import { DefinitiveProviderRejectionError } from './customer-vps-errors.js';
+import {
+  CustomerVpsError,
+  DefinitiveProviderRejectionError,
+} from './customer-vps-errors.js';
 import {
   appendGoldenSnapshotAuditEvent,
   getGoldenSnapshot,
@@ -343,7 +346,9 @@ function exactLabels(buildId: string, snapshotId: string, role: 'builder' | 'val
 function providerFailure(context: string, err: unknown): Error {
   const kind = err instanceof Error ? err.name : typeof err;
   console.error(`[golden-snapshot] ${context} failed: ${kind}`);
-  return new Error('Golden snapshot provider operation failed');
+  return err instanceof CustomerVpsError
+    ? err
+    : new Error('Golden snapshot provider operation failed');
 }
 
 export function createGoldenSnapshotService(rawDeps: GoldenSnapshotServiceDeps): GoldenSnapshotService {
@@ -856,6 +861,18 @@ export function createGoldenSnapshotService(rawDeps: GoldenSnapshotServiceDeps):
           labels: exactLabels(buildId, snapshot.snapshotId, 'builder'),
         });
       } catch (err: unknown) {
+        if (err instanceof CustomerVpsError && err.code === 'quota_exceeded') {
+          await deps.db.executor.updateTable('golden_snapshot_builds').set({
+            phase: 'snapshot_create', pending_operation: null, callback_expires_at: null,
+            updated_at: at,
+          }).where('build_id', '=', buildId).where('phase', '=', 'snapshot_wait')
+            .where('provider_snapshot_action_id', 'is', null).execute();
+          throw new CustomerVpsError(
+            err.status,
+            'snapshot_quota_exceeded',
+            'Snapshot capacity unavailable',
+          );
+        }
         throw providerFailure('snapshot create', err);
       }
       if (created.image.status === 'deleting') {

--- a/packages/platform/src/platform-startup.ts
+++ b/packages/platform/src/platform-startup.ts
@@ -38,6 +38,7 @@ import { resolvePlatformIntegrationConfig } from './integration-config.js';
 import { buildPlatformVerificationToken } from './platform-token.js';
 import { backfillFirstRunRecords } from './journey.js';
 import { logPlatformRouteError } from './platform-route-utils.js';
+import { CustomerVpsError } from './customer-vps-errors.js';
 import { registerPlatformWebSocketUpgradeHandler } from './platform-websocket-upgrade.js';
 
 interface GatewayPlatformUser {
@@ -478,6 +479,7 @@ export async function startPlatformServer(opts: StartPlatformServerOptions): Pro
         {
           claimGoldenSnapshotBuildBatch,
           listCallbackWaitGoldenSnapshotBuildIds,
+          enforceGoldenSnapshotRetention,
           listPendingGoldenSnapshotCleanup,
           listRunnableGoldenSnapshotBuildIds,
           listUnresolvedGoldenSnapshotBuildIds,
@@ -505,6 +507,7 @@ export async function startPlatformServer(opts: StartPlatformServerOptions): Pro
         goldenSnapshotPromise = (async () => {
           try {
             const workerNow = new Date().toISOString();
+            let quotaPressure = false;
             if (goldenSnapshotConfig.buildsEnabled) {
               await claimGoldenSnapshotBuildBatch(
                 db,
@@ -521,6 +524,9 @@ export async function startPlatformServer(opts: StartPlatformServerOptions): Pro
                 try {
                   await goldenSnapshotService!.runBuildStep(buildId);
                 } catch (err: unknown) {
+                  if (err instanceof CustomerVpsError && err.code === 'snapshot_quota_exceeded') {
+                    quotaPressure = true;
+                  }
                   console.error(`[golden-snapshot] worker step failed: ${err instanceof Error ? err.name : typeof err}`);
                 }
               }
@@ -554,6 +560,19 @@ export async function startPlatformServer(opts: StartPlatformServerOptions): Pro
               } catch (err: unknown) {
                 console.error(`[golden-snapshot] cleanup step failed: ${err instanceof Error ? err.name : typeof err}`);
               }
+            }
+            const retention = await enforceGoldenSnapshotRetention(db, {
+              retentionLimit: goldenSnapshotConfig.retentionLimit,
+              rollbackVersionsPerChannel: 2,
+              freshnessMaxAgeMs: goldenSnapshotConfig.freshnessMaxAgeMs,
+              testModeTtlMs: goldenSnapshotConfig.testModeTtlMs,
+              now: new Date().toISOString(),
+              quotaPressure,
+            });
+            if (retention.retiredSnapshotIds.length > 0 || retention.blocked) {
+              console.log(
+                `[golden-snapshot] retention retired=${retention.retiredSnapshotIds.length} blocked=${retention.blocked}`,
+              );
             }
           } catch (err: unknown) {
             logPlatformRouteError('golden snapshot reconciliation', err);

--- a/tests/platform/golden-snapshot-recovery.test.ts
+++ b/tests/platform/golden-snapshot-recovery.test.ts
@@ -1,0 +1,768 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  getActiveUserMachineByClerkId, getUserMachine, insertUserMachine, upsertHostBundleRelease, type PlatformDB,
+} from '../../packages/platform/src/db.js';
+import { createCustomerVpsService } from '../../packages/platform/src/customer-vps.js';
+import { loadCustomerVpsConfig } from '../../packages/platform/src/customer-vps-config.js';
+import { hashRegistrationToken } from '../../packages/platform/src/customer-vps-auth.js';
+import {
+  advanceGoldenSnapshot, claimGoldenSnapshotBuild, enqueueGoldenSnapshotBuild, markGoldenSnapshotReady,
+  reconcileExpiredGoldenSnapshotLeases, recordGoldenSnapshotProviderImage,
+} from '../../packages/platform/src/golden-snapshot-repository.js';
+import { createMockCustomerVpsSystemStore, createMockHetznerClient } from './customer-vps-fixtures.js';
+import { CustomerVpsError } from '../../packages/platform/src/customer-vps-errors.js';
+import { createTestPlatformDb, destroyTestPlatformDb } from './platform-db-test-helper.js';
+
+describe('golden snapshot recovery', () => {
+  let db: PlatformDB;
+  beforeEach(async () => {
+    ({ db } = await createTestPlatformDb());
+    await upsertHostBundleRelease(db, {
+      version: 'v2', gitCommit: '2222222', buildTime: '2026-07-02T00:00:00.000Z',
+      bundleKey: 'system-bundles/v2/matrix-host-bundle.tar.gz', checksumKey: null,
+      sha256: '2'.repeat(64), size: 100, createdAt: '2026-07-02T00:00:00.000Z',
+    });
+    await insertUserMachine(db, {
+      machineId: '30000000-0000-4000-8000-000000000010', clerkUserId: 'user_recover', handle: 'recover-me',
+      runtimeSlot: 'primary', developerTools: [], status: 'running', imageVersion: 'v1', serverType: 'cpx22',
+      hetznerServerId: 50, publicIPv4: '203.0.113.50', provisionedAt: '2026-07-01T00:00:00.000Z',
+    });
+    const compatibility = {
+      provider: 'hetzner' as const, architecture: 'x86' as const, region: 'eu-central', baseImage: 'ubuntu-24.04',
+      baseGeneration: 'ubuntu-24.04-v1', bootMode: 'bios' as const, activationAbi: 'host-v1', minimumDiskGb: 40,
+    };
+    const enqueued = await enqueueGoldenSnapshotBuild(db, {
+      bundleVersion: 'v2', compatibility,
+      snapshotId: '10000000-0000-4000-8000-000000000010',
+      buildId: '20000000-0000-4000-8000-000000000010', now: '2026-07-02T01:00:00.000Z',
+    });
+    const claimed = await claimGoldenSnapshotBuild(
+      db, enqueued.build.buildId, '2026-07-02T01:00:00.500Z', '2026-07-02T01:10:00.000Z', 5,
+    );
+    const fence = claimed!.leaseExpiresAt!;
+    await advanceGoldenSnapshot(db, enqueued.snapshot.snapshotId, enqueued.build.buildId, fence, 'candidate', 'building', '2026-07-02T01:00:01.000Z');
+    await advanceGoldenSnapshot(db, enqueued.snapshot.snapshotId, enqueued.build.buildId, fence, 'building', 'sanitizing', '2026-07-02T01:00:02.000Z');
+    await advanceGoldenSnapshot(db, enqueued.snapshot.snapshotId, enqueued.build.buildId, fence, 'sanitizing', 'validating', '2026-07-02T01:00:03.000Z');
+    await recordGoldenSnapshotProviderImage(db, enqueued.snapshot.snapshotId, {
+      buildId: enqueued.build.buildId, expectedLeaseExpiresAt: fence,
+      providerImageId: 302, providerImageStatus: 'available', imageDiskGb: 40,
+      imageArchitecture: 'x86', now: '2026-07-02T01:00:04.000Z',
+    });
+    await db.executor.updateTable('golden_snapshot_builds').set({
+      phase: 'validation_boot', status: 'running', lease_expires_at: '2026-07-02T01:10:00.000Z',
+    }).where('build_id', '=', enqueued.build.buildId).execute();
+    await markGoldenSnapshotReady(db, enqueued.snapshot.snapshotId, enqueued.build.buildId, {
+      validationSummary: { exactBundle: true, healthy: true, freshActivation: true, uniqueMachineId: true, uniqueSshHostKey: true, forbiddenStateAbsent: true },
+      expectedLeaseExpiresAt: '2026-07-02T01:10:00.000Z',
+      now: '2026-07-02T01:00:05.000Z',
+    });
+  });
+  afterEach(async () => destroyTestPlatformDb(db));
+
+  it('leases the exact image for replacement infrastructure and releases it after durable adoption', async () => {
+    const hetzner = createMockHetznerClient();
+    const systemStore = createMockCustomerVpsSystemStore({ hasDbLatest: async () => true });
+    const config = loadCustomerVpsConfig({
+      PLATFORM_SECRET: 'platform-secret', CUSTOMER_VPS_IMAGE_VERSION: 'v2',
+      HETZNER_SERVER_TYPE: 'cpx32',
+      MATRIX_HOST_BUNDLE_URL: 'https://bundles.example/system-bundles/v2/matrix-host-bundle.tar.gz',
+      GOLDEN_SNAPSHOTS_ENABLED: 'true', GOLDEN_SNAPSHOT_ROLLOUT_PERCENT: '100', GOLDEN_SNAPSHOT_REGION: 'eu-central',
+      S3_ACCESS_KEY_ID: 'access-key', S3_SECRET_ACCESS_KEY: 'secret-key', S3_ENDPOINT: 'https://r2.example',
+    });
+    const service = createCustomerVpsService({
+      db, config, hetzner, systemStore,
+      machineIdFactory: () => '30000000-0000-4000-8000-000000000011',
+      tokenFactory: () => ({
+        token: 'recovery-registration-token',
+        hash: hashRegistrationToken('recovery-registration-token'),
+        expiresAt: '2026-07-03T01:00:00.000Z',
+      }),
+      now: () => new Date('2026-07-03T00:00:00.000Z'),
+    });
+
+    const recovery = await service.recover({ clerkUserId: 'user_recover', runtimeSlot: 'primary' });
+
+    expect(hetzner.createServer).toHaveBeenCalledWith(expect.objectContaining({ image: 302 }));
+    const activeLease = await db.executor.selectFrom('golden_snapshot_leases').selectAll()
+      .where('machine_id', '=', '30000000-0000-4000-8000-000000000011').executeTakeFirstOrThrow();
+    expect(activeLease.purpose).toBe('recover');
+    expect(activeLease.released_at).toBeNull();
+
+    await service.register('recovery-registration-token', {
+      machineId: recovery.machineId,
+      hetznerServerId: 123456,
+      publicIPv4: '203.0.113.10',
+      imageVersion: 'v2',
+      bundleSha256: '2'.repeat(64),
+      healthy: true,
+    });
+
+    const releasedLease = await db.executor.selectFrom('golden_snapshot_leases').selectAll()
+      .where('machine_id', '=', recovery.machineId).executeTakeFirstOrThrow();
+    expect(releasedLease.released_at).toBe('2026-07-03T00:00:00.000Z');
+    expect(await getUserMachine(db, recovery.machineId)).toMatchObject({
+      sourceSnapshotId: '10000000-0000-4000-8000-000000000010',
+      sourceBaseGeneration: 'ubuntu-24.04-v1',
+      targetBundleVersion: 'v2',
+      targetBundleSha256: '2'.repeat(64),
+      serverType: 'cpx22',
+    });
+  });
+
+  it('releases an expired recovery lease whose intended machine row was never adopted', async () => {
+    const orphanMachineId = '30000000-0000-4000-8000-000000000099';
+    await db.executor.insertInto('golden_snapshot_leases').values({
+      lease_id: '40000000-0000-4000-8000-000000000099',
+      snapshot_id: '10000000-0000-4000-8000-000000000010',
+      machine_id: orphanMachineId,
+      purpose: 'recover',
+      target_bundle_version: 'v2',
+      created_at: '2026-07-03T00:00:00.000Z',
+      expires_at: '2026-07-03T00:01:00.000Z',
+      released_at: null,
+    }).execute();
+
+    await expect(reconcileExpiredGoldenSnapshotLeases(db, '2026-07-03T00:02:00.000Z', 10)).resolves.toBe(1);
+    await expect(db.executor.selectFrom('golden_snapshot_leases').select('released_at')
+      .where('machine_id', '=', orphanMachineId).executeTakeFirstOrThrow()).resolves.toMatchObject({
+      released_at: '2026-07-03T00:02:00.000Z',
+    });
+  });
+
+  it('retains the old server until the replacement registers healthy', async () => {
+    let resolveCreate!: (server: { id: number; status: string; publicIPv4: string }) => void;
+    const createServer = vi.fn(() => new Promise<{ id: number; status: string; publicIPv4: string }>((resolve) => {
+      resolveCreate = resolve;
+    }));
+    const config = loadCustomerVpsConfig({
+      PLATFORM_SECRET: 'platform-secret', CUSTOMER_VPS_IMAGE_VERSION: 'v2',
+      MATRIX_HOST_BUNDLE_URL: 'https://bundles.example/system-bundles/v2/matrix-host-bundle.tar.gz',
+      GOLDEN_SNAPSHOTS_ENABLED: 'true', GOLDEN_SNAPSHOT_ROLLOUT_PERCENT: '100', GOLDEN_SNAPSHOT_REGION: 'eu-central',
+      S3_ACCESS_KEY_ID: 'access-key', S3_SECRET_ACCESS_KEY: 'secret-key', S3_ENDPOINT: 'https://r2.example',
+    });
+    const service = createCustomerVpsService({
+      db, config, hetzner: createMockHetznerClient({ createServer }),
+      systemStore: createMockCustomerVpsSystemStore({ hasDbLatest: async () => true }),
+      machineIdFactory: () => '30000000-0000-4000-8000-000000000017',
+      tokenFactory: () => ({
+        token: 'cutover-registration-token',
+        hash: hashRegistrationToken('cutover-registration-token'),
+        expiresAt: '2026-07-03T01:00:00.000Z',
+      }),
+      now: () => new Date('2026-07-03T00:00:00.000Z'),
+    });
+
+    const recoveryPromise = service.recover({ clerkUserId: 'user_recover', runtimeSlot: 'primary' });
+    await vi.waitFor(() => expect(createServer).toHaveBeenCalledTimes(1));
+    await expect(getActiveUserMachineByClerkId(db, 'user_recover', 'primary')).resolves.toMatchObject({
+      machineId: '30000000-0000-4000-8000-000000000017',
+      status: 'recovering',
+      hetznerServerId: null,
+      recoveryOldServerId: 50,
+      recoveryEncryptedPayload: expect.any(String),
+    });
+
+    resolveCreate({ id: 123462, status: 'running', publicIPv4: '203.0.113.17' });
+    await expect(recoveryPromise).resolves.toMatchObject({
+      machineId: '30000000-0000-4000-8000-000000000017', status: 'recovering',
+    });
+    await expect(db.executor.selectFrom('provider_deletion_queue')
+      .select(['provider_server_id', 'reason'])
+      .where('provider_server_id', '=', 50)
+      .executeTakeFirst()).resolves.toBeUndefined();
+    await expect(getUserMachine(db, '30000000-0000-4000-8000-000000000017'))
+      .resolves.toMatchObject({
+        publicIPv4: '203.0.113.50',
+        recoveryOldServerId: 50,
+        recoveryEncryptedPayload: expect.any(String),
+      });
+
+    await service.register('cutover-registration-token', {
+      machineId: '30000000-0000-4000-8000-000000000017',
+      hetznerServerId: 123462, publicIPv4: '203.0.113.17', imageVersion: 'v2',
+      bundleSha256: '2'.repeat(64), healthy: true,
+    });
+    await expect(db.executor.selectFrom('provider_deletion_queue')
+      .select(['provider_server_id', 'reason'])
+      .where('provider_server_id', '=', 50)
+      .executeTakeFirst()).resolves.toEqual({
+      provider_server_id: 50,
+      reason: 'recover_old_server',
+    });
+  });
+
+  it('reconciles an ambiguous recovery create response by exact replacement labels', async () => {
+    const replacement = {
+      id: 123463, status: 'running', publicIPv4: '203.0.113.18',
+      labels: {
+        app: 'matrix-os', clerk_user_id: 'user_recover', runtime_slot: 'primary',
+        machine_id: '30000000-0000-4000-8000-000000000018', image_source: 'snapshot',
+        snapshot_id: '10000000-0000-4000-8000-000000000010',
+      },
+    };
+    const createServer = vi.fn().mockRejectedValue(new Error('response lost'));
+    const listServersByLabel = vi.fn().mockResolvedValue([replacement]);
+    const deleteServer = vi.fn().mockResolvedValue(undefined);
+    const config = loadCustomerVpsConfig({
+      PLATFORM_SECRET: 'platform-secret', CUSTOMER_VPS_IMAGE_VERSION: 'v2',
+      MATRIX_HOST_BUNDLE_URL: 'https://bundles.example/system-bundles/v2/matrix-host-bundle.tar.gz',
+      GOLDEN_SNAPSHOTS_ENABLED: 'true', GOLDEN_SNAPSHOT_ROLLOUT_PERCENT: '100', GOLDEN_SNAPSHOT_REGION: 'eu-central',
+      CUSTOMER_VPS_RECONCILIATION_STALE_AFTER_MS: '1000',
+      S3_ACCESS_KEY_ID: 'access-key', S3_SECRET_ACCESS_KEY: 'secret-key', S3_ENDPOINT: 'https://r2.example',
+    });
+    const service = createCustomerVpsService({
+      db, config,
+      hetzner: createMockHetznerClient({ createServer, listServersByLabel, deleteServer }),
+      systemStore: createMockCustomerVpsSystemStore({ hasDbLatest: async () => true }),
+      machineIdFactory: () => '30000000-0000-4000-8000-000000000018',
+      now: () => new Date('2026-07-03T00:00:00.000Z'),
+    });
+
+    await expect(service.recover({ clerkUserId: 'user_recover', runtimeSlot: 'primary' }))
+      .rejects.toMatchObject({ code: 'provider_unavailable' });
+    await expect(service.reconcileProvisioning()).resolves.toMatchObject({ checked: 1, failed: 0, running: 0 });
+    expect(listServersByLabel).toHaveBeenCalledWith('machine_id=30000000-0000-4000-8000-000000000018');
+    await expect(getUserMachine(db, '30000000-0000-4000-8000-000000000018')).resolves.toMatchObject({
+      status: 'recovering', hetznerServerId: 123463, recoveryOldServerId: 50,
+      publicIPv4: '203.0.113.50',
+      recoveryEncryptedPayload: expect.any(String),
+      sourceSnapshotId: '10000000-0000-4000-8000-000000000010', targetBundleVersion: 'v2',
+    });
+    expect(deleteServer).not.toHaveBeenCalled();
+  });
+
+  it('restores the old VPS immediately after a definitive recovery create rejection', async () => {
+    const createServer = vi.fn().mockRejectedValue(
+      new CustomerVpsError(429, 'quota_exceeded', 'Provisioning capacity unavailable'),
+    );
+    const config = loadCustomerVpsConfig({
+      PLATFORM_SECRET: 'platform-secret', CUSTOMER_VPS_IMAGE_VERSION: 'v2',
+      MATRIX_HOST_BUNDLE_URL: 'https://bundles.example/system-bundles/v2/matrix-host-bundle.tar.gz',
+      GOLDEN_SNAPSHOTS_ENABLED: 'true', GOLDEN_SNAPSHOT_ROLLOUT_PERCENT: '100', GOLDEN_SNAPSHOT_REGION: 'eu-central',
+      S3_ACCESS_KEY_ID: 'access-key', S3_SECRET_ACCESS_KEY: 'secret-key', S3_ENDPOINT: 'https://r2.example',
+    });
+    const service = createCustomerVpsService({
+      db, config, hetzner: createMockHetznerClient({ createServer }),
+      systemStore: createMockCustomerVpsSystemStore({ hasDbLatest: async () => true }),
+      machineIdFactory: () => '30000000-0000-4000-8000-000000000019',
+      now: () => new Date('2026-07-03T00:00:00.000Z'),
+    });
+
+    await expect(service.recover({ clerkUserId: 'user_recover', runtimeSlot: 'primary' }))
+      .rejects.toMatchObject({ code: 'quota_exceeded' });
+    await expect(getActiveUserMachineByClerkId(db, 'user_recover', 'primary')).resolves.toMatchObject({
+      machineId: '30000000-0000-4000-8000-000000000010', status: 'running',
+      hetznerServerId: 50, recoveryOldServerId: null, recoveryEncryptedPayload: null,
+    });
+    await expect(db.executor.selectFrom('golden_snapshot_leases').select('released_at')
+      .where('machine_id', '=', '30000000-0000-4000-8000-000000000019').executeTakeFirstOrThrow())
+      .resolves.toMatchObject({ released_at: '2026-07-03T00:00:00.000Z' });
+  });
+
+  it('restores the old VPS after bounded reconciliation proves no replacement was adopted', async () => {
+    const createServer = vi.fn().mockRejectedValue(new Error('response lost'));
+    const listServersByLabel = vi.fn().mockResolvedValue([]);
+    const config = loadCustomerVpsConfig({
+      PLATFORM_SECRET: 'platform-secret', CUSTOMER_VPS_IMAGE_VERSION: 'v2',
+      MATRIX_HOST_BUNDLE_URL: 'https://bundles.example/system-bundles/v2/matrix-host-bundle.tar.gz',
+      GOLDEN_SNAPSHOTS_ENABLED: 'true', GOLDEN_SNAPSHOT_ROLLOUT_PERCENT: '100', GOLDEN_SNAPSHOT_REGION: 'eu-central',
+      CUSTOMER_VPS_RECONCILIATION_STALE_AFTER_MS: '1000',
+      S3_ACCESS_KEY_ID: 'access-key', S3_SECRET_ACCESS_KEY: 'secret-key', S3_ENDPOINT: 'https://r2.example',
+    });
+    const service = createCustomerVpsService({
+      db, config, hetzner: createMockHetznerClient({
+        createServer,
+        listServersByLabel,
+        getServer: vi.fn().mockResolvedValue({
+          id: 50, status: 'running', publicIPv4: '203.0.113.50', publicIPv6: null,
+        }),
+      }),
+      systemStore: createMockCustomerVpsSystemStore({ hasDbLatest: async () => true }),
+      machineIdFactory: () => '30000000-0000-4000-8000-000000000020',
+      tokenFactory: () => ({
+        token: 'expired-recovery-token', hash: hashRegistrationToken('expired-recovery-token'),
+        expiresAt: '2026-07-02T23:59:00.000Z',
+      }),
+      now: () => new Date('2026-07-03T00:00:00.000Z'),
+    });
+
+    await expect(service.recover({ clerkUserId: 'user_recover', runtimeSlot: 'primary' }))
+      .rejects.toMatchObject({ code: 'provider_unavailable' });
+    await expect(service.reconcileProvisioning()).resolves.toMatchObject({ running: 1 });
+    await expect(getUserMachine(db, '30000000-0000-4000-8000-000000000010')).resolves.toMatchObject({
+      status: 'running', hetznerServerId: 50, publicIPv4: '203.0.113.50',
+      recoveryOldServerId: null, recoveryEncryptedPayload: null,
+    });
+    await expect(getUserMachine(db, '30000000-0000-4000-8000-000000000020')).resolves.toBeUndefined();
+  });
+
+  it('keeps an expired recovery lease while provider adoption remains ambiguous', async () => {
+    const machineId = '30000000-0000-4000-8000-000000000019';
+    await insertUserMachine(db, {
+      machineId, clerkUserId: 'user_stuck_recovery', handle: 'stuck-recovery',
+      runtimeSlot: 'primary', developerTools: [], status: 'recovering', imageVersion: 'v2',
+      hetznerServerId: null, recoveryOldServerId: 519, recoveryEncryptedPayload: 'sealed-intent',
+      provisionedAt: '2026-07-03T00:00:00.000Z',
+    });
+    await db.executor.insertInto('golden_snapshot_leases').values({
+      lease_id: '40000000-0000-4000-8000-000000000019',
+      snapshot_id: '10000000-0000-4000-8000-000000000010',
+      machine_id: machineId,
+      purpose: 'recover',
+      target_bundle_version: 'v2',
+      created_at: '2026-07-03T00:00:00.000Z',
+      expires_at: '2026-07-03T00:01:00.000Z',
+      released_at: null,
+    }).execute();
+
+    await expect(reconcileExpiredGoldenSnapshotLeases(db, '2026-07-03T00:02:00.000Z', 10)).resolves.toBe(0);
+    await expect(db.executor.selectFrom('golden_snapshot_leases').select('released_at')
+      .where('machine_id', '=', machineId).executeTakeFirstOrThrow()).resolves.toMatchObject({
+      released_at: null,
+    });
+  });
+
+  it('keeps an expired recovery lease through registration and preserves snapshot provenance', async () => {
+    const config = loadCustomerVpsConfig({
+      PLATFORM_SECRET: 'platform-secret', CUSTOMER_VPS_IMAGE_VERSION: 'v2',
+      MATRIX_HOST_BUNDLE_URL: 'https://bundles.example/system-bundles/v2/matrix-host-bundle.tar.gz',
+      GOLDEN_SNAPSHOTS_ENABLED: 'true', GOLDEN_SNAPSHOT_ROLLOUT_PERCENT: '100', GOLDEN_SNAPSHOT_REGION: 'eu-central',
+      S3_ACCESS_KEY_ID: 'access-key', S3_SECRET_ACCESS_KEY: 'secret-key', S3_ENDPOINT: 'https://r2.example',
+    });
+    const service = createCustomerVpsService({
+      db, config, hetzner: createMockHetznerClient(),
+      systemStore: createMockCustomerVpsSystemStore({ hasDbLatest: async () => true }),
+      machineIdFactory: () => '30000000-0000-4000-8000-000000000021',
+      tokenFactory: () => ({
+        token: 'delayed-registration-token', hash: hashRegistrationToken('delayed-registration-token'),
+        expiresAt: '2026-07-03T01:00:00.000Z',
+      }),
+      now: () => new Date('2026-07-03T00:00:00.000Z'),
+    });
+    const recovery = await service.recover({ clerkUserId: 'user_recover', runtimeSlot: 'primary' });
+    await expect(reconcileExpiredGoldenSnapshotLeases(db, '2026-07-03T00:11:00.000Z', 10)).resolves.toBe(0);
+
+    await expect(service.register('delayed-registration-token', {
+      machineId: recovery.machineId, hetznerServerId: 123456, publicIPv4: '203.0.113.21',
+      imageVersion: 'v1', bundleSha256: '1'.repeat(64), healthy: true,
+    })).rejects.toMatchObject({ status: 409, code: 'registration_rejected' });
+    await expect(service.register('delayed-registration-token', {
+      machineId: recovery.machineId, hetznerServerId: 123456, publicIPv4: '203.0.113.21',
+      imageVersion: 'v2', bundleSha256: '2'.repeat(64), healthy: true,
+    })).resolves.toMatchObject({ registered: true, status: 'running' });
+    await expect(getUserMachine(db, recovery.machineId)).resolves.toMatchObject({
+      sourceSnapshotId: '10000000-0000-4000-8000-000000000010',
+      sourceBaseGeneration: 'ubuntu-24.04-v1', targetBundleVersion: 'v2',
+      targetBundleSha256: '2'.repeat(64),
+    });
+    await expect(db.executor.selectFrom('golden_snapshot_leases').select('released_at')
+      .where('machine_id', '=', recovery.machineId).executeTakeFirstOrThrow())
+      .resolves.toMatchObject({ released_at: '2026-07-03T00:00:00.000Z' });
+  });
+
+  it('re-renders clean-image activation after a definite recovery clone rejection', async () => {
+    const createServer = vi.fn()
+      .mockRejectedValueOnce(new CustomerVpsError(500, 'snapshot_clone_rejected', 'Provisioning provider unavailable'))
+      .mockResolvedValueOnce({ id: 123457, status: 'running', publicIPv4: '203.0.113.11' });
+    const config = loadCustomerVpsConfig({
+      PLATFORM_SECRET: 'platform-secret', CUSTOMER_VPS_IMAGE_VERSION: 'v2',
+      MATRIX_HOST_BUNDLE_URL: 'https://bundles.example/system-bundles/v2/matrix-host-bundle.tar.gz',
+      GOLDEN_SNAPSHOTS_ENABLED: 'true', GOLDEN_SNAPSHOT_ROLLOUT_PERCENT: '100', GOLDEN_SNAPSHOT_REGION: 'eu-central',
+      S3_ACCESS_KEY_ID: 'access-key', S3_SECRET_ACCESS_KEY: 'secret-key', S3_ENDPOINT: 'https://r2.example',
+    });
+    const service = createCustomerVpsService({
+      db, config, hetzner: createMockHetznerClient({ createServer }),
+      systemStore: createMockCustomerVpsSystemStore({ hasDbLatest: async () => true }),
+      machineIdFactory: () => '30000000-0000-4000-8000-000000000012',
+      now: () => new Date('2026-07-03T00:00:00.000Z'),
+    });
+
+    await service.recover({ clerkUserId: 'user_recover', runtimeSlot: 'primary' });
+    expect(createServer).toHaveBeenNthCalledWith(1, expect.objectContaining({ image: 302 }));
+    expect(createServer).toHaveBeenNthCalledWith(2, expect.not.objectContaining({ image: expect.anything() }));
+    expect(createServer.mock.calls[1]![0].userData).toContain('MATRIX_IMAGE_SOURCE=clean_image');
+    expect(createServer.mock.calls[1]![0].userData).not.toContain('MATRIX_IMAGE_SOURCE=snapshot');
+  });
+
+  it('falls back to a clean image when an accepted recovery clone action fails', async () => {
+    const createServer = vi.fn()
+      .mockResolvedValueOnce({
+        id: 123458, status: 'starting', publicIPv4: '203.0.113.12', createActionId: 9001,
+      })
+      .mockResolvedValueOnce({ id: 123459, status: 'running', publicIPv4: '203.0.113.13' });
+    const config = loadCustomerVpsConfig({
+      PLATFORM_SECRET: 'platform-secret', CUSTOMER_VPS_IMAGE_VERSION: 'v2',
+      MATRIX_HOST_BUNDLE_URL: 'https://bundles.example/system-bundles/v2/matrix-host-bundle.tar.gz',
+      GOLDEN_SNAPSHOTS_ENABLED: 'true', GOLDEN_SNAPSHOT_ROLLOUT_PERCENT: '100', GOLDEN_SNAPSHOT_REGION: 'eu-central',
+      S3_ACCESS_KEY_ID: 'access-key', S3_SECRET_ACCESS_KEY: 'secret-key', S3_ENDPOINT: 'https://r2.example',
+    });
+    const deleteServer = vi.fn().mockResolvedValue(undefined);
+    const service = createCustomerVpsService({
+      db, config,
+      hetzner: createMockHetznerClient({
+        createServer,
+        deleteServer,
+        getAction: vi.fn().mockResolvedValue({ id: 9001, status: 'error', command: 'create_server' }),
+        getServer: vi.fn(async (serverId: number) => serverId === 50
+          ? { id: 50, status: 'running', publicIPv4: '203.0.113.50', publicIPv6: null }
+          : null),
+      }),
+      systemStore: createMockCustomerVpsSystemStore({ hasDbLatest: async () => true }),
+      machineIdFactory: () => '30000000-0000-4000-8000-000000000013',
+      tokenFactory: () => ({
+        token: 'fallback-registration-token',
+        hash: hashRegistrationToken('fallback-registration-token'),
+        expiresAt: '2026-07-03T01:00:00.000Z',
+      }),
+      now: () => new Date('2026-07-03T00:00:00.000Z'),
+    });
+
+    const recovery = await service.recover({ clerkUserId: 'user_recover', runtimeSlot: 'primary' });
+    expect(createServer).toHaveBeenNthCalledWith(1, expect.objectContaining({ image: 302 }));
+    expect(createServer).toHaveBeenNthCalledWith(2, expect.not.objectContaining({ image: expect.anything() }));
+    expect(createServer.mock.calls[1]![0].userData).toContain('MATRIX_IMAGE_SOURCE=clean_image');
+    expect(deleteServer).toHaveBeenCalledWith(123458);
+    await expect(service.register('fallback-registration-token', {
+      machineId: recovery.machineId,
+      hetznerServerId: 123459,
+      publicIPv4: '203.0.113.13',
+      imageVersion: 'v2',
+      bundleSha256: '2'.repeat(64),
+      healthy: true,
+    })).resolves.toMatchObject({ registered: true, status: 'running' });
+    expect(await getUserMachine(db, recovery.machineId)).toMatchObject({
+      sourceSnapshotId: null,
+      sourceBaseGeneration: null,
+    });
+  });
+
+  it('persists a slow recovery create action for asynchronous reconciliation', async () => {
+    let currentNow = new Date('2026-07-03T00:00:00.000Z');
+    const server = {
+      id: 123460, status: 'starting', publicIPv4: '203.0.113.14', createActionId: 9002,
+    };
+    const createServer = vi.fn().mockResolvedValue(server);
+    const getAction = vi.fn().mockResolvedValue({ id: 9002, status: 'running', command: 'create_server' });
+    const config = loadCustomerVpsConfig({
+      PLATFORM_SECRET: 'platform-secret', CUSTOMER_VPS_IMAGE_VERSION: 'v2',
+      MATRIX_HOST_BUNDLE_URL: 'https://bundles.example/system-bundles/v2/matrix-host-bundle.tar.gz',
+      GOLDEN_SNAPSHOTS_ENABLED: 'true', GOLDEN_SNAPSHOT_ROLLOUT_PERCENT: '100', GOLDEN_SNAPSHOT_REGION: 'eu-central',
+      CUSTOMER_VPS_RECONCILIATION_STALE_AFTER_MS: '1000',
+      S3_ACCESS_KEY_ID: 'access-key', S3_SECRET_ACCESS_KEY: 'secret-key', S3_ENDPOINT: 'https://r2.example',
+    });
+    const service = createCustomerVpsService({
+      db, config,
+      hetzner: createMockHetznerClient({ createServer, getAction, getServer: vi.fn().mockResolvedValue(server) }),
+      systemStore: createMockCustomerVpsSystemStore({ hasDbLatest: async () => true }),
+      machineIdFactory: () => '30000000-0000-4000-8000-000000000014',
+      now: () => currentNow,
+    });
+
+    const recovery = await service.recover({ clerkUserId: 'user_recover', runtimeSlot: 'primary' });
+    expect(createServer).toHaveBeenCalledTimes(1);
+    expect(await getUserMachine(db, recovery.machineId)).toMatchObject({
+      status: 'recovering',
+      recoveryCreateActionId: 9002,
+      recoveryOldServerId: 50,
+    });
+
+    getAction.mockResolvedValue({ id: 9002, status: 'success', command: 'create_server' });
+    currentNow = new Date('2026-07-03T00:02:00.000Z');
+    await service.reconcileProvisioning();
+    expect(createServer).toHaveBeenCalledTimes(1);
+    expect(await getUserMachine(db, recovery.machineId)).toMatchObject({
+      status: 'recovering',
+      recoveryCreateActionId: null,
+      recoveryOldServerId: 50,
+      recoveryEncryptedPayload: expect.any(String),
+    });
+    await expect(db.executor.selectFrom('provider_deletion_queue').select('provider_server_id')
+      .where('provider_server_id', '=', 50).executeTakeFirst()).resolves.toBeUndefined();
+  });
+
+  it('cleans an expired recovery replacement before releasing its snapshot lease', async () => {
+    let currentNow = new Date('2026-07-03T00:00:00.000Z');
+    const replacement = {
+      id: 123464, status: 'starting' as const, publicIPv4: '203.0.113.18', createActionId: 9005,
+    };
+    const deleteServer = vi.fn().mockResolvedValue(undefined);
+    const service = createCustomerVpsService({
+      db,
+      config: loadCustomerVpsConfig({
+        PLATFORM_SECRET: 'platform-secret', CUSTOMER_VPS_IMAGE_VERSION: 'v2',
+        MATRIX_HOST_BUNDLE_URL: 'https://bundles.example/system-bundles/v2/matrix-host-bundle.tar.gz',
+        GOLDEN_SNAPSHOTS_ENABLED: 'true', GOLDEN_SNAPSHOT_ROLLOUT_PERCENT: '100',
+        GOLDEN_SNAPSHOT_REGION: 'eu-central', CUSTOMER_VPS_RECONCILIATION_STALE_AFTER_MS: '1000',
+        S3_ACCESS_KEY_ID: 'access-key', S3_SECRET_ACCESS_KEY: 'secret-key', S3_ENDPOINT: 'https://r2.example',
+      }),
+      hetzner: createMockHetznerClient({
+        createServer: vi.fn().mockResolvedValue(replacement),
+        getAction: vi.fn().mockResolvedValue({ id: 9005, status: 'running', command: 'create_server' }),
+        deleteServer,
+        getServer: vi.fn(async (serverId: number) => serverId === 50
+          ? { id: 50, status: 'running', publicIPv4: '203.0.113.50', publicIPv6: null }
+          : null),
+      }),
+      systemStore: createMockCustomerVpsSystemStore({ hasDbLatest: async () => true }),
+      machineIdFactory: () => '30000000-0000-4000-8000-000000000024',
+      tokenFactory: () => ({
+        token: 'expiring-recovery-token', hash: hashRegistrationToken('expiring-recovery-token'),
+        expiresAt: '2026-07-03T00:01:00.000Z',
+      }),
+      now: () => currentNow,
+    });
+
+    const recovery = await service.recover({ clerkUserId: 'user_recover', runtimeSlot: 'primary' });
+    await expect(db.executor.selectFrom('golden_snapshot_leases').select('released_at')
+      .where('machine_id', '=', recovery.machineId).executeTakeFirstOrThrow())
+      .resolves.toMatchObject({ released_at: null });
+
+    currentNow = new Date('2026-07-03T00:02:00.000Z');
+    await service.reconcileProvisioning();
+
+    expect(deleteServer).toHaveBeenCalledWith(replacement.id);
+    await expect(getUserMachine(db, '30000000-0000-4000-8000-000000000010')).resolves.toMatchObject({
+      status: 'running', hetznerServerId: 50, recoveryOldServerId: null, recoveryEncryptedPayload: null,
+    });
+    await expect(getUserMachine(db, recovery.machineId)).resolves.toBeUndefined();
+    await expect(db.executor.selectFrom('golden_snapshot_leases').select('released_at')
+      .where('machine_id', '=', recovery.machineId).executeTakeFirstOrThrow())
+      .resolves.toMatchObject({ released_at: '2026-07-03T00:02:00.000Z' });
+  });
+
+  it('restores the old machine after a delayed clean recovery create action fails', async () => {
+    let currentNow = new Date('2026-07-03T00:00:00.000Z');
+    const replacement = {
+      id: 123462, status: 'starting' as const, publicIPv4: '203.0.113.16', createActionId: 9004,
+    };
+    const getAction = vi.fn().mockResolvedValue({ id: 9004, status: 'running', command: 'create_server' });
+    const deleteServer = vi.fn().mockResolvedValue(undefined);
+    const service = createCustomerVpsService({
+      db,
+      config: loadCustomerVpsConfig({
+        PLATFORM_SECRET: 'platform-secret', CUSTOMER_VPS_IMAGE_VERSION: 'v2',
+        MATRIX_HOST_BUNDLE_URL: 'https://bundles.example/system-bundles/v2/matrix-host-bundle.tar.gz',
+        GOLDEN_SNAPSHOTS_ENABLED: 'false', CUSTOMER_VPS_RECONCILIATION_STALE_AFTER_MS: '1000',
+        S3_ACCESS_KEY_ID: 'access-key', S3_SECRET_ACCESS_KEY: 'secret-key', S3_ENDPOINT: 'https://r2.example',
+      }),
+      hetzner: createMockHetznerClient({
+        createServer: vi.fn().mockResolvedValue(replacement), getAction, deleteServer,
+        getServer: vi.fn(async (serverId: number) => serverId === 50
+          ? { id: 50, status: 'running', publicIPv4: '203.0.113.50', publicIPv6: null }
+          : null),
+      }),
+      systemStore: createMockCustomerVpsSystemStore({ hasDbLatest: async () => true }),
+      machineIdFactory: () => '30000000-0000-4000-8000-000000000023',
+      now: () => currentNow,
+    });
+
+    const recovery = await service.recover({ clerkUserId: 'user_recover', runtimeSlot: 'primary' });
+    expect(await getUserMachine(db, recovery.machineId)).toMatchObject({
+      status: 'recovering', recoveryOldServerId: 50, recoveryCreateActionId: 9004,
+    });
+
+    getAction.mockResolvedValue({ id: 9004, status: 'error', command: 'create_server' });
+    currentNow = new Date('2026-07-03T00:02:00.000Z');
+    await service.reconcileProvisioning();
+
+    expect(deleteServer).toHaveBeenCalledWith(123462);
+    await expect(getUserMachine(db, '30000000-0000-4000-8000-000000000010')).resolves.toMatchObject({
+      status: 'running', hetznerServerId: 50, recoveryOldServerId: null, recoveryEncryptedPayload: null,
+    });
+    await expect(getUserMachine(db, recovery.machineId)).resolves.toBeUndefined();
+  });
+
+  it('keeps one durable cleanup job while a rejected recovery server is still deleting', async () => {
+    let currentNow = new Date('2026-07-03T00:00:00.000Z');
+    const replacement = {
+      id: 123465, status: 'deleting' as const, publicIPv4: '203.0.113.19', createActionId: 9006,
+    };
+    const getAction = vi.fn().mockResolvedValue({ id: 9006, status: 'running', command: 'create_server' });
+    const createServer = vi.fn().mockResolvedValue(replacement);
+    const deleteServer = vi.fn().mockResolvedValue(undefined);
+    const service = createCustomerVpsService({
+      db,
+      config: loadCustomerVpsConfig({
+        PLATFORM_SECRET: 'platform-secret', CUSTOMER_VPS_IMAGE_VERSION: 'v2',
+        MATRIX_HOST_BUNDLE_URL: 'https://bundles.example/system-bundles/v2/matrix-host-bundle.tar.gz',
+        GOLDEN_SNAPSHOTS_ENABLED: 'false', CUSTOMER_VPS_RECONCILIATION_STALE_AFTER_MS: '1000',
+        S3_ACCESS_KEY_ID: 'access-key', S3_SECRET_ACCESS_KEY: 'secret-key', S3_ENDPOINT: 'https://r2.example',
+      }),
+      hetzner: createMockHetznerClient({
+        createServer, getAction, deleteServer,
+        getServer: vi.fn(async (serverId: number) => serverId === 50
+          ? { id: 50, status: 'running', publicIPv4: '203.0.113.50', publicIPv6: null }
+          : replacement),
+      }),
+      systemStore: createMockCustomerVpsSystemStore({ hasDbLatest: async () => true }),
+      machineIdFactory: () => '30000000-0000-4000-8000-000000000025',
+      now: () => currentNow,
+    });
+
+    const recovery = await service.recover({ clerkUserId: 'user_recover', runtimeSlot: 'primary' });
+    getAction.mockResolvedValue({ id: 9006, status: 'error', command: 'create_server' });
+    currentNow = new Date('2026-07-03T00:02:00.000Z');
+    await service.reconcileProvisioning();
+    currentNow = new Date('2026-07-03T00:04:00.000Z');
+    await service.reconcileProvisioning();
+
+    await expect(db.executor.selectFrom('provider_deletion_queue').selectAll()
+      .where('provider_server_id', '=', replacement.id).execute()).resolves.toHaveLength(1);
+    await expect(getUserMachine(db, recovery.machineId)).resolves.toMatchObject({
+      status: 'recovering', recoveryCreateActionId: 9006, hetznerServerId: replacement.id,
+    });
+    expect(createServer).toHaveBeenCalledTimes(1);
+  });
+
+  it('reconciles an ambiguous clean fallback after a pending snapshot clone fails', async () => {
+    let currentNow = new Date('2026-07-03T00:00:00.000Z');
+    const createServer = vi.fn()
+      .mockResolvedValueOnce({
+        id: 123461, status: 'starting', publicIPv4: '203.0.113.15', createActionId: 9003,
+      })
+      .mockRejectedValueOnce(new Error('response lost'));
+    const getAction = vi.fn().mockResolvedValue({ id: 9003, status: 'running', command: 'create_server' });
+    const deleteServer = vi.fn().mockResolvedValue(undefined);
+    const config = loadCustomerVpsConfig({
+      PLATFORM_SECRET: 'platform-secret', CUSTOMER_VPS_IMAGE_VERSION: 'v2',
+      MATRIX_HOST_BUNDLE_URL: 'https://bundles.example/system-bundles/v2/matrix-host-bundle.tar.gz',
+      GOLDEN_SNAPSHOTS_ENABLED: 'true', GOLDEN_SNAPSHOT_ROLLOUT_PERCENT: '100', GOLDEN_SNAPSHOT_REGION: 'eu-central',
+      CUSTOMER_VPS_RECONCILIATION_STALE_AFTER_MS: '1000',
+      S3_ACCESS_KEY_ID: 'access-key', S3_SECRET_ACCESS_KEY: 'secret-key', S3_ENDPOINT: 'https://r2.example',
+    });
+    const service = createCustomerVpsService({
+      db, config,
+      hetzner: createMockHetznerClient({
+        createServer, getAction, deleteServer,
+        getServer: vi.fn(async (serverId: number) => serverId === 50
+          ? { id: 50, status: 'running', publicIPv4: '203.0.113.50', publicIPv6: null }
+          : null),
+        listServersByLabel: vi.fn().mockResolvedValue([]),
+      }),
+      systemStore: createMockCustomerVpsSystemStore({ hasDbLatest: async () => true }),
+      machineIdFactory: () => '30000000-0000-4000-8000-000000000015',
+      now: () => currentNow,
+    });
+
+    const recovery = await service.recover({ clerkUserId: 'user_recover', runtimeSlot: 'primary' });
+    getAction.mockResolvedValue({ id: 9003, status: 'error', command: 'create_server' });
+    currentNow = new Date('2026-07-03T00:02:00.000Z');
+    await service.reconcileProvisioning();
+
+    expect(deleteServer).toHaveBeenCalledWith(123461);
+    expect(deleteServer).not.toHaveBeenCalledWith(50);
+    expect(await db.executor.selectFrom('provider_deletion_queue').select('provider_server_id')
+      .where('provider_server_id', '=', 50).execute()).toEqual([]);
+    expect(await getUserMachine(db, recovery.machineId)).toMatchObject({
+      status: 'recovering',
+      hetznerServerId: null,
+      recoveryOldServerId: 50,
+      recoveryEncryptedPayload: expect.any(String),
+    });
+
+    currentNow = new Date('2026-07-04T00:00:00.000Z');
+    await service.reconcileProvisioning();
+    await expect(getUserMachine(db, '30000000-0000-4000-8000-000000000010')).resolves.toMatchObject({
+      status: 'running', hetznerServerId: 50,
+      recoveryOldServerId: null, recoveryEncryptedPayload: null,
+    });
+    await expect(getUserMachine(db, recovery.machineId)).resolves.toBeUndefined();
+  });
+
+  it('keeps the predecessor routable until a reconciled clean fallback registers', async () => {
+    let currentNow = new Date('2026-07-03T00:00:00.000Z');
+    const createServer = vi.fn()
+      .mockResolvedValueOnce({
+        id: 123466, status: 'starting', publicIPv4: '203.0.113.20', createActionId: 9007,
+      })
+      .mockResolvedValueOnce({
+        id: 123467, status: 'running', publicIPv4: '203.0.113.21',
+      });
+    const getAction = vi.fn().mockResolvedValue({ id: 9007, status: 'running', command: 'create_server' });
+    const deleteServer = vi.fn().mockResolvedValue(undefined);
+    const service = createCustomerVpsService({
+      db,
+      config: loadCustomerVpsConfig({
+        PLATFORM_SECRET: 'platform-secret', CUSTOMER_VPS_IMAGE_VERSION: 'v2',
+        MATRIX_HOST_BUNDLE_URL: 'https://bundles.example/system-bundles/v2/matrix-host-bundle.tar.gz',
+        GOLDEN_SNAPSHOTS_ENABLED: 'true', GOLDEN_SNAPSHOT_ROLLOUT_PERCENT: '100',
+        GOLDEN_SNAPSHOT_REGION: 'eu-central', CUSTOMER_VPS_RECONCILIATION_STALE_AFTER_MS: '1000',
+        S3_ACCESS_KEY_ID: 'access-key', S3_SECRET_ACCESS_KEY: 'secret-key', S3_ENDPOINT: 'https://r2.example',
+      }),
+      hetzner: createMockHetznerClient({
+        createServer, getAction, deleteServer,
+        getServer: vi.fn(async (serverId: number) => serverId === 50
+          ? { id: 50, status: 'running', publicIPv4: '203.0.113.50', publicIPv6: null }
+          : null),
+      }),
+      systemStore: createMockCustomerVpsSystemStore({ hasDbLatest: async () => true }),
+      machineIdFactory: () => '30000000-0000-4000-8000-000000000026',
+      now: () => currentNow,
+    });
+
+    const recovery = await service.recover({ clerkUserId: 'user_recover', runtimeSlot: 'primary' });
+    getAction.mockResolvedValue({ id: 9007, status: 'error', command: 'create_server' });
+    currentNow = new Date('2026-07-03T00:02:00.000Z');
+    await service.reconcileProvisioning();
+
+    expect(deleteServer).toHaveBeenCalledWith(123466);
+    expect(deleteServer).not.toHaveBeenCalledWith(50);
+    await expect(getUserMachine(db, recovery.machineId)).resolves.toMatchObject({
+      status: 'recovering',
+      hetznerServerId: 123467,
+      recoveryOldServerId: 50,
+      recoveryOldPublicIPv4: '203.0.113.50',
+      recoveryEncryptedPayload: expect.any(String),
+    });
+    await expect(db.executor.selectFrom('provider_deletion_queue').select('provider_server_id')
+      .where('provider_server_id', '=', 50).executeTakeFirst()).resolves.toBeUndefined();
+  });
+
+  it('does not apply a cascaded historical provisioning job to clean recovery registration', async () => {
+    await db.executor.insertInto('provisioning_jobs').values({
+      job_id: '50000000-0000-4000-8000-000000000001',
+      machine_id: '30000000-0000-4000-8000-000000000010',
+      status: 'completed', attempts: 1,
+      available_at: '2026-07-01T00:00:00.000Z', claimed_at: '2026-07-01T00:00:01.000Z',
+      lease_expires_at: null, encrypted_payload: 'legacy-completed-payload', last_error_code: null,
+      created_at: '2026-07-01T00:00:00.000Z', updated_at: '2026-07-01T00:01:00.000Z',
+      completed_at: '2026-07-01T00:01:00.000Z', target_bundle_version: 'v1',
+      target_bundle_sha256: '1'.repeat(64), image_source: 'snapshot',
+      snapshot_id: '10000000-0000-4000-8000-000000000010', snapshot_lease_id: null,
+      activation_step: 'registered', provider_create_action_id: null, fallback_reason: null,
+    }).execute();
+    const config = loadCustomerVpsConfig({
+      PLATFORM_SECRET: 'platform-secret', CUSTOMER_VPS_IMAGE_VERSION: 'v2',
+      MATRIX_HOST_BUNDLE_URL: 'https://bundles.example/system-bundles/v2/matrix-host-bundle.tar.gz',
+      GOLDEN_SNAPSHOTS_ENABLED: 'false',
+      S3_ACCESS_KEY_ID: 'access-key', S3_SECRET_ACCESS_KEY: 'secret-key', S3_ENDPOINT: 'https://r2.example',
+    });
+    const service = createCustomerVpsService({
+      db, config, hetzner: createMockHetznerClient(),
+      systemStore: createMockCustomerVpsSystemStore({ hasDbLatest: async () => true }),
+      machineIdFactory: () => '30000000-0000-4000-8000-000000000016',
+      tokenFactory: () => ({
+        token: 'clean-recovery-registration-token',
+        hash: hashRegistrationToken('clean-recovery-registration-token'),
+        expiresAt: '2026-07-03T01:00:00.000Z',
+      }),
+      now: () => new Date('2026-07-03T00:00:00.000Z'),
+    });
+
+    const recovery = await service.recover({ clerkUserId: 'user_recover', runtimeSlot: 'primary' });
+    await expect(service.register('clean-recovery-registration-token', {
+      machineId: recovery.machineId,
+      hetznerServerId: 123456,
+      publicIPv4: '203.0.113.10',
+      imageVersion: 'v2',
+      bundleSha256: '2'.repeat(64),
+      healthy: true,
+    })).resolves.toMatchObject({ registered: true, status: 'running' });
+    expect(await getUserMachine(db, recovery.machineId)).toMatchObject({
+      sourceSnapshotId: null,
+      sourceBaseGeneration: null,
+      targetBundleVersion: 'v2',
+      targetBundleSha256: '2'.repeat(64),
+    });
+  });
+});

--- a/tests/platform/golden-snapshot-repository.test.ts
+++ b/tests/platform/golden-snapshot-repository.test.ts
@@ -21,6 +21,7 @@ import {
   reconcileExpiredGoldenSnapshotLeases,
   reconcileRevokedGoldenSnapshotBaseGeneration,
   releaseGoldenSnapshotLease,
+  releaseGoldenSnapshotLeaseInTransaction,
   reserveGoldenSnapshotValidationCreate,
   retryGoldenSnapshotCleanup,
   retireGoldenSnapshot,
@@ -1385,6 +1386,37 @@ describe('golden snapshot repository', () => {
     }));
   });
 
+  it('releases a lease on the caller transaction without opening a nested transaction', async () => {
+    const enqueued = await enqueueGoldenSnapshotBuild(db, {
+      bundleVersion: 'v1', compatibility,
+      snapshotId: '10000000-0000-4000-8000-000000000064',
+      buildId: '20000000-0000-4000-8000-000000000064', now: '2026-07-03T00:00:00.000Z',
+    });
+    await db.executor.updateTable('golden_snapshots').set({
+      state: 'ready', ready_at: '2026-07-03T00:01:00.000Z', provider_image_id: 964,
+      provider_image_status: 'available', image_disk_gb: 40, image_architecture: 'x86',
+    }).where('snapshot_id', '=', enqueued.snapshot.snapshotId).execute();
+    const selected = await selectAndLeaseGoldenSnapshot(db, {
+      targetBundleVersion: 'v1', compatibility, serverDiskGb: 80,
+      machineId: '30000000-0000-4000-8000-000000000064', purpose: 'provision',
+      leaseId: '40000000-0000-4000-8000-000000000064',
+      now: '2026-07-03T00:02:00.000Z', expiresAt: '2026-07-03T00:12:00.000Z',
+    });
+
+    await expect(db.transaction(async (trx) => releaseGoldenSnapshotLeaseInTransaction(
+      {
+        ...trx,
+        transaction: async () => { throw new Error('nested transaction attempted'); },
+      },
+      selected!.lease.leaseId,
+      '2026-07-03T00:03:00.000Z',
+    ))).resolves.toBe(true);
+
+    await expect(db.executor.selectFrom('golden_snapshot_leases').select('released_at')
+      .where('lease_id', '=', selected!.lease.leaseId).executeTakeFirstOrThrow())
+      .resolves.toEqual({ released_at: '2026-07-03T00:03:00.000Z' });
+  });
+
   it('retains the bounded orphan deadline when revoking an in-flight provider create', async () => {
     const enqueued = await enqueueGoldenSnapshotBuild(db, {
       bundleVersion: 'v1', compatibility,
@@ -1421,8 +1453,10 @@ describe('golden snapshot repository', () => {
     await promoteHostBundleChannel(db, 'stable', 'v1', '2026-07-01T00:02:00.000Z');
 
     expect(await retireGoldenSnapshot(
-      db, enqueued.snapshot.snapshotId, 'freshness_expired', '2026-07-03T00:00:00.000Z', 2,
-      24 * 60 * 60 * 1000,
+      db, enqueued.snapshot.snapshotId, 'freshness_expired', '2026-07-03T00:00:00.000Z', {
+        rollbackVersionsPerChannel: 2,
+        freshnessMaxAgeMs: 24 * 60 * 60 * 1000,
+      },
     )).toBe(false);
     const replacement = await enqueueGoldenSnapshotBuild(db, {
       bundleVersion: 'v1', compatibility, replaceReady: true,
@@ -1433,8 +1467,10 @@ describe('golden snapshot repository', () => {
       state: 'ready', ready_at: '2026-07-03T00:02:00.000Z', provider_image_id: 114,
     }).where('snapshot_id', '=', replacement.snapshot.snapshotId).execute();
     expect(await retireGoldenSnapshot(
-      db, enqueued.snapshot.snapshotId, 'freshness_expired', '2026-07-03T00:03:00.000Z', 2,
-      24 * 60 * 60 * 1000,
+      db, enqueued.snapshot.snapshotId, 'freshness_expired', '2026-07-03T00:03:00.000Z', {
+        rollbackVersionsPerChannel: 2,
+        freshnessMaxAgeMs: 24 * 60 * 60 * 1000,
+      },
     )).toBe(true);
     await expect(getGoldenSnapshot(db, enqueued.snapshot.snapshotId)).resolves.toMatchObject({
       state: 'retiring',
@@ -1460,7 +1496,8 @@ describe('golden snapshot repository', () => {
     await promoteHostBundleChannel(db, 'stable', 'v2', '2026-07-03T00:03:00.000Z');
 
     expect(await retireGoldenSnapshot(
-      db, historical.snapshot.snapshotId, 'retention', '2026-07-03T00:04:00.000Z', 1,
+      db, historical.snapshot.snapshotId, 'retention', '2026-07-03T00:04:00.000Z',
+      { rollbackVersionsPerChannel: 1 },
     )).toBe(true);
   });
 
@@ -1590,6 +1627,28 @@ describe('golden snapshot repository', () => {
     )).rejects.toThrow('provider action conflict');
     await expect(getGoldenSnapshotCreateIntent(db, '40000000-0000-4000-8000-000000000056'))
       .resolves.toMatchObject({ providerCreateActionId: 7001 });
+  });
+
+  it('retires an exact provider image even when legacy build linkage is absent', async () => {
+    const enqueued = await enqueueGoldenSnapshotBuild(db, {
+      bundleVersion: 'v1', compatibility,
+      snapshotId: '10000000-0000-4000-8000-000000000027',
+      buildId: '20000000-0000-4000-8000-000000000027', now: '2026-07-03T00:00:00.000Z',
+    });
+    await db.executor.updateTable('golden_snapshots').set({
+      state: 'failed', provider_image_id: 127, failure_code: 'legacy_failed',
+    }).where('snapshot_id', '=', enqueued.snapshot.snapshotId).execute();
+    await db.executor.deleteFrom('golden_snapshot_builds')
+      .where('build_id', '=', enqueued.build.buildId).execute();
+
+    await expect(retireGoldenSnapshot(
+      db, enqueued.snapshot.snapshotId, 'failed_build', '2026-07-03T00:01:00.000Z',
+    )).resolves.toBe(true);
+    await expect(listPendingGoldenSnapshotCleanup(db, '2026-07-03T00:01:00.000Z', 10)).resolves.toEqual([
+      expect.objectContaining({
+        buildId: null, resourceType: 'snapshot_image', providerResourceId: 127,
+      }),
+    ]);
   });
 
   it('marks a base generation revoked immediately and quarantines it in bounded batches', async () => {

--- a/tests/platform/golden-snapshot-retention.test.ts
+++ b/tests/platform/golden-snapshot-retention.test.ts
@@ -1,0 +1,318 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { insertUserMachine, promoteHostBundleChannel, type PlatformDB, upsertHostBundleRelease } from '../../packages/platform/src/db.js';
+import {
+  advanceGoldenSnapshot, claimGoldenSnapshotBuild,
+  enforceGoldenSnapshotRetention,
+  enqueueGoldenSnapshotBuild,
+  markGoldenSnapshotReady,
+  recordGoldenSnapshotProviderImage,
+  revokeGoldenSnapshot,
+} from '../../packages/platform/src/golden-snapshot-repository.js';
+import { createTestPlatformDb, destroyTestPlatformDb } from './platform-db-test-helper.js';
+
+const compatibility = {
+  provider: 'hetzner' as const,
+  architecture: 'x86' as const,
+  region: 'eu-central',
+  baseImage: 'ubuntu-24.04',
+  baseGeneration: 'ubuntu-24.04-v1',
+  bootMode: 'bios' as const,
+  activationAbi: 'host-v1',
+  minimumDiskGb: 40,
+};
+const validationSummary = {
+  exactBundle: true as const,
+  healthy: true as const,
+  freshActivation: true as const,
+  uniqueMachineId: true as const,
+  uniqueSshHostKey: true as const,
+  forbiddenStateAbsent: true as const,
+};
+
+describe('golden snapshot retention', () => {
+  let db: PlatformDB;
+  beforeEach(async () => ({ db } = await createTestPlatformDb()));
+  afterEach(async () => destroyTestPlatformDb(db));
+
+  async function ready(index: number, testMode = false) {
+    const version = `v${index}`;
+    const at = `2026-07-${String(index).padStart(2, '0')}T00:00:00.000Z`;
+    await upsertHostBundleRelease(db, {
+      version, gitCommit: `${index}`.repeat(7), buildTime: at,
+      bundleKey: `system-bundles/${version}/matrix-host-bundle.tar.gz`, checksumKey: null,
+      sha256: index.toString(16).repeat(64), size: 100, createdAt: at,
+    });
+    const snapshotId = `10000000-0000-4000-8000-${String(index).padStart(12, '0')}`;
+    const buildId = `20000000-0000-4000-8000-${String(index).padStart(12, '0')}`;
+    const enqueued = await enqueueGoldenSnapshotBuild(db, {
+      bundleVersion: version, compatibility, snapshotId, buildId, testMode, now: at,
+    });
+    const claimed = await claimGoldenSnapshotBuild(db, buildId, at, '2026-08-01T00:10:00.000Z', 5);
+    const fence = claimed!.leaseExpiresAt!;
+    await advanceGoldenSnapshot(db, snapshotId, buildId, fence, 'candidate', 'building', at);
+    await advanceGoldenSnapshot(db, snapshotId, buildId, fence, 'building', 'sanitizing', at);
+    await advanceGoldenSnapshot(db, snapshotId, buildId, fence, 'sanitizing', 'validating', at);
+    await recordGoldenSnapshotProviderImage(db, snapshotId, {
+      buildId: enqueued.build.buildId, expectedLeaseExpiresAt: fence,
+      providerImageId: 300 + index, providerImageStatus: 'available', imageDiskGb: 40,
+      imageArchitecture: 'x86', now: at,
+    });
+    const leaseExpiresAt = new Date(new Date(at).getTime() + 600_000).toISOString();
+    await db.executor.updateTable('golden_snapshot_builds').set({
+      phase: 'validation_boot', status: 'running', lease_expires_at: leaseExpiresAt,
+    }).where('build_id', '=', enqueued.build.buildId).execute();
+    await markGoldenSnapshotReady(db, snapshotId, enqueued.build.buildId, {
+      validationSummary, expectedLeaseExpiresAt: leaseExpiresAt, now: at,
+    });
+    return { version, snapshotId };
+  }
+
+  it('retires only unleased, non-channel, non-rollback snapshots and preserves one compatible image', async () => {
+    const oldest = await ready(1);
+    const rollback = await ready(2);
+    const leased = await ready(3);
+    const newest = await ready(4);
+    await promoteHostBundleChannel(db, 'stable', rollback.version, '2026-07-04T01:00:00.000Z');
+    await promoteHostBundleChannel(db, 'stable', newest.version, '2026-07-04T02:00:00.000Z');
+    await db.executor.insertInto('golden_snapshot_leases').values({
+      lease_id: '40000000-0000-4000-8000-000000000003', snapshot_id: leased.snapshotId,
+      machine_id: '30000000-0000-4000-8000-000000000003', purpose: 'provision',
+      target_bundle_version: newest.version, created_at: '2026-07-04T00:00:00.000Z',
+      expires_at: '2026-07-04T03:00:00.000Z', released_at: null,
+    }).execute();
+
+    const result = await enforceGoldenSnapshotRetention(db, {
+      retentionLimit: 3, rollbackVersionsPerChannel: 1,
+      now: '2026-07-04T02:30:00.000Z', quotaPressure: false,
+    });
+
+    expect(result).toEqual({ retiredSnapshotIds: [oldest.snapshotId], blocked: false });
+    expect((await db.executor.selectFrom('golden_snapshots').select(['snapshot_id', 'state']).execute()))
+      .toEqual(expect.arrayContaining([
+        expect.objectContaining({ snapshot_id: rollback.snapshotId, state: 'ready' }),
+        expect.objectContaining({ snapshot_id: leased.snapshotId, state: 'ready' }),
+        expect.objectContaining({ snapshot_id: newest.snapshotId, state: 'ready' }),
+      ]));
+  });
+
+  it('refuses quota-pressure deletion when every candidate is protected', async () => {
+    const only = await ready(1);
+    await promoteHostBundleChannel(db, 'stable', only.version, '2026-07-02T00:00:00.000Z');
+    await expect(enforceGoldenSnapshotRetention(db, {
+      retentionLimit: 1, rollbackVersionsPerChannel: 1,
+      now: '2026-07-03T00:00:00.000Z', quotaPressure: true,
+    })).resolves.toEqual({ retiredSnapshotIds: [], blocked: true });
+  });
+
+  it('retires a freshness-expired channel snapshot only after its replacement is ready', async () => {
+    const stale = await ready(1);
+    await promoteHostBundleChannel(db, 'stable', stale.version, '2026-07-01T01:00:00.000Z');
+
+    await expect(enforceGoldenSnapshotRetention(db, {
+      retentionLimit: 20, rollbackVersionsPerChannel: 2,
+      freshnessMaxAgeMs: 24 * 60 * 60 * 1000,
+      now: '2026-07-03T00:00:00.000Z', quotaPressure: false,
+    })).resolves.toEqual({ retiredSnapshotIds: [], blocked: true });
+
+    const replacement = await enqueueGoldenSnapshotBuild(db, {
+      bundleVersion: stale.version, compatibility, replaceReady: true,
+      snapshotId: '10000000-0000-4000-8000-000000000011',
+      buildId: '20000000-0000-4000-8000-000000000011',
+      now: '2026-07-03T00:01:00.000Z',
+    });
+    await db.executor.updateTable('golden_snapshots').set({
+      state: 'ready', ready_at: '2026-07-03T00:02:00.000Z', provider_image_id: 311,
+    }).where('snapshot_id', '=', replacement.snapshot.snapshotId).execute();
+
+    await expect(enforceGoldenSnapshotRetention(db, {
+      retentionLimit: 20, rollbackVersionsPerChannel: 2,
+      freshnessMaxAgeMs: 24 * 60 * 60 * 1000,
+      now: '2026-07-03T00:03:00.000Z', quotaPressure: false,
+    })).resolves.toEqual({ retiredSnapshotIds: [stale.snapshotId], blocked: false });
+  });
+
+  it('expires test-mode snapshots on their own TTL without counting them against production retention', async () => {
+    const expiredTest = await ready(1, true);
+    const productionOld = await ready(2);
+    const productionNew = await ready(3);
+
+    await expect(enforceGoldenSnapshotRetention(db, {
+      retentionLimit: 2,
+      rollbackVersionsPerChannel: 1,
+      testModeTtlMs: 24 * 60 * 60 * 1000,
+      now: '2026-07-04T00:00:00.000Z',
+      quotaPressure: false,
+    })).resolves.toEqual({ retiredSnapshotIds: [expiredTest.snapshotId], blocked: false });
+
+    await expect(db.executor.selectFrom('golden_snapshots').select(['snapshot_id', 'state'])
+      .where('snapshot_id', 'in', [productionOld.snapshotId, productionNew.snapshotId])
+      .orderBy('snapshot_id').execute()).resolves.toEqual([
+      { snapshot_id: productionOld.snapshotId, state: 'ready' },
+      { snapshot_id: productionNew.snapshotId, state: 'ready' },
+    ]);
+  });
+
+  it('does not report retention blocked when the only freshness-expired image is leased', async () => {
+    const stale = await ready(1);
+    await db.executor.insertInto('golden_snapshot_leases').values({
+      lease_id: '40000000-0000-4000-8000-000000000091', snapshot_id: stale.snapshotId,
+      machine_id: '30000000-0000-4000-8000-000000000091', purpose: 'provision',
+      target_bundle_version: stale.version, created_at: '2026-07-01T01:00:00.000Z',
+      expires_at: '2026-07-04T00:00:00.000Z', released_at: null,
+    }).execute();
+
+    await expect(enforceGoldenSnapshotRetention(db, {
+      retentionLimit: 20, rollbackVersionsPerChannel: 2,
+      freshnessMaxAgeMs: 24 * 60 * 60 * 1000,
+      now: '2026-07-03T00:00:00.000Z', quotaPressure: false,
+    })).resolves.toEqual({ retiredSnapshotIds: [], blocked: false });
+  });
+
+  it('releases bounded expired recovery leases only after machine recovery is terminal', async () => {
+    const snapshot = await ready(1);
+    await insertUserMachine(db, {
+      machineId: '30000000-0000-4000-8000-000000000099', clerkUserId: 'user_lease', handle: 'lease-test',
+      runtimeSlot: 'primary', developerTools: [], status: 'running', imageVersion: 'v1',
+      provisionedAt: '2026-07-01T00:00:00.000Z',
+    });
+    await db.executor.insertInto('golden_snapshot_leases').values({
+      lease_id: '40000000-0000-4000-8000-000000000099', snapshot_id: snapshot.snapshotId,
+      machine_id: '30000000-0000-4000-8000-000000000099', purpose: 'recover', target_bundle_version: 'v1',
+      created_at: '2026-07-01T00:00:00.000Z', expires_at: '2026-07-01T00:10:00.000Z', released_at: null,
+    }).execute();
+    await enforceGoldenSnapshotRetention(db, {
+      retentionLimit: 1, rollbackVersionsPerChannel: 1,
+      now: '2026-07-02T00:00:00.000Z', quotaPressure: false,
+    });
+    expect(await db.executor.selectFrom('golden_snapshot_leases').select('released_at')
+      .where('lease_id', '=', '40000000-0000-4000-8000-000000000099').executeTakeFirst()).toEqual({
+      released_at: '2026-07-02T00:00:00.000Z',
+    });
+  });
+
+  it('retires failed or quarantined provider images even below the ready retention limit', async () => {
+    const revoked = await ready(1);
+    await revokeGoldenSnapshot(db, revoked.snapshotId, 'validation_revoked', '2026-07-02T00:00:00.000Z');
+
+    await expect(enforceGoldenSnapshotRetention(db, {
+      retentionLimit: 20, rollbackVersionsPerChannel: 1,
+      now: '2026-07-03T00:00:00.000Z', quotaPressure: false,
+    })).resolves.toEqual({ retiredSnapshotIds: [revoked.snapshotId], blocked: false });
+    expect(await db.executor.selectFrom('golden_snapshots').select('state')
+      .where('snapshot_id', '=', revoked.snapshotId).executeTakeFirst()).toEqual({ state: 'retiring' });
+  });
+
+  it('retires and replaces a pre-ready quarantined snapshot with no provider image or lease', async () => {
+    const at = '2026-07-01T00:00:00.000Z';
+    await upsertHostBundleRelease(db, {
+      version: 'v-pre-ready', gitCommit: 'abcdef0', buildTime: at,
+      bundleKey: 'system-bundles/v-pre-ready/matrix-host-bundle.tar.gz', checksumKey: null,
+      sha256: 'a'.repeat(64), size: 100, createdAt: at,
+    });
+    const first = await enqueueGoldenSnapshotBuild(db, {
+      bundleVersion: 'v-pre-ready', compatibility,
+      snapshotId: '10000000-0000-4000-8000-000000000021',
+      buildId: '20000000-0000-4000-8000-000000000021',
+      now: at,
+    });
+    await revokeGoldenSnapshot(
+      db, first.snapshot.snapshotId, 'bundle_digest_mismatch', '2026-07-01T00:01:00.000Z',
+    );
+
+    await expect(enforceGoldenSnapshotRetention(db, {
+      retentionLimit: 20, rollbackVersionsPerChannel: 1,
+      now: '2026-07-01T00:02:00.000Z', quotaPressure: false,
+    })).resolves.toEqual({ retiredSnapshotIds: [first.snapshot.snapshotId], blocked: false });
+    await expect(db.executor.selectFrom('golden_snapshots').select('state')
+      .where('snapshot_id', '=', first.snapshot.snapshotId).executeTakeFirst())
+      .resolves.toEqual({ state: 'deleted' });
+
+    const replacement = await enqueueGoldenSnapshotBuild(db, {
+      bundleVersion: 'v-pre-ready', compatibility,
+      snapshotId: '10000000-0000-4000-8000-000000000022',
+      buildId: '20000000-0000-4000-8000-000000000022',
+      now: '2026-07-01T00:03:00.000Z',
+    });
+    expect(replacement).toMatchObject({
+      reused: false,
+      snapshot: { imageGeneration: 2, state: 'candidate' },
+    });
+  });
+
+  it('preserves rollback history independently for a quiet channel', async () => {
+    const rollback = await ready(1);
+    const current = await ready(2);
+    const disposable = await ready(3);
+    await ready(4);
+    await promoteHostBundleChannel(db, 'stable', rollback.version, '2026-07-05T00:00:00.000Z');
+    await promoteHostBundleChannel(db, 'stable', current.version, '2026-07-05T01:00:00.000Z');
+
+    const noisyReleases = Array.from({ length: 101 }, (_, index) => {
+      const version = `noise-${index}`;
+      const promotedAt = new Date(Date.UTC(2026, 7, 1, 0, 0, index)).toISOString();
+      return {
+        release: {
+          version, channel: null, git_commit: `noise-${index}`, git_ref: null,
+          build_time: promotedAt, bundle_key: `system-bundles/${version}/matrix-host-bundle.tar.gz`,
+          checksum_key: null, incremental_manifest_key: null, incremental_manifest_sha256: null,
+          sha256: index.toString(16).padStart(64, '0'), size: 100, severity: 'normal',
+          update_type: 'manual', changelog: null, created_at: promotedAt,
+        },
+        history: { channel: 'dev', version, promoted_at: promotedAt },
+      };
+    });
+    await db.transaction(async (trx) => {
+      await trx.executor.insertInto('host_bundle_releases').values(noisyReleases.map((row) => row.release)).execute();
+      await trx.executor.insertInto('host_bundle_release_channels').values(noisyReleases.map((row) => row.history)).execute();
+      await trx.executor.insertInto('host_bundle_channels').values({
+        channel: 'dev', version: 'noise-100', updated_at: noisyReleases[100]!.history.promoted_at,
+      }).execute();
+    });
+
+    const result = await enforceGoldenSnapshotRetention(db, {
+      retentionLimit: 3, rollbackVersionsPerChannel: 1,
+      now: '2026-08-02T00:00:00.000Z', quotaPressure: false,
+    });
+    expect(result).toEqual({ retiredSnapshotIds: [disposable.snapshotId], blocked: false });
+    expect(await db.executor.selectFrom('golden_snapshots').select('state')
+      .where('snapshot_id', '=', rollback.snapshotId).executeTakeFirst()).toEqual({ state: 'ready' });
+  });
+
+  it('retires channel history older than the configured rollback window', async () => {
+    const expiredHistory = await ready(1);
+    const rollback = await ready(2);
+    const current = await ready(3);
+    await promoteHostBundleChannel(db, 'stable', expiredHistory.version, '2026-07-04T01:00:00.000Z');
+    await promoteHostBundleChannel(db, 'stable', rollback.version, '2026-07-04T02:00:00.000Z');
+    await promoteHostBundleChannel(db, 'stable', current.version, '2026-07-04T03:00:00.000Z');
+
+    await expect(enforceGoldenSnapshotRetention(db, {
+      retentionLimit: 2, rollbackVersionsPerChannel: 1,
+      now: '2026-07-04T04:00:00.000Z', quotaPressure: false,
+    })).resolves.toEqual({ retiredSnapshotIds: [expiredHistory.snapshotId], blocked: false });
+  });
+
+  it('continues a bounded sweep after one candidate retirement fails', async () => {
+    const first = await ready(1);
+    const second = await ready(2);
+    await ready(3);
+    const originalTransaction = db.transaction.bind(db);
+    let calls = 0;
+    const flakyDb = {
+      ...db,
+      transaction: async <T>(fn: (trx: PlatformDB) => Promise<T>) => {
+        calls += 1;
+        if (calls === 1) throw new Error('synthetic transient failure');
+        return originalTransaction(fn);
+      },
+    } as PlatformDB;
+
+    const result = await enforceGoldenSnapshotRetention(flakyDb, {
+      retentionLimit: 1, rollbackVersionsPerChannel: 0,
+      now: '2026-07-04T00:00:00.000Z', quotaPressure: false,
+    });
+    expect(result).toEqual({ retiredSnapshotIds: [second.snapshotId], blocked: true });
+    expect(await db.executor.selectFrom('golden_snapshots').select('state')
+      .where('snapshot_id', '=', first.snapshotId).executeTakeFirst()).toEqual({ state: 'ready' });
+  });
+});

--- a/tests/platform/golden-snapshot-routes.test.ts
+++ b/tests/platform/golden-snapshot-routes.test.ts
@@ -141,6 +141,15 @@ describe('golden snapshot control-plane routes', () => {
     expect(response.status).toBe(202);
   });
 
+  it('uses the scoped operator credential for snapshot administration', async () => {
+    expect((await app().request('/snapshots', {
+      headers: { authorization: 'Bearer platform-secret' },
+    })).status).toBe(401);
+    expect((await app().request('/snapshots', {
+      headers: { authorization: 'Bearer operator-secret' },
+    })).status).toBe(200);
+  });
+
   it('passes phase tokens to the service and returns only generic callback errors', async () => {
     service.consumeCallback.mockRejectedValueOnce(new GoldenSnapshotCallbackError('unauthorized'));
     const response = await app().request('/snapshot-builds/20000000-0000-4000-8000-000000000001/callback', {
@@ -229,5 +238,95 @@ describe('golden snapshot control-plane routes', () => {
     );
     expect(callback.status).toBe(400);
 
+    const headers = { authorization: 'Bearer operator-secret', 'content-type': 'application/json' };
+    const retryBody = JSON.stringify({ padding: 'x'.repeat(2_000) });
+    const retry = await app().request(
+      '/snapshot-builds/20000000-0000-4000-8000-000000000001/retry',
+      {
+        method: 'POST',
+        headers: { ...headers, 'content-length': String(Buffer.byteLength(retryBody)) },
+        body: retryBody,
+      },
+    );
+    expect(retry.status).toBe(413);
+
+    const revoke = await app().request(
+      '/snapshots/10000000-0000-4000-8000-000000000001/revoke',
+      { method: 'POST', headers, body: JSON.stringify({ reason: 'unsafe', padding: 'x'.repeat(5_000) }) },
+    );
+    expect(revoke.status).toBe(413);
+  });
+
+  it('provides authenticated bounded status and immediate revocation controls without provider details', async () => {
+    const enqueue = await app().request('/snapshot-builds', {
+      method: 'POST', headers: { authorization: 'Bearer platform-secret', 'content-type': 'application/json' },
+      body: JSON.stringify({ bundleVersion: 'v1' }),
+    });
+    const { snapshotId } = await enqueue.json() as { snapshotId: string };
+    const status = await app().request('/snapshots?limit=10', {
+      headers: { authorization: 'Bearer operator-secret' },
+    });
+    expect(status.status).toBe(200);
+    expect(await status.json()).toEqual({ snapshots: [expect.objectContaining({ snapshotId, state: 'candidate' })] });
+    expect(JSON.stringify(await app().request('/snapshots?limit=10', {
+      headers: { authorization: 'Bearer operator-secret' },
+    }).then((response) => response.json()))).not.toContain('providerImageId');
+
+    const revoked = await app().request(`/snapshots/${snapshotId}/revoke`, {
+      method: 'POST', headers: { authorization: 'Bearer operator-secret', 'content-type': 'application/json' },
+      body: JSON.stringify({ reason: 'operator_revoked' }),
+    });
+    expect(revoked.status).toBe(200);
+    expect(await revoked.json()).toEqual({ revoked: true });
+  });
+
+  it('retries only a persisted failed build through the authenticated bounded control', async () => {
+    const enqueue = await app().request('/snapshot-builds', {
+      method: 'POST', headers: { authorization: 'Bearer platform-secret', 'content-type': 'application/json' },
+      body: JSON.stringify({ bundleVersion: 'v1' }),
+    });
+    const ids = await enqueue.json() as { snapshotId: string; buildId: string };
+    await db.executor.updateTable('golden_snapshots').set({ state: 'failed', failure_code: 'synthetic_failure' })
+      .where('snapshot_id', '=', ids.snapshotId).execute();
+    await db.executor.updateTable('golden_snapshot_builds').set({ status: 'failed', phase: 'failed' })
+      .where('build_id', '=', ids.buildId).execute();
+
+    const retried = await app().request(`/snapshot-builds/${ids.buildId}/retry`, {
+      method: 'POST', headers: { authorization: 'Bearer operator-secret' },
+    });
+    expect(retried.status).toBe(200);
+    expect(await retried.json()).toEqual({ retried: true });
+    expect(await db.executor.selectFrom('golden_snapshot_builds').select(['status', 'phase'])
+      .where('build_id', '=', ids.buildId).executeTakeFirst()).toMatchObject({ status: 'queued', phase: 'requested' });
+    expect(await db.executor.selectFrom('golden_snapshots').select('state')
+      .where('snapshot_id', '=', ids.snapshotId).executeTakeFirst()).toEqual({ state: 'candidate' });
+  });
+
+  it('returns generic JSON when retry or revoke persistence is unavailable', async () => {
+    const brokenDb = {
+      ...db,
+      transaction: async () => { throw new Error('synthetic database path'); },
+      executor: new Proxy(db.executor, {
+        get(target, property, receiver) {
+          if (property === 'updateTable') return () => { throw new Error('synthetic database path'); };
+          return Reflect.get(target, property, receiver);
+        },
+      }),
+    } as PlatformDB;
+    const brokenApp = createGoldenSnapshotRoutes({
+      db: brokenDb, service, config, platformSecret: 'platform-secret', operatorSecret: 'operator-secret',
+      now: () => '2026-07-03T00:00:00.000Z', idFactory: () => ids.shift()!,
+    });
+    const retry = await brokenApp.request('/snapshot-builds/20000000-0000-4000-8000-000000000001/retry', {
+      method: 'POST', headers: { authorization: 'Bearer operator-secret' },
+    });
+    expect(retry.status).toBe(500);
+    expect(await retry.json()).toEqual({ error: 'Snapshot retry unavailable' });
+    const revoke = await brokenApp.request('/snapshots/10000000-0000-4000-8000-000000000001/revoke', {
+      method: 'POST', headers: { authorization: 'Bearer operator-secret', 'content-type': 'application/json' },
+      body: JSON.stringify({ reason: 'operator_revoked' }),
+    });
+    expect(revoke.status).toBe(500);
+    expect(await revoke.json()).toEqual({ error: 'Snapshot revocation unavailable' });
   });
 });

--- a/tests/platform/golden-snapshot-service.test.ts
+++ b/tests/platform/golden-snapshot-service.test.ts
@@ -21,7 +21,10 @@ import {
 } from '../../packages/platform/src/golden-snapshot-repository.js';
 import type { GoldenSnapshotRuntimeConfig } from '../../packages/platform/src/golden-snapshot-schema.js';
 import { createMockHetznerClient } from './customer-vps-fixtures.js';
-import { DefinitiveProviderRejectionError } from '../../packages/platform/src/customer-vps-errors.js';
+import {
+  CustomerVpsError,
+  DefinitiveProviderRejectionError,
+} from '../../packages/platform/src/customer-vps-errors.js';
 import { createTestPlatformDb, destroyTestPlatformDb } from './platform-db-test-helper.js';
 
 const compatibility = {
@@ -1288,6 +1291,24 @@ describe('golden snapshot build service', () => {
     expect(await service.runBuildStep(enqueued.build.buildId)).toBe('snapshot_wait');
     expect(await service.runBuildStep(enqueued.build.buildId)).toBe('snapshot_wait');
     expect(hetzner.createServer).toHaveBeenCalledTimes(1);
+  });
+
+  it('requeues snapshot creation after provider quota pressure', async () => {
+    const { enqueued, service } = await setup({
+      createSnapshot: vi.fn().mockRejectedValue(
+        new CustomerVpsError(429, 'quota_exceeded', 'Provisioning capacity unavailable'),
+      ),
+    });
+    await service.runBuildStep(enqueued.build.buildId);
+    await service.consumeCallback(enqueued.build.buildId, 'phase-token-long-enough', {
+      eventId: randomUUID(),
+      phase: 'sanitized', bundleVersion: 'v1', bundleSha256: '1'.repeat(64), ...builderFingerprints,
+    });
+    await expect(service.runBuildStep(enqueued.build.buildId))
+      .rejects.toMatchObject({ code: 'snapshot_quota_exceeded' });
+    await expect(getGoldenSnapshotBuild(db, enqueued.build.buildId)).resolves.toMatchObject({
+      phase: 'snapshot_create', pendingOperation: null,
+    });
   });
 
   it('uses a bounded hard power-off fallback when graceful shutdown stalls', async () => {

--- a/tests/platform/golden-snapshot-worker-wiring.test.ts
+++ b/tests/platform/golden-snapshot-worker-wiring.test.ts
@@ -20,6 +20,8 @@ describe('golden snapshot worker wiring', () => {
     );
     expect(worker).toContain("logPlatformRouteError('golden snapshot reconciliation', err)");
     expect(worker.indexOf('try {')).toBeLessThan(worker.indexOf('claimGoldenSnapshotBuildBatch'));
+    expect(worker.indexOf('const retention = await enforceGoldenSnapshotRetention'))
+      .toBeLessThan(worker.indexOf("logPlatformRouteError('golden snapshot reconciliation', err)"));
   });
 
   it('pauses build claims while keeping cleanup enabled when builds are disabled', async () => {
@@ -42,6 +44,9 @@ describe('golden snapshot worker wiring', () => {
       .toBeGreaterThan(worker.indexOf('listRunnableGoldenSnapshotBuildIds'));
     expect(worker.indexOf('listCallbackWaitGoldenSnapshotBuildIds'))
       .toBeLessThan(worker.indexOf('listUnresolvedGoldenSnapshotBuildIds'));
+    expect(worker).toContain("err.code === 'snapshot_quota_exceeded'");
+    expect(worker).toContain('quotaPressure = true');
+    expect(worker).toContain('quotaPressure,');
   });
 
   it('mounts snapshot status routes before the generic bundle catch-all', async () => {


### PR DESCRIPTION
## Summary

- accelerate replacement recovery without treating the golden image as an owner backup
- add bounded retention, revocation, cleanup retry, reconciliation, and operator controls
- preserve predecessor routing until exact target registration and safe handoff

## Tests

- [x] Recovery, retention, repository, and route focused cases: 43 passed across the correction run
- [x] Platform TypeScript project check
- [x] PR size: 9 files, 1,276 additions

## Invariants

### Source of truth

Postgres recovery jobs, owner backup scope, predecessor/replacement identity, leases, revocations, retention protection, and cleanup records are authoritative.

### Lock/transaction scope

Selection, handoff, revoke, retry, and cleanup writes use bounded transactions/conditional updates. Provider calls remain outside transaction and lock scope with timeouts.

### Acceptable orphan states

Only durable ambiguous-create, cleanup-pending, failed, and quarantined states with exact provenance are accepted. Routing never moves to an unvalidated replacement.

### Authorization source

Existing customer ownership/billing checks protect recovery. Operator status/retry/revoke paths use the separate operator secret and return generic client errors.

### Deferred scope

Release workflow enqueue, public rollout enablement, production deployment, and private operator-site documentation remain deferred upstack or to separate authorization.