### PR TITLE
fix(runtime): prevent first-open terminal palette leakage

### DIFF
--- a/scripts/build-host-bundle.sh
+++ b/scripts/build-host-bundle.sh
@@ -79,9 +79,13 @@ mv "$STAGE_DIR/runtime/$NODE_DIST" "$STAGE_DIR/runtime/node"
 
 curl --fail --location --max-time 180 "$ZELLIJ_URL" -o "$DIST_DIR/$ZELLIJ_ARCHIVE"
 tar -xzf "$DIST_DIR/$ZELLIJ_ARCHIVE" -C "$STAGE_DIR/bin" zellij
+if [ -L "$STAGE_DIR/bin/zellij" ] || [ ! -f "$STAGE_DIR/bin/zellij" ]; then
+  echo "extracted Zellij binary must be a regular file" >&2
+  exit 1
+fi
+printf '%s  %s\n' "$ZELLIJ_BINARY_SHA256" "$STAGE_DIR/bin/zellij" | sha256sum -c -
 chmod 0755 "$STAGE_DIR/bin/zellij"
 test -x "$STAGE_DIR/bin/zellij"
-printf '%s  %s\n' "$ZELLIJ_BINARY_SHA256" "$STAGE_DIR/bin/zellij" | sha256sum -c -
 ZELLIJ_ACTUAL_VERSION="$("$STAGE_DIR/bin/zellij" --version)"
 [ "$ZELLIJ_ACTUAL_VERSION" = "zellij $ZELLIJ_VERSION" ] || {
   echo "staged Zellij version mismatch: expected zellij $ZELLIJ_VERSION" >&2

--- a/scripts/build-host-bundle.sh
+++ b/scripts/build-host-bundle.sh
@@ -10,7 +10,20 @@ NODE_DIST="node-v${NODE_VERSION}-linux-x64"
 NODE_ARCHIVE="${NODE_DIST}.tar.xz"
 NODE_BASE_URL="https://nodejs.org/dist/v${NODE_VERSION}"
 NODE_URL="${NODE_BASE_URL}/${NODE_ARCHIVE}"
-ZELLIJ_VERSION="${HOST_BUNDLE_ZELLIJ_VERSION:-0.44.1}"
+if [[ ${HOST_BUNDLE_ZELLIJ_VERSION+x} != ${HOST_BUNDLE_ZELLIJ_BINARY_SHA256+x} ]]; then
+  echo "HOST_BUNDLE_ZELLIJ_VERSION and HOST_BUNDLE_ZELLIJ_BINARY_SHA256 must be set together" >&2
+  exit 1
+fi
+ZELLIJ_VERSION="${HOST_BUNDLE_ZELLIJ_VERSION:-0.44.3}"
+ZELLIJ_BINARY_SHA256="${HOST_BUNDLE_ZELLIJ_BINARY_SHA256:-397481870c4fc3bae646cd7613cde3a1cebdc204558a6cb9a7c603d4c852fc90}"
+if [[ ! "$ZELLIJ_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  echo "HOST_BUNDLE_ZELLIJ_VERSION must be a semantic version" >&2
+  exit 1
+fi
+if [[ ! "$ZELLIJ_BINARY_SHA256" =~ ^[0-9a-f]{64}$ ]]; then
+  echo "HOST_BUNDLE_ZELLIJ_BINARY_SHA256 must be a lowercase 64-character SHA-256" >&2
+  exit 1
+fi
 ZELLIJ_ARCHIVE="zellij-x86_64-unknown-linux-musl.tar.gz"
 ZELLIJ_URL="https://github.com/zellij-org/zellij/releases/download/v${ZELLIJ_VERSION}/${ZELLIJ_ARCHIVE}"
 GH_VERSION="${HOST_BUNDLE_GH_VERSION:-2.86.0}"
@@ -68,6 +81,13 @@ curl --fail --location --max-time 180 "$ZELLIJ_URL" -o "$DIST_DIR/$ZELLIJ_ARCHIV
 tar -xzf "$DIST_DIR/$ZELLIJ_ARCHIVE" -C "$STAGE_DIR/bin" zellij
 chmod 0755 "$STAGE_DIR/bin/zellij"
 test -x "$STAGE_DIR/bin/zellij"
+printf '%s  %s\n' "$ZELLIJ_BINARY_SHA256" "$STAGE_DIR/bin/zellij" | sha256sum -c -
+ZELLIJ_ACTUAL_VERSION="$("$STAGE_DIR/bin/zellij" --version)"
+[ "$ZELLIJ_ACTUAL_VERSION" = "zellij $ZELLIJ_VERSION" ] || {
+  echo "staged Zellij version mismatch: expected zellij $ZELLIJ_VERSION" >&2
+  exit 1
+}
+timeout --signal=KILL 15s node "$ROOT_DIR/scripts/smoke-zellij-host-query.mjs" "$STAGE_DIR/bin/zellij"
 curl --fail --location --max-time 180 "$GH_URL" -o "$DIST_DIR/$GH_ARCHIVE"
 tar -xzf "$DIST_DIR/$GH_ARCHIVE" -C "$DIST_DIR"
 install -m 0755 "$DIST_DIR/$GH_DIST/bin/gh" "$STAGE_DIR/runtime/node/bin/gh"

--- a/scripts/smoke-zellij-host-query.mjs
+++ b/scripts/smoke-zellij-host-query.mjs
@@ -1,0 +1,269 @@
+#!/usr/bin/env node
+
+import { execFile } from "node:child_process";
+import { randomUUID } from "node:crypto";
+import { access, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { promisify } from "node:util";
+import { spawn } from "node-pty";
+
+const execFileAsync = promisify(execFile);
+const TEST_TIMEOUT_MS = 10_000;
+const OLD_HOST_QUERY_TIMEOUT_MS = 500;
+const HOST_REPLY_DELAY_MS = OLD_HOST_QUERY_TIMEOUT_MS + 250;
+const SENTINEL = `matrix-zellij-input-${randomUUID()}`;
+const MAX_CAPTURE_BYTES = 1024 * 1024;
+
+const zellijBinary = resolve(process.argv[2] ?? "");
+if (!process.argv[2]) {
+  console.error("usage: smoke-zellij-host-query.mjs <path-to-staged-zellij>");
+  process.exit(2);
+}
+await access(zellijBinary);
+
+const { stdout: versionOutput } = await execFileAsync(zellijBinary, ["--version"], {
+  timeout: 2_000,
+});
+const version = versionOutput.trim().replace(/^zellij\s+/, "");
+if (!/^\d+\.\d+\.\d+$/.test(version)) {
+  throw new Error(`unexpected Zellij version output: ${versionOutput.trim()}`);
+}
+
+const testRoot = await mkdtemp(join(tmpdir(), "mzq-"));
+const homeDir = join(testRoot, "home");
+const configDir = join(testRoot, "config", "zellij");
+const cacheDir = join(testRoot, "cache");
+const dataDir = join(testRoot, "data");
+const runtimeDir = join(testRoot, "runtime");
+const tempDir = join(testRoot, "tmp");
+const configPath = join(configDir, "config.kdl");
+const layoutPath = join(testRoot, "layout.kdl");
+const probePath = join(testRoot, "pane-probe.mjs");
+const resultPath = join(testRoot, "pane-input.json");
+const sessionName = `mhq-${randomUUID().slice(0, 8)}`;
+try {
+  await Promise.all([
+    mkdir(homeDir, { recursive: true }),
+    mkdir(configDir, { recursive: true }),
+    mkdir(cacheDir, { recursive: true }),
+    mkdir(dataDir, { recursive: true }),
+    mkdir(runtimeDir, { recursive: true }),
+    mkdir(tempDir, { recursive: true }),
+    mkdir(join(cacheDir, "zellij", version), { recursive: true }),
+  ]);
+  await writeFile(join(cacheDir, "zellij", version, "seen_release_notes"), "");
+
+  await writeFile(configPath, [
+    "pane_frames false",
+    "simplified_ui true",
+    "show_startup_tips false",
+    "session_serialization false",
+    "disable_session_metadata true",
+    "copy_on_select false",
+    "",
+  ].join("\n"));
+
+  await writeFile(probePath, `
+import { writeFile } from "node:fs/promises";
+
+const resultPath = process.argv[2];
+const sentinel = process.argv[3];
+const chunks = [];
+let totalBytes = 0;
+let overflow = false;
+let finished = false;
+const maxInputBytes = 64 * 1024;
+
+if (process.stdin.isTTY && typeof process.stdin.setRawMode === "function") {
+  process.stdin.setRawMode(true);
+}
+process.stdin.resume();
+
+async function finish() {
+  if (finished) return;
+  finished = true;
+  const input = Buffer.concat(chunks, totalBytes);
+  await writeFile(resultPath, JSON.stringify({
+    inputBase64: input.toString("base64"),
+    overflow,
+  }));
+  process.exit(0);
+}
+
+process.stdin.on("data", (chunk) => {
+  const bytes = Buffer.from(chunk);
+  if (totalBytes + bytes.length > maxInputBytes) {
+    overflow = true;
+    void finish();
+    return;
+  }
+  chunks.push(bytes);
+  totalBytes += bytes.length;
+  if (Buffer.concat(chunks, totalBytes).includes(Buffer.from(sentinel))) {
+    setTimeout(() => void finish(), 400);
+  }
+});
+
+setTimeout(() => void finish(), 7_000);
+`);
+
+  await writeFile(layoutPath, `layout {
+  pane command="${process.execPath}" {
+    args "${probePath}" "${resultPath}" "${SENTINEL}"
+  }
+}
+`);
+} catch (error) {
+  await rm(testRoot, { recursive: true, force: true });
+  throw error;
+}
+
+const isolatedEnv = {
+  COLORTERM: "truecolor",
+  HOME: homeDir,
+  LANG: "C.UTF-8",
+  PATH: process.env.PATH ?? "/usr/bin:/bin",
+  SHELL: "/bin/sh",
+  TERM: "xterm-256color",
+  TMPDIR: tempDir,
+  XDG_CACHE_HOME: cacheDir,
+  XDG_CONFIG_HOME: join(testRoot, "config"),
+  XDG_DATA_HOME: dataDir,
+  XDG_RUNTIME_DIR: runtimeDir,
+  ZELLIJ_CONFIG_DIR: configDir,
+  ZELLIJ_CONFIG_FILE: configPath,
+};
+
+let terminal;
+let capturedOutput = "";
+let startupRepliesSent = false;
+let delayedReplyScheduled = false;
+let sentinelSent = false;
+let replyTimer;
+let sentinelTimer;
+let timeoutTimer;
+
+try {
+  terminal = spawn(
+    zellijBinary,
+    ["--session", sessionName, "--new-session-with-layout", layoutPath],
+    {
+      name: "xterm-256color",
+      cols: 120,
+      rows: 40,
+      cwd: homeDir,
+      env: isolatedEnv,
+    },
+  );
+
+  await new Promise((resolveTest, rejectTest) => {
+    timeoutTimer = setTimeout(() => {
+      const diagnostic = capturedOutput.replaceAll("\x1b", "<ESC>").slice(-2_000);
+      rejectTest(new Error(
+        `Zellij host-query smoke test exceeded ${TEST_TIMEOUT_MS}ms: ${diagnostic}`,
+      ));
+    }, TEST_TIMEOUT_MS);
+
+    terminal.onData((data) => {
+      capturedOutput = (capturedOutput + data).slice(-MAX_CAPTURE_BYTES);
+
+      if (!startupRepliesSent && capturedOutput.includes("\x1b]4;255;?\x1b\\")) {
+        startupRepliesSent = true;
+        const paletteReplies = Array.from(
+          { length: 255 },
+          (_, index) => index < 42 ? index : index + 1,
+        ).map(
+          (index) => `\x1b]4;${index};rgb:ffff/0000/ffff\x1b\\`,
+        ).join("");
+        terminal.write([
+          "\x1b[4;960;1440t",
+          "\x1b[6;24;12t",
+          "\x1b]11;rgb:0000/0000/0000\x1b\\",
+          "\x1b]10;rgb:ffff/ffff/ffff\x1b\\",
+          paletteReplies,
+        ].join(""));
+        delayedReplyScheduled = true;
+        replyTimer = setTimeout(() => {
+          terminal.write("\x1b]4;42;rgb:ffff/0000/ffff\x1b\\");
+          sentinelTimer = setTimeout(() => {
+            sentinelSent = true;
+            terminal.write(`${SENTINEL}\r`);
+          }, 500);
+        }, HOST_REPLY_DELAY_MS);
+      }
+
+      if (capturedOutput.includes(SENTINEL)) {
+        rejectTest(new Error("pane input sentinel was echoed before the probe consumed it"));
+      }
+    });
+
+    terminal.onExit(({ exitCode }) => {
+      if (exitCode !== 0) {
+        const diagnostic = capturedOutput.replaceAll("\x1b", "<ESC>").slice(-2_000);
+        rejectTest(new Error(
+          `Zellij exited before the smoke test completed (exit ${exitCode}): ${diagnostic}`,
+        ));
+      }
+    });
+
+    let pollAttempts = 0;
+    const maxPollAttempts = Math.ceil(TEST_TIMEOUT_MS / 50);
+    const pollResult = async () => {
+      try {
+        const result = JSON.parse(await readFile(resultPath, "utf8"));
+        resolveTest(result);
+      } catch (error) {
+        const missing = error instanceof Error && "code" in error && error.code === "ENOENT";
+        if (missing || error instanceof SyntaxError) {
+          pollAttempts += 1;
+          if (pollAttempts >= maxPollAttempts) {
+            rejectTest(new Error("pane input probe did not produce a bounded result"));
+            return;
+          }
+          setTimeout(() => void pollResult(), 50);
+          return;
+        }
+        rejectTest(error);
+      }
+    };
+    void pollResult();
+  }).then((result) => {
+    if (!startupRepliesSent || !delayedReplyScheduled) {
+      throw new Error("Zellij did not issue the expected OSC 4 host palette queries");
+    }
+    if (result.overflow) {
+      throw new Error("pane input exceeded the 64 KiB smoke-test limit");
+    }
+    const paneInput = Buffer.from(result.inputBase64, "base64");
+    const inputText = paneInput.toString("utf8");
+    if (!inputText.includes(SENTINEL)) {
+      throw new Error(
+        `pane did not receive ordinary input after the delayed host reply (sent=${sentinelSent}, residual=${paneInput.toString("hex")})`,
+      );
+    }
+    if (inputText.includes("rgb:") || paneInput.includes(Buffer.from("\x1b]4;"))) {
+      throw new Error("delayed OSC 4 host reply leaked into the pane's stdin");
+    }
+  });
+
+  console.log(`Zellij host-query smoke test passed for ${zellijBinary}`);
+} finally {
+  clearTimeout(replyTimer);
+  clearTimeout(sentinelTimer);
+  clearTimeout(timeoutTimer);
+  if (terminal) terminal.kill();
+  try {
+    await execFileAsync(zellijBinary, ["kill-session", sessionName], {
+      cwd: homeDir,
+      env: isolatedEnv,
+      timeout: 2_000,
+    });
+  } catch (error) {
+    if (!(error instanceof Error)) throw error;
+    if (!error.message.includes("Session not found") && !error.message.includes("No active zellij sessions")) {
+      console.error(`Zellij smoke-test cleanup warning: ${error.message}`);
+    }
+  }
+  await rm(testRoot, { recursive: true, force: true });
+}

--- a/tests/platform/customer-vps-host-bundle.test.ts
+++ b/tests/platform/customer-vps-host-bundle.test.ts
@@ -104,6 +104,7 @@ describe('customer VPS host bundle', () => {
     );
     expect(script).toContain('HOST_BUNDLE_ZELLIJ_VERSION and HOST_BUNDLE_ZELLIJ_BINARY_SHA256 must be set together');
     expect(script).toContain('[[ ! "$ZELLIJ_BINARY_SHA256" =~ ^[0-9a-f]{64}$ ]]');
+    expect(script).toContain('if [ -L "$STAGE_DIR/bin/zellij" ] || [ ! -f "$STAGE_DIR/bin/zellij" ]; then');
     expect(script).toContain("printf '%s  %s\\n' \"$ZELLIJ_BINARY_SHA256\" \"$STAGE_DIR/bin/zellij\" | sha256sum -c -");
     expect(script).toContain('ZELLIJ_ACTUAL_VERSION="$("$STAGE_DIR/bin/zellij" --version)"');
     expect(script).toContain('[ "$ZELLIJ_ACTUAL_VERSION" = "zellij $ZELLIJ_VERSION" ]');
@@ -120,6 +121,13 @@ describe('customer VPS host bundle', () => {
     expect(smoke).toContain('mkdtemp(join(tmpdir(), "mzq-"))');
     expect(smoke).toContain('XDG_CACHE_HOME: cacheDir');
     expect(smoke).toContain('await rm(testRoot, { recursive: true, force: true })');
+
+    const regularFileCheck = script.indexOf('if [ -L "$STAGE_DIR/bin/zellij" ] || [ ! -f "$STAGE_DIR/bin/zellij" ]; then');
+    const digestCheck = script.indexOf("printf '%s  %s\\n' \"$ZELLIJ_BINARY_SHA256\" \"$STAGE_DIR/bin/zellij\" | sha256sum -c -");
+    const permissionChange = script.indexOf('chmod 0755 "$STAGE_DIR/bin/zellij"');
+    expect(regularFileCheck).toBeGreaterThan(-1);
+    expect(digestCheck).toBeGreaterThan(regularFileCheck);
+    expect(permissionChange).toBeGreaterThan(digestCheck);
   });
 
   it('fails closed before building when Zellij overrides are unpaired or malformed', () => {

--- a/tests/platform/customer-vps-host-bundle.test.ts
+++ b/tests/platform/customer-vps-host-bundle.test.ts
@@ -37,6 +37,20 @@ function runDevBundleGate(env: Record<string, string>) {
   }
 }
 
+function runHostBundlePreflight(env: Record<string, string>) {
+  const root = process.cwd();
+  const childEnv = { ...process.env };
+  delete childEnv.HOST_BUNDLE_ZELLIJ_VERSION;
+  delete childEnv.HOST_BUNDLE_ZELLIJ_BINARY_SHA256;
+
+  return spawnSync('bash', [join(root, 'scripts/build-host-bundle.sh')], {
+    cwd: root,
+    encoding: 'utf8',
+    env: { ...childEnv, ...env },
+    timeout: 2_000,
+  });
+}
+
 describe('customer VPS host bundle', () => {
   it('build script packages the systemd entrypoint binaries', () => {
     const root = process.cwd();
@@ -77,6 +91,62 @@ describe('customer VPS host bundle', () => {
     expect(script).toContain('matrix-messaging-health');
     expect(script).toContain('"$STAGE_DIR/runtime/node/bin/gh"');
     expect(script).toContain('bin app runtime systemd release.json');
+  });
+
+  it('pins, verifies, smoke-tests, and packages the configured Zellij binary', () => {
+    const root = process.cwd();
+    const script = readFileSync(join(root, 'scripts/build-host-bundle.sh'), 'utf8');
+    const smoke = readFileSync(join(root, 'scripts/smoke-zellij-host-query.mjs'), 'utf8');
+
+    expect(script).toContain('ZELLIJ_VERSION="${HOST_BUNDLE_ZELLIJ_VERSION:-0.44.3}"');
+    expect(script).toContain(
+      'ZELLIJ_BINARY_SHA256="${HOST_BUNDLE_ZELLIJ_BINARY_SHA256:-397481870c4fc3bae646cd7613cde3a1cebdc204558a6cb9a7c603d4c852fc90}"',
+    );
+    expect(script).toContain('HOST_BUNDLE_ZELLIJ_VERSION and HOST_BUNDLE_ZELLIJ_BINARY_SHA256 must be set together');
+    expect(script).toContain('[[ ! "$ZELLIJ_BINARY_SHA256" =~ ^[0-9a-f]{64}$ ]]');
+    expect(script).toContain("printf '%s  %s\\n' \"$ZELLIJ_BINARY_SHA256\" \"$STAGE_DIR/bin/zellij\" | sha256sum -c -");
+    expect(script).toContain('ZELLIJ_ACTUAL_VERSION="$("$STAGE_DIR/bin/zellij" --version)"');
+    expect(script).toContain('[ "$ZELLIJ_ACTUAL_VERSION" = "zellij $ZELLIJ_VERSION" ]');
+    expect(script).toContain(
+      'timeout --signal=KILL 15s node "$ROOT_DIR/scripts/smoke-zellij-host-query.mjs" "$STAGE_DIR/bin/zellij"',
+    );
+    expect(script).toContain('chmod 0755 "$STAGE_DIR/bin/zellij"');
+    expect(script).toContain('tar -C "$STAGE_DIR" -czf "$DIST_DIR/$BUNDLE_NAME" bin app runtime systemd release.json incremental-manifest.json');
+    expect(smoke).toContain('import { spawn } from "node-pty"');
+    expect(smoke).toContain('const TEST_TIMEOUT_MS = 10_000');
+    expect(smoke).toContain('const OLD_HOST_QUERY_TIMEOUT_MS = 500');
+    expect(smoke).toContain('const HOST_REPLY_DELAY_MS = OLD_HOST_QUERY_TIMEOUT_MS + 250');
+    expect(smoke).toContain('const maxInputBytes = 64 * 1024');
+    expect(smoke).toContain('mkdtemp(join(tmpdir(), "mzq-"))');
+    expect(smoke).toContain('XDG_CACHE_HOME: cacheDir');
+    expect(smoke).toContain('await rm(testRoot, { recursive: true, force: true })');
+  });
+
+  it('fails closed before building when Zellij overrides are unpaired or malformed', () => {
+    const versionOnly = runHostBundlePreflight({
+      HOST_BUNDLE_ZELLIJ_VERSION: '0.44.3',
+    });
+    expect(versionOnly.status).toBe(1);
+    expect(versionOnly.stderr).toContain(
+      'HOST_BUNDLE_ZELLIJ_VERSION and HOST_BUNDLE_ZELLIJ_BINARY_SHA256 must be set together',
+    );
+
+    const digestOnly = runHostBundlePreflight({
+      HOST_BUNDLE_ZELLIJ_BINARY_SHA256: 'a'.repeat(64),
+    });
+    expect(digestOnly.status).toBe(1);
+    expect(digestOnly.stderr).toContain(
+      'HOST_BUNDLE_ZELLIJ_VERSION and HOST_BUNDLE_ZELLIJ_BINARY_SHA256 must be set together',
+    );
+
+    const malformedDigest = runHostBundlePreflight({
+      HOST_BUNDLE_ZELLIJ_VERSION: '0.44.3',
+      HOST_BUNDLE_ZELLIJ_BINARY_SHA256: '../not-a-digest',
+    });
+    expect(malformedDigest.status).toBe(1);
+    expect(malformedDigest.stderr).toContain(
+      'HOST_BUNDLE_ZELLIJ_BINARY_SHA256 must be a lowercase 64-character SHA-256',
+    );
   });
 
   it('host bundle defers heavy optional tools to selectable boot-time packs', () => {


### PR DESCRIPTION
## Summary

- upgrade the staged Zellij host binary from 0.44.1 to 0.44.3, pinned to SHA-256 `397481870c4fc3bae646cd7613cde3a1cebdc204558a6cb9a7c603d4c852fc90`
- fail closed when version/digest overrides are unpaired or malformed; reject symlink/non-regular extraction results; verify the digest before any permission change and require exact `zellij <version>` output before packaging
- run a bounded `node-pty` smoke test against the staged binary that delays a valid OSC 4 palette reply beyond Zellij 0.44.1's 500 ms host-query window and requires it to be consumed before ordinary pane input

Upstream: [Zellij 0.44.3](https://github.com/zellij-org/zellij/releases/tag/v0.44.3), [host-query forwarding fix](https://github.com/zellij-org/zellij/pull/5149).

## Tests

- regression proof: the PTY smoke exits 1 against Zellij 0.44.1 (`delayed OSC 4 host reply leaked into the pane's stdin`) and exits 0 against 0.44.3
- `pnpm exec vitest run tests/platform/customer-vps-host-bundle.test.ts -t 'pins, verifies|fails closed' --reporter=dot` (2 passed)
- Greptile security regression: verified the regular-file check and digest verification precede `chmod` (red before fix, green after)
- `pnpm exec vitest run tests/gateway/zellij-runtime.test.ts tests/gateway/shell-zellij.test.ts tests/gateway/terminal-ws.test.ts tests/gateway/terminal-zellij-ws.test.ts --reporter=dot` (126 passed; 1 unchanged environment-dependent prompt-label failure)
- exact pnpm TypeScript chain used by `typecheck` (passed; Bun is unavailable locally)
- `pnpm run check:patterns` (passed)
- `pnpm run test` (9,947 passed, 145 failed, 20 skipped; failures are unchanged sandbox/toolchain failures such as `listen`/`spawnSync` `EPERM`, missing local Vitest linkage, and app-build timeouts)
- `bash -n scripts/build-host-bundle.sh`, `node --check scripts/smoke-zellij-host-query.mjs`, and `git diff --check` (passed)

The complete local host-bundle build requires Bun, Elixir/Mix, and the production Clerk build key; none are present on this worker. The host-bundle release workflow remains the authoritative real immutable build and packaging check.

## Review/Monitoring

- branch is frozen while CI, unresolved review threads, Codex review comments, and the latest trusted Greptile result are monitored
- every actionable finding will be fixed and revalidated; this PR will not be treated as ready until required CI is green and Greptile reports 5/5

## Invariants

- **Source of truth:** the immutable host bundle is canonical for `/opt/matrix/bin/zellij`; the build script's paired version and SHA-256 configuration selects and authenticates the exact binary before packaging.
- **Lock/transaction scope:** no database or shared-state transaction is introduced. Verification and the PTY smoke run inside the local staging build before the tarball is created; no network call occurs inside a lock.
- **Acceptable orphan states:** a failed download, digest/version check, or smoke test aborts the build and may leave only local `dist/host-bundle` staging artifacts. Nothing is published, registered, or promoted.
- **Auth source of truth:** unchanged. Terminal and host-bundle authentication paths are not modified.
- **Deferred scope:** no gateway, browser-terminal, REST, WebSocket, schema, persisted-data, or client-side escape-sequence filter changes. Existing contaminated scrollback remains owner data and is not rewritten or deleted.

## Rollout and recovery

- promote the exact immutable bundle through dev → canary → beta → stable, checking `/opt/matrix/bin/zellij --version`, gateway health, fleet readiness, and terminal create/attach failures at each stage
- expect the normal brief terminal disconnect from the gateway restart and schedule broad promotion for a low-activity window
- advise affected owners to permanently close only the contaminated session and create a new one; `clear` does not remove persisted replay
- if a regression appears, stop promotion and deploy the previous exact bundle so its 0.44.1 binary is reinstalled; do not rely on the local `matrix-update rollback` path
