### PR TITLE
fix(runtime): keep OpenClaw npm cache writable under systemd

### DIFF
--- a/distro/customer-vps/host-bin/matrix-openclaw-gateway
+++ b/distro/customer-vps/host-bin/matrix-openclaw-gateway
@@ -15,6 +15,8 @@ OPENCLAW_STATE_DIR="${OPENCLAW_STATE_DIR:-$MATRIX_RUNTIME_HOME/.openclaw}"
 OPENCLAW_CONFIG_PATH="${OPENCLAW_CONFIG_PATH:-$OPENCLAW_STATE_DIR/openclaw.json}"
 OPENCLAW_ENV_FILE="${OPENCLAW_ENV_FILE:-$MATRIX_RUNTIME_HOME/system/agent-runtime/openclaw.env}"
 OPENCLAW_BIN="${OPENCLAW_BIN:-$MATRIX_NODE_PREFIX/bin/openclaw}"
+# ProtectHome=read-only blocks ~/.npm; PrivateTmp keeps plugin repair cache writable and ephemeral.
+OPENCLAW_NPM_CACHE_DIR="${TMPDIR:-/tmp}/matrix-openclaw/npm-cache"
 
 if [ ! -x "$OPENCLAW_BIN" ]; then
   echo "matrix-openclaw-gateway: runtime is not installed" >&2
@@ -32,7 +34,7 @@ fi
 OPENCLAW_GATEWAY_TOKEN="${token_line#OPENCLAW_GATEWAY_TOKEN=}"
 : "${OPENCLAW_GATEWAY_TOKEN:?matrix-openclaw-gateway: runtime authentication is unavailable}"
 
-install -d -m 0700 "$OPENCLAW_STATE_DIR"
+install -d -m 0700 "$OPENCLAW_STATE_DIR" "$OPENCLAW_NPM_CACHE_DIR"
 if [ ! -e "$OPENCLAW_CONFIG_PATH" ]; then
   config_tmp="$(mktemp "$OPENCLAW_STATE_DIR/.openclaw.json.XXXXXX")"
   cleanup() { rm -f "$config_tmp"; }
@@ -84,4 +86,5 @@ fi
 # gateway.auth.mode token, plugins.allow, and tools.deny at bootstrap.
 export HOME="$MATRIX_RUNTIME_HOME"
 export OPENCLAW_STATE_DIR OPENCLAW_CONFIG_PATH OPENCLAW_GATEWAY_TOKEN
+export npm_config_cache="$OPENCLAW_NPM_CACHE_DIR"
 exec "$OPENCLAW_BIN" gateway run --bind loopback --port 18789 --auth token

--- a/shell/src/components/settings/sections/AgentRuntimePanel.tsx
+++ b/shell/src/components/settings/sections/AgentRuntimePanel.tsx
@@ -310,13 +310,20 @@ function MessagingProviders({
     <Button
       size="sm"
       variant="outline"
+      disabled={busy}
       onClick={() => setHermesConfigOpen(true)}
       aria-label="Configure Hermes provider"
     >
       <Settings2Icon className="size-3.5" /> Configure Hermes
     </Button>
   ) : onOpenTerminal ? (
-    <Button size="sm" variant="outline" onClick={() => onOpenTerminal(terminalAction)} aria-label="Configure Openclaw provider">
+    <Button
+      size="sm"
+      variant="outline"
+      disabled={busy}
+      onClick={() => onOpenTerminal(terminalAction)}
+      aria-label="Configure Openclaw provider"
+    >
       <TerminalIcon className="size-3.5" /> Configure OpenClaw
     </Button>
   ) : null;

--- a/shell/src/lib/agent-config.ts
+++ b/shell/src/lib/agent-config.ts
@@ -10,6 +10,10 @@ import { getGatewayUrl } from "./gateway";
 
 const READ_TIMEOUT_MS = 10_000;
 const MUTATION_TIMEOUT_MS = 15_000;
+// Runtime transitions have a 75s gateway deadline and can include bounded
+// systemd readiness work. Keep the client waiting past that deadline so a
+// successful transition is not reported as an ambiguous network failure.
+const RUNTIME_SWITCH_TIMEOUT_MS = 90_000;
 const MAX_RESPONSE_BYTES = 1024 * 1024;
 const SAFE_ERROR_CODE_MAX = 64;
 
@@ -157,13 +161,16 @@ export async function updateAgentSettings(
   options: ClientOptions = {},
 ): Promise<NormalizedAgentSettings> {
   const fetcher = options.fetcher ?? fetch;
+  const timeoutMs = update.runtime === undefined
+    ? MUTATION_TIMEOUT_MS
+    : RUNTIME_SWITCH_TIMEOUT_MS;
   let response: Response;
   try {
     response = await fetcher(`${getGatewayUrl()}/api/settings/agent`, requestInit({
       method: "PUT",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify(update),
-    }, MUTATION_TIMEOUT_MS));
+    }, timeoutMs));
   } catch (error) {
     throw new AgentSettingsClientError(
       "unavailable",

--- a/tests/deploy/customer-vps/openclaw-systemd.test.ts
+++ b/tests/deploy/customer-vps/openclaw-systemd.test.ts
@@ -1,4 +1,4 @@
-import { access, chmod, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { access, chmod, mkdir, mkdtemp, readFile, rm, symlink, writeFile } from "node:fs/promises";
 import { execFile } from "node:child_process";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -123,6 +123,65 @@ describe("customer VPS OpenClaw runtime", () => {
     expect(wrapper).toContain("runtime policy validation failed");
     expect(wrapper).toContain("gateway run --bind loopback --port 18789 --auth token");
     expect(wrapper).not.toMatch(/--token[ =]/);
+  });
+
+  it("keeps npm plugin repair cache out of the read-only owner home", async () => {
+    const root = await mkdtemp(join(tmpdir(), "matrix-openclaw-gateway-test-"));
+    const runtimeHome = join(root, "home");
+    const stateDir = join(runtimeHome, ".openclaw");
+    const agentRuntimeDir = join(runtimeHome, "system/agent-runtime");
+    const nodeBinDir = join(root, "node/bin");
+    const privateTmpDir = join(root, "tmp");
+    const openClawBin = join(nodeBinDir, "openclaw");
+    const tokenPath = join(agentRuntimeDir, "openclaw.env");
+    const capturedCachePath = join(stateDir, "captured-npm-cache");
+
+    try {
+      await mkdir(stateDir, { recursive: true });
+      await mkdir(agentRuntimeDir, { recursive: true });
+      await mkdir(nodeBinDir, { recursive: true });
+      await mkdir(privateTmpDir, { recursive: true });
+      await writeFile(tokenPath, `OPENCLAW_GATEWAY_TOKEN=${"a".repeat(64)}\n`);
+      await symlink(process.execPath, join(nodeBinDir, "node"));
+      await writeFile(
+        openClawBin,
+        [
+          "#!/usr/bin/env bash",
+          "set -euo pipefail",
+          ': "${npm_config_cache:?npm cache must be configured}"',
+          'mkdir -p "$npm_config_cache/_cacache"',
+          'printf \'%s\\n\' "$npm_config_cache" >"$OPENCLAW_STATE_DIR/captured-npm-cache"',
+        ].join("\n"),
+      );
+      await chmod(openClawBin, 0o755);
+      await chmod(runtimeHome, 0o555);
+
+      const env = { ...process.env };
+      delete env.npm_config_cache;
+      delete env.NPM_CONFIG_CACHE;
+
+      await expect(execFileAsync("bash", [wrapperPath], {
+        env: {
+          ...env,
+          MATRIX_RUNTIME_HOME: runtimeHome,
+          MATRIX_NODE_PREFIX: join(root, "node"),
+          OPENCLAW_STATE_DIR: stateDir,
+          OPENCLAW_CONFIG_PATH: join(stateDir, "openclaw.json"),
+          OPENCLAW_ENV_FILE: tokenPath,
+          OPENCLAW_BIN: openClawBin,
+          TMPDIR: privateTmpDir,
+        },
+      })).resolves.toMatchObject({ stderr: "" });
+
+      expect(await readFile(capturedCachePath, "utf8")).toBe(
+        `${privateTmpDir}/matrix-openclaw/npm-cache\n`,
+      );
+      await expect(access(join(runtimeHome, ".npm"))).rejects.toMatchObject({ code: "ENOENT" });
+      await expect(access(join(stateDir, "npm-cache"))).rejects.toMatchObject({ code: "ENOENT" });
+    } finally {
+      await chmod(runtimeHome, 0o700).catch(() => {});
+      await rm(root, { recursive: true, force: true });
+    }
   });
 
   it("uses a bounded, hardened owner service", async () => {

--- a/tests/shell/agent-config.test.ts
+++ b/tests/shell/agent-config.test.ts
@@ -180,6 +180,19 @@ describe("shell agent settings wire client", () => {
     expect(timeout).toHaveBeenNthCalledWith(3, 10_000);
   });
 
+  it("allows runtime switches to outlive the controller deadline without extending ordinary mutations", async () => {
+    const timeout = vi.spyOn(AbortSignal, "timeout");
+    const fetcher = vi.fn(async () => Response.json(currentAgentSettingsView()));
+
+    await expect(updateAgentSettings({ effort: "low" }, { fetcher }))
+      .resolves.toMatchObject({ kind: "current" });
+    await expect(updateAgentSettings({ runtime: "openclaw", revision: 4 }, { fetcher }))
+      .resolves.toMatchObject({ kind: "current" });
+
+    expect(timeout).toHaveBeenNthCalledWith(1, 15_000);
+    expect(timeout).toHaveBeenNthCalledWith(2, 90_000);
+  });
+
   it("submits a BYOK value only to the existing write-only route", async () => {
     const timeout = vi.spyOn(AbortSignal, "timeout");
     const fetcher = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {

--- a/tests/shell/agent-settings.test.tsx
+++ b/tests/shell/agent-settings.test.tsx
@@ -239,6 +239,49 @@ describe("Canvas Agent runtime settings", () => {
     expect(await screen.findByText("OpenClaw is active")).toBeVisible();
   });
 
+  it("disables provider configuration while a runtime switch is pending", async () => {
+    const initial = makeView();
+    initial.runtime.options[1] = {
+      id: "openclaw",
+      displayName: "OpenClaw",
+      installState: "installed",
+      health: "stopped",
+      selectionState: "available",
+      configured: false,
+      capabilities: ["provider_catalog", "model_selection", "authentication"],
+    };
+    const updated = structuredClone(initial);
+    updated.runtime.selected = "openclaw";
+    updated.runtime.options[0].selectionState = "available";
+    updated.runtime.options[1].selectionState = "active";
+    updated.runtime.options[1].health = "healthy";
+    updated.currentSelection.messaging = {
+      runtime: "openclaw",
+      provider: null,
+      model: null,
+      configured: false,
+    };
+    let resolveSwitch!: (value: Response) => void;
+    const switchResponse = new Promise<Response>((resolve) => {
+      resolveSwitch = resolve;
+    });
+    const fetcher = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => (
+      init?.method === "PUT" ? switchResponse : response(initial)
+    ));
+    vi.stubGlobal("fetch", fetcher);
+    render(<AgentRuntimePanel onOpenTerminal={vi.fn()} />);
+
+    const configureHermes = await screen.findByRole("button", { name: "Configure Hermes provider" });
+    expect(configureHermes).toBeEnabled();
+
+    fireEvent.click(screen.getByRole("button", { name: "Use OpenClaw" }));
+
+    await waitFor(() => expect(configureHermes).toBeDisabled());
+
+    resolveSwitch(response(updated));
+    expect(await screen.findByRole("button", { name: "Configure Openclaw provider" })).toBeEnabled();
+  });
+
   it("never falls back to an unavailable messaging model", async () => {
     const initial = makeView();
     initial.providers[1].models = [


### PR DESCRIPTION
## Summary

- Redirect OpenClaw's npm cache to service-private temporary storage.
- Preserve the existing `ProtectHome=read-only` systemd hardening.
- Give runtime-switch mutations a dedicated 90-second Shell timeout while keeping ordinary agent-setting mutations at 15 seconds.
- Disable both provider Configure actions while an agent-settings mutation is pending.
- Add focused regressions for the hardened npm cache, client timeout contracts, and pending UI state.

## Root cause

OpenClaw repairs its missing Matrix plugin during gateway startup. npm defaults to `~/.npm`, but the customer VPS unit intentionally makes the owner home read-only. The write fails with `EROFS`, activation fails, and the runtime controller rolls back to Hermes.

The wrapper now exports `npm_config_cache` beneath the unit's writable `PrivateTmp` namespace. This keeps repair artifacts ephemeral and avoids expanding filesystem permissions or storing cache data in owner state.

Live preview testing exposed a second timing issue. The Shell stopped waiting for every agent-setting mutation after 15 seconds, while the VPS runtime controller permits a switch to run for 75 seconds. Aborting the browser request does not cancel the controller operation, so the UI could report a failure even though OpenClaw became healthy and active shortly afterward. A retry could then return a revision conflict.

Runtime-switch mutations now wait up to 90 seconds, past the controller deadline. Other agent-setting writes keep the existing 15-second bound. While that mutation is pending, runtime switching and both Configure actions share the same busy state so configuration cannot race the transition.

## User impact

Switching from Hermes to an installed OpenClaw runtime can complete when the Matrix plugin needs first-start repair. The runtime and Configure actions remain disabled while the request is pending, and the Shell no longer times out before the server's bounded transition deadline. Existing rollback behavior remains unchanged if activation fails.

## Tests

- TDD timeout regression failed with runtime switches still using 15 seconds, then passed with the dedicated 90-second bound.
- TDD UI regression failed while Configure remained enabled during a deferred runtime switch, then passed after binding both Configure actions to the shared busy state.
- Focused Shell/OpenClaw suites: 43/43 passed locally.
- `pnpm --filter shell exec tsc --noEmit`: passed locally.
- `./scripts/review/check-patterns.sh`: 0 violations; existing warnings only.
- `git diff --check`: passed.
- Current-head Greptile: 5/5 on `631248ce5407b9ec2848b19d4e26fac2226dbb3f`.
- Full CI run `31006670564`: passed, including typecheck, React Doctor, Shell production build, four unit-test shards, and E2E.
- Docker run `31006669634`: passed, including image build and smoke scenarios.
- Original current-head preview run `31005628127`: passed and published `v2026.08.05-pr1156-631248c`.
- Clean-state teardown run `31008736376`: passed and deleted the previous `pr-1156` VPS.
- Pinned clean-state deployment run `31009550861`: passed and provisioned a new `pr-1156` from the existing immutable current-head bundle.
- Authenticated inventory verification run `31009925531`: passed.

## Live validation status

- Warm-path validation passed on the previous preview VPS: Hermes -> OpenClaw and OpenClaw -> Hermes both succeeded.
- The previous VPS and its retained OpenClaw state were deleted, and a newly provisioned `pr-1156` came online with `v2026.08.05-pr1156-631248c`.
- Authenticated inventory verification passed for the clean replacement VPS.
- Cold first-start acceptance passed on the newly provisioned VPS.
- The clean-state checklist was reported successful: a single OpenClaw activation completed without refresh or retry, both Configure actions stayed disabled during the transition, OpenClaw became healthy/active, and switching back to Hermes succeeded.

## Review/Monitoring

- Cold first-start acceptance has passed and the PR is Ready for Review.
- `ready-for-ci` and `preview-vps` are applied.
- Preview shell: https://app.matrix-os.com/vm/pr-1156
- Reopen run `31008784254` rebuilt the already-published version and correctly refused to overwrite its immutable R2 object after detecting different archive bytes. No artifact was overwritten. The safe pinned-version workflow then deployed the existing verified bundle successfully in run `31009550861`.

## Invariants

### Source of truth

- OpenClaw configuration and durable runtime state remain under the existing owner-controlled `.openclaw` and agent-runtime paths.
- The npm cache is non-authoritative, reproducible process scratch data owned by the systemd service's `PrivateTmp` namespace.
- Gateway runtime state and its revision remain authoritative for completed transitions; the longer Shell timeout does not introduce client state.

### Lock/transaction scope

- No database transaction, external lock, or request boundary changes.
- Existing runtime-control serialization, revision checks, deadlines, and rollback remain authoritative.
- The Shell only waits longer and disables conflicting controls for runtime mutations; it does not alter or bypass the controller lock.

### Acceptable orphan states

- Private npm cache bytes may remain for the lifetime of the service namespace and can be discarded safely.
- Failure to create or use the cache fails startup normally, allowing the existing controller to keep or restore Hermes.
- A client may disconnect during a transition; the server-owned operation and rollback contract remain bounded independently.

### Auth source of truth

- Authentication remains the existing owner-only OpenClaw token file consumed by the gateway wrapper. No new API, credential path, or privilege is added.

### Deferred scope

- Replacing the synchronous runtime mutation with a separate asynchronous operation-ID and polling protocol.
- Relaxing systemd filesystem hardening or making npm cache persistent.
- Changing OpenClaw or Matrix plugin versions and installer pinning.
- Automating the feature-specific Hermes/OpenClaw preview acceptance steps.
