### PR TITLE
fix(agent): repair OpenClaw install and add Hermes settings UI

### DIFF
--- a/distro/customer-vps/host-bin/matrix-hermes-dashboard
+++ b/distro/customer-vps/host-bin/matrix-hermes-dashboard
@@ -11,6 +11,8 @@ fi
 MATRIX_RUNTIME_HOME="${MATRIX_RUNTIME_HOME:-${MATRIX_HOME:-/home/matrix/home}}"
 HERMES_HOME="${HERMES_HOME:-$MATRIX_RUNTIME_HOME/.hermes}"
 HERMES_BIN="${HERMES_BIN:-$MATRIX_RUNTIME_HOME/.local/bin/hermes}"
+auth_dir="$MATRIX_RUNTIME_HOME/system/agent-runtime"
+auth_file="$auth_dir/hermes-dashboard.env"
 
 if declare -F matrix_export_owner_env >/dev/null 2>&1; then
   matrix_export_owner_env
@@ -23,5 +25,77 @@ if [ ! -x "$HERMES_BIN" ]; then
   echo "matrix-hermes-dashboard: hermes binary not found at $HERMES_BIN; exiting" >&2
   exit 0
 fi
+
+umask 077
+mkdir -p "$auth_dir"
+chmod 0700 "$auth_dir"
+
+create_auth_file() {
+  local auth_tmp password secret
+  auth_tmp="$(mktemp "$auth_dir/.hermes-dashboard.env.XXXXXX")"
+  trap 'rm -f "${auth_tmp:-}"' RETURN
+  password="$(od -An -N32 -tx1 /dev/urandom | tr -d ' \n')"
+  secret="$(od -An -N32 -tx1 /dev/urandom | tr -d ' \n')"
+  printf '%s\n' \
+    'HERMES_DASHBOARD_BASIC_AUTH_USERNAME=matrix' \
+    "HERMES_DASHBOARD_BASIC_AUTH_PASSWORD=$password" \
+    "HERMES_DASHBOARD_BASIC_AUTH_SECRET=$secret" > "$auth_tmp"
+  chmod 0600 "$auth_tmp"
+  if mv -n "$auth_tmp" "$auth_file"; then
+    # GNU mv -n exits zero even when a racing process won. The temp file only
+    # disappears when this process installed it.
+    if [ ! -e "$auth_tmp" ]; then
+      auth_tmp=""
+    fi
+  fi
+}
+
+if [ ! -e "$auth_file" ] && [ ! -L "$auth_file" ]; then
+  create_auth_file
+fi
+
+if [ -L "$auth_file" ] || [ ! -f "$auth_file" ] || [ "$(stat -c '%a' "$auth_file")" != "600" ]; then
+  echo "matrix-hermes-dashboard: invalid dashboard credential file" >&2
+  exit 1
+fi
+
+HERMES_DASHBOARD_BASIC_AUTH_USERNAME=""
+HERMES_DASHBOARD_BASIC_AUTH_PASSWORD=""
+HERMES_DASHBOARD_BASIC_AUTH_SECRET=""
+auth_entries=0
+while IFS='=' read -r key value || [ -n "$key$value" ]; do
+  [ -z "$key$value" ] && continue
+  case "$key" in
+    HERMES_DASHBOARD_BASIC_AUTH_USERNAME)
+      [ -z "$HERMES_DASHBOARD_BASIC_AUTH_USERNAME" ] || exit 1
+      HERMES_DASHBOARD_BASIC_AUTH_USERNAME="$value"
+      ;;
+    HERMES_DASHBOARD_BASIC_AUTH_PASSWORD)
+      [ -z "$HERMES_DASHBOARD_BASIC_AUTH_PASSWORD" ] || exit 1
+      HERMES_DASHBOARD_BASIC_AUTH_PASSWORD="$value"
+      ;;
+    HERMES_DASHBOARD_BASIC_AUTH_SECRET)
+      [ -z "$HERMES_DASHBOARD_BASIC_AUTH_SECRET" ] || exit 1
+      HERMES_DASHBOARD_BASIC_AUTH_SECRET="$value"
+      ;;
+    *)
+      echo "matrix-hermes-dashboard: invalid dashboard credential entry" >&2
+      exit 1
+      ;;
+  esac
+  auth_entries=$((auth_entries + 1))
+done < "$auth_file"
+
+if [ "$auth_entries" -ne 3 ] \
+  || [ "$HERMES_DASHBOARD_BASIC_AUTH_USERNAME" != "matrix" ] \
+  || [[ ! "$HERMES_DASHBOARD_BASIC_AUTH_PASSWORD" =~ ^[a-f0-9]{64}$ ]] \
+  || [[ ! "$HERMES_DASHBOARD_BASIC_AUTH_SECRET" =~ ^[a-f0-9]{64}$ ]]; then
+  echo "matrix-hermes-dashboard: invalid dashboard credentials" >&2
+  exit 1
+fi
+export HERMES_DASHBOARD_BASIC_AUTH_USERNAME
+export HERMES_DASHBOARD_BASIC_AUTH_PASSWORD
+export HERMES_DASHBOARD_BASIC_AUTH_SECRET
+export HERMES_DASHBOARD_SESSION_TOKEN="$HERMES_DASHBOARD_BASIC_AUTH_SECRET"
 
 exec "$HERMES_BIN" dashboard --host 127.0.0.1 --port 9119

--- a/distro/customer-vps/host-bin/matrix-install-openclaw
+++ b/distro/customer-vps/host-bin/matrix-install-openclaw
@@ -15,6 +15,9 @@ MATRIX_NODE_PREFIX="${MATRIX_NODE_PREFIX:-/opt/matrix/runtime/node}"
 OPENCLAW_VERSION="${OPENCLAW_VERSION:-2026.7.1}"
 OPENCLAW_SHA512="${OPENCLAW_SHA512:-81efd7b2cf7d0870233cbfe29261ff505a223ab8dcc43078b16df2f66872083f9d616df0cd5ed329b015764ad7160006d9dd818e92687cff7bcd467eba6c68f2}"
 OPENCLAW_TARBALL_URL="${OPENCLAW_TARBALL_URL:-https://registry.npmjs.org/openclaw/-/openclaw-${OPENCLAW_VERSION}.tgz}"
+NODE_RUNTIME_VERSION="${NODE_RUNTIME_VERSION:-24.18.0}"
+NODE_RUNTIME_SHA256="${NODE_RUNTIME_SHA256:-783130984963db7ba9cbd01089eaf2c2efb055c7c1693c943174b967b3050cb8}"
+NODE_RUNTIME_TARBALL_URL="${NODE_RUNTIME_TARBALL_URL:-https://nodejs.org/dist/v${NODE_RUNTIME_VERSION}/node-v${NODE_RUNTIME_VERSION}-linux-x64.tar.gz}"
 OPENCLAW_STATE_DIR="${OPENCLAW_STATE_DIR:-$MATRIX_RUNTIME_HOME/.openclaw}"
 OPENCLAW_ENV_FILE="${OPENCLAW_ENV_FILE:-$MATRIX_RUNTIME_HOME/system/agent-runtime/openclaw.env}"
 
@@ -47,61 +50,123 @@ check_admission() {
   fi
 }
 
-check_node_version() {
-  local node_major node_minor
-  node_major="$($MATRIX_NODE_PREFIX/bin/node -p 'process.versions.node.split(".")[0]')"
-  node_minor="$($MATRIX_NODE_PREFIX/bin/node -p 'process.versions.node.split(".")[1]')"
-  if [ "$node_major" -ne 24 ] || { [ "$node_major" -eq 24 ] && [ "$node_minor" -lt 15 ]; }; then
+openclaw_node_is_compatible() {
+  local version="${1#v}" major minor patch
+  IFS=. read -r major minor patch <<EOF
+$version
+EOF
+  case "$major:$minor:$patch" in
+    *[!0-9:]*|::*|*:|*::*) return 1 ;;
+  esac
+  case "$major" in
+    22) [ "$minor" -gt 22 ] || { [ "$minor" -eq 22 ] && [ "$patch" -ge 3 ]; } ;;
+    23) return 1 ;;
+    24) [ "$minor" -ge 15 ] ;;
+    25) [ "$minor" -gt 9 ] || { [ "$minor" -eq 9 ] && [ "$patch" -ge 0 ]; } ;;
+    *) [ "$major" -gt 25 ] ;;
+  esac
+}
+
+upgrade_bundled_node_runtime() (
+  set -euo pipefail
+  local tmp_dir archive extracted replacement
+  [ "$(uname -m)" = "x86_64" ] || {
+    echo "matrix-install-openclaw: automatic Node runtime repair is unavailable on this architecture" >&2
+    exit 2
+  }
+  tmp_dir="$(mktemp -d /tmp/matrix-node-runtime.XXXXXX)"
+  replacement=""
+  cleanup_node_upgrade() {
+    [ -z "$replacement" ] || rm -f -- "$replacement"
+    rm -rf -- "$tmp_dir"
+  }
+  trap cleanup_node_upgrade EXIT INT TERM
+  archive="$tmp_dir/node-runtime.tar.gz"
+  extracted="$tmp_dir/node-v${NODE_RUNTIME_VERSION}-linux-x64"
+  replacement="$MATRIX_NODE_PREFIX/bin/.node-${NODE_RUNTIME_VERSION}.new"
+
+  log "updating the bundled Node runtime to ${NODE_RUNTIME_VERSION}"
+  curl --fail --location --retry 3 --retry-delay 5 --retry-all-errors \
+    --connect-timeout 10 --max-time 300 \
+    "$NODE_RUNTIME_TARBALL_URL" -o "$archive"
+  printf '%s  %s\n' "$NODE_RUNTIME_SHA256" "$archive" >"$tmp_dir/node-runtime.sha256"
+  sha256sum -c "$tmp_dir/node-runtime.sha256"
+  tar -xzf "$archive" -C "$tmp_dir" "node-v${NODE_RUNTIME_VERSION}-linux-x64/bin/node"
+  install -o root -g "$MATRIX_RUNTIME_USER" -m 0755 "$extracted/bin/node" "$replacement"
+  "$replacement" --version >/dev/null
+  mv -f "$replacement" "$MATRIX_NODE_PREFIX/bin/node"
+  replacement=""
+)
+
+ensure_compatible_node_runtime() {
+  local installed_version
+  [ -x "$MATRIX_NODE_PREFIX/bin/node" ] || {
+    echo "matrix-install-openclaw: bundled Node runtime is unavailable" >&2
+    exit 2
+  }
+  installed_version="$($MATRIX_NODE_PREFIX/bin/node -p 'process.versions.node')"
+  if openclaw_node_is_compatible "$installed_version"; then
+    return
+  fi
+  upgrade_bundled_node_runtime
+  installed_version="$($MATRIX_NODE_PREFIX/bin/node -p 'process.versions.node')"
+  if ! openclaw_node_is_compatible "$installed_version"; then
     echo "matrix-install-openclaw: bundled Node runtime is incompatible" >&2
     exit 2
   fi
 }
 
-if ! id "$MATRIX_RUNTIME_USER" >/dev/null 2>&1; then
-  echo "matrix-install-openclaw: runtime user is unavailable" >&2
-  exit 1
-fi
+main() {
+  if ! id "$MATRIX_RUNTIME_USER" >/dev/null 2>&1; then
+    echo "matrix-install-openclaw: runtime user is unavailable" >&2
+    exit 1
+  fi
 
-check_node_version
-check_admission
+  check_admission
+  ensure_compatible_node_runtime
 
-install -d -o "$MATRIX_RUNTIME_USER" -g "$MATRIX_RUNTIME_USER" -m 0700 \
-  "$OPENCLAW_STATE_DIR" "$(dirname "$OPENCLAW_ENV_FILE")"
+  install -d -o "$MATRIX_RUNTIME_USER" -g "$MATRIX_RUNTIME_USER" -m 0700 \
+    "$OPENCLAW_STATE_DIR" "$(dirname "$OPENCLAW_ENV_FILE")"
 
-tmp_dir="$(mktemp -d /tmp/matrix-openclaw-install.XXXXXX)"
-cleanup() {
-  find "$tmp_dir" -mindepth 1 -maxdepth 1 -type l -delete 2>/dev/null || true
-  rm -rf "$tmp_dir"
+  tmp_dir="$(mktemp -d /tmp/matrix-openclaw-install.XXXXXX)"
+  cleanup() {
+    find "$tmp_dir" -mindepth 1 -maxdepth 1 -type l -delete 2>/dev/null || true
+    rm -rf "$tmp_dir"
+  }
+  trap cleanup EXIT INT TERM
+  archive="$tmp_dir/openclaw.tgz"
+
+  curl --fail --location --retry 3 --retry-delay 5 --retry-all-errors \
+    --connect-timeout 10 --max-time 180 \
+    "$OPENCLAW_TARBALL_URL" -o "$archive"
+  printf '%s  %s\n' "$OPENCLAW_SHA512" "$archive" >"$tmp_dir/openclaw.sha512"
+  sha512sum -c "$tmp_dir/openclaw.sha512"
+  tar -tzf "$archive" package/npm-shrinkwrap.json package/package.json package/openclaw.mjs >/dev/null
+  chown "root:$MATRIX_RUNTIME_USER" "$tmp_dir" "$archive"
+  chmod 0750 "$tmp_dir"
+  chmod 0640 "$archive"
+
+  log "installing pinned OpenClaw runtime"
+  run_installer_as_runtime_user env \
+    HOME="$MATRIX_RUNTIME_HOME" \
+    OPENCLAW_STATE_DIR="$OPENCLAW_STATE_DIR" \
+    PATH="$MATRIX_NODE_PREFIX/bin:/usr/local/bin:/usr/bin:/bin" \
+    "$MATRIX_NODE_PREFIX/bin/npm" install --global --prefix "$MATRIX_NODE_PREFIX" "$archive"
+
+  test -x "$MATRIX_NODE_PREFIX/bin/openclaw"
+
+  if [ ! -s "$OPENCLAW_ENV_FILE" ]; then
+    token="$(openssl rand -hex 32)"
+    token_tmp="$(mktemp "$(dirname "$OPENCLAW_ENV_FILE")/.openclaw.env.XXXXXX")"
+    printf 'OPENCLAW_GATEWAY_TOKEN=%s\n' "$token" >"$token_tmp"
+    chown "$MATRIX_RUNTIME_USER:$MATRIX_RUNTIME_USER" "$token_tmp"
+    chmod 0600 "$token_tmp"
+    mv -f "$token_tmp" "$OPENCLAW_ENV_FILE"
+  fi
+
+  log "OpenClaw ${OPENCLAW_VERSION} installed"
 }
-trap cleanup EXIT INT TERM
-archive="$tmp_dir/openclaw.tgz"
 
-curl --fail --location --retry 3 --retry-delay 5 --retry-all-errors \
-  --connect-timeout 10 --max-time 180 \
-  "$OPENCLAW_TARBALL_URL" -o "$archive"
-printf '%s  %s\n' "$OPENCLAW_SHA512" "$archive" >"$tmp_dir/openclaw.sha512"
-sha512sum -c "$tmp_dir/openclaw.sha512"
-tar -tzf "$archive" package/npm-shrinkwrap.json package/package.json package/openclaw.mjs >/dev/null
-chown "root:$MATRIX_RUNTIME_USER" "$tmp_dir" "$archive"
-chmod 0750 "$tmp_dir"
-chmod 0640 "$archive"
-
-log "installing pinned OpenClaw runtime"
-run_installer_as_runtime_user env \
-  HOME="$MATRIX_RUNTIME_HOME" \
-  OPENCLAW_STATE_DIR="$OPENCLAW_STATE_DIR" \
-  PATH="$MATRIX_NODE_PREFIX/bin:/usr/local/bin:/usr/bin:/bin" \
-  "$MATRIX_NODE_PREFIX/bin/npm" install --global --prefix "$MATRIX_NODE_PREFIX" "$archive"
-
-test -x "$MATRIX_NODE_PREFIX/bin/openclaw"
-
-if [ ! -s "$OPENCLAW_ENV_FILE" ]; then
-  token="$(openssl rand -hex 32)"
-  token_tmp="$(mktemp "$(dirname "$OPENCLAW_ENV_FILE")/.openclaw.env.XXXXXX")"
-  printf 'OPENCLAW_GATEWAY_TOKEN=%s\n' "$token" >"$token_tmp"
-  chown "$MATRIX_RUNTIME_USER:$MATRIX_RUNTIME_USER" "$token_tmp"
-  chmod 0600 "$token_tmp"
-  mv -f "$token_tmp" "$OPENCLAW_ENV_FILE"
+if [ "${BASH_SOURCE[0]}" = "$0" ]; then
+  main "$@"
 fi
-
-log "OpenClaw ${OPENCLAW_VERSION} installed"

--- a/distro/customer-vps/host-bin/matrix-sync-agent
+++ b/distro/customer-vps/host-bin/matrix-sync-agent
@@ -318,6 +318,11 @@ apply_update() {
       sudo systemctl start --no-block matrix-symphony.service || true
       log "Symphony service enabled"
     fi
+    if [ -f "$extract_dir/systemd/matrix-hermes-dashboard.service" ]; then
+      sudo systemctl enable matrix-hermes-dashboard.service
+      sudo systemctl restart --no-block matrix-hermes-dashboard.service || true
+      log "Hermes dashboard service refreshed"
+    fi
     if [ -x /opt/matrix/messaging/bin/synapse ] && [ -x /opt/matrix/messaging/bin/mautrix-telegram ] && [ -x /opt/matrix/messaging/bin/mautrix-whatsapp ]; then
       sudo systemctl enable matrix-homeserver.service matrix-bridge-telegram.service matrix-bridge-whatsapp.service
       sudo systemctl start --no-block matrix-homeserver.service matrix-bridge-telegram.service matrix-bridge-whatsapp.service || true

--- a/packages/gateway/src/agent-config/hermes-client.ts
+++ b/packages/gateway/src/agent-config/hermes-client.ts
@@ -1,7 +1,13 @@
+import { constants as fsConstants } from "node:fs";
+import { open } from "node:fs/promises";
+import { join } from "node:path";
+
 const DEFAULT_HERMES_BASE_URL = "http://127.0.0.1:9119";
 const DEFAULT_HERMES_TIMEOUT_MS = 10_000;
 const MAX_HERMES_JSON_BYTES = 1024 * 1024;
+const MAX_HERMES_AUTH_FILE_BYTES = 4 * 1024;
 const HERMES_PATH = /^\/api\/[a-z0-9_/-]+$/;
+const HERMES_AUTH_VALUE = /^[a-f0-9]{64}$/;
 
 type FetchLike = (
   input: string | URL | Request,
@@ -110,6 +116,7 @@ async function readBoundedBody(response: Response): Promise<Uint8Array> {
 export function createHermesDashboardClient(options: {
   baseUrl?: string;
   fetchImpl?: FetchLike;
+  authFilePath?: string;
 } = {}) {
   const baseUrl = options.baseUrl
     ?? process.env.HERMES_DASHBOARD_URL
@@ -117,21 +124,92 @@ export function createHermesDashboardClient(options: {
   validateHermesDashboardUrl(baseUrl);
   const normalizedBaseUrl = baseUrl.replace(/\/$/, "");
   const fetchImpl = options.fetchImpl ?? globalThis.fetch;
+  const authFilePath = options.authFilePath ?? join(
+    process.env.MATRIX_HOME ?? "/home/matrix/home",
+    "system/agent-runtime/hermes-dashboard.env",
+  );
+  let sessionToken: string | null = null;
+  let tokenPromise: Promise<string> | null = null;
 
-  async function fetchPath(
+  async function readSessionToken(): Promise<string> {
+    let handle;
+    try {
+      handle = await open(authFilePath, fsConstants.O_RDONLY | fsConstants.O_NOFOLLOW);
+      const stat = await handle.stat();
+      if (!stat.isFile() || stat.size > MAX_HERMES_AUTH_FILE_BYTES || (stat.mode & 0o777) !== 0o600) {
+        throw new Error("invalid Hermes dashboard credential file");
+      }
+      const contents = await handle.readFile({ encoding: "utf8" });
+      const values = new Map<string, string>();
+      for (const line of contents.split("\n")) {
+        if (line === "") continue;
+        const separator = line.indexOf("=");
+        if (separator <= 0) throw new Error("invalid Hermes dashboard credential entry");
+        const key = line.slice(0, separator);
+        const value = line.slice(separator + 1);
+        if (values.has(key)) throw new Error("duplicate Hermes dashboard credential entry");
+        values.set(key, value);
+      }
+      if (values.size !== 3
+        || values.get("HERMES_DASHBOARD_BASIC_AUTH_USERNAME") !== "matrix"
+        || !HERMES_AUTH_VALUE.test(values.get("HERMES_DASHBOARD_BASIC_AUTH_PASSWORD") ?? "")
+        || !HERMES_AUTH_VALUE.test(values.get("HERMES_DASHBOARD_BASIC_AUTH_SECRET") ?? "")) {
+        throw new Error("invalid Hermes dashboard credentials");
+      }
+      return values.get("HERMES_DASHBOARD_BASIC_AUTH_SECRET")!;
+    } catch (err) {
+      throw new HermesUnavailableError(err);
+    } finally {
+      await handle?.close();
+    }
+  }
+
+  async function getSessionToken(): Promise<string> {
+    if (sessionToken !== null) return sessionToken;
+    if (tokenPromise !== null) return tokenPromise;
+    tokenPromise = readSessionToken().then((token) => {
+      sessionToken = token;
+      return token;
+    }).finally(() => {
+      tokenPromise = null;
+    });
+    return tokenPromise;
+  }
+
+  async function rawFetch(
     path: string,
-    init: Omit<RequestInit, "redirect"> = {},
+    init: Omit<RequestInit, "redirect">,
+    token: string | null,
   ): Promise<Response> {
-    validatePath(path);
+    const headers = new Headers(init.headers);
+    headers.delete("cookie");
+    headers.delete("authorization");
+    headers.delete("x-hermes-session-token");
+    if (token !== null) headers.set("x-hermes-session-token", token);
     try {
       return await fetchImpl(`${normalizedBaseUrl}${path}`, {
         ...init,
+        headers,
         signal: init.signal ?? AbortSignal.timeout(DEFAULT_HERMES_TIMEOUT_MS),
         redirect: "error",
       });
     } catch (err) {
       throw new HermesUnavailableError(err);
     }
+  }
+
+  async function fetchPath(
+    path: string,
+    init: Omit<RequestInit, "redirect"> = {},
+  ): Promise<Response> {
+    validatePath(path);
+    let response = await rawFetch(path, init, sessionToken);
+    if (response.status !== 401) return response;
+    await response.body?.cancel();
+    sessionToken = null;
+    const authenticatedToken = await getSessionToken();
+    response = await rawFetch(path, init, authenticatedToken);
+    return response;
   }
 
   async function requestJson(

--- a/packages/gateway/src/routes/hermes.ts
+++ b/packages/gateway/src/routes/hermes.ts
@@ -35,6 +35,10 @@ export { validateHermesDashboardUrl } from "../agent-config/hermes-client.js";
 // ---------------------------------------------------------------------------
 
 const HERMES_BODY_LIMIT = 64 * 1024; // 64 KiB
+const MAX_CONFIG_FIELDS = 1024;
+const CONFIG_PATH = /^[a-z][a-z0-9_]*(?:\.[a-z][a-z0-9_]*){0,7}$/;
+const ENV_KEY = /^[A-Z][A-Z0-9_]{0,127}$/;
+const SENSITIVE_CONFIG_SEGMENT = /(?:^|_)(?:api_?key|secret|token|password|credential)(?:s|_.*)?$/i;
 
 // Safe platform/channel id: lowercase-start slug, 1–63 chars.
 // Mirrors the SAFE_SLUG from app-db-types.ts.
@@ -94,9 +98,113 @@ const ModelSetSchema = z.object({
 });
 
 const EnvSetSchema = z.object({
-  key: z.string().min(1).max(256),
+  key: z.string().regex(ENV_KEY),
   value: z.string().max(4096),
-});
+}).strict();
+
+const EnvDeleteSchema = z.object({
+  key: z.string().regex(ENV_KEY),
+}).strict();
+
+const ConfigListItemSchema = z.union([
+  z.string().max(4096),
+  z.number().finite(),
+  z.boolean(),
+]);
+
+const ConfigChangeSchema = z.object({
+  path: z.string().min(1).max(160).regex(CONFIG_PATH),
+  value: z.union([
+    z.string().max(8192),
+    z.number().finite(),
+    z.boolean(),
+    z.array(ConfigListItemSchema).max(128),
+  ]),
+}).strict();
+
+const ConfigChangesSchema = z.object({
+  changes: z.array(ConfigChangeSchema).min(1).max(64),
+}).strict();
+
+type ConfigField = {
+  type: "boolean" | "number" | "string" | "select" | "list";
+  description: string;
+  category: string;
+  options?: string[];
+};
+
+function isPlainRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function isSensitiveConfigPath(path: string): boolean {
+  return path.split(".").some((segment) => SENSITIVE_CONFIG_SEGMENT.test(segment));
+}
+
+function sanitizeConfig(value: unknown, path = ""): unknown {
+  if (Array.isArray(value)) return value.map((entry) => sanitizeConfig(entry, path));
+  if (!isPlainRecord(value)) return value;
+  const sanitized: Record<string, unknown> = {};
+  for (const [key, entry] of Object.entries(value)) {
+    const entryPath = path ? `${path}.${key}` : key;
+    if (isSensitiveConfigPath(entryPath)) continue;
+    sanitized[key] = sanitizeConfig(entry, entryPath);
+  }
+  return sanitized;
+}
+
+function parseConfigSchema(value: unknown): { fields: Record<string, ConfigField>; categoryOrder: string[] } | null {
+  if (!isPlainRecord(value) || !isPlainRecord(value.fields) || !Array.isArray(value.category_order)) return null;
+  const entries = Object.entries(value.fields);
+  if (entries.length > MAX_CONFIG_FIELDS) return null;
+  const fields: Record<string, ConfigField> = {};
+  for (const [path, rawField] of entries) {
+    if (!CONFIG_PATH.test(path) || isSensitiveConfigPath(path) || !isPlainRecord(rawField)) continue;
+    const type = rawField.type;
+    const description = rawField.description;
+    const category = rawField.category;
+    if (!(["boolean", "number", "string", "select", "list"] as unknown[]).includes(type)
+      || typeof description !== "string" || description.length > 512
+      || typeof category !== "string" || category.length > 64) {
+      continue;
+    }
+    let options: string[] | undefined;
+    if (type === "select") {
+      if (!Array.isArray(rawField.options)
+        || rawField.options.length > 128
+        || rawField.options.some((option) => typeof option !== "string" || option.length > 256)) {
+        continue;
+      }
+      options = rawField.options as string[];
+    }
+    fields[path] = { type: type as ConfigField["type"], description, category, ...(options ? { options } : {}) };
+  }
+  const categoryOrder = value.category_order.filter(
+    (category): category is string => typeof category === "string" && category.length <= 64,
+  ).slice(0, 64);
+  return { fields, categoryOrder };
+}
+
+function fieldAcceptsValue(field: ConfigField, value: unknown): boolean {
+  switch (field.type) {
+    case "boolean": return typeof value === "boolean";
+    case "number": return typeof value === "number" && Number.isFinite(value);
+    case "string": return typeof value === "string";
+    case "select": return typeof value === "string" && Boolean(field.options?.includes(value));
+    case "list": return ConfigListItemSchema.array().max(128).safeParse(value).success;
+  }
+}
+
+function setConfigPath(config: Record<string, unknown>, path: string, value: unknown): void {
+  const segments = path.split(".");
+  let target = config;
+  for (const segment of segments.slice(0, -1)) {
+    const child = target[segment];
+    if (!isPlainRecord(child)) target[segment] = {};
+    target = target[segment] as Record<string, unknown>;
+  }
+  target[segments.at(-1)!] = value;
+}
 
 const PlatformUpdateSchema = z.object({
   enabled: z.boolean().optional(),
@@ -127,6 +235,21 @@ export interface HermesRouteDeps {
 export function createHermesRoutes(_deps: HermesRouteDeps = {}): Hono {
   const app = new Hono();
   const hermesFetch = (_deps.client ?? createHermesDashboardClient()).fetch;
+  let configurationWriteTail = Promise.resolve();
+
+  async function serializeConfigurationWrite<T>(operation: () => Promise<T>): Promise<T> {
+    const previous = configurationWriteTail;
+    let release = () => {};
+    configurationWriteTail = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    await previous;
+    try {
+      return await operation();
+    } finally {
+      release();
+    }
+  }
 
   // ------------------------------------------------------------------
   // GET /status  (aggregates /api/status + /api/model/info into coarse shape)
@@ -201,6 +324,89 @@ export function createHermesRoutes(_deps: HermesRouteDeps = {}): Hono {
     } catch (err) {
       if (err instanceof HermesUnavailableError) return unavailable(c);
       console.error("[hermes-proxy] /config error:", err);
+      return upstreamError(c, 503);
+    }
+  });
+
+  // ------------------------------------------------------------------
+  // GET /configuration  (safe, version-aware Settings aggregate)
+  // ------------------------------------------------------------------
+  app.get("/configuration", async (c) => {
+    const authErr = checkAuth(c);
+    if (authErr) return authErr;
+
+    try {
+      const [configRes, defaultsRes, schemaRes] = await Promise.all([
+        hermesFetch("/api/config"),
+        hermesFetch("/api/config/defaults"),
+        hermesFetch("/api/config/schema"),
+      ]);
+      if (!configRes.ok || !defaultsRes.ok || !schemaRes.ok) return upstreamError(c);
+      const config = await configRes.json() as unknown;
+      const defaults = await defaultsRes.json() as unknown;
+      const schema = parseConfigSchema(await schemaRes.json());
+      if (!isPlainRecord(config) || !isPlainRecord(defaults) || !schema) return upstreamError(c);
+      return c.json({
+        config: sanitizeConfig(config),
+        defaults: sanitizeConfig(defaults),
+        fields: schema.fields,
+        categoryOrder: schema.categoryOrder,
+      });
+    } catch (err) {
+      if (err instanceof HermesUnavailableError) return unavailable(c);
+      console.error("[hermes-proxy] GET /configuration error:", err);
+      return upstreamError(c, 503);
+    }
+  });
+
+  // ------------------------------------------------------------------
+  // PUT /configuration  (typed patch; full config never enters browser)
+  // ------------------------------------------------------------------
+  app.put("/configuration", bodyLimit({ maxSize: HERMES_BODY_LIMIT }), async (c) => {
+    const authErr = checkAuth(c);
+    if (authErr) return authErr;
+
+    let raw: unknown;
+    try {
+      raw = await c.req.json();
+    } catch (err) {
+      logIgnoredHermesError("PUT /configuration invalid JSON", err);
+      return c.json({ error: "Invalid JSON" }, 400);
+    }
+    const parsed = ConfigChangesSchema.safeParse(raw);
+    if (!parsed.success) return c.json({ error: "Invalid request body" }, 400);
+
+    try {
+      return await serializeConfigurationWrite(async () => {
+        const [configRes, schemaRes] = await Promise.all([
+          hermesFetch("/api/config"),
+          hermesFetch("/api/config/schema"),
+        ]);
+        if (!configRes.ok || !schemaRes.ok) return upstreamError(c);
+        const current = await configRes.json() as unknown;
+        const schema = parseConfigSchema(await schemaRes.json());
+        if (!isPlainRecord(current) || !schema) return upstreamError(c);
+
+        for (const change of parsed.data.changes) {
+          const field = schema.fields[change.path];
+          if (!field || isSensitiveConfigPath(change.path) || !fieldAcceptsValue(field, change.value)) {
+            return c.json({ error: "Invalid configuration change" }, 400);
+          }
+        }
+
+        const updated = structuredClone(current);
+        for (const change of parsed.data.changes) setConfigPath(updated, change.path, change.value);
+        const saveRes = await hermesFetch("/api/config", {
+          method: "PUT",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ config: updated }),
+        });
+        if (!saveRes.ok) return upstreamError(c);
+        return c.json({ ok: true, config: sanitizeConfig(updated) });
+      });
+    } catch (err) {
+      if (err instanceof HermesUnavailableError) return unavailable(c);
+      console.error("[hermes-proxy] PUT /configuration error:", err);
       return upstreamError(c, 503);
     }
   });
@@ -325,6 +531,38 @@ export function createHermesRoutes(_deps: HermesRouteDeps = {}): Hono {
     } catch (err) {
       if (err instanceof HermesUnavailableError) return unavailable(c);
       console.error("[hermes-proxy] PUT /env error:", err);
+      return upstreamError(c, 503);
+    }
+  });
+
+  // ------------------------------------------------------------------
+  // DELETE /env  (remove one allowlisted-shape environment key)
+  // ------------------------------------------------------------------
+  app.delete("/env", bodyLimit({ maxSize: HERMES_BODY_LIMIT }), async (c) => {
+    const authErr = checkAuth(c);
+    if (authErr) return authErr;
+
+    let raw: unknown;
+    try {
+      raw = await c.req.json();
+    } catch (err) {
+      logIgnoredHermesError("DELETE /env invalid JSON", err);
+      return c.json({ error: "Invalid JSON" }, 400);
+    }
+    const parsed = EnvDeleteSchema.safeParse(raw);
+    if (!parsed.success) return c.json({ error: "Invalid request body" }, 400);
+
+    try {
+      const res = await hermesFetch("/api/env", {
+        method: "DELETE",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(parsed.data),
+      });
+      if (!res.ok) return upstreamError(c);
+      return c.json(await res.json());
+    } catch (err) {
+      if (err instanceof HermesUnavailableError) return unavailable(c);
+      console.error("[hermes-proxy] DELETE /env error:", err);
       return upstreamError(c, 503);
     }
   });

--- a/packages/gateway/src/server.ts
+++ b/packages/gateway/src/server.ts
@@ -3951,7 +3951,10 @@ export async function createGateway(config: GatewayConfig) {
     );
     throw err;
   }
-  const hermesClient = createHermesDashboardClient({ baseUrl: hermesDashboardUrl });
+  const hermesClient = createHermesDashboardClient({
+    baseUrl: hermesDashboardUrl,
+    authFilePath: join(homePath, "system/agent-runtime/hermes-dashboard.env"),
+  });
   const agentRuntimeServices = createAgentRuntimeServices({
     homePath,
     client: hermesClient,

--- a/shell/src/components/settings/sections/AgentRuntimePanel.tsx
+++ b/shell/src/components/settings/sections/AgentRuntimePanel.tsx
@@ -15,6 +15,7 @@ import {
   LoaderCircleIcon,
   RadioIcon,
   RefreshCwIcon,
+  Settings2Icon,
   TerminalIcon,
 } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
@@ -30,6 +31,7 @@ import {
   type NormalizedAgentSettings,
 } from "@/lib/agent-config";
 import type { TerminalLaunchAction } from "@/lib/terminal-launch";
+import { HermesConfigurationDialog } from "./HermesConfigurationDialog";
 
 interface AgentRuntimePanelProps {
   onOpenTerminal?: (action: TerminalLaunchAction) => void;
@@ -300,22 +302,45 @@ function MessagingProviders({
   const selectedModel = providerModels.some((entry) => entry.id === preferredModel)
     ? preferredModel
     : providerModels[0]?.id ?? "";
-  const terminalAction = view.runtime.selected === "hermes" ? "hermes-model" : "openclaw-model-auth";
+  const isHermes = view.runtime.selected === "hermes";
+  const [hermesConfigOpen, setHermesConfigOpen] = useState(false);
+  const hermesVersion = view.runtime.options.find((runtime) => runtime.id === "hermes")?.version;
+  const terminalAction = "openclaw-model-auth";
+  const configureAction = isHermes ? (
+    <Button
+      size="sm"
+      variant="outline"
+      onClick={() => setHermesConfigOpen(true)}
+      aria-label="Configure Hermes provider"
+    >
+      <Settings2Icon className="size-3.5" /> Configure Hermes
+    </Button>
+  ) : onOpenTerminal ? (
+    <Button size="sm" variant="outline" onClick={() => onOpenTerminal(terminalAction)} aria-label="Configure Openclaw provider">
+      <TerminalIcon className="size-3.5" /> Configure OpenClaw
+    </Button>
+  ) : null;
+  const hermesDialog = (
+    <HermesConfigurationDialog
+      open={hermesConfigOpen}
+      onOpenChange={setHermesConfigOpen}
+      version={hermesVersion}
+    />
+  );
 
   if (providers.length === 0) {
     return (
-      <Card>
-        <CardContent className="flex min-h-32 flex-col items-center justify-center gap-2 py-8 text-center">
-          <AlertTriangleIcon className="size-5 text-muted-foreground" />
-          <p className="text-sm font-medium">No providers available</p>
-          <p className="max-w-sm text-xs text-muted-foreground">Start and configure the selected messaging runtime, then retry.</p>
-          {onOpenTerminal && (
-            <Button size="sm" variant="outline" onClick={() => onOpenTerminal(terminalAction)} aria-label={`Configure ${statusLabel(view.runtime.selected)} provider`}>
-              <TerminalIcon className="size-3.5" /> Configure {statusLabel(view.runtime.selected)}
-            </Button>
-          )}
-        </CardContent>
-      </Card>
+      <>
+        <Card>
+          <CardContent className="flex min-h-32 flex-col items-center justify-center gap-2 py-8 text-center">
+            <AlertTriangleIcon className="size-5 text-muted-foreground" />
+            <p className="text-sm font-medium">No providers available</p>
+            <p className="max-w-sm text-xs text-muted-foreground">Start and configure the selected messaging runtime, then retry.</p>
+            {configureAction}
+          </CardContent>
+        </Card>
+        {hermesDialog}
+      </>
     );
   }
 
@@ -372,17 +397,14 @@ function MessagingProviders({
             <span className="text-xs text-muted-foreground">{provider?.displayName}</span>
           </div>
           <div className="flex gap-2">
-            {onOpenTerminal && (
-              <Button size="sm" variant="outline" onClick={() => onOpenTerminal(terminalAction)} aria-label={`Configure ${statusLabel(view.runtime.selected)} provider`}>
-                <TerminalIcon className="size-3.5" /> Configure
-              </Button>
-            )}
+            {configureAction}
             <Button size="sm" disabled={busy || !selectedProviderId || !selectedModel} onClick={() => onSave(selectedProviderId, selectedModel)}>
               Save messaging model
             </Button>
           </div>
         </div>
       </CardContent>
+      {hermesDialog}
     </Card>
   );
 }

--- a/shell/src/components/settings/sections/HermesConfigurationDialog.tsx
+++ b/shell/src/components/settings/sections/HermesConfigurationDialog.tsx
@@ -1,0 +1,781 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import {
+  AlertTriangleIcon,
+  CheckCircle2Icon,
+  KeyRoundIcon,
+  LoaderCircleIcon,
+  RotateCcwIcon,
+  SearchIcon,
+  Settings2Icon,
+  ShieldCheckIcon,
+  SparklesIcon,
+  Trash2Icon,
+} from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { Switch } from "@/components/ui/switch";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { Textarea } from "@/components/ui/textarea";
+import { SHELL_Z_INDEX } from "@/lib/shell-layering";
+import {
+  configValueAt,
+  HermesConfigurationError,
+  loadHermesConfiguration,
+  loadHermesEnvironment,
+  removeHermesCredential,
+  saveHermesConfiguration,
+  saveHermesCredential,
+  type HermesConfigField,
+  type HermesConfigValue,
+  type HermesConfiguration,
+  type HermesEnvironment,
+} from "@/lib/hermes-configuration";
+
+interface HermesConfigurationDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  version?: string;
+}
+
+function titleCase(value: string): string {
+  return value.split(/[._-]/).map((part) => (
+    part.length === 0 ? part : part[0].toUpperCase() + part.slice(1)
+  )).join(" ");
+}
+
+function valuesEqual(left: unknown, right: unknown): boolean {
+  return JSON.stringify(left) === JSON.stringify(right);
+}
+
+function setConfigValue(config: Record<string, unknown>, path: string, value: HermesConfigValue) {
+  const updated = structuredClone(config);
+  const segments = path.split(".");
+  let target = updated;
+  for (const segment of segments.slice(0, -1)) {
+    const existing = target[segment];
+    if (existing === null || typeof existing !== "object" || Array.isArray(existing)) target[segment] = {};
+    target = target[segment] as Record<string, unknown>;
+  }
+  target[segments.at(-1)!] = value;
+  return updated;
+}
+
+function isConfigValue(value: unknown): value is HermesConfigValue {
+  return typeof value === "string"
+    || typeof value === "number"
+    || typeof value === "boolean"
+    || (Array.isArray(value) && value.every((entry) => (
+      typeof entry === "string" || typeof entry === "number" || typeof entry === "boolean"
+    )));
+}
+
+function parseListValue(text: string): Array<string | number | boolean> | null {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text) as unknown;
+  } catch (error) {
+    if (!(error instanceof SyntaxError)) {
+      console.warn("Hermes list setting parsing failed", error instanceof Error ? error.name : "UnknownError");
+    }
+    return null;
+  }
+  return isConfigValue(parsed) && Array.isArray(parsed) ? parsed : null;
+}
+
+function fieldTextValue(field: HermesConfigField, value: unknown): string {
+  if (field.type === "list") return JSON.stringify(value ?? [], null, 2);
+  if (field.type === "number" && typeof value === "number") return String(value);
+  return "";
+}
+
+async function attemptCredentialMutation(operation: () => Promise<void>, action: "save" | "remove"): Promise<boolean> {
+  try {
+    await operation();
+    return true;
+  } catch (error) {
+    console.warn(
+      action === "save" ? "Hermes credential save failed" : "Hermes credential removal failed",
+      error instanceof Error ? error.name : "UnknownError",
+    );
+    return false;
+  }
+}
+
+function configurationCategories(configuration: HermesConfiguration | null) {
+  if (!configuration) return [];
+  // Bounded by the gateway's 1,024-field schema cap.
+  const counts = new Map<string, number>();
+  for (const field of Object.values(configuration.fields)) {
+    counts.set(field.category, (counts.get(field.category) ?? 0) + 1);
+  }
+  const ordered = configuration.categoryOrder.filter((entry) => counts.has(entry));
+  const orderedSet = new Set(ordered);
+  const remaining = [...counts.keys()].filter((entry) => !orderedSet.has(entry)).sort();
+  return [...ordered, ...remaining].map((id) => ({ id, count: counts.get(id) ?? 0 }));
+}
+
+function matchingConfigurationFields(configuration: HermesConfiguration | null, search: string, category: string) {
+  if (!configuration) return [];
+  const query = search.trim().toLowerCase();
+  return Object.entries(configuration.fields).filter(([path, field]) => (
+    query
+      ? `${path} ${field.description} ${field.category}`.toLowerCase().includes(query)
+      : field.category === category
+  ));
+}
+
+function matchingCredentials(environment: HermesEnvironment, search: string) {
+  const query = search.trim().toLowerCase();
+  return Object.entries(environment).filter(([key, entry]) => (
+    !entry.channel_managed
+    && (!query || `${key} ${entry.provider_label} ${entry.description}`.toLowerCase().includes(query))
+  )).sort(([, left], [, right]) => (
+    Number(right.is_set) - Number(left.is_set) || left.provider_label.localeCompare(right.provider_label)
+  ));
+}
+
+function FieldEditor({
+  path,
+  field,
+  value,
+  defaultValue,
+  onChange,
+  onValidityChange,
+  inputText,
+  invalid,
+  onInputTextChange,
+}: {
+  path: string;
+  field: HermesConfigField;
+  value: unknown;
+  defaultValue: unknown;
+  onChange: (value: HermesConfigValue) => void;
+  onValidityChange: (valid: boolean) => void;
+  inputText: string;
+  invalid: boolean;
+  onInputTextChange: (value: string) => void;
+}) {
+  const inputId = `hermes-setting-${path.replaceAll(".", "-")}`;
+  const canRestore = isConfigValue(defaultValue) && !valuesEqual(value, defaultValue);
+
+  let control;
+  if (field.type === "boolean") {
+    control = (
+      <Switch
+        id={inputId}
+        aria-label={field.description}
+        checked={value === true}
+        onCheckedChange={(checked) => {
+          onValidityChange(true);
+          onChange(checked);
+        }}
+      />
+    );
+  } else if (field.type === "number") {
+    control = (
+      <Input
+        id={inputId}
+        aria-label={field.description}
+        type="number"
+        value={inputText}
+        aria-invalid={invalid}
+        onChange={(event) => {
+          const raw = event.target.value;
+          onInputTextChange(raw);
+          if (raw.trim().length === 0) {
+            onValidityChange(false);
+            return;
+          }
+          const next = Number(raw);
+          if (!Number.isFinite(next)) {
+            onValidityChange(false);
+            return;
+          }
+          onValidityChange(true);
+          onChange(next);
+        }}
+      />
+    );
+  } else if (field.type === "select") {
+    control = (
+      <select
+        id={inputId}
+        aria-label={field.description}
+        className="h-9 w-full rounded-md border border-input bg-transparent px-3 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        value={typeof value === "string" ? value : ""}
+        onChange={(event) => {
+          onValidityChange(true);
+          onChange(event.target.value);
+        }}
+      >
+        {field.options?.map((option) => (
+          <option key={option || "default"} value={option}>{option || "Automatic"}</option>
+        ))}
+      </select>
+    );
+  } else if (field.type === "list") {
+    control = (
+      <div className="space-y-1.5">
+        <Textarea
+          id={inputId}
+          aria-label={field.description}
+          className="min-h-24 font-mono text-xs"
+          value={inputText}
+          aria-invalid={invalid}
+          onChange={(event) => {
+            const nextText = event.target.value;
+            onInputTextChange(nextText);
+            const parsed = parseListValue(nextText);
+            if (parsed === null) {
+              onValidityChange(false);
+              return;
+            }
+            onValidityChange(true);
+            onChange(parsed);
+          }}
+        />
+        <p className={invalid ? "text-xs text-destructive" : "text-xs text-muted-foreground"}>
+          {invalid ? "Enter a valid JSON list before saving." : "JSON list · strings, numbers, and booleans are supported."}
+        </p>
+      </div>
+    );
+  } else {
+    control = (
+      <Input
+        id={inputId}
+        aria-label={field.description}
+        value={typeof value === "string" ? value : ""}
+        onChange={(event) => {
+          onValidityChange(true);
+          onChange(event.target.value);
+        }}
+      />
+    );
+  }
+
+  return (
+    <article className="rounded-xl border border-border/60 bg-background/50 p-4 transition-colors focus-within:border-ember/40">
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0">
+          <Label htmlFor={inputId} className="text-sm font-medium">{field.description}</Label>
+          <p className="mt-1 truncate font-mono text-[11px] text-muted-foreground" title={path}>{path}</p>
+        </div>
+        {canRestore && (
+          <Button
+            type="button"
+            size="sm"
+            variant="ghost"
+            className="h-7 shrink-0 px-2 text-xs"
+            aria-label={`Restore default for ${field.description}`}
+            onClick={() => {
+              if (field.type === "list" || field.type === "number") {
+                onInputTextChange(fieldTextValue(field, defaultValue));
+              }
+              onValidityChange(true);
+              onChange(defaultValue);
+            }}
+          >
+            <RotateCcwIcon className="size-3" /> Default
+          </Button>
+        )}
+      </div>
+      <div className={field.type === "boolean" ? "mt-3 flex justify-end" : "mt-3"}>{control}</div>
+      {field.type === "number" && invalid && <p className="mt-1.5 text-xs text-destructive">Enter a number before saving.</p>}
+    </article>
+  );
+}
+
+function CredentialRow({
+  envKey,
+  entry,
+  onCommitted,
+}: {
+  envKey: string;
+  entry: HermesEnvironment[string];
+  onCommitted: (isSet: boolean) => Promise<boolean>;
+}) {
+  const label = entry.provider_label || titleCase(envKey.replace(/_(?:API_)?KEY$|_TOKEN$/, ""));
+  const [value, setValue] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [confirmRemove, setConfirmRemove] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [feedback, setFeedback] = useState<string | null>(null);
+
+  const save = () => {
+    if (busy) return;
+    setBusy(true);
+    setError(null);
+    setFeedback(null);
+    void attemptCredentialMutation(() => saveHermesCredential(envKey, value), "save").then((saved) => {
+      if (saved) {
+        setValue("");
+        return onCommitted(true).then((refreshed) => {
+          if (!refreshed) setFeedback("Credential saved. Live status could not be refreshed.");
+        }).catch((refreshError: unknown) => {
+          console.warn("Hermes credential status refresh failed", refreshError instanceof Error ? refreshError.name : "UnknownError");
+          setFeedback("Credential saved. Live status could not be refreshed.");
+        });
+      }
+      setError("Credential could not be saved.");
+    }).finally(() => {
+      setBusy(false);
+    });
+  };
+
+  const remove = () => {
+    if (busy) return;
+    if (!confirmRemove) {
+      setConfirmRemove(true);
+      return;
+    }
+    setBusy(true);
+    setError(null);
+    setFeedback(null);
+    void attemptCredentialMutation(() => removeHermesCredential(envKey), "remove").then((removed) => {
+      if (removed) {
+        setConfirmRemove(false);
+        return onCommitted(false).then((refreshed) => {
+          if (!refreshed) setFeedback("Credential removed. Live status could not be refreshed.");
+        }).catch((refreshError: unknown) => {
+          console.warn("Hermes credential status refresh failed", refreshError instanceof Error ? refreshError.name : "UnknownError");
+          setFeedback("Credential removed. Live status could not be refreshed.");
+        });
+      }
+      setError("Credential could not be removed.");
+    }).finally(() => {
+      setBusy(false);
+    });
+  };
+
+  return (
+    <article className="rounded-xl border border-border/60 bg-background/50 p-4">
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          <h4 className="text-sm font-semibold">{label}</h4>
+          <p className="mt-1 text-xs text-muted-foreground">{entry.description || envKey}</p>
+        </div>
+        <Badge variant="secondary" className={entry.is_set ? "bg-forest/10 text-forest" : undefined}>
+          {entry.is_set ? <CheckCircle2Icon className="size-3" /> : <KeyRoundIcon className="size-3" />}
+          {entry.is_set ? "Connected" : "Not set"}
+        </Badge>
+      </div>
+      {entry.is_set && entry.redacted_value && (
+        <p className="mt-3 rounded-md bg-muted/40 px-3 py-2 font-mono text-xs text-muted-foreground">{entry.redacted_value}</p>
+      )}
+      <div className="mt-3 grid gap-2 sm:grid-cols-[1fr_auto]">
+        <div>
+          <Label htmlFor={`hermes-env-${envKey}`} className="sr-only">New {label} API key</Label>
+          <Input
+            id={`hermes-env-${envKey}`}
+            type="password"
+            autoComplete="off"
+            placeholder={entry.is_set ? "Replace credential" : "Paste credential"}
+            value={value}
+            onChange={(event) => setValue(event.target.value)}
+          />
+        </div>
+        <Button size="sm" disabled={busy || value.length === 0} aria-label={`Save ${label} credential`} onClick={save}>
+          Save
+        </Button>
+      </div>
+      <div className="mt-2 flex items-center justify-between gap-3">
+        <span className="font-mono text-[10px] text-muted-foreground">{envKey}</span>
+        {entry.is_set && (
+          <Button
+            size="sm"
+            variant={confirmRemove ? "destructive" : "ghost"}
+            className="h-7 px-2 text-xs"
+            disabled={busy}
+            aria-label={`Remove ${label} credential`}
+            onClick={remove}
+          >
+            <Trash2Icon className="size-3" /> {confirmRemove ? "Confirm remove" : "Remove"}
+          </Button>
+        )}
+      </div>
+      {error && <p role="alert" className="mt-2 text-xs text-destructive">{error}</p>}
+      {feedback && <p role="status" className="mt-2 text-xs text-warning">{feedback}</p>}
+    </article>
+  );
+}
+
+export function HermesConfigurationDialog({ open, onOpenChange, version }: HermesConfigurationDialogProps) {
+  const [configuration, setConfiguration] = useState<HermesConfiguration | null>(null);
+  const [environment, setEnvironment] = useState<HermesEnvironment>({});
+  const [drafts, setDrafts] = useState<Record<string, HermesConfigValue>>({});
+  const [invalidFields, setInvalidFields] = useState<Record<string, true>>({});
+  const [fieldTexts, setFieldTexts] = useState<Record<string, string>>({});
+  const [category, setCategory] = useState("general");
+  const [search, setSearch] = useState("");
+  const [credentialSearch, setCredentialSearch] = useState("");
+  const [tab, setTab] = useState("settings");
+  const [loading, setLoading] = useState(open);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [notice, setNotice] = useState<string | null>(null);
+  const [previousOpen, setPreviousOpen] = useState(open);
+  const hasLoadedConfiguration = useRef(false);
+  const environmentRevision = useRef(0);
+  const pendingConfigValues = useRef<Record<string, HermesConfigValue>>({});
+  const latestConfiguration = useRef(configuration);
+  latestConfiguration.current = configuration;
+
+  if (open !== previousOpen) {
+    setPreviousOpen(open);
+    if (open) {
+      setLoading(true);
+      setError(null);
+      setNotice(null);
+      setTab("settings");
+    }
+  }
+
+  const commitEnvironmentMutation = async (envKey: string, isSet: boolean): Promise<boolean> => {
+    const revision = environmentRevision.current + 1;
+    environmentRevision.current = revision;
+    setEnvironment((current) => {
+      const entry = current[envKey];
+      if (!entry) return current;
+      return {
+        ...current,
+        [envKey]: {
+          ...entry,
+          is_set: isSet,
+          redacted_value: "",
+        },
+      };
+    });
+    try {
+      const nextEnvironment = await loadHermesEnvironment();
+      if (revision === environmentRevision.current) setEnvironment(nextEnvironment);
+      return true;
+    } catch (refreshError) {
+      if (revision !== environmentRevision.current) return true;
+      console.warn("Hermes credential status refresh failed", refreshError instanceof Error ? refreshError.name : "UnknownError");
+      return false;
+    }
+  };
+
+  useEffect(() => {
+    if (!open) return;
+    let cancelled = false;
+    const environmentReadRevision = environmentRevision.current;
+    void Promise.all([loadHermesConfiguration(), loadHermesEnvironment()]).then(([nextConfig, nextEnv]) => {
+      if (cancelled) return;
+      setConfiguration(nextConfig);
+      if (environmentReadRevision === environmentRevision.current) setEnvironment(nextEnv);
+      setDrafts((current) => Object.fromEntries(
+        Object.entries(current).filter(([path]) => Object.hasOwn(nextConfig.fields, path)),
+      ));
+      setInvalidFields((current) => Object.fromEntries(
+        Object.entries(current).filter(([path]) => Object.hasOwn(nextConfig.fields, path)),
+      ));
+      setFieldTexts((current) => Object.fromEntries(
+        Object.entries(current).filter(([path]) => Object.hasOwn(nextConfig.fields, path)),
+      ));
+      if (!hasLoadedConfiguration.current) {
+        hasLoadedConfiguration.current = true;
+        setCategory(nextConfig.categoryOrder[0] ?? Object.values(nextConfig.fields)[0]?.category ?? "general");
+      }
+    }).catch((loadError: unknown) => {
+      if (!cancelled) setError(loadError instanceof HermesConfigurationError ? loadError.message : "Hermes configuration is unavailable.");
+    }).finally(() => {
+      if (!cancelled) setLoading(false);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [open]);
+
+  const categories = configurationCategories(configuration);
+  const visibleFields = matchingConfigurationFields(configuration, search, category);
+  const visibleCredentials = matchingCredentials(environment, credentialSearch);
+  const invalidFieldCount = Object.keys(invalidFields).length;
+  const draftCount = Object.keys(drafts).length;
+
+  const save = async () => {
+    if (!configuration || invalidFieldCount > 0) return;
+    const changes = Object.entries(drafts).map(([path, value]) => ({ path, value }));
+    if (changes.length === 0) return;
+    const submittedFieldTexts = fieldTexts;
+    pendingConfigValues.current = Object.fromEntries(changes.map(({ path, value }) => [path, value]));
+    setSaving(true);
+    setError(null);
+    setNotice(null);
+    try {
+      await saveHermesConfiguration(changes);
+      setConfiguration((current) => {
+        const latest = current ?? configuration;
+        let updatedConfig = latest.config;
+        for (const change of changes) updatedConfig = setConfigValue(updatedConfig, change.path, change.value);
+        return { ...latest, config: updatedConfig };
+      });
+      setDrafts((current) => {
+        const next = { ...current };
+        for (const change of changes) {
+          if (Object.hasOwn(current, change.path) && Object.is(current[change.path], change.value)) {
+            delete next[change.path];
+          }
+        }
+        return next;
+      });
+      setFieldTexts((current) => {
+        const next = { ...current };
+        for (const change of changes) {
+          if (Object.hasOwn(submittedFieldTexts, change.path)
+            && current[change.path] === submittedFieldTexts[change.path]) {
+            delete next[change.path];
+          }
+        }
+        return next;
+      });
+      setNotice("Hermes settings saved");
+    } catch (saveError) {
+      setError(saveError instanceof HermesConfigurationError ? saveError.message : "Hermes configuration could not be saved.");
+      setDrafts((current) => {
+        const next = { ...current };
+        const authoritativeConfig = latestConfiguration.current?.config ?? configuration.config;
+        for (const change of changes) {
+          const storedValue = configValueAt(authoritativeConfig, change.path);
+          if (!Object.hasOwn(current, change.path)) {
+            if (!valuesEqual(change.value, storedValue)) next[change.path] = change.value;
+          } else if (valuesEqual(current[change.path], storedValue)) {
+            delete next[change.path];
+          }
+        }
+        return next;
+      });
+    } finally {
+      pendingConfigValues.current = {};
+      setSaving(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent
+        className="flex h-[min(86vh,820px)] flex-col gap-0 overflow-hidden p-0 sm:max-w-5xl"
+        style={{ zIndex: SHELL_Z_INDEX.popover }}
+        overlayStyle={{ zIndex: SHELL_Z_INDEX.popover }}
+      >
+        <DialogHeader className="border-b border-border/60 bg-gradient-to-r from-ember/8 via-background to-forest/5 px-6 py-5 pr-14">
+          <div className="flex flex-wrap items-start justify-between gap-3">
+            <div>
+              <DialogTitle className="flex items-center gap-2 text-xl">
+                <SparklesIcon className="size-5 text-ember" /> Configure Hermes
+              </DialogTitle>
+              <DialogDescription className="mt-1.5">
+                A friendly control center generated from the exact Hermes version installed on this computer.
+              </DialogDescription>
+            </div>
+            {version && <Badge variant="outline">Version {version}</Badge>}
+          </div>
+        </DialogHeader>
+
+        {loading ? (
+          <div role="status" className="flex flex-1 items-center justify-center gap-2 text-sm text-muted-foreground">
+            <LoaderCircleIcon className="size-4 animate-spin" /> Reading Hermes capabilities
+          </div>
+        ) : error && !configuration ? (
+          <div role="alert" className="flex flex-1 flex-col items-center justify-center gap-3 p-8 text-center">
+            <AlertTriangleIcon className="size-6 text-destructive" />
+            <p className="text-sm font-medium">{error}</p>
+          </div>
+        ) : configuration ? (
+          <Tabs value={tab} onValueChange={setTab} className="min-h-0 flex-1 gap-0">
+            <div className="flex items-center justify-between gap-3 border-b border-border/60 px-6 py-3">
+              <TabsList>
+                <TabsTrigger value="settings" onClick={() => {
+                  setTab("settings");
+                }}><Settings2Icon /> Settings</TabsTrigger>
+                <TabsTrigger value="credentials" onClick={() => {
+                  setTab("credentials");
+                }}><KeyRoundIcon /> Credentials</TabsTrigger>
+              </TabsList>
+              <p className="hidden text-xs text-muted-foreground sm:block">
+                {Object.keys(configuration.fields).length} settings discovered from this Hermes installation
+              </p>
+            </div>
+
+            <TabsContent value="settings" className="min-h-0">
+              <div className="grid h-full min-h-0 md:grid-cols-[220px_1fr]">
+                <aside className="hidden min-h-0 border-r border-border/60 bg-muted/15 p-3 md:block">
+                  <ScrollArea className="h-full">
+                    <nav aria-label="Hermes setting categories" className="space-y-1 pr-2">
+                      {categories.map((entry) => (
+                        <button
+                          key={entry.id}
+                          type="button"
+                          aria-label={`${titleCase(entry.id)}, ${entry.count} ${entry.count === 1 ? "setting" : "settings"}`}
+                          aria-current={!search && category === entry.id ? "page" : undefined}
+                          className={`flex w-full items-center justify-between rounded-lg px-3 py-2 text-left text-sm transition-colors ${!search && category === entry.id ? "bg-ember/10 font-medium text-foreground" : "text-muted-foreground hover:bg-muted/60 hover:text-foreground"}`}
+                          onClick={() => {
+                            setSearch("");
+                            setCategory(entry.id);
+                          }}
+                        >
+                          <span>{titleCase(entry.id)}</span>
+                          <span className="text-xs opacity-70">{entry.count}</span>
+                        </button>
+                      ))}
+                    </nav>
+                  </ScrollArea>
+                </aside>
+                <div className="flex min-h-0 flex-col">
+                  <div className="border-b border-border/60 px-4 py-3 sm:px-5">
+                    <select
+                      aria-label="Hermes setting category"
+                      className="mb-2 h-9 w-full rounded-md border border-input bg-transparent px-3 text-sm md:hidden"
+                      value={category}
+                      onChange={(event) => {
+                        setSearch("");
+                        setCategory(event.target.value);
+                      }}
+                    >
+                      {categories.map((entry) => (
+                        <option key={entry.id} value={entry.id}>{titleCase(entry.id)} ({entry.count})</option>
+                      ))}
+                    </select>
+                    <div className="relative">
+                      <SearchIcon className="pointer-events-none absolute left-3 top-2.5 size-4 text-muted-foreground" />
+                      <Input
+                        type="search"
+                        aria-label="Search Hermes settings"
+                        placeholder="Search all settings and command capabilities…"
+                        className="pl-9"
+                        value={search}
+                        onChange={(event) => setSearch(event.target.value)}
+                      />
+                    </div>
+                  </div>
+                  <ScrollArea className="min-h-0 flex-1">
+                    <div className="space-y-3 p-4 pb-8 sm:p-5">
+                      <div className="flex items-center justify-between gap-3">
+                        <div>
+                          <h3 className="text-sm font-semibold">{search ? "Search results" : titleCase(category)}</h3>
+                          <p className="text-xs text-muted-foreground">{visibleFields.length} configurable {visibleFields.length === 1 ? "setting" : "settings"}</p>
+                        </div>
+                        {category === "security" && !search && (
+                          <Badge variant="outline" className="text-warning"><ShieldCheckIcon className="size-3" /> Review carefully</Badge>
+                        )}
+                      </div>
+                      {visibleFields.map(([path, field]) => {
+                        const storedValue = configValueAt(configuration.config, path);
+                        const value = Object.hasOwn(drafts, path) ? drafts[path] : storedValue;
+                        return (
+                          <FieldEditor
+                            key={path}
+                            path={path}
+                            field={field}
+                            value={value}
+                            defaultValue={configValueAt(configuration.defaults, path)}
+                            inputText={fieldTexts[path] ?? fieldTextValue(field, value)}
+                            invalid={Object.hasOwn(invalidFields, path)}
+                            onInputTextChange={(nextText) => {
+                              setFieldTexts((current) => ({ ...current, [path]: nextText }));
+                            }}
+                            onValidityChange={(valid) => {
+                              setInvalidFields((current) => {
+                                if (valid) {
+                                  if (!Object.hasOwn(current, path)) return current;
+                                  const rest = { ...current };
+                                  delete rest[path];
+                                  return rest;
+                                }
+                                return Object.hasOwn(current, path) ? current : { ...current, [path]: true };
+                              });
+                            }}
+                            onChange={(nextValue) => {
+                              setNotice(null);
+                              setDrafts((current) => {
+                                const comparisonValue = Object.hasOwn(pendingConfigValues.current, path)
+                                  ? pendingConfigValues.current[path]
+                                  : storedValue;
+                                if (valuesEqual(nextValue, comparisonValue)) {
+                                  const rest = { ...current };
+                                  delete rest[path];
+                                  return rest;
+                                }
+                                return { ...current, [path]: nextValue };
+                              });
+                            }}
+                          />
+                        );
+                      })}
+                      {visibleFields.length === 0 && (
+                        <div className="rounded-xl border border-dashed p-8 text-center text-sm text-muted-foreground">No Hermes settings match that search.</div>
+                      )}
+                    </div>
+                  </ScrollArea>
+                  <div className="flex flex-wrap items-center justify-between gap-3 border-t border-border/60 bg-background/95 px-4 py-3 sm:px-5">
+                    <div aria-live="polite" className="text-xs">
+                      {error ? <span className="text-destructive">{error}</span>
+                        : notice ? <span className="flex items-center gap-1 text-forest"><CheckCircle2Icon className="size-3" />{notice}{draftCount > 0 && ` · ${draftCount} newer unsaved ${draftCount === 1 ? "change" : "changes"}`}</span>
+                          : invalidFieldCount > 0 ? <span className="text-destructive">Fix {invalidFieldCount} invalid {invalidFieldCount === 1 ? "setting" : "settings"} before saving.</span>
+                          : <span className="text-muted-foreground">{draftCount} unsaved {draftCount === 1 ? "change" : "changes"}</span>}
+                    </div>
+                    <div className="flex gap-2">
+                      <Button size="sm" variant="outline" disabled={saving || (draftCount === 0 && invalidFieldCount === 0)} onClick={() => {
+                        setDrafts({});
+                        setInvalidFields({});
+                        setFieldTexts({});
+                      }}>Discard</Button>
+                      <Button size="sm" disabled={saving || draftCount === 0 || invalidFieldCount > 0} aria-label="Save Hermes settings" onClick={() => void save()}>
+                        {saving && <LoaderCircleIcon className="size-3.5 animate-spin" />} Save changes
+                      </Button>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </TabsContent>
+
+            <TabsContent value="credentials" className="min-h-0">
+              <div className="flex h-full min-h-0 flex-col">
+                <div className="border-b border-border/60 px-4 py-3 sm:px-6">
+                  <div className="flex items-start gap-3 rounded-xl border border-forest/20 bg-forest/5 p-3">
+                    <ShieldCheckIcon className="mt-0.5 size-4 shrink-0 text-forest" />
+                    <div>
+                      <p className="text-sm font-medium">Secrets stay write-only</p>
+                      <p className="mt-0.5 text-xs text-muted-foreground">Hermes returns only connection state and redacted previews. Channel credentials remain in their dedicated channel setup.</p>
+                    </div>
+                  </div>
+                  <div className="relative mt-3">
+                    <SearchIcon className="pointer-events-none absolute left-3 top-2.5 size-4 text-muted-foreground" />
+                    <Input type="search" aria-label="Search Hermes credentials" placeholder="Search providers and credentials…" className="pl-9" value={credentialSearch} onChange={(event) => setCredentialSearch(event.target.value)} />
+                  </div>
+                </div>
+                <ScrollArea className="min-h-0 flex-1">
+                  <div className="grid gap-3 p-4 pb-8 sm:grid-cols-2 sm:p-6">
+                    {visibleCredentials.map(([key, entry]) => (
+                      <CredentialRow
+                        key={key}
+                        envKey={key}
+                        entry={entry}
+                        onCommitted={(isSet) => commitEnvironmentMutation(key, isSet)}
+                      />
+                    ))}
+                    {visibleCredentials.length === 0 && (
+                      <div className="col-span-full rounded-xl border border-dashed p-8 text-center text-sm text-muted-foreground">No credentials match that search.</div>
+                    )}
+                  </div>
+                </ScrollArea>
+              </div>
+            </TabsContent>
+          </Tabs>
+        ) : null}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/shell/src/components/ui/dialog.tsx
+++ b/shell/src/components/ui/dialog.tsx
@@ -51,13 +51,15 @@ function DialogContent({
   className,
   children,
   showCloseButton = true,
+  overlayStyle,
   ...props
 }: React.ComponentProps<typeof DialogPrimitive.Content> & {
   showCloseButton?: boolean
+  overlayStyle?: React.CSSProperties
 }) {
   return (
     <DialogPortal data-slot="dialog-portal">
-      <DialogOverlay />
+      <DialogOverlay style={overlayStyle} />
       <DialogPrimitive.Content
         data-slot="dialog-content"
         className={cn(

--- a/shell/src/lib/hermes-configuration.ts
+++ b/shell/src/lib/hermes-configuration.ts
@@ -1,0 +1,139 @@
+import { z } from "zod/v4";
+import { getGatewayUrl } from "./gateway";
+
+const RESPONSE_LIMIT_BYTES = 1024 * 1024;
+const READ_TIMEOUT_MS = 10_000;
+const WRITE_TIMEOUT_MS = 15_000;
+
+const ConfigFieldSchema = z.object({
+  type: z.enum(["boolean", "number", "string", "select", "list"]),
+  description: z.string().max(512),
+  category: z.string().max(64),
+  options: z.array(z.string().max(256)).max(128).optional(),
+}).strict();
+
+const ConfigurationSchema = z.object({
+  config: z.record(z.string(), z.unknown()),
+  defaults: z.record(z.string(), z.unknown()),
+  fields: z.record(z.string(), ConfigFieldSchema),
+  categoryOrder: z.array(z.string().max(64)).max(64),
+}).strict();
+
+const EnvironmentEntrySchema = z.object({
+  is_set: z.boolean(),
+  redacted_value: z.string().nullable().optional(),
+  description: z.string().max(512).default(""),
+  url: z.string().nullable().optional(),
+  category: z.string().max(64).default(""),
+  is_password: z.boolean().default(true),
+  tools: z.array(z.string()).max(128).default([]),
+  advanced: z.boolean().default(false),
+  channel_managed: z.boolean().default(false),
+  provider: z.string().max(128).default(""),
+  provider_label: z.string().max(128).default(""),
+});
+
+const EnvironmentSchema = z.record(z.string(), EnvironmentEntrySchema);
+const SaveResponseSchema = z.object({ ok: z.literal(true) }).passthrough();
+
+export type HermesConfiguration = z.infer<typeof ConfigurationSchema>;
+export type HermesConfigField = z.infer<typeof ConfigFieldSchema>;
+export type HermesEnvironment = z.infer<typeof EnvironmentSchema>;
+export type HermesConfigValue = string | number | boolean | Array<string | number | boolean>;
+export interface HermesConfigChange {
+  path: string;
+  value: HermesConfigValue;
+}
+
+export class HermesConfigurationError extends Error {
+  constructor(message = "Hermes configuration is unavailable.") {
+    super(message);
+    this.name = "HermesConfigurationError";
+  }
+}
+
+async function boundedJson(response: Response): Promise<unknown> {
+  const text = await response.text();
+  if (new TextEncoder().encode(text).byteLength > RESPONSE_LIMIT_BYTES) {
+    throw new HermesConfigurationError();
+  }
+  try {
+    return JSON.parse(text) as unknown;
+  } catch (error) {
+    console.warn(
+      "Hermes configuration response parsing failed",
+      error instanceof Error ? error.name : "UnknownError",
+    );
+    throw new HermesConfigurationError();
+  }
+}
+
+async function request(path: string, init: RequestInit = {}, timeoutMs = READ_TIMEOUT_MS): Promise<unknown> {
+  let response: Response;
+  try {
+    response = await fetch(`${getGatewayUrl()}${path}`, {
+      ...init,
+      signal: AbortSignal.timeout(timeoutMs),
+    });
+  } catch (error) {
+    console.warn(
+      "Hermes configuration request failed",
+      error instanceof Error ? error.name : "UnknownError",
+    );
+    throw new HermesConfigurationError();
+  }
+  if (!response.ok) {
+    throw new HermesConfigurationError(
+      init.method ? "Hermes configuration could not be saved." : undefined,
+    );
+  }
+  return boundedJson(response);
+}
+
+export async function loadHermesConfiguration(): Promise<HermesConfiguration> {
+  const parsed = ConfigurationSchema.safeParse(await request("/api/hermes/configuration"));
+  if (!parsed.success) throw new HermesConfigurationError();
+  return parsed.data;
+}
+
+export async function loadHermesEnvironment(): Promise<HermesEnvironment> {
+  const parsed = EnvironmentSchema.safeParse(await request("/api/hermes/env"));
+  if (!parsed.success) throw new HermesConfigurationError();
+  return parsed.data;
+}
+
+export async function saveHermesConfiguration(changes: HermesConfigChange[]): Promise<void> {
+  const parsed = SaveResponseSchema.safeParse(await request("/api/hermes/configuration", {
+    method: "PUT",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ changes }),
+  }, WRITE_TIMEOUT_MS));
+  if (!parsed.success) throw new HermesConfigurationError("Hermes configuration could not be saved.");
+}
+
+export async function saveHermesCredential(key: string, value: string): Promise<void> {
+  const parsed = SaveResponseSchema.safeParse(await request("/api/hermes/env", {
+    method: "PUT",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ key, value }),
+  }, WRITE_TIMEOUT_MS));
+  if (!parsed.success) throw new HermesConfigurationError("Hermes credential could not be saved.");
+}
+
+export async function removeHermesCredential(key: string): Promise<void> {
+  const parsed = SaveResponseSchema.safeParse(await request("/api/hermes/env", {
+    method: "DELETE",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ key }),
+  }, WRITE_TIMEOUT_MS));
+  if (!parsed.success) throw new HermesConfigurationError("Hermes credential could not be removed.");
+}
+
+export function configValueAt(config: Record<string, unknown>, path: string): unknown {
+  let value: unknown = config;
+  for (const segment of path.split(".")) {
+    if (value === null || typeof value !== "object" || Array.isArray(value)) return undefined;
+    value = (value as Record<string, unknown>)[segment];
+  }
+  return value;
+}

--- a/shell/src/lib/terminal-launch.ts
+++ b/shell/src/lib/terminal-launch.ts
@@ -3,7 +3,6 @@ export type TerminalLaunchAction =
   | "codex-login"
   | "github-ssh-login"
   | "hermes-install"
-  | "hermes-model"
   | "openclaw-install"
   | "openclaw-model-auth";
 
@@ -35,11 +34,6 @@ const TERMINAL_ACTIONS: Record<TerminalLaunchAction, TerminalLaunchConfig> = {
     action: "hermes-install",
     label: "Install Hermes",
     command: "/opt/matrix/bin/matrix-agent-runtime-control install hermes",
-  },
-  "hermes-model": {
-    action: "hermes-model",
-    label: "Hermes provider setup",
-    command: "hermes model",
   },
   "openclaw-install": {
     action: "openclaw-install",

--- a/tests/deploy/customer-vps/openclaw-systemd.test.ts
+++ b/tests/deploy/customer-vps/openclaw-systemd.test.ts
@@ -1,5 +1,7 @@
-import { access, readFile } from "node:fs/promises";
+import { access, chmod, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { execFile } from "node:child_process";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { promisify } from "node:util";
 import { describe, expect, it } from "vitest";
 
@@ -23,9 +25,64 @@ describe("customer VPS OpenClaw runtime", () => {
     expect(installer).toContain("--connect-timeout 10 --max-time 180");
     expect(installer).toContain("sha512sum -c");
     expect(installer).toContain("timeout 300");
-    expect(installer).toContain('[ "$node_major" -eq 24 ] && [ "$node_minor" -lt 15 ]');
+    expect(installer).toContain('NODE_RUNTIME_VERSION="${NODE_RUNTIME_VERSION:-24.18.0}"');
+    expect(installer).toContain(
+      'NODE_RUNTIME_SHA256="${NODE_RUNTIME_SHA256:-783130984963db7ba9cbd01089eaf2c2efb055c7c1693c943174b967b3050cb8}"',
+    );
+    expect(installer).toContain("upgrade_bundled_node_runtime");
     expect(installer).toContain("npm-shrinkwrap.json");
     expect(installer).not.toContain("@latest");
+  });
+
+  it.each([
+    ["22.22.3", true],
+    ["22.23.0", true],
+    ["23.11.1", false],
+    ["24.14.1", false],
+    ["24.15.0", true],
+    ["25.8.9", false],
+    ["25.9.0", true],
+    ["26.0.0", true],
+  ])("matches OpenClaw 2026.7.1's Node engine for %s", async (version, compatible) => {
+    const invocation = `source "${installerPath}"; openclaw_node_is_compatible "$1"`;
+    const result = execFileAsync("bash", ["-c", invocation, "openclaw-node-check", version]);
+    if (compatible) {
+      await expect(result).resolves.toMatchObject({ stderr: "" });
+    } else {
+      await expect(result).rejects.toMatchObject({ code: 1 });
+    }
+  });
+
+  it("repairs a retained incompatible Node runtime before downloading OpenClaw", async () => {
+    const installer = await readFile(installerPath, "utf8");
+    const main = installer.slice(installer.indexOf("main()"));
+
+    expect(main.indexOf("check_admission")).toBeLessThan(main.indexOf("ensure_compatible_node_runtime"));
+    expect(main.indexOf("ensure_compatible_node_runtime")).toBeLessThan(main.indexOf('"$OPENCLAW_TARBALL_URL"'));
+    expect(installer).toContain('mv -f "$replacement" "$MATRIX_NODE_PREFIX/bin/node"');
+    expect(installer).toContain('openclaw_node_is_compatible "$installed_version"');
+  });
+
+  it("rechecks compatibility after repairing a retained Node runtime", async () => {
+    const prefix = await mkdtemp(join(tmpdir(), "matrix-openclaw-node-test-"));
+    try {
+      await mkdir(join(prefix, "bin"));
+      await writeFile(join(prefix, "version"), "24.14.1\n");
+      await writeFile(join(prefix, "bin/node"), `#!/usr/bin/env bash\ncat "${join(prefix, "version")}"\n`);
+      await chmod(join(prefix, "bin/node"), 0o755);
+      const invocation = [
+        `source "${installerPath}"`,
+        "MATRIX_NODE_PREFIX=\"$1\"",
+        "upgrade_bundled_node_runtime() { printf '24.18.0\\n' >\"$MATRIX_NODE_PREFIX/version\"; }",
+        "ensure_compatible_node_runtime",
+      ].join("; ");
+
+      await expect(execFileAsync("bash", ["-c", invocation, "node-repair", prefix]))
+        .resolves.toMatchObject({ stderr: "" });
+      expect(await readFile(join(prefix, "version"), "utf8")).toBe("24.18.0\n");
+    } finally {
+      await rm(prefix, { recursive: true, force: true });
+    }
   });
 
   it("fails admission before downloading on constrained hosts", async () => {

--- a/tests/gateway/hermes-client.test.ts
+++ b/tests/gateway/hermes-client.test.ts
@@ -1,9 +1,18 @@
-import { describe, expect, it, vi } from "vitest";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   createHermesDashboardClient,
 } from "../../packages/gateway/src/agent-config/hermes-client.js";
 
 describe("Hermes dashboard client", () => {
+  const cleanupPaths: string[] = [];
+
+  afterEach(() => {
+    for (const path of cleanupPaths.splice(0)) rmSync(path, { recursive: true, force: true });
+  });
+
   it("forwards the caller signal and rejects oversized JSON responses", async () => {
     const fetchImpl = vi.fn(async () => new Response(
       JSON.stringify({ payload: "x".repeat(1024 * 1024) }),
@@ -46,5 +55,41 @@ describe("Hermes dashboard client", () => {
         redirect: "error",
       }),
     );
+  });
+
+  it("authenticates protected Hermes 0.20 loopback endpoints with the host-owned session token", async () => {
+    const homePath = mkdtempSync(join(tmpdir(), "hermes-dashboard-auth-"));
+    cleanupPaths.push(homePath);
+    const authFilePath = join(homePath, "system/agent-runtime/hermes-dashboard.env");
+    mkdirSync(join(homePath, "system/agent-runtime"), { recursive: true });
+    writeFileSync(authFilePath, [
+      "HERMES_DASHBOARD_BASIC_AUTH_USERNAME=matrix",
+      `HERMES_DASHBOARD_BASIC_AUTH_PASSWORD=${"a".repeat(64)}`,
+      `HERMES_DASHBOARD_BASIC_AUTH_SECRET=${"b".repeat(64)}`,
+      "",
+    ].join("\n"), { mode: 0o600 });
+
+    const fetchImpl = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+      const headers = new Headers(init?.headers);
+      expect(new URL(String(input)).pathname).toBe("/api/status");
+      const sessionToken = headers.get("x-hermes-session-token");
+      if (sessionToken === null) {
+        return Response.json({ detail: "Unauthorized" }, { status: 401 });
+      }
+      expect(sessionToken).toBe("b".repeat(64));
+      expect(headers.has("authorization")).toBe(false);
+      expect(headers.has("cookie")).toBe(false);
+      return Response.json({ gateway_running: true });
+    });
+    const client = createHermesDashboardClient({
+      baseUrl: "http://127.0.0.1:9119",
+      fetchImpl,
+      authFilePath,
+    });
+
+    await expect(client.readJson("/api/status", new AbortController().signal)).resolves.toEqual({
+      gateway_running: true,
+    });
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
   });
 });

--- a/tests/gateway/hermes-proxy.test.ts
+++ b/tests/gateway/hermes-proxy.test.ts
@@ -47,6 +47,17 @@ function withAuth(app: Hono): Hono {
   return authed;
 }
 
+function authenticatedApp(deps: HermesRouteDeps): Hono {
+  const app = new Hono();
+  app.use("*", async (c, next) => {
+    markAuthContextReady(c as Parameters<typeof markAuthContextReady>[0]);
+    c.set(JWT_CLAIMS_CONTEXT_KEY as never, { sub: "user-123" });
+    await next();
+  });
+  app.route("/api/hermes", createHermesRoutes(deps));
+  return app;
+}
+
 function upstreamJson(data: unknown, status = 200): Response {
   return new Response(JSON.stringify(data), {
     status,
@@ -117,6 +128,159 @@ describe("Allowlist", () => {
 
     const res = await authed.request("/api/hermes/config/extra/unknown");
     expect(res.status).toBe(404);
+  });
+});
+
+describe("Hermes configuration management", () => {
+  const schema = {
+    fields: {
+      model: { type: "string", description: "Default model", category: "general" },
+      "agent.max_turns": { type: "number", description: "Maximum turns", category: "agent" },
+      "memory.memory_enabled": { type: "boolean", description: "Use memory", category: "memory" },
+      "approvals.mode": {
+        type: "select",
+        description: "Dangerous command approval mode",
+        category: "security",
+        options: ["ask", "deny"],
+      },
+      "auxiliary.vision.api_key": { type: "string", description: "Secret", category: "auxiliary" },
+    },
+    category_order: ["general", "agent", "memory", "security", "auxiliary"],
+  };
+  const currentConfig = {
+    model: "anthropic/claude-sonnet-4.6",
+    agent: { max_turns: 90 },
+    memory: { memory_enabled: true },
+    approvals: { mode: "ask" },
+    auxiliary: { vision: { api_key: "never-send-this-to-the-browser" } },
+  };
+
+  function makeClient(fetchImpl: HermesRouteDeps["client"]["fetch"]): NonNullable<HermesRouteDeps["client"]> {
+    return {
+      fetch: fetchImpl,
+      readJson: vi.fn(),
+      requestJson: vi.fn(),
+    };
+  }
+
+  it("aggregates the exact-version schema, defaults, and config without secret-bearing paths", async () => {
+    const upstreamFetch = vi.fn(async (path: string) => {
+      if (path === "/api/config") return upstreamJson(currentConfig);
+      if (path === "/api/config/defaults") return upstreamJson(currentConfig);
+      if (path === "/api/config/schema") return upstreamJson(schema);
+      return upstreamJson({}, 404);
+    });
+    const app = authenticatedApp({ client: makeClient(upstreamFetch) });
+
+    const res = await app.request("/api/hermes/configuration");
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.config.auxiliary?.vision?.api_key).toBeUndefined();
+    expect(body.defaults.auxiliary?.vision?.api_key).toBeUndefined();
+    expect(body.fields["auxiliary.vision.api_key"]).toBeUndefined();
+    expect(body.fields["agent.max_turns"]).toEqual(expect.objectContaining({ type: "number" }));
+    expect(body.categoryOrder).toEqual(schema.category_order);
+    expect(upstreamFetch).toHaveBeenCalledTimes(3);
+  });
+
+  it("accepts the 679-field schema published by Hermes Agent 0.20", async () => {
+    const exactVersionFields = Object.fromEntries(Array.from({ length: 679 }, (_, index) => [
+      `section.field_${index}`,
+      { type: "string", description: `Field ${index}`, category: "section" },
+    ]));
+    const upstreamFetch = vi.fn(async (path: string) => {
+      if (path === "/api/config/schema") {
+        return upstreamJson({ fields: exactVersionFields, category_order: ["section"] });
+      }
+      if (path === "/api/config" || path === "/api/config/defaults") return upstreamJson({ section: {} });
+      return upstreamJson({}, 404);
+    });
+    const app = authenticatedApp({ client: makeClient(upstreamFetch) });
+
+    const res = await app.request("/api/hermes/configuration");
+
+    expect(res.status).toBe(200);
+    expect(Object.keys((await res.json()).fields)).toHaveLength(679);
+  });
+
+  it("validates and applies only changed schema paths while preserving server-side secrets", async () => {
+    let savedBody: unknown;
+    const upstreamFetch = vi.fn(async (path: string, init?: RequestInit) => {
+      if (path === "/api/config" && init?.method === "PUT") {
+        savedBody = JSON.parse(String(init.body));
+        return upstreamJson({ ok: true });
+      }
+      if (path === "/api/config") return upstreamJson(currentConfig);
+      if (path === "/api/config/schema") return upstreamJson(schema);
+      return upstreamJson({}, 404);
+    });
+    const app = authenticatedApp({ client: makeClient(upstreamFetch) });
+
+    const res = await app.request("/api/hermes/configuration", {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        changes: [
+          { path: "agent.max_turns", value: 120 },
+          { path: "approvals.mode", value: "deny" },
+        ],
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(savedBody).toEqual({
+      config: {
+        ...currentConfig,
+        agent: { max_turns: 120 },
+        approvals: { mode: "deny" },
+      },
+    });
+    expect(JSON.stringify(await res.json())).not.toContain("never-send-this-to-the-browser");
+  });
+
+  it.each([
+    [{ path: "unknown.field", value: true }],
+    [{ path: "agent.max_turns", value: "unbounded" }],
+    [{ path: "approvals.mode", value: "yolo" }],
+    [{ path: "auxiliary.vision.api_key", value: "secret" }],
+    [{ path: "__proto__.polluted", value: true }],
+  ])("rejects unsafe or schema-invalid configuration changes", async (change) => {
+    const upstreamFetch = vi.fn(async (path: string) => {
+      if (path === "/api/config") return upstreamJson(currentConfig);
+      if (path === "/api/config/schema") return upstreamJson(schema);
+      return upstreamJson({}, 404);
+    });
+    const app = authenticatedApp({ client: makeClient(upstreamFetch) });
+
+    const res = await app.request("/api/hermes/configuration", {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ changes: [change] }),
+    });
+
+    expect(res.status).toBe(400);
+    expect(upstreamFetch).not.toHaveBeenCalledWith(
+      "/api/config",
+      expect.objectContaining({ method: "PUT" }),
+    );
+  });
+
+  it("removes a credential through Hermes' write-only env API", async () => {
+    const upstreamFetch = vi.fn(async () => upstreamJson({ ok: true }));
+    const app = authenticatedApp({ client: makeClient(upstreamFetch) });
+
+    const res = await app.request("/api/hermes/env", {
+      method: "DELETE",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ key: "OPENROUTER_API_KEY" }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(upstreamFetch).toHaveBeenCalledWith("/api/env", expect.objectContaining({
+      method: "DELETE",
+      body: JSON.stringify({ key: "OPENROUTER_API_KEY" }),
+    }));
   });
 });
 

--- a/tests/platform/customer-vps-cloud-init.test.ts
+++ b/tests/platform/customer-vps-cloud-init.test.ts
@@ -329,6 +329,13 @@ exit 99
     expect(wrapper).toContain('source /opt/matrix/env/host.env');
     expect(wrapper).toContain('source /opt/matrix/bin/matrix-owner-env');
     expect(wrapper).toContain('HERMES_BIN=');
+    expect(wrapper).toContain('HERMES_DASHBOARD_BASIC_AUTH_USERNAME');
+    expect(wrapper).toContain('HERMES_DASHBOARD_BASIC_AUTH_PASSWORD');
+    expect(wrapper).toContain('HERMES_DASHBOARD_BASIC_AUTH_SECRET');
+    expect(wrapper).toContain('export HERMES_DASHBOARD_SESSION_TOKEN="$HERMES_DASHBOARD_BASIC_AUTH_SECRET"');
+    expect(wrapper).toContain('mktemp "$auth_dir/.hermes-dashboard.env.XXXXXX"');
+    expect(wrapper).toContain('chmod 0600 "$auth_tmp"');
+    expect(wrapper).toContain('mv -n "$auth_tmp" "$auth_file"');
     expect(wrapper).toContain('dashboard --host 127.0.0.1 --port 9119');
     expect(wrapper).toContain('exit 0');
 

--- a/tests/platform/customer-vps-host-bundle.test.ts
+++ b/tests/platform/customer-vps-host-bundle.test.ts
@@ -1014,6 +1014,21 @@ test "$(readlink "$MATRIX_LEGACY_HOME/.hermes")" = "$MATRIX_HOME/.hermes"
     expect(gatewayStart).toBeGreaterThan(daemonReload);
   });
 
+  it('restarts the optional Hermes dashboard after replacing its host wrapper', () => {
+    const root = process.cwd();
+    const syncAgent = readFileSync(join(root, 'distro/customer-vps/host-bin/matrix-sync-agent'), 'utf8');
+
+    expect(syncAgent).toContain('if [ -f "$extract_dir/systemd/matrix-hermes-dashboard.service" ]; then');
+    expect(syncAgent).toContain('sudo systemctl enable matrix-hermes-dashboard.service');
+    expect(syncAgent).toContain('sudo systemctl restart --no-block matrix-hermes-dashboard.service || true');
+    expect(syncAgent.indexOf('log "Updated bin scripts"')).toBeLessThan(
+      syncAgent.indexOf('sudo systemctl restart --no-block matrix-hermes-dashboard.service || true'),
+    );
+    expect(syncAgent.indexOf('sudo systemctl restart --no-block matrix-hermes-dashboard.service || true')).toBeLessThan(
+      syncAgent.indexOf('sudo systemctl start matrix-gateway matrix-shell'),
+    );
+  });
+
   it('sync agent periodically cleans stale local bundle artifacts', () => {
     const root = process.cwd();
     const syncAgent = readFileSync(join(root, 'distro/customer-vps/host-bin/matrix-sync-agent'), 'utf8');

--- a/tests/shell/agent-settings.test.tsx
+++ b/tests/shell/agent-settings.test.tsx
@@ -119,6 +119,17 @@ function response(value: unknown, status = 200) {
   });
 }
 
+function hermesConfiguration() {
+  return {
+    config: { model: "nous/hermes-4-405b" },
+    defaults: { model: "nous/hermes-4-405b" },
+    fields: {
+      model: { type: "string", description: "Default model", category: "general" },
+    },
+    categoryOrder: ["general"],
+  };
+}
+
 afterEach(() => {
   vi.unstubAllGlobals();
 });
@@ -128,6 +139,8 @@ describe("Canvas Agent runtime settings", () => {
     const view = makeView();
     const fetcher = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
       if (String(input).endsWith("/api/settings/api-key")) return response({ valid: true });
+      if (String(input).endsWith("/api/hermes/configuration")) return response(hermesConfiguration());
+      if (String(input).endsWith("/api/hermes/env")) return response({});
       return response(view);
     });
     vi.stubGlobal("fetch", fetcher);
@@ -159,7 +172,8 @@ describe("Canvas Agent runtime settings", () => {
     fireEvent.click(screen.getByRole("button", { name: "Sign in with Claude" }));
     expect(onOpenTerminal).toHaveBeenCalledWith("claude-login");
     fireEvent.click(screen.getByRole("button", { name: "Configure Hermes provider" }));
-    expect(onOpenTerminal).toHaveBeenCalledWith("hermes-model");
+    expect(await screen.findByRole("heading", { name: "Configure Hermes" })).toBeVisible();
+    expect(onOpenTerminal).not.toHaveBeenCalledWith(expect.stringContaining("hermes"));
   });
 
   it("offers visible provider setup when the selected runtime has no catalog", async () => {
@@ -173,12 +187,17 @@ describe("Canvas Agent runtime settings", () => {
     };
     view.runtime.options[0].configured = false;
     const onOpenTerminal = vi.fn();
-    vi.stubGlobal("fetch", vi.fn(async () => response(view)));
+    vi.stubGlobal("fetch", vi.fn(async (input: RequestInfo | URL) => {
+      if (String(input).endsWith("/api/hermes/configuration")) return response(hermesConfiguration());
+      if (String(input).endsWith("/api/hermes/env")) return response({});
+      return response(view);
+    }));
 
     render(<AgentRuntimePanel onOpenTerminal={onOpenTerminal} />);
 
     fireEvent.click(await screen.findByRole("button", { name: "Configure Hermes provider" }));
-    expect(onOpenTerminal).toHaveBeenCalledWith("hermes-model");
+    expect(await screen.findByRole("heading", { name: "Configure Hermes" })).toBeVisible();
+    expect(onOpenTerminal).not.toHaveBeenCalledWith(expect.stringContaining("hermes"));
   });
 
   it("switches only to an installed runtime with the current revision", async () => {

--- a/tests/shell/hermes-configuration.test.tsx
+++ b/tests/shell/hermes-configuration.test.tsx
@@ -1,0 +1,509 @@
+// @vitest-environment jsdom
+
+import React from "react";
+import "@testing-library/jest-dom/vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { HermesConfigurationDialog } from "../../shell/src/components/settings/sections/HermesConfigurationDialog.js";
+
+function response(value: unknown, status = 200) {
+  return new Response(JSON.stringify(value), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+const configuration = {
+  config: {
+    model: "anthropic/claude-sonnet-4.6",
+    agent: { max_turns: 90 },
+    memory: { memory_enabled: true },
+    approvals: { mode: "ask" },
+  },
+  defaults: {
+    model: "anthropic/claude-sonnet-4.6",
+    agent: { max_turns: 60 },
+    memory: { memory_enabled: true },
+    approvals: { mode: "ask" },
+  },
+  fields: {
+    model: { type: "string", description: "Default model", category: "general" },
+    "agent.max_turns": { type: "number", description: "Maximum turns", category: "agent" },
+    "memory.memory_enabled": { type: "boolean", description: "Use long-term memory", category: "memory" },
+    "approvals.mode": {
+      type: "select",
+      description: "Command approval mode",
+      category: "security",
+      options: ["ask", "deny"],
+    },
+  },
+  categoryOrder: ["general", "agent", "memory", "security"],
+};
+
+const environment = {
+  OPENROUTER_API_KEY: {
+    is_set: true,
+    redacted_value: "sk-or-••••••••abcd",
+    description: "OpenRouter API key",
+    url: "https://openrouter.ai/keys",
+    category: "provider",
+    is_password: true,
+    tools: [],
+    advanced: false,
+    channel_managed: false,
+    provider: "openrouter",
+    provider_label: "OpenRouter",
+  },
+  DISCORD_BOT_TOKEN: {
+    is_set: true,
+    redacted_value: "••••discord",
+    description: "Discord bot token",
+    category: "messaging",
+    is_password: true,
+    tools: [],
+    advanced: false,
+    channel_managed: true,
+    provider: "",
+    provider_label: "",
+  },
+};
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("Hermes configuration dialog", () => {
+  it("renders version-aware categories and saves only changed typed fields", async () => {
+    const fetcher = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.endsWith("/api/hermes/configuration") && init?.method === "PUT") {
+        return response({ ok: true, config: { ...configuration.config, agent: { max_turns: 120 } } });
+      }
+      if (url.endsWith("/api/hermes/configuration")) return response(configuration);
+      if (url.endsWith("/api/hermes/env")) return response(environment);
+      return response({}, 404);
+    });
+    vi.stubGlobal("fetch", fetcher);
+
+    render(<HermesConfigurationDialog open onOpenChange={vi.fn()} version="0.17.0" />);
+
+    expect(await screen.findByRole("heading", { name: "Configure Hermes" })).toBeVisible();
+    expect(screen.getByRole("dialog")).toHaveStyle({ zIndex: "11000" });
+    expect(screen.getByRole("dialog")).toHaveClass("sm:max-w-5xl");
+    expect(document.querySelector('[data-slot="dialog-overlay"]')).toHaveStyle({ zIndex: "11000" });
+    expect(screen.getByText("Version 0.17.0")).toBeVisible();
+    expect(screen.getByText("4 settings discovered from this Hermes installation")).toBeVisible();
+    fireEvent.click(screen.getByRole("button", { name: "Agent, 1 setting" }));
+    const turns = screen.getByRole("spinbutton", { name: "Maximum turns" });
+    expect(turns).toHaveValue(90);
+    fireEvent.change(turns, { target: { value: "120" } });
+    expect(screen.getByText("1 unsaved change")).toBeVisible();
+    fireEvent.click(screen.getByRole("button", { name: "Save Hermes settings" }));
+
+    await waitFor(() => expect(fetcher).toHaveBeenCalledWith(
+      expect.stringContaining("/api/hermes/configuration"),
+      expect.objectContaining({
+        method: "PUT",
+        body: JSON.stringify({ changes: [{ path: "agent.max_turns", value: 120 }] }),
+      }),
+    ));
+    expect(await screen.findByText("Hermes settings saved")).toBeVisible();
+  });
+
+  it("preserves edits made while an older settings save is pending", async () => {
+    let resolveSave: ((value: Response) => void) | undefined;
+    const fetcher = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.endsWith("/api/hermes/configuration") && init?.method === "PUT") {
+        return new Promise<Response>((resolve) => {
+          resolveSave = resolve;
+        });
+      }
+      if (url.endsWith("/api/hermes/configuration")) return response(configuration);
+      if (url.endsWith("/api/hermes/env")) return response(environment);
+      return response({}, 404);
+    });
+    vi.stubGlobal("fetch", fetcher);
+    render(<HermesConfigurationDialog open onOpenChange={vi.fn()} />);
+
+    fireEvent.click(await screen.findByRole("button", { name: "Agent, 1 setting" }));
+    const turns = screen.getByRole("spinbutton", { name: "Maximum turns" });
+    fireEvent.change(turns, { target: { value: "120" } });
+    fireEvent.click(screen.getByRole("button", { name: "Save Hermes settings" }));
+    await waitFor(() => expect(resolveSave).toBeDefined());
+
+    fireEvent.change(turns, { target: { value: "150" } });
+    resolveSave?.(response({ ok: true }));
+
+    expect(await screen.findByText(/Hermes settings saved.*1 newer unsaved change/)).toBeVisible();
+    expect(turns).toHaveValue(150);
+    fireEvent.click(screen.getByRole("button", { name: "Discard" }));
+    expect(turns).toHaveValue(120);
+  });
+
+  it("keeps a revert made during a pending save as a saveable newer change", async () => {
+    let resolveFirstSave: ((value: Response) => void) | undefined;
+    let saveCount = 0;
+    const fetcher = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.endsWith("/api/hermes/configuration") && init?.method === "PUT") {
+        saveCount += 1;
+        if (saveCount === 1) {
+          return new Promise<Response>((resolve) => {
+            resolveFirstSave = resolve;
+          });
+        }
+        return response({ ok: true });
+      }
+      if (url.endsWith("/api/hermes/configuration")) return response(configuration);
+      if (url.endsWith("/api/hermes/env")) return response(environment);
+      return response({}, 404);
+    });
+    vi.stubGlobal("fetch", fetcher);
+    render(<HermesConfigurationDialog open onOpenChange={vi.fn()} />);
+
+    fireEvent.click(await screen.findByRole("button", { name: "Agent, 1 setting" }));
+    const turns = screen.getByRole("spinbutton", { name: "Maximum turns" });
+    fireEvent.change(turns, { target: { value: "120" } });
+    fireEvent.click(screen.getByRole("button", { name: "Save Hermes settings" }));
+    await waitFor(() => expect(resolveFirstSave).toBeDefined());
+
+    fireEvent.change(turns, { target: { value: "90" } });
+    resolveFirstSave?.(response({ ok: true }));
+
+    expect(await screen.findByText(/Hermes settings saved.*1 newer unsaved change/)).toBeVisible();
+    expect(turns).toHaveValue(90);
+    expect(screen.getByRole("button", { name: "Save Hermes settings" })).toBeEnabled();
+    fireEvent.click(screen.getByRole("button", { name: "Save Hermes settings" }));
+    await waitFor(() => expect(fetcher).toHaveBeenCalledWith(
+      expect.stringContaining("/api/hermes/configuration"),
+      expect.objectContaining({
+        method: "PUT",
+        body: JSON.stringify({ changes: [{ path: "agent.max_turns", value: 90 }] }),
+      }),
+    ));
+  });
+
+  it("keeps the submitted value saveable when a pending save fails", async () => {
+    let resolveSave: ((value: Response) => void) | undefined;
+    const fetcher = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.endsWith("/api/hermes/configuration") && init?.method === "PUT") {
+        return new Promise<Response>((resolve) => {
+          resolveSave = resolve;
+        });
+      }
+      if (url.endsWith("/api/hermes/configuration")) return response(configuration);
+      if (url.endsWith("/api/hermes/env")) return response(environment);
+      return response({}, 404);
+    });
+    vi.stubGlobal("fetch", fetcher);
+    render(<HermesConfigurationDialog open onOpenChange={vi.fn()} />);
+
+    fireEvent.click(await screen.findByRole("button", { name: "Agent, 1 setting" }));
+    const turns = screen.getByRole("spinbutton", { name: "Maximum turns" });
+    fireEvent.change(turns, { target: { value: "120" } });
+    fireEvent.click(screen.getByRole("button", { name: "Save Hermes settings" }));
+    await waitFor(() => expect(resolveSave).toBeDefined());
+
+    fireEvent.change(turns, { target: { value: "120" } });
+    resolveSave?.(response({}, 500));
+
+    expect(await screen.findByText("Hermes configuration could not be saved.")).toBeVisible();
+    expect(turns).toHaveValue(120);
+    expect(screen.getByRole("button", { name: "Save Hermes settings" })).toBeEnabled();
+  });
+
+  it("merges a pending save into configuration freshly loaded after reopening", async () => {
+    let resolveSave: ((value: Response) => void) | undefined;
+    let configurationReads = 0;
+    const freshConfiguration = {
+      ...configuration,
+      config: { ...configuration.config, model: "openai/gpt-5", fresh: { enabled: true } },
+      defaults: { ...configuration.defaults, fresh: { enabled: false } },
+      fields: {
+        ...configuration.fields,
+        "fresh.enabled": { type: "boolean", description: "Fresh runtime setting", category: "fresh" },
+      },
+      categoryOrder: [...configuration.categoryOrder, "fresh"],
+    };
+    vi.stubGlobal("fetch", vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.endsWith("/api/hermes/configuration") && init?.method === "PUT") {
+        return new Promise<Response>((resolve) => {
+          resolveSave = resolve;
+        });
+      }
+      if (url.endsWith("/api/hermes/configuration")) {
+        configurationReads += 1;
+        return response(configurationReads === 1 ? configuration : freshConfiguration);
+      }
+      if (url.endsWith("/api/hermes/env")) return response(environment);
+      return response({}, 404);
+    }));
+
+    function Harness() {
+      const [open, setOpen] = React.useState(true);
+      return (
+        <>
+          <button type="button" onClick={() => setOpen(true)}>Open Hermes configuration</button>
+          <HermesConfigurationDialog open={open} onOpenChange={setOpen} />
+        </>
+      );
+    }
+    render(<Harness />);
+
+    fireEvent.click(await screen.findByRole("button", { name: "Agent, 1 setting" }));
+    fireEvent.change(screen.getByRole("spinbutton", { name: "Maximum turns" }), { target: { value: "120" } });
+    fireEvent.click(screen.getByRole("button", { name: "Save Hermes settings" }));
+    await waitFor(() => expect(resolveSave).toBeDefined());
+
+    fireEvent.click(screen.getByRole("button", { name: "Close" }));
+    await waitFor(() => expect(screen.queryByRole("dialog")).not.toBeInTheDocument());
+    fireEvent.click(screen.getByRole("button", { name: "Open Hermes configuration" }));
+    expect(await screen.findByRole("button", { name: "Fresh, 1 setting" })).toBeVisible();
+
+    resolveSave?.(response({ ok: true }));
+
+    expect(await screen.findByRole("button", { name: "Fresh, 1 setting" })).toBeVisible();
+    fireEvent.click(screen.getByRole("button", { name: "General, 1 setting" }));
+    expect(screen.getByRole("textbox", { name: "Default model" })).toHaveValue("openai/gpt-5");
+    fireEvent.click(screen.getByRole("button", { name: "Agent, 1 setting" }));
+    expect(screen.getByRole("spinbutton", { name: "Maximum turns" })).toHaveValue(120);
+  });
+
+  it("searches all exact-version fields and restores an individual default", async () => {
+    vi.stubGlobal("fetch", vi.fn(async (input: RequestInfo | URL) => (
+      String(input).endsWith("/api/hermes/env") ? response(environment) : response(configuration)
+    )));
+    render(<HermesConfigurationDialog open onOpenChange={vi.fn()} />);
+
+    const search = await screen.findByRole("searchbox", { name: "Search Hermes settings" });
+    fireEvent.change(search, { target: { value: "maximum turns" } });
+    expect(screen.getByRole("spinbutton", { name: "Maximum turns" })).toBeVisible();
+    fireEvent.click(screen.getByRole("button", { name: "Restore default for Maximum turns" }));
+    expect(screen.getByRole("spinbutton", { name: "Maximum turns" })).toHaveValue(60);
+  });
+
+  it("manages write-only credentials without duplicating channel-owned secrets", async () => {
+    const fetcher = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.endsWith("/api/hermes/configuration")) return response(configuration);
+      if (url.endsWith("/api/hermes/env") && init?.method) return response({ ok: true });
+      if (url.endsWith("/api/hermes/env")) return response(environment);
+      return response({}, 404);
+    });
+    vi.stubGlobal("fetch", fetcher);
+    render(<HermesConfigurationDialog open onOpenChange={vi.fn()} />);
+
+    fireEvent.click(await screen.findByRole("tab", { name: "Credentials" }));
+    expect(screen.getByText("OpenRouter")).toBeVisible();
+    expect(screen.queryByText("Discord bot token")).not.toBeInTheDocument();
+    expect(screen.getByText("sk-or-••••••••abcd")).toBeVisible();
+    const input = screen.getByLabelText("New OpenRouter API key");
+    expect(input).toHaveAttribute("type", "password");
+    fireEvent.change(input, { target: { value: "sk-or-new-secret" } });
+    fireEvent.click(screen.getByRole("button", { name: "Save OpenRouter credential" }));
+
+    await waitFor(() => expect(fetcher).toHaveBeenCalledWith(
+      expect.stringContaining("/api/hermes/env"),
+      expect.objectContaining({
+        method: "PUT",
+        body: JSON.stringify({ key: "OPENROUTER_API_KEY", value: "sk-or-new-secret" }),
+      }),
+    ));
+    expect(input).toHaveValue("");
+
+    fireEvent.click(screen.getByRole("button", { name: "Remove OpenRouter credential" }));
+    expect(screen.getByRole("button", { name: "Remove OpenRouter credential" })).toHaveTextContent("Confirm remove");
+    fireEvent.click(screen.getByRole("button", { name: "Remove OpenRouter credential" }));
+    await waitFor(() => expect(fetcher).toHaveBeenCalledWith(
+      expect.stringContaining("/api/hermes/env"),
+      expect.objectContaining({
+        method: "DELETE",
+        body: JSON.stringify({ key: "OPENROUTER_API_KEY" }),
+      }),
+    ));
+  });
+
+  it("blocks saving when a list setting contains invalid JSON", async () => {
+    const listConfiguration = {
+      ...configuration,
+      config: { ...configuration.config, tools: { allowed: ["bash"] } },
+      defaults: { ...configuration.defaults, tools: { allowed: [] } },
+      fields: {
+        ...configuration.fields,
+        "tools.allowed": { type: "list", description: "Allowed tools", category: "tools" },
+      },
+      categoryOrder: [...configuration.categoryOrder, "tools"],
+    };
+    const fetcher = vi.fn(async (input: RequestInfo | URL) => (
+      String(input).endsWith("/api/hermes/env") ? response(environment) : response(listConfiguration)
+    ));
+    vi.stubGlobal("fetch", fetcher);
+    render(<HermesConfigurationDialog open onOpenChange={vi.fn()} />);
+
+    const search = await screen.findByRole("searchbox", { name: "Search Hermes settings" });
+    fireEvent.change(search, { target: { value: "allowed tools" } });
+    const list = screen.getByRole("textbox", { name: "Allowed tools" });
+    fireEvent.change(list, { target: { value: '["bash", "python"]' } });
+    fireEvent.change(list, { target: { value: '["bash"' } });
+
+    expect(screen.getByText("Enter a valid JSON list before saving.")).toBeVisible();
+    expect(screen.getByRole("button", { name: "Save Hermes settings" })).toBeDisabled();
+    fireEvent.change(search, { target: { value: "maximum turns" } });
+    expect(screen.getByRole("spinbutton", { name: "Maximum turns" })).toBeVisible();
+    fireEvent.change(search, { target: { value: "allowed tools" } });
+    expect(screen.getByRole("textbox", { name: "Allowed tools" })).toHaveValue('["bash"');
+    expect(screen.getByText("Enter a valid JSON list before saving.")).toBeVisible();
+    expect(screen.getByRole("button", { name: "Save Hermes settings" })).toBeDisabled();
+    expect(fetcher).not.toHaveBeenCalledWith(
+      expect.stringContaining("/api/hermes/configuration"),
+      expect.objectContaining({ method: "PUT" }),
+    );
+  });
+
+  it("keeps an emptied number blank and blocks saving instead of converting it to zero", async () => {
+    vi.stubGlobal("fetch", vi.fn(async (input: RequestInfo | URL) => (
+      String(input).endsWith("/api/hermes/env") ? response(environment) : response(configuration)
+    )));
+    render(<HermesConfigurationDialog open onOpenChange={vi.fn()} />);
+
+    fireEvent.click(await screen.findByRole("button", { name: "Agent, 1 setting" }));
+    const turns = screen.getByRole("spinbutton", { name: "Maximum turns" });
+    fireEvent.change(turns, { target: { value: "120" } });
+    fireEvent.change(turns, { target: { value: "" } });
+
+    expect(turns).toHaveValue(null);
+    expect(screen.getByText("Enter a number before saving.")).toBeVisible();
+    expect(screen.getByRole("button", { name: "Save Hermes settings" })).toBeDisabled();
+    fireEvent.click(screen.getByRole("button", { name: "General, 1 setting" }));
+    fireEvent.click(screen.getByRole("button", { name: "Agent, 1 setting" }));
+    expect(screen.getByRole("spinbutton", { name: "Maximum turns" })).toHaveValue(null);
+    expect(screen.getByText("Enter a number before saving.")).toBeVisible();
+  });
+
+  it("keeps a successful credential mutation when only its status refresh fails", async () => {
+    let environmentReads = 0;
+    const fetcher = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.endsWith("/api/hermes/configuration")) return response(configuration);
+      if (url.endsWith("/api/hermes/env") && init?.method === "PUT") return response({ ok: true });
+      if (url.endsWith("/api/hermes/env")) {
+        environmentReads += 1;
+        return environmentReads === 1 ? response(environment) : response({}, 503);
+      }
+      return response({}, 404);
+    });
+    vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    vi.stubGlobal("fetch", fetcher);
+    render(<HermesConfigurationDialog open onOpenChange={vi.fn()} />);
+
+    fireEvent.click(await screen.findByRole("tab", { name: "Credentials" }));
+    const input = screen.getByLabelText("New OpenRouter API key");
+    fireEvent.change(input, { target: { value: "sk-or-new-secret" } });
+    fireEvent.click(screen.getByRole("button", { name: "Save OpenRouter credential" }));
+
+    expect(await screen.findByText("Credential saved. Live status could not be refreshed.")).toBeVisible();
+    expect(input).toHaveValue("");
+    expect(screen.getByText("Connected")).toBeVisible();
+    expect(screen.queryByText("sk-or-••••••••abcd")).not.toBeInTheDocument();
+    expect(screen.queryByText("Credential could not be saved.")).not.toBeInTheDocument();
+  });
+
+  it("preserves unsaved invalid text when the dialog closes and reopens", async () => {
+    const listConfiguration = {
+      ...configuration,
+      config: { ...configuration.config, tools: { allowed: ["bash"] } },
+      defaults: { ...configuration.defaults, tools: { allowed: [] } },
+      fields: {
+        ...configuration.fields,
+        "tools.allowed": { type: "list", description: "Allowed tools", category: "tools" },
+      },
+      categoryOrder: [...configuration.categoryOrder, "tools"],
+    };
+    vi.stubGlobal("fetch", vi.fn(async (input: RequestInfo | URL) => (
+      String(input).endsWith("/api/hermes/env") ? response(environment) : response(listConfiguration)
+    )));
+
+    function Harness() {
+      const [open, setOpen] = React.useState(true);
+      return (
+        <>
+          <button type="button" onClick={() => setOpen(true)}>Open Hermes configuration</button>
+          <HermesConfigurationDialog open={open} onOpenChange={setOpen} />
+        </>
+      );
+    }
+    render(<Harness />);
+
+    const search = await screen.findByRole("searchbox", { name: "Search Hermes settings" });
+    fireEvent.change(search, { target: { value: "allowed tools" } });
+    fireEvent.change(screen.getByRole("textbox", { name: "Allowed tools" }), { target: { value: '["bash"' } });
+    fireEvent.click(screen.getByRole("button", { name: "Close" }));
+    await waitFor(() => expect(screen.queryByRole("dialog")).not.toBeInTheDocument());
+    fireEvent.click(screen.getByRole("button", { name: "Open Hermes configuration" }));
+
+    expect(await screen.findByRole("textbox", { name: "Allowed tools" })).toHaveValue('["bash"');
+    expect(screen.getByText("Enter a valid JSON list before saving.")).toBeVisible();
+    expect(screen.getByRole("button", { name: "Save Hermes settings" })).toBeDisabled();
+  });
+
+  it("ignores an older credential refresh that resolves after a newer mutation", async () => {
+    const initialEnvironment = {
+      ...environment,
+      OPENAI_API_KEY: {
+        ...environment.OPENROUTER_API_KEY,
+        is_set: false,
+        redacted_value: "",
+        description: "OpenAI API key",
+        provider: "openai",
+        provider_label: "OpenAI",
+      },
+    };
+    const newerEnvironment = {
+      ...initialEnvironment,
+      OPENROUTER_API_KEY: {
+        ...initialEnvironment.OPENROUTER_API_KEY,
+        is_set: true,
+        redacted_value: "••••new-router",
+      },
+      OPENAI_API_KEY: {
+        ...initialEnvironment.OPENAI_API_KEY,
+        is_set: true,
+        redacted_value: "••••new-openai",
+      },
+    };
+    let environmentReads = 0;
+    const pendingRefreshes: Array<(value: Response) => void> = [];
+    vi.stubGlobal("fetch", vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.endsWith("/api/hermes/configuration")) return response(configuration);
+      if (url.endsWith("/api/hermes/env") && init?.method === "PUT") return response({ ok: true });
+      if (url.endsWith("/api/hermes/env")) {
+        environmentReads += 1;
+        if (environmentReads === 1) return response(initialEnvironment);
+        return new Promise<Response>((resolve) => pendingRefreshes.push(resolve));
+      }
+      return response({}, 404);
+    }));
+    render(<HermesConfigurationDialog open onOpenChange={vi.fn()} />);
+
+    fireEvent.click(await screen.findByRole("tab", { name: "Credentials" }));
+    const routerInput = screen.getByLabelText("New OpenRouter API key");
+    const openaiInput = screen.getByLabelText("New OpenAI API key");
+    fireEvent.change(routerInput, { target: { value: "router-new" } });
+    fireEvent.change(openaiInput, { target: { value: "openai-new" } });
+    fireEvent.click(screen.getByRole("button", { name: "Save OpenRouter credential" }));
+    fireEvent.click(screen.getByRole("button", { name: "Save OpenAI credential" }));
+    await waitFor(() => expect(pendingRefreshes).toHaveLength(2));
+
+    pendingRefreshes[1](response(newerEnvironment));
+    expect(await screen.findByText("••••new-router")).toBeVisible();
+    expect(screen.getByText("••••new-openai")).toBeVisible();
+    pendingRefreshes[0](response(initialEnvironment));
+    await waitFor(() => expect(screen.queryByText("sk-or-••••••••abcd")).not.toBeInTheDocument());
+    expect(screen.getByText("••••new-router")).toBeVisible();
+    expect(screen.getByText("••••new-openai")).toBeVisible();
+  });
+});

--- a/tests/shell/terminal-launch.test.ts
+++ b/tests/shell/terminal-launch.test.ts
@@ -29,10 +29,6 @@ describe("terminal launch paths", () => {
     expect(githubLogin?.command).toContain("gh auth login --hostname github.com --web");
     expect(githubLogin?.command).toContain("Matrix-managed key");
     expect(githubLogin?.command).not.toContain("--git-protocol ssh");
-    expect(terminalLaunchConfig("hermes-model")).toMatchObject({
-      action: "hermes-model",
-      command: "hermes model",
-    });
     expect(terminalLaunchConfig("openclaw-model-auth")).toMatchObject({
       action: "openclaw-model-auth",
       command: "openclaw models auth add",


### PR DESCRIPTION
## Summary

- Repair upgraded VPSes whose retained Node 24.14.1 runtime is outside OpenClaw 2026.7.1's exact engine range by installing the SHA256-pinned Node 24.18.0 executable before the SHA512-pinned OpenClaw package.
- Replace Hermes' terminal-only configuration action with a searchable, responsive Settings UI generated from the exact installed runtime schema, verified live with Hermes Agent 0.20.0.
- Add typed, authenticated gateway routes for safe Hermes config and write-only credential management while preserving channel-owned secrets.
- Bridge Hermes 0.20's protected loopback dashboard endpoints through its supported `X-Hermes-Session-Token` contract using an owner-local mode-0600 credential file.
- Prevent invalid list/number drafts from saving stale values, preserve newer edits and user reverts across pending saves, merge save completions into freshly reloaded configuration, preserve unsaved text across navigation and reopening, and order credential refreshes so stale responses or redacted metadata cannot overwrite newer mutations.
- Keep agent installation visible in Terminal; this PR changes day-to-day Hermes configuration, not the visible installer contract.

Stack: 1/1 (based on `main`)

## Diagnosis

OpenClaw 2026.7.1 declares `node >=22.22.3 <23 || >=24.15.0 <25 || >=25.9.0`. Existing VPS upgrades retain `/opt/matrix/runtime/node`, so the observed 24.14.1 runtime is genuinely incompatible; lowering the compatibility gate would only defer the failure into npm. The installer now verifies and atomically replaces only the incompatible Node executable with the official pinned 24.18.0 build before continuing.

Hermes Agent 0.20.0 exposes configuration, defaults, schema, and environment endpoints, with its ephemeral dashboard session token required for sensitive loopback reads. Matrix now treats the installed runtime's schema as the UI source of truth instead of attempting to encode a moving command/field surface in the shell. The loopback-only dashboard wrapper derives Hermes' supported `HERMES_DASHBOARD_SESSION_TOKEN` from the random local credential secret, while the gateway reads that strict file with `O_NOFOLLOW` and sends `X-Hermes-Session-Token` only to `127.0.0.1`; the token never reaches the browser or logs.

The exact 0.20.0 runtime publishes 679 typed configuration fields. The gateway therefore accepts up to 1,024 fields—large enough for the verified version while retaining a finite resource bound—and filters sensitive paths before returning the schema to the browser.

## Tests

- `bun run typecheck`
- `bun run check:patterns` (0 violations)
- `bun run test` (857 files passed; 9,599 tests passed; 3 files / 20 tests intentionally skipped)
- focused changed-surface Vitest (166 passed), including the existing-VPS updater, 679-field exact-version schema, Hermes auth contract, and pending-save/reopen race regressions
- focused shell ESLint
- `pnpm dlx react-doctor@latest . --yes --scope changed --base origin/main --no-score --no-dead-code --no-supply-chain --verbose` (0 errors; 2 advisory component-organization warnings)
- `bash -n distro/customer-vps/host-bin/matrix-install-openclaw distro/customer-vps/host-bin/matrix-hermes-dashboard`
- executed `matrix-hermes-dashboard` against a temporary runtime home and verified the credential file contains only the three expected values at mode `0600`

## Screenshots

Live exact-head PR-preview screenshots:

### Hermes settings

![Hermes configuration in Settings](https://matrix-os-www-git-docs-hermes-settings-ui-finnaai.vercel.app/images/hermes-settings.png)

### Write-only credentials

![Hermes credentials in Settings](https://matrix-os-www-git-docs-hermes-settings-ui-finnaai.vercel.app/images/hermes-credentials.png)

### OpenClaw install action

![OpenClaw install action on the Agent page](https://matrix-os-www-git-docs-hermes-settings-ui-finnaai.vercel.app/images/openclaw-install-action.png)

### Visible pinned installer

![OpenClaw installer running visibly in Terminal](https://matrix-os-www-git-docs-hermes-settings-ui-finnaai.vercel.app/images/openclaw-visible-install.png)

## Invariants

### Source of truth

- Hermes remains the source of truth for its owner-controlled config and environment files. The gateway reads Hermes' live `/api/config`, `/api/config/defaults`, `/api/config/schema`, and `/api/env` contracts.
- The owner-local `system/agent-runtime/hermes-dashboard.env` file is the source of truth for the random Matrix-to-Hermes dashboard credential; the wrapper derives Hermes' loopback session token from its secret, and the file is created once at mode `0600`, never exposed through a Matrix route, and reused across service restarts.
- The exact OpenClaw package/version and integrity hash remain pinned in the host installer. The Node compatibility predicate mirrors that pinned package's engine contract.

### Lock/transaction scope

- Hermes configuration writes are serialized through one bounded promise tail. Each write reads the current full config, merges only validated non-sensitive fields, and sends one full-config PUT to Hermes.
- Node repair is filesystem-local: download and checksum verification happen before an atomic executable replacement. No external call is made while holding an application lock.

### Acceptable orphan states

- A failed Node download or checksum leaves the existing executable untouched and removes temporary files. A successful Node repair followed by an OpenClaw install failure leaves a compatible Node runtime that is safe for retry.
- A rejected Hermes config or credential write leaves the previous Hermes state authoritative; the Settings dialog keeps unsaved input visible for retry.
- If the dashboard credential file is missing, malformed, too large, symlinked, or has broader permissions, the integration fails closed without returning its contents.

### Auth source of truth

- Existing Matrix gateway authentication remains authoritative for all `/api/hermes/*` routes. The loopback Hermes dashboard is not exposed directly to the browser; only the gateway presents Hermes' supported loopback session-token header.
- Sensitive schema paths are filtered server-side, credentials are returned only as redacted presence metadata, and write/delete keys must match the bounded uppercase environment-key contract.

### Deferred scope

- OpenClaw configuration remains in its existing visible terminal workflow; this PR does not invent a second OpenClaw settings model.
- This PR does not change OpenClaw to `latest`, change the pinned OpenClaw artifact, or broaden system sudo privileges.
- Runtime schema changes in future Hermes versions are intentionally discovered from that installed version rather than hard-coded in Matrix.
