### PR TITLE
feat(terminal): migrate gateway and agent runtimes

### DIFF
--- a/distro/customer-vps/host-bin/matrix-terminal-pane
+++ b/distro/customer-vps/host-bin/matrix-terminal-pane
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-if [ "$#" -ne 1 ] || [ "$1" != "shell" ]; then
+if [ "$#" -ne 1 ] || [[ "$1" != "shell" && "$1" != "agent" ]]; then
   exit 64
 fi
 

--- a/packages/gateway/package.json
+++ b/packages/gateway/package.json
@@ -34,6 +34,7 @@
     "@matrix-os/contracts": "workspace:*",
     "@matrix-os/kernel": "workspace:*",
     "@matrix-os/observability": "workspace:*",
+    "@matrix-os/terminal-runtime": "workspace:*",
     "@pipedream/sdk": "^2.4.3",
     "@types/node-cron": "^3.0.11",
     "chokidar": "^4.0.0",

--- a/packages/gateway/src/agent-launcher.ts
+++ b/packages/gateway/src/agent-launcher.ts
@@ -4,8 +4,13 @@ import { fileURLToPath } from "node:url";
 import { promisify } from "node:util";
 import { z } from "zod/v4";
 import { CODEX_VERIFIED_VERSION } from "@matrix-os/contracts";
+import { createOperationId } from "@matrix-os/terminal-runtime";
 import { CodexExecutableSchema } from "./coding-agents/codex-executable.js";
 import { codexExecContractStatus } from "./coding-agents/codex-version.js";
+import {
+  buildSupervisedAgentLaunch,
+  type SupervisedAgentConfiguration,
+} from "./coding-agents/supervised-launch.js";
 
 export const SupportedAgentSchema = z.enum(["claude", "codex", "opencode", "pi"]);
 export type SupportedAgent = z.infer<typeof SupportedAgentSchema>;
@@ -51,6 +56,10 @@ export interface AgentLaunchSpec {
   args: string[];
   cwd: string;
   env: Record<string, string>;
+  supervised?: {
+    configurationRef: string;
+    configuration: SupervisedAgentConfiguration;
+  };
 }
 
 type CommandRunner = (
@@ -395,6 +404,7 @@ export function createAgentLauncher(options: {
   runtimeHome?: string;
   codexExecutable?: string;
   now?: () => number;
+  terminalRuntimeMode?: "legacy" | "supervised";
 } = {}) {
   const runCommand = options.runCommand ?? defaultRunCommand;
   const cwd = options.cwd ?? process.cwd();
@@ -510,6 +520,36 @@ export function createAgentLauncher(options: {
     detectAgents: detectAgentInstallations,
 
     buildLaunch(input: AgentLaunchInput): AgentLaunchSpec {
+      if (options.terminalRuntimeMode === "supervised") {
+        if (!input.sandbox) {
+          throw new Error("Agent sandbox preflight is required");
+        }
+        const supervised = buildSupervisedAgentLaunch({
+          operationId: createOperationId(),
+          agent: input.agent,
+          cwd: input.cwd,
+          ...(input.prompt ? { prompt: input.prompt } : {}),
+          ...(input.mode ? { mode: input.mode } : {}),
+          ...(input.approvalPolicy
+            ? { approvalPolicy: input.approvalPolicy }
+            : {}),
+          sandbox: input.sandbox,
+          homePath: input.runtimeHome ?? options.runtimeHome,
+          ...(input.providerEventPath
+            ? { providerEventPath: input.providerEventPath }
+            : {}),
+        });
+        return {
+          command: supervised.matrixArgv[0],
+          args: [supervised.matrixArgv[1]],
+          cwd: input.cwd,
+          env: {},
+          supervised: {
+            configurationRef: supervised.descriptor.configurationRef,
+            configuration: supervised.configuration,
+          },
+        };
+      }
       return buildAgentLaunch({
         ...input,
         runtimeHome: input.runtimeHome ?? options.runtimeHome,

--- a/packages/gateway/src/agent-launcher.ts
+++ b/packages/gateway/src/agent-launcher.ts
@@ -524,6 +524,9 @@ export function createAgentLauncher(options: {
         if (!input.sandbox) {
           throw new Error("Agent sandbox preflight is required");
         }
+        const supervisedCodexExecutable = input.agent === "codex"
+          ? input.codexExecutable ?? options.codexExecutable
+          : undefined;
         const supervised = buildSupervisedAgentLaunch({
           operationId: createOperationId(),
           agent: input.agent,
@@ -535,6 +538,9 @@ export function createAgentLauncher(options: {
             : {}),
           sandbox: input.sandbox,
           homePath: input.runtimeHome ?? options.runtimeHome,
+          ...(supervisedCodexExecutable
+            ? { codexExecutable: supervisedCodexExecutable }
+            : {}),
           ...(input.providerEventPath
             ? { providerEventPath: input.providerEventPath }
             : {}),

--- a/packages/gateway/src/agent-session-manager.ts
+++ b/packages/gateway/src/agent-session-manager.ts
@@ -37,6 +37,7 @@ export interface WorkspaceSession {
     status: RuntimeStatus;
     zellijSession?: string;
     zellijLayoutPath?: string;
+    runtimeId?: string;
     tmuxSession?: string;
     fallbackReason?: string;
   };
@@ -206,6 +207,19 @@ function isActive(session: WorkspaceSession): boolean {
 
 function decorateSession(session: WorkspaceSession, runtime: ZellijRuntime): WorkspaceSessionView {
   if (session.runtime.type !== "zellij") return session;
+  if (session.runtime.zellijSession?.startsWith("matrix-t-")) {
+    return {
+      ...session,
+      nativeAttachCommand: ["zellij", "attach", session.runtime.zellijSession],
+      observeCommand: [
+        "zellij",
+        "attach",
+        session.runtime.zellijSession,
+        "--index",
+        "0",
+      ],
+    };
+  }
   return {
     ...session,
     nativeAttachCommand: runtime.attachCommand(session.id),
@@ -380,6 +394,9 @@ export function createAgentSessionManager(options: {
           status: runtimeStart.status,
           zellijSession: runtimeStart.sessionName,
           zellijLayoutPath: runtimeStart.layoutPath,
+          ...(runtimeStart.runtimeId
+            ? { runtimeId: runtimeStart.runtimeId }
+            : {}),
         },
         terminalSessionId: `term_${sessionId}`,
         transcriptPath: join(homePath, "system", "session-output", `${sessionId}.jsonl`),

--- a/packages/gateway/src/coding-agents/codex-app-server-runner.mjs
+++ b/packages/gateway/src/coding-agents/codex-app-server-runner.mjs
@@ -66,6 +66,7 @@ const RunnerConfigSchema = z.object({
   writableRoots: z.array(z.string().min(1).max(4096).refine(isAbsolute)).max(20),
 }).strict();
 const FdRunnerEnvelopeSchema = z.object({
+  command: z.string().trim().min(1).max(4096).refine(isAbsolute).optional(),
   eventPath: z.string().min(1).max(4096).refine(isAbsolute),
   expectedVersion: z.string().regex(/^\d+\.\d+\.\d+$/),
   config: RunnerConfigSchema,
@@ -180,7 +181,7 @@ if (process.argv[2] === "--fd-config") {
     const envelope = await readBoundedConfigurationFd();
     eventPath = envelope.eventPath;
     expectedVersion = envelope.expectedVersion;
-    command = "codex";
+    command = envelope.command ?? "codex";
     commandArgs = [];
     config = envelope.config;
   } catch (_error) {

--- a/packages/gateway/src/coding-agents/codex-app-server-runner.mjs
+++ b/packages/gateway/src/coding-agents/codex-app-server-runner.mjs
@@ -1,6 +1,7 @@
 import { spawn } from "node:child_process";
 import { createHash } from "node:crypto";
 import { constants } from "node:fs";
+import { createReadStream } from "node:fs";
 import { chmod, lstat, mkdir, open, rm } from "node:fs/promises";
 import { createServer } from "node:net";
 import { dirname, isAbsolute } from "node:path";
@@ -63,6 +64,11 @@ const RunnerConfigSchema = z.object({
   approvalPolicy: z.enum(["untrusted", "on-request", "never"]),
   sandbox: z.enum(["read-only", "workspace-write", "danger-full-access"]),
   writableRoots: z.array(z.string().min(1).max(4096).refine(isAbsolute)).max(20),
+}).strict();
+const FdRunnerEnvelopeSchema = z.object({
+  eventPath: z.string().min(1).max(4096).refine(isAbsolute),
+  expectedVersion: z.string().regex(/^\d+\.\d+\.\d+$/),
+  config: RunnerConfigSchema,
 }).strict();
 const ApprovalRequestSchema = z.object({
   id: NativeRequestIdSchema,
@@ -146,11 +152,54 @@ function fail(message) {
   process.exit(1);
 }
 
-const eventPath = process.argv[2];
-const expectedVersion = process.argv[3];
-const command = process.argv[4];
-const encodedConfig = process.argv.at(-1);
-const commandArgs = process.argv.slice(5, -1);
+async function readBoundedConfigurationFd() {
+  const chunks = [];
+  let total = 0;
+  for await (const chunk of createReadStream(null, {
+    fd: 3,
+    autoClose: false,
+  })) {
+    total += chunk.byteLength;
+    if (total > 128 * 1024) {
+      throw new Error("configuration_too_large");
+    }
+    chunks.push(Buffer.from(chunk));
+  }
+  return FdRunnerEnvelopeSchema.parse(JSON.parse(
+    Buffer.concat(chunks, total).toString("utf8"),
+  ));
+}
+
+let eventPath;
+let expectedVersion;
+let command;
+let commandArgs;
+let config;
+if (process.argv[2] === "--fd-config") {
+  try {
+    const envelope = await readBoundedConfigurationFd();
+    eventPath = envelope.eventPath;
+    expectedVersion = envelope.expectedVersion;
+    command = "codex";
+    commandArgs = [];
+    config = envelope.config;
+  } catch (_error) {
+    fail("Codex app-server runner configuration is invalid.");
+  }
+} else {
+  eventPath = process.argv[2];
+  expectedVersion = process.argv[3];
+  command = process.argv[4];
+  const encodedConfig = process.argv.at(-1);
+  commandArgs = process.argv.slice(5, -1);
+  try {
+    const bytes = Buffer.from(encodedConfig ?? "", "base64");
+    if (bytes.toString("base64") !== encodedConfig) throw new Error("invalid_base64");
+    config = RunnerConfigSchema.parse(JSON.parse(new TextDecoder("utf-8", { fatal: true }).decode(bytes)));
+  } catch (_error) {
+    fail("Codex app-server runner configuration is invalid.");
+  }
+}
 if (
   !eventPath ||
   !isAbsolute(eventPath) ||
@@ -158,14 +207,6 @@ if (
   !/^\d+\.\d+\.\d+$/.test(expectedVersion ?? "") ||
   !command
 ) {
-  fail("Codex app-server runner configuration is invalid.");
-}
-let config;
-try {
-  const bytes = Buffer.from(encodedConfig ?? "", "base64");
-  if (bytes.toString("base64") !== encodedConfig) throw new Error("invalid_base64");
-  config = RunnerConfigSchema.parse(JSON.parse(new TextDecoder("utf-8", { fatal: true }).decode(bytes)));
-} catch (_error) {
   fail("Codex app-server runner configuration is invalid.");
 }
 

--- a/packages/gateway/src/coding-agents/supervised-launch.ts
+++ b/packages/gateway/src/coding-agents/supervised-launch.ts
@@ -29,6 +29,7 @@ export function buildSupervisedAgentLaunch(input: {
   prompt?: string;
   mode?: "default" | "plan" | "review" | "full_access";
   approvalPolicy?: "untrusted" | "on-request" | "on-failure" | "never";
+  codexExecutable?: string;
   providerEventPath?: string;
   sandbox: {
     enabled: boolean;
@@ -70,7 +71,12 @@ export function buildSupervisedAgentLaunch(input: {
         }
       : {}),
     ...(input.agent === "codex"
-      ? { codexExpectedVersion: CODEX_VERIFIED_VERSION }
+      ? {
+          codexExpectedVersion: CODEX_VERIFIED_VERSION,
+          ...(input.codexExecutable
+            ? { codexExecutable: input.codexExecutable }
+            : {}),
+        }
       : {}),
   });
   return {

--- a/packages/gateway/src/coding-agents/supervised-launch.ts
+++ b/packages/gateway/src/coding-agents/supervised-launch.ts
@@ -1,0 +1,84 @@
+import { relative, resolve, sep } from "node:path";
+import {
+  AgentConfigurationSchema,
+  HomeRelativeCwdSchema,
+  OperationIdSchema,
+  type AgentConfiguration,
+} from "@matrix-os/terminal-runtime";
+import { CODEX_VERIFIED_VERSION } from "@matrix-os/contracts";
+
+export const SupervisedAgentConfigurationSchema = AgentConfigurationSchema;
+export type SupervisedAgentConfiguration = AgentConfiguration;
+
+function relativeOwnerPath(homePath: string, path: string) {
+  const root = resolve(homePath);
+  const target = resolve(path);
+  if (target !== root && !target.startsWith(`${root}${sep}`)) {
+    throw new Error("terminal_agent_path_invalid");
+  }
+  return HomeRelativeCwdSchema.parse({
+    kind: "home-relative",
+    path: relative(root, target).split(sep).join("/"),
+  });
+}
+
+export function buildSupervisedAgentLaunch(input: {
+  operationId: string;
+  agent: "claude" | "codex" | "opencode" | "pi";
+  cwd: string;
+  prompt?: string;
+  mode?: "default" | "plan" | "review" | "full_access";
+  approvalPolicy?: "untrusted" | "on-request" | "on-failure" | "never";
+  providerEventPath?: string;
+  sandbox: {
+    enabled: boolean;
+    mode?: "read-only" | "workspace-write" | "danger-full-access";
+    writableRoots?: string[];
+    denyWriteRoots?: string[];
+    adminOverride?: boolean;
+  };
+  homePath?: string;
+}) {
+  const configurationRef = OperationIdSchema.parse(input.operationId);
+  const homePath = resolve(
+    input.homePath ?? process.env.MATRIX_HOME ?? "/home/matrix/home",
+  );
+  const configuration = SupervisedAgentConfigurationSchema.parse({
+    schemaVersion: 1,
+    agent: input.agent,
+    cwd: relativeOwnerPath(homePath, input.cwd),
+    ...(input.prompt ? { prompt: input.prompt } : {}),
+    mode: input.mode ?? "default",
+    approvalPolicy: input.approvalPolicy ?? "never",
+    sandbox: {
+      enabled: input.sandbox.enabled,
+      ...(input.sandbox.mode ? { mode: input.sandbox.mode } : {}),
+      writableRoots: (input.sandbox.writableRoots ?? [])
+        .map((path) => relativeOwnerPath(homePath, path)),
+      denyWriteRoots: (input.sandbox.denyWriteRoots ?? [])
+        .map((path) => relativeOwnerPath(homePath, path)),
+      ...(input.sandbox.adminOverride !== undefined
+        ? { adminOverride: input.sandbox.adminOverride }
+        : {}),
+    },
+    ...(input.providerEventPath
+      ? {
+          providerEventPath: relativeOwnerPath(
+            homePath,
+            input.providerEventPath,
+          ).path,
+        }
+      : {}),
+    ...(input.agent === "codex"
+      ? { codexExpectedVersion: CODEX_VERIFIED_VERSION }
+      : {}),
+  });
+  return {
+    descriptor: { kind: "agent" as const, configurationRef },
+    matrixArgv: [
+      "/opt/matrix/bin/matrix-terminal-pane",
+      "agent",
+    ] as const,
+    configuration,
+  };
+}

--- a/packages/gateway/src/server.ts
+++ b/packages/gateway/src/server.ts
@@ -48,6 +48,7 @@ import { createWorkspaceSessionOrchestrator } from "./workspace-session-orchestr
 import { createWorkspaceEventStore } from "./workspace-events.js";
 import { createWorkspaceEventPublisher } from "./workspace-event-publisher.js";
 import { createZellijRuntime } from "./zellij-runtime.js";
+import { createSupervisedZellijRuntime } from "./supervised-zellij-runtime.js";
 import { createSessionRuntimeBridge } from "./session-runtime-bridge.js";
 import { createWorkspaceStartupRecovery } from "./workspace-startup-recovery.js";
 import { createChannelManager, type ChannelManager } from "./channels/manager.js";
@@ -249,6 +250,12 @@ import {
   shellWsMessageDataToString,
 } from "./shell/index.js";
 import {
+  createSupervisedZellijAdapter,
+  initializeGatewayTerminalRuntime,
+  resolveGatewayTerminalRuntimeMode,
+  supervisedZellijEnvironment,
+} from "./shell/runtime-client.js";
+import {
   CLIENT_ERROR_LOG_BODY_LIMIT,
   ClientErrorReportSchema,
   forwardClientErrorToPostHog,
@@ -332,6 +339,8 @@ export async function createGateway(config: GatewayConfig) {
   });
   const { injectWebSocket, upgradeWebSocket } = createNodeWebSocket({ app });
 
+  const terminalRuntimeMode = config.terminalRuntime?.mode ??
+    resolveGatewayTerminalRuntimeMode(process.env.MATRIX_TERMINAL_RUNTIME_MODE);
   const terminalSessionsPersistPath = join(homePath, "system", "terminal-sessions.json");
   // PTY session handles are process-local and cannot survive a gateway restart.
   // Zellij shell sessions are the canonical durable terminal surface; reset this
@@ -345,8 +354,40 @@ export async function createGateway(config: GatewayConfig) {
     bufferSize: 1024 * 1024,
     persistPath: terminalSessionsPersistPath,
     autoRestore: false,
+    ...(terminalRuntimeMode === "supervised"
+      ? { externalEnv: supervisedZellijEnvironment(homePath) }
+      : {}),
   });
-  const workspaceZellijRuntime = createZellijRuntime({ homePath });
+  const terminalRuntimeClient = await initializeGatewayTerminalRuntime({
+    mode: terminalRuntimeMode,
+    nodeEnv: process.env.NODE_ENV,
+    homePath,
+    ...(config.terminalRuntime?.supervisor
+      ? { supervisor: config.terminalRuntime.supervisor }
+      : {}),
+  });
+  const directZellijAdapter = terminalRuntimeMode === "supervised"
+    ? createZellijAdapter({
+        cwd: homePath,
+        env: {
+          ...process.env,
+          ...supervisedZellijEnvironment(homePath),
+        },
+      })
+    : createZellijAdapter({ homePath });
+  const zellijAdapter = terminalRuntimeClient
+    ? createSupervisedZellijAdapter({
+        runtime: terminalRuntimeClient,
+        zellij: directZellijAdapter,
+      })
+    : directZellijAdapter;
+  const workspaceZellijRuntime = terminalRuntimeClient
+    ? createSupervisedZellijRuntime({
+        homePath,
+        runtime: terminalRuntimeClient,
+        zellij: directZellijAdapter,
+      })
+    : createZellijRuntime({ homePath });
   const workspaceSessionRuntimeBridge = createSessionRuntimeBridge({
     homePath,
     registry: sessionRegistry,
@@ -354,7 +395,6 @@ export async function createGateway(config: GatewayConfig) {
   });
   const shellScrollbackStore = new ScrollbackStore({ homePath });
   const shellPreferencesStore = new ShellPreferencesStore({ homePath });
-  const zellijAdapter = createZellijAdapter({ homePath });
   const shellLayoutStore = new LayoutStore({ homePath, adapter: zellijAdapter });
   const zellijShellRegistry = new ZellijShellRegistry({
     homePath,
@@ -442,6 +482,7 @@ export async function createGateway(config: GatewayConfig) {
     cwd: homePath,
     runtimeHome: homePath,
     codexExecutable,
+    terminalRuntimeMode,
   });
   let internalIntegrationBaseUrl: string | null = null;
   const PLATFORM_USER_ID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
@@ -559,6 +600,9 @@ export async function createGateway(config: GatewayConfig) {
   });
   const codingAgentProviders: CodingAgentProviderAdapter[] = [];
   const codingAgentRegistryProviders: CodingAgentProviderAdapter[] = [];
+  let workspaceAgentSessionManager:
+    | ReturnType<typeof createAgentSessionManager>
+    | undefined;
   if (codingAgentWorkspaceAgents.length > 0) {
     const codingAgentProjectManager = createProjectManager({ homePath });
     codexEventBridge = codexExecutable
@@ -573,6 +617,7 @@ export async function createGateway(config: GatewayConfig) {
       inputWriter: (sessionId, input, signal) =>
         workspaceZellijRuntime.sendInput(sessionId, input, signal),
     });
+    workspaceAgentSessionManager = codingAgentSessionManager;
     const codingAgentWorkspaceRuntime = createWorkspaceSessionOrchestrator({
       projectManager: codingAgentProjectManager,
       worktreeManager: codingAgentWorktreeManager,
@@ -2870,6 +2915,9 @@ export async function createGateway(config: GatewayConfig) {
   const workspaceStartupRecovery = await createWorkspaceStartupRecovery({
     homePath,
     eventPublisher: workspaceEventPublisher,
+    ...(workspaceAgentSessionManager
+      ? { agentSessionManager: workspaceAgentSessionManager }
+      : {}),
   }).run();
   if (workspaceStartupRecovery.status === "degraded") {
     console.warn("[gateway] Workspace startup recovery completed with degraded steps");

--- a/packages/gateway/src/server/types.ts
+++ b/packages/gateway/src/server/types.ts
@@ -1,4 +1,5 @@
 import type { SpawnFn } from "../dispatcher.js";
+import type { SupervisorClient } from "@matrix-os/terminal-runtime";
 
 export interface GatewayConfig {
   homePath: string;
@@ -7,6 +8,10 @@ export interface GatewayConfig {
   maxTurns?: number;
   spawnFn?: SpawnFn;
   syncReport?: { added: string[]; updated: string[]; skipped: string[] };
+  terminalRuntime?: {
+    mode: "legacy" | "supervised";
+    supervisor?: SupervisorClient;
+  };
 }
 
 export type ServerMessage =

--- a/packages/gateway/src/session-registry.ts
+++ b/packages/gateway/src/session-registry.ts
@@ -128,6 +128,7 @@ export interface SessionRegistryOptions {
    * same persist file and double-spawning bash children.
    */
   autoRestore?: boolean;
+  externalEnv?: Readonly<Record<string, string>>;
 }
 
 type SubscriberFn = (msg: PtyServerMessage) => void;
@@ -313,6 +314,7 @@ export class SessionRegistry {
   private readonly spawnFn: SpawnFn;
   private readonly allowedShells: Set<string>;
   private readonly sessionTtlMs: number;
+  private readonly externalEnv: Readonly<Record<string, string>>;
   private persistTimer?: ReturnType<typeof setTimeout>;
   private persistQueue: Promise<void> = Promise.resolve();
 
@@ -326,6 +328,7 @@ export class SessionRegistry {
     this.bufferSize = options?.bufferSize ?? 1024 * 1024;
     this.persistPath = options?.persistPath ?? join(homePath, "system", "terminal-sessions.json");
     this.sessionTtlMs = normalizeSessionTtl(options?.sessionTtlMs);
+    this.externalEnv = options?.externalEnv ?? {};
     this.allowedShells = options?.allowedShells
       ? new Set(options.allowedShells)
       : DEFAULT_ALLOWED_SHELLS;
@@ -623,6 +626,7 @@ export class SessionRegistry {
         ...(process.env.MATRIX_RUNTIME_DIR ? { MATRIX_RUNTIME_DIR: process.env.MATRIX_RUNTIME_DIR } : {}),
         ...(process.env.MATRIX_RUNTIME_HOME ? { MATRIX_RUNTIME_HOME: process.env.MATRIX_RUNTIME_HOME } : {}),
         ...(process.env.MATRIX_RUNTIME_USER ? { MATRIX_RUNTIME_USER: process.env.MATRIX_RUNTIME_USER } : {}),
+        ...this.externalEnv,
       }),
     };
   }

--- a/packages/gateway/src/session-runtime-bridge.ts
+++ b/packages/gateway/src/session-runtime-bridge.ts
@@ -60,9 +60,18 @@ export function createSessionRuntimeBridge(options: {
         if (!session.runtime.zellijSession) {
           return failure(409, "session_unavailable", "Session is not attachable");
         }
-        command = splitCommand(parsed.data.mode === "observe"
-          ? options.zellijRuntime.observeCommand(session.id)
-          : options.zellijRuntime.attachCommand(session.id));
+        command = session.runtime.zellijSession.startsWith("matrix-t-")
+          ? {
+              command: "zellij",
+              args: [
+                "attach",
+                session.runtime.zellijSession,
+                ...(parsed.data.mode === "observe" ? ["--index", "0"] : []),
+              ],
+            }
+          : splitCommand(parsed.data.mode === "observe"
+              ? options.zellijRuntime.observeCommand(session.id)
+              : options.zellijRuntime.attachCommand(session.id));
       } else if (session.runtime.type === "tmux") {
         if (!session.runtime.tmuxSession) {
           return failure(409, "session_unavailable", "Session is not attachable");

--- a/packages/gateway/src/shell/registry.ts
+++ b/packages/gateway/src/shell/registry.ts
@@ -35,6 +35,13 @@ export interface ShellRegistryAdapter {
   createSession(options: { name: string; cwd?: string; layout?: string; cmd?: string }): Promise<void>;
   deleteSession(name: string, options?: { force?: boolean }): Promise<void>;
   renameSession?(name: string, nextName: string): Promise<void>;
+  runtimeProjection?(name: string): {
+    runtimeId: string;
+    lifecycleState: string;
+    recoverable: boolean;
+    recoveryReason: string | null;
+    metadataRevision?: number;
+  } | null;
 }
 
 const ShellSessionSchema = z.object({
@@ -65,6 +72,20 @@ const ShellSessionSchema = z.object({
   visualStatusUpdatedAt: z.string().optional(),
   agent: AgentKindSchema.optional(),
   cwd: z.string().max(4096).optional(),
+  runtimeId: z.string().regex(/^[0-9a-f]{32}$/).optional(),
+  lifecycleState: z.enum([
+    "starting",
+    "live",
+    "interrupted",
+    "recoverable",
+    "recovering",
+    "deleting",
+    "exited",
+    "failed",
+  ]).optional(),
+  recoverable: z.boolean().optional(),
+  recoveryReason: z.string().max(64).nullable().optional(),
+  metadataRevision: z.number().int().positive().optional(),
 });
 
 const RegistryFileSchema = z.object({
@@ -94,7 +115,7 @@ export type ShellSession = Omit<PersistedShellSession, "cwd"> & {
   aliases: ShellSessionAlias[];
   references: ShellSessionReference[];
   recoverable: boolean;
-  recoveryReason?: "missing_runtime_session";
+  recoveryReason?: string | null;
   agent?: AgentKind;
   subtitle?: string;
   lastAction?: string;
@@ -160,6 +181,7 @@ export class ShellRegistry {
           ...(existing ?? this.adoptSession(name, now)),
           status: "active" as const,
           updatedAt: existing?.status === "active" ? existing.updatedAt : now,
+          ...this.runtimeFields(name),
         };
         activeSessions.push(session);
         if (!existing || existing.status !== "active") {
@@ -194,6 +216,7 @@ export class ShellRegistry {
         ...(existing ?? this.adoptSession(targetName, now)),
         status: "active" as const,
         updatedAt: existing?.status === "active" ? existing.updatedAt : now,
+        ...this.runtimeFields(targetName),
       };
       if (!existing || existing.status !== "active") {
         file.sessions[targetName] = session;
@@ -229,6 +252,7 @@ export class ShellRegistry {
           ...(layoutName ? { layoutName } : {}),
           ...(agent ? { agent } : {}),
           ...(cwd ? { cwd } : {}),
+          ...this.runtimeFields(name),
         };
         file.sessions[name] = session;
         await this.write(file);
@@ -252,6 +276,7 @@ export class ShellRegistry {
         kind: "session",
         ...(agent ? { agent } : {}),
         ...(cwd ? { cwd } : {}),
+        ...this.runtimeFields(name),
       };
       file.sessions[name] = session;
       if (file.order) {
@@ -296,6 +321,7 @@ export class ShellRegistry {
       const next: PersistedShellSession = {
         ...existing,
         updatedAt: now,
+        ...this.runtimeFields(targetName),
         ...(patch.placement !== undefined ? { placement: patch.placement } : {}),
         ...(patch.lastSeenSeq !== undefined ? { lastSeenSeq: patch.lastSeenSeq } : {}),
       };
@@ -361,22 +387,26 @@ export class ShellRegistry {
       this.retargetAliasesAndReferences(file, targetName, safeNextName);
 
       await this.options.adapter.renameSession(targetName, safeNextName);
+      Object.assign(next, this.runtimeFields(safeNextName));
+      const immutableRuntimeIdentity = Boolean(existing.runtimeId);
       let scrollbackRenamed = false;
       let preferencesRenamed = false;
       let agentStateRenamed = false;
       try {
-        await this.options.scrollbackStore?.rename(targetName, safeNextName);
-        scrollbackRenamed = true;
-        await this.options.preferencesStore?.rename(targetName, safeNextName);
-        preferencesRenamed = true;
-        try {
-          await this.agentStateStore.rename(targetName, safeNextName);
-          agentStateRenamed = true;
-        } catch (err: unknown) {
-          console.warn(
-            "[shell] failed to rename agent session state:",
-            err instanceof Error ? err.message : String(err),
-          );
+        if (!immutableRuntimeIdentity) {
+          await this.options.scrollbackStore?.rename(targetName, safeNextName);
+          scrollbackRenamed = true;
+          await this.options.preferencesStore?.rename(targetName, safeNextName);
+          preferencesRenamed = true;
+          try {
+            await this.agentStateStore.rename(targetName, safeNextName);
+            agentStateRenamed = true;
+          } catch (err: unknown) {
+            console.warn(
+              "[shell] failed to rename agent session state:",
+              err instanceof Error ? err.message : String(err),
+            );
+          }
         }
         if (file.order) {
           const nextLive = new Set(live);
@@ -442,7 +472,8 @@ export class ShellRegistry {
       const safeName = validateSessionName(name);
       const file = await this.read();
       const targetName = this.resolveSessionName(file, safeName);
-      if (!file.sessions[targetName]) {
+      const persistedSession = file.sessions[targetName];
+      if (!persistedSession) {
         if (!options.force) {
           throw shellError("session_not_found", "Session not found", 404);
         }
@@ -458,8 +489,11 @@ export class ShellRegistry {
       }
       this.removeReferencesForTarget(file, targetName);
       this.removeAliasesForTarget(file, targetName);
-      await this.cleanupScrollback(targetName);
-      await this.cleanupAgentState(targetName);
+      const storageIdentity = this.storageIdentity(persistedSession ?? {
+        name: targetName,
+      });
+      await this.cleanupScrollback(storageIdentity);
+      await this.cleanupAgentState(storageIdentity);
       await this.write(file);
     });
   }
@@ -514,16 +548,36 @@ export class ShellRegistry {
       attachedClients: 0,
       placement: "active",
       lastSeenSeq: null,
+      ...this.runtimeFields(name),
     };
   }
 
+  private runtimeFields(name: string): Partial<PersistedShellSession> {
+    const projection = this.options.adapter.runtimeProjection?.(name);
+    if (!projection) return {};
+    return {
+      runtimeId: projection.runtimeId,
+      lifecycleState: projection.lifecycleState as PersistedShellSession["lifecycleState"],
+      recoverable: projection.recoverable,
+      recoveryReason: projection.recoveryReason,
+      ...(projection.metadataRevision
+        ? { metadataRevision: projection.metadataRevision }
+        : {}),
+    };
+  }
+
+  private storageIdentity(session: Pick<PersistedShellSession, "name" | "runtimeId">): string {
+    return session.runtimeId ? `matrix-t-${session.runtimeId}` : session.name;
+  }
+
   private async decorateSession(session: PersistedShellSession, file?: RegistryFile): Promise<ShellSession> {
+    const storageIdentity = this.storageIdentity(session);
     const [activity, agentSnapshot, focusedPaneCwd] = await Promise.all([
-      this.options.scrollbackStore?.latestActivity?.(session.name),
-      this.readAgentSnapshot(session.name),
+      this.options.scrollbackStore?.latestActivity?.(storageIdentity),
+      this.readAgentSnapshot(storageIdentity),
       this.readFocusedPaneCwd(session.name),
     ]);
-    const latestSeq = activity?.latestSeq ?? await this.options.scrollbackStore?.latestSeq(session.name) ?? null;
+    const latestSeq = activity?.latestSeq ?? await this.options.scrollbackStore?.latestSeq(storageIdentity) ?? null;
     const lastSeenSeq = session.lastSeenSeq ?? session.lastSeq ?? latestSeq;
     const unread = latestSeq !== null && lastSeenSeq !== null && latestSeq > lastSeenSeq;
     const references = file ? this.referencesForTarget(file, session.name) : [];

--- a/packages/gateway/src/shell/runtime-client.ts
+++ b/packages/gateway/src/shell/runtime-client.ts
@@ -1,0 +1,381 @@
+import { realpath } from "node:fs/promises";
+import { relative, resolve, sep } from "node:path";
+import {
+  DisplayNameSchema,
+  HomeRelativeCwdSchema,
+  LifecycleStateSchema,
+  MetadataRevisionSchema,
+  OperationIdSchema,
+  RecoveryReasonSchema,
+  RuntimeIdSchema,
+  createOperationId,
+  createSupervisorClient,
+  type HomeRelativeCwd,
+  type ProtocolRequest,
+  type SupervisorClient,
+} from "@matrix-os/terminal-runtime";
+import { z } from "zod/v4";
+import type {
+  AttachOptions,
+  CreateSessionOptions,
+  ZellijAdapter,
+} from "./zellij.js";
+
+const MAX_RUNTIME_PROJECTIONS = 2_048;
+const RecoveryModeSchema = z.enum(["serialized", "fresh-shell"]).nullable();
+const RuntimeProjectionSchema = z.object({
+  runtimeId: RuntimeIdSchema,
+  displayName: DisplayNameSchema.optional(),
+  lifecycleState: LifecycleStateSchema,
+  recoverable: z.boolean().default(false),
+  recoveryReason: RecoveryReasonSchema.nullable().default(null),
+  recoveryMode: RecoveryModeSchema.default(null),
+  metadataRevision: MetadataRevisionSchema.optional(),
+}).strict();
+const RuntimeProjectionListSchema = z.array(RuntimeProjectionSchema)
+  .max(MAX_RUNTIME_PROJECTIONS);
+const StartProjectionSchema = z.object({
+  runtimeId: RuntimeIdSchema,
+  lifecycleState: LifecycleStateSchema,
+}).passthrough();
+const RenameProjectionSchema = z.object({
+  runtimeId: RuntimeIdSchema,
+  displayName: DisplayNameSchema,
+  metadataRevision: MetadataRevisionSchema,
+}).strict();
+
+export type GatewayTerminalRuntimeProjection = z.infer<typeof RuntimeProjectionSchema>;
+export type GatewayTerminalRuntimeMode = "legacy" | "supervised";
+
+export function resolveGatewayTerminalRuntimeMode(
+  value: string | undefined,
+): GatewayTerminalRuntimeMode {
+  if (value === undefined || value === "" || value === "legacy") return "legacy";
+  if (value === "supervised") return "supervised";
+  throw new Error("terminal_runtime_mode_invalid");
+}
+
+export function supervisedZellijEnvironment(
+  homePath: string,
+  uid = process.getuid?.() ?? 1000,
+): Record<string, string> {
+  const root = resolve(homePath, "system", "terminal-runtime");
+  return {
+    XDG_CACHE_HOME: resolve(root, "zellij-cache"),
+    XDG_CONFIG_HOME: resolve(root, "zellij-config-home"),
+    XDG_DATA_HOME: resolve(root, "zellij-data"),
+    XDG_RUNTIME_DIR: `/run/user/${uid}`,
+    ZELLIJ_CONFIG_DIR: "/opt/matrix/libexec/terminal-runtime/current",
+    ZELLIJ_CONFIG_FILE:
+      "/opt/matrix/libexec/terminal-runtime/current/config.kdl",
+  };
+}
+
+export interface GatewayTerminalRuntimeClient {
+  list(): Promise<GatewayTerminalRuntimeProjection[]>;
+  inspect(runtimeId: string): Promise<GatewayTerminalRuntimeProjection>;
+  createShell(input: {
+    displayName: string;
+    cwd?: string;
+  }): Promise<GatewayTerminalRuntimeProjection>;
+  createAgent(input: {
+    displayName: string;
+    cwd: string;
+    configurationRef: string;
+  }): Promise<GatewayTerminalRuntimeProjection>;
+  rename(input: {
+    runtimeId: string;
+    displayName: string;
+    baseRevision: number;
+  }): Promise<GatewayTerminalRuntimeProjection>;
+  delete(runtimeId: string): Promise<void>;
+}
+
+function terminalRuntimeError(code: string): Error {
+  const error = new Error("terminal_runtime_request_failed");
+  Object.defineProperty(error, "code", { value: code, enumerable: true });
+  return error;
+}
+
+async function responseResult(
+  supervisor: SupervisorClient,
+  request: ProtocolRequest,
+): Promise<unknown> {
+  const response = await supervisor.request(request);
+  if (!response.ok) throw terminalRuntimeError(response.error.code);
+  return response.result;
+}
+
+async function homeRelativeCwd(homePath: string, cwd?: string): Promise<HomeRelativeCwd> {
+  try {
+    const root = await realpath(resolve(homePath));
+    const target = await realpath(resolve(cwd ?? root));
+    if (target !== root && !target.startsWith(`${root}${sep}`)) {
+      throw new Error("terminal_cwd_invalid");
+    }
+    const path = relative(root, target).split(sep).join("/");
+    return HomeRelativeCwdSchema.parse({ kind: "home-relative", path });
+  } catch (error: unknown) {
+    if (error instanceof Error && error.message === "terminal_cwd_invalid") {
+      throw error;
+    }
+    throw new Error("terminal_cwd_invalid", { cause: error });
+  }
+}
+
+function completeStartProjection(
+  result: unknown,
+  displayName: string,
+): GatewayTerminalRuntimeProjection {
+  const parsed = StartProjectionSchema.parse(result);
+  return RuntimeProjectionSchema.parse({
+    ...parsed,
+    displayName,
+    metadataRevision: 1,
+  });
+}
+
+export function createGatewayTerminalRuntimeClient(options: {
+  homePath: string;
+  supervisor?: SupervisorClient;
+}): GatewayTerminalRuntimeClient {
+  const supervisor = options.supervisor ?? createSupervisorClient();
+  const homePath = resolve(options.homePath);
+  return {
+    async list() {
+      const result = await responseResult(supervisor, {
+        version: 1,
+        operationId: createOperationId(),
+        operation: "List",
+        input: {},
+      });
+      return RuntimeProjectionListSchema.parse(result);
+    },
+    async inspect(runtimeId) {
+      const trustedId = RuntimeIdSchema.parse(runtimeId);
+      const result = await responseResult(supervisor, {
+        version: 1,
+        operationId: createOperationId(),
+        operation: "Inspect",
+        input: { runtimeId: trustedId },
+      });
+      return RuntimeProjectionSchema.parse(result);
+    },
+    async createShell(input) {
+      const displayName = DisplayNameSchema.parse(input.displayName);
+      const result = await responseResult(supervisor, {
+        version: 1,
+        operationId: createOperationId(),
+        operation: "CreateStart",
+        input: {
+          displayName,
+          cwd: await homeRelativeCwd(homePath, input.cwd),
+          launch: { kind: "shell" },
+        },
+      });
+      return completeStartProjection(result, displayName);
+    },
+    async createAgent(input) {
+      const displayName = DisplayNameSchema.parse(input.displayName);
+      const configurationRef = OperationIdSchema.parse(input.configurationRef);
+      const result = await responseResult(supervisor, {
+        version: 1,
+        operationId: configurationRef,
+        operation: "CreateStart",
+        input: {
+          displayName,
+          cwd: await homeRelativeCwd(homePath, input.cwd),
+          launch: { kind: "agent", configurationRef },
+        },
+      });
+      return completeStartProjection(result, displayName);
+    },
+    async rename(input) {
+      const runtimeId = RuntimeIdSchema.parse(input.runtimeId);
+      const displayName = DisplayNameSchema.parse(input.displayName);
+      const baseRevision = MetadataRevisionSchema.parse(input.baseRevision);
+      const result = await responseResult(supervisor, {
+        version: 1,
+        operationId: createOperationId(),
+        operation: "RenameMetadata",
+        input: { runtimeId, displayName, baseRevision },
+      });
+      const renamed = RenameProjectionSchema.parse(result);
+      return RuntimeProjectionSchema.parse({
+        ...renamed,
+        lifecycleState: "live",
+      });
+    },
+    async delete(runtimeId) {
+      const trustedId = RuntimeIdSchema.parse(runtimeId);
+      await responseResult(supervisor, {
+        version: 1,
+        operationId: createOperationId(),
+        operation: "Delete",
+        input: { runtimeId: trustedId },
+      });
+    },
+  };
+}
+
+export async function initializeGatewayTerminalRuntime(options: {
+  mode: GatewayTerminalRuntimeMode;
+  nodeEnv?: string;
+  homePath: string;
+  supervisor?: SupervisorClient;
+}): Promise<GatewayTerminalRuntimeClient | null> {
+  if (options.mode === "legacy") return null;
+  const runtime = createGatewayTerminalRuntimeClient(options);
+  try {
+    await runtime.list();
+  } catch (error: unknown) {
+    if (options.nodeEnv !== "production") throw error;
+    throw new Error("terminal_supervisor_unavailable", { cause: error });
+  }
+  return runtime;
+}
+
+function zellijIdentity(runtimeId: string): string {
+  return `matrix-t-${RuntimeIdSchema.parse(runtimeId)}`;
+}
+
+export function createSupervisedZellijAdapter(options: {
+  runtime: GatewayTerminalRuntimeClient;
+  zellij: ZellijAdapter;
+}): ZellijAdapter {
+  const byName = new Map<string, GatewayTerminalRuntimeProjection>();
+
+  function remember(projection: GatewayTerminalRuntimeProjection): void {
+    if (!projection.displayName) return;
+    byName.delete(projection.displayName);
+    while (byName.size >= MAX_RUNTIME_PROJECTIONS) {
+      const oldest = byName.keys().next().value as string | undefined;
+      if (!oldest) break;
+      byName.delete(oldest);
+    }
+    byName.set(projection.displayName, projection);
+  }
+
+  function resolved(name: string): GatewayTerminalRuntimeProjection {
+    const projection = byName.get(DisplayNameSchema.parse(name));
+    if (!projection) throw new Error("terminal_runtime_not_resolved");
+    return projection;
+  }
+
+  async function resolveName(name: string): Promise<GatewayTerminalRuntimeProjection> {
+    const trustedName = DisplayNameSchema.parse(name);
+    const cached = byName.get(trustedName);
+    if (cached) return cached;
+    const projection = (await options.runtime.list())
+      .find((candidate) => candidate.displayName === trustedName);
+    if (!projection) throw new Error("terminal_runtime_not_resolved");
+    remember(projection);
+    return projection;
+  }
+
+  async function mappedName(name: string): Promise<string> {
+    return zellijIdentity((await resolveName(name)).runtimeId);
+  }
+
+  return {
+    runtimeProjection(name: string) {
+      return byName.get(DisplayNameSchema.parse(name)) ?? null;
+    },
+    async health() {
+      try {
+        await options.runtime.list();
+        return await options.zellij.health();
+      } catch (error: unknown) {
+        console.warn(
+          "[terminal-runtime] supervised health unavailable:",
+          error instanceof Error ? error.message : String(error),
+        );
+        return { ok: false, code: "zellij_failed" };
+      }
+    },
+    async listSessions() {
+      const projections = await options.runtime.list();
+      byName.clear();
+      const live: string[] = [];
+      for (const projection of projections) {
+        remember(projection);
+        if (
+          projection.displayName &&
+          ["starting", "live", "recovering"].includes(projection.lifecycleState)
+        ) {
+          live.push(projection.displayName);
+        }
+      }
+      return live;
+    },
+    async focusedPaneCwd(name) {
+      return await options.zellij.focusedPaneCwd(await mappedName(name));
+    },
+    async createSession(input: CreateSessionOptions) {
+      if (input.layout || input.cmd) {
+        throw new Error("terminal_supervised_launch_unsupported");
+      }
+      remember(await options.runtime.createShell({
+        displayName: input.name,
+        ...(input.cwd ? { cwd: input.cwd } : {}),
+      }));
+    },
+    async deleteSession(name) {
+      const projection = await resolveName(name);
+      await options.runtime.delete(projection.runtimeId);
+      if (projection.displayName) byName.delete(projection.displayName);
+    },
+    async renameSession(name, nextName) {
+      const projection = await resolveName(name);
+      if (!projection.metadataRevision) {
+        throw new Error("terminal_metadata_unavailable");
+      }
+      const renamed = await options.runtime.rename({
+        runtimeId: projection.runtimeId,
+        displayName: nextName,
+        baseRevision: projection.metadataRevision,
+      });
+      if (projection.displayName) byName.delete(projection.displayName);
+      remember(renamed);
+    },
+    async validateLayout(path) {
+      await options.zellij.validateLayout(path);
+    },
+    attachSession(name: string, attachOptions: AttachOptions = {}) {
+      return options.zellij.attachSession(
+        zellijIdentity(resolved(name).runtimeId),
+        attachOptions,
+      );
+    },
+    async sendInput(name, data) {
+      await options.zellij.sendInput(await mappedName(name), data);
+    },
+    async listTabs(name) {
+      return await options.zellij.listTabs(await mappedName(name));
+    },
+    async createTab(name, input) {
+      return await options.zellij.createTab(await mappedName(name), input);
+    },
+    async switchTab(name, tab) {
+      return await options.zellij.switchTab(await mappedName(name), tab);
+    },
+    async closeTab(name, tab) {
+      return await options.zellij.closeTab(await mappedName(name), tab);
+    },
+    async splitPane(name, input) {
+      return await options.zellij.splitPane(await mappedName(name), input);
+    },
+    async closePane(name, pane) {
+      return await options.zellij.closePane(await mappedName(name), pane);
+    },
+    async applyLayout(name, layout) {
+      return await options.zellij.applyLayout(await mappedName(name), layout);
+    },
+    async dumpLayout(name) {
+      return await options.zellij.dumpLayout(await mappedName(name));
+    },
+    async setShellTheme(themeId) {
+      await options.zellij.setShellTheme(themeId);
+    },
+  };
+}

--- a/packages/gateway/src/shell/ws.ts
+++ b/packages/gateway/src/shell/ws.ts
@@ -54,7 +54,12 @@ export interface ShellWsSocket {
 }
 
 interface ShellWsRegistry {
-  list(): Promise<Array<{ name: string; status?: "active" | "exited"; canonicalSize?: TerminalSize | null }>>;
+  list(): Promise<Array<{
+    name: string;
+    status?: "active" | "exited";
+    canonicalSize?: TerminalSize | null;
+    runtimeId?: string;
+  }>>;
 }
 
 interface ShellWsAdapter {
@@ -381,7 +386,7 @@ export function createShellWsHandler(options: ShellWsHandlerOptions) {
     attachPromise = (async () => {
       const abortController = new AbortController();
       let child: ShellAttachProcess | null = null;
-      const outputCompat = await createSeededOutputCompat(safeName, replayBuffer);
+      const outputCompat = await createSeededOutputCompat(runtime.name, replayBuffer);
       if (!canUseAttachPromise(runtime, attachPromise)) {
         return false;
       }
@@ -577,7 +582,10 @@ export function createShellWsHandler(options: ShellWsHandlerOptions) {
       return { onMessage: () => undefined, onClose: () => undefined };
     }
 
-    const runtime = runtimeFor(safeName);
+    const runtimeIdentity = info.runtimeId
+      ? `matrix-t-${info.runtimeId}`
+      : safeName;
+    const runtime = runtimeFor(runtimeIdentity);
     if (!runtime) {
       sendJson(ws, { type: "error", code: "session_capacity", message: "Too many active sessions" });
       ws.close?.();

--- a/packages/gateway/src/shell/zellij.ts
+++ b/packages/gateway/src/shell/zellij.ts
@@ -89,6 +89,13 @@ export interface AttachOptions {
 }
 
 export interface ZellijAdapter {
+  runtimeProjection?(name: string): {
+    runtimeId: string;
+    lifecycleState: string;
+    recoverable: boolean;
+    recoveryReason: string | null;
+    metadataRevision?: number;
+  } | null;
   health(): Promise<{ ok: boolean; code: "ok" | "zellij_failed" }>;
   listSessions(): Promise<string[]>;
   focusedPaneCwd(name: string): Promise<string | null>;
@@ -138,6 +145,9 @@ const SAFE_ATTACH_ENV_KEYS = new Set([
   "USER",
   "WAYLAND_DISPLAY",
   "XAUTHORITY",
+  "XDG_CACHE_HOME",
+  "XDG_CONFIG_HOME",
+  "XDG_DATA_HOME",
   "XDG_RUNTIME_DIR",
 ]);
 

--- a/packages/gateway/src/supervised-zellij-runtime.ts
+++ b/packages/gateway/src/supervised-zellij-runtime.ts
@@ -1,0 +1,176 @@
+import { resolve } from "node:path";
+import {
+  RuntimeIdSchema,
+  createAgentConfigurationStore,
+  type AgentConfiguration,
+} from "@matrix-os/terminal-runtime";
+import type { AgentLaunchSpec } from "./agent-launcher.js";
+import type {
+  GatewayTerminalRuntimeClient,
+  GatewayTerminalRuntimeProjection,
+} from "./shell/runtime-client.js";
+import type { ZellijAdapter } from "./shell/zellij.js";
+import type {
+  ZellijHealth,
+  ZellijStartResult,
+} from "./zellij-runtime.js";
+
+const MAX_RUNTIME_CACHE_ENTRIES = 2_048;
+const AGENT_LAYOUT_PATH =
+  "/opt/matrix/libexec/terminal-runtime/current/agent-layout.kdl";
+const SHELL_LAYOUT_PATH =
+  "/opt/matrix/libexec/terminal-runtime/current/layout.kdl";
+
+type AgentConfigurationStore = {
+  publish(
+    configurationRef: string,
+    configuration: AgentConfiguration,
+  ): Promise<void>;
+  remove(configurationRef: string): Promise<void>;
+};
+
+function zellijIdentity(runtimeId: string): string {
+  return `matrix-t-${RuntimeIdSchema.parse(runtimeId)}`;
+}
+
+export function createSupervisedZellijRuntime(options: {
+  homePath: string;
+  runtime: GatewayTerminalRuntimeClient;
+  zellij: ZellijAdapter;
+  configurations?: AgentConfigurationStore;
+}) {
+  const homePath = resolve(options.homePath);
+  const configurations =
+    options.configurations ?? createAgentConfigurationStore();
+  const bySessionId = new Map<string, GatewayTerminalRuntimeProjection>();
+
+  function remember(
+    sessionId: string,
+    projection: GatewayTerminalRuntimeProjection,
+  ): void {
+    bySessionId.delete(sessionId);
+    while (bySessionId.size >= MAX_RUNTIME_CACHE_ENTRIES) {
+      const oldest = bySessionId.keys().next().value as string | undefined;
+      if (!oldest) break;
+      bySessionId.delete(oldest);
+    }
+    bySessionId.set(sessionId, projection);
+  }
+
+  async function projectionFor(
+    sessionId: string,
+  ): Promise<GatewayTerminalRuntimeProjection> {
+    const cached = bySessionId.get(sessionId);
+    if (cached) return cached;
+    const projection = (await options.runtime.list())
+      .find((candidate) => candidate.displayName === sessionId);
+    if (!projection) throw new Error("terminal_runtime_not_resolved");
+    remember(sessionId, projection);
+    return projection;
+  }
+
+  function cachedIdentity(sessionId: string): string {
+    const projection = bySessionId.get(sessionId);
+    if (!projection) throw new Error("terminal_runtime_not_resolved");
+    return zellijIdentity(projection.runtimeId);
+  }
+
+  return {
+    async start(input: {
+      sessionId: string;
+      launch: AgentLaunchSpec;
+    }): Promise<ZellijStartResult> {
+      let projection: GatewayTerminalRuntimeProjection;
+      if (input.launch.supervised) {
+        const { configurationRef, configuration } = input.launch.supervised;
+        await configurations.publish(configurationRef, configuration);
+        try {
+          projection = await options.runtime.createAgent({
+            displayName: input.sessionId,
+            cwd: input.launch.cwd,
+            configurationRef,
+          });
+        } catch (error: unknown) {
+          await configurations.remove(configurationRef).catch(
+            (cleanupError: unknown) => {
+              console.warn(
+                "[terminal-runtime] agent configuration cleanup failed:",
+                cleanupError instanceof Error
+                  ? cleanupError.message
+                  : String(cleanupError),
+              );
+            },
+          );
+          throw error;
+        }
+      } else {
+        projection = await options.runtime.createShell({
+          displayName: input.sessionId,
+          cwd: input.launch.cwd,
+        });
+      }
+      remember(input.sessionId, projection);
+      return {
+        ok: true,
+        status: projection.lifecycleState === "live" ? "running" : "starting",
+        sessionName: zellijIdentity(projection.runtimeId),
+        runtimeId: projection.runtimeId,
+        layoutPath: input.launch.supervised
+          ? AGENT_LAYOUT_PATH
+          : SHELL_LAYOUT_PATH,
+      };
+    },
+    attachCommand(sessionId: string): string[] {
+      return ["zellij", "attach", cachedIdentity(sessionId)];
+    },
+    observeCommand(sessionId: string): string[] {
+      return [
+        "zellij",
+        "attach",
+        cachedIdentity(sessionId),
+        "--index",
+        "0",
+      ];
+    },
+    async sendInput(
+      sessionId: string,
+      input: string,
+      _signal?: AbortSignal,
+    ): Promise<void> {
+      const projection = await projectionFor(sessionId);
+      await options.zellij.sendInput(
+        zellijIdentity(projection.runtimeId),
+        input,
+      );
+    },
+    async kill(sessionId: string): Promise<{ ok: true }> {
+      const projection = await projectionFor(sessionId);
+      await options.runtime.delete(projection.runtimeId);
+      bySessionId.delete(sessionId);
+      return { ok: true };
+    },
+    async health(): Promise<ZellijHealth> {
+      try {
+        await options.runtime.list();
+        return {
+          available: true,
+          status: "ok",
+          fallbackReason: null,
+          version: null,
+        };
+      } catch (error: unknown) {
+        console.warn(
+          "[terminal-runtime] workspace runtime health failed:",
+          error instanceof Error ? error.message : String(error),
+        );
+        return {
+          available: false,
+          status: "degraded",
+          fallbackReason: "supervisor_unavailable",
+          version: null,
+        };
+      }
+    },
+    homePath,
+  };
+}

--- a/packages/gateway/src/workspace-routes.ts
+++ b/packages/gateway/src/workspace-routes.ts
@@ -29,7 +29,15 @@ type AgentLauncher = ReturnType<typeof createAgentLauncher>;
 type AgentSessionManager = ReturnType<typeof createAgentSessionManager>;
 type AgentSandbox = ReturnType<typeof createAgentSandbox>;
 type SessionRuntimeBridge = ReturnType<typeof createSessionRuntimeBridge>;
-type ZellijRuntime = ReturnType<typeof createZellijRuntime>;
+type ZellijRuntime = Pick<
+  ReturnType<typeof createZellijRuntime>,
+  | "start"
+  | "attachCommand"
+  | "observeCommand"
+  | "sendInput"
+  | "kill"
+  | "health"
+>;
 type ReviewStore = ReturnType<typeof createReviewStore>;
 type TaskManager = ReturnType<typeof createTaskManager>;
 type PreviewManager = ReturnType<typeof createPreviewManager>;

--- a/packages/gateway/src/workspace-startup-recovery.ts
+++ b/packages/gateway/src/workspace-startup-recovery.ts
@@ -212,19 +212,22 @@ export async function runWorkspaceStartupRecovery(
 export function createWorkspaceStartupRecovery(options: {
   homePath: string;
   eventPublisher?: WorkspaceStartupRecoveryDeps["eventPublisher"];
+  agentSessionManager?: WorkspaceStartupRecoveryDeps["agentSessionManager"];
 }) {
   const homePath = resolve(options.homePath);
   const stateOps = createStateOps({ homePath });
   const projectManager = createProjectManager({ homePath });
   const worktreeManager = createWorktreeManager({ homePath });
-  const agentLauncher = createAgentLauncher({ cwd: homePath });
-  const zellijRuntime = createZellijRuntime({ homePath });
-  const agentSessionManager = createAgentSessionManager({
-    homePath,
-    worktreeManager,
-    agentLauncher,
-    zellijRuntime,
-  });
+  const agentSessionManager = options.agentSessionManager ?? (() => {
+    const agentLauncher = createAgentLauncher({ cwd: homePath });
+    const zellijRuntime = createZellijRuntime({ homePath });
+    return createAgentSessionManager({
+      homePath,
+      worktreeManager,
+      agentLauncher,
+      zellijRuntime,
+    });
+  })();
 
   return {
     run: () => runWorkspaceStartupRecovery({

--- a/packages/gateway/src/zellij-runtime.ts
+++ b/packages/gateway/src/zellij-runtime.ts
@@ -47,7 +47,8 @@ export interface ZellijLayoutResult {
 
 export interface ZellijStartResult extends ZellijLayoutResult {
   ok: true;
-  status: "running";
+  status: "starting" | "running";
+  runtimeId?: string;
 }
 
 export interface ZellijHealth {

--- a/packages/terminal-runtime/assets/agent-layout.kdl
+++ b/packages/terminal-runtime/assets/agent-layout.kdl
@@ -1,0 +1,5 @@
+layout {
+    pane command="/opt/matrix/bin/matrix-terminal-pane" {
+        args "agent"
+    }
+}

--- a/packages/terminal-runtime/src/agent-configurations.ts
+++ b/packages/terminal-runtime/src/agent-configurations.ts
@@ -1,0 +1,151 @@
+import {
+  constants,
+  type FileHandle,
+  lstat,
+  mkdir,
+  open,
+  readdir,
+  rm,
+  unlink,
+} from 'node:fs/promises';
+import { join, resolve } from 'node:path';
+import {
+  AgentConfigurationSchema,
+  OperationIdSchema,
+  type AgentConfiguration,
+} from './contracts.js';
+
+export const MAX_AGENT_CONFIGURATION_BYTES = 128 * 1024;
+export const MAX_PENDING_AGENT_CONFIGURATIONS = 128;
+export const AGENT_CONFIGURATION_TTL_MS = 10 * 60 * 1_000;
+
+async function closeWithLog(handle: FileHandle | null): Promise<void> {
+  if (!handle) return;
+  try {
+    await handle.close();
+  } catch (error: unknown) {
+    console.warn(
+      '[terminal-runtime] agent configuration close failed:',
+      error instanceof Error ? error.message : String(error),
+    );
+  }
+}
+
+export function defaultAgentConfigurationDirectory(
+  uid = process.getuid?.() ?? 1000,
+): string {
+  return `/run/user/${uid}/matrix-terminal-agent-config`;
+}
+
+export function createAgentConfigurationStore(options: {
+  directory?: string;
+  now?: () => number;
+} = {}) {
+  const directory = resolve(
+    options.directory ?? defaultAgentConfigurationDirectory(),
+  );
+  const now = options.now ?? Date.now;
+
+  async function ensureDirectory(): Promise<void> {
+    await mkdir(directory, { recursive: true, mode: 0o700 });
+  }
+
+  async function sweep(): Promise<void> {
+    await ensureDirectory();
+    const entries = await readdir(directory);
+    for (let index = 0; index < entries.length; index += 32) {
+      await Promise.all(entries.slice(index, index + 32).map(async (entry) => {
+        const path = join(directory, entry);
+        try {
+          const stat = await lstat(path);
+          if (
+            stat.isSymbolicLink() ||
+            stat.isFile() && (
+              !OperationIdSchema.safeParse(entry).success ||
+              stat.nlink !== 1 ||
+              now() - stat.mtimeMs > AGENT_CONFIGURATION_TTL_MS
+            )
+          ) {
+            await unlink(path);
+          }
+        } catch (error: unknown) {
+          if (!(error instanceof Error && 'code' in error && error.code === 'ENOENT')) {
+            console.warn(
+              '[terminal-runtime] agent configuration sweep failed:',
+              error instanceof Error ? error.message : String(error),
+            );
+          }
+        }
+      }));
+    }
+  }
+
+  function pathFor(configurationRef: string): string {
+    return join(directory, OperationIdSchema.parse(configurationRef));
+  }
+
+  return {
+    async publish(
+      configurationRef: string,
+      configurationInput: AgentConfiguration,
+    ): Promise<void> {
+      const configuration = AgentConfigurationSchema.parse(configurationInput);
+      const bytes = Buffer.from(JSON.stringify(configuration), 'utf8');
+      if (bytes.byteLength > MAX_AGENT_CONFIGURATION_BYTES) {
+        throw new Error('agent_configuration_too_large');
+      }
+      await sweep();
+      const entries = await readdir(directory);
+      if (entries.filter((entry) => OperationIdSchema.safeParse(entry).success)
+        .length >= MAX_PENDING_AGENT_CONFIGURATIONS) {
+        throw new Error('agent_configuration_capacity');
+      }
+      const path = pathFor(configurationRef);
+      let handle: FileHandle | null = null;
+      try {
+        handle = await open(path, 'wx', 0o600);
+        await handle.writeFile(bytes);
+        await handle.sync();
+      } finally {
+        await closeWithLog(handle);
+      }
+    },
+    async claim(configurationRef: string): Promise<AgentConfiguration> {
+      await ensureDirectory();
+      const path = pathFor(configurationRef);
+      let handle: FileHandle | null = null;
+      try {
+        const before = await lstat(path);
+        if (!before.isFile() || before.isSymbolicLink() || before.nlink !== 1) {
+          throw new Error('agent_configuration_invalid');
+        }
+        handle = await open(path, constants.O_RDONLY | constants.O_NOFOLLOW);
+        const stat = await handle.stat();
+        if (
+          !stat.isFile() ||
+          stat.nlink !== 1 ||
+          stat.size > MAX_AGENT_CONFIGURATION_BYTES
+        ) {
+          throw new Error('agent_configuration_invalid');
+        }
+        const bytes = await handle.readFile();
+        if (bytes.byteLength > MAX_AGENT_CONFIGURATION_BYTES) {
+          throw new Error('agent_configuration_invalid');
+        }
+        const value: unknown = JSON.parse(bytes.toString('utf8'));
+        const configuration = AgentConfigurationSchema.parse(value);
+        await unlink(path);
+        return configuration;
+      } catch (error: unknown) {
+        await rm(path, { force: true });
+        throw error;
+      } finally {
+        await closeWithLog(handle);
+      }
+    },
+    async remove(configurationRef: string): Promise<void> {
+      await rm(pathFor(configurationRef), { force: true });
+    },
+    sweep,
+  };
+}

--- a/packages/terminal-runtime/src/contracts.ts
+++ b/packages/terminal-runtime/src/contracts.ts
@@ -32,6 +32,25 @@ export const LaunchDataSchema = z.discriminatedUnion('kind', [
     configurationRef: OperationIdSchema,
   }).strict(),
 ]);
+export const AgentProviderSchema = z.enum(['claude', 'codex', 'opencode', 'pi']);
+const AgentConfigurationSandboxSchema = z.object({
+  enabled: z.boolean(),
+  mode: z.enum(['read-only', 'workspace-write', 'danger-full-access']).optional(),
+  writableRoots: z.array(HomeRelativeCwdSchema).max(20),
+  denyWriteRoots: z.array(HomeRelativeCwdSchema).max(20),
+  adminOverride: z.boolean().optional(),
+}).strict();
+export const AgentConfigurationSchema = z.object({
+  schemaVersion: z.literal(1),
+  agent: AgentProviderSchema,
+  cwd: HomeRelativeCwdSchema,
+  prompt: z.string().min(1).max(64 * 1024).optional(),
+  mode: z.enum(['default', 'plan', 'review', 'full_access']),
+  approvalPolicy: z.enum(['untrusted', 'on-request', 'on-failure', 'never']),
+  sandbox: AgentConfigurationSandboxSchema,
+  providerEventPath: HomeRelativePathSchema.optional(),
+  codexExpectedVersion: z.string().regex(/^\d+\.\d+\.\d+$/).optional(),
+}).strict();
 export const ReceiptSchema = z.object({
   schemaVersion: z.literal(1),
   runtimeId: RuntimeIdSchema,
@@ -164,6 +183,7 @@ export type Receipt = z.infer<typeof ReceiptSchema>;
 export type NameIndex = z.infer<typeof NameIndexSchema>;
 export type OperationRecord = z.infer<typeof OperationRecordSchema>;
 export type Descriptor = z.infer<typeof DescriptorSchema>;
+export type AgentConfiguration = z.infer<typeof AgentConfigurationSchema>;
 export type HomeRelativeCwd = z.infer<typeof HomeRelativeCwdSchema>;
 export type ProtocolRequest = z.infer<typeof ProtocolRequestSchema>;
 export type ProtocolResponse = z.infer<typeof ProtocolResponseSchema>;

--- a/packages/terminal-runtime/src/contracts.ts
+++ b/packages/terminal-runtime/src/contracts.ts
@@ -33,6 +33,11 @@ export const LaunchDataSchema = z.discriminatedUnion('kind', [
   }).strict(),
 ]);
 export const AgentProviderSchema = z.enum(['claude', 'codex', 'opencode', 'pi']);
+export const AgentExecutablePathSchema = z.string()
+  .trim()
+  .min(1)
+  .max(4096)
+  .regex(/^\/[^\u0000\r\n]+$/);
 const AgentConfigurationSandboxSchema = z.object({
   enabled: z.boolean(),
   mode: z.enum(['read-only', 'workspace-write', 'danger-full-access']).optional(),
@@ -50,6 +55,7 @@ export const AgentConfigurationSchema = z.object({
   sandbox: AgentConfigurationSandboxSchema,
   providerEventPath: HomeRelativePathSchema.optional(),
   codexExpectedVersion: z.string().regex(/^\d+\.\d+\.\d+$/).optional(),
+  codexExecutable: AgentExecutablePathSchema.optional(),
 }).strict();
 export const ReceiptSchema = z.object({
   schemaVersion: z.literal(1),

--- a/packages/terminal-runtime/src/index.ts
+++ b/packages/terminal-runtime/src/index.ts
@@ -2,3 +2,4 @@ export * from './client.js'; export * from './contracts.js'; export * from './de
 export * from './operation-handler.js'; export * from './receipts.js'; export * from './reconciliation.js'; export * from './runtime-state.js'; export * from './storage.js';
 export * from './keeper.js'; export * from './supervisor.js'; export * from './systemd.js';
 export * from './keeper-client.js'; export * from './pane.js';
+export * from './agent-configurations.js';

--- a/packages/terminal-runtime/src/keeper.ts
+++ b/packages/terminal-runtime/src/keeper.ts
@@ -14,6 +14,8 @@ import {
 import { claimKeeperDescriptor } from './keeper-client.js';
 
 const KEEPER_LAYOUT = '/opt/matrix/libexec/terminal-runtime/current/layout.kdl';
+const AGENT_LAYOUT =
+  '/opt/matrix/libexec/terminal-runtime/current/agent-layout.kdl';
 const ZELLIJ_CONFIG =
   '/opt/matrix/libexec/terminal-runtime/current/config.kdl';
 const ZELLIJ = '/opt/matrix/bin/zellij';
@@ -82,7 +84,7 @@ export function keeperEnvironment(
   return {
     HOME: home,
     MATRIX_HOME: home,
-    PATH: '/opt/matrix/bin:/opt/matrix/runtime/node/bin:/usr/bin:/bin',
+    PATH: `${home}/.local/bin:/opt/matrix/bin:/opt/matrix/runtime/node/bin:/usr/bin:/bin`,
     LANG: 'C.UTF-8',
     TERM: 'xterm-256color',
     XDG_CACHE_HOME: join(stateRoot, 'zellij-cache'),
@@ -100,6 +102,11 @@ export function buildKeeperLaunch(
 ): KeeperLaunch {
   const descriptor = DescriptorSchema.parse(rawDescriptor);
   const sessionName = `matrix-t-${descriptor.runtimeId}`;
+  const environment = keeperEnvironment(home);
+  if (descriptor.launch.kind === 'agent') {
+    environment.MATRIX_TERMINAL_CONFIGURATION_REF =
+      descriptor.launch.configurationRef;
+  }
   return {
     file: ZELLIJ,
     args: descriptor.intent === 'recover'
@@ -108,10 +115,10 @@ export function buildKeeperLaunch(
           '--session',
           sessionName,
           '--new-session-with-layout',
-          KEEPER_LAYOUT,
+          descriptor.launch.kind === 'agent' ? AGENT_LAYOUT : KEEPER_LAYOUT,
         ],
     cwd: ownerPath(home, descriptor.cwd.path),
-    env: keeperEnvironment(home),
+    env: environment,
   };
 }
 
@@ -226,7 +233,10 @@ async function cgroupRoles(
     .filter((entry) =>
       entry.comm === 'zellij' && !entry.args.includes('list-sessions'))
     .sort((left, right) => left.pid - right.pid);
-  const shell = processes.find((entry) => entry.comm === 'bash');
+  const shell = processes.find((entry) =>
+    entry.comm === 'bash' ||
+    entry.args.some((argument) => argument.endsWith('/pane.js')) &&
+      entry.args.includes('agent'));
   if (!keeper || zellij.length < 2 || (requireShell && !shell)) return null;
   return {
     keeper: keeper.pid,

--- a/packages/terminal-runtime/src/pane.ts
+++ b/packages/terminal-runtime/src/pane.ts
@@ -62,6 +62,9 @@ function claudePermissionMode(
   if (configuration.mode === 'plan' || configuration.mode === 'review') {
     return 'plan';
   }
+  if (configuration.approvalPolicy === 'on-failure') {
+    throw new Error('claude_approval_policy_unsupported');
+  }
   if (
     configuration.approvalPolicy === 'never' &&
     (
@@ -151,6 +154,9 @@ export function buildProviderLaunch(
         env: environment,
         stdin: null,
         fdPayload: JSON.stringify({
+          ...(configuration.codexExecutable
+            ? { command: configuration.codexExecutable }
+            : {}),
           eventPath: ownerPath(home, configuration.providerEventPath),
           expectedVersion: configuration.codexExpectedVersion,
           config: {

--- a/packages/terminal-runtime/src/pane.ts
+++ b/packages/terminal-runtime/src/pane.ts
@@ -1,4 +1,13 @@
 import { spawn } from 'node:child_process';
+import { resolve, sep } from 'node:path';
+import {
+  AgentConfigurationSchema,
+  OperationIdSchema,
+  type AgentConfiguration,
+} from './contracts.js';
+import {
+  createAgentConfigurationStore,
+} from './agent-configurations.js';
 
 const SAFE_ENVIRONMENT_KEYS = [
   'HOME',
@@ -7,6 +16,18 @@ const SAFE_ENVIRONMENT_KEYS = [
   'PATH',
   'TERM',
 ] as const;
+const DEFAULT_HOME = '/home/matrix/home';
+const CODEX_RUNNER =
+  '/opt/matrix/libexec/terminal-runtime/current/codex-app-server-runner.mjs';
+
+export type ProviderLaunch = {
+  file: string;
+  args: string[];
+  cwd: string;
+  env: Record<string, string>;
+  stdin: string | null;
+  fdPayload: string | null;
+};
 
 export function paneEnvironment(
   source: NodeJS.ProcessEnv = process.env,
@@ -19,21 +40,212 @@ export function paneEnvironment(
   return environment;
 }
 
+function ownerPath(home: string, relativePath: string): string {
+  const root = resolve(home);
+  const target = resolve(root, relativePath);
+  if (target !== root && !target.startsWith(`${root}${sep}`)) {
+    throw new Error('agent_cwd_invalid');
+  }
+  return target;
+}
+
+function absoluteRoots(
+  roots: AgentConfiguration['sandbox']['writableRoots'],
+  home: string,
+): string[] {
+  return roots.map((root) => ownerPath(home, root.path));
+}
+
+function claudePermissionMode(
+  configuration: AgentConfiguration,
+): 'default' | 'dontAsk' | 'plan' | 'bypassPermissions' {
+  if (configuration.mode === 'plan' || configuration.mode === 'review') {
+    return 'plan';
+  }
+  if (
+    configuration.approvalPolicy === 'never' &&
+    (
+      configuration.sandbox.mode === 'danger-full-access' ||
+      !configuration.sandbox.enabled
+    )
+  ) {
+    return 'bypassPermissions';
+  }
+  if (
+    configuration.sandbox.enabled &&
+    configuration.sandbox.mode !== 'danger-full-access' &&
+    ['on-request', 'never'].includes(configuration.approvalPolicy)
+  ) {
+    return 'dontAsk';
+  }
+  return 'default';
+}
+
+function claudeSettings(
+  configuration: AgentConfiguration,
+  home: string,
+): Record<string, unknown> {
+  return {
+    permissions: {
+      defaultMode: claudePermissionMode(configuration),
+    },
+    sandbox: {
+      enabled: configuration.sandbox.enabled,
+      failIfUnavailable: configuration.sandbox.enabled,
+      allowUnsandboxedCommands: false,
+      filesystem: {
+        allowWrite: absoluteRoots(
+          configuration.sandbox.writableRoots,
+          home,
+        ),
+        denyWrite: absoluteRoots(
+          configuration.sandbox.denyWriteRoots,
+          home,
+        ),
+      },
+    },
+  };
+}
+
+export function buildProviderLaunch(
+  rawConfiguration: AgentConfiguration,
+  home = DEFAULT_HOME,
+): ProviderLaunch {
+  const configuration = AgentConfigurationSchema.parse(rawConfiguration);
+  const cwd = ownerPath(home, configuration.cwd.path);
+  const environment = paneEnvironment({
+    ...process.env,
+    HOME: home,
+    MATRIX_HOME: home,
+  });
+  switch (configuration.agent) {
+    case 'claude':
+      return {
+        file: 'claude',
+        args: [
+          '--setting-sources',
+          '',
+          '--settings',
+          '/proc/self/fd/3',
+          '--strict-mcp-config',
+          '--no-chrome',
+          ...(configuration.prompt ? ['--print'] : []),
+        ],
+        cwd,
+        env: environment,
+        stdin: configuration.prompt ?? null,
+        fdPayload: JSON.stringify(claudeSettings(configuration, home)),
+      };
+    case 'codex': {
+      if (
+        !configuration.prompt ||
+        !configuration.providerEventPath ||
+        !configuration.codexExpectedVersion
+      ) {
+        throw new Error('codex_configuration_invalid');
+      }
+      return {
+        file: process.execPath,
+        args: [CODEX_RUNNER, '--fd-config'],
+        cwd,
+        env: environment,
+        stdin: null,
+        fdPayload: JSON.stringify({
+          eventPath: ownerPath(home, configuration.providerEventPath),
+          expectedVersion: configuration.codexExpectedVersion,
+          config: {
+            prompt: configuration.prompt,
+            approvalPolicy: configuration.approvalPolicy === 'on-failure'
+              ? 'on-request'
+              : configuration.approvalPolicy,
+            sandbox: configuration.sandbox.enabled
+              ? configuration.sandbox.mode ?? 'workspace-write'
+              : 'danger-full-access',
+            writableRoots: absoluteRoots(
+              configuration.sandbox.writableRoots,
+              home,
+            ),
+          },
+        }),
+      };
+    }
+    case 'opencode':
+      return {
+        file: 'opencode',
+        args: ['run'],
+        cwd,
+        env: environment,
+        stdin: configuration.prompt ?? null,
+        fdPayload: JSON.stringify(configuration),
+      };
+    case 'pi':
+      return {
+        file: 'pi',
+        args: [],
+        cwd,
+        env: environment,
+        stdin: configuration.prompt ?? null,
+        fdPayload: JSON.stringify(configuration),
+      };
+  }
+}
+
+async function waitForChild(
+  launch: ProviderLaunch,
+  spawnChild = spawn,
+): Promise<number> {
+  return await new Promise<number>((resolveChild, rejectChild) => {
+    const child = spawnChild(launch.file, launch.args, {
+      cwd: launch.cwd,
+      env: launch.env,
+      shell: false,
+      stdio: [
+        launch.stdin === null ? 'inherit' : 'pipe',
+        'inherit',
+        'inherit',
+        launch.fdPayload === null ? 'ignore' : 'pipe',
+      ],
+    });
+    child.once('error', (error: Error) => rejectChild(error));
+    child.once('exit', (code, signal) => {
+      if (signal !== null) resolveChild(128);
+      else resolveChild(code ?? 1);
+    });
+    if (launch.stdin !== null) child.stdin?.end(launch.stdin);
+    if (launch.fdPayload !== null) {
+      const configurationPipe = child.stdio[3];
+      if (
+        configurationPipe &&
+        'end' in configurationPipe &&
+        typeof configurationPipe.end === 'function'
+      ) {
+        configurationPipe.end(launch.fdPayload);
+      } else {
+        child.kill('SIGTERM');
+        rejectChild(new Error('agent_configuration_pipe_unavailable'));
+      }
+    }
+  });
+}
+
 export async function runPane(kind: string | undefined): Promise<number> {
-  if (kind !== 'shell') return 64;
-  return await new Promise<number>((resolve, reject) => {
-    const child = spawn('/bin/bash', ['--login'], {
+  if (kind === 'shell') {
+    return await waitForChild({
+      file: '/bin/bash',
+      args: ['--login'],
       cwd: process.cwd(),
       env: paneEnvironment(),
-      shell: false,
-      stdio: 'inherit',
+      stdin: null,
+      fdPayload: null,
     });
-    child.once('error', (error: Error) => reject(error));
-    child.once('exit', (code, signal) => {
-      if (signal !== null) resolve(128);
-      else resolve(code ?? 1);
-    });
-  });
+  }
+  if (kind !== 'agent') return 64;
+  const configurationRef = OperationIdSchema.parse(
+    process.env.MATRIX_TERMINAL_CONFIGURATION_REF,
+  );
+  const store = createAgentConfigurationStore();
+  const configuration = await store.claim(configurationRef);
+  return await waitForChild(buildProviderLaunch(configuration));
 }
 
 if (process.argv[1]?.endsWith('/pane.js')) {

--- a/packages/terminal-runtime/src/pane.ts
+++ b/packages/terminal-runtime/src/pane.ts
@@ -59,11 +59,11 @@ function absoluteRoots(
 function claudePermissionMode(
   configuration: AgentConfiguration,
 ): 'default' | 'dontAsk' | 'plan' | 'bypassPermissions' {
-  if (configuration.mode === 'plan' || configuration.mode === 'review') {
-    return 'plan';
-  }
   if (configuration.approvalPolicy === 'on-failure') {
     throw new Error('claude_approval_policy_unsupported');
+  }
+  if (configuration.mode === 'plan' || configuration.mode === 'review') {
+    return 'plan';
   }
   if (
     configuration.approvalPolicy === 'never' &&

--- a/packages/terminal-runtime/src/systemd.ts
+++ b/packages/terminal-runtime/src/systemd.ts
@@ -37,7 +37,10 @@ export function classifyRuntimeProcesses(
       process.args.some((argument) => argument.endsWith('/keeper.js'))),
     zellijClient: zellij.length >= 2,
     zellijServer: zellij.length >= 2,
-    shell: processes.some((process) => process.comm === 'bash'),
+    shell: processes.some((process) =>
+      process.comm === 'bash' ||
+      process.args.some((argument) => argument.endsWith('/pane.js')) &&
+        process.args.includes('agent')),
   };
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -519,6 +519,9 @@ importers:
       '@matrix-os/observability':
         specifier: workspace:*
         version: link:../observability
+      '@matrix-os/terminal-runtime':
+        specifier: workspace:*
+        version: link:../terminal-runtime
       '@pipedream/sdk':
         specifier: ^2.4.3
         version: 2.4.3

--- a/scripts/build-host-bundle.sh
+++ b/scripts/build-host-bundle.sh
@@ -114,6 +114,13 @@ install -m 0644 \
 install -m 0644 \
   "$ROOT_DIR/packages/terminal-runtime/assets/layout.kdl" \
   "$terminal_generation_build/layout.kdl"
+install -m 0644 \
+  "$ROOT_DIR/packages/terminal-runtime/assets/agent-layout.kdl" \
+  "$terminal_generation_build/agent-layout.kdl"
+install -m 0755 \
+  "$ROOT_DIR/packages/gateway/src/coding-agents/codex-app-server-runner.mjs" \
+  "$ROOT_DIR/packages/gateway/src/coding-agents/codex-provider-version-check.mjs" \
+  "$terminal_generation_build/"
 cc -std=c11 -Wall -Wextra -Werror -O2 \
   "$ROOT_DIR/packages/terminal-runtime/native/supervisor-acceptor.c" \
   -o "$terminal_generation_build/supervisor-acceptor"

--- a/specs/109-persist-terminal-sessions/tasks.md
+++ b/specs/109-persist-terminal-sessions/tasks.md
@@ -51,14 +51,14 @@
 
 ## Phase 3: User Story 1 — Deployment-Surviving Shell and Agent Runtimes (P1)
 
-- [ ] T026 [P] [US1] Add failing production fail-closed and local direct-spawn tests in `tests/gateway/terminal-runtime-client.test.ts`
-- [ ] T027 [P] [US1] Add failing shell create/list/attach/delete immutable-runtime integration tests in `tests/gateway/shell-terminal-runtime.test.ts`
-- [ ] T028 [P] [US1] Add failing agent stdin/FD launch and sensitive-argv scan tests in `tests/gateway/agent-terminal-runtime.test.ts`
-- [ ] T029 [US1] Inject one compatible runtime client at terminal route registration in `packages/gateway/src/server.ts` and `packages/gateway/src/shell/runtime-client.ts`
-- [ ] T030 [US1] Route production shell creation/list/attach/delete through runtime IDs while retaining local node-pty in `packages/gateway/src/shell/zellij.ts` and `packages/gateway/src/shell/registry.ts`
-- [ ] T031 [US1] Route coding-agent terminal creation and liveness through supervised runtimes in `packages/gateway/src/zellij-runtime.ts` and `packages/gateway/src/agent-session-service.ts`
-- [ ] T032 [US1] Remove prompts/settings/cwd/dynamic options from Matrix-managed provider argv/layouts by using stdin or anonymous FDs in `packages/gateway/src/agent-launcher.ts` and `packages/gateway/src/coding-agents/`
-- [ ] T033 [US1] Preserve attach PTYs in the gateway cgroup and drain only subscribers/attach clients on shutdown in `packages/gateway/src/shell/terminal-websocket.ts` and `packages/gateway/src/server.ts`
+- [X] T026 [P] [US1] Add failing production fail-closed and local direct-spawn tests in `tests/gateway/terminal-runtime-client.test.ts`
+- [X] T027 [P] [US1] Add failing shell create/list/attach/delete immutable-runtime integration tests in `tests/gateway/shell-terminal-runtime.test.ts`
+- [X] T028 [P] [US1] Add failing agent stdin/FD launch and sensitive-argv scan tests in `tests/gateway/agent-terminal-runtime.test.ts`
+- [X] T029 [US1] Inject one compatible runtime client at terminal route registration in `packages/gateway/src/server.ts` and `packages/gateway/src/shell/runtime-client.ts`
+- [X] T030 [US1] Route production shell creation/list/attach/delete through runtime IDs while retaining local node-pty in `packages/gateway/src/shell/zellij.ts` and `packages/gateway/src/shell/registry.ts`
+- [X] T031 [US1] Route coding-agent terminal creation and liveness through supervised runtimes in `packages/gateway/src/zellij-runtime.ts` and `packages/gateway/src/agent-session-service.ts`
+- [X] T032 [US1] Remove prompts/settings/cwd/dynamic options from Matrix-managed provider argv/layouts by using stdin or anonymous FDs in `packages/gateway/src/agent-launcher.ts` and `packages/gateway/src/coding-agents/`
+- [X] T033 [US1] Preserve attach PTYs in the gateway cgroup and drain only subscribers/attach clients on shutdown in `packages/gateway/src/shell/terminal-websocket.ts` and `packages/gateway/src/server.ts`
 
 **Independent test**: gateway crash/restart changes only gateway and attach PIDs; keeper, server, shell, and agent stay unchanged and attachable.
 

--- a/tests/gateway/agent-launcher.test.ts
+++ b/tests/gateway/agent-launcher.test.ts
@@ -253,6 +253,26 @@ describe("agent-launcher", () => {
     ]);
   });
 
+  it("preserves the configured Codex executable in supervised launch configuration", () => {
+    const codexExecutable = "/opt/matrix/runtime/node/bin/codex";
+    const launcher = createAgentLauncher({
+      codexExecutable,
+      terminalRuntimeMode: "supervised",
+      runtimeHome: "/home/matrix/home",
+    });
+
+    const launch = launcher.buildLaunch({
+      agent: "codex",
+      cwd: "/home/matrix/home/projects/repo",
+      prompt: "fix tests",
+      sandbox: { enabled: true, mode: "workspace-write" },
+      providerEventPath: "/home/matrix/home/system/coding-agents/provider-events/sess_bound.jsonl",
+    });
+
+    expect(launch.supervised?.configuration).toMatchObject({ codexExecutable });
+    expect(JSON.stringify([launch.command, ...launch.args])).not.toContain(codexExecutable);
+  });
+
   it("keeps an unverified configured Codex version installed but workspace-incompatible", async () => {
     const codexExecutable = "/opt/matrix/runtime/node/bin/codex";
     const runCommand = vi.fn(async (command: string, args: string[]) => {

--- a/tests/gateway/agent-terminal-runtime.test.ts
+++ b/tests/gateway/agent-terminal-runtime.test.ts
@@ -69,6 +69,21 @@ describe("supervised coding-agent launch", () => {
     expect(SupervisedAgentConfigurationSchema.safeParse(input).success).toBe(false);
   });
 
+  it("hands the selected Codex executable through configuration, never Matrix argv", () => {
+    const codexExecutable = "/opt/matrix/runtime/node/bin/codex";
+    const launch = buildSupervisedAgentLaunch({
+      operationId: OPERATION_ID,
+      agent: "codex",
+      codexExecutable,
+      cwd: "/home/matrix/home/projects/private",
+      prompt: "repair the private project",
+      sandbox: { enabled: true, mode: "workspace-write" },
+    });
+
+    expect(launch.configuration).toMatchObject({ codexExecutable });
+    expect(JSON.stringify(launch.matrixArgv)).not.toContain(codexExecutable);
+  });
+
   it("publishes one configuration before CreateStart and removes it on rejection", async () => {
     const configuration = buildSupervisedAgentLaunch({
       operationId: OPERATION_ID,

--- a/tests/gateway/agent-terminal-runtime.test.ts
+++ b/tests/gateway/agent-terminal-runtime.test.ts
@@ -1,8 +1,9 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
   buildSupervisedAgentLaunch,
   SupervisedAgentConfigurationSchema,
 } from "../../packages/gateway/src/coding-agents/supervised-launch.js";
+import { createSupervisedZellijRuntime } from "../../packages/gateway/src/supervised-zellij-runtime.js";
 
 const OPERATION_ID = "abcdef0123456789abcdef0123456789";
 
@@ -66,5 +67,61 @@ describe("supervised coding-agent launch", () => {
       },
     };
     expect(SupervisedAgentConfigurationSchema.safeParse(input).success).toBe(false);
+  });
+
+  it("publishes one configuration before CreateStart and removes it on rejection", async () => {
+    const configuration = buildSupervisedAgentLaunch({
+      operationId: OPERATION_ID,
+      agent: "claude",
+      cwd: "/home/matrix/home/projects/private",
+      prompt: "private prompt",
+      sandbox: { enabled: true, mode: "workspace-write" },
+    });
+    const configurations = {
+      publish: vi.fn(async () => undefined),
+      remove: vi.fn(async () => undefined),
+    };
+    const runtime = {
+      list: vi.fn(async () => []),
+      inspect: vi.fn(),
+      createShell: vi.fn(),
+      createAgent: vi.fn(async () => {
+        throw new Error("supervisor rejected");
+      }),
+      rename: vi.fn(),
+      delete: vi.fn(),
+    };
+    const zellij = { sendInput: vi.fn() };
+    const supervised = createSupervisedZellijRuntime({
+      homePath: "/home/matrix/home",
+      runtime: runtime as never,
+      zellij: zellij as never,
+      configurations,
+    });
+
+    await expect(supervised.start({
+      sessionId: "sess-private",
+      launch: {
+        command: configuration.matrixArgv[0],
+        args: [configuration.matrixArgv[1]],
+        cwd: "/home/matrix/home/projects/private",
+        env: {},
+        supervised: {
+          configurationRef: OPERATION_ID,
+          configuration: configuration.configuration,
+        },
+      },
+    })).rejects.toThrow("supervisor rejected");
+
+    expect(configurations.publish).toHaveBeenCalledWith(
+      OPERATION_ID,
+      configuration.configuration,
+    );
+    expect(runtime.createAgent).toHaveBeenCalledWith({
+      displayName: "sess-private",
+      cwd: "/home/matrix/home/projects/private",
+      configurationRef: OPERATION_ID,
+    });
+    expect(configurations.remove).toHaveBeenCalledWith(OPERATION_ID);
   });
 });

--- a/tests/gateway/agent-terminal-runtime.test.ts
+++ b/tests/gateway/agent-terminal-runtime.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildSupervisedAgentLaunch,
+  SupervisedAgentConfigurationSchema,
+} from "../../packages/gateway/src/coding-agents/supervised-launch.js";
+
+const OPERATION_ID = "abcdef0123456789abcdef0123456789";
+
+describe("supervised coding-agent launch", () => {
+  it.each(["claude", "codex", "opencode", "pi"] as const)(
+    "keeps %s prompt, cwd, credentials, and dynamic options out of Matrix-managed argv",
+    (agent) => {
+      const prompt = "fix the secret regression";
+      const cwd = "/home/matrix/home/projects/private";
+      const launch = buildSupervisedAgentLaunch({
+        operationId: OPERATION_ID,
+        agent,
+        cwd,
+        prompt,
+        mode: "plan",
+        approvalPolicy: "on-request",
+        sandbox: {
+          enabled: true,
+          mode: "workspace-write",
+          writableRoots: [cwd],
+          denyWriteRoots: ["/home/matrix/home/system"],
+        },
+      });
+
+      expect(launch.descriptor).toEqual({
+        kind: "agent",
+        configurationRef: OPERATION_ID,
+      });
+      expect(launch.matrixArgv).toEqual([
+        "/opt/matrix/bin/matrix-terminal-pane",
+        "agent",
+      ]);
+      expect(JSON.stringify(launch.matrixArgv)).not.toContain(prompt);
+      expect(JSON.stringify(launch.matrixArgv)).not.toContain(cwd);
+      expect(JSON.stringify(launch.matrixArgv)).not.toContain(agent);
+      expect(JSON.stringify(launch.matrixArgv)).not.toContain("on-request");
+      expect(SupervisedAgentConfigurationSchema.parse(launch.configuration)).toMatchObject({
+        schemaVersion: 1,
+        agent,
+        cwd: { kind: "home-relative", path: "projects/private" },
+        prompt,
+        mode: "plan",
+        approvalPolicy: "on-request",
+      });
+    },
+  );
+
+  it("rejects absolute or traversal configuration cwd values", () => {
+    const input = {
+      schemaVersion: 1,
+      agent: "codex",
+      cwd: { kind: "home-relative", path: "../private" },
+      prompt: "safe prompt",
+      mode: "default",
+      approvalPolicy: "never",
+      sandbox: {
+        enabled: true,
+        mode: "workspace-write",
+        writableRoots: [],
+        denyWriteRoots: [],
+      },
+    };
+    expect(SupervisedAgentConfigurationSchema.safeParse(input).success).toBe(false);
+  });
+});

--- a/tests/gateway/shell-terminal-runtime.test.ts
+++ b/tests/gateway/shell-terminal-runtime.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  createSupervisedZellijAdapter,
+  type GatewayTerminalRuntimeClient,
+} from "../../packages/gateway/src/shell/runtime-client.js";
+import type { ZellijAdapter } from "../../packages/gateway/src/shell/zellij.js";
+
+const RUNTIME_ID = "0123456789abcdef0123456789abcdef";
+const LIVE = {
+  runtimeId: RUNTIME_ID,
+  displayName: "calm-otter",
+  lifecycleState: "live" as const,
+  recoverable: false,
+  recoveryReason: null,
+  recoveryMode: null,
+  metadataRevision: 1,
+};
+
+function directAdapter() {
+  const process = {
+    write: vi.fn(),
+    resize: vi.fn(),
+    kill: vi.fn(),
+    onData: vi.fn(() => ({ dispose: vi.fn() })),
+    onExit: vi.fn(() => ({ dispose: vi.fn() })),
+  };
+  const adapter = {
+    health: vi.fn(async () => ({ ok: true as const, code: "ok" as const })),
+    listSessions: vi.fn(async () => []),
+    focusedPaneCwd: vi.fn(async () => null),
+    createSession: vi.fn(async () => undefined),
+    deleteSession: vi.fn(async () => undefined),
+    renameSession: vi.fn(async () => undefined),
+    validateLayout: vi.fn(async () => undefined),
+    attachSession: vi.fn(() => process),
+    sendInput: vi.fn(async () => undefined),
+    listTabs: vi.fn(async () => []),
+    createTab: vi.fn(async () => ({ ok: true })),
+    switchTab: vi.fn(async () => ({ ok: true })),
+    closeTab: vi.fn(async () => ({ ok: true })),
+    splitPane: vi.fn(async () => ({ ok: true })),
+    closePane: vi.fn(async () => ({ ok: true })),
+    applyLayout: vi.fn(async () => ({ ok: true })),
+    dumpLayout: vi.fn(async () => ({ kdl: "" })),
+    setShellTheme: vi.fn(async () => undefined),
+  } satisfies ZellijAdapter;
+  return { adapter, process };
+}
+
+function runtimeClient(): GatewayTerminalRuntimeClient {
+  return {
+    list: vi.fn(async () => [LIVE]),
+    inspect: vi.fn(async () => LIVE),
+    createShell: vi.fn(async () => ({ ...LIVE, lifecycleState: "starting" })),
+    createAgent: vi.fn(async () => ({ ...LIVE, lifecycleState: "starting" })),
+    rename: vi.fn(async () => ({ ...LIVE, displayName: "swift-otter", metadataRevision: 2 })),
+    delete: vi.fn(async () => undefined),
+  };
+}
+
+describe("supervised shell adapter", () => {
+  it("maps display names to immutable runtime identities for attach and input", async () => {
+    const runtime = runtimeClient();
+    const direct = directAdapter();
+    const adapter = createSupervisedZellijAdapter({ runtime, zellij: direct.adapter });
+
+    await expect(adapter.listSessions()).resolves.toEqual(["calm-otter"]);
+    adapter.attachSession("calm-otter");
+    await adapter.sendInput("calm-otter", "hello\r");
+
+    expect(direct.adapter.attachSession).toHaveBeenCalledWith(
+      `matrix-t-${RUNTIME_ID}`,
+      {},
+    );
+    expect(direct.adapter.sendInput).toHaveBeenCalledWith(
+      `matrix-t-${RUNTIME_ID}`,
+      "hello\r",
+    );
+    expect(runtime.createShell).not.toHaveBeenCalled();
+  });
+
+  it("creates and deletes through the supervisor without direct zellij lifecycle calls", async () => {
+    const runtime = runtimeClient();
+    const direct = directAdapter();
+    const adapter = createSupervisedZellijAdapter({ runtime, zellij: direct.adapter });
+
+    await adapter.createSession({ name: "calm-otter", cwd: "/home/matrix/home/projects/example" });
+    await adapter.deleteSession("calm-otter");
+
+    expect(runtime.createShell).toHaveBeenCalledWith({
+      displayName: "calm-otter",
+      cwd: "/home/matrix/home/projects/example",
+    });
+    expect(runtime.delete).toHaveBeenCalledWith(RUNTIME_ID);
+    expect(direct.adapter.createSession).not.toHaveBeenCalled();
+    expect(direct.adapter.deleteSession).not.toHaveBeenCalled();
+  });
+
+  it("renames metadata without changing the zellij identity", async () => {
+    const runtime = runtimeClient();
+    const direct = directAdapter();
+    const adapter = createSupervisedZellijAdapter({ runtime, zellij: direct.adapter });
+    await adapter.listSessions();
+
+    await adapter.renameSession("calm-otter", "swift-otter");
+    adapter.attachSession("swift-otter");
+
+    expect(runtime.rename).toHaveBeenCalledWith({
+      runtimeId: RUNTIME_ID,
+      displayName: "swift-otter",
+      baseRevision: 1,
+    });
+    expect(direct.adapter.renameSession).not.toHaveBeenCalled();
+    expect(direct.adapter.attachSession).toHaveBeenCalledWith(
+      `matrix-t-${RUNTIME_ID}`,
+      {},
+    );
+  });
+
+  it("never creates or recovers while resolving an attach", () => {
+    const runtime = runtimeClient();
+    const direct = directAdapter();
+    const adapter = createSupervisedZellijAdapter({ runtime, zellij: direct.adapter });
+
+    expect(() => adapter.attachSession("missing-session")).toThrow("terminal_runtime_not_resolved");
+    expect(runtime.createShell).not.toHaveBeenCalled();
+    expect(runtime.createAgent).not.toHaveBeenCalled();
+  });
+});

--- a/tests/gateway/terminal-runtime-client.test.ts
+++ b/tests/gateway/terminal-runtime-client.test.ts
@@ -1,0 +1,123 @@
+import { mkdtemp, mkdir, realpath, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { ProtocolRequest, ProtocolResponse, SupervisorClient } from "@matrix-os/terminal-runtime";
+import {
+  initializeGatewayTerminalRuntime,
+  type GatewayTerminalRuntimeClient,
+} from "../../packages/gateway/src/shell/runtime-client.js";
+
+const RUNTIME_ID = "0123456789abcdef0123456789abcdef";
+const roots: string[] = [];
+
+function supervisor(
+  respond: (request: ProtocolRequest) => ProtocolResponse,
+): SupervisorClient {
+  return { request: vi.fn(async (request) => respond(request)) };
+}
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+});
+
+describe("gateway terminal runtime client", () => {
+  it("retains direct spawn when the dormant production mode is legacy", async () => {
+    await expect(initializeGatewayTerminalRuntime({
+      mode: "legacy",
+      nodeEnv: "production",
+      homePath: "/home/matrix/home",
+    })).resolves.toBeNull();
+  });
+
+  it("fails closed when supervised production cannot complete a protocol-v1 List", async () => {
+    const client = supervisor(() => {
+      throw new Error("socket unavailable");
+    });
+
+    await expect(initializeGatewayTerminalRuntime({
+      mode: "supervised",
+      nodeEnv: "production",
+      homePath: "/home/matrix/home",
+      supervisor: client,
+    })).rejects.toThrow("terminal_supervisor_unavailable");
+  });
+
+  it("probes compatibility and sends only validated protocol operations", async () => {
+    const homePath = await mkdtemp(join(tmpdir(), "matrix-terminal-client-"));
+    roots.push(homePath);
+    await mkdir(join(homePath, "projects", "example"), { recursive: true });
+    const request = vi.fn(async (input: ProtocolRequest): Promise<ProtocolResponse> => {
+      if (input.operation === "List") {
+        return {
+          version: 1,
+          ok: true,
+          operationId: input.operationId,
+          result: [],
+        };
+      }
+      if (input.operation === "CreateStart") {
+        return {
+          version: 1,
+          ok: true,
+          operationId: input.operationId,
+          result: { runtimeId: RUNTIME_ID, lifecycleState: "starting" },
+        };
+      }
+      throw new Error("unexpected operation");
+    });
+
+    const runtime = await initializeGatewayTerminalRuntime({
+      mode: "supervised",
+      nodeEnv: "production",
+      homePath,
+      supervisor: { request },
+    });
+    expect(runtime).not.toBeNull();
+    const cwd = await realpath(join(homePath, "projects", "example"));
+    await (runtime as GatewayTerminalRuntimeClient).createShell({
+      displayName: "calm-otter",
+      cwd,
+    });
+
+    expect(request).toHaveBeenNthCalledWith(1, expect.objectContaining({
+      version: 1,
+      operation: "List",
+      input: {},
+    }));
+    expect(request).toHaveBeenNthCalledWith(2, expect.objectContaining({
+      version: 1,
+      operation: "CreateStart",
+      input: {
+        displayName: "calm-otter",
+        cwd: { kind: "home-relative", path: "projects/example" },
+        launch: { kind: "shell" },
+      },
+    }));
+    expect(JSON.stringify(request.mock.calls)).not.toContain(cwd);
+  });
+
+  it("rejects cwd escape before contacting the supervisor", async () => {
+    const homePath = await mkdtemp(join(tmpdir(), "matrix-terminal-client-"));
+    const outside = await mkdtemp(join(tmpdir(), "matrix-terminal-outside-"));
+    roots.push(homePath, outside);
+    const client = supervisor((request) => ({
+      version: 1,
+      ok: true,
+      operationId: request.operationId,
+      result: [],
+    }));
+    const runtime = await initializeGatewayTerminalRuntime({
+      mode: "supervised",
+      nodeEnv: "test",
+      homePath,
+      supervisor: client,
+    });
+
+    await expect(runtime?.createShell({
+      displayName: "calm-otter",
+      cwd: outside,
+    })).rejects.toThrow("terminal_cwd_invalid");
+    expect(client.request).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/terminal-runtime/agent-configurations.test.ts
+++ b/tests/terminal-runtime/agent-configurations.test.ts
@@ -1,4 +1,13 @@
-import { lstat, mkdtemp, readFile, rm, symlink } from 'node:fs/promises';
+import {
+  link,
+  lstat,
+  mkdtemp,
+  readFile,
+  rm,
+  symlink,
+  utimes,
+  writeFile,
+} from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, describe, expect, it } from 'vitest';
@@ -57,5 +66,52 @@ describe('terminal agent configuration store', () => {
       'agent_configuration_invalid',
     );
     await expect(lstat(target)).rejects.toMatchObject({ code: 'ENOENT' });
+  });
+
+  it('rejects a hard link and removes only the untrusted directory entry', async () => {
+    const directory = await mkdtemp(join(tmpdir(), 'matrix-agent-config-'));
+    const target = join(directory, 'target');
+    roots.push(directory);
+    await writeFile(target, JSON.stringify(configuration), { mode: 0o600 });
+    await link(target, join(directory, operationId));
+    const store = createAgentConfigurationStore({ directory });
+
+    await expect(store.claim(operationId)).rejects.toThrow(
+      'agent_configuration_invalid',
+    );
+    await expect(readFile(target, 'utf8')).resolves.toContain('private prompt');
+    await expect(lstat(join(directory, operationId))).rejects.toMatchObject({
+      code: 'ENOENT',
+    });
+  });
+
+  it('sweeps stale and malformed entries without touching a fresh valid entry', async () => {
+    const directory = await mkdtemp(join(tmpdir(), 'matrix-agent-config-'));
+    roots.push(directory);
+    const store = createAgentConfigurationStore({
+      directory,
+      now: () => 20 * 60 * 1_000,
+    });
+    await store.publish(operationId, configuration);
+    const staleId = '11111111111111111111111111111111';
+    await writeFile(
+      join(directory, staleId),
+      JSON.stringify(configuration),
+      { mode: 0o600 },
+    );
+    await utimes(join(directory, staleId), 0, 0);
+    await writeFile(join(directory, 'malformed-entry'), 'untrusted', {
+      mode: 0o600,
+    });
+
+    await store.sweep();
+
+    await expect(lstat(join(directory, operationId))).resolves.toBeTruthy();
+    await expect(lstat(join(directory, staleId))).rejects.toMatchObject({
+      code: 'ENOENT',
+    });
+    await expect(
+      lstat(join(directory, 'malformed-entry')),
+    ).rejects.toMatchObject({ code: 'ENOENT' });
   });
 });

--- a/tests/terminal-runtime/agent-configurations.test.ts
+++ b/tests/terminal-runtime/agent-configurations.test.ts
@@ -1,0 +1,61 @@
+import { lstat, mkdtemp, readFile, rm, symlink } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  createAgentConfigurationStore,
+} from '../../packages/terminal-runtime/src/agent-configurations.js';
+
+const operationId = 'fedcba9876543210fedcba9876543210';
+const roots: string[] = [];
+const configuration = {
+  schemaVersion: 1 as const,
+  agent: 'claude' as const,
+  cwd: { kind: 'home-relative' as const, path: 'projects/example' },
+  prompt: 'private prompt',
+  mode: 'plan' as const,
+  approvalPolicy: 'on-request' as const,
+  sandbox: {
+    enabled: true,
+    mode: 'workspace-write' as const,
+    writableRoots: [
+      { kind: 'home-relative' as const, path: 'projects/example' },
+    ],
+    denyWriteRoots: [],
+  },
+};
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) =>
+    rm(root, { recursive: true, force: true })));
+});
+
+describe('terminal agent configuration store', () => {
+  it('publishes exclusively at 0600 and unlinks immediately on claim', async () => {
+    const directory = await mkdtemp(join(tmpdir(), 'matrix-agent-config-'));
+    roots.push(directory);
+    const store = createAgentConfigurationStore({ directory });
+
+    await store.publish(operationId, configuration);
+    const path = join(directory, operationId);
+    expect((await lstat(path)).mode & 0o777).toBe(0o600);
+    expect(await readFile(path, 'utf8')).toContain('private prompt');
+    await expect(store.publish(operationId, configuration)).rejects.toThrow();
+
+    await expect(store.claim(operationId)).resolves.toEqual(configuration);
+    await expect(lstat(path)).rejects.toMatchObject({ code: 'ENOENT' });
+  });
+
+  it('rejects a symlink without reading its target', async () => {
+    const directory = await mkdtemp(join(tmpdir(), 'matrix-agent-config-'));
+    const target = join(directory, 'target');
+    roots.push(directory);
+    await symlink(target, join(directory, operationId));
+    const store = createAgentConfigurationStore({ directory });
+
+    await expect(store.claim(operationId)).rejects.toThrow(
+      'agent_configuration_invalid',
+    );
+    await expect(lstat(target)).rejects.toMatchObject({ code: 'ENOENT' });
+  });
+});

--- a/tests/terminal-runtime/services.test.ts
+++ b/tests/terminal-runtime/services.test.ts
@@ -172,7 +172,7 @@ describe('terminal runtime service boundary', () => {
         ...(agent === 'codex'
           ? {
               providerEventPath: 'system/session-output/example.jsonl',
-              codexExpectedVersion: '0.144.6',
+              codexExpectedVersion: '0.145.0',
             }
           : {}),
       }, '/home/matrix/home');
@@ -203,6 +203,26 @@ describe('terminal runtime service boundary', () => {
     }, '/home/matrix/home')).toThrow('claude_approval_policy_unsupported');
   });
 
+  it.each(['plan', 'review'] as const)(
+    'rejects Claude on-failure approval in supervised %s mode',
+    (mode) => {
+      expect(() => buildProviderLaunch({
+        schemaVersion: 1,
+        agent: 'claude',
+        cwd: { kind: 'home-relative', path: 'projects/private' },
+        prompt: 'repair the private project',
+        mode,
+        approvalPolicy: 'on-failure',
+        sandbox: {
+          enabled: true,
+          mode: 'workspace-write',
+          writableRoots: [],
+          denyWriteRoots: [],
+        },
+      }, '/home/matrix/home')).toThrow('claude_approval_policy_unsupported');
+    },
+  );
+
   it('hands the selected Codex executable to the runner through fd 3 only', () => {
     const codexExecutable = '/opt/matrix/runtime/node/bin/codex';
     const launch = buildProviderLaunch({
@@ -219,7 +239,7 @@ describe('terminal runtime service boundary', () => {
         denyWriteRoots: [],
       },
       providerEventPath: 'system/session-output/example.jsonl',
-      codexExpectedVersion: '0.144.6',
+      codexExpectedVersion: '0.145.0',
       codexExecutable,
     }, '/home/matrix/home');
 

--- a/tests/terminal-runtime/services.test.ts
+++ b/tests/terminal-runtime/services.test.ts
@@ -186,6 +186,50 @@ describe('terminal runtime service boundary', () => {
     },
   );
 
+  it('rejects Claude on-failure approval in supervised mode', () => {
+    expect(() => buildProviderLaunch({
+      schemaVersion: 1,
+      agent: 'claude',
+      cwd: { kind: 'home-relative', path: 'projects/private' },
+      prompt: 'repair the private project',
+      mode: 'default',
+      approvalPolicy: 'on-failure',
+      sandbox: {
+        enabled: true,
+        mode: 'workspace-write',
+        writableRoots: [],
+        denyWriteRoots: [],
+      },
+    }, '/home/matrix/home')).toThrow('claude_approval_policy_unsupported');
+  });
+
+  it('hands the selected Codex executable to the runner through fd 3 only', () => {
+    const codexExecutable = '/opt/matrix/runtime/node/bin/codex';
+    const launch = buildProviderLaunch({
+      schemaVersion: 1,
+      agent: 'codex',
+      cwd: { kind: 'home-relative', path: 'projects/private' },
+      prompt: 'repair the private project',
+      mode: 'default',
+      approvalPolicy: 'never',
+      sandbox: {
+        enabled: true,
+        mode: 'workspace-write',
+        writableRoots: [],
+        denyWriteRoots: [],
+      },
+      providerEventPath: 'system/session-output/example.jsonl',
+      codexExpectedVersion: '0.144.6',
+      codexExecutable,
+    }, '/home/matrix/home');
+
+    expect(JSON.parse(launch.fdPayload ?? '{}')).toMatchObject({
+      command: codexExecutable,
+    });
+    expect(JSON.stringify([launch.file, ...launch.args]))
+      .not.toContain(codexExecutable);
+  });
+
   it('notifies readiness only after exact session and complete cgroup evidence pass', async () => {
     const notifyReady = vi.fn(async () => undefined);
     const sequence = [

--- a/tests/terminal-runtime/services.test.ts
+++ b/tests/terminal-runtime/services.test.ts
@@ -12,6 +12,7 @@ import {
 import {
   unitNameForRuntimeId,
 } from '../../packages/terminal-runtime/src/contracts.js';
+import { buildProviderLaunch } from '../../packages/terminal-runtime/src/pane.js';
 import {
   decodePeerCredentials,
   handleSupervisorFrame,
@@ -109,7 +110,7 @@ describe('terminal runtime service boundary', () => {
       '--session',
       `matrix-t-${runtimeId}`,
       '--new-session-with-layout',
-      '/opt/matrix/libexec/terminal-runtime/current/layout.kdl',
+      '/opt/matrix/libexec/terminal-runtime/current/agent-layout.kdl',
     ]);
     expect(create.cwd).toBe('/home/matrix/home/projects/example');
     expect(JSON.stringify(create.args)).not.toContain('configurationRef');
@@ -118,10 +119,12 @@ describe('terminal runtime service boundary', () => {
     expect(create.env.ZELLIJ_CONFIG_FILE).toBe(
       '/opt/matrix/libexec/terminal-runtime/current/config.kdl',
     );
+    expect(create.env.MATRIX_TERMINAL_CONFIGURATION_REF).toBe(operationId);
     expect(Object.keys(create.env).sort()).toEqual([
       'HOME',
       'LANG',
       'MATRIX_HOME',
+      'MATRIX_TERMINAL_CONFIGURATION_REF',
       'PATH',
       'TERM',
       'XDG_CACHE_HOME',
@@ -132,6 +135,44 @@ describe('terminal runtime service boundary', () => {
       'ZELLIJ_CONFIG_FILE',
     ]);
   });
+
+  it.each(['claude', 'codex', 'opencode', 'pi'] as const)(
+    'builds a fixed %s provider launch with dynamic data on stdin or fd 3',
+    (agent) => {
+      const prompt = 'repair the private project';
+      const launch = buildProviderLaunch({
+        schemaVersion: 1,
+        agent,
+        cwd: { kind: 'home-relative', path: 'projects/private' },
+        prompt,
+        mode: 'plan',
+        approvalPolicy: 'on-request',
+        sandbox: {
+          enabled: true,
+          mode: 'workspace-write',
+          writableRoots: [
+            { kind: 'home-relative', path: 'projects/private' },
+          ],
+          denyWriteRoots: [
+            { kind: 'home-relative', path: 'system' },
+          ],
+        },
+        ...(agent === 'codex'
+          ? {
+              providerEventPath: 'system/session-output/example.jsonl',
+              codexExpectedVersion: '0.144.6',
+            }
+          : {}),
+      }, '/home/matrix/home');
+
+      expect(JSON.stringify(launch.args)).not.toContain(prompt);
+      expect(JSON.stringify(launch.args)).not.toContain('/home/matrix/home');
+      expect(JSON.stringify(launch.args)).not.toContain('on-request');
+      expect(JSON.stringify(launch.args)).not.toContain('workspace-write');
+      expect(`${launch.stdin ?? ''}${launch.fdPayload ?? ''}`).toContain(prompt);
+      expect(launch.cwd).toBe('/home/matrix/home/projects/private');
+    },
+  );
 
   it('notifies readiness only after exact session and complete cgroup evidence pass', async () => {
     const notifyReady = vi.fn(async () => undefined);

--- a/tests/terminal-runtime/services.test.ts
+++ b/tests/terminal-runtime/services.test.ts
@@ -83,6 +83,18 @@ describe('terminal runtime service boundary', () => {
       zellijServer: false,
       shell: true,
     });
+    expect(classifyRuntimeProcesses([
+      { comm: 'node', args: ['/generation/keeper.js'] },
+      { comm: 'zellij', args: ['zellij', '--session', `matrix-t-${runtimeId}`] },
+      { comm: 'zellij', args: ['zellij', '--server', `matrix-t-${runtimeId}`] },
+      { comm: 'node', args: ['/generation/pane.js', 'agent'] },
+      { comm: 'codex', args: ['codex', 'app-server'] },
+    ])).toEqual({
+      keeper: true,
+      zellijClient: true,
+      zellijServer: true,
+      shell: true,
+    });
   });
 
   it('keeps all user-derived launch data out of keeper argv and preserves command gating', () => {


### PR DESCRIPTION
## Summary

- inject one protocol-v1 terminal-runtime client at gateway startup and fail closed in production supervised mode while preserving the legacy direct-spawn development path
- route shell and coding-agent create, list, attach, input, immutable metadata rename, and delete through supervisor-generated runtime IDs; attach PTYs remain gateway-owned and never enter terminal-session cgroups
- persist immutable Zellij/runtime identities across gateway restarts and keep multi-device attach resolution side-effect-free
- replace Matrix-managed prompt, cwd, settings, provider, policy, and dynamic-option argv with a bounded one-shot owner configuration, stdin, or anonymous fd; keeper and pane argv are fixed
- install the fixed agent pane/layout and Codex fd-config runner in the stable terminal-runtime generation
- keep the production default on legacy ownership until PR 9; this is PR 6/9 stacked on #1113

## Tests

- Red first:
  - `tests/gateway/terminal-runtime-client.test.ts`
  - `tests/gateway/shell-terminal-runtime.test.ts`
  - `tests/gateway/agent-terminal-runtime.test.ts`
  - `tests/terminal-runtime/agent-configurations.test.ts`
- `pnpm exec vitest run` across terminal client, shell/runtime routing, agent launch/session, runtime bridge, registry, WebSocket, routes, startup recovery, configuration, service, operation-handler, and deployment suites — 245 passed
- focused Codex, runtime, installer, shell-option, and Desktop command-palette suites — 59 passed
- `pnpm --filter '@matrix-os/contracts' typecheck`, terminal-runtime typecheck, and gateway `tsc --noEmit` — passed
- `pnpm run check:patterns` — 0 violations
- `git diff --check` — passed
- React Doctor ran for the touched React test surface; no diagnostic points at `tests/desktop/command-palette.test.tsx`. Its changed-scope report contains only accumulated/pre-existing shell findings outside this PR's React-test delta.
- `tests/platform/customer-vps-host-bundle.test.ts` passes every Codex/bundle assertion but its unrelated log-permission test fails locally because the test process runs as root and can write the nominally unwritable directory; exact-head non-root CI remains authoritative.

## Review/Monitoring

- Frozen exact head: `768d1b3fe8ca49f5ba8c038aa76502c4775c2153`.
- Exact-head CI [passed](https://github.com/HamedMP/matrix-os/actions/runs/30959155238).
- Exact-head Docker [passed](https://github.com/HamedMP/matrix-os/actions/runs/30959155234).
- Exact-head preview, Codex provider-contract, and Neo worker checks passed.
- Exact-head Greptile: 5/5; both review threads are resolved.
- Supervised gateway/agent routing remains dormant until the activation layer. Do not merge this layer independently.

## Invariants

- **Source of truth:** the root terminal supervisor and its protocol-v1 receipts/name index remain authoritative for runtime identity and lifecycle. Gateway JSON stores only compatible presentation metadata and immutable runtime references; Zellij process discovery never proves lifecycle. The verified provider pin is inherited from PR5.
- **Lock/transaction scope:** CreateStart, metadata rename, and Delete serialize in the supervisor under the existing global-name then per-runtime lock order. Gateway caches are bounded projections only and never implement uniqueness or liveness. One-shot agent configuration publication is exclusive and fsynced before CreateStart.
- **Acceptable orphan states:** if the supervisor rejects CreateStart, the gateway removes the unpublished one-shot configuration. If the gateway dies after supervisor acceptance, the supervisor operation continues and a restarted gateway resolves the same runtime. The recurring symlink-safe sweep removes stale/malformed one-shot files; no attach path creates or recovers a runtime.
- **Auth source of truth:** existing owner authentication remains authoritative at gateway routes. The gateway speaks only the owner Unix socket protocol; the supervisor continues to enforce `SO_PEERCRED`, strict schemas, immutable template selection, and bounded frames.
- **Deferred scope:** this PR does not add the explicit recovery route, authoritative interrupted projection, retention/pressure reaping, race-complete deletion cleanup, recovery UI, legacy migration, production activation, merge, or stable deployment. Those remain in PRs 7–9.
