### PR TITLE
fix(terminal): track live agent process transitions

### DIFF
--- a/packages/gateway/src/shell/agent-session-state.ts
+++ b/packages/gateway/src/shell/agent-session-state.ts
@@ -105,6 +105,7 @@ export function deriveAgentVisualStatus(
   unread: boolean,
 ): AgentDerivedVisualStatus | null {
   if (!snapshot) return null;
+  if (snapshot.phase === "ended") return null;
   if (snapshot.phase === "started") return "idle";
   if (snapshot.phase === "waiting") return "waiting";
   if (snapshot.phase === "running") return "running";
@@ -149,15 +150,17 @@ export class AgentSessionStateStore {
         return current;
       }
 
+      const resetEnrichment = event.type === "session-started" || current?.agent !== event.agent;
+
       const next: AgentSessionSnapshot = AgentSessionSnapshotSchema.parse({
         version: 1,
         sessionName,
         agent: event.agent,
         phase: phaseForEvent(event.type, current?.phase),
-        ...(current?.subtitle ? { subtitle: current.subtitle } : {}),
-        ...(current?.lastAction ? { lastAction: current.lastAction } : {}),
-        ...(current?.model ? { model: current.model } : {}),
-        ...(current?.strength ? { strength: current.strength } : {}),
+        ...(!resetEnrichment && current?.subtitle ? { subtitle: current.subtitle } : {}),
+        ...(!resetEnrichment && current?.lastAction ? { lastAction: current.lastAction } : {}),
+        ...(!resetEnrichment && current?.model ? { model: current.model } : {}),
+        ...(!resetEnrichment && current?.strength ? { strength: current.strength } : {}),
         ...(event.subtitle !== undefined
           ? optionalProperty("subtitle", sanitizeAgentSubtitle(event.subtitle))
           : {}),

--- a/packages/gateway/src/shell/focused-pane-runtime.ts
+++ b/packages/gateway/src/shell/focused-pane-runtime.ts
@@ -1,0 +1,11 @@
+export interface FocusedPaneRuntimeObservation {
+  cwd: string | null;
+  command: string | null;
+  observed: boolean;
+}
+
+export const UNAVAILABLE_FOCUSED_PANE_RUNTIME: FocusedPaneRuntimeObservation = {
+  cwd: null,
+  command: null,
+  observed: false,
+};

--- a/packages/gateway/src/shell/registry.ts
+++ b/packages/gateway/src/shell/registry.ts
@@ -3,6 +3,10 @@ import { join } from "node:path";
 import { z } from "zod/v4";
 import { writeUtf8FileAtomic } from "./atomic-write.js";
 import {
+  UNAVAILABLE_FOCUSED_PANE_RUNTIME,
+  type FocusedPaneRuntimeObservation,
+} from "./focused-pane-runtime.js";
+import {
   AgentKindSchema,
   AgentSessionStateStore,
   deriveAgentVisualStatus,
@@ -31,7 +35,7 @@ const MAX_CONCURRENT_SESSION_DECORATIONS = 8;
 
 export interface ShellRegistryAdapter {
   listSessions(): Promise<string[]>;
-  focusedPaneCwd?(name: string): Promise<string | null>;
+  focusedPaneRuntime?(name: string): Promise<FocusedPaneRuntimeObservation>;
   createSession(options: { name: string; cwd?: string; layout?: string; cmd?: string }): Promise<void>;
   deleteSession(name: string, options?: { force?: boolean }): Promise<void>;
   renameSession?(name: string, nextName: string): Promise<void>;
@@ -95,6 +99,7 @@ export type ShellSession = Omit<PersistedShellSession, "cwd"> & {
   references: ShellSessionReference[];
   recoverable: boolean;
   recoveryReason?: "missing_runtime_session";
+  /** Agent currently observed in the focused pane, not the persisted launch provider. */
   agent?: AgentKind;
   subtitle?: string;
   lastAction?: string;
@@ -518,28 +523,51 @@ export class ShellRegistry {
   }
 
   private async decorateSession(session: PersistedShellSession, file?: RegistryFile): Promise<ShellSession> {
-    const [activity, agentSnapshot, focusedPaneCwd] = await Promise.all([
+    const [activity, agentSnapshot, focusedPaneRuntime] = await Promise.all([
       this.options.scrollbackStore?.latestActivity?.(session.name),
       this.readAgentSnapshot(session.name),
-      this.readFocusedPaneCwd(session.name),
+      this.readFocusedPaneRuntime(session.name),
     ]);
     const latestSeq = activity?.latestSeq ?? await this.options.scrollbackStore?.latestSeq(session.name) ?? null;
     const lastSeenSeq = session.lastSeenSeq ?? session.lastSeq ?? latestSeq;
     const unread = latestSeq !== null && lastSeenSeq !== null && latestSeq > lastSeenSeq;
     const references = file ? this.referencesForTarget(file, session.name) : [];
     const recoverable = session.status === "exited" && references.length > 0;
-    const gitContext = await this.readGitContext({ sessionName: session.name, cwd: focusedPaneCwd ?? session.cwd });
-    const visualStatus = deriveAgentVisualStatus(agentSnapshot, unread)
+    const gitContext = await this.readGitContext({
+      sessionName: session.name,
+      cwd: focusedPaneRuntime.cwd ?? session.cwd,
+    });
+    const observedAgent = focusedPaneRuntime.observed
+      ? inferAgentFromCommand(focusedPaneRuntime.command ?? undefined)
+      : undefined;
+    const compatibleSnapshot = agentSnapshot?.phase !== "ended" && (
+      focusedPaneRuntime.observed
+        ? agentSnapshot?.agent === observedAgent
+        : Boolean(agentSnapshot)
+    ) ? agentSnapshot : null;
+    const launchHintAgent = !focusedPaneRuntime.observed
+      && !agentSnapshot
+      && session.agent
+      && isRecentShellTimestamp(session.updatedAt, SHELL_RUNNING_FALLBACK_WINDOW_MS)
+      ? session.agent
+      : undefined;
+    const liveAgent = focusedPaneRuntime.observed
+      ? observedAgent
+      : compatibleSnapshot?.agent ?? launchHintAgent;
+    const agentVisualStatus = liveAgent
+      ? deriveAgentVisualStatus(compatibleSnapshot, unread) ?? "running"
+      : null;
+    const visualStatus = agentVisualStatus
       ?? this.deriveVisualStatus(session, unread, activity);
-    const { cwd: _internalCwd, ...publicSession } = session;
+    const { cwd: _internalCwd, agent: _launchHint, ...publicSession } = session;
     return {
       ...publicSession,
-      ...(agentSnapshot?.agent ? { agent: agentSnapshot.agent } : {}),
-      ...(agentSnapshot?.subtitle ? { subtitle: agentSnapshot.subtitle } : {}),
-      ...(agentSnapshot?.lastAction ? { lastAction: agentSnapshot.lastAction } : {}),
-      ...(agentSnapshot?.agentUpdatedAt ? { agentUpdatedAt: agentSnapshot.agentUpdatedAt } : {}),
-      ...(agentSnapshot?.model ? { model: agentSnapshot.model } : {}),
-      ...(agentSnapshot?.strength ? { strength: agentSnapshot.strength } : {}),
+      ...(liveAgent ? { agent: liveAgent } : {}),
+      ...(compatibleSnapshot?.subtitle ? { subtitle: compatibleSnapshot.subtitle } : {}),
+      ...(compatibleSnapshot?.lastAction ? { lastAction: compatibleSnapshot.lastAction } : {}),
+      ...(compatibleSnapshot?.agentUpdatedAt ? { agentUpdatedAt: compatibleSnapshot.agentUpdatedAt } : {}),
+      ...(compatibleSnapshot?.model ? { model: compatibleSnapshot.model } : {}),
+      ...(compatibleSnapshot?.strength ? { strength: compatibleSnapshot.strength } : {}),
       ...(gitContext?.project ? { project: gitContext.project } : {}),
       ...(gitContext?.repository ? { repository: gitContext.repository } : {}),
       ...(gitContext?.branch ? { branch: gitContext.branch } : {}),
@@ -806,17 +834,26 @@ export class ShellRegistry {
     }
   }
 
-  private async readFocusedPaneCwd(name: string): Promise<string | null> {
-    if (!this.options.adapter.focusedPaneCwd) return null;
+  private async readFocusedPaneRuntime(name: string): Promise<FocusedPaneRuntimeObservation> {
+    if (!this.options.adapter.focusedPaneRuntime) return UNAVAILABLE_FOCUSED_PANE_RUNTIME;
     try {
-      const cwd = await this.options.adapter.focusedPaneCwd(name);
-      return cwd ? await resolveShellCwd(cwd, this.options.homePath) : null;
+      const runtime = await this.options.adapter.focusedPaneRuntime(name);
+      if (!runtime.cwd) return runtime;
+      try {
+        return { ...runtime, cwd: await resolveShellCwd(runtime.cwd, this.options.homePath) };
+      } catch (err: unknown) {
+        console.warn(
+          "[shell] focused pane cwd unavailable:",
+          err instanceof Error ? err.message : String(err),
+        );
+        return { ...runtime, cwd: null };
+      }
     } catch (err: unknown) {
       console.warn(
-        "[shell] focused pane cwd unavailable:",
+        "[shell] focused pane runtime unavailable:",
         err instanceof Error ? err.message : String(err),
       );
-      return null;
+      return UNAVAILABLE_FOCUSED_PANE_RUNTIME;
     }
   }
 
@@ -848,13 +885,34 @@ export function inferAgentFromCommand(command: string | undefined): AgentKind | 
     token.replace(/^(?:"(.*)"|'(.*)')$/, "$1$2")
   )) ?? [];
   let index = 0;
-  const usesEnv = tokens[index]?.split("/").pop() === "env";
-  if (usesEnv) index += 1;
-  while (
-    index < tokens.length &&
-    (/^[A-Za-z_][A-Za-z0-9_]*=/.test(tokens[index]) || (usesEnv && tokens[index].startsWith("-")))
-  ) {
+  if (tokens[index]?.split("/").pop() === "env") {
     index += 1;
+    while (index < tokens.length) {
+      const token = tokens[index];
+      if (/^[A-Za-z_][A-Za-z0-9_]*=/.test(token)) {
+        index += 1;
+        continue;
+      }
+      if (token === "--") {
+        index += 1;
+        break;
+      }
+      if (token === "-i" || token === "--ignore-environment" || token === "-0" || token === "--null") {
+        index += 1;
+        continue;
+      }
+      if (/^(?:--unset|--chdir)=/.test(token) || /^-[uC].+/.test(token)) {
+        index += 1;
+        continue;
+      }
+      if (token === "-u" || token === "--unset" || token === "-C" || token === "--chdir") {
+        if (tokens[index + 1] === undefined) return undefined;
+        index += 2;
+        continue;
+      }
+      if (token.startsWith("-")) return undefined;
+      break;
+    }
   }
   const executable = tokens[index]?.split("/").pop();
   const parsed = AgentKindSchema.safeParse(executable);

--- a/packages/gateway/src/shell/registry.ts
+++ b/packages/gateway/src/shell/registry.ts
@@ -918,7 +918,22 @@ export function inferAgentFromCommand(command: string | undefined): AgentKind | 
   }
   const executable = tokens[index]?.split("/").pop();
   const parsed = AgentKindSchema.safeParse(executable);
-  return parsed.success ? parsed.data : undefined;
+  if (parsed.success) return parsed.data;
+
+  const wrappedScript = tokens[index + 1];
+  const matrixNodePrefix = process.env.MATRIX_NODE_PREFIX?.trim() || "/opt/matrix/runtime/node";
+  const managedCodexLaunchers = [
+    join(matrixNodePrefix, "bin", "codex"),
+    join(matrixNodePrefix, "lib", "node_modules", "@openai", "codex", "bin", "codex.js"),
+  ];
+  if (
+    executable === "node"
+    && wrappedScript !== undefined
+    && managedCodexLaunchers.includes(wrappedScript)
+  ) {
+    return "codex";
+  }
+  return undefined;
 }
 
 function inferAliasSource(name: string): ShellSessionAliasSource {

--- a/packages/gateway/src/shell/registry.ts
+++ b/packages/gateway/src/shell/registry.ts
@@ -540,11 +540,13 @@ export class ShellRegistry {
     const observedAgent = focusedPaneRuntime.observed
       ? inferAgentFromCommand(focusedPaneRuntime.command ?? undefined)
       : undefined;
-    const compatibleSnapshot = agentSnapshot?.phase !== "ended" && (
-      focusedPaneRuntime.observed
-        ? agentSnapshot?.agent === observedAgent
-        : Boolean(agentSnapshot)
-    ) ? agentSnapshot : null;
+    const compatibleSnapshot = agentSnapshot
+      && agentSnapshot.phase !== "ended"
+      && (!focusedPaneRuntime.observed || (
+        observedAgent !== undefined && agentSnapshot.agent === observedAgent
+      ))
+      ? agentSnapshot
+      : null;
     const launchHintAgent = !focusedPaneRuntime.observed
       && !agentSnapshot
       && session.agent

--- a/packages/gateway/src/shell/zellij.ts
+++ b/packages/gateway/src/shell/zellij.ts
@@ -113,6 +113,9 @@ export interface ZellijAdapter {
   setShellTheme(themeId: MatrixZellijShellThemeId): Promise<void>;
 }
 
+const ZellijTabInfoSchema = z.object({
+  tab_id: z.number().int().nonnegative(),
+}).passthrough();
 const ZellijPaneListSchema = z.array(z.object({
   is_plugin: z.boolean(),
   is_focused: z.boolean(),
@@ -294,6 +297,22 @@ export function createZellijAdapter(deps: ZellijAdapterDeps = {}): ZellijAdapter
   let ensureConfigPromise: Promise<void> | null = null;
   let shellThemeId: MatrixZellijShellThemeId = "dark";
 
+  function cacheFocusedPaneRuntime(
+    name: string,
+    value: FocusedPaneRuntimeObservation,
+  ): FocusedPaneRuntimeObservation {
+    while (focusedPaneRuntimeCache.size >= MAX_FOCUSED_PANE_RUNTIME_CACHE_ENTRIES) {
+      const oldest = focusedPaneRuntimeCache.keys().next().value as string | undefined;
+      if (!oldest) break;
+      focusedPaneRuntimeCache.delete(oldest);
+    }
+    focusedPaneRuntimeCache.set(name, {
+      expiresAt: nowMs() + FOCUSED_PANE_RUNTIME_CACHE_TTL_MS,
+      value,
+    });
+    return value;
+  }
+
   async function ensureMatrixZellijConfig(): Promise<void> {
     if (!zellijConfigPaths) {
       return;
@@ -451,38 +470,31 @@ export function createZellijAdapter(deps: ZellijAdapterDeps = {}): ZellijAdapter
         if (!panes.success) {
           throw new Error("Invalid focused pane runtime response");
         }
-        const focusedPane = panes.data.find((pane) => (
-          !pane.is_plugin && pane.is_focused
-        ));
+        const focusedPanes = panes.data.filter((pane) => !pane.is_plugin && pane.is_focused);
+        let focusedPane = focusedPanes.length === 1 ? focusedPanes[0] : undefined;
+        if (focusedPanes.length > 1) {
+          const tabJson = await run(["--session", name, "action", "current-tab-info", "--json"]);
+          const tab = ZellijTabInfoSchema.safeParse(JSON.parse(tabJson));
+          if (!tab.success) {
+            throw new Error("Invalid focused tab runtime response");
+          }
+          focusedPane = focusedPanes.find((pane) => pane.tab_id === tab.data.tab_id);
+        }
+        if (!focusedPane?.pane_command) {
+          console.warn("[shell] focused pane command unavailable");
+          return cacheFocusedPaneRuntime(name, UNAVAILABLE_FOCUSED_PANE_RUNTIME);
+        }
         const value: FocusedPaneRuntimeObservation = {
-          cwd: focusedPane?.pane_cwd ?? null,
-          command: focusedPane?.pane_command ?? null,
+          cwd: focusedPane.pane_cwd ?? null,
+          command: focusedPane.pane_command,
           observed: true,
         };
-        while (focusedPaneRuntimeCache.size >= MAX_FOCUSED_PANE_RUNTIME_CACHE_ENTRIES) {
-          const oldest = focusedPaneRuntimeCache.keys().next().value as string | undefined;
-          if (!oldest) break;
-          focusedPaneRuntimeCache.delete(oldest);
-        }
-        focusedPaneRuntimeCache.set(name, {
-          expiresAt: nowMs() + FOCUSED_PANE_RUNTIME_CACHE_TTL_MS,
-          value,
-        });
-        return value;
+        return cacheFocusedPaneRuntime(name, value);
       } catch (err: unknown) {
         if (!(err instanceof Error && "code" in err && (err as { code?: unknown }).code === "zellij_failed")) {
           console.warn("[shell] focused pane runtime unavailable:", err instanceof Error ? err.message : String(err));
         }
-        while (focusedPaneRuntimeCache.size >= MAX_FOCUSED_PANE_RUNTIME_CACHE_ENTRIES) {
-          const oldest = focusedPaneRuntimeCache.keys().next().value as string | undefined;
-          if (!oldest) break;
-          focusedPaneRuntimeCache.delete(oldest);
-        }
-        focusedPaneRuntimeCache.set(name, {
-          expiresAt: nowMs() + FOCUSED_PANE_RUNTIME_CACHE_TTL_MS,
-          value: UNAVAILABLE_FOCUSED_PANE_RUNTIME,
-        });
-        return UNAVAILABLE_FOCUSED_PANE_RUNTIME;
+        return cacheFocusedPaneRuntime(name, UNAVAILABLE_FOCUSED_PANE_RUNTIME);
       }
     },
     async createSession(options) {

--- a/packages/gateway/src/shell/zellij.ts
+++ b/packages/gateway/src/shell/zellij.ts
@@ -21,6 +21,10 @@ import {
   type MatrixZellijConfigPaths,
 } from "./zellij-config.js";
 import { applyTerminalTruecolorEnv } from "../terminal-env.js";
+import {
+  UNAVAILABLE_FOCUSED_PANE_RUNTIME,
+  type FocusedPaneRuntimeObservation,
+} from "./focused-pane-runtime.js";
 
 type ExecFile = typeof nodeExecFile;
 type Disposable = { dispose(): void };
@@ -91,7 +95,7 @@ export interface AttachOptions {
 export interface ZellijAdapter {
   health(): Promise<{ ok: boolean; code: "ok" | "zellij_failed" }>;
   listSessions(): Promise<string[]>;
-  focusedPaneCwd(name: string): Promise<string | null>;
+  focusedPaneRuntime(name: string): Promise<FocusedPaneRuntimeObservation>;
   createSession(options: CreateSessionOptions): Promise<void>;
   deleteSession(name: string, options?: { force?: boolean }): Promise<void>;
   renameSession(name: string, nextName: string): Promise<void>;
@@ -117,6 +121,7 @@ const ZellijPaneListSchema = z.array(z.object({
   is_focused: z.boolean(),
   tab_id: z.number().int().nonnegative(),
   pane_cwd: z.string().min(1).max(4096).nullable().optional(),
+  pane_command: z.string().trim().min(1).max(4096).nullable().optional(),
 }).passthrough()).max(256);
 
 const SAFE_ATTACH_ENV_KEYS = new Set([
@@ -149,8 +154,8 @@ const ZELLIJ_CONTEXT_ENV_KEYS = new Set([
 const DEFAULT_STARTUP_DELAY_MS = 500;
 const DEFAULT_RETAINED_PTY_TTL_MS = 4 * 60 * 60 * 1000;
 const DEFAULT_MAX_RETAINED_PTYS = 128;
-const FOCUSED_PANE_CWD_CACHE_TTL_MS = 15_000;
-const MAX_FOCUSED_PANE_CWD_CACHE_ENTRIES = 128;
+const FOCUSED_PANE_RUNTIME_CACHE_TTL_MS = 4_000;
+const MAX_FOCUSED_PANE_RUNTIME_CACHE_ENTRIES = 128;
 type RetainedCreatePty = {
   process: ShellAttachProcess;
   startedAtMs: number;
@@ -284,7 +289,10 @@ export function createZellijAdapter(deps: ZellijAdapterDeps = {}): ZellijAdapter
   const cwd = deps.cwd ?? process.cwd();
   const spawnPty = deps.spawnPty ?? defaultPtySpawn();
   const retainedCreatePtys = new Map<string, RetainedCreatePty>();
-  const focusedPaneCwdCache = new Map<string, { expiresAt: number; value: string | null }>();
+  const focusedPaneRuntimeCache = new Map<string, {
+    expiresAt: number;
+    value: FocusedPaneRuntimeObservation;
+  }>();
   const zellijConfigPaths = deps.homePath ? matrixZellijConfigPaths(deps.homePath) : null;
   let ensureConfigPromise: Promise<void> | null = null;
   let shellThemeId: MatrixZellijShellThemeId = "dark";
@@ -432,14 +440,14 @@ export function createZellijAdapter(deps: ZellijAdapterDeps = {}): ZellijAdapter
         .map((line) => line.trim().split(/\s+/)[0])
         .filter(Boolean);
     },
-    async focusedPaneCwd(name) {
-      const cached = focusedPaneCwdCache.get(name);
+    async focusedPaneRuntime(name) {
+      const cached = focusedPaneRuntimeCache.get(name);
       if (cached && cached.expiresAt > nowMs()) {
-        focusedPaneCwdCache.delete(name);
-        focusedPaneCwdCache.set(name, cached);
+        focusedPaneRuntimeCache.delete(name);
+        focusedPaneRuntimeCache.set(name, cached);
         return cached.value;
       }
-      if (cached) focusedPaneCwdCache.delete(name);
+      if (cached) focusedPaneRuntimeCache.delete(name);
       try {
         const [tabJson, panesJson] = await Promise.all([
           run(["--session", name, "action", "current-tab-info", "--json"]),
@@ -447,27 +455,41 @@ export function createZellijAdapter(deps: ZellijAdapterDeps = {}): ZellijAdapter
         ]);
         const tab = ZellijTabInfoSchema.safeParse(JSON.parse(tabJson));
         const panes = ZellijPaneListSchema.safeParse(JSON.parse(panesJson));
-        const value = tab.success && panes.success ? panes.data.find((pane) => (
-          !pane.is_plugin && pane.is_focused && pane.tab_id === tab.data.tab_id && pane.pane_cwd
-        ))?.pane_cwd ?? null : null;
-        while (focusedPaneCwdCache.size >= MAX_FOCUSED_PANE_CWD_CACHE_ENTRIES) {
-          const oldest = focusedPaneCwdCache.keys().next().value as string | undefined;
-          if (!oldest) break;
-          focusedPaneCwdCache.delete(oldest);
+        if (!tab.success || !panes.success) {
+          throw new Error("Invalid focused pane runtime response");
         }
-        focusedPaneCwdCache.set(name, { expiresAt: nowMs() + FOCUSED_PANE_CWD_CACHE_TTL_MS, value });
+        const focusedPane = panes.data.find((pane) => (
+          !pane.is_plugin && pane.is_focused && pane.tab_id === tab.data.tab_id
+        ));
+        const value: FocusedPaneRuntimeObservation = {
+          cwd: focusedPane?.pane_cwd ?? null,
+          command: focusedPane?.pane_command ?? null,
+          observed: true,
+        };
+        while (focusedPaneRuntimeCache.size >= MAX_FOCUSED_PANE_RUNTIME_CACHE_ENTRIES) {
+          const oldest = focusedPaneRuntimeCache.keys().next().value as string | undefined;
+          if (!oldest) break;
+          focusedPaneRuntimeCache.delete(oldest);
+        }
+        focusedPaneRuntimeCache.set(name, {
+          expiresAt: nowMs() + FOCUSED_PANE_RUNTIME_CACHE_TTL_MS,
+          value,
+        });
         return value;
       } catch (err: unknown) {
         if (!(err instanceof Error && "code" in err && (err as { code?: unknown }).code === "zellij_failed")) {
-          console.warn("[shell] focused pane cwd unavailable:", err instanceof Error ? err.message : String(err));
+          console.warn("[shell] focused pane runtime unavailable:", err instanceof Error ? err.message : String(err));
         }
-        while (focusedPaneCwdCache.size >= MAX_FOCUSED_PANE_CWD_CACHE_ENTRIES) {
-          const oldest = focusedPaneCwdCache.keys().next().value as string | undefined;
+        while (focusedPaneRuntimeCache.size >= MAX_FOCUSED_PANE_RUNTIME_CACHE_ENTRIES) {
+          const oldest = focusedPaneRuntimeCache.keys().next().value as string | undefined;
           if (!oldest) break;
-          focusedPaneCwdCache.delete(oldest);
+          focusedPaneRuntimeCache.delete(oldest);
         }
-        focusedPaneCwdCache.set(name, { expiresAt: nowMs() + FOCUSED_PANE_CWD_CACHE_TTL_MS, value: null });
-        return null;
+        focusedPaneRuntimeCache.set(name, {
+          expiresAt: nowMs() + FOCUSED_PANE_RUNTIME_CACHE_TTL_MS,
+          value: UNAVAILABLE_FOCUSED_PANE_RUNTIME,
+        });
+        return UNAVAILABLE_FOCUSED_PANE_RUNTIME;
       }
     },
     async createSession(options) {

--- a/packages/gateway/src/shell/zellij.ts
+++ b/packages/gateway/src/shell/zellij.ts
@@ -113,9 +113,6 @@ export interface ZellijAdapter {
   setShellTheme(themeId: MatrixZellijShellThemeId): Promise<void>;
 }
 
-const ZellijTabInfoSchema = z.object({
-  tab_id: z.number().int().nonnegative(),
-}).passthrough();
 const ZellijPaneListSchema = z.array(z.object({
   is_plugin: z.boolean(),
   is_focused: z.boolean(),
@@ -449,17 +446,13 @@ export function createZellijAdapter(deps: ZellijAdapterDeps = {}): ZellijAdapter
       }
       if (cached) focusedPaneRuntimeCache.delete(name);
       try {
-        const [tabJson, panesJson] = await Promise.all([
-          run(["--session", name, "action", "current-tab-info", "--json"]),
-          run(["--session", name, "action", "list-panes", "--all", "--json"]),
-        ]);
-        const tab = ZellijTabInfoSchema.safeParse(JSON.parse(tabJson));
+        const panesJson = await run(["--session", name, "action", "list-panes", "--all", "--json"]);
         const panes = ZellijPaneListSchema.safeParse(JSON.parse(panesJson));
-        if (!tab.success || !panes.success) {
+        if (!panes.success) {
           throw new Error("Invalid focused pane runtime response");
         }
         const focusedPane = panes.data.find((pane) => (
-          !pane.is_plugin && pane.is_focused && pane.tab_id === tab.data.tab_id
+          !pane.is_plugin && pane.is_focused
         ));
         const value: FocusedPaneRuntimeObservation = {
           cwd: focusedPane?.pane_cwd ?? null,

--- a/specs/098-terminal-session-reliability/checklists/requirements.md
+++ b/specs/098-terminal-session-reliability/checklists/requirements.md
@@ -35,3 +35,4 @@
 - Reviewed against `specs/099-shell-connection-resilience/`; this spec owns terminal runtime/session lifecycle, while 099 owns browser-shell live connection resilience.
 - `.specify/feature.json` is intentionally treated as a local active-feature pointer rather than a durable spec artifact.
 - Ready for implementation planning and task generation one slice at a time.
+- Focused-pane live agent precedence and the complete provider-switch lifecycle are specified with degraded fallback, resource bounds, and compatibility criteria.

--- a/specs/098-terminal-session-reliability/implementation-notes.md
+++ b/specs/098-terminal-session-reliability/implementation-notes.md
@@ -4,7 +4,7 @@
 
 ### Focused-Pane Live Agent Detection
 
-The focused Zellij pane's validated foreground command is now the primary source of truth for active terminal agent identity. Exact allowlisted command parsing recognizes Claude, Codex, OpenCode, and Pi, including supported `env` wrappers, without substring matching. Successful shell observations clear every agent-only response field, while recognized processes appear immediately even before provider hooks start.
+The focused Zellij pane's validated foreground command is now the primary source of truth for active terminal agent identity. Exact allowlisted command parsing recognizes Claude, Codex, OpenCode, and Pi, including supported `env` wrappers and the managed npm Codex Node entrypoint, without accepting generic Node scripts or substring matches. Successful shell observations clear every agent-only response field, while recognized processes appear immediately even before provider hooks start.
 
 Provider hooks remain optional enrichment. Matching non-ended snapshots can supply subtitle, action, model, strength, timestamp, and semantic visual status. Mismatched or ended snapshots are not exposed, and a recognized process without compatible enrichment is shown as running. When pane inspection is unavailable, the gateway falls back to a non-ended hook snapshot and then a persisted launch hint for at most 12 seconds.
 
@@ -56,6 +56,7 @@ Rename consumes an existing alias when the canonical session is renamed to that 
 
 - A single session follows `Terminal → Claude → Terminal → Codex → Terminal` within successive five-second refreshes, changing logos and compact card height without retaining the prior provider's metadata.
 - Manually launched agents and first-run/authentication screens receive the correct agent identity before hook metadata exists.
+- VPS Codex sessions installed through the managed npm package expose the Codex identity and matching hook subtitle/model metadata even though Zellij reports the Node launcher as the foreground process-group leader.
 - In multi-pane sessions, the focused pane alone determines which agent appears on the session card.
 
 - A terminal with newer command-start or recent-output evidence shows as running even if old metadata says waiting.

--- a/specs/098-terminal-session-reliability/implementation-notes.md
+++ b/specs/098-terminal-session-reliability/implementation-notes.md
@@ -2,6 +2,14 @@
 
 ## Completed In This PR
 
+### Focused-Pane Live Agent Detection
+
+The focused Zellij pane's validated foreground command is now the primary source of truth for active terminal agent identity. Exact allowlisted command parsing recognizes Claude, Codex, OpenCode, and Pi, including supported `env` wrappers, without substring matching. Successful shell observations clear every agent-only response field, while recognized processes appear immediately even before provider hooks start.
+
+Provider hooks remain optional enrichment. Matching non-ended snapshots can supply subtitle, action, model, strength, timestamp, and semantic visual status. Mismatched or ended snapshots are not exposed, and a recognized process without compatible enrichment is shown as running. When pane inspection is unavailable, the gateway falls back to a non-ended hook snapshot and then a persisted launch hint for at most 12 seconds.
+
+Session-start and provider-change events clear old enrichment before accepting fields from the new event. An ended snapshot no longer derives an active visual status, so correctness does not depend on any provider emitting a session-end event.
+
 ### Sticky Visual Status
 
 Older bundles could persist terminal `visualStatus` metadata such as `waiting` or `running` in `system/shell-sessions.json`. When a newer bundle loaded that owner metadata, the saved visual state could keep a live terminal looking stuck even after current scrollback showed newer command activity, command completion, or a quiet live shell.
@@ -46,6 +54,10 @@ Rename consumes an existing alias when the canonical session is renamed to that 
 
 ## Expected User Experience
 
+- A single session follows `Terminal → Claude → Terminal → Codex → Terminal` within successive five-second refreshes, changing logos and compact card height without retaining the prior provider's metadata.
+- Manually launched agents and first-run/authentication screens receive the correct agent identity before hook metadata exists.
+- In multi-pane sessions, the focused pane alone determines which agent appears on the session card.
+
 - A terminal with newer command-start or recent-output evidence shows as running even if old metadata says waiting.
 - A terminal with command-finished evidence or unread output shows finished/idle according to current scrollback and unread state.
 - A quiet live terminal with old waiting metadata settles back to idle instead of staying visually stuck.
@@ -71,6 +83,8 @@ Rename consumes an existing alias when the canonical session is renamed to that 
 
 ```bash
 bun run test tests/gateway/shell-registry.test.ts
+bun run test tests/gateway/shell-zellij.test.ts
+bun run test tests/gateway/agent-session-state.test.ts
 bun run test tests/gateway/shell-routes.test.ts
 bun run test tests/gateway/terminal-zellij-ws.test.ts
 bun run test tests/shell/terminal-session-state.test.ts

--- a/specs/098-terminal-session-reliability/spec.md
+++ b/specs/098-terminal-session-reliability/spec.md
@@ -199,7 +199,7 @@ A developer can launch and exit different coding agents in the same terminal and
 - **FR-017**: Matrix MUST provide an operator-readable status path for terminal/session health that does not depend solely on direct SSH access to the customer VPS.
 - **FR-018**: Matrix MUST avoid exposing provider errors, raw filesystem paths, or raw runtime failures in user-facing terminal recovery messages.
 - **FR-019**: Matrix MUST derive live agent identity from the focused terminal pane's validated foreground command whenever pane inspection succeeds.
-- **FR-020**: Matrix MUST recognize only the exact allowlisted commands `claude`, `codex`, `opencode`, and `pi`, including safely parsed `env` wrappers, and MUST NOT use substring matching.
+- **FR-020**: Matrix MUST recognize only the exact allowlisted commands `claude`, `codex`, `opencode`, and `pi`, including safely parsed known launchers such as `env` and the managed npm Codex Node entrypoint, and MUST NOT treat generic Node scripts or substring matches as agents.
 - **FR-021**: A successful observation of a shell, missing command, or unrecognized command MUST omit `agent`, `subtitle`, `lastAction`, `agentUpdatedAt`, `model`, and `strength` from the session response.
 - **FR-022**: Hook enrichment MUST be exposed only when its provider matches the observed agent and its phase is not `ended`; an observed recognized agent without compatible enrichment MUST fall back to `running`.
 - **FR-023**: When focused-pane inspection is unavailable, Matrix MAY fall back to a non-ended hook snapshot, then to the persisted launch hint for at most 12 seconds.

--- a/specs/098-terminal-session-reliability/spec.md
+++ b/specs/098-terminal-session-reliability/spec.md
@@ -100,6 +100,25 @@ Engineers can change terminal behavior without editing a giant UI component that
 2. **Given** shell placement changes, **When** the UI updates optimistically and later rolls back, **Then** rollback affects only the fields in the failed mutation.
 3. **Given** session-list state changes, **When** pane layout and workspace-session state are unchanged, **Then** those independent states are not rederived or clobbered by accident.
 
+---
+
+### User Story 6 - Live Focused-Pane Agent Identity (Priority: P1)
+
+A developer can launch and exit different coding agents in the same terminal and the session card follows the focused pane's foreground process within the existing refresh cycle. Provider hooks enrich the card when available but never keep an exited or replaced provider visible.
+
+**Why this priority**: Persisted launch metadata and delayed or missing provider end hooks can leave terminal cards showing the wrong agent, model, or task after the foreground process has changed.
+
+**Independent Test**: Advance one terminal through `Terminal → Claude → Terminal → Codex → Terminal` while polling session summaries every five seconds. Each refresh must show only the currently observed provider and matching enrichment, with plain-terminal layout restored after each agent exits.
+
+**Acceptance Scenarios**:
+
+1. **Given** a plain terminal, **When** Claude is launched manually in its focused pane, **Then** the next refresh identifies Claude even on a first-run or authentication screen with no hook snapshot.
+2. **Given** Claude is observed with matching hook enrichment, **When** Claude exits to the shell, **Then** the next refresh removes the Claude badge, subtitle, action, model, strength, and agent timestamp.
+3. **Given** Claude previously populated enrichment, **When** Codex becomes the focused pane's foreground command, **Then** Codex appears immediately without inheriting any Claude enrichment.
+4. **Given** several panes exist, **When** their foreground commands differ, **Then** only the focused terminal pane determines the session's live agent identity.
+5. **Given** focused-pane inspection is unavailable, **When** a non-ended hook snapshot exists, **Then** Matrix may use that snapshot; otherwise it may use the persisted launch provider for no more than 12 seconds.
+6. **Given** a successful focused-pane observation reports a shell or unrecognized command, **When** stale hook or launch metadata exists, **Then** runtime truth wins and the response omits every agent-specific field.
+
 ### Edge Cases
 
 - A user upgrades with old saved `waiting` or `running` metadata from a previous release.
@@ -117,6 +136,10 @@ Engineers can change terminal behavior without editing a giant UI component that
 - A terminal delete succeeds server-side but the client refresh fails.
 - A terminal delete fails and the optimistic UI has already removed the row.
 - The runtime host is reachable but session-listing is temporarily degraded.
+- A recognized agent is displaying setup, first-run, or authentication UI before hooks start.
+- The focused pane changes while another pane continues running an agent.
+- Zellij returns malformed pane JSON, a missing command, or a command wrapped with `env`.
+- A provider changes without the prior provider emitting a session-end hook.
 
 ## Requirements *(mandatory)*
 
@@ -134,6 +157,7 @@ Engineers can change terminal behavior without editing a giant UI component that
 - **F-010 Insufficient upgrade-state tests**: Current tests cover many fresh-state flows, but not enough upgraded persisted-state cases where old metadata survives into a new bundle.
 - **F-011 Incomplete end-to-end lifecycle proof**: There is no single acceptance test proving a process keeps running across tab switch, backgrounding, refresh, reconnect, and return.
 - **F-012 Operational diagnosis dependency**: Live incident diagnosis can be blocked when the expected smoke SSH key no longer authenticates, so platform-side and product-side evidence paths need to be stronger.
+- **F-013 Persisted agent identity masquerades as live state**: The saved launch provider and non-authoritative hook snapshots can outlive the foreground process, causing stale badges and cross-provider metadata leakage.
 
 ### One-by-One Work Order
 
@@ -143,6 +167,7 @@ Engineers can change terminal behavior without editing a giant UI component that
 4. **Slice 4: Make stale refresh visible and recoverable** - Covers F-004, F-005, and F-008. Deliver stale-state UX and field-scoped optimistic rollback behavior for terminal session list refresh, delete, rename, reorder, placement, and seen-state operations.
 5. **Slice 5: Extract terminal state seams** - Covers F-007. Deliver testable terminal session state helpers or stores that isolate shell/session refresh behavior from unrelated file, project, and agent-menu state.
 6. **Slice 6: Add non-SSH operational diagnostics** - Covers F-012. Deliver a supported status path for customer runtime/session health when direct VPS SSH is unavailable, using coarse metadata only.
+7. **Slice 7: Track focused-pane agent identity** - Covers F-013. Make the focused pane foreground command authoritative, retain hooks as provider-matched enrichment, and prove the complete Terminal/Claude/Terminal/Codex/Terminal lifecycle within five-second polling.
 
 ### Planning Readiness Review
 
@@ -173,6 +198,14 @@ Engineers can change terminal behavior without editing a giant UI component that
 - **FR-016**: Matrix MUST add a lifecycle test that proves a long-running terminal process remains live across tab switching, backgrounding, refresh, reconnect, and return.
 - **FR-017**: Matrix MUST provide an operator-readable status path for terminal/session health that does not depend solely on direct SSH access to the customer VPS.
 - **FR-018**: Matrix MUST avoid exposing provider errors, raw filesystem paths, or raw runtime failures in user-facing terminal recovery messages.
+- **FR-019**: Matrix MUST derive live agent identity from the focused terminal pane's validated foreground command whenever pane inspection succeeds.
+- **FR-020**: Matrix MUST recognize only the exact allowlisted commands `claude`, `codex`, `opencode`, and `pi`, including safely parsed `env` wrappers, and MUST NOT use substring matching.
+- **FR-021**: A successful observation of a shell, missing command, or unrecognized command MUST omit `agent`, `subtitle`, `lastAction`, `agentUpdatedAt`, `model`, and `strength` from the session response.
+- **FR-022**: Hook enrichment MUST be exposed only when its provider matches the observed agent and its phase is not `ended`; an observed recognized agent without compatible enrichment MUST fall back to `running`.
+- **FR-023**: When focused-pane inspection is unavailable, Matrix MAY fall back to a non-ended hook snapshot, then to the persisted launch hint for at most 12 seconds.
+- **FR-024**: Session-start and provider-change events MUST reset subtitle, action, model, and strength before applying new-provider event fields, and ended snapshots MUST NOT derive an active visual status.
+- **FR-025**: `GET /api/terminal/sessions` MUST retain its compatible optional response fields, with `agent` defined as the currently observed or safely degraded active agent rather than the originally launched provider.
+- **FR-026**: Matrix MUST retain the existing five-second session polling contract and MUST NOT require provider session-end hooks for correct exit or provider-switch behavior.
 
 ### Security Architecture
 
@@ -193,6 +226,7 @@ Engineers can change terminal behavior without editing a giant UI component that
 - Recovery paths MUST distinguish invalid input from recoverable legacy identifiers.
 - User-facing terminal errors MUST use coarse, actionable categories such as reconnecting, stale, exited, recoverable, and unavailable.
 - Logs may include enough diagnostic detail for operators, but client responses MUST NOT expose provider errors, filesystem paths, tokens, private host details, or raw runtime command output.
+- Foreground command text is internal classification input only. Session responses MUST expose the allowlisted agent identity, never the raw command or arguments.
 - Health checks and reachability probes MUST return coarse status only.
 
 #### Resource Management
@@ -200,6 +234,7 @@ Engineers can change terminal behavior without editing a giant UI component that
 - Any in-memory session, reconnect, or subscriber registries touched by this work MUST retain explicit caps and stale-entry eviction.
 - Terminal WebSocket subscribers MUST be evicted when sends fail or connections go stale.
 - Polling and retry loops MUST be bounded and cancelable when components unmount or users leave the surface.
+- Focused-pane observation caches MUST be capped and expire before the next five-second refresh can reuse stale foreground-process data.
 - Durable session metadata updates MUST remain atomic and must not corrupt owner files if a write fails.
 - Stale/recoverable session metadata cleanup MUST be safe for owner data and must not delete active runtime sessions.
 
@@ -207,6 +242,7 @@ Engineers can change terminal behavior without editing a giant UI component that
 
 - The shell must receive one coherent session summary from the gateway, including liveness, visual status, stale/recoverable flags, attach target, unread state, and safe user actions.
 - The gateway must reconcile runtime sessions, scrollback/activity evidence, saved shell metadata, and pane/layout references before returning session summaries.
+- The gateway must obtain focused cwd and foreground command from the same bounded Zellij pane inspection and apply runtime-agent precedence before serializing a session summary.
 - Browser terminal views must reattach through the owner-authorized WebSocket/session path after tab switch, refresh, and reconnect.
 - Operator diagnostics must be available through an authenticated platform or gateway path even when direct VPS SSH is unavailable.
 
@@ -218,6 +254,8 @@ Engineers can change terminal behavior without editing a giant UI component that
 - If delete succeeds but post-delete refresh fails, remove the deleted session locally and mark the list stale until refresh succeeds.
 - If delete fails, restore only the deleted row's optimistic state.
 - If saved metadata is corrupt or references impossible sessions, ignore the broken portion, preserve owner data, and surface a recoverable state.
+- If focused-pane inspection fails or returns malformed data, use only the bounded degraded fallback chain; do not reinterpret the failed observation as a successful shell observation.
+- If a provider hook is delayed, missing, mismatched, or never emits session end, the next successful pane observation still determines the visible agent identity.
 
 ### Key Entities *(include if feature involves data)*
 
@@ -225,6 +263,7 @@ Engineers can change terminal behavior without editing a giant UI component that
 - **Session Summary**: The owner-visible row/card describing liveness, visual status, stale state, unread state, attach target, and allowed actions.
 - **Durable UI Metadata**: Owner-controlled saved preferences such as placement, last seen output, order, and display metadata.
 - **Activity Evidence**: Recent terminal output and command boundary marks used to infer running, finished, idle, or waiting state.
+- **Focused-Pane Runtime Observation**: A bounded Zellij inspection result containing the focused pane's validated cwd and foreground command plus whether observation succeeded.
 - **Pane Reference**: A shell layout reference to a terminal session that may be live, stale, or recoverable.
 - **Workspace Session Alias**: A higher-level session record that may point at the same runtime terminal session.
 - **Stale State Marker**: A user-visible indicator that Matrix is showing last-known state because refresh or attach evidence is incomplete.
@@ -244,6 +283,7 @@ Engineers can change terminal behavior without editing a giant UI component that
 - **SC-008**: Terminal session state tests can exercise refresh/reconcile behavior without rendering unrelated file-tree, project-list, or agent-install menu UI.
 - **SC-009**: User-facing terminal/session recovery errors expose no raw provider errors, filesystem paths, tokens, or host internals in 100% of tested failures.
 - **SC-010**: Operator diagnostics can confirm terminal session health for a customer runtime without requiring direct SSH access in at least one supported path.
+- **SC-011**: The tested `Terminal → Claude → Terminal → Codex → Terminal` lifecycle updates identity, enrichment, logos, labels, and compact card height within each five-second refresh, with zero prior-provider fields remaining after an exit or switch.
 
 ## Assumptions
 

--- a/tests/gateway/agent-session-state.test.ts
+++ b/tests/gateway/agent-session-state.test.ts
@@ -87,6 +87,47 @@ describe("agent session state", () => {
     expect(deriveAgentVisualStatus(completed, false)).toBe("idle");
   });
 
+  it("resets enrichment on SessionStart and when the provider changes", async () => {
+    const root = await tempRoot();
+    const store = new AgentSessionStateStore({ homePath: root });
+
+    await store.apply(event("turn-started", "2026-07-18T10:00:00.000Z", {
+      subtitle: "Claude task",
+      action: "Edited registry.ts",
+      model: "claude-opus-4-6",
+      strength: "high",
+    }));
+    const restarted = await store.apply(event("session-started", "2026-07-18T10:00:01.000Z"));
+
+    expect(restarted).not.toHaveProperty("subtitle");
+    expect(restarted).not.toHaveProperty("lastAction");
+    expect(restarted).not.toHaveProperty("model");
+    expect(restarted).not.toHaveProperty("strength");
+
+    await store.apply(event("metadata-updated", "2026-07-18T10:00:02.000Z", {
+      subtitle: "Claude metadata",
+      model: "claude-opus-4-6",
+    }));
+    const changedProvider = await store.apply(event("turn-started", "2026-07-18T10:00:03.000Z", {
+      agent: "claude",
+    }));
+
+    expect(changedProvider.agent).toBe("claude");
+    expect(changedProvider).not.toHaveProperty("subtitle");
+    expect(changedProvider).not.toHaveProperty("lastAction");
+    expect(changedProvider).not.toHaveProperty("model");
+    expect(changedProvider).not.toHaveProperty("strength");
+  });
+
+  it("does not derive an active visual status from an ended snapshot", async () => {
+    const root = await tempRoot();
+    const store = new AgentSessionStateStore({ homePath: root });
+    await store.apply(event("session-ended", "2026-07-18T10:00:00.000Z"));
+
+    expect(deriveAgentVisualStatus(await store.get("calm-otter"), true)).toBeNull();
+    expect(deriveAgentVisualStatus(await store.get("calm-otter"), false)).toBeNull();
+  });
+
   it("rejects events older than the current snapshot", async () => {
     const root = await tempRoot();
     const store = new AgentSessionStateStore({ homePath: root });

--- a/tests/gateway/shell-registry.test.ts
+++ b/tests/gateway/shell-registry.test.ts
@@ -183,6 +183,15 @@ describe("shell registry", () => {
     expect(inferAgentFromCommand("--unsafe codex")).toBeUndefined();
   });
 
+  it.each([
+    "claude-helper",
+    "my-codex-wrapper",
+    "bash -lc claude",
+    "env -S 'codex --full-auto'",
+  ])("does not infer agents from substrings or unsupported wrappers: %s", (command) => {
+    expect(inferAgentFromCommand(command)).toBeUndefined();
+  });
+
   it("uses agent lifecycle evidence before a long-running outer CLI process", async () => {
     const root = await tempRoot();
     const agentStateStore = new AgentSessionStateStore({ homePath: root });
@@ -401,6 +410,34 @@ describe("shell registry", () => {
     vi.setSystemTime(new Date("2026-07-18T10:00:12.001Z"));
     const expired = await registry.get("launch-hint");
     expect(expired).not.toHaveProperty("agent");
+  });
+
+  it("does not expose an ended hook snapshot when pane inspection is unavailable", async () => {
+    const root = await tempRoot();
+    const agentStateStore = new AgentSessionStateStore({ homePath: root });
+    await agentStateStore.apply({
+      sessionName: "main",
+      agent: "claude",
+      type: "session-ended",
+      occurredAt: "2026-07-18T10:00:00.000Z",
+      subtitle: "Finished Claude task",
+      model: "claude-opus-4-6",
+      strength: "high",
+    });
+    const adapter = {
+      listSessions: vi.fn(async () => ["main"]),
+      createSession: vi.fn(async () => undefined),
+      deleteSession: vi.fn(async () => undefined),
+      focusedPaneRuntime: vi.fn(async () => ({ cwd: null, command: null, observed: false })),
+    };
+    const registry = new ShellRegistry({ homePath: root, adapter, agentStateStore });
+
+    const [session] = await registry.list();
+    expect(session).not.toHaveProperty("agent");
+    expect(session).not.toHaveProperty("subtitle");
+    expect(session).not.toHaveProperty("model");
+    expect(session).not.toHaveProperty("strength");
+    expect(session.visualStatus).toBe("idle");
   });
 
   it("keeps session rename available when agent metadata rename fails", async () => {

--- a/tests/gateway/shell-registry.test.ts
+++ b/tests/gateway/shell-registry.test.ts
@@ -162,6 +162,11 @@ describe("shell registry", () => {
     ["claude --resume", "claude"],
     ["env FOO=bar codex --full-auto", "codex"],
     ["/usr/bin/env --ignore-environment FOO=bar codex --full-auto", "codex"],
+    [
+      "/opt/matrix/runtime/node/bin/node /opt/matrix/runtime/node/lib/node_modules/@openai/codex/bin/codex.js --full-auto",
+      "codex",
+    ],
+    ["/opt/matrix/runtime/node/bin/node /opt/matrix/runtime/node/bin/codex", "codex"],
     ["opencode .", "opencode"],
     ["pi", "pi"],
   ] as const)("infers %s as a recognized agent launch", async (cmd, expectedAgent) => {
@@ -188,6 +193,10 @@ describe("shell registry", () => {
     "my-codex-wrapper",
     "bash -lc claude",
     "env -S 'codex --full-auto'",
+    "node codex.js",
+    "node /tmp/my-codex-wrapper.js",
+    "node /tmp/lib/node_modules/@openai/codex/bin/not-codex.js",
+    "node /tmp/lib/node_modules/@openai/codex/bin/codex.js",
   ])("does not infer agents from substrings or unsupported wrappers: %s", (command) => {
     expect(inferAgentFromCommand(command)).toBeUndefined();
   });
@@ -291,6 +300,42 @@ describe("shell registry", () => {
     }]);
   });
 
+  it("exposes matching Codex enrichment for the managed npm launcher", async () => {
+    const root = await tempRoot();
+    const agentStateStore = new AgentSessionStateStore({ homePath: root });
+    await agentStateStore.apply({
+      sessionName: "main",
+      agent: "codex",
+      type: "turn-started",
+      occurredAt: "2026-07-21T08:00:00.000Z",
+      subtitle: "Fix live terminal detection",
+      action: "Editing registry.ts",
+      model: "gpt-5.4",
+      strength: "high",
+    });
+    const adapter = {
+      listSessions: vi.fn(async () => ["main"]),
+      createSession: vi.fn(async () => undefined),
+      deleteSession: vi.fn(async () => undefined),
+      focusedPaneRuntime: vi.fn(async () => ({
+        cwd: root,
+        command: "/opt/matrix/runtime/node/bin/node /opt/matrix/runtime/node/lib/node_modules/@openai/codex/bin/codex.js",
+        observed: true,
+      })),
+    };
+    const registry = new ShellRegistry({ homePath: root, adapter, agentStateStore });
+
+    await expect(registry.list()).resolves.toMatchObject([{
+      name: "main",
+      agent: "codex",
+      subtitle: "Fix live terminal detection",
+      lastAction: "Editing registry.ts",
+      model: "gpt-5.4",
+      strength: "high",
+      visualStatus: "running",
+    }]);
+  });
+
   it("follows Terminal to Claude to Terminal to Codex to Terminal without stale enrichment", async () => {
     const root = await tempRoot();
     const agentStateStore = new AgentSessionStateStore({ homePath: root });
@@ -333,7 +378,7 @@ describe("shell registry", () => {
     }]);
     command = "zsh";
     await expectPlainTerminal();
-    command = "/opt/matrix/bin/codex";
+    command = "/opt/matrix/runtime/node/bin/node /opt/matrix/runtime/node/lib/node_modules/@openai/codex/bin/codex.js";
     const [codex] = await registry.list();
     expect(codex).toMatchObject({ agent: "codex", visualStatus: "running" });
     expect(codex).not.toHaveProperty("subtitle");

--- a/tests/gateway/shell-registry.test.ts
+++ b/tests/gateway/shell-registry.test.ts
@@ -72,12 +72,12 @@ describe("shell registry", () => {
       listSessions: vi.fn(async () => sessionNames),
       createSession: vi.fn(async () => undefined),
       deleteSession: vi.fn(async () => undefined),
-      focusedPaneCwd: vi.fn(async () => {
+      focusedPaneRuntime: vi.fn(async () => {
         activeLookups += 1;
         peakLookups = Math.max(peakLookups, activeLookups);
         await lookupGate;
         activeLookups -= 1;
-        return null;
+        return { cwd: null, command: null, observed: true };
       }),
     };
     const registry = new ShellRegistry({
@@ -87,13 +87,13 @@ describe("shell registry", () => {
     });
 
     const listPromise = registry.list();
-    await vi.waitFor(() => expect(adapter.focusedPaneCwd).toHaveBeenCalledTimes(8));
+    await vi.waitFor(() => expect(adapter.focusedPaneRuntime).toHaveBeenCalledTimes(8));
     expect(peakLookups).toBe(8);
     releaseLookups();
 
     const sessions = await listPromise;
     expect(sessions.map((session) => session.name)).toEqual(sessionNames);
-    expect(adapter.focusedPaneCwd).toHaveBeenCalledTimes(sessionNames.length);
+    expect(adapter.focusedPaneRuntime).toHaveBeenCalledTimes(sessionNames.length);
   });
 
   it("adds gateway-owned project and Git context while preserving the session cwd", async () => {
@@ -105,7 +105,7 @@ describe("shell registry", () => {
       listSessions: vi.fn(async () => Array.from(live)),
       createSession: vi.fn(async ({ name }: { name: string }) => { live.add(name); }),
       deleteSession: vi.fn(async () => undefined),
-      focusedPaneCwd: vi.fn(async () => cwd),
+      focusedPaneRuntime: vi.fn(async () => ({ cwd, command: "zsh", observed: true })),
     };
     const gitContextResolver = {
       resolve: vi.fn(async () => ({
@@ -263,6 +263,144 @@ describe("shell registry", () => {
       name: "calm-otter",
       visualStatus: "running",
     }]);
+  });
+
+  it("detects a manually launched Claude process in a plain terminal", async () => {
+    const root = await tempRoot();
+    const adapter = {
+      listSessions: vi.fn(async () => ["main"]),
+      createSession: vi.fn(async () => undefined),
+      deleteSession: vi.fn(async () => undefined),
+      focusedPaneRuntime: vi.fn(async () => ({ cwd: root, command: "claude", observed: true })),
+    };
+    const registry = new ShellRegistry({ homePath: root, adapter });
+
+    await expect(registry.list()).resolves.toMatchObject([{
+      name: "main",
+      agent: "claude",
+      visualStatus: "running",
+    }]);
+  });
+
+  it("follows Terminal to Claude to Terminal to Codex to Terminal without stale enrichment", async () => {
+    const root = await tempRoot();
+    const agentStateStore = new AgentSessionStateStore({ homePath: root });
+    await agentStateStore.apply({
+      sessionName: "main",
+      agent: "claude",
+      type: "turn-started",
+      occurredAt: "2026-07-18T10:00:00.000Z",
+      subtitle: "Claude task",
+      action: "Edited registry.ts",
+      model: "claude-opus-4-6",
+      strength: "high",
+    });
+    let command = "zsh";
+    const adapter = {
+      listSessions: vi.fn(async () => ["main"]),
+      createSession: vi.fn(async () => undefined),
+      deleteSession: vi.fn(async () => undefined),
+      focusedPaneRuntime: vi.fn(async () => ({ cwd: root, command, observed: true })),
+    };
+    const registry = new ShellRegistry({ homePath: root, adapter, agentStateStore });
+
+    const expectPlainTerminal = async () => {
+      const [session] = await registry.list();
+      expect(session).not.toHaveProperty("agent");
+      expect(session).not.toHaveProperty("subtitle");
+      expect(session).not.toHaveProperty("lastAction");
+      expect(session).not.toHaveProperty("agentUpdatedAt");
+      expect(session).not.toHaveProperty("model");
+      expect(session).not.toHaveProperty("strength");
+    };
+
+    await expectPlainTerminal();
+    command = "claude";
+    await expect(registry.list()).resolves.toMatchObject([{
+      agent: "claude",
+      subtitle: "Claude task",
+      model: "claude-opus-4-6",
+      strength: "high",
+    }]);
+    command = "zsh";
+    await expectPlainTerminal();
+    command = "/opt/matrix/bin/codex";
+    const [codex] = await registry.list();
+    expect(codex).toMatchObject({ agent: "codex", visualStatus: "running" });
+    expect(codex).not.toHaveProperty("subtitle");
+    expect(codex).not.toHaveProperty("lastAction");
+    expect(codex).not.toHaveProperty("agentUpdatedAt");
+    expect(codex).not.toHaveProperty("model");
+    expect(codex).not.toHaveProperty("strength");
+    command = "bash";
+    await expectPlainTerminal();
+  });
+
+  it("lets a successful runtime observation override stale persisted and hook providers", async () => {
+    const root = await tempRoot();
+    const agentStateStore = new AgentSessionStateStore({ homePath: root });
+    await agentStateStore.apply({
+      sessionName: "main",
+      agent: "claude",
+      type: "attention-requested",
+      occurredAt: "2026-07-18T10:00:00.000Z",
+      subtitle: "Stale Claude task",
+      action: "Requested approval",
+      model: "claude-opus-4-6",
+      strength: "high",
+    });
+    const live = new Set<string>();
+    const adapter = {
+      listSessions: vi.fn(async () => Array.from(live)),
+      createSession: vi.fn(async ({ name }: { name: string }) => { live.add(name); }),
+      deleteSession: vi.fn(async () => undefined),
+      focusedPaneRuntime: vi.fn(async () => ({ cwd: root, command: "opencode", observed: true })),
+    };
+    const registry = new ShellRegistry({ homePath: root, adapter, agentStateStore });
+    await registry.create({ name: "main", cmd: "codex", agent: "codex" });
+
+    const [session] = await registry.list();
+    expect(session).toMatchObject({ agent: "opencode", visualStatus: "running" });
+    expect(session).not.toHaveProperty("subtitle");
+    expect(session).not.toHaveProperty("lastAction");
+    expect(session).not.toHaveProperty("agentUpdatedAt");
+    expect(session).not.toHaveProperty("model");
+    expect(session).not.toHaveProperty("strength");
+  });
+
+  it("uses non-ended hooks and then a 12-second launch hint when pane inspection is unavailable", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-18T10:00:00.000Z"));
+    const root = await tempRoot();
+    const live = new Set<string>();
+    const adapter = {
+      listSessions: vi.fn(async () => Array.from(live)),
+      createSession: vi.fn(async ({ name }: { name: string }) => { live.add(name); }),
+      deleteSession: vi.fn(async () => undefined),
+      focusedPaneRuntime: vi.fn(async () => { throw new Error("pane inspection failed"); }),
+    };
+    const agentStateStore = new AgentSessionStateStore({ homePath: root });
+    await agentStateStore.apply({
+      sessionName: "hooked",
+      agent: "claude",
+      type: "turn-started",
+      occurredAt: "2026-07-18T10:00:00.000Z",
+      subtitle: "Hook fallback",
+    });
+    const registry = new ShellRegistry({ homePath: root, adapter, agentStateStore });
+    await registry.create({ name: "hooked" });
+    await registry.create({ name: "launch-hint", cmd: "codex", agent: "codex" });
+
+    await expect(registry.get("hooked")).resolves.toMatchObject({
+      agent: "claude",
+      subtitle: "Hook fallback",
+      visualStatus: "running",
+    });
+    await expect(registry.get("launch-hint")).resolves.toMatchObject({ agent: "codex", visualStatus: "running" });
+
+    vi.setSystemTime(new Date("2026-07-18T10:00:12.001Z"));
+    const expired = await registry.get("launch-hint");
+    expect(expired).not.toHaveProperty("agent");
   });
 
   it("keeps session rename available when agent metadata rename fails", async () => {

--- a/tests/gateway/shell-zellij.test.ts
+++ b/tests/gateway/shell-zellij.test.ts
@@ -182,6 +182,34 @@ describe("zellij adapter", () => {
     });
   });
 
+  it("expires focused runtime observations before the next five-second refresh", async () => {
+    let now = 0;
+    let paneCommand = "claude";
+    const execFile = vi.fn((_file, args: string[], _opts, cb) => {
+      cb(null, args.includes("current-tab-info")
+        ? JSON.stringify({ tab_id: 1 })
+        : JSON.stringify([{
+          id: 1,
+          is_plugin: false,
+          is_focused: true,
+          tab_id: 1,
+          pane_cwd: "/home/alice/project",
+          pane_command: paneCommand,
+        }]), "");
+      return childProcess();
+    });
+    const adapter = createZellijAdapter({ execFile, spawn: vi.fn(), timeoutMs: 25, nowMs: () => now });
+
+    await expect(adapter.focusedPaneRuntime("main")).resolves.toMatchObject({ command: "claude" });
+    paneCommand = "codex";
+    now = 3_999;
+    await expect(adapter.focusedPaneRuntime("main")).resolves.toMatchObject({ command: "claude" });
+    now = 5_000;
+    await expect(adapter.focusedPaneRuntime("main")).resolves.toMatchObject({ command: "codex" });
+
+    expect(execFile).toHaveBeenCalledTimes(4);
+  });
+
   it("treats zellij's no-active-sessions response as an empty session list", async () => {
     const execFile = vi.fn((_file, _args, _opts, cb) => {
       cb(Object.assign(new Error("zellij exited"), { code: 1 }), "", "NO ACTIVE ZELLIJ SESSIONS FOUND\n");

--- a/tests/gateway/shell-zellij.test.ts
+++ b/tests/gateway/shell-zellij.test.ts
@@ -165,6 +165,11 @@ describe("zellij adapter", () => {
   it.each([
     ["env FOO=bar codex --full-auto", "codex"],
     ["/usr/bin/env --ignore-environment claude", "claude"],
+    [
+      "/opt/matrix/runtime/node/bin/node /opt/matrix/runtime/node/lib/node_modules/@openai/codex/bin/codex.js",
+      "codex",
+    ],
+    ["/opt/matrix/runtime/node/bin/node /opt/matrix/runtime/node/bin/codex", "codex"],
     ["env -u DEBUG opencode .", "opencode"],
     ["env --unset=DEBUG pi", "pi"],
   ] as const)("keeps wrapped focused commands available for exact agent classification: %s", async (paneCommand, agent) => {

--- a/tests/gateway/shell-zellij.test.ts
+++ b/tests/gateway/shell-zellij.test.ts
@@ -86,13 +86,15 @@ describe("zellij adapter", () => {
     );
   });
 
-  it("reads the focused terminal pane runtime from the bounded list-panes query", async () => {
-    const execFile = vi.fn((_file, _args: string[], _opts, cb) => {
-      cb(null, JSON.stringify([
-        { id: 1, is_plugin: false, is_focused: false, tab_id: 2, pane_cwd: "/home/alice/other", pane_command: "zsh" },
-        { id: 2, is_plugin: false, is_focused: true, tab_id: 4, pane_cwd: "/home/alice/project", pane_command: "claude --resume" },
-        { id: 3, is_plugin: true, is_focused: false, tab_id: 4, pane_cwd: null },
-      ]), "");
+  it("uses current-tab info to disambiguate focused panes from several tabs", async () => {
+    const execFile = vi.fn((_file, args: string[], _opts, cb) => {
+      cb(null, args.includes("current-tab-info")
+        ? JSON.stringify({ tab_id: 4 })
+        : JSON.stringify([
+          { id: 1, is_plugin: false, is_focused: true, tab_id: 2, pane_cwd: "/home/alice/other", pane_command: "zsh" },
+          { id: 2, is_plugin: false, is_focused: true, tab_id: 4, pane_cwd: "/home/alice/project", pane_command: "claude --resume" },
+          { id: 3, is_plugin: true, is_focused: false, tab_id: 4, pane_cwd: null },
+        ]), "");
       return childProcess();
     });
     const adapter = createZellijAdapter({ execFile, spawn: vi.fn(), timeoutMs: 25 });
@@ -107,7 +109,7 @@ describe("zellij adapter", () => {
       command: "claude --resume",
       observed: true,
     });
-    expect(execFile).toHaveBeenCalledTimes(1);
+    expect(execFile).toHaveBeenCalledTimes(2);
     expect(execFile).toHaveBeenCalledWith(
       "zellij",
       ["--session", "main", "action", "list-panes", "--all", "--json"],
@@ -116,12 +118,9 @@ describe("zellij adapter", () => {
     );
   });
 
-  it("observes a focused pane when current-tab-info would be unavailable without an attached client", async () => {
-    const execFile = vi.fn((_file, args: string[], _opts, cb) => {
-      if (args.includes("current-tab-info")) {
-        cb(Object.assign(new Error("No active tab found for current client"), { code: 1 }), "", "");
-      } else {
-        cb(null, JSON.stringify([{
+  it("observes a single focused pane without requiring an attached client", async () => {
+    const execFile = vi.fn((_file, _args: string[], _opts, cb) => {
+      cb(null, JSON.stringify([{
           id: 1,
           is_plugin: false,
           is_focused: true,
@@ -129,7 +128,6 @@ describe("zellij adapter", () => {
           pane_cwd: "/home/alice/project",
           pane_command: "codex",
         }]), "");
-      }
       return childProcess();
     });
     const adapter = createZellijAdapter({ execFile, spawn: vi.fn(), timeoutMs: 25 });
@@ -140,6 +138,28 @@ describe("zellij adapter", () => {
       observed: true,
     });
     expect(execFile).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns an unavailable observation when detached multi-tab focus is ambiguous", async () => {
+    const execFile = vi.fn((_file, args: string[], _opts, cb) => {
+      if (args.includes("current-tab-info")) {
+        cb(Object.assign(new Error("No active tab found for current client"), { code: 1 }), "", "");
+      } else {
+        cb(null, JSON.stringify([
+          { id: 1, is_plugin: false, is_focused: true, tab_id: 1, pane_cwd: "/home/alice/one", pane_command: "claude" },
+          { id: 2, is_plugin: false, is_focused: true, tab_id: 2, pane_cwd: "/home/alice/two", pane_command: "codex" },
+        ]), "");
+      }
+      return childProcess();
+    });
+    const adapter = createZellijAdapter({ execFile, spawn: vi.fn(), timeoutMs: 25 });
+
+    await expect(adapter.focusedPaneRuntime("main")).resolves.toEqual({
+      cwd: null,
+      command: null,
+      observed: false,
+    });
+    expect(execFile).toHaveBeenCalledTimes(2);
   });
 
   it.each([
@@ -167,7 +187,8 @@ describe("zellij adapter", () => {
     expect(inferAgentFromCommand(runtime.command ?? undefined)).toBe(agent);
   });
 
-  it("reports a successful observation with no command when the focused pane omits pane_command", async () => {
+  it("warns and returns an unavailable observation when the focused pane omits pane_command", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
     const execFile = vi.fn((_file, _args: string[], _opts, cb) => {
       cb(null, JSON.stringify([{
           id: 1,
@@ -181,10 +202,11 @@ describe("zellij adapter", () => {
     const adapter = createZellijAdapter({ execFile, spawn: vi.fn(), timeoutMs: 25 });
 
     await expect(adapter.focusedPaneRuntime("main")).resolves.toEqual({
-      cwd: "/home/alice/project",
+      cwd: null,
       command: null,
-      observed: true,
+      observed: false,
     });
+    expect(warn).toHaveBeenCalledWith("[shell] focused pane command unavailable");
   });
 
   it("returns an unavailable observation for malformed pane JSON", async () => {

--- a/tests/gateway/shell-zellij.test.ts
+++ b/tests/gateway/shell-zellij.test.ts
@@ -11,6 +11,7 @@ import {
   createZellijAdapter,
   sanitizeZellijError,
 } from "../../packages/gateway/src/shell/zellij.js";
+import { inferAgentFromCommand } from "../../packages/gateway/src/shell/registry.js";
 import { matrixTerminalShellScript } from "../../packages/gateway/src/shell/zellij-config.js";
 
 const execFileAsync = promisify(nodeExecFile);
@@ -85,13 +86,13 @@ describe("zellij adapter", () => {
     );
   });
 
-  it("reads the focused terminal pane cwd from bounded structured zellij queries", async () => {
+  it("reads the focused terminal pane runtime from bounded structured zellij queries", async () => {
     const execFile = vi.fn((_file, args: string[], _opts, cb) => {
       const stdout = args.includes("current-tab-info")
         ? JSON.stringify({ tab_id: 4, active: true })
         : JSON.stringify([
-          { id: 1, is_plugin: false, is_focused: true, tab_id: 2, pane_cwd: "/home/alice/other" },
-          { id: 2, is_plugin: false, is_focused: true, tab_id: 4, pane_cwd: "/home/alice/project" },
+          { id: 1, is_plugin: false, is_focused: true, tab_id: 2, pane_cwd: "/home/alice/other", pane_command: "zsh" },
+          { id: 2, is_plugin: false, is_focused: true, tab_id: 4, pane_cwd: "/home/alice/project", pane_command: "claude --resume" },
           { id: 3, is_plugin: true, is_focused: false, tab_id: 4, pane_cwd: null },
         ]);
       cb(null, stdout, "");
@@ -99,8 +100,16 @@ describe("zellij adapter", () => {
     });
     const adapter = createZellijAdapter({ execFile, spawn: vi.fn(), timeoutMs: 25 });
 
-    await expect(adapter.focusedPaneCwd("main")).resolves.toBe("/home/alice/project");
-    await expect(adapter.focusedPaneCwd("main")).resolves.toBe("/home/alice/project");
+    await expect(adapter.focusedPaneRuntime("main")).resolves.toEqual({
+      cwd: "/home/alice/project",
+      command: "claude --resume",
+      observed: true,
+    });
+    await expect(adapter.focusedPaneRuntime("main")).resolves.toEqual({
+      cwd: "/home/alice/project",
+      command: "claude --resume",
+      observed: true,
+    });
     expect(execFile).toHaveBeenCalledTimes(2);
     expect(execFile).toHaveBeenCalledWith(
       "zellij",
@@ -108,6 +117,69 @@ describe("zellij adapter", () => {
       expect.objectContaining({ timeout: 25, signal: expect.any(AbortSignal) }),
       expect.any(Function),
     );
+  });
+
+  it.each([
+    ["env FOO=bar codex --full-auto", "codex"],
+    ["/usr/bin/env --ignore-environment claude", "claude"],
+    ["env -u DEBUG opencode .", "opencode"],
+    ["env --unset=DEBUG pi", "pi"],
+  ] as const)("keeps wrapped focused commands available for exact agent classification: %s", async (paneCommand, agent) => {
+    const execFile = vi.fn((_file, args: string[], _opts, cb) => {
+      cb(null, args.includes("current-tab-info")
+        ? JSON.stringify({ tab_id: 1 })
+        : JSON.stringify([{
+          id: 1,
+          is_plugin: false,
+          is_focused: true,
+          tab_id: 1,
+          pane_cwd: "/home/alice/project",
+          pane_command: paneCommand,
+        }]), "");
+      return childProcess();
+    });
+    const adapter = createZellijAdapter({ execFile, spawn: vi.fn(), timeoutMs: 25 });
+
+    const runtime = await adapter.focusedPaneRuntime("main");
+
+    expect(runtime).toMatchObject({ command: paneCommand, observed: true });
+    expect(inferAgentFromCommand(runtime.command ?? undefined)).toBe(agent);
+  });
+
+  it("reports a successful observation with no command when the focused pane omits pane_command", async () => {
+    const execFile = vi.fn((_file, args: string[], _opts, cb) => {
+      cb(null, args.includes("current-tab-info")
+        ? JSON.stringify({ tab_id: 1 })
+        : JSON.stringify([{
+          id: 1,
+          is_plugin: false,
+          is_focused: true,
+          tab_id: 1,
+          pane_cwd: "/home/alice/project",
+        }]), "");
+      return childProcess();
+    });
+    const adapter = createZellijAdapter({ execFile, spawn: vi.fn(), timeoutMs: 25 });
+
+    await expect(adapter.focusedPaneRuntime("main")).resolves.toEqual({
+      cwd: "/home/alice/project",
+      command: null,
+      observed: true,
+    });
+  });
+
+  it("returns an unavailable observation for malformed pane JSON", async () => {
+    const execFile = vi.fn((_file, args: string[], _opts, cb) => {
+      cb(null, args.includes("current-tab-info") ? JSON.stringify({ tab_id: 1 }) : "{not-json", "");
+      return childProcess();
+    });
+    const adapter = createZellijAdapter({ execFile, spawn: vi.fn(), timeoutMs: 25 });
+
+    await expect(adapter.focusedPaneRuntime("main")).resolves.toEqual({
+      cwd: null,
+      command: null,
+      observed: false,
+    });
   });
 
   it("treats zellij's no-active-sessions response as an empty session list", async () => {

--- a/tests/gateway/shell-zellij.test.ts
+++ b/tests/gateway/shell-zellij.test.ts
@@ -86,16 +86,13 @@ describe("zellij adapter", () => {
     );
   });
 
-  it("reads the focused terminal pane runtime from bounded structured zellij queries", async () => {
-    const execFile = vi.fn((_file, args: string[], _opts, cb) => {
-      const stdout = args.includes("current-tab-info")
-        ? JSON.stringify({ tab_id: 4, active: true })
-        : JSON.stringify([
-          { id: 1, is_plugin: false, is_focused: true, tab_id: 2, pane_cwd: "/home/alice/other", pane_command: "zsh" },
-          { id: 2, is_plugin: false, is_focused: true, tab_id: 4, pane_cwd: "/home/alice/project", pane_command: "claude --resume" },
-          { id: 3, is_plugin: true, is_focused: false, tab_id: 4, pane_cwd: null },
-        ]);
-      cb(null, stdout, "");
+  it("reads the focused terminal pane runtime from the bounded list-panes query", async () => {
+    const execFile = vi.fn((_file, _args: string[], _opts, cb) => {
+      cb(null, JSON.stringify([
+        { id: 1, is_plugin: false, is_focused: false, tab_id: 2, pane_cwd: "/home/alice/other", pane_command: "zsh" },
+        { id: 2, is_plugin: false, is_focused: true, tab_id: 4, pane_cwd: "/home/alice/project", pane_command: "claude --resume" },
+        { id: 3, is_plugin: true, is_focused: false, tab_id: 4, pane_cwd: null },
+      ]), "");
       return childProcess();
     });
     const adapter = createZellijAdapter({ execFile, spawn: vi.fn(), timeoutMs: 25 });
@@ -110,7 +107,7 @@ describe("zellij adapter", () => {
       command: "claude --resume",
       observed: true,
     });
-    expect(execFile).toHaveBeenCalledTimes(2);
+    expect(execFile).toHaveBeenCalledTimes(1);
     expect(execFile).toHaveBeenCalledWith(
       "zellij",
       ["--session", "main", "action", "list-panes", "--all", "--json"],
@@ -119,16 +116,40 @@ describe("zellij adapter", () => {
     );
   });
 
+  it("observes a focused pane when current-tab-info would be unavailable without an attached client", async () => {
+    const execFile = vi.fn((_file, args: string[], _opts, cb) => {
+      if (args.includes("current-tab-info")) {
+        cb(Object.assign(new Error("No active tab found for current client"), { code: 1 }), "", "");
+      } else {
+        cb(null, JSON.stringify([{
+          id: 1,
+          is_plugin: false,
+          is_focused: true,
+          tab_id: 1,
+          pane_cwd: "/home/alice/project",
+          pane_command: "codex",
+        }]), "");
+      }
+      return childProcess();
+    });
+    const adapter = createZellijAdapter({ execFile, spawn: vi.fn(), timeoutMs: 25 });
+
+    await expect(adapter.focusedPaneRuntime("main")).resolves.toEqual({
+      cwd: "/home/alice/project",
+      command: "codex",
+      observed: true,
+    });
+    expect(execFile).toHaveBeenCalledTimes(1);
+  });
+
   it.each([
     ["env FOO=bar codex --full-auto", "codex"],
     ["/usr/bin/env --ignore-environment claude", "claude"],
     ["env -u DEBUG opencode .", "opencode"],
     ["env --unset=DEBUG pi", "pi"],
   ] as const)("keeps wrapped focused commands available for exact agent classification: %s", async (paneCommand, agent) => {
-    const execFile = vi.fn((_file, args: string[], _opts, cb) => {
-      cb(null, args.includes("current-tab-info")
-        ? JSON.stringify({ tab_id: 1 })
-        : JSON.stringify([{
+    const execFile = vi.fn((_file, _args: string[], _opts, cb) => {
+      cb(null, JSON.stringify([{
           id: 1,
           is_plugin: false,
           is_focused: true,
@@ -147,10 +168,8 @@ describe("zellij adapter", () => {
   });
 
   it("reports a successful observation with no command when the focused pane omits pane_command", async () => {
-    const execFile = vi.fn((_file, args: string[], _opts, cb) => {
-      cb(null, args.includes("current-tab-info")
-        ? JSON.stringify({ tab_id: 1 })
-        : JSON.stringify([{
+    const execFile = vi.fn((_file, _args: string[], _opts, cb) => {
+      cb(null, JSON.stringify([{
           id: 1,
           is_plugin: false,
           is_focused: true,
@@ -169,8 +188,8 @@ describe("zellij adapter", () => {
   });
 
   it("returns an unavailable observation for malformed pane JSON", async () => {
-    const execFile = vi.fn((_file, args: string[], _opts, cb) => {
-      cb(null, args.includes("current-tab-info") ? JSON.stringify({ tab_id: 1 }) : "{not-json", "");
+    const execFile = vi.fn((_file, _args: string[], _opts, cb) => {
+      cb(null, "{not-json", "");
       return childProcess();
     });
     const adapter = createZellijAdapter({ execFile, spawn: vi.fn(), timeoutMs: 25 });
@@ -185,10 +204,8 @@ describe("zellij adapter", () => {
   it("expires focused runtime observations before the next five-second refresh", async () => {
     let now = 0;
     let paneCommand = "claude";
-    const execFile = vi.fn((_file, args: string[], _opts, cb) => {
-      cb(null, args.includes("current-tab-info")
-        ? JSON.stringify({ tab_id: 1 })
-        : JSON.stringify([{
+    const execFile = vi.fn((_file, _args: string[], _opts, cb) => {
+      cb(null, JSON.stringify([{
           id: 1,
           is_plugin: false,
           is_focused: true,
@@ -207,7 +224,7 @@ describe("zellij adapter", () => {
     now = 5_000;
     await expect(adapter.focusedPaneRuntime("main")).resolves.toMatchObject({ command: "codex" });
 
-    expect(execFile).toHaveBeenCalledTimes(4);
+    expect(execFile).toHaveBeenCalledTimes(2);
   });
 
   it("treats zellij's no-active-sessions response as an empty session list", async () => {

--- a/tests/shell/terminal-app-component.test.tsx
+++ b/tests/shell/terminal-app-component.test.tsx
@@ -549,7 +549,7 @@ describe("TerminalApp", () => {
 
     await advanceRefresh("claude");
     expect(card().style.height).toBe("78px");
-    expect(screen.getByTestId("terminal-session-agent-state-main").textContent).toContain("Claude Code");
+    expect(screen.getByTestId("terminal-session-agent-state-main").textContent).toContain("Claude");
     expect(screen.getByTestId("terminal-session-agent-state-main").textContent).toContain("claude-opus-4-6");
     expectOptimizedImageSrc(screen.getByTestId("terminal-session-agent-logo-image-claude"), "/agent-logos/claude-code.png");
 

--- a/tests/shell/terminal-app-component.test.tsx
+++ b/tests/shell/terminal-app-component.test.tsx
@@ -498,6 +498,81 @@ describe("TerminalApp", () => {
     );
   });
 
+  it("polls through Terminal, Claude, Terminal, Codex, Terminal without stale badges or card layout", async () => {
+    type Phase = "terminal" | "claude" | "codex";
+    let phase: Phase = "terminal";
+    vi.mocked(fetch).mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.includes("/api/terminal/layout") && init?.method === "PUT") {
+        return Promise.resolve(mockJsonResponse({ ok: true }));
+      }
+      if (url.includes("/api/terminal/layout")) return Promise.resolve(mockJsonResponse({}));
+      if (url.endsWith("/api/terminal/sessions") && init?.method !== "POST") {
+        const agentFields = phase === "claude"
+          ? {
+              agent: "claude",
+              subtitle: "Claude task",
+              model: "claude-opus-4-6",
+              strength: "high",
+              visualStatus: "running",
+            }
+          : phase === "codex"
+            ? { agent: "codex", visualStatus: "running" }
+            : {};
+        return Promise.resolve(mockJsonResponse({
+          sessions: [{ name: "main", status: "active", placement: "active", tabs: [], ...agentFields }],
+        }));
+      }
+      return Promise.resolve(mockJsonResponse({}));
+    });
+
+    render(<TerminalApp />);
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    const advanceRefresh = async (nextPhase: Phase) => {
+      phase = nextPhase;
+      await act(async () => {
+        vi.advanceTimersByTime(5_000);
+        await Promise.resolve();
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+    };
+    const card = () => screen.getByTestId("terminal-session-card-main");
+
+    expect(card().style.height).toBe("52px");
+    expect(screen.queryByTestId(/terminal-session-agent-logo-/)).toBeNull();
+
+    await advanceRefresh("claude");
+    expect(card().style.height).toBe("78px");
+    expect(screen.getByTestId("terminal-session-agent-state-main").textContent).toContain("Claude Code");
+    expect(screen.getByTestId("terminal-session-agent-state-main").textContent).toContain("claude-opus-4-6");
+    expectOptimizedImageSrc(screen.getByTestId("terminal-session-agent-logo-image-claude"), "/agent-logos/claude-code.png");
+
+    await advanceRefresh("terminal");
+    expect(card().style.height).toBe("52px");
+    expect(screen.queryByTestId("terminal-session-subtitle-main")).toBeNull();
+    expect(screen.queryByTestId(/terminal-session-agent-logo-/)).toBeNull();
+
+    await advanceRefresh("codex");
+    expect(card().style.height).toBe("60px");
+    const codexState = screen.getByTestId("terminal-session-agent-state-main");
+    expect(codexState.textContent).toContain("Codex");
+    expect(codexState.textContent).not.toContain("Claude");
+    expect(codexState.textContent).not.toContain("claude-opus-4-6");
+    expect(codexState.textContent).not.toContain("High");
+    expect(screen.queryByTestId("terminal-session-subtitle-main")).toBeNull();
+    expectOptimizedImageSrc(screen.getByTestId("terminal-session-agent-logo-image-codex"), "/agent-logos/codex.png");
+
+    await advanceRefresh("terminal");
+    expect(card().style.height).toBe("52px");
+    expect(screen.queryByTestId(/terminal-session-agent-logo-/)).toBeNull();
+  });
+
   it("shows compact Git context only when it fits on the existing metadata line", () => {
     expect(doesCompactGitContextFit({ availableWidth: 360, primaryWidth: 190, contextWidth: 130 })).toBe(true);
     expect(doesCompactGitContextFit({ availableWidth: 280, primaryWidth: 190, contextWidth: 130 })).toBe(false);


### PR DESCRIPTION
## Summary

- make the focused Zellij pane's validated `pane_command` the source of truth for live Claude, Codex, OpenCode, and Pi identity
- clear agent fields immediately when the focused pane returns to a shell, while allowing provider-matched, non-ended hook enrichment and a bounded degraded fallback
- reset stale visual enrichment on provider/session changes and treat `ended` as inactive
- update spec 098 and add gateway, adapter, state-store, and five-second shell polling lifecycle regressions
- use the existing bounded `list-panes --all --json` observation directly, including when no Zellij client is attached
- recognize the exact managed npm Codex Node entrypoint that Zellij reports as the foreground process-group leader, without accepting generic Node scripts or lookalike paths

## Tests

- `pnpm exec vitest run tests/gateway/shell-zellij.test.ts tests/gateway/shell-registry.test.ts tests/gateway/agent-session-state.test.ts tests/shell/terminal-app-component.test.tsx` — 205 passed
- `./node_modules/.bin/vitest run tests/gateway/shell-registry.test.ts tests/gateway/shell-zellij.test.ts` after preview feedback — 105 passed, including managed npm launcher identity and matching Codex subtitle/model enrichment
- `pnpm --filter '@matrix-os/gateway' exec tsc --noEmit` — passed
- `pnpm run typecheck:build-kernel` — passed
- package typechecks for gateway, observability, platform, proxy, and edge-router — passed
- `pnpm run check:patterns` — 0 violations (5 baseline warnings)
- `pnpm dlx react-doctor@latest shell --verbose --scope changed` — completed; production React is unchanged and reported findings are outside this diff
- real Zellij probe — Codex first-run authentication screen exposed `agent: "codex"` and `visualStatus: "running"`; exiting returned the same session to a response with every agent-specific field omitted after one refresh

The repository-wide unit command progressed to 5,479 passing tests before the runner exhausted its 150 GB filesystem; remaining failures were `ENOSPC`, not assertions. The focused suite was rerun successfully afterward. Local Matrix UI screenshot capture was blocked by baseline workspace dependency resolution in the shell dev server; the polling regression verifies labels, logos, metadata removal, and compact card heights across the full lifecycle.

## Review / Monitoring

Review `0408b9163..c25a67e37`. The branch is frozen for review.

- CI, unresolved review threads, Codex comments, and the latest trusted Greptile rating are being monitored.
- Do not merge until required checks pass and Greptile reports 5/5.

## Invariants

### Source of truth

- A successful focused-pane runtime observation is canonical for live agent identity.
- Provider hooks may enrich only the same observed provider while their phase is not `ended`.
- On observation failure only, a non-ended hook snapshot may fall back first; the persisted launch hint is allowed for at most 12 seconds and is never exposed directly as live state.

### Lock/transaction scope

- Existing shell registry reconciliation remains serialized by its mutation queue.
- Decoration performs bounded read-only runtime, hook, scrollback, and Git-context observations; it does not add database writes, transactions, or external network calls.

### Acceptable orphan states

- No new durable entity is created. A failed pane observation degrades to bounded hook/launch-hint state; a successful shell observation clears live agent state even if persisted or hook metadata is stale.
- Zellij observation cache entries remain capped and expire before the existing five-second UI refresh.

### Auth source of truth

- Existing terminal route authentication and authorization are unchanged. `GET /api/terminal/sessions` keeps the same response shape and optional agent fields.
- Zellij command output is locally sourced and validated with bounded Zod schemas before classification.

### Deferred scope

- No realtime terminal-agent protocol, owner-data migration, or dependence on provider `SessionEnd` hooks.
- PR #1085 is deployed to the disposable `pr-1085` preview. The preview feedback exposed the npm Codex process-group shape; commit `c25a67e37` fixes it and is rebuilding the version-pinned preview bundle.
- The public-docs update is committed in a separate manual `matrix-os-site` worktree, but its push is blocked because the authenticated account has read-only access to that private repository (`Write access to repository not granted`).
