### PR TITLE
fix(terminal): repair session control layering and colors

### DIFF
--- a/shell/src/components/terminal/NewSessionSplitButton.tsx
+++ b/shell/src/components/terminal/NewSessionSplitButton.tsx
@@ -41,7 +41,7 @@ export function NewSessionSplitButton({
       <ButtonGroup
         aria-label="New session actions"
         data-testid="terminal-new-session-split-button"
-        className="terminal-new-session-split-button"
+        className="terminal-drawer-primary-control terminal-new-session-split-button"
       >
         <Button
           type="button"

--- a/shell/src/components/terminal/TerminalSidebar.tsx
+++ b/shell/src/components/terminal/TerminalSidebar.tsx
@@ -63,6 +63,7 @@ export const DEFAULT_TERMINAL_SIDEBAR_WIDTH = 392;
 const MIN_TERMINAL_SIDEBAR_WIDTH = 280;
 const MAX_TERMINAL_SIDEBAR_WIDTH = 560;
 const TERMINAL_SIDEBAR_TRANSITION = "opacity 140ms ease, transform 180ms ease";
+const TERMINAL_SIDEBAR_MENU_Z_INDEX = 3;
 const SHELL_STATUS_DOT_CSS = `
 @keyframes terminal-session-status-pulse {
   0%, 100% { box-shadow: 0 0 0 4px rgba(95, 184, 95, 0.24); }
@@ -87,12 +88,15 @@ const SHELL_STATUS_DOT_CSS = `
 .terminal-refresh-icon--loading {
   animation: terminal-refresh-spin 0.9s linear infinite;
 }
-.terminal-new-session-split-button {
-  align-items: stretch;
+.terminal-drawer-primary-control {
   background: var(--terminal-drawer-primary-button-bg);
   border: 1px solid color-mix(in srgb, var(--terminal-drawer-primary-button-bg) 78%, var(--terminal-drawer-primary-button-fg));
-  border-radius: 10px;
   box-shadow: 0 1px 0 color-mix(in srgb, var(--terminal-drawer-primary-button-fg) 14%, transparent) inset;
+  color: var(--terminal-drawer-primary-button-fg);
+}
+.terminal-new-session-split-button {
+  align-items: stretch;
+  border-radius: 10px;
   display: inline-flex;
   height: 40px;
   overflow: hidden;
@@ -137,6 +141,31 @@ const SHELL_STATUS_DOT_CSS = `
   cursor: not-allowed;
   opacity: 0.72;
 }
+.terminal-drawer-primary-icon-button {
+  border-radius: 10px;
+  cursor: pointer;
+  flex-shrink: 0;
+  height: 40px;
+  padding: 0;
+  transition: box-shadow 160ms ease, filter 150ms ease, transform 120ms ease;
+  width: 40px;
+}
+.terminal-drawer-primary-icon-button:hover:not(:disabled) {
+  filter: brightness(1.1);
+}
+.terminal-drawer-primary-icon-button:active:not(:disabled) {
+  transform: scale(0.96);
+}
+.terminal-drawer-primary-icon-button:focus-visible {
+  box-shadow:
+    0 0 0 2px var(--terminal-drawer-bg),
+    0 0 0 4px color-mix(in srgb, var(--terminal-drawer-primary-button-bg) 68%, var(--terminal-drawer-primary-button-fg));
+  outline: none;
+}
+.terminal-drawer-primary-icon-button:disabled {
+  cursor: not-allowed;
+  opacity: 0.72;
+}
 .terminal-new-session-dropdown-chevron {
   transition: transform 180ms cubic-bezier(0.22, 1, 0.36, 1);
 }
@@ -155,6 +184,7 @@ const SHELL_STATUS_DOT_CSS = `
   .terminal-new-session-split-button,
   .terminal-new-session-primary-action,
   .terminal-new-session-dropdown-trigger,
+  .terminal-drawer-primary-icon-button,
   .terminal-new-session-dropdown-chevron {
     transition: none;
   }
@@ -932,6 +962,7 @@ export function LocalTerminalSidebar() {
   const statusDotStyles = <style>{SHELL_STATUS_DOT_CSS}</style>;
 
   if (!ctx.sidebarOpen && !ctx.mobile) {
+    const railMenuOpen = newSessionMenuAnchor === "rail";
     return (
       <>
         {statusDotStyles}
@@ -942,10 +973,12 @@ export function LocalTerminalSidebar() {
             display: "flex",
             minHeight: 0,
             opacity: 1,
-            overflow: newSessionMenuAnchor === "rail" ? "visible" : "hidden",
+            overflow: railMenuOpen ? "visible" : "hidden",
+            position: railMenuOpen ? "relative" : undefined,
             transform: "translateX(0)",
             transition: TERMINAL_SIDEBAR_TRANSITION,
             width: 76,
+            zIndex: railMenuOpen ? TERMINAL_SIDEBAR_MENU_Z_INDEX : undefined,
           }}
         >
           <CollapsedSessionsRail
@@ -1078,17 +1111,7 @@ export function LocalTerminalSidebar() {
                   aria-label="Refresh sessions"
                   onClick={() => void fetchShells()}
                   disabled={shellsLoading}
-                  className="flex items-center justify-center"
-                  style={{
-                    background: "var(--terminal-drawer-button-bg)",
-                    border: "1px solid var(--terminal-drawer-button-border)",
-                    borderRadius: 10,
-                    color: "var(--terminal-drawer-button-fg)",
-                    cursor: shellsLoading ? "not-allowed" : "pointer",
-                    height: 40,
-                    opacity: shellsLoading ? 0.72 : 1,
-                    width: 40,
-                  }}
+                  className="terminal-drawer-primary-control terminal-drawer-primary-icon-button flex items-center justify-center"
                 >
                   <RefreshCwIcon
                     className={shellsLoading ? "terminal-refresh-icon--loading" : undefined}
@@ -1101,16 +1124,7 @@ export function LocalTerminalSidebar() {
                   type="button"
                   aria-label="Hide sessions drawer"
                   onClick={() => ctx.setSidebarOpen(false)}
-                  className="flex items-center justify-center"
-                  style={{
-                    background: "var(--terminal-drawer-button-bg)",
-                    border: "1px solid var(--terminal-drawer-button-border)",
-                    borderRadius: 10,
-                    color: "var(--terminal-drawer-button-fg)",
-                    cursor: "pointer",
-                    height: 40,
-                    width: 40,
-                  }}
+                  className="terminal-drawer-primary-control terminal-drawer-primary-icon-button flex items-center justify-center"
                 >
                   <ChevronsLeftIcon data-testid="terminal-drawer-collapse-icon" size={17} strokeWidth={2} />
                 </button>

--- a/shell/src/components/terminal/TerminalSidebar.tsx
+++ b/shell/src/components/terminal/TerminalSidebar.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useRef, useState, type CSSProperties, type Keyb
 import { ChevronsLeftIcon, RefreshCwIcon, SearchIcon } from "lucide-react";
 
 import { getGatewayUrl } from "@/lib/gateway";
+import { SHELL_Z_INDEX } from "@/lib/shell-layering";
 import { NewSessionMenu } from "./NewSessionMenu";
 import { NewSessionSplitButton } from "./NewSessionSplitButton";
 import { ShellCloseConfirmation } from "./ShellCloseConfirmation";
@@ -63,7 +64,6 @@ export const DEFAULT_TERMINAL_SIDEBAR_WIDTH = 392;
 const MIN_TERMINAL_SIDEBAR_WIDTH = 280;
 const MAX_TERMINAL_SIDEBAR_WIDTH = 560;
 const TERMINAL_SIDEBAR_TRANSITION = "opacity 140ms ease, transform 180ms ease";
-const TERMINAL_SIDEBAR_MENU_Z_INDEX = 3;
 const SHELL_STATUS_DOT_CSS = `
 @keyframes terminal-session-status-pulse {
   0%, 100% { box-shadow: 0 0 0 4px rgba(95, 184, 95, 0.24); }
@@ -978,7 +978,7 @@ export function LocalTerminalSidebar() {
             transform: "translateX(0)",
             transition: TERMINAL_SIDEBAR_TRANSITION,
             width: 76,
-            zIndex: railMenuOpen ? TERMINAL_SIDEBAR_MENU_Z_INDEX : undefined,
+            zIndex: railMenuOpen ? SHELL_Z_INDEX.terminalCollapsedRailMenu : undefined,
           }}
         >
           <CollapsedSessionsRail

--- a/shell/src/lib/shell-layering.ts
+++ b/shell/src/lib/shell-layering.ts
@@ -1,4 +1,7 @@
 export const SHELL_Z_INDEX = {
+  // Collapsed Terminal rail elevation while its session menu is open. This must
+  // outrank xterm's link canvas (z-index 2) without escaping the app surface.
+  terminalCollapsedRailMenu: 3,
   // Panel-local card elevation. This stays below app windows and only orders
   // sibling rows inside a shell surface.
   terminalSessionMenuCard: 30,

--- a/tests/shell/terminal-app-component.test.tsx
+++ b/tests/shell/terminal-app-component.test.tsx
@@ -2594,6 +2594,7 @@ describe("TerminalApp", () => {
     sidebarShell = screen.getByTestId("terminal-sidebar-shell");
     expect(screen.queryByRole("menu", { name: "New session menu" })).toBeNull();
     expect(sidebarShell.style.overflow).toBe("hidden");
+    expect(sidebarShell.style.position).toBe("");
     expect(sidebarShell.style.zIndex).toBe("");
   });
 

--- a/tests/shell/terminal-app-component.test.tsx
+++ b/tests/shell/terminal-app-component.test.tsx
@@ -2027,6 +2027,33 @@ describe("TerminalApp", () => {
     expect(dropdownTrigger.getAttribute("data-state")).toBe("closed");
   });
 
+  it("uses one primary surface for every desktop drawer header control", async () => {
+    render(<TerminalApp />);
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    const controls = [
+      screen.getByTestId("terminal-new-session-split-button"),
+      screen.getByRole("button", { name: "Refresh sessions" }),
+      screen.getByRole("button", { name: "Hide sessions drawer" }),
+    ];
+
+    for (const control of controls) {
+      expect(control.classList.contains("terminal-drawer-primary-control")).toBe(true);
+      expect(control.getAttribute("style") ?? "").not.toContain("--terminal-drawer-button-");
+    }
+
+    const primaryControlStyles = Array.from(document.querySelectorAll("style"))
+      .map((style) => style.textContent ?? "")
+      .find((styles) => styles.includes(".terminal-drawer-primary-control"));
+    expect(primaryControlStyles).toContain("background: var(--terminal-drawer-primary-button-bg)");
+    expect(primaryControlStyles).toContain("color: var(--terminal-drawer-primary-button-fg)");
+  });
+
   it("opens split-button session choices with ArrowDown from the primary action", async () => {
     render(<TerminalApp />);
 
@@ -2531,6 +2558,43 @@ describe("TerminalApp", () => {
     expect(matrixRailButton.textContent).toBe("mma");
     expect(matrixRailButton.getAttribute("aria-current")).toBe("true");
     expect(matrixRailButton.getAttribute("data-selected")).toBe("true");
+  });
+
+  it("elevates the collapsed new-session menu above terminal content only while open", async () => {
+    render(<TerminalApp />);
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Hide sessions drawer" }));
+
+    let sidebarShell = screen.getByTestId("terminal-sidebar-shell");
+    expect(sidebarShell.style.overflow).toBe("hidden");
+    expect(sidebarShell.style.zIndex).toBe("");
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "New session" }));
+      await Promise.resolve();
+    });
+
+    sidebarShell = screen.getByTestId("terminal-sidebar-shell");
+    expect(screen.getByRole("menu", { name: "New session menu" })).toBeTruthy();
+    expect(sidebarShell.style.overflow).toBe("visible");
+    expect(sidebarShell.style.position).toBe("relative");
+    expect(sidebarShell.style.zIndex).toBe("3");
+
+    await act(async () => {
+      fireEvent.pointerDown(document.body);
+      await Promise.resolve();
+    });
+
+    sidebarShell = screen.getByTestId("terminal-sidebar-shell");
+    expect(screen.queryByRole("menu", { name: "New session menu" })).toBeNull();
+    expect(sidebarShell.style.overflow).toBe("hidden");
+    expect(sidebarShell.style.zIndex).toBe("");
   });
 
   it("uses Paper collapsed rail abbreviations and fixed control sizing", async () => {


### PR DESCRIPTION
## Summary

- Elevate the collapsed terminal session rail only while the New Session menu is open, keeping the menu visible and interactive above xterm.
- Restore clipped overflow and normal stacking as soon as the menu closes.
- Apply one shared primary terminal drawer control surface to the split New Session control, Refresh, and Hide Drawer, including hover, pressed, focus, disabled, and reduced-motion states.
- Add regressions for conditional rail layering and primary-token consistency.

## Tests

- `pnpm exec vitest run tests/shell/terminal-app-component.test.tsx tests/shell/terminal-globals-css.test.ts` — 88 passed
- `pnpm --filter './shell' exec tsc --noEmit` — passed
- `bun run typecheck` — passed
- `bun run check:patterns` — passed with the repository's existing scanner warnings and 0 violations
- `bun run test` — attempted under ambient Node 26 and Flox Node 24; the reused native dependency tree is ABI-mixed (`better-sqlite3` was built for Node 26), and sandboxed fixture `git add`/Unix-socket operations fail locally. Clean Node 24 CI is required before merge.

## Visual evidence

- Canvas: collapsed New Session menu is fully visible, owns its center hit target above the xterm link canvas, and restores `overflow: hidden` / normal stacking after dismissal.
- Desktop/Developer: the collapsed menu owns its hit target above xterm with the same conditional `z-index: 3` behavior.
- Light, Matrix OS Dark, and Matrix terminal themes: New Session, Refresh, and Hide Drawer have identical computed background, foreground, border, and inset-highlight values.

## Review and monitoring

- Greptile: trusted 5/5 on head `51fab1380bcaf3f809511f2fdb8ef30336f779d7`; both review findings fixed and threads resolved.
- Label-triggered CI: passed, including Type Check, Pattern Scan, React Doctor, shell production build, sync-client package validation, all four unit-test shards, E2E, Docker image/smoke, and the final CI Results gate.

## Invariants

- Source of truth: existing terminal sidebar state and terminal theme CSS variables remain authoritative.
- Lock/transaction scope: none; UI-only change.
- Acceptable orphan states: none introduced.
- Auth source of truth: unchanged.
- Public APIs, schemas, backend behavior, and persisted data: unchanged.
- Deferred scope: production host-bundle publication and deployment after merge.
