### PR TITLE
fix(desktop): ship signed launchable macOS builds

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -66,38 +66,35 @@ jobs:
           MAC_CERTIFICATE_PASSWORD: ${{ secrets.MATRIX_DESKTOP_MAC_CERTIFICATE_PASSWORD || secrets.CSC_KEY_PASSWORD }}
         run: |
           set -euo pipefail
-          if [ -n "${MAC_CERTIFICATE:-}" ]; then
-            cert_delimiter="MATRIX_DESKTOP_CERT_$(uuidgen | tr '[:lower:]' '[:upper:]' | tr -d '-')"
-            password_delimiter="MATRIX_DESKTOP_CERT_PASSWORD_$(uuidgen | tr '[:lower:]' '[:upper:]' | tr -d '-')"
-            {
-              echo "CSC_LINK<<$cert_delimiter"
-              printf '%s\n' "$MAC_CERTIFICATE"
-              echo "$cert_delimiter"
-              echo "CSC_KEY_PASSWORD<<$password_delimiter"
-              printf '%s\n' "${MAC_CERTIFICATE_PASSWORD:-}"
-              echo "$password_delimiter"
-            } >> "$GITHUB_ENV"
-          else
-            echo "CSC_IDENTITY_AUTO_DISCOVERY=false" >> "$GITHUB_ENV"
+          if [ -z "${MAC_CERTIFICATE:-}" ]; then
+            echo "MATRIX_DESKTOP_MAC_CERTIFICATE or CSC_LINK is required" >&2
+            exit 1
           fi
+          if [ -z "${MAC_CERTIFICATE_PASSWORD:-}" ]; then
+            echo "MATRIX_DESKTOP_MAC_CERTIFICATE_PASSWORD or CSC_KEY_PASSWORD is required" >&2
+            exit 1
+          fi
+          cert_delimiter="MATRIX_DESKTOP_CERT_$(uuidgen | tr '[:lower:]' '[:upper:]' | tr -d '-')"
+          password_delimiter="MATRIX_DESKTOP_CERT_PASSWORD_$(uuidgen | tr '[:lower:]' '[:upper:]' | tr -d '-')"
+          {
+            echo "CSC_LINK<<$cert_delimiter"
+            printf '%s\n' "$MAC_CERTIFICATE"
+            echo "$cert_delimiter"
+            echo "CSC_KEY_PASSWORD<<$password_delimiter"
+            printf '%s\n' "$MAC_CERTIFICATE_PASSWORD"
+            echo "$password_delimiter"
+          } >> "$GITHUB_ENV"
 
       - name: Validate Apple notarization secrets
         shell: bash
         run: |
           set -euo pipefail
-          present=0
-          missing=0
           for var in APPLE_ID APPLE_APP_SPECIFIC_PASSWORD APPLE_TEAM_ID; do
-            if [ -n "${!var:-}" ]; then
-              present=$((present + 1))
-            else
-              missing=$((missing + 1))
+            if [ -z "${!var:-}" ]; then
+              echo "Missing required Apple notarization secret: $var" >&2
+              exit 1
             fi
           done
-          if [ "$present" -gt 0 ] && [ "$missing" -gt 0 ]; then
-            echo "APPLE_ID, APPLE_APP_SPECIFIC_PASSWORD, and APPLE_TEAM_ID must be set together for notarization." >&2
-            exit 1
-          fi
 
       - name: Apply desktop release version
         if: ${{ inputs.version != '' || inputs.version_suffix != '' }}
@@ -169,7 +166,27 @@ jobs:
             exit 1
           fi
 
-      - name: Smoke test macOS DMG mount
+      - name: Verify macOS signature and notarization
+        shell: bash
+        run: |
+          set -euo pipefail
+          app_path="$(find desktop/dist -maxdepth 2 -type d -name "Matrix OS.app" -print -quit)"
+          if [ -z "$app_path" ]; then
+            echo "Missing unpacked macOS app for signature verification" >&2
+            exit 1
+          fi
+          codesign --verify --deep --strict --verbose=2 "$app_path"
+          codesign -dv --verbose=4 "$app_path" 2>&1 \
+            | grep "Authority=Developer ID Application" >/dev/null
+          xcrun stapler validate "$app_path"
+          spctl --assess --type execute --verbose=4 "$app_path"
+          if pnpm exec asar list "$app_path/Contents/Resources/app.asar" \
+            | grep "node_modules/@matrix-os/contracts" >/dev/null; then
+            echo "Packaged app contains raw @matrix-os/contracts sources" >&2
+            exit 1
+          fi
+
+      - name: Smoke test macOS DMG mount and Launch smoke test macOS app
         shell: bash
         env:
           ARTIFACT_BASE: ${{ steps.mac_artifact.outputs.artifact_base }}
@@ -178,7 +195,12 @@ jobs:
           dmg_path="desktop/dist/${ARTIFACT_BASE}.dmg"
           mount_dir="$(mktemp -d)"
           copy_dir="$(mktemp -d)"
+          app_pid=""
           cleanup() {
+            if [ -n "$app_pid" ]; then
+              kill "$app_pid" 2>/dev/null || true
+              wait "$app_pid" 2>/dev/null || true
+            fi
             hdiutil detach "$mount_dir" -quiet || true
             rm -rf "$mount_dir" "$copy_dir"
           }
@@ -187,6 +209,24 @@ jobs:
           ditto "$mount_dir/Matrix OS.app" "$copy_dir/Matrix OS.app"
           if [ ! -x "$copy_dir/Matrix OS.app/Contents/MacOS/Matrix OS" ]; then
             echo "Copied macOS app is missing executable entrypoint" >&2
+            exit 1
+          fi
+          app_log="$copy_dir/matrix-os-launch.log"
+          OPERATOR_USER_DATA_DIR="$copy_dir/user-data" \
+            "$copy_dir/Matrix OS.app/Contents/MacOS/Matrix OS" --disable-gpu >"$app_log" 2>&1 &
+          app_pid=$!
+          for _ in {1..10}; do
+            if ! kill -0 "$app_pid" 2>/dev/null; then
+              wait "$app_pid" || true
+              cat "$app_log"
+              echo "Packaged macOS app exited during launch smoke test" >&2
+              exit 1
+            fi
+            sleep 1
+          done
+          if grep -q "ERR_UNSUPPORTED_NODE_MODULES_TYPE_STRIPPING" "$app_log"; then
+            cat "$app_log"
+            echo "Packaged macOS app attempted to load raw TypeScript from node_modules" >&2
             exit 1
           fi
 

--- a/desktop/electron-builder.yml
+++ b/desktop/electron-builder.yml
@@ -8,6 +8,7 @@ directories:
 files:
   - out/**
   - "!**/.vite/**"
+  - "!**/node_modules/@matrix-os/contracts/**"
 asarUnpack: []
 protocols:
   - name: Matrix OS

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -29,7 +29,6 @@
     "@fontsource/instrument-sans": "^5.2.5",
     "@fontsource/jetbrains-mono": "^5.2.5",
     "@lezer/highlight": "^1.2.3",
-    "@matrix-os/contracts": "workspace:*",
     "@radix-ui/react-collapsible": "^1.1.12",
     "@radix-ui/react-context-menu": "^2.2.16",
     "@radix-ui/react-dialog": "^1.1.15",
@@ -63,6 +62,7 @@
     "zustand": "^5.0.13"
   },
   "devDependencies": {
+    "@matrix-os/contracts": "workspace:*",
     "@tailwindcss/vite": "^4.1.18",
     "@types/react": "^19",
     "@types/react-dom": "^19",

--- a/docs/dev/desktop-release.md
+++ b/docs/dev/desktop-release.md
@@ -27,8 +27,9 @@ electron-builder:
 - `APPLE_TEAM_ID`
 
 `MATRIX_DESKTOP_MAC_CERTIFICATE` may be a base64-encoded `.p12` payload or a
-secure URL supported by electron-builder. Do not publish a public release from a
-run where signing or notarization was skipped.
+secure URL supported by electron-builder. macOS release jobs fail before the
+build if any certificate, certificate-password, or notarization secret is
+missing; unsigned artifacts must never reach a release.
 
 ## Channels
 
@@ -67,7 +68,10 @@ git push origin desktop-v0.1.0
 
 The release workflow builds macOS arm64/x64 DMG+ZIP artifacts, Linux x64
 AppImage artifacts, merges `latest-mac.yml`, generates checksums, and creates
-the GitHub release with generated changelog notes.
+the GitHub release with generated changelog notes. Before upload, each macOS
+build verifies its Developer ID signature, stapled notarization ticket, and
+Gatekeeper assessment; inspects the ASAR for raw workspace TypeScript; mounts
+the DMG; and launches the copied app in an isolated profile.
 
 ## Updates
 

--- a/package.json
+++ b/package.json
@@ -64,6 +64,11 @@
       }
     },
     "packageExtensions": {
+      "electron-vite@*": {
+        "dependencies": {
+          "electron": "^41.0.3"
+        }
+      },
       "node-pty@*": {
         "dependencies": {
           "node-gyp": "12.3.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,7 +4,7 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
-packageExtensionsChecksum: sha256-m9DsuDtJANdLytZP9n/Bml4jTXvRcMW5PxlVKX5MJog=
+packageExtensionsChecksum: sha256-rZpBjPGwynkZBO6ecOJcSqSzQ7VMBks/aE429NKBlCU=
 
 importers:
 
@@ -324,9 +324,6 @@ importers:
       '@lezer/highlight':
         specifier: ^1.2.3
         version: 1.2.3
-      '@matrix-os/contracts':
-        specifier: workspace:*
-        version: link:../packages/contracts
       '@radix-ui/react-collapsible':
         specifier: ^1.1.12
         version: 1.1.12(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
@@ -421,6 +418,9 @@ importers:
         specifier: ^5.0.13
         version: 5.0.13(@types/react@19.2.14)(react@19.2.6)(use-sync-external-store@1.6.0(react@19.2.6))
     devDependencies:
+      '@matrix-os/contracts':
+        specifier: workspace:*
+        version: link:../packages/contracts
       '@tailwindcss/vite':
         specifier: ^4.1.18
         version: 4.3.0(vite@7.3.5(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.51.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2))
@@ -24279,6 +24279,7 @@ snapshots:
       '@babel/core': 7.29.0
       '@babel/plugin-transform-arrow-functions': 7.27.1(@babel/core@7.29.0)
       cac: 6.7.14
+      electron: 41.7.1
       esbuild: 0.25.12
       magic-string: 0.30.21
       picocolors: 1.1.1

--- a/tests/desktop/desktop-release-workflows.test.ts
+++ b/tests/desktop/desktop-release-workflows.test.ts
@@ -59,10 +59,10 @@ describe("desktop release workflows", () => {
     expect(config).not.toContain("MATRIX_DESKTOP_UPDATE_CHANNEL ?? process.env.OPERATOR_UPDATE_CHANNEL");
   });
 
-  it("bundles preload runtime schema dependencies for sandboxed IPC validation", () => {
-    const config = readFileSync(join(root, "desktop/electron.vite.config.ts"), "utf8");
+  it("keeps raw workspace TypeScript out of the packaged app archive", () => {
+    const builder = readFileSync(join(root, "desktop/electron-builder.yml"), "utf8");
 
-    expect(config).toContain('externalizeDepsPlugin({ exclude: ["zod", "@matrix-os/contracts"] })');
+    expect(builder).toContain('- "!**/node_modules/@matrix-os/contracts/**"');
   });
 
   it("bundles runtime schema dependencies into the Electron main process", () => {
@@ -93,12 +93,21 @@ describe("desktop release workflows", () => {
 
     expect(build).toContain("Validate Apple notarization secrets");
     expect(build).toContain("Prepare mac signing environment");
-    expect(build).toContain("CSC_IDENTITY_AUTO_DISCOVERY=false");
+    expect(build).toContain("MATRIX_DESKTOP_MAC_CERTIFICATE or CSC_LINK is required");
+    expect(build).toContain("MATRIX_DESKTOP_MAC_CERTIFICATE_PASSWORD or CSC_KEY_PASSWORD is required");
+    expect(build).not.toContain("CSC_IDENTITY_AUTO_DISCOVERY=false");
     expect(build).toContain("cert_delimiter=\"MATRIX_DESKTOP_CERT_$(uuidgen");
     expect(build).toContain("password_delimiter=\"MATRIX_DESKTOP_CERT_PASSWORD_$(uuidgen");
     expect(build).toContain("MAC_CERTIFICATE: ${{ secrets.MATRIX_DESKTOP_MAC_CERTIFICATE || secrets.CSC_LINK }}");
     expect(build).not.toContain("CSC_LINK: ${{ secrets.MATRIX_DESKTOP_MAC_CERTIFICATE || secrets.CSC_LINK }}");
-    expect(build).toContain("APPLE_ID, APPLE_APP_SPECIFIC_PASSWORD, and APPLE_TEAM_ID must be set together");
+    expect(build).toContain("Missing required Apple notarization secret");
+    expect(build).toContain("Verify macOS signature and notarization");
+    expect(build).toContain('codesign --verify --deep --strict --verbose=2 "$app_path"');
+    expect(build).toContain('grep "Authority=Developer ID Application" >/dev/null');
+    expect(build).toContain('xcrun stapler validate "$app_path"');
+    expect(build).toContain('spctl --assess --type execute --verbose=4 "$app_path"');
+    expect(build).toContain("Launch smoke test macOS app");
+    expect(build).toContain("ERR_UNSUPPORTED_NODE_MODULES_TYPE_STRIPPING");
     expect(build).toContain("Apply desktop release version");
     expect(build).toContain("RELEASE_VERSION: ${{ inputs.version }}");
     expect(build).toContain("j.version = exact ||");

--- a/tests/desktop/packaging.test.ts
+++ b/tests/desktop/packaging.test.ts
@@ -41,4 +41,32 @@ describe("desktop packaging", () => {
     expect(entitlementKeys).not.toContain("com.apple.security.network.client");
     expect(entitlementKeys).not.toContain("com.apple.security.files.user-selected.read-write");
   });
+
+  it("does not ship raw TypeScript workspace contracts in the app archive", () => {
+    const raw = readFileSync(join(process.cwd(), "desktop/electron-builder.yml"), "utf8");
+    const config = parse(raw) as { files?: string[] };
+    const packageJson = JSON.parse(
+      readFileSync(join(process.cwd(), "desktop/package.json"), "utf8"),
+    ) as {
+      dependencies?: Record<string, string>;
+      devDependencies?: Record<string, string>;
+    };
+
+    expect(config.files).toContain("!**/node_modules/@matrix-os/contracts/**");
+    expect(packageJson.dependencies).not.toHaveProperty("@matrix-os/contracts");
+    expect(packageJson.devDependencies?.["@matrix-os/contracts"]).toBe("workspace:*");
+  });
+
+  it("gives electron-vite a resolvable Electron dependency in the global virtual store", () => {
+    const raw = readFileSync(join(process.cwd(), "package.json"), "utf8");
+    const packageJson = JSON.parse(raw) as {
+      pnpm?: {
+        packageExtensions?: Record<string, { dependencies?: Record<string, string> }>;
+      };
+    };
+
+    expect(packageJson.pnpm?.packageExtensions?.["electron-vite@*"]?.dependencies?.electron).toBe(
+      "^41.0.3",
+    );
+  });
 });


### PR DESCRIPTION
## Summary

- bundle `@matrix-os/contracts` into Electron runtime bundles and keep its raw TypeScript sources out of `app.asar`
- add the explicit `electron-vite -> electron` dependency edge required by pnpm's global virtual store
- make macOS certificate and notarization credentials mandatory for every release build
- verify Developer ID signing, stapling, Gatekeeper, ASAR contents, DMG mounting, and packaged-app startup before artifacts upload
- update the desktop release runbook and add regression coverage

## Root cause

The main-process build externalized the workspace contracts package. electron-builder then copied the package's raw `src/index.ts` into `app.asar/node_modules`, where packaged Electron refuses Node type stripping and crashes at startup. Separately, the release workflow explicitly disabled signing when Apple credentials were absent, allowing unsigned artifacts to be published.

## Tests

- `pnpm exec vitest run tests/desktop/desktop-release-workflows.test.ts tests/desktop/packaging.test.ts` — 18 passed
- `pnpm --filter desktop run typecheck`
- `pnpm --filter desktop build`
- `CI=true pnpm install --frozen-lockfile`
- `bun run check:patterns:diff` — 0 violations
- parsed `.github/workflows/desktop-build.yml` with the workspace YAML parser
- built an unsigned local arm64 directory package for inspection: raw contracts absent from ASAR
- launched the packaged arm64 app with isolated user data for 10 seconds: app remained running and the type-stripping crash did not recur

## Release follow-up

The repository currently has none of the required Apple release secrets. Before dispatching the next Desktop Canary release, add the certificate, certificate password, Apple ID, app-specific password, and team ID documented in `docs/dev/desktop-release.md`. The workflow now fails closed until they exist.

## Invariants

### Source of truth

- `desktop/out/**` is the executable Electron bundle; workspace TypeScript must not be a packaged runtime dependency.
- GitHub Actions secrets are the sole source for the Developer ID certificate and Apple notarization credentials.

### Lock/transaction scope

- No database, transaction, or shared lock behavior changes.
- Signing, notarization, package inspection, and launch verification complete before artifact upload.

### Acceptable orphan states

- Missing credentials or any verification failure leaves a failed workflow with no uploaded release artifact.
- DMG mounts, copied apps, and launch processes are cleaned up by the workflow trap.

### Auth source of truth

- GitHub Actions repository secrets are required; there is no unsigned fallback.

### Deferred scope

- Provisioning Apple credentials and dispatching the first signed canary require repository-owner access and are not encoded in this PR.
- An existing non-fatal updater initialization warning observed during local launch smoke is unrelated to the reported startup crash.

