### PR TITLE
feat(terminal): define runtime contracts and durable state

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "test:coverage": "sh -c 'pnpm --filter @matrix-os/observability build && pnpm --filter @matrix-os/kernel build && vitest run --coverage \"$@\"' --",
     "test:e2e": "sh -c 'pnpm --filter @matrix-os/observability build && pnpm --filter @matrix-os/kernel build && vitest run --config vitest.e2e.config.ts \"$@\"' --",
     "typecheck:build-kernel": "pnpm --filter '@matrix-os/observability' build && pnpm --filter '@matrix-os/kernel' build",
-    "typecheck": "bun run typecheck:build-kernel && pnpm --filter '@matrix-os/observability' exec tsc --noEmit && pnpm --filter '@matrix-os/gateway' exec tsc --noEmit && pnpm --filter '@matrix-os/platform' exec tsc --noEmit -p tsconfig.typecheck.json && pnpm --filter '@matrix-os/proxy' exec tsc --noEmit && pnpm --filter '@matrix-os/edge-router' exec tsc --noEmit && pnpm --filter desktop run typecheck",
+    "typecheck": "bun run typecheck:build-kernel && pnpm --filter '@matrix-os/terminal-runtime' typecheck && pnpm --filter '@matrix-os/observability' exec tsc --noEmit && pnpm --filter '@matrix-os/gateway' exec tsc --noEmit && pnpm --filter '@matrix-os/platform' exec tsc --noEmit -p tsconfig.typecheck.json && pnpm --filter '@matrix-os/proxy' exec tsc --noEmit && pnpm --filter '@matrix-os/edge-router' exec tsc --noEmit && pnpm --filter desktop run typecheck",
     "check:patterns": "./scripts/review/check-patterns.sh",
     "check:patterns:diff": "./scripts/review/check-patterns.sh --diff main",
     "lint": "bun run --filter './shell' lint"

--- a/packages/terminal-runtime/package.json
+++ b/packages/terminal-runtime/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@matrix-os/terminal-runtime",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "scripts": {
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "zod": "^4.4.3"
+  },
+  "devDependencies": {
+    "@types/node": "^24.12.0",
+    "typescript": "^5.9.3"
+  }
+}

--- a/packages/terminal-runtime/src/client.ts
+++ b/packages/terminal-runtime/src/client.ts
@@ -1,0 +1,88 @@
+import { createConnection, type Socket } from 'node:net';
+import {
+  ProtocolRequestSchema,
+  ProtocolResponseSchema,
+  type ProtocolRequest,
+  type ProtocolResponse,
+} from './contracts.js';
+import { decodeFrame, encodeFrame, MAX_FRAME_BYTES } from './framing.js';
+const DEFAULT_TIMEOUT_MS = 10_000;
+const MAX_FRAME_CHUNKS = 1_024;
+export type SupervisorClient = {
+  request(request: ProtocolRequest): Promise<ProtocolResponse>;
+};
+export function createSupervisorClient(options: {
+  socketPath?: string;
+  timeoutMs?: number;
+  connect?: (path: string) => Socket;
+} = {}): SupervisorClient {
+  const socketPath = options.socketPath ?? '/run/matrix-terminal-runtime/supervisor.sock';
+  if (!socketPath.startsWith('/') || socketPath.length > 107) {
+    throw new Error('invalid_socket_configuration');
+  }
+  const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  if (!Number.isSafeInteger(timeoutMs) || timeoutMs < 1 || timeoutMs > 60_000) {
+    throw new Error('invalid_timeout_configuration');
+  }
+  const connect = options.connect ?? ((path: string) => createConnection(path));
+  return {
+    async request(request: ProtocolRequest): Promise<ProtocolResponse> {
+      const parsedRequest = ProtocolRequestSchema.parse(request);
+      const outbound = encodeFrame(parsedRequest);
+      return await new Promise<ProtocolResponse>((resolve, reject) => {
+        const socket = connect(socketPath);
+        const chunks: Buffer[] = [];
+        let total = 0;
+        let settled = false;
+        const finish = (
+          error: Error | null,
+          response?: ProtocolResponse,
+        ): void => {
+          if (settled) return;
+          settled = true;
+          socket.destroy();
+          if (error) reject(error);
+          else if (response) resolve(response);
+          else reject(new Error('supervisor_unavailable'));
+        };
+        socket.setTimeout(timeoutMs);
+        socket.once('timeout', () => finish(new Error('supervisor_timeout')));
+        socket.once('error', (error: Error) => {
+          finish(new Error('supervisor_unavailable', { cause: error }));
+        });
+        socket.once('close', () => {
+          finish(new Error('supervisor_unavailable'));
+        });
+        socket.on('data', (chunk: Buffer) => {
+          total += chunk.byteLength;
+          if (total > MAX_FRAME_BYTES + 4) {
+            finish(new Error('frame_too_large'));
+            return;
+          }
+          if (chunks.length >= MAX_FRAME_CHUNKS) {
+            finish(new Error('frame_too_fragmented'));
+            return;
+          }
+          chunks.push(Buffer.from(chunk));
+        });
+        socket.once('end', () => {
+          try {
+            const response = ProtocolResponseSchema.parse(
+              decodeFrame(Buffer.concat(chunks, total)),
+            );
+            finish(null, response);
+          } catch (error: unknown) {
+            finish(
+              error instanceof Error
+                ? error
+                : new Error('supervisor_invalid_response'),
+            );
+          }
+        });
+        socket.once('connect', () => {
+          socket.end(outbound);
+        });
+      });
+    },
+  };
+}

--- a/packages/terminal-runtime/src/contracts.ts
+++ b/packages/terminal-runtime/src/contracts.ts
@@ -1,0 +1,178 @@
+import { randomBytes } from 'node:crypto';
+import { z } from 'zod/v4';
+export const RuntimeIdSchema = z.string().regex(/^[0-9a-f]{32}$/);
+export const OperationIdSchema = z.string().regex(/^[0-9a-f]{32}$/);
+export const DisplayNameSchema = z.string().regex(/^[a-z0-9][a-z0-9_-]{0,63}$/);
+export const MetadataRevisionSchema = z.number().int().positive().max(Number.MAX_SAFE_INTEGER);
+export const GenerationSchema = z.number().int().positive().max(Number.MAX_SAFE_INTEGER);
+export const IsoTimestampSchema = z.string().datetime({ offset: true });
+export const HomeRelativePathSchema = z.string()
+  .max(4096)
+  .refine((value) => {
+    if (value === '') return true;
+    if (value.startsWith('/') || value.includes('\0') || value.includes('\\')) return false;
+    return value.split('/').every((segment) => segment.length > 0 && segment !== '.' && segment !== '..');
+  }, 'path must be owner-home relative');
+export const HomeRelativeCwdSchema = z.object({
+  kind: z.literal('home-relative'),
+  path: HomeRelativePathSchema,
+}).strict();
+export const LifecycleStateSchema = z.enum(['starting', 'live', 'interrupted',
+  'recoverable', 'recovering', 'deleting', 'exited', 'failed']);
+export const RecoveryReasonSchema = z.enum(['cwd_unavailable',
+  'history_unavailable', 'unsupported_state', 'metadata_corrupt',
+  'runtime_lost', 'startup_failed']);
+export const LaunchDataSchema = z.discriminatedUnion('kind', [
+  z.object({ kind: z.literal('shell') }).strict(),
+  z.object({
+    kind: z.literal('agent'),
+    // The provider configuration travels on an inherited anonymous FD in the
+    // supervised launcher. This opaque correlation ID is not a provider name,
+    // executable, prompt, credential, path, or environment value.
+    configurationRef: OperationIdSchema,
+  }).strict(),
+]);
+export const ReceiptSchema = z.object({
+  schemaVersion: z.literal(1),
+  runtimeId: RuntimeIdSchema,
+  displayName: DisplayNameSchema,
+  cwd: HomeRelativeCwdSchema,
+  createdAt: IsoTimestampSchema,
+  metadataRevision: MetadataRevisionSchema,
+  lastKnown: z.object({
+    state: LifecycleStateSchema,
+    at: IsoTimestampSchema,
+    bootId: z.string().min(1).max(128).regex(/^[A-Za-z0-9._-]+$/),
+  }).strict(),
+  zellij: z.object({
+    sessionName: z.string().regex(/^matrix-t-[0-9a-f]{32}$/),
+  }).strict(),
+}).strict().superRefine((value, context) => {
+  if (value.zellij.sessionName !== `matrix-t-${value.runtimeId}`) {
+    context.addIssue({
+      code: 'custom',
+      path: ['zellij', 'sessionName'],
+      message: 'session identity must match runtime identity',
+    });
+  }
+});
+const NameTargetSchema = z.object({
+  runtimeId: RuntimeIdSchema,
+  metadataRevision: MetadataRevisionSchema,
+}).strict();
+const AliasTargetSchema = z.object({
+  runtimeId: RuntimeIdSchema,
+  expiresAt: IsoTimestampSchema,
+}).strict();
+export const NameIndexSchema = z.object({
+  schemaVersion: z.literal(1),
+  canonical: z.record(DisplayNameSchema, NameTargetSchema),
+  aliases: z.record(DisplayNameSchema, AliasTargetSchema),
+}).strict();
+export const OperationRecordSchema = z.object({
+  schemaVersion: z.literal(1),
+  operationId: OperationIdSchema,
+  runtimeId: RuntimeIdSchema.nullable(),
+  generation: GenerationSchema,
+  intent: z.enum(['create', 'recover', 'rename', 'delete', 'reconcile']),
+  status: z.enum(['accepted', 'claimed', 'ready', 'failed']),
+  requestHash: z.string().regex(/^[0-9a-f]{64}$/),
+  committedAt: IsoTimestampSchema,
+  result: z.unknown().optional(),
+}).strict();
+export const DescriptorSchema = z.object({
+  schemaVersion: z.literal(1),
+  runtimeId: RuntimeIdSchema,
+  operationId: OperationIdSchema,
+  intent: z.enum(['create', 'recover']),
+  cwd: HomeRelativeCwdSchema,
+  launch: LaunchDataSchema,
+  createdAt: IsoTimestampSchema,
+}).strict();
+const RequestBase = {
+  version: z.literal(1),
+  operationId: OperationIdSchema,
+};
+export const ProtocolRequestSchema = z.discriminatedUnion('operation', [
+  z.object({
+    ...RequestBase,
+    operation: z.literal('CreateStart'),
+    input: z.object({
+      displayName: DisplayNameSchema,
+      cwd: HomeRelativeCwdSchema.optional(),
+      launch: LaunchDataSchema,
+    }).strict(),
+  }).strict(),
+  z.object({
+    ...RequestBase,
+    operation: z.literal('Inspect'),
+    input: z.object({ runtimeId: RuntimeIdSchema }).strict(),
+  }).strict(),
+  z.object({
+    ...RequestBase,
+    operation: z.literal('List'),
+    input: z.object({}).strict(),
+  }).strict(),
+  z.object({
+    ...RequestBase,
+    operation: z.literal('Recover'),
+    input: z.object({ runtimeId: RuntimeIdSchema }).strict(),
+  }).strict(),
+  z.object({
+    ...RequestBase,
+    operation: z.literal('RenameMetadata'),
+    input: z.object({
+      runtimeId: RuntimeIdSchema,
+      displayName: DisplayNameSchema,
+      baseRevision: MetadataRevisionSchema,
+    }).strict(),
+  }).strict(),
+  z.object({
+    ...RequestBase,
+    operation: z.literal('Delete'),
+    input: z.object({ runtimeId: RuntimeIdSchema }).strict(),
+  }).strict(),
+  z.object({
+    ...RequestBase,
+    operation: z.literal('Reconcile'),
+    input: z.object({}).strict(),
+  }).strict(),
+]);
+export const ProtocolErrorCodeSchema = z.enum([
+  'invalid_request', 'not_found', 'conflict', 'unavailable', 'failed',
+]);
+export const ProtocolResponseSchema = z.discriminatedUnion('ok', [
+  z.object({
+    version: z.literal(1),
+    ok: z.literal(true),
+    operationId: OperationIdSchema,
+    result: z.unknown(),
+  }).strict(),
+  z.object({
+    version: z.literal(1),
+    ok: z.literal(false),
+    operationId: OperationIdSchema.optional(),
+    error: z.object({
+      code: ProtocolErrorCodeSchema,
+      message: z.string().min(1).max(128),
+    }).strict(),
+  }).strict(),
+]);
+export type RuntimeId = z.infer<typeof RuntimeIdSchema>;
+export type OperationId = z.infer<typeof OperationIdSchema>;
+export type Receipt = z.infer<typeof ReceiptSchema>;
+export type NameIndex = z.infer<typeof NameIndexSchema>;
+export type OperationRecord = z.infer<typeof OperationRecordSchema>;
+export type Descriptor = z.infer<typeof DescriptorSchema>;
+export type HomeRelativeCwd = z.infer<typeof HomeRelativeCwdSchema>;
+export type ProtocolRequest = z.infer<typeof ProtocolRequestSchema>;
+export type ProtocolResponse = z.infer<typeof ProtocolResponseSchema>;
+export type LifecycleState = z.infer<typeof LifecycleStateSchema>;
+export type RecoveryReason = z.infer<typeof RecoveryReasonSchema>;
+export function createRuntimeId(): RuntimeId {
+  return RuntimeIdSchema.parse(randomBytes(16).toString('hex'));
+}
+export function unitNameForRuntimeId(runtimeId: string): string {
+  const trustedId = RuntimeIdSchema.parse(runtimeId);
+  return `matrix-terminal-session@${trustedId}.service`;
+}

--- a/packages/terminal-runtime/src/descriptors.ts
+++ b/packages/terminal-runtime/src/descriptors.ts
@@ -1,0 +1,185 @@
+import {
+  DescriptorSchema,
+  OperationIdSchema,
+  RuntimeIdSchema,
+  type Descriptor,
+} from './contracts.js';
+import { isStateNotFound, SecureDirectory } from './storage.js';
+const DEFAULT_MAX_PENDING = 128;
+const DEFAULT_TTL_MS = 10 * 60 * 1000;
+const MAX_DESCRIPTOR_BYTES = 128 * 1024;
+function pendingName(runtimeId: string, operationId: string): string {
+  return `${RuntimeIdSchema.parse(runtimeId)}.${OperationIdSchema.parse(operationId)}.pending.json`;
+}
+function claimedName(runtimeId: string, operationId: string): string {
+  return `${RuntimeIdSchema.parse(runtimeId)}.${OperationIdSchema.parse(operationId)}.claimed.json`;
+}
+function isInvalidDescriptorArtifact(error: unknown): boolean {
+  return (
+    error instanceof Error &&
+    [
+      'state_invalid',
+      'state_too_large',
+      'unsafe_file',
+      'state_not_found',
+    ].includes(error.message)
+  );
+}
+export class DescriptorStore {
+  private readonly authorizeClaim: (input: {
+    runtimeId: string;
+    operationId: string;
+    pid: number;
+  }) => Promise<boolean>;
+  private readonly nowMs: () => number;
+  private readonly maxPending: number;
+  private readonly ttlMs: number;
+  constructor(
+    private readonly directory: SecureDirectory,
+    options: {
+      authorizeClaim: (input: {
+        runtimeId: string;
+        operationId: string;
+        pid: number;
+      }) => Promise<boolean>;
+      nowMs?: () => number;
+      maxPending?: number;
+      ttlMs?: number;
+    },
+  ) {
+    this.authorizeClaim = options.authorizeClaim;
+    this.nowMs = options.nowMs ?? Date.now;
+    this.maxPending = options.maxPending ?? DEFAULT_MAX_PENDING;
+    this.ttlMs = options.ttlMs ?? DEFAULT_TTL_MS;
+  }
+  async publish(descriptor: Descriptor): Promise<void> {
+    const parsed = DescriptorSchema.parse(descriptor);
+    const pending = (await this.directory.list()).filter((name) =>
+      name.endsWith('.pending.json'),
+    );
+    if (pending.length >= this.maxPending) throw new Error('descriptor_capacity');
+    await this.directory.createJsonExclusive(
+      pendingName(parsed.runtimeId, parsed.operationId),
+      parsed,
+      MAX_DESCRIPTOR_BYTES,
+    );
+  }
+  async claim(input: {
+    runtimeId: string;
+    operationId: string;
+    pid: number;
+  }): Promise<Descriptor> {
+    const runtimeId = RuntimeIdSchema.parse(input.runtimeId);
+    const operationId = OperationIdSchema.parse(input.operationId);
+    if (!Number.isSafeInteger(input.pid) || input.pid <= 0) {
+      throw new Error('claim_unauthorized');
+    }
+    if (!(await this.authorizeClaim({ runtimeId, operationId, pid: input.pid }))) {
+      throw new Error('claim_unauthorized');
+    }
+    const pending = pendingName(runtimeId, operationId);
+    const claimed = claimedName(runtimeId, operationId);
+    try {
+      await this.directory.moveExclusive(pending, claimed);
+    } catch (error: unknown) {
+      if (isStateNotFound(error)) throw new Error('descriptor_not_found');
+      throw error;
+    }
+    try {
+      const parsed = DescriptorSchema.parse(
+        await this.directory.readJson(claimed, MAX_DESCRIPTOR_BYTES),
+      );
+      if (parsed.runtimeId !== runtimeId || parsed.operationId !== operationId) {
+        throw new Error('descriptor_invalid');
+      }
+      if (this.nowMs() - Date.parse(parsed.createdAt) > this.ttlMs) {
+        throw new Error('descriptor_expired');
+      }
+      return parsed;
+    } finally {
+      await this.directory.remove(claimed).catch((error: unknown) => {
+        if (!isStateNotFound(error)) throw error;
+      });
+    }
+  }
+  async remove(runtimeId: string, operationId: string): Promise<void> {
+    for (const name of [
+      pendingName(runtimeId, operationId),
+      claimedName(runtimeId, operationId),
+    ]) {
+      await this.directory.remove(name).catch((error: unknown) => {
+        if (!isStateNotFound(error)) throw error;
+      });
+    }
+  }
+  async removeRuntime(runtimeId: string): Promise<void> {
+    const id = RuntimeIdSchema.parse(runtimeId);
+    const prefix = `${id}.`;
+    for (const name of await this.directory.list()) {
+      if (
+        name.startsWith(prefix) &&
+        (name.endsWith('.pending.json') || name.endsWith('.claimed.json'))
+      ) {
+        await this.directory.remove(name).catch((error: unknown) => {
+          if (!isStateNotFound(error)) throw error;
+        });
+      }
+    }
+  }
+  async countPending(): Promise<number> {
+    return (await this.directory.list()).filter((name) =>
+      name.endsWith('.pending.json'),
+    ).length;
+  }
+  async pendingKind(
+    runtimeId: string,
+  ): Promise<'create-pending' | 'recover-pending' | null> {
+    const prefix = `${RuntimeIdSchema.parse(runtimeId)}.`;
+    const names = (await this.directory.list()).filter(
+      (name) => name.startsWith(prefix) && name.endsWith('.pending.json'),
+    );
+    for (const name of names) {
+      let value: unknown;
+      try {
+        value = await this.directory.readJson(name, MAX_DESCRIPTOR_BYTES);
+      } catch (error: unknown) {
+        if (isInvalidDescriptorArtifact(error)) continue;
+        throw error;
+      }
+      const descriptor = DescriptorSchema.safeParse(value);
+      if (descriptor.success) return `${descriptor.data.intent}-pending`;
+    }
+    return null;
+  }
+  async sweep(options: {
+    isActive: (input: { runtimeId: string; operationId: string }) => Promise<boolean>;
+    isLocked: (input: { runtimeId: string; operationId: string }) => Promise<boolean>;
+  }): Promise<number> {
+    let removed = 0;
+    for (const name of await this.directory.list()) {
+      const match = name.match(/^([0-9a-f]{32})\.([0-9a-f]{32})\.pending\.json$/);
+      if (!match) continue;
+      const [, runtimeId, operationId] = match;
+      if (
+        (await options.isActive({ runtimeId, operationId })) ||
+        (await options.isLocked({ runtimeId, operationId }))
+      ) {
+        continue;
+      }
+      let value: unknown;
+      try {
+        value = await this.directory.readJson(name, MAX_DESCRIPTOR_BYTES);
+      } catch (error: unknown) {
+        if (isInvalidDescriptorArtifact(error)) continue;
+        throw error;
+      }
+      const parsed = DescriptorSchema.safeParse(value);
+      if (!parsed.success) continue;
+      const descriptor: Descriptor = parsed.data;
+      if (this.nowMs() - Date.parse(descriptor.createdAt) <= this.ttlMs) continue;
+      await this.directory.remove(name);
+      removed += 1;
+    }
+    return removed;
+  }
+}

--- a/packages/terminal-runtime/src/framing.ts
+++ b/packages/terminal-runtime/src/framing.ts
@@ -1,0 +1,163 @@
+export const MAX_FRAME_BYTES = 128 * 1024;
+const MAX_JSON_DEPTH = 128;
+const MAX_OBJECT_KEYS = 4_096;
+function fail(code: string): never {
+  throw new Error(code);
+}
+class UniqueJsonKeyParser {
+  private offset = 0;
+  constructor(private readonly text: string) {}
+  validate(): void {
+    this.skipWhitespace();
+    this.parseValue();
+    this.skipWhitespace();
+    if (this.offset !== this.text.length) fail('frame_invalid_json');
+  }
+  private parseValue(depth = 0): void {
+    if (depth > MAX_JSON_DEPTH) fail('frame_too_complex');
+    this.skipWhitespace();
+    const token = this.text[this.offset];
+    if (token === '{') return this.parseObject(depth);
+    if (token === '[') return this.parseArray(depth);
+    if (token === '"') {
+      this.parseString();
+      return;
+    }
+    if (this.text.startsWith('true', this.offset)) {
+      this.offset += 4;
+      return;
+    }
+    if (this.text.startsWith('false', this.offset)) {
+      this.offset += 5;
+      return;
+    }
+    if (this.text.startsWith('null', this.offset)) {
+      this.offset += 4;
+      return;
+    }
+    this.parseNumber();
+  }
+  private parseObject(depth: number): void {
+    this.offset += 1;
+    this.skipWhitespace();
+    const keys = new Set<string>();
+    if (this.text[this.offset] === '}') {
+      this.offset += 1;
+      return;
+    }
+    while (this.offset < this.text.length) {
+      if (this.text[this.offset] !== '"') fail('frame_invalid_json');
+      const key = this.parseString();
+      if (keys.has(key)) fail('frame_duplicate_key');
+      if (keys.size >= MAX_OBJECT_KEYS) fail('frame_too_complex');
+      keys.add(key);
+      this.skipWhitespace();
+      if (this.text[this.offset] !== ':') fail('frame_invalid_json');
+      this.offset += 1;
+      this.parseValue(depth + 1);
+      this.skipWhitespace();
+      const token = this.text[this.offset];
+      if (token === '}') {
+        this.offset += 1;
+        return;
+      }
+      if (token !== ',') fail('frame_invalid_json');
+      this.offset += 1;
+      this.skipWhitespace();
+    }
+    fail('frame_invalid_json');
+  }
+  private parseArray(depth: number): void {
+    this.offset += 1;
+    this.skipWhitespace();
+    if (this.text[this.offset] === ']') {
+      this.offset += 1;
+      return;
+    }
+    while (this.offset < this.text.length) {
+      this.parseValue(depth + 1);
+      this.skipWhitespace();
+      const token = this.text[this.offset];
+      if (token === ']') {
+        this.offset += 1;
+        return;
+      }
+      if (token !== ',') fail('frame_invalid_json');
+      this.offset += 1;
+    }
+    fail('frame_invalid_json');
+  }
+  private parseString(): string {
+    const start = this.offset;
+    this.offset += 1;
+    while (this.offset < this.text.length) {
+      const token = this.text[this.offset];
+      if (token === '"') {
+        this.offset += 1;
+        try {
+          return JSON.parse(this.text.slice(start, this.offset)) as string;
+        } catch (error: unknown) {
+          if (error instanceof SyntaxError) fail('frame_invalid_json');
+          throw error;
+        }
+      }
+      if (token === '\\') {
+        this.offset += 1;
+        const escaped = this.text[this.offset];
+        if (escaped === 'u') {
+          const digits = this.text.slice(this.offset + 1, this.offset + 5);
+          if (!/^[0-9a-fA-F]{4}$/.test(digits)) fail('frame_invalid_json');
+          this.offset += 5;
+          continue;
+        }
+        if (!'"\\/bfnrt'.includes(escaped ?? '')) fail('frame_invalid_json');
+        this.offset += 1;
+        continue;
+      }
+      if (token === undefined || token.charCodeAt(0) < 0x20) fail('frame_invalid_json');
+      this.offset += 1;
+    }
+    fail('frame_invalid_json');
+  }
+  private parseNumber(): void {
+    const match = this.text.slice(this.offset).match(/^-?(?:0|[1-9]\d*)(?:\.\d+)?(?:[eE][+-]?\d+)?/);
+    if (!match) fail('frame_invalid_json');
+    this.offset += match[0].length;
+  }
+  private skipWhitespace(): void {
+    while (/[\t\n\r ]/.test(this.text[this.offset] ?? '')) this.offset += 1;
+  }
+}
+export function parseUniqueJson(text: string): unknown {
+  new UniqueJsonKeyParser(text).validate();
+  try {
+    return JSON.parse(text) as unknown;
+  } catch (error: unknown) {
+    if (error instanceof SyntaxError) fail('frame_invalid_json');
+    throw error;
+  }
+}
+export function encodeFrame(value: unknown): Buffer {
+  const payload = Buffer.from(JSON.stringify(value), 'utf8');
+  if (payload.byteLength > MAX_FRAME_BYTES) fail('frame_too_large');
+  const frame = Buffer.allocUnsafe(payload.byteLength + 4);
+  frame.writeUInt32BE(payload.byteLength, 0);
+  payload.copy(frame, 4);
+  return frame;
+}
+export function decodeFrame(input: Uint8Array): unknown {
+  const frame = Buffer.from(input);
+  if (frame.byteLength < 4) fail('frame_incomplete');
+  const length = frame.readUInt32BE(0);
+  if (length > MAX_FRAME_BYTES) fail('frame_too_large');
+  if (frame.byteLength < length + 4) fail('frame_incomplete');
+  if (frame.byteLength !== length + 4) fail('frame_trailing_bytes');
+  let text: string;
+  try {
+    text = new TextDecoder('utf-8', { fatal: true }).decode(frame.subarray(4));
+  } catch (error: unknown) {
+    if (error instanceof TypeError) fail('frame_invalid_utf8');
+    throw error;
+  }
+  return parseUniqueJson(text);
+}

--- a/packages/terminal-runtime/src/index.ts
+++ b/packages/terminal-runtime/src/index.ts
@@ -1,0 +1,2 @@
+export * from './client.js'; export * from './contracts.js'; export * from './descriptors.js'; export * from './framing.js'; export * from './locks.js';
+export * from './operation-handler.js'; export * from './receipts.js'; export * from './reconciliation.js'; export * from './runtime-state.js'; export * from './storage.js';

--- a/packages/terminal-runtime/src/locks.ts
+++ b/packages/terminal-runtime/src/locks.ts
@@ -1,0 +1,92 @@
+import { spawn } from 'node:child_process';
+import { type FileHandle } from 'node:fs/promises';
+import { RuntimeIdSchema } from './contracts.js';
+import { SecureDirectory } from './storage.js';
+const LOCK_TIMEOUT_MS = 10_000;
+type LockHandle = { release(): Promise<void> };
+async function waitForFlock(
+  handle: FileHandle,
+  flockPath: string,
+  timeoutMs: number,
+): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    let settled = false;
+    const child = spawn(flockPath, ['--exclusive', '3'], {
+      shell: false,
+      stdio: ['ignore', 'ignore', 'ignore', handle.fd],
+    });
+    const finish = (error?: Error): void => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      if (error) reject(error);
+      else resolve();
+    };
+    const timer = setTimeout(() => {
+      child.kill('SIGKILL');
+      finish(new Error('lock_timeout'));
+    }, timeoutMs);
+    timer.unref();
+    child.once('error', (error: Error) => {
+      finish(new Error('lock_failed', { cause: error }));
+    });
+    child.once('exit', (code, signal) => {
+      if (code === 0 && signal === null) finish();
+      else finish(new Error('lock_failed'));
+    });
+  });
+}
+export class FlockManager {
+  private constructor(
+    private readonly directory: SecureDirectory,
+    private readonly flockPath: string,
+    private readonly timeoutMs: number,
+  ) {}
+  static async open(
+    root: string,
+    options: { flockPath?: string; timeoutMs?: number } = {},
+  ): Promise<FlockManager> {
+    const directory = await SecureDirectory.open(root);
+    return new FlockManager(
+      directory,
+      options.flockPath ?? '/usr/bin/flock',
+      options.timeoutMs ?? LOCK_TIMEOUT_MS,
+    );
+  }
+  private async acquire(name: string): Promise<LockHandle> {
+    const handle = await this.directory.openLock(name);
+    try {
+      await waitForFlock(handle, this.flockPath, this.timeoutMs);
+      return { release: async () => handle.close() };
+    } catch (error: unknown) {
+      await handle.close();
+      throw error;
+    }
+  }
+  async withNameIndex<T>(callback: () => Promise<T>): Promise<T> {
+    const lock = await this.acquire('name-index.lock');
+    try {
+      return await callback();
+    } finally {
+      await lock.release();
+    }
+  }
+  async withRuntime<T>(
+    runtimeId: string,
+    includeNameIndex: boolean,
+    callback: () => Promise<T>,
+  ): Promise<T> {
+    const id = RuntimeIdSchema.parse(runtimeId);
+    const held: LockHandle[] = [];
+    try {
+      if (includeNameIndex) held.push(await this.acquire('name-index.lock'));
+      held.push(await this.acquire(`runtime-${id}.lock`));
+      return await callback();
+    } finally {
+      for (const lock of held.reverse()) await lock.release();
+    }
+  }
+  async close(): Promise<void> {
+    await this.directory.close();
+  }
+}

--- a/packages/terminal-runtime/src/operation-handler.ts
+++ b/packages/terminal-runtime/src/operation-handler.ts
@@ -1,0 +1,469 @@
+import { createHash } from 'node:crypto';
+import { readFile } from 'node:fs/promises';
+import {
+  ProtocolRequestSchema, RuntimeIdSchema, createRuntimeId, type Descriptor,
+  type HomeRelativeCwd, type OperationRecord, type ProtocolRequest,
+  type ProtocolResponse, type Receipt,
+} from './contracts.js';
+import { reconcileLifecycle, type RuntimeEvidence } from './reconciliation.js';
+import type { ReceiptReadResult } from './receipts.js';
+import type { RuntimeState } from './runtime-state.js';
+const MAX_LIST_RUNTIMES = 2_048;
+export type UnitInspection = {
+  runtimeId: string; cgroupPopulated: boolean; keeperReady: boolean;
+  keeperAlive: boolean; zellijResponsive: boolean;
+  unit: 'active' | 'activating' | 'inactive' | 'failed' | 'missing';
+  requiredProcessesInCgroup: boolean;
+  resurrection: 'valid' | 'missing' | 'corrupt' | 'incompatible';
+};
+export interface SystemdExecutor {
+  start(runtimeId: string): Promise<void>; stop(runtimeId: string): Promise<void>;
+  inspect(runtimeId: string): Promise<UnitInspection | null>; list(): Promise<UnitInspection[]>;
+}
+type OperationHandlerOptions = {
+  state: RuntimeState; executor: SystemdExecutor; now?: () => Date;
+  bootId?: () => Promise<string>; createId?: () => string;
+  resolveCwd: (cwd: HomeRelativeCwd) => Promise<HomeRelativeCwd>;
+};
+type ProtocolErrorCode = 'invalid_request' | 'not_found' | 'conflict'
+  | 'unavailable' | 'failed';
+type StoredOutcome = { ok: true; value: unknown }
+  | { ok: false; code: ProtocolErrorCode };
+class OperationFailure extends Error {
+  constructor(readonly code: ProtocolErrorCode, cause?: unknown) {
+    super('operation_failed', cause === undefined ? undefined : { cause });
+  }
+}
+function requestHash(request: ProtocolRequest): string {
+  return createHash('sha256').update(JSON.stringify(request)).digest('hex');
+}
+function errorResponse(operationId: string | undefined, code: ProtocolErrorCode): ProtocolResponse {
+  return {
+    version: 1,
+    ok: false,
+    ...(operationId ? { operationId } : {}),
+    error: { code, message: 'Request failed' },
+  };
+}
+function mapError(error: unknown): ProtocolErrorCode {
+  if (error instanceof OperationFailure) return error.code;
+  if (!(error instanceof Error)) return 'failed';
+  if (['state_conflict', 'name_conflict', 'operation_id_conflict',
+    'descriptor_capacity'].includes(error.message)) return 'conflict';
+  if (['state_not_found', 'descriptor_not_found'].includes(error.message))
+    return 'not_found';
+  if (error.message.startsWith('lock_')) return 'unavailable';
+  return 'failed';
+}
+function parseStoredOutcome(value: unknown): StoredOutcome | null {
+  if (typeof value !== 'object' || value === null || !('ok' in value)) return null;
+  if (value.ok === true && 'value' in value) {
+    return { ok: true, value: value.value };
+  }
+  if (value.ok === false && 'code' in value && typeof value.code === 'string' &&
+    ['invalid_request', 'not_found', 'conflict', 'unavailable', 'failed']
+      .includes(value.code)) {
+    return { ok: false, code: value.code as ProtocolErrorCode };
+  }
+  return null;
+}
+function unwrapOutcome(outcome: StoredOutcome): unknown {
+  if (outcome.ok) return outcome.value;
+  throw new OperationFailure(outcome.code);
+}
+async function defaultBootId(): Promise<string> {
+  const value = (await readFile('/proc/sys/kernel/random/boot_id', 'utf8')).trim();
+  if (!/^[A-Za-z0-9._-]{1,128}$/.test(value)) throw new Error('boot_id_invalid');
+  return value;
+}
+function evidenceFor(receipt: ReceiptReadResult, inspection: UnitInspection | null,
+  descriptor: RuntimeEvidence['descriptor'], bootIdMatches: boolean): RuntimeEvidence {
+  return {
+    deleteIntent: receipt?.kind === 'supported' &&
+      receipt.receipt.lastKnown.state === 'deleting',
+    unit: inspection?.unit ?? 'missing',
+    cgroupPopulated: inspection?.cgroupPopulated ?? false,
+    keeperReady: inspection?.keeperReady ?? false, keeperAlive: inspection?.keeperAlive ?? false,
+    zellijResponsive: inspection?.zellijResponsive ?? false,
+    requiredProcessesInCgroup: inspection?.requiredProcessesInCgroup ?? false,
+    descriptor,
+    receipt: receipt === null ? 'missing'
+      : receipt.kind === 'unsupported' ? 'unsupported' : 'valid',
+    resurrection: inspection?.resurrection ?? 'missing',
+    priorState: receipt?.kind === 'supported' ? receipt.receipt.lastKnown.state : null,
+    bootIdMatches,
+  };
+}
+export function createOperationHandler(options: OperationHandlerOptions) {
+  const now = options.now ?? (() => new Date());
+  const bootId = options.bootId ?? defaultBootId;
+  const createId = options.createId ?? createRuntimeId;
+  async function inspectRuntime(runtimeId: string) {
+    const id = RuntimeIdSchema.parse(runtimeId);
+    const [receipt, inspection, descriptor, currentBootId] = await Promise.all([
+      options.state.receipts.read(id), options.executor.inspect(id),
+      options.state.descriptors.pendingKind(id), bootId(),
+    ]);
+    return {
+      runtimeId: id,
+      ...(receipt?.kind === 'supported'
+        ? {
+            displayName: receipt.receipt.displayName,
+            metadataRevision: receipt.receipt.metadataRevision,
+          }
+        : {}),
+      ...reconcileLifecycle(evidenceFor(receipt, inspection, descriptor,
+        receipt?.kind !== 'supported' ||
+          receipt.receipt.lastKnown.bootId === currentBootId)),
+    };
+  }
+  async function listRuntimes() {
+    const [units, receipts] = await Promise.all([
+      options.executor.list(), options.state.receipts.list(),
+    ]);
+    const runtimeIds = new Set<string>();
+    const addRuntimeId = (runtimeId: string) => {
+      const id = RuntimeIdSchema.parse(runtimeId);
+      if (!runtimeIds.has(id) && runtimeIds.size >= MAX_LIST_RUNTIMES) {
+        throw new Error('runtime_list_capacity');
+      }
+      runtimeIds.add(id);
+    };
+    for (const unit of units) addRuntimeId(unit.runtimeId);
+    for (const receipt of receipts) addRuntimeId(receipt.runtimeId);
+    return await Promise.all([...runtimeIds].sort().map(inspectRuntime));
+  }
+  async function beginOperation(request: ProtocolRequest,
+    intent: OperationRecord['intent'], runtimeId: string | null,
+  ): Promise<{ record: OperationRecord; replay: StoredOutcome | null }> {
+    const hash = requestHash(request);
+    const current = await options.state.operations.read(request.operationId);
+    if (current) {
+      if (current.requestHash !== hash) throw new Error('operation_id_conflict');
+      if (current.intent !== intent || current.runtimeId !== runtimeId) {
+        throw new Error('operation_state_conflict');
+      }
+      return { record: current, replay: parseStoredOutcome(current.result) };
+    }
+    const record = await options.state.operations.commit({
+      schemaVersion: 1, operationId: request.operationId, runtimeId,
+      generation: await options.state.operations.nextGeneration(),
+      intent, status: 'accepted', requestHash: hash, committedAt: now().toISOString(),
+    });
+    return { record, replay: parseStoredOutcome(record.result) };
+  }
+  async function finishOperation(record: OperationRecord,
+    outcome: StoredOutcome): Promise<void> {
+    await options.state.operations.complete({
+      ...record, status: outcome.ok ? 'ready' : 'failed', result: outcome,
+    });
+  }
+  async function succeedOperation(record: OperationRecord,
+    value: unknown): Promise<unknown> {
+    await finishOperation(record, { ok: true, value });
+    return value;
+  }
+  async function failOperation(record: OperationRecord, error: unknown): Promise<never> {
+    const code = mapError(error);
+    await finishOperation(record, { ok: false, code });
+    throw new OperationFailure(code, error);
+  }
+  async function mutate(request: ProtocolRequest, intent: OperationRecord['intent'],
+    runtimeId: string | null,
+    callback: (record: OperationRecord, resuming: boolean) => Promise<unknown>,
+  ): Promise<unknown> {
+    return await options.state.locks.withNameIndex(async () => {
+      const existing = await options.state.operations.read(request.operationId);
+      if (existing && existing.requestHash !== requestHash(request)) {
+        throw new Error('operation_id_conflict');
+      }
+      const target = existing?.runtimeId ?? runtimeId;
+      const run = async () => {
+        const operation = await beginOperation(request, intent, target);
+        return operation.replay
+          ? unwrapOutcome(operation.replay)
+          : callback(operation.record, existing !== null);
+      };
+      return target === null
+        ? run()
+        : options.state.locks.withRuntime(target, false, run);
+    });
+  }
+  async function markReceiptFailed(runtimeId: string): Promise<void> {
+    const current = await options.state.receipts.read(runtimeId);
+    if (current?.kind !== 'supported') return;
+    await options.state.receipts.replace({
+      ...current.receipt,
+      lastKnown: { ...current.receipt.lastKnown, state: 'failed',
+        at: now().toISOString() },
+    });
+  }
+  async function failStart(record: OperationRecord, runtimeId: string,
+    operationId: string, error: unknown): Promise<never> {
+    await options.state.descriptors.remove(runtimeId, operationId);
+    await markReceiptFailed(runtimeId);
+    return await failOperation(record, error);
+  }
+  async function createStart(request: Extract<ProtocolRequest,
+    { operation: 'CreateStart' }>) {
+    const proposedId = RuntimeIdSchema.parse(createId());
+    return await mutate(request, 'create', proposedId, async (record, resuming) => {
+      const runtimeId = RuntimeIdSchema.parse(record.runtimeId);
+      let existingName = await options.state.names.resolve(request.input.displayName, now().getTime());
+      if (!existingName) {
+        const orphan = await options.state.receipts.findByDisplayName(request.input.displayName);
+        if (orphan) {
+          await options.state.names.register(request.input.displayName, orphan.runtimeId, orphan.metadataRevision, now().getTime());
+          existingName = { runtimeId: orphan.runtimeId, source: 'canonical' };
+        }
+      }
+      if (existingName && (!resuming || existingName.runtimeId !== runtimeId)) {
+        const result = await inspectRuntime(existingName.runtimeId);
+        // Failed identities stay reserved; only explicit Recover may restart them.
+        if (result.lifecycleState === 'failed')
+          return await failOperation(record, new Error('runtime_failed'));
+        return await succeedOperation(record, result);
+      }
+      const stored = await options.state.receipts.read(runtimeId);
+      if (stored?.kind === 'unsupported')
+        return await failOperation(record, new Error('state_conflict'));
+      if (stored?.kind === 'supported' &&
+        stored.receipt.lastKnown.state === 'failed')
+        return await failOperation(record, new Error('runtime_failed'));
+      if (stored?.kind === 'supported' &&
+        stored.receipt.displayName !== request.input.displayName)
+        return await failOperation(record, new Error('state_conflict'));
+      let cwd: HomeRelativeCwd;
+      if (stored?.kind === 'supported') {
+        cwd = stored.receipt.cwd;
+      } else {
+        try {
+          cwd = await options.resolveCwd(request.input.cwd ?? {
+            kind: 'home-relative', path: '',
+          });
+        } catch (error: unknown) {
+          return await failOperation(record, error);
+        }
+        const createdAt = now().toISOString();
+        await options.state.receipts.create({
+          schemaVersion: 1, runtimeId, displayName: request.input.displayName,
+          cwd, createdAt, metadataRevision: 1,
+          lastKnown: { state: 'starting', at: createdAt, bootId: await bootId() },
+          zellij: { sessionName: `matrix-t-${runtimeId}` },
+        });
+      }
+      if (!existingName) await options.state.names.register(
+        request.input.displayName, runtimeId, 1, now().getTime());
+      const inspection = await options.executor.inspect(runtimeId);
+      if (inspection?.unit === 'active' || inspection?.unit === 'activating') {
+        return await succeedOperation(record, await inspectRuntime(runtimeId));
+      }
+      const createdAt = now().toISOString();
+      const descriptor: Descriptor = {
+        schemaVersion: 1, runtimeId, operationId: request.operationId,
+        intent: 'create', cwd, launch: request.input.launch, createdAt,
+      };
+      try {
+        // Fixed-template systemd start is idempotent and resumes this runtime only.
+        await options.state.descriptors.removeRuntime(runtimeId);
+        await options.state.descriptors.publish(descriptor);
+        await options.executor.start(runtimeId);
+      } catch (error: unknown) {
+        return await failStart(record, runtimeId, request.operationId, error);
+      }
+      return await succeedOperation(record,
+        { runtimeId, lifecycleState: 'starting' });
+    });
+  }
+  async function recover(request: Extract<ProtocolRequest, { operation: 'Recover' }>) {
+    return await mutate(
+      request,
+      'recover',
+      request.input.runtimeId,
+      async (record) => {
+        const current = await options.state.receipts.read(request.input.runtimeId);
+        if (!current || current.kind !== 'supported') {
+          return await failOperation(record, new Error('state_not_found'));
+        }
+        if (current.receipt.lastKnown.state === 'deleting') {
+          return await failOperation(record, new Error('state_conflict'));
+        }
+        const inspection = await options.executor.inspect(current.receipt.runtimeId);
+        if (inspection?.unit === 'active' || inspection?.unit === 'activating') {
+          const result = await inspectRuntime(current.receipt.runtimeId);
+          return await succeedOperation(record, result);
+        }
+        let cwd: HomeRelativeCwd;
+        try {
+          cwd = await options.resolveCwd(current.receipt.cwd);
+        } catch (error: unknown) {
+          try {
+            cwd = await options.resolveCwd({ kind: 'home-relative', path: '' });
+          } catch (fallbackError: unknown) {
+            return await failOperation(record,
+              new AggregateError([error, fallbackError], 'cwd_unavailable'));
+          }
+        }
+        const descriptor: Descriptor = {
+          schemaVersion: 1, runtimeId: current.receipt.runtimeId,
+          operationId: request.operationId, intent: 'recover', cwd,
+          launch: { kind: 'shell' }, createdAt: now().toISOString(),
+        };
+        try {
+          await options.state.descriptors.removeRuntime(current.receipt.runtimeId);
+          await options.state.descriptors.publish(descriptor);
+          await options.state.receipts.replace({
+            ...current.receipt,
+            cwd,
+            lastKnown: { state: 'recovering', at: now().toISOString(),
+              bootId: await bootId() },
+          });
+          await options.executor.start(current.receipt.runtimeId);
+        } catch (error: unknown) {
+          return await failStart(record, current.receipt.runtimeId,
+            request.operationId, error);
+        }
+        return await succeedOperation(record, {
+          runtimeId: current.receipt.runtimeId, lifecycleState: 'recovering',
+        });
+      },
+    );
+  }
+  async function renameMetadata(request: Extract<ProtocolRequest,
+    { operation: 'RenameMetadata' }>) {
+    return await mutate(
+      request,
+      'rename',
+      request.input.runtimeId,
+      async (record) => {
+        const current = await options.state.receipts.read(request.input.runtimeId);
+        if (!current || current.kind !== 'supported') {
+          throw new Error('state_not_found');
+        }
+        const nextRevision = request.input.baseRevision + 1;
+        if (
+          current.receipt.metadataRevision !== request.input.baseRevision &&
+          (current.receipt.metadataRevision !== nextRevision ||
+            current.receipt.displayName !== request.input.displayName)
+        ) throw new Error('state_conflict');
+        const target = await options.state.names.resolve(
+          request.input.displayName, now().getTime(),
+        );
+        if (target && target.runtimeId !== request.input.runtimeId) {
+          throw new Error('name_conflict');
+        }
+        if (current.receipt.metadataRevision === request.input.baseRevision) {
+          await options.state.receipts.replace({
+            ...current.receipt, displayName: request.input.displayName,
+            metadataRevision: nextRevision,
+          });
+        }
+        const revision = await options.state.names.rename({
+          runtimeId: request.input.runtimeId,
+          to: request.input.displayName,
+          baseRevision: request.input.baseRevision,
+          nowMs: now().getTime(),
+        });
+        return await succeedOperation(record, {
+          runtimeId: request.input.runtimeId,
+          displayName: request.input.displayName,
+          metadataRevision: revision,
+        });
+      },
+    );
+  }
+  async function finishDeletion(runtimeId: string,
+    record: OperationRecord | null): Promise<{ runtimeId: string; deleted: true }> {
+    await options.state.names.deleteRuntime(runtimeId);
+    await options.state.descriptors.removeRuntime(runtimeId);
+    const result = { runtimeId, deleted: true as const };
+    if (record) await finishOperation(record, { ok: true, value: result });
+    await options.state.receipts.delete(runtimeId);
+    return result;
+  }
+  async function deleteRuntime(request: Extract<ProtocolRequest,
+    { operation: 'Delete' }>) {
+    return await mutate(
+      request,
+      'delete',
+      request.input.runtimeId,
+      async (record) => {
+        const current = await options.state.receipts.read(request.input.runtimeId);
+        if (!current) {
+          const result = { runtimeId: request.input.runtimeId, deleted: true };
+          return await succeedOperation(record, result);
+        }
+        if (current.kind !== 'supported') {
+          return await failOperation(record, new Error('state_conflict'));
+        }
+        const deleting: Receipt = { ...current.receipt,
+          lastKnown: { state: 'deleting', at: now().toISOString(),
+            bootId: await bootId() } };
+        await options.state.receipts.replace(deleting);
+        await options.executor.stop(request.input.runtimeId);
+        const inspection = await options.executor.inspect(request.input.runtimeId);
+        if (
+          inspection?.cgroupPopulated ||
+          inspection?.unit === 'active' ||
+          inspection?.unit === 'activating'
+        ) {
+          return { runtimeId: request.input.runtimeId,
+            lifecycleState: 'deleting' };
+        }
+        return await finishDeletion(request.input.runtimeId, record);
+      },
+    );
+  }
+  async function reconcile(request: Extract<ProtocolRequest,
+    { operation: 'Reconcile' }>) {
+    return await mutate(request, 'reconcile', null, async (record) => {
+      for (const { runtimeId, state } of await options.state.receipts.list()) {
+        if (
+          state?.kind !== 'supported' ||
+          state.receipt.lastKnown.state !== 'deleting'
+        ) continue;
+        await options.state.locks.withRuntime(runtimeId, false, async () => {
+          let inspection = await options.executor.inspect(runtimeId);
+          if (
+            inspection?.cgroupPopulated ||
+            inspection?.unit === 'active' ||
+            inspection?.unit === 'activating'
+          ) {
+            await options.executor.stop(runtimeId);
+            inspection = await options.executor.inspect(runtimeId);
+          }
+          if (
+            inspection?.cgroupPopulated ||
+            inspection?.unit === 'active' ||
+            inspection?.unit === 'activating'
+          ) return;
+          const deletion = await options.state.operations.latest(runtimeId, 'delete');
+          await finishDeletion(runtimeId, deletion);
+        });
+      }
+      const result = await listRuntimes();
+      // The supervisor invokes Reconcile at startup and on its recurring sweep.
+      return await succeedOperation(record, result);
+    });
+  }
+  return async (rawRequest: unknown): Promise<ProtocolResponse> => {
+    const parsed = ProtocolRequestSchema.safeParse(rawRequest);
+    if (!parsed.success) return errorResponse(undefined, 'invalid_request');
+    const request = parsed.data;
+    try {
+      let result: unknown;
+      switch (request.operation) {
+        case 'CreateStart': result = await createStart(request); break;
+        case 'Inspect': result = await inspectRuntime(request.input.runtimeId); break;
+        case 'List': result = await listRuntimes(); break;
+        case 'Recover': result = await recover(request); break;
+        case 'RenameMetadata': result = await renameMetadata(request); break;
+        case 'Delete': result = await deleteRuntime(request); break;
+        case 'Reconcile': result = await reconcile(request); break;
+      }
+      return { version: 1, ok: true, operationId: request.operationId, result };
+    } catch (error: unknown) {
+      return errorResponse(request.operationId, mapError(error));
+    }
+  };
+}

--- a/packages/terminal-runtime/src/receipts.ts
+++ b/packages/terminal-runtime/src/receipts.ts
@@ -1,0 +1,260 @@
+import {
+  DisplayNameSchema,
+  NameIndexSchema,
+  OperationIdSchema,
+  OperationRecordSchema,
+  ReceiptSchema,
+  RuntimeIdSchema,
+  type NameIndex,
+  type OperationRecord,
+  type Receipt,
+} from './contracts.js';
+import { isStateNotFound, SecureDirectory } from './storage.js';
+const NAME_INDEX_FILE = 'name-index.json';
+const ALIAS_TTL_MS = 24 * 60 * 60 * 1000;
+function emptyNameIndex(): NameIndex {
+  return { schemaVersion: 1, canonical: {}, aliases: {} };
+}
+function receiptFile(runtimeId: string): string {
+  return `${RuntimeIdSchema.parse(runtimeId)}.json`;
+}
+function operationFile(operationId: string): string {
+  return `operation-${OperationIdSchema.parse(operationId)}.json`;
+}
+export type ReceiptReadResult =
+  | { kind: 'supported'; receipt: Receipt }
+  | { kind: 'unsupported'; schemaVersion: number }
+  | null;
+export class ReceiptStore {
+  constructor(private readonly directory: SecureDirectory) {}
+  async create(receipt: Receipt): Promise<void> {
+    const parsed = ReceiptSchema.parse(receipt);
+    await this.directory.createJsonExclusive(receiptFile(parsed.runtimeId), parsed);
+  }
+  async replace(receipt: Receipt): Promise<void> {
+    const parsed = ReceiptSchema.parse(receipt);
+    await this.directory.replaceJson(receiptFile(parsed.runtimeId), parsed);
+  }
+  async read(runtimeId: string): Promise<ReceiptReadResult> {
+    let value: unknown;
+    try {
+      value = await this.directory.readJson(receiptFile(runtimeId));
+    } catch (error: unknown) {
+      if (isStateNotFound(error)) return null;
+      throw error;
+    }
+    const parsed = ReceiptSchema.safeParse(value);
+    if (parsed.success) return { kind: 'supported', receipt: parsed.data };
+    if (typeof value === 'object' && value !== null &&
+      'schemaVersion' in value && typeof value.schemaVersion === 'number' &&
+      Number.isInteger(value.schemaVersion) && value.schemaVersion > 1) {
+      return { kind: 'unsupported', schemaVersion: value.schemaVersion };
+    }
+    throw new Error('state_invalid');
+  }
+  async list(): Promise<Array<{ runtimeId: string; state: ReceiptReadResult }>> {
+    const names = (await this.directory.list()).filter((name) => /^[0-9a-f]{32}\.json$/.test(name));
+    const records: Array<{ runtimeId: string; state: ReceiptReadResult }> = [];
+    for (const name of names) {
+      const runtimeId = name.slice(0, 32);
+      records.push({ runtimeId, state: await this.read(runtimeId) });
+    }
+    return records;
+  }
+  async findByDisplayName(displayName: string): Promise<Receipt | null> {
+    const name = DisplayNameSchema.parse(displayName);
+    const matches = (await this.list()).flatMap(({ state }) => state?.kind ===
+      'supported' && state.receipt.displayName === name ? [state.receipt] : []);
+    if (matches.length > 1) throw new Error('name_conflict');
+    return matches[0] ?? null;
+  }
+  async delete(runtimeId: string): Promise<void> {
+    try {
+      await this.directory.remove(receiptFile(runtimeId));
+    } catch (error: unknown) {
+      if (!isStateNotFound(error)) throw error;
+    }
+  }
+}
+export type NameResolution = {
+  runtimeId: string;
+  metadataRevision?: number;
+  source: 'canonical' | 'alias';
+};
+export class NameIndexStore {
+  constructor(private readonly directory: SecureDirectory) {}
+  private async load(): Promise<NameIndex> {
+    try {
+      return NameIndexSchema.parse(await this.directory.readJson(NAME_INDEX_FILE));
+    } catch (error: unknown) {
+      if (isStateNotFound(error)) return emptyNameIndex();
+      throw error;
+    }
+  }
+  private async save(index: NameIndex): Promise<void> {
+    await this.directory.replaceJson(NAME_INDEX_FILE, NameIndexSchema.parse(index));
+  }
+  async register(
+    displayName: string,
+    runtimeId: string,
+    metadataRevision: number,
+    nowMs: number,
+  ): Promise<void> {
+    const name = DisplayNameSchema.parse(displayName);
+    const id = RuntimeIdSchema.parse(runtimeId);
+    const index = await this.load();
+    for (const [alias, target] of Object.entries(index.aliases)) {
+      if (Date.parse(target.expiresAt) <= nowMs) delete index.aliases[alias];
+    }
+    if (index.canonical[name] || index.aliases[name]) throw new Error('name_conflict');
+    index.canonical[name] = { runtimeId: id, metadataRevision };
+    await this.save(index);
+  }
+  async resolve(displayName: string, nowMs: number): Promise<NameResolution | null> {
+    const name = DisplayNameSchema.parse(displayName);
+    const index = await this.load();
+    const canonical = index.canonical[name];
+    if (canonical) return { ...canonical, source: 'canonical' };
+    const alias = index.aliases[name];
+    if (!alias) return null;
+    if (Date.parse(alias.expiresAt) <= nowMs) return null;
+    return { runtimeId: alias.runtimeId, source: 'alias' };
+  }
+  async rename(input: {
+    runtimeId: string;
+    to: string;
+    baseRevision: number;
+    nowMs: number;
+  }): Promise<number> {
+    const runtimeId = RuntimeIdSchema.parse(input.runtimeId);
+    const to = DisplayNameSchema.parse(input.to);
+    const index = await this.load();
+    const currentEntry = Object.entries(index.canonical).find(
+      ([, target]) => target.runtimeId === runtimeId,
+    );
+    if (
+      currentEntry?.[0] === to &&
+      currentEntry[1].metadataRevision === input.baseRevision + 1
+    ) {
+      return currentEntry[1].metadataRevision;
+    }
+    if (!currentEntry) throw new Error('state_conflict');
+    const [from, current] = currentEntry;
+    if (
+      current.runtimeId !== runtimeId ||
+      current.metadataRevision !== input.baseRevision
+    ) {
+      throw new Error('state_conflict');
+    }
+    if (from === to) return current.metadataRevision;
+    const existingCanonical = index.canonical[to];
+    const existingAlias = index.aliases[to];
+    if (
+      (existingCanonical && existingCanonical.runtimeId !== runtimeId) ||
+      (existingAlias &&
+        existingAlias.runtimeId !== runtimeId &&
+        Date.parse(existingAlias.expiresAt) > input.nowMs)
+    ) {
+      throw new Error('name_conflict');
+    }
+    const nextRevision = input.baseRevision + 1;
+    delete index.canonical[from];
+    delete index.aliases[to];
+    index.canonical[to] = { runtimeId, metadataRevision: nextRevision };
+    index.aliases[from] = {
+      runtimeId,
+      expiresAt: new Date(input.nowMs + ALIAS_TTL_MS).toISOString(),
+    };
+    await this.save(index);
+    return nextRevision;
+  }
+  async deleteRuntime(runtimeId: string): Promise<void> {
+    const id = RuntimeIdSchema.parse(runtimeId);
+    const index = await this.load();
+    for (const [name, target] of Object.entries(index.canonical)) {
+      if (target.runtimeId === id) delete index.canonical[name];
+    }
+    for (const [name, target] of Object.entries(index.aliases)) {
+      if (target.runtimeId === id) delete index.aliases[name];
+    }
+    await this.save(index);
+  }
+}
+export class OperationRecordStore {
+  constructor(private readonly directory: SecureDirectory) {}
+  async read(operationId: string): Promise<OperationRecord | null> {
+    try {
+      return OperationRecordSchema.parse(
+        await this.directory.readJson(operationFile(operationId)),
+      );
+    } catch (error: unknown) {
+      if (isStateNotFound(error)) return null;
+      throw error;
+    }
+  }
+  async commit(record: OperationRecord): Promise<OperationRecord> {
+    const parsed = OperationRecordSchema.parse(record);
+    const current = await this.read(parsed.operationId);
+    if (current) {
+      if (current.requestHash !== parsed.requestHash ||
+        current.runtimeId !== parsed.runtimeId || current.intent !== parsed.intent) {
+        throw new Error('operation_id_conflict');
+      }
+      return current;
+    }
+    try {
+      await this.directory.createJsonExclusive(operationFile(parsed.operationId), parsed);
+      return parsed;
+    } catch (error: unknown) {
+      if (!(error instanceof Error) || error.message !== 'state_conflict') throw error;
+      const raced = await this.read(parsed.operationId);
+      if (!raced || raced.requestHash !== parsed.requestHash) {
+        throw new Error('operation_id_conflict');
+      }
+      return raced;
+    }
+  }
+  private async listRecords(): Promise<OperationRecord[]> {
+    const records: OperationRecord[] = [];
+    for (const name of await this.directory.list()) {
+      const match = name.match(/^operation-([0-9a-f]{32})\.json$/);
+      if (!match) continue;
+      const record = await this.read(match[1]);
+      if (record) records.push(record);
+    }
+    return records;
+  }
+  async nextGeneration(): Promise<number> {
+    return Math.max(0, ...(await this.listRecords()).map((record) => record.generation)) + 1;
+  }
+  async latest(runtimeId: string, intent: OperationRecord['intent']) {
+    const id = RuntimeIdSchema.parse(runtimeId);
+    return (await this.listRecords())
+      .filter((record) => record.runtimeId === id && record.intent === intent)
+      .sort((left, right) => right.generation - left.generation)[0] ?? null;
+  }
+  async complete(record: OperationRecord): Promise<OperationRecord> {
+    const parsed = OperationRecordSchema.parse(record);
+    if (parsed.status !== 'ready' && parsed.status !== 'failed') {
+      throw new Error('operation_state_conflict');
+    }
+    const current = await this.read(parsed.operationId);
+    if (
+      !current ||
+      current.generation !== parsed.generation ||
+      current.requestHash !== parsed.requestHash ||
+      current.intent !== parsed.intent ||
+      current.runtimeId !== parsed.runtimeId
+    ) {
+      throw new Error('operation_state_conflict');
+    }
+    if (current.status === 'ready' || current.status === 'failed') {
+      if (JSON.stringify(current) !== JSON.stringify(parsed)) {
+        throw new Error('operation_state_conflict');
+      }
+      return current;
+    }
+    await this.directory.replaceJson(operationFile(parsed.operationId), parsed);
+    return parsed;
+  }
+}

--- a/packages/terminal-runtime/src/reconciliation.ts
+++ b/packages/terminal-runtime/src/reconciliation.ts
@@ -1,0 +1,84 @@
+import type { LifecycleState, RecoveryReason } from './contracts.js';
+export type RuntimeEvidence = {
+  deleteIntent: boolean;
+  unit: 'active' | 'activating' | 'inactive' | 'failed' | 'missing';
+  cgroupPopulated: boolean;
+  keeperReady: boolean;
+  keeperAlive: boolean;
+  zellijResponsive: boolean;
+  requiredProcessesInCgroup: boolean;
+  descriptor: 'create-pending' | 'create-claimed' | 'recover-pending' | 'recover-claimed' | null;
+  receipt: 'valid' | 'unsupported' | 'corrupt' | 'missing';
+  resurrection: 'valid' | 'missing' | 'corrupt' | 'incompatible';
+  priorState: LifecycleState | null;
+  bootIdMatches: boolean;
+};
+export type ReconciledLifecycle = {
+  lifecycleState: LifecycleState;
+  recoverable: boolean;
+  recoveryReason: RecoveryReason | null;
+  recoveryMode: 'serialized' | 'fresh-shell' | null;
+};
+function result(
+  lifecycleState: LifecycleState,
+  recoverable: boolean,
+  recoveryReason: RecoveryReason | null = null,
+  recoveryMode: ReconciledLifecycle['recoveryMode'] = null,
+): ReconciledLifecycle {
+  return { lifecycleState, recoverable, recoveryReason, recoveryMode };
+}
+export function reconcileLifecycle(evidence: RuntimeEvidence): ReconciledLifecycle {
+  if (evidence.deleteIntent) return result('deleting', false);
+  if (evidence.receipt === 'unsupported') {
+    return result('failed', false, 'unsupported_state');
+  }
+  if (evidence.unit === 'active') {
+    if (
+      evidence.cgroupPopulated &&
+      evidence.keeperReady &&
+      evidence.keeperAlive &&
+      evidence.zellijResponsive &&
+      evidence.requiredProcessesInCgroup
+    ) {
+      return result('live', false);
+    }
+    if (evidence.descriptor?.startsWith('recover-')) return result('recovering', false);
+    return result('starting', false);
+  }
+  if (evidence.unit === 'activating') {
+    if (evidence.descriptor?.startsWith('recover-')) return result('recovering', false);
+    return result('starting', false);
+  }
+  if (evidence.receipt === 'corrupt') {
+    return result('failed', false, 'metadata_corrupt');
+  }
+  if (evidence.descriptor?.startsWith('recover-')) return result('recovering', false);
+  if (evidence.descriptor?.startsWith('create-')) return result('starting', false);
+  if (evidence.receipt === 'valid') {
+    const mode =
+      evidence.resurrection === 'valid' ? 'serialized' : 'fresh-shell';
+    const reason =
+      evidence.resurrection === 'valid' ? null : 'history_unavailable';
+    if (
+      evidence.priorState === 'live' ||
+      evidence.priorState === 'recovering'
+    ) {
+      return result('interrupted', true, reason, mode);
+    }
+    if (evidence.unit === 'failed') {
+      return result('failed', true, 'startup_failed', mode);
+    }
+    if (evidence.priorState === 'failed') {
+      return result('failed', true, 'startup_failed', mode);
+    }
+    if (evidence.priorState === 'exited') {
+      return result('exited', true, reason, mode);
+    }
+    return result('recoverable', true, reason, mode);
+  }
+  if (evidence.cgroupPopulated) {
+    // Missing metadata alone never authorizes terminating a populated cgroup.
+    return result('interrupted', false, 'metadata_corrupt');
+  }
+  return result('failed', false, 'runtime_lost');
+}

--- a/packages/terminal-runtime/src/runtime-state.ts
+++ b/packages/terminal-runtime/src/runtime-state.ts
@@ -1,0 +1,93 @@
+import { join } from 'node:path';
+import { DescriptorStore } from './descriptors.js';
+import { FlockManager } from './locks.js';
+import {
+  NameIndexStore,
+  OperationRecordStore,
+  ReceiptStore,
+} from './receipts.js';
+import { SecureDirectory } from './storage.js';
+
+export type RuntimeState = {
+  receipts: ReceiptStore;
+  names: NameIndexStore;
+  operations: OperationRecordStore;
+  descriptors: DescriptorStore;
+  locks: FlockManager;
+  close(): Promise<void>;
+};
+
+async function closeResources(
+  resources: Array<{ close(): Promise<void> }>,
+): Promise<void> {
+  const results = await Promise.allSettled(
+    [...resources].reverse().map(async (resource) => resource.close()),
+  );
+  const errors = results
+    .filter((result): result is PromiseRejectedResult => result.status === 'rejected')
+    .map((result) => result.reason);
+  if (errors.length > 0) throw new AggregateError(errors, 'runtime_state_close_failed');
+}
+
+export async function createRuntimeState(options: {
+  durableRoot: string;
+  runtimeRoot: string;
+  authorizeDescriptorClaim?: (input: {
+    runtimeId: string;
+    operationId: string;
+    pid: number;
+  }) => Promise<boolean>;
+  nowMs?: () => number;
+}): Promise<RuntimeState> {
+  const resources: Array<{ close(): Promise<void> }> = [];
+  let durableDirectory: SecureDirectory;
+  let receiptsDirectory: SecureDirectory;
+  let operationsDirectory: SecureDirectory;
+  let descriptorDirectory: SecureDirectory;
+  let locks: FlockManager;
+  try {
+    durableDirectory = await SecureDirectory.open(options.durableRoot);
+    resources.push(durableDirectory);
+    receiptsDirectory = await SecureDirectory.open(
+      join(options.durableRoot, 'receipts'),
+    );
+    resources.push(receiptsDirectory);
+    operationsDirectory = await SecureDirectory.open(
+      join(options.durableRoot, 'operations'),
+    );
+    resources.push(operationsDirectory);
+    descriptorDirectory = await SecureDirectory.open(
+      join(options.runtimeRoot, 'descriptors'),
+    );
+    resources.push(descriptorDirectory);
+    locks = await FlockManager.open(join(options.runtimeRoot, 'locks'));
+    resources.push(locks);
+  } catch (error: unknown) {
+    const cleanup = await Promise.allSettled(
+      [...resources].reverse().map(async (resource) => resource.close()),
+    );
+    const cleanupErrors = cleanup
+      .filter(
+        (result): result is PromiseRejectedResult => result.status === 'rejected',
+      )
+      .map((result) => result.reason);
+    if (cleanupErrors.length > 0) {
+      throw new AggregateError([error, ...cleanupErrors], 'runtime_state_open_failed');
+    }
+    throw error;
+  }
+  const descriptors = new DescriptorStore(descriptorDirectory, {
+    authorizeClaim: options.authorizeDescriptorClaim ?? (async () => false),
+    nowMs: options.nowMs,
+  });
+  return {
+    receipts: new ReceiptStore(receiptsDirectory),
+    names: new NameIndexStore(durableDirectory),
+    operations: new OperationRecordStore(operationsDirectory),
+    descriptors,
+    locks,
+    async close() {
+      await closeResources(resources);
+    },
+  };
+}

--- a/packages/terminal-runtime/src/storage.ts
+++ b/packages/terminal-runtime/src/storage.ts
@@ -1,0 +1,328 @@
+import { randomBytes } from 'node:crypto';
+import {
+  constants,
+  type Dirent,
+  type Stats,
+} from 'node:fs';
+import {
+  type FileHandle,
+  chmod,
+  link,
+  lstat,
+  mkdir,
+  open,
+  opendir,
+  rename,
+  unlink,
+} from 'node:fs/promises';
+import { dirname, isAbsolute, resolve, sep } from 'node:path';
+const DEFAULT_MAX_FILE_BYTES = 128 * 1024;
+const DEFAULT_MAX_ENTRIES = 512;
+const SAFE_FILE_NAME = /^[A-Za-z0-9][A-Za-z0-9._-]{0,191}$/;
+function stateError(code: string, cause?: unknown): Error {
+  return new Error(code, cause === undefined ? undefined : { cause });
+}
+function isErrorCode(error: unknown, code: string): boolean {
+  return error instanceof Error && 'code' in error && error.code === code;
+}
+function validateFileName(name: string): string {
+  if (!SAFE_FILE_NAME.test(name)) throw stateError('unsafe_file_name');
+  return name;
+}
+async function ensureDirectoryPath(path: string): Promise<void> {
+  const absolute = resolve(path);
+  const parts = absolute.split(sep).filter(Boolean);
+  let current = isAbsolute(absolute) ? sep : '';
+  for (const part of parts) {
+    current = current === sep ? `${sep}${part}` : resolve(current, part);
+    try {
+      const stat = await lstat(current);
+      if (stat.isSymbolicLink() || !stat.isDirectory()) throw stateError('unsafe_parent');
+    } catch (error: unknown) {
+      if (!isErrorCode(error, 'ENOENT')) throw error;
+      try {
+        await mkdir(current, { mode: 0o700 });
+      } catch (mkdirError: unknown) {
+        if (!isErrorCode(mkdirError, 'EEXIST')) throw mkdirError;
+      }
+      const created = await lstat(current);
+      if (created.isSymbolicLink() || !created.isDirectory()) throw stateError('unsafe_parent');
+    }
+  }
+}
+function assertSafeFileStat(stat: Stats, maxBytes: number): void {
+  if (!stat.isFile() || stat.isSymbolicLink() || stat.nlink !== 1) {
+    throw stateError('unsafe_file');
+  }
+  if (stat.size > maxBytes) throw stateError('state_too_large');
+}
+function encodeJson(value: unknown, maxBytes: number): Buffer {
+  const encoded = Buffer.from(`${JSON.stringify(value)}\n`, 'utf8');
+  if (encoded.byteLength > maxBytes) throw stateError('state_too_large');
+  return encoded;
+}
+export class SecureDirectory {
+  private closed = false;
+  private constructor(
+    readonly path: string,
+    private readonly handle: FileHandle,
+    private readonly maxEntries: number,
+  ) {}
+  static async open(
+    path: string,
+    options: { maxEntries?: number } = {},
+  ): Promise<SecureDirectory> {
+    await ensureDirectoryPath(path);
+    const absolute = resolve(path);
+    const parentStat = await lstat(absolute);
+    if (parentStat.isSymbolicLink() || !parentStat.isDirectory()) {
+      throw stateError('unsafe_parent');
+    }
+    if ((parentStat.mode & 0o777) !== 0o700) {
+      await chmod(absolute, 0o700);
+    }
+    const handle = await open(
+      absolute,
+      constants.O_RDONLY | constants.O_DIRECTORY | constants.O_NOFOLLOW,
+    );
+    const openedStat = await handle.stat();
+    if (
+      !openedStat.isDirectory() ||
+      openedStat.dev !== parentStat.dev ||
+      openedStat.ino !== parentStat.ino
+    ) {
+      await handle.close();
+      throw stateError('unsafe_parent');
+    }
+    return new SecureDirectory(absolute, handle, options.maxEntries ?? DEFAULT_MAX_ENTRIES);
+  }
+  private procPath(name?: string): string {
+    if (this.closed) throw stateError('state_closed');
+    const base = `/proc/self/fd/${this.handle.fd}`;
+    return name === undefined ? base : `${base}/${validateFileName(name)}`;
+  }
+  async openLock(name: string): Promise<FileHandle> {
+    const handle = await open(
+      this.procPath(name),
+      constants.O_RDWR |
+        constants.O_CREAT |
+        constants.O_NOFOLLOW,
+      0o600,
+    );
+    try {
+      const stat = await handle.stat();
+      if (!stat.isFile() || stat.nlink !== 1) throw stateError('unsafe_file');
+      if ((stat.mode & 0o777) !== 0o600) await handle.chmod(0o600);
+      return handle;
+    } catch (error: unknown) {
+      await handle.close();
+      throw error;
+    }
+  }
+  async list(): Promise<string[]> {
+    const directory = await opendir(this.procPath());
+    const names: string[] = [];
+    try {
+      let entry: Dirent | null;
+      while ((entry = await directory.read()) !== null) {
+        if (!entry.isFile() && !entry.isSymbolicLink()) continue;
+        if (names.length >= this.maxEntries) throw stateError('state_capacity');
+        names.push(entry.name);
+      }
+    } finally {
+      await directory.close();
+    }
+    return names.sort();
+  }
+  async readBytes(
+    name: string,
+    maxBytes = DEFAULT_MAX_FILE_BYTES,
+  ): Promise<Buffer> {
+    const path = this.procPath(name);
+    let before: Stats;
+    try {
+      before = await lstat(path);
+    } catch (error: unknown) {
+      if (isErrorCode(error, 'ENOENT')) throw stateError('state_not_found', error);
+      throw error;
+    }
+    assertSafeFileStat(before, maxBytes);
+    let file: FileHandle;
+    try {
+      file = await open(path, constants.O_RDONLY | constants.O_NOFOLLOW);
+    } catch (error: unknown) {
+      if (isErrorCode(error, 'ELOOP')) throw stateError('unsafe_file', error);
+      throw error;
+    }
+    try {
+      const after = await file.stat();
+      assertSafeFileStat(after, maxBytes);
+      if (before.dev !== after.dev || before.ino !== after.ino) {
+        throw stateError('unsafe_file');
+      }
+      const bytes = Buffer.allocUnsafe(maxBytes + 1);
+      let offset = 0;
+      while (offset <= maxBytes) {
+        const { bytesRead } = await file.read(
+          bytes,
+          offset,
+          maxBytes + 1 - offset,
+          offset,
+        );
+        if (bytesRead === 0) break;
+        offset += bytesRead;
+      }
+      if (offset > maxBytes) throw stateError('state_too_large');
+      return bytes.subarray(0, offset);
+    } finally {
+      await file.close();
+    }
+  }
+  async readJson(name: string, maxBytes = DEFAULT_MAX_FILE_BYTES): Promise<unknown> {
+    const bytes = await this.readBytes(name, maxBytes);
+    try {
+      return JSON.parse(bytes.toString('utf8')) as unknown;
+    } catch (error: unknown) {
+      if (error instanceof SyntaxError) throw stateError('state_invalid', error);
+      throw error;
+    }
+  }
+  async createJsonExclusive(
+    name: string,
+    value: unknown,
+    maxBytes = DEFAULT_MAX_FILE_BYTES,
+  ): Promise<void> {
+    const targetName = validateFileName(name);
+    const bytes = encodeJson(value, maxBytes);
+    const tempName = `tmp-${randomBytes(12).toString('hex')}`;
+    const tempPath = this.procPath(tempName);
+    let temp: FileHandle | undefined;
+    try {
+      temp = await open(
+        tempPath,
+        constants.O_WRONLY |
+          constants.O_CREAT |
+          constants.O_EXCL |
+          constants.O_NOFOLLOW,
+        0o600,
+      );
+      await temp.writeFile(bytes);
+      await temp.sync();
+      await temp.close();
+      temp = undefined;
+      try {
+        await link(tempPath, this.procPath(targetName));
+      } catch (error: unknown) {
+        if (isErrorCode(error, 'EEXIST')) throw stateError('state_conflict', error);
+        throw error;
+      }
+      await unlink(tempPath);
+      await this.handle.sync();
+    } catch (error: unknown) {
+      if (temp) await temp.close();
+      await unlink(tempPath).catch((cleanupError: unknown) => {
+        if (!isErrorCode(cleanupError, 'ENOENT')) throw cleanupError;
+      });
+      throw error;
+    }
+  }
+  async replaceJson(
+    name: string,
+    value: unknown,
+    maxBytes = DEFAULT_MAX_FILE_BYTES,
+  ): Promise<void> {
+    const targetName = validateFileName(name);
+    const bytes = encodeJson(value, maxBytes);
+    const tempName = `tmp-${randomBytes(12).toString('hex')}`;
+    const tempPath = this.procPath(tempName);
+    let temp: FileHandle | undefined;
+    try {
+      temp = await open(
+        tempPath,
+        constants.O_WRONLY |
+          constants.O_CREAT |
+          constants.O_EXCL |
+          constants.O_NOFOLLOW,
+        0o600,
+      );
+      await temp.writeFile(bytes);
+      await temp.sync();
+      await temp.close();
+      temp = undefined;
+      await rename(tempPath, this.procPath(targetName));
+      await this.handle.sync();
+    } catch (error: unknown) {
+      if (temp) await temp.close();
+      await unlink(tempPath).catch((cleanupError: unknown) => {
+        if (!isErrorCode(cleanupError, 'ENOENT')) throw cleanupError;
+      });
+      throw error;
+    }
+  }
+  async moveExclusive(from: string, to: string): Promise<void> {
+    const source = this.procPath(from);
+    const target = this.procPath(to);
+    const before = await lstat(source).catch((error: unknown) => {
+      if (isErrorCode(error, 'ENOENT')) throw stateError('state_not_found', error);
+      throw error;
+    });
+    assertSafeFileStat(before, DEFAULT_MAX_FILE_BYTES);
+    try {
+      await link(source, target);
+    } catch (error: unknown) {
+      if (isErrorCode(error, 'EEXIST')) throw stateError('state_conflict', error);
+      throw error;
+    }
+    try {
+      await unlink(source);
+      await this.handle.sync();
+    } catch (error: unknown) {
+      await unlink(target).catch((cleanupError: unknown) => {
+        if (!isErrorCode(cleanupError, 'ENOENT')) throw cleanupError;
+      });
+      throw error;
+    }
+  }
+  async remove(name: string): Promise<void> {
+    const path = this.procPath(name);
+    let before: Stats;
+    try {
+      before = await lstat(path);
+    } catch (error: unknown) {
+      if (isErrorCode(error, 'ENOENT')) throw stateError('state_not_found', error);
+      throw error;
+    }
+    assertSafeFileStat(before, DEFAULT_MAX_FILE_BYTES);
+    const file = await open(path, constants.O_RDONLY | constants.O_NOFOLLOW).catch(
+      (error: unknown) => {
+        if (isErrorCode(error, 'ELOOP')) throw stateError('unsafe_file', error);
+        throw error;
+      },
+    );
+    try {
+      const after = await file.stat();
+      assertSafeFileStat(after, DEFAULT_MAX_FILE_BYTES);
+      if (before.dev !== after.dev || before.ino !== after.ino) {
+        throw stateError('unsafe_file');
+      }
+    } finally {
+      await file.close();
+    }
+    await unlink(path);
+    await this.handle.sync();
+  }
+  async close(): Promise<void> {
+    if (this.closed) return;
+    this.closed = true;
+    await this.handle.close();
+  }
+}
+export function isStateNotFound(error: unknown): boolean {
+  return error instanceof Error && error.message === 'state_not_found';
+}
+export function secureChildPath(parent: string, child: string): string {
+  validateFileName(child);
+  const target = resolve(parent, child);
+  if (dirname(target) !== resolve(parent)) throw stateError('unsafe_file_name');
+  return target;
+}

--- a/packages/terminal-runtime/tsconfig.json
+++ b/packages/terminal-runtime/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "declaration": true,
+    "outDir": "dist"
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -870,6 +870,19 @@ importers:
         specifier: ^4.0.18
         version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@1.8.0))(lightningcss@1.32.0)(msw@2.12.13(@types/node@25.5.0)(typescript@5.9.3))(sass@1.51.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2)
 
+  packages/terminal-runtime:
+    dependencies:
+      zod:
+        specifier: ^4.4.3
+        version: 4.4.3
+    devDependencies:
+      '@types/node':
+        specifier: ^24.12.0
+        version: 24.13.1
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+
   packages/ui:
     dependencies:
       react:

--- a/tests/terminal-runtime/client.test.ts
+++ b/tests/terminal-runtime/client.test.ts
@@ -1,0 +1,72 @@
+import { EventEmitter } from 'node:events';
+import type { Socket } from 'node:net';
+import { describe, expect, it } from 'vitest';
+import { createSupervisorClient } from '../../packages/terminal-runtime/src/client.js';
+import { decodeFrame, encodeFrame } from '../../packages/terminal-runtime/src/framing.js';
+const OPERATION_ID = 'fedcba9876543210fedcba9876543210';
+const REQUEST = {
+  version: 1 as const, operation: 'List' as const,
+  operationId: OPERATION_ID, input: {},
+};
+type FakeSocket = EventEmitter & {
+  setTimeout(ms: number): void;
+  end(bytes: Buffer): void;
+  destroy(): void;
+};
+function fakeSocket(options: {
+  onEnd?: (socket: FakeSocket, bytes: Buffer) => void;
+  timeout?: boolean;
+}): FakeSocket {
+  const socket = new EventEmitter() as FakeSocket;
+  socket.setTimeout = () => {
+    if (options.timeout) queueMicrotask(() => socket.emit('timeout'));
+  };
+  socket.end = (bytes) => options.onEnd?.(socket, bytes);
+  socket.destroy = () => undefined;
+  return socket;
+}
+function request(socket: FakeSocket) {
+  return createSupervisorClient({
+    socketPath: '/run/matrix-terminal-runtime/supervisor.sock',
+    timeoutMs: 1_000,
+    connect: () => {
+      queueMicrotask(() => socket.emit('connect'));
+      return socket as unknown as Socket;
+    },
+  }).request(REQUEST);
+}
+describe('terminal runtime supervisor client', () => {
+  it('exchanges exactly one bounded request and response', async () => {
+    const received: unknown[] = [];
+    const socket = fakeSocket({ onEnd: (peer, bytes) => {
+      received.push(decodeFrame(bytes));
+      queueMicrotask(() => {
+        peer.emit('data', encodeFrame({
+          version: 1, ok: true, operationId: OPERATION_ID, result: [],
+        }));
+        peer.emit('end');
+      });
+    } });
+    await expect(request(socket)).resolves.toMatchObject({ ok: true, result: [] });
+    expect(received).toEqual([REQUEST]);
+  });
+  it('fails closed on timeout and invalid socket configuration', async () => {
+    expect(() => createSupervisorClient({ socketPath: 'relative.sock' }))
+      .toThrow('invalid_socket_configuration');
+    expect(() => createSupervisorClient({
+      socketPath: '/run/matrix-terminal-runtime/supervisor.sock', timeoutMs: 0,
+    })).toThrow('invalid_timeout_configuration');
+    await expect(request(fakeSocket({ timeout: true })))
+      .rejects.toThrow('supervisor_timeout');
+  });
+  it('rejects incomplete and pathologically fragmented responses', async () => {
+    await expect(request(fakeSocket({ onEnd: (peer) => {
+      queueMicrotask(() => peer.emit('close'));
+    } }))).rejects.toThrow('supervisor_unavailable');
+    await expect(request(fakeSocket({ onEnd: (peer) => {
+      queueMicrotask(() => {
+        for (let index = 0; index < 1_025; index += 1) peer.emit('data', Buffer.alloc(0));
+      });
+    } }))).rejects.toThrow('frame_too_fragmented');
+  });
+});

--- a/tests/terminal-runtime/contracts.test.ts
+++ b/tests/terminal-runtime/contracts.test.ts
@@ -1,0 +1,196 @@
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, expect, it, vi } from 'vitest';
+import {
+  OperationIdSchema,
+  ProtocolRequestSchema,
+  RuntimeIdSchema,
+  unitNameForRuntimeId,
+} from '../../packages/terminal-runtime/src/contracts.js';
+import {
+  MAX_FRAME_BYTES,
+  decodeFrame,
+  encodeFrame,
+} from '../../packages/terminal-runtime/src/framing.js';
+import {
+  createOperationHandler,
+  type SystemdExecutor,
+} from '../../packages/terminal-runtime/src/operation-handler.js';
+import {
+  createRuntimeState,
+  type RuntimeState,
+} from '../../packages/terminal-runtime/src/runtime-state.js';
+const RUNTIME_ID = '0123456789abcdef0123456789abcdef';
+const OPERATION_ID = 'fedcba9876543210fedcba9876543210';
+describe('terminal runtime protocol contracts', () => {
+  it('accepts only immutable 128-bit lowercase hex identities', () => {
+    expect(RuntimeIdSchema.parse(RUNTIME_ID)).toBe(RUNTIME_ID);
+    expect(OperationIdSchema.parse(OPERATION_ID)).toBe(OPERATION_ID);
+    for (const value of [
+      '../matrix-gateway.service',
+      '0123456789abcdef0123456789abcde ',
+      '0123456789ABCDEF0123456789ABCDEF',
+      '--system',
+      'matrix-terminal-session@x.service',
+      '0123456789abcdef0123456789abcdef0',
+      '0123456789abcdef;systemctl-start',
+      '',
+    ]) {
+      expect(RuntimeIdSchema.safeParse(value).success).toBe(false);
+      expect(OperationIdSchema.safeParse(value).success).toBe(false);
+    }
+  });
+  it('derives the one trusted template unit only after runtime validation', () => {
+    expect(unitNameForRuntimeId(RUNTIME_ID)).toBe(
+      `matrix-terminal-session@${RUNTIME_ID}.service`,
+    );
+    expect(() => unitNameForRuntimeId('../ssh')).toThrow();
+    expect(() => unitNameForRuntimeId('--user')).toThrow();
+  });
+  it('accepts exactly the seven version-one operation shapes', () => {
+    const requests = [
+      {
+        version: 1,
+        operation: 'CreateStart',
+        operationId: OPERATION_ID,
+        input: {
+          displayName: 'primary',
+          cwd: { kind: 'home-relative', path: 'projects/matrix' },
+          launch: { kind: 'shell' },
+        },
+      },
+      {
+        version: 1,
+        operation: 'Inspect',
+        operationId: OPERATION_ID,
+        input: { runtimeId: RUNTIME_ID },
+      },
+      { version: 1, operation: 'List', operationId: OPERATION_ID, input: {} },
+      {
+        version: 1,
+        operation: 'Recover',
+        operationId: OPERATION_ID,
+        input: { runtimeId: RUNTIME_ID },
+      },
+      {
+        version: 1,
+        operation: 'RenameMetadata',
+        operationId: OPERATION_ID,
+        input: { runtimeId: RUNTIME_ID, displayName: 'renamed', baseRevision: 1 },
+      },
+      {
+        version: 1,
+        operation: 'Delete',
+        operationId: OPERATION_ID,
+        input: { runtimeId: RUNTIME_ID },
+      },
+      { version: 1, operation: 'Reconcile', operationId: OPERATION_ID, input: {} },
+    ];
+    for (const request of requests) {
+      expect(ProtocolRequestSchema.parse(request)).toEqual(request);
+    }
+  });
+  it('rejects unknown keys and privileged injection fields', () => {
+    const base = {
+      version: 1,
+      operation: 'Inspect',
+      operationId: OPERATION_ID,
+      input: { runtimeId: RUNTIME_ID },
+    };
+    expect(
+      ProtocolRequestSchema.safeParse({ ...base, template: 'ssh.service' }).success,
+    ).toBe(false);
+    expect(
+      ProtocolRequestSchema.safeParse({
+        ...base,
+        input: { ...base.input, unit: 'matrix-gateway.service' },
+      }).success,
+    ).toBe(false);
+    expect(
+      ProtocolRequestSchema.safeParse({
+        version: 1,
+        operation: 'StartUnit',
+        operationId: OPERATION_ID,
+        input: {},
+      }).success,
+    ).toBe(false);
+    expect(
+      ProtocolRequestSchema.safeParse({
+        version: 1,
+        operation: 'CreateStart',
+        operationId: OPERATION_ID,
+        input: {
+          displayName: 'primary',
+          launch: { kind: 'shell', command: 'bash' },
+        },
+      }).success,
+    ).toBe(false);
+  });
+  it('frames strict UTF-8 JSON with one bounded big-endian message', () => {
+    const value = {
+      version: 1,
+      operation: 'Inspect',
+      operationId: OPERATION_ID,
+      input: { runtimeId: RUNTIME_ID },
+    };
+    expect(decodeFrame(encodeFrame(value))).toEqual(value);
+    const oversized = Buffer.alloc(MAX_FRAME_BYTES + 5);
+    oversized.writeUInt32BE(MAX_FRAME_BYTES + 1, 0);
+    expect(() => decodeFrame(oversized)).toThrow('frame_too_large');
+    const trailing = Buffer.concat([encodeFrame(value), Buffer.from([0])]);
+    expect(() => decodeFrame(trailing)).toThrow('frame_trailing_bytes');
+    const invalidUtf8 = Buffer.from([0, 0, 0, 2, 0xc3, 0x28]);
+    expect(() => decodeFrame(invalidUtf8)).toThrow('frame_invalid_utf8');
+    const duplicate = Buffer.from(
+      `{"version":1,"operation":"List","operationId":"${OPERATION_ID}","input":{},"input":{}}`,
+    );
+    const duplicateFrame = Buffer.alloc(duplicate.length + 4);
+    duplicateFrame.writeUInt32BE(duplicate.length, 0);
+    duplicate.copy(duplicateFrame, 4);
+    expect(() => decodeFrame(duplicateFrame)).toThrow('frame_duplicate_key');
+    const deep = Buffer.from(`${'['.repeat(130)}0${']'.repeat(130)}`);
+    const deepFrame = Buffer.alloc(deep.length + 4);
+    deepFrame.writeUInt32BE(deep.length); deep.copy(deepFrame, 4);
+    expect(() => decodeFrame(deepFrame)).toThrow('frame_too_complex');
+  });
+  it('rejects invalid requests before the systemd executor observes a call', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'matrix-terminal-contracts-'));
+    let state: RuntimeState | undefined;
+    const executor: SystemdExecutor = {
+      start: vi.fn(),
+      stop: vi.fn(),
+      inspect: vi.fn(),
+      list: vi.fn(),
+    };
+    try {
+      state = await createRuntimeState({
+        durableRoot: join(root, 'durable'),
+        runtimeRoot: join(root, 'run'),
+      });
+      const handle = createOperationHandler({
+        state, executor, resolveCwd: async (cwd) => cwd,
+      });
+      for (const runtimeId of [
+        '../matrix-gateway',
+        '--system',
+        'matrix-gateway.service',
+        `${RUNTIME_ID};reboot`,
+        `${RUNTIME_ID}0`,
+      ]) {
+        await expect(handle({
+          version: 1,
+          operation: 'Inspect',
+          operationId: OPERATION_ID,
+          input: { runtimeId },
+        })).resolves.toMatchObject({ ok: false, error: { code: 'invalid_request' } });
+      }
+      expect(executor.inspect).not.toHaveBeenCalled();
+      expect(executor.start).not.toHaveBeenCalled();
+      expect(executor.stop).not.toHaveBeenCalled();
+    } finally {
+      await state?.close();
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/terminal-runtime/filesystem-security.test.ts
+++ b/tests/terminal-runtime/filesystem-security.test.ts
@@ -1,0 +1,206 @@
+import {
+  chmod,
+  link,
+  lstat,
+  mkdir,
+  mkdtemp,
+  readFile,
+  rm,
+  symlink,
+  writeFile,
+} from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { DescriptorStore } from '../../packages/terminal-runtime/src/descriptors.js';
+import { FlockManager } from '../../packages/terminal-runtime/src/locks.js';
+import { SecureDirectory } from '../../packages/terminal-runtime/src/storage.js';
+const RUNTIME_ID = '0123456789abcdef0123456789abcdef';
+const OPERATION_ID = 'fedcba9876543210fedcba9876543210';
+const NOW_MS = Date.parse('2026-07-26T00:00:00.000Z');
+function descriptor(operationId = OPERATION_ID) {
+  return {
+    schemaVersion: 1 as const,
+    runtimeId: RUNTIME_ID,
+    operationId,
+    intent: 'create' as const,
+    cwd: { kind: 'home-relative' as const, path: 'projects/matrix' },
+    launch: { kind: 'shell' as const },
+    createdAt: new Date(NOW_MS).toISOString(),
+  };
+}
+describe('terminal runtime filesystem security', () => {
+  it('pins a real 0700 parent and rejects symlink parents', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'matrix-terminal-pinned-'));
+    const real = join(root, 'real');
+    const linked = join(root, 'linked');
+    try {
+      await mkdir(real, { mode: 0o700 });
+      await symlink(real, linked);
+      await expect(SecureDirectory.open(linked)).rejects.toThrow('unsafe_parent');
+      const directory = await SecureDirectory.open(real);
+      try {
+        const mode = (await lstat(real)).mode & 0o777;
+        expect(mode).toBe(0o700);
+      } finally {
+        await directory.close();
+      }
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+  it('fails safely on symlink and hard-link replacement', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'matrix-terminal-links-'));
+    const parent = join(root, 'state');
+    const external = join(root, 'external.json');
+    try {
+      await mkdir(parent, { mode: 0o700 });
+      await writeFile(external, '{}', { mode: 0o600 });
+      const directory = await SecureDirectory.open(parent);
+      try {
+        await symlink(external, join(parent, 'symlink.json'));
+        await expect(directory.readJson('symlink.json', 1024)).rejects.toThrow(
+          'unsafe_file',
+        );
+        await link(external, join(parent, 'hardlink.json'));
+        await expect(directory.readJson('hardlink.json', 1024)).rejects.toThrow(
+          'unsafe_file',
+        );
+      } finally {
+        await directory.close();
+      }
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+  it('never follows a replaced lock file', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'matrix-terminal-lock-link-'));
+    const lockRoot = join(root, 'locks');
+    const external = join(root, 'external');
+    let locks: FlockManager | undefined;
+    try {
+      await mkdir(lockRoot, { mode: 0o700 });
+      await writeFile(external, 'unchanged', { mode: 0o600 });
+      await symlink(external, join(lockRoot, 'name-index.lock'));
+      locks = await FlockManager.open(lockRoot);
+      await expect(
+        locks.withNameIndex(async () => undefined),
+      ).rejects.toBeInstanceOf(Error);
+      await expect(readFile(external, 'utf8')).resolves.toBe('unchanged');
+    } finally {
+      await locks?.close();
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+  it('publishes exclusively, fsyncs, and never overwrites an existing target', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'matrix-terminal-exclusive-'));
+    try {
+      await chmod(root, 0o700);
+      const directory = await SecureDirectory.open(root);
+      try {
+        await directory.createJsonExclusive('record.json', { value: 1 });
+        await expect(
+          directory.createJsonExclusive('record.json', { value: 2 }),
+        ).rejects.toThrow('state_conflict');
+        expect(JSON.parse(await readFile(join(root, 'record.json'), 'utf8'))).toEqual({
+          value: 1,
+        });
+        expect((await lstat(join(root, 'record.json'))).mode & 0o777).toBe(0o600);
+      } finally {
+        await directory.close();
+      }
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+  it('claims descriptors once, unlinks immediately, and enforces caller authorization', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'matrix-terminal-descriptor-'));
+    try {
+      await chmod(root, 0o700);
+      const directory = await SecureDirectory.open(root);
+      const store = new DescriptorStore(directory, {
+        authorizeClaim: async ({ runtimeId, pid }) =>
+          runtimeId === RUNTIME_ID && pid === 4242,
+        nowMs: () => NOW_MS,
+      });
+      try {
+        await store.publish(descriptor());
+        await expect(
+          store.claim({ runtimeId: RUNTIME_ID, operationId: OPERATION_ID, pid: 1 }),
+        ).rejects.toThrow('claim_unauthorized');
+        await expect(
+          store.claim({ runtimeId: RUNTIME_ID, operationId: OPERATION_ID, pid: 4242 }),
+        ).resolves.toEqual(descriptor());
+        await expect(
+          store.claim({ runtimeId: RUNTIME_ID, operationId: OPERATION_ID, pid: 4242 }),
+        ).rejects.toThrow('descriptor_not_found');
+        const replacedId = '11111111111111111111111111111111';
+        const external = join(root, 'external.json');
+        const pending = join(root, `${RUNTIME_ID}.${replacedId}.pending.json`);
+        await writeFile(external, '{}', { mode: 0o600 });
+        await store.publish(descriptor(replacedId));
+        await rm(pending);
+        await symlink(external, pending);
+        await expect(
+          store.claim({ runtimeId: RUNTIME_ID, operationId: replacedId, pid: 4242 }),
+        ).rejects.toThrow('unsafe_file');
+        await expect(readFile(external, 'utf8')).resolves.toBe('{}');
+        await rm(pending);
+        await rm(external);
+        const expiredId = '22222222222222222222222222222222';
+        await directory.replaceJson(`${RUNTIME_ID}.${expiredId}.pending.json`, {
+          ...descriptor(expiredId),
+          createdAt: new Date(NOW_MS - 11 * 60 * 1000).toISOString(),
+        });
+        await expect(store.claim({
+          runtimeId: RUNTIME_ID, operationId: expiredId, pid: 4242,
+        })).rejects.toThrow('descriptor_expired');
+        expect(await directory.list()).toEqual([]);
+      } finally {
+        await directory.close();
+      }
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+  it('enforces descriptor size/count limits and sweeps only proven stale files', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'matrix-terminal-descriptor-caps-'));
+    try {
+      await chmod(root, 0o700);
+      const directory = await SecureDirectory.open(root);
+      const store = new DescriptorStore(directory, {
+        authorizeClaim: async () => true,
+        nowMs: () => NOW_MS,
+        maxPending: 2,
+        ttlMs: 10 * 60 * 1000,
+      });
+      try {
+        const secondId = '11111111111111111111111111111111';
+        await store.publish(descriptor());
+        await store.publish(descriptor(secondId));
+        await expect(
+          store.publish(descriptor('22222222222222222222222222222222')),
+        ).rejects.toThrow('descriptor_capacity');
+        const staleName = `${RUNTIME_ID}.${OPERATION_ID}.pending.json`;
+        await directory.replaceJson(staleName, {
+          ...descriptor(),
+          createdAt: new Date(NOW_MS - 11 * 60 * 1000).toISOString(),
+        });
+        await directory.replaceJson('invalid.json', { value: 'not-a-descriptor' });
+        const oversized = `33333333333333333333333333333333.44444444444444444444444444444444.pending.json`;
+        await writeFile(join(root, oversized), 'x'.repeat(129 * 1024), { mode: 0o600 });
+        await store.sweep({
+          isActive: async () => false,
+          isLocked: async ({ runtimeId }) => runtimeId === '33333333333333333333333333333333',
+        });
+        expect(await directory.list()).not.toContain(staleName);
+        expect(await directory.list()).toContain('invalid.json');
+        expect(await directory.list()).toContain(oversized);
+      } finally {
+        await directory.close();
+      }
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/terminal-runtime/operation-handler.test.ts
+++ b/tests/terminal-runtime/operation-handler.test.ts
@@ -1,0 +1,267 @@
+import { createHash } from 'node:crypto';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { ProtocolRequestSchema } from '../../packages/terminal-runtime/src/contracts.js';
+import { createOperationHandler, type SystemdExecutor } from '../../packages/terminal-runtime/src/operation-handler.js';
+import { createRuntimeState, type RuntimeState } from '../../packages/terminal-runtime/src/runtime-state.js';
+const RUNTIME_ID = '0123456789abcdef0123456789abcdef';
+const CREATE_OPERATION_ID = '10000000000000000000000000000000';
+const RECOVER_OPERATION_ID = '20000000000000000000000000000000';
+const NOW = new Date('2026-07-26T00:00:00.000Z');
+function executor(): SystemdExecutor {
+  return {
+    start: vi.fn(async () => undefined),
+    stop: vi.fn(async () => undefined),
+    inspect: vi.fn(async () => null),
+    list: vi.fn(async () => []),
+  };
+}
+function createRequest(operationId = CREATE_OPERATION_ID) {
+  return {
+    version: 1 as const,
+    operation: 'CreateStart' as const,
+    operationId,
+    input: {
+      displayName: 'primary',
+      cwd: { kind: 'home-relative' as const, path: 'projects/matrix' },
+      launch: { kind: 'shell' as const },
+    },
+  };
+}
+describe('terminal runtime operation handler', () => {
+  let root: string | undefined;
+  let state: RuntimeState | undefined;
+  afterEach(async () => {
+    await state?.close();
+    state = undefined;
+    if (root) await rm(root, { recursive: true, force: true });
+    root = undefined;
+  });
+  async function setup(
+    resolveCwd = async (cwd: { kind: 'home-relative'; path: string }) => cwd,
+  ) {
+    root = await mkdtemp(join(tmpdir(), 'matrix-terminal-handler-'));
+    state = await createRuntimeState({
+      durableRoot: join(root, 'durable'),
+      runtimeRoot: join(root, 'run'),
+    });
+    const systemd = executor();
+    const handle = createOperationHandler({
+      state,
+      executor: systemd,
+      now: () => NOW,
+      bootId: async () => 'boot-id-1',
+      createId: () => RUNTIME_ID,
+      resolveCwd,
+    });
+    return { handle, systemd };
+  }
+  it('replays an identical create result without starting a duplicate runtime', async () => {
+    const { handle, systemd } = await setup();
+    const request = createRequest();
+    const first = await handle(request);
+    const retry = await handle(request);
+    const sameName = await handle(
+      createRequest('30000000000000000000000000000000'),
+    );
+    expect(first).toMatchObject({
+      ok: true,
+      result: { runtimeId: RUNTIME_ID, lifecycleState: 'starting' },
+    });
+    expect(retry).toEqual(first);
+    expect(sameName).toMatchObject({
+      ok: true,
+      result: { runtimeId: RUNTIME_ID },
+    });
+    expect(systemd.start).toHaveBeenCalledTimes(1);
+    expect(systemd.start).toHaveBeenCalledWith(RUNTIME_ID);
+    const conflict = await handle({
+      ...request,
+      input: { ...request.input, displayName: 'different' },
+    });
+    expect(conflict).toMatchObject({
+      ok: false,
+      error: { code: 'conflict', message: 'Request failed' },
+    });
+    expect(systemd.start).toHaveBeenCalledTimes(1);
+  });
+  it('serializes recover retries and starts at most one unit', async () => {
+    const { handle, systemd } = await setup();
+    await handle(createRequest());
+    await state!.descriptors.claim({
+      runtimeId: RUNTIME_ID,
+      operationId: CREATE_OPERATION_ID,
+      pid: 1,
+    }).catch(() => undefined);
+    await state!.receipts.replace({
+      schemaVersion: 1,
+      runtimeId: RUNTIME_ID,
+      displayName: 'primary',
+      cwd: { kind: 'home-relative', path: 'projects/matrix' },
+      createdAt: NOW.toISOString(),
+      metadataRevision: 1,
+      lastKnown: {
+        state: 'interrupted',
+        at: NOW.toISOString(),
+        bootId: 'boot-id-1',
+      },
+      zellij: { sessionName: `matrix-t-${RUNTIME_ID}` },
+    });
+    vi.mocked(systemd.start).mockClear();
+    const request = {
+      version: 1 as const,
+      operation: 'Recover' as const,
+      operationId: RECOVER_OPERATION_ID,
+      input: { runtimeId: RUNTIME_ID },
+    };
+    const [first, retry] = await Promise.all([handle(request), handle(request)]);
+    expect(first).toMatchObject({
+      ok: true,
+      result: { runtimeId: RUNTIME_ID, lifecycleState: 'recovering' },
+    });
+    expect(retry).toEqual(first);
+    expect(systemd.start).toHaveBeenCalledTimes(1);
+  });
+  it('lists receipt-only runtimes and assigns unique ordered operation generations', async () => {
+    const { handle, systemd } = await setup();
+    await handle(createRequest());
+    const listed = await handle({
+      version: 1,
+      operation: 'List',
+      operationId: '40000000000000000000000000000000',
+      input: {},
+    });
+    expect(listed).toMatchObject({
+      ok: true,
+      result: [{ runtimeId: RUNTIME_ID, displayName: 'primary' }],
+    });
+    vi.mocked(systemd.list).mockResolvedValueOnce(Array.from({ length: 2_049 }, (_, index) => ({
+      runtimeId: index.toString(16).padStart(32, '0'), unit: 'inactive', cgroupPopulated: false,
+      keeperReady: false, keeperAlive: false, zellijResponsive: false,
+      requiredProcessesInCgroup: false, resurrection: 'missing',
+    })));
+    await expect(handle({
+      version: 1, operation: 'List',
+      operationId: '41000000000000000000000000000000', input: {},
+    })).resolves.toMatchObject({ ok: false, error: { code: 'failed' } });
+    const operationIds = Array.from(
+      { length: 8 },
+      (_, index) => `${(index + 5).toString(16)}${'0'.repeat(31)}`,
+    );
+    await Promise.all(
+      operationIds.map((operationId) =>
+        handle({
+          version: 1,
+          operation: 'Reconcile',
+          operationId,
+          input: {},
+        }),
+      ),
+    );
+    const generations = await Promise.all(
+      operationIds.map(async (operationId) => {
+        const record = await state!.operations.read(operationId);
+        return record?.generation;
+      }),
+    );
+    expect(new Set(generations).size).toBe(generations.length);
+  });
+  it('records one failed create and removes its launch descriptor', async () => {
+    const { handle, systemd } = await setup();
+    vi.mocked(systemd.start).mockRejectedValueOnce(new Error('systemd_failed'));
+    const response = await handle(createRequest());
+    expect(response).toMatchObject({
+      ok: false,
+      error: { code: 'failed', message: 'Request failed' },
+    });
+    expect(await state!.receipts.read(RUNTIME_ID)).toMatchObject({
+      kind: 'supported',
+      receipt: { lastKnown: { state: 'failed' } },
+    });
+    expect(await state!.descriptors.countPending()).toBe(0);
+    const retry = await handle(createRequest());
+    expect(retry).toEqual(response);
+    const newAttempt = await handle(createRequest(
+      '50000000000000000000000000000000',
+    ));
+    expect(newAttempt).toMatchObject({ ok: false, error: { code: 'failed' } });
+    await expect(handle({
+      version: 1, operation: 'Recover',
+      operationId: '51000000000000000000000000000000',
+      input: { runtimeId: RUNTIME_ID },
+    })).resolves.toMatchObject({
+      ok: true, result: { runtimeId: RUNTIME_ID, lifecycleState: 'recovering' },
+    });
+    expect(systemd.start).toHaveBeenCalledTimes(2);
+  });
+  it('repairs an interrupted receipt-to-name publication without a duplicate', async () => {
+    const { handle, systemd } = await setup();
+    vi.spyOn(state!.names, 'register').mockRejectedValueOnce(new Error('index_write_failed'));
+    await expect(handle(createRequest())).resolves.toMatchObject({ ok: false, error: { code: 'failed' } });
+    expect(await state!.receipts.read(RUNTIME_ID)).toMatchObject({ kind: 'supported' });
+    expect(await state!.names.resolve('primary', NOW.getTime())).toBeNull();
+    await expect(handle(createRequest('52000000000000000000000000000000')))
+      .resolves.toMatchObject({ ok: true, result: { runtimeId: RUNTIME_ID } });
+    expect((await state!.receipts.list())).toHaveLength(1);
+    expect(systemd.start).not.toHaveBeenCalled();
+    await expect(handle(createRequest())).resolves.toMatchObject({ ok: true,
+      result: { runtimeId: RUNTIME_ID, lifecycleState: 'starting' } });
+    expect(systemd.start).toHaveBeenCalledTimes(1);
+  });
+  it('resumes an accepted create against its original runtime', async () => {
+    const { handle, systemd } = await setup();
+    const request = createRequest();
+    await state!.operations.commit({
+      schemaVersion: 1, operationId: request.operationId, runtimeId: RUNTIME_ID,
+      generation: 1, intent: 'create', status: 'accepted',
+      requestHash: createHash('sha256')
+        .update(JSON.stringify(ProtocolRequestSchema.parse(request))).digest('hex'),
+      committedAt: NOW.toISOString(),
+    });
+    await state!.receipts.create({
+      schemaVersion: 1, runtimeId: RUNTIME_ID, displayName: 'primary',
+      cwd: request.input.cwd, createdAt: NOW.toISOString(), metadataRevision: 1,
+      lastKnown: { state: 'starting', at: NOW.toISOString(), bootId: 'boot-id-1' },
+      zellij: { sessionName: `matrix-t-${RUNTIME_ID}` },
+    });
+    await state!.names.register('primary', RUNTIME_ID, 1, NOW.getTime());
+    await expect(handle(request)).resolves.toMatchObject({
+      ok: true, result: { runtimeId: RUNTIME_ID, lifecycleState: 'starting' },
+    });
+    expect(systemd.start).toHaveBeenCalledWith(RUNTIME_ID);
+  });
+  it('reconcile completes deletion only after the cgroup is empty', async () => {
+    const { handle, systemd } = await setup();
+    await handle(createRequest());
+    vi.mocked(systemd.inspect).mockResolvedValueOnce({
+      runtimeId: RUNTIME_ID, unit: 'inactive', cgroupPopulated: true,
+      keeperReady: false, keeperAlive: false, zellijResponsive: false,
+      requiredProcessesInCgroup: false, resurrection: 'missing',
+    });
+    await expect(handle({
+      version: 1, operation: 'Delete',
+      operationId: '60000000000000000000000000000000',
+      input: { runtimeId: RUNTIME_ID },
+    })).resolves.toMatchObject({
+      ok: true, result: { lifecycleState: 'deleting' },
+    });
+    await handle({
+      version: 1, operation: 'Reconcile',
+      operationId: '70000000000000000000000000000000', input: {},
+    });
+    expect(await state!.receipts.read(RUNTIME_ID)).toBeNull();
+    expect(await state!.names.resolve('primary', NOW.getTime())).toBeNull();
+  });
+  it('fails before launch when cwd cannot be resolved inside the owner home', async () => {
+    const { handle, systemd } = await setup(async () => {
+      throw new Error('cwd_unavailable');
+    });
+    await expect(handle(createRequest())).resolves.toMatchObject({
+      ok: false, error: { code: 'failed', message: 'Request failed' },
+    });
+    expect(systemd.start).not.toHaveBeenCalled();
+    expect(await state!.receipts.read(RUNTIME_ID)).toBeNull();
+  });
+});

--- a/tests/terminal-runtime/storage-contracts.test.ts
+++ b/tests/terminal-runtime/storage-contracts.test.ts
@@ -1,0 +1,268 @@
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import {
+  DescriptorSchema,
+  NameIndexSchema,
+  OperationRecordSchema,
+  ReceiptSchema,
+} from '../../packages/terminal-runtime/src/contracts.js';
+import {
+  createRuntimeState,
+  type RuntimeState,
+} from '../../packages/terminal-runtime/src/runtime-state.js';
+import { SecureDirectory } from '../../packages/terminal-runtime/src/storage.js';
+import {
+  reconcileLifecycle,
+  type RuntimeEvidence,
+} from '../../packages/terminal-runtime/src/reconciliation.js';
+const RUNTIME_ID = '0123456789abcdef0123456789abcdef';
+const OTHER_RUNTIME_ID = '11111111111111111111111111111111';
+const OPERATION_ID = 'fedcba9876543210fedcba9876543210';
+const NOW = '2026-07-26T00:00:00.000Z';
+function receipt() {
+  return {
+    schemaVersion: 1 as const,
+    runtimeId: RUNTIME_ID,
+    displayName: 'primary',
+    cwd: { kind: 'home-relative' as const, path: 'projects/matrix' },
+    createdAt: NOW,
+    metadataRevision: 1,
+    lastKnown: { state: 'live' as const, at: NOW, bootId: 'boot-id-1' },
+    zellij: { sessionName: `matrix-t-${RUNTIME_ID}` },
+  };
+}
+describe('terminal runtime durable state contracts', () => {
+  it('strictly validates receipt, name-index, operation, and descriptor schemas', () => {
+    expect(ReceiptSchema.parse(receipt())).toEqual(receipt());
+    expect(
+      NameIndexSchema.parse({
+        schemaVersion: 1,
+        canonical: { primary: { runtimeId: RUNTIME_ID, metadataRevision: 1 } },
+        aliases: {},
+      }),
+    ).toBeTruthy();
+    expect(
+      OperationRecordSchema.parse({
+        schemaVersion: 1,
+        operationId: OPERATION_ID,
+        runtimeId: RUNTIME_ID,
+        generation: 1,
+        intent: 'create',
+        status: 'accepted',
+        requestHash: 'a'.repeat(64),
+        committedAt: NOW,
+      }),
+    ).toBeTruthy();
+    expect(
+      DescriptorSchema.parse({
+        schemaVersion: 1,
+        runtimeId: RUNTIME_ID,
+        operationId: OPERATION_ID,
+        intent: 'create',
+        cwd: { kind: 'home-relative', path: 'projects/matrix' },
+        launch: { kind: 'agent', configurationRef: OPERATION_ID },
+        createdAt: NOW,
+      }),
+    ).toBeTruthy();
+    expect(ReceiptSchema.safeParse({ ...receipt(), command: 'bash' }).success).toBe(false);
+    expect(
+      ReceiptSchema.safeParse({
+        ...receipt(),
+        cwd: { kind: 'home-relative', path: '/etc' },
+      }).success,
+    ).toBe(false);
+    expect(
+      DescriptorSchema.safeParse({
+        schemaVersion: 2,
+        runtimeId: RUNTIME_ID,
+        operationId: OPERATION_ID,
+        intent: 'create',
+        cwd: { kind: 'home-relative', path: '..' },
+        launch: { kind: 'shell' },
+        createdAt: NOW,
+      }).success,
+    ).toBe(false);
+  });
+  it('persists receipts exclusively and reports future schemas without guessing', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'matrix-terminal-state-'));
+    let state: RuntimeState | undefined;
+    try {
+      state = await createRuntimeState({
+        durableRoot: join(root, 'durable'),
+        runtimeRoot: join(root, 'run'),
+      });
+      await state.receipts.create(receipt());
+      await expect(state.receipts.create(receipt())).rejects.toThrow('state_conflict');
+      await expect(state.receipts.read(RUNTIME_ID)).resolves.toEqual({
+        kind: 'supported',
+        receipt: receipt(),
+      });
+      const receipts = await SecureDirectory.open(join(root, 'durable', 'receipts'));
+      try {
+        await receipts.replaceJson(`${RUNTIME_ID}.json`, {
+          schemaVersion: 99,
+          runtimeId: RUNTIME_ID,
+        });
+      } finally {
+        await receipts.close();
+      }
+      await expect(state.receipts.read(RUNTIME_ID)).resolves.toEqual({
+        kind: 'unsupported',
+        schemaVersion: 99,
+      });
+    } finally {
+      await state?.close();
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+  it('keeps canonical names and aliases globally unique with revision checks', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'matrix-terminal-names-'));
+    let state: RuntimeState | undefined;
+    try {
+      state = await createRuntimeState({
+        durableRoot: join(root, 'durable'),
+        runtimeRoot: join(root, 'run'),
+      });
+      await state.names.register('primary', RUNTIME_ID, 1, Date.parse(NOW));
+      await expect(state.names.resolve('primary', Date.parse(NOW))).resolves.toEqual({
+        runtimeId: RUNTIME_ID,
+        metadataRevision: 1,
+        source: 'canonical',
+      });
+      await state.names.rename({
+        runtimeId: RUNTIME_ID,
+        to: 'renamed',
+        baseRevision: 1,
+        nowMs: Date.parse(NOW),
+      });
+      await expect(state.names.resolve('renamed', Date.parse(NOW))).resolves.toMatchObject({
+        runtimeId: RUNTIME_ID,
+        metadataRevision: 2,
+        source: 'canonical',
+      });
+      await expect(state.names.resolve('primary', Date.parse(NOW))).resolves.toMatchObject({
+        runtimeId: RUNTIME_ID,
+        source: 'alias',
+      });
+      await expect(
+        state.names.rename({
+          runtimeId: RUNTIME_ID,
+          to: 'next',
+          baseRevision: 1,
+          nowMs: Date.parse(NOW),
+        }),
+      ).rejects.toThrow('state_conflict');
+      await expect(state.names.rename({
+        runtimeId: RUNTIME_ID, to: 'renamed',
+        baseRevision: 2, nowMs: Date.parse(NOW),
+      })).resolves.toBe(2);
+      await expect(state.names.register(
+        'primary', OTHER_RUNTIME_ID, 1, Date.parse(NOW) + 24 * 60 * 60 * 1000 + 1,
+      )).resolves.toBeUndefined();
+    } finally {
+      await state?.close();
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+  it('makes operation retries crash-safe and rejects semantic ID reuse', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'matrix-terminal-operations-'));
+    const record = {
+      schemaVersion: 1 as const,
+      operationId: OPERATION_ID,
+      runtimeId: RUNTIME_ID,
+      generation: 1,
+      intent: 'recover' as const,
+      status: 'accepted' as const,
+      requestHash: 'a'.repeat(64),
+      committedAt: NOW,
+    };
+    let state: RuntimeState | undefined;
+    try {
+      state = await createRuntimeState({
+        durableRoot: join(root, 'durable'),
+        runtimeRoot: join(root, 'run'),
+      });
+      await expect(state.operations.commit(record)).resolves.toEqual(record);
+      await expect(state.operations.commit(record)).resolves.toEqual(record);
+      await expect(
+        state.operations.commit({ ...record, requestHash: 'b'.repeat(64) }),
+      ).rejects.toThrow('operation_id_conflict');
+      const completed = {
+        ...record,
+        status: 'ready' as const,
+        result: { ok: true, value: { lifecycleState: 'recovering' } },
+      };
+      await expect(state.operations.complete(completed)).resolves.toEqual(completed);
+      await expect(state.operations.complete(completed)).resolves.toEqual(completed);
+      await expect(
+        state.operations.complete({
+          ...completed,
+          result: { ok: true, value: { lifecycleState: 'different' } },
+        }),
+      ).rejects.toThrow('operation_state_conflict');
+    } finally {
+      await state?.close();
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+  it('applies lifecycle evidence precedence without treating receipts as live', () => {
+    const base: RuntimeEvidence = {
+      deleteIntent: false,
+      unit: 'inactive',
+      cgroupPopulated: false,
+      keeperReady: false,
+      keeperAlive: false,
+      zellijResponsive: false,
+      requiredProcessesInCgroup: false,
+      descriptor: null,
+      receipt: 'valid',
+      resurrection: 'valid',
+      priorState: 'live',
+      bootIdMatches: false,
+    };
+    expect(reconcileLifecycle(base)).toMatchObject({
+      lifecycleState: 'interrupted',
+      recoverable: true,
+      recoveryMode: 'serialized',
+    });
+    expect(reconcileLifecycle({ ...base, deleteIntent: true })).toMatchObject({
+      lifecycleState: 'deleting',
+      recoverable: false,
+    });
+    expect(
+      reconcileLifecycle({
+        ...base,
+        unit: 'active',
+        cgroupPopulated: true,
+        keeperReady: true,
+        keeperAlive: true,
+        zellijResponsive: true,
+        requiredProcessesInCgroup: true,
+      }),
+    ).toMatchObject({ lifecycleState: 'live', recoverable: false });
+    expect(
+      reconcileLifecycle({
+        ...base,
+        receipt: 'unsupported',
+        resurrection: 'missing',
+        unit: 'active',
+        cgroupPopulated: true,
+        keeperReady: true,
+        keeperAlive: true,
+        zellijResponsive: true,
+        requiredProcessesInCgroup: true,
+      }),
+    ).toMatchObject({
+      lifecycleState: 'failed',
+      recoveryReason: 'unsupported_state',
+    });
+    expect(reconcileLifecycle({
+      ...base, bootIdMatches: true, priorState: 'recovering',
+    })).toMatchObject({ lifecycleState: 'interrupted', recoverable: true });
+    expect(reconcileLifecycle({
+      ...base, bootIdMatches: true, priorState: 'failed',
+    })).toMatchObject({ lifecycleState: 'failed', recoverable: true });
+  });
+});


### PR DESCRIPTION
## Summary

- add the dormant `@matrix-os/terminal-runtime` protocol-v1 package with the exact seven typed operations, supervisor-generated immutable runtime IDs, bounded strict framing, and an unprivileged fail-closed Unix-socket client
- add owner-state receipts, the canonical/alias name index, crash-safe operation records, ordered kernel `flock` locks, and deterministic lifecycle evidence precedence
- add pinned-parent/no-follow storage plus exclusive fsynced publication, one-shot descriptors, peer-authorization injection, descriptor TTL/count/size cleanup, and a fixed runtime-ID-only systemd executor seam
- keep production behavior unchanged; no supervisor service, keeper, gateway integration, or runtime activation is included in this layer

## Tests

- Red phase: the three initial contract/storage/filesystem suites failed because the terminal-runtime modules did not exist
- Red phase: follow-up tests reproduced duplicate Recover, receipt-only List omission, stale descriptor claims, cwd validation bypass, incomplete socket hangs, fragmentation growth, and lifecycle precedence defects before their fixes
- `pnpm --filter '@matrix-os/terminal-runtime' typecheck`
- `pnpm exec vitest run tests/terminal-runtime/*.test.ts` — 28 tests passed
- `./scripts/review/check-patterns.sh --diff codex/terminal-runtime-prod-zellij` — 0 violations; the one path warning was manually verified as fixed trusted roots plus validated child names through pinned directory FDs
- `git diff --check codex/terminal-runtime-prod-zellij..HEAD`
- `pnpm test` was stopped after unrelated existing gateway app-build waits and kernel heartbeat tests repeatedly hit 20–71 second local environment timeouts; exact-head GitHub CI is the authority for the full repository suite

## Review/Monitoring

- Frozen exact head: `33ea56da788bb12a3d8cfd9c564ba756e2e00e1d`.
- Stacked on #1095; this contracts/state layer remains dormant.
- Exact-head CI [passed](https://github.com/HamedMP/matrix-os/actions/runs/30959153105), including typecheck, pattern scan, unit shards, E2E, and shell build.
- Exact-head Docker [passed](https://github.com/HamedMP/matrix-os/actions/runs/30959152805).
- Exact-head Greptile: 5/5; all five review threads are resolved.
- Do not merge or activate this layer independently.

## Invariants

- **Source of truth:** version-1 runtime receipts are canonical for immutable identity and recovery intent; the locked name index is canonical for current name/alias resolution; operation records make mutating retries deterministic. Unit/cgroup/keeper/Zellij evidence outranks receipts for liveness, while unsupported receipt versions fail closed.
- **Lock/transaction scope:** every mutation acquires the global name-index `flock` before the per-runtime `flock`; operation generation, receipt/index/descriptor changes, and fixed executor calls occur inside that critical section. No provider or network call occurs under these locks.
- **Acceptable orphan states:** an accepted operation, receipt, name entry, or descriptor can survive a process crash independently. Create publishes its complete receipt first; if name-index publication is interrupted, the next create scans bounded validated receipts under the global lock, repairs the canonical mapping, and resolves the original runtime rather than creating a duplicate. Accepted creates resume the same fixed-template start after later crashes. Reconciliation projects these bounded states without treating a receipt as live or killing a populated cgroup. Failed starts retain their immutable failed/recoverable identity and remove their descriptor; a new create cannot implicitly replace or restart them, while explicit Recover can. Delete retains all durable state until recurring Reconcile proves the unit and cgroup empty, then completes the delete record before removing its receipt so cleanup remains crash-retryable.
- **Auth source of truth:** this PR defines only the unprivileged client and typed handler seam. The root `SO_PEERCRED` acceptor and exact terminal-unit cgroup authorization arrive in the next stacked host-services PR; no production socket is installed or activated here.
- **Deferred scope:** native acceptor, keeper/pane processes, static systemd units, updater and sudo replacement, gateway/agent migration, recovery API, UI, legacy migration, resource pruning, deployment activation, and public docs are intentionally excluded and remain assigned to later stack layers.

