### PR TITLE
fix(agent): validate Hermes MoA preset readiness

### DIFF
--- a/packages/gateway/src/agent-config/hermes-source.ts
+++ b/packages/gateway/src/agent-config/hermes-source.ts
@@ -17,6 +17,8 @@ export type HermesJsonReader = (
 const MAX_HERMES_PROVIDERS = 31;
 const MAX_HERMES_MODELS = 253;
 const MAX_MODELS_PER_PROVIDER = 128;
+const MAX_MOA_PRESETS = 64;
+const MAX_MOA_REFERENCES = 32;
 
 const ProviderIdSchema = z.string()
   .trim()
@@ -45,6 +47,21 @@ const HermesProviderSchema = z.object({
   auth_type: z.string().max(64).optional(),
   is_user_defined: z.boolean().optional(),
   models: z.array(z.unknown()).max(512).optional(),
+}).passthrough();
+
+const HermesConfigSchema = z.object({
+  moa: z.unknown().optional(),
+}).passthrough();
+
+const MoASlotSchema = z.object({
+  provider: ProviderIdSchema,
+  model: ModelIdSchema,
+  enabled: z.boolean().optional(),
+}).passthrough();
+
+const MoAPresetSchema = z.object({
+  reference_models: z.array(z.unknown()).max(MAX_MOA_REFERENCES),
+  aggregator: z.unknown(),
 }).passthrough();
 
 function authKindForProvider(
@@ -82,17 +99,80 @@ function parseModelIds(rawModels: unknown[] | undefined, currentModel: string | 
   return [currentModel, ...models].slice(0, MAX_MODELS_PER_PROVIDER);
 }
 
+function isPlainRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function selectedMoAPreset(
+  config: unknown,
+  currentProvider: string | null,
+  currentModel: string | null,
+): unknown {
+  const parsedConfig = HermesConfigSchema.safeParse(config);
+  if (!parsedConfig.success || !isPlainRecord(parsedConfig.data.moa)) return null;
+  const moa = parsedConfig.data.moa;
+  const presets = moa.presets;
+  if (isPlainRecord(presets)) {
+    const entries = Object.entries(presets);
+    if (entries.length === 0 || entries.length > MAX_MOA_PRESETS) return null;
+    const defaultPreset = ModelIdSchema.safeParse(moa.default_preset);
+    const presetName = currentProvider === "moa" && currentModel !== null
+      ? currentModel
+      : defaultPreset.success
+        ? defaultPreset.data
+        : entries[0]?.[0];
+    return presetName === undefined ? null : presets[presetName];
+  }
+  return currentProvider === "moa" && currentModel !== "default" ? null : moa;
+}
+
+function moaDependenciesAuthenticated(input: {
+  config: unknown;
+  providers: unknown[];
+  currentProvider: string | null;
+  currentModel: string | null;
+}): boolean {
+  const preset = MoAPresetSchema.safeParse(selectedMoAPreset(
+    input.config,
+    input.currentProvider,
+    input.currentModel,
+  ));
+  if (!preset.success) return false;
+
+  const dependencies = preset.data.reference_models.flatMap((slot) => {
+    const parsed = MoASlotSchema.safeParse(slot);
+    return parsed.success && parsed.data.enabled !== false
+      ? [parsed.data.provider]
+      : [];
+  });
+  const aggregator = MoASlotSchema.safeParse(preset.data.aggregator);
+  if (dependencies.length === 0 || !aggregator.success) return false;
+  dependencies.push(aggregator.data.provider);
+
+  const authenticatedProviders = new Set<string>();
+  for (const rawProvider of input.providers) {
+    const provider = HermesProviderSchema.safeParse(rawProvider);
+    if (!provider.success || provider.data.authenticated !== true) continue;
+    const id = ProviderIdSchema.safeParse(provider.data.slug);
+    if (id.success && id.data !== "moa") authenticatedProviders.add(id.data);
+  }
+  return dependencies.every((provider) => authenticatedProviders.has(provider));
+}
+
 function normalizeProvider(
   raw: unknown,
   currentProvider: string | null,
   currentModel: string | null,
+  moaAuthenticated: boolean,
 ): AgentProviderDescriptor | null {
   const parsed = HermesProviderSchema.safeParse(raw);
   if (!parsed.success) return null;
   const id = ProviderIdSchema.safeParse(parsed.data.slug);
   if (!id.success) return null;
   const name = DisplayNameSchema.safeParse(parsed.data.name);
-  const authenticated = parsed.data.authenticated === true;
+  const authenticated = id.data === "moa"
+    ? moaAuthenticated
+    : parsed.data.authenticated === true;
   const authKind = authKindForProvider(
     parsed.data.auth_type,
     parsed.data.is_user_defined === true,
@@ -130,6 +210,7 @@ function normalizeProvider(
 export function normalizeHermesRuntimeSnapshot(input: {
   status: unknown;
   options: unknown;
+  config?: unknown;
 }): AgentRuntimeSettingsSnapshot {
   const status = HermesStatusSchema.parse(input.status);
   const options = HermesOptionsSchema.parse(input.options);
@@ -139,9 +220,20 @@ export function normalizeHermesRuntimeSnapshot(input: {
     ? currentProviderResult.data
     : null;
   const currentModel = currentModelResult.success ? currentModelResult.data : null;
+  const moaAuthenticated = moaDependenciesAuthenticated({
+    config: input.config,
+    providers: options.providers,
+    currentProvider,
+    currentModel,
+  });
   const normalizedProviders: AgentProviderDescriptor[] = [];
   for (const rawProvider of options.providers) {
-    const provider = normalizeProvider(rawProvider, currentProvider, currentModel);
+    const provider = normalizeProvider(
+      rawProvider,
+      currentProvider,
+      currentModel,
+      moaAuthenticated,
+    );
     if (!provider) continue;
     const duplicateIndex = normalizedProviders.findIndex(
       (entry) => entry.id === provider.id,
@@ -258,22 +350,30 @@ export function createHermesRuntimeSource(
       const promise = Promise.allSettled([
         readJson("/api/status", signal),
         readJson("/api/model/options", signal),
-      ]).then(([statusResult, modelOptionsResult]) => {
+        readJson("/api/config", signal),
+      ]).then(([statusResult, modelOptionsResult, configResult]) => {
         signal.throwIfAborted();
         if (statusResult.status === "rejected") throw statusResult.reason;
         let modelOptions: unknown = { providers: [] };
+        let config: unknown;
+        let partialFailure: unknown;
         if (modelOptionsResult.status === "fulfilled") {
           modelOptions = modelOptionsResult.value;
         } else {
-          logWarning(
-            modelOptionsResult.reason instanceof Error
-              ? modelOptionsResult.reason.name
-              : "UnknownError",
-          );
+          partialFailure = modelOptionsResult.reason;
+        }
+        if (configResult.status === "fulfilled") {
+          config = configResult.value;
+        } else {
+          partialFailure ??= configResult.reason;
+        }
+        if (partialFailure !== undefined) {
+          logWarning(partialFailure instanceof Error ? partialFailure.name : "UnknownError");
         }
         return normalizeHermesRuntimeSnapshot({
           status: statusResult.value,
           options: modelOptions,
+          config,
         });
       }).catch((err: unknown) => {
         logWarning(err instanceof Error ? err.name : "UnknownError");

--- a/shell/src/components/settings/sections/AgentRuntimePanel.tsx
+++ b/shell/src/components/settings/sections/AgentRuntimePanel.tsx
@@ -306,7 +306,16 @@ function MessagingProviders({
   const [hermesConfigOpen, setHermesConfigOpen] = useState(false);
   const hermesVersion = view.runtime.options.find((runtime) => runtime.id === "hermes")?.version;
   const terminalAction = "openclaw-model-auth";
-  const configureAction = isHermes ? (
+  const configureAction = isHermes && provider?.id === "moa" && onOpenTerminal ? (
+    <Button
+      size="sm"
+      variant="outline"
+      onClick={() => onOpenTerminal("hermes-moa-configure")}
+      aria-label="Configure MoA provider"
+    >
+      <TerminalIcon className="size-3.5" /> Configure MoA
+    </Button>
+  ) : isHermes ? (
     <Button
       size="sm"
       variant="outline"

--- a/shell/src/lib/terminal-launch.ts
+++ b/shell/src/lib/terminal-launch.ts
@@ -3,6 +3,7 @@ export type TerminalLaunchAction =
   | "codex-login"
   | "github-ssh-login"
   | "hermes-install"
+  | "hermes-moa-configure"
   | "openclaw-install"
   | "openclaw-model-auth";
 
@@ -34,6 +35,11 @@ const TERMINAL_ACTIONS: Record<TerminalLaunchAction, TerminalLaunchConfig> = {
     action: "hermes-install",
     label: "Install Hermes",
     command: "/opt/matrix/bin/matrix-agent-runtime-control install hermes",
+  },
+  "hermes-moa-configure": {
+    action: "hermes-moa-configure",
+    label: "Configure Mixture of Agents",
+    command: "hermes moa configure",
   },
   "openclaw-install": {
     action: "openclaw-install",

--- a/tests/gateway/agent-config-hermes-source.test.ts
+++ b/tests/gateway/agent-config-hermes-source.test.ts
@@ -56,6 +56,109 @@ describe("Hermes agent settings source", () => {
     });
   });
 
+  it("requires action when the selected MoA preset has an unauthenticated dependency", () => {
+    const snapshot = normalizeHermesRuntimeSnapshot({
+      status: { gateway_running: true },
+      options: {
+        provider: "moa",
+        model: "default",
+        providers: [
+          {
+            slug: "moa",
+            name: "Mixture of Agents",
+            authenticated: true,
+            auth_type: "virtual",
+            models: ["default"],
+          },
+          {
+            slug: "anthropic",
+            authenticated: true,
+            auth_type: "api_key",
+            models: ["claude-sonnet-4-5"],
+          },
+          {
+            slug: "openrouter",
+            authenticated: false,
+            auth_type: "api_key",
+            models: [],
+          },
+        ],
+      },
+      config: {
+        moa: {
+          presets: {
+            default: {
+              reference_models: [
+                { provider: "anthropic", model: "claude-sonnet-4-5", enabled: true },
+              ],
+              aggregator: { provider: "openrouter", model: "anthropic/claude-opus-4.6" },
+            },
+          },
+        },
+      },
+    });
+
+    expect(snapshot.providers.find((provider) => provider.id === "moa")?.authStatus)
+      .toEqual({
+        state: "action_required",
+        authenticated: false,
+        action: "open_login_terminal",
+      });
+    expect(snapshot.messaging).toEqual({
+      runtime: "hermes",
+      provider: "moa",
+      model: "default",
+      configured: true,
+    });
+  });
+
+  it("reports the selected MoA preset ready when every dependency is authenticated", () => {
+    const snapshot = normalizeHermesRuntimeSnapshot({
+      status: { gateway_running: true },
+      options: {
+        provider: "moa",
+        model: "team",
+        providers: [
+          {
+            slug: "moa",
+            name: "Mixture of Agents",
+            authenticated: true,
+            auth_type: "virtual",
+            models: ["default", "team"],
+          },
+          {
+            slug: "anthropic",
+            authenticated: true,
+            auth_type: "api_key",
+            models: ["claude-sonnet-4-5", "claude-opus-4-6"],
+          },
+          {
+            slug: "openrouter",
+            authenticated: false,
+            auth_type: "api_key",
+            models: [],
+          },
+        ],
+      },
+      config: {
+        moa: {
+          presets: {
+            team: {
+              reference_models: [
+                { provider: "anthropic", model: "claude-sonnet-4-5" },
+                { provider: "openrouter", model: "ignored", enabled: false },
+              ],
+              aggregator: { provider: "anthropic", model: "claude-opus-4-6" },
+            },
+          },
+        },
+      },
+    });
+
+    expect(snapshot.providers.find((provider) => provider.id === "moa")?.authStatus)
+      .toEqual({ state: "ready", authenticated: true, action: "none" });
+  });
+
   it("loads status and curated model options with the caller's abort signal", async () => {
     const readJson = vi.fn(async (path: string, _signal: AbortSignal) => {
       if (path === "/api/status") {
@@ -80,6 +183,7 @@ describe("Hermes agent settings source", () => {
     expect(snapshot.messaging.configured).toBe(true);
     expect(readJson).toHaveBeenNthCalledWith(1, "/api/status", signal);
     expect(readJson).toHaveBeenNthCalledWith(2, "/api/model/options", signal);
+    expect(readJson).toHaveBeenNthCalledWith(3, "/api/config", signal);
   });
 
   it("keeps dashboard reachability when provider inventory requires authentication", async () => {
@@ -169,11 +273,11 @@ describe("Hermes agent settings source", () => {
 
     await Promise.all([source(signal), source(signal), source(signal)]);
     await source(signal);
-    expect(readJson).toHaveBeenCalledTimes(2);
+    expect(readJson).toHaveBeenCalledTimes(3);
 
     now += 5_001;
     await source(signal);
-    expect(readJson).toHaveBeenCalledTimes(4);
+    expect(readJson).toHaveBeenCalledTimes(6);
   });
 
   it("invalidates a cached inventory after a successful configuration mutation", async () => {
@@ -185,12 +289,12 @@ describe("Hermes agent settings source", () => {
 
     await source(signal);
     await source(signal);
-    expect(readJson).toHaveBeenCalledTimes(2);
+    expect(readJson).toHaveBeenCalledTimes(3);
 
     source.invalidate();
     await source(signal);
 
-    expect(readJson).toHaveBeenCalledTimes(4);
+    expect(readJson).toHaveBeenCalledTimes(6);
   });
 
   it("negative-caches an unreachable runtime without logging raw errors", async () => {
@@ -211,7 +315,7 @@ describe("Hermes agent settings source", () => {
 
     expect(snapshots.map((snapshot) => snapshot.runtime.options[0]?.health))
       .toEqual(["unreachable", "unreachable", "unreachable"]);
-    expect(readJson).toHaveBeenCalledTimes(2);
+    expect(readJson).toHaveBeenCalledTimes(3);
     expect(logWarning).toHaveBeenCalledOnce();
     expect(logWarning).toHaveBeenCalledWith("Error");
     expect(JSON.stringify(logWarning.mock.calls)).not.toContain(canary);

--- a/tests/gateway/agent-runtime-services.test.ts
+++ b/tests/gateway/agent-runtime-services.test.ts
@@ -628,9 +628,12 @@ describe("Hermes agent runtime services", () => {
       }),
       stop: vi.fn(async () => {}),
     };
-    const readJson = vi.fn(async (path: string) => path === "/api/status"
-      ? { gateway_running: active === "hermes" }
-      : {
+    const readJson = vi.fn(async (path: string) => {
+      if (path === "/api/status") {
+        return { gateway_running: active === "hermes" };
+      }
+      if (path === "/api/model/options") {
+        return {
           provider: "nous",
           model: "hermes-4-405b",
           providers: [{
@@ -640,7 +643,11 @@ describe("Hermes agent runtime services", () => {
             auth_type: "oauth",
             models: ["hermes-4-405b"],
           }],
-        });
+        };
+      }
+      if (path === "/api/config") return {};
+      throw new Error(`Unexpected Hermes path: ${path}`);
+    });
     const openClawRpc = {
       call: vi.fn(async (method: string) => {
         if (method === "health") return { ok: true, ts: 1_789_000_000_000 };
@@ -685,11 +692,19 @@ describe("Hermes agent runtime services", () => {
     });
 
     await services.source(new AbortController().signal);
-    expect(readJson).toHaveBeenCalledTimes(2);
+    expect(readJson.mock.calls.map(([path]) => path)).toEqual([
+      "/api/status",
+      "/api/model/options",
+      "/api/config",
+    ]);
     await services.controller.update({ runtime: "openclaw", revision: 0 });
     await services.controller.update({ runtime: "hermes", revision: 1 });
 
-    expect(readJson).toHaveBeenCalledTimes(6);
+    expect(readJson).toHaveBeenCalledTimes(9);
+    for (const path of ["/api/status", "/api/model/options", "/api/config"]) {
+      expect(readJson.mock.calls.filter(([calledPath]) => calledPath === path))
+        .toHaveLength(3);
+    }
     expect(hostControl.stop).not.toHaveBeenCalled();
     await services.controller.close();
   });

--- a/tests/gateway/agent-settings-hermes-integration.test.ts
+++ b/tests/gateway/agent-settings-hermes-integration.test.ts
@@ -31,6 +31,7 @@ describe("unified agent settings Hermes integration", () => {
       if (path === "/api/status") {
         return Response.json({ version: "1.0.0", gateway_running: true });
       }
+      if (path === "/api/config") return Response.json({});
       return Response.json({
         provider: "nous",
         model: "hermes-4-405b",
@@ -73,6 +74,7 @@ describe("unified agent settings Hermes integration", () => {
       model: "hermes-4-405b",
       configured: true,
     });
-    expect(fetchImpl).toHaveBeenCalledTimes(2);
+    expect(fetchImpl.mock.calls.map(([url]) => new URL(String(url)).pathname))
+      .toEqual(["/api/status", "/api/model/options", "/api/config"]);
   });
 });

--- a/tests/shell/agent-settings.test.tsx
+++ b/tests/shell/agent-settings.test.tsx
@@ -200,6 +200,47 @@ describe("Canvas Agent runtime settings", () => {
     expect(onOpenTerminal).not.toHaveBeenCalledWith(expect.stringContaining("hermes"));
   });
 
+  it("offers a dedicated MoA setup terminal when preset dependencies need action", async () => {
+    const view = makeView();
+    view.providers.push({
+      id: "moa",
+      displayName: "Mixture of Agents",
+      runtime: "hermes",
+      scopes: ["messaging"],
+      authKind: "oauth_login",
+      supportedAuthKinds: ["oauth_login"],
+      models: [{
+        id: "default",
+        displayName: "default",
+        capabilities: ["tools"],
+        efforts: [],
+        available: true,
+      }],
+      authStatus: {
+        state: "action_required",
+        authenticated: false,
+        action: "open_login_terminal",
+      },
+    });
+    view.currentSelection.messaging = {
+      runtime: "hermes",
+      provider: "moa",
+      model: "default",
+      configured: true,
+    };
+    const onOpenTerminal = vi.fn();
+    vi.stubGlobal("fetch", vi.fn(async () => response(view)));
+
+    render(<AgentRuntimePanel onOpenTerminal={onOpenTerminal} />);
+
+    const configure = await screen.findByRole("button", { name: "Configure MoA provider" });
+    expect(within(screen.getByRole("button", { name: "Choose Mixture of Agents" }))
+      .getByText("Action Required")).toBeVisible();
+    fireEvent.click(configure);
+    expect(onOpenTerminal).toHaveBeenCalledWith("hermes-moa-configure");
+    expect(screen.queryByRole("heading", { name: "Configure Hermes" })).toBeNull();
+  });
+
   it("switches only to an installed runtime with the current revision", async () => {
     const initial = makeView();
     initial.runtime.options[1] = {

--- a/tests/shell/terminal-launch.test.ts
+++ b/tests/shell/terminal-launch.test.ts
@@ -33,6 +33,11 @@ describe("terminal launch paths", () => {
       action: "openclaw-model-auth",
       command: "openclaw models auth add",
     });
+    expect(terminalLaunchConfig("hermes-moa-configure")).toMatchObject({
+      action: "hermes-moa-configure",
+      label: "Configure Mixture of Agents",
+      command: "hermes moa configure",
+    });
   });
 
   it("maps runtime installs to the validated host control without sudo", () => {


### PR DESCRIPTION
## Summary

- validate the active Hermes MoA preset instead of trusting the upstream provider-level `authenticated` flag
- require every enabled MoA reference provider and the aggregator provider to be authenticated before Matrix shows MoA as Ready
- fail closed to Action Required when the bounded MoA config response is missing, malformed, or incomplete
- add a visible Configure MoA action that opens `hermes moa configure` in the Matrix terminal

## Problem

Hermes reports the virtual `moa` provider as authenticated even when the selected preset's reference or aggregator providers have no credentials. Matrix therefore showed **Ready**, but the first real inference failed with `No LLM provider configured for task=moa_reference` or `task=moa_aggregator`.

The gateway now derives MoA readiness from the selected preset and the authenticated provider inventory. Ordinary non-MoA provider readiness is unchanged.

## Tests

- `flox activate -- bun run test -- tests/gateway/agent-config-hermes-source.test.ts tests/gateway/agent-runtime-services.test.ts tests/gateway/agent-settings-hermes-integration.test.ts tests/shell/agent-settings.test.tsx tests/shell/terminal-launch.test.ts` — 46 tests passed
- Hermes/Agent regression group — 121 tests passed across 15 files
- `flox activate -- bun run typecheck` — passed
- `flox activate -- bun run check:patterns` — passed with existing repository warnings and no violations
- focused ESLint for both changed shell files — passed
- `flox activate -- bun run build:shell:production` — passed
- `bun run test` — 10,421 passed, 20 skipped, and 24 unrelated macOS-local failures across existing Unix-socket, Linux-command, and shell timing tests; the MAT-259 lifecycle regression passes and the required Linux CI shards remain authoritative
- the first exact-head CI run exposed a stale lifecycle fixture that counted only two Hermes snapshot endpoints; commit `236c04aa` updates it to cover `/api/status`, `/api/model/options`, and `/api/config`

## Invariants

### Source of truth

- Hermes remains the source of truth for the selected model and MoA preset configuration.
- Matrix only derives a bounded readiness result from Hermes `/api/config` and `/api/model/options`; it does not copy credentials or configuration.

### Lock/transaction scope

- No database writes, locks, or transactions are introduced.
- The three loopback Hermes reads are independent, bounded, authenticated, and executed concurrently.

### Acceptable orphan states

- There are no new persisted objects or orphan states.
- If any MoA readiness input is unavailable or invalid, the UI fails closed to Action Required and keeps the saved provider/model selection intact.

### Auth source of truth

- The existing Matrix-to-Hermes dashboard token remains the authentication boundary.
- Provider secrets remain write-only and owned by Hermes; Matrix receives only provider authentication state.

### Deferred scope

- This does not change Hermes' upstream virtual-provider contract or mutate MoA presets.
- Configuring credentials remains an explicit visible Hermes terminal flow.

## Tracking

- [MAT-259](https://linear.app/matrix-os/issue/MAT-259/fix-false-ready-state-for-incomplete-hermes-moa-presets)
- Related: #1154, #1156
