### PR TITLE
feat(terminal): add recovery lifecycle APIs

### DIFF
--- a/packages/gateway/src/shell/reaper.ts
+++ b/packages/gateway/src/shell/reaper.ts
@@ -3,11 +3,12 @@ interface ReapableSession {
   status?: "active" | "exited";
   updatedAt?: string;
   kind?: string;
+  lifecycleState?: string;
 }
 
 interface ReaperRegistry {
   list(): Promise<ReapableSession[]>;
-  delete(name: string, options?: { force?: boolean }): Promise<void>;
+  delete(name: string, options?: { force?: boolean }): Promise<unknown>;
 }
 
 export interface ShellSessionReaperOptions {
@@ -41,7 +42,14 @@ export function createShellSessionReaper(options: ShellSessionReaperOptions) {
     }
     const cutoff = Date.now() - ttlMs;
     for (const session of sessions) {
-      if (!session.kind || session.status !== "exited") {
+      if (
+        !session.kind ||
+        session.status !== "exited" ||
+        session.lifecycleState !== undefined &&
+          ["starting", "live", "recovering", "deleting"].includes(
+            session.lifecycleState,
+          )
+      ) {
         continue;
       }
       const updatedAt = session.updatedAt ? Date.parse(session.updatedAt) : Number.NaN;
@@ -50,12 +58,12 @@ export function createShellSessionReaper(options: ShellSessionReaperOptions) {
       }
       try {
         await options.registry.delete(session.name, { force: true });
-        console.log("[shell] reaped exited session:", session.name);
+        console.log("[shell] reaped one exited terminal runtime");
       } catch (err: unknown) {
-        console.warn("[shell] failed to reap session:", {
-          session: session.name,
-          error: err instanceof Error ? err.message : String(err),
-        });
+        console.warn(
+          "[shell] failed to reap one exited terminal runtime",
+          { errorType: err instanceof Error ? err.name : "unknown" },
+        );
       }
     }
   }

--- a/packages/gateway/src/shell/registry.ts
+++ b/packages/gateway/src/shell/registry.ts
@@ -33,7 +33,14 @@ export interface ShellRegistryAdapter {
   listSessions(): Promise<string[]>;
   focusedPaneCwd?(name: string): Promise<string | null>;
   createSession(options: { name: string; cwd?: string; layout?: string; cmd?: string }): Promise<void>;
-  deleteSession(name: string, options?: { force?: boolean }): Promise<void>;
+  deleteSession(
+    name: string,
+    options?: { force?: boolean },
+  ): Promise<
+    void |
+    { deleted: true } |
+    { deleted: false; lifecycleState: "deleting" }
+  >;
   renameSession?(name: string, nextName: string): Promise<void>;
   runtimeProjection?(name: string): {
     runtimeId: string;
@@ -42,6 +49,22 @@ export interface ShellRegistryAdapter {
     recoveryReason: string | null;
     metadataRevision?: number;
   } | null;
+  listRuntimeProjections?(): Promise<Array<{
+    runtimeId: string;
+    displayName?: string;
+    lifecycleState: string;
+    recoverable: boolean;
+    recoveryReason: string | null;
+    metadataRevision?: number;
+  }>>;
+  recoverSession?(name: string): Promise<{
+    runtimeId: string;
+    displayName?: string;
+    lifecycleState: string;
+    recoverable: boolean;
+    recoveryReason: string | null;
+    metadataRevision?: number;
+  }>;
 }
 
 const ShellSessionSchema = z.object({
@@ -170,7 +193,17 @@ export class ShellRegistry {
   async list(): Promise<ShellSession[]> {
     return this.withMutationLock(async () => {
       const file = await this.read();
-      const live = await this.options.adapter.listSessions();
+      const projections =
+        await this.options.adapter.listRuntimeProjections?.();
+      const live = projections
+        ? projections.flatMap((projection) =>
+            projection.displayName &&
+            ["starting", "live", "recovering"].includes(
+              projection.lifecycleState,
+            )
+              ? [projection.displayName]
+              : [])
+        : await this.options.adapter.listSessions();
       let changed = false;
       const now = new Date().toISOString();
       const activeSessions: PersistedShellSession[] = [];
@@ -184,20 +217,64 @@ export class ShellRegistry {
           ...this.runtimeFields(name),
         };
         activeSessions.push(session);
-        if (!existing || existing.status !== "active") {
+        if (
+          !existing ||
+          JSON.stringify(existing) !== JSON.stringify(session)
+        ) {
           file.sessions[name] = session;
           changed = true;
         }
       }
 
-      changed = await this.markMissingMetadataExited(file, new Set(live)) || changed;
+      const inactiveProjectedSessions: PersistedShellSession[] = [];
+      if (projections) {
+        const liveSet = new Set(live);
+        for (const projection of projections) {
+          if (!projection.displayName || liveSet.has(projection.displayName)) {
+            continue;
+          }
+          const existing = file.sessions[projection.displayName];
+          const session: PersistedShellSession = {
+            ...(existing ?? this.adoptSession(projection.displayName, now)),
+            name: projection.displayName,
+            status: "exited",
+            updatedAt: existing?.updatedAt ?? now,
+            ...this.runtimeFieldsFromProjection(projection),
+          };
+          inactiveProjectedSessions.push(session);
+          if (
+            !existing ||
+            JSON.stringify(existing) !== JSON.stringify(session)
+          ) {
+            file.sessions[projection.displayName] = session;
+            changed = true;
+          }
+        }
+      }
+
+      const knownNames = new Set(
+        projections
+          ? projections.flatMap((projection) =>
+              projection.displayName ? [projection.displayName] : [])
+          : live,
+      );
+      changed = await this.markMissingMetadataExited(file, knownNames) || changed;
       changed = this.normalizeCustomOrder(file, activeSessions) || changed;
 
       if (changed) {
         await this.write(file);
       }
 
-      return this.decorateSessions(this.withRecoverableReferences(file, live, this.orderActiveSessions(file, activeSessions)), file);
+      const visible = [
+        ...this.orderActiveSessions(file, activeSessions),
+        ...inactiveProjectedSessions.sort((left, right) =>
+          left.createdAt.localeCompare(right.createdAt) ||
+          left.name.localeCompare(right.name)),
+      ];
+      return this.decorateSessions(
+        this.withRecoverableReferences(file, [...knownNames], visible),
+        file,
+      );
     });
   }
 
@@ -209,6 +286,10 @@ export class ShellRegistry {
       const live = await this.options.adapter.listSessions();
       if (!live.includes(targetName)) {
         throw shellError("session_not_found", "Session not found", 404);
+      }
+      const projection = this.options.adapter.runtimeProjection?.(targetName);
+      if (projection && projection.lifecycleState !== "live") {
+        throw shellError("session_not_live", "Session is not ready", 409);
       }
       const now = new Date().toISOString();
       const existing = file.sessions[targetName];
@@ -467,7 +548,46 @@ export class ShellRegistry {
     });
   }
 
-  async delete(name: string, options: { force?: boolean } = {}): Promise<void> {
+  async recover(name: string): Promise<ShellSession> {
+    return this.withMutationLock(async () => {
+      const safeName = validateSessionName(name);
+      if (!this.options.adapter.recoverSession) {
+        throw shellError(
+          "session_recovery_unavailable",
+          "Request failed",
+          503,
+        );
+      }
+      const file = await this.read();
+      const targetName = this.resolveSessionName(file, safeName);
+      const projection = await this.options.adapter.recoverSession(targetName);
+      const now = new Date().toISOString();
+      const existing =
+        file.sessions[targetName] ?? this.adoptSession(targetName, now);
+      const next: PersistedShellSession = {
+        ...existing,
+        status: ["starting", "live", "recovering"].includes(
+          projection.lifecycleState,
+        )
+          ? "active"
+          : "exited",
+        updatedAt: now,
+        ...this.runtimeFieldsFromProjection(projection),
+      };
+      file.sessions[targetName] = next;
+      await this.write(file);
+      return await this.decorateSession(next, file);
+    });
+  }
+
+  async delete(
+    name: string,
+    options: { force?: boolean } = {},
+  ): Promise<
+    void |
+    { deleted: true } |
+    { deleted: false; lifecycleState: "deleting" }
+  > {
     return this.withMutationLock(async () => {
       const safeName = validateSessionName(name);
       const file = await this.read();
@@ -482,7 +602,25 @@ export class ShellRegistry {
           throw shellError("session_not_found", "Session not found", 404);
         }
       }
-      await this.options.adapter.deleteSession(targetName, options);
+      const deletion = await this.options.adapter.deleteSession(
+        targetName,
+        options,
+      );
+      if (deletion && !deletion.deleted) {
+        file.sessions[targetName] = {
+          ...(persistedSession ?? this.adoptSession(
+            targetName,
+            new Date().toISOString(),
+          )),
+          status: "exited",
+          lifecycleState: "deleting",
+          recoverable: false,
+          recoveryReason: null,
+          updatedAt: new Date().toISOString(),
+        };
+        await this.write(file);
+        return deletion;
+      }
       delete file.sessions[targetName];
       if (file.order) {
         file.order = file.order.filter((entry) => entry !== targetName);
@@ -495,6 +633,7 @@ export class ShellRegistry {
       await this.cleanupScrollback(storageIdentity);
       await this.cleanupAgentState(storageIdentity);
       await this.write(file);
+      return deletion;
     });
   }
 
@@ -555,6 +694,16 @@ export class ShellRegistry {
   private runtimeFields(name: string): Partial<PersistedShellSession> {
     const projection = this.options.adapter.runtimeProjection?.(name);
     if (!projection) return {};
+    return this.runtimeFieldsFromProjection(projection);
+  }
+
+  private runtimeFieldsFromProjection(projection: {
+    runtimeId: string;
+    lifecycleState: string;
+    recoverable: boolean;
+    recoveryReason: string | null;
+    metadataRevision?: number;
+  }): Partial<PersistedShellSession> {
     return {
       runtimeId: projection.runtimeId,
       lifecycleState: projection.lifecycleState as PersistedShellSession["lifecycleState"],
@@ -581,7 +730,10 @@ export class ShellRegistry {
     const lastSeenSeq = session.lastSeenSeq ?? session.lastSeq ?? latestSeq;
     const unread = latestSeq !== null && lastSeenSeq !== null && latestSeq > lastSeenSeq;
     const references = file ? this.referencesForTarget(file, session.name) : [];
-    const recoverable = session.status === "exited" && references.length > 0;
+    const authoritativeLifecycle = session.lifecycleState !== undefined;
+    const recoverable = authoritativeLifecycle
+      ? session.recoverable ?? false
+      : session.status === "exited" && references.length > 0;
     const gitContext = await this.readGitContext({ sessionName: session.name, cwd: focusedPaneCwd ?? session.cwd });
     const visualStatus = deriveAgentVisualStatus(agentSnapshot, unread)
       ?? this.deriveVisualStatus(session, unread, activity);
@@ -608,7 +760,11 @@ export class ShellRegistry {
       aliases: file ? this.aliasesForTarget(file, session.name) : [],
       references,
       recoverable,
-      ...(recoverable ? { recoveryReason: "missing_runtime_session" as const } : {}),
+      ...(authoritativeLifecycle
+        ? { recoveryReason: session.recoveryReason ?? null }
+        : recoverable
+          ? { recoveryReason: "missing_runtime_session" as const }
+          : {}),
     };
   }
 

--- a/packages/gateway/src/shell/routes.ts
+++ b/packages/gateway/src/shell/routes.ts
@@ -2,7 +2,7 @@ import { Hono, type Context } from "hono";
 import { bodyLimit } from "hono/body-limit";
 import { z } from "zod/v4";
 import { createRateLimiter, type RateLimiter } from "../security/rate-limiter.js";
-import { toShellError } from "./errors.js";
+import { shellError, toShellError } from "./errors.js";
 import { SESSION_NAME_PATTERN } from "./names.js";
 import {
   saveTerminalPasteAsset,
@@ -26,7 +26,12 @@ interface SessionRegistryRoutes {
     cmd?: string;
     agent?: AgentKind;
   }): Promise<unknown>;
-  delete(name: string, options?: { force?: boolean }): Promise<void>;
+  delete(name: string, options?: { force?: boolean }): Promise<
+    void |
+    { deleted: true } |
+    { deleted: false; lifecycleState: "deleting" }
+  >;
+  recover?(name: string): Promise<unknown>;
   rename?(name: string, nextName: string): Promise<unknown>;
   reorder?(order: string[]): Promise<unknown[]>;
   updateUiState?(name: string, input: {
@@ -148,6 +153,7 @@ const SessionRenameBodySchema = z.object({
 const SessionOrderBodySchema = z.object({
   order: z.array(SafeSessionNameSchema).max(100),
 }).strict();
+const EmptyRecoveryBodySchema = z.object({}).strict();
 
 function safeCwdSchema() {
   return z.string().min(1).max(1024)
@@ -161,6 +167,7 @@ export function createShellRoutes(deps: ShellRouteDeps): Hono {
     deps.sessionCreateRateLimiter ?? createRateLimiter(SHELL_SESSION_CREATE_RATE_LIMIT);
   const sessionBodyLimit = bodyLimit({ maxSize: 4096 });
   const sessionRenameBodyLimit = bodyLimit({ maxSize: 1024 });
+  const sessionRecoveryBodyLimit = bodyLimit({ maxSize: 512 });
   const sessionOrderBodyLimit = bodyLimit({ maxSize: 8192 });
   const uiStateBodyLimit = bodyLimit({ maxSize: 1024 });
   const preferencesBodyLimit = bodyLimit({ maxSize: 4096 });
@@ -224,7 +231,7 @@ export function createShellRoutes(deps: ShellRouteDeps): Hono {
   app.post("/sessions", sessionBodyLimit, async (c) => {
     try {
       const body = CreateSessionBodySchema.parse(await c.req.json());
-      if (!sessionCreateRateLimiter.check("shell-session-create")) {
+      if (!sessionCreateRateLimiter.check("shell-session-start")) {
         return c.json(
           { error: { code: "rate_limited", message: "Request failed" } },
           429,
@@ -254,14 +261,57 @@ export function createShellRoutes(deps: ShellRouteDeps): Hono {
 
   app.delete("/sessions/:name", deleteBodyLimit, async (c) => {
     try {
-      await deps.registry.delete(SafeSessionNameSchema.parse(c.req.param("name")), {
+      const deletion = await deps.registry.delete(SafeSessionNameSchema.parse(c.req.param("name")), {
         force: new URL(c.req.url).searchParams.get("force") === "1",
       });
-      return c.json({ ok: true });
+      return c.json(
+        { ok: true },
+        deletion && !deletion.deleted ? 202 : 200,
+      );
     } catch (err) {
       return safeError(c, err);
     }
   });
+
+  app.post(
+    "/sessions/:name/recover",
+    sessionRecoveryBodyLimit,
+    async (c) => {
+      try {
+        if (!deps.registry.recover) {
+          return unavailable(c, "session_recovery_unavailable");
+        }
+        const name = SafeSessionNameSchema.parse(c.req.param("name"));
+        await parseEmptyRecoveryBody(c);
+        if (!sessionCreateRateLimiter.check("shell-session-start")) {
+          return c.json(
+            { error: { code: "rate_limited", message: "Request failed" } },
+            429,
+            {
+              "Retry-After": String(
+                Math.ceil(
+                  SHELL_SESSION_CREATE_RATE_LIMIT.lockoutMs / 1000,
+                ),
+              ),
+            },
+          );
+        }
+        const session = await deps.registry.recover(name);
+        const lifecycleState =
+          typeof session === "object" &&
+          session !== null &&
+          "lifecycleState" in session
+            ? (session as { lifecycleState?: unknown }).lifecycleState
+            : undefined;
+        return c.json(
+          { session },
+          lifecycleState === "live" ? 200 : 202,
+        );
+      } catch (err: unknown) {
+        return safeError(c, err);
+      }
+    },
+  );
 
   const renameSessionHandler = async (c: Context) => {
     try {
@@ -548,6 +598,22 @@ function unavailable(c: Context, code: string) {
 
 function bodyTooLarge(c: Context) {
   return c.json({ error: { code: "payload_too_large", message: "Request too large" } }, 413);
+}
+
+async function parseEmptyRecoveryBody(c: Context): Promise<void> {
+  const text = await c.req.text();
+  if (text.trim() === "") return;
+  let value: unknown;
+  try {
+    value = JSON.parse(text) as unknown;
+  } catch (error: unknown) {
+    if (!(error instanceof SyntaxError)) throw error;
+    throw shellError("invalid_request", "Invalid request", 400);
+  }
+  const parsed = EmptyRecoveryBodySchema.safeParse(value);
+  if (!parsed.success) {
+    throw shellError("invalid_request", "Invalid request", 400);
+  }
 }
 
 async function assertSessionExists(registry: SessionRegistryRoutes, name: string): Promise<void> {

--- a/packages/gateway/src/shell/runtime-client.ts
+++ b/packages/gateway/src/shell/runtime-client.ts
@@ -20,6 +20,7 @@ import type {
   CreateSessionOptions,
   ZellijAdapter,
 } from "./zellij.js";
+import { shellError } from "./errors.js";
 
 const MAX_RUNTIME_PROJECTIONS = 2_048;
 const RecoveryModeSchema = z.enum(["serialized", "fresh-shell"]).nullable();
@@ -43,9 +44,22 @@ const RenameProjectionSchema = z.object({
   displayName: DisplayNameSchema,
   metadataRevision: MetadataRevisionSchema,
 }).strict();
+const DeleteProjectionSchema = z.union([
+  z.object({
+    runtimeId: RuntimeIdSchema,
+    deleted: z.literal(true),
+  }).strict(),
+  z.object({
+    runtimeId: RuntimeIdSchema,
+    lifecycleState: z.literal("deleting"),
+  }).strict(),
+]);
 
 export type GatewayTerminalRuntimeProjection = z.infer<typeof RuntimeProjectionSchema>;
 export type GatewayTerminalRuntimeMode = "legacy" | "supervised";
+export type GatewayTerminalDeleteResult =
+  | { runtimeId: string; deleted: true }
+  | { runtimeId: string; deleted: false; lifecycleState: "deleting" };
 
 export function resolveGatewayTerminalRuntimeMode(
   value: string | undefined,
@@ -88,7 +102,8 @@ export interface GatewayTerminalRuntimeClient {
     displayName: string;
     baseRevision: number;
   }): Promise<GatewayTerminalRuntimeProjection>;
-  delete(runtimeId: string): Promise<void>;
+  recover(runtimeId: string): Promise<GatewayTerminalRuntimeProjection>;
+  delete(runtimeId: string): Promise<GatewayTerminalDeleteResult>;
 }
 
 function terminalRuntimeError(code: string): Error {
@@ -206,14 +221,33 @@ export function createGatewayTerminalRuntimeClient(options: {
         lifecycleState: "live",
       });
     },
-    async delete(runtimeId) {
+    async recover(runtimeId) {
       const trustedId = RuntimeIdSchema.parse(runtimeId);
-      await responseResult(supervisor, {
+      const result = await responseResult(supervisor, {
         version: 1,
         operationId: createOperationId(),
-        operation: "Delete",
+        operation: "Recover",
         input: { runtimeId: trustedId },
       });
+      return RuntimeProjectionSchema.parse(result);
+    },
+    async delete(runtimeId) {
+      const trustedId = RuntimeIdSchema.parse(runtimeId);
+      const result = DeleteProjectionSchema.parse(
+        await responseResult(supervisor, {
+          version: 1,
+          operationId: createOperationId(),
+          operation: "Delete",
+          input: { runtimeId: trustedId },
+        }),
+      );
+      return "deleted" in result
+        ? result
+        : {
+            runtimeId: result.runtimeId,
+            deleted: false,
+            lifecycleState: result.lifecycleState,
+          };
     },
   };
 }
@@ -274,12 +308,38 @@ export function createSupervisedZellijAdapter(options: {
   }
 
   async function mappedName(name: string): Promise<string> {
-    return zellijIdentity((await resolveName(name)).runtimeId);
+    const projection = await resolveName(name);
+    if (projection.lifecycleState !== "live") {
+      throw shellError("session_not_live", "Session is not ready", 409);
+    }
+    return zellijIdentity(projection.runtimeId);
+  }
+
+  async function listRuntimeProjections() {
+    const projections = await options.runtime.list();
+    byName.clear();
+    for (const projection of projections) remember(projection);
+    return projections;
   }
 
   return {
     runtimeProjection(name: string) {
       return byName.get(DisplayNameSchema.parse(name)) ?? null;
+    },
+    listRuntimeProjections,
+    async recoverSession(name: string) {
+      const projection = await resolveName(name);
+      if (projection.lifecycleState === "live") return projection;
+      const recovered = await options.runtime.recover(projection.runtimeId);
+      const next = RuntimeProjectionSchema.parse({
+        ...projection,
+        ...recovered,
+        displayName: projection.displayName,
+        metadataRevision:
+          recovered.metadataRevision ?? projection.metadataRevision,
+      });
+      remember(next);
+      return next;
     },
     async health() {
       try {
@@ -294,11 +354,9 @@ export function createSupervisedZellijAdapter(options: {
       }
     },
     async listSessions() {
-      const projections = await options.runtime.list();
-      byName.clear();
+      const projections = await listRuntimeProjections();
       const live: string[] = [];
       for (const projection of projections) {
-        remember(projection);
         if (
           projection.displayName &&
           ["starting", "live", "recovering"].includes(projection.lifecycleState)
@@ -322,8 +380,22 @@ export function createSupervisedZellijAdapter(options: {
     },
     async deleteSession(name) {
       const projection = await resolveName(name);
-      await options.runtime.delete(projection.runtimeId);
-      if (projection.displayName) byName.delete(projection.displayName);
+      const result = await options.runtime.delete(projection.runtimeId);
+      if (result.deleted) {
+        if (projection.displayName) byName.delete(projection.displayName);
+        return { deleted: true as const };
+      }
+      const deleting = RuntimeProjectionSchema.parse({
+        ...projection,
+        lifecycleState: "deleting",
+        recoverable: false,
+        recoveryReason: null,
+      });
+      remember(deleting);
+      return {
+        deleted: false as const,
+        lifecycleState: "deleting" as const,
+      };
     },
     async renameSession(name, nextName) {
       const projection = await resolveName(name);
@@ -342,8 +414,12 @@ export function createSupervisedZellijAdapter(options: {
       await options.zellij.validateLayout(path);
     },
     attachSession(name: string, attachOptions: AttachOptions = {}) {
+      const projection = resolved(name);
+      if (projection.lifecycleState !== "live") {
+        throw shellError("session_not_live", "Session is not ready", 409);
+      }
       return options.zellij.attachSession(
-        zellijIdentity(resolved(name).runtimeId),
+        zellijIdentity(projection.runtimeId),
         attachOptions,
       );
     },

--- a/packages/gateway/src/shell/zellij.ts
+++ b/packages/gateway/src/shell/zellij.ts
@@ -96,11 +96,34 @@ export interface ZellijAdapter {
     recoveryReason: string | null;
     metadataRevision?: number;
   } | null;
+  listRuntimeProjections?(): Promise<Array<{
+    runtimeId: string;
+    displayName?: string;
+    lifecycleState: string;
+    recoverable: boolean;
+    recoveryReason: string | null;
+    metadataRevision?: number;
+  }>>;
+  recoverSession?(name: string): Promise<{
+    runtimeId: string;
+    displayName?: string;
+    lifecycleState: string;
+    recoverable: boolean;
+    recoveryReason: string | null;
+    metadataRevision?: number;
+  }>;
   health(): Promise<{ ok: boolean; code: "ok" | "zellij_failed" }>;
   listSessions(): Promise<string[]>;
   focusedPaneCwd(name: string): Promise<string | null>;
   createSession(options: CreateSessionOptions): Promise<void>;
-  deleteSession(name: string, options?: { force?: boolean }): Promise<void>;
+  deleteSession(
+    name: string,
+    options?: { force?: boolean },
+  ): Promise<
+    void |
+    { deleted: true } |
+    { deleted: false; lifecycleState: "deleting" }
+  >;
   renameSession(name: string, nextName: string): Promise<void>;
   validateLayout(path: string): Promise<void>;
   attachSession(name: string, options?: AttachOptions): ShellAttachProcess;

--- a/packages/terminal-runtime/assets/config.kdl
+++ b/packages/terminal-runtime/assets/config.kdl
@@ -1,1 +1,6 @@
-// Recovery serialization remains dormant until the recovery lifecycle layer.
+session_serialization true
+serialize_pane_viewport true
+scrollback_lines_to_serialize 10000
+serialization_interval 5
+pane_frames false
+default_shell "/bin/bash"

--- a/packages/terminal-runtime/src/contracts.ts
+++ b/packages/terminal-runtime/src/contracts.ts
@@ -110,6 +110,7 @@ export const DescriptorSchema = z.object({
   runtimeId: RuntimeIdSchema,
   operationId: OperationIdSchema,
   intent: z.enum(['create', 'recover']),
+  recoveryMode: z.enum(['serialized', 'fresh-shell']).optional(),
   cwd: HomeRelativeCwdSchema,
   launch: LaunchDataSchema,
   createdAt: IsoTimestampSchema,

--- a/packages/terminal-runtime/src/index.ts
+++ b/packages/terminal-runtime/src/index.ts
@@ -3,3 +3,5 @@ export * from './operation-handler.js'; export * from './receipts.js'; export * 
 export * from './keeper.js'; export * from './supervisor.js'; export * from './systemd.js';
 export * from './keeper-client.js'; export * from './pane.js';
 export * from './agent-configurations.js';
+export * from './recovery-state.js';
+export * from './telemetry.js';

--- a/packages/terminal-runtime/src/keeper.ts
+++ b/packages/terminal-runtime/src/keeper.ts
@@ -109,7 +109,9 @@ export function buildKeeperLaunch(
   }
   return {
     file: ZELLIJ,
-    args: descriptor.intent === 'recover'
+    args:
+      descriptor.intent === 'recover' &&
+      descriptor.recoveryMode !== 'fresh-shell'
       ? ['attach', sessionName]
       : [
           '--session',
@@ -267,7 +269,13 @@ export async function runKeeper(runtimeIdInput: string | undefined): Promise<num
   let stopping = false;
   let exitCode = 0;
   let renderWindow = '';
-  let confirmationGated = descriptor.intent === 'create';
+  const requiresConfirmation =
+    descriptor.intent === 'recover' &&
+    descriptor.recoveryMode !== 'fresh-shell';
+  const startsFresh =
+    descriptor.intent === 'create' ||
+    descriptor.recoveryMode === 'fresh-shell';
+  let confirmationGated = !requiresConfirmation;
   const pty = spawnPty(launch.file, launch.args, {
     name: 'xterm-256color',
     cols: 120,
@@ -293,7 +301,7 @@ export async function runKeeper(runtimeIdInput: string | undefined): Promise<num
   try {
     await waitForKeeperReadiness({
       runtimeId,
-      requiresConfirmation: descriptor.intent === 'recover',
+      requiresConfirmation,
       readEvidence: async () => ({
         clientAlive,
         confirmationGated,
@@ -301,7 +309,7 @@ export async function runKeeper(runtimeIdInput: string | undefined): Promise<num
           sessionName,
           launch.env,
         ),
-        roles: await cgroupRoles(cgroup, descriptor.intent === 'create'),
+        roles: await cgroupRoles(cgroup, startsFresh),
       }),
       delay: async (milliseconds) =>
         await new Promise((resolveDelay) => setTimeout(resolveDelay, milliseconds)),

--- a/packages/terminal-runtime/src/operation-handler.ts
+++ b/packages/terminal-runtime/src/operation-handler.ts
@@ -8,7 +8,12 @@ import {
 import { reconcileLifecycle, type RuntimeEvidence } from './reconciliation.js';
 import type { ReceiptReadResult } from './receipts.js';
 import type { RuntimeState } from './runtime-state.js';
+import type { RuntimeArtifactManager } from './recovery-state.js';
 const MAX_LIST_RUNTIMES = 2_048;
+const INACTIVE_RETENTION_MS = 7 * 24 * 60 * 60 * 1_000;
+const MAX_INACTIVE_RECOVERY_SETS = 128;
+const RECOVERY_AGGREGATE_TARGET_BYTES = 1024 * 1024 * 1024;
+const RECOVERY_RUNTIME_TARGET_BYTES = 64 * 1024 * 1024;
 export type UnitInspection = {
   runtimeId: string; cgroupPopulated: boolean; keeperReady: boolean;
   keeperAlive: boolean; zellijResponsive: boolean;
@@ -24,6 +29,7 @@ type OperationHandlerOptions = {
   state: RuntimeState; executor: SystemdExecutor; now?: () => Date;
   bootId?: () => Promise<string>; createId?: () => string;
   resolveCwd: (cwd: HomeRelativeCwd) => Promise<HomeRelativeCwd>;
+  artifacts?: RuntimeArtifactManager;
 };
 type ProtocolErrorCode = 'invalid_request' | 'not_found' | 'conflict'
   | 'unavailable' | 'failed';
@@ -77,7 +83,8 @@ async function defaultBootId(): Promise<string> {
   return value;
 }
 function evidenceFor(receipt: ReceiptReadResult, inspection: UnitInspection | null,
-  descriptor: RuntimeEvidence['descriptor'], bootIdMatches: boolean): RuntimeEvidence {
+  descriptor: RuntimeEvidence['descriptor'], bootIdMatches: boolean,
+  resurrection?: UnitInspection['resurrection']): RuntimeEvidence {
   return {
     deleteIntent: receipt?.kind === 'supported' &&
       receipt.receipt.lastKnown.state === 'deleting',
@@ -89,7 +96,7 @@ function evidenceFor(receipt: ReceiptReadResult, inspection: UnitInspection | nu
     descriptor,
     receipt: receipt === null ? 'missing'
       : receipt.kind === 'unsupported' ? 'unsupported' : 'valid',
-    resurrection: inspection?.resurrection ?? 'missing',
+    resurrection: resurrection ?? inspection?.resurrection ?? 'missing',
     priorState: receipt?.kind === 'supported' ? receipt.receipt.lastKnown.state : null,
     bootIdMatches,
   };
@@ -100,9 +107,10 @@ export function createOperationHandler(options: OperationHandlerOptions) {
   const createId = options.createId ?? createRuntimeId;
   async function inspectRuntime(runtimeId: string) {
     const id = RuntimeIdSchema.parse(runtimeId);
-    const [receipt, inspection, descriptor, currentBootId] = await Promise.all([
+    const [receipt, inspection, descriptor, currentBootId, artifact] = await Promise.all([
       options.state.receipts.read(id), options.executor.inspect(id),
       options.state.descriptors.pendingKind(id), bootId(),
+      options.artifacts?.inspect(id),
     ]);
     return {
       runtimeId: id,
@@ -114,7 +122,8 @@ export function createOperationHandler(options: OperationHandlerOptions) {
         : {}),
       ...reconcileLifecycle(evidenceFor(receipt, inspection, descriptor,
         receipt?.kind !== 'supported' ||
-          receipt.receipt.lastKnown.bootId === currentBootId)),
+          receipt.receipt.lastKnown.bootId === currentBootId,
+        artifact?.state)),
     };
   }
   async function listRuntimes() {
@@ -294,19 +303,33 @@ export function createOperationHandler(options: OperationHandlerOptions) {
           return await succeedOperation(record, result);
         }
         let cwd: HomeRelativeCwd;
+        let cwdFallback = false;
         try {
           cwd = await options.resolveCwd(current.receipt.cwd);
         } catch (error: unknown) {
           try {
             cwd = await options.resolveCwd({ kind: 'home-relative', path: '' });
+            cwdFallback = true;
           } catch (fallbackError: unknown) {
             return await failOperation(record,
               new AggregateError([error, fallbackError], 'cwd_unavailable'));
           }
         }
+        const resurrection = await options.artifacts?.inspect(
+          current.receipt.runtimeId,
+        );
+        const recoveryMode = resurrection?.state === 'valid'
+          ? 'serialized'
+          : 'fresh-shell';
+        if (options.artifacts && recoveryMode === 'fresh-shell') {
+          await options.artifacts.prepareFreshRecovery(
+            current.receipt.runtimeId,
+          );
+        }
         const descriptor: Descriptor = {
           schemaVersion: 1, runtimeId: current.receipt.runtimeId,
           operationId: request.operationId, intent: 'recover', cwd,
+          recoveryMode,
           launch: { kind: 'shell' }, createdAt: now().toISOString(),
         };
         try {
@@ -324,7 +347,14 @@ export function createOperationHandler(options: OperationHandlerOptions) {
             request.operationId, error);
         }
         return await succeedOperation(record, {
-          runtimeId: current.receipt.runtimeId, lifecycleState: 'recovering',
+          runtimeId: current.receipt.runtimeId,
+          lifecycleState: 'recovering',
+          recoveryMode,
+          recoveryReason: cwdFallback
+            ? 'cwd_unavailable'
+            : recoveryMode === 'fresh-shell'
+              ? 'history_unavailable'
+              : null,
         });
       },
     );
@@ -374,6 +404,7 @@ export function createOperationHandler(options: OperationHandlerOptions) {
   }
   async function finishDeletion(runtimeId: string,
     record: OperationRecord | null): Promise<{ runtimeId: string; deleted: true }> {
+    await options.artifacts?.remove(runtimeId);
     await options.state.names.deleteRuntime(runtimeId);
     await options.state.descriptors.removeRuntime(runtimeId);
     const result = { runtimeId, deleted: true as const };
@@ -442,6 +473,32 @@ export function createOperationHandler(options: OperationHandlerOptions) {
         });
       }
       const result = await listRuntimes();
+      if (options.artifacts) {
+        for (const runtime of result) {
+          if (
+            ['interrupted', 'exited', 'failed'].includes(
+              runtime.lifecycleState,
+            )
+          ) {
+            await options.artifacts.clearAgentState(runtime.runtimeId);
+          }
+        }
+        const protectedRuntimeIds = new Set(
+          result.flatMap((runtime) =>
+            ['starting', 'live', 'recovering', 'deleting']
+              .includes(runtime.lifecycleState)
+              ? [runtime.runtimeId]
+              : []),
+        );
+        await options.artifacts.prune({
+          protectedRuntimeIds,
+          nowMs: now().getTime(),
+          retentionMs: INACTIVE_RETENTION_MS,
+          maxInactiveSets: MAX_INACTIVE_RECOVERY_SETS,
+          aggregateTargetBytes: RECOVERY_AGGREGATE_TARGET_BYTES,
+          perRuntimeTargetBytes: RECOVERY_RUNTIME_TARGET_BYTES,
+        });
+      }
       // The supervisor invokes Reconcile at startup and on its recurring sweep.
       return await succeedOperation(record, result);
     });

--- a/packages/terminal-runtime/src/recovery-state.ts
+++ b/packages/terminal-runtime/src/recovery-state.ts
@@ -1,0 +1,466 @@
+import {
+  lstat,
+  readdir,
+  rmdir,
+  unlink,
+} from 'node:fs/promises';
+import { join, resolve } from 'node:path';
+import { RuntimeIdSchema } from './contracts.js';
+import { SecureDirectory, isStateNotFound } from './storage.js';
+
+const ZELLIJ_CONTRACT = 'contract_version_1';
+const MAX_CONTRACT_DIRECTORIES = 32;
+const MAX_RECOVERY_FILES = 4_096;
+const MAX_RECOVERY_FILE_BYTES = 64 * 1024 * 1024;
+const MAX_LAYOUT_BYTES = 1024 * 1024;
+
+export type RecoveryStateKind =
+  | 'valid'
+  | 'missing'
+  | 'corrupt'
+  | 'incompatible';
+
+export type RecoveryStateInspection = {
+  state: RecoveryStateKind;
+  bytes: number;
+  files: number;
+  updatedAtMs: number | null;
+};
+
+export type RecoveryPruneInput = {
+  protectedRuntimeIds: Set<string>;
+  nowMs: number;
+  retentionMs: number;
+  maxInactiveSets: number;
+  aggregateTargetBytes: number;
+  perRuntimeTargetBytes: number;
+};
+
+export type RecoveryPruneResult = {
+  removedRuntimeIds: string[];
+  inactiveSets: number;
+  aggregateBytes: number;
+};
+
+export interface RuntimeArtifactManager {
+  inspect(runtimeId: string): Promise<RecoveryStateInspection>;
+  remove(runtimeId: string): Promise<void>;
+  prepareFreshRecovery(runtimeId: string): Promise<void>;
+  clearAgentState(runtimeId: string): Promise<void>;
+  prune(input: RecoveryPruneInput): Promise<RecoveryPruneResult>;
+}
+
+function sessionName(runtimeId: string): string {
+  return `matrix-t-${RuntimeIdSchema.parse(runtimeId)}`;
+}
+
+function zellijRoot(cacheRoot: string): string {
+  return join(resolve(cacheRoot), 'zellij');
+}
+
+function sessionInfoRoot(cacheRoot: string, contract = ZELLIJ_CONTRACT): string {
+  return join(zellijRoot(cacheRoot), contract, 'session_info');
+}
+
+export function zellijSessionStatePath(
+  cacheRoot: string,
+  runtimeId: string,
+): string {
+  return join(sessionInfoRoot(cacheRoot), sessionName(runtimeId));
+}
+
+function isMissing(error: unknown): boolean {
+  return error instanceof Error &&
+    'code' in error &&
+    error.code === 'ENOENT';
+}
+
+function validSerializedLayout(value: string): boolean {
+  if (!/\blayout\s*\{/.test(value)) return false;
+  let depth = 0;
+  let quoted = false;
+  let escaped = false;
+  let lineComment = false;
+  let blockCommentDepth = 0;
+  for (let index = 0; index < value.length; index += 1) {
+    const char = value[index]!;
+    const next = value[index + 1];
+    if (lineComment) {
+      if (char === '\n') lineComment = false;
+      continue;
+    }
+    if (blockCommentDepth > 0) {
+      if (char === '/' && next === '*') {
+        blockCommentDepth += 1;
+        index += 1;
+      } else if (char === '*' && next === '/') {
+        blockCommentDepth -= 1;
+        index += 1;
+      }
+      continue;
+    }
+    if (quoted) {
+      if (escaped) escaped = false;
+      else if (char === '\\') escaped = true;
+      else if (char === '"') quoted = false;
+      continue;
+    }
+    if (char === '/' && next === '/') {
+      lineComment = true;
+      index += 1;
+    } else if (char === '/' && next === '*') {
+      blockCommentDepth = 1;
+      index += 1;
+    } else if (char === '"') {
+      quoted = true;
+    } else if (char === '{') {
+      depth += 1;
+    } else if (char === '}') {
+      depth -= 1;
+      if (depth < 0) return false;
+    }
+  }
+  return depth === 0 && !quoted && blockCommentDepth === 0;
+}
+
+async function contractNames(cacheRoot: string): Promise<string[]> {
+  let entries;
+  try {
+    entries = await readdir(zellijRoot(cacheRoot), { withFileTypes: true });
+  } catch (error: unknown) {
+    if (isMissing(error)) return [];
+    throw error;
+  }
+  const names = entries
+    .filter((entry) =>
+      entry.isDirectory() &&
+      /^contract_version_[0-9]{1,6}$/.test(entry.name))
+    .map((entry) => entry.name)
+    .sort();
+  if (names.length > MAX_CONTRACT_DIRECTORIES) {
+    throw new Error('recovery_contract_capacity');
+  }
+  return names;
+}
+
+async function incompatibleStateExists(
+  cacheRoot: string,
+  runtimeId: string,
+): Promise<boolean> {
+  for (const contract of await contractNames(cacheRoot)) {
+    if (contract === ZELLIJ_CONTRACT) continue;
+    try {
+      const stat = await lstat(
+        join(sessionInfoRoot(cacheRoot, contract), sessionName(runtimeId)),
+      );
+      if (stat.isDirectory() && !stat.isSymbolicLink()) return true;
+    } catch (error: unknown) {
+      if (!isMissing(error)) throw error;
+    }
+  }
+  return false;
+}
+
+async function inspectCurrent(
+  cacheRoot: string,
+  runtimeId: string,
+): Promise<RecoveryStateInspection | null> {
+  const path = zellijSessionStatePath(cacheRoot, runtimeId);
+  let directoryStat;
+  try {
+    directoryStat = await lstat(path);
+  } catch (error: unknown) {
+    if (isMissing(error)) return null;
+    throw error;
+  }
+  if (directoryStat.isSymbolicLink() || !directoryStat.isDirectory()) {
+    return {
+      state: 'corrupt',
+      bytes: 0,
+      files: 0,
+      updatedAtMs: directoryStat.mtimeMs,
+    };
+  }
+  let directory: SecureDirectory | null = null;
+  try {
+    directory = await SecureDirectory.open(path, {
+      maxEntries: MAX_RECOVERY_FILES,
+    });
+    const names = await directory.list();
+    if (!names.includes('session-layout.kdl')) {
+      return {
+        state: 'corrupt',
+        bytes: 0,
+        files: names.length,
+        updatedAtMs: directoryStat.mtimeMs,
+      };
+    }
+    let bytes = 0;
+    for (const name of names) {
+      const stat = await directory.statFile(name, MAX_RECOVERY_FILE_BYTES);
+      bytes += stat.size;
+      if (!Number.isSafeInteger(bytes)) throw new Error('recovery_size_invalid');
+    }
+    const layout = (
+      await directory.readBytes('session-layout.kdl', MAX_LAYOUT_BYTES)
+    ).toString('utf8');
+    if (!validSerializedLayout(layout)) {
+      return {
+        state: 'corrupt',
+        bytes,
+        files: names.length,
+        updatedAtMs: directoryStat.mtimeMs,
+      };
+    }
+    const contents = [
+      ...layout.matchAll(/\bcontents_file\s*=\s*"(initial_contents_[0-9]+)"/g),
+    ].map((match) => match[1]!);
+    for (const name of contents) {
+      if (!names.includes(name)) {
+        return {
+          state: 'corrupt',
+          bytes,
+          files: names.length,
+          updatedAtMs: directoryStat.mtimeMs,
+        };
+      }
+    }
+    return {
+      state: 'valid',
+      bytes,
+      files: names.length,
+      updatedAtMs: directoryStat.mtimeMs,
+    };
+  } catch (error: unknown) {
+    if (
+      error instanceof Error &&
+      [
+        'state_capacity',
+        'state_too_large',
+        'unsafe_file',
+        'unsafe_file_name',
+      ].includes(error.message)
+    ) {
+      return {
+        state: 'corrupt',
+        bytes: 0,
+        files: 0,
+        updatedAtMs: directoryStat.mtimeMs,
+      };
+    }
+    throw error;
+  } finally {
+    await directory?.close();
+  }
+}
+
+async function removeSessionDirectory(path: string): Promise<void> {
+  let stat;
+  try {
+    stat = await lstat(path);
+  } catch (error: unknown) {
+    if (isMissing(error)) return;
+    throw error;
+  }
+  if (stat.isSymbolicLink()) {
+    await unlink(path);
+    return;
+  }
+  if (!stat.isDirectory()) throw new Error('recovery_state_unsafe');
+  const directory = await SecureDirectory.open(path, {
+    maxEntries: MAX_RECOVERY_FILES,
+  });
+  try {
+    for (const name of await directory.list()) {
+      await directory.removeLeaf(name);
+    }
+  } finally {
+    await directory.close();
+  }
+  await rmdir(path).catch((error: unknown) => {
+    if (!isMissing(error)) throw error;
+  });
+}
+
+export function createZellijRecoveryStore(options: {
+  cacheRoot: string;
+}): RuntimeArtifactManager {
+  const cacheRoot = resolve(options.cacheRoot);
+
+  async function inspect(
+    runtimeId: string,
+  ): Promise<RecoveryStateInspection> {
+    const id = RuntimeIdSchema.parse(runtimeId);
+    const current = await inspectCurrent(cacheRoot, id);
+    if (current) return current;
+    if (await incompatibleStateExists(cacheRoot, id)) {
+      return {
+        state: 'incompatible',
+        bytes: 0,
+        files: 0,
+        updatedAtMs: null,
+      };
+    }
+    return {
+      state: 'missing',
+      bytes: 0,
+      files: 0,
+      updatedAtMs: null,
+    };
+  }
+
+  async function remove(runtimeId: string): Promise<void> {
+    const id = RuntimeIdSchema.parse(runtimeId);
+    const contracts = new Set([
+      ZELLIJ_CONTRACT,
+      ...(await contractNames(cacheRoot)),
+    ]);
+    for (const contract of contracts) {
+      await removeSessionDirectory(
+        join(sessionInfoRoot(cacheRoot, contract), sessionName(id)),
+      );
+    }
+  }
+
+  async function listCurrentRuntimeIds(): Promise<string[]> {
+    let entries;
+    try {
+      entries = await readdir(sessionInfoRoot(cacheRoot), {
+        withFileTypes: true,
+      });
+    } catch (error: unknown) {
+      if (isMissing(error)) return [];
+      throw error;
+    }
+    const ids = entries.flatMap((entry) => {
+      const match = entry.isDirectory() &&
+        !entry.isSymbolicLink() &&
+        /^matrix-t-([0-9a-f]{32})$/.exec(entry.name);
+      return match ? [RuntimeIdSchema.parse(match[1])] : [];
+    });
+    if (ids.length > MAX_RECOVERY_FILES) {
+      throw new Error('recovery_set_capacity');
+    }
+    return ids.sort();
+  }
+
+  return {
+    inspect,
+    remove,
+    prepareFreshRecovery: remove,
+    clearAgentState: async (runtimeId) => {
+      RuntimeIdSchema.parse(runtimeId);
+    },
+    async prune(input) {
+      const protectedIds = new Set(
+        [...input.protectedRuntimeIds].map((id) => RuntimeIdSchema.parse(id)),
+      );
+      const entries = await Promise.all(
+        (await listCurrentRuntimeIds()).map(async (runtimeId) => ({
+          runtimeId,
+          inspection: await inspect(runtimeId),
+        })),
+      );
+      const inactive = entries
+        .filter((entry) => !protectedIds.has(entry.runtimeId))
+        .sort((left, right) =>
+          (left.inspection.updatedAtMs ?? 0) -
+            (right.inspection.updatedAtMs ?? 0) ||
+          left.runtimeId.localeCompare(right.runtimeId));
+      const removedRuntimeIds: string[] = [];
+      let inactiveSets = inactive.length;
+      let aggregateBytes = entries.reduce(
+        (total, entry) => total + entry.inspection.bytes,
+        0,
+      );
+      for (const entry of inactive) {
+        const expired =
+          entry.inspection.updatedAtMs !== null &&
+          input.nowMs - entry.inspection.updatedAtMs > input.retentionMs;
+        const oversized =
+          entry.inspection.bytes > input.perRuntimeTargetBytes;
+        const overCount = inactiveSets > input.maxInactiveSets;
+        const overAggregate = aggregateBytes > input.aggregateTargetBytes;
+        if (!expired && !oversized && !overCount && !overAggregate) continue;
+        await remove(entry.runtimeId);
+        removedRuntimeIds.push(entry.runtimeId);
+        inactiveSets -= 1;
+        aggregateBytes -= entry.inspection.bytes;
+      }
+      return { removedRuntimeIds, inactiveSets, aggregateBytes };
+    },
+  };
+}
+
+async function removeOwnerLeaf(
+  directoryPath: string,
+  name: string,
+): Promise<void> {
+  let stat;
+  try {
+    stat = await lstat(directoryPath);
+  } catch (error: unknown) {
+    if (isMissing(error)) return;
+    throw error;
+  }
+  if (stat.isSymbolicLink() || !stat.isDirectory()) {
+    throw new Error('runtime_artifact_parent_unsafe');
+  }
+  const directory = await SecureDirectory.open(directoryPath, {
+    maxEntries: MAX_RECOVERY_FILES,
+  });
+  try {
+    await directory.removeLeaf(name).catch((error: unknown) => {
+      if (!isStateNotFound(error)) throw error;
+    });
+  } finally {
+    await directory.close();
+  }
+}
+
+export function createRuntimeArtifactManager(options: {
+  cacheRoot: string;
+  scrollbackDirectory: string;
+  agentStateDirectory: string;
+}): RuntimeArtifactManager {
+  const zellij = createZellijRecoveryStore({ cacheRoot: options.cacheRoot });
+  const scrollbackDirectory = resolve(options.scrollbackDirectory);
+  const agentStateDirectory = resolve(options.agentStateDirectory);
+
+  async function removeAuxiliary(runtimeId: string): Promise<void> {
+    const identity = sessionName(runtimeId);
+    await removeOwnerLeaf(scrollbackDirectory, `${identity}.ndjson`);
+    await removeOwnerLeaf(agentStateDirectory, `${identity}.json`);
+  }
+
+  return {
+    inspect: async (runtimeId) => await zellij.inspect(runtimeId),
+    async remove(runtimeId) {
+      const id = RuntimeIdSchema.parse(runtimeId);
+      await zellij.remove(id);
+      await removeAuxiliary(id);
+    },
+    async prepareFreshRecovery(runtimeId) {
+      const id = RuntimeIdSchema.parse(runtimeId);
+      await zellij.remove(id);
+      await removeOwnerLeaf(
+        agentStateDirectory,
+        `${sessionName(id)}.json`,
+      );
+    },
+    async clearAgentState(runtimeId) {
+      const id = RuntimeIdSchema.parse(runtimeId);
+      await removeOwnerLeaf(
+        agentStateDirectory,
+        `${sessionName(id)}.json`,
+      );
+    },
+    async prune(input) {
+      const result = await zellij.prune(input);
+      for (const runtimeId of result.removedRuntimeIds) {
+        await removeAuxiliary(runtimeId);
+      }
+      return result;
+    },
+  };
+}

--- a/packages/terminal-runtime/src/runtime-op.ts
+++ b/packages/terminal-runtime/src/runtime-op.ts
@@ -29,6 +29,7 @@ import {
   classifyRuntimeProcesses,
   createSystemdExecutor,
 } from './systemd.js';
+import { createRuntimeArtifactManager } from './recovery-state.js';
 
 const execFile = promisify(execFileCallback);
 const HOME = '/home/matrix/home';
@@ -235,7 +236,12 @@ async function createHostState(owner: { uid: number; gid: number }) {
     authorizeDescriptorClaim: async ({ runtimeId, pid }) =>
       await belongsToRuntimeCgroup(pid, runtimeId),
   });
-  return { state, executor, owner };
+  const artifacts = createRuntimeArtifactManager({
+    cacheRoot: `${DURABLE_ROOT}/zellij-cache`,
+    scrollbackDirectory: `${HOME}/system/scrollback`,
+    agentStateDirectory: `${HOME}/system/agent-sessions`,
+  });
+  return { state, executor, owner, artifacts };
 }
 
 async function servePeer(): Promise<void> {
@@ -249,6 +255,7 @@ async function servePeer(): Promise<void> {
       state: host.state,
       executor: host.executor,
       resolveCwd,
+      artifacts: host.artifacts,
     });
     await writeResponse(await handleSupervisorFrame({
       peer,
@@ -302,6 +309,7 @@ async function maintenance(): Promise<void> {
         state: host.state,
         executor: host.executor,
         resolveCwd,
+        artifacts: host.artifacts,
       });
       await handler({
         version: 1,

--- a/packages/terminal-runtime/src/storage.ts
+++ b/packages/terminal-runtime/src/storage.ts
@@ -20,6 +20,7 @@ import { dirname, isAbsolute, resolve, sep } from 'node:path';
 const DEFAULT_MAX_FILE_BYTES = 128 * 1024;
 const DEFAULT_MAX_ENTRIES = 512;
 const SAFE_FILE_NAME = /^[A-Za-z0-9][A-Za-z0-9._-]{0,191}$/;
+const SAFE_LEAF_NAME = /^[^/\0]{1,255}$/;
 function stateError(code: string, cause?: unknown): Error {
   return new Error(code, cause === undefined ? undefined : { cause });
 }
@@ -28,6 +29,14 @@ function isErrorCode(error: unknown, code: string): boolean {
 }
 function validateFileName(name: string): string {
   if (!SAFE_FILE_NAME.test(name)) throw stateError('unsafe_file_name');
+  return name;
+}
+function validateLeafName(name: string): string {
+  if (
+    !SAFE_LEAF_NAME.test(name) ||
+    name === '.' ||
+    name === '..'
+  ) throw stateError('unsafe_file_name');
   return name;
 }
 async function ensureDirectoryPath(path: string): Promise<void> {
@@ -209,6 +218,32 @@ export class SecureDirectory {
       throw error;
     }
   }
+  async statFile(
+    name: string,
+    maxBytes = DEFAULT_MAX_FILE_BYTES,
+  ): Promise<{ size: number; mtimeMs: number }> {
+    const path = this.procPath(name);
+    const before = await lstat(path).catch((error: unknown) => {
+      if (isErrorCode(error, 'ENOENT')) throw stateError('state_not_found', error);
+      throw error;
+    });
+    assertSafeFileStat(before, maxBytes);
+    const file = await open(path, constants.O_RDONLY | constants.O_NOFOLLOW)
+      .catch((error: unknown) => {
+        if (isErrorCode(error, 'ELOOP')) throw stateError('unsafe_file', error);
+        throw error;
+      });
+    try {
+      const after = await file.stat();
+      assertSafeFileStat(after, maxBytes);
+      if (before.dev !== after.dev || before.ino !== after.ino) {
+        throw stateError('unsafe_file');
+      }
+      return { size: after.size, mtimeMs: after.mtimeMs };
+    } finally {
+      await file.close();
+    }
+  }
   async createJsonExclusive(
     name: string,
     value: unknown,
@@ -326,6 +361,35 @@ export class SecureDirectory {
     try {
       const after = await file.stat();
       assertSafeFileStat(after, DEFAULT_MAX_FILE_BYTES);
+      if (before.dev !== after.dev || before.ino !== after.ino) {
+        throw stateError('unsafe_file');
+      }
+    } finally {
+      await file.close();
+    }
+    await unlink(path);
+    await this.handle.sync();
+  }
+  async removeLeaf(name: string): Promise<void> {
+    const path = `${this.procPath()}/${validateLeafName(name)}`;
+    const before = await lstat(path).catch((error: unknown) => {
+      if (isErrorCode(error, 'ENOENT')) throw stateError('state_not_found', error);
+      throw error;
+    });
+    if (before.isSymbolicLink()) {
+      await unlink(path);
+      await this.handle.sync();
+      return;
+    }
+    assertSafeFileStat(before, Number.MAX_SAFE_INTEGER);
+    const file = await open(path, constants.O_RDONLY | constants.O_NOFOLLOW)
+      .catch((error: unknown) => {
+        if (isErrorCode(error, 'ELOOP')) throw stateError('unsafe_file', error);
+        throw error;
+      });
+    try {
+      const after = await file.stat();
+      assertSafeFileStat(after, Number.MAX_SAFE_INTEGER);
       if (before.dev !== after.dev || before.ino !== after.ino) {
         throw stateError('unsafe_file');
       }

--- a/packages/terminal-runtime/src/telemetry.ts
+++ b/packages/terminal-runtime/src/telemetry.ts
@@ -1,0 +1,72 @@
+import { createHash } from 'node:crypto';
+import {
+  LifecycleStateSchema,
+  RuntimeIdSchema,
+  type LifecycleState,
+} from './contracts.js';
+
+const MAX_TELEMETRY_RUNTIMES = 2_048;
+const LifecycleJournalCode = new Set([
+  'runtime_created',
+  'recovery_started',
+  'recovery_ready',
+  'recovery_fallback',
+  'runtime_interrupted',
+  'delete_started',
+  'delete_complete',
+  'reconcile_failed',
+] as const);
+
+export type RuntimeLifecycleJournalCode =
+  typeof LifecycleJournalCode extends Set<infer Code> ? Code : never;
+
+function boundedCount(value: number): number {
+  if (!Number.isSafeInteger(value) || value < 0) {
+    throw new Error('telemetry_count_invalid');
+  }
+  return value;
+}
+
+export function summarizeRuntimeTelemetry(input: {
+  runtimes: Array<{ runtimeId: string; lifecycleState: string }>;
+  descriptorCount: number;
+  recoveryBytes: number;
+  memoryPressureEvents: number;
+  taskPressureEvents: number;
+}) {
+  if (input.runtimes.length > MAX_TELEMETRY_RUNTIMES) {
+    throw new Error('telemetry_runtime_capacity');
+  }
+  const counts: Partial<Record<LifecycleState, number>> = {};
+  for (const runtime of input.runtimes) {
+    RuntimeIdSchema.parse(runtime.runtimeId);
+    const state = LifecycleStateSchema.parse(runtime.lifecycleState);
+    counts[state] = (counts[state] ?? 0) + 1;
+  }
+  const lifecycleCounts = Object.fromEntries(
+    Object.entries(counts).sort(([left], [right]) =>
+      left.localeCompare(right)),
+  );
+  return {
+    runtimeCount: input.runtimes.length,
+    lifecycleCounts,
+    descriptorCount: boundedCount(input.descriptorCount),
+    recoveryBytes: boundedCount(input.recoveryBytes),
+    memoryPressureEvents: boundedCount(input.memoryPressureEvents),
+    taskPressureEvents: boundedCount(input.taskPressureEvents),
+  };
+}
+
+export function lifecycleJournalCode(
+  runtimeId: string,
+  code: RuntimeLifecycleJournalCode,
+): { code: RuntimeLifecycleJournalCode; runtimeHash: string } {
+  const id = RuntimeIdSchema.parse(runtimeId);
+  if (!LifecycleJournalCode.has(code)) {
+    throw new Error('lifecycle_journal_code_invalid');
+  }
+  return {
+    code,
+    runtimeHash: createHash('sha256').update(id).digest('hex').slice(0, 12),
+  };
+}

--- a/tests/gateway/agent-terminal-runtime.test.ts
+++ b/tests/gateway/agent-terminal-runtime.test.ts
@@ -104,7 +104,11 @@ describe("supervised coding-agent launch", () => {
         throw new Error("supervisor rejected");
       }),
       rename: vi.fn(),
-      delete: vi.fn(),
+      recover: vi.fn(),
+      delete: vi.fn(async () => ({
+        runtimeId: "0123456789abcdef0123456789abcdef",
+        deleted: true as const,
+      })),
     };
     const zellij = { sendInput: vi.fn() };
     const supervised = createSupervisedZellijRuntime({

--- a/tests/gateway/shell-reaper.test.ts
+++ b/tests/gateway/shell-reaper.test.ts
@@ -8,6 +8,7 @@ function session(input: {
   status: "active" | "exited";
   ageMs: number;
   kind?: string;
+  lifecycleState?: string;
 }) {
   const stamp = new Date(Date.now() - input.ageMs).toISOString();
   return {
@@ -16,6 +17,9 @@ function session(input: {
     createdAt: stamp,
     updatedAt: stamp,
     ...(input.kind ? { kind: input.kind } : {}),
+    ...(input.lifecycleState
+      ? { lifecycleState: input.lifecycleState }
+      : {}),
   };
 }
 
@@ -37,6 +41,13 @@ describe("shell session reaper", () => {
         session({ name: "fresh-tagged", status: "exited", ageMs: 2 * DAY, kind: "session" }),
         session({ name: "old-legacy", status: "exited", ageMs: 30 * DAY }),
         session({ name: "old-active", status: "active", ageMs: 30 * DAY, kind: "session" }),
+        session({
+          name: "old-activating",
+          status: "exited",
+          ageMs: 30 * DAY,
+          kind: "session",
+          lifecycleState: "recovering",
+        }),
       ]),
       delete: vi.fn(async (name: string) => {
         deleted.push(name);

--- a/tests/gateway/shell-registry.test.ts
+++ b/tests/gateway/shell-registry.test.ts
@@ -19,6 +19,51 @@ afterEach(async () => {
 });
 
 describe("shell registry", () => {
+  it("projects supervised interrupted state and recovers by immutable identity", async () => {
+    const root = await tempRoot();
+    let projection = {
+      runtimeId: "0123456789abcdef0123456789abcdef",
+      displayName: "calm-otter",
+      lifecycleState: "interrupted",
+      recoverable: true,
+      recoveryReason: "history_unavailable",
+      metadataRevision: 1,
+    };
+    const adapter = {
+      listSessions: vi.fn(async () => []),
+      listRuntimeProjections: vi.fn(async () => [projection]),
+      runtimeProjection: vi.fn(() => projection),
+      recoverSession: vi.fn(async () => {
+        projection = {
+          ...projection,
+          lifecycleState: "recovering",
+          recoverable: false,
+        };
+        return projection;
+      }),
+      createSession: vi.fn(async () => undefined),
+      deleteSession: vi.fn(async () => undefined),
+    };
+    const registry = new ShellRegistry({ homePath: root, adapter });
+
+    await expect(registry.list()).resolves.toMatchObject([{
+      name: "calm-otter",
+      status: "exited",
+      runtimeId: "0123456789abcdef0123456789abcdef",
+      lifecycleState: "interrupted",
+      recoverable: true,
+      recoveryReason: "history_unavailable",
+    }]);
+    await expect(registry.recover("calm-otter")).resolves.toMatchObject({
+      name: "calm-otter",
+      runtimeId: "0123456789abcdef0123456789abcdef",
+      lifecycleState: "recovering",
+      recoverable: false,
+    });
+    expect(adapter.recoverSession).toHaveBeenCalledWith("calm-otter");
+    expect(adapter.createSession).not.toHaveBeenCalled();
+  });
+
   it("decorates listed sessions concurrently", async () => {
     const root = await tempRoot();
     const live = new Set<string>();
@@ -1528,6 +1573,45 @@ describe("shell registry", () => {
     expect(persisted.sessions.main).toBeUndefined();
     expect(persisted.sessions.docs).toBeDefined();
     expect(persisted.aliases?.["matrix-sess_run_8162a7cca11891c0"]).toBeUndefined();
+  });
+
+  it("retains metadata while supervised deletion is still draining its cgroup", async () => {
+    const root = await tempRoot();
+    const live = new Set<string>();
+    const adapter = {
+      listSessions: vi.fn(async () => [...live]),
+      createSession: vi.fn(async ({ name }: { name: string }) => {
+        live.add(name);
+      }),
+      deleteSession: vi.fn(async () => ({
+        deleted: false,
+        lifecycleState: "deleting" as const,
+      })),
+      runtimeProjection: vi.fn(() => ({
+        runtimeId: "0123456789abcdef0123456789abcdef",
+        lifecycleState: "live",
+        recoverable: false,
+        recoveryReason: null,
+        metadataRevision: 1,
+      })),
+    };
+    const registry = new ShellRegistry({ homePath: root, adapter });
+    await registry.create({ name: "calm-otter" });
+
+    await expect(registry.delete("calm-otter")).resolves.toEqual({
+      deleted: false,
+      lifecycleState: "deleting",
+    });
+    const persisted = JSON.parse(
+      await readFile(
+        join(root, "system", "shell-sessions.json"),
+        "utf8",
+      ),
+    );
+    expect(persisted.sessions["calm-otter"]).toMatchObject({
+      runtimeId: "0123456789abcdef0123456789abcdef",
+      lifecycleState: "deleting",
+    });
   });
 
   it("force deletes live orphan zellij sessions missing from metadata", async () => {

--- a/tests/gateway/shell-terminal-runtime.test.ts
+++ b/tests/gateway/shell-terminal-runtime.test.ts
@@ -54,7 +54,11 @@ function runtimeClient(): GatewayTerminalRuntimeClient {
     createShell: vi.fn(async () => ({ ...LIVE, lifecycleState: "starting" })),
     createAgent: vi.fn(async () => ({ ...LIVE, lifecycleState: "starting" })),
     rename: vi.fn(async () => ({ ...LIVE, displayName: "swift-otter", metadataRevision: 2 })),
-    delete: vi.fn(async () => undefined),
+    recover: vi.fn(async () => ({ ...LIVE, lifecycleState: "recovering" })),
+    delete: vi.fn(async () => ({
+      runtimeId: RUNTIME_ID,
+      deleted: true as const,
+    })),
   };
 }
 
@@ -125,5 +129,64 @@ describe("supervised shell adapter", () => {
     expect(() => adapter.attachSession("missing-session")).toThrow("terminal_runtime_not_resolved");
     expect(runtime.createShell).not.toHaveBeenCalled();
     expect(runtime.createAgent).not.toHaveBeenCalled();
+  });
+
+  it("lists interrupted runtimes without attaching and recovers exactly once", async () => {
+    const interrupted = {
+      ...LIVE,
+      lifecycleState: "interrupted" as const,
+      recoverable: true,
+      recoveryReason: "history_unavailable" as const,
+      recoveryMode: "fresh-shell" as const,
+    };
+    const runtime = runtimeClient();
+    vi.mocked(runtime.list).mockResolvedValue([interrupted]);
+    vi.mocked(runtime.recover).mockResolvedValue({
+      ...interrupted,
+      lifecycleState: "recovering",
+      recoverable: false,
+    });
+    const direct = directAdapter();
+    const adapter = createSupervisedZellijAdapter({
+      runtime,
+      zellij: direct.adapter,
+    });
+
+    await expect(adapter.listSessions()).resolves.toEqual([]);
+    await expect(adapter.listRuntimeProjections?.()).resolves.toEqual([
+      interrupted,
+    ]);
+    await expect(adapter.recoverSession?.("calm-otter")).resolves
+      .toMatchObject({
+        runtimeId: RUNTIME_ID,
+        displayName: "calm-otter",
+        lifecycleState: "recovering",
+      });
+
+    expect(runtime.recover).toHaveBeenCalledOnce();
+    expect(runtime.recover).toHaveBeenCalledWith(RUNTIME_ID);
+    expect(runtime.createShell).not.toHaveBeenCalled();
+    expect(direct.adapter.createSession).not.toHaveBeenCalled();
+  });
+
+  it("reports deletion as pending while the supervisor still sees a populated cgroup", async () => {
+    const runtime = runtimeClient();
+    vi.mocked(runtime.delete).mockResolvedValue({
+      runtimeId: RUNTIME_ID,
+      deleted: false,
+      lifecycleState: "deleting",
+    });
+    const direct = directAdapter();
+    const adapter = createSupervisedZellijAdapter({
+      runtime,
+      zellij: direct.adapter,
+    });
+    await adapter.listSessions();
+
+    await expect(adapter.deleteSession("calm-otter")).resolves.toEqual({
+      deleted: false,
+      lifecycleState: "deleting",
+    });
+    expect(direct.adapter.deleteSession).not.toHaveBeenCalled();
   });
 });

--- a/tests/gateway/terminal-recovery-route.test.ts
+++ b/tests/gateway/terminal-recovery-route.test.ts
@@ -1,0 +1,132 @@
+import { Hono } from "hono";
+import { describe, expect, it, vi } from "vitest";
+import { createRateLimiter } from "../../packages/gateway/src/security/rate-limiter.js";
+import {
+  createShellRoutes,
+} from "../../packages/gateway/src/shell/routes.js";
+
+function createRegistry() {
+  return {
+    list: vi.fn(async () => []),
+    create: vi.fn(async ({ name }: { name: string }) => ({ name })),
+    delete: vi.fn(async () => undefined),
+    recover: vi.fn(async (name: string) => ({
+      name,
+      runtimeId: "0123456789abcdef0123456789abcdef",
+      lifecycleState: "recovering",
+      recoverable: false,
+    })),
+  };
+}
+
+function createApp(
+  registry: ReturnType<typeof createRegistry>,
+  sessionCreateRateLimiter = createRateLimiter({
+    maxAttempts: 120,
+    windowMs: 60_000,
+    lockoutMs: 10_000,
+    maxKeys: 1,
+  }),
+) {
+  const deps = { registry, sessionCreateRateLimiter };
+  const app = new Hono();
+  app.route("/api/terminal", createShellRoutes(deps));
+  app.route("/api", createShellRoutes(deps));
+  return app;
+}
+
+describe("terminal recovery route", () => {
+  it("accepts no body or exactly an empty object and reports readiness honestly", async () => {
+    const registry = createRegistry();
+    const app = createApp(registry);
+
+    const recovering = await app.request(
+      "/api/terminal/sessions/calm-otter/recover",
+      { method: "POST" },
+    );
+    expect(recovering.status).toBe(202);
+    await expect(recovering.json()).resolves.toMatchObject({
+      session: {
+        name: "calm-otter",
+        lifecycleState: "recovering",
+      },
+    });
+
+    registry.recover.mockResolvedValueOnce({
+      name: "calm-otter",
+      runtimeId: "0123456789abcdef0123456789abcdef",
+      lifecycleState: "live",
+      recoverable: false,
+    });
+    const live = await app.request(
+      "/api/sessions/calm-otter/recover",
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: "{}",
+      },
+    );
+    expect(live.status).toBe(200);
+    expect(registry.recover).toHaveBeenCalledTimes(2);
+  });
+
+  it("rejects non-empty bodies, invalid names, and oversized requests generically", async () => {
+    const registry = createRegistry();
+    const app = createApp(registry);
+    const invalidBody = await app.request(
+      "/api/terminal/sessions/calm-otter/recover",
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ force: true }),
+      },
+    );
+    const invalidName = await app.request(
+      "/api/terminal/sessions/Bad%20Name/recover",
+      { method: "POST" },
+    );
+    const oversized = await app.request(
+      "/api/terminal/sessions/calm-otter/recover",
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: " ".repeat(2_000),
+      },
+    );
+
+    expect(invalidBody.status).toBe(400);
+    expect(invalidName.status).toBe(400);
+    expect(oversized.status).toBe(413);
+    await expect(invalidBody.json()).resolves.toEqual({
+      error: { code: "invalid_request", message: "Invalid request" },
+    });
+    expect(registry.recover).not.toHaveBeenCalled();
+  });
+
+  it("shares the create/recover limiter across canonical and legacy mounts", async () => {
+    const registry = createRegistry();
+    const limiter = createRateLimiter({
+      maxAttempts: 1,
+      windowMs: 60_000,
+      lockoutMs: 10_000,
+      maxKeys: 1,
+    });
+    const app = createApp(registry, limiter);
+
+    expect((await app.request("/api/terminal/sessions", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ name: "first-shell" }),
+    })).status).toBe(201);
+    const response = await app.request(
+      "/api/sessions/calm-otter/recover",
+      { method: "POST" },
+    );
+
+    expect(response.status).toBe(429);
+    await expect(response.json()).resolves.toEqual({
+      error: { code: "rate_limited", message: "Request failed" },
+    });
+    expect(registry.recover).not.toHaveBeenCalled();
+  });
+});

--- a/tests/terminal-runtime/operation-handler.test.ts
+++ b/tests/terminal-runtime/operation-handler.test.ts
@@ -41,6 +41,13 @@ describe('terminal runtime operation handler', () => {
   });
   async function setup(
     resolveCwd = async (cwd: { kind: 'home-relative'; path: string }) => cwd,
+    artifacts?: {
+      inspect(runtimeId: string): Promise<{
+        state: 'valid' | 'missing' | 'corrupt' | 'incompatible';
+      }>;
+      remove(runtimeId: string): Promise<void>;
+      prune(input: { protectedRuntimeIds: Set<string> }): Promise<unknown>;
+    },
   ) {
     root = await mkdtemp(join(tmpdir(), 'matrix-terminal-handler-'));
     state = await createRuntimeState({
@@ -55,6 +62,7 @@ describe('terminal runtime operation handler', () => {
       bootId: async () => 'boot-id-1',
       createId: () => RUNTIME_ID,
       resolveCwd,
+      ...(artifacts ? { artifacts } : {}),
     });
     return { handle, systemd };
   }
@@ -124,6 +132,52 @@ describe('terminal runtime operation handler', () => {
     expect(retry).toEqual(first);
     expect(systemd.start).toHaveBeenCalledTimes(1);
   });
+  it.each([
+    ['valid', 'serialized', null],
+    ['missing', 'fresh-shell', 'history_unavailable'],
+    ['corrupt', 'fresh-shell', 'history_unavailable'],
+    ['incompatible', 'fresh-shell', 'history_unavailable'],
+  ] as const)(
+    'projects %s resurrection state into explicit recovery mode %s',
+    async (artifactState, recoveryMode, recoveryReason) => {
+      const artifacts = {
+        inspect: vi.fn(async () => ({ state: artifactState })),
+        remove: vi.fn(async () => undefined),
+        prune: vi.fn(async () => ({ removedRuntimeIds: [] })),
+      };
+      const { handle } = await setup(undefined, artifacts);
+      await handle(createRequest());
+      await state!.receipts.replace({
+        schemaVersion: 1,
+        runtimeId: RUNTIME_ID,
+        displayName: 'primary',
+        cwd: { kind: 'home-relative', path: 'projects/matrix' },
+        createdAt: NOW.toISOString(),
+        metadataRevision: 1,
+        lastKnown: {
+          state: 'interrupted',
+          at: NOW.toISOString(),
+          bootId: 'old-boot',
+        },
+        zellij: { sessionName: `matrix-t-${RUNTIME_ID}` },
+      });
+
+      await expect(handle({
+        version: 1,
+        operation: 'Inspect',
+        operationId: '21000000000000000000000000000000',
+        input: { runtimeId: RUNTIME_ID },
+      })).resolves.toMatchObject({
+        ok: true,
+        result: {
+          lifecycleState: 'interrupted',
+          recoverable: true,
+          recoveryMode,
+          recoveryReason,
+        },
+      });
+    },
+  );
   it('lists receipt-only runtimes and assigns unique ordered operation generations', async () => {
     const { handle, systemd } = await setup();
     await handle(createRequest());
@@ -233,7 +287,12 @@ describe('terminal runtime operation handler', () => {
     expect(systemd.start).toHaveBeenCalledWith(RUNTIME_ID);
   });
   it('reconcile completes deletion only after the cgroup is empty', async () => {
-    const { handle, systemd } = await setup();
+    const artifacts = {
+      inspect: vi.fn(async () => ({ state: 'missing' as const })),
+      remove: vi.fn(async () => undefined),
+      prune: vi.fn(async () => ({ removedRuntimeIds: [] })),
+    };
+    const { handle, systemd } = await setup(undefined, artifacts);
     await handle(createRequest());
     vi.mocked(systemd.inspect).mockResolvedValueOnce({
       runtimeId: RUNTIME_ID, unit: 'inactive', cgroupPopulated: true,
@@ -247,12 +306,53 @@ describe('terminal runtime operation handler', () => {
     })).resolves.toMatchObject({
       ok: true, result: { lifecycleState: 'deleting' },
     });
+    expect(artifacts.remove).not.toHaveBeenCalled();
     await handle({
       version: 1, operation: 'Reconcile',
       operationId: '70000000000000000000000000000000', input: {},
     });
     expect(await state!.receipts.read(RUNTIME_ID)).toBeNull();
     expect(await state!.names.resolve('primary', NOW.getTime())).toBeNull();
+    expect(artifacts.remove).toHaveBeenCalledWith(RUNTIME_ID);
+  });
+  it('serializes Delete before Recover and never recreates removed state', async () => {
+    let releaseStop = () => undefined;
+    const stopGate = new Promise<void>((resolveStop) => {
+      releaseStop = resolveStop;
+    });
+    const artifacts = {
+      inspect: vi.fn(async () => ({ state: 'missing' as const })),
+      remove: vi.fn(async () => undefined),
+      prune: vi.fn(async () => ({ removedRuntimeIds: [] })),
+    };
+    const { handle, systemd } = await setup(undefined, artifacts);
+    await handle(createRequest());
+    vi.mocked(systemd.start).mockClear();
+    vi.mocked(systemd.stop).mockImplementationOnce(async () => await stopGate);
+    const deleting = handle({
+      version: 1,
+      operation: 'Delete',
+      operationId: '61000000000000000000000000000000',
+      input: { runtimeId: RUNTIME_ID },
+    });
+    await vi.waitFor(() => expect(systemd.stop).toHaveBeenCalledTimes(1));
+    const recovering = handle({
+      version: 1,
+      operation: 'Recover',
+      operationId: '62000000000000000000000000000000',
+      input: { runtimeId: RUNTIME_ID },
+    });
+    releaseStop();
+
+    await expect(deleting).resolves.toMatchObject({
+      ok: true,
+      result: { deleted: true },
+    });
+    await expect(recovering).resolves.toMatchObject({
+      ok: false,
+      error: { code: 'not_found' },
+    });
+    expect(systemd.start).not.toHaveBeenCalled();
   });
   it('fails before launch when cwd cannot be resolved inside the owner home', async () => {
     const { handle, systemd } = await setup(async () => {

--- a/tests/terminal-runtime/operation-handler.test.ts
+++ b/tests/terminal-runtime/operation-handler.test.ts
@@ -147,6 +147,7 @@ describe('terminal runtime operation handler', () => {
       };
       const { handle } = await setup(undefined, artifacts);
       await handle(createRequest());
+      await state!.descriptors.removeRuntime(RUNTIME_ID);
       await state!.receipts.replace({
         schemaVersion: 1,
         runtimeId: RUNTIME_ID,
@@ -155,7 +156,7 @@ describe('terminal runtime operation handler', () => {
         createdAt: NOW.toISOString(),
         metadataRevision: 1,
         lastKnown: {
-          state: 'interrupted',
+          state: 'live',
           at: NOW.toISOString(),
           bootId: 'old-boot',
         },

--- a/tests/terminal-runtime/recovery-state.test.ts
+++ b/tests/terminal-runtime/recovery-state.test.ts
@@ -1,0 +1,134 @@
+import {
+  lstat,
+  mkdir,
+  mkdtemp,
+  readFile,
+  rm,
+  symlink,
+  utimes,
+  writeFile,
+} from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  createZellijRecoveryStore,
+  zellijSessionStatePath,
+} from "../../packages/terminal-runtime/src/recovery-state.js";
+
+const FIRST = "0123456789abcdef0123456789abcdef";
+const SECOND = "11111111111111111111111111111111";
+const THIRD = "22222222222222222222222222222222";
+const roots: string[] = [];
+
+async function tempRoot() {
+  const root = await mkdtemp(join(tmpdir(), "matrix-zellij-recovery-"));
+  roots.push(root);
+  return root;
+}
+
+async function writeState(
+  cacheRoot: string,
+  runtimeId: string,
+  layout = "layout {\n  pane\n}\n",
+) {
+  const directory = zellijSessionStatePath(cacheRoot, runtimeId);
+  await mkdir(directory, { recursive: true, mode: 0o700 });
+  await writeFile(join(directory, "session-layout.kdl"), layout, {
+    mode: 0o600,
+  });
+  await writeFile(join(directory, "initial_contents_1"), "saved output\n", {
+    mode: 0o600,
+  });
+  return directory;
+}
+
+afterEach(async () => {
+  await Promise.all(
+    roots.splice(0).map((root) => rm(root, { recursive: true, force: true })),
+  );
+});
+
+describe("Zellij recovery state", () => {
+  it("maps exact v0.44.3 contract state and classifies missing, corrupt, and incompatible sets", async () => {
+    const cacheRoot = await tempRoot();
+    await writeState(cacheRoot, FIRST);
+    await writeState(cacheRoot, SECOND, "layout {\n  pane {\n");
+    const incompatible = join(
+      cacheRoot,
+      "zellij",
+      "contract_version_2",
+      "session_info",
+      `matrix-t-${THIRD}`,
+    );
+    await mkdir(incompatible, { recursive: true, mode: 0o700 });
+    await writeFile(join(incompatible, "session-layout.kdl"), "layout {}\n");
+    const store = createZellijRecoveryStore({ cacheRoot });
+
+    await expect(store.inspect(FIRST)).resolves.toMatchObject({
+      state: "valid",
+      files: 2,
+    });
+    await expect(store.inspect(SECOND)).resolves.toMatchObject({
+      state: "corrupt",
+    });
+    await expect(store.inspect(THIRD)).resolves.toMatchObject({
+      state: "incompatible",
+    });
+    await expect(
+      store.inspect("33333333333333333333333333333333"),
+    ).resolves.toEqual({
+      state: "missing",
+      bytes: 0,
+      files: 0,
+      updatedAtMs: null,
+    });
+  });
+
+  it("removes only the exact runtime state without following attacker symlinks", async () => {
+    const cacheRoot = await tempRoot();
+    const directory = await writeState(cacheRoot, FIRST);
+    const protectedFile = join(cacheRoot, "protected");
+    await writeFile(protectedFile, "keep");
+    await symlink(protectedFile, join(directory, "untrusted-link"));
+    await writeState(cacheRoot, SECOND);
+    const store = createZellijRecoveryStore({ cacheRoot });
+
+    await store.remove(FIRST);
+
+    await expect(readFile(protectedFile, "utf8")).resolves.toBe("keep");
+    await expect(lstat(join(directory, "session-layout.kdl"))).rejects
+      .toMatchObject({ code: "ENOENT" });
+    await expect(store.inspect(SECOND)).resolves.toMatchObject({
+      state: "valid",
+    });
+  });
+
+  it("prunes oldest inactive state for count, age, and bytes but never protected live state", async () => {
+    const cacheRoot = await tempRoot();
+    const first = await writeState(cacheRoot, FIRST);
+    const second = await writeState(cacheRoot, SECOND);
+    const third = await writeState(cacheRoot, THIRD);
+    await utimes(first, 1, 1);
+    await utimes(second, 2, 2);
+    await utimes(third, 3, 3);
+    const store = createZellijRecoveryStore({ cacheRoot });
+
+    const result = await store.prune({
+      protectedRuntimeIds: new Set([FIRST]),
+      nowMs: 10_000,
+      retentionMs: 5_000,
+      maxInactiveSets: 1,
+      aggregateTargetBytes: 1,
+      perRuntimeTargetBytes: 1,
+    });
+
+    expect(result.removedRuntimeIds).toEqual([SECOND, THIRD]);
+    await expect(store.inspect(FIRST)).resolves.toMatchObject({
+      state: "valid",
+    });
+    await expect(store.inspect(SECOND)).resolves.toMatchObject({
+      state: "missing",
+    });
+  });
+});

--- a/tests/terminal-runtime/services.test.ts
+++ b/tests/terminal-runtime/services.test.ts
@@ -1,3 +1,4 @@
+import { readFile } from 'node:fs/promises';
 import { describe, expect, it, vi } from 'vitest';
 import {
   buildKeeperLaunch,
@@ -23,6 +24,18 @@ const runtimeId = '0123456789abcdef0123456789abcdef';
 const operationId = 'fedcba9876543210fedcba9876543210';
 
 describe('terminal runtime service boundary', () => {
+  it('uses the exact verified v0.44.3 serialization options without forced commands', async () => {
+    const config = await readFile(
+      'packages/terminal-runtime/assets/config.kdl',
+      'utf8',
+    );
+    expect(config).toContain('session_serialization true');
+    expect(config).toContain('serialize_pane_viewport true');
+    expect(config).toContain('scrollback_lines_to_serialize 10000');
+    expect(config).toContain('serialization_interval 5');
+    expect(config).not.toContain('--force-run-commands');
+  });
+
   it('runs a keeper launched through the atomically switched generation symlink', () => {
     expect(isKeeperEntrypoint(
       'file:///opt/matrix/libexec/terminal-runtime/v1/abc/keeper.js',

--- a/tests/terminal-runtime/telemetry.test.ts
+++ b/tests/terminal-runtime/telemetry.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import {
+  lifecycleJournalCode,
+  summarizeRuntimeTelemetry,
+} from "../../packages/terminal-runtime/src/telemetry.js";
+
+describe("terminal runtime telemetry", () => {
+  it("emits only bounded coarse counts, pressure, and aggregate bytes", () => {
+    const summary = summarizeRuntimeTelemetry({
+      runtimes: [
+        {
+          runtimeId: "0123456789abcdef0123456789abcdef",
+          lifecycleState: "live",
+        },
+        {
+          runtimeId: "11111111111111111111111111111111",
+          lifecycleState: "interrupted",
+        },
+      ],
+      descriptorCount: 3,
+      recoveryBytes: 42,
+      memoryPressureEvents: 2,
+      taskPressureEvents: 1,
+    });
+
+    expect(summary).toEqual({
+      runtimeCount: 2,
+      lifecycleCounts: {
+        interrupted: 1,
+        live: 1,
+      },
+      descriptorCount: 3,
+      recoveryBytes: 42,
+      memoryPressureEvents: 2,
+      taskPressureEvents: 1,
+    });
+    expect(JSON.stringify(summary)).not.toMatch(
+      /012345|111111|displayName|prompt|provider|path|command/i,
+    );
+  });
+
+  it("uses only a generic lifecycle code and a truncated runtime digest in journals", () => {
+    const event = lifecycleJournalCode(
+      "0123456789abcdef0123456789abcdef",
+      "recovery_started",
+    );
+    expect(event).toEqual({
+      code: "recovery_started",
+      runtimeHash: expect.stringMatching(/^[0-9a-f]{12}$/),
+    });
+    expect(JSON.stringify(event)).not.toContain("0123456789abcdef");
+    expect(() => lifecycleJournalCode(
+      "0123456789abcdef0123456789abcdef",
+      "private prompt" as never,
+    )).toThrow();
+  });
+});


### PR DESCRIPTION
## Summary

- add the explicit, strictly bounded terminal recovery route with one create/recover limiter shared by the canonical and legacy mounts
- project authoritative supervisor lifecycle state into shell reads and reject input/attach operations until the immutable runtime is live
- classify the exact Zellij 0.44.3-matrix.1 resurrection cache, restore valid serialized state with native command confirmation, and fall back to a fresh shell for missing/corrupt/incompatible history
- make deletion wait for an empty cgroup before removing receipts, name metadata, agent state, gateway scrollback, and runtime-specific Zellij state
- add protected-live retention/pruning, stale agent-state cleanup after authoritative loss, reaper safeguards, and coarse privacy-preserving telemetry

This is layer 7 of the production terminal-persistence Graphite stack. Supervised runtimes remain dormant by default; this PR does not activate production ownership or add the recovery UI.

## Tests

- `pnpm exec vitest run tests/gateway/terminal-recovery-route.test.ts tests/gateway/shell-registry.test.ts tests/gateway/shell-terminal-runtime.test.ts tests/gateway/shell-reaper.test.ts tests/gateway/agent-terminal-runtime.test.ts tests/terminal-runtime/operation-handler.test.ts tests/terminal-runtime/recovery-state.test.ts tests/terminal-runtime/services.test.ts tests/terminal-runtime/telemetry.test.ts` — 104 passed
- `pnpm --filter @matrix-os/terminal-runtime typecheck` — passed
- `pnpm --dir packages/gateway exec tsc --noEmit` — passed
- `bash scripts/review/check-patterns.sh` — 0 violations; repository-wide advisory warnings only
- `git diff --check` — passed

## Review/Monitoring

- Frozen exact head: `d9a0b442f0f77e063c341f404f7459f2cee5154c`.
- Exact-head CI [passed](https://github.com/HamedMP/matrix-os/actions/runs/30959156089).
- Exact-head Docker [passed](https://github.com/HamedMP/matrix-os/actions/runs/30959154028).
- Exact-head preview build/publish workflows passed.
- Exact-head Greptile: 5/5; unresolved review threads: 0.
- Recovery APIs remain dormant until production activation. Do not merge this layer independently.

## Invariants

- **Source of truth:** systemd unit/cgroup/readiness evidence remains authoritative for liveness. Receipts express identity and recovery intent; Zellij cache inspection chooses serialized versus fresh-shell recovery but never proves a runtime live.
- **Lock/transaction scope:** supervisor operations continue under the global name-index lock followed by the per-runtime flock. Recovery classification, delete intent, cgroup-empty verification, metadata removal, and reconciliation use that ordered critical section; no network calls occur inside it.
- **Acceptable orphan states:** a failed recovery retains its receipt and can be retried; a failed or populated delete remains `deleting` and retains all state; a failed pruning/removal sweep is retried by reconciliation. Missing/corrupt/incompatible resurrection state produces a bounded fresh-shell reason and never reruns an agent.
- **Auth source of truth:** existing gateway owner authentication remains global to both terminal mounts. The route validates the name and empty body before dispatch, while the root supervisor independently authenticates the gateway through `SO_PEERCRED`.
- **Deferred scope:** this layer does not add Canvas/Desktop recovery UI, migrate saved layouts, activate supervised mode by default, migrate legacy sessions, restart live terminal services, merge, or deploy to stable.
