### PR TITLE
fix(cli): reject unsupported long t flag

### DIFF
--- a/packages/sync-client/src/cli/commands/run.ts
+++ b/packages/sync-client/src/cli/commands/run.ts
@@ -14,6 +14,15 @@ async function clientFromArgs(args: Record<string, unknown>) {
   return createShellClient({ gatewayUrl: profile.gatewayUrl, token });
 }
 
+export function hasUnsupportedLongTtySpelling(rawArgs: string[] | undefined): boolean {
+  if (!Array.isArray(rawArgs)) {
+    return false;
+  }
+  const separator = rawArgs.indexOf("--");
+  const matrixArgs = separator >= 0 ? rawArgs.slice(0, separator) : rawArgs;
+  return matrixArgs.includes("--t");
+}
+
 export function parseRunCommand(rawArgs: string[] | undefined): string[] {
   if (!Array.isArray(rawArgs)) {
     return [];
@@ -197,6 +206,12 @@ export const runCommand = defineCommand({
   run: async ({ args, rawArgs }) => {
     const json = args.json === true;
     try {
+      if (hasUnsupportedLongTtySpelling(rawArgs)) {
+        throw Object.assign(
+          new Error("`--t` is not supported; use `-t` or `--tty`"),
+          { code: "invalid_request" },
+        );
+      }
       const command = parseRunCommand(rawArgs);
       if (command.length === 0) {
         throw Object.assign(new Error(RUN_USAGE), { code: "invalid_request" });

--- a/packages/sync-client/src/cli/commands/run.ts
+++ b/packages/sync-client/src/cli/commands/run.ts
@@ -20,7 +20,7 @@ export function hasUnsupportedLongTtySpelling(rawArgs: string[] | undefined): bo
   }
   const separator = rawArgs.indexOf("--");
   const matrixArgs = separator >= 0 ? rawArgs.slice(0, separator) : rawArgs;
-  return matrixArgs.includes("--t");
+  return matrixArgs.some((arg) => arg === "--t" || arg.startsWith("--t="));
 }
 
 export function parseRunCommand(rawArgs: string[] | undefined): string[] {

--- a/tests/cli/run.test.ts
+++ b/tests/cli/run.test.ts
@@ -168,6 +168,14 @@ describe("run CLI command", () => {
     expect(result.stdout).not.toMatch(/\s--t(?:\s|$)/m);
   });
 
+  it("rejects the unsupported --t spelling", async () => {
+    const result = await runMatrixCli(["run", "--t", "--", "echo", "ok"]);
+
+    expect(result.status).toBe(1);
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toContain("`--t` is not supported; use `-t` or `--tty`");
+  });
+
   it("infers agents behind env and inline environment assignments", () => {
     expect(inferRunAgent(["env", "FOO=bar", "claude"])).toBe("claude");
     expect(inferRunAgent(["DEBUG=1", "/opt/matrix/runtime/node/bin/codex"])).toBe("codex");

--- a/tests/cli/run.test.ts
+++ b/tests/cli/run.test.ts
@@ -8,6 +8,7 @@ import { WebSocketServer } from "ws";
 import {
   createOrAttachRunSession,
   exitCodeFromRunResult,
+  hasUnsupportedLongTtySpelling,
   inferRunAgent,
   parseRunCommand,
   quoteCommandArg,
@@ -157,6 +158,8 @@ describe("run CLI command", () => {
     expect(parseRunCommand(["-it", "--cwd=projects/app", "pnpm", "test"])).toEqual(["pnpm", "test"]);
     expect(parseRunCommand(["-it", "--session=setup", "claude"])).toEqual(["claude"]);
     expect(parseRunCommand(["--tty", "--", "claude"])).toEqual(["claude"]);
+    expect(hasUnsupportedLongTtySpelling(["--t", "--", "claude"])).toBe(true);
+    expect(hasUnsupportedLongTtySpelling(["--", "echo", "--t"])).toBe(false);
   });
 
   it("shows the standard -t and --tty flags in help", async () => {

--- a/tests/cli/run.test.ts
+++ b/tests/cli/run.test.ts
@@ -158,8 +158,14 @@ describe("run CLI command", () => {
     expect(parseRunCommand(["-it", "--cwd=projects/app", "pnpm", "test"])).toEqual(["pnpm", "test"]);
     expect(parseRunCommand(["-it", "--session=setup", "claude"])).toEqual(["claude"]);
     expect(parseRunCommand(["--tty", "--", "claude"])).toEqual(["claude"]);
+  });
+
+  it("detects unsupported long t spellings only in Matrix arguments", () => {
     expect(hasUnsupportedLongTtySpelling(["--t", "--", "claude"])).toBe(true);
+    expect(hasUnsupportedLongTtySpelling(["--t=true", "--", "claude"])).toBe(true);
+    expect(hasUnsupportedLongTtySpelling(["--t=false", "--", "claude"])).toBe(true);
     expect(hasUnsupportedLongTtySpelling(["--", "echo", "--t"])).toBe(false);
+    expect(hasUnsupportedLongTtySpelling(["--", "echo", "--t=true"])).toBe(false);
   });
 
   it("shows the standard -t and --tty flags in help", async () => {
@@ -173,6 +179,14 @@ describe("run CLI command", () => {
 
   it("rejects the unsupported --t spelling", async () => {
     const result = await runMatrixCli(["run", "--t", "--", "echo", "ok"]);
+
+    expect(result.status).toBe(1);
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toContain("`--t` is not supported; use `-t` or `--tty`");
+  });
+
+  it("rejects an unsupported --t=value spelling", async () => {
+    const result = await runMatrixCli(["run", "--t=true", "--", "echo", "ok"]);
 
     expect(result.status).toBe(1);
     expect(result.stdout).toBe("");


### PR DESCRIPTION
## Summary

- reject the unsupported `matrix run --t` spelling at the CLI boundary
- continue accepting the standard `-t`, `--tty`, and combined `-it` forms
- keep arguments after `--` untouched so remote commands may receive their own `--t`
- add a process-level regression test for the sanitized actionable error

## Tests

- `pnpm exec vitest run tests/cli/run.test.ts` (15 passed)
- `pnpm --filter '@finnaai/matrix' exec tsc --noEmit`
- `pnpm run check:patterns`
- `pnpm run test` (823 files / 9,214 tests passed; 7 unrelated UI suites could not import because the linked dependency store could not resolve `vitest` from `@testing-library/jest-dom`)
- root typecheck commands passed through kernel, observability, gateway, platform, proxy, and edge-router; the unrelated Desktop step has existing implicit-`any` errors in `CommandPalette.tsx:174` and `PanelStrip.tsx:115`
- `bun run typecheck` was unavailable because Bun is not installed in this environment

## Invariants

- **Source of truth:** the raw `matrix run` argv at the CLI boundary; only Matrix-side arguments before `--` are checked.
- **Lock/transaction scope:** no database writes, persistence, locks, or transactions are involved. Validation runs before authentication or network activity.
- **Acceptable orphan states:** none. A rejected invocation creates no remote session and performs no remote action.
- **Auth source of truth:** the existing Matrix profile token and authentication flow are unchanged.
- **Deferred scope:** no compatibility period for `--t`; no behavior changes to `-t`, `--tty`, `-it`, or remote command arguments after `--`.

## Review / monitoring

- Commit range frozen at `b76770476..f7874eacf`
- CI and Greptile review pending
