### PR TITLE
fix(desktop): replace stale canary release assets

### DIFF
--- a/.github/workflows/desktop-release-canary.yml
+++ b/.github/workflows/desktop-release-canary.yml
@@ -83,6 +83,15 @@ jobs:
         run: |
           printf 'Automated Matrix OS Desktop canary for %s.\n' "$GITHUB_SHA" > RELEASE_NOTES.md
 
+      - name: Remove previous desktop-canary release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          if gh release view desktop-canary >/dev/null 2>&1; then
+            gh release delete desktop-canary --yes
+          fi
+
       - name: Publish desktop-canary prerelease
         uses: softprops/action-gh-release@v3
         with:

--- a/tests/desktop/desktop-release-workflows.test.ts
+++ b/tests/desktop/desktop-release-workflows.test.ts
@@ -86,6 +86,24 @@ describe("desktop release workflows", () => {
     expect(workflow).not.toContain("version_suffix:");
   });
 
+  it("recreates the disposable canary release after preparing the complete artifact set", () => {
+    const workflow = readFileSync(join(root, ".github/workflows/desktop-release-canary.yml"), "utf8");
+    const downloadIndex = workflow.indexOf("uses: actions/download-artifact@v6");
+    const manifestIndex = workflow.indexOf("name: Generate release manifest");
+    const notesIndex = workflow.indexOf("name: Write release notes");
+    const cleanupIndex = workflow.indexOf("name: Remove previous desktop-canary release");
+    const publishIndex = workflow.indexOf("name: Publish desktop-canary prerelease");
+
+    expect(workflow).toContain("GH_TOKEN: ${{ github.token }}");
+    expect(workflow).toContain("gh release delete desktop-canary --yes");
+    expect(workflow).not.toContain("gh release delete desktop-canary --yes --cleanup-tag");
+    expect(downloadIndex).toBeGreaterThan(-1);
+    expect(manifestIndex).toBeGreaterThan(downloadIndex);
+    expect(notesIndex).toBeGreaterThan(manifestIndex);
+    expect(cleanupIndex).toBeGreaterThan(notesIndex);
+    expect(publishIndex).toBeGreaterThan(cleanupIndex);
+  });
+
   it("patches exact release versions and validates notarization inputs before packaging", () => {
     const build = readFileSync(join(root, ".github/workflows/desktop-build.yml"), "utf8");
     const release = readFileSync(join(root, ".github/workflows/desktop-release.yml"), "utf8");


### PR DESCRIPTION
## Summary

- recreate the disposable `desktop-canary` GitHub release after each successful build so timestamped artifacts cannot accumulate indefinitely
- preserve the moved `desktop-canary` tag while removing only the previous release object
- enforce cleanup ordering after artifact download, manifest generation, and release-note generation but before publication
- add a regression test covering the exact release target and ordering

The current mutable release accumulated 826 assets because every canary has a unique timestamped filename while `overwrite_files: true` only replaces identical names. This change makes each canary release contain only its current signed artifacts and gives it a current publication date.

## Tests

- `flox activate -- pnpm exec vitest run tests/desktop/desktop-release-workflows.test.ts` — 15/15 passed
- `flox activate -- bun run typecheck` — passed
- `flox activate -- bun run check:patterns` — 0 violations; 5 pre-existing warnings outside this diff
- `git diff --check` — passed

## Review / Monitoring

- merge only after current-head Greptile 5/5 and zero unresolved review threads
- apply `ready-for-ci` only after the Greptile gate passes
- after merge, delete the existing bloated canary release and dispatch the corrected Desktop Canary workflow
- verify ARM64/x64 signing, notarization, DMG mount, app launch smoke, release date, manifest commit, and final asset count

## Invariants

### Source of truth

- the `desktop-canary` tag and GitHub release remain the source of truth for the rolling desktop canary channel

### Lock/transaction scope

- the existing `desktop-release-canary` concurrency group serializes release replacement; no database or filesystem transaction changes are involved

### Acceptable orphan states

- cleanup runs only after all platform builds and release metadata generation succeed
- if final GitHub publication fails after cleanup, the `desktop-canary` tag remains available and rerunning the workflow recreates the release; no stable or versioned release is touched

### Auth source of truth

- cleanup uses the workflow-scoped `github.token` with the existing `contents: write` permission

### Deferred scope

- historical canary binaries are intentionally not retained; durable history belongs in immutable versioned desktop releases
