### PR TITLE
ci(release): enqueue golden snapshot builds

### DIFF
--- a/.github/workflows/host-bundle-release.yml
+++ b/.github/workflows/host-bundle-release.yml
@@ -368,6 +368,7 @@ jobs:
           PUBLISH_VERSION: ${{ needs.build.outputs.version }}
           PUBLISH_SEVERITY: ${{ steps.meta.outputs.severity }}
           PUBLISH_CHANGELOG: ${{ steps.meta.outputs.changelog }}
+          GOLDEN_SNAPSHOT_ELIGIBLE: ${{ (github.event_name == 'push' && ((github.ref_type == 'branch' && github.ref_name == 'main') || github.ref_type == 'tag')) || (github.event_name == 'workflow_dispatch' && inputs.channel != '') }}
         run: |
           set -euo pipefail
           ARGS=("$PUBLISH_VERSION")
@@ -380,6 +381,34 @@ jobs:
 
           ./scripts/publish-release.sh "${ARGS[@]}"
 
+  enqueue-golden-snapshot:
+    name: Enqueue golden snapshot build
+    needs: [dev-bundle-gate, build, publish]
+    if: ${{ needs.dev-bundle-gate.outputs.should_build == 'true' && ((github.event_name == 'push' && ((github.ref_type == 'branch' && github.ref_name == 'main') || github.ref_type == 'tag')) || (github.event_name == 'workflow_dispatch' && inputs.channel != '')) }}
+    continue-on-error: true
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    env:
+      PLATFORM_PUBLIC_URL: ${{ vars.PLATFORM_PUBLIC_URL || 'https://app.matrix-os.com' }}
+      PLATFORM_SECRET: ${{ secrets.PLATFORM_SECRET }}
+      PUBLISH_CHANNEL: ${{ needs.build.outputs.channel }}
+      PUBLISH_VERSION: ${{ needs.build.outputs.version }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: pnpm/action-setup@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: pnpm
+
+      - name: Install enqueue dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Enqueue idempotent snapshot build
+        run: node scripts/enqueue-golden-snapshot.mjs --version "$PUBLISH_VERSION"
+
   deploy:
     name: Deploy published host bundle
     needs: [dev-bundle-gate, build, publish]
@@ -389,11 +418,12 @@ jobs:
     env:
       PLATFORM_PUBLIC_URL: ${{ vars.PLATFORM_PUBLIC_URL || 'https://app.matrix-os.com' }}
       PLATFORM_SECRET: ${{ secrets.PLATFORM_SECRET }}
+      PUBLISH_VERSION: ${{ needs.build.outputs.version }}
     steps:
       - name: Trigger exact-version VPS deploy
         run: |
           set -euo pipefail
-          VERSION="${{ needs.build.outputs.version }}"
+          VERSION="$PUBLISH_VERSION"
           if [ -z "${PLATFORM_SECRET:-}" ]; then
             echo "PLATFORM_SECRET is required to deploy published host bundles." >&2
             exit 1

--- a/.github/workflows/platform-cloud-run.yml
+++ b/.github/workflows/platform-cloud-run.yml
@@ -116,6 +116,36 @@ jobs:
             exit 1
           fi
 
+      - name: Verify golden snapshot operator secret
+        run: |
+          set -euo pipefail
+          snapshot_operator_secret_name=golden-snapshot-operator-secret
+          gcloud secrets describe "$snapshot_operator_secret_name" \
+            --project "$GCP_PROJECT_ID" >/dev/null
+          snapshot_operator_secret_tmpfile="$(mktemp)"
+          trap 'rm -f "$snapshot_operator_secret_tmpfile"' EXIT
+          if ! gcloud secrets versions access latest --secret "$snapshot_operator_secret_name" \
+            --project "$GCP_PROJECT_ID" >"$snapshot_operator_secret_tmpfile"; then
+            echo "Golden snapshot operator secret must have an accessible latest version." >&2
+            exit 1
+          fi
+          if [ ! -s "$snapshot_operator_secret_tmpfile" ]; then
+            echo "Golden snapshot operator secret must not be empty." >&2
+            exit 1
+          fi
+          accessor_member="$(
+            gcloud secrets get-iam-policy "$snapshot_operator_secret_name" \
+              --project "$GCP_PROJECT_ID" \
+              --flatten='bindings[].members' \
+              --filter="bindings.role:roles/secretmanager.secretAccessor AND bindings.members:serviceAccount:${CLOUD_RUN_SERVICE_ACCOUNT}" \
+              --format='value(bindings.members)' \
+              | head -1
+          )"
+          if [ "$accessor_member" != "serviceAccount:${CLOUD_RUN_SERVICE_ACCOUNT}" ]; then
+            echo "Golden snapshot operator secret must grant roles/secretmanager.secretAccessor to ${CLOUD_RUN_SERVICE_ACCOUNT}." >&2
+            exit 1
+          fi
+
       - name: Verify Stripe billing secrets
         run: |
           set -euo pipefail
@@ -382,7 +412,7 @@ jobs:
             --allow-unauthenticated \
             "${traffic_flags[@]}" \
             --set-env-vars "PLATFORM_RUNTIME_MODE=cloud_run,PLATFORM_PORT=8080,PLATFORM_PUBLIC_URL=${PLATFORM_PUBLIC_URL},MATRIX_API_ORIGIN=${MATRIX_API_ORIGIN},CUSTOMER_VPS_ENABLED=true,CUSTOMER_VPS_TLS_VERIFY=false,CUSTOMER_VPS_IMAGE_VERSION=${CUSTOMER_VPS_IMAGE_VERSION},CUSTOMER_VPS_CLOUD_INIT_PATH=distro/customer-vps/cloud-init.yaml,MATRIX_LEGACY_CONTAINER_ROUTING_ENABLED=false,AUTH_SHELL_HOST=127.0.0.1,AUTH_SHELL_PORT=3200,MATRIX_APP_DOMAIN_HOSTS=${MATRIX_APP_DOMAIN_HOSTS},MATRIX_CODE_DOMAIN_HOSTS=${MATRIX_CODE_DOMAIN_HOSTS},NEXT_PUBLIC_MATRIX_APP_URL=${MATRIX_APP_URL},MATRIX_BILLING_PROVIDER=stripe,POSTHOG_HOST=https://eu.i.posthog.com,POSTHOG_API_HOST=https://eu.i.posthog.com,NEXT_PUBLIC_POSTHOG_HOST=${POSTHOG_PUBLIC_HOST},NEXT_PUBLIC_POSTHOG_API_HOST=${POSTHOG_PUBLIC_API_HOST},R2_PREFIX_ROOT=matrixos-sync" \
-            --set-secrets "PLATFORM_DATABASE_URL=platform-database-url:latest,PLATFORM_SECRET=platform-secret:latest,PLATFORM_JWT_SECRET=platform-jwt-secret:latest,EDGE_ROUTER_SECRET=edge-router-secret:latest,CLERK_SECRET_KEY=clerk-secret-key:latest,STRIPE_SECRET_KEY=stripe-secret-key:latest,STRIPE_WEBHOOK_SECRET=stripe-webhook-secret:latest,STRIPE_PRICE_MATRIX_STARTER_MONTHLY=stripe-price-matrix-starter-monthly:latest,STRIPE_PRICE_MATRIX_STARTER_ANNUAL=stripe-price-matrix-starter-annual:latest,STRIPE_PRICE_MATRIX_BUILDER_MONTHLY=stripe-price-matrix-builder-monthly:latest,STRIPE_PRICE_MATRIX_BUILDER_ANNUAL=stripe-price-matrix-builder-annual:latest,STRIPE_PRICE_MATRIX_MAX_MONTHLY=stripe-price-matrix-max-monthly:latest,STRIPE_PRICE_MATRIX_MAX_ANNUAL=stripe-price-matrix-max-annual:latest,PIPEDREAM_CLIENT_ID=pipedream-client-id:latest,PIPEDREAM_CLIENT_SECRET=pipedream-client-secret:latest,PIPEDREAM_PROJECT_ID=pipedream-project-id:latest,PIPEDREAM_ENVIRONMENT=pipedream-environment:latest,R2_ACCOUNT_ID=r2-account-id:latest,R2_BUCKET=r2-bucket:latest,R2_ACCESS_KEY_ID=r2-access-key-id:latest,R2_SECRET_ACCESS_KEY=r2-secret-access-key:latest,R2_BUNDLES_ACCOUNT_ID=r2-bundles-account-id:latest,R2_BUNDLES_BUCKET=r2-bundles-bucket:latest,R2_BUNDLES_ENDPOINT=r2-bundles-endpoint:latest,R2_BUNDLES_ACCESS_KEY_ID=r2-bundles-access-key-id:latest,R2_BUNDLES_SECRET_ACCESS_KEY=r2-bundles-secret-access-key:latest,HETZNER_API_TOKEN=hetzner-api-token:latest,POSTHOG_TOKEN=posthog-token:latest,POSTHOG_PROJECT_TOKEN=posthog-project-token:latest,NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=next-public-clerk-publishable-key:latest,NEXT_PUBLIC_POSTHOG_KEY=next-public-posthog-key:latest,NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN=next-public-posthog-project-token:latest" \
+            --set-secrets "PLATFORM_DATABASE_URL=platform-database-url:latest,PLATFORM_SECRET=platform-secret:latest,GOLDEN_SNAPSHOT_OPERATOR_SECRET=golden-snapshot-operator-secret:latest,PLATFORM_JWT_SECRET=platform-jwt-secret:latest,EDGE_ROUTER_SECRET=edge-router-secret:latest,CLERK_SECRET_KEY=clerk-secret-key:latest,STRIPE_SECRET_KEY=stripe-secret-key:latest,STRIPE_WEBHOOK_SECRET=stripe-webhook-secret:latest,STRIPE_PRICE_MATRIX_STARTER_MONTHLY=stripe-price-matrix-starter-monthly:latest,STRIPE_PRICE_MATRIX_STARTER_ANNUAL=stripe-price-matrix-starter-annual:latest,STRIPE_PRICE_MATRIX_BUILDER_MONTHLY=stripe-price-matrix-builder-monthly:latest,STRIPE_PRICE_MATRIX_BUILDER_ANNUAL=stripe-price-matrix-builder-annual:latest,STRIPE_PRICE_MATRIX_MAX_MONTHLY=stripe-price-matrix-max-monthly:latest,STRIPE_PRICE_MATRIX_MAX_ANNUAL=stripe-price-matrix-max-annual:latest,PIPEDREAM_CLIENT_ID=pipedream-client-id:latest,PIPEDREAM_CLIENT_SECRET=pipedream-client-secret:latest,PIPEDREAM_PROJECT_ID=pipedream-project-id:latest,PIPEDREAM_ENVIRONMENT=pipedream-environment:latest,R2_ACCOUNT_ID=r2-account-id:latest,R2_BUCKET=r2-bucket:latest,R2_ACCESS_KEY_ID=r2-access-key-id:latest,R2_SECRET_ACCESS_KEY=r2-secret-access-key:latest,R2_BUNDLES_ACCOUNT_ID=r2-bundles-account-id:latest,R2_BUNDLES_BUCKET=r2-bundles-bucket:latest,R2_BUNDLES_ENDPOINT=r2-bundles-endpoint:latest,R2_BUNDLES_ACCESS_KEY_ID=r2-bundles-access-key-id:latest,R2_BUNDLES_SECRET_ACCESS_KEY=r2-bundles-secret-access-key:latest,HETZNER_API_TOKEN=hetzner-api-token:latest,POSTHOG_TOKEN=posthog-token:latest,POSTHOG_PROJECT_TOKEN=posthog-project-token:latest,NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=next-public-clerk-publishable-key:latest,NEXT_PUBLIC_POSTHOG_KEY=next-public-posthog-key:latest,NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN=next-public-posthog-project-token:latest" \
             --format=json); then
             exit 1
           fi

--- a/.github/workflows/preview-platform.yml
+++ b/.github/workflows/preview-platform.yml
@@ -111,6 +111,37 @@ jobs:
             --quiet
           echo "IMAGE=$image" >> "$GITHUB_ENV"
 
+      - name: Verify preview golden snapshot operator secret
+        if: steps.config.outputs.configured == 'true'
+        run: |
+          set -euo pipefail
+          snapshot_operator_secret_name=golden-snapshot-operator-secret-preview
+          gcloud secrets describe "$snapshot_operator_secret_name" \
+            --project "$GCP_PROJECT_ID" >/dev/null
+          snapshot_operator_secret_tmpfile="$(mktemp)"
+          trap 'rm -f "$snapshot_operator_secret_tmpfile"' EXIT
+          if ! gcloud secrets versions access latest --secret "$snapshot_operator_secret_name" \
+            --project "$GCP_PROJECT_ID" >"$snapshot_operator_secret_tmpfile"; then
+            echo "Preview golden snapshot operator secret must have an accessible latest version." >&2
+            exit 1
+          fi
+          if [ ! -s "$snapshot_operator_secret_tmpfile" ]; then
+            echo "Preview golden snapshot operator secret must not be empty." >&2
+            exit 1
+          fi
+          accessor_member="$(
+            gcloud secrets get-iam-policy "$snapshot_operator_secret_name" \
+              --project "$GCP_PROJECT_ID" \
+              --flatten='bindings[].members' \
+              --filter="bindings.role:roles/secretmanager.secretAccessor AND bindings.members:serviceAccount:${CLOUD_RUN_SERVICE_ACCOUNT}" \
+              --format='value(bindings.members)' \
+              | head -1
+          )"
+          if [ "$accessor_member" != "serviceAccount:${CLOUD_RUN_SERVICE_ACCOUNT}" ]; then
+            echo "Preview golden snapshot operator secret must grant roles/secretmanager.secretAccessor to ${CLOUD_RUN_SERVICE_ACCOUNT}." >&2
+            exit 1
+          fi
+
       - name: Deploy zero-traffic tagged revision to preview service
         if: steps.config.outputs.configured == 'true'
         run: |
@@ -134,7 +165,7 @@ jobs:
               --no-traffic \
               --allow-unauthenticated \
               --set-env-vars "PLATFORM_RUNTIME_MODE=cloud_run,PLATFORM_PORT=8080,PLATFORM_PREVIEW=true,CUSTOMER_VPS_ENABLED=true,CUSTOMER_VPS_IMAGE_VERSION=dev,CUSTOMER_VPS_CLOUD_INIT_PATH=distro/customer-vps/cloud-init.yaml,AUTH_SHELL_HOST=127.0.0.1,AUTH_SHELL_PORT=3200,MATRIX_LEGACY_CONTAINER_ROUTING_ENABLED=false,MATRIX_STRIPE_BILLING_ENABLED=true,PLATFORM_PUBLIC_URL=${PREVIEW_PUBLIC_URL},MATRIX_API_ORIGIN=${api_origin},MATRIX_APP_URL=${PREVIEW_PUBLIC_URL},MATRIX_APP_DOMAIN_HOSTS=${PREVIEW_DOMAIN}" \
-              --set-secrets "PLATFORM_DATABASE_URL=platform-database-url-staging:latest,PLATFORM_SECRET=platform-preview-secret:latest,PLATFORM_JWT_SECRET=platform-preview-jwt-secret:latest,EDGE_ROUTER_SECRET=edge-router-preview-secret:latest,CLERK_SECRET_KEY=clerk-secret-key:latest,NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=next-public-clerk-publishable-key:latest,R2_BUNDLES_ACCOUNT_ID=r2-bundles-account-id:latest,R2_BUNDLES_BUCKET=r2-bundles-bucket:latest,R2_BUNDLES_ENDPOINT=r2-bundles-endpoint:latest,R2_BUNDLES_ACCESS_KEY_ID=r2-bundles-access-key-id:latest,R2_BUNDLES_SECRET_ACCESS_KEY=r2-bundles-secret-access-key:latest,STRIPE_SECRET_KEY=stripe-secret-key-test:latest,STRIPE_WEBHOOK_SECRET=stripe-webhook-secret-test:latest,STRIPE_PRICE_MATRIX_STARTER_MONTHLY=stripe-price-matrix-starter-monthly-test:latest,STRIPE_PRICE_MATRIX_STARTER_ANNUAL=stripe-price-matrix-starter-annual-test:latest,STRIPE_PRICE_MATRIX_BUILDER_MONTHLY=stripe-price-matrix-builder-monthly-test:latest,STRIPE_PRICE_MATRIX_BUILDER_ANNUAL=stripe-price-matrix-builder-annual-test:latest,STRIPE_PRICE_MATRIX_MAX_MONTHLY=stripe-price-matrix-max-monthly-test:latest,STRIPE_PRICE_MATRIX_MAX_ANNUAL=stripe-price-matrix-max-annual-test:latest" \
+              --set-secrets "PLATFORM_DATABASE_URL=platform-database-url-staging:latest,PLATFORM_SECRET=platform-preview-secret:latest,GOLDEN_SNAPSHOT_OPERATOR_SECRET=golden-snapshot-operator-secret-preview:latest,PLATFORM_JWT_SECRET=platform-preview-jwt-secret:latest,EDGE_ROUTER_SECRET=edge-router-preview-secret:latest,CLERK_SECRET_KEY=clerk-secret-key:latest,NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=next-public-clerk-publishable-key:latest,R2_BUNDLES_ACCOUNT_ID=r2-bundles-account-id:latest,R2_BUNDLES_BUCKET=r2-bundles-bucket:latest,R2_BUNDLES_ENDPOINT=r2-bundles-endpoint:latest,R2_BUNDLES_ACCESS_KEY_ID=r2-bundles-access-key-id:latest,R2_BUNDLES_SECRET_ACCESS_KEY=r2-bundles-secret-access-key:latest,STRIPE_SECRET_KEY=stripe-secret-key-test:latest,STRIPE_WEBHOOK_SECRET=stripe-webhook-secret-test:latest,STRIPE_PRICE_MATRIX_STARTER_MONTHLY=stripe-price-matrix-starter-monthly-test:latest,STRIPE_PRICE_MATRIX_STARTER_ANNUAL=stripe-price-matrix-starter-annual-test:latest,STRIPE_PRICE_MATRIX_BUILDER_MONTHLY=stripe-price-matrix-builder-monthly-test:latest,STRIPE_PRICE_MATRIX_BUILDER_ANNUAL=stripe-price-matrix-builder-annual-test:latest,STRIPE_PRICE_MATRIX_MAX_MONTHLY=stripe-price-matrix-max-monthly-test:latest,STRIPE_PRICE_MATRIX_MAX_ANNUAL=stripe-price-matrix-max-annual-test:latest" \
               --cpu 1 --memory 1Gi --concurrency 10 --timeout 300 --min-instances 0 --max-instances 2 \
               --quiet
           }

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "docker:build": "docker compose -f docker-compose.dev.yml build --no-cache",
     "cleanup:local-artifacts": "node scripts/cleanup-local-artifacts.mjs",
     "observability:posthog-alerts": "node scripts/observability/setup-posthog-alerts.mjs",
+    "release:enqueue-golden-snapshot": "node scripts/enqueue-golden-snapshot.mjs",
     "test": "sh -c 'pnpm --filter @matrix-os/observability build && pnpm --filter @matrix-os/kernel build && vitest run \"$@\"' --",
     "test:watch": "sh -c 'pnpm --filter @matrix-os/observability build && pnpm --filter @matrix-os/kernel build && vitest \"$@\"' --",
     "test:integration": "vitest run --config vitest.integration.config.ts",

--- a/packages/platform/src/db.ts
+++ b/packages/platform/src/db.ts
@@ -113,6 +113,8 @@ interface HostBundleReleasesTable {
   channel: string | null;
   git_commit: string;
   git_ref: string | null;
+  snapshot_eligible: boolean;
+  snapshot_eligibility_source: string;
   build_time: string;
   bundle_key: string;
   checksum_key: string | null;
@@ -675,6 +677,7 @@ export interface HostBundleReleaseRecord {
   channel: string | null;
   gitCommit: string;
   gitRef: string | null;
+  snapshotEligible: boolean;
   buildTime: string;
   bundleKey: string;
   checksumKey: string | null;
@@ -693,6 +696,7 @@ export interface NewHostBundleRelease {
   channel?: string | null;
   gitCommit: string;
   gitRef?: string | null;
+  snapshotEligible?: boolean;
   buildTime: string;
   bundleKey: string;
   checksumKey?: string | null;
@@ -1286,6 +1290,9 @@ async function migrate(db: Kysely<PlatformDatabase>): Promise<void> {
       channel TEXT,
       git_commit TEXT NOT NULL,
       git_ref TEXT,
+      snapshot_eligible BOOLEAN NOT NULL DEFAULT FALSE,
+      snapshot_eligibility_source TEXT NOT NULL DEFAULT 'legacy'
+        CHECK (snapshot_eligibility_source IN ('legacy', 'explicit')),
       build_time TEXT NOT NULL,
       bundle_key TEXT NOT NULL,
       checksum_key TEXT,
@@ -1300,6 +1307,22 @@ async function migrate(db: Kysely<PlatformDatabase>): Promise<void> {
     )
   `.execute(db);
   await sql`ALTER TABLE host_bundle_releases ADD COLUMN IF NOT EXISTS channel TEXT`.execute(db);
+  await sql`ALTER TABLE host_bundle_releases ADD COLUMN IF NOT EXISTS snapshot_eligible BOOLEAN NOT NULL DEFAULT FALSE`.execute(db);
+  await sql`ALTER TABLE host_bundle_releases ADD COLUMN IF NOT EXISTS snapshot_eligibility_source TEXT NOT NULL DEFAULT 'legacy'`.execute(db);
+  await sql`
+    DO $$
+    BEGIN
+      IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint
+        WHERE conrelid = 'host_bundle_releases'::regclass
+          AND conname = 'host_bundle_releases_snapshot_eligibility_source_check'
+      ) THEN
+        ALTER TABLE host_bundle_releases
+          ADD CONSTRAINT host_bundle_releases_snapshot_eligibility_source_check
+          CHECK (snapshot_eligibility_source IN ('legacy', 'explicit'));
+      END IF;
+    END $$
+  `.execute(db);
   await sql`ALTER TABLE host_bundle_releases ADD COLUMN IF NOT EXISTS incremental_manifest_key TEXT`.execute(db);
   await sql`ALTER TABLE host_bundle_releases ADD COLUMN IF NOT EXISTS incremental_manifest_sha256 TEXT`.execute(db);
   await sql`ALTER TABLE host_bundle_releases ALTER COLUMN size TYPE BIGINT`.execute(db);
@@ -1330,6 +1353,17 @@ async function migrate(db: Kysely<PlatformDatabase>): Promise<void> {
     FROM host_bundle_releases
     WHERE channel IS NOT NULL
     ON CONFLICT (channel, version) DO NOTHING
+  `.execute(db);
+  await sql`
+    UPDATE host_bundle_releases AS release
+    SET snapshot_eligible = TRUE
+    WHERE release.snapshot_eligible = FALSE
+      AND release.snapshot_eligibility_source = 'legacy'
+      AND EXISTS (
+        SELECT 1 FROM host_bundle_channels AS channel
+        WHERE channel.version = release.version
+          AND channel.channel IN ('dev', 'canary', 'beta', 'stable')
+      )
   `.execute(db);
   await sql`
     INSERT INTO host_bundle_release_channels(channel, version, promoted_at)
@@ -2077,6 +2111,7 @@ function mapHostBundleRelease(row: HostBundleReleasesTable): HostBundleReleaseRe
     channel: row.channel,
     gitCommit: row.git_commit,
     gitRef: row.git_ref,
+    snapshotEligible: row.snapshot_eligible,
     buildTime: row.build_time,
     bundleKey: row.bundle_key,
     checksumKey: row.checksum_key,
@@ -2098,6 +2133,8 @@ function toHostBundleReleaseRow(record: NewHostBundleRelease): HostBundleRelease
     channel: record.channel ?? null,
     git_commit: record.gitCommit,
     git_ref: record.gitRef ?? null,
+    snapshot_eligible: record.snapshotEligible ?? false,
+    snapshot_eligibility_source: record.snapshotEligible === undefined ? 'legacy' : 'explicit',
     build_time: HostBundleTimestampSchema.parse(record.buildTime),
     bundle_key: record.bundleKey,
     checksum_key: record.checksumKey ?? null,
@@ -3271,8 +3308,7 @@ export async function upsertHostBundleRelease(
 ): Promise<HostBundleReleaseRecord> {
   await db.ready;
   const row = toHostBundleReleaseRow(record);
-  return db.executor.transaction().execute(async (trx) => {
-    const saved = await trx
+  const saved = await db.executor
       .insertInto('host_bundle_releases')
       .values(row)
       .onConflict((oc) =>
@@ -3282,6 +3318,11 @@ export async function upsertHostBundleRelease(
           changelog: row.changelog,
           incremental_manifest_key: row.incremental_manifest_key,
           incremental_manifest_sha256: row.incremental_manifest_sha256,
+          snapshot_eligible: sql<boolean>`host_bundle_releases.snapshot_eligible OR ${row.snapshot_eligible}`,
+          snapshot_eligibility_source: sql<string>`CASE
+            WHEN ${row.snapshot_eligibility_source} = 'explicit' THEN 'explicit'
+            ELSE host_bundle_releases.snapshot_eligibility_source
+          END`,
         })
           .where(sql<boolean>`host_bundle_releases.bundle_key = ${row.bundle_key}`)
           .where(sql<boolean>`host_bundle_releases.git_commit = ${row.git_commit}`)
@@ -3295,11 +3336,10 @@ export async function upsertHostBundleRelease(
       )
       .returningAll()
       .executeTakeFirst();
-    if (!saved) {
-      throw new HostBundleReleaseConflictError(row.version);
-    }
-    return mapHostBundleRelease(saved);
-  });
+  if (!saved) {
+    throw new HostBundleReleaseConflictError(row.version);
+  }
+  return mapHostBundleRelease(saved);
 }
 
 export async function getHostBundleRelease(
@@ -3348,8 +3388,16 @@ export async function promoteHostBundleChannel(
   updatedAt = new Date().toISOString(),
 ): Promise<HostBundleChannelRecord> {
   await db.ready;
-  return db.executor.transaction().execute(async (trx) => {
-    const release = await trx
+  return db.transaction((trx) => promoteHostBundleChannelInTransaction(trx, channel, version, updatedAt));
+}
+
+async function promoteHostBundleChannelInTransaction(
+  db: PlatformDB,
+  channel: string,
+  version: string,
+  updatedAt: string,
+): Promise<HostBundleChannelRecord> {
+    const release = await db.executor
       .selectFrom('host_bundle_releases')
       .selectAll()
       .where('version', '=', version)
@@ -3358,7 +3406,7 @@ export async function promoteHostBundleChannel(
     if (!release) {
       throw new Error('Cannot promote unknown host bundle release');
     }
-    const row = await trx
+    const row = await db.executor
       .insertInto('host_bundle_channels')
       .values({ channel, version, updated_at: updatedAt })
       .onConflict((oc) =>
@@ -3369,7 +3417,7 @@ export async function promoteHostBundleChannel(
       )
       .returningAll()
       .executeTakeFirstOrThrow();
-    await trx
+    await db.executor
       .insertInto('host_bundle_release_channels')
       .values({ channel, version, promoted_at: updatedAt })
       .onConflict((oc) => oc.columns(['channel', 'version']).doUpdateSet({
@@ -3377,6 +3425,23 @@ export async function promoteHostBundleChannel(
       }))
       .executeTakeFirst();
     return mapHostBundleChannel(row);
+}
+
+export async function registerHostBundleRelease(
+  db: PlatformDB,
+  record: NewHostBundleRelease,
+  channel?: string,
+): Promise<{ release: HostBundleReleaseRecord; channel?: HostBundleChannelRecord }> {
+  await db.ready;
+  return db.transaction(async (trx) => {
+    const release = await upsertHostBundleRelease(trx, record);
+    if (!channel) return { release };
+    return {
+      release,
+      channel: await promoteHostBundleChannelInTransaction(
+        trx, channel, release.version, new Date().toISOString(),
+      ),
+    };
   });
 }
 

--- a/packages/platform/src/golden-snapshot-release-repository.ts
+++ b/packages/platform/src/golden-snapshot-release-repository.ts
@@ -1,0 +1,168 @@
+import { randomUUID } from 'node:crypto';
+import { z } from 'zod/v4';
+import type { PlatformDB } from './db.js';
+import { enqueueGoldenSnapshotBuild } from './golden-snapshot-repository.js';
+import {
+  compatibilityKey,
+  GoldenSnapshotCompatibilitySchema,
+  GoldenSnapshotStateSchema,
+  type GoldenSnapshotCompatibility,
+  type GoldenSnapshotState,
+} from './golden-snapshot-schema.js';
+
+const IsoDateSchema = z.string().datetime({ offset: true })
+  .transform((value) => new Date(value).toISOString());
+// Status is projected onto every accepted host-bundle release, including
+// legacy/non-eligible names that can never identify a snapshot build.
+const HostBundleStatusVersionSchema = z.string().min(1).max(128).regex(/^[A-Za-z0-9._-]+$/);
+const CoarseStatusFreshnessSchema = z.object({
+  now: IsoDateSchema,
+  freshnessMaxAgeMs: z.number().int().min(60_000).max(365 * 24 * 60 * 60 * 1000),
+}).strict();
+
+export type GoldenSnapshotCoarseStatus =
+  | 'not_requested'
+  | 'requested'
+  | 'building'
+  | 'ready'
+  | 'failed'
+  | 'unavailable';
+
+function coarseStatus(states: GoldenSnapshotState[]): GoldenSnapshotCoarseStatus {
+  if (states.includes('ready')) return 'ready';
+  if (states.some((state) => state === 'building' || state === 'sanitizing' || state === 'validating')) {
+    return 'building';
+  }
+  if (states.includes('candidate')) return 'requested';
+  if (states.some((state) => state === 'failed' || state === 'quarantined')) return 'failed';
+  if (states.some((state) => state === 'retiring' || state === 'deleted')) return 'unavailable';
+  return 'not_requested';
+}
+
+export async function getGoldenSnapshotCoarseStatus(
+  db: PlatformDB,
+  rawBundleVersion: string,
+  rawCompatibility?: GoldenSnapshotCompatibility,
+  rawFreshness?: z.input<typeof CoarseStatusFreshnessSchema>,
+): Promise<GoldenSnapshotCoarseStatus> {
+  const bundleVersion = HostBundleStatusVersionSchema.parse(rawBundleVersion);
+  return (await getGoldenSnapshotCoarseStatuses(db, [bundleVersion], rawCompatibility, rawFreshness))
+    .get(bundleVersion) ?? 'not_requested';
+}
+
+export async function getGoldenSnapshotCoarseStatuses(
+  db: PlatformDB,
+  rawBundleVersions: string[],
+  rawCompatibility?: GoldenSnapshotCompatibility,
+  rawFreshness?: z.input<typeof CoarseStatusFreshnessSchema>,
+): Promise<Map<string, GoldenSnapshotCoarseStatus>> {
+  const bundleVersions = z.array(HostBundleStatusVersionSchema).max(100)
+    .transform((versions) => [...new Set(versions)]).parse(rawBundleVersions);
+  const activeCompatibilityKey = rawCompatibility === undefined
+    ? undefined
+    : compatibilityKey(GoldenSnapshotCompatibilitySchema.parse(rawCompatibility));
+  const freshness = rawFreshness === undefined
+    ? undefined
+    : CoarseStatusFreshnessSchema.parse(rawFreshness);
+  const freshnessCutoff = freshness === undefined
+    ? undefined
+    : new Date(new Date(freshness.now).getTime() - freshness.freshnessMaxAgeMs).toISOString();
+  await db.ready;
+  const result = new Map<string, GoldenSnapshotCoarseStatus>(
+    bundleVersions.map((version) => [version, 'not_requested']),
+  );
+  if (bundleVersions.length === 0) return result;
+  let query = db.executor.selectFrom('host_bundle_releases')
+    .innerJoin('golden_snapshots', 'golden_snapshots.bundle_sha256', 'host_bundle_releases.sha256')
+    .select(['host_bundle_releases.version as bundle_version', 'golden_snapshots.state'])
+    .where('host_bundle_releases.version', 'in', bundleVersions)
+    .where('golden_snapshots.test_mode', '=', false);
+  if (activeCompatibilityKey !== undefined) {
+    query = query.where('golden_snapshots.compatibility_key', '=', activeCompatibilityKey);
+  }
+  if (freshnessCutoff !== undefined) {
+    query = query.where((eb) => eb.or([
+      eb('golden_snapshots.state', '!=', 'ready'),
+      eb('golden_snapshots.ready_at', '>', freshnessCutoff),
+    ]));
+  }
+  const rows = await query.groupBy(['host_bundle_releases.version', 'golden_snapshots.state']).execute();
+  const grouped = new Map<string, GoldenSnapshotState[]>();
+  for (const row of rows) {
+    const states = grouped.get(row.bundle_version) ?? [];
+    states.push(GoldenSnapshotStateSchema.parse(row.state));
+    grouped.set(row.bundle_version, states);
+  }
+  for (const [version, states] of grouped) result.set(version, coarseStatus(states));
+  return result;
+}
+
+const MissingBuildReconciliationInputSchema = z.object({
+  compatibility: GoldenSnapshotCompatibilitySchema,
+  now: IsoDateSchema,
+  limit: z.number().int().min(1).max(100),
+  freshnessMaxAgeMs: z.number().int().min(60_000).max(365 * 24 * 60 * 60 * 1000),
+}).strict();
+
+export async function reconcileMissingGoldenSnapshotBuilds(
+  db: PlatformDB,
+  rawInput: z.input<typeof MissingBuildReconciliationInputSchema>,
+): Promise<{ enqueued: number }> {
+  const input = MissingBuildReconciliationInputSchema.parse(rawInput);
+  const key = compatibilityKey(input.compatibility);
+  const freshnessCutoff = new Date(
+    new Date(input.now).getTime() - input.freshnessMaxAgeMs,
+  ).toISOString();
+  await db.ready;
+  // During the first rollout, an old platform revision can accept and promote
+  // a release while stripping the new eligibility field. Only legacy rows are
+  // repaired; an explicit false remains an authoritative opt-out.
+  await db.executor.updateTable('host_bundle_releases').set({ snapshot_eligible: true })
+    .where('snapshot_eligible', '=', false)
+    .where('snapshot_eligibility_source', '=', 'legacy')
+    .where((eb) => eb.exists(
+      eb.selectFrom('host_bundle_channels').select('channel')
+        .whereRef('host_bundle_channels.version', '=', 'host_bundle_releases.version')
+        .where('host_bundle_channels.channel', 'in', ['dev', 'canary', 'beta', 'stable']),
+    )).execute();
+  const missing = await db.executor.selectFrom('host_bundle_releases')
+    .select('version')
+    .where('snapshot_eligible', '=', true)
+    .where((eb) => eb.not(eb.exists(
+      eb.selectFrom('golden_snapshots').select('snapshot_id')
+        .whereRef('golden_snapshots.bundle_sha256', '=', 'host_bundle_releases.sha256')
+        .where('golden_snapshots.compatibility_key', '=', key)
+        .where('golden_snapshots.test_mode', '=', false)
+        .where('golden_snapshots.state', '=', 'ready')
+        .where('golden_snapshots.ready_at', '>', freshnessCutoff),
+    )))
+    .where((eb) => eb.not(eb.exists(
+      eb.selectFrom('golden_snapshots').select('snapshot_id')
+        .whereRef('golden_snapshots.bundle_sha256', '=', 'host_bundle_releases.sha256')
+        .where('golden_snapshots.compatibility_key', '=', key)
+        .where('golden_snapshots.test_mode', '=', false)
+        .where('golden_snapshots.state', 'in', [
+          'candidate', 'building', 'sanitizing', 'validating', 'failed', 'quarantined',
+        ]),
+    )))
+    .orderBy('build_time', 'desc').limit(input.limit).execute();
+  let enqueued = 0;
+  for (const release of missing) {
+    try {
+      const result = await enqueueGoldenSnapshotBuild(db, {
+        bundleVersion: release.version,
+        compatibility: input.compatibility,
+        replaceReady: true,
+        snapshotId: randomUUID(),
+        buildId: randomUUID(),
+        now: input.now,
+      });
+      if (!result.reused) enqueued += 1;
+    } catch (err: unknown) {
+      console.error(
+        `[golden-snapshot] missing-build enqueue failed release=${release.version}: ${err instanceof Error ? err.name : typeof err}`,
+      );
+    }
+  }
+  return { enqueued };
+}

--- a/packages/platform/src/host-bundle-routes.ts
+++ b/packages/platform/src/host-bundle-routes.ts
@@ -9,12 +9,21 @@ import {
   HostBundleReleaseConflictError,
   listHostBundleReleases,
   promoteHostBundleChannel,
+  registerHostBundleRelease,
   upsertHostBundleRelease,
   type HostBundleReleaseRecord,
   type PlatformDB,
 } from './db.js';
 import type { CustomerVpsObjectStore } from './customer-vps-r2.js';
 import { timingSafeTokenEquals } from './platform-token.js';
+import {
+  getGoldenSnapshotCoarseStatus,
+  getGoldenSnapshotCoarseStatuses,
+} from './golden-snapshot-release-repository.js';
+import {
+  GoldenSnapshotBundleVersionSchema,
+  type GoldenSnapshotCompatibility,
+} from './golden-snapshot-schema.js';
 
 const HOST_BUNDLE_READ_TIMEOUT_MS = 30_000;
 const HOST_BUNDLE_IMAGE_VERSION_PATTERN = /^[A-Za-z0-9._-]{1,128}$/;
@@ -32,6 +41,7 @@ const HostBundleReleaseBodySchema = z.object({
   version: z.string().regex(HOST_BUNDLE_IMAGE_VERSION_PATTERN),
   gitCommit: z.string().min(7).max(64),
   gitRef: z.string().max(256).nullable().optional(),
+  snapshotEligible: z.boolean().optional(),
   buildTime: z.string().datetime({ offset: true })
     .transform((value) => new Date(value).toISOString()),
   bundleKey: z.string().regex(/^system-bundles\/[A-Za-z0-9._-]{1,128}\/matrix-host-bundle\.tar\.gz$/),
@@ -44,6 +54,14 @@ const HostBundleReleaseBodySchema = z.object({
   updateType: z.enum(['manual', 'auto']).optional(),
   changelog: z.string().max(32_000).nullable().optional(),
   channel: z.string().regex(HOST_BUNDLE_CHANNEL_PATTERN).optional(),
+}).superRefine((value, ctx) => {
+  if (value.snapshotEligible === true
+    && !GoldenSnapshotBundleVersionSchema.safeParse(value.version).success) {
+    ctx.addIssue({
+      code: 'custom', path: ['version'],
+      message: 'Snapshot-eligible release version is invalid',
+    });
+  }
 });
 
 const HostBundleChannelBodySchema = z.object({
@@ -60,6 +78,7 @@ function isObjectNotFoundError(err: unknown): boolean {
 
 function hostBundleReleaseResponse(
   release: HostBundleReleaseRecord,
+  snapshotStatus: Awaited<ReturnType<typeof getGoldenSnapshotCoarseStatus>>,
   url?: string,
   channel?: string,
 ): Record<string, unknown> {
@@ -80,6 +99,7 @@ function hostBundleReleaseResponse(
     updateType: release.updateType,
     changelog: release.changelog,
     createdAt: release.createdAt,
+    snapshotStatus,
     ...(url ? { url } : {}),
   };
 }
@@ -101,6 +121,8 @@ export function createHostBundleRoutes(opts: {
     properties: Record<string, string | number | boolean | null | undefined>,
   ) => void;
   logRouteError: (route: string, err: unknown) => void;
+  goldenSnapshotCompatibility?: GoldenSnapshotCompatibility;
+  goldenSnapshotFreshnessMaxAgeMs?: number;
 }) {
   const { db, platformSecret, capturePlatformEvent, logRouteError } = opts;
   const routes = new Hono();
@@ -134,6 +156,24 @@ export function createHostBundleRoutes(opts: {
     return null;
   }
 
+  async function snapshotStatusOrUnavailable(
+    release: HostBundleReleaseRecord,
+    route: string,
+  ): Promise<Awaited<ReturnType<typeof getGoldenSnapshotCoarseStatus>>> {
+    try {
+      return await getGoldenSnapshotCoarseStatus(
+        db, release.version, opts.goldenSnapshotCompatibility,
+        opts.goldenSnapshotFreshnessMaxAgeMs === undefined ? undefined : {
+          now: new Date().toISOString(),
+          freshnessMaxAgeMs: opts.goldenSnapshotFreshnessMaxAgeMs,
+        },
+      );
+    } catch (err: unknown) {
+      logRouteError(`${route} snapshot status`, err);
+      return release.snapshotEligible ? 'unavailable' : 'not_requested';
+    }
+  }
+
   routes.get('/releases', async (c) => {
     const channel = c.req.query('channel');
     if (channel !== undefined && !HOST_BUNDLE_CHANNEL_PATTERN.test(channel)) {
@@ -141,9 +181,26 @@ export function createHostBundleRoutes(opts: {
     }
     try {
       const releases = await listHostBundleReleases(db, 100, channel);
+      let statuses = new Map<string, Awaited<ReturnType<typeof getGoldenSnapshotCoarseStatus>>>();
+      try {
+        statuses = await getGoldenSnapshotCoarseStatuses(
+          db,
+          releases.map((release) => release.version),
+          opts.goldenSnapshotCompatibility,
+          opts.goldenSnapshotFreshnessMaxAgeMs === undefined ? undefined : {
+            now: new Date().toISOString(),
+            freshnessMaxAgeMs: opts.goldenSnapshotFreshnessMaxAgeMs,
+          },
+        );
+      } catch (err: unknown) {
+        logRouteError('/system-bundles/releases snapshot statuses', err);
+      }
+      const releasesWithStatus = releases.map((release) => hostBundleReleaseResponse(
+        release, statuses.get(release.version) ?? (release.snapshotEligible ? 'unavailable' : 'not_requested'),
+      ));
       return c.json({
         generatedAt: new Date().toISOString(),
-        releases: releases.map((release) => hostBundleReleaseResponse(release)),
+        releases: releasesWithStatus,
       });
     } catch (err: unknown) {
       logRouteError('/system-bundles/releases', err);
@@ -163,7 +220,11 @@ export function createHostBundleRoutes(opts: {
         return c.json({ error: 'Not found' }, 404);
       }
       const url = await getSignedBundleUrl(release);
-      return c.json(hostBundleReleaseResponse(release, url), 200, {
+      return c.json(hostBundleReleaseResponse(
+        release,
+        await snapshotStatusOrUnavailable(release, '/system-bundles/releases/:version'),
+        url,
+      ), 200, {
         'cache-control': 'private, max-age=30',
       });
     } catch (err: unknown) {
@@ -187,10 +248,9 @@ export function createHostBundleRoutes(opts: {
       return c.json({ error: 'Invalid request' }, 400);
     }
     try {
-      const release = await upsertHostBundleRelease(db, parsed.data);
-      let channel;
-      if (parsed.data.channel) {
-        channel = await promoteHostBundleChannel(db, parsed.data.channel, release.version);
+      const registered = await registerHostBundleRelease(db, parsed.data, parsed.data.channel);
+      const { release, channel } = registered;
+      if (channel && parsed.data.channel) {
         capturePlatformEvent(MATRIX_TELEMETRY_EVENTS.HOST_BUNDLE_CHANNEL_PROMOTED, {
           channel: parsed.data.channel,
           version: release.version,
@@ -206,8 +266,14 @@ export function createHostBundleRoutes(opts: {
         severity: release.severity,
         updateType: release.updateType,
       });
+      const snapshotStatus = await snapshotStatusOrUnavailable(
+        release, '/system-bundles/releases',
+      );
       return c.json({
-        release: hostBundleReleaseResponse(release),
+        release: hostBundleReleaseResponse(
+          release,
+          snapshotStatus,
+        ),
         ...(channel ? { channel } : {}),
       });
     } catch (err: unknown) {
@@ -322,7 +388,12 @@ export function createHostBundleRoutes(opts: {
           return c.json({ error: 'Not found' }, 404);
         }
         const url = await getSignedBundleUrl(release);
-        return c.json(hostBundleReleaseResponse(release, url, channel), 200, {
+        return c.json(hostBundleReleaseResponse(
+          release,
+          await snapshotStatusOrUnavailable(release, '/system-bundles/channels/:channel'),
+          url,
+          channel,
+        ), 200, {
           'cache-control': 'private, max-age=30',
         });
       } catch (err: unknown) {
@@ -425,7 +496,12 @@ export function createHostBundleRoutes(opts: {
     if (file.endsWith('.json')) {
       try {
         const url = await getSignedBundleUrl(release);
-        return c.json(hostBundleReleaseResponse(release, url, isChannelAlias ? imageVersion : undefined), 200, {
+        return c.json(hostBundleReleaseResponse(
+          release,
+          await snapshotStatusOrUnavailable(release, '/system-bundles/:imageVersion/:file'),
+          url,
+          isChannelAlias ? imageVersion : undefined,
+        ), 200, {
           'cache-control': 'private, max-age=30',
         });
       } catch (err: unknown) {
@@ -483,7 +559,12 @@ export function createHostBundleRoutes(opts: {
         return c.json({ error: 'Not found' }, 404);
       }
       const url = await getSignedBundleUrl(release);
-      return c.json(hostBundleReleaseResponse(release, url, channel), 200, {
+      return c.json(hostBundleReleaseResponse(
+        release,
+        await snapshotStatusOrUnavailable(release, '/system-bundles/channels/:channel'),
+        url,
+        channel,
+      ), 200, {
         'cache-control': 'private, max-age=30',
       });
     } catch (err: unknown) {

--- a/packages/platform/src/main.ts
+++ b/packages/platform/src/main.ts
@@ -463,6 +463,8 @@ export function createApp(deps: {
     getHostBundleObjectStore: () => deps.hostBundleObjectStore ?? (allowHostBundleSyncStoreFallback ? deps.customerVpsObjectStore : undefined),
     capturePlatformEvent,
     logRouteError: logPlatformRouteError,
+    goldenSnapshotCompatibility: deps.goldenSnapshotConfig?.compatibility,
+    goldenSnapshotFreshnessMaxAgeMs: deps.goldenSnapshotConfig?.freshnessMaxAgeMs,
   }));
 
   // OAuth 2.0 Device Flow (RFC 8628) -- mounted before any host-based routing

--- a/packages/platform/src/platform-startup.ts
+++ b/packages/platform/src/platform-startup.ts
@@ -484,9 +484,11 @@ export async function startPlatformServer(opts: StartPlatformServerOptions): Pro
           listRunnableGoldenSnapshotBuildIds,
           listUnresolvedGoldenSnapshotBuildIds,
         },
+        { reconcileMissingGoldenSnapshotBuilds },
       ] = await Promise.all([
         import('./golden-snapshot-service.js'),
         import('./golden-snapshot-repository.js'),
+        import('./golden-snapshot-release-repository.js'),
       ]);
       const builderTemplate = await readFile(
         process.env.GOLDEN_SNAPSHOT_BUILDER_CLOUD_INIT_PATH
@@ -509,6 +511,16 @@ export async function startPlatformServer(opts: StartPlatformServerOptions): Pro
             const workerNow = new Date().toISOString();
             let quotaPressure = false;
             if (goldenSnapshotConfig.buildsEnabled) {
+              try {
+                await reconcileMissingGoldenSnapshotBuilds(db, {
+                  compatibility: goldenSnapshotConfig.compatibility,
+                  now: workerNow,
+                  limit: goldenSnapshotConfig.reconciliationBatchSize,
+                  freshnessMaxAgeMs: goldenSnapshotConfig.freshnessMaxAgeMs,
+                });
+              } catch (err: unknown) {
+                logPlatformRouteError('golden snapshot release reconciliation', err);
+              }
               await claimGoldenSnapshotBuildBatch(
                 db,
                 workerNow,

--- a/scripts/enqueue-golden-snapshot.mjs
+++ b/scripts/enqueue-golden-snapshot.mjs
@@ -1,0 +1,121 @@
+#!/usr/bin/env node
+
+import { pathToFileURL } from 'node:url';
+import { createRequire } from 'node:module';
+
+const require = createRequire(new URL('../packages/platform/package.json', import.meta.url));
+const { z } = require('zod/v4');
+
+const REQUEST_TIMEOUT_MS = 10_000;
+const MAX_RESPONSE_BYTES = 8 * 1024;
+
+const ReleaseContextSchema = z.object({
+  eventName: z.string().min(1).max(64),
+  refType: z.enum(['branch', 'tag']),
+  refName: z.string().min(1).max(255),
+  channel: z.enum(['dev', 'canary', 'beta', 'stable']).optional(),
+}).strict();
+
+const EnqueueInputSchema = z.object({
+  platformUrl: z.url().max(2_048),
+  platformSecret: z.string().min(1).max(8_192),
+  bundleVersion: z.string().min(1).max(128),
+}).strict();
+
+const EnqueueResponseSchema = z.object({
+  status: z.enum(['queued', 'running', 'completed', 'failed']),
+  reused: z.boolean(),
+}).passthrough();
+
+export function isEligibleSnapshotRelease(input) {
+  const parsed = ReleaseContextSchema.safeParse(input);
+  if (!parsed.success) return false;
+  if (parsed.data.eventName === 'workflow_dispatch') return parsed.data.channel !== undefined;
+  if (parsed.data.eventName !== 'push') return false;
+  if (parsed.data.refType === 'tag') return /^v[^\s/]{1,253}$/.test(parsed.data.refName);
+  return parsed.data.refName === 'main';
+}
+
+async function readBoundedJson(response) {
+  if (!response.body) throw new Error('Snapshot build enqueue failed');
+  const reader = response.body.getReader();
+  const chunks = [];
+  let total = 0;
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      total += value.byteLength;
+      if (total > MAX_RESPONSE_BYTES) throw new Error('Snapshot build enqueue failed');
+      chunks.push(value);
+    }
+  } finally {
+    reader.releaseLock();
+  }
+  try {
+    return JSON.parse(Buffer.concat(chunks).toString('utf8'));
+  } catch {
+    throw new Error('Snapshot build enqueue failed');
+  }
+}
+
+export async function enqueueGoldenSnapshot(input) {
+  const { fetchImpl = fetch, ...untrusted } = input;
+  const parsed = EnqueueInputSchema.safeParse(untrusted);
+  if (!parsed.success) throw new Error('Snapshot build enqueue configuration is invalid');
+  const endpoint = new URL('/system-bundles/snapshot-builds', parsed.data.platformUrl);
+  if (endpoint.protocol !== 'https:' && endpoint.hostname !== 'localhost') {
+    throw new Error('Snapshot build enqueue configuration is invalid');
+  }
+
+  let response;
+  try {
+    response = await fetchImpl(endpoint.toString(), {
+      method: 'POST',
+      redirect: 'error',
+      headers: {
+        authorization: `Bearer ${parsed.data.platformSecret}`,
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({ bundleVersion: parsed.data.bundleVersion }),
+      signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+    });
+  } catch {
+    throw new Error('Snapshot build enqueue failed');
+  }
+  if (response.status !== 202) throw new Error('Snapshot build enqueue failed');
+  const result = EnqueueResponseSchema.safeParse(await readBoundedJson(response));
+  if (!result.success) throw new Error('Snapshot build enqueue failed');
+  return { status: result.data.status, reused: result.data.reused };
+}
+
+function parseVersion(argv) {
+  const index = argv.indexOf('--version');
+  return index >= 0 ? argv[index + 1] : undefined;
+}
+
+async function main() {
+  const context = {
+    eventName: process.env.GITHUB_EVENT_NAME ?? '',
+    refType: process.env.GITHUB_REF_TYPE ?? '',
+    refName: process.env.GITHUB_REF_NAME ?? '',
+    channel: process.env.PUBLISH_CHANNEL || undefined,
+  };
+  if (!isEligibleSnapshotRelease(context)) {
+    process.stdout.write('Golden snapshot build not eligible for this release.\n');
+    return;
+  }
+  const result = await enqueueGoldenSnapshot({
+    platformUrl: process.env.PLATFORM_PUBLIC_URL ?? '',
+    platformSecret: process.env.PLATFORM_SECRET ?? '',
+    bundleVersion: parseVersion(process.argv.slice(2)) ?? '',
+  });
+  process.stdout.write(`Golden snapshot build ${result.reused ? 'already exists' : 'queued'}.\n`);
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch(() => {
+    process.stderr.write('Golden snapshot build enqueue failed. Host bundle publication and fleet deployment are unaffected.\n');
+    process.exitCode = 1;
+  });
+}

--- a/scripts/publish-release-r2.mjs
+++ b/scripts/publish-release-r2.mjs
@@ -6,6 +6,7 @@ import { createRequire } from "node:module";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import { resolveReleaseSnapshotEligibility } from "./release-snapshot-eligibility.mjs";
 
 const scriptDir = dirname(fileURLToPath(import.meta.url));
 const root = resolve(scriptDir, "..");
@@ -76,6 +77,12 @@ const incrementalManifestKey = `system-bundles/${version}/incremental-manifest.j
 const bucket = process.env.R2_BUCKET || "matrixos-sync";
 const platformPublicUrl = process.env.PLATFORM_PUBLIC_URL || "https://app.matrix-os.com";
 const updateType = severity === "security" ? "auto" : "manual";
+const snapshotEligible = resolveReleaseSnapshotEligibility(
+  channel,
+  Object.hasOwn(process.env, "GOLDEN_SNAPSHOT_ELIGIBLE")
+    ? process.env.GOLDEN_SNAPSHOT_ELIGIBLE
+    : undefined,
+);
 
 function required(name) {
   const value = process.env[name];
@@ -228,6 +235,7 @@ const registrationBody = {
   severity,
   updateType,
   changelog: changelog || null,
+  snapshotEligible,
   ...(channel === "none" ? {} : { channel }),
 };
 

--- a/scripts/publish-release.sh
+++ b/scripts/publish-release.sh
@@ -111,6 +111,18 @@ BUILD_TIME="${BUILD_TIME:-$PUBLISHED}"
 BUNDLE_KEY="system-bundles/$VERSION/matrix-host-bundle.tar.gz"
 CHECKSUM_KEY="system-bundles/$VERSION/matrix-host-bundle.tar.gz.sha256"
 INCREMENTAL_MANIFEST_KEY="system-bundles/$VERSION/incremental-manifest.json"
+if [ "${GOLDEN_SNAPSHOT_ELIGIBLE+x}" = "x" ]; then
+  SNAPSHOT_ELIGIBLE="$GOLDEN_SNAPSHOT_ELIGIBLE"
+else
+  case "$CHANNEL" in
+    dev|canary|beta|stable) SNAPSHOT_ELIGIBLE="true" ;;
+    *) SNAPSHOT_ELIGIBLE="false" ;;
+  esac
+fi
+if [ "$SNAPSHOT_ELIGIBLE" != "true" ] && [ "$SNAPSHOT_ELIGIBLE" != "false" ]; then
+  echo "GOLDEN_SNAPSHOT_ELIGIBLE must be true or false" >&2
+  exit 1
+fi
 
 REGISTRATION_BODY=$(python3 -c "
 import json, sys
@@ -128,9 +140,10 @@ print(json.dumps({
     'severity': sys.argv[11],
     'updateType': sys.argv[12],
     'changelog': sys.argv[13] or None,
+    'snapshotEligible': sys.argv[15] == 'true',
     **({} if sys.argv[14] == 'none' else {'channel': sys.argv[14]}),
 }, indent=2))
-" "$VERSION" "$GIT_COMMIT" "$GIT_REF" "$BUILD_TIME" "$BUNDLE_KEY" "$CHECKSUM_KEY" "$INCREMENTAL_MANIFEST_KEY" "$INCREMENTAL_MANIFEST_SHA256" "$SHA256" "$SIZE" "$SEVERITY" "$UPDATE_TYPE" "$CHANGELOG" "$CHANNEL")
+" "$VERSION" "$GIT_COMMIT" "$GIT_REF" "$BUILD_TIME" "$BUNDLE_KEY" "$CHECKSUM_KEY" "$INCREMENTAL_MANIFEST_KEY" "$INCREMENTAL_MANIFEST_SHA256" "$SHA256" "$SIZE" "$SEVERITY" "$UPDATE_TYPE" "$CHANGELOG" "$CHANNEL" "$SNAPSHOT_ELIGIBLE")
 
 incremental_object_count() {
   python3 -c "import json,sys; print(len(json.load(open(sys.argv[1])).get('files', [])))" "$INCREMENTAL_MANIFEST"

--- a/scripts/release-snapshot-eligibility.mjs
+++ b/scripts/release-snapshot-eligibility.mjs
@@ -1,0 +1,11 @@
+const CUSTOMER_RELEASE_CHANNELS = new Set(['dev', 'canary', 'beta', 'stable']);
+
+export function resolveReleaseSnapshotEligibility(channel, explicitValue) {
+  if (explicitValue !== undefined) {
+    if (explicitValue !== 'true' && explicitValue !== 'false') {
+      throw new Error('GOLDEN_SNAPSHOT_ELIGIBLE must be true or false');
+    }
+    return explicitValue === 'true';
+  }
+  return CUSTOMER_RELEASE_CHANNELS.has(channel);
+}

--- a/tests/platform/ci-workflows.test.ts
+++ b/tests/platform/ci-workflows.test.ts
@@ -286,6 +286,22 @@ describe('CI workflows', () => {
     }
   });
 
+  it('preflights and binds distinct golden snapshot operator secrets for platform revisions', () => {
+    const root = process.cwd();
+    const production = readFileSync(join(root, '.github/workflows/platform-cloud-run.yml'), 'utf8');
+    const preview = readFileSync(join(root, '.github/workflows/preview-platform.yml'), 'utf8');
+
+    expect(production).toContain('Verify golden snapshot operator secret');
+    expect(production).toContain('GOLDEN_SNAPSHOT_OPERATOR_SECRET=golden-snapshot-operator-secret:latest');
+    expect(production).toContain('gcloud secrets versions access latest --secret "$snapshot_operator_secret_name"');
+    expect(production).toContain('roles/secretmanager.secretAccessor');
+
+    expect(preview).toContain('Verify preview golden snapshot operator secret');
+    expect(preview).toContain('GOLDEN_SNAPSHOT_OPERATOR_SECRET=golden-snapshot-operator-secret-preview:latest');
+    expect(preview).toContain('gcloud secrets versions access latest --secret "$snapshot_operator_secret_name"');
+    expect(preview).toContain('roles/secretmanager.secretAccessor');
+  });
+
   it('does not require add-on prices or focused portal configurations for platform deployment', () => {
     const root = process.cwd();
     const workflow = readFileSync(join(root, '.github/workflows/platform-cloud-run.yml'), 'utf8');
@@ -453,7 +469,9 @@ describe('CI workflows', () => {
     expect(workflow).toContain("github.event_name == 'push' && github.ref_type == 'branch' && github.ref_name == 'main'");
     expect(workflow).toContain('|| inputs.deploy_after_publish');
     expect(workflow).not.toContain("|| inputs.severity == 'security'");
-    expect(workflow).toContain('VERSION="${{ needs.build.outputs.version }}"');
+    expect(workflow).toContain('PUBLISH_VERSION: ${{ needs.build.outputs.version }}');
+    expect(workflow).toContain('VERSION="$PUBLISH_VERSION"');
+    expect(workflow).not.toContain('VERSION="${{ needs.build.outputs.version }}"');
     expect(workflow).toContain('DEPLOY_RESPONSE="$(curl --fail --silent --show-error --max-time 30 \\');
     expect(workflow).toContain('failed="$(printf \'%s\' "$DEPLOY_RESPONSE" | jq -r \'.failed // 0\')"');
     expect(workflow).toContain('triggered="$(printf \'%s\' "$DEPLOY_RESPONSE" | jq -r \'.triggered // 0\')"');

--- a/tests/platform/customer-vps-host-bundle.test.ts
+++ b/tests/platform/customer-vps-host-bundle.test.ts
@@ -899,7 +899,8 @@ test "$(readlink "$MATRIX_LEGACY_HOME/.hermes")" = "$MATRIX_HOME/.hermes"
     expect(workflow).toContain('Refusing to publish a host bundle with the example Clerk publishable key.');
     expect(workflow).not.toContain('HEAD_COMMIT_MESSAGE');
     expect(workflow).not.toContain('CHANGED_FILES="$changed_files"');
-    expect(workflow).not.toContain('continue-on-error: true');
+    expect(workflow.slice(workflow.indexOf('\n  publish:'), workflow.indexOf('\n  enqueue-golden-snapshot:')))
+      .not.toContain('continue-on-error: true');
   });
 
   it('host bundle release workflow waits for same-sha CI instead of duplicating the full suite', () => {

--- a/tests/platform/host-bundle-route.test.ts
+++ b/tests/platform/host-bundle-route.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { sql } from 'kysely';
 import { createApp } from '../../packages/platform/src/main.js';
 import type { CustomerVpsObjectStore } from '../../packages/platform/src/customer-vps-r2.js';
 import {
@@ -9,6 +10,7 @@ import {
   upsertHostBundleRelease,
 } from '../../packages/platform/src/db.js';
 import type { Orchestrator } from '../../packages/platform/src/orchestrator.js';
+import { enqueueGoldenSnapshotBuild } from '../../packages/platform/src/golden-snapshot-repository.js';
 import { createTestPlatformDb, destroyTestPlatformDb } from './platform-db-test-helper.js';
 
 describe('platform host bundle route', () => {
@@ -233,6 +235,32 @@ describe('platform host bundle route', () => {
       'system-bundles/v2026.05.12-1/matrix-host-bundle.tar.gz',
       3600,
     );
+  });
+
+  it('serves a channel manifest with unavailable status when snapshot lookup fails', async () => {
+    await seedRelease();
+    await db.executor.updateTable('host_bundle_releases').set({ snapshot_eligible: true })
+      .where('version', '=', 'v2026.05.12-1').execute();
+    await promoteHostBundleChannel(db, 'stable', 'v2026.05.12-1');
+    await db.executor.schema.dropTable('golden_snapshots').cascade().execute();
+    const app = createApp({
+      db,
+      orchestrator,
+      customerVpsObjectStore: {
+        getObject: vi.fn(),
+        getPresignedGetUrl: vi.fn().mockResolvedValue('https://r2.example/signed-host-bundle'),
+        putObject: vi.fn(),
+      } as unknown as CustomerVpsObjectStore,
+    });
+
+    const response = await app.request('/system-bundles/channels/stable.json');
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      version: 'v2026.05.12-1',
+      channel: 'stable',
+      snapshotStatus: 'unavailable',
+    });
   });
 
   it('uses dedicated host bundle object storage for channel manifests', async () => {
@@ -573,6 +601,228 @@ describe('platform host bundle route', () => {
     });
   });
 
+  it('rejects snapshot eligibility for a version outside the snapshot identity schema', async () => {
+    const app = createApp({
+      db, orchestrator, platformSecret: 'secret',
+      customerVpsObjectStore: { getObject: vi.fn(), putObject: vi.fn() } as unknown as CustomerVpsObjectStore,
+    });
+    const response = await app.request('/system-bundles/releases', {
+      method: 'POST',
+      headers: { authorization: 'Bearer secret', 'content-type': 'application/json' },
+      body: JSON.stringify({
+        version: '.rollback', gitCommit: 'c1598218', gitRef: 'main', snapshotEligible: true,
+        buildTime: '2026-07-19T00:00:00.000Z',
+        bundleKey: 'system-bundles/.rollback/matrix-host-bundle.tar.gz', checksumKey: null,
+        sha256: 'b'.repeat(64), size: 1234,
+      }),
+    });
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({ error: 'Invalid request' });
+  });
+
+  it('exposes only coarse snapshot lifecycle status with immutable release metadata', async () => {
+    await seedRelease();
+    await enqueueGoldenSnapshotBuild(db, {
+      bundleVersion: 'v2026.05.12-1',
+      compatibility: {
+        provider: 'hetzner',
+        architecture: 'x86',
+        region: 'eu-central',
+        baseImage: 'ubuntu-24.04',
+        baseGeneration: 'ubuntu-24.04-v1',
+        bootMode: 'bios',
+        activationAbi: 'host-v1',
+        minimumDiskGb: 40,
+      },
+      snapshotId: '10000000-0000-4000-8000-000000000099',
+      buildId: '20000000-0000-4000-8000-000000000099',
+      now: '2026-07-19T00:00:00.000Z',
+    });
+    const app = createApp({
+      db,
+      orchestrator,
+      customerVpsObjectStore: {
+        getObject: vi.fn(),
+        getPresignedGetUrl: vi.fn().mockResolvedValue('https://r2.example/signed-host-bundle'),
+        putObject: vi.fn(),
+      } as unknown as CustomerVpsObjectStore,
+    });
+
+    const response = await app.request('/system-bundles/releases/v2026.05.12-1.json');
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      version: 'v2026.05.12-1',
+      sha256: 'a'.repeat(64),
+      snapshotStatus: 'requested',
+    });
+  });
+
+  it('derives snapshot status from the immutable digest when another release version names the same bytes', async () => {
+    await seedRelease();
+    await upsertHostBundleRelease(db, {
+      version: 'v2026.05.12-alias', gitCommit: 'c1598218', gitRef: 'main',
+      buildTime: '2026-07-19T00:00:00.000Z',
+      bundleKey: 'system-bundles/v2026.05.12-alias/matrix-host-bundle.tar.gz', checksumKey: null,
+      sha256: 'a'.repeat(64), size: 1234, snapshotEligible: true,
+    });
+    await enqueueGoldenSnapshotBuild(db, {
+      bundleVersion: 'v2026.05.12-1',
+      compatibility: {
+        provider: 'hetzner', architecture: 'x86', region: 'eu-central', baseImage: 'ubuntu-24.04',
+        baseGeneration: 'ubuntu-24.04-v1', bootMode: 'bios', activationAbi: 'host-v1', minimumDiskGb: 40,
+      },
+      snapshotId: '10000000-0000-4000-8000-000000000098',
+      buildId: '20000000-0000-4000-8000-000000000098',
+      now: '2026-07-19T00:00:00.000Z',
+    });
+    const app = createApp({
+      db, orchestrator,
+      customerVpsObjectStore: {
+        getObject: vi.fn(), getPresignedGetUrl: vi.fn().mockResolvedValue('https://r2.example/signed-host-bundle'),
+        putObject: vi.fn(),
+      } as unknown as CustomerVpsObjectStore,
+    });
+
+    const response = await app.request('/system-bundles/releases/v2026.05.12-alias.json');
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      version: 'v2026.05.12-alias', sha256: 'a'.repeat(64), snapshotStatus: 'requested',
+    });
+  });
+
+  it('returns not_requested snapshot status for a valid release version that is not snapshot-eligible', async () => {
+    await upsertHostBundleRelease(db, {
+      version: '.rollback', gitCommit: 'c1598218', gitRef: 'main',
+      buildTime: '2026-07-19T00:00:00.000Z',
+      bundleKey: 'system-bundles/.rollback/matrix-host-bundle.tar.gz', checksumKey: null,
+      sha256: 'b'.repeat(64), size: 1234, snapshotEligible: false,
+    });
+    const app = createApp({
+      db,
+      orchestrator,
+      customerVpsObjectStore: {
+        getObject: vi.fn(),
+        getPresignedGetUrl: vi.fn().mockResolvedValue('https://r2.example/signed-host-bundle'),
+        putObject: vi.fn(),
+      } as unknown as CustomerVpsObjectStore,
+    });
+
+    const response = await app.request('/system-bundles/releases/.rollback.json');
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      version: '.rollback', snapshotStatus: 'not_requested',
+    });
+  });
+
+  it('keeps release publication successful when snapshot status is unavailable', async () => {
+    await db.executor.schema.dropTable('golden_snapshots').cascade().execute();
+    const app = createApp({
+      db, orchestrator, platformSecret: 'secret',
+      customerVpsObjectStore: { getObject: vi.fn(), putObject: vi.fn() } as unknown as CustomerVpsObjectStore,
+    });
+
+    const response = await app.request('/system-bundles/releases', {
+      method: 'POST',
+      headers: { authorization: 'Bearer secret', 'content-type': 'application/json' },
+      body: JSON.stringify({
+        version: 'v2026.07.21-status-isolation', gitCommit: 'c1598218', gitRef: 'main',
+        snapshotEligible: true, buildTime: '2026-07-21T00:00:00.000Z',
+        bundleKey: 'system-bundles/v2026.07.21-status-isolation/matrix-host-bundle.tar.gz',
+        checksumKey: null, sha256: 'c'.repeat(64), size: 1234,
+      }),
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      release: { version: 'v2026.07.21-status-isolation', snapshotStatus: 'unavailable' },
+    });
+    await expect(getHostBundleRelease(db, 'v2026.07.21-status-isolation')).resolves.toBeDefined();
+  });
+
+  it('reports not requested for an ineligible published release when snapshot storage is unavailable', async () => {
+    await db.executor.schema.dropTable('golden_snapshots').cascade().execute();
+    const app = createApp({
+      db, orchestrator, platformSecret: 'secret',
+      customerVpsObjectStore: { getObject: vi.fn(), putObject: vi.fn() } as unknown as CustomerVpsObjectStore,
+    });
+
+    const response = await app.request('/system-bundles/releases', {
+      method: 'POST',
+      headers: { authorization: 'Bearer secret', 'content-type': 'application/json' },
+      body: JSON.stringify({
+        version: 'v2026.07.21-status-not-requested', gitCommit: 'c1598218', gitRef: 'main',
+        snapshotEligible: false, buildTime: '2026-07-21T00:00:00.000Z',
+        bundleKey: 'system-bundles/v2026.07.21-status-not-requested/matrix-host-bundle.tar.gz',
+        checksumKey: null, sha256: 'e'.repeat(64), size: 1234,
+      }),
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      release: { version: 'v2026.07.21-status-not-requested', snapshotStatus: 'not_requested' },
+    });
+  });
+
+  it('keeps immutable release metadata available when snapshot status storage is unavailable', async () => {
+    await seedRelease();
+    await upsertHostBundleRelease(db, {
+      version: 'v2026.05.12-1', gitCommit: 'c1598218', gitRef: 'refs/tags/v2026.05.12-1',
+      buildTime: '2026-05-12T00:00:00.000Z',
+      bundleKey: 'system-bundles/v2026.05.12-1/matrix-host-bundle.tar.gz',
+      checksumKey: 'system-bundles/v2026.05.12-1/matrix-host-bundle.tar.gz.sha256',
+      sha256: 'a'.repeat(64), size: 1234, snapshotEligible: true,
+    });
+    await db.executor.schema.dropTable('golden_snapshots').cascade().execute();
+    const app = createApp({
+      db, orchestrator,
+      customerVpsObjectStore: {
+        getObject: vi.fn(), getPresignedGetUrl: vi.fn().mockResolvedValue('https://r2.example/signed-host-bundle'),
+        putObject: vi.fn(),
+      } as unknown as CustomerVpsObjectStore,
+    });
+
+    const response = await app.request('/system-bundles/v2026.05.12-1/release.json');
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      version: 'v2026.05.12-1', snapshotStatus: 'unavailable',
+    });
+  });
+
+  it('rolls back release registration when its requested channel promotion fails', async () => {
+    await sql`
+      CREATE OR REPLACE FUNCTION reject_host_bundle_channel_promotion() RETURNS trigger AS $$
+      BEGIN
+        RAISE EXCEPTION 'injected channel promotion failure';
+      END;
+      $$ LANGUAGE plpgsql
+    `.execute(db.executor);
+    await sql`
+      CREATE TRIGGER reject_host_bundle_channel_promotion
+      BEFORE INSERT OR UPDATE ON host_bundle_channels
+      FOR EACH ROW EXECUTE FUNCTION reject_host_bundle_channel_promotion()
+    `.execute(db.executor);
+    const app = createApp({
+      db, orchestrator, platformSecret: 'secret',
+      customerVpsObjectStore: { getObject: vi.fn(), putObject: vi.fn() } as unknown as CustomerVpsObjectStore,
+    });
+
+    const response = await app.request('/system-bundles/releases', {
+      method: 'POST',
+      headers: { authorization: 'Bearer secret', 'content-type': 'application/json' },
+      body: JSON.stringify({
+        version: 'v2026.07.21-atomic', gitCommit: 'c1598218', gitRef: 'main',
+        snapshotEligible: true, buildTime: '2026-07-21T00:00:00.000Z',
+        bundleKey: 'system-bundles/v2026.07.21-atomic/matrix-host-bundle.tar.gz',
+        checksumKey: null, sha256: 'd'.repeat(64), size: 1234, channel: 'dev',
+      }),
+    });
+
+    expect(response.status).toBe(502);
+    await expect(getHostBundleRelease(db, 'v2026.07.21-atomic')).resolves.toBeUndefined();
+  });
+
   it('only adds release channel history when channel promotion succeeds', async () => {
     await upsertHostBundleRelease(db, {
       version: 'v2026.05.12-6',
@@ -646,6 +896,86 @@ describe('platform host bundle route', () => {
       sha256: 'a'.repeat(64),
       size: 1234,
     });
+  });
+
+  it('preserves snapshot eligibility when metadata re-registration omits it', async () => {
+    await upsertHostBundleRelease(db, {
+      version: 'v2026.05.12-snapshot',
+      gitCommit: 'c1598218',
+      gitRef: 'refs/tags/v2026.05.12-1',
+      snapshotEligible: true,
+      buildTime: '2026-05-12T00:00:00.000Z',
+      bundleKey: 'system-bundles/v2026.05.12-snapshot/matrix-host-bundle.tar.gz',
+      checksumKey: 'system-bundles/v2026.05.12-snapshot/matrix-host-bundle.tar.gz.sha256',
+      sha256: 'a'.repeat(64),
+      size: 1234,
+    });
+
+    await expect(upsertHostBundleRelease(db, {
+      version: 'v2026.05.12-snapshot',
+      gitCommit: 'c1598218',
+      gitRef: 'refs/tags/v2026.05.12-1',
+      buildTime: '2026-05-12T00:00:00.000Z',
+      bundleKey: 'system-bundles/v2026.05.12-snapshot/matrix-host-bundle.tar.gz',
+      checksumKey: 'system-bundles/v2026.05.12-snapshot/matrix-host-bundle.tar.gz.sha256',
+      sha256: 'a'.repeat(64),
+      size: 1234,
+      severity: 'security',
+    })).resolves.toMatchObject({ snapshotEligible: true, severity: 'security' });
+  });
+
+  it('preserves snapshot eligibility when metadata re-registration explicitly sends false', async () => {
+    await upsertHostBundleRelease(db, {
+      version: 'v2026.05.12-snapshot-explicit-false',
+      gitCommit: 'c1598218',
+      gitRef: 'refs/tags/v2026.05.12-1',
+      snapshotEligible: true,
+      buildTime: '2026-05-12T00:00:00.000Z',
+      bundleKey: 'system-bundles/v2026.05.12-snapshot-explicit-false/matrix-host-bundle.tar.gz',
+      checksumKey: 'system-bundles/v2026.05.12-snapshot-explicit-false/matrix-host-bundle.tar.gz.sha256',
+      sha256: 'a'.repeat(64),
+      size: 1234,
+    });
+
+    await expect(upsertHostBundleRelease(db, {
+      version: 'v2026.05.12-snapshot-explicit-false',
+      gitCommit: 'c1598218',
+      gitRef: 'refs/tags/v2026.05.12-1',
+      snapshotEligible: false,
+      buildTime: '2026-05-12T00:00:00.000Z',
+      bundleKey: 'system-bundles/v2026.05.12-snapshot-explicit-false/matrix-host-bundle.tar.gz',
+      checksumKey: 'system-bundles/v2026.05.12-snapshot-explicit-false/matrix-host-bundle.tar.gz.sha256',
+      sha256: 'a'.repeat(64),
+      size: 1234,
+      severity: 'security',
+    })).resolves.toMatchObject({ snapshotEligible: true, severity: 'security' });
+  });
+
+  it('atomically promotes an identical release to snapshot eligible on trusted re-publication', async () => {
+    await upsertHostBundleRelease(db, {
+      version: 'v2026.05.12-snapshot-promoted',
+      gitCommit: 'c1598218',
+      gitRef: 'refs/tags/v2026.05.12-1',
+      snapshotEligible: false,
+      buildTime: '2026-05-12T00:00:00.000Z',
+      bundleKey: 'system-bundles/v2026.05.12-snapshot-promoted/matrix-host-bundle.tar.gz',
+      checksumKey: 'system-bundles/v2026.05.12-snapshot-promoted/matrix-host-bundle.tar.gz.sha256',
+      sha256: 'a'.repeat(64),
+      size: 1234,
+    });
+
+    await expect(upsertHostBundleRelease(db, {
+      version: 'v2026.05.12-snapshot-promoted',
+      gitCommit: 'c1598218',
+      gitRef: 'refs/tags/v2026.05.12-1',
+      snapshotEligible: true,
+      buildTime: '2026-05-12T00:00:00.000Z',
+      bundleKey: 'system-bundles/v2026.05.12-snapshot-promoted/matrix-host-bundle.tar.gz',
+      checksumKey: 'system-bundles/v2026.05.12-snapshot-promoted/matrix-host-bundle.tar.gz.sha256',
+      sha256: 'a'.repeat(64),
+      size: 1234,
+      severity: 'security',
+    })).resolves.toMatchObject({ snapshotEligible: true, severity: 'security' });
   });
 
   it('returns 409 when release registration would replace an immutable artifact', async () => {

--- a/tests/platform/host-bundle-snapshot-workflow.test.ts
+++ b/tests/platform/host-bundle-snapshot-workflow.test.ts
@@ -1,0 +1,348 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  getHostBundleRelease,
+  promoteHostBundleChannel,
+  upsertHostBundleRelease,
+  type PlatformDB,
+} from '../../packages/platform/src/db.js';
+import {
+  enqueueGoldenSnapshotBuild,
+} from '../../packages/platform/src/golden-snapshot-repository.js';
+import {
+  getGoldenSnapshotCoarseStatuses,
+  reconcileMissingGoldenSnapshotBuilds,
+} from '../../packages/platform/src/golden-snapshot-release-repository.js';
+import { createTestPlatformDb, destroyTestPlatformDb } from './platform-db-test-helper.js';
+import {
+  enqueueGoldenSnapshot,
+  isEligibleSnapshotRelease,
+} from '../../scripts/enqueue-golden-snapshot.mjs';
+import { resolveReleaseSnapshotEligibility } from '../../scripts/release-snapshot-eligibility.mjs';
+
+const root = process.cwd();
+
+describe('host bundle golden snapshot release hook', () => {
+  it('accepts immutable main, tag, and trusted manual customer-channel releases', () => {
+    expect(isEligibleSnapshotRelease({ eventName: 'push', refType: 'branch', refName: 'main' })).toBe(true);
+    expect(isEligibleSnapshotRelease({ eventName: 'push', refType: 'tag', refName: 'v0.9.1' })).toBe(true);
+    expect(isEligibleSnapshotRelease({ eventName: 'push', refType: 'branch', refName: 'preview-123' })).toBe(false);
+    expect(isEligibleSnapshotRelease({
+      eventName: 'workflow_dispatch', refType: 'branch', refName: 'release-candidate', channel: 'stable',
+    })).toBe(true);
+    expect(isEligibleSnapshotRelease({
+      eventName: 'workflow_dispatch', refType: 'branch', refName: 'release-candidate',
+    })).toBe(false);
+  });
+
+  it('enqueues with platform auth, a bounded request, redirect rejection, and a generic result', async () => {
+    const fetchImpl = vi.fn(async () => new Response(JSON.stringify({
+      snapshotId: '10000000-0000-4000-8000-000000000001',
+      buildId: '20000000-0000-4000-8000-000000000001',
+      status: 'queued',
+      reused: false,
+      providerError: 'must not escape',
+    }), { status: 202, headers: { 'content-type': 'application/json' } }));
+
+    await expect(enqueueGoldenSnapshot({
+      platformUrl: 'https://app.matrix-os.com/',
+      platformSecret: 'test-secret',
+      bundleVersion: 'v2026.07.19-1053',
+      fetchImpl,
+    })).resolves.toEqual({ status: 'queued', reused: false });
+
+    expect(fetchImpl).toHaveBeenCalledWith(
+      'https://app.matrix-os.com/system-bundles/snapshot-builds',
+      expect.objectContaining({
+        method: 'POST',
+        redirect: 'error',
+        headers: expect.objectContaining({ authorization: 'Bearer test-secret' }),
+        body: JSON.stringify({ bundleVersion: 'v2026.07.19-1053' }),
+        signal: expect.any(AbortSignal),
+      }),
+    );
+  });
+
+  it('does not expose provider or response details when enqueueing fails', async () => {
+    const fetchImpl = vi.fn(async () => new Response('provider quota secret', { status: 503 }));
+    await expect(enqueueGoldenSnapshot({
+      platformUrl: 'https://app.matrix-os.com',
+      platformSecret: 'test-secret',
+      bundleVersion: 'v2026.07.19-1053',
+      fetchImpl,
+    })).rejects.toThrow('Snapshot build enqueue failed');
+  });
+
+  it('keeps snapshot enqueue failure isolated from existing fleet deployment', () => {
+    const workflow = readFileSync(join(root, '.github/workflows/host-bundle-release.yml'), 'utf8');
+    const enqueueJob = workflow.slice(
+      workflow.indexOf('\n  enqueue-golden-snapshot:'),
+      workflow.indexOf('\n  deploy:'),
+    );
+    const deployJob = workflow.slice(workflow.indexOf('\n  deploy:'));
+
+    expect(enqueueJob).toContain('needs: [dev-bundle-gate, build, publish]');
+    expect(enqueueJob).toContain('continue-on-error: true');
+    expect(enqueueJob).toContain("github.event_name == 'push'");
+    expect(enqueueJob).toContain("(github.event_name == 'workflow_dispatch' && inputs.channel != '')");
+    expect(enqueueJob).toContain("github.ref_name == 'main'");
+    expect(enqueueJob).toContain("github.ref_type == 'tag'");
+    expect(enqueueJob).toContain('PUBLISH_CHANNEL: ${{ needs.build.outputs.channel }}');
+    expect(enqueueJob).toContain('PUBLISH_VERSION: ${{ needs.build.outputs.version }}');
+    expect(enqueueJob).toContain('scripts/enqueue-golden-snapshot.mjs --version "$PUBLISH_VERSION"');
+    expect(enqueueJob).not.toContain('--version "${{ needs.build.outputs.version }}"');
+    expect(deployJob).toContain('needs: [dev-bundle-gate, build, publish]');
+    expect(deployJob).not.toContain('enqueue-golden-snapshot');
+  });
+
+  it('uses the same manual-channel eligibility rule for durable release registration', () => {
+    const workflow = readFileSync(join(root, '.github/workflows/host-bundle-release.yml'), 'utf8');
+
+    expect(workflow).toContain(
+      "GOLDEN_SNAPSHOT_ELIGIBLE: ${{ (github.event_name == 'push' && ((github.ref_type == 'branch' && github.ref_name == 'main') || github.ref_type == 'tag')) || (github.event_name == 'workflow_dispatch' && inputs.channel != '') }}",
+    );
+  });
+
+  it('resolves enqueue validation from the platform package and preserves eligibility in both publishers', () => {
+    const enqueueScript = readFileSync(join(root, 'scripts/enqueue-golden-snapshot.mjs'), 'utf8');
+    const nodePublisher = readFileSync(join(root, 'scripts/publish-release-r2.mjs'), 'utf8');
+
+    expect(enqueueScript).not.toContain("import { z } from 'zod/v4'");
+    expect(enqueueScript).toContain('createRequire');
+    expect(enqueueScript).toContain('packages/platform/package.json');
+    expect(nodePublisher).toContain('resolveReleaseSnapshotEligibility');
+  });
+
+  it('defaults customer channels eligible while keeping preview and explicit opt-out ineligible', () => {
+    for (const channel of ['dev', 'canary', 'beta', 'stable']) {
+      expect(resolveReleaseSnapshotEligibility(channel)).toBe(true);
+    }
+    expect(resolveReleaseSnapshotEligibility('none')).toBe(false);
+    expect(resolveReleaseSnapshotEligibility('preview')).toBe(false);
+    expect(resolveReleaseSnapshotEligibility('dev', 'false')).toBe(false);
+    expect(resolveReleaseSnapshotEligibility('none', 'true')).toBe(true);
+    expect(() => resolveReleaseSnapshotEligibility('dev', 'yes')).toThrow('must be true or false');
+  });
+});
+
+describe('durable golden snapshot release reconciliation', () => {
+  let db: PlatformDB;
+  beforeEach(async () => ({ db } = await createTestPlatformDb()));
+  afterEach(async () => destroyTestPlatformDb(db));
+
+  it('enqueues eligible durable releases missing a candidate and batches coarse status reads', async () => {
+    await upsertHostBundleRelease(db, {
+      version: 'v1', gitCommit: '1111111', gitRef: 'main', snapshotEligible: true, buildTime: '2026-07-01T00:00:00.000Z',
+      bundleKey: 'system-bundles/v1/matrix-host-bundle.tar.gz', checksumKey: null,
+      sha256: '1'.repeat(64), size: 100, createdAt: '2026-07-01T00:00:00.000Z',
+    });
+    await upsertHostBundleRelease(db, {
+      version: 'preview-1', gitCommit: '2222222', gitRef: 'preview-1', buildTime: '2026-07-02T00:00:00.000Z',
+      bundleKey: 'system-bundles/preview-1/matrix-host-bundle.tar.gz', checksumKey: null,
+      sha256: '2'.repeat(64), size: 100, createdAt: '2026-07-02T00:00:00.000Z',
+    });
+    await upsertHostBundleRelease(db, {
+      version: 'manual-main', gitCommit: '3333333', gitRef: 'main', snapshotEligible: false,
+      buildTime: '2026-07-02T01:00:00.000Z', bundleKey: 'system-bundles/manual-main/matrix-host-bundle.tar.gz',
+      checksumKey: null, sha256: '3'.repeat(64), size: 100, createdAt: '2026-07-02T01:00:00.000Z',
+    });
+    const compatibility = {
+      provider: 'hetzner' as const, architecture: 'x86' as const, region: 'eu-central',
+      baseImage: 'ubuntu-24.04', baseGeneration: 'ubuntu-24.04-v1',
+      bootMode: 'bios' as const, activationAbi: 'host-v1', minimumDiskGb: 40,
+    };
+
+    await expect(reconcileMissingGoldenSnapshotBuilds(db, {
+      compatibility, now: '2026-07-03T00:00:00.000Z', limit: 25, freshnessMaxAgeMs: 86_400_000,
+    })).resolves.toEqual({ enqueued: 1 });
+    await expect(reconcileMissingGoldenSnapshotBuilds(db, {
+      compatibility, now: '2026-07-03T00:01:00.000Z', limit: 25, freshnessMaxAgeMs: 86_400_000,
+    })).resolves.toEqual({ enqueued: 0 });
+    const statuses = await getGoldenSnapshotCoarseStatuses(db, ['v1', 'preview-1', 'manual-main', 'missing']);
+    expect(Object.fromEntries(statuses)).toEqual({
+      v1: 'requested', 'preview-1': 'not_requested', 'manual-main': 'not_requested', missing: 'not_requested',
+    });
+  });
+
+  it('backfills a legacy release promoted before the new platform becomes authoritative', async () => {
+    await upsertHostBundleRelease(db, {
+      version: 'legacy-main-race', gitCommit: 'aaaaaaa', gitRef: 'main',
+      buildTime: '2026-07-02T02:00:00.000Z',
+      bundleKey: 'system-bundles/legacy-main-race/matrix-host-bundle.tar.gz', checksumKey: null,
+      sha256: 'a'.repeat(64), size: 100, createdAt: '2026-07-02T02:00:00.000Z',
+    });
+    await promoteHostBundleChannel(db, 'dev', 'legacy-main-race', '2026-07-02T02:01:00.000Z');
+    await upsertHostBundleRelease(db, {
+      version: 'explicit-opt-out', gitCommit: 'bbbbbbb', gitRef: 'main', snapshotEligible: false,
+      buildTime: '2026-07-02T03:00:00.000Z',
+      bundleKey: 'system-bundles/explicit-opt-out/matrix-host-bundle.tar.gz', checksumKey: null,
+      sha256: 'b'.repeat(64), size: 100, createdAt: '2026-07-02T03:00:00.000Z',
+    });
+    await promoteHostBundleChannel(db, 'beta', 'explicit-opt-out', '2026-07-02T03:01:00.000Z');
+    const compatibility = {
+      provider: 'hetzner' as const, architecture: 'x86' as const, region: 'eu-central',
+      baseImage: 'ubuntu-24.04', baseGeneration: 'ubuntu-24.04-v1',
+      bootMode: 'bios' as const, activationAbi: 'host-v1', minimumDiskGb: 40,
+    };
+
+    await expect(reconcileMissingGoldenSnapshotBuilds(db, {
+      compatibility, now: '2026-07-03T00:00:00.000Z', limit: 25, freshnessMaxAgeMs: 86_400_000,
+    })).resolves.toEqual({ enqueued: 1 });
+    await expect(getHostBundleRelease(db, 'legacy-main-race'))
+      .resolves.toMatchObject({ snapshotEligible: true });
+    await expect(getHostBundleRelease(db, 'explicit-opt-out'))
+      .resolves.toMatchObject({ snapshotEligible: false });
+  });
+
+  it('never lets test-mode snapshots satisfy production reconciliation or public status', async () => {
+    await upsertHostBundleRelease(db, {
+      version: 'v-test-isolation', gitCommit: '4444444', gitRef: 'main', snapshotEligible: true,
+      buildTime: '2026-07-04T00:00:00.000Z',
+      bundleKey: 'system-bundles/v-test-isolation/matrix-host-bundle.tar.gz', checksumKey: null,
+      sha256: '4'.repeat(64), size: 100, createdAt: '2026-07-04T00:00:00.000Z',
+    });
+    const compatibility = {
+      provider: 'hetzner' as const, architecture: 'x86' as const, region: 'eu-central',
+      baseImage: 'ubuntu-24.04', baseGeneration: 'ubuntu-24.04-v1',
+      bootMode: 'bios' as const, activationAbi: 'host-v1', minimumDiskGb: 40,
+    };
+    await enqueueGoldenSnapshotBuild(db, {
+      bundleVersion: 'v-test-isolation', compatibility, testMode: true,
+      snapshotId: '10000000-0000-4000-8000-000000000099',
+      buildId: '20000000-0000-4000-8000-000000000099',
+      now: '2026-07-04T00:01:00.000Z',
+    });
+
+    expect(Object.fromEntries(await getGoldenSnapshotCoarseStatuses(db, ['v-test-isolation'])))
+      .toEqual({ 'v-test-isolation': 'not_requested' });
+    await expect(reconcileMissingGoldenSnapshotBuilds(db, {
+      compatibility, now: '2026-07-04T00:02:00.000Z', limit: 25, freshnessMaxAgeMs: 86_400_000,
+    })).resolves.toEqual({ enqueued: 1 });
+  });
+
+  it('enqueues one immutable replacement for a stale ready snapshot and reuses it on reconciliation', async () => {
+    await upsertHostBundleRelease(db, {
+      version: 'v-stale', gitCommit: '8888888', gitRef: 'main', snapshotEligible: true,
+      buildTime: '2026-07-01T00:00:00.000Z',
+      bundleKey: 'system-bundles/v-stale/matrix-host-bundle.tar.gz', checksumKey: null,
+      sha256: '8'.repeat(64), size: 100, createdAt: '2026-07-01T00:00:00.000Z',
+    });
+    const compatibility = {
+      provider: 'hetzner' as const, architecture: 'x86' as const, region: 'eu-central',
+      baseImage: 'ubuntu-24.04', baseGeneration: 'ubuntu-24.04-v1',
+      bootMode: 'bios' as const, activationAbi: 'host-v1', minimumDiskGb: 40,
+    };
+    const original = await enqueueGoldenSnapshotBuild(db, {
+      bundleVersion: 'v-stale', compatibility,
+      snapshotId: '10000000-0000-4000-8000-000000000088',
+      buildId: '20000000-0000-4000-8000-000000000088', now: '2026-07-01T00:01:00.000Z',
+    });
+    await db.executor.updateTable('golden_snapshots').set({
+      state: 'ready', ready_at: '2026-07-01T00:02:00.000Z', provider_image_id: 88,
+    }).where('snapshot_id', '=', original.snapshot.snapshotId).execute();
+
+    await expect(reconcileMissingGoldenSnapshotBuilds(db, {
+      compatibility, now: '2026-07-03T00:00:00.000Z', limit: 25,
+      freshnessMaxAgeMs: 24 * 60 * 60 * 1000,
+    })).resolves.toEqual({ enqueued: 1 });
+    await expect(reconcileMissingGoldenSnapshotBuilds(db, {
+      compatibility, now: '2026-07-03T00:01:00.000Z', limit: 25,
+      freshnessMaxAgeMs: 24 * 60 * 60 * 1000,
+    })).resolves.toEqual({ enqueued: 0 });
+    await expect(db.executor.selectFrom('golden_snapshots')
+      .select(['image_generation', 'state']).where('bundle_sha256', '=', '8'.repeat(64))
+      .orderBy('image_generation').execute()).resolves.toEqual([
+      { image_generation: 1, state: 'ready' },
+      { image_generation: 2, state: 'candidate' },
+    ]);
+    expect(Object.fromEntries(await getGoldenSnapshotCoarseStatuses(
+      db,
+      ['v-stale'],
+      compatibility,
+      { now: '2026-07-03T00:01:00.000Z', freshnessMaxAgeMs: 24 * 60 * 60 * 1000 },
+    ))).toEqual({ 'v-stale': 'requested' });
+  });
+
+  it('reports status only for the active provisioning compatibility', async () => {
+    await upsertHostBundleRelease(db, {
+      version: 'v-active-compatibility', gitCommit: '5555555', gitRef: 'main', snapshotEligible: true,
+      buildTime: '2026-07-05T00:00:00.000Z',
+      bundleKey: 'system-bundles/v-active-compatibility/matrix-host-bundle.tar.gz', checksumKey: null,
+      sha256: '5'.repeat(64), size: 100, createdAt: '2026-07-05T00:00:00.000Z',
+    });
+    const activeCompatibility = {
+      provider: 'hetzner' as const, architecture: 'x86' as const, region: 'eu-central',
+      baseImage: 'ubuntu-24.04', baseGeneration: 'ubuntu-24.04-v2',
+      bootMode: 'bios' as const, activationAbi: 'host-v1', minimumDiskGb: 40,
+    };
+    await enqueueGoldenSnapshotBuild(db, {
+      bundleVersion: 'v-active-compatibility',
+      compatibility: { ...activeCompatibility, baseGeneration: 'ubuntu-24.04-v1' },
+      snapshotId: '10000000-0000-4000-8000-000000000097',
+      buildId: '20000000-0000-4000-8000-000000000097', now: '2026-07-05T00:01:00.000Z',
+    });
+    await db.executor.updateTable('golden_snapshots').set({ state: 'ready' })
+      .where('snapshot_id', '=', '10000000-0000-4000-8000-000000000097').execute();
+    await enqueueGoldenSnapshotBuild(db, {
+      bundleVersion: 'v-active-compatibility', compatibility: activeCompatibility,
+      snapshotId: '10000000-0000-4000-8000-000000000098',
+      buildId: '20000000-0000-4000-8000-000000000098', now: '2026-07-05T00:02:00.000Z',
+    });
+
+    expect(Object.fromEntries(await getGoldenSnapshotCoarseStatuses(
+      db, ['v-active-compatibility'], activeCompatibility,
+    ))).toEqual({ 'v-active-compatibility': 'requested' });
+  });
+
+  it('prioritizes the newest missing eligible release within each bounded reconciliation batch', async () => {
+    for (const [version, day, sha] of [['v-backlog-old', '01', '6'], ['v-backlog-new', '02', '7']] as const) {
+      await upsertHostBundleRelease(db, {
+        version, gitCommit: sha.repeat(7), gitRef: 'main', snapshotEligible: true,
+        buildTime: `2026-07-${day}T00:00:00.000Z`,
+        bundleKey: `system-bundles/${version}/matrix-host-bundle.tar.gz`, checksumKey: null,
+        sha256: sha.repeat(64), size: 100, createdAt: `2026-07-${day}T00:00:00.000Z`,
+      });
+    }
+    const compatibility = {
+      provider: 'hetzner' as const, architecture: 'x86' as const, region: 'eu-central',
+      baseImage: 'ubuntu-24.04', baseGeneration: 'ubuntu-24.04-v1',
+      bootMode: 'bios' as const, activationAbi: 'host-v1', minimumDiskGb: 40,
+    };
+
+    await expect(reconcileMissingGoldenSnapshotBuilds(db, {
+      compatibility, now: '2026-07-03T00:00:00.000Z', limit: 1, freshnessMaxAgeMs: 86_400_000,
+    })).resolves.toEqual({ enqueued: 1 });
+    await expect(db.executor.selectFrom('golden_snapshots').select('bundle_version').execute())
+      .resolves.toEqual([{ bundle_version: 'v-backlog-new' }]);
+  });
+
+  it('continues the bounded reconciliation batch after one release cannot enqueue', async () => {
+    for (const [version, day, sha] of [['v-reconcile-old', '01', '6'], ['v-reconcile-corrupt', '02', '7']] as const) {
+      await upsertHostBundleRelease(db, {
+        version, gitCommit: sha.repeat(7), gitRef: 'main', snapshotEligible: true,
+        buildTime: `2026-07-${day}T00:00:00.000Z`,
+        bundleKey: `system-bundles/${version}/matrix-host-bundle.tar.gz`, checksumKey: null,
+        sha256: sha.repeat(64), size: 100, createdAt: `2026-07-${day}T00:00:00.000Z`,
+      });
+    }
+    await db.executor.updateTable('host_bundle_releases').set({ sha256: 'invalid-provenance' })
+      .where('version', '=', 'v-reconcile-corrupt').execute();
+    const compatibility = {
+      provider: 'hetzner' as const, architecture: 'x86' as const, region: 'eu-central',
+      baseImage: 'ubuntu-24.04', baseGeneration: 'ubuntu-24.04-v1',
+      bootMode: 'bios' as const, activationAbi: 'host-v1', minimumDiskGb: 40,
+    };
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+    await expect(reconcileMissingGoldenSnapshotBuilds(db, {
+      compatibility, now: '2026-07-03T00:00:00.000Z', limit: 25, freshnessMaxAgeMs: 86_400_000,
+    })).resolves.toEqual({ enqueued: 1 });
+    await expect(db.executor.selectFrom('golden_snapshots').select('bundle_version').execute())
+      .resolves.toEqual([{ bundle_version: 'v-reconcile-old' }]);
+    expect(consoleError).toHaveBeenCalledWith(expect.stringContaining(
+      '[golden-snapshot] missing-build enqueue failed release=v-reconcile-corrupt',
+    ));
+    consoleError.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary

- enqueue one idempotent golden-snapshot build after every eligible successful main/tag host-bundle publication
- key requests through immutable release metadata and expose only coarse snapshot status without blocking publication or existing-fleet deployment
- deploy distinct production/preview golden-snapshot operator secrets only after preflight and service-account access checks
- extract release status/reconciliation persistence from the lifecycle repository into a focused module

## Validation

- `bun run test:golden-snapshots` — 400/400 tests, one worker, at stack head (including CI workflow assertions)
- `pnpm --dir packages/platform exec tsc --noEmit`
- `bun run check:patterns` — 5 advisory warnings, 0 violations
- `git diff --check`

## Invariants

### Source of truth

- Immutable platform host-bundle release metadata is authoritative for eligibility and target identity.
- Platform Postgres snapshot/build rows are canonical for build status; workflow completion never implies readiness.

### Lock/transaction scope

- Release registration retains its transaction boundaries; snapshot enqueue is a separate authenticated request after publication.
- No provider request is made and no release/deploy transaction is held while snapshot automation runs.

### Acceptable orphan states

- An eligible published release may temporarily have no build row if enqueue fails, or may have a queued/failed build.
- Bounded reconciliation and idempotent retry recover these states; neither blocks the published bundle or existing-fleet deployment.

### Authorization source

- Release enqueue uses the scoped release/platform bearer credential; test-mode and operator controls use a distinct operator secret.
- Cloud Run binds separate production and preview operator secrets only after verifying nonempty versions and Secret Manager access.

### Deferred scope

- Production feature enablement depends on separately authorized provider validation and rollout gates.
- Dashboards/alerts, stable-channel rollout, and customer deployment remain outside this PR; remaining lifecycle extraction is tracked in #1127.
