### PR TITLE
fix(ci): scope Docker tests to local runtime changes

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -58,7 +58,7 @@ OTA payloads.
 | Workflow | Owner | When it runs | Required? |
 | --- | --- | --- | --- |
 | `ci.yml` | Core code validation | `ready-for-ci`, ready PRs, merge queue, `main`, manual | Yes, via `CI Results` |
-| `docker-test.yml` | Legacy/local Docker scenario validation | `ready-for-ci`, ready PRs, merge queue, `main`, nightly, manual | Required when Docker/runtime paths are touched |
+| `docker-test.yml` | Legacy/local Docker scenario validation | Docker/local-runtime changes on `ready-for-ci`, ready PRs, and `main`; every merge queue, nightly, and manual run | Required when Docker/local-runtime paths are touched |
 | `host-bundle-release.yml` | VPS-native customer runtime release | `main`, `v*` tags, manual | Required for host bundle publishing |
 | `platform-cloud-run.yml` | Platform/app-shell Cloud Run deployment | `main` when platform/auth-shell inputs change, manual | Required for app.matrix-os.com platform changes |
 | `release.yml` / `cli-release.yml` | Installable `@finnaai/matrix` CLI release plus standalone binaries | Manual CLI release | Required for CLI publishing |
@@ -84,6 +84,21 @@ Workflows must fail closed if the script exits non-zero, emits invalid JSON, or
 returns an unknown lane. `runtime/*` tags are intentionally invalid until the
 host-bundle release workflow migrates away from the existing `v*` runtime tag
 contract.
+
+## Docker Relevance Router
+
+Use `scripts/ci/docker-relevance.mjs` as the source of truth for whether a PR or
+`main` push needs the legacy/local Docker validation. It includes the dev image,
+Compose and startup configuration, Docker scenario harness, root workspace
+metadata, gateway/kernel/shell dependencies, home templates, and the shared
+sync-client protocol imported by the gateway. Platform-only, proxy-only,
+installable CLI, desktop/mobile, docs/specs, and unrelated workflow changes do
+not spend a Docker runner.
+
+The PR and `main` paths are relevance-filtered for cost and signal. The merge
+queue, nightly, and manual runs remain comprehensive so an incomplete path rule
+cannot silently remove the recurring full scenario coverage. Classification
+errors fail the workflow instead of being interpreted as an irrelevant change.
 
 ## Release Rules
 

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -91,9 +91,9 @@ Use `scripts/ci/docker-relevance.mjs` as the source of truth for whether a PR or
 `main` push needs the legacy/local Docker validation. It includes the dev image,
 Compose and startup configuration, Docker scenario harness, root workspace
 metadata, gateway/kernel/shell dependencies, home templates, and the shared
-sync-client protocol imported by the gateway. Platform-only, proxy-only,
-installable CLI, desktop/mobile, docs/specs, and unrelated workflow changes do
-not spend a Docker runner.
+sync-client protocol and package export manifest imported by the gateway.
+Platform-only, proxy-only, installable CLI, desktop/mobile, docs/specs, and
+unrelated workflow changes do not spend a Docker runner.
 
 The PR and `main` paths are relevance-filtered for cost and signal. The merge
 queue, nightly, and manual runs remain comprehensive so an incomplete path rule

--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -28,7 +28,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Detect source changes
+      - name: Classify Docker/local-runtime changes
         id: changed
         env:
           PR_ACTION: ${{ github.event.action || '' }}
@@ -59,29 +59,23 @@ jobs:
 
           if [ "$GITHUB_EVENT_NAME" = "pull_request" ]; then
             git fetch --no-tags --depth=1 origin "$GITHUB_BASE_REF"
-            changed_files="$(git diff --name-only "origin/$GITHUB_BASE_REF" "$GITHUB_SHA")"
+            node scripts/ci/docker-relevance.mjs \
+              --base "origin/$GITHUB_BASE_REF" \
+              --head "$GITHUB_SHA" \
+              --format github >> "$GITHUB_OUTPUT"
           else
             zero_sha="0000000000000000000000000000000000000000"
             if [ -n "${GITHUB_EVENT_BEFORE:-}" ] && [ "$GITHUB_EVENT_BEFORE" != "$zero_sha" ] && git cat-file -e "${GITHUB_EVENT_BEFORE}^{commit}" 2>/dev/null; then
-              changed_files="$(git diff --name-only "$GITHUB_EVENT_BEFORE" "$GITHUB_SHA")"
+              node scripts/ci/docker-relevance.mjs \
+                --base "$GITHUB_EVENT_BEFORE" \
+                --head "$GITHUB_SHA" \
+                --format github >> "$GITHUB_OUTPUT"
             else
-              changed_files="$(git show --pretty= --name-only "$GITHUB_SHA")"
+              node scripts/ci/docker-relevance.mjs \
+                --commit "$GITHUB_SHA" \
+                --format github >> "$GITHUB_OUTPUT"
             fi
           fi
-
-          should_run=false
-          while IFS= read -r file; do
-            [ -z "$file" ] && continue
-            case "$file" in
-              docs/*|specs/*|*.md) ;;
-              *) should_run=true; break ;;
-            esac
-          done <<EOF
-          $changed_files
-          EOF
-
-          echo "should_run=$should_run" >> "$GITHUB_OUTPUT"
-          echo "Docker relevant changes: $should_run"
 
   docker-build:
     name: Build Docker Test Image

--- a/scripts/ci/docker-relevance.mjs
+++ b/scripts/ci/docker-relevance.mjs
@@ -102,10 +102,7 @@ export function readChangedPaths(
   }
 
   const stdout = typeof result.stdout === "string" ? result.stdout : "";
-  const paths = stdout
-    .split("\n")
-    .map((line) => line.trim())
-    .filter(Boolean);
+  const paths = stdout.split("\0").filter(Boolean);
 
   if (paths.length > MAX_CHANGED_PATHS) {
     throw new Error(`Git returned more than ${MAX_CHANGED_PATHS} changed paths`);
@@ -127,7 +124,7 @@ function buildGitArgs({ base, head, commit }) {
       throw new Error("--commit cannot be combined with --base or --head");
     }
     validateGitRef(commit, "--commit");
-    return ["show", "--pretty=", "--name-only", "--no-renames", commit, "--"];
+    return ["show", "--pretty=", "--name-only", "--no-renames", "-z", commit, "--"];
   }
 
   if (!base || !head) {
@@ -135,7 +132,7 @@ function buildGitArgs({ base, head, commit }) {
   }
   validateGitRef(base, "--base");
   validateGitRef(head, "--head");
-  return ["diff", "--name-only", "--no-renames", `${base}..${head}`, "--"];
+  return ["diff", "--name-only", "--no-renames", "-z", `${base}..${head}`, "--"];
 }
 
 function validateGitRef(ref, flag) {

--- a/scripts/ci/docker-relevance.mjs
+++ b/scripts/ci/docker-relevance.mjs
@@ -1,0 +1,274 @@
+#!/usr/bin/env node
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+export const GIT_DIFF_TIMEOUT_MS = 30_000;
+export const GIT_MAX_BUFFER_BYTES = 4 * 1024 * 1024;
+export const MAX_CHANGED_PATHS = 10_000;
+export const MAX_MATCHED_PATHS = 20;
+export const MAX_DIAGNOSTIC_CHARS = 2_000;
+
+const ROOT_DOCKER_INPUTS = Object.freeze([
+  ".dockerignore",
+  ".env.docker.example",
+  ".npmrc",
+  "Dockerfile",
+  "Dockerfile.dev",
+  "package.json",
+  "pnpm-lock.yaml",
+  "pnpm-workspace.yaml",
+  "tsconfig.json",
+]);
+
+const EXACT_DOCKER_INPUTS = Object.freeze([
+  ".github/workflows/docker-test.yml",
+  "distro/cloudflared-dev-vps.yml",
+  "distro/conduit.toml",
+  "distro/docker-dev-entrypoint.sh",
+  "distro/init-postgres.sh",
+  "distro/p10k.zsh",
+  "distro/zshrc",
+  "scripts/branch-dev.sh",
+  "scripts/build-default-apps.mjs",
+  "scripts/ci/docker-relevance.mjs",
+  "scripts/fix-node-pty-perms.mjs",
+  "scripts/sync-matrix-agent-skills.sh",
+]);
+
+const DOCKER_INPUT_PREFIXES = Object.freeze([
+  "distro/observability/",
+  "home/",
+  "packages/brand/",
+  "packages/contracts/",
+  "packages/gateway/",
+  "packages/kernel/",
+  "packages/mcp-browser/",
+  "packages/observability/",
+  "packages/sync-client/src/protocol/",
+  "packages/ui/",
+  "scripts/docker-test/",
+  "shell/",
+  "skills/",
+]);
+
+export function classifyDockerChanges(changedPaths = []) {
+  if (!Array.isArray(changedPaths)) {
+    throw new Error("Changed paths must be an array");
+  }
+  if (changedPaths.length > MAX_CHANGED_PATHS) {
+    throw new Error(`Changed path count exceeds the ${MAX_CHANGED_PATHS} path limit`);
+  }
+
+  const matchedPaths = [];
+  for (const path of changedPaths) {
+    const normalized = normalizePath(path);
+    if (!normalized || !isDockerRelevantPath(normalized)) {
+      continue;
+    }
+    if (matchedPaths.length < MAX_MATCHED_PATHS && !matchedPaths.includes(normalized)) {
+      matchedPaths.push(normalized);
+    }
+  }
+
+  if (matchedPaths.length > 0) {
+    return {
+      shouldRun: true,
+      reason: "Docker/local-runtime inputs changed",
+      matchedPaths,
+    };
+  }
+
+  return {
+    shouldRun: false,
+    reason: "no Docker/local-runtime inputs changed",
+    matchedPaths: [],
+  };
+}
+
+export function readChangedPaths(
+  { base = "", head = "", commit = "" } = {},
+  { spawnGit = spawnSync } = {},
+) {
+  const args = buildGitArgs({ base, head, commit });
+  const result = spawnGit("git", args, {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+    timeout: GIT_DIFF_TIMEOUT_MS,
+    maxBuffer: GIT_MAX_BUFFER_BYTES,
+  });
+
+  if (result.error || result.status !== 0) {
+    throw new Error(`git ${args[0]} failed: ${formatGitFailure(args, result)}`);
+  }
+
+  const stdout = typeof result.stdout === "string" ? result.stdout : "";
+  const paths = stdout
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean);
+
+  if (paths.length > MAX_CHANGED_PATHS) {
+    throw new Error(`Git returned more than ${MAX_CHANGED_PATHS} changed paths`);
+  }
+  return paths;
+}
+
+export function formatGitFailure(args, result) {
+  if (result.error instanceof Error) {
+    return truncateDiagnostic(result.error.message || String(result.error));
+  }
+  const stderr = typeof result.stderr === "string" ? result.stderr.trim() : "";
+  return truncateDiagnostic(stderr || `git ${args.join(" ")} failed`);
+}
+
+function buildGitArgs({ base, head, commit }) {
+  if (commit) {
+    if (base || head) {
+      throw new Error("--commit cannot be combined with --base or --head");
+    }
+    validateGitRef(commit, "--commit");
+    return ["show", "--pretty=", "--name-only", "--no-renames", commit, "--"];
+  }
+
+  if (!base || !head) {
+    throw new Error("Both --base and --head are required for a git diff");
+  }
+  validateGitRef(base, "--base");
+  validateGitRef(head, "--head");
+  return ["diff", "--name-only", "--no-renames", `${base}..${head}`, "--"];
+}
+
+function validateGitRef(ref, flag) {
+  if (
+    typeof ref !== "string" ||
+    ref.length === 0 ||
+    ref.length > 256 ||
+    ref.startsWith("-") ||
+    /[\0\r\n]/.test(ref)
+  ) {
+    throw new Error(`${flag} contains an invalid git revision`);
+  }
+}
+
+function normalizePath(path) {
+  if (typeof path !== "string") {
+    throw new Error("Every changed path must be a string");
+  }
+  if (path.length > 4_096 || /[\0\r\n]/.test(path)) {
+    throw new Error("Changed path contains invalid characters or exceeds 4096 characters");
+  }
+  return path.replaceAll("\\", "/").replace(/^\.\/+/, "").replace(/\/{2,}/g, "/");
+}
+
+function isDockerRelevantPath(path) {
+  if (ROOT_DOCKER_INPUTS.includes(path) || EXACT_DOCKER_INPUTS.includes(path)) {
+    return true;
+  }
+  if (/^docker-compose(?:\.[^/]+)?\.ya?ml$/.test(path)) {
+    return true;
+  }
+  if (/^distro\/docker-compose\.(?:local|multi)\.ya?ml$/.test(path)) {
+    return true;
+  }
+  return DOCKER_INPUT_PREFIXES.some((prefix) => path.startsWith(prefix));
+}
+
+function truncateDiagnostic(message) {
+  const normalized = String(message).replace(/[\r\n]+/g, " ").trim();
+  if (normalized.length <= MAX_DIAGNOSTIC_CHARS) {
+    return normalized;
+  }
+  return `${normalized.slice(0, MAX_DIAGNOSTIC_CHARS - 1)}…`;
+}
+
+function parseArgs(argv) {
+  const parsed = {
+    base: "",
+    head: "",
+    commit: "",
+    paths: [],
+    format: "json",
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === "--base") parsed.base = requireValue(argv, ++index, arg);
+    else if (arg === "--head") parsed.head = requireValue(argv, ++index, arg);
+    else if (arg === "--commit") parsed.commit = requireValue(argv, ++index, arg);
+    else if (arg === "--path") parsed.paths.push(requireValue(argv, ++index, arg));
+    else if (arg === "--format") parsed.format = requireValue(argv, ++index, arg);
+    else if (arg === "--help" || arg === "-h") parsed.help = true;
+    else throw new Error(`Unknown argument: ${arg}`);
+  }
+
+  if (parsed.paths.length > MAX_CHANGED_PATHS) {
+    throw new Error(`--path may be repeated at most ${MAX_CHANGED_PATHS} times`);
+  }
+  if (parsed.format !== "json" && parsed.format !== "github") {
+    throw new Error("--format must be either json or github");
+  }
+  return parsed;
+}
+
+function requireValue(argv, index, flag) {
+  const value = argv[index];
+  if (!value || value.startsWith("--")) {
+    throw new Error(`${flag} requires a value`);
+  }
+  return value;
+}
+
+function resolveChangedPaths(args) {
+  const hasPaths = args.paths.length > 0;
+  const hasGitSource = Boolean(args.base || args.head || args.commit);
+  if (hasPaths && hasGitSource) {
+    throw new Error("--path cannot be combined with git revision arguments");
+  }
+  if (hasPaths) {
+    return args.paths;
+  }
+  if (!hasGitSource) {
+    throw new Error("Provide --path, --commit, or both --base and --head");
+  }
+  return readChangedPaths(args);
+}
+
+function printHelp() {
+  process.stdout.write(`Usage: node scripts/ci/docker-relevance.mjs [options]
+
+Change source (choose one):
+  --base <ref> --head <ref>  Classify paths changed across a git range
+  --commit <ref>             Classify paths changed by one commit
+  --path <path>              Classify an explicit path; repeatable
+
+Output:
+  --format json              Emit the decision as JSON (default)
+  --format github            Emit should_run=true|false for GITHUB_OUTPUT
+`);
+}
+
+function main() {
+  try {
+    const args = parseArgs(process.argv.slice(2));
+    if (args.help) {
+      printHelp();
+      return;
+    }
+    const decision = classifyDockerChanges(resolveChangedPaths(args));
+    const matches = decision.matchedPaths.length > 0 ? `: ${decision.matchedPaths.join(", ")}` : "";
+    process.stderr.write(`docker-relevance: ${decision.reason}${matches}\n`);
+    if (args.format === "github") {
+      process.stdout.write(`should_run=${decision.shouldRun}\n`);
+    } else {
+      process.stdout.write(`${JSON.stringify(decision, null, 2)}\n`);
+    }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Unknown classifier failure";
+    process.stderr.write(`docker-relevance: ${truncateDiagnostic(message)}\n`);
+    process.exitCode = 1;
+  }
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  main();
+}

--- a/scripts/ci/docker-relevance.mjs
+++ b/scripts/ci/docker-relevance.mjs
@@ -33,6 +33,7 @@ const EXACT_DOCKER_INPUTS = Object.freeze([
   "scripts/ci/docker-relevance.mjs",
   "scripts/fix-node-pty-perms.mjs",
   "scripts/sync-matrix-agent-skills.sh",
+  "packages/sync-client/package.json",
 ]);
 
 const DOCKER_INPUT_PREFIXES = Object.freeze([

--- a/tests/platform/ci-workflows.test.ts
+++ b/tests/platform/ci-workflows.test.ts
@@ -172,7 +172,8 @@ describe('CI workflows', () => {
     const readme = readFileSync(join(root, '.github/workflows/README.md'), 'utf8');
 
     expect(workflow).toContain('node scripts/ci/docker-relevance.mjs');
-    expect(workflow).toContain('--base "origin/$GITHUB_BASE_REF" --head "$GITHUB_SHA"');
+    expect(workflow).toContain('--base "origin/$GITHUB_BASE_REF"');
+    expect(workflow).toContain('--head "$GITHUB_SHA"');
     expect(workflow).toContain('--commit "$GITHUB_SHA"');
     expect(workflow).toContain('--format github >> "$GITHUB_OUTPUT"');
     expect(workflow).toContain('[ "$GITHUB_EVENT_NAME" = "merge_group" ]');
@@ -180,7 +181,7 @@ describe('CI workflows', () => {
     expect(workflow).toContain('[ "$GITHUB_EVENT_NAME" = "workflow_dispatch" ]');
     expect(workflow).not.toContain('case "$file" in');
     expect(readme).toContain('scripts/ci/docker-relevance.mjs');
-    expect(readme).toContain('merge queue, nightly, and manual runs remain comprehensive');
+    expect(readme).toMatch(/merge\s+queue, nightly, and manual runs remain comprehensive/);
   });
 
   it('gives Docker scenario jobs enough timeout for slow artifact transfer before tests start', () => {

--- a/tests/platform/ci-workflows.test.ts
+++ b/tests/platform/ci-workflows.test.ts
@@ -166,6 +166,23 @@ describe('CI workflows', () => {
     expect(workflow).toContain('Full Docker scenario matrix covers push runs; PR smoke runs only on pull_request events.');
   });
 
+  it('routes PR and main Docker checks through the tested relevance classifier', () => {
+    const root = process.cwd();
+    const workflow = readFileSync(join(root, '.github/workflows/docker-test.yml'), 'utf8');
+    const readme = readFileSync(join(root, '.github/workflows/README.md'), 'utf8');
+
+    expect(workflow).toContain('node scripts/ci/docker-relevance.mjs');
+    expect(workflow).toContain('--base "origin/$GITHUB_BASE_REF" --head "$GITHUB_SHA"');
+    expect(workflow).toContain('--commit "$GITHUB_SHA"');
+    expect(workflow).toContain('--format github >> "$GITHUB_OUTPUT"');
+    expect(workflow).toContain('[ "$GITHUB_EVENT_NAME" = "merge_group" ]');
+    expect(workflow).toContain('[ "$GITHUB_EVENT_NAME" = "schedule" ]');
+    expect(workflow).toContain('[ "$GITHUB_EVENT_NAME" = "workflow_dispatch" ]');
+    expect(workflow).not.toContain('case "$file" in');
+    expect(readme).toContain('scripts/ci/docker-relevance.mjs');
+    expect(readme).toContain('merge queue, nightly, and manual runs remain comprehensive');
+  });
+
   it('gives Docker scenario jobs enough timeout for slow artifact transfer before tests start', () => {
     const root = process.cwd();
     const workflow = readFileSync(join(root, '.github/workflows/docker-test.yml'), 'utf8');

--- a/tests/scripts/docker-relevance.test.ts
+++ b/tests/scripts/docker-relevance.test.ts
@@ -41,6 +41,7 @@ describe("Docker CI relevance classifier", () => {
     "shell/app/page.tsx",
     "home/system/config.json",
     "skills/matrix/SKILL.md",
+    "packages/sync-client/package.json",
     "packages/sync-client/src/protocol/messages.ts",
   ])("runs for Docker/local-runtime input %s", (path) => {
     expect(classifyDockerChanges([path])).toMatchObject({
@@ -53,7 +54,6 @@ describe("Docker CI relevance classifier", () => {
     "Dockerfile.platform",
     "distro/docker-compose.platform.yml",
     "packages/cli/src/index.ts",
-    "packages/sync-client/package.json",
     "packages/sync-client/src/commands/login.ts",
     "packages/platform/src/index.ts",
     "packages/proxy/src/index.ts",

--- a/tests/scripts/docker-relevance.test.ts
+++ b/tests/scripts/docker-relevance.test.ts
@@ -129,6 +129,24 @@ describe("Docker CI relevance classifier", () => {
     ).toThrow(/ETIMEDOUT/);
   });
 
+  it("parses NUL-delimited git paths without trimming significant whitespace", () => {
+    const paths = readChangedPaths(
+      { base: "origin/main", head: "head-sha", commit: "" },
+      {
+        spawnGit: (_command, args) => {
+          expect(args).toContain("-z");
+          return {
+            status: 0,
+            stdout: "shell/path with space.tsx\0 packages/gateway/leading.ts\0",
+            stderr: "",
+          };
+        },
+      },
+    );
+
+    expect(paths).toEqual(["shell/path with space.tsx", " packages/gateway/leading.ts"]);
+  });
+
   it("bounds git diagnostics before surfacing a failure", () => {
     const message = formatGitFailure(["diff"], {
       status: 128,

--- a/tests/scripts/docker-relevance.test.ts
+++ b/tests/scripts/docker-relevance.test.ts
@@ -25,6 +25,7 @@ describe("Docker CI relevance classifier", () => {
     "scripts/docker-test/fresh-install.sh",
     "scripts/build-default-apps.mjs",
     "scripts/branch-dev.sh",
+    "scripts/ci/docker-relevance.mjs",
     "scripts/fix-node-pty-perms.mjs",
     "scripts/sync-matrix-agent-skills.sh",
     "distro/docker-dev-entrypoint.sh",
@@ -61,7 +62,7 @@ describe("Docker CI relevance classifier", () => {
     "packages/neo-worker/src/index.ts",
     "packages/symphony-elixir/lib/symphony.ex",
     "desktop/src/main.ts",
-    "mobile/app/index.tsx",
+    "apps/mobile/app/index.tsx",
     "docs/dev/docker-development.md",
     "specs/001-example/spec.md",
     "README.md",
@@ -153,11 +154,11 @@ describe("Docker CI relevance classifier", () => {
   });
 
   it.each([
-    [],
-    ["--base", "origin/main"],
-    ["--commit", "HEAD", "--path", "shell/app/page.tsx"],
-    ["--path", "shell/app/page.tsx", "--format", "xml"],
-    ["--unknown"],
+    [[]],
+    [["--base", "origin/main"]],
+    [["--commit", "HEAD", "--path", "shell/app/page.tsx"]],
+    [["--path", "shell/app/page.tsx", "--format", "xml"]],
+    [["--unknown"]],
   ])("rejects invalid CLI arguments: %j", (args) => {
     const script = join(process.cwd(), "scripts/ci/docker-relevance.mjs");
     const result = spawnSync(process.execPath, [script, ...args], {

--- a/tests/scripts/docker-relevance.test.ts
+++ b/tests/scripts/docker-relevance.test.ts
@@ -1,0 +1,184 @@
+import { spawnSync } from "node:child_process";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  classifyDockerChanges,
+  formatGitFailure,
+  GIT_DIFF_TIMEOUT_MS,
+  GIT_MAX_BUFFER_BYTES,
+  MAX_DIAGNOSTIC_CHARS,
+  readChangedPaths,
+} from "../../scripts/ci/docker-relevance.mjs";
+
+describe("Docker CI relevance classifier", () => {
+  it.each([
+    "Dockerfile",
+    "Dockerfile.dev",
+    ".dockerignore",
+    ".env.docker.example",
+    "docker-compose.dev.yml",
+    "package.json",
+    "pnpm-lock.yaml",
+    "pnpm-workspace.yaml",
+    "tsconfig.json",
+    ".github/workflows/docker-test.yml",
+    "scripts/docker-test/fresh-install.sh",
+    "scripts/build-default-apps.mjs",
+    "scripts/branch-dev.sh",
+    "scripts/fix-node-pty-perms.mjs",
+    "scripts/sync-matrix-agent-skills.sh",
+    "distro/docker-dev-entrypoint.sh",
+    "distro/init-postgres.sh",
+    "distro/observability/prometheus.yml",
+    "packages/brand/src/index.ts",
+    "packages/contracts/src/index.ts",
+    "packages/gateway/src/index.ts",
+    "packages/kernel/src/index.ts",
+    "packages/mcp-browser/src/index.ts",
+    "packages/observability/src/index.ts",
+    "packages/ui/src/Button.tsx",
+    "shell/app/page.tsx",
+    "home/system/config.json",
+    "skills/matrix/SKILL.md",
+    "packages/sync-client/src/protocol/messages.ts",
+  ])("runs for Docker/local-runtime input %s", (path) => {
+    expect(classifyDockerChanges([path])).toMatchObject({
+      shouldRun: true,
+      matchedPaths: [path],
+    });
+  });
+
+  it.each([
+    "Dockerfile.platform",
+    "distro/docker-compose.platform.yml",
+    "packages/cli/src/index.ts",
+    "packages/sync-client/package.json",
+    "packages/sync-client/src/commands/login.ts",
+    "packages/platform/src/index.ts",
+    "packages/proxy/src/index.ts",
+    "packages/edge-router/src/index.ts",
+    "packages/clerk-sync/src/index.ts",
+    "packages/neo-worker/src/index.ts",
+    "packages/symphony-elixir/lib/symphony.ex",
+    "desktop/src/main.ts",
+    "mobile/app/index.tsx",
+    "docs/dev/docker-development.md",
+    "specs/001-example/spec.md",
+    "README.md",
+    ".github/workflows/ci.yml",
+    "scripts/build-host-bundle.sh",
+  ])("skips unrelated input %s", (path) => {
+    expect(classifyDockerChanges([path])).toEqual({
+      shouldRun: false,
+      reason: "no Docker/local-runtime inputs changed",
+      matchedPaths: [],
+    });
+  });
+
+  it("runs when any path in a mixed change set is relevant", () => {
+    expect(
+      classifyDockerChanges([
+        "docs/dev/docker-development.md",
+        "packages/cli/src/index.ts",
+        "packages/gateway/src/index.ts",
+      ]),
+    ).toEqual({
+      shouldRun: true,
+      reason: "Docker/local-runtime inputs changed",
+      matchedPaths: ["packages/gateway/src/index.ts"],
+    });
+  });
+
+  it("skips an empty change set", () => {
+    expect(classifyDockerChanges([])).toEqual({
+      shouldRun: false,
+      reason: "no Docker/local-runtime inputs changed",
+      matchedPaths: [],
+    });
+  });
+
+  it("normalizes relative prefixes and Windows separators", () => {
+    expect(classifyDockerChanges(["./shell\\app\\page.tsx"]).matchedPaths).toEqual([
+      "shell/app/page.tsx",
+    ]);
+  });
+
+  it("uses bounded, timed git execution and fails closed on timeouts", () => {
+    expect(GIT_DIFF_TIMEOUT_MS).toBe(30_000);
+    expect(GIT_MAX_BUFFER_BYTES).toBeLessThanOrEqual(4 * 1024 * 1024);
+
+    expect(() =>
+      readChangedPaths(
+        { base: "origin/main", head: "head-sha", commit: "" },
+        {
+          spawnGit: (_command, _args, options) => {
+            expect(options.timeout).toBe(GIT_DIFF_TIMEOUT_MS);
+            expect(options.maxBuffer).toBe(GIT_MAX_BUFFER_BYTES);
+            return {
+              status: null,
+              stdout: "",
+              stderr: "",
+              error: Object.assign(new Error("spawn git ETIMEDOUT"), {
+                code: "ETIMEDOUT",
+              }),
+            };
+          },
+        },
+      ),
+    ).toThrow(/ETIMEDOUT/);
+  });
+
+  it("bounds git diagnostics before surfacing a failure", () => {
+    const message = formatGitFailure(["diff"], {
+      status: 128,
+      stdout: "",
+      stderr: "x".repeat(MAX_DIAGNOSTIC_CHARS * 2),
+    });
+
+    expect(message.length).toBeLessThanOrEqual(MAX_DIAGNOSTIC_CHARS + 1);
+    expect(message).toMatch(/…$/);
+  });
+
+  it("emits only the GitHub output assignment on stdout", () => {
+    const script = join(process.cwd(), "scripts/ci/docker-relevance.mjs");
+    const result = spawnSync(
+      process.execPath,
+      [script, "--path", "packages/gateway/src/index.ts", "--format", "github"],
+      { encoding: "utf8" },
+    );
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toBe("should_run=true\n");
+    expect(result.stderr).toContain("Docker/local-runtime inputs changed");
+  });
+
+  it.each([
+    [],
+    ["--base", "origin/main"],
+    ["--commit", "HEAD", "--path", "shell/app/page.tsx"],
+    ["--path", "shell/app/page.tsx", "--format", "xml"],
+    ["--unknown"],
+  ])("rejects invalid CLI arguments: %j", (args) => {
+    const script = join(process.cwd(), "scripts/ci/docker-relevance.mjs");
+    const result = spawnSync(process.execPath, [script, ...args], {
+      encoding: "utf8",
+    });
+
+    expect(result.status).toBe(1);
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toContain("docker-relevance:");
+  });
+
+  it("fails closed when git cannot resolve the requested revision", () => {
+    const script = join(process.cwd(), "scripts/ci/docker-relevance.mjs");
+    const result = spawnSync(
+      process.execPath,
+      [script, "--commit", "definitely-not-a-real-revision"],
+      { encoding: "utf8" },
+    );
+
+    expect(result.status).toBe(1);
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toContain("docker-relevance:");
+  });
+});


### PR DESCRIPTION
## Summary

- replace the broad non-docs Docker heuristic with a tested Docker/local-runtime relevance classifier
- keep pull-request and `main` runs path-aware while preserving comprehensive merge-queue, nightly, and manual runs
- fail closed on invalid revisions, Git failures, timeouts, oversized output, and malformed inputs
- document which delivery surfaces do and do not own the legacy/local Docker validation

## Why

Docker is a legacy/local-development runtime in Matrix OS, not the production customer deployment path. CLI-, platform-, desktop-, mobile-, docs-, and release-only changes should not spend an Alpine Docker runner, while changes to the dev image, Compose setup, gateway/kernel/shell runtime, home template, shared sync protocol, or its package export manifest still need the Docker check.

## Tests

- `pnpm exec vitest run tests/scripts/docker-relevance.test.ts tests/platform/ci-workflows.test.ts` — 89 passed
- underlying full typecheck chain — passed (the `bun` launcher is unavailable in this environment)
- `pnpm run check:patterns` — 0 violations; repository-wide pre-existing warnings only
- `pnpm install --frozen-lockfile` — passed
- full `pnpm run test` — 9,267 passed; the long, resource-contended run reported five unrelated test failures, all of which passed when rerun in isolation (101 assertions total). Seven unrelated UI suites still fail to import because the pnpm-linked `@testing-library/jest-dom` cannot resolve `vitest` from the global store.
- screenshots not applicable (no user-visible UI changes)

## Invariants

- **Source of truth:** `scripts/ci/docker-relevance.mjs` owns PR/`main` Docker relevance. The workflow explicitly owns the comprehensive merge-queue, nightly, and manual overrides.
- **Lock/transaction scope:** none. Classification is a bounded, read-only Git operation with no database or network writes.
- **Acceptable orphan states:** none. Invalid input, Git errors, timeouts, and excessive output exit non-zero and fail the routing job instead of silently skipping Docker validation.
- **Auth source of truth:** unchanged. GitHub Actions supplies the checked-out event SHA and base ref; the classifier validates refs and invokes Git without a shell.
- **Deferred scope:** production VPS host-bundle releases, platform deployment, branch-protection settings, Hermes/package pinning, and removal of the legacy Docker development stack are unchanged.
