### PR TITLE
fix(workflow): prohibit squash subject overrides

### DIFF
--- a/.agents/skills/land/SKILL.md
+++ b/.agents/skills/land/SKILL.md
@@ -18,6 +18,14 @@ description:
 - No need to delete remote branches after merge; the repo auto-deletes head
   branches.
 
+## Non-negotiable squash-merge subject
+
+- Never pass `--subject` or `-s` to `gh pr merge`; always let GitHub generate
+  the repository-default squash-merge subject.
+- Custom `--body` and `--body-file` values are allowed.
+- Treat an exact PR title requirement as applying only to the PR title; never
+  use it to override the squash-merge subject.
+
 ## Preconditions
 
 - `gh` CLI is authenticated.

--- a/tests/kernel/land-skill.test.ts
+++ b/tests/kernel/land-skill.test.ts
@@ -9,7 +9,18 @@ describe("land skill", () => {
       "utf8",
     );
 
-    expect(skill).toContain('gh pr merge --squash --body "$pr_body"');
-    expect(skill).not.toContain("--subject");
+    expect(skill).toContain(
+      "Never pass `--subject` or `-s` to `gh pr merge`",
+    );
+    expect(skill).toContain(
+      "Custom `--body` and `--body-file` values are allowed",
+    );
+
+    const mergeCommands = skill.match(/^gh pr merge .*$/gm) ?? [];
+    expect(mergeCommands).toContain('gh pr merge --squash --body "$pr_body"');
+    expect(mergeCommands).not.toHaveLength(0);
+    for (const command of mergeCommands) {
+      expect(command).not.toMatch(/\s(?:--subject|-s)(?:\s|=|$)/);
+    }
   });
 });


### PR DESCRIPTION
## Summary

- make the land skill explicitly forbid `--subject` and `-s` on `gh pr merge`
- preserve support for custom squash-merge bodies via `--body` or `--body-file`
- strengthen the regression test so merge command examples cannot reintroduce a subject override

## Tests

- ✅ `pnpm exec vitest run tests/kernel/land-skill.test.ts`
- ✅ skill validator: `quick_validate.py .agents/skills/land`
- ✅ `bun run check:patterns` (0 violations; 5 existing warnings)
- ⚠️ `bun run typecheck` reaches Desktop, then fails on two unrelated `origin/main` implicit-any errors in `CommandPalette.tsx:174` and `PanelStrip.tsx:115`
- ⚠️ `bun run test` under ambient Node 26.3.1: 767 files / 8,500 tests pass; 34 files / 274 tests fail, predominantly because localStorage is unavailable without `--localstorage-file`; the changed land-skill regression passes

## Invariants

- source of truth: `.agents/skills/land/SKILL.md` remains the canonical landing workflow
- locking/transactions: not applicable; documentation and regression-test change only
- orphan handling: not applicable
- authorization: unchanged
- deferred work: unrelated baseline typecheck and Node 26 test-environment failures are intentionally not modified here

## Review and monitoring

- Greptile: trusted 5/5 on head `973f124513b0fba13faa262cda99ec1a176ae10f`
- `ready-for-ci`: added only after the trusted 5/5 result
- label-triggered CI: green, including typecheck, pattern scan, React Doctor, docs contracts, sync-client packaging, shell production build, all four unit-test shards, E2E tests, Docker image build, and Docker smoke test
- skipped by workflow selection: preview VPS jobs and Docker scenario matrix
