### PR TITLE
feat(platform): define golden snapshot persistence

### DIFF
--- a/packages/platform/src/customer-vps-config.ts
+++ b/packages/platform/src/customer-vps-config.ts
@@ -1,3 +1,9 @@
+import {
+  DEFAULT_GOLDEN_SNAPSHOT_FRESHNESS_MAX_AGE_MS,
+  GoldenSnapshotRuntimeConfigSchema,
+  type GoldenSnapshotRuntimeConfig,
+} from './golden-snapshot-schema.js';
+
 export interface CustomerVpsConfig {
   hetznerApiToken: string;
   location: string;
@@ -26,6 +32,7 @@ export interface CustomerVpsConfig {
   reconciliationStaleAfterMs: number;
   maxProvisionAttempts: number;
   previewProvisioningLimit: number;
+  goldenSnapshots: GoldenSnapshotRuntimeConfig;
 }
 
 const DEFAULT_POSTHOG_PUBLIC_HOST = 'https://eu.posthog.com';
@@ -42,6 +49,16 @@ function boundedIntegerFromEnv(value: string | undefined, fallback: number, maxi
   if (value === undefined || value === '') return fallback;
   const parsed = Number(value);
   return Number.isSafeInteger(parsed) && parsed > 0 && parsed <= maximum ? parsed : fallback;
+}
+
+function boundedInteger(value: string | undefined, fallback: number, minimum: number, maximum: number): number {
+  if (value === undefined || value === '') return fallback;
+  const parsed = Number(value);
+  return Number.isSafeInteger(parsed) && parsed >= minimum && parsed <= maximum ? parsed : fallback;
+}
+
+function enabledFromEnv(value: string | undefined): boolean {
+  return value === 'true';
 }
 
 export function loadCustomerVpsConfig(env: NodeJS.ProcessEnv = process.env): CustomerVpsConfig {
@@ -87,5 +104,49 @@ export function loadCustomerVpsConfig(env: NodeJS.ProcessEnv = process.env): Cus
       DEFAULT_PREVIEW_PROVISIONING_LIMIT,
       MAX_PREVIEW_PROVISIONING_LIMIT,
     ),
+    goldenSnapshots: GoldenSnapshotRuntimeConfigSchema.parse({
+      enabled: enabledFromEnv(env.GOLDEN_SNAPSHOTS_ENABLED),
+      buildsEnabled: enabledFromEnv(env.GOLDEN_SNAPSHOT_BUILDS_ENABLED),
+      rolloutPercent: boundedInteger(env.GOLDEN_SNAPSHOT_ROLLOUT_PERCENT, 0, 0, 100),
+      compatibility: {
+        provider: 'hetzner',
+        architecture: env.GOLDEN_SNAPSHOT_ARCHITECTURE ?? 'x86',
+        region: env.GOLDEN_SNAPSHOT_REGION ?? 'eu-central',
+        baseImage: env.GOLDEN_SNAPSHOT_BASE_IMAGE || env.HETZNER_IMAGE || 'ubuntu-24.04',
+        baseGeneration: env.GOLDEN_SNAPSHOT_BASE_GENERATION ?? 'ubuntu-24.04-v1',
+        bootMode: env.GOLDEN_SNAPSHOT_BOOT_MODE ?? 'bios',
+        activationAbi: env.GOLDEN_SNAPSHOT_ACTIVATION_ABI ?? 'host-v1',
+        minimumDiskGb: boundedInteger(env.GOLDEN_SNAPSHOT_MINIMUM_DISK_GB, 40, 1, 2_048),
+      },
+      maxBuildAttempts: boundedInteger(env.GOLDEN_SNAPSHOT_MAX_BUILD_ATTEMPTS, 5, 1, 10),
+      maxConcurrentBuilds: boundedInteger(env.GOLDEN_SNAPSHOT_MAX_CONCURRENT_BUILDS, 2, 1, 10),
+      buildLeaseMs: boundedInteger(env.GOLDEN_SNAPSHOT_BUILD_LEASE_MS, 5 * 60 * 1000, 60_000, 30 * 60 * 1000),
+      provisioningLeaseMs: boundedInteger(
+        env.GOLDEN_SNAPSHOT_PROVISIONING_LEASE_MS,
+        10 * 60 * 1000,
+        60_000,
+        30 * 60 * 1000,
+      ),
+      retentionLimit: boundedInteger(env.GOLDEN_SNAPSHOT_RETENTION_LIMIT, 20, 1, 29),
+      freshnessMaxAgeMs: boundedInteger(
+        env.GOLDEN_SNAPSHOT_FRESHNESS_MAX_AGE_MS,
+        DEFAULT_GOLDEN_SNAPSHOT_FRESHNESS_MAX_AGE_MS,
+        60_000,
+        365 * 24 * 60 * 60 * 1000,
+      ),
+      testModeTtlMs: boundedInteger(
+        env.GOLDEN_SNAPSHOT_TEST_MODE_TTL_MS,
+        24 * 60 * 60 * 1000,
+        60_000,
+        30 * 24 * 60 * 60 * 1000,
+      ),
+      auditRetentionMs: boundedInteger(
+        env.GOLDEN_SNAPSHOT_AUDIT_RETENTION_MS,
+        90 * 24 * 60 * 60 * 1000,
+        24 * 60 * 60 * 1000,
+        365 * 24 * 60 * 60 * 1000,
+      ),
+      reconciliationBatchSize: boundedInteger(env.GOLDEN_SNAPSHOT_RECONCILIATION_BATCH_SIZE, 25, 1, 100),
+    }),
   };
 }

--- a/packages/platform/src/db.ts
+++ b/packages/platform/src/db.ts
@@ -18,6 +18,8 @@ import {
 const DEFAULT_PLATFORM_DB_URL =
   process.env.PLATFORM_DATABASE_URL ??
   (process.env.POSTGRES_URL ? `${process.env.POSTGRES_URL}/matrixos_platform` : undefined);
+const HostBundleTimestampSchema = z.string().datetime({ offset: true })
+  .transform((value) => new Date(value).toISOString());
 
 type Executor = Kysely<PlatformDatabase> | Transaction<PlatformDatabase>;
 
@@ -117,6 +119,149 @@ interface HostBundleReleaseChannelsTable {
   channel: string;
   version: string;
   promoted_at: string;
+}
+
+export interface GoldenSnapshotsTable {
+  snapshot_id: string;
+  bundle_version: string;
+  bundle_sha256: string;
+  source_git_commit: string;
+  compatibility_key: string;
+  provider: string;
+  architecture: string;
+  region: string;
+  base_image: string;
+  base_generation: string;
+  boot_mode: string;
+  activation_abi: string;
+  minimum_disk_gb: number;
+  test_mode: boolean;
+  image_generation: number;
+  state: string;
+  provider_image_id: number | null;
+  provider_image_status: string | null;
+  image_disk_gb: number | null;
+  image_architecture: string | null;
+  validation_summary: unknown | null;
+  failure_code: string | null;
+  ready_at: string | null;
+  quarantined_at: string | null;
+  retiring_at: string | null;
+  deleted_at: string | null;
+  created_at: string;
+  updated_at: string;
+  revision: number;
+}
+
+export interface GoldenSnapshotBuildsTable {
+  build_id: string;
+  snapshot_id: string;
+  phase: string;
+  status: string;
+  attempts: number;
+  available_at: string;
+  claimed_at: string | null;
+  lease_expires_at: string | null;
+  callback_phase: string | null;
+  callback_token_hash: string | null;
+  callback_expires_at: string | null;
+  callback_event_id: string | null;
+  callback_payload_sha256: string | null;
+  callback_outcome: unknown | null;
+  builder_machine_id_sha256: string | null;
+  builder_ssh_host_key_sha256: string | null;
+  provider_builder_id: number | null;
+  provider_builder_action_id: number | null;
+  provider_snapshot_action_id: number | null;
+  provider_validation_id: number | null;
+  provider_validation_action_id: number | null;
+  pending_operation: string | null;
+  last_error_code: string | null;
+  created_at: string;
+  updated_at: string;
+  completed_at: string | null;
+}
+
+export interface GoldenSnapshotLeasesTable {
+  lease_id: string;
+  snapshot_id: string;
+  machine_id: string;
+  purpose: string;
+  target_bundle_version: string;
+  created_at: string;
+  expires_at: string;
+  released_at: string | null;
+}
+
+export interface GoldenSnapshotCallbackReceiptsTable {
+  build_id: string;
+  event_id: string;
+  callback_phase: string;
+  token_sha256: string | null;
+  payload_sha256: string;
+  outcome: unknown;
+  created_at: string;
+  expires_at: string;
+}
+
+export interface GoldenSnapshotCreateIntentsTable {
+  intent_id: string;
+  snapshot_id: string;
+  lease_id: string;
+  machine_id: string;
+  purpose: string;
+  rollout_generation: number;
+  state: string;
+  provider_create_action_id: number | null;
+  created_at: string;
+  updated_at: string;
+  completed_at: string | null;
+}
+
+export interface GoldenSnapshotRolloutControlsTable {
+  compatibility_key: string;
+  enabled: boolean;
+  percentage: number;
+  generation: number;
+  updated_at: string;
+}
+
+export interface GoldenSnapshotRevokedBaseGenerationsTable {
+  base_generation: string;
+  reason: string;
+  revoked_at: string;
+  updated_at: string;
+}
+
+export interface GoldenSnapshotCleanupTable {
+  cleanup_id: string;
+  snapshot_id: string | null;
+  build_id: string | null;
+  resource_type: string;
+  provider_resource_id: number;
+  provenance_key: string;
+  reason: string;
+  status: string;
+  attempts: number;
+  next_attempt_at: string;
+  lease_expires_at: string | null;
+  last_error_code: string | null;
+  created_at: string;
+  completed_at: string | null;
+}
+
+export interface GoldenSnapshotAuditEventsTable {
+  event_id: string;
+  snapshot_id: string | null;
+  build_id: string | null;
+  cleanup_id: string | null;
+  event_type: string;
+  actor_type: string;
+  actor_id_hash: string | null;
+  from_state: string | null;
+  to_state: string | null;
+  reason: string | null;
+  created_at: string;
 }
 
 interface ProviderDeletionQueueTable {
@@ -336,6 +481,15 @@ export interface PlatformDatabase {
   host_bundle_releases: HostBundleReleasesTable;
   host_bundle_channels: HostBundleChannelsTable;
   host_bundle_release_channels: HostBundleReleaseChannelsTable;
+  golden_snapshots: GoldenSnapshotsTable;
+  golden_snapshot_builds: GoldenSnapshotBuildsTable;
+  golden_snapshot_callback_receipts: GoldenSnapshotCallbackReceiptsTable;
+  golden_snapshot_create_intents: GoldenSnapshotCreateIntentsTable;
+  golden_snapshot_rollout_controls: GoldenSnapshotRolloutControlsTable;
+  golden_snapshot_leases: GoldenSnapshotLeasesTable;
+  golden_snapshot_revoked_base_generations: GoldenSnapshotRevokedBaseGenerationsTable;
+  golden_snapshot_cleanup: GoldenSnapshotCleanupTable;
+  golden_snapshot_audit_events: GoldenSnapshotAuditEventsTable;
   provider_deletion_queue: ProviderDeletionQueueTable;
   billing_customers: BillingCustomersTable;
   billing_subscriptions: BillingSubscriptionsTable;
@@ -1071,7 +1225,7 @@ async function migrate(db: Kysely<PlatformDatabase>): Promise<void> {
       incremental_manifest_key TEXT,
       incremental_manifest_sha256 TEXT,
       sha256 TEXT NOT NULL,
-      size INTEGER NOT NULL,
+      size BIGINT NOT NULL,
       severity TEXT NOT NULL DEFAULT 'normal',
       update_type TEXT NOT NULL DEFAULT 'manual',
       changelog TEXT,
@@ -1081,6 +1235,7 @@ async function migrate(db: Kysely<PlatformDatabase>): Promise<void> {
   await sql`ALTER TABLE host_bundle_releases ADD COLUMN IF NOT EXISTS channel TEXT`.execute(db);
   await sql`ALTER TABLE host_bundle_releases ADD COLUMN IF NOT EXISTS incremental_manifest_key TEXT`.execute(db);
   await sql`ALTER TABLE host_bundle_releases ADD COLUMN IF NOT EXISTS incremental_manifest_sha256 TEXT`.execute(db);
+  await sql`ALTER TABLE host_bundle_releases ALTER COLUMN size TYPE BIGINT`.execute(db);
   await sql`CREATE INDEX IF NOT EXISTS idx_host_bundle_releases_channel ON host_bundle_releases(channel)`.execute(db);
   await sql`CREATE INDEX IF NOT EXISTS idx_host_bundle_releases_created_at ON host_bundle_releases(created_at)`.execute(db);
 
@@ -1114,6 +1269,272 @@ async function migrate(db: Kysely<PlatformDatabase>): Promise<void> {
     SELECT channel, version, updated_at
     FROM host_bundle_channels
     ON CONFLICT (channel, version) DO UPDATE SET promoted_at = EXCLUDED.promoted_at
+  `.execute(db);
+
+  await sql`
+    CREATE TABLE IF NOT EXISTS golden_snapshots (
+      snapshot_id TEXT PRIMARY KEY,
+      bundle_version TEXT NOT NULL REFERENCES host_bundle_releases(version),
+      bundle_sha256 TEXT NOT NULL CHECK (bundle_sha256 ~ '^[a-f0-9]{64}$'),
+      source_git_commit TEXT NOT NULL,
+      compatibility_key TEXT NOT NULL CHECK (compatibility_key ~ '^[a-f0-9]{64}$'),
+      provider TEXT NOT NULL,
+      architecture TEXT NOT NULL,
+      region TEXT NOT NULL,
+      base_image TEXT NOT NULL,
+      base_generation TEXT NOT NULL,
+      boot_mode TEXT NOT NULL,
+      activation_abi TEXT NOT NULL,
+      minimum_disk_gb INTEGER NOT NULL CHECK (minimum_disk_gb > 0),
+      test_mode BOOLEAN NOT NULL DEFAULT FALSE,
+      image_generation INTEGER NOT NULL DEFAULT 1 CHECK (image_generation > 0),
+      state TEXT NOT NULL CHECK (state IN ('candidate', 'building', 'sanitizing', 'validating', 'ready', 'failed', 'quarantined', 'retiring', 'deleted')),
+      provider_image_id BIGINT,
+      provider_image_status TEXT,
+      image_disk_gb INTEGER CHECK (image_disk_gb IS NULL OR image_disk_gb > 0),
+      image_architecture TEXT,
+      validation_summary JSONB,
+      failure_code TEXT,
+      ready_at TEXT,
+      quarantined_at TEXT,
+      retiring_at TEXT,
+      deleted_at TEXT,
+      created_at TEXT NOT NULL,
+      updated_at TEXT NOT NULL,
+      revision INTEGER NOT NULL DEFAULT 1 CHECK (revision > 0),
+      UNIQUE (bundle_sha256, compatibility_key, test_mode, image_generation),
+      UNIQUE (provider_image_id)
+    )
+  `.execute(db);
+  await sql`ALTER TABLE golden_snapshots ADD COLUMN IF NOT EXISTS test_mode BOOLEAN NOT NULL DEFAULT FALSE`.execute(db);
+  await sql`ALTER TABLE golden_snapshots ADD COLUMN IF NOT EXISTS image_generation INTEGER NOT NULL DEFAULT 1 CHECK (image_generation > 0)`.execute(db);
+  await sql`ALTER TABLE golden_snapshots DROP CONSTRAINT IF EXISTS golden_snapshots_bundle_sha256_compatibility_key_key`.execute(db);
+  await sql`ALTER TABLE golden_snapshots DROP CONSTRAINT IF EXISTS golden_snapshots_bundle_sha256_compatibility_key_test_mode_key`.execute(db);
+  await sql`DROP INDEX IF EXISTS idx_golden_snapshots_identity`.execute(db);
+  await sql`
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_golden_snapshots_identity
+    ON golden_snapshots(bundle_sha256, compatibility_key, test_mode, image_generation)
+  `.execute(db);
+  await sql`
+    CREATE INDEX IF NOT EXISTS idx_golden_snapshots_selectable
+    ON golden_snapshots(compatibility_key, ready_at DESC)
+    WHERE state = 'ready'
+  `.execute(db);
+  await sql`
+    CREATE INDEX IF NOT EXISTS idx_golden_snapshots_bundle
+    ON golden_snapshots(bundle_version, compatibility_key)
+  `.execute(db);
+
+  await sql`
+    CREATE TABLE IF NOT EXISTS golden_snapshot_revoked_base_generations (
+      base_generation TEXT PRIMARY KEY,
+      reason TEXT NOT NULL,
+      revoked_at TEXT NOT NULL,
+      updated_at TEXT NOT NULL
+    )
+  `.execute(db);
+
+  await sql`
+    CREATE TABLE IF NOT EXISTS golden_snapshot_builds (
+      build_id TEXT PRIMARY KEY,
+      snapshot_id TEXT NOT NULL UNIQUE REFERENCES golden_snapshots(snapshot_id) ON DELETE CASCADE,
+      phase TEXT NOT NULL CHECK (phase IN ('requested', 'builder_create', 'builder_boot', 'sanitizing', 'snapshot_create', 'snapshot_wait', 'validation_create', 'validation_boot', 'cleanup', 'completed', 'failed', 'reconciling')),
+      status TEXT NOT NULL CHECK (status IN ('queued', 'running', 'completed', 'failed')),
+      attempts INTEGER NOT NULL DEFAULT 0 CHECK (attempts >= 0),
+      available_at TEXT NOT NULL,
+      claimed_at TEXT,
+      lease_expires_at TEXT,
+      callback_phase TEXT,
+      callback_token_hash TEXT,
+      callback_expires_at TEXT,
+      callback_event_id TEXT,
+      callback_payload_sha256 TEXT CHECK (callback_payload_sha256 IS NULL OR callback_payload_sha256 ~ '^[a-f0-9]{64}$'),
+      callback_outcome JSONB,
+      builder_machine_id_sha256 TEXT CHECK (builder_machine_id_sha256 IS NULL OR builder_machine_id_sha256 ~ '^[a-f0-9]{64}$'),
+      builder_ssh_host_key_sha256 TEXT CHECK (builder_ssh_host_key_sha256 IS NULL OR builder_ssh_host_key_sha256 ~ '^[a-f0-9]{64}$'),
+      provider_builder_id BIGINT,
+      provider_builder_action_id BIGINT,
+      provider_snapshot_action_id BIGINT,
+      provider_validation_id BIGINT,
+      provider_validation_action_id BIGINT,
+      pending_operation TEXT,
+      last_error_code TEXT,
+      created_at TEXT NOT NULL,
+      updated_at TEXT NOT NULL,
+      completed_at TEXT
+    )
+  `.execute(db);
+  await sql`
+    ALTER TABLE golden_snapshot_builds
+    ADD COLUMN IF NOT EXISTS builder_machine_id_sha256 TEXT
+  `.execute(db);
+  await sql`
+    ALTER TABLE golden_snapshot_builds
+    ADD COLUMN IF NOT EXISTS builder_ssh_host_key_sha256 TEXT
+  `.execute(db);
+  await sql`
+    ALTER TABLE golden_snapshot_builds
+    ADD COLUMN IF NOT EXISTS provider_builder_action_id BIGINT
+  `.execute(db);
+  await sql`
+    ALTER TABLE golden_snapshot_builds
+    ADD COLUMN IF NOT EXISTS callback_event_id TEXT
+  `.execute(db);
+  await sql`
+    ALTER TABLE golden_snapshot_builds
+    ADD COLUMN IF NOT EXISTS callback_payload_sha256 TEXT
+  `.execute(db);
+  await sql`
+    ALTER TABLE golden_snapshot_builds
+    ADD COLUMN IF NOT EXISTS callback_outcome JSONB
+  `.execute(db);
+  await sql`
+    CREATE INDEX IF NOT EXISTS idx_golden_snapshot_builds_dispatch
+    ON golden_snapshot_builds(status, available_at, lease_expires_at)
+  `.execute(db);
+
+  await sql`
+    CREATE TABLE IF NOT EXISTS golden_snapshot_callback_receipts (
+      build_id TEXT NOT NULL REFERENCES golden_snapshot_builds(build_id) ON DELETE CASCADE,
+      event_id TEXT NOT NULL,
+      callback_phase TEXT NOT NULL CHECK (length(callback_phase) BETWEEN 1 AND 64),
+      token_sha256 TEXT CHECK (token_sha256 ~ '^[a-f0-9]{64}$'),
+      payload_sha256 TEXT NOT NULL CHECK (payload_sha256 ~ '^[a-f0-9]{64}$'),
+      outcome JSONB NOT NULL,
+      created_at TEXT NOT NULL,
+      expires_at TEXT NOT NULL,
+      PRIMARY KEY (build_id, event_id)
+    )
+  `.execute(db);
+  await sql`
+    ALTER TABLE golden_snapshot_callback_receipts
+    ADD COLUMN IF NOT EXISTS token_sha256 TEXT
+      CHECK (token_sha256 ~ '^[a-f0-9]{64}$')
+  `.execute(db);
+  await sql`
+    CREATE INDEX IF NOT EXISTS idx_golden_snapshot_callback_receipts_expiry
+    ON golden_snapshot_callback_receipts(expires_at, build_id, event_id)
+  `.execute(db);
+
+  await sql`
+    CREATE TABLE IF NOT EXISTS golden_snapshot_leases (
+      lease_id TEXT PRIMARY KEY,
+      snapshot_id TEXT NOT NULL REFERENCES golden_snapshots(snapshot_id),
+      machine_id TEXT NOT NULL,
+      purpose TEXT NOT NULL CHECK (purpose IN ('provision', 'recover')),
+      target_bundle_version TEXT NOT NULL REFERENCES host_bundle_releases(version),
+      created_at TEXT NOT NULL,
+      expires_at TEXT NOT NULL,
+      released_at TEXT
+    )
+  `.execute(db);
+  await sql`
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_golden_snapshot_leases_machine_active
+    ON golden_snapshot_leases(machine_id)
+    WHERE released_at IS NULL
+  `.execute(db);
+  await sql`
+    CREATE INDEX IF NOT EXISTS idx_golden_snapshot_leases_protection
+    ON golden_snapshot_leases(snapshot_id, expires_at)
+    WHERE released_at IS NULL
+  `.execute(db);
+
+  await sql`
+    CREATE TABLE IF NOT EXISTS golden_snapshot_rollout_controls (
+      compatibility_key TEXT PRIMARY KEY CHECK (compatibility_key ~ '^[a-f0-9]{64}$'),
+      enabled BOOLEAN NOT NULL DEFAULT false,
+      percentage INTEGER NOT NULL DEFAULT 0 CHECK (percentage BETWEEN 0 AND 100),
+      generation BIGINT NOT NULL DEFAULT 1 CHECK (generation > 0),
+      updated_at TEXT NOT NULL
+    )
+  `.execute(db);
+
+  await sql`
+    CREATE TABLE IF NOT EXISTS golden_snapshot_create_intents (
+      intent_id TEXT PRIMARY KEY,
+      snapshot_id TEXT NOT NULL REFERENCES golden_snapshots(snapshot_id),
+      lease_id TEXT NOT NULL REFERENCES golden_snapshot_leases(lease_id),
+      machine_id TEXT NOT NULL,
+      purpose TEXT NOT NULL CHECK (purpose IN ('provision', 'recover')),
+      rollout_generation BIGINT NOT NULL CHECK (rollout_generation >= 0),
+      state TEXT NOT NULL CHECK (state IN ('pending', 'accepted', 'denied', 'activated', 'cleaned')),
+      provider_create_action_id BIGINT,
+      created_at TEXT NOT NULL,
+      updated_at TEXT NOT NULL,
+      completed_at TEXT,
+      UNIQUE (lease_id)
+    )
+  `.execute(db);
+  await sql`
+    CREATE INDEX IF NOT EXISTS idx_golden_snapshot_create_intents_open
+    ON golden_snapshot_create_intents(snapshot_id, state)
+    WHERE completed_at IS NULL
+  `.execute(db);
+
+  await sql`
+    CREATE TABLE IF NOT EXISTS golden_snapshot_cleanup (
+      cleanup_id TEXT PRIMARY KEY,
+      snapshot_id TEXT REFERENCES golden_snapshots(snapshot_id),
+      build_id TEXT REFERENCES golden_snapshot_builds(build_id),
+      resource_type TEXT NOT NULL CHECK (resource_type IN ('builder_server', 'validation_server', 'snapshot_image')),
+      provider_resource_id BIGINT NOT NULL CHECK (provider_resource_id > 0),
+      provenance_key TEXT NOT NULL,
+      reason TEXT NOT NULL,
+      status TEXT NOT NULL CHECK (status IN ('queued', 'running', 'completed', 'failed', 'quarantined')),
+      attempts INTEGER NOT NULL DEFAULT 0 CHECK (attempts >= 0),
+      next_attempt_at TEXT NOT NULL,
+      lease_expires_at TEXT,
+      last_error_code TEXT,
+      created_at TEXT NOT NULL,
+      completed_at TEXT
+    )
+  `.execute(db);
+  await sql`
+    CREATE TABLE IF NOT EXISTS golden_snapshot_audit_events (
+      event_id TEXT PRIMARY KEY,
+      snapshot_id TEXT REFERENCES golden_snapshots(snapshot_id) ON DELETE SET NULL,
+      build_id TEXT REFERENCES golden_snapshot_builds(build_id) ON DELETE SET NULL,
+      cleanup_id TEXT REFERENCES golden_snapshot_cleanup(cleanup_id) ON DELETE SET NULL,
+      event_type TEXT NOT NULL CHECK (length(event_type) BETWEEN 1 AND 64),
+      actor_type TEXT NOT NULL CHECK (actor_type IN ('release', 'worker', 'operator')),
+      actor_id_hash TEXT CHECK (actor_id_hash IS NULL OR actor_id_hash ~ '^[a-f0-9]{64}$'),
+      from_state TEXT,
+      to_state TEXT,
+      reason TEXT,
+      created_at TEXT NOT NULL
+    )
+  `.execute(db);
+  await sql`
+    CREATE INDEX IF NOT EXISTS idx_golden_snapshot_audit_events_retention
+    ON golden_snapshot_audit_events(created_at, event_id)
+  `.execute(db);
+  await sql`
+    DO $$
+    DECLARE
+      current_definition TEXT;
+    BEGIN
+      SELECT pg_get_constraintdef(oid) INTO current_definition
+      FROM pg_constraint
+      WHERE conrelid = 'golden_snapshot_cleanup'::regclass
+        AND conname = 'golden_snapshot_cleanup_status_check';
+      IF current_definition IS NULL OR current_definition NOT LIKE '%quarantined%' THEN
+        ALTER TABLE golden_snapshot_cleanup
+          DROP CONSTRAINT IF EXISTS golden_snapshot_cleanup_status_check;
+        ALTER TABLE golden_snapshot_cleanup
+          ADD CONSTRAINT golden_snapshot_cleanup_status_check
+          CHECK (status IN ('queued', 'running', 'completed', 'failed', 'quarantined'));
+      END IF;
+    END $$
+  `.execute(db);
+  await sql`
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_golden_snapshot_cleanup_resource_active
+    ON golden_snapshot_cleanup(resource_type, provider_resource_id)
+    WHERE completed_at IS NULL
+  `.execute(db);
+  await sql`
+    CREATE INDEX IF NOT EXISTS idx_golden_snapshot_cleanup_dispatch
+    ON golden_snapshot_cleanup(status, next_attempt_at, lease_expires_at)
+    WHERE completed_at IS NULL
   `.execute(db);
 
   await sql`
@@ -1502,7 +1923,7 @@ function mapHostBundleRelease(row: HostBundleReleasesTable): HostBundleReleaseRe
     incrementalManifestKey: row.incremental_manifest_key,
     incrementalManifestSha256: row.incremental_manifest_sha256,
     sha256: row.sha256,
-    size: row.size,
+    size: Number(row.size),
     severity: row.severity,
     updateType: row.update_type,
     changelog: row.changelog,
@@ -1517,7 +1938,7 @@ function toHostBundleReleaseRow(record: NewHostBundleRelease): HostBundleRelease
     channel: record.channel ?? null,
     git_commit: record.gitCommit,
     git_ref: record.gitRef ?? null,
-    build_time: record.buildTime,
+    build_time: HostBundleTimestampSchema.parse(record.buildTime),
     bundle_key: record.bundleKey,
     checksum_key: record.checksumKey ?? null,
     incremental_manifest_key: record.incrementalManifestKey ?? null,
@@ -1527,7 +1948,9 @@ function toHostBundleReleaseRow(record: NewHostBundleRelease): HostBundleRelease
     severity: record.severity ?? 'normal',
     update_type: record.updateType ?? 'manual',
     changelog: record.changelog ?? null,
-    created_at: record.createdAt ?? now,
+    created_at: record.createdAt === undefined
+      ? now
+      : HostBundleTimestampSchema.parse(record.createdAt),
   };
 }
 
@@ -2671,9 +3094,6 @@ export async function upsertHostBundleRelease(
       .values(row)
       .onConflict((oc) =>
         oc.column('version').doUpdateSet({
-          git_commit: row.git_commit,
-          git_ref: row.git_ref,
-          build_time: row.build_time,
           severity: row.severity,
           update_type: row.update_type,
           changelog: row.changelog,
@@ -2681,6 +3101,9 @@ export async function upsertHostBundleRelease(
           incremental_manifest_sha256: row.incremental_manifest_sha256,
         })
           .where(sql<boolean>`host_bundle_releases.bundle_key = ${row.bundle_key}`)
+          .where(sql<boolean>`host_bundle_releases.git_commit = ${row.git_commit}`)
+          .where(sql<boolean>`host_bundle_releases.git_ref IS NOT DISTINCT FROM ${row.git_ref}`)
+          .where(sql<boolean>`host_bundle_releases.build_time::timestamptz = ${row.build_time}::timestamptz`)
           .where(sql<boolean>`host_bundle_releases.checksum_key IS NOT DISTINCT FROM ${row.checksum_key}`)
           .where(sql<boolean>`host_bundle_releases.incremental_manifest_key IS NOT DISTINCT FROM ${row.incremental_manifest_key}`)
           .where(sql<boolean>`host_bundle_releases.incremental_manifest_sha256 IS NOT DISTINCT FROM ${row.incremental_manifest_sha256}`)
@@ -2747,6 +3170,7 @@ export async function promoteHostBundleChannel(
       .selectFrom('host_bundle_releases')
       .selectAll()
       .where('version', '=', version)
+      .forUpdate()
       .executeTakeFirst();
     if (!release) {
       throw new Error('Cannot promote unknown host bundle release');

--- a/packages/platform/src/golden-snapshot-repository.ts
+++ b/packages/platform/src/golden-snapshot-repository.ts
@@ -1,0 +1,1823 @@
+import { randomUUID } from 'node:crypto';
+import { sql } from 'kysely';
+import { z } from 'zod/v4';
+import type { PlatformDB } from './db.js';
+import {
+  canTransitionGoldenSnapshot,
+  compatibilityKey,
+  GoldenSnapshotBaseGenerationSchema,
+  GoldenSnapshotBuildPhaseSchema,
+  GoldenSnapshotBuildStatusSchema,
+  GoldenSnapshotCompatibilitySchema,
+  GoldenSnapshotStateSchema,
+  GoldenSnapshotValidationSummarySchema,
+  type GoldenSnapshotCompatibility,
+  type GoldenSnapshotState,
+  type GoldenSnapshotValidationSummary,
+} from './golden-snapshot-schema.js';
+import { chooseGoldenSnapshot } from './golden-snapshot-selection.js';
+
+const UuidSchema = z.string().uuid();
+const IsoDateSchema = z.string().datetime({ offset: true })
+  .transform((value) => new Date(value).toISOString());
+const Sha256Schema = z.string().regex(/^[a-f0-9]{64}$/);
+const BoundedCodeSchema = z.string().min(1).max(128).regex(/^[a-z0-9][a-z0-9._-]*$/);
+
+const SnapshotRowSchema = z.object({
+  snapshot_id: UuidSchema,
+  bundle_version: z.string().min(1).max(128),
+  bundle_sha256: Sha256Schema,
+  source_git_commit: z.string().min(1).max(128),
+  compatibility_key: Sha256Schema,
+  provider: z.literal('hetzner'),
+  architecture: z.enum(['x86', 'arm']),
+  region: z.string(),
+  base_image: z.string(),
+  base_generation: z.string(),
+  boot_mode: z.enum(['bios', 'uefi']),
+  activation_abi: z.string(),
+  minimum_disk_gb: z.number().int().positive(),
+  test_mode: z.boolean(),
+  image_generation: z.number().int().positive(),
+  state: GoldenSnapshotStateSchema,
+  provider_image_id: z.coerce.number().int().positive().nullable(),
+  provider_image_status: z.string().nullable(),
+  image_disk_gb: z.number().int().positive().nullable(),
+  image_architecture: z.enum(['x86', 'arm']).nullable(),
+  validation_summary: GoldenSnapshotValidationSummarySchema.nullable(),
+  failure_code: z.string().nullable(),
+  ready_at: z.string().nullable(),
+  quarantined_at: z.string().nullable(),
+  retiring_at: z.string().nullable(),
+  deleted_at: z.string().nullable(),
+  created_at: z.string(),
+  updated_at: z.string(),
+  revision: z.number().int().positive(),
+});
+
+const BuildRowSchema = z.object({
+  build_id: UuidSchema,
+  snapshot_id: UuidSchema,
+  phase: GoldenSnapshotBuildPhaseSchema,
+  status: GoldenSnapshotBuildStatusSchema,
+  attempts: z.number().int().nonnegative(),
+  available_at: z.string(),
+  claimed_at: z.string().nullable(),
+  lease_expires_at: z.string().nullable(),
+  callback_phase: z.string().nullable(),
+  callback_token_hash: z.string().nullable(),
+  callback_expires_at: z.string().nullable(),
+  callback_event_id: UuidSchema.nullable(),
+  callback_payload_sha256: Sha256Schema.nullable(),
+  callback_outcome: z.unknown().nullable(),
+  builder_machine_id_sha256: Sha256Schema.nullable(),
+  builder_ssh_host_key_sha256: Sha256Schema.nullable(),
+  provider_builder_id: z.coerce.number().int().positive().nullable(),
+  provider_builder_action_id: z.coerce.number().int().positive().nullable(),
+  provider_snapshot_action_id: z.coerce.number().int().positive().nullable(),
+  provider_validation_id: z.coerce.number().int().positive().nullable(),
+  provider_validation_action_id: z.coerce.number().int().positive().nullable(),
+  pending_operation: z.string().nullable(),
+  last_error_code: z.string().nullable(),
+  created_at: z.string(),
+  updated_at: z.string(),
+  completed_at: z.string().nullable(),
+});
+
+const LeaseRowSchema = z.object({
+  lease_id: UuidSchema,
+  snapshot_id: UuidSchema,
+  machine_id: UuidSchema,
+  purpose: z.enum(['provision', 'recover']),
+  target_bundle_version: z.string(),
+  created_at: z.string(),
+  expires_at: z.string(),
+  released_at: z.string().nullable(),
+});
+
+const CreateIntentRowSchema = z.object({
+  intent_id: UuidSchema,
+  snapshot_id: UuidSchema,
+  lease_id: UuidSchema,
+  machine_id: UuidSchema,
+  purpose: z.enum(['provision', 'recover']),
+  rollout_generation: z.coerce.number().int().nonnegative(),
+  state: z.enum(['pending', 'accepted', 'denied', 'activated', 'cleaned']),
+  provider_create_action_id: z.coerce.number().int().positive().nullable(),
+  created_at: z.string(),
+  updated_at: z.string(),
+  completed_at: z.string().nullable(),
+});
+
+const RolloutControlRowSchema = z.object({
+  compatibility_key: Sha256Schema,
+  enabled: z.boolean(),
+  percentage: z.coerce.number().int().min(0).max(100),
+  generation: z.coerce.number().int().positive().max(Number.MAX_SAFE_INTEGER),
+  updated_at: z.string(),
+});
+
+const CleanupRowSchema = z.object({
+  cleanup_id: UuidSchema,
+  snapshot_id: UuidSchema.nullable(),
+  build_id: UuidSchema.nullable(),
+  resource_type: z.enum(['builder_server', 'validation_server', 'snapshot_image']),
+  provider_resource_id: z.coerce.number().int().positive(),
+  provenance_key: z.string(),
+  reason: z.string(),
+  status: z.enum(['queued', 'running', 'completed', 'failed', 'quarantined']),
+  attempts: z.number().int().nonnegative(),
+  next_attempt_at: z.string(),
+  lease_expires_at: z.string().nullable(),
+  last_error_code: z.string().nullable(),
+  created_at: z.string(),
+  completed_at: z.string().nullable(),
+});
+
+export type GoldenSnapshotRecord = ReturnType<typeof mapSnapshot>;
+export type GoldenSnapshotBuildRecord = ReturnType<typeof mapBuild>;
+export type GoldenSnapshotLeaseRecord = ReturnType<typeof mapLease>;
+export type GoldenSnapshotCreateIntentRecord = ReturnType<typeof mapCreateIntent>;
+export type GoldenSnapshotRolloutControlRecord = ReturnType<typeof mapRolloutControl>;
+export type GoldenSnapshotCleanupRecord = ReturnType<typeof mapCleanup>;
+
+export class GoldenSnapshotBuildRequiresRetryError extends Error {
+  constructor() {
+    super('Golden snapshot terminal build requires explicit retry or replacement');
+    this.name = 'GoldenSnapshotBuildRequiresRetryError';
+  }
+}
+
+function mapSnapshot(input: unknown) {
+  const row = SnapshotRowSchema.parse(input);
+  return {
+    snapshotId: row.snapshot_id,
+    bundleVersion: row.bundle_version,
+    bundleSha256: row.bundle_sha256,
+    sourceGitCommit: row.source_git_commit,
+    compatibilityKey: row.compatibility_key,
+    compatibility: {
+      provider: row.provider,
+      architecture: row.architecture,
+      region: row.region,
+      baseImage: row.base_image,
+      baseGeneration: row.base_generation,
+      bootMode: row.boot_mode,
+      activationAbi: row.activation_abi,
+      minimumDiskGb: row.minimum_disk_gb,
+    } satisfies GoldenSnapshotCompatibility,
+    testMode: row.test_mode,
+    imageGeneration: row.image_generation,
+    state: row.state,
+    providerImageId: row.provider_image_id,
+    providerImageStatus: row.provider_image_status,
+    imageDiskGb: row.image_disk_gb,
+    imageArchitecture: row.image_architecture,
+    validationSummary: row.validation_summary,
+    failureCode: row.failure_code,
+    readyAt: row.ready_at,
+    quarantinedAt: row.quarantined_at,
+    retiringAt: row.retiring_at,
+    deletedAt: row.deleted_at,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+    revision: row.revision,
+  };
+}
+
+function mapBuild(input: unknown) {
+  const row = BuildRowSchema.parse(input);
+  return {
+    buildId: row.build_id,
+    snapshotId: row.snapshot_id,
+    phase: row.phase,
+    status: row.status,
+    attempts: row.attempts,
+    availableAt: row.available_at,
+    claimedAt: row.claimed_at,
+    leaseExpiresAt: row.lease_expires_at,
+    callbackPhase: row.callback_phase,
+    callbackTokenHash: row.callback_token_hash,
+    callbackExpiresAt: row.callback_expires_at,
+    callbackEventId: row.callback_event_id,
+    callbackPayloadSha256: row.callback_payload_sha256,
+    callbackOutcome: row.callback_outcome,
+    builderMachineIdSha256: row.builder_machine_id_sha256,
+    builderSshHostKeySha256: row.builder_ssh_host_key_sha256,
+    providerBuilderId: row.provider_builder_id,
+    providerBuilderActionId: row.provider_builder_action_id,
+    providerSnapshotActionId: row.provider_snapshot_action_id,
+    providerValidationId: row.provider_validation_id,
+    providerValidationActionId: row.provider_validation_action_id,
+    pendingOperation: row.pending_operation,
+    lastErrorCode: row.last_error_code,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+    completedAt: row.completed_at,
+  };
+}
+
+function mapLease(input: unknown) {
+  const row = LeaseRowSchema.parse(input);
+  return {
+    leaseId: row.lease_id,
+    snapshotId: row.snapshot_id,
+    machineId: row.machine_id,
+    purpose: row.purpose,
+    targetBundleVersion: row.target_bundle_version,
+    createdAt: row.created_at,
+    expiresAt: row.expires_at,
+    releasedAt: row.released_at,
+  };
+}
+
+function mapCreateIntent(input: unknown) {
+  const row = CreateIntentRowSchema.parse(input);
+  return {
+    intentId: row.intent_id,
+    snapshotId: row.snapshot_id,
+    leaseId: row.lease_id,
+    machineId: row.machine_id,
+    purpose: row.purpose,
+    rolloutGeneration: row.rollout_generation,
+    state: row.state,
+    providerCreateActionId: row.provider_create_action_id,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+    completedAt: row.completed_at,
+  };
+}
+
+function mapRolloutControl(input: unknown) {
+  const row = RolloutControlRowSchema.parse(input);
+  return {
+    compatibilityKey: row.compatibility_key,
+    enabled: row.enabled,
+    percentage: row.percentage,
+    generation: row.generation,
+    updatedAt: row.updated_at,
+  };
+}
+
+function mapCleanup(input: unknown) {
+  const row = CleanupRowSchema.parse(input);
+  return {
+    cleanupId: row.cleanup_id,
+    snapshotId: row.snapshot_id,
+    buildId: row.build_id,
+    resourceType: row.resource_type,
+    providerResourceId: row.provider_resource_id,
+    provenanceKey: row.provenance_key,
+    reason: row.reason,
+    status: row.status,
+    attempts: row.attempts,
+    nextAttemptAt: row.next_attempt_at,
+    leaseExpiresAt: row.lease_expires_at,
+    lastErrorCode: row.last_error_code,
+    createdAt: row.created_at,
+    completedAt: row.completed_at,
+  };
+}
+
+type AuditActor = 'release' | 'worker' | 'operator';
+
+async function appendGoldenSnapshotAuditEvent(
+  trx: PlatformDB,
+  input: {
+    snapshotId?: string | null;
+    buildId?: string | null;
+    cleanupId?: string | null;
+    eventType: string;
+    actorType: AuditActor;
+    fromState?: string | null;
+    toState?: string | null;
+    reason?: string | null;
+    now: string;
+  },
+): Promise<void> {
+  await trx.executor.insertInto('golden_snapshot_audit_events').values({
+    event_id: randomUUID(),
+    snapshot_id: input.snapshotId ?? null,
+    build_id: input.buildId ?? null,
+    cleanup_id: input.cleanupId ?? null,
+    event_type: BoundedCodeSchema.parse(input.eventType),
+    actor_type: input.actorType,
+    actor_id_hash: null,
+    from_state: input.fromState ?? null,
+    to_state: input.toState ?? null,
+    reason: input.reason === undefined || input.reason === null
+      ? null
+      : BoundedCodeSchema.parse(input.reason),
+    created_at: IsoDateSchema.parse(input.now),
+  }).execute();
+}
+
+const EnqueueInputSchema = z.object({
+  bundleVersion: z.string().min(1).max(128),
+  compatibility: GoldenSnapshotCompatibilitySchema,
+  snapshotId: UuidSchema,
+  buildId: UuidSchema,
+  testMode: z.boolean().default(false),
+  replaceReady: z.boolean().default(false),
+  now: IsoDateSchema,
+}).strict();
+
+const RegisteredReleaseSha256Schema = z.string().regex(/^[a-f0-9]{64}$/i)
+  .transform((value) => value.toLowerCase());
+
+export async function enqueueGoldenSnapshotBuild(
+  db: PlatformDB,
+  rawInput: z.input<typeof EnqueueInputSchema>,
+): Promise<{ snapshot: GoldenSnapshotRecord; build: GoldenSnapshotBuildRecord; reused: boolean }> {
+  const input = EnqueueInputSchema.parse(rawInput);
+  await db.ready;
+  return db.transaction(async (trx) => {
+    await sql`SELECT pg_advisory_xact_lock(hashtext(${input.compatibility.baseGeneration}))`.execute(trx.executor);
+    const revokedGeneration = await trx.executor.selectFrom('golden_snapshot_revoked_base_generations')
+      .select('base_generation').where('base_generation', '=', input.compatibility.baseGeneration)
+      .executeTakeFirst();
+    if (revokedGeneration) throw new Error('Base generation is revoked');
+    const release = await trx.executor.selectFrom('host_bundle_releases')
+      .select(['version', 'sha256', 'git_commit'])
+      .where('version', '=', input.bundleVersion)
+      .executeTakeFirstOrThrow();
+    const bundleSha256 = RegisteredReleaseSha256Schema.parse(release.sha256);
+    const key = compatibilityKey(input.compatibility);
+    const latestSnapshot = await trx.executor.selectFrom('golden_snapshots').selectAll()
+      .where('bundle_sha256', '=', bundleSha256).where('compatibility_key', '=', key)
+      .where('test_mode', '=', input.testMode)
+      .orderBy('image_generation', 'desc').forUpdate().executeTakeFirst();
+    const createReplacement = latestSnapshot === undefined
+      || latestSnapshot.state === 'retiring'
+      || latestSnapshot.state === 'deleted'
+      || (input.replaceReady && latestSnapshot.state === 'ready');
+    const imageGeneration = createReplacement ? (latestSnapshot?.image_generation ?? 0) + 1 : latestSnapshot.image_generation;
+    const insertedSnapshot = createReplacement
+      ? await trx.executor.insertInto('golden_snapshots').values({
+      snapshot_id: input.snapshotId,
+      bundle_version: release.version,
+      bundle_sha256: bundleSha256,
+      source_git_commit: release.git_commit,
+      compatibility_key: key,
+      provider: input.compatibility.provider,
+      architecture: input.compatibility.architecture,
+      region: input.compatibility.region,
+      base_image: input.compatibility.baseImage,
+      base_generation: input.compatibility.baseGeneration,
+      boot_mode: input.compatibility.bootMode,
+      activation_abi: input.compatibility.activationAbi,
+      minimum_disk_gb: input.compatibility.minimumDiskGb,
+      test_mode: input.testMode,
+      image_generation: imageGeneration,
+      state: 'candidate',
+      provider_image_id: null,
+      provider_image_status: null,
+      image_disk_gb: null,
+      image_architecture: null,
+      validation_summary: null,
+      failure_code: null,
+      ready_at: null,
+      quarantined_at: null,
+      retiring_at: null,
+      deleted_at: null,
+      created_at: input.now,
+      updated_at: input.now,
+      revision: 1,
+    }).onConflict((oc) => oc.columns([
+      'bundle_sha256', 'compatibility_key', 'test_mode', 'image_generation',
+    ]).doNothing()).returningAll().executeTakeFirst()
+      : undefined;
+    const snapshotRow = insertedSnapshot ?? latestSnapshot ?? await trx.executor.selectFrom('golden_snapshots')
+      .selectAll().where('bundle_sha256', '=', bundleSha256).where('compatibility_key', '=', key)
+      .where('test_mode', '=', input.testMode)
+      .where('image_generation', '=', imageGeneration)
+      .executeTakeFirstOrThrow();
+    const snapshot = mapSnapshot(snapshotRow);
+    const insertedBuild = await trx.executor.insertInto('golden_snapshot_builds').values({
+      build_id: input.buildId,
+      snapshot_id: snapshot.snapshotId,
+      phase: 'requested',
+      status: 'queued',
+      attempts: 0,
+      available_at: input.now,
+      claimed_at: null,
+      lease_expires_at: null,
+      callback_phase: null,
+      callback_token_hash: null,
+      callback_expires_at: null,
+      callback_event_id: null,
+      callback_payload_sha256: null,
+      callback_outcome: null,
+      builder_machine_id_sha256: null,
+      builder_ssh_host_key_sha256: null,
+      provider_builder_id: null,
+      provider_snapshot_action_id: null,
+      provider_validation_id: null,
+      provider_validation_action_id: null,
+      pending_operation: null,
+      last_error_code: null,
+      created_at: input.now,
+      updated_at: input.now,
+      completed_at: null,
+    }).onConflict((oc) => oc.column('snapshot_id').doNothing()).returningAll().executeTakeFirst();
+    const buildRow = insertedBuild ?? await trx.executor.selectFrom('golden_snapshot_builds')
+      .selectAll().where('snapshot_id', '=', snapshot.snapshotId).executeTakeFirstOrThrow();
+    const build = mapBuild(buildRow);
+    if (!insertedBuild && (build.status === 'failed'
+      || ['failed', 'quarantined', 'retiring', 'deleted'].includes(snapshot.state))) {
+      throw new GoldenSnapshotBuildRequiresRetryError();
+    }
+    if (insertedBuild) {
+      await appendGoldenSnapshotAuditEvent(trx, {
+        snapshotId: snapshot.snapshotId,
+        buildId: buildRow.build_id,
+        eventType: 'build_enqueued',
+        actorType: 'release',
+        toState: 'candidate',
+        now: input.now,
+      });
+    }
+    return { snapshot, build, reused: insertedSnapshot === undefined };
+  });
+}
+
+async function countGoldenSnapshotInfrastructure(
+  trx: PlatformDB,
+): Promise<number> {
+  const active = await sql<{ count: number | string }>`
+    SELECT COALESCE(SUM(GREATEST(
+      1,
+      (CASE WHEN provider_builder_id IS NOT NULL OR pending_operation LIKE 'builder:%' THEN 1 ELSE 0 END)
+      + (CASE WHEN provider_validation_id IS NOT NULL OR pending_operation LIKE 'validation:%' THEN 1 ELSE 0 END)
+    )), 0) AS count
+    FROM golden_snapshot_builds
+    WHERE status = 'running'
+  `.execute(trx.executor);
+  const cleanup = await trx.executor.selectFrom('golden_snapshot_cleanup')
+    .select((eb) => eb.fn.countAll<number>().as('count'))
+    .where('resource_type', 'in', ['builder_server', 'validation_server'])
+    .where('completed_at', 'is', null).executeTakeFirstOrThrow();
+  return Number(active.rows[0]?.count ?? 0) + Number(cleanup.count);
+}
+
+export async function getGoldenSnapshot(db: PlatformDB, rawSnapshotId: string): Promise<GoldenSnapshotRecord | undefined> {
+  const snapshotId = UuidSchema.parse(rawSnapshotId);
+  await db.ready;
+  const row = await db.executor.selectFrom('golden_snapshots').selectAll().where('snapshot_id', '=', snapshotId).executeTakeFirst();
+  return row ? mapSnapshot(row) : undefined;
+}
+
+export async function claimGoldenSnapshotBuild(
+  db: PlatformDB,
+  rawBuildId: string,
+  rawNow: string,
+  rawLeaseExpiresAt: string,
+  rawMaxAttempts: number,
+  rawMaxConcurrent: number = 2,
+): Promise<GoldenSnapshotBuildRecord | undefined> {
+  const buildId = UuidSchema.parse(rawBuildId);
+  const now = IsoDateSchema.parse(rawNow);
+  const leaseExpiresAt = IsoDateSchema.parse(rawLeaseExpiresAt);
+  const maxAttempts = z.number().int().min(1).max(20).parse(rawMaxAttempts);
+  const maxConcurrent = z.number().int().min(1).max(10).parse(rawMaxConcurrent);
+  if (Date.parse(leaseExpiresAt) <= Date.parse(now)) {
+    throw new Error('Golden snapshot build lease expiration must be after now');
+  }
+  await db.ready;
+  return db.transaction(async (trx) => {
+    await sql`SELECT pg_advisory_xact_lock(hashtext('golden_snapshot_build_capacity'))`
+      .execute(trx.executor);
+    if (await terminalizeExhaustedGoldenSnapshotBuild(trx, buildId, now, maxAttempts)) {
+      return undefined;
+    }
+    const reclaimable = await trx.executor.selectFrom('golden_snapshot_builds')
+      .select('build_id')
+      .where('build_id', '=', buildId)
+      .where('status', '=', 'running')
+      .where('attempts', '<', maxAttempts)
+      .where('lease_expires_at', '<=', now)
+      .where((eb) => eb.or([
+        eb('phase', 'not in', ['builder_boot', 'validation_boot']),
+        eb('callback_expires_at', 'is', null),
+        eb('callback_expires_at', '<=', now),
+      ]))
+      .forUpdate()
+      .executeTakeFirst();
+    if (!reclaimable && await countGoldenSnapshotInfrastructure(trx) >= maxConcurrent) {
+      return undefined;
+    }
+    const row = await trx.executor.updateTable('golden_snapshot_builds').set({
+      status: 'running', attempts: sql<number>`attempts + 1`, claimed_at: now,
+      lease_expires_at: leaseExpiresAt, updated_at: now,
+    }).where('build_id', '=', buildId).where('attempts', '<', maxAttempts)
+      .where((eb) => eb.exists(
+        eb.selectFrom('golden_snapshots').select('snapshot_id')
+          .whereRef('golden_snapshots.snapshot_id', '=', 'golden_snapshot_builds.snapshot_id')
+          .where('golden_snapshots.state', 'in', ['candidate', 'building', 'sanitizing', 'validating']),
+      ))
+      .where((eb) => eb.or([
+        eb.and([eb('status', '=', 'queued'), eb('available_at', '<=', now)]),
+        eb.and([
+          eb('status', '=', 'running'),
+          eb('lease_expires_at', '<=', now),
+          eb.or([
+            eb('phase', 'not in', ['builder_boot', 'validation_boot']),
+            eb('callback_expires_at', 'is', null),
+            eb('callback_expires_at', '<=', now),
+          ]),
+        ]),
+      ])).returningAll().executeTakeFirst();
+    if (row) return mapBuild(row);
+    return undefined;
+  });
+}
+
+async function terminalizeExhaustedGoldenSnapshotBuild(
+  trx: PlatformDB,
+  buildId: string,
+  now: string,
+  maxAttempts: number,
+): Promise<boolean> {
+  const exhausted = await trx.executor.selectFrom('golden_snapshot_builds').selectAll()
+    .where('build_id', '=', buildId).where('status', '=', 'running')
+    .where('attempts', '>=', maxAttempts).where('lease_expires_at', '<=', now)
+    .where((eb) => eb.or([
+      eb('phase', 'not in', ['builder_boot', 'validation_boot']),
+      eb('callback_expires_at', 'is', null),
+      eb('callback_expires_at', '<=', now),
+    ]))
+    .forUpdate().executeTakeFirst();
+  if (!exhausted) return false;
+  const snapshot = await trx.executor.selectFrom('golden_snapshots').selectAll()
+    .where('snapshot_id', '=', exhausted.snapshot_id).forUpdate().executeTakeFirstOrThrow();
+  await trx.executor.updateTable('golden_snapshot_builds').set({
+    phase: 'failed', status: 'failed', last_error_code: 'retry_budget_exhausted',
+    lease_expires_at: null, callback_phase: null, callback_token_hash: null,
+    callback_expires_at: null, completed_at: now, updated_at: now,
+  }).where('build_id', '=', buildId).where('status', '=', 'running')
+    .where('attempts', '>=', maxAttempts).executeTakeFirstOrThrow();
+  await trx.executor.updateTable('golden_snapshots').set({
+    state: 'failed', failure_code: 'retry_budget_exhausted', updated_at: now,
+    revision: sql<number>`revision + 1`,
+  }).where('snapshot_id', '=', snapshot.snapshot_id)
+    .where('state', 'in', ['candidate', 'building', 'sanitizing', 'validating']).execute();
+  await appendGoldenSnapshotAuditEvent(trx, {
+    snapshotId: snapshot.snapshot_id, buildId, eventType: 'build_failed', actorType: 'worker',
+    fromState: snapshot.state, toState: 'failed', reason: 'retry_budget_exhausted', now,
+  });
+  const resources = [
+    exhausted.provider_builder_id === null ? undefined : {
+      type: 'builder_server' as const, id: exhausted.provider_builder_id,
+    },
+    exhausted.provider_validation_id === null ? undefined : {
+      type: 'validation_server' as const, id: exhausted.provider_validation_id,
+    },
+    snapshot.provider_image_id === null ? undefined : {
+      type: 'snapshot_image' as const, id: snapshot.provider_image_id,
+    },
+  ].filter((resource): resource is {
+    type: 'builder_server' | 'validation_server' | 'snapshot_image'; id: number;
+  } => resource !== undefined);
+  for (const resource of resources) {
+    await trx.executor.insertInto('golden_snapshot_cleanup').values({
+      cleanup_id: randomUUID(), snapshot_id: snapshot.snapshot_id, build_id: buildId,
+      resource_type: resource.type, provider_resource_id: resource.id,
+      provenance_key: `build:${buildId}:${resource.type}`, reason: 'retry_budget_exhausted',
+      status: 'queued', attempts: 0, next_attempt_at: now, lease_expires_at: null,
+      last_error_code: null, created_at: now, completed_at: null,
+    }).onConflict((oc) => oc.columns(['resource_type', 'provider_resource_id'])
+      .where('completed_at', 'is', null).doNothing()).execute();
+  }
+  return true;
+}
+
+export async function claimGoldenSnapshotBuildBatch(
+  db: PlatformDB,
+  rawNow: string,
+  rawLeaseExpiresAt: string,
+  rawMaxAttempts: number,
+  rawLimit: number,
+  rawMaxConcurrent: number,
+): Promise<GoldenSnapshotBuildRecord[]> {
+  const now = IsoDateSchema.parse(rawNow);
+  const leaseExpiresAt = IsoDateSchema.parse(rawLeaseExpiresAt);
+  const maxAttempts = z.number().int().min(1).max(20).parse(rawMaxAttempts);
+  const limit = z.number().int().min(1).max(100).parse(rawLimit);
+  const maxConcurrent = z.number().int().min(1).max(10).parse(rawMaxConcurrent);
+  if (Date.parse(leaseExpiresAt) <= Date.parse(now)) {
+    throw new Error('Golden snapshot build lease expiration must be after now');
+  }
+  await db.ready;
+  return db.transaction(async (trx) => {
+    await sql`SELECT pg_advisory_xact_lock(hashtext('golden_snapshot_build_capacity'))`
+      .execute(trx.executor);
+    const exhausted = await trx.executor.selectFrom('golden_snapshot_builds').select('build_id')
+      .where('status', '=', 'running').where('attempts', '>=', maxAttempts)
+      .where('lease_expires_at', '<=', now)
+      .where((eb) => eb.or([
+        eb('phase', 'not in', ['builder_boot', 'validation_boot']),
+        eb('callback_expires_at', 'is', null),
+        eb('callback_expires_at', '<=', now),
+      ]))
+      .orderBy('build_id').forUpdate().skipLocked()
+      .limit(limit).execute();
+    for (const row of exhausted) {
+      await terminalizeExhaustedGoldenSnapshotBuild(trx, row.build_id, now, maxAttempts);
+    }
+    const reclaimable = await trx.executor.selectFrom('golden_snapshot_builds')
+      .select('build_id')
+      .where('attempts', '<', maxAttempts)
+      .where((eb) => eb.exists(
+        eb.selectFrom('golden_snapshots').select('snapshot_id')
+          .whereRef('golden_snapshots.snapshot_id', '=', 'golden_snapshot_builds.snapshot_id')
+          .where('golden_snapshots.state', 'in', ['candidate', 'building', 'sanitizing', 'validating']),
+      ))
+      .where('status', '=', 'running')
+      .where('lease_expires_at', '<=', now)
+      .where((eb) => eb.or([
+        eb('phase', 'not in', ['builder_boot', 'validation_boot']),
+        eb('callback_expires_at', 'is', null),
+        eb('callback_expires_at', '<=', now),
+      ]))
+      .orderBy('available_at')
+      .orderBy('build_id')
+      .forUpdate()
+      .skipLocked()
+      .limit(limit)
+      .execute();
+    const claimed: GoldenSnapshotBuildRecord[] = [];
+    for (const candidate of reclaimable) {
+      const row = await trx.executor.updateTable('golden_snapshot_builds').set({
+        status: 'running',
+        attempts: sql<number>`attempts + 1`,
+        claimed_at: now,
+        lease_expires_at: leaseExpiresAt,
+        updated_at: now,
+      }).where('build_id', '=', candidate.build_id)
+        .where('attempts', '<', maxAttempts)
+        .where('status', '=', 'running')
+        .where('lease_expires_at', '<=', now)
+        .returningAll()
+        .executeTakeFirst();
+      if (row) claimed.push(mapBuild(row));
+    }
+    const capacity = Math.min(
+      limit - claimed.length,
+      Math.max(0, maxConcurrent - await countGoldenSnapshotInfrastructure(trx)),
+    );
+    if (capacity === 0) return claimed;
+    const queued = await trx.executor.selectFrom('golden_snapshot_builds')
+      .select('build_id')
+      .where('attempts', '<', maxAttempts)
+      .where((eb) => eb.exists(
+        eb.selectFrom('golden_snapshots').select('snapshot_id')
+          .whereRef('golden_snapshots.snapshot_id', '=', 'golden_snapshot_builds.snapshot_id')
+          .where('golden_snapshots.state', 'in', ['candidate', 'building', 'sanitizing', 'validating']),
+      ))
+      .where('status', '=', 'queued')
+      .where('available_at', '<=', now)
+      .orderBy('available_at')
+      .orderBy('build_id')
+      .forUpdate()
+      .skipLocked()
+      .limit(capacity)
+      .execute();
+    for (const candidate of queued) {
+      const row = await trx.executor.updateTable('golden_snapshot_builds').set({
+        status: 'running',
+        attempts: sql<number>`attempts + 1`,
+        claimed_at: now,
+        lease_expires_at: leaseExpiresAt,
+        updated_at: now,
+      }).where('build_id', '=', candidate.build_id)
+        .where('attempts', '<', maxAttempts)
+        .where('status', '=', 'queued')
+        .where('available_at', '<=', now)
+        .returningAll()
+        .executeTakeFirst();
+      if (row) claimed.push(mapBuild(row));
+    }
+    return claimed;
+  });
+}
+
+export async function advanceGoldenSnapshot(
+  db: PlatformDB,
+  rawSnapshotId: string,
+  rawBuildId: string,
+  rawExpectedLeaseExpiresAt: string,
+  rawFrom: GoldenSnapshotState,
+  rawTo: GoldenSnapshotState,
+  rawNow: string,
+): Promise<boolean> {
+  const snapshotId = UuidSchema.parse(rawSnapshotId);
+  const buildId = UuidSchema.parse(rawBuildId);
+  const expectedLeaseExpiresAt = IsoDateSchema.parse(rawExpectedLeaseExpiresAt);
+  const from = GoldenSnapshotStateSchema.parse(rawFrom);
+  const to = GoldenSnapshotStateSchema.parse(rawTo);
+  const now = IsoDateSchema.parse(rawNow);
+  if (!canTransitionGoldenSnapshot(from, to)) throw new Error(`Invalid golden snapshot transition: ${from} -> ${to}`);
+  const genericTransitions = new Set([
+    'candidate:building', 'building:sanitizing', 'sanitizing:validating',
+  ]);
+  if (!genericTransitions.has(`${from}:${to}`)) {
+    throw new Error(`Golden snapshot specialized lifecycle transition required: ${from} -> ${to}`);
+  }
+  await db.ready;
+  return db.transaction(async (trx) => {
+    const activeBuild = await trx.executor.selectFrom('golden_snapshot_builds')
+      .select('build_id')
+      .where('build_id', '=', buildId)
+      .where('snapshot_id', '=', snapshotId)
+      .where('status', '=', 'running')
+      .where('lease_expires_at', '=', expectedLeaseExpiresAt)
+      .where('lease_expires_at', '>', now)
+      .forUpdate()
+      .executeTakeFirst();
+    if (!activeBuild) return false;
+    const result = await trx.executor.updateTable('golden_snapshots').set({
+      state: to,
+      updated_at: now,
+      revision: sql<number>`revision + 1`,
+    }).where('snapshot_id', '=', snapshotId).where('state', '=', from)
+      .returning('snapshot_id').executeTakeFirst();
+    if (!result) return false;
+    const phaseByState: Partial<Record<GoldenSnapshotState, string>> = {
+      building: 'builder_create',
+      sanitizing: 'sanitizing',
+      validating: 'validation_create',
+    };
+    const phase = phaseByState[to];
+    if (!phase) throw new Error(`Missing build phase for golden snapshot state: ${to}`);
+    await trx.executor.updateTable('golden_snapshot_builds').set({ phase, updated_at: now })
+      .where('build_id', '=', buildId).where('status', '=', 'running')
+      .where('lease_expires_at', '=', expectedLeaseExpiresAt).executeTakeFirstOrThrow();
+    await appendGoldenSnapshotAuditEvent(trx, {
+      snapshotId, buildId, eventType: 'snapshot_transition', actorType: 'worker',
+      fromState: from, toState: to, now,
+    });
+    return true;
+  });
+}
+
+const ProviderImageInputSchema = z.object({
+  buildId: UuidSchema,
+  expectedLeaseExpiresAt: IsoDateSchema,
+  providerSnapshotActionId: z.number().int().positive().nullable().optional(),
+  providerImageId: z.number().int().positive(),
+  providerImageStatus: z.enum(['creating', 'available']),
+  imageDiskGb: z.number().int().min(1).max(2_048),
+  imageArchitecture: z.enum(['x86', 'arm']),
+  now: IsoDateSchema,
+}).strict();
+
+export async function recordGoldenSnapshotProviderImage(
+  db: PlatformDB,
+  rawSnapshotId: string,
+  rawInput: z.input<typeof ProviderImageInputSchema>,
+): Promise<boolean> {
+  const snapshotId = UuidSchema.parse(rawSnapshotId);
+  const input = ProviderImageInputSchema.parse(rawInput);
+  await db.ready;
+  return db.transaction(async (trx) => {
+    const build = await trx.executor.selectFrom('golden_snapshot_builds').selectAll()
+      .where('build_id', '=', input.buildId).where('snapshot_id', '=', snapshotId)
+      .forUpdate().executeTakeFirst();
+    const current = await trx.executor.selectFrom('golden_snapshots').selectAll()
+      .where('snapshot_id', '=', snapshotId).forUpdate().executeTakeFirst();
+    if (!current) return false;
+    const queueLateImage = async (): Promise<void> => {
+      await trx.executor.insertInto('golden_snapshot_cleanup').values({
+        cleanup_id: randomUUID(), snapshot_id: snapshotId, build_id: build?.build_id ?? null,
+        resource_type: 'snapshot_image', provider_resource_id: input.providerImageId,
+        provenance_key: `snapshot:${snapshotId}`, reason: 'late_provider_image',
+        status: 'queued', attempts: 0, next_attempt_at: input.now, lease_expires_at: null,
+        last_error_code: null, created_at: input.now, completed_at: null,
+      }).onConflict((oc) => oc.columns(['resource_type', 'provider_resource_id'])
+        .where('completed_at', 'is', null).doNothing()).execute();
+    };
+    const isCurrentProviderImage = current.provider_image_id !== null
+      && Number(current.provider_image_id) === input.providerImageId;
+    if (isCurrentProviderImage && current.architecture !== input.imageArchitecture) {
+      if (build?.status === 'running') {
+        await trx.executor.updateTable('golden_snapshot_builds').set({
+          phase: 'failed', status: 'failed', last_error_code: 'provider_image_metadata_conflict',
+          lease_expires_at: null, callback_phase: null, callback_token_hash: null,
+          callback_expires_at: null, pending_operation: null,
+          completed_at: input.now, updated_at: input.now,
+        }).where('build_id', '=', build.build_id).where('status', '=', 'running').execute();
+        const resources = [
+          build.provider_builder_id === null ? undefined : {
+            type: 'builder_server' as const, id: Number(build.provider_builder_id),
+          },
+          build.provider_validation_id === null ? undefined : {
+            type: 'validation_server' as const, id: Number(build.provider_validation_id),
+          },
+        ].filter((resource): resource is {
+          type: 'builder_server' | 'validation_server'; id: number;
+        } => resource !== undefined);
+        for (const resource of resources) {
+          await trx.executor.insertInto('golden_snapshot_cleanup').values({
+            cleanup_id: randomUUID(), snapshot_id: snapshotId, build_id: build.build_id,
+            resource_type: resource.type, provider_resource_id: resource.id,
+            provenance_key: `build:${build.build_id}:${resource.type}`,
+            reason: 'provider_image_metadata_conflict', status: 'queued', attempts: 0,
+            next_attempt_at: input.now, lease_expires_at: null, last_error_code: null,
+            created_at: input.now, completed_at: null,
+          }).onConflict((oc) => oc.columns(['resource_type', 'provider_resource_id'])
+            .where('completed_at', 'is', null).doNothing()).execute();
+        }
+      }
+      const quarantined = await trx.executor.updateTable('golden_snapshots').set({
+        state: 'quarantined', failure_code: 'provider_image_metadata_conflict',
+        quarantined_at: input.now, updated_at: input.now, revision: sql<number>`revision + 1`,
+      }).where('snapshot_id', '=', snapshotId).where('revision', '=', current.revision)
+        .returning('snapshot_id').executeTakeFirst();
+      if (quarantined) {
+        await appendGoldenSnapshotAuditEvent(trx, {
+          snapshotId, buildId: build?.build_id, eventType: 'snapshot_quarantined', actorType: 'worker',
+          fromState: current.state, toState: 'quarantined',
+          reason: 'provider_image_metadata_conflict', now: input.now,
+        });
+      }
+      return false;
+    }
+    if (current.state === 'ready' && isCurrentProviderImage) return true;
+    if (!build || build.status !== 'running'
+      || build.lease_expires_at !== input.expectedLeaseExpiresAt
+      || build.lease_expires_at <= input.now) {
+      await queueLateImage();
+      return false;
+    }
+    if (!['sanitizing', 'validating'].includes(current.state)
+      || current.architecture !== input.imageArchitecture) {
+      await queueLateImage();
+      return false;
+    }
+    if (current.provider_image_id !== null && Number(current.provider_image_id) !== input.providerImageId) {
+      await trx.executor.updateTable('golden_snapshot_builds').set({
+        phase: 'failed', status: 'failed', last_error_code: 'provider_image_identity_conflict',
+        lease_expires_at: null, callback_phase: null, callback_token_hash: null,
+        callback_expires_at: null, pending_operation: null,
+        completed_at: input.now, updated_at: input.now,
+      }).where('build_id', '=', build.build_id)
+        .where('status', '=', 'running').executeTakeFirstOrThrow();
+      await trx.executor.updateTable('golden_snapshots').set({
+        state: 'quarantined', failure_code: 'provider_image_identity_conflict',
+        quarantined_at: input.now, updated_at: input.now, revision: sql<number>`revision + 1`,
+      }).where('snapshot_id', '=', snapshotId).where('revision', '=', current.revision).executeTakeFirstOrThrow();
+      await appendGoldenSnapshotAuditEvent(trx, {
+        snapshotId, buildId: build.build_id, eventType: 'snapshot_quarantined', actorType: 'worker',
+        fromState: current.state, toState: 'quarantined', reason: 'provider_image_identity_conflict', now: input.now,
+      });
+      const resources = [
+        build?.provider_builder_id === null || build?.provider_builder_id === undefined ? undefined : {
+          type: 'builder_server' as const, id: build.provider_builder_id,
+        },
+        build?.provider_validation_id === null || build?.provider_validation_id === undefined ? undefined : {
+          type: 'validation_server' as const, id: build.provider_validation_id,
+        },
+        { type: 'snapshot_image' as const, id: Number(current.provider_image_id) },
+        { type: 'snapshot_image' as const, id: input.providerImageId },
+      ].filter((resource): resource is {
+        type: 'builder_server' | 'validation_server' | 'snapshot_image'; id: number;
+      } => resource !== undefined);
+      for (const resource of resources) {
+        await trx.executor.insertInto('golden_snapshot_cleanup').values({
+          cleanup_id: randomUUID(), snapshot_id: snapshotId, build_id: build?.build_id ?? null,
+          resource_type: resource.type, provider_resource_id: resource.id,
+          provenance_key: `snapshot:${snapshotId}:conflict:${resource.type}:${resource.id}`,
+          reason: 'provider_image_identity_conflict', status: 'queued', attempts: 0,
+          next_attempt_at: input.now, lease_expires_at: null, last_error_code: null,
+          created_at: input.now, completed_at: null,
+        }).onConflict((oc) => oc.columns(['resource_type', 'provider_resource_id'])
+          .where('completed_at', 'is', null).doNothing()).execute();
+      }
+      return false;
+    }
+    if (current.provider_image_status === 'available' && input.providerImageStatus === 'creating') {
+      return true;
+    }
+    const row = await trx.executor.updateTable('golden_snapshots').set({
+      state: 'validating',
+      provider_image_id: input.providerImageId, provider_image_status: input.providerImageStatus,
+      image_disk_gb: input.imageDiskGb, image_architecture: input.imageArchitecture,
+      updated_at: input.now, revision: sql<number>`revision + 1`,
+    }).where('snapshot_id', '=', snapshotId).where('revision', '=', current.revision)
+      .where('state', 'in', ['sanitizing', 'validating'])
+      .returning('snapshot_id').executeTakeFirst();
+    if (!row) return false;
+    await trx.executor.updateTable('golden_snapshot_builds').set({
+      provider_snapshot_action_id: input.providerSnapshotActionId ?? build.provider_snapshot_action_id,
+      pending_operation: null,
+      updated_at: input.now,
+    }).where('build_id', '=', build.build_id)
+      .where('status', '=', 'running')
+      .where('lease_expires_at', '=', input.expectedLeaseExpiresAt)
+      .executeTakeFirstOrThrow();
+    if (current.state !== 'validating') {
+      await appendGoldenSnapshotAuditEvent(trx, {
+        snapshotId, buildId: build.build_id, eventType: 'snapshot_transition', actorType: 'worker',
+        fromState: current.state, toState: 'validating', now: input.now,
+      });
+    }
+    return true;
+  });
+}
+
+export async function markGoldenSnapshotReady(
+  db: PlatformDB,
+  rawSnapshotId: string,
+  rawBuildId: string,
+  rawInput: { validationSummary: GoldenSnapshotValidationSummary; expectedLeaseExpiresAt: string; now: string },
+): Promise<GoldenSnapshotRecord> {
+  const snapshotId = UuidSchema.parse(rawSnapshotId);
+  const buildId = UuidSchema.parse(rawBuildId);
+  const validationSummary = GoldenSnapshotValidationSummarySchema.parse(rawInput.validationSummary);
+  const expectedLeaseExpiresAt = IsoDateSchema.parse(rawInput.expectedLeaseExpiresAt);
+  const now = IsoDateSchema.parse(rawInput.now);
+  await db.ready;
+  return db.transaction(async (trx) => {
+    const baseGeneration = await trx.executor.selectFrom('golden_snapshots')
+      .select('base_generation').where('snapshot_id', '=', snapshotId).executeTakeFirstOrThrow();
+    await sql`SELECT pg_advisory_xact_lock(hashtext(${baseGeneration.base_generation}))`.execute(trx.executor);
+    const build = await trx.executor.selectFrom('golden_snapshot_builds').selectAll()
+      .where('build_id', '=', buildId).where('snapshot_id', '=', snapshotId).forUpdate().executeTakeFirst();
+    if (!build || build.phase !== 'validation_boot' || build.status !== 'running'
+      || build.lease_expires_at !== expectedLeaseExpiresAt || build.lease_expires_at <= now) {
+      throw new Error('Golden snapshot readiness requires the current validation lease');
+    }
+    const snapshot = await trx.executor.selectFrom('golden_snapshots').selectAll()
+      .where('snapshot_id', '=', snapshotId).forUpdate().executeTakeFirstOrThrow();
+    const revokedGeneration = await trx.executor.selectFrom('golden_snapshot_revoked_base_generations')
+      .select('base_generation').where('base_generation', '=', snapshot.base_generation).executeTakeFirst();
+    if (revokedGeneration) throw new Error('Base generation is revoked');
+    if (snapshot.state !== 'validating' || snapshot.provider_image_status !== 'available'
+      || snapshot.provider_image_id === null || snapshot.image_architecture !== snapshot.architecture) {
+      throw new Error('Golden snapshot is not validated and available');
+    }
+    await trx.executor.updateTable('golden_snapshot_builds').set({
+      phase: 'completed', status: 'completed', updated_at: now, completed_at: now,
+      lease_expires_at: null, callback_token_hash: null, callback_expires_at: null,
+    }).where('build_id', '=', buildId).where('status', '=', 'running').executeTakeFirstOrThrow();
+    const snapshotRow = await trx.executor.updateTable('golden_snapshots').set({
+      state: 'ready', validation_summary: validationSummary, ready_at: now, updated_at: now,
+      failure_code: null, revision: sql<number>`revision + 1`,
+    }).where('snapshot_id', '=', snapshotId).where('revision', '=', snapshot.revision)
+      .returningAll().executeTakeFirst();
+    if (!snapshotRow) throw new Error('Golden snapshot is not validated and available');
+    await appendGoldenSnapshotAuditEvent(trx, {
+      snapshotId, buildId, eventType: 'snapshot_ready', actorType: 'worker',
+      fromState: snapshot.state, toState: 'ready', now,
+    });
+    return mapSnapshot(snapshotRow);
+  });
+}
+
+const SelectInputSchema = z.object({
+  targetBundleVersion: z.string().min(1).max(128),
+  compatibility: GoldenSnapshotCompatibilitySchema,
+  serverDiskGb: z.number().int().min(1).max(2_048),
+  machineId: UuidSchema,
+  purpose: z.enum(['provision', 'recover']),
+  leaseId: UuidSchema,
+  now: IsoDateSchema,
+  expiresAt: IsoDateSchema,
+  maxLeaseMs: z.number().int().min(60_000).max(60 * 60 * 1000).default(10 * 60 * 1000),
+}).strict();
+
+async function retireQuarantinedSnapshotAfterLeaseDrain(
+  trx: PlatformDB,
+  snapshot: {
+    snapshot_id: string;
+    state: string;
+    provider_image_id: number | null;
+    failure_code: string | null;
+    revision: number;
+  },
+  now: string,
+): Promise<void> {
+  if (snapshot.state !== 'quarantined' || snapshot.provider_image_id === null) return;
+  // Expired-but-unreleased leases still protect ambiguous provider clones.
+  const remainingUnreleasedLease = await trx.executor.selectFrom('golden_snapshot_leases').select('lease_id')
+    .where('snapshot_id', '=', snapshot.snapshot_id).where('released_at', 'is', null)
+    .executeTakeFirst();
+  if (remainingUnreleasedLease) return;
+  await trx.executor.insertInto('golden_snapshot_cleanup').values({
+    cleanup_id: randomUUID(), snapshot_id: snapshot.snapshot_id, build_id: null,
+    resource_type: 'snapshot_image', provider_resource_id: snapshot.provider_image_id,
+    provenance_key: `snapshot:${snapshot.snapshot_id}`,
+    reason: snapshot.failure_code ?? 'revoked', status: 'queued', attempts: 0,
+    next_attempt_at: now, lease_expires_at: null, last_error_code: null,
+    created_at: now, completed_at: null,
+  }).onConflict((oc) => oc.columns(['resource_type', 'provider_resource_id'])
+    .where('completed_at', 'is', null).doNothing()).execute();
+  await trx.executor.updateTable('golden_snapshots').set({
+    state: 'retiring', retiring_at: now, updated_at: now,
+    revision: sql<number>`revision + 1`,
+  }).where('snapshot_id', '=', snapshot.snapshot_id)
+    .where('revision', '=', snapshot.revision)
+    .where('state', '=', 'quarantined')
+    .executeTakeFirstOrThrow();
+  await appendGoldenSnapshotAuditEvent(trx, {
+    snapshotId: snapshot.snapshot_id, eventType: 'snapshot_retiring', actorType: 'worker',
+    fromState: 'quarantined', toState: 'retiring', reason: snapshot.failure_code, now,
+  });
+}
+
+export async function selectAndLeaseGoldenSnapshot(
+  db: PlatformDB,
+  rawInput: z.input<typeof SelectInputSchema>,
+): Promise<{ snapshot: GoldenSnapshotRecord; lease: GoldenSnapshotLeaseRecord } | undefined> {
+  const parsedInput = SelectInputSchema.parse(rawInput);
+  const input = {
+    ...parsedInput,
+    now: new Date(parsedInput.now).toISOString(),
+    expiresAt: new Date(parsedInput.expiresAt).toISOString(),
+  };
+  const key = compatibilityKey(input.compatibility);
+  const leaseDurationMs = Date.parse(input.expiresAt) - Date.parse(input.now);
+  if (leaseDurationMs <= 0) {
+    throw new Error('Golden snapshot lease expiration must be after now');
+  }
+  if (leaseDurationMs > input.maxLeaseMs) {
+    throw new Error('Golden snapshot lease exceeds maximum TTL');
+  }
+  await db.ready;
+  return db.transaction(async (trx) => {
+    await sql`SELECT pg_advisory_xact_lock(hashtext(${input.compatibility.baseGeneration}))`.execute(trx.executor);
+    const existingLease = await trx.executor.selectFrom('golden_snapshot_leases')
+      .selectAll()
+      .where('golden_snapshot_leases.machine_id', '=', input.machineId)
+      .where('golden_snapshot_leases.released_at', 'is', null).forUpdate().executeTakeFirst();
+    if (existingLease) {
+      const sameTarget = existingLease.purpose === input.purpose
+        && existingLease.target_bundle_version === input.targetBundleVersion;
+      const expired = new Date(existingLease.expires_at).getTime() <= new Date(input.now).getTime();
+      const leasedSnapshotRow = await trx.executor.selectFrom('golden_snapshots').selectAll()
+        .where('snapshot_id', '=', existingLease.snapshot_id).forUpdate().executeTakeFirst();
+      const snapshotRow = sameTarget && leasedSnapshotRow?.state === 'ready'
+        ? leasedSnapshotRow
+        : undefined;
+      const existingSnapshot = snapshotRow ? mapSnapshot(snapshotRow) : undefined;
+      const revokedGeneration = existingSnapshot
+        ? await trx.executor.selectFrom('golden_snapshot_revoked_base_generations')
+          .select('base_generation').where('base_generation', '=', existingSnapshot.compatibility.baseGeneration)
+          .executeTakeFirst()
+        : undefined;
+      const reusable = existingSnapshot !== undefined
+        && revokedGeneration === undefined
+        && existingSnapshot.providerImageId !== null
+        && existingSnapshot.providerImageStatus === 'available'
+        && existingSnapshot.readyAt !== null
+        && !existingSnapshot.testMode
+        && existingSnapshot.compatibilityKey === key
+        && existingSnapshot.compatibility.activationAbi === input.compatibility.activationAbi
+        && existingSnapshot.compatibility.minimumDiskGb <= input.serverDiskGb
+        && (existingSnapshot.imageDiskGb === null || existingSnapshot.imageDiskGb <= input.serverDiskGb);
+      if (!expired) {
+        if (!sameTarget || !reusable) return undefined;
+        return { snapshot: existingSnapshot, lease: mapLease(existingLease) };
+      }
+      if (reusable) {
+        const renewed = await trx.executor.updateTable('golden_snapshot_leases')
+          .set({ expires_at: input.expiresAt })
+          .where('lease_id', '=', existingLease.lease_id).where('released_at', 'is', null)
+          .returningAll().executeTakeFirst();
+        if (!renewed) return undefined;
+        return { snapshot: existingSnapshot, lease: mapLease(renewed) };
+      }
+      const provisioningJob = await trx.executor.selectFrom('provisioning_jobs').select('status')
+        .where('machine_id', '=', input.machineId).executeTakeFirst();
+      const recoveryMachine = existingLease.purpose === 'recover'
+        ? await trx.executor.selectFrom('user_machines').select('status')
+          .where('machine_id', '=', input.machineId).where('deleted_at', 'is', null).executeTakeFirst()
+        : undefined;
+      if (provisioningJob?.status === 'queued' || provisioningJob?.status === 'running'
+        || recoveryMachine?.status === 'recovering') return undefined;
+      const released = await trx.executor.updateTable('golden_snapshot_leases').set({ released_at: input.now })
+        .where('lease_id', '=', existingLease.lease_id).where('released_at', 'is', null)
+        .returning('lease_id').executeTakeFirst();
+      if (!released) return undefined;
+      if (leasedSnapshotRow) {
+        await retireQuarantinedSnapshotAfterLeaseDrain(trx, leasedSnapshotRow, input.now);
+      }
+    }
+    const target = await trx.executor.selectFrom('host_bundle_releases').select(['sha256', 'build_time'])
+      .where('version', '=', input.targetBundleVersion).executeTakeFirstOrThrow();
+    const targetSha256 = Sha256Schema.parse(target.sha256.toLowerCase());
+    const candidates = await trx.executor.selectFrom('golden_snapshots')
+      .innerJoin('host_bundle_releases', 'host_bundle_releases.version', 'golden_snapshots.bundle_version')
+      .selectAll('golden_snapshots').select('host_bundle_releases.build_time as source_release_build_time')
+      .where('golden_snapshots.state', '=', 'ready').where('golden_snapshots.compatibility_key', '=', key)
+      .where('golden_snapshots.test_mode', '=', false)
+      .where((eb) => eb.not(eb.exists(
+        eb.selectFrom('golden_snapshot_revoked_base_generations').select('base_generation')
+          .whereRef('golden_snapshot_revoked_base_generations.base_generation', '=', 'golden_snapshots.base_generation'),
+      )))
+      .where('golden_snapshots.minimum_disk_gb', '<=', input.serverDiskGb)
+      .where((eb) => eb.or([
+        eb('golden_snapshots.bundle_sha256', '=', targetSha256),
+        sql<boolean>`${sql.ref('host_bundle_releases.build_time')}::timestamptz < ${target.build_time}::timestamptz`,
+      ]))
+      .where((eb) => eb.or([
+        eb('golden_snapshots.image_disk_gb', 'is', null),
+        eb('golden_snapshots.image_disk_gb', '<=', input.serverDiskGb),
+      ]))
+      .orderBy(sql<number>`CASE WHEN ${sql.ref('golden_snapshots.bundle_sha256')} = ${targetSha256} THEN 0 ELSE 1 END`)
+      .orderBy(sql`${sql.ref('host_bundle_releases.build_time')}::timestamptz`, 'desc')
+      .orderBy('golden_snapshots.ready_at', 'desc').limit(100).execute();
+    const chosen = chooseGoldenSnapshot({
+      targetBundleSha256: targetSha256,
+      targetReleaseBuildTime: target.build_time,
+      compatibilityKey: key,
+      serverDiskGb: input.serverDiskGb,
+      activationAbi: input.compatibility.activationAbi,
+    }, candidates.map((row) => ({
+      snapshotId: row.snapshot_id,
+      bundleVersion: row.bundle_version,
+      bundleSha256: row.bundle_sha256,
+      compatibilityKey: row.compatibility_key,
+      sourceReleaseBuildTime: row.source_release_build_time,
+      state: GoldenSnapshotStateSchema.parse(row.state),
+      minimumDiskGb: row.minimum_disk_gb,
+      imageDiskGb: row.image_disk_gb,
+      activationAbi: row.activation_abi,
+      readyAt: row.ready_at ?? '',
+    })));
+    if (!chosen) return undefined;
+    const locked = await trx.executor.selectFrom('golden_snapshots').selectAll()
+      .where('snapshot_id', '=', chosen.snapshotId).where('state', '=', 'ready').forUpdate().executeTakeFirst();
+    if (!locked) return undefined;
+    const snapshot = mapSnapshot(locked);
+    if (snapshot.providerImageId === null || snapshot.readyAt === null) return undefined;
+    const leaseRow = await trx.executor.insertInto('golden_snapshot_leases').values({
+      lease_id: input.leaseId,
+      snapshot_id: snapshot.snapshotId,
+      machine_id: input.machineId,
+      purpose: input.purpose,
+      target_bundle_version: input.targetBundleVersion,
+      created_at: input.now,
+      expires_at: input.expiresAt,
+      released_at: null,
+    }).onConflict((oc) => oc.column('machine_id').where('released_at', 'is', null).doNothing())
+      .returningAll().executeTakeFirst();
+    if (!leaseRow) return undefined;
+    return { snapshot, lease: mapLease(leaseRow) };
+  });
+}
+
+export async function initializeGoldenSnapshotRolloutControl(
+  db: PlatformDB,
+  rawInput: {
+    compatibility: GoldenSnapshotCompatibility;
+    enabled: boolean;
+    percentage: number;
+    now: string;
+  },
+): Promise<GoldenSnapshotRolloutControlRecord> {
+  const input = z.object({
+    compatibility: GoldenSnapshotCompatibilitySchema,
+    enabled: z.boolean(),
+    percentage: z.number().int().min(0).max(100),
+    now: IsoDateSchema,
+  }).parse(rawInput);
+  const key = compatibilityKey(input.compatibility);
+  await db.ready;
+  return db.transaction(async (trx) => {
+    await sql`SELECT pg_advisory_xact_lock(hashtext(${key}))`.execute(trx.executor);
+    await trx.executor.insertInto('golden_snapshot_rollout_controls').values({
+      compatibility_key: key,
+      enabled: input.enabled,
+      percentage: input.percentage,
+      generation: 1,
+      updated_at: input.now,
+    }).onConflict((oc) => oc.column('compatibility_key').doNothing()).execute();
+    const row = await trx.executor.selectFrom('golden_snapshot_rollout_controls').selectAll()
+      .where('compatibility_key', '=', key).executeTakeFirstOrThrow();
+    return mapRolloutControl(row);
+  });
+}
+
+export async function getGoldenSnapshotRolloutControl(
+  db: PlatformDB,
+  rawCompatibilityKey: string,
+): Promise<GoldenSnapshotRolloutControlRecord | undefined> {
+  const key = Sha256Schema.parse(rawCompatibilityKey);
+  await db.ready;
+  const row = await db.executor.selectFrom('golden_snapshot_rollout_controls').selectAll()
+    .where('compatibility_key', '=', key).executeTakeFirst();
+  return row ? mapRolloutControl(row) : undefined;
+}
+
+export async function updateGoldenSnapshotRolloutControl(
+  db: PlatformDB,
+  rawInput: {
+    compatibilityKey: string;
+    enabled: boolean;
+    percentage: number;
+    now: string;
+  },
+): Promise<GoldenSnapshotRolloutControlRecord> {
+  const input = z.object({
+    compatibilityKey: Sha256Schema,
+    enabled: z.boolean(),
+    percentage: z.number().int().min(0).max(100),
+    now: IsoDateSchema,
+  }).parse(rawInput);
+  await db.ready;
+  return db.transaction(async (trx) => {
+    await sql`SELECT pg_advisory_xact_lock(hashtext(${input.compatibilityKey}))`
+      .execute(trx.executor);
+    const current = await trx.executor.selectFrom('golden_snapshot_rollout_controls').selectAll()
+      .where('compatibility_key', '=', input.compatibilityKey).forUpdate().executeTakeFirst();
+    const row = current
+      ? await trx.executor.updateTable('golden_snapshot_rollout_controls').set({
+          enabled: input.enabled,
+          percentage: input.percentage,
+          generation: sql<number>`generation + 1`,
+          updated_at: input.now,
+        }).where('compatibility_key', '=', input.compatibilityKey).returningAll().executeTakeFirstOrThrow()
+      : await trx.executor.insertInto('golden_snapshot_rollout_controls').values({
+          compatibility_key: input.compatibilityKey,
+          enabled: input.enabled,
+          percentage: input.percentage,
+          generation: 1,
+          updated_at: input.now,
+        }).returningAll().executeTakeFirstOrThrow();
+    await trx.executor.updateTable('golden_snapshot_create_intents').set({
+      state: 'denied', updated_at: input.now,
+    }).where('snapshot_id', 'in', trx.executor.selectFrom('golden_snapshots')
+      .select('snapshot_id').where('compatibility_key', '=', input.compatibilityKey))
+      .where('state', 'in', ['pending', 'accepted'])
+      .where('completed_at', 'is', null).execute();
+    return mapRolloutControl(row);
+  });
+}
+
+export async function createGoldenSnapshotCreateIntent(
+  db: PlatformDB,
+  rawInput: {
+    intentId: string;
+    snapshotId: string;
+    leaseId: string;
+    machineId: string;
+    purpose: 'provision' | 'recover';
+    rolloutGeneration: number;
+    now: string;
+  },
+): Promise<GoldenSnapshotCreateIntentRecord | undefined> {
+  const input = z.object({
+    intentId: UuidSchema, snapshotId: UuidSchema, leaseId: UuidSchema, machineId: UuidSchema,
+    purpose: z.enum(['provision', 'recover']), rolloutGeneration: z.number().int().nonnegative(),
+    now: IsoDateSchema,
+  }).parse(rawInput);
+  await db.ready;
+  return db.transaction(async (trx) => {
+    const identity = await trx.executor.selectFrom('golden_snapshots')
+      .select(['snapshot_id', 'base_generation', 'compatibility_key'])
+      .where('snapshot_id', '=', input.snapshotId)
+      .executeTakeFirst();
+    if (!identity) return undefined;
+    await sql`SELECT pg_advisory_xact_lock(hashtext(${identity.base_generation}))`.execute(trx.executor);
+    await sql`SELECT pg_advisory_xact_lock(hashtext(${identity.compatibility_key}))`.execute(trx.executor);
+    const rollout = await trx.executor.selectFrom('golden_snapshot_rollout_controls').selectAll()
+      .where('compatibility_key', '=', identity.compatibility_key).forUpdate().executeTakeFirst();
+    if (!rollout || !rollout.enabled || Number(rollout.generation) !== input.rolloutGeneration) {
+      return undefined;
+    }
+    const snapshot = await trx.executor.selectFrom('golden_snapshots').selectAll()
+      .where('snapshot_id', '=', input.snapshotId).forUpdate().executeTakeFirst();
+    if (!snapshot || snapshot.state !== 'ready') return undefined;
+    const revoked = await trx.executor.selectFrom('golden_snapshot_revoked_base_generations')
+      .select('base_generation').where('base_generation', '=', snapshot.base_generation).executeTakeFirst();
+    if (revoked) return undefined;
+    const lease = await trx.executor.selectFrom('golden_snapshot_leases').selectAll()
+      .where('lease_id', '=', input.leaseId).forUpdate().executeTakeFirst();
+    if (!lease || lease.released_at !== null || lease.snapshot_id !== input.snapshotId
+      || lease.machine_id !== input.machineId || lease.purpose !== input.purpose) return undefined;
+    await trx.executor.insertInto('golden_snapshot_create_intents').values({
+      intent_id: input.intentId, snapshot_id: input.snapshotId, lease_id: input.leaseId,
+      machine_id: input.machineId, purpose: input.purpose,
+      rollout_generation: input.rolloutGeneration, state: 'pending',
+      provider_create_action_id: null, created_at: input.now, updated_at: input.now, completed_at: null,
+    }).onConflict((oc) => oc.column('lease_id').doNothing()).execute();
+    const row = await trx.executor.selectFrom('golden_snapshot_create_intents').selectAll()
+      .where('lease_id', '=', input.leaseId).executeTakeFirstOrThrow();
+    if (row.snapshot_id !== input.snapshotId || row.machine_id !== input.machineId
+      || row.purpose !== input.purpose || Number(row.rollout_generation) !== input.rolloutGeneration) {
+      throw new Error('Golden snapshot create intent provenance conflict');
+    }
+    return mapCreateIntent(row);
+  });
+}
+
+export async function getGoldenSnapshotCreateIntent(
+  db: PlatformDB,
+  rawLeaseId: string,
+): Promise<GoldenSnapshotCreateIntentRecord | undefined> {
+  const leaseId = UuidSchema.parse(rawLeaseId);
+  await db.ready;
+  const row = await db.executor.selectFrom('golden_snapshot_create_intents').selectAll()
+    .where('lease_id', '=', leaseId).executeTakeFirst();
+  return row ? mapCreateIntent(row) : undefined;
+}
+
+export async function markGoldenSnapshotCreateIntentAccepted(
+  db: PlatformDB,
+  rawLeaseId: string,
+  rawProviderActionId: number | null,
+  rawNow: string,
+): Promise<GoldenSnapshotCreateIntentRecord | undefined> {
+  const leaseId = UuidSchema.parse(rawLeaseId);
+  const providerActionId = rawProviderActionId === null
+    ? null : z.number().int().positive().parse(rawProviderActionId);
+  const now = IsoDateSchema.parse(rawNow);
+  await db.ready;
+  return db.transaction(async (trx) => {
+    const current = await trx.executor.selectFrom('golden_snapshot_create_intents').selectAll()
+      .where('lease_id', '=', leaseId).forUpdate().executeTakeFirst();
+    if (!current || current.state === 'denied') return current ? mapCreateIntent(current) : undefined;
+    if (!['pending', 'accepted'].includes(current.state)) return mapCreateIntent(current);
+    if (providerActionId !== null && current.provider_create_action_id !== null
+      && Number(current.provider_create_action_id) !== providerActionId) {
+      throw new Error('Golden snapshot create intent provider action conflict');
+    }
+    const row = await trx.executor.updateTable('golden_snapshot_create_intents').set({
+      state: 'accepted', provider_create_action_id: providerActionId ?? current.provider_create_action_id,
+      updated_at: now,
+    }).where('intent_id', '=', current.intent_id).returningAll().executeTakeFirstOrThrow();
+    return mapCreateIntent(row);
+  });
+}
+
+export async function markGoldenSnapshotCreateIntentCompleted(
+  db: PlatformDB,
+  rawLeaseId: string,
+  rawState: 'activated' | 'cleaned',
+  rawNow: string,
+): Promise<boolean> {
+  const leaseId = UuidSchema.parse(rawLeaseId);
+  const state = z.enum(['activated', 'cleaned']).parse(rawState);
+  const now = IsoDateSchema.parse(rawNow);
+  await db.ready;
+  const updated = await db.executor.updateTable('golden_snapshot_create_intents').set({
+    state, updated_at: now, completed_at: now,
+  }).where('lease_id', '=', leaseId).where('state', 'in', ['pending', 'accepted'])
+    .returning('intent_id').executeTakeFirst();
+  return updated !== undefined;
+}
+
+export async function releaseGoldenSnapshotLease(db: PlatformDB, rawLeaseId: string, rawNow: string): Promise<boolean> {
+  const leaseId = UuidSchema.parse(rawLeaseId);
+  const now = IsoDateSchema.parse(rawNow);
+  await db.ready;
+  return db.transaction(async (trx) => {
+    const lease = await trx.executor.selectFrom('golden_snapshot_leases')
+      .select(['snapshot_id', 'released_at'])
+      .where('lease_id', '=', leaseId)
+      .forUpdate().executeTakeFirst();
+    if (!lease || lease.released_at !== null) return false;
+    const snapshot = await trx.executor.selectFrom('golden_snapshots').selectAll()
+      .where('snapshot_id', '=', lease.snapshot_id)
+      .forUpdate()
+      .executeTakeFirst();
+    if (!snapshot) return false;
+    const released = await trx.executor.updateTable('golden_snapshot_leases').set({ released_at: now })
+      .where('lease_id', '=', leaseId).where('released_at', 'is', null)
+      .returning('lease_id').executeTakeFirst();
+    if (!released) return false;
+    await retireQuarantinedSnapshotAfterLeaseDrain(trx, snapshot, now);
+    return true;
+  });
+}
+
+async function releaseExpiredGoldenSnapshotLease(
+  db: PlatformDB,
+  rawLeaseId: string,
+  rawNow: string,
+): Promise<boolean> {
+  const leaseId = UuidSchema.parse(rawLeaseId);
+  const now = IsoDateSchema.parse(rawNow);
+  await db.ready;
+  return db.transaction(async (trx) => {
+    const lease = await trx.executor.selectFrom('golden_snapshot_leases')
+      .selectAll().where('lease_id', '=', leaseId).forUpdate().executeTakeFirst();
+    if (!lease || lease.released_at !== null || lease.expires_at > now) return false;
+
+    if (lease.purpose === 'provision') {
+      const job = await trx.executor.selectFrom('provisioning_jobs').select('status')
+        .where('machine_id', '=', lease.machine_id).forUpdate().executeTakeFirst();
+      if (job && !['completed', 'failed'].includes(job.status)) return false;
+    } else {
+      const machine = await trx.executor.selectFrom('user_machines').select('status')
+        .where('machine_id', '=', lease.machine_id).forUpdate().executeTakeFirst();
+      if (machine && !['running', 'failed', 'deleted'].includes(machine.status)) return false;
+    }
+
+    const snapshot = await trx.executor.selectFrom('golden_snapshots').selectAll()
+      .where('snapshot_id', '=', lease.snapshot_id).forUpdate().executeTakeFirst();
+    if (!snapshot) return false;
+    const released = await trx.executor.updateTable('golden_snapshot_leases').set({ released_at: now })
+      .where('lease_id', '=', leaseId).where('released_at', 'is', null)
+      .returning('lease_id').executeTakeFirst();
+    if (!released) return false;
+    await retireQuarantinedSnapshotAfterLeaseDrain(trx, snapshot, now);
+    return true;
+  });
+}
+
+export async function reconcileExpiredGoldenSnapshotLeases(
+  db: PlatformDB,
+  rawNow: string,
+  rawLimit: number,
+): Promise<number> {
+  const now = IsoDateSchema.parse(rawNow);
+  const limit = z.number().int().min(1).max(100).parse(rawLimit);
+  await db.ready;
+  const provisionLeases = await db.executor.selectFrom('golden_snapshot_leases')
+    .leftJoin('provisioning_jobs', 'provisioning_jobs.machine_id', 'golden_snapshot_leases.machine_id')
+    .select('golden_snapshot_leases.lease_id')
+    .where('golden_snapshot_leases.released_at', 'is', null)
+    .where('golden_snapshot_leases.expires_at', '<=', now)
+    .where('golden_snapshot_leases.purpose', '=', 'provision')
+    .where((eb) => eb.or([
+      eb('provisioning_jobs.job_id', 'is', null),
+      eb('provisioning_jobs.status', 'in', ['completed', 'failed']),
+    ]))
+    .orderBy('golden_snapshot_leases.expires_at').orderBy('golden_snapshot_leases.lease_id')
+    .limit(limit).execute();
+  const remaining = limit - provisionLeases.length;
+  const recoveryLeases = remaining === 0 ? [] : await db.executor
+    .selectFrom('golden_snapshot_leases')
+    .leftJoin('user_machines', 'user_machines.machine_id', 'golden_snapshot_leases.machine_id')
+    .select('golden_snapshot_leases.lease_id')
+    .where('golden_snapshot_leases.released_at', 'is', null)
+    .where('golden_snapshot_leases.expires_at', '<=', now)
+    .where('golden_snapshot_leases.purpose', '=', 'recover')
+    .where((eb) => eb.or([
+      eb('user_machines.machine_id', 'is', null),
+      eb('user_machines.status', 'in', ['running', 'failed', 'deleted']),
+    ]))
+    .orderBy('golden_snapshot_leases.expires_at').orderBy('golden_snapshot_leases.lease_id')
+    .limit(remaining).execute();
+  let released = 0;
+  for (const lease of [...provisionLeases, ...recoveryLeases]) {
+    if (await releaseExpiredGoldenSnapshotLease(db, lease.lease_id, now)) released += 1;
+  }
+  return released;
+}
+
+export async function revokeGoldenSnapshot(
+  db: PlatformDB, rawSnapshotId: string, rawFailureCode: string, rawNow: string,
+): Promise<boolean> {
+  const snapshotId = UuidSchema.parse(rawSnapshotId);
+  const failureCode = BoundedCodeSchema.parse(rawFailureCode);
+  const now = IsoDateSchema.parse(rawNow);
+  await db.ready;
+  return db.transaction(async (trx) => {
+    const snapshotIdentity = await trx.executor.selectFrom('golden_snapshots')
+      .select(['snapshot_id', 'base_generation']).where('snapshot_id', '=', snapshotId)
+      .executeTakeFirst();
+    if (!snapshotIdentity) return false;
+    await sql`SELECT pg_advisory_xact_lock(hashtext(${snapshotIdentity.base_generation}))`
+      .execute(trx.executor);
+    const buildIdentity = await trx.executor.selectFrom('golden_snapshot_builds').select('build_id')
+      .where('snapshot_id', '=', snapshotId).executeTakeFirst();
+    const build = buildIdentity
+      ? await trx.executor.selectFrom('golden_snapshot_builds').selectAll()
+        .where('build_id', '=', buildIdentity.build_id).forUpdate().executeTakeFirst()
+      : undefined;
+    const snapshot = await trx.executor.selectFrom('golden_snapshots').selectAll()
+      .where('snapshot_id', '=', snapshotId).forUpdate().executeTakeFirst();
+    if (!snapshot || !['candidate', 'building', 'sanitizing', 'validating', 'ready', 'failed'].includes(snapshot.state)) {
+      return false;
+    }
+    // Do not infer provider completion from time alone: only an explicit release
+    // after durable workflow/provider reconciliation permits image cleanup.
+    const unreleasedLease = await trx.executor.selectFrom('golden_snapshot_leases').select('lease_id')
+      .where('snapshot_id', '=', snapshotId).where('released_at', 'is', null)
+      .executeTakeFirst();
+    await trx.executor.updateTable('golden_snapshots').set({
+      state: 'quarantined', failure_code: failureCode, quarantined_at: now, updated_at: now,
+      revision: sql<number>`revision + 1`,
+    }).where('snapshot_id', '=', snapshotId).where('revision', '=', snapshot.revision).executeTakeFirstOrThrow();
+    await trx.executor.updateTable('golden_snapshot_create_intents').set({
+      state: 'denied', updated_at: now,
+    }).where('snapshot_id', '=', snapshotId).where('state', 'in', ['pending', 'accepted'])
+      .where('completed_at', 'is', null).execute();
+    await appendGoldenSnapshotAuditEvent(trx, {
+      snapshotId, buildId: build?.build_id, eventType: 'snapshot_revoked', actorType: 'operator',
+      fromState: snapshot.state, toState: 'quarantined', reason: failureCode, now,
+    });
+    if (build && (build.status === 'queued' || build.status === 'running')) {
+      await trx.executor.updateTable('golden_snapshot_builds').set({
+        phase: 'failed', status: 'failed', last_error_code: failureCode,
+        lease_expires_at: null, callback_phase: null, callback_token_hash: null,
+        callback_expires_at: build.pending_operation === null ? null : build.callback_expires_at,
+        completed_at: now, updated_at: now,
+      }).where('build_id', '=', build.build_id).where('status', 'in', ['queued', 'running']).execute();
+    }
+    const resources = [
+      build?.provider_builder_id === null || build?.provider_builder_id === undefined ? undefined : {
+        type: 'builder_server' as const, id: build.provider_builder_id,
+      },
+      build?.provider_validation_id === null || build?.provider_validation_id === undefined ? undefined : {
+        type: 'validation_server' as const, id: build.provider_validation_id,
+      },
+      snapshot.provider_image_id === null || unreleasedLease ? undefined : {
+        type: 'snapshot_image' as const, id: snapshot.provider_image_id,
+      },
+    ].filter((resource): resource is {
+      type: 'builder_server' | 'validation_server' | 'snapshot_image'; id: number;
+    } => resource !== undefined);
+    for (const resource of resources) {
+      await trx.executor.insertInto('golden_snapshot_cleanup').values({
+        cleanup_id: randomUUID(), snapshot_id: snapshotId, build_id: build?.build_id ?? null,
+        resource_type: resource.type, provider_resource_id: resource.id,
+        provenance_key: `revoke:${snapshotId}:${resource.type}`, reason: failureCode,
+        status: 'queued', attempts: 0, next_attempt_at: now, lease_expires_at: null,
+        last_error_code: null, created_at: now, completed_at: null,
+      }).onConflict((oc) => oc.columns(['resource_type', 'provider_resource_id'])
+        .where('completed_at', 'is', null).doNothing()).execute();
+    }
+    return true;
+  });
+}
+
+export async function revokeGoldenSnapshotBaseGeneration(
+  db: PlatformDB,
+  rawBaseGeneration: string,
+  rawFailureCode: string,
+  rawNow: string,
+): Promise<boolean> {
+  const baseGeneration = GoldenSnapshotBaseGenerationSchema.parse(rawBaseGeneration);
+  const failureCode = BoundedCodeSchema.parse(rawFailureCode);
+  const now = IsoDateSchema.parse(rawNow);
+  await db.ready;
+  return db.transaction(async (trx) => {
+    await sql`SELECT pg_advisory_xact_lock(hashtext(${baseGeneration}))`.execute(trx.executor);
+    const inserted = await trx.executor.insertInto('golden_snapshot_revoked_base_generations').values({
+      base_generation: baseGeneration,
+      reason: failureCode,
+      revoked_at: now,
+      updated_at: now,
+    }).onConflict((oc) => oc.column('base_generation').doNothing()).returning('base_generation').executeTakeFirst();
+    await trx.executor.updateTable('golden_snapshot_create_intents').set({
+      state: 'denied', updated_at: now,
+    }).where('snapshot_id', 'in', trx.executor.selectFrom('golden_snapshots')
+      .select('snapshot_id').where('base_generation', '=', baseGeneration))
+      .where('state', 'in', ['pending', 'accepted']).where('completed_at', 'is', null).execute();
+    if (inserted) {
+      await appendGoldenSnapshotAuditEvent(trx, {
+        eventType: 'base_generation_revoked', actorType: 'operator', reason: failureCode, now,
+      });
+    }
+    return inserted !== undefined;
+  });
+}
+
+export async function reconcileRevokedGoldenSnapshotBaseGeneration(
+  db: PlatformDB,
+  rawBaseGeneration: string,
+  rawNow: string,
+  rawLimit = 100,
+): Promise<{ processed: number; hasMore: boolean }> {
+  const baseGeneration = GoldenSnapshotBaseGenerationSchema.parse(rawBaseGeneration);
+  const now = IsoDateSchema.parse(rawNow);
+  const limit = z.number().int().min(1).max(100).parse(rawLimit);
+  await db.ready;
+  return db.transaction(async (trx) => {
+    const marker = await trx.executor.selectFrom('golden_snapshot_revoked_base_generations').selectAll()
+      .where('base_generation', '=', baseGeneration).executeTakeFirst();
+    if (!marker) return { processed: 0, hasMore: false };
+    const candidates = await trx.executor.selectFrom('golden_snapshots').select('snapshot_id')
+      .where('base_generation', '=', baseGeneration)
+      .where('state', 'in', ['candidate', 'building', 'sanitizing', 'validating', 'ready', 'failed'])
+      .orderBy('snapshot_id').limit(limit + 1).execute();
+    const hasMore = candidates.length > limit;
+    const snapshotIds = candidates.slice(0, limit).map((snapshot) => snapshot.snapshot_id);
+    if (snapshotIds.length === 0) return { processed: 0, hasMore: false };
+    const builds = await trx.executor.selectFrom('golden_snapshot_builds').selectAll()
+      .where('snapshot_id', 'in', snapshotIds).orderBy('build_id').forUpdate().execute();
+    const snapshots = await trx.executor.selectFrom('golden_snapshots').selectAll()
+      .where('snapshot_id', 'in', snapshotIds)
+      .where('state', 'in', ['candidate', 'building', 'sanitizing', 'validating', 'ready', 'failed'])
+      .orderBy('snapshot_id').forUpdate().execute();
+    if (snapshots.length === 0) return { processed: 0, hasMore };
+    // Expired rows stay in this set until reconciliation proves the associated
+    // provisioning/recovery workflow terminal and writes released_at.
+    const snapshotsWithUnreleasedLeases = new Set((await trx.executor.selectFrom('golden_snapshot_leases')
+      .select('snapshot_id').where('snapshot_id', 'in', snapshotIds)
+      .where('released_at', 'is', null).execute()).map((lease) => lease.snapshot_id));
+    await trx.executor.updateTable('golden_snapshots').set({
+      state: 'quarantined', failure_code: marker.reason, quarantined_at: now, updated_at: now,
+      revision: sql<number>`revision + 1`,
+    }).where('snapshot_id', 'in', snapshotIds)
+      .where('state', 'in', ['candidate', 'building', 'sanitizing', 'validating', 'ready', 'failed']).execute();
+    await trx.executor.updateTable('golden_snapshot_builds').set({
+      phase: 'failed', status: 'failed', last_error_code: marker.reason,
+      lease_expires_at: null, callback_phase: null, callback_token_hash: null,
+      callback_expires_at: sql<string | null>`CASE
+        WHEN pending_operation IS NULL THEN NULL
+        ELSE callback_expires_at
+      END`,
+      completed_at: now, updated_at: now,
+    }).where('snapshot_id', 'in', snapshotIds).where('status', 'in', ['queued', 'running']).execute();
+    const buildBySnapshot = new Map(builds.map((build) => [build.snapshot_id, build]));
+    for (const snapshot of snapshots) {
+      const build = buildBySnapshot.get(snapshot.snapshot_id);
+      await appendGoldenSnapshotAuditEvent(trx, {
+        snapshotId: snapshot.snapshot_id, buildId: build?.build_id,
+        eventType: 'snapshot_revoked', actorType: 'worker', fromState: snapshot.state,
+        toState: 'quarantined', reason: marker.reason, now,
+      });
+      const resources = [
+        build?.provider_builder_id === null || build?.provider_builder_id === undefined ? undefined : {
+          type: 'builder_server' as const, id: build.provider_builder_id,
+        },
+        build?.provider_validation_id === null || build?.provider_validation_id === undefined ? undefined : {
+          type: 'validation_server' as const, id: build.provider_validation_id,
+        },
+        snapshot.provider_image_id === null || snapshotsWithUnreleasedLeases.has(snapshot.snapshot_id) ? undefined : {
+          type: 'snapshot_image' as const, id: snapshot.provider_image_id,
+        },
+      ].filter((resource): resource is {
+        type: 'builder_server' | 'validation_server' | 'snapshot_image'; id: number;
+      } => resource !== undefined);
+      for (const resource of resources) {
+        await trx.executor.insertInto('golden_snapshot_cleanup').values({
+          cleanup_id: randomUUID(), snapshot_id: snapshot.snapshot_id, build_id: build?.build_id ?? null,
+          resource_type: resource.type, provider_resource_id: resource.id,
+          provenance_key: `revoke:${snapshot.snapshot_id}:${resource.type}`, reason: marker.reason,
+          status: 'queued', attempts: 0, next_attempt_at: now, lease_expires_at: null,
+          last_error_code: null, created_at: now, completed_at: null,
+        }).onConflict((oc) => oc.columns(['resource_type', 'provider_resource_id'])
+          .where('completed_at', 'is', null).doNothing()).execute();
+      }
+    }
+    return { processed: snapshots.length, hasMore };
+  });
+}
+
+export async function retireGoldenSnapshot(
+  db: PlatformDB,
+  rawSnapshotId: string,
+  rawReason: string,
+  rawNow: string,
+  rawRollbackVersionsPerChannel = 2,
+  rawFreshnessMaxAgeMs?: number,
+): Promise<boolean> {
+  const snapshotId = UuidSchema.parse(rawSnapshotId);
+  const reason = BoundedCodeSchema.parse(rawReason);
+  const now = IsoDateSchema.parse(rawNow);
+  const rollbackVersionsPerChannel = z.number().int().min(0).max(20).parse(rawRollbackVersionsPerChannel);
+  const freshnessMaxAgeMs = rawFreshnessMaxAgeMs === undefined
+    ? undefined
+    : z.number().int().min(60_000).max(365 * 24 * 60 * 60 * 1000).parse(rawFreshnessMaxAgeMs);
+  await db.ready;
+  return db.transaction(async (trx) => {
+    const retirementTarget = await trx.executor.selectFrom('golden_snapshots').selectAll()
+      .where('snapshot_id', '=', snapshotId).executeTakeFirst();
+    if (!retirementTarget || !['ready', 'failed', 'quarantined'].includes(retirementTarget.state)) return false;
+    const compatibilityRows = retirementTarget.state === 'ready'
+      ? await trx.executor.selectFrom('golden_snapshots').selectAll()
+        .where('compatibility_key', '=', retirementTarget.compatibility_key)
+        .where('test_mode', '=', retirementTarget.test_mode)
+        .where('state', '=', 'ready')
+        .orderBy('snapshot_id').forUpdate().execute()
+      : [await trx.executor.selectFrom('golden_snapshots').selectAll()
+        .where('snapshot_id', '=', snapshotId).forUpdate().executeTakeFirst()];
+    const snapshotRow = compatibilityRows.find((row) => row?.snapshot_id === snapshotId);
+    if (!snapshotRow || !['ready', 'failed', 'quarantined'].includes(snapshotRow.state)) return false;
+    const freshnessExpired = snapshotRow.state === 'ready'
+      && freshnessMaxAgeMs !== undefined
+      && snapshotRow.ready_at !== null
+      && new Date(snapshotRow.ready_at).getTime() <= new Date(now).getTime() - freshnessMaxAgeMs;
+    const release = await trx.executor.selectFrom('host_bundle_releases').select('version')
+      .where('version', '=', snapshotRow.bundle_version).forUpdate().executeTakeFirst();
+    if (!release) return false;
+    // Expiry makes a lease eligible for reconciliation; it does not prove that
+    // the provider clone is terminal. Every unreleased lease therefore remains
+    // a deletion barrier until the workflow/reconciler releases it durably.
+    const unreleasedLease = await trx.executor.selectFrom('golden_snapshot_leases').select('lease_id')
+      .where('snapshot_id', '=', snapshotId).where('released_at', 'is', null)
+      .executeTakeFirst();
+    if (unreleasedLease) return false;
+    // Channel promotion to this bundle locks the same immutable release row
+    // before changing either channel table. Holding that row lock makes these
+    // current/rollback guard reads atomic with every promotion to this version;
+    // row-locking only existing channel rows would not protect an absent row.
+    const currentChannel = await trx.executor.selectFrom('host_bundle_channels').select('channel')
+      .where('version', '=', snapshotRow.bundle_version).executeTakeFirst();
+    let rollbackProtected = false;
+    if (snapshotRow.state === 'ready' && rollbackVersionsPerChannel > 0) {
+      const rollbackReference = await sql<{ channel: string }>`
+        SELECT channel
+        FROM (
+          SELECT channel, version,
+            ROW_NUMBER() OVER (PARTITION BY channel ORDER BY promoted_at DESC, version DESC) AS rollback_rank
+          FROM host_bundle_release_channels
+        ) AS ranked_release_channels
+        WHERE version = ${snapshotRow.bundle_version}
+          AND rollback_rank <= ${rollbackVersionsPerChannel}
+        LIMIT 1
+      `.execute(trx.executor);
+      rollbackProtected = rollbackReference.rows.length > 0;
+    }
+    if (snapshotRow.state === 'ready' && (currentChannel || rollbackProtected)) {
+      if (!freshnessExpired) return false;
+      const readyReplacement = compatibilityRows.find((row) => row
+        && row.snapshot_id !== snapshotId
+        && row.bundle_sha256 === snapshotRow.bundle_sha256
+        && row.ready_at !== null
+        && snapshotRow.ready_at !== null
+        && row.ready_at > snapshotRow.ready_at);
+      if (!readyReplacement) return false;
+    }
+    if (snapshotRow.state === 'ready' && !freshnessExpired) {
+      const otherReady = compatibilityRows.find((row) => row?.snapshot_id !== snapshotId);
+      if (!otherReady) return false;
+    }
+    if (snapshotRow.provider_image_id !== null) {
+      await trx.executor.insertInto('golden_snapshot_cleanup').values({
+        cleanup_id: randomUUID(), snapshot_id: snapshotId, build_id: null,
+        resource_type: 'snapshot_image', provider_resource_id: snapshotRow.provider_image_id,
+        provenance_key: `snapshot:${snapshotId}`, reason, status: 'queued', attempts: 0,
+        next_attempt_at: now, lease_expires_at: null, last_error_code: null,
+        created_at: now, completed_at: null,
+      }).onConflict((oc) => oc.columns(['resource_type', 'provider_resource_id'])
+        .where('completed_at', 'is', null).doNothing()).execute();
+    }
+    const updated = await trx.executor.updateTable('golden_snapshots').set({
+      state: 'retiring', retiring_at: now, updated_at: now, revision: sql<number>`revision + 1`,
+    }).where('snapshot_id', '=', snapshotId).where('revision', '=', snapshotRow.revision)
+      .returning('snapshot_id').executeTakeFirst();
+    if (updated) {
+      await appendGoldenSnapshotAuditEvent(trx, {
+        snapshotId, eventType: 'snapshot_retiring', actorType: 'operator',
+        fromState: snapshotRow.state, toState: 'retiring', reason, now,
+      });
+    }
+    return updated !== undefined;
+  });
+}
+
+export async function listPendingGoldenSnapshotCleanup(
+  db: PlatformDB, rawNow: string, rawLimit: number,
+): Promise<GoldenSnapshotCleanupRecord[]> {
+  const now = IsoDateSchema.parse(rawNow);
+  const limit = z.number().int().min(1).max(100).parse(rawLimit);
+  await db.ready;
+  const rows = await db.executor.selectFrom('golden_snapshot_cleanup').selectAll()
+    .where('completed_at', 'is', null).where('next_attempt_at', '<=', now)
+    .where((eb) => eb.or([eb('status', '=', 'queued'), eb.and([
+      eb('status', '=', 'running'), eb('lease_expires_at', '<=', now),
+    ])])).orderBy('created_at').limit(limit).execute();
+  return rows.map(mapCleanup);
+}
+
+export async function retryGoldenSnapshotCleanup(
+  db: PlatformDB,
+  rawCleanupId: string,
+  rawNow: string,
+): Promise<boolean> {
+  const cleanupId = UuidSchema.parse(rawCleanupId);
+  const now = IsoDateSchema.parse(rawNow);
+  await db.ready;
+  return db.transaction(async (trx) => {
+    const row = await trx.executor.updateTable('golden_snapshot_cleanup').set({
+      status: 'queued', attempts: 0, next_attempt_at: now,
+      lease_expires_at: null, last_error_code: null,
+    }).where('cleanup_id', '=', cleanupId)
+      .where('completed_at', 'is', null)
+      .where('status', 'in', ['failed', 'quarantined'])
+      .returning(['cleanup_id', 'snapshot_id', 'build_id'])
+      .executeTakeFirst();
+    if (!row) return false;
+    await appendGoldenSnapshotAuditEvent(trx, {
+      snapshotId: row.snapshot_id, buildId: row.build_id, cleanupId: row.cleanup_id,
+      eventType: 'cleanup_retried', actorType: 'operator', now,
+    });
+    return true;
+  });
+}
+
+export async function pruneGoldenSnapshotAuditEvents(
+  db: PlatformDB,
+  rawBefore: string,
+  rawLimit: number,
+): Promise<number> {
+  const before = IsoDateSchema.parse(rawBefore);
+  const limit = z.number().int().min(1).max(100).parse(rawLimit);
+  await db.ready;
+  return db.transaction(async (trx) => {
+    const rows = await trx.executor.selectFrom('golden_snapshot_audit_events')
+      .select('event_id').where('created_at', '<', before)
+      .orderBy('created_at').orderBy('event_id').forUpdate().skipLocked().limit(limit).execute();
+    if (rows.length === 0) return 0;
+    const deleted = await trx.executor.deleteFrom('golden_snapshot_audit_events')
+      .where('event_id', 'in', rows.map((row) => row.event_id)).returning('event_id').execute();
+    return deleted.length;
+  });
+}

--- a/packages/platform/src/golden-snapshot-schema.ts
+++ b/packages/platform/src/golden-snapshot-schema.ts
@@ -1,0 +1,114 @@
+import { createHash } from 'node:crypto';
+import { z } from 'zod/v4';
+
+const SAFE_COMPATIBILITY_VALUE = /^[a-z0-9][a-z0-9._-]{0,63}$/;
+
+export const GoldenSnapshotBaseGenerationSchema = z.string()
+  .min(1)
+  .max(64)
+  .regex(SAFE_COMPATIBILITY_VALUE);
+
+export const GoldenSnapshotStateSchema = z.enum([
+  'candidate',
+  'building',
+  'sanitizing',
+  'validating',
+  'ready',
+  'failed',
+  'quarantined',
+  'retiring',
+  'deleted',
+]);
+
+export type GoldenSnapshotState = z.infer<typeof GoldenSnapshotStateSchema>;
+
+export const GoldenSnapshotBuildStatusSchema = z.enum(['queued', 'running', 'completed', 'failed']);
+export const GoldenSnapshotBuildPhaseSchema = z.enum([
+  'requested',
+  'builder_create',
+  'builder_boot',
+  'sanitizing',
+  'snapshot_create',
+  'snapshot_wait',
+  'validation_create',
+  'validation_boot',
+  'cleanup',
+  'completed',
+  'failed',
+  'reconciling',
+]);
+
+export const GoldenSnapshotCompatibilitySchema = z.object({
+  provider: z.literal('hetzner'),
+  architecture: z.enum(['x86', 'arm']),
+  region: z.string().min(1).max(64).regex(SAFE_COMPATIBILITY_VALUE),
+  baseImage: z.string().min(1).max(64).regex(SAFE_COMPATIBILITY_VALUE),
+  baseGeneration: GoldenSnapshotBaseGenerationSchema,
+  bootMode: z.enum(['bios', 'uefi']),
+  activationAbi: z.string().min(1).max(64).regex(SAFE_COMPATIBILITY_VALUE),
+  minimumDiskGb: z.number().int().min(1).max(2_048),
+}).strict();
+
+export type GoldenSnapshotCompatibility = z.infer<typeof GoldenSnapshotCompatibilitySchema>;
+
+export const DEFAULT_GOLDEN_SNAPSHOT_FRESHNESS_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000;
+
+export const GoldenSnapshotRuntimeConfigSchema = z.object({
+  enabled: z.boolean(),
+  buildsEnabled: z.boolean(),
+  rolloutPercent: z.number().int().min(0).max(100),
+  compatibility: GoldenSnapshotCompatibilitySchema,
+  maxBuildAttempts: z.number().int().min(1).max(10),
+  maxConcurrentBuilds: z.number().int().min(1).max(10),
+  buildLeaseMs: z.number().int().min(60_000).max(30 * 60 * 1000),
+  provisioningLeaseMs: z.number().int().min(60_000).max(30 * 60 * 1000),
+  retentionLimit: z.number().int().min(1).max(29),
+  freshnessMaxAgeMs: z.number().int().min(60_000).max(365 * 24 * 60 * 60 * 1000),
+  testModeTtlMs: z.number().int().min(60_000).max(30 * 24 * 60 * 60 * 1000),
+  auditRetentionMs: z.number().int().min(24 * 60 * 60 * 1000).max(365 * 24 * 60 * 60 * 1000),
+  reconciliationBatchSize: z.number().int().min(1).max(100),
+}).strict();
+
+export type GoldenSnapshotRuntimeConfig = z.infer<typeof GoldenSnapshotRuntimeConfigSchema>;
+
+export const GoldenSnapshotValidationSummarySchema = z.object({
+  exactBundle: z.literal(true),
+  healthy: z.literal(true),
+  freshActivation: z.literal(true),
+  uniqueMachineId: z.literal(true),
+  uniqueSshHostKey: z.literal(true),
+  forbiddenStateAbsent: z.literal(true),
+}).strict();
+
+export type GoldenSnapshotValidationSummary = z.infer<typeof GoldenSnapshotValidationSummarySchema>;
+
+const ALLOWED_TRANSITIONS: Record<GoldenSnapshotState, readonly GoldenSnapshotState[]> = {
+  candidate: ['building', 'failed', 'quarantined', 'retiring'],
+  building: ['sanitizing', 'failed', 'quarantined', 'retiring'],
+  sanitizing: ['validating', 'failed', 'quarantined', 'retiring'],
+  validating: ['ready', 'failed', 'quarantined', 'retiring'],
+  ready: ['quarantined', 'retiring'],
+  failed: ['quarantined', 'retiring'],
+  quarantined: ['retiring'],
+  retiring: ['deleted'],
+  deleted: [],
+};
+
+export function canTransitionGoldenSnapshot(from: GoldenSnapshotState, to: GoldenSnapshotState): boolean {
+  return ALLOWED_TRANSITIONS[from].includes(to);
+}
+
+export function compatibilityKey(input: GoldenSnapshotCompatibility): string {
+  const parsed = GoldenSnapshotCompatibilitySchema.parse(input);
+  const normalized = [
+    parsed.provider,
+    parsed.architecture,
+    parsed.region,
+    parsed.baseImage,
+    parsed.baseGeneration,
+    parsed.bootMode,
+    parsed.activationAbi,
+    String(parsed.minimumDiskGb),
+  ].join('\n');
+  return createHash('sha256').update(normalized).digest('hex');
+}

--- a/packages/platform/src/golden-snapshot-selection.ts
+++ b/packages/platform/src/golden-snapshot-selection.ts
@@ -1,0 +1,58 @@
+import type { GoldenSnapshotState } from './golden-snapshot-schema.js';
+
+export interface GoldenSnapshotSelectionTarget {
+  targetBundleSha256: string;
+  targetReleaseBuildTime: string;
+  compatibilityKey: string;
+  serverDiskGb: number;
+  activationAbi: string;
+}
+
+export interface GoldenSnapshotSelectionCandidate {
+  snapshotId: string;
+  bundleVersion: string;
+  bundleSha256: string;
+  compatibilityKey: string;
+  sourceReleaseBuildTime: string;
+  state: GoldenSnapshotState;
+  minimumDiskGb: number;
+  imageDiskGb: number | null;
+  activationAbi: string;
+  readyAt: string;
+  revoked?: boolean;
+}
+
+function isCompatible(
+  target: GoldenSnapshotSelectionTarget,
+  candidate: GoldenSnapshotSelectionCandidate,
+): boolean {
+  const requiredDiskGb = Math.max(candidate.minimumDiskGb, candidate.imageDiskGb ?? 0);
+  return candidate.state === 'ready'
+    && candidate.revoked !== true
+    && candidate.compatibilityKey === target.compatibilityKey
+    && candidate.activationAbi === target.activationAbi
+    && requiredDiskGb <= target.serverDiskGb;
+}
+
+export function chooseGoldenSnapshot(
+  target: GoldenSnapshotSelectionTarget,
+  candidates: readonly GoldenSnapshotSelectionCandidate[],
+): GoldenSnapshotSelectionCandidate | undefined {
+  const eligible = candidates.filter((candidate) => isCompatible(target, candidate));
+  const exact = eligible
+    .filter((candidate) => candidate.bundleSha256 === target.targetBundleSha256)
+    .toSorted((left, right) => right.readyAt.localeCompare(left.readyAt));
+  if (exact[0]) return exact[0];
+
+  const targetBuildTime = Date.parse(target.targetReleaseBuildTime);
+  if (!Number.isFinite(targetBuildTime)) return undefined;
+  return eligible
+    .map((candidate) => ({ candidate, buildTime: Date.parse(candidate.sourceReleaseBuildTime) }))
+    .filter(({ buildTime }) => Number.isFinite(buildTime) && buildTime < targetBuildTime)
+    .toSorted((left, right) => {
+      const releaseOrder = right.buildTime - left.buildTime;
+      return releaseOrder !== 0
+        ? releaseOrder
+        : right.candidate.readyAt.localeCompare(left.candidate.readyAt);
+    })[0]?.candidate;
+}

--- a/tests/platform/customer-vps.test.ts
+++ b/tests/platform/customer-vps.test.ts
@@ -134,6 +134,70 @@ describe('platform/customer-vps', () => {
     expect(loadCustomerVpsConfig({ CUSTOMER_VPS_PREVIEW_PROVISIONING_LIMIT: '2.5' }).previewProvisioningLimit).toBe(8);
   });
 
+  it('keeps golden snapshots disabled by default and bounds every control-plane budget', () => {
+    expect(loadCustomerVpsConfig({}).goldenSnapshots).toMatchObject({
+      enabled: false,
+      buildsEnabled: false,
+      rolloutPercent: 0,
+      maxBuildAttempts: 5,
+      maxConcurrentBuilds: 2,
+      retentionLimit: 20,
+      freshnessMaxAgeMs: 7 * 24 * 60 * 60 * 1000,
+      testModeTtlMs: 24 * 60 * 60 * 1000,
+      auditRetentionMs: 90 * 24 * 60 * 60 * 1000,
+    });
+
+    expect(loadCustomerVpsConfig({
+      GOLDEN_SNAPSHOTS_ENABLED: 'true',
+      GOLDEN_SNAPSHOT_BUILDS_ENABLED: 'true',
+      GOLDEN_SNAPSHOT_ROLLOUT_PERCENT: '25',
+      GOLDEN_SNAPSHOT_MAX_BUILD_ATTEMPTS: '3',
+      GOLDEN_SNAPSHOT_MAX_CONCURRENT_BUILDS: '4',
+      GOLDEN_SNAPSHOT_RETENTION_LIMIT: '12',
+      GOLDEN_SNAPSHOT_FRESHNESS_MAX_AGE_MS: '120000',
+      GOLDEN_SNAPSHOT_TEST_MODE_TTL_MS: '180000',
+      GOLDEN_SNAPSHOT_AUDIT_RETENTION_MS: '86400000',
+      GOLDEN_SNAPSHOT_ARCHITECTURE: 'x86',
+      GOLDEN_SNAPSHOT_REGION: 'eu-central',
+    }).goldenSnapshots).toMatchObject({
+      enabled: true,
+      buildsEnabled: true,
+      rolloutPercent: 25,
+      maxBuildAttempts: 3,
+      maxConcurrentBuilds: 4,
+      retentionLimit: 12,
+      freshnessMaxAgeMs: 120000,
+      testModeTtlMs: 180000,
+      auditRetentionMs: 86400000,
+      compatibility: expect.objectContaining({ architecture: 'x86', region: 'eu-central' }),
+    });
+
+    expect(loadCustomerVpsConfig({
+      GOLDEN_SNAPSHOT_ROLLOUT_PERCENT: '101',
+      GOLDEN_SNAPSHOT_MAX_BUILD_ATTEMPTS: '0',
+      GOLDEN_SNAPSHOT_MAX_CONCURRENT_BUILDS: '11',
+      GOLDEN_SNAPSHOT_RETENTION_LIMIT: '31',
+      GOLDEN_SNAPSHOT_FRESHNESS_MAX_AGE_MS: '999',
+      GOLDEN_SNAPSHOT_TEST_MODE_TTL_MS: '999',
+      GOLDEN_SNAPSHOT_AUDIT_RETENTION_MS: '999',
+      GOLDEN_SNAPSHOT_BUILD_LEASE_MS: '999',
+    }).goldenSnapshots).toMatchObject({
+      rolloutPercent: 0,
+      maxBuildAttempts: 5,
+      maxConcurrentBuilds: 2,
+      retentionLimit: 20,
+      freshnessMaxAgeMs: 7 * 24 * 60 * 60 * 1000,
+      testModeTtlMs: 24 * 60 * 60 * 1000,
+      auditRetentionMs: 90 * 24 * 60 * 60 * 1000,
+      buildLeaseMs: 5 * 60 * 1000,
+    });
+
+    expect(loadCustomerVpsConfig({
+      GOLDEN_SNAPSHOT_BASE_IMAGE: '',
+      HETZNER_IMAGE: 'ubuntu-24.04',
+    }).goldenSnapshots.compatibility.baseImage).toBe('ubuntu-24.04');
+  });
+
   it('classifies only server-marked dedicated and legacy preview runtime slots as previews', () => {
     expect(isPreviewMachine({ handle: 'pr-897', runtimeSlot: 'pr-897', provisioningClass: 'preview' })).toBe(true);
     expect(isPreviewMachine({ handle: 'pr-703', runtimeSlot: 'preview', provisioningClass: 'preview' })).toBe(true);

--- a/tests/platform/golden-snapshot-schema.test.ts
+++ b/tests/platform/golden-snapshot-schema.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest';
+import {
+  GoldenSnapshotCompatibilitySchema,
+  GoldenSnapshotRuntimeConfigSchema,
+  GoldenSnapshotStateSchema,
+  canTransitionGoldenSnapshot,
+  compatibilityKey,
+} from '../../packages/platform/src/golden-snapshot-schema.js';
+
+describe('golden snapshot schema', () => {
+  const compatibility = {
+    provider: 'hetzner' as const,
+    architecture: 'x86' as const,
+    region: 'eu-central',
+    baseImage: 'ubuntu-24.04',
+    baseGeneration: 'ubuntu-24.04-v1',
+    bootMode: 'bios' as const,
+    activationAbi: 'host-v1',
+    minimumDiskGb: 40,
+  };
+
+  it('normalizes a bounded compatibility class into a stable identity', () => {
+    const parsed = GoldenSnapshotCompatibilitySchema.parse(compatibility);
+    expect(compatibilityKey(parsed)).toMatch(/^[a-f0-9]{64}$/);
+    expect(compatibilityKey(parsed)).toBe(compatibilityKey({ ...parsed }));
+  });
+
+  it('rejects unbounded or unsafe compatibility values', () => {
+    expect(GoldenSnapshotCompatibilitySchema.safeParse({ ...compatibility, region: '../nbg1' }).success).toBe(false);
+    expect(GoldenSnapshotCompatibilitySchema.safeParse({ ...compatibility, minimumDiskGb: 0 }).success).toBe(false);
+    expect(GoldenSnapshotCompatibilitySchema.safeParse({ ...compatibility, minimumDiskGb: 10_000 }).success).toBe(false);
+    expect(GoldenSnapshotCompatibilitySchema.safeParse({ ...compatibility, provider: 'arbitrary' }).success).toBe(false);
+  });
+
+  it('allows only explicit fail-closed lifecycle transitions', () => {
+    expect(GoldenSnapshotStateSchema.options).toEqual([
+      'candidate',
+      'building',
+      'sanitizing',
+      'validating',
+      'ready',
+      'failed',
+      'quarantined',
+      'retiring',
+      'deleted',
+    ]);
+    expect(canTransitionGoldenSnapshot('candidate', 'building')).toBe(true);
+    expect(canTransitionGoldenSnapshot('validating', 'ready')).toBe(true);
+    expect(canTransitionGoldenSnapshot('ready', 'quarantined')).toBe(true);
+    expect(canTransitionGoldenSnapshot('ready', 'deleted')).toBe(false);
+    expect(canTransitionGoldenSnapshot('quarantined', 'ready')).toBe(false);
+    expect(canTransitionGoldenSnapshot('failed', 'building')).toBe(false);
+    expect(canTransitionGoldenSnapshot('deleted', 'candidate')).toBe(false);
+  });
+
+  it('bounds concurrent snapshot infrastructure', () => {
+    const base = {
+      enabled: false,
+      buildsEnabled: false,
+      rolloutPercent: 0,
+      compatibility,
+      maxBuildAttempts: 5,
+      maxConcurrentBuilds: 2,
+      buildLeaseMs: 60_000,
+      provisioningLeaseMs: 60_000,
+      retentionLimit: 20,
+      freshnessMaxAgeMs: 7 * 24 * 60 * 60 * 1000,
+      testModeTtlMs: 24 * 60 * 60 * 1000,
+      auditRetentionMs: 90 * 24 * 60 * 60 * 1000,
+      reconciliationBatchSize: 25,
+    };
+    expect(GoldenSnapshotRuntimeConfigSchema.parse(base).maxConcurrentBuilds).toBe(2);
+    expect(GoldenSnapshotRuntimeConfigSchema.safeParse({ ...base, maxConcurrentBuilds: 0 }).success).toBe(false);
+    expect(GoldenSnapshotRuntimeConfigSchema.safeParse({ ...base, maxConcurrentBuilds: 11 }).success).toBe(false);
+    expect(GoldenSnapshotRuntimeConfigSchema.safeParse({ ...base, retentionLimit: 0 }).success).toBe(false);
+    expect(GoldenSnapshotRuntimeConfigSchema.safeParse({ ...base, freshnessMaxAgeMs: 0 }).success).toBe(false);
+    expect(GoldenSnapshotRuntimeConfigSchema.safeParse({ ...base, testModeTtlMs: 0 }).success).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

- add the canonical Kysely/Postgres schema, bounded config, repositories, and pure exact/compatible-older selector
- keep provider I/O and customer provisioning out of this foundation layer

## Tests

- [x] Golden snapshot schema/config tests: 5 passed
- [x] Platform TypeScript project check
- [x] PR size: 7 files, 2,630 additions

## Invariants

### Source of truth

Platform Postgres is authoritative for immutable bundle provenance, snapshot/build lifecycle, rollout controls, leases, cleanup, audit events, and revocation markers.

### Lock/transaction scope

Related writes use Kysely transactions, advisory locks, conditional updates, and `ON CONFLICT`; this layer performs no provider calls.

### Acceptable orphan states

No provider resources are created here. Incomplete database work remains in explicit queued/running/failed/quarantined lifecycle records for bounded reconciliation by later layers.

### Authorization source

This PR adds no public endpoint and changes no authorization boundary. Operator and release authorization are wired in later control-plane layers.

### Deferred scope

Provider image creation, build orchestration, customer cloning, recovery, release enqueue, rollout enablement, and production deployment remain deferred upstack. Splitting the large repository implementation into lifecycle, selection/lease, cleanup/reconciliation, and retirement modules without behavior changes is explicitly deferred to #1152.