### PR TITLE
fix(gateway): restore malformed OpenClaw snapshots

### DIFF
--- a/packages/gateway/src/agent-config/openclaw-adapter.ts
+++ b/packages/gateway/src/agent-config/openclaw-adapter.ts
@@ -258,7 +258,7 @@ export function createOpenClawRuntimeAdapter(options: {
   async function restorePrimary(previous: string | null): Promise<void> {
     const signal = AbortSignal.timeout(2_000);
     try {
-      const current = await readConfig(signal);
+      const current = await readConfig(signal, true);
       await patchPrimary(previous, current.hash, signal);
     } catch (error) {
       console.warn(

--- a/tests/gateway/openclaw-runtime-adapter.test.ts
+++ b/tests/gateway/openclaw-runtime-adapter.test.ts
@@ -334,6 +334,36 @@ describe("OpenClaw messaging runtime adapter", () => {
     });
   });
 
+  it("restores the prior primary when the rollback snapshot is malformed", async () => {
+    const rpc = createRpc({
+      "models.list": [models],
+      "models.authStatus": [auth],
+      "config.get": [
+        config("openai/gpt-5.4", "before-hash"),
+        config("openai/gpt-5.4", "mutated-hash"),
+        config("INVALID PRIMARY", "rollback-read-hash"),
+      ],
+      "config.patch": [{ ok: true }, { ok: true }],
+    });
+    const adapter = createOpenClawRuntimeAdapter({ rpc, lifecycle: lifecycle() });
+
+    await expect(adapter.configure({
+      provider: "anthropic",
+      model: "claude-opus-4-6",
+    }, new AbortController().signal)).rejects.toMatchObject({
+      kind: "invalid_response",
+    });
+
+    const patchCalls = rpc.call.mock.calls.filter(([method]) => method === "config.patch");
+    expect(patchCalls).toHaveLength(2);
+    expect(patchCalls[1]?.[1]).toEqual({
+      raw: JSON.stringify({
+        agents: { defaults: { model: { primary: "openai/gpt-5.4" } } },
+      }),
+      baseHash: "rollback-read-hash",
+    });
+  });
+
   it("restores the prior primary when the initial patch outcome is unknown", async () => {
     const rpc = createRpc({
       "models.list": [models],


### PR DESCRIPTION
## Summary

- tolerate malformed OpenClaw primary values while reading the fresh rollback hash
- preserve optimistic-concurrency compensation after a mismatched or ambiguous config update
- add a regression test proving the prior primary is restored with the fresh hash

Stack: 1/1, based on `main`.

## Tests

- `pnpm exec vitest run tests/gateway/openclaw-runtime-adapter.test.ts` (16/16)
- `pnpm --filter @matrix-os/gateway exec tsc --noEmit`
- `bun run typecheck`
- `bun run check:patterns` (0 violations)
- `bun run test` was attempted but stopped after unrelated shared-host failures/timeouts in host-bundle, zellij, platform, CLI, and app-runtime suites; GitHub CI is the authoritative clean-environment aggregate gate

## Review / Monitoring

- Follow-up for the post-merge Greptile P1 on #983.
- Merge only after current-head Greptile 5/5, zero unresolved review threads, and green CI.

## Invariants

### Source of truth
- OpenClaw's redacted `config.get` snapshot remains authoritative for the current config hash and primary selection.

### Lock/transaction scope
- OpenClaw's `baseHash` optimistic-concurrency check remains the mutation guard; this change only allows rollback to retain the fresh hash when the observed primary is malformed.
- No network call is moved into a new lock or transaction.

### Acceptable orphan states
- If the compensating patch itself fails, the adapter logs a bounded error and preserves the existing best-effort rollback behavior.
- A malformed concurrent primary no longer prevents the compensating patch from being attempted.

### Auth source of truth
- Existing authenticated Settings and runtime-control boundaries are unchanged.
- OpenClaw RPC authentication and authorization behavior is unchanged.

### Deferred scope
- No runtime installation, runtime switching, provider catalog, or OpenClaw supply-chain pin behavior changes are included.
