### PR TITLE
fix(ci): allow platform deploys without portal configs

### DIFF
--- a/.github/workflows/platform-cloud-run.yml
+++ b/.github/workflows/platform-cloud-run.yml
@@ -181,7 +181,9 @@ jobs:
             rm -f "$describe_error_tmpfile"
           done
 
-          if [ "$available_portal_configuration_secrets" -eq 1 ]; then
+          expected_portal_configuration_secrets="${#optional_portal_configuration_secrets[@]}"
+          if [ "$available_portal_configuration_secrets" -gt 0 ] && \
+            [ "$available_portal_configuration_secrets" -lt "$expected_portal_configuration_secrets" ]; then
             echo "Focused Stripe portal configuration secrets are incomplete; configure both intervals or neither." >&2
             exit 1
           fi

--- a/.github/workflows/platform-cloud-run.yml
+++ b/.github/workflows/platform-cloud-run.yml
@@ -116,7 +116,7 @@ jobs:
             exit 1
           fi
 
-      - name: Verify Stripe billing price secrets
+      - name: Verify Stripe billing secrets
         run: |
           set -euo pipefail
           required_price_secrets=(
@@ -128,6 +128,8 @@ jobs:
             STRIPE_PRICE_MATRIX_MAX_ANNUAL=stripe-price-matrix-max-annual
             STRIPE_PRICE_EXTRA_RUNTIME_MONTHLY=stripe-price-extra-runtime-monthly
             STRIPE_PRICE_EXTRA_RUNTIME_ANNUAL=stripe-price-extra-runtime-annual
+          )
+          optional_portal_configuration_secrets=(
             STRIPE_PORTAL_CONFIGURATION_EXTRA_RUNTIME_MONTHLY=stripe-portal-configuration-extra-runtime-monthly
             STRIPE_PORTAL_CONFIGURATION_EXTRA_RUNTIME_ANNUAL=stripe-portal-configuration-extra-runtime-annual
           )
@@ -163,6 +165,65 @@ jobs:
               exit 1
             fi
           done
+
+          available_portal_configuration_secrets=0
+          for entry in "${optional_portal_configuration_secrets[@]}"; do
+            secret_name="${entry#*=}"
+            describe_error_tmpfile="$(mktemp)"
+            if gcloud secrets describe "$secret_name" \
+              --project "$GCP_PROJECT_ID" >/dev/null 2>"$describe_error_tmpfile"; then
+              available_portal_configuration_secrets=$((available_portal_configuration_secrets + 1))
+            elif ! grep -Fq 'NOT_FOUND' "$describe_error_tmpfile"; then
+              cat "$describe_error_tmpfile" >&2
+              rm -f "$describe_error_tmpfile"
+              exit 1
+            fi
+            rm -f "$describe_error_tmpfile"
+          done
+
+          if [ "$available_portal_configuration_secrets" -eq 1 ]; then
+            echo "Focused Stripe portal configuration secrets are incomplete; configure both intervals or neither." >&2
+            exit 1
+          fi
+
+          if [ "$available_portal_configuration_secrets" -eq 0 ]; then
+            echo "Focused Stripe portal configurations are not provisioned. Add-computer billing will remain unavailable."
+            echo 'PORTAL_CONFIGURATION_SECRET_BINDINGS=' >> "$GITHUB_ENV"
+          else
+            portal_configuration_secret_bindings=()
+            for entry in "${optional_portal_configuration_secrets[@]}"; do
+              env_name="${entry%%=*}"
+              secret_name="${entry#*=}"
+              portal_secret_tmpfile="$(mktemp)"
+              if ! gcloud secrets versions access latest --secret "$secret_name" \
+                --project "$GCP_PROJECT_ID" >"$portal_secret_tmpfile"; then
+                rm -f "$portal_secret_tmpfile"
+                echo "$secret_name must have an accessible latest version for $env_name." >&2
+                exit 1
+              fi
+              if [ ! -s "$portal_secret_tmpfile" ]; then
+                rm -f "$portal_secret_tmpfile"
+                echo "$secret_name must not be empty for $env_name." >&2
+                exit 1
+              fi
+              rm -f "$portal_secret_tmpfile"
+              accessor_member="$(
+                gcloud secrets get-iam-policy "$secret_name" \
+                  --project "$GCP_PROJECT_ID" \
+                  --flatten='bindings[].members' \
+                  --filter="bindings.role:roles/secretmanager.secretAccessor AND bindings.members:serviceAccount:${CLOUD_RUN_SERVICE_ACCOUNT}" \
+                  --format='value(bindings.members)' \
+                  | head -1
+              )"
+              if [ "$accessor_member" != "serviceAccount:${CLOUD_RUN_SERVICE_ACCOUNT}" ]; then
+                echo "$secret_name must grant roles/secretmanager.secretAccessor to ${CLOUD_RUN_SERVICE_ACCOUNT}" >&2
+                exit 1
+              fi
+              portal_configuration_secret_bindings+=("${env_name}=${secret_name}:latest")
+            done
+            PORTAL_CONFIGURATION_SECRET_BINDINGS="$(IFS=,; echo "${portal_configuration_secret_bindings[*]}")"
+            echo "PORTAL_CONFIGURATION_SECRET_BINDINGS=${PORTAL_CONFIGURATION_SECRET_BINDINGS}" >> "$GITHUB_ENV"
+          fi
 
       - name: Verify Pipedream integration secrets
         run: |
@@ -313,7 +374,7 @@ jobs:
             --allow-unauthenticated \
             "${traffic_flags[@]}" \
             --set-env-vars "PLATFORM_RUNTIME_MODE=cloud_run,PLATFORM_PORT=8080,PLATFORM_PUBLIC_URL=${PLATFORM_PUBLIC_URL},MATRIX_API_ORIGIN=${MATRIX_API_ORIGIN},CUSTOMER_VPS_ENABLED=true,CUSTOMER_VPS_TLS_VERIFY=false,CUSTOMER_VPS_IMAGE_VERSION=${CUSTOMER_VPS_IMAGE_VERSION},CUSTOMER_VPS_CLOUD_INIT_PATH=distro/customer-vps/cloud-init.yaml,MATRIX_LEGACY_CONTAINER_ROUTING_ENABLED=false,AUTH_SHELL_HOST=127.0.0.1,AUTH_SHELL_PORT=3200,MATRIX_APP_DOMAIN_HOSTS=${MATRIX_APP_DOMAIN_HOSTS},MATRIX_CODE_DOMAIN_HOSTS=${MATRIX_CODE_DOMAIN_HOSTS},NEXT_PUBLIC_MATRIX_APP_URL=${MATRIX_APP_URL},MATRIX_BILLING_PROVIDER=stripe,POSTHOG_HOST=https://eu.i.posthog.com,POSTHOG_API_HOST=https://eu.i.posthog.com,NEXT_PUBLIC_POSTHOG_HOST=${POSTHOG_PUBLIC_HOST},NEXT_PUBLIC_POSTHOG_API_HOST=${POSTHOG_PUBLIC_API_HOST},R2_PREFIX_ROOT=matrixos-sync" \
-            --set-secrets "PLATFORM_DATABASE_URL=platform-database-url:latest,PLATFORM_SECRET=platform-secret:latest,PLATFORM_JWT_SECRET=platform-jwt-secret:latest,EDGE_ROUTER_SECRET=edge-router-secret:latest,CLERK_SECRET_KEY=clerk-secret-key:latest,STRIPE_SECRET_KEY=stripe-secret-key:latest,STRIPE_WEBHOOK_SECRET=stripe-webhook-secret:latest,STRIPE_PRICE_MATRIX_STARTER_MONTHLY=stripe-price-matrix-starter-monthly:latest,STRIPE_PRICE_MATRIX_STARTER_ANNUAL=stripe-price-matrix-starter-annual:latest,STRIPE_PRICE_MATRIX_BUILDER_MONTHLY=stripe-price-matrix-builder-monthly:latest,STRIPE_PRICE_MATRIX_BUILDER_ANNUAL=stripe-price-matrix-builder-annual:latest,STRIPE_PRICE_MATRIX_MAX_MONTHLY=stripe-price-matrix-max-monthly:latest,STRIPE_PRICE_MATRIX_MAX_ANNUAL=stripe-price-matrix-max-annual:latest,STRIPE_PRICE_EXTRA_RUNTIME_MONTHLY=stripe-price-extra-runtime-monthly:latest,STRIPE_PRICE_EXTRA_RUNTIME_ANNUAL=stripe-price-extra-runtime-annual:latest,STRIPE_PORTAL_CONFIGURATION_EXTRA_RUNTIME_MONTHLY=stripe-portal-configuration-extra-runtime-monthly:latest,STRIPE_PORTAL_CONFIGURATION_EXTRA_RUNTIME_ANNUAL=stripe-portal-configuration-extra-runtime-annual:latest,PIPEDREAM_CLIENT_ID=pipedream-client-id:latest,PIPEDREAM_CLIENT_SECRET=pipedream-client-secret:latest,PIPEDREAM_PROJECT_ID=pipedream-project-id:latest,PIPEDREAM_ENVIRONMENT=pipedream-environment:latest,R2_ACCOUNT_ID=r2-account-id:latest,R2_BUCKET=r2-bucket:latest,R2_ACCESS_KEY_ID=r2-access-key-id:latest,R2_SECRET_ACCESS_KEY=r2-secret-access-key:latest,R2_BUNDLES_ACCOUNT_ID=r2-bundles-account-id:latest,R2_BUNDLES_BUCKET=r2-bundles-bucket:latest,R2_BUNDLES_ENDPOINT=r2-bundles-endpoint:latest,R2_BUNDLES_ACCESS_KEY_ID=r2-bundles-access-key-id:latest,R2_BUNDLES_SECRET_ACCESS_KEY=r2-bundles-secret-access-key:latest,HETZNER_API_TOKEN=hetzner-api-token:latest,POSTHOG_TOKEN=posthog-token:latest,POSTHOG_PROJECT_TOKEN=posthog-project-token:latest,NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=next-public-clerk-publishable-key:latest,NEXT_PUBLIC_POSTHOG_KEY=next-public-posthog-key:latest,NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN=next-public-posthog-project-token:latest" \
+            --set-secrets "PLATFORM_DATABASE_URL=platform-database-url:latest,PLATFORM_SECRET=platform-secret:latest,PLATFORM_JWT_SECRET=platform-jwt-secret:latest,EDGE_ROUTER_SECRET=edge-router-secret:latest,CLERK_SECRET_KEY=clerk-secret-key:latest,STRIPE_SECRET_KEY=stripe-secret-key:latest,STRIPE_WEBHOOK_SECRET=stripe-webhook-secret:latest,STRIPE_PRICE_MATRIX_STARTER_MONTHLY=stripe-price-matrix-starter-monthly:latest,STRIPE_PRICE_MATRIX_STARTER_ANNUAL=stripe-price-matrix-starter-annual:latest,STRIPE_PRICE_MATRIX_BUILDER_MONTHLY=stripe-price-matrix-builder-monthly:latest,STRIPE_PRICE_MATRIX_BUILDER_ANNUAL=stripe-price-matrix-builder-annual:latest,STRIPE_PRICE_MATRIX_MAX_MONTHLY=stripe-price-matrix-max-monthly:latest,STRIPE_PRICE_MATRIX_MAX_ANNUAL=stripe-price-matrix-max-annual:latest,STRIPE_PRICE_EXTRA_RUNTIME_MONTHLY=stripe-price-extra-runtime-monthly:latest,STRIPE_PRICE_EXTRA_RUNTIME_ANNUAL=stripe-price-extra-runtime-annual:latest,PIPEDREAM_CLIENT_ID=pipedream-client-id:latest,PIPEDREAM_CLIENT_SECRET=pipedream-client-secret:latest,PIPEDREAM_PROJECT_ID=pipedream-project-id:latest,PIPEDREAM_ENVIRONMENT=pipedream-environment:latest,R2_ACCOUNT_ID=r2-account-id:latest,R2_BUCKET=r2-bucket:latest,R2_ACCESS_KEY_ID=r2-access-key-id:latest,R2_SECRET_ACCESS_KEY=r2-secret-access-key:latest,R2_BUNDLES_ACCOUNT_ID=r2-bundles-account-id:latest,R2_BUNDLES_BUCKET=r2-bundles-bucket:latest,R2_BUNDLES_ENDPOINT=r2-bundles-endpoint:latest,R2_BUNDLES_ACCESS_KEY_ID=r2-bundles-access-key-id:latest,R2_BUNDLES_SECRET_ACCESS_KEY=r2-bundles-secret-access-key:latest,HETZNER_API_TOKEN=hetzner-api-token:latest,POSTHOG_TOKEN=posthog-token:latest,POSTHOG_PROJECT_TOKEN=posthog-project-token:latest,NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=next-public-clerk-publishable-key:latest,NEXT_PUBLIC_POSTHOG_KEY=next-public-posthog-key:latest,NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN=next-public-posthog-project-token:latest${PORTAL_CONFIGURATION_SECRET_BINDINGS:+,${PORTAL_CONFIGURATION_SECRET_BINDINGS}}" \
             --format=json); then
             exit 1
           fi

--- a/docs/platform/dev/deployment.md
+++ b/docs/platform/dev/deployment.md
@@ -100,10 +100,12 @@ STRIPE_PORTAL_CONFIGURATION_EXTRA_RUNTIME_MONTHLY=stripe-portal-configuration-ex
 STRIPE_PORTAL_CONFIGURATION_EXTRA_RUNTIME_ANNUAL=stripe-portal-configuration-extra-runtime-annual
 ```
 
-The two portal configurations are required for the customer-facing add-computer
-flow. Configure each for subscription updates and expose only the extra-runtime
-choices matching that configuration's monthly or annual interval. The platform
-fails closed instead of falling back to a general portal when one is missing.
+The two portal configurations are required to enable the customer-facing
+add-computer flow, but their absence does not block an otherwise healthy
+platform deployment. Configure both for subscription updates and expose only
+the extra-runtime choices matching that configuration's monthly or annual
+interval. The deployment rejects a partial pair, and the platform fails closed
+instead of falling back to a general portal when both are absent.
 
 The `Platform Cloud Run` workflow preflights these secrets, mounts them into
 the deployed revision, smokes `/sign-in` for the pre-VPS billing shell, and

--- a/tests/platform/ci-workflows.test.ts
+++ b/tests/platform/ci-workflows.test.ts
@@ -204,8 +204,11 @@ describe('CI workflows', () => {
     const workflow = readFileSync(join(root, '.github/workflows/platform-cloud-run.yml'), 'utf8');
 
     expect(workflow).toContain('optional_portal_configuration_secrets=(');
+    expect(workflow).toContain('STRIPE_PORTAL_CONFIGURATION_EXTRA_RUNTIME_MONTHLY=stripe-portal-configuration-extra-runtime-monthly');
+    expect(workflow).toContain('STRIPE_PORTAL_CONFIGURATION_EXTRA_RUNTIME_ANNUAL=stripe-portal-configuration-extra-runtime-annual');
     expect(workflow).toContain('available_portal_configuration_secrets=0');
-    expect(workflow).toContain('if [ "$available_portal_configuration_secrets" -eq 1 ]; then');
+    expect(workflow).toContain('expected_portal_configuration_secrets="${#optional_portal_configuration_secrets[@]}"');
+    expect(workflow).toContain('[ "$available_portal_configuration_secrets" -lt "$expected_portal_configuration_secrets" ]; then');
     expect(workflow).toContain('Focused Stripe portal configuration secrets are incomplete');
     expect(workflow).toContain('if [ "$available_portal_configuration_secrets" -eq 0 ]; then');
     expect(workflow).toContain('Add-computer billing will remain unavailable');

--- a/tests/platform/ci-workflows.test.ts
+++ b/tests/platform/ci-workflows.test.ts
@@ -12,8 +12,6 @@ describe('CI workflows', () => {
     ['STRIPE_PRICE_MATRIX_MAX_ANNUAL', 'stripe-price-matrix-max-annual'],
     ['STRIPE_PRICE_EXTRA_RUNTIME_MONTHLY', 'stripe-price-extra-runtime-monthly'],
     ['STRIPE_PRICE_EXTRA_RUNTIME_ANNUAL', 'stripe-price-extra-runtime-annual'],
-    ['STRIPE_PORTAL_CONFIGURATION_EXTRA_RUNTIME_MONTHLY', 'stripe-portal-configuration-extra-runtime-monthly'],
-    ['STRIPE_PORTAL_CONFIGURATION_EXTRA_RUNTIME_ANNUAL', 'stripe-portal-configuration-extra-runtime-annual'],
   ] as const;
 
   it('exposes a stable aggregate CI result job for branch protection', () => {
@@ -201,6 +199,20 @@ describe('CI workflows', () => {
     }
   });
 
+  it('binds focused Stripe portal configurations only when the complete pair exists', () => {
+    const root = process.cwd();
+    const workflow = readFileSync(join(root, '.github/workflows/platform-cloud-run.yml'), 'utf8');
+
+    expect(workflow).toContain('optional_portal_configuration_secrets=(');
+    expect(workflow).toContain('available_portal_configuration_secrets=0');
+    expect(workflow).toContain('if [ "$available_portal_configuration_secrets" -eq 1 ]; then');
+    expect(workflow).toContain('Focused Stripe portal configuration secrets are incomplete');
+    expect(workflow).toContain('if [ "$available_portal_configuration_secrets" -eq 0 ]; then');
+    expect(workflow).toContain('Add-computer billing will remain unavailable');
+    expect(workflow).toContain('PORTAL_CONFIGURATION_SECRET_BINDINGS=');
+    expect(workflow).toContain('${PORTAL_CONFIGURATION_SECRET_BINDINGS:+,${PORTAL_CONFIGURATION_SECRET_BINDINGS}}');
+  });
+
   it('wires Pipedream integration secrets into platform Cloud Run', () => {
     const root = process.cwd();
     const workflow = readFileSync(join(root, '.github/workflows/platform-cloud-run.yml'), 'utf8');
@@ -219,7 +231,7 @@ describe('CI workflows', () => {
     const root = process.cwd();
     const workflow = readFileSync(join(root, '.github/workflows/platform-cloud-run.yml'), 'utf8');
 
-    expect(workflow).toContain('Verify Stripe billing price secrets');
+    expect(workflow).toContain('Verify Stripe billing secrets');
     expect(workflow).toContain('gcloud secrets describe "$secret_name"');
     expect(workflow).toContain('price_secret_tmpfile="$(mktemp)"');
     expect(workflow).toContain('gcloud secrets versions access latest --secret "$secret_name"');


### PR DESCRIPTION
## Summary

- stop absent focused Stripe portal configuration secrets from blocking the entire Platform Cloud Run deployment
- treat the monthly and annual configurations as an optional all-or-nothing pair: validate and bind both when present, fail on partial configuration, and safely omit both when absent
- preserve the runtime fail-closed behavior for add-computer billing and document the deployment semantics

## Tests

- `pnpm exec vitest run tests/platform/ci-workflows.test.ts tests/repository/site-extraction.test.ts --reporter=dot` — 27 passed
- YAML parse validation for `.github/workflows/platform-cloud-run.yml` — passed
- `bash -n` on the Stripe preflight and Cloud Run deploy step bodies — passed
- manual full typecheck sequence matching the repository script — passed; `bun run typecheck` itself could not start because bun is unavailable on this runner
- `pnpm run check:patterns` — 0 violations, pre-existing warnings only
- monolithic `pnpm run test` was stopped after unrelated resource-contention, process-timeout, and permission-simulation failures appeared; the changed workflow/docs suites remained green and CI sharding is the authoritative broad gate

## Review/Monitoring

- worktree-pr-monitor loop is active
- merge is blocked until required CI is green, unresolved review feedback is cleared, and the latest trusted Greptile result is 5/5
- when merging, retain the default pull-request commit subject

## Invariants

### Source of truth

- Google Secret Manager remains canonical for deployment secret availability and values
- platform billing configuration remains server-owned; absent focused portal configuration keeps add-computer billing unavailable rather than exposing the general portal

### Lock/transaction scope

- this change performs no database reads or writes and adds no transaction boundary
- deployment preflight network calls occur only in GitHub Actions before Cloud Run revision creation

### Acceptable orphan states

- when neither focused portal configuration exists, the platform deploys without those environment bindings and add-computer billing returns the existing generic unavailable response
- when only one exists, or either configured secret is empty/inaccessible, deployment fails before creating a candidate revision

### Auth source of truth

- GitHub OIDC and the configured Google Cloud service account remain authoritative for deployment access
- the Cloud Run runtime service account must retain Secret Manager accessor permission for every bound secret

### Deferred scope

- creating Stripe Billing Portal configurations and their Google Secret Manager entries remains an explicit operator task before enabling customer add-computer billing
- this PR does not change Stripe pricing, subscription projection, runtime entitlements, or customer data