### PR TITLE
feat(terminal): install supervised runtime services

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -80,9 +80,9 @@ RUN npm install -g \
 RUN npm install -g --ignore-scripts \
     "@earendil-works/pi-coding-agent@${PI_CODING_AGENT_VERSION}"
 
-RUN curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.sh \
+RUN curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/841a5a744ad115b001a2720bf1eeb6bec3dfcc7d/scripts/install.sh \
     -o /tmp/hermes-agent-install.sh && \
-    bash /tmp/hermes-agent-install.sh --skip-setup && \
+    bash /tmp/hermes-agent-install.sh --skip-setup --commit 841a5a744ad115b001a2720bf1eeb6bec3dfcc7d && \
     rm -f /tmp/hermes-agent-install.sh
 
 # Browser IDE served only on the private Docker network and exposed publicly

--- a/distro/customer-vps/cloud-init.yaml
+++ b/distro/customer-vps/cloud-init.yaml
@@ -564,6 +564,9 @@ runcmd:
     [ "$expected" = "$actual" ] || { echo "matrix-host: bundle sha256 mismatch" >&2; exit 1; }
     tar -xzf /tmp/matrix-host.tgz -C /opt/matrix
     chown -R root:matrix /opt/matrix/bin /opt/matrix/app /opt/matrix/runtime
+    if [ -d /opt/matrix/libexec ]; then
+      chown -R root:root /opt/matrix/libexec
+    fi
     chmod -R g+rwX /opt/matrix/app
     if [ -f /opt/matrix/release.json ]; then
       bundle_version="$(sed -n 's/^[[:space:]]*"version"[[:space:]]*:[[:space:]]*"\([^"]\+\)".*/\1/p' /opt/matrix/release.json | head -n 1)"
@@ -581,6 +584,7 @@ runcmd:
     if [ -d /opt/matrix/systemd ]; then
       install -d -o root -g root -m 0755 /etc/systemd/system
       install -o root -g root -m 0644 /opt/matrix/systemd/*.service /etc/systemd/system/
+      install -o root -g root -m 0644 /opt/matrix/systemd/*.slice /etc/systemd/system/
     fi
     if [ -f /opt/matrix/release.json ]; then
       chown root:matrix /opt/matrix/release.json
@@ -625,6 +629,7 @@ runcmd:
     fi
 
     systemctl daemon-reload
+    systemctl enable --now matrix-terminal-runtime.service
     loginctl enable-linger matrix
     systemctl start "user@$(id -u matrix).service"
     systemctl enable matrix-restore.service matrix-gateway.service matrix-shell.service matrix-code-server.service matrix-code.service matrix-sync-agent.service matrix-symphony.service matrix-hermes.service matrix-hermes-dashboard.service matrix-linux-tools.service matrix-developer-tools.service matrix-db-backup.timer nginx

--- a/distro/customer-vps/host-bin/matrix-sync-agent
+++ b/distro/customer-vps/host-bin/matrix-sync-agent
@@ -14,6 +14,9 @@ source /opt/matrix/env/host.env
 readonly APP_DIR="/opt/matrix/app"
 readonly STAGING_DIR="/opt/matrix/staging"
 readonly BIN_DIR="/opt/matrix/bin"
+readonly TERMINAL_RUNTIME_LIBEXEC="/opt/matrix/libexec/terminal-runtime"
+readonly TERMINAL_RUNTIME_GENERATIONS="/opt/matrix/libexec/terminal-runtime/v1"
+readonly TERMINAL_RUNTIME_CURRENT="/opt/matrix/libexec/terminal-runtime/current"
 readonly ZELLIJ_BINARY="$BIN_DIR/zellij"
 readonly ZELLIJ_BUILD_METADATA="$BIN_DIR/zellij.build.json"
 readonly ZELLIJ_ROLLBACK_DIR="$APP_DIR/.zellij.rollback"
@@ -40,9 +43,159 @@ readonly SYMPHONY_ENV_FILE="/opt/matrix/env/symphony.env"
 # is preserved across updates instead of being wiped.
 readonly SYMPHONY_MANAGED_KEYS="MATRIX_HANDLE PLATFORM_INTERNAL_URL UPGRADE_TOKEN"
 
+terminal_runtime_candidate=""
+terminal_runtime_generation_id=""
+
 log() { echo "matrix-sync-agent: $(date -u +%Y-%m-%dT%H:%M:%SZ) $*"; }
 current_version() { cat "$VERSION_FILE" 2>/dev/null || echo "unknown"; }
 platform_url() { echo "${MATRIX_UPDATE_MANIFEST_BASE_URL:-${PLATFORM_INTERNAL_URL:-https://app.matrix-os.com}}"; }
+
+verify_terminal_runtime_generation() {
+  local generation_dir="$1" expected_id="$2"
+  local manifest="$generation_dir/runtime-manifest.sha256"
+  local listed_count actual_count computed_id
+  [ -d "$generation_dir" ] || return 1
+  [ ! -L "$generation_dir" ] || return 1
+  [ -f "$manifest" ] && [ ! -L "$manifest" ] || return 1
+  if find "$generation_dir" -mindepth 1 ! -type d ! -type f -print -quit |
+    grep -q .; then
+    return 1
+  fi
+  if find "$generation_dir" -type f -links +1 -print -quit | grep -q .; then
+    return 1
+  fi
+  if ! awk '
+    length($1) != 64 || $1 !~ /^[0-9a-f]+$/ { exit 1 }
+    $2 !~ /^[A-Za-z0-9._\/-]+$/ || $2 ~ /^\// || $2 ~ /(^|\/)\.\.(\/|$)/ {
+      exit 1
+    }
+    { count += 1; paths[$2] += 1 }
+    END {
+      if (count < 1 || count > 4096) exit 1
+      for (path in paths) if (paths[path] != 1) exit 1
+    }
+  ' "$manifest"; then
+    return 1
+  fi
+  listed_count="$(awk 'END { print NR + 0 }' "$manifest")"
+  actual_count="$(
+    find "$generation_dir" -type f ! -path "$manifest" |
+      wc -l
+  )"
+  [ "$listed_count" = "$actual_count" ] || return 1
+  if ! (cd "$generation_dir" && sha256sum --strict -c runtime-manifest.sha256 >/dev/null); then
+    return 1
+  fi
+  computed_id="$(sha256sum "$manifest" | awk '{print $1}')"
+  [ "$computed_id" = "$expected_id" ]
+}
+
+prepare_terminal_runtime_candidate() {
+  local bundle_root="$1"
+  local runtime_root="$bundle_root/libexec/terminal-runtime"
+  local current_target companion
+  local -a generations=()
+  local entry_count root_entry_count
+  terminal_runtime_candidate=""
+  terminal_runtime_generation_id=""
+  [ -e "$runtime_root" ] || return 0
+  for companion in \
+    "$bundle_root/bin/matrix-terminal-supervisor" \
+    "$bundle_root/bin/matrix-terminal-keeper" \
+    "$bundle_root/bin/matrix-terminal-pane" \
+    "$bundle_root/bin/matrix-terminal-runtime-op" \
+    "$bundle_root/systemd/matrix-terminal-runtime.service" \
+    "$bundle_root/systemd/matrix-terminal-session@.service" \
+    "$bundle_root/systemd/matrix-terminal.slice"; do
+    [ -f "$companion" ] && [ ! -L "$companion" ] || return 1
+  done
+  [ -d "$runtime_root/v1" ] && [ ! -L "$runtime_root/v1" ] || return 1
+  [ -L "$runtime_root/current" ] || return 1
+  root_entry_count="$(
+    find "$runtime_root" -mindepth 1 -maxdepth 1 -print | wc -l
+  )"
+  [ "$root_entry_count" -eq 2 ] || return 1
+  entry_count="$(
+    find "$runtime_root/v1" -mindepth 1 -maxdepth 1 -print | wc -l
+  )"
+  [ "$entry_count" -eq 1 ] || return 1
+  mapfile -d '' generations < <(
+    find "$runtime_root/v1" -mindepth 1 -maxdepth 1 -type d -print0
+  )
+  [ "${#generations[@]}" -eq 1 ] || return 1
+  terminal_runtime_generation_id="$(basename "${generations[0]}")"
+  [[ "$terminal_runtime_generation_id" =~ ^[0-9a-f]{64}$ ]] || return 1
+  current_target="$(readlink "$runtime_root/current")"
+  [ "$current_target" = "v1/$terminal_runtime_generation_id" ] || return 1
+  verify_terminal_runtime_generation \
+    "${generations[0]}" \
+    "$terminal_runtime_generation_id" || return 1
+  terminal_runtime_candidate="${generations[0]}"
+}
+
+install_terminal_runtime_generation() {
+  [ -n "$terminal_runtime_candidate" ] || return 0
+  local generation_root="$TERMINAL_RUNTIME_GENERATIONS"
+  local generation_dir="$generation_root/$terminal_runtime_generation_id"
+  local generation_next="$generation_root/.${terminal_runtime_generation_id}.next"
+  local current_next="$TERMINAL_RUNTIME_LIBEXEC/.current.next"
+  sudo install -d -o root -g root -m 0755 "$generation_root"
+  if [ ! -d "$generation_dir" ]; then
+    sudo rm -rf -- "$generation_next"
+    sudo install -d -o root -g root -m 0755 "$generation_next"
+    sudo cp -a -- "$terminal_runtime_candidate/." "$generation_next/"
+    sudo chown -R root:root "$generation_next"
+    if ! verify_terminal_runtime_generation \
+      "$generation_next" \
+      "$terminal_runtime_generation_id"; then
+      sudo rm -rf -- "$generation_next"
+      return 1
+    fi
+    sudo mv -- "$generation_next" "$generation_dir"
+  elif ! verify_terminal_runtime_generation \
+    "$generation_dir" \
+    "$terminal_runtime_generation_id"; then
+    return 1
+  fi
+  sudo rm -f -- "$current_next"
+  sudo ln -s "v1/$terminal_runtime_generation_id" "$current_next"
+  sudo mv -T -- "$current_next" "$TERMINAL_RUNTIME_CURRENT"
+}
+
+install_terminal_runtime_wrappers() {
+  local source_dir="$1"
+  local wrapper wrapper_name wrapper_next
+  for wrapper in \
+    "$source_dir/matrix-terminal-supervisor" \
+    "$source_dir/matrix-terminal-keeper" \
+    "$source_dir/matrix-terminal-pane" \
+    "$source_dir/matrix-terminal-runtime-op"; do
+    [ -f "$wrapper" ] || return 1
+    [ ! -L "$wrapper" ] || return 1
+    wrapper_name="$(basename "$wrapper")"
+    wrapper_next="$BIN_DIR/.${wrapper_name}.next"
+    sudo install -o root -g root -m 0755 "$wrapper" "$wrapper_next"
+    sudo mv -f -- "$wrapper_next" "$BIN_DIR/$wrapper_name"
+  done
+}
+
+install_systemd_units_atomic() {
+  local source_dir="$1"
+  local unit_source unit_name unit_next
+  sudo install -d -o root -g root -m 0755 /etc/systemd/system
+  while IFS= read -r -d '' unit_source; do
+    unit_name="$(basename "$unit_source")"
+    if [[ ! "$unit_name" =~ ^matrix-[A-Za-z0-9@_.-]+\.(service|slice)$ ]]; then
+      return 1
+    fi
+    unit_next="/etc/systemd/system/.${unit_name}.next"
+    sudo install -o root -g root -m 0644 "$unit_source" "$unit_next"
+    sudo mv -f -- "$unit_next" "/etc/systemd/system/$unit_name"
+  done < <(
+    find "$source_dir" -maxdepth 1 -type f \
+      \( -name 'matrix-*.service' -o -name 'matrix-*.slice' \) -print0
+  )
+}
 
 # Echo the lines of an existing symphony.env that this agent does not manage so
 # operator-set configuration survives a host bundle update. Blank and comment
@@ -331,6 +484,11 @@ apply_update() {
       zellij_candidate=true
     fi
   fi
+  if ! prepare_terminal_runtime_candidate "$extract_dir"; then
+    log "ERROR: terminal_runtime_candidate_invalid"
+    rm -rf "$extract_dir" "$bundle_file"
+    return 1
+  fi
 
   # Any bundle that replaces Zellij extends the existing one-level app rollback
   # to the exact binary and identity record. Candidate status controls only the
@@ -355,7 +513,20 @@ apply_update() {
     sudo install -o root -g matrix -m 0644 "$extract_dir/release.json" "$RELEASE_FILE"
     log "Updated release metadata"
   fi
+  if ! install_terminal_runtime_generation; then
+    log "ERROR: terminal_runtime_generation_install_failed"
+    do_rollback || log "ERROR: rollback after terminal runtime install failure failed"
+    rm -rf "$extract_dir" "$bundle_file"
+    return 1
+  fi
   if [ -d "$extract_dir/bin" ]; then
+    if [ -n "$terminal_runtime_candidate" ] &&
+      ! install_terminal_runtime_wrappers "$extract_dir/bin"; then
+      log "ERROR: terminal_runtime_wrapper_install_failed"
+      do_rollback || log "ERROR: rollback after terminal wrapper failure failed"
+      rm -rf "$extract_dir" "$bundle_file"
+      return 1
+    fi
     if [ "$zellij_candidate" = true ]; then
       zellij_next="$BIN_DIR/.zellij.next"
       sudo rm -f -- "$zellij_next"
@@ -385,9 +556,15 @@ apply_update() {
         rm -rf "$extract_dir" "$bundle_file"
         return 1
       fi
-      sudo find "$extract_dir/bin" -maxdepth 1 -type f ! -name 'zellij' ! -name 'zellij.build.json' -exec cp -a {} "$BIN_DIR/" \;
+      sudo find "$extract_dir/bin" -maxdepth 1 -type f \
+        ! -name 'zellij' \
+        ! -name 'zellij.build.json' \
+        ! -name 'matrix-terminal-*' \
+        -exec cp -a {} "$BIN_DIR/" \;
     else
-      sudo find "$extract_dir/bin" -maxdepth 1 -type f -exec cp -a {} "$BIN_DIR/" \;
+      sudo find "$extract_dir/bin" -maxdepth 1 -type f \
+        ! -name 'matrix-terminal-*' \
+        -exec cp -a {} "$BIN_DIR/" \;
       if [ -f "$extract_dir/bin/zellij" ]; then
         sudo rm -f -- "$ZELLIJ_BUILD_METADATA"
       fi
@@ -399,10 +576,19 @@ apply_update() {
   log "Updated Symphony env"
 
   if [ -d "$extract_dir/systemd" ]; then
-    sudo install -d -o root -g root -m 0755 /etc/systemd/system
-    sudo find "$extract_dir/systemd" -maxdepth 1 -name 'matrix-*.service' -exec install -o root -g root -m 0644 {} /etc/systemd/system/ \;
+    if ! install_systemd_units_atomic "$extract_dir/systemd"; then
+      log "ERROR: systemd_unit_install_failed"
+      do_rollback || log "ERROR: rollback after systemd unit failure failed"
+      rm -rf "$extract_dir" "$bundle_file"
+      return 1
+    fi
     sudo systemctl daemon-reload
     log "Installed systemd units"
+    if [ -f "$extract_dir/systemd/matrix-terminal-runtime.service" ] &&
+      ! sudo systemctl is-enabled --quiet matrix-terminal-runtime.service; then
+      sudo systemctl enable --now matrix-terminal-runtime.service
+      log "Terminal runtime supervisor enabled"
+    fi
     if [ -f "$extract_dir/systemd/matrix-code-server.service" ]; then
       sudo systemctl enable matrix-code-server.service
       sudo systemctl start --no-block matrix-code-server.service || true

--- a/distro/customer-vps/host-bin/matrix-sync-agent
+++ b/distro/customer-vps/host-bin/matrix-sync-agent
@@ -770,6 +770,9 @@ apply_update() {
         log "ERROR: terminal_runtime_supervisor_start_failed"
         if ! terminate_new_terminal_runtime_supervisor_after_failed_start; then
           log "ERROR: terminal_runtime_supervisor_cleanup_failed"
+          log "WARN: terminal_runtime_supervisor_cleanup_preserved_host_layer"
+          do_rollback explicit ||
+            log "ERROR: application rollback after supervisor cleanup failure failed"
           rm -rf "$extract_dir" "$bundle_file"
           return 1
         fi

--- a/distro/customer-vps/host-bin/matrix-sync-agent
+++ b/distro/customer-vps/host-bin/matrix-sync-agent
@@ -742,10 +742,17 @@ apply_update() {
   done
   if [ "$healthy" = true ]; then
     if [ "$terminal_runtime_enable_after_health" = true ]; then
-      if ! sudo systemctl enable --now matrix-terminal-runtime.service; then
+      if ! sudo systemctl enable matrix-terminal-runtime.service; then
         log "ERROR: terminal_runtime_supervisor_enable_failed"
         do_rollback failed-update ||
           log "ERROR: rollback after terminal supervisor enable failure failed"
+        rm -rf "$extract_dir" "$bundle_file"
+        return 1
+      fi
+      if ! sudo systemctl start matrix-terminal-runtime.service; then
+        log "ERROR: terminal_runtime_supervisor_start_failed"
+        do_rollback failed-update ||
+          log "ERROR: rollback after terminal supervisor start failure failed"
         rm -rf "$extract_dir" "$bundle_file"
         return 1
       fi

--- a/distro/customer-vps/host-bin/matrix-sync-agent
+++ b/distro/customer-vps/host-bin/matrix-sync-agent
@@ -242,7 +242,24 @@ backup_terminal_runtime_for_failed_update() {
     sudo chown root:matrix "$snapshot_next/supervisor-was-enabled"
     sudo chmod 0640 "$snapshot_next/supervisor-was-enabled"
   fi
+  if sudo systemctl is-active --quiet matrix-terminal-runtime.service; then
+    sudo touch "$snapshot_next/supervisor-was-active"
+    sudo chown root:matrix "$snapshot_next/supervisor-was-active"
+    sudo chmod 0640 "$snapshot_next/supervisor-was-active"
+  fi
   sudo mv -- "$snapshot_next" "$TERMINAL_RUNTIME_FAILED_UPDATE_SNAPSHOT"
+}
+
+terminate_new_terminal_runtime_supervisor_after_failed_start() {
+  local snapshot="$APP_DIR.rollback/.terminal-runtime.failed-update"
+  [ -d "$snapshot" ] && [ ! -L "$snapshot" ] || return 1
+  [ ! -f "$snapshot/supervisor-was-active" ] || return 1
+  sudo systemctl stop matrix-terminal-runtime.service || return 1
+  sudo systemctl reset-failed matrix-terminal-runtime.service ||
+    log "WARN: terminal_runtime_supervisor_reset_failed"
+  if sudo systemctl is-active --quiet matrix-terminal-runtime.service; then
+    return 1
+  fi
 }
 
 restore_terminal_runtime_after_failed_update() {
@@ -751,6 +768,11 @@ apply_update() {
       fi
       if ! sudo systemctl start matrix-terminal-runtime.service; then
         log "ERROR: terminal_runtime_supervisor_start_failed"
+        if ! terminate_new_terminal_runtime_supervisor_after_failed_start; then
+          log "ERROR: terminal_runtime_supervisor_cleanup_failed"
+          rm -rf "$extract_dir" "$bundle_file"
+          return 1
+        fi
         do_rollback failed-update ||
           log "ERROR: rollback after terminal supervisor start failure failed"
         rm -rf "$extract_dir" "$bundle_file"

--- a/distro/customer-vps/host-bin/matrix-sync-agent
+++ b/distro/customer-vps/host-bin/matrix-sync-agent
@@ -17,6 +17,7 @@ readonly BIN_DIR="/opt/matrix/bin"
 readonly TERMINAL_RUNTIME_LIBEXEC="/opt/matrix/libexec/terminal-runtime"
 readonly TERMINAL_RUNTIME_GENERATIONS="/opt/matrix/libexec/terminal-runtime/v1"
 readonly TERMINAL_RUNTIME_CURRENT="/opt/matrix/libexec/terminal-runtime/current"
+readonly TERMINAL_RUNTIME_FAILED_UPDATE_SNAPSHOT="$APP_DIR/.terminal-runtime.failed-update"
 readonly ZELLIJ_BINARY="$BIN_DIR/zellij"
 readonly ZELLIJ_BUILD_METADATA="$BIN_DIR/zellij.build.json"
 readonly ZELLIJ_ROLLBACK_DIR="$APP_DIR/.zellij.rollback"
@@ -197,6 +198,103 @@ install_systemd_units_atomic() {
   )
 }
 
+backup_terminal_runtime_for_failed_update() {
+  local snapshot_next="${TERMINAL_RUNTIME_FAILED_UPDATE_SNAPSHOT}.next"
+  local artifact name
+  sudo rm -rf -- "$snapshot_next" "$TERMINAL_RUNTIME_FAILED_UPDATE_SNAPSHOT"
+  sudo install -d -o root -g matrix -m 0750 \
+    "$snapshot_next/bin" \
+    "$snapshot_next/systemd"
+  if [ -L "$TERMINAL_RUNTIME_CURRENT" ]; then
+    local current_target
+    current_target="$(readlink "$TERMINAL_RUNTIME_CURRENT")"
+    [[ "$current_target" =~ ^v1/[0-9a-f]{64}$ ]] || return 1
+    printf '%s\n' "$current_target" |
+      sudo tee "$snapshot_next/current-target" >/dev/null
+    sudo chown root:matrix "$snapshot_next/current-target"
+    sudo chmod 0640 "$snapshot_next/current-target"
+  fi
+  for artifact in \
+    "$BIN_DIR/matrix-terminal-supervisor" \
+    "$BIN_DIR/matrix-terminal-keeper" \
+    "$BIN_DIR/matrix-terminal-pane" \
+    "$BIN_DIR/matrix-terminal-runtime-op"; do
+    name="$(basename "$artifact")"
+    if [ -e "$artifact" ] || [ -L "$artifact" ]; then
+      [ -f "$artifact" ] && [ ! -L "$artifact" ] || return 1
+      sudo install -o root -g matrix -m 0750 \
+        "$artifact" "$snapshot_next/bin/$name"
+    fi
+  done
+  for artifact in \
+    /etc/systemd/system/matrix-terminal-runtime.service \
+    /etc/systemd/system/matrix-terminal-session@.service \
+    /etc/systemd/system/matrix-terminal.slice; do
+    name="$(basename "$artifact")"
+    if [ -e "$artifact" ] || [ -L "$artifact" ]; then
+      [ -f "$artifact" ] && [ ! -L "$artifact" ] || return 1
+      sudo install -o root -g matrix -m 0640 \
+        "$artifact" "$snapshot_next/systemd/$name"
+    fi
+  done
+  if sudo systemctl is-enabled --quiet matrix-terminal-runtime.service; then
+    sudo touch "$snapshot_next/supervisor-was-enabled"
+    sudo chown root:matrix "$snapshot_next/supervisor-was-enabled"
+    sudo chmod 0640 "$snapshot_next/supervisor-was-enabled"
+  fi
+  sudo mv -- "$snapshot_next" "$TERMINAL_RUNTIME_FAILED_UPDATE_SNAPSHOT"
+}
+
+restore_terminal_runtime_after_failed_update() {
+  local snapshot="$TERMINAL_RUNTIME_FAILED_UPDATE_SNAPSHOT"
+  local artifact name restore_next
+  [ -d "$snapshot" ] && [ ! -L "$snapshot" ] || return 0
+  if [ -f "$snapshot/current-target" ] && [ ! -L "$snapshot/current-target" ]; then
+    local current_target current_next
+    current_target="$(cat "$snapshot/current-target")"
+    [[ "$current_target" =~ ^v1/[0-9a-f]{64}$ ]] || return 1
+    [ -d "$TERMINAL_RUNTIME_LIBEXEC/$current_target" ] || return 1
+    current_next="$TERMINAL_RUNTIME_LIBEXEC/.current.rollback-next"
+    sudo rm -f -- "$current_next"
+    sudo ln -s "$current_target" "$current_next"
+    sudo mv -T -- "$current_next" "$TERMINAL_RUNTIME_CURRENT"
+  else
+    sudo rm -f -- "$TERMINAL_RUNTIME_CURRENT"
+  fi
+  for name in \
+    matrix-terminal-supervisor \
+    matrix-terminal-keeper \
+    matrix-terminal-pane \
+    matrix-terminal-runtime-op; do
+    artifact="$snapshot/bin/$name"
+    if [ -f "$artifact" ] && [ ! -L "$artifact" ]; then
+      restore_next="$BIN_DIR/.${name}.rollback-next"
+      sudo install -o root -g root -m 0755 "$artifact" "$restore_next"
+      sudo mv -f -- "$restore_next" "$BIN_DIR/$name"
+    else
+      sudo rm -f -- "$BIN_DIR/$name"
+    fi
+  done
+  for name in \
+    matrix-terminal-runtime.service \
+    matrix-terminal-session@.service \
+    matrix-terminal.slice; do
+    artifact="$snapshot/systemd/$name"
+    if [ -f "$artifact" ] && [ ! -L "$artifact" ]; then
+      restore_next="/etc/systemd/system/.${name}.rollback-next"
+      sudo install -o root -g root -m 0644 "$artifact" "$restore_next"
+      sudo mv -f -- "$restore_next" "/etc/systemd/system/$name"
+    else
+      sudo rm -f -- "/etc/systemd/system/$name"
+    fi
+  done
+  if [ ! -f "$snapshot/supervisor-was-enabled" ]; then
+    sudo systemctl disable matrix-terminal-runtime.service >/dev/null 2>&1 || true
+  fi
+  sudo systemctl daemon-reload
+  sudo rm -rf -- "$snapshot"
+}
+
 # Echo the lines of an existing symphony.env that this agent does not manage so
 # operator-set configuration survives a host bundle update. Blank and comment
 # lines are kept; managed KEY= lines are dropped (re-emitted with fresh values
@@ -247,16 +345,17 @@ clear_zellij_rollback() {
 backup_zellij_for_rollback() {
   local rollback_next="${ZELLIJ_ROLLBACK_DIR}.next"
   sudo rm -rf -- "$rollback_next"
-  sudo install -d -o root -g root -m 0700 "$rollback_next"
+  sudo install -d -o root -g matrix -m 0750 "$rollback_next"
   if [ -f "$ZELLIJ_BINARY" ]; then
-    sudo install -o root -g root -m 0755 "$ZELLIJ_BINARY" "$rollback_next/zellij"
+    sudo install -o root -g matrix -m 0750 "$ZELLIJ_BINARY" "$rollback_next/zellij"
     sudo touch "$rollback_next/had-binary"
   fi
   if [ -f "$ZELLIJ_BUILD_METADATA" ]; then
-    sudo install -o root -g root -m 0644 "$ZELLIJ_BUILD_METADATA" "$rollback_next/zellij.build.json"
+    sudo install -o root -g matrix -m 0640 "$ZELLIJ_BUILD_METADATA" "$rollback_next/zellij.build.json"
     sudo touch "$rollback_next/had-build-metadata"
   fi
-  sudo chmod 0600 "$rollback_next"/had-* 2>/dev/null || true
+  sudo chown root:matrix "$rollback_next"/had-* 2>/dev/null || true
+  sudo chmod 0640 "$rollback_next"/had-* 2>/dev/null || true
   clear_zellij_rollback
   sudo mv -- "$rollback_next" "$ZELLIJ_ROLLBACK_DIR"
 }
@@ -421,6 +520,7 @@ apply_update() {
   fi
   local manifest version sha256 bundle_url cur bundle_file extract_dir
   local zellij_candidate=false zellij_expected_sha256="" zellij_actual_sha256="" zellij_next=""
+  local terminal_runtime_enable_after_health=false
   manifest="$(cat "$UPDATE_MARKER")"
   version="$(json_field "$manifest" version)"
   sha256="$(json_field "$manifest" sha256)"
@@ -500,6 +600,18 @@ apply_update() {
   if [ -f "$extract_dir/bin/zellij" ]; then
     backup_zellij_for_rollback
   fi
+  if [ -n "$terminal_runtime_candidate" ]; then
+    if ! backup_terminal_runtime_for_failed_update; then
+      log "ERROR: terminal_runtime_rollback_snapshot_failed"
+      sudo rm -rf -- \
+        "${TERMINAL_RUNTIME_FAILED_UPDATE_SNAPSHOT}.next" \
+        "$TERMINAL_RUNTIME_FAILED_UPDATE_SNAPSHOT"
+      sudo systemctl start matrix-gateway matrix-shell
+      sudo systemctl start --no-block matrix-symphony || true
+      rm -rf "$extract_dir" "$bundle_file"
+      return 1
+    fi
+  fi
   sudo rm -rf "$APP_DIR.rollback"
   if [ -d "$APP_DIR" ]; then
     sudo mv "$APP_DIR" "$APP_DIR.rollback"
@@ -515,7 +627,7 @@ apply_update() {
   fi
   if ! install_terminal_runtime_generation; then
     log "ERROR: terminal_runtime_generation_install_failed"
-    do_rollback || log "ERROR: rollback after terminal runtime install failure failed"
+    do_rollback failed-update || log "ERROR: rollback after terminal runtime install failure failed"
     rm -rf "$extract_dir" "$bundle_file"
     return 1
   fi
@@ -523,7 +635,7 @@ apply_update() {
     if [ -n "$terminal_runtime_candidate" ] &&
       ! install_terminal_runtime_wrappers "$extract_dir/bin"; then
       log "ERROR: terminal_runtime_wrapper_install_failed"
-      do_rollback || log "ERROR: rollback after terminal wrapper failure failed"
+      do_rollback failed-update || log "ERROR: rollback after terminal wrapper failure failed"
       rm -rf "$extract_dir" "$bundle_file"
       return 1
     fi
@@ -532,27 +644,27 @@ apply_update() {
       sudo rm -f -- "$zellij_next"
       if ! sudo install -o root -g root -m 0755 "$extract_dir/bin/zellij" "$zellij_next"; then
         log "ERROR: zellij candidate staging failed"
-        do_rollback || log "ERROR: rollback after zellij staging failure failed"
+        do_rollback failed-update || log "ERROR: rollback after zellij staging failure failed"
         rm -rf "$extract_dir" "$bundle_file"
         return 1
       fi
       if ! sudo mv -f "$zellij_next" "$BIN_DIR/zellij"; then
         sudo rm -f -- "$zellij_next"
         log "ERROR: zellij candidate commit failed"
-        do_rollback || log "ERROR: rollback after zellij commit failure failed"
+        do_rollback failed-update || log "ERROR: rollback after zellij commit failure failed"
         rm -rf "$extract_dir" "$bundle_file"
         return 1
       fi
       if ! sudo install -o root -g root -m 0644 "$extract_dir/bin/zellij.build.json" "$BIN_DIR/zellij.build.json"; then
         log "ERROR: zellij candidate metadata commit failed"
-        do_rollback || log "ERROR: rollback after zellij metadata failure failed"
+        do_rollback failed-update || log "ERROR: rollback after zellij metadata failure failed"
         rm -rf "$extract_dir" "$bundle_file"
         return 1
       fi
       zellij_actual_sha256="$(sha256sum "$BIN_DIR/zellij" | awk '{print $1}')"
       if [ "$zellij_actual_sha256" != "$zellij_expected_sha256" ]; then
         log "ERROR: zellij_installed_digest_mismatch"
-        do_rollback || log "ERROR: rollback after zellij digest failure failed"
+        do_rollback failed-update || log "ERROR: rollback after zellij digest failure failed"
         rm -rf "$extract_dir" "$bundle_file"
         return 1
       fi
@@ -578,7 +690,7 @@ apply_update() {
   if [ -d "$extract_dir/systemd" ]; then
     if ! install_systemd_units_atomic "$extract_dir/systemd"; then
       log "ERROR: systemd_unit_install_failed"
-      do_rollback || log "ERROR: rollback after systemd unit failure failed"
+      do_rollback failed-update || log "ERROR: rollback after systemd unit failure failed"
       rm -rf "$extract_dir" "$bundle_file"
       return 1
     fi
@@ -586,8 +698,7 @@ apply_update() {
     log "Installed systemd units"
     if [ -f "$extract_dir/systemd/matrix-terminal-runtime.service" ] &&
       ! sudo systemctl is-enabled --quiet matrix-terminal-runtime.service; then
-      sudo systemctl enable --now matrix-terminal-runtime.service
-      log "Terminal runtime supervisor enabled"
+      terminal_runtime_enable_after_health=true
     fi
     if [ -f "$extract_dir/systemd/matrix-code-server.service" ]; then
       sudo systemctl enable matrix-code-server.service
@@ -630,11 +741,21 @@ apply_update() {
     sleep 5
   done
   if [ "$healthy" = true ]; then
+    if [ "$terminal_runtime_enable_after_health" = true ]; then
+      if ! sudo systemctl enable --now matrix-terminal-runtime.service; then
+        log "ERROR: terminal_runtime_supervisor_enable_failed"
+        do_rollback failed-update ||
+          log "ERROR: rollback after terminal supervisor enable failure failed"
+        rm -rf "$extract_dir" "$bundle_file"
+        return 1
+      fi
+      log "Terminal runtime supervisor enabled"
+    fi
     log "Health check passed — update to $version complete"
     rm -f "$UPDATE_MARKER" "$UPDATE_ERROR_MARKER"
   else
     log "ERROR: health check failed — rolling back"
-    do_rollback
+    do_rollback failed-update
     rm -rf "$extract_dir" "$bundle_file"
     return 1
   fi
@@ -645,6 +766,11 @@ apply_update() {
 
 # ── Rollback ─────────────────────────────────────────────────────────
 do_rollback() {
+  local rollback_kind="${1:-explicit}"
+  case "$rollback_kind" in
+    explicit|failed-update) ;;
+    *) log "ERROR: invalid rollback kind"; return 1 ;;
+  esac
   if [ ! -d "$APP_DIR.rollback" ]; then
     log "ERROR: no rollback available at $APP_DIR.rollback"; return 1
   fi
@@ -657,6 +783,11 @@ do_rollback() {
   fi
   sudo mv "$APP_DIR.rollback" "$APP_DIR"
   restore_zellij_after_rollback
+  if [ "$rollback_kind" = "failed-update" ]; then
+    restore_terminal_runtime_after_failed_update
+  else
+    sudo rm -rf -- "$APP_DIR/.terminal-runtime.failed-update"
+  fi
   sudo chown -R matrix:matrix "$APP_DIR"
   sudo systemctl start matrix-gateway matrix-shell
   sudo systemctl start --no-block matrix-symphony || true
@@ -843,7 +974,7 @@ while true; do
   fi
   if [ -f "$ROLLBACK_TRIGGER" ]; then
     sudo rm -f "$ROLLBACK_TRIGGER"
-    do_rollback || log "Rollback failed"
+    do_rollback explicit || log "Rollback failed"
   fi
   if [ -f "$UPDATE_REPAIR_TRIGGER" ]; then
     sudo rm -f "$UPDATE_REPAIR_TRIGGER"

--- a/distro/customer-vps/host-bin/matrix-terminal-keeper
+++ b/distro/customer-vps/host-bin/matrix-terminal-keeper
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "$#" -ne 1 ] || [[ ! "$1" =~ ^[0-9a-f]{32}$ ]]; then
+  exit 64
+fi
+
+exec /opt/matrix/runtime/node/bin/node \
+  /opt/matrix/libexec/terminal-runtime/current/keeper.js "$1"

--- a/distro/customer-vps/host-bin/matrix-terminal-pane
+++ b/distro/customer-vps/host-bin/matrix-terminal-pane
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "$#" -ne 1 ] || [ "$1" != "shell" ]; then
+  exit 64
+fi
+
+exec /opt/matrix/runtime/node/bin/node \
+  /opt/matrix/libexec/terminal-runtime/current/pane.js "$1"

--- a/distro/customer-vps/host-bin/matrix-terminal-runtime-op
+++ b/distro/customer-vps/host-bin/matrix-terminal-runtime-op
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "$#" -ne 1 ]; then
+  exit 64
+fi
+
+case "$1" in
+  serve-peer|serve-keeper|maintenance)
+    exec /opt/matrix/runtime/node/bin/node \
+      /opt/matrix/libexec/terminal-runtime/current/runtime-op.js "$1"
+    ;;
+  *)
+    exit 64
+    ;;
+esac

--- a/distro/customer-vps/host-bin/matrix-terminal-supervisor
+++ b/distro/customer-vps/host-bin/matrix-terminal-supervisor
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+exec /opt/matrix/libexec/terminal-runtime/current/supervisor-acceptor

--- a/distro/customer-vps/systemd/matrix-terminal-runtime.service
+++ b/distro/customer-vps/systemd/matrix-terminal-runtime.service
@@ -1,0 +1,23 @@
+[Unit]
+Description=Matrix terminal runtime supervisor
+After=local-fs.target
+Before=matrix-gateway.service
+
+[Service]
+Type=simple
+User=root
+Group=matrix
+RuntimeDirectory=matrix-terminal-runtime
+RuntimeDirectoryMode=0750
+ExecStart=/opt/matrix/bin/matrix-terminal-supervisor
+KillMode=control-group
+Restart=on-failure
+RestartSec=2
+TimeoutStartSec=30
+TimeoutStopSec=30
+StandardOutput=null
+StandardError=journal
+NoNewPrivileges=yes
+
+[Install]
+WantedBy=multi-user.target

--- a/distro/customer-vps/systemd/matrix-terminal-runtime.service
+++ b/distro/customer-vps/systemd/matrix-terminal-runtime.service
@@ -4,7 +4,8 @@ After=local-fs.target
 Before=matrix-gateway.service
 
 [Service]
-Type=simple
+Type=notify
+NotifyAccess=main
 User=root
 Group=matrix
 RuntimeDirectory=matrix-terminal-runtime

--- a/distro/customer-vps/systemd/matrix-terminal-session@.service
+++ b/distro/customer-vps/systemd/matrix-terminal-session@.service
@@ -1,0 +1,18 @@
+[Unit]
+Description=Matrix terminal runtime session
+
+[Service]
+Type=notify
+NotifyAccess=all
+User=matrix
+Group=matrix
+Slice=matrix-terminal.slice
+ExecStart=/opt/matrix/bin/matrix-terminal-keeper %i
+KillMode=control-group
+TimeoutStartSec=30
+TimeoutStopSec=30
+Restart=no
+MemoryHigh=50%
+TasksMax=512
+StandardOutput=null
+StandardError=journal

--- a/distro/customer-vps/systemd/matrix-terminal.slice
+++ b/distro/customer-vps/systemd/matrix-terminal.slice
@@ -1,0 +1,12 @@
+[Unit]
+Description=Matrix terminal runtime aggregate slice
+
+[Slice]
+MemoryAccounting=yes
+TasksAccounting=yes
+CPUAccounting=yes
+IOAccounting=yes
+MemoryHigh=75%
+TasksMax=2048
+CPUWeight=80
+IOWeight=80

--- a/packages/terminal-runtime/assets/config.kdl
+++ b/packages/terminal-runtime/assets/config.kdl
@@ -1,0 +1,1 @@
+// Recovery serialization remains dormant until the recovery lifecycle layer.

--- a/packages/terminal-runtime/assets/layout.kdl
+++ b/packages/terminal-runtime/assets/layout.kdl
@@ -1,0 +1,5 @@
+layout {
+    pane command="/opt/matrix/bin/matrix-terminal-pane" {
+        args "shell"
+    }
+}

--- a/packages/terminal-runtime/native/supervisor-acceptor.c
+++ b/packages/terminal-runtime/native/supervisor-acceptor.c
@@ -5,6 +5,7 @@
 #include <poll.h>
 #include <pwd.h>
 #include <signal.h>
+#include <stddef.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -32,6 +33,43 @@ static int set_cloexec(int fd) {
   int flags = fcntl(fd, F_GETFD);
   if (flags < 0) return -1;
   return fcntl(fd, F_SETFD, flags | FD_CLOEXEC);
+}
+
+static int notify_ready(void) {
+  const char *notify_socket = getenv("NOTIFY_SOCKET");
+  static const char ready[] = "READY=1";
+  if (notify_socket == NULL || notify_socket[0] == '\0') {
+    errno = ENOENT;
+    return -1;
+  }
+
+  size_t path_length = strlen(notify_socket);
+  if (path_length >= sizeof(((struct sockaddr_un *)0)->sun_path)) {
+    errno = ENAMETOOLONG;
+    return -1;
+  }
+
+  int fd = socket(AF_UNIX, SOCK_DGRAM | SOCK_CLOEXEC, 0);
+  if (fd < 0) return -1;
+
+  struct sockaddr_un address;
+  memset(&address, 0, sizeof(address));
+  address.sun_family = AF_UNIX;
+  if (notify_socket[0] == '@') {
+    address.sun_path[0] = '\0';
+    memcpy(address.sun_path + 1, notify_socket + 1, path_length - 1);
+  } else {
+    memcpy(address.sun_path, notify_socket, path_length + 1);
+  }
+  socklen_t address_length = (socklen_t)(
+      offsetof(struct sockaddr_un, sun_path) + path_length +
+      (notify_socket[0] == '@' ? 0 : 1));
+  ssize_t sent = sendto(fd, ready, sizeof(ready) - 1, MSG_NOSIGNAL,
+                        (struct sockaddr *)&address, address_length);
+  int saved_errno = errno;
+  close(fd);
+  errno = saved_errno;
+  return sent == (ssize_t)(sizeof(ready) - 1) ? 0 : -1;
 }
 
 static int create_listener(const char *path, uid_t owner_uid, gid_t owner_gid) {
@@ -201,7 +239,11 @@ int main(void) {
   };
   pid_t maintenance = spawn_maintenance();
   size_t workers = 0;
-  if (maintenance < 0) stopping = 1;
+  int exit_status = 0;
+  if (maintenance < 0 || notify_ready() < 0) {
+    exit_status = 1;
+    stopping = 1;
+  }
   while (!stopping) {
     int result = poll(listeners, 2, 1000);
     if (result < 0) {
@@ -244,5 +286,5 @@ int main(void) {
   if (maintenance > 0) (void)kill(maintenance, SIGTERM);
   while (waitpid(-1, NULL, 0) > 0 || errno == EINTR) {
   }
-  return 0;
+  return exit_status;
 }

--- a/packages/terminal-runtime/native/supervisor-acceptor.c
+++ b/packages/terminal-runtime/native/supervisor-acceptor.c
@@ -2,6 +2,7 @@
 
 #include <errno.h>
 #include <fcntl.h>
+#include <limits.h>
 #include <poll.h>
 #include <pwd.h>
 #include <signal.h>
@@ -19,7 +20,8 @@
 
 #define PUBLIC_SOCKET "/run/matrix-terminal-runtime/supervisor.sock"
 #define KEEPER_SOCKET "/run/matrix-terminal-runtime/keeper.sock"
-#define WORKER "/opt/matrix/bin/matrix-terminal-runtime-op"
+#define NODE "/opt/matrix/runtime/node/bin/node"
+#define GENERATION_PREFIX "/opt/matrix/libexec/terminal-runtime/v1/"
 #define MAX_WORKERS 128
 
 static volatile sig_atomic_t stopping = 0;
@@ -33,6 +35,29 @@ static int set_cloexec(int fd) {
   int flags = fcntl(fd, F_GETFD);
   if (flags < 0) return -1;
   return fcntl(fd, F_SETFD, flags | FD_CLOEXEC);
+}
+
+static int resolve_worker(char worker[PATH_MAX]) {
+  static const char self_name[] = "/supervisor-acceptor", worker_name[] = "/runtime-op.js";
+  char executable[PATH_MAX];
+  ssize_t length = readlink("/proc/self/exe", executable, sizeof(executable) - 1);
+  size_t prefix_length = strlen(GENERATION_PREFIX);
+  if (length < 0 || (size_t)length != prefix_length + 64 +
+      sizeof(self_name) - 1) return -1;
+  executable[length] = '\0';
+  if (memcmp(executable, GENERATION_PREFIX, prefix_length) != 0 ||
+      strcmp(executable + prefix_length + 64, self_name) != 0) return -1;
+  for (size_t index = prefix_length; index < prefix_length + 64; index += 1) {
+    if (!((executable[index] >= '0' && executable[index] <= '9') ||
+          (executable[index] >= 'a' && executable[index] <= 'f'))) return -1;
+  }
+  memcpy(worker, executable, prefix_length + 64);
+  memcpy(worker + prefix_length + 64, worker_name, sizeof(worker_name));
+  struct stat metadata;
+  if (lstat(worker, &metadata) < 0 || !S_ISREG(metadata.st_mode) ||
+      metadata.st_uid != 0 || metadata.st_nlink != 1 ||
+      (metadata.st_mode & 0022) != 0) return -1;
+  return 0;
 }
 
 static int notify_ready(void) {
@@ -120,7 +145,8 @@ static int write_all(int fd, const void *buffer, size_t length) {
   return 0;
 }
 
-static pid_t serve_connection(int connection, const char *mode,
+static pid_t serve_connection(int connection, const char *worker,
+                              const char *mode,
                               uid_t matrix_uid) {
   struct ucred credentials;
   socklen_t credentials_length = sizeof(credentials);
@@ -168,8 +194,8 @@ static pid_t serve_connection(int connection, const char *mode,
         _exit(126);
       }
     }
-    char *const arguments[] = {(char *)WORKER, (char *)mode, NULL};
-    execv(WORKER, arguments);
+    char *const arguments[] = {(char *)NODE, (char *)worker, (char *)mode, NULL};
+    execv(NODE, arguments);
     _exit(127);
   }
 
@@ -185,12 +211,12 @@ static pid_t serve_connection(int connection, const char *mode,
   return child;
 }
 
-static pid_t spawn_maintenance(void) {
+static pid_t spawn_maintenance(const char *worker) {
   pid_t child = fork();
   if (child != 0) return child;
   char *const arguments[] = {
-      (char *)WORKER, (char *)"maintenance", NULL};
-  execv(WORKER, arguments);
+      (char *)NODE, (char *)worker, (char *)"maintenance", NULL};
+  execv(NODE, arguments);
   _exit(127);
 }
 
@@ -206,6 +232,8 @@ static void reap_children(pid_t *maintenance, size_t *workers) {
 }
 
 int main(void) {
+  char worker[PATH_MAX];
+  if (resolve_worker(worker) < 0) return fputs("terminal_runtime_generation_invalid\n", stderr), 1;
   struct passwd *matrix = getpwnam("matrix");
   if (matrix == NULL || matrix->pw_uid == 0) {
     fputs("terminal_runtime_owner_unavailable\n", stderr);
@@ -237,7 +265,7 @@ int main(void) {
       {.fd = public_listener, .events = POLLIN, .revents = 0},
       {.fd = keeper_listener, .events = POLLIN, .revents = 0},
   };
-  pid_t maintenance = spawn_maintenance();
+  pid_t maintenance = spawn_maintenance(worker);
   size_t workers = 0;
   int exit_status = 0;
   if (maintenance < 0 || notify_ready() < 0) {
@@ -252,7 +280,7 @@ int main(void) {
     }
     reap_children(&maintenance, &workers);
     if (maintenance < 0 && !stopping) {
-      maintenance = spawn_maintenance();
+      maintenance = spawn_maintenance(worker);
       if (maintenance < 0) {
         stopping = 1;
         break;
@@ -271,11 +299,12 @@ int main(void) {
         close(connection);
         continue;
       }
-      pid_t worker = serve_connection(
+      pid_t child = serve_connection(
           connection,
+          worker,
           index == 0 ? "serve-peer" : "serve-keeper",
           matrix->pw_uid);
-      if (worker > 0) workers += 1;
+      if (child > 0) workers += 1;
     }
   }
 

--- a/packages/terminal-runtime/native/supervisor-acceptor.c
+++ b/packages/terminal-runtime/native/supervisor-acceptor.c
@@ -1,0 +1,248 @@
+#define _GNU_SOURCE
+
+#include <errno.h>
+#include <fcntl.h>
+#include <poll.h>
+#include <pwd.h>
+#include <signal.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <sys/un.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#define PUBLIC_SOCKET "/run/matrix-terminal-runtime/supervisor.sock"
+#define KEEPER_SOCKET "/run/matrix-terminal-runtime/keeper.sock"
+#define WORKER "/opt/matrix/bin/matrix-terminal-runtime-op"
+#define MAX_WORKERS 128
+
+static volatile sig_atomic_t stopping = 0;
+
+static void handle_signal(int signal_number) {
+  (void)signal_number;
+  stopping = 1;
+}
+
+static int set_cloexec(int fd) {
+  int flags = fcntl(fd, F_GETFD);
+  if (flags < 0) return -1;
+  return fcntl(fd, F_SETFD, flags | FD_CLOEXEC);
+}
+
+static int create_listener(const char *path, uid_t owner_uid, gid_t owner_gid) {
+  int fd = socket(AF_UNIX, SOCK_STREAM | SOCK_CLOEXEC, 0);
+  if (fd < 0) return -1;
+
+  struct sockaddr_un address;
+  memset(&address, 0, sizeof(address));
+  address.sun_family = AF_UNIX;
+  if (strlen(path) >= sizeof(address.sun_path)) {
+    close(fd);
+    errno = ENAMETOOLONG;
+    return -1;
+  }
+  memcpy(address.sun_path, path, strlen(path) + 1);
+  if (unlink(path) < 0 && errno != ENOENT) {
+    close(fd);
+    return -1;
+  }
+  if (bind(fd, (struct sockaddr *)&address, sizeof(address)) < 0) {
+    close(fd);
+    return -1;
+  }
+  if (chown(path, owner_uid, owner_gid) < 0 || chmod(path, 0600) < 0) {
+    close(fd);
+    unlink(path);
+    return -1;
+  }
+  if (listen(fd, 64) < 0) {
+    close(fd);
+    unlink(path);
+    return -1;
+  }
+  return fd;
+}
+
+static int write_all(int fd, const void *buffer, size_t length) {
+  const uint8_t *cursor = buffer;
+  size_t written = 0;
+  while (written < length) {
+    ssize_t result = write(fd, cursor + written, length - written);
+    if (result < 0) {
+      if (errno == EINTR) continue;
+      return -1;
+    }
+    written += (size_t)result;
+  }
+  return 0;
+}
+
+static pid_t serve_connection(int connection, const char *mode,
+                              uid_t matrix_uid) {
+  struct ucred credentials;
+  socklen_t credentials_length = sizeof(credentials);
+  if (getsockopt(connection, SOL_SOCKET, SO_PEERCRED, &credentials,
+                 &credentials_length) < 0 ||
+      credentials_length != sizeof(credentials) ||
+      credentials.uid != matrix_uid || credentials.pid < 1) {
+    close(connection);
+    return -1;
+  }
+
+  int credential_pipe[2];
+  if (pipe(credential_pipe) < 0) {
+    close(connection);
+    return -1;
+  }
+  if (set_cloexec(credential_pipe[0]) < 0 ||
+      set_cloexec(credential_pipe[1]) < 0) {
+    close(credential_pipe[0]);
+    close(credential_pipe[1]);
+    close(connection);
+    return -1;
+  }
+
+  pid_t child = fork();
+  if (child < 0) {
+    close(credential_pipe[0]);
+    close(credential_pipe[1]);
+    close(connection);
+    return -1;
+  }
+  if (child == 0) {
+    close(credential_pipe[1]);
+    if (dup2(connection, STDIN_FILENO) < 0 ||
+        dup2(connection, STDOUT_FILENO) < 0) {
+      _exit(126);
+    }
+    close(connection);
+    if (credential_pipe[0] != 3) {
+      if (dup2(credential_pipe[0], 3) < 0) _exit(126);
+      close(credential_pipe[0]);
+    } else {
+      int flags = fcntl(3, F_GETFD);
+      if (flags < 0 || fcntl(3, F_SETFD, flags & ~FD_CLOEXEC) < 0) {
+        _exit(126);
+      }
+    }
+    char *const arguments[] = {(char *)WORKER, (char *)mode, NULL};
+    execv(WORKER, arguments);
+    _exit(127);
+  }
+
+  close(credential_pipe[0]);
+  close(connection);
+  uint32_t serialized[3] = {
+      (uint32_t)credentials.pid,
+      (uint32_t)credentials.uid,
+      (uint32_t)credentials.gid,
+  };
+  (void)write_all(credential_pipe[1], serialized, sizeof(serialized));
+  close(credential_pipe[1]);
+  return child;
+}
+
+static pid_t spawn_maintenance(void) {
+  pid_t child = fork();
+  if (child != 0) return child;
+  char *const arguments[] = {
+      (char *)WORKER, (char *)"maintenance", NULL};
+  execv(WORKER, arguments);
+  _exit(127);
+}
+
+static void reap_children(pid_t *maintenance, size_t *workers) {
+  pid_t child;
+  while ((child = waitpid(-1, NULL, WNOHANG)) > 0) {
+    if (child == *maintenance) {
+      *maintenance = -1;
+    } else if (*workers > 0) {
+      *workers -= 1;
+    }
+  }
+}
+
+int main(void) {
+  struct passwd *matrix = getpwnam("matrix");
+  if (matrix == NULL || matrix->pw_uid == 0) {
+    fputs("terminal_runtime_owner_unavailable\n", stderr);
+    return 1;
+  }
+
+  struct sigaction action;
+  memset(&action, 0, sizeof(action));
+  action.sa_handler = handle_signal;
+  sigemptyset(&action.sa_mask);
+  if (sigaction(SIGTERM, &action, NULL) < 0 ||
+      sigaction(SIGINT, &action, NULL) < 0) {
+    return 1;
+  }
+
+  int public_listener = create_listener(
+      PUBLIC_SOCKET, matrix->pw_uid, matrix->pw_gid);
+  int keeper_listener = create_listener(
+      KEEPER_SOCKET, matrix->pw_uid, matrix->pw_gid);
+  if (public_listener < 0 || keeper_listener < 0) {
+    if (public_listener >= 0) close(public_listener);
+    if (keeper_listener >= 0) close(keeper_listener);
+    unlink(PUBLIC_SOCKET);
+    unlink(KEEPER_SOCKET);
+    return 1;
+  }
+
+  struct pollfd listeners[2] = {
+      {.fd = public_listener, .events = POLLIN, .revents = 0},
+      {.fd = keeper_listener, .events = POLLIN, .revents = 0},
+  };
+  pid_t maintenance = spawn_maintenance();
+  size_t workers = 0;
+  if (maintenance < 0) stopping = 1;
+  while (!stopping) {
+    int result = poll(listeners, 2, 1000);
+    if (result < 0) {
+      if (errno == EINTR) continue;
+      break;
+    }
+    reap_children(&maintenance, &workers);
+    if (maintenance < 0 && !stopping) {
+      maintenance = spawn_maintenance();
+      if (maintenance < 0) {
+        stopping = 1;
+        break;
+      }
+    }
+    for (size_t index = 0; index < 2; index += 1) {
+      if ((listeners[index].revents & POLLIN) == 0) continue;
+      int connection = accept4(
+          listeners[index].fd, NULL, NULL, SOCK_CLOEXEC);
+      if (connection < 0) {
+        if (errno == EINTR) continue;
+        stopping = 1;
+        break;
+      }
+      if (workers >= MAX_WORKERS) {
+        close(connection);
+        continue;
+      }
+      pid_t worker = serve_connection(
+          connection,
+          index == 0 ? "serve-peer" : "serve-keeper",
+          matrix->pw_uid);
+      if (worker > 0) workers += 1;
+    }
+  }
+
+  close(public_listener);
+  close(keeper_listener);
+  unlink(PUBLIC_SOCKET);
+  unlink(KEEPER_SOCKET);
+  if (maintenance > 0) (void)kill(maintenance, SIGTERM);
+  while (waitpid(-1, NULL, 0) > 0 || errno == EINTR) {
+  }
+  return 0;
+}

--- a/packages/terminal-runtime/package.json
+++ b/packages/terminal-runtime/package.json
@@ -9,9 +9,11 @@
   "main": "src/index.ts",
   "types": "src/index.ts",
   "scripts": {
+    "build": "tsc",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "node-pty": "^1.1.0",
     "zod": "^4.4.3"
   },
   "devDependencies": {

--- a/packages/terminal-runtime/src/contracts.ts
+++ b/packages/terminal-runtime/src/contracts.ts
@@ -172,6 +172,9 @@ export type RecoveryReason = z.infer<typeof RecoveryReasonSchema>;
 export function createRuntimeId(): RuntimeId {
   return RuntimeIdSchema.parse(randomBytes(16).toString('hex'));
 }
+export function createOperationId(): OperationId {
+  return OperationIdSchema.parse(randomBytes(16).toString('hex'));
+}
 export function unitNameForRuntimeId(runtimeId: string): string {
   const trustedId = RuntimeIdSchema.parse(runtimeId);
   return `matrix-terminal-session@${trustedId}.service`;

--- a/packages/terminal-runtime/src/descriptors.ts
+++ b/packages/terminal-runtime/src/descriptors.ts
@@ -102,6 +102,29 @@ export class DescriptorStore {
       });
     }
   }
+  async claimRuntime(input: {
+    runtimeId: string;
+    pid: number;
+  }): Promise<Descriptor> {
+    const runtimeId = RuntimeIdSchema.parse(input.runtimeId);
+    if (!Number.isSafeInteger(input.pid) || input.pid <= 0) {
+      throw new Error('claim_unauthorized');
+    }
+    const prefix = `${runtimeId}.`;
+    const operationIds = (await this.directory.list())
+      .filter((name) =>
+        name.startsWith(prefix) && name.endsWith('.pending.json'))
+      .map((name) =>
+        name.slice(prefix.length, -'.pending.json'.length))
+      .map((value) => OperationIdSchema.parse(value));
+    if (operationIds.length === 0) throw new Error('descriptor_not_found');
+    if (operationIds.length !== 1) throw new Error('descriptor_conflict');
+    return await this.claim({
+      runtimeId,
+      operationId: operationIds[0],
+      pid: input.pid,
+    });
+  }
   async remove(runtimeId: string, operationId: string): Promise<void> {
     for (const name of [
       pendingName(runtimeId, operationId),

--- a/packages/terminal-runtime/src/index.ts
+++ b/packages/terminal-runtime/src/index.ts
@@ -1,2 +1,4 @@
 export * from './client.js'; export * from './contracts.js'; export * from './descriptors.js'; export * from './framing.js'; export * from './locks.js';
 export * from './operation-handler.js'; export * from './receipts.js'; export * from './reconciliation.js'; export * from './runtime-state.js'; export * from './storage.js';
+export * from './keeper.js'; export * from './supervisor.js'; export * from './systemd.js';
+export * from './keeper-client.js'; export * from './pane.js';

--- a/packages/terminal-runtime/src/keeper-client.ts
+++ b/packages/terminal-runtime/src/keeper-client.ts
@@ -1,0 +1,80 @@
+import { createConnection, type Socket } from 'node:net';
+import { z } from 'zod/v4';
+import {
+  DescriptorSchema,
+  RuntimeIdSchema,
+  type Descriptor,
+} from './contracts.js';
+import {
+  decodeFrame,
+  encodeFrame,
+  MAX_FRAME_BYTES,
+} from './framing.js';
+
+const KeeperResponseSchema = z.discriminatedUnion('ok', [
+  z.object({ ok: z.literal(true), descriptor: DescriptorSchema }).strict(),
+  z.object({
+    ok: z.literal(false),
+    error: z.literal('claim_failed'),
+  }).strict(),
+]);
+
+export async function claimKeeperDescriptor(options: {
+  runtimeId: string;
+  socketPath?: string;
+  timeoutMs?: number;
+  connect?: (path: string) => Socket;
+}): Promise<Descriptor> {
+  const runtimeId = RuntimeIdSchema.parse(options.runtimeId);
+  const socketPath = options.socketPath ??
+    '/run/matrix-terminal-runtime/keeper.sock';
+  const timeoutMs = options.timeoutMs ?? 10_000;
+  if (!socketPath.startsWith('/') || socketPath.length > 107) {
+    throw new Error('keeper_socket_invalid');
+  }
+  if (!Number.isSafeInteger(timeoutMs) || timeoutMs < 1 || timeoutMs > 30_000) {
+    throw new Error('keeper_timeout_invalid');
+  }
+  const connect = options.connect ?? ((path: string) => createConnection(path));
+  return await new Promise<Descriptor>((resolve, reject) => {
+    const socket = connect(socketPath);
+    const chunks: Buffer[] = [];
+    let total = 0;
+    let settled = false;
+    const finish = (error: Error | null, descriptor?: Descriptor): void => {
+      if (settled) return;
+      settled = true;
+      socket.destroy();
+      if (error) reject(error);
+      else if (descriptor) resolve(descriptor);
+      else reject(new Error('keeper_claim_failed'));
+    };
+    socket.setTimeout(timeoutMs);
+    socket.once('timeout', () => finish(new Error('keeper_claim_timeout')));
+    socket.once('error', (error: Error) =>
+      finish(new Error('keeper_claim_failed', { cause: error })));
+    socket.once('close', () => finish(new Error('keeper_claim_failed')));
+    socket.on('data', (chunk: Buffer) => {
+      total += chunk.byteLength;
+      if (total > MAX_FRAME_BYTES + 4 || chunks.length >= 1_024) {
+        finish(new Error('keeper_claim_invalid'));
+        return;
+      }
+      chunks.push(Buffer.from(chunk));
+    });
+    socket.once('end', () => {
+      try {
+        const response = KeeperResponseSchema.parse(
+          decodeFrame(Buffer.concat(chunks, total)),
+        );
+        if (!response.ok) throw new Error('keeper_claim_failed');
+        finish(null, response.descriptor);
+      } catch (error: unknown) {
+        finish(error instanceof Error ? error : new Error('keeper_claim_invalid'));
+      }
+    });
+    socket.once('connect', () => {
+      socket.end(encodeFrame({ version: 1, runtimeId }));
+    });
+  });
+}

--- a/packages/terminal-runtime/src/keeper.ts
+++ b/packages/terminal-runtime/src/keeper.ts
@@ -1,0 +1,359 @@
+import { execFile as execFileCallback } from 'node:child_process';
+import {
+  readFile,
+  realpath,
+} from 'node:fs/promises';
+import { join, resolve, sep } from 'node:path';
+import { promisify, stripVTControlCharacters } from 'node:util';
+import { spawn as spawnPty } from 'node-pty';
+import {
+  DescriptorSchema,
+  RuntimeIdSchema,
+  type Descriptor,
+} from './contracts.js';
+import { claimKeeperDescriptor } from './keeper-client.js';
+
+const KEEPER_LAYOUT = '/opt/matrix/libexec/terminal-runtime/current/layout.kdl';
+const ZELLIJ_CONFIG =
+  '/opt/matrix/libexec/terminal-runtime/current/config.kdl';
+const ZELLIJ = '/opt/matrix/bin/zellij';
+const DEFAULT_HOME = '/home/matrix/home';
+const execFile = promisify(execFileCallback);
+
+function recordKeeperFailure(error: unknown, code: string): void {
+  const suffix = error instanceof Error ? '' : '_non_error';
+  process.stderr.write(`${code}${suffix}\n`);
+}
+
+export type KeeperRoles = {
+  keeper: number;
+  zellijClient: number;
+  zellijServer: number;
+  shell: number;
+};
+
+export type KeeperEvidence = {
+  clientAlive: boolean;
+  sessionResponsive: boolean;
+  confirmationGated?: boolean;
+  roles: KeeperRoles | null;
+};
+
+export type KeeperLaunch = {
+  file: string;
+  args: string[];
+  cwd: string;
+  env: Record<string, string>;
+};
+
+function ownerPath(home: string, relativePath: string): string {
+  const root = resolve(home);
+  const target = resolve(root, relativePath);
+  if (target !== root && !target.startsWith(`${root}${sep}`)) {
+    throw new Error('keeper_cwd_invalid');
+  }
+  return target;
+}
+
+export async function validateKeeperCwd(
+  home: string,
+  relativePath: string,
+): Promise<string> {
+  try {
+    const root = await realpath(home);
+    const target = await realpath(ownerPath(root, relativePath));
+    if (target !== root && !target.startsWith(`${root}${sep}`)) {
+      throw new Error('keeper_cwd_invalid');
+    }
+    return target;
+  } catch (error: unknown) {
+    if (error instanceof Error && error.message === 'keeper_cwd_invalid') {
+      throw error;
+    }
+    throw new Error('keeper_cwd_invalid', { cause: error });
+  }
+}
+
+export function keeperEnvironment(
+  home = DEFAULT_HOME,
+  uid = process.getuid?.() ?? 1000,
+): Record<string, string> {
+  const stateRoot = join(home, 'system/terminal-runtime');
+  return {
+    HOME: home,
+    MATRIX_HOME: home,
+    PATH: '/opt/matrix/bin:/opt/matrix/runtime/node/bin:/usr/bin:/bin',
+    LANG: 'C.UTF-8',
+    TERM: 'xterm-256color',
+    XDG_CACHE_HOME: join(stateRoot, 'zellij-cache'),
+    XDG_CONFIG_HOME: join(stateRoot, 'zellij-config-home'),
+    XDG_DATA_HOME: join(stateRoot, 'zellij-data'),
+    XDG_RUNTIME_DIR: `/run/user/${uid}`,
+    ZELLIJ_CONFIG_DIR: '/opt/matrix/libexec/terminal-runtime/current',
+    ZELLIJ_CONFIG_FILE: ZELLIJ_CONFIG,
+  };
+}
+
+export function buildKeeperLaunch(
+  rawDescriptor: Descriptor,
+  home = DEFAULT_HOME,
+): KeeperLaunch {
+  const descriptor = DescriptorSchema.parse(rawDescriptor);
+  const sessionName = `matrix-t-${descriptor.runtimeId}`;
+  return {
+    file: ZELLIJ,
+    args: descriptor.intent === 'recover'
+      ? ['attach', sessionName]
+      : [
+          '--session',
+          sessionName,
+          '--new-session-with-layout',
+          KEEPER_LAYOUT,
+        ],
+    cwd: ownerPath(home, descriptor.cwd.path),
+    env: keeperEnvironment(home),
+  };
+}
+
+export async function waitForKeeperReadiness(options: {
+  runtimeId: string;
+  requiresConfirmation?: boolean;
+  timeoutMs?: number;
+  pollMs?: number;
+  readEvidence(): Promise<KeeperEvidence>;
+  delay(ms: number): Promise<void>;
+  notifyReady(evidence: { runtimeId: string; roles: KeeperRoles }): Promise<void>;
+}): Promise<{ runtimeId: string; roles: KeeperRoles }> {
+  const runtimeId = RuntimeIdSchema.parse(options.runtimeId);
+  const timeoutMs = options.timeoutMs ?? 25_000;
+  const pollMs = options.pollMs ?? 250;
+  if (!Number.isSafeInteger(timeoutMs) || timeoutMs < 1 || timeoutMs > 30_000) {
+    throw new Error('keeper_timeout_invalid');
+  }
+  if (!Number.isSafeInteger(pollMs) || pollMs < 1 || pollMs > 1_000) {
+    throw new Error('keeper_poll_invalid');
+  }
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() <= deadline) {
+    const evidence = await options.readEvidence();
+    if (!evidence.clientAlive) throw new Error('keeper_client_exited');
+    if (
+      evidence.sessionResponsive &&
+      evidence.roles &&
+      (!options.requiresConfirmation || evidence.confirmationGated === true)
+    ) {
+      const ready = { runtimeId, roles: evidence.roles };
+      await options.notifyReady(ready);
+      return ready;
+    }
+    await options.delay(pollMs);
+  }
+  throw new Error('keeper_readiness_timeout');
+}
+
+export async function monitorKeeperOnce(options: {
+  clientAlive: boolean;
+  sessionResponds(): Promise<boolean>;
+}): Promise<boolean> {
+  return options.clientAlive && await options.sessionResponds();
+}
+
+export function isKeeperEntrypoint(moduleUrl: string, argvPath: string | undefined): boolean {
+  if (!argvPath) return false;
+  return moduleUrl.endsWith('/keeper.js') && argvPath.endsWith('/keeper.js');
+}
+
+async function exactSessionResponds(
+  sessionName: string,
+  environment: Record<string, string>,
+): Promise<boolean> {
+  try {
+    const { stdout } = await execFile(
+      ZELLIJ,
+      ['list-sessions', '--no-formatting'],
+      { env: environment, timeout: 2_000, maxBuffer: 64 * 1024 },
+    );
+    return stdout.split(/\r?\n/).some((line) =>
+      line.trim().split(/\s+/, 1)[0] === sessionName);
+  } catch (error: unknown) {
+    if (error instanceof Error) return false;
+    throw error;
+  }
+}
+
+async function ownCgroup(runtimeId: string): Promise<string> {
+  const membership = await readFile('/proc/self/cgroup', 'utf8');
+  const unified = membership.split(/\r?\n/)
+    .find((line) => line.startsWith('0::'));
+  if (!unified) throw new Error('keeper_cgroup_invalid');
+  const relative = unified.slice(3);
+  const expected = `/matrix-terminal-session@${runtimeId}.service`;
+  if (!relative.endsWith(expected) || relative.includes('..')) {
+    throw new Error('keeper_cgroup_invalid');
+  }
+  return `/sys/fs/cgroup${relative}`;
+}
+
+async function cgroupRoles(
+  path: string,
+  requireShell: boolean,
+): Promise<KeeperRoles | null> {
+  const pids = (await readFile(`${path}/cgroup.procs`, 'utf8'))
+    .split(/\s+/)
+    .filter(Boolean)
+    .map((value) => Number.parseInt(value, 10));
+  const processes = (await Promise.all(pids.map(async (pid) => {
+    try {
+      const [comm, cmdline] = await Promise.all([
+        readFile(`/proc/${pid}/comm`, 'utf8'),
+        readFile(`/proc/${pid}/cmdline`),
+      ]);
+      return {
+        pid,
+        comm: comm.trim(),
+        args: cmdline.toString('utf8').split('\0').filter(Boolean),
+      };
+    } catch (error: unknown) {
+      if (error instanceof Error && 'code' in error && error.code === 'ENOENT') {
+        return null;
+      }
+      throw error;
+    }
+  }))).filter((value) => value !== null);
+  const keeper = processes.find((entry) =>
+    entry.args.some((argument) => argument.endsWith('/keeper.js')));
+  const zellij = processes
+    .filter((entry) =>
+      entry.comm === 'zellij' && !entry.args.includes('list-sessions'))
+    .sort((left, right) => left.pid - right.pid);
+  const shell = processes.find((entry) => entry.comm === 'bash');
+  if (!keeper || zellij.length < 2 || (requireShell && !shell)) return null;
+  return {
+    keeper: keeper.pid,
+    zellijClient: zellij[0].pid,
+    zellijServer: zellij[1].pid,
+    shell: shell?.pid ?? 0,
+  };
+}
+
+async function notifySystemdReady(): Promise<void> {
+  await execFile(
+    '/usr/bin/systemd-notify',
+    ['--ready', `--pid=${process.pid}`, '--status=terminal-runtime-ready'],
+    { timeout: 2_000, maxBuffer: 16 * 1024 },
+  );
+}
+
+export async function runKeeper(runtimeIdInput: string | undefined): Promise<number> {
+  const runtimeId = RuntimeIdSchema.parse(runtimeIdInput);
+  const descriptor = await claimKeeperDescriptor({ runtimeId });
+  const launch = {
+    ...buildKeeperLaunch(descriptor),
+    cwd: await validateKeeperCwd(DEFAULT_HOME, descriptor.cwd.path),
+  };
+  const cgroup = await ownCgroup(runtimeId);
+  const sessionName = `matrix-t-${runtimeId}`;
+  let clientAlive = true;
+  let stopping = false;
+  let exitCode = 0;
+  let renderWindow = '';
+  let confirmationGated = descriptor.intent === 'create';
+  const pty = spawnPty(launch.file, launch.args, {
+    name: 'xterm-256color',
+    cols: 120,
+    rows: 40,
+    cwd: launch.cwd,
+    env: launch.env,
+  });
+  pty.onData((data) => {
+    // Inspect a bounded in-memory window only; never copy terminal contents to
+    // journals or durable supervisor state.
+    renderWindow = `${renderWindow}${data}`.slice(-16_384);
+    if (
+      !confirmationGated &&
+      stripVTControlCharacters(renderWindow).includes('<ENTER> run')
+    ) {
+      confirmationGated = true;
+    }
+  });
+  pty.onExit(() => {
+    clientAlive = false;
+    if (!stopping) exitCode = 17;
+  });
+  try {
+    await waitForKeeperReadiness({
+      runtimeId,
+      requiresConfirmation: descriptor.intent === 'recover',
+      readEvidence: async () => ({
+        clientAlive,
+        confirmationGated,
+        sessionResponsive: await exactSessionResponds(
+          sessionName,
+          launch.env,
+        ),
+        roles: await cgroupRoles(cgroup, descriptor.intent === 'create'),
+      }),
+      delay: async (milliseconds) =>
+        await new Promise((resolveDelay) => setTimeout(resolveDelay, milliseconds)),
+      notifyReady: async () => await notifySystemdReady(),
+    });
+    return await new Promise<number>((resolveKeeper) => {
+      let checking = false;
+      const monitor = setInterval(async () => {
+        if (stopping || checking) return;
+        checking = true;
+        try {
+          if (!await monitorKeeperOnce({
+            clientAlive,
+            sessionResponds: async () =>
+              await exactSessionResponds(sessionName, launch.env),
+          })) {
+            stopping = true;
+            clearInterval(monitor);
+            resolveKeeper(exitCode || 18);
+          }
+        } catch (error: unknown) {
+          recordKeeperFailure(error, 'terminal_keeper_monitor_failed');
+          exitCode = 19;
+          stopping = true;
+          clearInterval(monitor);
+          resolveKeeper(exitCode);
+        } finally {
+          checking = false;
+        }
+      }, 1_000);
+      monitor.unref();
+      const stop = (): void => {
+        if (stopping) return;
+        stopping = true;
+        clearInterval(monitor);
+        try {
+          pty.kill();
+        } catch (error: unknown) {
+          recordKeeperFailure(error, 'terminal_keeper_stop_failed');
+          exitCode = 1;
+        }
+        resolveKeeper(exitCode);
+      };
+      process.once('SIGTERM', stop);
+      process.once('SIGINT', stop);
+    });
+  } finally {
+    stopping = true;
+    try {
+      pty.kill();
+    } catch (error: unknown) {
+      recordKeeperFailure(error, 'terminal_keeper_cleanup_failed');
+      exitCode = 1;
+    }
+  }
+}
+
+if (isKeeperEntrypoint(import.meta.url, process.argv[1])) {
+  try {
+    process.exitCode = await runKeeper(process.argv[2]);
+  } catch (error: unknown) {
+    recordKeeperFailure(error, 'terminal_keeper_start_failed');
+    process.exitCode = 16;
+  }
+}

--- a/packages/terminal-runtime/src/locks.ts
+++ b/packages/terminal-runtime/src/locks.ts
@@ -4,35 +4,110 @@ import { RuntimeIdSchema } from './contracts.js';
 import { SecureDirectory } from './storage.js';
 const LOCK_TIMEOUT_MS = 10_000;
 type LockHandle = { release(): Promise<void> };
-async function waitForFlock(
+async function acquireFlock(
   handle: FileHandle,
   flockPath: string,
   timeoutMs: number,
-): Promise<void> {
+): Promise<LockHandle> {
+  const child = spawn(
+    flockPath,
+    ['--exclusive', '/proc/self/fd/3', '/usr/bin/tee'],
+    {
+      shell: false,
+      stdio: ['pipe', 'pipe', 'ignore', handle.fd],
+    },
+  );
+  if (!child.stdin || !child.stdout) {
+    child.kill('SIGKILL');
+    throw new Error('lock_failed');
+  }
+  const childInput = child.stdin;
+  const childOutput = child.stdout;
   await new Promise<void>((resolve, reject) => {
     let settled = false;
-    const child = spawn(flockPath, ['--exclusive', '3'], {
-      shell: false,
-      stdio: ['ignore', 'ignore', 'ignore', handle.fd],
-    });
     const finish = (error?: Error): void => {
       if (settled) return;
       settled = true;
       clearTimeout(timer);
+      childOutput.removeListener('data', onData);
       if (error) reject(error);
       else resolve();
     };
+    const onData = (): void => finish();
     const timer = setTimeout(() => {
       child.kill('SIGKILL');
       finish(new Error('lock_timeout'));
     }, timeoutMs);
     timer.unref();
+    childOutput.once('data', onData);
     child.once('error', (error: Error) => {
       finish(new Error('lock_failed', { cause: error }));
     });
     child.once('exit', (code, signal) => {
-      if (code === 0 && signal === null) finish();
-      else finish(new Error('lock_failed'));
+      if (!settled || code !== 0 || signal !== null) {
+        finish(new Error('lock_failed'));
+      }
+    });
+    childInput.write('locked\n');
+  });
+  let released = false;
+  return {
+    release: async () => {
+      if (released) return;
+      released = true;
+      try {
+        await new Promise<void>((resolve, reject) => {
+          const timer = setTimeout(() => {
+            child.kill('SIGKILL');
+            reject(new Error('lock_release_timeout'));
+          }, timeoutMs);
+          timer.unref();
+          child.once('error', (error: Error) => {
+            clearTimeout(timer);
+            reject(new Error('lock_release_failed', { cause: error }));
+          });
+          child.once('exit', (code, signal) => {
+            clearTimeout(timer);
+            if (code === 0 && signal === null) resolve();
+            else reject(new Error('lock_release_failed'));
+          });
+          childInput.end();
+        });
+      } finally {
+        await handle.close();
+      }
+    },
+  };
+}
+async function probeFlock(
+  handle: FileHandle,
+  flockPath: string,
+  timeoutMs: number,
+): Promise<boolean> {
+  return new Promise<boolean>((resolve, reject) => {
+    const child = spawn(
+      flockPath,
+      ['--exclusive', '--nonblock', '/proc/self/fd/3', '/usr/bin/true'],
+      {
+        shell: false,
+        stdio: ['ignore', 'ignore', 'ignore', handle.fd],
+      },
+    );
+    const timer = setTimeout(() => {
+      child.kill('SIGKILL');
+      reject(new Error('lock_probe_timeout'));
+    }, timeoutMs);
+    timer.unref();
+    child.once('error', (error: Error) => {
+      clearTimeout(timer);
+      reject(new Error('lock_probe_failed', { cause: error }));
+    });
+    child.once('exit', (code, signal) => {
+      clearTimeout(timer);
+      if (signal !== null) reject(new Error('lock_probe_failed'));
+      else if (code === 0) resolve(false);
+      else if (code === 1) resolve(true);
+      else reject(new Error('lock_probe_failed'));
     });
   });
 }
@@ -56,8 +131,7 @@ export class FlockManager {
   private async acquire(name: string): Promise<LockHandle> {
     const handle = await this.directory.openLock(name);
     try {
-      await waitForFlock(handle, this.flockPath, this.timeoutMs);
-      return { release: async () => handle.close() };
+      return await acquireFlock(handle, this.flockPath, this.timeoutMs);
     } catch (error: unknown) {
       await handle.close();
       throw error;
@@ -84,6 +158,15 @@ export class FlockManager {
       return await callback();
     } finally {
       for (const lock of held.reverse()) await lock.release();
+    }
+  }
+  async isRuntimeLocked(runtimeId: string): Promise<boolean> {
+    const id = RuntimeIdSchema.parse(runtimeId);
+    const handle = await this.directory.openLock(`runtime-${id}.lock`);
+    try {
+      return await probeFlock(handle, this.flockPath, this.timeoutMs);
+    } finally {
+      await handle.close();
     }
   }
   async close(): Promise<void> {

--- a/packages/terminal-runtime/src/pane.ts
+++ b/packages/terminal-runtime/src/pane.ts
@@ -1,0 +1,41 @@
+import { spawn } from 'node:child_process';
+
+const SAFE_ENVIRONMENT_KEYS = [
+  'HOME',
+  'LANG',
+  'MATRIX_HOME',
+  'PATH',
+  'TERM',
+] as const;
+
+export function paneEnvironment(
+  source: NodeJS.ProcessEnv = process.env,
+): Record<string, string> {
+  const environment: Record<string, string> = {};
+  for (const key of SAFE_ENVIRONMENT_KEYS) {
+    const value = source[key];
+    if (value) environment[key] = value;
+  }
+  return environment;
+}
+
+export async function runPane(kind: string | undefined): Promise<number> {
+  if (kind !== 'shell') return 64;
+  return await new Promise<number>((resolve, reject) => {
+    const child = spawn('/bin/bash', ['--login'], {
+      cwd: process.cwd(),
+      env: paneEnvironment(),
+      shell: false,
+      stdio: 'inherit',
+    });
+    child.once('error', (error: Error) => reject(error));
+    child.once('exit', (code, signal) => {
+      if (signal !== null) resolve(128);
+      else resolve(code ?? 1);
+    });
+  });
+}
+
+if (process.argv[1]?.endsWith('/pane.js')) {
+  process.exitCode = await runPane(process.argv[2]);
+}

--- a/packages/terminal-runtime/src/receipts.ts
+++ b/packages/terminal-runtime/src/receipts.ts
@@ -257,4 +257,15 @@ export class OperationRecordStore {
     await this.directory.replaceJson(operationFile(parsed.operationId), parsed);
     return parsed;
   }
+  async removeCompleted(operationId: string): Promise<void> {
+    const id = OperationIdSchema.parse(operationId);
+    const current = await this.read(id);
+    if (!current) return;
+    if (current.status !== 'ready' && current.status !== 'failed') {
+      throw new Error('operation_state_conflict');
+    }
+    await this.directory.remove(operationFile(id)).catch((error: unknown) => {
+      if (!isStateNotFound(error)) throw error;
+    });
+  }
 }

--- a/packages/terminal-runtime/src/runtime-op.ts
+++ b/packages/terminal-runtime/src/runtime-op.ts
@@ -1,0 +1,354 @@
+import { execFile as execFileCallback } from 'node:child_process';
+import { read } from 'node:fs';
+import {
+  readFile,
+  realpath,
+  stat,
+} from 'node:fs/promises';
+import { relative, resolve, sep } from 'node:path';
+import { promisify } from 'node:util';
+import { z } from 'zod/v4';
+import {
+  HomeRelativeCwdSchema,
+  RuntimeIdSchema,
+  createOperationId,
+  type HomeRelativeCwd,
+} from './contracts.js';
+import { createOperationHandler } from './operation-handler.js';
+import { createRuntimeState } from './runtime-state.js';
+import {
+  decodeFrame,
+  encodeFrame,
+  MAX_FRAME_BYTES,
+} from './framing.js';
+import {
+  decodePeerCredentials,
+  handleSupervisorFrame,
+} from './supervisor.js';
+import {
+  classifyRuntimeProcesses,
+  createSystemdExecutor,
+} from './systemd.js';
+
+const execFile = promisify(execFileCallback);
+const HOME = '/home/matrix/home';
+const DURABLE_ROOT = `${HOME}/system/terminal-runtime`;
+const RUNTIME_ROOT = '/run/matrix-terminal-runtime';
+const KeeperRequestSchema = z.object({
+  version: z.literal(1),
+  runtimeId: RuntimeIdSchema,
+}).strict();
+
+async function readPeer(): Promise<ReturnType<typeof decodePeerCredentials>> {
+  const bytes = Buffer.alloc(12);
+  let offset = 0;
+  while (offset < bytes.byteLength) {
+    const bytesRead = await new Promise<number>((resolveRead, rejectRead) => {
+      read(
+        3,
+        bytes,
+        offset,
+        bytes.byteLength - offset,
+        null,
+        (error, count) => {
+          if (error) rejectRead(error);
+          else resolveRead(count);
+        },
+      );
+    });
+    if (bytesRead === 0) throw new Error('peer_credentials_invalid');
+    offset += bytesRead;
+  }
+  return decodePeerCredentials(bytes);
+}
+
+async function readRequest(): Promise<Buffer> {
+  return await new Promise<Buffer>((resolveRequest, rejectRequest) => {
+    const chunks: Buffer[] = [];
+    let total = 0;
+    let settled = false;
+    const onData = (chunk: Buffer): void => {
+      total += chunk.byteLength;
+      if (total > MAX_FRAME_BYTES + 4 || chunks.length >= 1_024) {
+        finish(new Error('request_too_large'));
+        return;
+      }
+      chunks.push(Buffer.from(chunk));
+    };
+    const onError = (error: Error): void => finish(error);
+    const onEnd = (): void => finish(null);
+    const finish = (error: Error | null): void => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      process.stdin.removeListener('data', onData);
+      process.stdin.removeListener('error', onError);
+      process.stdin.removeListener('end', onEnd);
+      if (error) {
+        chunks.length = 0;
+        process.stdin.destroy();
+        rejectRequest(error);
+      } else {
+        const request = Buffer.concat(chunks, total);
+        chunks.length = 0;
+        resolveRequest(request);
+      }
+    };
+    const timer = setTimeout(
+      () => finish(new Error('request_timeout')),
+      10_000,
+    );
+    timer.unref();
+    process.stdin.on('data', onData);
+    process.stdin.once('error', onError);
+    process.stdin.once('end', onEnd);
+    process.stdin.resume();
+  });
+}
+
+async function writeResponse(response: Buffer): Promise<void> {
+  await new Promise<void>((resolveWrite, rejectWrite) => {
+    const timer = setTimeout(() => {
+      process.stdout.destroy();
+      rejectWrite(new Error('response_timeout'));
+    }, 10_000);
+    timer.unref();
+    process.stdout.write(response, (error?: Error | null) => {
+      clearTimeout(timer);
+      if (error) rejectWrite(error);
+      else resolveWrite();
+    });
+  });
+}
+
+async function resolveCwd(cwd: HomeRelativeCwd): Promise<HomeRelativeCwd> {
+  const parsed = HomeRelativeCwdSchema.parse(cwd);
+  const home = await realpath(HOME);
+  const target = await realpath(resolve(home, parsed.path));
+  if (target !== home && !target.startsWith(`${home}${sep}`)) {
+    throw new Error('cwd_unavailable');
+  }
+  const ownerRelative = relative(home, target);
+  return HomeRelativeCwdSchema.parse({
+    kind: 'home-relative',
+    path: ownerRelative === '' ? '' : ownerRelative,
+  });
+}
+
+async function belongsToRuntimeCgroup(
+  pid: number,
+  runtimeId: string,
+): Promise<boolean> {
+  if (!Number.isSafeInteger(pid) || pid < 1) return false;
+  const membership = await readFile(`/proc/${pid}/cgroup`, 'utf8');
+  const expected = `/matrix-terminal-session@${runtimeId}.service`;
+  return membership.split(/\r?\n/).some((line) => {
+    if (!line.startsWith('0::')) return false;
+    const cgroup = line.slice(3);
+    return cgroup.endsWith(expected) && !cgroup.includes('..');
+  });
+}
+
+async function inspectProcesses(path: string): Promise<{
+  keeper: boolean;
+  zellijClient: boolean;
+  zellijServer: boolean;
+  shell: boolean;
+}> {
+  const pids = (await readFile(`${path}/cgroup.procs`, 'utf8'))
+    .split(/\s+/)
+    .filter(Boolean)
+    .map((value) => Number.parseInt(value, 10));
+  const processes = await Promise.all(pids.map(async (pid) => {
+    try {
+      const [comm, cmdline] = await Promise.all([
+        readFile(`/proc/${pid}/comm`, 'utf8'),
+        readFile(`/proc/${pid}/cmdline`),
+      ]);
+      return {
+        comm: comm.trim(),
+        args: cmdline.toString('utf8').split('\0').filter(Boolean),
+      };
+    } catch (error: unknown) {
+      if (error instanceof Error && 'code' in error && error.code === 'ENOENT') {
+        return null;
+      }
+      throw error;
+    }
+  }));
+  return classifyRuntimeProcesses(
+    processes.filter((value) => value !== null),
+  );
+}
+
+async function sessionResponds(runtimeId: string): Promise<boolean> {
+  const environment = {
+    HOME,
+    MATRIX_HOME: HOME,
+    PATH: '/opt/matrix/bin:/opt/matrix/runtime/node/bin:/usr/bin:/bin',
+    LANG: 'C.UTF-8',
+    XDG_CACHE_HOME: `${DURABLE_ROOT}/zellij-cache`,
+    XDG_CONFIG_HOME: `${DURABLE_ROOT}/zellij-config-home`,
+    XDG_DATA_HOME: `${DURABLE_ROOT}/zellij-data`,
+    ZELLIJ_CONFIG_DIR: '/opt/matrix/libexec/terminal-runtime/current',
+    ZELLIJ_CONFIG_FILE:
+      '/opt/matrix/libexec/terminal-runtime/current/config.kdl',
+  };
+  try {
+    const { stdout } = await execFile(
+      '/usr/sbin/runuser',
+      [
+        '--user',
+        'matrix',
+        '--',
+        '/opt/matrix/bin/zellij',
+        'list-sessions',
+        '--no-formatting',
+      ],
+      { env: environment, timeout: 2_000, maxBuffer: 64 * 1024 },
+    );
+    const expected = `matrix-t-${RuntimeIdSchema.parse(runtimeId)}`;
+    return stdout.split(/\r?\n/).some((line) =>
+      line.trim().split(/\s+/, 1)[0] === expected);
+  } catch (error: unknown) {
+    if (error instanceof Error) return false;
+    throw error;
+  }
+}
+
+async function readOwner() {
+  const owner = await stat(HOME);
+  if (owner.uid === 0) throw new Error('owner_invalid');
+  return { uid: owner.uid, gid: owner.gid };
+}
+
+async function createHostState(owner: { uid: number; gid: number }) {
+  const executor = createSystemdExecutor({
+    inspectProcesses: async (path) => await inspectProcesses(path),
+    sessionResponds,
+  });
+  const state = await createRuntimeState({
+    durableRoot: DURABLE_ROOT,
+    runtimeRoot: RUNTIME_ROOT,
+    durableOwner: { uid: owner.uid, gid: owner.gid },
+    runtimeOwner: { uid: 0, gid: 0 },
+    authorizeDescriptorClaim: async ({ runtimeId, pid }) =>
+      await belongsToRuntimeCgroup(pid, runtimeId),
+  });
+  return { state, executor, owner };
+}
+
+async function servePeer(): Promise<void> {
+  const peer = await readPeer();
+  const owner = await readOwner();
+  if (peer.uid !== owner.uid) throw new Error('peer_unauthorized');
+  const request = await readRequest();
+  const host = await createHostState(owner);
+  try {
+    const handler = createOperationHandler({
+      state: host.state,
+      executor: host.executor,
+      resolveCwd,
+    });
+    await writeResponse(await handleSupervisorFrame({
+      peer,
+      matrixUid: host.owner.uid,
+      request,
+      handler,
+    }));
+  } finally {
+    await host.state.close();
+  }
+}
+
+async function serveKeeper(): Promise<void> {
+  const peer = await readPeer();
+  const owner = await readOwner();
+  if (peer.uid !== owner.uid) throw new Error('claim_unauthorized');
+  const request = await readRequest();
+  const host = await createHostState(owner);
+  try {
+    const parsed = KeeperRequestSchema.parse(decodeFrame(request));
+    const descriptor = await host.state.descriptors.claimRuntime({
+      runtimeId: parsed.runtimeId,
+      pid: peer.pid,
+    });
+    await writeResponse(encodeFrame({ ok: true, descriptor }));
+  } catch (error: unknown) {
+    if (!(error instanceof Error)) throw error;
+    await writeResponse(encodeFrame({ ok: false, error: 'claim_failed' }));
+  } finally {
+    await host.state.close();
+  }
+}
+
+async function maintenance(): Promise<void> {
+  let stopping = false;
+  let resolveStopped: () => void = () => undefined;
+  const stopped = new Promise<void>((resolveStop) => {
+    resolveStopped = resolveStop;
+  });
+  const stop = (): void => {
+    stopping = true;
+    resolveStopped();
+  };
+  process.once('SIGTERM', stop);
+  process.once('SIGINT', stop);
+  while (!stopping) {
+    const host = await createHostState(await readOwner());
+    const operationId = createOperationId();
+    try {
+      const handler = createOperationHandler({
+        state: host.state,
+        executor: host.executor,
+        resolveCwd,
+      });
+      await handler({
+        version: 1,
+        operation: 'Reconcile',
+        operationId,
+        input: {},
+      });
+      await host.state.descriptors.sweep({
+        isActive: async ({ runtimeId }) => {
+          const unit = await host.executor.inspect(runtimeId);
+          return unit?.unit === 'active' || unit?.unit === 'activating';
+        },
+        isLocked: async ({ runtimeId }) =>
+          await host.state.locks.isRuntimeLocked(runtimeId),
+      });
+    } finally {
+      try {
+        await host.state.operations.removeCompleted(operationId);
+      } finally {
+        await host.state.close();
+      }
+    }
+    let timer: NodeJS.Timeout | undefined;
+    await Promise.race([
+      stopped,
+      new Promise<void>((resolveDelay) => {
+        timer = setTimeout(resolveDelay, 60_000);
+        timer.unref();
+      }),
+    ]);
+    if (timer) clearTimeout(timer);
+  }
+}
+
+export async function runRuntimeOp(mode: string | undefined): Promise<void> {
+  if (mode === 'serve-peer') return await servePeer();
+  if (mode === 'serve-keeper') return await serveKeeper();
+  if (mode === 'maintenance') return await maintenance();
+  throw new Error('runtime_op_invalid');
+}
+
+if (process.argv[1]?.endsWith('/runtime-op.js')) {
+  try {
+    await runRuntimeOp(process.argv[2]);
+  } catch (error: unknown) {
+    const suffix = error instanceof Error ? '' : '_non_error';
+    process.stderr.write(`terminal_runtime_op_failed${suffix}\n`);
+    process.exitCode = 1;
+  }
+}

--- a/packages/terminal-runtime/src/runtime-state.ts
+++ b/packages/terminal-runtime/src/runtime-state.ts
@@ -32,6 +32,8 @@ async function closeResources(
 export async function createRuntimeState(options: {
   durableRoot: string;
   runtimeRoot: string;
+  durableOwner?: { uid: number; gid: number };
+  runtimeOwner?: { uid: number; gid: number };
   authorizeDescriptorClaim?: (input: {
     runtimeId: string;
     operationId: string;
@@ -46,18 +48,23 @@ export async function createRuntimeState(options: {
   let descriptorDirectory: SecureDirectory;
   let locks: FlockManager;
   try {
-    durableDirectory = await SecureDirectory.open(options.durableRoot);
+    durableDirectory = await SecureDirectory.open(options.durableRoot, {
+      owner: options.durableOwner,
+    });
     resources.push(durableDirectory);
     receiptsDirectory = await SecureDirectory.open(
       join(options.durableRoot, 'receipts'),
+      { owner: options.durableOwner },
     );
     resources.push(receiptsDirectory);
     operationsDirectory = await SecureDirectory.open(
       join(options.durableRoot, 'operations'),
+      { owner: options.durableOwner },
     );
     resources.push(operationsDirectory);
     descriptorDirectory = await SecureDirectory.open(
       join(options.runtimeRoot, 'descriptors'),
+      { owner: options.runtimeOwner },
     );
     resources.push(descriptorDirectory);
     locks = await FlockManager.open(join(options.runtimeRoot, 'locks'));

--- a/packages/terminal-runtime/src/storage.ts
+++ b/packages/terminal-runtime/src/storage.ts
@@ -7,6 +7,7 @@ import {
 import {
   type FileHandle,
   chmod,
+  chown,
   link,
   lstat,
   mkdir,
@@ -67,10 +68,14 @@ export class SecureDirectory {
     readonly path: string,
     private readonly handle: FileHandle,
     private readonly maxEntries: number,
+    private readonly owner?: { uid: number; gid: number },
   ) {}
   static async open(
     path: string,
-    options: { maxEntries?: number } = {},
+    options: {
+      maxEntries?: number;
+      owner?: { uid: number; gid: number };
+    } = {},
   ): Promise<SecureDirectory> {
     await ensureDirectoryPath(path);
     const absolute = resolve(path);
@@ -80,6 +85,12 @@ export class SecureDirectory {
     }
     if ((parentStat.mode & 0o777) !== 0o700) {
       await chmod(absolute, 0o700);
+    }
+    if (
+      options.owner &&
+      (parentStat.uid !== options.owner.uid || parentStat.gid !== options.owner.gid)
+    ) {
+      await chown(absolute, options.owner.uid, options.owner.gid);
     }
     const handle = await open(
       absolute,
@@ -94,7 +105,12 @@ export class SecureDirectory {
       await handle.close();
       throw stateError('unsafe_parent');
     }
-    return new SecureDirectory(absolute, handle, options.maxEntries ?? DEFAULT_MAX_ENTRIES);
+    return new SecureDirectory(
+      absolute,
+      handle,
+      options.maxEntries ?? DEFAULT_MAX_ENTRIES,
+      options.owner,
+    );
   }
   private procPath(name?: string): string {
     if (this.closed) throw stateError('state_closed');
@@ -113,6 +129,12 @@ export class SecureDirectory {
       const stat = await handle.stat();
       if (!stat.isFile() || stat.nlink !== 1) throw stateError('unsafe_file');
       if ((stat.mode & 0o777) !== 0o600) await handle.chmod(0o600);
+      if (
+        this.owner &&
+        (stat.uid !== this.owner.uid || stat.gid !== this.owner.gid)
+      ) {
+        await handle.chown(this.owner.uid, this.owner.gid);
+      }
       return handle;
     } catch (error: unknown) {
       await handle.close();
@@ -206,6 +228,7 @@ export class SecureDirectory {
           constants.O_NOFOLLOW,
         0o600,
       );
+      if (this.owner) await temp.chown(this.owner.uid, this.owner.gid);
       await temp.writeFile(bytes);
       await temp.sync();
       await temp.close();
@@ -245,6 +268,7 @@ export class SecureDirectory {
           constants.O_NOFOLLOW,
         0o600,
       );
+      if (this.owner) await temp.chown(this.owner.uid, this.owner.gid);
       await temp.writeFile(bytes);
       await temp.sync();
       await temp.close();

--- a/packages/terminal-runtime/src/supervisor.ts
+++ b/packages/terminal-runtime/src/supervisor.ts
@@ -1,0 +1,62 @@
+import {
+  ProtocolResponseSchema,
+  type ProtocolResponse,
+} from './contracts.js';
+import {
+  decodeFrame,
+  encodeFrame,
+  MAX_FRAME_BYTES,
+} from './framing.js';
+
+export type PeerCredentials = {
+  pid: number;
+  uid: number;
+  gid: number;
+};
+
+export function decodePeerCredentials(bytes: Buffer): PeerCredentials {
+  if (bytes.byteLength !== 12) throw new Error('peer_credentials_invalid');
+  const peer = {
+    pid: bytes.readUInt32LE(0),
+    uid: bytes.readUInt32LE(4),
+    gid: bytes.readUInt32LE(8),
+  };
+  if (peer.pid < 1 || peer.uid > 0x7fff_ffff || peer.gid > 0x7fff_ffff) {
+    throw new Error('peer_credentials_invalid');
+  }
+  return peer;
+}
+
+function invalidResponse(): ProtocolResponse {
+  return {
+    version: 1,
+    ok: false,
+    error: { code: 'invalid_request', message: 'Request failed' },
+  };
+}
+
+export async function handleSupervisorFrame(options: {
+  peer: PeerCredentials;
+  matrixUid: number;
+  request: Buffer;
+  handler(request: unknown): Promise<ProtocolResponse>;
+}): Promise<Buffer> {
+  if (
+    !Number.isSafeInteger(options.matrixUid) ||
+    options.matrixUid < 1 ||
+    options.peer.uid !== options.matrixUid
+  ) {
+    return encodeFrame(invalidResponse());
+  }
+  if (options.request.byteLength > MAX_FRAME_BYTES + 4) {
+    return encodeFrame(invalidResponse());
+  }
+  try {
+    const request = decodeFrame(options.request);
+    const response = ProtocolResponseSchema.parse(await options.handler(request));
+    return encodeFrame(response);
+  } catch (error: unknown) {
+    if (!(error instanceof Error)) throw error;
+    return encodeFrame(invalidResponse());
+  }
+}

--- a/packages/terminal-runtime/src/systemd.ts
+++ b/packages/terminal-runtime/src/systemd.ts
@@ -1,0 +1,188 @@
+import { execFile as execFileCallback } from 'node:child_process';
+import { readFile as readFileDefault } from 'node:fs/promises';
+import { promisify } from 'node:util';
+import {
+  RuntimeIdSchema,
+  unitNameForRuntimeId,
+} from './contracts.js';
+import type {
+  SystemdExecutor,
+  UnitInspection,
+} from './operation-handler.js';
+
+const execFileDefault = promisify(execFileCallback);
+const TEMPLATE_PREFIX = 'matrix-terminal-session@';
+const TEMPLATE_SUFFIX = '.service';
+
+type RunFile = (
+  file: string,
+  args: string[],
+  options: { timeout: number; maxBuffer: number },
+) => Promise<{ stdout: string; stderr?: string }>;
+
+type ProcessRoles = {
+  keeper: boolean;
+  zellijClient: boolean;
+  zellijServer: boolean;
+  shell: boolean;
+};
+
+export function classifyRuntimeProcesses(
+  processes: Array<{ comm: string; args: string[] }>,
+): ProcessRoles {
+  const zellij = processes.filter((process) =>
+    process.comm === 'zellij' && !process.args.includes('list-sessions'));
+  return {
+    keeper: processes.some((process) =>
+      process.args.some((argument) => argument.endsWith('/keeper.js'))),
+    zellijClient: zellij.length >= 2,
+    zellijServer: zellij.length >= 2,
+    shell: processes.some((process) => process.comm === 'bash'),
+  };
+}
+
+function parseShow(stdout: string): Record<string, string> {
+  const result: Record<string, string> = {};
+  for (const line of stdout.split(/\r?\n/)) {
+    if (line === '') continue;
+    const separator = line.indexOf('=');
+    if (separator < 1) throw new Error('systemd_show_invalid');
+    const key = line.slice(0, separator);
+    if (!['ActiveState', 'SubState', 'ControlGroup'].includes(key)) {
+      throw new Error('systemd_show_invalid');
+    }
+    result[key] = line.slice(separator + 1);
+  }
+  return result;
+}
+
+function unitState(show: Record<string, string>): UnitInspection['unit'] {
+  if (show.ActiveState === 'active') return 'active';
+  if (show.ActiveState === 'activating') return 'activating';
+  if (show.ActiveState === 'failed') return 'failed';
+  if (show.ActiveState === 'inactive') return 'inactive';
+  return 'missing';
+}
+
+function cgroupPopulated(raw: string): boolean {
+  const match = raw.match(/(?:^|\n)populated ([01])(?:\n|$)/);
+  if (!match) throw new Error('cgroup_events_invalid');
+  return match[1] === '1';
+}
+
+function cgroupPath(controlGroup: string, runtimeId: string): string {
+  const expected = unitNameForRuntimeId(runtimeId);
+  if (
+    !controlGroup.startsWith('/') ||
+    controlGroup.includes('..') ||
+    !controlGroup.endsWith(`/${expected}`)
+  ) {
+    throw new Error('systemd_cgroup_invalid');
+  }
+  return `/sys/fs/cgroup${controlGroup}`;
+}
+
+export function createSystemdExecutor(options: {
+  runFile?: RunFile;
+  readFile?: (path: string, encoding: 'utf8') => Promise<string>;
+  inspectProcesses?: (cgroupPath: string, runtimeId: string) => Promise<ProcessRoles>;
+  sessionResponds?: (runtimeId: string) => Promise<boolean>;
+} = {}): SystemdExecutor {
+  const runFile = options.runFile ?? (async (file, args, runOptions) =>
+    await execFileDefault(file, args, runOptions));
+  const readFile = options.readFile ?? readFileDefault;
+  const inspectProcesses = options.inspectProcesses ?? (async () => ({
+    keeper: false,
+    zellijClient: false,
+    zellijServer: false,
+    shell: false,
+  }));
+  const sessionResponds = options.sessionResponds ?? (async () => false);
+
+  const runSystemctl = async (args: string[]) => await runFile(
+    '/usr/bin/systemctl',
+    args,
+    { timeout: 30_000, maxBuffer: 256 * 1024 },
+  );
+
+  const executor: SystemdExecutor = {
+    async start(runtimeId) {
+      await runSystemctl(['start', unitNameForRuntimeId(runtimeId)]);
+    },
+    async stop(runtimeId) {
+      await runSystemctl(['stop', unitNameForRuntimeId(runtimeId)]);
+    },
+    async inspect(runtimeId) {
+      const id = RuntimeIdSchema.parse(runtimeId);
+      let result: { stdout: string };
+      try {
+        result = await runSystemctl([
+          'show',
+          unitNameForRuntimeId(id),
+          '--property=ActiveState,SubState,ControlGroup',
+          '--no-pager',
+        ]);
+      } catch (error: unknown) {
+        if (error instanceof Error && 'code' in error && error.code === 4) return null;
+        throw error;
+      }
+      const show = parseShow(result.stdout);
+      const unit = unitState(show);
+      if (!show.ControlGroup) {
+        return {
+          runtimeId: id,
+          unit,
+          cgroupPopulated: false,
+          keeperReady: false,
+          keeperAlive: false,
+          zellijResponsive: false,
+          requiredProcessesInCgroup: false,
+          resurrection: 'missing',
+        };
+      }
+      const path = cgroupPath(show.ControlGroup, id);
+      const [events, roles, responsive] = await Promise.all([
+        readFile(`${path}/cgroup.events`, 'utf8'),
+        inspectProcesses(path, id),
+        sessionResponds(id),
+      ]);
+      return {
+        runtimeId: id,
+        unit,
+        cgroupPopulated: cgroupPopulated(events),
+        keeperReady: unit === 'active' && show.SubState === 'running',
+        keeperAlive: roles.keeper,
+        zellijResponsive: responsive,
+        requiredProcessesInCgroup: roles.keeper && roles.zellijClient &&
+          roles.zellijServer && roles.shell,
+        resurrection: 'missing',
+      };
+    },
+    async list() {
+      const result = await runSystemctl([
+        'list-units',
+        `${TEMPLATE_PREFIX}*.service`,
+        '--all',
+        '--plain',
+        '--no-legend',
+        '--no-pager',
+      ]);
+      const ids: string[] = [];
+      for (const line of result.stdout.split(/\r?\n/)) {
+        const unit = line.trim().split(/\s+/, 1)[0];
+        if (!unit) continue;
+        if (!unit.startsWith(TEMPLATE_PREFIX) || !unit.endsWith(TEMPLATE_SUFFIX)) {
+          throw new Error('systemd_list_invalid');
+        }
+        ids.push(RuntimeIdSchema.parse(
+          unit.slice(TEMPLATE_PREFIX.length, -TEMPLATE_SUFFIX.length),
+        ));
+      }
+      const inspections = await Promise.all(
+        ids.map(async (id) => await executor.inspect(id)),
+      );
+      return inspections.filter((value): value is UnitInspection => value !== null);
+    },
+  };
+  return executor;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -872,6 +872,9 @@ importers:
 
   packages/terminal-runtime:
     dependencies:
+      node-pty:
+        specifier: ^1.1.0
+        version: 1.1.0
       zod:
         specifier: ^4.4.3
         version: 4.4.3
@@ -6878,6 +6881,7 @@ packages:
   '@xmldom/xmldom@0.8.11':
     resolution: {integrity: sha512-cQzWCtO6C8TQiYl1ruKNn2U6Ao4o4WBBcbL61yJl84x+j5sOWWFU9X7DpND8XZG3daDppSsigMdfAIl2upQBRw==}
     engines: {node: '>=10.0.0'}
+    deprecated: this version has critical issues, please update to the latest version
 
   '@xterm/addon-fit@0.11.0':
     resolution: {integrity: sha512-jYcgT6xtVYhnhgxh3QgYDnnNMYTcf8ElbxxFzX0IZo+vabQqSPAjC3c1wJrKB5E19VwQei89QCiZZP86DCPF7g==}

--- a/scripts/build-host-bundle.sh
+++ b/scripts/build-host-bundle.sh
@@ -18,7 +18,12 @@ GH_URL="https://github.com/cli/cli/releases/download/v${GH_VERSION}/${GH_ARCHIVE
 UV_INSTALLER_URL="${HOST_BUNDLE_UV_INSTALLER_URL:-https://astral.sh/uv/install.sh}"
 
 rm -rf "$DIST_DIR"
-mkdir -p "$STAGE_DIR/bin" "$STAGE_DIR/app" "$STAGE_DIR/runtime" "$STAGE_DIR/systemd"
+mkdir -p \
+  "$STAGE_DIR/bin" \
+  "$STAGE_DIR/app" \
+  "$STAGE_DIR/runtime" \
+  "$STAGE_DIR/systemd" \
+  "$STAGE_DIR/libexec/terminal-runtime/v1"
 
 pnpm install --frozen-lockfile
 pnpm rebuild node-pty
@@ -26,6 +31,7 @@ pnpm --filter '@matrix-os/observability' build
 pnpm --filter '@matrix-os/brand' build
 pnpm --filter '@matrix-os/kernel' build
 pnpm --filter '@matrix-os/gateway' build
+pnpm --filter '@matrix-os/terminal-runtime' build
 mkdir -p "$ROOT_DIR/packages/gateway/dist/app-runtime"
 cp -a "$ROOT_DIR/packages/gateway/src/app-runtime/"*.html "$ROOT_DIR/packages/gateway/dist/app-runtime/"
 : "${NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY:?set NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY before building the customer host bundle}"
@@ -91,11 +97,78 @@ INSTALLER_NO_MODIFY_PATH=1 UV_INSTALL_DIR="$STAGE_DIR/runtime/node/bin" sh "$DIS
 chmod -R g+rwX "$STAGE_DIR/runtime/node/lib/node_modules" "$STAGE_DIR/runtime/node/bin"
 find "$STAGE_DIR/runtime/node/lib/node_modules" "$STAGE_DIR/runtime/node/bin" -type d -exec chmod g+s {} +
 
+terminal_generation_build="$STAGE_DIR/libexec/terminal-runtime/v1/payload"
+install -d -m 0755 \
+  "$terminal_generation_build/node_modules/node-pty/build/Release" \
+  "$terminal_generation_build/node_modules/node-pty/lib" \
+  "$terminal_generation_build/node_modules/zod"
+install -m 0755 \
+  "$ROOT_DIR/packages/terminal-runtime/dist/"*.js \
+  "$terminal_generation_build/"
+install -m 0644 \
+  "$ROOT_DIR/packages/terminal-runtime/package.json" \
+  "$terminal_generation_build/package.json"
+install -m 0644 \
+  "$ROOT_DIR/packages/terminal-runtime/assets/config.kdl" \
+  "$terminal_generation_build/config.kdl"
+install -m 0644 \
+  "$ROOT_DIR/packages/terminal-runtime/assets/layout.kdl" \
+  "$terminal_generation_build/layout.kdl"
+cc -std=c11 -Wall -Wextra -Werror -O2 \
+  "$ROOT_DIR/packages/terminal-runtime/native/supervisor-acceptor.c" \
+  -o "$terminal_generation_build/supervisor-acceptor"
+install -m 0644 \
+  "$(readlink -f "$ROOT_DIR/node_modules/node-pty")/package.json" \
+  "$terminal_generation_build/node_modules/node-pty/package.json"
+cp -aL --no-preserve=links \
+  "$(readlink -f "$ROOT_DIR/node_modules/node-pty")/lib/." \
+  "$terminal_generation_build/node_modules/node-pty/lib/"
+install -m 0755 \
+  "$(readlink -f "$ROOT_DIR/node_modules/node-pty")/build/Release/pty.node" \
+  "$terminal_generation_build/node_modules/node-pty/build/Release/pty.node"
+install -m 0644 \
+  "$(readlink -f "$ROOT_DIR/node_modules/zod")/package.json" \
+  "$terminal_generation_build/node_modules/zod/package.json"
+cp -aL --no-preserve=links \
+  "$(readlink -f "$ROOT_DIR/node_modules/zod")/v4" \
+  "$terminal_generation_build/node_modules/zod/v4"
+if find "$terminal_generation_build" -type l -print -quit | grep -q .; then
+  echo "terminal_runtime_generation_contains_symlink" >&2
+  exit 1
+fi
+if find "$terminal_generation_build" -type f -links +1 -print -quit |
+  grep -q .; then
+  echo "terminal_runtime_generation_contains_hardlink" >&2
+  exit 1
+fi
+(
+  cd "$terminal_generation_build"
+  LC_ALL=C find . -type f ! -name runtime-manifest.sha256 -printf '%P\n' |
+    LC_ALL=C sort |
+    while IFS= read -r runtime_file; do
+      if [[ ! "$runtime_file" =~ ^[A-Za-z0-9._/-]+$ ]]; then
+        echo "terminal_runtime_manifest_path_invalid" >&2
+        exit 1
+      fi
+      sha256sum "$runtime_file"
+    done >runtime-manifest.sha256
+)
+terminal_generation_id="$(
+  sha256sum "$terminal_generation_build/runtime-manifest.sha256" |
+    awk '{print $1}'
+)"
+mv \
+  "$terminal_generation_build" \
+  "$STAGE_DIR/libexec/terminal-runtime/v1/$terminal_generation_id"
+ln -s \
+  "v1/$terminal_generation_id" \
+  "$STAGE_DIR/libexec/terminal-runtime/current"
+
 cp -a "$ROOT_DIR/distro/customer-vps/host-bin/." "$STAGE_DIR/bin/"
 cp -a "$ROOT_DIR/distro/customer-vps/systemd/." "$STAGE_DIR/systemd/"
 # The bundle is usually extracted as root:root during in-place upgrades, while
 # the systemd units execute these wrappers as the matrix user.
-chmod 0755 "$STAGE_DIR/bin/matrix-owner-env" "$STAGE_DIR/bin/matrix-gateway" "$STAGE_DIR/bin/matrix-agent-bridge" "$STAGE_DIR/bin/matrix-sync-bundled-home-assets" "$STAGE_DIR/bin/matrix-shell" "$STAGE_DIR/bin/matrix-code" "$STAGE_DIR/bin/matrix-sync-agent" "$STAGE_DIR/bin/matrix-symphony" "$STAGE_DIR/bin/matrix-symphony-control" "$STAGE_DIR/bin/matrix-update" "$STAGE_DIR/bin/matrix-ensure-swap" "$STAGE_DIR/bin/matrix-install-hermes" "$STAGE_DIR/bin/matrix-hermes-dashboard" "$STAGE_DIR/bin/matrix-install-linux-tools" "$STAGE_DIR/bin/matrix-install-tool-pack" "$STAGE_DIR/bin/matrix-install-developer-tools" "$STAGE_DIR/bin/matrix-messaging-health" "$STAGE_DIR/bin/matrix-messaging-backup" "$STAGE_DIR/bin/matrix-messaging-restore" "$STAGE_DIR/bin/zellij" "$STAGE_DIR/runtime/node/bin/gh"
+chmod 0755 "$STAGE_DIR/bin/matrix-owner-env" "$STAGE_DIR/bin/matrix-gateway" "$STAGE_DIR/bin/matrix-agent-bridge" "$STAGE_DIR/bin/matrix-sync-bundled-home-assets" "$STAGE_DIR/bin/matrix-shell" "$STAGE_DIR/bin/matrix-code" "$STAGE_DIR/bin/matrix-sync-agent" "$STAGE_DIR/bin/matrix-symphony" "$STAGE_DIR/bin/matrix-symphony-control" "$STAGE_DIR/bin/matrix-update" "$STAGE_DIR/bin/matrix-ensure-swap" "$STAGE_DIR/bin/matrix-install-hermes" "$STAGE_DIR/bin/matrix-hermes-dashboard" "$STAGE_DIR/bin/matrix-install-linux-tools" "$STAGE_DIR/bin/matrix-install-tool-pack" "$STAGE_DIR/bin/matrix-install-developer-tools" "$STAGE_DIR/bin/matrix-messaging-health" "$STAGE_DIR/bin/matrix-messaging-backup" "$STAGE_DIR/bin/matrix-messaging-restore" "$STAGE_DIR/bin/matrix-terminal-supervisor" "$STAGE_DIR/bin/matrix-terminal-keeper" "$STAGE_DIR/bin/matrix-terminal-pane" "$STAGE_DIR/bin/matrix-terminal-runtime-op" "$STAGE_DIR/bin/zellij" "$STAGE_DIR/runtime/node/bin/gh"
 
 cp -a "$ROOT_DIR/node_modules" "$STAGE_DIR/app/node_modules"
 install -m 0755 "$DIST_DIR/$GH_DIST/bin/gh" "$STAGE_DIR/app/node_modules/.bin/gh"
@@ -135,7 +208,7 @@ node "$ROOT_DIR/scripts/host-bundle-release.mjs" write-release
 HOST_BUNDLE_INCREMENTAL_EXCLUDE_PREFIXES="${HOST_BUNDLE_INCREMENTAL_EXCLUDE_PREFIXES:-node_modules/}" \
   node "$ROOT_DIR/scripts/host-bundle-incremental-manifest.mjs" "$STAGE_DIR/app" "$STAGE_DIR/incremental-manifest.json" "$DIST_DIR/objects"
 cp -a "$STAGE_DIR/incremental-manifest.json" "$DIST_DIR/incremental-manifest.json"
-tar -C "$STAGE_DIR" -czf "$DIST_DIR/$BUNDLE_NAME" bin app runtime systemd release.json incremental-manifest.json
+tar -C "$STAGE_DIR" -czf "$DIST_DIR/$BUNDLE_NAME" bin app runtime systemd libexec release.json incremental-manifest.json
 node "$ROOT_DIR/scripts/host-bundle-release.mjs" write-manifest
 
 printf '%s\n' "$DIST_DIR/$BUNDLE_NAME"

--- a/scripts/install-server.sh
+++ b/scripts/install-server.sh
@@ -476,6 +476,9 @@ install_bundle() {
   ok "Host bundle checksum verified"
   section "Extracting Matrix OS"
   tar -xzf "$tmp_bundle" -C /opt/matrix
+  if [ -d /opt/matrix/libexec ]; then
+    chown -R root:root /opt/matrix/libexec
+  fi
   chmod 0755 /opt/matrix/bin/matrix-* /opt/matrix/bin/zellij 2>/dev/null || true
   cleanup_install_tmp
   INSTALL_TMP_BUNDLE=""
@@ -524,12 +527,15 @@ install_systemd_units() {
   install -m 0644 /opt/matrix/systemd/matrix-shell.service /etc/systemd/system/matrix-shell.service
   install -m 0644 /opt/matrix/systemd/matrix-code.service /etc/systemd/system/matrix-code.service
   install -m 0644 /opt/matrix/systemd/matrix-code-server.service /etc/systemd/system/matrix-code-server.service
+  install -m 0644 /opt/matrix/systemd/matrix-terminal-runtime.service /etc/systemd/system/matrix-terminal-runtime.service
+  install -m 0644 '/opt/matrix/systemd/matrix-terminal-session@.service' '/etc/systemd/system/matrix-terminal-session@.service'
+  install -m 0644 /opt/matrix/systemd/matrix-terminal.slice /etc/systemd/system/matrix-terminal.slice
   if [ -f /opt/matrix/systemd/matrix-developer-tools.service ]; then
     install -m 0644 /opt/matrix/systemd/matrix-developer-tools.service /etc/systemd/system/matrix-developer-tools.service
   fi
   write_self_host_restore_service
   run_required "reloading systemd" systemctl daemon-reload
-  run_required "enabling Matrix OS services" systemctl enable docker matrix-restore matrix-gateway matrix-shell matrix-code matrix-code-server
+  run_required "enabling Matrix OS services" systemctl enable docker matrix-restore matrix-gateway matrix-shell matrix-code matrix-code-server matrix-terminal-runtime
   if [ -f /etc/systemd/system/matrix-developer-tools.service ] && [ -n "$MATRIX_DEVELOPER_TOOLS" ]; then
     run_required "enabling optional developer tools service" systemctl enable matrix-developer-tools
   fi
@@ -664,6 +670,7 @@ EOF
 start_services() {
   section "Starting Matrix OS services"
   run_required "starting docker" systemctl enable --now docker
+  run_required "starting terminal runtime supervisor" systemctl start matrix-terminal-runtime
   restart_required_service matrix-restore
   restart_required_service matrix-gateway
   restart_required_service matrix-shell

--- a/tests/deploy/cloud-workspace-runtime.test.ts
+++ b/tests/deploy/cloud-workspace-runtime.test.ts
@@ -36,6 +36,7 @@ describe("cloud workspace runtime gates", () => {
       expect(source).toContain("matrixos ALL=(ALL) NOPASSWD:ALL");
       expect(source).toContain("chmod 0440 /etc/sudoers.d/matrixos");
     }
+    expect(devDockerfile).toMatch(/hermes-agent\/841a5a744ad115b001a2720bf1eeb6bec3dfcc7d\/scripts\/install\.sh[\s\S]*--commit 841a5a744ad115b001a2720bf1eeb6bec3dfcc7d/);
   });
 
   it("creates workspace-owned recovery directories on startup", () => {

--- a/tests/deploy/customer-vps/terminal-runtime-services.test.ts
+++ b/tests/deploy/customer-vps/terminal-runtime-services.test.ts
@@ -136,7 +136,11 @@ describe('customer VPS terminal runtime services', () => {
     expect(updater).toContain('ln -s');
     expect(updater).toContain('mv -T');
     expect(updater).toContain('systemctl daemon-reload');
-    expect(updater).toContain('enable --now matrix-terminal-runtime.service');
+    expect(updater).toContain('systemctl enable matrix-terminal-runtime.service');
+    expect(updater).toContain('systemctl start matrix-terminal-runtime.service');
+    expect(updater).not.toContain(
+      'systemctl enable --now matrix-terminal-runtime.service',
+    );
     expect(updater).not.toContain('restart matrix-terminal-runtime.service');
     expect(updater).not.toContain('stop matrix-terminal-runtime.service');
     expect(updater).not.toContain('matrix-terminal-session@*');
@@ -270,5 +274,6 @@ describe('customer VPS terminal runtime services', () => {
     expect(updater).not.toContain(
       'systemctl stop matrix-terminal-session@',
     );
+    expect(updater).toContain('terminal_runtime_supervisor_start_failed');
   });
 });

--- a/tests/deploy/customer-vps/terminal-runtime-services.test.ts
+++ b/tests/deploy/customer-vps/terminal-runtime-services.test.ts
@@ -112,7 +112,10 @@ describe('customer VPS terminal runtime services', () => {
       expect(source).toContain('getsockopt');
       expect(source).toContain('/run/matrix-terminal-runtime/supervisor.sock');
       expect(source).toContain('/run/matrix-terminal-runtime/keeper.sock');
-      expect(source).toContain('/opt/matrix/bin/matrix-terminal-runtime-op');
+      expect(source).toContain('/proc/self/exe');
+      expect(source).toContain('/opt/matrix/runtime/node/bin/node');
+      expect(source).toContain('runtime-op.js');
+      expect(source).not.toContain('/opt/matrix/bin/matrix-terminal-runtime-op');
       expect(source).toContain('NOTIFY_SOCKET');
       expect(source).toContain('READY=1');
       expect(source).toContain('#define MAX_WORKERS 128');

--- a/tests/deploy/customer-vps/terminal-runtime-services.test.ts
+++ b/tests/deploy/customer-vps/terminal-runtime-services.test.ts
@@ -245,4 +245,30 @@ describe('customer VPS terminal runtime services', () => {
       rmSync(bundle, { recursive: true, force: true });
     }
   });
+
+  it('restores stable host artifacts only for failed update rollback', () => {
+    const updater = read('distro/customer-vps/host-bin/matrix-sync-agent');
+
+    expect(updater).toContain('backup_terminal_runtime_for_failed_update()');
+    expect(updater).toContain('restore_terminal_runtime_after_failed_update()');
+    expect(updater).toContain('backup_terminal_runtime_for_failed_update');
+    expect(updater).toContain('do_rollback failed-update');
+    expect(updater).toContain('do_rollback explicit');
+    expect(updater).toContain('local rollback_kind="${1:-explicit}"');
+    expect(updater).toContain(
+      'if [ "$rollback_kind" = "failed-update" ]; then',
+    );
+    expect(updater).toContain(
+      'restore_terminal_runtime_after_failed_update',
+    );
+    expect(updater).toContain(
+      'sudo rm -rf -- "$APP_DIR/.terminal-runtime.failed-update"',
+    );
+    expect(updater).not.toContain(
+      'systemctl stop matrix-terminal-runtime.service',
+    );
+    expect(updater).not.toContain(
+      'systemctl stop matrix-terminal-session@',
+    );
+  });
 });

--- a/tests/deploy/customer-vps/terminal-runtime-services.test.ts
+++ b/tests/deploy/customer-vps/terminal-runtime-services.test.ts
@@ -142,7 +142,6 @@ describe('customer VPS terminal runtime services', () => {
       'systemctl enable --now matrix-terminal-runtime.service',
     );
     expect(updater).not.toContain('restart matrix-terminal-runtime.service');
-    expect(updater).not.toContain('stop matrix-terminal-runtime.service');
     expect(updater).not.toContain('matrix-terminal-session@*');
     expect(cloudInit).toContain('chown -R root:root /opt/matrix/libexec');
     expect(cloudInit).toContain('/opt/matrix/systemd/*.slice');
@@ -158,6 +157,51 @@ describe('customer VPS terminal runtime services', () => {
     expect(installer).not.toContain(
       'systemctl enable matrix-terminal-session@',
     );
+  });
+
+  it('terminates only a newly introduced supervisor before failed-start rollback', () => {
+    const updater = read('distro/customer-vps/host-bin/matrix-sync-agent');
+    const cleanup = extractShellFunction(
+      updater,
+      'terminate_new_terminal_runtime_supervisor_after_failed_start',
+    );
+    const startFailure = updater.slice(
+      updater.indexOf(
+        'if ! sudo systemctl start matrix-terminal-runtime.service; then',
+      ),
+      updater.indexOf('log "Terminal runtime supervisor enabled"'),
+    );
+
+    expect(updater).toContain(
+      'systemctl is-active --quiet matrix-terminal-runtime.service',
+    );
+    expect(updater).toContain('supervisor-was-active');
+    expect(cleanup).toContain(
+      '[ ! -f "$snapshot/supervisor-was-active" ] || return 1',
+    );
+    expect(cleanup).toContain(
+      'sudo systemctl stop matrix-terminal-runtime.service',
+    );
+    expect(cleanup).toContain(
+      'sudo systemctl reset-failed matrix-terminal-runtime.service',
+    );
+    expect(cleanup).toContain(
+      'if sudo systemctl is-active --quiet matrix-terminal-runtime.service; then',
+    );
+    expect(startFailure.indexOf(
+      'terminate_new_terminal_runtime_supervisor_after_failed_start',
+    )).toBeGreaterThan(startFailure.indexOf(
+      'terminal_runtime_supervisor_start_failed',
+    ));
+    expect(startFailure.indexOf('do_rollback failed-update')).toBeGreaterThan(
+      startFailure.indexOf(
+        'terminate_new_terminal_runtime_supervisor_after_failed_start',
+      ),
+    );
+    expect(
+      updater.match(/systemctl stop matrix-terminal-runtime\.service/g),
+    ).toHaveLength(1);
+    expect(updater).not.toContain('systemctl stop matrix-terminal-session@');
   });
 
   it('rejects a hard-linked immutable generation before privileged install', () => {
@@ -267,9 +311,6 @@ describe('customer VPS terminal runtime services', () => {
     );
     expect(updater).toContain(
       'sudo rm -rf -- "$APP_DIR/.terminal-runtime.failed-update"',
-    );
-    expect(updater).not.toContain(
-      'systemctl stop matrix-terminal-runtime.service',
     );
     expect(updater).not.toContain(
       'systemctl stop matrix-terminal-session@',

--- a/tests/deploy/customer-vps/terminal-runtime-services.test.ts
+++ b/tests/deploy/customer-vps/terminal-runtime-services.test.ts
@@ -198,6 +198,16 @@ describe('customer VPS terminal runtime services', () => {
         'terminate_new_terminal_runtime_supervisor_after_failed_start',
       ),
     );
+    const cleanupFailure = startFailure.slice(
+      startFailure.indexOf(
+        'if ! terminate_new_terminal_runtime_supervisor_after_failed_start; then',
+      ),
+      startFailure.indexOf('do_rollback failed-update'),
+    );
+    expect(cleanupFailure).toContain('do_rollback explicit');
+    expect(cleanupFailure).toContain(
+      'terminal_runtime_supervisor_cleanup_preserved_host_layer',
+    );
     expect(
       updater.match(/systemctl stop matrix-terminal-runtime\.service/g),
     ).toHaveLength(1);

--- a/tests/deploy/customer-vps/terminal-runtime-services.test.ts
+++ b/tests/deploy/customer-vps/terminal-runtime-services.test.ts
@@ -1,0 +1,120 @@
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const root = process.cwd();
+const read = (path: string) => readFileSync(join(root, path), 'utf8');
+
+describe('customer VPS terminal runtime services', () => {
+  it('defines the dormant stable supervisor, aggregate slice, and fixed template', () => {
+    const supervisor = read('distro/customer-vps/systemd/matrix-terminal-runtime.service');
+    const slice = read('distro/customer-vps/systemd/matrix-terminal.slice');
+    const session = read('distro/customer-vps/systemd/matrix-terminal-session@.service');
+
+    expect(supervisor).toContain('ExecStart=/opt/matrix/bin/matrix-terminal-supervisor');
+    expect(supervisor).toContain('RuntimeDirectory=matrix-terminal-runtime');
+    expect(supervisor).toContain('RuntimeDirectoryMode=0750');
+    expect(supervisor).toContain('WantedBy=multi-user.target');
+    expect(supervisor).not.toContain('matrix-terminal-session@');
+
+    expect(slice).toContain('MemoryAccounting=yes');
+    expect(slice).toContain('TasksAccounting=yes');
+    expect(slice).toContain('CPUAccounting=yes');
+    expect(slice).toContain('IOAccounting=yes');
+    expect(slice).toContain('MemoryHigh=75%');
+    expect(slice).toContain('TasksMax=2048');
+    expect(slice).toContain('CPUWeight=80');
+    expect(slice).toContain('IOWeight=80');
+
+    expect(session).toContain('Type=notify');
+    expect(session).toContain('User=matrix');
+    expect(session).toContain('Group=matrix');
+    expect(session).toContain('Slice=matrix-terminal.slice');
+    expect(session).toContain('ExecStart=/opt/matrix/bin/matrix-terminal-keeper %i');
+    expect(session).toContain('KillMode=control-group');
+    expect(session).toContain('TimeoutStartSec=30');
+    expect(session).toContain('TimeoutStopSec=30');
+    expect(session).toContain('Restart=no');
+    expect(session).toContain('MemoryHigh=50%');
+    expect(session).toContain('TasksMax=512');
+    expect(session).toContain('StandardOutput=null');
+    for (const forbidden of [
+      'EnvironmentFile',
+      '[Install]',
+      'WantedBy',
+      'RequiredBy',
+      'Requires=',
+      'PartOf=',
+    ]) {
+      expect(session).not.toContain(forbidden);
+    }
+  });
+
+  it('ships fixed stable wrappers that cannot select another executable or generation', () => {
+    const wrappers = [
+      ['matrix-terminal-supervisor', 'supervisor-acceptor'],
+      ['matrix-terminal-keeper', 'keeper.js'],
+      ['matrix-terminal-pane', 'pane.js'],
+      ['matrix-terminal-runtime-op', 'runtime-op.js'],
+    ] as const;
+    for (const [name, target] of wrappers) {
+      const script = read(`distro/customer-vps/host-bin/${name}`);
+      expect(script).toContain('/opt/matrix/libexec/terminal-runtime/current/');
+      expect(script).toContain(target);
+      expect(script).not.toContain('eval ');
+      expect(script).not.toContain('/opt/matrix/app');
+    }
+  });
+
+  it('compiles a warning-free SO_PEERCRED acceptor with fixed socket and worker paths', () => {
+    const sourcePath = join(
+      root,
+      'packages/terminal-runtime/native/supervisor-acceptor.c',
+    );
+    const source = readFileSync(sourcePath, 'utf8');
+    const outputDir = mkdtempSync(join(tmpdir(), 'matrix-terminal-acceptor-'));
+    try {
+      const result = spawnSync('cc', [
+        '-std=c11',
+        '-Wall',
+        '-Wextra',
+        '-Werror',
+        '-O2',
+        sourcePath,
+        '-o',
+        join(outputDir, 'supervisor-acceptor'),
+      ], { encoding: 'utf8' });
+      expect(result.status, result.stderr).toBe(0);
+      expect(source).toContain('SO_PEERCRED');
+      expect(source).toContain('getsockopt');
+      expect(source).toContain('/run/matrix-terminal-runtime/supervisor.sock');
+      expect(source).toContain('/run/matrix-terminal-runtime/keeper.sock');
+      expect(source).toContain('/opt/matrix/bin/matrix-terminal-runtime-op');
+      expect(source).not.toContain('system(');
+      expect(source).not.toContain('/bin/sh');
+    } finally {
+      rmSync(outputDir, { recursive: true, force: true });
+    }
+  });
+
+  it('packages one immutable v1 generation and atomically switches current', () => {
+    const build = read('scripts/build-host-bundle.sh');
+    const updater = read('distro/customer-vps/host-bin/matrix-sync-agent');
+
+    expect(build).toContain("pnpm --filter '@matrix-os/terminal-runtime' build");
+    expect(build).toContain('packages/terminal-runtime/native/supervisor-acceptor.c');
+    expect(build).toContain('$STAGE_DIR/libexec/terminal-runtime/v1');
+    expect(build).toContain('libexec release.json');
+    expect(updater).toContain('/opt/matrix/libexec/terminal-runtime/v1');
+    expect(updater).toContain('/opt/matrix/libexec/terminal-runtime/current');
+    expect(updater).toContain('ln -s');
+    expect(updater).toContain('mv -T');
+    expect(updater).toContain('systemctl daemon-reload');
+    expect(updater).toContain('enable --now matrix-terminal-runtime.service');
+    expect(updater).not.toContain('restart matrix-terminal-runtime.service');
+    expect(updater).not.toContain('stop matrix-terminal-runtime.service');
+    expect(updater).not.toContain('matrix-terminal-session@*');
+  });
+});

--- a/tests/deploy/customer-vps/terminal-runtime-services.test.ts
+++ b/tests/deploy/customer-vps/terminal-runtime-services.test.ts
@@ -35,6 +35,8 @@ describe('customer VPS terminal runtime services', () => {
     expect(supervisor).toContain('ExecStart=/opt/matrix/bin/matrix-terminal-supervisor');
     expect(supervisor).toContain('RuntimeDirectory=matrix-terminal-runtime');
     expect(supervisor).toContain('RuntimeDirectoryMode=0750');
+    expect(supervisor).toContain('Type=notify');
+    expect(supervisor).toContain('NotifyAccess=main');
     expect(supervisor).toContain('WantedBy=multi-user.target');
     expect(supervisor).not.toContain('matrix-terminal-session@');
 
@@ -111,6 +113,8 @@ describe('customer VPS terminal runtime services', () => {
       expect(source).toContain('/run/matrix-terminal-runtime/supervisor.sock');
       expect(source).toContain('/run/matrix-terminal-runtime/keeper.sock');
       expect(source).toContain('/opt/matrix/bin/matrix-terminal-runtime-op');
+      expect(source).toContain('NOTIFY_SOCKET');
+      expect(source).toContain('READY=1');
       expect(source).toContain('#define MAX_WORKERS 128');
       expect(source).toContain('workers >= MAX_WORKERS');
       expect(source).not.toContain('system(');

--- a/tests/deploy/customer-vps/terminal-runtime-services.test.ts
+++ b/tests/deploy/customer-vps/terminal-runtime-services.test.ts
@@ -1,11 +1,30 @@
 import { spawnSync } from 'node:child_process';
-import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { createHash } from 'node:crypto';
+import {
+  linkSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
 
 const root = process.cwd();
 const read = (path: string) => readFileSync(join(root, path), 'utf8');
+function extractShellFunction(script: string, name: string): string {
+  const lines = script.split('\n');
+  const start = lines.findIndex((line) => line === `${name}() {`);
+  const end = lines.findIndex((line, index) => index > start && line === '}');
+  if (start < 0 || end < 0) throw new Error('shell_function_missing');
+  return lines.slice(start, end + 1).join('\n');
+}
+function sha256(value: string): string {
+  return createHash('sha256').update(value).digest('hex');
+}
 
 describe('customer VPS terminal runtime services', () => {
   it('defines the dormant stable supervisor, aggregate slice, and fixed template', () => {
@@ -92,6 +111,8 @@ describe('customer VPS terminal runtime services', () => {
       expect(source).toContain('/run/matrix-terminal-runtime/supervisor.sock');
       expect(source).toContain('/run/matrix-terminal-runtime/keeper.sock');
       expect(source).toContain('/opt/matrix/bin/matrix-terminal-runtime-op');
+      expect(source).toContain('#define MAX_WORKERS 128');
+      expect(source).toContain('workers >= MAX_WORKERS');
       expect(source).not.toContain('system(');
       expect(source).not.toContain('/bin/sh');
     } finally {
@@ -102,11 +123,14 @@ describe('customer VPS terminal runtime services', () => {
   it('packages one immutable v1 generation and atomically switches current', () => {
     const build = read('scripts/build-host-bundle.sh');
     const updater = read('distro/customer-vps/host-bin/matrix-sync-agent');
+    const cloudInit = read('distro/customer-vps/cloud-init.yaml');
+    const installer = read('scripts/install-server.sh');
 
     expect(build).toContain("pnpm --filter '@matrix-os/terminal-runtime' build");
     expect(build).toContain('packages/terminal-runtime/native/supervisor-acceptor.c');
     expect(build).toContain('$STAGE_DIR/libexec/terminal-runtime/v1');
     expect(build).toContain('libexec release.json');
+    expect(build).toContain('runtime-manifest.sha256');
     expect(updater).toContain('/opt/matrix/libexec/terminal-runtime/v1');
     expect(updater).toContain('/opt/matrix/libexec/terminal-runtime/current');
     expect(updater).toContain('ln -s');
@@ -116,5 +140,109 @@ describe('customer VPS terminal runtime services', () => {
     expect(updater).not.toContain('restart matrix-terminal-runtime.service');
     expect(updater).not.toContain('stop matrix-terminal-runtime.service');
     expect(updater).not.toContain('matrix-terminal-session@*');
+    expect(cloudInit).toContain('chown -R root:root /opt/matrix/libexec');
+    expect(cloudInit).toContain('/opt/matrix/systemd/*.slice');
+    expect(cloudInit).toContain(
+      'systemctl enable --now matrix-terminal-runtime.service',
+    );
+    expect(cloudInit).not.toContain(
+      'systemctl enable matrix-terminal-session@',
+    );
+    expect(installer).toContain('matrix-terminal-runtime.service');
+    expect(installer).toContain('matrix-terminal-session@.service');
+    expect(installer).toContain('matrix-terminal.slice');
+    expect(installer).not.toContain(
+      'systemctl enable matrix-terminal-session@',
+    );
+  });
+
+  it('rejects a hard-linked immutable generation before privileged install', () => {
+    const updater = read('distro/customer-vps/host-bin/matrix-sync-agent');
+    const generation = mkdtempSync(join(tmpdir(), 'matrix-generation-hardlink-'));
+    try {
+      writeFileSync(join(generation, 'keeper.js'), 'keeper');
+      linkSync(join(generation, 'keeper.js'), join(generation, 'alias.js'));
+      const fileHash = sha256('keeper');
+      const manifest = `${fileHash}  alias.js\n${fileHash}  keeper.js\n`;
+      writeFileSync(join(generation, 'runtime-manifest.sha256'), manifest);
+      const generationId = sha256(manifest);
+      const result = spawnSync('bash', ['-c', [
+        'set -euo pipefail',
+        extractShellFunction(updater, 'verify_terminal_runtime_generation'),
+        'verify_terminal_runtime_generation "$1" "$2"',
+      ].join('\n'), 'verify-generation', generation, generationId], {
+        encoding: 'utf8',
+      });
+      expect(result.status).not.toBe(0);
+    } finally {
+      rmSync(generation, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects incomplete runtime bundles before privileged install', () => {
+    const updater = read('distro/customer-vps/host-bin/matrix-sync-agent');
+    const bundle = mkdtempSync(join(tmpdir(), 'matrix-runtime-preflight-'));
+    const generationRoot = join(bundle, 'libexec', 'terminal-runtime');
+    const generation = join(generationRoot, 'v1', 'placeholder');
+    const bin = join(bundle, 'bin');
+    const systemd = join(bundle, 'systemd');
+    try {
+      mkdirSync(generation, { recursive: true });
+      mkdirSync(bin);
+      mkdirSync(systemd);
+      writeFileSync(join(generation, 'keeper.js'), 'keeper');
+      const manifest = `${sha256('keeper')}  keeper.js\n`;
+      writeFileSync(join(generation, 'runtime-manifest.sha256'), manifest);
+      const generationId = sha256(manifest);
+      const finalGeneration = join(generationRoot, 'v1', generationId);
+      mkdirSync(finalGeneration);
+      for (const name of ['keeper.js', 'runtime-manifest.sha256']) {
+        writeFileSync(
+          join(finalGeneration, name),
+          readFileSync(join(generation, name)),
+        );
+      }
+      rmSync(generation, { recursive: true });
+      symlinkSync(`v1/${generationId}`, join(generationRoot, 'current'));
+
+      const shell = [
+        'set -euo pipefail',
+        'terminal_runtime_candidate=""',
+        'terminal_runtime_generation_id=""',
+        extractShellFunction(updater, 'verify_terminal_runtime_generation'),
+        extractShellFunction(updater, 'prepare_terminal_runtime_candidate'),
+        'prepare_terminal_runtime_candidate "$1"',
+      ].join('\n');
+      const incomplete = spawnSync(
+        'bash',
+        ['-c', shell, 'runtime-preflight', bundle],
+        { encoding: 'utf8' },
+      );
+      expect(incomplete.status).not.toBe(0);
+
+      for (const name of [
+        'matrix-terminal-supervisor',
+        'matrix-terminal-keeper',
+        'matrix-terminal-pane',
+        'matrix-terminal-runtime-op',
+      ]) {
+        writeFileSync(join(bin, name), '#!/bin/sh\nexit 0\n', { mode: 0o755 });
+      }
+      for (const name of [
+        'matrix-terminal-runtime.service',
+        'matrix-terminal-session@.service',
+        'matrix-terminal.slice',
+      ]) {
+        writeFileSync(join(systemd, name), '[Unit]\n');
+      }
+      const complete = spawnSync(
+        'bash',
+        ['-c', shell, 'runtime-preflight', bundle],
+        { encoding: 'utf8' },
+      );
+      expect(complete.status, complete.stderr).toBe(0);
+    } finally {
+      rmSync(bundle, { recursive: true, force: true });
+    }
   });
 });

--- a/tests/platform/customer-vps-host-bundle.test.ts
+++ b/tests/platform/customer-vps-host-bundle.test.ts
@@ -67,7 +67,9 @@ describe('customer VPS host bundle', () => {
     expect(script).toContain('HOST_BUNDLE_INCREMENTAL_EXCLUDE_PREFIXES="${HOST_BUNDLE_INCREMENTAL_EXCLUDE_PREFIXES:-node_modules/}"');
     expect(script).toContain('scripts/host-bundle-incremental-manifest.mjs" "$STAGE_DIR/app" "$STAGE_DIR/incremental-manifest.json" "$DIST_DIR/objects"');
     expect(script).toContain('scripts/host-bundle-release.mjs" write-manifest');
-    expect(script).toContain('bin app runtime systemd release.json incremental-manifest.json');
+    expect(script).toContain(
+      'bin app runtime systemd libexec release.json incremental-manifest.json',
+    );
     expect(script).toContain('manifest.json');
     expect(script).toContain('release.json');
     expect(script).toContain('incremental-manifest.json');
@@ -85,7 +87,7 @@ describe('customer VPS host bundle', () => {
     expect(script).toContain('cp -a "$ROOT_DIR/distro/customer-vps/systemd/." "$STAGE_DIR/systemd/"');
     expect(script).toContain('matrix-messaging-health');
     expect(script).toContain('"$STAGE_DIR/runtime/node/bin/gh"');
-    expect(script).toContain('bin app runtime systemd release.json');
+    expect(script).toContain('bin app runtime systemd libexec release.json');
   });
 
   it('ships only the reproducible production Zellij candidate', () => {
@@ -1141,7 +1143,13 @@ test "$(readlink "$MATRIX_LEGACY_HOME/.hermes")" = "$MATRIX_HOME/.hermes"
     expect(syncAgent).toContain('/opt/matrix/env/symphony.env');
     expect(syncAgent).toContain('sudo install -o root -g matrix -m 0640 "$temp_file" "$SYMPHONY_ENV_FILE" || status=$?');
     expect(syncAgent).toContain('rm -f "$temp_file"');
-    expect(syncAgent).toContain("sudo find \"$extract_dir/systemd\" -maxdepth 1 -name 'matrix-*.service'");
+    expect(syncAgent).toContain(
+      'install_systemd_units_atomic "$extract_dir/systemd"',
+    );
+    expect(syncAgent).toContain(
+      '\\( -name \'matrix-*.service\' -o -name \'matrix-*.slice\' \\)',
+    );
+    expect(syncAgent).toContain('sudo mv -f -- "$unit_next"');
     expect(syncAgent).toContain('sudo systemctl daemon-reload');
     expect(syncAgent).toContain('sudo systemctl enable matrix-code-server.service');
     expect(syncAgent).toContain('sudo systemctl start --no-block matrix-code-server.service || true');

--- a/tests/scripts/terminal-runtime-spike.test.ts
+++ b/tests/scripts/terminal-runtime-spike.test.ts
@@ -158,7 +158,9 @@ describe('terminal runtime spike evidence', () => {
     expect(syncAgent).toContain('zellij_candidate_digest_mismatch');
     expect(syncAgent).toContain('mv -f "$zellij_next" "$BIN_DIR/zellij"');
     expect(syncAgent).toContain('zellij_installed_digest_mismatch');
-    expect(syncAgent).toContain("! -name 'zellij' ! -name 'zellij.build.json'");
+    expect(syncAgent).toContain("! -name 'zellij'");
+    expect(syncAgent).toContain("! -name 'zellij.build.json'");
+    expect(syncAgent).toContain("! -name 'matrix-terminal-*'");
     expect(syncAgent).toContain('backup_zellij_for_rollback');
     expect(syncAgent).toContain('restore_zellij_after_rollback');
     expect(syncAgent).toContain('readonly ZELLIJ_ROLLBACK_DIR="$APP_DIR/.zellij.rollback"');

--- a/tests/terminal-runtime/filesystem-security.test.ts
+++ b/tests/terminal-runtime/filesystem-security.test.ts
@@ -14,6 +14,7 @@ import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
 import { DescriptorStore } from '../../packages/terminal-runtime/src/descriptors.js';
 import { FlockManager } from '../../packages/terminal-runtime/src/locks.js';
+import { validateKeeperCwd } from '../../packages/terminal-runtime/src/keeper.js';
 import { SecureDirectory } from '../../packages/terminal-runtime/src/storage.js';
 const RUNTIME_ID = '0123456789abcdef0123456789abcdef';
 const OPERATION_ID = 'fedcba9876543210fedcba9876543210';
@@ -45,6 +46,23 @@ describe('terminal runtime filesystem security', () => {
       } finally {
         await directory.close();
       }
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+  it('revalidates keeper cwd against symlink escape immediately before launch', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'matrix-terminal-cwd-'));
+    const home = join(root, 'home');
+    const project = join(home, 'project');
+    const outside = join(root, 'outside');
+    try {
+      await mkdir(project, { recursive: true });
+      await mkdir(outside);
+      await symlink(outside, join(home, 'escape'));
+      await expect(validateKeeperCwd(home, 'project')).resolves.toBe(project);
+      await expect(validateKeeperCwd(home, 'escape')).rejects.toThrow(
+        'keeper_cwd_invalid',
+      );
     } finally {
       await rm(root, { recursive: true, force: true });
     }
@@ -92,6 +110,39 @@ describe('terminal runtime filesystem security', () => {
       await rm(root, { recursive: true, force: true });
     }
   });
+  it('holds the kernel flock for the full runtime critical section', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'matrix-terminal-lock-held-'));
+    const firstEntered = Promise.withResolvers<void>();
+    const releaseFirst = Promise.withResolvers<void>();
+    const secondEntered = Promise.withResolvers<void>();
+    let locks: FlockManager | undefined;
+    try {
+      locks = await FlockManager.open(root);
+      const first = locks.withRuntime(RUNTIME_ID, false, async () => {
+        firstEntered.resolve();
+        await releaseFirst.promise;
+      });
+      await firstEntered.promise;
+      expect(await locks.isRuntimeLocked(RUNTIME_ID)).toBe(true);
+      const second = locks.withRuntime(RUNTIME_ID, false, async () => {
+        secondEntered.resolve();
+      });
+      const raced = await Promise.race([
+        secondEntered.promise.then(() => 'entered'),
+        new Promise<'waiting'>((resolve) =>
+          setTimeout(() => resolve('waiting'), 50),
+        ),
+      ]);
+      expect(raced).toBe('waiting');
+      releaseFirst.resolve();
+      await Promise.all([first, second]);
+      expect(await locks.isRuntimeLocked(RUNTIME_ID)).toBe(false);
+    } finally {
+      releaseFirst.resolve();
+      await locks?.close();
+      await rm(root, { recursive: true, force: true });
+    }
+  });
   it('publishes exclusively, fsyncs, and never overwrites an existing target', async () => {
     const root = await mkdtemp(join(tmpdir(), 'matrix-terminal-exclusive-'));
     try {
@@ -129,10 +180,10 @@ describe('terminal runtime filesystem security', () => {
           store.claim({ runtimeId: RUNTIME_ID, operationId: OPERATION_ID, pid: 1 }),
         ).rejects.toThrow('claim_unauthorized');
         await expect(
-          store.claim({ runtimeId: RUNTIME_ID, operationId: OPERATION_ID, pid: 4242 }),
+          store.claimRuntime({ runtimeId: RUNTIME_ID, pid: 4242 }),
         ).resolves.toEqual(descriptor());
         await expect(
-          store.claim({ runtimeId: RUNTIME_ID, operationId: OPERATION_ID, pid: 4242 }),
+          store.claimRuntime({ runtimeId: RUNTIME_ID, pid: 4242 }),
         ).rejects.toThrow('descriptor_not_found');
         const replacedId = '11111111111111111111111111111111';
         const external = join(root, 'external.json');

--- a/tests/terminal-runtime/services.test.ts
+++ b/tests/terminal-runtime/services.test.ts
@@ -1,13 +1,17 @@
 import { describe, expect, it, vi } from 'vitest';
 import {
   buildKeeperLaunch,
+  isKeeperEntrypoint,
   monitorKeeperOnce,
   waitForKeeperReadiness,
 } from '../../packages/terminal-runtime/src/keeper.js';
 import {
+  classifyRuntimeProcesses,
   createSystemdExecutor,
-  unitNameForRuntimeId,
 } from '../../packages/terminal-runtime/src/systemd.js';
+import {
+  unitNameForRuntimeId,
+} from '../../packages/terminal-runtime/src/contracts.js';
 import {
   decodePeerCredentials,
   handleSupervisorFrame,
@@ -18,6 +22,13 @@ const runtimeId = '0123456789abcdef0123456789abcdef';
 const operationId = 'fedcba9876543210fedcba9876543210';
 
 describe('terminal runtime service boundary', () => {
+  it('runs a keeper launched through the atomically switched generation symlink', () => {
+    expect(isKeeperEntrypoint(
+      'file:///opt/matrix/libexec/terminal-runtime/v1/abc/keeper.js',
+      '/opt/matrix/libexec/terminal-runtime/current/keeper.js',
+    )).toBe(true);
+  });
+
   it('derives only the fixed template instance after validating the runtime ID', () => {
     expect(unitNameForRuntimeId(runtimeId))
       .toBe(`matrix-terminal-session@${runtimeId}.service`);
@@ -59,6 +70,20 @@ describe('terminal runtime service boundary', () => {
     ], expect.objectContaining({ timeout: 30_000 }));
   });
 
+  it('does not count transient Zellij inspection clients as runtime roles', () => {
+    expect(classifyRuntimeProcesses([
+      { comm: 'node', args: ['/generation/keeper.js'] },
+      { comm: 'zellij', args: ['zellij', '--session', `matrix-t-${runtimeId}`] },
+      { comm: 'zellij', args: ['zellij', 'list-sessions', '--no-formatting'] },
+      { comm: 'bash', args: ['bash', '--login'] },
+    ])).toEqual({
+      keeper: true,
+      zellijClient: false,
+      zellijServer: false,
+      shell: true,
+    });
+  });
+
   it('keeps all user-derived launch data out of keeper argv and preserves command gating', () => {
     const create = buildKeeperLaunch({
       schemaVersion: 1,
@@ -84,12 +109,15 @@ describe('terminal runtime service boundary', () => {
       '--session',
       `matrix-t-${runtimeId}`,
       '--new-session-with-layout',
-      '/opt/matrix/libexec/terminal-runtime/v1/layout.kdl',
+      '/opt/matrix/libexec/terminal-runtime/current/layout.kdl',
     ]);
     expect(create.cwd).toBe('/home/matrix/home/projects/example');
     expect(JSON.stringify(create.args)).not.toContain('configurationRef');
     expect(recover.args).toEqual(['attach', `matrix-t-${runtimeId}`]);
     expect(recover.args).not.toContain('--force-run-commands');
+    expect(create.env.ZELLIJ_CONFIG_FILE).toBe(
+      '/opt/matrix/libexec/terminal-runtime/current/config.kdl',
+    );
     expect(Object.keys(create.env).sort()).toEqual([
       'HOME',
       'LANG',
@@ -130,6 +158,48 @@ describe('terminal runtime service boundary', () => {
     });
 
     expect(evidence.roles.shell).toBe(13);
+    expect(notifyReady).toHaveBeenCalledTimes(1);
+  });
+
+  it('withholds recovery readiness until native command confirmation is visible', async () => {
+    const notifyReady = vi.fn(async () => undefined);
+    const sequence = [
+      {
+        clientAlive: true,
+        sessionResponsive: true,
+        confirmationGated: false,
+        roles: {
+          keeper: 10,
+          zellijClient: 11,
+          zellijServer: 12,
+          shell: 0,
+        },
+      },
+      {
+        clientAlive: true,
+        sessionResponsive: true,
+        confirmationGated: true,
+        roles: {
+          keeper: 10,
+          zellijClient: 11,
+          zellijServer: 12,
+          shell: 0,
+        },
+      },
+    ];
+    const readEvidence = vi.fn(
+      async () => sequence.shift() ?? sequence[0],
+    );
+    await waitForKeeperReadiness({
+      runtimeId,
+      requiresConfirmation: true,
+      timeoutMs: 1_000,
+      pollMs: 1,
+      readEvidence,
+      delay: vi.fn(async () => undefined),
+      notifyReady,
+    });
+    expect(readEvidence).toHaveBeenCalledTimes(2);
     expect(notifyReady).toHaveBeenCalledTimes(1);
   });
 

--- a/tests/terminal-runtime/services.test.ts
+++ b/tests/terminal-runtime/services.test.ts
@@ -1,0 +1,212 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  buildKeeperLaunch,
+  monitorKeeperOnce,
+  waitForKeeperReadiness,
+} from '../../packages/terminal-runtime/src/keeper.js';
+import {
+  createSystemdExecutor,
+  unitNameForRuntimeId,
+} from '../../packages/terminal-runtime/src/systemd.js';
+import {
+  decodePeerCredentials,
+  handleSupervisorFrame,
+} from '../../packages/terminal-runtime/src/supervisor.js';
+import { decodeFrame, encodeFrame } from '../../packages/terminal-runtime/src/framing.js';
+
+const runtimeId = '0123456789abcdef0123456789abcdef';
+const operationId = 'fedcba9876543210fedcba9876543210';
+
+describe('terminal runtime service boundary', () => {
+  it('derives only the fixed template instance after validating the runtime ID', () => {
+    expect(unitNameForRuntimeId(runtimeId))
+      .toBe(`matrix-terminal-session@${runtimeId}.service`);
+
+    for (const value of [
+      '../matrix-gateway',
+      '--system',
+      `${runtimeId}.service`,
+      `${runtimeId}\nmatrix-gateway`,
+      'matrix-terminal-session@other.service',
+    ]) {
+      expect(() => unitNameForRuntimeId(value)).toThrow();
+    }
+  });
+
+  it('never invokes systemctl for invalid runtime identities or accepts arbitrary properties', async () => {
+    const runFile = vi.fn(async () => ({ stdout: '', stderr: '' }));
+    const executor = createSystemdExecutor({
+      runFile,
+      readFile: vi.fn(async () => 'populated 0\n'),
+      inspectProcesses: vi.fn(async () => ({
+        keeper: true,
+        zellijClient: true,
+        zellijServer: true,
+        shell: true,
+      })),
+      sessionResponds: vi.fn(async () => true),
+    });
+
+    await expect(executor.start('--system')).rejects.toThrow();
+    await expect(executor.stop('../matrix-gateway')).rejects.toThrow();
+    await expect(executor.inspect(`${runtimeId}.service`)).rejects.toThrow();
+    expect(runFile).not.toHaveBeenCalled();
+
+    await executor.start(runtimeId);
+    expect(runFile).toHaveBeenCalledWith('/usr/bin/systemctl', [
+      'start',
+      `matrix-terminal-session@${runtimeId}.service`,
+    ], expect.objectContaining({ timeout: 30_000 }));
+  });
+
+  it('keeps all user-derived launch data out of keeper argv and preserves command gating', () => {
+    const create = buildKeeperLaunch({
+      schemaVersion: 1,
+      runtimeId,
+      operationId,
+      intent: 'create',
+      cwd: { kind: 'home-relative', path: 'projects/example' },
+      launch: { kind: 'agent', configurationRef: operationId },
+      createdAt: '2026-07-26T00:00:00.000Z',
+    }, '/home/matrix/home');
+    const recover = buildKeeperLaunch({
+      schemaVersion: 1,
+      runtimeId,
+      operationId,
+      intent: 'recover',
+      cwd: { kind: 'home-relative', path: '' },
+      launch: { kind: 'shell' },
+      createdAt: '2026-07-26T00:00:00.000Z',
+    }, '/home/matrix/home');
+
+    expect(create.file).toBe('/opt/matrix/bin/zellij');
+    expect(create.args).toEqual([
+      '--session',
+      `matrix-t-${runtimeId}`,
+      '--new-session-with-layout',
+      '/opt/matrix/libexec/terminal-runtime/v1/layout.kdl',
+    ]);
+    expect(create.cwd).toBe('/home/matrix/home/projects/example');
+    expect(JSON.stringify(create.args)).not.toContain('configurationRef');
+    expect(recover.args).toEqual(['attach', `matrix-t-${runtimeId}`]);
+    expect(recover.args).not.toContain('--force-run-commands');
+    expect(Object.keys(create.env).sort()).toEqual([
+      'HOME',
+      'LANG',
+      'MATRIX_HOME',
+      'PATH',
+      'TERM',
+      'XDG_CACHE_HOME',
+      'XDG_CONFIG_HOME',
+      'XDG_DATA_HOME',
+      'XDG_RUNTIME_DIR',
+      'ZELLIJ_CONFIG_DIR',
+      'ZELLIJ_CONFIG_FILE',
+    ]);
+  });
+
+  it('notifies readiness only after exact session and complete cgroup evidence pass', async () => {
+    const notifyReady = vi.fn(async () => undefined);
+    const sequence = [
+      { clientAlive: true, sessionResponsive: false, roles: null },
+      {
+        clientAlive: true,
+        sessionResponsive: true,
+        roles: {
+          keeper: 10,
+          zellijClient: 11,
+          zellijServer: 12,
+          shell: 13,
+        },
+      },
+    ];
+    const evidence = await waitForKeeperReadiness({
+      runtimeId,
+      timeoutMs: 1_000,
+      pollMs: 1,
+      readEvidence: vi.fn(async () => sequence.shift() ?? sequence[0]),
+      delay: vi.fn(async () => undefined),
+      notifyReady,
+    });
+
+    expect(evidence.roles.shell).toBe(13);
+    expect(notifyReady).toHaveBeenCalledTimes(1);
+  });
+
+  it('fails readiness and monitoring when the foreground client or server disappears', async () => {
+    const notifyReady = vi.fn(async () => undefined);
+    await expect(waitForKeeperReadiness({
+      runtimeId,
+      timeoutMs: 20,
+      pollMs: 1,
+      readEvidence: vi.fn(async () => ({
+        clientAlive: false,
+        sessionResponsive: true,
+        roles: {
+          keeper: 10,
+          zellijClient: 11,
+          zellijServer: 12,
+          shell: 13,
+        },
+      })),
+      delay: vi.fn(async () => undefined),
+      notifyReady,
+    })).rejects.toThrow('keeper_client_exited');
+    expect(notifyReady).not.toHaveBeenCalled();
+
+    await expect(monitorKeeperOnce({
+      clientAlive: true,
+      sessionResponds: vi.fn(async () => false),
+    })).resolves.toBe(false);
+    await expect(monitorKeeperOnce({
+      clientAlive: false,
+      sessionResponds: vi.fn(async () => true),
+    })).resolves.toBe(false);
+  });
+
+  it('authenticates the peer before parsing or dispatching a bounded protocol frame', async () => {
+    const peerBytes = Buffer.alloc(12);
+    peerBytes.writeUInt32LE(1234, 0);
+    peerBytes.writeUInt32LE(1001, 4);
+    peerBytes.writeUInt32LE(1001, 8);
+    expect(decodePeerCredentials(peerBytes)).toEqual({
+      pid: 1234,
+      uid: 1001,
+      gid: 1001,
+    });
+
+    const handler = vi.fn(async () => ({
+      version: 1 as const,
+      ok: true as const,
+      operationId,
+      result: [],
+    }));
+    const request = encodeFrame({
+      version: 1,
+      operation: 'List',
+      operationId,
+      input: {},
+    });
+    const rejected = await handleSupervisorFrame({
+      peer: { pid: 99, uid: 2000, gid: 2000 },
+      matrixUid: 1001,
+      request,
+      handler,
+    });
+    expect(handler).not.toHaveBeenCalled();
+    expect(decodeFrame(rejected)).toMatchObject({
+      version: 1,
+      ok: false,
+      error: { code: 'invalid_request' },
+    });
+
+    const accepted = await handleSupervisorFrame({
+      peer: { pid: 1234, uid: 1001, gid: 1001 },
+      matrixUid: 1001,
+      request,
+      handler,
+    });
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(decodeFrame(accepted)).toMatchObject({ ok: true, operationId });
+  });
+});

--- a/tests/terminal-runtime/storage-contracts.test.ts
+++ b/tests/terminal-runtime/storage-contracts.test.ts
@@ -202,6 +202,10 @@ describe('terminal runtime durable state contracts', () => {
           result: { ok: true, value: { lifecycleState: 'different' } },
         }),
       ).rejects.toThrow('operation_state_conflict');
+      await expect(
+        state.operations.removeCompleted(OPERATION_ID),
+      ).resolves.toBeUndefined();
+      await expect(state.operations.read(OPERATION_ID)).resolves.toBeNull();
     } finally {
       await state?.close();
       await rm(root, { recursive: true, force: true });


### PR DESCRIPTION
Stack: 3/9 on #1109 (production stack rooted at #1092)

## Summary

- Installs the dormant root-owned terminal supervisor, aggregate resource slice, and fixed per-runtime systemd template without starting any session instance.
- Ships the keeper, pane, runtime-operation worker, and `SO_PEERCRED` acceptor as a content-addressed immutable generation outside `/opt/matrix/app`.
- Enforces fixed unit derivation, peer UID checks before request parsing, exact keeper cgroup claims, readiness evidence, kernel-backed flock lifetime, bounded workers and buffers, and generic lifecycle-only journaling.
- Updates fresh-host, self-host, and in-place bundle installation with atomic wrapper/unit/current-generation switching while excluding all terminal units and the supervisor from normal restart/stop behavior.

This layer remains dormant for production terminal creation. Gateway and agent routing are intentionally deferred to PR 6, and production activation remains deferred to PR 9.

## Tests

- `pnpm --filter '@matrix-os/terminal-runtime' typecheck`
- `pnpm run check:patterns` — 0 violations
- `pnpm exec vitest run tests/terminal-runtime tests/deploy/customer-vps/terminal-runtime-services.test.ts tests/deploy/customer-vps/cloud-init.test.ts tests/scripts/install-server.test.ts tests/scripts/terminal-runtime-spike.test.ts` — 65 passed
- `pnpm exec vitest run tests/platform/customer-vps-host-bundle.test.ts tests/deploy/customer-vps/symphony-env-merge.test.ts` — 51 passed outside the restricted sandbox
- Review-fix rerun: terminal service/spike suites — 28 passed; unrestricted host-bundle/updater suites — 51 passed.
- `bash -n` for every changed shell entrypoint and updater script
- `cc -std=c11 -Wall -Wextra -Werror -O2 packages/terminal-runtime/native/supervisor-acceptor.c`
- Production-generation smoke test imported copied `zod/v4` and `node-pty` and verified zero symlinks/hard links.
- Full local `pnpm exec vitest run` was not used as a green signal: the restricted sandbox produced unrelated EPERM and loopback/network timeouts across existing app-runtime, heartbeat, CLI, git, and platform suites. Exact-head GitHub CI is authoritative for the broad gate.

## Review/Monitoring

- Frozen exact head: `0cb1d06b85ef635d495b5afc63816fde8672bda0`.
- Exact-head CI [passed](https://github.com/HamedMP/matrix-os/actions/runs/30959154167), including typecheck, patterns, unit shards, E2E, and shell build.
- Exact-head Docker [passed](https://github.com/HamedMP/matrix-os/actions/runs/30959155776).
- Exact-head preview bundle build/deploy and Codex provider-contract workflows passed.
- Exact-head Greptile: 5/5; all three review threads are resolved.
- The earlier disposable cgroup/readiness proof is retained as historical evidence only; final exact production behavior is proved at the activation tip.
- This layer remains dormant. Do not merge or activate it independently.

## Invariants

- **Source of truth:** durable receipts and operation records preserve identity and intent; systemd unit state, `cgroup.events`, keeper readiness, exact Zellij responsiveness, and required process membership are authoritative for liveness. A receipt alone never reports `live`.
- **Lock / transaction scope:** the supervisor acquires the global name-index flock before the per-runtime flock and holds each kernel lock for the complete local operation. No network call occurs inside these critical sections. Systemd receives only a derived fixed-template unit name.
- **Acceptable orphan states:** automatic failed-install rollback restores the prior `current` target, four stable wrappers, and three terminal unit files before restarting the legacy gateway; a newly copied but unreferenced immutable generation may remain for bounded later GC. Explicit application rollback deliberately preserves the newer compatible protocol-v1 host components. Pre-existing supervisors and live terminal cgroups are never stopped or restarted. A failed first-ever supervisor start is the sole exception: the updater proves it was not active before the update, stops it, clears restart-pending state, verifies inactivity, and only then restores files. If systemd cannot prove that cleanup, it still rolls back the application but deliberately retains the newer compatible host layer instead of swapping files beneath a possibly live process. A first existing-VPS bundle can install the new updater before a later dormant stack layer installs the stable supervisor payload; PR 9 activation must pass the supervisor compatibility preflight.
- **Auth source of truth:** the owner-only Unix sockets are mode `0600`; the root acceptor obtains kernel `SO_PEERCRED` before starting a worker. Public operations require the current `matrix` UID. Keeper descriptor claims additionally require the peer PID to belong to the exact trusted terminal unit cgroup.
- **Error / privacy policy:** protocol responses and journals expose only bounded generic codes. Terminal bytes, display names, cwd values, prompts, commands, providers, credentials, and paths are never written to unit metadata or journals.
- **Deferred scope:** no gateway/browser attach routing, agent launch migration, recovery/retention behavior, UI, legacy migration, production activation, updater typed root socket, or sudo removal is included here. Those are PRs 4–9.

## Deployment guarantees

- No `matrix-terminal-session@…` instance is enabled, enumerated, recovered, or started at boot.
- Normal bundle update and rollback paths never stop or restart `matrix-terminal-session@*`, `matrix-terminal.slice`, or `matrix-terminal-runtime.service`.
- First-time supervisor enablement and start are separate final transitions after the new gateway health check passes: enable failure rolls back before a process starts, and failed start cleanup stops only the newly introduced supervisor and verifies inactivity before restoring prior bytes. If that proof fails, the application rolls back while the compatible newer host layer remains intact. No rollback-capable step follows a successful start.
- Running helpers retain their mapped process image while future starts resolve the atomically switched immutable generation.

