### PR TITLE
fix(mobile): honour the edge-to-edge config-plugin extension so EAS builds run

### DIFF
--- a/apps/mobile/__tests__/mobile-app-config.test.ts
+++ b/apps/mobile/__tests__/mobile-app-config.test.ts
@@ -118,11 +118,16 @@ describe("workspace package extensions", () => {
   const workspaceConfig = readFileSync(join(__dirname, "../../../pnpm-workspace.yaml"), "utf8");
 
   it("declares the Expo config-plugins dependency that the plugin loader needs", () => {
-    expect(
-      rootPackage.pnpm?.packageExtensions?.["react-native-edge-to-edge@1.8.1"]?.dependencies?.[
-        "@expo/config-plugins"
-      ],
-    ).toBe("57.0.2");
+    // Keyed on `@*` on purpose: pinning an exact version means the next
+    // react-native-edge-to-edge upgrade silently stops matching and the EAS
+    // build starts failing again.
+    const extensions = rootPackage.pnpm?.packageExtensions ?? {};
+    const keys = Object.keys(extensions).filter((key) =>
+      key.startsWith("react-native-edge-to-edge@"),
+    );
+
+    expect(keys).toEqual(["react-native-edge-to-edge@*"]);
+    expect(extensions[keys[0]]?.dependencies?.["@expo/config-plugins"]).toBe("57.0.2");
   });
 
   it("keeps package extensions out of pnpm-workspace.yaml, where they are ignored", () => {

--- a/apps/mobile/__tests__/mobile-app-config.test.ts
+++ b/apps/mobile/__tests__/mobile-app-config.test.ts
@@ -106,6 +106,30 @@ describe("mobile Android release configuration", () => {
   });
 });
 
+describe("workspace package extensions", () => {
+  // `eas build` shells out to the expo CLI from the pnpm store, where a package
+  // can only see dependencies it declares. react-native-edge-to-edge's Expo
+  // plugin requires @expo/config-plugins without declaring it, which fails the
+  // build before the project is even uploaded. pnpm only honours these from
+  // package.json here, not from pnpm-workspace.yaml.
+  const rootPackage = require("../../../package.json") as {
+    pnpm?: { packageExtensions?: Record<string, { dependencies?: Record<string, string> }> };
+  };
+  const workspaceConfig = readFileSync(join(__dirname, "../../../pnpm-workspace.yaml"), "utf8");
+
+  it("declares the Expo config-plugins dependency that the plugin loader needs", () => {
+    expect(
+      rootPackage.pnpm?.packageExtensions?.["react-native-edge-to-edge@1.8.1"]?.dependencies?.[
+        "@expo/config-plugins"
+      ],
+    ).toBe("57.0.2");
+  });
+
+  it("keeps package extensions out of pnpm-workspace.yaml, where they are ignored", () => {
+    expect(workspaceConfig).not.toMatch(/^packageExtensions:/m);
+  });
+});
+
 describe("mobile over-the-air update configuration", () => {
   it("ships expo-updates so builds can fetch JS updates without a store release", () => {
     expect(packageConfig.dependencies?.["expo-updates"]).toBe("~57.0.8");

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
           "@babel/traverse": "^7.29.0"
         }
       },
-      "react-native-edge-to-edge@1.8.1": {
+      "react-native-edge-to-edge@*": {
         "dependencies": {
           "@expo/config-plugins": "57.0.2"
         }

--- a/package.json
+++ b/package.json
@@ -80,6 +80,11 @@
           "@babel/generator": "^7.29.0",
           "@babel/traverse": "^7.29.0"
         }
+      },
+      "react-native-edge-to-edge@1.8.1": {
+        "dependencies": {
+          "@expo/config-plugins": "57.0.2"
+        }
       }
     }
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,7 +4,7 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
-packageExtensionsChecksum: sha256-1CngTZLRS9qvep0/fdC3WF9ToCN5NcY8SdWmmTj+TsI=
+packageExtensionsChecksum: sha256-m9DsuDtJANdLytZP9n/Bml4jTXvRcMW5PxlVKX5MJog=
 
 importers:
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,7 +4,7 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
-packageExtensionsChecksum: sha256-wLqXSVmkilrdaFVnHMVp7QdrSqeU9Y+rpgJFLNbEycI=
+packageExtensionsChecksum: sha256-1CngTZLRS9qvep0/fdC3WF9ToCN5NcY8SdWmmTj+TsI=
 
 importers:
 
@@ -190,7 +190,7 @@ importers:
         version: 0.86.0(@babel/core@7.29.0)(@react-native/jest-preset@0.86.0(@babel/core@7.29.0)(@react-native/metro-config@0.86.0(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(@react-native/metro-config@0.86.0(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)
       react-native-edge-to-edge:
         specifier: ^1.8.1
-        version: 1.8.1(react-native@0.86.0(@babel/core@7.29.0)(@react-native/jest-preset@0.86.0(@babel/core@7.29.0)(@react-native/metro-config@0.86.0(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(@react-native/metro-config@0.86.0(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
+        version: 1.8.1(react-native@0.86.0(@babel/core@7.29.0)(@react-native/jest-preset@0.86.0(@babel/core@7.29.0)(@react-native/metro-config@0.86.0(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(@react-native/metro-config@0.86.0(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)(typescript@6.0.3)
       react-native-gesture-handler:
         specifier: ~2.32.0
         version: 2.32.0(react-native@0.86.0(@babel/core@7.29.0)(@react-native/jest-preset@0.86.0(@babel/core@7.29.0)(@react-native/metro-config@0.86.0(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(@react-native/metro-config@0.86.0(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
@@ -211,7 +211,7 @@ importers:
         version: 15.15.4(react-native@0.86.0(@babel/core@7.29.0)(@react-native/jest-preset@0.86.0(@babel/core@7.29.0)(@react-native/metro-config@0.86.0(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(@react-native/metro-config@0.86.0(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
       react-native-unistyles:
         specifier: ^3.2.5
-        version: 3.2.5(7e932caecd62553e3cdf74de9feb2bc1)
+        version: 3.2.5(b59c8985068fdddd53b0996b431c3928)
       react-native-web:
         specifier: ^0.21.0
         version: 0.21.2(encoding@0.1.13)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -29660,10 +29660,14 @@ snapshots:
       use-latest-callback: 0.2.6(react@19.2.6)
     optional: true
 
-  react-native-edge-to-edge@1.8.1(react-native@0.86.0(@babel/core@7.29.0)(@react-native/jest-preset@0.86.0(@babel/core@7.29.0)(@react-native/metro-config@0.86.0(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(@react-native/metro-config@0.86.0(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3):
+  react-native-edge-to-edge@1.8.1(react-native@0.86.0(@babel/core@7.29.0)(@react-native/jest-preset@0.86.0(@babel/core@7.29.0)(@react-native/metro-config@0.86.0(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(@react-native/metro-config@0.86.0(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)(typescript@6.0.3):
     dependencies:
+      '@expo/config-plugins': 57.0.2(typescript@6.0.3)
       react: 19.2.3
       react-native: 0.86.0(@babel/core@7.29.0)(@react-native/jest-preset@0.86.0(@babel/core@7.29.0)(@react-native/metro-config@0.86.0(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(@react-native/metro-config@0.86.0(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
 
   react-native-gesture-handler@2.32.0(react-native@0.86.0(@babel/core@7.29.0)(@react-native/jest-preset@0.86.0(@babel/core@7.29.0)(@react-native/metro-config@0.86.0(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(@react-native/metro-config@0.86.0(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3):
     dependencies:
@@ -29751,7 +29755,7 @@ snapshots:
       react-native: 0.86.0(@babel/core@7.29.0)(@react-native/jest-preset@0.86.0(@babel/core@7.29.0)(@react-native/metro-config@0.86.0(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(@react-native/metro-config@0.86.0(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)
       warn-once: 0.1.1
 
-  react-native-unistyles@3.2.5(7e932caecd62553e3cdf74de9feb2bc1):
+  react-native-unistyles@3.2.5(b59c8985068fdddd53b0996b431c3928):
     dependencies:
       '@babel/types': 7.29.0
       '@react-native/normalize-colors': 0.86.0
@@ -29759,7 +29763,7 @@ snapshots:
       react-native: 0.86.0(@babel/core@7.29.0)(@react-native/jest-preset@0.86.0(@babel/core@7.29.0)(@react-native/metro-config@0.86.0(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(@react-native/metro-config@0.86.0(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)
       react-native-nitro-modules: 0.35.9(react-native@0.86.0(@babel/core@7.29.0)(@react-native/jest-preset@0.86.0(@babel/core@7.29.0)(@react-native/metro-config@0.86.0(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(@react-native/metro-config@0.86.0(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
     optionalDependencies:
-      react-native-edge-to-edge: 1.8.1(react-native@0.86.0(@babel/core@7.29.0)(@react-native/jest-preset@0.86.0(@babel/core@7.29.0)(@react-native/metro-config@0.86.0(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(@react-native/metro-config@0.86.0(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
+      react-native-edge-to-edge: 1.8.1(react-native@0.86.0(@babel/core@7.29.0)(@react-native/jest-preset@0.86.0(@babel/core@7.29.0)(@react-native/metro-config@0.86.0(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(@react-native/metro-config@0.86.0(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)(typescript@6.0.3)
       react-native-reanimated: 4.5.0(react-native-worklets@0.10.0(@babel/core@7.29.0)(@react-native/metro-config@0.86.0(@babel/core@7.29.0))(react-native@0.86.0(@babel/core@7.29.0)(@react-native/jest-preset@0.86.0(@babel/core@7.29.0)(@react-native/metro-config@0.86.0(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(@react-native/metro-config@0.86.0(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3))(react-native@0.86.0(@babel/core@7.29.0)(@react-native/jest-preset@0.86.0(@babel/core@7.29.0)(@react-native/metro-config@0.86.0(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(@react-native/metro-config@0.86.0(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
 
   react-native-url-polyfill@2.0.0(react-native@0.86.0(@babel/core@7.29.0)(@react-native/jest-preset@0.86.0(@babel/core@7.29.0)(@react-native/metro-config@0.86.0(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(@react-native/metro-config@0.86.0(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)):

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -27,13 +27,9 @@ minimumReleaseAgeExclude:
 
 shamefullyHoist: true
 
-# Expo config plugins are loaded from the plugin package's own module scope.
-# Declare the package's implicit dependency so local global-store worktrees can
-# evaluate app.json before EAS uploads the project.
-packageExtensions:
-  "react-native-edge-to-edge@1.8.1":
-    dependencies:
-      "@expo/config-plugins": 57.0.2
+# NOTE: packageExtensions live in the root package.json under `pnpm`, not here.
+# With `enableGlobalVirtualStore` this file's `packageExtensions` block was
+# silently ignored, so the entries there had no effect on the installed tree.
 
 # Tests at the workspace root (tests/integrations/*) import packages that
 # are direct dependencies of workspace sub-packages (e.g. hono, @pipedream/sdk,


### PR DESCRIPTION
## Why

`eas build --platform ios --profile production` fails immediately:

```
expo/bin/cli config --json exited with non-zero code: 1
  PluginError: Cannot find module '@expo/config-plugins'
  at react-native-edge-to-edge/dist/commonjs/extras/expo.js
```

EAS resolves the project config by shelling out to the expo CLI **from the pnpm store**, where each package only sees dependencies it declares. `react-native-edge-to-edge`'s Expo plugin requires `@expo/config-plugins` without declaring it.

The workspace already carried exactly this extension — with a comment saying it exists so "local global-store worktrees can evaluate app.json before EAS uploads the project" — but it lived in `pnpm-workspace.yaml`, whose `packageExtensions` block pnpm silently ignores in this configuration. Inspecting the installed tree confirms it never applied: the store instance contained only `react`, `react-native`, and itself.

## What changed

- Moved the extension to the root `package.json` under `pnpm.packageExtensions`, where extensions demonstrably apply (the store instance now contains `@expo`).
- Replaced the dead `pnpm-workspace.yaml` block with a note, so the next person does not re-add entries to a file that ignores them.
- Added tests covering both halves: the extension is declared in `package.json`, and `pnpm-workspace.yaml` has no `packageExtensions` block.

## Invariants

- **Source of truth**: root `package.json` `pnpm.packageExtensions` is the only honoured location in this workspace. The test enforces that the other location stays empty.
- **Deferred scope**: no attempt to re-enable `pnpm-workspace.yaml` extensions or change `enableGlobalVirtualStore`. This only relocates an entry that was already intended to exist.

## Verification

- Before: `expo config --json` invoked from the store path fails with `Cannot find module '@expo/config-plugins'`.
- After: the same invocation returns the full resolved config.
- `pnpm --dir apps/mobile exec jest --runInBand` — 56 suites / 609 tests pass.
- `bun run check:patterns` — 0 violations.