### PR TITLE
feat(platform): provision VPSes from golden snapshots

### DIFF
--- a/packages/platform/src/customer-vps-errors.ts
+++ b/packages/platform/src/customer-vps-errors.ts
@@ -1,7 +1,9 @@
 export type CustomerVpsFailureCode =
   | 'quota_exceeded'
+  | 'snapshot_quota_exceeded'
   | 'provider_unavailable'
   | 'provider_timeout'
+  | 'snapshot_clone_rejected'
   | 'user_data_too_large'
   | 'r2_unavailable'
   | 'invalid_state'

--- a/packages/platform/src/customer-vps-hetzner.ts
+++ b/packages/platform/src/customer-vps-hetzner.ts
@@ -107,11 +107,31 @@ const ProviderImageSchema = z.object({
   labels: ProviderLabelsSchema.default({}),
   protection: z.object({ delete: z.boolean() }),
 }).passthrough();
-const ProviderCapacityErrorSchema = z.object({
+const ProviderErrorSchema = z.object({
   error: z.object({
     code: z.string().min(1).max(128),
+    details: z.object({
+      fields: z.array(z.object({
+        name: z.string().min(1).max(128),
+      }).passthrough()).max(32).optional(),
+    }).passthrough().optional(),
   }).passthrough(),
 }).passthrough();
+
+async function isSnapshotImageRejection(res: Response): Promise<boolean> {
+  let body: unknown;
+  try {
+    body = await res.clone().json();
+  } catch (err: unknown) {
+    if (!(err instanceof SyntaxError)) {
+      logCustomerVpsError('hetzner createServer rejection classification', err);
+    }
+    return false;
+  }
+  const parsed = ProviderErrorSchema.safeParse(body);
+  if (!parsed.success) return false;
+  return parsed.data.error.details?.fields?.some((field) => field.name === 'image') ?? false;
+}
 
 async function isDefinitiveCapacityRejection(res: Response): Promise<boolean> {
   if (res.status !== 412) return false;
@@ -124,7 +144,7 @@ async function isDefinitiveCapacityRejection(res: Response): Promise<boolean> {
     }
     return false;
   }
-  const parsed = ProviderCapacityErrorSchema.safeParse(body);
+  const parsed = ProviderErrorSchema.safeParse(body);
   return parsed.success && parsed.data.error.code === 'resource_unavailable';
 }
 
@@ -276,8 +296,14 @@ export function createHetznerClient(
         );
       }
       if (!res.ok) {
+        const snapshotImageRejected = input.image !== undefined && await isSnapshotImageRejection(res);
         const capacityRejected = await isDefinitiveCapacityRejection(res);
         await logProviderRejection('createServer', res);
+        if (snapshotImageRejected) {
+          throw new DefinitiveProviderRejectionError(
+            500, 'snapshot_clone_rejected', 'Provisioning provider unavailable',
+          );
+        }
         if (capacityRejected) {
           throw new DefinitiveProviderRejectionError(
             503, 'quota_exceeded', 'Provisioning capacity unavailable',

--- a/packages/platform/src/customer-vps-schema.ts
+++ b/packages/platform/src/customer-vps-schema.ts
@@ -65,7 +65,9 @@ export const RegisterRequestSchema = z.object({
   publicIPv4: PublicIPv4Schema,
   publicIPv6: z.ipv6().optional(),
   imageVersion: z.string().min(1).max(128),
-});
+  bundleSha256: z.string().regex(/^[a-f0-9]{64}$/).optional(),
+  healthy: z.boolean().optional(),
+}).strict();
 
 export const RecoverRequestSchema = z.object({
   clerkUserId: ClerkUserIdSchema,

--- a/packages/platform/src/customer-vps.ts
+++ b/packages/platform/src/customer-vps.ts
@@ -1,4 +1,5 @@
 import { randomUUID, randomBytes } from 'node:crypto';
+import { sql } from 'kysely';
 import type {
   PlatformDB,
   UserMachineProvisioningClass,
@@ -9,6 +10,7 @@ import {
   claimUserMachineRecovery,
   completeUserMachineRegistration,
   getActiveUserMachineByClerkId,
+  getHostBundleRelease,
   getHostBundleReleaseByChannel,
   getUserMachine,
   insertUserMachine,
@@ -82,7 +84,23 @@ import {
   openProvisioningPayload,
   sealProvisioningPayload,
   type NewProvisioningJob,
+  type ProvisioningPayload,
 } from './customer-vps-provisioning-jobs.js';
+import {
+  chooseProvisioningImage,
+  chooseRecoveryImage,
+  fallbackProvisioningImage,
+  resolveGoldenSnapshotRollout,
+  type ProvisioningImageDecision,
+} from './golden-snapshot-activation.js';
+import {
+  createGoldenSnapshotCreateIntent,
+  getGoldenSnapshot,
+  getGoldenSnapshotRecoveryRegistrationTarget,
+  markGoldenSnapshotCreateIntentAccepted,
+  releaseGoldenSnapshotLease,
+  releaseGoldenSnapshotLeaseInTransaction,
+} from './golden-snapshot-repository.js';
 
 export interface ProvisionResponse {
   machineId: string;
@@ -190,6 +208,9 @@ const DEFAULT_CLOUD_INIT_TEMPLATE = [
   "      MATRIX_DEVELOPER_TOOLS='{{developerTools}}'",
   '      MATRIX_IMAGE_VERSION={{imageVersion}}',
   '      MATRIX_UPDATE_CHANNEL={{updateChannel}}',
+  '      MATRIX_IMAGE_SOURCE={{imageSource}}',
+  '      MATRIX_TARGET_BUNDLE_SHA256={{targetBundleSha256}}',
+  '      MATRIX_SNAPSHOT_SOURCE_VERSION={{snapshotSourceVersion}}',
   '      MATRIX_HOST_BUNDLE_URL={{hostBundleUrl}}',
   '      MATRIX_PLATFORM_REGISTER_URL={{platformRegisterUrl}}',
   '      PLATFORM_INTERNAL_URL={{platformInternalUrl}}',
@@ -230,6 +251,8 @@ const PROVIDER_DELETION_RETRY_MAX_MS = 60 * 60_000;
 const RESIZE_STATUS_POLL_INTERVAL_MS = 1_000;
 const RESIZE_STATUS_POLL_TIMEOUT_MS = 90_000;
 const PROVISIONING_JOB_LEASE_MS = 5 * 60_000;
+const RECOVERY_CREATE_ACTION_POLL_ATTEMPTS = 6;
+const RECOVERY_CREATE_ACTION_POLL_INTERVAL_MS = 1_000;
 
 function activeProvisionResponse(row: UserMachineRecord, etaSeconds: number): ProvisionResponse {
   if (row.status !== 'provisioning' && row.status !== 'running') {
@@ -240,6 +263,12 @@ function activeProvisionResponse(row: UserMachineRecord, etaSeconds: number): Pr
     status: row.status,
     etaSeconds,
   };
+}
+
+function isAmbiguousProviderCreateError(err: unknown): boolean {
+  return !(err instanceof CustomerVpsError)
+    || err.code === 'provider_timeout'
+    || err.code === 'provider_unavailable';
 }
 
 async function findExistingProvisioningMachine(
@@ -327,6 +356,7 @@ const MAX_LOCAL_PROVISION_QUEUE_DEPTH = 20;
 interface HostBundleRef {
   imageVersion: string;
   hostBundleUrl: string;
+  sha256?: string | null;
 }
 
 function hostBundleUrlForImageVersion(config: CustomerVpsConfig, imageVersion: string): string {
@@ -344,7 +374,12 @@ function hostBundleUrlForImageVersion(config: CustomerVpsConfig, imageVersion: s
 
 async function resolveHostBundleRef(db: PlatformDB, config: CustomerVpsConfig): Promise<HostBundleRef> {
   if (config.hostBundleUrlOverride || !HOST_BUNDLE_CHANNELS.has(config.imageVersion)) {
-    return { imageVersion: config.imageVersion, hostBundleUrl: config.hostBundleUrl };
+    const release = await getHostBundleRelease(db, config.imageVersion);
+    return {
+      imageVersion: config.imageVersion,
+      hostBundleUrl: config.hostBundleUrl,
+      sha256: release?.sha256 ?? null,
+    };
   }
 
   const release = await getHostBundleReleaseByChannel(db, config.imageVersion);
@@ -353,12 +388,13 @@ async function resolveHostBundleRef(db: PlatformDB, config: CustomerVpsConfig): 
       `host bundle channel missing release channel=${config.imageVersion}`,
       new Error('falling back to configured host bundle URL without immutable version pin'),
     );
-    return { imageVersion: config.imageVersion, hostBundleUrl: config.hostBundleUrl };
+    return { imageVersion: config.imageVersion, hostBundleUrl: config.hostBundleUrl, sha256: null };
   }
 
   return {
     imageVersion: release.version,
     hostBundleUrl: hostBundleUrlForImageVersion(config, release.version),
+    sha256: release.sha256,
   };
 }
 
@@ -468,6 +504,18 @@ async function assertBillingResizeAllowed(
   }
 }
 
+async function assertMachineProviderMutationAllowed(
+  deps: CustomerVpsServiceDeps,
+  machine: Pick<UserMachineRecord, 'clerkUserId' | 'runtimeSlot' | 'provisioningClass'>,
+  serverType: string,
+  now: Date,
+): Promise<void> {
+  // Preview authorization is platform/operator scoped and deliberately does
+  // not consume or depend on the owner's customer billing entitlement.
+  if (machine.provisioningClass === 'preview') return;
+  await assertBillingResizeAllowed(deps, machine.clerkUserId, machine.runtimeSlot, serverType, now);
+}
+
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
@@ -575,6 +623,325 @@ export function createCustomerVpsService(deps: CustomerVpsServiceDeps): Customer
     }
   }
 
+  async function waitForRecoveryCreateAction(actionId: number): Promise<'success' | 'error' | 'pending'> {
+    for (let attempt = 0; attempt < RECOVERY_CREATE_ACTION_POLL_ATTEMPTS; attempt += 1) {
+      try {
+        const action = await deps.hetzner.getAction(actionId);
+        if (action?.status === 'success') return 'success';
+        if (action?.status === 'error') return 'error';
+      } catch (err: unknown) {
+        logCustomerVpsError(`recovery create action refresh failed actionId=${actionId}`, err);
+      }
+      if (attempt + 1 < RECOVERY_CREATE_ACTION_POLL_ATTEMPTS) {
+        await sleep(RECOVERY_CREATE_ACTION_POLL_INTERVAL_MS);
+      }
+    }
+    return 'pending';
+  }
+
+  async function removeRejectedRecoveryServer(input: {
+    serverId: number;
+    machineId: string;
+    handle: string;
+  }): Promise<boolean> {
+    try {
+      await deps.hetzner.deleteServer(input.serverId);
+      if (await deps.hetzner.getServer(input.serverId)) {
+        const err = new Error('Recovery server deletion has not completed');
+        await queueProviderDeletion({
+          providerServerId: input.serverId,
+          reason: 'rejected_snapshot_recovery_clone',
+          machineId: input.machineId,
+          handle: input.handle,
+          err,
+        });
+        return false;
+      }
+      return true;
+    } catch (err: unknown) {
+      logCustomerVpsError('rejected snapshot recovery clone cleanup failed', err);
+      await queueProviderDeletion({
+        providerServerId: input.serverId,
+        reason: 'rejected_snapshot_recovery_clone',
+        machineId: input.machineId,
+        handle: input.handle,
+        err,
+      });
+      return false;
+    }
+  }
+
+  async function reconcilePendingRecoveryCreate(
+    row: UserMachineRecord,
+  ): Promise<'settled' | 'pending' | 'failed'> {
+    if (row.status !== 'recovering') return 'settled';
+    const restoreOldMachine = async (encryptedPayload: string): Promise<boolean> => {
+      let payload: ProvisioningPayload;
+      try {
+        payload = openProvisioningPayload(encryptedPayload, deps.config.platformSecret);
+      } catch (err: unknown) {
+        logCustomerVpsError(`recovery rollback intent decode failed machineId=${row.machineId}`, err);
+        return false;
+      }
+      if (!payload.recovery) return false;
+      const expected = payload.recovery;
+      const recoveryTarget = await getGoldenSnapshotRecoveryRegistrationTarget(deps.db, row.machineId);
+      await runInPlatformTransaction(deps.db, async (trx) => {
+        await updateUserMachine(trx, row.machineId, {
+          machineId: expected.oldMachineId,
+          status: expected.oldStatus,
+          hetznerServerId: row.recoveryOldServerId,
+          publicIPv4: expected.oldPublicIPv4,
+          publicIPv6: expected.oldPublicIPv6,
+          imageVersion: expected.oldImageVersion,
+          sourceSnapshotId: expected.oldSourceSnapshotId,
+          sourceBaseGeneration: expected.oldSourceBaseGeneration,
+          targetBundleVersion: expected.oldTargetBundleVersion,
+          targetBundleSha256: expected.oldTargetBundleSha256,
+          serverType: expected.oldServerType,
+          recoveryCreateActionId: null,
+          recoveryEncryptedPayload: null,
+          recoveryOldServerId: null,
+          registrationTokenHash: expected.oldRegistrationTokenHash,
+          registrationTokenExpiresAt: expected.oldRegistrationTokenExpiresAt,
+          provisionedAt: expected.oldProvisionedAt,
+          lastSeenAt: expected.oldLastSeenAt,
+          failureCode: expected.oldFailureCode,
+          failureAt: expected.oldFailureAt,
+        });
+        if (recoveryTarget) {
+          await releaseGoldenSnapshotLeaseInTransaction(trx, recoveryTarget.leaseId, now().toISOString());
+        }
+      });
+      return true;
+    };
+    const registrationExpired = row.registrationTokenExpiresAt !== null
+      && new Date(row.registrationTokenExpiresAt).getTime() < now().getTime();
+    if (registrationExpired && row.hetznerServerId !== null && row.recoveryEncryptedPayload !== null) {
+      try {
+        await deps.hetzner.deleteServer(row.hetznerServerId);
+        if (await deps.hetzner.getServer(row.hetznerServerId)) return 'pending';
+      } catch (err: unknown) {
+        logCustomerVpsError(`expired recovery replacement cleanup failed machineId=${row.machineId}`, err);
+        return 'pending';
+      }
+      return await restoreOldMachine(row.recoveryEncryptedPayload) ? 'settled' : 'pending';
+    }
+    if (row.recoveryCreateActionId === null) {
+      if (row.recoveryEncryptedPayload === null) return 'settled';
+      let payload: ProvisioningPayload;
+      try {
+        payload = openProvisioningPayload(row.recoveryEncryptedPayload, deps.config.platformSecret);
+      } catch (err: unknown) {
+        logCustomerVpsError(`recovery intent decode failed machineId=${row.machineId}`, err);
+        return 'pending';
+      }
+      if (!payload.recovery) return 'pending';
+      const expected = payload.recovery;
+      if (row.hetznerServerId !== null) {
+        return 'pending';
+      }
+      if (!deps.hetzner.listServersByLabel) return 'pending';
+      let candidates: Awaited<ReturnType<NonNullable<HetznerClient['listServersByLabel']>>>;
+      try {
+        candidates = await deps.hetzner.listServersByLabel(`machine_id=${row.machineId}`);
+      } catch (err: unknown) {
+        logCustomerVpsError(`recovery create label reconciliation failed machineId=${row.machineId}`, err);
+        return 'pending';
+      }
+      const matches = candidates.filter((candidate) => {
+        const labels = candidate.labels ?? {};
+        return labels.machine_id === row.machineId
+          && labels.clerk_user_id === row.clerkUserId
+          && labels.runtime_slot === row.runtimeSlot
+          && labels.image_source === expected.imageSource
+          && (expected.sourceSnapshotId === null
+            ? labels.snapshot_id === undefined
+            : labels.snapshot_id === expected.sourceSnapshotId);
+      });
+      if (matches.length === 0 && row.registrationTokenExpiresAt !== null
+        && new Date(row.registrationTokenExpiresAt).getTime() < now().getTime()) {
+        await restoreOldMachine(row.recoveryEncryptedPayload);
+        return 'settled';
+      }
+      if (matches.length !== 1) {
+        if (matches.length > 1) {
+          logCustomerVpsError(
+            `recovery create provenance ambiguous machineId=${row.machineId}`,
+            new Error('Multiple exact-labeled replacement servers'),
+          );
+        }
+        return 'pending';
+      }
+      const replacement = matches[0]!;
+      // A label-list response proves identity, not create-action success.
+      // Keep the old VPS until the replacement itself registers healthy.
+      await runInPlatformTransaction(deps.db, async (trx) => {
+        await updateUserMachine(trx, row.machineId, {
+          hetznerServerId: replacement.id,
+          imageVersion: expected.targetBundleVersion,
+          sourceSnapshotId: expected.sourceSnapshotId,
+          sourceBaseGeneration: expected.sourceBaseGeneration,
+          targetBundleVersion: expected.targetBundleVersion,
+          targetBundleSha256: expected.targetBundleSha256,
+          recoveryCreateActionId: replacement.createActionId ?? null,
+          recoveryEncryptedPayload: row.recoveryEncryptedPayload,
+          recoveryOldServerId: row.recoveryOldServerId,
+          provisionedAt: now().toISOString(),
+          lastSeenAt: null,
+        });
+      });
+      return 'pending';
+    }
+    let action;
+    try {
+      action = await deps.hetzner.getAction(row.recoveryCreateActionId);
+    } catch (err: unknown) {
+      logCustomerVpsError(
+        `recovery create action reconciliation failed actionId=${row.recoveryCreateActionId}`,
+        err,
+      );
+      return 'pending';
+    }
+    if (!action || action.status === 'running') return 'pending';
+    const at = now().toISOString();
+    if (action.status === 'success') {
+      await runInPlatformTransaction(deps.db, async (trx) => {
+        await updateUserMachine(trx, row.machineId, {
+          recoveryCreateActionId: null,
+          recoveryEncryptedPayload: row.recoveryEncryptedPayload,
+          recoveryOldServerId: row.recoveryOldServerId,
+        });
+      });
+      return 'pending';
+    }
+
+    if (row.hetznerServerId === null || !await removeRejectedRecoveryServer({
+      serverId: row.hetznerServerId,
+      machineId: row.machineId,
+      handle: row.handle,
+    })) {
+      return 'pending';
+    }
+
+    const recoveryTarget = await getGoldenSnapshotRecoveryRegistrationTarget(deps.db, row.machineId);
+    if (row.sourceSnapshotId !== null && row.recoveryEncryptedPayload !== null) {
+      try {
+        const payload = openProvisioningPayload(row.recoveryEncryptedPayload, deps.config.platformSecret);
+        if (!payload.recovery) throw new Error('Recovery intent is missing durable provenance');
+        const imageVersion = row.targetBundleVersion ?? row.imageVersion ?? deps.config.imageVersion;
+        const hostConfig = buildHostConfig(
+          deps.config,
+          {
+            clerkUserId: row.clerkUserId,
+            handle: row.handle,
+            runtimeSlot: row.runtimeSlot,
+            developerTools: row.developerTools,
+          },
+          row.machineId,
+          payload.registrationToken,
+          payload.postgresPassword,
+          {
+            imageVersion,
+            hostBundleUrl: hostBundleUrlForImageVersion(deps.config, imageVersion),
+          },
+        );
+        const cleanRecoveryPayload = sealProvisioningPayload({
+          registrationToken: payload.registrationToken,
+          postgresPassword: payload.postgresPassword,
+          recovery: {
+            ...payload.recovery,
+            imageSource: 'clean_image',
+            sourceSnapshotId: null,
+            sourceBaseGeneration: null,
+          },
+        }, deps.config.platformSecret);
+        await runInPlatformTransaction(deps.db, async (trx) => {
+          await updateUserMachine(trx, row.machineId, {
+            hetznerServerId: null,
+            publicIPv4: null,
+            publicIPv6: null,
+            sourceSnapshotId: null,
+            sourceBaseGeneration: null,
+            recoveryCreateActionId: null,
+            recoveryEncryptedPayload: cleanRecoveryPayload,
+          });
+          if (recoveryTarget) {
+            await releaseGoldenSnapshotLeaseInTransaction(trx, recoveryTarget.leaseId, at);
+          }
+        });
+        let cleanServer;
+        try {
+          cleanServer = await deps.hetzner.createServer({
+            name: buildRecoveryServerName(row.handle, row.machineId),
+            serverType: row.serverType ?? deps.config.serverType,
+            location: row.location ?? deps.config.location,
+            userData: renderCloudInitTemplate(
+              deps.cloudInitTemplate ?? DEFAULT_CLOUD_INIT_TEMPLATE,
+              {
+                ...hostConfig,
+                imageSource: 'clean_image',
+                targetBundleSha256: row.targetBundleSha256 ?? '',
+                snapshotSourceVersion: '',
+              },
+            ),
+            labels: {
+              app: 'matrix-os', clerk_user_id: row.clerkUserId, runtime_slot: row.runtimeSlot,
+              machine_id: row.machineId, image_source: 'clean_image',
+            },
+          });
+        } catch (err: unknown) {
+          logCustomerVpsError(`recovery clean fallback create ambiguous machineId=${row.machineId}`, err);
+          return 'pending';
+        }
+        const pending = cleanServer.createActionId !== undefined;
+        await runInPlatformTransaction(deps.db, async (trx) => {
+          await updateUserMachine(trx, row.machineId, {
+            hetznerServerId: cleanServer.id,
+            publicIPv4: cleanServer.publicIPv4,
+            publicIPv6: cleanServer.publicIPv6,
+            sourceSnapshotId: null,
+            sourceBaseGeneration: null,
+            recoveryCreateActionId: cleanServer.createActionId ?? null,
+            recoveryEncryptedPayload: pending ? cleanRecoveryPayload : null,
+            recoveryOldServerId: pending ? row.recoveryOldServerId : null,
+          });
+          if (!pending && row.recoveryOldServerId !== null) {
+            await enqueueProviderDeletionTx(trx, {
+              providerServerId: row.recoveryOldServerId,
+              reason: 'recover_old_server',
+              machineId: row.machineId,
+              handle: row.handle,
+              detail: 'clean fallback replacement created',
+            });
+          }
+        });
+        return pending ? 'pending' : 'settled';
+      } catch (err: unknown) {
+        logCustomerVpsError(`recovery clean fallback failed machineId=${row.machineId}`, err);
+      }
+    }
+
+    if (row.recoveryEncryptedPayload !== null
+      && await restoreOldMachine(row.recoveryEncryptedPayload)) {
+      return 'settled';
+    }
+
+    await runInPlatformTransaction(deps.db, async (trx) => {
+      await updateUserMachine(trx, row.machineId, {
+        status: 'failed',
+        failureCode: 'provider_unavailable',
+        failureAt: at,
+        recoveryCreateActionId: null,
+        recoveryEncryptedPayload: null,
+      });
+      if (recoveryTarget) {
+        await releaseGoldenSnapshotLeaseInTransaction(trx, recoveryTarget.leaseId, at);
+      }
+    });
+    return 'failed';
+  }
+
   // Enqueues a provider-server deletion on the given transaction-or-db handle.
   // Unlike queueProviderDeletion, this propagates insert failures so a caller
   // can keep the status change and the deletion enqueue in one atomic unit —
@@ -589,10 +956,11 @@ export function createCustomerVpsService(deps: CustomerVpsServiceDeps): Customer
       handle?: string | null;
       detail: string;
     },
-  ): Promise<void> {
+  ): Promise<string> {
     const currentTime = now().toISOString();
+    const deletionId = randomUUID();
     await insertProviderDeletion(handle, {
-      id: randomUUID(),
+      id: deletionId,
       providerServerId: input.providerServerId,
       reason: input.reason,
       machineId: input.machineId ?? null,
@@ -601,6 +969,7 @@ export function createCustomerVpsService(deps: CustomerVpsServiceDeps): Customer
       createdAt: currentTime,
       lastError: input.detail,
     });
+    return deletionId;
   }
 
   async function retryProviderDeletions(): Promise<void> {
@@ -612,6 +981,10 @@ export function createCustomerVpsService(deps: CustomerVpsServiceDeps): Customer
     for (const deletion of pending) {
       try {
         await deps.hetzner.deleteServer(deletion.providerServerId);
+        if (deletion.reason === 'rejected_snapshot_recovery_clone'
+          && await deps.hetzner.getServer(deletion.providerServerId)) {
+          throw new Error('Provider server deletion has not completed');
+        }
         await markProviderDeletionCompleted(deps.db, deletion.id, now().toISOString());
       } catch (err: unknown) {
         const attempts = deletion.attempts + 1;
@@ -679,7 +1052,7 @@ export function createCustomerVpsService(deps: CustomerVpsServiceDeps): Customer
   async function dispatchProvisioningJob(
     jobId: string,
     propagateFailure: boolean,
-  ): Promise<'completed' | 'failed' | 'skipped'> {
+  ): Promise<'completed' | 'failed' | 'skipped' | 'pending'> {
     const claimedAt = now();
     const pendingJob = await getProvisioningJob(deps.db, jobId);
     if (
@@ -736,6 +1109,68 @@ export function createCustomerVpsService(deps: CustomerVpsServiceDeps): Customer
     try {
       const payload = openProvisioningPayload(job.encryptedPayload, deps.config.platformSecret);
       const imageVersion = row.imageVersion ?? deps.config.imageVersion;
+      let imageDecision: ProvisioningImageDecision;
+      let transitionedToFallback = false;
+      let effectiveProviderCreateActionId = job.providerCreateActionId;
+      if (job.imageSource === 'snapshot' && job.snapshotId && job.snapshotLeaseId) {
+        const rollout = await resolveGoldenSnapshotRollout(
+          deps.db,
+          deps.config.goldenSnapshots,
+          row.machineId,
+          claimedAt.toISOString(),
+        );
+        const persistedSnapshot = await getGoldenSnapshot(deps.db, job.snapshotId);
+        const freshnessCutoff = new Date(
+          claimedAt.getTime() - deps.config.goldenSnapshots.freshnessMaxAgeMs,
+        ).toISOString();
+        if (!rollout.included || !persistedSnapshot?.providerImageId || persistedSnapshot.state !== 'ready'
+          || !persistedSnapshot.readyAt || persistedSnapshot.readyAt <= freshnessCutoff) {
+          await fallbackProvisioningImage(deps.db, {
+            jobId: job.jobId,
+            reason: !rollout.included
+              ? 'snapshot_rollout_disabled'
+              : persistedSnapshot?.state === 'ready' ? 'snapshot_stale' : 'snapshot_unavailable',
+            now: claimedAt.toISOString(),
+          });
+          transitionedToFallback = true;
+          effectiveProviderCreateActionId = null;
+          imageDecision = {
+            imageSource: 'clean_image',
+            targetBundleVersion: imageVersion,
+            targetBundleSha256: job.targetBundleSha256 ?? '0'.repeat(64),
+          };
+        } else {
+          imageDecision = {
+            imageSource: 'snapshot',
+            targetBundleVersion: imageVersion,
+            targetBundleSha256: job.targetBundleSha256 ?? persistedSnapshot.bundleSha256,
+            snapshotId: persistedSnapshot.snapshotId,
+            snapshotLeaseId: job.snapshotLeaseId,
+            providerImageId: persistedSnapshot.providerImageId,
+            sourceBundleVersion: persistedSnapshot.bundleVersion,
+            sourceBaseGeneration: persistedSnapshot.compatibility.baseGeneration,
+            rolloutGeneration: rollout.generation,
+            exact: persistedSnapshot.bundleSha256 === job.targetBundleSha256,
+            requiresExactUpdate: persistedSnapshot.bundleSha256 !== job.targetBundleSha256,
+          };
+        }
+      } else if (job.imageSource === 'clean_image') {
+        imageDecision = {
+          imageSource: 'clean_image',
+          targetBundleVersion: imageVersion,
+          targetBundleSha256: job.targetBundleSha256 ?? '0'.repeat(64),
+        };
+      } else {
+        imageDecision = await chooseProvisioningImage(deps.db, deps.config.goldenSnapshots, {
+          jobId: job.jobId,
+          machineId: row.machineId,
+          targetBundleVersion: imageVersion,
+          serverType: row.serverType ?? deps.config.serverType,
+          purpose: 'provision',
+          leaseId: randomUUID(),
+          now: claimedAt.toISOString(),
+        });
+      }
       const hostConfig = buildHostConfig(
         deps.config,
         {
@@ -754,14 +1189,43 @@ export function createCustomerVpsService(deps: CustomerVpsServiceDeps): Customer
       );
       const userData = renderCloudInitTemplate(
         deps.cloudInitTemplate ?? DEFAULT_CLOUD_INIT_TEMPLATE,
-        hostConfig,
+        {
+          ...hostConfig,
+          imageSource: imageDecision.imageSource,
+          targetBundleSha256: imageDecision.targetBundleSha256 === '0'.repeat(64) ? '' : imageDecision.targetBundleSha256,
+          snapshotSourceVersion: imageDecision.imageSource === 'snapshot' ? imageDecision.sourceBundleVersion : '',
+        },
       );
-      const existingServers = deps.hetzner.listServersByLabel
+      let existingServers = deps.hetzner.listServersByLabel
         ? (await deps.hetzner.listServersByLabel(`machine_id=${row.machineId}`))
           .toSorted((left, right) => left.id - right.id)
         : [];
-      const existingServer = existingServers[0];
-      const server = existingServer ?? await deps.hetzner.createServer({
+      if (imageDecision.imageSource === 'clean_image' && (job.fallbackReason || transitionedToFallback)) {
+        const staleSnapshotServers = existingServers.filter((candidate) => candidate.labels?.snapshot_id);
+        for (const stale of staleSnapshotServers) {
+          try {
+            await deps.hetzner.deleteServer(stale.id);
+            if (await deps.hetzner.getServer(stale.id)) return 'pending';
+          } catch (cleanupErr: unknown) {
+            logCustomerVpsError('snapshot fallback server cleanup failed', cleanupErr);
+            await queueProviderDeletion({
+              providerServerId: stale.id, reason: 'snapshot_fallback_server',
+              machineId: row.machineId, handle: row.handle, err: cleanupErr,
+            });
+            return 'pending';
+          }
+        }
+        existingServers = existingServers.filter((candidate) => !candidate.labels?.snapshot_id);
+      }
+      const selectedSnapshotId = imageDecision.imageSource === 'snapshot' ? imageDecision.snapshotId : undefined;
+      const matchingServers = selectedSnapshotId
+        ? existingServers.filter((server) => server.labels?.snapshot_id === selectedSnapshotId)
+        : existingServers.filter((server) => !server.labels?.snapshot_id);
+      if (existingServers.length > 0 && matchingServers.length === 0) {
+        throw new Error('Existing provider server image provenance is ambiguous');
+      }
+      const existingServer = matchingServers[0];
+      const createInput = {
           name: buildServerName(row.handle),
           serverType: row.serverType ?? deps.config.serverType,
           location: row.location ?? deps.config.location,
@@ -771,11 +1235,102 @@ export function createCustomerVpsService(deps: CustomerVpsServiceDeps): Customer
             clerk_user_id: row.clerkUserId,
             runtime_slot: row.runtimeSlot,
             machine_id: row.machineId,
+            image_source: imageDecision.imageSource,
+            ...(imageDecision.imageSource === 'snapshot' ? { snapshot_id: imageDecision.snapshotId } : {}),
           },
-        });
+          ...(imageDecision.imageSource === 'snapshot' ? { image: imageDecision.providerImageId } : {}),
+        };
+      let server = existingServer;
+      if (!server) {
+        await assertMachineProviderMutationAllowed(deps, row, createInput.serverType, now());
+        try {
+          if (imageDecision.imageSource === 'snapshot') {
+            const selectableSnapshot = await getGoldenSnapshot(deps.db, imageDecision.snapshotId);
+            if (selectableSnapshot?.state !== 'ready'
+              || selectableSnapshot.providerImageId !== imageDecision.providerImageId) {
+              throw new CustomerVpsError(409, 'snapshot_clone_rejected', 'Provisioning image unavailable');
+            }
+            const intent = await createGoldenSnapshotCreateIntent(deps.db, {
+              intentId: randomUUID(), snapshotId: imageDecision.snapshotId,
+              leaseId: imageDecision.snapshotLeaseId, machineId: row.machineId,
+              purpose: 'provision', rolloutGeneration: imageDecision.rolloutGeneration,
+              now: now().toISOString(),
+            });
+            if (!intent || intent.state === 'denied') {
+              throw new CustomerVpsError(409, 'snapshot_clone_rejected', 'Provisioning image unavailable');
+            }
+          }
+          server = await deps.hetzner.createServer(createInput);
+          if (imageDecision.imageSource === 'snapshot') {
+            const accepted = await markGoldenSnapshotCreateIntentAccepted(
+              deps.db, imageDecision.snapshotLeaseId, server.createActionId ?? null, now().toISOString(),
+            );
+            if (!accepted || accepted.state === 'denied') {
+              try {
+                await deps.hetzner.deleteServer(server.id);
+              } catch (cleanupErr: unknown) {
+                await queueProviderDeletion({
+                  providerServerId: server.id, reason: 'denied_snapshot_create',
+                  machineId: row.machineId, handle: row.handle, err: cleanupErr,
+                });
+              }
+              throw new CustomerVpsError(409, 'snapshot_clone_rejected', 'Provisioning image unavailable');
+            }
+          }
+        } catch (createErr: unknown) {
+          if (isAmbiguousProviderCreateError(createErr)) {
+            logCustomerVpsError('provision create outcome is ambiguous; awaiting exact-label reconciliation', createErr);
+            return 'pending';
+          }
+          if (!(createErr instanceof CustomerVpsError)
+            || createErr.code !== 'snapshot_clone_rejected'
+            || imageDecision.imageSource !== 'snapshot') throw createErr;
+          await fallbackProvisioningImage(deps.db, {
+            jobId: job.jobId,
+            reason: 'clone_rejected',
+            now: now().toISOString(),
+          });
+          effectiveProviderCreateActionId = null;
+          imageDecision = {
+            imageSource: 'clean_image',
+            targetBundleVersion: imageDecision.targetBundleVersion,
+            targetBundleSha256: imageDecision.targetBundleSha256,
+          };
+          await assertMachineProviderMutationAllowed(deps, row, createInput.serverType, now());
+          try {
+            server = await deps.hetzner.createServer({
+              name: createInput.name,
+              serverType: createInput.serverType,
+              location: createInput.location,
+              userData: renderCloudInitTemplate(
+                deps.cloudInitTemplate ?? DEFAULT_CLOUD_INIT_TEMPLATE,
+                {
+                  ...hostConfig,
+                  imageSource: 'clean_image',
+                  targetBundleSha256: imageDecision.targetBundleSha256,
+                  snapshotSourceVersion: '',
+                },
+              ),
+              labels: {
+                app: 'matrix-os', clerk_user_id: row.clerkUserId, runtime_slot: row.runtimeSlot,
+                machine_id: row.machineId, image_source: 'clean_image',
+              },
+            });
+          } catch (fallbackCreateErr: unknown) {
+            if (isAmbiguousProviderCreateError(fallbackCreateErr)) {
+              logCustomerVpsError(
+                'clean fallback create outcome is ambiguous; awaiting exact-label reconciliation',
+                fallbackCreateErr,
+              );
+              return 'pending';
+            }
+            throw fallbackCreateErr;
+          }
+        }
+      }
       adoptedExistingServer = Boolean(existingServer);
       if (!adoptedExistingServer) serverIdForCompensation = server.id;
-      for (const duplicate of existingServers.slice(1)) {
+      for (const duplicate of matchingServers.slice(1)) {
         try {
           await deps.hetzner.deleteServer(duplicate.id);
         } catch (cleanupErr: unknown) {
@@ -789,6 +1344,65 @@ export function createCustomerVpsService(deps: CustomerVpsServiceDeps): Customer
           });
         }
       }
+      const createActionId = effectiveProviderCreateActionId ?? server.createActionId ?? null;
+      if (adoptedExistingServer && createActionId === null && server.status !== 'running') {
+        const observedAt = now().toISOString();
+        await runInPlatformTransaction(deps.db, async (trx) => {
+          await updateUserMachine(trx, row.machineId, {
+            hetznerServerId: server!.id,
+            publicIPv4: server!.publicIPv4,
+            publicIPv6: server!.publicIPv6,
+          });
+          await trx.executor.updateTable('provisioning_jobs').set({
+            activation_step: 'creating', updated_at: observedAt,
+          }).where('job_id', '=', job.jobId).where('status', '=', 'running').executeTakeFirstOrThrow();
+        });
+        return 'pending';
+      }
+      if (createActionId !== null) {
+        if (effectiveProviderCreateActionId === null) {
+          const observedAt = now().toISOString();
+          await runInPlatformTransaction(deps.db, async (trx) => {
+            await updateUserMachine(trx, row.machineId, {
+              hetznerServerId: server!.id,
+              publicIPv4: server!.publicIPv4,
+              publicIPv6: server!.publicIPv6,
+            });
+            await trx.executor.updateTable('provisioning_jobs').set({
+              provider_create_action_id: createActionId,
+              activation_step: 'creating',
+              updated_at: observedAt,
+            }).where('job_id', '=', job.jobId).where('status', '=', 'running').executeTakeFirstOrThrow();
+          });
+        }
+        let action;
+        try {
+          action = await deps.hetzner.getAction(createActionId);
+        } catch (actionErr: unknown) {
+          logCustomerVpsError('provision create action refresh failed', actionErr);
+          return 'pending';
+        }
+        if (!action || action.status === 'running') return 'pending';
+        if (action.status === 'error') {
+          if (imageDecision.imageSource !== 'snapshot') {
+            throw new Error('Provider create action failed');
+          }
+          await fallbackProvisioningImage(deps.db, {
+            jobId: job.jobId, reason: 'clone_rejected', now: now().toISOString(),
+          });
+          try {
+            await deps.hetzner.deleteServer(server.id);
+            if (await deps.hetzner.getServer(server.id)) return 'pending';
+          } catch (cleanupErr: unknown) {
+            logCustomerVpsError('rejected snapshot clone cleanup failed', cleanupErr);
+            await queueProviderDeletion({
+              providerServerId: server.id, reason: 'rejected_snapshot_clone',
+              machineId: row.machineId, handle: row.handle, err: cleanupErr,
+            });
+          }
+          return 'pending';
+        }
+      }
       const completedAt = now().toISOString();
       await runInPlatformTransaction(deps.db, async (trx) => {
         await updateUserMachine(trx, row.machineId, {
@@ -796,9 +1410,16 @@ export function createCustomerVpsService(deps: CustomerVpsServiceDeps): Customer
           publicIPv4: server.publicIPv4,
           publicIPv6: server.publicIPv6,
         });
+        await trx.executor.updateTable('provisioning_jobs').set({
+          provider_create_action_id: server.createActionId ?? null,
+          updated_at: completedAt,
+        }).where('job_id', '=', job.jobId).where('status', '=', 'running').execute();
         const completed = await completeProvisioningJob(trx, job.jobId, completedAt);
         if (!completed) {
-          throw new Error('Provisioning job completion lost its lease');
+          const settledJob = await getProvisioningJob(trx, job.jobId);
+          if (settledJob?.status !== 'completed') {
+            throw new Error('Provisioning job completion lost its lease');
+          }
         }
       });
       return 'completed';
@@ -829,6 +1450,10 @@ export function createCustomerVpsService(deps: CustomerVpsServiceDeps): Customer
             failureCode: toFailureCode(err),
             failureAt: failedAt,
           });
+          const latestJob = await getProvisioningJob(trx, job.jobId);
+          if (latestJob?.snapshotLeaseId) {
+            await releaseGoldenSnapshotLeaseInTransaction(trx, latestJob.snapshotLeaseId, failedAt);
+          }
           await failProvisioningJob(trx, job.jobId, failedAt, toFailureCode(err));
         });
       } catch (statusErr: unknown) {
@@ -1139,29 +1764,155 @@ export function createCustomerVpsService(deps: CustomerVpsServiceDeps): Customer
       if (!expectedRegistrationTokenHash || !registrationTokenMatches(token, expectedRegistrationTokenHash)) {
         throw new CustomerVpsError(401, 'registration_rejected', 'Registration rejected');
       }
-
-      const lastSeenAt = now().toISOString();
-      const updated = await completeUserMachineRegistration(
-        deps.db,
-        input.machineId,
-        input.hetznerServerId,
-        expectedRegistrationTokenHash,
-        lastSeenAt,
-        {
-          status: 'running',
-          publicIPv4: input.publicIPv4,
-          publicIPv6: input.publicIPv6,
-          imageVersion: input.imageVersion,
-          lastSeenAt,
-          registrationTokenHash: null,
-          registrationTokenExpiresAt: null,
-          failureCode: null,
-          failureAt: null,
-        },
-      );
-      if (!updated) {
-        throw new CustomerVpsError(409, 'invalid_state', 'Machine cannot register');
+      const provisioningJob = row.status === 'provisioning'
+        ? await getProvisioningJobByMachineId(deps.db, input.machineId)
+        : undefined;
+      const recoveryTarget = row.status === 'recovering'
+        ? await getGoldenSnapshotRecoveryRegistrationTarget(deps.db, input.machineId)
+        : undefined;
+      const persistedRecoveryTarget = row.status === 'recovering'
+        && row.sourceSnapshotId !== null
+        && row.sourceBaseGeneration !== null
+        && row.targetBundleVersion !== null
+        && row.targetBundleSha256 !== null
+        ? {
+            snapshotId: row.sourceSnapshotId,
+            baseGeneration: row.sourceBaseGeneration,
+            targetBundleVersion: row.targetBundleVersion,
+            targetBundleSha256: row.targetBundleSha256,
+          }
+        : undefined;
+      let sourceSnapshotId: string | null = persistedRecoveryTarget?.snapshotId ?? recoveryTarget?.snapshotId ?? null;
+      let sourceBaseGeneration: string | null = persistedRecoveryTarget?.baseGeneration ?? recoveryTarget?.baseGeneration ?? null;
+      let registrationTarget: { targetBundleVersion: string; targetBundleSha256: string } | undefined =
+        row.targetBundleVersion !== null && row.targetBundleSha256 !== null
+          ? {
+              targetBundleVersion: row.targetBundleVersion,
+              targetBundleSha256: row.targetBundleSha256,
+            }
+          : persistedRecoveryTarget ?? recoveryTarget;
+      if (!registrationTarget && provisioningJob?.imageSource === 'snapshot') {
+        if (provisioningJob.targetBundleVersion === null || provisioningJob.targetBundleSha256 === null) {
+          throw new CustomerVpsError(409, 'registration_rejected', 'Registration rejected');
+        }
+        if (provisioningJob.snapshotId === null) {
+          throw new CustomerVpsError(409, 'registration_rejected', 'Registration rejected');
+        }
+        const sourceSnapshot = await getGoldenSnapshot(deps.db, provisioningJob.snapshotId);
+        if (!sourceSnapshot || sourceSnapshot.state !== 'ready') {
+          throw new CustomerVpsError(409, 'registration_rejected', 'Registration rejected');
+        }
+        sourceSnapshotId = sourceSnapshot.snapshotId;
+        sourceBaseGeneration = sourceSnapshot.compatibility.baseGeneration;
+        registrationTarget = {
+          targetBundleVersion: provisioningJob.targetBundleVersion,
+          targetBundleSha256: provisioningJob.targetBundleSha256,
+        };
       }
+      if (!registrationTarget
+        && provisioningJob?.targetBundleVersion !== null
+        && provisioningJob?.targetBundleVersion !== undefined
+        && provisioningJob.targetBundleSha256 !== null) {
+        registrationTarget = {
+          targetBundleVersion: provisioningJob.targetBundleVersion,
+          targetBundleSha256: provisioningJob.targetBundleSha256,
+        };
+      }
+      if (registrationTarget
+        && registrationTarget.targetBundleSha256 !== '0'.repeat(64)
+        && (input.imageVersion !== registrationTarget.targetBundleVersion
+          || input.bundleSha256 !== registrationTarget.targetBundleSha256
+          || input.healthy !== true)) {
+        throw new CustomerVpsError(409, 'registration_rejected', 'Registration rejected');
+      }
+      const lastSeenAt = now().toISOString();
+      const updated = await runInPlatformTransaction(deps.db, async (trx) => {
+        const snapshotLeaseId = provisioningJob?.snapshotLeaseId ?? recoveryTarget?.leaseId;
+        if (sourceSnapshotId !== null) {
+          if (sourceBaseGeneration === null) {
+            throw new CustomerVpsError(409, 'registration_rejected', 'Registration rejected');
+          }
+          await sql`SELECT pg_advisory_xact_lock(hashtext(${sourceBaseGeneration}))`
+            .execute(trx.executor);
+          const readySource = await trx.executor.selectFrom('golden_snapshots').select('snapshot_id')
+            .where('snapshot_id', '=', sourceSnapshotId).where('state', '=', 'ready')
+            .forUpdate().executeTakeFirst();
+          if (!readySource) {
+            throw new CustomerVpsError(409, 'registration_rejected', 'Registration rejected');
+          }
+        }
+        if (sourceSnapshotId !== null && snapshotLeaseId) {
+          const createIntent = await trx.executor.selectFrom('golden_snapshot_create_intents').selectAll()
+            .where('lease_id', '=', snapshotLeaseId).forUpdate().executeTakeFirst();
+          if (!createIntent || createIntent.state === 'denied') {
+            throw new CustomerVpsError(409, 'registration_rejected', 'Registration rejected');
+          }
+          if (createIntent.state !== 'activated') {
+            const activation = await trx.executor.updateTable('golden_snapshot_create_intents').set({
+              state: 'activated', updated_at: lastSeenAt, completed_at: lastSeenAt,
+            }).where('intent_id', '=', createIntent.intent_id)
+              .where('state', 'in', ['pending', 'accepted'])
+              .returning('intent_id').executeTakeFirst();
+            if (!activation) {
+              throw new CustomerVpsError(409, 'registration_rejected', 'Registration rejected');
+            }
+          }
+        }
+        const registered = await completeUserMachineRegistration(
+          trx,
+          input.machineId,
+          input.hetznerServerId,
+          expectedRegistrationTokenHash,
+          lastSeenAt,
+          {
+            status: 'running',
+            publicIPv4: input.publicIPv4,
+            publicIPv6: input.publicIPv6,
+            imageVersion: input.imageVersion,
+            sourceSnapshotId,
+            sourceBaseGeneration,
+            targetBundleVersion: registrationTarget?.targetBundleVersion
+              ?? provisioningJob?.targetBundleVersion
+              ?? input.imageVersion,
+            targetBundleSha256: registrationTarget?.targetBundleSha256
+              ?? provisioningJob?.targetBundleSha256
+              ?? input.bundleSha256
+              ?? null,
+            recoveryCreateActionId: null,
+            recoveryEncryptedPayload: null,
+            recoveryOldServerId: null,
+            lastSeenAt,
+            registrationTokenHash: null,
+            registrationTokenExpiresAt: null,
+            failureCode: null,
+            failureAt: null,
+          },
+        );
+        if (!registered) throw new CustomerVpsError(409, 'invalid_state', 'Machine cannot register');
+        if (row.recoveryOldServerId !== null) {
+          await enqueueProviderDeletionTx(trx, {
+            providerServerId: row.recoveryOldServerId,
+            reason: 'recover_old_server',
+            machineId: row.machineId,
+            handle: row.handle,
+            detail: 'recovery replacement registered before create-action reconciliation',
+          });
+        }
+        if (recoveryTarget) {
+          await releaseGoldenSnapshotLeaseInTransaction(trx, recoveryTarget.leaseId, lastSeenAt);
+        }
+        if (provisioningJob?.snapshotLeaseId) {
+          await releaseGoldenSnapshotLeaseInTransaction(trx, provisioningJob.snapshotLeaseId, lastSeenAt);
+        }
+        if (provisioningJob?.status === 'running') {
+          const completed = await completeProvisioningJob(trx, provisioningJob.jobId, lastSeenAt);
+          if (!completed) throw new Error('Provisioning job registration completion lost its lease');
+        }
+        await trx.executor.updateTable('provisioning_jobs').set({
+          activation_step: 'registered', updated_at: lastSeenAt,
+        }).where('machine_id', '=', input.machineId).where('status', '=', 'completed').execute();
+        return registered;
+      });
 
       const warnings: string[] = [];
       try {
@@ -1208,6 +1959,11 @@ export function createCustomerVpsService(deps: CustomerVpsServiceDeps): Customer
       // Resolve before claiming recovery so bundle lookup failures do not clear
       // the old provider server id and leave a billable VPS untracked.
       const bundleRef = await resolveHostBundleRef(deps.db, deps.config);
+      let recoveryImage: ProvisioningImageDecision = {
+        imageSource: 'clean_image',
+        targetBundleVersion: bundleRef.imageVersion,
+        targetBundleSha256: bundleRef.sha256 ?? '0'.repeat(64),
+      };
       const hostConfig = buildHostConfig(
         deps.config,
         {
@@ -1221,26 +1977,81 @@ export function createCustomerVpsService(deps: CustomerVpsServiceDeps): Customer
         postgresPassword,
         bundleRef,
       );
-      const existing = await claimUserMachineRecovery(deps.db, input.clerkUserId, input.runtimeSlot);
+      if (deps.config.goldenSnapshots.enabled) {
+        recoveryImage = await chooseRecoveryImage(deps.db, deps.config.goldenSnapshots, {
+          machineId,
+          targetBundleVersion: bundleRef.imageVersion,
+          serverType: billingContext?.serverType ?? active.serverType ?? deps.config.serverType,
+          purpose: 'recover',
+          leaseId: randomUUID(),
+          now: currentTime.toISOString(),
+        });
+      }
+      const sealRecoveryIntent = (decision: ProvisioningImageDecision): string => sealProvisioningPayload({
+        registrationToken: registration.token,
+        postgresPassword,
+        recovery: {
+          oldMachineId: active.machineId,
+          oldStatus: active.status,
+          oldPublicIPv4: active.publicIPv4,
+          oldPublicIPv6: active.publicIPv6,
+          oldImageVersion: active.imageVersion,
+          oldSourceSnapshotId: active.sourceSnapshotId,
+          oldSourceBaseGeneration: active.sourceBaseGeneration,
+          oldTargetBundleVersion: active.targetBundleVersion,
+          oldTargetBundleSha256: active.targetBundleSha256,
+          oldServerType: active.serverType,
+          oldRegistrationTokenHash: active.registrationTokenHash,
+          oldRegistrationTokenExpiresAt: active.registrationTokenExpiresAt,
+          oldProvisionedAt: active.provisionedAt,
+          oldLastSeenAt: active.lastSeenAt,
+          oldFailureCode: active.failureCode,
+          oldFailureAt: active.failureAt,
+          imageSource: decision.imageSource,
+          targetBundleVersion: decision.targetBundleVersion,
+          targetBundleSha256: decision.targetBundleSha256,
+          sourceSnapshotId: decision.imageSource === 'snapshot' ? decision.snapshotId : null,
+          sourceBaseGeneration: decision.imageSource === 'snapshot' ? decision.sourceBaseGeneration : null,
+        },
+      }, deps.config.platformSecret);
+      let encryptedRecoveryPayload = sealRecoveryIntent(recoveryImage);
+      const intendedServerType = billingContext?.serverType ?? active.serverType ?? deps.config.serverType;
+      const existing = await claimUserMachineRecovery(deps.db, input.clerkUserId, active.runtimeSlot, {
+        machineId,
+        encryptedPayload: encryptedRecoveryPayload,
+        serverType: intendedServerType,
+        registrationTokenHash: registration.hash,
+        registrationTokenExpiresAt: registration.expiresAt,
+      });
       if (!existing) {
+        if (recoveryImage.imageSource === 'snapshot') {
+          await releaseGoldenSnapshotLease(deps.db, recoveryImage.snapshotLeaseId, currentTime.toISOString());
+        }
         const latest = await getActiveUserMachineByClerkId(deps.db, input.clerkUserId, input.runtimeSlot);
         if (latest?.status === 'recovering') {
           throw new CustomerVpsError(409, 'invalid_state', 'Recovery already in progress');
         }
         throw new CustomerVpsError(404, 'not_found', 'Machine not found');
       }
-      const oldMachineId = existing.machineId;
-      const oldServerId = active.hetznerServerId;
+      const oldMachineId = active.machineId;
+      const oldServerId = existing.recoveryOldServerId;
 
       let newServerId: number | null = null;
+      let createPending = false;
+      let createOutcomeAmbiguous = false;
       try {
         const userData = renderCloudInitTemplate(
           deps.cloudInitTemplate ?? DEFAULT_CLOUD_INIT_TEMPLATE,
-          hostConfig,
+          {
+            ...hostConfig,
+            imageSource: recoveryImage.imageSource,
+            targetBundleSha256: recoveryImage.targetBundleSha256 === '0'.repeat(64) ? '' : recoveryImage.targetBundleSha256,
+            snapshotSourceVersion: recoveryImage.imageSource === 'snapshot' ? recoveryImage.sourceBundleVersion : '',
+          },
         );
-        const server = await deps.hetzner.createServer({
+        const recoveryCreateInput = {
           name: buildRecoveryServerName(existing.handle, machineId),
-          serverType: billingContext?.serverType ?? active.serverType ?? deps.config.serverType,
+          serverType: intendedServerType,
           location: active.location ?? deps.config.location,
           userData,
           labels: {
@@ -1248,19 +2059,160 @@ export function createCustomerVpsService(deps: CustomerVpsServiceDeps): Customer
             clerk_user_id: existing.clerkUserId,
             runtime_slot: existing.runtimeSlot,
             machine_id: machineId,
+            image_source: recoveryImage.imageSource,
+            ...(recoveryImage.imageSource === 'snapshot' ? { snapshot_id: recoveryImage.snapshotId } : {}),
           },
-        });
+          ...(recoveryImage.imageSource === 'snapshot' ? { image: recoveryImage.providerImageId } : {}),
+        };
+        let server;
+        await assertMachineProviderMutationAllowed(deps, existing, recoveryCreateInput.serverType, now());
+        try {
+          if (recoveryImage.imageSource === 'snapshot') {
+            const selectableSnapshot = await getGoldenSnapshot(deps.db, recoveryImage.snapshotId);
+            if (selectableSnapshot?.state !== 'ready'
+              || selectableSnapshot.providerImageId !== recoveryImage.providerImageId) {
+              throw new CustomerVpsError(409, 'snapshot_clone_rejected', 'Provisioning image unavailable');
+            }
+            const intent = await createGoldenSnapshotCreateIntent(deps.db, {
+              intentId: randomUUID(), snapshotId: recoveryImage.snapshotId,
+              leaseId: recoveryImage.snapshotLeaseId, machineId,
+              purpose: 'recover', rolloutGeneration: recoveryImage.rolloutGeneration,
+              now: now().toISOString(),
+            });
+            if (!intent || intent.state === 'denied') {
+              throw new CustomerVpsError(409, 'snapshot_clone_rejected', 'Provisioning image unavailable');
+            }
+          }
+          server = await deps.hetzner.createServer(recoveryCreateInput);
+          if (recoveryImage.imageSource === 'snapshot') {
+            const accepted = await markGoldenSnapshotCreateIntentAccepted(
+              deps.db, recoveryImage.snapshotLeaseId, server.createActionId ?? null, now().toISOString(),
+            );
+            if (!accepted || accepted.state === 'denied') {
+              await removeRejectedRecoveryServer({ serverId: server.id, machineId, handle: existing.handle });
+              throw new CustomerVpsError(409, 'snapshot_clone_rejected', 'Provisioning image unavailable');
+            }
+          }
+        } catch (createErr: unknown) {
+          if (!(createErr instanceof CustomerVpsError)
+            || createErr.code !== 'snapshot_clone_rejected'
+            || recoveryImage.imageSource !== 'snapshot') {
+            createOutcomeAmbiguous = isAmbiguousProviderCreateError(createErr);
+            throw createErr;
+          }
+          await releaseGoldenSnapshotLease(deps.db, recoveryImage.snapshotLeaseId, now().toISOString());
+          recoveryImage = {
+            imageSource: 'clean_image',
+            targetBundleVersion: recoveryImage.targetBundleVersion,
+            targetBundleSha256: recoveryImage.targetBundleSha256,
+          };
+          encryptedRecoveryPayload = sealRecoveryIntent(recoveryImage);
+          await updateUserMachine(deps.db, machineId, {
+            recoveryEncryptedPayload: encryptedRecoveryPayload,
+          });
+          await assertMachineProviderMutationAllowed(deps, existing, recoveryCreateInput.serverType, now());
+          try {
+            server = await deps.hetzner.createServer({
+              name: recoveryCreateInput.name,
+              serverType: recoveryCreateInput.serverType,
+              location: recoveryCreateInput.location,
+              userData: renderCloudInitTemplate(
+                deps.cloudInitTemplate ?? DEFAULT_CLOUD_INIT_TEMPLATE,
+                {
+                  ...hostConfig,
+                  imageSource: 'clean_image',
+                  targetBundleSha256: recoveryImage.targetBundleSha256,
+                  snapshotSourceVersion: '',
+                },
+              ),
+              labels: {
+                app: 'matrix-os', clerk_user_id: existing.clerkUserId, runtime_slot: existing.runtimeSlot,
+                machine_id: machineId, image_source: 'clean_image',
+              },
+            });
+          } catch (fallbackCreateErr: unknown) {
+            createOutcomeAmbiguous = isAmbiguousProviderCreateError(fallbackCreateErr);
+            throw fallbackCreateErr;
+          }
+        }
         newServerId = server.id;
+        if (server.createActionId !== undefined) {
+          const createResult = await waitForRecoveryCreateAction(server.createActionId);
+          if (createResult === 'error') {
+            if (recoveryImage.imageSource !== 'snapshot') {
+              throw new CustomerVpsError(500, 'provider_unavailable', 'Provisioning provider unavailable');
+            }
+            const removed = await removeRejectedRecoveryServer({
+              serverId: server.id,
+              machineId,
+              handle: existing.handle,
+            });
+            if (!removed) {
+              throw new CustomerVpsError(500, 'provider_timeout', 'Provisioning provider unavailable');
+            }
+            newServerId = null;
+            await releaseGoldenSnapshotLease(deps.db, recoveryImage.snapshotLeaseId, now().toISOString());
+            recoveryImage = {
+              imageSource: 'clean_image',
+              targetBundleVersion: recoveryImage.targetBundleVersion,
+              targetBundleSha256: recoveryImage.targetBundleSha256,
+            };
+            encryptedRecoveryPayload = sealRecoveryIntent(recoveryImage);
+            await updateUserMachine(deps.db, machineId, {
+              recoveryEncryptedPayload: encryptedRecoveryPayload,
+            });
+            await assertMachineProviderMutationAllowed(deps, existing, recoveryCreateInput.serverType, now());
+            try {
+              server = await deps.hetzner.createServer({
+                name: recoveryCreateInput.name,
+                serverType: recoveryCreateInput.serverType,
+                location: recoveryCreateInput.location,
+                userData: renderCloudInitTemplate(
+                  deps.cloudInitTemplate ?? DEFAULT_CLOUD_INIT_TEMPLATE,
+                  {
+                    ...hostConfig,
+                    imageSource: 'clean_image',
+                    targetBundleSha256: recoveryImage.targetBundleSha256,
+                    snapshotSourceVersion: '',
+                  },
+                ),
+                labels: {
+                  app: 'matrix-os', clerk_user_id: existing.clerkUserId, runtime_slot: existing.runtimeSlot,
+                  machine_id: machineId, image_source: 'clean_image',
+                },
+              });
+            } catch (fallbackCreateErr: unknown) {
+              createOutcomeAmbiguous = isAmbiguousProviderCreateError(fallbackCreateErr);
+              throw fallbackCreateErr;
+            }
+            newServerId = server.id;
+            if (server.createActionId !== undefined) {
+              const fallbackCreateResult = await waitForRecoveryCreateAction(server.createActionId);
+              if (fallbackCreateResult === 'error') {
+                throw new CustomerVpsError(500, 'provider_unavailable', 'Provisioning provider unavailable');
+              }
+              createPending = fallbackCreateResult === 'pending';
+            }
+          } else {
+            createPending = createResult === 'pending';
+          }
+        }
         await runInPlatformTransaction(deps.db, async (trx) => {
-          await updateUserMachine(trx, oldMachineId, {
-            machineId,
+          await updateUserMachine(trx, machineId, {
             status: 'recovering',
             hetznerServerId: server.id,
-            publicIPv4: server.publicIPv4,
-            publicIPv6: server.publicIPv6,
             imageVersion: bundleRef.imageVersion,
-            serverType: billingContext?.serverType ?? active.serverType ?? deps.config.serverType,
-            location: active.location ?? deps.config.location,
+            sourceSnapshotId: recoveryImage.imageSource === 'snapshot' ? recoveryImage.snapshotId : null,
+            sourceBaseGeneration: recoveryImage.imageSource === 'snapshot'
+              ? recoveryImage.sourceBaseGeneration
+              : null,
+            targetBundleVersion: recoveryImage.targetBundleVersion,
+            targetBundleSha256: recoveryImage.targetBundleSha256,
+            recoveryCreateActionId: createPending ? server.createActionId ?? null : null,
+            recoveryEncryptedPayload: encryptedRecoveryPayload,
+            recoveryOldServerId: oldServerId,
+            serverType: recoveryCreateInput.serverType,
+            location: recoveryCreateInput.location,
             registrationTokenHash: registration.hash,
             registrationTokenExpiresAt: registration.expiresAt,
             provisionedAt: currentTime.toISOString(),
@@ -1272,6 +2224,9 @@ export function createCustomerVpsService(deps: CustomerVpsServiceDeps): Customer
         });
       } catch (err: unknown) {
         const mapped = genericProviderError(err);
+        if (createOutcomeAmbiguous) {
+          throw mapped;
+        }
         if (newServerId !== null) {
           try {
             await deps.hetzner.deleteServer(newServerId);
@@ -1287,30 +2242,41 @@ export function createCustomerVpsService(deps: CustomerVpsServiceDeps): Customer
           }
         }
         try {
-          await updateUserMachine(deps.db, oldMachineId, {
-            status: 'failed',
-            failureCode: toFailureCode(err),
-            failureAt: now().toISOString(),
+          if (recoveryImage.imageSource === 'snapshot') {
+            await releaseGoldenSnapshotLease(deps.db, recoveryImage.snapshotLeaseId, now().toISOString());
+          }
+          await runInPlatformTransaction(deps.db, async (trx) => {
+            const recoveryRow = await getActiveUserMachineByClerkId(
+              trx, input.clerkUserId, active.runtimeSlot,
+            );
+            if (!recoveryRow || recoveryRow.status !== 'recovering') return;
+            await updateUserMachine(trx, recoveryRow.machineId, {
+              machineId: oldMachineId,
+              status: active.status,
+              hetznerServerId: active.hetznerServerId,
+              publicIPv4: active.publicIPv4,
+              publicIPv6: active.publicIPv6,
+              imageVersion: active.imageVersion,
+              sourceSnapshotId: active.sourceSnapshotId,
+              sourceBaseGeneration: active.sourceBaseGeneration,
+              targetBundleVersion: active.targetBundleVersion,
+              targetBundleSha256: active.targetBundleSha256,
+              recoveryCreateActionId: active.recoveryCreateActionId,
+              recoveryEncryptedPayload: active.recoveryEncryptedPayload,
+              recoveryOldServerId: active.recoveryOldServerId,
+              serverType: active.serverType,
+              registrationTokenHash: active.registrationTokenHash,
+              registrationTokenExpiresAt: active.registrationTokenExpiresAt,
+              provisionedAt: active.provisionedAt,
+              lastSeenAt: active.lastSeenAt,
+              failureCode: active.failureCode,
+              failureAt: active.failureAt,
+            });
           });
         } catch (statusErr: unknown) {
           logCustomerVpsError('recover failure status update failed', statusErr);
         }
         throw mapped;
-      }
-
-      if (oldServerId) {
-        try {
-          await deps.hetzner.deleteServer(oldServerId);
-        } catch (err: unknown) {
-          logCustomerVpsError('recover old server cleanup failed', err);
-          await queueProviderDeletion({
-            providerServerId: oldServerId,
-            reason: 'recover_old_server',
-            machineId: oldMachineId,
-            handle: existing.handle,
-            err,
-          });
-        }
       }
 
       return {
@@ -1338,7 +2304,7 @@ export function createCustomerVpsService(deps: CustomerVpsServiceDeps): Customer
         };
       }
 
-      await assertBillingResizeAllowed(deps, row.clerkUserId, row.runtimeSlot, input.serverType, now());
+      await assertMachineProviderMutationAllowed(deps, row, input.serverType, now());
       const claimed = await claimRunningUserMachineResize(
         deps.db,
         row.machineId,
@@ -1584,7 +2550,19 @@ export function createCustomerVpsService(deps: CustomerVpsServiceDeps): Customer
       );
       let failed = 0;
       let running = 0;
-      for (const row of rows) {
+      for (let row of rows) {
+        if (row.status === 'recovering') {
+          const recoveryCreate = await reconcilePendingRecoveryCreate(row);
+          if (recoveryCreate === 'pending') continue;
+          if (recoveryCreate === 'failed') {
+            failed += 1;
+            continue;
+          }
+          const refreshed = await getUserMachine(deps.db, row.machineId)
+            ?? await getActiveUserMachineByClerkId(deps.db, row.clerkUserId, row.runtimeSlot);
+          if (!refreshed) continue;
+          row = refreshed;
+        }
         if (!row.hetznerServerId) {
           await cleanupUntrackedServersForMachine(row);
           await updateUserMachine(deps.db, row.machineId, {

--- a/packages/platform/src/profile-routing.ts
+++ b/packages/platform/src/profile-routing.ts
@@ -8,6 +8,7 @@ const RESERVED_SUBDOMAINS = new Set(["www", "api", "admin", "mail", "ftp"]);
 export interface CustomerVpsProxyMachine {
   status: string;
   publicIPv4: string | null;
+  recoveryOldServerId?: number | null;
 }
 
 export const EntitlementStatusSchema = z.enum(['active', 'missing', 'expired', 'disabled', 'changed']);
@@ -41,9 +42,14 @@ export function buildCustomerVpsProxyUrl(
   path: string,
   queryString = "",
 ): string | null {
-  if (machine.status !== "running" || !machine.publicIPv4) return null;
+  if (!isCustomerVpsProxyMachineRoutable(machine) || !machine.publicIPv4) return null;
   const safePath = path.startsWith("/") ? path : `/${path}`;
   return `https://${machine.publicIPv4}:443${safePath}${queryString}`;
+}
+
+export function isCustomerVpsProxyMachineRoutable(machine: CustomerVpsProxyMachine): boolean {
+  return machine.status === "running"
+    || (machine.status === "recovering" && machine.recoveryOldServerId != null);
 }
 
 export function deriveEntitlementAccess(state: EntitlementState): EntitlementAccessDecision {

--- a/packages/platform/src/session-routing-middleware.ts
+++ b/packages/platform/src/session-routing-middleware.ts
@@ -19,6 +19,7 @@ import { canClerkUserAccessMachine } from './customer-vps-preview.js';
 import { issueSyncJwt } from './sync-jwt.js';
 import {
   buildCustomerVpsProxyUrl,
+  isCustomerVpsProxyMachineRoutable,
   type EntitlementAccessDecision,
 } from './profile-routing.js';
 import {
@@ -659,7 +660,7 @@ export function createSessionRoutingMiddleware(opts: CreateSessionRoutingMiddlew
         applyNoStoreHeaders(c);
         return c.json({ error: 'Paid beta access required' }, 402);
       }
-      if (machine.status !== 'running') {
+      if (!isCustomerVpsProxyMachineRoutable(machine) || machine.publicIPv4 === null) {
         if (isGatewayPath) {
           applyNoStoreHeaders(c);
           return c.json({
@@ -778,7 +779,9 @@ export function createSessionRoutingMiddleware(opts: CreateSessionRoutingMiddlew
       : await getRunningUserMachineByHandle(db, identity.handle);
     if (!runningMachine && identity.userId) {
       requestedActiveMachine = await getAccessibleActiveUserMachineByClerkId(db, identity.userId, runtimeSlot);
-      if (!requestedActiveMachine) {
+      if (requestedActiveMachine && isCustomerVpsProxyMachineRoutable(requestedActiveMachine)) {
+        runningMachine = requestedActiveMachine;
+      } else if (!requestedActiveMachine) {
         const handleMachine = await getRunningUserMachineByHandle(db, identity.handle);
         if (handleMachine && canClerkUserAccessMachine(handleMachine, identity.userId)) {
           runningMachine = handleMachine;

--- a/tests/platform/customer-vps-hetzner.test.ts
+++ b/tests/platform/customer-vps-hetzner.test.ts
@@ -53,6 +53,42 @@ describe('platform/customer-vps-hetzner', () => {
     }
   });
 
+  it('does not misclassify an unrelated HTTP 400 as a snapshot clone rejection', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    try {
+      const fetchImpl = vi.fn().mockResolvedValue(
+        new Response('{"error":{"code":"invalid_input","message":"invalid server name","details":{"fields":[{"name":"name","messages":["is invalid"]}]}}}', {
+          status: 400,
+        }),
+      );
+      const client = createHetznerClient(config, fetchImpl as unknown as typeof fetch);
+
+      await expect(client.createServer({ ...createInput, image: 302 })).rejects.toMatchObject({
+        code: 'provider_unavailable',
+      });
+    } finally {
+      consoleError.mockRestore();
+    }
+  });
+
+  it('classifies a bounded provider image-field rejection as a snapshot clone rejection', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    try {
+      const fetchImpl = vi.fn().mockResolvedValue(
+        new Response('{"error":{"code":"invalid_input","message":"invalid input","details":{"fields":[{"name":"image","messages":["is incompatible"]}]}}}', {
+          status: 422,
+        }),
+      );
+      const client = createHetznerClient(config, fetchImpl as unknown as typeof fetch);
+
+      await expect(client.createServer({ ...createInput, image: 302 })).rejects.toMatchObject({
+        code: 'snapshot_clone_rejected',
+      });
+    } finally {
+      consoleError.mockRestore();
+    }
+  });
+
   it('maps 429 to quota_exceeded without logging a rejection', async () => {
     const fetchImpl = vi.fn().mockResolvedValue(new Response('', { status: 429 }));
     const client = createHetznerClient(config, fetchImpl as unknown as typeof fetch);

--- a/tests/platform/customer-vps.test.ts
+++ b/tests/platform/customer-vps.test.ts
@@ -459,10 +459,32 @@ describe('platform/customer-vps', () => {
       name: 'matrix-pr-897',
       serverType: 'cpx22',
     });
-    expect(resolveBillingEntitlement).toHaveBeenCalledTimes(2);
+    // The customer primary is authorized at request, claim, and provider-mutation
+    // boundaries. Operator preview calls remain outside customer billing checks.
+    expect(resolveBillingEntitlement).toHaveBeenCalledTimes(3);
     await expect(getUserMachine(db, preview.machineId)).resolves.toMatchObject({
       provisioningClass: 'preview',
       accessClerkUserIds: ['user_789'],
+    });
+  });
+
+  it('keeps operator preview creation outside customer billing authorization', async () => {
+    const resolveBillingEntitlement = vi.fn().mockResolvedValue(null);
+    const { service, hetzner } = createService({
+      config: createTestConfig({ previewProvisioningLimit: 1 }),
+      resolveBillingEntitlement,
+    });
+
+    const preview = await service.provisionPreview({
+      clerkUserId: 'user_123',
+      handle: 'pr-899',
+      runtimeSlot: 'pr-899',
+    });
+    expect(preview).toMatchObject({ status: 'provisioning' });
+    expect(hetzner.createServer).toHaveBeenCalledOnce();
+    expect(resolveBillingEntitlement).not.toHaveBeenCalled();
+    await expect(getUserMachine(db, preview.machineId)).resolves.toMatchObject({
+      handle: 'pr-899', provisioningClass: 'preview',
     });
   });
 
@@ -692,14 +714,21 @@ describe('platform/customer-vps', () => {
 
   it('retires failed exact and legacy previews before retry capacity checks', async () => {
     let nextId = 0;
+    let nextProviderId = 123455;
     const ids = [
       '9f05824c-8d0a-4d83-9cb4-b312d43ff112',
       '721c3ef8-23f6-47e4-a890-6f6dc14759d1',
       '188d9ce1-395d-4d4c-a7b7-22754c3ab991',
     ];
+    const createServer = vi.fn(async () => ({
+      id: ++nextProviderId,
+      status: 'running',
+      publicIPv4: `203.0.113.${nextProviderId - 123400}`,
+    }));
     const { service, hetzner } = createService({
       config: createTestConfig({ previewProvisioningLimit: 1 }),
       machineIdFactory: () => ids[nextId++] ?? ids[2]!,
+      hetzner: createMockHetznerClient({ createServer }),
     });
 
     const failedExact = await service.provisionPreview({
@@ -1401,6 +1430,21 @@ describe('platform/customer-vps', () => {
     expect(systemStore.writtenMeta).toHaveLength(1);
   });
 
+  it('completes registration after an already-authorized create when entitlement later changes', async () => {
+    const resolveBillingEntitlement = vi.fn().mockResolvedValue(activeEntitlement());
+    const { service } = createService({ resolveBillingEntitlement });
+    const provisioned = await service.provision({ clerkUserId: 'user_123', handle: 'alice' });
+    resolveBillingEntitlement.mockResolvedValue(null);
+
+    await expect(service.register('registration-token', {
+      machineId: provisioned.machineId,
+      hetznerServerId: 123456,
+      publicIPv4: '203.0.113.10',
+      imageVersion: 'matrix-os-host-2026.04.26-1',
+      healthy: true,
+    })).resolves.toMatchObject({ registered: true, status: 'running' });
+  });
+
   it('returns a warning when registration metadata cannot be persisted', async () => {
     const { service } = createService({
       systemStore: createMockCustomerVpsSystemStore({
@@ -1618,7 +1662,7 @@ describe('platform/customer-vps', () => {
     expect(hetzner.deleteServer).not.toHaveBeenCalled();
   });
 
-  it('creates a replacement machine in recovering state from R2 preflight', async () => {
+  it('keeps the old server until the replacement from R2 preflight registers healthy', async () => {
     const machineIds = [
       '9f05824c-8d0a-4d83-9cb4-b312d43ff112',
       'f973bb98-2538-4f9f-a10d-1be5920a7bf7',
@@ -1663,6 +1707,17 @@ describe('platform/customer-vps', () => {
       runtimeSlot: 'primary',
       status: 'recovering',
     });
+    expect(hetzner.deleteServer).not.toHaveBeenCalledWith(123456);
+    await service.register('registration-token', {
+      machineId: recovered.machineId,
+      hetznerServerId: 789012,
+      publicIPv4: '203.0.113.11',
+      imageVersion: 'stable',
+      bundleSha256: '0'.repeat(64),
+      healthy: true,
+    });
+    expect(hetzner.deleteServer).not.toHaveBeenCalledWith(123456);
+    await service.reconcileProvisioning();
     expect(hetzner.deleteServer).toHaveBeenCalledWith(123456);
     expect(
       vi.mocked(hetzner.createServer).mock.invocationCallOrder[1],
@@ -1677,11 +1732,38 @@ describe('platform/customer-vps', () => {
     expect(row).toMatchObject({
       clerkUserId: 'user_123',
       handle: 'alice',
-      status: 'recovering',
+      status: 'running',
       hetznerServerId: 789012,
       publicIPv4: '203.0.113.11',
       location: 'hil',
     });
+    await expect(getUserMachine(db, provisioned.machineId)).resolves.toBeUndefined();
+  });
+
+  it('falls back to a clean image when recovery snapshot selection is unavailable', async () => {
+    const { service } = createService();
+    const provisioned = await service.provision({ clerkUserId: 'user_123', handle: 'alice' });
+    await service.register('registration-token', {
+      machineId: provisioned.machineId, hetznerServerId: 123456,
+      publicIPv4: '203.0.113.10', imageVersion: 'matrix-os-host-2026.04.26-1',
+    });
+    const enabled = loadCustomerVpsConfig({
+      GOLDEN_SNAPSHOTS_ENABLED: 'true', GOLDEN_SNAPSHOT_ROLLOUT_PERCENT: '100',
+      GOLDEN_SNAPSHOT_REGION: 'eu-central', PLATFORM_SECRET: 'platform-secret',
+    }).goldenSnapshots;
+    const { service: recoveryService, hetzner } = createService({
+      config: createTestConfig({ goldenSnapshots: enabled }),
+      machineIdFactory: () => 'f973bb98-2538-4f9f-a10d-1be5920a7bf7',
+      systemStore: createMockCustomerVpsSystemStore({ hasDbLatest: vi.fn().mockResolvedValue(true) }),
+    });
+
+    await expect(recoveryService.recover({ clerkUserId: 'user_123' })).resolves.toMatchObject({
+      oldMachineId: provisioned.machineId,
+      machineId: 'f973bb98-2538-4f9f-a10d-1be5920a7bf7',
+      status: 'recovering',
+    });
+    expect(hetzner.createServer).toHaveBeenCalledWith(expect.not.objectContaining({ image: expect.anything() }));
+    expect(vi.mocked(hetzner.createServer).mock.calls[0]![0].userData).toContain('MATRIX_IMAGE_SOURCE=clean_image');
     await expect(getUserMachine(db, provisioned.machineId)).resolves.toBeUndefined();
   });
 
@@ -1774,6 +1856,7 @@ describe('platform/customer-vps', () => {
   });
 
   it('queues failed old-server cleanup after recovery and retries it during reconciliation', async () => {
+    let currentNow = new Date('2026-04-26T12:00:00.000Z');
     const machineIds = [
       '9f05824c-8d0a-4d83-9cb4-b312d43ff112',
       'f973bb98-2538-4f9f-a10d-1be5920a7bf7',
@@ -1801,6 +1884,7 @@ describe('platform/customer-vps', () => {
         hasDbLatest: vi.fn().mockResolvedValue(true),
       }),
       machineIdFactory: () => machineIds.shift()!,
+      now: () => currentNow,
     });
     const provisioned = await service.provision({ clerkUserId: 'user_123', handle: 'alice' });
     await service.register('registration-token', {
@@ -1810,21 +1894,31 @@ describe('platform/customer-vps', () => {
       imageVersion: 'matrix-os-host-2026.04.26-1',
     });
 
-    await service.recover({ clerkUserId: 'user_123' });
+    const recovered = await service.recover({ clerkUserId: 'user_123' });
+    await service.register('registration-token', {
+      machineId: recovered.machineId,
+      hetznerServerId: 789012,
+      publicIPv4: '203.0.113.11',
+      imageVersion: 'stable',
+      bundleSha256: '0'.repeat(64),
+      healthy: true,
+    });
 
     const queued = await listPendingProviderDeletions(db, '2026-04-26T12:00:00.000Z', 10);
     expect(queued).toHaveLength(1);
     expect(queued[0]).toMatchObject({
       providerServerId: 123456,
       reason: 'recover_old_server',
-      machineId: provisioned.machineId,
+      machineId: recovered.machineId,
       handle: 'alice',
     });
 
     await service.reconcileProvisioning();
+    currentNow = new Date('2026-04-26T12:15:00.000Z');
+    await service.reconcileProvisioning();
 
     expect(deleteServer).toHaveBeenCalledTimes(2);
-    expect(await listPendingProviderDeletions(db, '2026-04-26T12:00:00.000Z', 10)).toHaveLength(0);
+    expect(await listPendingProviderDeletions(db, currentNow.toISOString(), 10)).toHaveLength(0);
   });
 
   it('rejects concurrent recover calls before creating a second replacement server', async () => {

--- a/tests/platform/golden-snapshot-provisioning.test.ts
+++ b/tests/platform/golden-snapshot-provisioning.test.ts
@@ -1,0 +1,964 @@
+import { readFile } from 'node:fs/promises';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  getUserMachine,
+  insertUserMachine,
+  parseNullableProviderActionId,
+  upsertHostBundleRelease,
+  type PlatformDB,
+} from '../../packages/platform/src/db.js';
+import { insertProvisioningJob, sealProvisioningPayload, getProvisioningJob } from '../../packages/platform/src/customer-vps-provisioning-jobs.js';
+import {
+  chooseProvisioningImage,
+  chooseRecoveryImage,
+  fallbackProvisioningImage,
+} from '../../packages/platform/src/golden-snapshot-activation.js';
+import {
+  advanceGoldenSnapshot,
+  claimGoldenSnapshotBuild,
+  createGoldenSnapshotCreateIntent,
+  enqueueGoldenSnapshotBuild,
+  markGoldenSnapshotReady,
+  recordGoldenSnapshotProviderImage,
+  retryGoldenSnapshotBuild,
+  revokeGoldenSnapshot,
+  updateGoldenSnapshotRolloutControl,
+} from '../../packages/platform/src/golden-snapshot-repository.js';
+import type { GoldenSnapshotRuntimeConfig } from '../../packages/platform/src/golden-snapshot-schema.js';
+import { createTestPlatformDb, destroyTestPlatformDb } from './platform-db-test-helper.js';
+import { createCustomerVpsService } from '../../packages/platform/src/customer-vps.js';
+import { loadCustomerVpsConfig } from '../../packages/platform/src/customer-vps-config.js';
+import { CustomerVpsError } from '../../packages/platform/src/customer-vps-errors.js';
+import { hashRegistrationToken } from '../../packages/platform/src/customer-vps-auth.js';
+import { createMockCustomerVpsSystemStore, createMockHetznerClient } from './customer-vps-fixtures.js';
+
+const compatibility = {
+  provider: 'hetzner' as const, architecture: 'x86' as const, region: 'eu-central', baseImage: 'ubuntu-24.04',
+  baseGeneration: 'ubuntu-24.04-v1', bootMode: 'bios' as const, activationAbi: 'host-v1', minimumDiskGb: 40,
+};
+const config: GoldenSnapshotRuntimeConfig = {
+  enabled: true, buildsEnabled: false, rolloutPercent: 100, compatibility,
+  maxBuildAttempts: 5, maxConcurrentBuilds: 2, buildLeaseMs: 300_000, provisioningLeaseMs: 600_000,
+  retentionLimit: 20, freshnessMaxAgeMs: 7 * 24 * 60 * 60 * 1000, reconciliationBatchSize: 25,
+  testModeTtlMs: 24 * 60 * 60 * 1000, auditRetentionMs: 90 * 24 * 60 * 60 * 1000,
+};
+
+describe('golden snapshot provisioning activation', () => {
+  let db: PlatformDB;
+  beforeEach(async () => {
+    ({ db } = await createTestPlatformDb());
+    for (const [version, day, sha] of [['v1', '01', '1'], ['v2', '02', '2']] as const) {
+      await upsertHostBundleRelease(db, {
+        version, gitCommit: sha.repeat(7), buildTime: `2026-07-${day}T00:00:00.000Z`,
+        bundleKey: `system-bundles/${version}/matrix-host-bundle.tar.gz`, checksumKey: null,
+        sha256: sha.repeat(64), size: 100, createdAt: `2026-07-${day}T00:00:00.000Z`,
+      });
+    }
+    await insertUserMachine(db, {
+      machineId: '30000000-0000-4000-8000-000000000001', clerkUserId: 'user_1', handle: 'alice',
+      runtimeSlot: 'primary', developerTools: [], status: 'provisioning', imageVersion: 'v2',
+      provisionedAt: '2026-07-03T00:00:00.000Z',
+    });
+    await insertProvisioningJob(db, {
+      jobId: '50000000-0000-4000-8000-000000000001',
+      machineId: '30000000-0000-4000-8000-000000000001',
+      encryptedPayload: sealProvisioningPayload({ registrationToken: 'registration-token', postgresPassword: 'postgres-password' }, 'platform-secret'),
+      availableAt: '2026-07-03T00:00:00.000Z', createdAt: '2026-07-03T00:00:00.000Z',
+    });
+    await db.executor.updateTable('provisioning_jobs').set({ status: 'running' })
+      .where('job_id', '=', '50000000-0000-4000-8000-000000000001').execute();
+  });
+  afterEach(async () => destroyTestPlatformDb(db));
+
+  async function readySnapshot(version: 'v1' | 'v2', imageId: number) {
+    const suffix = version === 'v1' ? '1' : '2';
+    const enqueued = await enqueueGoldenSnapshotBuild(db, {
+      bundleVersion: version, compatibility,
+      snapshotId: `10000000-0000-4000-8000-00000000000${suffix}`,
+      buildId: `20000000-0000-4000-8000-00000000000${suffix}`,
+      now: `2026-07-0${suffix}T01:00:00.000Z`,
+    });
+    const claimed = await claimGoldenSnapshotBuild(
+      db, enqueued.build.buildId, '2026-07-03T00:00:00.500Z', '2026-07-03T00:10:00.000Z', 5,
+    );
+    const fence = claimed!.leaseExpiresAt!;
+    await advanceGoldenSnapshot(db, enqueued.snapshot.snapshotId, enqueued.build.buildId, fence, 'candidate', 'building', '2026-07-03T00:00:01.000Z');
+    await advanceGoldenSnapshot(db, enqueued.snapshot.snapshotId, enqueued.build.buildId, fence, 'building', 'sanitizing', '2026-07-03T00:00:02.000Z');
+    await advanceGoldenSnapshot(db, enqueued.snapshot.snapshotId, enqueued.build.buildId, fence, 'sanitizing', 'validating', '2026-07-03T00:00:03.000Z');
+    await recordGoldenSnapshotProviderImage(db, enqueued.snapshot.snapshotId, {
+      buildId: enqueued.build.buildId, expectedLeaseExpiresAt: fence,
+      providerImageId: imageId, providerImageStatus: 'available', imageDiskGb: 40,
+      imageArchitecture: 'x86', now: '2026-07-03T00:00:04.000Z',
+    });
+    await db.executor.updateTable('golden_snapshot_builds').set({
+      phase: 'validation_boot', status: 'running', lease_expires_at: '2026-07-03T00:10:00.000Z',
+    }).where('build_id', '=', enqueued.build.buildId).execute();
+    await markGoldenSnapshotReady(db, enqueued.snapshot.snapshotId, enqueued.build.buildId, {
+      validationSummary: {
+        exactBundle: true, healthy: true, freshActivation: true, uniqueMachineId: true,
+        uniqueSshHostKey: true, forbiddenStateAbsent: true,
+      }, expectedLeaseExpiresAt: '2026-07-03T00:10:00.000Z', now: '2026-07-03T00:00:05.000Z',
+    });
+    return enqueued.snapshot.snapshotId;
+  }
+
+  it('atomically selects an exact snapshot, leases it, and persists durable activation provenance', async () => {
+    const snapshotId = await readySnapshot('v2', 302);
+    const selected = await chooseProvisioningImage(db, config, {
+      jobId: '50000000-0000-4000-8000-000000000001', machineId: '30000000-0000-4000-8000-000000000001',
+      targetBundleVersion: 'v2', serverType: 'cpx22', purpose: 'provision',
+      leaseId: '40000000-0000-4000-8000-000000000001', now: '2026-07-03T00:01:00.000Z',
+    });
+    expect(selected).toMatchObject({ imageSource: 'snapshot', providerImageId: 302, snapshotId, exact: true });
+    expect(await getProvisioningJob(db, '50000000-0000-4000-8000-000000000001')).toMatchObject({
+      imageSource: 'snapshot', snapshotId, snapshotLeaseId: '40000000-0000-4000-8000-000000000001',
+      targetBundleVersion: 'v2', targetBundleSha256: '2'.repeat(64), activationStep: 'creating',
+    });
+  });
+
+  it('links the provisioning job to its singleton create intent', async () => {
+    const snapshotId = await readySnapshot('v2', 302);
+    const leaseId = '40000000-0000-4000-8000-000000000001';
+    const intentId = '60000000-0000-4000-8000-000000000001';
+    const selected = await chooseProvisioningImage(db, config, {
+      jobId: '50000000-0000-4000-8000-000000000001',
+      machineId: '30000000-0000-4000-8000-000000000001',
+      targetBundleVersion: 'v2', serverType: 'cpx22', purpose: 'provision', leaseId,
+      now: '2026-07-03T00:01:00.000Z',
+    });
+    expect(selected).toMatchObject({ imageSource: 'snapshot', snapshotId, snapshotLeaseId: leaseId });
+
+    await expect(createGoldenSnapshotCreateIntent(db, {
+      intentId, snapshotId, leaseId, machineId: '30000000-0000-4000-8000-000000000001',
+      purpose: 'provision', rolloutGeneration: 1, now: '2026-07-03T00:02:00.000Z',
+    })).resolves.toMatchObject({ intentId });
+    await expect(createGoldenSnapshotCreateIntent(db, {
+      intentId: '60000000-0000-4000-8000-000000000002',
+      snapshotId, leaseId, machineId: '30000000-0000-4000-8000-000000000001',
+      purpose: 'provision', rolloutGeneration: 1, now: '2026-07-03T00:03:00.000Z',
+    })).resolves.toMatchObject({ intentId });
+    await expect(getProvisioningJob(db, '50000000-0000-4000-8000-000000000001'))
+      .resolves.toMatchObject({ snapshotCreateIntentId: intentId });
+  });
+
+  it('uses only a compatible older snapshot and records that exact update is required', async () => {
+    await readySnapshot('v1', 301);
+    const selected = await chooseProvisioningImage(db, config, {
+      jobId: '50000000-0000-4000-8000-000000000001', machineId: '30000000-0000-4000-8000-000000000001',
+      targetBundleVersion: 'v2', serverType: 'cpx22', purpose: 'provision',
+      leaseId: '40000000-0000-4000-8000-000000000001', now: '2026-07-03T00:01:00.000Z',
+    });
+    expect(selected).toMatchObject({ imageSource: 'snapshot', providerImageId: 301, exact: false, requiresExactUpdate: true });
+  });
+
+  it('never selects a snapshot outside the configured freshness window', async () => {
+    const snapshotId = await readySnapshot('v2', 302);
+    await db.executor.updateTable('golden_snapshots').set({
+      ready_at: '2026-06-01T00:00:00.000Z',
+    }).where('snapshot_id', '=', snapshotId).execute();
+
+    const selected = await chooseProvisioningImage(db, config, {
+      jobId: '50000000-0000-4000-8000-000000000001', machineId: '30000000-0000-4000-8000-000000000001',
+      targetBundleVersion: 'v2', serverType: 'cpx22', purpose: 'provision',
+      leaseId: '40000000-0000-4000-8000-000000000001', now: '2026-07-03T00:01:00.000Z',
+    });
+
+    expect(selected).toEqual({
+      imageSource: 'clean_image', targetBundleVersion: 'v2', targetBundleSha256: '2'.repeat(64),
+    });
+  });
+
+  it('falls back clean when a persisted snapshot decision expires before provisioning resumes', async () => {
+    await readySnapshot('v2', 302);
+    await chooseProvisioningImage(db, config, {
+      jobId: '50000000-0000-4000-8000-000000000001', machineId: '30000000-0000-4000-8000-000000000001',
+      targetBundleVersion: 'v2', serverType: 'cpx22', purpose: 'provision',
+      leaseId: '40000000-0000-4000-8000-000000000001', now: '2026-07-03T00:01:00.000Z',
+    });
+    await db.executor.updateTable('provisioning_jobs').set({
+      status: 'queued', lease_expires_at: null, available_at: '2026-07-20T00:00:00.000Z',
+      provider_create_action_id: 1700,
+    }).where('job_id', '=', '50000000-0000-4000-8000-000000000001').execute();
+    const createServer = vi.fn().mockResolvedValue({
+      id: 1201, status: 'running', publicIPv4: '203.0.113.201', createActionId: 1701,
+    });
+    const getAction = vi.fn().mockImplementation(async (actionId: number) => ({
+      id: actionId,
+      status: actionId === 1700 ? 'error' as const : 'success' as const,
+      command: 'create_server',
+    }));
+    const staleServer = {
+      id: 1200, status: 'running' as const, publicIPv4: '203.0.113.200',
+      labels: {
+        machine_id: '30000000-0000-4000-8000-000000000001',
+        snapshot_id: '10000000-0000-4000-8000-000000000002',
+      },
+    };
+    const deleteServer = vi.fn().mockResolvedValue(undefined);
+    const customerConfig = loadCustomerVpsConfig({
+      PLATFORM_SECRET: 'platform-secret', CUSTOMER_VPS_IMAGE_VERSION: 'v2',
+      MATRIX_HOST_BUNDLE_URL: 'https://bundles.example/system-bundles/v2/matrix-host-bundle.tar.gz',
+      GOLDEN_SNAPSHOTS_ENABLED: 'true', GOLDEN_SNAPSHOT_ROLLOUT_PERCENT: '100',
+      GOLDEN_SNAPSHOT_REGION: 'eu-central', HETZNER_SERVER_TYPE: 'cpx22',
+      GOLDEN_SNAPSHOT_FRESHNESS_MAX_AGE_MS: String(7 * 24 * 60 * 60 * 1000),
+      S3_ACCESS_KEY_ID: 'access-key', S3_SECRET_ACCESS_KEY: 'secret-key', S3_ENDPOINT: 'https://r2.example',
+    });
+    const service = createCustomerVpsService({
+      db, config: customerConfig, hetzner: createMockHetznerClient({
+        createServer, deleteServer, getAction,
+        listServersByLabel: vi.fn().mockResolvedValue([staleServer]),
+        getServer: vi.fn().mockResolvedValue(null),
+      }),
+      systemStore: createMockCustomerVpsSystemStore(),
+      now: () => new Date('2026-07-20T00:00:00.000Z'),
+    });
+
+    await expect(service.dispatchProvisioningJobs()).resolves.toMatchObject({ completed: 1, failed: 0 });
+    expect(deleteServer).toHaveBeenCalledWith(1200);
+    expect(createServer).toHaveBeenCalledWith(expect.not.objectContaining({ image: 302 }));
+    expect(getAction).toHaveBeenCalledWith(1701);
+    expect(getAction).not.toHaveBeenCalledWith(1700);
+    await expect(getProvisioningJob(db, '50000000-0000-4000-8000-000000000001')).resolves.toMatchObject({
+      imageSource: 'clean_image', fallbackReason: 'snapshot_stale', snapshotId: null, snapshotLeaseId: null,
+    });
+  });
+
+  it('falls back to clean image when disabled, incompatible, absent, or clone preparation fails', async () => {
+    const clean = await chooseProvisioningImage(db, { ...config, enabled: false }, {
+      jobId: '50000000-0000-4000-8000-000000000001', machineId: '30000000-0000-4000-8000-000000000001',
+      targetBundleVersion: 'v2', serverType: 'cpx22', purpose: 'provision',
+      leaseId: '40000000-0000-4000-8000-000000000001', now: '2026-07-03T00:01:00.000Z',
+    });
+    expect(clean).toEqual({ imageSource: 'clean_image', targetBundleVersion: 'v2', targetBundleSha256: '2'.repeat(64) });
+
+    await readySnapshot('v2', 302);
+    const snapshot = await db.executor.selectFrom('golden_snapshots').select('compatibility_key')
+      .where('provider_image_id', '=', 302).executeTakeFirstOrThrow();
+    await updateGoldenSnapshotRolloutControl(db, {
+      compatibilityKey: snapshot.compatibility_key,
+      enabled: true,
+      percentage: 100,
+      now: '2026-07-03T00:01:30.000Z',
+    });
+    const selected = await chooseProvisioningImage(db, config, {
+      jobId: '50000000-0000-4000-8000-000000000001', machineId: '30000000-0000-4000-8000-000000000001',
+      targetBundleVersion: 'v2', serverType: 'cpx22', purpose: 'provision',
+      leaseId: '40000000-0000-4000-8000-000000000001', now: '2026-07-03T00:02:00.000Z',
+    });
+    expect(selected.imageSource).toBe('snapshot');
+    await db.executor.updateTable('provisioning_jobs').set({ provider_create_action_id: 888 })
+      .where('job_id', '=', '50000000-0000-4000-8000-000000000001').execute();
+    await fallbackProvisioningImage(db, {
+      jobId: '50000000-0000-4000-8000-000000000001', reason: 'clone_rejected', now: '2026-07-03T00:03:00.000Z',
+    });
+    expect(await getProvisioningJob(db, '50000000-0000-4000-8000-000000000001')).toMatchObject({
+      imageSource: 'clean_image', snapshotId: null, snapshotLeaseId: null,
+      providerCreateActionId: null, activationStep: 'fallback_pending', fallbackReason: 'clone_rejected',
+    });
+  });
+
+  it('persists a clean decision when rollout is excluded and release metadata is missing', async () => {
+    await db.executor.deleteFrom('host_bundle_releases').where('version', '=', 'v2').execute();
+    const clean = await chooseProvisioningImage(db, { ...config, rolloutPercent: 0 }, {
+      jobId: '50000000-0000-4000-8000-000000000001',
+      machineId: '30000000-0000-4000-8000-000000000001',
+      targetBundleVersion: 'v2', serverType: 'cpx22', purpose: 'provision',
+      leaseId: '40000000-0000-4000-8000-000000000001', now: '2026-07-03T00:01:00.000Z',
+    });
+    expect(clean).toEqual({
+      imageSource: 'clean_image', targetBundleVersion: 'v2', targetBundleSha256: '0'.repeat(64),
+    });
+    expect(await getProvisioningJob(db, '50000000-0000-4000-8000-000000000001')).toMatchObject({
+      imageSource: 'clean_image', activationStep: 'creating', targetBundleVersion: 'v2',
+    });
+  });
+
+  it('keeps Postgres rollout authority after process-local defaults change', async () => {
+    await readySnapshot('v2', 329);
+    const input = {
+      jobId: '50000000-0000-4000-8000-000000000001',
+      machineId: '30000000-0000-4000-8000-000000000001',
+      targetBundleVersion: 'v2', serverType: 'cpx22', purpose: 'provision' as const,
+      leaseId: '40000000-0000-4000-8000-000000000029', now: '2026-07-03T00:01:00.000Z',
+    };
+    await expect(chooseProvisioningImage(db, { ...config, enabled: false, rolloutPercent: 0 }, input))
+      .resolves.toMatchObject({ imageSource: 'clean_image' });
+    await expect(chooseProvisioningImage(db, config, { ...input, now: '2026-07-03T00:02:00.000Z' }))
+      .resolves.toMatchObject({ imageSource: 'clean_image' });
+
+    const snapshot = await db.executor.selectFrom('golden_snapshots').select('compatibility_key')
+      .where('provider_image_id', '=', 329).executeTakeFirstOrThrow();
+    await updateGoldenSnapshotRolloutControl(db, {
+      compatibilityKey: snapshot.compatibility_key,
+      enabled: true,
+      percentage: 100,
+      now: '2026-07-03T00:03:00.000Z',
+    });
+    await expect(chooseProvisioningImage(db, config, { ...input, now: '2026-07-03T00:04:00.000Z' }))
+      .resolves.toMatchObject({ imageSource: 'snapshot', rolloutGeneration: 2 });
+  });
+
+  it('accepts metadata-free clean-image registration without treating the zero digest as provenance', async () => {
+    const machineId = '30000000-0000-4000-8000-000000000001';
+    await db.executor.deleteFrom('host_bundle_releases').where('version', '=', 'v2').execute();
+    await chooseProvisioningImage(db, { ...config, rolloutPercent: 0 }, {
+      jobId: '50000000-0000-4000-8000-000000000001', machineId,
+      targetBundleVersion: 'v2', serverType: 'cpx22', purpose: 'provision',
+      leaseId: '40000000-0000-4000-8000-000000000001', now: '2026-07-03T00:01:00.000Z',
+    });
+    await db.transaction(async (trx) => {
+      await trx.executor.updateTable('user_machines').set({
+        hetzner_server_id: 902,
+        registration_token_hash: hashRegistrationToken('metadata-free-token'),
+        registration_token_expires_at: '2026-07-03T01:00:00.000Z',
+      }).where('machine_id', '=', machineId).execute();
+      await trx.executor.updateTable('provisioning_jobs').set({ activation_step: 'created' })
+        .where('machine_id', '=', machineId).execute();
+    });
+    const service = createCustomerVpsService({
+      db,
+      config: loadCustomerVpsConfig({
+        PLATFORM_SECRET: 'platform-secret', CUSTOMER_VPS_IMAGE_VERSION: 'v2',
+        MATRIX_HOST_BUNDLE_URL: 'https://bundles.example/system-bundles/v2/matrix-host-bundle.tar.gz',
+        S3_ACCESS_KEY_ID: 'access-key', S3_SECRET_ACCESS_KEY: 'secret-key', S3_ENDPOINT: 'https://r2.example',
+      }),
+      hetzner: createMockHetznerClient(),
+      systemStore: createMockCustomerVpsSystemStore(),
+      now: () => new Date('2026-07-03T00:10:00.000Z'),
+    });
+
+    await expect(service.register('metadata-free-token', {
+      machineId, hetznerServerId: 902, publicIPv4: '203.0.113.92', imageVersion: 'v2',
+    })).resolves.toMatchObject({ registered: true, status: 'running' });
+  });
+
+  it('rejects a clean-image registration until exact target provenance and health match', async () => {
+    const machineId = '30000000-0000-4000-8000-000000000001';
+    await db.transaction(async (trx) => {
+      await trx.executor.updateTable('user_machines').set({
+        hetzner_server_id: 901,
+        registration_token_hash: hashRegistrationToken('clean-registration-token'),
+        registration_token_expires_at: '2026-07-03T01:00:00.000Z',
+      }).where('machine_id', '=', machineId).execute();
+      await trx.executor.updateTable('provisioning_jobs').set({
+        image_source: 'clean_image', target_bundle_version: 'v2',
+        target_bundle_sha256: '2'.repeat(64), activation_step: 'created',
+      }).where('machine_id', '=', machineId).execute();
+    });
+    const customerConfig = loadCustomerVpsConfig({
+      PLATFORM_SECRET: 'platform-secret', CUSTOMER_VPS_IMAGE_VERSION: 'v2',
+      MATRIX_HOST_BUNDLE_URL: 'https://bundles.example/system-bundles/v2/matrix-host-bundle.tar.gz',
+      S3_ACCESS_KEY_ID: 'access-key', S3_SECRET_ACCESS_KEY: 'secret-key', S3_ENDPOINT: 'https://r2.example',
+    });
+    const service = createCustomerVpsService({
+      db, config: customerConfig, hetzner: createMockHetznerClient(),
+      systemStore: createMockCustomerVpsSystemStore(),
+      now: () => new Date('2026-07-03T00:10:00.000Z'),
+    });
+    const register = (imageVersion: string, bundleSha256: string, healthy: boolean) =>
+      service.register('clean-registration-token', {
+        machineId, hetznerServerId: 901, publicIPv4: '203.0.113.91',
+        imageVersion, bundleSha256, healthy,
+      });
+
+    await expect(register('v1', '2'.repeat(64), true))
+      .rejects.toMatchObject({ status: 409, code: 'registration_rejected' });
+    await expect(register('v2', '1'.repeat(64), true))
+      .rejects.toMatchObject({ status: 409, code: 'registration_rejected' });
+    await expect(register('v2', '2'.repeat(64), false))
+      .rejects.toMatchObject({ status: 409, code: 'registration_rejected' });
+    await expect(getUserMachine(db, machineId)).resolves.toMatchObject({ status: 'provisioning' });
+    await expect(register('v2', '2'.repeat(64), true))
+      .resolves.toMatchObject({ registered: true, status: 'running' });
+  });
+
+  it('resets the bounded attempt budget for an explicit operator retry', async () => {
+    const enqueued = await enqueueGoldenSnapshotBuild(db, {
+      bundleVersion: 'v1', compatibility,
+      snapshotId: '10000000-0000-4000-8000-000000000008',
+      buildId: '20000000-0000-4000-8000-000000000008', now: '2026-07-03T00:00:00.000Z',
+    });
+    await db.executor.updateTable('golden_snapshots').set({ state: 'failed', failure_code: 'retry_exhausted' })
+      .where('snapshot_id', '=', enqueued.snapshot.snapshotId).execute();
+    await db.executor.updateTable('golden_snapshot_builds').set({
+      status: 'failed', phase: 'failed', attempts: config.maxBuildAttempts,
+      provider_builder_id: 801, provider_builder_action_id: 800, provider_snapshot_action_id: 802,
+      provider_validation_id: 803, provider_validation_action_id: 804,
+      callback_phase: 'validated', callback_token_hash: 'a'.repeat(64),
+      callback_expires_at: null, pending_operation: null,
+    }).where('build_id', '=', enqueued.build.buildId).execute();
+
+    expect(await retryGoldenSnapshotBuild(db, enqueued.build.buildId, '2026-07-03T00:10:00.000Z')).toBe(false);
+    const cleanup = await db.executor.selectFrom('golden_snapshot_cleanup')
+      .select(['cleanup_id', 'resource_type', 'provider_resource_id', 'reason'])
+      .orderBy('provider_resource_id').execute();
+    expect(cleanup.map(({ cleanup_id: _cleanupId, ...row }) => row)).toEqual([
+      { resource_type: 'builder_server', provider_resource_id: 801, reason: 'operator_retry' },
+      { resource_type: 'validation_server', provider_resource_id: 803, reason: 'operator_retry' },
+    ]);
+    await db.executor.updateTable('golden_snapshot_cleanup').set({
+      status: 'completed', completed_at: '2026-07-03T00:10:30.000Z', attempts: 1,
+    }).where('cleanup_id', 'in', cleanup.map((row) => row.cleanup_id)).execute();
+    expect(await retryGoldenSnapshotBuild(db, enqueued.build.buildId, '2026-07-03T00:11:00.000Z')).toBe(true);
+    expect(await db.executor.selectFrom('golden_snapshot_builds').select([
+      'status', 'phase', 'attempts', 'provider_builder_id', 'provider_snapshot_action_id',
+      'provider_builder_action_id',
+      'provider_validation_id', 'provider_validation_action_id', 'callback_phase',
+      'callback_token_hash', 'callback_expires_at', 'pending_operation',
+    ])
+      .where('build_id', '=', enqueued.build.buildId).executeTakeFirst()).toEqual({
+      status: 'queued', phase: 'requested', attempts: 0,
+      provider_builder_id: null, provider_builder_action_id: null, provider_snapshot_action_id: null,
+      provider_validation_id: null, provider_validation_action_id: null,
+      callback_phase: null, callback_token_hash: null, callback_expires_at: null,
+      pending_operation: null,
+    });
+    expect(await db.executor.selectFrom('golden_snapshot_cleanup')
+      .select('completed_at').where('build_id', '=', enqueued.build.buildId).execute())
+      .toEqual([{ completed_at: '2026-07-03T00:10:30.000Z' }, { completed_at: '2026-07-03T00:10:30.000Z' }]);
+  });
+
+  it('blocks operator retry until an ambiguous create has been reconciled', async () => {
+    const enqueued = await enqueueGoldenSnapshotBuild(db, {
+      bundleVersion: 'v1', compatibility,
+      snapshotId: '10000000-0000-4000-8000-000000000028',
+      buildId: '20000000-0000-4000-8000-000000000028', now: '2026-07-03T00:00:00.000Z',
+    });
+    const deadline = '2026-07-03T00:30:00.000Z';
+    await db.executor.updateTable('golden_snapshots').set({
+      state: 'failed', failure_code: 'provider_create_ambiguous',
+    }).where('snapshot_id', '=', enqueued.snapshot.snapshotId).execute();
+    await db.executor.updateTable('golden_snapshot_builds').set({
+      status: 'failed', phase: 'failed', attempts: config.maxBuildAttempts,
+      pending_operation: `builder:${enqueued.build.buildId}`, callback_expires_at: deadline,
+    }).where('build_id', '=', enqueued.build.buildId).execute();
+
+    await expect(retryGoldenSnapshotBuild(
+      db, enqueued.build.buildId, '2026-07-03T00:10:00.000Z',
+    )).resolves.toBe(false);
+    await expect(db.executor.selectFrom('golden_snapshot_builds')
+      .select(['status', 'pending_operation', 'callback_expires_at'])
+      .where('build_id', '=', enqueued.build.buildId).executeTakeFirstOrThrow()).resolves.toEqual({
+      status: 'failed',
+      pending_operation: `builder:${enqueued.build.buildId}`,
+      callback_expires_at: deadline,
+    });
+  });
+
+  it('coerces persisted recovery action BIGINT values to safe numbers', async () => {
+    expect(parseNullableProviderActionId('9004')).toBe(9004);
+    expect(parseNullableProviderActionId(null)).toBeNull();
+    expect(() => parseNullableProviderActionId('9007199254740992')).toThrow();
+
+    await db.executor.updateTable('user_machines').set({
+      recovery_create_action_id: 9004,
+    }).where('machine_id', '=', '30000000-0000-4000-8000-000000000001').execute();
+
+    const machine = await getUserMachine(db, '30000000-0000-4000-8000-000000000001');
+    expect(machine?.recoveryCreateActionId).toBe(9004);
+    expect(typeof machine?.recoveryCreateActionId).toBe('number');
+  });
+
+  it('locks a source generation and snapshot before its create intent during registration', async () => {
+    const source = await readFile(
+      new URL('../../packages/platform/src/customer-vps.ts', import.meta.url),
+      'utf8',
+    );
+    const registerStart = source.indexOf('async register(token, input)');
+    const transactionStart = source.indexOf('runInPlatformTransaction', registerStart);
+    const transactionEnd = source.indexOf('return { registered: true', transactionStart);
+    const registrationTransaction = source.slice(transactionStart, transactionEnd);
+    const generationLock = registrationTransaction.indexOf('pg_advisory_xact_lock');
+    const snapshotLock = registrationTransaction.indexOf("selectFrom('golden_snapshots')");
+    const intentLock = registrationTransaction.indexOf("selectFrom('golden_snapshot_create_intents')");
+
+    expect(generationLock).toBeGreaterThanOrEqual(0);
+    expect(snapshotLock).toBeGreaterThan(generationLock);
+    expect(intentLock).toBeGreaterThan(snapshotLock);
+  });
+
+  it('retries a quarantined image-less build only after exact cleanup completes', async () => {
+    const enqueued = await enqueueGoldenSnapshotBuild(db, {
+      bundleVersion: 'v1', compatibility,
+      snapshotId: '10000000-0000-4000-8000-000000000018',
+      buildId: '20000000-0000-4000-8000-000000000018', now: '2026-07-03T00:00:00.000Z',
+    });
+    await db.executor.updateTable('golden_snapshots').set({
+      state: 'quarantined', failure_code: 'builder_activation_services_ready_failed',
+      quarantined_at: '2026-07-03T00:05:00.000Z',
+    }).where('snapshot_id', '=', enqueued.snapshot.snapshotId).execute();
+    await db.executor.updateTable('golden_snapshot_builds').set({
+      status: 'failed', phase: 'failed', attempts: 1, provider_builder_id: 811,
+    }).where('build_id', '=', enqueued.build.buildId).execute();
+    await db.executor.insertInto('golden_snapshot_cleanup').values({
+      cleanup_id: '60000000-0000-4000-8000-000000000018',
+      snapshot_id: enqueued.snapshot.snapshotId, build_id: enqueued.build.buildId,
+      resource_type: 'builder_server', provider_resource_id: 811,
+      provenance_key: `build:${enqueued.build.buildId}:builder_server`,
+      reason: 'builder_activation_services_ready_failed', status: 'queued', attempts: 0,
+      next_attempt_at: '2026-07-03T00:05:00.000Z', lease_expires_at: null,
+      last_error_code: null, created_at: '2026-07-03T00:05:00.000Z',
+      completed_at: null,
+    }).execute();
+
+    expect(await retryGoldenSnapshotBuild(
+      db, enqueued.build.buildId, '2026-07-03T00:09:00.000Z',
+    )).toBe(false);
+    await db.executor.updateTable('golden_snapshot_cleanup').set({
+      status: 'completed', attempts: 1, completed_at: '2026-07-03T00:09:30.000Z',
+    }).where('cleanup_id', '=', '60000000-0000-4000-8000-000000000018').execute();
+    expect(await retryGoldenSnapshotBuild(
+      db, enqueued.build.buildId, '2026-07-03T00:10:00.000Z',
+    )).toBe(true);
+    expect(await db.executor.selectFrom('golden_snapshots').select('state')
+      .where('snapshot_id', '=', enqueued.snapshot.snapshotId).executeTakeFirst()).toEqual({ state: 'candidate' });
+    expect(await db.executor.selectFrom('golden_snapshot_cleanup').select('cleanup_id')
+      .where('snapshot_id', '=', enqueued.snapshot.snapshotId)
+      .where('completed_at', 'is', null).execute()).toEqual([]);
+  });
+
+  it('enforces exact bundle provenance when a snapshot recovery registers', async () => {
+    await readySnapshot('v1', 301);
+    const machineId = '30000000-0000-4000-8000-000000000009';
+    const decision = await chooseRecoveryImage(db, config, {
+      machineId, targetBundleVersion: 'v2', serverType: 'cpx22', purpose: 'recover',
+      leaseId: '40000000-0000-4000-8000-000000000009', now: '2026-07-03T00:01:00.000Z',
+    });
+    expect(decision.imageSource).toBe('snapshot');
+    if (decision.imageSource !== 'snapshot') throw new Error('expected snapshot recovery decision');
+    await insertUserMachine(db, {
+      machineId, clerkUserId: 'user_9', handle: 'recovered', runtimeSlot: 'primary',
+      developerTools: [], status: 'recovering', imageVersion: 'v2', hetznerServerId: 909,
+      registrationTokenHash: hashRegistrationToken('recovery-token'),
+      registrationTokenExpiresAt: '2026-07-03T01:00:00.000Z',
+      provisionedAt: '2026-07-03T00:02:00.000Z',
+    });
+    const customerConfig = loadCustomerVpsConfig({
+      PLATFORM_SECRET: 'platform-secret', CUSTOMER_VPS_IMAGE_VERSION: 'v2',
+      MATRIX_HOST_BUNDLE_URL: 'https://bundles.example/system-bundles/v2/matrix-host-bundle.tar.gz',
+      GOLDEN_SNAPSHOTS_ENABLED: 'true', GOLDEN_SNAPSHOT_ROLLOUT_PERCENT: '100',
+      GOLDEN_SNAPSHOT_REGION: 'eu-central', HETZNER_SERVER_TYPE: 'cpx22',
+      S3_ACCESS_KEY_ID: 'access-key', S3_SECRET_ACCESS_KEY: 'secret-key', S3_ENDPOINT: 'https://r2.example',
+    });
+    const service = createCustomerVpsService({
+      db, config: customerConfig, hetzner: createMockHetznerClient(),
+      systemStore: createMockCustomerVpsSystemStore(), now: () => new Date('2026-07-03T00:03:00.000Z'),
+    });
+
+    await expect(service.register('recovery-token', {
+      machineId, hetznerServerId: 909, publicIPv4: '203.0.113.19', imageVersion: 'v1',
+      bundleSha256: '1'.repeat(64), healthy: true,
+    })).rejects.toMatchObject({ status: 409, code: 'registration_rejected' });
+    expect((await db.executor.selectFrom('golden_snapshot_leases').select('released_at')
+      .where('machine_id', '=', machineId).executeTakeFirstOrThrow()).released_at).toBeNull();
+    await revokeGoldenSnapshot(
+      db, decision.snapshotId,
+      'operator_revoked', '2026-07-03T00:02:30.000Z',
+    );
+    await expect(service.register('recovery-token', {
+      machineId, hetznerServerId: 909, publicIPv4: '203.0.113.19', imageVersion: 'v2',
+      bundleSha256: '2'.repeat(64), healthy: true,
+    })).rejects.toMatchObject({ status: 409, code: 'registration_rejected' });
+    expect((await db.executor.selectFrom('golden_snapshot_leases').select('released_at')
+      .where('machine_id', '=', machineId).executeTakeFirstOrThrow()).released_at).toBeNull();
+  });
+
+  it('holds the leased exact image through create completion and releases it only after registration', async () => {
+    await readySnapshot('v2', 302);
+    let currentNow = new Date('2026-07-03T00:10:00.000Z');
+    let created = false;
+    const server = { id: 123456, status: 'running' as const, publicIPv4: '203.0.113.10', createActionId: 777,
+      labels: { machine_id: '30000000-0000-4000-8000-000000000002', snapshot_id: '10000000-0000-4000-8000-000000000002' } };
+    const getAction = vi.fn()
+      .mockResolvedValueOnce({ id: 777, status: 'running', command: 'create_server' })
+      .mockResolvedValueOnce({ id: 777, status: 'success', command: 'create_server' });
+    const hetzner = createMockHetznerClient({
+      createServer: vi.fn(async () => { created = true; return server; }),
+      listServersByLabel: vi.fn(async () => created ? [server] : []),
+      getAction,
+    });
+    const customerConfig = loadCustomerVpsConfig({
+      PLATFORM_SECRET: 'platform-secret', CUSTOMER_VPS_IMAGE_VERSION: 'v2',
+      MATRIX_HOST_BUNDLE_URL: 'https://bundles.example/system-bundles/v2/matrix-host-bundle.tar.gz',
+      GOLDEN_SNAPSHOTS_ENABLED: 'true', GOLDEN_SNAPSHOT_ROLLOUT_PERCENT: '100',
+      GOLDEN_SNAPSHOT_REGION: 'eu-central', HETZNER_SERVER_TYPE: 'cpx22',
+      S3_ACCESS_KEY_ID: 'access-key', S3_SECRET_ACCESS_KEY: 'secret-key', S3_ENDPOINT: 'https://r2.example',
+    });
+    const service = createCustomerVpsService({
+      db, config: customerConfig, hetzner, systemStore: createMockCustomerVpsSystemStore(),
+      machineIdFactory: () => '30000000-0000-4000-8000-000000000002',
+      provisioningJobIdFactory: () => '50000000-0000-4000-8000-000000000002',
+      now: () => currentNow,
+    });
+
+    await service.provision({ clerkUserId: 'user_2', handle: 'bob', runtimeSlot: 'primary' });
+
+    expect(hetzner.createServer).toHaveBeenCalledWith(expect.objectContaining({ image: 302 }));
+    expect(await getProvisioningJob(db, '50000000-0000-4000-8000-000000000002')).toMatchObject({
+      status: 'running', imageSource: 'snapshot', providerCreateActionId: 777,
+    });
+    expect((await db.executor.selectFrom('golden_snapshot_leases').selectAll()
+      .where('machine_id', '=', '30000000-0000-4000-8000-000000000002').executeTakeFirstOrThrow()).released_at).toBeNull();
+
+    currentNow = new Date('2026-07-03T00:20:01.000Z');
+    await service.reconcileProvisioning();
+    expect(await getProvisioningJob(db, '50000000-0000-4000-8000-000000000002')).toMatchObject({
+      status: 'completed', imageSource: 'snapshot', activationStep: 'created',
+    });
+    const lease = await db.executor.selectFrom('golden_snapshot_leases').selectAll()
+      .where('machine_id', '=', '30000000-0000-4000-8000-000000000002').executeTakeFirstOrThrow();
+    expect(lease.released_at).toBeNull();
+    expect(getAction).toHaveBeenCalledTimes(2);
+    await db.executor.updateTable('user_machines').set({
+      registration_token_hash: hashRegistrationToken('registration-token'),
+      registration_token_expires_at: '2026-07-03T00:30:00.000Z',
+    }).where('machine_id', '=', '30000000-0000-4000-8000-000000000002').execute();
+    await expect(service.register('registration-token', {
+      machineId: '30000000-0000-4000-8000-000000000002', hetznerServerId: 123456,
+      publicIPv4: '203.0.113.10', imageVersion: 'v2',
+    })).rejects.toMatchObject({ status: 409, code: 'registration_rejected' });
+    await expect(service.register('registration-token', {
+      machineId: '30000000-0000-4000-8000-000000000002', hetznerServerId: 123456,
+      publicIPv4: '203.0.113.10', imageVersion: 'v2', bundleSha256: '2'.repeat(64), healthy: true,
+    })).resolves.toMatchObject({ registered: true, status: 'running' });
+    expect((await db.executor.selectFrom('golden_snapshot_leases').select('released_at')
+      .where('machine_id', '=', '30000000-0000-4000-8000-000000000002').executeTakeFirstOrThrow()).released_at)
+      .toBe('2026-07-03T00:20:01.000Z');
+    expect(await getUserMachine(db, '30000000-0000-4000-8000-000000000002')).toMatchObject({
+      sourceSnapshotId: '10000000-0000-4000-8000-000000000002',
+      sourceBaseGeneration: 'ubuntu-24.04-v1',
+      targetBundleVersion: 'v2',
+      targetBundleSha256: '2'.repeat(64),
+    });
+  });
+
+  it('accepts registration idempotently when a concurrent request already activated the create intent', async () => {
+    await readySnapshot('v2', 302);
+    const machineId = '30000000-0000-4000-8000-000000000022';
+    const jobId = '50000000-0000-4000-8000-000000000022';
+    const service = createCustomerVpsService({
+      db,
+      config: loadCustomerVpsConfig({
+        PLATFORM_SECRET: 'platform-secret', CUSTOMER_VPS_IMAGE_VERSION: 'v2',
+        MATRIX_HOST_BUNDLE_URL: 'https://bundles.example/system-bundles/v2/matrix-host-bundle.tar.gz',
+        GOLDEN_SNAPSHOTS_ENABLED: 'true', GOLDEN_SNAPSHOT_ROLLOUT_PERCENT: '100',
+        GOLDEN_SNAPSHOT_REGION: 'eu-central', HETZNER_SERVER_TYPE: 'cpx22',
+        S3_ACCESS_KEY_ID: 'access-key', S3_SECRET_ACCESS_KEY: 'secret-key', S3_ENDPOINT: 'https://r2.example',
+      }),
+      hetzner: createMockHetznerClient({
+        createServer: vi.fn().mockResolvedValue({
+          id: 1022, status: 'running', publicIPv4: '203.0.113.122',
+          labels: { machine_id: machineId, snapshot_id: '10000000-0000-4000-8000-000000000002' },
+        }),
+      }),
+      systemStore: createMockCustomerVpsSystemStore(),
+      machineIdFactory: () => machineId,
+      provisioningJobIdFactory: () => jobId,
+      tokenFactory: () => ({
+        token: 'concurrent-registration-token', hash: hashRegistrationToken('concurrent-registration-token'),
+        expiresAt: '2026-07-03T01:00:00.000Z',
+      }),
+      now: () => new Date('2026-07-03T00:20:00.000Z'),
+    });
+
+    await service.provision({ clerkUserId: 'user_22', handle: 'concurrent', runtimeSlot: 'primary' });
+    await db.executor.updateTable('golden_snapshot_create_intents').set({ state: 'activated' })
+      .where('machine_id', '=', machineId).execute();
+
+    await expect(service.register('concurrent-registration-token', {
+      machineId, hetznerServerId: 1022, publicIPv4: '203.0.113.122', imageVersion: 'v2',
+      bundleSha256: '2'.repeat(64), healthy: true,
+    })).resolves.toMatchObject({ registered: true, status: 'running' });
+  });
+
+  it('preserves the requested location when a rejected snapshot clone falls back synchronously', async () => {
+    await readySnapshot('v2', 302);
+    const createServer = vi.fn()
+      .mockRejectedValueOnce(new CustomerVpsError(500, 'snapshot_clone_rejected', 'Provisioning provider unavailable'))
+      .mockResolvedValueOnce({ id: 123459, status: 'running', publicIPv4: '203.0.113.13' });
+    const customerConfig = loadCustomerVpsConfig({
+      PLATFORM_SECRET: 'platform-secret', CUSTOMER_VPS_IMAGE_VERSION: 'v2',
+      MATRIX_HOST_BUNDLE_URL: 'https://bundles.example/system-bundles/v2/matrix-host-bundle.tar.gz',
+      GOLDEN_SNAPSHOTS_ENABLED: 'true', GOLDEN_SNAPSHOT_ROLLOUT_PERCENT: '100',
+      GOLDEN_SNAPSHOT_REGION: 'eu-central', HETZNER_SERVER_TYPE: 'cpx22', HETZNER_LOCATION: 'nbg1',
+      S3_ACCESS_KEY_ID: 'access-key', S3_SECRET_ACCESS_KEY: 'secret-key', S3_ENDPOINT: 'https://r2.example',
+    });
+    const service = createCustomerVpsService({
+      db, config: customerConfig,
+      hetzner: createMockHetznerClient({ createServer }),
+      systemStore: createMockCustomerVpsSystemStore(),
+      machineIdFactory: () => '30000000-0000-4000-8000-000000000003',
+      provisioningJobIdFactory: () => '50000000-0000-4000-8000-000000000003',
+      now: () => new Date('2026-07-03T00:10:00.000Z'),
+    });
+
+    await service.provision({ clerkUserId: 'user_3', handle: 'carol', location: 'hil' });
+
+    expect(createServer).toHaveBeenNthCalledWith(1, expect.objectContaining({ image: 302, location: 'hil' }));
+    expect(createServer).toHaveBeenNthCalledWith(2, expect.objectContaining({ location: 'hil' }));
+  });
+
+  it('settles a running snapshot job when the clone registers before action reconciliation', async () => {
+    await readySnapshot('v2', 302);
+    const machineId = '30000000-0000-4000-8000-000000000010';
+    const jobId = '50000000-0000-4000-8000-000000000010';
+    const server = {
+      id: 1010, status: 'running' as const, publicIPv4: '203.0.113.110', createActionId: 1710,
+      labels: { machine_id: machineId, snapshot_id: '10000000-0000-4000-8000-000000000002' },
+    };
+    const customerConfig = loadCustomerVpsConfig({
+      PLATFORM_SECRET: 'platform-secret', CUSTOMER_VPS_IMAGE_VERSION: 'v2',
+      MATRIX_HOST_BUNDLE_URL: 'https://bundles.example/system-bundles/v2/matrix-host-bundle.tar.gz',
+      GOLDEN_SNAPSHOTS_ENABLED: 'true', GOLDEN_SNAPSHOT_ROLLOUT_PERCENT: '100',
+      GOLDEN_SNAPSHOT_REGION: 'eu-central', HETZNER_SERVER_TYPE: 'cpx22',
+      S3_ACCESS_KEY_ID: 'access-key', S3_SECRET_ACCESS_KEY: 'secret-key', S3_ENDPOINT: 'https://r2.example',
+    });
+    let resolveCreateAction!: (value: { id: number; status: 'success'; command: string }) => void;
+    const getAction = vi.fn(() => new Promise<{ id: number; status: 'success'; command: string }>((resolve) => {
+      resolveCreateAction = resolve;
+    }));
+    const deleteServer = vi.fn().mockResolvedValue(undefined);
+    const service = createCustomerVpsService({
+      db, config: customerConfig,
+      hetzner: createMockHetznerClient({
+        createServer: vi.fn().mockResolvedValue(server),
+        listServersByLabel: vi.fn().mockResolvedValue([]),
+        getAction,
+        deleteServer,
+      }),
+      systemStore: createMockCustomerVpsSystemStore(),
+      machineIdFactory: () => machineId,
+      provisioningJobIdFactory: () => jobId,
+      tokenFactory: () => ({
+        token: 'early-registration-token',
+        hash: hashRegistrationToken('early-registration-token'),
+        expiresAt: '2026-07-03T01:00:00.000Z',
+      }),
+      now: () => new Date('2026-07-03T00:10:00.000Z'),
+    });
+
+    const provisionPromise = service.provision({ clerkUserId: 'user_10', handle: 'early', runtimeSlot: 'primary' });
+    await vi.waitFor(() => expect(getAction).toHaveBeenCalledTimes(1));
+    expect(await getProvisioningJob(db, jobId)).toMatchObject({ status: 'running', activationStep: 'creating' });
+    await expect(service.register('early-registration-token', {
+      machineId, hetznerServerId: 1010, publicIPv4: '203.0.113.110', imageVersion: 'v2',
+      bundleSha256: '2'.repeat(64), healthy: true,
+    })).resolves.toMatchObject({ registered: true, status: 'running' });
+    expect(await getProvisioningJob(db, jobId)).toMatchObject({ status: 'completed', activationStep: 'registered' });
+    expect((await db.executor.selectFrom('golden_snapshot_leases').select('released_at')
+      .where('machine_id', '=', machineId).executeTakeFirstOrThrow()).released_at)
+      .toBe('2026-07-03T00:10:00.000Z');
+    resolveCreateAction({ id: 1710, status: 'success', command: 'create_server' });
+    await expect(provisionPromise).resolves.toMatchObject({ machineId });
+    expect(deleteServer).not.toHaveBeenCalledWith(1010);
+    await expect(getUserMachine(db, machineId)).resolves.toMatchObject({ status: 'running' });
+  });
+
+  it('persists clean fallback before waiting for a rejected clone to disappear', async () => {
+    await readySnapshot('v2', 302);
+    const machineId = '30000000-0000-4000-8000-000000000011';
+    const jobId = '50000000-0000-4000-8000-000000000011';
+    const server = {
+      id: 1011, status: 'running' as const, publicIPv4: '203.0.113.111', createActionId: 1711,
+      labels: { machine_id: machineId, snapshot_id: '10000000-0000-4000-8000-000000000002' },
+    };
+    const customerConfig = loadCustomerVpsConfig({
+      PLATFORM_SECRET: 'platform-secret', CUSTOMER_VPS_IMAGE_VERSION: 'v2',
+      MATRIX_HOST_BUNDLE_URL: 'https://bundles.example/system-bundles/v2/matrix-host-bundle.tar.gz',
+      GOLDEN_SNAPSHOTS_ENABLED: 'true', GOLDEN_SNAPSHOT_ROLLOUT_PERCENT: '100',
+      GOLDEN_SNAPSHOT_REGION: 'eu-central', HETZNER_SERVER_TYPE: 'cpx22',
+      S3_ACCESS_KEY_ID: 'access-key', S3_SECRET_ACCESS_KEY: 'secret-key', S3_ENDPOINT: 'https://r2.example',
+    });
+    const service = createCustomerVpsService({
+      db, config: customerConfig,
+      hetzner: createMockHetznerClient({
+        createServer: vi.fn().mockResolvedValue(server),
+        listServersByLabel: vi.fn().mockResolvedValue([]),
+        getAction: vi.fn().mockResolvedValue({ id: 1711, status: 'error', command: 'create_server' }),
+        getServer: vi.fn().mockResolvedValue(server),
+      }),
+      systemStore: createMockCustomerVpsSystemStore(), machineIdFactory: () => machineId,
+      provisioningJobIdFactory: () => jobId, now: () => new Date('2026-07-03T00:10:00.000Z'),
+    });
+
+    await service.provision({ clerkUserId: 'user_11', handle: 'fallback', runtimeSlot: 'primary' });
+    expect(await getProvisioningJob(db, jobId)).toMatchObject({
+      status: 'running', imageSource: 'clean_image', providerCreateActionId: null,
+      activationStep: 'fallback_pending', fallbackReason: 'clone_rejected',
+    });
+  });
+
+  it('uses clean Ubuntu after a definite snapshot clone rejection without masking ambiguous failures', async () => {
+    await readySnapshot('v2', 302);
+    const createServer = vi.fn()
+      .mockRejectedValueOnce(new CustomerVpsError(500, 'snapshot_clone_rejected', 'Provisioning provider unavailable'))
+      .mockResolvedValueOnce({ id: 123456, status: 'running', publicIPv4: '203.0.113.10' });
+    const hetzner = createMockHetznerClient({ createServer });
+    const customerConfig = loadCustomerVpsConfig({
+      PLATFORM_SECRET: 'platform-secret', CUSTOMER_VPS_IMAGE_VERSION: 'v2',
+      MATRIX_HOST_BUNDLE_URL: 'https://bundles.example/system-bundles/v2/matrix-host-bundle.tar.gz',
+      GOLDEN_SNAPSHOTS_ENABLED: 'true', GOLDEN_SNAPSHOT_ROLLOUT_PERCENT: '100',
+      GOLDEN_SNAPSHOT_REGION: 'eu-central', HETZNER_SERVER_TYPE: 'cpx22',
+      S3_ACCESS_KEY_ID: 'access-key', S3_SECRET_ACCESS_KEY: 'secret-key', S3_ENDPOINT: 'https://r2.example',
+    });
+    const service = createCustomerVpsService({
+      db, config: customerConfig, hetzner, systemStore: createMockCustomerVpsSystemStore(),
+      machineIdFactory: () => '30000000-0000-4000-8000-000000000003',
+      provisioningJobIdFactory: () => '50000000-0000-4000-8000-000000000003',
+      now: () => new Date('2026-07-03T00:20:00.000Z'),
+    });
+
+    await service.provision({ clerkUserId: 'user_3', handle: 'carol', runtimeSlot: 'primary' });
+    expect(createServer).toHaveBeenNthCalledWith(1, expect.objectContaining({ image: 302 }));
+    expect(createServer).toHaveBeenNthCalledWith(2, expect.not.objectContaining({ image: expect.anything() }));
+    const snapshotUserData = createServer.mock.calls[0]![0].userData;
+    const fallbackUserData = createServer.mock.calls[1]![0].userData;
+    expect(snapshotUserData).toContain('MATRIX_IMAGE_SOURCE=snapshot');
+    expect(fallbackUserData).toContain('MATRIX_IMAGE_SOURCE=clean_image');
+    expect(fallbackUserData).toContain('MATRIX_SNAPSHOT_SOURCE_VERSION=');
+    expect(fallbackUserData).not.toContain('MATRIX_IMAGE_SOURCE=snapshot');
+    expect(await getProvisioningJob(db, '50000000-0000-4000-8000-000000000003')).toMatchObject({
+      status: 'completed', imageSource: 'clean_image', fallbackReason: 'clone_rejected',
+    });
+  });
+
+  it('records clean fallback creation while the provider action is still running', async () => {
+    await readySnapshot('v2', 302);
+    const machineId = '30000000-0000-4000-8000-000000000023';
+    const jobId = '50000000-0000-4000-8000-000000000023';
+    const createServer = vi.fn()
+      .mockRejectedValueOnce(new CustomerVpsError(
+        500, 'snapshot_clone_rejected', 'Provisioning provider unavailable',
+      ))
+      .mockResolvedValueOnce({
+        id: 1023, status: 'initializing', publicIPv4: '203.0.113.123', createActionId: 1723,
+      });
+    const service = createCustomerVpsService({
+      db,
+      config: loadCustomerVpsConfig({
+        PLATFORM_SECRET: 'platform-secret', CUSTOMER_VPS_IMAGE_VERSION: 'v2',
+        MATRIX_HOST_BUNDLE_URL: 'https://bundles.example/system-bundles/v2/matrix-host-bundle.tar.gz',
+        GOLDEN_SNAPSHOTS_ENABLED: 'true', GOLDEN_SNAPSHOT_ROLLOUT_PERCENT: '100',
+        GOLDEN_SNAPSHOT_REGION: 'eu-central', HETZNER_SERVER_TYPE: 'cpx22',
+        S3_ACCESS_KEY_ID: 'access-key', S3_SECRET_ACCESS_KEY: 'secret-key', S3_ENDPOINT: 'https://r2.example',
+      }),
+      hetzner: createMockHetznerClient({
+        createServer,
+        getAction: vi.fn().mockResolvedValue({ id: 1723, status: 'running', command: 'create_server' }),
+      }),
+      systemStore: createMockCustomerVpsSystemStore(),
+      machineIdFactory: () => machineId,
+      provisioningJobIdFactory: () => jobId,
+      now: () => new Date('2026-07-03T00:20:00.000Z'),
+    });
+
+    await service.provision({ clerkUserId: 'user_23', handle: 'fallback-running', runtimeSlot: 'primary' });
+
+    await expect(getProvisioningJob(db, jobId)).resolves.toMatchObject({
+      status: 'running', imageSource: 'clean_image', activationStep: 'creating',
+      providerCreateActionId: 1723, fallbackReason: 'clone_rejected',
+    });
+  });
+
+  it('keeps an ambiguous snapshot create pending and adopts the exact labeled server on retry', async () => {
+    await readySnapshot('v2', 302);
+    const machineId = '30000000-0000-4000-8000-000000000012';
+    const jobId = '50000000-0000-4000-8000-000000000012';
+    let adoptedStatus: 'initializing' | 'running' = 'initializing';
+    const adoptedServer = () => ({
+      id: 1012,
+      status: adoptedStatus,
+      publicIPv4: '203.0.113.112',
+      labels: {
+        machine_id: machineId,
+        snapshot_id: '10000000-0000-4000-8000-000000000002',
+      },
+    });
+    let currentNow = new Date('2026-07-03T00:20:00.000Z');
+    let lookupCount = 0;
+    const createServer = vi.fn().mockRejectedValue(new Error('provider response lost'));
+    const customerConfig = loadCustomerVpsConfig({
+      PLATFORM_SECRET: 'platform-secret', CUSTOMER_VPS_IMAGE_VERSION: 'v2',
+      MATRIX_HOST_BUNDLE_URL: 'https://bundles.example/system-bundles/v2/matrix-host-bundle.tar.gz',
+      GOLDEN_SNAPSHOTS_ENABLED: 'true', GOLDEN_SNAPSHOT_ROLLOUT_PERCENT: '100',
+      GOLDEN_SNAPSHOT_REGION: 'eu-central', HETZNER_SERVER_TYPE: 'cpx22',
+      S3_ACCESS_KEY_ID: 'access-key', S3_SECRET_ACCESS_KEY: 'secret-key', S3_ENDPOINT: 'https://r2.example',
+    });
+    const service = createCustomerVpsService({
+      db, config: customerConfig,
+      hetzner: createMockHetznerClient({
+        createServer,
+        listServersByLabel: vi.fn(async () => (++lookupCount === 1 ? [] : [adoptedServer()])),
+      }),
+      systemStore: createMockCustomerVpsSystemStore(),
+      machineIdFactory: () => machineId,
+      provisioningJobIdFactory: () => jobId,
+      now: () => currentNow,
+    });
+
+    await service.provision({ clerkUserId: 'user_12', handle: 'ambiguous', runtimeSlot: 'primary' });
+    await expect(getProvisioningJob(db, jobId)).resolves.toMatchObject({
+      status: 'running', imageSource: 'snapshot', activationStep: 'creating',
+    });
+    await expect(getUserMachine(db, machineId)).resolves.toMatchObject({ status: 'provisioning' });
+
+    currentNow = new Date('2026-07-03T00:26:00.000Z');
+    await expect(service.dispatchProvisioningJobs()).resolves.toMatchObject({ completed: 0, failed: 0 });
+    await expect(getProvisioningJob(db, jobId)).resolves.toMatchObject({
+      status: 'running', activationStep: 'creating',
+    });
+    adoptedStatus = 'running';
+    currentNow = new Date('2026-07-03T00:32:00.000Z');
+    await expect(service.dispatchProvisioningJobs()).resolves.toMatchObject({ completed: 1, failed: 0 });
+    expect(createServer).toHaveBeenCalledTimes(1);
+    await expect(getProvisioningJob(db, jobId)).resolves.toMatchObject({ status: 'completed' });
+    await expect(getUserMachine(db, machineId)).resolves.toMatchObject({ hetznerServerId: 1012 });
+  });
+
+  it('keeps an ambiguous clean fallback create pending and adopts it without a third create', async () => {
+    await readySnapshot('v2', 302);
+    const machineId = '30000000-0000-4000-8000-000000000013';
+    const jobId = '50000000-0000-4000-8000-000000000013';
+    const adoptedServer = {
+      id: 1013,
+      status: 'running' as const,
+      publicIPv4: '203.0.113.113',
+      labels: { machine_id: machineId },
+    };
+    let currentNow = new Date('2026-07-03T00:20:00.000Z');
+    let lookupCount = 0;
+    const createServer = vi.fn()
+      .mockRejectedValueOnce(new CustomerVpsError(
+        500, 'snapshot_clone_rejected', 'Provisioning provider unavailable',
+      ))
+      .mockRejectedValueOnce(new Error('clean provider response lost'));
+    const service = createCustomerVpsService({
+      db,
+      config: loadCustomerVpsConfig({
+        PLATFORM_SECRET: 'platform-secret', CUSTOMER_VPS_IMAGE_VERSION: 'v2',
+        MATRIX_HOST_BUNDLE_URL: 'https://bundles.example/system-bundles/v2/matrix-host-bundle.tar.gz',
+        GOLDEN_SNAPSHOTS_ENABLED: 'true', GOLDEN_SNAPSHOT_ROLLOUT_PERCENT: '100',
+        GOLDEN_SNAPSHOT_REGION: 'eu-central', HETZNER_SERVER_TYPE: 'cpx22',
+        S3_ACCESS_KEY_ID: 'access-key', S3_SECRET_ACCESS_KEY: 'secret-key', S3_ENDPOINT: 'https://r2.example',
+      }),
+      hetzner: createMockHetznerClient({
+        createServer,
+        listServersByLabel: vi.fn(async () => (++lookupCount === 1 ? [] : [adoptedServer])),
+      }),
+      systemStore: createMockCustomerVpsSystemStore(),
+      machineIdFactory: () => machineId,
+      provisioningJobIdFactory: () => jobId,
+      now: () => currentNow,
+    });
+
+    await service.provision({ clerkUserId: 'user_13', handle: 'clean-ambiguous', runtimeSlot: 'primary' });
+    await expect(getProvisioningJob(db, jobId)).resolves.toMatchObject({
+      status: 'running', imageSource: 'clean_image', activationStep: 'fallback_pending',
+    });
+
+    currentNow = new Date('2026-07-03T00:26:00.000Z');
+    await expect(service.dispatchProvisioningJobs()).resolves.toMatchObject({ completed: 1, failed: 0 });
+    expect(createServer).toHaveBeenCalledTimes(2);
+    await expect(getUserMachine(db, machineId)).resolves.toMatchObject({ hetznerServerId: 1013 });
+  });
+});

--- a/tests/platform/proxy-routing.test.ts
+++ b/tests/platform/proxy-routing.test.ts
@@ -344,6 +344,47 @@ describe("platform proxy routing", () => {
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
+  it("keeps routing to the healthy predecessor while a recovery replacement is unregistered", async () => {
+    process.env.PLATFORM_JWT_SECRET = JWT_SECRET;
+    await deleteContainer(db, "alice");
+    await insertUserMachine(db, {
+      machineId: "9f05824c-8d0a-4d83-9cb4-b312d43ff202",
+      clerkUserId: "user_alice",
+      handle: "alice",
+      status: "recovering",
+      hetznerServerId: 123502,
+      recoveryOldServerId: 123500,
+      publicIPv4: "203.0.113.42",
+      imageVersion: "matrix-os-host-dev",
+      provisionedAt: "2026-05-06T00:00:00.000Z",
+    });
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response("healthy predecessor", { status: 200 }),
+    );
+    const app = createApp({
+      db,
+      orchestrator: stubOrchestrator(),
+      platformSecret: "platform-secret-123",
+    });
+    const issued = await issueSyncJwt({
+      secret: JWT_SECRET,
+      clerkUserId: "user_alice",
+      handle: "alice",
+      gatewayUrl: "https://app.matrix-os.com",
+    });
+
+    const res = await app.request("/api/health", {
+      headers: {
+        host: "app.matrix-os.com",
+        authorization: `Bearer ${issued.token}`,
+      },
+    });
+
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe("healthy predecessor");
+    expect(fetchMock.mock.calls[0]?.[0]).toBe("https://203.0.113.42:443/api/health");
+  });
+
   it("routes mobile app session-token launches to the hinted customer VPS without Clerk cookies", async () => {
     await insertUserMachine(db, {
       machineId: "machine-alice-mobile-app",


### PR DESCRIPTION
## Summary

- integrate exact/compatible-older snapshot selection into customer VPS creation
- persist resumable clone/fallback steps, recheck ownership and billing before billable creates, and route only after exact target registration
- fall back automatically to the existing clean Ubuntu/full cloud-init path on unsafe snapshot outcomes

## Tests

- [x] Exact cloning and fallback cases: 27 passed
- [x] Platform TypeScript project check
- [x] PR size: 10 files, 2,231 additions

## Invariants

### Source of truth

Postgres owner/runtime slot, billing decision, target bundle, snapshot lease/intent, provisioning job, and registration provenance are authoritative.

### Lock/transaction scope

Related writes are transactional and idempotent. Provider create/action calls run outside locks with bounded timeouts, followed by durable state rechecks.

### Acceptable orphan states

Ambiguous customer creates remain pending for exact-label adoption; rejected or unsafe clones enter bounded exact cleanup before clean-image fallback. Duplicate authoritative servers are forbidden.

### Authorization source

Existing Clerk customer ownership and billing entitlement checks are re-resolved before every billable create and before routing.

### Deferred scope

Recovery/retirement, release enqueue, public rollout, production deployment, and customer-wide enablement remain deferred upstack.