### PR TITLE
docs(vps): document snapshot operations and rollout

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -79,6 +79,36 @@ HETZNER_SERVER_TYPE=cpx22
 HETZNER_IMAGE=ubuntu-24.04
 HETZNER_SSH_KEY_NAME=
 
+# Optional golden VPS snapshot acceleration. Keep both controls disabled until
+# the separately authorized disposable-provider spike and rollout gates in
+# docs/dev/golden-vps-snapshots.md pass. Builds and selection are independent.
+# Enabled/percentage are bootstrap defaults for a missing Postgres rollout row;
+# operator mutations are durable and authoritative after initialization.
+GOLDEN_SNAPSHOT_BUILDS_ENABLED=false
+GOLDEN_SNAPSHOTS_ENABLED=false
+GOLDEN_SNAPSHOT_ROLLOUT_PERCENT=0
+GOLDEN_SNAPSHOT_ARCHITECTURE=x86
+GOLDEN_SNAPSHOT_REGION=eu-central
+# Defaults to HETZNER_IMAGE when unset.
+GOLDEN_SNAPSHOT_BASE_IMAGE=
+GOLDEN_SNAPSHOT_BASE_GENERATION=ubuntu-24.04-v1
+GOLDEN_SNAPSHOT_BOOT_MODE=bios
+GOLDEN_SNAPSHOT_ACTIVATION_ABI=host-v1
+GOLDEN_SNAPSHOT_MINIMUM_DISK_GB=40
+GOLDEN_SNAPSHOT_MAX_BUILD_ATTEMPTS=5
+GOLDEN_SNAPSHOT_MAX_CONCURRENT_BUILDS=2
+GOLDEN_SNAPSHOT_BUILD_LEASE_MS=300000
+GOLDEN_SNAPSHOT_PROVISIONING_LEASE_MS=600000
+GOLDEN_SNAPSHOT_RETENTION_LIMIT=20
+GOLDEN_SNAPSHOT_FRESHNESS_MAX_AGE_MS=604800000
+GOLDEN_SNAPSHOT_RECONCILIATION_BATCH_SIZE=25
+GOLDEN_SNAPSHOT_RECONCILIATION_INTERVAL_MS=15000
+# Required when CUSTOMER_VPS_ENABLED=true. Generate independently with: openssl rand -hex 32
+# Never reuse PLATFORM_SECRET; the platform refuses to start when they match.
+# This authorizes snapshot status, rollout, retry, revoke, inventory, cleanup,
+# and explicitly isolated test-mode enqueue. Never expose it to release automation.
+GOLDEN_SNAPSHOT_OPERATOR_SECRET=
+
 # Cloudflare R2 — used for VPS metadata, hourly DB snapshots, and recovery.
 R2_ACCOUNT_ID=
 R2_ACCESS_KEY_ID=

--- a/docs/dev/golden-vps-snapshots.md
+++ b/docs/dev/golden-vps-snapshots.md
@@ -1,0 +1,187 @@
+# Golden VPS Snapshots
+
+Golden VPS snapshots accelerate new customer and recovery machine creation. They are an optional, fail-closed optimization around the existing immutable host-bundle and clean Ubuntu cloud-init path. They are not backups, customer images, or a pool of warm servers.
+
+The approved product invariants and policy are defined by [spec 109](../../specs/109-golden-vps-snapshots/spec.md). The implementation plan, data model, provider research, design contracts, and executable checklist live beside it in `specs/109-golden-vps-snapshots/`. Exact operational request fields come from the bounded live route schemas in `packages/platform/src/golden-snapshot-routes.ts`; this guide does not override those schemas.
+
+## V1 Invariants
+
+- Build a new sanitized candidate for each eligible immutable main or tag host bundle. Do not keep running or powered-off warm customer VPSes.
+- Select an exact snapshot first. A compatible older snapshot may be used only when first boot updates it to the requested exact bundle before health, registration, or routing succeeds.
+- Never select a newer snapshot for an older requested bundle.
+- Keep snapshot building, publication, existing-fleet deployment, and customer provisioning as separate failure domains.
+- Fall back to the existing clean Ubuntu/full cloud-init path whenever lookup, compatibility, cloning, activation, or validation is definitely unsafe.
+- Do not issue a second provider create after an ambiguous timeout. Reconcile exact immutable labels first.
+- Do not mark an image selectable until an independent clone proves the exact bundle, runtime health, fresh identity, and sanitation invariants.
+- Customer data and owner backups never enter a golden snapshot. Recovery restores an owner-scoped backup only after base activation.
+
+The feature ships disabled. `GOLDEN_SNAPSHOT_BUILDS_ENABLED` controls candidate production. `GOLDEN_SNAPSHOTS_ENABLED` and `GOLDEN_SNAPSHOT_ROLLOUT_PERCENT` only bootstrap a missing compatibility-scoped Postgres rollout row; the durable row is authoritative thereafter. Builds and selection are deliberately separate.
+
+## Architecture and Source of Truth
+
+Platform Postgres is authoritative for immutable bundle provenance, snapshot state, build attempts, leases, cleanup work, and release/channel protection. Hetzner holds provider resources but is not the lifecycle source of truth. R2 holds immutable host-bundle bytes and checksums.
+
+Each logical image is keyed by the host bundle SHA-256 plus a compatibility key containing provider, architecture, region policy, base image/generation, boot mode, activation ABI, and minimum disk size. Re-registering a channel does not create a new identity. Preview/PR artifacts are not eligible for the release hook.
+
+The durable lifecycle is:
+
+| State | Selectable | Meaning |
+|---|---:|---|
+| `candidate` | no | Idempotent build request exists |
+| `building` | no | Ephemeral builder is being created or booted |
+| `sanitizing` | no | Exact bundle is installed and sensitive state is being removed |
+| `validating` | no | Provider image exists; an independent clone is proving it |
+| `ready` | yes | Validation evidence passed and provider image is available |
+| `failed` | no | Bounded retry may be explicitly requested |
+| `quarantined` | no | Safety or provenance is uncertain; automatic retry is forbidden |
+| `retiring` | no | Selection is disabled and exact-resource cleanup is queued |
+| `deleted` | no | Provider deletion was reconciled and recorded |
+
+Related state changes use Postgres transactions. Provider requests are always outside transaction and row-lock scope. Selection and lease insertion are one transaction; retirement takes a row lock, rechecks active leases, creates idempotent cleanup work, and removes the image from eligibility atomically.
+
+## Build and Validation
+
+The release workflow enqueues the immutable bundle version only after publication. Enqueue failure is non-blocking, and the existing `deploy` job does not depend on snapshot success.
+
+The worker uses bounded batches and leases. Ephemeral builders and validation clones carry exact labels for build ID, snapshot ID, and role. Those labels are also the only allowed basis for adopting a resource after an ambiguous create result. Zero matches means wait; multiple exact matches quarantine the build. Cleanup verifies the recorded resource ID and labels before deletion.
+
+The sanitizer must remove or reset all of the following before shutdown:
+
+- Matrix/customer credentials, environment files, registration tokens, and provisioning markers
+- owner home/data, databases or container volumes, conversations, sessions, memory, and logs
+- SSH host keys, `authorized_keys`, TLS keys, and provider/bootstrap credentials
+- `/etc/machine-id`, systemd random seed, cloud-init instance/cache state
+- network leases and persistent interface identity
+- shell history, temporary files, package-manager credentials, and secret-bearing builder logs
+
+The validation clone must then prove:
+
+- `/opt/matrix/app/BUNDLE_VERSION` and `/opt/matrix/app/BUNDLE_SHA256` match the requested immutable version and SHA-256
+- required Matrix services and local health are ready
+- machine ID and SSH host identity are newly generated
+- activation/registration state is fresh
+- the forbidden owner, credential, log, cloud-init, and builder markers remain absent
+
+The sanitizer writes a bounded evidence manifest only after every required category is removed. The validation clone requires every manifest entry before synthetic activation and then rechecks stable forbidden paths afterward. Missing evidence for any sanitation category fails validation closed.
+
+Validation callbacks use a short-lived per-phase token stored only as a hash. Failed or incomplete evidence never produces `ready`.
+
+## Provisioning and Recovery
+
+Selection order is exact compatible image, compatible older image, then clean Ubuntu. Compatibility includes architecture, region policy, boot mode, activation ABI, minimum disk, and base generation. A compatible older image is not healthy until exact-bundle activation completes.
+
+The snapshot lease remains active while the provider clone is in flight. Owner identity, platform registration material, tunnel credentials, TLS material, and runtime secrets are injected only through first-boot cloud-init after the clone. First boot regenerates machine ID, SSH host keys, cloud-init instance state, and runtime registration before routing.
+
+A definite provider rejection that proves the snapshot cannot be cloned may fall back to clean Ubuntu. Timeouts, connection loss, and other ambiguous results must reconcile the labeled provider resource; they must not create a second server. The existing clean-image path remains authoritative when the feature is disabled or no safe snapshot is available.
+
+Recovery uses the same image decision and lease rules, but a golden snapshot is never treated as owner backup data. Existing backup ownership checks remain unchanged. After replacement creation succeeds, platform atomically replaces the machine/provider identity, marks the replacement `recovering`, and begins exact old-server cleanup. The replacement remains unroutable until registration proves the requested bundle version, SHA-256, and health and moves the machine to `running`; persisted provenance keeps those checks mandatory even if the bounded snapshot lease has expired. The previous server is not retained as a rollback after replacement adoption. A later registration timeout marks and reaps the unroutable replacement; an operator or customer must retry recovery. Disable snapshot selection or revoke the candidate before that retry when the next attempt must use clean Ubuntu.
+
+## Configuration
+
+All values are bounded during configuration parsing. Defaults keep building and selection off.
+
+| Variable | Default | Purpose |
+|---|---:|---|
+| `GOLDEN_SNAPSHOT_BUILDS_ENABLED` | `false` | Allow candidate build workers |
+| `GOLDEN_SNAPSHOTS_ENABLED` | `false` | Allow provisioning/recovery selection |
+| `GOLDEN_SNAPSHOT_ROLLOUT_PERCENT` | `0` | Deterministic customer rollout percentage |
+| `GOLDEN_SNAPSHOT_ARCHITECTURE` | `x86` | Provider architecture compatibility |
+| `GOLDEN_SNAPSHOT_REGION` | `eu-central` | Region compatibility policy |
+| `GOLDEN_SNAPSHOT_BASE_IMAGE` | `HETZNER_IMAGE` | Clean builder base image |
+| `GOLDEN_SNAPSHOT_BASE_GENERATION` | `ubuntu-24.04-v1` | Revocable base-image generation |
+| `GOLDEN_SNAPSHOT_BOOT_MODE` | `bios` | Boot compatibility |
+| `GOLDEN_SNAPSHOT_ACTIVATION_ABI` | `host-v1` | First-boot activation contract |
+| `GOLDEN_SNAPSHOT_MINIMUM_DISK_GB` | `40` | Image/server disk compatibility |
+| `GOLDEN_SNAPSHOT_MAX_BUILD_ATTEMPTS` | `5` | Build and cleanup retry budget |
+| `GOLDEN_SNAPSHOT_MAX_CONCURRENT_BUILDS` | `2` | Durable running builder/validator cap; bounded to 1-10 |
+| `GOLDEN_SNAPSHOT_BUILD_LEASE_MS` | `300000` | Build/cleanup claim lease |
+| `GOLDEN_SNAPSHOT_PROVISIONING_LEASE_MS` | `600000` | Clone lease |
+| `GOLDEN_SNAPSHOT_RETENTION_LIMIT` | `20` | Ready-image target below provider quota |
+| `GOLDEN_SNAPSHOT_FRESHNESS_MAX_AGE_MS` | `604800000` | Maximum selectable snapshot age; stale images are retired |
+| `GOLDEN_SNAPSHOT_RECONCILIATION_BATCH_SIZE` | `25` | Per-cycle work cap |
+| `GOLDEN_SNAPSHOT_RECONCILIATION_INTERVAL_MS` | `15000` | Worker cadence; values outside 1,000-3,600,000 ms disable it |
+| `GOLDEN_SNAPSHOT_OPERATOR_SECRET` | none | Separate bearer credential for snapshot status, retry, revoke, inventory, and cleanup controls; never give it to release automation |
+
+Release automation uses `PLATFORM_SECRET` only for idempotent build enqueue. All
+snapshot status and destructive controls require `GOLDEN_SNAPSHOT_OPERATOR_SECRET`, so
+a compromised publication credential cannot revoke images or requeue cleanup. Terminal
+failed/quarantined cleanup can be retried on its existing exact-resource row through
+`POST /system-bundles/snapshot-cleanup/:cleanupId/retry`; the route never accepts a
+provider ID or provenance override.
+
+Candidate builds may be enabled only after gates 1-4 pass. Keep snapshot selection disabled through gate 5; a build row or even a `ready` image is not by itself approval to serve customer or recovery clones.
+
+## Authenticated Operations
+
+Snapshot control routes are mounted below `/system-bundles`. Release automation uses
+the platform/release bearer only to enqueue an eligible published bundle. Status,
+retry, revocation, inventory, and cleanup controls require the separate
+`GOLDEN_SNAPSHOT_OPERATOR_SECRET`; release automation must not receive it. The callback
+instead uses a short-lived, single-build, phase-bound bearer token whose hash is
+persisted and compared in constant time. Mutating routes have Hono body limits and
+strict Zod schemas. Responses contain lifecycle IDs/states and allowlisted failure
+codes only; raw provider responses are logged server-side and never returned.
+
+| Route | Authorization | Body limit | Purpose |
+|---|---|---:|---|
+| `POST /system-bundles/snapshot-builds` with production `testMode: false` | platform/release bearer | 8 KiB | Idempotently enqueue an eligible immutable published bundle |
+| `POST /system-bundles/snapshot-builds` with operator-only `testMode: true` | snapshot-operator bearer | 8 KiB | Enqueue a bounded disposable spike candidate without granting test-mode authority to release automation |
+| `GET /system-bundles/snapshot-builds/:buildId` | snapshot-operator bearer | none | Read coarse build phase/status |
+| `GET /system-bundles/snapshots?limit=N&cursor=opaque` | snapshot-operator bearer | none | List deterministic bounded lifecycle pages without provider IDs |
+| `POST /system-bundles/snapshot-builds/:buildId/retry` | snapshot-operator bearer | 1 KiB | Retry only a persisted safe `failed` build |
+| `POST /system-bundles/snapshots/:snapshotId/revoke` | snapshot-operator bearer | 4 KiB | Immediately quarantine one snapshot |
+| `GET /system-bundles/snapshots/:snapshotId/affected-machines?limit=N&cursor=opaque` | snapshot-operator bearer | none | Enumerate a deterministic bounded page for one exact source snapshot |
+| `POST /system-bundles/snapshot-base-generations/:baseGeneration/revoke` | snapshot-operator bearer | 4 KiB | Immediately persist the generation deny marker; bounded worker pages asynchronously quarantine snapshots and terminate builds |
+| `GET /system-bundles/snapshot-base-generations/:baseGeneration/affected-machines?limit=N&cursor=opaque` | snapshot-operator bearer | none | Enumerate a deterministic bounded page of retained machines; follow `nextCursor` until absent |
+| `POST /system-bundles/snapshot-cleanup/:cleanupId/retry` | snapshot-operator bearer | 1 KiB | Requeue one terminal exact-resource cleanup row within its bounded retry policy |
+| `POST /system-bundles/snapshot-builds/:buildId/callback` | short-lived phase callback bearer | 64 KiB | Accept bounded synthetic sanitation or validation evidence |
+
+The public release metadata includes only `snapshotStatus` (`not_requested`, `requested`, `building`, `ready`, `failed`, or `unavailable`). It never exposes image IDs or provider errors.
+
+## Retention, Revocation, and Cleanup
+
+Normal reconciliation retains the configured number of ready images. Retirement refuses to delete:
+
+- current channel versions
+- bounded recent rollback versions for each channel
+- images with an active provisioning/recovery lease
+- the newest and therefore sole guaranteed image for a compatibility key
+
+Freshness-expired images are no longer selectable and receive none of the channel, rollback, or sole-compatible protections above. Once their active leases end, bounded reconciliation moves them through ordinary guarded retirement.
+
+Quota-pressure selection aims one image below the configured limit and reports `blocked` when no safe deletion exists. It does not weaken protections. A revoked snapshot leaves selection immediately through an atomic state update. Generation revocation is deliberately two-stage: the route transaction first persists the durable deny marker, which immediately blocks enqueue, readiness, and selection for that generation; a bounded worker then quarantines matching rows, terminates builds, and reconciles exact provider resources asynchronously. A successful route response does not claim that this later containment work is complete. Existing leases remain recorded; release of the final lease atomically moves the image to retiring and queues high-priority exact-resource cleanup even when the bundle is still a current or rollback channel.
+
+Delete timeouts remain `running` or return to the bounded queue. A missing exact resource is accepted as completed. A resource whose labels or recorded provenance do not match is quarantined for operator review and is never deleted by guessing.
+
+Acceptable temporary orphan states are a labeled builder or validator after an ambiguous create, an available labeled image awaiting adoption, and a recorded cleanup item whose provider deletion is not yet observable. Unlabeled or mismatched resources are not adopted or deleted automatically.
+
+## Rollout Gates
+
+Production selection must remain disabled until all gates pass:
+
+1. Focused unit/integration suites, pattern checks, platform typecheck, and the known repository baseline are reviewed.
+2. A separately authorized disposable Hetzner project runs the spike in the spec quickstart.
+3. The spike records creation Action behavior, image readiness timing, clone compatibility across intended architecture/location/server types, cloud-init rerun behavior, and deletion convergence.
+4. A validation clone proves the full sanitation and exact activation contract.
+5. Builds run safely with selection still off; retention and cleanup remain bounded below quota.
+6. Selection starts at a small deterministic percentage for both new-customer provisioning and recovery; clean-image fallback metrics remain healthy for both flows.
+7. Expand the shared rollout percentage only after provisioning and recovery are both proven at the smaller cohort. V1 has no independent recovery selection switch.
+
+No live provider spike was run by this repository change because production provider resources require separate operator authorization. The implementation relies on official Hetzner API contracts for request shapes and fails closed where readiness or timeout recovery is ambiguous. Relevant references are the [Cloud API](https://docs.hetzner.cloud/reference/cloud), [snapshot overview](https://docs.hetzner.com/cloud/servers/backups-snapshots/overview/), [snapshot FAQ](https://docs.hetzner.com/cloud/servers/backups-snapshots/faq/), and [server FAQ](https://docs.hetzner.com/cloud/servers/faq/).
+
+## Disablement, Rollback, and Incidents
+
+For immediate rollback, use the operator-authenticated `PUT /system-bundles/snapshot-rollout` control with the active compatibility key, `enabled: false`, and `percentage: 0`. The transaction increments the rollout fence and denies overlapping uncompleted snapshot-create intents. New provisioning and recovery then use clean Ubuntu; existing VPSes and host-bundle deployment remain unchanged. Set `GOLDEN_SNAPSHOT_BUILDS_ENABLED=false` separately to stop new candidates while allowing already-ready images to remain recorded. Changing only the bootstrap environment values after the rollout row exists does not override durable operator state.
+
+Incident classification:
+
+- **Build or sanitation failure:** quarantine the candidate, clean exact labeled resources, keep publication and fleet deploy green.
+- **Validation failure:** never select the image; revoke/retire it after evidence capture.
+- **Clone definite rejection:** record coarse fallback and use clean Ubuntu.
+- **Clone ambiguous result:** reconcile labels; do not create again.
+- **Registration timeout:** keep the replacement unroutable, mark it failed, queue exact cleanup, and retry recovery explicitly; revoke or disable snapshot selection first when clean Ubuntu is required.
+- **Identity or secret evidence:** disable selection immediately, revoke the snapshot and base generation, preserve public-safe evidence, and follow the private security incident process.
+- **Quota pressure:** run protected retention; if blocked, stop builds and escalate instead of deleting protected images.
+- **Provider disappearance/delete timeout:** preserve the DB record and reconcile until absence or exact deletion is proven.
+
+Repository documentation must remain public-safe. Customer identifiers, IP addresses, provider tokens, resource IDs tied to incidents, and private dashboards belong in the private operator system. A separate PR is required for the private operator/site runbook, and the canonical public docs require a separate PR in `FinnaAI/matrix-os-site`; neither is part of this repository stack.

--- a/docs/dev/releases.md
+++ b/docs/dev/releases.md
@@ -33,6 +33,7 @@ that image.
 - Host-bundle updates must never overwrite owner data. Do not delete or replace `/home/matrix/home`, `/opt/matrix/env`, or the local Postgres data directory during deploys or rollbacks.
 - `pnpm-workspace.yaml` sets `minimumReleaseAge: 10080` and CI/release paths use `pnpm install --frozen-lockfile`; do not bypass either during releases.
 - Host bundle release validation is blocking. If typecheck, tests, public build-env validation, build, publish, or registration fails, do not publish or deploy the bundle.
+- Eligible main/tag releases request a golden snapshot build after publication. This request is an optional acceleration path: enqueue/build failure does not block publication or the unchanged existing-fleet deploy job. See [Golden VPS Snapshots](golden-vps-snapshots.md).
 - CLI releases are manual through `.github/workflows/release.yml`; bump `packages/sync-client/package.json`, run the sync-client checks, and dispatch the workflow with the same semver.
 - Fleet upgrade operations, blocked-machine handling, and the durable control-plane setup are documented in [Fleet Upgrade Operations](fleet-upgrade-operations.md).
 - Staging platform containers and disposable feature VPSes are temporary test

--- a/docs/dev/vps-deployment.md
+++ b/docs/dev/vps-deployment.md
@@ -55,6 +55,8 @@ system-bundles/<CUSTOMER_VPS_IMAGE_VERSION>/matrix-host-bundle.tar.gz.sha256
 
 The per-user Docker image path is legacy/local-development only. It is not used for production customer VPSes.
 
+New customer and recovery creation may optionally use a validated golden VPS snapshot as a fail-closed acceleration layer. It never replaces the immutable host-bundle source of truth, owner backup flow, or clean Ubuntu fallback. See [Golden VPS Snapshots](golden-vps-snapshots.md) for lifecycle, sanitation, rollout gates, and disablement.
+
 ### Archived Legacy Shared-Container Mode
 
 This section is historical context for old deployments only. Do not use it for new production work.
@@ -229,6 +231,7 @@ Root `matrix-os.com` stays pointed at Vercel. The `app` and `code` subdomains ha
 cat > /root/matrix-os/.env << 'EOF'
 ANTHROPIC_API_KEY=sk-ant-...
 PLATFORM_SECRET=your-random-secret
+GOLDEN_SNAPSHOT_OPERATOR_SECRET=your-separate-random-secret
 CLERK_SECRET_KEY=sk_live_...
 NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=pk_live_...
 GEMINI_API_KEY=your-gemini-api-key
@@ -240,6 +243,7 @@ EOF
 |----------|-----------|---------------|-------------|
 | `ANTHROPIC_API_KEY` | platform/proxy | runtime | Shared Anthropic API key for routed AI calls |
 | `PLATFORM_SECRET` | platform | runtime | Bearer token for admin API auth |
+| `GOLDEN_SNAPSHOT_OPERATOR_SECRET` | platform | runtime | Required when `CUSTOMER_VPS_ENABLED=true`; distinct bearer token for snapshot status, retry, revocation, inventory, and cleanup controls |
 | `CLERK_SECRET_KEY` | platform | runtime | Server-side Clerk JWT verification |
 | `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY` | host bundle | **build time** | Baked into Next.js bundle (NEXT_PUBLIC_ prefix) |
 | `GEMINI_API_KEY` | platform/gateway when configured | runtime | Google Gemini API key for image/icon generation |
@@ -250,6 +254,16 @@ EOF
 | `S3_BUCKET` / `R2_BUCKET` | customer VPS gateway/sync | runtime | R2 bucket name, default `matrixos-sync` |
 | `MATRIX_HOME_MIRROR` | customer VPS gateway/sync | runtime | `true` enables three-way sync (VPS home ↔ R2 ↔ peer) |
 | `PLATFORM_INTERNAL_URL` | customer VPS gateway | runtime | Base URL for platform-owned internal APIs; customer VPSes use it with their per-host token for sync and integrations |
+
+Generate the two platform bearer credentials independently and store both in the
+deployment secret manager. Never reuse one value for the other; customer-VPS platform
+startup rejects a missing, short, or shared snapshot operator credential even while
+snapshot builds and selection are disabled.
+
+```bash
+PLATFORM_SECRET=$(openssl rand -hex 32)
+GOLDEN_SNAPSHOT_OPERATOR_SECRET=$(openssl rand -hex 32)
+```
 
 **Build-time vs runtime**: `NEXT_PUBLIC_*` vars are embedded into the Next.js JavaScript bundle during `next build`. They must be available when building the customer host bundle. Runtime vars for customer VPSes live in `/opt/matrix/env/host.env`, `/opt/matrix/env/r2.env`, and host systemd environment files.
 

--- a/packages/platform/src/golden-snapshot-repository.ts
+++ b/packages/platform/src/golden-snapshot-repository.ts
@@ -36,6 +36,75 @@ const RetirementPolicySchema = z.object({
   rollbackVersionsPerChannel: z.number().int().min(0).max(20).default(2),
   freshnessMaxAgeMs: z.number().int().min(60_000).max(365 * 24 * 60 * 60 * 1000).optional(),
 }).strict();
+const GoldenSnapshotOperationalCursorSchema = z.object({
+  createdAt: IsoDateSchema,
+  snapshotId: UuidSchema,
+}).strict();
+const OperationalStatusPageInputSchema = z.object({
+  limit: z.number().int().min(1).max(100),
+  cursor: GoldenSnapshotOperationalCursorSchema.optional(),
+}).strict();
+const AffectedMachineCursorSchema = z.object({
+  machineId: UuidSchema,
+}).strict();
+const AffectedMachinePageInputSchema = z.object({
+  limit: z.number().int().min(1).max(100),
+  cursor: AffectedMachineCursorSchema.optional(),
+}).strict();
+
+export type GoldenSnapshotOperationalCursor = z.infer<typeof GoldenSnapshotOperationalCursorSchema>;
+export type GoldenSnapshotAffectedMachineCursor = z.infer<typeof AffectedMachineCursorSchema>;
+
+export interface GoldenSnapshotAffectedMachine {
+  machineId: string;
+  runtimeSlot: string;
+  sourceSnapshotId: string;
+  targetBundleVersion: string;
+  status: string;
+  updatedAt: string;
+}
+
+export function encodeGoldenSnapshotOperationalCursor(rawCursor: GoldenSnapshotOperationalCursor): string {
+  const cursor = GoldenSnapshotOperationalCursorSchema.parse(rawCursor);
+  return Buffer.from(JSON.stringify(cursor), 'utf8').toString('base64url');
+}
+
+export function decodeGoldenSnapshotOperationalCursor(rawCursor: string): GoldenSnapshotOperationalCursor {
+  const cursor = z.string().min(16).max(512).regex(/^[A-Za-z0-9_-]+$/).parse(rawCursor);
+  const decoded = Buffer.from(cursor, 'base64url').toString('utf8');
+  if (Buffer.byteLength(decoded, 'utf8') > 256) throw new Error('Invalid snapshot status cursor');
+  try {
+    return GoldenSnapshotOperationalCursorSchema.parse(JSON.parse(decoded));
+  } catch (err: unknown) {
+    if (err instanceof SyntaxError || err instanceof z.ZodError) {
+      throw new Error('Invalid snapshot status cursor');
+    }
+    throw err;
+  }
+}
+
+export function encodeGoldenSnapshotAffectedMachineCursor(
+  rawCursor: GoldenSnapshotAffectedMachineCursor,
+): string {
+  const cursor = AffectedMachineCursorSchema.parse(rawCursor);
+  return Buffer.from(JSON.stringify(cursor), 'utf8').toString('base64url');
+}
+
+export function decodeGoldenSnapshotAffectedMachineCursor(
+  rawCursor: string,
+): GoldenSnapshotAffectedMachineCursor {
+  const cursor = z.string().min(16).max(512).regex(/^[A-Za-z0-9_-]+$/).parse(rawCursor);
+  const decoded = Buffer.from(cursor, 'base64url').toString('utf8');
+  if (Buffer.byteLength(decoded, 'utf8') > 256) throw new Error('Invalid affected-machine cursor');
+  try {
+    return AffectedMachineCursorSchema.parse(JSON.parse(decoded));
+  } catch (err: unknown) {
+    if (err instanceof SyntaxError || err instanceof z.ZodError) {
+      throw new Error('Invalid affected-machine cursor');
+    }
+    throw err;
+  }
+}
 
 const SnapshotRowSchema = z.object({
   snapshot_id: UuidSchema,
@@ -1838,6 +1907,117 @@ export async function revokeGoldenSnapshotBaseGeneration(
   });
 }
 
+export async function listRevokedGoldenSnapshotBaseGenerations(
+  db: PlatformDB,
+  rawLimit = 25,
+): Promise<string[]> {
+  const limit = z.number().int().min(1).max(100).parse(rawLimit);
+  await db.ready;
+  const rows = await db.executor.selectFrom('golden_snapshot_revoked_base_generations')
+    .select('base_generation')
+    .where(({ exists, selectFrom }) => exists(
+      selectFrom('golden_snapshots').select('snapshot_id')
+        .whereRef(
+          'golden_snapshots.base_generation',
+          '=',
+          'golden_snapshot_revoked_base_generations.base_generation',
+        )
+        .where('golden_snapshots.state', 'in', [
+          'candidate', 'building', 'sanitizing', 'validating', 'ready', 'failed',
+        ]),
+    ))
+    .orderBy('updated_at')
+    .orderBy('base_generation')
+    .limit(limit)
+    .execute();
+  return rows.map((row) => GoldenSnapshotBaseGenerationSchema.parse(row.base_generation));
+}
+
+async function listGoldenSnapshotAffectedMachinesForScope(
+  db: PlatformDB,
+  scope: { baseGeneration: string } | { snapshotId: string },
+  input: z.infer<typeof AffectedMachinePageInputSchema>,
+): Promise<{
+  machines: GoldenSnapshotAffectedMachine[];
+  nextCursor?: GoldenSnapshotAffectedMachineCursor;
+}> {
+  // user_machines.provisioned_at is TEXT NOT NULL. Coalescing each optional
+  // activity timestamp to that durable floor keeps GREATEST non-null while
+  // still selecting the newest lifecycle timestamp.
+  const updatedAt = sql<string>`GREATEST(
+    COALESCE(last_seen_at, provisioned_at),
+    COALESCE(failure_at, provisioned_at),
+    COALESCE(resize_started_at, provisioned_at)
+  )`;
+  await db.ready;
+  let query = db.executor.selectFrom('user_machines').select([
+    'machine_id', 'runtime_slot', 'source_snapshot_id', 'target_bundle_version', 'status',
+    updatedAt.as('provenance_updated_at'),
+  ])
+    .where('source_snapshot_id', 'is not', null)
+    .where('target_bundle_version', 'is not', null)
+    .where('deleted_at', 'is', null)
+    .where('status', 'in', ['running', 'recovering', 'resizing']);
+  query = 'baseGeneration' in scope
+    ? query.where('source_base_generation', '=', scope.baseGeneration)
+    : query.where('source_snapshot_id', '=', scope.snapshotId);
+  if (input.cursor) {
+    query = query.where('machine_id', '>', input.cursor.machineId);
+  }
+  const rows = await query.orderBy('machine_id').limit(input.limit + 1).execute();
+  const pageRows = rows.slice(0, input.limit);
+  const machines = pageRows.map((row): GoldenSnapshotAffectedMachine => {
+    if (!row.source_snapshot_id || !row.target_bundle_version) {
+      throw new Error('Affected machine provenance is incomplete');
+    }
+    return {
+      machineId: UuidSchema.parse(row.machine_id),
+      runtimeSlot: z.string().min(1).max(32).parse(row.runtime_slot),
+      sourceSnapshotId: UuidSchema.parse(row.source_snapshot_id),
+      targetBundleVersion: GoldenSnapshotBundleVersionSchema.parse(row.target_bundle_version),
+      status: z.enum(['running', 'recovering', 'resizing']).parse(row.status),
+      updatedAt: IsoDateSchema.parse(row.provenance_updated_at),
+    };
+  });
+  const last = machines.at(-1);
+  return {
+    machines,
+    ...(rows.length > input.limit && last ? {
+      nextCursor: { machineId: last.machineId },
+    } : {}),
+  };
+}
+
+export async function listGoldenSnapshotAffectedMachines(
+  db: PlatformDB,
+  rawBaseGeneration: string,
+  rawInput: z.input<typeof AffectedMachinePageInputSchema>,
+): Promise<{
+  machines: GoldenSnapshotAffectedMachine[];
+  nextCursor?: GoldenSnapshotAffectedMachineCursor;
+}> {
+  return listGoldenSnapshotAffectedMachinesForScope(
+    db,
+    { baseGeneration: GoldenSnapshotBaseGenerationSchema.parse(rawBaseGeneration) },
+    AffectedMachinePageInputSchema.parse(rawInput),
+  );
+}
+
+export async function listGoldenSnapshotAffectedMachinesBySnapshot(
+  db: PlatformDB,
+  rawSnapshotId: string,
+  rawInput: z.input<typeof AffectedMachinePageInputSchema>,
+): Promise<{
+  machines: GoldenSnapshotAffectedMachine[];
+  nextCursor?: GoldenSnapshotAffectedMachineCursor;
+}> {
+  return listGoldenSnapshotAffectedMachinesForScope(
+    db,
+    { snapshotId: UuidSchema.parse(rawSnapshotId) },
+    AffectedMachinePageInputSchema.parse(rawInput),
+  );
+}
+
 export async function reconcileRevokedGoldenSnapshotBaseGeneration(
   db: PlatformDB,
   rawBaseGeneration: string,
@@ -1866,6 +2046,10 @@ export async function reconcileRevokedGoldenSnapshotBaseGeneration(
       .where('state', 'in', ['candidate', 'building', 'sanitizing', 'validating', 'ready', 'failed'])
       .orderBy('snapshot_id').forUpdate().execute();
     if (snapshots.length === 0) return { processed: 0, hasMore };
+    await trx.executor.updateTable('golden_snapshot_revoked_base_generations')
+      .set({ updated_at: now })
+      .where('base_generation', '=', baseGeneration)
+      .execute();
     // Expired rows stay in this set until reconciliation proves the associated
     // provisioning/recovery workflow terminal and writes released_at.
     const snapshotsWithUnreleasedLeases = new Set((await trx.executor.selectFrom('golden_snapshot_leases')
@@ -2224,26 +2408,53 @@ export async function enforceGoldenSnapshotRetention(
 
 export async function listGoldenSnapshotOperationalStatus(
   db: PlatformDB,
-  rawLimit: number,
-): Promise<Array<{
+  rawInput: z.input<typeof OperationalStatusPageInputSchema>,
+): Promise<{
+  snapshots: Array<{
   snapshotId: string;
   bundleVersion: string;
   state: GoldenSnapshotState;
   failureCode: string | null;
   updatedAt: string;
-}>> {
-  const limit = z.number().int().min(1).max(100).parse(rawLimit);
+  }>;
+  nextCursor?: GoldenSnapshotOperationalCursor;
+}> {
+  const input = OperationalStatusPageInputSchema.parse(rawInput);
   await db.ready;
-  const rows = await db.executor.selectFrom('golden_snapshots').select([
-    'snapshot_id', 'bundle_version', 'state', 'failure_code', 'updated_at',
-  ]).orderBy('updated_at', 'desc').limit(limit).execute();
-  return rows.map((row) => ({
+  let query = db.executor.selectFrom('golden_snapshots').select([
+    'snapshot_id', 'bundle_version', 'state', 'failure_code', 'created_at', 'updated_at',
+  ]);
+  if (input.cursor) {
+    query = query.where((eb) => eb.or([
+      eb('created_at', '<', input.cursor!.createdAt),
+      eb.and([
+        eb('created_at', '=', input.cursor!.createdAt),
+        eb('snapshot_id', '<', input.cursor!.snapshotId),
+      ]),
+    ]));
+  }
+  const rows = await query.orderBy('created_at', 'desc').orderBy('snapshot_id', 'desc')
+    .limit(input.limit + 1).execute();
+  const pageRows = rows.slice(0, input.limit);
+  const snapshots = pageRows.map((row) => ({
     snapshotId: UuidSchema.parse(row.snapshot_id),
     bundleVersion: z.string().min(1).max(128).parse(row.bundle_version),
     state: GoldenSnapshotStateSchema.parse(row.state),
     failureCode: row.failure_code === null ? null : BoundedCodeSchema.parse(row.failure_code),
     updatedAt: IsoDateSchema.parse(row.updated_at),
   }));
+  const last = pageRows.at(-1);
+  return {
+    snapshots,
+    ...(rows.length > input.limit && last
+      ? {
+          nextCursor: {
+            createdAt: IsoDateSchema.parse(last.created_at),
+            snapshotId: UuidSchema.parse(last.snapshot_id),
+          },
+        }
+      : {}),
+  };
 }
 
 export async function retryGoldenSnapshotBuild(

--- a/packages/platform/src/golden-snapshot-routes.ts
+++ b/packages/platform/src/golden-snapshot-routes.ts
@@ -7,14 +7,26 @@ import { bearerTokenMatches } from './customer-vps-auth.js';
 import {
   enqueueGoldenSnapshotBuild,
   GoldenSnapshotBuildRequiresRetryError,
+  decodeGoldenSnapshotAffectedMachineCursor,
+  decodeGoldenSnapshotOperationalCursor,
+  encodeGoldenSnapshotAffectedMachineCursor,
+  encodeGoldenSnapshotOperationalCursor,
   getGoldenSnapshot,
   getGoldenSnapshotBuild,
+  listGoldenSnapshotAffectedMachines,
+  listGoldenSnapshotAffectedMachinesBySnapshot,
   listGoldenSnapshotOperationalStatus,
+  retryGoldenSnapshotCleanup,
   retryGoldenSnapshotBuild,
   revokeGoldenSnapshot,
+  revokeGoldenSnapshotBaseGeneration,
+  updateGoldenSnapshotRolloutControl,
 } from './golden-snapshot-repository.js';
 import type { GoldenSnapshotRuntimeConfig } from './golden-snapshot-schema.js';
-import { GoldenSnapshotBundleVersionSchema } from './golden-snapshot-schema.js';
+import {
+  GoldenSnapshotBaseGenerationSchema,
+  GoldenSnapshotBundleVersionSchema,
+} from './golden-snapshot-schema.js';
 import {
   GoldenSnapshotCallbackSchema,
   GoldenSnapshotCallbackError,
@@ -25,13 +37,50 @@ const SNAPSHOT_ENQUEUE_BODY_LIMIT = 8 * 1024;
 const SNAPSHOT_CALLBACK_BODY_LIMIT = 64 * 1024;
 const SNAPSHOT_RETRY_BODY_LIMIT = 1024;
 const SNAPSHOT_REVOKE_BODY_LIMIT = 4 * 1024;
+const SNAPSHOT_ROLLOUT_BODY_LIMIT = 4 * 1024;
 const BuildIdSchema = z.string().uuid();
 const SnapshotIdSchema = z.string().uuid();
-const StatusQuerySchema = z.coerce.number().int().min(1).max(100).default(25);
+const CleanupIdSchema = z.string().uuid();
+const StatusCursorSchema = z.string().min(16).max(512).regex(/^[A-Za-z0-9_-]+$/).transform((value, ctx) => {
+  try {
+    return decodeGoldenSnapshotOperationalCursor(value);
+  } catch (err: unknown) {
+    if (err instanceof Error) {
+      ctx.addIssue({ code: 'custom', message: 'Invalid cursor' });
+      return z.NEVER;
+    }
+    throw err;
+  }
+});
+const StatusQuerySchema = z.object({
+  limit: z.coerce.number().int().min(1).max(100).default(25),
+  cursor: StatusCursorSchema.optional(),
+}).strict();
+const AffectedMachineCursorParamSchema = z.string().min(16).max(512)
+  .regex(/^[A-Za-z0-9_-]+$/).transform((value, ctx) => {
+    try {
+      return decodeGoldenSnapshotAffectedMachineCursor(value);
+    } catch (err: unknown) {
+      if (err instanceof Error) {
+        ctx.addIssue({ code: 'custom', message: 'Invalid cursor' });
+        return z.NEVER;
+      }
+      throw err;
+    }
+  });
+const AffectedMachineQuerySchema = z.object({
+  limit: z.coerce.number().int().min(1).max(100).default(25),
+  cursor: AffectedMachineCursorParamSchema.optional(),
+}).strict();
 const RevokeSchema = z.object({ reason: z.string().min(1).max(128).regex(/^[a-z0-9][a-z0-9._-]*$/) }).strict();
 const EnqueueSchema = z.object({
   bundleVersion: GoldenSnapshotBundleVersionSchema,
   testMode: z.boolean().optional().default(false),
+}).strict();
+const RolloutMutationSchema = z.object({
+  compatibilityKey: z.string().regex(/^[a-f0-9]{64}$/),
+  enabled: z.boolean(),
+  percentage: z.number().int().min(0).max(100),
 }).strict();
 
 export interface GoldenSnapshotRoutesDeps {
@@ -131,13 +180,41 @@ export function createGoldenSnapshotRoutes(deps: GoldenSnapshotRoutesDeps): Hono
   routes.get('/snapshots', async (c) => {
     const authError = requireBearerAuth(c, deps.operatorSecret);
     if (authError) return authError;
-    const limit = StatusQuerySchema.safeParse(c.req.query('limit'));
-    if (!limit.success) return c.json({ error: 'Invalid request' }, 400);
+    const query = StatusQuerySchema.safeParse({
+      limit: c.req.query('limit'),
+      cursor: c.req.query('cursor'),
+    });
+    if (!query.success) return c.json({ error: 'Invalid request' }, 400);
     try {
-      return c.json({ snapshots: await listGoldenSnapshotOperationalStatus(deps.db, limit.data) });
+      const page = await listGoldenSnapshotOperationalStatus(deps.db, query.data);
+      return c.json({
+        snapshots: page.snapshots,
+        ...(page.nextCursor ? { nextCursor: encodeGoldenSnapshotOperationalCursor(page.nextCursor) } : {}),
+      });
     } catch (err: unknown) {
       console.error(`[golden-snapshot] status failed: ${err instanceof Error ? err.name : typeof err}`);
       return c.json({ error: 'Snapshot status unavailable' }, 500);
+    }
+  });
+
+  routes.put('/snapshot-rollout', bodyLimit({ maxSize: SNAPSHOT_ROLLOUT_BODY_LIMIT }), async (c) => {
+    const authError = requireBearerAuth(c, deps.operatorSecret);
+    if (authError) return authError;
+    const body = RolloutMutationSchema.safeParse(await readJson(c));
+    if (!body.success) return c.json({ error: 'Invalid request' }, 400);
+    try {
+      const updated = await updateGoldenSnapshotRolloutControl(deps.db, {
+        ...body.data,
+        now: now(),
+      });
+      return c.json({
+        updated: true,
+        enabled: updated.enabled,
+        percentage: updated.percentage,
+      });
+    } catch (err: unknown) {
+      console.error(`[golden-snapshot] rollout mutation failed: ${err instanceof Error ? err.name : typeof err}`);
+      return c.json({ error: 'Snapshot rollout unavailable' }, 500);
     }
   });
 
@@ -165,6 +242,89 @@ export function createGoldenSnapshotRoutes(deps: GoldenSnapshotRoutesDeps): Hono
     } catch (err: unknown) {
       console.error(`[golden-snapshot] revocation failed: ${err instanceof Error ? err.name : typeof err}`);
       return c.json({ error: 'Snapshot revocation unavailable' }, 500);
+    }
+  });
+
+  routes.post(
+    '/snapshot-base-generations/:baseGeneration/revoke',
+    bodyLimit({ maxSize: SNAPSHOT_REVOKE_BODY_LIMIT }),
+    async (c) => {
+      const authError = requireBearerAuth(c, deps.operatorSecret);
+      if (authError) return authError;
+      const baseGeneration = GoldenSnapshotBaseGenerationSchema.safeParse(c.req.param('baseGeneration'));
+      const body = RevokeSchema.safeParse(await readJson(c));
+      if (!baseGeneration.success || !body.success) return c.json({ error: 'Invalid request' }, 400);
+      try {
+        await revokeGoldenSnapshotBaseGeneration(
+          deps.db,
+          baseGeneration.data,
+          body.data.reason,
+          now(),
+        );
+        return c.json({ revoked: true });
+      } catch (err: unknown) {
+        console.error(`[golden-snapshot] base generation revocation failed: ${err instanceof Error ? err.name : typeof err}`);
+        return c.json({ error: 'Snapshot revocation unavailable' }, 500);
+      }
+    },
+  );
+
+  routes.get('/snapshot-base-generations/:baseGeneration/affected-machines', async (c) => {
+    const authError = requireBearerAuth(c, deps.operatorSecret);
+    if (authError) return authError;
+    const baseGeneration = GoldenSnapshotBaseGenerationSchema.safeParse(c.req.param('baseGeneration'));
+    const query = AffectedMachineQuerySchema.safeParse({
+      limit: c.req.query('limit'),
+      cursor: c.req.query('cursor'),
+    });
+    if (!baseGeneration.success || !query.success) return c.json({ error: 'Invalid request' }, 400);
+    try {
+      const page = await listGoldenSnapshotAffectedMachines(deps.db, baseGeneration.data, query.data);
+      return c.json({
+        machines: page.machines,
+        ...(page.nextCursor ? {
+          nextCursor: encodeGoldenSnapshotAffectedMachineCursor(page.nextCursor),
+        } : {}),
+      });
+    } catch (err: unknown) {
+      console.error(`[golden-snapshot] affected machines failed: ${err instanceof Error ? err.name : typeof err}`);
+      return c.json({ error: 'Affected machine inventory unavailable' }, 500);
+    }
+  });
+
+  routes.get('/snapshots/:snapshotId/affected-machines', async (c) => {
+    const authError = requireBearerAuth(c, deps.operatorSecret);
+    if (authError) return authError;
+    const snapshotId = SnapshotIdSchema.safeParse(c.req.param('snapshotId'));
+    const query = AffectedMachineQuerySchema.safeParse({
+      limit: c.req.query('limit'),
+      cursor: c.req.query('cursor'),
+    });
+    if (!snapshotId.success || !query.success) return c.json({ error: 'Invalid request' }, 400);
+    try {
+      const page = await listGoldenSnapshotAffectedMachinesBySnapshot(deps.db, snapshotId.data, query.data);
+      return c.json({
+        machines: page.machines,
+        ...(page.nextCursor ? {
+          nextCursor: encodeGoldenSnapshotAffectedMachineCursor(page.nextCursor),
+        } : {}),
+      });
+    } catch (err: unknown) {
+      console.error(`[golden-snapshot] snapshot affected machines failed: ${err instanceof Error ? err.name : typeof err}`);
+      return c.json({ error: 'Affected machine inventory unavailable' }, 500);
+    }
+  });
+
+  routes.post('/snapshot-cleanup/:cleanupId/retry', bodyLimit({ maxSize: SNAPSHOT_RETRY_BODY_LIMIT }), async (c) => {
+    const authError = requireBearerAuth(c, deps.operatorSecret);
+    if (authError) return authError;
+    const cleanupId = CleanupIdSchema.safeParse(c.req.param('cleanupId'));
+    if (!cleanupId.success) return c.json({ error: 'Invalid request' }, 400);
+    try {
+      return c.json({ retried: await retryGoldenSnapshotCleanup(deps.db, cleanupId.data, now()) });
+    } catch (err: unknown) {
+      console.error(`[golden-snapshot] cleanup retry failed: ${err instanceof Error ? err.name : typeof err}`);
+      return c.json({ error: 'Snapshot cleanup retry unavailable' }, 500);
     }
   });
 

--- a/packages/platform/src/main.ts
+++ b/packages/platform/src/main.ts
@@ -330,6 +330,13 @@ export function createApp(deps: {
   const legacyContainerRoutingEnabled =
     appEnv.MATRIX_LEGACY_CONTAINER_ROUTING_ENABLED === 'true' && !deps.customerVpsService;
   const platformSecret = deps.platformSecret ?? appEnv.PLATFORM_SECRET ?? '';
+  const goldenSnapshotOperatorSecret = appEnv.GOLDEN_SNAPSHOT_OPERATOR_SECRET ?? '';
+  if (deps.goldenSnapshotService && deps.goldenSnapshotConfig
+    && (goldenSnapshotOperatorSecret.length < 16
+      || platformSecret.length < 16
+      || goldenSnapshotOperatorSecret === platformSecret)) {
+    throw new Error('Golden snapshot control-plane credentials are misconfigured');
+  }
   const allowHostBundleSyncStoreFallback = appEnv.CUSTOMER_VPS_ENABLED !== 'true';
   const app = new Hono<{
     Variables: {
@@ -453,7 +460,7 @@ export function createApp(deps: {
       service: deps.goldenSnapshotService,
       config: deps.goldenSnapshotConfig,
       platformSecret,
-      operatorSecret: appEnv.GOLDEN_SNAPSHOT_OPERATOR_SECRET ?? '',
+      operatorSecret: goldenSnapshotOperatorSecret,
     }));
   }
   app.route('/system-bundles', createHostBundleRoutes({

--- a/packages/platform/src/platform-startup.ts
+++ b/packages/platform/src/platform-startup.ts
@@ -481,8 +481,10 @@ export async function startPlatformServer(opts: StartPlatformServerOptions): Pro
           listCallbackWaitGoldenSnapshotBuildIds,
           enforceGoldenSnapshotRetention,
           listPendingGoldenSnapshotCleanup,
+          listRevokedGoldenSnapshotBaseGenerations,
           listRunnableGoldenSnapshotBuildIds,
           listUnresolvedGoldenSnapshotBuildIds,
+          reconcileRevokedGoldenSnapshotBaseGeneration,
         },
         { reconcileMissingGoldenSnapshotBuilds },
       ] = await Promise.all([
@@ -510,6 +512,21 @@ export async function startPlatformServer(opts: StartPlatformServerOptions): Pro
           try {
             const workerNow = new Date().toISOString();
             let quotaPressure = false;
+            let revocationBudget = goldenSnapshotConfig.reconciliationBatchSize;
+            const revokedBaseGenerations = await listRevokedGoldenSnapshotBaseGenerations(
+              db, goldenSnapshotConfig.reconciliationBatchSize,
+            );
+            for (const baseGeneration of revokedBaseGenerations) {
+              if (revocationBudget <= 0) break;
+              try {
+                const reconciled = await reconcileRevokedGoldenSnapshotBaseGeneration(
+                  db, baseGeneration, workerNow, revocationBudget,
+                );
+                revocationBudget -= reconciled.processed;
+              } catch (err: unknown) {
+                console.error(`[golden-snapshot] revoked generation reconciliation failed: ${err instanceof Error ? err.name : typeof err}`);
+              }
+            }
             if (goldenSnapshotConfig.buildsEnabled) {
               try {
                 await reconcileMissingGoldenSnapshotBuilds(db, {

--- a/tests/platform/golden-snapshot-routes.test.ts
+++ b/tests/platform/golden-snapshot-routes.test.ts
@@ -1,10 +1,13 @@
 import { randomUUID } from 'node:crypto';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { upsertHostBundleRelease, type PlatformDB } from '../../packages/platform/src/db.js';
+import { readFile } from 'node:fs/promises';
+import { insertUserMachine, upsertHostBundleRelease, type PlatformDB } from '../../packages/platform/src/db.js';
 import { createGoldenSnapshotRoutes } from '../../packages/platform/src/golden-snapshot-routes.js';
 import { GoldenSnapshotCallbackError } from '../../packages/platform/src/golden-snapshot-service.js';
 import { createApp as createPlatformApp } from '../../packages/platform/src/main.js';
 import type { GoldenSnapshotRuntimeConfig } from '../../packages/platform/src/golden-snapshot-schema.js';
+import { compatibilityKey } from '../../packages/platform/src/golden-snapshot-schema.js';
+import { getGoldenSnapshotRolloutControl } from '../../packages/platform/src/golden-snapshot-repository.js';
 import { createTestPlatformDb, destroyTestPlatformDb } from './platform-db-test-helper.js';
 
 const config: GoldenSnapshotRuntimeConfig = {
@@ -22,6 +25,13 @@ const config: GoldenSnapshotRuntimeConfig = {
 };
 
 describe('golden snapshot control-plane routes', () => {
+  it('fails startup when release and operator credentials are empty, short, or identical', async () => {
+    const source = await readFile('packages/platform/src/main.ts', 'utf8');
+    expect(source).toContain('goldenSnapshotOperatorSecret.length < 16');
+    expect(source).toContain('platformSecret.length < 16');
+    expect(source).toContain('goldenSnapshotOperatorSecret === platformSecret');
+    expect(source).toContain('Golden snapshot control-plane credentials are misconfigured');
+  });
   let db: PlatformDB;
   let ids: string[];
   const service = {
@@ -78,6 +88,24 @@ describe('golden snapshot control-plane routes', () => {
       .executeTakeFirst()).toEqual({ test_mode: true });
   });
 
+  it('separates release enqueue credentials from operator controls', async () => {
+    const operatorEnqueue = await app().request('/snapshot-builds', {
+      method: 'POST',
+      headers: { authorization: 'Bearer operator-secret', 'content-type': 'application/json' },
+      body: JSON.stringify({ bundleVersion: 'v1' }),
+    });
+    expect(operatorEnqueue.status).toBe(401);
+
+    const releaseStatus = await app().request('/snapshots', {
+      headers: { authorization: 'Bearer platform-secret' },
+    });
+    expect(releaseStatus.status).toBe(401);
+    const operatorStatus = await app().request('/snapshots', {
+      headers: { authorization: 'Bearer operator-secret' },
+    });
+    expect(operatorStatus.status).toBe(200);
+  });
+
   it('rejects terminal build reuse until an explicit retry resets it', async () => {
     const request = () => app().request('/snapshot-builds', {
       method: 'POST', headers: { authorization: 'Bearer platform-secret', 'content-type': 'application/json' },
@@ -124,7 +152,7 @@ describe('golden snapshot control-plane routes', () => {
     const platformApp = createPlatformApp({
       db,
       orchestrator: {} as never,
-      platformSecret: 'platform-secret',
+      platformSecret: 'injected-platform-secret',
       goldenSnapshotService: service as never,
       goldenSnapshotConfig: config,
       env: { GOLDEN_SNAPSHOT_OPERATOR_SECRET: 'injected-operator-secret' },
@@ -148,6 +176,35 @@ describe('golden snapshot control-plane routes', () => {
     expect((await app().request('/snapshots', {
       headers: { authorization: 'Bearer operator-secret' },
     })).status).toBe(200);
+  });
+
+  it('mutates durable rollout authority with bounded operator-only input', async () => {
+    const key = compatibilityKey(config.compatibility);
+    const body = JSON.stringify({ compatibilityKey: key, enabled: true, percentage: 10 });
+    expect((await app().request('/snapshot-rollout', {
+      method: 'PUT', headers: { authorization: 'Bearer platform-secret', 'content-type': 'application/json' }, body,
+    })).status).toBe(401);
+
+    const updated = await app().request('/snapshot-rollout', {
+      method: 'PUT', headers: { authorization: 'Bearer operator-secret', 'content-type': 'application/json' }, body,
+    });
+    expect(updated.status).toBe(200);
+    expect(await updated.json()).toEqual({ updated: true, enabled: true, percentage: 10 });
+    await expect(getGoldenSnapshotRolloutControl(db, key))
+      .resolves.toMatchObject({ enabled: true, percentage: 10, generation: 1 });
+
+    const oversized = JSON.stringify({
+      compatibilityKey: key, enabled: false, percentage: 0, padding: 'x'.repeat(5_000),
+    });
+    expect((await app().request('/snapshot-rollout', {
+      method: 'PUT',
+      headers: {
+        authorization: 'Bearer operator-secret',
+        'content-type': 'application/json',
+        'content-length': String(Buffer.byteLength(oversized)),
+      },
+      body: oversized,
+    })).status).toBe(413);
   });
 
   it('passes phase tokens to the service and returns only generic callback errors', async () => {
@@ -255,6 +312,12 @@ describe('golden snapshot control-plane routes', () => {
       { method: 'POST', headers, body: JSON.stringify({ reason: 'unsafe', padding: 'x'.repeat(5_000) }) },
     );
     expect(revoke.status).toBe(413);
+
+    const generationRevoke = await app().request(
+      '/snapshot-base-generations/ubuntu-24.04-v1/revoke',
+      { method: 'POST', headers, body: JSON.stringify({ reason: 'unsafe', padding: 'x'.repeat(5_000) }) },
+    );
+    expect(generationRevoke.status).toBe(413);
   });
 
   it('provides authenticated bounded status and immediate revocation controls without provider details', async () => {
@@ -280,6 +343,55 @@ describe('golden snapshot control-plane routes', () => {
     expect(await revoked.json()).toEqual({ revoked: true });
   });
 
+  it('paginates operational status with a bounded opaque cursor', async () => {
+    for (const [version, digit] of [['v2', '2'], ['v3', '3']] as const) {
+      await upsertHostBundleRelease(db, {
+        version, gitCommit: digit.repeat(7), buildTime: `2026-07-0${digit}T00:00:00.000Z`,
+        bundleKey: `system-bundles/${version}/matrix-host-bundle.tar.gz`, checksumKey: null,
+        sha256: digit.repeat(64), size: 100, createdAt: `2026-07-0${digit}T00:00:00.000Z`,
+      });
+    }
+    const routes = app();
+    for (const version of ['v1', 'v2', 'v3']) {
+      const response = await routes.request('/snapshot-builds', {
+        method: 'POST',
+        headers: { authorization: 'Bearer platform-secret', 'content-type': 'application/json' },
+        body: JSON.stringify({ bundleVersion: version }),
+      });
+      expect(response.status).toBe(202);
+    }
+
+    const first = await routes.request('/snapshots?limit=2', {
+      headers: { authorization: 'Bearer operator-secret' },
+    });
+    expect(first.status).toBe(200);
+    const firstPage = await first.json() as { snapshots: Array<{ snapshotId: string }>; nextCursor?: string };
+    expect(firstPage.snapshots).toHaveLength(2);
+    expect(firstPage.nextCursor).toMatch(/^[A-Za-z0-9_-]{16,512}$/);
+
+    const listedSnapshotIds = firstPage.snapshots.map((row) => row.snapshotId);
+    const unseenSnapshot = await db.executor.selectFrom('golden_snapshots').select('snapshot_id')
+      .where('snapshot_id', 'not in', listedSnapshotIds).executeTakeFirstOrThrow();
+    await db.executor.updateTable('golden_snapshots')
+      .set({ updated_at: '2026-07-04T00:00:00.000Z' })
+      .where('snapshot_id', '=', unseenSnapshot.snapshot_id).execute();
+
+    const second = await routes.request(`/snapshots?limit=2&cursor=${firstPage.nextCursor}`, {
+      headers: { authorization: 'Bearer operator-secret' },
+    });
+    expect(second.status).toBe(200);
+    const secondPage = await second.json() as { snapshots: Array<{ snapshotId: string }>; nextCursor?: string };
+    expect(secondPage.snapshots).toHaveLength(1);
+    expect(secondPage.nextCursor).toBeUndefined();
+    expect(secondPage.snapshots[0]?.snapshotId).toBe(unseenSnapshot.snapshot_id);
+    expect(new Set([...firstPage.snapshots, ...secondPage.snapshots].map((row) => row.snapshotId)).size).toBe(3);
+
+    const invalid = await routes.request('/snapshots?limit=2&cursor=not-a-real-cursor', {
+      headers: { authorization: 'Bearer operator-secret' },
+    });
+    expect(invalid.status).toBe(400);
+  });
+
   it('retries only a persisted failed build through the authenticated bounded control', async () => {
     const enqueue = await app().request('/snapshot-builds', {
       method: 'POST', headers: { authorization: 'Bearer platform-secret', 'content-type': 'application/json' },
@@ -300,6 +412,127 @@ describe('golden snapshot control-plane routes', () => {
       .where('build_id', '=', ids.buildId).executeTakeFirst()).toMatchObject({ status: 'queued', phase: 'requested' });
     expect(await db.executor.selectFrom('golden_snapshots').select('state')
       .where('snapshot_id', '=', ids.snapshotId).executeTakeFirst()).toEqual({ state: 'candidate' });
+  });
+
+  it('atomically records a bounded base-system generation revocation through operator auth', async () => {
+    const enqueue = await app().request('/snapshot-builds', {
+      method: 'POST', headers: { authorization: 'Bearer platform-secret', 'content-type': 'application/json' },
+      body: JSON.stringify({ bundleVersion: 'v1' }),
+    });
+    const { snapshotId } = await enqueue.json() as { snapshotId: string };
+    const headers = { authorization: 'Bearer operator-secret', 'content-type': 'application/json' };
+
+    expect((await app().request('/snapshot-base-generations/ubuntu-24.04-v1/revoke', {
+      method: 'POST', headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ reason: 'base_generation_revoked' }),
+    })).status).toBe(401);
+    expect((await app().request('/snapshot-base-generations/INVALID!/revoke', {
+      method: 'POST', headers,
+      body: JSON.stringify({ reason: 'base_generation_revoked' }),
+    })).status).toBe(400);
+
+    const revoked = await app().request('/snapshot-base-generations/ubuntu-24.04-v1/revoke', {
+      method: 'POST', headers,
+      body: JSON.stringify({ reason: 'base_generation_revoked' }),
+    });
+    expect(revoked.status).toBe(200);
+    expect(await revoked.json()).toEqual({ revoked: true });
+    expect(await db.executor.selectFrom('golden_snapshots').select('state')
+      .where('snapshot_id', '=', snapshotId).executeTakeFirstOrThrow()).toEqual({ state: 'candidate' });
+
+    const repeated = await app().request('/snapshot-base-generations/ubuntu-24.04-v1/revoke', {
+      method: 'POST', headers,
+      body: JSON.stringify({ reason: 'base_generation_revoked' }),
+    });
+    expect(repeated.status).toBe(200);
+    expect(await repeated.json()).toEqual({ revoked: true });
+  });
+
+  it('lists affected machines with bounded opaque pagination and no owner or provider details', async () => {
+    const common = {
+      clerkUserId: 'user_snapshot_owner', handle: 'snapshot-owner', runtimeSlot: 'primary',
+      status: 'running', sourceSnapshotId: '10000000-0000-4000-8000-000000000001',
+      sourceBaseGeneration: 'ubuntu-24.04-v1', targetBundleVersion: 'v1',
+    } as const;
+    await insertUserMachine(db, {
+      ...common, machineId: '30000000-0000-4000-8000-000000000001',
+      provisionedAt: '2026-07-01T00:00:00.000Z', lastSeenAt: '2026-07-02T00:00:00.000Z',
+      failureAt: '2026-07-03T00:00:00.000Z', resizeStartedAt: '2026-07-04T00:00:00.000Z',
+      hetznerServerId: 123, publicIPv4: '203.0.113.10',
+    });
+    await insertUserMachine(db, {
+      ...common, machineId: '30000000-0000-4000-8000-000000000002', runtimeSlot: 'review',
+      provisionedAt: '2026-07-01T00:00:00.000Z', lastSeenAt: '2026-07-03T00:00:00.000Z',
+      hetznerServerId: 124, publicIPv4: '203.0.113.11',
+    });
+    await insertUserMachine(db, {
+      ...common, machineId: '30000000-0000-4000-8000-000000000003', runtimeSlot: 'failed',
+      status: 'failed', provisionedAt: '2026-07-04T00:00:00.000Z',
+    });
+    const unauthorized = await app().request(
+      '/snapshot-base-generations/ubuntu-24.04-v1/affected-machines',
+    );
+    expect(unauthorized.status).toBe(401);
+    const first = await app().request(
+      '/snapshot-base-generations/ubuntu-24.04-v1/affected-machines?limit=1',
+      { headers: { authorization: 'Bearer operator-secret' } },
+    );
+    expect(first.status).toBe(200);
+    const firstPage = await first.json() as { machines: Array<Record<string, unknown>>; nextCursor: string };
+    expect(firstPage.machines).toEqual([{
+      machineId: '30000000-0000-4000-8000-000000000001', runtimeSlot: 'primary',
+      sourceSnapshotId: '10000000-0000-4000-8000-000000000001', targetBundleVersion: 'v1',
+      status: 'running', updatedAt: '2026-07-04T00:00:00.000Z',
+    }]);
+    expect(firstPage.nextCursor).toMatch(/^[A-Za-z0-9_-]{16,512}$/);
+    expect(firstPage.machines[0]).not.toHaveProperty('clerkUserId');
+    expect(firstPage.machines[0]).not.toHaveProperty('hetznerServerId');
+    expect(firstPage.machines[0]).not.toHaveProperty('publicIPv4');
+
+    await db.executor.updateTable('user_machines')
+      .set({ last_seen_at: '2026-07-01T12:00:00.000Z' })
+      .where('machine_id', '=', '30000000-0000-4000-8000-000000000002')
+      .execute();
+
+    const second = await app().request(
+      `/snapshot-base-generations/ubuntu-24.04-v1/affected-machines?limit=1&cursor=${firstPage.nextCursor}`,
+      { headers: { authorization: 'Bearer operator-secret' } },
+    );
+    expect(second.status).toBe(200);
+    expect(await second.json()).toEqual({ machines: [{
+      machineId: '30000000-0000-4000-8000-000000000002', runtimeSlot: 'review',
+      sourceSnapshotId: '10000000-0000-4000-8000-000000000001', targetBundleVersion: 'v1',
+      status: 'running', updatedAt: '2026-07-01T12:00:00.000Z',
+    }] });
+
+    await insertUserMachine(db, {
+      ...common, machineId: '30000000-0000-4000-8000-000000000005', runtimeSlot: 'provisioned-only',
+      provisionedAt: '2026-07-05T00:00:00.000Z',
+    });
+    await insertUserMachine(db, {
+      ...common, machineId: '30000000-0000-4000-8000-000000000004', runtimeSlot: 'other-image',
+      sourceSnapshotId: '10000000-0000-4000-8000-000000000099',
+      provisionedAt: '2026-07-04T00:00:00.000Z',
+    });
+    const snapshotScoped = await app().request(
+      '/snapshots/10000000-0000-4000-8000-000000000001/affected-machines?limit=10',
+      { headers: { authorization: 'Bearer operator-secret' } },
+    );
+    expect(snapshotScoped.status).toBe(200);
+    expect((await snapshotScoped.json() as { machines: Array<Record<string, unknown>> }).machines).toEqual([
+      expect.objectContaining({ machineId: '30000000-0000-4000-8000-000000000001' }),
+      expect.objectContaining({ machineId: '30000000-0000-4000-8000-000000000002' }),
+      expect.objectContaining({
+        machineId: '30000000-0000-4000-8000-000000000005',
+        updatedAt: '2026-07-05T00:00:00.000Z',
+      }),
+    ]);
+
+    const invalid = await app().request(
+      '/snapshot-base-generations/ubuntu-24.04-v1/affected-machines?cursor=not-valid',
+      { headers: { authorization: 'Bearer operator-secret' } },
+    );
+    expect(invalid.status).toBe(400);
   });
 
   it('returns generic JSON when retry or revoke persistence is unavailable', async () => {
@@ -328,5 +561,24 @@ describe('golden snapshot control-plane routes', () => {
     });
     expect(revoke.status).toBe(500);
     expect(await revoke.json()).toEqual({ error: 'Snapshot revocation unavailable' });
+  });
+
+  it('requeues one terminal exact-resource cleanup through operator auth', async () => {
+    const cleanupId = '50000000-0000-4000-8000-000000000041';
+    await db.executor.insertInto('golden_snapshot_cleanup').values({
+      cleanup_id: cleanupId, snapshot_id: null, build_id: null,
+      resource_type: 'builder_server', provider_resource_id: 941,
+      provenance_key: 'builder:941', reason: 'ambiguous_delete', status: 'failed',
+      attempts: 5, next_attempt_at: '2026-07-03T00:10:00.000Z', lease_expires_at: null,
+      last_error_code: 'delete_timeout', created_at: '2026-07-03T00:00:00.000Z', completed_at: null,
+    }).execute();
+    expect((await app().request(`/snapshot-cleanup/${cleanupId}/retry`, {
+      method: 'POST', headers: { authorization: 'Bearer platform-secret' },
+    })).status).toBe(401);
+    const response = await app().request(`/snapshot-cleanup/${cleanupId}/retry`, {
+      method: 'POST', headers: { authorization: 'Bearer operator-secret' },
+    });
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ retried: true });
   });
 });

--- a/tests/platform/golden-snapshot-worker-wiring.test.ts
+++ b/tests/platform/golden-snapshot-worker-wiring.test.ts
@@ -49,9 +49,57 @@ describe('golden snapshot worker wiring', () => {
     expect(worker).toContain('quotaPressure,');
   });
 
+  it('claims builds through the transactionally enforced concurrent-infrastructure cap', async () => {
+    const source = await readFile('packages/platform/src/platform-startup.ts', 'utf8');
+    const worker = source.slice(
+      source.indexOf('const runGoldenSnapshotWorker = async () => {'),
+      source.indexOf('const reconciliationIntervalMs = Number'),
+    );
+    expect(worker).toContain('claimGoldenSnapshotBuildBatch(');
+    expect(worker).toContain('goldenSnapshotConfig.maxConcurrentBuilds');
+    expect(worker).not.toContain('listClaimableGoldenSnapshotBuildIds(');
+  });
+
+  it('reconciles durable base-generation revocations in bounded pages even when builds are disabled', async () => {
+    const source = await readFile('packages/platform/src/platform-startup.ts', 'utf8');
+    const worker = source.slice(
+      source.indexOf('const runGoldenSnapshotWorker = async () => {'),
+      source.indexOf('const reconciliationIntervalMs = Number'),
+    );
+    expect(worker).toContain('listRevokedGoldenSnapshotBaseGenerations');
+    expect(worker).toContain('reconcileRevokedGoldenSnapshotBaseGeneration');
+    expect(worker.indexOf('listRevokedGoldenSnapshotBaseGenerations'))
+      .toBeLessThan(worker.indexOf('if (goldenSnapshotConfig.buildsEnabled)'));
+    expect(worker.indexOf('listRevokedGoldenSnapshotBaseGenerations'))
+      .toBeLessThan(worker.indexOf('reconcileMissingGoldenSnapshotBuilds'));
+    expect(worker.indexOf('listRevokedGoldenSnapshotBaseGenerations'))
+      .toBeLessThan(worker.indexOf('claimGoldenSnapshotBuildBatch'));
+    expect(worker.indexOf('listRevokedGoldenSnapshotBaseGenerations'))
+      .toBeLessThan(worker.indexOf('listUnresolvedGoldenSnapshotBuildIds'));
+    expect(worker).toContain('goldenSnapshotConfig.reconciliationBatchSize');
+  });
+
   it('mounts snapshot status routes before the generic bundle catch-all', async () => {
     const source = await readFile('packages/platform/src/main.ts', 'utf8');
     expect(source.indexOf('createGoldenSnapshotRoutes({'))
       .toBeLessThan(source.indexOf('createHostBundleRoutes({'));
+  });
+
+  it('documents the dedicated operator credential as mandatory for customer VPS installs', async () => {
+    const [exampleEnv, deploymentGuide] = await Promise.all([
+      readFile('.env.example', 'utf8'),
+      readFile('docs/dev/vps-deployment.md', 'utf8'),
+    ]);
+
+    expect(exampleEnv).toContain(
+      '# Required when CUSTOMER_VPS_ENABLED=true. Generate independently with: openssl rand -hex 32',
+    );
+    expect(exampleEnv).toContain(
+      '# Never reuse PLATFORM_SECRET; the platform refuses to start when they match.',
+    );
+    expect(deploymentGuide).toContain('GOLDEN_SNAPSHOT_OPERATOR_SECRET=$(openssl rand -hex 32)');
+    expect(deploymentGuide).toContain(
+      '| `GOLDEN_SNAPSHOT_OPERATOR_SECRET` | platform | runtime | Required when `CUSTOMER_VPS_ENABLED=true`',
+    );
   });
 });


### PR DESCRIPTION
## Summary

- document snapshot rollout gates, fallback, recovery, reconciliation, retention, quota pressure, revocation, rollback, and incident handling
- distinguish release automation from operator-only test-mode controls
- add an authenticated, bounded snapshot-scoped affected-machine inventory endpoint without owner/provider detail leakage
- preserve the boundary between public repository guidance and private operator/site documentation

## Validation

- `bun run test:golden-snapshots` — 400/400 tests, one worker, at stack head
- `pnpm --dir packages/platform exec tsc --noEmit`
- `git diff --check`
- no live provider resources or customer deployments were used

## Invariants

### Source of truth

- `specs/109-golden-vps-snapshots/spec.md` is the product contract; platform Postgres is the runtime lifecycle and selection source of truth.
- Provider resources and labels remain reconciliation evidence only.

### Lock/transaction scope

- The inventory route is read-only and bounded; this documentation/operations layer adds no provider work to transaction scope.
- Atomic selection leases and lifecycle/retirement writes remain short database transactions with provider work outside them.

### Acceptable orphan states

- Only exactly labeled builders, validators, clones, or images recorded for bounded reconciliation and cleanup are acceptable.
- Ambiguous or failed resources remain non-selectable; broad cleanup by guesswork is prohibited.

### Authorization source

- Release automation uses scoped platform/release auth; test-mode creation, inventory, and operator controls require the distinct operator credential.
- Existing verified owner/session authorization continues to govern customer provisioning.

### Deferred scope

- A separate PR in the private `FinnaAI/matrix-os-site` repository is required for canonical public documentation.
- Private incident commands, identifiers, dashboards/alerts, and the disposable live Hetzner spike require separate authorization.
