### PR TITLE
fix(vps): harden golden snapshot dev validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -306,7 +306,7 @@ jobs:
     name: Unit Tests (${{ matrix.shard }}/4)
     needs: [changes, patterns, sync-client]
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 15
     strategy:
       fail-fast: false
       matrix:

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "observability:posthog-alerts": "node scripts/observability/setup-posthog-alerts.mjs",
     "release:enqueue-golden-snapshot": "node scripts/enqueue-golden-snapshot.mjs",
     "test": "sh -c 'pnpm --filter @matrix-os/observability build && pnpm --filter @matrix-os/kernel build && vitest run \"$@\"' --",
+    "test:golden-snapshots": "bun run test -- --maxWorkers=1 --no-file-parallelism tests/platform/golden-snapshot-*.test.ts tests/platform/host-bundle-snapshot-workflow.test.ts tests/platform/host-bundle-route.test.ts tests/platform/r2-client.test.ts tests/platform/ci-workflows.test.ts tests/platform/customer-vps.test.ts tests/platform/customer-vps-cloud-init.test.ts tests/platform/customer-vps-hetzner.test.ts tests/platform/customer-vps-host-bundle.test.ts",
     "test:watch": "sh -c 'pnpm --filter @matrix-os/observability build && pnpm --filter @matrix-os/kernel build && vitest \"$@\"' --",
     "test:integration": "vitest run --config vitest.integration.config.ts",
     "test:coverage": "sh -c 'pnpm --filter @matrix-os/observability build && pnpm --filter @matrix-os/kernel build && vitest run --coverage \"$@\"' --",

--- a/specs/109-golden-vps-snapshots/quickstart.md
+++ b/specs/109-golden-vps-snapshots/quickstart.md
@@ -15,10 +15,18 @@ named in PR #1053. A green targeted golden-snapshot gate does not rewrite that b
 baseline. Any new failure, changed failure identity, or failure in a snapshot-targeted
 suite fails this stack's gate; baseline entries are never silently reclassified.
 
+Run the complete snapshot gate in one Vitest process with one worker. This is the preferred low-CPU validation path; it builds shared prerequisites once and avoids concurrent PGlite migration suites.
+
+```bash
+bun run test:golden-snapshots
+```
+
+The narrower commands below are for isolating a failure. Keep `--maxWorkers=1` when CPU pressure matters.
+
 ## 2. Run the lifecycle and provider contract tests
 
 ```bash
-pnpm exec vitest run \
+pnpm exec vitest run --maxWorkers=1 --no-file-parallelism \
   tests/platform/golden-snapshot-repository.test.ts \
   tests/platform/golden-snapshot-selection.test.ts \
   tests/platform/golden-snapshot-service.test.ts \
@@ -34,7 +42,7 @@ reconciliation; retention never deletes leased/protected snapshots.
 ## 3. Run host sanitation contract tests
 
 ```bash
-pnpm exec vitest run tests/platform/golden-snapshot-host-scripts.test.ts
+pnpm exec vitest run --maxWorkers=1 --no-file-parallelism tests/platform/golden-snapshot-host-scripts.test.ts
 ```
 
 Expected: tests cover every sanitation category in the approved spec, verify services
@@ -46,10 +54,18 @@ keys, machine identity, credentials, and logs.
 ## 4. Run provisioning/fallback tests
 
 ```bash
-pnpm exec vitest run \
+pnpm exec vitest run --maxWorkers=1 --no-file-parallelism \
   tests/platform/golden-snapshot-provisioning.test.ts \
-  tests/platform/customer-vps.test.ts
+  tests/platform/customer-vps.test.ts \
+  tests/platform/customer-vps-cloud-init.test.ts \
+  tests/platform/customer-vps-hetzner.test.ts \
+  tests/platform/customer-vps-host-bundle.test.ts
 ```
+
+These are the explicit customer-VPS suites exercised by the combined gate. Do not use
+the broad `customer-vps*.test.ts` glob: it pulls unrelated fleet, telemetry, TLS, and
+release suites into the snapshot feedback loop and needlessly increases CPU and DB
+migration work.
 
 Required scenarios:
 
@@ -68,7 +84,7 @@ Required scenarios:
 ## 5. Run workflow tests and review gates
 
 ```bash
-pnpm exec vitest run tests/platform/host-bundle-snapshot-workflow.test.ts
+pnpm exec vitest run --maxWorkers=1 --no-file-parallelism tests/platform/host-bundle-snapshot-workflow.test.ts
 bun run check:patterns
 bun run typecheck
 bun run test

--- a/tests/platform/golden-snapshot-dev-gate.test.ts
+++ b/tests/platform/golden-snapshot-dev-gate.test.ts
@@ -1,0 +1,27 @@
+import { readFile } from 'node:fs/promises';
+import { describe, expect, it } from 'vitest';
+
+describe('golden snapshot developer gate', () => {
+  it('runs only the explicit customer VPS contract suites needed by snapshot provisioning', async () => {
+    const packageJson = JSON.parse(await readFile('package.json', 'utf8')) as {
+      scripts: Record<string, string>;
+    };
+    const command = packageJson.scripts['test:golden-snapshots'];
+    expect(command).not.toContain('tests/platform/customer-vps*.test.ts');
+    expect(command).toContain('tests/platform/customer-vps.test.ts');
+    expect(command).toContain('tests/platform/customer-vps-cloud-init.test.ts');
+    expect(command).toContain('tests/platform/customer-vps-hetzner.test.ts');
+    expect(command).toContain('tests/platform/customer-vps-host-bundle.test.ts');
+    expect(command).toContain('tests/platform/golden-snapshot-*.test.ts');
+    expect(command).toContain('tests/platform/r2-client.test.ts');
+    expect(command).toContain('tests/platform/ci-workflows.test.ts');
+    expect(command).toContain('--maxWorkers=1');
+    expect(command).toContain('--no-file-parallelism');
+  });
+
+  it('leaves enough CI time for a completed unit shard to run post-job cleanup', async () => {
+    const workflow = await readFile('.github/workflows/ci.yml', 'utf8');
+    const unitJob = workflow.slice(workflow.indexOf('\n  unit:'), workflow.indexOf('\n  docs-contract:'));
+    expect(unitJob).toContain('timeout-minutes: 15');
+  });
+});


### PR DESCRIPTION
## Summary

- add a reproducible one-worker golden snapshot gate, including the signed object-store URL regression
- preserve bounded exact-label image discovery after ambiguous provider responses
- scrub and verify crash-dump state and reject unsupported ARM builders in V1
- keep validation failures generic without exposing provider errors, credentials, resource IDs, or secret-bearing logs

## Verification

- [x] Final focused provisioning, recovery, routing, and host-script suites: 62 passed with one worker
- [x] Earlier exact-head route, workflow, worker-wiring, and release suites: 89 passed with one worker and no file parallelism
- [x] Platform TypeScript project check
- [x] Pattern scanner: 5 advisory warnings, 0 violations
- [x] Authorized test-mode Hetzner smoke reached ready only after two independent validation clones proved exact bundle, service readiness, fresh activation, unique identity, and forbidden-state absence
- [x] Provider reconciliation left zero disposable servers and retained one test-mode golden image for the separately authorized dev trial

## Invariants

### Source of truth

`specs/109-golden-vps-snapshots/spec.md` is authoritative; `specs/109-golden-vps-snapshots/quickstart.md` defines the bounded developer gate.

### Lock/transaction scope

Lifecycle state, callback receipts, exact-resource cleanup, and orphan-discovery decisions use short Postgres transactions. Provider calls and boot polling remain outside transaction and lock scope.

### Acceptable orphan states

Only exactly labeled unresolved resources recorded for bounded reconciliation and cleanup are acceptable. Late images remain non-selectable, discoverable, and exact-ID cleaned.

### Authorization source

Existing distinct release and operator credentials remain authoritative. The live smoke used only the separately authorized test-mode operator path.

### Deferred scope

Customer or public rollout, production snapshot selection, existing-fleet deployment, stable/canary changes, and production provider resources remain deferred. Reusing a migrated test fixture to reduce wall time and resolving existing locked dependency advisories remain separate work.